### PR TITLE
Fix audio playback on safari/ipad

### DIFF
--- a/views/fragments/recentDetections.html
+++ b/views/fragments/recentDetections.html
@@ -36,7 +36,7 @@
           <img loading="lazy" width="400" src="/spectrogram?clip={{urlquery .ClipName}}" alt="Spectrogram Image" class="max-w-full h-auto rounded-md">
 
           <!-- Audio player -->
-          <audio controls class="audio-control" preload="none">
+          <audio controls class="audio-control" preload="metadata">
             <source src="{{.ClipName}}" type="audio/wav">
             Your browser does not support the audio element.
           </audio>
@@ -69,7 +69,7 @@
     <div class="flex justify-center mt-3">
       <div class="w-full">
         <img loading="lazy" width="400" src="/spectrogram?clip={{urlquery .ClipName}}" alt="Spectrogram Image" class="max-w-full h-auto rounded-md">
-        <audio controls class="audio-control" preload="none">
+        <audio controls class="audio-control" preload="metadata">
           <source src="{{.ClipName}}" type="audio/wav">
           Your browser does not support the audio element.
         </audio>

--- a/views/fragments/searchResults.html
+++ b/views/fragments/searchResults.html
@@ -42,7 +42,7 @@
       </td>
       <td class="py-1 px-4">     
         <!-- Audio player -->
-        <audio controls class="audio-control" preload="none">
+        <audio controls class="audio-control" preload="metadata">
           <source src="{{.ClipName}}" type="audio/wav">
           Your browser does not support the audio element.
         </audio>

--- a/views/fragments/speciesDetections.html
+++ b/views/fragments/speciesDetections.html
@@ -47,7 +47,7 @@
           <img loading="lazy" width="400" src="/spectrogram?clip={{urlquery .ClipName}}" alt="Spectrogram Image" class="max-w-full h-auto rounded-md"></a>
 
           <!-- Audio player -->
-          <audio controls class="audio-control" preload="none">
+          <audio controls class="audio-control" preload="metadata">
             <source src="{{.ClipName}}" type="audio/wav">
             Your browser does not support the audio element.
           </audio>


### PR DESCRIPTION
Had the chance to try birdnet-go on an iPad when visiting a relative. Found out that audio playback was not working as expected. It only worked if I first clicked play, then paused, and clicked play again. Based on some [research online](https://meta.discourse.org/t/secure-media-audio-does-not-play-on-safari-on-the-first-click/156124/18) it appears to be fixable by preloading the metadata.

Was able to verify that the changes fixes the playback issues on iPads.