### PR TITLE
Add initial devcontainer integration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,14 @@
+{
+	"name": "Go Build Environment",
+	"dockerFile": "../Dockerfile",
+	"build": {
+		"context": "..",
+		"target": "buildenv"
+	},
+	"runArgs": ["--device=/dev/snd"],
+	"containerEnv": {
+		"ALSA_CARD": "0"
+	},
+	"postCreateCommand": "apt-get update && apt-get install -y ca-certificates libasound2 ffmpeg sox && apt-get clean && go install github.com/cosmtrek/air@latest",
+	"postAttachCommand": "make dev_server"
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Use ARGs to define default build-time variables for TensorFlow version and target platform
 ARG TENSORFLOW_VERSION=v2.14.0
 
-FROM golang:1.22.1-bookworm as build
+FROM golang:1.22.1-bookworm as buildenv
 
 # Pass in ARGs after FROM to use them in build stage
 ARG TENSORFLOW_VERSION
@@ -32,6 +32,8 @@ WORKDIR /root/src
 
 # Download TensorFlow headers
 RUN git clone --branch ${TENSORFLOW_VERSION} --depth 1 https://github.com/tensorflow/tensorflow.git
+
+FROM buildenv as build
 
 # Compile BirdNET-Go
 COPY . BirdNET-Go

--- a/Makefile
+++ b/Makefile
@@ -107,6 +107,9 @@ macos_arm: TFLITE_LIB=tflite_c_$(TFLITE_VERSION)_$(GOOS)_$(GOARCH).tar.gz
 macos_arm: $(LABELS_ZIP) check-tools check-tensorflow download-tflite install-tflite build
 	$(CGO_FLAGS) go build $(LDFLAGS) -o $(BINARY_DIR)/$(BINARY_NAME)
 
+dev_server: 
+	$(CGO_FLAGS) air realtime
+
 clean:
 	go clean
 	rm -rf $(BINARY_DIR)/* tflite_c *.tar.gz *.zip


### PR DESCRIPTION
Recently there has been many new users who would like to get started with the project. To make it easier to start contributing to the project it might be beneficial to have a devcontainer setup.

This pr adds a very basic devcontainer that on startup will start a "dev_server" which was also added to the makefile. This dev_server is in reality just making use of the [air](https://github.com/cosmtrek/air) tool for hot reloading on any code changes. I would assume that might be how development is supposed to be done since there is already a .air.toml file :)

Will try to make another pull request soon where I update the docs a bit to mention the devcontainer.