### PR TITLE
fix: Fix root dashboard to trigger topBirdsChart to render

### DIFF
--- a/assets/util.js
+++ b/assets/util.js
@@ -51,6 +51,7 @@ function initializeDatePicker() {
 		// triggering a page change
 		picker.value = today
 		picker.classList.remove('invisible');
+		htmx.trigger(picker, 'load');
 	}
 	else if (picker.value !== newValue) {
 		// Only trigger change if the value is actually different

--- a/views/elements/dashboard.html
+++ b/views/elements/dashboard.html
@@ -17,7 +17,7 @@
 					</g>
 				</svg>
 			</button>
-			<input type="date" hx-get="/api/v1/top-birds" hx-target="#topBirdsChart" hx-trigger="change"
+			<input type="date" hx-get="/api/v1/top-birds" hx-target="#topBirdsChart" hx-trigger="change, load"
 				hx-include="*[name]" hx-params="date"
 				class="input input-sm sm:w-36 focus-visible:outline-none self-center whitespace-nowrap" id="datePicker"
 				name="date" onchange="updateDate(this.value)">


### PR DESCRIPTION
Discovered an issue where the `topBirdsChart` didn't load when the dashboard was loaded on the root path.

This wasn't discovered in my initial testing as I had no birds being recorded on the dev server. 

This issue is now corrected with a new trigger (one which doesn't load the other routes). 

**NOTE**: Since there's no cache clearing mechanism, in order for the redirect to be fixed and the `topBirdsChart` to populate, the cache needs to be cleared on the local device before it will start working as intended. In desktop chrome, you can clear the cache from the network tab. In mobile chrome, this can be done by connecting the device over dev tools (while connected to a desktop in developer mode) and clearing it in the network tab as well (but I don't expect many people to do this).

Shown working here:

![image](https://github.com/user-attachments/assets/d0a8ef3c-5927-4328-a5a9-e2f71a2c4413)

