### PR TITLE
feat: make range filter model selectable between latest and previous …

### DIFF
--- a/internal/birdnet/birdnet.go
+++ b/internal/birdnet/birdnet.go
@@ -1,3 +1,4 @@
+// birdnet.go BirdNET model specific code
 package birdnet
 
 import (
@@ -6,6 +7,7 @@ import (
 	"bytes"
 	_ "embed" // Embedding data directly into the binary.
 	"fmt"
+	"log"
 	"runtime"
 	"strings"
 	"sync"
@@ -20,10 +22,13 @@ import (
 //go:embed BirdNET_GLOBAL_6K_V2.4_Model_FP32.tflite
 var modelData []byte
 
-// Embedded TensorFlow Lite meta model data.
+// Embedded TensorFlow Lite range filter model data.
 //
+//go:embed BirdNET_GLOBAL_6K_V2.4_MData_Model_FP16.tflite
+var metaModelDataV1 []byte
+
 //go:embed BirdNET_GLOBAL_6K_V2.4_MData_Model_V2_FP16.tflite
-var metaModelData []byte
+var metaModelDataV2 []byte
 
 const modelVersion = "BirdNET GLOBAL 6K V2.4 FP32"
 
@@ -101,8 +106,20 @@ func (bn *BirdNET) initializeModel() error {
 	return nil
 }
 
+// getMetaModelData returns the appropriate meta model data based on the settings.
+func (bn *BirdNET) getMetaModelData() []byte {
+	if bn.Settings.BirdNET.RangeFilter.Version == "legacy" {
+		log.Printf("Using legacy range filter model")
+		return metaModelDataV1
+	}
+	log.Printf("Using latest range filter model")
+	return metaModelDataV2
+}
+
 // initializeMetaModel loads and initializes the meta model used for additional analysis.
 func (bn *BirdNET) initializeMetaModel() error {
+	metaModelData := bn.getMetaModelData()
+
 	model := tflite.NewModel(metaModelData)
 	if model == nil {
 		return fmt.Errorf("cannot load meta model from embedded data")

--- a/internal/birdnet/rangefilter.go
+++ b/internal/birdnet/rangefilter.go
@@ -48,16 +48,16 @@ func (bn *BirdNET) GetProbableSpecies() ([]string, error) {
 	}
 
 	// check bn.Settings.BirdNET.LocationFilterThreshold for valid value
-	if bn.Settings.BirdNET.LocationFilterThreshold < 0 ||
-		bn.Settings.BirdNET.LocationFilterThreshold > 1 {
+	if bn.Settings.BirdNET.RangeFilter.Threshold < 0 ||
+		bn.Settings.BirdNET.RangeFilter.Threshold > 1 {
 		fmt.Println("Invalid LocationFilterThreshold value, using default value of 0.01")
-		bn.Settings.BirdNET.LocationFilterThreshold = 0.01
+		bn.Settings.BirdNET.RangeFilter.Threshold = 0.01
 	}
 
 	// Collect species scores above a certain threshold
 	var speciesScores []SpeciesScore
 	for _, filter := range filters {
-		if filter.Score >= bn.Settings.BirdNET.LocationFilterThreshold {
+		if filter.Score >= bn.Settings.BirdNET.RangeFilter.Threshold {
 			// DEBUG print species which pass location threshold filter
 			//fmt.Println("Filter: ", filter.Label, " Score: ", filter.Score)
 			speciesScores = append(speciesScores, SpeciesScore{Score: float64(filter.Score), Label: filter.Label})
@@ -283,5 +283,5 @@ func (bn *BirdNET) RunFilterProcess(dateStr string, dateFormat string) {
 		return
 	}
 
-	PrintSpeciesScores(parsedDate, labels, float64(bn.Settings.BirdNET.LocationFilterThreshold))
+	PrintSpeciesScores(parsedDate, labels, float64(bn.Settings.BirdNET.RangeFilter.Threshold))
 }

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -27,14 +27,17 @@ type Settings struct {
 	}
 
 	BirdNET struct {
-		Sensitivity             float64 // birdnet analysis sigmoid sensitivity
-		Threshold               float64 // threshold for prediction confidence to report
-		Overlap                 float64 // birdnet analysis overlap between chunks
-		Longitude               float64 // longitude of recording location for prediction filtering
-		Latitude                float64 // latitude of recording location for prediction filtering
-		Threads                 int     // number of CPU threads to use for analysis
-		Locale                  string  // language to use for labels
-		LocationFilterThreshold float32 // rangefilter species occurrence threshold
+		Sensitivity float64 // birdnet analysis sigmoid sensitivity
+		Threshold   float64 // threshold for prediction confidence to report
+		Overlap     float64 // birdnet analysis overlap between chunks
+		Longitude   float64 // longitude of recording location for prediction filtering
+		Latitude    float64 // latitude of recording location for prediction filtering
+		Threads     int     // number of CPU threads to use for analysis
+		Locale      string  // language to use for labels
+		RangeFilter struct {
+			Version   string  // version of range filter model
+			Threshold float32 // rangefilter species occurrence threshold
+		}
 	}
 
 	Input struct {

--- a/internal/conf/config.yaml
+++ b/internal/conf/config.yaml
@@ -22,7 +22,9 @@ birdnet:
   locale: en            # language to use for labels
   latitude: 00.000      # latitude of recording location for prediction filtering
   longitude: 00.000     # longitude of recording location for prediction filtering
-  locationfilterthreshold: 0.01 # rangefilter species occurrence threshold
+  rangefilter:
+      model: latest     # model to use for range filter: "latest" or "legacy" for previous model
+      threshold: 0.01   # rangefilter species occurrence threshold
 
 # Realtime processing settings
 realtime:

--- a/internal/conf/defaults.go
+++ b/internal/conf/defaults.go
@@ -26,7 +26,8 @@ func setDefaultConfig() {
 	viper.SetDefault("birdnet.locale", "en")
 	viper.SetDefault("birdnet.latitude", 0.000)
 	viper.SetDefault("birdnet.longitude", 0.000)
-	viper.SetDefault("birdnet.locationfilterthreshold", 0.01)
+	viper.SetDefault("birdnet.rangefilter.model", "latest")
+	viper.SetDefault("birdnet.rangefilter.threshold", 0.01)
 
 	viper.SetDefault("realtime.interval", 15)
 	viper.SetDefault("realtime.processingtime", false)


### PR DESCRIPTION
…"legacy" version.

Also introduces a sliglty changed birdnet config layout with new config node birdnet.rangefilter with mode and threshold (renamed from birdnet.locationfilterthreshold) settings

```
# BirdNET model specific settings
birdnet:
  sensitivity: 1.0      # sigmoid sensitivity, 0.1 to 1.5
  threshold: 0.8        # threshold for prediction confidence to report, 0.0 to 1.0
  overlap: 0.0          # overlap between chunks, 0.0 to 2.9
  threads: 0            # 0 to use all available CPU threads
  locale: en            # language to use for labels
  latitude: 00.000      # latitude of recording location for prediction filtering
  longitude: 00.000     # longitude of recording location for prediction filtering
  rangefilter:
      model: latest     # model to use for range filter: "latest" or "legacy" for previous model
      threshold: 0.01   # rangefilter species occurrence threshold
```