### PR TITLE
refactor: enhance RTSP URL sanitization and streamline audio source a…

### DIFF
--- a/internal/analysis/processor/actions.go
+++ b/internal/analysis/processor/actions.go
@@ -266,6 +266,10 @@ func (a *MqttAction) Execute(data interface{}) error {
 		birdImage = imageprovider.BirdImage{}
 	}
 
+	// Create a copy of the Note with sanitized RTSP URL
+	noteCopy := a.Note
+	noteCopy.Source = conf.SanitizeRTSPUrl(noteCopy.Source)
+
 	// Wrap note with bird image
 	noteWithBirdImage := NoteWithBirdImage{Note: a.Note, BirdImage: birdImage}
 

--- a/internal/conf/utils.go
+++ b/internal/conf/utils.go
@@ -406,11 +406,16 @@ func IsSafePath(path string) bool {
 }
 
 // SanitizeRTSPUrl removes sensitive information from RTSP URL and returns a display-friendly version
-func SanitizeRTSPUrl(url string) string {
+func SanitizeRTSPUrl(source string) string {
+	// If not an RTSP URL, return as is
+	if !strings.HasPrefix(source, "rtsp://") {
+		return source
+	}
+
 	// Find the @ symbol that separates credentials from host
 	atIndex := -1
-	for i := len("rtsp://"); i < len(url); i++ {
-		if url[i] == '@' {
+	for i := len("rtsp://"); i < len(source); i++ {
+		if source[i] == '@' {
 			atIndex = i
 			break
 		}
@@ -418,13 +423,13 @@ func SanitizeRTSPUrl(url string) string {
 
 	if atIndex > -1 {
 		// Keep only rtsp:// and everything after @
-		url = "rtsp://" + url[atIndex+1:]
+		source = "rtsp://" + source[atIndex+1:]
 	}
 
 	// Find the first slash after the host:port
 	slashIndex := -1
-	for i := len("rtsp://"); i < len(url); i++ {
-		if url[i] == '/' {
+	for i := len("rtsp://"); i < len(source); i++ {
+		if source[i] == '/' {
 			slashIndex = i
 			break
 		}
@@ -432,8 +437,8 @@ func SanitizeRTSPUrl(url string) string {
 
 	if slashIndex > -1 {
 		// Keep only up to the first slash
-		url = url[:slashIndex]
+		source = source[:slashIndex]
 	}
 
-	return url
+	return source
 }

--- a/internal/observation/observation.go
+++ b/internal/observation/observation.go
@@ -44,12 +44,7 @@ func New(settings *conf.Settings, beginTime, endTime time.Time, species string, 
 	if settings.Input.Path != "" {
 		audioSource = settings.Input.Path
 	} else {
-		// If source is RTSP, sanitize URL before applying it
-		if strings.HasPrefix(source, "rtsp://") {
-			audioSource = conf.SanitizeRTSPUrl(source)
-		} else {
-			audioSource = source
-		}
+		audioSource = source
 	}
 
 	// Round confidence to two decimal places


### PR DESCRIPTION
…ssignment

- Updated the SanitizeRTSPUrl function to return the original source if it is not an RTSP URL.
- Simplified the audio source assignment in the New function by removing unnecessary sanitization checks.
- Added a copy of the Note with a sanitized RTSP URL in the Execute method of MqttAction.

fixes https://github.com/tphakala/birdnet-go/issues/534 which was caused by RTSP URL sanitization for Note struct, capture prosess was no longer able to find correct capture buffer