### PR TITLE
Improve devcontainer setup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,8 +7,10 @@
 	},
 	"runArgs": ["--device=/dev/snd"],
 	"containerEnv": {
-		"ALSA_CARD": "0"
+		"ALSA_CARD": "0",
+		"CGO_ENABLED": "1",
+		"CGO_CFLAGS": "-I /root/src/tensorflow"
 	},
-	"postCreateCommand": "apt-get update && apt-get install -y ca-certificates libasound2 ffmpeg sox && apt-get clean && go install github.com/cosmtrek/air@latest",
-	"postAttachCommand": "make dev_server"
+	"postCreateCommand": ".devcontainer/postCreateCommand.sh",
+	"postAttachCommand": "make dev_server",
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,5 +19,8 @@
 				"golang.go"
 			]
 		}
+	},
+	"features": {
+		"ghcr.io/devcontainers/features/github-cli:1": {}
 	}
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,4 +13,11 @@
 	},
 	"postCreateCommand": ".devcontainer/postCreateCommand.sh",
 	"postAttachCommand": "make dev_server",
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"golang.go"
+			]
+		}
+	}
 }

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -3,6 +3,7 @@
 # Install required apt dependencies
 apt-get update
 apt-get install -y ca-certificates libasound2 ffmpeg sox
+apt-get install -y nano vim
 apt-get clean
 
 # Install air to support live reloading of server on code changes

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -1,0 +1,10 @@
+# Install required apt dependencies
+apt-get update
+apt-get install -y ca-certificates libasound2 ffmpeg sox
+apt-get clean
+
+# Install air to support live reloading of server on code changes
+go install github.com/cosmtrek/air@latest
+
+# Install golangci-lint to allow running of linting locally
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.57.2

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # Install required apt dependencies
 apt-get update
 apt-get install -y ca-certificates libasound2 ffmpeg sox
@@ -7,4 +9,4 @@ apt-get clean
 go install github.com/cosmtrek/air@latest
 
 # Install golangci-lint to allow running of linting locally
-curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.57.2
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$(go env GOPATH)/bin" v1.57.2


### PR DESCRIPTION
I'm trying to use the devcontainer myself for development now. Found some missing dependencies that I thought could be useful to have in it.

- **Add golangci-lint to devcontainer**
- **Add golang extension to devcontainer**
- **Add github cli to devcontainer**
