### PR TITLE
Define docker volumes & add docker documentation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 Dockerfile
 .dockerignore
 .gitignore
+.git

--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@ Dockerfile
 .dockerignore
 .gitignore
 .git
+.github

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,30 @@
+name: Deploy Image to GHCR
+
+on:
+  push:
+    branches:
+    - main
+  workflow_dispatch:
+
+jobs:
+  push-docker-image:
+    runs-on: ubuntu-latest
+    steps:
+    - name: 'Checkout GitHub Action'
+      uses: actions/checkout@v4.1.1
+
+    - name: 'Login to GitHub Container Registry'
+      uses: docker/login-action@v3.0.0
+      with:
+        registry: ghcr.io
+        username: ${{github.actor}}
+        password: ${{secrets.GITHUB_TOKEN}}
+
+    - name: 'Generate downcase repository name'
+      run: |
+        echo "REPO=${GITHUB_REPOSITORY,,}" >>${GITHUB_ENV}
+
+    - name: 'Build Inventory Image'
+      run: |
+        docker build . --tag ghcr.io/${REPO}:latest
+        docker push ghcr.io/${REPO}:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,5 +28,8 @@ RUN ldconfig
 VOLUME /config
 RUN mkdir -p /root/.config && ln -s /config /root/.config/birdnet-go
 
+VOLUME /data
+WORKDIR /data
+
 ENTRYPOINT ["/usr/bin/birdnet-go"]
 CMD ["realtime"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,18 @@
 FROM golang:1.22.0-bookworm as build
 
-ARG TESNSORFLOW_VERSION=v2.14.0
+ARG TENSORFLOW_VERSION=v2.14.0
 ARG PLATFORM=linux_amd64
 
 # Download and configure precompiled TensorFlow Lite C library
 RUN curl -L \
-    https://github.com/tphakala/tflite_c/releases/download/${TESNSORFLOW_VERSION}/tflite_c_${TESNSORFLOW_VERSION}_${PLATFORM}.tar.gz | \
+    https://github.com/tphakala/tflite_c/releases/download/${TENSORFLOW_VERSION}/tflite_c_${TENSORFLOW_VERSION}_${PLATFORM}.tar.gz | \
     tar -C "/usr/local/lib" -xz \
     && ldconfig
 
 WORKDIR /root/src
 
 # Download TensorFlow headers
-RUN git clone --branch ${TESNSORFLOW_VERSION} --depth 1 https://github.com/tensorflow/tensorflow.git
+RUN git clone --branch ${TENSORFLOW_VERSION} --depth 1 https://github.com/tensorflow/tensorflow.git
 
 # Compile BirdNET-GO
 COPY . BirdNET-Go

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,5 +24,9 @@ COPY --from=build /root/src/BirdNET-Go/bin /usr/bin/
 COPY --from=build /usr/local/lib/libtensorflowlite_c.so /usr/local/lib/libtensorflowlite_c.so
 RUN ldconfig
 
+# Add symlink to /config directory where configs can be stored 
+VOLUME /config
+RUN mkdir -p /root/.config && ln -s /config /root/.config/birdnet-go
+
 ENTRYPOINT ["/usr/bin/birdnet-go"]
 CMD ["realtime"]

--- a/README.md
+++ b/README.md
@@ -31,6 +31,22 @@ BirdNET-Go is an AI solution for continuous avian monitoring and identification
 Ready to run binaries can be found from releases section https://github.com/tphakala/BirdNET-Go/releases/
 Archives also contains libtensorflowlite_c library.
 
+### Docker
+
+```
+docker run -ti \
+  -p 8080:8080 \
+  -v /path/to/config:/config \
+  -v /path/to/data:/data \
+  ghcr.io/tphakala/birdnet-go:latest
+```
+
+| Parameter | Function |
+| :----: | --- |
+| `-p 8080` | BirdNET-GO webserver port. |
+| `-v /config` | Config directory in the container. |
+| `-v /data` | Data such as database and recordings. |
+
 ## Compiling for Linux
 
 ### Install TensorFlow Lite C library and setup headers for compile process


### PR DESCRIPTION
Defines a /config and /data volume for the docker image where the end-user can mount in filesystems from the host. Allowing for these volumes to persist outside the container.

I also added a very basic example on how to run the container in the README.md. It can probably be improved a bit, but it is a start!