### PR TITLE
feat: New "priority" cleanup policy

### DIFF
--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -54,9 +54,11 @@ type Settings struct {
 				Path      string // path to audio clip export directory
 				Type      string // audio file type, wav, mp3 or flac
 				Retention struct {
-					Enabled            bool // true to enable audio clip retention
-					MinEvictionHours   int  // minimum number of hours to keep audio clips
-					MinClipsPerSpecies int  // minimum number of clips per species to keep
+					Enabled            bool   // true to enable audio clip retention
+					Mode               string // retention mode, "age" or "priority"
+					DiskUsageLimit     string // maximum disk usage percentage before retention
+					MinEvictionHours   int    // minimum number of hours to keep audio clips
+					MinClipsPerSpecies int    // minimum number of clips per species to keep
 				}
 			}
 		}

--- a/internal/conf/config.yaml
+++ b/internal/conf/config.yaml
@@ -37,9 +37,11 @@ realtime:
       path: clips/        # path to audio clip export directory
       type: wav           # only wav supported for now
       retention:
-        enabled: false         # true to enable retention policy of clips
-        minEvictionHours: 0    # minumum number of hours before considering clip for eviction
-        minClipsPerSpecies: 0  # minumum number of clips per species to keep before starting evictions
+        enabled: true           # true to enable retention policy of clips
+        mode: priority          # age or priority
+        diskusagelimit: 80%     # percentage of disk usage to trigger eviction        
+        minClipsPerSpecies: 10  # minumum number of clips per species to keep before starting evictions
+        minEvictionHours: 0     # minumum number of hours before considering clip for eviction
   
   log:
     enabled: false      # true to enable OBS chat log

--- a/internal/conf/defaults.go
+++ b/internal/conf/defaults.go
@@ -38,9 +38,12 @@ func setDefaultConfig() {
 	viper.SetDefault("realtime.audio.export.path", "clips/")
 	viper.SetDefault("realtime.audio.export.type", "wav")
 
-	viper.SetDefault("realtime.audio.export.retention.enabled", false)
+	viper.SetDefault("realtime.audio.export.retention.enabled", true)
+	viper.SetDefault("realtime.audio.export.retention.debug", false)
+	viper.SetDefault("realtime.audio.export.retention.mode", "priority")
+	viper.SetDefault("realtime.audio.export.retention.diskusagelimit", "80%")
+	viper.SetDefault("realtime.audio.export.retention.minClipsPerSpecies", 10)
 	viper.SetDefault("realtime.audio.export.retention.minEvictionHours", 0)
-	viper.SetDefault("realtime.audio.export.retention.minClipsPerSpecies", 0)
 
 	viper.SetDefault("realtime.log.enabled", false)
 	viper.SetDefault("realtime.log.path", "birdnet.txt")

--- a/internal/conf/utils.go
+++ b/internal/conf/utils.go
@@ -3,12 +3,14 @@ package conf
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"log"
 	"os"
 	"os/user"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 
 	"github.com/mitchellh/mapstructure"
@@ -176,4 +178,16 @@ func structToMap(settings *Settings) (map[string]interface{}, error) {
 		return nil, err
 	}
 	return result, nil
+}
+
+// ParsePercentage converts a percentage string (e.g., "80%") to a float64
+func ParsePercentage(percentage string) (float64, error) {
+	if strings.HasSuffix(percentage, "%") {
+		value, err := strconv.ParseFloat(strings.TrimSuffix(percentage, "%"), 64)
+		if err != nil {
+			return 0, err
+		}
+		return value, nil
+	}
+	return 0, errors.New("invalid percentage format")
 }

