### PR TITLE
feat(birdweather) Birdweather location fuzzing

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -3,6 +3,10 @@ BirdNET-Go is work of
 
 Tomi P. Hakala
 
+Contributions by Hampus Carlsson, Jan Vrska, @twt--, @aster1sk, @hoover67
+
+If you are missing from contributors list please let me know!
+
 BirdNET model by the K. Lisa Yang Center for Conservation Bioacoustics
 at the Cornell Lab of Ornithology in collaboration with Chemnitz
 University of Technology. Stefan Kahl, Connor Wood, Maximilian Eibl,

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ BirdNET-Go is an AI solution for continuous avian monitoring and identification
 - BirdWeather.com API integration
 - Realtime log file output can be used as overlay in OBS for bird feeder streams etc.
 - Minimal runtime dependencies, BirdNET Tensorflow Lite model is embedded in compiled binary
+- Provides endpoint for Prometheus data scraping
 - Runs on Windows, Linux and macOS
 - Low resource usage, works on Raspberry Pi 3 and equivalent 64-bit single board computers
 
@@ -79,6 +80,10 @@ Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International
 ## Authors
 
 Tomi P. Hakala
+
+Contributions by Hampus Carlsson, Jan Vrska, @twt--, @aster1sk, @hoover67
+
+Please let me know if you are missing from contributors list!
 
 BirdNET AI model by the K. Lisa Yang Center for Conservation Bioacoustics at the Cornell Lab of Ornithology in collaboration with Chemnitz University of Technology. Stefan Kahl, Connor Wood, Maximilian Eibl, Holger Klinck.
 

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -262,7 +262,7 @@ realtime:
   birdweather:
     enabled: false		  # true to enable birdweather uploads
     locationaccuracy: 500 # accuracy of location in meters
-	debug: false		  # true to enable birdweather api debug mode
+    debug: false		  # true to enable birdweather api debug mode
     id: 00000			  # birdweather ID
 	
   rtsp:

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -52,10 +52,11 @@ type Settings struct {
 		}
 
 		Birdweather struct {
-			Enabled   bool    // true to enable birdweather uploads
-			Debug     bool    // true to enable debug mode
-			ID        string  // birdweather ID
-			Threshold float64 // threshold for prediction confidence for uploads
+			Enabled          bool    // true to enable birdweather uploads
+			Debug            bool    // true to enable debug mode
+			ID               string  // birdweather ID
+			Threshold        float64 // threshold for prediction confidence for uploads
+			LocationAccuracy float64 // accuracy of location in meters
 		}
 
 		PrivacyFilter struct {
@@ -259,10 +260,11 @@ realtime:
     path: birdnet.txt	# path to OBS chat log
 
   birdweather:
-    enabled: false		# true to enable birdweather uploads
-    debug: false		# true to enable birdweather api debug mode
-    id: 00000			# birdweather ID
-
+    enabled: false		  # true to enable birdweather uploads
+    locationaccuracy: 500 # accuracy of location in meters
+	debug: false		  # true to enable birdweather api debug mode
+    id: 00000			  # birdweather ID
+	
   rtsp:
     url:				# RTSP stream URL
     transport: tcp		# RTSP Transport Protocol


### PR DESCRIPTION
Added location fuzzing support for BirdWeather uploads, you can add location precision in meters to config.yaml, however this seems to require some support from BirdWeather backend also, request sent to Tim to support this.

Config example

  birdweather:
    enabled: false		  # true to enable birdweather uploads
    locationaccuracy: 500   # accuracy of location in meters
    debug: false		  # true to enable birdweather api debug mode
    id: 00000			  # birdweather ID
	