### PR TITLE
fix: Various fixes to sound card initialization messages etc.

### DIFF
--- a/internal/myaudio/analysis_buffer.go
+++ b/internal/myaudio/analysis_buffer.go
@@ -279,7 +279,10 @@ func AnalysisBufferMonitor(wg *sync.WaitGroup, bn *birdnet.BirdNET, quitChan cha
 	// preRecordingTime is the time to subtract from the current time to get the start time of the detection
 	const preRecordingTime = -5000 * time.Millisecond
 
-	defer wg.Done()
+	wg.Add(1)
+	defer func() {
+		wg.Done()
+	}()
 
 	// Creating a ticker that ticks every 100ms
 	ticker := time.NewTicker(pollInterval)

--- a/internal/myaudio/capture.go
+++ b/internal/myaudio/capture.go
@@ -48,10 +48,13 @@ var ffmpegMonitor *FFmpegMonitor
 
 // ListAudioSources returns a list of available audio capture devices.
 func ListAudioSources() ([]AudioDeviceInfo, error) {
+	// Create a slice to store audio device information
+	var devices []AudioDeviceInfo
+
 	// Initialize the audio context
 	ctx, err := malgo.InitContext(nil, malgo.ContextConfig{}, nil)
 	if err != nil {
-		return nil, fmt.Errorf("failed to initialize context: %w", err)
+		return devices, fmt.Errorf("failed to initialize context: %w", err)
 	}
 
 	// Ensure the context is uninitialized when the function returns
@@ -64,14 +67,16 @@ func ListAudioSources() ([]AudioDeviceInfo, error) {
 	// Get a list of capture devices
 	infos, err := ctx.Devices(malgo.Capture)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get devices: %w", err)
+		return devices, fmt.Errorf("failed to get devices: %w", err)
 	}
-
-	// Create a slice to store audio device information
-	var devices []AudioDeviceInfo
 
 	// Iterate through the list of devices
 	for i := range infos {
+		// Skip the discard/null device
+		if strings.Contains(infos[i].Name(), "Discard all samples") {
+			continue
+		}
+
 		// Decode the device ID from hexadecimal to ASCII
 		decodedID, err := hexToASCII(infos[i].ID.String())
 		if err != nil {
@@ -317,9 +322,14 @@ func CaptureAudio(settings *conf.Settings, wg *sync.WaitGroup, quitChan, restart
 		}
 	}
 
-	// Handle local audio device if configured
+	// Handle sound card source if configured
 	if settings.Realtime.Audio.Source != "" {
-		// Try to select and test a capture device
+		// Validate audio device
+		if err := ValidateAudioDevice(settings); err != nil {
+			log.Printf("⚠️ Audio device validation failed: %v", err)
+			return
+		}
+
 		selectedSource, err := selectCaptureSource(settings)
 		if err != nil {
 			log.Printf("❌ Audio device selection failed: %v", err)
@@ -338,10 +348,121 @@ func CaptureAudio(settings *conf.Settings, wg *sync.WaitGroup, quitChan, restart
 	}
 }
 
-// selectCaptureSource selects and tests an appropriate capture device based on the provided settings.
-// It prints available devices, tests the selected device, and returns the selected device and any error encountered.
-func selectCaptureSource(settings *conf.Settings) (captureSource, error) {
+// isHardwareDevice checks if the device ID indicates a hardware device
+func isHardwareDevice(decodedID string) bool {
+	// On Linux, hardware devices have IDs in the format ":X,Y"
+	if runtime.GOOS == "linux" {
+		return strings.Contains(decodedID, ":") && strings.Contains(decodedID, ",")
+	}
+	// On Windows and macOS, consider all devices as potential hardware devices
+	// as the ID format is different and we rely on the OS's device enumeration
+	return true
+}
+
+// getHardwareDevices filters the device infos to return only hardware devices
+func getHardwareDevices(infos []malgo.DeviceInfo) []malgo.DeviceInfo {
+	var hardwareDevices []malgo.DeviceInfo
+	for i := range infos {
+		decodedID, err := hexToASCII(infos[i].ID.String())
+		if err != nil {
+			continue
+		}
+		if isHardwareDevice(decodedID) {
+			hardwareDevices = append(hardwareDevices, infos[i])
+		}
+	}
+	return hardwareDevices
+}
+
+// TestCaptureDevice tests if a capture device can be initialized and started.
+// Returns true if the device is working, false otherwise.
+func TestCaptureDevice(ctx *malgo.AllocatedContext, info *malgo.DeviceInfo) bool {
+	deviceConfig := malgo.DefaultDeviceConfig(malgo.Capture)
+	deviceConfig.Capture.Format = malgo.FormatS16
+	deviceConfig.Capture.Channels = conf.NumChannels
+	deviceConfig.Capture.DeviceID = info.ID.Pointer()
+	deviceConfig.SampleRate = conf.SampleRate
+	deviceConfig.Alsa.NoMMap = 1
+
+	// Try to initialize the device
+	device, err := malgo.InitDevice(ctx.Context, deviceConfig, malgo.DeviceCallbacks{})
+	if err != nil {
+		return false
+	}
+	defer device.Uninit()
+
+	// Try to start the device
+	if err := device.Start(); err != nil {
+		return false
+	}
+
+	// Stop the device
+	_ = device.Stop()
+	return true
+}
+
+// ValidateAudioDevice checks if the configured audio source is available and working.
+// Returns an error if the device is not available or not working.
+// This function also updates the settings if the device is not valid.
+func ValidateAudioDevice(settings *conf.Settings) error {
+	if settings.Realtime.Audio.Source == "" {
+		return nil
+	}
+
+	var backend malgo.Backend
+	switch runtime.GOOS {
+	case "linux":
+		backend = malgo.BackendAlsa
+	case "windows":
+		backend = malgo.BackendWasapi
+	case "darwin":
+		backend = malgo.BackendCoreaudio
+	}
+
 	// Initialize malgo context
+	malgoCtx, err := malgo.InitContext([]malgo.Backend{backend}, malgo.ContextConfig{}, nil)
+	if err != nil {
+		settings.Realtime.Audio.Source = ""
+		return fmt.Errorf("failed to initialize audio context: %w", err)
+	}
+	defer malgoCtx.Uninit() //nolint:errcheck
+
+	// Get list of capture devices
+	infos, err := malgoCtx.Devices(malgo.Capture)
+	if err != nil {
+		settings.Realtime.Audio.Source = ""
+		return fmt.Errorf("failed to get capture devices: %w", err)
+	}
+
+	// Filter to get only hardware devices
+	hardwareDevices := getHardwareDevices(infos)
+	if len(hardwareDevices) == 0 {
+		settings.Realtime.Audio.Source = ""
+		return fmt.Errorf("no hardware audio capture devices found")
+	}
+
+	// Try to find and test the configured device
+	for i := range hardwareDevices {
+		decodedID, err := hexToASCII(hardwareDevices[i].ID.String())
+		if err != nil {
+			continue
+		}
+
+		if matchesDeviceSettings(decodedID, &hardwareDevices[i], settings.Realtime.Audio.Source) {
+			if TestCaptureDevice(malgoCtx, &hardwareDevices[i]) {
+				return nil
+			}
+			settings.Realtime.Audio.Source = ""
+			return fmt.Errorf("configured audio device '%s' failed hardware test", settings.Realtime.Audio.Source)
+		}
+	}
+
+	settings.Realtime.Audio.Source = ""
+	return fmt.Errorf("configured audio device '%s' not found", settings.Realtime.Audio.Source)
+}
+
+// selectCaptureSource selects and tests an appropriate capture device based on the provided settings.
+func selectCaptureSource(settings *conf.Settings) (captureSource, error) {
 	var backend malgo.Backend
 	switch runtime.GOOS {
 	case "linux":
@@ -360,11 +481,7 @@ func selectCaptureSource(settings *conf.Settings) (captureSource, error) {
 	if err != nil {
 		return captureSource{}, fmt.Errorf("audio context initialization failed: %w", err)
 	}
-	defer malgoCtx.Uninit() //nolint:errcheck // We handle errors in the caller
-
-	fmt.Println("Available Capture Sources:")
-
-	var selectedSource captureSource
+	defer malgoCtx.Uninit() //nolint:errcheck
 
 	// Get list of capture sources
 	infos, err := malgoCtx.Devices(malgo.Capture)
@@ -372,69 +489,34 @@ func selectCaptureSource(settings *conf.Settings) (captureSource, error) {
 		return captureSource{}, fmt.Errorf("failed to get capture devices: %w", err)
 	}
 
-	// If no devices are available, return appropriate error
-	if len(infos) == 0 {
-		return captureSource{}, fmt.Errorf("no audio capture devices found")
-	}
+	// Filter to get only hardware devices
+	hardwareDevices := getHardwareDevices(infos)
 
-	for i := range infos {
-		// Decode the device ID from hexadecimal to ASCII
-		decodedID, err := hexToASCII(infos[i].ID.String())
+	fmt.Println("Available Hardware Capture Sources:")
+	for i := range hardwareDevices {
+		decodedID, err := hexToASCII(hardwareDevices[i].ID.String())
 		if err != nil {
 			fmt.Printf("❌ Error decoding ID for device %d: %v\n", i, err)
 			continue
 		}
 
-		// Prepare the output string for listing available devices
-		output := fmt.Sprintf("  %d: %s", i, infos[i].Name())
+		output := fmt.Sprintf("  %d: %s", i, hardwareDevices[i].Name())
 		if runtime.GOOS == "linux" {
-			output = fmt.Sprintf("%s, %s", output, decodedID) // Include decoded ID in the output for Linux
+			output = fmt.Sprintf("%s, %s", output, decodedID)
 		}
 
-		// Determine if the current device matches the specified settings
-		if matchesDeviceSettings(decodedID, &infos[i], settings.Realtime.Audio.Source) {
-			selectedSource = captureSource{
-				Name:    infos[i].Name(),
-				ID:      decodedID,
-				Pointer: infos[i].ID.Pointer(),
+		if matchesDeviceSettings(decodedID, &hardwareDevices[i], settings.Realtime.Audio.Source) {
+			if TestCaptureDevice(malgoCtx, &hardwareDevices[i]) {
+				fmt.Printf("%s (✅ selected)\n", output)
+				return captureSource{
+					Name:    hardwareDevices[i].Name(),
+					ID:      decodedID,
+					Pointer: hardwareDevices[i].ID.Pointer(),
+				}, nil
 			}
-
-			// Try to actually initialize and test the device
-			deviceConfig := malgo.DefaultDeviceConfig(malgo.Capture)
-			deviceConfig.Capture.Format = malgo.FormatS16
-			deviceConfig.Capture.Channels = conf.NumChannels
-			deviceConfig.Capture.DeviceID = selectedSource.Pointer
-			deviceConfig.SampleRate = conf.SampleRate
-			deviceConfig.Alsa.NoMMap = 1
-
-			// Try to initialize the device
-			testDevice, err := malgo.InitDevice(malgoCtx.Context, deviceConfig, malgo.DeviceCallbacks{})
-			if err != nil {
-				if settings.Debug {
-					log.Printf("❌ Device initialization test failed for %s: %v", selectedSource.Name, err)
-				}
-				fmt.Printf("%s (❌ initialization failed)\n", output)
-				continue
-			}
-
-			// Try to start the device
-			if err := testDevice.Start(); err != nil {
-				if settings.Debug {
-					log.Printf("❌ Device start test failed for %s: %v", selectedSource.Name, err)
-				}
-				testDevice.Uninit()
-				fmt.Printf("%s (❌ start failed)\n", output)
-				continue
-			}
-
-			// Stop and uninit the test device
-			_ = testDevice.Stop()
-			testDevice.Uninit()
-
-			fmt.Printf("%s (✅ working)\n", output)
-			return selectedSource, nil
+			fmt.Printf("%s (❌ device test failed)\n", output)
+			continue
 		}
-
 		fmt.Println(output)
 	}
 

--- a/internal/myaudio/ffmpeg_input.go
+++ b/internal/myaudio/ffmpeg_input.go
@@ -180,6 +180,7 @@ func (p *FFmpegProcess) Cleanup(url string) {
 
 	select {
 	case <-done:
+		log.Printf("🛑 FFmpeg process for RTSP source %s stopped normally", url)
 		// Process finished normally
 	case <-time.After(10 * time.Second):
 		// Timeout occurred, forcefully kill the process
@@ -364,7 +365,7 @@ func startFFmpeg(ctx context.Context, config FFmpegConfig) (*FFmpegProcess, erro
 	}
 
 	// Log the FFmpeg command for debugging purposes
-	log.Println("⬆️  Starting FFmpeg with command:", cmd.String())
+	log.Printf("⬆️ Starting FFmpeg with command: %s", cmd.String())
 
 	// Start the FFmpeg process
 	if err := cmd.Start(); err != nil {
@@ -474,7 +475,6 @@ func manageFfmpegLifecycle(ctx context.Context, config FFmpegConfig, restartChan
 		select {
 		case <-ctx.Done():
 			// Context cancelled, stop the FFmpeg process
-			log.Printf("🔴 Context cancelled, stopping FFmpeg for RTSP source %s.", config.URL)
 			process.Cleanup(config.URL)
 			return ctx.Err()
 
@@ -555,9 +555,6 @@ func getExitCode(err error) int {
 
 // CaptureAudioRTSP is the main function for capturing audio from an RTSP stream
 func CaptureAudioRTSP(url, transport string, wg *sync.WaitGroup, quitChan <-chan struct{}, restartChan chan struct{}, audioLevelChan chan AudioLevelData) {
-	// Ensure the WaitGroup is decremented when the function exits
-	defer wg.Done()
-
 	// Return with error if FFmpeg path is not set
 	if conf.GetFfmpegBinaryName() == "" {
 		log.Printf("❌ FFmpeg is not available, cannot capture audio from RTSP source %s.", url)

--- a/views/settings/audioSettings.html
+++ b/views/settings/audioSettings.html
@@ -132,12 +132,10 @@ x-init="
             </label>
             <select x-model="audioCapture.source"
                     name="realtime.audio.source"
-                    class="select select-bordered select-sm w-full"
-                    :disabled="audioCapture.rtsp.urls.length > 0">
-                <option value="">Select an audio source</option>
+                    class="select select-bordered select-sm w-full">
+                <option value="">No sound card capture</option>
                 <template x-for="device in audioDevices" :key="device.Index">
                     <option :value="device.Name" 
-                            :selected="device.Name.toLowerCase().includes(audioCapture.source.toLowerCase()) || device.Name === audioCapture.source" 
                             x-text="device.Name"></option>
                 </template>
             </select>
@@ -146,7 +144,7 @@ x-init="
                  class="tooltip" 
                  role="tooltip"
                  aria-live="polite">
-                Audio source to use for analysis (e.g., 'sysdefault'). This setting is disabled if RTSP URLs are configured.
+                Audio source to use for analysis (e.g., 'sysdefault'). Select 'No sound card capture' to disable sound card capture.
             </div>
         </div>
 

--- a/views/settings/audioSettings.html
+++ b/views/settings/audioSettings.html
@@ -123,7 +123,7 @@ x-init="
 
         <div class="form-control relative">
             <label class="label justify-start" for="audioSource">
-                <span class="label-text">Audio Source</span>
+                <span class="label-text">Audio Source (requires application restart to take effect)</span>
                 <span class="help-icon" 
                       role="button"
                       aria-label="Show help for audio source"
@@ -133,10 +133,12 @@ x-init="
             <select x-model="audioCapture.source"
                     name="realtime.audio.source"
                     class="select select-bordered select-sm w-full">
-                <option value="">No sound card capture</option>
+                <option value="" :selected="!audioCapture.source">No sound card capture</option>
                 <template x-for="device in audioDevices" :key="device.Index">
                     <option :value="device.Name" 
-                            x-text="device.Name"></option>
+                        :selected="audioCapture.source && (device.Name.toLowerCase().includes(audioCapture.source.toLowerCase()) || device.Name === audioCapture.source)"
+                        x-text="device.Name">
+                    </option>
                 </template>
             </select>
             <div x-show="showTooltip === 'audioSource'" 


### PR DESCRIPTION
This PR contains fixes for application startup messages related to sound cart initialization, messages for failed sound card initialization are now less dramatic etc.

Also it is now possible to enable both local sound card analysis and RTSP analysis, UI no longer disables sound card selecton menu when RTSP URLs are configured. For deployments without any sound cards UI now has "No sound card capture" selection.