### PR TITLE
Enable incremental docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,9 @@ RUN git clone --branch ${TENSORFLOW_VERSION} --depth 1 https://github.com/tensor
 
 # Compile BirdNET-Go
 COPY . BirdNET-Go
-RUN cd BirdNET-Go && make TARGETPLATFORM=${TARGETPLATFORM}
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    cd BirdNET-Go && make TARGETPLATFORM=${TARGETPLATFORM}
 
 # Create final image using a multi-platform base image
 FROM debian:bookworm-slim


### PR DESCRIPTION
Based on this [guide](https://docs.docker.com/build/guide/mounts/) the Dockerfile was modified to enable build and dependency cache for go inside the builder container. Meaning that go will no longer download all dependencies on every single rebuild. Greatly speeds up the local build process.