### PR TITLE
fix: Add context timeout for MQTT publish

### DIFF
--- a/internal/analysis/processor/processor.go
+++ b/internal/analysis/processor/processor.go
@@ -2,6 +2,7 @@
 package processor
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"strings"
@@ -113,13 +114,33 @@ func New(settings *conf.Settings, ds datastore.Interface, bn *birdnet.BirdNET, m
 
 		// Connect to the MQTT broker in a separate goroutine to avoid blocking the main thread.
 		go func() {
-			log.Println("Connecting to MQTT broker")
-			err := p.MqttClient.Connect()
-			if err != nil {
-				log.Printf("Failed to connect to MQTT broker: %s", err)
-			} else {
-				log.Println("Successfully connected to MQTT broker")
+			const maxRetries = 5
+			retryDelay := time.Second
+
+			for i := 0; i < maxRetries; i++ {
+				log.Println("Connecting to MQTT broker")
+
+				// Create a context with a timeout for the connection attempt
+				ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+
+				err := p.MqttClient.Connect(ctx)
+				cancel() // Cancel the context to release resources
+
+				if err == nil {
+					log.Println("Successfully connected to MQTT broker")
+					return
+				}
+
+				log.Printf("Failed to connect to MQTT broker (attempt %d/%d): %s", i+1, maxRetries, err)
+
+				if i < maxRetries-1 {
+					log.Printf("Retrying in %v", retryDelay)
+					time.Sleep(retryDelay)
+					retryDelay *= 2 // Exponential backoff
+				}
 			}
+
+			log.Println("Failed to connect to MQTT broker after maximum retries")
 		}()
 	}
 


### PR DESCRIPTION
This commit adds a context with a timeout for publishing MQTT messages in the `MqttAction` and `Client` structs. This ensures that the publish operation does not block indefinitely and provides better error handling. If the publish operation exceeds the timeout, an error is returned indicating a timeout.