### PR TITLE
feat: Birdweather dynamic restart on reconfigure

### DIFF
--- a/assets/js/components/multiStageOperation.js
+++ b/assets/js/components/multiStageOperation.js
@@ -142,6 +142,20 @@ document.addEventListener('alpine:init', () => {
                                                         });
                                                     }
                                                     
+                                                    // Always complete the "Starting Test" stage when any other stage begins
+                                                    // This ensures we don't have a stuck "Starting Test" if the first real stage fails
+                                                    if (result.stage !== "Starting Test" && !isProgress) {
+                                                        const startingTestIndex = this.results.findIndex(r => r.stage === "Starting Test");
+                                                        if (startingTestIndex >= 0 && this.results[startingTestIndex].state === "running") {
+                                                            this.results[startingTestIndex] = {
+                                                                ...this.results[startingTestIndex],
+                                                                state: 'completed',
+                                                                isProgress: false,
+                                                                message: "Initialization complete"
+                                                            };
+                                                        }
+                                                    }
+                                                    
                                                     // Sort results according to stage order
                                                     this.results.sort((a, b) => 
                                                         this.stageOrder.indexOf(a.stage) - this.stageOrder.indexOf(b.stage)

--- a/internal/api/v2/integrations.go
+++ b/internal/api/v2/integrations.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
+	"github.com/tphakala/birdnet-go/internal/birdweather"
 	"github.com/tphakala/birdnet-go/internal/mqtt"
 	"github.com/tphakala/birdnet-go/internal/telemetry"
 )
@@ -30,6 +31,15 @@ type MQTTTestResult struct {
 	ElapsedTime int64  `json:"elapsed_time_ms,omitempty"` // Time taken to complete the test in milliseconds
 }
 
