### PR TITLE
Add in a --rtsptransport flag to realtime command

### DIFF
--- a/cmd/realtime/realtime.go
+++ b/cmd/realtime/realtime.go
@@ -36,6 +36,7 @@ func setupFlags(cmd *cobra.Command, settings *conf.Settings) error {
 	cmd.Flags().StringVar(&settings.Realtime.Log.Path, "logpath", viper.GetString("realtime.log.path"), "Path to save log files")
 	cmd.Flags().BoolVar(&settings.Realtime.ProcessingTime, "processingtime", viper.GetBool("realtime.processingtime"), "Report processing time for each detection")
 	cmd.Flags().StringVar(&settings.Realtime.RTSP, "rtsp", viper.GetString("realtime.rtsp"), "URL of RTSP audio stream to capture")
+	cmd.Flags().StringVar(&settings.Realtime.RTSPTransport, "rtsptransport", viper.GetString("realtime.rtsptransport"), "RTSP transport (tcp/udp)")
 
 	// Bind flags to the viper settings
 	if err := viper.BindPFlags(cmd.Flags()); err != nil {

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -61,6 +61,7 @@ type Settings struct {
 		}
 
 		RTSP string // RTSP stream URL
+		RTSPTransport string //RTSP Transport Protocol
 	}
 
 	WebServer struct {

--- a/internal/myaudio/capture.go
+++ b/internal/myaudio/capture.go
@@ -172,8 +172,14 @@ func captureAudioRTSP(settings *conf.Settings, wg *sync.WaitGroup, quitChan chan
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	rtsp_transport := "udp"
+	if (settings.Realtime.RTSPTransport != "") {
+		rtsp_transport = settings.Realtime.RTSPTransport;
+	}
+
 	// Start ffmpeg
 	cmd := exec.CommandContext(ctx, "ffmpeg",
+		"-rtsp_transport", rtsp_transport, // RTSP transport protocol (tcp/udp)
 		"-i", settings.Realtime.RTSP,
 		"-loglevel", "error",
 		"-vn",         // No video


### PR DESCRIPTION
By default ffmpeg will use UDP when streaming from an RTSP source. Some setups (in my case when running the docker container in a Kubernetes cluster) won't work with a UDP connection, and so require a TCP connection instead.

This PR adds in an --rtsptransport flag, which defaults to udp, but can be set to tcp if required.

This is my first attempt working with Go, so please feel free to point me in the right direction if there's a better way to be doing something! 