### PR TITLE
Add initial Dockerfile setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+Dockerfile
+.dockerignore
+.gitignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM golang:1.22.0-bookworm as build
+
+ARG TESNSORFLOW_VERSION=v2.14.0
+ARG PLATFORM=linux_amd64
+
+# Download and configure precompiled TensorFlow Lite C library
+RUN curl -L \
+    https://github.com/tphakala/tflite_c/releases/download/${TESNSORFLOW_VERSION}/tflite_c_${TESNSORFLOW_VERSION}_${PLATFORM}.tar.gz | \
+    tar -C "/usr/local/lib" -xz \
+    && ldconfig
+
+WORKDIR /root/src
+
+# Download TensorFlow headers
+RUN git clone --branch ${TESNSORFLOW_VERSION} --depth 1 https://github.com/tensorflow/tensorflow.git
+
+# Compile BirdNET-GO
+COPY . BirdNET-Go
+RUN cd BirdNET-Go && make
+
+# Create final image
+FROM debian:bookworm-slim
+COPY --from=build /root/src/BirdNET-Go/bin /usr/bin/
+COPY --from=build /usr/local/lib/libtensorflowlite_c.so /usr/local/lib/libtensorflowlite_c.so
+RUN ldconfig
+
+ENTRYPOINT ["/usr/bin/birdnet-go"]
+CMD ["realtime"]


### PR DESCRIPTION
Hi, I am really happy to see this project coming along nicely! One issue I always had with the original BirdNET-Pi project was that is did not support docker. Which made it really hard to try out before deciding to run it on a raspberry, since it pretty much required a dedicated VM...

While the go approach for this project makes it way easier to try out, I still believe a docker image could be beneficial! Therefore, I would like to make a contribution on getting us started with a initial dockerfile.

This PR allows for BirdNET-Go to be built and bundled into a container. The container will by default execute
the realtime command, starting the server. The image is currently based on debian bookworm since I found that easiest to get running. However, in the future it might be better bundle it in a alpine image to reduce the size even more. It might also be of interest to utilize Github Actions to build a docker for every release. Would happily contribute to that in the future too!