### PR TITLE
Enable usage of rootless docker

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -24,7 +24,7 @@ jobs:
       run: |
         echo "REPO=${GITHUB_REPOSITORY,,}" >>${GITHUB_ENV}
 
-    - name: 'Build Inventory Image'
+    - name: 'Build BirdNET-Go Image'
       run: |
         docker build . --tag ghcr.io/${REPO}:latest
         docker push ghcr.io/${REPO}:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,9 @@ RUN cd BirdNET-Go && make TARGETPLATFORM=${TARGETPLATFORM}
 # Create final image using a multi-platform base image
 FROM debian:bookworm-slim
 
+# Add docker user to the audio group, allowing for ALSA to be used
+RUN usermod -a -G audio root
+
 # Install ALSA library and SOX
 RUN apt-get update && apt-get install -y \
     libasound2 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,9 +34,6 @@ RUN cd BirdNET-Go && make TARGETPLATFORM=${TARGETPLATFORM}
 # Create final image using a multi-platform base image
 FROM debian:bookworm-slim
 
-# Add docker user to the audio group, allowing for ALSA to be used
-RUN usermod -a -G audio root
-
 # Install ALSA library and SOX
 RUN apt-get update && apt-get install -y \
     libasound2 \

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Archives also contains libtensorflowlite_c library.
 ```
 docker run -ti \
   -p 8080:8080 \
+  --device /dev/snd \
   -v /path/to/config:/config \
   -v /path/to/data:/data \
   ghcr.io/tphakala/birdnet-go:latest
@@ -44,6 +45,7 @@ docker run -ti \
 | Parameter | Function |
 | :----: | --- |
 | `-p 8080` | BirdNET-GO webserver port. |
+| `--device /dev/snd` | Mounts in audio devices to the container. |
 | `-v /config` | Config directory in the container. |
 | `-v /data` | Data such as database and recordings. |
 


### PR DESCRIPTION
I'm using podman and had some issues with the most recent change. This adds the runtime user to the audio group, and adds instructions on how to mount in the audio devices to the container.