### PR TITLE
fix: Correct filename encoding in audio clip content disposition header

### DIFF
--- a/internal/httpcontroller/handlers/media.go
+++ b/internal/httpcontroller/handlers/media.go
@@ -647,7 +647,7 @@ func (h *Handlers) ServeAudioClip(c echo.Context) error {
 	c.Response().Header().Set("Content-Description", "File Transfer")
 	// Set both ASCII and UTF-8 versions of the filename for better browser compatibility
 	c.Response().Header().Set(echo.HeaderContentDisposition,
-		fmt.Sprintf(`attachment; filename="%q"; filename*=UTF-8''%q`,
+		fmt.Sprintf(`attachment; filename="%s"; filename*=UTF-8''%s`,
 			safeFilename,
 			safeFilename))
 


### PR DESCRIPTION
Modify filename formatting to use %s instead of %q to prevent double-quoting, ensuring proper filename display in browser downloads