--- a/internal/diskmanager/age.go
+++ b/internal/diskmanager/age.go
@@ -1,0 +1,52 @@
+// agemode.go age based cleanup code
+package diskmanager
+
+import (
+	"log"
+	"os"
+
+	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/datastore"
+)
+
+// AgeBasedCleanup removes clips from the filesystem based on their age and the number of clips per species.
+// TODO: handle quit channel properly if it happens during cleanup
+func AgeBasedCleanup(dataStore datastore.Interface) error {
+	MinEvictionHours := conf.Setting().Realtime.Audio.Export.Retention.MinEvictionHours
+	MinClipsPerSpecies := conf.Setting().Realtime.Audio.Export.Retention.MinClipsPerSpecies
+
+	// Perform cleanup operation on every tick
+	clipsForRemoval, err := dataStore.GetClipsQualifyingForRemoval(MinEvictionHours, MinClipsPerSpecies)
+	if err != nil {
+		log.Printf("Error retrieving clips for removal: %s\n", err)
+		return err
+	}
+
+	log.Printf("Found %d clips to remove\n", len(clipsForRemoval))
+
+	for _, clip := range clipsForRemoval {
+		// Attempt to remove the clip file from the filesystem
+		if err := os.Remove(clip.ClipName); err != nil {
+			if os.IsNotExist(err) {
+				// Attempt to delete the database record if the clip file aleady doesn't exist
+				if err := dataStore.DeleteNoteClipPath(clip.ID); err != nil {
+					log.Printf("Failed to delete clip path for %s: %s\n", clip.ID, err)
+
+				} else {
+					log.Printf("Cleared clip path of missing clip for %s\n", clip.ID)
+				}
+			} else {
+				log.Printf("Failed to remove %s: %s\n", clip.ClipName, err)
+			}
+		} else {
+			log.Printf("Removed %s\n", clip.ClipName)
+			// Attempt to delete the database record if the file removal was successful
+			if err := dataStore.DeleteNoteClipPath(clip.ID); err != nil {
+				log.Printf("Failed to delete clip path for %s: %s\n", clip.ID, err)
+			}
+		}
+		return err
+	}
+
+	return nil
+}

