### PR TITLE
feat(processor) add dog bark filter which can be used to track recent dog barks to filter out regularly occuring false detections

### DIFF
--- a/internal/analysis/processor/dogbarkfilter.go
+++ b/internal/analysis/processor/dogbarkfilter.go
@@ -1,0 +1,78 @@
+package processor
+
+import (
+	"encoding/csv"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/tphakala/birdnet-go/internal/conf"
+)
+
+// Assuming a predefined time limit for filtering detections after a dog bark.
+const DogBarkFilterTimeLimit = 300 * time.Second
+
+// DogBarkFilter contains a list of species to be filtered within the time limit after a dog bark.
+type DogBarkFilter struct {
+	SpeciesList []string
+}
+
+// LoadDogBarkFilterConfig reads the dog bark filter configuration from a CSV file.
+func LoadDogBarkFilterConfig(fileName string) (DogBarkFilter, error) {
+	var config DogBarkFilter
+
+	// Retrieve the default config paths from your application settings.
+	configPaths, err := conf.GetDefaultConfigPaths()
+	if err != nil {
+		return DogBarkFilter{}, err
+	}
+
+	var file *os.File
+	// Attempt to open the file from one of the default config paths.
+	for _, path := range configPaths {
+		fullPath := filepath.Join(path, fileName)
+		file, err = os.Open(fullPath)
+		if err == nil {
+			break
+		}
+	}
+
+	if file == nil {
+		// if file is not found just return empty config and error
+		return DogBarkFilter{}, fmt.Errorf("file '%s' not found in default config paths", fileName)
+	}
+	defer file.Close()
+
+	reader := csv.NewReader(file)
+	// Assuming no header and one species per line.
+	records, err := reader.ReadAll()
+	if err != nil {
+		return DogBarkFilter{}, err
+	}
+
+	for _, record := range records {
+		if len(record) == 0 {
+			continue // Skip empty lines
+		}
+		// Assuming the species name is the only entry in each record.
+		species := strings.ToLower(strings.TrimSpace(record[0]))
+		config.SpeciesList = append(config.SpeciesList, species)
+	}
+	log.Println("Dog bark filter config loaded")
+
+	return config, nil
+}
+
+// Check if the species should be filtered based on the last dog bark timestamp.
+func (c DogBarkFilter) Check(species string, lastDogBark time.Time) bool {
+	species = strings.ToLower(species)
+	for _, s := range c.SpeciesList {
+		if s == species {
+			return time.Since(lastDogBark) <= DogBarkFilterTimeLimit
+		}
+	}
+	return false
+}

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -60,6 +60,10 @@ type Settings struct {
 			Enabled bool // true to enable privacy filter
 		}
 
+		DogBarkFilter struct {
+			Enabled bool // true to enable dog bark filter
+		}
+
 		RTSP string // RTSP stream URL
 	}
 
@@ -224,6 +228,9 @@ realtime:
     id: 00000			# birdweather ID
 
   privacyfilter:
+    enabled: true
+
+  dogbarkfilter:
     enabled: true
 
 webserver:

--- a/internal/conf/consts.go
+++ b/internal/conf/consts.go
@@ -8,4 +8,5 @@ const (
 
 	SpeciesConfigCSV  = "species_config.csv"
 	SpeciesActionsCSV = "species_actions.csv"
+	DogBarkFilterCSV  = "dog_bark_filter.csv"
 )


### PR DESCRIPTION
BirdNET model is often incorrectly detecting dog barks as owls, this commit implements a filter which tracks dog barks and filters out user configured species detections if it happens within 5 minutes of last dog bark detection.

Species which are filtered by dog bark filter are configured in dog_bark_filter.cvs in BirdNET-Go config directory, file content should be species name per line, species can be common name or scientific name like:

ural owl
strix uralensis

Filter must be enabled in config file by setting

realtime:
    dogbarkfilter:
        enabled: true