### PR TITLE
support RTSP by using `ffmpeg` to convert the stream

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,13 +37,14 @@ RUN apt-get update && apt-get install -y \
     ca-certificates \
     libasound2 \
     sox \
+    ffmpeg \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=build /root/src/BirdNET-Go/bin /usr/bin/
 COPY --from=build /usr/local/lib/libtensorflowlite_c.so /usr/local/lib/
 RUN ldconfig
 
-# Add symlink to /config directory where configs can be stored 
+# Add symlink to /config directory where configs can be stored
 VOLUME /config
 RUN mkdir -p /root/.config && ln -s /config /root/.config/birdnet-go
 

--- a/cmd/realtime/realtime.go
+++ b/cmd/realtime/realtime.go
@@ -35,6 +35,7 @@ func setupFlags(cmd *cobra.Command, settings *conf.Settings) error {
 	cmd.Flags().StringVar(&settings.Realtime.AudioExport.Path, "clippath", viper.GetString("realtime.audioexport.path"), "Path to save audio clips")
 	cmd.Flags().StringVar(&settings.Realtime.Log.Path, "logpath", viper.GetString("realtime.log.path"), "Path to save log files")
 	cmd.Flags().BoolVar(&settings.Realtime.ProcessingTime, "processingtime", viper.GetBool("realtime.processingtime"), "Report processing time for each detection")
+	cmd.Flags().StringVar(&settings.Realtime.RTSP, "rtsp", viper.GetString("realtime.rtsp"), "URL of RTSP audio stream to capture")
 
 	// Bind flags to the viper settings
 	if err := viper.BindPFlags(cmd.Flags()); err != nil {

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -59,6 +59,8 @@ type Settings struct {
 		PrivacyFilter struct {
 			Enabled bool // true to enable privacy filter
 		}
+
+		RTSP string // RTSP stream URL
 	}
 
 	WebServer struct {
@@ -215,7 +217,7 @@ realtime:
   log:
     enabled: false		# true to enable OBS chat log
     path: birdnet.txt	# path to OBS chat log
-    
+
   birdweather:
     enabled: false		# true to enable birdweather uploads
     debug: false		# true to enable birdweather api debug mode


### PR DESCRIPTION
adding very basic support for RTSP.

usage: `birdnet-go realtime --rtsp rtsp://...`
if an rtsp URL is not provided, it will default to using the audio device.

I've been running this for the past week without issues.

resolves #12 