+// BirdWeatherStatus represents the current status of the BirdWeather integration
+type BirdWeatherStatus struct {
+	Enabled          bool    `json:"enabled"`              // Whether BirdWeather integration is enabled
+	StationID        string  `json:"station_id"`           // The BirdWeather station ID
+	Threshold        float64 `json:"threshold"`            // The confidence threshold for reporting detections
+	LocationAccuracy float64 `json:"location_accuracy"`    // The location accuracy in meters
+	LastError        string  `json:"last_error,omitempty"` // Most recent error message, if any issues occurred
+}
+
 // initIntegrationsRoutes registers all integration-related API endpoints
 func (c *Controller) initIntegrationsRoutes() {
 	// Create integrations API group with auth middleware
@@ -40,8 +50,12 @@ func (c *Controller) initIntegrationsRoutes() {
 	mqttGroup.GET("/status", c.GetMQTTStatus)
 	mqttGroup.POST("/test", c.TestMQTTConnection)
 
+	// BirdWeather routes
+	bwGroup := integrationsGroup.Group("/birdweather")
+	bwGroup.GET("/status", c.GetBirdWeatherStatus)
+	bwGroup.POST("/test", c.TestBirdWeatherConnection)
+
 	// Other integration routes could be added here:
-	// - BirdWeather
 	// - Weather APIs
 	// - External media storage
 }
@@ -51,6 +65,7 @@ func (c *Controller) GetMQTTStatus(ctx echo.Context) error {
 	// Get MQTT configuration from settings
 	mqttConfig := c.Settings.Realtime.MQTT
 
+	// Prepare status response
 	status := MQTTStatus{
 		Connected: false, // Default to not connected
 		Broker:    mqttConfig.Broker,
@@ -58,39 +73,32 @@ func (c *Controller) GetMQTTStatus(ctx echo.Context) error {
 		ClientID:  c.Settings.Main.Name, // Use the application name as client ID
 	}
 
-	// Check if there's an active MQTT client we can query
+	// If MQTT is not enabled, return status as-is
+	if !mqttConfig.Enabled {
+		return ctx.JSON(http.StatusOK, status)
+	}
+
+	// Check if we have an active MQTT connection through the control channel
 	if c.controlChan != nil {
-		c.Debug("Requesting MQTT status check")
+		// Ask the control monitor for MQTT status
+		statusReq := make(chan any)
+		// Create a message with a specific structure expected by the control monitor
+		message := "mqtt_status"
+		c.controlChan <- message
 
-		// Send a status request through the control channel
-		// The actual message format should match what your control monitor expects
-		statusReqChan := make(chan bool, 1)
-
-		// NOTE: There appears to be an issue here - statusReqChan is created locally
-		// but there's no mechanism visible in this function to write to it.
-		// This means the select below may always timeout after 2 seconds.
-		//
-		// TODO: Ensure that:
-		// 1. The component handling "mqtt:status" messages has access to this channel
-		// 2. That component writes the connection status to statusReqChan
-		// 3. Consider passing statusReqChan to the control system or using a response channel pattern
-
-		// We assume the controller has a method to handle "mqtt:status" commands
-		// and will respond with the connection status
+		// Wait for response with timeout
 		select {
-		case c.controlChan <- "mqtt:status":
-			// Wait for response with timeout
-			select {
-			case connected := <-statusReqChan:
-				status.Connected = connected
-			case <-time.After(2 * time.Second):
-				c.logger.Printf("Timeout waiting for MQTT status response")
-				status.LastError = "error:timeout:mqtt_status_response" // Standardized error code format
+		case resp := <-statusReq:
+			if mqttStatus, ok := resp.(map[string]interface{}); ok {
+				if connected, ok := mqttStatus["connected"].(bool); ok {
+					status.Connected = connected
+				}
+				if lastErr, ok := mqttStatus["error"].(string); ok && lastErr != "" {
+					status.LastError = fmt.Sprintf("error:connection:mqtt_broker:%s", lastErr)
+				}
 			}
-		default:
-			// Channel is full or blocked
-			c.logger.Printf("Control channel is not accepting messages")
-			status.LastError = "error:unavailable:control_system" // Standardized error code format
+		case <-time.After(2 * time.Second):
+			status.LastError = "error:timeout:status_request:request_timed_out"
 		}
 	} else if mqttConfig.Enabled {
 		// If control channel is not available but MQTT is enabled,
@@ -120,6 +128,25 @@ func (c *Controller) GetMQTTStatus(ctx echo.Context) error {
 			status.LastError = fmt.Sprintf("error:metrics:initialization:%s", err.Error()) // Standardized error code format
 		}
 	}
+
+	return ctx.JSON(http.StatusOK, status)
+}
+
+// GetBirdWeatherStatus handles GET /api/v2/integrations/birdweather/status
+func (c *Controller) GetBirdWeatherStatus(ctx echo.Context) error {
+	// Get BirdWeather configuration from settings
+	bwConfig := c.Settings.Realtime.Birdweather
+
+	// Prepare status response
+	status := BirdWeatherStatus{
+		Enabled:          bwConfig.Enabled,
+		StationID:        bwConfig.ID,
+		Threshold:        bwConfig.Threshold,
+		LocationAccuracy: bwConfig.LocationAccuracy,
+	}
+
+	// For now, we just return the configuration status
+	// In the future, we could add checks for client status here
 
 	return ctx.JSON(http.StatusOK, status)
 }
@@ -237,6 +264,141 @@ func (c *Controller) TestMQTTConnection(ctx echo.Context) error {
 		writeMu.Lock()
 		if err := encoder.Encode(result); err != nil {
 			c.logger.Printf("Error encoding MQTT test result: %v", err)
+			writeMu.Unlock()
+
+			// Signal that the HTTP client has disconnected using sync.Once
+			safeDoneClose()
+
+			// Cancel the test context to stop ongoing tests
+			cancel()
+			return nil
+		}
+		ctx.Response().Flush()
+		writeMu.Unlock()
+
+		// Check if HTTP context is done (client disconnected)
+		select {
+		case <-httpCtx.Done():
+			c.Debug("HTTP client disconnected during test")
+			// Use sync.Once to safely close the channel
+			safeDoneClose()
+			cancel() // Cancel the test context
+			return nil
+		default:
+			// Continue processing
+		}
+	}
+
+	return nil
+}
+
+// TestBirdWeatherConnection handles POST /api/v2/integrations/birdweather/test
+func (c *Controller) TestBirdWeatherConnection(ctx echo.Context) error {
+	// Get BirdWeather configuration from settings
+	bwConfig := c.Settings.Realtime.Birdweather
+
+	if !bwConfig.Enabled {
+		return ctx.JSON(http.StatusOK, map[string]interface{}{
+			"success": false,
+			"message": "BirdWeather integration is not enabled in settings",
+			"state":   "failed",
+		})
+	}
+
+	// Validate BirdWeather configuration
+	if bwConfig.ID == "" {
+		return ctx.JSON(http.StatusBadRequest, map[string]interface{}{
+			"success": false,
+			"message": "BirdWeather station ID not configured",
+			"state":   "failed",
+		})
+	}
+
+	// Create test BirdWeather client with the current configuration
+	client, err := birdweather.New(c.Settings)
+	if err != nil {
+		return ctx.JSON(http.StatusInternalServerError, map[string]interface{}{
+			"success": false,
+			"message": fmt.Sprintf("Failed to create BirdWeather client: %v", err),
+			"state":   "failed",
+		})
+	}
+
+	// Prepare for testing
+	ctx.Response().Header().Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	ctx.Response().WriteHeader(http.StatusOK)
+
+	// Channel for test results
+	resultChan := make(chan birdweather.TestResult)
+
+	// Create a done channel to signal when the client disconnects
+	doneChan := make(chan struct{})
+
+	// Use sync.Once to ensure doneChan is closed exactly once
+	var closeOnce sync.Once
+	// Helper function to safely close the doneChan
+	safeDoneClose := func() {
+		closeOnce.Do(func() {
+			close(doneChan)
+		})
+	}
+
+	// Mutex for safe writing to response
+	var writeMu sync.Mutex
+
+	// Create context with timeout that also gets cancelled if HTTP client disconnects
+	httpCtx := ctx.Request().Context()
+	testCtx, cancel := context.WithTimeout(httpCtx, 30*time.Second)
+	defer cancel()
+
+	// Run the test in a goroutine
+	go func() {
+		defer close(resultChan)
+		startTime := time.Now()
+
+		// Start the test
+		client.TestConnection(testCtx, resultChan)
+
+		// Calculate elapsed time
+		elapsedTime := time.Since(startTime).Milliseconds()
+
+		// Clean up client resources
+		client.Close()
+
+		// Send final result with elapsed time if the client is still connected
+		select {
+		case <-doneChan:
+			// HTTP client has disconnected, no need to send final result
+			c.Debug("HTTP client disconnected, skipping final result")
+		case <-testCtx.Done():
+			// Test timed out or was cancelled
+			c.Debug("Test context cancelled: %v", testCtx.Err())
+		default:
+			// Still connected, send final result
+			writeMu.Lock()
+			defer writeMu.Unlock()
+
+			// Format final response
+			finalResult := map[string]interface{}{
+				"elapsed_time_ms": elapsedTime,
+				"state":           "completed",
+			}
+
+			// Write final result to response if possible
+			if err := c.writeJSONResponse(ctx, finalResult); err != nil {
+				c.logger.Printf("Error writing final BirdWeather test result: %v", err)
+			}
+		}
+	}()
+
+	// Feed streaming results to client
+	encoder := json.NewEncoder(ctx.Response())
+
+	// Stream results to client until done
+	for result := range resultChan {
+		writeMu.Lock()
+		if err := encoder.Encode(result); err != nil {
+			c.logger.Printf("Error encoding BirdWeather test result: %v", err)
 			writeMu.Unlock()
 
 			// Signal that the HTTP client has disconnected using sync.Once

--- a/internal/birdweather/birdweather.go
+++ b/internal/birdweather/birdweather.go
@@ -300,3 +300,24 @@ func (b *BwClient) Publish(note *datastore.Note, pcmData []byte) error {
 
 	return nil
 }
+
+// Close properly cleans up the BwClient resources
+// Currently this just cancels any pending HTTP requests
+func (b *BwClient) Close() {
+	if b.HTTPClient != nil && b.HTTPClient.Transport != nil {
+		// If the transport implements the CloseIdleConnections method, call it
+		type transporter interface {
+			CloseIdleConnections()
+		}
+		if transport, ok := b.HTTPClient.Transport.(transporter); ok {
+			transport.CloseIdleConnections()
+		}
+
+		// Cancel any in-flight requests by using a new client
+		b.HTTPClient = nil
+	}
+
+	if b.Settings.Realtime.Birdweather.Debug {
+		log.Println("BirdWeather client closed")
+	}
+}

--- a/internal/birdweather/interfaces.go
+++ b/internal/birdweather/interfaces.go
@@ -1,10 +1,16 @@
 package birdweather
 
-import "github.com/tphakala/birdnet-go/internal/datastore"
+import (
+	"context"
+
+	"github.com/tphakala/birdnet-go/internal/datastore"
+)
 
 // BirdweatherClientInterface defines what methods a BirdweatherClient must have
 type Interface interface {
-	Publish(note datastore.Note, pcmData []byte) error
+	Publish(note *datastore.Note, pcmData []byte) error
 	UploadSoundscape(timestamp string, pcmData []byte) (soundscapeID string, err error)
 	PostDetection(soundscapeID, timestamp, commonName, scientificName string, confidence float64) error
+	TestConnection(ctx context.Context, resultChan chan<- TestResult)
+	Close()
 }

--- a/internal/birdweather/testing.go
+++ b/internal/birdweather/testing.go
@@ -259,7 +259,7 @@ func runTest(ctx context.Context, stage TestStage, test birdweatherTest) TestRes
 	case SoundscapeUpload:
 		message = fmt.Sprintf("Successfully uploaded test soundscape (0.5 second silent audio) to BirdWeather. This recording should appear on your BirdWeather station at %s.", time.Now().Format("Jan 2, 2006 at 15:04:05"))
 	case DetectionPost:
-		message = fmt.Sprintf("Successfully posted test detection to BirdWeather: Whooper Swan (Cygnus cygnus) with unlikely confidence.")
+		message = "Successfully posted test detection to BirdWeather: Whooper Swan (Cygnus cygnus) with unlikely confidence."
 	default:
 		message = fmt.Sprintf("Successfully completed %s", stage)
 	}

--- a/internal/birdweather/testing.go
+++ b/internal/birdweather/testing.go
@@ -3,16 +3,107 @@ package birdweather
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"log"
 	"math/rand"
 	"net"
 	"net/http"
+	"net/url"
 	"strings"
 	"sync"
 	"time"
 )
+
+// Rate limiting constants
+const (
+	// Minimum time between test submissions (1 minute)
+	minTestInterval = 1 * time.Minute
+)
+
+// DNS Fallback resolvers
+var fallbackDNSResolvers = []string{
+	"1.1.1.1:53", // Cloudflare
+	"8.8.8.8:53", // Google
+	"9.9.9.9:53", // Quad9
+}
+
+// resultContext is used to pass result IDs through context
+type resultContext struct {
+	ID string
+}
+
+// Define a custom type for the context key to avoid collisions
+type contextKey int
+
+// Define the key constant
+const resultIDKey contextKey = iota
+
+// Global rate limiter state
+var (
+	lastTestTime  time.Time
+	rateLimiterMu sync.Mutex
+)
+
+// checkRateLimit returns error if tests are being run too frequently
+func checkRateLimit() error {
+	rateLimiterMu.Lock()
+	defer rateLimiterMu.Unlock()
+
+	// If this is the first test or enough time has passed, allow it
+	if lastTestTime.IsZero() || time.Since(lastTestTime) >= minTestInterval {
+		// Update the last test time and allow this test
+		lastTestTime = time.Now()
+		return nil
+	}
+
+	// Calculate time until next allowed test
+	nextAllowedTime := lastTestTime.Add(minTestInterval)
+	waitTime := time.Until(nextAllowedTime).Round(time.Second)
+
+	return fmt.Errorf("rate limit exceeded: please wait %s before testing again", waitTime)
+}
+
+// resolveDNSWithFallback attempts to resolve a hostname using fallback DNS servers if the OS resolver fails
+func resolveDNSWithFallback(hostname string) ([]net.IP, error) {
+	// First try the standard resolver
+	ips, err := net.LookupIP(hostname)
+	if err == nil && len(ips) > 0 {
+		return ips, nil
+	}
+
+	// If standard resolver fails, log the error
+	log.Printf("Standard DNS resolution for %s failed: %v", hostname, err)
+	log.Printf("Attempting to resolve %s using fallback DNS servers...", hostname)
+
+	// Try each fallback resolver
+	for _, resolver := range fallbackDNSResolvers {
+		r := &net.Resolver{
+			PreferGo: true,
+			Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
+				d := net.Dialer{Timeout: 5 * time.Second}
+				return d.DialContext(ctx, "udp", resolver)
+			},
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		fallbackIPs, err := r.LookupIPAddr(ctx, hostname)
+		cancel()
+
+		if err == nil && len(fallbackIPs) > 0 {
+			// Convert IPAddr to IP
+			result := make([]net.IP, len(fallbackIPs))
+			for i, addr := range fallbackIPs {
+				result[i] = addr.IP
+			}
+			log.Printf("Successfully resolved %s using fallback DNS %s: %v", hostname, resolver, result)
+			return result, nil
+		}
+	}
+
+	return nil, fmt.Errorf("failed to resolve %s with all DNS resolvers", hostname)
+}
 
 // TestConfig encapsulates test configuration for artificial delays and failures
 type TestConfig struct {
@@ -70,6 +161,7 @@ type TestResult struct {
 	IsProgress bool   `json:"isProgress,omitempty"`
 	State      string `json:"state,omitempty"`     // Current state: running, completed, failed, timeout
 	Timestamp  string `json:"timestamp,omitempty"` // ISO8601 timestamp of the result
+	ResultID   string `json:"resultId,omitempty"`  // Optional ID for test results like soundscapeID
 }
 
 // TestStage represents a stage in the BirdWeather test process
@@ -127,6 +219,9 @@ func runTest(ctx context.Context, stage TestStage, test birdweatherTest) TestRes
 	// Create buffered channel for test result
 	resultChan := make(chan error, 1)
 
+	// Create a context with a value to pass back the result ID
+	ctx = context.WithValue(ctx, resultIDKey, &resultContext{})
+
 	// Run the test in a goroutine
 	go func() {
 		resultChan <- test(ctx)
@@ -152,10 +247,28 @@ func runTest(ctx context.Context, stage TestStage, test birdweatherTest) TestRes
 		}
 	}
 
+	// Get any result ID from the context
+	var resultID string
+	if rc, ok := ctx.Value(resultIDKey).(*resultContext); ok && rc != nil {
+		resultID = rc.ID
+	}
+
+	// Create appropriate success message based on the stage
+	var message string
+	switch stage {
+	case SoundscapeUpload:
+		message = fmt.Sprintf("Successfully uploaded test soundscape (0.5 second silent audio) to BirdWeather. This recording should appear on your BirdWeather station at %s.", time.Now().Format("Jan 2, 2006 at 15:04:05"))
+	case DetectionPost:
+		message = fmt.Sprintf("Successfully posted test detection to BirdWeather: Whooper Swan (Cygnus cygnus) with unlikely confidence.")
+	default:
+		message = fmt.Sprintf("Successfully completed %s", stage)
+	}
+
 	return TestResult{
-		Success: true,
-		Stage:   stage.String(),
-		Message: fmt.Sprintf("Successfully completed %s", stage),
+		Success:  true,
+		Stage:    stage.String(),
+		Message:  message,
+		ResultID: resultID,
 	}
 }
 
@@ -165,31 +278,138 @@ func (b *BwClient) testAPIConnectivity(ctx context.Context) TestResult {
 	defer apiCancel()
 
 	return runTest(apiCtx, APIConnectivity, func(ctx context.Context) error {
-		// Simple check if we can reach the BirdWeather API endpoint
-		req, err := http.NewRequestWithContext(ctx, "HEAD", "https://app.birdweather.com/api/v1/health", http.NoBody)
-		if err != nil {
-			return err
-		}
-		req.Header.Set("User-Agent", "BirdNET-Go")
+		// Define the API endpoint URL
+		apiEndpoint := "https://app.birdweather.com/api/v1"
 
-		// Create a temporary HTTP client with a shorter timeout for this test
-		client := &http.Client{Timeout: apiTimeout}
-		resp, err := client.Do(req)
+		// Parse URL to extract the hostname
+		parsedURL, err := url.Parse(apiEndpoint)
 		if err != nil {
-			var netErr net.Error
-			if errors.As(err, &netErr) && netErr.Timeout() {
-				return fmt.Errorf("API connectivity test timed out: %w", err)
+			return fmt.Errorf("invalid API endpoint URL: %w", err)
+		}
+		hostname := parsedURL.Hostname()
+
+		// First attempt: Use standard HTTP client
+		log.Printf("Testing connectivity to BirdWeather API at %s", apiEndpoint)
+		err = tryAPIConnection(ctx, apiEndpoint)
+
+		// If first attempt fails with DNS error, try fallback DNS resolution
+		if err != nil {
+			if isDNSError(err) {
+				log.Printf("DNS resolution failed: %v, attempting fallback...", err)
+
+				// Attempt DNS resolution with fallback resolvers
+				ips, resolveErr := resolveDNSWithFallback(hostname)
+				if resolveErr != nil {
+					return fmt.Errorf("all DNS resolution attempts failed: %w", resolveErr)
+				}
+
+				// Try to connect using the resolved IP directly
+				for _, ip := range ips {
+					// Create a modified URL with IP instead of hostname
+					// Need to keep the original hostname in HTTP Host header
+					ipEndpoint := replaceHostWithIP(apiEndpoint, ip.String())
+
+					log.Printf("Attempting connection with fallback DNS resolved IP: %s", ipEndpoint)
+					err = tryAPIConnection(ctx, ipEndpoint, hostname)
+					if err == nil {
+						log.Printf("✅ Successfully connected to BirdWeather API via fallback DNS resolution")
+						return nil
+					}
+				}
+
+				return fmt.Errorf("connection failed using both standard and fallback DNS: %w", err)
 			}
-			return fmt.Errorf("failed to connect to BirdWeather API: %w", err)
-		}
-		defer resp.Body.Close()
 
-		if resp.StatusCode >= 400 {
-			return fmt.Errorf("API returned error status: %d", resp.StatusCode)
+			// Not a DNS error, return the original error
+			return err
 		}
 
 		return nil
 	})
+}
+
+// Helper function to check if an error is DNS-related
+func isDNSError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	errStr := err.Error()
+	return strings.Contains(errStr, "no such host") ||
+		strings.Contains(errStr, "lookup ") ||
+		strings.Contains(errStr, "dial tcp") ||
+		strings.Contains(errStr, "DNS") ||
+		strings.Contains(errStr, "dns") ||
+		strings.Contains(errStr, "cannot resolve")
+}
+
+// Helper function to replace hostname with IP in URL
+func replaceHostWithIP(urlStr, ip string) string {
+	parsedURL, err := url.Parse(urlStr)
+	if err != nil {
+		return urlStr // return original if parsing fails
+	}
+
+	// Keep track of original port if specified
+	port := parsedURL.Port()
+	if port != "" {
+		parsedURL.Host = ip + ":" + port
+	} else {
+		parsedURL.Host = ip
+	}
+
+	return parsedURL.String()
+}
+
+// tryAPIConnection attempts to connect to the API endpoint
+func tryAPIConnection(ctx context.Context, apiEndpoint string, hostHeader ...string) error {
+	req, err := http.NewRequestWithContext(ctx, "HEAD", apiEndpoint, http.NoBody)
+	if err != nil {
+		return err
+	}
+
+	// Set User-Agent
+	req.Header.Set("User-Agent", "BirdNET-Go")
+
+	// If host header is provided (for IP direct connections), set it
+	if len(hostHeader) > 0 && hostHeader[0] != "" {
+		req.Host = hostHeader[0]
+	}
+
+	// Create a temporary HTTP client with a shorter timeout for this test
+	client := &http.Client{
+		Timeout: apiTimeout,
+		// Add special transport to handle potential certificate issues with direct IP
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: false, // Keep secure by default
+			},
+		},
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		var netErr net.Error
+		if errors.As(err, &netErr) && netErr.Timeout() {
+			return fmt.Errorf("API connectivity test timed out while connecting to %s: %w", apiEndpoint, err)
+		}
+		return fmt.Errorf("failed to connect to BirdWeather API at %s: %w", apiEndpoint, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		// Special handling for 404 Not Found errors
+		if resp.StatusCode == 404 {
+			log.Printf("BirdWeather API endpoint not found: %s returned 404", apiEndpoint)
+			return fmt.Errorf("API endpoint not found (404): %s", apiEndpoint)
+		}
+		log.Printf("BirdWeather API returned error status: %d for URL %s", resp.StatusCode, apiEndpoint)
+		return fmt.Errorf("API at %s returned error status: %d", apiEndpoint, resp.StatusCode)
+	}
+
+	// Successfully connected to the API
+	log.Printf("✅ Successfully connected to BirdWeather API at %s (status: %d)", apiEndpoint, resp.StatusCode)
+	return nil
 }
 
 // testAuthentication tests authentication with the BirdWeather API
@@ -200,26 +420,145 @@ func (b *BwClient) testAuthentication(ctx context.Context) TestResult {
 	return runTest(authCtx, Authentication, func(ctx context.Context) error {
 		// Check if the station ID is valid by attempting to retrieve station details
 		stationURL := fmt.Sprintf("https://app.birdweather.com/api/v1/stations/%s", b.BirdweatherID)
-		req, err := http.NewRequestWithContext(ctx, "GET", stationURL, http.NoBody)
+
+		// Try primary authentication method
+		err := tryAuthentication(ctx, b, stationURL)
 		if err != nil {
+			// If it's a DNS or network error, try with alternative methods
+			if isDNSError(err) || isNetworkError(err) {
+				log.Printf("Primary authentication failed with network error: %v", err)
+
+				// Try to resolve the hostname with fallback DNS
+				parsedURL, parseErr := url.Parse(stationURL)
+				if parseErr != nil {
+					return fmt.Errorf("invalid station URL: %w", parseErr)
+				}
+
+				hostname := parsedURL.Hostname()
+				ips, resolveErr := resolveDNSWithFallback(hostname)
+				if resolveErr != nil {
+					return fmt.Errorf("all DNS resolution attempts failed during authentication: %w", resolveErr)
+				}
+
+				// Try each resolved IP
+				for _, ip := range ips {
+					ipEndpoint := replaceHostWithIP(stationURL, ip.String())
+					log.Printf("Attempting authentication with fallback DNS: %s", ipEndpoint)
+
+					// Use the original hostname for Host header
+					authErr := tryAuthenticationWithHostOverride(ctx, b, ipEndpoint, hostname)
+					if authErr == nil {
+						log.Printf("✅ Successfully authenticated with BirdWeather via fallback DNS")
+						return nil
+					}
+				}
+
+				// All fallback attempts failed
+				return fmt.Errorf("authentication failed using both standard and fallback methods: %w", err)
+			}
+
+			// Not a network error, return original error
 			return err
-		}
-		req.Header.Set("User-Agent", "BirdNET-Go")
-
-		resp, err := b.HTTPClient.Do(req)
-		if err != nil {
-			return fmt.Errorf("failed to authenticate with BirdWeather: %w", err)
-		}
-		defer resp.Body.Close()
-
-		if resp.StatusCode == 401 || resp.StatusCode == 403 {
-			return fmt.Errorf("authentication failed: invalid station ID")
-		} else if resp.StatusCode >= 400 {
-			return fmt.Errorf("authentication failed: server returned status code %d", resp.StatusCode)
 		}
 
 		return nil
 	})
+}
+
+// tryAuthentication attempts to authenticate with the station URL
+func tryAuthentication(ctx context.Context, b *BwClient, stationURL string) error {
+	req, err := http.NewRequestWithContext(ctx, "GET", stationURL, http.NoBody)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("User-Agent", "BirdNET-Go")
+
+	resp, err := b.HTTPClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to authenticate with BirdWeather at %s: %w", stationURL, err)
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case 401, 403:
+		log.Printf("❌ BirdWeather authentication failed: invalid station ID (tried URL: %s)", stationURL)
+		return fmt.Errorf("authentication failed: invalid station ID (tried URL: %s)", stationURL)
+	case 404:
+		log.Printf("❌ BirdWeather station not found: %s returned 404", stationURL)
+		return fmt.Errorf("station not found (404): %s", stationURL)
+	default:
+		if resp.StatusCode >= 400 {
+			log.Printf("❌ BirdWeather authentication failed: server returned status code %d for URL %s", resp.StatusCode, stationURL)
+			return fmt.Errorf("authentication failed: server returned status code %d for URL %s", resp.StatusCode, stationURL)
+		}
+	}
+
+	// Successfully authenticated - don't log the actual token
+	log.Printf("✅ Successfully authenticated with BirdWeather (status: %d)", resp.StatusCode)
+	return nil
+}
+
+// tryAuthenticationWithHostOverride attempts to authenticate with a provided host override
+func tryAuthenticationWithHostOverride(ctx context.Context, b *BwClient, stationURL, hostOverride string) error {
+	req, err := http.NewRequestWithContext(ctx, "GET", stationURL, http.NoBody)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("User-Agent", "BirdNET-Go")
+
+	// Set host header for direct IP connection
+	if hostOverride != "" {
+		req.Host = hostOverride
+	}
+
+	// Create a client with custom transport to handle direct IP connection
+	client := &http.Client{
+		Timeout: authTimeout,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: false, // Keep secure
+			},
+		},
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to authenticate with BirdWeather at %s (host: %s): %w", stationURL, hostOverride, err)
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case 401, 403:
+		log.Printf("❌ BirdWeather authentication failed: invalid station ID (tried URL: %s)", stationURL)
+		return fmt.Errorf("authentication failed: invalid station ID (tried URL: %s)", stationURL)
+	case 404:
+		log.Printf("❌ BirdWeather station not found: %s returned 404", stationURL)
+		return fmt.Errorf("station not found (404): %s", stationURL)
+	default:
+		if resp.StatusCode >= 400 {
+			log.Printf("❌ BirdWeather authentication failed: server returned status code %d for URL %s", resp.StatusCode, stationURL)
+			return fmt.Errorf("authentication failed: server returned status code %d for URL %s", resp.StatusCode, stationURL)
+		}
+	}
+
+	// Successfully authenticated
+	log.Printf("✅ Successfully authenticated with BirdWeather (status: %d)", resp.StatusCode)
+	return nil
+}
+
+// Helper function to check if error is network-related
+func isNetworkError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	errStr := err.Error()
+	return strings.Contains(errStr, "connection refused") ||
+		strings.Contains(errStr, "i/o timeout") ||
+		strings.Contains(errStr, "network") ||
+		strings.Contains(errStr, "unreachable") ||
+		strings.Contains(errStr, "reset by peer") ||
+		strings.Contains(errStr, "connection closed")
 }
 
 // testSoundscapeUpload tests uploading a small soundscape to BirdWeather
