### PR TITLE
fix: remove redundant copy of reset_auth.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,6 @@ USER dev-user
 WORKDIR /home/dev-user/src/BirdNET-Go
 
 COPY --chown=dev-user ./Makefile ./
-COPY --chown=dev-user ./reset_auth.sh ./
 
 # Download TensorFlow headers
 ARG TENSORFLOW_VERSION
@@ -64,9 +63,8 @@ ARG TFLITE_LIB_DIR
 COPY --from=build ${TFLITE_LIB_DIR}/libtensorflowlite_c.so ${TFLITE_LIB_DIR}
 RUN ldconfig
 
-# Include reset_auth tool from build stage
-COPY --from=build /home/dev-user/src/BirdNET-Go/reset_auth.sh /usr/bin/
-RUN chmod +x /usr/bin/reset_auth.sh
+# Include reset_auth tool
+COPY ./reset_auth.sh /usr/bin/
 
 # Add symlink to /config directory where configs can be stored
 VOLUME /config


### PR DESCRIPTION
For some reason the reset_auth.sh script was copied over to the build
stage, not used there, and then copied over to the runtime stage. This
is redundant and can be removed.

Updates Dockerfile to remove the redundant copy. Instead copies directly
from the host into the runtime stage. In addition, removes the chmod
since the file is already executable.