--- a/internal/diskmanager/priority.go
+++ b/internal/diskmanager/priority.go
@@ -1,0 +1,308 @@
+// priority.go priority based cleanup code
+package diskmanager
+
+import (
+	"encoding/csv"
+	"errors"
+	"log"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/tphakala/birdnet-go/internal/conf"
+)
+
+// Policy defines cleanup policies
+type Policy struct {
+	AlwaysCleanupFirst map[string]bool // Species to always cleanup first
+	NeverCleanup       map[string]bool // Species to never cleanup
+}
+
+// FileInfo holds information about a file
+type FileInfo struct {
+	Path       string
+	Species    string
+	Confidence int
+	Timestamp  time.Time
+	Size       int64
+}
+
+// LoadPolicy loads the cleanup policies from a CSV file
+func LoadPolicy(policyFile string) (*Policy, error) {
+	file, err := os.Open(policyFile)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	reader := csv.NewReader(file)
+	records, err := reader.ReadAll()
+	if err != nil {
+		return nil, err
+	}
+
+	policy := &Policy{
+		AlwaysCleanupFirst: make(map[string]bool),
+		NeverCleanup:       make(map[string]bool),
+	}
+
+	for _, record := range records {
+		if len(record) != 2 {
+			return nil, errors.New("invalid policy record")
+		}
+		if record[1] == "always" {
+			policy.AlwaysCleanupFirst[record[0]] = true
+		} else if record[1] == "never" {
+			policy.NeverCleanup[record[0]] = true
+		}
+	}
+
+	return policy, nil
+}
+
+// GetDiskUsage returns the disk usage percentage
+func GetDiskUsage(baseDir string) (float64, error) {
+	var stat syscall.Statfs_t
+	err := syscall.Statfs(baseDir, &stat)
+	if err != nil {
+		return 0, err
+	}
+
+	total := stat.Blocks * uint64(stat.Bsize)
+	free := stat.Bfree * uint64(stat.Bsize)
+	used := total - free
+
+	return (float64(used) / float64(total)) * 100, nil
+}
+
+// GetAudioFiles returns a list of audio files in the directory and its subdirectories
+func GetAudioFiles(baseDir string, allowedExts []string, debug bool) ([]FileInfo, error) {
+	var files []FileInfo
+
+	err := filepath.Walk(baseDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() {
+			ext := filepath.Ext(info.Name())
+			if contains(allowedExts, ext) {
+				fileInfo, err := parseFileInfo(path, info)
+				if err != nil {
+					return err
+				}
+				/*if debug {
+					log.Printf("Found file: %s, Species: %s, Confidence: %d, Timestamp: %s", fileInfo.Path, fileInfo.Species, fileInfo.Confidence, fileInfo.Timestamp)
+				}*/
+				files = append(files, fileInfo)
+			}
+		}
+		return nil
+	})
+
+	return files, err
+}
+
+// contains checks if a string is in a slice
+func contains(slice []string, item string) bool {
+	for _, s := range slice {
+		if s == item {
+			return true
+		}
+	}
+	return false
+}
+
+// parseFileInfo parses the file information from the file path and os.FileInfo
+func parseFileInfo(path string, info os.FileInfo) (FileInfo, error) {
+	name := filepath.Base(info.Name())
+	parts := strings.Split(name, "_")
+	if len(parts) < 3 {
+		return FileInfo{}, errors.New("invalid file name format")
+	}
+
+	// The species name might contain underscores, so we need to handle the last two parts separately
+	confidenceStr := parts[len(parts)-2]
+	timestampStr := parts[len(parts)-1]
+	species := strings.Join(parts[:len(parts)-2], "_")
+
+	confidence, err := strconv.Atoi(strings.TrimSuffix(confidenceStr, "p"))
+	if err != nil {
+		return FileInfo{}, err
+	}
+
+	timestamp, err := time.Parse("20060102T150405Z", strings.TrimSuffix(timestampStr, ".wav"))
+	if err != nil {
+		return FileInfo{}, err
+	}
+
+	return FileInfo{
+		Path:       path,
+		Species:    species,
+		Confidence: confidence,
+		Timestamp:  timestamp,
+		Size:       info.Size(),
+	}, nil
+}
+
+// PriorityBasedCleanup cleans up old audio files based on the configuration and monitors for quit signals
+func PriorityBasedCleanup(quitChan chan struct{}) error {
+	settings := conf.Setting()
+
+	debug := settings.Realtime.Audio.Export.Debug
+	baseDir := settings.Realtime.Audio.Export.Path
+	thresholdStr := settings.Realtime.Audio.Export.Retention.DiskUsageLimit
+	minClipsPerSpecies := settings.Realtime.Audio.Export.Retention.MinClipsPerSpecies
+
+	// Convert 80% string etc. to 80.0 float64
+	threshold, err := conf.ParsePercentage(thresholdStr)
+	if err != nil {
+		return err
+	}
+
+	// Only remove files with extensions in this list
+	allowedExts := []string{".wav"}
+
+	if debug {
+		log.Printf("Starting cleanup process. Base directory: %s, Threshold: %.1f%%", baseDir, threshold)
+	}
+
+	// Get the current disk usage
+	diskUsage, err := GetDiskUsage(baseDir)
+	if err != nil {
+		return err
+	}
+
+	if debug {
+		log.Printf("Current disk usage: %.1f%%", diskUsage)
+	}
+
+	// If disk usage is below the threshold, no cleanup is needed
+	if diskUsage < threshold {
+		if debug {
+			log.Printf("Disk usage %.1f%% is below the %.1f%% threshold. No cleanup needed.", diskUsage, threshold)
+		}
+		return nil
+	} else {
+		if debug {
+			log.Printf("Disk usage %.1f%% is above the %.1f%% threshold. Cleanup needed.", diskUsage, threshold)
+		}
+	}
+
+	// Get the list of audio files
+	files, err := GetAudioFiles(baseDir, allowedExts, debug)
+	if err != nil {
+		return err
+	}
+
+	// Sort files by the cleanup priority and get the initial count of files per species per subdirectory
+	speciesMonthCount := sortFiles(files, debug)
+
+	// Debug: write sorted files to a file
+	if debug {
+		if err := WriteSortedFilesToFile(files, "file_cleanup_order.txt"); err != nil {
+			return err
+		}
+	}
+
+	// Delete files until disk usage is below the threshold or 100 files have been deleted
+	deletedFiles := 0
+	maxDeletions := 1000
+	totalFreedSpace := int64(0)
+	for _, file := range files {
+		select {
+		case <-quitChan:
+			if debug {
+				log.Println("Received quit signal, exiting cleanup loop.")
+			}
+			return nil
+		default:
+			// Get the subdirectory name
+			subDir := filepath.Dir(file.Path)
+			if diskUsage < threshold || deletedFiles >= maxDeletions || speciesMonthCount[file.Species][subDir] <= minClipsPerSpecies {
+				continue
+			}
+
+			if debug {
+				log.Printf("Deleting file: %s", file.Path)
+			}
+
+			// Delete the file deemed for cleanup
+			err = os.Remove(file.Path)
+			if err != nil {
+				return err
+			}
+
+			// Increment deleted files count and update species count
+			deletedFiles++
+			speciesMonthCount[file.Species][subDir]--
+
+			// Add file size to total freed space
+			totalFreedSpace += file.Size
+
+			// Update disk usage
+			diskUsage, err = GetDiskUsage(baseDir)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	if debug {
+		log.Printf("Cleanup process completed. %d files deleted. Total space freed: %.2f MB", deletedFiles, float64(totalFreedSpace)/(1024*1024))
+	}
+
+	return nil
+}
+
+func sortFiles(files []FileInfo, debug bool) map[string]map[string]int {
+	if debug {
+		log.Printf("Sorting files by cleanup priority.")
+	}
+
+	// Count the number of files for each species in each subdirectory
+	speciesMonthCount := make(map[string]map[string]int)
+	for _, file := range files {
+		subDir := filepath.Dir(file.Path)
+		if _, exists := speciesMonthCount[file.Species]; !exists {
+			speciesMonthCount[file.Species] = make(map[string]int)
+		}
+		speciesMonthCount[file.Species][subDir]++
+	}
+
+	sort.Slice(files, func(i, j int) bool {
+		// Defensive check for nil pointers
+		if files[i].Path == "" || files[j].Path == "" {
+			return false
+		}
+
+		// Priority 1: Oldest files first
+		if files[i].Timestamp != files[j].Timestamp {
+			return files[i].Timestamp.Before(files[j].Timestamp)
+		}
+
+		// Priority 3: Species with the most occurrences in the subdirectory
+		subDirI := filepath.Dir(files[i].Path)
+		subDirJ := filepath.Dir(files[j].Path)
+		if speciesMonthCount[files[i].Species][subDirI] != speciesMonthCount[files[j].Species][subDirJ] {
+			return speciesMonthCount[files[i].Species][subDirI] > speciesMonthCount[files[j].Species][subDirJ]
+		}
+
+		// Priority 4: Confidence level
+		if files[i].Confidence != files[j].Confidence {
+			return files[i].Confidence > files[j].Confidence
+		}
+
+		// Default to oldest timestamp
+		return files[i].Timestamp.Before(files[j].Timestamp)
+	})
+
+	if debug {
+		log.Printf("Files sorted.")
+	}
+
+	return speciesMonthCount
+}

--- a/internal/diskmanager/util.go
+++ b/internal/diskmanager/util.go
@@ -1,0 +1,33 @@
+package diskmanager
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"time"
+)
+
+// WriteSortedFilesToFile writes the sorted list of files to a text file for investigation
+func WriteSortedFilesToFile(files []FileInfo, filePath string) error {
+	file, err := os.Create(filePath)
+	if err != nil {
+		return fmt.Errorf("failed to create file: %w", err)
+	}
+	defer file.Close()
+
+	for _, fileInfo := range files {
+		line := fmt.Sprintf("Path: %s, Species: %s, Confidence: %d, Timestamp: %s, Size: %d\n",
+			fileInfo.Path, fileInfo.Species, fileInfo.Confidence, fileInfo.Timestamp.Format(time.RFC3339), fileInfo.Size)
+		_, err := file.WriteString(line)
+		if err != nil {
+			return fmt.Errorf("failed to write to file: %w", err)
+		}
+	}
+
+	if err := file.Sync(); err != nil {
+		return fmt.Errorf("failed to sync file: %w", err)
+	}
+
+	log.Printf("Sorted files have been written to %s", filePath)
+	return nil
+}


### PR DESCRIPTION
The priority disk cleanup feature purges recordings based on several policy rules. This helps maintain disk usage within user-defined limits while retaining valuable recordings.

This retention policy will be enabled by default.

1. **Configurable Threshold**:
   - Cleanup starts when disk usage exceeds a user-defined threshold (e.g., 80%).

2. **Sorting Policies**:
   - **Oldest Files First**: The primary criterion is to delete the oldest recordings first.
   - **Species Occurrences**: Files are prioritized for deletion based on the number of occurrences of each species, with species having the most recordings prioritized to be deleted first as these are often least interesting to user
   - **Confidence Level**: Files with lower confidence levels are prioritized for deletion over those with higher confidence levels.
   - **Default to Oldest Timestamp**: If other criteria are equal, the oldest files are prioritized.

3. **Minimum Clips Per Species**:
   - Ensures that a minimum number of recordings per species are retained for each month.
   - This attempts to spare rare recordings from deletion

4. **Controlled Deletion Process**:
   - Stops deleting files once disk usage falls below the threshold, each cleanup cycle is limited 1000 deletions
   - Cleanup cycle runs at 5 minute intervals
   - QuitChannel is monitored and cleanup loop exits cleanly if application exit is requested