### PR TITLE
feat: Add initial retention policy

### DIFF
--- a/internal/analysis/realtime.go
+++ b/internal/analysis/realtime.go
@@ -7,6 +7,7 @@ import (
 	"os/signal"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/tphakala/birdnet-go/internal/analysis/processor"
 	"github.com/tphakala/birdnet-go/internal/analysis/queue"
@@ -82,6 +83,8 @@ func RealtimeAnalysis(settings *conf.Settings) error {
 	startBufferMonitor(&wg, bn, quitChan)
 	// start audio capture
 	startAudioCapture(&wg, settings, quitChan, restartChan, audioBuffer)
+	// start cleanup of clips
+	startClipCleanupMonitor(&wg, settings, dataStore, quitChan)
 
 	// start quit signal monitor
 	monitorCtrlC(quitChan)
@@ -105,6 +108,7 @@ func RealtimeAnalysis(settings *conf.Settings) error {
 			startAudioCapture(&wg, settings, quitChan, restartChan, audioBuffer)
 		}
 	}
+
 }
 
 // startAudioCapture initializes and starts the audio capture routine in a new goroutine.
@@ -117,6 +121,12 @@ func startAudioCapture(wg *sync.WaitGroup, settings *conf.Settings, quitChan cha
 func startBufferMonitor(wg *sync.WaitGroup, bn *birdnet.BirdNET, quitChan chan struct{}) {
 	wg.Add(1)
 	go myaudio.BufferMonitor(wg, bn, quitChan)
+}
+
+// startClipCleanupMonitor initializes and starts the clip cleanup monitoring routine in a new goroutine.
+func startClipCleanupMonitor(wg *sync.WaitGroup, settings *conf.Settings, dataStore datastore.Interface, quitChan chan struct{}) {
+	wg.Add(1)
+	go ClipCleanupMonitor(wg, settings, dataStore, quitChan)
 }
 
 // monitorCtrlC listens for the SIGINT (Ctrl+C) signal and triggers the application shutdown process.
@@ -138,5 +148,36 @@ func closeDataStore(store datastore.Interface) {
 		log.Printf("Failed to close database: %v", err)
 	} else {
 		log.Println("Successfully closed database")
+	}
+}
+
+// ClipCleanupMonitor monitors the database and deletes clips that meets the retention policy.
+func ClipCleanupMonitor(wg *sync.WaitGroup, settings *conf.Settings, dataStore datastore.Interface, quitChan chan struct{}) {
+	defer wg.Done()
+
+	// Creating a ticker that ticks every 1 minute
+	ticker := time.NewTicker(1 * time.Minute)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-quitChan:
+			// Quit signal received, stop the clip cleanup monitor
+			return
+
+		case <-ticker.C: // Wait for the next tick
+			clipsForRemoval, _ := dataStore.GetClipsQualifyingForRemoval(settings.Realtime.Retention.MinEvictionHours, settings.Realtime.Retention.MinClipsPerSpecies)
+
+			log.Printf("Found %d clips to remove\n", len(clipsForRemoval))
+
+			for _, clip := range clipsForRemoval {
+				if err := os.Remove(clip.ClipName); err != nil {
+					log.Printf("Failed to remove %s: %s\n", clip.ClipName, err)
+				} else {
+					log.Printf("Removed %s\n", clip.ClipName)
+				}
+				dataStore.DeleteNoteClipPath(clip.ID)
+			}
+		}
 	}
 }

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -66,6 +66,11 @@ type Settings struct {
 			Enabled bool // true to enable dog bark filter
 		}
 
