### PR TITLE
feat: BirdNET overlap setting impacts now realtime process also

### DIFF
--- a/internal/analysis/realtime.go
+++ b/internal/analysis/realtime.go
@@ -57,8 +57,9 @@ func RealtimeAnalysis(settings *conf.Settings) error {
 	fmt.Printf("System details: %s %s %s on %s hardware\n", info.OS, info.Platform, info.PlatformVersion, hwModel)
 
 	// Log the start of BirdNET-Go Analyzer in realtime mode and its configurations.
-	fmt.Printf("Starting analyzer in realtime mode. Threshold: %v, sensitivity: %v, interval: %v\n",
+	fmt.Printf("Starting analyzer in realtime mode. Threshold: %v, overlap: %v, sensitivity: %v, interval: %v\n",
 		settings.BirdNET.Threshold,
+		settings.BirdNET.Overlap,
 		settings.BirdNET.Sensitivity,
 		settings.Realtime.Interval)
 

--- a/internal/conf/config.yaml
+++ b/internal/conf/config.yaml
@@ -17,7 +17,7 @@ main:
 birdnet:
   sensitivity: 1.0      # sigmoid sensitivity, 0.1 to 1.5
   threshold: 0.8        # threshold for prediction confidence to report, 0.0 to 1.0
-  overlap: 0.0          # overlap between chunks, 0.0 to 2.9
+  overlap: 1.5          # overlap between chunks, 0.0 to 2.9
   threads: 0            # 0 to use all available CPU threads
   locale: en            # language to use for labels
   latitude: 00.000      # latitude of recording location for prediction filtering

--- a/internal/conf/validate.go
+++ b/internal/conf/validate.go
@@ -9,6 +9,12 @@ func validateSettings(settings *Settings) error {
 	if settings.Realtime.MQTT.Enabled && settings.Realtime.MQTT.Broker == "" {
 		return errors.New("MQTT broker URL is required when MQTT is enabled")
 	}
+
+	// Add validation for BirdNET.Overlap
+	if settings.BirdNET.Overlap < 0 || settings.BirdNET.Overlap > 2.9 {
+		return errors.New("BirdNET overlap value must be between 0 and 2.9 seconds")
+	}
+
 	// Other options to validate go here
 
 	return nil

--- a/internal/myaudio/buffers.go
+++ b/internal/myaudio/buffers.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/smallnest/ringbuffer"
 	"github.com/tphakala/birdnet-go/internal/birdnet"
+	"github.com/tphakala/birdnet-go/internal/conf"
 )
 
 const (
@@ -17,15 +18,32 @@ const (
 
 // A variable to set the overlap. Can range from 0 to 2 seconds, represented in bytes.
 // For example, for 1.5-second overlap: overlapSize = 144000
+/*
 var overlapSize int = 144000 // Set as required
-var readSize int = chunkSize - overlapSize
+var readSize int = chunkSize - overlapSize*/
+
+var overlapSize int
+var readSize int
 
 // ringBuffers is a map to store ring buffers for each audio source
 var ringBuffers map[string]*ringbuffer.RingBuffer
 var prevData map[string][]byte
 
+// ConvertSecondsToBytes converts overlap in seconds to bytes
+func ConvertSecondsToBytes(seconds float64) int {
+	const sampleRate = 48000 // 48 kHz
+	const bytesPerSample = 2 // 16-bit PCM data (2 bytes per sample)
+	return int(seconds * sampleRate * bytesPerSample)
+}
+
 // InitRingBuffers initializes the ring buffers for each audio source with a given capacity.
 func InitRingBuffers(capacity int, sources []string) {
+	settings := conf.Setting()
+
+	// Set overlapSize based on user setting in seconds
+	overlapSize = ConvertSecondsToBytes(settings.BirdNET.Overlap)
+	readSize = chunkSize - overlapSize
+
 	ringBuffers = make(map[string]*ringbuffer.RingBuffer)
 	prevData = make(map[string][]byte)
 	for _, source := range sources {


### PR DESCRIPTION
Previously overlap for realtime process was fixed to 1.5 seconds, now it is set by birdnet.overlap setting which now defaults to 1.5 if it is not set. Setting value is validated to be in range of 0 to 2.9 (seconds).

Overlap has impact on detection accuracy, higher overlap causes more samples to be taken of each 3 second chunks analysed by BirdNET AI model. Overlap setting higher than 1.5 is not recommended for realtime use due to increase in CPU usage.