### PR TITLE
feat(audio): make audio source user configurable

### DIFF
--- a/cmd/realtime/realtime.go
+++ b/cmd/realtime/realtime.go
@@ -32,7 +32,7 @@ func Command(settings *conf.Settings) *cobra.Command {
 
 // setupRealtimeFlags configures flags specific to the realtime command.
 func setupFlags(cmd *cobra.Command, settings *conf.Settings) error {
-	cmd.Flags().StringVar(&settings.Realtime.AudioExport.Path, "clippath", viper.GetString("realtime.audioexport.path"), "Path to save audio clips")
+	cmd.Flags().StringVar(&settings.Realtime.Audio.Export.Path, "clippath", viper.GetString("realtime.audio.export.path"), "Path to save audio clips")
 	cmd.Flags().StringVar(&settings.Realtime.Log.Path, "logpath", viper.GetString("realtime.log.path"), "Path to save log files")
 	cmd.Flags().BoolVar(&settings.Realtime.ProcessingTime, "processingtime", viper.GetBool("realtime.processingtime"), "Report processing time for each detection")
 	cmd.Flags().StringVar(&settings.Realtime.RTSP.Url, "rtsp", viper.GetString("realtime.rtsp.url"), "URL of RTSP audio stream to capture")

--- a/internal/analysis/processor/actions.go
+++ b/internal/analysis/processor/actions.go
@@ -102,11 +102,11 @@ func (a DatabaseAction) Execute(data interface{}) error {
 		}
 
 		// Save audio clip to file if enabled
-		if a.Settings.Realtime.AudioExport.Enabled {
+		if a.Settings.Realtime.Audio.Export.Enabled {
 			time.Sleep(1 * time.Second) // Sleep for 1 second to allow the audio buffer to fill
 			pcmData, _ := a.AudioBuffer.ReadSegment(a.Note.BeginTime, time.Now())
 			if err := myaudio.SavePCMDataToWAV(a.Note.ClipName, pcmData); err != nil {
-				log.Printf("error saving audio clip to %s: %s\n", a.Settings.Realtime.AudioExport.Type, err)
+				log.Printf("error saving audio clip to %s: %s\n", a.Settings.Realtime.Audio.Export.Type, err)
 				return err
 			} else if a.Settings.Debug {
 				log.Printf("Saved audio clip to %s\n", a.Note.ClipName)
@@ -124,7 +124,7 @@ func (a DatabaseAction) Execute(data interface{}) error {
 // Execute saves the audio clip to a file
 func (a SaveAudioAction) Execute(data interface{}) error {
 	if err := myaudio.SavePCMDataToWAV(a.ClipName, a.pcmData); err != nil {
-		log.Printf("error saving audio clip to %s: %s\n", a.Settings.Realtime.AudioExport.Type, err)
+		log.Printf("error saving audio clip to %s: %s\n", a.Settings.Realtime.Audio.Export.Type, err)
 		return err
 	} else if a.Settings.Debug {
 		log.Printf("Saved audio clip to %s\n", a.ClipName)

--- a/internal/analysis/processor/processor.go
+++ b/internal/analysis/processor/processor.go
@@ -192,9 +192,10 @@ func (p *Processor) processResults(item *queue.Results) []Detections {
 
 		// Human detection handling for privacy filter
 		if p.Settings.Realtime.PrivacyFilter.Enabled {
-			if strings.Contains(speciesLowercase, "human") && result.Confidence > 0.1 {
+			if strings.Contains(speciesLowercase, "human") && result.Confidence > 0.05 {
 				log.Printf("Human detected, updating last detection timestamp for privacy filtering")
-				p.LastHumanDetection = time.Now()
+				// now minus 2 seconds
+				p.LastHumanDetection = time.Now().Add(-3 * time.Second)
 			}
 		}
 
@@ -240,7 +241,7 @@ func (p *Processor) processResults(item *queue.Results) []Detections {
 
 func (p *Processor) generateClipName(scientificName string, confidence float32) string {
 	// Get the base path from the configuration
-	basePath := conf.GetBasePath(p.Settings.Realtime.AudioExport.Path)
+	basePath := conf.GetBasePath(p.Settings.Realtime.Audio.Export.Path)
 
 	// Replace whitespaces with underscores and convert to lowercase
 	formattedName := strings.ToLower(strings.ReplaceAll(scientificName, " ", "_"))

--- a/internal/analysis/realtime.go
+++ b/internal/analysis/realtime.go
@@ -211,7 +211,7 @@ func ClipCleanupMonitor(wg *sync.WaitGroup, settings *conf.Settings, dataStore d
 
 		case <-ticker.C:
 			// Perform cleanup operation on every tick
-			clipsForRemoval, err := dataStore.GetClipsQualifyingForRemoval(settings.Realtime.Retention.MinEvictionHours, settings.Realtime.Retention.MinClipsPerSpecies)
+			clipsForRemoval, err := dataStore.GetClipsQualifyingForRemoval(settings.Realtime.Audio.Export.Retention.MinEvictionHours, settings.Realtime.Audio.Export.Retention.MinClipsPerSpecies)
 			if err != nil {
 				log.Printf("Error retrieving clips for removal: %s\n", err)
 				continue // Skip this tick's cleanup if there's an error

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -47,7 +47,7 @@ type Settings struct {
 		ProcessingTime bool // true to report processing time for each prediction
 
 		Audio struct {
-			Device string // audio device to use for analysis
+			Source string // audio source to use for analysis
 			Export struct {
 				Enabled   bool   // export audio clips containing indentified bird calls
 				Path      string // path to audio clip export directory

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -46,10 +46,18 @@ type Settings struct {
 		Interval       int  // minimum interval between log messages in seconds
 		ProcessingTime bool // true to report processing time for each prediction
 
-		AudioExport struct {
-			Enabled bool   // export audio clips containing indentified bird calls
-			Path    string // path to audio clip export directory
-			Type    string // audio file type, wav, mp3 or flac
+		Audio struct {
+			Device string // audio device to use for analysis
+			Export struct {
+				Enabled   bool   // export audio clips containing indentified bird calls
+				Path      string // path to audio clip export directory
+				Type      string // audio file type, wav, mp3 or flac
+				Retention struct {
+					Enabled            bool // true to enable audio clip retention
+					MinEvictionHours   int  // minimum number of hours to keep audio clips
+					MinClipsPerSpecies int  // minimum number of clips per species to keep
+				}
+			}
 		}
 
 		Log struct {
@@ -71,11 +79,6 @@ type Settings struct {
 
 		DogBarkFilter struct {
 			Enabled bool // true to enable dog bark filter
-		}
-
-		Retention struct {
-			MinEvictionHours   int // minimum number of hours to keep audio clips
-			MinClipsPerSpecies int // minimum number of clips per species to keep
 		}
 
 		RTSP struct {

--- a/internal/conf/config.yaml
+++ b/internal/conf/config.yaml
@@ -29,10 +29,16 @@ realtime:
   interval: 15          # duplicate prediction interval in seconds
   processingtime: false # true to report processing time for each prediction
   
-  audioexport:
-    enabled: true       # true to export audio clips containing indentified bird calls
-    path: clips/        # path to audio clip export directory
-    type: wav           # only wav supported for now
+  audio:
+    device: sysdefault    # audio device to use for analysis
+    export:
+      enabled: true       # true to export audio clips containing indentified bird calls
+      path: clips/        # path to audio clip export directory
+      type: wav           # only wav supported for now
+      retention:
+        enabled: false         # true to enable retention policy of clips
+        minEvictionHours: 0    # minumum number of hours before considering clip for eviction
+        minClipsPerSpecies: 0  # minumum number of clips per species to keep before starting evictions
   
   log:
     enabled: false      # true to enable OBS chat log
@@ -65,10 +71,7 @@ realtime:
     enabled: false         # true to enable Prometheus compatible telemetry endpoint
     listen: "0.0.0.0:8090" # IP address and port to listen on
 
-  retention:
-    enabled: false         # true to enable retention policy of clips
-    minEvictionHours: 0    # minumum number of hours before considering clip for eviction
-    minClipsPerSpecies: 0  # minumum number of clips per species to keep before starting evictions
+
 
 webserver:
   enabled: true         # true to enable web server

--- a/internal/conf/config.yaml
+++ b/internal/conf/config.yaml
@@ -30,7 +30,7 @@ realtime:
   processingtime: false # true to report processing time for each prediction
   
   audio:
-    device: sysdefault    # audio device to use for analysis
+    source: "sysdefault"  # audio source to use for analysis
     export:
       enabled: true       # true to export audio clips containing indentified bird calls
       path: clips/        # path to audio clip export directory

--- a/internal/conf/defaults.go
+++ b/internal/conf/defaults.go
@@ -31,9 +31,15 @@ func setDefaultConfig() {
 	viper.SetDefault("realtime.interval", 15)
 	viper.SetDefault("realtime.processingtime", false)
 
-	viper.SetDefault("realtime.audioexport.enabled", true)
-	viper.SetDefault("realtime.audioexport.path", "clips/")
-	viper.SetDefault("realtime.audioexport.type", "wav")
+	viper.SetDefault("realtime.audio.source", "sysdefault")
+
+	viper.SetDefault("realtime.audio.export.enabled", true)
+	viper.SetDefault("realtime.audio.export.path", "clips/")
+	viper.SetDefault("realtime.audio.export.type", "wav")
+
+	viper.SetDefault("realtime.audio.export.retention.enabled", false)
+	viper.SetDefault("realtime.audio.export.retention.minEvictionHours", 0)
+	viper.SetDefault("realtime.audio.export.retention.minClipsPerSpecies", 0)
 
 	viper.SetDefault("realtime.log.enabled", false)
 	viper.SetDefault("realtime.log.path", "birdnet.txt")
@@ -58,10 +64,6 @@ func setDefaultConfig() {
 
 	viper.SetDefault("realtime.telemetry.enabled", false)
 	viper.SetDefault("realtime.telemetry.listen", "0.0.0.0:8090")
-
-	viper.SetDefault("realtime.retention.enabled", false)
-	viper.SetDefault("realtime.retention.minEvictionHours", 0)
-	viper.SetDefault("realtime.retention.minClipsPerSpecies", 0)
 
 	viper.SetDefault("webserver.enabled", true)
 	viper.SetDefault("webserver.port", "8080")

--- a/internal/httpcontroller/updateconfig.go
+++ b/internal/httpcontroller/updateconfig.go
@@ -139,10 +139,10 @@ func updateServerSettings(s *Server, formValues map[string]interface{}) {
 
 	// Realtime settings - Audio Export
 	if val, ok := formValues["realtime.audioexport.enabled"].(bool); ok {
-		s.Settings.Realtime.AudioExport.Enabled = val
+		s.Settings.Realtime.Audio.Export.Enabled = val
 	}
 	if audioExportPath, ok := formValues["realtime.audioexport.path"].(string); ok {
-		s.Settings.Realtime.AudioExport.Path = audioExportPath
+		s.Settings.Realtime.Audio.Export.Path = audioExportPath
 	}
 
 	// Realtime settings - Log

--- a/internal/myaudio/capture.go
+++ b/internal/myaudio/capture.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
+	"strings"
 	"sync"
 	"time"
 	"unsafe"
@@ -15,15 +16,6 @@ import (
 	"github.com/gen2brain/malgo"
 	"github.com/tphakala/birdnet-go/internal/conf"
 )
-
-// hexToASCII converts a hexadecimal string to an ASCII string.
-func hexToASCII(hexStr string) (string, error) {
-	bytes, err := hex.DecodeString(hexStr)
-	if err != nil {
-		return "", err // return the error if hex decoding fails
-	}
-	return string(bytes), nil
-}
 
 func CaptureAudio(settings *conf.Settings, wg *sync.WaitGroup, quitChan chan struct{}, restartChan chan struct{}, audioBuffer *AudioBuffer) {
 	if settings.Realtime.RTSP.Url != "" {
@@ -33,6 +25,75 @@ func CaptureAudio(settings *conf.Settings, wg *sync.WaitGroup, quitChan chan str
 		// Default audio capture
 		captureAudioMalgo(settings, wg, quitChan, restartChan, audioBuffer)
 	}
+}
+
+// captureSource holds information about an audio capture source.
+type captureSource struct {
+	Name    string
+	ID      string
+	Pointer unsafe.Pointer
+}
+
+// selectCaptureSource selects an appropriate capture device based on the provided settings and available device information.
+// It prints available devices and returns the selected device and any error encountered.
+func selectCaptureSource(settings *conf.Settings, infos []malgo.DeviceInfo) (captureSource, error) {
+	fmt.Println("Available Capture Sources:")
+
+	var selectedSource captureSource
+	var deviceFound bool
+
+	for i, info := range infos {
+		// Decode the device ID from hex to ASCII
+		decodedID, err := hexToASCII(info.ID.String())
+		if err != nil {
+			fmt.Printf("Error decoding ID for device %d: %v\n", i, err)
+			continue
+		}
+
+		// Prepare the output string for listing available devices
+		output := fmt.Sprintf("  %d: %s", i, info.Name())
+		if runtime.GOOS == "linux" {
+			output = fmt.Sprintf("%s, %s", output, decodedID) // Include decoded ID in the output for Linux
+		}
+
+		// Determine if the current device matches the specified settings
+		if matchesDeviceSettings(decodedID, info, settings.Realtime.Audio.Source) {
+			selectedSource = captureSource{
+				Name:    info.Name(),
+				ID:      decodedID,
+				Pointer: info.ID.Pointer(),
+			}
+			deviceFound = true
+		}
+
+		fmt.Println(output)
+	}
+
+	// If no device was found, return an error
+	if !deviceFound {
+		return captureSource{}, fmt.Errorf("no suitable capture source found for device setting %s", settings.Realtime.Audio.Source)
+	}
+
+	return selectedSource, nil
+}
+
+// matchesDeviceSettings checks if the device matches the settings specified by the user.
+func matchesDeviceSettings(decodedID string, info malgo.DeviceInfo, audioSource string) bool {
+	if runtime.GOOS == "windows" && audioSource == "sysdefault" {
+		// On Windows, there is no "sysdefault" device. Use miniaudio's default device instead.
+		return info.IsDefault == 1
+	}
+	// Check if the decoded ID or device name matches the user's setting.
+	return decodedID == audioSource || strings.Contains(info.Name(), audioSource)
+}
+
+// hexToASCII converts a hexadecimal string to an ASCII string.
+func hexToASCII(hexStr string) (string, error) {
+	bytes, err := hex.DecodeString(hexStr)
+	if err != nil {
+		return "", err // return the error if hex decoding fails
+	}
+	return string(bytes), nil
 }
 
 func captureAudioMalgo(settings *conf.Settings, wg *sync.WaitGroup, quitChan chan struct{}, restartChan chan struct{}, audioBuffer *AudioBuffer) {
@@ -71,58 +132,20 @@ func captureAudioMalgo(settings *conf.Settings, wg *sync.WaitGroup, quitChan cha
 
 	var infos []malgo.DeviceInfo
 
-	// Get list of capture devices
+	// Get list of capture sources
 	infos, err = malgoCtx.Devices(malgo.Capture)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}
 
-	// Keep record of default capture device
-	var captureDeviceName string
-	var captureDeviceID string
-	var defaultDevicePointer unsafe.Pointer
-
-	fmt.Println("Capture Devices")
-	for i, info := range infos {
-
-		// Decode the device ID from hex to ASCII
-		decodedID, err := hexToASCII(info.ID.String())
-		if err != nil {
-			fmt.Printf("Error decoding ID for device %d: %v\n", i, err)
-			continue
-		}
-
-		defaultStatus := ""
-
-		// Check for "sysdefault" device on Linux
-		if runtime.GOOS == "linux" {
-			if decodedID == "sysdefault" {
-				//defaultStatus = "[default]" // mark as default
-				captureDeviceName = info.Name()
-				captureDeviceID = decodedID
-				defaultDevicePointer = info.ID.Pointer()
-			}
-		} else {
-			// Windows and macOS do not have "sysdefault" devices so we'll check for miniaudios default device
-			if info.IsDefault == 1 {
-				defaultStatus = "[miniaudio default]" // mark as default
-				captureDeviceName = info.Name()
-				captureDeviceID = decodedID
-				defaultDevicePointer = info.ID.Pointer()
-			}
-		}
-
-		// Output device information with decoded ID
-		output := fmt.Sprintf("    %d: %s, %s", i, info.Name(), decodedID)
-		if defaultStatus != "" {
-			output += ", " + defaultStatus // append default status if not empty
-		}
-		fmt.Println(output)
+	// Select the capture source based on the settings
+	captureSource, err := selectCaptureSource(settings, infos)
+	if err != nil {
+		log.Fatalf("Error selecting capture source: %v", err)
+		panic(err)
 	}
-
-	//selectedDeviceInfo := infos[2]
-	deviceConfig.Capture.DeviceID = defaultDevicePointer
+	deviceConfig.Capture.DeviceID = captureSource.Pointer
 
 	// Write to ringbuffer when audio data is received
 	// BufferMonitor() will poll this buffer and read data from it
@@ -183,7 +206,7 @@ func captureAudioMalgo(settings *conf.Settings, wg *sync.WaitGroup, quitChan cha
 		fmt.Println("Device started")
 	}
 	// print audio device we are attached to
-	fmt.Printf("Listening on device: %s (%s)\n", captureDeviceName, captureDeviceID)
+	fmt.Printf("Listening on source: %s (%s)\n", captureSource.Name, captureSource.ID)
 
 	// Now, instead of directly waiting on QuitChannel,
 	// check if it's closed in a non-blocking select.


### PR DESCRIPTION
Add Realtime.Audio.Source setting which allows user configurable audio source, it defaults to "sysdefault" on Linux. Audio clip retention policy settings are moved under Realtime.Audio.Export node.