+		Retention struct {
+			MinEvictionHours   int // minimum number of hours to keep audio clips
+			MinClipsPerSpecies int // minimum number of clips per species to keep
+		}
+
 		RTSP struct {
 			Url       string // RTSP stream URL
 			Transport string // RTSP Transport Protocol
@@ -265,6 +270,11 @@ realtime:
 
   dogbarkfilter:
     enabled: true
+
+  retention:
+    enabled: true                   # true to enable retention policy of clips
+    minEvictionHours: 72			# minumum number of hours before considering clip for eviction
+    minClipsPerSpecies: 10		    # minumum number of clips per species to keep before starting evictions
 
 webserver:
   enabled: true		# true to enable web server

--- a/internal/datastore/interfaces_test.go
+++ b/internal/datastore/interfaces_test.go
@@ -1,0 +1,88 @@
+package datastore
+
+import (
+	"testing"
+	"time"
+
+	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/logger"
+)
+
+func createDatabase(t testing.TB, settings *conf.Settings) Interface {
+	tempDir := t.TempDir()
+	settings.Output.SQLite.Enabled = true
+	settings.Output.SQLite.Path = tempDir + "/test.db"
+
+	dataStore := New(settings)
+
+	// Open a connection to the database and handle possible errors.
+	if err := dataStore.Open(); err != nil {
+		logger.Error("main", "Failed to open database: %v", err)
+	} else {
+		t.Cleanup(func() { dataStore.Close() })
+	}
+
+	return dataStore
+}
+
+func TestGetClipsQualifyingForRemoval(t *testing.T) {
+
+	settings := &conf.Settings{}
+
+	dataStore := createDatabase(t, settings)
+
+	// One Cool bird should be removed since there is one too many
+	// No Amazing bird should be removed since there is only one
+	// While there are two Wonderful birds, only one of them are old enough, but too few to be removed
+	// While there are two Magnificent birds, only one of them have a clip, meaning that the remaining one should be kept
+	dataStore.Save(&Note{
+		ClipName:       "test.wav",
+		ScientificName: "Cool bird",
+		BeginTime:      time.Now().Add(-2 * time.Hour),
+	}, []Results{})
+	dataStore.Save(&Note{
+		ClipName:       "test2.wav",
+		ScientificName: "Amazing bird",
+		BeginTime:      time.Now().Add(-2 * time.Hour),
+	}, []Results{})
+	dataStore.Save(&Note{
+		ClipName:       "test3.wav",
+		ScientificName: "Cool bird",
+		BeginTime:      time.Now().Add(-2 * time.Hour),
+	}, []Results{})
+	dataStore.Save(&Note{
+		ClipName:       "test4.wav",
+		ScientificName: "Wonderful bird",
+		BeginTime:      time.Now().Add(-2 * time.Hour),
+	}, []Results{})
+	dataStore.Save(&Note{
+		ClipName:       "test5.wav",
+		ScientificName: "Magnificent bird",
+		BeginTime:      time.Now().Add(-2 * time.Hour),
+	}, []Results{})
+	dataStore.Save(&Note{
+		ClipName:       "",
+		ScientificName: "Magnificent bird",
+		BeginTime:      time.Now(),
+	}, []Results{})
+	dataStore.Save(&Note{
+		ClipName:       "test7.wav",
+		ScientificName: "Wonderful bird",
+		BeginTime:      time.Now(),
+	}, []Results{})
+
+	minHours := 1
+	minClips := 1
+
+	clipsForRemoval, err := dataStore.GetClipsQualifyingForRemoval(minHours, minClips)
+
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+	if len(clipsForRemoval) != 1 {
+		t.Errorf("Expected one entry in clipsForRemoval, got %d", len(clipsForRemoval))
+	}
+	if clipsForRemoval[0].ScientificName != "Cool bird" {
+		t.Errorf("Expected ScientificName to be 'Cool bird', got '%s'", clipsForRemoval[0].ScientificName)
+	}
+}


### PR DESCRIPTION
As [mentioned](https://github.com/tphakala/birdnet-go/issues/69#issuecomment-2043282550), I wanted to give the simple retention policy a try. Anything is better than nothing as my raspberry keeps running out of space otherwise. I am still trying out this change locally and might make some more changes to it. However, I thought it could still be a good idea to open up this pull request to get some feedback on the idea itself and the code.

The simple retention policy works by every minute, querying the database for clips older than **minEvictionHours**, for these clips, it will then remove those for species that have more than **minClipsPerSpecies**. Always removing the oldest clips first.

I am a bit uncertain of where to place all the logic. Right now I jammed it into the realtime.go and interface.go, but there might be better places to put it? In addition, it has to be decided if this is a feature which should be enabled by default or not. In addition, the spectrogram images are currently saved to the clips folder too, I wonder if it might be better to move them to some other cached directory?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced automated clip cleanup based on retention policies to manage storage efficiently.
- **Enhancements**
	- Updated settings to allow configuration of clip retention parameters.
- **Tests**
	- Added tests to ensure proper identification and removal of clips according to the new retention policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->