### PR TITLE
Fix SQL error in GetClipsQualifyingForRemoval

### DIFF
--- a/internal/datastore/interfaces.go
+++ b/internal/datastore/interfaces.go
@@ -214,7 +214,7 @@ func (ds *DataStore) GetClipsQualifyingForRemoval(minHours int, minClips int) ([
 	}
 
 	// Main query to find clips qualifying for removal based on retention policy
-	err := ds.DB.Model(&Note{}).
+	err := ds.DB.Table("(?) AS n", ds.DB.Model(&Note{})).
 		Select("n.ID, n.scientific_name, n.clip_name, sub.num_recordings").
 		Joins("INNER JOIN (?) AS sub ON n.ID = sub.ID", subquery).
 		Where("strftime('%s', 'now') - strftime('%s', begin_time) > ?", minHours*3600). // Convert hours to seconds for comparison


### PR DESCRIPTION
This [commit](https://github.com/tphakala/birdnet-go/commit/16c0961738664f8fc5dbef203d6651258d2c173e) removed a important **n** from the SQL statement. Causing unit tests etc to fail:

![image](https://github.com/tphakala/birdnet-go/assets/8884086/58b39507-cdf3-4d77-8a2d-b325132bde13)

Since the original commit got merged quite quickly, so did a small hack I used to get in a **AS n**. This pull request fixes that hack by doing it the way gorm intended for it to be done.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the query logic for identifying clips eligible for removal based on retention policies, enhancing performance and accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->