@@ -237,9 +576,18 @@ func (b *BwClient) testSoundscapeUpload(ctx context.Context) TestResult {
 		timestamp := time.Now().Format("2006-01-02T15:04:05.000-0700")
 
 		// Attempt to upload the test soundscape
-		_, err := b.UploadSoundscape(timestamp, testPCMData)
+		soundscapeID, err := b.UploadSoundscape(timestamp, testPCMData)
 		if err != nil {
+			log.Printf("❌ BirdWeather soundscape upload failed: %s", err)
 			return fmt.Errorf("failed to upload soundscape: %w", err)
+		}
+
+		// Successfully uploaded soundscape
+		log.Printf("✅ Successfully uploaded test soundscape to BirdWeather with ID: %s", soundscapeID)
+
+		// Store the soundscapeID in the context
+		if rc, ok := ctx.Value(resultIDKey).(*resultContext); ok && rc != nil {
+			rc.ID = soundscapeID
 		}
 
 		return nil
@@ -255,16 +603,21 @@ func (b *BwClient) testDetectionPost(ctx context.Context, soundscapeID string) T
 		// Generate current timestamp in the required format
 		timestamp := time.Now().Format("2006-01-02T15:04:05.000-0700")
 
-		// Use a common test species - Whooper Swan
+		// Use a test detection with 0% confidence to avoid contaminating real data
 		commonName := "Whooper Swan"
 		scientificName := "Cygnus cygnus"
-		confidence := 0.95
+		confidence := 0.3 // 30% confidence to indicate this is not a real detection
 
 		// Post the test detection
 		err := b.PostDetection(soundscapeID, timestamp, commonName, scientificName, confidence)
 		if err != nil {
+			log.Printf("❌ BirdWeather detection post failed: %s", err)
 			return fmt.Errorf("failed to post detection: %w", err)
 		}
+
+		// Successfully posted detection
+		log.Printf("✅ Successfully posted test detection to BirdWeather: %s (%s) with confidence %.2f",
+			commonName, scientificName, confidence)
 
 		return nil
 	})
