### PR TITLE
Remove unexpected tab character from config

### DIFF
--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -264,7 +264,7 @@ realtime:
     locationaccuracy: 500 # accuracy of location in meters
     debug: false		  # true to enable birdweather api debug mode
     id: 00000			  # birdweather ID
-	
+
   rtsp:
     url:				# RTSP stream URL
     transport: tcp		# RTSP Transport Protocol


### PR DESCRIPTION
Fixes config validation issue mentioned in #148 Was able to verify that it works in my fork