### PR TITLE
Default date picker to local time zone

### DIFF
--- a/views/index.html
+++ b/views/index.html
@@ -39,7 +39,7 @@
 		// Set the date picker to today's date
 		setTimeout(function () {
 			var datePicker = document.getElementById('datePicker');
-			var today = new Date().toISOString().split('T')[0];
+			var today = new Date().toLocaleString('sv').split(' ')[0];
 			datePicker.value = today;
 		}, 0); // Set timeout for 0ms
 


### PR DESCRIPTION
`new Date().toISOString()` always returns the current time in UTC, so when it's after UTC midnight, but still before UTC midnight of the previous day (say, at 10 PM in New York), the date picker defaults to tomorrow, which will never contain any data.

This changes to use `toLocaleString` to ensure the date picker always reflects the browser's local today date. It uses the Swedish (`sv`) locale simply because they use an `YYYY-MM-DD` date format, which is the most useful in this case