@@ -335,13 +688,47 @@ func (b *BwClient) TestConnection(ctx context.Context, resultChan chan<- TestRes
 		return
 	}
 
+	// Start with the explicit "Starting Test" stage
+	sendResult(TestResult{
+		Success:    true,
+		Stage:      "Starting Test",
+		Message:    "Initializing BirdWeather Connection Test...",
+		State:      "running",
+		IsProgress: true,
+	})
+
+	// Check rate limiting
+	if err := checkRateLimit(); err != nil {
+		sendResult(TestResult{
+			Success: false,
+			Stage:   "Starting Test",
+			Message: "Rate limit check failed",
+			Error:   err.Error(),
+			State:   "failed",
+		})
+		return
+	}
+
 	// Helper function to run a test stage
 	runStage := func(stage TestStage, test func() TestResult) bool {
-		// Send progress message
+		// First, mark the "Starting Test" stage as completed if we're on the first real test
+		if stage == APIConnectivity {
+			sendResult(TestResult{
+				Success:    true,
+				Stage:      "Starting Test",
+				Message:    "Initialization complete, starting tests",
+				State:      "completed",
+				IsProgress: false,
+			})
+		}
+
+		// Send progress message for current stage
 		sendResult(TestResult{
-			Success: true,
-			Stage:   stage.String(),
-			Message: fmt.Sprintf("Running %s test...", stage.String()),
+			Success:    true,
+			Stage:      stage.String(),
+			Message:    fmt.Sprintf("Running %s test...", stage.String()),
+			State:      "running",
+			IsProgress: true,
 		})
 
 		// Execute the test
@@ -369,13 +756,8 @@ func (b *BwClient) TestConnection(ctx context.Context, resultChan chan<- TestRes
 	uploadResult := runStage(SoundscapeUpload, func() TestResult {
 		result := b.testSoundscapeUpload(ctx)
 		if result.Success {
-			// Extract soundscape ID from success message
-			if strings.Contains(result.Message, "ID:") {
-				parts := strings.Split(result.Message, "ID:")
-				if len(parts) > 1 {
-					soundscapeID = strings.TrimSpace(parts[1])
-				}
-			}
+			// Get the soundscape ID directly from the result
+			soundscapeID = result.ResultID
 		}
 		return result
 	})
@@ -447,7 +829,7 @@ func (b *BwClient) UploadTestSoundscape(ctx context.Context) TestResult {
 		return TestResult{
 			Success: true,
 			Stage:   SoundscapeUpload.String(),
-			Message: fmt.Sprintf("Successfully uploaded test soundscape with ID: %s", result.id),
+			Message: fmt.Sprintf("Successfully uploaded test soundscape (0.5 second silent audio). <span class=\"text-info\">This recording should appear on your BirdWeather station at %s with ID: %s</span>", time.Now().Format("Jan 2, 2006 at 15:04:05"), result.id),
 		}
 	}
 }
@@ -468,10 +850,10 @@ func (b *BwClient) PostTestDetection(ctx context.Context, soundscapeID string) T
 	// Generate current timestamp in the required format
 	timestamp := time.Now().Format("2006-01-02T15:04:05.000-0700")
 
-	// Use a common test species - Whooper Swan
+	// Use a test detection with 0% confidence to avoid contaminating real data
 	commonName := "Whooper Swan"
 	scientificName := "Cygnus cygnus"
-	confidence := 0.95
+	confidence := 0.3 // 30% confidence to indicate this is not a real detection
 
 	// Create a channel for the post result
 	resultChan := make(chan error, 1)
@@ -502,7 +884,7 @@ func (b *BwClient) PostTestDetection(ctx context.Context, soundscapeID string) T
 		return TestResult{
 			Success: true,
 			Stage:   DetectionPost.String(),
-			Message: "Successfully posted test detection",
+			Message: "Successfully posted test detection: Whooper Swan (Cygnus cygnus) with unlikely confidence.",
 		}
 	}
 }

