### PR TITLE
chore(deps): update Go version to 1.24.1 in Dockerfile, go.mod, and C…

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   golangci:
     name: lint
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -40,4 +40,4 @@ jobs:
           # Require: The version of golangci-lint to use.
           # When `install-mode` is `binary` (default) the value can be v1.2 or v1.2.3 or `latest` to use the latest version.
           # When `install-mode` is `goinstall` the value can be v1.2.3, `latest`, or the hash of a commit.
-          version: v1.63
+          version: v1.64

--- a/.github/workflows/golangci-test.yml
+++ b/.github/workflows/golangci-test.yml
@@ -11,7 +11,7 @@ jobs:
 
   unit-tests:
     needs: golangci
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.24'
           check-latest: true
 
       - name: Install Linux system dependencies

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.24'
           check-latest: true
 
       - name: Install Linux system dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG TFLITE_LIB_DIR=/usr/lib
 ARG TENSORFLOW_VERSION=2.17.1
 
-FROM --platform=$BUILDPLATFORM golang:1.23.5-bookworm AS buildenv
+FROM --platform=$BUILDPLATFORM golang:1.24.1-bookworm AS buildenv
 
 # Pass BUILD_VERSION through to the build stage
 ARG BUILD_VERSION

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/tphakala/birdnet-go
 
-go 1.23.2
-
-toolchain go1.24.1
+go 1.24.1
 
 require (
 	cgt.name/pkg/go-mwclient v1.3.0


### PR DESCRIPTION
…I workflows

- Updated the Go version in Dockerfile and go.mod to 1.24.1 for consistency.
- Modified GitHub Actions workflows for nightly and release builds to use Go 1.24, ensuring compatibility with the latest features and improvements.