### PR TITLE
Feat: Add Species Code to analytics endpoints

### DIFF
--- a/internal/api/v2/analytics.go
+++ b/internal/api/v2/analytics.go
@@ -14,6 +14,7 @@ import (
 type SpeciesDailySummary struct {
 	ScientificName string `json:"scientific_name"`
 	CommonName     string `json:"common_name"`
+	SpeciesCode    string `json:"species_code,omitempty"`
 	Count          int    `json:"count"`
 	HourlyCounts   []int  `json:"hourly_counts"`
 	HighConfidence bool   `json:"high_confidence"`
@@ -26,6 +27,7 @@ type SpeciesDailySummary struct {
 type SpeciesSummary struct {
 	ScientificName string  `json:"scientific_name"`
 	CommonName     string  `json:"common_name"`
+	SpeciesCode    string  `json:"species_code,omitempty"`
 	Count          int     `json:"count"`
 	FirstSeen      string  `json:"first_seen,omitempty"`
 	LastSeen       string  `json:"last_seen,omitempty"`
@@ -79,6 +81,7 @@ func (c *Controller) GetDailySpeciesSummary(ctx echo.Context) error {
 	birdData := make(map[string]struct {
 		CommonName     string
 		ScientificName string
+		SpeciesCode    string
 		Count          int
 		HourlyCounts   [24]int
 		HighConfidence bool
@@ -116,6 +119,7 @@ func (c *Controller) GetDailySpeciesSummary(ctx echo.Context) error {
 			birdData[birdKey] = struct {
 				CommonName     string
 				ScientificName string
+				SpeciesCode    string
 				Count          int
 				HourlyCounts   [24]int
 				HighConfidence bool
@@ -124,6 +128,7 @@ func (c *Controller) GetDailySpeciesSummary(ctx echo.Context) error {
 			}{
 				CommonName:     note.CommonName,
 				ScientificName: note.ScientificName,
+				SpeciesCode:    note.SpeciesCode,
 				Count:          totalCount,
 				HourlyCounts:   hourlyCounts,
 				HighConfidence: note.Confidence >= 0.8, // Define high confidence
@@ -176,6 +181,7 @@ func (c *Controller) GetDailySpeciesSummary(ctx echo.Context) error {
 		result = append(result, SpeciesDailySummary{
 			ScientificName: data.ScientificName,
 			CommonName:     data.CommonName,
+			SpeciesCode:    data.SpeciesCode,
 			Count:          data.Count,
 			HourlyCounts:   hourlyCounts,
 			HighConfidence: data.HighConfidence,
@@ -240,6 +246,7 @@ func (c *Controller) GetSpeciesSummary(ctx echo.Context) error {
 		summary := SpeciesSummary{
 			ScientificName: data.ScientificName,
 			CommonName:     data.CommonName,
+			SpeciesCode:    data.SpeciesCode,
 			Count:          data.Count,
 			FirstSeen:      firstSeen,
 			LastSeen:       lastSeen,

--- a/internal/api/v2/analytics_test.go
+++ b/internal/api/v2/analytics_test.go
@@ -34,6 +34,7 @@ func TestGetSpeciesSummary(t *testing.T) {
 		{
 			ScientificName: "Turdus migratorius",
 			CommonName:     "American Robin",
+			SpeciesCode:    "amerob",
 			Count:          42,
 			FirstSeen:      firstSeen,
 			LastSeen:       lastSeen,
@@ -43,6 +44,7 @@ func TestGetSpeciesSummary(t *testing.T) {
 		{
 			ScientificName: "Cyanocitta cristata",
 			CommonName:     "Blue Jay",
+			SpeciesCode:    "blujay",
 			Count:          27,
 			FirstSeen:      time.Now().AddDate(0, -2, 0),
 			LastSeen:       time.Now(),
@@ -78,9 +80,11 @@ func TestGetSpeciesSummary(t *testing.T) {
 		assert.Len(t, response, 2)
 		assert.Equal(t, "Turdus migratorius", response[0]["scientific_name"])
 		assert.Equal(t, "American Robin", response[0]["common_name"])
+		assert.Equal(t, "amerob", response[0]["species_code"])
 		assert.Equal(t, float64(42), response[0]["count"])
 		assert.Equal(t, "Cyanocitta cristata", response[1]["scientific_name"])
 		assert.Equal(t, "Blue Jay", response[1]["common_name"])
+		assert.Equal(t, "blujay", response[1]["species_code"])
 		assert.Equal(t, float64(27), response[1]["count"])
 	}
 

--- a/internal/datastore/analytics.go
+++ b/internal/datastore/analytics.go
@@ -10,6 +10,7 @@ import (
 type SpeciesSummaryData struct {
 	ScientificName string
 	CommonName     string
+	SpeciesCode    string
 	Count          int
 	FirstSeen      time.Time
 	LastSeen       time.Time
@@ -39,6 +40,7 @@ func (ds *DataStore) GetSpeciesSummaryData() ([]SpeciesSummaryData, error) {
 		SELECT 
 			scientific_name,
 			MAX(common_name) as common_name,
+			species_code,
 			COUNT(*) as count,
 			MIN(date || ' ' || time) as first_seen,
 			MAX(date || ' ' || time) as last_seen,
@@ -62,6 +64,7 @@ func (ds *DataStore) GetSpeciesSummaryData() ([]SpeciesSummaryData, error) {
 		if err := rows.Scan(
 			&summary.ScientificName,
 			&summary.CommonName,
+			&summary.SpeciesCode,
 			&summary.Count,
 			&firstSeenStr,
 			&lastSeenStr,

--- a/internal/datastore/interfaces.go
+++ b/internal/datastore/interfaces.go
@@ -276,6 +276,7 @@ func (ds *DataStore) GetTopBirdsData(selectedDate string, minConfidenceNormalize
 	type SpeciesCount struct {
 		CommonName     string
 		ScientificName string
+		SpeciesCode    string
 		Count          int
 		Confidence     float64
 		Date           string
@@ -289,9 +290,9 @@ func (ds *DataStore) GetTopBirdsData(selectedDate string, minConfidenceNormalize
 
 	// First, get the count and common names
 	query := ds.DB.Table("notes").
-		Select("common_name, scientific_name, COUNT(*) as count, MAX(confidence) as confidence, date, MAX(time) as time").
+		Select("common_name, scientific_name, species_code, COUNT(*) as count, MAX(confidence) as confidence, date, MAX(time) as time").
 		Where("date = ? AND confidence >= ?", selectedDate, minConfidenceNormalized).
-		Group("common_name, scientific_name, date").
+		Group("common_name, scientific_name, species_code, date").
 		Order("count DESC").
 		Limit(reportCount)
 
@@ -306,6 +307,7 @@ func (ds *DataStore) GetTopBirdsData(selectedDate string, minConfidenceNormalize
 		note := Note{
 			CommonName:     result.CommonName,
 			ScientificName: result.ScientificName,
+			SpeciesCode:    result.SpeciesCode,
 			Confidence:     result.Confidence,
 			Date:           result.Date,
 			Time:           result.Time,


### PR DESCRIPTION
I'm using the `/api/v2/analytics/species/summary` and `/api/v2/analytics/species/daily` endpoints in Home Assistant. 

I really like templating direct URLs to the ebird website so I can view them from my Home Assistant dashboard. But this requires the species code.

e.g.: https://ebird.org/species/amecro

I'd like to add the `species_code` to the bundled analytics summary endpoints. 

I've run this locally and deployed an image to my server. It returns the data as expected. But haven't been able to confirm whether or not the tests work.

Returned data from the server looks good. 

![image](https://github.com/user-attachments/assets/c7136dff-651c-4e43-b3d7-7d669f6dbc59)

![image](https://github.com/user-attachments/assets/43cdb352-726c-4df8-8937-a27c4599ca34)

