### PR TITLE
feat: add birdnet-user to docker runtime image

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -euo pipefail
+
+# Inspired from https://github.com/docker-library/postgres/blob/master/17/bookworm/docker-entrypoint.sh
+# and https://github.com/redis/docker-library-redis/blob/master/docker-entrypoint.sh
+
+# Downgrade user if running as root, otherwise run as current user, allowing `--user` argument to work
+if [ "$(id -u)" = '0' ]; then
+    # Allow birdnet-user to write to the mounted volumes
+    find /data /config \! -user birdnet-user -exec chown birdnet-user:birdnet-user '{}' +
+
+    exec gosu birdnet-user "$BASH_SOURCE" "$@"
+fi
+
+echo "🐋 Starting BirdNET-Go inside container as $(id)..."
+
+# Check if the current user is in the audio group
+if ! id | grep -q '\baudio\b'; then
+    echo "Current user is not in the audio group. If running container with `--user`, ensure the user is in the audio group by passing `--group-add audio` to docker run"
+fi
+
+# Check read and write access for mounted volumes
+directories=("/data" "/config")
+if [[ -n "$directories" ]]; then
+    for directory in "${directories[@]}"; do
+        if ! test -r "$directory"; then
+            echo "birdnet-user ($(id)) does not have read access to $directory, $(stat -c "currently owned by uid=%u gid=%g with permissions %a/%A" $directory)"
+            exit 1
+        fi
+        if ! test -w "$directory"; then
+            echo "birdnet-user ($(id)) does not have write access to $directory, $(stat -c "currently owned by uid=%u gid=%g with permissions %a/%A" $directory)"
+            exit 1
+        fi
+    done
+fi
+
+exec /usr/bin/birdnet-go $@

--- a/internal/conf/utils.go
+++ b/internal/conf/utils.go
@@ -23,6 +23,12 @@ import (
 func GetDefaultConfigPaths() ([]string, error) {
 	var configPaths []string
 
+	// Prioritize CONFIG_PATH environment variable if set
+	configPath := os.Getenv("CONFIG_PATH")
+	if configPath != "" {
+		return []string{configPath}, nil
+	}
+
 	// Fetch the directory of the executable.
 	exePath, err := os.Executable()
 	if err != nil {


### PR DESCRIPTION

Fixes #322 

**Changes:**

   - Introduces a non-root user `birdnet-user` to the Docker image to enhance security and prevent potential vulnerabilities.
   - The entrypoint script utilizes `gosu` to downgrade to the less privileged `birdnet-user` (gid=10002, uid=10002), ensuring the container does not run as the root user.
   - Adjusts volume mount permissions for `/data` and `/config` to the new user during the downgrade process.
   - Supports running the container with an arbitrary user/group ID by passing `--user` into the `docker run` command. Safeguards are in place to ensure the specified user/group ID has the required permissions to the mounted volumes and belongs to the audio group.
   - Introduces the `CONFIG_PATH` environment variable to allow setting the configuration path. This is particularly useful when running inside a container, as the configuration might be mounted in a different path than expected when running on a real machine.

These changes should not leave any existing volumes in a bad state and should be easy for everyone to use. However, it would be good if someone else could try out these changes to be on the safe side before we merge anything. 