### PR TITLE
feat: update locale options in installation script and configuration

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -667,12 +667,12 @@ configure_locale() {
     print_message "Available languages:" "$YELLOW"
     
     # Create arrays for locales
-    declare -a locale_codes=("af" "ca" "cs" "zh" "hr" "da" "nl" "en" "et" "fi" "fr" "de" "el" "hu" "is" "id" "it" "ja" "lv" "lt" "no" "pl" "pt" "ru" "sk" "sl" "es" "sv" "th" "uk")
-    declare -a locale_names=("Afrikaans" "Catalan" "Czech" "Chinese" "Croatian" "Danish" "Dutch" "English" "Estonian" "Finnish" "French" "German" "Greek" "Hungarian" "Icelandic" "Indonesia" "Italian" "Japanese" "Latvian" "Lithuania" "Norwegian" "Polish" "Portuguese" "Russian" "Slovak" "Slovenian" "Spanish" "Swedish" "Thai" "Ukrainian")
+    declare -a locale_codes=("af" "ar" "bg" "ca" "cs" "zh" "hr" "da" "nl" "en" "en-uk" "en-us" "et" "fi" "fr" "de" "el" "he" "hu" "is" "id" "it" "ja" "ko" "lv" "lt" "ml" "no" "pl" "pt" "pt-br" "pt-pt" "ro" "ru" "sr" "sk" "sl" "es" "sv" "th" "tr" "uk")
+    declare -a locale_names=("Afrikaans" "Arabic" "Bulgarian" "Catalan" "Czech" "Chinese" "Croatian" "Danish" "Dutch" "English" "English (UK)" "English (US)" "Estonian" "Finnish" "French" "German" "Greek" "Hebrew" "Hungarian" "Icelandic" "Indonesian" "Italian" "Japanese" "Korean" "Latvian" "Lithuanian" "Malayalam" "Norwegian" "Polish" "Portuguese" "Brazilian Portuguese" "Portuguese (Portugal)" "Romanian" "Russian" "Serbian" "Slovak" "Slovenian" "Spanish" "Swedish" "Thai" "Turkish" "Ukrainian")
     
     # Display available locales
     for i in "${!locale_codes[@]}"; do
-        printf "%2d) %-12s" "$((i+1))" "${locale_names[i]}"
+        printf "%2d) %-20s" "$((i+1))" "${locale_names[i]}"
         if [ $((i % 3)) -eq 2 ]; then
             echo
         fi

--- a/internal/conf/defaults.go
+++ b/internal/conf/defaults.go
@@ -26,7 +26,7 @@ func setDefaultConfig() {
 	viper.SetDefault("birdnet.threshold", 0.8)
 	viper.SetDefault("birdnet.overlap", 0.0)
 	viper.SetDefault("birdnet.threads", 0)
-	viper.SetDefault("birdnet.locale", "en")
+	viper.SetDefault("birdnet.locale", "en-uk")
 	viper.SetDefault("birdnet.latitude", 0.000)
 	viper.SetDefault("birdnet.longitude", 0.000)
 	viper.SetDefault("birdnet.modelpath", "")

--- a/internal/conf/locale.go
+++ b/internal/conf/locale.go
@@ -21,6 +21,9 @@ var ModelLabelMapping = map[string]LabelConfig{
 	},
 }
 
+// IMPORTANT: When adding or modifying locale entries, also update the locale_codes and locale_names arrays
+// in the configure_locale() function in install.sh to keep installation options in sync with app capabilities.
+
 // LocaleCodeMapping maps 2-letter codes to file identifiers for the V2.4 format
 var LocaleCodeMapping = map[string]string{
 	"af":    "af",


### PR DESCRIPTION
- Added new locale codes and names to the `configure_locale()` function in `install.sh`, including support for Arabic, Bulgarian, and additional English variants.
- Changed the default locale in `defaults.go` from "en" to "en-uk".
- Added a note in `locale.go` to ensure synchronization between locale options and application capabilities.

These changes enhance the localization support of the application.