### PR TITLE
Fix & improve docker multi platform builds

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -47,11 +47,6 @@ jobs:
     needs: test-docker-image
     if: github.event_name == 'push' && github.ref_name == 'main'
     runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        include:
-          - platform: linux/arm64
-          - platform: linux/amd64
     steps:
       - name: Checkout GitHub Action
         uses: actions/checkout@v4.1.5
@@ -78,6 +73,7 @@ jobs:
           tags: |
             ghcr.io/${{ env.REPO }}:dev
             ghcr.io/${{ env.REPO }}:${{ github.sha }}
-          platforms: ${{ matrix.platform }}
-          cache-from: type=gha,scope=${{ matrix.platform }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.platform }}
+          platforms: linux/arm64, linux/amd64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: false


### PR DESCRIPTION
Fixes missing x86 build mentioned in #175 

Followed this [guide](https://www.docker.com/blog/faster-multi-platform-builds-dockerfile-cross-compilation-guide/) to make improvements to the cross compilation process:

- Make use of `BUILDPLATFORM `in dockerfile to get better docker caching and build speeds, since the platform of the computer used to build the image is used as much as possible, limiting the need for emulation.
- Moves some args around to make fork off the building context as late as possible, resulting in better docker builder layer reuse for different platforms

With the utilization of BUILDPLATFORM, the docker caching works way better for different platforms. Eliminating the need for separate build jobs added in #165. Meaning that only one job will be used again, that builds all the different platforms. Speed is even better now when rebuilding without any changes in github actions, around 20s.

In addition, removes the extra unknown platform by setting `provenance: false` based on answers in: https://github.com/docker/build-push-action/issues/820