### PR TITLE
refactor: Refactor configuration package to improve settings handling

### DIFF
--- a/internal/conf/utils.go
+++ b/internal/conf/utils.go
@@ -1,4 +1,4 @@
-// conf/utils.go
+// conf/utils.go various util functions for configuration package
 package conf
 
 import (
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+
+	"github.com/mitchellh/mapstructure"
 )
 
 // getDefaultConfigPaths returns a list of default configuration paths for the current operating system.
@@ -164,4 +166,14 @@ func GetBoardModel() string {
 	// Return the board model as a string.
 	model := strings.TrimSpace(string(data))
 	return model
+}
+
+// structToMap converts a struct to a map using mapstructure
+func structToMap(settings *Settings) (map[string]interface{}, error) {
+	var result map[string]interface{}
+	err := mapstructure.Decode(settings, &result)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
 }

--- a/internal/conf/validate.go
+++ b/internal/conf/validate.go
@@ -1,0 +1,15 @@
+// conf/validate.go config settings validation code goes here
+package conf
+
+import "errors"
+
+// validateSettings validates the settings
+func validateSettings(settings *Settings) error {
+	// Add your validation logic here
+	if settings.Realtime.MQTT.Enabled && settings.Realtime.MQTT.Broker == "" {
+		return errors.New("MQTT broker URL is required when MQTT is enabled")
+	}
+	// Other options to validate go here
+
+	return nil
+}


### PR DESCRIPTION
Settings are now accessible through the conf.Setting() function. This allows direct access to settings without the need to import a Settings pointer into a class or function.

Accessing Settings

```
// Accessing a setting
if conf.Setting().Debug {
    fmt.Println("Debug is enabled")
} else {
    fmt.Println("Debug is disabled")
}

// Accessing a nested setting
if conf.Setting().Realtime.Audio.Export.Enabled {
    fmt.Println("Audio export is enabled")
} else {
    fmt.Println("Audio export is disabled")
}
```

Updating Settings at Runtime

```
// Copy current settings
newSettings := *conf.Setting()

// Modify the necessary setting
newSettings.Realtime.Audio.Export.Enabled = true

// Update settings
if err := conf.UpdateSettings(&newSettings); err != nil {
    log.Fatalf("Error updating settings: %v", err)
}
```