### PR TITLE
feat: Prevent redirect from root dashboard path

### DIFF
--- a/assets/util.js
+++ b/assets/util.js
@@ -45,9 +45,15 @@ function initializeDatePicker() {
 
 	const today = getIsoDateString(new Date());
 	const newValue = hashDate || today;
-	
-	// Only trigger change if the value is actually different
-	if (picker.value !== newValue) {
+
+	if (hashDate === '') {
+		// Allow the dashboard root path to always load "today" without
+		// triggering a page change
+		picker.value = today
+		picker.classList.remove('invisible');
+	}
+	else if (picker.value !== newValue) {
+		// Only trigger change if the value is actually different
 		picker.value = newValue;
 		picker.classList.remove('invisible');
 		htmx.trigger(picker, 'change');


### PR DESCRIPTION
- Prevents pushing a date (e.g. `192.168.1.100:8080/#2025-03-27`) to the URL when loading the dashboard without any value set (e.g. the root path `192.168.1.100:8080/`).
- Still allows today's date to be set once you start changing it with the picker. 
- Useful when wanting to reload the webpage and always get today's information.
- Resolves https://github.com/tphakala/birdnet-go/issues/571
- Might resolve: https://github.com/tphakala/birdnet-go/issues/585