### PR TITLE
BirdNET debug

### DIFF
--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -194,6 +194,7 @@ type InputConfig struct {
 }
 
 type BirdNETConfig struct {
+	Debug       bool                // true to enable debug mode
 	Sensitivity float64             // birdnet analysis sigmoid sensitivity
 	Threshold   float64             // threshold for prediction confidence to report
 	Overlap     float64             // birdnet analysis overlap between chunks

--- a/internal/conf/defaults.go
+++ b/internal/conf/defaults.go
@@ -21,6 +21,7 @@ func setDefaultConfig() {
 	viper.SetDefault("main.log.rotationday", "Sunday")
 
 	// BirdNET configuration
+	viper.SetDefault("birdnet.debug", false)
 	viper.SetDefault("birdnet.sensitivity", 1.0)
 	viper.SetDefault("birdnet.threshold", 0.8)
 	viper.SetDefault("birdnet.overlap", 0.0)

--- a/internal/myaudio/process.go
+++ b/internal/myaudio/process.go
@@ -33,18 +33,26 @@ func ProcessData(bn *birdnet.BirdNET, data []byte, startTime time.Time, source s
 	// get elapsed time
 	elapsedTime := time.Since(predictStart)
 
-	// Sort results by confidence (descending order)
-	/*sort.Slice(results, func(i, j int) bool {
-		return results[i].Confidence > results[j].Confidence
-	})
-
-	// DEBUG print species of results with confidence > 0.20 in green
-	green := color.New(color.FgGreen).SprintfFunc()
-	for _, result := range results {
-		if result.Confidence > 0.20 {
-			fmt.Println(green("%.2f %s", result.Confidence, result.Species))
+	// DEBUG print all BirdNET results
+	if conf.Setting().BirdNET.Debug {
+		debugThreshold := float32(0) // set to 0 for now, maybe add a config option later
+		hasHighConfidenceResults := false
+		for _, result := range results {
+			if result.Confidence > debugThreshold {
+				hasHighConfidenceResults = true
+				break
+			}
 		}
-	}*/
+
+		if hasHighConfidenceResults {
+			log.Println("[birdnet] results:")
+			for _, result := range results {
+				if result.Confidence > debugThreshold {
+					log.Printf("[birdnet] %.2f %s\n", result.Confidence, result.Species)
+				}
+			}
+		}
+	}
 
 	// Get the current settings
 	settings := conf.Setting()


### PR DESCRIPTION
Added debug flag for BirdNET processing, when enabled all results of segment analysis is printed to log. More debug will be enabled later.