### PR TITLE
Clear clip path from note during cleanup when clip is missing

### DIFF
--- a/internal/analysis/realtime.go
+++ b/internal/analysis/realtime.go
@@ -223,7 +223,7 @@ func ClipCleanupMonitor(wg *sync.WaitGroup, settings *conf.Settings, dataStore d
 				// Attempt to remove the clip file from the filesystem
 				if err := os.Remove(clip.ClipName); err != nil {
 					if os.IsNotExist(err) {
-						// Only attempt to delete the database record if the file removal was successful
+						// Attempt to delete the database record if the clip file aleady doesn't exist
 						if err := dataStore.DeleteNoteClipPath(clip.ID); err != nil {
 							log.Printf("Failed to delete clip path for %s: %s\n", clip.ID, err)
 						} else {
@@ -234,7 +234,7 @@ func ClipCleanupMonitor(wg *sync.WaitGroup, settings *conf.Settings, dataStore d
 					}
 				} else {
 					log.Printf("Removed %s\n", clip.ClipName)
-					// Only attempt to delete the database record if the file removal was successful
+					// Attempt to delete the database record if the file removal was successful
 					if err := dataStore.DeleteNoteClipPath(clip.ID); err != nil {
 						log.Printf("Failed to delete clip path for %s: %s\n", clip.ID, err)
 					}

--- a/internal/analysis/realtime.go
+++ b/internal/analysis/realtime.go
@@ -222,7 +222,16 @@ func ClipCleanupMonitor(wg *sync.WaitGroup, settings *conf.Settings, dataStore d
 			for _, clip := range clipsForRemoval {
 				// Attempt to remove the clip file from the filesystem
 				if err := os.Remove(clip.ClipName); err != nil {
-					log.Printf("Failed to remove %s: %s\n", clip.ClipName, err)
+					if os.IsNotExist(err) {
+						// Only attempt to delete the database record if the file removal was successful
+						if err := dataStore.DeleteNoteClipPath(clip.ID); err != nil {
+							log.Printf("Failed to delete clip path for %s: %s\n", clip.ID, err)
+						} else {
+							log.Printf("Cleared clip path of missing clip for %s\n", clip.ID)
+						}
+					} else {
+						log.Printf("Failed to remove %s: %s\n", clip.ClipName, err)
+					}
 				} else {
 					log.Printf("Removed %s\n", clip.ClipName)
 					// Only attempt to delete the database record if the file removal was successful


### PR DESCRIPTION
When the clip cleanup process tries to delete a clip file, and the OS reports that the file does not exist, this will now detect that condition and still attempt to clear the clipPath from the clip.

Closes #149 