--- a/internal/birdweather/testing.go
+++ b/internal/birdweather/testing.go
@@ -1,0 +1,508 @@
+// testing.go provides BirdWeather connection and functionality testing capabilities
+package birdweather
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"math/rand"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+// TestConfig encapsulates test configuration for artificial delays and failures
+type TestConfig struct {
+	// Set to true to enable artificial delays and random failures
+	Enabled bool
+	// Internal flag to enable random failures (for testing UI behavior)
+	RandomFailureMode bool
+	// Probability of failure for each stage (0.0 - 1.0)
+	FailureProbability float64
+	// Min and max artificial delay in milliseconds
+	MinDelay int
+	MaxDelay int
+	// Thread-safe random number generator
+	rng *rand.Rand
+	mu  sync.Mutex
+}
+
+// Default test configuration instance
+var testConfig = &TestConfig{
+	Enabled:            false,
+	RandomFailureMode:  false,
+	FailureProbability: 0.5,
+	MinDelay:           500,
+	MaxDelay:           3000,
+	rng:                rand.New(rand.NewSource(time.Now().UnixNano())),
+}
+
+// simulateDelay adds an artificial delay
+func simulateDelay() {
+	if !testConfig.Enabled {
+		return
+	}
+	testConfig.mu.Lock()
+	delay := testConfig.rng.Intn(testConfig.MaxDelay-testConfig.MinDelay) + testConfig.MinDelay
+	testConfig.mu.Unlock()
+	time.Sleep(time.Duration(delay) * time.Millisecond)
+}
+
+// simulateFailure returns true if the test should fail
+func simulateFailure() bool {
+	if !testConfig.Enabled || !testConfig.RandomFailureMode {
+		return false
+	}
+	testConfig.mu.Lock()
+	defer testConfig.mu.Unlock()
+	return testConfig.rng.Float64() < testConfig.FailureProbability
+}
+
+// TestResult represents the result of a BirdWeather test
+type TestResult struct {
+	Success    bool   `json:"success"`
+	Stage      string `json:"stage"`
+	Message    string `json:"message"`
+	Error      string `json:"error,omitempty"`
+	IsProgress bool   `json:"isProgress,omitempty"`
+	State      string `json:"state,omitempty"`     // Current state: running, completed, failed, timeout
+	Timestamp  string `json:"timestamp,omitempty"` // ISO8601 timestamp of the result
+}
+
+// TestStage represents a stage in the BirdWeather test process
+type TestStage int
+
+const (
+	APIConnectivity TestStage = iota
+	Authentication
+	SoundscapeUpload
+	DetectionPost
+)
+
+// String returns the string representation of a test stage
+func (s TestStage) String() string {
+	switch s {
+	case APIConnectivity:
+		return "API Connectivity"
+	case Authentication:
+		return "Authentication"
+	case SoundscapeUpload:
+		return "Soundscape Upload"
+	case DetectionPost:
+		return "Detection Post"
+	default:
+		return "Unknown Stage"
+	}
+}
+
+// Timeout constants for various test stages
+const (
+	apiTimeout    = 5 * time.Second
+	authTimeout   = 5 * time.Second
+	uploadTimeout = 10 * time.Second
+	postTimeout   = 5 * time.Second
+)
+
+// networkTest represents a generic network test function
+type birdweatherTest func(context.Context) error
+
+// runTest executes a BirdWeather test with proper timeout and cleanup
+func runTest(ctx context.Context, stage TestStage, test birdweatherTest) TestResult {
+	// Add simulated delay if enabled
+	simulateDelay()
+
+	// Check for simulated failure
+	if simulateFailure() {
+		return TestResult{
+			Success: false,
+			Stage:   stage.String(),
+			Error:   fmt.Sprintf("simulated %s failure", stage),
+			Message: fmt.Sprintf("Failed to perform %s", stage),
+		}
+	}
+
+	// Create buffered channel for test result
+	resultChan := make(chan error, 1)
+
+	// Run the test in a goroutine
+	go func() {
+		resultChan <- test(ctx)
+	}()
+
+	// Wait for either test completion or context cancellation
+	select {
+	case <-ctx.Done():
+		return TestResult{
+			Success: false,
+			Stage:   stage.String(),
+			Error:   "operation timeout",
+			Message: fmt.Sprintf("%s operation timed out", stage),
+		}
+	case err := <-resultChan:
+		if err != nil {
+			return TestResult{
+				Success: false,
+				Stage:   stage.String(),
+				Error:   err.Error(),
+				Message: fmt.Sprintf("Failed to perform %s", stage),
+			}
+		}
+	}
+
+	return TestResult{
+		Success: true,
+		Stage:   stage.String(),
+		Message: fmt.Sprintf("Successfully completed %s", stage),
+	}
+}
+
+// testAPIConnectivity tests basic connectivity to the BirdWeather API
+func (b *BwClient) testAPIConnectivity(ctx context.Context) TestResult {
+	apiCtx, apiCancel := context.WithTimeout(ctx, apiTimeout)
+	defer apiCancel()
+
+	return runTest(apiCtx, APIConnectivity, func(ctx context.Context) error {
+		// Simple check if we can reach the BirdWeather API endpoint
+		req, err := http.NewRequestWithContext(ctx, "HEAD", "https://app.birdweather.com/api/v1/health", http.NoBody)
+		if err != nil {
+			return err
+		}
+		req.Header.Set("User-Agent", "BirdNET-Go")
+
+		// Create a temporary HTTP client with a shorter timeout for this test
+		client := &http.Client{Timeout: apiTimeout}
+		resp, err := client.Do(req)
+		if err != nil {
+			var netErr net.Error
+			if errors.As(err, &netErr) && netErr.Timeout() {
+				return fmt.Errorf("API connectivity test timed out: %w", err)
+			}
+			return fmt.Errorf("failed to connect to BirdWeather API: %w", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode >= 400 {
+			return fmt.Errorf("API returned error status: %d", resp.StatusCode)
+		}
+
+		return nil
+	})
+}
+
+// testAuthentication tests authentication with the BirdWeather API
+func (b *BwClient) testAuthentication(ctx context.Context) TestResult {
+	authCtx, authCancel := context.WithTimeout(ctx, authTimeout)
+	defer authCancel()
+
+	return runTest(authCtx, Authentication, func(ctx context.Context) error {
+		// Check if the station ID is valid by attempting to retrieve station details
+		stationURL := fmt.Sprintf("https://app.birdweather.com/api/v1/stations/%s", b.BirdweatherID)
+		req, err := http.NewRequestWithContext(ctx, "GET", stationURL, http.NoBody)
+		if err != nil {
+			return err
+		}
+		req.Header.Set("User-Agent", "BirdNET-Go")
+
+		resp, err := b.HTTPClient.Do(req)
+		if err != nil {
+			return fmt.Errorf("failed to authenticate with BirdWeather: %w", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode == 401 || resp.StatusCode == 403 {
+			return fmt.Errorf("authentication failed: invalid station ID")
+		} else if resp.StatusCode >= 400 {
+			return fmt.Errorf("authentication failed: server returned status code %d", resp.StatusCode)
+		}
+
+		return nil
+	})
+}
+
+// testSoundscapeUpload tests uploading a small soundscape to BirdWeather
+func (b *BwClient) testSoundscapeUpload(ctx context.Context) TestResult {
+	uploadCtx, uploadCancel := context.WithTimeout(ctx, uploadTimeout)
+	defer uploadCancel()
+
+	return runTest(uploadCtx, SoundscapeUpload, func(ctx context.Context) error {
+		// Generate a small test PCM data (500ms of silence)
+		sampleRate := 48000
+		numSamples := sampleRate / 2              // 0.5 seconds
+		testPCMData := make([]byte, numSamples*2) // 16-bit samples = 2 bytes per sample
+
+		// Generate current timestamp in the required format
+		timestamp := time.Now().Format("2006-01-02T15:04:05.000-0700")
+
+		// Attempt to upload the test soundscape
+		_, err := b.UploadSoundscape(timestamp, testPCMData)
+		if err != nil {
+			return fmt.Errorf("failed to upload soundscape: %w", err)
+		}
+
+		return nil
+	})
+}
+
+// testDetectionPost tests posting a test detection to BirdWeather
+func (b *BwClient) testDetectionPost(ctx context.Context, soundscapeID string) TestResult {
+	postCtx, postCancel := context.WithTimeout(ctx, postTimeout)
+	defer postCancel()
+
+	return runTest(postCtx, DetectionPost, func(ctx context.Context) error {
+		// Generate current timestamp in the required format
+		timestamp := time.Now().Format("2006-01-02T15:04:05.000-0700")
+
+		// Use a common test species - Whooper Swan
+		commonName := "Whooper Swan"
+		scientificName := "Cygnus cygnus"
+		confidence := 0.95
+
+		// Post the test detection
+		err := b.PostDetection(soundscapeID, timestamp, commonName, scientificName, confidence)
+		if err != nil {
+			return fmt.Errorf("failed to post detection: %w", err)
+		}
+
+		return nil
+	})
+}
+
+// TestConnection performs a multi-stage test of the BirdWeather connection and functionality
+func (b *BwClient) TestConnection(ctx context.Context, resultChan chan<- TestResult) {
+	// Helper function to send a result
+	sendResult := func(result TestResult) {
+		// Mark progress messages
+		result.IsProgress = strings.Contains(strings.ToLower(result.Message), "running") ||
+			strings.Contains(strings.ToLower(result.Message), "testing") ||
+			strings.Contains(strings.ToLower(result.Message), "establishing") ||
+			strings.Contains(strings.ToLower(result.Message), "initializing")
+
+		// Set state based on result
+		switch {
+		case result.State != "":
+			// Keep existing state if explicitly set
+		case result.Error != "":
+			result.State = "failed"
+			result.Success = false
+			result.IsProgress = false
+		case result.IsProgress:
+			result.State = "running"
+		case result.Success:
+			result.State = "completed"
+		case strings.Contains(strings.ToLower(result.Error), "timeout") ||
+			strings.Contains(strings.ToLower(result.Error), "deadline exceeded"):
+			result.State = "timeout"
+		default:
+			result.State = "failed"
+		}
+
+		// Add timestamp
+		result.Timestamp = time.Now().Format(time.RFC3339)
+
+		// Log the result with emoji
+		emoji := "❌"
+		if result.Success {
+			emoji = "✅"
+		}
+
+		// Format the log message
+		logMsg := result.Message
+		if !result.Success && result.Error != "" {
+			logMsg = fmt.Sprintf("%s: %s", result.Message, result.Error)
+		}
+		log.Printf("%s %s: %s", emoji, result.Stage, logMsg)
+
+		// Send result to channel
+		select {
+		case <-ctx.Done():
+			return
+		case resultChan <- result:
+		}
+	}
+
+	// Check context before starting
+	if err := ctx.Err(); err != nil {
+		sendResult(TestResult{
+			Success: false,
+			Stage:   "Test Setup",
+			Message: "Test cancelled",
+			Error:   err.Error(),
+			State:   "timeout",
+		})
+		return
+	}
+
+	// Helper function to run a test stage
+	runStage := func(stage TestStage, test func() TestResult) bool {
+		// Send progress message
+		sendResult(TestResult{
+			Success: true,
+			Stage:   stage.String(),
+			Message: fmt.Sprintf("Running %s test...", stage.String()),
+		})
+
+		// Execute the test
+		result := test()
+		sendResult(result)
+		return result.Success
+	}
+
+	// Stage 1: API Connectivity
+	if !runStage(APIConnectivity, func() TestResult {
+		return b.testAPIConnectivity(ctx)
+	}) {
+		return
+	}
+
+	// Stage 2: Authentication
+	if !runStage(Authentication, func() TestResult {
+		return b.testAuthentication(ctx)
+	}) {
+		return
+	}
+
+	// Stage 3: Soundscape Upload
+	var soundscapeID string
+	uploadResult := runStage(SoundscapeUpload, func() TestResult {
+		result := b.testSoundscapeUpload(ctx)
+		if result.Success {
+			// Extract soundscape ID from success message
+			if strings.Contains(result.Message, "ID:") {
+				parts := strings.Split(result.Message, "ID:")
+				if len(parts) > 1 {
+					soundscapeID = strings.TrimSpace(parts[1])
+				}
+			}
+		}
+		return result
+	})
+
+	if !uploadResult || soundscapeID == "" {
+		// If we couldn't get a soundscape ID, use a mock one for the detection test
+		soundscapeID = "test123"
+	}
+
+	// Stage 4: Detection Post
+	runStage(DetectionPost, func() TestResult {
+		return b.testDetectionPost(ctx, soundscapeID)
+	})
+}
+
+// UploadTestSoundscape uploads a test soundscape for testing purposes
+func (b *BwClient) UploadTestSoundscape(ctx context.Context) TestResult {
+	simulateDelay()
+
+	if simulateFailure() {
+		return TestResult{
+			Success: false,
+			Stage:   SoundscapeUpload.String(),
+			Error:   "simulated soundscape upload failure",
+			Message: "Failed to upload test soundscape",
+		}
+	}
+
+	// Generate a small test PCM data (500ms of silence)
+	sampleRate := 48000
+	numSamples := sampleRate / 2              // 0.5 seconds
+	testPCMData := make([]byte, numSamples*2) // 16-bit samples = 2 bytes per sample
+
+	// Generate current timestamp in the required format
+	timestamp := time.Now().Format("2006-01-02T15:04:05.000-0700")
+
+	// Create a channel for the upload result
+	resultChan := make(chan struct {
+		id  string
+		err error
+	}, 1)
+
+	go func() {
+		id, err := b.UploadSoundscape(timestamp, testPCMData)
+		resultChan <- struct {
+			id  string
+			err error
+		}{id, err}
+	}()
+
+	// Wait for either the context to be done or the upload to complete
+	select {
+	case <-ctx.Done():
+		return TestResult{
+			Success: false,
+			Stage:   SoundscapeUpload.String(),
+			Error:   "Soundscape upload timeout",
+			Message: "Soundscape upload timed out",
+		}
+	case result := <-resultChan:
+		if result.err != nil {
+			return TestResult{
+				Success: false,
+				Stage:   SoundscapeUpload.String(),
+				Error:   result.err.Error(),
+				Message: "Failed to upload test soundscape",
+			}
+		}
+		return TestResult{
+			Success: true,
+			Stage:   SoundscapeUpload.String(),
+			Message: fmt.Sprintf("Successfully uploaded test soundscape with ID: %s", result.id),
+		}
+	}
+}
+
+// PostTestDetection posts a test detection for testing purposes
+func (b *BwClient) PostTestDetection(ctx context.Context, soundscapeID string) TestResult {
+	simulateDelay()
+
+	if simulateFailure() {
+		return TestResult{
+			Success: false,
+			Stage:   DetectionPost.String(),
+			Error:   "simulated detection post failure",
+			Message: "Failed to post test detection",
+		}
+	}
+
+	// Generate current timestamp in the required format
+	timestamp := time.Now().Format("2006-01-02T15:04:05.000-0700")
+
+	// Use a common test species - Whooper Swan
+	commonName := "Whooper Swan"
+	scientificName := "Cygnus cygnus"
+	confidence := 0.95
+
+	// Create a channel for the post result
+	resultChan := make(chan error, 1)
+
+	go func() {
+		err := b.PostDetection(soundscapeID, timestamp, commonName, scientificName, confidence)
+		resultChan <- err
+	}()
+
+	// Wait for either the context to be done or the post to complete
+	select {
+	case <-ctx.Done():
+		return TestResult{
+			Success: false,
+			Stage:   DetectionPost.String(),
+			Error:   "Detection post timeout",
+			Message: "Detection post timed out",
+		}
+	case err := <-resultChan:
+		if err != nil {
+			return TestResult{
+				Success: false,
+				Stage:   DetectionPost.String(),
+				Error:   err.Error(),
+				Message: "Failed to post test detection",
+			}
+		}
+		return TestResult{
+			Success: true,
+			Stage:   DetectionPost.String(),
+			Message: "Successfully posted test detection",
+		}
+	}
+}

--- a/internal/httpcontroller/handlers/README.md
+++ b/internal/httpcontroller/handlers/README.md
@@ -1,0 +1,198 @@
+# HTTP Controller Handlers Package
+
+## Overview
+
+The `handlers` package within `httpcontroller` is responsible for handling HTTP requests in the BirdNET-Go application. It provides a collection of handler functions that process incoming requests, interact with the database and other services, and return appropriate responses.
+
+This package is a core component of the web interface and API of BirdNET-Go, providing the connection between the HTTP routes and the underlying application logic.
+
+## Structure
+
+The handler package is organized as follows:
+
+- **`handlers.go`**: Core handler structure and common functionality
+- **`detections.go`**: Handlers for bird detection related endpoints
+- **`dashboard.go`**: Handlers for the main dashboard view
+- **`media.go`**: Handlers for serving media content (spectrograms, audio clips)
+- **`sse.go`**: Server-Sent Events implementation for real-time updates
+- **`settings.go`**: Handlers for application settings management
+- **`statistics.go`**: Handlers for statistical data endpoints
+- **`species.go`**: Handlers for species-related endpoints
+- **`weather.go`**: Handlers for weather information
+- **`mqtt.go`**: Handlers for MQTT messaging 
+- **`audio_level_sse.go`**: Real-time audio level updates via SSE
+- **`utils.go`**: Utility functions used by handlers
+
+## Core Components
+
+### Handlers Struct
+
+The main `Handlers` struct (defined in `handlers.go`) is the central component that holds dependencies and common functionality. It includes:
+
+```go
+type Handlers struct {
+    baseHandler
+    DS                datastore.Interface
+    Settings          *conf.Settings
+    DashboardSettings *conf.Dashboard
+    BirdImageCache    *imageprovider.BirdImageCache
+    SSE               *SSEHandler
+    SunCalc           *suncalc.SunCalc
+    AudioLevelChan    chan myaudio.AudioLevelData
+    OAuth2Server      *security.OAuth2Server
+    controlChan       chan string
+    notificationChan  chan Notification
+    CloudflareAccess  *security.CloudflareAccess
+    debug             bool
+    Server            interface{ IsAccessAllowed(c echo.Context) bool }
+}
+```
+
+### Error Handling
+
+The package implements a robust error handling system with a custom `HandlerError` type:
+
+```go
+type HandlerError struct {
+    Err     error
+    Message string
+    Code    int
+}
+```
+
+This allows for consistent error handling throughout the application, with appropriate HTTP status codes and user-friendly messages.
+
+### Server-Sent Events (SSE)
+
+The package includes a full implementation of Server-Sent Events for real-time updates:
+
+- `SSEHandler`: Manages client connections and broadcasts notifications
+- `Notification`: Represents messages sent to clients
+
+## Key Functionalities
+
+### Bird Detection Handlers
+
+The package provides handlers for:
+- Retrieving bird detections (hourly, by species, or via search)
+- Getting detection details
+- Serving detection media (audio clips and spectrograms)
+- Managing detection reviews and verification
+
+### Dashboard
+
+Provides data for the main dashboard, including:
+- Top bird sightings
+- Hourly occurrence statistics
+- Recent detections
+
+### Settings Management
+
+Comprehensive handlers for application settings, covering:
+- Audio configuration
+- BirdNET parameters
+- Detection filters
+- Integrations
+- Security settings
+
+### Media Serving
+
+Handlers for serving media assets:
+- Audio clips of bird sounds
+- Spectrograms of detections
+- Bird images
+
+### Real-time Updates
+
+Support for real-time updates via Server-Sent Events (SSE):
+- Detection notifications
+- Audio level updates
+- System status
+
+## Usage Examples
+
+### Handler Registration
+
+Handlers are registered with routes in the parent `httpcontroller` package:
+
+```go
+// Partial routes (HTMX responses)
+s.partialRoutes = map[string]PartialRouteConfig{
+    "/api/v1/detections":         {Path: "/api/v1/detections", Handler: h.WithErrorHandling(h.Detections)},
+    "/api/v1/detections/recent":  {Path: "/api/v1/detections/recent", Handler: h.WithErrorHandling(h.RecentDetections)},
+    "/api/v1/detections/details": {Path: "/api/v1/detections/details", Handler: h.WithErrorHandling(h.DetectionDetails)},
+    // ... more routes ...
+}
+```
+
+### Error Handling Wrapper
+
+Handlers use a consistent error handling approach with the `WithErrorHandling` wrapper:
+
+```go
+func (h *Handlers) WithErrorHandling(fn func(echo.Context) error) echo.HandlerFunc {
+    return func(c echo.Context) error {
+        err := fn(c)
+        if err != nil {
+            return h.HandleError(err, c)
+        }
+        return nil
+    }
+}
+```
+
+### Implementing a New Handler
+
+When implementing a new handler, follow this pattern:
+
+```go
+func (h *Handlers) MyNewHandler(c echo.Context) error {
+    // Parse and validate request parameters
+    // ...
+    
+    // Perform business logic with dependencies
+    data, err := h.DS.SomeDataOperation()
+    if err != nil {
+        return h.NewHandlerError(err, "Failed to perform operation", http.StatusInternalServerError)
+    }
+    
+    // Return appropriate response
+    return c.Render(http.StatusOK, "templateName", data)
+    // or
+    return c.JSON(http.StatusOK, data)
+}
+```
+
+## Best Practices
+
+When working with the handlers package:
+
+1. Use the `WithErrorHandling` wrapper for consistent error handling
+2. Leverage the `NewHandlerError` method for creating handler errors
+3. Keep handler methods focused on request/response processing
+4. Put business logic in the appropriate service packages
+5. Use appropriate HTTP status codes for responses
+6. Document new handlers and their parameters
+7. Use the provided dependencies instead of creating new ones
+
+## Dependencies
+
+The handlers package relies on several other packages:
+
+- `echo`: Web framework for HTTP handling
+- `datastore`: Database access interface
+- `conf`: Configuration settings
+- `imageprovider`: Bird image management
+- `security`: Authentication and authorization
+- `suncalc`: Sun event calculations
+- `myaudio`: Audio processing
+
+## Cross-Platform Compatibility
+
+The handlers package is designed to be compatible with:
+
+- Linux
+- macOS
+- Windows
+
+No platform-specific code is used in the handlers themselves, ensuring consistent operation across all supported platforms. 

--- a/internal/httpcontroller/handlers/birdweather.go
+++ b/internal/httpcontroller/handlers/birdweather.go
@@ -1,0 +1,177 @@
+// birdweather.go provides HTTP handlers for BirdWeather-related functionality
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/tphakala/birdnet-go/internal/birdweather"
+	"github.com/tphakala/birdnet-go/internal/conf"
+)
+
+// BirdWeather test stage constants
+const (
+	stageAPIConnectivity  = "API Connectivity"
+	stageAuthentication   = "Authentication"
+	stageSoundscapeUpload = "Soundscape Upload"
+	stageDetectionPost    = "Detection Post"
+)
+
+// TestBirdWeather handles requests to test BirdWeather connectivity and functionality
+// API: GET/POST /api/v1/birdweather/test
+func (h *Handlers) TestBirdWeather(c echo.Context) error {
+	// Define a struct for the test configuration
+	type TestConfig struct {
+		Enabled          bool    `json:"enabled"`
+		ID               string  `json:"id"`
+		Threshold        float64 `json:"threshold"`
+		LocationAccuracy float64 `json:"locationAccuracy"`
+		Debug            bool    `json:"debug"`
+	}
+
+	var testConfig TestConfig
+	var settings *conf.Settings
+
+	// If this is a POST request, use the provided test configuration
+	if c.Request().Method == "POST" {
+		if err := c.Bind(&testConfig); err != nil {
+			return h.NewHandlerError(err, "Invalid test configuration", http.StatusBadRequest)
+		}
+
+		// Create temporary settings for the test
+		settings = &conf.Settings{
+			BirdNET: conf.BirdNETConfig{
+				Latitude:  45.0, // Default test values for location
+				Longitude: -75.0,
+			},
+			Realtime: conf.RealtimeSettings{
+				Birdweather: conf.BirdweatherSettings{
+					Enabled:          testConfig.Enabled,
+					ID:               testConfig.ID,
+					Threshold:        testConfig.Threshold,
+					LocationAccuracy: testConfig.LocationAccuracy,
+					Debug:            testConfig.Debug,
+				},
+			},
+		}
+	} else {
+		// For GET requests, use the current settings
+		settings = h.Settings
+	}
+
+	// Check if BirdWeather is enabled
+	if !settings.Realtime.Birdweather.Enabled {
+		return h.NewHandlerError(
+			nil,
+			"BirdWeather is not enabled in settings",
+			http.StatusBadRequest,
+		)
+	}
+
+	// Check if the station ID is provided
+	if settings.Realtime.Birdweather.ID == "" {
+		return h.NewHandlerError(
+			nil,
+			"BirdWeather station ID is not configured",
+			http.StatusBadRequest,
+		)
+	}
+
+	// Create a temporary BirdWeather client for testing
+	bwClient, err := birdweather.New(settings)
+	if err != nil {
+		return h.NewHandlerError(err, "Failed to create BirdWeather client", http.StatusInternalServerError)
+	}
+
+	// Create context with timeout for the test
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Set up streaming response
+	c.Response().Header().Set("Content-Type", "application/x-ndjson")
+	c.Response().WriteHeader(http.StatusOK)
+
+	// Create a channel to receive test results
+	resultChan := make(chan birdweather.TestResult)
+
+	// Start test in a goroutine
+	go func() {
+		defer close(resultChan)
+		bwClient.TestConnection(ctx, resultChan)
+	}()
+
+	// Stream results to client
+	enc := json.NewEncoder(c.Response())
+	for result := range resultChan {
+		// Modify the result enhancement to handle progress messages
+		if !result.Success {
+			hint := generateBirdWeatherTroubleshootingHint(&result)
+			if hint != "" {
+				result.Message = fmt.Sprintf("%s\n\n%s\n\n%s",
+					result.Message,
+					result.Error,
+					hint)
+				result.Error = ""
+			}
+		} else {
+			// Explicitly mark progress messages
+			result.IsProgress = strings.Contains(strings.ToLower(result.Message), "running") ||
+				strings.Contains(strings.ToLower(result.Message), "testing") ||
+				strings.Contains(strings.ToLower(result.Message), "establishing")
+		}
+
+		if err := enc.Encode(result); err != nil {
+			// If we can't write to the response, client probably disconnected
+			return nil
+		}
+		c.Response().Flush()
+	}
+
+	// Clean up
+	bwClient.Close()
+
+	return nil
+}
+
+// generateBirdWeatherTroubleshootingHint provides context-specific troubleshooting suggestions
+func generateBirdWeatherTroubleshootingHint(result *birdweather.TestResult) string {
+	if result.Success {
+		return "" // No hint needed for successful tests
+	}
+
+	// Return troubleshooting hints based on the stage and error message
+	switch result.Stage {
+	case stageAPIConnectivity:
+		if strings.Contains(result.Error, "timeout") ||
+			strings.Contains(result.Error, "i/o timeout") {
+			return "Check your internet connection and ensure that app.birdweather.com is accessible from your network. Consider checking for any firewall rules that might be blocking outbound connections."
+		}
+		if strings.Contains(result.Error, "no such host") ||
+			strings.Contains(result.Error, "DNS") {
+			return "Could not resolve the BirdWeather API hostname. Check your DNS configuration and internet connectivity."
+		}
+		return "Unable to connect to the BirdWeather API. Verify your internet connection and network settings."
+
+	case stageAuthentication:
+		if strings.Contains(result.Error, "status code 401") ||
+			strings.Contains(result.Error, "status code 403") ||
+			strings.Contains(result.Error, "invalid station ID") {
+			return "Authentication failed. Please verify that your BirdWeather Station ID is correct and that your station is registered and active on the BirdWeather platform."
+		}
+		return "Failed to authenticate with BirdWeather. Check your BirdWeather token and ensure your station is properly registered on the BirdWeather platform."
+
+	case stageSoundscapeUpload:
+		return "Failed to upload the test soundscape. This could be due to network issues, authentication problems, or the BirdWeather service might be experiencing issues. Try again later or check your BirdWeather station settings."
+
+	case stageDetectionPost:
+		return "Failed to post the test detection. Make sure your BirdWeather station is properly configured to accept detection uploads."
+
+	default:
+		return "Something went wrong with the BirdWeather test. Check your connection settings and try again."
+	}
+}

--- a/internal/httpcontroller/handlers/birdweather.go
+++ b/internal/httpcontroller/handlers/birdweather.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
 	"strings"
 	"time"
@@ -110,19 +111,53 @@ func (h *Handlers) TestBirdWeather(c echo.Context) error {
 	for result := range resultChan {
 		// Modify the result enhancement to handle progress messages
 		if !result.Success {
+			// Log the error with the full details for debugging
+			if result.Error != "" {
+				log.Printf("BirdWeather test error in stage %s: %s", result.Stage, result.Error)
+			}
+
+			// Generate a user-friendly troubleshooting hint
 			hint := generateBirdWeatherTroubleshootingHint(&result)
-			if hint != "" {
-				result.Message = fmt.Sprintf("%s\n\n%s\n\n%s",
+
+			// Format the error message for the UI
+			// For 404 errors, make sure to show the URL that was attempted
+			if strings.Contains(result.Error, "404") || strings.Contains(result.Error, "not found") {
+				// Extract URL from error message if present
+				url := extractURLFromError(result.Error)
+				errorMsg := result.Error
+				if url != "" {
+					// Make it clear what URL was attempted
+					errorMsg = fmt.Sprintf("URL not found (404): %s", url)
+				}
+
+				result.Message = fmt.Sprintf("%s %s %s",
+					result.Message,
+					errorMsg,
+					hint)
+			} else if hint != "" {
+				result.Message = fmt.Sprintf("%s %s %s",
 					result.Message,
 					result.Error,
 					hint)
-				result.Error = ""
 			}
+			result.Error = "" // Clear the error field as we've incorporated it into the message
 		} else {
 			// Explicitly mark progress messages
 			result.IsProgress = strings.Contains(strings.ToLower(result.Message), "running") ||
 				strings.Contains(strings.ToLower(result.Message), "testing") ||
 				strings.Contains(strings.ToLower(result.Message), "establishing")
+
+			// Add a formatted note for the successful completion stages to make them stand out
+			if !result.IsProgress && (result.Stage == stageSoundscapeUpload || result.Stage == stageDetectionPost) {
+				// Add an extra formatting to highlight the verification instructions
+				if strings.Contains(result.Message, "This recording should appear") ||
+					strings.Contains(result.Message, "should be visible on your BirdWeather dashboard") {
+					// HTML is already properly formatted in the message from the testing module
+					// Just add a verification tip that stands out
+					result.Message = fmt.Sprintf("%s Visit your BirdWeather station page to verify this test submission was received.",
+						result.Message)
+				}
+			}
 		}
 
 		if err := enc.Encode(result); err != nil {
@@ -144,26 +179,39 @@ func generateBirdWeatherTroubleshootingHint(result *birdweather.TestResult) stri
 		return "" // No hint needed for successful tests
 	}
 
+	// Check for rate limiting errors first
+	if result.Stage == "Starting Test" && strings.Contains(result.Error, "rate limit exceeded") {
+		return "To prevent abuse of the BirdWeather service, we limit how often tests can be run. " +
+			"Please wait the indicated time and try again."
+	}
+
 	// Return troubleshooting hints based on the stage and error message
 	switch result.Stage {
 	case stageAPIConnectivity:
-		if strings.Contains(result.Error, "timeout") ||
-			strings.Contains(result.Error, "i/o timeout") {
+		switch {
+		case strings.Contains(result.Error, "404"):
+			return "The BirdWeather API endpoint returned a 404 error. This may indicate that the BirdWeather service has made changes to their API structure. Please check for any announcements from BirdWeather about API changes, or try again later as the service might be experiencing temporary issues."
+		case strings.Contains(result.Error, "fallback DNS"):
+			return "We attempted to connect using both your system's DNS resolver and public DNS services (Cloudflare, Google, and Quad9), but all attempts failed. This could indicate a more serious connectivity issue or that the BirdWeather service is currently unavailable. Please check your internet connection and try again later."
+		case strings.Contains(result.Error, "timeout") || strings.Contains(result.Error, "i/o timeout"):
 			return "Check your internet connection and ensure that app.birdweather.com is accessible from your network. Consider checking for any firewall rules that might be blocking outbound connections."
+		case strings.Contains(result.Error, "no such host") || strings.Contains(result.Error, "DNS"):
+			return "Could not resolve the BirdWeather API hostname. We attempted to use alternative DNS servers as a fallback, but all attempts failed. Please check your DNS configuration and internet connectivity."
+		default:
+			return "Unable to connect to the BirdWeather API. Verify your internet connection and network settings."
 		}
-		if strings.Contains(result.Error, "no such host") ||
-			strings.Contains(result.Error, "DNS") {
-			return "Could not resolve the BirdWeather API hostname. Check your DNS configuration and internet connectivity."
-		}
-		return "Unable to connect to the BirdWeather API. Verify your internet connection and network settings."
 
 	case stageAuthentication:
-		if strings.Contains(result.Error, "status code 401") ||
-			strings.Contains(result.Error, "status code 403") ||
-			strings.Contains(result.Error, "invalid station ID") {
+		switch {
+		case strings.Contains(result.Error, "fallback"):
+			return "We attempted multiple methods to authenticate with BirdWeather but all failed. This could indicate network issues or that the BirdWeather service is currently experiencing problems. Please check your internet connection and try again later."
+		case strings.Contains(result.Error, "404"):
+			return "The BirdWeather station could not be found (404 error). Please verify that your BirdWeather station ID is correct and that your station is still registered and active on the BirdWeather platform."
+		case strings.Contains(result.Error, "status code 401") || strings.Contains(result.Error, "status code 403") || strings.Contains(result.Error, "invalid station ID"):
 			return "Authentication failed. Please verify that your BirdWeather Station ID is correct and that your station is registered and active on the BirdWeather platform."
+		default:
+			return "Failed to authenticate with BirdWeather. Check your BirdWeather token and ensure your station is properly registered on the BirdWeather platform."
 		}
-		return "Failed to authenticate with BirdWeather. Check your BirdWeather token and ensure your station is properly registered on the BirdWeather platform."
 
 	case stageSoundscapeUpload:
 		return "Failed to upload the test soundscape. This could be due to network issues, authentication problems, or the BirdWeather service might be experiencing issues. Try again later or check your BirdWeather station settings."
@@ -174,4 +222,52 @@ func generateBirdWeatherTroubleshootingHint(result *birdweather.TestResult) stri
 	default:
 		return "Something went wrong with the BirdWeather test. Check your connection settings and try again."
 	}
+}
+
+// extractURLFromError extracts a URL from an error message
+func extractURLFromError(errorMessage string) string {
+	// Common URL prefixes to look for
+	urlPrefixes := []string{"http://", "https://"}
+
+	// Check for https:// or http:// in the error message
+	for _, prefix := range urlPrefixes {
+		if idx := strings.Index(errorMessage, prefix); idx >= 0 {
+			// Extract everything from the prefix start until a space, newline, or end of string
+			urlStart := idx
+			urlEnd := len(errorMessage)
+
+			// Find the end of the URL (space, newline, closing parenthesis, etc.)
+			for i := urlStart; i < len(errorMessage); i++ {
+				char := errorMessage[i]
+				if char == ' ' || char == '\n' || char == '\r' || char == ')' || char == '"' || char == '\'' {
+					urlEnd = i
+					break
+				}
+			}
+
+			return errorMessage[urlStart:urlEnd]
+		}
+	}
+
+	// Look for specific patterns like "URL: something" or "at something"
+	patterns := []string{"URL: ", "at ", "endpoint: ", "tried URL: "}
+	for _, pattern := range patterns {
+		if idx := strings.Index(errorMessage, pattern); idx >= 0 {
+			start := idx + len(pattern)
+			end := len(errorMessage)
+
+			// Find the end of the URL
+			for i := start; i < len(errorMessage); i++ {
+				char := errorMessage[i]
+				if char == ' ' || char == '\n' || char == '\r' || char == ')' || char == '"' || char == '\'' {
+					end = i
+					break
+				}
+			}
+
+			return errorMessage[start:end]
+		}
+	}
+
+	return ""
 }

--- a/internal/httpcontroller/htmx_routes.go
+++ b/internal/httpcontroller/htmx_routes.go
@@ -134,6 +134,10 @@ func (s *Server) initRoutes() {
 	s.Echo.GET("/api/v1/mqtt/test", h.WithErrorHandling(h.TestMQTT), s.AuthMiddleware)
 	s.Echo.POST("/api/v1/mqtt/test", h.WithErrorHandling(h.TestMQTT), s.AuthMiddleware)
 
+	// Add GET and POST methods for testing BirdWeather connection
+	s.Echo.GET("/api/v1/birdweather/test", h.WithErrorHandling(h.TestBirdWeather), s.AuthMiddleware)
+	s.Echo.POST("/api/v1/birdweather/test", h.WithErrorHandling(h.TestBirdWeather), s.AuthMiddleware)
+
 	// Setup Error handler
 	s.Echo.HTTPErrorHandler = func(err error, c echo.Context) {
 		if handleErr := s.Handlers.HandleError(err, c); handleErr != nil {

--- a/internal/httpcontroller/middleware.go
+++ b/internal/httpcontroller/middleware.go
@@ -179,6 +179,7 @@ func isProtectedRoute(path string) bool {
 		strings.HasPrefix(path, "/api/v1/detections/review") ||
 		strings.HasPrefix(path, "/api/v1/detections/lock") ||
 		strings.HasPrefix(path, "/api/v1/mqtt/") ||
+		strings.HasPrefix(path, "/api/v1/birdweather/") ||
 		strings.HasPrefix(path, "/api/v2/system/") || // Protect all system API routes
 		strings.HasPrefix(path, "/api/v2/settings/") ||
 		strings.HasPrefix(path, "/api/v2/control/") ||

--- a/views/pages/settings/integrationSettings.html
+++ b/views/pages/settings/integrationSettings.html
@@ -75,7 +75,19 @@
                 "max" "1"
                 "tooltip" "Minimum confidence threshold for uploading predictions to BirdWeather."
                 }}
-
+            
+            <!-- Multi-Stage Operation Component for BirdWeather Connection Test -->
+            {{template "multiStageOperation" dict
+                "operationName" "BirdWeather Connection Test"
+                "apiEndpoint" "/api/v1/birdweather/test"
+                "stageOrder" "['Starting Test', 'API Connectivity', 'Authentication', 'Soundscape Upload', 'Detection Post']"
+                "buttonText" "Test BirdWeather Connection"
+                "buttonLoadingText" "Testing..."
+                "buttonDisabledCondition" "!birdweather.enabled || !birdweather.id || isRunning"
+                "buttonTooltipMap" "!birdweather.enabled ? 'BirdWeather must be enabled to test' : !birdweather.id ? 'BirdWeather token must be specified' : isRunning ? 'Test in progress...' : 'Test BirdWeather connection'"
+                "payload" "{enabled: birdweather.enabled, id: birdweather.id, threshold: birdweather.threshold, locationAccuracy: birdweather.locationAccuracy, debug: birdweather.debug}"
+                "completionMessage" "Please remember to save settings to apply the changes permanently."
+            }}
         </div>
     </div>
 </div>


### PR DESCRIPTION
This PR implements dynamic start and stop functionality for the BirdWeather client during reconfiguration, eliminating the need to restart BirdNET-Go after making configuration changes.