### PR TITLE
feat: Add gain control to audio player

### DIFF
--- a/assets/audioplayer.js
+++ b/assets/audioplayer.js
@@ -1,4 +1,36 @@
 htmx.on('htmx:afterSettle', function (event) {
+    // Initialize Web Audio Context
+    let audioContext;
+    try {
+        audioContext = new (window.AudioContext || window.webkitAudioContext)();
+    } catch (e) {
+        console.warn('Web Audio API is not supported in this browser');
+    }
+
+    // Constants
+    const SLIDER_INACTIVITY_TIMEOUT_MS = 5000; // 5 seconds
+    const SLIDER_MARGIN = 8; // Margin between spectrogram and slider
+
+    // Store audio nodes for each player
+    const audioNodes = new Map();
+
+    // Track currently active gain control
+    let activeGainControl = null;
+
+    // Function to convert decibels to gain value
+    const dbToGain = (db) => Math.pow(10, db / 20);
+
+    // Function to convert gain to decibels
+    const gainToDb = (gain) => 20 * Math.log10(gain);
+
+    // Function to hide active gain control
+    const hideActiveGainControl = () => {
+        if (activeGainControl) {
+            activeGainControl.hideSlider();
+            activeGainControl = null;
+        }
+    };
+
     // Attach the audio players
     const audioElements = document.querySelectorAll('[id^="audio-"]');
     audioElements && audioElements.forEach(audio => {
@@ -14,7 +46,258 @@ htmx.on('htmx:afterSettle', function (event) {
         const spectrogramContainer = playerOverlay.closest('.relative');
         const positionIndicator = document.getElementById(`position-indicator-${id}`);
 
+        // Create volume control elements
+        const volumeControl = document.createElement('div');
+        volumeControl.style.cssText = 'position: absolute; top: 8px; right: 8px; z-index: 10; opacity: 0; transition: opacity 0.2s;';
+        volumeControl.innerHTML = `
+            <div class="volume-control-container" style="position: relative;">
+                <button class="volume-button" style="padding: 4px; border-radius: 50%; background: rgba(0, 0, 0, 0.5); transition: background 0.2s;">
+                    <svg width="20" height="20" viewBox="0 0 24 24" style="color: white;">
+                        <path d="M12 5v14l-7-7h-3v-4h3l7-7z" fill="currentColor"/>
+                        <path d="M16 8a4 4 0 0 1 0 8" stroke="currentColor" fill="none" stroke-width="2" stroke-linecap="round"/>
+                        <path d="M19 5a8 8 0 0 1 0 14" stroke="currentColor" fill="none" stroke-width="2" stroke-linecap="round"/>
+                    </svg>
+                </button>
+            </div>
+        `;
+
+        // Create slider element separately
+        const sliderElement = document.createElement('div');
+        sliderElement.className = 'volume-slider';
+        sliderElement.style.cssText = 'display: none; position: absolute; background: rgba(0, 0, 0, 0.5); padding: 12px 8px; border-radius: 4px; z-index: 1000;';
+        sliderElement.innerHTML = `
+            <div style="display: flex; flex-direction: column; align-items: center; gap: 8px;">
+                <input type="range" min="0" max="12" step="3" value="0" 
+                       style="writing-mode: bt-lr; -webkit-appearance: slider-vertical; height: 100px; width: 24px; background: transparent;">
+                <span style="color: white; font-size: 12px;">0 dB</span>
+            </div>
+        `;
+
+        // Add volume control and slider to player
+        spectrogramContainer.appendChild(volumeControl);
+        spectrogramContainer.appendChild(sliderElement);
+
+        // Style the volume slider to match player theme
+        const sliderStyle = document.createElement('style');
+        sliderStyle.textContent = `
+            .volume-button:hover {
+                background: rgba(0, 0, 0, 0.7) !important;
+            }
+            input[type=range]::-webkit-slider-thumb {
+                -webkit-appearance: none;
+                height: 12px;
+                width: 12px;
+                border-radius: 50%;
+                background: white;
+                cursor: pointer;
+                margin-top: -4px;
+            }
+            input[type=range]::-webkit-slider-runnable-track {
+                width: 100%;
+                height: 4px;
+                background: rgba(255, 255, 255, 0.3);
+                border-radius: 2px;
+            }
+            input[type=range]:focus {
+                outline: none;
+            }
+        `;
+        document.head.appendChild(sliderStyle);
+
+        let sliderTimeout;
+        let isSliderActive = false;
+
+        // Add hover behavior to match other controls
+        spectrogramContainer.addEventListener('mouseenter', () => {
+            volumeControl.style.opacity = '1'; // Keep fully visible
+        });
+
+        // Add hover behavior to match other controls
+        spectrogramContainer.addEventListener('mouseleave', () => {
+            // Only reduce opacity if the slider is NOT visible
+            if (!isSliderActive) {
+                volumeControl.style.opacity = '0';
+            }
+        });
+
         let updateInterval;
+        let audioSource;
+        let gainNode;
+
+        // Initialize Web Audio nodes if supported
+        if (audioContext) {
+            try {
+                audioSource = audioContext.createMediaElementSource(audio);
+                gainNode = audioContext.createGain();
+                gainNode.gain.value = 1; // 0dB = gain of 1
+                
+                // Create and configure compressor for normalization
+                const compressor = audioContext.createDynamicsCompressor();
+                compressor.threshold.value = -24;
+                compressor.knee.value = 30;
+                compressor.ratio.value = 12;
+                compressor.attack.value = 0.003;
+                compressor.release.value = 0.25;
+
+                // Connect the audio graph
+                audioSource
+                    .connect(gainNode)
+                    .connect(compressor)
+                    .connect(audioContext.destination);
+
+                // Store nodes for this player
+                audioNodes.set(id, { source: audioSource, gain: gainNode, compressor });
+
+                // Add volume control interactions
+                const volumeButton = volumeControl.querySelector('.volume-button');
+                const sliderInput = sliderElement.querySelector('input');
+                const dbDisplay = sliderElement.querySelector('span');
+
+                // Function to calculate optimal slider position
+                const calculateSliderPosition = () => {
+                    const spectrogramRect = spectrogramContainer.getBoundingClientRect();
+                    const sliderRect = sliderElement.getBoundingClientRect();
+                    const viewportWidth = window.innerWidth;
+                    
+                    // Calculate position relative to the spectrogram container
+                    let left = spectrogramRect.width + SLIDER_MARGIN;
+                    let top = 0;
+
+                    // Check if slider would go off the right edge of the viewport
+                    if (spectrogramRect.right + SLIDER_MARGIN + sliderRect.width > viewportWidth) {
+                        // Position on the left side instead
+                        left = -sliderRect.width - SLIDER_MARGIN;
+                    }
+
+                    // Vertically center the slider relative to the spectrogram
+                    top = (spectrogramRect.height - sliderRect.height) / 2;
+
+                    return { top, left };
+                };
+
+                // Function to update slider position
+                const updateSliderPosition = () => {
+                    if (sliderElement.style.display !== 'none') {
+                        const { top, left } = calculateSliderPosition();
+                        sliderElement.style.top = `${top}px`;
+                        sliderElement.style.left = `${left}px`;
+                    }
+                };
+
+                // Function to hide slider
+                const hideSlider = () => {
+                    sliderElement.style.display = 'none';
+                    isSliderActive = false;
+
+                    // Only lower opacity if the user is NOT hovering over the spectrogram
+                    if (!spectrogramContainer.matches(':hover')) {
+                        volumeControl.style.opacity = '0';
+                    }
+
+                    if (sliderTimeout) {
+                        clearTimeout(sliderTimeout);
+                        sliderTimeout = null;
+                    }
+
+                    // Clear active gain control if this one is being hidden
+                    if (activeGainControl && activeGainControl.id === id) {
+                        activeGainControl = null;
+                    }
+                };
+
+                // Function to show slider
+                const showSlider = () => {
+                    // Hide any other active gain control first
+                    hideActiveGainControl();
+
+                    sliderElement.style.display = 'block';
+                    isSliderActive = true;
+                    volumeControl.style.opacity = '1';
+                    updateSliderPosition();
+
+                    // Set this as the active gain control
+                    activeGainControl = {
+                        id: id,
+                        hideSlider: hideSlider
+                    };
+
+                    // Reset and start inactivity timer
+                    if (sliderTimeout) {
+                        clearTimeout(sliderTimeout);
+                    }
+                    sliderTimeout = setTimeout(hideSlider, SLIDER_INACTIVITY_TIMEOUT_MS);
+                };
+
+                // Function to reset inactivity timer
+                const resetTimer = () => {
+                    if (sliderTimeout) {
+                        clearTimeout(sliderTimeout);
+                    }
+                    sliderTimeout = setTimeout(hideSlider, SLIDER_INACTIVITY_TIMEOUT_MS);
+                };
+
+                // Add scroll and resize listeners for slider positioning
+                window.addEventListener('scroll', updateSliderPosition, { passive: true });
+                window.addEventListener('resize', () => {
+                    // Hide slider on window resize
+                    hideSlider();
+                }, { passive: true });
+
+                // Toggle volume slider visibility
+                volumeButton.addEventListener('click', (e) => {
+                    e.stopPropagation();
+                    if (sliderElement.style.display === 'none') {
+                        showSlider();
+                    } else {
+                        hideSlider();
+                    }
+                });
+
+                // Add interaction listeners to reset timer
+                sliderElement.addEventListener('mouseover', resetTimer);
+                sliderElement.addEventListener('mousemove', resetTimer);
+                sliderInput.addEventListener('input', (e) => {
+                    resetTimer();
+                    const dbValue = parseInt(e.target.value);
+                    const gainValue = dbToGain(dbValue);
+                    gainNode.gain.value = gainValue;
+                    dbDisplay.textContent = `${dbValue} dB`;
+                });
+
+                // Function to handle gain adjustment via mouse wheel
+                const handleWheel = (e) => {
+                    if (sliderElement.style.display !== 'none') {
+                        e.preventDefault(); // Prevent page scrolling
+                        resetTimer();
+                        const currentValue = parseInt(sliderInput.value);
+                        // Determine scroll direction and adjust by step value (3dB)
+                        const step = e.deltaY < 0 ? 3 : -3;
+                        const newValue = Math.max(0, Math.min(12, currentValue + step));
+                        
+                        if (newValue !== currentValue) {
+                            sliderInput.value = newValue;
+                            const gainValue = dbToGain(newValue);
+                            gainNode.gain.value = gainValue;
+                            dbDisplay.textContent = `${newValue} dB`;
+                        }
+                    }
+                };
+
+                // Add mouse wheel control for gain when slider is visible
+                sliderElement.addEventListener('wheel', handleWheel, { passive: false });
+                spectrogramContainer.addEventListener('wheel', handleWheel, { passive: false });
+
+                // Hide volume slider when clicking outside
+                document.addEventListener('click', (e) => {
+                    if (!volumeControl.contains(e.target) && !sliderElement.contains(e.target)) {
+                        hideSlider();
+                    }
+                });
+
+            } catch (e) {
+                console.warn('Error setting up Web Audio API:', e);
+            }
+        }
 
         // Function to update progress
         const updateProgress = () => {
@@ -41,6 +324,9 @@ htmx.on('htmx:afterSettle', function (event) {
         // Function to toggle play/pause state of the audio
         const togglePlay = (e) => {
             e.stopPropagation(); // Prevent event from bubbling up
+            if (audioContext && audioContext.state === 'suspended') {
+                audioContext.resume();
+            }
             if (audio.paused) {
                 audio.play();
             } else {

--- a/assets/audioplayer.js
+++ b/assets/audioplayer.js
@@ -63,13 +63,14 @@ htmx.on('htmx:afterSettle', function (event) {
 
         // Create slider element separately
         const sliderElement = document.createElement('div');
-        sliderElement.className = 'volume-slider';
-        sliderElement.style.cssText = 'display: none; position: absolute; background: rgba(0, 0, 0, 0.5); padding: 12px 8px; border-radius: 4px; z-index: 1000;';
+        sliderElement.className = 'volume-slider bg-transparent';
+        sliderElement.style.cssText = 'display: none; position: absolute; background: transparent; z-index: 1000;';
         sliderElement.innerHTML = `
-            <div style="display: flex; flex-direction: column; align-items: center; gap: 8px;">
+            <div class="flex flex-col items-center space-y-2 bg-transparent">
                 <input type="range" min="0" max="12" step="3" value="0" 
-                       style="writing-mode: bt-lr; -webkit-appearance: slider-vertical; height: 100px; width: 24px; background: transparent;">
-                <span style="color: white; font-size: 12px;">0 dB</span>
+                    class="h-20 w-12 appearance-none bg-transparent"
+                    style="writing-mode: bt-lr; -webkit-appearance: slider-vertical;">
+                <span class="text-base-content text-xs">+0 dB</span>
             </div>
         `;
 
@@ -88,20 +89,21 @@ htmx.on('htmx:afterSettle', function (event) {
                 height: 12px;
                 width: 12px;
                 border-radius: 50%;
-                background: white;
+                background: var(--fallback-bc,oklch(var(--bc)));
                 cursor: pointer;
                 margin-top: -4px;
+                transform: translateX(-16px);
             }
             input[type=range]::-webkit-slider-runnable-track {
                 width: 100%;
                 height: 4px;
-                background: rgba(255, 255, 255, 0.3);
                 border-radius: 2px;
             }
             input[type=range]:focus {
                 outline: none;
             }
         `;
+
         document.head.appendChild(sliderStyle);
 
         let sliderTimeout;
@@ -253,15 +255,21 @@ htmx.on('htmx:afterSettle', function (event) {
                     }
                 });
 
+                // Function to update gain value and display
+                const updateGainValue = (newValue) => {
+                    sliderInput.value = newValue;
+                    const gainValue = dbToGain(newValue);
+                    gainNode.gain.value = gainValue;
+                    dbDisplay.textContent = `+${newValue} dB`;
+                };
+
                 // Add interaction listeners to reset timer
                 sliderElement.addEventListener('mouseover', resetTimer);
                 sliderElement.addEventListener('mousemove', resetTimer);
                 sliderInput.addEventListener('input', (e) => {
                     resetTimer();
                     const dbValue = parseInt(e.target.value);
-                    const gainValue = dbToGain(dbValue);
-                    gainNode.gain.value = gainValue;
-                    dbDisplay.textContent = `${dbValue} dB`;
+                    updateGainValue(dbValue);
                 });
 
                 // Function to handle gain adjustment via mouse wheel
@@ -275,10 +283,7 @@ htmx.on('htmx:afterSettle', function (event) {
                         const newValue = Math.max(0, Math.min(12, currentValue + step));
                         
                         if (newValue !== currentValue) {
-                            sliderInput.value = newValue;
-                            const gainValue = dbToGain(newValue);
-                            gainNode.gain.value = gainValue;
-                            dbDisplay.textContent = `${newValue} dB`;
+                            updateGainValue(newValue);
                         }
                     }
                 };

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,6 +6,7 @@ module.exports = {
     './views/*.html',
     './views/*/*.html',
     './views/*/*/*.html',
+    './assets/*.js',
   ],
   safelist: [
     'bg-red-500',


### PR DESCRIPTION
This PR adds gain control to audio player. Gain can be controlled by mouse wheel when mouse is on top of spectrogram, it is also possible to use gain slider with mouse cursor.

Tested with chromium based browser (Edge) and Firefox. Mobile version has known issues which will be fixed later.

Fixes https://github.com/tphakala/birdnet-go/discussions/458