### PR TITLE
Added Portuguese (Brazil) labels file (labels_pt-br.txt)

### DIFF
--- a/internal/birdnet/data/labels/labels_pt-br.txt
+++ b/internal/birdnet/data/labels/labels_pt-br.txt
@@ -1,0 +1,17415 @@
+Struthio camelus_avestruz-comum_ostric2
+Struthio molybdophanes_avestruz-da-etiópia_ostric3
+Struthio camelus/molybdophanes_avestruz-comum/avestruz-da-etiópia_y00934
+Casuarius casuarius_southern cassowary_soucas1
+Casuarius bennetti_dwarf cassowary_dwacas1
+Casuarius unappendiculatus_northern cassowary_norcas1
+Dromaius novaehollandiae_emu_emu1
+Apteryx australis_southern brown kiwi_sobkiw1
+Apteryx australis australis_southern brown kiwi (South I.)_sobkiw2
+Apteryx australis lawryi_southern brown kiwi (Stewart I.)_sobkiw3
+Apteryx rowi_okarito brown kiwi_okbkiw1
+Apteryx mantelli_north island brown kiwi_nibkiw1
+Apteryx owenii_little spotted kiwi_liskiw1
+Apteryx rowi x owenii_okarito brown x little spotted kiwi (hybrid)_x01059
+Apteryx maxima_great spotted kiwi_grskiw1
+Apteryx sp._kiwi sp._kiwi1
+Rhea americana_ema_grerhe1
+Rhea pennata_lesser rhea_lesrhe2
+Rhea pennata tarapacensis/garleppi_lesser rhea (Puna)_lesrhe4
+Rhea pennata pennata_lesser rhea (Darwin's)_lesrhe3
+Nothocercus julius_tawny-breasted tinamou_tabtin1
+Nothocercus bonapartei_highland tinamou_higtin1
+Nothocercus bonapartei [bonapartei Group]_highland tinamou (South American)_higtin2
+Nothocercus bonapartei frantzii_highland tinamou (Costa Rican)_higtin3
+Nothocercus nigrocapillus_hooded tinamou_hootin1
+Tinamus tao_azulona_grytin1
+Tinamus solitarius_macuco_soltin1
+Tinamus osgoodi_black tinamou_blatin1
+Tinamus major_inhambu-serra_gretin1
+Tinamus guttatus_inhambu-galinha_whttin1
+Tinamus sp._Tinamus sp._tinamu1
+Crypturellus cinereus_inhambu-pixuna_cintin1
+Crypturellus berlepschi_berlepsch's tinamou_bertin1
+Crypturellus soui_tururim_littin1
+Crypturellus ptaritepui_tepui tinamou_teptin1
+Crypturellus obsoletus_inhambuguaçu_brotin1
+Crypturellus obsoletus castaneus_inhambuguaçu (castaneus)_brntin1
+Crypturellus obsoletus [obsoletus Group]_inhambuguaçu [grupo obsoletus]_brntin2
+Crypturellus undulatus_jaó_undtin1
+Crypturellus transfasciatus_pale-browed tinamou_pabtin1
+Crypturellus strigulosus_inhambu-relógio_bratin1
+Crypturellus duidae_inhambu-de-pé-cinza_gyltin1
+Crypturellus erythropus_inhambu-de-perna-vermelha_reltin1
+Crypturellus noctivagus_jaó-do-sul/zabelê_yeltin1
+Crypturellus noctivagus zabele_zabelê_yeltin2
+Crypturellus noctivagus noctivagus_jaó-do-sul_yeltin3
+Crypturellus atrocapillus_inhambu-de-coroa-preta_blctin1
+Crypturellus boucardi_slaty-breasted tinamou_slbtin1
+Crypturellus kerriae_choco tinamou_chotin1
+Crypturellus variegatus_inhambu-anhangá_vartin1
+Crypturellus cinnamomeus_thicket tinamou_thitin1
+Crypturellus cinnamomeus occidentalis_thicket tinamou (occidentalis)_thitin2
+Crypturellus cinnamomeus [cinnamomeus Group]_thicket tinamou (cinnamomeus Group)_thitin3
+Crypturellus brevirostris_inhambu-carijó_rustin1
+Crypturellus bartletti_inhambu-anhangaí_bartin2
+Crypturellus parvirostris_inhambu-chororó_smbtin1
+Crypturellus casiquiare_barred tinamou_bartin1
+Crypturellus tataupa_inhambu-chintã_tattin1
+Crypturellus sp._crypturellus sp. (inhambu)_cryptu1
+Rhynchotus rufescens_perdiz_rewtin1
+Rhynchotus maculicollis_huayco tinamou_huatin1
+Nothoprocta taczanowskii_taczanowski's tinamou_tactin1
+Nothoprocta ornata_ornate tinamou_orntin1
+Nothoprocta perdicaria_chilean tinamou_chitin1
+Nothoprocta cinerascens_brushland tinamou_brutin1
+Nothoprocta pentlandii_andean tinamou_andtin1
+Nothoprocta curvirostris_curve-billed tinamou_cubtin1
+Nothoprocta sp._Nothoprocta sp._nothop1
+Nothura boraquira_codorna-do-nordeste_whbnot1
+Nothura minor_codorna-mineira_lesnot1
+Nothura darwinii_darwin's nothura_darnot1
+Nothura maculosa_codorna-amarela_sponot1
+Nothura boraquira/maculosa_white-bellied/spotted nothura_y01225
+Nothura minor/maculosa_lesser/spotted nothura_y01226
+Taoniscus nanus_codorna-carapé_dwatin1
+Eudromia elegans_elegant crested-tinamou_elctin1
+Eudromia formosa_quebracho crested-tinamou_quctin1
+Tinamotis pentlandii_puna tinamou_puntin1
+Tinamotis ingoufi_patagonian tinamou_pattin1
+Tinamidae sp._tinamou sp._tinamo1
+Anhima cornuta_anhuma_horscr1
+Chauna torquata_tachã_souscr1
+Chauna chavaria_northern screamer_norscr1
+Anseranas semipalmata_magpie goose_maggoo1
+Dendrocygna guttata_spotted whistling-duck_spwduc1
+Dendrocygna eytoni_plumed whistling-duck_plwduc1
+Dendrocygna viduata_irerê_wfwduc1
+Dendrocygna guttata x viduata_spotted x white-faced whistling-duck (hybrid)_x00721
+Dendrocygna autumnalis_marreca-cabocla_bbwduc
+Dendrocygna autumnalis fulgens_marreca-cabocla (fulgens)_bkbwhd1
+Dendrocygna autumnalis autumnalis_marreca-cabocla (autumnalis)_bkbwhd2
+Dendrocygna viduata x autumnalis_irerê x marreca-d'asa-branca (híbrido)_x01141
+Dendrocygna arborea_west indian whistling-duck_wiwduc1
+Dendrocygna autumnalis x arborea_black-bellied x west indian whistling-duck (hybrid)_x00775
+Dendrocygna bicolor_marreca-caneleira_fuwduc
+Dendrocygna viduata x bicolor_irerê x marreca-caneleira (híbrido)_x00938
+Dendrocygna autumnalis x bicolor_marreca-cabocla x marreca-caneleira (híbrido)_x00875
+Dendrocygna arcuata_wandering whistling-duck_wawduc1
+Dendrocygna eytoni x arcuata_plumed x wandering whistling-duck (hybrid)_x00990
+Dendrocygna eytoni/arcuata_plumed/wandering whistling-duck_y01227
+Dendrocygna javanica_marreca-de-java_lewduc1
+Dendrocygna bicolor/javanica_marreca-caneleira/marreca-de-java_y01080
+Dendrocygna arcuata x javanica_wandering x lesser whistling-duck (hybrid)_x00360
+Dendrocygna sp._Dendrocygna sp._whistl1
+Thalassornis leuconotus_white-backed duck_whbduc1
+Anser indicus_ganso-de-cabeça-listada_bahgoo
+Anser canagicus_ganso-imperial_empgoo
+Anser caerulescens_ganso-das-neves_snogoo
+Anser indicus x caerulescens_bar-headed x snow goose (hybrid)_x00991
+Anser rossii_ganso-das-neves-pequeno_rosgoo
+Anser caerulescens x rossii_ganso-das-neves x ganso-das-neves-pequeno (híbrido)_sxrgoo1
+Anser caerulescens/rossii_ganso-das-neves/ganso-das-neves-pequeno_y00469
+Anser anser_ganso-bravo_gragoo
+Anser anser anser_ganso-bravo (anser)_gragoo2
+Anser anser rubrirostris_ganso-bravo (rubrirostris)_gragoo3
+Anser anser (Domestic type)_ganso-bravo (forma doméstica)_gragoo1
+Anser indicus x anser_bar-headed x graylag goose (hybrid)_x00992
+Anser canagicus x anser_ganso-imperial x ganso-bravo (híbrido)_x01119
+Anser cygnoides_ganso-africano_swagoo1
+Anser cygnoides (Domestic type)_ganso-africano (forma doméstica)_swagoo2
+Anser indicus x cygnoides_ganso-de-cabeça-listada x ganso-africano (híbrido)_x01143
+Anser caerulescens x cygnoides_ganso-das-neves x ganso-africano (híbrido)_x01144
+Anser indicus x caerulescens x cygnoides_ganso-de-cabeça-listada x ganso-das-neves x ganso-africano (híbrido)_x01142
+Anser anser x cygnoides_ganso-bravo x ganso-africano (híbrido)_x00776
+Anser albifrons_ganso-de-testa-branca_gwfgoo
+Anser albifrons flavirostris_ganso-de-testa-branca-da-gronelândia_gwfgoo1
+Anser albifrons albifrons_ganso-de-testa-branca (albifrons)_gwfgoo4
+Anser albifrons gambelli/sponsa_ganso-de-testa-branca (gambelli/sponsa)_gwfgoo2
+Anser albifrons elgasi_ganso-de-testa-branca (elgasi)_gwfgoo3
+Anser indicus x albifrons_ganso-de-cabeça-listada x ganso-de-testa-branca (híbrido)_x00755
+Anser canagicus x albifrons_ganso-imperial x ganso-de-testa-branca (híbrido)_x00361
+Anser caerulescens x albifrons_ganso-das-neves x ganso-de-testa-branca (híbrido)_x00627
+Anser rossii x albifrons_ganso-das-neves-pequeno x ganso-de-testa-branca (híbrido)_x00362
+Anser anser x albifrons_ganso-bravo x ganso-de-testa-branca (híbrido)_x01145
+Anser erythropus_ganso-pequeno_lwfgoo
+Anser albifrons/erythropus_ganso-de-testa-branca/ganso-pequeno_y00707
+Anser fabalis_ganso-campestre-da-taiga_taibeg1
+Anser serrirostris_ganso-campestre-da-tundra_tunbeg1
+Anser albifrons x serrirostris_greater white-fronted goose x tundra bean-goose (hybrid)_x01089
+Anser fabalis/serrirostris_ganso-campestre-da-taiga/ganso-campestre-da-tundra_y00468
+Anser brachyrhynchus_ganso-de-bico-curto_pifgoo
+Anser sp. (Domestic type)_ganso-bravo (doméstica)_domgoo1
+Anser sp._Anser sp._anser1
+Branta bernicla_ganso-de-faces-pretas_brant
+Branta bernicla bernicla_ganso-de-faces-pretas-comum_dabbra1
+Branta bernicla hrota_ganso-de-faces-pretas-da-gronelândia_atlbra1
+Branta bernicla nigricans_ganso-negro_blkbra1
+Branta bernicla (Gray-bellied)_ganso-de-faces-pretas (ventre cinzento)_gybbra1
+Branta bernicla bernicla x nigricans_ganso-de-faces-pretas (bernicla x nigricans)_brant2
+Branta bernicla hrota x nigricans_ganso-de-faces-pretas-da-gronelândia x ganso-negro_brant1
+Anser caerulescens x Branta bernicla_ganso-das-neves x ganso-de-faces-pretas (híbrido)_x00685
+Branta leucopsis_ganso-marisco_bargoo
+Anser indicus x Branta leucopsis_ganso-de-cabeça-listada x ganso-marisco (híbrido)_x00363
+Anser canagicus x Branta leucopsis_emperor x barnacle goose (hybrid)_x00993
+Anser caerulescens x Branta leucopsis_snow x barnacle goose (hybrid)_x00994
+Anser rossii x Branta leucopsis_ross's x barnacle goose (hybrid)_x00995
+Anser anser x Branta leucopsis_ganso-bravo x ganso-marisco (híbrido)_x00649
+Anser albifrons x Branta leucopsis_ganso-de-testa-branca x ganso-marisco (híbrido)_x00757
+Anser erythropus x Branta leucopsis_ganso-pequeno x ganso-marisco (híbrido)_x00364
+Anser brachyrhynchus x Branta leucopsis_ganso-de-bico-curto x ganso-marisco (híbrido)_x00756
+Branta hutchinsii_ganso-palrador_cacgoo1
+Branta hutchinsii leucopareia_ganso-palrador (leucopareia)_alcgoo1
+Branta hutchinsii hutchinsii_ganso-palrador (hutchinsii)_ricgoo1
+Branta hutchinsii minima_ganso-palrador (minima)_cacgoo2
+Branta hutchinsii taverneri_ganso-palrador (taverneri)_tacgoo1
+Anser canagicus x Branta hutchinsii_ganso-imperial x ganso-palrador (híbrido)_x00831
+Anser caerulescens x Branta hutchinsii_ganso-das-neves x ganso-palrador (híbrido)_x00692
+Anser rossii x Branta hutchinsii_ganso-das-neves-pequeno x ganso-palrador (híbrido)_x00694
+Branta bernicla x hutchinsii_ganso-de-faces-pretas x ganso-palrador (híbrido)_x00722
+Anser albifrons x Branta hutchinsii_ganso-de-testa-branca x ganso-palrador (híbrido)_x00414
+Branta leucopsis x hutchinsii_ganso-marisco x ganso-palrador (híbrido)_x00416
+Branta canadensis_ganso-do-canadá_cangoo
+Branta canadensis moffitti/maxima_ganso-do-canadá (moffitti/maxima)_cangoo4
+Branta canadensis occidentalis/fulva_ganso-do-canadá (occidentalis/fulva)_cangoo3
+Branta canadensis [canadensis Group]_ganso-do-canadá [grupo canadensis]_cangoo1
+Anser indicus x Branta canadensis_ganso-de-cabeça-listada x ganso-do-canadá (híbrido)_x00908
+Anser cygnoides x Branta canadensis_ganso-africano x ganso-do-canadá (híbrido)_swagoo3
+Anser brachyrhynchus x Branta canadensis_ganso-de-bico-curto x ganso-do-canadá (híbrido)_x00650
+Anser albifrons x Branta canadensis_ganso-de-testa-branca x ganso-do-canadá (híbrido)_x00415
+Anser albifrons x Branta hutchinsii/canadensis_greater white-fronted x cackling/canada goose (hybrid)_x01088
+Anser anser x Branta canadensis_ganso-bravo x ganso-do-canadá (híbrido)_x00758
+Anser sp. (Domestic type) x Branta canadensis_domestic goose sp. x canada goose (hybrid)_x00759
+Anser caerulescens x Branta canadensis_ganso-das-neves x ganso-do-canadá (híbrido)_x00197
+Anser rossii x Branta canadensis_ganso-das-neves-pequeno x ganso-do-canadá (híbrido)_x00693
+Branta leucopsis x canadensis_ganso-marisco x ganso-do-canadá (híbrido)_x00417
+Branta hutchinsii/canadensis_ganso-palrador/ganso-do-canadá_y00470
+Anser caerulescens/rossii x Branta hutchinsii/canadensis_ganso-das-neves/ganso-das-neves-pequeno x ganso-palrador/ganso-do-canadá (híbrido)_y00765
+Branta sandvicensis_hawaiian goose_hawgoo
+Branta leucopsis x sandvicensis_barnacle x hawaiian goose (hybrid)_x01139
+Branta ruficollis_ganso-de-peito-ruivo_rebgoo1
+Anser albifrons x Branta ruficollis_ganso-de-testa-branca x ganso-de-peito-ruivo (híbrido)_x00939
+Branta bernicla x ruficollis_brant x red-breasted goose (hybrid)_x00996
+Branta leucopsis x ruficollis_ganso-marisco x ganso-de-peito-ruivo (híbrido)_x00365
+Branta sp._ganso (Branta) sp._branta1
+Cereopsis novaehollandiae_cape barren goose_cabgoo1
+Stictonetta naevosa_freckled duck_freduc1
+Cyanochen cyanoptera_blue-winged goose_buwgoo1
+Cygnus olor_cisne-mudo_mutswa
+Anser anser x Cygnus olor_ganso-bravo x cisne-mudo (híbrido)_x00366
+Cygnus atratus_cisne-preto_blkswa
+Cygnus olor x atratus_mute x black swan (hybrid)_x01037
+Cygnus melancoryphus_cisne-de-pescoço-preto_blnswa2
+Cygnus buccinator_trumpeter swan_truswa
+Cygnus olor x buccinator_mute x trumpeter swan (hybrid)_x00832
+Cygnus columbianus_cisne-pequeno_tunswa
+Cygnus columbianus columbianus_cisne-assobiador_tunswa1
+Cygnus columbianus bewickii_cisne-pequeno (bewickii)_bewswa1
+Cygnus columbianus columbianus x bewickii_tundra swan (Whistling x Bewick's)_tunswa2
+Cygnus buccinator x columbianus_trumpeter x tundra swan (hybrid)_x00418
+Cygnus buccinator/columbianus_trumpeter/tundra swan_y00471
+Cygnus cygnus_cisne-bravo_whoswa
+Cygnus olor x cygnus_mute x whooper swan (hybrid)_x00997
+Cygnus buccinator x cygnus_trumpeter x whooper swan (hybrid)_x00419
+Cygnus columbianus/cygnus_cisne-pequeno/cisne-bravo_y00708
+Cygnus sp._cisne sp._swan1
+Coscoroba coscoroba_capororoca_cosswa1
+Sarkidiornis melanotos_knob-billed duck_comduc2
+Sarkidiornis sylvicola_pato-de-crista_comduc3
+Pteronetta hartlaubii_hartlaub's duck_harduc1
+Oressochen jubatus_pato-corredor_origoo1
+Oressochen melanopterus_andean goose_andgoo1
+Chloephaga picta_ganso-de-magalhães_uplgoo1
+Chloephaga picta (White-breasted)_ganso-de-magalhães (White-breasted)_uplgoo2
+Chloephaga picta (Bar-breasted)_ganso-de-magalhães (Bar-breasted)_uplgoo3
+Chloephaga hybrida_kelp goose_kelgoo1
+Chloephaga poliocephala_ashy-headed goose_ashgoo1
+Chloephaga rubidiceps_ruddy-headed goose_ruhgoo1
+Chloephaga poliocephala x rubidiceps_ashy-headed x ruddy-headed goose (hybrid)_x01120
+Chloephaga sp._Chloephaga sp._chloep1
+Anatidae (goose sp.)_ganso (Anser/Chen/Branta) sp._goose1
+Radjah radjah_tadorna-de-cabeça-branca_radshe1
+Alopochen aegyptiaca_ganso-do-egipto_egygoo
+Alopochen mauritiana_mauritius shelduck_maushe1
+Alopochen kervazoi_reunion shelduck_reushe1
+Tadorna ferruginea_pato-casarca_rudshe
+Alopochen aegyptiaca x Tadorna ferruginea_ganso-do-egipto x pato-casarca (híbrido)_x00367
+Tadorna cana_tadorna-do-cabo_soashe1
+Tadorna tadornoides_australian shelduck_ausshe1
+Tadorna variegata_paradise shelduck_parshe1
+Tadorna tadorna_tadorna_comshe
+Tadorna ferruginea x tadorna_pato-casarca x tadorna (híbrido)_x00876
+Tadorna cristata_crested shelduck_creshe1
+Plectropterus gambensis_pato-ferrão_spwgoo1
+Plectropterus gambensis gambensis_pato-ferrão (gambensis)_spwgoo2
+Plectropterus gambensis niger_pato-ferrão (niger)_spwgoo3
+Tachyeres patachonicus_flying steamer-duck_flystd1
+Tachyeres pteneres_flightless steamer-duck_flistd1
+Tachyeres pteneres [undescribed form]_flightless steamer-duck (Chiloe form)_flistd2
+Tachyeres brachypterus_falkland steamer-duck_falstd1
+Tachyeres brachypterus (Flightless)_falkland steamer-duck (Flightless)_falstd2
+Tachyeres brachypterus (Flying)_falkland steamer-duck (Flying)_falstd3
+Tachyeres leucocephalus_white-headed steamer-duck_whhstd1
+Tachyeres sp._steamer-duck sp._steame1
+Lophonetta specularioides_crested duck_creduc1
+Speculanas specularis_spectacled duck_speduc2
+Cairina moschata_pato-do-mato_musduc
+Cairina moschata (Domestic type)_pato-do-mato (doméstico)_musduc3
+Alopochen aegyptiaca x Cairina moschata_egyptian goose x muscovy duck (hybrid)_x01045
+Nettapus pulchellus_gansinho-australiano_grnpyg1
+Nettapus coromandelianus_gansinho-oriental_copgoo1
+Nettapus pulchellus/coromandelianus_green/cotton pygmy-goose_y01228
+Nettapus auritus_pato-orelhudo_afrpyg1
+Callonetta leucophrys_marreca-de-coleira_rintea1
+Aix sponsa_pato-carolino_wooduc
+Tadorna tadorna x Aix sponsa_tadorna x pato-carolino (híbrido)_x00940
+Aix galericulata_pato-mandarim_manduc
+Aix sponsa x galericulata_pato-carolino x pato-mandarim (híbrido)_x00833
+Chenonetta jubata_pato-de-crina_manduc1
+Chenonetta finschi_finsch's duck_finduc1
+Amazonetta brasiliensis_marreca-ananaí_bratea1
+Hymenolaimus malacorhynchos_blue duck_bluduc1
+Merganetta armata_torrent duck_torduc1
+Salvadorina waigiuensis_salvadori's teal_saltea1
+Sibirionetta formosa_marrequinha-formosa_baitea
+Spatula querquedula_marreco_gargan
+Spatula hottentota_blue-billed teal_hottea1
+Spatula versicolor_marreca-cricri_siltea1
+Spatula puna_puna teal_puntea1
+Spatula discors_marreca-de-asa-azul_buwtea
+Spatula cyanoptera_marreca-colorada_cintea
+Spatula cyanoptera septentrionalium_pato-canela (septentrionalium)_cintea1
+Spatula cyanoptera [orinoma Group]_pato-canela (Grupo orinoma)_cintea6
+Spatula cyanoptera cyanoptera_pato-canela (cyanoptera)_cintea5
+Spatula discors x cyanoptera_marreca-de-asa-azul x marreca-colorada (híbrido)_bwxtea1
+Spatula discors/cyanoptera_marreca-de-asa-azul/marreca-colorada_y00314
+Spatula platalea_marreca-colhereira_redsho1
+Spatula smithii_cape shoveler_capsho1
+Spatula rhynchotis_australasian shoveler_aussho1
+Spatula clypeata_pato-colhereiro_norsho
+Spatula querquedula x clypeata_marreco x pato-colhereiro (híbrido)_x00836
+Spatula discors x clypeata_marreca-d'asa-azul x pato-colhereiro (híbrido)_x00629
+Spatula cyanoptera x clypeata_pato-canela x pato-colhereiro (híbrido)_x00630
+Mareca strepera_frisada_gadwal
+Mareca strepera strepera_frisada (strepera)_gadwal1
+Mareca strepera couesi_frisada (couesi)_gadwal2
+Spatula clypeata x Mareca strepera_pato-colhereiro x frisada (híbrido)_x00457
+Mareca falcata_pato-falcado_falduc
+Sibirionetta formosa x Mareca falcata_marrequinha-formosa x pato-falcado (híbrido)_x00368
+Mareca strepera x falcata_frisada x pato-falcado (híbrido)_x00369
+Mareca penelope_piadeira_eurwig
+Spatula clypeata x Mareca penelope_pato-colhereiro x piadeira (híbrido)_x01140
+Mareca strepera x penelope_frisada x piadeira (híbrido)_x00723
+Mareca americana_piadeira-americana_amewig
+Aix sponsa x Mareca americana_pato-carolino x piadeira-americana (híbrido)_x00877
+Spatula discors x Mareca americana_marreca-d'asa-azul x piadeira-americana (híbrido)_x00370
+Spatula clypeata x Mareca americana_pato-colhereiro x piadeira-americana (híbrido)_x00777
+Mareca strepera x americana_frisada x piadeira-americana (híbrido)_x00724
+Mareca penelope x americana_piadeira x piadeira-americana (híbrido)_x00421
+Mareca penelope/americana_piadeira/piadeira-americana_y00670
+Mareca sibilatrix_marreca-oveira_chiwig1
+Mareca penelope x sibilatrix_eurasian x chiloe wigeon (hybrid)_x00998
+Mareca marecula_amsterdam duck_amsduc1
+Anas sparsa_african black duck_afbduc1
+Anas undulata_yellow-billed duck_yebduc1
+Anas melleri_meller's duck_melduc1
+Anas superciliosa_pato-preto-australiano_pabduc1
+Anas laysanensis_laysan duck_layduc
+Anas wyvilliana_hawaiian duck_hawduc
+Anas luzonica_philippine duck_phiduc1
+Anas poecilorhyncha_indian spot-billed duck_isbduc1
+Anas zonorhyncha_eastern spot-billed duck_spbduc
+Anas poecilorhyncha/zonorhyncha_indian/eastern spot-billed duck_y00830
+Anas platyrhynchos_pato-real_mallar3
+Anas platyrhynchos (Domestic type)_pato-real (forma doméstica)_mallar2
+Alopochen aegyptiaca x Anas platyrhynchos_ganso-do-egipto x pato-real (híbrido)_x01147
+Tadorna ferruginea x Anas platyrhynchos_pato-casarca x pato-real (híbrido)_x01148
+Cairina moschata x Anas platyrhynchos_pato-mudo x pato-real (híbrido)_mdxmal1
+Aix sponsa x Anas platyrhynchos_pato-carolino x pato-real (híbrido)_x00205
+Spatula clypeata x Anas platyrhynchos_pato-colhereiro x pato-real (híbrido)_x00612
+Mareca strepera x Anas platyrhynchos_frisada x pato-real (híbrido)_x00420
+Mareca penelope x Anas platyrhynchos_piadeira x pato-real (híbrido)_x00647
+Mareca americana x Anas platyrhynchos_piadeira-americana x pato-real (híbrido)_x00611
+Anas sparsa x platyrhynchos_african black duck x mallard (hybrid)_x01149
+Anas undulata x platyrhynchos_yellow-billed duck x mallard (hybrid)_x00760
+Anas platyrhynchos x superciliosa_pato-real x pato-preto-australiano (híbrido)_x00458
+Anas platyrhynchos x wyvilliana_mallard x hawaiian duck (hybrid)_x00423
+Anas platyrhynchos x poecilorhyncha_mallard x indian spot-billed duck (hybrid)_x00834
+Anas platyrhynchos x zonorhyncha_mallard x eastern spot-billed duck (hybrid)_x00835
+Anas platyrhynchos/superciliosa_pato-real/pato-preto-australiano_y01128
+Anas platyrhynchos/wyvilliana_mallard/hawaiian duck_y01129
+Anas platyrhynchos/poecilorhyncha_mallard/indian spot-billed duck_y01130
+Anas platyrhynchos/zonorhyncha_mallard/eastern spot-billed duck_y01131
+Anas diazi_mexican duck_mexduc
+Anas platyrhynchos x diazi_mallard x mexican duck (hybrid)_mallar4
+Anas platyrhynchos/diazi_mallard/mexican duck_mallar
+Anas rubripes_pato-escuro-americano_ambduc
+Mareca americana x Anas rubripes_piadeira-americana x pato-escuro-americano (híbrido)_x00941
+Anas platyrhynchos x rubripes_pato-real x pato-escuro-americano (híbrido)_x00004
+Anas platyrhynchos/rubripes_pato-real/pato-escuro-americano_y00600
+Anas fulvigula_mottled duck_motduc
+Anas fulvigula fulvigula_mottled duck (Florida)_motduc1
+Anas fulvigula maculosa_mottled duck (Gulf Coast)_motduc2
+Anas platyrhynchos x fulvigula_mallard x mottled duck (hybrid)_x00422
+Anas platyrhynchos x diazi/fulvigula_mallard x mexican/mottled duck (hybrid)_y01098
+Anas diazi x fulvigula_mexican x mottled duck (hybrid)_x00922
+Anas platyrhynchos/fulvigula_mallard/mottled duck_y00632
+Anas diazi/fulvigula_mexican/mottled duck_y01099
+Anas rubripes/fulvigula_american black/mottled duck_y00633
+Anas capensis_marrequinha-de-bico-vermelho_captea1
+Anas bahamensis_marreca-toicinho_whcpin
+Anas bahamensis bahamensis/rubrirostris_marreca-toicinho (bahamensis/rubrirostris)_whcpin1
+Anas bahamensis galapagensis_marreca-toicinho (galapagensis)_whcpin2
+Anas platyrhynchos x bahamensis_pato-real x arrábio-de-faces-brancas (híbrido)_x00778
+Anas erythrorhyncha_arrábio-de-bico-vermelho_rebduc1
+Anas acuta_arrabio_norpin
+Sibirionetta formosa x Anas acuta_marrequinha-formosa x arrábio (híbrido)_x00837
+Mareca strepera x Anas acuta_frisada x arrábio (híbrido)_x00610
+Mareca penelope x Anas acuta_piadeira x arrábio (híbrido)_x00761
+Mareca americana x Anas acuta_piadeira-americana x arrábio (híbrido)_x00196
+Anas superciliosa x acuta_pacific black duck x northern pintail (hybrid)_x01087
+Anas platyrhynchos x acuta_pato-real x arrábio (híbrido)_x00628
+Anas rubripes x acuta_pato-escuro-americano x arrábio (híbrido)_x00674
+Anas eatoni_eaton's pintail_eatpin1
+Anas georgica_marreca-parda_yebpin1
+Anas georgica georgica_marreca-parda (georgica)_yebpin2
+Anas georgica spinicauda/niceforoi_marreca-parda (spinicauda/niceforoi)_yebpin3
+Anas bahamensis x georgica_arrábio-de-faces-brancas x marreca-parda (híbrido)_x01150
+Anas crecca_marrequinha_gnwtea
+Anas crecca crecca_marrequinha-comum_egwtea1
+Anas crecca carolinensis_marrequinha-americana_agwtea1
+Anas crecca crecca x carolinensis_marrequinha-comum x marrequinha-americana (híbrido)_gnwtea1
+Sibirionetta formosa x Anas crecca_baikal x green-winged teal (hybrid)_x00999
+Spatula querquedula x Anas crecca_marreco x marrequinha (híbrido)_x00371
+Spatula discors x Anas crecca_marreca-d'asa-azul x marrequinha (híbrido)_x00673
+Spatula cyanoptera x Anas crecca_pato-canela x marrequinha (híbrido)_x00763
+Mareca strepera x Anas crecca_frisada x marrequinha (híbrido)_x00762
+Mareca penelope x Anas crecca_piadeira x marrequinha (híbrido)_x00372
+Mareca americana x Anas crecca_piadeira-americana x marrequinha (híbrido)_x00646
+Anas platyrhynchos x crecca_pato-real x marrequinha (híbrido)_x00670
+Anas acuta x crecca_arrábio x marrequinha (híbrido)_x00725
+Spatula querquedula/Anas crecca_marreco/marrequinha_y00766
+Anas andium_andean teal_spetea3
+Anas andium altipetens_andean teal (Merida)_andtea2
+Anas andium andium_andean teal (Andean)_andtea3
+Anas flavirostris_marreca-pardinha_yebtea1
+Anas flavirostris flavirostris_marreca-pardinha (flavirostris)_spetea2
+Anas flavirostris oxyptera_marreca-pardinha (oxyptera)_spetea4
+Anas georgica/flavirostris_marreca-parda/marreca-pardinha_y00367
+Anas andium/flavirostris_andean/yellow-billed teal_spetea1
+Anas theodori_mauritius duck_mauduc1
+Anas albogularis_andaman teal_andtea1
+Anas gibberifrons_marrequinha-de-sunda_suntea1
+Anas gracilis_gray teal_gretea1
+Anas superciliosa x gracilis_pacific black duck x gray teal (hybrid)_x00926
+Anas castanea_marrequinha-castanha_chetea1
+Anas superciliosa x castanea_pacific black duck x chestnut teal (hybrid)_x00925
+Anas gracilis x castanea_gray x chestnut teal (hybrid)_x00913
+Anas gracilis/castanea_gray/chestnut teal_y00368
+Anas bernieri_bernier's teal_bertea1
+Anas aucklandica_auckland islands teal_auitea1
+Anas nesiotis_campbell islands teal_caitea1
+Anas chlorotis_brown teal_brotea1
+Anas platyrhynchos x chlorotis_mallard x brown teal (hybrid)_x00878
+Anas sp._Anas sp._anas1
+Anatidae sp. (teal sp.)_marrequinha sp._teal
+Anatidae sp. (dabbling duck sp.)_pato-de-superfície (anatídeo) sp._dabduc1
+Malacorhynchus membranaceus_pink-eared duck_pieduc1
+Marmaronetta angustirostris_pardilheira_martea1
+Rhodonessa caryophyllacea_pink-headed duck_pihduc1
+Asarcornis scutulata_white-winged duck_whwduc1
+Netta rufina_pato-de-bico-vermelho_recpoc
+Anas platyrhynchos x Netta rufina_pato-real x pato-de-bico-vermelho (híbrido)_x00648
+Netta erythrophthalma_paturi-preta_soupoc1
+Netta peposaca_marrecão_robpoc1
+Aythya valisineria_zarro-grande_canvas
+Aythya americana_zarro-americano_redhea
+Anas platyrhynchos x Aythya americana_pato-real x zarro-americano (híbrido)_x00879
+Aythya valisineria x americana_zarro-grande x zarro-americano (híbrido)_x00684
+Aythya ferina_zarro_compoc
+Anas platyrhynchos x Aythya ferina_mallard x common pochard (hybrid)_x01000
+Netta rufina x Aythya ferina_pato-de-bico-vermelho x zarro (híbrido)_x00373
+Aythya collaris_caturro_rinduc
+Anas platyrhynchos x Aythya collaris_mallard x ring-necked duck (hybrid)_x01001
+Aythya valisineria x collaris_zarro-grande x caturro (híbrido)_x00880
+Aythya americana x collaris_zarro-americano x caturro (híbrido)_x00679
+Aythya nyroca_pêrra_ferduc
+Netta rufina x Aythya nyroca_pato-de-bico-vermelho x pêrra (híbrido)_x00374
+Aythya ferina x nyroca_zarro x pêrra (híbrido)_x00764
+Aythya innotata_madagascar pochard_madpoc1
+Aythya baeri_baer's pochard_baepoc1
+Aythya ferina x baeri_common x baer's pochard (hybrid)_x01093
+Aythya nyroca x baeri_ferruginous duck x baer's pochard (hybrid)_x00838
+Aythya nyroca/baeri_ferruginous duck/baer's pochard_y00709
+Aythya australis_zarro-australiano_wheduc1
+Anas gracilis x Aythya australis_gray teal x hardhead (hybrid)_x00912
+Aythya fuligula_negrinha_tufduc
+Anas platyrhynchos x Aythya fuligula_pato-real x negrinha (híbrido)_x00375
+Netta rufina x Aythya fuligula_pato-de-bico-vermelho x negrinha (híbrido)_x00376
+Aythya ferina x fuligula_zarro x negrinha (híbrido)_x00683
+Aythya collaris x fuligula_caturro x negrinha (híbrido)_x00652
+Aythya nyroca x fuligula_pêrra x negrinha (híbrido)_x00839
+Aythya novaeseelandiae_new zealand scaup_nezsca1
+Aythya marila_negrelho_gresca
+Aythya americana x marila_zarro-americano x negrelho (híbrido)_x00680
+Aythya collaris x marila_caturro x negrelho (híbrido)_x00779
+Aythya fuligula x marila_negrinha x negrelho (híbrido)_x00654
+Aythya affinis_negrelho-americano_lessca
+Aythya americana x affinis_zarro-americano x negrelho-americano (híbrido)_x00678
+Aythya collaris x affinis_caturro x negrelho-americano (híbrido)_x00613
+Aythya fuligula x affinis_negrinha x negrelho-americano (híbrido)_x00653
+Aythya valisineria x marila/affinis_zarro-grande x negrelho/negrelho-americano (híbrido)_x00377
+Aythya americana x marila/affinis_zarro-americano x negrelho/negrelho-americano (híbrido)_x00681
+Aythya collaris x marila/affinis_caturro x negrelho/negrelho-americano (híbrido)_x00682
+Aythya fuligula x marila/affinis_negrinha x negrelho/negrelho-americano (híbrido)_tdxsca1
+Aythya marila/affinis_negrelho/negrelho-americano_scaup
+Aythya sp._zarro (Aythya) sp._aythya1
+Polysticta stelleri_êider-de-steller_steeid
+Camptorhynchus labradorius_labrador duck_labduc
+Somateria fischeri_êider-de-lunetas_speeid
+Somateria spectabilis_êider-real_kineid
+Somateria fischeri x spectabilis_êider-de-lunetas x êider-real (híbrido)_x00942
+Somateria mollissima_êider_comeid
+Somateria mollissima mollissima_êider (mollissima)_comeid5
+Somateria mollissima faeroeensis_êider (faeroeensis)_comeid6
+Somateria mollissima v-nigrum_êider (v-nigrum)_comeid1
+Somateria mollissima dresseri_êider (dresseri)_comeid2
+Somateria mollissima borealis_êider (borealis)_comeid3
+Somateria mollissima sedentaria_êider (sedentaria)_comeid4
+Tadorna tadorna x Somateria mollissima_tadorna x êider (híbrido)_x01151
+Anas platyrhynchos x Somateria mollissima_pato-real x êider (híbrido)_x00881
+Somateria spectabilis x mollissima_êider-real x êider (híbrido)_x00665
+Somateria spectabilis/mollissima_êider-real/êider_eider
+Somateria sp._êider (Somateria) sp._eider1
+Histrionicus histrionicus_pato-arlequim_harduc
+Melanitta perspicillata_negrola-de-lunetas_sursco
+Melanitta fusca_negrola-d'asa-branca_whwsco3
+Melanitta deglandi_negrola-de-degland_whwsco2
+Melanitta stejnegeri_negrola-de-stejneger_whwsco1
+Melanitta perspicillata x deglandi_negrola-de-lunetas x negrola-de-degland (híbrido)_x00882
+Melanitta deglandi x stejnegeri_negrola-de-degland x negrola-de-stejneger (híbrido)_x01170
+Melanitta fusca/deglandi/stejnegeri_negrola-d'asa-branca/negrola-de-degland/de-stejneger_whwsco
+Melanitta deglandi/stejnegeri_negrola-de-degland/de-stejneger_whwsco4
+Melanitta nigra_negrola-comum_blksco1
+Melanitta americana_negrola-americana_blksco2
+Melanitta perspicillata/americana_negrola-de-lunetas/negrola-americana_dawsco
+Melanitta nigra/americana_negrola-comum/negrola-americana_blksco
+Melanitta sp._negrola sp._scoter
+Clangula hyemalis_pato-rabilongo_lotduc
+Bucephala albeola_olho-dourado-de-touca_buffle
+Bucephala clangula_olho-dourado-comum_comgol
+Bucephala albeola x clangula_olho-dourado-de-touca x olho-dourado-comum (híbrido)_x00655
+Bucephala albeola x clangula/islandica_olho-dourado-de-touca x olho-dourado-comum/olho-dourado-da-islândia (híbrido)_x00909
+Bucephala islandica_olho-dourado-da-islândia_bargol
+Bucephala albeola x islandica_olho-dourado-de-touca x olho-dourado-da-islândia (híbrido)_x01152
+Bucephala clangula x islandica_olho-dourado-comum x olho-dourado-da-islândia (híbrido)_cxbgol1
+Bucephala clangula/islandica_olho-dourado-comum/olho-dourado-da-islândia_y00004
+Mergellus albellus_merganso-pequeno_smew
+Bucephala clangula x Mergellus albellus_olho-dourado-comum x merganso-pequeno (híbrido)_x00378
+Lophodytes cucullatus_merganso-capuchinho_hoomer
+Aix sponsa x Lophodytes cucullatus_pato-carolino x merganso-capuchinho (híbrido)_x00202
+Bucephala albeola x Lophodytes cucullatus_olho-dourado-de-touca x merganso-capuchinho (híbrido)_x00424
+Bucephala clangula x Lophodytes cucullatus_olho-dourado-comum x merganso-capuchinho (híbrido)_x00425
+Bucephala islandica x Lophodytes cucullatus_olho-dourado-da-islândia x merganso-capuchinho (híbrido)_x00426
+Bucephala clangula/islandica x Lophodytes cucullatus_olho-dourado-comum/olho-dourado-da-islândia x merganso-capuchinho (híbrido)_x00631
+Mergellus albellus x Lophodytes cucullatus_merganso-pequeno x merganso-capuchinho (híbrido)_x00379
+Mergus australis_auckland islands merganser_auimer1
+Mergus merganser_merganso-grande_commer
+Mergus merganser merganser/orientalis_merganso-grande (merganser/orientalis)_goosan1
+Mergus merganser americanus_merganso-grande (americanus)_commer1
+Somateria mollissima x Mergus merganser_êider x merganso-grande (híbrido)_x00840
+Lophodytes cucullatus x Mergus merganser_merganso-capuchinho x merganso-grande (híbrido)_x00726
+Mergus octosetaceus_pato-mergulhão_bramer1
+Mergus serrator_merganso-de-poupa_rebmer
+Aythya collaris x Mergus serrator_caturro x merganso-de-poupa (híbrido)_x00614
+Mergus merganser x serrator_merganso-grande x merganso-de-poupa (híbrido)_x00780
+Mergus merganser/serrator_merganso-grande/merganso-de-poupa_y00224
+Mergus squamatus_scaly-sided merganser_scsmer1
+Mergellus/Lophodytes/Mergus sp._merganso (Lophodytes/Mergus) sp._mergan1
+Heteronetta atricapilla_marreca-de-cabeça-preta_blhduc1
+Nomonyx dominicus_marreca-caucau_masduc
+Oxyura jamaicensis_pato-rabo-alçado-americano_rudduc
+Nomonyx dominicus/Oxyura jamaicensis_marreca-de-bico-roxo/pato-rabo-alçado-americano_y00710
+Oxyura ferruginea_andean duck_andduc1
+Oxyura ferruginea andina_andean duck (andina)_andduc2
+Oxyura ferruginea ferruginea_andean duck (ferruginea)_rudduc2
+Oxyura leucocephala_pato-rabo-alçado_whhduc1
+Oxyura jamaicensis x leucocephala_pato-rabo-alçado-americano x pato-rabo-alçado (híbrido)_x00705
+Oxyura maccoa_maccoa duck_macduc1
+Oxyura vittata_marreca-rabo-de-espinho_lakduc1
+Oxyura ferruginea/vittata_pato-rabo-alçado-americano/marreca-pé-na-bunda_y00601
+Oxyura australis_blue-billed duck_blbduc1
+Biziura lobata_musk duck_musduc1
+Anatidae (duck sp.)_pato-de-superfície (anatíneo) sp._duck1
+Anatidae sp._anatídeo sp._waterf1
+Alectura lathami_australian brushturkey_ausbrt1
+Alectura lathami purpureicollis_australian brushturkey (Purple-pouched)_ausbru1
+Alectura lathami lathami_australian brushturkey (Yellow-pouched)_ausbru2
+Aepypodius arfakianus_wattled brushturkey_watbrt1
+Aepypodius bruijnii_waigeo brushturkey_brubrt1
+Talegalla cuvieri_red-billed brushturkey_rebbrt1
+Talegalla fuscirostris_yellow-legged brushturkey_bkbbrt1
+Talegalla jobiensis_red-legged brushturkey_bncbrt1
+Talegalla sp._Talegalla sp._talega1
+Leipoa ocellata_malleefowl_mallee1
+Macrocephalon maleo_maleo_maleo1
+Eulipoa wallacei_moluccan megapode_molscr1
+Megapodius pritchardii_tongan megapode_niuscr1
+Megapodius laperouse_micronesian megapode_micscr1
+Megapodius nicobariensis_nicobar megapode_nicscr1
+Megapodius cumingii_philippine megapode_tabscr1
+Megapodius bernsteinii_sula megapode_sulscr1
+Megapodius tenimberensis_tanimbar megapode_tanscr1
+Megapodius freycinet_dusky megapode_dusscr1
+Megapodius freycinet [freycinet Group]_dusky megapode (Dusky)_dusscr2
+Megapodius freycinet forsteni/buruensis_dusky megapode (Forsten's)_forscr1
+Megapodius geelvinkianus_biak megapode_dusscr3
+Megapodius eremita_melanesian megapode_melscr1
+Megapodius layardi_vanuatu megapode_vanscr1
+Megapodius decollatus_new guinea megapode_negscr1
+Megapodius reinwardt_galinha-do-mato-de-reinwardt_orfscr1
+Ortalis vetula_plain chachalaca_placha
+Ortalis cinereiceps_gray-headed chachalaca_grhcha1
+Ortalis garrula_chestnut-winged chachalaca_chwcha1
+Ortalis ruficauda_rufous-vented chachalaca_ruvcha1
+Ortalis ruficauda ruficrissa_rufous-vented chachalaca (Rufous-vented)_ruvcha2
+Ortalis ruficauda ruficauda_rufous-vented chachalaca (Rufous-tipped)_ruvcha3
+Ortalis erythroptera_rufous-headed chachalaca_ruhcha1
+Ortalis wagleri_rufous-bellied chachalaca_rubcha1
+Ortalis poliocephala_west mexican chachalaca_wemcha1
+Ortalis wagleri x poliocephala_rufous-bellied x west mexican chachalaca (hybrid)_x01121
+Ortalis canicollis_aracuã-do-pantanal_chacha1
+Ortalis leucogastra_white-bellied chachalaca_whbcha1
+Ortalis columbiana_colombian chachalaca_colcha1
+Ortalis guttata_aracuã-pintado/aracuã-guarda-faca_specha3
+Ortalis guttata guttata/subaffinis_aracuã-pintado_specha6
+Ortalis guttata remota_aracuã-guarda-faca_specha5
+Ortalis araucuan_aracuã-de-barriga-branca_specha2
+Ortalis squamata_aracuã-escamoso_specha4
+Ortalis motmot_aracuã-pequeno_varcha1
+Ortalis ruficeps_aracuãzinho_varcha3
+Ortalis superciliaris_aracuã-de-sobrancelhas_bubcha1
+Ortalis sp._Ortalis sp._chacha2
+Penelope argyrotis_band-tailed guan_batgua1
+Penelope barbata_bearded guan_beagua1
+Penelope ortoni_baudo guan_baugua1
+Penelope montagnii_andean guan_andgua1
+Penelope marail_jacumirim_margua1
+Penelope superciliaris_jacupemba_rumgua1
+Penelope superciliaris pseudonyma_jacupemba (pseudonyma)_rumgua5
+Penelope superciliaris [superciliaris Group]_jacupemba (Grupo superciliaris)_rumgua6
+Penelope dabbenei_red-faced guan_refgua1
+Penelope jacquacu_jacu-de-spix_spigua1
+Penelope jacquacu granti_jacu-de-spix (granti)_spigua3
+Penelope jacquacu [jacquacu Group]_jacu-de-spix [grupo jacquacu]_spigua2
+Penelope marail/jacquacu_jacumirim/jacu-de-spix_y00657
+Penelope purpurascens_crested guan_cregua1
+Penelope perspicax_cauca guan_caugua1
+Penelope albipennis_white-winged guan_whwgua1
+Penelope obscura_jacuguaçu_dulgua1
+Penelope superciliaris/obscura_rusty-margined/dusky-legged guan_y01229
+Penelope bridgesi_yungas guan_dulgua3
+Penelope pileata_jacupiranga_whcgua1
+Penelope ochrogaster_jacu-de-barriga-castanha_chbgua1
+Penelope jacucaca_jacucaca_whbgua1
+Penelope sp._penelope sp. (jacu)_penelo1
+Pipile pipile_trinidad piping-guan_trpgua1
+Pipile cumanensis_jacutinga-de-garganta-azul_butpig1
+Pipile grayi_jacutinga-de-garganta-branca_butpig2
+Pipile cumanensis/grayi_blue-throated/white-throated piping-guan_btpgua1
+Pipile cujubi_cujubi_rtpgua1
+Pipile cujubi nattereri_cujubi (nattereri)_retpig2
+Pipile cujubi cujubi_cujubi (cujubi)_retpig1
+Pipile grayi x cujubi_white-throated x red-throated piping-guan (hybrid)_x01078
+Pipile grayi/cujubi_jacutinga-de-garganta-branca/cujubi_y00831
+Pipile jacutinga_jacutinga_bfpgua1
+Aburria aburri_wattled guan_watgua1
+Chamaepetes unicolor_black guan_blagua1
+Chamaepetes goudotii_sickle-winged guan_siwgua1
+Penelopina nigra_highland guan_higgua1
+Oreophasis derbianus_horned guan_horgua1
+Nothocrax urumutum_urumutum_noccur1
+Mitu tomentosum_mutum-do-norte_crecur2
+Mitu salvini_salvin's curassow_salcur1
+Mitu tuberosum_mutum-cavalo_rabcur2
+Mitu mitu_mutum-do-nordeste_alacur1
+Pauxi pauxi_helmeted curassow_helcur1
+Pauxi koepckeae_sira curassow_horcur2
+Pauxi unicornis_horned curassow_horcur3
+Crax rubra_great curassow_grecur1
+Crax alberti_blue-billed curassow_bubcur1
+Crax daubentoni_yellow-knobbed curassow_yekcur1
+Crax alector_mutum-poranga_blacur1
+Crax globulosa_mutum-de-fava_watcur1
+Crax fasciolata_mutum-de-penacho_bafcur1
+Crax fasciolata pinima_mutum-de-penacho (pinima)_bafcur2
+Crax fasciolata fasciolata/grayi_mutum-de-penacho (fasciolata/grayi)_bafcur3
+Crax blumenbachii_mutum-de-bico-vermelho_rebcur1
+Cracidae sp. (curassow sp.)_cracidae sp. (mutum sp.)_curass1
+Cracidae sp._Cracidae sp._cracid1
+Numida meleagris_galinha-d'angola_helgui
+Numida meleagris sabyi_galinha-d'angola (sabyi)_helgui2
+Numida meleagris galeatus_galinha-d'angola (galeatus)_helgui4
+Numida meleagris meleagris/somaliensis_galinha-d'angola (melagris/somaliensis)_helgui3
+Numida meleagris reichenowi_galinha-d'angola (reichenowi)_helgui5
+Numida meleagris [mitratus Group]_galinha-d'angola [grupo mitratus]_helgui6
+Numida meleagris (Domestic type)_galinha-d'angola (doméstico)_helgui1
+Agelastes meleagrides_white-breasted guineafowl_whbgui1
+Agelastes niger_black guineafowl_blagui1
+Acryllium vulturinum_vulturine guineafowl_vulgui1
+Guttera plumifera_plumed guineafowl_plugui1
+Guttera pucherani_eastern crested guineafowl_cregui3
+Guttera verreauxi_western crested guineafowl_cregui2
+Guttera edouardi_southern crested guineafowl_cregui4
+Guttera pucherani/verreauxi/edouardi_crested guineafowl sp._cregui1
+Ptilopachus petrosus_galinha-da-pedra_stopar1
+Ptilopachus petrosus petrosus_galinha-da-pedra (petrosus)_stopar2
+Ptilopachus petrosus major_galinha-da-pedra (major)_stopar3
+Ptilopachus nahani_nahan's partridge_nahfra2
+Rhynchortyx cinctus_tawny-faced quail_tafqua1
+Oreortyx pictus_mountain quail_mouqua
+Dendrortyx leucophrys_buffy-crowned wood-partridge_bcwpar1
+Dendrortyx macroura_long-tailed wood-partridge_ltwpar1
+Dendrortyx barbatus_bearded wood-partridge_bewpar1
+Philortyx fasciatus_banded quail_banqua1
+Colinus virginianus_codorniz-da-virgínia_norbob
+Colinus virginianus [virginianus Group]_codorniz-da-virgínia [grupo virginianus]_norbob1
+Colinus virginianus graysoni/nigripectus_codorniz-da-virgínia (graysoni/nigripectus)_norbob2
+Colinus virginianus [pectoralis Group]_codorniz-da-virgínia [grupo pectoralis]_norbob3
+Colinus virginianus [coyoleos Group]_codorniz-da-virgínia [grupo coyoleos]_masbob1
+Colinus nigrogularis_black-throated bobwhite_bltbob1
+Colinus leucopogon_spot-bellied bobwhite_crebob2
+Colinus cristatus_uru-do-campo_crebob1
+Callipepla squamata_scaled quail_scaqua
+Colinus virginianus x Callipepla squamata_northern bobwhite x scaled quail (hybrid)_x00688
+Callipepla douglasii_elegant quail_elequa
+Callipepla californica_codorniz-da-califórnia_calqua
+Colinus virginianus x Callipepla californica_northern bobwhite x california quail (hybrid)_x01011
+Callipepla squamata x californica_scaled x california quail (hybrid)_x00687
+Callipepla gambelii_gambel's quail_gamqua
+Callipepla squamata x gambelii_scaled x gambel's quail (hybrid)_x00689
+Callipepla californica x gambelii_california x gambel's quail (hybrid)_y00315
+Callipepla californica/gambelii_california/gambel's quail_y00711
+Cyrtonyx montezumae_montezuma quail_monqua
+Cyrtonyx montezumae [montezumae Group]_montezuma quail (Montezuma)_monqua1
+Cyrtonyx montezumae sallei/rowleyi_montezuma quail (Salle's)_monqua2
+Cyrtonyx ocellatus_ocellated quail_ocequa1
+Dactylortyx thoracicus_singing quail_sinqua1
+Odontophorus gujanensis_uru-corcovado_mawqua1
+Odontophorus capueira_uru_swwqua1
+Odontophorus melanotis_black-eared wood-quail_bewqua1
+Odontophorus atrifrons_black-fronted wood-quail_bfwqua1
+Odontophorus erythrops_rufous-fronted wood-quail_rfwqua1
+Odontophorus hyperythrus_chestnut wood-quail_chwqua1
+Odontophorus melanonotus_dark-backed wood-quail_dbwqua1
+Odontophorus speciosus_rufous-breasted wood-quail_rbwqua1
+Odontophorus dialeucos_tacarcuna wood-quail_tawqua1
+Odontophorus strophium_gorgeted wood-quail_gowqua1
+Odontophorus columbianus_venezuelan wood-quail_venwoq1
+Odontophorus leucolaemus_black-breasted wood-quail_bbwqua1
+Odontophorus [undescribed form]_pasco wood-quail (undescribed form)_paswoq1
+Odontophorus balliviani_stripe-faced wood-quail_sfwqua1
+Odontophorus stellatus_uru-de-topete_stwqua1
+Odontophorus guttatus_spotted wood-quail_spwqua1
+Odontophorus sp._Odontophorus sp._woodqu1
+Odontophoridae sp._Odontophoridae sp._quail1
+Xenoperdix udzungwensis_udzungwa partridge_udzpar1
+Xenoperdix udzungwensis udzungwensis_udzungwa partridge (Udzungwa)_udzpar3
+Xenoperdix udzungwensis obscuratus_udzungwa partridge (Rubeho)_udzpar2
+Caloperdix oculeus_ferruginous partridge_ferpar2
+Rollulus rouloul_crested partridge_crepar1
+Melanoperdix niger_black partridge_blapar2
+Arborophila torqueola_hill partridge_hilpar1
+Arborophila rufipectus_sichuan partridge_sicpar1
+Arborophila mandellii_chestnut-breasted partridge_chbpar2
+Arborophila gingica_white-necklaced partridge_whnpar2
+Arborophila rufogularis_rufous-throated partridge_rutpar1
+Arborophila rubrirostris_red-billed partridge_rebpar3
+Arborophila cambodiana_chestnut-headed partridge_chhpar1
+Arborophila cambodiana diversa_chestnut-headed partridge (Siamese)_chhpar3
+Arborophila cambodiana cambodiana/chandamonyi_chestnut-headed partridge (Chestnut-headed)_chhpar2
+Arborophila ardens_hainan partridge_haipar1
+Arborophila crudigularis_taiwan partridge_taipar1
+Arborophila atrogularis_white-cheeked partridge_whcpar1
+Arborophila brunneopectus_bar-backed partridge_babpar1
+Arborophila davidi_orange-necked partridge_ornpar1
+Arborophila hyperythra_red-breasted partridge_rebpar5
+Arborophila campbelli_malayan partridge_gybpar3
+Arborophila rolli_roll's partridge_gybpar5
+Arborophila sumatrana_sumatran partridge_gybpar6
+Arborophila rolli/sumatrana_roll's/sumatran partridge_y01018
+Arborophila javanica_chestnut-bellied partridge_chbpar1
+Arborophila orientalis_gray-breasted partridge_gybpar4
+Lerwa lerwa_snow partridge_snopar1
+Ithaginis cruentus_blood pheasant_blophe1
+Tragopan melanocephalus_western tragopan_westra1
+Tragopan satyra_satyr tragopan_sattra1
+Tragopan blythii_blyth's tragopan_blytra1
+Tragopan temminckii_temminck's tragopan_temtra1
+Tragopan caboti_cabot's tragopan_cabtra1
+Tetraophasis obscurus_chestnut-throated monal-partridge_verpar1
+Tetraophasis szechenyii_buff-throated monal-partridge_szepar1
+Lophophorus impejanus_monal-dos-himalaias_himmon1
+Lophophorus sclateri_sclater's monal_sclmon1
+Lophophorus sclateri arunachalensis_sclater's monal (White-tailed)_sclmon3
+Lophophorus sclateri sclateri/orientalis_sclater's monal (Band-tailed)_sclmon5
+Lophophorus lhuysii_chinese monal_chimon1
+Pucrasia macrolopha_koklass pheasant_kokphe1
+Meleagris gallopavo_perú-bravo_wiltur
+Meleagris gallopavo (Domestic type)_perú-bravo (forma doméstica)_wiltur1
+Meleagris ocellata_ocellated turkey_ocetur1
+Bonasa umbellus_ruffed grouse_rufgro
+Tetrastes bonasia_galinha-montês_hazgro1
+Tetrastes sewerzowi_chinese grouse_sevgro1
+Centrocercus urophasianus_greater sage-grouse_saggro
+Centrocercus minimus_gunnison sage-grouse_gusgro
+Centrocercus urophasianus/minimus_greater/gunnison sage-grouse_y00608
+Dendragapus obscurus_dusky grouse_dusgro
+Dendragapus fuliginosus_sooty grouse_soogro1
+Dendragapus obscurus/fuliginosus_dusky/sooty grouse_blugrs
+Tympanuchus phasianellus_sharp-tailed grouse_shtgro
+Centrocercus urophasianus x Tympanuchus phasianellus_greater sage-grouse x sharp-tailed grouse (hybrid)_x00727
+Dendragapus obscurus x Tympanuchus phasianellus_dusky x sharp-tailed grouse (hybrid)_x00781
+Tympanuchus cupido_greater prairie-chicken_grpchi
+Tympanuchus cupido pinnatus_greater prairie-chicken (pinnatus)_greprc1
+Tympanuchus cupido cupido_greater prairie-chicken (Heath Hen)_heahen1
+Tympanuchus cupido attwateri_greater prairie-chicken (Attwater's)_attprc1
+Tympanuchus phasianellus x cupido_sharp-tailed grouse x greater prairie-chicken (hybrid)_x00728
+Tympanuchus pallidicinctus_lesser prairie-chicken_lepchi
+Tympanuchus cupido x pallidicinctus_greater x lesser prairie-chicken (hybrid)_x00668
+Tympanuchus cupido/pallidicinctus_greater/lesser prairie-chicken_y00664
+Lagopus leucura_white-tailed ptarmigan_whtpta1
+Lagopus lagopus_lagopo-ruivo_wilpta
+Lagopus lagopus scotica/hibernica_lagopo-ruivo (scotica/hibernica)_wilpta1
+Lagopus lagopus [lagopus Group]_lagopo-ruivo [grupo lagopus]_wilpta2
+Lagopus muta_lagopo-cinzento_rocpta1
+Lagopus sp._lagopo sp._ptarmi1
+Falcipennis falcipennis_siberian grouse_sibgro2
+Canachites canadensis_spruce grouse_sprgro
+Canachites canadensis [canadensis Group]_spruce grouse (Spruce)_sprgro1
+Canachites canadensis franklinii/isleibi_spruce grouse (Franklin's)_frsgro1
+Canachites canadensis [canadensis Group] x franklinii/isleibi_spruce grouse (Spruce x Franklin's)_sprgro9
+Bonasa umbellus/Canachites canadensis_ruffed/spruce grouse_y00674
+Tetrao urogallus_galo-montês_wescap1
+Tetrao urogalloides_black-billed capercaillie_blbcap1
+Tetrao urogallus x urogalloides_western x black-billed capercaillie (hybrid)_x01169
+Tetrao urogallus/urogalloides_western/black-billed capercaillie_y01338
+Lyrurus tetrix_tetraz-lira_blagro1
+Tetrao urogallus x Lyrurus tetrix_galo-montês x tetraz-lira (híbrido)_x00841
+Lyrurus mlokosiewiczi_tetraz-caucasiano_caugro1
+Tetraoninae sp._grouse sp._grouse1
+Rhizothera longirostris_long-billed partridge_lobpar3
+Rhizothera dulitensis_dulit partridge_lobpar2
+Perdix hodgsoniae_tibetan partridge_tibpar1
+Perdix perdix_charrela_grypar
+Perdix dauurica_charrela-dáurica_daupar1
+Syrmaticus soemmerringii_copper pheasant_copphe1
+Syrmaticus reevesii_faisão-venerado_reephe1
+Syrmaticus mikado_mikado pheasant_mikphe1
+Syrmaticus ellioti_elliot's pheasant_ellphe1
+Syrmaticus humiae_mrs. hume's pheasant_humphe1
+Chrysolophus pictus_faisão-dourado_golphe
+Chrysolophus pictus (Domestic type)_faisão-dourado (tipo doméstico)_golphe1
+Chrysolophus amherstiae_faisão-de-lady-amherst_laaphe1
+Chrysolophus pictus x amherstiae_golden x lady amherst's pheasant (hybrid)_x01017
+Phasianus colchicus_faisão_rinphe1
+Phasianus colchicus (Domestic type)_faisão (tipo doméstico)_rinphe37
+Phasianus versicolor_green pheasant_rinphe2
+Phasianus colchicus x versicolor_ring-necked x green pheasant (hybrid)_x01018
+Phasianus colchicus/versicolor_ring-necked/green pheasant_rinphe
+Catreus wallichii_cheer pheasant_chephe1
+Crossoptilon harmani_tibetan eared-pheasant_whieap2
+Crossoptilon crossoptilon_white eared-pheasant_whieap1
+Crossoptilon harmani x crossoptilon_tibetan x white eared-pheasant (hybrid)_x00943
+Crossoptilon harmani/crossoptilon_tibetan/white eared-pheasant_whephe1
+Crossoptilon mantchuricum_brown eared-pheasant_brephe1
+Crossoptilon auritum_blue eared-pheasant_blephe1
+Lophura edwardsi_edwards's pheasant_edwphe1
+Lophura swinhoii_swinhoe's pheasant_swiphe1
+Lophura bulweri_bulwer's pheasant_bulphe1
+Lophura leucomelanos_kalij pheasant_kalphe
+Lophura nycthemera_silver pheasant_silphe
+Lophura edwardsi x nycthemera_edwards's x silver pheasant (hybrid)_impphe1
+Lophura erythrophthalma_malayan crestless fireback_crefir5
+Lophura pyronota_bornean crestless fireback_crefir6
+Lophura diardi_siamese fireback_siafir1
+Lophura inornata_salvadori's pheasant_salphe1
+Lophura inornata hoogerwerfi_salvadori's pheasant (Hoogerwerf's)_salphe3
+Lophura inornata inornata_salvadori's pheasant (Salvadori's)_salphe2
+Lophura rufa_malayan crested fireback_crefir3
+Lophura ignita_bornean crested fireback_crefir4
+Rheinardia ocellata_vietnamese crested argus_crearg1
+Rheinardia nigrescens_malayan crested argus_crearg3
+Argusianus argus_great argus_grearg1
+Afropavo congensis_congo peacock_conpea1
+Pavo cristatus_pavão-real_compea
+Pavo cristatus (Domestic type)_pavão-real (forma doméstica)_indpea1
+Pavo muticus_pavão-verde_grepea1
+Pavo cristatus x muticus_indian x green peafowl (hybrid)_x00380
+Tropicoperdix chloropus_scaly-breasted partridge_scbpar1
+Tropicoperdix chloropus tonkinensis_scaly-breasted partridge (Tonkin)_scbpar2
+Tropicoperdix chloropus [chloropus Group]_scaly-breasted partridge (Green-legged)_scbpar3
+Tropicoperdix charltonii_chestnut-necklaced partridge_chnpar1
+Tropicoperdix graydoni_sabah partridge_chnpar3
+Arborophila/Tropicoperdix sp._Arborophila/Tropicoperdix sp._arboro1
+Haematortyx sanguiniceps_crimson-headed partridge_crhpar1
+Galloperdix spadicea_red spurfowl_redspu1
+Galloperdix lunulata_painted spurfowl_paispu1
+Galloperdix spadicea/lunulata_red/painted spurfowl_y00768
+Galloperdix bicalcarata_sri lanka spurfowl_ceyspu1
+Polyplectron napoleonis_palawan peacock-pheasant_palpep1
+Polyplectron schleiermacheri_bornean peacock-pheasant_bopphe1
+Polyplectron malacense_malayan peacock-pheasant_mapphe1
+Polyplectron germaini_germain's peacock-pheasant_gepphe1
+Polyplectron katsumatae_hainan peacock-pheasant_grypep3
+Polyplectron bicalcaratum_gray peacock-pheasant_grypep2
+Polyplectron inopinatum_mountain peacock-pheasant_mopphe1
+Polyplectron chalcurum_bronze-tailed peacock-pheasant_btpphe1
+Phasianidae sp. (pheasant sp.)_pheasant sp._pheasa1
+Bambusicola fytchii_mountain bamboo-partridge_mobpar1
+Bambusicola thoracicus_chinese bamboo-partridge_chbpar3
+Bambusicola sonorivox_taiwan bamboo-partridge_taibap1
+Bambusicola thoracicus/sonorivox_chinese/taiwan bamboo-partridge_y01257
+Gallus varius_green junglefowl_grejun1
+Gallus gallus_galo-bravo-vermelho_redjun
+Gallus gallus (Domestic type)_galo (forma doméstica)_redjun1
+Gallus sonneratii_gray junglefowl_grejun2
+Gallus lafayettii_sri lanka junglefowl_ceyjun1
+Peliperdix lathami_latham's francolin_forfra2
+Ortygornis sephaena_crested francolin_crefra2
+Ortygornis sephaena rovuma_crested francolin (Kirk's)_crefra1
+Ortygornis sephaena [sephaena Group]_crested francolin (Crested)_crefra3
+Ortygornis pondicerianus_gray francolin_gryfra
+Ortygornis gularis_swamp francolin_swafra1
+Francolinus pintadeanus_chinese francolin_chifra1
+Francolinus francolinus_francolim-escuro_blkfra
+Francolinus francolinus francolinus/arabistanicus_francolim-escuro (francolinus/arabistanicus)_blkfra1
+Francolinus francolinus [henrici Group]_francolim-escuro [grupo henrici]_blkfra2
+Francolinus pictus_painted francolin_paifra1
+Campocolinus coqui_coqui francolin_coqfra2
+Campocolinus coqui [hubbardi Group]_coqui francolin (Plain-breasted)_coqfra1
+Campocolinus coqui coqui_coqui francolin (Bar-breasted)_coqfra3
+Campocolinus albogularis_white-throated francolin_whtfra2
+Campocolinus albogularis albogularis/buckleyi_white-throated francolin (White-throated)_whtfra1
+Campocolinus albogularis dewittei_white-throated francolin (Chestnut-breasted)_whtfra3
+Campocolinus schlegelii_schlegel's francolin_schfra2
+Scleroptila streptophora_ring-necked francolin_rinfra2
+Scleroptila levaillantii_red-winged francolin_rewfra2
+Scleroptila finschi_finsch's francolin_finfra2
+Scleroptila psilolaema_moorland francolin_moofra2
+Scleroptila elgonensis_elgon francolin_moofra3
+Scleroptila afra_gray-winged francolin_gywfra1
+Scleroptila gutturalis_orange river francolin_orrfra2
+Scleroptila gutturalis gutturalis/lorti_orange river francolin (Archer's)_orrfra1
+Scleroptila gutturalis jugularis_orange river francolin (Kunene)_orrfra3
+Scleroptila gutturalis levalliantoides_orange river francolin (Orange River)_orrfra4
+Scleroptila shelleyi_shelley's francolin_shefra1
+Scleroptila whytei_whyte's francolin_shefra3
+Scleroptila shelleyi/whytei_shelley's/whyte's francolin_shefra2
+Tetraogallus tibetanus_tibetan snowcock_tibsno1
+Tetraogallus altaicus_altai snowcock_altsno1
+Tetraogallus caucasicus_galo-das-neves-do-cáucaso_causno1
+Tetraogallus caspius_galo-das-neves-do-cáspio_cassno1
+Tetraogallus himalayensis_himalayan snowcock_himsno
+Tetraogallus tibetanus/himalayensis_tibetan/himalayan snowcock_y00936
+Ammoperdix griseogularis_perdiz-assobiadeira_sespar1
+Ammoperdix heyi_perdiz-do-deserto_sanpar1
+Synoicus ypsilophorus_codorniz-parda_broqua1
+Synoicus monorthonyx_snow mountain quail_snmqua2
+Synoicus chinensis_codorniz-chinesa_blbqua1
+Synoicus chinensis (Domestic type)_codorniz-chinesa (doméstica)_bubqua9
+Synoicus adansonii_blue quail_bluqua1
+Margaroperdix madagarensis_madagascar partridge_madpar2
+Coturnix coturnix_codorniz_comqua1
+Coturnix japonica_codorniz-japonesa_japqua
+Coturnix japonica (Domestic type)_codorniz-japonesa (doméstica)_japqua1
+Coturnix delegorguei_harlequin quail_harqua1
+Coturnix coromandelica_rain quail_raiqua1
+Coturnix coturnix/coromandelica_common/rain quail_y00935
+Coturnix pectoralis_stubble quail_stuqua1
+Coturnix novaezelandiae_new zealand quail_nezqua1
+Synoicus/Coturnix sp._codorniz sp._coturn1
+Alectoris barbara_perdiz-mourisca_barpar2
+Alectoris melanocephala_arabian partridge_arapar1
+Alectoris rufa_perdiz-comum_relpar1
+Alectoris chukar_perdiz-chucar_chukar
+Alectoris graeca_perdiz-grega_rocpar2
+Alectoris graeca [graeca Group]_perdiz-grega [grupo graeca]_rocpar3
+Alectoris graeca whitakeri_perdiz-grega (whitakeri)_rocpar4
+Alectoris rufa x graeca_perdiz-comum x perdiz-grega (híbrido)_x00640
+Alectoris chukar x graeca_perdiz-chucar x perdiz-grega (híbrido)_x00381
+Alectoris rufa/graeca_perdiz-comum/perdiz-grega_y00767
+Alectoris philbyi_philby's partridge_phipar1
+Alectoris magna_przevalski's partridge_przpar1
+Alectoris sp._Alectoris sp._alecto1
+Perdicula asiatica_jungle bush-quail_jubqua1
+Perdicula argoondah_rock bush-quail_robqua1
+Perdicula asiatica/argoondah_jungle/rock bush-quail_y00712
+Perdicula erythrorhyncha_painted bush-quail_pabqua1
+Perdicula manipurensis_manipur bush-quail_mabqua1
+Ophrysia superciliosa_himalayan quail_himqua1
+Pternistis hartlaubi_hartlaub's spurfowl_harfra3
+Pternistis camerunensis_mount cameroon spurfowl_camfra2
+Pternistis nobilis_handsome spurfowl_hanfra2
+Pternistis castaneicollis_chestnut-naped spurfowl_chnfra2
+Pternistis castaneicollis castaneicollis_chestnut-naped spurfowl (Northern)_chnfra1
+Pternistis castaneicollis atrifrons_chestnut-naped spurfowl (Black-fronted)_chnfra3
+Pternistis erckelii_francolim-de-sobrancelhas-pretas_ercfra
+Pternistis ochropectus_djibouti spurfowl_djifra1
+Pternistis swierstrai_swierstra's spurfowl_swifra2
+Pternistis ahantensis_perdiz-do-gunal_ahafra2
+Pternistis griseostriatus_gray-striped spurfowl_gysfra1
+Pternistis jacksoni_jackson's spurfowl_jacfra2
+Pternistis adspersus_red-billed spurfowl_rebfra1
+Pternistis capensis_cape spurfowl_capfra2
+Pternistis natalensis_natal spurfowl_natfra2
+Pternistis hildebrandti_hildebrandt's spurfowl_hilfra2
+Pternistis bicalcaratus_choca_dosfra2
+Pternistis squamatus_scaly spurfowl_scafra2
+Pternistis icterorhynchus_heuglin's spurfowl_heufra1
+Pternistis clappertoni_clapperton's spurfowl_clafra1
+Pternistis harwoodi_harwood's spurfowl_harfra4
+Pternistis swainsonii_swainson's spurfowl_swafra2
+Pternistis leucoscepus_yellow-necked spurfowl_yenspu1
+Pternistis rufopictus_gray-breasted spurfowl_gybfra1
+Pternistis afer_red-necked spurfowl_renfra1
+Pternistis afer cranchii/harterti_red-necked spurfowl (Cranch's)_renfra2
+Pternistis afer [leucoparaeus Group]_red-necked spurfowl (Northern)_renfra3
+Pternistis afer afer_red-necked spurfowl (Benguela)_renfra4
+Pternistis afer castaneiventer_red-necked spurfowl (Southern)_renfra5
+Phasianidae sp. (francolin/spurfowl sp.)_francolim sp._franco1
+Columba livia_pombo-doméstico_rocpig
+Columba livia (Wild type)_pombo-doméstico (Wild type)_rocpig2
+Columba livia (Feral Pigeon)_pombo-doméstico (feral)_rocpig1
+Columba rupestris_hill pigeon_hilpig1
+Columba livia/rupestris_rock/hill pigeon_y01112
+Columba leuconota_snow pigeon_snopig1
+Columba guinea_pomba-de-cibe_spepig1
+Columba albitorques_white-collared pigeon_whcpig1
+Columba oenas_seixa_stodov1
+Columba eversmanni_seixa-asiática_pabpig1
+Columba oliviae_somali pigeon_sompig1
+Columba palumbus_pombo-torcaz_cowpig1
+Columba palumbus [palumbus Group]_pombo-torcaz [grupo palumbus]_comwop1
+Columba palumbus casiotis_pombo-torcaz (casiotis)_comwop2
+Columba trocaz_pombo-da-madeira_tropig1
+Columba bollii_pombo-turquesa_bolpig1
+Columba unicincta_afep pigeon_afepig1
+Columba junoniae_pombo-rabil_laupig1
+Columba arquatrix_rameron pigeon_rampig1
+Columba sjostedti_cameroon pigeon_campig1
+Columba thomensis_maroon pigeon_marpig1
+Columba delegorguei_eastern bronze-naped pigeon_delpig1
+Columba delegorguei sharpei_eastern bronze-naped pigeon (Northern)_delpig2
+Columba delegorguei delegorguei_eastern bronze-naped pigeon (Southern)_delpig3
+Columba iriditorques_western bronze-naped pigeon_brnpig1
+Columba malherbii_sao tome pigeon_satpig1
+Columba thiriouxi_mauritius wood-pigeon_mauwop1
+Columba pollenii_comoro pigeon_compig1
+Columba hodgsonii_speckled wood-pigeon_spwpig1
+Columba albinucha_white-naped pigeon_whnpig1
+Columba pulchricollis_ashy wood-pigeon_aswpig1
+Columba elphinstonii_nilgiri wood-pigeon_niwpig1
+Columba torringtoniae_sri lanka wood-pigeon_ceywop1
+Columba punicea_pale-capped pigeon_pacpig1
+Columba argentina_silvery wood-pigeon_siwpig1
+Columba palumboides_andaman wood-pigeon_anwpig1
+Columba janthina_black wood-pigeon_jawpig1
+Columba jouyi_ryukyu pigeon_ryupig1
+Columba versicolor_bonin pigeon_bonpig1
+Columba vitiensis_pombo-de-garganta-branca_metpig1
+Columba vitiensis [vitiensis Group]_pombo-de-garganta-branca [grupo vitiensis]_metpig2
+Columba vitiensis castaneiceps_pombo-de-garganta-branca (castaneiceps)_metpig3
+Columba leucomela_white-headed pigeon_whhpig1
+Columba pallidiceps_yellow-legged pigeon_yelpig1
+Columba sp._pombo (Columba) sp._columb1
+Aplopelia larvata_lemon dove_lemdov2
+Aplopelia larvata inornata_lemon dove (Western)_lemdov1
+Aplopelia larvata principalis_lemon dove (Principe)_lemdov3
+Aplopelia larvata simplex_lemon dove (Sao Tome)_fordov1
+Aplopelia larvata larvata/bronzina_lemon dove (Lemon)_lemdov4
+Patagioenas cayennensis_pomba-galega_pavpig2
+Patagioenas speciosa_pomba-trocal_scapig2
+Patagioenas squamosa_scaly-naped pigeon_scnpig1
+Patagioenas picazuro_pomba-asa-branca_picpig2
+Patagioenas corensis_bare-eyed pigeon_baepig2
+Patagioenas maculosa_pomba-do-orvalho_spwpig3
+Patagioenas maculosa albipennis_pomba-do-orvalho (albipennis)_spwpig2
+Patagioenas maculosa maculosa_pomba-do-orvalho (maculosa)_spwpig4
+Patagioenas leucocephala_white-crowned pigeon_whcpig2
+Patagioenas flavirostris_red-billed pigeon_rebpig1
+Patagioenas inornata_plain pigeon_plapig
+Patagioenas fasciata_pomba-de-coleira_batpig1
+Patagioenas fasciata [fasciata Group]_pomba-de-coleira [grupo fasciata]_batpig2
+Patagioenas fasciata vioscae_pomba-de-coleira (vioscae)_batpig4
+Patagioenas fasciata [albilinea Group]_pomba-de-coleira [grupo albilinea]_batpig3
+Columba livia/Patagioenas fasciata_pombo-doméstico/pomba-de-coleira_y00319
+Patagioenas araucana_chilean pigeon_chipig2
+Patagioenas caribaea_ring-tailed pigeon_ritpig
+Patagioenas oenops_peruvian pigeon_perpig2
+Patagioenas plumbea_pomba-amargosa_plupig2
+Patagioenas subvinacea_pomba-botafogo_rudpig
+Patagioenas subvinacea subvinacea/berlepschi_pomba-botafogo (subvinacea/berlepschi)_rudpig2
+Patagioenas subvinacea [purpureotincta Group]_pomba-botafogo [grupo purpureotincta]_rudpig3
+Patagioenas plumbea/subvinacea_pomba-amargosa/botafogo_y00781
+Patagioenas nigrirostris_short-billed pigeon_shbpig
+Patagioenas subvinacea/nigrirostris_ruddy/short-billed pigeon_y00782
+Patagioenas goodsoni_dusky pigeon_duspig2
+Patagioenas sp._Patagioenas sp._patagi1
+Ectopistes migratorius_passenger pigeon_paspig
+Nesoenas picturatus_malagasy turtle-dove_matdov1
+Nesoenas mayeri_pink pigeon_pinpig2
+Nesoenas cicur_mauritius turtle-dove_mautud1
+Nesoenas rodericanus_rodrigues turtle-dove_rodtud1
+Streptopelia turtur_rola-brava_eutdov
+Streptopelia lugens_dusky turtle-dove_dutdov1
+Streptopelia hypopyrrha_rola-de-adamawa_adtdov1
+Streptopelia orientalis_rola-oriental_ortdov
+Streptopelia bitorquata_rola-de-colar-insular_iscdov1
+Streptopelia dusumieri_philippine collared-dove_phicod1
+Streptopelia decaocto_rola-de-colar_eucdov
+Streptopelia turtur x decaocto_rola-brava x rola-de-colar (híbrido)_x00382
+Streptopelia orientalis x decaocto_oriental turtle-dove x eurasian collared-dove (hybrid)_x01084
+Streptopelia xanthocycla_burmese collared-dove_eurcod2
+Streptopelia decaocto/xanthocycla_eurasian/burmese collared-dove_y01178
+Streptopelia roseogrisea_rola-rosada_afcdov1
+Streptopelia roseogrisea (Domestic type)_rola-doméstica_afrcod1
+Streptopelia decaocto x roseogrisea_rola-de-colar x rola-rosada (híbrido)_x00799
+Streptopelia decaocto/roseogrisea_rola-de-colar/rola-rosada_y00851
+Streptopelia reichenowi_white-winged collared-dove_wwcdov1
+Streptopelia decipiens_rola-gemedora_afmdov1
+Streptopelia semitorquata_rola-grande-de-coleira_reedov1
+Streptopelia capicola_ring-necked dove_rindov
+Streptopelia vinacea_rola-de-colar-da-guiné_vindov1
+Streptopelia tranquebarica_red collared-dove_recdov1
+Streptopelia decaocto/tranquebarica_eurasian/red collared-dove_y01078
+Streptopelia sp._rola (Streptopelia) sp._strept1
+Spilopelia chinensis_rola-malhada_spodov
+Spilopelia chinensis suratensis/ceylonensis_rola-malhada (suratensis/ceylonensis)_spodov1
+Spilopelia chinensis chinensis/tigrina_rola-malhada (chinensis/tigrina)_spodov2
+Spilopelia senegalensis_rola-dos-palmares_laudov1
+Macropygia unchall_barred cuckoo-dove_bacdov1
+Macropygia phasianella_brown cuckoo-dove_brcdov1
+Macropygia macassariensis_flores sea cuckoo-dove_ducdov1
+Macropygia magna_timor cuckoo-dove_timcud1
+Macropygia timorlaoensis_tanimbar cuckoo-dove_tancud1
+Macropygia amboinensis_amboyna cuckoo-dove_sbcdov1
+Macropygia doreya_sultan's cuckoo-dove_sulcud1
+Macropygia doreya [albicapilla Group]_sultan's cuckoo-dove (Sulawesi)_sulcud3
+Macropygia doreya [doreya Group]_sultan's cuckoo-dove (Sultan's)_sulcud4
+Macropygia amboinensis/doreya_amboyna/sultan's cuckoo-dove_y01028
+Macropygia rufipennis_andaman cuckoo-dove_ancdov1
+Macropygia tenuirostris_philippine cuckoo-dove_phcdov1
+Macropygia [undescribed form]_palawan cuckoo-dove (undescribed form)_palcud1
+Macropygia emiliana_ruddy cuckoo-dove_rucdov1
+Macropygia cinnamomea_enggano cuckoo-dove_engcud1
+Macropygia modiglianii_barusan cuckoo-dove_barcud1
+Macropygia nigrirostris_black-billed cuckoo-dove_bbcdov1
+Macropygia mackinlayi_spot-breasted cuckoo-dove_macdov1
+Macropygia ruficeps_rola-cuco-pequena_licdov1
+Macropygia ruficeps [undescribed form]_rola-cuco-pequena (Eucalypt)_litcud9
+Macropygia sp._Macropygia sp._macrop1
+Reinwardtoena reinwardti_great cuckoo-dove_grcdov2
+Reinwardtoena browni_pied cuckoo-dove_picdov1
+Reinwardtoena crassirostris_crested cuckoo-dove_crcdov1
+Turacoena manadensis_white-faced cuckoo-dove_wfcdov1
+Turacoena sulaensis_sula cuckoo-dove_sulcud2
+Turacoena modesta_rola-cuco-ardósia_slacud1
+Turtur chalcospilos_emerald-spotted wood-dove_eswdov1
+Turtur abyssinicus_pomba-brava_bbwdov1
+Turtur afer_rola-de-manchas-azuis_bswdov1
+Turtur tympanistria_rola-de-papo-branco_tamdov1
+Turtur brehmeri_blue-headed wood-dove_bhwdov1
+Turtur sp._Turtur sp._turtur1
+Oena capensis_rolinha-rabilonga_namdov1
+Chalcophaps indica_asian emerald dove_emedov2
+Chalcophaps longirostris_pacific emerald dove_emedov3
+Chalcophaps indica x longirostris_asian x pacific emerald dove (hybrid)_x00849
+Chalcophaps indica/longirostris_asian/pacific emerald dove_emedov1
+Chalcophaps stephani_stephan's dove_stedov1
+Henicophaps albifrons_new guinea bronzewing_negbro1
+Henicophaps foersteri_new britain bronzewing_nebbro1
+Pampusana hoedtii_rola-terrícola-de-wetar_wegdov1
+Pampusana stairi_shy ground dove_frgdov1
+Pampusana sanctaecrucis_santa cruz ground dove_scgdov1
+Pampusana salamonis_thick-billed ground dove_tbgdov1
+Pampusana ferruginea_tanna ground dove_tangrd1
+Pampusana beccarii_bronze ground dove_brgdov1
+Pampusana beccarii beccarii_bronze ground dove (Western)_brogrd1
+Pampusana beccarii [johannae Group]_bronze ground dove (Eastern)_brogrd2
+Pampusana canifrons_palau ground dove_pagdov1
+Pampusana jobiensis_white-bibbed ground dove_wbgdov1
+Pampusana rubescens_marquesan ground dove_margrd1
+Pampusana kubaryi_caroline islands ground dove_cigdov1
+Pampusana erythroptera_polynesian ground dove_pogdov1
+Pampusana xanthonura_white-throated ground dove_wtgdov1
+Pampusana norfolkensis_norfolk ground dove_norgrd1
+Phaps chalcoptera_common bronzewing_combro1
+Phaps elegans_brush bronzewing_brubro1
+Phaps chalcoptera/elegans_common/brush bronzewing_y01230
+Phaps histrionica_flock bronzewing_flobro1
+Ocyphaps lophotes_crested pigeon_crepig1
+Geophaps plumifera_spinifex pigeon_spipig2
+Geophaps plumifera ferruginea_spinifex pigeon (Rufous-bellied)_spipig4
+Geophaps plumifera plumifera/leucogaster_spinifex pigeon (White-bellied)_spipig5
+Geophaps scripta_squatter pigeon_squpig1
+Geophaps smithii_partridge pigeon_parpig1
+Geophaps smithii blaauwi_partridge pigeon (Yellow-faced)_parpig2
+Geophaps smithii smithii_partridge pigeon (Red-faced)_parpig3
+Petrophassa rufipennis_chestnut-quilled rock-pigeon_cqrpig1
+Petrophassa albipennis_white-quilled rock-pigeon_wqrpig1
+Leucosarcia melanoleuca_wonga pigeon_wonpig1
+Geopelia cuneata_rolinha-diamante_diadov1
+Geopelia striata_zebra dove_zebdov
+Geopelia placida_peaceful dove_peadov1
+Geopelia maugeus_rola-de-timor_bardov2
+Geopelia humeralis_bar-shouldered dove_basdov1
+Columbina inca_inca dove_incdov
+Columbina passerina_rolinha-cinzenta_cogdov
+Columbina minuta_rolinha-de-asa-canela_pbgdov1
+Columbina talpacoti_rolinha-roxa_rugdov
+Columbina passerina x talpacoti_rolinha-cinzenta x rolinha-púrpura (híbrido)_x01164
+Columbina passerina/talpacoti_rolinha-cinzenta/rolinha-roxa_y00852
+Columbina buckleyi_ecuadorian ground dove_ecgdov1
+Columbina squammata_rolinha-fogo-apagou_scadov1
+Columbina talpacoti x squammata_rolinha-púrpura x rolinha-fogo-apagou (híbrido)_x01153
+Columbina picui_rolinha-picuí_pigdov1
+Columbina cruziana_rolinha-de-bico-dourado_crgdov1
+Columbina cyanopis_rolinha-do-planalto_begdov2
+Columbina sp._Columbina sp._y00320
+Claravis pretiosa_pararu-azul_blgdov1
+Paraclaravis mondetoura_maroon-chested ground dove_mcgdov1
+Paraclaravis geoffroyi_pararu-espelho_pwgdov1
+Metriopelia ceciliae_bare-faced ground dove_bfgdov1
+Metriopelia morenoi_bare-eyed ground dove_begdov1
+Metriopelia melanoptera_black-winged ground dove_bwgdov1
+Metriopelia aymara_golden-spotted ground dove_gsgdov1
+Uropelia campestris_rolinha-vaqueira_ltgdov1
+Starnoenas cyanocephala_blue-headed quail-dove_bhqdov1
+Geotrygon purpurata_purple quail-dove_sapqud1
+Geotrygon saphirina_juriti-safira_sapqud2
+Geotrygon versicolor_crested quail-dove_crqdov1
+Geotrygon montana_pariri_ruqdov
+Geotrygon montana montana_pariri (montana)_rudqud1
+Geotrygon montana martinica_pariri (martinica)_rudqud2
+Geotrygon violacea_juriti-vermelha_viqdov1
+Geotrygon caniceps_gray-fronted quail-dove_gfqdov
+Geotrygon leucometopia_white-fronted quail-dove_wfqdov
+Geotrygon chrysia_key west quail-dove_kwqdov
+Geotrygon mystacea_bridled quail-dove_brqdov1
+Leptotrygon veraguensis_olive-backed quail-dove_obqdov1
+Leptotila verreauxi_juriti-pupu_whtdov
+Leptotila verreauxi [verreauxi Group]_juriti-pupu [grupo verreauxi]_whtdov1
+Leptotila verreauxi decolor_juriti-pupu (decolor)_whtdov2
+Leptotila verreauxi [brasiliensis Group]_juriti-pupu [grupo brasiliensis]_whtdov3
+Leptotila jamaicensis_caribbean dove_cardov1
+Leptotila cassinii_gray-chested dove_grcdov1
+Leptotila cassinii cerviniventris_gray-chested dove (cerviniventris)_gycdov3
+Leptotila cassinii rufinucha_gray-chested dove (rufinucha)_gycdov2
+Leptotila cassinii cassinii_gray-chested dove (cassinii)_gycdov1
+Leptotila conoveri_tolima dove_toldov1
+Leptotila ochraceiventris_ochre-bellied dove_ocbdov1
+Leptotila plumbeiceps_gray-headed dove_gyhdov1
+Leptotila plumbeiceps plumbeiceps/notia_gray-headed dove (Gray-headed)_gyhdov2
+Leptotila plumbeiceps battyi/malae_gray-headed dove (Brown-backed)_gyhdov3
+Leptotila rufaxilla_juriti-de-testa-branca_grfdov1
+Leptotila wellsi_grenada dove_gredov1
+Leptotila pallida_pallid dove_paldov1
+Leptotila megalura_large-tailed dove_latdov1
+Leptotila sp._leptotila sp. (juriti)_leptot1
+Zentrygon carrikeri_tuxtla quail-dove_tuqdov1
+Zentrygon costaricensis_buff-fronted quail-dove_bfqdov1
+Zentrygon lawrencii_purplish-backed quail-dove_pbqdov1
+Zentrygon albifacies_white-faced quail-dove_wfqdov1
+Zentrygon frenata_white-throated quail-dove_wtqdov1
+Zentrygon linearis_lined quail-dove_liqdov1
+Zentrygon linearis linearis_lined quail-dove (linearis)_linqud1
+Zentrygon linearis trinitatis_lined quail-dove (trinitatis)_linqud2
+Zentrygon chiriquensis_chiriqui quail-dove_chqdov1
+Zentrygon goldmani_russet-crowned quail-dove_rcqdov1
+Geotrygon/Leptotrygon/Zentrygon sp._quail-dove sp._geotry1
+Zenaida meloda_west peruvian dove_wepdov1
+Zenaida asiatica_white-winged dove_whwdov
+Zenaida aurita_zenaida dove_zendov
+Zenaida galapagoensis_galapagos dove_galdov1
+Zenaida auriculata_avoante_eardov1
+Zenaida macroura_rola-carpideira_moudov
+Streptopelia decaocto x Zenaida macroura_rola-de-colar x rola-carpideira (híbrido)_x00767
+Zenaida asiatica x macroura_white-winged x mourning dove (hybrid)_x01086
+Zenaida aurita/macroura_zenaida/mourning dove_y01207
+Zenaida auriculata/macroura_eared/mourning dove_y01326
+Zenaida graysoni_socorro dove_socdov1
+Caloenas nicobarica_nicobar pigeon_nicpig1
+Caloenas maculata_spotted green pigeon_spgpig1
+Raphus cucullatus_dodo_dodo1
+Pezophaps solitaria_rodrigues solitaire_rodsol2
+Gallicolumba tristigmata_sulawesi ground dove_sugdov1
+Gallicolumba rufigula_cinnamon ground dove_cigdov2
+Gallicolumba platenae_mindoro bleeding-heart_mibhea2
+Gallicolumba keayi_negros bleeding-heart_nebhea1
+Gallicolumba menagei_sulu bleeding-heart_subhea1
+Gallicolumba luzonica_luzon bleeding-heart_lubhea1
+Gallicolumba crinigera_mindanao bleeding-heart_minblh1
+Microgoura meeki_choiseul pigeon_chopig1
+Trugon terrestris_thick-billed ground-pigeon_tbgpig2
+Otidiphaps nobilis_pheasant pigeon_phepig1
+Otidiphaps nobilis nobilis_pheasant pigeon (Green-naped)_phepig2
+Otidiphaps nobilis aruensis_pheasant pigeon (White-naped)_phepig3
+Otidiphaps nobilis cervicalis_pheasant pigeon (Gray-naped)_phepig4
+Otidiphaps nobilis insularis_pheasant pigeon (Black-naped)_phepig5
+Goura cristata_western crowned-pigeon_wecpig1
+Goura sclaterii_sclater's crowned-pigeon_soucrp1
+Goura scheepmakeri_scheepmaker's crowned-pigeon_soucrp2
+Goura victoria_victoria crowned-pigeon_vicpig1
+Goura sp._crowned-pigeon sp._crowne1
+Didunculus strigirostris_tooth-billed pigeon_tobpig1
+Phapitreron leucotis_white-eared brown-dove_whedov1
+Phapitreron leucotis leucotis_white-eared brown-dove (White-eared)_whebrd1
+Phapitreron leucotis nigrorum_white-eared brown-dove (Buff-eared)_whebrd2
+Phapitreron leucotis brevirostris/occipitalis_white-eared brown-dove (Short-billed)_whebrd3
+Phapitreron amethystinus_amethyst brown-dove_amedov1
+Phapitreron amethystinus amethystinus/imeldae_amethyst brown-dove (Amethyst)_amebrd1
+Phapitreron amethystinus maculipectus_amethyst brown-dove (Gray-breasted)_amebrd2
+Phapitreron amethystinus frontalis_amethyst brown-dove (Cebu)_amebrd3
+Phapitreron brunneiceps_mindanao brown-dove_daedov2
+Phapitreron cinereiceps_tawitawi brown-dove_daedov3
+Phapitreron sp._brown-dove sp._brownd1
+Treron olax_little green-pigeon_ligpig1
+Treron vernans_pink-necked green-pigeon_pinpig3
+Treron fulvicollis_cinnamon-headed green-pigeon_cihpig1
+Treron bicinctus_orange-breasted green-pigeon_orbpig1
+Treron pompadora_sri lanka green-pigeon_pogpig1
+Treron affinis_gray-fronted green-pigeon_pomgrp2
+Treron chloropterus_andaman green-pigeon_pomgrp4
+Treron phayrei_ashy-headed green-pigeon_pomgrp5
+Treron axillaris_philippine green-pigeon_pomgrp1
+Treron aromaticus_buru green-pigeon_pomgrp3
+Treron curvirostra_thick-billed green-pigeon_thbpig1
+Treron curvirostra [curvirostra Group]_thick-billed green-pigeon (Thick-billed)_thbpig3
+Treron curvirostra hypothapsinus/smicrus_thick-billed green-pigeon (Barusan)_thbpig2
+Treron griseicauda_gray-cheeked green-pigeon_gycpig1
+Treron teysmannii_sumba green-pigeon_sugpig2
+Treron floris_flores green-pigeon_flgpig1
+Treron psittaceus_pombo-verde-de-timor_timgrp1
+Treron capellei_large green-pigeon_lagpig1
+Treron phoenicopterus_yellow-footed green-pigeon_yefpig1
+Treron phoenicopterus chlorigaster/phillipsi_yellow-footed green-pigeon (Yellow-bellied)_yefgrp6
+Treron phoenicopterus [phoenicopterus Group]_yellow-footed green-pigeon (Gray-bellied)_yefgrp7
+Treron waalia_pomba-verde-amarela_brgpig1
+Treron griveaudi_comoro green-pigeon_madgrp2
+Treron australis_madagascar green-pigeon_madgrp1
+Treron pembaensis_pemba green-pigeon_pegpig1
+Treron sanctithomae_sao tome green-pigeon_stgpig1
+Treron seimundi_yellow-vented green-pigeon_yevpig1
+Treron apicauda_pin-tailed green-pigeon_pitpig1
+Treron calvus_pombo-verde-africano_afrgrp1
+Treron calvus [calvus Group]_pombo-verde-africano [grupo calvus]_afrgrp2
+Treron calvus delalandii/granti_pombo-verde-africano (delalandii/granti)_afrgrp3
+Treron oxyurus_sumatran green-pigeon_gnspig1
+Treron sphenurus_wedge-tailed green-pigeon_wetpig1
+Treron sieboldii_white-bellied green-pigeon_whbpig1
+Treron formosae_whistling green-pigeon_whgpig1
+Treron formosae permagnus/medioximus_whistling green-pigeon (Ryukyu)_whigrp1
+Treron formosae formosae/filipinus_whistling green-pigeon (Taiwan)_whigrp2
+Treron sp._green-pigeon sp._treron1
+Ptilinopus cinctus_pombo-frugívoro-de-dorso-negro_bbfdov1
+Ptilinopus alligator_black-banded fruit-dove_bbfdov2
+Ptilinopus dohertyi_red-naped fruit-dove_rnfdov1
+Ptilinopus porphyreus_pink-headed fruit-dove_phfdov1
+Ptilinopus occipitalis_yellow-breasted fruit-dove_ybfdov2
+Ptilinopus marchei_flame-breasted fruit-dove_fbfdov1
+Ptilinopus merrilli_cream-breasted fruit-dove_crbfrd1
+Ptilinopus fischeri_red-eared fruit-dove_refdov1
+Ptilinopus fischeri fischeri/centralis_red-eared fruit-dove (Red-eared)_reefrd1
+Ptilinopus fischeri meridionalis_red-eared fruit-dove (Lompobattang)_reefrd2
+Ptilinopus jambu_jambu fruit-dove_jafdov1
+Ptilinopus epius_maroon-chinned fruit-dove_macfrd1
+Ptilinopus subgularis_banggai fruit-dove_macfrd3
+Ptilinopus mangoliensis_sula fruit-dove_macfrd2
+Ptilinopus leclancheri_black-chinned fruit-dove_bcfdov1
+Ptilinopus bernsteinii_scarlet-breasted fruit-dove_sbfdov1
+Ptilinopus magnificus_wompoo fruit-dove_wofdov1
+Ptilinopus perlatus_pink-spotted fruit-dove_psfdov1
+Ptilinopus ornatus_ornate fruit-dove_orfdov1
+Ptilinopus ornatus ornatus_ornate fruit-dove (Western)_ornfrd1
+Ptilinopus ornatus gestroi_ornate fruit-dove (Eastern)_ornfrd2
+Ptilinopus tannensis_tanna fruit-dove_tafdov1
+Ptilinopus aurantiifrons_orange-fronted fruit-dove_offdov1
+Ptilinopus wallacii_wallace's fruit-dove_wafdov1
+Ptilinopus superbus_superb fruit-dove_sufdov1
+Ptilinopus superbus temminckii_superb fruit-dove (Western)_supfrd1
+Ptilinopus superbus superbus_superb fruit-dove (Eastern)_supfrd2
+Ptilinopus perousii_many-colored fruit-dove_mcfdov1
+Ptilinopus ponapensis_purple-capped fruit-dove_pucfrd1
+Ptilinopus hernsheimi_kosrae fruit-dove_kosfrd1
+Ptilinopus porphyraceus_crimson-crowned fruit-dove_ccfdov1
+Ptilinopus porphyraceus porphyraceus_crimson-crowned fruit-dove (Tongan)_crcfrd1
+Ptilinopus porphyraceus fasciatus_crimson-crowned fruit-dove (Samoan)_crcfrd2
+Ptilinopus pelewensis_palau fruit-dove_pafdov1
+Ptilinopus rarotongensis_cook islands fruit-dove_cifdov1
+Ptilinopus roseicapilla_mariana fruit-dove_mafdov2
+Ptilinopus regina_pombo-frugívoro-de-coroa-rosada_rcfdov1
+Ptilinopus regina xanthogaster/roseipileum_pombo-frugívoro-de-coroa-rosada (xanthogaster/roseipileum)_rocfrd6
+Ptilinopus regina [regina Group]_pombo-frugívoro-de-coroa-rosada (Grupo regina)_rocfrd7
+Ptilinopus richardsii_silver-capped fruit-dove_scfdov1
+Ptilinopus chrysogaster_raiatea fruit-dove_gygfrd2
+Ptilinopus purpuratus_gray-green fruit-dove_gygfrd1
+Ptilinopus chalcurus_makatea fruit-dove_mafdov1
+Ptilinopus coralensis_atoll fruit-dove_atfdov1
+Ptilinopus greyi_red-bellied fruit-dove_rbfdov1
+Ptilinopus huttoni_rapa fruit-dove_rafdov1
+Ptilinopus dupetithouarsii_white-capped fruit-dove_wcfdov1
+Ptilinopus mercierii_red-moustached fruit-dove_rmfdov1
+Ptilinopus insularis_henderson island fruit-dove_hifdov1
+Ptilinopus coronulatus_coroneted fruit-dove_cofdov1
+Ptilinopus pulchellus_beautiful fruit-dove_befdov1
+Ptilinopus monacha_blue-capped fruit-dove_bcfdov2
+Ptilinopus rivoli_white-breasted fruit-dove_whbfrd1
+Ptilinopus rivoli prasinorrhous_white-breasted fruit-dove (Moluccan)_whbfrd2
+Ptilinopus rivoli bellus_white-breasted fruit-dove (Mountain)_whbfrd3
+Ptilinopus rivoli [rivoli Group]_white-breasted fruit-dove (White-bibbed)_whbfrd7
+Ptilinopus speciosus_geelvink fruit-dove_yebfrd1
+Ptilinopus solomonensis_yellow-bibbed fruit-dove_yebfrd2
+Ptilinopus viridis_claret-breasted fruit-dove_cbfdov1
+Ptilinopus eugeniae_white-headed fruit-dove_whfdov2
+Ptilinopus iozonus_orange-bellied fruit-dove_obfdov1
+Ptilinopus insolitus_knob-billed fruit-dove_kbfdov1
+Ptilinopus hyogastrus_gray-headed fruit-dove_gyhfrd1
+Ptilinopus granulifrons_carunculated fruit-dove_cafdov1
+Ptilinopus melanospilus_black-naped fruit-dove_bknfrd1
+Ptilinopus nainus_dwarf fruit-dove_dwafrd1
+Ptilinopus arcanus_negros fruit-dove_nefdov1
+Ptilinopus victor_orange dove_oradov1
+Ptilinopus luteovirens_golden dove_goldov1
+Ptilinopus layardi_whistling dove_veldov1
+Ptilinopus [undescribed form]_manui fruit-dove (undescribed form)_manfrd1
+Ptilinopus sp._fruit-dove sp._fruitd1
+Drepanoptila holosericea_cloven-feathered dove_clfdov1
+Alectroenas nitidissimus_mauritius blue-pigeon_mabpig2
+Alectroenas payandeei_rodrigues blue-pigeon_rodblp1
+Alectroenas madagascariensis_madagascar blue-pigeon_mabpig1
+Alectroenas sganzini_comoro blue-pigeon_cobpig1
+Alectroenas pulcherrimus_seychelles blue-pigeon_sebpig1
+Ducula poliocephala_pink-bellied imperial-pigeon_pbipig1
+Ducula forsteni_white-bellied imperial-pigeon_wbipig1
+Ducula mindorensis_mindoro imperial-pigeon_miipig2
+Ducula radiata_gray-headed imperial-pigeon_gyhimp1
+Ducula carola_spotted imperial-pigeon_spipig3
+Ducula aenea_green imperial-pigeon_gripig1
+Ducula aenea [aenea Group]_green imperial-pigeon (Green)_grnimp1
+Ducula aenea nuchalis_green imperial-pigeon (Maroon-naped)_grnimp3
+Ducula aenea paulina_green imperial-pigeon (Rufous-naped)_grnimp4
+Ducula oenothorax_enggano imperial-pigeon_grnimp5
+Ducula nicobarica_nicobar imperial-pigeon_grnimp2
+Ducula perspicillata_spectacled imperial-pigeon_wheimp2
+Ducula neglecta_seram imperial-pigeon_wheimp1
+Ducula concinna_elegant imperial-pigeon_elipig1
+Ducula pacifica_pacific imperial-pigeon_paipig1
+Ducula rubricera_red-knobbed imperial-pigeon_rkipig1
+Ducula rubricera rubricera_red-knobbed imperial-pigeon (Pink-necked)_rekimp1
+Ducula rubricera rufigula_red-knobbed imperial-pigeon (Gray-necked)_rekimp2
+Ducula oceanica_micronesian imperial-pigeon_miipig1
+Ducula aurorae_polynesian imperial-pigeon_poipig1
+Ducula galeata_nuku hiva imperial-pigeon_marimp1
+Ducula myristicivora_spice imperial-pigeon_spipig1
+Ducula geelvinkiana_geelvink imperial-pigeon_spiimp2
+Ducula rufigaster_purple-tailed imperial-pigeon_ptipig1
+Ducula basilica_cinnamon-bellied imperial-pigeon_cbipig2
+Ducula basilica basilica_cinnamon-bellied imperial-pigeon (Gray-naped)_cibimp1
+Ducula basilica obiensis_cinnamon-bellied imperial-pigeon (Golden-naped)_cibimp2
+Ducula finschii_finsch's imperial-pigeon_fiipig1
+Ducula chalconota_rufescent imperial-pigeon_rufimp1
+Ducula chalconota chalconota_rufescent imperial-pigeon (Purple-rumped)_rufimp2
+Ducula chalconota smaragdina_rufescent imperial-pigeon (Green-rumped)_rufimp3
+Ducula pistrinaria_island imperial-pigeon_isipig1
+Ducula rosacea_pombo-imperial-de-cabeça-rosada_phipig1
+Ducula whartoni_christmas island imperial-pigeon_ciipig1
+Ducula pickeringii_gray imperial-pigeon_gryimp1
+Ducula latrans_barking imperial-pigeon_peipig1
+Columba vitiensis/Ducula latrans_metallic pigeon/barking imperial-pigeon_y01277
+Ducula brenchleyi_chestnut-bellied imperial-pigeon_cbipig1
+Ducula bakeri_baker's imperial-pigeon_baipig1
+Ducula goliath_new caledonian imperial-pigeon_ncipig1
+Ducula pinon_pinon's imperial-pigeon_piipig2
+Ducula pinon pinon/jobiensis_pinon's imperial-pigeon (Gray-headed)_pinimp1
+Ducula pinon salvadorii_pinon's imperial-pigeon (Pink-headed)_pinimp2
+Ducula melanochroa_bismarck imperial-pigeon_biipig1
+Ducula mullerii_collared imperial-pigeon_coipig1
+Ducula zoeae_zoe's imperial-pigeon_zoeimp1
+Ducula cuprea_malabar imperial-pigeon_mouimp1
+Ducula badia_mountain imperial-pigeon_moipig1
+Ducula lacernulata_dark-backed imperial-pigeon_dbipig1
+Ducula lacernulata lacernulata_dark-backed imperial-pigeon (Gray-headed)_dabimp1
+Ducula lacernulata williami_dark-backed imperial-pigeon (Pink-headed)_dabimp2
+Ducula lacernulata sasakensis_dark-backed imperial-pigeon (Gray-crowned)_dabimp3
+Ducula cineracea_pombo-imperial-de-timor_tiipig1
+Ducula bicolor_pombo-imperial-preto-e-branco_piipig1
+Ducula subflavescens_yellowish imperial-pigeon_torimp2
+Ducula spilorrhoa_torresian imperial-pigeon_torimp1
+Ducula luctuosa_silver-tipped imperial-pigeon_whiimp1
+Ducula sp._imperial-pigeon sp._imperi1
+Lopholaimus antarcticus_topknot pigeon_toppig1
+Hemiphaga novaeseelandiae_new zealand pigeon_nezpig2
+Hemiphaga novaeseelandiae spadicea_new zealand pigeon (Norfolk I.)_noipig1
+Hemiphaga novaeseelandiae novaeseelandiae_new zealand pigeon (New Zealand)_nezpig1
+Hemiphaga chathamensis_chatham islands pigeon_nezpig3
+Cryptophaps poecilorrhoa_sombre pigeon_sompig2
+Gymnophaps albertisii_papuan mountain-pigeon_pampig2
+Gymnophaps mada_buru mountain-pigeon_lotmop1
+Gymnophaps stalkeri_seram mountain-pigeon_lotmop2
+Gymnophaps solomonensis_pale mountain-pigeon_pampig1
+Columbidae sp._Columbidae sp._dove1
+Mesitornis variegatus_white-breasted mesite_whbmes2
+Mesitornis unicolor_brown mesite_bromes1
+Monias benschi_subdesert mesite_submes1
+Syrrhaptes tibetanus_tibetan sandgrouse_tibsan1
+Syrrhaptes paradoxus_ganga-das-estepes_palsan1
+Pterocles alchata_ganga_pitsan1
+Pterocles alchata alchata_ganga (alchata)_pitsan2
+Pterocles alchata caudacutus_ganga (caudacutus)_pitsan3
+Pterocles namaqua_namaqua sandgrouse_namsan1
+Pterocles exustus_ganga-castanha_chbsan
+Pterocles exustus [exustus Group]_ganga-castanha [grupo exustus]_chbsan1
+Pterocles exustus erlangeri_ganga-castanha (erlangeri)_chbsan2
+Pterocles exustus hindustan_ganga-castanha (hindustan)_chbsan3
+Pterocles senegallus_ganga-malhada_sposan1
+Pterocles orientalis_cortiçol-de-barriga-preta_blbsan1
+Pterocles gutturalis_yellow-throated sandgrouse_yetsan1
+Pterocles coronatus_cortiçol-coroado_crosan1
+Pterocles decoratus_black-faced sandgrouse_blfsan1
+Pterocles personatus_madagascar sandgrouse_madsan1
+Pterocles lichtensteinii_cortiçol-pedrês_licsan1
+Pterocles lichtensteinii [lichtensteinii Group]_cortiçol-pedrês [grupo lichtensteinii]_licsan2
+Pterocles lichtensteinii arabicus_cortiçol-pedrês (arabicus)_licsan3
+Pterocles bicinctus_double-banded sandgrouse_dobsan1
+Pterocles quadricinctus_cortiçol-dourado_fobsan1
+Pterocles indicus_painted sandgrouse_paisan1
+Pterocles burchelli_burchell's sandgrouse_bursan1
+Pterocles sp._cortiçol (Pterocles) sp._sandgr1
+Otis tarda_abetarda_grebus1
+Ardeotis arabs_abetarda-do-sara_arabus1
+Ardeotis kori_kori bustard_korbus1
+Ardeotis nigriceps_great indian bustard_indbus1
+Ardeotis australis_australian bustard_ausbus1
+Chlamydotis undulata_hubara_houbus1
+Chlamydotis undulata fuertaventurae_hubara (fuertaventurae)_houbus2
+Chlamydotis undulata undulata_hubara (undulata)_houbus3
+Chlamydotis macqueenii_abetarda-de-macqueen_macbus1
+Neotis ludwigii_ludwig's bustard_ludbus1
+Neotis denhami_abetarda-real_stabus1
+Neotis denhami denhami_abetarda-real (denhami)_denbus1
+Neotis denhami jacksoni_abetarda-real (jacksoni)_denbus2
+Neotis denhami stanleyi_abetarda-real (stanleyi)_denbus3
+Neotis heuglinii_heuglin's bustard_heubus1
+Neotis nuba_nubian bustard_nubbus1
+Eupodotis senegalensis_white-bellied bustard_whbbus2
+Eupodotis senegalensis [senegalensis Group]_white-bellied bustard (White-bellied)_whbbus1
+Eupodotis senegalensis barrowii/mackenziei_white-bellied bustard (Barrow's)_whbbus3
+Eupodotis caerulescens_blue bustard_blubus1
+Heterotetrax vigorsii_karoo bustard_karbus1
+Heterotetrax rueppelii_rüppell's bustard_ruebus1
+Heterotetrax humilis_little brown bustard_libbus1
+Lophotis savilei_savile's bustard_savbus1
+Lophotis gindiana_buff-crested bustard_bucbus1
+Lophotis ruficrista_red-crested bustard_recbus1
+Afrotis afra_black bustard_blabus3
+Afrotis afraoides_white-quilled bustard_whqbus1
+Lissotis melanogaster_abetarda-de-barriga-preta_bkbbus1
+Lissotis hartlaubii_hartlaub's bustard_harbus2
+Houbaropsis bengalensis_bengal florican_benflo2
+Sypheotides indicus_lesser florican_lesflo2
+Tetrax tetrax_sisão_litbus1
+Otididae sp._abetarda sp._bustar1
+Corythaeola cristata_andua-gigante_grbtur1
+Crinifer concolor_gray go-away-bird_grygab1
+Crinifer personatus_bare-faced go-away-bird_bfgbir1
+Crinifer personatus personatus_bare-faced go-away-bird (Brown-faced)_bafgab1
+Crinifer personatus leopoldi_bare-faced go-away-bird (Black-faced)_bafgab2
+Crinifer leucogaster_white-bellied go-away-bird_wbgbir1
+Crinifer piscator_pavão-cinzento_wesple1
+Crinifer zonurus_eastern plantain-eater_easple1
+Gallirex johnstoni_rwenzori turaco_ruwtur2
+Gallirex johnstoni johnstoni_rwenzori turaco (Rwenzori)_ruwtur1
+Gallirex johnstoni bredoi_rwenzori turaco (Mt. Kabobo)_ruwtur3
+Gallirex johnstoni kivuensis_rwenzori turaco (Kivu)_ruwtur4
+Gallirex porphyreolophus_purple-crested turaco_puctur2
+Menelikornis leucotis_white-cheeked turaco_whctur1
+Menelikornis leucotis leucotis_white-cheeked turaco (White-cheeked)_whctur3
+Menelikornis leucotis donaldsoni_white-cheeked turaco (Donaldson's)_whctur4
+Menelikornis ruspolii_prince ruspoli's turaco_prrtur1
+Menelikornis leucotis x ruspolii_white-cheeked x prince ruspoli's turaco (hybrid)_x00800
+Tauraco violaceus_pavão-azul_viotur1
+Tauraco rossae_ross's turaco_rostur1
+Tauraco macrorhynchus_yellow-billed turaco_yebtur1
+Tauraco macrorhynchus macrorhynchus_yellow-billed turaco (Yellow-billed)_yebtur2
+Tauraco macrorhynchus verreauxii_yellow-billed turaco (Verreaux's)_yebtur3
+Tauraco bannermani_bannerman's turaco_bantur1
+Tauraco leucolophus_white-crested turaco_whctur2
+Tauraco schuettii_black-billed turaco_blbtur1
+Tauraco schuettii emini_black-billed turaco (Green-rumped)_bkbtur1
+Tauraco schuettii schuettii_black-billed turaco (Black-rumped)_bkbtur2
+Tauraco schalowi_schalow's turaco_schtur1
+Tauraco erythrolophus_red-crested turaco_rectur1
+Tauraco persa_andua-da-guiné_guitur1
+Tauraco persa buffoni_andua-da-guiné (buffoni)_guitur2
+Tauraco persa persa/zenkeri_andua-da-guiné (persa/zenkeri)_guitur3
+Tauraco hartlaubi_hartlaub's turaco_hartur1
+Tauraco fischeri_fischer's turaco_fistur1
+Tauraco fischeri fischeri_fischer's turaco (Fischer's)_fistur2
+Tauraco fischeri zanzibaricus_fischer's turaco (Zanzibar)_fistur3
+Tauraco livingstonii_livingstone's turaco_livtur1
+Tauraco corythaix_knysna turaco_knytur1
+Tauraco corythaix phoebus_knysna turaco (Northern)_knytur2
+Tauraco corythaix corythaix_knysna turaco (Southern)_knytur3
+Tauraco sp._Tauraco sp._taurac1
+Musophagidae sp._turaco sp._turaco1
+Guira guira_anu-branco_guicuc1
+Crotophaga major_anu-coroca_greani1
+Crotophaga ani_anu-preto_smbani
+Crotophaga sulcirostris_groove-billed ani_grbani
+Crotophaga ani/sulcirostris_smooth-billed/groove-billed ani_y00498
+Tapera naevia_saci_strcuc1
+Dromococcyx phasianellus_peixe-frito_phecuc1
+Dromococcyx pavoninus_peixe-frito-pavonino_pavcuc1
+Morococcyx erythropygus_lesser ground-cuckoo_legcuc1
+Geococcyx velox_lesser roadrunner_lesroa1
+Geococcyx californianus_greater roadrunner_greroa
+Geococcyx velox/californianus_lesser/greater roadrunner_y00957
+Neomorphus geoffroyi_jacu-estalo_rvgcuc1
+Neomorphus squamiger_jacu-estalo-escamoso_scgcuc1
+Neomorphus radiolosus_banded ground-cuckoo_bagcuc1
+Neomorphus rufipennis_jacu-estalo-de-asa-vermelha_rwgcuc1
+Neomorphus pucheranii_jacu-estalo-de-bico-vermelho_rbgcuc1
+Carpococcyx viridis_sumatran ground-cuckoo_sugcuc1
+Carpococcyx radiceus_bornean ground-cuckoo_bogcuc1
+Carpococcyx renauldi_coral-billed ground-cuckoo_cbgcuc1
+Coua cristata_crested coua_crecou1
+Coua cristata cristata/dumonti_crested coua (Crested)_crecou2
+Coua cristata pyropyga/maxima_crested coua (Chestnut-vented)_crecou7
+Coua verreauxi_verreaux's coua_vercou1
+Coua caerulea_blue coua_blucou1
+Coua ruficeps_red-capped coua_reccou2
+Coua olivaceiceps_olive-capped coua_reccou3
+Coua reynaudii_red-fronted coua_refcou1
+Coua coquereli_coquerel's coua_coqcou1
+Coua cursor_running coua_runcou1
+Coua gigas_giant coua_giacou1
+Coua delalandei_snail-eating coua_snecou1
+Coua serriana_red-breasted coua_rebcou1
+Coua sp._coua sp._coua1
+Centropus milo_buff-headed coucal_buhcou1
+Centropus ateralbus_pied coucal_piecou1
+Centropus chalybeus_biak coucal_biacou1
+Centropus menbeki_greater black coucal_grbcou1
+Centropus unirufus_rufous coucal_rufcou1
+Centropus chlororhynchos_green-billed coucal_grbcou2
+Centropus melanops_black-faced coucal_blfcou1
+Centropus rectunguis_short-toed coucal_shtcou1
+Centropus steerii_black-hooded coucal_blhcou1
+Centropus celebensis_bay coucal_baycou1
+Centropus anselli_gabon coucal_gabcou1
+Centropus leucogaster_cuco-de-garganta-preta_bltcou1
+Centropus senegalensis_pássaro-governo_sencou1
+Centropus monachus_blue-headed coucal_blhcou2
+Centropus cupreicaudus_coppery-tailed coucal_cotcou1
+Centropus superciliosus_white-browed coucal_whbcou2
+Centropus burchellii_burchell's coucal_whbcou3
+Centropus superciliosus x burchellii_white-browed x burchell's coucal (hybrid)_x01122
+Centropus superciliosus/burchellii_white-browed/burchell's coucal_whbcou1
+Centropus nigrorufus_sunda coucal_suncou1
+Centropus andamanensis_andaman coucal_andcou1
+Centropus sinensis_greater coucal_grecou1
+Centropus sinensis [sinensis Group]_greater coucal (Greater)_grecou2
+Centropus sinensis parroti_greater coucal (Southern)_grecou3
+Centropus goliath_goliath coucal_golcou1
+Centropus toulou_malagasy coucal_madcou1
+Centropus grillii_cuco-de-barriga-preta_blacou1
+Centropus viridis_philippine coucal_phicou1
+Centropus bengalensis_cucal-bengali_lescou1
+Centropus sinensis/bengalensis_greater/lesser coucal_y01087
+Centropus violaceus_violaceous coucal_viocou1
+Centropus bernsteini_lesser black coucal_lebcou1
+Centropus phasianinus_pheasant coucal_phecou2
+Centropus phasianinus mui_pheasant coucal (Timor)_phecou3
+Centropus phasianinus spilopterus_pheasant coucal (Kai)_kaicou1
+Centropus phasianinus [phasianinus Group]_pheasant coucal (Pheasant)_phecou1
+Centropus sp._cuco (Centropus) sp._coucal1
+Rhinortha chlorophaea_raffles's malkoha_rafmal1
+Ceuthmochares aereus_cuco-de-bico-amarelo_yellow5
+Ceuthmochares australis_green malkoha_yellow6
+Taccocua leschenaultii_sirkeer malkoha_sirmal1
+Zanclostomus javanicus_red-billed malkoha_rebmal2
+Phaenicophaeus curvirostris_chestnut-breasted malkoha_chbmal2
+Phaenicophaeus oeneicaudus_mentawai malkoha_chbmal3
+Phaenicophaeus sumatranus_chestnut-bellied malkoha_chbmal1
+Phaenicophaeus pyrrhocephalus_red-faced malkoha_refmal1
+Phaenicophaeus viridirostris_blue-faced malkoha_blfmal1
+Phaenicophaeus diardi_black-bellied malkoha_blbmal1
+Phaenicophaeus tristis_green-billed malkoha_grbmal1
+Rhamphococcyx calyorhynchus_yellow-billed malkoha_yebmal1
+Dasylophus superciliosus_red-crested malkoha_recmal1
+Dasylophus cumingi_scale-feathered malkoha_scfmal1
+Cuculidae sp. (malkoha sp.)_malkoha sp._malkoh1
+Clamator coromandus_chestnut-winged cuckoo_chwcuc1
+Clamator glandarius_cuco-rabilongo_grscuc1
+Clamator levaillantii_cuco-de-levaillant_levcuc1
+Clamator jacobinus_cuco-jacobino_piecuc1
+Coccycua minuta_chincoã-pequeno_litcuc2
+Coccycua pumila_papa-lagarta-de-papo-ferrugem_dwacuc1
+Coccycua cinerea_papa-lagarta-cinzento_asccuc1
+Piaya cayana_alma-de-gato_squcuc1
+Piaya cayana mexicana_alma-de-gato (mexicana)_squcuc2
+Piaya cayana thermophila_alma-de-gato (thermophila)_squcuc3
+Piaya cayana nigricrissa_alma-de-gato (nigricrissa)_squcuc5
+Piaya cayana [cayana Group]_alma-de-gato [grupo cayana]_squcuc4
+Piaya melanogaster_chincoã-de-bico-vermelho_blbcuc1
+Piaya cayana/melanogaster_alma-de-gato/chincoã-de-bico-vermelho_y00857
+Coccyzus melacoryphus_papa-lagarta-acanelado_dabcuc1
+Coccyzus americanus_papa-lagarta-de-asa-vermelha_yebcuc
+Coccyzus euleri_papa-lagarta-de-euler_pebcuc1
+Coccyzus americanus/euleri_papa-lagarta-de-asa-vermelha/de-euler_y00958
+Coccyzus minor_papa-lagarta-do-mangue_mancuc
+Coccyzus ferrugineus_cocos cuckoo_coccuc1
+Coccyzus erythropthalmus_papa-lagarta-de-bico-preto_bkbcuc
+Coccyzus americanus/erythropthalmus_papa-lagarta-de-asa-vermelha/de-bico-preto_y00616
+Coccyzus lansbergi_gray-capped cuckoo_gyccuc
+Coccyzus pluvialis_chestnut-bellied cuckoo_chbcuc4
+Coccyzus rufigularis_bay-breasted cuckoo_babcuc4
+Coccyzus vetula_jamaican lizard-cuckoo_jamlic1
+Coccyzus vieilloti_puerto rican lizard-cuckoo_purlic1
+Coccyzus merlini_great lizard-cuckoo_grelic1
+Coccyzus merlini bahamensis_great lizard-cuckoo (Bahamas)_grelic2
+Coccyzus merlini [merlini Group]_great lizard-cuckoo (Cuban)_grelic3
+Coccyzus longirostris_hispaniolan lizard-cuckoo_hislic1
+Coccyzus sp._coccyzus sp. (papa-lagarta)_coccyz1
+Nannococcyx psix_st. helena cuckoo_sthcuc1
+Pachycoccyx audeberti_thick-billed cuckoo_thbcuc1
+Pachycoccyx audeberti validus/brazzae_thick-billed cuckoo (African)_thbcuc2
+Pachycoccyx audeberti audeberti_thick-billed cuckoo (Madagascar)_thbcuc3
+Microdynamis parva_dwarf koel_dwakoe1
+Eudynamys scolopaceus_asian koel_asikoe2
+Eudynamys melanorhynchus_black-billed koel_bkbkoe1
+Eudynamys orientalis_pacific koel_asikoe3
+Eudynamys orientalis [orientalis Group]_pacific koel (Oriental)_packoe1
+Eudynamys orientalis cyanocephalus/subcyanocephalus_pacific koel (Australian)_packoe2
+Eudynamys sp._Eudynamys sp._eudyna1
+Urodynamis taitensis_long-tailed koel_lotkoe1
+Scythrops novaehollandiae_cuco-tucano_chbcuc2
+Chrysococcyx maculatus_asian emerald cuckoo_asecuc1
+Chrysococcyx xanthorhynchus_violet cuckoo_viocuc1
+Chrysococcyx maculatus/xanthorhynchus_asian emerald/violet cuckoo_y00855
+Chrysococcyx caprius_cuco-bronzeado-grande_didcuc1
+Chrysococcyx klaas_cuco-bronzeado-pequeno_klacuc1
+Chrysococcyx caprius/klaas_cuco-bronzeado-grande/cuco-bronzeado-pequeno_y00856
+Chrysococcyx flavigularis_yellow-throated cuckoo_yetcuc1
+Chrysococcyx cupreus_cuco-esmeraldino_afecuc1
+Chrysococcyx cupreus cupreus_cuco-esmeraldino (cupreus)_afecuc2
+Chrysococcyx cupreus intermedius_cuco-esmeraldino (intermedius)_afecuc3
+Chrysococcyx cupreus insularum_cuco-esmeraldino (insularum)_afecuc4
+Chrysococcyx sp._Chrysococcyx sp._chryso2
+Chrysococcyx/Chalcites sp._Chrysococcyx/Chalcites sp._chryso1
+Chalcites megarhynchus_long-billed cuckoo_lobcuc1
+Chalcites basalis_horsfield's bronze-cuckoo_hobcuc1
+Chalcites osculans_black-eared cuckoo_blecuc1
+Chalcites ruficollis_rufous-throated bronze-cuckoo_rtbcuc1
+Chalcites lucidus_cuco-brilhante_shbcuc1
+Chalcites lucidus harterti_cuco-brilhante (harterti)_shibrc1
+Chalcites lucidus layardi_cuco-brilhante (layardi)_shibrc2
+Chalcites lucidus lucidus_cuco-brilhante (lucidus)_shibrc3
+Chalcites lucidus plagosus_cuco-brilhante (plagosus)_shibrc4
+Chalcites meyerii_white-eared bronze-cuckoo_webcuc1
+Chalcites minutillus_little bronze-cuckoo_libcuc1
+Chalcites minutillus [minutillus Group]_little bronze-cuckoo (Little)_litbrc1
+Chalcites minutillus [poecilurus Group]_little bronze-cuckoo (Gould's)_litbrc2
+Chalcites minutillus rufomerus/salvadorii_little bronze-cuckoo (Banda)_litbrc3
+Chalcites lucidus/minutillus_shining/little bronze-cuckoo_y00854
+Chalcites crassirostris_pied bronze-cuckoo_litbrc5
+Chalcites sp. (bronze-cuckoo sp.)_bronze-cuckoo sp._bronze1
+Chalcites sp._Chalcites sp._chalci1
+Heteroscenes pallidus_cuco-pálido_palcuc1
+Caliechthrus leucolophus_white-crowned cuckoo_whckoe1
+Cacomantis castaneiventris_chestnut-breasted cuckoo_chbcuc3
+Cacomantis flabelliformis_fan-tailed cuckoo_fatcuc1
+Cacomantis flabelliformis [flabelliformis Group]_fan-tailed cuckoo (Sahul)_fatcuc7
+Cacomantis flabelliformis pyrrophanus_fan-tailed cuckoo (New Caledonian)_fatcuc4
+Cacomantis flabelliformis schistaceigularis_fan-tailed cuckoo (Vanuatu)_fatcuc5
+Cacomantis flabelliformis simus_fan-tailed cuckoo (Fiji)_fatcuc6
+Cacomantis castaneiventris/flabelliformis_chestnut-breasted/fan-tailed cuckoo_y01325
+Cacomantis sonneratii_banded bay cuckoo_babcuc2
+Cacomantis merulinus_plaintive cuckoo_placuc1
+Cacomantis passerinus_gray-bellied cuckoo_placuc3
+Cacomantis merulinus/passerinus_plaintive/gray-bellied cuckoo_y00783
+Cacomantis sepulcralis_sunda brush cuckoo_brucuc2
+Cacomantis virescens_sulawesi brush cuckoo_brucuc5
+Cacomantis aeruginosus_moluccan brush cuckoo_molcuc1
+Cacomantis variolosus_sahul brush cuckoo_brucuc3
+Cacomantis sepulcralis/variolosus_cuco-sarapintado (sepulcralis/variolosus)_y01336
+Cacomantis aeruginosus/variolosus_cuco-sarapintado (aeroginosus/variolosus)_y01332
+Cacomantis [undescribed form]_tanimbar brush cuckoo (undescribed form)_brucuc15
+Cacomantis addendus_solomons brush cuckoo_brucuc13
+Cacomantis blandus_manus brush cuckoo_brucuc10
+Cacomantis sp._Cacomantis sp._cacoma1
+Cercococcyx mechowi_dusky long-tailed cuckoo_dltcuc1
+Cercococcyx olivinus_olive long-tailed cuckoo_oltcuc1
+Cercococcyx montanus_barred long-tailed cuckoo_bltcuc1
+Cercococcyx montanus montanus_barred long-tailed cuckoo (Njombo's)_bltcuc2
+Cercococcyx montanus patulus_barred long-tailed cuckoo (Eastern)_bltcuc3
+Cercococcyx sp._Cercococcyx sp._cercoc1
+Surniculus dicruroides_fork-tailed drongo-cuckoo_asidrc2
+Surniculus velutinus_philippine drongo-cuckoo_phidrc1
+Surniculus lugubris_square-tailed drongo-cuckoo_asidrc3
+Surniculus dicruroides/lugubris_fork-tailed/square-tailed drongo-cuckoo_y00784
+Surniculus musschenbroeki_moluccan drongo-cuckoo_asidrc4
+Hierococcyx vagans_moustached hawk-cuckoo_mohcuc1
+Hierococcyx sparverioides_large hawk-cuckoo_larhac2
+Hierococcyx bocki_dark hawk-cuckoo_larhac1
+Hierococcyx sparverioides/bocki_large/dark hawk-cuckoo_lahcuc1
+Hierococcyx varius_common hawk-cuckoo_cohcuc1
+Hierococcyx sparverioides/varius_large/common hawk-cuckoo_y01091
+Hierococcyx hyperythrus_northern hawk-cuckoo_nohcuc1
+Hierococcyx pectoralis_philippine hawk-cuckoo_phhcuc1
+Hierococcyx nisicolor_hodgson's hawk-cuckoo_hodhac1
+Hierococcyx fugax_malaysian hawk-cuckoo_malhac1
+Hierococcyx sp._hawk-cuckoo sp._hawkcu1
+Cuculus clamosus_black cuckoo_blacuc1
+Cuculus clamosus gabonensis_black cuckoo (Rufous-throated)_blkcuc1
+Cuculus clamosus clamosus_black cuckoo (Black)_blkcuc2
+Cuculus solitarius_cuco-solitário_reccuc1
+Cuculus poliocephalus_lesser cuckoo_lescuc1
+Cuculus crassirostris_sulawesi cuckoo_suhcuc1
+Cuculus micropterus_indian cuckoo_indcuc1
+Cuculus poliocephalus/micropterus_lesser/indian cuckoo_y01093
+Cuculus gularis_cuco-africano_afrcuc1
+Cuculus rochii_madagascar cuckoo_madcuc1
+Cuculus saturatus_himalayan cuckoo_himcuc1
+Cuculus lepidus_sunda cuckoo_suncuc2
+Cuculus canorus_cuco-canoro_comcuc
+Cuculus gularis/canorus_cuco-africano/cuco-canoro_y00853
+Cuculus optatus_cuco-oriental_oricuc2
+Cuculus poliocephalus/optatus_lesser/oriental cuckoo_y01094
+Cuculus saturatus/optatus_himalayan/oriental cuckoo_y00730
+Cuculus canorus/optatus_cuco-canoro/cuco-oriental_y00729
+Cuculus sp._cuco (Cuculus) sp._cuculu1
+Cuculidae sp._Cuculidae sp._cuckoo3
+Eurostopodus argus_spotted nightjar_sponig1
+Eurostopodus nigripennis_solomons nightjar_solnig1
+Eurostopodus exul_new caledonian nightjar_necnig2
+Eurostopodus mystacalis_white-throated nightjar_whtnig3
+Eurostopodus diabolicus_diabolical nightjar_dianig1
+Eurostopodus papuensis_papuan nightjar_papnig1
+Eurostopodus archboldi_archbold's nightjar_arcnig1
+Lyncornis temminckii_malaysian eared-nightjar_malnig1
+Lyncornis macrotis_great eared-nightjar_grenig1
+Lyncornis macrotis cerviniceps/bourdilloni_great eared-nightjar (Great)_greean6
+Lyncornis macrotis jacobsoni_great eared-nightjar (Simeulue)_greean3
+Lyncornis macrotis macrotis_great eared-nightjar (Philippine)_greean4
+Lyncornis macrotis macropterus_great eared-nightjar (Sulawesi)_greean5
+Gactornis enarratus_collared nightjar_colnig1
+Chordeiles nacunda_corucão_nacnig1
+Chordeiles pusillus_bacurauzinho_leanig1
+Chordeiles rupestris_bacurau-da-praia_sacnig1
+Chordeiles acutipennis_bacurau-de-asa-fina_lesnig
+Chordeiles minor_bacurau-norte-americano_comnig
+Chordeiles gundlachii_bacurau-das-antilhas_antnig
+Chordeiles minor/gundlachii_common/antillean nighthawk_y01174
+Chordeiles sp._Chordeiles sp._nighth1
+Lurocalis semitorquatus_tuju_shtnig1
+Lurocalis semitorquatus [semitorquatus Group]_tuju [grupo semitorquatus]_shtnig2
+Lurocalis semitorquatus nattereri_tuju (nattereri)_shtnig3
+Lurocalis rufiventris_rufous-bellied nighthawk_rubnig1
+Nyctiprogne leucopyga_bacurau-de-cauda-barrada_batnig1
+Nyctiprogne leucopyga [leucopyga Group]_bacurau-de-cauda-barrada [grupo leucopyga]_batnig3
+Nyctiprogne leucopyga latifascia_bacurau-da-venezuela_batnig4
+Nyctiprogne vielliardi_bacurau-do-são-francisco_bahnig1
+Nyctipolus nigrescens_bacurau-de-lajeado_blanig1
+Nyctipolus hirundinaceus_bacurauzinho-da-caatinga_pygnig1
+Nyctidromus albicollis_bacurau_compau
+Nyctidromus anthonyi_scrub nightjar_scrnig1
+Tepuiornis whitelyi_bacurau-dos-tepuis_rornig1
+Uropsalis segmentata_swallow-tailed nightjar_swtnig1
+Uropsalis lyra_lyre-tailed nightjar_lytnig1
+Quechuavis decussata_tschudi's nightjar_bawnig3
+Setopagis heterura_bacurau-chintã-do-norte_samnig1
+Setopagis parvula_bacurau-chintã_litnig1
+Setopagis maculosa_cayenne nightjar_caynig1
+Antiurus maculicaudus_bacurau-de-rabo-maculado_sptnig1
+Systellura longirostris_bacurau-da-telha/de-roraima_bawnig1
+Systellura longirostris roraimae_bacurau-de-roraima_bawnig5
+Systellura longirostris ruficervix_bacurau-da-telha (ruficervix)_bawnig6
+Systellura longirostris atripunctata_bacurau-da-telha (atripunctata)_bawnig7
+Systellura longirostris bifasciata/patagonica_bacurau-da-telha (bifasciata/patagonica)_bawnig8
+Systellura longirostris longirostris_bacurau-da-telha_bawnig9
+Systellura longirostris mochaensis_bacurau-da-telha (mochaensis)_bawnig4
+Eleothreptus candicans_bacurau-de-rabo-branco_whwnig1
+Eleothreptus anomalus_curiango-do-banhado_siwnig1
+Hydropsalis cayennensis_bacurau-de-cauda-branca_whtnig1
+Hydropsalis climacocerca_acurana_latnig1
+Hydropsalis torquata_bacurau-tesoura_sctnig2
+Hydropsalis sp._Hydropsalis sp._hydrop1
+Macropsalis forcipata_bacurau-tesourão_lotnig2
+Siphonorhis americana_jamaican pauraque_jampau
+Siphonorhis brewsteri_least pauraque_leapau1
+Nyctiphrynus mcleodii_eared poorwill_earpoo1
+Nyctiphrynus yucatanicus_yucatan poorwill_yucpoo1
+Nyctiphrynus ocellatus_bacurau-ocelado_ocepoo1
+Nyctiphrynus rosenbergi_choco poorwill_chopoo1
+Phalaenoptilus nuttallii_common poorwill_compoo
+Antrostomus carolinensis_chuck-will's-widow_chwwid
+Antrostomus rufus_joão-corta-pau_rufnig1
+Antrostomus rufus [rufus Group]_joão-corta-pau [grupo rufus]_rufnig2
+Antrostomus rufus otiosus_joão-corta-pau (otiosus)_rufnig4
+Antrostomus rufus minimus_joão-corta-pau (minimus)_rufnig3
+Antrostomus cubanensis_cuban nightjar_granig2
+Antrostomus ekmani_hispaniolan nightjar_granig3
+Antrostomus salvini_tawny-collared nightjar_tacnig1
+Antrostomus badius_yucatan nightjar_yucnig1
+Antrostomus sericocaudatus_bacurau-rabo-de-seda_sitnig1
+Antrostomus ridgwayi_buff-collared nightjar_bucnig
+Antrostomus vociferus_eastern whip-poor-will_easwpw1
+Antrostomus saturatus_dusky nightjar_dusnig1
+Antrostomus arizonae_mexican whip-poor-will_souwpw1
+Antrostomus vociferus/arizonae_eastern/mexican whip-poor-will_whpwil
+Antrostomus noctitherus_puerto rican nightjar_purnig1
+Antrostomus sp._Antrostomus sp._antros1
+Veles binotatus_brown nightjar_bronig1
+Caprimulgus vexillarius_noitibó-de-balanceiros_pewnig1
+Caprimulgus longipennis_noitibó-de-estandarte_stwnig1
+Caprimulgus ruficollis_noitibó-de-nuca-vermelha_rennig1
+Caprimulgus indicus_jungle nightjar_grynig2
+Caprimulgus jotaka_gray nightjar_grynig1
+Caprimulgus indicus/jotaka_jungle/gray nightjar_granig
+Caprimulgus phalaena_palau nightjar_palnig1
+Caprimulgus europaeus_noitibó-cinzento_eurnig1
+Caprimulgus ruficollis/europaeus_noitibó-de-nuca-vermelha/noitibó-cinzento_y00677
+Caprimulgus fraenatus_sombre nightjar_somnig1
+Caprimulgus rufigena_rufous-cheeked nightjar_rucnig1
+Caprimulgus aegyptius_noitibó-do-deserto_egynig1
+Caprimulgus nubicus_noitibó-da-núbia_nubnig1
+Caprimulgus nubicus nubicus/tamaricis_noitibó-da-núbia (nubicus/tamaricis)_nubnig2
+Caprimulgus nubicus torridus_noitibó-da-núbia (torridus)_nubnig3
+Caprimulgus nubicus jonesi_noitibó-da-núbia (jonesi)_nubnig4
+Caprimulgus mahrattensis_sykes's nightjar_syknig1
+Caprimulgus eximius_golden nightjar_golnig1
+Caprimulgus macrurus_noitibó-de-cauda-larga_latnig2
+Caprimulgus ritae_timor nightjar_timnig1
+Caprimulgus andamanicus_andaman nightjar_andnig1
+Caprimulgus meesi_mees's nightjar_meenig1
+Caprimulgus atripennis_jerdon's nightjar_jernig1
+Caprimulgus manillensis_philippine nightjar_phinig1
+Caprimulgus celebensis_sulawesi nightjar_sulnig1
+Caprimulgus donaldsoni_donaldson smith's nightjar_dosnig1
+Caprimulgus pectoralis_fiery-necked nightjar_finnig1
+Caprimulgus pectoralis nigriscapularis_fiery-necked nightjar (Black-shouldered)_bksnig1
+Caprimulgus pectoralis [pectoralis Group]_fiery-necked nightjar (Fiery-necked)_finnig6
+Caprimulgus poliocephalus_montane nightjar_monnig1
+Caprimulgus poliocephalus poliocephalus_montane nightjar (Abyssinian)_abynig1
+Caprimulgus poliocephalus [ruwenzorii Group]_montane nightjar (Rwenzori)_monnig2
+Caprimulgus asiaticus_indian nightjar_indnig1
+Caprimulgus madagascariensis_madagascar nightjar_madnig1
+Caprimulgus natalensis_swamp nightjar_swanig1
+Caprimulgus inornatus_plain nightjar_planig1
+Caprimulgus stellatus_star-spotted nightjar_stsnig1
+Caprimulgus solala_nechisar nightjar_necnig1
+Caprimulgus affinis_noitibó-da-savana_savnig1
+Caprimulgus affinis [monticolus Group]_savanna nightjar (Northern)_savnig12
+Caprimulgus affinis [affinis Group]_savanna nightjar (Sunda)_savnig13
+Caprimulgus griseatus_chirruping nightjar_kaynig1
+Caprimulgus tristigma_freckled nightjar_frenig1
+Caprimulgus concretus_bonaparte's nightjar_bonnig1
+Caprimulgus pulchellus_salvadori's nightjar_salnig1
+Caprimulgus prigoginei_itombwe nightjar_itonig1
+Caprimulgus batesi_bates's nightjar_batnig2
+Caprimulgus climacurus_noitibó-rabilongo_lotnig1
+Caprimulgus clarus_slender-tailed nightjar_sltnig1
+Caprimulgus fossii_square-tailed nightjar_sqtnig1
+Caprimulgus sp._noitibó (Caprimulgus) sp._caprim1
+Caprimulgidae sp._bacurau sp._nightj1
+Phyllaemulor bracteatus_urutau-ferrugem_rufpot1
+Nyctibius grandis_urutau-grande_grepot1
+Nyctibius aethereus_urutau-pardo_lotpot1
+Nyctibius griseus_urutau_compot1
+Nyctibius jamaicensis_northern potoo_norpot1
+Nyctibius jamaicensis [mexicanus Group]_northern potoo (Middle American)_norpot2
+Nyctibius jamaicensis jamaicensis/abbotti_northern potoo (Caribbean)_norpot3
+Nyctibius maculosus_andean potoo_andpot1
+Nyctibius leucopterus_urutau-de-asa-branca_whwpot1
+Nyctibiidae sp._nyctibius sp. (urutau)_potoo1
+Steatornis caripensis_guácharo_oilbir1
+Podargus strigoides_tawny frogmouth_tawfro1
+Podargus ocellatus_marbled frogmouth_marfro1
+Podargus ocellatus [ocellatus Group]_marbled frogmouth (Marbled)_marfro2
+Podargus ocellatus plumiferus_marbled frogmouth (Plumed)_marfro3
+Podargus papuensis_papuan frogmouth_papfro1
+Rigidipenna inexpectata_solomons frogmouth_soifro1
+Batrachostomus auritus_large frogmouth_larfro1
+Batrachostomus harterti_dulit frogmouth_dulfro1
+Batrachostomus septimus_philippine frogmouth_phifro1
+Batrachostomus stellatus_gould's frogmouth_goufro1
+Batrachostomus moniliger_sri lanka frogmouth_ceyfro1
+Batrachostomus hodgsoni_hodgson's frogmouth_hodfro1
+Batrachostomus poliolophus_sumatran frogmouth_shtfro3
+Batrachostomus mixtus_bornean frogmouth_shtfro2
+Batrachostomus javensis_javan frogmouth_javfro3
+Batrachostomus affinis_blyth's frogmouth_javfro2
+Batrachostomus affinis continentalis_blyth's frogmouth (Indochinese)_blyfro1
+Batrachostomus affinis affinis_blyth's frogmouth (Blyth's)_blyfro2
+Batrachostomus chaseni_palawan frogmouth_palfro1
+Batrachostomus cornutus_sunda frogmouth_sunfro1
+Batrachostomus sp._Batrachostomus sp._batrac1
+Podargidae sp._frogmouth sp._frogmo1
+Aegotheles savesi_new caledonian owlet-nightjar_nconig1
+Aegotheles insignis_feline owlet-nightjar_feonig1
+Aegotheles tatei_starry owlet-nightjar_spaown1
+Aegotheles wallacii_wallace's owlet-nightjar_waonig1
+Aegotheles albertisi_mountain owlet-nightjar_moonig1
+Aegotheles crinifrons_moluccan owlet-nightjar_molown1
+Aegotheles cristatus_australian owlet-nightjar_auonig1
+Aegotheles affinis_vogelkop owlet-nightjar_barown2
+Aegotheles bennettii_barred owlet-nightjar_barown1
+Aegotheles bennettii bennettii/wiedenfeldi_barred owlet-nightjar (Barred)_barown3
+Aegotheles bennettii plumifer_barred owlet-nightjar (Dwarf)_barown4
+Aegotheles terborghi_karimui owlet-nightjar_barown5
+Aegotheles sp._owlet-nightjar sp._owletn1
+Cypseloides niger_taperuçu-escuro_blkswi
+Cypseloides niger borealis_black swift (borealis)_blkswi1
+Cypseloides niger costaricensis_black swift (costaricensis)_blkswi2
+Cypseloides niger niger_black swift (niger)_blkswi3
+Cypseloides lemosi_taperuçu-de-peito-branco_whcswi2
+Cypseloides rothschildi_rothschild's swift_rotswi1
+Cypseloides fumigatus_taperuçu-preto_sooswi1
+Cypseloides storeri_white-fronted swift_whfswi1
+Cypseloides cryptus_taperuçu-de-mento-branco_whcswi1
+Cypseloides cherriei_spot-fronted swift_spfswi1
+Cypseloides senex_taperuçu-velho_grdswi1
+Cypseloides sp._Cypseloides sp._cypsel1
+Streptoprocne rutila_chestnut-collared swift_chcswi1
+Streptoprocne phelpsi_taperuçu-dos-tepuis_tepswi1
+Streptoprocne zonaris_taperuçu-de-coleira-branca_whcswi
+Streptoprocne semicollaris_white-naped swift_whnswi1
+Streptoprocne biscutata_taperuçu-de-coleira-falha_bisswi1
+Streptoprocne sp._Streptoprocne sp._strept2
+Mearnsia picina_philippine spinetail_phinee1
+Mearnsia novaeguineae_papuan spinetail_papnee1
+Zoonavena grandidieri_madagascar spinetail_malspi1
+Zoonavena thomensis_sao tome spinetail_satspi1
+Zoonavena sylvatica_white-rumped spinetail_whrnee1
+Telacanthura ussheri_rabo-espinhoso-malhado_motspi1
+Telacanthura melanopygia_black spinetail_blaspi1
+Rhaphidura leucopygialis_silver-rumped spinetail_sirnee1
+Rhaphidura sabini_sabine's spinetail_sabspi1
+Neafrapus cassini_cassin's spinetail_casspi1
+Neafrapus boehmi_bat-like spinetail_balspi1
+Chaetura cinereiventris_andorinhão-de-sobre-cinzento_grrswi1
+Chaetura cinereiventris phaeopygos_andorinhão-de-sobre-cinzento (phaeopygos)_gyrswi3
+Chaetura cinereiventris occidentalis_andorinhão-de-sobre-cinzento (occidentalis)_gyrswi4
+Chaetura cinereiventris [sclateri Group]_andorinhão-de-sobre-cinzento [grupo sclateri]_gyrswi1
+Chaetura cinereiventris cinereiventris_andorinhão-de-sobre-cinzento (cinereiventris)_gyrswi2
+Chaetura spinicaudus_andorinhão-de-sobre-branco_barswi
+Chaetura spinicaudus aetherodroma_andorinhão-de-sobre-branco (aetherodroma)_barswi1
+Chaetura spinicaudus spinicaudus_andorinhão-de-sobre-branco (spinicaudus)_barswi2
+Chaetura spinicaudus aethalea_andorinhão-de-sobre-branco (aethalea)_barswi3
+Chaetura fumosa_costa rican swift_corswi
+Chaetura martinica_lesser antillean swift_leaswi1
+Chaetura egregia_taperá-de-garganta-branca_parswi1
+Chaetura pelagica_andorinhão-peregrino_chiswi
+Chaetura vauxi_vaux's swift_vauswi
+Chaetura vauxi vauxi_vaux's swift (Vaux's)_vauswi1
+Chaetura vauxi gaumeri_vaux's swift (Yucatan)_vauswi2
+Chaetura vauxi [richmondi Group]_vaux's swift (Richmond's)_vauswi3
+Chaetura vauxi aphanes_vaux's swift (aphanes)_vauswi4
+Chaetura pelagica/vauxi_chimney/vaux's swift_y00321
+Chaetura chapmani_andorinhão-de-chapman_chaswi2
+Chaetura andrei_ashy-tailed swift_astswi1
+Chaetura meridionalis_andorinhão-do-temporal_sicswi1
+Chaetura brachyura_andorinhão-de-rabo-curto_shtswi1
+Chaetura brachyura [brachyura Group]_andorinhão-de-rabo-curto [grupo brachyura]_shtswi2
+Chaetura brachyura ocypetes_andorinhão-de-rabo-curto (ocypetes)_shtswi3
+Chaetura sp._Chaetura sp._chaetu
+Hirundapus caudacutus_andorinhão-de-ferradura_whtnee
+Hirundapus caudacutus caudacutus_white-throated needletail (White-lored)_whtnee1
+Hirundapus caudacutus nudipes_white-throated needletail (Himalayan)_whtnee2
+Hirundapus cochinchinensis_silver-backed needletail_sibnee1
+Hirundapus giganteus_brown-backed needletail_brbnee1
+Hirundapus celebensis_purple needletail_purnee1
+Hirundapus sp._andorinhão (Hirundapus) sp._hirund1
+Hydrochous gigas_waterfall swift_watswi1
+Collocalia troglodytes_pygmy swiftlet_pygswi2
+Collocalia dodgei_bornean swiftlet_cavswi3
+Collocalia natalis_christmas island swiftlet_chiswi1
+Collocalia linchi_cave swiftlet_cavswi2
+Collocalia affinis_plume-toed swiftlet_pltswi1
+Collocalia marginata_gray-rumped swiftlet_gyrswi5
+Collocalia isonota_ridgetop swiftlet_ridswi1
+Collocalia marginata/isonota_gray-rumped/ridgetop swiftlet_y01084
+Collocalia sumbawae_tenggara swiftlet_tenswi1
+Collocalia neglecta_drab swiftlet_draswi1
+Collocalia esculenta_andorinhão-brilhante_gloswi1
+Collocalia neglecta/esculenta_drab/glossy swiftlet_y01077
+Collocalia uropygialis_satin swiftlet_satswi1
+Collocalia sp._white-bellied swiftlet sp._whbswi1
+Aerodramus elaphrus_seychelles swiftlet_seyswi1
+Aerodramus francicus_mascarene swiftlet_masswi1
+Aerodramus unicolor_indian swiftlet_indswi1
+Aerodramus infuscatus_moluccan swiftlet_molswi5
+Aerodramus mearnsi_philippine swiftlet_phiswi1
+Aerodramus hirundinaceus_mountain swiftlet_mouswi2
+Aerodramus spodiopygius_white-rumped swiftlet_whrswi2
+Aerodramus terraereginae_australian swiftlet_ausswi1
+Aerodramus brevirostris_himalayan swiftlet_himswi2
+Aerodramus brevirostris brevirostris/innominatus_himalayan swiftlet (Himalayan)_himswi1
+Aerodramus brevirostris rogersi_himalayan swiftlet (Indochinese)_indswi2
+Aerodramus vulcanorum_volcano swiftlet_volswi1
+Aerodramus whiteheadi_whitehead's swiftlet_whiswi1
+Aerodramus nuditarsus_bare-legged swiftlet_balswi1
+Aerodramus orientalis_mayr's swiftlet_mayswi1
+Aerodramus amelis_ameline swiftlet_palswi2
+Aerodramus vanikorensis_uniform swiftlet_uniswi1
+Aerodramus salangana_mossy-nest swiftlet_monswi2
+Aerodramus pelewensis_palau swiftlet_palswi1
+Aerodramus bartschi_mariana swiftlet_marswi
+Aerodramus inquietus_caroline islands swiftlet_caiswi1
+Aerodramus sawtelli_atiu swiftlet_atiswi1
+Aerodramus leucophaeus_tahiti swiftlet_polswi1
+Aerodramus ocistus_marquesan swiftlet_marswi2
+Aerodramus maximus_black-nest swiftlet_blnswi1
+Aerodramus fuciphagus_andorinhão-de-ninho-comestível_y00731
+Aerodramus fuciphagus germani/amechanus_andorinhão-de-ninho-comestível (germani/amechanus)_gerswi1
+Aerodramus fuciphagus [fuciphagus Group]_andorinhão-de-ninho-comestível (fuciphagus group)_ednswi1
+Aerodramus papuensis_three-toed swiftlet_papswi1
+Aerodramus sp._dark swiftlet sp._aerodr1
+Collocalia/Aerodramus sp._swiftlet sp._swiftl1
+Schoutedenapus myoptilus_scarce swift_scaswi1
+Tachymarptis melba_andorinhão-real_alpswi1
+Tachymarptis aequatorialis_andorinhão-malhado_motswi2
+Apus alexandri_andorinhão-de-cabo-verde_aleswi1
+Apus apus_andorinhão-preto_comswi
+Apus alexandri/apus_cape verde/common swift_y01231
+Apus unicolor_andorinhão-da-serra_plaswi1
+Apus niansae_nyanza swift_nyaswi1
+Apus pallidus_andorinhão-pálido_palswi3
+Apus apus/pallidus_andorinhão-preto/andorinhão-pálido_y00732
+Apus unicolor/pallidus_andorinhão-da-serra/andorinhão-pálido_y00860
+Apus barbatus_african swift_afrswi1
+Apus barbatus sladeniae_african swift (Bioko)_afrswi2
+Apus barbatus [barbatus Group]_african swift (African)_afrswi3
+Apus apus/barbatus_common/african swift_y00370
+Apus berliozi_forbes-watson's swift_fowswi1
+Apus bradfieldi_bradfield's swift_braswi1
+Apus balstoni_malagasy swift_madswi1
+Apus pacificus_andorinhão-asiático_fotswi
+Apus salimalii_salim ali's swift_saaswi1
+Apus leuconyx_blyth's swift_blyswi1
+Apus cooki_cook's swift_cooswi1
+Apus pacificus/cooki_pacific/cook's swift_y00959
+Apus pacificus/salimalii/leuconyx/cooki_fork-tailed swift sp._fotswi1
+Apus acuticauda_dark-rumped swift_darswi1
+Apus affinis_andorinhão-pequeno_litswi1
+Apus affinis [affinis Group]_andorinhão-pequeno [grupo affinis]_litswi2
+Apus affinis bannermani_andorinhão-pequeno (bannermani)_litswi3
+Apus affinis singalensis_andorinhão-pequeno (singalensis)_litswi4
+Apus nipalensis_house swift_houswi1
+Apus affinis/nipalensis_little/house swift_y00960
+Apus horus_horus swift_horswi1
+Apus horus (White-rumped)_horus swift (White-rumped)_horswi2
+Apus horus (Brown-rumped)_horus swift (Brown-rumped)_horswi3
+Apus caffer_andorinhão-cafre_whrswi1
+Apus affinis x caffer_little x white-rumped swift (hybrid)_x01060
+Apus batesi_bates's swift_batswi1
+Apus sp._Apus sp._apus2
+Apus/Tachymarptis sp._andorinhão (Apus/Tachymarptis) sp._apus1
+Aeronautes saxatalis_white-throated swift_whtswi
+Aeronautes montivagus_andorinhão-serrano_whtswi1
+Aeronautes andecolus_andean swift_andswi1
+Aeronautes montivagus/andecolus_white-tipped/andean swift_y00669
+Panyptila cayennensis_andorinhão-estofador_lstswi1
+Panyptila sanctihieronymi_great swallow-tailed swift_gstswi1
+Cypsiurus balasiensis_asian palm swift_aspswi1
+Cypsiurus parvus_andorinhão-dos-palmares_afpswi1
+Cypsiurus gracilis_malagasy palm swift_malpas1
+Cypsiurus gracilis griveaudi_malagasy palm swift (Comoro)_afrpas2
+Cypsiurus gracilis gracilis_malagasy palm swift (Madagascar)_afrpas3
+Tachornis phoenicobia_antillean palm swift_anpswi
+Tachornis furcata_pygmy palm swift_pygswi1
+Tachornis squamata_andorinhão-do-buriti_ftpswi1
+Apodidae sp. (large swift sp.)_andorinhão (apodídeo grande) sp._larswi1
+Apodidae sp. (small swift sp.)_andorinhão (apodídeo pequeno) sp._smaswi1
+Apodidae sp._Apodidae sp._swift1
+Hemiprocne coronata_crested treeswift_cretre1
+Hemiprocne longipennis_gray-rumped treeswift_gyrtre1
+Hemiprocne comata_whiskered treeswift_whitre1
+Hemiprocne mystacea_moustached treeswift_moutre1
+Hemiprocne sp._treeswift sp._treesw1
+Topaza pella_beija-flor-brilho-de-fogo_critop1
+Topaza pyra_topázio-de-fogo_fietop1
+Topaza pella/pyra_beija-flor-brilho-de-fogo/topázio-de-fogo_y00861
+Florisuga mellivora_beija-flor-azul-de-rabo-branco_whnjac1
+Florisuga fusca_beija-flor-preto_blkjac1
+Eutoxeres aquila_white-tipped sicklebill_whtsic1
+Eutoxeres condamini_buff-tailed sicklebill_butsic1
+Eutoxeres aquila/condamini_white-tipped/buff-tailed sicklebill_y01339
+Ramphodon naevius_beija-flor-rajado_sabher1
+Glaucis dohrnii_balança-rabo-canela_hobher2
+Glaucis aeneus_bronzy hermit_broher
+Glaucis hirsutus_balança-rabo-de-bico-torto_rubher
+Threnetes ruckeri_band-tailed barbthroat_batbar1
+Threnetes leucurus_balança-rabo-de-garganta-preta_patbar1
+Threnetes niger_balança-rabo-escuro_soobar1
+Threnetes niger loehkeni_balança-rabo-escuro (loehkeni)_soobar3
+Threnetes niger niger_balança-rabo-escuro (niger)_soobar4
+Anopetia gounellei_rabo-branco-de-cauda-larga_brther2
+Phaethornis hispidus_rabo-branco-cinza_whbher1
+Phaethornis yaruqui_white-whiskered hermit_whwher1
+Phaethornis guy_green hermit_greher1
+Phaethornis syrmatophorus_tawny-bellied hermit_tabher1
+Phaethornis koepckeae_koepcke's hermit_koeher1
+Phaethornis philippii_rabo-branco-amarelo_nebher1
+Phaethornis bourcieri_rabo-branco-de-bico-reto/barriga-cinza_stbher1
+Phaethornis bourcieri bourcieri_rabo-branco-de-bico-reto_stbher2
+Phaethornis bourcieri major_rabo-branco-de-barriga-cinza_stbher3
+Phaethornis longirostris_long-billed hermit_lobher
+Phaethornis longirostris [longirostris Group]_long-billed hermit (Central American)_lobher1
+Phaethornis longirostris baroni_long-billed hermit (Baron's)_lobher3
+Phaethornis mexicanus_mexican hermit_mexher1
+Phaethornis mexicanus griseoventer_mexican hermit (Jalisco)_lobher4
+Phaethornis mexicanus mexicanus_mexican hermit (Mexican)_lobher2
+Phaethornis superciliosus_rabo-branco-de-bigodes_lother1
+Phaethornis longirostris/superciliosus_long-billed/long-tailed hermit_y00596
+Phaethornis malaris_rabo-branco-de-bico-grande/rabo-branco-de-margarette_grbher1
+Phaethornis malaris malaris/insolitus_rabo-branco-de-bico-grande (malaris/insolitus)_grbher6
+Phaethornis malaris [moorei Group]_rabo-branco-de-bico-grande (grupo moorei)_grbher5
+Phaethornis malaris margarettae_rabo-branco-de-margarette_grbher4
+Phaethornis anthophilus_pale-bellied hermit_pabher1
+Phaethornis squalidus_rabo-branco-pequeno_duther1
+Phaethornis maranhaoensis [unrecognized species]_rabo-branco-do-maranhão [forma não reconhecido]_marher1
+Phaethornis rupurumii_rabo-branco-do-rupununi_stther1
+Phaethornis longuemareus_little hermit_lither2
+Phaethornis aethopygus_rabo-branco-do-tapajós_lither3
+Phaethornis idaliae_rabo-branco-mirim_minher1
+Phaethornis nattereri_rabo-branco-de-sobre-amarelo_cither1
+Phaethornis atrimentalis_rabo-branco-de-garganta-escura_bkther1
+Phaethornis striigularis_stripe-throated hermit_stther2
+Phaethornis griseogularis_rabo-branco-de-garganta-cinza_gycher1
+Phaethornis griseogularis porcullae_rabo-branco-de-garganta-cinzenta (porcullae)_gycher3
+Phaethornis griseogularis griseogularis/zonura_rabo-branco-de-garganta-cinzenta (griseogularis/zonura)_gycher2
+Phaethornis ruber_rabo-branco-rubro_redher1
+Phaethornis stuarti_white-browed hermit_whbher3
+Phaethornis ruber/stuarti_reddish/white-browed hermit_y00693
+Phaethornis subochraceus_rabo-branco-de-barriga-fulva_bubher1
+Phaethornis augusti_rabo-branco-cinza-claro_socher1
+Phaethornis pretrei_rabo-branco-acanelado_plaher1
+Phaethornis eurynome_rabo-branco-de-garganta-rajada_scther1
+Phaethornis sp._Phaethornis sp._hermit1
+Doryfera ludovicae_green-fronted lancebill_grflan1
+Doryfera johannae_bico-de-lança_blflan1
+Schistes albogularis_white-throated daggerbill_webhum3
+Schistes geoffroyi_geoffroy's daggerbill_webhum1
+Schistes albogularis/geoffroyi_white-throated/geoffroy's daggerbill_webhum2
+Augastes scutatus_beija-flor-de-gravata-verde_hyavis1
+Augastes lumachella_beija-flor-de-gravata-vermelha_hoovis2
+Colibri serrirostris_beija-flor-de-orelha-violeta_wvvear1
+Colibri coruscans_beija-flor-violeta_spvear1
+Colibri delphinae_beija-flor-marrom_brvear1
+Colibri thalassinus_mexican violetear_grnvie1
+Colibri cyanotus_lesser violetear_lesvio1
+Colibri cyanotus cabanidis_lesser violetear (Costa Rican)_grnvie2
+Colibri cyanotus cyanotus/crissalis_lesser violetear (Andean)_grnvio1
+Colibri coruscans/cyanotus_sparkling/lesser violetear_y00862
+Colibri sp._Colibri sp._violet1
+Heliactin bilophus_chifre-de-ouro_horsun2
+Androdon aequatorialis_tooth-billed hummingbird_tobhum1
+Heliothryx barroti_purple-crowned fairy_pucfai1
+Heliothryx auritus_beija-flor-de-bochecha-azul_bkefai1
+Polytmus guainumbi_beija-flor-de-bico-curvo_whtgol1
+Polytmus milleri_tepui goldenthroat_tepgol1
+Polytmus theresiae_beija-flor-verde_grtgol1
+Avocettula recurvirostris_beija-flor-de-bico-virado_fitawl1
+Chrysolampis mosquitus_beija-flor-vermelho_ruthum1
+Anthracothorax mango_jamaican mango_jamman1
+Anthracothorax nigricollis_beija-flor-de-veste-preta_bltman1
+Anthracothorax nigricollis nigricollis_black-throated mango (Black-throated)_bktman1
+Anthracothorax nigricollis iridescens_black-throated mango (Ecuadorian)_gnbman2
+Anthracothorax viridigula_beija-flor-de-veste-verde_grtman1
+Anthracothorax prevostii_green-breasted mango_gnbman
+Anthracothorax veraguensis_veraguan mango_verman1
+Anthracothorax dominicus_hispaniolan mango_antman2
+Anthracothorax aurulentus_puerto rican mango_antman3
+Anthracothorax viridis_green mango_greman1
+Anthracothorax sp._Anthracothorax sp._mango1
+Eulampis jugularis_purple-throated carib_putcar1
+Eulampis holosericeus_green-throated carib_grtcar1
+Eulampis jugularis/holosericeus_purple-throated/green-throated carib_y01200
+Heliangelus mavors_orange-throated sunangel_ortsun1
+Heliangelus clarisse_longuemare's sunangel_amtsun2
+Heliangelus spencei_merida sunangel_amtsun4
+Heliangelus amethysticollis_amethyst-throated sunangel_amtsun3
+Heliangelus strophianus_gorgeted sunangel_gorsun1
+Heliangelus exortis_tourmaline sunangel_tousun1
+Heliangelus micraster_little sunangel_litsun1
+Heliangelus viola_purple-throated sunangel_putsun1
+Heliangelus viola viola_purple-throated sunangel (Purple-throated)_putsun4
+Heliangelus viola splendidus/pyropus_purple-throated sunangel (Brilliant)_putsun2
+Heliangelus amethysticollis x viola_amethyst-throated x purple-throated sunangel (hybrid)_x01046
+Heliangelus regalis_royal sunangel_roysun1
+Heliangelus sp._Heliangelus sp._helian1
+Sephanoides sephaniodes_green-backed firecrown_grbfir1
+Sephanoides fernandensis_juan fernandez firecrown_juffir1
+Sephanoides sephaniodes/fernandensis_green-backed/juan fernandez firecrown_y00371
+Discosura popelairii_wire-crested thorntail_wictho2
+Discosura langsdorffi_rabo-de-espinho_bkbtho1
+Discosura letitiae_coppery thorntail_coptho2
+Discosura conversii_green thorntail_gretho1
+Discosura longicaudus_bandeirinha_ratcoq2
+Lophornis ornatus_beija-flor-de-leque-canela_tufcoq1
+Lophornis gouldii_topetinho-do-brasil-central_doecoq1
+Lophornis magnificus_topetinho-vermelho_fricoq1
+Lophornis brachylophus_short-crested coquette_shccoq
+Lophornis delattrei_rufous-crested coquette_ruccoq1
+Lophornis stictolophus_spangled coquette_spacoq1
+Lophornis verreauxii_topetinho-verde-amazônico_fescoq2
+Lophornis chalybeus_topetinho-verde_fescoq3
+Lophornis pavoninus_topetinho-pavão_peacoq1
+Lophornis helenae_black-crested coquette_blccoq1
+Lophornis adorabilis_white-crested coquette_whccoq1
+Discosura/Lophornis sp._Discosura/Lophornis sp._y00786
+Phlogophilus hemileucurus_ecuadorian piedtail_ecupie1
+Phlogophilus harterti_peruvian piedtail_perpie1
+Adelomyia melanogenys_speckled hummingbird_spehum1
+Adelomyia melanogenys [melanogenys Group]_speckled hummingbird (melanogenys Group)_spehum2
+Adelomyia melanogenys maculata_speckled hummingbird (maculata)_spehum3
+Adelomyia melanogenys inornata_speckled hummingbird (inornata)_spehum4
+Aglaiocercus kingii_long-tailed sylph_lotsyl1
+Aglaiocercus coelestis_violet-tailed sylph_vitsyl1
+Aglaiocercus berlepschi_venezuelan sylph_vensyl1
+Sappho sparganurus_red-tailed comet_retcom1
+Polyonymus caroli_bronze-tailed comet_brtcom1
+Taphrolesbia griseiventris_gray-bellied comet_gybcom1
+Oreotrochilus chimborazo_ecuadorian hillstar_ecuhil1
+Oreotrochilus cyanolaemus_blue-throated hillstar_buthil1
+Oreotrochilus stolzmanni_green-headed hillstar_andhil2
+Oreotrochilus melanogaster_black-breasted hillstar_blbhil1
+Oreotrochilus stolzmanni/melanogaster_green-headed/black-breasted hillstar_y00372
+Oreotrochilus estella_andean hillstar_andhil3
+Oreotrochilus leucopleurus_white-sided hillstar_whshil1
+Oreotrochilus estella/leucopleurus_andean/white-sided hillstar_y01232
+Oreotrochilus adela_wedge-tailed hillstar_wethil1
+Oreotrochilus sp._Oreotrochilus sp._oreotr1
+Opisthoprora euryptera_mountain avocetbill_mouavo1
+Lesbia victoriae_black-tailed trainbearer_blttra1
+Lesbia nuna_green-tailed trainbearer_grttra1
+Lesbia victoriae/nuna_black-tailed/green-tailed trainbearer_y00684
+Ramphomicron dorsale_black-backed thornbill_blbtho1
+Ramphomicron microrhynchum_purple-backed thornbill_pubtho1
+Chalcostigma ruficeps_rufous-capped thornbill_ructho1
+Chalcostigma olivaceum_olivaceous thornbill_olitho1
+Chalcostigma stanleyi_blue-mantled thornbill_blmtho1
+Chalcostigma heteropogon_bronze-tailed thornbill_brttho1
+Chalcostigma herrani_rainbow-bearded thornbill_rabtho1
+Oxypogon stuebelii_buffy helmetcrest_bufhel1
+Oxypogon cyanolaemus_blue-bearded helmetcrest_bubhel1
+Oxypogon lindenii_white-bearded helmetcrest_whbhel1
+Oxypogon guerinii_green-bearded helmetcrest_gnbhel1
+Oxypogon sp._helmetcrest sp._beahel1
+Oreonympha nobilis_bearded mountaineer_beamou1
+Oreonympha nobilis albolimbata_bearded mountaineer (Western)_beamou2
+Oreonympha nobilis nobilis_bearded mountaineer (Eastern)_beamou3
+Metallura iracunda_perija metaltail_permet1
+Metallura tyrianthina_tyrian metaltail_tyrmet1
+Metallura tyrianthina districta_tyrian metaltail (Santa Marta)_tyrmet2
+Metallura tyrianthina chloropogon_tyrian metaltail (Costa)_tyrmet3
+Metallura tyrianthina oreopola_tyrian metaltail (Merida)_tyrmet4
+Metallura tyrianthina tyrianthina/quitensis_tyrian metaltail (Tyrian)_tyrmet5
+Metallura tyrianthina septentrionalis_tyrian metaltail (septentrionalis)_tyrmet6
+Metallura tyrianthina smaragdinicollis_tyrian metaltail (smaragdinicollis)_tyrmet7
+Aglaiocercus kingii x Metallura tyrianthina_long-tailed sylph x tyrian metaltail (hybrid)_x00944
+Metallura williami_viridian metaltail_virmet1
+Metallura williami recisa_viridian metaltail (recisa)_virmet2
+Metallura williami williami_viridian metaltail (Viridian)_virmet3
+Metallura williami primolina_viridian metaltail (Ecuadorian)_virmet4
+Metallura williami atrigularis_viridian metaltail (Black-throated)_virmet5
+Metallura baroni_violet-throated metaltail_vitmet1
+Metallura odomae_neblina metaltail_nebmet1
+Metallura theresiae_coppery metaltail_copmet1
+Metallura eupogon_fire-throated metaltail_fitmet1
+Metallura aeneocauda_scaled metaltail_scamet1
+Metallura phoebe_black metaltail_blamet1
+Metallura sp._metaltail sp._metalt1
+Haplophaedia aureliae_greenish puffleg_grepuf1
+Haplophaedia assimilis_buff-thighed puffleg_butpuf1
+Haplophaedia lugens_hoary puffleg_hoapuf1
+Eriocnemis nigrivestis_black-breasted puffleg_blbpuf3
+Eriocnemis isabellae_gorgeted puffleg_gorpuf1
+Eriocnemis vestita_glowing puffleg_glopuf2
+Eriocnemis derbyi_black-thighed puffleg_bltpuf1
+Eriocnemis godini_turquoise-throated puffleg_tutpuf1
+Eriocnemis cupreoventris_coppery-bellied puffleg_cobpuf1
+Eriocnemis luciani_sapphire-vented puffleg_savpuf1
+Eriocnemis luciani [luciani Group]_sapphire-vented puffleg (Sapphire-vented)_savpuf2
+Eriocnemis luciani sapphiropygia/catharina_sapphire-vented puffleg (Coppery-naped)_savpuf3
+Eriocnemis mosquera_golden-breasted puffleg_gobpuf1
+Eriocnemis glaucopoides_blue-capped puffleg_blcpuf1
+Eriocnemis mirabilis_colorful puffleg_colpuf2
+Eriocnemis aline_emerald-bellied puffleg_embpuf1
+Loddigesia mirabilis_marvelous spatuletail_marspa1
+Aglaeactis cupripennis_shining sunbeam_shisun1
+Aglaeactis castelnaudii_white-tufted sunbeam_whtsun1
+Aglaeactis cupripennis x castelnaudii_shining x white-tufted sunbeam (hybrid)_x00672
+Aglaeactis cupripennis/castelnaudii_shining/white-tufted sunbeam_y01208
+Aglaeactis aliciae_purple-backed sunbeam_pubsun1
+Aglaeactis pamela_black-hooded sunbeam_blhsun1
+Coeligena coeligena_bronzy inca_broinc1
+Coeligena wilsoni_brown inca_broinc2
+Coeligena prunellei_black inca_blainc1
+Coeligena torquata_collared inca_colinc1
+Coeligena torquata [torquata Group]_collared inca (Collared)_colinc2
+Coeligena torquata eisenmanni_collared inca (Vilcabamba)_colinc5
+Coeligena conradii_green inca_colinc4
+Coeligena inca_gould's inca_colinc3
+Coeligena violifer_violet-throated starfrontlet_vitsta1
+Coeligena violifer dichroura_violet-throated starfrontlet (Huanuco)_vitsta2
+Coeligena violifer albicaudata_violet-throated starfrontlet (Apurimac)_vitsta3
+Coeligena violifer osculans_violet-throated starfrontlet (Cuzco)_vitsta4
+Coeligena violifer violifer_violet-throated starfrontlet (Bolivian)_vitsta5
+Coeligena iris_rainbow starfrontlet_raista1
+Coeligena phalerata_white-tailed starfrontlet_whtsta1
+Coeligena orina_dusky starfrontlet_dussta1
+Coeligena lutetiae_buff-winged starfrontlet_buwsta1
+Coeligena consita_perija starfrontlet_gobsta2
+Coeligena bonapartei_golden-bellied starfrontlet_gobsta1
+Coeligena eos_merida starfrontlet_gobsta4
+Coeligena helianthea_blue-throated starfrontlet_bltsta1
+Coeligena bonapartei x helianthea_golden-bellied x blue-throated starfrontlet (hybrid)_x01047
+Coeligena sp._Coeligena sp._coelig1
+Lafresnaya lafresnayi_mountain velvetbreast_mouvel1
+Ensifera ensifera_sword-billed hummingbird_swbhum1
+Pterophanes cyanopterus_great sapphirewing_gresap1
+Boissonneaua flavescens_buff-tailed coronet_butcor1
+Boissonneaua matthewsii_chestnut-breasted coronet_chbcor1
+Boissonneaua jardini_velvet-purple coronet_vepcor1
+Boissonneaua flavescens x jardini_buff-tailed x velvet-purple coronet (hybrid)_x00383
+Ocreatus underwoodii_white-booted racket-tail_boorat1
+Ocreatus peruanus_peruvian racket-tail_boorat2
+Ocreatus addae_rufous-booted racket-tail_rubrat1
+Ocreatus addae annae_rufous-booted racket-tail (Anna's)_boorat3
+Ocreatus addae addae_rufous-booted racket-tail (Adda's)_boorat4
+Ocreatus peruanus/addae_peruvian/rufous-booted racket-tail_y01214
+Urochroa bougueri_rufous-gaped hillstar_whthil2
+Urochroa leucura_green-backed hillstar_whthil3
+Urosticte benjamini_purple-bibbed whitetip_pubwhi1
+Urosticte ruficrissa_rufous-vented whitetip_ruvwhi1
+Heliodoxa xanthogonys_brilhante-veludo_vebbri1
+Heliodoxa gularis_pink-throated brilliant_pitbri1
+Heliodoxa branickii_rufous-webbed brilliant_ruwbri1
+Heliodoxa schreibersii_brilhante-de-garganta-preta_bltbri1
+Heliodoxa schreibersii schreibersii_brilhante-de-garganta-preta (schreibersii)_bktbri1
+Heliodoxa schreibersii whitelyana_brilhante-de-garganta-preta (whitelyana)_bktbri2
+Heliodoxa aurescens_beija-flor-estrela_goujew1
+Heliodoxa rubinoides_fawn-breasted brilliant_fabbri1
+Heliodoxa jacula_green-crowned brilliant_grcbri1
+Heliodoxa imperatrix_empress brilliant_empbri1
+Boissonneaua flavescens x Heliodoxa imperatrix_buff-tailed coronet x empress brilliant (hybrid)_x01032
+Heliodoxa leadbeateri_violet-fronted brilliant_vifbri1
+Heliodoxa rubricauda_beija-flor-rubi_brarub1
+Patagona gigas_giant hummingbird_giahum1
+Patagona gigas peruviana_giant hummingbird (Northern)_giahum2
+Patagona gigas gigas_giant hummingbird (Southern)_giahum3
+Sternoclyta cyanopectus_violet-chested hummingbird_vichum2
+Hylonympha macrocerca_scissor-tailed hummingbird_scthum1
+Eugenes fulgens_rivoli's hummingbird_maghum1
+Eugenes spectabilis_talamanca hummingbird_maghum2
+Heliomaster longirostris_bico-reto-cinzento_lobsta1
+Heliomaster constantii_plain-capped starthroat_plcsta
+Heliomaster longirostris/constantii_long-billed/plain-capped starthroat_y00863
+Heliomaster squamosus_bico-reto-de-banda-branca_stbsta1
+Heliomaster furcifer_bico-reto-azul_bltsta2
+Panterpe insignis_fiery-throated hummingbird_fithum1
+Lampornis viridipallens_green-throated mountain-gem_gtmgem1
+Lampornis sybillae_green-breasted mountain-gem_gbmgem1
+Lampornis amethystinus_amethyst-throated mountain-gem_amthum1
+Lampornis amethystinus [amethystinus Group]_amethyst-throated mountain-gem (Amethyst-throated)_amthum2
+Lampornis amethystinus margaritae_amethyst-throated mountain-gem (Violet-throated)_amthum3
+Lampornis clemenciae_blue-throated mountain-gem_buthum
+Lampornis hemileucus_white-bellied mountain-gem_wbmgem1
+Lampornis calolaemus_purple-throated mountain-gem_ptmgem
+Lampornis [undescribed form]_azuero mountain-gem (undescribed form)_azumog1
+Lampornis castaneoventris_white-throated mountain-gem_wtmgem1
+Lampornis castaneoventris cinereicauda_white-throated mountain-gem (Gray-tailed)_whtmog2
+Lampornis castaneoventris castaneoventris_white-throated mountain-gem (Blue-tailed)_whtmog1
+Lampornis calolaemus x castaneoventris_purple-throated x white-throated mountain-gem (hybrid)_x00945
+Lampornis calolaemus/castaneoventris_purple-throated/white-throated mountain-gem_y00864
+Lamprolaima rhami_garnet-throated hummingbird_gathum1
+Tilmatura dupontii_sparkling-tailed hummingbird_spthum1
+Calliphlox amethystina_estrelinha-ametista_amewoo1
+Thaumastura cora_peruvian sheartail_pershe2
+Myrmia micrura_short-tailed woodstar_shtwoo1
+Myrtis fanny_purple-collared woodstar_pucwoo1
+Rhodopis vesper_oasis hummingbird_oashum1
+Eulidia yarrellii_chilean woodstar_chiwoo1
+Thaumastura cora x Eulidia yarrellii_peruvian sheartail x chilean woodstar (hybrid)_x00736
+Microstilbon burmeisteri_slender-tailed woodstar_sltwoo1
+Chaetocercus mulsant_white-bellied woodstar_whbwoo6
+Chaetocercus bombus_little woodstar_litwoo5
+Chaetocercus heliodor_gorgeted woodstar_gorwoo2
+Chaetocercus astreans_santa marta woodstar_samwoo2
+Chaetocercus berlepschi_esmeraldas woodstar_esmwoo2
+Chaetocercus jourdanii_rufous-shafted woodstar_ruswoo1
+Chaetocercus sp._Chaetocercus sp._chaeto1
+Philodice bryantae_magenta-throated woodstar_matwoo1
+Philodice mitchellii_purple-throated woodstar_putwoo1
+Trochilidae sp. (woodstar sp.)_woodstar sp._woodst1
+Doricha enicura_slender sheartail_sleshe1
+Doricha eliza_mexican sheartail_mexshe1
+Calothorax lucifer_lucifer hummingbird_luchum
+Calothorax pulcher_beautiful hummingbird_beahum1
+Calothorax lucifer/pulcher_lucifer/beautiful hummingbird_y01030
+Archilochus colubris_ruby-throated hummingbird_rthhum
+Archilochus alexandri_black-chinned hummingbird_bkchum
+Calothorax lucifer x Archilochus alexandri_lucifer x black-chinned hummingbird (hybrid)_x00946
+Archilochus colubris x alexandri_ruby-throated x black-chinned hummingbird (hybrid)_x00850
+Archilochus colubris/alexandri_ruby-throated/black-chinned hummingbird_archil1
+Nesophlox evelynae_bahama woodstar_bahwoo
+Nesophlox lyrura_inagua woodstar_inawoo2
+Mellisuga minima_vervain hummingbird_verhum1
+Mellisuga helenae_bee hummingbird_beehum1
+Calypte anna_anna's hummingbird_annhum
+Calothorax lucifer x Calypte anna_lucifer x anna's hummingbird (hybrid)_x00690
+Archilochus alexandri x Calypte anna_black-chinned x anna's hummingbird (hybrid)_x00651
+Calypte costae_costa's hummingbird_coshum
+Calothorax lucifer x Calypte costae_lucifer x costa's hummingbird (hybrid)_x00737
+Archilochus alexandri x Calypte costae_black-chinned x costa's hummingbird (hybrid)_x00384
+Calypte anna x costae_anna's x costa's hummingbird (hybrid)_x00618
+Calypte anna/costae_anna's/costa's hummingbird_calypt
+Selasphorus calliope_calliope hummingbird_calhum
+Archilochus alexandri x Selasphorus calliope_black-chinned x calliope hummingbird (hybrid)_x00768
+Calypte anna x Selasphorus calliope_anna's x calliope hummingbird (hybrid)_x00619
+Selasphorus rufus_rufous hummingbird_rufhum
+Archilochus colubris x Selasphorus rufus_ruby-throated x rufous hummingbird (hybrid)_x01048
+Archilochus alexandri x Selasphorus rufus_black-chinned x rufous hummingbird (hybrid)_x00738
+Calypte anna x Selasphorus rufus_anna's x rufous hummingbird (hybrid)_x00626
+Selasphorus calliope x rufus_calliope x rufous hummingbird (hybrid)_x00852
+Selasphorus sasin_allen's hummingbird_allhum
+Archilochus alexandri x Selasphorus sasin_black-chinned x allen's hummingbird (hybrid)_x01154
+Calypte anna x Selasphorus sasin_anna's x allen's hummingbird (hybrid)_x00691
+Calypte costae x Selasphorus sasin_costa's x allen's hummingbird (hybrid)_x01155
+Selasphorus rufus x sasin_rufous x allen's hummingbird (hybrid)_x00385
+Selasphorus rufus/sasin_rufous/allen's hummingbird_y00001
+Selasphorus platycercus_broad-tailed hummingbird_brthum
+Calothorax lucifer x Selasphorus platycercus_lucifer x broad-tailed hummingbird (hybrid)_x01095
+Archilochus colubris x Selasphorus platycercus_ruby-throated x broad-tailed hummingbird (hybrid)_x01049
+Archilochus alexandri x Selasphorus platycercus_black-chinned x broad-tailed hummingbird (hybrid)_x01091
+Calypte anna x Selasphorus platycercus_anna's x broad-tailed hummingbird (hybrid)_x01096
+Selasphorus calliope x platycercus_calliope x broad-tailed hummingbird (hybrid)_x00851
+Selasphorus rufus x platycercus_rufous x broad-tailed hummingbird (hybrid)_x00386
+Selasphorus heloisa_bumblebee hummingbird_bumhum
+Selasphorus ellioti_wine-throated hummingbird_withum1
+Selasphorus flammula_volcano hummingbird_volhum1
+Selasphorus flammula flammula_volcano hummingbird (Purple-throated)_volhum2
+Selasphorus flammula torridus_volcano hummingbird (Heliotrope-throated)_volhum4
+Selasphorus flammula simoni_volcano hummingbird (Rose-throated)_volhum3
+Selasphorus scintilla_scintillant hummingbird_scihum1
+Selasphorus ardens_glow-throated hummingbird_glthum1
+Calypte anna x Selasphorus sp._anna's hummingbird x selasphorus sp. (hybrid)_x00739
+Selasphorus sp._Selasphorus sp._selasp
+Phaeoptila sordida_dusky hummingbird_dushum1
+Riccordia ricordii_cuban emerald_cubeme1
+Riccordia bracei_brace's emerald_braeme2
+Riccordia elegans [unrecognized species]_elegant emerald (unrecognized species)_braeme3
+Riccordia swainsonii_hispaniolan emerald_hiseme1
+Riccordia maugaeus_puerto rican emerald_pureme1
+Riccordia bicolor_blue-headed hummingbird_blhhum1
+Cynanthus latirostris_broad-billed hummingbird_brbhum
+Archilochus alexandri x Cynanthus latirostris_black-chinned x broad-billed hummingbird (hybrid)_x00676
+Calypte anna x Cynanthus latirostris_anna's x broad-billed hummingbird (hybrid)_x00387
+Calypte costae x Cynanthus latirostris_costa's x broad-billed hummingbird (hybrid)_x01097
+Phaeoptila sordida/Cynanthus latirostris_dusky/broad-billed hummingbird_y01215
+Cynanthus lawrencei_tres marias hummingbird_brbhum3
+Cynanthus latirostris/lawrencei_broad-billed/tres marias hummingbird_y01201
+Cynanthus doubledayi_turquoise-crowned hummingbird_brbhum2
+Cynanthus latirostris x doubledayi_broad-billed x turquoise-crowned hummingbird (hybrid)_x00388
+Phaeoptila sordida/Cynanthus doubledayi_dusky/turquoise-crowned hummingbird_y00373
+Cynanthus latirostris/doubledayi_broad-billed/turquoise-crowned hummingbird_y00374
+Cynanthus auriceps_golden-crowned emerald_goceme1
+Cynanthus forficatus_cozumel emerald_cozeme1
+Cynanthus canivetii_canivet's emerald_caneme1
+Cynanthus canivetii canivetii_canivet's emerald (Canivet's)_caneme2
+Cynanthus canivetii salvini/osberti_canivet's emerald (Salvin's)_caneme3
+Chlorostilbon mellisugus_esmeralda-de-cauda-azul_blteme1
+Chlorostilbon olivaresi_chiribiquete emerald_chieme1
+Chlorostilbon gibsoni_red-billed emerald_rebeme1
+Chlorostilbon lucidus_besourinho-de-bico-vermelho_glbeme1
+Chlorostilbon poortmani_short-tailed emerald_shteme1
+Chlorostilbon stenurus_narrow-tailed emerald_nateme2
+Chlorostilbon alice_green-tailed emerald_grteme1
+Chlorostilbon russatus_coppery emerald_copeme1
+Chlorostilbon assimilis_garden emerald_gareme1
+Chlorostilbon melanorhynchus_western emerald_weseme1
+Riccordia/Cynanthus/Chlorostilbon sp._Riccordia/Cynanthus/Chlorostilbon sp._chloro2
+Basilinna leucotis_white-eared hummingbird_whehum
+Eugenes fulgens x Basilinna leucotis_rivoli's x white-eared hummingbird (hybrid)_x01101
+Cynanthus latirostris x Basilinna leucotis_broad-billed x white-eared hummingbird (hybrid)_x01129
+Basilinna xantusii_xantus's hummingbird_xanhum
+Pampa curvipennis_wedge-tailed sabrewing_wetsab1
+Pampa curvipennis curvipennis_wedge-tailed sabrewing (Curve-winged)_wetsab2
+Pampa curvipennis pampa_wedge-tailed sabrewing (Wedge-tailed)_wetsab3
+Pampa curvipennis excellens_wedge-tailed sabrewing (Long-tailed)_lotsab1
+Pampa rufa_rufous sabrewing_rufsab1
+Klais guimeti_violet-headed hummingbird_vihhum1
+Abeillia abeillei_emerald-chinned hummingbird_emchum1
+Orthorhyncus cristatus_antillean crested hummingbird_anchum1
+Orthorhyncus cristatus exilis_antillean crested hummingbird (Lesser Antilles)_anchum2
+Orthorhyncus cristatus ornatus_antillean crested hummingbird (St. Vincent)_anchum3
+Orthorhyncus cristatus cristatus_antillean crested hummingbird (Barbados)_anchum4
+Orthorhyncus cristatus emigrans_antillean crested hummingbird (Grenadines and Grenada)_anchum5
+Stephanoxis lalandi_beija-flor-de-topete-verde_plover3
+Stephanoxis loddigesii_beija-flor-de-topete-azul_plover4
+Anthocephala floriceps_santa marta blossomcrown_samblo1
+Anthocephala berlepschi_tolima blossomcrown_tolblo1
+Campylopterus largipennis_asa-de-sabre-da-guiana/de-cauda-escura_gybsab1
+Campylopterus largipennis largipennis_asa-de-sabre-da-guiana_gybsab2
+Campylopterus largipennis obscurus_asa-de-sabre-de-cauda-escura_gybsab3
+Campylopterus calcirupicola_asa-de-sabre-da-mata-seca_gybsab4
+Campylopterus diamantinensis_asa-de-sabre-do-espinhaço_gybsab5
+Campylopterus hemileucurus_violet sabrewing_viosab1
+Campylopterus hyperythrus_asa-de-sabre-canela_rubsab1
+Campylopterus duidae_asa-de-sabre-de-peito-camurça_bubsab1
+Campylopterus villaviscensio_napo sabrewing_napsab1
+Campylopterus falcatus_lazuline sabrewing_lazsab1
+Campylopterus phainopeplus_santa marta sabrewing_samsab1
+Campylopterus ensipennis_white-tailed sabrewing_whtsab1
+Chalybura urochrysia_bronze-tailed plumeleteer_brtplu1
+Chalybura buffonii_white-vented plumeleteer_whvplu1
+Chalybura buffonii [buffonii Group]_white-vented plumeleteer (White-vented)_whvplu2
+Chalybura buffonii caeruleogaster_white-vented plumeleteer (Blue-bellied)_whvplu3
+Chalybura buffonii intermedia_white-vented plumeleteer (Ecuadorian)_whvplu4
+Thalurania glaucopis_beija-flor-de-fronte-violeta_vicwoo2
+Thalurania watertonii_beija-flor-de-costas-violeta_lotwoo2
+Thalurania colombica_crowned woodnymph_crowoo1
+Thalurania colombica (Violet-crowned Woodnymph)_crowned woodnymph (Northern/Colombian Violet-crowned)_vicwoo1
+Thalurania colombica venusta/townsendi_crowned woodnymph (Northern Violet-crowned)_vicwoo3
+Thalurania colombica colombica/rostrifera_crowned woodnymph (Colombian Violet-crowned)_vicwoo4
+Thalurania colombica (Green-crowned Woodnymph)_crowned woodnymph (Green-crowned/Emerald-bellied)_grcwoo2
+Thalurania colombica [fannyae Group]_crowned woodnymph (Green-crowned)_gncwoo1
+Thalurania colombica hypochlora_crowned woodnymph (Emerald-bellied)_gncwoo2
+Thalurania furcata_beija-flor-tesoura-verde_fotwoo1
+Thalurania glaucopis/furcata_beija-flor-de-fronte-violeta/beija-flor-tesoura-verde_y01132
+Microchera albocoronata_snowcap_snowca1
+Microchera cupreiceps_coppery-headed emerald_coheme1
+Microchera chionura_white-tailed emerald_whteme1
+Goldmania violiceps_violet-capped hummingbird_vichum1
+Goldmania bella_pirre hummingbird_ruchum1
+Eupherusa ridgwayi_mexican woodnymph_mexwoo1
+Eupherusa poliocerca_white-tailed hummingbird_whthum1
+Eupherusa cyanophrys_blue-capped hummingbird_blchum2
+Eupherusa eximia_stripe-tailed hummingbird_stthum1
+Eupherusa nigriventris_black-bellied hummingbird_blbhum1
+Phaeochroa cuvierii_scaly-breasted hummingbird_scbhum1
+Phaeochroa cuvierii roberti_scaly-breasted hummingbird (Robert's)_scbhum2
+Phaeochroa cuvierii [cuvierii Group]_scaly-breasted hummingbird (Cuvier's)_scbhum3
+Leucippus fallax_buffy hummingbird_bufhum1
+Thaumasius baeri_tumbes hummingbird_tumhum1
+Thaumasius taczanowskii_spot-throated hummingbird_spthum2
+Taphrospilus hypostictus_many-spotted hummingbird_mashum1
+Eupetomena macroura_beija-flor-tesoura_swthum1
+Eupetomena cirrochloris_beija-flor-cinza_somhum1
+Talaphorus chlorocercus_beija-flor-pintado_olshum1
+Trochilus polytmus_red-billed streamertail_stream2
+Trochilus scitulus_black-billed streamertail_stream3
+Trochilus polytmus x scitulus_red-billed x black-billed streamertail (hybrid)_stream4
+Trochilus polytmus/scitulus_red-billed/black-billed streamertail_stream1
+Ramosomyia violiceps_violet-crowned hummingbird_vichum
+Cynanthus latirostris x Ramosomyia violiceps_broad-billed x violet-crowned hummingbird (hybrid)_x00633
+Ramosomyia viridifrons_green-fronted hummingbird_grfhum1
+Ramosomyia viridifrons viridifrons_green-fronted hummingbird (Green-fronted)_gnfhum1
+Ramosomyia viridifrons wagneri_green-fronted hummingbird (Cinnamon-sided)_gnfhum2
+Ramosomyia viridifrons villadai_green-fronted hummingbird (villadai)_gnfhum3
+Ramosomyia violiceps/viridifrons_violet-crowned/green-fronted hummingbird_y01216
+Saucerottia cyanocephala_azure-crowned hummingbird_azchum1
+Saucerottia cyanocephala cyanocephala_azure-crowned hummingbird (Azure-crowned)_azchum2
+Saucerottia cyanocephala chlorostephana_azure-crowned hummingbird (Mosquitia)_azchum3
+Saucerottia hoffmanni_blue-vented hummingbird_buvhum1
+Saucerottia beryllina_berylline hummingbird_berhum
+Saucerottia beryllina beryllina/viola_berylline hummingbird (Northern)_berhum1
+Saucerottia beryllina [devillei Group]_berylline hummingbird (Sumichrast's)_berhum2
+Cynanthus latirostris x Saucerottia beryllina_broad-billed x berylline hummingbird (hybrid)_x01172
+Eugenes fulgens x Saucerottia beryllina_rivoli's x berylline hummingbird (hybrid)_mxbhum1
+Saucerottia cyanura_blue-tailed hummingbird_blthum1
+Saucerottia edward_snowy-bellied hummingbird_snbhum1
+Saucerottia saucerottei_steely-vented hummingbird_stvhum2
+Saucerottia alfaroana [unrecognized species]_guanacaste hummingbird (unrecognized species)_guahum1
+Saucerottia cyanifrons_indigo-capped hummingbird_inchum1
+Saucerottia castaneiventris_chestnut-bellied hummingbird_chbhum1
+Saucerottia viridigaster_green-bellied hummingbird_grbhum1
+Saucerottia cupreicauda_beija-flor-de-barriga-verde_gnbhum2
+Saucerottia tobaci_copper-rumped hummingbird_corhum1
+Saucerottia sp._Saucerottia sp._saucer1
+Amazilia rutila_cinnamon hummingbird_cinhum1
+Amazilia rutila graysoni_cinnamon hummingbird (Tres Marias Is.)_cinhum2
+Amazilia rutila [rutila Group]_cinnamon hummingbird (Mainland)_cinhum3
+Amazilia yucatanensis_buff-bellied hummingbird_bubhum
+Amazilia yucatanensis yucatanensis_buff-bellied hummingbird (Yucatan)_bubhum1
+Amazilia yucatanensis cerviniventris/chalconota_buff-bellied hummingbird (Northern)_bubhum2
+Amazilia tzacatl_rufous-tailed hummingbird_rtlhum
+Amazilia tzacatl [tzacatl Group]_rufous-tailed hummingbird (Rufous-tailed)_ruthum2
+Amazilia tzacatl handleyi_rufous-tailed hummingbird (Escudo)_ruthum3
+Amazilia rutila x tzacatl_cinnamon x rufous-tailed hummingbird (hybrid)_x00947
+Amazilia yucatanensis/tzacatl_buff-bellied/rufous-tailed hummingbird_y00375
+Amazilia luciae_honduran emerald_honeme1
+Saucerottia cyanocephala x Amazilia luciae_azure-crowned hummingbird x honduran emerald (hybrid)_x00916
+Amazilia tzacatl x luciae_rufous-tailed hummingbird x honduran emerald (hybrid)_x01033
+Amazilis amazilia_amazilia hummingbird_amahum1
+Amazilis amazilia [dumerilii Group]_amazilia hummingbird (White-throated)_amahum2
+Amazilis amazilia amazilia_amazilia hummingbird (Green-throated)_amahum4
+Amazilis amazilia caeruleigularis_amazilia hummingbird (Blue-throated)_amahum5
+Uranomitra franciae_andean emerald_andeme1
+Chrysuronia versicolor_beija-flor-de-banda-branca/beija-flor-de-cabeça-azul_vereme1
+Chrysuronia versicolor [versicolor Group]_beija-flor-de-banda-branca_vereme2
+Chrysuronia versicolor rondoniae_beija-flor-de-cabeça-azul_vereme3
+Chrysuronia goudoti_shining-green hummingbird_shghum1
+Chrysuronia oenone_beija-flor-de-cauda-dourada_gotsap1
+Chrysuronia boucardi_mangrove hummingbird_manhum1
+Chrysuronia coeruleogularis_sapphire-throated hummingbird_sathum1
+Chrysuronia lilliae_sapphire-bellied hummingbird_sabhum1
+Chrysuronia goudoti/coeruleogularis/lilliae_shining-green/sapphire-throated/sapphire-bellied hummingbird_lepido3
+Chrysuronia humboldtii_humboldt's sapphire_humsap2
+Chrysuronia grayi_blue-headed sapphire_blhsap1
+Chrysuronia brevirostris_beija-flor-de-bico-preto_whceme1
+Chrysuronia leucogaster_beija-flor-de-barriga-branca_plbeme1
+Leucochloris albicollis_beija-flor-de-papo-branco_whthum2
+Chionomesa fimbriata_beija-flor-de-garganta-verde_glteme1
+Chionomesa lactea_beija-flor-de-peito-azul_saseme1
+Chionomesa lactea lactea/zimmeri_beija-flor-de-peito-azul (lactea/zimmeri)_saseme2
+Chionomesa lactea bartletti_beija-flor-de-peito-azul (bartletti)_saseme3
+Chionomesa fimbriata/lactea_beija-flor-de-garganta-verde/beija-flor-de-peito-azul_y00376
+Hylocharis sapphirina_beija-flor-safira_rutsap1
+Hylocharis chrysura_beija-flor-dourado_gilhum1
+Elliotomyia chionogaster_beija-flor-verde-e-branco_whbhum1
+Elliotomyia chionogaster chionogaster_beija-flor-verde-e-branco (chionogaster)_whbhum2
+Elliotomyia chionogaster hypoleuca_beija-flor-verde-e-branco (hypoleuca)_whbhum3
+Elliotomyia viridicauda_green-and-white hummingbird_gawhum1
+Elliotomyia chionogaster/viridicauda_white-bellied/green-and-white hummingbird_y00377
+Polyerata rosenbergi_purple-chested hummingbird_puchum1
+Polyerata amabilis_blue-chested hummingbird_blchum1
+Polyerata decora_charming hummingbird_chahum1
+Chlorestes candida_white-bellied emerald_whbeme1
+Chlorestes eliciae_blue-throated goldentail_bltgol1
+Chlorestes cyanus_beija-flor-roxo_whcsap1
+Chlorestes julie_violet-bellied hummingbird_vibhum1
+Chlorestes notata_beija-flor-de-garganta-azul_bucsap1
+Aglaiocercus kingii x Trochilidae sp. (Bogota Sunangel)_bogota sunangel (hybrid)_bogsun2
+Trochilidae sp._Trochilidae sp._hummin
+Mentocrex kioloides_madagascar forest rail_madwor1
+Mentocrex beankaensis_tsingy forest rail_tsiwor1
+Sarothrura pulchra_franga-d'água-pintada_whsflu1
+Sarothrura pulchra [pulchra Group]_franga-d'água-pintada [grupo pulchra]_whsflu2
+Sarothrura pulchra centralis_franga-d'água-pintada (centralis)_whsflu3
+Sarothrura elegans_buff-spotted flufftail_busflu1
+Sarothrura rufa_red-chested flufftail_recflu1
+Sarothrura lugens_chestnut-headed flufftail_chhflu1
+Sarothrura boehmi_streaky-breasted flufftail_stbflu1
+Sarothrura affinis_striped flufftail_strflu1
+Sarothrura insularis_madagascar flufftail_madflu1
+Sarothrura ayresi_white-winged flufftail_whwflu1
+Sarothrura watersi_slender-billed flufftail_slbflu1
+Sarothrura sp._flufftail sp._flufft1
+Rallicula rubra_chestnut forest rail_chfrai1
+Rallicula leucospila_white-striped forest rail_wsfrai1
+Rallicula forbesi_forbes's forest rail_forrai1
+Rallicula mayri_mayr's forest rail_mayrai1
+Rallus obsoletus_ridgway's rail_ridrai1
+Rallus obsoletus obsoletus_ridgway's rail (San Francisco Bay)_clarai3
+Rallus obsoletus levipes_ridgway's rail (Light-footed)_clarai4
+Rallus obsoletus beldingi_ridgway's rail (South Baja)_clarai6
+Rallus obsoletus yumanensis_ridgway's rail (Yuma)_clarai5
+Rallus tenuirostris_aztec rail_kinrai2
+Rallus longirostris_saracura-matraca_manrai1
+Rallus longirostris berryorum_sarucura-matraca (berryorum)_manrai2
+Rallus longirostris cypereti_saracura-matraca (cypereti)_clarai10
+Rallus longirostris [longirostris Group]_saracura-matraca [grupo longirostris]_clarai8
+Rallus elegans_king rail_kinrai4
+Rallus elegans elegans_king rail (Northern)_kinrai1
+Rallus elegans ramsdeni_king rail (Cuban)_kinrai3
+Rallus tenuirostris/elegans_aztec/king rail_kinrai
+Rallus crepitans_clapper rail_clarai11
+Rallus crepitans crepitans/waynei_clapper rail (Atlantic Coast)_clarai1
+Rallus crepitans saturatus/scottii_clapper rail (Gulf Coast)_clarai2
+Rallus crepitans [caribaeus Group]_clapper rail (Caribbean)_clarai7
+Rallus crepitans [pallidus Group]_clapper rail (Yucatan)_clarai9
+Rallus elegans x crepitans_king x clapper rail (hybrid)_x00948
+Rallus elegans/crepitans_king/clapper rail_rallus
+Rallus obsoletus/longirostris/crepitans_ridgway's/mangrove/clapper rail_clarai
+Rallus sp. (large Rallus sp.)_large rail sp._larrai1
+Rallus wetmorei_plain-flanked rail_plfrai1
+Rallus limicola_virginia rail_virrai
+Rallus aequatorialis_ecuadorian rail_virrai1
+Rallus elegans/limicola_king/virginia rail_y00602
+Rallus semiplumbeus_bogota rail_bograi1
+Rallus antarcticus_austral rail_ausrai1
+Rallus aquaticus_frango-d'água_watrai1
+Rallus indicus_brown-cheeked rail_bncrai1
+Rallus aquaticus/indicus_water/brown-cheeked rail_y00949
+Rallus caerulescens_african rail_afrrai1
+Rallus madagascariensis_madagascar rail_madrai1
+Rallus sp._Rallus sp._rallus1
+Dryolimnas cuvieri_white-throated rail_whtrai1
+Dryolimnas augusti_reunion rail_reurai1
+Aphanapteryx bonasia_red rail_redrai1
+Erythromachus leguati_rodrigues rail_rodrai1
+Crex crex_codornizão_corcra
+Crecopsis egregia_codornizão-africano_afrcra1
+Rougetius rougetii_rouget's rail_rourai1
+Aphanocrex podarces_st. helena rail_sthcra1
+Mundia elpenor_ascension crake_asccra1
+Aramidopsis plateni_snoring rail_plarai1
+Lewinia striata_slaty-breasted rail_slbrai1
+Lewinia mirifica_luzon rail_luzrai1
+Lewinia pectoralis_lewin's rail_lewrai1
+Lewinia muelleri_auckland islands rail_auirai1
+Gymnocrex rosenbergii_blue-faced rail_bafrai2
+Gymnocrex plumbeiventris_bare-eyed rail_baerai1
+Gymnocrex talaudensis_talaud rail_talrai1
+Diaphorapteryx hawkinsi_hawkins's rail_hawrai1
+Gallirallus calayanensis_calayan rail_calrai1
+Gallirallus wallacii_invisible rail_invrai1
+Gallirallus castaneoventris_chestnut rail_cherai1
+Gallirallus australis_weka_weka1
+Gallirallus lafresnayanus_new caledonian rail_necrai1
+Gallirallus sylvestris_lord howe rail_lohrai1
+Gallirallus okinawae_okinawa rail_okirai1
+Gallirallus pacificus_tahiti rail_tahrai1
+Gallirallus philippensis_frango-d'água-filipino_bubrai1
+Gallirallus modestus_chatham islands rail_chirai1
+Gallirallus dieffenbachii_dieffenbach's rail_dierai1
+Gallirallus insignis_new britain rail_nebrai1
+Gallirallus woodfordi_woodford's rail_woorai1
+Gallirallus woodfordi tertius_woodford's rail (Bougainville)_woorai2
+Gallirallus woodfordi immaculatus_woodford's rail (Santa Isabel)_woorai3
+Gallirallus woodfordi woodfordi_woodford's rail (Guadalcanal)_woorai4
+Gallirallus poecilopterus_bar-winged rail_bawrai1
+Gallirallus owstoni_guam rail_guarai1
+Gallirallus wakensis_wake island rail_wairai1
+Gallirallus torquatus_barred rail_barrai1
+Gallirallus rovianae_roviana rail_rovrai1
+Canirallus oculeus_gray-throated rail_gytrai1
+Pardirallus maculatus_saracura-carijó_sporai
+Pardirallus nigricans_saracura-sanã_blarai1
+Pardirallus sanguinolentus_saracura-do-banhado_plurai1
+Mustelirallus albicollis_sanã-carijó_astcra1
+Mustelirallus cerverai_zapata rail_zaprai1
+Mustelirallus colombianus_colombian crake_colcra2
+Mustelirallus erythrops_turu-turu_pabcra
+Amaurolimnas concolor_saracura-lisa_unicra1
+Aramides ypecaha_saracuruçu_giwrai1
+Aramides wolfi_brown wood-rail_brwrai1
+Aramides mangle_saracura-do-mangue_liwrai1
+Aramides axillaris_rufous-necked wood-rail_rnwrai1
+Aramides albiventris_russet-naped wood-rail_runwor1
+Aramides cajaneus_saracura-três-potes_gycwor1
+Aramides cajaneus cajaneus_saracura-três-potes (cajaneus)_gycwor2
+Aramides cajaneus avicenniae_saracura-três-potes (avicenniae)_gycwor3
+Aramides albiventris/cajaneus_russet-naped/gray-cowled wood-rail_gnwrai1
+Aramides calopterus_saracura-de-asa-vermelha_rwwrai1
+Aramides saracura_saracura-do-mato_sbwrai1
+Aramides sp._aramides sp. (saracura)_woodra1
+Tribonyx ventralis_black-tailed nativehen_btnhen1
+Tribonyx hodgenorum_hodgen's waterhen_hodwat1
+Tribonyx mortierii_tasmanian nativehen_tanhen1
+Porphyriops melanops_galinha-d'água-carijó_spfgal1
+Porzana carolina_sora_sora
+Porzana porzana_franga-d'água-malhada_spocra1
+Porzana fluminea_australian crake_auscra1
+Paragallinula angulata_galinha-d'água-pequena_lesmoo1
+Gallinula silvestris_makira moorhen_sacmoo1
+Gallinula nesiotis_tristan moorhen_trimoo2
+Gallinula comeri_gough moorhen_trimoo3
+Gallinula chloropus_galinha-d'água-europeia_commoo3
+Gallinula galeata_galinha-d'água_comgal1
+Gallinula galeata [galeata Group]_galinha-d'água [grupo galeata]_commoo2
+Gallinula galeata garmani_galinha-d'água (garmani)_comgal2
+Gallinula galeata sandvicensis_galinha-d'água (sandvicensis)_commoo1
+Gallinula chloropus/galeata_galinha-d'água/galinha-d'água-americana_commoo
+Gallinula tenebrosa_galinha-d'água-sombria_dusmoo1
+Gallinula pacifica_samoan moorhen_sammoo1
+Fulica rufifrons_carqueja-de-escudo-vermelho_refcoo1
+Fulica cornuta_horned coot_horcoo1
+Fulica gigantea_giant coot_giacoo1
+Fulica armillata_carqueja-de-bico-manchado_regcoo1
+Fulica atra_galeirão-comum_eurcoo
+Gallinula chloropus x Fulica atra_galinha-d'água x galeirão-comum (híbrido)_x00389
+Fulica newtonii_mascarene coot_mascoo1
+Fulica cristata_galeirão-de-crista_rekcoo1
+Fulica atra x cristata_galeirão-comum x galeirão-de-crista (híbrido)_x00911
+Fulica atra/cristata_galeirão-comum/galeirão-de-crista_y00680
+Fulica alai_hawaiian coot_hawcoo
+Fulica alai (Red-shielded)_hawaiian coot (Red-shielded)_hawcoo1
+Fulica alai (White-shielded)_hawaiian coot (White-shielded)_hawcoo2
+Fulica americana_galeirão-americano_y00475
+Fulica americana (Red-shielded)_galeirão-americano (frente vermelha)_amecoo
+Fulica americana (White-shielded)_galeirão-americano (Caraíbas)_carcoo1
+Gallinula galeata x Fulica americana_galinha-d'água-americana x galeirão-americano (híbrido)_x00390
+Fulica ardesiaca_slate-colored coot_slccoo1
+Fulica ardesiaca (White-billed)_slate-colored coot (White-billed)_slccoo2
+Fulica ardesiaca (Yellow-billed)_slate-colored coot (Yellow-billed)_slccoo3
+Fulica armillata x ardesiaca_red-gartered x slate-colored coot (hybrid)_x00845
+Fulica leucoptera_carqueja-de-bico-amarelo_whwcoo1
+Fulica sp._fulica sp. (carqueja)_coot1
+Porphyrio alleni_frango-d’água-africano_allgal1
+Porphyrio martinica_frango-d'água-azul_purgal2
+Porphyrio flavirostris_frango-d'água-pequeno_azugal1
+Porphyrio paepae_marquesan swamphen_marswa1
+Porphyrio kukwiedei_new caledonian gallinule_necgal1
+Porphyrio caerulescens_reunion gallinule_reugal1
+Porphyrio porphyrio_camão_purswa1
+Porphyrio indicus_camão-de-dorso-preto_purswa4
+Porphyrio madagascariensis_camão-africano_purswa2
+Porphyrio hochstetteri_south island takahe_takahe3
+Porphyrio mantelli_north island takahe_takahe2
+Porphyrio melanotus_camão-australasiático_purswa6
+Porphyrio pulverulentus_camão-das-filipinas_purswa5
+Porphyrio albus_lord howe swamphen_lohswa1
+Porphyrio poliocephalus_camão-de-cabeça-cinzenta_purswa3
+Porphyrio indicus x poliocephalus_camão-de-dorso-preto x camão-de-cabeça-cinzenta (híbrido)_x00844
+Porphyrio madagascariensis x poliocephalus_african x gray-headed swamphen (hybrid)_x01061
+Porphyrio indicus/poliocephalus_camão-de-dorso-preto/camão-de-cabeça-cinzenta_y00951
+Porphyrio madagascariensis/poliocephalus_african/gray-headed swamphen_y01233
+Porphyrio sp. (swamphen sp.)_Porphyrio sp._purswa
+Gallinula/Fulica/Porphyrio sp._galinha-d'água/carqueja/frango-d'água_y00614
+Himantornis haematopus_nkulengu rail_nkurai1
+Poliolimnas cinereus_franga-d'água-de-sobrancelha-branca_whbcra1
+Megacrex inepta_new guinea flightless rail_ngfrai1
+Gallicrex cinerea_watercock_waterc1
+Amaurornis isabellina_isabelline bush-hen_isabuh1
+Amaurornis olivacea_plain bush-hen_plabuh1
+Amaurornis phoenicurus_franga-d'água-de-peito-branco_whbwat1
+Amaurornis magnirostris_talaud bush-hen_talbuh1
+Amaurornis moluccana_pale-vented bush-hen_rutbuh1
+Aenigmatolimnas marginalis_franga-d'água-raiada_strcra1
+Rallina tricolor_red-necked crake_rencra1
+Rallina canningi_andaman crake_andcra1
+Rallina [undescribed form]_great nicobar crake (undescribed form)_grncra1
+Rallina fasciata_red-legged crake_relcra1
+Rallina eurizonoides_slaty-legged crake_sllcra1
+Rallina sp._Rallina sp._rallin1
+Zapornia fusca_franga-d'água-de-peito-ruivo_rubcra1
+Zapornia paykullii_band-bellied crake_babcra1
+Zapornia akool_brown crake_brocra1
+Zapornia flavirostra_frango-d'água-negro_blacra1
+Zapornia parva_franga-d'água-bastarda_litcra1
+Zapornia pusilla_franga-d'água-pequena_baicra1
+Zapornia pusilla intermedia_franga-d'água-pequena (intermedia)_baicra2
+Zapornia pusilla pusilla_franga-d'água-pequena (pusilla)_baicra3
+Zapornia pusilla [palustris Group]_franga-d'água-pequena [grupo palustris]_baicra4
+Zapornia parva/pusilla_franga-d'água-bastarda/franga-d'água-pequena_y00950
+Porzana porzana/Zapornia parva/pusilla_franga-d'água-malhada/franga-d'água-bastarda/franga-d'água-pequena_y01026
+Zapornia astrictocarpus_st. helena crake_sthrai1
+Zapornia palmeri_laysan rail_layrai
+Zapornia olivieri_sakalava rail_sakrai1
+Zapornia bicolor_black-tailed crake_bltcra1
+Zapornia sandwichensis_hawaiian rail_hawrai
+Zapornia nigra_miller's rail_milrai1
+Zapornia atra_henderson island crake_heicra1
+Zapornia tabuensis_franga-d'água-de-tongatapu_spocra2
+Zapornia monasa_kosrae crake_koscra1
+Zapornia sp._Zapornia sp._zaporn1
+Rufirallus schomburgkii_maxalalagá_ocecra1
+Rufirallus viridis_sanã-castanha_ruccra1
+Rufirallus fasciatus_sanã-zebrada_blbcra1
+Rufirallus leucopyrrhus_sanã-vermelha_rawcra1
+Rufirallus xenopterus_sanã-de-cara-ruiva_rufcra1
+Anurolimnas castaneiceps_sanã-de-cabeça-castanha_chhcra1
+Coturnicops exquisitus_swinhoe's rail_swirai1
+Coturnicops noveboracensis_yellow rail_yelrai
+Coturnicops noveboracensis noveboracensis_yellow rail (Northern)_yelrai1
+Coturnicops noveboracensis goldmani_yellow rail (Goldman's)_yelrai2
+Laterallus rogersi_inaccessible island rail_inirai1
+Laterallus notatus_pinto-d'água-carijó_sperai1
+Laterallus flaviventer_sanã-amarela_yebcra1
+Laterallus levraudi_rusty-flanked crake_rufcra2
+Laterallus melanophaius_sanã-parda_ruscra1
+Rufirallus leucopyrrhus/Laterallus melanophaius_sanã-parda/sanã-vermelha_y01025
+Laterallus ruber_ruddy crake_rudcra1
+Laterallus albigularis_white-throated crake_whtcra1
+Laterallus albigularis albigularis/cerdaleus_white-throated crake (Rufous-faced)_whtcra2
+Laterallus albigularis cinereiceps_white-throated crake (Gray-faced)_whtcra3
+Laterallus ruber/albigularis_ruddy/white-throated crake_y00844
+Laterallus exilis_sanã-do-capim_grbcra1
+Laterallus spilonota_galapagos rail_galrai1
+Laterallus jamaicensis_sanã-preta_blkrai
+Laterallus jamaicensis jamaicensis/coturniculus_sanã-preta (jamaicensis/coturniculus)_blkrai1
+Laterallus jamaicensis salinasi/murivagans_sanã-preta (salinasi/murivagans)_blkrai2
+Laterallus jamaicensis tuerosi_sanã-preta (tuerosi)_blkrai3
+Laterallus spilopterus_sanã-cinza_dowcra1
+Porzana/Zapornia sp._Porzana/Zapornia sp._porzan1
+Rallidae sp. (rail/crake sp.)_sanã/saracura sp._rail1
+Podica senegalensis_pés-de-barbatanas_afrfin1
+Heliopais personatus_masked finfoot_masfin3
+Heliornis fulica_picaparra_sungre1
+Aramus guarauna_carão_limpki
+Aramus guarauna [pictus Group]_carão [grupo pictus]_limpki1
+Aramus guarauna guarauna_carão (guarauna)_limpki2
+Psophia crepitans_jacamim-do-napo/de-costas-amarelas/de-costas-cinzentas_gywtru1
+Psophia crepitans napensis_jacamim-do-napo_gywtru2
+Psophia crepitans ochroptera_jacamim-de-costas-amarelas_pawtru3
+Psophia crepitans crepitans_jacamim-de-costas-cinzentas_gywtru3
+Psophia leucoptera_jacamim-de-costas-brancas_pawtru2
+Psophia viridis_jacamim-de-costas-escuras/de-costas-verdes/de-costas-marrons/do-xingu_dawtru1
+Psophia viridis viridis_jacamim-de-costas-verdes_dawtru4
+Psophia viridis dextralis_jacamim-de-costas-marrons_dawtru2
+Psophia viridis interjecta_jacamim-do-xingu_dawtru5
+Psophia viridis obscura_jacamim-de-costas-escuras_dawtru3
+Psophia sp._Psophia sp._trumpe1
+Balearica regulorum_gray crowned-crane_grccra1
+Balearica pavonina_grou-coroado_blccra1
+Anthropoides virgo_grou-pequeno_demcra1
+Anthropoides paradiseus_blue crane_blucra2
+Bugeranus carunculatus_wattled crane_watcra2
+Leucogeranus leucogeranus_grou-siberiano_sibcra1
+Antigone canadensis_grou-americano_sancra
+Antigone canadensis canadensis_grou-americano (canadensis)_sancra1
+Antigone canadensis tabida/rowani_grou-americano (tabida/rowani)_sancra2
+Antigone canadensis pulla_grou-americano (pulla)_sancra4
+Antigone canadensis pratensis_grou-americano (pratensis)_sancra5
+Antigone canadensis nesiotes_grou-americano (nesiotes)_sancra6
+Antigone antigone_sarus crane_sarcra1
+Antigone rubicunda_brolga_brolga1
+Antigone antigone x rubicunda_sarus crane x brolga (hybrid)_x00949
+Antigone vipio_white-naped crane_whncra1
+Grus grus_grou-comum_comcra
+Antigone canadensis x Grus grus_grou-americano x grou-comum (híbrido)_x00657
+Grus monacha_grou-de-capuz_hoocra1
+Grus grus x monacha_grou-comum x grou-de-capuz (híbrido)_x00884
+Grus americana_whooping crane_whocra
+Antigone canadensis x Grus americana_sandhill x whooping crane (hybrid)_x00790
+Grus nigricollis_black-necked crane_blncra1
+Grus japonensis_red-crowned crane_reccra1
+Gruidae sp._crane sp._crane1
+Pluvianellus socialis_magellanic plover_magplo1
+Chionis minor_black-faced sheathbill_blfshe1
+Chionis albus_pomba-antártica_snoshe2
+Hesperoburhinus bistriatus_téu-téu-da-savana_dstkne
+Hesperoburhinus superciliaris_peruvian thick-knee_petkne1
+Esacus recurvirostris_great thick-knee_grtkne1
+Esacus magnirostris_alcaravão-dos-recifes_beathk1
+Burhinus capensis_spotted thick-knee_sptkne1
+Burhinus vermiculatus_water thick-knee_watkne1
+Burhinus grallarius_bush thick-knee_butkne1
+Burhinus oedicnemus_alcaravão_eutkne1
+Burhinus indicus_indian thick-knee_indthk1
+Burhinus senegalensis_alcaravão-do-senegal_setkne1
+Burhinus sp._alcaravão (Burhinus) sp._burhin1
+Pluvianus aegyptius_ave-do-crocodilo_egyplo1
+Himantopus himantopus_pernilongo_bkwsti
+Himantopus leucocephalus_pied stilt_piesti1
+Himantopus himantopus x leucocephalus_black-winged x pied stilt (hybrid)_x00830
+Himantopus himantopus/leucocephalus_black-winged/pied stilt_y00932
+Himantopus novaezelandiae_black stilt_blasti1
+Himantopus leucocephalus x novaezelandiae_pied x black stilt (hybrid)_x00459
+Himantopus leucocephalus/novaezelandiae_pied/black stilt_y01133
+Himantopus mexicanus_pernilongo-de-costas-negras/de-costas-brancas_bknsti
+Himantopus mexicanus mexicanus_pernilongo-de-costas-negras_bknsti1
+Himantopus mexicanus knudseni_pernilongo-de-costas-negras/de-costas-brancas (knudseni)_hawsti1
+Himantopus mexicanus melanurus_pernilongo-de-costas-brancas_bknsti2
+Himantopus mexicanus mexicanus x melanurus_pernilongo-de-costas-negras x de-costas-brancas (híbrido)_bknsti3
+Himantopus himantopus x mexicanus_pernilongo x pernilongo-de-dorso-preto (híbrido)_x00846
+Cladorhynchus leucocephalus_banded stilt_bansti1
+Recurvirostra avosetta_alfaiate_pieavo1
+Recurvirostra novaehollandiae_red-necked avocet_renavo1
+Recurvirostra andina_andean avocet_andavo1
+Recurvirostra americana_american avocet_ameavo
+Himantopus mexicanus x Recurvirostra americana_black-necked stilt x american avocet (hybrid)_x00732
+Recurvirostridae sp._stilt/avocet sp._y00722
+Ibidorhyncha struthersii_ibisbill_ibisbi1
+Haematopus ostralegus_ostraceiro_euroys1
+Haematopus ostralegus ostralegus/longipes_ostraceiro (ostralegus/longipes)_euroys2
+Haematopus ostralegus osculans_ostraceiro (osculans)_euroys3
+Haematopus longirostris_pied oystercatcher_pieoys1
+Haematopus finschi_south island oystercatcher_soioys1
+Haematopus chathamensis_chatham islands oystercatcher_chaoys1
+Haematopus unicolor_variable oystercatcher_varoys1
+Haematopus unicolor x finschi_south island x variable oystercatcher (hybrid)_x00928
+Haematopus fuliginosus_sooty oystercatcher_soooys1
+Haematopus palliatus_piru-piru_ameoys
+Haematopus moquini_ostraceiro-preto_afroys1
+Haematopus meadewaldoi_canarian oystercatcher_canoys1
+Haematopus ater_blackish oystercatcher_blaoys1
+Haematopus leucopodus_magellanic oystercatcher_magoys1
+Haematopus bachmani_black oystercatcher_blkoys
+Haematopus palliatus x bachmani_american x black oystercatcher (hybrid)_x00006
+Haematopus palliatus/bachmani_american/black oystercatcher_y01027
+Haematopus sp._oystercatcher sp._oyster1
+Pluvialis squatarola_batuiruçu-de-axila-preta_bkbplo
+Pluvialis apricaria_tarambola-dourada_eugplo
+Pluvialis dominica_batuiruçu_amgplo
+Pluvialis fulva_tarambola-dourada-siberiana_pagplo
+Pluvialis dominica/fulva_batuiruçu/tarambola-dourada-siberiana_y00222
+Pluvialis dominica/apricaria/fulva_tarambola-dourada/batuiruçu/tarambola-dourada-siberiana_golplo
+Pluvialis sp._Pluvialis sp._y00494
+Oreopholus ruficollis_batuíra-de-papo-ferrugíneo_tatdot1
+Hoploxypterus cayanus_mexeriqueira_pielap1
+Phegornis mitchellii_diademed sandpiper-plover_diaplo1
+Zonibyx modestus_batuíra-de-peito-tijolo_rucdot1
+Eudromias morinellus_borrelho-ruivo_eurdot
+Charadrius vociferus_borrelho-de-coleira-dupla_killde
+Charadrius hiaticula_borrelho-grande-de-coleira_corplo
+Charadrius semipalmatus_batuíra-de-bando_semplo
+Charadrius hiaticula/semipalmatus_borrelho-grande-de-coleira/batuíra-de-bando_y00845
+Charadrius melodus_batuíra-melodiosa_pipplo
+Thinornis cucullatus_hooded plover_hooplo2
+Thinornis melanops_black-fronted dotterel_blfdot1
+Thinornis novaeseelandiae_shore plover_shoplo1
+Thinornis forbesi_borrelho-de-forbes_forplo1
+Thinornis tricollaris_borrelho-de-três-coleiras_thbplo1
+Thinornis tricollaris tricollaris_borrelho-de-três-coleiras (tricollaris)_thbplo2
+Thinornis tricollaris bifrontatus_borrelho-de-três-coleiras (bifrontatus)_thbplo3
+Thinornis dubius_borrelho-pequeno-de-coleira_lirplo
+Thinornis dubius curonicus_borrelho-pequeno-de-coleira (curonicus)_lirplo1
+Thinornis dubius dubius/jerdoni_borrelho-pequeno-de-coleira (dubius/jerdoni)_lirplo2
+Charadrius hiaticula/Thinornis dubius_borrelho-grande-de-coleira/borrelho-pequeno-de-coleira_y00379
+Thinornis placidus_long-billed plover_lobplo1
+Charadrius/Thinornis sp._borrelho (Charadrius/Thinornis) sp._charad2
+Vanellus vanellus_abibe_norlap
+Vanellus crassirostris_long-toed lapwing_lotlap1
+Vanellus armatus_abibe-armado_blaplo1
+Vanellus spinosus_tui-tui-ferrão_spwlap1
+Vanellus duvaucelii_river lapwing_rivlap1
+Vanellus malabaricus_yellow-wattled lapwing_yewlap2
+Vanellus tectus_abibe-de-cabeça-preta_blhlap1
+Vanellus albiceps_barbilhão-de-gola-branca_whhlap1
+Vanellus armatus x albiceps_abibe-armado x barbilhão-de-gola-branca (híbrido)_x00885
+Vanellus lugubris_senegal lapwing_senlap1
+Vanellus melanopterus_black-winged lapwing_blwlap1
+Vanellus coronatus_crowned lapwing_crolap1
+Vanellus senegallus_abibe-carúncula_watlap1
+Vanellus melanocephalus_spot-breasted lapwing_spblap1
+Vanellus superciliosus_brown-chested lapwing_brclap1
+Vanellus cinereus_gray-headed lapwing_gyhlap1
+Vanellus indicus_abibe-do-índico_rewlap1
+Vanellus indicus [indicus Group]_abibe-do-índico (Grupo indicus)_rewlap6
+Vanellus indicus atronuchalis_abibe-do-índico (atronuchalis)_rewlap5
+Vanellus macropterus_javan lapwing_sunlap1
+Vanellus tricolor_banded lapwing_banlap1
+Vanellus miles_abibe-de-máscara_maslap1
+Vanellus miles miles_abibe-de-máscara (miles)_maslap2
+Vanellus miles novaehollandiae_abibe-de-máscara (novaehollandiae)_maslap3
+Vanellus gregarius_abibe-sociável_soclap1
+Vanellus leucurus_abibe-de-cauda-branca_whtlap1
+Vanellus chilensis_quero-quero_soulap1
+Vanellus chilensis cayennensis_quero-quero (cayennensis)_soulap2
+Vanellus chilensis lampronotus_quero-quero (lampronotus)_soulap3
+Vanellus chilensis chilensis/fretensis_quero-quero (chilensis/fretensis)_soulap4
+Vanellus resplendens_andean lapwing_andlap1
+Vanellus sp._Vanellus sp._lapwin1
+Erythrogonys cinctus_red-kneed dotterel_rekdot1
+Peltohyas australis_inland dotterel_inldot2
+Anarhynchus asiaticus_borrelho-do-cáspio_casplo1
+Anarhynchus veredus_borrelho-oriental_oriplo1
+Anarhynchus mongolus_siberian sand-plover_lessap2
+Anarhynchus atrifrons_tibetan sand-plover_lessap1
+Anarhynchus mongolus/atrifrons_siberian/tibetan sand-plover_lesplo
+Anarhynchus leschenaultii_borrelho-grande-de-colar-ruivo_grsplo
+Anarhynchus mongolus/atrifrons/leschenaultii_sand-plover sp._y00648
+Anarhynchus bicinctus_double-banded plover_dobplo1
+Anarhynchus frontalis_wrybill_wrybil1
+Anarhynchus obscurus_red-breasted dotterel_rebdot1
+Anarhynchus obscurus aquilonius_red-breasted dotterel (Northern)_rebdot2
+Anarhynchus obscurus obscurus_red-breasted dotterel (Southern)_rebdot3
+Anarhynchus wilsonia_batuíra-bicuda_wilplo
+Anarhynchus collaris_batuíra-de-coleira_colplo1
+Anarhynchus montanus_mountain plover_mouplo
+Anarhynchus alticola_puna plover_punplo1
+Anarhynchus falklandicus_batuíra-de-coleira-dupla_twbplo1
+Anarhynchus thoracicus_madagascar plover_madplo1
+Anarhynchus pecuarius_borrelho-do-gado_kitplo1
+Anarhynchus sanctaehelenae_st. helena plover_sthplo1
+Anarhynchus ruficapillus_borrelho-de-barrete-ruivo_recplo1
+Anarhynchus nivosus_borrelho-de-coleira-interrompida-americano_snoplo5
+Anarhynchus nivosus nivosus_borrelho-de-coleira-interrompida-americano (nivosus)_snoplo3
+Anarhynchus nivosus occidentalis_borrelho-de-coleira-interrompida-americano (occidentalis)_snoplo4
+Anarhynchus pallidus_chestnut-banded plover_chbplo1
+Anarhynchus peronii_borrelho-da-malásia_malplo1
+Anarhynchus marginatus_white-fronted plover_whfplo1
+Anarhynchus javanicus_javan plover_javplo1
+Anarhynchus alexandrinus_borrelho-de-coleira-interrompida_kenplo1
+Anarhynchus alexandrinus alexandrinus/nihonensis_borrelho-de-coleira-interrompida (alexandrinus/nihonensis)_snoplo1
+Anarhynchus alexandrinus seebohmi_borrelho-de-coleira-interrompida (seebohmi)_snoplo2
+Anarhynchus nivosus/alexandrinus_borrelho-de-coleira-interrompida/borrelho-de-coleira-interrompida-americano_snoplo
+Anarhynchus dealbatus_white-faced plover_whfplo2
+Anarhynchus alexandrinus/dealbatus_kentish/white-faced plover_y00378
+Anarhynchus sp._Anarhynchus sp._anarhy1
+Charadrius/Thinornis/Anarhynchus sp._Charadrius/Thinornis/Anarhynchus sp._smaplo1
+Charadriidae sp._Charadriidae sp._plover2
+Pedionomus torquatus_plains-wanderer_plawan1
+Attagis gayi_rufous-bellied seedsnipe_rubsee2
+Attagis malouinus_white-bellied seedsnipe_whbsee2
+Thinocorus orbignyianus_gray-breasted seedsnipe_gybsee1
+Thinocorus rumicivorus_agachadeira-mirim_leasee1
+Rostratula benghalensis_narceja-pintada-grande_grpsni1
+Rostratula australis_australian painted-snipe_auspas1
+Nycticryphes semicollaris_narceja-de-bico-torto_soapas1
+Hydrophasianus chirurgus_pheasant-tailed jacana_phtjac1
+Jacana spinosa_northern jacana_norjac
+Jacana jacana_jaçanã_watjac1
+Jacana jacana hypomelaena_jaçanã (hypomelaena)_watjac2
+Jacana jacana [jacana Group]_jaçanã [grupo jacana]_watjac3
+Jacana spinosa x jacana_northern x wattled jacana (hybrid)_x00791
+Jacana spinosa/jacana_northern/wattled jacana_y00846
+Microparra capensis_jaçaná-pequeno_lesjac1
+Irediparra gallinacea_jaçanã-de-crista_cocjac1
+Metopidius indicus_bronze-winged jacana_brwjac1
+Actophilornis africanus_jaçaná_afrjac1
+Actophilornis albinucha_madagascar jacana_madjac1
+Jacanidae sp._jacana sp._jacana1
+Bartramia longicauda_maçarico-do-campo_uplsan
+Numenius tahitiensis_bristle-thighed curlew_brtcur
+Numenius phaeopus_maçarico-galego/maçarico-de-bico-torto_whimbr
+Numenius phaeopus hudsonicus_maçarico-de-bico-torto_whimbr3
+Numenius phaeopus [phaeopus Group]_maçarico-galego [grupo phaeopus]_whimbr5
+Numenius phaeopus phaeopus_maçarico-galego (phaeopus)_whimbr1
+Numenius phaeopus alboaxillaris_maçarico-galego (alboaxillaris)_whimbr4
+Numenius phaeopus variegatus/rogachevae_maçarico-galego (variegatus)_whimbr2
+Numenius minutus_little curlew_litcur
+Numenius borealis_maçarico-esquimó_eskcur
+Numenius americanus_long-billed curlew_lobcur
+Numenius madagascariensis_maçarico-oriental_faecur
+Numenius tenuirostris_slender-billed curlew_slbcur
+Numenius arquata_maçarico-real_eurcur
+Numenius phaeopus/arquata_maçarico-galego/maçarico-real_y00774
+Numenius madagascariensis/arquata_maçarico-oriental/maçarico-real_y00952
+Numenius sp._Numenius sp._curlew1
+Limosa lapponica_fuselo_batgod
+Limosa lapponica [lapponica Group]_fuselo [grupo lapponica]_batgod1
+Limosa lapponica [baueri Group]_fuselo [grupo baueri]_batgod2
+Limosa limosa_milherango_bktgod
+Limosa limosa islandica_milherango (islandica)_bktgod1
+Limosa limosa limosa_milherango (limosa)_bktgod2
+Limosa limosa melanuroides_milherango (melanuroides)_bktgod3
+Limosa limosa bohaii_milherango (bohaii)_bktgod4
+Limosa lapponica/limosa_fuselo/milherango_y00380
+Limosa haemastica_maçarico-de-bico-virado_hudgod
+Limosa lapponica x haemastica_fuselo x maçaricão-de-bico-virado (híbrido)_x01025
+Limosa limosa x haemastica_milherango x maçaricão-de-bico-virado (híbrido)_x01026
+Limosa fedoa_maçarico-marmóreo_margod
+Limosa haemastica/fedoa_maçaricão-de-bico-virado/maçarico-marmóreo_y00381
+Limosa sp._Limosa sp._godwit1
+Limnodromus semipalmatus_maçarico-asiático_asidow1
+Limnodromus griseus_maçarico-de-costas-brancas_shbdow
+Limnodromus griseus griseus_maçarico-de-costas-brancas (griseus)_shbdow1
+Limnodromus griseus hendersoni_maçarico-de-costas-brancas (hendersoni)_shbdow2
+Limnodromus griseus caurinus_maçarico-de-costas-brancas (caurinus)_shbdow3
+Limnodromus scolopaceus_maçarico-de-bico-comprido_lobdow
+Limnodromus griseus/scolopaceus_maçarico-de-costas-brancas/maçarico-de-bico-comprido_dowitc
+Lymnocryptes minimus_narceja-galega_jacsni
+Scolopax minor_galinhola americana_amewoo
+Scolopax rusticola_galinhola_eurwoo
+Scolopax mira_amami woodcock_amawoo1
+Scolopax rusticola/mira_eurasian/amami woodcock_y01217
+Scolopax bukidnonensis_bukidnon woodcock_bukwoo1
+Scolopax saturata_javan woodcock_duswoo4
+Scolopax rosenbergii_new guinea woodcock_duswoo3
+Scolopax celebensis_sulawesi woodcock_sulwoo1
+Scolopax rochussenii_moluccan woodcock_molwoo1
+Coenocorypha barrierensis_north island snipe_noisni1
+Coenocorypha iredalei_south island snipe_soisni1
+Coenocorypha pusilla_chatham islands snipe_chisni1
+Coenocorypha huegeli_snares snipe_snisni1
+Coenocorypha aucklandica_subantarctic snipe_subsni1
+Gallinago imperialis_imperial snipe_impsni1
+Gallinago jamesoni_jameson's snipe_andsni1
+Gallinago stricklandii_fuegian snipe_fuesni1
+Gallinago solitaria_narceja-solitária_solsni1
+Gallinago nemoricola_wood snipe_woosni1
+Gallinago media_narceja-real_gresni1
+Gallinago megala_narceja-de-swinhoe_swisni1
+Gallinago stenura_narceja-siberiana_pitsni
+Gallinago megala/stenura_narceja-de-swinhoe/narceja-siberiana_y00723
+Gallinago hardwickii_latham's snipe_latsni1
+Gallinago nigripennis_african snipe_afrsni1
+Gallinago gallinago_common snipe_comsni
+Gallinago media x gallinago_great x common snipe (hybrid)_x00792
+Gallinago stenura/gallinago_narceja/narceja-siberiana_y00847
+Gallinago delicata_narceja-de-wilson_wilsni1
+Gallinago gallinago/delicata_narceja/narceja-de-wilson_y00477
+Gallinago undulata_narcejão_giasni1
+Gallinago nobilis_noble snipe_nobsni1
+Gallinago andina_puna snipe_punsni1
+Gallinago macrodactyla_madagascar snipe_madsni1
+Gallinago paraguaiae_narceja_soasni2
+Gallinago delicata/paraguaiae_wilson's/pantanal snipe_y01125
+Gallinago magellanica_magellanic snipe_soasni3
+Gallinago paraguaiae/magellanica_paraguayan/magellanic snipe_soasni1
+Gallinago sp._Gallinago sp._snipe2
+Phalaropus tricolor_pisa-n'água_wilpha
+Phalaropus fulicarius_pisa-n’água-de-bico-grosso_redpha1
+Phalaropus lobatus_pisa-n’água-de-pescoço-vermelho_renpha
+Phalaropus fulicarius/lobatus_pisa-n’água-de-bico-grosso/pisa-n’água-de-pescoço-vermelho_y00635
+Phalaropus sp._falaropo sp._phalar
+Xenus cinereus_maçarico-tereque_tersan
+Actitis hypoleucos_maçarico-das-rochas_comsan
+Actitis macularius_maçarico-pintado_sposan
+Actitis hypoleucos/macularius_maçarico-das-rochas/maçarico-pintado_y00668
+Tringa ochropus_maçarico-bique-bique_grnsan
+Tringa solitaria_maçarico-solitário_solsan
+Tringa solitaria solitaria_maçarico-solitário (solitaria)_solsan1
+Tringa solitaria cinnamomea_maçarico-solitário (cinnamomea)_solsan2
+Actitis hypoleucos/Tringa solitaria_maçarico-das-rochas/maçarico-solitário_y01311
+Tringa brevipes_maçarico-de-cauda-cinzenta_gyttat1
+Tringa incana_wandering tattler_wantat1
+Tringa brevipes/incana_gray-tailed/wandering tattler_y00495
+Tringa stagnatilis_perna-verde-fino_marsan
+Tringa glareola_maçarico-de-bico-curto_woosan
+Tringa totanus_maçarico-de-perna-vermelha_comred1
+Tringa flavipes_maçarico-de-perna-amarela_lesyel
+Tringa guttifer_nordmann's greenshank_norgre1
+Tringa semipalmata_maçarico-de-asa-branca/grande-de-asa-branca_willet1
+Tringa semipalmata semipalmata_maçarico-de-asa-branca_willet2
+Tringa semipalmata inornata_maçarico-grande-de-asa-branca_willet3
+Tringa erythropus_perna-vermelha-bastardo_spored
+Tringa totanus/erythropus_perna-vermelha/perna-vermelha-bastardo_y00383
+Tringa nebularia_perna-verde-comum_comgre
+Tringa guttifer/nebularia_nordmann's/common greenshank_y00954
+Tringa melanoleuca_maçarico-grande-de-perna-amarela_greyel
+Tringa flavipes/melanoleuca_maçarico-de-perna-amarela/grande-de-perna-amarela_y00476
+Tringa sp._tringa sp. (maçarico)_tringa1
+Prosobonia cancellata_kiritimati sandpiper_kirsan1
+Prosobonia leucoptera_white-winged sandpiper_whwsan1
+Prosobonia ellisi_moorea sandpiper_moosan1
+Prosobonia parvirostris_tuamotu sandpiper_tuasan1
+Arenaria interpres_vira-pedras_rudtur
+Arenaria melanocephala_black turnstone_blktur
+Calidris tenuirostris_seixoeira-grande_grekno
+Calidris canutus_maçarico-de-papo-vermelho_redkno
+Calidris tenuirostris/canutus_seixoeira-grande/seixoeira_y00382
+Calidris virgata_surfbird_surfbi
+Calidris tenuirostris x virgata_great knot x surfbird (hybrid)_x00733
+Calidris canutus x virgata_red knot x surfbird (hybrid)_x00675
+Calidris pugnax_combatente_ruff
+Calidris falcinellus_pilrito-de-bico-grosso_brbsan
+Calidris acuminata_pilrito-acuminado_shtsan
+Calidris ferruginea_maçarico-de-bico-curvo_cursan
+Calidris himantopus_maçarico-pernilongo_stisan
+Calidris temminckii_pilrito-de-temminck_temsti
+Calidris subminuta_pilrito-de-dedos-compridos_lotsti
+Calidris ruficollis_pilrito-de-pescoço-ruivo_rensti
+Calidris pygmaea_spoon-billed sandpiper_spbsan1
+Calidris subruficollis_maçarico-acanelado_bubsan
+Calidris alba_maçarico-branco_sander
+Calidris alpina_pilrito-de-peito-preto_dunlin
+Calidris alpina pacifica/arcticola_pilrito-de-peito-preto (pacifica/arcticola)_dunlin1
+Calidris alpina hudsonia_pilrito-de-peito-preto (hudsonia)_dunlin2
+Calidris alpina arctica_pilrito-de-peito-preto (arctica)_dunlin3
+Calidris alpina schinzii_pilrito-de-peito-preto (schinzii)_dunlin4
+Calidris alpina alpina/centralis_pilrito-de-peito-preto (alpina/centralis)_dunlin5
+Calidris alpina [sakhalina Group]_pilrito-de-peito-preto [grupo sakhalina]_dunlin6
+Calidris ferruginea/alpina_pilrito-de-bico-comprido/pilrito-de-peito-preto_y01074
+Calidris maritima_pilrito-escuro_pursan
+Calidris alpina x maritima_pilrito-de-peito-preto x pilrito-escuro (híbrido)_x00433
+Calidris ptilocnemis_rock sandpiper_rocsan
+Calidris ptilocnemis ptilocnemis_rock sandpiper (Pribilof Is.)_rocsan2
+Calidris ptilocnemis quarta/tschuktschorum/couesi_rock sandpiper (quarta/tschuktschorum/couesi)_rocsan5
+Calidris ptilocnemis quarta_rock sandpiper (Kuril Is.)_rocsan4
+Calidris ptilocnemis tschuktschorum_rock sandpiper (Bering Strait)_rocsan1
+Calidris ptilocnemis couesi_rock sandpiper (Aleutian)_rocsan3
+Calidris maritima/ptilocnemis_purple/rock sandpiper_y00953
+Calidris bairdii_maçarico-de-bico-fino_baisan
+Calidris subruficollis x bairdii_pilrito-acanelado x pilrito-de-bico-fino (híbrido)_x01123
+Calidris minuta_maçarico-pequeno_litsti
+Calidris ruficollis/minuta_pilrito-de-pescoço-ruivo/pilrito-pequeno_y00497
+Calidris fuscicollis_maçarico-de-sobre-branco_whrsan
+Arenaria interpres x Calidris fuscicollis_ruddy turnstone x white-rumped sandpiper (hybrid)_x01062
+Calidris subruficollis x fuscicollis_pilrito-de-sobre-branco x pilrito-acanelado (híbrido)_x00431
+Calidris alpina x fuscicollis_pilrito-de-peito-preto x pilrito-de-sobre-branco (híbrido)_x00430
+Calidris minutilla_maçariquinho_leasan
+Calidris melanotos_maçarico-de-colete_pecsan
+Calidris ferruginea x melanotos_pilrito-de-bico-comprido x pilrito-de-colete (híbrido)_x00432
+Calidris fuscicollis x melanotos_white-rumped x pectoral sandpiper (hybrid)_x01094
+Calidris acuminata/melanotos_pilrito-acuminado/pilrito-de-colete_y00705
+Calidris mauri_maçarico-do-alasca_wessan
+Calidris pusilla_maçarico-rasteirinho_semsan
+Calidris fuscicollis x pusilla_white-rumped x semipalmated sandpiper (hybrid)_x01042
+Calidris mauri/pusilla_pilrito-miúdo/pilrito-rasteirinho_y00496
+Calidris sp. (peep sp.)_pilrito sp._calidr
+Calidris sp._calidris sp. (maçarico)_calidr1
+Scolopacidae sp._limícola (scolopacidae) sp._scolop1
+Charadriiformes sp. (large shorebird sp.)_limícola grande sp._larsho1
+Turnix tanki_yellow-legged buttonquail_yelbut1
+Turnix maculosus_toirão-malhado_rebbut2
+Turnix suscitator_barred buttonquail_barbut1
+Turnix ocellatus_spotted buttonquail_spobut2
+Turnix sylvaticus_toirão_smabut2
+Turnix velox_little buttonquail_litbut1
+Turnix pyrrhothorax_red-chested buttonquail_recbut1
+Turnix worcesteri_luzon buttonquail_luzbut1
+Turnix everetti_sumba buttonquail_sumbut1
+Turnix nanus_black-rumped buttonquail_hotbut3
+Turnix hottentottus_fynbos buttonquail_hotbut1
+Turnix castanotus_chestnut-backed buttonquail_chbbut2
+Turnix olivii_buff-breasted buttonquail_bubbut1
+Turnix varius_painted buttonquail_paibut
+Turnix novaecaledoniae_new caledonian buttonquail_paibut1
+Turnix melanogaster_black-breasted buttonquail_blbbut2
+Turnix nigricollis_madagascar buttonquail_madbut1
+Turnix sp._toirão (Turnix) sp._button1
+Ortyxelos meiffrenii_quail-plover_quailp1
+Dromas ardeola_caranguejeiro_craplo1
+Smutsornis africanus_double-banded courser_dobcou2
+Rhinoptilus chalcopterus_asa-de-bronze_brwcou1
+Rhinoptilus bitorquatus_jerdon's courser_jercou1
+Rhinoptilus cinctus_three-banded courser_thbcou1
+Cursorius temminckii_corredeira-de-temminck_temcou1
+Cursorius coromandelicus_indian courser_indcou1
+Cursorius cursor_corredeira_crccou1
+Cursorius somalensis_somali courser_somcou1
+Cursorius rufus_burchell's courser_burcou2
+Glareolidae sp. (courser sp.)_courser sp._course1
+Glareola nuchalis_perdiz-do-mar-de-colar-branco_rocpra1
+Glareola nuchalis liberiae_perdiz-do-mar-de-colar-branco (liberiae)_rocpra2
+Glareola nuchalis nuchalis_perdiz-do-mar-de-colar-branco (nuchalis)_rocpra3
+Glareola isabella_pedriz-do-mar-australiana_auspra1
+Glareola cinerea_gray pratincole_grypra1
+Glareola lactea_small pratincole_smapra1
+Glareola ocularis_madagascar pratincole_madpra1
+Glareola pratincola_perdiz-do-mar_colpra
+Glareola nordmanni_perdiz-do-mar-d'asa-preta_blwpra1
+Glareola pratincola/nordmanni_perdiz-do-mar/perdiz-d'asa-preta_y00776
+Glareola maldivarum_perdiz-do-mar-oriental_oripra
+Glareola pratincola/maldivarum_perdiz-do-mar/perdiz-do-mar-oriental_y00775
+Glareola sp._perdiz-do-mar (Glareola) sp._pratin1
+Charadriiformes sp. (shorebird sp.)_Charadriiformes sp._shoreb1
+Stercorarius longicaudus_mandrião-de-cauda-comprida_lotjae
+Stercorarius parasiticus_mandrião-parasítico_parjae
+Stercorarius longicaudus/parasiticus_mandrião-de-cauda-comprida/parasítico_y00481
+Stercorarius pomarinus_mandrião-pomarino_pomjae
+Stercorarius longicaudus/pomarinus_mandrião-de-cauda-comprida/pomarino_y00480
+Stercorarius parasiticus/pomarinus_mandrião-parasítico/pomarino_y00479
+Stercorarius skua_mandrião-grande_gresku1
+Stercorarius chilensis_mandrião-chileno_chisku1
+Stercorarius antarcticus_mandrião-antártico_brnsku3
+Stercorarius antarcticus lonnbergi_mandrião-antártico (lonnbergi)_brnsku1
+Stercorarius antarcticus antarcticus_mandrião-antártico (antarcticus)_sousku1
+Stercorarius antarcticus hamiltoni_mandrião-antártico (hamiltoni)_brnsku2
+Stercorarius maccormicki_mandrião-do-sul_sopsku1
+Stercorarius sp. (jaeger sp.)_mandrião-pomarino/parasítico/de-cauda-comprida_jaeger
+Stercorarius sp. (skua sp.)_alcaide sp._skua
+Stercorarius sp._mandrião sp._y00615
+Cerorhinca monocerata_rhinoceros auklet_rhiauk
+Fratercula cirrhata_papagaio-do-mar-de-penachos_tufpuf
+Fratercula arctica_papagaio-do-mar_atlpuf
+Fratercula corniculata_horned puffin_horpuf
+Fratercula sp._papagaio-do-mar (Fratercula) sp._puffin1
+Ptychoramphus aleuticus_cassin's auklet_casauk
+Aethia pusilla_least auklet_leaauk
+Aethia pygmaea_whiskered auklet_whiauk
+Aethia cristatella_torda-de-penacho_creauk
+Aethia psittacula_torda-papagaio_parauk
+Ptychoramphus/Aethia sp._auklet sp._auklet
+Brachyramphus perdix_airinho-de-bico-comprido_lobmur
+Brachyramphus brevirostris_kittlitz's murrelet_kitmur
+Brachyramphus marmoratus_marbled murrelet_marmur
+Cepphus grylle_airo-d'asa-branca_blkgui
+Cepphus grylle mandtii_airo-d'asa-branca (mandtii)_blkgui2
+Cepphus grylle [grylle Group]_airo-d'asa-branca [grupo grylle]_blkgui1
+Cepphus carbo_spectacled guillemot_spegui1
+Cepphus columba_pigeon guillemot_piggui
+Cepphus columba snowi_pigeon guillemot (snowi)_piggui2
+Cepphus columba [columba Group]_pigeon guillemot (columba Group)_piggui1
+Cepphus grylle/columba_black/pigeon guillemot_y00223
+Alca torda_torda-mergulheira_razorb
+Pinguinus impennis_great auk_greauk
+Alle alle_torda-miúda_doveki
+Uria lomvia_airo-de-freio_thbmur
+Uria aalge_airo_commur
+Uria lomvia x aalge_airo-de-freio x airo (híbrido)_x00793
+Uria lomvia/aalge_airo-de-freio/airo_murre
+Alca/Uria sp._airo/torda-mergulheira_laralc1
+Synthliboramphus antiquus_torda-miúda-do-pacífico_ancmur
+Synthliboramphus wumizusume_japanese murrelet_japmur1
+Synthliboramphus scrippsi_scripps's murrelet_xanmur2
+Synthliboramphus hypoleucus_guadalupe murrelet_xanmur1
+Synthliboramphus scrippsi/hypoleucus_scripps's/guadalupe murrelet (Xantus's Murrelet)_xanmur
+Synthliboramphus craveri_craveri's murrelet_cramur
+Synthliboramphus scrippsi/craveri_scripps's/craveri's murrelet_y00777
+Synthliboramphus scrippsi/hypoleucus/craveri_scripps's/guadalupe/craveri's murrelet_y00482
+Brachyramphus/Synthliboramphus sp._murrelet sp._murrel
+Alcidae sp._alcídeo sp._alcid
+Creagrus furcatus_swallow-tailed gull_swtgul1
+Hydrocoloeus minutus_gaivota-pequena_litgul
+Rhodostethia rosea_gaivota-rosada_rosgul
+Rissa tridactyla_gaivota-tridáctila_bklkit
+Rissa tridactyla tridactyla_gaivota-tridáctila (tridactyla)_bklkit1
+Rissa tridactyla pollicaris_gaivota-tridáctila (pollicaris)_bklkit2
+Rissa brevirostris_red-legged kittiwake_relkit
+Rissa tridactyla/brevirostris_black-legged/red-legged kittiwake_y00697
+Pagophila eburnea_gaivota-marfim_ivogul
+Xema sabini_gaivota-de-sabine_sabgul
+Saundersilarus saundersi_saunders's gull_saugul2
+Chroicocephalus genei_gaivota-de-bico-fino_slbgul1
+Chroicocephalus philadelphia_guincho-americano_bongul
+Chroicocephalus novaehollandiae_silver gull_silgul2
+Chroicocephalus novaehollandiae novaehollandiae/forsteri_silver gull (Silver)_silgul1
+Chroicocephalus novaehollandiae scopulinus_silver gull (Red-billed)_rebgul1
+Chroicocephalus bulleri_black-billed gull_blbgul1
+Chroicocephalus novaehollandiae/bulleri_silver/black-billed gull_y00384
+Chroicocephalus serranus_andean gull_andgul1
+Chroicocephalus maculipennis_gaivota-maria-velha_brhgul2
+Chroicocephalus maculipennis (White-winged)_gaivota-maria-velha (White-winged)_bnhgul3
+Chroicocephalus maculipennis (Dark-winged)_gaivota-maria-velha (Dark-winged)_bnhgul2
+Chroicocephalus ridibundus_gaivota-de-capuz-escuro_bkhgul
+Chroicocephalus genei x ridibundus_gaivota-de-bico-fino x guincho-comum (híbrido)_x00391
+Chroicocephalus genei/ridibundus_gaivota-de-bico-fino/guincho-comum_y00778
+Chroicocephalus brunnicephalus_gaivota-do-índico_bnhgul1
+Chroicocephalus genei x brunnicephalus_gaivota-de-bico-fino x gaivota-do-índico (híbrido)_x00734
+Chroicocephalus ridibundus/brunnicephalus_guincho-comum/gaivota-do-índico_y00955
+Chroicocephalus cirrocephalus_gaivota-de-cabeça-cinza_grhgul
+Chroicocephalus maculipennis/cirrocephalus_gaivota-maria-velha/gaivota-de-cabeça-cinza_y00385
+Chroicocephalus hartlaubii_hartlaub's gull_hargul1
+Chroicocephalus cirrocephalus x hartlaubii_gray-hooded x hartlaub's gull (hybrid)_x00886
+Chroicocephalus sp._Chroicocephalus sp._chroic1
+Leucophaeus modestus_gray gull_grygul
+Leucophaeus scoresbii_dolphin gull_dolgul2
+Leucophaeus atricilla_gaivota-alegre_laugul
+Chroicocephalus cirrocephalus x Leucophaeus atricilla_gaivota-de-cabeça-cinzenta x gaivota-alegre (híbrido)_x00392
+Leucophaeus pipixcan_gaivota-de-franklin_fragul
+Chroicocephalus philadelphia x Leucophaeus pipixcan_guincho-americano x gaivota-das-pradarias (híbrido)_x00794
+Leucophaeus atricilla/pipixcan_gaivota-alegre/de-franklin_y00685
+Leucophaeus fuliginosus_lava gull_lavgul1
+Ichthyaetus ichthyaetus_gaivotão-de-cabeça-preta_gbhgul2
+Ichthyaetus relictus_gaivota-relíquia_relgul2
+Ichthyaetus audouinii_gaivota-de-audouin_audgul1
+Ichthyaetus melanocephalus_gaivota-de-cabeça-preta_medgul1
+Chroicocephalus ridibundus x Ichthyaetus melanocephalus_guincho-comum x gaivota-de-cabeça-preta (híbrido)_x00695
+Chroicocephalus ridibundus/Ichthyaetus melanocephalus_guincho-comum/gaivota-de-cabeça-preta_y00779
+Ichthyaetus hemprichii_gaivota-fuliginosa_soogul2
+Ichthyaetus leucophthalmus_gaivota-d'olho-branco_whegul2
+Larus pacificus_pacific gull_pacgul1
+Larus belcheri_belcher's gull_belgul
+Larus crassirostris_black-tailed gull_bktgul
+Larus atlanticus_gaivota-de-rabo-preto_olrgul1
+Larus heermanni_heermann's gull_heegul
+Larus canus_famego_mewgul
+Larus canus canus_famego (canus)_comgul1
+Larus canus heinei_famego (heinei)_mewgul3
+Larus canus kamtschatschensis_famego (kamtschatschensis)_kamgul1
+Chroicocephalus ridibundus x Larus canus_guincho-comum x famego (híbrido)_x00393
+Ichthyaetus melanocephalus x Larus canus_gaivota-de-cabeça-preta x famego (híbrido)_x00847
+Larus brachyrhynchus_famego-americano_mewgul2
+Larus canus/brachyrhynchus_famego/famego-americano_y00441
+Larus delawarensis_gaivota-de-bico-riscado_ribgul
+Chroicocephalus ridibundus x Larus delawarensis_guincho-comum x gaivota-de-bico-riscado (híbrido)_x00641
+Leucophaeus atricilla x Larus delawarensis_gaivota-alegre x gaivota-de-bico-riscado (híbrido)_x00616
+Leucophaeus pipixcan x Larus delawarensis_gaivota-das-pradarias x gaivota-de-bico-riscado (híbrido)_x00795
+Larus canus x delawarensis_famego x gaivota-de-bico-riscado (híbrido)_x00394
+Larus livens_yellow-footed gull_yefgul
+Larus occidentalis_western gull_wesgul
+Larus livens/occidentalis_yellow-footed/western gull_y00683
+Larus cachinnans_gaivota-do-cáspio_casgul2
+Larus dominicanus_gaivotão_kelgul
+Larus dominicanus dominicanus_gaivotão (dominicanus)_kelgul3
+Larus dominicanus austrinus_gaivotão (austrinus)_kelgul2
+Larus dominicanus judithae_gaivotão (judithae)_kelgul4
+Larus dominicanus vetula_gaivotão (vetula)_kelgul1
+Larus dominicanus melisandae_gaivotão (melisandae)_kelgul5
+Larus smithsonianus_gaivota-prateada-americana_amhgul1
+Larus delawarensis x smithsonianus_gaivota-de-bico-riscado x gaivota-prateada-americana (híbrido)_x00796
+Larus vegae_vega gull_veggul1
+Larus smithsonianus/vegae_american herring/vega gull_y01294
+Larus mongolicus_mongolian gull_casgul4
+Larus vegae/mongolicus_vega/mongolian gull_y01295
+Larus argentatus_gaivota-prateada_euhgul1
+Larus cachinnans x argentatus_gaivota-do-cáspio x gaivota-prateada (híbrido)_x00915
+Larus dominicanus x smithsonianus_gaivotão-austral x gaivota-prateada-americana (híbrido)_kxhgul1
+Larus cachinnans/argentatus_gaivota-do-cáspio/gaivota-prateada_y01261
+Larus smithsonianus/argentatus_gaivota-prateada-americana/gaivota-prateada_y01345
+Larus michahellis_gaivota-de-patas-amarelas_yelgul1
+Larus michahellis atlantis_gaivota-de-patas-amarelas-macaronésica_yelgul2
+Larus michahellis michahellis_gaivota-de-patas-amarelas-continental_yelgul3
+Larus cachinnans x michahellis_gaivota-do-cáspio x gaivota-de-patas-amarelas (híbrido)_x00395
+Larus cachinnans/michahellis_gaivota-do-cáspio/gaivota-de-patas-amarelas_y00724
+Larus argentatus/michahellis_gaivota-prateada/gaivota-de-patas-amarelas_y00848
+Larus cachinnans/argentatus/michahellis_gaivota-do-cáspio/gaivota-prateada/gaivota-de-patas-amarelas_y00386
+Larus armenicus_gaivota-da-arménia_armgul1
+Larus cachinnans/michahellis/armenicus_gaivota-do-cáspio/gaivota-de-patas-amarelas/gaivota-da-arménia_y00725
+Larus marinus_gaivotão-real_gbbgul
+Larus smithsonianus x marinus_gaivota-prateada-americana x gaivotão-real (híbrido)_x00047
+Larus argentatus x marinus_gaivota-prateada x gaivotão-real (híbrido)_x01130
+Larus michahellis x marinus_gaivota-de-patas-amarelas x gaivotão-real (híbrido)_x00397
+Larus hyperboreus_gaivotão-branco_glagul
+Larus smithsonianus x hyperboreus_gaivota-prateada-americana x gaivotão-branco (híbrido)_x01131
+Larus vegae x hyperboreus_vega x glaucous gull (hybrid)_x01132
+Larus argentatus x hyperboreus_gaivota-prateada x gaivotão-branco (híbrido)_x01133
+Larus smithsonianus/vegae/argentatus x hyperboreus_american herring/vega/european herring x glaucous gull (hybrid)_nelgul
+Larus marinus x hyperboreus_gaivotão-real x gaivotão-branco (híbrido)_x00632
+Larus fuscus_gaivota-da-asa-escura_lbbgul
+Larus fuscus fuscus_gaivota-da-asa-escura (fuscus)_lbbgul1
+Larus fuscus intermedius_gaivota-da-asa-escura (intermedius)_lbbgul2
+Larus fuscus graellsii_gaivota-da-asa-escura (graellsii)_lbbgul3
+Larus fuscus heuglini_gaivota-da-asa-escura (heuglini)_lbbgul4
+Larus fuscus barabensis_gaivota-da-asa-escura (barabensis)_casgul3
+Larus fuscus taimyrensis_gaivota-da-asa-escura (taimyrensis)_lbbgul5
+Larus fuscus intermedius/graellsii_gaivota-d'asa-escura (intermedius/graellsii)_lbbgul6
+Larus delawarensis x fuscus_ring-billed x lesser black-backed gull (hybrid)_x01008
+Larus smithsonianus x fuscus_gaivota-prateada-americana x gaivota-d'asa-escura (híbrido)_x01134
+Larus argentatus x fuscus_gaivota-prateada x gaivota-d'asa-escura (híbrido)_x00057
+Larus michahellis x fuscus_gaivota-de-patas-amarelas x gaivota-d'asa-escura (híbrido)_x00396
+Larus smithsonianus/vegae/mongolicus/argentatus/fuscus_herring complex/lesser black-backed gull_y00726
+Larus michahellis/fuscus_gaivota-de-patas-amarelas/gaivota-d'asa-escura_y00849
+Larus californicus_california gull_calgul
+Larus californicus californicus_california gull (californicus)_calgul1
+Larus californicus albertaensis_california gull (albertaensis)_calgul2
+Larus smithsonianus x californicus_american herring x california gull (hybrid)_x00797
+Larus glaucescens_gaivota-do-mar-de-bering_glwgul
+Larus occidentalis x glaucescens_western x glaucous-winged gull (hybrid)_x00051
+Larus smithsonianus x glaucescens_gaivota-prateada-americana x gaivota-do-mar-de-bering (híbrido)_x00050
+Larus hyperboreus x glaucescens_gaivotão-branco x gaivota-do-mar-de-bering (híbrido)_x00048
+Larus smithsonianus/glaucescens_gaivota-prateada-americana/gaivota-do-mar-de-bering_y00956
+Larus occidentalis/glaucescens_western/glaucous-winged gull_y00656
+Larus schistisagus_gaivota-de-kamechatca_slbgul
+Larus vegae x schistisagus_vega x slaty-backed gull (hybrid)_x00434
+Larus glaucescens x schistisagus_gaivota-do-mar-de-bering x gaivota-de-kamechatca (híbrido)_x00436
+Larus hyperboreus x schistisagus_gaivotão-branco x gaivota-de-kamechatca (híbrido)_x00437
+Larus glaucoides_gaivota-branca_y00478
+Larus glaucoides thayeri_gaivota-branca (thayeri)_thagul
+Larus glaucoides kumlieni_gaivota-branca (kumlieni)_kumgul1
+Larus glaucoides thayeri/kumlieni_gaivota-branca (thayeri/kumlieni)_icegul2
+Larus glaucoides glaucoides_gaivota-branca (glaucoides)_icegul1
+Larus glaucoides kumlieni/glaucoides_gaivota-branca (kumlieni/glaucoides)_icegul
+Larus glaucoides thayeri x glaucoides/kumlieni_gaivota-branca (thayeri x glaucoides/kumlieni)_x00435
+Larus smithsonianus x glaucoides_gaivota-prateada-americana x gaivota-branca (híbrido)_x00617
+Larus smithsonianus/glaucoides_gaivota-prateada-americana/gaivota-branca_y00682
+Larus argentatus/glaucoides_gaivota-prateada/gaivota-branca_y01296
+Larus sp. (white-winged gull sp.)_gaivota-de-asas-brancas (Larus) sp._whwgul1
+Larus sp._Larus sp._larus1
+Larinae sp._Larinae sp._larus
+Rynchops flavirostris_talha-mar-africano_afrski1
+Rynchops albicollis_indian skimmer_indski1
+Rynchops niger_talha-mar_blkski
+Rynchops niger niger_talha-mar (niger)_blkski1
+Rynchops niger cinerascens_talha-mar (cinerascens)_blkski2
+Rynchops niger intercedens_talha-mar (intercedens)_blkski3
+Gygis alba_grazina_whiter
+Gygis alba alba_grazina (alba)_whiter3
+Gygis alba candida/leucopes_grazina (candida/leucopes)_whiter4
+Gygis alba microrhyncha_grazina (microrhyncha)_whiter5
+Anous stolidus_trinta-réis-escuro_brnnod
+Anous tenuirostris_lesser noddy_lesnod1
+Anous minutus_trinta-réis-preto_blknod
+Anous minutus americanus_trinta-réis-preto (americanus)_blknod3
+Anous minutus melanogenys_trinta-réis-preto (melanogenys)_blknod1
+Anous minutus [minutus Group]_trinta-réis-preto [grupo minutus]_blknod2
+Anous stolidus/minutus_trinta-réis-escuro/preto_noddy
+Anous tenuirostris/minutus_lesser/black noddy_y00780
+Anous albivitta_gray noddy_grynod1
+Anous ceruleus_blue-gray noddy_bugnod
+Anous albivitta/ceruleus_gray/blue-gray noddy_y01328
+Onychoprion aleuticus_gaivina-das-aleutas_aleter1
+Onychoprion fuscatus_trinta-réis-das-rocas_sooter1
+Onychoprion anaethetus_garajau-de-dorso-castanho_briter1
+Onychoprion fuscatus/anaethetus_garajau-de-dorso-preto/garajau-de-dorso-castanho_y00318
+Onychoprion lunatus_gray-backed tern_gybter1
+Onychoprion anaethetus/lunatus_bridled/gray-backed tern_y01324
+Onychoprion sp._Onychoprion sp._onycho1
+Sternula albifrons_chilreta_litter1
+Sternula saundersi_saunders's tern_sauter2
+Sternula albifrons/saundersi_little/saunders's tern_y00662
+Sternula balaenarum_damara tern_damter2
+Sternula nereis_australian fairy tern_faiter2
+Sternula albifrons x nereis_little x australian fairy tern (hybrid)_x00798
+Sternula albifrons/nereis_little/australian fairy tern_y00850
+Sternula antillarum_trinta-réis-miúdo_leater1
+Sternula albifrons/antillarum_chilreta/trinta-réis-miúdo_y00661
+Sternula superciliaris_trinta-réis-pequeno_yebter2
+Sternula lorata_peruvian tern_perter2
+Sternula sp._Sternula sp._sternu1
+Phaetusa simplex_trinta-réis-grande_labter1
+Gelochelidon nilotica_trinta-réis-de-bico-preto_gubter2
+Gelochelidon macrotarsa_australian tern_gubter3
+Gelochelidon nilotica/macrotarsa_gull-billed/australian tern_gubter1
+Hydroprogne caspia_garajau-grande_caster1
+Larosterna inca_inca tern_incter1
+Chlidonias hybrida_gaivina-dos-pauis_whiter2
+Chlidonias albostriatus_black-fronted tern_blfter1
+Chlidonias niger_trinta-réis-negro_blkter
+Chlidonias niger niger_trinta-réis-negro (niger)_blkter1
+Chlidonias niger surinamensis_trinta-réis-negro (surinamensis)_blkter2
+Chlidonias leucopterus_trinta-réis-negro-de-asa-branca_whwter
+Chlidonias sp._gaivina (Chlidonias) sp._chlido1
+Sterna aurantia_river tern_rivter1
+Sterna forsteri_gaivina-de-forster_forter
+Sterna trudeaui_trinta-réis-de-coroa-branca_truter
+Sterna paradisaea_trinta-réis-ártico_arcter
+Sterna forsteri x paradisaea_gaivina-de-forster x gaivina-do-árctico (híbrido)_x01165
+Sterna hirundinacea_trinta-réis-de-bico-vermelho_soater1
+Sterna vittata_trinta-réis-antártico_antter1
+Sterna vittata [vittata Group]_trinta-réis-antártico [grupo vittata]_antter2
+Sterna vittata georgiae_trinta-réis-antártico (georgiae)_antter3
+Sterna paradisaea/vittata_gaivina-do-árctico/trinta-reis-antárctico_y01134
+Sterna virgata_kerguelen tern_kerter1
+Sterna hirundo_trinta-réis-boreal_comter
+Sterna hirundo hirundo/tibetana_trinta-réis-boreal (hirundo/tibetana)_comter1
+Sterna hirundo longipennis_trinta-réis-boreal (longipennis)_comter2
+Sterna hirundo hirundo/tibetana x longipennis_gaivina-comum (hirundo/tibetana x longipennis)_comter3
+Sterna hirundo x paradisaea_trinta-réis-boreal x trinta-réis-ártico (híbrido)_x00910
+Sterna forsteri/hirundo_gaivina-de-forster/gaivina-comum_y00727
+Sterna hirundo/paradisaea_trinta-réis-boreal/trinta-réis-ártico_y00317
+Sterna repressa_gaivina-arábica_whcter1
+Sterna sumatrana_gaivina-de-nuca-preta_blnter1
+Sterna dougallii_trinta-réis-róseo_roster
+Sterna hirundo x dougallii_gaivina-comum x garajau-rosado (híbrido)_x00735
+Sterna striata_white-fronted tern_whfter1
+Sterna acuticauda_black-bellied tern_blbter1
+Sterna aurantia/acuticauda_river/black-bellied tern_y01065
+Sterna sp._trinta-réis sp. (Sterna)_sterna
+Thalasseus sandvicensis_trinta-réis-de-bando_santer1
+Thalasseus sandvicensis sandvicensis_trinta-réis-de-bando (sandvicensis)_santer4
+Thalasseus sandvicensis acuflavidus_trinta-réis-de-bando (acuflavidus)_santer2
+Thalasseus sandvicensis eurygnathus_trinta-réis-de-bando (eurygnathus)_santer3
+Thalasseus sandvicensis acuflavidus x eurygnathus_trinta-réis-de-bando (acuflavidus x eurygnathus)_santer5
+Thalasseus elegans_garajau-elegante_eleter1
+Thalasseus sandvicensis x elegans_garajau-de-bico-preto x garajau-elegante (híbrido)_x00438
+Thalasseus sandvicensis/elegans_garajau-de-bico-preto/garajau-elegante_y01310
+Thalasseus bengalensis_garajau-pequeno_lecter2
+Thalasseus albididorsalis_garajau-real-africano_royter2
+Thalasseus maximus_trinta-réis-real_royter1
+Thalasseus elegans/maximus_garajau-elegante/garajau-real_y00316
+Thalasseus albididorsalis/maximus_west african crested/royal tern_y00387
+Thalasseus bergii_garajau-de-bico-amarelo_grcter1
+Thalasseus bengalensis x bergii_lesser x great crested tern (hybrid)_x01040
+Thalasseus bengalensis/bergii_garajau-pequeno/garajau-de-bico-amarelo_y01330
+Thalasseus bernsteini_chinese crested tern_chcter2
+Thalasseus bergii x bernsteini_great x chinese crested tern (hybrid)_x00848
+Thalasseus sp._trinta-réis sp. (Thalasseus)_thalas1
+Hydroprogne/Thalasseus sp._garajau (Hydroprogne/Thalasseus) sp._larter1
+Sterninae sp._Sterninae sp._tern1
+Laridae sp._Laridae sp._y00728
+Phoenicopterus chilensis_flamingo-chileno_chifla1
+Phoenicopterus ruber_flamingo_grefla2
+Phoenicopterus chilensis x ruber_chilean x american flamingo (hybrid)_x01038
+Phoenicopterus roseus_flamingo-comum_grefla3
+Phoenicopterus chilensis x roseus_chilean x greater flamingo (hybrid)_x01039
+Phoenicopterus ruber/roseus_flamingo-americano/flamingo-comum_grefla
+Phoeniconaias minor_flamingo-pequeno_lesfla1
+Phoenicopterus roseus/Phoeniconaias minor_flamingo-comum/flamingo-pequeno_y00369
+Phoenicoparrus andinus_flamingo-dos-andes_andfla2
+Phoenicoparrus jamesi_flamingo-da-puna_jamfla1
+Phoenicopteridae sp._Phoenicopteridae sp._flamin1
+Rollandia rolland_mergulhão-de-orelha-branca_whtgre3
+Rollandia microptera_titicaca grebe_titgre1
+Tachybaptus rufolavatus_alaotra grebe_alagre1
+Tachybaptus ruficollis_mergulhão-pequeno-europeu_litgre1
+Tachybaptus ruficollis [ruficollis Group]_mergulhão-pequeno-europeu (grupo ruficollis)_litgre3
+Tachybaptus ruficollis [tricolor Group]_mergulhão-pequeno-europeu (grupo tricolor)_litgre4
+Tachybaptus novaehollandiae_mergulhão-australasiático_ausgre1
+Tachybaptus pelzelnii_madagascar grebe_madgre1
+Tachybaptus dominicus_mergulhão-pequeno_leagre
+Podilymbus podiceps_mergulhão-caçador_pibgre
+Podilymbus gigas_atitlan grebe_atigre1
+Poliocephalus poliocephalus_hoary-headed grebe_hohgre1
+Tachybaptus novaehollandiae/Poliocephalus poliocephalus_australasian/hoary-headed grebe_y01019
+Poliocephalus rufopectus_new zealand grebe_nezgre1
+Podiceps major_mergulhão-grande_gregre1
+Podiceps auritus_mergulhão-de-penachos_horgre
+Podiceps grisegena_mergulhão-de-faces-brancas_rengre
+Podiceps cristatus_mergulhão-de-crista_grcgre1
+Podiceps nigricollis_cagarraz_eargre
+Podiceps auritus/nigricollis_mergulhão-de-penachos/cagarraz_y00229
+Podiceps andinus_colombian grebe_colgre1
+Podiceps occipitalis_mergulhão-de-orelha-amarela_silgre1
+Podiceps occipitalis juninensis_mergulhão-de-orelha-amarela (juninensis)_silgre3
+Podiceps occipitalis occipitalis_mergulhão-de-orelha-amarela (occipitalis)_silgre2
+Podiceps taczanowskii_junin grebe_jungre1
+Podiceps gallardoi_hooded grebe_hoogre1
+Podiceps sp._Podiceps sp._podice1
+Aechmophorus occidentalis_western grebe_wesgre
+Aechmophorus clarkii_clark's grebe_clagre
+Aechmophorus occidentalis x clarkii_western x clark's grebe (hybrid)_x00427
+Aechmophorus occidentalis/clarkii_western/clark's grebe_y00012
+Podicipedidae sp._mergulhão sp._grebe1
+Opisthocomus hoazin_cigana_hoatzi1
+Rhynochetos jubatus_kagu_kagu1
+Eurypyga helias_pavãozinho-do-pará_sunbit1
+Eurypyga helias major/meridionalis_sunbittern (Northern)_sunbit5
+Eurypyga helias helias_sunbittern (Amazonian)_sunbit4
+Phaethon lepturus_rabo-de-palha-de-bico-laranja_whttro
+Phaethon lepturus lepturus_rabo-de-palha-de-bico-laranja (lepturus)_whttro7
+Phaethon lepturus fulvus_rabo-de-palha-de-bico-laranja (fulvus)_whttro4
+Phaethon lepturus europae_rabo-de-palha-de-bico-laranja (europae)_whttro6
+Phaethon lepturus catesbyi_rabo-de-palha-de-bico-laranja (catesbyi)_whttro2
+Phaethon lepturus dorotheae_rabo-de-palha-de-bico-laranja (dorotheae)_whttro3
+Phaethon lepturus ascensionis_rabo-de-palha-de-bico-laranja (ascensionis)_whttro5
+Phaethon aethereus_rabo-de-palha-de-bico-vermelho_rebtro
+Phaethon rubricauda_rabo-de-palha-de-cauda-vermelha_rettro
+Phaethon aethereus/rubricauda_rabo-de-palha-de-bico-vermelho/de-cauda-vermelha_y00473
+Phaethon sp._Phaethon sp._tropic1
+Gavia stellata_mobelha-pequena_retloo
+Gavia arctica_mobelha-de-garganta-preta_arcloo
+Gavia pacifica_mobelha-do-pacífico_pacloo
+Gavia arctica/pacifica_mobelha-de-garganta-preta/mobelha-do-pacífico_y00219
+Gavia immer_mobelha-grande_comloo
+Gavia adamsii_mobelha-de-bico-amarelo_yebloo
+Gavia immer x adamsii_mobelha-grande x mobelha-de-bico-amarelo (híbrido)_x01146
+Gavia immer/adamsii_mobelha-grande/mobelha-de-bico-amarelo_y00220
+Gavia sp._mobelha sp._loon
+Aptenodytes patagonicus_pinguim-rei_kinpen1
+Aptenodytes forsteri_emperor penguin_emppen1
+Pygoscelis adeliae_adelie penguin_adepen1
+Pygoscelis papua_gentoo penguin_genpen1
+Pygoscelis antarcticus_chinstrap penguin_chipen2
+Megadyptes antipodes_yellow-eyed penguin_yeepen1
+Eudyptula minor_little penguin_litpen1
+Spheniscus demersus_african penguin_jacpen1
+Spheniscus humboldti_humboldt penguin_humpen1
+Spheniscus mendiculus_galapagos penguin_galpen1
+Spheniscus magellanicus_pinguim-de-magalhães_magpen1
+Spheniscus humboldti x magellanicus_humboldt x magellanic penguin (hybrid)_x01082
+Eudyptes pachyrhynchus_fiordland penguin_fiopen1
+Eudyptes sclateri_erect-crested penguin_bicpen1
+Eudyptes chrysolophus_pinguim-macaroni_macpen1
+Eudyptes schlegeli_royal penguin_roypen1
+Eudyptes chrysocome_pinguim-de-penacho-amarelo_rocpen1
+Eudyptes chrysocome chrysocome_pinguim-de-penacho-amarelo (chrysocome)_rocpen2
+Eudyptes chrysocome filholi_pinguim-de-penacho-amarelo (filholi)_rocpen3
+Eudyptes chrysolophus x chrysocome_pinguim-de-testa-amarela x pinguim-de-penachos-amarelos (híbrido)_x00921
+Eudyptes moseleyi_moseley's rockhopper penguin_rocpen4
+Eudyptes robustus_snares penguin_snapen1
+Spheniscidae sp._Spheniscidae sp._pengui1
+Diomedea sanfordi_albatroz-real-do-norte_royalb3
+Diomedea epomophora_albatroz-real_royalb2
+Diomedea sanfordi/epomophora_albatroz-real/albatroz-real-do-norte_royalb1
+Diomedea exulans_albatroz-errante_wanalb1
+Diomedea dabbenena_albatroz-de-tristão_wanalb3
+Diomedea exulans/dabbenena_snowy/tristan albatross_y01234
+Diomedea antipodensis_antipodean albatross_antalb1
+Diomedea antipodensis antipodensis_antipodean albatross (New Zealand)_wanalb2
+Diomedea antipodensis gibsoni_antipodean albatross (Gibson's)_wanalb4
+Diomedea exulans/dabbenena/antipodensis_snowy/tristan/antipodean albatross_wanalb
+Diomedea amsterdamensis_amsterdam albatross_wanalb5
+Diomedea exulans/amsterdamensis_snowy/amsterdam albatross_y01260
+Diomedea sp._Diomedea sp._laralb1
+Phoebastria irrorata_waved albatross_wavalb
+Phoebastria immutabilis_laysan albatross_layalb
+Phoebastria nigripes_black-footed albatross_bkfalb
+Phoebastria immutabilis x nigripes_laysan x black-footed albatross (hybrid)_x00017
+Phoebastria albatrus_short-tailed albatross_shtalb
+Phoebetria fusca_piau-preto_sooalb1
+Phoebetria palpebrata_piau-de-costas-claras_limalb1
+Thalassarche chlororhynchos_albatroz-de-nariz-amarelo_yenalb2
+Thalassarche carteri_indian yellow-nosed albatross_yenalb3
+Thalassarche chlororhynchos/carteri_atlantic/indian yellow-nosed albatross_yenalb
+Thalassarche chrysostoma_albatroz-de-cabeça-cinza_gyhalb
+Thalassarche bulleri_buller's albatross_bulalb2
+Thalassarche cauta_albatroz-de-coroa-branca_whcalb1
+Thalassarche cauta cauta_albatroz-de-coroa-branca (cauta)_whcalb2
+Thalassarche cauta steadi_albatroz-de-coroa-branca (steadi)_whcalb3
+Thalassarche salvini_albatroz-de-salvin_salalb1
+Thalassarche eremita_albatroz-das-ilhas-chatham_shyalb2
+Thalassarche cauta/salvini/eremita_albatroz-arisco/albatroz-de-salvin/albatroz-das-ilhas-chatham_shyalb
+Thalassarche melanophris_albatroz-de-sobrancelha_bkbalb
+Thalassarche melanophris melanophris_albatroz-de-sobrancelha (melanophris)_bkbalb1
+Thalassarche melanophris impavida_albatroz-de-sobrancelha (impavida)_bkbalb2
+Thalassarche chrysostoma x melanophris_gray-headed x black-browed albatross (hybrid)_x01063
+Thalassarche sp._Thalassarche sp._smaalb1
+Diomedeidae sp._Diomedeidae sp._albatr1
+Oceanites oceanicus_alma-de-mestre_wispet
+Oceanites oceanicus oceanicus/exasperatus_alma-de-mestre (oceanicus/exasperatus)_wilstp2
+Oceanites oceanicus chilensis_alma-de-mestre (chilensis)_wilstp1
+Oceanites pincoyae_pincoya storm-petrel_pumstp1
+Oceanites barrosi [unrecognized species]_andean storm-petrel (unrecognized species)_andstp1
+Oceanites gracilis_elliot's storm-petrel_wvspet1
+Oceanites gracilis galapagoensis_elliot's storm-petrel (Galapagos)_ellstp1
+Oceanites gracilis gracilis_elliot's storm-petrel (Humboldt)_ellstp2
+Oceanites sp._Oceanites sp._oceani1
+Garrodia nereis_gray-backed storm-petrel_gybstp1
+Pelagodroma marina_calcamar_wfspet
+Fregetta grallaria_painho-de-barriga-branca_wbspet1
+Fregetta grallaria [grallaria Group]_painho-de-barriga-branca [grupo grallaria]_whbstp1
+Fregetta grallaria titan_painho-de-barriga-branca (titan)_whbstp2
+Fregetta maoriana_new zealand storm-petrel_nezstp1
+Fregetta lineata_new caledonian storm-petrel_necstp1
+Fregetta tropica_painho-de-barriga-preta_bbspet1
+Fregetta tropica tropica_painho-de-barriga-preta (tropica)_bkbstp1
+Fregetta tropica melanoleuca_painho-de-barriga-preta (melanoleuca)_bkbstp2
+Fregetta grallaria/tropica_painho-de-barriga-branca/painho-de-barriga-preta_y00388
+Nesofregetta fuliginosa_polynesian storm-petrel_pospet1
+Hydrobates pelagicus_alma-de-mestre-europeu_bripet
+Hydrobates pelagicus pelagicus_alma-de-mestre-europeu (pelagicus)_eurstp1
+Hydrobates pelagicus melitensis_alma-de-mestre-europeu (militensis)_eurstp2
+Hydrobates furcatus_fork-tailed storm-petrel_ftspet
+Hydrobates hornbyi_ringed storm-petrel_rispet1
+Hydrobates leucorhous_painho-de-cauda-furcada_lcspet
+Hydrobates leucorhous leucorhous_painho-de-cauda-furcada (leucorhoa)_leastp3
+Hydrobates leucorhous chapmani_painho-de-cauda-furcada (chapmani)_leastp4
+Hydrobates socorroensis_townsend's storm-petrel_leastp5
+Hydrobates leucorhous/socorroensis_leach's/townsend's storm-petrel_y00937
+Hydrobates leucorhous/socorroensis (dark-rumped)_leach's/townsend's storm-petrel (dark-rumped)_leastp1
+Hydrobates leucorhous/socorroensis (white-rumped)_leach's/townsend's storm-petrel (white-rumped)_y00938
+Hydrobates cheimomnestes_ainley's storm-petrel_leastp2
+Hydrobates leucorhous/socorroensis/cheimomnestes_leach's/townsend's/ainley's storm-petrel_y00939
+Hydrobates monorhis_painho-de-swinhoe_swspet
+Hydrobates homochroa_ashy storm-petrel_asspet
+Hydrobates castro_painho-da-ilha-da-madeira_barpet
+Hydrobates castro castro_painho-da-ilha-da-madeira (castro)_barstp4
+Hydrobates castro [undescribed form]_painho-da-ilha-da-madeira (undescribed form)_barstp3
+Hydrobates castro bangsi_painho-da-ilha-da-madeira (bangsi)_barstp5
+Hydrobates monteiroi_painho-de-monteiro_monstp1
+Hydrobates jabejabe_jaba-jaba_cavstp1
+Hydrobates sp. (Band-rumped complex)_paínho sp. (Oceanodroma sp. de uropígio branco)_oceano2
+Hydrobates tethys_wedge-rumped storm-petrel_wrspet
+Hydrobates melania_black storm-petrel_bkspet
+Hydrobates macrodactylus_guadalupe storm-petrel_guspet
+Hydrobates markhami_markham's storm-petrel_maspet
+Hydrobates melania/markhami_black/markham's storm-petrel_y00715
+Hydrobates matsudairae_painho-de-matsudaira_maspet2
+Hydrobates monorhis/matsudairae_painho-de-swinhoe/painho-de-matsudaira_y01337
+Hydrobates tristrami_tristram's storm-petrel_trspet
+Hydrobates microsoma_least storm-petrel_lsspet
+Hydrobates sp._Hydrobates sp._oceano1
+Oceanitidae/Hydrobatidae sp. (dark-rumped)_painho (hidrobatídeo) de uropígio escuro sp._stormp1
+Oceanitidae/Hydrobatidae sp. (white-rumped)_painho (hidrobatídeo) de uropígio claro sp._stormp2
+Oceanitidae/Hydrobatidae sp._Oceanitidae/Hydrobatidae sp._stopet
+Macronectes giganteus_petrel-grande_angpet1
+Macronectes halli_petrel-grande-do-norte_norgip1
+Macronectes giganteus/halli_petrel-grande/do-norte_y00228
+Fulmarus glacialis_pombalete_norful
+Fulmarus glacialis glacialis/auduboni_pombalete (glacialis/auduboni)_norful4
+Fulmarus glacialis rodgersii_pombalete (rodgersii)_norful3
+Fulmarus glacialoides_pardelão-prateado_souful1
+Thalassoica antarctica_antarctic petrel_antpet1
+Daption capense_pomba-do-cabo_cappet
+Daption capense capense_pintado (capense)_cappet1
+Daption capense australe_pintado (australe)_cappet2
+Pagodroma nivea_snow petrel_snopet1
+Aphrodroma brevirostris_grazina-de-bico-curto_kerpet2
+Pterodroma rupinarum_large st. helena petrel_lshpet1
+Pterodroma macroptera_fura-buxo-de-cara-cinza_grwpet3
+Pterodroma gouldi_fura-buxo-de-gould_grwpet2
+Pterodroma macroptera/gouldi_fura-buxo-de-cara-cinza/de-gould_grwpet1
+Pterodroma neglecta_petrel-de-kermadec_kerpet
+Pterodroma magentae_magenta petrel_magpet1
+Pterodroma arminjoniana_grazina-de-trindade_tripet1
+Pterodroma heraldica_herald petrel_herpet2
+Pterodroma arminjoniana/heraldica_trindade/herald petrel_herpet
+Pterodroma ultima_murphy's petrel_murpet
+Pterodroma solandri_providence petrel_solpet1
+Pterodroma atrata_henderson petrel_henpet1
+Pterodroma madeira_grazina-da-madeira_madpet
+Pterodroma feae_grazina-de-desertas (feae/deserta)_feapet1
+Pterodroma feae feae_grazina-de-desertas (feae)_feapet3
+Pterodroma feae deserta_grazina-de-desertas (deserta)_feapet2
+Pterodroma madeira/feae_grazina-da-madeira/grazina-de-desertas_y00609
+Pterodroma mollis_grazina-delicada_soppet1
+Pterodroma baraui_barau's petrel_barpet1
+Pterodroma lessonii_grazina-de-cabeça-branca_whhpet1
+Pterodroma inexpectata_mottled petrel_motpet
+Pterodroma cahow_bermuda petrel_berpet
+Pterodroma hasitata_diablotim_bkcpet
+Pterodroma hasitata (White-faced)_diablotim (White-faced)_bkcpet4
+Pterodroma hasitata (Dark-faced)_diablotim (Dark-faced)_bkcpet3
+Pterodroma cahow/hasitata_bermuda/black-capped petrel_y00713
+Pterodroma caribbaea_jamaican petrel_bkcpet2
+Pterodroma externa_juan fernandez petrel_jufpet
+Pterodroma incerta_grazina-de-barriga-branca_atlpet1
+Pterodroma phaeopygia_galapagos petrel_galpet
+Pterodroma sandwichensis_hawaiian petrel_hawpet1
+Pterodroma phaeopygia/sandwichensis_galapagos/hawaiian petrel (Dark-rumped Petrel)_y00472
+Pterodroma cervicalis_white-necked petrel_whnpet
+Pterodroma externa/cervicalis_juan fernandez/white-necked petrel_y01135
+Pterodroma hypoleuca_bonin petrel_bonpet
+Pterodroma nigripennis_black-winged petrel_bkwpet
+Pterodroma axillaris_chatham islands petrel_chapet1
+Pterodroma cookii_cook's petrel_coopet
+Pterodroma defilippiana_masatierra petrel_maspet3
+Pterodroma leucoptera_gould's petrel_goupet1
+Pterodroma leucoptera leucoptera_gould's petrel (Gould's)_goupet2
+Pterodroma leucoptera caledonica_gould's petrel (New Caledonian)_goupet3
+Pterodroma brevipes_collared petrel_colpet1
+Pterodroma brevipes brevipes_collared petrel (Collared)_goupet4
+Pterodroma brevipes magnificens_collared petrel (Magnificent)_goupet5
+Pterodroma longirostris_stejneger's petrel_stepet
+Pterodroma pycrofti_pycroft's petrel_pycpet1
+Pterodroma sp. (Cookilaria sp.)_pterodroma sp. (Cookilaria sp.)_coopet1
+Pterodroma alba_phoenix petrel_phopet1
+Pterodroma occulta_vanuatu petrel_venpet1
+Pterodroma sp._freira (Pterodroma) sp._pterod
+Halobaena caerulea_petrel-azul_blupet1
+Pachyptila turtur_fairy prion_faipri1
+Pachyptila vittata_faigão-de-bico-largo_brbpri1
+Pachyptila salvini_salvin's prion_salpri2
+Pachyptila macgillivrayi_macgillivray's prion_salpri3
+Pachyptila salvini/macgillivrayi_salvin's/macgillivray's prion_salpri1
+Pachyptila vittata/macgillivrayi_broad-billed/macgillivray's prion_y01297
+Pachyptila vittata/salvini/macgillivrayi_broad-billed/salvin's/macgillivray's prion_y01298
+Pachyptila desolata_faigão-rola_dovpri1
+Pachyptila belcheri_faigão-de-bico-fino_slbpri1
+Pachyptila crassirostris_fulmar prion_fulpri1
+Pachyptila sp._Pachyptila sp._prion1
+Halobaena caerulea/Pachyptila sp._Blue Petrel/prion sp._y01299
+Bulweria bulwerii_alma-negra_bulpet
+Bulweria fallax_jouanin's petrel_joupet
+Bulweria bifax_small st. helena petrel_sshpet1
+Bulweria sp._Bulweria sp._bulwer1
+Pseudobulweria macgillivrayi_fiji petrel_fijpet1
+Pseudobulweria aterrima_mascarene petrel_maspet1
+Pseudobulweria rostrata_tahiti petrel_tahpet1
+Pseudobulweria becki_beck's petrel_becpet1
+Pseudobulweria [undescribed form]_lava petrel (undescribed form)_lavpet1
+Pseudobulweria sp._Pseudobulweria sp._pseudo2
+Bulweria/Pseudobulweria sp._Bulweria/Pseudobulweria sp._y01224
+Procellaria cinerea_pardela-cinza_grapet
+Procellaria aequinoctialis_pardela-preta_whcpet1
+Procellaria conspicillata_pardela-de-óculos_spepet1
+Procellaria parkinsoni_parkinson's petrel_parpet1
+Procellaria westlandica_westland petrel_wespet1
+Procellaria sp._Procellaria sp._procel1
+Calonectris leucomelas_cagarra-do-pacífico_strshe
+Calonectris borealis_cagarra-grande_corshe1
+Calonectris diomedea_cagarra-do-mediterrâneo_scoshe1
+Calonectris borealis/diomedea_cagarra/cagarra-do-mediterrâneo_corshe
+Calonectris edwardsii_cagarra-de-cabo-verde_cavshe1
+Calonectris borealis/diomedea/edwardsii_cagarra/cagarra-do-mediterrâneo/cagarra-de-cabo-verde_y00676
+Ardenna creatopus_pink-footed shearwater_pifshe
+Ardenna carneipes_pardela-de-patas-rosadas_flfshe
+Ardenna gravis_pardela-de-barrete_greshe
+Calonectris borealis/diomedea/Ardenna gravis_cagarra/cagarra-do-mediterrâneo/pardela-de-barrete_y00606
+Ardenna pacifica_pardela-rabilonga_wetshe
+Ardenna bulleri_buller's shearwater_bulshe
+Ardenna grisea_pardela-escura_sooshe
+Ardenna tenuirostris_pardela-de-cauda-curta_shtshe
+Ardenna grisea/tenuirostris_pardela-escura/pardela-de-cauda-curta_y00020
+Puffinus nativitatis_christmas shearwater_chrshe
+Puffinus subalaris_galapagos shearwater_audshe3
+Puffinus subalaris (Dark-winged)_galapagos shearwater (Dark-winged)_galshe1
+Puffinus subalaris (Light-winged)_galapagos shearwater (Light-winged)_galshe2
+Puffinus puffinus_pardela-sombria_manshe
+Puffinus yelkouan_fura-bucho-do-mediterrâneo_levshe1
+Puffinus mauretanicus_fura-bucho-das-baleares_balshe1
+Puffinus yelkouan/mauretanicus_fura-bucho-do-mediterrâneo/fura-bucho-das-baleares_medshe1
+Puffinus huttoni_hutton's shearwater_hutshe1
+Puffinus bannermani_bannerman's shearwater_troshe4
+Puffinus auricularis_townsend's shearwater_towshe1
+Puffinus newelli_newell's shearwater_towshe2
+Puffinus auricularis/newelli_townsend's/newell's shearwater_towshe
+Puffinus myrtae_rapa shearwater_towshe3
+Puffinus newelli/myrtae_newell's/rapa shearwater_y00931
+Puffinus bryani_bryan's shearwater_bryshe1
+Puffinus opisthomelas_black-vented shearwater_bkvshe
+Puffinus gavia_fluttering shearwater_flushe1
+Puffinus huttoni/gavia_hutton's/fluttering shearwater_y00832
+Puffinus assimilis_little shearwater_litshe8
+Puffinus assimilis assimilis_little shearwater (Tasman)_litshe3
+Puffinus assimilis haurakiensis_little shearwater (Hauraki)_litshe6
+Puffinus assimilis kermadecensis_little shearwater (Kermadec)_litshe5
+Puffinus assimilis tunneyi_little shearwater (West Australian)_litshe7
+Puffinus elegans_pardela-pequena_litshe4
+Puffinus assimilis/elegans_little/subantarctic shearwater_litshe
+Puffinus baroli_pintainho_litshe1
+Puffinus boydi_pardela-de-cabo-verde_litshe2
+Puffinus baroli/boydi_pintainho/pedreiro_y00714
+Puffinus lherminieri_pardela-de-asa-larga_audshe
+Puffinus bailloni_tropical shearwater_troshe5
+Puffinus bailloni bailloni_tropical shearwater (Mascarene)_troshe2
+Puffinus bailloni [dichrous Group]_tropical shearwater (Indopacific)_troshe3
+Puffinus bannermani/bailloni_bannerman's/tropical shearwater_troshe1
+Puffinus persicus_persian shearwater_pershe1
+Puffinus heinrothi_heinroth's shearwater_heishe1
+Puffinus sp._Puffinus sp._bawshe1
+Procellariidae sp. (shearwater sp.)_cagarra/pardela sp._shearw
+Pelecanoides garnotii_peruvian diving-petrel_pedpet1
+Pelecanoides urinatrix_common diving-petrel_codpet1
+Pelecanoides georgicus_south georgia diving-petrel_sgdpet1
+Pelecanoides magellani_petrel-mergulhador_madpet1
+Pelecanoides sp._diving-petrel sp._diving1
+Procellariidae sp._Procellariidae sp._procel2
+Anastomus oscitans_asian openbill_asiope1
+Anastomus lamelligerus_african openbill_afrope1
+Ciconia nigra_cegonha-preta_blasto1
+Ciconia abdimii_abdim's stork_abdsto1
+Ciconia microscelis_african woolly-necked stork_wonsto2
+Ciconia episcopus_asian woolly-necked stork_wonsto1
+Ciconia stormi_storm's stork_stosto1
+Ciconia maguari_maguari_magsto1
+Ciconia ciconia_cegonha-branca_whisto1
+Ciconia nigra x ciconia_black x white stork (hybrid)_x01098
+Ciconia boyciana_oriental stork_oristo1
+Ciconia sp._cegonha (Ciconia) sp._ciconi1
+Ephippiorhynchus asiaticus_black-necked stork_blnsto1
+Ephippiorhynchus senegalensis_jabiru-africano_sabsto1
+Jabiru mycteria_tuiuiú_jabiru
+Leptoptilos javanicus_lesser adjutant_lesadj1
+Leptoptilos crumenifer_marabu_marsto1
+Leptoptilos dubius_greater adjutant_greadj1
+Leptoptilos javanicus/dubius_lesser/greater adjutant_y00716
+Mycteria americana_cabeça-seca_woosto
+Mycteria cinerea_milky stork_milsto1
+Mycteria ibis_tântalo-africano_yebsto1
+Mycteria leucocephala_painted stork_paisto1
+Mycteria cinerea x leucocephala_milky x painted stork (hybrid)_x00729
+Mycteria cinerea/leucocephala_milky/painted stork_y01136
+Ciconiidae sp._cegonha (ciconiidae) sp._stork1
+Fregata aquila_rabiforcado-de-ascensão_asifri1
+Fregata magnificens_fragata_magfri
+Fregata magnificens rothschildi_rabiforcado-magnífico (rothschildi)_magfri1
+Fregata magnificens magnificens_rabiforcado-magnífico (magnificens)_magfri2
+Fregata ariel_tesourão-pequeno/fragata-pequena_lesfri
+Fregata ariel ariel/iredalei_tesourão-pequeno_lesfri1
+Fregata ariel trinitatis_fragata-pequena_lesfri2
+Fregata minor_fragata-grande_grefri
+Fregata andrewsi_rabiforcado-da-ilha-natal_chifri1
+Fregata sp._Fregata sp._frigat
+Papasula abbotti_abbott's booby_abbboo2
+Morus bassanus_atobá-boreal_norgan
+Morus capensis_atobá-do-cabo_capgan1
+Morus serrator_atobá-australiano_ausgan1
+Sula sula_atobá-de-pé-vermelho_refboo
+Sula sula sula_atobá-de-pé-vermelho (sula)_refboo1
+Sula sula rubripes_atobá-de-pé-vermelho (rubripes)_refboo2
+Sula sula websteri_atobá-de-pé-vermelho (websteri)_refboo3
+Sula leucogaster_atobá-pardo_brnboo
+Sula leucogaster leucogaster_atobá-pardo (leucogaster)_brnboo2
+Sula leucogaster plotus_atobá-pardo (plotus)_brnboo3
+Sula brewsteri_cocos booby_cocboo1
+Sula brewsteri brewsteri_cocos booby (Brewster's)_brnboo1
+Sula brewsteri etesiaca_cocos booby (Colombian)_brnboo4
+Sula leucogaster/brewsteri_brown/cocos booby_y01312
+Sula dactylatra_atobá-grande_masboo
+Sula leucogaster x dactylatra_atobá-grande x atobá-pardo (híbrido)_x00782
+Sula granti_nazca booby_nazboo1
+Sula dactylatra x granti_masked x nazca booby (hybrid)_x01064
+Sula dactylatra/granti_masked/nazca booby_y00474
+Sula nebouxii_blue-footed booby_bfoboo
+Sula leucogaster x nebouxii_brown x blue-footed booby (hybrid)_x00950
+Sula variegata_peruvian booby_perboo1
+Sula nebouxii x variegata_blue-footed x peruvian booby (hybrid)_x01065
+Sula sp._Sula sp._booby1
+Sulidae sp._Sulidae sp._sulid
+Anhinga anhinga_biguatinga_anhing
+Anhinga rufa_mergulhão-serpente_darter3
+Anhinga melanogaster_mergulhão-serpente-oriental_darter2
+Anhinga novaehollandiae_australasian darter_darter4
+Microcarbo melanoleucos_corvo-marinho-alvinegro-pequeno_lipcor1
+Microcarbo africanus_corvo-marinho-africano_lotcor1
+Microcarbo coronatus_crowned cormorant_crocor1
+Microcarbo africanus/coronatus_reed/crowned cormorant_y01300
+Microcarbo niger_little cormorant_litcor1
+Microcarbo pygmaeus_corvo-marinho-pequeno_pygcor2
+Poikilocarbo gaimardi_red-legged cormorant_relcor1
+Urile penicillatus_brandt's cormorant_bracor
+Urile urile_red-faced cormorant_refcor
+Urile pelagicus_pelagic cormorant_pelcor
+Urile perspicillatus_pallas's cormorant_palcor1
+Phalacrocorax neglectus_bank cormorant_bancor1
+Phalacrocorax capensis_cape cormorant_capcor1
+Phalacrocorax carbo_corvo-marinho-comum_grecor
+Phalacrocorax carbo carbo/sinensis_corvo-marinho-comum (peito-preto)_grecor6
+Phalacrocorax carbo carbo_corvo-marinho-comum (carbo)_grecor1
+Phalacrocorax carbo novaehollandiae_corvo-marinho-comum (novaehollandiae)_grecor2
+Phalacrocorax carbo sinensis/hanedae_corvo-marinho-comum (sinensis/hanedae)_grecor3
+Phalacrocorax carbo maroccanus_corvo-marinho-comum (maroccanus)_grecor5
+Phalacrocorax carbo lucidus_corvo-marinho-comum (lucidus)_grecor4
+Phalacrocorax capillatus_japanese cormorant_japcor1
+Phalacrocorax carbo/capillatus_great/japanese cormorant_y01020
+Phalacrocorax nigrogularis_socotra cormorant_soccor1
+Phalacrocorax punctatus_spotted shag_sposha1
+Phalacrocorax featherstoni_pitt island shag_piisha1
+Phalacrocorax fuscicollis_indian cormorant_indcor1
+Microcarbo niger/Phalacrocorax fuscicollis_little/indian cormorant_y00770
+Phalacrocorax sulcirostris_corvo-marinho-preto-pequeno_libcor1
+Phalacrocorax varius_pied cormorant_piecor1
+Phalacrocorax fuscescens_black-faced cormorant_blfcor1
+Gulosus aristotelis_galheta_eursha1
+Gulosus aristotelis aristotelis_galheta (aristotelis)_eursha2
+Gulosus aristotelis desmarestii_galheta (desmarestii)_eursha3
+Gulosus aristotelis riggenbachi_galheta (riggenbachi)_eursha4
+Phalacrocorax carbo/Gulosus aristotelis_corvo-marinho-comum/galheta_y00769
+Nannopterum harrisi_flightless cormorant_flicor1
+Nannopterum auritum_corvo-marinho-d'orelhas_doccor
+Phalacrocorax carbo/Nannopterum auritum_corvo-marinho-comum/corvo-marinho-d'orelhas_y00694
+Nannopterum brasilianum_biguá_neocor
+Nannopterum auritum x brasilianum_corvo-marinho-d'orelhas x biguá (híbrido)_x00783
+Nannopterum auritum/brasilianum_corvo-marinho-d'orelhas/biguá_y00833
+Leucocarbo magellanicus_magellanic cormorant_magcor1
+Leucocarbo bougainvilliorum_guanay cormorant_guacor1
+Leucocarbo ranfurlyi_bounty islands shag_boisha1
+Leucocarbo carunculatus_new zealand king shag_rofsha1
+Leucocarbo chalconotus_stewart island shag_brosha1
+Leucocarbo chalconotus chalconotus_stewart island shag (Otago)_stisha1
+Leucocarbo chalconotus stewarti_stewart island shag (Foveaux)_stisha2
+Leucocarbo onslowi_chatham islands shag_chisha1
+Leucocarbo colensoi_auckland islands shag_auisha1
+Leucocarbo campbelli_campbell islands shag_caisha2
+Leucocarbo georgianus_south georgia shag_sogsha1
+Leucocarbo atriceps_imperial cormorant_impcor1
+Leucocarbo atriceps (Blue-eyed)_imperial cormorant (Blue-eyed)_impcor2
+Leucocarbo atriceps (King)_imperial cormorant (King)_impcor3
+Leucocarbo bransfieldensis_biguá-das-shetland_antsha1
+Leucocarbo melanogenis_crozet shag_crosha1
+Leucocarbo verrucosus_kerguelen shag_kersha1
+Leucocarbo nivalis_heard island shag_heisha1
+Leucocarbo purpurascens_macquarie shag_macsha1
+Phalacrocoracidae sp._corvo-marinho (Phalacrocorax) sp._cormor1
+Eudocimus albus_white ibis_whiibi
+Eudocimus ruber_guará_scaibi
+Eudocimus albus x ruber_white x scarlet ibis (hybrid)_x00428
+Plegadis falcinellus_íbis-preta_gloibi
+Plegadis chihi_caraúna_whfibi
+Plegadis falcinellus x chihi_íbis-preta x íbis-de-faces-brancas (híbrido)_gxwibi1
+Plegadis falcinellus/chihi_íbis-preta/íbis-de-faces-brancas_plegad
+Plegadis ridgwayi_puna ibis_punibi1
+Plegadis chihi/ridgwayi_white-faced/puna ibis_y00836
+Lophotibis cristata_madagascar ibis_madibi1
+Cercibis oxycerca_trombeteiro_shtibi1
+Mesembrinibis cayennensis_coró-coró_greibi1
+Phimosus infuscatus_tapicuru_bafibi1
+Plegadis chihi/Phimosus infuscatus_white-faced/bare-faced ibis_y01263
+Theristicus caerulescens_curicaca-real_pluibi1
+Theristicus caudatus_curicaca_bunibi1
+Theristicus melanopis_black-faced ibis_bkfibi1
+Theristicus branickii_andean ibis_bkfibi2
+Theristicus melanopis/branickii_black-faced/andean ibis_blfibi1
+Theristicus sp._Theristicus sp._theris1
+Threskiornis aethiopicus_íbis-sagrada_sacibi2
+Threskiornis bernieri_malagasy sacred ibis_sacibi3
+Threskiornis aethiopicus/bernieri_african/malagasy sacred ibis_sacibi1
+Threskiornis solitarius_reunion ibis_reusol1
+Threskiornis melanocephalus_black-headed ibis_blhibi1
+Threskiornis molucca_íbis-branca-australiana_ausibi1
+Threskiornis spinicollis_straw-necked ibis_stnibi1
+Threskiornis molucca x spinicollis_australian x straw-necked ibis (hybrid)_x01157
+Pseudibis papillosa_red-naped ibis_renibi1
+Pseudibis davisoni_white-shouldered ibis_whsibi1
+Pseudibis gigantea_giant ibis_giaibi1
+Geronticus eremita_íbis-pelada_waldra1
+Geronticus calvus_southern bald ibis_balibi1
+Nipponia nippon_crested ibis_creibi1
+Bostrychia olivacea_olive ibis_oliibi2
+Bostrychia bocagei_sao tome ibis_oliibi3
+Bostrychia rara_spot-breasted ibis_spbibi1
+Bostrychia hagedash_singanga_hadibi1
+Bostrychia carunculata_wattled ibis_watibi1
+Threskiornithidae sp. (ibis sp.)_Threskiornithidae sp._ibis1
+Platalea leucorodia_colhereiro-europeu_eurspo1
+Platalea regia_colhereiro-real_royspo1
+Platalea alba_colhereiro-africano_afrspo1
+Platalea minor_black-faced spoonbill_blfspo1
+Platalea leucorodia x minor_eurasian x black-faced spoonbill (hybrid)_x00883
+Platalea flavipes_yellow-billed spoonbill_yebspo1
+Platalea ajaja_colhereiro_rosspo1
+Platalea sp._spoonbill sp._spoonb1
+Tigriornis leucolopha_garça-tigre_whcbit1
+Tigrisoma lineatum_socó-boi_ruther1
+Tigrisoma mexicanum_bare-throated tiger-heron_btther1
+Tigrisoma fasciatum_socó-jararaca_father1
+Tigrisoma sp._Tigrisoma sp._tigerh1
+Cochlearius cochlearius_arapapá_bobher1
+Cochlearius cochlearius [zeledoni Group]_arapapá [grupo zeledoni]_bobher3
+Cochlearius cochlearius cochlearius/panamensis_arapapá (cochlearius/panamensis)_bobher4
+Agamia agami_garça-da-mata_agaher1
+Zebrilus undulatus_socoí-zigue-zague_zigher1
+Botaurus stellaris_abetouro_grebit1
+Botaurus poiciloptilus_australasian bittern_ausbit1
+Botaurus lentiginosus_abetouro-americano_amebit
+Botaurus pinnatus_socó-boi-baio_pinbit1
+Botaurus involucris_socoí-amarelo_stbbit1
+Botaurus exilis_socoí-vermelho_leabit
+Botaurus exilis exilis/pullus_socoí-vermelho (exilis/pullus)_leabit7
+Botaurus exilis [erythromelas Group]_socoí-vermelho (Grupo erythromelas)_leabit8
+Botaurus flavicollis_garçote-preto_blabit1
+Botaurus cinnamomeus_garçote-canela_cinbit1
+Botaurus eurhythmus_garçote-da-manchúria_schbit1
+Botaurus cinnamomeus/eurhythmus_garçote-canela/garçote-da-manchúria_y01116
+Botaurus sturmii_garçote-anão_dwabit1
+Botaurus minutus_garçote-comum_litbit1
+Botaurus minutus minutus_garçote-comum (minutus)_litbit2
+Botaurus minutus payesii_garçote-comum (payesii)_litbit3
+Botaurus minutus podiceps_garçote-comum (podiceps)_litbit4
+Botaurus sinensis_yellow bittern_yelbit
+Botaurus cinnamomeus/sinensis_cinnamon/yellow bittern_y00389
+Botaurus dubius_black-backed bittern_bkbbit1
+Botaurus novaezelandiae_new zealand bittern_nezbit1
+Botaurus sp. (small bittern sp.)_socoí sp._smabit1
+Nyctanassa violacea_savacu-de-coroa_ycnher
+Nyctanassa violacea [violacea Group]_savacu-de-coroa [grupo violacea]_yecnih1
+Nyctanassa violacea pauper_savacu-de-coroa (pauper)_yecnih2
+Nyctanassa carcinocatactes_bermuda night heron_bernih1
+Nycticorax nycticorax_socó-dorminhoco_bcnher
+Nycticorax nycticorax nycticorax_socó-dorminhoco (nycticorax)_bkcnih1
+Nycticorax nycticorax hoactli_socó-dorminhoco (hoactli)_bkcnih2
+Nycticorax nycticorax obscurus_socó-dorminhoco (obscurus)_bkcnih4
+Nycticorax nycticorax falklandicus_socó-dorminhoco (falklandicus)_bkcnih3
+Nyctanassa violacea x Nycticorax nycticorax_socó-dorminhoco x savacu-de-coroa (híbrido)_x00704
+Nycticorax nycticorax/Nyctanassa violacea_socó-dorminhoco/savacu-de-coroa_y00610
+Nycticorax duboisi_reunion night heron_reunih1
+Nycticorax mauritianus_mauritius night heron_maunih1
+Nycticorax megacephalus_rodrigues night heron_rodnih1
+Nycticorax caledonicus_goraz-canela_runher1
+Nycticorax nycticorax x caledonicus_black-crowned x nankeen night heron (hybrid)_x01041
+Nycticorax nycticorax/caledonicus_goraz/goraz-canela_y00940
+Nycticorax olsoni_ascension night heron_asnher1
+Gorsachius melanolophus_malayan night heron_manher1
+Gorsachius goisagi_japanese night heron_janher1
+Gorsachius melanolophus/goisagi_malayan/japanese night heron_y00941
+Pilherodius pileatus_garça-real_capher1
+Syrigma sibilatrix_maria-faceira_whiher1
+Egretta caerulea_garça-azul_libher
+Egretta tricolor_garça-tricolor_triher
+Egretta caerulea x tricolor_garça-morena x garça-tricolor (híbrido)_x00696
+Egretta rufescens_reddish egret_redegr
+Egretta tricolor x rufescens_tricolored heron x reddish egret (hybrid)_x00785
+Egretta vinaceigula_slaty egret_slaegr1
+Egretta ardesiaca_garça-preta_blaher1
+Egretta sacra_garça-dos-recifes-oriental_pacreh1
+Egretta eulophotes_chinese egret_chiegr
+Egretta thula_garça-branca-pequena_snoegr
+Egretta caerulea x thula_garça-azul x garça-branca-pequena (híbrido)_x00615
+Egretta tricolor x thula_garça-tricolor x garça-branca-pequena (híbrido)_x00730
+Egretta garzetta_garça-pequena-europeia_litegr
+Egretta garzetta garzetta_garça-pequena-europeia (garzetta)_litegr1
+Egretta garzetta immaculata_garça-pequena-europeia (immaculata)_litegr3
+Egretta garzetta dimorpha_garça-pequena-europeia (dimorpha)_litegr2
+Egretta thula x garzetta_garça-branca-americana x garça-branca-pequena (híbrido)_x00697
+Egretta gularis_garça-negra_werher
+Egretta gularis gularis_garça-negra (gularis)_wesreh1
+Egretta gularis schistacea_garça-negra (schistacea)_wesreh2
+Egretta garzetta x gularis_garça-branca-pequena x garça-dos-recifes-ocidental (híbrido)_x00656
+Egretta garzetta/gularis_garça-branca-pequena/garça-dos-recifes-ocidental_y00835
+Egretta picata_garça-pedrês_pieher2
+Egretta novaehollandiae_garça-de-faces-brancas_whfher1
+Egretta sp._Egretta sp._egrett1
+Calherodius leuconotus_garça-nocturna-de-dorso-branco_wbnher1
+Oroanassa magnifica_white-eared night heron_wenher1
+Butorides striata_socozinho_strher
+Butorides striata striata_socozinho (striata)_strher2
+Butorides striata sundevalli_socozinho (sundevalli)_strher3
+Butorides striata [atricapilla Group]_socozinho [grupo atricapilla]_strher1
+Butorides virescens_socó-mirim_grnher
+Butorides virescens virescens/bahamensis_socó-mirim (virescens/bahamensis)_grnher1
+Butorides virescens anthonyi_socó-mirim (anthonyi)_grnher2
+Butorides virescens frazari_socó-mirim (frazari)_grnher3
+Butorides striata x virescens_socózinho x socó-mirim (híbrido)_x00765
+Butorides striata/virescens_socózinho/socó-mirim_y00771
+Zonerodius heliosylus_forest bittern_forbit1
+Ardeola rufiventris_rufous-bellied heron_rubher2
+Ardeola ralloides_garça-caranguejeira_squher1
+Ardeola idae_malagasy pond-heron_mapher1
+Ardeola grayii_papa-ratos-indiano_inpher1
+Ardeola bacchus_chinese pond-heron_chpher1
+Ardeola grayii x bacchus_indian x chinese pond-heron (hybrid)_x01124
+Ardeola speciosa_javan pond-heron_japher1
+Ardeola bacchus x speciosa_chinese x javan pond-heron (hybrid)_x01125
+Ardeola sp._garça (Ardeola) sp._pondhe1
+Ardea ibis_garça-vaqueira_categr1
+Ardea coromanda_eastern cattle-egret_categr2
+Ardea ibis/coromanda_western/eastern cattle-egret_categr
+Ardea pacifica_pacific heron_pacher1
+Ardea alba_garça-branca-grande_greegr
+Ardea alba alba_garça-branca-grande (alba)_greegr1
+Ardea alba melanorhynchos_garça-branca-grande (melanorhynchos)_greegr4
+Ardea alba egretta_garça-branca-grande (egretta)_greegr2
+Ardea alba modesta_garça-branca-grande (modesta)_greegr3
+Ardea brachyrhyncha_yellow-billed egret_integr3
+Ardea alba/brachyrhyncha_great/yellow-billed egret_y01235
+Ardea ibis/brachyrhyncha_western cattle-egret/yellow-billed egret_y01236
+Ardea intermedia_medium egret_integr1
+Ardea coromanda/intermedia_eastern cattle-egret/medium egret_y01237
+Ardea alba/intermedia_great/medium egret_y01238
+Ardea brachyrhyncha/intermedia_yellow-billed/medium egret_y01239
+Ardea plumifera_plumed egret_integr2
+Ardea coromanda/plumifera_eastern cattle-egret/plumed egret_y01240
+Ardea alba/plumifera_great/plumed egret_y01241
+Ardea intermedia/plumifera_medium/plumed egret_y01242
+Ardea cinerea_garça-moura-europeia_graher1
+Ardea cinerea cinerea/jouyi_garça-moura-europeia (cinerea/jouyi)_gryher1
+Ardea cinerea firasa_garça-moura-europeia (firasa)_gryher3
+Ardea cinerea monicae_garça-moura-europeia (monicae)_gryher2
+Ardea alba x cinerea_garça-branca-grande x garça-real (híbrido)_x00398
+Ardea herodias_garça-azul-grande_grbher3
+Ardea herodias [herodias Group]_garça-azul-grande [grupo herodias]_grbher
+Ardea herodias occidentalis_garça-azul-grande (occidentalis)_grwher
+Ardea herodias wardi x occidentalis_garça-azul-grande (Wurdemann's)_wurher
+Ardea alba x herodias_garça-branca-grande x garça-azul-grande (híbrido)_x00677
+Ardea cocoi_garça-moura_cocher1
+Ardea alba x cocoi_great egret x cocoi heron (hybrid)_x01051
+Ardea herodias x cocoi_garça-real-americana x garça-moura (híbrido)_x00784
+Ardea herodias/cocoi_garça-real-americana/garça-moura_y00834
+Ardea purpurea_garça-roxa_purher1
+Ardea purpurea bournei_garça-roxa (bournei)_purher2
+Ardea purpurea [purpurea Group]_garça-roxa [grupo purpurea]_purher3
+Ardea cinerea x purpurea_gray x purple heron (hybrid)_x01050
+Ardea cinerea/purpurea_garça-moura-europeia/garça-roxa_y01021
+Ardea humbloti_humblot's heron_humher1
+Ardea insignis_white-bellied heron_whbher2
+Ardea sumatrana_garça-de-sumatra_grbher2
+Ardea melanocephala_garça-de-cabeça-preta_blhher1
+Ardea goliath_garça-gigante_golher1
+Ardea sp._Ardea sp._ardea1
+Ardeidae sp._Ardeidae sp._heron1
+Egretta/Ardea sp._garça-branca (Egretta/Ardea) sp._whiegr1
+Scopus umbretta_pássaro-martelo_hamerk1
+Balaeniceps rex_shoebill_shoebi1
+Pelecanus erythrorhynchos_american white pelican_amwpel
+Pelecanus occidentalis_pelicano_brnpel
+Pelecanus occidentalis carolinensis_pelicano (carolinensis)_brnpel2
+Pelecanus occidentalis californicus_pelicano (californicus)_brnpel3
+Pelecanus occidentalis occidentalis/murphyi_pelicano (occidentalis/murphyi)_brnpel1
+Pelecanus occidentalis urinator_pelicano-pardo (urinator)_brnpel4
+Pelecanus thagus_peruvian pelican_perpel1
+Pelecanus onocrotalus_pelicano-branco_grwpel1
+Pelecanus conspicillatus_pelicano-australiano_auspel1
+Pelecanus rufescens_pelicano-cinzento_pibpel1
+Pelecanus philippensis_spot-billed pelican_spbpel1
+Pelecanus crispus_pelicano-crespo_dalpel1
+Pelecanus onocrotalus x crispus_pelicano-branco x pelicano-crespo (híbrido)_x00842
+Pelecanus sp._pelicano sp._pelica1
+Gymnogyps californianus_california condor_calcon
+Sarcoramphus papa_urubu-rei_kinvul1
+Vultur gryphus_condor_andcon1
+Coragyps atratus_urubu-preto_blkvul
+Cathartes aura_urubu-de-cabeça-vermelha_turvul
+Cathartes aura [aura Group]_urubu-de-cabeça-vermelha [grupo aura]_turvul2
+Cathartes aura [undescribed form]_turkey vulture (Choco)_turvul6
+Cathartes aura ruficollis_urubu-de-cabeça-vermelha (ruficollis)_turvul1
+Cathartes aura jota_urubu-de-cabeça-vermelha (jota)_turvul3
+Cathartes burrovianus_urubu-de-cabeça-amarela_lyhvul1
+Cathartes melambrotus_urubu-da-mata_gyhvul1
+Cathartes sp._Cathartes sp._cathar1
+Cathartidae sp._Cathartidae sp._vultur1
+Sagittarius serpentarius_secretário_secret2
+Pandion haliaetus_águia-pescadora_osprey
+Pandion haliaetus haliaetus_águia-pescadora (haliaetus)_osprey3
+Pandion haliaetus carolinensis_águia-pescadora (carolinensis)_osprey1
+Pandion haliaetus ridgwayi_águia-pescadora (ridgwayi)_osprey2
+Pandion haliaetus cristatus_águia-pescadora (cristatus)_osprey4
+Gampsonyx swainsonii_gaviãozinho_peakit1
+Chelictinia riocourii_scissor-tailed kite_sctkit1
+Elanus leucurus_gavião-peneira_whtkit
+Elanus caeruleus_peneireiro-cinzento_bkskit1
+Elanus caeruleus caeruleus_peneireiro-cinzento (caeruleus)_bkskit2
+Elanus caeruleus [vociferus Group]_peneireiro-cinzento [grupo vociferus]_bkskit3
+Elanus axillaris_black-shouldered kite_auskit1
+Elanus scriptus_letter-winged kite_lewkit1
+Polyboroides typus_serpentário-pequeno_afhhaw1
+Polyboroides radiatus_madagascar harrier-hawk_mahhaw1
+Gypohierax angolensis_abutre-das-palmeiras_panvul1
+Gypaetus barbatus_brita-ossos_lammer1
+Gypaetus barbatus barbatus_brita-ossos (barbatus)_lammer2
+Gypaetus barbatus meridionalis_brita-ossos (meridionalis)_lammer3
+Neophron percnopterus_britango_egyvul1
+Eutriorchis astur_madagascar serpent-eagle_maseag1
+Chondrohierax uncinatus_gavião-caracoleiro_hobkit
+Chondrohierax uncinatus uncinatus_gavião-caracoleiro (uncinatus)_hobkit1
+Chondrohierax uncinatus mirus_gavião-caracoleiro (mirus)_hobkit3
+Chondrohierax wilsonii_cuban kite_hobkit2
+Leptodon cayanensis_gavião-gato_grhkit1
+Leptodon forbesi_gavião-gato-do-nordeste_whckit1
+Aviceda cuculoides_falcão-cuco_afrcuh1
+Aviceda madagascariensis_madagascar cuckoo-hawk_madcuh1
+Aviceda jerdoni_jerdon's baza_jerbaz1
+Aviceda subcristata_baza-australiano_pacbaz1
+Aviceda leuphotes_black baza_blabaz1
+Pernis apivorus_bútio-vespeiro-ocidental_euhbuz1
+Pernis ptilorhynchus_bútio-vespeiro-oriental_orihob2
+Pernis ptilorhynchus orientalis_bútio-vespeiro-oriental (orientalis)_orihob3
+Pernis ptilorhynchus ruficollis/philippensis_bútio-vespeiro-oriental (ruficollis/philippensis)_orihob4
+Pernis ptilorhynchus [ptilorhynchus Group]_oriental honey-buzzard (Sunda)_orihob10
+Pernis apivorus x ptilorhynchus_bútio-vespeiro-ocidental x bútio-vespeiro-oriental (híbrido)_x00786
+Pernis apivorus/ptilorhynchus_bútio-vespeiro-ocidental/bútio-vespeiro-oriental_y00658
+Pernis celebensis_sulawesi honey-buzzard_barhob1
+Pernis steerei_philippine honey-buzzard_barhob2
+Elanoides forficatus_gavião-tesoura_swtkit
+Hamirostra melanosternon_black-breasted kite_bkbkit1
+Lophoictinia isura_square-tailed kite_sqtkit1
+Henicopernis longicauda_long-tailed honey-buzzard_lthbuz1
+Henicopernis infuscatus_black honey-buzzard_blhbuz1
+Sarcogyps calvus_red-headed vulture_rehvul1
+Trigonoceps occipitalis_abutre-de-cabeça-branca_whhvul1
+Aegypius monachus_abutre-preto_cinvul1
+Torgos tracheliotos_abutre-real_lafvul1
+Necrosyrtes monachus_abutre-de-capucho_hoovul1
+Gyps himalayensis_himalayan griffon_himgri1
+Gyps bengalensis_white-rumped vulture_whrvul1
+Gyps africanus_grifo-africano_whbvul1
+Gyps indicus_indian vulture_indvul1
+Gyps tenuirostris_slender-billed vulture_slbvul1
+Gyps coprotheres_cape griffon_capgri1
+Gyps africanus/coprotheres_white-backed vulture/cape griffon_y00942
+Gyps rueppelli_grifo-pedrês_ruegri1
+Gyps africanus/rueppelli_grifo-africano/grifo-pedrês_y00634
+Gyps fulvus_grifo-comum_eurgri1
+Gyps rueppelli/fulvus_grifo-pedrês/grifo-comum_y00837
+Gyps himalayensis/fulvus_himalayan/eurasian griffon_y00838
+Gyps sp._grifo (Gyps) sp._gyps1
+Accipitridae sp. (old world vulture sp.)_abutre (Velho Mundo) sp._olwvul1
+Spilornis klossi_nicobar serpent-eagle_nicsee1
+Spilornis rufipectus_sulawesi serpent-eagle_suseag1
+Spilornis kinabaluensis_mountain serpent-eagle_moseag1
+Spilornis cheela_crested serpent-eagle_crseag1
+Spilornis cheela [cheela Group]_crested serpent-eagle (Crested)_cresee1
+Spilornis cheela davisoni_crested serpent-eagle (Andaman)_cresee9
+Spilornis cheela minimus_crested serpent-eagle (Central Nicobar)_cresee5
+Spilornis cheela perplexus_crested serpent-eagle (Ryukyu)_cresee7
+Spilornis cheela natunensis_crested serpent-eagle (Natuna)_cresee6
+Spilornis cheela abbotti_crested serpent-eagle (Simeulue)_cresee2
+Spilornis cheela asturinus_crested serpent-eagle (Nias)_cresee3
+Spilornis cheela sipora_crested serpent-eagle (Mentawai)_cresee8
+Spilornis cheela baweanus_crested serpent-eagle (Bawean)_cresee4
+Spilornis holospilus_philippine serpent-eagle_phseag1
+Spilornis elgini_andaman serpent-eagle_anseag1
+Pithecophaga jefferyi_philippine eagle_grpeag1
+Terathopius ecaudatus_águia-pintada_batele1
+Circaetus cinerascens_guincho-pequeno_baseag1
+Circaetus fasciolatus_southern banded snake-eagle_faseag1
+Circaetus spectabilis_congo snake-eagle_coseag1
+Circaetus beaudouini_guincho-da-guiné_beasne1
+Circaetus pectoralis_black-chested snake-eagle_bkbsne1
+Circaetus gallicus_águia-cobreira_shteag1
+Circaetus cinereus_guincho-castanho_brseag1
+Circaetus sp._águia-cobreira (Circaertus) sp._snakee1
+Stephanoaetus coronatus_águia-coroada_crheag1
+Nisaetus nanus_wallace's hawk-eagle_walhae1
+Nisaetus kelaarti_legge's hawk-eagle_mouhae2
+Nisaetus nipalensis_mountain hawk-eagle_mouhae1
+Nisaetus nipalensis nipalensis_mountain hawk-eagle (nipalensis)_mouhae5
+Nisaetus nipalensis orientalis_mountain hawk-eagle (orientalis)_mouhae4
+Nisaetus alboniger_blyth's hawk-eagle_blyhae1
+Nisaetus bartelsi_javan hawk-eagle_javhae1
+Nisaetus lanceolatus_sulawesi hawk-eagle_sulhae1
+Nisaetus pinskeri_pinsker's hawk-eagle_pinhae1
+Nisaetus philippensis_philippine hawk-eagle_phihae1
+Nisaetus cirrhatus_changeable hawk-eagle_y00839
+Nisaetus cirrhatus cirrhatus/ceylanensis_changeable hawk-eagle (Crested)_crehae1
+Nisaetus cirrhatus [limnaeetus Group]_changeable hawk-eagle (Changeable)_chahae1
+Nisaetus floris_flores hawk-eagle_flohae1
+Nisaetus sp._Nisaetus sp._nisaet1
+Spizaetus tyrannus_gavião-pega-macaco_blheag1
+Spizaetus melanoleucus_gavião-pato_bawhae1
+Spizaetus ornatus_gavião-de-penacho_orheag1
+Spizaetus isidori_black-and-chestnut eagle_baceag2
+Spizaetus sp._Spizaetus sp._spizae1
+Lophotriorchis kienerii_rufous-bellied eagle_rubeag2
+Polemaetus bellicosus_águia-marcial_mareag1
+Lophaetus occipitalis_águia-de-penacho_loceag1
+Ictinaetus malaiensis_black eagle_blaeag1
+Clanga hastata_indian spotted eagle_inseag1
+Clanga pomarina_águia-da-pomerânia_leseag1
+Clanga clanga_águia-malhada_grseag1
+Clanga pomarina x clanga_águia-da-pomerânia x águia-malhada (híbrido)_x00843
+Clanga pomarina/clanga_águia-da-pomerânia/águia-malhada_y00718
+Clanga hastata/clanga_indian/greater spotted eagle_y00719
+Hieraaetus wahlbergi_águia-de-wahlberg_waheag3
+Hieraaetus ayresii_ayres's hawk-eagle_ayheag1
+Hieraaetus weiskei_pygmy eagle_liteag3
+Hieraaetus pennatus_águia-calçada_booeag1
+Hieraaetus morphnoides_little eagle_liteag1
+Aquila nipalensis_águia-das-estepes_steeag1
+Aquila heliaca_águia-imperial-oriental_impeag1
+Aquila adalberti_águia-imperial-ibérica_spaeag1
+Aquila rapax_águia-fulva_taweag1
+Aquila nipalensis/rapax_águia-das-estepes/águia-fulva_y01022
+Aquila africana_cassin's hawk-eagle_cashae1
+Aquila gurneyi_gurney's eagle_gureag1
+Aquila audax_wedge-tailed eagle_weteag1
+Aquila chrysaetos_águia-real_goleag
+Aquila verreauxii_águia-preta_vereag1
+Aquila fasciata_águia-perdigueira_boneag2
+Aquila spilogaster_águia-preta-e-branca_afrhae1
+Aquila sp._águia (Aquila) sp._aquila1
+Clanga/Aquila sp._Clanga/Aquila sp._y01070
+Harpyopsis novaeguineae_new guinea eagle_negeag1
+Macheiramphus alcinus_papa-morcegos_bathaw1
+Morphnus guianensis_uiraçu_creeag1
+Harpia harpyja_gavião-real_hareag1
+Lophospiza trivirgata_crested goshawk_cregos1
+Lophospiza griseiceps_sulawesi goshawk_sulgos1
+Micronisus gabar_açor-palrador_gabgos2
+Urotriorchis macrourus_long-tailed hawk_lothaw1
+Melierax metabates_açor-cantador_dacgos1
+Melierax poliopterus_eastern chanting-goshawk_eacgos1
+Melierax metabates/poliopterus_dark/eastern chanting-goshawk_y01289
+Melierax canorus_pale chanting-goshawk_pacgos1
+Melierax metabates/canorus_dark/pale chanting-goshawk_y01290
+Kaupifalco monogrammicus_mioto-papa-lagartos_lizbuz1
+Aerospiza tachiro_african goshawk_afrgos1
+Aerospiza tachiro macroscelides_african goshawk (Banded)_recgos2
+Aerospiza tachiro toussenelii/canescens_african goshawk (Red-chested)_recgos3
+Aerospiza tachiro lopezi_african goshawk (Bioko)_recgos4
+Aerospiza tachiro unduliventer/croizati_african goshawk (Ethiopian)_afrgos2
+Aerospiza tachiro sparsimfasciata_african goshawk (Eastern)_afrgos3
+Aerospiza tachiro pembaensis_african goshawk (Pemba)_afrgos4
+Aerospiza tachiro tachiro_african goshawk (Southern)_afrgos5
+Aerospiza castanilius_chestnut-flanked sparrowhawk_chfspa1
+Tachyspiza erythropus_gavião-pequeno_retspa1
+Tachyspiza minulla_little sparrowhawk_litspa1
+Tachyspiza virgata_besra_besra1
+Lophospiza trivirgata/Tachyspiza virgata_crested goshawk/besra_y01073
+Tachyspiza nanus_small sparrowhawk_smaspa1
+Tachyspiza erythrauchen_rufous-necked sparrowhawk_runspa1
+Tachyspiza cirrocephala_collared sparrowhawk_colspa1
+Tachyspiza brachyura_new britain sparrowhawk_nebspa1
+Tachyspiza rhodogaster_vinous-breasted sparrowhawk_vibspa1
+Tachyspiza gularis_gavião-japonês_japspa1
+Tachyspiza virgata/gularis_besra/japanese sparrowhawk_y00943
+Tachyspiza badia_gavião-chicra_shikra1
+Tachyspiza badia sphenura/polyzonoides_gavião-chicra (sphenura/polyzonoides)_shikra2
+Tachyspiza badia [badia Group]_gavião-chicra [grupo badia]_shikra3
+Tachyspiza butleri_nicobar sparrowhawk_nicspa1
+Tachyspiza brevipes_gavião-do-levante_levspa1
+Tachyspiza soloensis_gavião-chinês_grfhaw1
+Tachyspiza imitator_imitator sparrowhawk_imispa1
+Tachyspiza francesiae_frances's sparrowhawk_fragos2
+Tachyspiza trinotata_spot-tailed goshawk_sptgos1
+Tachyspiza poliocephala_gray-headed goshawk_gyhgos1
+Tachyspiza princeps_new britain goshawk_nebgos1
+Tachyspiza novaehollandiae_gray goshawk_grygos1
+Tachyspiza hiogaster_variable goshawk_vargos1
+Tachyspiza hiogaster sylvestris_variable goshawk (Lesser Sundas)_vargos2
+Tachyspiza hiogaster [hiogaster Group]_variable goshawk (Variable)_vargos3
+Tachyspiza melanochlamys_black-mantled goshawk_blmgos1
+Tachyspiza albogularis_pied goshawk_piegos1
+Tachyspiza rufitorques_fiji goshawk_fijgos1
+Tachyspiza henicogramma_moluccan goshawk_molgos1
+Tachyspiza luteoschistacea_slaty-mantled goshawk_slmgos1
+Tachyspiza haplochroa_new caledonian goshawk_necgos1
+Tachyspiza fasciata_açor-australiano_brogos1
+Tachyspiza cirrocephala/fasciata_collared sparrowhawk/brown goshawk_y00841
+Tachyspiza hiogaster/fasciata_variable/brown goshawk_y01023
+Erythrotriorchis buergersi_chestnut-shouldered goshawk_chsgos1
+Erythrotriorchis radiatus_red goshawk_redgos1
+Accipiter poliogaster_tauató-pintado_gybhaw1
+Accipiter ovampensis_ovambo sparrowhawk_ovaspa2
+Accipiter madagascariensis_madagascar sparrowhawk_madspa1
+Accipiter nisus_gavião_eurspa1
+Tachyspiza brevipes/Accipiter nisus_gavião-do-levante/gavião_y00842
+Accipiter rufiventris_rufous-breasted sparrowhawk_rucspa2
+Accipiter rufiventris perspicillaris_rufous-breasted sparrowhawk (Ethiopian)_rucspa3
+Accipiter rufiventris rufiventris_rufous-breasted sparrowhawk (Rufous-breasted)_rucspa4
+Accipiter striatus_tauató-miúdo_shshaw
+Accipiter striatus [striatus Group]_tauató-miúdo [grupo striatus]_shshaw1
+Accipiter striatus [velox Group]_tauató-miúdo [grupo velox]_shshaw2
+Accipiter striatus madrensis_gavião-miúdo (madrensis)_shshaw6
+Accipiter striatus chionogaster_tauató-miúdo (chionogaster)_shshaw3
+Accipiter striatus ventralis_tauató-miúdo (ventralis)_shshaw4
+Accipiter striatus erythronemius_tauató-miúdo (erythronemius)_shshaw5
+Astur bicolor_gavião-bombachinha-grande_bichaw1
+Astur bicolor bicolor/fidens_gavião-bombachinha-grande (bicolor/fidens)_bichaw2
+Astur bicolor pileatus/guttifer_gavião-bombachinha-grande (pileatus/guttifer)_bichaw3
+Astur chilensis_chilean hawk_bichaw4
+Astur bicolor/chilensis_bicolored/chilean hawk_y01209
+Astur cooperii_cooper's hawk_coohaw
+Accipiter striatus/Astur cooperii_sharp-shinned/cooper's hawk_y00612
+Astur gundlachi_gundlach's hawk_gunhaw1
+Astur gentilis_açor_norgos1
+Accipiter nisus/Astur gentilis_gavião/açor_y00392
+Astur atricapillus_american goshawk_norgos
+Astur cooperii x atricapillus_cooper's hawk x american goshawk (hybrid)_x00988
+Astur cooperii/atricapillus_cooper's hawk/american goshawk_y00666
+Astur gentilis/atricapillus_eurasian/american goshawk_y01256
+Astur meyerianus_meyer's goshawk_meygos1
+Astur melanoleucus_black goshawk_blagos1
+Astur henstii_henst's goshawk_hengos1
+Aerospiza/Tachyspiza/Accipiter/Astur sp._gavião/açor sp._accipi
+Megatriorchis doriae_doria's hawk_dorgos1
+Circus aeruginosus_águia-sapeira_wemhar1
+Circus ranivorus_african marsh harrier_afmhar1
+Circus spilonotus_eastern marsh harrier_easmah1
+Circus aeruginosus/spilonotus_western/eastern marsh harrier_y00391
+Circus spilothorax_papuan harrier_easmah2
+Circus spilonotus/spilothorax_eastern marsh/papuan harrier_eamhar1
+Circus approximans_swamp harrier_swahar1
+Circus maillardi_reunion harrier_reuhar2
+Circus macrosceles_malagasy harrier_reuhar3
+Circus buffoni_gavião-do-banhado_lowhar1
+Circus assimilis_tartaranhão-malhado_spohar1
+Circus approximans/assimilis_swamp/spotted harrier_y01243
+Circus maurus_black harrier_blahar1
+Circus cinereus_gavião-cinza_cinhar1
+Circus cyaneus_tartaranhão-cinzento_norhar1
+Circus hudsonius_tartaranhão-cinzento-americano_norhar2
+Circus cyaneus/hudsonius_tartaranhão-cinzento/tartaranhão-cinzento-americano_norhar
+Circus macrourus_tartaranhão-pálido_palhar1
+Circus cyaneus x macrourus_tartaranhão-cinzento x tartaranhão-pálido (híbrido)_x00399
+Circus melanoleucos_pied harrier_piehar1
+Circus pygargus_águia-caçadeira_monhar1
+Circus macrourus x pygargus_pallid x montagu's harrier (hybrid)_x01099
+Circus cyaneus/pygargus_tartaranhão-cinzento/águia-caçadeira_y00840
+Circus macrourus/pygargus_tartaranhão-pálido/águia-caçadeira_y00720
+Circus sp._Circus sp._harrie1
+Microspizias superciliosus_tauató-passarinho_tinhaw1
+Microspizias collaris_semicollared hawk_semhaw2
+Harpagus bidentatus_gavião-ripina_dotkit1
+Harpagus diodon_gavião-bombachinha_rutkit1
+Milvus milvus_milhafre-real_redkit1
+Milvus milvus milvus_milhafre-real (milvus)_redkit2
+Milvus milvus fasciicauda_milhafre-real-de-cabo-verde_redkit3
+Milvus migrans_milhafre-preto_blakit1
+Milvus migrans [migrans Group]_milhafre-preto [grupo migrans]_blkkit1
+Milvus migrans lineatus/formosanus_milhafre-preto (lineatus/formosanus)_blkkit2
+Milvus migrans aegyptius/parasitus_milhafre-preto (aegyptius/parasitus)_blkkit3
+Milvus milvus/migrans_milhafre-real/milhafre-preto_y00611
+Haliastur indus_milhafre-de-dorso-ruivo_brakit1
+Milvus migrans/Haliastur indus_milhafre-preto/milhafre-de-dorso-ruivo_y00393
+Haliastur sphenurus_whistling kite_whikit1
+Haliaeetus albicilla_pigargo_whteag
+Haliaeetus leucocephalus_pigargo-americano_baleag
+Haliaeetus leucoryphus_pigargo-de-pallas_pafeag1
+Haliaeetus pelagicus_steller's sea-eagle_stseag
+Haliaeetus leucocephalus x pelagicus_bald eagle x steller's sea-eagle (hybrid)_x00989
+Aquila chrysaetos/Haliaeetus leucocephalus_águia-real/pigargo-americano_y00944
+Icthyophaga vocifer_pigargo-africano_affeag1
+Icthyophaga vociferoides_madagascar fish-eagle_mafeag1
+Icthyophaga leucogaster_pigargo-oriental_wbseag1
+Icthyophaga sanfordi_sanford's sea-eagle_solsee1
+Icthyophaga humilis_lesser fish-eagle_lefeag1
+Icthyophaga ichthyaetus_gray-headed fish-eagle_gyhfie1
+Icthyophaga humilis/ichthyaetus_lesser/gray-headed fish-eagle_y00721
+Haliaeetus/Icthyophaga sp._Haliaeetus/Icthyophaga sp._haliae1
+Butastur liventer_rufous-winged buzzard_ruwbuz1
+Butastur rufipennis_grasshopper buzzard_grabuz1
+Butastur teesa_white-eyed buzzard_whebuz1
+Butastur indicus_bútio-de-faces-cinzentas_gyfbuz1
+Ictinia mississippiensis_sovi-do-norte_miskit
+Ictinia plumbea_sovi_plukit1
+Ictinia mississippiensis/plumbea_sovi-do-norte/sovi_y00772
+Geranospiza caerulescens_gavião-pernilongo_crahaw
+Geranospiza caerulescens [nigra Group]_gavião-pernilongo [grupo nigra]_crahaw1
+Geranospiza caerulescens caerulescens_gavião-pernilongo (caerulescens)_crahaw2
+Geranospiza caerulescens gracilis/flexipes_gavião-pernilongo (gracilis/flexipes)_crahaw3
+Busarellus nigricollis_gavião-belo_blchaw1
+Rostrhamus sociabilis_gavião-caramujeiro_snakit
+Helicolestes hamatus_gavião-do-igapó_slbkit1
+Morphnarchus princeps_barred hawk_barhaw1
+Cryptoleucopteryx plumbea_plumbeous hawk_pluhaw
+Buteogallus schistaceus_gavião-azul_slchaw2
+Buteogallus anthracinus_gavião-caranguejeiro-negro_comblh1
+Buteogallus anthracinus anthracinus_gavião-caranguejeiro-negro (anthracinus)_cobhaw
+Buteogallus anthracinus [subtilis Group]_gavião-caranguejeiro-negro [grupo subtilis]_mabhaw1
+Buteogallus gundlachii_cuban black hawk_cubblh1
+Buteogallus aequinoctialis_gavião-caranguejeiro_ruchaw1
+Buteogallus meridionalis_gavião-caboclo_savhaw1
+Buteogallus lacernulatus_gavião-pombo-pequeno_whnhaw2
+Buteogallus urubitinga_gavião-preto_grbhaw1
+Buteogallus urubitinga ridgwayi_bútio-preto (ridgwayi)_grbhaw2
+Buteogallus urubitinga urubitinga_bútio-preto (urubitinga)_grbhaw3
+Buteogallus anthracinus/urubitinga_gavião-caranguejeiro-negro/gavião-preto_y00945
+Buteogallus solitarius_águia-solitária_soleag1
+Buteogallus coronatus_águia-cinzenta_croeag1
+Buteogallus sp._Buteogallus sp._buteog1
+Rupornis magnirostris_gavião-carijó_roahaw
+Rupornis magnirostris gracilis_gavião-carijó (gracilis)_roahaw2
+Rupornis magnirostris [magnirostris Group]_bútio-carijó [grupo magnirostris]_roahaw3
+Rupornis magnirostris [pucherani Group]_bútio-carijó [grupo pucherani]_roahaw4
+Parabuteo unicinctus_gavião-asa-de-telha_hrshaw
+Parabuteo unicinctus harrisi_gavião-asa-de-telha (harrisi)_harhaw1
+Parabuteo unicinctus unicinctus_gavião-asa-de-telha (unicinctus)_harhaw2
+Parabuteo leucorrhous_gavião-de-sobre-branco_whrhaw1
+Geranoaetus albicaudatus_gavião-de-rabo-branco_whthaw
+Geranoaetus polyosoma_gavião-de-costas-vermelhas_rebhaw2
+Geranoaetus polyosoma (Puna)_gavião-de-costas-vermelhas (Puna)_punhaw1
+Geranoaetus polyosoma (Red-backed)_gavião-de-costas-vermelhas (Red-backed)_rebhaw1
+Geranoaetus polyosoma polyosoma_gavião-de-costas-vermelhas (polyosoma)_varhaw1
+Geranoaetus polyosoma exsul_gavião-de-costas-vermelhas (exsul)_varhaw2
+Geranoaetus melanoleucus_águia-serrana_bcbeag1
+Geranoaetus sp._Geranoaetus sp._gerano1
+Pseudastur occidentalis_gray-backed hawk_gybhaw2
+Pseudastur albicollis_gavião-branco_whihaw1
+Pseudastur albicollis ghiesbreghti_gavião-branco (ghiesbreghti)_whihaw2
+Pseudastur albicollis costaricensis_gavião-branco (costaricensis)_whihaw3
+Pseudastur albicollis williaminae_gavião-branco (williaminae)_whihaw5
+Pseudastur albicollis albicollis_gavião-branco (albicollis)_whihaw4
+Pseudastur polionotus_gavião-pombo-grande_manhaw2
+Leucopternis semiplumbeus_semiplumbeous hawk_semhaw
+Leucopternis melanops_gavião-de-cara-preta_blfhaw1
+Leucopternis kuhli_gavião-vaqueiro_whbhaw2
+Bermuteo avivorus_bermuda hawk_berhaw1
+Buteo plagiatus_gray hawk_gryhaw2
+Buteo nitidus_gavião-pedrês_gryhaw3
+Buteo plagiatus/nitidus_gray/gray-lined hawk_gryhaw1
+Buteo platypterus_gavião-de-asa-larga_brwhaw
+Buteo platypterus platypterus_gavião-de-asa-larga (platypterus)_brwhaw1
+Buteo platypterus [antillarum Group]_gavião-de-asa-larga [grupo antillarum]_brwhaw2
+Buteo lineatus_red-shouldered hawk_reshaw
+Buteo lineatus [lineatus Group]_red-shouldered hawk (lineatus Group)_reshaw5
+Buteo lineatus extimus_red-shouldered hawk (extimus)_reshaw2
+Buteo lineatus elegans_red-shouldered hawk (elegans)_reshaw4
+Buteogallus anthracinus x Buteo lineatus_common black x red-shouldered hawk (hybrid)_x00787
+Buteo ridgwayi_ridgway's hawk_ridhaw1
+Buteo platypterus x lineatus_broad-winged x red-shouldered hawk (hybrid)_x00400
+Buteo platypterus/lineatus_broad-winged/red-shouldered hawk_y00773
+Buteo albonotatus_gavião-urubu_zothaw
+Buteo solitarius_hawaiian hawk_hawhaw
+Buteo albigula_white-throated hawk_whthaw1
+Buteo brachyurus_gavião-de-cauda-curta_shthaw
+Buteo swainsoni_gavião-papa-gafanhoto_swahaw
+Buteo galapagoensis_galapagos hawk_galhaw1
+Buteo jamaicensis_red-tailed hawk_rethaw
+Buteo jamaicensis harlani_red-tailed hawk (Harlan's)_hrthaw1
+Buteo jamaicensis abieticola_red-tailed hawk (abieticola)_rethaw4
+Buteo jamaicensis calurus/alascensis_red-tailed hawk (calurus/alascensis)_wrthaw1
+Buteo jamaicensis borealis_red-tailed hawk (borealis)_erthaw1
+Buteo jamaicensis calurus/abieticola_red-tailed hawk (calurus/abieticola)_rethaw9
+Buteo jamaicensis kriderii_red-tailed hawk (Krider's)_krthaw1
+Buteo jamaicensis fuertesi_red-tailed hawk (fuertesi)_frthaw1
+Buteo jamaicensis suttoni_red-tailed hawk (Sutton's)_rethaw14
+Buteo jamaicensis kemsiesi/hadropus_red-tailed hawk (kemsiesi/hadropus)_rethaw5
+Buteo jamaicensis costaricensis_red-tailed hawk (costaricensis)_rethaw1
+Buteo jamaicensis fumosus_red-tailed hawk (fumosus)_rethaw6
+Buteo jamaicensis socorroensis_red-tailed hawk (socorroensis)_rethaw7
+Buteo jamaicensis umbrinus_red-tailed hawk (umbrinus)_rethaw8
+Buteo jamaicensis jamaicensis_red-tailed hawk (jamaicensis)_rethaw2
+Buteo jamaicensis solitudinis_red-tailed hawk (solitudinis)_rethaw3
+Buteo lineatus x jamaicensis_red-shouldered x red-tailed hawk (hybrid)_x00686
+Buteo ventralis_rufous-tailed hawk_ruthaw1
+Buteo lagopus_bútio-calçado_rolhaw
+Buteo swainsoni x lagopus_bútio-das-pradarias x bútio-calçado (híbrido)_x00788
+Buteo jamaicensis x lagopus_red-tailed x rough-legged hawk (hybrid)_x00731
+Buteo regalis_ferruginous hawk_ferhaw
+Buteo jamaicensis x regalis_red-tailed x ferruginous hawk (hybrid)_x00930
+Buteo auguralis_red-necked buzzard_renbuz1
+Buteo augur_augur buzzard_augbuz2
+Buteo augur augur_augur buzzard (Augur)_augbuz1
+Buteo augur archeri_augur buzzard (Archer's)_arcbuz1
+Buteo rufofuscus_jackal buzzard_jacbuz1
+Buteo oreophilus_mountain buzzard_moubuz2
+Buteo buteo_águia-d'asa-redonda_combuz1
+Buteo buteo buteo_águia-d'asa-redonda (buteo)_combuz7
+Buteo buteo arrigonii_águia-d'asa-redonda (arrigonii)_combuz8
+Buteo buteo rothschildi_queimado_combuz2
+Buteo buteo insularum_águia-d'asa-redonda (insularum)_combuz3
+Buteo buteo bannermani_águia-d'asa-redonda (bannermani)_combuz4
+Buteo buteo vulpinus/menetriesi_bútio-das-estepes_combuz5
+Buteo trizonatus_forest buzzard_moubuz3
+Buteo [undescribed form]_elgin buzzard (undescribed form)_moubuz4
+Buteo brachypterus_madagascar buzzard_madbuz1
+Buteo socotraensis_socotra buzzard_socbuz1
+Buteo rufinus_bútio-mourisco_lolbuz1
+Buteo rufinus rufinus_bútio-mourisco (rufinus)_lolbuz2
+Buteo rufinus cirtensis_bútio-mourisco (cirtensis)_lolbuz3
+Buteo buteo x rufinus_águia-d'asa-redonda x bútio-mourisco (híbrido)_x00766
+Buteo buteo/rufinus_águia-d'asa-redonda/bútio-mourisco_y01024
+Buteo hemilasius_upland buzzard_uplbuz1
+Buteo rufinus x hemilasius_long-legged x upland buzzard (hybrid)_x00789
+Buteo rufinus/hemilasius_long-legged/upland buzzard_y00843
+Buteo refectus_himalayan buzzard_combuz9
+Buteo buteo/refectus_common/himalayan buzzard_y00946
+Buteo japonicus_eastern buzzard_combuz6
+Buteo buteo/japonicus_common/eastern buzzard_y01258
+Buteo refectus/japonicus_himalayan/eastern buzzard_y00948
+Buteo buteo/refectus/japonicus_common/himalayan/eastern buzzard_y00947
+Buteo sp._bútio (Buteo) sp._buteo
+Geranoaetus/Buteo sp._Geranoaetus/Buteo sp._y00681
+Buteo/eagle sp._bútio/águia sp._y00221
+Accipitridae sp. (hawk sp.)_gavião sp._hawk
+Accipitridae sp. (eagle sp.)_águia (Haliaeetus/Aquila) sp._eagle1
+Tyto tenebricosa_sooty owl_sooowl1
+Tyto tenebricosa tenebricosa/arfaki_sooty owl (Greater)_grsowl1
+Tyto tenebricosa multipunctata_sooty owl (Lesser)_lesowl1
+Tyto novaehollandiae_australian masked-owl_aumowl1
+Tyto aurantia_golden masked-owl_nebmao1
+Tyto almae_seram masked-owl_sermao1
+Tyto sororcula_lesser masked-owl_lemowl1
+Tyto sororcula cayelii_lesser masked-owl (Buru)_lesmao1
+Tyto sororcula sororcula_lesser masked-owl (Tanimbar)_lesmao2
+Tyto manusi_manus masked-owl_manowl2
+Tyto nigrobrunnea_taliabu masked-owl_talowl1
+Tyto inexspectata_minahasa masked-owl_minowl1
+Tyto rosenbergii_sulawesi masked-owl_sulowl1
+Tyto prigoginei_itombwe owl_cobowl1
+Tyto longimembris_australasian grass-owl_ausgro1
+Tyto capensis_african grass-owl_afgowl1
+Tyto alba_coruja-das-torres_webowl1
+Tyto alba [alba Group]_coruja-das-torres [grupo alba]_barowl2
+Tyto alba schmitzi_coruja-das-torres (schmitzi)_barowl14
+Tyto alba gracilirostris_coruja-das-torres-das-canárias_barowl15
+Tyto alba poensis_coruja-das-torres (poensis)_barowl16
+Tyto alba detorta_coruja-das-torres (detorta)_barowl3
+Tyto alba thomensis_coruja-das-torres (thomensis)_barowl4
+Tyto javanica_eastern barn owl_eabowl1
+Tyto javanica [javanica Group]_eastern barn owl (Eastern)_barowl7
+Tyto javanica crassirostris_eastern barn owl (Boang)_barowl6
+Tyto alba/javanica_western/eastern barn owl_y01293
+Tyto furcata_suindara_brnowl
+Tyto furcata [tuidara Group]_suindara [grupo tuidara]_barowl8
+Tyto furcata furcata_suindara (furcata)_barowl28
+Tyto furcata bargei_suindara (bargei)_barowl9
+Tyto furcata nigrescens/insularis_suindara (nigrescens/insularis)_barowl10
+Tyto furcata punctatissima_suindara (punctatissima)_barowl11
+Tyto deroepstorffi_andaman masked-owl_barowl5
+Tyto glaucops_ashy-faced owl_asfowl1
+Tyto soumagnei_red owl_marowl1
+Tyto sp._Tyto sp._tyto1
+Phodilus badius_oriental bay-owl_orbowl1
+Phodilus assimilis_sri lanka bay-owl_srlbao1
+Otus sagittatus_white-fronted scops-owl_wfsowl2
+Otus balli_andaman scops-owl_ansowl1
+Otus rufescens_reddish scops-owl_resowl1
+Otus thilohoffmanni_serendib scops-owl_sersco1
+Otus icterorhynchus_sandy scops-owl_sasowl1
+Otus icterorhynchus icterorhynchus_sandy scops-owl (Sandy)_sansco2
+Otus icterorhynchus holerythrus_sandy scops-owl (Reddish)_sansco3
+Otus ireneae_sokoke scops-owl_sosowl1
+Otus alfredi_flores scops-owl_flsowl1
+Otus spilocephalus_mountain scops-owl_mosowl2
+Otus brookii_rajah scops-owl_rasowl1
+Otus brookii solokensis_rajah scops-owl (Sumatran)_rajsco2
+Otus brookii brookii_rajah scops-owl (Bornean)_rajsco1
+Otus angelinae_javan scops-owl_jasowl2
+Otus mentawi_mentawai scops-owl_mesowl1
+Otus bakkamoena_indian scops-owl_insowl1
+Otus lettia_collared scops-owl_cosowl1
+Otus gurneyi_giant scops-owl_mineao1
+Otus lempiji_sunda scops-owl_susowl2
+Otus lettia/lempiji_collared/sunda scops-owl_y01137
+Otus semitorques_japanese scops-owl_jasowl1
+Otus silvicola_wallace's scops-owl_wasowl1
+Otus fuliginosus_palawan scops-owl_pasowl2
+Otus megalotis_philippine scops-owl_phsowl1
+Otus everetti_everett's scops-owl_evesco1
+Otus nigrorum_negros scops-owl_negsco1
+Otus mindorensis_mindoro scops-owl_misowl2
+Otus magicus_moluccan scops-owl_mosowl1
+Otus magicus [magicus Group]_moluccan scops-owl (Moluccan)_molsco1
+Otus magicus kalidupae_moluccan scops-owl (Kalidupa)_sulsco4
+Otus tempestatis_wetar scops-owl_molsco2
+Otus jolandae_rinjani scops-owl_rinsco1
+Otus podarginus_palau scops-owl_palowl2
+Otus mantananensis_mantanani scops-owl_masowl2
+Otus elegans_ryukyu scops-owl_ryusco1
+Otus manadensis_sulawesi scops-owl_susowl1
+Otus mendeni_banggai scops-owl_sulsco5
+Otus collari_sangihe scops-owl_sansco1
+Otus siaoensis_siau scops-owl_sulsco2
+Otus sulaensis_sula scops-owl_sulsco3
+Otus beccarii_biak scops-owl_biasco1
+Otus umbra_simeulue scops-owl_sisowl1
+Otus enganensis_enggano scops-owl_ensowl1
+Otus alius_nicobar scops-owl_nicsco1
+Otus pamelae_arabian scops-owl_arasco1
+Otus scops_mocho-d'orelhas_eursco1
+Otus cyprius_mocho-d'orelhas-do-chipre_eursco3
+Otus scops/cyprius_mocho-d'orelhas/mocho-d'orelhas-do-chipre_y00394
+Otus bikegila_mocho-d'orelhas-do-príncipe_prisco1
+Otus pembaensis_pemba scops-owl_pesowl2
+Otus hartlaubi_sao tome scops-owl_stsowl1
+Otus senegalensis_mocho-d'orelhas-africano_afsowl1
+Otus senegalensis senegalensis_mocho-d'orelhas-africano (senegalensis)_afrsco1
+Otus senegalensis feae_mocho-d'orelhas-africano (feae)_afrsco3
+Otus senegalensis nivosus_mocho-d'orelhas-africano (nivosus)_afrsco4
+Otus brucei_mocho-d'orelhas-pálido_pasowl3
+Otus scops/brucei_mocho-d'orelhas/mocho-d'orelhas-pálido_y00858
+Otus mirus_mindanao scops-owl_misowl1
+Otus longicornis_luzon scops-owl_lusowl1
+Otus moheliensis_moheli scops-owl_mohsco1
+Otus pauliani_comoro scops-owl_cosowl3
+Otus insularis_seychelles scops-owl_sesowl1
+Otus sunia_oriental scops-owl_orsowl
+Otus sunia [sunia Group]_oriental scops-owl (Southern)_orisco1
+Otus sunia [japonicus Group]_oriental scops-owl (Northern)_orisco11
+Otus sunia modestus_oriental scops-owl (Walden's)_orisco2
+Otus socotranus_socotra scops-owl_afrsco2
+Otus capnodes_anjouan scops-owl_ansowl2
+Otus mayottensis_mayotte scops-owl_maysco1
+Otus grucheti_reunion scops-owl_reusco1
+Otus murivorus_rodrigues scops-owl_rodsco1
+Otus sauzieri_mauritius scops-owl_mausco1
+Otus rutilus_madagascar scops-owl_madsco1
+Otus rutilus rutilus_madagascar scops-owl (Rainforest)_masowl1
+Otus rutilus madagascariensis_madagascar scops-owl (Torotoroka)_torsco1
+Otus sp._mocho-d'orelhas (Otus) sp._otus1
+Psiloscops flammeolus_flammulated owl_flaowl
+Gymnasio nudipes_puerto rican owl_prsowl
+Megascops clarkii_bare-shanked screech-owl_bssowl
+Megascops trichopsis_whiskered screech-owl_whsowl1
+Megascops albogularis_white-throated screech-owl_whtsco1
+Megascops choliba_corujinha-do-mato_trsowl
+Megascops koepckeae_koepcke's screech-owl_koesco1
+Megascops koepckeae koepckeae_koepcke's screech-owl (Koepcke's)_koesco2
+Megascops koepckeae hockingi_koepcke's screech-owl (Apurimac)_apusco1
+Megascops ingens_rufescent screech-owl_rufsco1
+Megascops ingens colombianus_rufescent screech-owl (Colombian)_colsco1
+Megascops ingens ingens/venezuelanus_rufescent screech-owl (Rufescent)_rufsco2
+Megascops petersoni_cinnamon screech-owl_cinsco1
+Megascops marshalli_cloud-forest screech-owl_clfsco1
+Megascops hoyi_montane forest screech-owl_mofsco1
+Megascops guatemalae_middle american screech-owl_vesowl
+Megascops guatemalae [guatemalae Group]_middle american screech-owl (Middle American)_versco1
+Megascops guatemalae vermiculatus_middle american screech-owl (Vermiculated)_versco5
+Megascops centralis_choco screech-owl_versco2
+Megascops [undescribed form]_puntarenas screech-owl (undescribed form)_punsco1
+Megascops roraimae_corujinha-de-roraima_foosco1
+Megascops roraimae roraimae_corujinha-de-roraima (roraimae)_versco4
+Megascops roraimae [napensis Group]_corujinha-de-roraima [grupo napensis]_versco3
+Megascops sanctaecatarinae_corujinha-do-sul_lotsco1
+Megascops barbarus_bearded screech-owl_besowl
+Megascops seductus_balsas screech-owl_basowl
+Megascops cooperi_pacific screech-owl_pasowl4
+Megascops cooperi lambi_pacific screech-owl (lambi)_pacsco1
+Megascops cooperi cooperi_pacific screech-owl (cooperi)_pacsco2
+Megascops kennicottii_western screech-owl_wesowl1
+Megascops kennicottii [kennicottii Group]_western screech-owl (Northern)_wessco1
+Megascops kennicottii vinaceus_western screech-owl (Vinaceous)_wessco3
+Megascops kennicottii suttoni_western screech-owl (Sutton's)_wessco2
+Megascops asio_eastern screech-owl_easowl1
+Megascops asio [asio Group]_eastern screech-owl (Northern)_eassco1
+Megascops asio mccallii_eastern screech-owl (McCall's)_eassco2
+Megascops kennicottii x asio_western x eastern screech-owl (hybrid)_x00933
+Megascops gilesi_santa marta screech-owl_samsco1
+Megascops roboratus_peruvian screech-owl_persco1
+Megascops roboratus pacificus_peruvian screech-owl (pacificus)_persco2
+Megascops roboratus roboratus_peruvian screech-owl (roboratus)_persco3
+Megascops watsonii_corujinha-das-guianas/relógio/de-belém/do-xingu_tabsco1
+Megascops watsonii watsonii_corujinha-das-guianas/de-belém/do-xingu_tabsco2
+Megascops watsonii usta_corujinha-relógio_tabsco3
+Megascops atricapilla_corujinha-sapo/corujinha-de-alagoas_bkcsco1
+Megascops sp._Megascops sp._screec1
+Margarobyas lawrencii_bare-legged owl_balowl
+Ptilopsis leucotis_mocho-de-face-branca_nwfowl1
+Ptilopsis granti_southern white-faced owl_swfowl1
+Lophostrix cristata_coruja-de-crista_creowl1
+Jubula lettii_maned owl_manowl1
+Pulsatrix perspicillata_murucututu_speowl1
+Pulsatrix koeniswaldiana_murucututu-de-barriga-amarela_tabowl1
+Pulsatrix melanota_band-bellied owl_babowl1
+Pulsatrix sp._Pulsatrix sp._pulsat1
+Bubo scandiacus_coruja-das-neves_snoowl1
+Bubo virginianus_jacurutu_grhowl
+Bubo magellanicus_lesser horned owl_grhowl2
+Bubo virginianus/magellanicus_great/lesser horned owl_y01197
+Bubo bengalensis_rock eagle-owl_roeowl1
+Bubo cinerascens_grayish eagle-owl_graeao1
+Bubo africanus_spotted eagle-owl_spoeao2
+Bubo milesi_arabian eagle-owl_speowl2
+Bubo capensis_cape eagle-owl_caeowl1
+Bubo capensis dillonii/mackinderi_cape eagle-owl (Northern)_capeao1
+Bubo capensis capensis_cape eagle-owl (Cape)_capeao2
+Bubo ascalaphus_bufo-mourisco_pheowl1
+Bubo ascalaphus ascalaphus_bufo-mourisco (ascalaphus)_phaeao1
+Bubo ascalaphus desertorum_bufo-mourisco (desertorum)_phaeao2
+Bubo bubo_bufo-real_eueowl1
+Bubo sp._Bubo sp._bubo1
+Ketupa poensis_fraser's eagle-owl_fraeao1
+Ketupa poensis poensis_fraser's eagle-owl (Western)_freowl1
+Ketupa poensis vosseleri_fraser's eagle-owl (Usambara)_useowl1
+Ketupa leucosticta_akun eagle-owl_akeowl1
+Ketupa lactea_corujão-leitoso_veeowl1
+Ketupa shelleyi_shelley's eagle-owl_sheowl1
+Ketupa blakistoni_blakiston's fish-owl_blfowl1
+Ketupa blakistoni doerriesi_blakiston's fish-owl (doerriesi)_blafio2
+Ketupa blakistoni blakistoni_blakiston's fish-owl (blakistoni)_blafio4
+Ketupa ketupu_buffy fish-owl_bufowl2
+Ketupa zeylonensis_bufo-pescador_brfowl1
+Ketupa zeylonensis semenowi_bufo-pescador (semenowi)_brnfio2
+Ketupa zeylonensis [zeylonensis Group]_bufo-pescador [grupo zeylonensis]_brnfio1
+Ketupa ketupu x zeylonensis_buffy x brown fish-owl (hybrid)_x00401
+Ketupa flavipes_tawny fish-owl_tafowl1
+Ketupa coromanda_dusky eagle-owl_dueowl1
+Ketupa nipalensis_spot-bellied eagle-owl_sbeowl1
+Ketupa sumatrana_barred eagle-owl_baeowl1
+Ketupa philippensis_philippine eagle-owl_pheowl2
+Scotopelia peli_corujão-pesqueiro_pefowl1
+Scotopelia ussheri_rufous fishing-owl_rufowl1
+Scotopelia bouvieri_vermiculated fishing-owl_vefowl1
+Surnia ulula_mocho-rabilongo_nohowl
+Surnia ulula caparoch_mocho-rabilongo (caparoch)_nohowl1
+Surnia ulula ulula/tianschanica_mocho-rabilongo (ulula/tianschanica)_nohowl2
+Glaucidium passerinum_mocho-anão_eupowl1
+Glaucidium perlatum_mochinho-pintado_pesowl1
+Glaucidium gnoma_northern pygmy-owl_nopowl
+Glaucidium gnoma gnoma_northern pygmy-owl (Mountain)_moupyo1
+Glaucidium gnoma [californicum Group]_northern pygmy-owl (Pacific)_norpyo1
+Glaucidium gnoma pinicola_northern pygmy-owl (Rocky Mts.)_norpyo2
+Glaucidium gnoma cobanense_northern pygmy-owl (Guatemalan)_norpyo4
+Glaucidium gnoma hoskinsii_northern pygmy-owl (Cape)_norpyo3
+Glaucidium costaricanum_costa rican pygmy-owl_crpowl
+Glaucidium nubicola_cloud-forest pygmy-owl_clopyo1
+Glaucidium jardinii_andean pygmy-owl_anpowl1
+Glaucidium bolivianum_yungas pygmy-owl_yupowl1
+Glaucidium parkeri_subtropical pygmy-owl_supowl1
+Glaucidium griseiceps_central american pygmy-owl_capowl1
+Glaucidium sanchezi_tamaulipas pygmy-owl_tapowl1
+Glaucidium palmarum_colima pygmy-owl_copowl1
+Glaucidium hardyi_caburé-da-amazônia_amapyo1
+Glaucidium mooreorum_caburé-de-pernambuco_perpyo1
+Glaucidium minutissimum_caburé-miudinho_leapyo1
+Glaucidium brasilianum_caburé_fepowl
+Glaucidium brasilianum [brasilianum Group]_caburé [grupo brasilianum]_ferpyo1
+Glaucidium brasilianum tucumanum_caburé (tucumanum)_ferpyo2
+Glaucidium nana_austral pygmy-owl_aupowl1
+Glaucidium brasilianum/nana_ferruginous/austral pygmy-owl_y01138
+Glaucidium peruanum_peruvian pygmy-owl_pepowl1
+Glaucidium siju_cuban pygmy-owl_cupowl1
+Glaucidium tephronotum_red-chested owlet_recowl1
+Glaucidium tephronotum tephronotum_red-chested owlet (Western)_recowl2
+Glaucidium tephronotum pycrafti_red-chested owlet (Pycraft's)_recowl3
+Glaucidium tephronotum medje_red-chested owlet (Eastern)_recowl4
+Glaucidium sjostedti_sjöstedt's owlet_sjoowl1
+Glaucidium cuculoides_asian barred owlet_asbowl1
+Glaucidium castanopterum_javan owlet_javowl1
+Glaucidium radiatum_jungle owlet_junowl1
+Glaucidium cuculoides/radiatum_asian barred/jungle owlet_y00859
+Glaucidium castanotum_chestnut-backed owlet_chbowl1
+Glaucidium capense_african barred owlet_afbowl1
+Glaucidium capense scheffleri_african barred owlet (Spot-fronted)_afbowl2
+Glaucidium capense capense/ngamiense_african barred owlet (Bar-fronted)_afrbao1
+Glaucidium capense etchecopari_african barred owlet (Etchecopar's)_cheowl2
+Glaucidium capense castaneum_african barred owlet (Chestnut)_cheowl3
+Glaucidium albertinum_albertine owlet_albowl1
+Glaucidium sp._Glaucidium sp._glauci1
+Taenioptynx brodiei_collared owlet_colowl1
+Taenioptynx sylvaticus_sunda owlet_colowl3
+Micrathene whitneyi_elf owl_elfowl
+Xenoglaux loweryi_long-whiskered owlet_lowowl1
+Athene brama_spotted owlet_spoowl1
+Athene noctua_mocho-galego_litowl1
+Athene noctua [noctua Group]_mocho-galego [grupo noctua]_litowl3
+Athene noctua spilogastra/somaliensis_mocho-galego (spilogastra/somaliensis)_litowl5
+Athene noctua lilith_mocho-galego (lilith)_litowl2
+Athene noctua bactriana_mocho-galego (bactriana)_litowl4
+Athene blewitti_forest owlet_forowl1
+Athene jacquinoti_west solomons owl_solboo1
+Athene granti_guadalcanal owl_solboo2
+Athene malaitae_malaita owl_solboo3
+Athene roseoaxillaris_makira owl_solboo4
+Athene superciliaris_white-browed owl_whbowl1
+Athene cunicularia_coruja-buraqueira_burowl
+Athene cunicularia hypugaea/rostrata_coruja-buraqueira (hypugaea/rostrata)_burowl2
+Athene cunicularia floridana_coruja-buraqueira (floridana)_burowl3
+Athene cunicularia [guadeloupensis Group]_coruja-buraqueira [grupo guadeloupensis]_burowl5
+Athene cunicularia [tolimae Group]_coruja-buraqueira [grupo tolimae]_burowl1
+Athene cunicularia nanodes/juninensis_coruja-buraqueira (nanodes/juninensis)_burowl6
+Athene cunicularia grallaria_coruja-buraqueira (grallaria)_burowl4
+Athene cunicularia [cunicularia Group]_coruja-buraqueira [grupo cunicularia]_burowl7
+Strix virgata_coruja-do-mato_motowl
+Strix virgata [virgata Group]_coruja-do-mato [grupo virgata]_motowl1
+Strix virgata superciliaris/macconnelli_coruja-do-mato (superciliaris/macconnelli)_motowl3
+Strix virgata borelliana_coruja-do-mato (borelliana)_motowl2
+Strix nigrolineata_black-and-white owl_bawowl1
+Strix huhula_coruja-preta_bkbowl1
+Strix huhula [undescribed cloud-forest form]_coruja-preta (San Isidro)_saiowl1
+Strix albitarsis_rufous-banded owl_rubowl3
+Strix sp. (former Ciccaba sp.)_Ciccaba sp._ciccab1
+Strix seloputo_spotted wood-owl_spwowl1
+Strix ocellata_mottled wood-owl_mowowl1
+Strix leptogrammica_brown wood-owl_brwowl1
+Strix leptogrammica [indranee Group]_brown wood-owl (Brown)_brnwoo2
+Strix leptogrammica niasensis_brown wood-owl (Nias)_brnwoo12
+Strix leptogrammica [leptogrammica Group]_brown wood-owl (Bornean)_brnwoo1
+Strix aluco_tawny owl_tawowl1
+Strix mauritanica_maghreb owl_tawowl3
+Strix nivicolum_himalayan owl_himowl1
+Strix hadorami_coruja-da-palestina_humowl1
+Strix butleri_omani owl_omaowl1
+Strix occidentalis_spotted owl_spoowl
+Strix occidentalis caurina_spotted owl (Northern)_spoowl2
+Strix occidentalis occidentalis_spotted owl (California)_spoowl3
+Strix occidentalis lucida_spotted owl (Mexican)_spoowl4
+Strix varia_barred owl_brdowl
+Strix occidentalis x varia_spotted x barred owl (hybrid)_x00439
+Strix occidentalis/varia_spotted/barred owl_y01139
+Strix sartorii_cinereous owl_barowl13
+Strix fulvescens_fulvous owl_fulowl1
+Strix hylophila_coruja-listrada_rubowl2
+Strix rufipes_rufous-legged owl_rulowl1
+Strix chacoensis_chaco owl_chaowl1
+Strix uralensis_coruja-dos-urales_uraowl1
+Strix uralensis [uralensis Group]_ural owl (Ural)_uraowl10
+Strix uralensis davidi_ural owl (Pere David's)_pedowl1
+Strix nebulosa_coruja-cinzenta_grgowl
+Strix nebulosa nebulosa_coruja-cinzenta (nebulosa)_grgowl1
+Strix nebulosa lapponica_coruja-cinzenta (lapponica)_grgowl2
+Strix woodfordii_mocho-da-floresta_afwowl1
+Strix sp._Strix sp._strix1
+Asio grammicus_jamaican owl_jamowl1
+Asio otus_bufo-pequeno_loeowl
+Asio otus wilsonianus/tuftsi_bufo-pequeno (wilsonianus/tuftsi)_loeowl1
+Asio otus otus/canariensis_bufo-pequeno (otus/canariensis)_loeowl2
+Asio abyssinicus_abyssinian owl_aleowl1
+Asio madagascariensis_madagascar owl_mleowl1
+Asio clamator_coruja-orelhuda_strowl1
+Asio stygius_mocho-diabo_styowl1
+Asio flammeus_mocho-dos-banhados_sheowl
+Asio flammeus flammeus_mocho-dos-banhados (flammeus)_sheowl2
+Asio flammeus ponapensis_mocho-dos-banhados (ponapensis)_sheowl7
+Asio flammeus sandwichensis_mocho-dos-banhados (sandwichensis)_sheowl4
+Asio flammeus domingensis/portoricensis_mocho-dos-banhados (domingensis/portoricensis)_sheowl3
+Asio flammeus galapagoensis_mocho-dos-banhados (galapagoensis)_sheowl5
+Asio flammeus [suinda Group]_mocho-dos-banhados [grupo suinda]_sheowl6
+Asio otus/flammeus_bufo-pequeno/coruja-do-nabal_y00673
+Asio capensis_coruja-moura_marowl2
+Asio solomonensis_fearful owl_feaowl1
+Asio sp._Asio sp._asio1
+Aegolius funereus_mocho-funéreo_borowl
+Aegolius funereus [funereus Group]_mocho-funéreo [grupo funereus]_borowl1
+Aegolius funereus richardsoni_mocho-funéreo (richardsoni)_borowl2
+Aegolius acadicus_northern saw-whet owl_nswowl
+Aegolius acadicus acadicus_northern saw-whet owl (acadicus)_nswowl1
+Aegolius acadicus brooksi_northern saw-whet owl (Haida Gwaii)_nswowl2
+Aegolius funereus/acadicus_boreal/northern saw-whet owl_y01198
+Aegolius gradyi_bermuda saw-whet owl_bswowl1
+Aegolius ridgwayi_unspotted saw-whet owl_uswowl1
+Glaucidium/Aegolius sp. (pygmy-owl/saw-whet owl sp.)_Glaucidium/Aegolius sp._y00395
+Aegolius harrisii_caburé-acanelado_bufowl1
+Ninox rufa_rufous owl_rufowl2
+Ninox strenua_powerful owl_powowl1
+Ninox connivens_barking owl_barowl1
+Ninox rudolfi_sumba boobook_sumboo1
+Ninox affinis_andaman boobook_andhao1
+Ninox boobook_australian boobook_souboo8
+Ninox boobook [boobook Group]_australian boobook (Boobook)_souboo1
+Ninox boobook lurida_australian boobook (Red)_souboo7
+Ninox rotiensis_rote boobook_souboo4
+Ninox fusca_timor boobook_souboo5
+Ninox plesseni_alor boobook_souboo6
+Ninox leucopsis_tasmanian boobook_souboo3
+Ninox boobook/leucopsis_australian/tasmanian boobook_souboo2
+Ninox novaeseelandiae_morepork_morepo2
+Ninox albifacies_laughing owl_lauowl1
+Ninox sumbaensis_least boobook_lishao1
+Ninox scutulata_brown boobook_brnhao1
+Ninox obscura_hume's boobook_brnhao3
+Ninox japonica_northern boobook_norboo1
+Ninox scutulata/japonica_brown/northern boobook_y00785
+Ninox randi_chocolate boobook_choboo1
+Ninox philippensis_luzon boobook_phihao1
+Ninox spilocephala_mindanao boobook_minboo1
+Ninox mindorensis_mindoro boobook_minboo2
+Ninox spilonotus_romblon boobook_romboo1
+Ninox rumseyi_cebu boobook_cebboo1
+Ninox leventisi_camiguin boobook_camboo1
+Ninox reyi_sulu boobook_sulboo1
+Ninox ochracea_ochre-bellied boobook_ocbhao1
+Ninox burhani_togian boobook_toghao1
+Ninox ios_cinnabar boobook_cinhao1
+Ninox [undescribed form]_white-spotted boobook (undescribed form)_whshao1
+Ninox hypogramma_halmahera boobook_molhao3
+Ninox forbesi_tanimbar boobook_molhao2
+Ninox squamipila_seram boobook_hanboo2
+Ninox hantu_buru boobook_hanboo1
+Ninox natalis_christmas island boobook_chihao1
+Ninox theomacha_papuan boobook_junhao1
+Ninox meeki_manus boobook_manhao1
+Ninox punctulata_speckled boobook_spehao1
+Ninox variegata_bismarck boobook_bishao1
+Ninox odiosa_new britain boobook_nebhao1
+Ninox sp._boobook sp._booboo1
+Uroglaux dimorpha_papuan owl_paphao1
+Strigiformes sp._coruja (strigiforme) sp._owl1
+Colius striatus_speckled mousebird_spemou2
+Colius leucocephalus_white-headed mousebird_whhmou1
+Colius castanotus_red-backed mousebird_rebmou1
+Colius colius_white-backed mousebird_whbmou1
+Urocolius macrourus_rabo-de-junco_blnmou1
+Urocolius indicus_red-faced mousebird_refmou1
+Coliidae sp._mousebird sp._mouseb1
+Leptosomus discolor_cuckoo-roller_cuckoo1
+Leptosomus discolor gracilis_cuckoo-roller (Grande Comore)_cuckoo5
+Leptosomus discolor intermedius_cuckoo-roller (Anjouan)_cuckoo6
+Leptosomus discolor discolor_cuckoo-roller (Malagasy)_cuckoo7
+Apaloderma narina_narina trogon_nartro1
+Apaloderma aequatoriale_bare-cheeked trogon_bactro1
+Apaloderma vittatum_bar-tailed trogon_battro1
+Apaloderma sp._african trogon sp._afrtro1
+Apalharpactes reinwardtii_javan trogon_javtro1
+Apalharpactes mackloti_sumatran trogon_sumtro1
+Harpactes oreskios_orange-breasted trogon_orbtro2
+Harpactes oreskios [dulitensis Group]_orange-breasted trogon (Spice)_orbtro5
+Harpactes oreskios oreskios_orange-breasted trogon (Orange-breasted)_orbtro4
+Harpactes fasciatus_malabar trogon_maltro1
+Harpactes kasumba_red-naped trogon_rentro1
+Harpactes diardii_diard's trogon_diatro1
+Harpactes ardens_philippine trogon_phitro1
+Harpactes whiteheadi_whitehead's trogon_whitro1
+Harpactes orrhophaeus_cinnamon-rumped trogon_cirtro1
+Harpactes duvaucelii_scarlet-rumped trogon_scrtro1
+Harpactes erythrocephalus_red-headed trogon_rehtro1
+Harpactes wardi_ward's trogon_wartro1
+Apalharpactes/Harpactes sp._asian trogon sp._asitro1
+Euptilotis neoxenus_eared quetzal_earque
+Pharomachrus pavoninus_quetzal-pavão_pavque1
+Pharomachrus auriceps_golden-headed quetzal_gohque1
+Pharomachrus mocinno_resplendent quetzal_resque1
+Pharomachrus mocinno mocinno_resplendent quetzal (Guatemalan)_resque2
+Pharomachrus mocinno costaricensis_resplendent quetzal (Costa Rican)_resque3
+Pharomachrus fulgidus_white-tipped quetzal_whtque1
+Pharomachrus antisianus_crested quetzal_creque1
+Pharomachrus auriceps x antisianus_golden-headed x crested quetzal (hybrid)_x01126
+Pharomachrus auriceps/antisianus_golden-headed/crested quetzal_y00787
+Priotelus temnurus_cuban trogon_cubtro1
+Priotelus roseigaster_hispaniolan trogon_histro1
+Trogon clathratus_lattice-tailed trogon_lattro1
+Trogon massena_slaty-tailed trogon_slttro1
+Trogon massena massena/hoffmanni_slaty-tailed trogon (Massena)_slttro2
+Trogon massena australis_slaty-tailed trogon (Chapman's)_slttro3
+Trogon comptus_blue-tailed trogon_buttro1
+Trogon mesurus_ecuadorian trogon_bkttro2
+Trogon melanurus_surucuá-de-cauda-preta_blttro1
+Trogon melanurus macroura_surucuá-de-cauda-preta (macroura)_bkttro3
+Trogon melanurus melanurus/eumorphus_surucuá-de-cauda-preta (melanurus/eumorphus)_bkttro1
+Trogon melanocephalus_black-headed trogon_blhtro1
+Trogon citreolus_citreoline trogon_cittro1
+Trogon chionurus_surucuá-de-cauda-branca_whttro1
+Trogon viridis_surucuá-de-barriga-amarela_gnbtro1
+Trogon bairdii_baird's trogon_baitro1
+Trogon caligatus_gartered trogon_gartro1
+Trogon violaceus_surucuá-violáceo_viotro2
+Trogon ramonianus_surucuá-pequeno_viotro3
+Trogon violaceus/ramonianus_surucuá-violáceo/surucuá-pequeno_viotro1
+Trogon curucui_surucuá-de-barriga-vermelha_blctro1
+Trogon surrucura_surucuá-variado_surtro1
+Trogon surrucura aurantius_surucuá-variado (aurantius)_surtro2
+Trogon surrucura surrucura_surucuá-variado (surrucura)_surtro3
+Trogon curucui x surrucura_surucuá-de-barriga-vermelha x surucuá-variado (híbrido)_x01156
+Trogon tenellus_northern black-throated trogon_bkttro7
+Trogon cupreicauda_choco black-throated trogon_bkttro5
+Trogon rufus_surucuá-dourado-da-amazônia/de-murici_bkttro6
+Trogon chrysochloros_surucuá-dourado_bkttro4
+Trogon chrysochloros muriciensis_atlantic black-throated trogon (Alagoas)_bkttro14
+Trogon chrysochloros chrysochloros_atlantic black-throated trogon (Southern)_bkttro15
+Trogon elegans_elegant trogon_eletro
+Trogon elegans [ambiguus Group]_elegant trogon (Coppery-tailed)_eletro1
+Trogon elegans elegans/lubricus_elegant trogon (Elegant)_eletro2
+Trogon mexicanus_mountain trogon_moutro1
+Trogon collaris_surucuá-de-coleira_coltro1
+Trogon collaris puella_surucuá-de-coleira (puella)_coltro2
+Trogon collaris aurantiiventris/underwoodi_surucuá-de-coleira (aurantiiventris/underwoodi)_orbtro1
+Trogon collaris [collaris Group]_surucuá-de-coleira [grupo collaris]_coltro3
+Trogon personatus_surucuá-mascarado_mastro1
+Trogon sp._Trogon sp._newtro1
+Upupa epops_poupa_hoopoe
+Upupa epops [epops Group]_poupa [grupo epops]_eurhoo1
+Upupa epops senegalensis/waibeli_poupa (senegalensis/waibeli)_eurhoo3
+Upupa epops africana_poupa (africana)_eurhoo2
+Upupa marginata_madagascar hoopoe_madhoo1
+Upupa antaios_st. helena hoopoe_sthhoo1
+Phoeniculus purpureus_zombeteiro-de-bico-vermelho_grewoo2
+Phoeniculus damarensis_violet woodhoopoe_viowoo1
+Phoeniculus damarensis damarensis_violet woodhoopoe (Violet)_viowoo2
+Phoeniculus damarensis granti_violet woodhoopoe (Grant's)_viowoo3
+Phoeniculus purpureus/damarensis_green/violet woodhoopoe_y00659
+Phoeniculus somaliensis_black-billed woodhoopoe_blbwoo2
+Phoeniculus bollei_white-headed woodhoopoe_whhwoo1
+Phoeniculus bollei bollei/jacksoni_white-headed woodhoopoe (bollei/jacksoni)_whhwoo2
+Phoeniculus bollei okuensis_white-headed woodhoopoe (Oku)_whhwoo3
+Phoeniculus sp._zombeteiro sp._woodho1
+Rhinopomastus castaneiceps_forest scimitarbill_forwoo1
+Rhinopomastus castaneiceps castaneiceps_forest scimitarbill (Western)_forwoo2
+Rhinopomastus castaneiceps brunneiceps_forest scimitarbill (Eastern)_forwoo3
+Rhinopomastus aterrimus_zombeteiro-preto_blsbil1
+Rhinopomastus cyanomelas_common scimitarbill_cosbil1
+Rhinopomastus minor_abyssinian scimitarbill_absbil1
+Phoeniculus/Rhinopomastus sp._woodhoopoe/scimitarbill sp._y00961
+Bucorvus abyssinicus_alma-de-beafada_noghor1
+Bucorvus leadbeateri_southern ground-hornbill_soghor1
+Lophoceros camurus_red-billed dwarf hornbill_rbdhor1
+Lophoceros alboterminatus_crowned hornbill_crohor1
+Lophoceros bradfieldi_bradfield's hornbill_brahor1
+Lophoceros semifasciatus_west african pied hornbill_afphor2
+Lophoceros fasciatus_congo pied hornbill_afphor3
+Lophoceros semifasciatus/fasciatus_west african/congo pied hornbill_afphor1
+Lophoceros hemprichii_hemprich's hornbill_hemhor1
+Lophoceros nasutus_bico-de-serra-cinzento_afghor1
+Lophoceros pallidirostris_pale-billed hornbill_pabhor1
+Lophoceros sp._Lophoceros sp._lophoc1
+Tockus flavirostris_eastern yellow-billed hornbill_eybhor1
+Tockus leucomelas_southern yellow-billed hornbill_sybhor1
+Tockus jacksoni_jackson's hornbill_jachor1
+Tockus deckeni_von der decken's hornbill_vddhor1
+Tockus monteiri_monteiro's hornbill_monhor1
+Tockus rufirostris_southern red-billed hornbill_srbhor1
+Tockus damarensis_damara red-billed hornbill_drbhor1
+Tockus rufirostris x damarensis_southern x damara red-billed hornbill (hybrid)_x00667
+Tockus rufirostris/damarensis_southern/damara red-billed hornbill_y01291
+Tockus ruahae_tanzanian red-billed hornbill_trbhor1
+Tockus kempi_bico-de-serra-vermelho_wrbhor2
+Tockus erythrorhynchus_northern red-billed hornbill_rebhor1
+Tockus sp._bico-de-serra (Tockus) sp._tockus1
+Berenicornis comatus_white-crowned hornbill_whchor2
+Horizocerus albocristatus_western long-tailed hornbill_whchor1
+Horizocerus cassini_eastern long-tailed hornbill_whchor4
+Horizocerus albocristatus/cassini_western/eastern long-tailed hornbill_whchor3
+Horizocerus hartlaubi_western dwarf hornbill_bkdhor1
+Horizocerus granti_eastern dwarf hornbill_bkdhor2
+Horizocerus hartlaubi/granti_western/eastern dwarf hornbill_bldhor1
+Ceratogymna elata_calau-grande_yechor1
+Ceratogymna atrata_black-casqued hornbill_blchor1
+Ceratogymna elata/atrata_yellow-casqued/black-casqued hornbill_y00865
+Bycanistes brevis_silvery-cheeked hornbill_sichor1
+Bycanistes subcylindricus_calau-de-faces-cinzentas_bawhor2
+Bycanistes cylindricus_brown-cheeked hornbill_bnchor1
+Bycanistes albotibialis_white-thighed hornbill_whthor1
+Bycanistes bucinator_trumpeter hornbill_truhor1
+Bycanistes fistulator_calau-assobiador_piphor1
+Bycanistes fistulator fistulator_calau-assobiador (fistulator)_piphor2
+Bycanistes fistulator sharpii/duboisi_calau-assobiador (sharpii/duboisi)_piphor3
+Rhinoplax vigil_helmeted hornbill_helhor1
+Buceros hydrocorax_rufous hornbill_rufhor1
+Buceros hydrocorax hydrocorax_rufous hornbill (Northern)_rufhor3
+Buceros hydrocorax semigaleatus_rufous hornbill (Visayan)_rufhor6
+Buceros hydrocorax mindanensis_rufous hornbill (Southern)_rufhor4
+Buceros rhinoceros_rhinoceros hornbill_rhihor1
+Buceros bicornis_great hornbill_grehor1
+Buceros rhinoceros/bicornis_rhinoceros/great hornbill_y00396
+Anorrhinus galeritus_bushy-crested hornbill_buchor1
+Anorrhinus austeni_brown hornbill_brnhor1
+Anorrhinus tickelli_rusty-cheeked hornbill_ruchor1
+Ocyceros birostris_indian gray hornbill_inghor2
+Ocyceros griseus_malabar gray hornbill_maghor2
+Ocyceros birostris/griseus_indian/malabar gray hornbill_y00397
+Ocyceros gingalensis_sri lanka gray hornbill_ceghor1
+Anthracoceros malayanus_black hornbill_blahor1
+Anthracoceros montani_sulu hornbill_sulhor2
+Anthracoceros coronatus_malabar pied-hornbill_maphor1
+Anthracoceros albirostris_oriental pied-hornbill_orphor1
+Anthracoceros coronatus/albirostris_malabar/oriental pied-hornbill_y01097
+Anthracoceros marchei_palawan hornbill_palhor1
+Aceros nipalensis_rufous-necked hornbill_runhor1
+Rhyticeros cassidix_knobbed hornbill_knohor1
+Rhyticeros everetti_sumba hornbill_sumhor1
+Rhyticeros undulatus_wreathed hornbill_wrehor1
+Rhyticeros subruficollis_plain-pouched hornbill_plphor1
+Rhyticeros undulatus/subruficollis_wreathed/plain-pouched hornbill_y01032
+Rhyticeros narcondami_narcondam hornbill_narhor1
+Rhyticeros plicatus_blyth's hornbill_blyhor1
+Rhabdotorrhinus exarhatus_sulawesi hornbill_sulhor1
+Rhabdotorrhinus exarhatus exarhatus_sulawesi hornbill (Dwarf)_sulhor3
+Rhabdotorrhinus exarhatus sanfordi_sulawesi hornbill (Sanford's)_sulhor4
+Rhabdotorrhinus corrugatus_wrinkled hornbill_wrihor1
+Rhabdotorrhinus waldeni_writhe-billed hornbill_wrbhor1
+Rhabdotorrhinus leucocephalus_writhed hornbill_wrihor2
+Penelopides panini_visayan hornbill_tarhor1
+Penelopides manillae_luzon hornbill_luzhor1
+Penelopides mindorensis_mindoro hornbill_minhor2
+Penelopides samarensis_samar hornbill_samhor1
+Penelopides affinis_mindanao hornbill_minhor1
+Bucerotidae sp._hornbill sp._hornbi1
+Nyctyornis amictus_red-bearded bee-eater_rbbeat1
+Nyctyornis athertoni_blue-bearded bee-eater_bbbeat1
+Meropogon forsteni_purple-bearded bee-eater_pbbeat1
+Merops gularis_black bee-eater_blbeat1
+Merops mentalis_blue-moustached bee-eater_bumbee1
+Merops muelleri_blue-headed bee-eater_bhbeat2
+Merops bulocki_abelharuco-de-garganta-vermelha_rtbeat1
+Merops bullockoides_white-fronted bee-eater_wfbeat1
+Merops pusillus_abelharuco-dourado_libeat1
+Merops variegatus_blue-breasted bee-eater_bbbeat2
+Merops lafresnayii_ethiopian bee-eater_bubbee2
+Merops oreobates_cinnamon-chested bee-eater_ccbeat1
+Merops hirundineus_abelharuco-andorinha_stbeat1
+Merops breweri_black-headed bee-eater_bhbeat1
+Merops revoilii_somali bee-eater_sobeat1
+Merops albicollis_abelharuco-de-garganta-branca_wtbeat1
+Merops viridissimus_african green bee-eater_grnbee1
+Merops cyanophrys_arabian green bee-eater_grnbee2
+Merops viridissimus/cyanophrys_african/arabian green bee-eater_y01244
+Merops orientalis_asian green bee-eater_grnbee3
+Merops cyanophrys/orientalis_arabian/asian green bee-eater_y01188
+Merops boehmi_böhm's bee-eater_bobeat1
+Merops viridis_blue-throated bee-eater_btbeat2
+Merops americanus_rufous-crowned bee-eater_rucbee1
+Merops persicus_abelharuco-de-faces-azuis_bcbeat1
+Merops superciliosus_olive bee-eater_mabeat1
+Merops philippinus_abelharuco-de-cauda-azul_btbeat1
+Merops persicus/philippinus_abelharuco-de-faces-azuis/abelharuco-de-cauda-azul_y00734
+Merops ornatus_abelharuco-arco-íris_rabeat1
+Merops apiaster_abelharuco_eubeat1
+Merops leschenaulti_chestnut-headed bee-eater_chbeat1
+Merops malimbicus_rosy bee-eater_robeat1
+Merops nubicus_abelharuco-rosado_ncbeat1
+Merops nubicoides_southern carmine bee-eater_scbeat1
+Merops sp._abelharuco (Merops) sp._beeeat1
+Todus multicolor_cuban tody_cubtod1
+Todus subulatus_broad-billed tody_brbtod1
+Todus angustirostris_narrow-billed tody_nabtod1
+Todus subulatus/angustirostris_broad-billed/narrow-billed tody_y00866
+Todus todus_jamaican tody_jamtod1
+Todus mexicanus_puerto rican tody_purtod1
+Hylomanes momotula_tody motmot_todmot1
+Aspatha gularis_blue-throated motmot_bltmot1
+Momotus mexicanus_russet-crowned motmot_rucmot1
+Momotus coeruliceps_blue-capped motmot_bucmot1
+Momotus lessonii_lesson's motmot_bucmot2
+Momotus coeruliceps x lessonii_blue-capped x lesson's motmot (hybrid)_x00887
+Momotus coeruliceps/lessonii_blue-capped/lesson's motmot_y01033
+Momotus subrufescens_whooping motmot_bucmot3
+Momotus subrufescens [subrufescens Group]_whooping motmot (Whooping)_whomot1
+Momotus subrufescens argenticinctus_whooping motmot (argenticinctus)_whomot2
+Momotus bahamensis_trinidad motmot_trimot1
+Momotus momota_udu-de-coroa-azul_bucmot4
+Momotus aequatorialis_andean motmot_higmot1
+Baryphthengus martii_juruva-ruiva_rufmot1
+Momotus momota x Baryphthengus martii_udu-de-coroa-azul x juruva-ruiva (híbrido)_x00402
+Baryphthengus ruficapillus_juruva_rucmot2
+Momotus momota x Baryphthengus ruficapillus_udu-de-coroa-azul x juruva (híbrido)_x00769
+Electron carinatum_keel-billed motmot_kebmot1
+Electron platyrhynchum_udu-de-bico-largo_brbmot1
+Electron platyrhynchum [platyrhynchum Group]_udu-de-bico-largo [grupo platyrhynchum]_brbmot2
+Electron platyrhynchum [pyrrholaemum Group]_udu-de-bico-largo [grupo pyrrholaemum]_brbmot3
+Electron carinatum/platyrhynchum_keel-billed/broad-billed motmot_y00733
+Eumomota superciliosa_turquoise-browed motmot_tubmot1
+Momotidae sp._Momotidae sp._motmot1
+Alcedo hercules_blyth's kingfisher_blykin1
+Alcedo atthis_guarda-rios_comkin1
+Alcedo atthis [atthis Group]_guarda-rios [grupo atthis]_comkin2
+Alcedo atthis [hispidoides Group]_guarda-rios [grupo hispidoides]_comkin3
+Alcedo semitorquata_half-collared kingfisher_hackin1
+Alcedo quadribrachys_pica-peixe-azul_shbkin1
+Alcedo meninting_blue-eared kingfisher_blekin1
+Alcedo atthis/meninting_common/blue-eared kingfisher_y00398
+Alcedo peninsulae_malaysian blue-banded kingfisher_bubkin1
+Alcedo euryzona_javan blue-banded kingfisher_bubkin2
+Alcedo coerulescens_small blue kingfisher_smbkin1
+Ceyx azureus_azure kingfisher_azukin1
+Ceyx websteri_bismarck kingfisher_biskin1
+Ceyx cyanopectus_indigo-banded kingfisher_inbkin2
+Ceyx cyanopectus cyanopectus_indigo-banded kingfisher (Northern)_inbkin1
+Ceyx cyanopectus nigrirostris_indigo-banded kingfisher (Southern)_inbkin3
+Ceyx flumenicola_northern silvery-kingfisher_norsik1
+Ceyx argentatus_southern silvery-kingfisher_silkin1
+Ceyx pusillus_little kingfisher_litkin1
+Ceyx erithaca_black-backed dwarf-kingfisher_bkbkin1
+Ceyx rufidorsa_rufous-backed dwarf-kingfisher_rubkin1
+Ceyx erithaca/rufidorsa_black-backed/rufous-backed dwarf-kingfisher_y00867
+Ceyx melanurus_philippine dwarf-kingfisher_phikin1
+Ceyx melanurus melanurus_philippine dwarf-kingfisher (Luzon)_phidwk1
+Ceyx melanurus samarensis_philippine dwarf-kingfisher (Samar)_phidwk2
+Ceyx melanurus mindanensis_philippine dwarf-kingfisher (Mindanao)_phidwk3
+Ceyx sangirensis_sangihe dwarf-kingfisher_suldwk1
+Ceyx fallax_sulawesi dwarf-kingfisher_sulkin1
+Ceyx margarethae_dimorphic dwarf-kingfisher_vardwk1
+Ceyx wallacii_sula dwarf-kingfisher_vardwk2
+Ceyx lepidus_moluccan dwarf-kingfisher_varkin1
+Ceyx lepidus uropygialis_moluccan dwarf-kingfisher (North Moluccan)_vardwk3
+Ceyx lepidus lepidus_moluccan dwarf-kingfisher (Seram)_vardwk4
+Ceyx cajeli_buru dwarf-kingfisher_vardwk5
+Ceyx solitarius_papuan dwarf-kingfisher_vardwk6
+Ceyx dispar_manus dwarf-kingfisher_vardwk7
+Ceyx mulcatus_new ireland dwarf-kingfisher_vardwk8
+Ceyx sacerdotis_new britain dwarf-kingfisher_vardwk9
+Ceyx collectoris_new georgia dwarf-kingfisher_vardwk11
+Ceyx meeki_north solomons dwarf-kingfisher_nosdwk1
+Ceyx meeki pallidus_north solomons dwarf-kingfisher (Bougainville)_vardwk10
+Ceyx meeki meeki_north solomons dwarf-kingfisher (North Solomons)_vardwk12
+Ceyx nigromaxilla_guadalcanal dwarf-kingfisher_guadwk1
+Ceyx nigromaxilla malaitae_guadalcanal dwarf-kingfisher (Malaita)_vardwk13
+Ceyx nigromaxilla nigromaxilla_guadalcanal dwarf-kingfisher (Guadalcanal)_vardwk14
+Ceyx gentianus_makira dwarf-kingfisher_vardwk15
+Corythornis cristatus_pica-peixinho-de-poupa_malkin1
+Corythornis cristatus [cristatus Group]_pica-peixinho-de-poupa [grupo cristatus]_malkin3
+Corythornis cristatus thomensis_pica-peixinho-de-poupa (thomensis)_malkin5
+Corythornis cristatus nais_pica-peixinho-de-poupa (nais)_malkin4
+Corythornis vintsioides_malagasy kingfisher_malkin2
+Corythornis leucogaster_pica-peixinho-de-barriga-branca_whbkin1
+Corythornis madagascariensis_madagascar pygmy kingfisher_mapkin1
+Ispidina picta_pica-peixinho-pigmeu_afpkin1
+Ispidina picta picta/ferrugina_african pygmy kingfisher (Northern)_afpkin2
+Ispidina picta natalensis_african pygmy kingfisher (Southern)_afrpyk3
+Ispidina lecontei_african dwarf kingfisher_dwakin1
+Lacedo pulchella_banded kingfisher_bankin1
+Lacedo pulchella [pulchella Group]_banded kingfisher (Banded)_bankin2
+Lacedo pulchella melanops_banded kingfisher (Black-faced)_bankin3
+Dacelo novaeguineae_laughing kookaburra_laukoo1
+Dacelo leachii_blue-winged kookaburra_blwkoo1
+Dacelo tyro_spangled kookaburra_spakoo1
+Dacelo gaudichaud_rufous-bellied kookaburra_rubkoo1
+Dacelo rex_shovel-billed kookaburra_shbkoo1
+Cittura sanghirensis_sangihe lilac kingfisher_lickin1
+Cittura cyanotis_sulawesi lilac kingfisher_lickin2
+Pelargopsis amauroptera_brown-winged kingfisher_bnwkin1
+Pelargopsis capensis_stork-billed kingfisher_stbkin1
+Pelargopsis melanorhyncha_great-billed kingfisher_blbkin1
+Halcyon coromanda_ruddy kingfisher_rudkin1
+Halcyon badia_chocolate-backed kingfisher_chbkin2
+Halcyon smyrnensis_guarda-rios-de-papo-branco_whtkin2
+Halcyon gularis_brown-breasted kingfisher_bnbkin1
+Halcyon leucocephala_passarinha_gyhkin1
+Halcyon pileata_black-capped kingfisher_blckin1
+Halcyon cyanoventris_javan kingfisher_javkin1
+Halcyon senegalensis_guarda-rios-do-senegal_wookin1
+Halcyon senegaloides_mangrove kingfisher_mankin2
+Halcyon malimbica_pica-peixe-de-peito-azul_blbkin4
+Halcyon albiventris_brown-hooded kingfisher_brhkin1
+Halcyon chelicuti_pica-peixe-riscado_strkin1
+Todiramphus nigrocyaneus_blue-black kingfisher_blbkin3
+Todiramphus winchelli_rufous-lored kingfisher_rulkin1
+Todiramphus diops_blue-and-white kingfisher_bawkin1
+Todiramphus lazuli_lazuli kingfisher_lazkin1
+Todiramphus pyrrhopygius_red-backed kingfisher_rebkin2
+Todiramphus macleayii_forest kingfisher_forkin1
+Todiramphus albonotatus_new britain kingfisher_nebkin1
+Todiramphus leucopygius_ultramarine kingfisher_ultkin1
+Todiramphus farquhari_vanuatu kingfisher_chbkin1
+Todiramphus godeffroyi_marquesan kingfisher_markin2
+Todiramphus ruficollaris_mewing kingfisher_mankin1
+Todiramphus veneratus_society kingfisher_tahkin1
+Todiramphus veneratus youngi_society kingfisher (Moorea)_sockin1
+Todiramphus veneratus veneratus_society kingfisher (Tahiti)_sockin2
+Todiramphus gambieri_tuamotu kingfisher_tuakin2
+Todiramphus gambieri gertrudae_tuamotu kingfisher (Niau)_niakin1
+Todiramphus gambieri gambieri_tuamotu kingfisher (Mangareva)_mankin3
+Todiramphus tutus_chattering kingfisher_chakin2
+Todiramphus sacer_pacific kingfisher_packin1
+Todiramphus sacer [juliae Group]_pacific kingfisher (Vanuatu)_colkin5
+Todiramphus sacer [sacer Group]_pacific kingfisher (South Pacific)_colkin7
+Todiramphus sacer [solomonis Group]_pacific kingfisher (Solomons)_colkin8
+Todiramphus sacer [vitiensis Group]_pacific kingfisher (Fiji)_sackin6
+Todiramphus sacer marinus_pacific kingfisher (Lau)_packin2
+Todiramphus pelewensis_palau kingfisher_mickin4
+Todiramphus cinnamominus_guam kingfisher_mickin1
+Todiramphus reichenbachii_pohnpei kingfisher_mickin5
+Todiramphus recurvirostris_flat-billed kingfisher_flbkin1
+Todiramphus colonus_colonist kingfisher_colkin17
+Todiramphus sordidus_torresian kingfisher_colkin9
+Todiramphus sanctus_sacred kingfisher_sackin1
+Todiramphus sanctus sanctus_sacred kingfisher (Australasian)_sackin2
+Todiramphus sanctus canacorum_sacred kingfisher (New Caledonian)_sackin4
+Todiramphus sanctus macmillani_sacred kingfisher (Loyalty Is.)_sackin5
+Todiramphus sanctus vagans_sacred kingfisher (New Zealand)_sackin3
+Todiramphus chloris_guarda-rios-de-colar_colkin1
+Todiramphus chloris abyssinicus_guarda-rios-de-colar (abyssinicus)_colkin10
+Todiramphus chloris kalbaensis_guarda-rios-de-colar (kalbaensis)_colkin12
+Todiramphus chloris [humii Group]_guarda-rios-de-colar [grupo humii]_colkin4
+Todiramphus chloris occipitalis_guarda-rios-de-colar (occipitalis)_colkin14
+Todiramphus chloris [chloris Group]_guarda-rios-de-colar [grupo chloris]_colkin3
+Todiramphus saurophagus_beach kingfisher_beakin2
+Todiramphus saurophagus saurophagus_beach kingfisher (Beach)_beakin3
+Todiramphus saurophagus admiralitatis_beach kingfisher (Admiralty Is.)_beakin1
+Todiramphus albicilla_mariana kingfisher_colkin2
+Todiramphus tristrami_melanesian kingfisher_melkin1
+Todiramphus tristrami matthiae_melanesian kingfisher (St. Matthias Is.)_colkin13
+Todiramphus tristrami stresemanni_melanesian kingfisher (Dampier Straits)_colkin15
+Todiramphus tristrami [nusae Group]_melanesian kingfisher (New Ireland)_colkin6
+Todiramphus tristrami tristrami_melanesian kingfisher (New Britain)_colkin16
+Todiramphus tristrami alberti_melanesian kingfisher (Bougainville-Guadalcanal)_colkin11
+Todiramphus funebris_sombre kingfisher_somkin1
+Todiramphus enigma_talaud kingfisher_talkin1
+Todiramphus australasia_guarda-rios-canela_cibkin1
+Todiramphus sp._Todiramphus sp._todira1
+Caridonax fulgidus_white-rumped kingfisher_whrkin1
+Melidora macrorrhina_hook-billed kingfisher_hobkin1
+Actenoides bougainvillei_moustached kingfisher_moukin2
+Actenoides bougainvillei bougainvillei_moustached kingfisher (Bougainville)_moukin3
+Actenoides bougainvillei excelsus_moustached kingfisher (Guadalcanal)_moukin4
+Actenoides concretus_rufous-collared kingfisher_ruckin1
+Actenoides lindsayi_spotted kingfisher_spokin1
+Actenoides hombroni_blue-capped kingfisher_blckin2
+Actenoides monachus_green-backed kingfisher_grbkin1
+Actenoides monachus monachus_green-backed kingfisher (Blue-headed)_gnbkin1
+Actenoides monachus capucinus_green-backed kingfisher (Black-headed)_gnbkin2
+Actenoides princeps_scaly-breasted kingfisher_scakin1
+Actenoides princeps princeps/erythrorhamphus_scaly-breasted kingfisher (Scaly-breasted)_scbkin1
+Actenoides princeps regalis_scaly-breasted kingfisher (Plain-backed)_scbkin2
+Syma torotoro_yellow-billed kingfisher_yebkin1
+Syma megarhyncha_mountain kingfisher_moukin1
+Syma torotoro/megarhyncha_yellow-billed/mountain kingfisher_y00868
+Tanysiptera hydrocharis_little paradise-kingfisher_lipkin1
+Tanysiptera galatea_common paradise-kingfisher_copkin1
+Tanysiptera galatea [galatea Group]_common paradise-kingfisher (Common)_compak16
+Tanysiptera galatea rosseliana_common paradise-kingfisher (Rossel)_compak15
+Tanysiptera ellioti_kofiau paradise-kingfisher_kopkin1
+Tanysiptera riedelii_biak paradise-kingfisher_bipkin1
+Tanysiptera carolinae_numfor paradise-kingfisher_nupkin1
+Tanysiptera nympha_red-breasted paradise-kingfisher_rbpkin1
+Tanysiptera danae_brown-headed paradise-kingfisher_bhpkin1
+Tanysiptera sylvia_buff-breasted paradise-kingfisher_bubpak1
+Tanysiptera nigriceps_black-capped paradise-kingfisher_bubpak2
+Megaceryle maxima_pica-peixe-gigante_giakin3
+Megaceryle lugubris_crested kingfisher_crekin1
+Megaceryle torquata_martim-pescador-grande_rinkin1
+Megaceryle torquata torquata/stictipennis_martim-pescador-grande (torquata/stictipennis)_rinkin3
+Megaceryle torquata stellata_martim-pescador-grande (stellata)_rinkin4
+Megaceryle alcyon_guarda-rios-cintado_belkin1
+Ceryle rudis_guarda-rios-malhado_piekin1
+Chloroceryle amazona_martim-pescador-verde_amakin1
+Chloroceryle aenea_martim-pescador-miúdo_ampkin1
+Chloroceryle americana_martim-pescador-pequeno_grnkin
+Chloroceryle inda_martim-pescador-da-mata_garkin1
+Chloroceryle sp._Chloroceryle sp._chloro3
+Alcedinidae sp._martim-pescador sp._kingfi1
+Coracias garrulus_rolieiro_eurrol1
+Coracias abyssinicus_rolieiro-da-abissínia_abyrol2
+Coracias caudatus_lilac-breasted roller_librol2
+Coracias caudatus lorti_lilac-breasted roller (Blue-breasted)_librol1
+Coracias caudatus caudatus_lilac-breasted roller (Lilac-breasted)_librol3
+Coracias spatulatus_racket-tailed roller_ratrol2
+Coracias naevius_rolieiro-de-nuca-branca_rucrol2
+Coracias benghalensis_indian roller_indrol2
+Coracias garrulus/benghalensis_european/indian roller_y01079
+Coracias affinis_indochinese roller_indrol3
+Coracias benghalensis x affinis_indian x indochinese roller (hybrid)_indrol4
+Coracias benghalensis/affinis_indian/indochinese roller_indrol1
+Coracias temminckii_purple-winged roller_puwrol1
+Coracias cyanogaster_rolieiro-de-barriga-azul_blbrol1
+Coracias sp._rolieiro (Coracias) sp._roller1
+Eurystomus glaucurus_peito-lilás_brbrol1
+Eurystomus glaucurus [afer Group]_peito-lilás [grupo afer]_brbrol2
+Eurystomus glaucurus glaucurus_peito-lilás (glaucurus)_brbrol3
+Eurystomus gularis_blue-throated roller_bltrol1
+Eurystomus orientalis_rolieiro-oriental_dollar1
+Eurystomus azureus_azure roller_purrol1
+Geobiastes squamiger_scaly ground-roller_scagrr1
+Brachypteracias leptosomus_short-legged ground-roller_slgrol1
+Uratelornis chimaera_long-tailed ground-roller_ltgrol1
+Atelornis pittoides_pitta-like ground-roller_plgrol1
+Atelornis crossleyi_rufous-headed ground-roller_rhgrol1
+Notharchus hyperrhynchus_macuru-de-testa-branca_whnpuf2
+Notharchus macrorhynchos_macuru-de-pescoço-branco_guipuf1
+Notharchus swainsoni_macuru-de-barriga-castanha_bubpuf1
+Notharchus pectoralis_black-breasted puffbird_blbpuf1
+Notharchus ordii_macuru-de-peito-marrom_brbpuf1
+Notharchus tectus_macuru-pintado_piepuf1
+Notharchus tectus subtectus_macuru-pintado (subtectus)_piepuf2
+Notharchus tectus tectus/picatus_macuru-pintado (tectus/picatus)_piepuf3
+Bucco macrodactylus_rapazinho-de-boné-vermelho_chcpuf1
+Bucco tamatia_rapazinho-carijó_spopuf1
+Bucco noanamae_sooty-capped puffbird_socpuf1
+Bucco capensis_rapazinho-de-colar_colpuf1
+Nystalus radiatus_barred puffbird_barpuf1
+Nystalus obamai_rapazinho-estriado-do-oeste_wespuf1
+Nystalus striolatus_rapazinho-estriado-de-rondônia/do-leste_strpuf1
+Nystalus striolatus striolatus_rapazinho-estriado-de-rondônia_strpuf2
+Nystalus striolatus torridus_rapazinho-estriado-do-leste_strpuf3
+Nystalus chacuru_joão-bobo_whepuf1
+Nystalus maculatus_rapazinho-dos-velhos/do-chaco_spbpuf1
+Nystalus maculatus maculatus_rapazinho-dos-velhos_spbpuf2
+Nystalus maculatus striatipectus_rapazinho-do-chaco_spbpuf3
+Hypnelus ruficollis_russet-throated puffbird_rutpuf1
+Hypnelus bicinctus_two-banded puffbird_rutpuf3
+Hypnelus ruficollis/bicinctus_russet-throated/two-banded puffbird_y01173
+Malacoptila fusca_barbudo-pardo_whcpuf1
+Malacoptila semicincta_barbudo-de-coleira_sempuf1
+Malacoptila striata_barbudo-rajado/rajado-pequeno_crcpuf1
+Malacoptila striata minor_barbudo-rajado-pequeno_crcpuf2
+Malacoptila striata striata_barbudo-rajado_crcpuf3
+Malacoptila rufa_barbudo-de-pescoço-ferrugem_runpuf1
+Malacoptila panamensis_white-whiskered puffbird_whwpuf1
+Malacoptila fulvogularis_black-streaked puffbird_blspuf1
+Malacoptila mystacalis_moustached puffbird_moupuf1
+Micromonacha lanceolata_macuru-papa-mosca_lanmon1
+Nonnula rubecula_macuru_rubnun1
+Nonnula sclateri_freirinha-amarelada_fucnun1
+Nonnula brunnea_brown nunlet_bronun1
+Nonnula frontalis_gray-cheeked nunlet_gycnun1
+Nonnula ruficapilla_freirinha-de-coroa-castanha_rucnun1
+Nonnula amaurocephala_freirinha-de-cabeça-castanha_chhnun1
+Nonnula sp._Nonnula sp._nunlet1
+Hapaloptila castanea_white-faced nunbird_whfnun2
+Monasa atra_chora-chuva-de-asa-branca_blanun1
+Monasa nigrifrons_chora-chuva-preto_blfnun1
+Monasa morphoeus_chora-chuva-de-cara-branca_whfnun1
+Monasa morphoeus grandior/fidelis_chora-chuva-de-cara-branca (grandior/fidelis)_whfnun3
+Monasa morphoeus pallescens/sclateri_chora-chuva-de-cara-branca (pallescens/sclateri)_whfnun4
+Monasa morphoeus [morphoeus Group]_chora-chuva-de-cara-branca [grupo morphoeus]_whfnun5
+Monasa flavirostris_chora-chuva-de-bico-amarelo_yebnun1
+Monasa sp._Monasa sp._monasa1
+Chelidoptera tenebrosa_urubuzinho_swwpuf1
+Bucconidae sp._Bucconidae sp._buccon1
+Galbalcyrhynchus leucotis_ariramba-vermelha_whejac1
+Galbalcyrhynchus purusianus_ariramba-castanha_purjac2
+Brachygalba albogularis_agulha-de-garganta-branca_whtjac1
+Brachygalba lugubris_ariramba-preta_brojac2
+Brachygalba goeringi_pale-headed jacamar_pahjac1
+Brachygalba salmoni_dusky-backed jacamar_dubjac1
+Jacamaralcyon tridactyla_cuitelão_thtjac1
+Galbula albirostris_ariramba-de-bico-amarelo_yebjac1
+Galbula albirostris albirostris_ariramba-de-bico-amarelo (albirostris)_yebjac2
+Galbula albirostris chalcocephala_ariramba-de-bico-amarelo (chalcocephala)_yebjac3
+Galbula cyanicollis_ariramba-da-mata_bucjac1
+Galbula ruficauda_ariramba-de-cauda-ruiva_rutjac1
+Galbula ruficauda melanogenia_ariramba-de-cauda-ruiva (melanogenia)_rutjac2
+Galbula ruficauda [ruficauda Group]_ariramba-de-cauda-ruiva [grupo ruficauda]_rutjac3
+Galbula ruficauda rufoviridis/heterogyna_ariramba-de-cauda-ruiva (rufoviridis/heterogyna)_rutjac4
+Galbula galbula_ariramba-de-cauda-verde_grtjac1
+Galbula tombacea_ariramba-de-barba-branca_whcjac1
+Galbula cyanescens_ariramba-da-capoeira_blfjac1
+Galbula pastazae_coppery-chested jacamar_cocjac2
+Galbula chalcothorax_ariramba-violácea_purjac1
+Galbula leucogastra_ariramba-bronzeada_brojac1
+Galbula dea_ariramba-do-paraíso_parjac1
+Galbula sp._Galbula sp._galbul1
+Jacamerops aureus_jacamaraçu_grejac2
+Galbulidae sp._Galbulidae sp._jacama1
+Trachylaemus goffinii_western yellow-billed barbet_yebbar1
+Trachylaemus goffinii goffinii_western yellow-billed barbet (Western)_yebbar3
+Trachylaemus goffinii togoensis_western yellow-billed barbet (Togo)_yebbar4
+Trachylaemus purpuratus_eastern yellow-billed barbet_yebbar5
+Trachyphonus vaillantii_crested barbet_crebar1
+Trachyphonus erythrocephalus_red-and-yellow barbet_raybar1
+Trachyphonus margaritatus_yellow-breasted barbet_yebbar2
+Trachyphonus darnaudii_d'arnaud's barbet_darbar1
+Trachyphonus darnaudii darnaudii/boehmi_d'arnaud's barbet (D'Arnaud's)_darbar2
+Trachyphonus darnaudii usambiro_d'arnaud's barbet (Usambiro)_darbar3
+Trachyphonus darnaudii emini_d'arnaud's barbet (Black-capped)_darbar4
+Cryptolybia olivacea_green barbet_grebar2
+Cryptolybia olivacea olivacea_green barbet (Green)_grnbar2
+Cryptolybia olivacea howelli_green barbet (Howell's)_grnbar1
+Cryptolybia olivacea woodwardi_green barbet (Woodward's)_grnbar4
+Cryptolybia olivacea rungweensis_green barbet (Misuku Hills)_grnbar5
+Cryptolybia olivacea belcheri_green barbet (Mt. Thyolo)_grnbar6
+Gymnobucco bonapartei_gray-throated barbet_gytbar1
+Gymnobucco bonapartei bonapartei_gray-throated barbet (Gray-throated)_gytbar2
+Gymnobucco bonapartei cinereiceps_gray-throated barbet (Gray-headed)_gytbar3
+Gymnobucco sladeni_sladen's barbet_slabar1
+Gymnobucco peli_bristle-nosed barbet_brnbar1
+Gymnobucco calvus_naked-faced barbet_nafbar1
+Gymnobucco calvus calvus/congicus_naked-faced barbet (Naked-faced)_nafbar2
+Gymnobucco calvus vernayi_naked-faced barbet (Pale-throated)_nafbar3
+Stactolaema leucotis_white-eared barbet_whebar1
+Stactolaema leucotis leucogrammica_white-eared barbet (White-lined)_whebar2
+Stactolaema leucotis leucotis/kilimensis_white-eared barbet (White-eared)_whebar3
+Stactolaema whytii_whyte's barbet_whybar1
+Stactolaema anchietae_anchieta's barbet_ancbar1
+Pogoniulus scolopaceus_speckled tinkerbird_spetin1
+Pogoniulus simplex_green tinkerbird_gretin2
+Pogoniulus leucomystax_moustached tinkerbird_moutin1
+Pogoniulus coryphaea_western tinkerbird_westin1
+Pogoniulus coryphaea coryphaea_western tinkerbird (Western)_westin2
+Pogoniulus coryphaea hildamariae_western tinkerbird (Eastern)_westin3
+Pogoniulus coryphaea angolensis_western tinkerbird (Angola)_westin4
+Pogoniulus atroflavus_red-rumped tinkerbird_rertin1
+Pogoniulus subsulphureus_yellow-throated tinkerbird_yettin1
+Pogoniulus bilineatus_barbadinho-de-rabadilha-limão_yertin1
+Pogoniulus bilineatus [bilineatus Group]_barbadinho-de-rabadilha-limão [grupo bilineatus]_yertin2
+Pogoniulus bilineatus makawai_barbadinho-de-rabadilha-limão (makawai)_whctin1
+Pogoniulus uropygialis_northern red-fronted tinkerbird_reftin1
+Pogoniulus pusillus_southern red-fronted tinkerbird_reftin4
+Pogoniulus chrysoconus_barbadinho-de-fronte-amarela_yeftin1
+Pogoniulus sp._barbadinho (Pogoniulus) sp._tinker1
+Buccanodon duchaillui_yellow-spotted barbet_yesbar1
+Tricholaema hirsuta_hairy-breasted barbet_habbar1
+Tricholaema hirsuta hirsuta_hairy-breasted barbet (Hairy-breasted)_habbar2
+Tricholaema hirsuta [flavipunctata Group]_hairy-breasted barbet (Streaky-throated)_habbar3
+Tricholaema diademata_red-fronted barbet_refbar2
+Tricholaema frontata_miombo barbet_miobar1
+Tricholaema leucomelas_pied barbet_piebar1
+Tricholaema frontata x leucomelas_miombo x pied barbet (hybrid)_x01009
+Tricholaema lacrymosa_spot-flanked barbet_spfbar1
+Tricholaema melanocephala_black-throated barbet_bltbar1
+Lybius undatus_banded barbet_banbar1
+Lybius vieilloti_barbadinho-de-testa-vermelha_viebar1
+Lybius leucocephalus_white-headed barbet_whhbar1
+Lybius leucocephalus [leucocephalus Group]_white-headed barbet (White-headed)_whhbar2
+Lybius leucocephalus senex_white-headed barbet (Brown-and-white)_whhbar3
+Lybius leucocephalus leucogaster_white-headed barbet (White-bellied)_whhbar4
+Lybius chaplini_chaplin's barbet_chabar1
+Lybius rubrifacies_red-faced barbet_refbar1
+Lybius guifsobalito_black-billed barbet_blbbar3
+Lybius torquatus_black-collared barbet_blcbar1
+Pogonornis melanopterus_brown-breasted barbet_brbbar1
+Pogonornis minor_black-backed barbet_blbbar1
+Pogonornis minor minor_black-backed barbet (Brown-backed)_bkbbar1
+Pogonornis minor macclounii_black-backed barbet (Black-backed)_bkbbar2
+Pogonornis bidentatus_barbaças-bidentado_dotbar1
+Pogonornis dubius_barbaças_beabar1
+Pogonornis rolleti_black-breasted barbet_blbbar4
+Lybiidae sp._barbaças (Lybiidae) sp._afrbar1
+Caloramphus hayii_sooty barbet_soobar2
+Caloramphus fuliginosus_brown barbet_brnbar2
+Psilopogon malabaricus_malabar barbet_crfbar1
+Psilopogon rubricapillus_crimson-fronted barbet_crfbar3
+Psilopogon haemacephalus_coppersmith barbet_copbar1
+Psilopogon haemacephalus indicus/delicus_coppersmith barbet (Western Yellow-faced)_copbar11
+Psilopogon haemacephalus roseus_coppersmith barbet (Javan Red-faced)_copbar4
+Psilopogon haemacephalus [haemacephalus Group]_coppersmith barbet (Philippine Yellow-faced)_copbar12
+Psilopogon haemacephalus [intermedius Group]_coppersmith barbet (Philippine Red-faced)_copbar13
+Psilopogon malabaricus/haemacephalus_malabar/coppersmith barbet_y00869
+Psilopogon cyanotis_blue-eared barbet_buebar1
+Psilopogon duvaucelii_black-eared barbet_buebar2
+Psilopogon cyanotis x duvaucelii_blue-eared x black-eared barbet (hybrid)_x01066
+Psilopogon cyanotis/duvaucelii_blue-eared/black-eared barbet_blebar1
+Psilopogon australis_yellow-eared barbet_litbar1
+Psilopogon eximius_bornean barbet_borbar1
+Psilopogon pyrolophus_fire-tufted barbet_fitbar1
+Psilopogon virens_great barbet_grebar1
+Psilopogon lagrandieri_red-vented barbet_revbar1
+Psilopogon rafflesii_red-crowned barbet_recbar1
+Psilopogon mystacophanos_red-throated barbet_retbar1
+Psilopogon javensis_black-banded barbet_blbbar2
+Psilopogon pulcherrimus_golden-naped barbet_gonbar1
+Psilopogon henricii_yellow-crowned barbet_yecbar1
+Psilopogon armillaris_flame-fronted barbet_flfbar1
+Psilopogon faiostrictus_green-eared barbet_grebar3
+Psilopogon lineatus_lineated barbet_linbar1
+Psilopogon faiostrictus/lineatus_green-eared/lineated barbet_y00399
+Psilopogon zeylanicus_brown-headed barbet_brhbar1
+Psilopogon lineatus/zeylanicus_lineated/brown-headed barbet_y01095
+Psilopogon viridis_white-cheeked barbet_whcbar1
+Psilopogon zeylanicus/viridis_brown-headed/white-cheeked barbet_y00870
+Psilopogon flavifrons_yellow-fronted barbet_yefbar1
+Psilopogon franklinii_golden-throated barbet_gotbar2
+Psilopogon franklinii franklinii_golden-throated barbet (Himalayan)_gotbar4
+Psilopogon franklinii ramsayi_golden-throated barbet (Malayan)_gotbar5
+Psilopogon auricularis_necklaced barbet_gotbar3
+Psilopogon monticola_mountain barbet_moubar1
+Psilopogon [undescribed Meratus form]_meratus barbet (undescribed form)_merbar1
+Psilopogon corvinus_brown-throated barbet_brtbar1
+Psilopogon chrysopogon_gold-whiskered barbet_gowbar2
+Psilopogon chrysopogon chrysopogon/laetus_gold-whiskered barbet (Gold-whiskered)_gowbar1
+Psilopogon chrysopogon chrysopsis_gold-whiskered barbet (Gold-faced)_gofbar1
+Psilopogon incognitus_moustached barbet_moubar2
+Psilopogon nuchalis_taiwan barbet_taibar2
+Psilopogon faber_chinese barbet_chibar1
+Psilopogon asiaticus_blue-throated barbet_bltbar2
+Psilopogon asiaticus asiaticus_blue-throated barbet (Red-crowned)_butbar1
+Psilopogon asiaticus davisoni_blue-throated barbet (Blue-crowned)_butbar2
+Psilopogon annamensis_indochinese barbet_indbar1
+Psilopogon oorti_black-browed barbet_blbbar5
+Psilopogon chersonesus_turquoise-throated barbet_tutbar1
+Psilopogon sp._Psilopogon sp._megala1
+Megalaimidae sp._asian barbet sp._asibar1
+Capito aurovirens_capitão-de-coroa_sccbar1
+Capito dayi_capitão-de-cinta_blgbar1
+Capito maculicoronatus_spot-crowned barbet_spcbar1
+Capito squamatus_orange-fronted barbet_orfbar1
+Capito hypoleucus_white-mantled barbet_whmbar1
+Capito wallacei_scarlet-banded barbet_scbbar2
+Capito fitzpatricki_sira barbet_sirbar1
+Capito quinticolor_five-colored barbet_ficbar1
+Capito brunneipectus_capitão-de-peito-marrom_brcbar1
+Capito niger_capitão-de-bigode-carijó_blsbar1
+Capito auratus_capitão-de-fronte-dourada_gilbar1
+Capito sp._Capito sp._capito1
+Eubucco richardsoni_capitão-de-bigode-limão_letbar1
+Eubucco richardsoni richardsoni/nigriceps_capitão-de-garganta-amarela (richardsoni/nigriceps)_letbar2
+Eubucco richardsoni aurantiicollis/purusianus_capitão-de-garganta-amarela (aurantiicollis/purusianus)_letbar3
+Eubucco tucinkae_capitão-de-colar-amarelo_schbar1
+Eubucco bourcierii_red-headed barbet_rehbar1
+Eubucco versicolor_versicolored barbet_verbar1
+Eubucco versicolor steerii_versicolored barbet (Blue-cowled)_verbar2
+Eubucco versicolor glaucogularis_versicolored barbet (Blue-chinned)_verbar3
+Eubucco versicolor versicolor_versicolored barbet (Blue-moustached)_verbar4
+Capitonidae sp._Capitonidae sp._newbar1
+Semnornis frantzii_prong-billed barbet_prbbar1
+Semnornis ramphastinus_toucan barbet_toubar1
+Aulacorhynchus prasinus_northern emerald-toucanet_noremt1
+Aulacorhynchus prasinus wagleri_northern emerald-toucanet (Wagler's)_emetou3
+Aulacorhynchus prasinus [prasinus Group]_northern emerald-toucanet (Emerald)_emetou2
+Aulacorhynchus prasinus caeruleogularis_northern emerald-toucanet (Blue-throated)_emetou4
+Aulacorhynchus prasinus cognatus_northern emerald-toucanet (Violet-throated)_emetou5
+Aulacorhynchus albivitta_araçari-de-garganta-branca_souemt1
+Aulacorhynchus albivitta lautus_araçari-de-garganta-branca (lautus)_emetou6
+Aulacorhynchus albivitta griseigularis_araçari-de-garganta-branca (griseigularis)_emetou9
+Aulacorhynchus albivitta albivitta/phaeolaemus_araçari-de-garganta-branca (albivitta/phaeolaemus)_emetou7
+Aulacorhynchus albivitta cyanolaemus_araçari-de-garganta-branca (cyanolaemus)_souemt2
+Aulacorhynchus albivitta atrogularis/dimidiatus_araçari-de-garganta-branca (atrogularis/dimidiatus)_emetou8
+Aulacorhynchus sulcatus_groove-billed toucanet_grbtou1
+Aulacorhynchus sulcatus calorhynchus_groove-billed toucanet (Yellow-billed)_grbtou2
+Aulacorhynchus sulcatus sulcatus/erythrognathus_groove-billed toucanet (Groove-billed)_grbtou3
+Aulacorhynchus derbianus_chestnut-tipped toucanet_chttou3
+Aulacorhynchus whitelianus_tucaninho-verde_chttou2
+Aulacorhynchus haematopygus_crimson-rumped toucanet_crrtou1
+Aulacorhynchus huallagae_yellow-browed toucanet_yebtou1
+Aulacorhynchus coeruleicinctis_blue-banded toucanet_blbtou1
+Aulacorhynchus sp._Aulacorhynchus sp._aulaco1
+Andigena hypoglauca_gray-breasted mountain-toucan_gybmot1
+Andigena laminirostris_plate-billed mountain-toucan_pbmtou1
+Andigena cucullata_hooded mountain-toucan_homtou1
+Andigena nigrirostris_black-billed mountain-toucan_bbmtou1
+Pteroglossus bailloni_araçari-banana_saftou2
+Pteroglossus viridis_araçari-miudinho_greara1
+Pteroglossus inscriptus_araçari-de-bico-riscado_letara1
+Pteroglossus inscriptus humboldti_araçari-de-bico-riscado (humboldti)_letara2
+Pteroglossus inscriptus inscriptus_araçari-de-bico-riscado (inscriptus)_letara3
+Pteroglossus torquatus_collared aracari_colara1
+Pteroglossus torquatus [torquatus Group]_collared aracari (Collared)_colara2
+Pteroglossus torquatus sanguineus_collared aracari (Stripe-billed)_colara4
+Pteroglossus torquatus erythropygius_collared aracari (Pale-mandibled)_colara5
+Pteroglossus frantzii_fiery-billed aracari_fibara1
+Pteroglossus aracari_araçari-de-bico-branco_blnara1
+Pteroglossus castanotis_araçari-castanho_cheara1
+Pteroglossus pluricinctus_araçari-de-cinta-dupla_mabara1
+Pteroglossus azara_araçari-de-bico-de-marfim/amarelo/marrom_ivbara1
+Pteroglossus azara flavirostris_araçari-de-bico-amarelo_ivbara4
+Pteroglossus azara azara_araçari-de-bico-de-marfim_ivbara5
+Pteroglossus azara mariae_araçari-de-bico-marrom_ivbara3
+Pteroglossus beauharnaisii_araçari-mulato_cucara1
+Pteroglossus bitorquatus_araçari-de-pescoço-vermelho_renara1
+Pteroglossus bitorquatus sturmii_araçari-de-pescoço-vermelho (sturmii)_renara2
+Pteroglossus bitorquatus bitorquatus/reichenowi_araçari-de-pescoço-vermelho (bitorquatus/reichenowi)_renara3
+Pteroglossus sp._Pteroglossus sp._aracar1
+Selenidera spectabilis_yellow-eared toucanet_yeetou1
+Selenidera piperivora_araçari-negro_guitou1
+Selenidera reinwardtii_saripoca-de-coleira_goctou1
+Selenidera reinwardtii reinwardtii_saripoca-de-coleira (reinwardtii)_goctou2
+Selenidera reinwardtii langsdorffii_saripoca-de-coleira (langsdorffii)_goctou3
+Selenidera nattereri_saripoca-de-bico-castanho_tattou1
+Selenidera gouldii_saripoca-de-gould_goutou1
+Selenidera maculirostris_araçari-poca_spbtou1
+Ramphastidae (small toucan sp.)_small toucan sp._smatou1
+Ramphastos toco_tucanuçu_toctou1
+Ramphastos ambiguus_yellow-throated toucan_bkmtou1
+Ramphastos ambiguus swainsonii_yellow-throated toucan (Chestnut-mandibled)_chmtou1
+Ramphastos ambiguus ambiguus/abbreviatus_yellow-throated toucan (Black-mandibled)_blmtou1
+Ramphastos tucanus_tucano-de-papo-branco_whttou1
+Ramphastos tucanus tucanus_tucano-grande-de-papo-branco (tucanus)_whttou2
+Ramphastos tucanus cuvieri/inca_tucano-grande-de-papo-branco (cuvieri/inca)_whttou3
+Ramphastos sulfuratus_keel-billed toucan_kebtou1
+Ramphastos brevis_choco toucan_chotou1
+Ramphastos vitellinus_tucano-de-bico-preto_chbtou1
+Ramphastos vitellinus citreolaemus_tucano-de-bico-preto (citreolaemus)_chbtou3
+Ramphastos vitellinus culminatus/pintoi_tucano-de-bico-preto (culminatus/pintoi)_chbtou7
+Ramphastos vitellinus citreolaemus x culminatus_tucano-de-bico-preto (citreolaemus x culminatus)_chbtou4
+Ramphastos vitellinus vitellinus_tucano-de-bico-preto (vitellinus)_chbtou8
+Ramphastos vitellinus culminatus x vitellinus_tucano-de-bico-preto (culminatus x vitellinus)_chbtou6
+Ramphastos vitellinus ariel_tucano-de-bico-preto (ariel)_chbtou2
+Ramphastos vitellinus culminatus x ariel_tucano-de-bico-preto (culminatus x ariel)_chbtou5
+Ramphastos dicolorus_tucano-de-bico-verde_rebtou2
+Ramphastos sp._Ramphastos sp._lartou1
+Prodotiscus insignis_cassin's honeybird_cashon1
+Prodotiscus zambesiae_green-backed honeybird_grbhon2
+Prodotiscus regulus_brown-backed honeybird_wahhon1
+Prodotiscus sp._honeybird sp._smahon1
+Melignomon zenkeri_zenker's honeyguide_zenhon1
+Melignomon eisentrauti_yellow-footed honeyguide_yefhon2
+Indicator pumilio_dwarf honeyguide_dwahon1
+Indicator willcocksi_willcocks's honeyguide_wilhon2
+Indicator meliphilus_pallid honeyguide_palhon1
+Indicator exilis_indicador-minúsculo-da-floresta_leahon2
+Indicator minor_lesser honeyguide_y00400
+Indicator minor conirostris/ussheri_lesser honeyguide (Thick-billed)_thbhon1
+Indicator minor [minor Group]_indicador-pequeno_leshon1
+Indicator maculatus_indicador-malhado_spohon2
+Indicator variegatus_scaly-throated honeyguide_scthon1
+Indicator xanthonotus_yellow-rumped honeyguide_yerhon1
+Indicator archipelagicus_malaysian honeyguide_malhon1
+Indicator indicator_pássaro-do-mel_grehon2
+Indicator sp._large honeyguide sp._larhon1
+Melichneutes robustus_lyre-tailed honeyguide_lython1
+Indicatoridae sp._indicador sp._honeyg1
+Jynx torquilla_torcicolo_eurwry
+Jynx ruficollis_red-throated wryneck_runwry1
+Jynx ruficollis ruficollis_red-throated wryneck (Rufous-necked)_runwry2
+Jynx ruficollis pulchricollis_red-throated wryneck (Bar-throated)_runwry3
+Jynx ruficollis aequatorialis_red-throated wryneck (Ethiopian)_runwry4
+Picumnus innominatus_speckled piculet_spepic1
+Picumnus aurifrons_picapauzinho-dourado_babpic1
+Picumnus pumilus_picapauzinho-do-orinoco_oripic1
+Picumnus lafresnayi_picapauzinho-do-amazonas_lafpic1
+Picumnus exilis_picapauzinho-de-pintas-amarelas/ondulado/de-costas-pintadas/de-pernambuco_gospic1
+Picumnus exilis undulatus_picapauzinho-ondulado_gospic4
+Picumnus exilis buffonii_picapauzinho-de-costas-pintadas_gospic5
+Picumnus exilis pernambucensis_picapauzinho-de-pernambuco_gospic6
+Picumnus exilis exilis_picapauzinho-de-pintas-amarelas_gospic7
+Picumnus sclateri_ecuadorian piculet_ecupic1
+Picumnus squamulatus_scaled piculet_scapic1
+Picumnus squamulatus [squamulatus Group]_scaled piculet (Scaled)_scapic2
+Picumnus squamulatus obsoletus_scaled piculet (Black-dotted)_gospic3
+Picumnus spilogaster_picapauzinho-de-pescoço-branco_whbpic2
+Picumnus spilogaster spilogaster/orinocensis_picapauzinho-de-pescoço-branco (spilogaster/orinocensis)_whbpic4
+Picumnus spilogaster pallidus_picapauzinho-de-pescoço-branco (pallidus)_whbpic5
+Picumnus minutissimus_arrowhead piculet_arrpic1
+Picumnus pygmaeus_picapauzinho-pintado_spopic1
+Picumnus steindachneri_speckle-chested piculet_spcpic1
+Picumnus varzeae_picapauzinho-da-várzea_varpic1
+Picumnus cirratus_picapauzinho-barrado_whbpic1
+Picumnus cirratus macconnelli/confusus_picapauzinho-barrado (macconnelli/confusus)_whbpic6
+Picumnus cirratus [cirratus Group]_picapauzinho-barrado [grupo cirratus]_whbpic7
+Picumnus dorbignyanus_ocellated piculet_ocepic2
+Picumnus cirratus/dorbignyanus_white-barred/ocellated piculet_y00962
+Picumnus temminckii_picapauzinho-de-coleira_occpic1
+Picumnus cirratus x temminckii_picapauzinho-barrado x picapauzinho-de-coleira (híbrido)_x00951
+Picumnus cirratus/temminckii_picapauzinho-barrado/picapauzinho-de-coleira_y01140
+Picumnus albosquamatus_picapauzinho-escamoso_whwpic1
+Picumnus cirratus x albosquamatus_picapauzinho-barrado x picapauzinho-escamoso (híbrido)_x00952
+Picumnus cirratus/albosquamatus_picapauzinho-barrado/picapauzinho-escamoso_y01141
+Picumnus fuscus_picapauzinho-fusco_runpic1
+Picumnus rufiventris_picapauzinho-vermelho_rubpic1
+Picumnus limae_picapauzinho-da-caatinga_ochpic1
+Picumnus nebulosus_picapauzinho-carijó_motpic1
+Picumnus castelnau_picapauzinho-creme_plbpic1
+Picumnus subtilis_picapauzinho-de-barras-finas_fibpic1
+Picumnus olivaceus_olivaceous piculet_olipic1
+Picumnus granadensis_grayish piculet_grapic1
+Picumnus cinnamomeus_chestnut piculet_chepic1
+Picumnus sp._Picumnus sp._newpic1
+Verreauxia africana_african piculet_afrpic1
+Sasia abnormis_rufous piculet_rufpic1
+Sasia ochracea_white-browed piculet_whbpic3
+Sasia abnormis/ochracea_rufous/white-browed piculet_y00401
+Nesoctites micromegas_antillean piculet_antpic1
+Hemicircus concretus_gray-and-buff woodpecker_gabwoo3
+Hemicircus concretus sordidus_gray-and-buff woodpecker (Gray-and-buff)_gabwoo2
+Hemicircus concretus concretus_gray-and-buff woodpecker (Red-crested)_gabwoo4
+Hemicircus canente_heart-spotted woodpecker_heswoo1
+Sphyrapicus thyroideus_williamson's sapsucker_wilsap
+Sphyrapicus varius_pica-pau-de-barriga-amarela_yebsap
+Sphyrapicus nuchalis_red-naped sapsucker_rensap
+Sphyrapicus varius x nuchalis_yellow-bellied x red-naped sapsucker (hybrid)_x00634
+Sphyrapicus varius/nuchalis_yellow-bellied/red-naped sapsucker_y00019
+Sphyrapicus ruber_red-breasted sapsucker_rebsap
+Sphyrapicus ruber ruber_red-breasted sapsucker (ruber)_rebsap1
+Sphyrapicus ruber daggetti_red-breasted sapsucker (daggetti)_rebsap2
+Sphyrapicus varius x ruber_yellow-bellied x red-breasted sapsucker (hybrid)_x00712
+Sphyrapicus nuchalis x ruber_red-naped x red-breasted sapsucker (hybrid)_rnxsap1
+Sphyrapicus varius/nuchalis x ruber_yellow-bellied/red-naped x red-breasted sapsucker (hybrid)_x01052
+Sphyrapicus nuchalis/ruber_red-naped/red-breasted sapsucker_y00789
+Sphyrapicus sp._sapsucker sp._sapsuc
+Xiphidiopicus percussus_cuban green woodpecker_cugwoo1
+Melanerpes candidus_pica-pau-branco_whiwoo1
+Melanerpes lewis_lewis's woodpecker_lewwoo
+Melanerpes herminieri_guadeloupe woodpecker_guawoo1
+Melanerpes portoricensis_puerto rican woodpecker_purwoo1
+Melanerpes erythrocephalus_red-headed woodpecker_rehwoo
+Melanerpes formicivorus_acorn woodpecker_acowoo
+Melanerpes formicivorus [formicivorus Group]_acorn woodpecker (Acorn)_acowoo1
+Melanerpes formicivorus angustifrons_acorn woodpecker (Narrow-fronted)_acowoo2
+Melanerpes chrysauchen_golden-naped woodpecker_gonwoo1
+Melanerpes cruentatus_benedito-de-testa-vermelha_yetwoo2
+Melanerpes flavifrons_benedito-de-testa-amarela_yefwoo1
+Melanerpes pulcher_beautiful woodpecker_beawoo2
+Melanerpes pucherani_black-cheeked woodpecker_blcwoo1
+Melanerpes cactorum_pica-pau-de-testa-branca_whfwoo1
+Melanerpes striatus_hispaniolan woodpecker_hiswoo1
+Melanerpes radiolatus_jamaican woodpecker_jamwoo1
+Melanerpes chrysogenys_golden-cheeked woodpecker_gocwoo1
+Melanerpes hypopolius_gray-breasted woodpecker_grbwoo1
+Melanerpes pygmaeus_yucatan woodpecker_yucwoo
+Melanerpes rubricapillus_red-crowned woodpecker_recwoo1
+Melanerpes uropygialis_gila woodpecker_gilwoo
+Melanerpes hoffmannii_hoffmann's woodpecker_hofwoo1
+Melanerpes rubricapillus x hoffmannii_red-crowned x hoffmann's woodpecker (hybrid)_x00440
+Melanerpes aurifrons_golden-fronted woodpecker_gofwoo
+Melanerpes aurifrons aurifrons_golden-fronted woodpecker (Northern)_gofwoo1
+Melanerpes aurifrons [santacruzi Group]_golden-fronted woodpecker (Velasquez's)_gofwoo2
+Melanerpes aurifrons polygrammus_golden-fronted woodpecker (West Mexico)_gofwoo3
+Melanerpes hoffmannii x aurifrons_hoffmann's x golden-fronted woodpecker (hybrid)_x00853
+Melanerpes hoffmannii/aurifrons_hoffmann's/golden-fronted woodpecker_y00963
+Melanerpes carolinus_red-bellied woodpecker_rebwoo
+Melanerpes aurifrons x carolinus_golden-fronted x red-bellied woodpecker (hybrid)_x00460
+Melanerpes aurifrons/carolinus_golden-fronted/red-bellied woodpecker_y00788
+Melanerpes superciliaris_west indian woodpecker_weiwoo1
+Melanerpes sp._Melanerpes sp._melane1
+Picoides tridactylus_pica-pau-tridáctilo_ettwoo1
+Picoides tridactylus [tridactylus Group]_pica-pau-tridáctilo [grupo tridactylus]_ettwoo2
+Picoides tridactylus funebris_pica-pau-tridáctilo (funebris)_ettwoo3
+Picoides dorsalis_american three-toed woodpecker_attwoo1
+Picoides dorsalis dorsalis_american three-toed woodpecker (Rocky Mts.)_attwoo2
+Picoides dorsalis fasciatus_american three-toed woodpecker (Northwest)_attwoo3
+Picoides dorsalis bacatus_american three-toed woodpecker (Eastern)_attwoo4
+Picoides arcticus_black-backed woodpecker_bkbwoo
+Picoides dorsalis/arcticus_american three-toed/black-backed woodpecker_y00617
+Yungipicus temminckii_sulawesi pygmy woodpecker_sulwoo2
+Yungipicus maculatus_philippine pygmy woodpecker_phiwoo1
+Yungipicus ramsayi_sulu pygmy woodpecker_phiwoo3
+Yungipicus nanus_brown-capped pygmy woodpecker_bncwoo3
+Yungipicus moluccensis_sunda pygmy woodpecker_bncwoo2
+Yungipicus canicapillus_gray-capped pygmy woodpecker_gycwoo1
+Yungipicus nanus/canicapillus_brown-capped/gray-capped pygmy woodpecker_y00735
+Yungipicus kizuki_japanese pygmy woodpecker_pygwoo1
+Leiopicus mahrattensis_yellow-crowned woodpecker_yecwoo1
+Dendrocoptes medius_pica-pau-médio_miswoo1
+Dendrocoptes auriceps_brown-fronted woodpecker_brfwoo1
+Dendrocoptes dorae_arabian woodpecker_arawoo1
+Chloropicus pyrrhogaster_fire-bellied woodpecker_fibwoo1
+Chloropicus xantholophus_golden-crowned woodpecker_gocwoo3
+Chloropicus namaquus_bearded woodpecker_beawoo1
+Dendropicos abyssinicus_abyssinian woodpecker_abywoo1
+Dendropicos lugubris_melancholy woodpecker_melwoo1
+Dendropicos gabonensis_gabon woodpecker_gabwoo1
+Dendropicos elliotii_elliot's woodpecker_ellwoo1
+Dendropicos elliotii elliotii_elliot's woodpecker (Elliot's)_ellwoo2
+Dendropicos elliotii johnstoni_elliot's woodpecker (Johnston's)_ellwoo3
+Dendropicos elachus_little gray woodpecker_ligwoo3
+Dendropicos poecilolaemus_speckle-breasted woodpecker_spbwoo2
+Dendropicos fuscescens_pica-pau-cardeal_carwoo1
+Dendropicos stierlingi_stierling's woodpecker_stiwoo1
+Dendropicos obsoletus_pica-pau-de-costas-pardas_brbwoo1
+Dendropicos goertae_pica-pau-cinzento_grywoo1
+Dendropicos goertae koenigi_pica-pau-cinzento (koenigi)_afgwoo2
+Dendropicos goertae [goertae Group]_pica-pau-cinzento [grupo goertae]_afgwoo1
+Dendropicos spodocephalus_mountain gray woodpecker_gyhwoo1
+Dendropicos griseocephalus_olive woodpecker_oliwoo2
+Dendropicos griseocephalus ruwenzori_olive woodpecker (Red-bellied)_oliwoo8
+Dendropicos griseocephalus kilimensis_olive woodpecker (Montane)_oliwoo9
+Dendropicos griseocephalus griseocephalus_olive woodpecker (Southern)_oliwoo10
+Dendrocopos hyperythrus_rufous-bellied woodpecker_rubwoo1
+Dendrocopos macei_fulvous-breasted woodpecker_fubwoo2
+Dendrocopos analis_freckle-breasted woodpecker_frbwoo1
+Dendrocopos atratus_stripe-breasted woodpecker_stbwoo4
+Dendrocopos noguchii_okinawa woodpecker_okiwoo1
+Dendrocopos leucotos_pica-pau-de-dorso-branco_whbwoo1
+Dendrocopos leucotos lilfordi_pica-pau-de-dorso-branco (lilfordi)_whbwoo3
+Dendrocopos leucotos [leucotos Group]_pica-pau-de-dorso-branco [grupo leucotos]_whbwoo9
+Dendrocopos leucotos owstoni_pica-pau-de-dorso-branco (owstoni)_whbwoo10
+Dendrocopos darjellensis_darjeeling woodpecker_darwoo1
+Dendrocopos major_pica-pau-malhado_grswoo
+Dendrocopos major canariensis/thanneri_pica-pau-malhado (canariensis/thanneri)_grswoo3
+Dendrocopos major numidus/mauritanus_pica-pau-malhado (numidus/mauritanus)_grswoo4
+Dendrocopos major [major Group]_pica-pau-malhado [grupo major]_grswoo2
+Dendrocopos major poelzami_pica-pau-malhado (poelzami)_grswoo9
+Dendrocopos major japonicus_pica-pau-malhado (japonicus)_grswoo12
+Dendrocopos major cabanisi/stresemanni_pica-pau-malhado (cabanisi/stresemanni)_grswoo21
+Dendrocopos leucopterus_white-winged woodpecker_whwwoo1
+Dendrocopos himalayensis_himalayan woodpecker_himwoo1
+Dendrocopos syriacus_pica-pau-dos-balcãs_syrwoo1
+Dendrocopos major x syriacus_pica-pau-malhado x pica-pau-dos-balcãs (híbrido)_x00914
+Dendrocopos major/syriacus_pica-pau-malhado/pica-pau-dos-balcãs_y00790
+Dendrocopos assimilis_sind woodpecker_sinwoo1
+Dendrocopos sp._pica-pau (Dendrocopos) sp._dendro1
+Dryobates minor_pica-pau-galego_leswoo1
+Dryobates cathpharius_crimson-naped woodpecker_crbwoo6
+Dendrocopos darjellensis/Dryobates cathpharius_darjeeling/crimson-naped woodpecker_y00964
+Dryobates pernyii_necklaced woodpecker_crbwoo7
+Dendrocopos darjellensis/Dryobates pernyii_darjeeling/necklaced woodpecker_y01278
+Dryobates cathpharius/pernyii_crimson-naped/necklaced woodpecker_crbwoo3
+Dryobates pubescens_downy woodpecker_dowwoo
+Dryobates pubescens pubescens/medianus_downy woodpecker (Eastern)_dowwoo1
+Dryobates pubescens leucurus/glacialis_downy woodpecker (Rocky Mts.)_dowwoo2
+Dryobates pubescens gairdnerii/turati_downy woodpecker (Pacific)_dowwoo3
+Dryobates nuttallii_nuttall's woodpecker_nutwoo
+Dryobates pubescens x nuttallii_downy x nuttall's woodpecker (hybrid)_x00662
+Dryobates scalaris_ladder-backed woodpecker_labwoo
+Dryobates pubescens x scalaris_downy x ladder-backed woodpecker (hybrid)_x00801
+Dryobates nuttallii x scalaris_nuttall's x ladder-backed woodpecker (hybrid)_x00620
+Dryobates pubescens/scalaris_downy/ladder-backed woodpecker_y01076
+Dryobates nuttallii/scalaris_nuttall's/ladder-backed woodpecker_y00965
+Dryobates borealis_red-cockaded woodpecker_recwoo
+Dryobates villosus_hairy woodpecker_haiwoo
+Dryobates villosus [villosus Group]_hairy woodpecker (Eastern)_haiwoo2
+Dryobates villosus [harrisi Group]_hairy woodpecker (Pacific)_haiwoo1
+Dryobates villosus orius/icastus_hairy woodpecker (Rocky Mts.)_haiwoo5
+Dryobates villosus jardinii/sanctorum_hairy woodpecker (South Mexican)_haiwoo4
+Dryobates villosus extimus_hairy woodpecker (Costa Rican)_haiwoo3
+Dryobates pubescens x villosus_downy x hairy woodpecker (hybrid)_x00803
+Dryobates nuttallii x villosus_nuttall's x hairy woodpecker (hybrid)_x00663
+Dryobates scalaris x villosus_ladder-backed x hairy woodpecker (hybrid)_x00802
+Dryobates pubescens/villosus_downy/hairy woodpecker_y00322
+Dryobates albolarvatus_white-headed woodpecker_whhwoo
+Dryobates villosus x albolarvatus_hairy x white-headed woodpecker (hybrid)_x01053
+Dryobates fumigatus_smoky-brown woodpecker_smbwoo1
+Dryobates stricklandi_strickland's woodpecker_strwoo
+Dryobates arizonae_arizona woodpecker_ariwoo
+Dryobates kirkii_pica-pau-de-sobre-vermelho_rerwoo1
+Dryobates cassini_pica-pau-de-colar-dourado_gocwoo2
+Dryobates spilogaster_pica-pau-verde-carijó_whswoo2
+Dryobates mixtus_pica-pau-chorão_chewoo3
+Dryobates lignarius_striped woodpecker_strwoo6
+Dryobates lignarius puncticeps_striped woodpecker (Bolivian)_strwoo16
+Dryobates lignarius lignarius_striped woodpecker (Striped)_strwoo17
+Dryobates sanguineus_blood-colored woodpecker_blcwoo3
+Dryobates passerinus_pica-pau-pequeno_litwoo2
+Dryobates sanguineus x passerinus_blood-colored x little woodpecker (hybrid)_x01020
+Dryobates frontalis_dot-fronted woodpecker_dofwoo1
+Dryobates callonotus_scarlet-backed woodpecker_scbwoo3
+Dryobates dignus_yellow-vented woodpecker_yevwoo1
+Dryobates nigriceps_bar-bellied woodpecker_babwoo2
+Dryobates affinis_pica-pau-avermelhado_reswoo1
+Dryobates passerinus/affinis_pica-pau-pequeno/pica-pau-avermelhado_y00871
+Dryobates chocoensis_choco woodpecker_chowoo1
+Dryobates maculifrons_pica-pau-de-testa-pintada_yeewoo1
+Dryobates sp._Dryobates sp._dryoba1
+Blythipicus rubiginosus_maroon woodpecker_marwoo1
+Blythipicus pyrrhotis_bay woodpecker_baywoo1
+Chrysocolaptes validus_orange-backed woodpecker_orbwoo1
+Chrysocolaptes guttacristatus_greater flameback_grefla1
+Chrysocolaptes socialis_malabar flameback_grefla4
+Chrysocolaptes guttacristatus/socialis_greater/malabar flameback_y01245
+Chrysocolaptes strictus_javan flameback_javfla1
+Chrysocolaptes haematribon_luzon flameback_luzfla1
+Chrysocolaptes xanthocephalus_yellow-faced flameback_yeffla1
+Chrysocolaptes lucidus_buff-spotted flameback_busfla1
+Chrysocolaptes erythrocephalus_red-headed flameback_rehfla1
+Chrysocolaptes stricklandi_crimson-backed flameback_crbfla1
+Chrysocolaptes festivus_white-naped woodpecker_whnwoo1
+Campephilus pollens_powerful woodpecker_powwoo1
+Campephilus haematogaster_crimson-bellied woodpecker_crbwoo1
+Campephilus haematogaster splendens_crimson-bellied woodpecker (Splendid)_crbwoo4
+Campephilus haematogaster haematogaster_crimson-bellied woodpecker (Crimson-bellied)_crbwoo5
+Campephilus rubricollis_pica-pau-de-barriga-vermelha_renwoo1
+Campephilus robustus_pica-pau-rei_robwoo1
+Campephilus melanoleucos_pica-pau-de-topete-vermelho_crcwoo1
+Campephilus guatemalensis_pale-billed woodpecker_pabwoo1
+Campephilus gayaquilensis_guayaquil woodpecker_guawoo2
+Campephilus leucopogon_pica-pau-de-barriga-preta_crbwoo2
+Campephilus melanoleucos x leucopogon_pica-pau-de-topete-vermelho/de-barriga-preta (híbrido)_x00854
+Campephilus magellanicus_magellanic woodpecker_magwoo1
+Campephilus principalis_ivory-billed woodpecker_ivbwoo
+Campephilus principalis principalis_ivory-billed woodpecker (Northern)_ivbwoo3
+Campephilus principalis bairdii_ivory-billed woodpecker (Cuban)_ivbwoo4
+Campephilus imperialis_imperial woodpecker_impwoo1
+Campephilus sp._Campephilus sp._campep1
+Micropternus brachyurus_rufous woodpecker_rufwoo2
+Meiglyptes tukki_buff-necked woodpecker_bunwoo1
+Meiglyptes grammithorax_buff-rumped woodpecker_burwoo1
+Meiglyptes tristis_zebra woodpecker_burwoo3
+Meiglyptes jugularis_black-and-buff woodpecker_babwoo3
+Gecinulus grantia_pale-headed woodpecker_pahwoo1
+Gecinulus viridis_bamboo woodpecker_bamwoo1
+Gecinulus grantia x viridis_pale-headed x bamboo woodpecker (hybrid)_x00805
+Gecinulus rafflesii_olive-backed woodpecker_olbwoo2
+Dinopium shorii_himalayan flameback_himfla1
+Dinopium javanense_common flameback_comfla1
+Chrysocolaptes guttacristatus/Dinopium javanense_greater/common flameback_y00737
+Chrysocolaptes socialis/Dinopium javanense_malabar/common flameback_y01279
+Dinopium shorii/javanense_himalayan/common flameback_y01090
+Dinopium everetti_spot-throated flameback_sptfla1
+Dinopium benghalense_black-rumped flameback_bkrfla1
+Dinopium psarodes_red-backed flameback_bkrfla2
+Dinopium benghalense x psarodes_black-rumped x red-backed flameback (hybrid)_bkrfla3
+Dinopium benghalense/psarodes_black-rumped/red-backed flameback_blrfla1
+Chrysocolaptes/Dinopium sp._flameback sp._flameb1
+Picus chlorolophus_lesser yellownape_lesyel1
+Picus chlorolophus [chlorolophus Group]_lesser yellownape (Himalayan)_lesyel12
+Picus chlorolophus chlorigaster/wellsi_lesser yellownape (Indian)_lesyel13
+Picus chlorolophus citrinocristatus/longipennis_lesser yellownape (Chinese)_lesyel11
+Picus chlorolophus rodgeri/vanheysti_lesser yellownape (Sunda)_lesyel14
+Picus puniceus_crimson-winged woodpecker_crwwoo1
+Picus xanthopygaeus_streak-throated woodpecker_sttwoo1
+Picus squamatus_scaly-bellied woodpecker_scbwoo1
+Picus rabieri_red-collared woodpecker_recwoo2
+Picus viridanus_streak-breasted woodpecker_stbwoo3
+Picus vittatus_laced woodpecker_lacwoo1
+Picus viridanus/vittatus_streak-breasted/laced woodpecker_y01034
+Picus awokera_japanese woodpecker_japwoo1
+Picus canus_peto-cinzento_gyfwoo1
+Picus canus canus/jessoensis_peto-cinzento (canus/jessoensis)_gyhwoo2
+Picus canus [guerini Group]_peto-cinzento [grupo guerini]_gyhwoo3
+Picus canus dedemi_peto-cinzento (dedemi)_gyhwoo4
+Picus erythropygius_black-headed woodpecker_blhwoo1
+Picus vaillantii_peto-mourisco_levwoo1
+Picus viridis_peto-real_eugwoo2
+Picus viridis viridis/karelini_peto-real (viridis/karelini)_grnwoo2
+Picus viridis innominatus_peto-real (innominatus)_grnwoo4
+Picus canus x viridis_peto-cinzento x peto-real (híbrido)_x00855
+Picus canus/viridis_gray-headed/eurasian green woodpecker_y01262
+Picus sharpei_peto-real-ibérico_grnwoo3
+Picus viridis x sharpei_peto-real x peto-real-ibérico (híbrido)_eugwoo1
+Picus viridis/sharpei_peto-real/peto-real-ibérico_grnwoo1
+Picus sp._peto (Picus) sp._picus1
+Chrysophlegma miniaceum_banded woodpecker_banwoo2
+Chrysophlegma flavinucha_greater yellownape_greyel1
+Picus chlorolophus/Chrysophlegma flavinucha_lesser/greater yellownape_y00736
+Chrysophlegma mentale_checker-throated woodpecker_chtwoo1
+Chrysophlegma mentale humii_checker-throated woodpecker (Checker-throated)_chtwoo2
+Chrysophlegma mentale mentale_checker-throated woodpecker (Javan)_chtwoo3
+Geocolaptes olivaceus_ground woodpecker_growoo1
+Pardipicus caroli_brown-eared woodpecker_brewoo1
+Pardipicus caroli arizelus_brown-eared woodpecker (Western)_bnewoo1
+Pardipicus caroli caroli_brown-eared woodpecker (Carol's)_bnewoo2
+Pardipicus nivosus_buff-spotted woodpecker_buswoo1
+Campethera tullbergi_tullberg's woodpecker_tulwoo2
+Campethera taeniolaema_fine-banded woodpecker_tulwoo3
+Campethera maculosa_green-backed woodpecker_grbwoo2
+Campethera maculosa maculosa_green-backed woodpecker (Little Green)_ligwoo1
+Campethera maculosa permista_green-backed woodpecker (Plain-backed)_gnbwoo1
+Campethera maculosa [cailliautii Group]_green-backed woodpecker (Spot-backed)_gnbwoo2
+Campethera nubica_nubian woodpecker_nubwoo1
+Campethera punctuligera_pica-pau-pintado_fiswoo1
+Campethera bennettii_bennett's woodpecker_benwoo1
+Campethera bennettii bennettii_bennett's woodpecker (Bennett's)_benwoo2
+Campethera bennettii capricorni_bennett's woodpecker (Light-spotted)_benwoo3
+Campethera scriptoricauda_speckle-throated woodpecker_reiwoo1
+Campethera notata_knysna woodpecker_knywoo1
+Campethera abingoni_pica-pau-de-rabo-dourado_gotwoo1
+Campethera abingoni chrysura_pica-pau-de-rabo-dourado (chrysura)_gotwoo2
+Campethera abingoni [abingoni Group]_pica-pau-de-rabo-dourado [grupo abingoni]_gotwoo3
+Campethera mombassica_mombasa woodpecker_momwoo1
+Mulleripicus fulvus_ashy woodpecker_ashwoo1
+Mulleripicus funebris_northern sooty-woodpecker_soowoo1
+Mulleripicus fuliginosus_southern sooty-woodpecker_sousow1
+Mulleripicus pulverulentus_great slaty woodpecker_grswoo1
+Dryocopus lineatus_pica-pau-de-banda-branca_linwoo1
+Dryocopus lineatus [lineatus Group]_pica-pau-de-banda-branca [grupo lineatus]_linwoo7
+Dryocopus lineatus fuscipennis_pica-pau-de-bandas-brancas (fuscipennis)_linwoo8
+Campephilus sp./Dryocopus lineatus_campephilus sp./pica-pau-de-banda-branca_y00679
+Dryocopus pileatus_pileated woodpecker_pilwoo
+Dryocopus schulzii_black-bodied woodpecker_blbwoo3
+Dryocopus lineatus x schulzii_lineated x black-bodied woodpecker (hybrid)_x00804
+Dryocopus javensis_white-bellied woodpecker_whbwoo2
+Dryocopus hodgei_andaman woodpecker_andwoo1
+Dryocopus martius_pica-pau-preto_blawoo1
+Dryocopus sp._Dryocopus sp._dryoco1
+Celeus loricatus_cinnamon woodpecker_cinwoo1
+Celeus torquatus_pica-pau-de-coleira_rinwoo1
+Celeus torquatus torquatus_pica-pau-de-coleira (torquatus)_rinwoo2
+Celeus torquatus occidentalis_pica-pau-de-coleira (occidentalis)_rinwoo3
+Celeus torquatus tinnunculus_pica-pau-de-coleira (tinnunculus)_rinwoo4
+Celeus galeatus_pica-pau-de-cara-canela_helwoo1
+Celeus castaneus_chestnut-colored woodpecker_chcwoo1
+Celeus undatus_waved woodpecker_wavwoo5
+Celeus undatus [grammicus Group]_picapauzinho-chocolate_scbwoo5
+Celeus undatus [undatus Group]_pica-pau-barrado_wavwoo1
+Celeus flavus_pica-pau-amarelo_crcwoo2
+Celeus spectabilis_pica-pau-lindo_ruhwoo1
+Celeus obrieni_pica-pau-do-parnaíba_caawoo1
+Celeus ochraceus_pica-pau-ocráceo_blcwoo5
+Celeus elegans_pica-pau-chocolate_chewoo2
+Celeus lugubris_pica-pau-louro_pacwoo1
+Celeus flavescens_pica-pau-de-cabeça-amarela_blcwoo4
+Celeus ochraceus/flavescens_pica-pau-ocráceo/pica-pau-de-cabeça-amarela_blcwoo2
+Celeus sp._Celeus sp._celeus1
+Piculus simplex_rufous-winged woodpecker_ruwwoo1
+Piculus callopterus_stripe-cheeked woodpecker_stcwoo1
+Piculus leucolaemus_pica-pau-de-garganta-branca_whtwoo2
+Piculus litae_lita woodpecker_litwoo1
+Piculus flavigula_pica-pau-bufador_yetwoo1
+Piculus chrysochloros_pica-pau-dourado-escuro/dourado-grande/de-garganta-barrada/dourado-de-belém/de-garganta-pintada_gogwoo1
+Piculus chrysochloros xanthochlorus_pica-pau-dourado-escuro/dourado-grande/de-garganta-barrada/dourado-de-belém/de-garganta-pintada (xanthochlorus)_gogwoo2
+Piculus chrysochloros capistratus_pica-pau-de-garganta-barrada_gogwoo3
+Piculus chrysochloros paraensis_pica-pau-dourado-de-belém_gogwoo4
+Piculus chrysochloros laemostictus_pica-pau-de-garganta-pintada_gogwoo5
+Piculus chrysochloros chrysochloros_pica-pau-dourado-escuro_gogwoo6
+Piculus chrysochloros polyzonus_pica-pau-dourado-grande_gogwoo7
+Piculus aurulentus_pica-pau-dourado_whbwoo7
+Piculus sp._Piculus sp._piculu1
+Colaptes rubiginosus_pica-pau-oliváceo_goowoo1
+Colaptes rubiginosus aeruginosus_pica-pau-oliváceo (aeruginosus)_goowoo3
+Colaptes rubiginosus [rubiginosus Group]_pica-pau-oliváceo [grupo rubiginosus]_goowoo2
+Colaptes rubiginosus rubripileus_pica-pau-oliváceo (rubripileus)_goowoo4
+Colaptes auricularis_gray-crowned woodpecker_grcwoo1
+Colaptes rivolii_crimson-mantled woodpecker_crmwoo2
+Colaptes rivolii [rivolii Group]_crimson-mantled woodpecker (Crimson-mantled)_crmwoo1
+Colaptes rivolii atriceps_crimson-mantled woodpecker (Black-crowned)_crmwoo3
+Colaptes atricollis_black-necked woodpecker_blnwoo1
+Colaptes punctigula_pica-pau-de-peito-pontilhado_spbwoo1
+Colaptes melanochloros_pica-pau-verde-barrado_grbwoo3
+Colaptes melanochloros melanochloros/nattereri_pica-pau-verde-barrado (melanochloros/nattereri)_gnbwoo3
+Colaptes melanochloros [melanolaimus Group]_pica-pau-verde-barrado [grupo melanolaimus]_gnbwoo4
+Colaptes auratus_pica-pau-mosqueado_norfli
+Colaptes auratus chrysocaulosus_pica-pau-mosqueado (chrysocaulosus)_norfli2
+Colaptes auratus gundlachi_pica-pau-mosqueado (gundlachi)_norfli3
+Colaptes auratus auratus/luteus_pica-pau-mosqueado (auratus/luteus)_yesfli
+Colaptes auratus [cafer Group]_pica-pau-mosqueado [grupo cafer]_resfli
+Colaptes auratus luteus x cafer_pica-pau-mosqueado (luteus x cafer)_rxyfli
+Colaptes mexicanoides_guatemalan flicker_norfli1
+Colaptes chrysoides_gilded flicker_gilfli
+Colaptes auratus x chrysoides_northern x gilded flicker (hybrid)_x00924
+Colaptes auratus/chrysoides_northern/gilded flicker_y00323
+Colaptes oceanicus_bermuda flicker_berfli1
+Colaptes fernandinae_fernandina's flicker_ferfli1
+Colaptes pitius_chilean flicker_chifli1
+Colaptes rupicola_andean flicker_andfli1
+Colaptes rupicola cinereicapillus_andean flicker (Northern)_andfli2
+Colaptes rupicola rupicola/puna_andean flicker (Southern)_andfli3
+Colaptes campestris_pica-pau-do-campo_camfli1
+Colaptes campestris campestris_pica-pau-do-campo (campestris)_camfli2
+Colaptes campestris campestroides_pica-pau-do-campo (campestroides)_camfli3
+Colaptes campestris campestris x campestroides_pica-pau-do-campo (campestris x campestroides)_camfli4
+Colaptes sp._Colaptes sp._colapt1
+Picidae sp._Picidae sp._woodpe1
+Cariama cristata_seriema_relser1
+Chunga burmeisteri_black-legged seriema_bllser1
+Herpetotheres cachinnans_acauã_laufal1
+Micrastur buckleyi_falcão-de-buckley_buffal1
+Micrastur semitorquatus_falcão-relógio_coffal1
+Micrastur mirandollei_tanatau_sbffal1
+Micrastur ruficollis_falcão-caburé_baffal1
+Micrastur mintoni_falcão-críptico_cryfof1
+Micrastur plumbeus_plumbeous forest-falcon_plffal1
+Micrastur ruficollis/plumbeus_barred/plumbeous forest-falcon_y00872
+Micrastur gilvicollis_falcão-mateiro_liffal1
+Micrastur ruficollis/gilvicollis_falcão-caburé/mateiro_y00689
+Micrastur sp._Micrastur sp._forest1
+Spiziapteryx circumcincta_falcãozinho-cinza_spwfal2
+Caracara lutosa_guadalupe caracara_guacar2
+Caracara plancus_carcará_y00678
+Caracara plancus cheriway_carcará (cheriway)_crecar1
+Caracara plancus plancus_carcará (plancus)_soucar1
+Ibycter americanus_cancão_retcar2
+Daptrius chimachima_carrapateiro_yehcar1
+Daptrius ater_gavião-de-anta_blacar1
+Daptrius chimango_chimango_chicar1
+Daptrius carunculatus_carunculated caracara_carcar1
+Daptrius megalopterus_mountain caracara_moucar1
+Daptrius albogularis_white-throated caracara_whtcar1
+Daptrius megalopterus/albogularis_mountain/white-throated caracara_y01280
+Daptrius australis_striated caracara_strcar1
+Polihierax semitorquatus_pygmy falcon_pygfal1
+Microhierax erythrogenys_philippine falconet_phifal1
+Microhierax melanoleucos_pied falconet_piefal2
+Microhierax caerulescens_collared falconet_colfal1
+Microhierax fringillarius_black-thighed falconet_bltfal1
+Microhierax latifrons_white-fronted falconet_whffal1
+Neohierax insignis_white-rumped falcon_whrfal1
+Falco naumanni_francelho_leskes1
+Falco tinnunculus_peneireiro-de-dorso-malhado_eurkes
+Falco tinnunculus [tinnunculus Group]_peneireiro-de-dorso-malhado [grupo tinnunculus]_eurkes2
+Falco tinnunculus canariensis/dacotiae_peneireiro-de-dorso-malhado (canariensis/dacotiae)_eurkes3
+Falco tinnunculus neglectus/alexandri_peneireiro-de-dorso-malhado (neglectus/alexandri)_eurkes4
+Falco tinnunculus rufescens_peneireiro-de-dorso-malhado (rufescens)_eurkes5
+Falco naumanni/tinnunculus_francelho/peneireiro-de-dorso-malhado_y00613
+Falco rupicolus_rock kestrel_eurkes1
+Falco naumanni/rupicolus_lesser/rock kestrel_y01292
+Falco tinnunculus/rupicolus_eurasian/rock kestrel_y00933
+Falco newtoni_malagasy kestrel_madkes1
+Falco punctatus_mauritius kestrel_maukes1
+Falco araeus_seychelles kestrel_seykes1
+Falco duboisi_reunion kestrel_reukes1
+Falco moluccensis_peneireiro-das-molucas_spokes1
+Falco cenchroides_nankeen kestrel_auskes1
+Falco rupicoloides_greater kestrel_grekes1
+Falco sparverius_quiriquiri_amekes
+Falco sparverius [sparverius Group]_quiriquiri [grupo sparverius]_amekes1
+Falco sparverius paulus_quiriquiri (paulus)_amekes7
+Falco sparverius caribaearum_quiriquiri (caribaearum)_amekes3
+Falco sparverius dominicensis_quiriquiri (dominicensis)_amekes4
+Falco sparverius sparverioides_quiriquiri (sparverioides)_amekes5
+Falco sparverius [cinnamominus Group]_quiriquiri [grupo cinnamominus]_amekes2
+Falco sparverius fernandensis_quiriquiri (fernandensis)_amekes6
+Falco alopex_fox kestrel_foxkes1
+Falco ardosiaceus_francelho-cinzento_grykes1
+Falco dickinsoni_dickinson's kestrel_dickes1
+Falco zoniventris_banded kestrel_bankes1
+Falco chicquera_red-necked falcon_renfal1
+Falco chicquera chicquera_red-necked falcon (Asian)_renfal2
+Falco chicquera ruficollis/horsbrughi_red-necked falcon (African)_renfal3
+Falco vespertinus_falcão-vespertino_reffal1
+Falco amurensis_falcão-do-amur_amufal1
+Falco vespertinus/amurensis_falcão-vespertino/falcão-do-amur_y01111
+Falco eleonorae_falcão-da-rainha_elefal1
+Falco concolor_falcão-cinzento_soofal1
+Falco columbarius_esmerilhão_merlin
+Falco columbarius [aesalon Group]_esmerilhão-europeu_merlin1
+Falco columbarius pallidus_esmerilhão (pallidus)_merlin2
+Falco columbarius columbarius_esmerilhão (columbarius)_taimer1
+Falco columbarius richardsonii_esmerilhão (richardsonii)_pramer1
+Falco columbarius suckleyi_esmerilhão (suckleyi)_blkmer1
+Falco subbuteo_ógea_eurhob
+Falco amurensis/subbuteo_falcão-do-amur/ógea_y00402
+Falco cuvierii_ógea-africano_afrhob1
+Falco severus_oriental hobby_orihob1
+Falco longipennis_ógea-australiana_aushob1
+Falco novaeseelandiae_new zealand falcon_nezfal1
+Falco berigora_brown falcon_brofal1
+Falco hypoleucos_gray falcon_gryfal1
+Falco subniger_black falcon_blafal1
+Falco femoralis_falcão-de-coleira_aplfal
+Falco rufigularis_cauré_batfal1
+Falco deiroleucus_falcão-de-peito-laranja_orbfal1
+Falco biarmicus_alfaneque_lanfal1
+Falco jugger_laggar falcon_lagfal1
+Falco cherrug_sacre_sakfal1
+Falco rusticolus_gerifalte_gyrfal
+Falco peregrinus_falcão-peregrino_perfal
+Falco peregrinus anatum_falcão-peregrino (anatum)_perfal1
+Falco peregrinus calidus/tundrius_falcão-peregrino (calidus/tundrius)_tupfal1
+Falco peregrinus pealei_falcão-peregrino (pealei)_pepfal1
+Falco peregrinus cassini_falcão-peregrino (cassini)_perfal2
+Falco peregrinus [peregrinus Group]_falcão-peregrino [grupo peregrinus]_perfal4
+Falco peregrinus brookei_falcão-peregrino (brookei)_perfal3
+Falco peregrinus pelegrinoides_falcão-peregrino (pelegrinoides)_barfal1
+Falco peregrinus madens_falcão-peregrino (madens)_perfal5
+Falco peregrinus babylonicus_falcão-peregrino (babylonicus)_perfal8
+Falco peregrinus minor_falcão-peregrino (minor)_perfal6
+Falco peregrinus radama_falcão-peregrino (radama)_perfal7
+Falco peregrinus peregrinator_falcão-peregrino (peregrinator)_perfal9
+Falco peregrinus ernesti/nesiotes_falcão-peregrino (ernesti/nesiotes)_perfal10
+Falco peregrinus macropus_falcão-peregrino (macropus)_perfal20
+Falco mexicanus_prairie falcon_prafal
+Falco peregrinus x mexicanus_peregrine x prairie falcon (hybrid)_x00698
+Falco fasciinucha_taita falcon_taifal1
+Falco sp. (large falcon sp.)_falcão grande (Falco) sp._larfal
+Falco sp. (small falcon sp.)_falco sp. (falcão pequeno sp.)_smafal
+Falco sp._Falco sp._falcon
+Accipitriformes/Falconiformes sp._rapinante diurna_diurap1
+Nestor notabilis_kea_kea1
+Nestor productus_norfolk island kaka_noikak1
+Nestor meridionalis_new zealand kaka_nezkak1
+Strigops habroptilus_kakapo_kakapo2
+Zanda funerea_yellow-tailed black-cockatoo_ytbcoc1
+Zanda latirostris_carnaby's black-cockatoo_slbblc1
+Zanda baudinii_baudin's black-cockatoo_whtblc1
+Calyptorhynchus banksii_red-tailed black-cockatoo_rtbcoc1
+Calyptorhynchus lathami_glossy black-cockatoo_glbcoc1
+Calyptorhynchus/Zanda sp._black-cockatoo sp._blackc2
+Nymphicus hollandicus_caturra_cockat
+Nymphicus hollandicus (Domestic type)_caturra (forma doméstica)_cockat1
+Probosciger aterrimus_palm cockatoo_palcoc1
+Callocephalon fimbriatum_gang-gang cockatoo_gagcoc1
+Eolophus roseicapilla_galah_galah
+Cacatua leadbeateri_pink cockatoo_pincoc1
+Cacatua haematuropygia_philippine cockatoo_phicoc1
+Cacatua goffiniana_cacatua-de-goffin_tancoc1
+Cacatua ducorpsii_solomons corella_duccoc1
+Cacatua pastinator_western corella_wescor1
+Cacatua sanguinea_little corella_litcor2
+Eolophus roseicapilla x Cacatua sanguinea_galah x little corella (hybrid)_x00953
+Cacatua tenuirostris_long-billed corella_lobcor1
+Cacatua sanguinea x tenuirostris_little x long-billed corella (hybrid)_x00806
+Cacatua sp. (corella sp.)_corella sp._corell1
+Cacatua alba_white cockatoo_whicoc1
+Cacatua ophthalmica_blue-eyed cockatoo_blecoc1
+Cacatua moluccensis_salmon-crested cockatoo_saccoc
+Cacatua alba x moluccensis_white x salmon-crested cockatoo (hybrid)_x00404
+Cacatua sulphurea_catatua-de-crista-amarela_yeccoc1
+Cacatua goffiniana x sulphurea_cacatua-de-goffin x catatua-de-crista-amarela (híbrido)_x00403
+Cacatua citrinocristata_citron-crested cockatoo_yeccoc5
+Cacatua galerita_sulphur-crested cockatoo_succoc
+Cacatua sanguinea x galerita_little corella x sulphur-crested cockatoo (hybrid)_x00920
+Cacatua sp._corella/white cockatoo sp._cacatu1
+Psittrichas fulgidus_pesquet's parrot_pespar1
+Coracopsis vasa_greater vasa parrot_vaspar1
+Coracopsis nigra_lesser vasa parrot_blapar1
+Coracopsis vasa/nigra_greater/lesser vasa parrot_y00873
+Coracopsis sibilans_comoro black parrot_levpar1
+Coracopsis vasa/sibilans_greater vasa/comoro black parrot_y01218
+Coracopsis barklyi_seychelles parrot_seypar1
+Micropsitta keiensis_yellow-capped pygmy-parrot_ycppar1
+Micropsitta geelvinkiana_geelvink pygmy-parrot_geppar1
+Micropsitta pusio_buff-faced pygmy-parrot_bfppar1
+Micropsitta bruijnii_red-breasted pygmy-parrot_rbppar1
+Micropsitta meeki_meek's pygmy-parrot_meppar1
+Micropsitta finschii_finsch's pygmy-parrot_fippar1
+Micropsitta sp._pygmy-parrot sp._pygmyp1
+Polytelis swainsonii_superb parrot_suppar1
+Polytelis anthopeplus_periquito-regente_regpar1
+Polytelis alexandrae_princess parrot_alepar1
+Alisterus scapularis_australian king-parrot_aukpar1
+Alisterus amboinensis_moluccan king-parrot_mokpar1
+Alisterus chloropterus_papuan king-parrot_pakpar1
+Aprosmictus jonquillaceus_papagaio-de-timor_olspar1
+Aprosmictus erythropterus_red-winged parrot_rewpar1
+Alisterus scapularis x Aprosmictus erythropterus_australian king-parrot x red-winged parrot (hybrid)_x00954
+Prioniturus mada_buru racquet-tail_burtai1
+Prioniturus platurus_golden-mantled racquet-tail_gmrtai1
+Prioniturus waterstradti_mindanao racquet-tail_mirtai1
+Prioniturus montanus_luzon racquet-tail_luzrat1
+Prioniturus platenae_blue-headed racquet-tail_bhrtai1
+Prioniturus mindorensis_mindoro racquet-tail_minrat1
+Prioniturus verticalis_blue-winged racquet-tail_bwrtai1
+Prioniturus flavicans_yellow-breasted racquet-tail_yebrat1
+Prioniturus luconensis_green racquet-tail_grrtai1
+Prioniturus discurus_blue-crowned racquet-tail_bcrtai1
+Prioniturus discurus whiteheadi_blue-crowned racquet-tail (Blue-crowned)_bucrat1
+Prioniturus discurus discurus_blue-crowned racquet-tail (Blue-capped)_bucrat2
+Prioniturus sp._racquet-tail sp._racque1
+Eclectus roratus_moluccan eclectus_eclpar1
+Eclectus cornelia_sumba eclectus_eclpar2
+Eclectus riedeli_tanimbar eclectus_eclpar3
+Eclectus polychloros_papuan eclectus_eclpar4
+Eclectus infectus_oceanic eclectus_ocepar1
+Eclectus sp._eclectus sp._eclpar
+Geoffroyus geoffroyi_papagaio-de-faces-vermelhas_recpar2
+Geoffroyus simplex_blue-collared parrot_blcpar3
+Geoffroyus heteroclitus_singing parrot_sinpar1
+Geoffroyus heteroclitus heteroclitus_singing parrot (Northern)_sinpar2
+Geoffroyus heteroclitus hyacinthinus_singing parrot (Rennell)_sinpar3
+Psittinus cyanurus_blue-rumped parrot_blrpar1
+Psittinus abbotti_simeulue parrot_burpar5
+Mascarinus mascarinus_mascarene parrot_maspar1
+Psittacula eupatria_periquito-alexandrino_alepar2
+Psittacula wardi_seychelles parakeet_seypar2
+Psittacula krameri_periquito-rabijunco_rorpar
+Psittacula eupatria/krameri_periquito-alexandrino/periquito-rabijunco_y01061
+Psittacula eques_echo parakeet_maupar1
+Psittacula himalayana_slaty-headed parakeet_slhpar1
+Psittacula finschii_gray-headed parakeet_gyhpar2
+Psittacula cyanocephala_plum-headed parakeet_plhpar1
+Psittacula krameri x cyanocephala_rose-ringed x plum-headed parakeet (hybrid)_x01023
+Psittacula himalayana x cyanocephala_slaty-headed x plum-headed parakeet (hybrid)_x00955
+Psittacula roseata_blossom-headed parakeet_blhpar3
+Psittacula columboides_malabar parakeet_malpar1
+Psittacula calthrapae_layard's parakeet_laypar1
+Psittacula derbiana_derbyan parakeet_derpar1
+Psittacula alexandri_red-breasted parakeet_rebpar4
+Psittacula caniceps_nicobar parakeet_nicpar1
+Psittacula exsul_newton's parakeet_newpar2
+Psittacula longicauda_long-tailed parakeet_lotpar2
+Psittacula longicauda tytleri_long-tailed parakeet (Andaman)_lotpar3
+Psittacula longicauda nicobarica_long-tailed parakeet (Nicobar)_lotpar6
+Psittacula longicauda longicauda/defontainei_long-tailed parakeet (Long-tailed)_lotpar5
+Psittacula longicauda modesta_long-tailed parakeet (Enggano)_lotpar4
+Psittacula sp._periquito (Psittacula) sp._psitta1
+Lophopsittacus bensoni_mauritius gray parrot_magpar1
+Lophopsittacus mauritianus_broad-billed parrot_brbpar3
+Necropsittacus rodricanus_rodrigues parrot_rodpar1
+Psittacella picta_painted tiger-parrot_patpar1
+Psittacella picta lorentzi_painted tiger-parrot (Snow Mountains)_paitip1
+Psittacella picta picta/excelsa_painted tiger-parrot (Eastern)_paitip2
+Psittacella brehmii_brehm's tiger-parrot_brtpar2
+Psittacella modesta_modest tiger-parrot_motpar1
+Psittacella madaraszi_madarasz's tiger-parrot_matpar1
+Psittacella sp._tiger-parrot sp._tigerp1
+Tanygnathus gramineus_black-lored parrot_bllpar1
+Tanygnathus megalorynchos_papagaio-de-bico-largo_grbpar1
+Tanygnathus lucionensis_blue-naped parrot_blnpar1
+Tanygnathus everetti_blue-backed parrot_azrpar8
+Tanygnathus sumatranus_azure-rumped parrot_azrpar9
+Tanygnathus everetti/sumatranus_blue-backed/azure-rumped parrot_azrpar1
+Pezoporus wallicus_ground parrot_gropar1
+Pezoporus wallicus flaviventris_ground parrot (Western)_gropar2
+Pezoporus wallicus wallicus_ground parrot (Eastern)_gropar3
+Pezoporus occidentalis_night parrot_nigpar2
+Neopsephotus bourkii_bourke's parrot_boupar2
+Neophema chrysostoma_blue-winged parrot_blwpar3
+Neophema elegans_elegant parrot_elepar1
+Neophema petrophila_rock parrot_rocpar1
+Neophema chrysogaster_orange-bellied parrot_orbpar1
+Neophema pulchella_turquoise parrot_turpar1
+Neophema splendida_scarlet-chested parrot_sccpar1
+Neophema sp._Neophema sp._neophe1
+Lathamus discolor_swift parrot_swipar1
+Prosopeia splendens_crimson shining-parrot_crspar1
+Prosopeia tabuensis_red shining-parrot_respar1
+Prosopeia personata_masked shining-parrot_maspar2
+Eunymphicus cornutus_horned parakeet_horpar2
+Eunymphicus uvaeensis_ouvea parakeet_horpar3
+Cyanoramphus ulietanus_raiatea parakeet_raipar1
+Cyanoramphus zealandicus_black-fronted parakeet_blfpar2
+Cyanoramphus unicolor_antipodes parakeet_antpar1
+Cyanoramphus novaezelandiae_red-crowned parakeet_refpar4
+Cyanoramphus hochstetteri_reischek's parakeet_reipar1
+Cyanoramphus saisseti_new caledonian parakeet_necpar1
+Cyanoramphus cookii_norfolk island parakeet_noipar1
+Cyanoramphus cookii cookii_norfolk island parakeet (Norfolk I.)_noipar2
+Cyanoramphus cookii subflavescens_norfolk island parakeet (Lord Howe I.)_noipar3
+Cyanoramphus auriceps_yellow-crowned parakeet_yefpar3
+Cyanoramphus novaezelandiae x auriceps_red-crowned x yellow-crowned parakeet (hybrid)_x01054
+Cyanoramphus forbesi_chatham islands parakeet_chipar1
+Cyanoramphus novaezelandiae x forbesi_red-crowned x chatham islands parakeet (hybrid)_x01100
+Cyanoramphus malherbi_malherbe's parakeet_malpar2
+Cyanoramphus sp._Cyanoramphus sp._cyanor1
+Barnardius zonarius_australian ringneck_polpar1
+Barnardius zonarius semitorquatus_australian ringneck (Twenty-eight)_polpar3
+Barnardius zonarius zonarius_australian ringneck (Port Lincoln)_polpar2
+Barnardius zonarius barnardi_australian ringneck (Mallee)_malrin2
+Barnardius zonarius macgillivrayi_australian ringneck (Cloncurry)_malrin3
+Barnardius zonarius semitorquatus x zonarius_australian ringneck (Twenty-eight x Port Lincoln)_ausrin1
+Barnardius zonarius zonarius x barnardi_australian ringneck (Port Lincoln x Mallee)_ausrin2
+Platycercus caledonicus_green rosella_greros2
+Platycercus elegans_crimson rosella_criros2
+Platycercus elegans [elegans Group]_crimson rosella (Crimson)_criros1
+Platycercus elegans flaveolus_crimson rosella (Yellow)_yelros1
+Platycercus elegans [elegans Group] x flaveolus_crimson rosella (Crimson x Yellow)_criros3
+Platycercus elegans adelaidae/subadelaidae_crimson rosella (Adelaide)_aderos1
+Platycercus venustus_northern rosella_norros1
+Platycercus eximius_eastern rosella_easros1
+Platycercus eximius (Domestic type)_eastern rosella (Domestic type)_easros5
+Platycercus caledonicus x eximius_green x eastern rosella (hybrid)_x00807
+Platycercus elegans x eximius_crimson x eastern rosella (hybrid)_x00808
+Platycercus adscitus_pale-headed rosella_pahros1
+Platycercus eximius x adscitus_eastern x pale-headed rosella (hybrid)_x00707
+Platycercus elegans x adscitus_crimson x pale-headed rosella (hybrid)_x00956
+Platycercus icterotis_western rosella_wesros1
+Platycercus sp._rosella sp._rosell1
+Northiella haematogaster_greater bluebonnet_bluebo1
+Northiella haematogaster haematogaster/pallescens_greater bluebonnet (Yellow-vented)_bluebo2
+Northiella haematogaster haematorrhoa_greater bluebonnet (Red-vented)_bluebo3
+Northiella narethae_naretha bluebonnet_bluebo4
+Psephotus haematonotus_red-rumped parrot_rerpar1
+Psephotellus varius_mulga parrot_mulpar1
+Psephotellus dissimilis_hooded parrot_hoopar1
+Psephotellus chrysopterygius_golden-shouldered parrot_gospar1
+Psephotellus pulcherrimus_paradise parrot_parpar2
+Purpureicephalus spurius_red-capped parrot_recpar1
+Nannopsittacus melanogenia_dusky-cheeked fig-parrot_orbfip1
+Nannopsittacus gulielmitertii_blue-fronted fig-parrot_orbfip2
+Nannopsittacus nigrifrons_black-fronted fig-parrot_crbfip1
+Nannopsittacus nigrifrons nigrifrons_black-fronted fig-parrot (Black-fronted)_orbfip3
+Nannopsittacus nigrifrons amabilis/ramuensis_black-fronted fig-parrot (Creamy-breasted)_orbfip4
+Cyclopsitta diophthalma_double-eyed fig-parrot_defpar1
+Cyclopsitta diophthalma [diophthalma Group]_double-eyed fig-parrot (Double-eyed)_doefip1
+Cyclopsitta diophthalma coxeni_double-eyed fig-parrot (Coxen's)_doefip2
+Cyclopsitta desmarestii_large fig-parrot_lafpar1
+Cyclopsitta desmarestii [desmarestii Group]_large fig-parrot (Large)_larfip1
+Cyclopsitta desmarestii godmani_large fig-parrot (Yellow-naped)_larfip2
+Cyclopsitta desmarestii cervicalis_large fig-parrot (Red-faced)_larfip3
+Cyclopsitta edwardsii_edwards's fig-parrot_edfpar1
+Cyclopsitta salvadorii_salvadori's fig-parrot_safpar1
+Nannopsittacus/Cyclopsitta sp._fig-parrot sp._obfpar1
+Bolbopsittacus lunulatus_guaiabero_guaiab1
+Melopsittacus undulatus_periquito-comum_budger
+Melopsittacus undulatus (Domestic type)_periquito-comum (forma doméstica)_budger1
+Oreopsittacus arfaki_plum-faced lorikeet_plflor1
+Charminetta wilhelminae_pygmy lorikeet_pyglor1
+Hypocharmosyna rubronotata_red-fronted lorikeet_reflor2
+Hypocharmosyna placentis_red-flanked lorikeet_reflor1
+Charmosynopsis toxopei_blue-fronted lorikeet_blflor1
+Charmosynopsis pulchella_fairy lorikeet_failor1
+Charmosyna multistriata_striated lorikeet_strlor1
+Charmosyna josefinae_josephine's lorikeet_joslor1
+Charmosyna papou_west papuan lorikeet_paplor1
+Charmosyna stellae_stella's lorikeet_paplor3
+Vini margarethae_duchess lorikeet_duclor1
+Vini meeki_meek's lorikeet_meelor1
+Vini diadema_new caledonian lorikeet_neclor1
+Vini rubrigularis_red-chinned lorikeet_reclor1
+Vini palmarum_palm lorikeet_pallor1
+Vini amabilis_red-throated lorikeet_retlor1
+Vini solitaria_collared lory_collor1
+Vini australis_blue-crowned lorikeet_blclor2
+Vini ultramarina_ultramarine lorikeet_ultlor1
+Vini stepheni_stephen's lorikeet_stelor1
+Vini kuhlii_kuhl's lorikeet_kuhlor1
+Vini peruviana_blue lorikeet_blulor1
+Neopsittacus musschenbroekii_yellow-billed lorikeet_yeblor2
+Neopsittacus pullicauda_orange-billed lorikeet_orblor1
+Neopsittacus musschenbroekii/pullicauda_yellow-billed/orange-billed lorikeet_y00874
+Lorius albidinucha_white-naped lory_whnlor2
+Lorius chlorocercus_yellow-bibbed lory_yeblor1
+Lorius garrulus_chattering lory_chalor1
+Lorius domicella_purple-naped lory_punlor1
+Lorius hypoinochrous_purple-bellied lory_publor1
+Lorius lory_black-capped lory_blclor1
+Psitteuteles versicolor_varied lorikeet_varlor1
+Psitteuteles pusillus_little lorikeet_litlor1
+Psitteuteles porphyrocephalus_purple-crowned lorikeet_puclor1
+Chalcopsitta fuscata_dusky lory_duslor1
+Chalcopsitta cardinalis_cardinal lory_carlor1
+Chalcopsitta duivenbodei_brown lory_brolor1
+Chalcopsitta atra_black lory_blalor1
+Chalcopsitta scintillata_yellow-streaked lory_yeslor1
+Glossoptilus goldiei_goldie's lorikeet_gollor1
+Trichoglossus concinnus_musk lorikeet_muslor1
+Trichoglossus johnstoniae_mindanao lorikeet_minlor1
+Trichoglossus iris_periquito-íris_irilor1
+Trichoglossus ornatus_ornate lorikeet_ornlor1
+Trichoglossus meyeri_yellow-cheeked lorikeet_yaglor2
+Trichoglossus flavoviridis_sula lorikeet_yaglor3
+Trichoglossus reticulatus_papagaio-de-risca-azul_blslor1
+Trichoglossus semilarvatus_blue-eared lory_blelor1
+Trichoglossus borneus_papagaio-escarlate_redlor1
+Trichoglossus cyanogenius_black-winged lory_blwlor1
+Trichoglossus histrio_red-and-blue lory_rablor1
+Trichoglossus squamatus_violet-necked lory_vinlor1
+Trichoglossus rubiginosus_pohnpei lorikeet_pohlor1
+Trichoglossus chlorolepidotus_scaly-breasted lorikeet_scblor1
+Trichoglossus haematodus_coconut lorikeet_railor4
+Trichoglossus rosenbergii_biak lorikeet_railor6
+Trichoglossus moluccanus_rainbow lorikeet_railor5
+Trichoglossus concinnus x moluccanus_musk x rainbow lorikeet (hybrid)_x00809
+Trichoglossus chlorolepidotus x moluccanus_scaly-breasted x rainbow lorikeet (hybrid)_x00810
+Trichoglossus chlorolepidotus/moluccanus_scaly-breasted/rainbow lorikeet_y01035
+Trichoglossus sp. (Musk/Rainbow/Scaly-breasted Lorikeet hybrid)_lorikeet sp. (Musk/Rainbow/Scaly-breasted Lorikeet hybrid)_x00856
+Trichoglossus rubritorquis_red-collared lorikeet_railor7
+Trichoglossus moluccanus x rubritorquis_rainbow x red-collared lorikeet (hybrid)_x00957
+Trichoglossus moluccanus/rubritorquis_rainbow/red-collared lorikeet_y01142
+Trichoglossus euteles_periquito-de-timor_olhlor1
+Trichoglossus capistratus_marigold lorikeet_railor2
+Trichoglossus weberi_leaf lorikeet_railor8
+Trichoglossus forsteni_sunset lorikeet_railor3
+Trichoglossus sp. (rainbow lorikeet complex)_rainbow lorikeet sp._railor1
+Psittaculidae sp. (lorikeet sp.)_lorikeet sp._y00637
+Loriculus vernalis_vernal hanging-parrot_vehpar1
+Loriculus beryllinus_sri lanka hanging-parrot_cehpar1
+Loriculus philippensis_philippine hanging-parrot_phihap1
+Loriculus camiguinensis_camiguin hanging-parrot_camhap1
+Loriculus bonapartei_black-billed hanging-parrot_phihap11
+Loriculus galgulus_blue-crowned hanging-parrot_bchpar1
+Loriculus stigmatus_sulawesi hanging-parrot_suhpar1
+Loriculus sclateri_sula hanging-parrot_sulhap1
+Loriculus amabilis_moluccan hanging-parrot_mohpar1
+Loriculus catamene_sangihe hanging-parrot_sahpar2
+Loriculus aurantiifrons_papuan hanging-parrot_paphap1
+Loriculus tener_green-fronted hanging-parrot_gfhpar1
+Loriculus exilis_pygmy hanging-parrot_pyghap1
+Loriculus pusillus_yellow-throated hanging-parrot_ythpar1
+Loriculus flosculus_wallace's hanging-parrot_wahpar2
+Loriculus sp._hanging-parrot sp._hangin1
+Agapornis swindernianus_black-collared lovebird_blclov2
+Agapornis canus_gray-headed lovebird_gyhlov1
+Agapornis pullarius_red-headed lovebird_rehlov1
+Agapornis taranta_black-winged lovebird_blwlov1
+Agapornis roseicollis_inseparável-de-faces-rosadas_peflov
+Agapornis roseicollis (Domestic type)_inseparável-de-faces-rosadas (tipo doméstico)_roflov3
+Agapornis fischeri_inseparável-de-fischer_fislov1
+Agapornis fischeri (Domestic type)_inseparável-de-fischer (tipo doméstico)_fislov2
+Agapornis personatus_inseparável-de-cabeça-preta_yeclov
+Agapornis personatus (Domestic type)_inseparável-de-cabeça-preta (tipo doméstico)_yeclov1
+Agapornis fischeri x personatus_inseparável-de-fischer x inseparável-de-cabeça-preta (híbrido)_x00671
+Agapornis fischeri/personatus_fischer's/yellow-collared lovebird_y00791
+Agapornis lilianae_lilian's lovebird_lillov1
+Agapornis nigrigenis_black-cheeked lovebird_blclov1
+Agapornis sp. (Domestic type)_domestic lovebird sp. (Domestic type)_domlov1
+Agapornis sp._inseparável (Agapornis) sp._lovebi1
+Psittacus timneh_timneh parrot_grypar10
+Psittacus erithacus_papagaio-cinzento_grepar
+Psittacus erithacus erithacus_papagaio-cinzento (erithacus)_grypar2
+Psittacus erithacus princeps_papagaio-cinzento (princeps)_grypar11
+Psittacus timneh/erithacus_timneh/gray parrot_y01246
+Poicephalus fuscicollis_brown-necked parrot_brnpar1
+Poicephalus fuscicollis fuscicollis_brown-necked parrot (Brown-necked)_bnnpar3
+Poicephalus fuscicollis suahelicus_brown-necked parrot (Gray-headed)_bnnpar4
+Poicephalus robustus_cape parrot_bnnpar2
+Poicephalus gulielmi_red-fronted parrot_refpar5
+Poicephalus gulielmi fantiensis_red-fronted parrot (Guinean)_refpar6
+Poicephalus gulielmi gulielmi/massaicus_red-fronted parrot (Red-fronted)_refpar7
+Poicephalus meyeri_meyer's parrot_meypar1
+Poicephalus rueppellii_rüppell's parrot_ruepar1
+Poicephalus cryptoxanthus_brown-headed parrot_brhpar2
+Poicephalus meyeri x cryptoxanthus_meyer's x brown-headed parrot (hybrid)_x01135
+Poicephalus crassus_niam-niam parrot_ninpar1
+Poicephalus rufiventris_red-bellied parrot_rebpar1
+Poicephalus senegalus_periquito-massarongo_senpar
+Poicephalus flavifrons_yellow-fronted parrot_yefpar4
+Poicephalus sp._Poicephalus sp._poicep1
+Touit batavicus_lilac-tailed parrotlet_litpar2
+Touit huetii_apuim-de-asa-vermelha_scspar1
+Touit costaricensis_red-fronted parrotlet_refpar1
+Touit dilectissimus_blue-fronted parrotlet_bufpar1
+Touit purpuratus_apuim-de-costas-azuis_sarpar2
+Touit melanonotus_apuim-de-costas-pretas_brbpar1
+Touit surdus_apuim-de-cauda-amarela_gotpar2
+Touit stictopterus_spot-winged parrotlet_spwpar2
+Touit sp._Touit sp._touit1
+Psilopsiagon aymara_gray-hooded parakeet_gyhpar1
+Psilopsiagon aurifrons_mountain parakeet_moupar2
+Bolborhynchus lineola_barred parakeet_barpar1
+Bolborhynchus ferrugineifrons_rufous-fronted parakeet_rufpar1
+Bolborhynchus orbygnesius_andean parakeet_andpar1
+Bolborhynchus lineola/orbygnesius_barred/andean parakeet_y00875
+Nannopsittaca panychlora_periquito-dos-tepuis_teppar1
+Nannopsittaca dachilleae_periquito-da-amazônia_amapar1
+Myiopsitta monachus_caturrita_monpar
+Myiopsitta monachus [monachus Group]_caturrita [grupo monachus]_monpar1
+Myiopsitta monachus luchsi_caturrita (luchsi)_monpar2
+Brotogeris sanctithomae_periquito-testinha_tuipar1
+Brotogeris tirica_periquito-rico_plapar1
+Brotogeris versicolurus_periquito-da-campina_whwpar
+Brotogeris chiriri_periquito-de-encontro-amarelo_yecpar
+Brotogeris versicolurus x chiriri_periquito-da-campina x periquito-de-encontro-amarelo (híbrido)_wwxpar1
+Brotogeris versicolurus/chiriri_periquito-da-campina/de-encontro-amarelo_y00483
+Brotogeris pyrrhoptera_gray-cheeked parakeet_gycpar1
+Brotogeris jugularis_orange-chinned parakeet_orcpar
+Brotogeris cyanoptera_periquito-de-asa-azul_cowpar1
+Brotogeris chrysoptera_periquito-de-asa-dourada_gowpar2
+Brotogeris sp._Brotogeris sp._brotog1
+Pionopsitta pileata_cuiú-cuiú_recpar3
+Triclaria malachitacea_sabiá-cica_blbpar4
+Hapalopsittaca amazonina_rusty-faced parrot_rufpar2
+Hapalopsittaca fuertesi_indigo-winged parrot_inwpar1
+Hapalopsittaca pyrrhops_red-faced parrot_refpar2
+Hapalopsittaca melanotis_black-winged parrot_blwpar1
+Pyrilia haematotis_brown-hooded parrot_brhpar1
+Pyrilia pulchra_rose-faced parrot_rofpar2
+Pyrilia pyrilia_saffron-headed parrot_sahpar1
+Pyrilia barrabandi_curica-de-bochecha-laranja_orcpar2
+Pyrilia caica_curica-de-chapeu-preto_caipar2
+Pyrilia aurantiocephala_papagaio-de-cabeça-laranja_balpar1
+Pyrilia vulturina_curica-urubu_vulpar1
+Pyrilia sp._Pyrilia sp._pyrili1
+Pionus fuscus_maitaca-roxa_duspar1
+Pionus sordidus_red-billed parrot_rebpar2
+Pionus maximiliani_maitaca-verde_schpar1
+Pionus tumultuosus_speckle-faced parrot_spfpar1
+Pionus tumultuosus seniloides_speckle-faced parrot (White-capped)_spfpar2
+Pionus tumultuosus tumultuosus_speckle-faced parrot (Plum-crowned)_spfpar3
+Pionus menstruus_maitaca-de-cabeça-azul/maitaca-de-barriga-azul_blhpar1
+Pionus menstruus menstruus/rubrigularis_maitaca-de-cabeça-azul_buhpar1
+Pionus menstruus reichenowi_maitaca-de-barriga-azul_buhpar2
+Pionus senilis_white-crowned parrot_whcpar
+Pionus chalcopterus_bronze-winged parrot_brwpar1
+Pionus sp._Pionus sp._pionus1
+Graydidascalus brachyurus_curica-verde_shtpar2
+Alipiopsitta xanthops_papagaio-galego_yefpar5
+Amazona festiva_papagaio-da-várzea_fespar1
+Amazona festiva bodini_papagaio-das-várzeas (bodini)_fespar2
+Amazona festiva festiva_papagaio-das-várzeas (festiva)_fespar3
+Amazona vinacea_papagaio-de-peito-roxo_vinpar1
+Amazona tucumana_tucuman amazon_tucpar1
+Amazona pretrei_papagaio-charão_respar2
+Amazona viridigenalis_red-crowned amazon_recpar
+Amazona finschi_lilac-crowned amazon_licpar
+Amazona viridigenalis x finschi_red-crowned x lilac-crowned amazon (hybrid)_x00958
+Amazona viridigenalis/finschi_red-crowned/lilac-crowned amazon_y01219
+Amazona autumnalis_papagaio-diadema_relpar
+Amazona autumnalis autumnalis/salvini_papagaio-diadema (autumnalis/salvini)_relpar10
+Amazona autumnalis lilacina_papagaio-diadema (lilacina)_relpar9
+Amazona autumnalis diadema_papagaio-diadema (diadema)_relpar4
+Amazona viridigenalis x autumnalis_red-crowned x red-lored amazon (hybrid)_x00857
+Amazona dufresniana_papagaio-de-bochecha-azul_blcpar2
+Amazona rhodocorytha_chauá_rebpar7
+Amazona arausiaca_red-necked amazon_renpar1
+Amazona martinicana_martinique amazon_marpar1
+Amazona versicolor_st. lucia amazon_stlpar1
+Amazona auropalliata_yellow-naped amazon_yenpar1
+Amazona oratrix_yellow-headed amazon_yehpar
+Amazona oratrix tresmariae_yellow-headed amazon (Tres Marias Is.)_yehpar2
+Amazona oratrix [oratrix Group]_yellow-headed amazon (Mainland)_yehpar1
+Amazona auropalliata x oratrix_yellow-naped x yellow-headed amazon (hybrid)_x01021
+Amazona auropalliata/oratrix_yellow-naped/yellow-headed amazon_y01195
+Amazona ochrocephala_papagaio-campeiro_ywcpar
+Amazona barbadensis_yellow-shouldered amazon_yespar1
+Amazona aestiva_papagaio-verdadeiro_bufpar
+Amazona agilis_black-billed amazon_blbpar1
+Amazona albifrons_white-fronted amazon_whfpar1
+Amazona xantholora_yellow-lored amazon_yelpar1
+Amazona collaria_yellow-billed amazon_yebpar1
+Amazona agilis/collaria_black-billed/yellow-billed amazon_y00876
+Amazona leucocephala_cuban amazon_cubpar1
+Amazona leucocephala leucocephala_cuban amazon (Cuban)_cubpar3
+Amazona leucocephala bahamensis_cuban amazon (Bahamas)_cubpar4
+Amazona leucocephala caymanensis/hesterna_cuban amazon (Cayman Is.)_cubpar5
+Amazona ventralis_hispaniolan amazon_hispar1
+Amazona vittata_puerto rican amazon_purpar1
+Amazona farinosa_papagaio-moleiro_meapar
+Amazona farinosa guatemalae/virenticeps_papagaio-moleiro (guatemalae/virenticeps)_meapar1
+Amazona farinosa farinosa_papagaio-moleiro (farinosa)_meapar2
+Amazona kawalli_papagaio-dos-garbes_kawpar1
+Amazona imperialis_imperial amazon_imppar1
+Amazona violacea_guadeloupe amazon_guapar1
+Amazona brasiliensis_papagaio-de-cara-roxa_retpar1
+Amazona guildingii_st. vincent amazon_stvpar1
+Amazona amazonica_curica_orwpar
+Amazona viridigenalis x amazonica_red-crowned x orange-winged amazon (hybrid)_x01168
+Amazona mercenarius_scaly-naped amazon_scnpar1
+Amazona sp._Amazona sp._amazon
+Forpus modestus_periquito-santo-de-bico-escuro/do-norte_dubpar1
+Forpus modestus modestus_periquito-santo-de-bico-escuro_dubpar2
+Forpus modestus sclateri_periquito-santo-do-norte_dubpar3
+Forpus cyanopygius_mexican parrotlet_mexpar1
+Forpus cyanopygius cyanopygius_mexican parrotlet (Mexican)_mexpar2
+Forpus cyanopygius insularis_mexican parrotlet (Tres Marias Is.)_mexpar3
+Forpus spengeli_turquoise-winged parrotlet_buwpar1
+Forpus crassirostris_tuim-de-bico-grosso_buwpar2
+Forpus xanthopterygius_tuim_buwpar3
+Forpus passerinus_periquito-santo_grrpar1
+Forpus conspicillatus_spectacled parrotlet_spepar1
+Forpus coelestis_pacific parrotlet_pacpar2
+Forpus xanthops_yellow-faced parrotlet_yefpar2
+Forpus sp._Forpus sp._forpus1
+Pionites melanocephalus_marianinha-de-cabeça-preta_blhpar4
+Pionites leucogaster_marianinha-de-cabeça-amarela_whbpar1
+Pionites leucogaster xanthomerius_marianinha-de-cabeça-amarela (xanthomerius)_whbpar2
+Pionites leucogaster xanthurus_marianinha-de-cabeça-amarela (xanthurus)_whbpar3
+Pionites leucogaster leucogaster_marianinha-de-cabeça-amarela (leucogaster)_whbpar4
+Deroptyus accipitrinus_anacã_refpar3
+Pyrrhura cruentata_tiriba-grande_bltpar2
+Pyrrhura devillei_tiriba-fogo_blwpar2
+Pyrrhura frontalis_tiriba-de-testa-vermelha_mabpar
+Pyrrhura frontalis frontalis_tiriba-de-testa-vermelha (frontalis)_mabpar2
+Pyrrhura frontalis chiripepe_tiriba-de-testa-vermelha (chiripepe)_mabpar1
+Pyrrhura lepida_tiriba-pérola_peapar1
+Pyrrhura lepida lepida_tiriba-pérola (lepida)_peapar2
+Pyrrhura lepida anerythra_tiriba-do-xingu_peapar3
+Pyrrhura lepida coerulescens_tiriba-pérola (coerulescens)_peapar4
+Pyrrhura perlata_tiriba-de-barriga-vermelha_crbpar1
+Pyrrhura molinae_cara-suja-do-pantanal_gncpar
+Pyrrhura pfrimeri_tiriba-do-paranã_pfrpar1
+Pyrrhura griseipectus_cara-suja_gybpar1
+Pyrrhura leucotis_tiriba-de-orelha-branca_mafpar3
+Pyrrhura griseipectus/leucotis_cara-suja/tiriba-de-orelha-branca_mafpar2
+Pyrrhura picta_tiriba-de-testa-azul_paipar1
+Pyrrhura picta eisenmanni_tiriba-de-testa-azul (eisenmanni)_paipar3
+Pyrrhura picta subandina_tiriba-de-testa-azul (subandina)_paipar4
+Pyrrhura picta caeruleiceps_tiriba-de-testa-azul (caeruleiceps)_paipar5
+Pyrrhura picta emma_tiriba-de-testa-azul (emma)_paipar6
+Pyrrhura picta picta_tiriba-de-testa-azul (picta)_paipar2
+Pyrrhura amazonum_tiriba-de-hellmayr/tiriba-do-madeira_sanpar2
+Pyrrhura amazonum amazonum_tiriba-de-hellmayr_sanpar3
+Pyrrhura amazonum snethlageae_tiriba-do-madeira_sanpar4
+Pyrrhura amazonum lucida_tiriba-de-hellmayr/tiriba-do-madeira (lucida)_sanpar5
+Pyrrhura lucianii_tiriba-de-deville_bonpar1
+Pyrrhura roseifrons_tiriba-de-cabeça-vermelha_rofpar3
+Pyrrhura roseifrons peruviana/dilutissima_tiriba-de-cabeça-vermelha (peruviana/dilutissima)_rofpar5
+Pyrrhura roseifrons parvifrons_tiriba-de-cabeça-vermelha (parvifrons)_rofpar1
+Pyrrhura roseifrons roseifrons_tiriba-de-cabeça-vermelha (roseifrons)_rofpar4
+Pyrrhura viridicata_santa marta parakeet_sampar1
+Pyrrhura egregia_tiriba-de-cauda-roxa_fispar1
+Pyrrhura melanura_tiriba-fura-mata_matpar2
+Pyrrhura melanura pacifica_tiriba-fura-mata (pacifica)_matpar4
+Pyrrhura melanura chapmani_tiriba-fura-mata (chapmani)_matpar5
+Pyrrhura melanura [melanura Group]_tiriba-fura-mata [grupo melanura]_matpar3
+Pyrrhura orcesi_el oro parakeet_elopar1
+Pyrrhura rupicola_tiriba-rupestre_blcpar1
+Pyrrhura albipectus_white-necked parakeet_whnpar1
+Pyrrhura calliptera_brown-breasted parakeet_brbpar2
+Pyrrhura hoematotis_red-eared parakeet_reepar1
+Pyrrhura rhodocephala_rose-headed parakeet_rohpar1
+Pyrrhura hoffmanni_sulphur-winged parakeet_suwpar1
+Pyrrhura sp._Pyrrhura sp._pyrrhu1
+Enicognathus ferrugineus_austral parakeet_auspar1
+Enicognathus leptorhynchus_slender-billed parakeet_slbpar1
+Enicognathus ferrugineus/leptorhynchus_austral/slender-billed parakeet_y00877
+Cyanoliseus patagonus_periquito-das-barreiras_burpar
+Cyanoliseus patagonus andinus_periquito-das-barreiras (andinus)_burpar1
+Cyanoliseus patagonus patagonus/conlara_periquito-das-barreiras (patagonus/conlara)_burpar3
+Cyanoliseus patagonus bloxami_periquito-das-barreiras (bloxami)_burpar2
+Anodorhynchus hyacinthinus_arara-azul_hyamac1
+Anodorhynchus glaucus_arara-azul-pequena_glamac1
+Anodorhynchus leari_arara-azul-de-lear_indmac1
+Rhynchopsitta pachyrhyncha_thick-billed parrot_thbpar
+Rhynchopsitta terrisi_maroon-fronted parrot_mafpar1
+Eupsittula nana_olive-throated parakeet_oltpar1
+Eupsittula nana astec/vicinalis_olive-throated parakeet (Aztec)_oltpar2
+Eupsittula nana nana_olive-throated parakeet (Jamaican)_oltpar3
+Eupsittula canicularis_orange-fronted parakeet_orfpar
+Eupsittula aurea_periquito-rei_pefpar1
+Eupsittula pertinax_periquito-de-bochecha-parda_brtpar1
+Eupsittula pertinax ocularis_periquito-de-bochecha-parda (ocularis)_bntpar1
+Eupsittula pertinax [pertinax Group]_periquito-de-bochecha-parda [grupo pertinax]_bntpar2
+Eupsittula cactorum_periquito-da-caatinga_cacpar1
+Conuropsis carolinensis_carolina parakeet_carpar
+Aratinga weddellii_periquito-de-cabeça-suja_duhpar
+Aratinga nenday_periquito-de-cabeça-preta_bkhpar
+Aratinga solstitialis_jandaia-amarela_sunpar1
+Aratinga maculata_cacaué_subpar1
+Aratinga jandaya_jandaia-verdadeira_janpar1
+Aratinga auricapillus_jandaia-de-testa-vermelha_gocpar2
+Cyanopsitta spixii_ararinha-azul_spimac1
+Orthopsittaca manilatus_maracanã-do-buriti_rebmac2
+Primolius maracana_maracanã_buwmac1
+Primolius couloni_maracanã-de-cabeça-azul_buhmac1
+Primolius auricollis_maracanã-de-colar_yecmac
+Ara ararauna_arara-canindé_baymac
+Ara glaucogularis_blue-throated macaw_bltmac1
+Ara severus_maracanã-guaçu_chfmac1
+Ara tricolor_cuban macaw_cubmac1
+Ara rubrogenys_red-fronted macaw_refmac1
+Ara militaris_military macaw_milmac
+Ara ambiguus_great green macaw_grgmac
+Ara macao_araracanga_scamac1
+Ara ararauna x macao_arara-canindé x araracanga (híbrido)_x00888
+Ara ambiguus x macao_great green x scarlet macaw (hybrid)_x00405
+Ara chloropterus_arara-vermelha_ragmac1
+Ara ararauna x chloropterus_arara-canindé x arara-vermelha (híbrido)_x00406
+Ara macao/chloropterus_araracanga/arara-vermelha_y00792
+Ara sp._Ara sp._larmac1
+Leptosittaca branickii_golden-plumed parakeet_goppar1
+Ognorhynchus icterotis_yellow-eared parrot_yeepar1
+Guaruba guarouba_ararajuba_golpar3
+Thectocercus acuticaudatus_aratinga-de-testa-azul_bucpar
+Thectocercus acuticaudatus [haemorrhous Group]_aratinga-de-testa-azul [grupo haemorrhous]_bucpar1
+Thectocercus acuticaudatus acuticaudatus/neumanni_aratinga-de-testa-azul (acuticaudatus/neumanni)_bucpar9
+Diopsittaca nobilis_maracanã-pequena_resmac2
+Diopsittaca nobilis nobilis_maracanã-pequena (nobilis)_resmac1
+Diopsittaca nobilis cumanensis/longipennis_maracanã-pequena (cumanensis/longipennis)_resmac3
+Orthopsittaca/Primolius/Diopsittaca sp._Orthopsittaca/Primolius/Diopsittaca sp._smamac1
+Psittacara holochlorus_green parakeet_grnpar
+Psittacara holochlorus holochlorus/brewsteri_green parakeet (Green)_grnpar1
+Psittacara holochlorus rubritorquis_green parakeet (Red-throated)_grnpar3
+Psittacara brevipes_socorro parakeet_grnpar2
+Psittacara strenuus_pacific parakeet_pacpar1
+Psittacara holochlorus x strenuus_green x pacific parakeet (hybrid)_x01022
+Psittacara holochlorus/strenuus_green/pacific parakeet_y00878
+Psittacara finschi_crimson-fronted parakeet_crfpar
+Psittacara holochlorus x finschi_green x crimson-fronted parakeet (hybrid)_x00959
+Psittacara wagleri_scarlet-fronted parakeet_scfpar2
+Psittacara frontatus_cordilleran parakeet_scfpar3
+Psittacara wagleri/frontatus_scarlet-fronted/cordilleran parakeet_scfpar1
+Psittacara mitratus_mitred parakeet_mitpar
+Psittacara mitratus [mitratus Group]_mitred parakeet (Mitred)_mitpar1
+Psittacara mitratus alticola_mitred parakeet (Chapman's)_mitpar2
+Psittacara frontatus/mitratus_cordilleran/mitred parakeet_y00793
+Psittacara erythrogenys_red-masked parakeet_rempar
+Psittacara mitratus/erythrogenys_mitred/red-masked parakeet_y00794
+Psittacara leucophthalmus_periquitão_whepar2
+Psittacara euops_cuban parakeet_cubpar2
+Psittacara chloropterus_hispaniolan parakeet_hispar
+Psittacara maugei_puerto rican parakeet_purpar2
+Psittacara labati_guadeloupe parakeet_guapar2
+Psittacara sp._Psittacara sp._psitta2
+Eupsittula/Aratinga/Thectocercus/Psittacara sp._Eupsittula/Aratinga/Thectocercus/Psittacara sp._aratin
+Psittaciformes sp. (parakeet sp.)_psittaciformes sp. (parakeet sp.)_parake
+Psittaciformes sp. (parrot sp.)_psittaciformes sp. (parrot sp.)_parrot
+Traversia lyalli_stephens island wren_stiwre1
+Acanthisitta chloris_rifleman_riflem1
+Xenicus longipes_bush wren_buswre1
+Xenicus gilviventris_south island wren_soiwre1
+Smithornis capensis_african broadbill_afrbro1
+Smithornis sharpei_gray-headed broadbill_gyhbro1
+Smithornis sharpei zenkeri_gray-headed broadbill (Zenker's)_gyhbro2
+Smithornis sharpei sharpei_gray-headed broadbill (Sharpe's)_gyhbro3
+Smithornis sharpei eurylaemus_gray-headed broadbill (Gray-headed)_gyhbro4
+Smithornis rufolateralis_rufous-sided broadbill_rusbro1
+Smithornis sp._Smithornis sp._smitho1
+Calyptomena viridis_green broadbill_grebro1
+Calyptomena hosii_hose's broadbill_hosbro1
+Calyptomena whiteheadi_whitehead's broadbill_whibro1
+Pseudocalyptomena graueri_grauer's broadbill_grabro1
+Psarisomus dalhousiae_long-tailed broadbill_lotbro1
+Corydon sumatranus_dusky broadbill_dusbro1
+Sarcophanops samarensis_visayan broadbill_visbro1
+Sarcophanops steerii_wattled broadbill_watbro1
+Serilophus lunatus_silver-breasted broadbill_sibbro3
+Serilophus rubropygius_gray-lored broadbill_sibbro2
+Serilophus lunatus/rubropygius_silver-breasted/gray-lored broadbill_sibbro1
+Cymbirhynchus macrorhynchos_black-and-red broadbill_barbro1
+Cymbirhynchus macrorhynchos affinis_black-and-red broadbill (Irrawaddy)_barbro2
+Cymbirhynchus macrorhynchos [macrorhynchos Group]_black-and-red broadbill (Black-and-red)_barbro3
+Eurylaimus javanicus_banded broadbill_banbro1
+Eurylaimus javanicus [harterti Group]_banded broadbill (Banded)_banbro2
+Eurylaimus javanicus javanicus_banded broadbill (Javan)_banbro3
+Eurylaimus ochromalus_black-and-yellow broadbill_baybro1
+Eurylaimus javanicus/ochromalus_banded/black-and-yellow broadbill_y00879
+Eurylaimidae sp._asian broadbill sp._asibro1
+Sapayoa aenigma_sapayoa_sapayo1
+Philepitta castanea_velvet asity_velasi1
+Philepitta schlegeli_schlegel's asity_schasi1
+Neodrepanis coruscans_common sunbird-asity_sunasi1
+Neodrepanis hypoxantha_yellow-bellied sunbird-asity_yebasi1
+Neodrepanis coruscans/hypoxantha_common/yellow-bellied sunbird-asity_y00880
+Erythropitta kochi_whiskered pitta_whipit1
+Erythropitta erythrogaster_philippine pitta_rebpit1
+Erythropitta erythrogaster [erythrogaster Group]_philippine pitta (Philippine)_bubpit1
+Erythropitta erythrogaster inspeculata_philippine pitta (Talaud)_talpit1
+Erythropitta dohertyi_sula pitta_sulpit1
+Erythropitta celebensis_sulawesi pitta_sulpit4
+Erythropitta celebensis celebensis_sulawesi pitta (Sulawesi)_sulpit3
+Erythropitta celebensis caeruleitorques_sulawesi pitta (Sangihe)_sanpit1
+Erythropitta celebensis palliceps_sulawesi pitta (Siau)_siapit1
+Erythropitta rufiventris_north moluccan pitta_molpit1
+Erythropitta rubrinucha_south moluccan pitta_sompit1
+Erythropitta macklotii_papuan pitta_pappit1
+Erythropitta macklotii habenichti_papuan pitta (Northern)_pappit2
+Erythropitta macklotii [macklotii Group]_papuan pitta (Southern)_soppit1
+Erythropitta macklotii finschii_papuan pitta (D'Entrecasteaux)_pappit5
+Erythropitta novaehibernicae_bismarck pitta_bispit1
+Erythropitta novaehibernicae novaehibernicae/extima_bismarck pitta (New Ireland)_neipit1
+Erythropitta novaehibernicae splendida_bismarck pitta (Tabar)_tabpit1
+Erythropitta novaehibernicae gazellae_bismarck pitta (New Britain)_nebpit1
+Erythropitta meeki_louisiade pitta_loupit1
+Erythropitta venusta_graceful pitta_blcpit1
+Erythropitta ussheri_black-crowned pitta_bkhpit1
+Erythropitta arquata_blue-banded pitta_blbpit1
+Erythropitta granatina_garnet pitta_garpit1
+Erythropitta sp._Erythropitta sp._erythr1
+Hydrornis phayrei_eared pitta_earpit1
+Hydrornis oatesi_rusty-naped pitta_runpit1
+Hydrornis nipalensis_blue-naped pitta_blnpit1
+Hydrornis soror_blue-rumped pitta_blrpit1
+Hydrornis caeruleus_giant pitta_giapit1
+Hydrornis schneideri_schneider's pitta_schpit1
+Hydrornis irena_malayan banded-pitta_banpit3
+Hydrornis guajanus_javan banded-pitta_banpit2
+Hydrornis schwaneri_bornean banded-pitta_banpit4
+Hydrornis baudii_blue-headed pitta_blhpit1
+Hydrornis cyaneus_blue pitta_blupit1
+Hydrornis elliotii_bar-bellied pitta_babpit1
+Hydrornis gurneyi_gurney's pitta_gurpit1
+Hydrornis sp._Hydrornis sp._hydror1
+Pitta angolensis_african pitta_afrpit1
+Pitta reichenowi_green-breasted pitta_grbpit1
+Pitta brachyura_indian pitta_indpit1
+Pitta moluccensis_blue-winged pitta_blwpit1
+Pitta nympha_fairy pitta_faipit1
+Pitta abbotti_nicobar hooded pitta_hoopit4
+Pitta sordida_western hooded pitta_wehpit1
+Pitta sordida cucullata_western hooded pitta (Chestnut-crowned)_hoopit3
+Pitta sordida mulleri/bangkana_western hooded pitta (Sunda)_hoopit5
+Pitta sordida sordida/palawanensis_western hooded pitta (Philippine)_hoopit6
+Pitta sordida sanghirana_western hooded pitta (Sangihe)_hoopit7
+Pitta abbotti/sordida_nicobar/western hooded pitta_y01247
+Pitta forsteni_minahasa hooded pitta_hoopit8
+Pitta novaeguineae_eastern hooded pitta_eahpit1
+Pitta novaeguineae novaeguineae/goodfellowi_eastern hooded pitta (Papuan)_hoopit9
+Pitta novaeguineae mefoorana_eastern hooded pitta (Numfor)_hoopit10
+Pitta rosenbergii_biak hooded pitta_hoopit11
+Pitta steerii_azure-breasted pitta_azbpit1
+Pitta versicolor_noisy pitta_noipit1
+Pitta maxima_ivory-breasted pitta_ivbpit1
+Pitta maxima maxima_ivory-breasted pitta (Ivory-breasted)_ivbpit2
+Pitta maxima morotaiensis_ivory-breasted pitta (Morotai)_ivbpit3
+Pitta concinna_ornate pitta_elepit2
+Pitta elegans_elegant pitta_elepit7
+Pitta vigorsii_banda sea pitta_elepit6
+Pitta concinna/elegans/vigorsii_ornate/elegant/banda sea pitta_y00403
+Pitta anerythra_black-faced pitta_blfpit1
+Pitta megarhyncha_mangrove pitta_manpit1
+Pitta superba_superb pitta_suppit1
+Pitta iris_rainbow pitta_raipit1
+Pitta sp._pitta sp. (genus Pitta)_pitta2
+Pittidae sp._pitta sp. (genus Erythropitta/Hydrornis/Pitta)_pitta1
+Euchrepomis callinota_rufous-rumped antwren_rurant1
+Euchrepomis humeralis_zidedê-de-encontro_chsant1
+Euchrepomis sharpei_yellow-rumped antwren_yerant1
+Euchrepomis spodioptila_zidedê-de-asa-cinza_aswant1
+Euchrepomis sp._Euchrepomis sp._euchre1
+Cymbilaimus lineatus_papa-formiga-barrado_fasant1
+Cymbilaimus sanctaemariae_choca-do-bambu_bamant1
+Hypoedaleus guttatus_chocão-carijó_spbant3
+Batara cinerea_matracão_giaant2
+Mackenziaena leachii_borralhara-assobiadora_latant1
+Mackenziaena severa_borralhara_tufant1
+Frederickena viridis_borralhara-do-norte_bltant3
+Frederickena unduliger_borralhara-ondulada_undant2
+Frederickena fulva_fulvous antshrike_fulant1
+Frederickena unduliger/fulva_undulated/fulvous antshrike_y00966
+Taraba major_choró-boi_greant1
+Sakesphorus canadensis_choca-de-crista-preta_blcant4
+Sakesphorus canadensis pulchellus_choró-de-crista-preta (pulchellus)_bkcant1
+Sakesphorus canadensis [canadensis Group]_choró-de-crista-preta [grupo canadensis]_bkcant2
+Sakesphorus luctuosus_choca-d'água_gloant1
+Sakesphoroides cristatus_choca-do-nordeste_sicant1
+Sakesphoroides cristatus niedeguidonae_choca-do-nordeste (niedeguidonae)_sicant2
+Sakesphoroides cristatus cristatus_choca-do-nordeste (cristatus)_sicant3
+Radinopsyche sellowi_chorozinho-da-caatinga_caaant1
+Biatas nigropectus_papo-branco_whbant2
+Thamnophilus doliatus_choca-barrada/choca-barrada-do-nordeste_barant1
+Thamnophilus doliatus [doliatus Group]_choca-barrada_barant4
+Thamnophilus doliatus capistratus_choca-barrada-do-nordeste_barant3
+Thamnophilus ruficapillus_choca-de-chapéu-vermelho_rucant1
+Thamnophilus ruficapillus [subfasciatus Group]_choca-de-chapéu-vermelho [grupo subfasciatus]_rucant4
+Thamnophilus ruficapillus ruficapillus/cochabambae_choca-de-chapéu-vermelho (ruficapillus/cochabambae)_rucant5
+Thamnophilus torquatus_choca-de-asa-vermelha_ruwant2
+Thamnophilus ruficapillus/torquatus_rufous-capped/rufous-winged antshrike_y01248
+Thamnophilus zarumae_chapman's antshrike_chaant1
+Thamnophilus multistriatus_bar-crested antshrike_bacant2
+Thamnophilus tenuepunctatus_lined antshrike_linant1
+Thamnophilus palliatus_choca-listrada_chbant2
+Thamnophilus [undescribed form]_inirida antshrike (undescribed form)_iniant1
+Thamnophilus bernardi_collared antshrike_colant1
+Thamnophilus bernardi bernardi_collared antshrike (Collared)_colant2
+Thamnophilus bernardi shumbae_collared antshrike (shumbae)_colant3
+Thamnophilus atrinucha_black-crowned antshrike_wesant1
+Thamnophilus bridgesi_black-hooded antshrike_blhant2
+Thamnophilus schistaceus_choca-de-olho-vermelho_plwant1
+Thamnophilus murinus_choca-murina_mocant1
+Thamnophilus schistaceus/murinus_choca-d'olho-vermelho/choca-murina_y01143
+Thamnophilus nigriceps_black antshrike_blaant1
+Thamnophilus praecox_cocha antshrike_cocant1
+Thamnophilus cryptoleucus_choca-selada_casant1
+Thamnophilus nigrocinereus_choca-preta-e-cinza_blgant2
+Thamnophilus punctatus_choca-bate-cabo_norsla1
+Thamnophilus punctatus punctatus/interpositus_choca-bate-cabo (punctatus/interpositus)_norsla2
+Thamnophilus punctatus leucogaster/huallagae_choca-bate-cabo (leucogaster/huallagae)_norsla3
+Thamnophilus stictocephalus_choca-de-natterer_natsla1
+Thamnophilus sticturus_choca-da-bolívia_bolsla1
+Thamnophilus pelzelni_choca-do-planalto_plasla1
+Thamnophilus ambiguus_choca-de-sooretama_soosla1
+Thamnophilus caerulescens_choca-da-mata_varant1
+Thamnophilus unicolor_uniform antshrike_uniant2
+Thamnophilus aethiops_choca-lisa_whsant2
+Thamnophilus aroyae_upland antshrike_uplant1
+Thamnophilus melanonotus_black-backed antshrike_blbant1
+Thamnophilus melanothorax_choca-de-cauda-pintada_batant2
+Thamnophilus amazonicus_choca-canela_amaant2
+Thamnophilus insignis_choca-de-roraima_stbant1
+Thamnophilus divisorius_choca-do-acre_acrant1
+Thamnophilus sp._Thamnophilus sp._thamno1
+Rhopias gularis_choquinha-de-garganta-pintada_sttant1
+Megastictus margaritatus_choca-pintada_peaant1
+Neoctantes niger_choca-preta_blabus1
+Clytoctantes alixii_recurve-billed bushbird_rebbus1
+Clytoctantes atrogularis_choca-de-garganta-preta_ronbus1
+Thamnistes anabatinus_russet antshrike_rusant1
+Thamnistes anabatinus [anabatinus Group]_russet antshrike (Tawny)_rusant2
+Thamnistes anabatinus aequatorialis/gularis_russet antshrike (Andean)_rusant3
+Thamnistes rufescens_rufescent antshrike_rufant12
+Thamnistes anabatinus/rufescens_russet/rufescent antshrike_y01114
+Thamnophilidae sp. (antshrike sp.)_antshrike sp._antshr1
+Dysithamnus stictothorax_choquinha-de-peito-pintado_spbant5
+Dysithamnus mentalis_choquinha-lisa_plaant1
+Dysithamnus striaticeps_streak-crowned antvireo_stcant1
+Dysithamnus puncticeps_spot-crowned antvireo_spcant1
+Dysithamnus xanthopterus_choquinha-de-asa-ferrugem_rubant2
+Dysithamnus occidentalis_bicolored antvireo_bicant4
+Dysithamnus plumbeus_choquinha-chumbo_pluant3
+Dysithamnus leucostictus_white-streaked antvireo_whsant4
+Dysithamnus leucostictus leucostictus_white-streaked antvireo (White-streaked)_whsant3
+Dysithamnus leucostictus tucuyensis_white-streaked antvireo (Venezuelan)_pluant4
+Dysithamnus sp._Dysithamnus sp._antvir1
+Thamnomanes ardesiacus_uirapuru-de-garganta-preta_dutant2
+Thamnomanes saturninus_uirapuru-selado_satant1
+Thamnomanes ardesiacus/saturninus_uirapuru-de-garganta-preta/selado_y00881
+Thamnomanes caesius_ipecuá_cinant1
+Thamnomanes schistogynus_uirapuru-azul_blsant1
+Thamnomanes caesius/schistogynus_ipecuá/uirapuru-azul_y00703
+Xenornis setifrons_spiny-faced antshrike_spfant1
+Isleria hauxwelli_choquinha-de-garganta-clara_pltant1
+Isleria guttata_choquinha-de-barriga-ruiva_rubant3
+Pygiptila stellaris_choca-cantadora_spwant2
+Epinecrophylla fulviventris_checker-throated stipplethroat_chtant1
+Epinecrophylla gutturalis_choquinha-de-barriga-parda_brbant2
+Epinecrophylla leucophthalma_choquinha-de-olho-branco_wheant1
+Epinecrophylla haematonota_choquinha-de-garganta-carijó/choquinha-do-rio-negro_rubsti1
+Epinecrophylla haematonota pyrrhonota_choquinha-do-rio-negro_sttant4
+Epinecrophylla haematonota fjeldsaai_rufous-backed stipplethroat (Yasuni)_bnbant1
+Epinecrophylla haematonota haematonota_choquinha-de-garganta-carijó_sttant5
+Epinecrophylla haematonota fjeldsaai x haematonota_rufous-backed stipplethroat (Yasuni x Rufous-backed)_x00931
+Epinecrophylla amazonica_choquinha-do-madeira/choquinha-do-rio-roosevelt_madant1
+Epinecrophylla amazonica amazonica_choquinha-do-madeira_sttant6
+Epinecrophylla amazonica dentei_choquinha-do-rio-roosevelt_rooant1
+Epinecrophylla haematonota/amazonica_choquinha-de-garganta-carijó/choquinha-do-rio-negro/choquinha-do-madeira/choquinha-do-rio-roosevelt_y01113
+Epinecrophylla spodionota_foothill stipplethroat_fooant1
+Epinecrophylla ornata_choquinha-ornada_ornant1
+Epinecrophylla ornata [ornata Group]_choquinha-ornada [grupo ornata]_ornant2
+Epinecrophylla ornata hoffmannsi_choquinha-ornada (hoffmannsi)_ornant3
+Epinecrophylla erythrura_choquinha-de-cauda-ruiva_rutant3
+Epinecrophylla sp._Epinecrophylla sp._epinec1
+Myrmotherula brachyura_choquinha-miúda_pygant1
+Myrmotherula ignota_choquinha-de-bico-curto_mouant
+Myrmotherula ignota ignota_choquinha-de-bico-curto (ignota)_mouant3
+Myrmotherula ignota obscura_choquinha-de-bico-curto (obscura)_mouant2
+Myrmotherula ambigua_choquinha-de-coroa-listrada_yetant1
+Myrmotherula sclateri_choquinha-de-garganta-amarela_sclant1
+Myrmotherula surinamensis_choquinha-estriada_guista1
+Myrmotherula multostriata_choquinha-estriada-da-amazônia_amasta1
+Myrmotherula pacifica_pacific antwren_pacant
+Myrmotherula cherriei_choquinha-de-peito-riscado_cheant1
+Myrmotherula klagesi_choquinha-do-tapajós_klaant1
+Myrmotherula longicauda_stripe-chested antwren_stcant4
+Myrmotherula axillaris_choquinha-de-flanco-branco_whfant2
+Myrmotherula axillaris [axillaris Group]_choquinha-de-flanco-branco [grupo axillaris]_whfant5
+Myrmotherula axillaris luctuosa_choquinha-de-flanco-branco (luctuosa)_whfant6
+Myrmotherula schisticolor_slaty antwren_slaant1
+Myrmotherula sunensis_choquinha-do-oeste_risant1
+Myrmotherula minor_choquinha-pequena_salant1
+Myrmotherula longipennis_choquinha-de-asa-comprida_lowant1
+Myrmotherula urosticta_choquinha-de-rabo-cintado_batant3
+Myrmotherula iheringi_choquinha-de-ihering/do-purus/do-bambu_iheant1
+Myrmotherula iheringi heteroptera_choquinha-do-purus_iheant2
+Myrmotherula iheringi iheringi_choquinha-de-ihering_iheant3
+Myrmotherula iheringi oreni_choquinha-do-bambu_bamant2
+Myrmotherula fluminensis_choquinha-fluminense_rdjant2
+Myrmotherula grisea_ashy antwren_ashant1
+Myrmotherula unicolor_choquinha-cinzenta_uniant1
+Myrmotherula snowi_choquinha-de-alagoas_alaant1
+Myrmotherula behni_choquinha-de-asa-lisa_plwant2
+Myrmotherula menetriesii_choquinha-de-garganta-cinza_gryant1
+Myrmotherula assimilis_choquinha-da-várzea_leaant1
+Myrmotherula sp._Myrmotherula sp._myrmot1
+Dichrozona cincta_tovaquinha_banant2
+Myrmorchilus strigilatus_tem-farinha-aí_stbant2
+Herpsilochmus pileatus_chorozinho-de-boné_bahant1
+Herpsilochmus atricapillus_chorozinho-de-chapéu-preto_blcant2
+Herpsilochmus praedictus_chorozinho-esperado_mapant1
+Herpsilochmus stotzi_chorozinho-do-aripuanã_ajpant1
+Herpsilochmus motacilloides_creamy-bellied antwren_crbant1
+Herpsilochmus parkeri_ash-throated antwren_astant1
+Herpsilochmus [undescribed Inambari-Tambopata form]_inambari-tambopata antwren (undescribed form)_intant1
+Herpsilochmus [undescribed Loreto form]_loreto antwren (undescribed form)_lorant1
+Herpsilochmus sticturus_chorozinho-de-cauda-pintada_sptant1
+Herpsilochmus dugandi_dugand's antwren_dugant1
+Herpsilochmus stictocephalus_chorozinho-de-cabeça-pintada_todant1
+Herpsilochmus gentryi_ancient antwren_ancant1
+Herpsilochmus dorsimaculatus_chorozinho-de-costas-manchadas_spbant4
+Herpsilochmus roraimae_chorozinho-de-roraima_rorant1
+Herpsilochmus pectoralis_chorozinho-de-papo-preto_pecant1
+Herpsilochmus longirostris_chorozinho-de-bico-comprido_labant1
+Herpsilochmus axillaris_yellow-breasted antwren_yebant2
+Herpsilochmus frater_chorozinho-de-asa-vermelha-do-norte_ruwant3
+Herpsilochmus rufimarginatus_chorozinho-de-asa-vermelha_ruwant4
+Herpsilochmus sp._Herpsilochmus sp._herpsi1
+Microrhopias quixensis_papa-formiga-de-bando_dowant1
+Microrhopias quixensis [boucardi Group]_papa-formiga-de-bando [grupo boucardi]_dowant3
+Microrhopias quixensis microstictus_papa-formiga-de-bando (microstictus)_dowant5
+Microrhopias quixensis quixensis_papa-formiga-de-bando (quixensis)_dowant7
+Microrhopias quixensis nigriventris_papa-formiga-de-bando (nigriventris)_dowant6
+Microrhopias quixensis albicauda/intercedens_papa-formiga-de-bando (albicauda/intercedens)_dowant8
+Microrhopias quixensis bicolor_papa-formiga-de-bando (bicolor)_dowant2
+Microrhopias quixensis emiliae_papa-formiga-de-bando (emiliae)_dowant4
+Formicivora iheringi_formigueiro-do-nordeste_nabant1
+Formicivora erythronotos_formigueiro-de-cabeça-negra_blhant4
+Formicivora intermedia_northern white-fringed antwren_whfant4
+Formicivora grisea_papa-formiga-pardo_whfant3
+Formicivora intermedia/grisea_northern/southern white-fringed antwren_whfant1
+Formicivora serrana_formigueiro-da-serra/formigueiro-do-litoral_serant4
+Formicivora serrana serrana/interposita_formigueiro-da-serra_serant1
+Formicivora serrana littoralis_formigueiro-do-litoral_resant1
+Formicivora melanogaster_formigueiro-de-barriga-preta_blbant2
+Formicivora rufa_papa-formiga-vermelho_rubant4
+Formicivora grantsaui_papa-formiga-do-sincorá_sinant1
+Formicivora acutirostris_bicudinho-do-brejo/bicudinho-do-brejo-paulista_parant1
+Formicivora acutirostris acutirostris_bicudinho-do-brejo_parant3
+Formicivora acutirostris paludicola_bicudinho-do-brejo-paulista_parant4
+Thamnophilidae sp. (antwren sp.)_choquinha (tamnofilídeo) sp._antwre1
+Drymophila ferruginea_dituí_ferant1
+Drymophila rubricollis_choquinha-dublê_berant1
+Drymophila genei_choquinha-da-serra_rutant1
+Drymophila ochropyga_choquinha-de-dorso-vermelho_ocrant1
+Drymophila malura_choquinha-carijó_dutant1
+Drymophila squamata_pintadinho_scaant2
+Drymophila devillei_choquinha-listrada_strant2
+Drymophila caudata_east andean antbird_lotant1
+Drymophila klagesi_klages's antbird_klaant2
+Drymophila hellmayri_santa marta antbird_samant2
+Drymophila striaticeps_streak-headed antbird_sthant1
+Drymophila sp._Drymophila sp._drymop1
+Hypocnemis cantator_cantador-da-guiana_guiwaa1
+Hypocnemis flavescens_cantador-sulfúreo_imewaa1
+Hypocnemis peruviana_cantador-sinaleiro_perwaa1
+Hypocnemis subflava_cantador-galego_yebwaa1
+Hypocnemis ochrogyna_cantador-ocráceo_ronwaa1
+Hypocnemis striata_cantador-estriado_spiwaa1
+Hypocnemis ochrogyna x striata_cantador-ocráceo x cantador-estriado (híbrido)_x00407
+Hypocnemis rondoni_cantador-de-rondon_manwaa1
+Hypocnemis sp. (warbling-antbird sp.)_cantador sp._warant1
+Hypocnemis hypoxantha_cantador-amarelo_yebant3
+Terenura sicki_zidedê-do-nordeste_orbant1
+Terenura maculata_zidedê_stcant3
+Cercomacroides laeta_chororó-didi_wilant1
+Cercomacroides parkeri_parker's antbird_parant2
+Cercomacroides tyrannina_chororó-escuro_dusant1
+Cercomacroides tyrannina tyrannina/crepera_chororó-escuro (tyrannina/crepera)_dusant2
+Cercomacroides tyrannina saturatior/vicina_chororó-escuro (saturatior/vicina)_dusant3
+Cercomacroides serva_chororó-preto_blaant2
+Cercomacroides nigrescens_chororó-negro_blaant4
+Cercomacroides fuscicauda_chororó-negro-do-acre_blaant5
+Cercomacroides nigrescens/fuscicauda_chororó-negro/negro-do-acre_y00967
+Cercomacroides sp._Cercomacroides sp._cercom1
+Cercomacra manu_chororó-de-manu_manant1
+Cercomacra cinerascens_chororó-pocuá_gryant2
+Cercomacra brasiliana_chororó-cinzento_rdjant1
+Cercomacra melanaria_chororó-do-pantanal_magant1
+Cercomacra ferdinandi_chororó-de-goiás_banant1
+Cercomacra nigricans_jet antbird_jetant1
+Cercomacra carbonaria_chororó-do-rio-branco_ribant1
+Pyriglena maura_papa-taoca-do-pantanal_wesfie1
+Pyriglena maura pacifica_papa-taoca-do-pantanal (pacifica)_whbfie1
+Pyriglena maura castanoptera_papa-taoca-do-pantanal (castanoptera)_whbfie2
+Pyriglena maura picea_papa-taoca-do-pantanal (picea)_whbfie3
+Pyriglena maura [maura Group]_papa-taoca-do-pantanal [grupo maurus]_wesfie2
+Pyriglena similis_papa-taoca-do-tapajós_whbfie9
+Pyriglena leuconota_papa-taoca-de-belém_eaafie1
+Pyriglena atra_papa-taoca-da-bahia_fbfeye1
+Pyriglena leucoptera_papa-taoca-do-sul_wsfeye1
+Rhopornis ardesiacus_gravatazeiro_sleant1
+Myrmoborus leucophrys_papa-formiga-de-sobrancelha_whbant6
+Myrmoborus lugubris_formigueiro-liso-do-pará/do-solimões/do-rio-negro_asbant1
+Myrmoborus myotherinus_formigueiro-de-cara-preta_blfant2
+Myrmoborus melanurus_formigueiro-de-cauda-preta_bltant1
+Myrmoborus lophotes_formigueiro-do-bambu_whlant1
+Hypocnemoides melanopogon_solta-asa-do-norte_blcant3
+Hypocnemoides maculicauda_solta-asa_batant1
+Myrmochanes hemileucus_formigueiro-preto-e-branco_bawant1
+Gymnocichla nudiceps_bare-crowned antbird_bacant1
+Sclateria naevia_papa-formiga-do-igarapé_silant1
+Percnostola rufifrons_formigueiro-de-cabeça-preta/de-hellmayr/de-pelzeln_blhant3
+Percnostola rufifrons minor/jensoni_formigueiro-de-pelzeln_bkhant1
+Percnostola rufifrons rufifrons/subcristata_formigueiro-de-cabeça-preta/de-hellmayr_bkhant2
+Percnostola arenarum_allpahuayo antbird_allant1
+Myrmelastes schistaceus_formigueiro-cinza_slcant3
+Myrmelastes saturatus_formigueiro-de-roraima_rorant2
+Myrmelastes hyperythrus_formigueiro-chumbo_pluant1
+Myrmelastes leucostigma_formigueiro-de-asa-pintada_spwant3
+Myrmelastes humaythae_formigueiro-de-cauda-curta_humant1
+Myrmelastes brunneiceps_brownish-headed antbird_brhant1
+Myrmelastes rufifacies_formigueiro-de-cara-ruiva_rufant4
+Myrmelastes caurensis_formigueiro-do-caura_cauant2
+Myrmelastes sp._Myrmelastes sp._schist1
+Myrmeciza longipes_formigueiro-de-barriga-branca_whbant1
+Poliocrania exsul_chestnut-backed antbird_chbant1
+Poliocrania exsul [exsul Group]_chestnut-backed antbird (Chestnut-backed)_chbant3
+Poliocrania exsul maculifer/cassini_chestnut-backed antbird (Short-tailed)_chbant4
+Ampelornis griseiceps_gray-headed antbird_gyhant1
+Sipia laemosticta_dull-mantled antbird_dumant1
+Sipia palliata_magdalena antbird_dumant3
+Sipia nigricauda_esmeraldas antbird_esmant1
+Sipia berlepschi_stub-tailed antbird_sttant3
+Sciaphylax hemimelaena_formigueiro-de-cauda-castanha/formigueiro-de-cauda-baia_chtant2
+Sciaphylax hemimelaena hemimelaena_formigueiro-de-cauda-castanha_chtant3
+Sciaphylax hemimelaena pallens_formigueiro-de-cauda-baia_chtant4
+Sciaphylax [undescribed form]_aripuana antbird (undescribed form)_ariant1
+Sciaphylax castanea_zimmer's antbird_zimant1
+Sciaphylax hemimelaena/castanea_chestnut-tailed/zimmer's antbird_y00690
+Myrmoderus ferrugineus_formigueiro-ferrugem_febant1
+Myrmoderus eowilsoni_cordillera azul antbird_whiant1
+Myrmoderus ruficauda_formigueiro-de-cauda-ruiva_scaant3
+Myrmoderus loricatus_formigueiro-assobiador_whbant4
+Myrmoderus squamosus_papa-formiga-de-grota_squant1
+Akletos melanoceps_formigueiro-grande_whsant1
+Akletos goeldii_formigueiro-de-goeldi_goeant1
+Hafferia fortis_formigueiro-de-taoca_sooant1
+Hafferia zeledoni_zeledon's antbird_zelant1
+Hafferia zeledoni zeledoni_zeledon's antbird (Zeledon's)_immant5
+Hafferia zeledoni berlepschi_zeledon's antbird (Choco)_immant4
+Hafferia immaculata_blue-lored antbird_immant1
+Hafferia immaculata immaculata_blue-lored antbird (Andean)_immant3
+Hafferia immaculata concepcion_blue-lored antbird (Concepcion)_immant2
+Aprositornis disjuncta_formigueiro-de-yapacana_yapant1
+Myrmophylax atrothorax_formigueiro-de-peito-preto_bltant2
+Ammonastes pelzelni_formigueiro-de-barriga-cinza_gybant1
+Myrmornis torquata_pinto-do-mato-carijó_wibant1
+Myrmornis torquata stictoptera_pinto-do-mato-carijó (stictoptera)_wibant2
+Myrmornis torquata torquata_pinto-do-mato-carijó (torquata)_wibant3
+Pithys albifrons_papa-formiga-de-topete_whpant1
+Pithys castaneus_white-masked antbird_whmant2
+Gymnopithys bicolor_bicolored antbird_bicant2
+Gymnopithys leucaspis_mãe-de-taoca-bochechuda_whcant1
+Gymnopithys rufigula_mãe-de-taoca-de-garganta-vermelha_rutant4
+Oneillornis salvini_mãe-de-taoca-de-cauda-barrada_whtant1
+Oneillornis lunulatus_lunulated antbird_lunant2
+Rhegmatorhina gymnops_mãe-de-taoca-de-cara-branca_baeant1
+Rhegmatorhina berlepschi_mãe-de-taoca-arlequim_harant1
+Rhegmatorhina hoffmannsi_mãe-de-taoca-papuda_whbant5
+Rhegmatorhina gymnops x hoffmannsi_bare-eyed x white-breasted antbird (hybrid)_x01102
+Rhegmatorhina berlepschi x hoffmannsi_harlequin x white-breasted antbird (hybrid)_x01103
+Rhegmatorhina cristata_mãe-de-taoca-cristada_chcant1
+Rhegmatorhina melanosticta_mãe-de-taoca-cabeçuda_hacant1
+Hylophylax naevioides_spotted antbird_spoant1
+Hylophylax naevius_guarda-floresta_spbant6
+Hylophylax punctulatus_guarda-várzea_dobant2
+Willisornis poecilinotus_rendadinho_scbant3
+Willisornis poecilinotus poecilinotus_rendadinho (poecilinotus)_scbant7
+Willisornis poecilinotus lepidonota/duidae_rendadinho (lepidonotus/duidae)_scbant6
+Willisornis poecilinotus gutturalis_rendadinho (gutturalis)_scbant5
+Willisornis poecilinotus griseiventris_rendadinho (griseiventris)_scbant4
+Willisornis vidua_rendadinho-do-xingu_scbant8
+Willisornis vidua nigrigula_rendadinho-do-xingu (nigrigula)_scbant1
+Willisornis vidua vidua_rendadinho-do-xingu (vidua)_xsbant1
+Willisornis poecilinotus x vidua_common x xingu scale-backed antbird (hybrid)_x01058
+Thamnophilidae sp. (antbird sp.)_choca (tamnofilídeo) sp._antbir1
+Phlegopsis nigromaculata_mãe-de-taoca_bsbeye1
+Phlegopsis erythroptera_mãe-de-taoca-avermelhada_rwbeye1
+Phlegopsis borbae_mãe-de-taoca-dourada_pafant1
+Phaenostictus mcleannani_ocellated antbird_oceant1
+Melanopareia torquata_meia-lua-do-cerrado/de-coleira-dupla_colcre1
+Melanopareia torquata bitorquata_meia-lua-de-coleira-dupla_colcre2
+Melanopareia torquata torquata/rufescens_meia-lua-do-cerrado_colcre3
+Melanopareia maximiliani_olive-crowned crescentchest_olccre1
+Melanopareia maximiliani maximiliani/argentina_olive-crowned crescentchest (Sierran)_olccre5
+Melanopareia maximiliani pallida_olive-crowned crescentchest (Chaco)_olccre4
+Melanopareia maranonica_marañon crescentchest_marcre1
+Melanopareia elegans_elegant crescentchest_elecre1
+Pittasoma michleri_black-crowned antpitta_blcant1
+Pittasoma rufopileatum_rufous-crowned antpitta_rucant3
+Conopophaga melanogaster_chupa-dente-grande_blbgna1
+Conopophaga melanops_cuspidor-de-máscara-preta_blcgna1
+Conopophaga aurita_chupa-dente-cintado_chbgna1
+Conopophaga snethlageae_chupa-dente-de-peito-preto_chbgna3
+Conopophaga peruviana_chupa-dente-do-peru_astgna1
+Conopophaga cearae_chupa-dente-do-nordeste_rufgna2
+Conopophaga roberti_chupa-dente-de-capuz_hoogna1
+Conopophaga lineata_chupa-dente_rufgna3
+Conopophaga castaneiceps_chestnut-crowned gnateater_chcgna1
+Conopophaga ardesiaca_slaty gnateater_slagna1
+Grallaria squamigera_undulated antpitta_undant1
+Grallaria gigantea_giant antpitta_giaant1
+Grallaria excelsa_great antpitta_greant2
+Grallaria varia_tovacuçu_varant2
+Grallaria alleni_moustached antpitta_mouant1
+Grallaria guatimalensis_tovaca-corujinha_scaant1
+Grallaria guatimalensis [guatimalensis Group]_scaled antpitta (guatimalensis Group)_scaant4
+Grallaria guatimalensis princeps/chocoensis_scaled antpitta (princeps/chocoensis)_scaant5
+Grallaria guatimalensis aripoensis_scaled antpitta (aripoensis)_scaant6
+Grallaria guatimalensis roraimae_scaled antpitta (roraimae)_scaant7
+Grallaria guatimalensis regulus/carmelitae_scaled antpitta (regulus/carmelitae)_scaant8
+Grallaria guatimalensis sororia_scaled antpitta (sororia)_scaant9
+Grallaria chthonia_tachira antpitta_tacant1
+Grallaria haplonota_plain-backed antpitta_plbant1
+Grallaria dignissima_ochre-striped antpitta_ocsant1
+Grallaria eludens_tovacuçu-xodó_eluant1
+Grallaria ruficapilla_chestnut-crowned antpitta_chcant2
+Grallaria watkinsi_watkins's antpitta_watant1
+Grallaria bangsi_santa marta antpitta_samant1
+Grallaria kaestneri_cundinamarca antpitta_cunant1
+Grallaria andicolus_stripe-headed antpitta_sthant2
+Grallaria griseonucha_gray-naped antpitta_gynant1
+Grallaria ridgelyi_jocotoco antpitta_jocant1
+Grallaria nuchalis_chestnut-naped antpitta_chnant1
+Grallaria carrikeri_pale-billed antpitta_pabant1
+Grallaria albigula_white-throated antpitta_whtant2
+Grallaria flavotincta_yellow-breasted antpitta_yebant1
+Grallaria hypoleuca_white-bellied antpitta_whbant3
+Grallaria przewalskii_rusty-tinged antpitta_rutant5
+Grallaria capitalis_bay antpitta_bayant1
+Grallaria erythroleuca_red-and-white antpitta_rawant1
+Grallaria spatiator_sierra nevada antpitta_rufant5
+Grallaria saltuensis_perija antpitta_rufant6
+Grallaria rufocinerea_bicolored antpitta_bicant3
+Grallaria rufula_muisca antpitta_rufant7
+Grallaria centralis_oxapampa antpitta_oxaant1
+Grallaria ayacuchensis_ayacucho antpitta_ayaant1
+Grallaria occabambae_urubamba antpitta_rufant10
+Grallaria sinaensis_puno antpitta_punant1
+Grallaria cochabambae_bolivian antpitta_rufant11
+Grallaria alvarezi_chami antpitta_chaant4
+Grallaria saturata_equatorial antpitta_equant1
+Grallaria rufula/saturata_muisca/equatorial antpitta_y00404
+Grallaria cajamarcae_cajamarca antpitta_rufant8
+Grallaria blakei_chestnut antpitta_cheant2
+Grallaria gravesi_chachapoyas antpitta_chaant5
+Grallaria oneilli_panao antpitta_panant1
+Grallaria obscura_junin antpitta_rufant9
+Grallaria sp. (rufula/blakei complex)_antpitta sp. (Rufous/Chestnut Antpitta complex)_rufant1
+Grallaria alticola_boyaca antpitta_tawant2
+Grallaria quitensis_tawny antpitta_tawant3
+Grallaria [undescribed form]_paisa antpitta (undescribed form)_paiant1
+Grallaria atuensis_atuen antpitta_tawant4
+Grallaria urraoensis_urrao antpitta_antant1
+Grallaria milleri_brown-banded antpitta_brbant1
+Grallaria erythrotis_rufous-faced antpitta_rufant2
+Grallaria sp._Grallaria sp._gralla1
+Cryptopezus nattereri_pinto-do-mato_spbant1
+Hylopezus perspicillatus_streak-chested antpitta_stcant2
+Hylopezus perspicillatus intermedius_streak-chested antpitta (Atlantic Slope)_stcant6
+Hylopezus perspicillatus lizanoi_streak-chested antpitta (Pacific Slope)_stcant7
+Hylopezus perspicillatus perspicillatus_streak-chested antpitta (Eastern Panama)_stcant5
+Hylopezus perspicillatus periophthalmicus_streak-chested antpitta (Baudo)_stcant8
+Hylopezus perspicillatus pallidior_streak-chested antpitta (Colombian Valleys)_stcant9
+Hylopezus macularius_torom-carijó/torom-do-imeri_spoant6
+Hylopezus macularius macularius_torom-carijó_spoant4
+Hylopezus macularius dilutus_torom-do-imeri_spoant3
+Hylopezus paraensis_torom-do-pará_spoant5
+Hylopezus whittakeri_torom-de-alta-floresta_alfant1
+Hylopezus auricularis_masked antpitta_masant1
+Hylopezus ochroleucus_pompeu_whbant7
+Myrmothera fulviventris_white-lored antpitta_whlant2
+Myrmothera berlepschi_torom-torom_amaant1
+Myrmothera dives_thicket antpitta_thiant1
+Myrmothera campanisona_tovaca-patinho_thlant2
+Myrmothera subcanescens_tovaca-do-tapajós_thlant3
+Myrmothera simplex_torom-de-peito-pardo_tepant1
+Myrmothera campanisona/simplex_tovaca-patinho/torom-de-peito-pardo_y00882
+Grallaricula flavirostris_ochre-breasted antpitta_ocbant1
+Grallaricula loricata_scallop-breasted antpitta_scbant2
+Grallaricula cucullata_hooded antpitta_hooant1
+Grallaricula [undescribed Cali form]_cali antpitta (undescribed form)_calant1
+Grallaricula peruviana_peruvian antpitta_perant1
+Grallaricula ochraceifrons_ochre-fronted antpitta_ocfant1
+Grallaricula ferrugineipectus_rusty-breasted antpitta_rubant5
+Grallaricula ferrugineipectus rara_rusty-breasted antpitta (rara)_rubant8
+Grallaricula ferrugineipectus ferrugineipectus_rusty-breasted antpitta (Rusty-breasted)_rubant6
+Grallaricula leymebambae_leymebamba antpitta_rubant7
+Grallaricula nana_tovaquinha-de-coroa-cinza_slcant2
+Grallaricula nana [nana Group]_slate-crowned antpitta (Slate-crowned)_slcant4
+Grallaricula nana kukenamensis_slate-crowned antpitta (Guianan)_slcant6
+Grallaricula cumanensis_sucre antpitta_slcant5
+Grallaricula lineifrons_crescent-faced antpitta_crfant1
+Pteroptochos castaneus_chestnut-throated huet-huet_cthhue1
+Pteroptochos tarnii_black-throated huet-huet_bthhue1
+Pteroptochos megapodius_moustached turca_moutur1
+Scelorchilus albicollis_white-throated tapaculo_whttap1
+Scelorchilus rubecula_chucao tapaculo_chutap1
+Liosceles thoracicus_corneteiro-da-mata_rubtap1
+Acropternis orthonyx_ocellated tapaculo_ocetap1
+Rhinocrypta lanceolata_crested gallito_cregal1
+Teledromas fuscus_sandy gallito_sangal1
+Psilorhamphus guttatus_tapaculo-pintado_spobam1
+Merulaxis ater_entufado_slabri1
+Merulaxis stresemanni_entufado-baiano_strbri1
+Eugralla paradoxa_ochre-flanked tapaculo_ocftap1
+Myornis senilis_ash-colored tapaculo_asctap1
+Eleoscytalopus indigoticus_macuquinho_whbtap1
+Eleoscytalopus psychopompus_macuquinho-baiano_bahtap1
+Scytalopus iraiensis_tapaculo-da-várzea_martap1
+Scytalopus diamantinensis_tapaculo-da-chapada-diamantina_diatap2
+Scytalopus novacapitalis_tapaculo-de-brasília_bratap1
+Scytalopus petrophilus_tapaculo-serrano_roctap1
+Scytalopus pachecoi_tapaculo-ferreirinho_platap1
+Scytalopus gonzagai_tapaculo-preto-baiano_sertap1
+Scytalopus speluncae_tapaculo-preto_moctap1
+Scytalopus fuscus_dusky tapaculo_dustap1
+Scytalopus magellanicus_magellanic tapaculo_magtap1
+Scytalopus affinis_ancash tapaculo_anctap1
+Scytalopus krabbei_white-winged tapaculo_whwtap1
+Scytalopus androstictus_loja tapaculo_partap4
+Scytalopus opacus_paramo tapaculo_partap2
+Scytalopus canus_paramillo tapaculo_partap1
+Scytalopus superciliaris_white-browed tapaculo_whbtap2
+Scytalopus zimmeri_zimmer's tapaculo_zimtap1
+Scytalopus simonsi_puna tapaculo_puntap1
+Scytalopus schulenbergi_diademed tapaculo_diatap1
+Scytalopus urubambae_vilcabamba tapaculo_viltap1
+Scytalopus whitneyi_ampay tapaculo_amptap1
+Scytalopus frankeae_jalca tapaculo_miltap1
+Scytalopus altirostris_neblina tapaculo_nebtap1
+Scytalopus parvirostris_trilling tapaculo_tritap1
+Scytalopus bolivianus_bolivian tapaculo_boltap1
+Scytalopus atratus_white-crowned tapaculo_whctap1
+Scytalopus sanctaemartae_santa marta tapaculo_samtap1
+Scytalopus micropterus_long-tailed tapaculo_lottap1
+Scytalopus femoralis_rufous-vented tapaculo_ruvtap1
+Scytalopus intermedius_utcubamba tapaculo_blatap2
+Scytalopus macropus_large-footed tapaculo_laftap1
+Scytalopus gettyae_junin tapaculo_juntap1
+Scytalopus unicolor_unicolored tapaculo_unitap1
+Scytalopus acutirostris_tschudi's tapaculo_tsctap1
+Scytalopus latrans_blackish tapaculo_blatap1
+Scytalopus latrans latrans_blackish tapaculo (Blackish)_blatap3
+Scytalopus latrans subcinereus_blackish tapaculo (Pacific)_blatap4
+Scytalopus [undescribed Lambayeque form]_lambayeque tapaculo (undescribed form)_lamtap1
+Scytalopus argentifrons_silvery-fronted tapaculo_siftap1
+Scytalopus argentifrons argentifrons_silvery-fronted tapaculo (Silvery-fronted)_siftap2
+Scytalopus argentifrons chiriquensis_silvery-fronted tapaculo (Chiriqui)_siftap3
+Scytalopus vicinior_nariño tapaculo_nartap2
+Scytalopus panamensis_tacarcuna tapaculo_tactap1
+Scytalopus chocoensis_choco tapaculo_chotap1
+Scytalopus rodriguezi_magdalena tapaculo_upmtap1
+Scytalopus rodriguezi yariguiorum_magdalena tapaculo (Yariguies)_magtap2
+Scytalopus rodriguezi rodriguezi_magdalena tapaculo (Upper Magdalena)_magtap3
+Scytalopus stilesi_stiles's tapaculo_stitap1
+Scytalopus alvarezlopezi_tatama tapaculo_alptap1
+Scytalopus robbinsi_ecuadorian tapaculo_ecutap1
+Scytalopus caracae_caracas tapaculo_cartap1
+Scytalopus [undescribed Turimiquire form]_turimiquire tapaculo (undescribed form)_turtap1
+Scytalopus griseicollis_pale-bellied tapaculo_mattap1
+Scytalopus latebricola_brown-rumped tapaculo_brrtap1
+Scytalopus perijanus_perija tapaculo_pertap1
+Scytalopus meridanus_merida tapaculo_mertap1
+Scytalopus meridanus meridanus_merida tapaculo (Merida)_mertap2
+Scytalopus meridanus fuscicauda_merida tapaculo (Lara)_lartap1
+Scytalopus parkeri_chusquea tapaculo_chutap2
+Scytalopus spillmanni_spillmann's tapaculo_spitap2
+Scytalopus sp._Scytalopus sp._scytal1
+Rhinocryptidae sp._Rhinocryptidae sp._tapacu1
+Formicarius colma_galinha-do-mato_rucant2
+Formicarius moniliger_mayan antthrush_bkfant2
+Formicarius analis_pinto-do-mato-de-cara-preta_blfant1
+Formicarius analis [hoffmanni Group]_pinto-do-mato-de-cara-preta [grupo hoffmanni]_bkfant1
+Formicarius analis [analis Group]_pinto-do-mato-de-cara-preta [grupo analis]_bkfant3
+Formicarius rufifrons_pinto-do-mato-de-fronte-ruiva_rufant3
+Formicarius nigricapillus_black-headed antthrush_blhant1
+Formicarius nigricapillus nigricapillus_black-headed antthrush (Central American)_bkhant7
+Formicarius nigricapillus destructus_black-headed antthrush (Choco)_bkhant8
+Formicarius rufipectus_rufous-breasted antthrush_rubant1
+Formicarius sp._Formicarius sp._formic1
+Chamaeza campanisona_tovaca-campainha_shtant1
+Chamaeza nobilis_tovaca-estriada_strant3
+Chamaeza meruloides_tovaca-cantadora_sucant1
+Chamaeza turdina_schwartz's antthrush_schant1
+Chamaeza ruficauda_tovaca-de-rabo-vermelho_rutant2
+Chamaeza mollissima_barred antthrush_barant2
+Chamaeza sp._Chamaeza sp._chamae1
+Formicarius/Chamaeza sp._Formicarius/Chamaeza sp._antthr1
+Sclerurus mexicanus_vira-folha-de-peito-vermelho_tatlea1
+Sclerurus mexicanus mexicanus_vira-folha-de-peito-vermelho (mexicanus)_tatlea5
+Sclerurus mexicanus pullus_vira-folha-de-peito-vermelho (pullus)_tatlea8
+Sclerurus obscurior_vira-folha-de-peito-vermelho/peruano_soalea1
+Sclerurus obscurior andinus_vira-folha-de-peito-vermelho (andinus)_tatlea2
+Sclerurus obscurior obscurior_vira-folha-de-peito-vermelho (obscurior)_tatlea6
+Sclerurus obscurior peruvianus_vira-folha-peruano_tatlea7
+Sclerurus obscurior macconnelli_vira-folha-de-peito-vermelho (macconnelli)_tatlea4
+Sclerurus obscurior bahiae_vira-folha-de-peito-vermelho (bahiae)_tatlea3
+Sclerurus mexicanus/obscurior_sclerurus mexicanus/obscurior_y00405
+Sclerurus rufigularis_vira-folha-de-bico-curto_shblea1
+Sclerurus guatemalensis_scaly-throated leaftosser_sctlea1
+Sclerurus caudacutus_vira-folha-pardo_bltlea1
+Sclerurus albigularis_vira-folha-de-garganta-cinza_grtlea1
+Sclerurus albigularis canigularis_gray-throated leaftosser (Central American)_gytlea1
+Sclerurus albigularis [albigularis Group]_gray-throated leaftosser (South American)_gytlea8
+Sclerurus scansor_vira-folha/vira-folha-cearense_rublea1
+Sclerurus scansor cearensis_vira-folha-cearense_rublea2
+Sclerurus scansor scansor_vira-folha_rublea3
+Sclerurus sp._Sclerurus sp._leafto1
+Geositta peruviana_coastal miner_coamin1
+Geositta tenuirostris_slender-billed miner_slbmin1
+Geositta cunicularia_curriqueiro_commin1
+Geositta cunicularia [frobeni Group]_curriqueiro [grupo frobeni]_commin3
+Geositta cunicularia georgei_curriqueiro (georgei)_commin6
+Geositta cunicularia deserticolor_curriqueiro (deserticolor)_commin4
+Geositta cunicularia fissirostris_curriqueiro (fissirostris)_commin5
+Geositta cunicularia [cunicularia Group]_curriqueiro [grupo cunicularia]_commin2
+Geositta punensis_puna miner_punmin1
+Geositta cunicularia/punensis_common/puna miner_y00795
+Geositta poeciloptera_andarilho_cammin2
+Geositta crassirostris_thick-billed miner_thbmin1
+Geositta rufipennis_rufous-banded miner_rubmin1
+Geositta maritima_grayish miner_gramin1
+Geositta antarctica_short-billed miner_shbmin1
+Geositta saxicolina_dark-winged miner_dawmin1
+Geositta isabellina_creamy-rumped miner_crrmin1
+Geositta sp._Geositta sp._miner1
+Certhiasomus stictolaemus_arapaçu-de-garganta-pintada_sptwoo1
+Sittasomus griseicapillus_arapaçu-verde_oliwoo1
+Sittasomus griseicapillus [griseus Group]_arapaçu-verde [grupo griseus]_oliwoo3
+Sittasomus griseicapillus aequatorialis_arapaçu-verde (aequatorialis)_oliwoo4
+Sittasomus griseicapillus [griseicapillus Group]_arapaçu-verde [grupo griseicapillus]_oliwoo5
+Sittasomus griseicapillus reiseri_arapaçu-verde (reiseri)_oliwoo6
+Sittasomus griseicapillus sylviellus/olivaceus_arapaçu-verde (sylviellus/olivaceus)_oliwoo7
+Deconychura typica_piping woodcreeper_lotwoo3
+Deconychura longicauda_arapaçu-rabudo_lotwoo4
+Deconychura pallida_arapaçu-pálido_lotwoo5
+Deconychura [undescribed form]_yungas woodcreeper (undescribed form)_yunwoo1
+Dendrocincla tyrannina_tyrannine woodcreeper_tyrwoo1
+Dendrocincla merula_arapaçu-da-taoca_whcwoo1
+Dendrocincla homochroa_ruddy woodcreeper_rudwoo1
+Dendrocincla anabatina_tawny-winged woodcreeper_tawwoo1
+Dendrocincla fuliginosa_arapaçu-pardo/pardo-de-mato-grosso_plbwoo1
+Dendrocincla fuliginosa [meruloides Group]_arapaçu-pardo [grupo meruloides]_plbwoo2
+Dendrocincla fuliginosa fuliginosa/rufoolivacea_arapaçu-pardo (fuliginosa/rufoolivacea)_plbwoo3
+Dendrocincla fuliginosa atrirostris/trumaii_arapaçu-pardo-de-mato-grosso_plbwoo17
+Dendrocincla turdina_arapaçu-liso/arapaçu-pardo-do-nordeste_plwwoo1
+Dendrocincla turdina taunayi_arapaçu-pardo-do-nordeste_plbwoo4
+Dendrocincla turdina turdina_arapaçu-liso_plbwoo5
+Dendrocincla sp._Dendrocincla sp._dendro2
+Glyphorynchus spirurus_arapaçu-bico-de-cunha_webwoo1
+Glyphorynchus spirurus [pectoralis Group]_arapaçu-bico-de-cunha [grupo pectoralis]_webwoo2
+Glyphorynchus spirurus [spirurus Group]_arapaçu-bico-de-cunha [grupo spirurus]_webwoo3
+Glyphorynchus spirurus albigularis_arapaçu-bico-de-cunha (albigularis)_webwoo4
+Glyphorynchus spirurus [cuneatus Group]_glyphorynchus spirurus [grupo cuneatus]_webwoo5
+Dendrexetastes rufigula_arapaçu-galinha-da-guiana/ocidental/do-pará_citwoo1
+Dendrexetastes rufigula devillei_arapaçu-galinha-ocidental_citwoo2
+Dendrexetastes rufigula rufigula_arapaçu-galinha-da-guiana_citwoo3
+Dendrexetastes rufigula paraensis/moniliger_arapaçu-galinha-do-pará_citwoo4
+Nasica longirostris_arapaçu-de-bico-comprido_lobwoo1
+Dendrocolaptes sanctithomae_northern barred-woodcreeper_nobwoo1
+Dendrocolaptes sanctithomae [sanctithomae Group]_northern barred-woodcreeper (Western)_norbaw1
+Dendrocolaptes sanctithomae punctipectus_northern barred-woodcreeper (Eastern)_norbaw2
+Dendrocolaptes certhia_arapaçu-concolor/barrado/do-napo/juruá/tapajós/xingu/leste_amabaw1
+Dendrocolaptes certhia radiolatus_arapaçu-barrado-do-napo_amabaw2
+Dendrocolaptes certhia certhia_arapaçu-barrado_amabaw3
+Dendrocolaptes certhia juruanus/polyzonus_arapaçu-barrado-do-juruá_amabaw4
+Dendrocolaptes certhia concolor_arapaçu-concolor_amabaw5
+Dendrocolaptes certhia ridgwayi_arapaçu-barrado-do-tapajós_amabaw6
+Dendrocolaptes certhia retentus_arapaçu-barrado-do-xingu_xinwoo1
+Dendrocolaptes certhia medius_arapaçu-barrado-do-leste_amabaw7
+Dendrocolaptes picumnus_arapaçu-meio-barrado/meio-barrado-do-xingu_blbwoo1
+Dendrocolaptes picumnus [puncticollis Group]_arapaçu-meio-barrado [grupo puncticollis]_bkbwoo1
+Dendrocolaptes picumnus [picumnus Group]_arapaçu-meio-barrado/meio-barrado-do-xingu [grupo picumnus]_bkbwoo2
+Dendrocolaptes picumnus pallescens/casaresi_arapaçu-meio-barrado (pallescens/casaresi)_bkbwoo3
+Dendrocolaptes hoffmannsi_arapaçu-marrom_hofwoo2
+Dendrocolaptes platyrostris_arapaçu-grande_plawoo1
+Dendrocolaptes sp._Dendrocolaptes sp._dendro4
+Hylexetastes stresemanni_arapaçu-de-barriga-pintada_babwoo1
+Hylexetastes perrotii_arapaçu-de-bico-vermelho_rebwoo1
+Hylexetastes uniformis_arapaçu-uniforme/de-loro-cinza_uniwoo1
+Hylexetastes uniformis uniformis_arapaçu-uniforme_rebwoo3
+Hylexetastes uniformis brigidai_arapaçu-de-loro-cinza_rebwoo4
+Xiphocolaptes promeropirhynchus_arapaçu-vermelho/arapaçu-do-carajás_stbwoo1
+Xiphocolaptes promeropirhynchus [emigrans Group]_arapaçu-vermelho/arapaçu-do-carajás [grupo emigrans]_stbwoo6
+Xiphocolaptes promeropirhynchus [promeropirhynchus Group]_arapaçu-vermelho_stbwoo7
+Xiphocolaptes promeropirhynchus [orenocensis Group]_arapaçu-vermelho/arapaçu-do-carajás [grupo orenocensis]_stbwoo8
+Xiphocolaptes promeropirhynchus carajaensis_arapaçu-do-carajás_stbwoo9
+Xiphocolaptes falcirostris_arapaçu-do-nordeste_mouwoo1
+Xiphocolaptes albicollis_arapaçu-de-garganta-branca_whtwoo1
+Xiphocolaptes major_arapaçu-do-campo_grrwoo1
+Xiphorhynchus obsoletus_arapaçu-riscado_strwoo2
+Xiphorhynchus atlanticus_arapaçu-rajado-do-nordeste_leswoo4
+Xiphorhynchus fuscus_arapaçu-rajado_leswoo2
+Xiphorhynchus pardalotus_arapaçu-assobiador_chrwoo1
+Xiphorhynchus ocellatus_arapaçu-ocelado/arapaçu-de-tschudi/arapaçu-ocelado-do-norte_ocewoo1
+Xiphorhynchus ocellatus [chunchotambo Group]_arapaçu-de-tschudi_ocewoo2
+Xiphorhynchus ocellatus beauperthuysii/lineatocapilla_arapaçu-ocelado-do-norte_ocewoo4
+Xiphorhynchus ocellatus ocellatus/perplexus_arapaçu-ocelado_ocewoo3
+Xiphorhynchus elegans_arapaçu-elegante_elewoo1
+Xiphorhynchus spixii_arapaçu-de-spix_spiwoo1
+Xiphorhynchus susurrans_cocoa woodcreeper_cocwoo1
+Xiphorhynchus susurrans [nana Group]_cocoa woodcreeper (Lawrence's)_cocwoo2
+Xiphorhynchus susurrans [susurrans Group]_cocoa woodcreeper (Cocoa)_cocwoo3
+Xiphorhynchus guttatus_arapaçu-de-garganta-amarela/arapaçu-de-lafresnaye_butwoo1
+Xiphorhynchus guttatus [guttatus Group]_arapaçu-de-garganta-amarela_butwoo2
+Xiphorhynchus guttatus guttatoides/dorbignyanus_arapaçu-de-lafresnaye_butwoo3
+Xiphorhynchus guttatus [eytoni Group]_arapaçu-de-garganta-amarela/arapaçu-de-lafresnaye [grupo eytoni]_butwoo4
+Xiphorhynchus flavigaster_ivory-billed woodcreeper_ivbwoo1
+Xiphorhynchus lachrymosus_black-striped woodcreeper_blswoo1
+Xiphorhynchus erythropygius_spotted woodcreeper_spowoo1
+Xiphorhynchus erythropygius erythropygius/parvus_spotted woodcreeper (Spotted)_spowoo2
+Xiphorhynchus erythropygius [aequatorialis Group]_spotted woodcreeper (Berlepsch's)_spowoo3
+Xiphorhynchus triangularis_olive-backed woodcreeper_olbwoo1
+Xiphorhynchus sp._Xiphorhynchus sp._xiphor1
+Dendroplex picus_arapaçu-de-bico-branco_stbwoo2
+Dendroplex kienerii_arapaçu-ferrugem_zimwoo2
+Dendroplex picus/kienerii_arapaçu-de-bico-branco/arapaçu-ferrugem_y00706
+Campylorhamphus trochilirostris_arapaçu-beija-flor_rebscy1
+Campylorhamphus falcularius_arapaçu-de-bico-torto_blbscy1
+Campylorhamphus procurvoides_arapaçu-de-bico-curvo/do-napo/do-tupana/do-tapajós/de-bico-curvo-de-rondônia_cubscy1
+Campylorhamphus procurvoides sanus_arapaçu-de-bico-curvo-do-napo_cubscy2
+Campylorhamphus procurvoides procurvoides_arapaçu-de-bico-curvo_cubscy3
+Campylorhamphus procurvoides gyldenstolpei_arapaçu-do-tupana_tupscy1
+Campylorhamphus probatus_arapaçu-do-tapajós/arapaçu-de-bico-curvo-de-rondônia_tapscy2
+Campylorhamphus probatus probatus_arapaçu-de-bico-curvo-de-rondônia_cubscy4
+Campylorhamphus probatus cardosoi_arapaçu-do-tapajós_tapscy1
+Campylorhamphus multostriatus_arapaçu-de-bico-curvo-do-xingu_cubscy5
+Campylorhamphus pusillus_brown-billed scythebill_brbscy1
+Campylorhamphus sp._Campylorhamphus sp._scythe1
+Drymotoxeres pucheranii_greater scythebill_grescy1
+Drymornis bridgesii_arapaçu-platino_scbwoo4
+Lepidocolaptes souleyetii_arapaçu-listrado_sthwoo1
+Lepidocolaptes angustirostris_arapaçu-de-cerrado_nabwoo1
+Lepidocolaptes leucogaster_white-striped woodcreeper_whswoo1
+Lepidocolaptes affinis_spot-crowned woodcreeper_spcwoo1
+Lepidocolaptes affinis affinis/lignicida_spot-crowned woodcreeper (Northern)_spcwoo4
+Lepidocolaptes affinis neglectus_spot-crowned woodcreeper (Southern)_spcwoo5
+Lepidocolaptes lacrymiger_montane woodcreeper_monwoo1
+Lepidocolaptes squamatus_arapaçu-escamoso/arapaçu-de-wagler_scawoo1
+Lepidocolaptes squamatus wagleri_arapaçu-de-wagler_scawoo4
+Lepidocolaptes squamatus squamatus_arapaçu-escamoso_scawoo3
+Lepidocolaptes falcinellus_arapaçu-escamoso-do-sul_scawoo2
+Lepidocolaptes duidae_arapaçu-do-duida_linwoo4
+Lepidocolaptes albolineatus_arapaçu-de-listras-brancas_linwoo3
+Lepidocolaptes fatimalimae_arapaçu-do-inambari_inawoo1
+Lepidocolaptes duidae/fatimalimae_arapaçu-do-duida/do-inambari_y00968
+Lepidocolaptes fuscicapillus_arapaçu-de-rondônia/arapaçu-de-listras-brancas-do-leste_ducwoo1
+Lepidocolaptes fuscicapillus fuscicapillus_arapaçu-de-rondônia_linwoo5
+Lepidocolaptes fuscicapillus layardi_arapaçu-de-listras-brancas-do-leste_linwoo6
+Lepidocolaptes sp._Lepidocolaptes sp._lepido1
+Dendrocolaptinae sp._Dendrocolaptinae sp._woodcr1
+Xenops tenuirostris_bico-virado-fino_slbxen1
+Xenops mexicanus_northern plain-xenops_plaxen2
+Xenops genibarbis_bico-virado-da-amazônia_plaxen3
+Xenops minutus_bico-virado-miúdo_plaxen4
+Xenops rutilans_bico-virado-carijó_strxen1
+Xenops tenuirostris/rutilans_bico-virado-fino/bico-virado-carijó_y00738
+Xenops sp._Xenops sp._xenops1
+Berlepschia rikeri_limpa-folha-do-buriti_potpal1
+Microxenops milleri_bico-virado-da-copa_rutxen1
+Pygarrhichas albogularis_white-throated treerunner_whttre2
+Ochetorhynchus andaecola_rock earthcreeper_rocear1
+Ochetorhynchus ruficaudus_straight-billed earthcreeper_stbear2
+Ochetorhynchus phoenicurus_band-tailed earthcreeper_batear1
+Ochetorhynchus melanurus_crag chilia_crachi1
+Pseudocolaptes lawrencii_buffy tuftedcheek_buftuf1
+Pseudocolaptes johnsoni_pacific tuftedcheek_buftuf3
+Pseudocolaptes boissonneautii_streaked tuftedcheek_strtuf1
+Premnornis guttuliger_rusty-winged barbtail_ruwbar1
+Tarphonomus harterti_bolivian earthcreeper_bolear1
+Tarphonomus certhioides_joão-chaquenho_chaear1
+Furnarius figulus_casaca-de-couro-da-lama_wibhor1
+Furnarius cinnamomeus_pacific hornero_palhor4
+Furnarius longirostris_caribbean hornero_palhor5
+Furnarius leucopus_casaca-de-couro-amarelo_palhor3
+Furnarius torridus_joão-de-bico-pálido_pabhor2
+Furnarius minor_joãozinho_leshor1
+Furnarius rufus_joão-de-barro_rufhor2
+Furnarius cristatus_crested hornero_crehor1
+Furnarius sp._Furnarius sp._horner1
+Lochmias nematura_joão-porca_shtstr1
+Phleocryptes melanops_bate-bico_wrlrus1
+Limnornis curvirostris_joão-da-palha_cubree1
+Geocerthia serrana_striated earthcreeper_strear1
+Upucerthia saturatior_patagonian forest earthcreeper_pafear1
+Upucerthia dumetaria_scale-throated earthcreeper_sctear1
+Upucerthia albigula_white-throated earthcreeper_whtear1
+Upucerthia validirostris_buff-breasted earthcreeper_bubear2
+Upucerthia validirostris jelskii/saturata_buff-breasted earthcreeper (Plain-breasted)_plbear1
+Upucerthia validirostris validirostris_buff-breasted earthcreeper (Buff-breasted)_bubear1
+Upucerthia sp._Upucerthia sp._upucer1
+Cinclodes pabsti_pedreiro/pedreiro-do-espinhaço_lotcin1
+Cinclodes pabsti espinhacensis_pedreiro-do-espinhaço_lotcin2
+Cinclodes pabsti pabsti_pedreiro_lotcin3
+Cinclodes fuscus_pedreiro-dos-andes_buwcin1
+Cinclodes antarcticus_blackish cinclodes_blacin1
+Cinclodes antarcticus maculirostris_blackish cinclodes (Black)_blacin2
+Cinclodes antarcticus antarcticus_blackish cinclodes (Blackish)_blacin3
+Cinclodes comechingonus_cordoba cinclodes_corcin1
+Cinclodes albidiventris_chestnut-winged cinclodes_chwcin1
+Cinclodes olrogi_olrog's cinclodes_olrcin1
+Cinclodes albiventris_cream-winged cinclodes_crwcin1
+Cinclodes albidiventris/albiventris/fuscus_bar-winged cinclodes sp._bawcin1
+Cinclodes oustaleti_gray-flanked cinclodes_gyfcin1
+Cinclodes excelsior_stout-billed cinclodes_stbcin1
+Cinclodes aricomae_royal cinclodes_roycin1
+Cinclodes palliatus_white-bellied cinclodes_whbcin1
+Cinclodes atacamensis_white-winged cinclodes_whwcin1
+Cinclodes patagonicus_dark-bellied cinclodes_dabcin1
+Cinclodes taczanowskii_surf cinclodes_surcin1
+Cinclodes nigrofumosus_seaside cinclodes_seacin1
+Cinclodes sp._Cinclodes sp._cinclo1
+Anabazenops dorsalis_barranqueiro-de-topete_ducfog1
+Anabazenops fuscus_trepador-coleira_wcfgle1
+Megaxenops parnaguae_bico-virado-da-caatinga_grexen1
+Cichlocolaptes leucophrus_trepador-sobrancelha_pabtre1
+Cichlocolaptes leucophrus leucophrus_trepador-sobrancelha (leucophrus)_pabtre2
+Cichlocolaptes leucophrus holti_trepador-sobrancelha (holti)_pabtre3
+Cichlocolaptes mazarbarnetti_trepador-do-nordeste_crytre1
+Heliobletus contaminatus_trepadorzinho_shbtre1
+Heliobletus [undescribed form]_trepadorzinho [forma não descrita]_bahtre1
+Neophilydor fuscipenne_slaty-winged foliage-gleaner_swfgle
+Neophilydor fuscipenne fuscipenne_slaty-winged foliage-gleaner (Dusky-winged)_slwfog1
+Neophilydor fuscipenne erythronotum_slaty-winged foliage-gleaner (Rufous-backed)_slwfog2
+Neophilydor erythrocercum_limpa-folha-de-sobre-ruivo_rurfog1
+Philydor novaesi_limpa-folha-do-nordeste_alfgle1
+Cichlocolaptes mazarbarnetti/Philydor novaesi_trepador-do-nordeste/limpa-folha-do-nordeste_y00969
+Philydor atricapillus_limpa-folha-coroado_bcfgle1
+Philydor pyrrhodes_limpa-folha-vermelho_crfgle1
+Philydor sp._Philydor sp._philyd1
+Anabacerthia variegaticeps_scaly-throated foliage-gleaner_stfgle1
+Anabacerthia variegaticeps variegaticeps_scaly-throated foliage-gleaner (Scaly-throated)_sctfog1
+Anabacerthia variegaticeps temporalis_scaly-throated foliage-gleaner (Spot-breasted)_sctfog2
+Anabacerthia striaticollis_montane foliage-gleaner_mofgle1
+Anabacerthia ruficaudata_limpa-folha-de-cauda-ruiva_rutfog1
+Anabacerthia amaurotis_limpa-folha-miúdo_whbfog1
+Anabacerthia lichtensteini_limpa-folha-ocráceo_obfgle2
+Anabacerthia sp._Anabacerthia sp._anabac1
+Syndactyla guttulata_guttulate foliage-gleaner_gufgle1
+Syndactyla subalaris_lineated foliage-gleaner_lifgle1
+Syndactyla rufosuperciliata_trepador-quiete_bbfgle1
+Syndactyla ruficollis_rufous-necked foliage-gleaner_rnfgle1
+Syndactyla dimidiata_limpa-folha-do-brejo_rumfog1
+Syndactyla roraimae_barranqueiro-de-roraima_wtfgle1
+Syndactyla ucayalae_limpa-folha-de-bico-virado_perrec1
+Syndactyla striata_bolivian recurvebill_bolrec1
+Syndactyla sp._Syndactyla sp._syndac1
+Ancistrops strigilatus_limpa-folha-picanço_chwhoo1
+Dendroma rufa_limpa-folha-de-testa-baia_bffgle
+Dendroma erythroptera_limpa-folha-de-asa-castanha_chwfog1
+Clibanornis rectirostris_cisqueiro-do-rio_ccfgle1
+Clibanornis dendrocolaptoides_cisqueiro_cangro1
+Clibanornis erythrocephalus_henna-hooded foliage-gleaner_hhfgle1
+Clibanornis rubiginosus_barranqueiro-ferrugem/barranqueiro-ferrugem-do-acre_rufgle1
+Clibanornis rubiginosus [rubiginosus Group]_barranqueiro-ferrugem/barranqueiro-ferrugem-do-acre [grupo rubiginosus]_rudfog1
+Clibanornis rubiginosus [nigricauda Group]_barranqueiro-ferrugem/barranqueiro-ferrugem-do-acre [grupo nigricauda]_rudfog2
+Clibanornis rubiginosus cinnamomeigula_barranqueiro-ferrugem/barranqueiro-ferrugem-do-acre (cinnamomeigula)_rudfog3
+Clibanornis rubiginosus [obscurus Group]_barranqueiro-ferrugem_rudfog4
+Clibanornis rubiginosus watkinsi_barranqueiro-ferrugem-do-acre_rudfog5
+Clibanornis rufipectus_santa marta foliage-gleaner_samfog1
+Thripadectes ignobilis_uniform treehunter_unitre1
+Thripadectes flammulatus_flammulated treehunter_flatre1
+Thripadectes scrutator_rufous-backed treehunter_rubtre1
+Thripadectes holostictus_striped treehunter_strtre1
+Thripadectes virgaticeps_streak-capped treehunter_stctre1
+Thripadectes rufobrunneus_streak-breasted treehunter_stbtre1
+Thripadectes melanorhynchus_black-billed treehunter_blbtre1
+Automolus rufipileatus_barranqueiro-de-coroa-castanha_ccfgle2
+Automolus melanopezus_barranqueiro-escuro_brfgle1
+Automolus cervinigularis_fawn-throated foliage-gleaner_butfog9
+Automolus cervinigularis cervinigularis_fawn-throated foliage-gleaner (Mexican)_butfog1
+Automolus cervinigularis hypophaeus_fawn-throated foliage-gleaner (hypophaeus)_butfog3
+Automolus exsertus_chiriqui foliage-gleaner_butfog4
+Automolus ochrolaemus_barranqueiro-camurça_btfgle1
+Automolus ochrolaemus pallidigularis_ochre-throated foliage-gleaner (pallidigularis)_butfog5
+Automolus ochrolaemus turdinus_ochre-throated foliage-gleaner (turdinus)_butfog6
+Automolus ochrolaemus ochrolaemus_ochre-throated foliage-gleaner (ochrolaemus)_butfog7
+Automolus ochrolaemus auricularis_ochre-throated foliage-gleaner (auricularis)_butfog8
+Automolus cervinigularis/ochrolaemus_fawn-throated/ochre-throated foliage-gleaner_y01220
+Automolus virgatus_western woodhaunter_strwoo5
+Automolus subulatus_limpa-folha-riscado_strwoo4
+Automolus infuscatus_barranqueiro-pardo/barranqueiro-pardo-do-norte_obfgle3
+Automolus infuscatus cervicalis/badius_barranqueiro-pardo-do-norte_olbfog2
+Automolus infuscatus infuscatus/purusianus_barranqueiro-pardo_olbfog1
+Automolus paraensis_barranqueiro-do-pará_parfog1
+Automolus lammi_barranqueiro-do-nordeste_perfog1
+Automolus leucophthalmus_barranqueiro-de-olho-branco_wefgle1
+Automolus sp._Automolus sp._automo1
+Furnariidae sp. (foliage-gleaner sp.)_furnariidae sp. (limpa-folha sp.)_foliag1
+Premnoplex brunnescens_spotted barbtail_spobar1
+Premnoplex tatei_white-throated barbtail_whtbar1
+Premnoplex tatei tatei_white-throated barbtail (White-throated)_whtbar2
+Premnoplex tatei pariae_white-throated barbtail (Paria)_whtbar3
+Margarornis bellulus_beautiful treerunner_beatre1
+Margarornis rubiginosus_ruddy treerunner_rudtre1
+Margarornis stellatus_fulvous-dotted treerunner_fudtre1
+Margarornis squamiger_pearled treerunner_peatre1
+Aphrastura spinicauda_thorn-tailed rayadito_thtray1
+Aphrastura masafuerae_masafuera rayadito_masray1
+Sylviorthorhynchus desmursii_des murs's wiretail_demwir1
+Sylviorthorhynchus yanacensis_tawny tit-spinetail_tatspi1
+Leptasthenura fuliginiceps_brown-capped tit-spinetail_bctspi1
+Leptasthenura platensis_rabudinho_tutspi1
+Leptasthenura aegithaloides_plain-mantled tit-spinetail_pmtspi1
+Leptasthenura aegithaloides grisescens_plain-mantled tit-spinetail (grisescens)_plmtis3
+Leptasthenura aegithaloides berlepschi_plain-mantled tit-spinetail (berlepschi)_plmtis2
+Leptasthenura aegithaloides aegithaloides_plain-mantled tit-spinetail (aegithaloides)_plmtis1
+Leptasthenura aegithaloides pallida_plain-mantled tit-spinetail (pallida)_plmtis4
+Leptasthenura striolata_grimpeirinho_sttspi2
+Leptasthenura pileata_rusty-crowned tit-spinetail_rctspi1
+Leptasthenura xenothorax_white-browed tit-spinetail_wbtspi1
+Leptasthenura striata_streaked tit-spinetail_sttspi1
+Leptasthenura striata striata/superciliaris_streaked tit-spinetail (Streak-throated)_strtis4
+Leptasthenura striata albigularis_streaked tit-spinetail (White-throated)_strtis2
+Leptasthenura andicola_andean tit-spinetail_antspi1
+Leptasthenura setaria_grimpeiro_artspi1
+Leptasthenura sp._Leptasthenura sp._titspi1
+Phacellodomus inornatus_plain thornbird_ruftho3
+Phacellodomus rufifrons_joão-de-pau_ruftho1
+Phacellodomus rufifrons [rufifrons Group]_joão-de-pau [grupo rufifrons]_ruftho2
+Phacellodomus rufifrons specularis_joão-de-pau (specularis)_ruftho7
+Phacellodomus [undescribed form]_mantaro thornbird (undescribed form)_mantho1
+Phacellodomus striaticeps_streak-fronted thornbird_stftho1
+Phacellodomus sibilatrix_tio-tio-pequeno_littho1
+Phacellodomus dorsalis_chestnut-backed thornbird_chbtho1
+Phacellodomus maculipectus_spot-breasted thornbird_spbtho1
+Phacellodomus striaticollis_tio-tio_frbtho1
+Phacellodomus ruber_graveteiro_gretho2
+Phacellodomus erythrophthalmus_joão-botina-da-mata_oretho1
+Phacellodomus ferrugineigula_joão-botina-do-brejo_orbtho1
+Phacellodomus erythrophthalmus/ferrugineigula_joão-botina-da-mata/joão-botina-do-brejo_reetho1
+Phacellodomus sp._Phacellodomus sp._thornb2
+Hellmayrea gularis_white-browed spinetail_whbspi2
+Hellmayrea gularis gularis_white-browed spinetail (gularis)_whbspi3
+Hellmayrea gularis brunneidorsalis_white-browed spinetail (brunneidorsalis)_whbspi4
+Hellmayrea gularis cinereiventris_white-browed spinetail (cinereiventris)_whbspi5
+Hellmayrea gularis rufiventris_white-browed spinetail (rufiventris)_whbspi6
+Anumbius annumbi_cochicho_firgat1
+Coryphistera alaudina_corredor-crestudo_lalbru1
+Asthenes dorbignyi_creamy-breasted canastero_crbcan1
+Asthenes dorbignyi huancavelicae_creamy-breasted canastero (Huancavelica)_crbcan5
+Asthenes dorbignyi arequipae_creamy-breasted canastero (Dark-winged)_crbcan4
+Asthenes dorbignyi usheri_creamy-breasted canastero (Pale-tailed)_crbcan3
+Asthenes dorbignyi dorbignyi/consobrina_creamy-breasted canastero (Rusty-vented)_crbcan2
+Asthenes berlepschi_berlepsch's canastero_bercan1
+Asthenes baeri_lenheiro_shbcan1
+Asthenes luizae_lenheiro-da-serra-do-cipó_cipcan1
+Asthenes hudsoni_joão-platino_hudcan1
+Asthenes anthoides_austral canastero_auscan1
+Asthenes urubambensis_line-fronted canastero_lifcan1
+Asthenes flammulata_many-striped canastero_mascan1
+Asthenes virgata_junin canastero_juncan1
+Asthenes maculicauda_scribble-tailed canastero_sctcan1
+Asthenes wyatti_streak-backed canastero_stbcan9
+Asthenes wyatti [wyatti Group]_streak-backed canastero (Streak-backed)_stbcan1
+Asthenes wyatti [sclateri Group]_streak-backed canastero (Puna)_puncan1
+Asthenes humilis_streak-throated canastero_sttcan1
+Asthenes modesta_cordilleran canastero_corcan1
+Asthenes moreirae_garrincha-chorona_itaspi1
+Asthenes pyrrholeuca_lenheiro-de-rabo-comprido_shbcan2
+Asthenes harterti_black-throated thistletail_bltthi1
+Asthenes helleri_puna thistletail_punthi1
+Asthenes ayacuchensis_ayacucho thistletail_vilthi3
+Asthenes vilcabambae_vilcabamba thistletail_vilthi2
+Asthenes pudibunda_canyon canastero_cancan1
+Asthenes ottonis_rusty-fronted canastero_rufcan1
+Asthenes heterura_maquis canastero_maqcan1
+Asthenes palpebralis_eye-ringed thistletail_eyrthi1
+Asthenes coryi_ochre-browed thistletail_ocbthi1
+Asthenes perijana_perija thistletail_perthi1
+Asthenes fuliginosa_white-chinned thistletail_whcthi1
+Asthenes fuliginosa fumigata_white-chinned thistletail (fumigata)_whcthi2
+Asthenes fuliginosa fuliginosa_white-chinned thistletail (fuliginosa)_whcthi3
+Asthenes fuliginosa peruviana/plengei_white-chinned thistletail (peruviana/plengei)_whcthi6
+Asthenes griseomurina_mouse-colored thistletail_mocthi1
+Asthenes sp._lenheiro (Asthenes) sp._canast1
+Acrobatornis fonsecai_acrobata_pilgra1
+Metopothrix aurantiaca_joão-folheiro_orfplu2
+Xenerpestes minlosi_double-banded graytail_dobgra1
+Xenerpestes singularis_equatorial graytail_equgra1
+Siptornis striaticollis_spectacled prickletail_spepri1
+Roraimia adusta_joão-de-roraima_rorbar1
+Thripophaga gutturata_joão-pintado_spespi1
+Thripophaga macroura_rabo-amarelo_strsof1
+Thripophaga cherriei_orinoco softtail_orisof1
+Thripophaga amacurensis_delta amacuro softtail_deasof1
+Thripophaga fusciceps_joão-liso_plasof1
+Thripophaga fusciceps dimorpha_joão-liso (dimorpha)_plasof2
+Thripophaga fusciceps obidensis_joão-liso (obidensis)_plasof4
+Thripophaga fusciceps fusciceps_joão-liso (fusciceps)_plasof3
+Thripophaga sp._Thripophaga sp._softta1
+Limnoctites rectirostris_arredio-do-gravatá_stbree2
+Limnornis curvirostris/Limnoctites rectirostris_junqueiro-de-bico-curvo/junqueiro-de-bico-direito_y00686
+Limnoctites sulphuriferus_arredio-de-papo-manchado_sutspi1
+Cranioleuca berlepschi_russet-mantled softtail_rumsof1
+Cranioleuca marcapatae_marcapata spinetail_marspi2
+Cranioleuca marcapatae weskei_marcapata spinetail (Pale-crowned)_marspi1
+Cranioleuca marcapatae marcapatae_marcapata spinetail (Rufous-crowned)_marspi4
+Cranioleuca albiceps_light-crowned spinetail_licspi1
+Cranioleuca albiceps albiceps_light-crowned spinetail (White-crowned)_licspi3
+Cranioleuca albiceps discolor_light-crowned spinetail (Buffy-crowned)_licspi4
+Cranioleuca vulpina_arredio-do-rio_rubspi4
+Cranioleuca dissita_coiba spinetail_rubspi5
+Cranioleuca vulpecula_arredio-de-peito-branco_parspi1
+Cranioleuca subcristata_crested spinetail_crespi1
+Cranioleuca pyrrhophia_arredio_stcspi2
+Cranioleuca henricae_bolivian spinetail_bolspi1
+Cranioleuca obsoleta_arredio-oliváceo_olispi1
+Cranioleuca pyrrhophia x obsoleta_arredio x arredio-oliváceo (híbrido)_x00740
+Cranioleuca pallida_arredio-pálido_palspi1
+Cranioleuca semicinerea_joão-de-cabeça-cinza_gyhspi1
+Cranioleuca albicapilla_creamy-crested spinetail_crcspi1
+Cranioleuca erythrops_red-faced spinetail_refspi1
+Cranioleuca demissa_joão-do-tepui_tepspi1
+Cranioleuca hellmayri_streak-capped spinetail_stcspi1
+Cranioleuca curtata_ash-browed spinetail_asbspi1
+Cranioleuca antisiensis_line-cheeked spinetail_licspi5
+Cranioleuca antisiensis antisiensis/palamblae_line-cheeked spinetail (Line-cheeked)_licspi2
+Cranioleuca antisiensis [baroni Group]_line-cheeked spinetail (Baron's)_barspi1
+Cranioleuca muelleri_joão-escamoso_scaspi1
+Cranioleuca sp._Cranioleuca sp._cranio1
+Pseudasthenes humicola_dusky-tailed canastero_dutcan1
+Pseudasthenes patagonica_patagonian canastero_patcan2
+Pseudasthenes steinbachi_steinbach's canastero_stecan1
+Pseudasthenes cactorum_cactus canastero_caccan1
+Spartonoica maluroides_boininha_bcwspi1
+Pseudoseisura cristata_casaca-de-couro_caacac1
+Pseudoseisura unirufa_casaca-de-couro-de-crista-cinza_rufcac2
+Pseudoseisura lophotes_coperete_brncac1
+Pseudoseisura gutturalis_white-throated cacholote_whtcac2
+Certhiaxis cinnamomeus_curutié_yecspi2
+Certhiaxis mustelinus_joão-da-canarana_rawspi2
+Certhiaxis cinnamomeus/mustelinus_curutié/joão-da-canarana_y00970
+Certhiaxis [undescribed form]_curutié-do-araguaia (espécie não descrita)_arrspi1
+Mazaria propinqua_joão-de-barriga-branca_whbspi1
+Schoeniophylax phryganophilus_bichoita_chospi2
+Synallaxis scutata_estrelinha-preta_occspi1
+Synallaxis cinerascens_pi-puí_gybspi1
+Synallaxis gujanensis_joão-teneném-becuá_plcspi1
+Synallaxis albilora_joão-do-pantanal_whlspi1
+Synallaxis simoni_joão-do-araguaia_whlspi3
+Synallaxis maranonica_marañon spinetail_marspi3
+Synallaxis hypochondriaca_great spinetail_grespi2
+Synallaxis stictothorax_necklaced spinetail_necspi1
+Synallaxis stictothorax [undescribed La Libertad form]_necklaced spinetail (La Libertad)_necspi4
+Synallaxis chinchipensis_chinchipe spinetail_necspi3
+Synallaxis zimmeri_russet-bellied spinetail_rubspi3
+Synallaxis brachyura_slaty spinetail_slaspi1
+Synallaxis subpudica_silvery-throated spinetail_sitspi1
+Synallaxis hellmayri_joão-xique-xique_resspi2
+Synallaxis ruficapilla_pichororé_rucspi1
+Synallaxis cinerea_joão-baiano_bahspi1
+Synallaxis infuscata_tatac_pinspi1
+Synallaxis [undescribed Amazonian form]_joão-do-norte [forma não descrita]_amaspi1
+Synallaxis moesta_dusky spinetail_dusspi1
+Synallaxis macconnelli_joão-escuro_mccspi1
+Synallaxis cabanisi_joão-de-cabanis_cabspi1
+Synallaxis hypospodia_joão-grilo_cibspi1
+Synallaxis spixi_joão-teneném_spispi1
+Synallaxis albigularis_joão-de-peito-escuro_dabspi1
+Synallaxis beverlyae_rio orinoco spinetail_riospi1
+Synallaxis albescens_uí-pi_pabspi1
+Synallaxis albescens [albescens Group]_uí-pi [grupo albescens]_pabspi15
+Synallaxis albescens australis_uí-pi (australis)_pabspi14
+Synallaxis frontalis_petrim_sofspi1
+Synallaxis azarae_azara's spinetail_azaspi1
+Synallaxis [undescribed Mantaro form]_mantaro spinetail (undescribed form)_manspi1
+Synallaxis courseni_apurimac spinetail_apuspi1
+Synallaxis azarae/courseni_azara's/apurimac spinetail_y00700
+Synallaxis kollari_joão-de-barba-grisalha_hotspi1
+Synallaxis erythrothorax_rufous-breasted spinetail_rubspi2
+Synallaxis candei_white-whiskered spinetail_whwspi1
+Synallaxis tithys_blackish-headed spinetail_blhspi1
+Synallaxis fuscorufa_rusty-headed spinetail_ruhspi1
+Synallaxis unirufa_rufous spinetail_rufspi1
+Synallaxis unirufa unirufa_rufous spinetail (unirufa)_rufspi2
+Synallaxis unirufa munoztebari_rufous spinetail (munoztebari)_rufspi3
+Synallaxis unirufa meridana_rufous spinetail (meridana)_rufspi4
+Synallaxis unirufa ochrogaster_rufous spinetail (ochrogaster)_rufspi5
+Synallaxis castanea_black-throated spinetail_bltspi1
+Synallaxis cinnamomea_stripe-breasted spinetail_stbspi1
+Synallaxis rutilans_joão-teneném-castanho_rudspi1
+Synallaxis rutilans [rutilans Group]_ruddy spinetail (Ruddy)_rudspi9
+Synallaxis rutilans omissa_ruddy spinetail (Sooty)_rudspi7
+Synallaxis cherriei_puruchém_chtspi1
+Synallaxis sp._Synallaxis sp._synall1
+Furnariidae sp. (spinetail sp.)_spinetail sp._spinet1
+Furnariidae sp._Furnariidae sp._furnar1
+Tyranneutes stolzmanni_uirapuruzinho_dwtman1
+Tyranneutes virescens_uirapuruzinho-do-norte_titman1
+Neopelma pallescens_fruxu-do-cerradão_pbtman1
+Neopelma chrysocephalum_fruxu-do-carrasco_sctman1
+Neopelma aurifrons_fruxu-baiano_witman1
+Neopelma chrysolophum_fruxu_sdmman1
+Neopelma sulphureiventer_fruxu-de-barriga-amarela_sbtman1
+Chloropipo flavicapilla_yellow-headed manakin_yehman2
+Chloropipo unicolor_jet manakin_jetman2
+Chiroxiphia bokermanni_soldadinho-do-araripe_araman1
+Chiroxiphia galeata_soldadinho_helman1
+Chiroxiphia lanceolata_lance-tailed manakin_latman1
+Chiroxiphia linearis_long-tailed manakin_lotman1
+Chiroxiphia pareola_tangará-príncipe/de-coroa-amarela_blbman1
+Chiroxiphia pareola pareola/atlantica_tangará-príncipe (pareola/atlantica)_bubman2
+Chiroxiphia pareola napensis_tangará-príncipe (napensis)_bubman1
+Chiroxiphia pareola regina_tangará-de-coroa-amarela_bubman3
+Chiroxiphia galeata x pareola_helmeted x blue-backed manakin (hybrid)_x01090
+Chiroxiphia boliviana_yungas manakin_yunman1
+Chiroxiphia caudata_tangará_swtman1
+Chiroxiphia galeata x caudata_soldadinho x tangará (híbrido) (rei-dos-tangarás)_x00960
+Ilicura militaris_tangarazinho_pitman1
+Masius chrysopterus_golden-winged manakin_gowman1
+Corapipo altera_white-ruffed manakin_whrman1
+Corapipo leucorrhoa_white-bibbed manakin_whbman2
+Corapipo gutturalis_dançarino-de-garganta-branca_whtman1
+Xenopipo uniformis_dançarino-oliváceo_oliman2
+Xenopipo atronitens_pretinho_blaman1
+Cryptopipo litae_choco manakin_grnman1
+Cryptopipo holochlora_green manakin_greman2
+Lepidothrix velutina_velvety manakin_bucman1
+Lepidothrix coronata_uirapuru-de-chapéu-azul_blcman1
+Lepidothrix coronata [coronata Group]_blue-capped manakin (Blue-capped)_bucman2
+Lepidothrix coronata [exquisita Group]_blue-capped manakin (Exquisite)_bucman3
+Lepidothrix nattereri_uirapuru-de-chapéu-branco_sncman1
+Lepidothrix vilasboasi_dançador-de-coroa-dourada_gocman2
+Lepidothrix iris_cabeça-de-prata_opcman1
+Lepidothrix suavissima_dançador-do-tepui_orbman1
+Lepidothrix serena_uirapuru-estrela_whfman1
+Lepidothrix suavissima/serena_dançador-do-tepui/uirapuru-estrela_y00886
+Lepidothrix isidorei_blue-rumped manakin_blrman1
+Lepidothrix coeruleocapilla_cerulean-capped manakin_cecman1
+Lepidothrix sp._Lepidothrix sp._lepido2
+Heterocercus aurantiivertex_dançarino-de-crista-laranja_orcman3
+Heterocercus flavivertex_dançarino-de-crista-amarela_yecman2
+Heterocercus linteatus_coroa-de-fogo_flcman2
+Heterocercus sp._Heterocercus sp._hetero1
+Manacus candei_white-collared manakin_whcman1
+Manacus aurantiacus_orange-collared manakin_orcman1
+Manacus vitellinus_golden-collared manakin_gocman1
+Manacus candei x vitellinus_white-collared x golden-collared manakin (hybrid)_x00811
+Manacus manacus_rendeira_whbman1
+Manacus vitellinus x manacus_golden-collared x white-bearded manakin (hybrid)_x01166
+Manacus vitellinus/manacus_golden-collared/white-bearded manakin_y01327
+Pipra aureola_uirapuru-vermelho_crhman1
+Pipra filicauda_rabo-de-arame_witman2
+Pipra fasciicauda_uirapuru-laranja_batman1
+Machaeropterus deliciosus_club-winged manakin_clwman1
+Machaeropterus striolatus_tangará-riscado_strman5
+Machaeropterus striolatus [striolatus Group]_tangará-riscado [grupo striolatus]_strman3
+Machaeropterus striolatus aureopectus_tangará-riscado (aureopectus)_strman4
+Machaeropterus eckelberryi_painted manakin_paiman1
+Machaeropterus striolatus/eckelberryi_striolated/painted manakin_y01121
+Machaeropterus regulus_tangará-rajado_strman2
+Machaeropterus pyrocephalus_uirapuru-cigarra_ficman1
+Pseudopipra pipra_cabeça-branca_whcman2
+Pseudopipra pipra anthracina_cabeça-branca (anthracina)_whcman3
+Pseudopipra pipra minima_white-crowned manakin (Choco)_whcman7
+Pseudopipra pipra unica/bolivari_white-crowned manakin (Colombian)_whcman17
+Pseudopipra pipra coracina_white-crowned manakin (Foothills)_whcman6
+Pseudopipra pipra comata/occulta_white-crowned manakin (Subtropical)_whcman18
+Pseudopipra pipra pipra_white-crowned manakin (Guianan)_whcman9
+Pseudopipra pipra [microlopha Group]_white-crowned manakin (Amazonian)_whcman19
+Pseudopipra pipra cephaleucos_white-crowned manakin (Atlantic)_whcman16
+Ceratopipra cornuta_dançador-de-crista_schman1
+Ceratopipra mentalis_red-capped manakin_recman1
+Ceratopipra erythrocephala_cabeça-de-ouro_gohman1
+Ceratopipra rubrocapilla_cabeça-encarnada_rehman1
+Ceratopipra chloromeros_dançador-de-cauda-graduada_rotman1
+Pipridae sp._Pipridae sp._manaki1
+Carpornis cucullata_corocoxó_hoober2
+Carpornis melanocephala_sabiá-pimenta_bkhber1
+Pipreola riefferii_green-and-black fruiteater_gabfru1
+Pipreola riefferii [riefferii Group]_green-and-black fruiteater (Green-and-black)_gabfru4
+Pipreola riefferii tallmanorum_green-and-black fruiteater (Sira)_gabfru3
+Pipreola intermedia_band-tailed fruiteater_batfru1
+Pipreola intermedia intermedia_band-tailed fruiteater (intermedia)_batfru2
+Pipreola intermedia signata_band-tailed fruiteater (signata)_batfru3
+Pipreola arcuata_barred fruiteater_barfru1
+Pipreola aureopectus_golden-breasted fruiteater_gobfru1
+Pipreola jucunda_orange-breasted fruiteater_orbfru1
+Pipreola lubomirskii_black-chested fruiteater_blcfru1
+Pipreola pulchra_masked fruiteater_masfru1
+Pipreola frontalis_scarlet-breasted fruiteater_scbfru1
+Pipreola frontalis squamipectus_scarlet-breasted fruiteater (squamipectus)_scbfru2
+Pipreola frontalis frontalis_scarlet-breasted fruiteater (frontalis)_scbfru3
+Pipreola chlorolepidota_fiery-throated fruiteater_fitfru1
+Pipreola formosa_handsome fruiteater_hanfru1
+Pipreola whitelyi_anambé-dos-tepuis_rebfru1
+Pipreola sp._Pipreola sp._pipreo1
+Ampelioides tschudii_scaled fruiteater_scafru1
+Zaratornis stresemanni_white-cheeked cotinga_whccot1
+Phytotoma raimondii_peruvian plantcutter_perpla1
+Phytotoma rutila_corta-ramos_whtpla1
+Phytotoma rara_rufous-tailed plantcutter_rutpla1
+Phibalura flavirostris_tesourinha-da-mata_swtcot1
+Phibalura flavirostris boliviana_tesourinha-da-mata (boliviana)_swtcot2
+Phibalura flavirostris flavirostris_tesourinha-da-mata (flavirostris)_swtcot3
+Doliornis remseni_chestnut-bellied cotinga_chbcot1
+Doliornis sclateri_bay-vented cotinga_bavcot1
+Ampelion rubrocristatus_red-crested cotinga_reccot1
+Ampelion rufaxilla_chestnut-crested cotinga_chccot1
+Phoenicircus carnifex_saurá_gurcot1
+Phoenicircus nigricollis_saurá-de-pescoço-preto_bnrcot1
+Rupicola rupicola_galo-da-serra_gcoroc1
+Rupicola peruvianus_andean cock-of-the-rock_andcot1
+Snowornis subalaris_gray-tailed piha_gytpih1
+Snowornis cryptolophus_olivaceous piha_olipih2
+Haematoderus militaris_anambé-militar_crifru1
+Querula purpurata_anambé-una_putfru1
+Pyroderus scutatus_pavó_rerfru1
+Cephalopterus glabricollis_bare-necked umbrellabird_banumb1
+Cephalopterus ornatus_anambé-preto_amaumb1
+Cephalopterus penduliger_long-wattled umbrellabird_lowumb1
+Perissocephalus tricolor_maú_capuch1
+Cotinga amabilis_lovely cotinga_lovcot1
+Cotinga ridgwayi_turquoise cotinga_turcot1
+Cotinga nattererii_blue cotinga_blucot1
+Cotinga maynana_anambé-turquesa_pltcot1
+Cotinga cotinga_anambé-de-peito-roxo_pubcot1
+Cotinga maculata_crejoá_bancot1
+Cotinga cayana_anambé-azul_spacot1
+Cotinga sp._Cotinga sp._blucot2
+Lipaugus unirufus_rufous piha_rufpih1
+Lipaugus streptophorus_cricrió-de-cinta-vermelha_rocpih1
+Lipaugus vociferans_cricrió_scrpih1
+Lipaugus lanioides_tropeiro-da-serra_civpih1
+Lipaugus ater_saudade_bagcot1
+Lipaugus conditus_saudade-de-asa-cinza_gywcot1
+Lipaugus weberi_chestnut-capped piha_chcpih1
+Lipaugus fuscocinereus_dusky piha_duspih1
+Lipaugus uropygialis_scimitar-winged piha_scwpih1
+Procnias tricarunculatus_three-wattled bellbird_thwbel
+Procnias albus_araponga-da-amazônia_whibel2
+Procnias averano_araponga-do-nordeste_beabel1
+Procnias nudicollis_araponga_batbel1
+Porphyrolaema porphyrolaema_anambé-de-garganta-encarnada_putcot1
+Carpodectes hopkei_black-tipped cotinga_bltcot1
+Carpodectes antoniae_yellow-billed cotinga_yebcot1
+Carpodectes nitidus_snowy cotinga_snocot1
+Xipholena punicea_anambé-roxo_pomcot1
+Xipholena lamellipennis_anambé-de-rabo-branco_whtcot1
+Xipholena atropurpurea_anambé-de-asa-branca_whwcot1
+Gymnoderus foetidus_anambé-pombo_banfru1
+Conioptilon mcilhennyi_anambé-de-cara-preta_blfcot1
+Tityra cayana_anambé-branco-de-rabo-preto_blttit1
+Tityra cayana braziliensis_anambé-branco-de-rabo-preto (braziliensis)_bkttit4
+Tityra cayana cayana_anambé-branco-de-rabo-preto (cayana)_bkttit5
+Tityra inquisitor_anambé-branco-de-bochecha-parda_blctit1
+Tityra leucura_anambé-branco-de-rabo-branco_whttit2
+Tityra semifasciata_anambé-branco-de-máscara-negra_mastit1
+Tityra sp._Tityra sp._tityra1
+Schiffornis major_flautim-ruivo_varsch1
+Schiffornis olivacea_flautim-oliváceo_thlsch7
+Schiffornis veraepacis_northern schiffornis_thlsch2
+Schiffornis veraepacis [veraepacis Group]_northern schiffornis (Northern)_norsch1
+Schiffornis veraepacis rosenbergi_northern schiffornis (Ecuadorian)_thlsch5
+Schiffornis aenea_foothill schiffornis_thlsch8
+Schiffornis stenorhyncha_russet-winged schiffornis_thlsch4
+Schiffornis turdina_flautim-marrom/flautim-da-amazônia_thlsch3
+Schiffornis turdina amazonum_flautim-da-amazônia_thlsch6
+Schiffornis turdina [turdina Group]_flautim-marrom_bnwsch1
+Schiffornis virescens_flautim_gresch2
+Schiffornis sp._Schiffornis sp._thlsch
+Laniocera hypopyrra_chorona-cinza_cinmou1
+Laniocera rufescens_speckled mourner_spemou1
+Iodopleura isabellae_anambé-de-coroa_whbpur1
+Iodopleura fusca_anambé-fusco_duspur1
+Iodopleura pipra_anambezinho_butpur1
+Iodopleura pipra leucopygia_anambezinho (leucopygia)_butpur2
+Iodopleura pipra pipra_anambezinho (pipra)_butpur3
+Laniisoma buckleyi_andean laniisoma_shlcot2
+Laniisoma elegans_chibante_shlcot3
+Xenopsaris albinucha_tijerila_whnxen1
+Pachyramphus viridis_caneleiro-verde/caneleiro-de-cara-amarela_grbbec1
+Pachyramphus viridis xanthogenys/peruanus_caneleiro-de-cara-amarela_gnbbec2
+Pachyramphus viridis griseigularis_caneleiro-verde (griseigularis)_gnbbec3
+Pachyramphus viridis viridis_caneleiro-verde_gnbbec1
+Pachyramphus versicolor_barred becard_barbec1
+Pachyramphus spodiurus_slaty becard_slabec1
+Pachyramphus rufus_caneleiro-cinzento_cinbec2
+Pachyramphus cinnamomeus_cinnamon becard_cinbec1
+Pachyramphus castaneus_caneleiro_chcbec1
+Pachyramphus polychopterus_caneleiro-preto_whwbec1
+Pachyramphus albogriseus_black-and-white becard_bawbec7
+Pachyramphus salvini_cryptic becard_bawbec6
+Pachyramphus albogriseus/salvini_black-and-white/cryptic becard_bawbec1
+Pachyramphus major_gray-collared becard_grcbec1
+Pachyramphus major uropygialis_gray-collared becard (Western)_gycbec2
+Pachyramphus major [major Group]_gray-collared becard (Eastern)_gycbec1
+Pachyramphus marginatus_caneleiro-bordado_blcbec1
+Pachyramphus surinamus_caneleiro-da-guiana_glbbec1
+Pachyramphus aglaiae_rose-throated becard_rotbec
+Pachyramphus niger_jamaican becard_jambec1
+Pachyramphus homochrous_one-colored becard_oncbec1
+Pachyramphus minor_caneleiro-pequeno_pitbec1
+Pachyramphus validus_caneleiro-de-chapéu-preto_crebec1
+Pachyramphus sp._Pachyramphus sp._becard1
+Oxyruncus cristatus_araponga-do-horto_sharpb1
+Onychorhynchus coronatus_maria-leque_royfly1
+Onychorhynchus coronatus mexicanus/fraterculus_tropical royal flycatcher (Northern)_royfly2
+Onychorhynchus coronatus occidentalis_tropical royal flycatcher (Pacific)_royfly3
+Onychorhynchus coronatus coronatus/castelnaui_maria-leque (coronatus/castelnaui)_royfly4
+Onychorhynchus swainsoni_maria-leque-do-sudeste_royfly5
+Terenotriccus erythrurus_papa-moscas-uirapuru_rutfly2
+Myiobius villosus_tawny-breasted flycatcher_tabfly1
+Myiobius sulphureipygius_sulphur-rumped flycatcher_surfly1
+Myiobius barbatus_assanhadinho_whifly1
+Myiobius barbatus [barbatus Group]_assanhadinho [grupo barbatus]_surfly4
+Myiobius barbatus mastacalis_assanhadinho (mastacalis)_surfly5
+Myiobius atricaudus_assanhadinho-de-cauda-preta_bltfly1
+Myiobius atricaudus [atricaudus Group]_assanhadinho-de-cauda-preta [grupo atricaudus]_bktfly1
+Myiobius atricaudus ridgwayi_assanhadinho-de-cauda-preta (ridgwayi)_bktfly2
+Myiobius sulphureipygius/atricaudus_sulphur-rumped/black-tailed flycatcher_y01037
+Myiobius barbatus/atricaudus_assanhadinho/assanhadinho-de-cauda-preta_y01038
+Myiobius sp._Myiobius sp._myiobi1
+Piprites chloris_papinho-amarelo_wibpip1
+Piprites griseiceps_gray-headed piprites_grhpip1
+Piprites pileata_caneleirinho-de-chapéu-preto_bkcpip1
+Neopipo cinnamomea_enferrujadinho_cinmat1
+Calyptura cristata_tietê-de-coroa_kincal1
+Platyrinchus saturatus_patinho-escuro_cicspa1
+Platyrinchus cancrominus_stub-tailed spadebill_sttspa1
+Platyrinchus mystaceus_patinho_whtspa1
+Platyrinchus mystaceus [albogularis Group]_patinho [grupo albogularis]_whtspa2
+Platyrinchus mystaceus [mystaceus Group]_patinho [grupo mystaceus]_whtspa3
+Platyrinchus coronatus_patinho-de-coroa-dourada_gocspa1
+Platyrinchus flavigularis_yellow-throated spadebill_yetspa1
+Platyrinchus platyrhynchos_patinho-de-coroa-branca_whcspa1
+Platyrinchus leucoryphus_patinho-de-asa-castanha_ruwspa1
+Platyrinchus sp._Platyrinchus sp._spadeb1
+Tachuris rubrigastra_papa-piri_mcrtyr1
+Mionectes striaticollis_streak-necked flycatcher_stnfly1
+Mionectes olivaceus_olive-streaked flycatcher_olsfly2
+Mionectes galbinus_olive-striped flycatcher_olsfly1
+Mionectes striaticollis/galbinus_streak-necked/olive-striped flycatcher_y00796
+Mionectes olivaceus/galbinus_olive-streaked/olive-striped flycatcher_y01249
+Mionectes oleagineus_abre-asa_ocbfly1
+Mionectes oleagineus assimilis_abre-asa (assimilis)_ocbfly3
+Mionectes oleagineus parcus_abre-asa (parcus)_ocbfly4
+Mionectes oleagineus pacificus_abre-asa (pacificus)_ocbfly5
+Mionectes oleagineus [oleagineus Group]_abre-asa [grupo oleagineus]_ocbfly10
+Mionectes macconnelli_abre-asa-da-mata/do-acre_mccfly1
+Mionectes macconnelli macconnelli_abre-asa-da-mata_mccfly2
+Mionectes macconnelli amazonus/peruanus_abre-asa-do-acre_mccfly4
+Mionectes oleagineus/macconnelli_abre-asa/abre-asa-da-mata_y00797
+Mionectes roraimae_abre-asa-do-tepui_mccfly3
+Mionectes macconnelli/roraimae_mcconnell's/sierra de lema flycatcher_y00406
+Mionectes rufiventris_abre-asa-de-cabeça-cinza_gyhfly1
+Mionectes sp._Mionectes sp._mionec1
+Leptopogon amaurocephalus_cabeçudo_secfly1
+Leptopogon superciliaris_slaty-capped flycatcher_slcfly1
+Leptopogon superciliaris transandinus_slaty-capped flycatcher (transandinus)_slcfly4
+Leptopogon superciliaris superciliaris_slaty-capped flycatcher (superciliaris)_slcfly2
+Leptopogon superciliaris albidiventer_slaty-capped flycatcher (albidiventer)_slcfly3
+Leptopogon rufipectus_rufous-breasted flycatcher_rubfly2
+Leptopogon taczanowskii_inca flycatcher_incfly1
+Pogonotriccus difficilis_estalinho_sdmtyr2
+Pogonotriccus eximius_barbudinho_sobtyr2
+Pogonotriccus ophthalmicus_marble-faced bristle-tyrant_mfbtyr1
+Pogonotriccus lanyoni_antioquia bristle-tyrant_anbtyr1
+Pogonotriccus paulista_não-pode-parar_saptyr1
+Pogonotriccus poecilotis_variegated bristle-tyrant_vabtyr1
+Pogonotriccus venezuelanus_venezuelan bristle-tyrant_vebtyr2
+Pogonotriccus orbitalis_spectacled bristle-tyrant_spbtyr1
+Pogonotriccus chapmani_barbudinho-do-tepui_chabrt1
+Phylloscartes oustaleti_papa-moscas-de-olheiras_oustyr1
+Phylloscartes flavovirens_yellow-green tyrannulet_yegtyr1
+Phylloscartes virescens_borboletinha-guianense_olgtyr1
+Phylloscartes ventralis_borboletinha-do-mato_moctyr2
+Phylloscartes beckeri_borboletinha-baiana_bahtyr1
+Phylloscartes kronei_maria-da-restinga_restyr1
+Phylloscartes sylviolus_maria-pequena_bartyr1
+Phylloscartes ceciliae_cara-pintada_alatyr1
+Phylloscartes roquettei_cara-dourada_migtyr1
+Phylloscartes superciliaris_rufous-browed tyrannulet_rubtyr1
+Phylloscartes nigrifrons_maria-de-testa-preta_blftyr1
+Phylloscartes flaviventris_rufous-lored tyrannulet_rultyr1
+Phylloscartes gualaquizae_ecuadorian tyrannulet_ecutyr1
+Phylloscartes parkeri_cinnamon-faced tyrannulet_ciftyr1
+Phylloscartes sp._Phylloscartes sp._phyllo2
+Pseudotriccus pelzelni_bronze-olive pygmy-tyrant_boptyr1
+Pseudotriccus pelzelni annectens/berlepschi_bronze-olive pygmy-tyrant (annectens/berlepschi)_bropyt1
+Pseudotriccus pelzelni pelzelni/peruvianus_bronze-olive pygmy-tyrant (pelzelni/peruvianus)_bropyt2
+Pseudotriccus simplex_hazel-fronted pygmy-tyrant_hfptyr1
+Pseudotriccus ruficeps_rufous-headed pygmy-tyrant_rhptyr1
+Corythopis torquatus_estalador-do-norte_rinant2
+Corythopis delalandi_estalador_souant1
+Myiornis auricularis_miudinho_eaptyr1
+Myiornis auricularis [undescribed form]_miúdinho [forma não descrita]_earpyt3
+Myiornis [undescribed form]_grilinho-de-caxias [forma não descrita]_mappyt1
+Myiornis albiventris_white-bellied pygmy-tyrant_wbptyr1
+Myiornis atricapillus_black-capped pygmy-tyrant_bcptyr1
+Myiornis ecaudatus_caçula_stptyr1
+Lophotriccus pileatus_scale-crested pygmy-tyrant_scptyr1
+Lophotriccus vitiosus_maria-fiteira_dbptyr1
+Lophotriccus eulophotes_maria-topetuda_lcptyr1
+Lophotriccus galeatus_sebinho-de-penacho_heptyr1
+Lophotriccus sp._Lophotriccus sp._lophot1
+Atalotriccus pilaris_maria-de-olho-claro_peptyr1
+Oncostoma cinereigulare_northern bentbill_norben1
+Oncostoma olivaceum_southern bentbill_souben1
+Hemitriccus minor_maria-sebinha_snttyr1
+Hemitriccus minor pallens_maria-sebinha (pallens)_snetot1
+Hemitriccus minor minor/snethlageae_maria-sebinha (minor/snethlageae)_snetot2
+Hemitriccus minor [undescribed form]_maria-sebinho [forma não descrita]_snetot5
+Hemitriccus spodiops_yungas tody-tyrant_yuttyr1
+Hemitriccus cohnhafti_maria-sebinha-do-acre_acrtot1
+Hemitriccus flammulatus_maria-de-peito-marchetado_flapyt1
+Hemitriccus diops_olho-falso_drbpyt1
+Hemitriccus obsoletus_catraca_bnbpyt1
+Hemitriccus josephinae_maria-bicudinha_bbttyr1
+Hemitriccus zosterops_maria-de-olho-branco_wettyr1
+Hemitriccus zosterops zosterops/flaviviridis_maria-d'olho-branco (zosterops/flaviviridis)_whetot4
+Hemitriccus zosterops [undescribed form]_maria-d'olho-branco [forma não descrita]_whetot3
+Hemitriccus griseipectus_maria-de-barriga-branca_whbtot1
+Hemitriccus orbitatus_tiririzinho-do-mato_erttyr1
+Hemitriccus iohannis_maria-peruviana_jottyr1
+Hemitriccus striaticollis_sebinho-rajado-amarelo_snttyr2
+Hemitriccus nidipendulus_tachuri-campainha_hattyr1
+Hemitriccus margaritaceiventer_sebinho-de-olho-de-ouro_pvttyr1
+Hemitriccus inornatus_maria-da-campina_pettyr1
+Hemitriccus minimus_maria-mirim_zittyr1
+Hemitriccus granadensis_black-throated tody-tyrant_btttyr1
+Hemitriccus cinnamomeipectus_cinnamon-breasted tody-tyrant_cbttyr1
+Hemitriccus mirandae_maria-do-nordeste_bbttyr2
+Hemitriccus kaempferi_maria-catarinense_kattyr1
+Hemitriccus rufigularis_buff-throated tody-tyrant_btttyr2
+Hemitriccus furcatus_papa-moscas-estrela_fotpyt1
+Hemitriccus sp._Hemitriccus sp._hemitr1
+Poecilotriccus ruficeps_rufous-crowned tody-flycatcher_rcttyr1
+Poecilotriccus luluae_johnson's tody-flycatcher_johtot1
+Poecilotriccus albifacies_ferreirinho-de-cara-branca_wcttyr1
+Poecilotriccus capitalis_maria-picaça_bawtyr1
+Poecilotriccus senex_maria-do-madeira_buctof1
+Poecilotriccus russatus_ferreirinho-ferrugem_rudtof1
+Poecilotriccus plumbeiceps_tororó_ocftof1
+Poecilotriccus fumifrons_ferreirinho-de-testa-parda_smftof1
+Poecilotriccus latirostris_ferreirinho-de-cara-parda_ruftof1
+Poecilotriccus sylvia_ferreirinho-da-capoeira_shtfly1
+Poecilotriccus calopterus_golden-winged tody-flycatcher_gowtof1
+Poecilotriccus pulchellus_black-backed tody-flycatcher_bkbtof1
+Poecilotriccus sp._Poecilotriccus sp._poecil1
+Taeniotriccus andrei_maria-bonita_blctyr2
+Todirostrum maculatum_ferreirinho-estriado_sptfly1
+Todirostrum poliocephalum_teque-teque_gyhtof1
+Todirostrum cinereum_ferreirinho-relógio_cotfly1
+Todirostrum cinereum [cinereum Group]_ferreirinho-relógio [grupo cinereum]_comtof1
+Todirostrum cinereum sclateri_ferreirinho-relógio (sclateri)_comtof2
+Todirostrum viridanum_maracaibo tody-flycatcher_matfly1
+Todirostrum nigriceps_black-headed tody-flycatcher_bhtfly1
+Todirostrum pictum_ferreirinho-pintado_patfly1
+Todirostrum chrysocrotaphum_ferreirinho-de-sobrancelha_ybtfly1
+Todirostrum sp._Todirostrum sp._todiro1
+Cnipodectes subbrunneus_flautim-pardo_brofly1
+Cnipodectes superrufus_flautim-rufo_ruftwi1
+Rhynchocyclus brevirostris_eye-ringed flatbill_eyrfla1
+Rhynchocyclus aequinoctialis_bico-chato-grande [grupo aequinoctialis]_olifla2
+Rhynchocyclus aequinoctialis [aequinoctialis Group]_western olivaceous flatbill (Western)_weofla2
+Rhynchocyclus aequinoctialis cryptus_western olivaceous flatbill (Cryptic)_weofla1
+Rhynchocyclus olivaceus_bico-chato-grande [grupo olivaceus]_olifla3
+Rhynchocyclus olivaceus guianensis/sordidus_eastern olivaceous flatbill (Guianan)_eaofla1
+Rhynchocyclus olivaceus olivaceus_eastern olivaceous flatbill (Olivaceous)_olifla12
+Rhynchocyclus aequinoctialis/olivaceus_rhynchocyclus aequinoctialis/olivaceus_olifla1
+Rhynchocyclus pacificus_pacific flatbill_pacfla1
+Rhynchocyclus fulvipectus_fulvous-breasted flatbill_fubfla1
+Rhynchocyclus sp._Rhynchocyclus sp._flatbi1
+Tolmomyias sulphurescens_bico-chato-de-orelha-preta_yeofly1
+Tolmomyias sulphurescens cinereiceps_bico-chato-de-orelha-preta (cinereiceps)_yeofly6
+Tolmomyias sulphurescens flavoolivaceus_bico-chato-de-orelha-preta (flavoolivaceus)_yeofly7
+Tolmomyias sulphurescens asemus_bico-chato-de-orelha-preta (asemus)_yeofly8
+Tolmomyias sulphurescens confusus_bico-chato-de-orelha-preta (confusus)_yeofly9
+Tolmomyias sulphurescens exortivus_bico-chato-de-orelha-preta (exortivus)_yeofly10
+Tolmomyias sulphurescens berlepschi_bico-chato-de-orelha-preta (berlepschi)_yeofly11
+Tolmomyias sulphurescens cherriei/duidae_bico-chato-de-orelha-preta (cherriei/duidae)_yeofly12
+Tolmomyias sulphurescens aequatorialis_bico-chato-de-orelha-preta (aequatorialis)_yeofly2
+Tolmomyias sulphurescens peruvianus_bico-chato-de-orelha-preta (peruvianus)_yeofly4
+Tolmomyias sulphurescens insignis_bico-chato-de-orelha-preta (insignis)_yeofly3
+Tolmomyias sulphurescens mixtus_bico-chato-de-orelha-preta (mixtus)_yeofly13
+Tolmomyias sulphurescens inornatus_bico-chato-de-orelha-preta (inornatus)_yeofly14
+Tolmomyias sulphurescens pallescens_bico-chato-de-orelha-preta (pallescens)_yeofly5
+Tolmomyias sulphurescens grisescens_bico-chato-de-orelha-preta (grisescens)_yeofly15
+Tolmomyias sulphurescens sulphurescens_bico-chato-de-orelha-preta (sulphurescens)_yeofly16
+Tolmomyias traylori_orange-eyed flatbill_orefly1
+Tolmomyias flavotectus_yellow-winged flatbill_yemfly2
+Tolmomyias assimilis_bico-chato-da-copa_yemfly1
+Tolmomyias assimilis neglectus_bico-chato-da-copa (neglectus)_yemfly4
+Tolmomyias assimilis examinatus_bico-chato-da-copa (examinatus)_yemfly5
+Tolmomyias assimilis obscuriceps_bico-chato-da-copa (obscuriceps)_yemfly6
+Tolmomyias assimilis [assimilis Group]_bico-chato-da-copa [grupo assimilis]_yemfly7
+Tolmomyias assimilis sucunduri_bico-chato-do-sucunduri_sucfly1
+Tolmomyias assimilis paraensis_bico-chato-da-copa (paraensis)_yemfly8
+Tolmomyias poliocephalus_bico-chato-de-cabeça-cinza_gycfly1
+Tolmomyias viridiceps_bico-chato-de-cara-verde_yebfly4
+Tolmomyias flaviventris_bico-chato-amarelo_yebfly3
+Tolmomyias viridiceps/flaviventris_bico-chato-de-cara-verde/bico-chato-amarelo_yebfly1
+Tolmomyias sp._Tolmomyias sp._tolmom1
+Pyrrhomyias cinnamomeus_cinnamon flycatcher_cinfly2
+Pyrrhomyias cinnamomeus assimilis_cinnamon flycatcher (Santa Marta)_cinfly3
+Pyrrhomyias cinnamomeus [vieillotioides Group]_cinnamon flycatcher (Venezuelan)_cinfly4
+Pyrrhomyias cinnamomeus cinnamomeus/pyrrhopterus_cinnamon flycatcher (Andean)_cinfly1
+Hirundinea ferruginea_gibão-de-couro_clifly1
+Hirundinea ferruginea ferruginea/sclateri_gibão-de-couro (ferruginea/sclateri)_clifly2
+Hirundinea ferruginea bellicosa/pallidior_gibão-de-couro (bellicosa/pallidior)_clifly3
+Myiotriccus ornatus_ornate flycatcher_ornfly1
+Myiotriccus ornatus ornatus/stellatus_ornate flycatcher (Western)_ornfly2
+Myiotriccus ornatus phoenicurus/aureiventris_ornate flycatcher (Eastern)_ornfly3
+Nephelomyias pulcher_handsome flycatcher_hanfly1
+Nephelomyias lintoni_orange-banded flycatcher_orbfly1
+Nephelomyias ochraceiventris_ochraceous-breasted flycatcher_ocbfly2
+Ornithion semiflavum_yellow-bellied tyrannulet_yebtyr1
+Ornithion brunneicapillus_brown-capped tyrannulet_brctyr
+Ornithion inerme_poaieiro-de-sobrancelha_whltyr1
+Camptostoma imberbe_northern beardless-tyrannulet_nobtyr
+Camptostoma obsoletum_risadinha_sobtyr1
+Camptostoma obsoletum [pusillum Group]_risadinha [grupo pusillum]_soubet1
+Camptostoma obsoletum [obsoletum Group]_risadinha [grupo obsoletum]_soubet2
+Suiriri suiriri_suiriri-cinzento_suifly1
+Mecocerculus poecilocercus_white-tailed tyrannulet_whttyr1
+Mecocerculus hellmayri_buff-banded tyrannulet_bubtyr1
+Mecocerculus stictopterus_white-banded tyrannulet_whbtyr1
+Mecocerculus leucophrys_alegrinho-de-garganta-branca_whttyr2
+Mecocerculus calopterus_rufous-winged tyrannulet_ruwtyr1
+Mecocerculus minor_sulphur-bellied tyrannulet_subtyr1
+Anairetes nigrocristatus_black-crested tit-tyrant_bkctit1
+Anairetes reguloides_pied-crested tit-tyrant_pcttyr1
+Anairetes alpinus_ash-breasted tit-tyrant_abttyr1
+Anairetes flavirostris_yellow-billed tit-tyrant_ybttyr1
+Anairetes parulus_tufted tit-tyrant_tuttyr1
+Anairetes fernandezianus_juan fernandez tit-tyrant_jfttyr1
+Anairetes sp._Anairetes sp._anaire1
+Uromyias agilis_agile tit-tyrant_agitit1
+Uromyias agraphia_unstreaked tit-tyrant_unstit1
+Nesotriccus tumbezanus_tumbesian tyrannulet_moctyr6
+Nesotriccus maranonicus_marañon tyrannulet_moctyr4
+Nesotriccus tumbezanus/maranonicus_tumbesian/marañon tyrannulet_y01203
+Nesotriccus ridgwayi_cocos tyrannulet_cocfly1
+Nesotriccus murinus_bagageiro_y01204
+Nesotriccus murinus incomtus/eremonomus_mouse-colored tyrannulet (Northern)_moctyr7
+Nesotriccus murinus murinus/wagae_mouse-colored tyrannulet (Southern)_moctyr3
+Nesotriccus sp._Nesotriccus sp._moctyr1
+Capsiempis flaveola_marianinha-amarela_yeltyr1
+Polystictus pectoralis_papa-moscas-canela_beatac1
+Polystictus superciliaris_papa-moscas-de-costas-cinzentas_gybtac1
+Culicivora caudacuta_papa-moscas-do-campo_shttyr1
+Pseudocolopteryx sclateri_tricolino_credor1
+Pseudocolopteryx acutipennis_tricolino-oliváceo_subdor1
+Pseudocolopteryx dinelliana_tricolino-pardo_dindor2
+Pseudocolopteryx flaviventris_amarelinho-do-junco_wardor1
+Pseudocolopteryx citreola_amarelinho-andino_ticdor1
+Pseudocolopteryx flaviventris/citreola_amarelinho-do-junco/amarelinho-andino_y00660
+Pseudocolopteryx sp._Pseudocolopteryx sp._doradi1
+Tyrannulus elatus_maria-te-viu_yectyr1
+Myiopagis gaimardii_maria-pechim_forela1
+Myiopagis parambae_choco elaenia_gryela1
+Myiopagis cinerea_guaracava-cinzenta-da-amazônia_gryela2
+Myiopagis olallai_foothill elaenia_fooela1
+Myiopagis olallai coopmansi_foothill elaenia (Antioquia)_fooela3
+Myiopagis olallai incognita_foothill elaenia (Perija)_fooela2
+Myiopagis olallai olallai_foothill elaenia (Foothill)_fooela4
+Myiopagis caniceps_guaracava-cinzenta_gryela3
+Myiopagis subplacens_pacific elaenia_pacela1
+Myiopagis flavivertex_guaracava-de-penacho-amarelo_yecela1
+Myiopagis cotta_jamaican elaenia_jamela1
+Myiopagis viridicata_guaracava-de-crista-alaranjada_greela
+Myiopagis viridicata minima/jaliscensis_guaracava-de-crista-alaranjada (minima/jaliscensis)_greela2
+Myiopagis viridicata [viridicata Group]_guaracava-de-crista-alaranjada [grupo viridicata]_greela3
+Myiopagis sp._Myiopagis sp._myiopa1
+Elaenia cristata_guaracava-de-topete-uniforme_plcela1
+Elaenia ruficeps_guaracava-de-topete-vermelho_rucela1
+Elaenia strepera_slaty elaenia_slaela1
+Elaenia gigas_mottle-backed elaenia_mobela1
+Elaenia sordida_tucão_higela3
+Elaenia dayi_guaracava-dos-tepuis_greela1
+Elaenia obscura_highland elaenia_higela2
+Elaenia flavogaster_guaracava-de-barriga-amarela_yebela1
+Elaenia parvirostris_tuque-pium_smbela1
+Elaenia pelzelni_guaracava-do-rio_broela1
+Elaenia spectabilis_guaracava-grande_larela1
+Elaenia ridleyana_cocoruta_norela1
+Elaenia mesoleuca_tuque_oliela1
+Elaenia chiriquensis_chibum_lesela1
+Elaenia brachyptera_coopmans's elaenia_cooela1
+Elaenia albiceps_guaracava-de-crista-branca_whcela1
+Elaenia albiceps [albiceps Group]_guaracava-de-crista-branca [grupo albiceps]_whcela2
+Elaenia albiceps chilensis_guaracava-de-crista-branca (chilensis)_whcela4
+Elaenia albiceps modesta_guaracava-de-crista-branca (modesta)_whcela3
+Elaenia parvirostris/albiceps_tuque-pium/guaracava-de-crista-branca_y00739
+Elaenia pallatangae_sierran elaenia_sieela3
+Elaenia frantzii_mountain elaenia_mouela1
+Elaenia olivina_guaracava-serrana_sieela2
+Elaenia martinica_caribbean elaenia_carela1
+Elaenia martinica [martinica Group]_caribbean elaenia (Caribbean)_carela2
+Elaenia martinica [cinerascens Group]_caribbean elaenia (Chinchorro)_carela3
+Elaenia fallax_greater antillean elaenia_graela1
+Elaenia fallax fallax_greater antillean elaenia (Jamaican)_graela3
+Elaenia fallax cherriei_greater antillean elaenia (Hispaniolan)_graela4
+Elaenia sp._Elaenia sp._elaeni1
+Serpophaga cinerea_torrent tyrannulet_tortyr1
+Serpophaga hypoleuca_alegrinho-do-rio_rivtyr1
+Serpophaga nigricans_joão-pobre_sootyr1
+Serpophaga subcristata_alegrinho_y01036
+Serpophaga subcristata subcristata/straminea_white-crested tyrannulet (Sulphur-bellied)_whctyr1
+Serpophaga subcristata munda_white-crested tyrannulet (White-bellied)_whbtyr2
+Serpophaga griseicapilla_alegrinho-trinador_gyctyr2
+Serpophaga subcristata/griseicapilla_alegrinho/alegrinho-trinador_y00884
+Serpophaga sp._Serpophaga sp._serpop1
+Phyllomyias virescens_piolhinho-verdoso_gretyr1
+Phyllomyias reiseri_piolhinho-do-grotão_reityr1
+Phyllomyias urichi_urich's tyrannulet_urityr1
+Phyllomyias sclateri_sclater's tyrannulet_scltyr1
+Phyllomyias fasciatus_piolhinho_platyr2
+Phyllomyias weedeni_piolhinho-do-acre_yuntyr1
+Phyllomyias griseiceps_piolhinho-de-cabeça-cinza_sohtyr1
+Phyllomyias griseiceps griseiceps_piolhinho-de-cabeça-cinzenta (griseiceps)_sohtyr2
+Phyllomyias griseiceps cristatus_piolhinho-de-cabeça-cinzenta (cristatus)_sohtyr3
+Phyllomyias griseiceps caucae_piolhinho-de-cabeça-cinzenta (caucae)_sohtyr4
+Phyllomyias griseiceps pallidiceps_piolhinho-de-cabeça-cinzenta (pallidiceps)_sohtyr5
+Phyllomyias plumbeiceps_plumbeous-crowned tyrannulet_plctyr1
+Phyllomyias griseocapilla_piolhinho-serrano_gyctyr1
+Phyllomyias sp._Phyllomyias sp._phyllo3
+Acrochordopus zeledoni_white-fronted tyrannulet_roltyr1
+Acrochordopus zeledoni zeledoni_white-fronted tyrannulet (Zeledon's)_roltyr2
+Acrochordopus zeledoni [leucogonys Group]_white-fronted tyrannulet (White-fronted)_roltyr4
+Acrochordopus burmeisteri_piolhinho-chiador_roltyr3
+Tyranniscus nigrocapillus_black-capped tyrannulet_blctyr1
+Tyranniscus cinereiceps_ashy-headed tyrannulet_ashtyr1
+Tyranniscus uropygialis_tawny-rumped tyrannulet_tartyr1
+Zimmerius cinereicapilla_red-billed tyrannulet_rebtyr2
+Zimmerius villarejoi_mishana tyrannulet_mistyr1
+Zimmerius chicomendesi_poaieiro-de-chico-mendes_chityr1
+Zimmerius acer_poaieiro-da-guiana_guityr1
+Zimmerius vilissimus_guatemalan tyrannulet_paltyr2
+Zimmerius parvus_mistletoe tyrannulet_paltyr3
+Zimmerius vilissimus/parvus_guatemalan/mistletoe tyrannulet_y01089
+Zimmerius albigularis_choco tyrannulet_chotyr1
+Zimmerius improbus_spectacled tyrannulet_paltyr4
+Zimmerius chrysops_golden-faced tyrannulet_goftyr1
+Zimmerius chrysops minimus/cumanensis_golden-faced tyrannulet (Coopmans's)_goftyr5
+Zimmerius chrysops chrysops_golden-faced tyrannulet (Golden-faced)_goftyr3
+Zimmerius viridiflavus_peruvian tyrannulet_pertyr1
+Zimmerius viridiflavus flavidifrons_peruvian tyrannulet (Loja)_goftyr4
+Zimmerius viridiflavus viridiflavus_peruvian tyrannulet (Peruvian)_pertyr2
+Zimmerius viridiflavus [undescribed form]_peruvian tyrannulet (Amazonas)_goftyr2
+Zimmerius bolivianus_bolivian tyrannulet_boltyr1
+Zimmerius petersi_venezuelan tyrannulet_paltyr5
+Zimmerius gracilipes_poaieiro-de-pata-fina_slftyr1
+Zimmerius sp._Zimmerius sp._zimmer1
+Euscarthmus fulviceps_fulvous-faced scrub-tyrant_tacpyt2
+Euscarthmus meloryphus_barulhento_tacpyt1
+Euscarthmus rufomarginatus_maria-corruíra_rsptyr1
+Pseudelaenia leucospodia_gray-and-white tyrannulet_gawtyr2
+Stigmatura napensis_papa-moscas-das-ilhas_lewtyr1
+Stigmatura bahiae_papa-moscas-do-sertão_leswat2
+Stigmatura [undescribed form]_stigmatura [forma não descrita]_oriwat1
+Stigmatura budytoides_alegrinho-balança-rabo_grwtyr1
+Stigmatura budytoides [budytoides Group]_alegrinho-balança-rabo [grupo budytoides]_grewat1
+Stigmatura budytoides gracilis_alegrinho-balança-rabo (gracilis)_grewat2
+Inezia tenuirostris_slender-billed tyrannulet_slbtyr1
+Inezia inornata_alegrinho-do-chaco_platyr1
+Inezia subflava_amarelinho_amatyr1
+Inezia caudata_amarelinho-da-amazônia_pattyr3
+Myiophobus flavicans_flavescent flycatcher_flafly2
+Myiophobus phoenicomitra_orange-crested flycatcher_orcfly1
+Myiophobus inornatus_unadorned flycatcher_unafly1
+Myiophobus roraimae_filipe-do-tepui_rorfly1
+Myiophobus cryptoxanthus_olive-chested flycatcher_olcfly1
+Myiophobus fasciatus_filipe_brcfly1
+Myiophobus crypterythrus_mouse-gray flycatcher_brcfly4
+Myiophobus fasciatus/crypterythrus_bran-colored/mouse-gray flycatcher_y01205
+Myiophobus rufescens_rufescent flycatcher_brcfly3
+Myiophobus crypterythrus/rufescens_mouse-gray/rufescent flycatcher_y01206
+Myiophobus sp._Myiophobus sp._myioph1
+Lathrotriccus euleri_enferrujado_eulfly1
+Lathrotriccus euleri [flaviventris Group]_enferrujado [grupo flaviventris]_eulfly2
+Lathrotriccus euleri euleri/argentinus_enferrujado (euleri/argentinus)_eulfly3
+Lathrotriccus griseipectus_gray-breasted flycatcher_gybfly1
+Aphanotriccus capitalis_tawny-chested flycatcher_tacfly1
+Aphanotriccus audax_black-billed flycatcher_blbfly1
+Xenotriccus callizonus_belted flycatcher_belfly1
+Xenotriccus mexicanus_pileated flycatcher_pilfly1
+Mitrephanes phaeocercus_tufted flycatcher_tuffly
+Mitrephanes phaeocercus phaeocercus/tenuirostris_tufted flycatcher (Mexican)_tuffly1
+Mitrephanes phaeocercus aurantiiventris_tufted flycatcher (Costa Rican)_tuffly2
+Mitrephanes phaeocercus berlepschi_tufted flycatcher (South American)_tuffly3
+Mitrephanes olivaceus_olive flycatcher_olifly2
+Contopus cooperi_piuí-boreal_olsfly
+Contopus ochraceus_ochraceous pewee_ochpew1
+Contopus pertinax_greater pewee_grepew
+Contopus pertinax pertinax_greater pewee (Mexican)_grepew1
+Contopus pertinax minor_greater pewee (Central American)_grepew2
+Contopus lugubris_dark pewee_darpew1
+Contopus fumigatus_piuí-de-topete_smcpew1
+Contopus pallidus_jamaican pewee_jampew1
+Contopus punensis_tumbes pewee_tropew2
+Contopus albogularis_piuí-queixado_whtpew1
+Contopus nigrescens_piuí-preto_blapew1
+Contopus cinereus_papa-moscas-cinzento_tropew3
+Contopus sordidulus_piuí-verdadeiro-do-oeste_wewpew
+Contopus bogotensis_northern tropical pewee_tropew4
+Contopus punensis/cinereus/bogotensis_tropical pewee sp._tropew1
+Contopus virens_piuí-verdadeiro-do-leste_eawpew
+Contopus sordidulus x virens_piuí-verdadeiro-do-oeste x piuí-verdadeiro-do-leste (híbrido)_x00858
+Contopus sordidulus/virens_piuí-verdadeiro-do-oeste/do-leste_woopew
+Contopus caribaeus_cuban pewee_cubpew1
+Contopus hispaniolensis_hispaniolan pewee_hispew1
+Contopus latirostris_lesser antillean pewee_leapew1
+Contopus latirostris brunneicapillus_lesser antillean pewee (Lesser Antilles)_leapew2
+Contopus latirostris blancoi_lesser antillean pewee (Puerto Rico)_leapew3
+Contopus latirostris latirostris_lesser antillean pewee (St. Lucia)_leapew4
+Contopus sp._Contopus sp._pewee1
+Cnemotriccus fuscatus_guaracavuçu_fusfly1
+Cnemotriccus fuscatus duidae_guaracavuçu (duidae)_fusfly3
+Cnemotriccus fuscatus [fuscatus Group]_guaracavuçu [grupo fuscatus]_fusfly2
+Empidonax flaviventris_yellow-bellied flycatcher_yebfly
+Empidonax virescens_papa-mosquitos_acafly
+Empidonax alnorum_papa-moscas-de-alder_aldfly
+Empidonax traillii_maria-fibiu_wilfly
+Empidonax traillii traillii_maria-fibiu (traillii)_wilfly1
+Empidonax traillii brewsteri/adastus_maria-fibiu (brewsteri/adastus)_wilfly2
+Empidonax traillii extimus_maria-fibiu (extimus)_wilfly3
+Empidonax alnorum/traillii_papa-mosquitos-de-alder/maria-fibui_y00324
+Empidonax albigularis_white-throated flycatcher_whtfly1
+Empidonax minimus_papa-mosquitos-pequeno_leafly
+Empidonax hammondii_hammond's flycatcher_hamfly
+Empidonax wrightii_gray flycatcher_gryfly
+Empidonax oberholseri_dusky flycatcher_dusfly
+Empidonax hammondii/oberholseri_hammond's/dusky flycatcher_y00014
+Empidonax wrightii/oberholseri_gray/dusky flycatcher_y00618
+Empidonax affinis_pine flycatcher_pinfly1
+Empidonax difficilis_western flycatcher_wesfly
+Empidonax difficilis [difficilis Group]_western flycatcher (Pacific-slope)_pasfly
+Empidonax difficilis occidentalis/hellmayri_western flycatcher (Cordilleran)_corfly
+Empidonax difficilis difficilis x hellmayri_western flycatcher (Pacific-slope x Cordilleran Flycatcher)_x00770
+Empidonax flavescens_yellowish flycatcher_yelfly1
+Empidonax flavescens imperturbatus/salvini_yellowish flycatcher (Northern)_yelfly11
+Empidonax flavescens flavescens_yellowish flycatcher (Southern)_yelfly6
+Empidonax fulvifrons_buff-breasted flycatcher_bubfly
+Empidonax atriceps_black-capped flycatcher_blcfly1
+Empidonax sp._Empidonax sp._empido
+Sayornis nigricans_black phoebe_blkpho
+Sayornis nigricans [nigricans Group]_black phoebe (Northern)_blkpho1
+Sayornis nigricans latirostris/angustirostris_black phoebe (White-winged)_blkpho2
+Sayornis phoebe_eastern phoebe_easpho
+Sayornis nigricans x phoebe_black x eastern phoebe (hybrid)_x00621
+Sayornis nigricans/phoebe_black/eastern phoebe_y01301
+Sayornis saya_say's phoebe_saypho
+Sayornis nigricans x saya_black x say's phoebe (hybrid)_x00635
+Sayornis sp._phoebe sp._phoebe1
+Guyramemua affine_suiriri-da-chapada_chafly3
+Suiriri suiriri/Guyramemua affine_suiriri-cinzento/da-chapada_y00883
+Sublegatus arenarum_northern scrub-flycatcher_nosfly1
+Sublegatus obscurior_sertanejo-escuro_amsfly1
+Sublegatus modestus_guaracava-modesta_sosfly1
+Sublegatus sp._scrub-flycatcher sp._scrubf1
+Pyrocephalus rubinus_príncipe_verfly
+Pyrocephalus rubinus [mexicanus Group]_príncipe (mexicanus Group)_verfly5
+Pyrocephalus rubinus saturatus_príncipe (saturatus)_verfly6
+Pyrocephalus rubinus [obscurus Group]_príncipe (obscurus Group)_verfly7
+Pyrocephalus rubinus rubinus_príncipe (rubinus)_verfly1
+Pyrocephalus nanus_brujo flycatcher_brufly1
+Pyrocephalus nanus nanus_brujo flycatcher (Galapagos)_verfly3
+Pyrocephalus nanus dubius_brujo flycatcher (San Cristobal)_verfly8
+Lessonia rufa_colegial_ausneg1
+Lessonia oreas_andean negrito_andneg1
+Lessonia rufa/oreas_austral/andean negrito_y00603
+Knipolegus orenocensis_maria-preta-ribeirinha_rivtyr2
+Knipolegus orenocensis orenocensis/xinguensis_maria-preta-ribeirinha (orenocensis/xinguensis)_rivtyr3
+Knipolegus orenocensis sclateri_maria-preta-ribeirinha (sclateri)_rivtyr4
+Knipolegus poecilurus_maria-preta-de-cauda-ruiva_ruttyr1
+Knipolegus poecilocercus_maria-preta-do-igapó_ambtyr1
+Knipolegus franciscanus_maria-preta-do-nordeste_whwblt2
+Knipolegus lophotes_maria-preta-de-penacho_crbtyr1
+Knipolegus nigerrimus_maria-preta-de-garganta-vermelha_vebtyr1
+Knipolegus signatus_jelski's black-tyrant_andtyr3
+Knipolegus cabanisi_plumbeous black-tyrant_andtyr2
+Knipolegus signatus/cabanisi_jelski's/plumbeous black-tyrant_andtyr1
+Knipolegus cyanirostris_maria-preta-de-bico-azulado_bbbtyr1
+Knipolegus striaticeps_maria-preta-acinzentada_cintyr1
+Knipolegus aterrimus_maria-preta-bate-rabo_whwblt1
+Knipolegus aterrimus heterogyna_maria-preta-bate-rabo (heterogyna)_whwblt4
+Knipolegus aterrimus aterrimus/anthracinus_maria-preta-bate-rabo (aterrimus/anthracinus)_whwblt5
+Knipolegus hudsoni_maria-preta-do-sul_hubtyr1
+Knipolegus aterrimus/hudsoni_maria-preta-bate-rabo/maria-preta-do-sul_y00971
+Knipolegus sp._Knipolegus sp._blackt1
+Hymenops perspicillatus_viuvinha-de-óculos_spetyr1
+Ochthornis littoralis_maria-da-praia_drwtyr1
+Satrapa icterophrys_suiriri-pequeno_yebtyr2
+Syrtidicola fluviatilis_gaúcha-d'água_ligtyr1
+Muscisaxicola maculirostris_gaúcha-de-bico-manchado_sbgtyr1
+Muscisaxicola griseus_taczanowski's ground-tyrant_tacgrt1
+Muscisaxicola juninensis_puna ground-tyrant_pugtyr1
+Muscisaxicola cinereus_cinereous ground-tyrant_cingrt1
+Muscisaxicola albifrons_white-fronted ground-tyrant_wfgtyr1
+Muscisaxicola flavinucha_ochre-naped ground-tyrant_ongtyr1
+Muscisaxicola rufivertex_rufous-naped ground-tyrant_rngtyr1
+Muscisaxicola rufivertex occipitalis_rufous-naped ground-tyrant (Chestnut-naped)_rungrt3
+Muscisaxicola rufivertex pallidiceps_rufous-naped ground-tyrant (pallidiceps)_rungrt2
+Muscisaxicola rufivertex rufivertex_rufous-naped ground-tyrant (Rufous-naped)_rungrt1
+Muscisaxicola maclovianus_gaúcha-de-cara-suja_dafgrt1
+Muscisaxicola maclovianus mentalis_gaúcha-de-cara-suja (mentalis)_dafgrt2
+Muscisaxicola maclovianus maclovianus_gaúcha-de-cara-suja (maclovianus)_dafgrt3
+Muscisaxicola albilora_white-browed ground-tyrant_wbgtyr1
+Muscisaxicola alpinus_plain-capped ground-tyrant_plcgrt1
+Muscisaxicola capistratus_gaúcha-de-barriga-alaranjada_cibgrt1
+Muscisaxicola frontalis_black-fronted ground-tyrant_bfgtyr1
+Muscisaxicola sp._Muscisaxicola sp._ground1
+Cnemarchus erythropygius_red-rumped bush-tyrant_rrbtyr1
+Cnemarchus rufipennis_rufous-webbed bush-tyrant_rwbtyr1
+Pyrope pyrope_fire-eyed diucon_fiediu1
+Xolmis velatus_noivinha-branca_whrmon2
+Xolmis irupero_noivinha_whimon1
+Nengetus cinereus_primavera_grymon1
+Neoxolmis coronatus_noivinha-coroada_bkcmon1
+Neoxolmis salinarum_salinas monjita_salmon1
+Neoxolmis rubetra_noivinha-castanha_rubmon1
+Neoxolmis rufiventris_gaúcho-chocolate_chvtyr2
+Agriornis montanus_black-billed shrike-tyrant_bkbsht1
+Agriornis albicauda_white-tailed shrike-tyrant_wtstyr1
+Agriornis lividus_great shrike-tyrant_gresht1
+Agriornis micropterus_gaúcho-de-barriga-cinza_gybsht1
+Agriornis micropterus andecola_gaúcho-de-barriga-cinza (andecola)_gybsht2
+Agriornis micropterus micropterus_gaúcho-de-barriga-cinza (micropterus)_gybsht3
+Agriornis murinus_gauchinho_lessht1
+Agriornis sp._Agriornis sp._shrike1
+Myiotheretes striaticollis_streak-throated bush-tyrant_stbtyr1
+Myiotheretes pernix_santa marta bush-tyrant_smbtyr1
+Myiotheretes fumigatus_smoky bush-tyrant_smbtyr2
+Myiotheretes fuscorufus_rufous-bellied bush-tyrant_rbbtyr1
+Myiotheretes sp._Myiotheretes sp._myioth2
+Arundinicola leucocephala_freirinha_whmtyr1
+Fluvicola pica_lavadeira-do-norte_piwtyr1
+Fluvicola albiventer_lavadeira-de-cara-branca_bbwtyr1
+Fluvicola nengeta_lavadeira-mascarada_mawtyr1
+Muscipipra vetula_tesoura-cinzenta_shtgrt1
+Gubernetes yetapa_tesoura-do-brejo_stttyr2
+Heteroxolmis dominicana_noivinha-de-rabo-preto_bawmon3
+Alectrurus tricolor_galito_cottyr1
+Alectrurus risora_tesoura-do-campo_stttyr1
+Silvicultrix frontalis_crowned chat-tyrant_crocht1
+Silvicultrix frontalis frontalis/albidiadema_crowned chat-tyrant (Crowned)_crocht2
+Silvicultrix frontalis spodionota/boliviana_crowned chat-tyrant (Kalinowski's)_crocht3
+Silvicultrix jelskii_jelski's chat-tyrant_jelcht1
+Silvicultrix pulchella_golden-browed chat-tyrant_gobcht1
+Silvicultrix diadema_yellow-bellied chat-tyrant_yebcht1
+Colorhamphus parvirostris_patagonian tyrant_pattyr2
+Ochthoeca salvini_tumbes chat-tyrant_tumtyr2
+Ochthoeca cinnamomeiventris_chestnut-bellied chat-tyrant_slbcht2
+Ochthoeca nigrita_blackish chat-tyrant_slbcht1
+Ochthoeca thoracica_maroon-belted chat-tyrant_slbcht3
+Ochthoeca rufipectoralis_rufous-breasted chat-tyrant_rbctyr1
+Ochthoeca fumicolor_brown-backed chat-tyrant_bbctyr1
+Ochthoeca superciliosa_rufous-browed chat-tyrant_bnbcht2
+Ochthoeca oenanthoides_d'orbigny's chat-tyrant_dorcht1
+Ochthoeca piurae_piura chat-tyrant_pictyr1
+Ochthoeca leucophrys_white-browed chat-tyrant_wbctyr1
+Silvicultrix/Ochthoeca sp._chat-tyrant sp._chatty1
+Colonia colonus_viuvinha_lottyr1
+Muscigralla brevicauda_short-tailed field tyrant_stftyr1
+Ramphotrigon megacephalum_maria-cabeçuda_lahfla2
+Ramphotrigon ruficauda_bico-chato-de-rabo-vermelho_rutfla1
+Ramphotrigon flammulatum_flammulated flycatcher_flafly1
+Ramphotrigon fuscicauda_maria-de-cauda-escura_dutfla1
+Ramphotrigon sp._Ramphotrigon sp._rampho1
+Attila phoenicurus_capitão-castanho_rutatt1
+Attila cinnamomeus_tinguaçu-ferrugem_cinatt1
+Attila torridus_ochraceous attila_ochatt1
+Attila citriniventris_tinguaçu-de-barriga-amarela_cibatt1
+Attila bolivianus_bate-para_ducatt1
+Attila rufus_capitão-de-saíra_gyhatt1
+Attila spadiceus_capitão-de-saíra-amarelo_brratt1
+Attila spadiceus [flammulatus Group]_capitão-de-saíra-amarelo [grupo flammulatus]_brratt2
+Attila spadiceus spadiceus/uropygiatus_capitão-de-saíra-amarelo (spadiceus/uropygiatus)_brratt3
+Attila sp._Attila sp._attila1
+Sirystes albogriseus_choco sirystes_siryst3
+Sirystes albocinereus_gritador-de-sobre-branco_whrsir1
+Sirystes subcanescens_gritador-da-guiana_todsir1
+Sirystes sibilator_gritador_sibsir1
+Sirystes sp._Sirystes sp._siryst1
+Casiornis rufus_maria-ferrugem_rufcas2
+Casiornis fuscus_caneleiro-enxofre_astcas2
+Rhytipterna holerythra_rufous mourner_rufmou1
+Rhytipterna simplex_vissiá_gramou1
+Rhytipterna immunda_vissiá-cantor_pabmou1
+Myiarchus semirufus_rufous flycatcher_ruffly1
+Myiarchus yucatanensis_yucatan flycatcher_yucfly1
+Myiarchus barbirostris_sad flycatcher_sadfly1
+Myiarchus tuberculifer_maria-cavaleira-pequena_ducfly
+Myiarchus tuberculifer olivascens_maria-cavaleira-pequena (olivascens)_ducfly3
+Myiarchus tuberculifer [lawrenceii Group]_maria-cavaleira-pequena (grupo lawrenceii)_ducfly4
+Myiarchus tuberculifer tuberculifer/pallidus_maria-cavaleira-pequena (tuberculifer/pallidus)_ducfly6
+Myiarchus tuberculifer nigriceps/atriceps_maria-cavaleira-pequena (nigriceps/atriceps)_ducfly5
+Myiarchus swainsoni_irré_swafly1
+Myiarchus swainsoni phaeonotus_irré (phaeonotus)_swafly2
+Myiarchus swainsoni [swainsoni Group]_irré [grupo swainsoni]_swafly4
+Myiarchus venezuelensis_venezuelan flycatcher_venfly1
+Myiarchus panamensis_panama flycatcher_panfly1
+Myiarchus venezuelensis/panamensis_venezuelan/panama flycatcher_y00972
+Myiarchus ferox_maria-cavaleira_shcfly1
+Myiarchus apicalis_apical flycatcher_apifly1
+Myiarchus phaeocephalus_sooty-crowned flycatcher_socfly2
+Myiarchus phaeocephalus phaeocephalus_sooty-crowned flycatcher (phaeocephalus)_socfly6
+Myiarchus phaeocephalus interior_sooty-crowned flycatcher (interior)_socfly7
+Myiarchus cephalotes_pale-edged flycatcher_paefly1
+Myiarchus cinerascens_ash-throated flycatcher_astfly
+Myiarchus nuttingi_nutting's flycatcher_nutfly
+Myiarchus nuttingi nuttingi/inquietus_nutting's flycatcher (Nutting's)_nutfly1
+Myiarchus nuttingi flavidior_nutting's flycatcher (Salvadoran)_nutfly2
+Myiarchus cinerascens/nuttingi_ash-throated/nutting's flycatcher_y01144
+Myiarchus crinitus_great crested flycatcher_grcfly
+Myiarchus tyrannulus_maria-cavaleira-de-rabo-enferrujado_bncfly
+Myiarchus tyrannulus magister_maria-cavaleira-de-rabo-enferrujado (magister)_bncfly1
+Myiarchus tyrannulus [cooperi Group]_maria-cavaleira-de-rabo-enferrujado [grupo cooperi]_bncfly5
+Myiarchus tyrannulus brachyurus_maria-cavaleira-de-rabo-enferrujado (brachyurus)_bncfly3
+Myiarchus tyrannulus tyrannulus/bahiae_maria-cavaleira-de-rabo-enferrujado (tyrannulus/bahiae)_bncfly4
+Myiarchus magnirostris_galapagos flycatcher_galfly1
+Myiarchus nugator_grenada flycatcher_grefly1
+Myiarchus validus_rufous-tailed flycatcher_rutfly1
+Myiarchus sagrae_la sagra's flycatcher_lasfly
+Myiarchus stolidus_stolid flycatcher_stofly1
+Myiarchus antillarum_puerto rican flycatcher_purfly1
+Myiarchus oberi_lesser antillean flycatcher_leafly1
+Myiarchus sp._Myiarchus sp._myiarc
+Machetornis rixosa_suiriri-cavaleiro_cattyr
+Philohydor lictor_bentevizinho-do-brejo_leskis1
+Pitangus sulphuratus_bem-te-vi_grekis
+Megarynchus pitangua_neinei_bobfly1
+Megarynchus pitangua [mexicanus Group]_neinei [grupo mexicanus]_bobfly3
+Megarynchus pitangua pitangua_neinei (pitangua)_bobfly5
+Megarynchus pitangua chrysogaster_neinei (chrysogaster)_bobfly4
+Myiozetetes cayanensis_bentevizinho-de-asa-ferrugínea_rumfly1
+Myiozetetes similis_bentevizinho-de-penacho-vermelho_socfly1
+Myiozetetes similis [texensis Group]_bentevizinho-de-penacho-vermelho [grupo texensis]_socfly3
+Myiozetetes similis [similis Group]_bentevizinho-de-penacho-vermelho [grupo similis]_socfly4
+Myiozetetes similis grandis_bentevizinho-de-penacho-vermelho (grandis)_socfly5
+Myiozetetes cayanensis/similis_bentevizinho-de-asa-ferrugínea/bentevizinho-de-penacho-vermelho_y00798
+Myiozetetes granadensis_bem-te-vi-de-cabeça-cinza_grcfly1
+Myiozetetes luteiventris_bem-te-vi-barulhento_ducfly2
+Myiozetetes granadensis/luteiventris_bem-te-vi-de-cabeça-cinza/bem-te-vi-barulhento_y00799
+Phelpsia inornata_white-bearded flycatcher_whbfly1
+Conopias albovittatus_white-ringed flycatcher_whrfly
+Conopias parvus_bem-te-vi-da-copa_yetfly2
+Conopias trivirgatus_bem-te-vi-pequeno_thsfly2
+Conopias parvus/trivirgatus_bem-te-vi-da-copa/pequeno_y00885
+Conopias cinchoneti_lemon-browed flycatcher_lebfly2
+Myiodynastes hemichrysus_golden-bellied flycatcher_gobfly1
+Myiodynastes chrysocephalus_golden-crowned flycatcher_gocfly1
+Myiodynastes bairdii_baird's flycatcher_baifly1
+Myiodynastes maculatus_bem-te-vi-rajado_strfly1
+Myiodynastes maculatus [maculatus Group]_bem-te-vi-rajado [grupo maculatus]_strfly2
+Myiodynastes maculatus solitarius_bem-te-vi-rajado (solitarius)_strfly3
+Myiodynastes luteiventris_bem-te-vi-de-barriga-sulfúrea_subfly
+Myiodynastes maculatus/luteiventris_bem-te-vi-rajado/bem-te-vi-de-barriga-sulfúrea_y00607
+Legatus leucophaius_bem-te-vi-pirata_pirfly1
+Empidonomus varius_peitica_varfly
+Empidonomus aurantioatrocristatus_peitica-de-chapéu-preto_croslf1
+Tyrannopsis sulphurea_suiriri-de-garganta-rajada_sulfly1
+Tyrannus niveigularis_snowy-throated kingbird_sntkin1
+Tyrannus albogularis_suiriri-de-garganta-branca_whtkin1
+Tyrannus melancholicus_suiriri_trokin
+Tyrannus melancholicus occidentalis_suiriri (occidentalis)_trokin5
+Tyrannus melancholicus satrapa_suiriri (satrapa)_trokin1
+Tyrannus melancholicus melancholicus/despotes_suiriri (melancholicus/despotes)_trokin4
+Tyrannus albogularis/melancholicus_suiriri-de-garganta-branca/suiriri_y00740
+Tyrannus couchii_couch's kingbird_coukin
+Tyrannus melancholicus/couchii_tropical/couch's kingbird_y00325
+Tyrannus vociferans_cassin's kingbird_caskin
+Tyrannus crassirostris_thick-billed kingbird_thbkin
+Tyrannus verticalis_western kingbird_weskin
+Tyrannus couchii x verticalis_couch's x western kingbird (hybrid)_x01035
+Tyrannus vociferans/verticalis_cassin's/western kingbird_y00619
+Tyrannus sp. (yellow-bellied)_yellow-bellied kingbird sp._yebkin2
+Tyrannus tyrannus_suiriri-valente_easkin
+Tyrannus verticalis x tyrannus_western x eastern kingbird (hybrid)_x00718
+Tyrannus dominicensis_suiriri-cinza_grykin
+Tyrannus melancholicus x dominicensis_suiriri x suiriri-cinzento (híbrido)_x00859
+Tyrannus caudifasciatus_loggerhead kingbird_logkin
+Tyrannus caudifasciatus [caudifasciatus Group]_loggerhead kingbird (Loggerhead)_logkin3
+Tyrannus caudifasciatus taylori_loggerhead kingbird (Puerto Rico)_logkin1
+Tyrannus caudifasciatus gabbii_loggerhead kingbird (Hispaniolan)_logkin2
+Tyrannus cubensis_giant kingbird_giakin1
+Tyrannus forficatus_scissor-tailed flycatcher_sctfly
+Tyrannus melancholicus x forficatus_tropical kingbird x scissor-tailed flycatcher (hybrid)_x01036
+Tyrannus couchii x forficatus_couch's kingbird x scissor-tailed flycatcher (hybrid)_x00441
+Tyrannus verticalis x forficatus_western kingbird x scissor-tailed flycatcher (hybrid)_x00442
+Tyrannus savana_tesourinha/tesourinha-do-norte_fotfly
+Tyrannus savana savana_tesourinha (savana)_fotfly1
+Tyrannus savana monachus_tesourinha-do-norte_fotfly2
+Tyrannus savana sanctaemartae_tesourinha/tesourinha-do-norte (sanctaemartae)_fotfly3
+Tyrannus savana circumdatus_tesourinha/tesourinha-do-norte (circumdatus)_fotfly4
+Tyrannus melancholicus x savana_suiriri x tesourinha-do-norte (híbrido)_x00408
+Tyrannus sp._Tyrannus sp._tyrann1
+Tyrannidae sp._Tyrannidae sp._flycat1
+Menura alberti_albert's lyrebird_alblyr1
+Menura novaehollandiae_superb lyrebird_suplyr1
+Atrichornis rufescens_rufous scrub-bird_rusbir1
+Atrichornis clamosus_noisy scrub-bird_nosbir1
+Ailuroedus buccoides_white-eared catbird_whecat1
+Ailuroedus stonii_ochre-breasted catbird_ocbcat1
+Ailuroedus geislerorum_tan-capped catbird_taccat1
+Ailuroedus maculosus_spotted catbird_spocat2
+Ailuroedus astigmaticus_huon catbird_huocat1
+Ailuroedus melanocephalus_black-capped catbird_bkccat1
+Ailuroedus jobiensis_northern catbird_norcat1
+Ailuroedus arfakianus_arfak catbird_arfcat1
+Ailuroedus melanotis_black-eared catbird_spocat1
+Ailuroedus crassirostris_green catbird_grecat1
+Ailuroedus sp._australasian catbird sp._auscat1
+Scenopoeetes dentirostris_tooth-billed bowerbird_tobcat2
+Archboldia papuensis_archbold's bowerbird_arcbow1
+Amblyornis inornata_vogelkop bowerbird_vogbow2
+Amblyornis macgregoriae_macgregor's bowerbird_macbow2
+Amblyornis subalaris_streaked bowerbird_strbow1
+Amblyornis flavifrons_golden-fronted bowerbird_gofbow1
+Prionodura newtoniana_golden bowerbird_golbow1
+Sericulus aureus_masked bowerbird_flabow3
+Sericulus ardens_flame bowerbird_flabow2
+Sericulus bakeri_fire-maned bowerbird_fimbow1
+Sericulus chrysocephalus_regent bowerbird_regbow1
+Ptilonorhynchus violaceus_satin bowerbird_satbow1
+Sericulus chrysocephalus x Ptilonorhynchus violaceus_regent x satin bowerbird (hybrid)_x00961
+Chlamydera guttata_western bowerbird_wesbow1
+Chlamydera maculata_spotted bowerbird_spobow1
+Chlamydera nuchalis_great bowerbird_grebow1
+Chlamydera lauterbachi_yellow-breasted bowerbird_yebbow1
+Chlamydera cerviniventris_fawn-breasted bowerbird_fabbow1
+Cormobates placens_papuan treecreeper_paptre1
+Cormobates leucophaea_white-throated treecreeper_whttre3
+Cormobates leucophaea minor_white-throated treecreeper (Little)_whttre1
+Cormobates leucophaea [leucophaea Group]_white-throated treecreeper (White-throated)_whttre4
+Climacteris affinis_white-browed treecreeper_whbtre2
+Climacteris erythrops_red-browed treecreeper_rebtre1
+Climacteris picumnus_brown treecreeper_brotre2
+Climacteris melanurus_black-tailed treecreeper_bkttre1
+Climacteris rufus_rufous treecreeper_ruftre3
+Climacteridae sp._australian treecreeper sp._austre1
+Amytornis barbatus_gray grasswren_grygra1
+Amytornis whitei_pilbara grasswren_strgra4
+Amytornis oweni_sandhill grasswren_sangra1
+Amytornis rowleyi_opalton grasswren_rusgra1
+Amytornis striatus_striated grasswren_strgra2
+Amytornis woodwardi_white-throated grasswren_whtgra1
+Amytornis dorotheae_carpentarian grasswren_cargra2
+Amytornis merrotsyi_short-tailed grasswren_shtgra1
+Amytornis textilis_western grasswren_thbgra1
+Amytornis textilis textilis_western grasswren (Western)_thbgra2
+Amytornis textilis myall_western grasswren (Gawler Ranges)_thbgra3
+Amytornis modestus_thick-billed grasswren_thbgra4
+Amytornis housei_black grasswren_blagra1
+Amytornis goyderi_eyrean grasswren_eyrgra1
+Amytornis purnelli_dusky grasswren_dusgra1
+Amytornis ballarae_kalkadoon grasswren_kalgra1
+Stipiturus malachurus_southern emuwren_souemu1
+Stipiturus ruficeps_rufous-crowned emuwren_rucemu1
+Stipiturus mallee_mallee emuwren_malemu1
+Sipodotus wallacii_wallace's fairywren_walfai1
+Clytomyias insignis_orange-crowned fairywren_orcfai1
+Chenorhamphus grayi_broad-billed fairywren_brbfai1
+Chenorhamphus campbelli_campbell's fairywren_brbfai2
+Malurus cyanocephalus_emperor fairywren_empfai1
+Malurus coronatus_purple-crowned fairywren_pucfai2
+Malurus elegans_red-winged fairywren_rewfai1
+Malurus pulcherrimus_blue-breasted fairywren_blbfai1
+Malurus assimilis_purple-backed fairywren_varfai1
+Malurus assimilis dulcis/rogersi_purple-backed fairywren (Lavender-flanked)_varfai2
+Malurus assimilis assimilis/bernieri_purple-backed fairywren (Purple-backed)_varfai3
+Malurus lamberti_variegated fairywren_varfai5
+Malurus assimilis/lamberti_purple-backed/variegated fairywren_y01109
+Malurus amabilis_lovely fairywren_lovfai1
+Malurus splendens_splendid fairywren_splfai1
+Malurus splendens splendens_splendid fairywren (Western)_splfai2
+Malurus splendens callainus_splendid fairywren (Central)_splfai3
+Malurus splendens melanotus/emmottorum_splendid fairywren (Eastern)_splfai6
+Malurus cyaneus_superb fairywren_supfai1
+Malurus leucopterus_white-winged fairywren_whwfai1
+Malurus leucopterus leuconotus_white-winged fairywren (Blue-and-white)_whwfai2
+Malurus leucopterus leucopterus/edouardi_white-winged fairywren (Black-and-white)_whwfai3
+Malurus cyaneus x leucopterus_superb x white-winged fairywren (hybrid)_x00409
+Malurus melanocephalus_red-backed fairywren_rebfai1
+Malurus cyaneus x melanocephalus_superb x red-backed fairywren (hybrid)_x00410
+Malurus alboscapulatus_white-shouldered fairywren_whsfai1
+Malurus sp._fairywren sp._fairyw1
+Myza celebensis_dark-eared myza_daehon1
+Myza sarasinorum_white-eared myza_grshon1
+Myza celebensis/sarasinorum_dark-eared/white-eared myza_y00887
+Acanthorhynchus tenuirostris_eastern spinebill_easspi1
+Acanthorhynchus superciliosus_western spinebill_wesspi1
+Certhionyx variegatus_pied honeyeater_piehon1
+Pycnopygius ixoides_plain honeyeater_plahon1
+Pycnopygius cinereus_marbled honeyeater_marhon1
+Pycnopygius stictocephalus_streak-headed honeyeater_sthhon1
+Prosthemadera novaeseelandiae_tui_tui1
+Anthornis melanura_new zealand bellbird_nezbel1
+Prosthemadera novaeseelandiae/Anthornis melanura_tui/new zealand bellbird_y00407
+Anthornis melanocephala_chatham islands bellbird_chibel1
+Meliphaga aruensis_puff-backed honeyeater_pubhon1
+Meliphaga notata_yellow-spotted honeyeater_yeshon1
+Meliphaga lewinii_lewin's honeyeater_lewhon1
+Meliphaga reticulata_papa-mel-de-peito-listado_stbhon3
+Meliphaga fordiana_kimberley honeyeater_kimhon1
+Meliphaga albilineata_white-lined honeyeater_whlhon1
+Meliphaga chrysogenys_orange-cheeked honeyeater_orchon1
+Meliphaga montana_forest honeyeater_forhon1
+Meliphaga mimikae_mottled honeyeater_spbmel1
+Meliphaga flavirictus_yellow-gaped honeyeater_yeghon1
+Meliphaga orientalis_mountain honeyeater_moumel1
+Meliphaga albonotata_scrub honeyeater_scrhon1
+Meliphaga analoga_mimic honeyeater_mimhon1
+Meliphaga vicina_tagula honeyeater_taghon1
+Meliphaga gracilis_graceful honeyeater_grahon2
+Meliphaga imitatrix_cryptic honeyeater_grahon5
+Meliphaga cinereifrons_elegant honeyeater_grahon3
+Meliphaga gracilis/cinereifrons_graceful/elegant honeyeater_grahon1
+Meliphaga sp._papa-mel (Meliphaga sp.)_meliph1
+Stomiopera flava_yellow honeyeater_yelhon1
+Stomiopera unicolor_white-gaped honeyeater_whghon1
+Purnella albifrons_white-fronted honeyeater_whfhon1
+Caligavis chrysops_yellow-faced honeyeater_yefhon1
+Caligavis subfrenata_black-throated honeyeater_blthon1
+Caligavis obscura_obscure honeyeater_obshon1
+Lichenostomus melanops_yellow-tufted honeyeater_yethon3
+Lichenostomus melanops melanops/meltoni_yellow-tufted honeyeater (Yellow-tufted)_yethon4
+Lichenostomus melanops cassidix_yellow-tufted honeyeater (Helmeted)_yethon5
+Lichenostomus cratitius_purple-gaped honeyeater_pughon1
+Manorina melanophrys_bell miner_belmin1
+Manorina melanocephala_noisy miner_noimin1
+Manorina flavigula_yellow-throated miner_yetmin1
+Manorina melanotis_black-eared miner_blemin1
+Manorina flavigula x melanotis_yellow-throated x black-eared miner (hybrid)_x00741
+Manorina sp._miner sp. (Manorina sp.)_miner2
+Melionyx fuscus_sooty honeyeater_soomel1
+Melionyx nouhuysi_short-bearded honeyeater_shbmel1
+Melionyx princeps_long-bearded honeyeater_lobmel1
+Melidectes torquatus_ornate melidectes_ornmel1
+Melidectes ochromelas_cinnamon-browed melidectes_cibmel1
+Melidectes leucostephes_vogelkop melidectes_vogmel1
+Melidectes foersteri_huon melidectes_huomel1
+Melidectes belfordi_belford's melidectes_belmel1
+Melidectes rufocrissalis_yellow-browed melidectes_yebmel1
+Melidectes belfordi x rufocrissalis_belford's x yellow-browed melidectes (hybrid)_x00742
+Melidectes belfordi/rufocrissalis_belford's/yellow-browed melidectes_y01063
+Melidectes sp._melidectes sp._melide1
+Bolemoreus frenatus_bridled honeyeater_brihon1
+Bolemoreus hindwoodi_eungella honeyeater_eunhon1
+Acanthagenys rufogularis_spiny-cheeked honeyeater_spchon1
+Anthochaera chrysoptera_little wattlebird_bruwat1
+Anthochaera lunulata_western wattlebird_litwat1
+Anthochaera phrygia_regent honeyeater_reghon1
+Anthochaera carunculata_red wattlebird_redwat1
+Anthochaera paradoxa_yellow wattlebird_yelwat1
+Anthochaera sp._wattlebird sp._wattle1
+Gavicalis versicolor_varied honeyeater_varhon1
+Gavicalis fasciogularis_mangrove honeyeater_manhon1
+Gavicalis virescens_singing honeyeater_sinhon1
+Gavicalis sp._Gavicalis sp._gavica1
+Ptilotula ornata_yellow-plumed honeyeater_yephon1
+Ptilotula penicillata_white-plumed honeyeater_whphon1
+Ptilotula flavescens_yellow-tinted honeyeater_yethon2
+Ptilotula fusca_fuscous honeyeater_fushon1
+Ptilotula keartlandi_gray-headed honeyeater_gyhhon1
+Ptilotula plumula_gray-fronted honeyeater_gyfhon1
+Stresemannia bougainvillei_bougainville honeyeater_bouhon1
+Ramsayornis modestus_brown-backed honeyeater_brbhon1
+Ramsayornis fasciatus_bar-breasted honeyeater_babhon1
+Conopophila albogularis_rufous-banded honeyeater_rubhon2
+Conopophila rufogularis_rufous-throated honeyeater_ruthon1
+Conopophila whitei_gray honeyeater_gryhon1
+Ashbyia lovensis_gibberbird_descha1
+Epthianura crocea_yellow chat_yelcha1
+Epthianura tricolor_crimson chat_cricha1
+Epthianura aurifrons_orange chat_oracha1
+Epthianura albifrons_white-fronted chat_whfcha1
+Melipotes gymnops_arfak honeyeater_arfhon1
+Melipotes fumigatus_smoky honeyeater_smohon1
+Melipotes carolae_foja honeyeater_washon1
+Melipotes ater_spangled honeyeater_spahon1
+Melipotes sp._Melipotes sp._melipo1
+Macgregoria pulchra_macgregor's honeyeater_machon3
+Melilestes megarhynchus_long-billed honeyeater_lobhon2
+Timeliopsis fulvigula_olive straightbill_olistr1
+Timeliopsis griseigula_tawny straightbill_tawstr1
+Sugomel nigrum_black honeyeater_blahon1
+Vosea whitemanensis_bismarck honeyeater_bismel1
+Myzomela blasii_seram myzomela_sermyz1
+Myzomela albigula_white-chinned myzomela_whcmyz1
+Myzomela eques_ruby-throated myzomela_retmyz1
+Myzomela cineracea_ashy myzomela_ashmyz1
+Myzomela simplex_moluccan myzomela_dusmyz4
+Myzomela rubrotincta_red-tinged myzomela_dusmyz3
+Myzomela rubrobrunnea_biak myzomela_dusmyz2
+Myzomela obscura_dusky myzomela_dusmyz5
+Myzomela cruentata_red myzomela_redmyz2
+Myzomela erythrina_reddish myzomela_redmyz3
+Myzomela nigrita_papuan black myzomela_blamyz1
+Myzomela pulchella_new ireland myzomela_neimyz1
+Myzomela prawiradilagae_alor myzomela_alomyz1
+Myzomela kuehni_crimson-hooded myzomela_crhmyz1
+Myzomela erythrocephala_red-headed myzomela_rehmyz1
+Myzomela dammermani_sumba myzomela_summyz1
+Myzomela irianawidodoae_rote myzomela_rotmyz2
+Myzomela adolphinae_elfin myzomela_moumyz1
+Myzomela chloroptera_sulawesi myzomela_sulmyz1
+Myzomela batjanensis_bacan myzomela_sulmyz3
+Myzomela [undescribed form]_obi myzomela (undescribed form)_obimyz1
+Myzomela wahe_taliabu myzomela_talmyz1
+Myzomela wakoloensis_wakolo myzomela_wakmyz1
+Myzomela wakoloensis elisabethae_wakolo myzomela (Seram)_wakmyz2
+Myzomela wakoloensis wakoloensis_wakolo myzomela (Buru)_wakmyz3
+Myzomela boiei_banda myzomela_banmyz1
+Myzomela boiei boiei_banda myzomela (Banda Islands)_banmyz2
+Myzomela boiei annabellae_banda myzomela (Tanimbar)_banmyz3
+Myzomela boiei [undescribed form]_banda myzomela (Babar)_banmyz4
+Myzomela caledonica_new caledonian myzomela_necmyz1
+Myzomela sanguinolenta_scarlet myzomela_scamyz1
+Myzomela rubratra_micronesian myzomela_micmyz1
+Myzomela cardinalis_cardinal myzomela_carmyz1
+Myzomela cardinalis lifuensis_cardinal myzomela (Loyalty)_carmyz2
+Myzomela cardinalis [cardinalis Group]_cardinal myzomela (Cardinal)_carmyz3
+Myzomela nigriventris_samoan myzomela_carmyz4
+Myzomela chermesina_rotuma myzomela_rotmyz1
+Myzomela sclateri_sclater's myzomela_scbmyz1
+Myzomela pammelaena_bismarck black myzomela_ebomyz1
+Myzomela lafargei_scarlet-naped myzomela_scnmyz1
+Myzomela eichhorni_yellow-vented myzomela_yevmyz1
+Myzomela malaitae_red-bellied myzomela_rebmyz1
+Myzomela melanocephala_black-headed myzomela_blhmyz1
+Myzomela tristrami_sooty myzomela_soomyz1
+Myzomela jugularis_sulphur-breasted myzomela_orbmyz1
+Myzomela erythromelas_black-bellied myzomela_blbmyz1
+Myzomela vulnerata_papa-mel-de-peito-preto_bkbmyz1
+Myzomela rosenbergii_red-collared myzomela_recmyz1
+Myzomela longirostris_long-billed myzomela_recmyz3
+Myzomela sp._papa-mel (Myzomela) sp._myzome1
+Gliciphila undulata_barred honeyeater_barhon2
+Gliciphila melanops_tawny-crowned honeyeater_tachon1
+Gliciphila notabilis_vanuatu honeyeater_nehhon1
+Glycichaera fallax_green-backed honeyeater_grbhon1
+Ptiloprora plumbea_leaden honeyeater_leahon1
+Ptiloprora meekiana_yellow-streaked honeyeater_olshon1
+Ptiloprora erythropleura_rufous-sided honeyeater_rushon1
+Ptiloprora mayri_mayr's honeyeater_mayhon1
+Ptiloprora guisei_rufous-backed honeyeater_rubhon1
+Ptiloprora perstriata_gray-streaked honeyeater_blbhon1
+Cissomela pectoralis_banded honeyeater_banhon1
+Lichmera lombokia_sunda honeyeater_sunhon1
+Lichmera argentauris_olive honeyeater_olihon1
+Lichmera indistincta_papa-mel-castanho_brohon1
+Lichmera incana_dark-brown honeyeater_dabhon1
+Lichmera squamata_white-tufted honeyeater_whthon2
+Lichmera alboauricularis_silver-eared honeyeater_siehon1
+Lichmera deningeri_buru honeyeater_burhon1
+Lichmera monticola_seram honeyeater_serhon1
+Lichmera flavicans_papa-mel-d'orelha-amarela_yeehon1
+Lichmera notabilis_black-chested honeyeater_blchon1
+Phylidonyris pyrrhopterus_crescent honeyeater_crehon2
+Phylidonyris novaehollandiae_new holland honeyeater_nehhon2
+Phylidonyris niger_white-cheeked honeyeater_whchon2
+Phylidonyris novaehollandiae x niger_new holland x white-cheeked honeyeater (hybrid)_x00923
+Trichodere cockerelli_white-streaked honeyeater_whshon1
+Nesoptilotis leucotis_white-eared honeyeater_whehon1
+Nesoptilotis flavicollis_yellow-throated honeyeater_yethon1
+Entomyzon cyanotis_blue-faced honeyeater_blfhon1
+Entomyzon cyanotis albipennis_blue-faced honeyeater (White-quilled)_bufhon1
+Entomyzon cyanotis [cyanotis Group]_blue-faced honeyeater (Blue-faced)_bufhon2
+Melithreptus albogularis_white-throated honeyeater_whthon1
+Melithreptus chloropsis_gilbert's honeyeater_whnhon3
+Melithreptus lunatus_white-naped honeyeater_whnhon2
+Melithreptus affinis_black-headed honeyeater_blhhon1
+Melithreptus brevirostris_brown-headed honeyeater_brhhon1
+Melithreptus gularis_black-chinned honeyeater_blchon2
+Melithreptus gularis laetior_black-chinned honeyeater (Golden-backed)_bkchon1
+Melithreptus gularis gularis_black-chinned honeyeater (Black-chinned)_bkchon2
+Melithreptus validirostris_strong-billed honeyeater_stbhon2
+Melithreptus sp._Melithreptus sp._melith1
+Meliarchus sclateri_makira honeyeater_sacmel1
+Guadalcanaria inexpectata_guadalcanal honeyeater_guahon1
+Meliphacator provocator_kadavu honeyeater_kanhon1
+Gymnomyza viridis_yellow-billed giant-honeyeater_chagih1
+Gymnomyza brunneirostris_duetting giant-honeyeater_duegih1
+Gymnomyza samoensis_mao_mao1
+Gymnomyza aubryana_crow honeyeater_crohon1
+Foulehaio procerior_western wattled-honeyeater_weswah1
+Foulehaio carunculatus_eastern wattled-honeyeater_easwah1
+Foulehaio taviunensis_northern wattled-honeyeater_norwah1
+Xanthotis flaviventer_tawny-breasted honeyeater_tabhon1
+Xanthotis polygrammus_spotted honeyeater_spohon3
+Xanthotis macleayanus_macleay's honeyeater_machon2
+Plectorhyncha lanceolata_striped honeyeater_strhon1
+Grantiella picta_painted honeyeater_paihon1
+Melitograis gilolensis_white-streaked friarbird_whsfri1
+Philemon citreogularis_little friarbird_litfri1
+Philemon meyeri_meyer's friarbird_meyfri1
+Philemon inornatus_pássaro-monge-de-timor_timfri1
+Philemon kisserensis_gray friarbird_gryfri1
+Philemon brassi_brass's friarbird_brafri1
+Philemon fuscicapillus_morotai friarbird_dusfri1
+Philemon moluccensis_buru friarbird_bkffri1
+Philemon plumigenis_tanimbar friarbird_bkffri2
+Philemon subcorniculatus_seram friarbird_serfri1
+Philemon eichhorni_new ireland friarbird_neifri1
+Philemon buceroides_pássaro-monge-de-capacete_helfri1
+Philemon buceroides novaeguineae_pássaro-monge-de-capacete (novaeguineae)_helfri3
+Philemon buceroides yorki_pássaro-monge-de-capacete (yorki)_helfri4
+Philemon buceroides gordoni/ammitophilus_helmeted friarbird (Arnhem Land)_helfri9
+Philemon buceroides buceroides/neglectus_pássaro-monge-de-capacete (buceroides/neglectus)_helfri2
+Philemon albitorques_white-naped friarbird_whnfri1
+Philemon cockerelli_new britain friarbird_nebfri1
+Philemon argenticeps_silver-crowned friarbird_sicfri1
+Philemon corniculatus_noisy friarbird_noifri1
+Philemon diemenensis_new caledonian friarbird_necfri1
+Philemon sp._friarbird sp._friarb1
+Meliphagidae sp._Meliphagidae sp._meliph2
+Dasyornis longirostris_western bristlebird_wesbri1
+Dasyornis brachypterus_eastern bristlebird_easbri1
+Dasyornis broadbenti_rufous bristlebird_rufbri1
+Pardalotus punctatus_spotted pardalote_spopar1
+Pardalotus punctatus millitaris_spotted pardalote (Wet Tropics)_spopar2
+Pardalotus punctatus punctatus_spotted pardalote (Spotted)_spopar3
+Pardalotus punctatus xanthopyge_spotted pardalote (Yellow-rumped)_spopar4
+Pardalotus quadragintus_forty-spotted pardalote_fospar1
+Pardalotus rubricatus_red-browed pardalote_rebpar6
+Pardalotus striatus_striated pardalote_strpar1
+Pardalotus striatus [melanocephalus Group]_striated pardalote (Black-headed)_strpar2
+Pardalotus striatus ornatus_striated pardalote (Eastern)_strpar3
+Pardalotus striatus striatus_striated pardalote (Yellow-tipped)_strpar4
+Pardalotus striatus substriatus_striated pardalote (Striated)_strpar5
+Pardalotus sp._Pardalotus sp._pardal1
+Pachycare flavogriseum_goldenface_dwawhi1
+Oreoscopus gutturalis_fernwren_fernwr1
+Pycnoptilus floccosus_pilotbird_pilotb1
+Pyrrholaemus brunneus_redthroat_redthr1
+Pyrrholaemus sagittatus_speckled warbler_spewar3
+Hylacola cauta_shy heathwren_shyhea1
+Hylacola pyrrhopygia_chestnut-rumped heathwren_chrhea1
+Calamanthus fuliginosus_striated fieldwren_strfie1
+Calamanthus campestris_rufous fieldwren_ruffie2
+Calamanthus montanellus_western fieldwren_ruffie3
+Calamanthus campestris/montanellus_rufous/western fieldwren_ruffie1
+Smicrornis brevirostris_weebill_weebil1
+Neosericornis citreogularis_yellow-throated scrubwren_yetscr1
+Origma robusta_mountain mouse-warbler_momwar1
+Origma murina_rusty mouse-warbler_rumwar1
+Origma solitaria_rockwarbler_rocwar1
+Sericornis humilis_tasmanian scrubwren_tasscr1
+Sericornis frontalis_white-browed scrubwren_whbscr1
+Sericornis frontalis laevigaster_white-browed scrubwren (Buff-breasted)_whbscr2
+Sericornis frontalis [frontalis Group]_white-browed scrubwren (White-browed)_whbscr4
+Sericornis maculatus_spotted scrubwren_whbscr3
+Sericornis frontalis/maculatus_white-browed/spotted scrubwren_y01172
+Sericornis keri_atherton scrubwren_athscr1
+Sericornis beccarii_tropical scrubwren_becscr1
+Sericornis magnirostra_large-billed scrubwren_labscr2
+Sericornis nouhuysi_large scrubwren_larscr1
+Aethomyias spilodera_pale-billed scrubwren_pabscr1
+Aethomyias nigrorufus_bicolored mouse-warbler_bimwar1
+Crateroscelis robusta/murina/Aethomyias nigrorufus_mouse-warbler sp._mousew1
+Aethomyias rufescens_vogelkop scrubwren_vogscr1
+Aethomyias perspicillatus_buff-faced scrubwren_bufscr1
+Aethomyias arfakianus_gray-green scrubwren_gygscr1
+Aethomyias papuensis_papuan scrubwren_papscr1
+Neosericornis/Sericornis/Aethomyias sp._scrubwren sp._scrubw1
+Acanthornis magna_scrubtit_scrubt2
+Aphelocephala leucopsis_southern whiteface_souwhi1
+Aphelocephala nigricincta_banded whiteface_banwhi1
+Aphelocephala pectoralis_chestnut-breasted whiteface_chbwhi1
+Acanthiza chrysorrhoa_yellow-rumped thornbill_yertho1
+Acanthiza cinerea_gray thornbill_mouger1
+Acanthiza murina_papuan thornbill_paptho1
+Acanthiza nana_yellow thornbill_yeltho1
+Acanthiza lineata_striated thornbill_strtho1
+Acanthiza apicalis_inland thornbill_inltho1
+Acanthiza ewingii_tasmanian thornbill_tastho1
+Acanthiza katherina_mountain thornbill_moutho1
+Acanthiza pusilla_brown thornbill_brotho1
+Acanthiza ewingii/pusilla_tasmanian/brown thornbill_y00973
+Acanthiza robustirostris_slaty-backed thornbill_slbtho1
+Acanthiza iredalei_slender-billed thornbill_slbtho2
+Acanthiza uropygialis_chestnut-rumped thornbill_chrtho1
+Acanthiza inornata_western thornbill_westho1
+Acanthiza reguloides_buff-rumped thornbill_burtho1
+Acanthiza sp._thornbill sp._thornb1
+Gerygone chrysogaster_yellow-bellied gerygone_yebger1
+Gerygone mouki_brown gerygone_broger1
+Gerygone chloronota_green-backed gerygone_gnbger1
+Gerygone palpebrosa_fairy gerygone_faiger1
+Gerygone palpebrosa [palpebrosa Group]_fairy gerygone (Black-throated)_faiger2
+Gerygone palpebrosa flavida_fairy gerygone (Fairy)_faiger3
+Gerygone magnirostris_large-billed gerygone_labger1
+Gerygone hypoxantha_biak gerygone_biager1
+Gerygone inornata_gerigone-lisa_plager1
+Gerygone dorsalis_rufous-sided gerygone_rusger1
+Gerygone olivacea_white-throated gerygone_whtger1
+Gerygone sulphurea_golden-bellied gerygone_gobger1
+Gerygone tenebrosa_dusky gerygone_dusger1
+Gerygone flavolateralis_fan-tailed gerygone_fatger1
+Gerygone citrina_rennell gerygone_fatger3
+Gerygone levigaster_mangrove gerygone_manger1
+Gerygone fusca_western gerygone_wesger1
+Gerygone ruficollis_brown-breasted gerygone_brbger1
+Gerygone insularis_lord howe gerygone_lohger1
+Gerygone modesta_norfolk island gerygone_noiger1
+Gerygone igata_gray gerygone_gryger1
+Gerygone albofrontata_chatham islands gerygone_chiger2
+Gerygone sp._gerygone sp._gerygo1
+Garritornis isidorei_papuan babbler_negbab1
+Pomatostomus temporalis_gray-crowned babbler_gycbab1
+Pomatostomus superciliosus_white-browed babbler_whbbab3
+Pomatostomus halli_hall's babbler_halbab1
+Pomatostomus ruficeps_chestnut-crowned babbler_chcbab2
+Pomatostomus sp._pseudo-babbler sp._pseudo1
+Orthonyx novaeguineae_papuan logrunner_norlog1
+Orthonyx temminckii_australian logrunner_soulog1
+Orthonyx spaldingii_chowchilla_chowch1
+Cinclosoma punctatum_spotted quail-thrush_spqthr1
+Cinclosoma castanotum_chestnut quail-thrush_chequt1
+Cinclosoma clarum_copperback quail-thrush_copqut1
+Cinclosoma castaneothorax_chestnut-breasted quail-thrush_cbqthr1
+Cinclosoma marginatum_western quail-thrush_chbqut1
+Cinclosoma cinnamomeum_cinnamon quail-thrush_ciqthr1
+Cinclosoma alisteri_nullarbor quail-thrush_nulqut1
+Cinclosoma ajax_painted quail-thrush_paqthr1
+Cinclosoma sp._quail-thrush sp._quailt1
+Ptilorrhoa leucosticta_spotted jewel-babbler_spjbab1
+Ptilorrhoa caerulescens_blue jewel-babbler_blujeb1
+Ptilorrhoa geislerorum_dimorphic jewel-babbler_blujeb2
+Ptilorrhoa caerulescens/geislerorum_blue/dimorphic jewel-babbler_bljbab1
+Ptilorrhoa castanonota_chestnut-backed jewel-babbler_cbjbab1
+Ptilorrhoa sp._jewel-babbler sp._jewelb1
+Pericrocotus erythropygius_white-bellied minivet_whbmin3
+Pericrocotus albifrons_jerdon's minivet_whbmin2
+Pericrocotus igneus_fiery minivet_fiemin1
+Pericrocotus cinnamomeus_small minivet_smamin1
+Pericrocotus solaris_gray-chinned minivet_gycmin1
+Pericrocotus solaris [solaris Group]_gray-chinned minivet (Gray-chinned)_gycmin2
+Pericrocotus solaris montanus/cinereigula_gray-chinned minivet (Gray-throated)_gycmin3
+Pericrocotus miniatus_sunda minivet_sunmin1
+Pericrocotus brevirostris_short-billed minivet_shbmin2
+Pericrocotus lansbergei_flores minivet_flomin1
+Pericrocotus ethologus_long-tailed minivet_lotmin1
+Pericrocotus flammeus_orange minivet_scamin3
+Pericrocotus speciosus_scarlet minivet_scamin1
+Pericrocotus speciosus [speciosus Group]_scarlet minivet (Scarlet)_scamin2
+Pericrocotus speciosus leytensis/novus_scarlet minivet (Philippine Red)_scamin6
+Pericrocotus speciosus [marchesae Group]_scarlet minivet (Philippine Yellow)_scamin4
+Pericrocotus speciosus exul/siebersi_scarlet minivet (Javan)_scamin5
+Pericrocotus tegimae_ryukyu minivet_ryumin1
+Pericrocotus divaricatus_ashy minivet_ashmin1
+Pericrocotus tegimae/divaricatus_ryukyu/ashy minivet_y01115
+Pericrocotus cantonensis_brown-rumped minivet_brrmin1
+Pericrocotus divaricatus/cantonensis_ashy/brown-rumped minivet_y00974
+Pericrocotus roseus_rosy minivet_rosmin1
+Pericrocotus cantonensis x roseus_brown-rumped x rosy minivet (hybrid)_rosmin3
+Pericrocotus sp. (red minivet sp.)_minivet sp. (red minivet sp.)_minive2
+Pericrocotus sp. (grey minivet sp.)_minivet sp. (gray minivet sp.)_minive3
+Pericrocotus sp._minivet sp._minive1
+Ceblepyris cucullatus_comoro cuckooshrike_ashcus3
+Ceblepyris cinereus_madagascar cuckooshrike_ashcus2
+Ceblepyris graueri_grauer's cuckooshrike_gracus1
+Ceblepyris caesius_gray cuckooshrike_grycus1
+Ceblepyris pectoralis_lagarteiro-cinzento_whbcus2
+Coracina caeruleogrisea_stout-billed cuckooshrike_stbcus1
+Coracina longicauda_hooded cuckooshrike_hoocus1
+Coracina bicolor_pied cuckooshrike_piecus1
+Coracina temminckii_cerulean cuckooshrike_cercus1
+Coracina maxima_ground cuckooshrike_grocus1
+Coracina lineata_barred cuckooshrike_yeecus1
+Coracina boyeri_boyer's cuckooshrike_boycus1
+Coracina novaehollandiae_cuco-picanço-de-faces-negras_bkfcus1
+Coracina welchmani_north melanesian cuckooshrike_melcus3
+Coracina papuensis_white-bellied cuckooshrike_whbcus1
+Coracina atriceps_moluccan cuckooshrike_molcus1
+Coracina ingens_manus cuckooshrike_whbcus4
+Coracina caledonica_south melanesian cuckooshrike_melcus1
+Coracina macei_indian cuckooshrike_larcuc1
+Coracina javensis_oriental cuckooshrike_larcuc11
+Coracina javensis javensis_oriental cuckooshrike (Javan)_javcus1
+Coracina javensis [nipalensis Group]_oriental cuckooshrike (Oriental)_larcuc2
+Coracina javensis rexpineti_oriental cuckooshrike (East Asian)_larcuc9
+Coracina macei/javensis_indian/oriental cuckooshrike_y01313
+Coracina larutensis_malayan cuckooshrike_larcuc3
+Coracina striata_bar-bellied cuckooshrike_babcus1
+Coracina striata [sumatrensis Group]_bar-bellied cuckooshrike (Roving)_babcuc25
+Coracina striata [striata Group]_bar-bellied cuckooshrike (Philippine)_babcuc3
+Coracina mindorensis_mindoro cuckooshrike_babcuc19
+Coracina panayensis_visayan cuckooshrike_babcuc5
+Coracina kochii_mindanao cuckooshrike_mincuc1
+Coracina guillemardi_sulu cuckooshrike_babcuc24
+Coracina dobsoni_andaman cuckooshrike_andcus1
+Coracina larvata_sunda cuckooshrike_suncus1
+Coracina personata_cuco-picanço-de-wallace_walcus1
+Coracina personata pollens_cuco-picanço-de-wallace (pollens)_walcuc1
+Coracina personata floris_cuco-picanço-de-wallace (floris)_walcuc2
+Coracina personata sumbensis_cuco-picanço-de-wallace (sumbensis)_walcuc4
+Coracina personata personata_cuco-picanço-de-wallace (personata)_walcuc5
+Coracina personata unimoda_cuco-picanço-de-wallace (unimoda)_walcuc6
+Coracina personata alfrediana_cuco-picanço-de-wallace (alfrediana)_walcuc3
+Coracina parvula_halmahera cuckooshrike_halcus1
+Coracina fortis_buru cuckooshrike_burcus1
+Coracina leucopygia_white-rumped cuckooshrike_whrcus1
+Coracina schistacea_slaty cuckooshrike_slacus1
+Coracina sp._Coracina sp._cuckoo2
+Lobotos lobatus_ghana cuckooshrike_ghacus1
+Lobotos oriolinus_oriole cuckooshrike_oricus1
+Campephaga flava_black cuckooshrike_blkcus1
+Campephaga petiti_petit's cuckooshrike_petcus1
+Campephaga phoenicea_lagarteiro-riscadinho_rescus1
+Campephaga quiscalina_purple-throated cuckooshrike_putcus1
+Campephaga sp._african cuckooshrike sp._afrcuc2
+Campochaera sloetii_golden cuckooshrike_golcus1
+Malindangia mcgregori_mcgregor's cuckooshrike_mcgcus1
+Lalage maculosa_polynesian triller_poltri1
+Lalage sharpei_samoan triller_samtri1
+Lalage leucopyga_long-tailed triller_lottri1
+Lalage sueurii_cuco-picanço-de-lesueur_whwtri2
+Lalage tricolor_cuco-picanço-d'asa-branca_whwtri1
+Lalage atrovirens_black-browed triller_blbtri1
+Lalage leucoptera_biak triller_bkbtri2
+Lalage moesta_white-browed triller_whbtri1
+Lalage leucomela_varied triller_vartri1
+Lalage conjuncta_mussau triller_vartri3
+Lalage melanoleuca_black-and-white triller_bawtri1
+Lalage melanoleuca melanoleuca_black-and-white triller (Northern)_bawtri2
+Lalage melanoleuca minor_black-and-white triller (Southern)_bawtri3
+Lalage leucopygialis_white-rumped triller_whrtri1
+Lalage nigra_pied triller_pietri1
+Lalage aurea_rufous-bellied triller_rubtri1
+Lalage newtoni_reunion cuckooshrike_reucus1
+Lalage typica_mauritius cuckooshrike_maucus1
+Lalage melaschistos_black-winged cuckooshrike_bkwcus1
+Lalage melanoptera_black-headed cuckooshrike_bkhcus1
+Coracina macei/javensis/Lalage melanoptera_indian/oriental/black-headed cuckooshrike_y00408
+Lalage fimbriata_lesser cuckooshrike_lescus1
+Lalage polioptera_indochinese cuckooshrike_indcus1
+Lalage sp._Lalage sp._trille1
+Celebesica abbotti_pygmy cuckooshrike_pygcus1
+Cyanograucalus azureus_blue cuckooshrike_blucus1
+Edolisoma anale_new caledonian cuckooshrike_neccus1
+Edolisoma coerulescens_blackish cuckooshrike_blacus1
+Edolisoma ostentum_white-winged cuckooshrike_whwcus1
+Edolisoma montanum_black-bellied cicadabird_bkbcus2
+Edolisoma dohertyi_pale-shouldered cicadabird_sumcus1
+Edolisoma dispar_kai cicadabird_kaicus1
+Edolisoma timoriense_timor cicadabird_timcic1
+Edolisoma timoriense emancipatum/kalaotuae_timor cicadabird (Flores Sea)_timcic2
+Edolisoma timoriense timoriense_timor cicadabird (Timor)_comcic12
+Edolisoma ceramense_pale cicadabird_pagcus1
+Edolisoma insperatum_pohnpei cicadabird_cicada3
+Edolisoma mindanense_black-bibbed cicadabird_bkbcus1
+Edolisoma mindanense lecroyae_black-bibbed cicadabird (Luzon)_bkbcuc1
+Edolisoma mindanense elusum_black-bibbed cicadabird (Mindoro)_bkbcuc2
+Edolisoma mindanense mindanense/ripleyi_black-bibbed cicadabird (Mindanao)_bkbcic3
+Edolisoma mindanense everetti_black-bibbed cicadabird (Sulu)_bkbcuc5
+Edolisoma schisticeps_gray-headed cicadabird_gyhcus1
+Edolisoma melas_black cicadabird_negcus1
+Edolisoma holopolium_solomons cicadabird_soicus1
+Edolisoma holopolium holopolium_solomons cicadabird (Solomons)_solcuc3
+Edolisoma holopolium pygmaeum_solomons cicadabird (New Georgia)_solcuc2
+Edolisoma tricolor_malaita cicadabird_solcuc4
+Edolisoma salomonis_cuco-picanço-de-makira_cicada7
+Edolisoma admiralitatis_manus cicadabird_mancic1
+Edolisoma salvadorii_sangihe cicadabird_sancic1
+Edolisoma salvadorii salvadorii_sangihe cicadabird (Sangihe)_sulcic2
+Edolisoma salvadorii talautense_sangihe cicadabird (Talaud)_sulcic1
+Edolisoma monacha_palau cicadabird_cicada4
+Edolisoma nesiotis_yap cicadabird_cicada5
+Edolisoma erythropygium_central melanesian cicadabird_cemcic1
+Edolisoma erythropygium ultimum_central melanesian cicadabird (Lihir)_comcic26
+Edolisoma erythropygium erythropygium/saturatius_central melanesian cicadabird (Central Melanesian)_cemcic2
+Edolisoma erythropygium nisorium_central melanesian cicadabird (Pavuvu)_comcic29
+Edolisoma morio_sulawesi cicadabird_sulcus2
+Edolisoma meyerii_geelvink cicadabird_comcic4
+Edolisoma pelingi_banggai cicadabird_comcic19
+Edolisoma obiense_obi cicadabird_comcic20
+Edolisoma sula_sula cicadabird_sulcus1
+Edolisoma grayi_north moluccan cicadabird_nomcic1
+Edolisoma grayi pererratum_north moluccan cicadabird (Tukangbesi)_comcic10
+Edolisoma grayi grayi_north moluccan cicadabird (North Moluccan)_comcic3
+Edolisoma incertum_papuan cicadabird_papcus1
+Edolisoma remotum_bismarck cicadabird_comcic6
+Edolisoma remotum matthiae_bismarck cicadabird (Mussau)_comcic25
+Edolisoma remotum remotum_bismarck cicadabird (New Ireland)_cicada6
+Edolisoma remotum rooki_bismarck cicadabird (Umboi)_comcic23
+Edolisoma remotum heinrothi_bismarck cicadabird (New Britain)_comcic24
+Edolisoma rostratum_rossel cicadabird_comcic5
+Edolisoma amboinense_south moluccan cicadabird_comcic11
+Edolisoma tenuirostre_cuco-picanço-de-bico-fino_cicada1
+Edolisoma sp._Edolisoma sp._edolis1
+Campephagidae sp._cuckooshrike sp._cuckoo4
+Mohoua albicilla_whitehead_whiteh1
+Mohoua ochrocephala_yellowhead_yellow3
+Mohoua novaeseelandiae_pipipi_pipipi1
+Daphoenositta miranda_black sittella_blksit1
+Daphoenositta papuensis_papuan sittella_varsit1
+Daphoenositta chrysoptera_varied sittella_varsit8
+Daphoenositta chrysoptera leucoptera_varied sittella (White-winged)_varsit3
+Daphoenositta chrysoptera striata_varied sittella (Striated)_varsit4
+Daphoenositta chrysoptera leucocephala_varied sittella (White-headed)_varsit5
+Daphoenositta chrysoptera chrysoptera_varied sittella (Orange-winged)_varsit6
+Daphoenositta chrysoptera pileata_varied sittella (Black-capped)_varsit7
+Androphobus viridis_papuan whipbird_papwhi1
+Psophodes olivaceus_eastern whipbird_easwhi1
+Psophodes nigrogularis_western whipbird_weswhi1
+Psophodes nigrogularis nigrogularis/oberon_western whipbird (Black-throated)_weswhi3
+Psophodes nigrogularis leucogaster/lashmari_western whipbird (White-bellied)_weswhi4
+Psophodes occidentalis_chiming wedgebill_chiwed1
+Psophodes cristatus_chirruping wedgebill_chiwed2
+Eulacestoma nigropectus_wattled ploughbill_watplo1
+Oreoica gutturalis_crested bellbird_crebel1
+Aleadryas rufinucha_rufous-naped bellbird_runwhi1
+Ornorectes cristatus_piping bellbird_crepit1
+Falcunculus frontatus_eastern shrike-tit_cresht1
+Falcunculus leucogaster_western shrike-tit_cresht2
+Falcunculus whitei_northern shrike-tit_cresht3
+Oreocharis arfaki_tit berrypecker_titber1
+Paramythia olivacea_western crested berrypecker_creber3
+Paramythia montium_eastern crested berrypecker_creber2
+Paramythia olivacea/montium_western/eastern crested berrypecker_creber1
+Pteruthius rufiventer_black-headed shrike-babbler_bhsbab1
+Pteruthius flaviscapis_pied shrike-babbler_wbsbab2
+Pteruthius aeralatus_white-browed shrike-babbler_whbshb1
+Pteruthius aeralatus ripleyi_white-browed shrike-babbler (Himalayan)_himshb1
+Pteruthius aeralatus validirostris_white-browed shrike-babbler (Chestnut-winged)_blyshb4
+Pteruthius aeralatus ricketti_white-browed shrike-babbler (Gray-breasted)_blyshb3
+Pteruthius aeralatus [aeralatus Group]_white-browed shrike-babbler (Blyth's)_blyshb2
+Pteruthius aeralatus annamensis_white-browed shrike-babbler (Dalat)_dalshb1
+Pteruthius xanthochlorus_green shrike-babbler_grsbab1
+Pteruthius xanthochlorus xanthochlorus/occidentalis_green shrike-babbler (Black-crowned)_grnshb2
+Pteruthius xanthochlorus pallidus/hybrida_green shrike-babbler (Eye-ringed)_grnshb1
+Pteruthius melanotis_black-eared shrike-babbler_besbab1
+Pteruthius aenobarbus_trilling shrike-babbler_cfsbab1
+Pteruthius intermedius_clicking shrike-babbler_clishb1
+Pteruthius intermedius aenobarbulus_clicking shrike-babbler (Garo Hills)_clishb2
+Pteruthius intermedius intermedius_clicking shrike-babbler (Clicking)_clishb3
+Pteruthius sp._shrike-babbler sp._shrike2
+Erpornis zantholeuca_white-bellied erpornis_whbyuh1
+Cyclarhis gujanensis_pitiguari_rubpep1
+Cyclarhis gujanensis [gujanensis Group]_pitiguari [grupo gujanensis]_rubpep2
+Cyclarhis gujanensis insularis_pitiguari (insularis)_rubpep3
+Cyclarhis gujanensis [virenticeps Group]_pitiguari [grupo virenticeps]_rubpep4
+Cyclarhis gujanensis viridis/cearensis_pitiguari (viridis/cearensis)_rubpep5
+Cyclarhis gujanensis ochrocephala_pitiguari (ochrocephala)_rubpep6
+Cyclarhis nigrirostris_black-billed peppershrike_blbpep1
+Cyclarhis gujanensis/nigrirostris_rufous-browed/black-billed peppershrike_y00891
+Hylophilus amaurocephalus_vite-vite-de-olho-cinza_gyegre1
+Hylophilus amaurocephalus [undescribed Beni form]_vite-vite-d'olhos-cinzentos [beni]_gyegre2
+Hylophilus poicilotis_verdinho-coroado_rucgre1
+Hylophilus olivaceus_olivaceous greenlet_oligre1
+Hylophilus pectoralis_vite-vite-de-cabeça-cinza_ashgre1
+Hylophilus flavipes_scrub greenlet_scrgre1
+Hylophilus flavipes viridiflavus/xuthus_scrub greenlet (Yellow-green)_scrgre2
+Hylophilus flavipes [flavipes Group]_scrub greenlet (Scrub)_scrgre3
+Hylophilus flavipes insularis_scrub greenlet (Tobago)_scrgre4
+Hylophilus semicinereus_verdinho-da-várzea_gycgre1
+Hylophilus brunneiceps_vite-vite-de-cabeça-marrom_brhgre1
+Hylophilus thoracicus_vite-vite_lecgre2
+Hylophilus thoracicus griseiventris/aemulus_vite-vite (griseiventris/aemulus)_lecgre1
+Hylophilus thoracicus thoracicus_vite-vite (thoracicus)_lecgre3
+Vireolanius melitophrys_chestnut-sided shrike-vireo_cssvir1
+Vireolanius pulchellus_green shrike-vireo_grsvir1
+Vireolanius eximius_yellow-browed shrike-vireo_ybsvir1
+Vireolanius leucotis_assobiador-do-castanhal_scsvir1
+Vireolanius leucotis mikettae_assobiador-do-castanhal (mikettae)_slcshv1
+Vireolanius leucotis [leucotis Group]_assobiador-do-castanhal [grupo leucotis]_slcshv2
+Tunchiornis ochraceiceps_vite-vite-uirapuru_tacgre1
+Tunchiornis ochraceiceps [ochraceiceps Group]_vite-vite-uirapuru [grupo ochraceiceps]_tacgre2
+Tunchiornis ochraceiceps ferrugineifrons/viridior_vite-vite-uirapuru (ferrugineifrons/viridior)_tacgre4
+Tunchiornis ochraceiceps luteifrons_vite-vite-uirapuru (luteifrons)_tacgre5
+Tunchiornis ochraceiceps rubrifrons/lutescens_vite-vite-uirapuru (rubrifrons/lutescens)_tacgre3
+Pachysylvia decurtata_lesser greenlet_lesgre1
+Pachysylvia decurtata decurtata/darienensis_lesser greenlet (Northern)_lesgre2
+Pachysylvia decurtata minor_lesser greenlet (Gray-headed)_lesgre3
+Pachysylvia hypoxantha_vite-vite-de-barriga-amarela_ducgre1
+Pachysylvia muscicapina_vite-vite-camurça_bucgre1
+Pachysylvia aurantiifrons_golden-fronted greenlet_gofgre1
+Pachysylvia semibrunnea_rufous-naped greenlet_rungre1
+Hylophilus/Tunchiornis/Pachysylvia sp._Hylophilus/Tunchiornis/Pachysylvia sp._greenl1
+Vireo hypochryseus_golden vireo_golvir1
+Vireo osburni_blue mountain vireo_blmvir1
+Vireo brevipennis_slaty vireo_slavir1
+Vireo atricapilla_black-capped vireo_bkcvir1
+Vireo nelsoni_dwarf vireo_dwavir1
+Vireo griseus_juruviara-d'olhos-brancos_whevir
+Vireo griseus [griseus Group]_juruviara-d'olhos-brancos [grupo griseus]_whevir1
+Vireo griseus perquisitor_juruviara-d'olhos-brancos (perquisitor)_whevir2
+Vireo atricapilla x griseus_black-capped x white-eyed vireo (hybrid)_x01067
+Vireo crassirostris_thick-billed vireo_thbvir
+Vireo pallens_mangrove vireo_manvir1
+Vireo pallens paluster_mangrove vireo (West Mexico)_manvir4
+Vireo pallens [semiflavus Group]_mangrove vireo (Northern Central America)_manvir3
+Vireo pallens approximans_mangrove vireo (Providencia)_thbvir2
+Vireo pallens [pallens Group]_mangrove vireo (Southern Central America)_manvir2
+Vireo bairdi_cozumel vireo_cozvir1
+Vireo caribaeus_san andres vireo_stavir1
+Vireo modestus_jamaican vireo_jamvir1
+Vireo gundlachii_cuban vireo_cubvir1
+Vireo latimeri_puerto rican vireo_purvir1
+Vireo nanus_flat-billed vireo_flbvir1
+Vireo bellii_bell's vireo_belvir
+Vireo bellii bellii/medius_bell's vireo (Eastern)_belvir1
+Vireo bellii arizonae_bell's vireo (Arizona)_belvir2
+Vireo bellii pusillus_bell's vireo (Least)_belvir3
+Vireo vicinior_gray vireo_gryvir
+Vireo huttoni_hutton's vireo_hutvir
+Vireo huttoni [huttoni Group]_hutton's vireo (Pacific)_hutvir1
+Vireo huttoni [stephensi Group]_hutton's vireo (Interior)_hutvir2
+Vireo flavifrons_juruviara-de-garganta-amarela_yetvir
+Vireo carmioli_yellow-winged vireo_yewvir1
+Vireo masteri_choco vireo_chovir1
+Vireo cassinii_cassin's vireo_casvir
+Vireo cassinii cassinii_cassin's vireo (Cassin's)_casvir1
+Vireo cassinii lucasanus_cassin's vireo (San Lucas)_casvir2
+Vireo solitarius_blue-headed vireo_buhvir
+Vireo flavifrons x solitarius_yellow-throated x blue-headed vireo (hybrid)_x00411
+Vireo cassinii/solitarius_cassin's/blue-headed vireo_y00485
+Vireo plumbeus_plumbeous vireo_plsvir
+Vireo plumbeus plumbeus/gravis_plumbeous vireo (Plumbeous)_pluvir1
+Vireo plumbeus notius/montanus_plumbeous vireo (Central American)_pluvir2
+Vireo plumbeus x solitarius_plumbeous x blue-headed vireo (hybrid)_x00412
+Vireo cassinii/plumbeus_cassin's/plumbeous vireo_y00484
+Vireo solitarius/plumbeus_blue-headed/plumbeous vireo_y01323
+Vireo cassinii/solitarius/plumbeus_solitary vireo sp._solvir1
+Vireo sclateri_vite-vite-do-tepui_tepgre1
+Vireo philadelphicus_juruviara-da-filadélfia_phivir
+Vireo gilvus_warbling vireo_warvir
+Vireo gilvus gilvus_warbling vireo (Eastern)_eawvir1
+Vireo gilvus [swainsoni Group]_warbling vireo (Western)_wewvir2
+Vireo philadelphicus/gilvus_philadelphia/warbling vireo_y00704
+Vireo leucophrys_brown-capped vireo_brcvir1
+Vireo leucophrys [amauronotus Group]_brown-capped vireo (Northern)_bncvir12
+Vireo leucophrys [leucophrys Group]_brown-capped vireo (Southern)_bncvir13
+Vireo olivaceus_juruviara-boreal_reevir1
+Vireo philadelphicus x olivaceus_juruviara-da-filadélfia x juruviara-norte-americano (híbrido)_x00889
+Vireo gilvus x olivaceus_warbling x red-eyed vireo (hybrid)_x00890
+Vireo philadelphicus/olivaceus_juruviara-da-filadélfia/juruviara-norte-americano_y00741
+Vireo chivi_juruviara_chivir1
+Vireo chivi [agilis Group]_juruviara (grupo agilis)_reevir3
+Vireo chivi chivi/diversus_juruviara (chivi/diversus)_reevir2
+Vireo olivaceus/chivi_juruviara-boreal/juruviara_reevir
+Vireo gracilirostris_juruviara-de-noronha_norvir1
+Vireo flavoviridis_juruviara-verde-amarelada_yegvir
+Vireo flavoviridis [flavoviridis Group]_juruviara-verde-amarelada [grupo flavoviridis]_yegvir5
+Vireo flavoviridis forreri_juruviara-verde-amarelada (forreri)_yegvir2
+Vireo olivaceus/flavoviridis_juruviara-boreal/juruviara-verde-amarelada_y01145
+Vireo altiloquus_juruviara-barbuda_bkwvir
+Vireo olivaceus/altiloquus_juruviara-norte-americano/juruviara-de-bigodes-pretos_y01146
+Vireo magister_yucatan vireo_yucvir
+Vireo sp. (Red-eyed Vireo complex)_vireo sp. (Red-eyed Vireo complex)_vireo2
+Vireo sp._Vireo sp._vireo1
+Pseudorectes ferrugineus_rusty pitohui_ruspit1
+Pseudorectes incertus_white-bellied pitohui_whbpit1
+Colluricincla woodwardi_sandstone shrikethrush_sansht2
+Colluricincla boweri_bower's shrikethrush_bowsht1
+Colluricincla harmonica_gray shrikethrush_grysht1
+Colluricincla tenebrosa_sooty shrikethrush_soosht1
+Colluricincla fortis_variable shrikethrush_litshr5
+Colluricincla affinis_waigeo shrikethrush_litshr6
+Colluricincla obscura_mamberamo shrikethrush_litshr1
+Colluricincla tappenbecki_sepik-ramu shrikethrush_litshr3
+Colluricincla megarhyncha_arafura shrikethrush_rufsht2
+Colluricincla discolor_tagula shrikethrush_litshr4
+Colluricincla rufogaster_rufous shrikethrush_litshr2
+Colluricincla megarhyncha/rufogaster_arafura/rufous shrikethrush_y00409
+Colluricincla sp._Colluricincla sp._collur1
+Melanorectes nigrescens_black pitohui_blapit1
+Coracornis sanghirensis_sangihe whistler_sansht1
+Coracornis raveni_maroon-backed whistler_mabwhi1
+Pachycephala olivacea_olive whistler_oliwhi1
+Pachycephala rufogularis_red-lored whistler_relwhi1
+Pachycephala inornata_gilbert's whistler_gilwhi1
+Pachycephala nudigula_bare-throated whistler_batwhi1
+Pachycephala orpheus_fawn-breasted whistler_fabwhi1
+Pachycephala orpheus orpheus_fawn-breasted whistler (Timor)_fabwhi2
+Pachycephala orpheus par/compar_fawn-breasted whistler (Banda Sea)_yetwhi4
+Pachycephala schlegelii_regent whistler_regwhi1
+Pachycephala chlorura_vanuatu whistler_necwhi2
+Pachycephala meyeri_vogelkop whistler_vogwhi1
+Pachycephala soror_sclater's whistler_sclwhi1
+Pachycephala vitiensis_white-throated fiji whistler_whtwhi1
+Pachycephala graeffii_yellow-throated fiji whistler_fijwhi1
+Pachycephala flavifrons_samoan whistler_samwhi1
+Pachycephala jacquinoti_tongan whistler_tonwhi1
+Pachycephala caledonica_new caledonian whistler_necwhi3
+Pachycephala implicata_guadalcanal hooded whistler_guhwhi1
+Pachycephala richardsi_bougainville hooded whistler_bohwhi1
+Pachycephala citreogaster_bismarck whistler_biswhi1
+Pachycephala collaris_louisiade whistler_louwhi1
+Pachycephala ornata_nendo whistler_temwhi2
+Pachycephala utupuae_utupua whistler_temwhi3
+Pachycephala vanikorensis_vanikoro whistler_temwhi4
+Pachycephala orioloides_oriole whistler_oriwhi1
+Pachycephala feminina_rennell whistler_renwhi1
+Pachycephala calliope_tenggara whistler_rubwhi1
+Pachycephala calliope [fulvotincta Group]_tenggara whistler (Rusty-breasted)_rubwhi3
+Pachycephala calliope calliope_tenggara whistler (Timor)_yetwhi3
+Pachycephala teysmanni_selayar whistler_rubwhi2
+Pachycephala macrorhyncha_moluccan whistler_yetwhi1
+Pachycephala sharpei_babar whistler_yetwhi6
+Pachycephala mentalis_black-chinned whistler_bkcwhi1
+Pachycephala balim_baliem whistler_golwhi2
+Pachycephala pectoralis_assobiadeira-dourada_y01193
+Pachycephala pectoralis fuliginosa/occidentalis_assobiadeira-dourada (fuliginosa/occidentalis)_weswhi2
+Pachycephala pectoralis [pectoralis Group]_assobiadeira-dourada [grupo pectoralis]_golwhi1
+Pachycephala melanura_black-tailed whistler_bltwhi1
+Pachycephala melanura dammeriana_black-tailed whistler (Damar)_yetwhi5
+Pachycephala melanura [melanura Group]_black-tailed whistler (Black-tailed)_bktwhi5
+Pachycephala orioloides x melanura_oriole x black-tailed whistler (hybrid)_x01158
+Pachycephala tenebrosa_morningbird_mornin1
+Pachycephala modesta_brown-backed whistler_brbwhi1
+Pachycephala lorentzi_lorentz's whistler_lorwhi1
+Pachycephala aurea_golden-backed whistler_gobwhi1
+Pachycephala philippinensis_yellow-bellied whistler_yebwhi1
+Pachycephala philippinensis fallax_yellow-bellied whistler (fallax)_yebwhi2
+Pachycephala philippinensis illex_yellow-bellied whistler (illex)_yebwhi3
+Pachycephala philippinensis [philippinensis Group]_yellow-bellied whistler (philippinensis Group)_yebwhi9
+Pachycephala hypoxantha_bornean whistler_borwhi1
+Pachycephala sulfuriventer_sulphur-bellied whistler_subwhi1
+Pachycephala cinerea_mangrove whistler_manwhi1
+Pachycephala albiventris_green-backed whistler_grbwhi1
+Pachycephala homeyeri_white-vented whistler_whvwhi1
+Pachycephala homeyeri homeyeri_white-vented whistler (Sulu)_whvwhi2
+Pachycephala homeyeri major_white-vented whistler (Cebu)_whvwhi3
+Pachycephala homeyeri winchelli_white-vented whistler (White-vented)_whvwhi4
+Pachycephala phaionota_island whistler_islwhi2
+Pachycephala melanorhyncha_biak whistler_biawhi1
+Pachycephala hyperythra_rusty whistler_ruswhi1
+Pachycephala simplex_gray whistler_grywhi2
+Pachycephala simplex simplex/brunnescens_gray whistler (Brown)_grywhi1
+Pachycephala simplex [griseiceps Group]_gray whistler (Gray-headed)_gyhwhi1
+Pachycephala arctitorquis_wallacean whistler_walwhi1
+Pachycephala griseonota_drab whistler_drawhi1
+Pachycephala griseonota [griseonota Group]_drab whistler (Drab)_drawhi2
+Pachycephala griseonota johni_drab whistler (Cinnamon-breasted)_drawhi3
+Pachycephala leucogastra_white-bellied whistler_whbwhi1
+Pachycephala monacha_black-headed whistler_blhwhi1
+Pachycephala rufiventris_rufous whistler_rufwhi1
+Pachycephala lanioides_white-breasted whistler_whbwhi2
+Pachycephala sp._Pachycephala sp._pachyc1
+Pitohui dichrous_hooded pitohui_hoopit1
+Pitohui cerviniventris_raja ampat pitohui_varpit4
+Pitohui kirhocephalus_northern variable pitohui_varpit2
+Pitohui uropygialis_southern variable pitohui_varpit3
+Pitohui kirhocephalus/uropygialis_northern/southern variable pitohui_y01147
+Oriolus melanotis_papa-figos-oliváceo_timori1
+Oriolus finschi_wetar oriole_timori3
+Oriolus bouroensis_buru oriole_burori2
+Oriolus decipiens_tanimbar oriole_burori3
+Oriolus forsteni_seram oriole_serori1
+Oriolus phaeochromus_halmahera oriole_halori1
+Oriolus szalayi_brown oriole_broori1
+Oriolus sagittatus_olive-backed oriole_olbori1
+Oriolus flavocinctus_green oriole_greori1
+Oriolus xanthonotus_dark-throated oriole_datori1
+Oriolus consobrinus_ventriloquial oriole_datori7
+Oriolus albiloris_white-lored oriole_whlori1
+Oriolus steerii_philippine oriole_phiori1
+Oriolus isabellae_isabela oriole_isaori1
+Oriolus oriolus_papa-figos_eugori2
+Oriolus kundoo_papa-figos-oriental_ingori1
+Oriolus oriolus/kundoo_papa-figos/papa-figos-oriental_y00691
+Oriolus auratus_papa-figos-dourado_afgori2
+Oriolus oriolus/auratus_papa-figos/papa-figos-dourado_y01041
+Oriolus chinensis_black-naped oriole_blnori1
+Oriolus chinensis diffusus_black-naped oriole (East Asian)_bknori1
+Oriolus chinensis [maculatus Group]_black-naped oriole (Sunda)_bknori2
+Oriolus chinensis [chinensis Group]_black-naped oriole (Philippine)_bknori4
+Oriolus chinensis melanisticus_black-naped oriole (Talaud)_bknori6
+Oriolus chinensis [frontalis Group]_black-naped oriole (Sulawesi)_bknori5
+Oriolus chinensis broderipi/boneratensis_black-naped oriole (Tenggara)_bknori7
+Oriolus kundoo/chinensis_indian golden/black-naped oriole_y00800
+Oriolus tenuirostris_slender-billed oriole_slbori1
+Oriolus chlorocephalus_green-headed oriole_grhori1
+Oriolus chlorocephalus chlorocephalus/amani_green-headed oriole (Green-headed)_gnhori1
+Oriolus chlorocephalus speculifer_green-headed oriole (Gorongosa)_gnhori2
+Oriolus crassirostris_sao tome oriole_satori1
+Oriolus brachyrynchus_western black-headed oriole_wbhori1
+Oriolus monacha_ethiopian black-headed oriole_dahori1
+Oriolus larvatus_african black-headed oriole_abhori1
+Oriolus percivali_black-tailed oriole_bltori1
+Oriolus nigripennis_black-winged oriole_blwori1
+Oriolus xanthornus_black-hooded oriole_blhori1
+Oriolus hosii_black oriole_blaori1
+Oriolus consanguineus_black-and-crimson oriole_bacori1
+Oriolus cruentus_javan oriole_bacori3
+Oriolus traillii_maroon oriole_marori2
+Oriolus traillii traillii/robinsoni_maroon oriole (Maroon)_marori7
+Oriolus traillii ardens/nigellicauda_maroon oriole (Crimson)_marori8
+Oriolus mellianus_silver oriole_silori1
+Oriolus sp._papa-figos (Oriolus) sp._oriolu1
+Sphecotheres hypoleucus_wetar figbird_wetfig1
+Sphecotheres viridis_papa-figos-de-timor_grnfig1
+Sphecotheres vieilloti_australasian figbird_ausfig1
+Sphecotheres vieilloti [flaviventris Group]_australasian figbird (flaviventris Group)_ausfig7
+Sphecotheres vieilloti salvadorii_australasian figbird (salvadorii)_ausfig3
+Sphecotheres vieilloti vieilloti_australasian figbird (vieilloti)_ausfig6
+Turnagra tanagra_north island piopio_noipio1
+Turnagra capensis_south island piopio_soipio1
+Machaerirhynchus nigripectus_black-breasted boatbill_blbboa1
+Machaerirhynchus flaviventer_yellow-breasted boatbill_yebboa1
+Artamus fuscus_ashy woodswallow_ashwoo2
+Artamus mentalis_fiji woodswallow_fijwoo1
+Artamus monachus_ivory-backed woodswallow_whbwoo8
+Artamus maximus_great woodswallow_grewoo1
+Artamus leucorynchus_andorinha-do-mato-de-peito-branco_whbwoo4
+Artamus insignis_bismarck woodswallow_biswoo1
+Artamus personatus_masked woodswallow_maswoo1
+Artamus superciliosus_white-browed woodswallow_whbwoo5
+Artamus personatus x superciliosus_masked x white-browed woodswallow (hybrid)_x00962
+Artamus personatus/superciliosus_masked/white-browed woodswallow_y01039
+Artamus cinereus_andorinha-do-mato-de-face-preta_blfwoo1
+Artamus cinereus normani/inkermani_andorinha-do-mato-de-face-preta (normani/inkermani)_bkfwoo1
+Artamus cinereus [cinereus Group]_andorinha-do-mato-de-face-preta [grupo cinereus]_bkfwoo2
+Artamus cyanopterus_dusky woodswallow_duswoo1
+Artamus minor_little woodswallow_litwoo4
+Artamus sp._Andorinha-do-mato (Artamus) sp._woodsw1
+Peltops montanus_mountain peltops_moupel1
+Peltops blainvillii_lowland peltops_lowpel1
+Cracticus mentalis_black-backed butcherbird_blbbut1
+Cracticus torquatus_gray butcherbird_grybut1
+Cracticus argenteus_silver-backed butcherbird_sibbut1
+Cracticus cassicus_hooded butcherbird_hoobut1
+Cracticus louisiadensis_tagula butcherbird_tagbut1
+Cracticus nigrogularis_pied butcherbird_piebut1
+Melloria quoyi_black butcherbird_blabut1
+Gymnorhina tibicen_australian magpie_ausmag2
+Gymnorhina tibicen papuana_australian magpie (Papuan)_ausmag1
+Gymnorhina tibicen [tibicen Group]_australian magpie (Black-backed)_ausmag3
+Gymnorhina tibicen dorsalis_australian magpie (Western)_ausmag6
+Gymnorhina tibicen [tibicen Group] x dorsalis_australian magpie (Black-backed x Western)_ausmag4
+Gymnorhina tibicen telonocua/tyrannica_australian magpie (White-backed)_ausmag7
+Gymnorhina tibicen [tibicen Group] x telonocua/tyrannica_australian magpie (Black-backed x White-backed)_ausmag5
+Gymnorhina tibicen hypoleuca_australian magpie (Tasmanian)_ausmag8
+Strepera graculina_pied currawong_piecur1
+Strepera fuliginosa_black currawong_blacur2
+Strepera versicolor_gray currawong_grycur1
+Strepera versicolor versicolor/plumbea_gray currawong (Gray)_grycur2
+Strepera versicolor arguta_gray currawong (Clinking)_grycur3
+Strepera versicolor melanoptera_gray currawong (Black-winged)_grycur4
+Strepera versicolor intermedia_gray currawong (Brown)_grycur5
+Strepera versicolor halmaturina_gray currawong (Kangaroo I.)_grycur6
+Strepera sp._currawong sp._curraw1
+Rhagologus leucostigma_mottled berryhunter_motwhi1
+Lanioturdus torquatus_white-tailed shrike_whtshr1
+Dyaphorophyia castanea_chestnut wattle-eye_chweye1
+Dyaphorophyia hormophora_west african wattle-eye_weawae1
+Dyaphorophyia tonsa_white-spotted wattle-eye_wsweye1
+Platysteira cyanea_brown-throated wattle-eye_btweye2
+Platysteira albifrons_white-fronted wattle-eye_wfweye1
+Platysteira peltata_black-throated wattle-eye_btweye1
+Platysteira laticincta_banded wattle-eye_baweye1
+Platysteira blissetti_red-cheeked wattle-eye_rcweye1
+Platysteira chalybea_black-necked wattle-eye_bnweye1
+Platysteira jamesoni_jameson's wattle-eye_jaweye1
+Platysteira concreta_yellow-bellied wattle-eye_ybweye1
+Platysteira concreta concreta_yellow-bellied wattle-eye (West African)_yebwae1
+Platysteira concreta ansorgei_yellow-bellied wattle-eye (Angola)_yebwae2
+Platysteira concreta graueri_yellow-bellied wattle-eye (Central African)_yebwae3
+Platysteira concreta kungwensis_yellow-bellied wattle-eye (Kungwe)_yebwae4
+Platysteira sp._wattle-eye sp._wattle2
+Batis margaritae_boulton's batis_boubat1
+Batis margaritae margaritae_boulton's batis (Angola)_boubat2
+Batis margaritae kathleenae_boulton's batis (Eastern)_boubat3
+Batis mixta_short-tailed batis_shtbat1
+Batis mixta mixta_short-tailed batis (Short-tailed)_shtbat2
+Batis mixta reichenowi_short-tailed batis (Reichenow's)_shtbat3
+Batis crypta_dark batis_darbat1
+Batis diops_rwenzori batis_ruwbat1
+Batis capensis_cape batis_capbat10
+Batis capensis [erythrophthalma Group]_cape batis (Gray-mantled)_capbat3
+Batis capensis capensis_cape batis (Cape)_capbat4
+Batis dimorpha_malawi batis_capbat2
+Batis capensis/dimorpha_cape/malawi batis_capbat1
+Batis fratrum_woodwards' batis_woobat1
+Batis molitor_chinspot batis_chibat1
+Batis soror_pale batis_palbat1
+Batis pririt_pririt batis_pribat1
+Batis senegalensis_papa-moscas-do-senegal_senbat1
+Batis orientalis_gray-headed batis_gyhbat1
+Batis erlangeri_western black-headed batis_bkhbat1
+Batis minor_eastern black-headed batis_bkhbat2
+Batis erlangeri/minor_western/eastern black-headed batis_blhbat1
+Batis perkeo_pygmy batis_pygbat1
+Batis minima_verreaux's batis_verbat1
+Batis ituriensis_ituri batis_itubat1
+Batis poensis_bioko batis_fepbat1
+Batis occulta_west african batis_weabat1
+Batis minulla_angola batis_angbat1
+Batis sp._batis sp._batis1
+Prionops plumatus_poupinha_whihel1
+Prionops plumatus plumatus_poupinha (plumatus)_whihel2
+Prionops plumatus [poliocephalus Group]_poupinha [grupo poliocephalus]_whihel3
+Prionops poliolophus_gray-crested helmetshrike_gychel1
+Prionops alberti_yellow-crested helmetshrike_yechel1
+Prionops caniceps_red-billed helmetshrike_chbhel1
+Prionops caniceps caniceps_red-billed helmetshrike (Red-billed)_rebhel1
+Prionops caniceps harterti_red-billed helmetshrike (Gray-cheeked)_rebhel2
+Prionops rufiventris_rufous-bellied helmetshrike_rubhel1
+Prionops retzii_retz's helmetshrike_rethel1
+Prionops gabela_angola helmetshrike_anghel1
+Prionops scopifrons_chestnut-fronted helmetshrike_chfhel1
+Megabyas flammulatus_african shrike-flycatcher_afrshf1
+Bias musicus_papa-moscas-pintado_bawfly1
+Tephrodornis sylvicola_malabar woodshrike_malwoo1
+Tephrodornis virgatus_large woodshrike_larwoo1
+Tephrodornis pondicerianus_common woodshrike_comwoo1
+Tephrodornis sylvicola/pondicerianus_malabar/common woodshrike_y01096
+Tephrodornis virgatus/pondicerianus_large/common woodshrike_y00663
+Tephrodornis affinis_sri lanka woodshrike_srlwoo1
+Hemipus picatus_bar-winged flycatcher-shrike_bwfshr1
+Hemipus hirundinaceus_black-winged flycatcher-shrike_bwfshr2
+Philentoma pyrhoptera_rufous-winged philentoma_ruwphi2
+Philentoma velata_maroon-breasted philentoma_mabphi2
+Philentoma pyrhoptera/velata_rufous-winged/maroon-breasted philentoma_y00889
+Newtonia archboldi_archbold's newtonia_arcnew1
+Newtonia brunneicauda_common newtonia_comnew1
+Newtonia amphichroa_dark newtonia_darnew1
+Newtonia amphichroa amphichroa_dark newtonia (amphichroa)_darnew2
+Newtonia amphichroa lavarambo_dark newtonia (lavarambo)_darnew3
+Newtonia fanovanae_red-tailed newtonia_retnew1
+Tylas eduardi_tylas vanga_tylvan1
+Tylas eduardi eduardi_tylas vanga (Eduard's)_tylvan2
+Tylas eduardi albigularis_tylas vanga (White-throated)_tylvan3
+Calicalicus madagascariensis_red-tailed vanga_retvan1
+Calicalicus rufocarpalis_red-shouldered vanga_resvan1
+Hypositta corallirostris_nuthatch-vanga_nuthat2
+Leptopterus chabert_chabert vanga_chavan2
+Leptopterus chabert chabert_chabert vanga (Chabert)_chavan1
+Leptopterus chabert schistocercus_chabert vanga (White-tailed)_chavan3
+Mystacornis crossleyi_crossley's vanga_crobab1
+Cyanolanius comorensis_comoro blue vanga_bluvan2
+Cyanolanius madagascarinus_madagascar blue vanga_bluvan3
+Vanga curvirostris_hook-billed vanga_hobvan1
+Vanga curvirostris curvirostris_hook-billed vanga (Hook-billed)_hobvan2
+Vanga curvirostris cetera_hook-billed vanga (Black-crowned)_hobvan3
+Pseudobias wardi_ward's flycatcher_warfly1
+Schetba rufa_rufous vanga_rufvan1
+Schetba rufa rufa_rufous vanga (rufa)_rufvan2
+Schetba rufa occidentalis_rufous vanga (occidentalis)_rufvan3
+Euryceros prevostii_helmet vanga_helvan1
+Oriolia bernieri_bernier's vanga_bervan1
+Falculea palliata_sickle-billed vanga_sibvan1
+Artamella viridis_white-headed vanga_whhvan1
+Artamella viridis viridis_white-headed vanga (viridis)_whhvan2
+Artamella viridis annae_white-headed vanga (annae)_whhvan3
+Xenopirostris polleni_pollen's vanga_polvan1
+Xenopirostris xenopirostris_lafresnaye's vanga_lafvan1
+Xenopirostris damii_van dam's vanga_vadvan1
+Vangidae sp._Vangidae sp._vangid1
+Pityriasis gymnocephala_bornean bristlehead_borbri1
+Aegithina tiphia_common iora_comior1
+Aegithina nigrolutea_white-tailed iora_whtior1
+Aegithina tiphia/nigrolutea_common/white-tailed iora_y00890
+Aegithina viridissima_green iora_greior2
+Aegithina lafresnayei_great iora_greior1
+Aegithina sp._iora sp._iora1
+Nilaus afer_picanço-pintadinho_brubru1
+Dryoscopus gambensis_northern puffback_norpuf1
+Dryoscopus pringlii_pringle's puffback_pripuf1
+Dryoscopus cubla_black-backed puffback_blbpuf2
+Dryoscopus cubla affinis_black-backed puffback (Black-winged)_bkbpuf1
+Dryoscopus cubla [cubla Group]_black-backed puffback (White-winged)_bkbpuf6
+Dryoscopus senegalensis_red-eyed puffback_reepuf1
+Dryoscopus angolensis_pink-footed puffback_pifpuf1
+Dryoscopus sabini_sabine's puffback_labpuf1
+Dryoscopus sp._picanço (Dryoscopus) sp._puffba1
+Bocagia minuta_marsh tchagra_martch2
+Bocagia minuta minuta_marsh tchagra (Marsh)_martch1
+Bocagia minuta anchietae/reichenowi_marsh tchagra (Anchieta's)_martch3
+Tchagra senegalus_picanço-assobiador_bkctch1
+Tchagra senegalus cucullatus_picanço-assobiador (cucullatus)_bkctch2
+Tchagra senegalus [senegalus Group]_picanço-assobiador [grupo senegalus]_bkctch3
+Tchagra australis_brown-crowned tchagra_brctch1
+Tchagra jamesi_three-streaked tchagra_thstch1
+Tchagra tchagra_southern tchagra_soutch1
+Tchagra sp._picanço-assobiador (Tchagra) sp._tchagr1
+Laniarius ruficeps_red-naped bushshrike_renbus1
+Laniarius nigerrimus_coastal boubou_sombou1
+Laniarius luehderi_lühder's bushshrike_luebus1
+Laniarius brauni_braun's bushshrike_brabus1
+Laniarius amboimensis_gabela bushshrike_gabbus1
+Laniarius turatii_picanço-da-guiné_turbou1
+Laniarius aethiopicus_ethiopian boubou_trobou2
+Laniarius major_tropical boubou_trobou1
+Laniarius sublacteus_zanzibar boubou_zanbou1
+Laniarius bicolor_gabon boubou_gabbou1
+Laniarius bicolor bicolor/guttatus_gabon boubou (Gabon)_gabbou2
+Laniarius bicolor sticturus_gabon boubou (Okavango)_gabbou3
+Laniarius ferrugineus_southern boubou_soubou1
+Laniarius barbarus_picanço-bárbaro_comgon1
+Laniarius erythrogaster_black-headed gonolek_blhgon1
+Laniarius atrococcineus_crimson-breasted gonolek_crbgon1
+Laniarius mufumbiri_papyrus gonolek_papgon1
+Laniarius atroflavus_yellow-breasted boubou_yebbou1
+Laniarius funebris_slate-colored boubou_slcbou1
+Laniarius leucorhynchus_lowland sooty boubou_soobou1
+Laniarius willardi_willard's sooty boubou_wisbou1
+Laniarius poensis_western boubou_mosbou1
+Laniarius poensis camerunensis_western boubou (Cameroon)_mosbou2
+Laniarius poensis poensis_western boubou (Bioko)_mosbou3
+Laniarius holomelas_albertine boubou_mosbou4
+Laniarius fuelleborni_fülleborn's boubou_fuebou1
+Laniarius fuelleborni usambaricus_fülleborn's boubou (Usambara)_fuebou2
+Laniarius fuelleborni fuelleborni_fülleborn's boubou (Fülleborn's)_fuebou3
+Laniarius sp._boubou sp._boubou1
+Rhodophoneus cruentus_rosy-patched bushshrike_ropbus1
+Telophorus zeylonus_bokmakierie_bokmak1
+Telophorus zeylonus [zeylonus Group]_bokmakierie (Southern)_bokmak2
+Telophorus zeylonus restrictus_bokmakierie (Chimanimani)_bokmak3
+Telophorus viridis_four-colored bushshrike_focbus2
+Telophorus viridis viridis_four-colored bushshrike (Gorgeous)_focbus1
+Telophorus viridis [quadricolor Group]_four-colored bushshrike (Four-colored)_focbus3
+Telophorus dohertyi_doherty's bushshrike_dohbus1
+Chlorophoneus bocagei_gray-green bushshrike_gygbus1
+Chlorophoneus sulfureopectus_picanço-de-peito-laranja_subbus1
+Chlorophoneus olivaceus_olive bushshrike_olibus1
+Chlorophoneus multicolor_many-colored bushshrike_macbus2
+Chlorophoneus nigrifrons_black-fronted bushshrike_blfbus1
+Chlorophoneus kupeensis_mount kupe bushshrike_mtkbus1
+Malaconotus cruentus_fiery-breasted bushshrike_fibbus1
+Malaconotus lagdeni_lagden's bushshrike_lagbus1
+Malaconotus lagdeni lagdeni_lagden's bushshrike (Lagden's)_lagbus2
+Malaconotus lagdeni centralis_lagden's bushshrike (Eastern)_lagbus3
+Malaconotus gladiator_green-breasted bushshrike_grbbus1
+Malaconotus blanchoti_picanço-oliváceo_gyhbus1
+Malaconotus monteiri_monteiro's bushshrike_monbus1
+Malaconotus monteiri perspicillatus_monteiro's bushshrike (Mt. Cameroon)_monbus2
+Malaconotus monteiri monteiri_monteiro's bushshrike (Monteiro's)_monbus3
+Malaconotus alius_uluguru bushshrike_ulubus1
+Telophorus/Malaconotus sp._bushshrike sp._bushsh1
+Chaetorhynchus papuensis_drongo fantail_papdro1
+Eutrichomyias rowleyi_cerulean flycatcher_cepfly1
+Lamprolia victoriae_taveuni silktail_silkta2
+Lamprolia klinesmithi_natewa silktail_silkta3
+Rhipidura atra_black fantail_blafan1
+Rhipidura nigrocinnamomea_black-and-cinnamon fantail_bacfan1
+Rhipidura superciliaris_mindanao blue-fantail_blufan1
+Rhipidura samarensis_visayan blue-fantail_visblf1
+Rhipidura sauli_tablas fantail_tabfan1
+Rhipidura albiventris_visayan fantail_visfan1
+Rhipidura cyaniceps_blue-headed fantail_blhfan1
+Rhipidura perlata_spotted fantail_spofan1
+Rhipidura fuscorufa_cinnamon-tailed fantail_citfan1
+Rhipidura cockerelli_white-winged fantail_whwfan1
+Rhipidura cockerelli [cockerelli Group]_white-winged fantail (White-winged)_cocfan1
+Rhipidura cockerelli lavellae_white-winged fantail (Dot-breasted)_cocfan2
+Rhipidura cockerelli albina_white-winged fantail (Black-breasted)_cocfan3
+Rhipidura coultasi_white-gorgeted fantail_cocfan4
+Rhipidura rufiventris_rabo-de-leque-de-ventre-ruivo_norfan1
+Rhipidura rufiventris obiensis_rabo-de-leque-de-ventre-ruivo (obiensis)_norfan2
+Rhipidura rufiventris bouruensis_rabo-de-leque-de-ventre-ruivo (bouruensis)_norfan3
+Rhipidura rufiventris assimilis/finitima_rabo-de-leque-de-ventre-ruivo (assimilis/finitima)_norfan4
+Rhipidura rufiventris cinerea_rabo-de-leque-de-ventre-ruivo (cinerea)_norfan10
+Rhipidura rufiventris tenkatei_rabo-de-leque-de-ventre-ruivo (tenkatei)_norfan5
+Rhipidura rufiventris rufiventris/pallidiceps_rabo-de-leque-de-ventre-ruivo (rufiventris/pallidiceps)_norfan6
+Rhipidura rufiventris hoedti_rabo-de-leque-de-ventre-ruivo (hoedti)_norfan11
+Rhipidura rufiventris kordensis_rabo-de-leque-de-ventre-ruivo (kordensis)_norfan12
+Rhipidura rufiventris nigromentalis_rabo-de-leque-de-ventre-ruivo (nigromentalis)_norfan8
+Rhipidura rufiventris [setosa Group]_rabo-de-leque-de-ventre-ruivo [grupo setosa]_norfan9
+Rhipidura rufiventris isura_rabo-de-leque-de-ventre-ruivo (isura)_norfan13
+Rhipidura diluta_brown-capped fantail_brcfan1
+Rhipidura threnothorax_sooty thicket-fantail_sotfan1
+Rhipidura maculipectus_black thicket-fantail_bltfan1
+Rhipidura leucothorax_white-bellied thicket-fantail_wbtfan1
+Rhipidura leucophrys_willie-wagtail_wilwag1
+Rhipidura javanica_malaysian pied-fantail_piefan1
+Rhipidura nigritorquis_philippine pied-fantail_phipif1
+Rhipidura albicollis_white-throated fantail_whtfan1
+Rhipidura albogularis_spot-breasted fantail_spbfan1
+Rhipidura albicollis x albogularis_white-throated x spot-breasted fantail (hybrid)_x00812
+Rhipidura albicollis/albogularis_white-throated/spot-breasted fantail_y00892
+Rhipidura phoenicura_rufous-tailed fantail_rutfan1
+Rhipidura euryura_white-bellied fantail_whbfan1
+Rhipidura aureola_white-browed fantail_whbfan2
+Rhipidura albicollis/aureola_white-throated/white-browed fantail_y00893
+Rhipidura albogularis/aureola_spot-breasted/white-browed fantail_y00801
+Rhipidura rufidorsa_rufous-backed fantail_rubfan1
+Rhipidura brachyrhyncha_dimorphic fantail_dimfan1
+Rhipidura dahli_bismarck fantail_bisfan1
+Rhipidura matthiae_mussau fantail_matfan1
+Rhipidura malaitae_malaita fantail_malfan1
+Rhipidura teysmanni_sulawesi fantail_rubfan2
+Rhipidura habibiei_peleng fantail_pelfan1
+Rhipidura sulaensis_taliabu fantail_rubfan3
+Rhipidura superflua_tawny-backed fantail_cibfan1
+Rhipidura dedemi_streak-breasted fantail_stbfan1
+Rhipidura opistherythra_long-tailed fantail_lotfan1
+Rhipidura lepida_palau fantail_palfan1
+Rhipidura semirubra_manus fantail_manfan2
+Rhipidura semicollaris_supertramp fantail_arafan2
+Rhipidura semicollaris [semicollaris Group]_supertramp fantail (Lesser Sundas)_supfan2
+Rhipidura semicollaris elegantula_supertramp fantail (Pale-fronted)_arafan8
+Rhipidura semicollaris reichenowi_supertramp fantail (Babar)_arafan9
+Rhipidura semicollaris hamadryas_supertramp fantail (Tanimbar)_arafan10
+Rhipidura semicollaris squamata/henrici_supertramp fantail (Black-chested)_supfan1
+Rhipidura dryas_arafura fantail_arafan1
+Rhipidura torrida_gilolo fantail_ruffan3
+Rhipidura rufifrons_australian rufous fantail_ruffan13
+Rhipidura dryas/rufifrons_arafura/australian rufous fantail_y01281
+Rhipidura louisiadensis_louisiade fantail_ruffan4
+Rhipidura melanolaema_santa cruz fantail_sacfan1
+Rhipidura melanolaema melanolaema/utupuae_santa cruz fantail (White-fronted)_ruffan8
+Rhipidura melanolaema agilis_santa cruz fantail (Brown-fronted)_ruffan9
+Rhipidura versicolor_micronesian rufous fantail_mirfan1
+Rhipidura versicolor uraniae_micronesian rufous fantail (Guam)_ruffan5
+Rhipidura versicolor saipanensis/mariae_micronesian rufous fantail (Marianas)_ruffan6
+Rhipidura versicolor versicolor_micronesian rufous fantail (Yap)_ruffan7
+Rhipidura rufofronta_solomons rufous fantail_sorfan1
+Rhipidura rufofronta [rufofronta Group]_solomons rufous fantail (Brown-backed)_ruffan10
+Rhipidura rufofronta russata/kuperi_solomons rufous fantail (Rufous-backed)_ruffan11
+Rhipidura rufofronta ugiensis_solomons rufous fantail (Dark-throated)_ruffan12
+Rhipidura kubaryi_pohnpei fantail_pohfan1
+Rhipidura albolimbata_friendly fantail_frifan1
+Rhipidura hyperythra_chestnut-bellied fantail_chbfan1
+Rhipidura drownei_bougainville fantail_brnfan1
+Rhipidura ocularis_guadalcanal fantail_brnfan2
+Rhipidura spilodera_vanuatu streaked fantail_strfan2
+Rhipidura layardi_fiji streaked fantail_fisfan1
+Rhipidura layardi layardi_fiji streaked fantail (Viti Levu)_strfan3
+Rhipidura layardi erythronota_fiji streaked fantail (Vanua Levu)_strfan7
+Rhipidura layardi rufilateralis_fiji streaked fantail (Taveuni)_strfan4
+Rhipidura verreauxi_new caledonian streaked fantail_strfan5
+Rhipidura tenebrosa_dusky fantail_dusfan1
+Rhipidura rennelliana_rennell fantail_renfan1
+Rhipidura personata_kadavu fantail_kanfan1
+Rhipidura nebulosa_samoan fantail_samfan1
+Rhipidura albiscapa_gray fantail_gryfan1
+Rhipidura albiscapa [pelzelni Group]_gray fantail (Melanesian)_gryfan2
+Rhipidura albiscapa keasti_gray fantail (keasti)_gryfan4
+Rhipidura albiscapa alisteri_gray fantail (alisteri)_gryfan5
+Rhipidura albiscapa albiscapa_gray fantail (albiscapa)_gryfan6
+Rhipidura albiscapa preissi_gray fantail (preissi)_gryfan7
+Rhipidura albiscapa albicauda_gray fantail (albicauda)_gryfan8
+Rhipidura phasiana_mangrove fantail_manfan1
+Rhipidura fuliginosa_new zealand fantail_nezfan1
+Rhipidura sp._fantail sp._fantai1
+Dicrurus sharpei_sharpe's drongo_shadro2
+Dicrurus sharpei occidentalis_sharpe's drongo (Western)_wstdro1
+Dicrurus sharpei sharpei_sharpe's drongo (Eastern)_shadro1
+Dicrurus ludwigii_square-tailed drongo_cstdro1
+Dicrurus sharpei/ludwigii_sharpe's/square-tailed drongo_sqtdro1
+Dicrurus atripennis_shining drongo_shidro1
+Dicrurus adsimilis_fork-tailed drongo_fotdro5
+Dicrurus adsimilis apivorus_fork-tailed drongo (Clancey's)_fotdro3
+Dicrurus adsimilis [adsimilis Group]_fork-tailed drongo (adsimilis Group)_fotdro2
+Dicrurus adsimilis divaricatus/lugubris_fork-tailed drongo (Glossy-backed)_fotdro4
+Dicrurus modestus_velvet-mantled drongo_vemdro6
+Dicrurus modestus atactus_velvet-mantled drongo (Fanti)_vemdro5
+Dicrurus modestus modestus_velvet-mantled drongo (Principe)_vemdro3
+Dicrurus modestus coracinus_velvet-mantled drongo (coracinus)_vemdro4
+Dicrurus aldabranus_aldabra drongo_alddro1
+Dicrurus fuscipennis_grande comore drongo_comdro1
+Dicrurus forficatus_crested drongo_credro1
+Dicrurus forficatus forficatus_crested drongo (Madagascar)_credro2
+Dicrurus forficatus potior_crested drongo (Comoro)_credro3
+Dicrurus waldenii_mayotte drongo_maydro1
+Dicrurus macrocercus_black drongo_bladro1
+Dicrurus leucophaeus_ashy drongo_ashdro1
+Dicrurus leucophaeus [longicaudatus Group/leucophaeus Group]_ashy drongo (Blackish/Sooty)_ashdro20
+Dicrurus leucophaeus [longicaudatus Group]_ashy drongo (Blackish)_ashdro4
+Dicrurus leucophaeus [leucophaeus Group]_ashy drongo (Sooty)_ashdro2
+Dicrurus leucophaeus innexus/leucogenis/salangensis_ashy drongo (Hainan/White-cheeked/White-lored)_ashdro3
+Dicrurus leucophaeus leucogenis_ashy drongo (White-cheeked)_ashdro13
+Dicrurus leucophaeus salangensis_ashy drongo (White-lored)_ashdro14
+Dicrurus leucophaeus innexus_ashy drongo (Hainan)_ashdro15
+Dicrurus leucophaeus [periophthalmicus Group]_ashy drongo (Sumatran)_ashdro5
+Dicrurus leucophaeus stigmatops_ashy drongo (Bornean)_ashdro6
+Dicrurus macrocercus/leucophaeus_black/ashy drongo_y00638
+Dicrurus caerulescens_white-bellied drongo_whbdro1
+Dicrurus caerulescens caerulescens_white-bellied drongo (White-bellied)_whbdro2
+Dicrurus caerulescens leucopygialis/insularis_white-bellied drongo (White-vented)_whbdro3
+Dicrurus annectens_crow-billed drongo_crbdro1
+Dicrurus aeneus_bronzed drongo_brodro1
+Dicrurus remifer_lesser racket-tailed drongo_lrtdro1
+Dicrurus hottentottus_hair-crested drongo_hacdro1
+Dicrurus hottentottus hottentottus/brevirostris_hair-crested drongo (Hair-crested)_hacdro6
+Dicrurus hottentottus viridinitens_hair-crested drongo (Mentawai)_sumdro2
+Dicrurus hottentottus borneensis_hair-crested drongo (Bornean)_hacdro4
+Dicrurus hottentottus jentincki/faberi_hair-crested drongo (Javan)_hacdro7
+Dicrurus hottentottus leucops/banggaiensis_hair-crested drongo (White-eyed)_hacdro12
+Dicrurus hottentottus guillemardi_hair-crested drongo (Obi)_hacdro8
+Dicrurus hottentottus pectoralis_hair-crested drongo (Sula)_hacdro10
+Dicrurus hottentottus suluensis_hair-crested drongo (Sulu)_hacdro11
+Dicrurus striatus_short-tailed drongo_hacdro3
+Dicrurus palawanensis_palawan drongo_paldro1
+Dicrurus palawanensis palawanensis_palawan drongo (Palawan)_hacdro9
+Dicrurus palawanensis cuyensis_palawan drongo (Cuyo)_hacdro5
+Dicrurus balicassius_balicassiao_balica1
+Dicrurus balicassius balicassius/abraensis_balicassiao (Balicassiao)_balica2
+Dicrurus balicassius mirabilis_balicassiao (Visayan)_balica3
+Dicrurus montanus_sulawesi drongo_suldro1
+Dicrurus sumatranus_sumatran drongo_sumdro1
+Dicrurus densus_drongo-de-wallacea_waldro1
+Dicrurus densus vicinus_drongo-de-wallacea (vicinus)_waldro4
+Dicrurus densus bimaensis_drongo-de-wallacea (bimaensis)_waldro2
+Dicrurus densus sumbae_drongo-de-wallacea (sumbae)_waldro5
+Dicrurus densus densus_drongo-de-wallacea (densus)_waldro7
+Dicrurus densus kuehni_drongo-de-wallacea (kuehni)_waldro6
+Dicrurus densus megalornis_drongo-de-wallacea (megalornis)_waldro3
+Dicrurus megarhynchus_ribbon-tailed drongo_ritdro1
+Dicrurus bracteatus_spangled drongo_spadro1
+Dicrurus bracteatus morotensis_spangled drongo (Morotai)_spadro7
+Dicrurus bracteatus atrocaeruleus_spangled drongo (Halmahera)_spadro5
+Dicrurus bracteatus buruensis_spangled drongo (Buru)_spadro3
+Dicrurus bracteatus amboinensis_spangled drongo (Seram)_spadro9
+Dicrurus bracteatus carbonarius_spangled drongo (Papuan)_spadro8
+Dicrurus bracteatus laemostictus_spangled drongo (Bismarck)_spadro2
+Dicrurus bracteatus meeki_spangled drongo (Guadalcanal)_spadro4
+Dicrurus bracteatus longirostris_spangled drongo (Makira)_spadro6
+Dicrurus bracteatus [bracteatus Group]_spangled drongo (Spangled)_spadro10
+Dicrurus [undescribed form]_bacan drongo (undescribed form)_bacdro1
+Dicrurus menagei_tablas drongo_tabdro1
+Dicrurus andamanensis_andaman drongo_anddro1
+Dicrurus paradiseus_greater racket-tailed drongo_grtdro1
+Dicrurus remifer/paradiseus_lesser/greater racket-tailed drongo_y00410
+Dicrurus lophorinus_sri lanka drongo_srldro1
+Dicrurus sp._drongo sp._drongo1
+Lycocorax pyrrhopterus_halmahera paradise-crow_paradi2
+Lycocorax obiensis_obi paradise-crow_paradi3
+Phonygammus keraudrenii_trumpet manucode_truman1
+Manucodia comrii_curl-crested manucode_cucman1
+Manucodia chalybatus_crinkle-collared manucode_crcman2
+Manucodia jobiensis_jobi manucode_jobman1
+Manucodia ater_glossy-mantled manucode_glmman2
+Phonygammus/Manucodia sp._manucode sp._manuco1
+Pteridophora alberti_king-of-saxony bird-of-paradise_kospar1
+Parotia carolae_carola's parotia_carpar1
+Parotia berlepschi_bronze parotia_carpar3
+Parotia sefilata_western parotia_wespar1
+Parotia wahnesi_wahnes's parotia_wahpar1
+Parotia lawesii_lawes's parotia_lawpar3
+Parotia helenae_eastern parotia_lawpar2
+Parotia lawesii/helenae_lawes's/eastern parotia_lawpar1
+Seleucidis melanoleucus_twelve-wired bird-of-paradise_twwbop1
+Drepanornis albertisi_black-billed sicklebill_blbsic1
+Drepanornis bruijnii_pale-billed sicklebill_pabsic1
+Semioptera wallacii_standardwing bird-of-paradise_walsta2
+Lophorina superba_vogelkop lophorina_vosbop1
+Lophorina latipennis_greater lophorina_grsbop1
+Lophorina minor_lesser lophorina_lesbop1
+Lophorina sp._lophorina sp._lophor1
+Ptiloris paradiseus_paradise riflebird_parrif1
+Ptiloris victoriae_victoria's riflebird_vicrif1
+Ptiloris magnificus_magnificent riflebird_magrif3
+Ptiloris intercedens_growling riflebird_magrif2
+Epimachus fastosus_black sicklebill_blasic1
+Epimachus meyeri_brown sicklebill_brosic1
+Paradigalla carunculata_long-tailed paradigalla_lotpar1
+Paradigalla brevicauda_short-tailed paradigalla_shtpar1
+Astrapia splendidissima_splendid astrapia_splast1
+Astrapia nigra_arfak astrapia_arfast1
+Astrapia rothschildi_huon astrapia_huoast1
+Astrapia stephaniae_stephanie's astrapia_prsast1
+Astrapia mayeri_ribbon-tailed astrapia_ritast1
+Astrapia stephaniae x mayeri_stephanie's x ribbon-tailed astrapia (hybrid)_x00413
+Cicinnurus regius_king bird-of-paradise_kbopar1
+Diphyllodes respublica_wilson's bird-of-paradise_wbopar1
+Diphyllodes magnificus_magnificent bird-of-paradise_mbopar2
+Paradisornis rudolphi_blue bird-of-paradise_bbopar1
+Paradisaea guilielmi_emperor bird-of-paradise_ebopar1
+Paradisaea rubra_red bird-of-paradise_rbopar2
+Paradisaea decora_goldie's bird-of-paradise_gbopar1
+Paradisaea minor_lesser bird-of-paradise_lbopar1
+Paradisaea raggiana_raggiana bird-of-paradise_rbopar1
+Paradisaea minor x raggiana_lesser x raggiana bird-of-paradise (hybrid)_x00814
+Paradisaea apoda_greater bird-of-paradise_gbopar2
+Paradisaea raggiana x apoda_raggiana x greater bird-of-paradise (hybrid)_x00929
+Ifrita kowaldi_blue-capped ifrita_bucifr1
+Trochocercus nitens_blue-headed crested flycatcher_bhcfly1
+Trochocercus cyanomelas_african crested flycatcher_afcfly1
+Trochocercus cyanomelas [bivittatus Group]_african crested flycatcher (Eastern)_afrcrf1
+Trochocercus cyanomelas cyanomelas/segregus_african crested flycatcher (Southern)_afrcrf2
+Hypothymis helenae_short-crested monarch_shcmon1
+Hypothymis azurea_black-naped monarch_blnmon1
+Hypothymis puella_pale-blue monarch_pabmon1
+Hypothymis coelestis_celestial monarch_celmon1
+Terpsiphone cyanescens_blue paradise-flycatcher_blpfly1
+Terpsiphone cinnamomea_rufous paradise-flycatcher_rupfly1
+Terpsiphone cinnamomea unirufa_rufous paradise-flycatcher (Northern)_rufpaf1
+Terpsiphone cinnamomea cinnamomea/talautensis_rufous paradise-flycatcher (Southern)_rufpaf2
+Terpsiphone atrocaudata_black paradise-flycatcher_japfly1
+Terpsiphone atrocaudata atrocaudata/illex_black paradise-flycatcher (Northern)_blkpaf1
+Terpsiphone atrocaudata periophthalmica_black paradise-flycatcher (Philippines)_jappaf3
+Terpsiphone incei_amur paradise-flycatcher_amupaf1
+Terpsiphone atrocaudata/incei_black/amur paradise-flycatcher_y00976
+Terpsiphone affinis_blyth's paradise-flycatcher_blypaf1
+Terpsiphone floris_tenggara paradise-flycatcher_blypaf3
+Hypothymis azurea x Terpsiphone affinis_black-naped monarch x blyth's paradise-flycatcher (hybrid)_x00463
+Terpsiphone incei/affinis_amur/blyth's paradise-flycatcher_y00977
+Terpsiphone bourbonnensis_mascarene paradise-flycatcher_mapfly2
+Terpsiphone paradisi_indian paradise-flycatcher_aspfly1
+Terpsiphone affinis/paradisi_blyth's/indian paradise-flycatcher_y00978
+Terpsiphone incei/affinis/paradisi_amur/blyth's/indian paradise-flycatcher_y00742
+Terpsiphone atrochalybeia_sao tome paradise-flycatcher_stpfly1
+Terpsiphone corvina_seychelles paradise-flycatcher_sepfly1
+Terpsiphone mutata_malagasy paradise-flycatcher_mapfly1
+Terpsiphone mutata [mutata Group]_malagasy paradise-flycatcher (Malagasy)_madpaf1
+Terpsiphone mutata vulpina/voeltzkowiana_malagasy paradise-flycatcher (Comoro)_madpaf2
+Terpsiphone mutata comorensis_malagasy paradise-flycatcher (Grande Comore)_madpaf3
+Terpsiphone rufiventer_viúva-ruça_bhpfly1
+Terpsiphone rufiventer [rufiventer Group]_viúva-ruça [grupo rufiventer]_bkhpaf1
+Terpsiphone rufiventer tricolor/neumanni_viúva-ruça (tricolor/neumanni)_bkhpaf3
+Terpsiphone rufiventer smithii_viúva-ruça (smithii)_bkhpaf2
+Terpsiphone bedfordi_bedford's paradise-flycatcher_bepfly1
+Terpsiphone rufocinerea_rufous-vented paradise-flycatcher_rvpfly1
+Terpsiphone batesi_bates's paradise-flycatcher_batpaf1
+Terpsiphone viridis_viúva-verde_afpfly1
+Terpsiphone rufiventer x viridis_viúva-ruça x viúva-verde (híbrido)_x00862
+Terpsiphone rufocinerea x viridis_rufous-vented x african paradise-flycatcher (hybrid)_x01159
+Terpsiphone rufocinerea/batesi_rufous-vented/bates's paradise-flycatcher_y01314
+Terpsiphone sp._paradise-flycatcher sp._paradi1
+Chasiempis sandwichensis_hawaii elepaio_elepai
+Chasiempis sandwichensis sandwichensis_hawaii elepaio (Kona coast)_elepai1
+Chasiempis sandwichensis bryani_hawaii elepaio (Mauna Kea)_elepai3
+Chasiempis sandwichensis ridgwayi_hawaii elepaio (Hilo coast)_elepai2
+Chasiempis sclateri_kauai elepaio_elepai5
+Chasiempis ibidis_oahu elepaio_elepai4
+Pomarea nigra_tahiti monarch_tahmon2
+Pomarea maupitiensis_maupiti monarch_maumon1
+Pomarea dimidiata_rarotonga monarch_rarmon1
+Pomarea fluxa_eiao monarch_eiamon1
+Pomarea nukuhivae_nuku hiva monarch_nuhmon1
+Pomarea iphis_iphis monarch_iphmon2
+Pomarea mira_ua pou monarch_uapmon1
+Pomarea mendozae_marquesan monarch_marmon2
+Pomarea whitneyi_fatu hiva monarch_fatmon1
+Mayrornis versicolor_ogea monarch_ogemon1
+Mayrornis lessoni_slaty monarch_slamon1
+Mayrornis schistaceus_vanikoro monarch_vanmon1
+Neolalage banksiana_buff-bellied monarch_bubmon1
+Clytorhynchus pachycephaloides_southern shrikebill_soushr2
+Clytorhynchus hamlini_rennell shrikebill_renshr1
+Clytorhynchus vitiensis_fiji shrikebill_fijshr1
+Clytorhynchus vitiensis powelli_fiji shrikebill (Manua)_fijshr2
+Clytorhynchus vitiensis [vitiensis Group]_fiji shrikebill (Fiji)_fijshr3
+Clytorhynchus vitiensis fortunae_fiji shrikebill (Fortuna)_fijshr4
+Clytorhynchus vitiensis keppeli_fiji shrikebill (Dusky)_fijshr5
+Clytorhynchus nigrogularis_black-throated shrikebill_bktshr1
+Clytorhynchus vitiensis/nigrogularis_fiji/black-throated shrikebill_y00802
+Clytorhynchus sanctaecrucis_santa cruz shrikebill_bktshr2
+Carterornis pileatus_white-naped monarch_whnmon1
+Carterornis castus_tanimbar monarch_loemon1
+Carterornis leucotis_white-eared monarch_whemon1
+Carterornis chrysomela_golden monarch_golmon1
+Metabolus rugensis_chuuk monarch_trumon1
+Monarcha godeffroyi_yap monarch_yapmon1
+Monarcha takatsukasae_tinian monarch_tinmon1
+Monarcha cinerascens_monarca-das-ilhas_islmon1
+Monarcha richardsii_white-capped monarch_whcmon1
+Monarcha castaneiventris_chestnut-bellied monarch_chbmon1
+Monarcha castaneiventris castaneiventris/obscurior_chestnut-bellied monarch (Chestnut-bellied)_chbmon2
+Monarcha castaneiventris megarhynchus_chestnut-bellied monarch (Makira)_chbmon3
+Monarcha castaneiventris ugiensis_chestnut-bellied monarch (Ugi)_chbmon4
+Monarcha castaneiventris erythrostictus_chestnut-bellied monarch (Bougainville)_boumon1
+Monarcha melanopsis_black-faced monarch_blfmon1
+Monarcha frater_black-winged monarch_blwmon1
+Monarcha frater frater_black-winged monarch (Arfak)_bkwmon1
+Monarcha frater kunupi/periophthalmicus_black-winged monarch (Masked)_bkwmon5
+Monarcha frater canescens_black-winged monarch (Pearly)_bkwmon4
+Monarcha melanopsis x frater_black-faced x black-winged monarch (hybrid)_x00963
+Monarcha sp._Monarcha sp._monarc1
+Symposiachrus axillaris_fan-tailed monarch_blamon1
+Symposiachrus rubiensis_rufous monarch_rufmon1
+Symposiachrus sacerdotum_flores monarch_flomon1
+Symposiachrus boanensis_boano monarch_blcmon1
+Symposiachrus bimaculatus_monarca-de-lunetas-das-molucas_molmon1
+Symposiachrus bimaculatus bimaculatus_monarca-de-lunetas-das-molucas (bimaculatus)_spemon3
+Symposiachrus bimaculatus diadematus_monarca-de-lunetas-das-molucas (diadematus)_spemon4
+Symposiachrus bimaculatus nigrimentum_monarca-de-lunetas-das-molucas (nigrimentum)_spemon6
+Symposiachrus trivirgatus_monarca-de-lunetas_spemon1
+Symposiachrus trivirgatus [trivirgatus Group]_monarca-de-lunetas [grupo trivirgatus]_spemon2
+Symposiachrus trivirgatus gouldii/melanorrhous_monarca-de-lunetas (gouldii/melanorrhous)_spemon5
+Symposiachrus melanopterus_louisiade spectacled monarch_spemon10
+Symposiachrus leucurus_kai monarch_whtmon1
+Symposiachrus everetti_tanahjampea monarch_whtmon2
+Symposiachrus loricatus_buru monarch_bltmon2
+Symposiachrus julianae_kofiau monarch_blbmon1
+Symposiachrus brehmii_biak monarch_biamon1
+Symposiachrus manadensis_hooded monarch_hoomon1
+Symposiachrus infelix_manus monarch_manmon1
+Symposiachrus menckei_mussau monarch_whbmon1
+Symposiachrus verticalis_bismarck monarch_bltmon1
+Symposiachrus verticalis ateralbus_bismarck monarch (Djaul)_bktmon1
+Symposiachrus verticalis verticalis_bismarck monarch (Black-tailed)_bktmon2
+Symposiachrus barbatus_solomons monarch_bawmon2
+Symposiachrus malaitae_malaita monarch_bawmon4
+Symposiachrus browni_kolombangara monarch_kolmon5
+Symposiachrus nigrotectus_vella lavella monarch_velmon1
+Symposiachrus mundus_banda sea monarch_blbmon2
+Symposiachrus vidua_white-collared monarch_whcmon2
+Symposiachrus guttula_spot-winged monarch_spwmon1
+Arses telescopthalmus_frilled monarch_frimon1
+Arses lorealis_frill-necked monarch_frnmon1
+Arses insularis_ochre-collared monarch_rucmon1
+Arses telescopthalmus x insularis_frilled x ochre-collared monarch (hybrid)_x00813
+Arses kaupi_pied monarch_piemon1
+Grallina cyanoleuca_cotovia-pega_maglar1
+Grallina bruijnii_torrent-lark_torlar1
+Myiagra erythrops_palau flycatcher_palfly3
+Myiagra freycineti_guam flycatcher_guafly1
+Myiagra pluto_pohnpei flycatcher_pohfly1
+Myiagra oceanica_chuuk flycatcher_ocefly1
+Myiagra atra_biak flycatcher_biafly1
+Myiagra galeata_moluccan flycatcher_molfly1
+Myiagra rubecula_leaden flycatcher_leafly2
+Myiagra ferrocyanea_steel-blue flycatcher_stbfly1
+Myiagra cervinicauda_ochre-headed flycatcher_ochfly1
+Myiagra caledonica_melanesian flycatcher_melfly1
+Myiagra vanikorensis_vanikoro flycatcher_vanfly1
+Myiagra albiventris_samoan flycatcher_samfly1
+Myiagra azureocapilla_azure-crested flycatcher_blcfly2
+Myiagra castaneigularis_chestnut-throated flycatcher_chtfly1
+Myiagra ruficollis_monarca-de-bico-largo_brbfly1
+Myiagra cyanoleuca_satin flycatcher_satfly1
+Myiagra rubecula/cyanoleuca_leaden/satin flycatcher_y00803
+Myiagra inquieta_restless flycatcher_resfly1
+Myiagra nana_paperbark flycatcher_papfly1
+Myiagra inquieta/nana_restless/paperbark flycatcher_y00894
+Myiagra alecto_shining flycatcher_shifly1
+Myiagra hebetior_mussau flycatcher_dulfly2
+Myiagra eichhorni_velvet flycatcher_velfly1
+Myiagra eichhorni eichhorni_velvet flycatcher (Velvet)_dulfly3
+Myiagra eichhorni cervinicolor_velvet flycatcher (Djaul)_dulfly4
+Myiagra sp._Myiagra sp._myiagr1
+Corcorax melanorhamphos_white-winged chough_whwcho1
+Struthidea cinerea_apostlebird_apostl1
+Melampitta lugubris_lesser melampitta_lesmel1
+Megalampitta gigantea_greater melampitta_gremel1
+Platylophus galericulatus_crested jayshrike_crejay1
+Corvinella corvina_picanço-de-bico-amarelo_yebshr1
+Urolestes melanoleucus_magpie shrike_magshr1
+Lanius tigrinus_tiger shrike_tigshr1
+Lanius bucephalus_bull-headed shrike_buhshr1
+Lanius collurio_picanço-de-dorso-ruivo_rebshr1
+Lanius phoenicuroides_picanço-do-turquestão_rutshr2
+Lanius collurio x phoenicuroides_picanço-de-dorso-ruivo x picanço-do-turquestão (híbrido)_x00860
+Lanius isabellinus_picanço-isabel_isashr1
+Lanius isabellinus isabellinus_picanço-isabel (isabellinus)_rutshr3
+Lanius isabellinus arenarius/tsaidamensis_picanço-isabel (arenarius/tsaidamensis)_rutshr4
+Lanius phoenicuroides/isabellinus_picanço-do-turquestão/picanço-isabel_rutshr1
+Lanius cristatus_picanço-castanho_brnshr
+Lanius cristatus cristatus/confusus_picanço-castanho (cristatus/confusus)_brnshr1
+Lanius cristatus superciliosus_picanço-castanho (superciliosus)_brnshr2
+Lanius cristatus lucionensis_picanço-castanho (lucionensis)_brnshr3
+Lanius tigrinus x cristatus_tiger x brown shrike (hybrid)_x00464
+Lanius phoenicuroides/isabellinus/cristatus_picanço-do-turquestão/picanço-isabel/picanço-castanho_y00975
+Lanius collurioides_burmese shrike_burshr1
+Lanius gubernator_picanço-de-emin_emishr1
+Lanius vittatus_bay-backed shrike_babshr1
+Lanius schach_picanço-rabilongo_lotshr1
+Lanius schach erythronotus/caniceps_picanço-rabilongo (erythronotus/caniceps)_lotshr2
+Lanius schach schach_picanço-rabilongo (schach)_lotshr3
+Lanius schach tricolor/longicaudatus_picanço-rabilongo (tricolor/longicaudatus)_lotshr4
+Lanius schach schach x tricolor_long-tailed shrike (schach x tricolor)_lotshr14
+Lanius schach bentet_picanço-rabilongo (bentet)_lotshr5
+Lanius schach [nasutus Group]_picanço-rabilongo [grupo nasutus]_lotshr6
+Lanius vittatus/schach_bay-backed/long-tailed shrike_y00411
+Lanius tephronotus_gray-backed shrike_gybshr1
+Lanius validirostris_mountain shrike_gycshr1
+Lanius ludovicianus_loggerhead shrike_logshr
+Lanius borealis_picanço-real-americano_norshr4
+Lanius borealis [mollis Group]_picanço-real-americano [grupo mollis]_norshr2
+Lanius borealis borealis_picanço-real-americano (borealis)_norshr3
+Lanius ludovicianus/borealis_loggerhead/northern shrike_y00620
+Lanius meridionalis_picanço-real-meridional_ibgshr1
+Lanius excubitor_picanço-real_norshr1
+Lanius excubitor [excubitor Group]_picanço-real [grupo excubitor]_grgshr2
+Lanius excubitor [elegans Group]_picanço-real [grupo elegans]_grgshr4
+Lanius excubitor aucheri/buryi_picanço-real (aucheri/buryi)_grgshr1
+Lanius excubitor uncinatus_picanço-real (uncinatus)_grgshr5
+Lanius excubitor pallidirostris_picanço-real (pallidirostris)_sogshr3
+Lanius excubitor lahtora_picanço-real (lahtora)_grgshr3
+Lanius borealis/excubitor_picanço-real-americano/picanço-real_norshr
+Lanius meridionalis/excubitor_picanço-real-meridional/picanço-real_y01040
+Lanius minor_picanço-de-mascarilha_legshr2
+Lanius sphenocercus_chinese gray shrike_chgshr1
+Lanius giganteus_giant shrike_chgshr3
+Lanius sphenocercus/giganteus_chinese gray/giant shrike_chgshr2
+Lanius excubitoroides_gray-backed fiscal_gybfis1
+Lanius cabanisi_long-tailed fiscal_lotfis1
+Lanius dorsalis_taita fiscal_taifis1
+Lanius somalicus_somali fiscal_somfis1
+Lanius mackinnoni_mackinnon's shrike_macshr1
+Lanius humeralis_northern fiscal_norfis1
+Lanius collaris_southern fiscal_soufis1
+Lanius collaris marwitzi_southern fiscal (Uhehe)_soufis2
+Lanius collaris [collaris Group]_southern fiscal (Southern)_soufis3
+Lanius humeralis/collaris_northern/southern fiscal (Common Fiscal)_comfis1
+Lanius souzae_souza's shrike_soushr3
+Lanius newtoni_newton's fiscal_newfis1
+Lanius nubicus_picanço-da-núbia_masshr1
+Lanius senator_picanço-barreteiro_wooshr1
+Lanius senator senator_picanço-barreteiro (senator)_wooshr2
+Lanius senator badius_picanço-barreteiro (badius)_wooshr3
+Lanius senator niloticus_picanço-barreteiro (niloticus)_wooshr4
+Lanius collurio x senator_picanço-de-dorso-ruivo x picanço-barreteiro (híbrido)_x00861
+Laniidae sp._picanço (Lanius) sp._shrike
+Eurocephalus ruppelli_white-rumped shrike_whrshr1
+Eurocephalus anguitimens_white-crowned shrike_whcshr1
+Platysmurus leucopterus_malayan black magpie_blkmag1
+Platysmurus aterrimus_bornean black magpie_blkmag2
+Perisoreus infaustus_gaio-siberiano_sibjay1
+Perisoreus internigrans_sichuan jay_sicjay1
+Perisoreus canadensis_canada jay_gryjay
+Perisoreus canadensis [canadensis Group]_canada jay (Boreal)_gryjay1
+Perisoreus canadensis capitalis/bicolor_canada jay (Rocky Mts.)_gryjay2
+Perisoreus canadensis obscurus/griseus_canada jay (Pacific)_gryjay3
+Cyanolyca mirabilis_white-throated jay_whtjay1
+Cyanolyca nanus_dwarf jay_dwajay1
+Cyanolyca pumilo_black-throated jay_bltjay1
+Cyanolyca argentigula_silvery-throated jay_sitjay1
+Cyanolyca cucullata_azure-hooded jay_azhjay1
+Cyanolyca pulchra_beautiful jay_beajay1
+Cyanolyca armillata_black-collared jay_blcjay2
+Cyanolyca armillata armillata/meridana_black-collared jay (Black-collared)_bkcjay1
+Cyanolyca armillata quindiuna_black-collared jay (Quindio)_bkcjay2
+Cyanolyca turcosa_turquoise jay_turjay1
+Cyanolyca viridicyanus_white-collared jay_whcjay2
+Cyanocorax colliei_black-throated magpie-jay_btmjay
+Cyanocorax formosus_white-throated magpie-jay_wtmjay1
+Cyanocorax colliei x formosus_black-throated x white-throated magpie-jay (hybrid)_x00443
+Cyanocorax colliei/formosus_black-throated/white-throated magpie-jay_y01067
+Cyanocorax morio_brown jay_brnjay
+Cyanocorax caeruleus_gralha-azul_azujay1
+Cyanocorax violaceus_gralha-violácea_viojay1
+Cyanocorax cyanomelas_gralha-do-pantanal_purjay1
+Cyanocorax cristatellus_gralha-do-campo_cucjay1
+Cyanocorax yncas_green jay_grnjay
+Cyanocorax yncas [luxuosus Group]_green jay (Green)_grnjay1
+Cyanocorax yncas [yncas Group]_green jay (Inca)_grnjay2
+Cyanocorax mystacalis_white-tailed jay_whtjay2
+Cyanocorax melanocyaneus_bushy-crested jay_bucjay1
+Cyanocorax yucatanicus_yucatan jay_yucjay1
+Cyanocorax beecheii_purplish-backed jay_pubjay1
+Cyanocorax sanblasianus_san blas jay_sabjay
+Cyanocorax dickeyi_tufted jay_tufjay1
+Cyanocorax affinis_black-chested jay_blcjay1
+Cyanocorax heilprini_gralha-de-nuca-azul/cancão-da-campina_aznjay1
+Cyanocorax heilprini heilprini_gralha-de-nuca-azul_aznjay2
+Cyanocorax heilprini hafferi_cancão-da-campina_camjay1
+Cyanocorax cayanus_gralha-da-guiana_cayjay1
+Cyanocorax chrysops_gralha-picaça_plcjay1
+Cyanocorax cyanopogon_gralha-cancã_whnjay1
+Cyanocorax sp._Cyanocorax sp._cyanoc1
+Gymnorhinus cyanocephalus_pinyon jay_pinjay
+Cyanocitta stelleri_steller's jay_stejay
+Cyanocitta stelleri [stelleri Group]_steller's jay (Coastal)_stejay1
+Cyanocitta stelleri annectens_steller's jay (Northwest Interior)_stejay8
+Cyanocitta stelleri [diademata Group]_steller's jay (Southwest Interior)_stejay2
+Cyanocitta stelleri [coronata Group]_steller's jay (Middle American)_stejay3
+Cyanocitta cristata_gaio-azul_blujay
+Cyanocorax yncas x Cyanocitta cristata_green x blue jay (hybrid)_bxgjay1
+Cyanocitta stelleri x cristata_steller's x blue jay (hybrid)_x00622
+Aphelocoma coerulescens_florida scrub-jay_flsjay
+Aphelocoma insularis_island scrub-jay_issjay
+Aphelocoma californica_california scrub-jay_cowscj1
+Cyanocitta stelleri x Aphelocoma californica_steller's jay x california scrub-jay (hybrid)_x00964
+Aphelocoma woodhouseii_woodhouse's scrub-jay_wooscj2
+Aphelocoma woodhouseii [woodhouseii Group]_woodhouse's scrub-jay (Woodhouse's)_wooscj1
+Aphelocoma woodhouseii sumichrasti/remota_woodhouse's scrub-jay (Sumichrast's)_wesscj1
+Cyanocitta stelleri x Aphelocoma woodhouseii_steller's jay x woodhouse's scrub-jay (hybrid)_x00891
+Aphelocoma californica/woodhouseii_california/woodhouse's scrub-jay_wesjay
+Aphelocoma wollweberi_mexican jay_mexjay4
+Aphelocoma wollweberi [wollweberi Group]_mexican jay (Arizona)_mexjay1
+Aphelocoma wollweberi couchii_mexican jay (Couch's)_mexjay2
+Aphelocoma wollweberi potosina_mexican jay (San Luis Potosi)_mexjay5
+Aphelocoma ultramarina_transvolcanic jay_mexjay3
+Aphelocoma wollweberi/ultramarina_mexican/transvolcanic jay_mexjay
+Aphelocoma unicolor_unicolored jay_unijay1
+Aphelocoma sp._Aphelocoma sp._scrjay
+Garrulus glandarius_gaio_eurjay1
+Garrulus glandarius [glandarius Group]_gaio [grupo glandarius]_eurjay2
+Garrulus glandarius [atricapillus Group]_gaio [grupo atricapillus]_eurjay3
+Garrulus glandarius [cervicalis Group]_gaio [grupo cervicalis]_eurjay4
+Garrulus glandarius hyrcanus_gaio (hyrcanus)_eurjay5
+Garrulus glandarius [brandtii Group]_gaio [grupo brandtii]_eurjay6
+Garrulus glandarius [bispecularis Group]_gaio [grupo bispecularis]_eurjay7
+Garrulus glandarius leucotis/oatesi_gaio (leucotis/oatesi)_eurjay8
+Garrulus glandarius [japonicus Group]_gaio [grupo japonicus]_eurjay9
+Garrulus lanceolatus_black-headed jay_blhjay1
+Garrulus lidthi_lidth's jay_lidjay1
+Corvidae sp. (jay sp.)_gralha sp. (Corvidae sp.)_jay1
+Cyanopica cooki_charneco_azwmag3
+Cyanopica cyanus_charneco-oriental_azwmag2
+Cyanopica cyanus [cyanus Group]_charneco-oriental [grupo cyanus]_azwmag1
+Cyanopica cyanus japonica_charneco-oriental (japonica)_azwmag4
+Urocissa ornata_sri lanka blue-magpie_ceymag1
+Urocissa caerulea_taiwan blue-magpie_formag1
+Urocissa flavirostris_yellow-billed blue-magpie_gobmag1
+Urocissa erythroryncha_red-billed blue-magpie_rbbmag
+Urocissa flavirostris/erythroryncha_yellow-billed/red-billed blue-magpie_y00804
+Urocissa whiteheadi_white-winged magpie_whwmag1
+Urocissa whiteheadi xanthomelana_white-winged magpie (Black-tailed)_whwmag2
+Urocissa whiteheadi whiteheadi_white-winged magpie (Gray-tailed)_whwmag3
+Cissa chinensis_common green-magpie_gremag1
+Cissa chinensis [chinensis Group]_common green-magpie (Common)_comgrm1
+Cissa chinensis margaritae_common green-magpie (Yellow-crowned)_comgrm2
+Cissa hypoleuca_indochinese green-magpie_yebmag1
+Cissa thalassina_javan green-magpie_shtmag1
+Cissa jefferyi_bornean green-magpie_borgrm1
+Cissa sp._green-magpie sp._greenm1
+Dendrocitta vagabunda_rufous treepie_ruftre2
+Dendrocitta formosae_gray treepie_grytre1
+Dendrocitta vagabunda/formosae_rufous/gray treepie_y00413
+Dendrocitta occipitalis_sumatran treepie_sumtre1
+Dendrocitta cinerascens_bornean treepie_bortre1
+Dendrocitta leucogastra_white-bellied treepie_whbtre1
+Dendrocitta frontalis_collared treepie_coltre1
+Dendrocitta bayleii_andaman treepie_andtre1
+Crypsirina temia_racket-tailed treepie_rattre1
+Crypsirina cucullata_hooded treepie_hootre1
+Temnurus temnurus_ratchet-tailed treepie_rattre2
+Dendrocitta/Crypsirina/Temnurus sp._treepie sp._treepi1
+Pica mauritanica_pega-do-magreb_eurmag3
+Pica asirensis_pega-da-arábia_eurmag5
+Pica bottanensis_black-rumped magpie_eurmag6
+Pica serica_oriental magpie_orimag1
+Pica pica_pega_eurmag1
+Pica pica melanotos_pega (melanotos)_eurmag2
+Pica pica [pica Group]_pega [grupo pica]_eurmag4
+Pica pica camtschatica_pega (camtschatica)_eurmag7
+Pica serica/pica_oriental/eurasian magpie_y01104
+Pica hudsonia_black-billed magpie_bkbmag1
+Pica nuttalli_yellow-billed magpie_yebmag
+Pica sp._pega (Pica) sp._pica1
+Zavattariornis stresemanni_stresemann's bush-crow_stbcro1
+Podoces hendersoni_mongolian ground-jay_mogjay1
+Podoces biddulphi_xinjiang ground-jay_xigjay1
+Podoces panderi_turkestan ground-jay_tugjay1
+Podoces pleskei_iranian ground-jay_irgjay1
+Nucifraga columbiana_clark's nutcracker_clanut
+Nucifraga caryocatactes_quebra-nozes_eurnut3
+Nucifraga hemispila_southern nutcracker_eurnut4
+Nucifraga caryocatactes/hemispila_northern/southern nutcracker_eurnut1
+Nucifraga multipunctata_kashmir nutcracker_sponut1
+Pyrrhocorax pyrrhocorax_gralha-de-bico-vermelho_rebcho1
+Pyrrhocorax pyrrhocorax [pyrrhocorax Group]_gralha-de-bico-vermelho [grupo pyrrhocorax]_rebcho2
+Pyrrhocorax pyrrhocorax baileyi_gralha-de-bico-vermelho (baileyi)_rebcho3
+Pyrrhocorax graculus_gralha-de-bico-amarelo_yebcho1
+Pyrrhocorax pyrrhocorax/graculus_gralha-de-bico-vermelho/gralha-de-bico-amarelo_y00895
+Ptilostomus afer_pêga-africana_piapia1
+Coloeus monedula_gralha-de-nuca-cinzenta_eurjac
+Coloeus dauuricus_gralha-dáurica_daujac1
+Coloeus monedula/dauuricus_eurasian/daurian jackdaw_y01179
+Corvus splendens_gralha-indiana_houcro1
+Corvus moneduloides_new caledonian crow_neccro1
+Corvus unicolor_banggai crow_bancro1
+Corvus enca_sunda crow_slbcro2
+Corvus sierramadrensis_sierra madre crow_slbcro5
+Corvus samarensis_samar crow_slbcro6
+Corvus celebensis_sulawesi crow_slbcro12
+Corvus pusillus_palawan crow_slbcro7
+Corvus violaceus_violet crow_slbcro3
+Corvus typicus_piping crow_pipcro1
+Corvus florensis_flores crow_flocro1
+Corvus kubaryi_mariana crow_marcro1
+Corvus validus_long-billed crow_lobcro1
+Corvus woodfordi_guadalcanal crow_guacro1
+Corvus meeki_bougainville crow_boucro1
+Corvus fuscicapillus_brown-headed crow_brhcro1
+Corvus tristis_gray crow_grycro1
+Corvus capensis_cape crow_capcro2
+Corvus frugilegus_gralha-calva_rook1
+Corvus frugilegus frugilegus_gralha-calva (frugilegus)_rook2
+Corvus frugilegus pastinator_gralha-calva (pastinator)_rook3
+Corvus brachyrhynchos_american crow_amecro
+Corvus minutus_cuban palm-crow_cupcro1
+Corvus palmarum_hispaniolan palm-crow_palcro1
+Corvus nasicus_cuban crow_cubcro1
+Corvus leucognaphalus_white-necked crow_whncro1
+Corvus jamaicensis_jamaican crow_jamcro1
+Corvus imparatus_tamaulipas crow_tamcro
+Corvus sinaloae_sinaloa crow_sincro1
+Corvus ossifragus_fish crow_fiscro
+Corvus splendens x ossifragus_house x fish crow (hybrid)_x00465
+Corvus brachyrhynchos/ossifragus_american/fish crow_y00414
+Corvus hawaiiensis_hawaiian crow_hawcro
+Corvus cryptoleucus_chihuahuan raven_chirav
+Corvus corone_gralha-preta_carcro1
+Corvus corone corone_gralha-preta (corone)_carcro2
+Corvus corone orientalis_gralha-preta (orientalis)_carcro3
+Corvus cornix_gralha-cinzenta_hoocro1
+Corvus cornix [cornix Group]_gralha-cinzenta [grupo cornix]_hoocro2
+Corvus cornix capellanus_gralha-cinzenta (capellanus)_hoocro3
+Corvus corone x cornix_gralha-preta x gralha-cinzenta (híbrido)_x00636
+Corvus corone/cornix_gralha-preta/gralha-cinzenta_y00743
+Corvus macrorhynchos_corvo-de-bico-grosso_labcro1
+Corvus macrorhynchos [macrorhynchos Group]_corvo-de-bico-grosso [grupo macrorhynchos]_labcro2
+Corvus macrorhynchos culminatus_corvo-de-bico-grosso (culminatus)_labcro3
+Corvus macrorhynchos levaillantii_corvo-de-bico-grosso (levaillantii)_labcro4
+Corvus corone/macrorhynchos_gralha-preta/corvo-de-bico-grosso_y01259
+Corvus philippinus_philippine jungle crow_labcro15
+Corvus orru_torresian crow_torcro2
+Corvus insularis_bismarck crow_torcro3
+Corvus bennetti_little crow_litcro1
+Corvus coronoides_australian raven_ausrav1
+Corvus mellori_little raven_litrav1
+Corvus tasmanicus_forest raven_forrav1
+Corvus torquatus_collared crow_colcro1
+Corvus albus_corvo-de-barriga-branca_piecro1
+Corvus ruficollis_corvo-do-deserto_brnrav1
+Corvus edithae_somali crow_somcro2
+Corvus albus x edithae_pied x somali crow (hybrid)_x00466
+Corvus sp. (crow sp.)_gralha (Corvus) sp._crow
+Corvus rhipidurus_corvo-de-cauda-curta_fatrav1
+Corvus albicollis_white-necked raven_whnrav1
+Corvus crassirostris_thick-billed raven_thbrav1
+Corvus corax_corvo_comrav
+Corvus sp. (raven sp.)_corvo (Corvus) sp._raven
+Corvus sp._gralha/corvo (Corvus) sp._y00639
+Corvidae sp._corvid sp._corvid2
+Cnemophilus loriae_loria's satinbird_lorsat1
+Cnemophilus macgregorii_crested satinbird_cresat1
+Cnemophilus macgregorii sanguineus_crested satinbird (Red)_cresat2
+Cnemophilus macgregorii macgregorii_crested satinbird (Yellow)_cresat3
+Loboparadisea sericea_yellow-breasted satinbird_yebsat1
+Melanocharis arfakiana_obscure berrypecker_obsber1
+Melanocharis nigra_black berrypecker_blaber1
+Melanocharis longicauda_mid-mountain berrypecker_lebber1
+Melanocharis versteri_fan-tailed berrypecker_fatber1
+Melanocharis citreola_satin berrypecker_satber1
+Melanocharis striativentris_streaked berrypecker_strber1
+Melanocharis crassirostris_thick-billed berrypecker_spober1
+Melanocharis piperata_spotted berrypecker_spober3
+Melanocharis sp._Melanocharis berrypecker sp._melber1
+Toxorhamphus novaeguineae_yellow-bellied longbill_yeblon1
+Toxorhamphus poliopterus_slaty-chinned longbill_slclon1
+Toxorhamphus novaeguineae/poliopterus_yellow-bellied/slaty-chinned longbill_y00888
+Oedistoma iliolophus_spectacled longbill_dwahon2
+Oedistoma pygmaeum_pygmy longbill_pyghon1
+Callaeas wilsoni_north island kokako_kokako3
+Callaeas cinereus_south island kokako_kokako4
+Philesturnus rufusater_north island saddleback_saddle2
+Philesturnus carunculatus_south island saddleback_saddle3
+Heteralocha acutirostris_huia_huia1
+Notiomystis cincta_stitchbird_stitch1
+Amalocichla sclateriana_greater ground-robin_grgrob1
+Amalocichla incerta_lesser ground-robin_legrob1
+Pachycephalopsis poliosoma_white-eyed robin_wherob1
+Pachycephalopsis hattamensis_green-backed robin_grbrob1
+Eugerygone rubra_garnet robin_garrob1
+Petroica macrocephala_tomtit_tomtit1
+Petroica macrocephala [macrocephala Group]_tomtit (New Zealand)_tomtit2
+Petroica macrocephala dannefaerdi_tomtit (Snares Is.)_tomtit3
+Petroica traversi_black robin_charob1
+Petroica longipes_north island robin_nezrob2
+Petroica australis_south island robin_nezrob3
+Petroica bivittata_subalpine robin_alprob1
+Petroica archboldi_snow mountain robin_snmrob1
+Petroica multicolor_norfolk robin_pacrob2
+Petroica goodenovii_red-capped robin_recrob1
+Petroica polymorpha_solomons robin_pacrob3
+Petroica pusilla_pacific robin_pacrob1
+Petroica pusilla [similis Group]_pacific robin (Vanuatu)_pacrob4
+Petroica pusilla pusilla_pacific robin (Samoan)_pacrob5
+Petroica rosea_rose robin_rosrob1
+Petroica rodinogaster_pink robin_pinrob1
+Petroica phoenicea_flame robin_flarob1
+Petroica boodang_scarlet robin_scarob2
+Petroica boodang campbelli_scarlet robin (Campbell's)_scarob3
+Petroica boodang boodang/leggii_scarlet robin (Scarlet)_scarob4
+Petroica sp._Petroica sp._petroi1
+Devioeca papuana_canary flyrobin_canfly2
+Kempiella flavovirescens_olive flyrobin_olifly3
+Kempiella griseoceps_yellow-legged flyrobin_yelfly4
+Cryptomicroeca flaviventris_yellow-bellied flyrobin_yebrob1
+Monachella muelleriana_torrent flyrobin_torfly1
+Monachella muelleriana muelleriana_torrent flyrobin (Torrent)_torfly2
+Monachella muelleriana coultasi_torrent flyrobin (New Britain)_torfly3
+Microeca hemixantha_golden-bellied flyrobin_gobfly2
+Microeca flavigaster_lemon-bellied flyrobin_lebfly3
+Microeca flavigaster [flavigaster Group]_lemon-bellied flyrobin (Lemon-bellied)_lebfly1
+Microeca flavigaster tormenti_lemon-bellied flyrobin (Kimberley)_lebfly4
+Microeca [undescribed form]_bismarck flyrobin (undescribed form)_bisfly1
+Microeca fascinans_jacky-winter_jacwin1
+Microeca/Devioeca/Kempiella sp._flyrobin sp._microe1
+Drymodes brunneopygia_southern scrub-robin_sosrob1
+Drymodes superciliaris_northern scrub-robin_nosrob1
+Drymodes beccarii_papuan scrub-robin_papscr2
+Heteromyias cinereifrons_gray-headed robin_gyhrob2
+Heteromyias armiti_black-capped robin_ashrob2
+Heteromyias albispecularis_arfak robin_gyhrob1
+Leucophantes brachyurus_black-chinned robin_blcrob1
+Plesiodryas albonotata_black-throated robin_bltrob1
+Poecilodryas hypoleuca_black-sided robin_blsrob2
+Poecilodryas superciliosa_white-browed robin_whbrob2
+Poecilodryas cerviniventris_buff-sided robin_busrob1
+Melanodryas vittata_dusky robin_dusrob1
+Melanodryas cucullata_hooded robin_hoorob1
+Melanodryas bimaculata_white-rumped robin_whrrob2
+Melanodryas pulverulenta_mangrove robin_manrob1
+Melanodryas sigillata_white-winged robin_whwrob2
+Melanodryas cyanus_blue-gray robin_bugrob1
+Melanodryas cryptoleuca_smoky robin_smorob2
+Eopsaltria placens_banded yellow robin_olyrob1
+Eopsaltria australis_eastern yellow robin_yelrob1
+Eopsaltria griseogularis_western yellow robin_gybrob1
+Eopsaltria georgiana_white-breasted robin_whbrob1
+Eopsaltria capito_pale-yellow robin_payrob1
+Eopsaltria leucops_white-faced robin_whfrob1
+Picathartes gymnocephalus_white-necked rockfowl_whnroc1
+Picathartes oreas_gray-necked rockfowl_gynroc1
+Chaetops frenatus_cape rockjumper_rufroc1
+Chaetops aurantius_drakensberg rockjumper_orbroc1
+Eupetes macrocerus_malaysian rail-babbler_marbab1
+Hyliota flavigaster_yellow-bellied hyliota_yebhyl1
+Hyliota australis_southern hyliota_souhyl1
+Hyliota usambara_usambara hyliota_usahyl1
+Hyliota violacea_violet-backed hyliota_vibhyl1
+Stenostira scita_fairy flycatcher_faifly1
+Chelidorhynx hypoxanthus_yellow-bellied fairy-fantail_yebfan1
+Elminia longicauda_african blue flycatcher_afbfly1
+Elminia albicauda_white-tailed blue flycatcher_wtbfly1
+Elminia nigromitrata_dusky crested flycatcher_ducfly1
+Elminia albiventris_white-bellied crested flycatcher_wbcfly1
+Elminia albiventris albiventris_white-bellied crested flycatcher (White-bellied)_whbcrf1
+Elminia albiventris toroensis_white-bellied crested flycatcher (Toro)_whbcrf2
+Elminia albonotata_white-tailed crested flycatcher_wtcfly1
+Culicicapa ceylonensis_gray-headed canary-flycatcher_gyhcaf1
+Culicicapa helianthea_citrine canary-flycatcher_citcaf1
+Cephalopyrus flammiceps_fire-capped tit_fictit1
+Sylviparus modestus_yellow-browed tit_yebtit3
+Melanochlora sultanea_sultan tit_sultit1
+Melanochlora sultanea [sultanea Group]_sultan tit (Yellow-crested)_sultit3
+Melanochlora sultanea gayeti_sultan tit (Black-crested)_sultit2
+Periparus ater_chapim-carvoeiro_coatit2
+Periparus ater britannicus/hibernicus_chapim-carvoeiro (britannicus/hibernicus)_coatit1
+Periparus ater [ater Group]_chapim-carvoeiro [grupo ater]_coatit3
+Periparus ater ledouci/atlas_chapim-carvoeiro (ledouci/atlas)_coatit4
+Periparus ater cypriotes_chapim-carvoeiro (cypriotes)_coatit5
+Periparus ater [phaeonotus Group]_chapim-carvoeiro [grupo phaeonotus]_coatit6
+Periparus ater melanolophus_chapim-carvoeiro (melanolophus)_bkctit2
+Periparus ater [aemodius Group]_chapim-carvoeiro [grupo aemodius]_coatit7
+Periparus ater ptilosus/kuatunensis_chapim-carvoeiro (ptilosus/kuatunensis)_coatit8
+Periparus rufonuchalis_rufous-naped tit_bkbtit2
+Periparus rubidiventris_rufous-vented tit_ruvtit2
+Periparus rufonuchalis/rubidiventris_rufous-naped/rufous-vented tit_y01066
+Periparus venustulus_yellow-bellied tit_yebtit4
+Periparus elegans_elegant tit_eletit2
+Periparus amabilis_palawan tit_paltit2
+Lophophanes cristatus_chapim-de-poupa_cretit2
+Lophophanes dichrous_gray-crested tit_gyctit1
+Sittiparus castaneoventris_chestnut-bellied tit_vartit3
+Sittiparus olivaceus_iriomote tit_vartit2
+Sittiparus varius_varied tit_vartit1
+Sittiparus castaneoventris/varius_chestnut-bellied/varied tit_y00982
+Sittiparus owstoni_owston's tit_vartit4
+Sittiparus semilarvatus_white-fronted tit_whftit2
+Poecile superciliosus_white-browed tit_whbtit4
+Poecile lugubris_chapim-sombrio_somtit3
+Poecile davidi_pere david's tit_pedtit1
+Poecile palustris_chapim-palustre_martit2
+Poecile hyrcanus_caspian tit_castit2
+Poecile hypermelaenus_black-bibbed tit_bkbtit1
+Poecile montanus_chapim-montês_wiltit1
+Poecile montanus [montanus Group]_chapim-montês [grupo montanus]_wiltit2
+Poecile montanus [songarus Group]_chapim-montês [grupo songarus]_sontit2
+Poecile palustris/montanus_chapim-palustre/chapim-montês_y00696
+Poecile weigoldicus_sichuan tit_sictit1
+Poecile carolinensis_carolina chickadee_carchi
+Poecile atricapillus_black-capped chickadee_bkcchi
+Poecile carolinensis x atricapillus_carolina x black-capped chickadee (hybrid)_x00195
+Poecile carolinensis/atricapillus_carolina/black-capped chickadee_y00033
+Poecile gambeli_mountain chickadee_mouchi
+Poecile gambeli [gambeli Group]_mountain chickadee (Rocky Mts.)_mouchi3
+Poecile gambeli [baileyae Group]_mountain chickadee (Pacific)_mouchi4
+Poecile atricapillus x gambeli_black-capped x mountain chickadee (hybrid)_x00623
+Poecile atricapillus/gambeli_black-capped/mountain chickadee_y00983
+Poecile sclateri_mexican chickadee_mexchi
+Poecile gambeli x sclateri_mountain x mexican chickadee (hybrid)_x01055
+Poecile rufescens_chestnut-backed chickadee_chbchi
+Poecile gambeli x rufescens_mountain x chestnut-backed chickadee (hybrid)_x01012
+Poecile hudsonicus_boreal chickadee_borchi2
+Poecile atricapillus x hudsonicus_black-capped x boreal chickadee (hybrid)_x00708
+Poecile gambeli x hudsonicus_mountain x boreal chickadee (hybrid)_x00637
+Poecile cinctus_chapim-da-lapónia_gyhchi
+Poecile montanus x cinctus_chapim-montês x chapim-da-lapónia (híbrido)_x00743
+Poecile sp._chapim (Poecile) sp._chicka1
+Cyanistes caeruleus_chapim-azul_blutit
+Cyanistes teneriffae_chapim-azul-das-canárias_afbtit2
+Cyanistes cyanus_chapim-de-cabeça-branca_azutit2
+Cyanistes cyanus [cyanus Group]_chapim-de-cabeça-branca [grupo cyanus]_azutit1
+Cyanistes cyanus [flavipectus Group]_chapim-de-cabeça-branca [grupo flavipectus]_yebtit5
+Cyanistes caeruleus x cyanus_chapim-azul x chapim-de-cabeça-branca (híbrido)_x00965
+Cyanistes caeruleus/cyanus_chapim-azul/chapim-de-cabeça-branca_y01148
+Baeolophus wollweberi_bridled titmouse_britit
+Baeolophus inornatus_oak titmouse_oaktit
+Baeolophus ridgwayi_juniper titmouse_juntit1
+Baeolophus wollweberi/ridgwayi_bridled/juniper titmouse_y01149
+Baeolophus inornatus/ridgwayi_oak/juniper titmouse (Plain Titmouse)_y00326
+Baeolophus bicolor_tufted titmouse_tuftit
+Poecile carolinensis x Baeolophus bicolor_carolina chickadee x tufted titmouse (hybrid)_x00709
+Poecile atricapillus x Baeolophus bicolor_black-capped chickadee x tufted titmouse (hybrid)_x00642
+Baeolophus atricristatus_black-crested titmouse_blctit4
+Baeolophus bicolor x atricristatus_tufted x black-crested titmouse (hybrid)_bcxtit1
+Baeolophus bicolor/atricristatus_tufted/black-crested titmouse_y00327
+Pseudopodoces humilis_ground tit_grotit1
+Parus monticolus_green-backed tit_grbtit1
+Parus major_chapim-real_gretit1
+Parus major [major Group]_chapim-real [grupo major]_gretit3
+Parus major [bokharensis Group]_chapim-real [grupo bokharensis]_turtit1
+Parus cinereus_asian tit_cintit13
+Parus cinereus [cinereus Group]_asian tit (Cinereous)_gretit2
+Parus cinereus [minor Group]_asian tit (Japanese)_japtit4
+Parus cinereus commixtus_asian tit (commixtus)_japtit2
+Parus cinereus amamiensis_asian tit (Amami)_japtit1
+Parus cinereus okinawae_asian tit (Okinawa)_japtit5
+Parus cinereus nigriloris_asian tit (Ishigaki)_japtit3
+Parus major/cinereus_great/asian tit_y01315
+Parus sp._Parus sp._parus1
+Machlolophus nuchalis_white-naped tit_whwtit2
+Machlolophus holsti_taiwan yellow tit_yeltit2
+Machlolophus xanthogenys_himalayan black-lored tit_blltit1
+Machlolophus aplonotus_indian yellow tit_indtit1
+Machlolophus spilonotus_yellow-cheeked tit_yectit1
+Melaniparus guineensis_chapim-da-guiné_whsblt1
+Melaniparus leucomelas_white-winged black-tit_whwblt3
+Melaniparus rufiventris_rufous-bellied tit_rubtit3
+Melaniparus rufiventris rufiventris/masukuensis_rufous-bellied tit (Rufous-bellied)_rubtit1
+Melaniparus rufiventris pallidiventris_rufous-bellied tit (Cinnamon-breasted)_rubtit2
+Melaniparus albiventris_white-bellied tit_whbtit5
+Melaniparus niger_southern black-tit_soublt1
+Melaniparus carpi_carp's tit_cartit2
+Melaniparus niger/carpi_southern black-tit/carp's tit_y01302
+Melaniparus funereus_dusky tit_dustit2
+Melaniparus griseiventris_miombo tit_miotit2
+Melaniparus fasciiventer_stripe-breasted tit_stbtit2
+Melaniparus thruppi_somali tit_somtit4
+Melaniparus fringillinus_red-throated tit_rettit2
+Melaniparus leuconotus_white-backed black-tit_whbblt1
+Melaniparus cinerascens_ashy tit_ashtit2
+Melaniparus afer_gray tit_grytit1
+Melaniparus cinerascens/afer_ashy/gray tit_y01303
+Melaniparus sp._african tit sp._afrtit1
+Paridae sp._chapim sp._parid1
+Auriparus flaviceps_verdin_verdin
+Remiz pendulinus_chapim-de-mascarilha_euptit1
+Remiz macronyx_black-headed penduline-tit_bhptit1
+Remiz pendulinus x macronyx_eurasian x black-headed penduline-tit (hybrid)_x01080
+Remiz pendulinus/macronyx_eurasian/black-headed penduline-tit_y01265
+Remiz coronatus_white-crowned penduline-tit_wcptit1
+Remiz consobrinus_chinese penduline-tit_chptit1
+Remiz sp._Remiz sp._remiz1
+Anthoscopus punctifrons_sennar penduline-tit_septit1
+Anthoscopus musculus_mouse-colored penduline-tit_mcptit1
+Anthoscopus parvulus_yellow penduline-tit_yeptit1
+Anthoscopus flavifrons_forest penduline-tit_foptit1
+Anthoscopus caroli_african penduline-tit_afptit1
+Anthoscopus caroli [ansorgei Group]_african penduline-tit (White-bellied)_afrpet2
+Anthoscopus caroli sylviella/sharpei_african penduline-tit (Buff-bellied)_afrpet1
+Anthoscopus caroli roccatii_african penduline-tit (Yellow-bellied)_afrpet3
+Anthoscopus caroli rankinei_african penduline-tit (Slaty-backed)_afrpet4
+Anthoscopus caroli [caroli Group]_african penduline-tit (Buff-vented)_afrpet5
+Anthoscopus minutus_southern penduline-tit_soptit1
+Chersomanes albofasciata_spike-heeled lark_sphlar12
+Chersomanes beesleyi_beesley's lark_beelar1
+Alaemon alaudipes_calhandra-de-bico-curvo_grhlar1
+Alaemon alaudipes boavistae_calhandra-de-bico-curvo (boavistae)_grehol1
+Alaemon alaudipes [alaudipes Group]_calhandra-de-bico-curvo [grupo alaudipes]_grehol2
+Alaemon hamertoni_lesser hoopoe-lark_lehlar1
+Ammomanopsis grayi_gray's lark_gralar2
+Certhilauda chuana_short-clawed lark_shclar1
+Certhilauda subcoronata_karoo long-billed lark_klblar6
+Certhilauda subcoronata benguelensis/kaokoensis_karoo long-billed lark (Benguela)_benlar1
+Certhilauda subcoronata [subcoronata Group]_karoo long-billed lark (Karoo)_klblar1
+Certhilauda semitorquata_eastern long-billed lark_elblar1
+Certhilauda curvirostris_cape long-billed lark_y00415
+Certhilauda curvirostris curvirostris/falcirostris_cape long-billed lark (Cape)_caplar1
+Certhilauda curvirostris brevirostris_cape long-billed lark (Agulhas)_agular1
+Certhilauda sp._long-billed lark sp._loblar1
+Pinarocorys erythropygia_rufous-rumped lark_rurlar1
+Pinarocorys nigricans_dusky lark_duslar1
+Ramphocoris clotbey_calhandra-de-bico-grosso_thblar1
+Ammomanes cinctura_calhandra-das-dunas_batlar1
+Ammomanes phoenicura_rufous-tailed lark_rutlar2
+Ammomanes deserti_calhandra-do-deserto_deslar1
+Ammomanes sp._calhandra (Ammomanes) sp._ammoma1
+Eremopterix australis_black-eared sparrow-lark_beslar1
+Eremopterix hova_madagascar lark_madlar1
+Eremopterix leucotis_chestnut-backed sparrow-lark_cbslar1
+Eremopterix nigriceps_pastor_bcslar1
+Eremopterix griseus_ashy-crowned sparrow-lark_ascspl1
+Eremopterix signatus_pastor-de-cabeça-castanha_chhspl1
+Eremopterix verticalis_gray-backed sparrow-lark_gybspl1
+Eremopterix leucopareia_fischer's sparrow-lark_fislar1
+Eremopterix sp._sparrow-lark sp._sparro2
+Calendulauda rufa_rusty lark_ruslar1
+Calendulauda sabota_sabota lark_sablar2
+Calendulauda sabota [naevia Group]_sabota lark (Bradfield's)_sablar1
+Calendulauda sabota [sabota Group]_sabota lark (Sabota)_sablar3
+Calendulauda gilletti_gillett's lark_gillar1
+Calendulauda poecilosterna_pink-breasted lark_piblar3
+Calendulauda africanoides_fawn-colored lark_faclar8
+Calendulauda africanoides [africanoides Group]_fawn-colored lark (Fawn-colored)_faclar2
+Calendulauda africanoides alopex/intercedens_fawn-colored lark (Foxy)_foxlar1
+Calendulauda albescens_karoo lark_karlar2
+Calendulauda burra_red lark_ferlar2
+Calendulauda erythrochlamys_dune lark_dunlar5
+Calendulauda erythrochlamys barlowi_dune lark (Barlow's)_barlar2
+Calendulauda erythrochlamys patae_dune lark (Coastal)_barlar4
+Calendulauda erythrochlamys cavei_dune lark (Cave's)_barlar3
+Calendulauda erythrochlamys erythrochlamys_dune lark (Dune)_dunlar3
+Calendulauda albescens x erythrochlamys_karoo x dune lark (hybrid)_x00863
+Heteromirafra archeri_liben lark_liblar1
+Heteromirafra ruddi_rudd's lark_rudlar1
+Plocealauda microptera_burmese bushlark_burbus1
+Plocealauda erythrocephala_indochinese bushlark_indbus3
+Plocealauda affinis_jerdon's bushlark_jerbus2
+Plocealauda erythroptera_indian bushlark_indbus2
+Plocealauda assamica_bengal bushlark_benbus1
+Plocealauda affinis/erythroptera_jerdon's/indian bushlark_y00744
+Mirafra passerina_monotonous lark_monlar2
+Mirafra cordofanica_kordofan lark_korlar1
+Mirafra williamsi_williams's lark_willar1
+Mirafra pulpa_friedmann's lark_frilar1
+Mirafra albicauda_white-tailed lark_whtlar1
+Mirafra cheniana_melodious lark_latlar1
+Mirafra javanica_singing bushlark_sinbus6
+Mirafra javanica [cantillans Group]_singing bushlark (Singing)_sinbus1
+Mirafra javanica [javanica Group]_singing bushlark (Australasian)_ausbus2
+Plocealauda erythrocephala/Mirafra javanica_indochinese/singing bushlark_y01340
+Plocealauda erythroptera/Mirafra javanica_indian/singing bushlark_y01118
+Plocealauda/Mirafra sp._Plocealauda/Mirafra sp._y01344
+Mirafra sp._Mirafra sp._mirafr1
+Amirafra collaris_collared lark_collar1
+Amirafra rufocinnamomea_flappet lark_flalar1
+Amirafra angolensis_angola lark_anglar1
+Corypha kurrae_highland lark_higlar1
+Corypha kurrae kurrae_highland lark (Sudan)_runlar3
+Corypha kurrae stresemanni/bamendae_highland lark (Bamenda)_runlar4
+Corypha kurrae henrici/batesi_highland lark (Western)_higlar2
+Corypha apiata_cape clapper lark_caclar1
+Corypha apiata apiata_cape clapper lark (Cape)_caclar2
+Corypha apiata marjoriae_cape clapper lark (Agulhas)_caclar3
+Corypha fasciolata_eastern clapper lark_eaclar1
+Corypha kabalii_plains lark_plalar1
+Corypha kabalii kabalii_plains lark (Kabali's)_runlar18
+Corypha kabalii malbranti_plains lark (Malbrant's)_runlar8
+Corypha nigrescens_plateau lark_runlar7
+Corypha africana_rufous-naped lark_runlar1
+Corypha africana [africana Group]_rufous-naped lark (Rufous-naped)_runlar5
+Corypha africana tropicalis_rufous-naped lark (Serengeti)_runlar6
+Corypha kabalii/africana_plains/rufous-naped lark_y01341
+Corypha nigrescens/africana_plateau/rufous-naped lark_y01342
+Corypha athi_sentinel lark_senlar1
+Corypha africana/athi_rufous-naped/sentinel lark_y01343
+Corypha somalica_somali lark_slblar1
+Corypha somalica ashi_somali lark (Ash's)_ashlar1
+Corypha somalica somalica/rochei_somali lark (Somali)_slblar4
+Corypha hypermetra_red-winged lark_rewlar1
+Corypha hypermetra hypermetra_red-winged lark (Red-winged)_rewlar6
+Corypha hypermetra gallarum_red-winged lark (Rift Valley)_rewlar3
+Corypha sharpii_russet lark_runlar2
+Corypha kidepoensis_kidepo lark_kidlar1
+Corypha sp._Corypha sp._coryph1
+Lullula arborea_cotovia-das-árvores_woolar1
+Spizocorys starki_stark's lark_stalar2
+Spizocorys personata_masked lark_maslar1
+Spizocorys conirostris_pink-billed lark_piblar1
+Spizocorys fringillaris_botha's lark_botlar1
+Spizocorys fremantlii_short-tailed lark_shtlar1
+Spizocorys obbiensis_obbia lark_obblar1
+Spizocorys sclateri_sclater's lark_scllar1
+Alauda leucoptera_calhandra-ruiva_whwlar1
+Alauda razae_calhandra-do-ilhéu-raso_razsky1
+Alauda arvensis_laverca_skylar
+Alauda arvensis [arvensis Group]_laverca [grupo arvensis]_skylar1
+Alauda arvensis [pekinensis Group]_laverca [grupo pekinensis]_skylar2
+Alauda arvensis japonica/intermedia_laverca (japonica/intermedia)_eursky1
+Alauda gulgula_laverca-oriental_orisky1
+Alauda arvensis/gulgula_laverca/laverca-oriental_y00652
+Galerida modesta_sun lark_sunlar1
+Galerida magnirostris_large-billed lark_lablar1
+Galerida deva_tawny lark_tawlar1
+Galerida theklae_cotovia-escura_thelar1
+Galerida cristata_cotovia-de-poupa_crelar1
+Galerida cristata [cristata Group]_cotovia-de-poupa [grupo cristata]_crelar2
+Galerida cristata macrorhyncha/randonii_cotovia-de-poupa (macrorhyncha/randonii)_crelar3
+Galerida theklae/cristata_cotovia-escura/cotovia-de-poupa_y00980
+Galerida malabarica_malabar lark_mallar1
+Galerida cristata/malabarica_crested/malabar lark_y00417
+Galerida sp._Galerida sp._galeri1
+Eremophila alpestris_calhandra-cornuda_horlar
+Eremophila alpestris atlas_calhandra-cornuda-do-atlas_horlar5
+Eremophila alpestris [penicillata Group]_calhandra-cornuda [grupo penicillata]_horlar6
+Eremophila alpestris [longirostris Group]_calhandra-cornuda [grupo longirostris]_horlar7
+Eremophila alpestris brandti_calhandra-cornuda (brandti)_horlar8
+Eremophila alpestris flava_calhandra-cornuda (flava)_horlar4
+Eremophila alpestris [alpestris Group]_calhandra-cornuda [grupo alpestris]_horlar3
+Eremophila alpestris [occidentalis Group]_calhandra-cornuda [grupo occidentalis]_horlar2
+Eremophila alpestris [strigata Group]_calhandra-cornuda [grupo strigata]_horlar1
+Eremophila alpestris enertera_calhandra-cornuda (enertera)_horlar9
+Eremophila alpestris [chrysolaema Group]_calhandra-cornuda [grupo chrysolaema]_horlar10
+Eremophila alpestris peregrina_calhandra-cornuda-colombiana_horlar11
+Eremophila bilopha_calhandra-cornuda-do-deserto_temlar1
+Eremophila alpestris/bilopha_calhandra-cornuda/calhandra-cornuda-do-deserto_y00898
+Calandrella eremica_rufous-capped lark_blalar4
+Calandrella blanfordi_blanford's lark_blalar2
+Calandrella blanfordi blanfordi_blanford's lark (Blanford's)_blalar3
+Calandrella blanfordi erlangeri_blanford's lark (Erlanger's)_erllar1
+Calandrella brachydactyla_calhandrinha-galucha_gstlar1
+Calandrella cinerea_red-capped lark_reclar1
+Calandrella acutirostris_calhandrinha-de-hume_humlar1
+Calandrella brachydactyla/acutirostris_calhandrinha-galucha/calhandrinha-de-hume_y00897
+Calandrella dukhunensis_mongolian short-toed lark_sstlar4
+Calandrella brachydactyla/dukhunensis_greater/mongolian short-toed lark_y01042
+Calandrella acutirostris/dukhunensis_hume's lark/mongolian short-toed lark_y00416
+Calandrella sp._calhandrinha sp._caland1
+Melanocorypha bimaculata_calhandra-bastarda_bimlar1
+Melanocorypha maxima_tibetan lark_tiblar1
+Melanocorypha mongolica_mongolian lark_monlar1
+Melanocorypha calandra_calhandra-real_callar1
+Melanocorypha bimaculata/calandra_calhandra-bastarda/calhandra-real_y00687
+Melanocorypha yeltoniensis_calhandra-preta_blalar1
+Chersophilus duponti_calhandra-de-dupont_duplar1
+Eremalauda dunni_calhandra-de-dunn-africana_dunlar1
+Eremalauda eremodites_calhandra-de-dunn-arábica_dunlar4
+Eremalauda dunni/eremodites_calhandra-de-dunn-africana/calhandra-de-dunn-arábica_dunlar2
+Alaudala somalica_somali short-toed lark_sstlar1
+Alaudala somalica [somalica Group]_somali short-toed lark (Somali)_sstlar2
+Alaudala somalica athensis_somali short-toed lark (Athi)_sstlar3
+Alaudala cheleensis_calhandrinha-asiática_lstlar2
+Alaudala rufescens_calhandrinha-das-marismas_mstlar1
+Alaudala heinei_calhandrinha-do-turquestão_tstlar1
+Alaudala cheleensis/heinei_calhandrinha-asiática/calhandrinha-do-turquestão_lstlar1
+Alaudala rufescens/heinei_calhandrinha-das-marismas/calhandrinha-do-turquestão_lstlar3
+Alaudala raytal_sand lark_sanlar1
+Alaudala sp._Alaudala sp._alauda1
+Calandrella brachydactyla/Alaudala sp._Calhandrinha-galucha/Calhandrinha (Alaudala) sp._y00675
+Calandrella/Alaudala sp._Calandrella/Alaudala sp._y00979
+Alaudidae sp._cotovia (alaudídeo) sp._lark1
+Panurus biarmicus_chapim-de-bigodes_bearee1
+Nicator chloris_tuta-malhada_yesnic1
+Nicator gularis_eastern nicator_easnic1
+Nicator vireo_yellow-throated nicator_yetnic1
+Nicator chloris/vireo_western/yellow-throated nicator_y00896
+Sylvietta virens_green crombec_grecro1
+Sylvietta denti_lemon-bellied crombec_lebcro1
+Sylvietta leucophrys_white-browed crombec_whbcro2
+Sylvietta leucophrys leucophrys/chloronota_white-browed crombec (White-browed)_whbcro1
+Sylvietta leucophrys chapini_white-browed crombec (Lendu)_whbcro3
+Sylvietta brachyura_carriça-rabeta_norcro1
+Sylvietta brachyura brachyura/carnapi_carriça-rabeta (brachyura/carnapi)_norcro3
+Sylvietta brachyura leucopsis_carriça-rabeta (leucopsis)_norcro2
+Sylvietta philippae_short-billed crombec_shbcro1
+Sylvietta ruficapilla_red-capped crombec_reccro1
+Sylvietta whytii_red-faced crombec_refcro1
+Sylvietta isabellina_somali crombec_somcro1
+Sylvietta rufescens_long-billed crombec_capcro1
+Sylvietta sp._carriça (Sylvietta) sp._crombe1
+Achaetops pycnopygius_rockrunner_damroc1
+Melocichla mentalis_boita-de-bigodes_mogwar1
+Sphenoeacus afer_cape grassbird_capgra1
+Cryptillas victorini_victorin's warbler_viswar1
+Macrosphenus kempi_kemp's longbill_kemlon1
+Macrosphenus flavicans_yellow longbill_yellon1
+Macrosphenus concolor_gray longbill_grylon1
+Macrosphenus pulitzeri_pulitzer's longbill_pullon1
+Macrosphenus kretschmeri_kretschmer's longbill_krelon1
+Macrosphenus sp._longbill sp._longbi1
+Neomixis tenella_common jery_comjer1
+Neomixis viridis_green jery_grejer1
+Neomixis striatigula_stripe-throated jery_sttjer1
+Neomixis striatigula striatigula/sclateri_stripe-throated jery (Stripe-throated)_sttjer2
+Neomixis striatigula pallidior_stripe-throated jery (Subdesert)_sttjer3
+Neomixis sp._jery sp._jery1
+Micromacronus leytensis_leyte plumed-warbler_mitbab1
+Micromacronus sordidus_mindanao plumed-warbler_minmib1
+Eremomela flavicrissalis_yellow-vented eremomela_yevere1
+Eremomela icteropygialis_yellow-bellied eremomela_yebere1
+Eremomela icteropygialis [icteropygialis Group]_yellow-bellied eremomela (Yellow-bellied)_yebere11
+Eremomela icteropygialis salvadorii_yellow-bellied eremomela (Salvadori's)_salere1
+Eremomela pusilla_senegal eremomela_senere1
+Eremomela canescens_green-backed eremomela_grbere1
+Eremomela scotops_green-capped eremomela_greere1
+Eremomela gregalis_karoo eremomela_yerere1
+Eremomela badiceps_rufous-crowned eremomela_rucere1
+Eremomela turneri_turner's eremomela_turere1
+Eremomela atricollis_black-necked eremomela_blnere1
+Eremomela usticollis_burnt-neck eremomela_bunere1
+Eremomela sp._eremomela sp._eremom1
+Drymocichla incana_red-winged gray warbler_rwgwar2
+Schistolais leontica_sierra leone prinia_silpri2
+Schistolais leucopogon_white-chinned prinia_whcpri2
+Oreophilais robertsi_roberts's warbler_robpri1
+Phragmacia substriata_namaqua warbler_nampri1
+Urolais epichlorus_green longtail_grnlon1
+Urolais epichlorus epichlorus_green longtail (Green)_grnlon2
+Urolais epichlorus mariae_green longtail (Bioko)_grnlon3
+Oreolais pulcher_black-collared apalis_blcapa2
+Oreolais ruwenzorii_rwenzori apalis_ruwapa1
+Artisornis metopias_african tailorbird_afrtai2
+Artisornis moreaui_long-billed tailorbird_lobtai1
+Artisornis moreaui moreaui_long-billed tailorbird (Long-billed)_lobtai2
+Artisornis moreaui sousae_long-billed tailorbird (Njesi)_lobtai3
+Poliolais lopezi_white-tailed warbler_whtwar1
+Poliolais lopezi manengubae_white-tailed warbler (Highland)_whtwar2
+Poliolais lopezi alexanderi_white-tailed warbler (Alexander's)_whtwar3
+Poliolais lopezi lopezi_white-tailed warbler (Bioko)_whtwar4
+Calamonastes undosus_miombo wren-warbler_miowrw2
+Calamonastes stierlingi_stierling's wren-warbler_miowrw3
+Calamonastes undosus x stierlingi_miombo x stierling's wren-warbler (hybrid)_x00966
+Calamonastes undosus/stierlingi_miombo/stierling's wren-warbler_miowrw1
+Calamonastes simplex_gray wren-warbler_grywrw1
+Calamonastes fasciolatus_barred wren-warbler_bawwar1
+Camaroptera brachyura_green-backed camaroptera_grbcam1
+Camaroptera brachyura [brevicaudata Group]_green-backed camaroptera (Gray-backed)_gnbcam2
+Camaroptera brachyura [brachyura Group]_green-backed camaroptera (Green-backed)_gnbcam1
+Camaroptera harterti_hartert's camaroptera_gnbcam3
+Camaroptera brachyura/harterti_green-backed/hartert's camaroptera_y01150
+Camaroptera superciliaris_yellow-browed camaroptera_yebcam1
+Camaroptera chloronota_olive-green camaroptera_olgcam1
+Camaroptera chloronota [chloronota Group]_olive-green camaroptera (Olive-green)_olgcam2
+Camaroptera chloronota toroensis/kamitugaensis_olive-green camaroptera (Tawny-breasted)_olgcam3
+Camaroptera sp._camaroptera sp._camaro1
+Spiloptila clamans_fuinha-de-cauda-branca_crilon1
+Phyllolais pulchella_buff-bellied warbler_bubwar2
+Apalis thoracica_bar-throated apalis_batapa2
+Apalis fuscigularis_taita apalis_batapa4
+Apalis flavigularis_yellow-throated apalis_batapa3
+Apalis lynesi_namuli apalis_batapa5
+Apalis nigriceps_black-capped apalis_blcapa1
+Apalis nigriceps nigriceps_black-capped apalis (Black-capped)_bkcapa1
+Apalis nigriceps collaris_black-capped apalis (White-tailed)_bkcapa2
+Apalis jacksoni_black-throated apalis_bltapa1
+Apalis chariessa_white-winged apalis_whwapa1
+Apalis binotata_masked apalis_masapa1
+Apalis personata_black-faced apalis_blfapa1
+Apalis flavida_yellow-breasted apalis_yebapa1
+Apalis flavida flavocincta/viridiceps_yellow-breasted apalis (Brown-tailed)_yebapa2
+Apalis flavida [flavida Group]_yellow-breasted apalis (Yellow-breasted)_yebapa3
+Apalis ruddi_rudd's apalis_rudapa1
+Apalis sharpii_sharpe's apalis_shaapa2
+Apalis rufogularis_buff-throated apalis_butapa1
+Apalis rufogularis rufogularis/sanderi_buff-throated apalis (Black-breasted)_butapa2
+Apalis rufogularis angolensis/brauni_buff-throated apalis (Angola)_butapa3
+Apalis rufogularis nigrescens/kigezi_buff-throated apalis (Buff-throated)_butapa4
+Apalis argentea_kungwe apalis_kunapa1
+Apalis bamendae_bamenda apalis_bamapa1
+Apalis goslingi_gosling's apalis_gosapa1
+Apalis kaboboensis_kabobo apalis_chtapa2
+Apalis porphyrolaema_chestnut-throated apalis_chtapa3
+Apalis chapini_chapin's apalis_chaapa1
+Apalis melanocephala_black-headed apalis_blhapa1
+Apalis chirindensis_chirinda apalis_chiapa1
+Apalis cinerea_gray apalis_gryapa1
+Apalis cinerea sclateri_gray apalis (Sclater's)_gryapa2
+Apalis cinerea grandis_gray apalis (Angola)_gryapa3
+Apalis cinerea cinerea/funebris_gray apalis (Gray)_gryapa4
+Apalis alticola_brown-headed apalis_brhapa1
+Apalis karamojae_karamoja apalis_karapa2
+Apalis stronachi_maasai apalis_karapa3
+Apalis sp._apalis sp._apalis1
+Orthotomus sutorius_common tailorbird_comtai1
+Orthotomus frontalis_rufous-fronted tailorbird_ruftai1
+Orthotomus atrogularis_dark-necked tailorbird_dantai1
+Orthotomus sutorius/atrogularis_common/dark-necked tailorbird_y01175
+Orthotomus chaktomuk_cambodian tailorbird_camtai1
+Orthotomus ruficeps_ashy tailorbird_ashtai1
+Orthotomus atrogularis/ruficeps_dark-necked/ashy tailorbird_y01176
+Orthotomus sepium_olive-backed tailorbird_olbtai1
+Orthotomus sericeus_rufous-tailed tailorbird_ruttai1
+Orthotomus castaneiceps_visayan tailorbird_phitai1
+Orthotomus derbianus_gray-backed tailorbird_gybtai1
+Orthotomus chloronotus_green-backed tailorbird_gnbtai1
+Orthotomus samarensis_yellow-breasted tailorbird_yebtai1
+Orthotomus nigriceps_white-browed tailorbird_whbtai1
+Orthotomus cinereiceps_white-eared tailorbird_whetai1
+Orthotomus sp._tailorbird sp._tailor1
+Prinia crinigera_himalayan prinia_strpri2
+Prinia striata_striped prinia_strpri8
+Prinia cooki_burmese prinia_brnpri2
+Prinia rocki_annam prinia_brnpri3
+Prinia polychroa_brown prinia_bropri1
+Prinia cooki/polychroa_burmese/brown prinia_y00442
+Prinia atrogularis_black-throated prinia_hilpri1
+Prinia khasiana_rufous-crowned prinia_bktpri2
+Prinia superciliaris_hill prinia_hilpri2
+Prinia cinereocapilla_gray-crowned prinia_gycpri1
+Prinia buchanani_rufous-fronted prinia_rufpri2
+Prinia rufescens_rufescent prinia_rufpri1
+Prinia hodgsonii_gray-breasted prinia_gybpri1
+Prinia rufescens/hodgsonii_rufescent/gray-breasted prinia_y01177
+Prinia familiaris_bar-winged prinia_bawpri1
+Prinia gracilis_fuinha-elegante_grapri1
+Prinia lepida_fuinha-elegante-asiática_delpri1
+Prinia gracilis/lepida_fuinha-elegante/fuinha-elegante-asiática_y00443
+Prinia sylvatica_jungle prinia_junpri1
+Prinia flaviventris_yellow-bellied prinia_yebpri1
+Prinia flaviventris [flaviventris Group]_yellow-bellied prinia (Yellow-bellied)_yebpri2
+Prinia flaviventris sonitans_yellow-bellied prinia (Chinese)_yebpri3
+Prinia socialis_ashy prinia_ashpri1
+Prinia flaviventris/socialis_yellow-bellied/ashy prinia_y01001
+Prinia subflava_tawny-flanked prinia_tafpri1
+Prinia inornata_plain prinia_plapri1
+Prinia somalica_pale prinia_palpri1
+Prinia fluviatilis_river prinia_rivpri1
+Prinia flavicans_black-chested prinia_blcpri1
+Prinia subflava/flavicans_tawny-flanked/black-chested prinia_y01304
+Prinia maculosa_karoo prinia_karpri1
+Prinia hypoxantha_drakensberg prinia_drapri1
+Prinia maculosa/hypoxantha_karoo/drakensberg prinia_y01305
+Prinia molleri_sao tome prinia_satpri1
+Prinia bairdii_banded prinia_banpri1
+Prinia bairdii bairdii/heinrichi_banded prinia (Banded)_banpri2
+Prinia bairdii melanops/obscura_banded prinia (Black-faced)_banpri3
+Prinia erythroptera_red-winged prinia_rewpri1
+Prinia rufifrons_red-fronted prinia_refwar2
+Prinia rufifrons rufifrons/smithi_red-fronted prinia (Red-fronted)_refwar1
+Prinia rufifrons rufidorsalis_red-fronted prinia (Rufous-backed)_refwar3
+Prinia sp._prinia sp._prinia1
+Euryptila subcinnamomea_cinnamon-breasted warbler_kopwar1
+Scepomycter winifredae_mrs. moreau's warbler_mrmwar1
+Scepomycter winifredae winifredae_mrs. moreau's warbler (Mrs. Moreau's)_mrmwar2
+Scepomycter winifredae rubehoensis_mrs. moreau's warbler (Rubeho)_mrmwar3
+Incana incana_socotra warbler_socwar2
+Malcorus pectoralis_rufous-eared warbler_ruewar2
+Bathmocercus cerviniventris_black-capped rufous-warbler_bkcruw1
+Bathmocercus rufus_black-faced rufous-warbler_bkfruw1
+Hypergerus atriceps_oriole warbler_oriwar2
+Eminia lepida_gray-capped warbler_gycwar3
+Cisticola erythrops_red-faced cisticola_refcis1
+Cisticola erythrops [erythrops Group]_red-faced cisticola (Red-faced)_refcis2
+Cisticola erythrops lepe_red-faced cisticola (Lepe)_refcis3
+Cisticola cantans_singing cisticola_sincis1
+Cisticola lateralis_whistling cisticola_whicis1
+Cisticola anonymus_chattering cisticola_chacis1
+Cisticola woosnami_trilling cisticola_tricis1
+Cisticola bulliens_bubbling cisticola_bubcis1
+Cisticola chubbi_chubb's cisticola_chucis1
+Cisticola chubbi discolor/adametzi_chubb's cisticola (Discolored)_chucis3
+Cisticola chubbi chubbi/marungensis_chubb's cisticola (Chubb's)_chucis4
+Cisticola hunteri_hunter's cisticola_huncis1
+Cisticola nigriloris_black-lored cisticola_bllcis1
+Cisticola bakerorum_kilombero cisticola_kilcis1
+Cisticola aberrans_rock-loving cisticola_rolcis2
+Cisticola aberrans [emini Group]_rock-loving cisticola (Rock-loving)_rolcis1
+Cisticola aberrans [aberrans Group]_rock-loving cisticola (Lazy)_rolcis3
+Cisticola bailunduensis_huambo cisticola_rolcis4
+Cisticola bodessa_boran cisticola_borcis1
+Cisticola chiniana_rattling cisticola_ratcis1
+Cisticola cinereolus_ashy cisticola_ashcis1
+Cisticola ruficeps_red-pate cisticola_repcis1
+Cisticola guinea_dorst's cisticola_dorcis1
+Cisticola rufilatus_tinkling cisticola_grycis1
+Cisticola subruficapilla_gray-backed cisticola_rehcis2
+Cisticola subruficapilla newtoni_gray-backed cisticola (Namib)_rehcis1
+Cisticola subruficapilla [subruficapilla Group]_gray-backed cisticola (Red-headed)_rehcis3
+Cisticola subruficapilla jamesi_gray-backed cisticola (Plain-breasted)_rehcis4
+Cisticola distinctus_lynes's cisticola_waicis2
+Cisticola lais_wailing cisticola_waicis1
+Cisticola restrictus_tana river cisticola_tarcis1
+Cisticola njombe_churring cisticola_chucis2
+Cisticola haematocephalus_coastal cisticola_wincis4
+Cisticola anderseni_white-tailed cisticola_whtcis1
+Cisticola luapula_luapula cisticola_wincis5
+Cisticola pipiens_chirping cisticola_chicis1
+Cisticola lugubris_ethiopian cisticola_wincis6
+Cisticola marginatus_winding cisticola_wincis3
+Cisticola marginatus/haematocephalus/luapula_winding/coastal/luapula cisticola_wincis1
+Cisticola galactotes_rufous-winged cisticola_wincis2
+Cisticola carruthersi_carruthers's cisticola_carcis1
+Cisticola tinniens_levaillant's cisticola_tincis1
+Cisticola robustus_stout cisticola_stocis1
+Cisticola robustus santae_stout cisticola (Western)_stocis2
+Cisticola robustus robustus/schraderi_stout cisticola (Stout)_stocis3
+Cisticola robustus omo_stout cisticola (Omo)_stocis4
+Cisticola robustus nuchalis/awemba_stout cisticola (Rufous-crowned)_stocis5
+Cisticola robustus angolensis_stout cisticola (Angola)_stocis6
+Cisticola natalensis_croaking cisticola_crocis1
+Cisticola fulvicapilla_piping cisticola_pipcis2
+Cisticola aberdare_aberdare cisticola_abecis1
+Cisticola angusticauda_tabora cisticola_tabcis1
+Cisticola melanurus_slender-tailed cisticola_sltcis1
+Cisticola brachypterus_siffling cisticola_sifcis1
+Cisticola rufus_rufous cisticola_rufcis1
+Cisticola troglodytes_foxy cisticola_foxcis1
+Cisticola nana_tiny cisticola_tincis3
+Cisticola juncidis_fuinha-dos-juncos_zitcis1
+Cisticola juncidis [juncidis Group]_fuinha-dos-juncos [grupo juncidis]_zitcis2
+Cisticola juncidis terrestris/uropygialis_fuinha-dos-juncos (terrestris/uropygialis)_zitcis3
+Cisticola juncidis [tinnabulans Group]_fuinha-dos-juncos [grupo tinnabulans]_zitcis4
+Cisticola juncidis brunniceps_fuinha-dos-juncos (brunniceps)_zitcis5
+Cisticola haesitatus_socotra cisticola_soccis1
+Cisticola cherina_madagascar cisticola_madcis2
+Cisticola aridulus_desert cisticola_descis1
+Cisticola textrix_cloud cisticola_clocis1
+Cisticola textrix [major Group]_cloud cisticola (Cloud)_clocis2
+Cisticola textrix textrix_cloud cisticola (Cape)_clocis3
+Cisticola eximius_black-backed cisticola_blncis1
+Cisticola eximius winneba_black-backed cisticola (winneba)_bkncis1
+Cisticola eximius eximius/occidens_black-backed cisticola (Black-backed)_bkncis2
+Cisticola dambo_dambo cisticola_clscis1
+Cisticola [undescribed form]_teke cisticola (undescribed form)_tekcis1
+Cisticola brunnescens_pectoral-patch cisticola_pepcis1
+Cisticola brunnescens lynesi/mbangensis_pectoral-patch cisticola (Lynes's)_pepcis2
+Cisticola brunnescens [brunnescens Group]_pectoral-patch cisticola (Pectoral-patch)_pepcis3
+Cisticola cinnamomeus_pale-crowned cisticola_paccis1
+Cisticola ayresii_wing-snapping cisticola_wiscis1
+Cisticola ayresii gabun_wing-snapping cisticola (Gabon)_wiscis2
+Cisticola ayresii [ayresii Group]_wing-snapping cisticola (Wing-snapping)_wiscis3
+Cisticola exilis_fuinha-de-cabeça-dourada_gohcis1
+Cisticola juncidis/exilis_fuinha-dos-juncos/fuinha-de-cabeça-dourada_y01127
+Cisticola sp._fuinha (Cisticola) sp._cistic1
+Graueria vittata_grauer's warbler_grawar1
+Nesillas aldabrana_aldabra brush-warbler_albwar1
+Nesillas typica_malagasy brush-warbler_malbrw1
+Nesillas typica longicaudata_malagasy brush-warbler (Anjouan)_anbwar1
+Nesillas typica [typica Group]_malagasy brush-warbler (Malagasy)_madbrw1
+Nesillas lantzii_subdesert brush-warbler_subbrw1
+Nesillas brevicaudata_grande comore brush-warbler_gcbwar1
+Nesillas mariae_moheli brush-warbler_mohbrw1
+Calamonastides gracilirostris_papyrus yellow-warbler_paywar1
+Calamonastides gracilirostris gracilirostris_papyrus yellow-warbler (Papyrus)_papyew1
+Calamonastides gracilirostris bensoni_papyrus yellow-warbler (Zambian)_papyew2
+Arundinax aedon_felosa-de-bico-grosso_thbwar1
+Iduna caligata_felosa-calçada-do-norte_boowar1
+Iduna rama_felosa-calçada-do-sul_sykwar2
+Iduna caligata/rama_felosa-calçada-do-norte/felosa-calçada-do-sul_y00643
+Iduna pallida_felosa-pálida-oriental_eaowar1
+Iduna opaca_felosa-pálida-ocidental_weowar1
+Iduna pallida/opaca_felosa-pálida-oriental/felosa-pálida-ocidental_y00623
+Iduna natalensis_african yellow-warbler_afywar1
+Iduna similis_mountain yellow-warbler_moywar1
+Iduna sp._Iduna sp._iduna1
+Hippolais languida_felosa-de-upcher_upcwar1
+Hippolais olivetorum_felosa-das-oliveiras_oltwar1
+Hippolais polyglotta_felosa-poliglota_melwar1
+Hippolais icterina_felosa-icterina_ictwar1
+Hippolais polyglotta/icterina_felosa-poliglota/felosa-icterina_y00644
+Hippolais sp._felosa (Hippolais) sp._hippol1
+Acrocephalus paludicola_felosa-aquática_aquwar1
+Acrocephalus bistrigiceps_black-browed reed warbler_bbrwar1
+Acrocephalus sorghophilus_streaked reed warbler_strwar1
+Acrocephalus melanopogon_felosa-real_mouwar1
+Acrocephalus schoenobaenus_felosa-dos-juncos_sedwar1
+Acrocephalus agricola_felosa-agrícola_padwar1
+Acrocephalus concinens_blunt-winged warbler_blwwar1
+Acrocephalus tangorum_manchurian reed warbler_manrew1
+Acrocephalus bistrigiceps/tangorum_black-browed/manchurian reed warbler_y00418
+Acrocephalus concinens/tangorum_blunt-winged/manchurian reed warbler_y00419
+Acrocephalus dumetorum_felosa-das-moitas_blrwar1
+Acrocephalus agricola/dumetorum_felosa-agrícola/felosa-das-moitas_y00751
+Acrocephalus orinus_large-billed reed warbler_labrew1
+Acrocephalus dumetorum/orinus_blyth's/large-billed reed warbler_y01250
+Acrocephalus agricola/concinens/dumetorum/orinus_paddyfield/blunt-winged/blyth's/large-billed reed warbler_y00420
+Acrocephalus palustris_felosa-palustre_marwar3
+Acrocephalus scirpaceus_rouxinol-pequeno-dos-caniços_eurwar1
+Acrocephalus scirpaceus scirpaceus_rouxinol-pequeno-dos-caniços (scirpaceus)_eurrew1
+Acrocephalus scirpaceus fuscus_rouxinol-pequeno-dos-caniços (fuscus)_eurrew2
+Acrocephalus scirpaceus avicenniae_rouxinol-pequeno-dos-caniços (avicenniae)_afrrew2
+Acrocephalus scirpaceus ammon_rouxinol-pequeno-dos-caniços (ammon)_eurwar3
+Acrocephalus scirpaceus [baeticatus Group]_rouxinol-pequeno-dos-caniços [grupo baeticatus]_afrwar1
+Acrocephalus palustris/scirpaceus_felosa-aquática/rouxinol-pequeno-dos-caniços_y01046
+Acrocephalus griseldis_rouxinol-grande-do-iraque_barwar2
+Acrocephalus gracilirostris_lesser swamp warbler_leswar1
+Acrocephalus rufescens_greater swamp warbler_grswar2
+Acrocephalus brevipennis_tchota-cana_cvswar1
+Acrocephalus newtoni_madagascar swamp warbler_maswar1
+Acrocephalus rodericanus_rodrigues warbler_rodbrw1
+Acrocephalus sechellensis_seychelles warbler_sebwar1
+Acrocephalus arundinaceus_rouxinol-grande-dos-caniços_grrwar1
+Acrocephalus scirpaceus/arundinaceus_rouxinol-pequeno-dos-caniços/rouxinol-grande-dos-caniços_y00667
+Acrocephalus orientalis_rouxinol-grande-oriental_orrwar1
+Acrocephalus stentoreus_felosa-ruidosa_clrwar1
+Acrocephalus stentoreus stentoreus/levantinus_felosa-ruidosa (stentoreus/levantinus)_clarew3
+Acrocephalus stentoreus [brunnescens Group]_felosa-ruidosa [grupo brunnescens]_clarew2
+Acrocephalus arundinaceus/orientalis/stentoreus_rouxinol-grande-dos-caniços/rouxinol-grande-oriental_y00996
+Acrocephalus luscinius_nightingale reed warbler_nigrew1
+Acrocephalus hiwae_saipan reed warbler_sairew1
+Acrocephalus australis_australian reed warbler_aurwar1
+Acrocephalus syrinx_caroline reed warbler_carrew1
+Acrocephalus nijoi_aguiguan reed warbler_agurew1
+Acrocephalus aequinoctialis_kiritimati reed warbler_chiwar1
+Acrocephalus mendanae_southern marquesan reed warbler_marwar2
+Acrocephalus yamashinae_pagan reed warbler_pagrew1
+Acrocephalus rehsei_nauru reed warbler_narwar1
+Acrocephalus familiaris_millerbird_miller
+Acrocephalus familiaris kingi_millerbird (Nihoa)_miller1
+Acrocephalus familiaris familiaris_millerbird (Laysan)_miller2
+Acrocephalus vaughani_pitcairn reed warbler_pirwar2
+Acrocephalus taiti_henderson island reed warbler_hirwar1
+Acrocephalus kerearako_cook islands reed warbler_cirwar2
+Acrocephalus rimitarae_rimatara reed warbler_rimrew1
+Acrocephalus musae_society islands reed warbler_soirew1
+Acrocephalus caffer_tahiti reed warbler_tahrew1
+Acrocephalus longirostris_moorea reed warbler_moorew1
+Acrocephalus percernis_northern marquesan reed warbler_marrew2
+Acrocephalus atyphus_tuamotu reed warbler_turwar1
+Acrocephalus astrolabii_mangareva reed warbler_manrew2
+Acrocephalus sp._felosa (Acrocephalus) sp._acroce1
+Iduna/Hippolais/Acrocephalus sp._Iduna/Hippolais/Acrocephalus sp._y00908
+Robsonius rabori_cordillera ground-warbler_luzwrb1
+Robsonius thompsoni_sierra madre ground-warbler_simgrw1
+Robsonius sorsogonensis_bicol ground-warbler_gybbab2
+Helopsaltes fasciolatus_cigarrinha-de-gray_grgwar1
+Helopsaltes amnicola_sakhalin grasshopper warbler_sakwar1
+Helopsaltes fasciolatus/amnicola_gray's/sakhalin grasshopper warbler_y00997
+Helopsaltes pryeri_marsh grassbird_margra1
+Helopsaltes certhiola_cigarrinha-de-pallas_pagwar1
+Helopsaltes ochotensis_middendorff's grasshopper warbler_migwar
+Helopsaltes pleskei_pleske's grasshopper warbler_plewar1
+Helopsaltes ochotensis/pleskei_middendorff's/pleske's grasshopper warbler_y01100
+Helopsaltes sp._Cigarrinha (Helopsaltes) sp._helops1
+Locustella lanceolata_cigarrinha-lanceolada_lanwar
+Locustella alfredi_bamboo warbler_baswar1
+Locustella fluviatilis_cigarrinha-ribeirinha_eurwar2
+Locustella luscinioides_cigarrinha-ruiva_savwar1
+Locustella fluviatilis/luscinioides_river/savi's warbler_y01185
+Locustella luteoventris_brown bush warbler_brbwar2
+Locustella naevia_cigarrinha-malhada_cogwar1
+Locustella lanceolata/naevia_lanceolated/common grasshopper warbler_y01186
+Locustella major_long-billed bush warbler_lbbwar1
+Locustella tacsanowskia_chinese bush warbler_chbwar1
+Locustella accentor_friendly bush warbler_frbwar1
+Locustella caudata_long-tailed bush warbler_ltbwar1
+Locustella castanea_sulawesi bush warbler_cbbwar2
+Locustella musculus_seram bush warbler_cbbwar4
+Locustella portenta_taliabu bush warbler_talgrw1
+Locustella disturbans_buru bush warbler_cbbwar3
+Locustella davidi_baikal bush warbler_spobuw1
+Locustella tacsanowskia/davidi_chinese/baikal bush warbler_y00998
+Locustella kashmirensis_west himalayan bush warbler_spobuw2
+Locustella thoracica_spotted bush warbler_spobuw3
+Locustella davidi/thoracica_baikal/spotted bush warbler_y00999
+Locustella alishanensis_taiwan bush warbler_taibuw1
+Locustella mandelli_russet bush warbler_rubwar1
+Locustella idonea_dalat bush warbler_dabwar1
+Locustella luteoventris/mandelli_brown/russet bush warbler_y01000
+Locustella chengi_sichuan bush warbler_sicbuw1
+Locustella montis_javan bush warbler_jabwar1
+Locustella montis montis_javan bush warbler (Javan)_javbuw1
+Locustella montis timorensis_javan bush warbler (Timor)_timbuw1
+Locustella seebohmi_benguet bush warbler_benbuw1
+Locustella sp._Cigarrinha (Locustella) sp._locust6
+Helopsaltes/Locustella sp._cigarrinha sp._locust2
+Poodytes albolimbatus_fly river grassbird_flrgra1
+Poodytes carteri_spinifexbird_spibir1
+Poodytes gramineus_little grassbird_litgra1
+Poodytes punctatus_new zealand fernbird_fernbi1
+Poodytes punctatus [punctatus Group]_new zealand fernbird (New Zealand)_fernbi2
+Poodytes punctatus caudatus_new zealand fernbird (Snares)_fernbi3
+Poodytes rufescens_chatham islands fernbird_chifer1
+Malia grata_malia_malia1
+Cincloramphus cruralis_brown songlark_broson1
+Cincloramphus grosvenori_bismarck thicketbird_bisthi1
+Cincloramphus rubiginosus_rusty thicketbird_rusthi1
+Cincloramphus bivittatus_pássaro-da-erva-de-timor_bubbus1
+Cincloramphus mathewsi_rufous songlark_rufson1
+Cincloramphus timoriensis_tawny grassbird_tawgra3
+Cincloramphus macrurus_papuan grassbird_tawgra2
+Cincloramphus macrurus interscapularis/mayri_papuan grassbird (interscapularis/mayri)_papgra1
+Cincloramphus macrurus [macrurus Group]_papuan grassbird (macrurus Group)_papgra2
+Cincloramphus timoriensis/macrurus_tawny/papuan grassbird_tawgra1
+Cincloramphus whitneyi_santo thicketbird_guathi2
+Cincloramphus turipavae_guadalcanal thicketbird_guathi1
+Cincloramphus mariae_new caledonian grassbird_necgra1
+Cincloramphus rufus_long-legged thicketbird_lolwar1
+Cincloramphus llaneae_bougainville thicketbird_bouthi1
+Elaphrornis palliseri_sri lanka bush warbler_ceybuw1
+Schoenicola platyurus_broad-tailed grassbird_brtgra2
+Schoenicola striatus_bristled grassbird_brigra2
+Catriscus brevirostris_fan-tailed grassbird_fatgra1
+Megalurus palustris_striated grassbird_strgra1
+Poodytes/Cincloramphus/Megalurus sp._Poodytes/Cincloramphus/Megalurus sp._megalu1
+Bradypterus sylvaticus_knysna warbler_knswar1
+Bradypterus bangwaensis_bangwa warbler_banscw1
+Bradypterus barratti_barratt's warbler_afswar1
+Bradypterus lopezi_evergreen-forest warbler_camscw1
+Bradypterus lopezi [lopezi Group]_evergreen-forest warbler (Lopez's)_evfwar1
+Bradypterus lopezi barakae_evergreen-forest warbler (Volcanic)_evfwar2
+Bradypterus lopezi boultoni_evergreen-forest warbler (Boulton's)_evfwar3
+Bradypterus lopezi [mariae Group]_evergreen-forest warbler (Eastern)_evfwar4
+Bradypterus cinnamomeus_cinnamon bracken-warbler_cibwar1
+Bradypterus seebohmi_gray emutail_gryemt1
+Bradypterus brunneus_brown emutail_bretai1
+Bradypterus grandis_dja river swamp warbler_jrswar1
+Bradypterus baboecala_little rush warbler_afbwar1
+Bradypterus carpalis_white-winged swamp warbler_wwswar1
+Bradypterus graueri_grauer's swamp warbler_grswar1
+Bradypterus centralis_highland rush warbler_hirwar2
+Bradypterus sp._felosa-do-mato (Bradypterus sp.)_bradyp1
+Donacobius atricapilla_japacanim_bkcdon
+Oxylabes madagascariensis_white-throated oxylabes_whtoxy1
+Bernieria madagascariensis_long-billed bernieria_lobber1
+Cryptosylvicola randrianasoloi_cryptic warbler_crywar1
+Hartertula flavoviridis_wedge-tailed jery_wetjer2
+Thamnornis chloropetoides_thamnornis_thamno2
+Crossleyia xanthophrys_madagascar yellowbrow_yeboxy1
+Crossleyia tenebrosa_dusky tetraka_dustet1
+Xanthomixis zosterops_spectacled tetraka_spetet1
+Xanthomixis apperti_appert's tetraka_apptet1
+Xanthomixis cinereiceps_gray-crowned tetraka_gyctet1
+Randia pseudozosterops_rand's warbler_ranwar1
+Pnoepyga albiventer_scaly-breasted cupwing_scbcup3
+Pnoepyga albiventer albiventer/pallidior_scaly-breasted cupwing (Himalayan)_sbwbab1
+Pnoepyga albiventer mutica_scaly-breasted cupwing (Chinese)_chicup1
+Pnoepyga formosana_taiwan cupwing_taiwrb1
+Pnoepyga immaculata_immaculate cupwing_immwrb1
+Pnoepyga albiventer/immaculata_scaly-breasted/immaculate cupwing_y00811
+Pnoepyga pusilla_tagarela-pigmeu_pywbab1
+Pnoepyga sp._cupwing sp._cupwin1
+Pseudochelidon eurystomina_african river martin_afrmar2
+Pseudochelidon sirintarae_white-eyed river martin_wermar2
+Psalidoprocne nitens_square-tailed sawwing_sqtsaw1
+Psalidoprocne fuliginosa_mountain sawwing_mousaw1
+Psalidoprocne albiceps_white-headed sawwing_whhsaw1
+Psalidoprocne albiceps albiceps_white-headed sawwing (White-headed)_whhsaw2
+Psalidoprocne albiceps suffusa_white-headed sawwing (Dusky-throated)_whhsaw3
+Psalidoprocne pristoptera_black sawwing_blksaw1
+Psalidoprocne obscura_andorinha-riça_fansaw1
+Psalidoprocne sp._sawwing sp._sawwin1
+Pseudhirundo griseopyga_andorinha-rabicinza_gyrswa1
+Cheramoeca leucosterna_white-backed swallow_whbswa3
+Phedina borbonica_mascarene martin_masmar1
+Neophedina cincta_banded martin_banmar1
+Phedinopsis brazzae_brazza's martin_bramar1
+Riparia paludicola_andorinha-dos-charcos_plamar1
+Riparia [undescribed form]_ethiopian martin (undescribed form)_ethmar1
+Riparia cowani_andorinha-dos-charcos-de-madagáscar_plamar3
+Riparia paludicola/cowani_plain/madagascar martin_y01251
+Riparia chinensis_gray-throated martin_gytmar1
+Riparia congica_congo martin_conmar1
+Riparia riparia_andorinha-do-barranco_banswa
+Riparia chinensis/riparia_gray-throated martin/bank swallow_y01086
+Riparia diluta_pale martin_pasmar1
+Riparia riparia/diluta_bank swallow/pale martin_y00808
+Riparia sp._andorinha (Riparia) sp._ripari1
+Tachycineta bicolor_andorinha-das-árvores_treswa
+Tachycineta stolzmanni_tumbes swallow_tumswa1
+Tachycineta albiventer_andorinha-do-rio_whwswa1
+Tachycineta leucorrhoa_andorinha-de-sobre-branco_whrswa1
+Tachycineta leucopyga_andorinha-chilena_chiswa1
+Tachycineta leucorrhoa/leucopyga_andorinha-de-sobre-branco/andorinha-chilena_y00702
+Tachycineta albilinea_mangrove swallow_manswa1
+Tachycineta euchrysea_golden swallow_golswa1
+Tachycineta thalassina_violet-green swallow_vigswa
+Tachycineta bicolor x thalassina_tree x violet-green swallow (hybrid)_x00716
+Tachycineta bicolor/thalassina_tree/violet-green swallow_y00701
+Tachycineta cyaneoviridis_bahama swallow_bahswa
+Tachycineta sp._Tachycineta sp._tachyc1
+Progne subis_andorinha-azul_purmar
+Progne subis subis/arboricola_andorinha-azul (subis/arboricola)_purmar1
+Progne subis hesperia_andorinha-azul (hesperia)_purmar2
+Progne cryptoleuca_cuban martin_cubmar
+Progne subis/cryptoleuca_purple/cuban martin_y00805
+Progne dominicensis_andorinha-do-caribe_carmar1
+Progne cryptoleuca x dominicensis_cuban x caribbean martin (hybrid)_y01264
+Progne sinaloae_sinaloa martin_sinmar1
+Progne dominicensis/sinaloae_caribbean/sinaloa martin_y00806
+Progne cryptoleuca/dominicensis/sinaloae_cuban/caribbean/sinaloa martin (Snowy-bellied Martin)_y00807
+Progne chalybea_andorinha-grande_gybmar
+Progne elegans_andorinha-do-sul_soumar
+Progne subis/elegans_andorinha-azul/andorinha-do-sul_y00745
+Progne chalybea/elegans_andorinha-grande/andorinha-do-sul_y00421
+Progne murphyi_peruvian martin_permar1
+Progne modesta_galapagos martin_galmar1
+Progne tapera_andorinha-do-campo_brcmar1
+Progne tapera tapera_andorinha-do-campo (tapera)_bncmar1
+Progne tapera fusca_andorinha-do-campo (fusca)_bncmar2
+Progne sp._Progne sp._martin1
+Stelgidopteryx serripennis_northern rough-winged swallow_nrwswa
+Stelgidopteryx serripennis [serripennis Group]_northern rough-winged swallow (Northern)_nrwswa1
+Stelgidopteryx serripennis ridgwayi/stuarti_northern rough-winged swallow (Ridgway's)_nrwswa2
+Tachycineta thalassina x Stelgidopteryx serripennis_violet-green x northern rough-winged swallow (hybrid)_x00715
+Stelgidopteryx ruficollis_andorinha-serradora_srwswa1
+Stelgidopteryx serripennis/ruficollis_northern/southern rough-winged swallow_y00899
+Atticora pileata_black-capped swallow_blcswa1
+Atticora tibialis_calcinha-branca_whtswa1
+Atticora fasciata_peitoril_whbswa2
+Pygochelidon cyanoleuca_andorinha-pequena-de-casa_bawswa1
+Pygochelidon cyanoleuca cyanoleuca_andorinha-pequena-de-casa (cyanoleuca)_bawswa3
+Pygochelidon cyanoleuca peruviana_andorinha-pequena-de-casa (peruviana)_bawswa5
+Pygochelidon cyanoleuca patagonica_andorinha-pequena-de-casa (patagonica)_bawswa4
+Pygochelidon melanoleuca_andorinha-de-coleira_blcswa2
+Alopochelidon fucata_andorinha-morena_tahswa2
+Orochelidon flavipes_pale-footed swallow_pafswa1
+Orochelidon murina_brown-bellied swallow_brbswa1
+Orochelidon andecola_andean swallow_andswa2
+Ptyonoprogne rupestris_andorinha-das-rochas_eurcrm1
+Ptyonoprogne obsoleta_pale crag-martin_rocmar1
+Ptyonoprogne rupestris/obsoleta_eurasian/pale crag-martin_y00981
+Ptyonoprogne rufigula_red-throated crag-martin_rocmar4
+Ptyonoprogne obsoleta/rufigula_pale/red-throated crag-martin_y01282
+Ptyonoprogne fuligula_andorinha-das-rochas-africana_rocmar5
+Ptyonoprogne rufigula/fuligula_red-throated/southern crag-martin_y01283
+Ptyonoprogne concolor_dusky crag-martin_duscrm1
+Ptyonoprogne rupestris/concolor_eurasian/dusky crag-martin_y00422
+Ptyonoprogne sp._Ptyonoprogne sp._ptyono1
+Hirundo atrocaerulea_montane blue swallow_bluswa1
+Hirundo nigrorufa_black-and-rufous swallow_barswa1
+Hirundo sp._Hirundo sp._hirund3
+Hirundo dimidiata_pearl-breasted swallow_pebswa1
+Hirundo domicola_hill swallow_pacswa3
+Hirundo javanica_andorinha-do-pacífico_pacswa1
+Hirundo tahitica_tahiti swallow_pacswa5
+Hirundo leucosoma_pied-winged swallow_piwswa1
+Hirundo megaensis_white-tailed swallow_whtswa2
+Hirundo neoxena_welcome swallow_welswa1
+Hirundo rustica_andorinha-de-bando_barswa
+Hirundo rustica rustica_andorinha-de-bando (rustica)_barswa2
+Hirundo rustica savignii_andorinha-de-bando (savignii)_barswa6
+Hirundo rustica transitiva_andorinha-de-bando (transitiva)_barswa7
+Hirundo rustica tytleri_andorinha-de-bando (tytleri)_barswa8
+Hirundo rustica gutturalis/mandschurica_andorinha-de-bando (gutturalis/mandschurica)_barswa4
+Hirundo rustica erythrogaster_andorinha-de-bando (erythrogaster)_barswa5
+Tachycineta bicolor x Hirundo rustica_andorinha-das-árvores x andorinha-das-chaminés (híbrido)_x00666
+Riparia riparia x Hirundo rustica_andorinha-das-barreiras x andorinha-das-chaminés (híbrido)_x00710
+Hirundo javanica/rustica_andorinha-das-chaminés/andorinha-do-pacífico_y00746
+Hirundo lucida_andorinha-da-guiné_recswa1
+Hirundo aethiopica_andorinha-da-etiópia_ethswa1
+Hirundo angolensis_angola swallow_angswa1
+Hirundo nigrita_white-throated blue swallow_wtbswa1
+Hirundo albigularis_white-throated swallow_whtswa3
+Hirundo smithii_andorinha-rabijunca_witswa1
+Atronanus fuliginosus_forest swallow_forswa2
+Psalidoprocne nitens/Atronanus fuliginosus_square-tailed sawwing/forest swallow_y00901
+Delichon urbicum_andorinha-dos-beirais-ocidental_comhom1
+Hirundo rustica x Delichon urbicum_andorinha-das-chaminés x andorinha-dos-beirais (híbrido)_x00659
+Delichon lagopodum_andorinha-dos-beirais-oriental_comhom2
+Delichon urbicum/lagopodum_andorinha-dos-beirais-ocidental/andorinha-dos-beirais-oriental_cohmar1
+Delichon dasypus_asian house-martin_ashmar1
+Delichon lagopodum/dasypus_siberian/asian house-martin_y00649
+Delichon nipalense_nepal house-martin_nephom1
+Delichon sp._house-martin sp._housem1
+Cecropis cucullata_greater striped swallow_grests1
+Cecropis rufula_andorinha-dáurica-ocidental_rerswa8
+Hirundo rustica x Cecropis rufula_andorinha-das-chaminés x andorinha-dáurica-ocidental (híbrido)_x00658
+Cecropis melanocrissus_african red-rumped swallow_rerswa12
+Cecropis melanocrissus domicella_african red-rumped swallow (domicella)_rerswa3
+Cecropis melanocrissus [melanocrissus Group]_african red-rumped swallow (melanocrissus Group)_rerswa13
+Cecropis rufula/melanocrissus_european/african red-rumped swallow_y01284
+Cecropis daurica_andorinha-dáurica-oriental_y00621
+Cecropis daurica [daurica Group]_andorinha-dáurica-oriental [grupo daurica]_errswa1
+Cecropis daurica [striolata Group]_andorinha-dáurica-oriental [grupo striolata]_strswa2
+Cecropis rufula/daurica_andorinha-dáurica-ocidental/andorinha-dáurica-oriental_y01285
+Cecropis rufula/melanocrissus/daurica_european/african/eastern red-rumped swallow_rerswa1
+Cecropis hyperythra_sri lanka swallow_srlswa1
+Cecropis badia_rufous-bellied swallow_rubswa1
+Cecropis abyssinica_lesser striped swallow_lessts1
+Cecropis cucullata/abyssinica_greater/lesser striped swallow_y01182
+Cecropis semirufa_andorinha-de-peito-ruivo_rucswa2
+Cecropis senegalensis_andorinha-do-senegal_mosswa2
+Cecropis sp._Cecropis sp._cecrop1
+Petrochelidon rufigula_red-throated swallow_retswa2
+Petrochelidon preussi_andorinha-das-rochas-de-preuss_preswa2
+Petrochelidon perdita_red sea swallow_resswa2
+Petrochelidon spilodera_south african swallow_soaswa2
+Petrochelidon fluvicola_streak-throated swallow_sttswa2
+Petrochelidon ariel_andorinha-ariel_faimar2
+Petrochelidon nigricans_andorinha-das-árvores-australiana_tremar2
+Petrochelidon ariel/nigricans_andorinha-ariel/andorinha-das-árvores-australiana_y00900
+Petrochelidon pyrrhonota_andorinha-de-dorso-acanelado_cliswa
+Petrochelidon pyrrhonota [pyrrhonota Group]_andorinha-de-dorso-acanelado [grupo pyrrhonota]_cliswa2
+Petrochelidon pyrrhonota melanogaster_andorinha-de-dorso-acanelado (melanogaster)_cliswa3
+Hirundo rustica x Petrochelidon pyrrhonota_andorinha-de-bando x andorinha-de-dorso-acanelado (híbrido)_x00717
+Tachycineta thalassina x Petrochelidon pyrrhonota_violet-green x cliff swallow (hybrid)_x00661
+Petrochelidon fulva_cave swallow_cavswa
+Petrochelidon fulva [fulva Group]_cave swallow (Caribbean)_cavswa2
+Petrochelidon fulva pallida_cave swallow (Texas)_cavswa3
+Petrochelidon fulva citata_cave swallow (Yucatan)_cavswa4
+Hirundo rustica x Petrochelidon fulva_barn x cave swallow (hybrid)_x00660
+Petrochelidon pyrrhonota x fulva_cliff x cave swallow (hybrid)_x00892
+Petrochelidon pyrrhonota/fulva_cliff/cave swallow_y00604
+Petrochelidon rufocollaris_chestnut-collared swallow_chcswa2
+Petrochelidon pyrrhonota/rufocollaris_cliff/chestnut-collared swallow_y00809
+Petrochelidon sp._Petrochelidon sp._petroc1
+Hirundinidae sp._andorinha (hirundinídeo) sp._swallo
+Andropadus importunus_sombre greenbul_somgre1
+Stelgidillas gracilirostris_slender-billed greenbul_slbgre1
+Calyptocichla serinus_golden greenbul_golgre1
+Neolestes torquatus_black-collared bulbul_blcbul1
+Bleda syndactylus_red-tailed bristlebill_combri2
+Bleda eximius_green-tailed bristlebill_gntbri1
+Bleda notatus_yellow-lored bristlebill_lesbri1
+Bleda ugandae_yellow-eyed bristlebill_lesbri3
+Bleda canicapillus_tuta-cabeça-vermelha_gyhbri1
+Bleda sp._bristlebill sp._bristl1
+Atimastillas flavicollis_yellow-gorgeted greenbul_yetgre2
+Atimastillas flavigula_pale-throated greenbul_patgre1
+Atimastillas flavigula soror_pale-throated greenbul (soror)_yetgre3
+Atimastillas flavigula flavigula_pale-throated greenbul (flavigula)_yetgre4
+Ixonotus guttatus_spotted greenbul_spogre1
+Thescelocichla leucopleura_palrador_swagre1
+Chlorocichla laetissima_joyful greenbul_joygre1
+Chlorocichla prigoginei_prigogine's greenbul_prigre1
+Chlorocichla falkensteini_yellow-necked greenbul_yengre1
+Chlorocichla flaviventris_yellow-bellied greenbul_yebgre1
+Chlorocichla simplex_tuta-modesta_simgre1
+Baeopogon indicator_honeyguide greenbul_hongre1
+Baeopogon clamans_sjöstedt's greenbul_sjogre1
+Arizelocichla montana_cameroon mountain greenbul_camgre2
+Arizelocichla masukuensis_shelley's greenbul_shegre1
+Arizelocichla masukuensis kakamegae/kungwensis_shelley's greenbul (Kakamega)_shebul1
+Arizelocichla masukuensis masukuensis/roehli_shelley's greenbul (Shelley's)_shegre2
+Arizelocichla tephrolaema_western mountain greenbul_wesmog1
+Arizelocichla kikuyuensis_kikuyu mountain greenbul_easmog5
+Arizelocichla nigriceps_black-headed mountain greenbul_easmog2
+Arizelocichla neumanni_uluguru mountain greenbul_easmog6
+Arizelocichla fusciceps_black-browed mountain greenbul_easmog4
+Arizelocichla striifacies_olive-headed greenbul_stfgre1
+Arizelocichla striifacies striifacies_olive-headed greenbul (Stripe-faced)_stcgre4
+Arizelocichla striifacies olivaceiceps_olive-headed greenbul (Olive-headed)_stcgre3
+Arizelocichla milanjensis_stripe-cheeked greenbul_stcgre1
+Arizelocichla chlorigula_yellow-throated mountain greenbul_easmog3
+Arizelocichla sp._Arizelocichla sp._arizel1
+Criniger barbatus_western bearded-greenbul_wesbeg1
+Criniger chloronotus_eastern bearded-greenbul_easbeg1
+Criniger calurus_tuta-de-cabelo_retgre1
+Criniger ndussumensis_white-bearded greenbul_whbgre1
+Criniger calurus/ndussumensis_red-tailed/white-bearded greenbul_y00904
+Criniger olivaceus_yellow-bearded greenbul_yebgre3
+Criniger sp._Criniger sp._crinig1
+Eurillas virens_tuta-pardinha_litgre2
+Eurillas latirostris_yellow-whiskered greenbul_yewgre1
+Eurillas curvirostris_plain greenbul_plagre2
+Eurillas curvirostris leonina_plain greenbul (leonina)_plagre1
+Eurillas curvirostris curvirostris_plain greenbul (curvirostris)_plagre3
+Eurillas gracilis_gray greenbul_grygre1
+Eurillas ansorgei_ansorge's greenbul_ansgre1
+Eurillas sp._tuta (Eurillas) sp._eurill1
+Phyllastrephus debilis_tiny greenbul_tingre1
+Phyllastrephus albigula_usambara greenbul_usabul1
+Phyllastrephus albigularis_white-throated greenbul_whtgre1
+Phyllastrephus viridiceps_angola greenbul_whtgre4
+Phyllastrephus flavostriatus_yellow-streaked greenbul_yesbul1
+Phyllastrephus flavostriatus alfredi_yellow-streaked greenbul (Sharpe's)_yesgre2
+Phyllastrephus flavostriatus [flavostriatus Group]_yellow-streaked greenbul (Yellow-streaked)_yesgre1
+Phyllastrephus xavieri_xavier's greenbul_xavgre1
+Phyllastrephus icterinus_icterine greenbul_ictgre1
+Phyllastrephus xavieri/icterinus_xavier's/icterine greenbul_y00905
+Phyllastrephus terrestris_terrestrial brownbul_terbro1
+Phyllastrephus poensis_cameroon olive-greenbul_caogre1
+Phyllastrephus strepitans_northern brownbul_norbro1
+Phyllastrephus cerviniventris_gray-olive greenbul_gyogre1
+Phyllastrephus fischeri_fischer's greenbul_fisgre1
+Phyllastrephus cabanisi_cabanis's greenbul_cabgre1
+Phyllastrephus cabanisi placidus_cabanis's greenbul (Placid)_cabgre3
+Phyllastrephus cabanisi [cabanisi Group]_cabanis's greenbul (Cabanis's)_cabgre2
+Phyllastrephus scandens_tuta-rabirruiva_leaflo1
+Phyllastrephus lorenzi_sassi's greenbul_sasgre1
+Phyllastrephus poliocephalus_gray-headed greenbul_gyhgre1
+Phyllastrephus hypochloris_toro olive-greenbul_toogre1
+Phyllastrephus baumanni_baumann's greenbul_baugre1
+Phyllastrephus fulviventris_pale-olive greenbul_paogre1
+Phyllastrephus sp._tuta (Phyllastrephus) sp._phylla1
+Pycnonotidae sp. (greenbul sp.)_tuta (Pycnonotidae) sp._greenb1
+Tricholestes criniger_hairy-backed bulbul_habbul1
+Setornis criniger_hook-billed bulbul_hobbul1
+Alophoixus phaeocephalus_yellow-bellied bulbul_yebbul2
+Alophoixus frater_gray-throated bulbul_gytbul1
+Alophoixus tephrogenys_gray-cheeked bulbul_gycbul2
+Alophoixus ruficrissus_penan bulbul_ochbul3
+Alophoixus ruficrissus ruficrissus/fowleri_penan bulbul (Penan)_penbul2
+Alophoixus ruficrissus meratusensis_penan bulbul (Meratus)_penbul1
+Alophoixus bres_brown-cheeked bulbul_gycbul3
+Alophoixus flaveolus_white-throated bulbul_whtbul1
+Alophoixus ochraceus_ochraceous bulbul_ochbul2
+Alophoixus pallidus_puff-throated bulbul_putbul1
+Alophoixus pallidus griseiceps_puff-throated bulbul (Gray-crowned)_putbul2
+Alophoixus pallidus [pallidus Group]_puff-throated bulbul (Puff-throated)_putbul3
+Alcurus striatus_striated bulbul_strbul2
+Iole finschii_finsch's bulbul_finbul1
+Iole palawanensis_sulphur-bellied bulbul_subbul1
+Iole viridescens_olive bulbul_olibul1
+Iole viridescens viridescens/lekhakuni_olive bulbul (Olive)_olibul2
+Iole viridescens cinnamomeoventris_olive bulbul (Baker's)_olibul3
+Iole crypta_buff-vented bulbul_buvbul1
+Iole viridescens/crypta_olive/buff-vented bulbul_y00423
+Iole charlottae_charlotte's bulbul_chabul1
+Iole cacharensis_cachar bulbul_cacbul1
+Iole propinqua_gray-eyed bulbul_gyebul1
+Iole propinqua [propinqua Group]_gray-eyed bulbul (Gray-eyed)_gyebul2
+Iole propinqua innectens_gray-eyed bulbul (innectens)_gyebul3
+Iole sp._Iole sp._iole1
+Hemixos flavala_ashy bulbul_ashbul1
+Hemixos flavala [flavala Group]_ashy bulbul (Ashy)_ashbul2
+Hemixos flavala remotus_ashy bulbul (Brown-backed)_ashbul6
+Hemixos cinereus_cinereous bulbul_cinbul1
+Hemixos cinereus cinereus_cinereous bulbul (Cinereous)_ashbul4
+Hemixos cinereus connectens_cinereous bulbul (Green-winged)_ashbul5
+Hemixos castanonotus_chestnut bulbul_chebul1
+Acritillas indica_yellow-browed bulbul_yebbul3
+Ixos leucogrammicus_cream-striped bulbul_crsbul1
+Ixos sumatranus_sumatran bulbul_sunbul1
+Ixos virescens_javan bulbul_sunbul3
+Ixos malaccensis_streaked bulbul_strbul1
+Ixos mcclellandii_mountain bulbul_moubul2
+Hypsipetes nicobariensis_nicobar bulbul_nicbul2
+Hypsipetes philippinus_philippine bulbul_phibul1
+Hypsipetes mindorensis_mindoro bulbul_minbul1
+Hypsipetes siquijorensis_streak-breasted bulbul_stbbul1
+Hypsipetes siquijorensis cinereiceps_streak-breasted bulbul (Tablas)_stbbul2
+Hypsipetes siquijorensis monticola_streak-breasted bulbul (Cebu)_stbbul3
+Hypsipetes siquijorensis siquijorensis_streak-breasted bulbul (Siquijor)_stbbul4
+Hypsipetes affinis_seram golden-bulbul_golbul3
+Hypsipetes affinis affinis_seram golden-bulbul (Seram)_sergob1
+Hypsipetes affinis flavicaudus_seram golden-bulbul (Ambon)_sergob2
+Hypsipetes platenae_sangihe golden-bulbul_sangob1
+Hypsipetes aureus_togian golden-bulbul_toggob1
+Hypsipetes harterti_banggai golden-bulbul_sulgob2
+Hypsipetes longirostris_sula golden-bulbul_sulgob3
+Hypsipetes chloris_halmahera golden-bulbul_halgob1
+Hypsipetes lucasi_obi golden-bulbul_obigob1
+Hypsipetes mysticalis_buru golden-bulbul_golbul4
+Hypsipetes guimarasensis_visayan bulbul_visbul1
+Hypsipetes everetti_yellowish bulbul_yelbul1
+Hypsipetes everetti everetti_yellowish bulbul (Yellowish)_yelbul2
+Hypsipetes everetti haynaldi_yellowish bulbul (Sulu)_yelbul3
+Hypsipetes catarmanensis_camiguin bulbul_yelbul4
+Hypsipetes rufigularis_zamboanga bulbul_zambul1
+Hypsipetes amaurotis_brown-eared bulbul_brebul1
+Hypsipetes borbonicus_reunion bulbul_reubul1
+Hypsipetes madagascariensis_malagasy bulbul_madbul1
+Hypsipetes olivaceus_mauritius bulbul_maubul1
+Hypsipetes thompsoni_white-headed bulbul_whhbul1
+Hypsipetes leucocephalus_black bulbul_blabul1
+Hypsipetes leucocephalus [psaroides Group]_black bulbul (psaroides Group)_blkbul1
+Hypsipetes leucocephalus sinensis/ambiens_black bulbul (Black)_blkbul2
+Hypsipetes leucocephalus [leucocephalus Group]_black bulbul (leucocephalus Group)_blkbul3
+Hypsipetes leucocephalus perniger_black bulbul (perniger)_blkbul4
+Hypsipetes leucocephalus nigerrimus_black bulbul (Gray-winged)_blkbul5
+Hypsipetes ganeesa_square-tailed bulbul_sqtbul1
+Hypsipetes ganeesa ganeesa_square-tailed bulbul (Indian)_sqtbul2
+Hypsipetes ganeesa humii_square-tailed bulbul (Sri Lanka)_sqtbul3
+Hypsipetes parvirostris_grande comore bulbul_combul1
+Hypsipetes moheliensis_moheli bulbul_mohbul1
+Hypsipetes crassirostris_seychelles bulbul_seybul1
+Microtarsus eutilotus_puff-backed bulbul_pubbul1
+Microtarsus melanoleucos_black-and-white bulbul_bawbul2
+Microtarsus urostictus_yellow-wattled bulbul_yewbul1
+Microtarsus priocephalus_gray-headed bulbul_gyhbul1
+Microtarsus melanocephalos_black-headed bulbul_blhbul1
+Microtarsus fuscoflavescens_andaman bulbul_andbul1
+Microtarsus nieuwenhuisii_blue-wattled bulbul_blwbul1
+Rubigula erythropthalmos_spectacled bulbul_spebul1
+Rubigula cyaniventris_gray-bellied bulbul_gybbul1
+Rubigula squamata_scaly-breasted bulbul_scbbul1
+Rubigula flaviventris_black-crested bulbul_blcbul2
+Rubigula gularis_flame-throated bulbul_bkcbul1
+Rubigula melanictera_black-capped bulbul_bkcbul2
+Rubigula dispar_ruby-throated bulbul_bkcbul3
+Rubigula dispar dispar_ruby-throated bulbul (Yellow-eyed)_rutbul1
+Rubigula dispar matamerah_ruby-throated bulbul (Red-eyed)_rutbul2
+Rubigula montis_bornean bulbul_bkcbul4
+Nok hualon_bare-faced bulbul_bafbul1
+Spizixos canifrons_crested finchbill_crefin1
+Spizixos semitorques_collared finchbill_colfin1
+Pycnonotus tympanistrigus_spot-necked bulbul_spnbul1
+Pycnonotus simplex_cream-vented bulbul_crvbul1
+Pycnonotus simplex simplex/halizonus_cream-vented bulbul (White-eyed)_crvbul2
+Pycnonotus simplex prillwitzi/perplexus_cream-vented bulbul (Red-eyed)_crvbul3
+Pycnonotus plumosus_olive-winged bulbul_olwbul1
+Pycnonotus plumosus [plumosus Group]_olive-winged bulbul (Olive-winged)_olwbul9
+Pycnonotus plumosus porphyreus_olive-winged bulbul (Barusan)_olwbul3
+Pycnonotus brunneus_red-eyed bulbul_reebul1
+Pycnonotus zeylanicus_straw-headed bulbul_sthbul1
+Pycnonotus pseudosimplex_cream-eyed bulbul_crebul1
+Pycnonotus simplex/pseudosimplex_cream-vented/cream-eyed bulbul_y01151
+Pycnonotus cinereifrons_ashy-fronted bulbul_asfbul1
+Pycnonotus luteolus_white-browed bulbul_whbbul2
+Pycnonotus blanfordi_ayeyarwady bulbul_ayebul1
+Pycnonotus conradi_streak-eared bulbul_stebul2
+Pycnonotus davisoni_pale-eyed bulbul_sttbul2
+Pycnonotus finlaysoni_stripe-throated bulbul_sttbul3
+Pycnonotus plumosus/finlaysoni_olive-winged/stripe-throated bulbul_y01196
+Pycnonotus davisoni/finlaysoni_pale-eyed/stripe-throated bulbul_sttbul1
+Pycnonotus flavescens_flavescent bulbul_flabul1
+Pycnonotus snouckaerti_aceh bulbul_orsbul2
+Pycnonotus bimaculatus_orange-spotted bulbul_orsbul3
+Pycnonotus snouckaerti/bimaculatus_aceh/orange-spotted bulbul_orsbul1
+Pycnonotus leucops_pale-faced bulbul_flabul3
+Pycnonotus xantholaemus_yellow-throated bulbul_yetbul1
+Pycnonotus penicillatus_yellow-eared bulbul_yeebul1
+Pycnonotus xanthorrhous_brown-breasted bulbul_brbbul1
+Pycnonotus sinensis_light-vented bulbul_livbul1
+Pycnonotus sinensis sinensis_light-vented bulbul (sinensis)_livbul2
+Pycnonotus sinensis hainanus_light-vented bulbul (hainanus)_livbul3
+Pycnonotus sinensis formosae/orii_light-vented bulbul (formosae/orii)_livbul4
+Pycnonotus taivanus_styan's bulbul_stybul1
+Pycnonotus sinensis x taivanus_light-vented x styan's bulbul (hybrid)_x00744
+Pycnonotus sinensis/taivanus_light-vented/styan's bulbul_y00987
+Pycnonotus barbatus_engole-malagueta_combul2
+Pycnonotus barbatus [barbatus Group]_engole-malagueta [grupo barbatus]_combul3
+Pycnonotus barbatus somaliensis_engole-malagueta (somaliensis)_combul5
+Pycnonotus barbatus dodsoni_engole-malagueta (dodsoni)_combul4
+Pycnonotus barbatus [tricolor Group]_engole-malagueta [grupo tricolor]_combul6
+Pycnonotus jocosus_red-whiskered bulbul_rewbul
+Pycnonotus goiavier_yellow-vented bulbul_yevbul1
+Pycnonotus goiavier [analis Group]_yellow-vented bulbul (Sunda)_yevbul9
+Pycnonotus goiavier [goiavier Group]_yellow-vented bulbul (Philippine)_yevbul10
+Pycnonotus cafer_red-vented bulbul_revbul
+Pycnonotus jocosus x cafer_red-whiskered x red-vented bulbul (hybrid)_x01024
+Pycnonotus jocosus/cafer_red-whiskered/red-vented bulbul_y00810
+Pycnonotus aurigaster_bulbul-de-barrete-preto_sohbul1
+Pycnonotus cafer x aurigaster_red-vented x sooty-headed bulbul (hybrid)_x00967
+Pycnonotus leucotis_tuta-de-faces-brancas_whebul1
+Pycnonotus cafer x leucotis_red-vented x white-eared bulbul (hybrid)_x01044
+Pycnonotus leucogenys_himalayan bulbul_whcbul2
+Pycnonotus xanthopygos_tuta-de-lunetas_whsbul1
+Pycnonotus nigricans_black-fronted bulbul_blfbul1
+Pycnonotus capensis_cape bulbul_capbul1
+Pycnonotus sp._Pycnonotus sp._pycnon3
+Microtarsus/Rubigula/Pycnonotus sp._Microtarsus/Rubigula/Pycnonotus sp._pycnon1
+Pycnonotidae sp._Pycnonotidae sp._pycnon2
+Phylloscopus sibilatrix_felosa-assobiadeira_woowar
+Phylloscopus bonelli_felosa-de-papo-branco_webwar1
+Phylloscopus sibilatrix x bonelli_wood x western bonelli's warbler (hybrid)_x01019
+Phylloscopus orientalis_felosa-do-levante_eabwar1
+Phylloscopus bonelli/orientalis_felosa-de-papo-branco/felosa-do-levante_y00814
+Phylloscopus maculipennis_ashy-throated warbler_astwar2
+Phylloscopus pulcher_buff-barred warbler_bubwar1
+Phylloscopus inornatus_felosa-listada_yebwar3
+Phylloscopus humei_felosa-de-hume_humwar1
+Phylloscopus humei humei_felosa-de-hume (humei)_humwar2
+Phylloscopus humei mandellii_felosa-de-hume (mandellii)_humwar3
+Phylloscopus inornatus/humei_felosa-listada/felosa-de-hume_y00641
+Phylloscopus subviridis_brooks's leaf warbler_brlwar1
+Phylloscopus yunnanensis_chinese leaf warbler_chilew1
+Phylloscopus proregulus_felosa-de-pallas_palwar5
+Phylloscopus kansuensis_gansu leaf warbler_ganlew1
+Phylloscopus chloronotus_lemon-rumped warbler_parwar1
+Phylloscopus forresti_sichuan leaf warbler_siclew1
+Phylloscopus kansuensis/forresti_gansu/sichuan leaf warbler_y01221
+Phylloscopus chloronotus/forresti_lemon-rumped/sichuan leaf warbler_y00991
+Phylloscopus tytleri_tytler's leaf warbler_tylwar1
+Phylloscopus schwarzi_felosa-de-radde_radwar1
+Phylloscopus armandii_yellow-streaked warbler_yeswar1
+Phylloscopus griseolus_sulphur-bellied warbler_subwar2
+Phylloscopus affinis_tickell's leaf warbler_y00989
+Phylloscopus affinis affinis/perflavus_tickell's leaf warbler (Tickell's)_tilwar1
+Phylloscopus affinis occisinensis_tickell's leaf warbler (Alpine)_alplew1
+Phylloscopus griseolus/affinis_sulphur-bellied/tickell's leaf warbler_y01152
+Phylloscopus fuscatus_felosa-sombria_duswar
+Phylloscopus schwarzi/fuscatus_felosa-de-radde/felosa-sombria_y00749
+Phylloscopus schwarzi/armandii/fuscatus_radde's/yellow-streaked/dusky warbler_y00990
+Phylloscopus fuligiventer_smoky warbler_smowar1
+Phylloscopus fuscatus/fuligiventer_dusky/smoky warbler_y00988
+Phylloscopus neglectus_felosa-do-irão_pllwar2
+Phylloscopus subaffinis_buff-throated warbler_butwar1
+Phylloscopus trochilus_felosa-musical_wlwwar
+Phylloscopus sindianus_felosinha-da-montanha_mouchi2
+Phylloscopus sindianus lorenzii_felosinha-do-cáucaso_mouchi1
+Phylloscopus sindianus sindianus_felosinha-da-montanha (sindianus)_mouchi5
+Phylloscopus canariensis_felosinha-das-canárias_caichi1
+Phylloscopus collybita_felosinha-comum_comchi1
+Phylloscopus collybita [collybita Group]_felosinha-comum [grupo collybita]_comchi3
+Phylloscopus collybita tristis_felosinha-triste_comchi4
+Phylloscopus trochilus x collybita_willow warbler x common chiffchaff (hybrid)_x01077
+Phylloscopus trochilus/collybita_felosa-musical/felosinha-comum_y00812
+Phylloscopus sindianus/collybita_felosinha-da-montanha/felosinha-comum_y01101
+Phylloscopus ibericus_felosinha-ibérica_ibechi2
+Phylloscopus trochilus/collybita/ibericus_felosa-musical/felosinha-comum/felosinha-ibérica_y01045
+Phylloscopus collybita/ibericus_felosinha-comum/felosinha-ibérica_y00813
+Phylloscopus cebuensis_lemon-throated leaf warbler_letwar1
+Phylloscopus olivaceus_philippine leaf warbler_phlwar1
+Phylloscopus coronatus_felosa-coroada-oriental_eacwar1
+Phylloscopus ijimae_ijima's leaf warbler_ijlwar1
+Phylloscopus umbrovirens_brown woodland-warbler_brwwar1
+Phylloscopus ruficapilla_yellow-throated woodland-warbler_yetwow1
+Phylloscopus laetus_red-faced woodland-warbler_rfwwar1
+Phylloscopus laurae_laura's woodland-warbler_lauwow1
+Phylloscopus herberti_black-capped woodland-warbler_bcwwar1
+Phylloscopus budongoensis_uganda woodland-warbler_ugawow1
+Phylloscopus intermedius_white-spectacled warbler_whswar1
+Phylloscopus poliogenys_gray-cheeked warbler_gycwar2
+Phylloscopus burkii_green-crowned warbler_goswar1
+Phylloscopus tephrocephalus_gray-crowned warbler_gycwar1
+Phylloscopus whistleri_whistler's warbler_whiwar2
+Phylloscopus burkii/whistleri_green-crowned/whistler's warbler_y00993
+Phylloscopus tephrocephalus/whistleri_gray-crowned/whistler's warbler_y00994
+Phylloscopus valentini_bianchi's warbler_biawar1
+Phylloscopus tephrocephalus/valentini_gray-crowned/bianchi's warbler_y00650
+Phylloscopus omeiensis_martens's warbler_marwar4
+Phylloscopus soror_alström's warbler_pltwar1
+Phylloscopus valentini/omeiensis/soror_bianchi's/martens's/alström's warbler_y00995
+Phylloscopus sp. (burkii complex)_phylloscopus sp. (Golden-spectacled Warbler complex)_seicer2
+Phylloscopus nitidus_felosa-verde-brilhante_grnwar1
+Phylloscopus trochiloides_felosa-verde_grewar3
+Phylloscopus trochiloides viridanus_felosa-verde (viridanus)_grewar6
+Phylloscopus trochiloides trochiloides/ludlowi_felosa-verde (trochiloides/ludlowi)_grewar5
+Phylloscopus trochiloides obscuratus_felosa-verde (obscuratus)_grewar4
+Phylloscopus nitidus/trochiloides_felosa-verde-brilhante/felosa-verde_y00642
+Phylloscopus plumbeitarsus_felosa-verde-listada_grewar2
+Phylloscopus trochiloides/plumbeitarsus_felosa-verde/felosa-verde-listada_grewar1
+Phylloscopus emeiensis_emei leaf warbler_emlwar1
+Phylloscopus magnirostris_large-billed leaf warbler_lblwar1
+Phylloscopus trochiloides/magnirostris_greenish/large-billed leaf warbler_y01088
+Phylloscopus tenellipes_pale-legged leaf warbler_pllwar1
+Phylloscopus borealoides_sakhalin leaf warbler_salwar1
+Phylloscopus tenellipes/borealoides_pale-legged/sakhalin leaf warbler_y00750
+Phylloscopus xanthodryas_felosa-do-japão_arcwar3
+Phylloscopus borealis_felosa-boreal_arcwar1
+Phylloscopus xanthodryas/borealis_felosa-do-japão/felosa-boreal_y00907
+Phylloscopus examinandus_felosa-do-cámechatca_arcwar2
+Phylloscopus borealis/examinandus_felosa-boreal/felosa-do-cámechatca_y00815
+Phylloscopus xanthodryas/borealis/examinandus_felosa-do-japão/felosa-boreal/felosa-do-cámechatca_arcwar
+Phylloscopus castaniceps_chestnut-crowned warbler_chcwar2
+Phylloscopus montis_felosa-de-peito-amarelo_yebwar2
+Phylloscopus grammiceps_sunda warbler_sunwar1
+Phylloscopus grammiceps sumatrensis_sunda warbler (Sumatran)_sunwar2
+Phylloscopus grammiceps grammiceps_sunda warbler (Javan)_sunwar3
+Phylloscopus calciatilis_limestone leaf warbler_limlew1
+Phylloscopus cantator_yellow-vented warbler_yevwar1
+Phylloscopus ricketti_sulphur-breasted warbler_subwar3
+Phylloscopus calciatilis/ricketti_limestone leaf/sulphur-breasted warbler_y00992
+Phylloscopus occipitalis_western crowned warbler_weclew1
+Phylloscopus reguloides_blyth's leaf warbler_blylew1
+Phylloscopus claudiae_claudia's leaf warbler_clalew1
+Phylloscopus goodsoni_hartert's leaf warbler_harlew1
+Phylloscopus reguloides/claudiae/goodsoni_blyth's/claudia's/hartert's leaf warbler_bllwar1
+Phylloscopus xanthoschistos_gray-hooded warbler_gyhwar2
+Phylloscopus intensior_davison's leaf warbler_davlew1
+Phylloscopus hainanus_hainan leaf warbler_halwar1
+Phylloscopus ogilviegranti_kloss's leaf warbler_klolew1
+Phylloscopus intensior/ogilviegranti_davison's/kloss's leaf warbler_wtlwar1
+Phylloscopus trivirgatus_mountain leaf warbler_mouwar2
+Phylloscopus nigrorum_negros leaf warbler_mouwar4
+Phylloscopus presbytes_felosinha-de-timor_tilwar2
+Phylloscopus presbytes floresianus_felosinha-de-timor (floresianus)_tilwar3
+Phylloscopus presbytes presbytes_felosinha-de-timor (presbytes)_tilwar4
+Phylloscopus rotiensis_rote leaf warbler_rolwar1
+Phylloscopus makirensis_makira leaf warbler_sclwar1
+Phylloscopus nesophilus_sulawesi leaf warbler_sulwar1
+Phylloscopus sarasinorum_lompobattang leaf warbler_sulwar3
+Phylloscopus [undescribed Selayar form]_selayar leaf warbler (undescribed form)_selwar1
+Phylloscopus poliocephalus_island leaf warbler_islwar1
+Phylloscopus poliocephalus suaramerdu_island leaf warbler (Peleng)_isllew4
+Phylloscopus poliocephalus emilsalimi_island leaf warbler (Taliabu)_isllew3
+Phylloscopus poliocephalus henrietta_island leaf warbler (Halmahera)_isllew8
+Phylloscopus poliocephalus waterstradti_island leaf warbler (Bacan)_isllew11
+Phylloscopus poliocephalus everetti_island leaf warbler (Buru)_isllew7
+Phylloscopus poliocephalus ceramensis_island leaf warbler (Seram)_isllew6
+Phylloscopus poliocephalus avicola_island leaf warbler (Kai)_isllew5
+Phylloscopus poliocephalus [poliocephalus Group]_island leaf warbler (New Guinea)_isllew2
+Phylloscopus poliocephalus [matthiae Group]_island leaf warbler (South Pacific)_isllew1
+Phylloscopus maforensis_numfor leaf warbler_isllew9
+Phylloscopus misoriensis_biak leaf warbler_isllew10
+Phylloscopus amoenus_kolombangara leaf warbler_kullew1
+Phylloscopus sp._felosa (Phylloscopus) sp._phyllo1
+Hylia prasina_beija-flor-verdinho_grehyl1
+Pholidornis rushiae_tit-hylia_tithyl1
+Erythrocercus mccallii_chestnut-capped flycatcher_chcfly1
+Erythrocercus holochlorus_yellow flycatcher_yelfly2
+Erythrocercus livingstonei_livingstone's flycatcher_livfly1
+Scotocerca inquieta_fuinha-dos-espinheiros_stswar1
+Scotocerca inquieta saharae/theresae_fuinha-dos-espinheiros (saharae/theresae)_scrwar1
+Scotocerca inquieta [inquieta Group]_fuinha-dos-espinheiros [grupo inquieta]_scrwar2
+Hemitesia neumanni_neumann's warbler_neuwar1
+Hemitesia pallidipes_pale-footed bush warbler_pfbwar1
+Urosphena subulata_cauda-cortada-de-timor_timstu1
+Urosphena whiteheadi_bornean stubtail_borstu1
+Urosphena squameiceps_asian stubtail_asistu1
+Tesia cyaniventer_gray-bellied tesia_gybtes1
+Tesia olivea_slaty-bellied tesia_slbtes1
+Tesia cyaniventer/olivea_gray-bellied/slaty-bellied tesia_y00906
+Tesia superciliaris_javan tesia_javtes1
+Tesia everetti_russet-capped tesia_ructes1
+Tesia sp._tesia sp. (genus Tesia)_tesia1
+Cettia major_chestnut-crowned bush warbler_ccbwar1
+Cettia brunnifrons_gray-sided bush warbler_gysbuw1
+Cettia castaneocoronata_chestnut-headed tesia_chhtes1
+Cettia cetti_rouxinol-bravo_cetwar1
+Cettia sp._Cettia sp._cettia1
+Abroscopus superciliaris_yellow-bellied warbler_yebwar1
+Abroscopus albogularis_rufous-faced warbler_rufwar1
+Abroscopus schisticeps_black-faced warbler_blfwar1
+Phyllergates cucullatus_mountain tailorbird_moutai2
+Phyllergates heterolaemus_rufous-headed tailorbird_ruhtai2
+Tickellia hodgsoni_broad-billed warbler_brbwar1
+Phyllergates cucullatus/Tickellia hodgsoni_mountain tailorbird/broad-billed warbler_y01153
+Horornis seebohmi_philippine bush warbler_phbwar1
+Horornis diphone_japanese bush warbler_jabwar
+Horornis diphone [cantans Group]_japanese bush warbler (Northern)_jabwar7
+Horornis diphone diphone_japanese bush warbler (Bonin)_jabwar6
+Horornis canturians_manchurian bush warbler_manbuw1
+Horornis diphone/canturians_japanese/manchurian bush warbler_y00747
+Horornis annae_palau bush warbler_pabwar1
+Horornis carolinae_tanimbar bush warbler_tabwar1
+Horornis parens_shade warbler_shawar1
+Horornis haddeni_odedi_odedi1
+Horornis ruficapilla_fiji bush warbler_fibwar1
+Horornis fortipes_brownish-flanked bush warbler_bfbwar1
+Horornis fortipes [fortipes Group]_brownish-flanked bush warbler (Brownish-flanked)_bfbwar2
+Horornis fortipes robustipes_brownish-flanked bush warbler (Taiwan)_bfbwar3
+Horornis brunnescens_hume's bush warbler_yebbuw2
+Horornis acanthizoides_yellowish-bellied bush warbler_ybbwar1
+Horornis fortipes/acanthizoides_brownish-flanked/yellowish-bellied bush warbler_y00748
+Horornis flavolivaceus_aberrant bush warbler_abbwar1
+Horornis flavolivaceus [vulcanius Group]_aberrant bush warbler (Sunda)_subwar4
+Horornis flavolivaceus [flavolivaceus Group]_aberrant bush warbler (Aberrant)_abbwar2
+Horornis flavolivaceus intricatus/oblitus_aberrant bush warbler (Perplexing)_abbwar3
+Horornis sp._Horornis sp._buswar1
+Leptopoecile sophiae_white-browed tit-warbler_wbtwar1
+Leptopoecile elegans_crested tit-warbler_crtwar1
+Aegithalos caudatus_chapim-rabilongo_lottit1
+Aegithalos caudatus caudatus_chapim-rabilongo (caudatus)_lottit2
+Aegithalos caudatus [europaeus Group]_chapim-rabilongo [grupo europaeus]_lottit3
+Aegithalos caudatus [alpinus Group]_chapim-rabilongo [grupo alpinus]_lottit4
+Aegithalos glaucogularis_silver-throated tit_lottit5
+Aegithalos leucogenys_white-cheeked tit_whctit1
+Aegithalos exilis_pygmy tit_pygtit1
+Aegithalos concinnus_black-throated tit_blttit2
+Aegithalos concinnus [concinnus Group]_black-throated tit (Black-throated)_bkttit1
+Aegithalos concinnus iredalei/rubricapillus_black-throated tit (Red-headed)_bkttit3
+Aegithalos concinnus annamensis_black-throated tit (Gray-crowned)_bkttit2
+Aegithalos niveogularis_white-throated tit_whttit1
+Aegithalos iouschistos_black-browed tit_bkbtit3
+Aegithalos iouschistos iouschistos_black-browed tit (Rufous-fronted)_bkbtit5
+Aegithalos iouschistos sharpei_black-browed tit (Burmese)_bkbtit6
+Aegithalos iouschistos bonvaloti/obscuratus_black-browed tit (Black-browed)_bkbtit4
+Aegithalos fuliginosus_sooty tit_sootit1
+Psaltriparus minimus_bushtit_bushti
+Psaltriparus minimus [minimus Group]_bushtit (Pacific)_bushti1
+Psaltriparus minimus plumbeus_bushtit (Interior)_bushti2
+Psaltriparus minimus [melanotis Group]_bushtit (melanotis Group)_bkebus
+Sylvia atricapilla_toutinegra-de-barrete_blackc1
+Sylvia borin_toutinegra-das-figueiras_garwar1
+Sylvia dohrni_dohrn's thrush-babbler_dohthb1
+Sylvia galinieri_abyssinian catbird_abycat1
+Sylvia nigricapillus_bush blackcap_busbla1
+Sylvia abyssinica_african hill babbler_afhbab1
+Sylvia abyssinica monachus_african hill babbler (Mt. Cameroon)_afhbab4
+Sylvia abyssinica claudei_african hill babbler (Claude's)_afhbab5
+Sylvia abyssinica stierlingi_african hill babbler (Stierling's)_afhbab6
+Sylvia abyssinica abyssinica/stictigula_african hill babbler (African)_afhbab2
+Sylvia atriceps_rwenzori hill babbler_afhbab3
+Curruca nisoria_toutinegra-barrada_barwar1
+Curruca layardi_layard's warbler_laywar2
+Curruca boehmi_banded parisoma_banwar2
+Curruca subcoerulea_chestnut-vented warbler_ruvwar2
+Curruca layardi/subcoerulea_layard's/chestnut-vented warbler_y01306
+Curruca curruca_papa-amoras-cinzento_leswhi4
+Curruca curruca curruca/blythi_papa-amoras-cinzento (curruca/blythi)_leswhi2
+Curruca curruca halimodendri_papa-amoras-cinzento (halimodendri)_leswhi3
+Curruca curruca curruca/blythi/halimodendri_papa-amoras-cinzento (curruca/blythi/halimodendri)_leswhi1
+Curruca curruca minula_papa-amoras-cinzento (minula)_smawhi1
+Curruca curruca curruca/minula_papa-amoras-cinzento (curruca/minula)_y01048
+Curruca curruca margelanica_papa-amoras-cinzento (margelanica)_marwhi1
+Curruca curruca minula/margelanica_papa-amoras-cinzento (minula/margelanica)_y01050
+Curruca curruca althaea_papa-amoras-cinzento (althaea)_humwhi1
+Curruca curruca curruca/althaea_papa-amoras-cinzento (curruca/althaea)_y00752
+Curruca curruca curruca/minula/althaea_papa-amoras-cinzento (curruca/minula/althaea)_y01049
+Curruca lugens_brown parisoma_brnwar1
+Curruca lugens griseiventris_brown parisoma (Gray-vented)_brnwar3
+Curruca lugens [lugens Group]_brown parisoma (Brown)_brnwar2
+Curruca buryi_yemen warbler_yemwar1
+Curruca leucomelaena_toutinegra-do-mar-vermelho_reswar1
+Curruca hortensis_toutinegra-real-ocidental_weowar2
+Curruca crassirostris_toutinegra-real-oriental_eaowar2
+Curruca hortensis/crassirostris_toutinegra-real-ocidental/toutinegra-real-oriental_y00816
+Curruca deserti_toutinegra-do-deserto-africana_afdwar1
+Curruca nana_toutinegra-do-deserto-asiática_asdwar1
+Curruca deserticola_toutinegra-do-atlas_triwar1
+Curruca mystacea_toutinegra-rosada_menwar1
+Curruca mystacea mystacea_toutinegra-rosada (mystacea)_menwar2
+Curruca mystacea rubescens/turcmenica_toutinegra-rosada (rubescens/turcmenica)_menwar3
+Curruca ruppeli_toutinegra-do-levante_ruewar1
+Curruca melanothorax_toutinegra-do-chipre_cypwar1
+Curruca melanocephala_toutinegra-dos-valados_sarwar1
+Curruca subalpina_felosa-de-moltoni_subwar8
+Curruca iberiae_toutinegra-de-bigodes-ocidental_subwar6
+Curruca cantillans_toutinegra-de-bigodes-oriental_easwar1
+Curruca iberiae/cantillans_toutinegra-de-bigodes-ocidental/toutinegra-de-bigodes-oriental_subwar1
+Curruca subalpina/iberiae/cantillans_toutinegra-de-moltoni/toutinegra-de-bigodes-ocidental/toutinegra-de-bigodes-oriental_y00909
+Curruca communis_papa-amoras-comum_grewhi1
+Curruca conspicillata_toutinegra-tomilheira_spewar2
+Curruca sarda_toutinegra-da-sardenha_marwar1
+Curruca undata_felosa-do-mato_darwar1
+Curruca balearica_toutinegra-das-baleares_balwar1
+Curruca sp._Toutinegra (Curruca) sp._curruc1
+Sylvia/Curruca sp._toutinegra (Sylvia) sp._sylvia1
+Passeriformes sp. (Old World warbler sp.)_old world warbler sp._olwwar1
+Myzornis pyrrhoura_fire-tailed myzornis_fitmyz1
+Moupinia poecilotis_rufous-tailed babbler_rutbab1
+Lioparus chrysotis_golden-breasted fulvetta_gobful1
+Chrysomma sinense_yellow-eyed babbler_yeebab1
+Chrysomma altirostre_jerdon's babbler_jerbab1
+Chrysomma altirostre scindicum_jerdon's babbler (Indus)_jerbab2
+Chrysomma altirostre griseigulare_jerdon's babbler (Himalayan)_jerbab3
+Chrysomma altirostre altirostre_jerdon's babbler (Irrawaddy)_jerbab4
+Rhopophilus albosuperciliaris_tarim babbler_tarbab1
+Rhopophilus pekinensis_beijing babbler_beibab1
+Fulvetta ruficapilla_spectacled fulvetta_speful1
+Fulvetta danisi_indochinese fulvetta_indful1
+Fulvetta striaticollis_chinese fulvetta_chiful1
+Fulvetta ludlowi_brown-throated fulvetta_ludful1
+Fulvetta vinipectus_white-browed fulvetta_whbful1
+Fulvetta vinipectus vinipectus/kangrae_white-browed fulvetta (White-throated)_whbful10
+Fulvetta vinipectus chumbiensis_white-browed fulvetta (Bhutan)_whbful4
+Fulvetta vinipectus austeni_white-browed fulvetta (Naga Hills)_whbful5
+Fulvetta vinipectus ripponi_white-browed fulvetta (Chin Hills)_whbful6
+Fulvetta vinipectus bieti/perstriata_white-browed fulvetta (Chinese)_whbful11
+Fulvetta vinipectus valentinae_white-browed fulvetta (Vietnam)_whbful8
+Fulvetta manipurensis_manipur fulvetta_sttful2
+Fulvetta cinereiceps_gray-hooded fulvetta_sttful1
+Fulvetta formosana_taiwan fulvetta_taiful1
+Fulvetta sp._fulvetta sp. (genus Fulvetta)_fulvet2
+Chamaea fasciata_wrentit_wrenti
+Paradoxornis heudei_reed parrotbill_reepar3
+Paradoxornis heudei polivanovi_reed parrotbill (Northern)_reepar5
+Paradoxornis heudei heudei_reed parrotbill (Reed)_reepar4
+Paradoxornis flavirostris_black-breasted parrotbill_blbpar2
+Paradoxornis guttaticollis_spot-breasted parrotbill_spbpar1
+Paradoxornis aemodius_great parrotbill_grepar1
+Paradoxornis unicolor_brown parrotbill_bropar1
+Paradoxornis paradoxus_three-toed parrotbill_thtpar1
+Paradoxornis gularis_gray-headed parrotbill_gyhpar3
+Paradoxornis margaritae_black-headed parrotbill_bkhpar1
+Paradoxornis gularis x margaritae_gray-headed x black-headed parrotbill (hybrid)_x00815
+Paradoxornis ruficeps_white-breasted parrotbill_ruhpar3
+Paradoxornis bakeri_rufous-headed parrotbill_ruhpar2
+Suthora davidiana_short-tailed parrotbill_shtpar3
+Suthora fulvifrons_fulvous parrotbill_fulpar1
+Suthora nipalensis_black-throated parrotbill_bltpar1
+Suthora nipalensis nipalensis/garhwalensis_black-throated parrotbill (Black-throated)_bktpar1
+Suthora nipalensis humii/crocotia_black-throated parrotbill (Orange-eared)_bktpar2
+Suthora nipalensis poliotis/feae_black-throated parrotbill (Gray-breasted)_bktpar3
+Suthora nipalensis ripponi/patriciae_black-throated parrotbill (Buff-breasted)_bktpar4
+Suthora nipalensis beaulieu/kamoli_black-throated parrotbill (Black-eared)_bktpar5
+Suthora verreauxi_golden parrotbill_golpar2
+Suthora atrosuperciliaris_pale-billed parrotbill_blbpar3
+Suthora conspicillata_spectacled parrotbill_spepar2
+Suthora zappeyi_gray-hooded parrotbill_gyhpar4
+Suthora ricketti_eye-ringed parrotbill_bnwpar1
+Suthora brunnea_brown-winged parrotbill_bnwpar2
+Suthora webbiana_vinous-throated parrotbill_vitpar1
+Suthora alphonsiana_ashy-throated parrotbill_astpar1
+Suthora webbiana x alphonsiana_vinous-throated x ashy-throated parrotbill (hybrid)_x00467
+Suthora przewalskii_rusty-throated parrotbill_rutpar2
+Paradoxornithidae sp._parrotbill sp._parrot1
+Parayuhina diademata_white-collared yuhina_whcyuh1
+Staphida everetti_chestnut-crested yuhina_chcyuh1
+Staphida castaniceps_striated yuhina_stryuh1
+Staphida castaniceps [striata Group]_striated yuhina (Gray-crowned)_stryuh6
+Staphida castaniceps castaniceps_striated yuhina (Rufous-crowned)_stryuh4
+Staphida torqueola_indochinese yuhina_indyuh1
+Yuhina nigrimenta_black-chinned yuhina_blcyuh1
+Yuhina brunneiceps_taiwan yuhina_taiyuh1
+Yuhina flavicollis_whiskered yuhina_whiyuh1
+Yuhina humilis_burmese yuhina_buryuh1
+Yuhina bakeri_white-naped yuhina_whnyuh1
+Yuhina gularis_stripe-throated yuhina_sttyuh1
+Yuhina occipitalis_rufous-vented yuhina_ruvyuh1
+Parayuhina/Staphida/Yuhina sp._yuhina sp._yuhina1
+Dasycrotapha speciosa_flame-templed babbler_fltbab1
+Dasycrotapha pygmaea_visayan pygmy-babbler_vispyb1
+Dasycrotapha plateni_mindanao pygmy-babbler_pygbab1
+Sterrhoptilus capitalis_rusty-crowned babbler_rucbab3
+Sterrhoptilus dennistouni_golden-crowned babbler_gocbab1
+Sterrhoptilus affinis_calabarzon babbler_bkcbab3
+Sterrhoptilus nigrocapitatus_visayan babbler_bkcbab10
+Zosterornis hypogrammicus_palawan striped-babbler_pasbab1
+Zosterornis striatus_luzon striped-babbler_lusbab1
+Zosterornis whiteheadi_chestnut-faced babbler_chfbab1
+Zosterornis latistriatus_panay striped-babbler_pasbab2
+Zosterornis nigrorum_negros striped-babbler_nesbab1
+Cleptornis marchei_golden white-eye_goweye1
+Rukia ruki_teardrop white-eye_trweye1
+Rukia longirostra_long-billed white-eye_lbweye2
+Megazosterops palauensis_giant white-eye_giweye1
+Heleia javanica_javan heleia_jgtwhe1
+Heleia pinaiae_gray-hooded heleia_gyhwhe1
+Heleia squamifrons_pygmy heleia_pyweye1
+Heleia goodfellowi_mindanao heleia_minwhe1
+Heleia squamiceps_sulawesi heleia_sthwhe1
+Heleia superciliaris_eyebrowed heleia_whbwhe1
+Heleia dohertyi_dark-crowned heleia_dacwhe1
+Heleia muelleri_olho-escuro-malhado_timwhe1
+Heleia crassirostris_flores heleia_flowhe1
+Heleia wallacei_yellow-spectacled heleia_ysweye1
+Apalopteron familiare_bonin white-eye_bonhon1
+Tephrozosterops stalkeri_rufescent white-eye_rufwhe1
+Zosterops ceylonensis_sri lanka white-eye_ceywhe1
+Zosterops nigrorum_yellowish white-eye_yelwhe1
+Zosterops atricapilla_black-capped white-eye_bkcwhe1
+Zosterops flavilateralis_pale white-eye_whbwhe3
+Zosterops mbuluensis_mbulu white-eye_brrwhe9
+Zosterops erythropleurus_chestnut-flanked white-eye_cfweye1
+Zosterops simplex_swinhoe's white-eye_swiwhe1
+Zosterops emiliae_mountain black-eye_mouble1
+Zosterops japonicus_warbling white-eye_warwhe1
+Zosterops simplex/japonicus_swinhoe's/warbling white-eye_y00424
+Zosterops palpebrosus_indian white-eye_indwhe1
+Zosterops simplex/palpebrosus_swinhoe's/indian white-eye_y01105
+Zosterops meyeni_lowland white-eye_loweye2
+Zosterops semiflavus_marianne white-eye_marwhe1
+Zosterops mouroniensis_comoro white-eye_coweye1
+Zosterops olivaceus_reunion white-eye_reuwhe1
+Zosterops chloronothos_mauritius white-eye_mauwhe1
+Zosterops borbonicus_reunion gray white-eye_maswhe2
+Zosterops mauritianus_mauritius gray white-eye_maswhe3
+Zosterops abyssinicus_abyssinian white-eye_wbweye1
+Zosterops socotranus_socotra white-eye_abywhe1
+Zosterops melanocephalus_cameroon speirops_camspe1
+Zosterops stenocricotus_forest white-eye_afywhe1
+Zosterops stuhlmanni_green white-eye_afywhe3
+Zosterops eurycricotus_kilimanjaro white-eye_brrwhe8
+Zosterops brunneus_bioko speirops_fepspe1
+Zosterops poliogastrus_ethiopian white-eye_heuwhe2
+Zosterops kaffensis_kafa white-eye_kafwhe1
+Zosterops kaffensis kaffensis_kafa white-eye (Kafa)_brrwhe7
+Zosterops kaffensis kulalensis_kafa white-eye (Kulal)_brrwhe5
+Zosterops kikuyuensis_kikuyu white-eye_brrwhe3
+Zosterops ficedulinus_principe white-eye_satwhe1
+Zosterops griseovirescens_annobon white-eye_anweye1
+Zosterops feae_sao tome white-eye_satwhe2
+Zosterops lugubris_black-capped speirops_blcspe1
+Zosterops leucophaeus_principe speirops_prispe1
+Zosterops silvanus_taita white-eye_brrwhe4
+Zosterops senegalensis_northern yellow white-eye_afywhe2
+Zosterops senegalensis senegalensis/demeryi_northern yellow white-eye (senegalensis/demeryi)_noywhe1
+Zosterops senegalensis jacksoni/gerhardi_northern yellow white-eye (jacksoni/gerhardi)_noywhe3
+Zosterops stuhlmanni/senegalensis_green/northern yellow white-eye_y00444
+Zosterops kasaicus_angola white-eye_noywhe2
+Zosterops pallidus_orange river white-eye_capwhe6
+Zosterops winifredae_south pare white-eye_brrwhe10
+Zosterops virens_cape white-eye_capwhe2
+Zosterops virens capensis_cape white-eye (Cape)_capwhe4
+Zosterops virens virens_cape white-eye (Green)_capwhe5
+Zosterops pallidus x virens_orange river x cape white-eye (hybrid)_x00968
+Zosterops pallidus/virens_orange river/cape white-eye_y01154
+Zosterops anderssoni_southern yellow white-eye_afywhe4
+Zosterops vaughani_pemba white-eye_peweye1
+Zosterops modestus_seychelles white-eye_seywhe1
+Zosterops anjuanensis_anjouan white-eye_anjwhe1
+Zosterops comorensis_moheli white-eye_mohwhe1
+Zosterops maderaspatanus_malagasy white-eye_madwhe1
+Zosterops kirki_kirk's white-eye_kirwhe1
+Zosterops mayottensis_mayotte white-eye_maywhe1
+Zosterops aldabrensis_aldabra white-eye_aldwhe1
+Zosterops chloris_lemon-bellied white-eye_yebwhe1
+Zosterops meratusensis_meratus white-eye_merwhe1
+Zosterops flavissimus_wakatobi white-eye_lebwhe2
+Zosterops atrifrons_black-crowned white-eye_bcweye2
+Zosterops nehrkorni_sangihe white-eye_sanwhe1
+Zosterops somadikartai_togian white-eye_togwhe1
+Zosterops consobrinorum_sulawesi white-eye_sulwhe1
+Zosterops anomalus_black-ringed white-eye_bkrwhe1
+Zosterops minor_black-fronted white-eye_bfweye1
+Zosterops minor [chrysolaemus Group]_black-fronted white-eye (Black-fronted)_bkfwhe1
+Zosterops minor minor/rothschildi_black-fronted white-eye (Green-fronted)_bkfwhe2
+Zosterops meeki_tagula white-eye_wtweye1
+Zosterops dehaani_morotai white-eye_crtwhe2
+Zosterops atriceps_cream-throated white-eye_crtwhe1
+Zosterops atriceps fuscifrons_cream-throated white-eye (Halmahera)_crtwhe3
+Zosterops atriceps atriceps_cream-throated white-eye (Bacan)_crtwhe4
+Zosterops [undescribed Obi form]_obi white-eye (undescribed form)_obiwhe1
+Zosterops buruensis_buru white-eye_burwhe1
+Zosterops stalkeri_seram white-eye_serwhe1
+Zosterops flavus_javan white-eye_jaweye2
+Zosterops citrinella_olho-branco-de-barriga-cinza_asbwhe1
+Zosterops citrinella unicus_olho-branco-de-barriga-cinza (unicus)_asbwhe2
+Zosterops citrinella [citrinella Group]_olho-branco-de-barriga-cinza (Grupo citrinella)_asbwhe6
+Zosterops luteus_australian yellow white-eye_ayweye3
+Zosterops lateralis_silvereye_silver3
+Zosterops citrinella x lateralis_ashy-bellied white-eye x silvereye (hybrid)_x01127
+Zosterops citrinella/lateralis_ashy-bellied white-eye/silvereye_y01286
+Zosterops paruhbesar_wangi-wangi white-eye_wawwhe1
+Zosterops auriventer_hume's white-eye_humwhe1
+Zosterops simplex/auriventer_swinhoe's/hume's white-eye_y01155
+Zosterops melanurus_sangkar white-eye_sanwhe2
+Zosterops everetti_everett's white-eye_evweye1
+Zosterops vellalavella_banded white-eye_baweye2
+Zosterops sanctaecrucis_santa cruz white-eye_sacwhe1
+Zosterops fuscicapilla_capped white-eye_capwhe3
+Zosterops fuscicapilla fuscicapilla_capped white-eye (Capped)_capwhe7
+Zosterops fuscicapilla crookshanki_capped white-eye (Oya Tabu)_capwhe8
+Zosterops flavifrons_yellow-fronted white-eye_yfweye1
+Zosterops superciliosus_bare-eyed white-eye_beweye1
+Zosterops lacertosus_sanford's white-eye_saweye2
+Zosterops gibbsi_vanikoro white-eye_vanwhe1
+Zosterops explorator_fiji white-eye_laweye1
+Zosterops lateralis/explorator_silvereye/fiji white-eye_y00817
+Zosterops hypoxanthus_black-headed white-eye_bhweye1
+Zosterops mysorensis_biak white-eye_biweye1
+Zosterops hamlini_bougainville white-eye_gytwhe2
+Zosterops oblitus_guadalcanal white-eye_gytwhe4
+Zosterops rendovae_makira white-eye_gytwhe5
+Zosterops oleagineus_yap white-eye_yapwhe1
+Zosterops finschii_dusky white-eye_duweye1
+Zosterops ponapensis_pohnpei white-eye_pohwhe1
+Zosterops cinereus_kosrae white-eye_koswhe1
+Zosterops rotensis_rota white-eye_rotwhe1
+Zosterops metcalfii_yellow-throated white-eye_ytweye1
+Zosterops stresemanni_malaita white-eye_maweye2
+Zosterops novaeguineae_new guinea white-eye_ngweye1
+Zosterops kuehni_ambon white-eye_ambwhe1
+Zosterops grayi_kai besar white-eye_grkwhe1
+Zosterops luteirostris_splendid white-eye_spweye2
+Zosterops uropygialis_kai kecil white-eye_likwhe1
+Zosterops splendidus_ranongga white-eye_gaweye1
+Zosterops kulambangrae_solomons white-eye_soiwhe2
+Zosterops tetiparius_dark-eyed white-eye_soiwhe3
+Zosterops natalis_christmas island white-eye_ciweye2
+Zosterops conspicillatus_bridled white-eye_brweye1
+Zosterops conspicillatus saypani_bridled white-eye (Saipan)_briwhe2
+Zosterops conspicillatus conspicillatus_bridled white-eye (Bridled)_briwhe1
+Zosterops semperi_caroline islands white-eye_ciweye1
+Zosterops hypolais_plain white-eye_plweye1
+Zosterops griseotinctus_louisiade white-eye_loweye1
+Zosterops murphyi_kolombangara white-eye_kulwhe1
+Zosterops inornatus_large lifou white-eye_llweye1
+Zosterops albogularis_white-chested white-eye_wcweye1
+Zosterops samoensis_samoan white-eye_saweye1
+Zosterops strenuus_robust white-eye_robwhe1
+Zosterops tenuirostris_slender-billed white-eye_sbweye1
+Zosterops minutus_small lifou white-eye_slweye1
+Zosterops xanthochroa_green-backed white-eye_gnbwhe1
+Zosterops rennellianus_rennell white-eye_reweye1
+Zosterops sp._Zosterops sp._zoster1
+Zosteropidae sp._white-eye sp._whitee1
+Timalia pileata_chestnut-capped babbler_chcbab1
+Dumetia hyperythra_tawny-bellied babbler_tabbab1
+Dumetia hyperythra hyperythra_tawny-bellied babbler (Tawny-bellied)_tabbab2
+Dumetia hyperythra albogularis/phillipsi_tawny-bellied babbler (White-throated)_tabbab5
+Dumetia atriceps_dark-fronted babbler_dafbab1
+Dumetia atriceps atriceps_dark-fronted babbler (atriceps)_dafbab2
+Dumetia atriceps bourdilloni_dark-fronted babbler (bourdilloni)_dafbab3
+Dumetia atriceps siccata_dark-fronted babbler (siccata)_dafbab4
+Dumetia atriceps nigrifrons_dark-fronted babbler (nigrifrons)_dafbab5
+Mixornis kelleyi_gray-faced tit-babbler_gyftib1
+Mixornis flavicollis_gray-cheeked tit-babbler_gyctib1
+Mixornis prillwitzi_kangean tit-babbler_gyctib3
+Mixornis gularis_pin-striped tit-babbler_sttbab1
+Mixornis gularis [gularis Group]_pin-striped tit-babbler (Pin-striped)_pistib1
+Mixornis gularis woodi_pin-striped tit-babbler (Palawan)_pistib2
+Mixornis kelleyi/gularis_gray-faced/pin-striped tit-babbler_y01051
+Mixornis bornensis_bold-striped tit-babbler_bostib1
+Mixornis bornensis [bornensis Group]_bold-striped tit-babbler (Bold-striped)_bostib2
+Mixornis bornensis cagayanensis_bold-striped tit-babbler (Mapun)_bostib3
+Macronus ptilosus_fluffy-backed tit-babbler_fbtbab1
+Macronus striaticeps_brown tit-babbler_brtbab1
+Cyanoderma chrysaeum_golden babbler_golbab1
+Cyanoderma erythropterum_chestnut-winged babbler_chwbab1
+Cyanoderma bicolor_gray-hooded babbler_chwbab3
+Cyanoderma melanothorax_crescent-chested babbler_crcbab1
+Cyanoderma rufifrons_rufous-fronted babbler_rufbab10
+Cyanoderma rufifrons [ambiguum Group]_rufous-fronted babbler (Buff-chested)_bucbab1
+Cyanoderma rufifrons [rufifrons Group]_rufous-fronted babbler (Rufous-fronted)_rufbab2
+Cyanoderma pyrrhops_black-chinned babbler_blcbab2
+Cyanoderma ruficeps_rufous-capped babbler_rucbab1
+Cyanoderma sp._Cyanoderma sp._cyanod1
+Spelaeornis caudatus_rufous-throated wren-babbler_rtwbab1
+Spelaeornis badeigularis_mishmi wren-babbler_miswrb1
+Spelaeornis troglodytoides_bar-winged wren-babbler_bwwbab1
+Spelaeornis kinneari_pale-throated wren-babbler_patwrb1
+Spelaeornis chocolatinus_naga wren-babbler_ltwbab1
+Spelaeornis oatesi_chin hills wren-babbler_chhwrb1
+Spelaeornis longicaudatus_tawny-breasted wren-babbler_tbwbab1
+Spelaeornis reptatus_gray-bellied wren-babbler_gybwrb1
+Spelaeornis [undescribed form]_lisu wren-babbler (undescribed form)_liswrb1
+Spelaeornis sp._Spelaeornis sp._spelae1
+Melanocichla lugubris_black laughingthrush_blalau1
+Melanocichla calva_bare-headed laughingthrush_bahlau1
+Pomatorhinus ferruginosus_black-crowned scimitar-babbler_cobscb1
+Pomatorhinus phayrei_brown-crowned scimitar-babbler_bncscb1
+Pomatorhinus phayrei phayrei/stanfordi_brown-crowned scimitar-babbler (Phayre's)_cobscb2
+Pomatorhinus phayrei [albogularis Group]_brown-crowned scimitar-babbler (albogularis Group)_cobscb3
+Pomatorhinus ferruginosus/phayrei_black-crowned/brown-crowned scimitar-babbler_cbsbab2
+Pomatorhinus ochraceiceps_red-billed scimitar-babbler_rbsbab1
+Pomatorhinus ferruginosus/ochraceiceps_black-crowned/red-billed scimitar-babbler_y01110
+Pomatorhinus phayrei/ochraceiceps_brown-crowned/red-billed scimitar-babbler_y01199
+Pomatorhinus superciliaris_slender-billed scimitar-babbler_sbsbab1
+Pomatorhinus ruficollis_streak-breasted scimitar-babbler_sbsbab3
+Pomatorhinus musicus_taiwan scimitar-babbler_taiscb1
+Pomatorhinus schisticeps_white-browed scimitar-babbler_wbsbab1
+Pomatorhinus ruficollis/schisticeps_streak-breasted/white-browed scimitar-babbler_y01119
+Pomatorhinus horsfieldii_indian scimitar-babbler_insbab1
+Pomatorhinus melanurus_sri lanka scimitar-babbler_srlscb1
+Pomatorhinus bornensis_sunda scimitar-babbler_chbscb2
+Pomatorhinus montanus_javan scimitar-babbler_chbscb1
+Pomatorhinus sp._Pomatorhinus sp._pomato1
+Erythrogenys hypoleucos_large scimitar-babbler_lasbab1
+Erythrogenys erythrogenys_rusty-cheeked scimitar-babbler_rcsbab1
+Erythrogenys imberbis_red-eyed scimitar-babbler_reescb1
+Erythrogenys mcclellandi_spot-breasted scimitar-babbler_spbscb1
+Erythrogenys gravivox_black-streaked scimitar-babbler_bksscb1
+Erythrogenys swinhoei_gray-sided scimitar-babbler_gysscb1
+Erythrogenys gravivox/swinhoei_black-streaked/gray-sided scimitar-babbler_y01316
+Erythrogenys erythrocnemis_black-necklaced scimitar-babbler_sbsbab2
+Stachyris nigricollis_black-throated babbler_bltbab1
+Stachyris grammiceps_white-breasted babbler_whbbab2
+Stachyris maculata_chestnut-rumped babbler_chrbab1
+Stachyris nigriceps_gray-throated babbler_gytbab1
+Stachyris poliocephala_gray-headed babbler_gyhbab1
+Stachyris nonggangensis_nonggang babbler_nonbab1
+Stachyris herberti_sooty babbler_soobab1
+Stachyris humei_sikkim wedge-billed babbler_wbwbab1
+Stachyris roberti_cachar wedge-billed babbler_chbbab1
+Stachyris leucotis_white-necked babbler_whnbab1
+Stachyris thoracica_white-bibbed babbler_whbbab1
+Stachyris oglei_snowy-throated babbler_sntbab1
+Stachyris strialata_spot-necked babbler_spnbab1
+Stachyris sp._Stachyris sp._stachy1
+Timaliidae sp._Timaliidae sp._babble1
+Graminicola bengalensis_indian grassbird_rurgra1
+Graminicola striatus_chinese grassbird_chigra1
+Turdinus macrodactylus_large wren-babbler_lawbab1
+Turdinus marmoratus_marbled wren-babbler_mawbab1
+Turdinus atrigularis_black-throated wren-babbler_btwbab1
+Malacopteron affine_sooty-capped babbler_socbab1
+Malacopteron albogulare_gray-breasted babbler_gybbab1
+Malacopteron cinereum_scaly-crowned babbler_sccbab1
+Malacopteron magnum_rufous-crowned babbler_rucbab2
+Malacopteron magnirostre_moustached babbler_moubab1
+Malacopteron palawanense_palawan babbler_palbab1
+Malacopteron sp._Malacopteron sp._malaco1
+Gampsorhynchus rufulus_white-hooded babbler_whhbab2
+Gampsorhynchus torquatus_collared babbler_colbab1
+Schoeniparus cinereus_yellow-throated fulvetta_yetful1
+Schoeniparus castaneceps_rufous-winged fulvetta_ruwful1
+Schoeniparus klossi_black-crowned fulvetta_bkcful1
+Schoeniparus variegaticeps_gold-fronted fulvetta_gofful2
+Schoeniparus rufogularis_rufous-throated fulvetta_rutful1
+Schoeniparus dubius_rusty-capped fulvetta_rucful1
+Schoeniparus brunneus_dusky fulvetta_dusful1
+Schoeniparus sp._Schoeniparus sp._fulvet1
+Pellorneum ruficeps_puff-throated babbler_putbab1
+Pellorneum fuscocapillus_brown-capped babbler_bncbab1
+Pellorneum palustre_marsh babbler_marbab2
+Pellorneum nigrocapitatum_malayan black-capped babbler_bkcbab1
+Pellorneum capistratoides_bornean black-capped babbler_bbcbab1
+Pellorneum capistratum_javan black-capped babbler_bkcbab2
+Pellorneum malaccense_short-tailed babbler_shtbab1
+Pellorneum malaccense malaccense_short-tailed babbler (Mourning)_shtbab2
+Pellorneum malaccense saturatum_short-tailed babbler (Glissando)_shtbab4
+Pellorneum malaccense poliogene_short-tailed babbler (Leaflitter)_shtbab6
+Pellorneum cinereiceps_ashy-headed babbler_ashbab1
+Pellorneum albiventre_spot-throated babbler_sptbab1
+Pellorneum tickelli_buff-breasted babbler_bubbab1
+Pellorneum buettikoferi_sumatran babbler_sumbab1
+Pellorneum pyrrogenys_temminck's babbler_tembab1
+Pellorneum rostratum_white-chested babbler_whcbab1
+Pellorneum rostratum rostratum_white-chested babbler (Malayan)_whcbab2
+Pellorneum rostratum macropterum_white-chested babbler (Bornean)_whcbab3
+Pellorneum bicolor_ferruginous babbler_ferbab1
+Pellorneum celebense_sulawesi babbler_sulbab1
+Laticilla burnesii_rufous-vented grass babbler_ruvpri1
+Laticilla cinerascens_swamp grass babbler_swapri1
+Illadopsis fulvescens_brown illadopsis_broill1
+Illadopsis fulvescens moloneyana/iboensis_brown illadopsis (Moloney's)_brnill1
+Illadopsis fulvescens [fulvescens Group]_brown illadopsis (Brown)_brnill2
+Illadopsis rufipennis_pale-breasted illadopsis_pabill1
+Illadopsis fulvescens/rufipennis_brown/pale-breasted illadopsis_y01317
+Illadopsis distans_tanzanian illadopsis_pabill3
+Illadopsis pyrrhoptera_mountain illadopsis_mouill1
+Illadopsis cleaveri_blackcap illadopsis_blaill1
+Illadopsis cleaveri cleaveri/johnsoni_blackcap illadopsis (Western)_blaill2
+Illadopsis cleaveri batesi/marchanti_blackcap illadopsis (Eastern)_blaill3
+Illadopsis cleaveri poensis_blackcap illadopsis (Bioko)_blaill4
+Illadopsis albipectus_scaly-breasted illadopsis_scbill1
+Illadopsis fulvescens/albipectus_pale-breasted/scaly-breasted illadopsis_y01319
+Illadopsis pyrrhoptera/albipectus_mountain/scaly-breasted illadopsis_y01318
+Illadopsis turdina_thrush babbler_thrbab1
+Illadopsis turdina harterti_thrush babbler (Rufous-tailed)_thrbab2
+Illadopsis turdina turdina_thrush babbler (Thrush)_thrbab3
+Illadopsis turdina upembae_thrush babbler (Olive)_thrbab4
+Illadopsis puveli_puvel's illadopsis_puvill1
+Illadopsis rufescens_rufous-winged illadopsis_ruwill1
+Illadopsis sp._illadopsis sp._illado1
+Kenopia striata_striped wren-babbler_stwbab3
+Malacocincla abbotti_abbott's babbler_abbbab1
+Malacocincla sepiaria_horsfield's babbler_horbab2
+Malacocincla sepiaria tardinata/barussana_horsfield's babbler (Hartert's)_horbab1
+Malacocincla sepiaria sepiaria_horsfield's babbler (Horsfield's)_horbab3
+Malacocincla sepiaria rufiventris/harterti_horsfield's babbler (Salvadori's)_horbab4
+Malacocincla perspicillata_black-browed babbler_blbbab1
+Gypsophila crassa_mountain wren-babbler_mowbab1
+Gypsophila brevicaudata_streaked wren-babbler_stwbab1
+Gypsophila annamensis_annam limestone babbler_limwrb4
+Gypsophila calcicola_rufous limestone babbler_limwrb2
+Gypsophila crispifrons_variable limestone babbler_limwrb3
+Gypsophila annamensis/calcicola/crispifrons_limestone babbler sp._liwbab1
+Gypsophila rufipectus_rusty-breasted wren-babbler_rbwbab1
+Ptilocichla mindanensis_striated wren-babbler_stwbab2
+Ptilocichla mindanensis minuta/fortichi_striated wren-babbler (minuta/fortichi)_strwrb13
+Ptilocichla mindanensis mindanensis/basilanica_striated wren-babbler (mindanensis/basilanica)_strwrb14
+Ptilocichla leucogrammica_bornean wren-babbler_bowbab1
+Ptilocichla falcata_falcated wren-babbler_fawbab1
+Napothera epilepidota_eyebrowed wren-babbler_eywbab1
+Napothera malacoptila_long-billed wren-babbler_lbwbab1
+Napothera albostriata_sumatran wren-babbler_sumwrb1
+Napothera pasquieri_white-throated wren-babbler_whtwrb1
+Napothera naungmungensis_naung mung scimitar-babbler_namscb1
+Napothera danjoui_short-tailed scimitar-babbler_stsbab1
+Pellorneidae sp._Pellorneidae sp._pellor1
+Alcippe poioicephala_brown-cheeked fulvetta_brcful1
+Alcippe grotei_black-browed fulvetta_bkbful1
+Alcippe brunneicauda_brown fulvetta_broful1
+Alcippe pyrrhoptera_javan fulvetta_javful1
+Alcippe nipalensis_nepal fulvetta_nepful1
+Alcippe davidi_david's fulvetta_gycful3
+Alcippe hueti_huet's fulvetta_gycful5
+Alcippe morrisonia_morrison's fulvetta_gycful1
+Alcippe fratercula_yunnan fulvetta_gycful4
+Alcippe peracensis_mountain fulvetta_mouful1
+Alcippe grotei/peracensis_black-browed/mountain fulvetta_y00653
+Alcippe sp._Alcippe sp._alcipp1
+Grammatoptila striata_striated laughingthrush_strlau2
+Cutia nipalensis_himalayan cutia_cutia1
+Cutia legalleni_vietnamese cutia_viecut1
+Laniellus langbianis_gray-crowned crocias_gyccro1
+Laniellus albonotatus_spotted crocias_spocro1
+Trochalopteron subunicolor_scaly laughingthrush_scalau1
+Trochalopteron austeni_brown-capped laughingthrush_brclau1
+Trochalopteron squamatum_blue-winged laughingthrush_blwlau1
+Trochalopteron lineatum_streaked laughingthrush_strlau1
+Trochalopteron imbricatum_bhutan laughingthrush_bhulau1
+Trochalopteron virgatum_striped laughingthrush_strlau3
+Trochalopteron variegatum_variegated laughingthrush_varlau1
+Trochalopteron affine_black-faced laughingthrush_blflau1
+Trochalopteron morrisonianum_white-whiskered laughingthrush_whwlau1
+Trochalopteron henrici_prince henry's laughingthrush_prhlau1
+Trochalopteron elliotii_elliot's laughingthrush_elllau1
+Trochalopteron milnei_red-tailed laughingthrush_retlau1
+Trochalopteron yersini_collared laughingthrush_collau1
+Trochalopteron erythrocephalum_chestnut-crowned laughingthrush_chclau2
+Trochalopteron erythrocephalum erythrocephalum/kali_chestnut-crowned laughingthrush (Chestnut-crowned)_chclau10
+Trochalopteron erythrocephalum nigrimentum_chestnut-crowned laughingthrush (Gray-crowned)_chclau9
+Trochalopteron chrysopterum_assam laughingthrush_asslau1
+Trochalopteron formosum_red-winged laughingthrush_rewlau1
+Trochalopteron melanostigma_silver-eared laughingthrush_sielau1
+Trochalopteron ngoclinhense_golden-winged laughingthrush_gowlau1
+Trochalopteron peninsulae_malayan laughingthrush_mallau1
+Trochalopteron sp._Trochalopteron sp._trocha1
+Montecincla jerdoni_banasura laughingthrush_bkclau1
+Montecincla cachinnans_nilgiri laughingthrush_bkclau2
+Montecincla fairbanki_palani laughingthrush_kerlau2
+Montecincla meridionalis_ashambu laughingthrush_kerlau3
+Heterophasia picaoides_long-tailed sibia_lotsib1
+Heterophasia auricularis_white-eared sibia_whesib1
+Heterophasia capistrata_rufous sibia_rufsib1
+Heterophasia pulchella_beautiful sibia_beasib1
+Heterophasia pulchella nigroaurita_beautiful sibia (Black-eared)_beasib2
+Heterophasia pulchella pulchella_beautiful sibia (Gray-eared)_beasib3
+Heterophasia gracilis_gray sibia_grysib1
+Heterophasia melanoleuca_black-backed sibia_blbsib1
+Heterophasia desgodinsi_black-headed sibia_blhsib1
+Heterophasia desgodinsi desgodinsi/tonkinensis_black-headed sibia (Black-headed)_bkhsib1
+Heterophasia desgodinsi engelbachi/kingi_black-headed sibia (engelbachi/kingi)_bkhsib2
+Heterophasia desgodinsi robinsoni_black-headed sibia (Lang Bian)_bkhsib3
+Actinodura nipalensis_hoary-throated barwing_hotbar1
+Actinodura morrisoniana_taiwan barwing_taibar1
+Actinodura waldeni_streak-throated barwing_sttbar1
+Actinodura waldeni daflaensis_streak-throated barwing (Gray-chested)_sttbar2
+Actinodura waldeni [waldeni Group]_streak-throated barwing (Rufous-chested)_sttbar6
+Actinodura nipalensis/waldeni_hoary-throated/streak-throated barwing_y00753
+Actinodura souliei_streaked barwing_strbar1
+Actinodura cyanouroptera_blue-winged minla_blwmin1
+Actinodura strigula_chestnut-tailed minla_chtmin1
+Actinodura egertoni_rusty-fronted barwing_rufbar1
+Actinodura ramsayi_spectacled barwing_spebar1
+Actinodura ramsayi radcliffei/yunnanensis_spectacled barwing (Eastern)_spebar2
+Actinodura ramsayi ramsayi_spectacled barwing (Western)_spebar3
+Actinodura sodangorum_black-crowned barwing_bkcbar1
+Leiothrix lutea_rouxinol-do-japão_reblei
+Leiothrix argentauris_silver-eared mesia_siemes1
+Leiothrix argentauris [argentauris Group]_silver-eared mesia (Silver-eared)_siemes2
+Leiothrix argentauris laurinae/rookmakeri_silver-eared mesia (Sumatran)_siemes3
+Minla ignotincta_red-tailed minla_retmin1
+Leioptila annectens_rufous-backed sibia_rubsib1
+Leioptila annectens [annectens Group]_rufous-backed sibia (Rufous-backed)_rubsib7
+Leioptila annectens eximia_rufous-backed sibia (Dalat)_rubsib6
+Liocichla bugunorum_bugun liocichla_buglio1
+Liocichla omeiensis_emei shan liocichla_gyflio1
+Liocichla steerii_taiwan liocichla_stelio1
+Liocichla phoenicea_red-faced liocichla_reflio2
+Liocichla ripponi_scarlet-faced liocichla_reflio3
+Argya malcolmi_large gray babbler_lagbab2
+Argya cinereifrons_ashy-headed laughingthrush_ashlau1
+Argya longirostris_slender-billed babbler_slbbab1
+Argya subrufa_rufous babbler_rufbab3
+Argya rufescens_orange-billed babbler_orbbab1
+Argya striata_jungle babbler_junbab2
+Argya striata [striata Group]_jungle babbler (Jungle)_junbab1
+Argya striata somervillei_jungle babbler (Black-winged)_junbab3
+Argya affinis_yellow-billed babbler_yebbab1
+Argya striata/affinis_jungle/yellow-billed babbler_y00818
+Argya rubiginosa_rufous chatterer_rufcha2
+Argya aylmeri_scaly chatterer_scacha1
+Argya altirostris_zaragateiro-do-iraque_irabab1
+Argya huttoni_zaragateiro-do-afeganistão_combab1
+Argya caudata_common babbler_combab3
+Argya fulva_zaragateiro-fulvo_fulcha1
+Argya squamiceps_zaragateiro-árabe_arabab1
+Argya earlei_striated babbler_strbab1
+Argya caudata/earlei_common/striated babbler_y01072
+Argya gularis_white-throated babbler_whtbab1
+Turdoides nipalensis_spiny babbler_spibab1
+Turdoides atripennis_capuchin babbler_capbab1
+Turdoides atripennis atripennis_capuchin babbler (Gray-hooded)_capbab2
+Turdoides atripennis rubiginosus_capuchin babbler (Black-crowned)_capbab4
+Turdoides atripennis bohndorffi_capuchin babbler (Brown-throated)_capbab3
+Turdoides gilberti_white-throated mountain-babbler_wtmbab1
+Turdoides chapini_chapin's mountain-babbler_chmbab1
+Turdoides rufocinctus_red-collared mountain-babbler_rcmbab1
+Turdoides plebejus_brown babbler_brobab1
+Turdoides leucopygia_white-rumped babbler_whrbab2
+Turdoides hindei_hinde's pied-babbler_hipbab1
+Turdoides squamulata_scaly babbler_scabab2
+Turdoides jardineii_arrow-marked babbler_armbab1
+Turdoides gymnogenys_bare-cheeked babbler_bacbab1
+Turdoides leucocephala_cretzschmar's babbler_crebab1
+Turdoides reinwardtii_blackcap babbler_blabab2
+Turdoides reinwardtii reinwardtii_blackcap babbler (Blackcap)_blabab1
+Turdoides reinwardtii stictilaema_blackcap babbler (Dusky-throated)_blabab3
+Turdoides tenebrosa_dusky babbler_dusbab2
+Turdoides bicolor_southern pied-babbler_sopbab1
+Turdoides hartlaubii_hartlaub's babbler_harbab1
+Turdoides sharpei_black-lored babbler_bklbab1
+Turdoides sharpei sharpei_black-lored babbler (Sharpe's)_bklbab2
+Turdoides sharpei vepres_black-lored babbler (Nanyuki)_bklbab3
+Turdoides melanops_black-faced babbler_bkfbab1
+Turdoides hypoleuca_northern pied-babbler_norpib1
+Argya/Turdoides sp._zaragateiro (Turdoides) sp._turdoi1
+Garrulax merulinus_spot-breasted laughingthrush_spblau1
+Garrulax annamensis_orange-breasted laughingthrush_orblau1
+Garrulax canorus_chinese hwamei_melthr
+Garrulax taewanus_taiwan hwamei_taihwa1
+Garrulax canorus x taewanus_chinese x taiwan hwamei (hybrid)_x00816
+Garrulax canorus/taewanus_chinese/taiwan hwamei_y00910
+Garrulax monileger_lesser necklaced laughingthrush_lenlau1
+Garrulax rufifrons_rufous-fronted laughingthrush_ruflau1
+Garrulax palliatus_sunda laughingthrush_sunlau1
+Garrulax leucolophus_zaragateiro-de-crista-branca_whclau2
+Garrulax bicolor_sumatran laughingthrush_sumlau1
+Garrulax milleti_black-hooded laughingthrush_blhlau1
+Garrulax strepitans_white-necked laughingthrush_whnlau1
+Garrulax ferrarius_cambodian laughingthrush_camlau1
+Garrulax maesi_gray laughingthrush_grylau1
+Garrulax castanotis_rufous-cheeked laughingthrush_ruclau3
+Garrulax sp._Garrulax sp._garrul1
+Ianthocincla sukatschewi_snowy-cheeked laughingthrush_suklau1
+Ianthocincla rufogularis_rufous-chinned laughingthrush_ruclau1
+Ianthocincla konkakinhensis_chestnut-eared laughingthrush_chelau1
+Ianthocincla cineracea_moustached laughingthrush_moulau1
+Ianthocincla cineracea cineracea/strenua_moustached laughingthrush (Western)_moulau2
+Ianthocincla cineracea cinereiceps_moustached laughingthrush (Eastern)_moulau3
+Ianthocincla ocellata_spotted laughingthrush_spolau1
+Ianthocincla ocellata [ocellata Group]_spotted laughingthrush (Brown-cheeked)_spolau6
+Ianthocincla ocellata artemisiae_spotted laughingthrush (Black-headed)_spolau5
+Ianthocincla maxima_giant laughingthrush_gialau1
+Ianthocincla bieti_biet's laughingthrush_bielau1
+Ianthocincla lunulata_barred laughingthrush_barlau1
+Pterorhinus delesserti_wayanad laughingthrush_wynlau1
+Pterorhinus gularis_rufous-vented laughingthrush_ruvlau1
+Pterorhinus vassali_white-cheeked laughingthrush_whclau1
+Pterorhinus galbanus_yellow-throated laughingthrush_yetlau1
+Pterorhinus courtoisi_blue-crowned laughingthrush_buclau1
+Pterorhinus mitratus_chestnut-capped laughingthrush_chclau3
+Pterorhinus treacheri_chestnut-hooded laughingthrush_chhlau1
+Pterorhinus [undescribed Meratus form]_meratus laughingthrush (undescribed form)_merlau1
+Pterorhinus ruficollis_rufous-necked laughingthrush_runlau1
+Pterorhinus nuchalis_chestnut-backed laughingthrush_chblau1
+Pterorhinus chinensis_black-throated laughingthrush_bltlau1
+Pterorhinus chinensis [chinensis Group]_black-throated laughingthrush (Black-throated)_bktlau1
+Pterorhinus chinensis monachus_black-throated laughingthrush (Hainan)_bktlau2
+Pterorhinus sannio_white-browed laughingthrush_whblau1
+Pterorhinus perspicillatus_masked laughingthrush_maslau1
+Pterorhinus pectoralis_greater necklaced laughingthrush_gnlthr
+Garrulax monileger/Pterorhinus pectoralis_lesser/greater necklaced laughingthrush_y01002
+Pterorhinus davidi_pere david's laughingthrush_pedlau1
+Pterorhinus woodi_mount victoria babax_chibub1
+Pterorhinus lanceolatus_chinese babax_chibab2
+Pterorhinus waddelli_giant babax_giabab1
+Pterorhinus koslowi_tibetan babax_tibbab1
+Pterorhinus albogularis_white-throated laughingthrush_whtlau1
+Pterorhinus ruficeps_rufous-crowned laughingthrush_ruclau2
+Pterorhinus caerulatus_gray-sided laughingthrush_gyslau
+Pterorhinus berthemyi_buffy laughingthrush_buflau1
+Pterorhinus poecilorhynchus_rusty laughingthrush_ruslau1
+Ianthocincla/Pterorhinus sp._Ianthocincla/Pterorhinus sp._iantho1
+Leiothrichidae sp. (laughingthrush sp.)_laughingthrush sp._laughi1
+Corthylio calendula_estrelinha-de-fogo_ruckin
+Regulus satrapa_golden-crowned kinglet_gockin
+Corthylio calendula/Regulus satrapa_ruby-crowned/golden-crowned kinglet_y00425
+Regulus regulus_estrelinha-de-poupa_goldcr1
+Regulus regulus [regulus Group]_estrelinha-de-poupa [grupo regulus]_goldcr6
+Regulus regulus ellenthalerae_estrelinha-de-poupa (ellenthalerae)_goldcr7
+Regulus regulus teneriffae_estrelinha-de-poupa (teneriffae)_caikin1
+Regulus regulus azoricus_estrelinha-de-poupa (São Miguel)_goldcr2
+Regulus regulus sanctaemariae_estrelinha-de-poupa (Santa Maria)_goldcr3
+Regulus regulus inermis_estrelinha-de-poupa (Ocidental)_goldcr4
+Regulus regulus [himalayensis Group]_estrelinha-de-poupa [grupo himalayensis]_goldcr5
+Regulus goodfellowi_flamecrest_flamec1
+Regulus madeirensis_bis-bis_firecr3
+Regulus ignicapilla_estrelinha-real_firecr1
+Regulus regulus/ignicapilla_estrelinha-de-poupa/estrelinha-real_y00622
+Tichodroma muraria_trepa-fragas_wallcr1
+Sitta leucopsis_white-cheeked nuthatch_whcnut1
+Sitta przewalskii_przevalski's nuthatch_prznut1
+Sitta magna_giant nuthatch_gianut1
+Sitta carolinensis_white-breasted nuthatch_whbnut
+Sitta carolinensis carolinensis_white-breasted nuthatch (Eastern)_whbnut2
+Sitta carolinensis [lagunae Group]_white-breasted nuthatch (Interior West)_whbnut3
+Sitta carolinensis aculeata/alexandrae_white-breasted nuthatch (Pacific)_whbnut4
+Sitta formosa_beautiful nuthatch_beanut1
+Sitta azurea_blue nuthatch_blunut1
+Sitta frontalis_velvet-fronted nuthatch_vefnut1
+Sitta solangiae_yellow-billed nuthatch_yebnut1
+Sitta frontalis/solangiae_velvet-fronted/yellow-billed nuthatch_y01044
+Sitta oenochlamys_sulphur-billed nuthatch_subnut1
+Sitta pygmaea_pygmy nuthatch_pygnut
+Sitta pusilla_brown-headed nuthatch_bnhnut
+Sitta insularis_bahama nuthatch_bnhnut2
+Sitta yunnanensis_yunnan nuthatch_yunnut1
+Sitta ledanti_trepadeira-azul-da-argélia_algnut1
+Sitta krueperi_trepadeira-azul-do-levante_krunut1
+Sitta canadensis_trepadeira-azul-do-canadá_rebnut
+Sitta whiteheadi_trepadeira-azul-da-córsega_cornut1
+Sitta villosa_snowy-browed nuthatch_snbnut1
+Sitta neumayer_trepadeira-rupestre-do-levante_rocnut1
+Sitta tephronota_trepadeira-rupestre-oriental_pernut1
+Sitta neumayer/tephronota_trepadeira-rupestre-do-levante/trepadeira-rupestre-oriental_y00903
+Sitta arctica_siberian nuthatch_eurnut6
+Sitta victoriae_white-browed nuthatch_whbnut1
+Sitta himalayensis_white-tailed nuthatch_whtnut1
+Sitta castanea_indian nuthatch_chbnut2
+Sitta cinnamoventris_chestnut-bellied nuthatch_chbnut3
+Sitta castanea/cinnamoventris_indian/chestnut-bellied nuthatch_y00902
+Sitta neglecta_burmese nuthatch_chbnut4
+Sitta cinnamoventris/neglecta_chestnut-bellied/burmese nuthatch_y01266
+Sitta europaea_trepadeira-azul_eurnut2
+Sitta europaea [europaea Group]_trepadeira-azul [grupo europaea]_eurnut9
+Sitta europaea [asiatica Group]_trepadeira-azul [grupo asiatica]_eurnut10
+Sitta europaea [roseilia Group]_trepadeira-azul [grupo roseilia]_eurnut7
+Sitta europaea sinensis/formosana_trepadeira-azul (sinensis/formosana)_eurnut8
+Sitta arctica/europaea_siberian/eurasian nuthatch_y01222
+Sitta nagaensis_chestnut-vented nuthatch_chvnut1
+Sitta cashmirensis_kashmir nuthatch_kasnut1
+Sitta sp._trepadeira (Sitta) sp._nuthat1
+Salpornis salvadori_african spotted creeper_spocre2
+Salpornis spilonota_indian spotted creeper_spocre3
+Certhia familiaris_trepadeira-do-norte_eurtre1
+Certhia hodgsoni_hodgson's treecreeper_eurtre3
+Certhia tianquanensis_sichuan treecreeper_sictre1
+Certhia americana_brown creeper_brncre
+Certhia americana [occidentalis Group]_brown creeper (occidentalis Group)_brncre1
+Certhia americana montana/idahoensis_brown creeper (montana/idahoensis)_brncre5
+Certhia americana americana/nigrescens_brown creeper (americana/nigrescens)_brncre3
+Certhia americana albescens/alticola_brown creeper (albescens/alticola)_brncre2
+Certhia americana pernigra_brown creeper (pernigra)_brncre6
+Certhia americana extima_brown creeper (extima)_brncre4
+Certhia brachydactyla_trepadeira-do-sul_shttre1
+Certhia familiaris/brachydactyla_trepadeira-do-norte/trepadeira-do-sul_y00640
+Certhia himalayana_bar-tailed treecreeper_battre1
+Certhia nipalensis_rusty-flanked treecreeper_ruftre4
+Certhia discolor_sikkim treecreeper_bnttre1
+Certhia manipurensis_hume's treecreeper_bnttre2
+Certhia sp._trepadeira (Certhia) sp._certhi1
+Microbates collaris_chirito-de-coleira_colgna1
+Microbates cinereiventris_tawny-faced gnatwren_tafgna1
+Ramphocaenus melanurus_chirito_lobgna5
+Ramphocaenus melanurus [rufiventris Group]_chirito [grupo rufiventris]_lobgna3
+Ramphocaenus melanurus [melanurus Group]_chirito [grupo melanurus]_lobgna2
+Ramphocaenus sticturus_chirito-do-bambu_lobgna4
+Ramphocaenus melanurus/sticturus_chirito/chirito-do-bambu_lobgna1
+Polioptila guianensis_balança-rabo-guianense_guigna3
+Polioptila schistaceigula_slate-throated gnatcatcher_sltgna1
+Polioptila clementsi_iquitos gnatcatcher_iqugna1
+Polioptila facilis_balança-rabo-do-rio-negro_guigna2
+Polioptila guianensis/facilis_guianan/rio negro gnatcatcher_y01156
+Polioptila attenboroughi_balança-rabo-do-inambari_inagna1
+Polioptila paraensis_balança-rabo-paraense_guigna4
+Polioptila attenboroughi/paraensis_inambari/klages's gnatcatcher_y01157
+Polioptila dumicola_balança-rabo-de-máscara_masgna1
+Polioptila lactea_balança-rabo-leitoso_crbgna1
+Polioptila lembeyei_cuban gnatcatcher_cubgna1
+Polioptila plumbea_balança-rabo-de-chapéu-preto/de-roraima/do-acre/do-nordeste_trogna1
+Polioptila plumbea plumbiceps/anteocularis_balança-rabo-de-chapéu-preto (plumbiceps/anteocularis)_trogna9
+Polioptila plumbea innotata_balança-rabo-de-roraima_trogna6
+Polioptila plumbea plumbea_balança-rabo-de-chapéu-preto_trogna8
+Polioptila plumbea parvirostris_balança-rabo-do-acre_trogna7
+Polioptila plumbea atricapilla_balança-rabo-do-nordeste_trogna5
+Polioptila maior_marañon gnatcatcher_trogna3
+Polioptila albiventris_yucatan gnatcatcher_whlgna3
+Polioptila bilineata_white-browed gnatcatcher_trogna2
+Polioptila caerulea_blue-gray gnatcatcher_buggna
+Polioptila caerulea [obscura Group]_blue-gray gnatcatcher (Western)_buggna2
+Polioptila caerulea caerulea_blue-gray gnatcatcher (Eastern)_buggna1
+Polioptila caerulea cozumelae_blue-gray gnatcatcher (Cozumel)_buggna3
+Polioptila melanura_black-tailed gnatcatcher_bktgna
+Polioptila californica_california gnatcatcher_calgna
+Polioptila nigriceps_black-capped gnatcatcher_bkcgna
+Polioptila melanura x nigriceps_black-tailed x black-capped gnatcatcher (hybrid)_x00643
+Polioptila albiloris_white-lored gnatcatcher_whlgna2
+Polioptila albiloris vanrossemi_white-lored gnatcatcher (Van Rossem's)_whlgna4
+Polioptila albiloris albiloris_white-lored gnatcatcher (Central American)_whlgna5
+Polioptila sp._Polioptila sp._gnatca1
+Salpinctes obsoletus_rock wren_rocwre
+Salpinctes obsoletus [obsoletus Group]_rock wren (Northern)_rocwre1
+Salpinctes obsoletus [guttatus Group]_rock wren (Central American)_rocwre2
+Microcerculus philomela_nightingale wren_nigwre1
+Microcerculus marginatus_uirapuru-veado_scbwre1
+Microcerculus marginatus luscinia_uirapuru-veado (luscinia)_scbwre2
+Microcerculus marginatus taeniatus/occidentalis_uirapuru-veado (taeniatus/occidentalis)_scbwre3
+Microcerculus marginatus [marginatus Group]_uirapuru-veado [grupo marginatus]_scbwre4
+Microcerculus ustulatus_flautista-do-tepui_fluwre1
+Microcerculus bambla_uirapuru-de-asa-branca_wibwre1
+Odontorchilus branickii_gray-mantled wren_gymwre1
+Odontorchilus cinereus_cambaxirra-cinzenta_tobwre1
+Catherpes mexicanus_canyon wren_canwre
+Hylorchilus sumichrasti_sumichrast's wren_sumwre1
+Hylorchilus navai_nava's wren_navwre1
+Ferminia cerverai_zapata wren_zapwre1
+Troglodytes aedon_corruíra-boreal_houwre
+Troglodytes aedon [aedon Group]_corruíra-boreal [grupo aedon]_houwre1
+Troglodytes aedon [brunneicollis Group]_corruíra-boreal [grupo brunneicollis]_bntwre1
+Troglodytes beani_cozumel wren_houwre3
+Troglodytes martinicensis_kalinago wren_cinwre1
+Troglodytes martinicensis guadeloupensis_kalinago wren (Guadeloupe)_houwre9
+Troglodytes martinicensis rufescens_kalinago wren (Dominica)_houwre6
+Troglodytes martinicensis martinicensis_kalinago wren (Martinique)_houwre7
+Troglodytes mesoleucus_st. lucia wren_houwre8
+Troglodytes musicus_st. vincent wren_houwre10
+Troglodytes grenadensis_grenada wren_houwre11
+Troglodytes musculus_corruíra_houwre4
+Troglodytes musculus [intermedius Group]_corruíra [grupo intermedius]_sohwre4
+Troglodytes musculus [audax Group]_corruíra [grupo audax]_sohwre5
+Troglodytes musculus carabayae_corruíra (carabayae)_houwre31
+Troglodytes musculus [musculus Group]_corruíra [grupo musculus]_sohwre6
+Troglodytes aedon/musculus_corruíra-boreal/corruíra_y01309
+Troglodytes cobbi_cobb's wren_houwre5
+Troglodytes sissonii_socorro wren_socwre2
+Troglodytes tanneri_clarion wren_clawre1
+Troglodytes rufociliatus_rufous-browed wren_rubwre2
+Troglodytes ochraceus_ochraceous wren_ochwre1
+Troglodytes solstitialis_mountain wren_mouwre1
+Troglodytes monticola_santa marta wren_samwre1
+Troglodytes rufulus_corruíra-do-tepui_tepwre1
+Troglodytes troglodytes_carriça_winwre4
+Troglodytes troglodytes islandicus_carriça (islandicus)_eurwre1
+Troglodytes troglodytes borealis_carriça (borealis)_eurwre2
+Troglodytes troglodytes zetlandicus_carriça (zetlandicus)_eurwre3
+Troglodytes troglodytes hebridensis_carriça (hebridensis)_eurwre4
+Troglodytes troglodytes fridariensis_carriça (fridariensis)_eurwre5
+Troglodytes troglodytes hirtensis_carriça (hirtensis)_eurwre6
+Troglodytes troglodytes indigenus_carriça (indigenus)_eurwre7
+Troglodytes troglodytes [troglodytes Group]_carriça [grupo troglodytes]_eurwre8
+Troglodytes pacificus_pacific wren_pacwre1
+Troglodytes pacificus [alascensis Group]_pacific wren (alascensis Group)_winwre1
+Troglodytes pacificus [pacificus Group]_pacific wren (pacificus Group)_winwre2
+Troglodytes hiemalis_winter wren_winwre3
+Troglodytes pacificus/hiemalis_pacific/winter wren_winwre
+Thryorchilus browni_timberline wren_timwre1
+Cistothorus stellaris_sedge wren_sedwre1
+Cistothorus platensis_corruíra-do-campo_sedwre
+Cistothorus platensis [elegans Group]_corruíra-do-campo [grupo elegans]_sedwre2
+Cistothorus platensis alticola_corruíra-do-campo (alticola)_sedwre6
+Cistothorus platensis aequatorialis_corruíra-do-campo (aequatorialis)_sedwre7
+Cistothorus platensis graminicola_corruíra-do-campo (graminicola)_sedwre8
+Cistothorus platensis minimus_corruíra-do-campo (minimus)_sedwre9
+Cistothorus platensis tucumanus_corruíra-do-campo (tucumanus)_sedwre10
+Cistothorus platensis platensis/polyglottus_corruíra-do-campo (platensis/polyglottus)_sedwre11
+Cistothorus platensis hornensis/falklandicus_corruíra-do-campo (hornensis/falklandicus)_sedwre12
+Cistothorus meridae_merida wren_merwre1
+Cistothorus apolinari_apolinar's wren_apowre1
+Cistothorus palustris_marsh wren_marwre
+Cistothorus palustris [paludicola Group]_marsh wren (paludicola Group)_marwre1
+Cistothorus palustris [plesius Group]_marsh wren (plesius Group)_marwre2
+Cistothorus palustris [palustris Group]_marsh wren (palustris Group)_marwre3
+Cistothorus palustris griseus_marsh wren (griseus)_marwre5
+Cistothorus palustris tolucensis_marsh wren (tolucensis)_marwre4
+Cistothorus stellaris/palustris_sedge/marsh wren_y00328
+Thryothorus ludovicianus_carolina wren_carwre
+Thryothorus ludovicianus [ludovicianus Group]_carolina wren (Northern)_carwre1
+Thryothorus ludovicianus [berlandieri Group]_carolina wren (Northeast Mexico/South Texas)_y00487
+Thryothorus ludovicianus albinucha/subfulvus_carolina wren (White-browed)_carwre2
+Troglodytes aedon x Thryothorus ludovicianus_northern house x carolina wren (hybrid)_x01068
+Thryomanes bewickii_bewick's wren_bewwre
+Thryomanes bewickii bewickii_bewick's wren (bewickii)_bewwre3
+Thryomanes bewickii [mexicanus Group]_bewick's wren (mexicanus Group)_bewwre2
+Thryomanes bewickii [spilurus Group]_bewick's wren (spilurus Group)_bewwre1
+Campylorhynchus albobrunneus_white-headed wren_whhwre1
+Campylorhynchus zonatus_band-backed wren_babwre1
+Campylorhynchus zonatus [zonatus Group]_band-backed wren (Mesoamerican)_babwre11
+Campylorhynchus zonatus costaricensis/panamensis_band-backed wren (Costa Rican)_babwre10
+Campylorhynchus zonatus brevirostris/curvirostris_band-backed wren (Colombian)_babwre9
+Campylorhynchus albobrunneus x zonatus_white-headed x band-backed wren (hybrid)_x00969
+Campylorhynchus megalopterus_gray-barred wren_grbwre1
+Campylorhynchus chiapensis_giant wren_giawre1
+Campylorhynchus humilis_russet-naped wren_runwre3
+Campylorhynchus rufinucha_veracruz wren_runwre2
+Campylorhynchus capistratus_rufous-backed wren_runwre4
+Campylorhynchus capistratus castaneus_rufous-backed wren (Sula Valley)_runwre8
+Campylorhynchus capistratus [capistratus Group]_rufous-backed wren (Rufous-backed)_rubwre14
+Campylorhynchus humilis/capistratus_russet-naped/rufous-backed wren_y01335
+Campylorhynchus gularis_spotted wren_spowre1
+Campylorhynchus jocosus_boucard's wren_bouwre1
+Campylorhynchus yucatanicus_yucatan wren_yucwre1
+Campylorhynchus brunneicapillus_cactus wren_cacwre
+Campylorhynchus brunneicapillus [brunneicapillus Group]_cactus wren (brunneicapillus Group)_cacwre2
+Campylorhynchus brunneicapillus [affinis Group]_cactus wren (affinis Group)_cacwre1
+Campylorhynchus nuchalis_stripe-backed wren_stbwre2
+Campylorhynchus fasciatus_fasciated wren_faswre1
+Campylorhynchus griseus_garrincha-dos-lhanos_bicwre1
+Campylorhynchus turdinus_catatau_thlwre1
+Campylorhynchus turdinus turdinus/hypostictus_thrush-like wren (Spot-breasted)_thlwre5
+Campylorhynchus turdinus unicolor_thrush-like wren (Unspotted)_thlwre4
+Pheugopedius spadix_sooty-headed wren_sohwre1
+Pheugopedius fasciatoventris_black-bellied wren_blbwre1
+Pheugopedius euophrys_plain-tailed wren_pltwre1
+Pheugopedius euophrys euophrys_plain-tailed wren (Western)_pltwre4
+Pheugopedius euophrys longipes/atriceps_plain-tailed wren (Eastern)_pltwre7
+Pheugopedius schulenbergi_gray-browed wren_pltwre3
+Pheugopedius [undescribed form]_mantaro wren (undescribed form)_manwre1
+Pheugopedius eisenmanni_inca wren_incwre1
+Pheugopedius mystacalis_whiskered wren_whiwre1
+Pheugopedius genibarbis_garrinchão-pai-avô_mouwre2
+Pheugopedius coraya_garrinchão-coraia_corwre1
+Pheugopedius genibarbis x coraya_garrinchão-pai-avô x garrinchão-coraia (híbrido)_x00970
+Pheugopedius genibarbis/coraya_garrinchão-pai-avô/garrinchão-coraia_y00984
+Pheugopedius rutilus_rufous-breasted wren_rubwre1
+Pheugopedius maculipectus_spot-breasted wren_spbwre1
+Pheugopedius sclateri_speckle-breasted wren_spbwre2
+Pheugopedius sclateri columbianus_speckle-breasted wren (Colombian)_spbwre5
+Pheugopedius sclateri paucimaculatus_speckle-breasted wren (Speckle-breasted)_spbwre3
+Pheugopedius sclateri sclateri_speckle-breasted wren (Marañon)_spbwre4
+Pheugopedius felix_happy wren_hapwre1
+Pheugopedius felix [felix Group]_happy wren (Mainland)_hapwre8
+Pheugopedius felix lawrencii_happy wren (Tres Marias Is.)_hapwre9
+Pheugopedius atrogularis_black-throated wren_bltwre1
+Pheugopedius sp._Pheugopedius sp._pheugo1
+Thryophilus sinaloa_sinaloa wren_sinwre1
+Thryophilus pleurostictus_banded wren_banwre1
+Thryophilus rufalbus_rufous-and-white wren_rawwre1
+Thryophilus sernai_antioquia wren_antwre2
+Thryophilus nicefori_niceforo's wren_nicwre1
+Cantorchilus thoracicus_stripe-breasted wren_stbwre1
+Cantorchilus leucopogon_stripe-throated wren_sttwre1
+Cantorchilus modestus_cabanis's wren_plawre1
+Cantorchilus zeledoni_canebrake wren_plawre3
+Cantorchilus modestus/zeledoni_cabanis's/canebrake wren_y00985
+Cantorchilus elutus_isthmian wren_istwre1
+Cantorchilus modestus/elutus_cabanis's/isthmian wren_y00986
+Cantorchilus semibadius_riverside wren_rivwre1
+Cantorchilus nigricapillus_bay wren_baywre1
+Cantorchilus nigricapillus [castaneus Group]_bay wren (Central American)_baywre2
+Cantorchilus nigricapillus nigricapillus/connectens_bay wren (South American)_baywre3
+Cantorchilus superciliaris_superciliated wren_supwre1
+Cantorchilus leucotis_garrinchão-de-barriga-vermelha_bubwre1
+Cantorchilus longirostris_garrinchão-de-bico-grande_lobwre1
+Cantorchilus guarayanus_garrincha-do-oeste_fabwre1
+Cantorchilus griseus_garrincha-cinza_grywre1
+Cantorchilus sp._Cantorchilus sp._cantor1
+Cinnycerthia unirufa_rufous wren_rufwre1
+Cinnycerthia olivascens_sharpe's wren_shawre1
+Cinnycerthia peruana_peruvian wren_perwre1
+Cinnycerthia fulva_fulvous wren_fulwre1
+Cinnycerthia sp._Cinnycerthia sp._cinnyc1
+Uropsila leucogastra_white-bellied wren_whbwre1
+Uropsila leucogastra [leucogastra Group]_white-bellied wren (Middle America)_whbwre3
+Uropsila leucogastra pacifica_white-bellied wren (West Mexico)_whbwre4
+Henicorhina leucosticta_uirapuru-de-peito-branco_wbwwre1
+Henicorhina leucosticta [prostheleuca Group]_uirapuru-de-peito-branco [grupo prostheleuca]_whbwow1
+Henicorhina leucosticta pittieri/costaricensis_uirapuru-de-peito-branco (pittieri/costaricensis)_whbwow2
+Henicorhina leucosticta inornata/eucharis_uirapuru-de-peito-branco (inornata/eucharis)_whbwow4
+Henicorhina leucosticta [leucosticta Group]_uirapuru-de-peito-branco [grupo leucosticta]_whbwow3
+Henicorhina leucoptera_bar-winged wood-wren_bwwwre1
+Henicorhina leucophrys_gray-breasted wood-wren_gbwwre1
+Henicorhina leucophrys [mexicana Group]_gray-breasted wood-wren (Central American)_gybwow1
+Henicorhina leucophrys brunneiceps_gray-breasted wood-wren (Choco)_gybwow2
+Henicorhina leucophrys bangsi_gray-breasted wood-wren (bangsi)_gybwow4
+Henicorhina leucophrys manastarae_gray-breasted wood-wren (Perija)_gybwow5
+Henicorhina leucophrys meridana_gray-breasted wood-wren (meridana)_gybwow6
+Henicorhina leucophrys venezuelensis_gray-breasted wood-wren (venezuelensis)_gybwow7
+Henicorhina leucophrys hilaris_gray-breasted wood-wren (hilaris)_gybwow9
+Henicorhina leucophrys leucophrys/boliviana_gray-breasted wood-wren (Andean)_gybwow8
+Henicorhina anachoreta_hermit wood-wren_gybwow3
+Henicorhina negreti_munchique wood-wren_munwow1
+Henicorhina sp._wood-wren sp._woodwr1
+Cyphorhinus dichrous_northern chestnut-breasted wren_chbwre2
+Cyphorhinus thoracicus_southern chestnut-breasted wren_chbwre3
+Cyphorhinus phaeocephalus_song wren_sonwre1
+Cyphorhinus arada_uirapuru-da-guiana/de-flanco-cinza/de-orelha-alaranjada/do-imeri/ferrugíneo_muswre2
+Cyphorhinus arada transfluvialis_uirapuru-do-imeri_muswre1
+Cyphorhinus arada salvini_uirapuru-verdadeiro (salvini)_muswre3
+Cyphorhinus arada arada_uirapuru-da-guiana_muswre4
+Cyphorhinus arada griseolateralis_uirapuru-de-flanco-cinza_muswre5
+Cyphorhinus arada interpositus_uirapuru-de-orelha-alaranjada_muswre6
+Cyphorhinus arada modulator_uirapuru-ferrugíneo_muswre7
+Troglodytidae sp._Troglodytidae sp._wren1
+Elachura formosa_spotted elachura_spwbab1
+Cinclus cinclus_melro-d'água_whtdip1
+Cinclus pallasii_brown dipper_brodip1
+Cinclus mexicanus_american dipper_amedip
+Cinclus mexicanus [mexicanus Group]_american dipper (Northern)_amedip1
+Cinclus mexicanus ardesiacus_american dipper (Costa Rican)_amedip2
+Cinclus leucocephalus_white-capped dipper_whcdip1
+Cinclus leucocephalus rivularis_white-capped dipper (Santa Marta)_whcdip2
+Cinclus leucocephalus leuconotus_white-capped dipper (White-bellied)_whcdip3
+Cinclus leucocephalus leucocephalus_white-capped dipper (White-capped)_whcdip4
+Cinclus schulzii_rufous-throated dipper_rutdip1
+Buphagus erythroryncha_red-billed oxpecker_reboxp1
+Buphagus africanus_yellow-billed oxpecker_yeboxp1
+Buphagus erythroryncha/africanus_red-billed/yellow-billed oxpecker_y00825
+Rhabdornis mystacalis_stripe-sided rhabdornis_stsrha2
+Rhabdornis grandis_long-billed rhabdornis_lobrha1
+Rhabdornis inornatus_stripe-breasted rhabdornis_stbrha1
+Rhabdornis rabori_visayan rhabdornis_visrha1
+Enodes erythrophris_fiery-browed myna_fibmyn1
+Scissirostrum dubium_finch-billed myna_fibmyn2
+Aplonis metallica_metallic starling_metsta1
+Aplonis metallica circumscripta_metallic starling (Violet-hooded)_metsta3
+Aplonis metallica [metallica Group]_metallic starling (Metallic)_metsta2
+Aplonis mystacea_yellow-eyed starling_yeesta1
+Aplonis crassa_tanimbar starling_tansta1
+Aplonis feadensis_atoll starling_atosta1
+Aplonis insularis_rennell starling_rensta1
+Aplonis magna_long-tailed starling_lotsta1
+Aplonis brunneicapillus_white-eyed starling_whesta2
+Aplonis grandis_brown-winged starling_brwsta1
+Aplonis dichroa_makira starling_sacsta1
+Aplonis zelandica_rusty-winged starling_ruwsta1
+Aplonis striata_striated starling_strsta1
+Aplonis pelzelni_pohnpei starling_pohsta1
+Aplonis cantoroides_singing starling_sinsta1
+Aplonis santovestris_mountain starling_mousta1
+Aplonis panayensis_asian glossy starling_asgsta1
+Aplonis mysolensis_moluccan starling_molsta1
+Aplonis minor_estorninho-de-cauda-curta_shtsta1
+Aplonis opaca_micronesian starling_micsta1
+Aplonis tabuensis_polynesian starling_polsta1
+Aplonis tabuensis [tabuensis Group]_polynesian starling (Polynesian)_polsta2
+Aplonis tabuensis manuae_polynesian starling (Manua)_polsta3
+Aplonis atrifusca_samoan starling_samsta1
+Aplonis corvina_kosrae starling_kossta1
+Aplonis cinerascens_rarotonga starling_rarsta1
+Aplonis mavornata_mysterious starling_myssta1
+Aplonis fusca_tasman starling_norsta1
+Aplonis ulietensis_raiatea starling_raista2
+Aplonis sp._Aplonis sp._aploni1
+Basilornis celebensis_sulawesi myna_sulmyn1
+Basilornis galeatus_helmeted myna_helmyn1
+Basilornis corythaix_long-crested myna_locmyn1
+Goodfellowia miranda_apo myna_apomyn2
+Sarcops calvus_coleto_coleto1
+Streptocitta albicollis_white-necked myna_whnmyn1
+Streptocitta albicollis torquata_white-necked myna (Northern)_whnmyn2
+Streptocitta albicollis albicollis_white-necked myna (Southern)_whnmyn3
+Streptocitta albertinae_bare-eyed myna_baemyn1
+Mino dumontii_yellow-faced myna_yefmyn1
+Mino anais_golden myna_golmyn1
+Mino kreffti_long-tailed myna_lotmyn1
+Ampeliceps coronatus_golden-crested myna_gocmyn1
+Gracula ptilogenys_sri lanka myna_ceymyn1
+Gracula religiosa_common hill myna_hilmyn
+Gracula religiosa [religiosa Group]_common hill myna (Common)_cohmyn1
+Gracula religiosa miotera_common hill myna (Simeulue)_cohmyn9
+Gracula religiosa robusta_common hill myna (Nias)_niamyn1
+Gracula religiosa enganensis_common hill myna (Enggano)_engmyn1
+Gracula venerata_tenggara hill myna_cohmyn2
+Gracula indica_southern hill myna_sohmyn1
+Sturnus vulgaris_estorninho_eursta
+Sturnus unicolor_estorninho-preto_sposta1
+Sturnus vulgaris/unicolor_estorninho-malhado/estorninho-preto_y00626
+Creatophora cinerea_wattled starling_watsta1
+Pastor roseus_estorninho-rosado_rossta2
+Agropsar sturninus_estorninho-dáurico_dausta1
+Agropsar philippensis_chestnut-cheeked starling_chcsta1
+Agropsar sturninus/philippensis_daurian/chestnut-cheeked starling_y00756
+Gracupica nigricollis_black-collared starling_bkcsta1
+Gracupica contra_indian pied starling_aspsta2
+Gracupica floweri_siamese pied starling_aspsta7
+Gracupica jalla_javan pied starling_aspsta3
+Gracupica contra/floweri/jalla_pied starling sp._piesta1
+Sturnornis albofrontatus_white-faced starling_whfsta2
+Leucopsar rothschildi_bali myna_balmyn1
+Necropsar rodericanus_rodrigues starling_rodsta2
+Fregilupus varius_reunion starling_reusta1
+Sturnia sinensis_white-shouldered starling_whssta2
+Sturnia pagodarum_brahminy starling_brasta1
+Sturnia malabarica_chestnut-tailed starling_chtsta2
+Sturnia malabarica malabarica_chestnut-tailed starling (Western)_chtsta1
+Sturnia malabarica nemoricola_chestnut-tailed starling (Eastern)_chtsta3
+Gracupica contra x Sturnia malabarica_indian pied x chestnut-tailed starling (hybrid)_x01027
+Sturnia blythii_malabar starling_malsta1
+Sturnia malabarica/blythii_chestnut-tailed/malabar starling_y00824
+Sturnia erythropygia_white-headed starling_whhsta2
+Spodiopsar sericeus_red-billed starling_rebsta1
+Spodiopsar cineraceus_white-cheeked starling_whcsta1
+Acridotheres tristis_mainato-de-mascarilha-amarela_commyn
+Acridotheres ginginianus_bank myna_banmyn1
+Acridotheres burmannicus_burmese myna_vibsta1
+Acridotheres leucocephalus_vinous-breasted myna_vibsta4
+Acridotheres burmannicus/leucocephalus_burmese/vinous-breasted myna_vibsta3
+Acridotheres melanopterus_black-winged myna_bkwsta1
+Acridotheres melanopterus melanopterus_black-winged myna (Black-winged)_bkwsta2
+Acridotheres melanopterus tricolor_black-winged myna (Gray-backed)_bkwsta3
+Acridotheres melanopterus tertius_black-winged myna (Gray-rumped)_bkwsta4
+Acridotheres fuscus_jungle myna_junmyn1
+Acridotheres fuscus mahrattensis_jungle myna (Blue-eyed)_junmyn3
+Acridotheres fuscus [fuscus Group]_jungle myna (Yellow-eyed)_junmyn6
+Acridotheres burmannicus x fuscus_burmese x jungle myna (hybrid)_x01056
+Acridotheres tristis/fuscus_common/jungle myna_y00823
+Acridotheres javanicus_javan myna_whvmyn
+Acridotheres fuscus x javanicus_jungle x javan myna (hybrid)_x01028
+Acridotheres cinereus_mainato-de-barriga-branca_pabmyn1
+Acridotheres albocinctus_collared myna_colmyn1
+Acridotheres grandis_great myna_whvmyn1
+Gracupica nigricollis x Acridotheres grandis_black-collared starling x great myna (hybrid)_x00468
+Gracupica floweri x Acridotheres grandis_siamese pied starling x great myna (hybrid)_x01136
+Acridotheres tristis x grandis_common x great myna (hybrid)_x00469
+Acridotheres leucocephalus x grandis_vinous-breasted x great myna (hybrid)_x01160
+Acridotheres fuscus x grandis_jungle x great myna (hybrid)_x01029
+Acridotheres javanicus x grandis_javan x great myna (hybrid)_x00893
+Acridotheres cristatellus_mainato-de-poupa_cremyn
+Spodiopsar cineraceus x Acridotheres cristatellus_white-cheeked starling x crested myna (hybrid)_x01083
+Acridotheres tristis x cristatellus_mainato-de-mascarilha-amarela x mainato-de-poupa (híbrido)_x01030
+Acridotheres albocinctus x cristatellus_collared x crested myna (hybrid)_x01031
+Acridotheres fuscus/cristatellus_jungle/crested myna_y01011
+Acridotheres sp. (black myna sp.)_mainato (Acridotheres) sp._blkmyn1
+Acridotheres sp._mainato (Acridotheres preto) sp._acrido1
+Hartlaubius auratus_madagascar starling_madsta1
+Cinnyricinclus leucogaster_violet-backed starling_vibsta2
+Onychognathus tenuirostris_slender-billed starling_slbsta1
+Onychognathus nabouroup_pale-winged starling_pawsta1
+Onychognathus neumanni_neumann's starling_neusta1
+Onychognathus morio_red-winged starling_rewsta1
+Onychognathus fulgidus_chestnut-winged starling_chwsta1
+Onychognathus fulgidus fulgidus_chestnut-winged starling (Chestnut-winged)_chwsta2
+Onychognathus fulgidus hartlaubii/intermedius_chestnut-winged starling (Hartlaub's)_chwsta3
+Onychognathus walleri_waller's starling_walsta1
+Onychognathus walleri preussi_waller's starling (Preuss's)_walsta3
+Onychognathus walleri elgonensis_waller's starling (Albertine)_walsta4
+Onychognathus walleri walleri_waller's starling (Waller's)_walsta5
+Onychognathus tristramii_estorninho-d'asa-ruiva_trista1
+Onychognathus albirostris_white-billed starling_whbsta1
+Onychognathus salvadorii_bristle-crowned starling_brcsta1
+Onychognathus blythii_somali starling_somsta1
+Onychognathus frater_socotra starling_socsta1
+Saroglossa spilopterus_spot-winged starling_spwsta1
+Neocichla gutturalis_babbling starling_babsta1
+Neocichla gutturalis gutturalis_babbling starling (Western)_babsta2
+Neocichla gutturalis angusta_babbling starling (Eastern)_babsta3
+Grafisia torquata_white-collared starling_whcsta2
+Speculipastor bicolor_magpie starling_magsta1
+Pholia sharpii_sharpe's starling_shasta2
+Arizelopsar femoralis_abbott's starling_abbsta2
+Poeoptera lugubris_narrow-tailed starling_natsta1
+Poeoptera stuhlmanni_stuhlmann's starling_stusta1
+Poeoptera kenricki_kenrick's starling_kensta1
+Notopholia corusca_estorninho-de-barriga-preta_bbgsta1
+Hylopsar purpureiceps_purple-headed starling_phgsta1
+Hylopsar cupreocauda_copper-tailed starling_ctgsta1
+Lamprotornis hildebrandti_hildebrandt's starling_hilsta1
+Lamprotornis shelleyi_shelley's starling_shesta1
+Lamprotornis australis_burchell's starling_bugsta1
+Lamprotornis purpuroptera_rüppell's starling_ruegls1
+Lamprotornis caudatus_long-tailed glossy starling_ltgsta1
+Lamprotornis mevesii_meves's starling_megsta1
+Lamprotornis mevesii mevesii_meves's starling (Meves's)_mevgls1
+Lamprotornis mevesii violacior_meves's starling (Cunene)_mevsta1
+Lamprotornis mevesii benguelensis_meves's starling (Benguela)_mevgls2
+Lamprotornis unicolor_ashy starling_ashsta2
+Lamprotornis splendidus_splendid starling_spgsta1
+Lamprotornis ornatus_principe starling_prgsta1
+Lamprotornis regius_golden-breasted starling_gobsta5
+Lamprotornis superbus_superb starling_supsta1
+Lamprotornis pulcher_chestnut-bellied starling_chbsta1
+Lamprotornis bicolor_african pied starling_afpsta1
+Lamprotornis albicapillus_white-crowned starling_whcsta3
+Lamprotornis fischeri_fischer's starling_fissta1
+Lamprotornis chloropterus_lesser blue-eared starling_lbesta1
+Lamprotornis chloropterus chloropterus_lesser blue-eared starling (Lesser)_lbegls1
+Lamprotornis chloropterus elisabeth_lesser blue-eared starling (Miombo)_lbegls2
+Lamprotornis acuticaudus_sharp-tailed starling_stgsta1
+Lamprotornis chalybaeus_estorninho-metálico-lamurioso_gbesta1
+Lamprotornis chloropterus/chalybaeus_lesser/greater blue-eared starling_y01331
+Lamprotornis iris_emerald starling_emesta1
+Lamprotornis purpureus_estorninho-metálico-de-cauda-curta_pugsta1
+Lamprotornis nitens_cape starling_capgls1
+Lamprotornis chalcurus_bronze-tailed starling_btgsta1
+Lamprotornis sp._Lamprotornis sp._glossy1
+Sturnidae sp._mainato/estorninho sp._y00757
+Melanotis caerulescens_blue mockingbird_blumoc
+Melanotis hypoleucus_blue-and-white mockingbird_bawmoc1
+Melanoptila glabrirostris_black catbird_blacat1
+Dumetella carolinensis_pássaro-gato_grycat
+Ramphocinclus brachyurus_martinique thrasher_whbthr3
+Ramphocinclus sanctaeluciae_st. lucia thrasher_whbthr4
+Allenia fusca_scaly-breasted thrasher_scbthr
+Margarops fuscatus_pearly-eyed thrasher_peethr1
+Allenia fusca/Margarops fuscatus_scaly-breasted/pearly-eyed thrasher_y01158
+Cinclocerthia ruficauda_brown trembler_brotre1
+Cinclocerthia gutturalis_gray trembler_gratre1
+Cinclocerthia ruficauda/gutturalis_brown/gray trembler_y01010
+Toxostoma curvirostre_curve-billed thrasher_cubthr
+Toxostoma curvirostre [curvirostre Group]_curve-billed thrasher (curvirostre Group)_cubthr1
+Toxostoma curvirostre [palmeri Group]_curve-billed thrasher (palmeri Group)_cubthr2
+Toxostoma ocellatum_ocellated thrasher_ocethr1
+Toxostoma rufum_debulhador_brnthr
+Toxostoma longirostre_long-billed thrasher_lobthr
+Toxostoma curvirostre x longirostre_curve-billed x long-billed thrasher (hybrid)_x00971
+Toxostoma rufum/longirostre_brown/long-billed thrasher_y00329
+Toxostoma guttatum_cozumel thrasher_cozthr1
+Toxostoma bendirei_bendire's thrasher_benthr
+Toxostoma curvirostre/bendirei_curve-billed/bendire's thrasher_y00330
+Toxostoma cinereum_gray thrasher_grathr1
+Toxostoma redivivum_california thrasher_calthr
+Toxostoma lecontei_leconte's thrasher_lecthr
+Toxostoma lecontei lecontei/macmillanorum_leconte's thrasher (LeConte's)_lecthr1
+Toxostoma lecontei arenicola_leconte's thrasher (Vizcaino)_lecthr2
+Toxostoma crissale_crissal thrasher_crithr
+Toxostoma redivivum x crissale_california x crissal thrasher (hybrid)_x00470
+Toxostoma sp._Toxostoma sp._toxost1
+Oreoscoptes montanus_sage thrasher_sagthr
+Mimus thenca_chilean mockingbird_chimoc1
+Mimus patagonicus_patagonian mockingbird_patmoc1
+Mimus saturninus_sabiá-do-campo_chbmoc1
+Mimus patagonicus/saturninus_patagonian/chalk-browed mockingbird_y01189
+Mimus triurus_calhandra-de-três-rabos_whbmoc1
+Mimus dorsalis_brown-backed mockingbird_brbmoc1
+Mimus gundlachii_bahama mockingbird_bahmoc
+Mimus parvulus_galapagos mockingbird_galmoc1
+Mimus trifasciatus_floreana mockingbird_chamoc1
+Mimus macdonaldi_española mockingbird_hoomoc1
+Mimus melanotis_san cristobal mockingbird_chamoc2
+Mimus longicaudatus_long-tailed mockingbird_lotmoc1
+Mimus graysoni_socorro mockingbird_socmoc1
+Mimus gilvus_sabiá-da-praia_tromoc
+Mimus gilvus gracilis/leucophaeus_tropical mockingbird (Mayan)_tromoc12
+Mimus gilvus [gilvus Group]_sabiá-da-praia [grupo gilvus]_tromoc1
+Mimus gilvus magnirostris_sabiá-da-praia (magnirostris)_tromoc2
+Mimus polyglottos_tordo-imitador_normoc
+Mimus gundlachii x polyglottos_bahama x northern mockingbird (hybrid)_x00907
+Mimus gilvus x polyglottos_tordo-imitador-da-praia x tordo-imitador (híbrido)_x00703
+Mimus gilvus/polyglottos_tordo-imitador-da-praia/tordo-imitador_y01122
+Mimidae sp._Mimidae sp._mimida1
+Pinarornis plumosus_boulder chat_boucha1
+Grandala coelicolor_grandala_granda1
+Sialia sialis_eastern bluebird_easblu
+Sialia sialis sialis/bermudensis_eastern bluebird (Eastern)_easblu1
+Sialia sialis [guatemalae Group]_eastern bluebird (Mexican)_easblu2
+Sialia mexicana_western bluebird_wesblu
+Sialia sialis x mexicana_eastern x western bluebird (hybrid)_x00972
+Sialia currucoides_mountain bluebird_moublu
+Sialia sialis x currucoides_eastern x mountain bluebird (hybrid)_x00864
+Sialia mexicana x currucoides_western x mountain bluebird (hybrid)_x00204
+Sialia sp._bluebird sp._bluebi
+Stizorhina fraseri_rufous flycatcher-thrush_rufthr1
+Stizorhina finschi_finsch's flycatcher-thrush_fifthr1
+Neocossyphus rufus_red-tailed ant-thrush_rtathr1
+Neocossyphus rufus gabunensis_red-tailed ant-thrush (Red-tailed)_retant3
+Neocossyphus rufus rufus_red-tailed ant-thrush (Coastal)_retant4
+Neocossyphus poensis_white-tailed ant-thrush_wtathr1
+Neocossyphus rufus/poensis_red-tailed/white-tailed ant-thrush_y01320
+Myadestes townsendi_townsend's solitaire_towsol
+Myadestes occidentalis_brown-backed solitaire_brbsol1
+Myadestes elisabeth_cuban solitaire_cubsol1
+Myadestes genibarbis_rufous-throated solitaire_rutsol1
+Myadestes genibarbis [genibarbis Group]_rufous-throated solitaire (Rufous-throated)_rutsol2
+Myadestes genibarbis sibilans_rufous-throated solitaire (St. Vincent)_rutsol3
+Myadestes melanops_black-faced solitaire_blfsol1
+Myadestes coloratus_varied solitaire_varsol1
+Myadestes unicolor_slate-colored solitaire_slcsol1
+Myadestes ralloides_andean solitaire_andsol1
+Myadestes ralloides plumbeiceps_andean solitaire (plumbeiceps)_andsol2
+Myadestes ralloides venezuelensis/candelae_andean solitaire (venezuelensis/candelae)_andsol3
+Myadestes ralloides ralloides_andean solitaire (ralloides)_andsol4
+Myadestes myadestinus_kamao_kamao
+Myadestes woahensis_amaui_amaui
+Myadestes lanaiensis_olomao_olomao
+Myadestes obscurus_omao_omao
+Myadestes palmeri_puaiohi_puaioh
+Zoothera dixoni_long-tailed thrush_lotthr1
+Zoothera mollissima_alpine thrush_alpthr1
+Zoothera salimalii_himalayan thrush_himthr1
+Zoothera mollissima/salimalii_alpine/himalayan thrush_y01005
+Zoothera griseiceps_sichuan thrush_sicthr1
+Zoothera mollissima/griseiceps_alpine/sichuan thrush_y01006
+Zoothera mollissima/salimalii/griseiceps_alpine/himalayan/sichuan thrush_y01052
+Zoothera heinrichi_geomalia_geomal1
+Zoothera marginata_dark-sided thrush_dasthr1
+Zoothera monticola_long-billed thrush_lobthr1
+Zoothera everetti_everett's thrush_evethr1
+Zoothera andromedae_tordo-de-sunda_sunthr1
+Zoothera aurea_tordo-de-white_scathr2
+Zoothera dauma_scaly thrush_scathr8
+Zoothera dauma dauma_scaly thrush (Scaly)_scathr3
+Zoothera dauma horsfieldi_scaly thrush (Horsfield's)_scathr7
+Zoothera dauma iriomotensis_scaly thrush (Iriomotejima)_scathr9
+Zoothera aurea/dauma_white's/scaly thrush_scathr1
+Zoothera major_amami thrush_scathr6
+Zoothera neilgherriensis_nilgiri thrush_scathr4
+Zoothera imbricata_sri lanka thrush_scathr5
+Zoothera terrestris_bonin thrush_bonthr2
+Zoothera margaretae_makira thrush_sacthr2
+Zoothera turipavae_guadalcanal thrush_sacthr3
+Zoothera lunulata_bassian thrush_oltthr1
+Zoothera talaseae_new britain thrush_nebthr1
+Zoothera atrigena_bougainville thrush_bouthr1
+Zoothera heinei_russet-tailed thrush_rutthr1
+Zoothera heinei [heinei Group]_russet-tailed thrush (Russet-tailed)_rutthr2
+Zoothera heinei eichhorni_russet-tailed thrush (Mussau)_rutthr3
+Zoothera lunulata/heinei_bassian/russet-tailed thrush_y01007
+Zoothera machiki_fawn-breasted thrush_fabthr1
+Zoothera sp._tordo (Zoothera) sp._zoothe1
+Chlamydochaera jefferyi_fruit-hunter_fruith1
+Cochoa purpurea_purple cochoa_purcoc1
+Cochoa viridis_green cochoa_grecoc1
+Cochoa purpurea/viridis_purple/green cochoa_y01009
+Cochoa beccarii_sumatran cochoa_sumcoc1
+Cochoa azurea_javan cochoa_javcoc1
+Ixoreus naevius_tordo-variegado_varthr
+Catharus gracilirostris_black-billed nightingale-thrush_bbnthr1
+Catharus aurantiirostris_sabiazinho-de-bico-laranja_obnthr1
+Catharus aurantiirostris [melpomene Group]_sabiazinho-de-bico-laranja [grupo melpomene]_orbnit1
+Catharus aurantiirostris [griseiceps Group]_sabiazinho-de-bico-laranja [grupo griseiceps]_orbnit2
+Catharus aurantiirostris [aurantiirostris Group]_orange-billed nightingale-thrush (Orange-billed)_orbnit3
+Catharus fuscater_slaty-backed nightingale-thrush_sbnthr1
+Catharus fuscater hellmayri_slaty-backed nightingale-thrush (Black-backed)_slbnit2
+Catharus fuscater [fuscater Group]_slaty-backed nightingale-thrush (Slaty-backed)_slbnit1
+Catharus occidentalis_russet nightingale-thrush_runthr1
+Catharus frantzii_ruddy-capped nightingale-thrush_rcnthr1
+Catharus occidentalis/frantzii_russet/ruddy-capped nightingale-thrush_y00426
+Catharus mexicanus_black-headed nightingale-thrush_bhnthr1
+Catharus dryas_yellow-throated nightingale-thrush_spnthr1
+Catharus maculatus_speckled nightingale-thrush_sponit2
+Catharus fuscescens_sabiazinho-norte-americano_veery
+Catharus minimus_sabiazinho-de-cara-cinza_gycthr
+Catharus bicknelli_bicknell's thrush_bicthr
+Catharus fuscescens x bicknelli_veery x bicknell's thrush (hybrid)_x00865
+Catharus minimus/bicknelli_gray-cheeked/bicknell's thrush_y00225
+Catharus ustulatus_sabiazinho-de-óculos_swathr
+Catharus ustulatus [ustulatus Group]_sabiazinho-de-óculos [grupo ustulatus]_swathr1
+Catharus ustulatus [swainsoni Group]_sabiazinho-de-óculos [grupo swainsoni]_swathr2
+Catharus guttatus_tordo-eremita_herthr
+Catharus guttatus [guttatus Group]_tordo-eremita [grupo guttatus]_herthr1
+Catharus guttatus [auduboni Group]_tordo-eremita [grupo auduboni]_herthr2
+Catharus guttatus faxoni/crymophilus_tordo-eremita (faxoni/crymophilus)_herthr3
+Catharus sp._catharus sp. (sabiazinho sp.)_cathus
+Hylocichla mustelina_tordo-dos-bosques_woothr
+Entomodestes coracinus_black solitaire_blasol1
+Entomodestes leucotis_white-eared solitaire_whesol1
+Cichlopsis leucogenys_sabiá-castanho_rubsol1
+Cichlopsis leucogenys chubbi_sabiá-castanho (chubbi)_rubsol2
+Cichlopsis leucogenys peruviana_sabiá-castanho (peruviana)_rubsol3
+Cichlopsis leucogenys gularis_sabiá-castanho (gularis)_rubsol4
+Cichlopsis leucogenys leucogenys_sabiá-castanho (leucogenys)_rubsol5
+Ridgwayia pinicola_aztec thrush_aztthr
+Geokichla sibirica_tordo-siberiano_sibthr1
+Geokichla sibirica sibirica_siberian thrush (Continental)_sibthr2
+Geokichla sibirica davisoni_siberian thrush (Sakhalin)_sibthr3
+Geokichla wardii_pied thrush_piethr1
+Geokichla guttata_spotted ground-thrush_spgthr1
+Geokichla guttata maxis_spotted ground-thrush (Lotti)_spogrt1
+Geokichla guttata lippensi_spotted ground-thrush (Upemba)_spogrt2
+Geokichla guttata [guttata Group]_spotted ground-thrush (Spotted)_spogrt3
+Geokichla camaronensis_black-eared ground-thrush_bkegrt1
+Geokichla camaronensis camaronensis_black-eared ground-thrush (Cameroon)_bkegrt2
+Geokichla camaronensis graueri_black-eared ground-thrush (Grauer's)_bkegrt3
+Geokichla princei_gray ground-thrush_grygrt1
+Geokichla princei princei_gray ground-thrush (Prince's)_grygrt2
+Geokichla princei batesi_gray ground-thrush (Bates's)_grygrt3
+Geokichla crossleyi_crossley's ground-thrush_crgthr1
+Geokichla crossleyi crossleyi_crossley's ground-thrush (Crossley's)_crogrt1
+Geokichla crossleyi pilettei_crossley's ground-thrush (Itombwe)_crogrt2
+Geokichla oberlaenderi_oberländer's ground-thrush_obgthr1
+Geokichla piaggiae_abyssinian ground-thrush_abgthr1
+Geokichla piaggiae [piaggiae Group]_abyssinian ground-thrush (Abyssinian)_abygrt1
+Geokichla piaggiae tanganjicae_abyssinian ground-thrush (Kivu)_kigthr1
+Geokichla gurneyi_orange ground-thrush_orgthr1
+Geokichla spiloptera_spot-winged thrush_spwthr1
+Geokichla cinerea_ashy thrush_ashthr1
+Geokichla dumasi_buru thrush_burthr1
+Geokichla joiceyi_seram thrush_serthr2
+Geokichla interpres_chestnut-capped thrush_chcthr1
+Geokichla leucolaema_enggano thrush_engthr1
+Geokichla dohertyi_tordo-de-doherty_chbthr1
+Geokichla peronii_tordo-de-timor_orbthr1
+Geokichla schistacea_slaty-backed thrush_slbthr1
+Geokichla erythronota_rusty-backed thrush_rubthr2
+Geokichla mendeni_red-and-black thrush_rabthr1
+Geokichla citrina_orange-headed thrush_orhthr1
+Geokichla citrina [citrina Group]_orange-headed thrush (Orange-headed)_orhthr2
+Geokichla citrina cyanota_orange-headed thrush (White-throated)_orhthr3
+Geokichla citrina albogularis/andamanensis_orange-headed thrush (Plain-winged)_orhthr4
+Geokichla citrina [aurimacula Group]_orange-headed thrush (Buff-throated)_orhthr5
+Geokichla sp._Geokichla sp._geokic1
+Turdus mupinensis_chinese thrush_chithr2
+Turdus simensis_ethiopian thrush_grothr2
+Turdus litsitsirupa_groundscraper thrush_grothr1
+Turdus viscivorus_tordoveia_misthr1
+Turdus philomelos_tordo-pinto_sonthr1
+Turdus tephronotus_african bare-eyed thrush_abethr1
+Turdus ludoviciae_somali thrush_somthr1
+Turdus mandarinus_chinese blackbird_chibla1
+Turdus libonyana_kurrichane thrush_kurthr1
+Turdus bewsheri_comoro thrush_comthr1
+Turdus smithi_karoo thrush_karthr1
+Turdus menachensis_yemen thrush_yemthr1
+Turdus olivaceus_olive thrush_olithr2
+Turdus smithi x olivaceus_karoo x olive thrush (hybrid)_x01034
+Turdus smithi/olivaceus_karoo/olive thrush_y01008
+Turdus iliacus_sabiá-ruivo_redwin
+Turdus iliacus coburni_sabiá-ruivo (coburni)_redwin1
+Turdus iliacus iliacus_sabiá-ruivo (iliacus)_redwin2
+Turdus plebejus_mountain thrush_mourob1
+Turdus lherminieri_forest thrush_forthr1
+Turdus abyssinicus_abyssinian thrush_abythr1
+Turdus abyssinicus oldeani_abyssinian thrush (Ngorongoro)_abythr2
+Turdus abyssinicus [abyssinicus Group]_abyssinian thrush (Abyssinian)_abythr3
+Turdus helleri_taita thrush_taithr1
+Turdus roehli_usambara thrush_usathr1
+Turdus merula_melro_eurbla
+Turdus flavipes_sabiá-una_yelthr1
+Turdus lawrencii_caraxué-de-bico-amarelo_lawthr1
+Turdus leucomelas_sabiá-barranco_pabthr1
+Turdus fumigatus_sabiá-da-mata_cocthr1
+Turdus fumigatus personus_sabiá-da-mata (personus)_cocthr2
+Turdus fumigatus [fumigatus Group]_sabiá-da-mata [grupo fumigatus]_cocthr3
+Turdus hauxwelli_sabiá-bicolor_hauthr1
+Turdus assimilis_white-throated thrush_whtrob1
+Turdus assimilis [assimilis Group]_white-throated thrush (White-throated)_whtthr1
+Turdus assimilis daguae_white-throated thrush (Dagua)_whtthr2
+Turdus albicollis_sabiá-coleira_whnrob1
+Turdus albicollis [phaeopygus Group]_sabiá-coleira [grupo phaeopygus]_whnthr1
+Turdus albicollis [albicollis Group]_sabiá-coleira [grupo albicollis]_whnthr2
+Turdus obsoletus_pale-vented thrush_pavthr1
+Turdus rufiventris_sabiá-laranjeira_rubthr1
+Turdus nudigenis_caraxué_baerob1
+Turdus maculirostris_ecuadorian thrush_ecuthr1
+Turdus sanchezorum_sabiá-da-várzea_hauthr3
+Turdus hauxwelli/sanchezorum_sabiá-bicolor/da-várzea_y00755
+Turdus grayi_clay-colored thrush_clcrob
+Turdus haplochrous_unicolored thrush_unithr1
+Turdus turdoides_sulawesi thrush_sulthr1
+Turdus infuscatus_black thrush_blarob1
+Turdus nigrescens_sooty thrush_soorob1
+Turdus migratorius_tordo-americano_amerob
+Turdus migratorius nigrideus_tordo-americano (nigrideus)_amerob3
+Turdus migratorius [migratorius Group]_tordo-americano [grupo migratorius]_amerob1
+Turdus migratorius confinis_tordo-americano (confinis)_amerob2
+Ixoreus naevius/Turdus migratorius_tordo-variegado/tordo-americano_y00822
+Turdus rufopalliatus_rufous-backed robin_rubrob
+Turdus rufopalliatus rufopalliatus_rufous-backed robin (Rufous-backed)_rubrob1
+Turdus rufopalliatus graysoni_rufous-backed robin (Grayson's)_rubrob2
+Turdus rufitorques_rufous-collared robin_rucrob1
+Turdus pelios_african thrush_afrthr1
+Turdus pelios [pelios Group]_african thrush (African)_afrthr2
+Turdus pelios nigrilorum/poensis_african thrush (Black-lored)_afrthr3
+Turdus pelios stormsi/graueri_african thrush (Orange-bellied)_afrthr4
+Turdus ravidus_grand cayman thrush_grcthr1
+Turdus aurantius_white-chinned thrush_whcthr1
+Turdus plumbeus_red-legged thrush_relthr1
+Turdus plumbeus plumbeus_red-legged thrush (Bahamas)_relthr5
+Turdus plumbeus [rubripes Group]_red-legged thrush (Cuban)_relthr11
+Turdus plumbeus ardosiaceus/albiventris_red-legged thrush (Antillean)_relthr3
+Turdus xanthorhynchus_principe thrush_prithr1
+Turdus olivaceofuscus_sao tome thrush_satthr1
+Turdus niveiceps_taiwan thrush_islthr24
+Turdus swalesi_la selle thrush_lasthr1
+Turdus jamaicensis_white-eyed thrush_whethr1
+Turdus leucops_sabiá-preto_paethr1
+Turdus falcklandii_austral thrush_austhr1
+Turdus falcklandii magellanicus/pembertoni_austral thrush (Magellan)_austhr2
+Turdus falcklandii falcklandii_austral thrush (Falkland)_austhr3
+Turdus reevei_plumbeous-backed thrush_plbthr2
+Turdus subalaris_sabiá-ferreiro_slathr3
+Turdus murinus_caraxué-dos-tepuis_bkbthr4
+Turdus eremita_tristan thrush_trithr1
+Turdus amaurochalinus_sabiá-poca_crbthr1
+Turdus ignobilis_caraxué-da-várzea_blbthr1
+Turdus ignobilis ignobilis/goodfellowi_caraxué-da-várzea (ignobilis/goodfellowi)_bkbthr1
+Turdus ignobilis debilis_caraxué-da-várzea (debilis)_bkbthr2
+Turdus arthuri_caraxué-da-campina_bkbthr3
+Turdus murinus/arthuri_caraxué-dos-tepuis/caraxué-da-campina_y01159
+Turdus ignobilis/arthuri_caraxué-de-bico-preto/caraxué-da-campina_y01160
+Turdus maranonicus_marañon thrush_marthr2
+Turdus fulviventris_chestnut-bellied thrush_chbthr2
+Turdus olivater_sabiá-de-cabeça-preta_blhthr1
+Turdus nigriceps_andean slaty thrush_slathr2
+Turdus fuscater_great thrush_grethr1
+Turdus serranus_glossy-black thrush_glbthr1
+Turdus chiguanco_chiguanco thrush_chithr1
+Turdus chiguanco chiguanco/conradi_chiguanco thrush (chiguanco/conradi)_chithr4
+Turdus chiguanco anthracinus_chiguanco thrush (anthracinus)_chithr3
+Turdus boulboul_gray-winged blackbird_gywbla1
+Turdus simillimus_indian blackbird_eurbla2
+Turdus simillimus simillimus/bourdilloni_indian blackbird (Indian)_indbla1
+Turdus simillimus nigropileus_indian blackbird (Black-capped)_indbla2
+Turdus simillimus kinnisii_indian blackbird (Sri Lanka)_indbla3
+Turdus unicolor_tordo-unicolor_ticthr1
+Turdus dissimilis_black-breasted thrush_blbthr2
+Turdus cardis_japanese thrush_japthr1
+Turdus dissimilis x cardis_black-breasted x japanese thrush (hybrid)_x01043
+Turdus hortulorum_gray-backed thrush_gybthr1
+Turdus pallidus_pale thrush_palthr1
+Turdus feae_gray-sided thrush_gysthr1
+Turdus obscurus_tordo-escuro_eyethr
+Turdus feae/obscurus_gray-sided/eyebrowed thrush_y01053
+Turdus chrysolaus_brown-headed thrush_brhthr1
+Turdus celaenops_izu thrush_izuthr1
+Turdus mindorensis_mindoro island-thrush_islthr22
+Turdus thomassoni_luzon island-thrush_islthr36
+Turdus nigrorum_mindanao island-thrush_minist1
+Turdus nigrorum nigrorum_mindanao island-thrush (Negros)_islthr23
+Turdus nigrorum malindangensis_mindanao island-thrush (Malindang)_islthr20
+Turdus nigrorum katanglad_mindanao island-thrush (Katanglad)_islthr15
+Turdus nigrorum kelleri_mindanao island-thrush (Apo)_islthr16
+Turdus erythropleurus_christmas island-thrush_islthr9
+Turdus schlegelii_wallacean island-thrush_walist1
+Turdus schlegelii hygroscopus_wallacean island-thrush (Latimojong)_islthr12
+Turdus schlegelii celebensis_wallacean island-thrush (Lompobattang)_islthr6
+Turdus schlegelii schlegelii_wallacean island-thrush (Schlegel's)_islthr31
+Turdus schlegelii sterlingi_wallacean island-thrush (Sterling's)_islthr33
+Turdus javanicus_sundaic island-thrush_sunist1
+Turdus javanicus loeseri_sundaic island-thrush (Loeser's)_islthr19
+Turdus javanicus indrapurae_sundaic island-thrush (Sumatran)_islthr13
+Turdus javanicus fumidus/biesenbachi_sundaic island-thrush (Sooty)_islthr10
+Turdus javanicus javanicus_sundaic island-thrush (Central Javan)_islthr42
+Turdus javanicus whiteheadi/stresemanni_sundaic island-thrush (Stresemann's)_islthr34
+Turdus javanicus seebohmi_sundaic island-thrush (Bornean)_islthr32
+Turdus deningeri_moluccan island-thrush_molist1
+Turdus deningeri sukahujan_moluccan island-thrush (Taliabu)_islthr59
+Turdus deningeri deningeri_moluccan island-thrush (Seram)_islthr7
+Turdus papuensis_papuan island-thrush_papist1
+Turdus papuensis versteegi_papuan island-thrush (Jayawijaya)_islthr37
+Turdus papuensis erebus_papuan island-thrush (Ashy)_islthr5
+Turdus papuensis papuensis_papuan island-thrush (Papuan)_islthr25
+Turdus papuensis keysseri_papuan island-thrush (Huon)_islthr47
+Turdus papuensis canescens_papuan island-thrush (Goodenough)_islthr4
+Turdus heinrothi_bismarck island-thrush_bisist1
+Turdus bougainvillei_bougainville island-thrush_islthr48
+Turdus kulambangrae_solomons island-thrush_solist1
+Turdus kulambangrae kulambangrae_solomons island-thrush (Kolombangara)_islthr17
+Turdus kulambangrae sladeni_solomons island-thrush (Guadalcanal)_islthr51
+Turdus vanikorensis_vanikoro island-thrush_vanist1
+Turdus vanikorensis rennellianus_vanikoro island-thrush (Rennell)_islthr52
+Turdus vanikorensis mareensis_vanikoro island-thrush (Mare)_islthr21
+Turdus vanikorensis [vanikorensis Group]_vanikoro island-thrush (Vanuatu)_islthr3
+Turdus vanikorensis placens_vanikoro island-thrush (Ureparapara)_islthr26
+Turdus vanikorensis efatensis_vanikoro island-thrush (Efate)_islthr8
+Turdus pritzbueri_white-headed island-thrush_islthr28
+Turdus xanthopus_new caledonian island-thrush_islthr40
+Turdus poliocephalus_tasman sea island-thrush_norist1
+Turdus poliocephalus vinitinctus_tasman sea island-thrush (Lord Howe I.)_islthr38
+Turdus poliocephalus poliocephalus_tasman sea island-thrush (Norfolk I.)_islthr27
+Turdus samoensis_samoan island-thrush_islthr30
+Turdus ruficeps_fiji island-thrush_fijist1
+Turdus ruficeps layardi_fiji island-thrush (Viti Levu)_islthr18
+Turdus ruficeps ruficeps_fiji island-thrush (Kadavu)_islthr29
+Turdus ruficeps vitiensis_fiji island-thrush (Vanua Levu)_islthr39
+Turdus ruficeps hades_fiji island-thrush (Gau)_islthr11
+Turdus ruficeps tempesti_fiji island-thrush (Taveuni)_islthr35
+Turdus maximus_tibetan blackbird_tibbla1
+Turdus kessleri_white-backed thrush_whbthr2
+Turdus pilaris_tordo-zornal_fieldf
+Turdus albocinctus_white-collared blackbird_whcbla1
+Turdus rubrocanus_chestnut thrush_chethr1
+Turdus rubrocanus rubrocanus_chestnut thrush (Silver-headed)_chethr2
+Turdus rubrocanus gouldii_chestnut thrush (Gray-headed)_chethr3
+Turdus torquatus_melro-de-colar_rinouz1
+Turdus torquatus torquatus_melro-de-colar (torquatus)_rinouz2
+Turdus torquatus alpestris_melro-de-colar (alpestris)_rinouz3
+Turdus torquatus amicorum_melro-de-colar (amicorum)_rinouz4
+Turdus atrogularis_tordo-de-garganta-preta_datthr1
+Turdus ruficollis_tordo-de-garganta-ruiva_retthr1
+Turdus atrogularis x ruficollis_tordo-de-garganta-preta x tordo-de-garganta-ruiva (híbrido)_x00644
+Turdus atrogularis/ruficollis_black-throated/red-throated thrush_y01202
+Turdus eunomus_tordo-sombrio_dusthr2
+Turdus naumanni_tordo-de-naumann_dusthr1
+Turdus atrogularis x naumanni_tordo-de-garganta-preta x tordo-de-naumann (híbrido)_x01137
+Turdus eunomus x naumanni_tordo-sombrio x tordo-de-naumann (híbrido)_x00973
+Turdus eunomus/naumanni_tordo-sombrio/tordo-de-naumann_dusthr
+Turdus sp._Turdus sp._turdus1
+Turdidae sp._Turdidae sp._thrush1
+Muscicapa griseisticta_gray-streaked flycatcher_gysfly1
+Muscicapa sibirica_dark-sided flycatcher_dasfly
+Muscicapa sibirica sibirica_dark-sided flycatcher (Siberian)_dasfly1
+Muscicapa sibirica [cacabata Group]_dark-sided flycatcher (Himalayan)_dasfly5
+Muscicapa griseisticta/sibirica_gray-streaked/dark-sided flycatcher_y01085
+Muscicapa ferruginea_ferruginous flycatcher_ferfly1
+Muscicapa dauurica_taralhão-castanho_asbfly
+Muscicapa dauurica dauurica_asian brown flycatcher (Northern)_asbfly2
+Muscicapa dauurica poonensis/siamensis_asian brown flycatcher (Southern)_asbfly3
+Muscicapa randi_ashy-breasted flycatcher_asbfly1
+Muscicapa segregata_sumba brown flycatcher_subfly2
+Muscicapa muttui_brown-breasted flycatcher_brbfly2
+Muscicapa dauurica/muttui_asian brown/brown-breasted flycatcher_y01322
+Muscicapa sodhii_sulawesi brown flycatcher_subfly3
+Muscicapa williamsoni_brown-streaked flycatcher_bnsfly1
+Muscicapa williamsoni williamsoni_brown-streaked flycatcher (Brown-streaked)_bnsfly2
+Muscicapa williamsoni umbrosa_brown-streaked flycatcher (Umber)_bnsfly3
+Muscicapa dauurica/williamsoni_asian brown/brown-streaked flycatcher_y00754
+Muscicapa adusta_african dusky flycatcher_afdfly1
+Muscicapa epulata_little flycatcher_ligfly2
+Muscicapa sethsmithi_yellow-footed flycatcher_yeffly1
+Muscicapa striata_taralhão-cinzento_spofly1
+Muscicapa striata [striata Group]_taralhão-cinzento [grupo striata]_spofly2
+Muscicapa striata tyrrhenica/balearica_taralhão-cinzento (tyrrhenica/balearica)_spofly3
+Muscicapa gambagae_gambaga flycatcher_gamfly1
+Muscicapa aquatica_swamp flycatcher_swafly3
+Muscicapa cassini_cassin's flycatcher_casfly1
+Muscicapa sp._taralhão sp._muscic1
+Myopornis boehmi_böhm's flycatcher_boefly1
+Artomyias ussheri_ussher's flycatcher_ussfly1
+Artomyias fuliginosa_sooty flycatcher_soofly1
+Bradornis comitatus_dusky-blue flycatcher_dubfly2
+Bradornis mariquensis_marico flycatcher_marfly1
+Bradornis microrhynchus_african gray flycatcher_afgfly1
+Bradornis microrhynchus pumilus_african gray flycatcher (Ethiopian)_grafly2
+Bradornis microrhynchus [microrhynchus Group]_african gray flycatcher (African Gray)_grafly1
+Bradornis sp._Bradornis sp._brador1
+Muscicapa/Bradornis sp._Muscicapa/Bradornis sp._y01003
+Agricola pallidus_pale flycatcher_palfly2
+Agricola pallidus [pallidus Group]_pale flycatcher (Pale)_palfly6
+Agricola pallidus bafirawari_pale flycatcher (Wajir)_palfly4
+Agricola pallidus subalaris/erlangeri_pale flycatcher (East Coast)_palfly5
+Agricola infuscatus_chat flycatcher_chafly2
+Fraseria cinerascens_white-browed forest-flycatcher_wbffly1
+Fraseria ocreata_african forest-flycatcher_afffly1
+Fraseria ocreata prosphora/kelsalli_african forest-flycatcher (Western)_afrfof1
+Fraseria ocreata ocreata_african forest-flycatcher (Eastern)_afrfof2
+Fraseria griseigularis_gray-throated tit-flycatcher_gyttif1
+Fraseria plumbea_gray tit-flycatcher_grytif1
+Fraseria olivascens_olivaceous flycatcher_olifly1
+Fraseria olivascens olivascens_olivaceous flycatcher (Olivaceous)_olifly4
+Fraseria olivascens nimbae_olivaceous flycatcher (Mt. Nimba)_olifly5
+Fraseria lendu_chapin's flycatcher_chafly1
+Fraseria lendu lendu_chapin's flycatcher (Chapin's)_chafly5
+Fraseria lendu itombwensis_chapin's flycatcher (Itombwe)_chafly4
+Fraseria tessmanni_tessmann's flycatcher_tesfly1
+Fraseria caerulescens_ashy flycatcher_ashfly1
+Namibornis herero_herero chat_hercha1
+Empidornis semipartitus_silverbird_silver1
+Sigelus silens_fiscal flycatcher_fisfly1
+Melaenornis ardesiacus_yellow-eyed black-flycatcher_yebfly2
+Melaenornis annamarulae_nimba flycatcher_nimfly1
+Melaenornis edolioides_northern black-flycatcher_nobfly1
+Melaenornis pammelaina_southern black-flycatcher_sobfly1
+Melaenornis fischeri_white-eyed slaty-flycatcher_wheslf1
+Melaenornis brunneus_angola slaty-flycatcher_angslf1
+Melaenornis chocolatinus_abyssinian slaty-flycatcher_abyslf1
+Humblotia flavirostris_grande comore flycatcher_grcfly3
+Alethe diademata_white-tailed alethe_ficale3
+Alethe castanea_fire-crested alethe_ficale2
+Tychaedon coryphoeus_karoo scrub-robin_kasrob2
+Tychaedon leucosticta_forest scrub-robin_fosrob1
+Tychaedon leucosticta [leucosticta Group]_forest scrub-robin (Forest)_forscr2
+Tychaedon leucosticta reichenowi_forest scrub-robin (Huila)_forscr3
+Tychaedon signata_brown scrub-robin_brsrob1
+Tychaedon quadrivirgata_bearded scrub-robin_besrob1
+Tychaedon quadrivirgata quadrivirgata_bearded scrub-robin (Bearded)_beascr1
+Tychaedon quadrivirgata greenwayi_bearded scrub-robin (Zanzibar)_beascr2
+Tychaedon barbata_miombo scrub-robin_misrob1
+Cercotrichas podobe_solitário-preto_blsrob1
+Cercotrichas galactotes_solitário_rutscr1
+Cercotrichas galactotes [galactotes Group]_solitário [grupo galactotes]_rtsrob1
+Cercotrichas galactotes minor/hamertoni_solitário (minor/hamertoni)_afrscr1
+Cercotrichas paena_kalahari scrub-robin_kasrob1
+Cercotrichas hartlaubi_brown-backed scrub-robin_bbsrob1
+Cercotrichas leucophrys_white-browed scrub-robin_rbsrob1
+Cercotrichas leucophrys [leucoptera Group]_white-browed scrub-robin (White-winged)_rebscr1
+Cercotrichas leucophrys [leucophrys Group]_white-browed scrub-robin (Red-backed)_rebscr2
+Cercotrichas sp._scrub-robin sp._scrubr1
+Copsychus fulicatus_indian robin_indrob1
+Copsychus saularis_oriental magpie-robin_magrob
+Copsychus saularis [saularis Group]_oriental magpie-robin (Oriental)_orimar1
+Copsychus saularis [amoenus Group]_oriental magpie-robin (Black)_orimar2
+Copsychus pyrropygus_rufous-tailed shama_rutsha2
+Copsychus albospecularis_madagascar magpie-robin_mamrob1
+Copsychus albospecularis albospecularis_madagascar magpie-robin (Black-bellied)_madmar1
+Copsychus albospecularis inexspectatus_madagascar magpie-robin (White-bellied)_madmar2
+Copsychus albospecularis pica_madagascar magpie-robin (White-winged)_madmar3
+Copsychus sechellarum_seychelles magpie-robin_semrob1
+Copsychus mindanensis_philippine magpie-robin_phimar1
+Copsychus malabaricus_white-rumped shama_whrsha
+Copsychus malabaricus [malabaricus Group]_white-rumped shama (White-rumped)_whrsha1
+Copsychus malabaricus ngae_white-rumped shama (Long-tailed)_whrsha18
+Copsychus malabaricus [melanurus Group]_white-rumped shama (Barusan)_whrsha3
+Copsychus leggei_sri lankan shama_whrsha5
+Copsychus stricklandii_white-crowned shama_whrsha16
+Copsychus barbouri_maratua shama_whrsha17
+Copsychus nigricauda_kangean shama_whrsha11
+Copsychus albiventris_andaman shama_andsha1
+Copsychus omissus_larwo shama_larsha1
+Copsychus luzoniensis_white-browed shama_whbsha1
+Copsychus superciliaris_visayan shama_vissha1
+Copsychus niger_white-vented shama_whvsha1
+Copsychus cebuensis_black shama_blasha1
+Leucoptilon concretum_white-tailed flycatcher_whtfly2
+Sholicola major_nilgiri sholakili_whbsho1
+Sholicola albiventris_white-bellied sholakili_whbsho3
+Niltava grandis_large niltava_larnil1
+Niltava grandis [grandis Group]_large niltava (Large)_larnil6
+Niltava grandis decorata_large niltava (Dalat)_larnil4
+Niltava macgrigoriae_small niltava_smanil1
+Niltava davidi_fujian niltava_fujnil1
+Niltava sundara_rufous-bellied niltava_rubnil1
+Niltava sumatrana_rufous-vented niltava_ruvnil1
+Niltava oatesi_chinese vivid niltava_vivnil2
+Niltava vivida_taiwan vivid niltava_vivnil3
+Niltava sp._niltava sp._niltav1
+Cyanoptila cyanomelana_blue-and-white flycatcher_bawfly2
+Cyanoptila cumatilis_zappey's flycatcher_zapfly1
+Cyanoptila cyanomelana/cumatilis_blue-and-white/zappey's flycatcher_y00911
+Eumyias sanfordi_matinan flycatcher_matfly2
+Eumyias hoevelli_blue-fronted flycatcher_blffly1
+Eumyias hyacinthinus_papa-moscas-azul-de-timor_tibfly2
+Eumyias oscillans_flores jungle flycatcher_flojuf2
+Eumyias stresemanni_sumba jungle flycatcher_flojuf1
+Eumyias sordidus_dull-blue flycatcher_dubfly3
+Eumyias albicaudatus_nilgiri flycatcher_nilfly2
+Eumyias indigo_indigo flycatcher_indfly1
+Eumyias indigo ruficrissa/cerviniventris_indigo flycatcher (Rufous-vented)_indfly2
+Eumyias indigo indigo_indigo flycatcher (Javan)_indfly3
+Eumyias thalassinus_verditer flycatcher_verfly4
+Eumyias albicaudatus/thalassinus_nilgiri/verditer flycatcher_y01103
+Eumyias additus_buru jungle flycatcher_burjuf1
+Eumyias panayensis_turquoise flycatcher_islfly1
+Anthipes monileger_white-gorgeted flycatcher_whgfly1
+Anthipes solitaris_rufous-browed flycatcher_rubfly3
+Cyornis ruckii_rück's blue flycatcher_rubfly1
+Cyornis herioti_blue-breasted blue flycatcher_bubfly1
+Cyornis camarinensis_rufous-breasted blue flycatcher_bubfly2
+Cyornis herioti/camarinensis_blue-breasted/rufous-breasted blue flycatcher_blbfly3
+Cyornis hainanus_hainan blue flycatcher_habfly1
+Cyornis pallidipes_white-bellied blue flycatcher_wbbfly1
+Cyornis poliogenys_pale-chinned flycatcher_pacblf1
+Cyornis unicolor_pale blue flycatcher_pabfly2
+Cyornis unicolor unicolor_pale blue flycatcher (Unicolored)_pabfly3
+Cyornis unicolor diaoluoensis_pale blue flycatcher (Diao Luo)_pabfly4
+Cyornis unicolor cyanopolia_pale blue flycatcher (Hartert's)_pabfly5
+Cyornis rubeculoides_blue-throated flycatcher_butfly1
+Cyornis glaucicomans_chinese blue flycatcher_butfly2
+Cyornis rubeculoides/glaucicomans_blue-throated/chinese blue flycatcher_bltfly2
+Cyornis hainanus/rubeculoides/glaucicomans_hainan blue/blue-throated/chinese blue flycatcher_y01329
+Cyornis magnirostris_large blue flycatcher_larblf1
+Cyornis whitei_hill blue flycatcher_hibfly1
+Cyornis magnirostris/whitei_large/hill blue flycatcher_y01092
+Cyornis banyumas_javan blue flycatcher_hibfly3
+Cyornis montanus_dayak blue flycatcher_hibfly4
+Cyornis kadayangensis_meratus blue flycatcher_merjuf1
+Cyornis caerulatus_sunda blue flycatcher_lobblf1
+Cyornis turcosus_malaysian blue flycatcher_mabfly1
+Cyornis lemprieri_palawan blue flycatcher_pabfly1
+Cyornis superbus_bornean blue flycatcher_bobfly2
+Cyornis tickelliae_tickell's blue flycatcher_tibfly3
+Cyornis poliogenys x tickelliae_pale-chinned x tickell's blue flycatcher (hybrid)_x00927
+Cyornis rubeculoides/tickelliae_blue-throated/tickell's blue flycatcher_y01069
+Cyornis sumatrensis_indochinese blue flycatcher_tibfly4
+Cyornis rufigastra_mangrove blue flycatcher_mabfly2
+Cyornis rufigastra [rufigastra Group]_mangrove blue flycatcher (Mangrove)_manblf1
+Cyornis rufigastra [blythi Group]_mangrove blue flycatcher (Philippine)_manblf2
+Cyornis omissus_sulawesi blue flycatcher_subfly1
+Cyornis omissus [omissus Group]_sulawesi blue flycatcher (Sulawesi)_sulblf1
+Cyornis omissus djampeanus_sulawesi blue flycatcher (Tanahjampea)_subfly4
+Cyornis kalaoensis_kalao blue flycatcher_subfly5
+Cyornis brunneatus_brown-chested jungle flycatcher_bncjuf1
+Cyornis nicobaricus_nicobar jungle flycatcher_nicjuf1
+Cyornis umbratilis_gray-chested jungle flycatcher_gycjuf1
+Cyornis olivaceus_fulvous-chested jungle flycatcher_fucjuf1
+Cyornis ruficauda_philippine jungle flycatcher_chtjuf2
+Cyornis ocularis_sulu jungle flycatcher_chtjuf3
+Cyornis ruficrissa_crocker jungle flycatcher_chtjuf4
+Cyornis pelingensis_banggai jungle flycatcher_banjuf1
+Cyornis colonus_sula jungle flycatcher_suljuf1
+Cyornis sp._Cyornis sp._blufly1
+Cossyphicula roberti_white-bellied robin-chat_wbrcha1
+Cossyphicula roberti roberti_white-bellied robin-chat (White-bellied)_whbroc1
+Cossyphicula roberti rufescentior_white-bellied robin-chat (Albertine)_whbroc2
+Cossyphicula isabellae_mountain robin-chat_morcha1
+Cossyphicula isabellae batesi_mountain robin-chat (Highland)_mouroc1
+Cossyphicula isabellae isabellae_mountain robin-chat (Mountain)_mouroc2
+Dessonornis archeri_archer's robin-chat_arrcha1
+Dessonornis archeri archeri_archer's robin-chat (Archer's)_arcroc1
+Dessonornis archeri kimbutui_archer's robin-chat (Kabobo)_arcroc2
+Dessonornis anomalus_olive-flanked robin-chat_ofrcha1
+Dessonornis anomalus grotei_olive-flanked robin-chat (White-bellied)_olfroc1
+Dessonornis anomalus mbuluensis_olive-flanked robin-chat (Black)_olfroc2
+Dessonornis anomalus [anomalus Group]_olive-flanked robin-chat (Olive-flanked)_olfroc3
+Dessonornis caffer_cape robin-chat_carcha1
+Dessonornis humeralis_white-throated robin-chat_wtrcha1
+Cossypha cyanocampter_blue-shouldered robin-chat_bsrcha1
+Cossypha semirufa_rüppell's robin-chat_rurcha1
+Cossypha heuglini_white-browed robin-chat_wbrcha2
+Cossypha natalensis_red-capped robin-chat_rcrcha1
+Cossypha dichroa_chorister robin-chat_chrcha1
+Cossypha heinrichi_white-headed robin-chat_whrcha1
+Cossypha niveicapilla_snowy-crowned robin-chat_scrcha1
+Cossypha albicapillus_white-crowned robin-chat_wcrcha1
+Cossypha sp._robin-chat sp._robinc1
+Xenocopsychus ansorgei_angola cave-chat_anccha1
+Cichladusa arquata_collared palm-thrush_copthr1
+Cichladusa ruficauda_rufous-tailed palm-thrush_rtpthr1
+Cichladusa guttata_spotted morning-thrush_spmthr1
+Erithacus rubecula_pisco-de-peito-ruivo_eurrob1
+Pogonocichla stellata_white-starred robin_whsrob1
+Swynnertonia swynnertoni_swynnerton's robin_swyrob1
+Swynnertonia swynnertoni rodgersi_swynnerton's robin (Udzungwa)_swyrob2
+Swynnertonia swynnertoni swynnertoni_swynnerton's robin (Swynnerton's)_swyrob3
+Chamaetylas poliocephala_brown-chested alethe_brcale1
+Chamaetylas poliocephala poliocephala_brown-chested alethe (Gray-headed)_bncale1
+Chamaetylas poliocephala hallae_brown-chested alethe (Gabela)_bncale2
+Chamaetylas poliocephala compsonota_brown-chested alethe (Chestnut-backed)_bncale3
+Chamaetylas poliocephala [carruthersi Group]_brown-chested alethe (Brown-chested)_bncale4
+Chamaetylas poliophrys_red-throated alethe_retale1
+Chamaetylas choloensis_thyolo alethe_choale1
+Chamaetylas fuelleborni_white-chested alethe_whcale1
+Stiphrornis pyrrholaemus_olive-backed forest robin_forrob6
+Stiphrornis erythrothorax_orange-breasted forest robin_obfrob1
+Stiphrornis mabirae_yellow-breasted forest robin_forrob4
+Stiphrornis sp._forest robin sp._forrob7
+Sheppardia polioptera_gray-winged robin-chat_gywroc1
+Sheppardia polioptera nigriceps/tessmanni_gray-winged robin-chat (Black-capped)_gywroc2
+Sheppardia polioptera polioptera_gray-winged robin-chat (Gray-winged)_gywroc3
+Sheppardia poensis_short-tailed akalat_shtaka2
+Sheppardia poensis granti_short-tailed akalat (Grant's)_bocaka2
+Sheppardia poensis poensis_short-tailed akalat (Bioko)_bocaka3
+Sheppardia poensis [kungwensis Group]_short-tailed akalat (Short-tailed)_shtaka1
+Sheppardia bocagei_bocage's akalat_bocaka11
+Sheppardia cyornithopsis_lowland akalat_lowaka1
+Sheppardia aequatorialis_equatorial akalat_equaka1
+Sheppardia sharpei_sharpe's akalat_shaaka1
+Sheppardia gunningi_east coast akalat_eacaka1
+Sheppardia gunningi sokokensis_east coast akalat (East Coast)_eacaka2
+Sheppardia gunningi alticola_east coast akalat (Montane)_eacaka4
+Sheppardia gunningi bensoni_east coast akalat (Benson's)_eacaka5
+Sheppardia gunningi gunningi_east coast akalat (Gunning's)_eacaka6
+Sheppardia gabela_gabela akalat_gabaka1
+Sheppardia montana_usambara akalat_usaaka1
+Sheppardia lowei_iringa akalat_iriaka1
+Sheppardia aurantiithorax_rubeho akalat_rubaka1
+Leonardina woodi_bagobo robin_bagbab2
+Vauriella gularis_eyebrowed jungle flycatcher_eyjfly1
+Vauriella insignis_rusty-flanked jungle flycatcher_rufjuf1
+Vauriella albigularis_negros jungle flycatcher_negjuf1
+Vauriella goodfellowi_mindanao jungle flycatcher_minjuf1
+Heinrichia calligyna_great shortwing_gresho1
+Heinrichia calligyna simplex_great shortwing (Minahasa)_gresho2
+Heinrichia calligyna calligyna/picta_great shortwing (Great)_gresho3
+Brachypteryx hyperythra_rusty-bellied shortwing_rubsho1
+Brachypteryx leucophris_asa-curta-pequeno_lessho1
+Brachypteryx cruralis_himalayan shortwing_whbsho4
+Brachypteryx sinensis_chinese shortwing_whbsho5
+Brachypteryx cruralis/sinensis_himalayan/chinese shortwing_y01161
+Brachypteryx goodfellowi_taiwan shortwing_whbsho6
+Brachypteryx poliogyna_philippine shortwing_whbsho7
+Brachypteryx erythrogyna_bornean shortwing_whbsho8
+Brachypteryx saturata_sumatran shortwing_whbsho9
+Brachypteryx montana_javan shortwing_whbsho10
+Brachypteryx floris_flores shortwing_whbsho11
+Brachypteryx [undescribed submontane Mindanao form]_mindanao shortwing (undescribed form)_minsho1
+Brachypteryx sp._Brachypteryx sp._brachy1
+Heteroxenicus stellatus_gould's shortwing_gousho1
+Larvivora sibilans_rouxinol-de-cauda-ruiva_rutrob1
+Larvivora ruficeps_rufous-headed robin_ruhrob1
+Larvivora akahige_japanese robin_japrob2
+Larvivora tanensis_izu robin_japrob3
+Larvivora akahige/tanensis_japanese/izu robin_japrob1
+Larvivora komadori_ryukyu robin_ryurob2
+Larvivora namiyei_okinawa robin_ryurob3
+Larvivora komadori/namiyei_ryukyu/okinawa robin_ryurob1
+Larvivora brunnea_indian blue robin_inbrob1
+Larvivora cyane_pisco-azul-siberiano_sibrob
+Irania gutturalis_pisco-de-garganta-branca_whtrob3
+Luscinia luscinia_rouxinol-oriental_thrnig1
+Luscinia megarhynchos_rouxinol_comnig1
+Luscinia megarhynchos megarhynchos/africana_rouxinol (megarhynchos/africana)_comnig2
+Luscinia megarhynchos golzii_rouxinol (golzii)_comnig3
+Luscinia luscinia x megarhynchos_thrush x common nightingale (hybrid)_x01010
+Luscinia luscinia/megarhynchos_rouxinol-oriental/rouxinol_y00625
+Luscinia phaenicuroides_white-bellied redstart_whbred1
+Luscinia svecica_pisco-de-peito-azul_blueth
+Luscinia svecica [svecica Group]_pisco-de-peito-azul [grupo svecica]_blueth1
+Luscinia svecica azuricollis_pisco-de-peito-azul (azuricollis)_blueth4
+Luscinia svecica cyanecula/namnetum_pisco-de-peito-azul (cyanecula/namnetum)_blueth2
+Luscinia svecica magna_pisco-de-peito-azul (magna)_blueth3
+Myophonus blighi_sri lanka whistling-thrush_ceywht1
+Myophonus melanurus_shiny whistling-thrush_shwthr1
+Myophonus glaucinus_javan whistling-thrush_javwht1
+Myophonus castaneus_sumatran whistling-thrush_chwwht1
+Myophonus borneensis_bornean whistling-thrush_borwht1
+Myophonus robinsoni_malayan whistling-thrush_mawthr2
+Myophonus horsfieldii_malabar whistling-thrush_mawthr1
+Myophonus insularis_taiwan whistling-thrush_fowthr1
+Myophonus caeruleus_blue whistling-thrush_blwthr1
+Myophonus caeruleus caeruleus_blue whistling-thrush (Black-billed)_bluwht1
+Myophonus caeruleus [flavirostris Group]_blue whistling-thrush (Yellow-billed)_bluwht2
+Myophonus sp._whistling-thrush sp._whistl2
+Enicurus scouleri_little forktail_litfor1
+Enicurus leschenaulti_white-crowned forktail_whcfor1
+Enicurus leschenaulti sinensis/indicus_white-crowned forktail (Northern)_whcfor4
+Enicurus leschenaulti frontalis/chaseni_white-crowned forktail (Malaysian)_whcfor10
+Enicurus leschenaulti leschenaulti_white-crowned forktail (Javan)_whcfor5
+Enicurus borneensis_bornean forktail_whcfor3
+Enicurus leschenaulti/borneensis_white-crowned/bornean forktail_y01210
+Enicurus maculatus_spotted forktail_spofor1
+Enicurus velatus_sunda forktail_sunfor1
+Enicurus ruficapillus_chestnut-naped forktail_chnfor1
+Enicurus immaculatus_black-backed forktail_blbfor1
+Enicurus schistaceus_slaty-backed forktail_slbfor1
+Enicurus sp._forktail sp._forkta1
+Calliope pectardens_firethroat_fireth1
+Calliope obscura_blackthroat_btbrob1
+Calliope pectardens/obscura_firethroat/blackthroat_y01307
+Calliope calliope_pisco-de-garganta-vermelha_sibrub
+Calliope pectoralis_himalayan rubythroat_himrub1
+Calliope tschebaiewi_chinese rubythroat_chirub1
+Calliope pectoralis/tschebaiewi_himalayan/chinese rubythroat (White-tailed Rubythroat)_whtrub1
+Myiomela leucura_white-tailed robin_whtrob2
+Myiomela leucura leucura/montium_white-tailed robin (White-tailed)_whtrob4
+Myiomela leucura cambodiana_white-tailed robin (Cambodian)_whtrob5
+Myiomela sumatrana_sumatran robin_sunrob2
+Myiomela diana_javan robin_sunrob3
+Cinclidium frontale_blue-fronted robin_blfrob1
+Tarsiger cyanurus_pisco-de-flanco-ruivo_refblu1
+Tarsiger albocoeruleus_qilian bluetail_refblu2
+Tarsiger cyanurus/albocoeruleus_red-flanked/qilian bluetail_refblu
+Tarsiger rufilatus_himalayan bluetail_himblu1
+Tarsiger cyanurus/rufilatus_red-flanked/himalayan bluetail_y00912
+Tarsiger hyperythrus_rufous-breasted bush-robin_rbbrob1
+Tarsiger indicus_white-browed bush-robin_wbbrob1
+Tarsiger formosanus_taiwan bush-robin_whbbur3
+Tarsiger chrysaeus_golden bush-robin_gobrob1
+Tarsiger johnstoniae_collared bush-robin_cobrob1
+Tarsiger formosanus/johnstoniae_taiwan/collared bush-robin_y01124
+Tarsiger sp._Tarsiger sp._tarsig1
+Ficedula zanthopygia_yellow-rumped flycatcher_korfly1
+Ficedula elisae_green-backed flycatcher_narfly1
+Ficedula narcissina_narcissus flycatcher_narfly2
+Ficedula owstoni_ryukyu flycatcher_narfly3
+Ficedula zanthopygia/elisae/narcissina/owstoni_yellow-rumped/green-backed/narcissus/ryukyu flycatcher_y00913
+Ficedula narcissina/owstoni_narcissus/ryukyu flycatcher_narfly
+Ficedula mugimaki_mugimaki flycatcher_mugfly
+Ficedula erithacus_slaty-backed flycatcher_slbfly1
+Ficedula nigrorufa_black-and-orange flycatcher_barfly1
+Ficedula tricolor_slaty-blue flycatcher_slbfly2
+Ficedula hyperythra_papa-moscas-de-sobrancelha-nivea_snbfly1
+Ficedula hodgsoni_pygmy flycatcher_pybfly1
+Ficedula strophiata_rufous-gorgeted flycatcher_rugfly1
+Ficedula sapphira_sapphire flycatcher_sapfly1
+Ficedula westermanni_papa-moscas-pedrês-pequeno_lipfly1
+Ficedula superciliaris_ultramarine flycatcher_ultfly1
+Ficedula superciliaris superciliaris_ultramarine flycatcher (Eyebrowed)_ultfly2
+Ficedula superciliaris aestigma_ultramarine flycatcher (Eastern)_ultfly3
+Ficedula ruficauda_rusty-tailed flycatcher_rutfly6
+Ficedula albicilla_papa-moscas-real-oriental_taifly1
+Ficedula subrubra_kashmir flycatcher_kasfly1
+Ficedula parva_papa-moscas-real_rebfly
+Ficedula albicilla/parva_papa-moscas-real-oriental/papa-moscas-real_y00821
+Ficedula semitorquata_papa-moscas-de-meio-colar_semfly1
+Ficedula hypoleuca_papa-moscas-preto_eupfly1
+Ficedula semitorquata x hypoleuca_papa-moscas-de-meio-colar x papa-moscas-preto (híbrido)_x00471
+Ficedula speculigera_papa-moscas-do-atlas_atlfly1
+Ficedula hypoleuca/speculigera_papa-moscas-preto/papa-moscas-do-atlas_y00819
+Ficedula albicollis_papa-moscas-de-colar_colfly1
+Ficedula semitorquata x albicollis_papa-moscas-de-meio-colar x papa-moscas-de-colar (híbrido)_x00472
+Ficedula hypoleuca x albicollis_papa-moscas-preto x papa-moscas-de-colar (híbrido)_x00817
+Ficedula hypoleuca/albicollis_european pied/collared flycatcher_y01211
+Ficedula hypoleuca/albicollis/semitorquata_papa-moscas-preto/papa-moscas-de-colar/papa-moscas-de-meio-colar_y00820
+Ficedula riedeli_tanimbar flycatcher_rucfly3
+Ficedula dumetoria_rufous-chested flycatcher_rucfly1
+Ficedula platenae_palawan flycatcher_palfly1
+Ficedula disposita_furtive flycatcher_furfly1
+Ficedula rufigula_rufous-throated flycatcher_rutfly5
+Ficedula henrici_damar flycatcher_damfly1
+Ficedula buruensis_cinnamon-chested flycatcher_cicfly1
+Ficedula bonthaina_lompobattang flycatcher_lomfly1
+Ficedula harterti_sumba flycatcher_sumfly1
+Ficedula timorensis_papa-moscas-de-timor_blbfly2
+Ficedula basilanica_little slaty flycatcher_lisfly1
+Ficedula basilanica samarensis_little slaty flycatcher (samarensis)_lisfly2
+Ficedula basilanica basilanica_little slaty flycatcher (basilanica)_lisfly3
+Ficedula crypta_cryptic flycatcher_rutfly7
+Ficedula luzoniensis_bundok flycatcher_bunfly1
+Ficedula sp._papa-moscas (Ficedula) sp._ficedu1
+Phoenicurus frontalis_blue-fronted redstart_blfred1
+Phoenicurus fuliginosus_plumbeous redstart_plured1
+Phoenicurus bicolor_luzon redstart_luzred1
+Phoenicurus erythronotus_rabirruivo-de-eversmann_rubred2
+Phoenicurus leucocephalus_white-capped redstart_whcred1
+Phoenicurus alaschanicus_ala shan redstart_alsred1
+Phoenicurus coeruleocephala_blue-capped redstart_bucred1
+Phoenicurus moussieri_rabirruivo-mourisco_moured1
+Phoenicurus phoenicurus_rabirruivo-de-testa-branca_comred2
+Phoenicurus phoenicurus phoenicurus_rabirruivo-de-testa-branca (phoenicurus)_comred5
+Phoenicurus phoenicurus samamisicus_rabirruivo-de-testa-branca (samamisicus)_comred6
+Phoenicurus hodgsoni_hodgson's redstart_hodred1
+Phoenicurus schisticeps_white-throated redstart_whtred1
+Phoenicurus erythrogastrus_rabirruivo-de-touca-branca_whwred2
+Phoenicurus ochruros_rabirruivo_blared1
+Phoenicurus ochruros gibraltariensis/aterrimus_rabirruivo (gibraltariensis/aterrimus)_blkred2
+Phoenicurus ochruros [ochruros Group]_rabirruivo [grupo ochruros]_blkred1
+Phoenicurus phoenicurus x ochruros_rabirruivo-de-testa-branca x rabirruivo (híbrido)_x00745
+Phoenicurus phoenicurus/ochruros_rabirruivo-de-testa-branca/rabirruivo_y01071
+Phoenicurus auroreus_daurian redstart_daured1
+Phoenicurus sp._rabirruivo (Phoenicurus) sp._redsta1
+Monticola rufocinereus_little rock-thrush_lirthr1
+Monticola rufiventris_chestnut-bellied rock-thrush_cbrthr1
+Monticola gularis_white-throated rock-thrush_wtrthr1
+Monticola cinclorhyncha_blue-capped rock-thrush_bcrthr1
+Monticola brevipes_short-toed rock-thrush_strthr1
+Monticola brevipes brevipes_short-toed rock-thrush (White-crowned)_shtrot1
+Monticola brevipes pretoriae_short-toed rock-thrush (Short-toed)_shtrot2
+Monticola explorator_sentinel rock-thrush_serthr1
+Monticola imerina_littoral rock-thrush_litrot1
+Monticola erythronotus_amber mountain rock-thrush_ammrot1
+Monticola sharpei_forest rock-thrush_forrot2
+Monticola sharpei sharpei_forest rock-thrush (Forest)_forrot1
+Monticola sharpei bensoni_forest rock-thrush (Benson's)_benrot1
+Monticola saxatilis_melro-das-rochas_rtrthr1
+Monticola solitarius_melro-azul_burthr
+Monticola solitarius solitarius/longirostris_melro-azul (solitarius/longirostris)_blurot1
+Monticola solitarius pandoo_melro-azul (pandoo)_blurot5
+Monticola solitarius philippensis_melro-azul (philippensis)_blurot2
+Monticola solitarius pandoo x philippensis_melro-azul (pandoo x philippensis)_blurot3
+Monticola solitarius madoci_melro-azul (madoci)_blurot4
+Monticola angolensis_miombo rock-thrush_mirthr1
+Monticola rupestris_cape rock-thrush_carthr1
+Monticola semirufus_white-winged cliff-chat_wwccha1
+Monticola sp._melro-das-rochas (Monticola) sp._rockth1
+Saxicola rubetra_cartaxo-nortenho_whinch1
+Phoenicurus phoenicurus x Saxicola rubetra_rabirruivo-de-testa-branca x cartaxo-nortenho (híbrido)_x00818
+Saxicola macrorhynchus_white-browed bushchat_whbbus4
+Saxicola insignis_white-throated bushchat_whtbus1
+Saxicola dacotiae_caldeireta_caisto1
+Saxicola rubicola_cartaxo_stonec4
+Saxicola rubetra/rubicola_whinchat/european stonechat_y01190
+Saxicola maurus_cartaxo-siberiano_sibsto1
+Saxicola maurus hemprichii_cartaxo-siberiano (hemprichii)_sibsto2
+Saxicola maurus [maurus Group]_cartaxo-siberiano [grupo maurus]_stonec2
+Saxicola maurus przewalskii_cartaxo-siberiano (przewalskii)_sibsto3
+Saxicola rubetra x maurus_cartaxo-nortenho x cartaxo-siberiano (híbrido)_x01161
+Saxicola macrorhynchus/maurus_white-browed bushchat/siberian stonechat_y01123
+Saxicola insignis/maurus_white-throated bushchat/siberian stonechat_y01191
+Saxicola rubicola/maurus_cartaxo/cartaxo-siberiano_stonec1
+Saxicola stejnegeri_amur stonechat_stonec7
+Saxicola maurus/stejnegeri_siberian/amur stonechat_y00427
+Saxicola torquatus_cartaxo-africano_afrsto1
+Saxicola torquatus [torquatus Group]_cartaxo-africano [grupo torquatus]_stonec3
+Saxicola torquatus albofasciatus_cartaxo-africano (albofasciatus)_stonec5
+Saxicola torquatus sibilla_cartaxo-africano (sibilla)_stonec6
+Saxicola tectes_cartaxo-da-reunião_reusto1
+Saxicola leucurus_cartaxo-de-cauda-branca_whtsto2
+Saxicola maurus/leucurus_cartaxo-siberiano/cartaxo-de-cauda-branca_y00914
+Saxicola caprata_cartaxo-preto_piebus1
+Saxicola jerdoni_jerdon's bushchat_jerbus1
+Saxicola ferreus_gray bushchat_grybus1
+Saxicola gutturalis_cartaxo-de-timor_timbus1
+Saxicola sp._Saxicola sp._saxico1
+Campicoloides bifasciatus_buff-streaked chat_busbus1
+Emarginata sinuata_sickle-winged chat_siccha1
+Emarginata schlegelii_karoo chat_karcha1
+Emarginata tractrac_tractrac chat_tracha1
+Pinarochroa sordida_moorland chat_moocha1
+Pinarochroa sordida sordida_moorland chat (Abyssinian)_moocha2
+Pinarochroa sordida ernesti_moorland chat (Mt. Kenya)_moocha4
+Pinarochroa sordida olimotiensis_moorland chat (Ngorongoro)_moocha5
+Pinarochroa sordida hypospodia_moorland chat (Mt. Kilimanjaro)_moocha6
+Thamnolaea cinnamomeiventris_mocking cliff-chat_moccha1
+Myrmecocichla nigra_sooty chat_soocha1
+Myrmecocichla aethiops_northern anteater-chat_noacha1
+Myrmecocichla formicivora_southern anteater-chat_soacha1
+Myrmecocichla tholloni_congo moor chat_conmoo1
+Myrmecocichla monticola_mountain chat_mouwhe1
+Myrmecocichla melaena_rüppell's chat_ruecha1
+Myrmecocichla arnotti_arnot's chat_whbcha2
+Myrmecocichla arnotti harterti_arnot's chat (Angola)_arncha1
+Myrmecocichla arnotti arnotti_arnot's chat (Arnot's)_arncha2
+Myrmecocichla arnotti collaris_arnot's chat (Ruaha)_ruacha1
+Oenanthe oenanthe_chasco-cinzento_norwhe
+Oenanthe oenanthe leucorhoa_chasco-cinzento-da-gronelândia_norwhe2
+Oenanthe oenanthe oenanthe/libanotica_chasco-cinzento (oenanthe/libanotica)_norwhe1
+Oenanthe seebohmi_chasco-de-seebohm_norwhe3
+Oenanthe oenanthe/seebohmi_northern/atlas wheatear_y01192
+Oenanthe pileata_capped wheatear_capwhe1
+Oenanthe bottae_buff-breasted wheatear_rebwhe2
+Oenanthe frenata_rusty-breasted wheatear_rebwhe3
+Oenanthe isabellina_chasco-isabel_isawhe1
+Oenanthe heuglinii_heuglin's wheatear_heuwhe1
+Oenanthe monacha_chasco-de-capuz_hoowhe1
+Oenanthe deserti_chasco-do-deserto_deswhe1
+Oenanthe hispanica_chasco-ruivo-ocidental_bkewhe1
+Oenanthe cypriaca_chasco-do-chipre_cypwhe1
+Oenanthe melanoleuca_chasco-ruivo-oriental_bkewhe2
+Oenanthe oenanthe/hispanica/melanoleuca_chasco-cinzento/chasco-ruivo-ocidental/chasco-ruivo-oriental_y00915
+Oenanthe hispanica/melanoleuca_chasco-ruivo-ocidental/chasco-ruivo-oriental_blewhe1
+Oenanthe pleschanka_chasco-malhado_piewhe1
+Oenanthe pleschanka (vittata form)_chasco-malhado (forma vittata)_piewhe2
+Oenanthe melanoleuca x pleschanka_chasco-ruivo-oriental x chasco-malhado (híbrido)_x00771
+Oenanthe cypriaca/pleschanka_chasco-do-chipre/chasco-malhado_y01004
+Oenanthe melanoleuca/pleschanka_chasco-ruivo-oriental/chasco-malhado_y01162
+Oenanthe albifrons_white-fronted black-chat_wfbcha1
+Oenanthe phillipsi_somali wheatear_somwhe1
+Oenanthe moesta_chasco-triste_rerwhe1
+Oenanthe melanura_rabinegro_blacks1
+Oenanthe familiaris_familiar chat_famcha1
+Oenanthe dubia_sombre rock chat_somcha1
+Oenanthe scotocerca_brown-tailed chat_brtcha1
+Oenanthe scotocerca [scotocerca Group]_brown-tailed chat (Brown-tailed)_bntcha1
+Oenanthe scotocerca spectatrix/validior_brown-tailed chat (Pale)_bntcha2
+Oenanthe fusca_brown rock chat_indcha1
+Oenanthe picata_chasco-oriental_varwhe1
+Oenanthe picata picata_chasco-oriental (picata)_varwhe2
+Oenanthe picata capistrata_chasco-oriental (capistrata)_varwhe3
+Oenanthe picata opistholeuca_chasco-oriental (opistholeuca)_varwhe4
+Oenanthe leucura_chasco-preto_blawhe1
+Oenanthe albonigra_hume's wheatear_humwhe2
+Oenanthe leucopyga_chasco-de-barrete-branco_whtwhe1
+Oenanthe lugentoides_chasco-árabe_mouwhe5
+Oenanthe lugubris_chasco-da-abissínia_mouwhe4
+Oenanthe finschii_chasco-de-finsch_finwhe1
+Oenanthe lugens_chasco-fúnebre_mouwhe2
+Oenanthe lugens lugens/persica_chasco-fúnebre (lugens/persica)_mouwhe3
+Oenanthe lugens halophila_chasco-do-magreb_mouwhe6
+Oenanthe lugens warriae_chasco-fúnebre (warriae)_mouwhe7
+Oenanthe lugentoides/lugens_chasco-árabe/chasco-fúnebre_y01287
+Oenanthe xanthoprymna_chasco-curdo_retwhe3
+Oenanthe chrysopygia_chasco-persa_retwhe2
+Oenanthe xanthoprymna/chrysopygia_chasco-curdo/persa_retwhe1
+Oenanthe sp._chasco (Oenanthe) sp._wheate1
+Muscicapidae sp._muscicapid sp._muscic2
+Bombycilla garrulus_picoteiro_bohwax
+Bombycilla cedrorum_picoteiro-americano_cedwax
+Bombycilla garrulus/cedrorum_picoteiro/picoteiro-americano_waxwin
+Bombycilla japonica_japanese waxwing_japwax1
+Bombycilla garrulus/japonica_bohemian/japanese waxwing_y00428
+Moho braccatus_kauai oo_kauoo
+Moho apicalis_oahu oo_oahoo
+Moho bishopi_bishop's oo_bisoo
+Moho nobilis_hawaii oo_hawoo
+Chaetoptila angustipluma_kioea_kioea
+Phainoptila melanoxantha_black-and-yellow silky-flycatcher_bayfly1
+Ptiliogonys cinereus_gray silky-flycatcher_grsfly1
+Ptiliogonys caudatus_long-tailed silky-flycatcher_ltsfly1
+Phainopepla nitens_phainopepla_phaino
+Dulus dominicus_palmchat_palmch1
+Hylocitrea bonensis_hylocitrea_olfwhi1
+Hylocitrea bonensis bonensis_hylocitrea (Northern)_hyloci1
+Hylocitrea bonensis bonthaina_hylocitrea (Southern)_hyloci2
+Hypocolius ampelinus_hipocólio_hypoco1
+Promerops gurneyi_gurney's sugarbird_gursug1
+Promerops cafer_cape sugarbird_capsug1
+Modulatrix stictigula_spot-throat_spothr1
+Arcanator orostruthus_dapple-throat_dapthr1
+Kakamega poliothorax_gray-chested babbler_gycill1
+Prionochilus maculatus_yellow-breasted flowerpecker_yebflo2
+Prionochilus percussus_crimson-breasted flowerpecker_crbflo1
+Prionochilus plateni_palawan flowerpecker_palflo1
+Prionochilus xanthopygius_yellow-rumped flowerpecker_yerflo1
+Prionochilus thoracicus_scarlet-breasted flowerpecker_scbflo2
+Prionochilus sp._Prionochilus sp._priono1
+Pachyglossa olivacea_olive-backed flowerpecker_olbflo1
+Pachyglossa agilis_pica-flor-de-bico-grosso_thbflo1
+Pachyglossa agilis agilis/zeylonica_pica-flor-de-bico-grosso (agilis/zeylonica)_thbflo2
+Pachyglossa agilis [obsoleta Group]_pica-flor-de-bico-grosso [grupo obsoleta]_thbflo4
+Pachyglossa agilis [aeruginosa Group]_pica-flor-de-bico-grosso [grupo aeruginosa]_thbflo3
+Pachyglossa everetti_brown-backed flowerpecker_brbflo1
+Pachyglossa propria_whiskered flowerpecker_whiflo1
+Pachyglossa chrysorrhea_yellow-vented flowerpecker_yevflo1
+Pachyglossa melanozantha_yellow-bellied flowerpecker_yebflo1
+Pachyglossa vincens_white-throated flowerpecker_whtflo1
+Dicaeum dayakorum_spectacled flowerpecker_speflo1
+Dicaeum annae_golden-rumped flowerpecker_gorflo1
+Dicaeum aureolimbatum_yellow-sided flowerpecker_yesflo1
+Dicaeum nigrilore_olive-capped flowerpecker_olcflo1
+Dicaeum anthonyi_yellow-crowned flowerpecker_flcflo2
+Dicaeum kampalili_flame-crowned flowerpecker_flcflo3
+Dicaeum bicolor_bicolored flowerpecker_bicflo1
+Dicaeum quadricolor_cebu flowerpecker_cebflo1
+Dicaeum australe_red-keeled flowerpecker_resflo1
+Dicaeum haematostictum_black-belted flowerpecker_rekflo1
+Dicaeum retrocinctum_scarlet-collared flowerpecker_sccflo1
+Dicaeum trigonostigma_orange-bellied flowerpecker_orbflo1
+Dicaeum trigonostigma [trigonostigma Group]_orange-bellied flowerpecker (Orange-bellied)_orbflo21
+Dicaeum trigonostigma xanthopygium/dorsale_orange-bellied flowerpecker (Orange-breasted)_orbflo22
+Dicaeum trigonostigma [sibuyanicum Group]_orange-bellied flowerpecker (Sibuyan)_orbflo23
+Dicaeum trigonostigma [cinereigulare Group]_orange-bellied flowerpecker (Gray-throated)_orbflo20
+Dicaeum trigonostigma sibutuense/assimile_orange-bellied flowerpecker (Sulu)_orbflo24
+Dicaeum hypoleucum_buzzing flowerpecker_whbflo1
+Dicaeum hypoleucum obscurum/cagayanense_buzzing flowerpecker (obscurum/cagayanense)_whbflo7
+Dicaeum hypoleucum pontifex_buzzing flowerpecker (pontifex)_whbflo4
+Dicaeum hypoleucum hypoleucum/mindanense_buzzing flowerpecker (hypoleucum/mindanense)_whbflo8
+Dicaeum erythrorhynchos_pale-billed flowerpecker_pabflo1
+Pachyglossa agilis/Dicaeum erythrorhynchos_thick-billed/pale-billed flowerpecker_y00826
+Dicaeum concolor_nilgiri flowerpecker_plaflo1
+Dicaeum erythrorhynchos/concolor_pale-billed/nilgiri flowerpecker_y01106
+Dicaeum minullum_plain flowerpecker_plaflo2
+Dicaeum virescens_andaman flowerpecker_andflo1
+Dicaeum pygmaeum_pygmy flowerpecker_pygflo1
+Dicaeum nehrkorni_crimson-crowned flowerpecker_crcflo1
+Dicaeum schistaceiceps_halmahera flowerpecker_flbflo3
+Dicaeum erythrothorax_buru flowerpecker_flbflo2
+Dicaeum vulneratum_ashy flowerpecker_ashflo1
+Dicaeum pectorale_olive-crowned flowerpecker_olcflo2
+Dicaeum geelvinkianum_red-capped flowerpecker_recflo1
+Dicaeum nitidum_louisiade flowerpecker_louflo1
+Dicaeum eximium_red-banded flowerpecker_rebflo1
+Dicaeum aeneum_midget flowerpecker_midflo1
+Dicaeum tristrami_mottled flowerpecker_motflo1
+Dicaeum igniferum_black-fronted flowerpecker_blfflo1
+Dicaeum maugei_pica-flor-de-peito-vermelho_recflo2
+Dicaeum ignipectus_fire-breasted flowerpecker_fibflo1
+Dicaeum ignipectus ignipectus/dolichorhynchum_fire-breasted flowerpecker (Fire-breasted)_fibflo12
+Dicaeum ignipectus formosum_fire-breasted flowerpecker (Taiwan)_fibflo8
+Dicaeum cambodianum_cambodian flowerpecker_fibflo3
+Dicaeum luzoniense_fire-throated flowerpecker_fibflo4
+Dicaeum beccarii_sumatran flowerpecker_fibflo5
+Dicaeum monticolum_black-sided flowerpecker_blsflo1
+Dicaeum [undescribed Meratus form]_meratus flowerpecker (undescribed form)_merflo2
+Dicaeum celebicum_gray-sided flowerpecker_gysflo1
+Dicaeum celebicum [celebicum Group]_gray-sided flowerpecker (Gray-sided)_gysflo2
+Dicaeum celebicum kuehni_gray-sided flowerpecker (Wakatobi)_gysflo3
+Dicaeum sanguinolentum_javan flowerpecker_blbflo5
+Dicaeum rhodopygiale_flores flowerpecker_blbflo6
+Dicaeum wilhelminae_sumba flowerpecker_blbflo3
+Dicaeum hanieli_timor flowerpecker_blbflo4
+Dicaeum keiense_pink-breasted flowerpecker_pibflo1
+Dicaeum hirundinaceum_mistletoebird_mistle1
+Dicaeum hirundinaceum hirundinaceum_mistletoebird (Australian)_mistle7
+Dicaeum hirundinaceum ignicolle_mistletoebird (Aru)_mistle3
+Dicaeum cruentatum_scarlet-backed flowerpecker_scbflo1
+Dicaeum trochileum_scarlet-headed flowerpecker_schflo1
+Pachyglossa/Dicaeum sp._Pachyglossa/Dicaeum sp._dicaeu1
+Dicaeidae sp._flowerpecker sp._flower2
+Chalcoparia singalensis_ruby-cheeked sunbird_rucsun2
+Deleornis fraseri_fraser's sunbird_sctsun2
+Deleornis axillaris_gray-headed sunbird_gyhsun1
+Anthreptes reichenowi_plain-backed sunbird_plbsun1
+Anthreptes anchietae_anchieta's sunbird_ancsun1
+Anthreptes simplex_plain sunbird_plasun1
+Anthreptes malacensis_brown-throated sunbird_pltsun2
+Anthreptes griseigularis_gray-throated sunbird_pltsun3
+Anthreptes malacensis/griseigularis_brown-throated/gray-throated sunbird_pltsun1
+Anthreptes rhodolaemus_red-throated sunbird_retsun3
+Anthreptes gabonicus_mouse-brown sunbird_mobsun1
+Anthreptes longuemarei_western violet-backed sunbird_wvbsun1
+Anthreptes longuemarei longuemarei/haussarum_western violet-backed sunbird (Northern)_wvbsun3
+Anthreptes longuemarei angolensis/nyassae_western violet-backed sunbird (Southern)_wvbsun2
+Anthreptes orientalis_eastern violet-backed sunbird_kvbsun1
+Anthreptes neglectus_uluguru violet-backed sunbird_uvbsun1
+Anthreptes aurantius_violet-tailed sunbird_vitsun1
+Anthreptes seimundi_little green sunbird_ligsun2
+Anthreptes rectirostris_yellow-chinned sunbird_grnsun1
+Anthreptes tephrolaemus_gray-chinned sunbird_grnsun2
+Anthreptes rubritorques_banded sunbird_bansun1
+Anthreptes [undescribed form]_mafwemiro sunbird (undescribed form)_mafsun1
+Hedydipna collaris_collared sunbird_colsun2
+Hedydipna platura_pygmy sunbird_pygsun2
+Hedydipna metallica_beija-flor-do-nilo_nivsun2
+Hedydipna pallidigaster_amani sunbird_amasun2
+Anabathmis reichenbachii_reichenbach's sunbird_reisun2
+Anabathmis hartlaubii_principe sunbird_prisun2
+Anabathmis newtonii_newton's sunbird_newsun2
+Dreptes thomensis_sao tome sunbird_satsun1
+Anthobaphes violacea_orange-breasted sunbird_orbsun2
+Cyanomitra verticalis_green-headed sunbird_gnhsun1
+Cyanomitra verticalis verticalis/viridisplendens_green-headed sunbird (Green-headed)_gnhsun3
+Cyanomitra verticalis cyanocephala/bohndorffi_green-headed sunbird (Blue-headed)_gnhsun2
+Cyanomitra bannermani_bannerman's sunbird_bansun3
+Cyanomitra cyanolaema_blue-throated brown sunbird_btbsun2
+Cyanomitra oritis_cameroon sunbird_camsun2
+Cyanomitra oritis bansoensis_cameroon sunbird (Green-headed)_camsun4
+Cyanomitra oritis poensis_cameroon sunbird (Bioko)_camsun5
+Cyanomitra oritis oritis_cameroon sunbird (Blue-headed)_camsun3
+Cyanomitra alinae_blue-headed sunbird_buhsun1
+Cyanomitra olivacea_olive sunbird_eaosun1
+Cyanomitra veroxii_mouse-colored sunbird_mocsun2
+Chalcomitra adelberti_buff-throated sunbird_butsun2
+Chalcomitra fuliginosa_carmelite sunbird_carsun2
+Chalcomitra rubescens_green-throated sunbird_gntsun1
+Chalcomitra amethystina_amethyst sunbird_amesun2
+Chalcomitra senegalensis_scarlet-chested sunbird_sccsun2
+Chalcomitra hunteri_hunter's sunbird_hunsun2
+Chalcomitra balfouri_socotra sunbird_socsun2
+Leptocoma zeylonica_purple-rumped sunbird_pursun3
+Leptocoma minima_crimson-backed sunbird_crbsun2
+Leptocoma zeylonica/minima_purple-rumped sunbird/crimson-backed sunbird_y01333
+Leptocoma brasiliana_van hasselt's sunbird_vahsun1
+Leptocoma sperata_purple-throated sunbird_putsun3
+Leptocoma sperata [sperata Group]_purple-throated sunbird (Purple-throated)_putsun5
+Leptocoma sperata juliae_purple-throated sunbird (Orange-lined)_putsun6
+Leptocoma aspasia_black sunbird_blksun1
+Leptocoma aspasia talautensis/sangirensis_black sunbird (Sangihe)_blksun29
+Leptocoma aspasia grayi_black sunbird (North Sulawesi)_blksun4
+Leptocoma aspasia porphyrolaema_black sunbird (South Sulawesi)_blksun5
+Leptocoma aspasia [undescribed form]_black sunbird (Menui)_blksun26
+Leptocoma aspasia [aspasioides Group]_black sunbird (Moluccan)_blksun27
+Leptocoma aspasia chlorolaema_black sunbird (Kai)_blksun10
+Leptocoma aspasia [aspasia Group]_black sunbird (Papuan)_blksun28
+Leptocoma aspasia [corinna Group]_black sunbird (Bismarck)_blksun25
+Leptocoma calcostetha_copper-throated sunbird_cotsun2
+Nectarinia bocagii_bocage's sunbird_bocsun2
+Nectarinia purpureiventris_purple-breasted sunbird_pubsun3
+Nectarinia tacazze_tacazze sunbird_tacsun1
+Nectarinia kilimensis_bronze sunbird_brosun1
+Nectarinia famosa_malachite sunbird_malsun1
+Nectarinia johnstoni_red-tufted sunbird_retsun2
+Drepanorhynchus reichenowi_golden-winged sunbird_gowsun2
+Cinnyris chloropygius_olive-bellied sunbird_olbsun3
+Cinnyris minullus_tiny sunbird_tinsun2
+Cinnyris gertrudis_western miombo sunbird_miosun2
+Cinnyris manoensis_eastern miombo sunbird_miosun3
+Cinnyris gertrudis/manoensis_western/eastern miombo sunbird_miosun1
+Cinnyris chalybeus_southern double-collared sunbird_sdcsun3
+Cinnyris neergaardi_neergaard's sunbird_neesun2
+Cinnyris stuhlmanni_stuhlmann's sunbird_stusun1
+Cinnyris prigoginei_prigogine's sunbird_prisun3
+Cinnyris ludovicensis_montane double-collared sunbird_mdcsun3
+Cinnyris ludovicensis ludovicensis_montane double-collared sunbird (Western)_mdcsun1
+Cinnyris ludovicensis whytei/skye_montane double-collared sunbird (Eastern)_mdcsun2
+Cinnyris reichenowi_northern double-collared sunbird_ndcsun2
+Cinnyris reichenowi preussi_northern double-collared sunbird (Western)_ndcsun1
+Cinnyris reichenowi reichenowi_northern double-collared sunbird (Eastern)_ndcsun3
+Cinnyris afer_greater double-collared sunbird_gdcsun2
+Cinnyris regius_regal sunbird_regsun2
+Cinnyris rockefelleri_rockefeller's sunbird_rocsun2
+Cinnyris mediocris_eastern double-collared sunbird_edcsun3
+Cinnyris usambaricus_usambara double-collared sunbird_edcsun4
+Cinnyris fuelleborni_forest double-collared sunbird_edcsun1
+Cinnyris moreaui_moreau's sunbird_morsun2
+Cinnyris loveridgei_loveridge's sunbird_lovsun3
+Cinnyris pulchellus_beautiful sunbird_beasun2
+Cinnyris melanogastrus_gorgeous sunbird_beasun3
+Cinnyris mariquensis_marico sunbird_marsun2
+Cinnyris shelleyi_shelley's sunbird_shesun2
+Cinnyris shelleyi shelleyi_shelley's sunbird (Shelley's)_shesun3
+Cinnyris shelleyi hofmanni_shelley's sunbird (Hofmann's)_shesun1
+Cinnyris congensis_congo sunbird_consun2
+Cinnyris erythrocercus_red-chested sunbird_recsun2
+Cinnyris nectarinioides_black-bellied sunbird_bkbsun1
+Cinnyris bifasciatus_purple-banded sunbird_pubsun4
+Cinnyris tsavoensis_tsavo sunbird_tsasun1
+Cinnyris chalcomelas_violet-breasted sunbird_vibsun2
+Cinnyris pembae_pemba sunbird_pemsun2
+Cinnyris bouvieri_orange-tufted sunbird_ortsun3
+Cinnyris osea_beija-flor-da-palestina_palsun2
+Cinnyris osea decorsei_beija-flor-da-palestina (decorsei)_palsun1
+Cinnyris osea osea_beija-flor-da-palestina (osea)_palsun3
+Cinnyris habessinicus_abyssinian sunbird_shisun3
+Cinnyris hellmayri_arabian sunbird_shisun4
+Cinnyris coccinigastrus_splendid sunbird_splsun2
+Cinnyris johannae_johanna's sunbird_johsun2
+Cinnyris superbus_superb sunbird_supsun2
+Cinnyris rufipennis_rufous-winged sunbird_ruwsun2
+Cinnyris oustaleti_oustalet's sunbird_oussun2
+Cinnyris oustaleti oustaleti_oustalet's sunbird (Angola)_oussun1
+Cinnyris oustaleti rhodesiae_oustalet's sunbird (Eastern)_oussun3
+Cinnyris talatala_white-bellied sunbird_whbsun2
+Cinnyris venustus_variable sunbird_varsun2
+Cinnyris venustus [venustus Group]_variable sunbird (Yellow-bellied)_varsun1
+Cinnyris venustus igneiventris_variable sunbird (Orange-chested)_varsun4
+Cinnyris venustus albiventris_variable sunbird (White-bellied)_varsun3
+Cinnyris fuscus_dusky sunbird_dussun2
+Cinnyris ursulae_ursula's sunbird_urssun2
+Cinnyris batesi_bates's sunbird_batsun2
+Cinnyris cupreus_copper sunbird_copsun2
+Cinnyris asiaticus_purple sunbird_pursun4
+Cinnyris ornatus_ornate sunbird_olbsun4
+Cinnyris ornatus [ornatus Group]_ornate sunbird (Ornate)_olbsun32
+Cinnyris ornatus rhizophorae_ornate sunbird (Cream-bellied)_olbsun7
+Cinnyris infrenatus_tukangbesi sunbird_olbsun23
+Cinnyris frenatus_sahul sunbird_olbsun2
+Cinnyris jugularis_garden sunbird_olbsun31
+Cinnyris aurora_palawan sunbird_olbsun6
+Cinnyris clementiae_south moluccan sunbird_olbsun1
+Cinnyris teysmanni_flores sea sunbird_olbsun8
+Cinnyris idenburgi_mamberamo sunbird_olbsun9
+Cinnyris buettikoferi_apricot-breasted sunbird_apbsun2
+Cinnyris solaris_beija-flor-de-peito-laranja_flbsun2
+Cinnyris sovimanga_souimanga sunbird_sousun2
+Cinnyris sovimanga aldabrensis_souimanga sunbird (Sooty-bellied)_sousun3
+Cinnyris sovimanga sovimanga_souimanga sunbird (Yellow-bellied)_sousun5
+Cinnyris sovimanga apolis_souimanga sunbird (White-bellied)_sousun4
+Cinnyris sovimanga abbotti/buchenorum_souimanga sunbird (Abbott's)_sousun1
+Cinnyris notatus_malagasy sunbird_madsun1
+Cinnyris notatus moebii_malagasy sunbird (Grande Comore)_madsun2
+Cinnyris notatus voeltzkowi_malagasy sunbird (Moheli)_madsun3
+Cinnyris notatus notatus_malagasy sunbird (Long-billed)_madsun4
+Cinnyris dussumieri_seychelles sunbird_seysun2
+Cinnyris humbloti_humblot's sunbird_humsun2
+Cinnyris comorensis_anjouan sunbird_anjsun2
+Cinnyris coquerellii_mayotte sunbird_maysun2
+Cinnyris lotenius_loten's sunbird_lobsun2
+Cinnyris asiaticus/lotenius_purple/loten's sunbird_y01334
+Cinnyris sp._Cinnyris sp._cinnyr1
+Aethopyga duyvenbodei_elegant sunbird_elesun1
+Aethopyga ignicauda_fire-tailed sunbird_fitsun1
+Aethopyga saturata_black-throated sunbird_bltsun1
+Aethopyga saturata [saturata Group]_black-throated sunbird (Black-throated)_bktsun11
+Aethopyga saturata johnsi_black-throated sunbird (Dalat)_bktsun10
+Aethopyga gouldiae_mrs. gould's sunbird_gousun1
+Aethopyga gouldiae gouldiae/isolata_mrs. gould's sunbird (Yellow-breasted)_gousun4
+Aethopyga gouldiae dabryii_mrs. gould's sunbird (Scarlet-breasted)_gousun3
+Aethopyga gouldiae annamensis_mrs. gould's sunbird (Purple-rumped)_gousun2
+Aethopyga nipalensis_green-tailed sunbird_grtsun1
+Aethopyga nipalensis [nipalensis Group]_green-tailed sunbird (Green-tailed)_gntsun3
+Aethopyga nipalensis angkanensis_green-tailed sunbird (Doi Inthanon)_gntsun2
+Aethopyga shelleyi_lovely sunbird_lovsun1
+Aethopyga temminckii_temminck's sunbird_temsun1
+Aethopyga mystacalis_javan sunbird_scasun1
+Aethopyga vigorsii_vigors's sunbird_wecsun1
+Aethopyga siparaja_crimson sunbird_eacsun1
+Aethopyga siparaja [seheriae Group]_crimson sunbird (Goulpourah)_crisun1
+Aethopyga siparaja [siparaja Group]_crimson sunbird (Crimson)_crisun2
+Aethopyga siparaja flavostriata/beccarii_crimson sunbird (Sulawesi)_crisun3
+Aethopyga temminckii/siparaja_temminck's/crimson sunbird_y00916
+Aethopyga magnifica_magnificent sunbird_magsun1
+Aethopyga christinae_fork-tailed sunbird_fotsun1
+Aethopyga christinae latouchii/sokolovi_fork-tailed sunbird (Fork-tailed)_fotsun2
+Aethopyga christinae christinae_fork-tailed sunbird (Hainan)_fotsun3
+Aethopyga bella_handsome sunbird_hansun1
+Aethopyga eximia_white-flanked sunbird_whfsun1
+Aethopyga flagrans_flaming sunbird_flasun1
+Aethopyga guimarasensis_maroon-naped sunbird_mansun1
+Aethopyga pulcherrima_metallic-winged sunbird_mewsun3
+Aethopyga pulcherrima jefferyi_metallic-winged sunbird (Luzon)_mousun1
+Aethopyga pulcherrima decorosa_metallic-winged sunbird (Bohol)_bohsun1
+Aethopyga pulcherrima pulcherrima_metallic-winged sunbird (Southern)_mewsun2
+Aethopyga linaraborae_lina's sunbird_linsun1
+Aethopyga primigenia_gray-hooded sunbird_gyhsun2
+Aethopyga boltoni_apo sunbird_moasun1
+Aethopyga tibolii_tboli sunbird_tbosun1
+Aethopyga sp._Aethopyga sp._aethop1
+Nectariniidae sp. (sunbird sp.)_sunbird sp._sunbir1
+Kurochkinegramma hypogrammicum_purple-naped spiderhunter_punsun1
+Arachnothera crassirostris_thick-billed spiderhunter_thbspi1
+Arachnothera robusta_long-billed spiderhunter_lobspi1
+Arachnothera flammifera_orange-tufted spiderhunter_ortspi1
+Arachnothera dilutior_pale spiderhunter_palspi2
+Arachnothera longirostra_little spiderhunter_litspi1
+Arachnothera juliae_whitehead's spiderhunter_whispi1
+Arachnothera clarae_naked-faced spiderhunter_nafspi1
+Arachnothera chrysogenys_yellow-eared spiderhunter_yeespi1
+Arachnothera flavigaster_spectacled spiderhunter_spespi2
+Arachnothera magna_streaked spiderhunter_strspi1
+Arachnothera affinis_streaky-breasted spiderhunter_stbspi2
+Arachnothera modesta_gray-breasted spiderhunter_gybspi2
+Arachnothera everetti_bornean spiderhunter_borspi1
+Arachnothera sp._spiderhunter sp._spider1
+Irena puella_asian fairy-bluebird_asfblu1
+Irena tweeddalii_palawan fairy-bluebird_asifab2
+Irena cyanogastra_philippine fairy-bluebird_phifab1
+Irena cyanogastra cyanogastra_philippine fairy-bluebird (cyanogastra)_phifab2
+Irena cyanogastra ellae_philippine fairy-bluebird (ellae)_phifab3
+Irena cyanogastra melanochlamys/hoogstraali_philippine fairy-bluebird (melanochlamys/hoogstraali)_phifab6
+Chloropsis flavipennis_philippine leafbird_philea1
+Chloropsis palawanensis_yellow-throated leafbird_yetlea1
+Chloropsis sonnerati_greater green leafbird_grglea1
+Chloropsis cyanopogon_lesser green leafbird_leglea1
+Chloropsis sonnerati/cyanopogon_greater/lesser green leafbird_y01054
+Chloropsis moluccensis_blue-winged leafbird_blwlea1
+Chloropsis cochinchinensis_javan leafbird_buwlea2
+Chloropsis kinabaluensis_bornean leafbird_borlea1
+Chloropsis jerdoni_jerdon's leafbird_jerlea1
+Chloropsis aurifrons_golden-fronted leafbird_goflea1
+Chloropsis jerdoni/aurifrons_jerdon's/golden-fronted leafbird_y01012
+Chloropsis media_sumatran leafbird_sumlea1
+Chloropsis hardwickii_orange-bellied leafbird_orblea1
+Chloropsis hardwickii hardwickii/malayana_orange-bellied leafbird (Orange-bellied)_orblea2
+Chloropsis hardwickii lazulina/melliana_orange-bellied leafbird (Grayish-crowned)_orblea3
+Chloropsis venusta_blue-masked leafbird_blmlea1
+Chloropsis sp._leafbird sp._leafbi1
+Peucedramus taeniatus_olive warbler_oliwar
+Urocynchramus pylzowi_przevalski's pinktail_przros1
+Bubalornis albirostris_white-billed buffalo-weaver_wbbwea1
+Bubalornis niger_red-billed buffalo-weaver_rbbwea1
+Dinemellia dinemelli_white-headed buffalo-weaver_whbwea1
+Sporopipes frontalis_speckle-fronted weaver_spfwea1
+Sporopipes squamifrons_scaly weaver_scawea1
+Plocepasser mahali_white-browed sparrow-weaver_wbswea1
+Plocepasser mahali melanorhynchus_white-browed sparrow-weaver (Black-billed)_whbspw1
+Plocepasser mahali ansorgei_white-browed sparrow-weaver (White-tailed)_whbspw2
+Plocepasser mahali pectoralis_white-browed sparrow-weaver (Spot-chested)_whbspw3
+Plocepasser mahali mahali_white-browed sparrow-weaver (White-breasted)_whbspw4
+Plocepasser superciliosus_chestnut-crowned sparrow-weaver_ccswea1
+Plocepasser rufoscapulatus_chestnut-backed sparrow-weaver_cbswea1
+Plocepasser donaldsoni_donaldson smith's sparrow-weaver_dsswea1
+Histurgops ruficauda_rufous-tailed weaver_rutwea1
+Pseudonigrita arnaudi_gray-capped social-weaver_gyhsow1
+Pseudonigrita cabanisi_black-capped social-weaver_bcswea1
+Philetairus socius_sociable weaver_socwea1
+Malimbus coronatus_red-crowned malimbe_recmal2
+Malimbus cassini_black-throated malimbe_bltmal1
+Malimbus ballmanni_gola malimbe_balmal2
+Malimbus racheliae_rachel's malimbe_racmal1
+Malimbus scutatus_red-vented malimbe_revmal1
+Malimbus ibadanensis_ibadan malimbe_ibamal1
+Malimbus erythrogaster_red-bellied malimbe_rebmal1
+Malimbus nitens_blue-billed malimbe_gramal1
+Malimbus malimbicus_crested malimbe_cremal1
+Malimbus rubricollis_red-headed malimbe_rehmal1
+Malimbus sp._malimbe sp._malimb1
+Anaplectes rubriceps_red-headed weaver_rehwea1
+Anaplectes rubriceps leuconotos_red-headed weaver (Northern)_rehwea2
+Anaplectes rubriceps rubriceps_red-headed weaver (Southern)_rehwea4
+Anaplectes jubaensis_red weaver_rehwea3
+Ploceus flavipes_yellow-legged weaver_yelwea2
+Ploceus bertrandi_bertram's weaver_berwea2
+Ploceus baglafecht_baglafecht weaver_bagwea1
+Ploceus baglafecht [baglafecht Group]_baglafecht weaver (Baglafecht)_bagwea2
+Ploceus baglafecht emini_baglafecht weaver (Emin's)_bagwea3
+Ploceus baglafecht reichenowi_baglafecht weaver (Reichenow's)_bagwea4
+Ploceus baglafecht [stuhlmanni Group]_baglafecht weaver (Stuhlmann's)_bagwea5
+Ploceus nigrimentus_black-chinned weaver_bkcwea1
+Ploceus bannermani_bannerman's weaver_banwea1
+Ploceus baglafecht/bannermani_baglafecht/bannerman's weaver_y01062
+Ploceus batesi_bates's weaver_batwea1
+Ploceus luteolus_little weaver_litwea1
+Ploceus pelzelni_slender-billed weaver_slbwea1
+Ploceus subpersonatus_loango weaver_loawea1
+Ploceus brachypterus_olive-naped weaver_bknwea1
+Ploceus nigricollis_black-necked weaver_bknwea2
+Ploceus brachypterus x nigricollis_olive-naped x black-necked weaver (hybrid)_bknwea3
+Ploceus brachypterus/nigricollis_olive-naped/black-necked weaver_blnwea1
+Ploceus ocularis_spectacled weaver_spewea1
+Ploceus ocularis crocatus_spectacled weaver (Yellow-throated)_spewea3
+Ploceus ocularis ocularis/suahelicus_spectacled weaver (Black-throated)_spewea4
+Ploceus nigricollis/ocularis_black-necked/spectacled weaver_y00929
+Ploceus melanogaster_black-billed weaver_blbwea1
+Ploceus melanogaster melanogaster_black-billed weaver (Western)_bkbwea1
+Ploceus melanogaster stephanophorus_black-billed weaver (Eastern)_bkbwea2
+Ploceus alienus_strange weaver_strwea1
+Ploceus capensis_cape weaver_capwea1
+Ploceus temporalis_bocage's weaver_bocwea1
+Ploceus subaureus_african golden-weaver_afgwea1
+Ploceus xanthops_holub's golden-weaver_hogwea1
+Ploceus aurantius_orange weaver_orawea1
+Ploceus bojeri_golden palm weaver_gopwea1
+Ploceus castaneiceps_taveta golden-weaver_tagwea1
+Ploceus princeps_principe golden-weaver_prgwea1
+Ploceus xanthopterus_southern brown-throated weaver_sbtwea1
+Ploceus castanops_northern brown-throated weaver_nbtwea1
+Ploceus burnieri_kilombero weaver_kilwea1
+Ploceus holoxanthus_ruvu weaver_ruvwea1
+Ploceus subaureus/holoxanthus_african golden-weaver/ruvu weaver_y01194
+Ploceus taeniopterus_northern masked-weaver_nomwea1
+Ploceus intermedius_lesser masked-weaver_lesmaw1
+Ploceus velatus_tecelão-de-máscara-setentrional_afmwea
+Ploceus vitellinus_vitelline masked-weaver_vimwea1
+Ploceus reichardi_tanganyika masked-weaver_tanmaw1
+Ploceus katangae_katanga masked-weaver_kamwea1
+Ploceus katangae upembae_katanga masked-weaver (Upemba)_katmaw1
+Ploceus katangae katangae_katanga masked-weaver (Katanga)_katmaw2
+Ploceus ruweti_lake lufira masked-weaver_lalmaw1
+Ploceus heuglini_heuglin's masked-weaver_hemwea1
+Ploceus galbula_rüppell's weaver_ruewea1
+Ploceus spekei_speke's weaver_spewea2
+Ploceus spekeoides_fox's weaver_foxwea1
+Ploceus castaneofuscus_chestnut-and-black weaver_viewea2
+Ploceus nigerrimus_vieillot's black weaver_viewea3
+Ploceus castaneofuscus/nigerrimus_chestnut-and-black/vieillot's black weaver_viewea1
+Ploceus cucullatus_cacho-caldeirão_vilwea1
+Ploceus cucullatus collaris_cacho-caldeirão (collaris)_vilwea2
+Ploceus cucullatus [cucullatus Group]_cacho-caldeirão [grupo cucullatus]_vilwea3
+Ploceus cucullatus nigriceps/graueri_cacho-caldeirão (nigriceps/graueri)_vilwea4
+Ploceus cucullatus spilonotus_cacho-caldeirão (spilonotus)_vilwea5
+Ploceus grandis_giant weaver_giawea1
+Ploceus weynsi_weyns's weaver_weywea1
+Ploceus golandi_kilifi weaver_clawea1
+Ploceus dichrocephalus_juba weaver_salwea1
+Ploceus melanocephalus_tecelão-de-cabeça-preta_blhwea1
+Ploceus jacksoni_golden-backed weaver_gobwea1
+Ploceus rubiginosus_chestnut weaver_chewea1
+Ploceus rubiginosus trothae_chestnut weaver (Benguela)_chewea2
+Ploceus rubiginosus rubiginosus_chestnut weaver (Chestnut)_chewea3
+Ploceus badius_cinnamon weaver_cinwea1
+Ploceus aureonucha_golden-naped weaver_gonwea1
+Ploceus tricolor_yellow-mantled weaver_yemwea1
+Ploceus albinucha_maxwell's black weaver_mabwea1
+Ploceus albinucha albinucha_maxwell's black weaver (White-naped)_mabwea2
+Ploceus albinucha maxwelli/holomelas_maxwell's black weaver (Maxwell's)_mabwea3
+Ploceus bicolor_dark-backed weaver_forwea1
+Ploceus insignis_brown-capped weaver_brcwea1
+Ploceus dorsomaculatus_yellow-capped weaver_yecwea1
+Ploceus preussi_preuss's weaver_prewea1
+Ploceus olivaceiceps_olive-headed weaver_olhwea1
+Ploceus nicolli_usambara weaver_usawea1
+Ploceus angolensis_bar-winged weaver_bawwea1
+Ploceus sanctithomae_sao tome weaver_satwea1
+Ploceus nelicourvi_nelicourvi weaver_nelwea1
+Ploceus sakalava_sakalava weaver_sakwea1
+Ploceus manyar_tecelão-mosqueado_strwea2
+Ploceus philippinus_baya weaver_baywea1
+Ploceus hypoxanthus_asian golden weaver_asgwea2
+Ploceus megarhynchus_finn's weaver_yelwea1
+Ploceus philippinus/megarhynchus_baya/finn's weaver_y01163
+Ploceus benghalensis_black-breasted weaver_benwea1
+Ploceus manyar/benghalensis_streaked/black-breasted weaver_y01120
+Ploceus sp._Ploceus sp._ploceu1
+Pachyphantes superciliosus_compact weaver_comwea1
+Quelea cardinalis_cardinal quelea_carque1
+Quelea erythrops_pardal-de-cabeça-vermelha_rehque1
+Quelea quelea_bico-carmim_rebque1
+Quelea sp._quelea sp._quelea1
+Brachycope anomala_bob-tailed weaver_botwea1
+Foudia madagascariensis_red fody_redfod1
+Foudia aldabrana_aldabra fody_rehfod3
+Foudia eminentissima_red-headed fody_rehfod1
+Foudia eminentissima consobrina_red-headed fody (Grande Comore)_rehfod4
+Foudia eminentissima [eminentissima Group]_red-headed fody (Southern Comoros)_rehfod2
+Foudia omissa_forest fody_forfod1
+Foudia madagascariensis/omissa_red/forest fody_y00930
+Foudia delloni_reunion fody_reufod1
+Foudia rubra_mauritius fody_maufod1
+Foudia sechellarum_seychelles fody_seyfod1
+Foudia flavicans_rodrigues fody_rodfod1
+Euplectes franciscanus_bispo-laranja_orabis1
+Euplectes orix_bispo-vermelho_redbis
+Euplectes nigroventris_zanzibar red bishop_zanbis1
+Euplectes hordeaceus_bispo-vermelho-d'asa-negra_blwbis1
+Euplectes gierowii_black bishop_blabis1
+Euplectes afer_arcebispo_yecbis
+Euplectes diadematus_fire-fronted bishop_fifbis1
+Euplectes aureus_golden-backed bishop_gobbis1
+Euplectes capensis_yellow bishop_yelbis1
+Euplectes capensis phoenicomerus_yellow bishop (Montane)_yelbis2
+Euplectes capensis xanthomelas_yellow bishop (Ethiopian)_yelbis3
+Euplectes capensis [capensis Group]_yellow bishop (Yellow)_yelbis4
+Euplectes sp. (bishop sp.)_bishop sp._bishop1
+Euplectes albonotatus_white-winged widowbird_whwwid1
+Euplectes macroura_viúva-de-manto-amarelo_yeswid2
+Euplectes macroura macrocercus_viúva-de-manto-amarelo (macrocercus)_yemwid1
+Euplectes macroura macroura/conradsi_viúva-de-manto-amarelo (macroura/conradsi)_yemwid2
+Euplectes laticauda_red-cowled widowbird_recwid2
+Euplectes ardens_red-collared widowbird_recwid3
+Euplectes laticauda/ardens_red-cowled/red-collared widowbird_recwid1
+Euplectes axillaris_fan-tailed widowbird_fatwid1
+Euplectes hartlaubi_marsh widowbird_marwid1
+Euplectes psammacromius_buff-shouldered widowbird_buswid1
+Euplectes progne_viúva-rabilonga_lotwid1
+Euplectes jacksoni_jackson's widowbird_jacwid1
+Euplectes sp. (widowbird sp.)_widowbird sp._widowb1
+Euplectes sp._Euplectes sp._euplec1
+Amblyospiza albifrons_grosbeak weaver_growea1
+Heteromunia pectoralis_pictorella munia_picmun1
+Oreostruthus fuliginosus_mountain firetail_moufir1
+Stagonopleura guttata_diamond firetail_diafir1
+Stagonopleura oculata_red-eared firetail_reefir1
+Stagonopleura bella_beautiful firetail_beafir1
+Neochmia phaeton_crimson finch_crifin1
+Neochmia phaeton evangelinae_crimson finch (White-bellied)_crifin2
+Neochmia phaeton phaeton_crimson finch (Black-bellied)_crifin3
+Neochmia temporalis_red-browed firetail_rebfir1
+Emblema pictum_painted firetail_paifir1
+Emblema ruficauda_star finch_stafin1
+Emblema modesta_plum-headed finch_plhfin1
+Stizoptera bichenovii_double-barred finch_dobfin1
+Taeniopygia guttata_mandarim_zebfin2
+Taeniopygia guttata guttata_mandarim (guttata)_zebfin1
+Taeniopygia guttata castanotis_mandarim (castanotis)_chefin1
+Taeniopygia guttata (Domestic type)_mandarim (tipo doméstico)_zebfin3
+Stizoptera bichenovii x Taeniopygia guttata_double-barred x zebra finch (hybrid)_x00906
+Poephila personata_masked finch_masfin1
+Poephila personata personata_masked finch (Masked)_masfin2
+Poephila personata leucotis_masked finch (White-eared)_masfin4
+Poephila acuticauda_long-tailed finch_lotfin1
+Poephila cincta_black-throated finch_bltfin1
+Poephila cincta atropygialis_black-throated finch (Black-rumped)_bktfin1
+Poephila cincta cincta_black-throated finch (White-rumped)_bktfin2
+Spermestes griseicapilla_gray-headed silverbill_gyhsil1
+Spermestes cucullata_bronze mannikin_broman1
+Spermestes fringilloides_magpie mannikin_magman1
+Spermestes bicolor_black-and-white mannikin_bawman1
+Spermestes bicolor bicolor/poensis_black-and-white mannikin (Black-and-white)_bawman2
+Spermestes bicolor nigriceps/woltersi_black-and-white mannikin (Red-backed)_bawman3
+Lepidopygia nana_madagascar munia_madmun1
+Euodice cantans_bico-de-chumbo-africano_afrsil1
+Euodice malabarica_bico-de-chumbo-indiano_indsil
+Padda oryzivora_pardal-de-java_javspa
+Padda fuscata_pardal-de-timor_timspa4
+Mayrimunia tristissima_streak-headed munia_sthmun2
+Mayrimunia leucosticta_white-spotted munia_sthmun3
+Mayrimunia tristissima x leucosticta_streak-headed x white-spotted munia (hybrid)_x00473
+Mayrimunia tristissima/leucosticta_streak-headed/white-spotted munia_sthmun1
+Lonchura punctulata_capuchinho-dominó_nutman
+Lonchura punctulata punctulata_capuchinho-dominó (punctulata)_scbmun1
+Lonchura punctulata [nisoria Group]_capuchinho-dominó [grupo nisoria]_scbmun2
+Lonchura kelaarti_black-throated munia_bltmun1
+Lonchura molucca_capuchinho-de-faces-pretas_blfmun1
+Lonchura striata_white-rumped munia_whrmun
+Lonchura striata (Domestic type)_white-rumped munia (Domestic type)_whrmun8
+Lonchura punctulata x striata_scaly-breasted x white-rumped munia (hybrid)_x01069
+Lonchura fuscans_dusky munia_dusmun1
+Lonchura leucogastra_white-bellied munia_whbmun1
+Lonchura leucogastroides_javan munia_javmun1
+Lonchura malacca_capuchinho-tricolor_trimun
+Lonchura malacca (Pale-flanked)_capuchinho-tricolor (Flancos Pálidos)_trimun1
+Lonchura malacca (Cinnamon-flanked)_capuchinho-tricolor (Flancos Oscuros)_trimun2
+Lonchura atricapilla_bico-de-chumbo-de-cabeça-preta_chemun
+Lonchura atricapilla [atricapilla Group]_bico-de-chumbo-de-cabeça-preta [grupo atricapilla]_chemun1
+Lonchura atricapilla formosana_bico-de-chumbo-de-cabeça-preta (formosana)_chemun2
+Lonchura malacca x atricapilla_capuchinho-tricolor x bico-de-chumbo-de-cabeça-preta (híbrido)_x00932
+Lonchura malacca/atricapilla_capuchinho-tricolor/bico-de-chumbo-de-cabeça-preta_y01164
+Lonchura ferruginosa_white-capped munia_whcmun1
+Lonchura maja_capuchinho-de-cabeça-branca_whhmun1
+Lonchura pallida_capuchinho-de-cabeça-pálida_pahmun1
+Lonchura grandis_grand munia_gramun1
+Lonchura teerinki_black-breasted munia_blbmun1
+Lonchura montana_snow mountain munia_snmmun1
+Lonchura monticola_alpine munia_alpmun1
+Lonchura vana_gray-banded munia_gybmun1
+Lonchura nevermanni_gray-crowned munia_gycmun1
+Lonchura caniceps_gray-headed munia_gyhmun1
+Lonchura spectabilis_hooded munia_hoomun1
+Lonchura forbesi_new ireland munia_neimun1
+Lonchura hunsteini_mottled munia_motmun1
+Lonchura nigerrima_new hanover munia_nehmun1
+Lonchura flaviprymna_yellow-rumped munia_yermun1
+Lonchura quinticolor_capuchinho-de-cinco-cores_ficmun1
+Lonchura castaneothorax_chestnut-breasted munia_chbmun1
+Lonchura caniceps x castaneothorax_gray-headed x chestnut-breasted munia (hybrid)_x01075
+Lonchura flaviprymna x castaneothorax_yellow-rumped x chestnut-breasted munia (hybrid)_x00936
+Lonchura stygia_black munia_blamun1
+Lonchura melaena_bismarck munia_bismun1
+Lonchura sp._Lonchura sp._lonchu1
+Chloebia gouldiae_gouldian finch_goufin3
+Erythrura prasina_pin-tailed parrotfinch_pitpar1
+Erythrura viridifacies_green-faced parrotfinch_grfpar1
+Erythrura hyperythra_tawny-breasted parrotfinch_tabpar1
+Erythrura psittacea_red-throated parrotfinch_retpar3
+Erythrura pealii_fiji parrotfinch_fijpar1
+Erythrura cyaneovirens_royal parrotfinch_roypar1
+Erythrura cyaneovirens [regia Group]_royal parrotfinch (Vanuatu)_roypar5
+Erythrura cyaneovirens cyaneovirens/gaughrani_royal parrotfinch (Samoan)_rehpar1
+Erythrura kleinschmidti_pink-billed parrotfinch_pibpar1
+Erythrura tricolor_pardal-periquito-tricolor_tripar1
+Erythrura coloria_red-eared parrotfinch_reepar2
+Erythrura papuana_papuan parrotfinch_pappar1
+Erythrura trichroa_blue-faced parrotfinch_blfpar3
+Erythrura papuana/trichroa_papuan/blue-faced parrotfinch_y01107
+Erythrura [undescribed form]_mount mutis parrotfinch (undescribed form)_timpar1
+Erythrura sp._parrotfinch sp._parrot2
+Nesocharis shelleyi_shelley's oliveback_fepoli1
+Nesocharis ansorgei_white-collared oliveback_whcoli1
+Coccopygia quartinia_yellow-bellied waxbill_yebwax2
+Coccopygia bocagei_angola waxbill_swewax1
+Coccopygia melanotis_swee waxbill_swewax3
+Mandingoa nitidula_green-backed twinspot_grbtwi1
+Mandingoa nitidula schlegeli/virginiae_green-backed twinspot (Orange-breasted)_gnbtwi1
+Mandingoa nitidula nitidula/chubbi_green-backed twinspot (Green-breasted)_gnbtwi2
+Cryptospiza shelleyi_shelley's crimsonwing_shcwin1
+Cryptospiza jacksoni_dusky crimsonwing_ducwin1
+Cryptospiza salvadorii_abyssinian crimsonwing_abcwin1
+Cryptospiza reichenovii_red-faced crimsonwing_rfcwin1
+Cryptospiza reichenovii reichenovii_red-faced crimsonwing (Western)_refcrw1
+Cryptospiza reichenovii australis/ocularis_red-faced crimsonwing (Eastern)_refcrw2
+Parmoptila rubrifrons_red-fronted antpecker_refant1
+Parmoptila woodhousei_woodhouse's antpecker_wooant1
+Parmoptila jamesoni_jameson's antpecker_jamant1
+Nigrita fusconotus_white-breasted nigrita_whbneg2
+Nigrita bicolor_chestnut-breasted nigrita_chbneg1
+Nigrita canicapillus_gray-headed nigrita_gyhneg1
+Nigrita luteifrons_pale-fronted nigrita_pafneg1
+Nigrita sp._nigrita sp._nigrit1
+Delacourella capistrata_gray-headed oliveback_gyholi1
+Brunhilda erythronotos_black-faced waxbill_blcwax1
+Brunhilda charmosyna_black-cheeked waxbill_rerwax1
+Glaucestrilda caerulescens_lavandinha_lavwax
+Glaucestrilda perreini_black-tailed waxbill_bltwax1
+Glaucestrilda thomensis_cinderella waxbill_cinwax1
+Estrilda nonnula_black-crowned waxbill_blcwax2
+Estrilda atricapilla_black-headed waxbill_blhwax1
+Estrilda kandti_kandt's waxbill_kanwax1
+Estrilda melpoda_faces-laranja_orcwax
+Estrilda poliopareia_anambra waxbill_anawax1
+Estrilda paludicola_fawn-breasted waxbill_fabwax1
+Estrilda paludicola ochrogaster_fawn-breasted waxbill (Abyssinian)_fabwax3
+Estrilda paludicola [paludicola Group]_fawn-breasted waxbill (Fawn-breasted)_fabwax2
+Estrilda paludicola benguellensis_fawn-breasted waxbill (benguellensis)_fabwax8
+Estrilda astrild_bico-de-lacre_comwax
+Estrilda nigriloris_black-lored waxbill_blfwax1
+Estrilda troglodytes_januário_bkrwax
+Estrilda rhodopyga_bico-de-lacre-de-uropígio-carmim_crrwax1
+Estrilda rufibarba_arabian waxbill_arawax1
+Estrilda sp._waxbill sp._waxbil1
+Ortygospiza atricollis_quailfinch_quailf1
+Ortygospiza atricollis [atricollis Group]_quailfinch (Black-faced)_bkfqua1
+Ortygospiza atricollis [fuscocrissa Group]_quailfinch (Spectacled)_afrqua2
+Ortygospiza atricollis [gabonensis Group]_quailfinch (Black-chinned)_rebqua1
+Paludipasser locustella_locustfinch_locust3
+Amadina fasciata_degolado_cutthr1
+Amadina erythrocephala_red-headed finch_rehfin1
+Amandava formosa_green avadavat_grnava1
+Amandava subflava_guarda-marinha_zebwax2
+Amandava amandava_bengali-mosqueado_redava
+Amandava amandava amandava/punicea_bengali-mosqueado (amandava/punicea)_redava1
+Amandava amandava flavidiventris_bengali-mosqueado (flavidiventris)_redava2
+Granatina ianthinogaster_purple grenadier_purgre2
+Granatina granatina_violet-eared waxbill_viewax1
+Uraeginthus angolensis_southern cordonbleu_bubcor1
+Uraeginthus bengalus_peito-celeste_reccor
+Uraeginthus cyanocephalus_blue-capped cordonbleu_blccor1
+Uraeginthus sp._cordonbleu sp._cordon1
+Spermophaga poliogenys_grant's bluebill_grablu1
+Spermophaga haematina_western bluebill_wesblu1
+Spermophaga haematina haematina/togoensis_western bluebill (Western)_wesblu2
+Spermophaga haematina pustulata_western bluebill (Red-rumped)_wesblu3
+Spermophaga ruficapilla_red-headed bluebill_rehblu1
+Pyrenestes minor_lesser seedcracker_lessee1
+Pyrenestes sanguineus_bico-grossudo-sanguíneo_crisee1
+Pyrenestes ostrinus_black-bellied seedcracker_blbsee1
+Pyrenestes sanguineus/ostrinus_crimson/black-bellied seedcracker_y01180
+Pytilia melba_green-winged pytilia_grwpyt1
+Pytilia afra_orange-winged pytilia_orwpyt1
+Pytilia phoenicoptera_red-winged pytilia_rewpyt1
+Pytilia lineata_red-billed pytilia_rebpyt1
+Pytilia hypogrammica_red-faced pytilia_refpyt1
+Pytilia sp._pytilia sp._pytili1
+Euschistospiza dybowskii_dybowski's twinspot_dybtwi1
+Euschistospiza cinereovinacea_dusky twinspot_dustwi1
+Euschistospiza cinereovinacea cinereovinacea_dusky twinspot (Angola)_dustwi2
+Euschistospiza cinereovinacea graueri_dusky twinspot (Grauer's)_dustwi3
+Hypargos niveoguttatus_red-throated twinspot_pettwi1
+Hypargos margaritatus_pink-throated twinspot_pittwi1
+Clytospiza monteiri_brown twinspot_brotwi1
+Lagonosticta senegala_peito-de-fogo_rebfir2
+Lagonosticta rubricata_african firefinch_afffin
+Lagonosticta rhodopareia_jameson's firefinch_jamfir1
+Lagonosticta virata_mali firefinch_malfir1
+Lagonosticta sanguinodorsalis_rock firefinch_rocfir1
+Lagonosticta umbrinodorsalis_chad firefinch_reifir1
+Lagonosticta rara_black-bellied firefinch_blbfir1
+Lagonosticta rufopicta_bar-breasted firefinch_babfir1
+Lagonosticta nitidula_brown firefinch_brnfir1
+Lagonosticta larvata_black-faced firefinch_bkffir1
+Lagonosticta larvata vinacea_black-faced firefinch (Vinaceous)_bkffir2
+Lagonosticta larvata nigricollis_black-faced firefinch (Gray)_bkffir3
+Lagonosticta larvata larvata_black-faced firefinch (Reddish)_bkffir4
+Lagonosticta sp._firefinch sp._firefi1
+Estrildidae sp._estrildídeo sp._estfin1
+Vidua macroura_viuvinha-bico-de-lacre_pitwhy
+Vidua orientalis_sahel paradise-whydah_nopwhy1
+Vidua interjecta_exclamatory paradise-whydah_ltpwhy1
+Vidua togoensis_togo paradise-whydah_topwhy1
+Vidua obtusa_broad-tailed paradise-whydah_btpwhy1
+Vidua paradisaea_eastern paradise-whydah_eapwhy1
+Vidua hypocherina_steel-blue whydah_stbwhy1
+Vidua fischeri_viuvinha-rabo-de-palha_sttwhy1
+Vidua regia_shaft-tailed whydah_shtwhy1
+Vidua chalybeata_village indigobird_vilind
+Vidua wilsoni_wilson's indigobird_pawind1
+Vidua nigeriae_quailfinch indigobird_quaind1
+Vidua maryae_jos plateau indigobird_jopind1
+Vidua raricola_jambandu indigobird_jamind1
+Vidua larvaticola_barka indigobird_bakind1
+Vidua camerunensis_cameroon indigobird_camind1
+Vidua funerea_dusky indigobird_varind1
+Vidua purpurascens_purple indigobird_purind1
+Vidua codringtoni_green indigobird_greind1
+Vidua sp. (paradise-whydah sp.)_paradise-whydah sp._paradi4
+Vidua sp. (whydah sp.)_whydah sp._whydah1
+Vidua sp. (indigobird sp.)_indigobird sp._indigo1
+Vidua sp._Vidua sp._vidua1
+Anomalospiza imberbis_parasitic weaver_parwea1
+Prunella collaris_ferreirinha-serrana_alpacc1
+Prunella himalayana_altai accentor_himacc1
+Prunella rubeculoides_robin accentor_robacc1
+Prunella strophiata_rufous-breasted accentor_rubacc1
+Prunella montanella_ferreirinha-siberiana_sibacc
+Prunella ocularis_ferreirinha-do-cáucaso_radacc2
+Prunella ocularis ocularis_ferreirinha-do-cáucaso (ocularis)_radacc1
+Prunella ocularis fagani_ferreirinha-do-cáucaso (fagani)_yemacc1
+Prunella fulvescens_brown accentor_broacc1
+Prunella atrogularis_ferreirinha-de-garganta-preta_bltacc1
+Prunella koslowi_mongolian accentor_monacc1
+Prunella modularis_ferreirinha_dunnoc1
+Prunella rubida_japanese accentor_japacc1
+Prunella immaculata_maroon-backed accentor_mabacc1
+Prunella sp._accentor sp._accent1
+Hypocryptadius cinnamomeus_cinnamon ibon_cinwhe1
+Passer ammodendri_saxaul sparrow_saxspa1
+Passer domesticus_pardal_houspa
+Passer domesticus [domesticus Group]_pardal-do-telhado [grupo domesticus]_houspa13
+Passer domesticus [indicus Group]_pardal-do-telhado [grupo indicus]_houspa14
+Passer italiae_pardal-italiano_itaspa1
+Passer domesticus x italiae_pardal-do-telhado x pardal-italiano (híbrido)_x00873
+Passer domesticus/italiae_pardal-do-telhado/pardal-italiano_y00692
+Passer hispaniolensis_pardal-espanhol_spaspa1
+Passer domesticus x hispaniolensis_pardal-do-telhado x pardal-espanhol (híbrido)_x00645
+Passer italiae x hispaniolensis_pardal-italiano x pardal-espanhol (híbrido)_x00974
+Passer domesticus/hispaniolensis_pardal-do-telhado/pardal-espanhol_y00829
+Passer italiae/hispaniolensis_pardal-italiano/pardal-espanhol_y01017
+Passer pyrrhonotus_sind sparrow_sinspa1
+Passer castanopterus_somali sparrow_somspa1
+Passer domesticus x castanopterus_house x somali sparrow (hybrid)_x00917
+Passer cinnamomeus_russet sparrow_russpa2
+Passer flaveolus_plain-backed sparrow_plbspa1
+Passer moabiticus_pardal-do-levante_desspa1
+Passer moabiticus moabiticus_pardal-do-levante (moabiticus)_desspa5
+Passer moabiticus yatii_pardal-do-levante (yatii)_desspa6
+Passer iagoensis_pardal-de-terra_cavspa1
+Passer hemileucus_abd al kuri sparrow_aakspa1
+Passer insularis_socotra sparrow_socspa1
+Passer motitensis_great rufous sparrow_grrspa1
+Passer rufocinctus_kenya rufous sparrow_kerspa2
+Passer shelleyi_shelley's rufous sparrow_shrspa1
+Passer cordofanicus_kordofan rufous sparrow_korspa1
+Passer melanurus_cape sparrow_capspa1
+Passer griseus_northern gray-headed sparrow_gyhspa1
+Passer swainsonii_swainson's sparrow_swaspa2
+Passer gongonensis_parrot-billed sparrow_pabspa1
+Passer suahelicus_swahili sparrow_swaspa1
+Passer diffusus_southern gray-headed sparrow_sghspa2
+Passer simplex_pardal-do-deserto_desspa3
+Passer zarudnyi_pardal-de-zarudny_desspa4
+Passer montanus_pardal-montês_eutspa
+Passer domesticus x montanus_pardal-do-telhado x pardal-montês (híbrido)_x00754
+Passer hispaniolensis x montanus_pardal-espanhol x pardal-montês (híbrido)_x00874
+Passer domesticus/montanus_pardal-do-telhado/pardal-montês_y00764
+Passer luteus_sudan golden sparrow_sugspa1
+Passer euchlorus_arabian golden sparrow_argspa2
+Passer eminibey_chestnut sparrow_chespa1
+Passer sp._Passer sp._passer2
+Gymnoris pyrgita_yellow-spotted bush sparrow_yespet1
+Gymnoris xanthocollis_pardal-de-garganta-amarela_chspet1
+Gymnoris superciliaris_yellow-throated bush sparrow_yetpet1
+Gymnoris dentata_sahel bush sparrow_buspet1
+Petronia petronia_pardal-francês_rocpet1
+Carpospiza brachydactyla_pardal-pálido_palroc1
+Montifringilla nivalis_pardal-alpino_whwsno1
+Montifringilla henrici_tibetan snowfinch_tibsno2
+Montifringilla adamsi_black-winged snowfinch_blwsno1
+Onychostruthus taczanowskii_white-rumped snowfinch_whrsno1
+Pyrgilauda davidiana_pere david's snowfinch_pedsno1
+Pyrgilauda ruficollis_rufous-necked snowfinch_runsno1
+Pyrgilauda blanfordi_blanford's snowfinch_blasno1
+Pyrgilauda theresae_afghan snowfinch_afgsno1
+Dendronanthus indicus_forest wagtail_forwag1
+Motacilla capensis_cape wagtail_capwag1
+Motacilla clara_mountain wagtail_mouwag1
+Motacilla bocagii_sao tome short-tail_boclon2
+Motacilla flaviventris_madagascar wagtail_madwag1
+Motacilla cinerea_alvéola-cinzenta_grywag
+Motacilla flava_alvéola-amarela_eaywag1
+Motacilla flava flavissima_alvéola-amarela-britânica_weywag14
+Motacilla flava lutea_alvéola-de-cabeça-amarela_weywag15
+Motacilla flava flavissima/lutea_alvéola-amarela (flavissima/lutea)_weywag13
+Motacilla flava thunbergi_alvéola-amarela-escandinava_weywag2
+Motacilla flava flava_alvéola-amarela-europeia_weywag16
+Motacilla flava flavissima x flava_alvéola-amarela-do-canal-da-mancha_weywag21
+Motacilla flava beema_alvéola-amarela-de-sykes_weywag17
+Motacilla flava flava/beema_alvéola-amarela-europeia/de-sykes_weywag3
+Motacilla flava iberiae_alvéola-amarela-ibérica_weywag18
+Motacilla flava cinereocapilla_alvéola-amarela-italiana_weywag19
+Motacilla flava [cinereocapilla Group]_alvéola-amarela-ibérica/italiana/do-egipto_weywag4
+Motacilla flava pygmaea_alvéola-amarela-do-egipto_weywag20
+Motacilla flava feldegg_alvéola-amarela-balcânica_weywag6
+Motacilla flava leucocephala_alvéola-amarela (leucocephala)_weywag7
+Motacilla flava (superciliaris intergrade)_alvéola-amarela (intermédia superciliaris)_weywag11
+Motacilla flava (dombrowskii intergrade)_alvéola-amarela (intermédia dombrowskii)_weywag10
+Motacilla flava (xanthophrys intergrade)_alvéola-amarela (intermédia xanthophrys)_weywag12
+Motacilla tschutschensis_alvéola-amarela-oriental_eaywag
+Motacilla tschutschensis tschutschensis/plexa_alvéola-amarela-oriental (tschutschensis/plexa)_eaywag2
+Motacilla tschutschensis taivana_alvéola-amarela-oriental (taivana)_weywag8
+Motacilla tschutschensis macronyx_alvéola-amarela-oriental (macronyx)_weywag9
+Motacilla flava/tschutschensis_alvéola-amarela/alvéola-amarela-oriental_y00597
+Motacilla citreola_alvéola-citrina_citwag
+Motacilla citreola citreola/werae_alvéola-citrina (citreola/werae)_citwag1
+Motacilla citreola calcarata_alvéola-citrina (calcarata)_citwag2
+Motacilla flava x citreola_alvéola-amarela x alvéola-citrina (híbrido)_x00934
+Motacilla tschutschensis/citreola_alvéola-amarela-oriental/alvéola-citrina_y00429
+Motacilla maderaspatensis_white-browed wagtail_whbwag1
+Motacilla samveasnae_mekong wagtail_mekwag1
+Motacilla grandis_japanese wagtail_japwag1
+Motacilla aguimp_african pied wagtail_afpwag1
+Motacilla alba_alvéola-branca_whiwag
+Motacilla alba alba/dukhunensis_alvéola-branca-comum_whiwag1
+Motacilla alba yarrellii_alvéola-branca-britânica_whiwag3
+Motacilla alba ocularis_alvéola-branca (ocularis)_whiwag2
+Motacilla alba subpersonata_alvéola-branca-de-marrocos_whiwag4
+Motacilla alba personata_alvéola-branca (personata)_whiwag5
+Motacilla alba baicalensis_alvéola-branca (baicalensis)_whiwag7
+Motacilla alba alba/dukhunensis/baicalensis_alvéola-branca (alba/dukhunensis/baicalensis)_whiwag11
+Motacilla alba lugens_alvéola-branca (lugens)_bkbwag
+Motacilla alba ocularis/lugens_alvéola-branca (ocularis/lugens)_whiwag13
+Motacilla alba leucopsis_alvéola-branca (leucopsis)_whiwag8
+Motacilla alba lugens x leucopsis_alvéola-branca (lugens x leucopsis)_whiwag14
+Motacilla alba alboides_alvéola-branca (alboides)_whiwag6
+Motacilla alba leucopsis x alboides_alvéola-branca (leucopsis x alboides)_whiwag12
+Motacilla maderaspatensis/alba_white-browed/white wagtail_y00917
+Motacilla sp._alvéola sp._wagtai1
+Anthus australis_australian pipit_auspip2
+Anthus novaeseelandiae_new zealand pipit_auspip3
+Anthus richardi_petinha-de-richard_ricpip1
+Anthus rufulus_paddyfield pipit_oripip1
+Anthus richardi/rufulus_richard's/paddyfield pipit_y00918
+Anthus cinnamomeus_african pipit_afrpip1
+Anthus cinnamomeus camaroonensis_african pipit (Cameroon)_afrpip2
+Anthus cinnamomeus eximius_african pipit (Yemen)_afrpip3
+Anthus cinnamomeus [cinnamomeus Group]_african pipit (African)_afrpip4
+Anthus cinnamomeus latistriatus_african pipit (Jackson's)_jacpip1
+Anthus cinnamomeus grotei_african pipit (Etosha)_afrpip5
+Anthus hoeschi_mountain pipit_moupip1
+Anthus nyassae_woodland pipit_woopip1
+Anthus similis_petinha-de-bico-comprido_lobpip1
+Anthus similis bannermani_petinha-de-bico-comprido (bannermani)_lobpip3
+Anthus similis captus_petinha-de-bico-comprido (captus)_lobpip4
+Anthus similis arabicus_petinha-de-bico-comprido (arabicus)_lobpip5
+Anthus similis sokotrae_petinha-de-bico-comprido (sokotrae)_lobpip6
+Anthus similis chyuluensis_petinha-de-bico-comprido (chyuluensis)_lobpip2
+Anthus similis [nivescens Group]_petinha-de-bico-comprido [grupo nivescens]_lobpip25
+Anthus similis jerdoni/decaptus_petinha-de-bico-comprido (jerdoni/decaptus)_lobpip8
+Anthus similis similis/travancoriensis_petinha-de-bico-comprido (similis/travancoriensis)_lobpip9
+Anthus similis yamethini_petinha-de-bico-comprido (yamethini)_lobpip10
+Anthus nicholsoni_nicholson's pipit_lobpip7
+Anthus godlewskii_petinha-de-blyth_blypip1
+Anthus richardi/godlewskii_petinha-de-richard/petinha-de-blyth_y01013
+Anthus campestris_petinha-dos-campos_tawpip1
+Anthus leucophrys_plain-backed pipit_plbpip1
+Anthus vaalensis_buffy pipit_bufpip1
+Anthus pallidiventris_long-legged pipit_lolpip1
+Anthus nilghiriensis_nilgiri pipit_nilpip1
+Anthus sylvanus_upland pipit_uplpip1
+Anthus berthelotii_corre-caminho_berpip1
+Anthus melindae_malindi pipit_malpip1
+Anthus lineiventris_striped pipit_strpip1
+Anthus crenatus_yellow-tufted pipit_yetpip1
+Anthus ruficollis_madanga_rtweye1
+Anthus gutturalis_alpine pipit_alppip1
+Anthus pratensis_petinha-dos-prados_meapip1
+Anthus roseatus_rosy pipit_rospip1
+Anthus trivialis_petinha-das-árvores_trepip
+Anthus pratensis/trivialis_petinha-dos-prados/petinha-das-árvores_y00672
+Anthus hodgsoni_petinha-silvestre_olbpip
+Anthus trivialis/hodgsoni_petinha-das-árvores/petinha-silvestre_y00758
+Anthus gustavi_petinha-da-sibéria_pecpip
+Anthus gustavi gustavi/stejnegeri_petinha-da-sibéria (gustavi/stejnegeri)_pecpip1
+Anthus gustavi menzbieri_petinha-da-sibéria (menzbieri)_pecpip2
+Anthus cervinus_petinha-de-garganta-ruiva_retpip
+Anthus spinoletta_petinha-ribeirinha_watpip1
+Anthus spinoletta spinoletta_petinha-ribeirinha-ocidental_watpip2
+Anthus spinoletta coutellii_petinha-ribeirinha (coutellii)_watpip3
+Anthus spinoletta blakistoni_petinha-ribeirinha (blakistoni)_watpip4
+Anthus pratensis/spinoletta_petinha-dos-prados/petinha-ribeirinha_y00671
+Anthus petrosus_petinha-marítima_rocpip1
+Anthus petrosus petrosus/kleinschmidti_petinha-marítima (petrosus/kleinschmidti)_rocpip3
+Anthus petrosus littoralis_petinha-marítima (littoralis)_rocpip2
+Anthus spinoletta/petrosus_petinha-ribeirinha/petinha-marítima_y00759
+Anthus japonicus_siberian pipit_sibpip1
+Anthus rubescens_petinha-fulva_amepip
+Anthus japonicus/rubescens_siberian/american pipit_y01308
+Anthus spinoletta/japonicus/rubescens_water/siberian/american pipit_y00760
+Anthus spragueii_sprague's pipit_sprpip
+Anthus chii_caminheiro-zumbidor_yelpip2
+Anthus peruvianus_peruvian pipit_yelpip3
+Anthus brevirostris_puna pipit_shbpip3
+Anthus furcatus_caminheiro-de-unha-curta_shbpip1
+Anthus brevirostris/furcatus_puna/short-billed pipit_y01212
+Anthus chacoensis_pampas pipit_chapip1
+Anthus correndera_caminheiro-de-espora_corpip1
+Anthus correndera [correndera Group]_caminheiro-de-espora [grupo correndera]_corpip2
+Anthus correndera grayi_caminheiro-de-espora (grayi)_corpip3
+Anthus antarcticus_south georgia pipit_sogpip1
+Anthus nattereri_caminheiro-dourado_ocbpip1
+Anthus hellmayri_caminheiro-de-barriga-acanelada_helpip1
+Anthus bogotensis_paramo pipit_parpip1
+Anthus bogotensis meridae_paramo pipit (meridae)_parpip2
+Anthus bogotensis [bogotensis Group]_paramo pipit (bogotensis Group)_parpip3
+Anthus brachyurus_short-tailed pipit_shtpip1
+Anthus caffer_bush pipit_buspip1
+Anthus sokokensis_sokoke pipit_sokpip1
+Anthus sp._Anthus sp._pipit1
+Tmetothylacus tenellus_golden pipit_golpip1
+Hemimacronyx chloris_yellow-breasted pipit_yebpip2
+Macronyx sharpei_sharpe's longclaw_shalon1
+Macronyx capensis_orange-throated longclaw_ortlon1
+Macronyx croceus_yellow-throated longclaw_yetlon1
+Macronyx fuelleborni_fülleborn's longclaw_fuelon2
+Macronyx flavicollis_abyssinian longclaw_abylon1
+Macronyx aurantiigula_pangani longclaw_panlon1
+Macronyx ameliae_rosy-throated longclaw_rotlon1
+Macronyx grimwoodi_grimwood's longclaw_grilon1
+Macronyx sp._longclaw sp._longcl1
+Fringilla coelebs_tentilhão_comcha
+Fringilla moreletti_tentilhão-dos-açores_comcha16
+Fringilla maderensis_tentilhão-da-madeira_comcha17
+Fringilla canariensis_canary islands chaffinch_caicha1
+Fringilla canariensis canariensis/ombriosa_canary islands chaffinch (Canary Is.)_comcha4
+Fringilla canariensis palmae_canary islands chaffinch (La Palma)_comcha6
+Fringilla spodiogenys_african chaffinch_afrcha1
+Fringilla spodiogenys africana_african chaffinch (African)_comcha1
+Fringilla spodiogenys spodiogenys/harterti_african chaffinch (Tunisian)_comcha2
+Fringilla coelebs x spodiogenys_common x african chaffinch (hybrid)_x01070
+Fringilla coelebs/spodiogenys_common/african chaffinch_y01252
+Fringilla teydea_tentilhão-azul-de-tenerife_blucha2
+Fringilla polatzeki_tentilhão-azul-da-gran-canária_blucha3
+Fringilla montifringilla_tentilhão-montês_brambl
+Fringilla coelebs x montifringilla_common chaffinch x brambling (hybrid)_x01071
+Fringilla coelebs/montifringilla_tentilhão/tentilhão-montês_y01056
+Chlorophonia elegantissima_elegant euphonia_eleeup1
+Chlorophonia musica_hispaniolan euphonia_anteup2
+Chlorophonia sclateri_puerto rican euphonia_anteup3
+Chlorophonia flavifrons_lesser antillean euphonia_anteup4
+Chlorophonia cyanocephala_gaturamo-rei_goreup1
+Chlorophonia cyanea_gaturamo-bandeira_blnchl1
+Chlorophonia pyrrhophrys_chestnut-breasted chlorophonia_chbchl1
+Chlorophonia flavirostris_yellow-collared chlorophonia_yecchl1
+Chlorophonia occipitalis_blue-crowned chlorophonia_blcchl1
+Chlorophonia callophrys_golden-browed chlorophonia_gobchl1
+Euphonia jamaica_jamaican euphonia_jameup1
+Euphonia saturata_orange-crowned euphonia_orceup1
+Euphonia plumbea_gaturamo-miúdo_plueup1
+Euphonia chlorotica_fim-fim_puteup1
+Euphonia finschi_gaturamo-capim_fineup1
+Euphonia concinna_velvet-fronted euphonia_vefeup1
+Euphonia trinitatis_trinidad euphonia_trieup1
+Euphonia concinna/trinitatis_velvet-fronted/trinidad euphonia_y01213
+Euphonia godmani_west mexican euphonia_screup3
+Euphonia affinis_scrub euphonia_screup1
+Euphonia luteicapilla_yellow-crowned euphonia_yeceup1
+Euphonia chrysopasta_gaturamo-verde_gobeup1
+Euphonia minuta_gaturamo-de-barriga-branca_whveup1
+Euphonia chalybea_cais-cais_gnteup1
+Euphonia violacea_gaturamo-verdadeiro_vioeup1
+Euphonia hirundinacea_yellow-throated euphonia_yeteup1
+Euphonia laniirostris_gaturamo-de-bico-grosso_thbeup1
+Euphonia laniirostris melanura/crassirostris_gaturamo-de-bico-grosso (melanura/crassirostris)_thbeup2
+Euphonia laniirostris [laniirostris Group]_gaturamo-de-bico-grosso [grupo laniirostris]_thbeup3
+Euphonia imitans_spot-crowned euphonia_spceup1
+Euphonia gouldi_olive-backed euphonia_olbeup1
+Euphonia fulvicrissa_fulvous-vented euphonia_fuveup1
+Euphonia anneae_tawny-capped euphonia_taceup1
+Euphonia xanthogaster_fim-fim-grande_orbeup1
+Euphonia mesochrysa_bronze-green euphonia_brgeup1
+Euphonia cayennensis_gaturamo-preto_goseup1
+Euphonia rufiventris_gaturamo-do-norte_rubeup1
+Euphonia pectoralis_ferro-velho_chbeup1
+Euphonia sp._Euphonia sp._euphon1
+Mycerobas icterioides_black-and-yellow grosbeak_baygro1
+Mycerobas affinis_collared grosbeak_colgro1
+Mycerobas icterioides/affinis_black-and-yellow/collared grosbeak_y01064
+Mycerobas melanozanthos_spot-winged grosbeak_spwgro1
+Mycerobas carnipes_white-winged grosbeak_whwgro1
+Mycerobas sp._Mycerobas sp._mycero1
+Coccothraustes abeillei_hooded grosbeak_hoogro1
+Coccothraustes vespertinus_bico-grossudo-americano_evegro
+Coccothraustes vespertinus (type 1)_bico-grossudo-americano (tipo 1)_evegro1
+Coccothraustes vespertinus (type 2)_bico-grossudo-americano (tipo 2)_evegro2
+Coccothraustes vespertinus (type 3)_bico-grossudo-americano (tipo 3)_evegro3
+Coccothraustes vespertinus (type 4)_bico-grossudo-americano (tipo 4)_evegro4
+Coccothraustes vespertinus (type 5)_bico-grossudo-americano (tipo 5)_evegro5
+Coccothraustes coccothraustes_bico-grossudo_hawfin
+Eophona migratoria_yellow-billed grosbeak_yebgro1
+Eophona personata_japanese grosbeak_japgro1
+Melamprosops phaeosoma_poo-uli_poouli
+Oreomystis bairdi_akikiki_akikik
+Paroreomyza maculata_oahu alauahio_oahala
+Paroreomyza flammea_kakawahie_kakawa
+Paroreomyza montana_maui alauahio_mauala
+Loxioides bailleui_palila_palila
+Telespiza cantans_laysan finch_layfin
+Telespiza ultima_nihoa finch_nihfin
+Chloridops kona_kona grosbeak_kongro
+Rhodacanthis flaviceps_lesser koa-finch_lekfin
+Rhodacanthis palmeri_greater koa-finch_grkfin
+Ciridops anna_ula-ai-hawane_ulahaw
+Palmeria dolei_akohekohe_crehon
+Himatione fraithii_laysan honeycreeper_apapan2
+Himatione sanguinea_apapane_apapan
+Drepanis coccinea_iiwi_iiwi
+Himatione sanguinea x Drepanis coccinea_apapane x iiwi (hybrid)_x00828
+Himatione sanguinea/Drepanis coccinea_apapane/iiwi_y01321
+Drepanis pacifica_hawaii mamo_hawmam1
+Drepanis funerea_black mamo_blkmam
+Psittirostra psittacea_ou_ou
+Dysmorodrepanis munroi_lanai hookbill_lanhoo
+Pseudonestor xanthophrys_maui parrotbill_maupar
+Hemignathus hanapepe_kauai nukupuu_nukupu2
+Hemignathus lucidus_oahu nukupuu_nukupu3
+Hemignathus affinis_maui nukupuu_nukupu1
+Hemignathus wilsoni_akiapolaau_akiapo
+Akialoa obscura_lesser akialoa_lesaki
+Akialoa ellisiana_oahu akialoa_greaki2
+Akialoa stejnegeri_kauai akialoa_greaki4
+Akialoa lanaiensis_maui-nui akialoa_greaki3
+Magumma parva_anianiau_aniani
+Chlorodrepanis virens_hawaii amakihi_hawama
+Chlorodrepanis virens wilsoni_hawaii amakihi (Maui)_hawama1
+Chlorodrepanis virens virens_hawaii amakihi (Hawaii)_hawama2
+Chlorodrepanis flava_oahu amakihi_oahama
+Chlorodrepanis stejnegeri_kauai amakihi_kauama
+Viridonia sagittirostris_greater amakihi_greama
+Loxops mana_hawaii creeper_hawcre
+Loxops caeruleirostris_akekee_akekee
+Loxops coccineus_hawaii akepa_akepa1
+Loxops wolstenholmei_oahu akepa_akepa2
+Loxops ochraceus_maui akepa_akepa3
+Drepanidinae sp._hawaiian honeycreeper sp._hawhon1
+Carpodacus erythrinus_peito-carmim_comros
+Carpodacus sipahi_scarlet finch_scafin1
+Carpodacus ferreorostris_bonin grosbeak_bongro1
+Carpodacus rhodochlamys_red-mantled rosefinch_remros1
+Carpodacus grandis_blyth's rosefinch_blyros1
+Carpodacus rhodochlamys/grandis_red-mantled/blyth's rosefinch_y01181
+Carpodacus pulcherrimus_himalayan beautiful rosefinch_bearos1
+Carpodacus davidianus_chinese beautiful rosefinch_chbros1
+Carpodacus waltoni_pink-rumped rosefinch_pirros1
+Carpodacus edwardsii_dark-rumped rosefinch_darros1
+Carpodacus rodochroa_pink-browed rosefinch_pibros2
+Carpodacus rodopeplus_spot-winged rosefinch_spwros2
+Carpodacus edwardsii/rodopeplus_dark-rumped/spot-winged rosefinch_y01075
+Carpodacus verreauxii_sharpe's rosefinch_spwros3
+Carpodacus vinaceus_vinaceous rosefinch_vinros2
+Carpodacus formosanus_taiwan rosefinch_vinros3
+Carpodacus synoicus_sinai rosefinch_sinros1
+Carpodacus stoliczkae_pale rosefinch_palros3
+Carpodacus roborowskii_tibetan rosefinch_tibros1
+Carpodacus sillemi_sillem's rosefinch_tahmof1
+Carpodacus rubicilloides_streaked rosefinch_strros1
+Carpodacus rubicilla_peito-carmim-grande_greros1
+Carpodacus rubicilla rubicilla_peito-carmim-grande (rubicilla)_greros3
+Carpodacus rubicilla [severtzovi Group]_peito-carmim-grande [grupo severtzovi]_greros4
+Carpodacus rubicilloides/rubicilla_streaked/great rosefinch_y01016
+Carpodacus sibiricus_peito-rosado-rabilongo_lotros1
+Carpodacus sibiricus [sibiricus Group]_long-tailed rosefinch (Siberian)_lotros7
+Carpodacus sibiricus lepidus/henrici_long-tailed rosefinch (Chinese)_lotros8
+Carpodacus puniceus_red-fronted rosefinch_refros1
+Carpodacus subhimachalus_crimson-browed finch_crbfin3
+Carpodacus roseus_peito-rosado_palros2
+Carpodacus trifasciatus_three-banded rosefinch_thbros1
+Carpodacus thura_himalayan white-browed rosefinch_whbros1
+Carpodacus rodochroa/thura_pink-browed/himalayan white-browed rosefinch_y01108
+Carpodacus dubius_chinese white-browed rosefinch_cwbros1
+Carpodacus sp._peito-carmim (Carpodacus) sp._carpod
+Pinicola enucleator_pine grosbeak_pingro
+Pinicola enucleator [enucleator Group]_bico-duro [grupo enucleator]_pingro2
+Pinicola enucleator flammula_bico-duro (flammula)_pingro3
+Pinicola enucleator carlottae_bico-duro (carlottae)_pingro4
+Pinicola enucleator montana_bico-duro (montana)_pingro5
+Pinicola enucleator californica_bico-duro (californica)_pingro1
+Pinicola enucleator leucura_bico-duro (leucura)_pingro6
+Pyrrhula nipalensis_brown bullfinch_brobul1
+Pyrrhula nipalensis [nipalensis Group]_brown bullfinch (Brown)_brnbul1
+Pyrrhula nipalensis waterstradti_brown bullfinch (Malayan)_brnbul2
+Pyrrhula leucogenis_white-cheeked bullfinch_whcbul1
+Pyrrhula aurantiaca_orange bullfinch_orabul1
+Pyrrhula erythrocephala_red-headed bullfinch_rehbul1
+Pyrrhula erythaca_gray-headed bullfinch_gyhbul2
+Pyrrhula owstoni_taiwan bullfinch_gyhbul5
+Pyrrhula nipalensis/erythaca_brown/gray-headed bullfinch_y00761
+Pyrrhula owstoni/erythaca_taiwan/gray-headed bullfinch_y00430
+Pyrrhula murina_priolo_eurbul1
+Pyrrhula pyrrhula_dom-fafe_eurbul
+Pyrrhula pyrrhula [pyrrhula Group]_dom-fafe [grupo pyrrhula]_eurbul2
+Pyrrhula pyrrhula [griseiventris Group]_dom-fafe [grupo griseiventris]_eurbul3
+Rhodopechys sanguineus_asa-carmim_crwfin2
+Rhodopechys sanguineus alienus_asa-carmim-africano_crwfin1
+Rhodopechys sanguineus sanguineus_asa-carmim-asiático_crwfin3
+Bucanetes githagineus_trumpeter finch_trufin2
+Bucanetes mongolicus_trombeteiro-da-mongólia_monfin2
+Agraphospiza rubescens_blanford's rosefinch_blaros1
+Pyrrhoplectes epauletta_gold-naped finch_gonfin1
+Callacanthis burtoni_spectacled finch_spefin1
+Procarduelis nipalensis_dark-breasted rosefinch_dabros1
+Leucosticte nemoricola_plain mountain finch_plmfin1
+Leucosticte brandti_black-headed mountain finch_bhmfin1
+Leucosticte arctoa_asian rosy-finch_asrfin1
+Leucosticte arctoa [arctoa Group]_asian rosy-finch (Silver-winged)_asirof6
+Leucosticte arctoa brunneonucha/gigliolii_asian rosy-finch (Tawny-naped)_asirof7
+Leucosticte tephrocotis_gray-crowned rosy-finch_gcrfin
+Leucosticte tephrocotis umbrina_gray-crowned rosy-finch (Pribilof Is.)_gycrof2
+Leucosticte tephrocotis griseonucha_gray-crowned rosy-finch (Aleutian and Kodiak Is.)_gycrof3
+Leucosticte tephrocotis littoralis_gray-crowned rosy-finch (Hepburn's)_gycrof1
+Leucosticte tephrocotis [tephrocotis Group]_gray-crowned rosy-finch (Gray-crowned)_gycrof4
+Leucosticte tephrocotis littoralis x [tephrocotis Group]_gray-crowned rosy-finch (Hepburn's x Gray-crowned)_gycrof5
+Leucosticte atrata_black rosy-finch_bkrfin
+Leucosticte tephrocotis x atrata_gray-crowned x black rosy-finch (hybrid)_x01003
+Leucosticte australis_brown-capped rosy-finch_bcrfin
+Leucosticte sp._rosy-finch sp._rosfin
+Haemorhous mexicanus_house finch_houfin
+Haemorhous mexicanus [mexicanus Group]_house finch (Common)_houfin1
+Haemorhous mexicanus mcgregori_house finch (McGregor's)_houfin2
+Haemorhous purpureus_purple finch_purfin
+Haemorhous purpureus purpureus_purple finch (Eastern)_purfin1
+Haemorhous purpureus californicus_purple finch (Western)_purfin2
+Haemorhous mexicanus x purpureus_house x purple finch (hybrid)_x01004
+Haemorhous mexicanus/purpureus_house/purple finch_y00338
+Haemorhous cassinii_cassin's finch_casfin
+Haemorhous purpureus/cassinii_purple/cassin's finch_y00762
+Haemorhous sp._Haemorhous sp._haemor1
+Rhodospiza obsoleta_asa-rosada_desfin2
+Rhynchostruthus percivali_arabian grosbeak_gowgro2
+Rhynchostruthus socotranus_socotra grosbeak_gowgro3
+Rhynchostruthus louisae_somali grosbeak_somgro1
+Chloris chloris_verdelhão_eurgre1
+Chloris sinica_oriental greenfinch_origre
+Chloris sinica [sinica Group]_oriental greenfinch (Oriental)_origre7
+Chloris sinica kittlitzi_oriental greenfinch (Bonin)_origre6
+Chloris spinoides_yellow-breasted greenfinch_yebgre4
+Chloris monguilloti_vietnamese greenfinch_viegre2
+Chloris ambigua_black-headed greenfinch_bkhgre1
+Linurgus olivaceus_oriole finch_orifin1
+Crithagra leucopygia_white-rumped seedeater_whrsee
+Crithagra mozambica_canário-de-testa-amarela_yefcan
+Crithagra citrinelloides_african citril_afrcit1
+Crithagra frontalis_western citril_wescit1
+Crithagra hyposticta_southern citril_soucit1
+Crithagra capistrata_black-faced canary_blfcan1
+Crithagra koliensis_papyrus canary_papcan1
+Crithagra scotops_forest canary_forcan1
+Crithagra rothschildi_arabian serin_olrser1
+Crithagra atrogularis_black-throated canary_bltcan1
+Crithagra reichenowi_reichenow's seedeater_reisee2
+Crithagra xanthopygia_yellow-rumped serin_yerser1
+Crithagra citrinipectus_lemon-breasted seedeater_lebsee1
+Crithagra dorsostriata_white-bellied canary_whbcan1
+Crithagra flavigula_yellow-throated serin_yetser1
+Crithagra xantholaema_salvadori's serin_salser1
+Crithagra donaldsoni_northern grosbeak-canary_norgrc1
+Crithagra buchanani_southern grosbeak-canary_sougrc1
+Crithagra sulphurata_brimstone canary_brican1
+Crithagra flaviventris_yellow canary_yelcan1
+Crithagra albogularis_white-throated canary_whtcan1
+Crithagra striolata_streaky seedeater_strsee1
+Crithagra whytii_yellow-browed seedeater_yebsee2
+Crithagra burtoni_thick-billed seedeater_thbsee1
+Crithagra melanochroa_kipengere seedeater_tansee1
+Crithagra rufobrunnea_principe seedeater_prisee1
+Crithagra concolor_sao tome grosbeak_satgro1
+Crithagra leucoptera_protea canary_procan1
+Crithagra mennelli_black-eared seedeater_blesee1
+Crithagra canicapilla_west african seedeater_sthsee3
+Crithagra gularis_streaky-headed seedeater_sthsee2
+Crithagra striatipectus_stripe-breasted seedeater_reisee3
+Crithagra reichardi_reichard's seedeater_reisee4
+Crithagra tristriata_brown-rumped seedeater_brrsee1
+Crithagra menachensis_yemen serin_yemser1
+Crithagra ankoberensis_ankober serin_ankser2
+Crithagra totta_cape siskin_capsis2
+Crithagra symonsi_drakensberg siskin_drasis2
+Crithagra sp._african seedeater sp._afrsee1
+Linaria flavirostris_pintarroxo-de-bico-amarelo_twite1
+Linaria cannabina_pintarroxo-de-bico-escuro_eurlin1
+Linaria flavirostris/cannabina_pintarroxo-de-bico-amarelo/pintarroxo-de-bico-escuro_y01057
+Linaria yemenensis_yemen linnet_yemlin1
+Linaria johannis_warsangli linnet_warlin1
+Acanthis flammea_pintarroxo-de-queixo-preto_redpol1
+Acanthis flammea flammea/rostrata/islandica_pintarroxo-de-queixo-preto (flammea/rostrata/islandica)_comred
+Acanthis flammea flammea_pintarroxo-de-queixo-preto (flammea)_comred3
+Acanthis flammea rostrata/islandica_pintarroxo-de-queixo-preto (rostrata/islandica)_comred4
+Acanthis flammea cabaret_pintarroxo-de-queixo-preto (cabaret)_lesred1
+Acanthis flammea [flammea Group/cabaret]_pintarroxo-de-queixo-preto (flammea Group/cabaret)_y00763
+Acanthis flammea hornemanni/exilipes_pintarroxo-de-queixo-preto (hornemanni/exilipes)_hoared
+Acanthis flammea exilipes_pintarroxo-de-queixo-preto (exilipes)_hoared2
+Acanthis flammea hornemanni_pintarroxo-de-queixo-preto (hornemanni)_hoared1
+Acanthis flammea [flammea Group x hornemanni/exilipes]_pintarroxo-de-queixo-preto (flammea Group x hornemanni/exilipes)_x00625
+Acanthis flammea [flammea Group/hornemanni/exilipes]_pintarroxo-de-queixo-preto (flammea Group/hornemanni/exilipes)_redpol
+Loxia pytyopsittacus_cruza-bico-papagaio_parcro2
+Loxia scotica_cruza-bico-escocês_scocro1
+Loxia curvirostra_cruza-bico_redcro
+Loxia curvirostra corsicana_cruza-bico-da-córsega_redcro11
+Loxia curvirostra balearica_cruza-bico-das-baleares_redcro12
+Loxia curvirostra poliogyna_cruza-bico-do-magreb_redcro13
+Loxia curvirostra guillemardi_cruza-bico-do-chipre_redcro14
+Loxia curvirostra mariae_cruza-bico-da-crimeia_redcro15
+Loxia curvirostra altaiensis_cruza-bico (altaiensis)_redcro16
+Loxia curvirostra tianschanica_cruza-bico (tianschanica)_redcro17
+Loxia curvirostra himalayensis_cruza-bico-dos-himalaias_redcro18
+Loxia curvirostra meridionalis_cruza-bico (meridionalis)_redcro19
+Loxia curvirostra japonica_cruza-bico-do-japão_redcro20
+Loxia curvirostra luzoniensis_cruza-bico (luzoniensis)_redcro21
+Loxia curvirostra (type A)_cruza-bico (tipo A)_redcro22
+Loxia curvirostra (type B)_cruza-bico (tipo B)_redcro23
+Loxia curvirostra (type C)_cruza-bico (tipo C)_redcro24
+Loxia curvirostra (type D)_cruza-bico (tipo D)_redcro25
+Loxia curvirostra (type E)_cruza-bico (tipo E)_redcro26
+Loxia curvirostra (type F)_cruza-bico (tipo F)_redcro27
+Loxia curvirostra (type X)_cruza-bico (tipo X)_redcro28
+Loxia curvirostra (type 1)_cruza-bico (tipo 1)_redcro1
+Loxia curvirostra (type 2)_cruza-bico (tipo 2)_redcro2
+Loxia curvirostra (type 3)_cruza-bico (tipo 3)_redcro3
+Loxia curvirostra (type 4)_cruza-bico (tipo 4)_redcro4
+Loxia curvirostra (type 5)_cruza-bico (tipo 5)_redcro5
+Loxia curvirostra (type 6)_cruza-bico (tipo 6)_redcro6
+Loxia curvirostra (type 7)_cruza-bico (tipo 7)_redcro7
+Loxia curvirostra (type 8)_cruza-bico (tipo 8)_redcro8
+Loxia curvirostra (type 10)_cruza-bico (tipo 10)_redcro10
+Loxia curvirostra mesamericana_cruza-bico (mesamericana)_redcro29
+Loxia curvirostra (type 12)_cruza-bico (tipo 12)_redcro39
+Loxia pytyopsittacus/curvirostra_cruza-bico-papagaio/cruza-bico_y00928
+Loxia sinesciuris_cruza-bico-de-cássia_redcro9
+Loxia curvirostra/sinesciuris_cruza-bico/cruza-bico-de-cássia_y01058
+Loxia megaplaga_hispaniolan crossbill_hiscro
+Loxia leucoptera_cruza-bico-listado_whwcro
+Loxia leucoptera bifasciata_cruza-bico-listado (bifasciata)_whwcro1
+Loxia leucoptera leucoptera_cruza-bico-listado (leucoptera)_whwcro2
+Loxia sp._cruza-bico (Loxia) sp._crossb
+Chrysocorythus estherae_indonesian serin_mouser2
+Chrysocorythus mindanensis_mindanao serin_mouser3
+Carduelis carduelis_pintassilgo-europeu_eurgol
+Carduelis caniceps_gray-crowned goldfinch_eurgol2
+Carduelis carduelis x caniceps_european x gray-crowned goldfinch (hybrid)_x01171
+Carduelis carduelis/caniceps_european/gray-crowned goldfinch_y01288
+Carduelis citrinella_milheirinha-serrana_citfin1
+Carduelis corsicana_milheirinha-da-córsega_corfin1
+Serinus serinus_milheirinha-europeia_eurser1
+Carduelis citrinella/Serinus serinus_milheirinha-serrana/milheirinha-europeia_y01059
+Serinus canaria_island canary_comcan
+Serinus canaria (Domestic type)_island canary (Domestic type)_islcan1
+Carduelis carduelis x Serinus canaria_pintassilgo x canário-da-terra (híbrido)_x01005
+Serinus pusillus_milheirinha-de-testa-vermelha_fifser1
+Serinus syriacus_milheirinha-do-levante_syrser1
+Serinus serinus/pusillus/syriacus_milheirinha-europeia/milheirinha-de-testa-vermelha/milheirinha-do-levante_y01060
+Serinus flavivertex_yellow-crowned canary_yeccan1
+Serinus canicollis_cape canary_capcan1
+Serinus nigriceps_ethiopian siskin_abysis1
+Serinus alario_black-headed canary_bkhcan2
+Serinus alario alario_black-headed canary (Black-headed)_bkhcan1
+Serinus alario leucolaemus_black-headed canary (Damara)_damcan1
+Serinus sp._milheirinha (Serinus) sp._canary1
+Spinus thibetanus_tibetan serin_tibser1
+Spinus spinus_lugre_eursis
+Spinus pinus_pine siskin_pinsis
+Spinus pinus pinus/macropterus_pine siskin (Northern)_pinsis1
+Spinus pinus perplexus_pine siskin (Chiapas)_pinsis2
+Spinus pinus (green morph)_pine siskin (green morph)_pinsis3
+Loxia curvirostra x Spinus pinus_red crossbill x pine siskin (hybrid)_x00904
+Spinus atriceps_black-capped siskin_blcsis1
+Spinus pinus x atriceps_pine x black-capped siskin (hybrid)_x00829
+Spinus notatus_black-headed siskin_blhsis1
+Spinus dominicensis_antillean siskin_antsis1
+Spinus psaltria_lesser goldfinch_lesgol
+Carduelis carduelis x Spinus psaltria_european x lesser goldfinch (hybrid)_x01006
+Spinus lawrencei_lawrence's goldfinch_lawgol
+Spinus tristis_american goldfinch_amegfi
+Carduelis carduelis x Spinus tristis_european x american goldfinch (hybrid)_x01007
+Spinus pinus x tristis_pine siskin x american goldfinch (hybrid)_x00905
+Spinus psaltria x tristis_lesser x american goldfinch (hybrid)_x00714
+Spinus sp. (goldfinch sp.)_new world goldfinch sp._goldfi
+Spinus spinescens_andean siskin_andsis1
+Spinus yarrellii_pintassilgo-do-nordeste_yefsis1
+Spinus xanthogastrus_yellow-bellied siskin_yebsis1
+Spinus cucullatus_red siskin_redsis1
+Spinus crassirostris_thick-billed siskin_thbsis1
+Spinus magellanicus_pintassilgo_hoosis1
+Spinus magellanicus longirostris_hooded siskin (Guianan)_hoosis3
+Spinus magellanicus [capitalis Group]_hooded siskin (Andean)_hoosis13
+Spinus magellanicus [magellanicus Group]_hooded siskin (Lowland)_hoosis14
+Spinus siemiradzkii_saffron siskin_safsis1
+Spinus olivaceus_olivaceous siskin_olisis1
+Spinus magellanicus/olivaceus_hooded/olivaceous siskin_y00698
+Spinus atratus_black siskin_blasis1
+Spinus uropygialis_yellow-rumped siskin_yersis1
+Spinus magellanicus x uropygialis_hooded x yellow-rumped siskin (hybrid)_x00713
+Spinus barbatus_black-chinned siskin_blcsis2
+Spinus [undescribed form]_monte desert siskin (undescribed form)_modsis1
+Spinus sp._Spinus sp._spinus1
+Acanthis/Spinus sp._fringilídeo Acanthis/Spinus sp._y00631
+Fringillidae sp._fringilídeo sp._finch1
+Calcarius lapponicus_escrevedeira-da-lapónia_laplon
+Calcarius ornatus_chestnut-collared longspur_chclon
+Calcarius pictus_smith's longspur_smilon
+Rhynchophanes mccownii_thick-billed longspur_mcclon
+Calcarius/Rhynchophanes sp._longspur sp._longsp1
+Plectrophenax nivalis_escrevedeira-das-neves_snobun
+Calcarius lapponicus x Plectrophenax nivalis_escrevedeira-da-lapónia x escrevedeira-das-neves (híbrido)_x00919
+Plectrophenax hyperboreus_mckay's bunting_mckbun
+Plectrophenax nivalis x hyperboreus_snow x mckay's bunting (hybrid)_x00447
+Plectrophenax nivalis/hyperboreus_snow/mckay's bunting_y00695
+Rhodinocichla rosea_rosy thrush-tanager_rottan2
+Rhodinocichla rosea schistacea_rosy thrush-tanager (Mexican)_rostht1
+Rhodinocichla rosea eximia_rosy thrush-tanager (Panama)_rostht2
+Rhodinocichla rosea [rosea Group]_rosy thrush-tanager (Southern)_rostht6
+Emberiza affinis_brown-rumped bunting_brrbun1
+Emberiza lathami_crested bunting_crebun1
+Emberiza melanocephala_escrevedeira-de-cabeça-preta_blhbun1
+Emberiza bruniceps_escrevedeira-de-cabeça-ruiva_rehbun1
+Emberiza melanocephala x bruniceps_escrevedeira-de-cabeça-preta x escrevedeira-de-cabeça-ruiva (híbrido)_x00871
+Emberiza melanocephala/bruniceps_escrevedeira-de-cabeça-preta/escrevedeira-de-cabeça-ruiva_y00923
+Emberiza calandra_trigueirão_corbun1
+Emberiza fucata_escrevedeira-d'orelhas-castanhas_chebun2
+Emberiza koslowi_tibetan bunting_tibbun1
+Emberiza jankowskii_rufous-backed bunting_rubbun1
+Emberiza cia_cia_rocbun1
+Emberiza godlewskii_godlewski's bunting_godbun1
+Emberiza godlewskii [godlewskii Group]_godlewski's bunting (godlewskii Group)_godbun2
+Emberiza godlewskii yunnanensis/khamensis_godlewski's bunting (yunnanensis/khamensis)_godbun3
+Emberiza cioides_meadow bunting_meabun1
+Emberiza cioides [cioides Group]_meadow bunting (Rufous-eared)_meabun7
+Emberiza cioides ciopsis_meadow bunting (Black-eared)_meabun6
+Emberiza cirlus_escrevedeira_cirbun1
+Emberiza stewarti_white-capped bunting_chbbun1
+Emberiza citrinella_escrevedeira-amarela_yellow2
+Emberiza leucocephalos_escrevedeira-de-barrete-branco_pinbun
+Emberiza citrinella x leucocephalos_escrevedeira-amarela x escrevedeira-de-barrete-branco (híbrido)_x00823
+Emberiza citrinella/leucocephalos_yellowhammer/pine bunting_y01223
+Emberiza buchanani_sombria-de-pescoço-cinzento_gyhbun1
+Emberiza cineracea_escrevedeira-cinzenta_cinbun1
+Emberiza cineracea cineracea_escrevedeira-cinzenta-ocidental_cinbun2
+Emberiza cineracea semenowi_escrevedeira-cinzenta-oriental_cinbun3
+Emberiza hortulana_sombria_ortbun1
+Emberiza buchanani/hortulana_sombria-de-pescoço-cinzento/sombria_y00922
+Emberiza caesia_sombria-de-capuz_crebun2
+Emberiza hortulana/caesia_sombria/sombria-de-capuz_y00431
+Emberiza cabanisi_cabanis's bunting_cabbun1
+Emberiza cabanisi cabanisi_cabanis's bunting (Cabanis's)_cabbun2
+Emberiza cabanisi orientalis_cabanis's bunting (Three-streaked)_cabbun3
+Emberiza flaviventris_golden-breasted bunting_gobbun1
+Emberiza poliopleura_somali bunting_sombun1
+Emberiza capensis_cape bunting_capbun1
+Emberiza capensis [capensis Group]_cape bunting (Cape)_capbun12
+Emberiza capensis vincenti_cape bunting (Vincent's)_vinbun1
+Emberiza impetuani_lark-like bunting_lalbun1
+Emberiza socotrana_socotra bunting_socbun1
+Emberiza tahapisi_cia-africana_cibbun1
+Emberiza goslingi_gosling's bunting_gosbun1
+Emberiza tahapisi x goslingi_cinnamon-breasted x gosling's bunting (hybrid)_x00975
+Emberiza sahari_escrevedeira-doméstica-do-sará_houbun3
+Emberiza striolata_escrevedeira-doméstica-do-levante_houbun2
+Emberiza siemsseni_slaty bunting_slabun1
+Emberiza elegans_yellow-throated bunting_yetbun1
+Emberiza yessoensis_ochre-rumped bunting_ocrbun1
+Emberiza pallasi_escrevedeira-de-pallas_palbun
+Emberiza schoeniclus_escrevedeira-dos-caniços_reebun
+Emberiza pallasi/schoeniclus_escrevedeira-de-pallas/escrevedeira-dos-caniços_y01015
+Emberiza aureola_escrevedeira-de-barriga-amarela_yebbun
+Emberiza pusilla_escrevedeira-pequena_litbun
+Emberiza rustica_escrevedeira-rústica_rusbun
+Emberiza sulphurata_yellow bunting_yelbun1
+Emberiza spodocephala_escrevedeira-de-faces-pretas_bkfbun1
+Emberiza personata_masked bunting_bkfbun2
+Emberiza spodocephala/personata_black-faced/masked bunting_blfbun1
+Emberiza rutila_escrevedeira-ferrugínea_chebun1
+Emberiza chrysophrys_escrevedeira-de-sobrolho_yebbun1
+Emberiza tristrami_tristram's bunting_tribun1
+Emberiza variabilis_gray bunting_grybun
+Emberiza sp._escrevedeira (Emberiza) sp._emberi1
+Oreothraupis arremonops_tanager finch_tanfin1
+Chlorospingus flavigularis_yellow-throated chlorospingus_ytbtan1
+Chlorospingus flavigularis hypophaeus_yellow-throated chlorospingus (Drab-breasted)_yetbut1
+Chlorospingus flavigularis flavigularis/marginatus_yellow-throated chlorospingus (Yellow-throated)_yetbut2
+Chlorospingus parvirostris_short-billed chlorospingus_shbbut1
+Chlorospingus flavigularis/parvirostris_yellow-throated/short-billed chlorospingus_y01126
+Chlorospingus canigularis_ashy-throated chlorospingus_atbtan1
+Chlorospingus canigularis olivaceiceps_ashy-throated chlorospingus (Olive-crowned)_astbut1
+Chlorospingus canigularis [canigularis Group]_ashy-throated chlorospingus (Ashy-throated)_astbut2
+Chlorospingus pileatus_sooty-capped chlorospingus_scbtan1
+Chlorospingus flavopectus_common chlorospingus_cobtan1
+Chlorospingus flavopectus ophthalmicus_common chlorospingus (Northeast Mexico)_combut1
+Chlorospingus flavopectus albifrons_common chlorospingus (Southwest Mexico)_combut3
+Chlorospingus flavopectus [postocularis Group]_common chlorospingus (Middle America)_combut4
+Chlorospingus flavopectus punctulatus_common chlorospingus (Central Panama)_combut2
+Chlorospingus flavopectus [venezuelanus Group]_common chlorospingus (Venezuela)_combut5
+Chlorospingus flavopectus [flavopectus Group]_common chlorospingus (Northern Andes)_combut6
+Chlorospingus flavopectus cinereocephalus_common chlorospingus (cinereocephalus)_combut7
+Chlorospingus flavopectus peruvianus_common chlorospingus (Southern Peru)_combut8
+Chlorospingus flavopectus bolivianus_common chlorospingus (Northern Bolivia)_combut9
+Chlorospingus flavopectus fulvigularis_common chlorospingus (Southern Bolivia)_combut10
+Chlorospingus flavopectus argentinus_common chlorospingus (Argentina)_combut11
+Chlorospingus tacarcunae_tacarcuna chlorospingus_tabtan1
+Chlorospingus inornatus_pirre chlorospingus_pibtan1
+Chlorospingus semifuscus_dusky chlorospingus_dubtan1
+Chlorospingus sp._chlorospingus sp._chloro1
+Rhynchospiza stolzmanni_tumbes sparrow_tumspa1
+Rhynchospiza dabbenei_yungas sparrow_stcspa2
+Rhynchospiza strigiceps_chaco sparrow_stcspa3
+Rhynchospiza dabbenei/strigiceps_yungas/chaco sparrow_stcspa1
+Peucaea carpalis_rufous-winged sparrow_ruwspa
+Peucaea sumichrasti_cinnamon-tailed sparrow_citspa1
+Peucaea ruficauda_stripe-headed sparrow_sthspa1
+Peucaea ruficauda acuminata_stripe-headed sparrow (Northern)_sthspa2
+Peucaea ruficauda [ruficauda Group]_stripe-headed sparrow (Southern)_sthspa7
+Peucaea humeralis_black-chested sparrow_blcspa1
+Peucaea mystacalis_bridled sparrow_brispa1
+Peucaea botterii_botteri's sparrow_botspa
+Peucaea botterii [botterii Group]_botteri's sparrow (Botteri's)_botspa1
+Peucaea botterii [petenica Group]_botteri's sparrow (Peten)_botspa2
+Peucaea cassinii_cassin's sparrow_casspa
+Peucaea botterii/cassinii_botteri's/cassin's sparrow_y00646
+Peucaea aestivalis_bachman's sparrow_bacspa
+Peucaea sp._Peucaea sp._peucae1
+Ammodramus savannarum_grasshopper sparrow_graspa
+Ammodramus humeralis_tico-tico-do-campo_graspa1
+Ammodramus aurifrons_cigarrinha-do-campo_yebspa1
+Ammodramus humeralis/aurifrons_tico-tico-do-campo/tico-tico-cigarrinha_y01083
+Arremonops rufivirgatus_olive sparrow_olispa
+Arremonops rufivirgatus [rufivirgatus Group]_olive sparrow (Olive)_olispa1
+Arremonops rufivirgatus [superciliosus Group]_olive sparrow (Pacific)_olispa2
+Arremonops chloronotus_green-backed sparrow_grbspa1
+Arremonops rufivirgatus/chloronotus_olive/green-backed sparrow_y00921
+Arremonops conirostris_tico-tico-cantor_blsspa1
+Arremonops tocuyensis_tocuyo sparrow_tocspa1
+Spizella passerina_chipping sparrow_chispa
+Spizella pallida_clay-colored sparrow_clcspa
+Spizella passerina x pallida_chipping x clay-colored sparrow (hybrid)_x00198
+Spizella atrogularis_black-chinned sparrow_bkcspa
+Spizella pusilla_field sparrow_fiespa
+Spizella passerina x pusilla_chipping x field sparrow (hybrid)_x00976
+Spizella pallida x pusilla_clay-colored x field sparrow (hybrid)_x00200
+Spizella breweri_brewer's sparrow_brespa
+Spizella breweri breweri_brewer's sparrow (breweri)_brespa1
+Spizella breweri taverneri_brewer's sparrow (taverneri)_timspa3
+Spizella pallida x breweri_clay-colored x brewer's sparrow (hybrid)_x00199
+Spizella atrogularis x breweri_black-chinned x brewer's sparrow (hybrid)_x00201
+Spizella pallida/breweri_clay-colored/brewer's sparrow_y01267
+Spizella wortheni_worthen's sparrow_worspa
+Spizella sp._Spizella sp._spizel1
+Amphispizopsis quinquestriata_five-striped sparrow_fisspa
+Amphispiza bilineata_black-throated sparrow_bktspa
+Chondestes grammacus_escrevedeira-arlequim_larspa
+Calamospiza melanocorys_lark bunting_larbun
+Arremon costaricensis_costa rican brushfinch_sthbrf3
+Arremon basilicus_sierra nevada brushfinch_sthbrf4
+Arremon perijanus_perija brushfinch_sthbrf5
+Arremon atricapillus_black-headed brushfinch_sthbrf1
+Arremon phaeopleurus_caracas brushfinch_sthbrf6
+Arremon phygas_paria brushfinch_sthbrf7
+Arremon assimilis_gray-browed brushfinch_sthbrf8
+Arremon torquatus_white-browed brushfinch_sthbrf2
+Arremon sp. (torquatus complex)_tico-tico (complexo torquatus) sp._shbfin1
+Arremon aurantiirostris_orange-billed sparrow_orbspa1
+Arremon aurantiirostris [aurantiirostris Group]_orange-billed sparrow (aurantiirostris Group)_orbspa2
+Arremon aurantiirostris erythrorhynchus_orange-billed sparrow (erythrorhynchus)_orbspa3
+Arremon aurantiirostris spectabilis_orange-billed sparrow (spectabilis)_orbspa4
+Arremon abeillei_black-capped sparrow_bkcspa1
+Arremon nigriceps_marañon sparrow_bkcspa2
+Arremon schlegeli_golden-winged sparrow_gowspa1
+Arremon taciturnus_tico-tico-de-bico-preto_pecspa1
+Arremon taciturnus axillaris_tico-tico-de-bico-preto (axillaris)_pecspa2
+Arremon taciturnus taciturnus/nigrirostris_tico-tico-de-bico-preto (taciturnus/nigrirostris)_pecspa3
+Arremon franciscanus_tico-tico-do-são-francisco_safspa1
+Arremon semitorquatus_tico-tico-do-mato_hacspa1
+Arremon dorbignii_moss-backed sparrow_sabspa4
+Arremon flavirostris_tico-tico-de-bico-amarelo/de-costas-cinza_sabspa1
+Arremon flavirostris polionotus_tico-tico-de-costas-cinza_sabspa2
+Arremon flavirostris flavirostris_tico-tico-de-bico-amarelo_sabspa3
+Arremon virenticeps_green-striped brushfinch_gsbfin1
+Arremon brunneinucha_chestnut-capped brushfinch_ccbfin
+Arremon brunneinucha apertus_chestnut-capped brushfinch (Plain-breasted)_chcbrf2
+Arremon brunneinucha [brunneinucha Group]_chestnut-capped brushfinch (Chestnut-capped)_chcbrf1
+Arremon crassirostris_sooty-faced finch_soffin1
+Arremon castaneiceps_olive finch_olifin1
+Spizelloides arborea_american tree sparrow_amtspa
+Spizella/Spizelloides sp._spizella sp./american tree sparrow_spizel
+Passerella iliaca_tico-tico-raposino_foxspa
+Passerella iliaca [unalaschcensis Group]_tico-tico-raposino [grupo unalaschcensis]_foxsp2
+Passerella iliaca [megarhyncha Group]_tico-tico-raposino [grupo megarhyncha]_foxsp4
+Passerella iliaca [schistacea Group]_tico-tico-raposino [grupo schistacea]_foxsp3
+Passerella iliaca iliaca/zaboria_tico-tico-raposino (iliaca/zaboria)_foxsp1
+Passerella iliaca [unalaschcensis Group] x zaboria_tico-tico-raposino (grupo unalaschcensis x zaboria)_foxspa20
+Junco hyemalis_junco_daejun
+Junco hyemalis hyemalis/carolinensis/cismontanus_junco (hyemalis/carolinensis/cismontanus)_daejun5
+Junco hyemalis hyemalis/carolinensis_junco (hyemalis/carolinensis)_slcjun
+Junco hyemalis cismontanus_junco (cismontanus)_daejun1
+Junco hyemalis [oreganus Group]_junco [grupo oreganus]_orejun
+Junco hyemalis mearnsi_junco (mearnsi)_pisjun
+Junco hyemalis [oreganus Group] x mearnsi_junco (grupo oreganus x mearnsi)_daejun3
+Junco hyemalis aikeni_junco (aikeni)_whwjun
+Junco hyemalis mearnsi x aikeni_junco (mearnsi x aikeni)_daejun7
+Junco hyemalis caniceps_junco (caniceps)_gyhjun
+Junco hyemalis [oreganus Group] x caniceps_junco (grupo oreganus x caniceps)_daejun8
+Junco hyemalis mearnsi x caniceps_junco (mearnsi x caniceps)_daejun4
+Junco hyemalis dorsalis_junco (dorsalis)_rebjun1
+Junco hyemalis caniceps x dorsalis_junco (caniceps x dorsalis)_daejun6
+Junco insularis_junco-de-guadalupe_daejun2
+Junco phaeonotus_yellow-eyed junco_yeejun
+Junco phaeonotus phaeonotus/palliatus_yellow-eyed junco (Mexican)_yeejun1
+Junco phaeonotus fulvescens_yellow-eyed junco (Chiapas)_yeejun3
+Junco phaeonotus alticola_yellow-eyed junco (Guatemalan)_yeejun4
+Junco hyemalis x phaeonotus_dark-eyed x yellow-eyed junco (hybrid)_x00869
+Junco hyemalis/phaeonotus_dark-eyed/yellow-eyed junco_y00333
+Junco bairdi_baird's junco_yeejun2
+Junco vulcani_volcano junco_voljun1
+Zonotrichia capensis_tico-tico_rucspa1
+Zonotrichia capensis [capensis Group]_tico-tico [grupo capensis]_rucspa6
+Zonotrichia capensis australis_tico-tico (australis)_rucspa5
+Zonotrichia leucophrys_tico-tico-coroado_whcspa
+Zonotrichia leucophrys leucophrys/oriantha_tico-tico-coroado (leucophrys/oriantha)_whcspa2
+Zonotrichia leucophrys leucophrys_tico-tico-coroado (leucophrys)_ewcspa1
+Zonotrichia leucophrys oriantha_tico-tico-coroado (oriantha)_mwcspa1
+Zonotrichia leucophrys gambelii_tico-tico-coroado (gambelii)_gwcspa
+Zonotrichia leucophrys nuttalli/pugetensis_tico-tico-coroado (nuttalli/pugetensis)_whcspa3
+Zonotrichia leucophrys nuttalli_tico-tico-coroado (nuttalli)_nwcspa
+Zonotrichia leucophrys pugetensis_tico-tico-coroado (pugetensis)_pswspa1
+Junco hyemalis x Zonotrichia leucophrys_dark-eyed junco x white-crowned sparrow (hybrid)_x01016
+Zonotrichia atricapilla_golden-crowned sparrow_gocspa
+Zonotrichia leucophrys x atricapilla_white-crowned x golden-crowned sparrow (hybrid)_x00053
+Zonotrichia querula_harris's sparrow_harspa
+Spizelloides arborea x Zonotrichia querula_american tree x harris's sparrow (hybrid)_x00752
+Zonotrichia leucophrys x querula_white-crowned x harris's sparrow (hybrid)_x00900
+Zonotrichia albicollis_chingolito_whtspa
+Zonotrichia leucophrys x albicollis_tico-tico-coroado x chingolito (híbrido)_x00451
+Zonotrichia atricapilla x albicollis_golden-crowned x white-throated sparrow (hybrid)_x00720
+Junco hyemalis x Zonotrichia albicollis_junco x chingolito (híbrido)_x00039
+Zonotrichia leucophrys/albicollis_tico-tico-coroado/chingolito_y00332
+Zonotrichia sp._tico-tico (Zonotrichia) sp._zonotr1
+Artemisiospiza nevadensis_sagebrush sparrow_sagspa1
+Artemisiospiza belli_bell's sparrow_belspa2
+Artemisiospiza belli belli_bell's sparrow (belli)_belspa1
+Artemisiospiza belli canescens_bell's sparrow (canescens)_belspa3
+Artemisiospiza belli clementeae_bell's sparrow (clementeae)_scsspa1
+Artemisiospiza belli cinerea_bell's sparrow (cinerea)_sagspa2
+Artemisiospiza nevadensis/belli_sagebrush/bell's sparrow (Sage Sparrow)_sagspa
+Oriturus superciliosus_striped sparrow_strspa1
+Pooecetes gramineus_vesper sparrow_vesspa
+Ammospiza leconteii_leconte's sparrow_lecspa
+Ammospiza maritima_seaside sparrow_seaspa
+Ammospiza maritima maritima/macgillivraii_seaside sparrow (Atlantic)_seaspa1
+Ammospiza maritima nigrescens_seaside sparrow (Dusky)_dusspa1
+Ammospiza maritima [sennetti Group]_seaside sparrow (Gulf of Mexico)_seaspa2
+Ammospiza maritima mirabilis_seaside sparrow (Cape Sable)_cssspa1
+Ammospiza nelsoni_nelson's sparrow_nstspa
+Ammospiza nelsoni nelsoni/altera_nelson's sparrow (Interior)_nstspa1
+Ammospiza nelsoni subvirgata_nelson's sparrow (Atlantic Coast)_nstspa2
+Ammospiza leconteii/nelsoni_leconte's/nelson's sparrow_y01165
+Ammospiza caudacuta_saltmarsh sparrow_sstspa
+Ammospiza nelsoni x caudacuta_nelson's x saltmarsh sparrow (hybrid)_x00450
+Ammospiza nelsoni/caudacuta_nelson's/saltmarsh sparrow (Sharp-tailed Sparrow)_shtspa
+Ammospiza sp._Ammospiza sp._ammosp1
+Passerculus sandwichensis_tico-tico-dos-prados_savspa
+Passerculus sandwichensis [sandwichensis Group]_tico-tico-dos-prados [grupo sandwichensis]_savspa4
+Passerculus sandwichensis princeps_tico-tico-dos-prados (princeps)_ipsspa
+Passerculus sandwichensis [guttatus Group]_tico-tico-dos-prados [grupo guttatus]_bldspa
+Passerculus sandwichensis sanctorum_tico-tico-dos-prados (sanctorum)_savspa3
+Passerculus sandwichensis rostratus/atratus_tico-tico-dos-prados (rostratus/atratus)_labspa
+Ammodramus savannarum x Passerculus sandwichensis_grasshopper x savannah sparrow (hybrid)_x01057
+Centronyx bairdii_baird's sparrow_baispa
+Ammodramus savannarum/Centronyx bairdii_grasshopper/baird's sparrow_y01081
+Centronyx henslowii_henslow's sparrow_henspa
+Ammodramus savannarum/Centronyx henslowii_grasshopper/henslow's sparrow_y01082
+Xenospiza baileyi_sierra madre sparrow_simspa1
+Melospiza melodia_tico-tico-musical_sonspa
+Melospiza melodia melodia/atlantica_tico-tico-musical (melodia/atlantica)_sonspa2
+Melospiza melodia sanaka/maxima_tico-tico-musical (sanaka/maxima)_sonspa6
+Melospiza melodia [rufina Group]_tico-tico-musical [grupo rufina]_sonspa4
+Melospiza melodia montana/merrilli_tico-tico-musical (montana/merrilli)_sonspa7
+Melospiza melodia [heermanni Group]_tico-tico-musical [grupo heermanni]_sonspa5
+Melospiza melodia samuelsis_tico-tico-musical (samuelsis)_sonspa8
+Melospiza melodia pusillula_tico-tico-musical (pusillula)_sonspa9
+Melospiza melodia [fallax Group]_tico-tico-musical [grupo fallax]_sonspa1
+Melospiza melodia [mexicana Group]_tico-tico-musical [grupo mexicana]_sonspa3
+Melospiza lincolnii_lincoln's sparrow_linspa
+Melospiza melodia x lincolnii_song x lincoln's sparrow (hybrid)_x00474
+Melospiza georgiana_swamp sparrow_swaspa
+Melospiza melodia x georgiana_song x swamp sparrow (hybrid)_x00702
+Melospiza lincolnii/georgiana_lincoln's/swamp sparrow_y00688
+Pezopetes capitalis_large-footed finch_laffin1
+Torreornis inexpectata_zapata sparrow_zapspa1
+Melozone kieneri_rusty-crowned ground-sparrow_rcgspa1
+Melozone fusca_canyon towhee_cantow
+Melozone albicollis_white-throated towhee_whttow1
+Melozone aberti_abert's towhee_abetow
+Melozone fusca x aberti_canyon x abert's towhee (hybrid)_x00870
+Melozone fusca/aberti_canyon/abert's towhee_y00331
+Melozone crissalis_california towhee_caltow
+Melozone aberti x crissalis_abert's x california towhee (hybrid)_x01138
+Melozone leucotis_white-eared ground-sparrow_wegspa1
+Melozone leucotis occipitalis_white-eared ground-sparrow (Gray-crowned)_whegrs1
+Melozone leucotis leucotis/nigrior_white-eared ground-sparrow (White-eared)_whegrs2
+Melozone biarcuata_white-faced ground-sparrow_pregrs1
+Melozone cabanisi_cabanis's ground-sparrow_pregrs2
+Aimophila rufescens_rusty sparrow_russpa1
+Aimophila ruficeps_rufous-crowned sparrow_rucspa
+Aimophila notosticta_oaxaca sparrow_oaxspa1
+Pipilo chlorurus_green-tailed towhee_gnttow
+Pipilo maculatus_spotted towhee_spotow
+Pipilo maculatus [oregonus Group]_spotted towhee (oregonus Group)_spotow1
+Pipilo maculatus arcticus_spotted towhee (arcticus)_spotow5
+Pipilo maculatus [maculatus Group]_spotted towhee (maculatus Group)_spotow2
+Pipilo maculatus macronyx_spotted towhee (Olive-backed)_spotow3
+Pipilo maculatus socorroensis_spotted towhee (Socorro)_spotow4
+Arremon brunneinucha x Pipilo maculatus_chestnut-capped brushfinch x spotted towhee (hybrid)_x00475
+Melozone fusca x Pipilo maculatus_canyon x spotted towhee (hybrid)_x00476
+Pipilo chlorurus x maculatus_green-tailed x spotted towhee (hybrid)_x00706
+Pipilo erythrophthalmus_pipilo-d'olho-vermelho_eastow
+Pipilo erythrophthalmus erythrophthalmus/canaster_pipilo-d'olho-vermelho (erythrophthalmus/canaster)_eastow1
+Pipilo erythrophthalmus alleni/rileyi_pipilo-d'olho-vermelho (alleni/rileyi)_eastow2
+Pipilo maculatus x erythrophthalmus_spotted x eastern towhee (hybrid)_x00446
+Pipilo maculatus/erythrophthalmus_spotted/eastern towhee (Rufous-sided Towhee)_y00226
+Pipilo naufragus_bermuda towhee_bertow1
+Pipilo ocai_collared towhee_coltow1
+Pipilo maculatus x ocai_spotted x collared towhee (hybrid)_x00445
+Melozone/Pipilo sp._towhee sp._towhee1
+Atlapetes pileatus_rufous-capped brushfinch_rcbfin1
+Atlapetes albinucha_white-naped brushfinch_wnbfin1
+Atlapetes albinucha albinucha_white-naped brushfinch (White-naped)_whnbrf1
+Atlapetes albinucha [gutturalis Group]_white-naped brushfinch (Yellow-throated)_whnbrf2
+Atlapetes tibialis_yellow-thighed brushfinch_yetfin1
+Atlapetes luteoviridis_yellow-green brushfinch_yegfin1
+Atlapetes albofrenatus_moustached brushfinch_mobfin1
+Atlapetes albofrenatus albofrenatus_moustached brushfinch (Moustached)_moubru1
+Atlapetes albofrenatus meridae_moustached brushfinch (Merida)_moubru2
+Atlapetes personatus_tico-tico-do-tepui_tebfin1
+Atlapetes melanocephalus_santa marta brushfinch_smbfin1
+Atlapetes semirufus_ochre-breasted brushfinch_obbfin1
+Atlapetes flaviceps_yellow-headed brushfinch_yehbrf1
+Atlapetes fuscoolivaceus_dusky-headed brushfinch_dhbfin1
+Atlapetes albinucha x fuscoolivaceus_white-naped x dusky-headed brushfinch (hybrid)_x01092
+Atlapetes leucopis_white-rimmed brushfinch_wrbfin1
+Atlapetes albiceps_white-headed brushfinch_whbfin1
+Atlapetes rufigenis_rufous-eared brushfinch_rebfin1
+Atlapetes crassus_choco brushfinch_tribrf1
+Atlapetes tricolor_golden-crowned brushfinch_tribrf2
+Atlapetes schistaceus_northern slaty brushfinch_slabru1
+Atlapetes taczanowskii_peruvian slaty brushfinch_slabru2
+Atlapetes pallidinucha_pale-naped brushfinch_pnbfin1
+Atlapetes blancae_antioquia brushfinch_antbrf1
+Atlapetes latinuchus_yellow-breasted brushfinch_yebbrf1
+Atlapetes latinuchus nigrifrons_yellow-breasted brushfinch (nigrifrons)_yebbru1
+Atlapetes latinuchus [latinuchus Group]_yellow-breasted brushfinch (Yellow-breasted)_yebbru2
+Atlapetes leucopterus_white-winged brushfinch_wwbfin1
+Atlapetes leucopterus leucopterus/dresseri_white-winged brushfinch (White-winged)_whwbrf1
+Atlapetes leucopterus paynteri_white-winged brushfinch (Paynter's)_whwbrf2
+Atlapetes pallidiceps_pale-headed brushfinch_phbfin1
+Atlapetes seebohmi_bay-crowned brushfinch_bcbfin1
+Atlapetes nationi_rusty-bellied brushfinch_rbbfin1
+Atlapetes forbesi_apurimac brushfinch_apubrf1
+Atlapetes melanopsis_black-spectacled brushfinch_bksbrf1
+Atlapetes terborghi_vilcabamba brushfinch_vilbrf1
+Atlapetes canigenis_cuzco brushfinch_cuzbrf1
+Atlapetes melanolaemus_black-faced brushfinch_bkfbrf1
+Atlapetes rufinucha_bolivian brushfinch_rnbfin1
+Atlapetes melanolaemus x rufinucha_black-faced x bolivian brushfinch (hybrid)_x00477
+Atlapetes fulviceps_fulvous-headed brushfinch_fhbfin1
+Atlapetes citrinellus_yellow-striped brushfinch_ysbfin1
+Atlapetes sp._tico-tico (Atlapetes) sp._atlape1
+Passerellidae sp._escrevedeira sp._sparro1
+Calyptophilus tertius_western chat-tanager_wectan1
+Calyptophilus frugivorus_eastern chat-tanager_eactan1
+Phaenicophilus palmarum_black-crowned palm-tanager_bcptan1
+Phaenicophilus poliocephalus_gray-crowned palm-tanager_gcptan1
+Phaenicophilus palmarum x poliocephalus_black-crowned x gray-crowned palm-tanager (hybrid)_x00901
+Phaenicophilus palmarum/poliocephalus_black-crowned/gray-crowned palm-tanager_y01166
+Xenoligea montana_white-winged warbler_whwwar1
+Microligea palustris_green-tailed warbler_grtwar1
+Nesospingus speculiferus_puerto rican tanager_purtan1
+Spindalis zena_western spindalis_wesspi
+Spindalis zena zena_western spindalis (Bahamas Black-backed)_wesspi2
+Spindalis zena townsendi_western spindalis (Bahamas Green-backed)_wesspi3
+Spindalis zena pretrei_western spindalis (Cuban)_wesspi4
+Spindalis zena salvini_western spindalis (Grand Cayman I.)_wesspi5
+Spindalis zena benedicti_western spindalis (Cozumel I.)_wesspi6
+Spindalis nigricephala_jamaican spindalis_jamspi
+Spindalis dominicensis_hispaniolan spindalis_hisspi
+Spindalis portoricensis_puerto rican spindalis_purspi
+Zeledonia coronata_wrenthrush_wrenth1
+Teretistris fernandinae_yellow-headed warbler_yehwar1
+Teretistris fornsi_oriente warbler_oriwar1
+Teretistris fernandinae x fornsi_yellow-headed x oriente warbler (hybrid)_x00935
+Teretistris fernandinae/fornsi_yellow-headed/oriente warbler_y01167
+Icteria virens_yellow-breasted chat_yebcha
+Icteria virens virens_yellow-breasted chat (virens)_yebcha1
+Icteria virens auricollis_yellow-breasted chat (auricollis)_yebcha2
+Xanthocephalus xanthocephalus_graúna-de-cabeça-amarela_yehbla
+Dolichonyx oryzivorus_triste-pia_boboli
+Sturnella neglecta_western meadowlark_wesmea
+Sturnella magna_pedro-ceroulo_easmea
+Sturnella magna hippocrepis_pedro-ceroulo (hippocrepis)_easmea3
+Sturnella magna [magna Group]_pedro-ceroulo [grupo magna]_easmea2
+Sturnella neglecta x magna_western x eastern meadowlark (hybrid)_x00827
+Sturnella neglecta/magna_western/eastern meadowlark_meadow
+Sturnella lilianae_chihuahuan meadowlark_lilmea2
+Sturnella neglecta x lilianae_western x chihuahuan meadowlark (hybrid)_x01085
+Sturnella neglecta/lilianae_western/chihuahuan meadowlark_y01183
+Sturnella magna/lilianae_eastern/chihuahuan meadowlark_y01184
+Sturnella sp._Sturnella meadowlark sp._stumea1
+Leistes militaris_polícia-inglesa-do-norte_rebbla1
+Leistes superciliaris_polícia-inglesa-do-sul_whbbla2
+Leistes bellicosus_peruvian meadowlark_permea1
+Leistes defilippii_peito-vermelho-grande_pammea1
+Leistes loyca_long-tailed meadowlark_lotmea1
+Leistes loyca obscurus_long-tailed meadowlark (Sierran)_lotmea6
+Leistes loyca [loyca Group]_long-tailed meadowlark (Long-tailed)_lotmea5
+Leistes sp._Leistes sp._leiste1
+Amblycercus holosericeus_yellow-billed cacique_yebcac1
+Amblycercus holosericeus holosericeus/flavirostris_yellow-billed cacique (Prevost's)_yebcac2
+Amblycercus holosericeus australis_yellow-billed cacique (Chapman's)_yebcac3
+Cassiculus melanicterus_yellow-winged cacique_yewcac1
+Psarocolius angustifrons_japu-pardo_ruboro1
+Psarocolius angustifrons [angustifrons Group]_japu-pardo [grupo angustifrons]_ruboro2
+Psarocolius angustifrons oleagineus_japu-pardo (oleagineus)_ruboro3
+Psarocolius atrovirens_dusky-green oropendola_dugoro1
+Psarocolius viridis_japu-verde_greoro1
+Psarocolius decumanus_japu_creoro1
+Psarocolius wagleri_chestnut-headed oropendola_chhoro1
+Psarocolius montezuma_montezuma oropendola_monoro1
+Psarocolius guatimozinus_black oropendola_blaoro1
+Psarocolius cassini_baudo oropendola_bauoro2
+Psarocolius bifasciatus_japuguaçu_olioro1
+Psarocolius bifasciatus yuracares/neivae_japuguaçu (yuracares/neivae)_olioro2
+Psarocolius bifasciatus bifasciatus_japuguaçu (bifasciatus)_olioro3
+Psarocolius sp._psarocolius sp. (japu sp.)_oropen1
+Cacicus solitarius_iraúna-de-bico-branco_sobcac1
+Cacicus chrysopterus_tecelão_gowcac1
+Cacicus sclateri_ecuadorian cacique_ecucac1
+Cacicus koepckeae_selva cacique_selcac1
+Cacicus uropygialis_scarlet-rumped cacique_scrcac1
+Cacicus uropygialis microrhynchus_scarlet-rumped cacique (Scarlet-rumped)_scrcac2
+Cacicus uropygialis pacificus_scarlet-rumped cacique (Pacific)_scrcac3
+Cacicus uropygialis uropygialis_scarlet-rumped cacique (Subtropical)_scrcac4
+Cacicus cela_xexéu_yercac1
+Cacicus cela flavicrissus/vitellinus_xexéu (flavicrissus/vitellinus)_yercac3
+Cacicus cela cela_xexéu (cela)_yercac2
+Cacicus chrysonotus_mountain cacique_moucac1
+Cacicus chrysonotus leucoramphus/peruvianus_mountain cacique (Golden-shouldered)_moucac2
+Cacicus chrysonotus chrysonotus_mountain cacique (Bolivian)_moucac3
+Cacicus latirostris_japu-de-rabo-verde_batoro1
+Cacicus haemorrhous_guaxe_rercac1
+Cacicus oseryi_japu-de-capacete_casoro2
+Cacicus sp._Cacicus sp._caciqu1
+Icterus dominicensis_hispaniolan oriole_graori1
+Icterus melanopsis_cuban oriole_graori2
+Icterus northropi_bahama oriole_graori3
+Icterus portoricensis_puerto rican oriole_graori4
+Icterus laudabilis_st. lucia oriole_stlori1
+Icterus oberi_montserrat oriole_monori1
+Icterus bonana_martinique oriole_marori1
+Icterus wagleri_black-vented oriole_bkvori
+Icterus maculialatus_bar-winged oriole_bawori1
+Icterus prosthemelas_black-cowled oriole_bkcori
+Icterus spurius_orchard oriole_orcori
+Icterus spurius spurius_orchard oriole (Orchard)_orcori2
+Icterus spurius fuertesi_orchard oriole (Fuertes's)_orcori3
+Icterus cucullatus_hooded oriole_hooori
+Icterus cucullatus cucullatus/sennetti_hooded oriole (cucullatus/sennetti)_hooori2
+Icterus cucullatus [nelsoni Group]_hooded oriole (nelsoni Group)_hooori1
+Icterus cucullatus igneus_hooded oriole (igneus)_hooori3
+Icteria virens x Icterus cucullatus_yellow-breasted chat x hooded oriole (hybrid)_x00478
+Icterus spurius x cucullatus_orchard x hooded oriole (hybrid)_x01167
+Icterus spurius/cucullatus_orchard/hooded oriole_y00488
+Icterus chrysater_yellow-backed oriole_yebori1
+Icterus auricapillus_orange-crowned oriole_orcori1
+Icterus graceannae_white-edged oriole_wheori1
+Icterus mesomelas_yellow-tailed oriole_yetori1
+Icterus graceannae/mesomelas_white-edged/yellow-tailed oriole_y00927
+Icterus cayanensis_inhapim/rouxinol-do-rio-negro_epaori1
+Icterus cayanensis chrysocephalus_rouxinol-do-rio-negro_epaori2
+Icterus cayanensis cayanensis_inhapim_epaori3
+Icterus pyrrhopterus_encontro_epaori4
+Icterus pyrrhopterus tibialis_encontro (tibialis)_varori2
+Icterus pyrrhopterus [pyrrhopterus Group]_encontro [grupo pyrrhopterus]_varori1
+Icterus icterus_venezuelan troupial_ventro1
+Icterus jamacaii_corrupião_camtro1
+Icterus croconotus_joão-pinto_orbtro3
+Icterus icterus/croconotus/jamacaii_troupial sp._troupi1
+Icterus pustulatus_streak-backed oriole_stbori
+Icterus pustulatus [pustulatus Group]_streak-backed oriole (West Mexican)_stbori1
+Icterus pustulatus [sclateri Group]_streak-backed oriole (Streak-backed)_stbori3
+Icterus pustulatus graysonii_streak-backed oriole (Tres Marias Is.)_stbori2
+Icterus wagleri x pustulatus_black-vented x streak-backed oriole (hybrid)_x00490
+Icterus bullockii_bullock's oriole_bulori
+Icterus auratus_orange oriole_oraori1
+Icterus leucopteryx_jamaican oriole_jamori1
+Icterus nigrogularis_joão-pinto-amarelo_yelori1
+Icterus pectoralis_spot-breasted oriole_spbori
+Icterus gularis_altamira oriole_altori
+Icterus graduacauda_audubon's oriole_audori
+Icterus graduacauda graduacauda/audubonii_audubon's oriole (Audubon's)_audori1
+Icterus graduacauda dickeyae/nayaritensis_audubon's oriole (Dickey's)_audori2
+Icterus gularis x graduacauda_altamira x audubon's oriole (hybrid)_x00449
+Icterus galbula_corrupião-de-baltimore_balori
+Icterus bullockii x galbula_bullock's x baltimore oriole (hybrid)_x00013
+Icterus bullockii/galbula_bullock's/baltimore oriole_y00022
+Icterus abeillei_black-backed oriole_blbori1
+Icterus bullockii x abeillei_bullock's x black-backed oriole (hybrid)_x00903
+Icterus bullockii/abeillei_bullock's/black-backed oriole_y00630
+Icterus parisorum_scott's oriole_scoori
+Icterus sp._Icterus sp._oriole
+Nesopsar nigerrimus_jamaican blackbird_jambla1
+Agelaius phoeniceus_red-winged blackbird_rewbla
+Agelaius phoeniceus [phoeniceus Group]_red-winged blackbird (Red-winged)_rewbla1
+Agelaius phoeniceus californicus/mailliardorum_red-winged blackbird (California Bicolored)_rewbla2
+Agelaius phoeniceus gubernator_red-winged blackbird (Mexican Bicolored)_rewbla3
+Agelaius assimilis_red-shouldered blackbird_resbla1
+Agelaius tricolor_tricolored blackbird_tribla
+Agelaius phoeniceus/tricolor_red-winged/tricolored blackbird_y00651
+Agelaius humeralis_tawny-shouldered blackbird_tasbla
+Agelaius assimilis/humeralis_red-shouldered/tawny-shouldered blackbird_y00926
+Agelaius xanthomus_yellow-shouldered blackbird_yesbla1
+Molothrus rufoaxillaris_chupim-azeviche_scrcow1
+Molothrus bonariensis_chupim_shicow
+Molothrus rufoaxillaris/bonariensis_chupim-azeviche/chupim_y00828
+Molothrus aeneus_bronzed cowbird_brocow
+Molothrus aeneus [aeneus Group]_bronzed cowbird (Bronzed)_brocow1
+Molothrus aeneus armenti_bronzed cowbird (Bronze-brown)_brocow2
+Molothrus bonariensis/aeneus_shiny/bronzed cowbird_y01117
+Molothrus ater_chopim-mulato_bnhcow
+Molothrus bonariensis/ater_vira-bosta/chopim-mulato_y00336
+Molothrus aeneus/ater_bronzed/brown-headed cowbird_y00337
+Molothrus oryzivorus_iraúna-grande_giacow
+Dives dives_melodious blackbird_melbla1
+Dives warczewiczi_scrub blackbird_scrbla1
+Ptiloxena atroviolacea_cuban blackbird_cubbla
+Euphagus carolinus_rusty blackbird_rusbla
+Euphagus cyanocephalus_brewer's blackbird_brebla
+Euphagus carolinus/cyanocephalus_rusty/brewer's blackbird_y00227
+Quiscalus quiscula_common grackle_comgra
+Quiscalus quiscula quiscula/stonei_common grackle (Florida/Purple)_comgra1
+Quiscalus quiscula stonei_common grackle (Purple)_comgra3
+Quiscalus quiscula quiscula_common grackle (Florida)_comgra4
+Quiscalus quiscula versicolor_common grackle (Bronzed)_comgra2
+Quiscalus major_boat-tailed grackle_botgra
+Quiscalus major major_boat-tailed grackle (major)_botgra1
+Quiscalus major torreyi/alabamensis_boat-tailed grackle (torreyi/alabamensis)_botgra2
+Quiscalus major westoni_boat-tailed grackle (westoni)_botgra3
+Quiscalus mexicanus_great-tailed grackle_grtgra
+Quiscalus mexicanus [graysoni Group]_great-tailed grackle (Western)_grtgra1
+Quiscalus mexicanus [mexicanus Group]_great-tailed grackle (Great-tailed)_grtgra2
+Euphagus cyanocephalus x Quiscalus mexicanus_brewer's blackbird x great-tailed grackle (hybrid)_x00753
+Quiscalus quiscula x mexicanus_common x great-tailed grackle (hybrid)_x00479
+Quiscalus major x mexicanus_boat-tailed x great-tailed grackle (hybrid)_x00977
+Quiscalus major/mexicanus_boat-tailed/great-tailed grackle_y00629
+Quiscalus palustris_slender-billed grackle_slbgra1
+Quiscalus nicaraguensis_nicaraguan grackle_nicgra1
+Quiscalus niger_greater antillean grackle_gragra1
+Quiscalus lugubris_iraúna-do-norte_cargra1
+Quiscalus lugubris [lugubris Group]_iraúna-do-norte (Grupo lugubris)_cargra11
+Quiscalus lugubris fortirostris_iraúna-do-norte (fortirostris)_cargra7
+Quiscalus sp._grackle sp._grackl
+Hypopyrrhus pyrohypogaster_red-bellied grackle_rebgra1
+Lampropsar tanagrinus_iraúna-velada_vefgra1
+Gymnomystax mexicanus_iratauá-grande_oribla1
+Macroagelaius subalaris_mountain grackle_mougra1
+Macroagelaius imthurni_iraúna-da-guiana_gotgra1
+Curaeus curaeus_austral blackbird_ausbla1
+Amblyramphus holosericeus_cardeal-do-banhado_schbla1
+Anumara forbesi_anumará_forbla1
+Gnorimopsar chopi_pássaro-preto_chobla1
+Oreopsar bolivianus_bolivian blackbird_bolbla1
+Agelaioides badius_asa-de-telha_bawcow4
+Agelaioides fringillarius_asa-de-telha-pálido_bawcow3
+Agelaioides badius/fringillarius_asa-de-telha/asa-de-telha-pálido_bawcow2
+Agelasticus xanthophthalmus_pale-eyed blackbird_paebla2
+Agelasticus cyanopus_carretão/carretão-do-norte_unibla2
+Agelasticus cyanopus atroolivaceus/unicolor_carretão_unibla1
+Agelasticus cyanopus cyanopus_carretão-do-norte_unibla3
+Agelasticus thilius_sargento_yewbla2
+Chrysomus ruficapillus_garibaldi_chcbla2
+Chrysomus icterocephalus_iratauá-pequeno_yehbla2
+Xanthopsar flavus_veste-amarela_sacbla2
+Pseudoleistes guirahuro_chupim-do-brejo_yermar1
+Pseudoleistes virescens_dragão_baymar1
+Icteridae sp._Icteridae sp._blackb
+Seiurus aurocapilla_mariquita-de-coroa-ruiva_ovenbi1
+Helmitheros vermivorum_worm-eating warbler_woewar1
+Spizella passerina/Helmitheros vermivorum_chipping sparrow/worm-eating warbler_y00432
+Parkesia motacilla_abana-rabo-da-serra_louwat
+Parkesia noveboracensis_abana-rabo-de-baixada_norwat
+Parkesia motacilla/noveboracensis_abana-rabo-da-serra/de-baixada_y00598
+Vermivora bachmanii_bachman's warbler_bacwar
+Vermivora chrysoptera_mariquita-d'asa-amarela_gowwar
+Vermivora cyanoptera_mariquita-d'asas-azuis_buwwar
+Vermivora chrysoptera x cyanoptera_mariquita-d'asa-amarela x mariquita-d'asas-azuis (híbrido)_x00669
+Vermivora chrysoptera x cyanoptera (F1 hybrid)_mariquita-d'asa-amarela x mariquita-d'asas-azuis (híbrido F1)_brewar
+Vermivora chrysoptera x cyanoptera (F2 backcross)_mariquita-d'asa-amarela x mariquita-d'asas-azuis (híbrido F2 backcross)_lawwar
+Vermivora chrysoptera/cyanoptera_mariquita-d'asa-amarela/mariquita-d'asas-azuis_y00665
+Mniotilta varia_riscadinha_bawwar
+Protonotaria citrea_mariquita-protonotária_prowar
+Limnothlypis swainsonii_swainson's warbler_swawar
+Oreothlypis superciliosa_crescent-chested warbler_crcwar
+Oreothlypis gutturalis_flame-throated warbler_fltwar1
+Leiothlypis peregrina_mariquita-do-tenessi_tenwar
+Leiothlypis celata_orange-crowned warbler_orcwar
+Leiothlypis celata celata/orestera_orange-crowned warbler (Gray-headed)_orcwar5
+Leiothlypis celata celata_orange-crowned warbler (celata)_orcwar1
+Leiothlypis celata orestera_orange-crowned warbler (orestera)_orcwar2
+Leiothlypis celata lutescens_orange-crowned warbler (lutescens)_orcwar3
+Leiothlypis celata sordida_orange-crowned warbler (sordida)_orcwar4
+Leiothlypis crissalis_colima warbler_colwar
+Leiothlypis luciae_lucy's warbler_lucwar
+Leiothlypis ruficapilla_nashville warbler_naswar
+Leiothlypis ruficapilla ruficapilla_nashville warbler (ruficapilla)_naswar1
+Leiothlypis ruficapilla ridgwayi_nashville warbler (ridgwayi)_naswar2
+Leiothlypis peregrina x ruficapilla_tennessee x nashville warbler (hybrid)_x01013
+Leiothlypis celata x ruficapilla_orange-crowned x nashville warbler (hybrid)_x00819
+Leiothlypis virginiae_virginia's warbler_virwar
+Leiothlypis crissalis x virginiae_colima x virginia's warbler (hybrid)_x00638
+Leiothlypis crissalis/virginiae_colima/virginia's warbler_y01253
+Leiothlypis sp._Leiothlypis sp._vermiv1
+Leucopeza semperi_semper's warbler_semwar1
+Oporornis agilis_mariquita-de-connecticut_conwar
+Geothlypis poliocephala_gray-crowned yellowthroat_gycyel
+Geothlypis aequinoctialis_pia-cobra-do-norte_masyel2
+Geothlypis auricularis_black-lored yellowthroat_masyel4
+Geothlypis velata_pia-cobra-do-sul_masyel5
+Geothlypis aequinoctialis/auricularis/velata_masked yellowthroat sp._masyel1
+Geothlypis tolmiei_macgillivray's warbler_macwar
+Geothlypis philadelphia_mourning warbler_mouwar
+Oporornis agilis x Geothlypis philadelphia_connecticut x mourning warbler (hybrid)_x00746
+Geothlypis tolmiei x philadelphia_macgillivray's x mourning warbler (hybrid)_x00699
+Oporornis/Geothlypis sp. (Mourning-type)_connecticut/macgillivray's/mourning warbler_oporor1
+Geothlypis tolmiei/philadelphia_macgillivray's/mourning warbler_y00628
+Geothlypis formosa_kentucky warbler_kenwar
+Geothlypis philadelphia x formosa_mourning x kentucky warbler (hybrid)_x00747
+Geothlypis semiflava_olive-crowned yellowthroat_olcyel1
+Geothlypis semiflava bairdi_olive-crowned yellowthroat (Baird's)_olcyel2
+Geothlypis semiflava chiriquensis_olive-crowned yellowthroat (Chiriqui)_masyel3
+Geothlypis semiflava semiflava_olive-crowned yellowthroat (Olive-crowned)_olcyel3
+Geothlypis speciosa_black-polled yellowthroat_blpyel1
+Geothlypis beldingi_belding's yellowthroat_belyel1
+Geothlypis rostrata_bahama yellowthroat_bahyel1
+Geothlypis flavovelata_altamira yellowthroat_altyel1
+Geothlypis trichas_mariquita-de-mascarilha_comyel
+Geothlypis trichas [arizela Group]_mariquita-de-mascarilha [grupo arizela]_comyel1
+Geothlypis trichas [melanops Group]_mariquita-de-mascarilha [grupo melanops]_comyel2
+Geothlypis trichas [trichas Group]_mariquita-de-mascarilha [grupo trichas]_comyel3
+Geothlypis trichas insperata_mariquita-de-mascarilha (insperata)_comyel5
+Geothlypis trichas chapalensis_mariquita-de-mascarilha (chapalensis)_comyel4
+Geothlypis poliocephala x trichas_gray-crowned x common yellowthroat (hybrid)_x00748
+Geothlypis tolmiei x trichas_macgillivray's warbler x common yellowthroat (hybrid)_x00700
+Geothlypis philadelphia x trichas_mourning warbler x common yellowthroat (hybrid)_x00749
+Geothlypis formosa x trichas_kentucky warbler x common yellowthroat (hybrid)_x01014
+Geothlypis nelsoni_hooded yellowthroat_hooyel1
+Geothlypis sp. (yellowthroat sp.)_yellowthroat sp._yellow7
+Catharopeza bishopi_whistling warbler_whiwar1
+Setophaga plumbea_plumbeous warbler_pluwar1
+Setophaga angelae_elfin-woods warbler_elwwar1
+Setophaga pharetra_arrowhead warbler_arrwar1
+Setophaga citrina_mariquita-de-capuz_hoowar
+Setophaga ruticilla_mariquita-de-rabo-vermelho_amered
+Setophaga kirtlandii_kirtland's warbler_kirwar
+Setophaga tigrina_mariquita-do-cabo-may_camwar
+Setophaga cerulea_mariquita-azul_cerwar
+Vermivora cyanoptera x Setophaga cerulea_mariquita-d'asas-azuis x mariquita-celeste (híbrido)_x00480
+Setophaga americana_mariquita-do-norte_norpar
+Setophaga ruticilla x americana_mariquita-de-rabo-vermelho x mariquita-do-norte (híbrido)_x00750
+Setophaga cerulea x americana_mariquita-azul x mariquita-do-norte (híbrido)_x00711
+Setophaga pitiayumi_mariquita_tropar
+Setophaga pitiayumi nigrilora_mariquita (nigrilora)_tropar1
+Setophaga pitiayumi pulchra_mariquita (pulchra)_tropar2
+Setophaga pitiayumi insularis_mariquita (insularis)_tropar3
+Setophaga pitiayumi graysoni_mariquita (graysoni)_tropar4
+Setophaga pitiayumi inornata_mariquita (inornata)_tropar5
+Setophaga pitiayumi cirrha_mariquita (cirrha)_tropar7
+Setophaga pitiayumi [pitiayumi Group]_mariquita [grupo pitiayumi]_tropar9
+Setophaga americana x pitiayumi_mariquita-do-norte x mariquita (híbrido)_x00203
+Setophaga americana/pitiayumi_mariquita-do-norte/mariquita_y00827
+Setophaga magnolia_mariquita-de-faces-pretas_magwar
+Leiothlypis ruficapilla x Setophaga magnolia_nashville x magnolia warbler (hybrid)_x00820
+Setophaga ruticilla x magnolia_american redstart x magnolia warbler (hybrid)_x01072
+Setophaga tigrina x magnolia_cape may x magnolia warbler (hybrid)_x01073
+Setophaga castanea_mariquita-de-peito-castanho_babwar
+Setophaga fusca_mariquita-papo-de-fogo_bkbwar
+Setophaga castanea x fusca_mariquita-de-peito-castanho x mariquita-papo-de-fogo (híbrido)_x00821
+Setophaga petechia_mariquita-amarela_yelwar
+Setophaga petechia [aestiva Group]_mariquita-amarela [grupo aestiva]_yelwar1
+Setophaga petechia [erithachorides Group]_mariquita-amarela [grupo erithachorides]_maywar1
+Setophaga petechia aureola_mariquita-amarela (aureola)_yelwar3
+Setophaga petechia [petechia Group]_mariquita-amarela [grupo petechia]_yelwar2
+Setophaga petechia [erithachorides Group x petechia Group]_mariquita-amarela [erithachorides x petechia]_yelwar4
+Geothlypis trichas x Setophaga petechia_mariquita-de-mascarilha x mariquita-dos-mangais (híbrido)_x00701
+Setophaga citrina x petechia_mariquita-de-capuz x mariquita-dos-mangais (híbrido)_x00822
+Setophaga ruticilla x petechia_mariquita-de-rabo-vermelho x mariquita-dos-mangais (híbrido)_x00481
+Setophaga pensylvanica_mariquita-de-flancos-castanhos_chswar
+Vermivora chrysoptera x cyanoptera (F1 hybrid) x pensylvanica_mariquita-d'asa-amarela x mariquita-d'asas-azuis (híbrido F1) x mariquita-de-flancos-castanhos_x01162
+Setophaga ruticilla x pensylvanica_mariquita-de-rabo-vermelho x mariquita-de-flancos-castanhos (híbrido)_x01163
+Setophaga magnolia x pensylvanica_mariquita-de-faces-pretas x mariquita-de-flancos-castanhos (híbrido)_x00772
+Setophaga striata_mariquita-de-perna-clara_bkpwar
+Setophaga castanea x striata_mariquita-de-peito-castanho x mariquita-de-perna-clara (híbrido)_x00894
+Setophaga castanea/striata_mariquita-de-peito-castanho/mariquita-de-perna-clara_y00627
+Setophaga caerulescens_mariquita-azul-de-garganta-preta_btbwar
+Setophaga cerulea x caerulescens_mariquita-celeste x mariquita-azul-de-garganta-preta (híbrido)_x00482
+Setophaga magnolia x caerulescens_mariquita-de-faces-pretas x mariquita-azul-de-garganta-preta (híbrido)_x00978
+Setophaga petechia x caerulescens_yellow x black-throated blue warbler (hybrid)_x01015
+Setophaga pensylvanica x caerulescens_mariquita-de-flancos-castanhos x mariquita-azul-de-garganta-preta (híbrido)_x00483
+Setophaga palmarum_mariquita-de-barrete-castanho_palwar
+Setophaga palmarum palmarum_mariquita-de-barrete-castanho (palmarum)_palwar3
+Setophaga palmarum hypochrysea_mariquita-de-barrete-castanho (hypochrysea)_palwar4
+Setophaga magnolia x palmarum_mariquita-de-faces-pretas x mariquita-de-barrete-castanho (híbrido)_x00979
+Setophaga pityophila_olive-capped warbler_olcwar1
+Setophaga pinus_pine warbler_pinwar
+Junco hyemalis/Setophaga pinus_dark-eyed junco/pine warbler_y00433
+Setophaga coronata_mariquita-coroada_yerwar
+Setophaga coronata coronata_mariquita-coroada (coronata)_myrwar
+Setophaga coronata auduboni_mariquita-coroada (auduboni)_audwar
+Setophaga coronata coronata x auduboni_mariquita-coroada (coronata x auduboni)_yerwar3
+Setophaga coronata nigrifrons_mariquita-coroada (nigrifrons)_yerwar1
+Setophaga coronata goldmani_mariquita-coroada (goldmani)_yerwar2
+Setophaga tigrina x coronata_mariquita-do-cabo-may x mariquita-coroada (híbrido)_x00980
+Setophaga magnolia x coronata_mariquita-de-faces-pretas x mariquita-coroada (híbrido)_x00773
+Setophaga palmarum x coronata_mariquita-de-barrete-castanho x mariquita-coroada (híbrido)_x00461
+Setophaga dominica_mariquita-de-garganta-amarela_yetwar
+Setophaga dominica albilora_mariquita-de-garganta-amarela (albilora)_yetwar1
+Setophaga dominica dominica/stoddardi_mariquita-de-garganta-amarela (dominica/stoddardi)_yetwar2
+Setophaga americana x dominica_mariquita-do-norte x mariquita-de-garganta-amarela (híbrido)_sutwar
+Setophaga pinus x dominica_pine x yellow-throated warbler (hybrid)_x01128
+Setophaga coronata x dominica_mariquita-coroada x mariquita-de-garganta-amarela (híbrido)_x00937
+Setophaga flavescens_bahama warbler_yetwar3
+Setophaga vitellina_vitelline warbler_vitwar1
+Setophaga discolor_prairie warbler_prawar
+Vermivora cyanoptera x Setophaga discolor_blue-winged x prairie warbler (hybrid)_x00719
+Setophaga petechia x discolor_yellow x prairie warbler (hybrid)_x00866
+Setophaga adelaidae_adelaide's warbler_adewar1
+Setophaga subita_barbuda warbler_barwar
+Setophaga delicata_st. lucia warbler_stlwar
+Setophaga graciae_grace's warbler_grawar
+Setophaga coronata x graciae_yellow-rumped x grace's warbler (hybrid)_x00484
+Setophaga nigrescens_black-throated gray warbler_btywar
+Setophaga americana x nigrescens_northern parula x black-throated gray warbler (hybrid)_x01081
+Setophaga coronata x nigrescens_yellow-rumped x black-throated gray warbler (hybrid)_x00895
+Setophaga graciae x nigrescens_grace's x black-throated gray warbler (hybrid)_x00639
+Setophaga townsendi_townsend's warbler_towwar
+Setophaga coronata x townsendi_yellow-rumped x townsend's warbler (hybrid)_x00624
+Setophaga nigrescens x townsendi_black-throated gray x townsend's warbler (hybrid)_x00867
+Setophaga nigrescens/townsendi_black-throated gray/townsend's warbler_y01014
+Setophaga occidentalis_hermit warbler_herwar
+Setophaga coronata x occidentalis_yellow-rumped x hermit warbler (hybrid)_x01074
+Setophaga nigrescens x occidentalis_black-throated gray x hermit warbler (hybrid)_x00485
+Setophaga townsendi x occidentalis_townsend's x hermit warbler (hybrid)_x00059
+Setophaga nigrescens/occidentalis_black-throated gray/hermit warbler_y00605
+Setophaga nigrescens/townsendi/occidentalis_black-throated gray/townsend's/hermit warbler_y01254
+Setophaga townsendi/occidentalis_townsend's/hermit warbler_y00645
+Setophaga chrysoparia_golden-cheeked warbler_gchwar
+Setophaga virens_mariquita-de-garganta-preta_btnwar
+Setophaga coronata x virens_mariquita-coroada x mariquita-verde-de-garganta-preta (híbrido)_x00486
+Setophaga townsendi x virens_townsend's x black-throated green warbler (hybrid)_x00664
+Setophaga sp._Setophaga sp._dendro3
+Basileuterus lachrymosus_fan-tailed warbler_fatwar
+Basileuterus rufifrons_rufous-capped warbler_rucwar
+Basileuterus rufifrons [rufifrons Group]_rufous-capped warbler (rufifrons Group)_rucwar2
+Basileuterus rufifrons salvini_rufous-capped warbler (salvini)_rucwar3
+Geothlypis trichas x Basileuterus rufifrons_common yellowthroat x rufous-capped warbler (hybrid)_x00751
+Basileuterus delattrii_chestnut-capped warbler_rucwar4
+Basileuterus rufifrons/delattrii_rufous-capped/chestnut-capped warbler_y00434
+Basileuterus melanogenys_black-cheeked warbler_blcwar1
+Basileuterus [undescribed form]_azuero warbler (undescribed form)_azuwar1
+Basileuterus ignotus_pirre warbler_pirwar1
+Basileuterus belli_golden-browed warbler_gobwar1
+Basileuterus culicivorus_pula-pula_gcrwar
+Basileuterus culicivorus [culicivorus Group]_pula-pula [grupo culicivorus]_gocwar1
+Basileuterus culicivorus [cabanisi Group]_pula-pula [grupo cabanisi]_gocwar3
+Basileuterus culicivorus [auricapilla Group]_pula-pula (grupo auricapillus)_gocwar2
+Basileuterus culicivorus hypoleucus_pula-pula (hypoleucus)_whbwar1
+Basileuterus melanotis_costa rican warbler_thswar5
+Basileuterus tacarcunae_tacarcuna warbler_thswar9
+Basileuterus tristriatus_three-striped warbler_thswar1
+Basileuterus tristriatus sanlucasensis_three-striped warbler (San Lucas)_thswar3
+Basileuterus tristriatus daedalus_three-striped warbler (daedalus)_thswar6
+Basileuterus tristriatus auricularis_three-striped warbler (auricularis)_thswar4
+Basileuterus tristriatus meridanus/bessereri_three-striped warbler (Venezuelan)_thswar7
+Basileuterus tristriatus pariae_three-striped warbler (Paria)_thswar8
+Basileuterus tristriatus tristriatus/baezae_three-striped warbler (Three-striped)_thswar10
+Basileuterus punctipectus_yungas warbler_thswar2
+Basileuterus trifasciatus_three-banded warbler_thbwar2
+Basileuterus sp._Basileuterus sp._basile1
+Myiothlypis griseiceps_gray-headed warbler_gyhwar1
+Myiothlypis basilica_santa marta warbler_samwar1
+Myiothlypis luteoviridis_citrine warbler_citwar1
+Myiothlypis luteoviridis [luteoviridis Group]_citrine warbler (Northern)_citwar2
+Myiothlypis luteoviridis striaticeps_citrine warbler (Peruvian)_citwar3
+Myiothlypis luteoviridis euophrys_citrine warbler (Bolivian)_citwar4
+Myiothlypis leucophrys_pula-pula-de-sobrancelha_whswar2
+Myiothlypis flaveola_canário-do-mato_flawar1
+Basileuterus culicivorus x Myiothlypis flaveola_pula-pula x canário-do-mato (híbrido)_x00487
+Myiothlypis leucoblephara_pula-pula-assobiador_whbwar2
+Myiothlypis signata_pale-legged warbler_palwar1
+Myiothlypis nigrocristata_black-crested warbler_blcwar2
+Myiothlypis fulvicauda_pula-pula-de-cauda-avermelhada_burwar1
+Myiothlypis rivularis_pula-pula-ribeirinho/pula-pula-da-guiana_rivwar1
+Myiothlypis rivularis mesoleuca_pula-pula-da-guiana_rivwar2
+Myiothlypis rivularis boliviana_riverbank warbler (Bolivian)_rivwar5
+Myiothlypis rivularis rivularis_riverbank warbler (Southern)_rivwar4
+Myiothlypis bivittata_pula-pula-de-duas-fitas_twbwar1
+Myiothlypis bivittata roraimae_pula-pula-de-duas-fitas (roraimae)_twbwar2
+Myiothlypis bivittata bivittata/argentinae_pula-pula-de-duas-fitas (bivittata/argentinae)_twbwar3
+Myiothlypis chlorophrys_choco warbler_gobwar4
+Myiothlypis chrysogaster_cuzco warbler_gobwar3
+Myiothlypis cinereicollis_gray-throated warbler_gytwar1
+Myiothlypis conspicillata_white-lored warbler_whlwar1
+Myiothlypis fraseri_gray-and-gold warbler_gagwar2
+Myiothlypis coronata_russet-crowned warbler_rucwar1
+Myiothlypis sp._Myiothlypis sp._myioth1
+Cardellina canadensis_mariquita-do-canadá_canwar
+Cardellina pusilla_mariquita-de-barrete-preto_wlswar
+Cardellina pusilla pileolata_mariquita-de-barrete-preto (pileolata)_wilwar1
+Cardellina pusilla pusilla_mariquita-de-barrete-preto (pusilla)_wilwar2
+Cardellina pusilla chryseola_mariquita-de-barrete-preto (chryseola)_wilwar3
+Cardellina rubrifrons_red-faced warbler_refwar
+Cardellina rubra_red warbler_redwar1
+Cardellina rubra melanauris_red warbler (Gray-cheeked)_redwar2
+Cardellina rubra rubra/rowleyi_red warbler (White-cheeked)_redwar3
+Cardellina versicolor_pink-headed warbler_pihwar1
+Myioborus pictus_painted redstart_paired
+Myioborus miniatus_mariquita-cinza_sltred
+Myioborus pictus x miniatus_painted x slate-throated redstart (hybrid)_x00896
+Myioborus brunniceps_brown-capped redstart_brcred1
+Myioborus castaneocapilla_mariquita-de-cabeça-parda_tepred1
+Myioborus pariae_paria redstart_parred1
+Myioborus cardonai_saffron-breasted redstart_sabred1
+Myioborus albifacies_white-faced redstart_whfred1
+Myioborus torquatus_collared redstart_colred1
+Myioborus flavivertex_yellow-crowned redstart_yecred1
+Myioborus ornatus_golden-fronted redstart_gofred1
+Myioborus ornatus chrysops_golden-fronted redstart (Golden-fronted)_gofred2
+Myioborus ornatus ornatus_golden-fronted redstart (Yellow-fronted)_gofred3
+Myioborus melanocephalus_spectacled redstart_spered1
+Myioborus ornatus x melanocephalus_golden-fronted x spectacled redstart (hybrid)_x00868
+Myioborus ornatus/melanocephalus_golden-fronted/spectacled redstart_y01168
+Myioborus albifrons_white-fronted redstart_whfred2
+Myioborus sp._Myioborus sp._myiobo1
+Parulidae sp._Parulidae sp._warble
+Passerellidae/Parulidae sp. (trilling song)_sparrow/warbler sp. (trilling song)_y00435
+Mitrospingus cassinii_dusky-faced tanager_duftan1
+Mitrospingus oleagineus_pipira-olivácea_olbtan1
+Lamprospiza melanoleuca_pipira-de-bico-vermelho_rbptan1
+Orthogonys chloricterus_catirumbava_olgtan1
+Piranga roseogularis_rose-throated tanager_rottan1
+Piranga flava_sanhaço-montano/de-fogo_heptan
+Piranga flava [hepatica Group]_sanhaço-montano/de-fogo [grupo hepatica]_heptan1
+Piranga flava [lutea Group]_sanhaço-montano_heptan2
+Piranga flava [flava Group]_sanhaço-de-fogo_heptan3
+Piranga rubra_sanhaço-vermelho_sumtan
+Piranga flava/rubra_sanhaço-montano/de-fogo/sanhaço-vermelho_y00924
+Piranga olivacea_sanhaço-escarlate_scatan
+Piranga rubra x olivacea_summer x scarlet tanager (hybrid)_x01079
+Piranga rubra/olivacea_sanhaço-de-fogo-migrador/sanhaço-d'asa-preta_y00925
+Piranga ludoviciana_western tanager_westan
+Piranga rubra x ludoviciana_summer x western tanager (hybrid)_x00824
+Piranga olivacea x ludoviciana_scarlet x western tanager (hybrid)_x00825
+Piranga bidentata_flame-colored tanager_flctan
+Piranga flava x bidentata_hepatic x flame-colored tanager (hybrid)_x00826
+Piranga ludoviciana x bidentata_western x flame-colored tanager (hybrid)_x00444
+Piranga leucoptera_sanhaço-de-asa-branca_whwtan1
+Piranga erythrocephala_red-headed tanager_rehtan1
+Piranga rubriceps_red-hooded tanager_rehtan2
+Piranga sp._Piranga sp._pirang1
+Habia rubica_tiê-de-bando/do-mato-grosso_rcatan1
+Habia rubica affinis/rosea_tiê-do-mato-grosso (affinis/rosea)_recant21
+Habia rubica [rubicoides Group]_tiê-de-bando/do-mato-grosso [grupo rubicoides]_recant1
+Habia rubica [rubra Group]_tiê-do-mato-grosso_recant2
+Habia rubica perijana_tiê-do-mato-grosso (perijana)_recant14
+Habia rubica rubica/bahiae_tiê-de-bando_recant3
+Driophlox fuscicauda_red-throated ant-tanager_rtatan1
+Driophlox fuscicauda [salvini Group]_red-throated ant-tanager (Salvin's)_retant1
+Driophlox fuscicauda [fuscicauda Group]_red-throated ant-tanager (Red-throated)_retant2
+Driophlox gutturalis_sooty ant-tanager_soatan1
+Driophlox atrimaxillaris_black-cheeked ant-tanager_bcatan1
+Driophlox cristata_crested ant-tanager_cratan1
+Habia/Driophlox sp._Habia/Driophlox sp._anttan1
+Chlorothraupis carmioli_carmiol's tanager_olitan1
+Chlorothraupis frenata_yellow-lored tanager_cartan2
+Chlorothraupis olivacea_lemon-spectacled tanager_lestan
+Chlorothraupis stolzmanni_ochre-breasted tanager_ocbtan1
+Chlorothraupis sp._Chlorothraupis sp._chloro4
+Periporphyrus celaeno_crimson-collared grosbeak_crcgro
+Periporphyrus erythromelas_bicudo-encarnado_rabgro1
+Caryothraustes poliogaster_black-faced grosbeak_blfgro1
+Caryothraustes poliogaster poliogaster_black-faced grosbeak (Northern)_bkfgro1
+Caryothraustes poliogaster scapularis_black-faced grosbeak (Southern)_bkfgro2
+Caryothraustes canadensis_furriel/furriel-do-norte_yeggro1
+Cardinalis phoeniceus_vermilion cardinal_vercar1
+Cardinalis cardinalis_northern cardinal_norcar
+Cardinalis cardinalis [cardinalis Group]_northern cardinal (Common)_norcar1
+Cardinalis cardinalis carneus_northern cardinal (Long-crested)_norcar2
+Cardinalis sinuatus_pyrrhuloxia_pyrrhu
+Cardinalis cardinalis x sinuatus_northern cardinal x pyrrhuloxia (hybrid)_x00774
+Cardinalis cardinalis/sinuatus_northern cardinal/pyrrhuloxia_y00647
+Pheucticus chrysopeplus_yellow grosbeak_yelgro
+Pheucticus chrysopeplus chrysopeplus/dilutus_yellow grosbeak (Northern)_yelgro2
+Pheucticus chrysopeplus aurantiacus_yellow grosbeak (Guatemalan)_yelgro1
+Pheucticus chrysogaster_golden grosbeak_gobgro1
+Pheucticus tibialis_black-thighed grosbeak_bltgro1
+Pheucticus aureoventris_rei-do-bosque_blbgro2
+Pheucticus aureoventris meridensis_rei-do-bosque (meridensis)_bkbgro2
+Pheucticus aureoventris crissalis_rei-do-bosque (crissalis)_bkbgro3
+Pheucticus aureoventris uropygialis/terminalis_rei-do-bosque (uropygialis/terminalis)_bkbgro4
+Pheucticus aureoventris aureoventris_rei-do-bosque (aureoventris)_bkbgro1
+Pheucticus ludovicianus_bico-grosso-de-peito-rosa_robgro
+Piranga olivacea x Pheucticus ludovicianus_scarlet tanager x rose-breasted grosbeak (hybrid)_x01002
+Pheucticus melanocephalus_black-headed grosbeak_bkhgro
+Pheucticus ludovicianus x melanocephalus_rose-breasted x black-headed grosbeak (hybrid)_x00448
+Pheucticus ludovicianus/melanocephalus_rose-breasted/black-headed grosbeak_y00334
+Pheucticus sp._Pheucticus sp._pheuct1
+Granatellus venustus_red-breasted chat_rebcha1
+Granatellus venustus venustus_red-breasted chat (Red-breasted)_rebcha2
+Granatellus venustus francescae_red-breasted chat (Tres Marias Is.)_rebcha3
+Granatellus sallaei_gray-throated chat_grtcha1
+Granatellus pelzelni_polícia-do-mato_robcha1
+Granatellus pelzelni pelzelni_polícia-do-mato (pelzelni)_robcha2
+Granatellus pelzelni paraensis_polícia-do-mato (paraensis)_robcha3
+Amaurospiza concolor_blue seedeater_blusee1
+Amaurospiza concolor relicta_blue seedeater (Slate-blue)_blusee2
+Amaurospiza concolor concolor_blue seedeater (Blue)_blusee3
+Amaurospiza aequatorialis_ecuadorian seedeater_blusee4
+Amaurospiza carrizalensis_carrizal seedeater_carsee1
+Amaurospiza moesta_negrinho-do-mato_blbsee3
+Cyanoloxia glaucocaerulea_azulinho_glbgro1
+Cyanoloxia cyanoides_blue-black grosbeak_bubgro1
+Cyanoloxia rothschildii_azulão-da-amazônia_bubgro2
+Cyanoloxia cyanoides/rothschildii_blue-black/amazonian grosbeak_y01068
+Cyanoloxia brissonii_azulão_ultgro1
+Cyanoloxia glaucocaerulea/brissonii_glaucous-blue grosbeak/azulão_y00436
+Cyanocompsa parellina_blue bunting_blubun
+Cyanocompsa parellina parellina/beneplacita_blue bunting (Middle America)_blubun1
+Cyanocompsa parellina indigotica_blue bunting (West Mexico)_blubun2
+Passerina caerulea_blue grosbeak_blugrb1
+Passerina amoena_lazuli bunting_lazbun
+Passerina cyanea_mariposa-azul_indbun
+Passerina caerulea x cyanea_blue grosbeak x indigo bunting (hybrid)_x00872
+Passerina amoena x cyanea_lazuli x indigo bunting (hybrid)_ixlbun
+Passerina amoena/cyanea_lazuli/indigo bunting_y00335
+Passerina rositae_rose-bellied bunting_robbun1
+Passerina leclancherii_orange-breasted bunting_orbbun1
+Passerina versicolor_varied bunting_varbun
+Passerina cyanea x versicolor_indigo x varied bunting (hybrid)_x01076
+Passerina ciris_painted bunting_paibun
+Passerina cyanea x ciris_indigo x painted bunting (hybrid)_x00918
+Passerina versicolor x ciris_varied x painted bunting (hybrid)_x00902
+Passerina sp._Passerina sp._buntin
+Spiza americana_papa-capim-americano_dickci
+Orchesticus abeillei_sanhaço-pardo_brotan1
+Paroaria coronata_cardeal_reccar
+Paroaria dominicana_cardeal-do-nordeste_reccar2
+Paroaria nigrogenis_masked cardinal_reccar3
+Paroaria gularis_cardeal-da-amazônia/cardeal-da-bolívia_reccar4
+Paroaria gularis gularis_cardeal-da-amazônia_reccar5
+Paroaria gularis cervicalis_cardeal-da-bolívia_reccar6
+Paroaria coronata x gularis_cardeal-do-nordeste x cardeal-da-amazônia/cardeal-da-bolívia (híbrido)_x00488
+Paroaria nigrogenis/gularis_masked/red-capped cardinal_reccar1
+Paroaria baeri_cardeal-do-araguaia/do-xingu_crfcar1
+Paroaria baeri baeri_cardeal-do-araguaia_crfcar2
+Paroaria baeri xinguensis_cardeal-do-xingu_crfcar3
+Paroaria gularis x baeri_cardeal-da-amazônia x cardeal-do-araguaia (híbrido)_x00897
+Paroaria gularis/baeri_cardeal-da-amazônia/cardeal-do-araguaia_y01169
+Paroaria capitata_cavalaria_yebcar
+Paroaria sp._Paroaria sp._paroar1
+Schistochlamys melanopis_sanhaço-de-coleira_blftan1
+Schistochlamys ruficapillus_bico-de-veludo_cintan1
+Cissopis leverianus_tietinga_magtan2
+Neothraupis fasciata_cigarra-do-campo_whbtan1
+Conothraupis speculigera_tiê-preto-e-branco_bawtan1
+Conothraupis mesoleuca_tiê-bicudo_cobtan2
+Compsothraupis loricata_tiê-caburé_scttan1
+Sericossypha albocristata_white-capped tanager_whctan1
+Nemosia pileata_saíra-de-chapéu-preto_hootan1
+Nemosia rourei_saíra-apunhalada_chttan1
+Creurgops verticalis_rufous-crested tanager_ructan4
+Creurgops dentatus_slaty tanager_slatan2
+Kleinothraupis atropileus_black-capped hemispingus_blchem1
+Kleinothraupis atropileus atropileus_black-capped hemispingus (Black-capped)_bkchem1
+Kleinothraupis atropileus auricularis_black-capped hemispingus (White-browed)_bkchem2
+Kleinothraupis calophrys_orange-browed hemispingus_orbhem1
+Kleinothraupis parodii_parodi's hemispingus_parhem1
+Kleinothraupis reyi_gray-capped hemispingus_gychem1
+Sphenopsis frontalis_oleaginous hemispingus_olehem1
+Sphenopsis melanotis_black-eared hemispingus_blehem1
+Sphenopsis melanotis [melanotis Group]_black-eared hemispingus (Black-eared)_bkehem2
+Sphenopsis melanotis ochracea_black-eared hemispingus (Western)_bkehem3
+Sphenopsis melanotis piurae/macrophrys_black-eared hemispingus (Piura)_bkehem1
+Thlypopsis sordida_saí-canário_orhtan1
+Thlypopsis sordida chrysopis/orinocensis_saí-canário (chrysopis/orinocensis)_orhtan5
+Thlypopsis sordida sordida_saí-canário (sordida)_orhtan4
+Thlypopsis inornata_buff-bellied tanager_bubtan1
+Thlypopsis fulviceps_fulvous-headed tanager_fuhtan1
+Thlypopsis pyrrhocoma_cabecinha-castanha_chhtan1
+Thlypopsis ruficeps_rust-and-yellow tanager_raytan1
+Thlypopsis superciliaris_superciliaried hemispingus_suphem1
+Thlypopsis superciliaris chrysophrys_superciliaried hemispingus (Yellow-browed)_suphem5
+Thlypopsis superciliaris [superciliaris Group]_superciliaried hemispingus (Superciliaried)_suphem2
+Thlypopsis superciliaris leucogastra/insignis_superciliaried hemispingus (White-bellied)_suphem4
+Thlypopsis superciliaris urubambae_superciliaried hemispingus (urubambae)_suphem3
+Thlypopsis ornata_rufous-chested tanager_ructan3
+Thlypopsis pectoralis_brown-flanked tanager_brftan1
+Thlypopsis sp._Thlypopsis sp._thlypo1
+Microspingus alticola_plain-tailed warbling finch_ptwfin1
+Microspingus erythrophrys_rusty-browed warbling finch_rbwfin2
+Microspingus lateralis_quete-do-sudeste_rrwfin1
+Microspingus cabanisi_quete-do-sul_gytwaf1
+Microspingus torquatus_ringed warbling finch_riwfin1
+Microspingus torquatus torquatus_ringed warbling finch (Ringed)_rinwaf1
+Microspingus torquatus pectoralis_ringed warbling finch (Black-breasted)_rinwaf2
+Microspingus melanoleucus_capacetinho_bcwfin2
+Microspingus cinereus_capacetinho-do-oco-do-pau_ciwfin1
+Microspingus trifasciatus_three-striped hemispingus_thshem1
+Nephelornis oneilli_pardusco_pardus2
+Trichothraupis melanops_tiê-de-topete_blgtan1
+Eucometis penicillata_pipira-da-taoca_grhtan1
+Eucometis penicillata [spodocephalus Group]_pipira-da-taoca [grupo spodocephalus]_gyhtan1
+Eucometis penicillata [penicillata Group]_pipira-da-taoca [grupo penicillata]_gyhtan2
+Heliothraupis oneilli_inti tanager_saptan1
+Loriotus cristatus_tiê-galo/pipira-de-natterer_flctan1
+Loriotus cristatus [cristatus Group]_tiê-galo_flctan2
+Loriotus cristatus nattereri_pipira-de-natterer_flctan3
+Loriotus rufiventer_tem-tem-de-crista-amarela_yectan1
+Loriotus luctuosus_tem-tem-de-dragona-branca_whstan1
+Loriotus luctuosus nitidissimus_tem-tem-d'ombros-brancos (nitidissimus)_whstan3
+Loriotus luctuosus [luctuosus Group]_tem-tem-d'ombros-brancos (Grupo luctuosus)_whstan7
+Tachyphonus surinamus_tem-tem-de-topete-ferrugíneo_fuctan1
+Loriotus cristatus/Tachyphonus surinamus_tiê-galo/pipira-de-natterer/tem-tem-de-topete-ferrugíneo_y00919
+Tachyphonus delatrii_tawny-crested tanager_tactan1
+Tachyphonus coronatus_tiê-preto_ructan1
+Tachyphonus rufus_pipira-preta_whltan1
+Tachyphonus phoenicius_tem-tem-de-dragona-vermelha_restan1
+Tachyphonus sp._Tachyphonus sp._tachyp1
+Lanio fulvus_pipira-parda_fustan1
+Lanio versicolor_pipira-de-asa-branca_wwstan1
+Lanio aurantius_black-throated shrike-tanager_btstan1
+Lanio leucothorax_white-throated shrike-tanager_wtstan1
+Lanio leucothorax leucothorax_white-throated shrike-tanager (White-throated)_whtsht3
+Lanio leucothorax [melanopygius Group]_white-throated shrike-tanager (Black-rumped)_whtsht7
+Ramphocelus sanguinolentus_crimson-collared tanager_crctan1
+Ramphocelus flammigerus_flame-rumped tanager_flrtan1
+Ramphocelus flammigerus flammigerus_flame-rumped tanager (Flame-rumped)_flrtan2
+Ramphocelus flammigerus icteronotus_flame-rumped tanager (Lemon-rumped)_flrtan3
+Ramphocelus flammigerus flammigerus x icteronotus_flame-rumped tanager (Flame-rumped x Lemon-rumped)_flrtan4
+Ramphocelus passerinii_scarlet-rumped tanager_y00599
+Ramphocelus passerinii passerinii_scarlet-rumped tanager (Passerini's)_pastan1
+Ramphocelus passerinii costaricensis_scarlet-rumped tanager (Cherrie's)_chetan1
+Ramphocelus flammigerus x passerinii_flame-rumped x scarlet-rumped tanager (hybrid)_x00489
+Ramphocelus bresilius_tiê-sangue_bratan1
+Ramphocelus melanogaster_black-bellied tanager_bkbtan1
+Ramphocelus carbo_pipira-vermelha_sibtan2
+Ramphocelus nigrogularis_pipira-de-máscara_mactan1
+Ramphocelus dimidiatus_crimson-backed tanager_crbtan1
+Ramphocelus passerinii x dimidiatus_scarlet-rumped x crimson-backed tanager (hybrid)_x00898
+Ramphocelus sp._Ramphocelus sp._rampho2
+Calochaetes coccineus_vermilion tanager_vertan1
+Cyanicterus cyanicterus_pipira-azul_blbtan2
+Bangsia arcaei_blue-and-gold tanager_bagtan1
+Bangsia melanochlamys_black-and-gold tanager_bagtan2
+Bangsia rothschildi_golden-chested tanager_goctan1
+Bangsia edwardsi_moss-backed tanager_mobtan1
+Bangsia aureocincta_gold-ringed tanager_gortan1
+Bangsia flavovirens_yellow-green tanager_ygbtan1
+Wetmorethraupis sterrhopteron_orange-throated tanager_orttan1
+Buthraupis montana_hooded mountain tanager_homtan1
+Sporathraupis cyanocephala_blue-capped tanager_blctan2
+Sporathraupis cyanocephala olivicyanea_blue-capped tanager (Blue-bellied)_buctan6
+Sporathraupis cyanocephala [cyanocephala Group]_blue-capped tanager (Blue-capped)_buctan9
+Sporathraupis cyanocephala subcinerea/buesingi_blue-capped tanager (Venezuelan)_buctan10
+Tephrophilus wetmorei_masked mountain tanager_mamtan1
+Chlorornis riefferii_grass-green tanager_grgtan1
+Cnemathraupis eximia_black-chested mountain tanager_bcmtan1
+Cnemathraupis eximia eximia/zimmeri_black-chested mountain tanager (Blue-rumped)_bcmtan3
+Cnemathraupis eximia chloronota/cyanocalyptra_black-chested mountain tanager (Moss-rumped)_bcmtan4
+Cnemathraupis aureodorsalis_golden-backed mountain tanager_gbmtan1
+Anisognathus melanogenys_black-cheeked mountain tanager_bkcmot1
+Anisognathus lacrymosus_lacrimose mountain tanager_lamtan1
+Anisognathus lacrymosus pallididorsalis_lacrimose mountain tanager (Perija)_lacmot1
+Anisognathus lacrymosus melanops_lacrimose mountain tanager (melanops)_lacmot2
+Anisognathus lacrymosus yariguierum_lacrimose mountain tanager (yariguierum)_lacmot3
+Anisognathus lacrymosus intensus_lacrimose mountain tanager (intensus)_lacmot4
+Anisognathus lacrymosus [palpebrosus Group]_lacrimose mountain tanager (palpebrosus Group)_lacmot5
+Anisognathus lacrymosus lacrymosus_lacrimose mountain tanager (lacrymosus)_lacmot6
+Anisognathus igniventris_scarlet-bellied mountain tanager_sbmtan1
+Anisognathus igniventris [lunulatus Group]_scarlet-bellied mountain tanager (Scarlet-bellied)_scbmot1
+Anisognathus igniventris igniventris_scarlet-bellied mountain tanager (Fire-bellied)_scbmot2
+Anisognathus somptuosus_blue-winged mountain tanager_bwmtan1
+Anisognathus somptuosus [somptuosus Group]_blue-winged mountain tanager (Blue-winged)_buwmot1
+Anisognathus somptuosus flavinucha_blue-winged mountain tanager (Bolivian)_buwmot2
+Anisognathus notabilis_black-chinned mountain tanager_bcmtan2
+Dubusia taeniata_buff-breasted mountain tanager_bbmtan1
+Dubusia taeniata carrikeri_buff-breasted mountain tanager (Carriker's)_bubmot4
+Dubusia taeniata taeniata_buff-breasted mountain tanager (Buff-breasted)_bubmot3
+Dubusia taeniata stictocephala_buff-breasted mountain tanager (Cerulean-streaked)_bubmot1
+Dubusia castaneoventris_chestnut-bellied mountain tanager_cbmtan1
+Pseudosaltator rufiventris_rufous-bellied mountain tanager_rubsal1
+Stephanophorus diadematus_sanhaço-frade_diatan1
+Iridosornis porphyrocephalus_purplish-mantled tanager_pumtan2
+Iridosornis analis_yellow-throated tanager_yettan1
+Iridosornis jelskii_golden-collared tanager_goctan3
+Iridosornis rufivertex_golden-crowned tanager_goctan4
+Iridosornis reinhardti_yellow-scarfed tanager_yestan1
+Pipraeidea melanonota_saíra-viúva_fabtan1
+Rauenia bonariensis_sanhaço-papa-laranja_baytan3
+Rauenia bonariensis darwinii_sanhaço-papa-laranja (darwinii)_baytan1
+Rauenia bonariensis [bonariensis Group]_sanhaço-papa-laranja [grupo bonariensis]_baytan4
+Chlorochrysa phoenicotis_glistening-green tanager_glgtan1
+Chlorochrysa calliparaea_orange-eared tanager_oretan1
+Chlorochrysa calliparaea calliparaea/bourcieri_orange-eared tanager (Orange-eared)_oretan2
+Chlorochrysa calliparaea fulgentissima_orange-eared tanager (Blue-throated)_oretan3
+Chlorochrysa nitidissima_multicolored tanager_multan1
+Thraupis episcopus_sanhaço-da-amazônia_bugtan
+Thraupis episcopus [cana Group]_sanhaço-da-amazônia [grupo cana]_bugtan1
+Thraupis episcopus [episcopus Group]_sanhaço-da-amazônia [grupo episcopus]_bugtan2
+Thraupis sayaca_sanhaço-cinzento_saytan1
+Thraupis glaucocolpa_glaucous tanager_glatan1
+Thraupis cyanoptera_sanhaço-de-encontro-azul_azstan1
+Thraupis ornata_sanhaço-de-encontro-amarelo_goctan2
+Thraupis abbas_yellow-winged tanager_yewtan1
+Thraupis palmarum_sanhaço-do-coqueiro_paltan1
+Thraupis palmarum [palmarum Group]_sanhaço-dos-coqueiros (Grupo palmarum)_paltan6
+Thraupis palmarum violilavata_sanhaço-dos-coqueiros (violilavata)_paltan3
+Thraupis sp._Thraupis sp._thraup1
+Ixothraupis varia_saíra-carijó_dottan1
+Ixothraupis rufigula_rufous-throated tanager_ruttan1
+Ixothraupis guttata_saíra-pintada_spetan1
+Ixothraupis xanthogastra_saíra-de-barriga-amarela_yebtan2
+Ixothraupis punctata_saíra-negaça_spotan1
+Ixothraupis sp._ixothraupis sp. (speckled tanager sp.)_ixothr1
+Chalcothraupis ruficervix_golden-naped tanager_gontan1
+Chalcothraupis ruficervix [ruficervix Group]_golden-naped tanager (Golden-naped)_gontan2
+Chalcothraupis ruficervix [fulvicervix Group]_golden-naped tanager (Rusty-naped)_gontan3
+Poecilostreptus cabanisi_azure-rumped tanager_azrtan1
+Poecilostreptus palmeri_gray-and-gold tanager_gagtan1
+Stilpnia cyanoptera_saíra-de-cabeça-preta_blhtan1
+Stilpnia cyanoptera cyanoptera_saíra-de-cabeça-preta (cyanoptera)_bkhtan1
+Stilpnia cyanoptera whitelyi_saíra-de-cabeça-preta (whitelyi)_bkhtan2
+Stilpnia viridicollis_silvery tanager_siltan1
+Stilpnia heinei_black-capped tanager_blctan1
+Stilpnia argyrofenges_green-throated tanager_gnttan1
+Stilpnia phillipsi_sira tanager_sirtan1
+Stilpnia peruviana_saíra-sapucaia_blbtan1
+Stilpnia preciosa_saíra-preciosa_chbtan1
+Stilpnia meyerdeschauenseei_green-capped tanager_grctan1
+Stilpnia cayana_saíra-amarela_bubtan2
+Stilpnia cayana cayana/fulvescens_saíra-amarela (cayana/fulvescens)_bubtan4
+Stilpnia cayana [flava Group]_saíra-amarela [grupo flava]_bubtan3
+Stilpnia cucullata_lesser antillean tanager_leatan1
+Stilpnia cucullata versicolor_lesser antillean tanager (St. Vincent)_leatan2
+Stilpnia cucullata cucullata_lesser antillean tanager (Grenada)_leatan3
+Stilpnia vitriolina_scrub tanager_scrtan1
+Stilpnia nigrocincta_saíra-mascarada_mastan1
+Stilpnia larvata_golden-hooded tanager_gohtan1
+Stilpnia cyanicollis_saíra-de-cabeça-azul_blntan1
+Stilpnia sp._Stilpnia sp._stilpn1
+Tangara vassorii_blue-and-black tanager_babtan1
+Tangara vassorii vassorii/branickii_blue-and-black tanager (Blue-and-black)_babtan2
+Tangara vassorii atrocoerulea_blue-and-black tanager (Spot-bellied)_babtan3
+Tangara nigroviridis_beryl-spangled tanager_bestan1
+Tangara dowii_spangle-cheeked tanager_spctan1
+Tangara fucosa_green-naped tanager_grntan1
+Tangara labradorides_metallic-green tanager_megtan1
+Tangara cyanotis_blue-browed tanager_blbtan3
+Tangara inornata_plain-colored tanager_plctan1
+Tangara mexicana_saíra-de-bando_turtan1
+Tangara brasiliensis_cambada-de-chaves_turtan3
+Tangara chilensis_sete-cores-da-amazônia_partan1
+Tangara velia_saíra-diamante/saíra-pérola_oprtan1
+Tangara velia [velia Group]_saíra-diamante_oprtan2
+Tangara velia cyanomelas_saíra-pérola_oprtan3
+Tangara callophrys_saíra-opala_opctan1
+Tangara seledon_saíra-sete-cores_grhtan2
+Tangara fastuosa_saíra-pintor_sectan1
+Tangara cyanocephala_saíra-militar_rentan1
+Tangara desmaresti_saíra-lagarta_brbtan1
+Tangara cyanoventris_saíra-douradinha_gietan1
+Tangara lavinia_rufous-winged tanager_ruwtan1
+Tangara gyrola_saíra-de-cabeça-castanha_bahtan1
+Tangara gyrola [albertinae Group]_saíra-de-cabeça-castanha [grupo albertinae]_bahtan2
+Tangara gyrola viridissima/toddi_saíra-de-cabeça-castanha (viridissima/toddi)_bahtan3
+Tangara gyrola gyrola_saíra-de-cabeça-castanha (gyrola)_bahtan4
+Tangara rufigenis_rufous-cheeked tanager_ructan2
+Tangara chrysotis_golden-eared tanager_goetan1
+Tangara xanthocephala_saffron-crowned tanager_sactan1
+Tangara parzudakii_flame-faced tanager_flftan1
+Tangara parzudakii parzudakii/urubambae_flame-faced tanager (Flame-faced)_flftan2
+Tangara parzudakii lunigera_flame-faced tanager (Yellow-faced)_flftan3
+Tangara schrankii_saíra-ouro_gagtan2
+Tangara johannae_blue-whiskered tanager_blwtan1
+Tangara arthus_golden tanager_goltan1
+Tangara arthus arthus_golden tanager (arthus)_goltan2
+Tangara arthus [aurulenta Group]_golden tanager (aurulenta Group)_goltan4
+Tangara arthus [pulchra Group]_golden tanager (pulchra Group)_goltan5
+Tangara florida_emerald tanager_emetan1
+Tangara icterocephala_silver-throated tanager_sittan1
+Tangara sp._Tangara sp._tangar3
+Tangara/Stilpnia sp._saíra sp._tangar2
+Thraupidae sp. (former Tangara sp.)_saíra pequena sp. (antigo Tangara sp.)_tangar1
+Tersina viridis_saí-andorinha_swatan1
+Dacnis albiventris_saí-de-barriga-branca_whbdac1
+Dacnis lineata_saí-de-máscara-preta_blfdac1
+Dacnis lineata egregia/aequatorialis_saí-de-máscara-preta (egregia/aequatorialis)_bkfdac1
+Dacnis lineata lineata_saí-de-máscara-preta (lineata)_bkfdac2
+Dacnis flaviventer_saí-amarela_yebdac1
+Dacnis hartlaubi_turquoise dacnis_turdac1
+Dacnis nigripes_saí-de-pernas-pretas_blldac1
+Dacnis venusta_scarlet-thighed dacnis_sctdac1
+Dacnis cayana_saí-azul_bludac1
+Dacnis viguieri_viridian dacnis_virdac1
+Dacnis berlepschi_scarlet-breasted dacnis_scbdac1
+Dacnis sp._Dacnis sp._dacnis1
+Cyanerpes nitidus_saí-de-bico-curto_shbhon2
+Cyanerpes lucidus_shining honeycreeper_shihon1
+Cyanerpes caeruleus_saí-de-perna-amarela_purhon1
+Cyanerpes cyaneus_saíra-beija-flor_relhon1
+Cyanerpes lucidus/cyaneus_shining/red-legged honeycreeper_y00654
+Cyanerpes sp._Cyanerpes sp._cyaner1
+Chlorophanes spiza_saí-verde_grehon1
+Iridophanes pulcherrimus_golden-collared honeycreeper_gochon2
+Heterospingus rubrifrons_sulphur-rumped tanager_surtan1
+Heterospingus xanthopygius_scarlet-browed tanager_scbtan2
+Hemithraupis guira_saíra-de-papo-preto_guitan1
+Hemithraupis ruficapilla_saíra-ferrugem_ruhtan1
+Hemithraupis guira/ruficapilla_saíra-de-papo-preto/saíra-ferrugem_y01055
+Hemithraupis flavicollis_saíra-galega_yebtan1
+Hemithraupis ruficapilla/flavicollis_saíra-ferrugem/saíra-galega_y01170
+Hemithraupis sp._Hemithraupis sp._y01255
+Chrysothlypis chrysomelas_black-and-yellow tanager_baytan2
+Chrysothlypis salmoni_scarlet-and-white tanager_sawtan1
+Thraupidae sp. (tanager sp.)_tanager sp. (Thraupidae sp.)_tanage
+Conirostrum bicolor_figuinha-do-mangue_biccon1
+Conirostrum margaritae_figuinha-amazônica_pebcon1
+Conirostrum speciosum_figuinha-de-rabo-castanho_chvcon1
+Conirostrum leucogenys_white-eared conebill_whecon1
+Conirostrum binghami_giant conebill_giacon1
+Conirostrum ferrugineiventre_white-browed conebill_whbcon1
+Conirostrum sitticolor_blue-backed conebill_blbcon1
+Conirostrum albifrons_capped conebill_capcon1
+Conirostrum albifrons [albifrons Group]_capped conebill (White-capped)_capcon3
+Conirostrum albifrons [atrocyaneum Group]_capped conebill (Blue-capped)_capcon2
+Conirostrum tamarugense_tamarugo conebill_tamcon1
+Conirostrum rufum_rufous-browed conebill_rubcon1
+Conirostrum cinereum_cinereous conebill_cincon1
+Conirostrum cinereum fraseri_cinereous conebill (Ochraceous)_cincon2
+Conirostrum cinereum cinereum/littorale_cinereous conebill (Cinereous)_cincon3
+Conirostrum sp._Conirostrum sp._conebi1
+Diglossa gloriosissima_chestnut-bellied flowerpiercer_chbflo1
+Diglossa lafresnayii_glossy flowerpiercer_gloflo1
+Diglossa mystacalis_moustached flowerpiercer_mouflo1
+Diglossa mystacalis unicincta_moustached flowerpiercer (unicincta)_mouflo2
+Diglossa mystacalis pectoralis_moustached flowerpiercer (pectoralis)_mouflo3
+Diglossa mystacalis albilinea_moustached flowerpiercer (albilinea)_mouflo4
+Diglossa mystacalis mystacalis_moustached flowerpiercer (mystacalis)_mouflo5
+Diglossa gloriosa_merida flowerpiercer_merflo1
+Diglossa humeralis_black flowerpiercer_blkflo1
+Diglossa brunneiventris_black-throated flowerpiercer_bktflo1
+Diglossa brunneiventris vuilleumieri_black-throated flowerpiercer (vuilleumieri)_bktflo2
+Diglossa brunneiventris brunneiventris_black-throated flowerpiercer (Black-throated)_bktflo3
+Diglossa carbonaria_gray-bellied flowerpiercer_gybflo1
+Diglossa brunneiventris x carbonaria_black-throated x gray-bellied flowerpiercer (hybrid)_x00981
+Diglossa venezuelensis_venezuelan flowerpiercer_venflo1
+Diglossa albilatera_white-sided flowerpiercer_whsflo1
+Diglossa duidae_fura-flor-escamoso_scaflo1
+Diglossa major_fura-flor-grande_greflo1
+Diglossa indigotica_indigo flowerpiercer_indflo1
+Diglossa baritula_cinnamon-bellied flowerpiercer_cibflo1
+Diglossa plumbea_slaty flowerpiercer_slaflo1
+Diglossa sittoides_rusty flowerpiercer_rusflo1
+Diglossa glauca_deep-blue flowerpiercer_debflo1
+Diglossa caerulescens_bluish flowerpiercer_bluflo1
+Diglossa cyanea_masked flowerpiercer_masflo1
+Diglossa cyanea [cyanea Group]_masked flowerpiercer (cyanea Group)_masflo7
+Diglossa cyanea melanopis_masked flowerpiercer (melanopis)_masflo6
+Diglossa sp._Diglossa sp._flower1
+Catamblyrhynchus diadema_plushcap_plushc1
+Urothraupis stolzmanni_black-backed bush tanager_bbbtan1
+Phrygilus atriceps_black-hooded sierra finch_bhsfin1
+Phrygilus punensis_peruvian sierra finch_pesfin1
+Phrygilus gayi_gray-hooded sierra finch_gyhsif1
+Phrygilus gayi minor_gray-hooded sierra finch (minor)_gyhsif2
+Phrygilus gayi gayi/caniceps_gray-hooded sierra finch (gayi/caniceps)_gyhsif3
+Phrygilus patagonicus_patagonian sierra finch_pasfin1
+Diuca diuca_diuca_codfin1
+Melanodera melanodera_white-bridled finch_cawfin1
+Melanodera melanodera princetoniana_white-bridled finch (Fuegian)_whbfin2
+Melanodera melanodera melanodera_white-bridled finch (Falkland)_whbfin3
+Melanodera xanthogramma_yellow-bridled finch_yebfin1
+Melanodera xanthogramma barrosi_yellow-bridled finch (White-tailed)_yebfin2
+Melanodera xanthogramma xanthogramma_yellow-bridled finch (Yellow-tailed)_yebfin3
+Xenodacnis parina_tit-like dacnis_tildac1
+Xenodacnis parina petersi/bella_tit-like dacnis (petersi/bella)_tildac3
+Xenodacnis parina parina_tit-like dacnis (parina)_tildac2
+Idiopsar dorsalis_red-backed sierra finch_rbsfin1
+Idiopsar erythronotus_white-throated sierra finch_wtsfin1
+Idiopsar speculifer_glacier finch_wwdfin1
+Idiopsar brachyurus_boulder finch_shtfin1
+Geospizopsis unicolor_plumbeous sierra finch_plsfin1
+Geospizopsis unicolor nivaria/geospizopsis_plumbeous sierra finch (Northern)_plsfin2
+Geospizopsis unicolor inca_plumbeous sierra finch (Peruvian)_plusif3
+Geospizopsis unicolor [unicolor Group]_plumbeous sierra finch (Southern)_plsfin3
+Geospizopsis plebejus_ash-breasted sierra finch_absfin1
+Haplospiza unicolor_cigarra-bambu_unifin1
+Haplospiza rustica_slaty finch_slafin1
+Acanthidops bairdi_peg-billed finch_pebfin1
+Lophospingus pusillus_black-crested finch_blcfin1
+Lophospingus griseocristatus_gray-crested finch_gycfin1
+Lophospingus pusillus/griseocristatus_black-crested/gray-crested finch_y00920
+Rowettia goughensis_gough island finch_goifin1
+Nesospiza acunhae_inaccessible island finch_nigfin1
+Nesospiza acunhae acunhae_inaccessible island finch (Lowland)_nigfin2
+Nesospiza acunhae fraseri_inaccessible island finch (Upland)_inifin1
+Nesospiza acunhae dunnei_inaccessible island finch (Dunn's)_wilfin2
+Nesospiza questi_nightingale island finch_nigfin3
+Nesospiza wilkinsi_wilkins's finch_wilfin3
+Nesospiza questi/wilkinsi_nightingale island/wilkins's finch_y01102
+Piezorina cinerea_cinereous finch_cinfin1
+Xenospingus concolor_slender-billed finch_slbfin3
+Incaspiza pulchra_great inca-finch_grifin1
+Incaspiza personata_rufous-backed inca-finch_rbifin1
+Incaspiza ortizi_gray-winged inca-finch_gywinf1
+Incaspiza laeta_buff-bridled inca-finch_bbifin1
+Incaspiza watkinsi_little inca-finch_liifin1
+Incaspiza sp._inca-finch sp._incafi1
+Rhopospina fruticeti_canário-andino-negro_mosfin1
+Rhopospina fruticeti fruticeti/peruviana_canário-andino-negro (fruticeti/peruvianus)_mousif1
+Rhopospina fruticeti coracina_canário-andino-negro (coracinus)_mousif2
+Rhopospina caerulescens_campainha-azul_blufin1
+Rhopospina alaudina_band-tailed sierra finch_btsfin1
+Rhopospina carbonaria_carbonated sierra finch_casfin1
+Phrygilus/Idiopsar/Geospizopsis/Rhopospina sp._sierra finch sp._sierra1
+Pseudospingus verticalis_black-headed hemispingus_blhhem1
+Pseudospingus xanthophthalmus_drab hemispingus_drahem1
+Cnemoscopus rubrirostris_gray-hooded bush tanager_gyhbut1
+Cnemoscopus rubrirostris rubrirostris_gray-hooded bush tanager (Red-billed)_gyhbut2
+Cnemoscopus rubrirostris chrysogaster_gray-hooded bush tanager (Black-billed)_gyhbut3
+Cypsnagra hirundinacea_bandoleta_whrtan1
+Donacospiza albifrons_tico-tico-do-banhado_ltrfin1
+Poospizopsis caesar_chestnut-breasted mountain finch_cbmfin1
+Poospizopsis hypochondria_rufous-sided warbling finch_rswfin1
+Castanozoster thoracicus_peito-pinhão_bcwfin1
+Poospiza goeringi_slaty-backed hemispingus_slbhem1
+Poospiza rufosuperciliaris_rufous-browed hemispingus_rubhem1
+Poospiza boliviana_bolivian warbling finch_bowfin1
+Poospiza ornata_cinnamon warbling finch_ciwfin2
+Poospiza whitii_black-and-chestnut warbling finch_barwaf2
+Poospiza nigrorufa_quem-te-vestiu_barwaf1
+Poospiza whitii/nigrorufa_black-and-chestnut/black-and-rufous warbling finch_barfin1
+Poospiza rubecula_rufous-breasted warbling finch_rbwfin1
+Poospiza hispaniolensis_collared warbling finch_cowfin1
+Poospiza garleppi_cochabamba mountain finch_comfin1
+Poospiza baeri_tucuman mountain finch_tumfin1
+Microspingus/Poospizopsis/Castanozoster/Poospiza sp._Microspingus/Poospizopsis/Castanozoster/Poospiza sp._warbli1
+Sicalis citrina_canário-rasteiro_styfin1
+Sicalis lutea_puna yellow-finch_puyfin1
+Sicalis uropygialis_bright-rumped yellow-finch_bryfin1
+Sicalis luteocephala_citron-headed yellow-finch_chyfin1
+Sicalis auriventris_greater yellow-finch_gryfin2
+Sicalis olivascens_greenish yellow-finch_gryfin3
+Sicalis mendozae_monte yellow-finch_monyef1
+Sicalis lebruni_patagonian yellow-finch_payfin1
+Sicalis columbiana_canário-do-amazonas_ofyfin1
+Sicalis flaveola_canário-da-terra_saffin
+Sicalis flaveola [flaveola Group]_canário-da-terra [grupo flaveola]_saffin1
+Sicalis flaveola pelzelni_canário-da-terra (pelzelni)_saffin2
+Sicalis luteola_tipio_gryfin1
+Sicalis luteola [chrysops Group]_tipio [grupo chrysops]_grayef1
+Sicalis luteola bogotensis_tipio (bogotensis)_grayef2
+Sicalis luteola [luteola Group]_tipio [grupo luteola]_grayef3
+Sicalis raimondii_raimondi's yellow-finch_rayfin1
+Sicalis taczanowskii_sulphur-throated finch_sutfin1
+Sicalis sp._Sicalis sp._yellow4
+Emberizoides herbicola_canário-do-campo_wtgfin1
+Emberizoides herbicola [sphenurus Group]_canário-do-campo (Grupo  sphenurus)_wetgrf7
+Emberizoides herbicola herbicola_canário-do-campo (herbicola)_wetgrf6
+Emberizoides duidae_duida grass-finch_dugfin1
+Emberizoides ypiranganus_canário-do-brejo_lesgrf1
+Emberizoides herbicola/ypiranganus_canário-do-campo/canário-dos-brejos_y00437
+Embernagra platensis_sabiá-do-banhado_grpfin1
+Embernagra platensis olivascens_sabiá-do-banhado (olivascens)_grepaf1
+Embernagra platensis platensis_sabiá-do-banhado (platensis)_grepaf2
+Embernagra longicauda_rabo-mole-da-serra_ptpfin1
+Volatinia jacarina_tiziu_blbgra1
+Sporophila bouvronides_estrela-do-norte_lessee2
+Sporophila lineola_bigodinho_linsee1
+Sporophila bouvronides/lineola_estrela-do-norte/bigodinho_y00699
+Sporophila leucoptera_chorão_whbsee1
+Sporophila leucoptera bicolor_chorão (bicolor)_whbsee3
+Sporophila leucoptera [leucoptera Group]_chorão [grupo leucoptera]_whbsee4
+Sporophila peruviana_parrot-billed seedeater_pabsee1
+Sporophila telasco_chestnut-throated seedeater_chtsee1
+Sporophila simplex_drab seedeater_drasee1
+Sporophila castaneiventris_caboclinho-de-peito-castanho_chbsee1
+Sporophila minuta_caboclinho-lindo_rubsee1
+Sporophila nigrorufa_caboclinho-do-sertão_batsee2
+Sporophila bouvreuil_caboclinho_capsee1
+Sporophila pileata_caboclinho-coroado_pebsee1
+Sporophila hypoxantha_caboclinho-de-barriga-vermelha_tabsee1
+Sporophila ruficollis_caboclinho-de-papo-escuro_datsee1
+Sporophila iberaensis_caboclinho-do-pantanal_ibesee1
+Sporophila palustris_caboclinho-de-papo-branco_marsee1
+Sporophila hypochroma_caboclinho-de-sobre-ferrugem_rursee1
+Sporophila cinnamomea_caboclinho-de-chapéu-cinzento_chesee1
+Sporophila hypochroma/cinnamomea_caboclinho-de-sobre-ruivo/caboclinho-de-barrete-cinzento_y00438
+Sporophila melanogaster_caboclinho-de-barriga-preta_blbsee2
+Sporophila funerea_thick-billed seed-finch_tbsfin1
+Sporophila angolensis_curió_cbsfin
+Sporophila nuttingi_nicaraguan seed-finch_nisfin1
+Sporophila maximiliani_bicudo_gbsfin1
+Sporophila crassirostris_bicudinho_lbsfin1
+Sporophila atrirostris_black-billed seed-finch_bbsfin1
+Sporophila corvina_variable seedeater_varsee3
+Sporophila corvina corvina_variable seedeater (Black)_varsee2
+Sporophila corvina [ophthalmica Group]_variable seedeater (Variable)_varsee4
+Sporophila intermedia_papa-capim-cinza_grysee1
+Sporophila americana_coleiro-do-norte_wibsee1
+Sporophila americana americana/dispar_wing-barred seedeater (Wing-barred)_wibsee4
+Sporophila americana murallae_papa-capim-de-caquetá_caqsee1
+Sporophila morelleti_morelet's seedeater_whcsee1
+Sporophila morelleti sharpei_morelet's seedeater (Sharpe's)_morsee1
+Sporophila morelleti morelleti_morelet's seedeater (Morelet's)_morsee2
+Sporophila torqueola_cinnamon-rumped seedeater_whcsee2
+Sporophila morelleti/torqueola_morelet's/cinnamon-rumped seedeater_whcsee
+Sporophila fringilloides_papa-capim-de-coleira_whnsee1
+Sporophila luctuosa_papa-capim-preto-e-branco_bawsee1
+Sporophila nigricollis_baiano_yebsee1
+Sporophila ardesiaca_papa-capim-de-costas-cinza_dubsee1
+Sporophila nigricollis/ardesiaca_baiano/papa-capim-de-costas-cinza_y01171
+Sporophila caerulescens_coleirinho_docsee1
+Sporophila schistacea_cigarrinha-do-norte_slcsee1
+Sporophila intermedia/schistacea_papa-capim-cinzento/cigarra-do-norte_y00439
+Sporophila falcirostris_cigarrinha-do-sul_temsee1
+Sporophila frontalis_pixoxó_bufsee1
+Sporophila plumbea_patativa_plusee1
+Sporophila beltoni_patativa-tropeira_trosee1
+Sporophila collaris_coleiro-do-brejo_rucsee1
+Sporophila albogularis_golinho_whtsee1
+Sporophila sp._Sporophila sp._sporop1
+Catamenia analis_band-tailed seedeater_batsee1
+Catamenia inornata_plain-colored seedeater_plcsee1
+Catamenia homochroa_patativa-da-amazônia_parsee1
+Catamenia homochroa oreophila_patativa-da-amazónia (oreophila)_parsee2
+Catamenia homochroa homochroa_patativa-da-amazónia (homochroa)_parsee3
+Catamenia homochroa duncani_patativa-da-amazónia (duncani)_parsee4
+Catamenia sp._Catamenia sp._catame1
+Charitospiza eucosma_mineirinho_cocfin2
+Coryphaspiza melanotis_tico-tico-de-máscara-negra_blmfin1
+Coryphospingus pileatus_tico-tico-rei-cinza_pilfin1
+Coryphospingus cucullatus_tico-tico-rei_recfin1
+Rhodospingus cruentus_crimson-breasted finch_crbfin1
+Gubernatrix cristata_cardeal-amarelo_yelcar1
+Diuca diuca x Gubernatrix cristata_diuca x cardeal-amarelo (híbrido)_x00899
+Coereba flaveola_cambacica_banana
+Coereba flaveola bahamensis_cambacica (bahamensis)_banana4
+Coereba flaveola caboti_cambacica (caboti)_banana3
+Coereba flaveola [flaveola Group]_cambacica [grupo flaveola]_banana6
+Coereba flaveola [portoricensis Group]_cambacica (portoricensis)_banana11
+Coereba flaveola [bartholemica Group]_cambacica [grupo bartholemica]_banana9
+Coereba flaveola atrata_cambacica (atrata)_banana12
+Coereba flaveola aterrima_cambacica (aterrima)_banana7
+Coereba flaveola lowii_cambacica (lowii)_banana10
+Coereba flaveola laurae/melanornis_cambacica (laurae/melanornis)_banana8
+Coereba flaveola [luteola Group]_cambacica [grupo luteola]_banana5
+Tiaris olivaceus_yellow-faced grassquit_yefgra1
+Euneornis campestris_orangequit_orange1
+Melopyrrha portoricensis_puerto rican bullfinch_purbul1
+Melopyrrha grandis_st. kitts bullfinch_purbul3
+Melopyrrha nigra_cuban bullfinch_cubbul2
+Melopyrrha taylori_grand cayman bullfinch_cubbul3
+Melopyrrha violacea_greater antillean bullfinch_grabul1
+Loxipasser anoxanthus_yellow-shouldered grassquit_yesgra1
+Phonipara canora_cuban grassquit_cubgra
+Loxigilla noctis_lesser antillean bullfinch_leabul1
+Loxigilla barbadensis_barbados bullfinch_barbul1
+Melanospiza richardsoni_st. lucia black finch_slbfin1
+Melanospiza bicolor_black-faced grassquit_bkfgra
+Asemospiza obscura_cigarra-parda_ducgra2
+Asemospiza fuliginosa_cigarra-preta_soogra2
+Pinaroloxias inornata_cocos finch_cocfin1
+Certhidea olivacea_green warbler-finch_warfin1
+Certhidea fusca_gray warbler-finch_grywaf1
+Platyspiza crassirostris_vegetarian finch_vegfin2
+Camarhynchus pallidus_woodpecker finch_woofin1
+Camarhynchus pallidus pallidus/productus_woodpecker finch (pallidus/productus)_woofin2
+Camarhynchus pallidus striatipecta_woodpecker finch (striatipecta)_woofin3
+Camarhynchus psittacula_large tree-finch_latfin1
+Camarhynchus pauper_medium tree-finch_metfin1
+Camarhynchus parvulus_small tree-finch_smtfin1
+Camarhynchus heliobates_mangrove finch_manfin1
+Geospiza fuliginosa_small ground-finch_smgfin1
+Geospiza magnirostris_large ground-finch_lagfin1
+Geospiza septentrionalis_vampire ground-finch_shbgrf1
+Geospiza acutirostris_genovesa ground-finch_shbgrf2
+Geospiza difficilis_sharp-beaked ground-finch_shbgrf3
+Geospiza scandens_common cactus-finch_cocfin3
+Geospiza fortis_medium ground-finch_megfin1
+Geospiza conirostris_española ground-finch_larcaf2
+Geospiza propinqua_genovesa cactus-finch_gencaf1
+Geospiza sp._Geospiza sp._geospi1
+Geospiza/Camarhynchus/Platyspiza/Certhidea sp._galapagos finch sp._galfin1
+Parkerthraustes humeralis_furriel-de-encontro_yesgro2
+Saltatricula multicolor_batuqueiro-chaquenho_mccfin1
+Saltatricula atricollis_batuqueiro_bltsal1
+Saltator maximus_tempera-viola_butsal1
+Saltator atripennis_black-winged saltator_blwsal1
+Saltator atriceps_black-headed saltator_blhsal1
+Saltator orenocensis_orinocan saltator_orisal1
+Saltator olivascens_trinca-ferro-oliváceo_grasal4
+Saltator grandis_cinnamon-bellied saltator_grasal2
+Saltator coerulescens_trinca-ferro-gongá_grasal3
+Saltator olivascens/coerulescens_olive-gray/bluish-gray saltator_grasal1
+Saltator striatipectus_streaked saltator_strsal1
+Saltator albicollis_lesser antillean saltator_leasal1
+Saltator similis_trinca-ferro_grwsal1
+Saltator nigriceps_black-cowled saltator_blcsal1
+Saltator maxillosus_bico-grosso_thbsal1
+Saltator aurantiirostris_bico-duro_gobsal1
+Saltator cinctus_masked saltator_massal1
+Saltator grossus_bico-encarnado_slcgro1
+Saltator fuliginosus_bico-de-pimenta_bltgro2
+Saltator sp._Saltator sp._saltat1
+Thraupidae sp._Thraupidae sp._thraup3
+Passeriformes sp._passeriforme_passer1
+Aves sp._ave sp._bird1


### PR DESCRIPTION
# Add Portuguese (Brazil) Labels File (`labels_pt-br.txt`)

## Summary
This PR adds a new label file for Portuguese (Brazil), `labels_pt-br.txt`, located in `internal/birdnet/data/labels/`. This allows BirdNET-Go users to utilize species names in Brazilian Portuguese instead of European Portuguese.

## Details
- The file was generated using the **eBird API**, ensuring accurate and standardized naming.
- The format follows the same structure as the existing `labels_pt.txt`: Scientific_Name_Portuguese_Brazilian_Name_eBird_Code
- Example lines from `labels_pt-br.txt`:
  - Turdus rufiventris_Sabiá-laranjeira_turruf
  - Amazona aestiva_Papagaio-verdadeiro_amaaes
  - Ara ararauna_Arara-canindé_ararau
   
## Why is this useful?
- Many Brazilian users prefer **pt-BR labels** instead of pt-PT.
- This enables better species identification for Brazilian birdwatchers.
- Ensures consistency with the **eBird taxonomy**.

## Notes:
- If needed, I can update the file with any required modifications.
- Let me know if there are any adjustments or format changes required.
- **Important:** The file contains **accented characters (e.g., á, é, í, ó, ú, ç)**. If any encoding issues arise, ensure the file is saved and processed using UTF-8 encoding.

Thank you for considering this contribution! 🚀
