### PR TITLE
Fix failing test and linter error

### DIFF
--- a/internal/datastore/interfaces.go
+++ b/internal/datastore/interfaces.go
@@ -301,7 +301,7 @@ func (ds *DataStore) GetClipsQualifyingForRemoval(minHours, minClips int) ([]Cli
 	var results []ClipForRemoval
 
 	// Define a subquery to count the number of recordings per scientific name
-	subquery := ds.DB.Model(&Note{}).Select("ID, scientific_name, ROW_NUMBER() OVER (PARTITION BY scientific_name) as num_recordings").
+	subquery := ds.DB.Model(&Note{}).Select("notes.ID, notes.scientific_name, ROW_NUMBER() OVER (PARTITION BY notes.scientific_name) as num_recordings").
 		Where("clip_name != ''").
 		// Exclude notes that have a lock
 		Joins("LEFT JOIN note_locks ON notes.id = note_locks.note_id").

--- a/internal/httpcontroller/handlers/media.go
+++ b/internal/httpcontroller/handlers/media.go
@@ -647,7 +647,7 @@ func (h *Handlers) ServeAudioClip(c echo.Context) error {
 	c.Response().Header().Set("Content-Description", "File Transfer")
 	// Set both ASCII and UTF-8 versions of the filename for better browser compatibility
 	c.Response().Header().Set(echo.HeaderContentDisposition,
-		fmt.Sprintf(`attachment; filename="%s"; filename*=UTF-8''%s`,
+		fmt.Sprintf(`attachment; filename="%q"; filename*=UTF-8''%q`,
 			safeFilename,
 			safeFilename))
 


### PR DESCRIPTION
This fixes the `TestGetClipsQualifyingForRemoval` test, that has been failing for a while.

![image](https://github.com/user-attachments/assets/6c654a3d-754d-45ed-8418-c1d4e83c0b7c)

And this linter error:

![image](https://github.com/user-attachments/assets/74c94078-14bc-4302-9e0f-bedfb830b54a)

Or I think so, because I wasn't able to replicate the build environment.