### PR TITLE
feat: enable use of TensorFlow XNNPACK delegate for accelerating infe…

### DIFF
--- a/internal/birdnet/birdnet.go
+++ b/internal/birdnet/birdnet.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/go-tflite"
+	"github.com/tphakala/go-tflite/delegates/xnnpack"
 )
 
 // Embedded TensorFlow Lite model data.
@@ -95,6 +96,10 @@ func (bn *BirdNET) initializeModel() error {
 
 	// Configure interpreter options.
 	options := tflite.NewInterpreterOptions()
+	// If OS is Linux and XNNPACK library is available, enable XNNPACK delegate
+	if runtime.GOOS == "linux" && CheckXNNPACKLibrary() && bn.Settings.BirdNET.UseXNNPACK {
+		options.AddDelegate(xnnpack.New(xnnpack.DelegateOptions{NumThreads: int32(threads)}))
+	}
 	options.SetNumThread(threads)
 	options.SetErrorReporter(func(msg string, user_data interface{}) {
 		fmt.Println(msg)

--- a/internal/birdnet/birdnet_utils.go
+++ b/internal/birdnet/birdnet_utils.go
@@ -1,0 +1,27 @@
+package birdnet
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// CheckXNNPACKLibrary checks for the presence of libXNNPACK.a in typical Debian Linux library paths
+func CheckXNNPACKLibrary() bool {
+	libraryPaths := []string{
+		"/usr/lib",
+		"/usr/local/lib",
+		"/lib",
+		"/lib/x86_64-linux-gnu",
+		"/usr/lib/x86_64-linux-gnu",
+	}
+
+	for _, path := range libraryPaths {
+		fullPath := filepath.Join(path, "libXNNPACK.a")
+		if _, err := os.Stat(fullPath); err == nil {
+			// XNNPACK library is present
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -193,6 +193,7 @@ type BirdNETConfig struct {
 	RangeFilter RangeFilterSettings // range filter settings
 	ModelPath   string              // path to external model file (empty for embedded)
 	LabelPath   string              // path to external label file (empty for embedded)
+	UseXNNPACK  bool                // true to use XNNPACK delegate for inference acceleration
 }
 
 // RangeFilterSettings contains settings for the range filter

--- a/internal/conf/config.yaml
+++ b/internal/conf/config.yaml
@@ -25,6 +25,9 @@ birdnet:
   rangefilter:
       model: latest       # model to use for range filter: "latest" or "legacy" for previous model
       threshold: 0.01     # rangefilter species occurrence threshold
+  modelpath: ""           # path to external model file (empty for embedded)
+  labelpath: ""           # path to external label file (empty for embedded)
+  usexnnpack: false       # true to use XNNPACK delegate for inference acceleration
 
 # Realtime processing settings
 realtime:

--- a/internal/conf/defaults.go
+++ b/internal/conf/defaults.go
@@ -30,6 +30,9 @@ func setDefaultConfig() {
 	viper.SetDefault("birdnet.longitude", 0.000)
 	viper.SetDefault("birdnet.rangefilter.model", "latest")
 	viper.SetDefault("birdnet.rangefilter.threshold", 0.01)
+	viper.SetDefault("birdnet.modelpath", "")
+	viper.SetDefault("birdnet.labelpath", "")
+	viper.SetDefault("birdnet.usexnnpack", false)
 
 	// Realtime configuration
 	viper.SetDefault("realtime.interval", 15)


### PR DESCRIPTION
…rence performance

TensorFlow 2.16.1 added the xnnpack_enable_subgraph_reshaping option, which now allows the use of the XNNPACK delegate for the BirdNET model. This PR enables the XNNPACK delegate for improved performance when the following prerequisites are met:

- XNNPACK delegate use is enabled for Linux OS only (for now)
- libtensorflowlite_c.so must be updated to 2.16.1 or newer
  - Precompiled 2.17.0 library will be available at https://github.com/tphakala/tflite_c
- libXNNPACK.a library must be present at /usr/lib
  - Precompiled libXNNPACK library will be made available
- birdnet.usexnnpack setting must be set to true in config.yaml