### PR TITLE
Improve devcontainer experience

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,7 @@
 {
 	"name": "Go Build Environment",
 	"dockerFile": "../Dockerfile",
+	"forwardPorts": [8080],
 	"build": {
 		"context": "..",
 		"target": "buildenv"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,8 +10,10 @@
 	"containerEnv": {
 		"ALSA_CARD": "0",
 		"CGO_ENABLED": "1",
-		"CGO_CFLAGS": "-I /root/src/tensorflow"
+		"CGO_CFLAGS": "-I /home/dev-user/src/tensorflow"
 	},
+	"containerUser": "dev-user",
+	"updateRemoteUserUID": true,
 	"postCreateCommand": ".devcontainer/postCreateCommand.sh",
 	"postAttachCommand": ".devcontainer/start_dev_server.sh",
 	"customizations": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,7 +13,7 @@
 		"CGO_CFLAGS": "-I /root/src/tensorflow"
 	},
 	"postCreateCommand": ".devcontainer/postCreateCommand.sh",
-	"postAttachCommand": "make dev_server",
+	"postAttachCommand": ".devcontainer/start_dev_server.sh",
 	"customizations": {
 		"vscode": {
 			"extensions": [

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -1,10 +1,15 @@
 #!/bin/bash
 
-# Install required apt dependencies
 apt-get update
-apt-get install -y ca-certificates libasound2 ffmpeg sox
+
+# Install required runtime dependencies
+apt-get install -y ca-certificates libasound2 ffmpeg sox alsa-utils
+
+# Install file editors
 apt-get install -y nano vim
-apt-get clean
+
+# Install extras
+apt-get install -y dialog
 
 # Install air to support live reloading of server on code changes
 go install github.com/air-verse/air@latest

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -7,7 +7,7 @@ apt-get install -y nano vim
 apt-get clean
 
 # Install air to support live reloading of server on code changes
-go install github.com/cosmtrek/air@latest
+go install github.com/air-verse/air@latest
 
 # Install golangci-lint to allow running of linting locally
 curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$(go env GOPATH)/bin" v1.57.2

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -1,15 +1,16 @@
 #!/bin/bash
+set -euxo pipefail
 
-apt-get update
+sudo apt-get update
 
 # Install required runtime dependencies
-apt-get install -y ca-certificates libasound2 ffmpeg sox alsa-utils
+sudo apt-get install -y ca-certificates libasound2 ffmpeg sox alsa-utils
 
 # Install file editors
-apt-get install -y nano vim
+sudo apt-get install -y nano vim
 
 # Install extras
-apt-get install -y dialog
+sudo apt-get install -y dialog
 
 # Install air to support live reloading of server on code changes
 go install github.com/air-verse/air@latest

--- a/.devcontainer/start_dev_server.sh
+++ b/.devcontainer/start_dev_server.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Capture the output of the `arecord -l` command
+arecord_output=$(arecord -l)
+
+# Extract recording cards
+card_names=$(echo "$arecord_output" | grep -oP 'card \d+: \w+ \[\K[^\]]+' | uniq)
+
+# Generate dialog menu options
+options=()
+cards=()
+index=1
+while IFS= read -r line; do
+    cards+=("$line")
+    options+=($index "$line")
+    ((index++))
+done <<< "$card_names"
+
+# Show dialog prompt to user
+mic_to_use=$(dialog --clear --backtitle "Audio Device Selection" --title "Select an Audio Device" --menu "Choose one of the following options:" 15 40 4 "${options[@]}"  2>&1 >/dev/tty)
+
+selected_mic=${cards[mic_to_use - 1]}
+
+# Start dev server with selected mic
+make dev_server REALTIME_ARGS="--source ${selected_mic}"

--- a/Makefile
+++ b/Makefile
@@ -104,8 +104,9 @@ darwin_arm64: TFLITE_LIB_ARCH=darwin_arm64.tar.gz
 darwin_arm64: $(LABELS_ZIP) check-tools check-tensorflow download-tflite install-tflite build
 	$(CGO_FLAGS) go build $(LDFLAGS) -o $(BINARY_DIR)/$(BINARY_NAME)
 
+dev_server: REALTIME_ARGS=""
 dev_server: 
-	$(CGO_FLAGS) air realtime
+	$(CGO_FLAGS) air realtime $(REALTIME_ARGS)
 
 clean:
 	go clean


### PR DESCRIPTION
* Add port forwarding of 8080 in devcontainer such that it will automatically start working, rather than waiting for vscode to detect that it is open
* Air now goes by a new repo name and the reference has been updated
* Now when starting the devcontainer you will be prompted for which recording device to use:
![image](https://github.com/tphakala/birdnet-go/assets/8884086/374b736b-40fb-448b-bf17-d88ed9d3b3c7)
* A dev-user is added for the buildenv stage, meaning that most steps will not run as root directly anymore. For devcontainer users, this has the advantage of being less likely to be able to create root-owned files on the host system

