### PR TITLE
github(workflow): Add tensorflow dependencies to golangci-lint

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -20,7 +20,15 @@ jobs:
         with:
           go-version-file: 'go.mod'
       - run: go version
-          
+
+      - name: Install dependencies
+        run: make check-tensorflow
+      
+      - name: Set environment variables for CGO
+        run: |
+          echo "CGO_ENABLED=1" >> $GITHUB_ENV
+          echo "CGO_CFLAGS=-I $HOME/src/tensorflow" >> $GITHUB_ENV
+
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v4
         with:


### PR DESCRIPTION
The workflow was always failing since it did not have the required tensorflow headers in the workflow. Causing it to fail with errors such as:

```
   Error: could not import github.com/tphakala/go-tflite (-: # github.com/tphakala/go-tflite
  In file included from ../../../go/pkg/mod/github.com/tphakala/go-tflite@v0.0.0-20231013114437-e78004b1b843/tflite.go:5:
  ./tflite.go.h:8:10: fatal error: tensorflow/lite/c/c_api.h: No such file or directory
      8 | #include <tensorflow/lite/c/c_api.h>
        |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~
  compilation terminated.) (typecheck)
  Error: undefined: tflite (typecheck)
  Error: undefined: tflite (typecheck)
  Error: undefined: tflite (typecheck)
```

Fixing it by making sure that the tensorflow headers are downloaded before running the linting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Improved CI workflow by adding steps to install dependencies and configure environment variables for CGO.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->