### PR TITLE
Optimize fetching of tensorflow header files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,10 @@ RUN PLATFORM='unknown'; \
 WORKDIR /root/src
 
 # Download TensorFlow headers
-RUN git clone --branch ${TENSORFLOW_VERSION} --depth 1 https://github.com/tensorflow/tensorflow.git
+RUN git clone --branch ${TENSORFLOW_VERSION} --filter=blob:none --depth 1 --no-checkout https://github.com/tensorflow/tensorflow.git \
+    && git -C tensorflow config core.sparseCheckout true \
+    && echo "**/*.h" >> tensorflow/.git/info/sparse-checkout \
+    && git -C tensorflow checkout
 
 FROM buildenv as build
 

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,10 @@ check-tensorflow:
 	@if [ ! -f "$(HOME)/src/tensorflow/tensorflow/lite/c/c_api.h" ]; then \
 		echo "TensorFlow Lite C API header not found. Cloning TensorFlow source..."; \
 		mkdir -p $(HOME)/src; \
-		git clone --branch v2.14.0 --depth 1 https://github.com/tensorflow/tensorflow.git $(HOME)/src/tensorflow; \
+		git clone --branch v2.14.0 --filter=blob:none --depth 1 --no-checkout https://github.com/tensorflow/tensorflow.git $(HOME)/src/tensorflow; \
+		git -C $(HOME)/src/tensorflow config core.sparseCheckout true; \
+		echo "**/*.h" >> $(HOME)/src/tensorflow/.git/info/sparse-checkout; \
+		git -C $(HOME)/src/tensorflow checkout; \
 	else \
 		echo "TensorFlow Lite C API header exists."; \
 	fi


### PR DESCRIPTION
Rather than cloning the whole tensorflow repository, which is rather large, clone only the header files. Accomplished by utilizing sparse checkout feature.

During testing, cloning tensorflow like this was over 5 times faster than the old approach. It can be optimized further by limiting which folders to grab header files from too. However, currently I am not too familiar with how the header files are dependent on each-other, so I decided not to go for the extreme "tensorflow/lite/**/*.h" pattern which I was able to build and run the application with, since some of the headers there had dependencies to tensorflow/core.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **Chores**
	- Improved the download and retrieval processes for TensorFlow headers by configuring sparse checkout in the Dockerfile and Makefile.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->