### PR TITLE
Fix invalid indents in default config

### DIFF
--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -223,7 +223,7 @@ realtime:
     path: clips/   		# path to audio clip export directory
     type: wav      		# only wav supported for now
   
-	log:
+  log:
     enabled: false		# true to enable OBS chat log
     path: birdnet.txt	# path to OBS chat log
 
@@ -233,8 +233,8 @@ realtime:
     id: 00000			# birdweather ID
 
   rtsp:
-	url: 				# RTSP stream URL
-	transport: tcp		# RTSP Transport Protocol
+    url:				# RTSP stream URL
+    transport: tcp		# RTSP Transport Protocol
 
   privacyfilter:
     enabled: true


### PR DESCRIPTION
The container did not start as expected anymore since this [commit](https://github.com/tphakala/birdnet-go/commit/94b19e7de8e5075f91f614a022a455def05a53fc) introduced some weird indents.

Got the following two errors:

> Created default config file at: /root/.config/birdnet-go/config.yaml
Error loading configuration: error initializing viper: While parsing config: yaml: line 36: found character that cannot start any token

> Created default config file at: /root/.config/birdnet-go/config.yaml
Error loading configuration: error initializing viper: While parsing config: yaml: line 46: found character that cannot start any token

My pull request fixes it by indenting correctly. Maybe we could add some sort of workflow to start the container and do some smaller tests in order to catch issues like this in the future :+1: 