### PR TITLE
Fix arm64 cross compilation in docker build on amd64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update && apt-get install -y \
     git \
     sudo \
     zip \
+    gcc-aarch64-linux-gnu \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /root/src
@@ -43,7 +44,13 @@ COPY . BirdNET-Go
 ARG TARGETPLATFORM
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
-    cd BirdNET-Go && make TARGETPLATFORM=${TARGETPLATFORM}
+    PLATFORM='unknown'; \
+    case "${TARGETPLATFORM}" in \
+        "linux/amd64") PLATFORM='linux_amd64' ;; \
+        "linux/arm64") PLATFORM='linux_arm64' ;; \
+        *) echo "Unsupported platform: '${TARGETPLATFORM}'" && exit 1 ;; \
+    esac; \
+    cd BirdNET-Go && make ${PLATFORM}
 
 # Create final image using a multi-platform base image
 FROM debian:bookworm-slim


### PR DESCRIPTION
As mentioned in [v0.5.4 release discussion](https://github.com/tphakala/birdnet-go/discussions/185#discussioncomment-9641107)

There have been issues running the linux/arm64 image since PR #176 which fixed the linux/amd64 build and introduced improvements to the cross-compilation process by utilizing BUILDPLATFORM. Since this PR cross-compilation provided by the build system will be used rather than emulation in the docker build. Unfortunately, this change does require some more changes to the Dockerfile/makefile to work as expected.

Currently, the arm64 image contains the amd64 binaries. Due to how the Dockerfile calls the make file without an argument, leading to this piece of code to be executed:
```make
# Default action
all: $(LABELS_ZIP) $(NATIVE_TARGET)
```

which depends on this:
```make
# Detect host architecture
UNAME_M := $(shell uname -m)
ifeq ($(UNAME_M),x86_64)
    NATIVE_TARGET := linux_amd64
else ifeq ($(UNAME_M),aarch64)
    NATIVE_TARGET := linux_arm64
else
    $(error Unsupported architecture)
endif
```

Since this part of the code no longer is being emulated by docker, uname -m will always return **x86_64**. Causing it to always be built even when --platform arm64 is requested.

This PR fixes that issue by instead calling the correct make target directly from the Dockerfile. Also had to install gcc-aarch64-linux-gnu for cross-compilation support in the dockerfile.

This time I went ahead and tried both arm64 and amd64 to be on the safe side after building with:

**docker buildx build --platform=linux/arm64,linux/amd64 --tag test  .**

```bash
docker run --platform linux/arm64 docker.io/library/test:latest
Created default config file at: /root/.config/birdnet-go/config.yaml
BirdNET-Go build date: 2024-06-02T22:32:45Z, using config file: /root/.config/birdnet-go/config.yaml
BirdNET GLOBAL 6K V2.4 FP32 model initialized, using 8 threads of available 8 CPUs
System details: linux debian 12.5 on  hardware
Starting analyzer in realtime mode. Threshold: 0.8, sensitivity: 1, interval: 15
Logging disabled
2024/06/02 22:39:15 Clip retention policy: usage
⇨ http server started on [::]:8080


docker run --platform linux/amd64 docker.io/library/test:latest
Created default config file at: /root/.config/birdnet-go/config.yaml
BirdNET-Go build date: 2024-06-02T22:32:48Z, using config file: /root/.config/birdnet-go/config.yaml
BirdNET GLOBAL 6K V2.4 FP32 model initialized, using 8 threads of available 8 CPUs
System details: linux debian 12.5 on unknown hardware
Starting analyzer in realtime mode. Threshold: 0.8, sensitivity: 1, interval: 15
Logging disabled
⇨ http server started on [::]:8080

```