### PR TITLE
Add basic github action for building docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 Dockerfile
 .dockerignore
 .gitignore
+.git

--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@ Dockerfile
 .dockerignore
 .gitignore
 .git
+.github

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,30 @@
+name: Deploy Image to GHCR
+
+on:
+  push:
+    branches:
+    - main
+  workflow_dispatch:
+
+jobs:
+  push-docker-image:
+    runs-on: ubuntu-latest
+    steps:
+    - name: 'Checkout GitHub Action'
+      uses: actions/checkout@v4.1.1
+
+    - name: 'Login to GitHub Container Registry'
+      uses: docker/login-action@v3.0.0
+      with:
+        registry: ghcr.io
+        username: ${{github.actor}}
+        password: ${{secrets.GITHUB_TOKEN}}
+
+    - name: 'Generate downcase repository name'
+      run: |
+        echo "REPO=${GITHUB_REPOSITORY,,}" >>${GITHUB_ENV}
+
+    - name: 'Build Inventory Image'
+      run: |
+        docker build . --tag ghcr.io/${REPO}:latest
+        docker push ghcr.io/${REPO}:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,18 @@
 FROM golang:1.22.0-bookworm as build
 
-ARG TESNSORFLOW_VERSION=v2.14.0
+ARG TENSORFLOW_VERSION=v2.14.0
 ARG PLATFORM=linux_amd64
 
 # Download and configure precompiled TensorFlow Lite C library
 RUN curl -L \
-    https://github.com/tphakala/tflite_c/releases/download/${TESNSORFLOW_VERSION}/tflite_c_${TESNSORFLOW_VERSION}_${PLATFORM}.tar.gz | \
+    https://github.com/tphakala/tflite_c/releases/download/${TENSORFLOW_VERSION}/tflite_c_${TENSORFLOW_VERSION}_${PLATFORM}.tar.gz | \
     tar -C "/usr/local/lib" -xz \
     && ldconfig
 
 WORKDIR /root/src
 
 # Download TensorFlow headers
-RUN git clone --branch ${TESNSORFLOW_VERSION} --depth 1 https://github.com/tensorflow/tensorflow.git
+RUN git clone --branch ${TENSORFLOW_VERSION} --depth 1 https://github.com/tensorflow/tensorflow.git
 
 # Compile BirdNET-GO
 COPY . BirdNET-Go


### PR DESCRIPTION
Implements a basic github action job that will for every commit to the main branch, build and push a docker
image to the latest tag. The latest tag will get overwritten after each commit.

In the future it might be better to instead decide on some better tagging strategy.