### PR TITLE
Allow files with .m4a extensions to be cleaned up

### DIFF
--- a/internal/diskmanager/file_utils.go
+++ b/internal/diskmanager/file_utils.go
@@ -15,7 +15,7 @@ import (
 )
 
 // allowedFileTypes is the list of file extensions that are allowed to be deleted
-var allowedFileTypes = []string{".wav", ".flac", ".aac", ".opus", ".mp3"}
+var allowedFileTypes = []string{".wav", ".flac", ".aac", ".opus", ".mp3", ".m4a"}
 
 // FileInfo holds information about a file
 type FileInfo struct {

--- a/internal/diskmanager/policy_age_test.go
+++ b/internal/diskmanager/policy_age_test.go
@@ -112,7 +112,7 @@ func TestAgeBasedCleanupFileTypeEligibility(t *testing.T) {
 // TestAgeBasedFilesAfterFilter tests the filtering of files for age-based cleanup
 func TestAgeBasedFilesAfterFilter(t *testing.T) {
 	db := &MockDB{}
-	allowedTypes := []string{".wav", ".mp3", ".flac", ".aac", ".opus"}
+	allowedTypes := []string{".wav", ".mp3", ".flac", ".aac", ".opus", ".m4a"}
 
 	// Create a temporary directory
 	testDir, err := os.MkdirTemp("", "age_filter_test")
@@ -123,7 +123,7 @@ func TestAgeBasedFilesAfterFilter(t *testing.T) {
 
 	// Let's create files of all relevant types
 	fileTypes := []string{
-		".wav", ".mp3", ".flac", ".aac", ".opus",
+		".wav", ".mp3", ".flac", ".aac", ".opus", ".m4a",
 		".txt", ".jpg", ".png", ".db", ".exe",
 	}
 

--- a/internal/diskmanager/policy_usage_test.go
+++ b/internal/diskmanager/policy_usage_test.go
@@ -71,6 +71,7 @@ func TestFileTypesEligibleForDeletion(t *testing.T) {
 		{"bubo_bubo_80p_20210102T150405Z.flac", ".flac", true, "FLAC files should be eligible for deletion"},
 		{"bubo_bubo_80p_20210102T150405Z.aac", ".aac", true, "AAC files should be eligible for deletion"},
 		{"bubo_bubo_80p_20210102T150405Z.opus", ".opus", true, "OPUS files should be eligible for deletion"},
+		{"bubo_bubo_80p_20210102T150405Z.m4a", ".m4a", true, "M4A files should be eligible for deletion"},
 
 		// Disallowed file types (should not be eligible for deletion)
 		{"bubo_bubo_80p_20210102T150405Z.txt", ".txt", false, "TXT files should not be eligible for deletion"},
@@ -134,6 +135,7 @@ func TestParseFileInfoWithDifferentExtensions(t *testing.T) {
 		{"bubo_bubo_80p_20210102T150405Z.flac", ".flac", true},
 		{"bubo_bubo_80p_20210102T150405Z.aac", ".aac", true},
 		{"bubo_bubo_80p_20210102T150405Z.opus", ".opus", true},
+		{"bubo_bubo_80p_20210102T150405Z.m4a", ".m4a", true},
 		{"bubo_bubo_80p_20210102T150405Z.txt", ".txt", false}, // Unsupported extension
 	}
 
@@ -439,6 +441,7 @@ func TestUsageBasedCleanupWithAllFileTypes(t *testing.T) {
 			{Path: tempDir + "/anas_platyrhynchos_70p_20210103T150405Z.flac", Species: "anas_platyrhynchos", Confidence: 70, Timestamp: parseTime("20210103T150405Z"), Size: 2048},
 			{Path: tempDir + "/erithacus_rubecula_60p_20210104T150405Z.aac", Species: "erithacus_rubecula", Confidence: 60, Timestamp: parseTime("20210104T150405Z"), Size: 768},
 			{Path: tempDir + "/passer_domesticus_90p_20210105T150405Z.opus", Species: "passer_domesticus", Confidence: 90, Timestamp: parseTime("20210105T150405Z"), Size: 1536},
+			{Path: tempDir + "/turdus_migratorius_95p_20210105T150405Z.m4a", Species: "turdus_migratorius", Confidence: 95, Timestamp: parseTime("20210105T150405Z"), Size: 2560},
 			// Add more instances of bubo_bubo to test min clips per species
 			{Path: tempDir + "/bubo_bubo_75p_20210106T150405Z.wav", Species: "bubo_bubo", Confidence: 75, Timestamp: parseTime("20210106T150405Z"), Size: 1024},
 			{Path: tempDir + "/bubo_bubo_65p_20210107T150405Z.mp3", Species: "bubo_bubo", Confidence: 65, Timestamp: parseTime("20210107T150405Z"), Size: 512},


### PR DESCRIPTION
AAC Export Type creates `.m4a` files. This PR allows these files to be pruned per the retention policy.