### PR TITLE
Add release tagging of docker images

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -66,7 +66,7 @@ jobs:
         with:
           push: true
           tags: |
-            ghcr.io/${{ env.REPO }}:latest
+            ghcr.io/${{ env.REPO }}:dev
             ghcr.io/${{ env.REPO }}:${{ github.sha }}
           platforms: linux/amd64,linux/arm64
           cache-from: type=local,src=/tmp/.buildx-cache

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   build:
@@ -35,3 +36,36 @@ jobs:
         compress_assets: auto
         build_command: make ${{ matrix.goos }}_${{ matrix.goarch }}
         extra_files: libtensorflowlite_c.so
+
+  docker-tagging:
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v3.0.0
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Generate downcase repository name
+      run: |
+        echo "REPO=${GITHUB_REPOSITORY,,}" >> ${GITHUB_ENV}
+
+    - name: Extract metadata (tags, labels) for Docker
+      id: meta
+      uses: docker/metadata-action@v5.5.1
+      with:
+        images: ghcr.io/${{ env.REPO }}
+        tags: |
+          type=semver,pattern={{version}}
+
+    - name: Tag docker image with release version
+      run: |
+        docker pull ghcr.io/${{ env.REPO }}:${{ github.sha }}
+        docker tag ghcr.io/${{ env.REPO }}:${{ github.sha }} ghcr.io/${{ env.REPO }}:${{ steps.meta.outputs.version }}
+        docker tag ghcr.io/${{ env.REPO }}:${{ github.sha }} ghcr.io/${{ env.REPO }}:latest
+
+    - name: Push tagged docker images
+      run: |
+        docker push ghcr.io/${{ env.REPO }}:${{ steps.meta.outputs.version }}
+        docker push ghcr.io/${{ env.REPO }}:latest

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -61,11 +61,5 @@ jobs:
 
     - name: Tag docker image with release version
       run: |
-        docker pull ghcr.io/${{ env.REPO }}:${{ github.sha }}
-        docker tag ghcr.io/${{ env.REPO }}:${{ github.sha }} ghcr.io/${{ env.REPO }}:${{ steps.meta.outputs.version }}
-        docker tag ghcr.io/${{ env.REPO }}:${{ github.sha }} ghcr.io/${{ env.REPO }}:latest
-
-    - name: Push tagged docker images
-      run: |
-        docker push ghcr.io/${{ env.REPO }}:${{ steps.meta.outputs.version }}
-        docker push ghcr.io/${{ env.REPO }}:latest
+        docker buildx imagetools create -t ghcr.io/${{ env.REPO }}:${{ steps.meta.outputs.version }} ghcr.io/${{ env.REPO }}:${{ github.sha }}
+        docker buildx imagetools create -t ghcr.io/${{ env.REPO }}:latest ghcr.io/${{ env.REPO }}:${{ github.sha }}


### PR DESCRIPTION
As mentioned before, docker images were not getting the release tags since workflows were missing for it. This PR adds a docker release tagging job to the release-build workflow. The job downloads the image with corresponding git hash and tags it with the release number. It makes use of the docker/metadata-action to strip the **v** from the release version since that appears to be the common approach. Meaning that v1.2.3 would become just 1.2.3. In addition it always tags with the latest tag.

In addition, the normal docker building workflow which is triggered for every commit, is modified to no longer tag with :latest, but rather with :dev. Meaning that those who want something relatively stable can use the :latest tag while those who want to live risky can use :dev

--- Demo ---
Creating a new release (v0.4.13) in my fork will correctly retag the most recent commit on the main branch:
![image](https://github.com/tphakala/birdnet-go/assets/8884086/2ca887fb-816d-4bc0-a6d9-2c5194f90fdd)

with :0.4.13 and :latest