### PR TITLE
Load spectrogram-placeholder.svg on missing Audio Files

### DIFF
--- a/views/fragments/detectionDetails.html
+++ b/views/fragments/detectionDetails.html
@@ -25,7 +25,7 @@
 		<div class="audio-player-container group relative min-w-[50px]">
 			<!-- Spectrogram Image -->
 			<img loading="lazy" src="/api/v1/media/spectrogram?clip={{.Note.ClipName}}" alt="Spectrogram"
-				class="w-full h-auto rounded-lg shadow-sm">
+				class="w-full h-auto rounded-lg shadow-sm" onerror="this.onerror=null; this.src='/assets/images/spectrogram-placeholder.svg'">
 	  
 			<!-- Play position indicator -->
 			<div id="position-indicator-0" class="absolute top-0 bottom-0 w-0.5 bg-gray-100 pointer-events-none"

--- a/views/fragments/listDetections.html
+++ b/views/fragments/listDetections.html
@@ -135,7 +135,7 @@
                     <div class="audio-player-container relative min-w-[50px]">
                         <!-- Spectrogram Image -->
                         <img loading="lazy" width="400" src="/api/v1/media/spectrogram?clip={{.ClipName}}" alt="Spectrogram Image"
-                            class="w-full h-auto rounded-md object-contain">
+                            class="w-full h-auto rounded-md object-contain" onerror="this.onerror=null; this.src='/assets/images/spectrogram-placeholder.svg'">
 
                         <!-- Play position indicator -->
                         <div id="position-indicator-{{.ID}}" class="absolute top-0 bottom-0 w-0.5 bg-gray-100 pointer-events-none"

--- a/views/fragments/recentDetections.html
+++ b/views/fragments/recentDetections.html
@@ -91,7 +91,7 @@
         <div class="audio-player-container relative min-w-[50px]">
           <!-- Spectrogram Image -->
           <img loading="lazy" width="400" src="/api/v1/media/spectrogram?clip={{.ClipName}}" alt="Spectrogram Image"
-            class="w-full h-auto rounded-md object-contain">
+            class="w-full h-auto rounded-md object-contain" onerror="this.onerror=null; this.src='/assets/images/spectrogram-placeholder.svg'">
 
           <!-- Play position indicator -->
           <div id="position-indicator-{{.ID}}" class="absolute top-0 bottom-0 w-0.5 bg-gray-100 pointer-events-none"
@@ -176,7 +176,7 @@
     <div class="audio-player-container relative">
       <!-- Spectrogram Image -->
       <img loading="lazy" src="/api/v1/media/spectrogram?clip={{.ClipName}}" alt="Spectrogram"
-        class="w-full h-auto rounded-md shadow-sm">
+        class="w-full h-auto rounded-md shadow-sm" onerror="this.onerror=null; this.src='/assets/images/spectrogram-placeholder.svg'">
 
       <!-- Play position indicator -->
       <div id="position-indicator-{{.ID}}b" class="absolute top-0 bottom-0 w-0.5 bg-gray-100 pointer-events-none"


### PR DESCRIPTION
PR is to make a cosmetic update to the HTML fragments when the audio file/spectrogram fails to load. This utilizes the existing asset `/assets/images/spectrogram-placeholder.svg` to replace the alt text currently being displayed.