### PR TITLE
Test docker image before pushing to registry

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -8,7 +8,8 @@ on:
 
 jobs:
   push-docker-image:
-    runs-on: ubuntu-latest
+    # Ubuntu-20.04 required until this is fixed: https://github.com/actions/runner-images/discussions/9074
+    runs-on: ubuntu-20.04
     steps:
       - name: 'Checkout GitHub Action'
         uses: actions/checkout@v4.1.1
@@ -35,7 +36,32 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-buildx-
 
-      - name: 'Build and Push Inventory Image'
+      - name: 'Build image for testing'
+        uses: docker/build-push-action@v5.1.0
+        with:
+          tags: ghcr.io/${{ env.REPO }}:test
+          load: true
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+
+      - name: 'Install alsa dummy module for testing built image'
+        run: |
+          sudo apt-get install linux-modules-extra-$(uname -r)
+          sudo modprobe snd-dummy
+
+      - name: 'Test built image'
+        run: |
+          docker run --rm -p 8080:8080 --device /dev/snd --env ALSA_CARD=0 ghcr.io/${{ env.REPO }}:test & p1=$!
+          if ! wget --retry-connrefused --waitretry=1 --tries=5 -q -O /dev/null http://localhost:8080; then
+            echo "Failed to reach container after 5 sec"
+            kill "$p1"
+            exit 1
+          else
+            echo "Container responded to request"
+            kill "$p1"
+          fi
+
+      - name: 'Build and push images for all platforms'
         uses: docker/build-push-action@v5.1.0
         with:
           push: true


### PR DESCRIPTION
As mentioned before, I thought it would be nice to have some sort of verification of the docker images. This pr adds such a feature by starting the image and giving it 5 sec to respond to a http request. Only if it responds within time, then the docker image(s) will be pushed to the registry.

Had to do a bit of fighting with the github action runner since it does not contain any alsa devices, causing the container to not start properly. I was able to work around this by installing the alsa dummy soundcard. Unfortunately, there appears to be certain issues with ubuntu-22 due to recent kernel changes, meaning that I had to downgrade to ubuntu-20.04 for this to work. However, there is a discussion ongoing on getting the ubuntu-22 runner behaving as expected in the [works](https://github.com/actions/runner-images/discussions/9074).