### PR TITLE
fix: Hourly occurences not being calculated correctly when using MySQL

### DIFF
--- a/internal/datastore/interfaces.go
+++ b/internal/datastore/interfaces.go
@@ -243,7 +243,7 @@ func (ds *DataStore) GetHourFormat() string {
 	case "sqlite":
 		return "strftime('%H', time)"
 	case "mysql":
-		return "DATE_FORMAT(time, '%H')"
+		return "TIME_FORMAT(time, '%H')"
 	default:
 		// Log or handle unsupported database types
 		return ""


### PR DESCRIPTION
When using a MySQL database the hourly occurrences table does not render correctly due to DATE_FORMAT being called on a time field. This MR switches the DATE_FORMAT call for TIME_FORMAT