### PR TITLE
Add MQTT Retain flag

### DIFF
--- a/assets/js/components/multiStageOperation.js
+++ b/assets/js/components/multiStageOperation.js
@@ -76,6 +76,9 @@ document.addEventListener('alpine:init', () => {
             isDNSResolutionIssue(result) {
                 if (!result) return false;
                 
+                // Only consider it a DNS issue if there was an actual failure
+                if (result.success === true && !result.error) return false;
+                
                 // Check for DNS-related keywords in error or message
                 const hasDNSError = result.error && (
                     result.error.toLowerCase().includes('dns') ||

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -146,6 +146,7 @@ type MQTTSettings struct {
 	Topic         string        // MQTT topic
 	Username      string        // MQTT username
 	Password      string        // MQTT password
+	Retain        bool          // true to retain messages
 	RetrySettings RetrySettings // settings for retry mechanism
 }
 

--- a/internal/conf/config.yaml
+++ b/internal/conf/config.yaml
@@ -19,7 +19,7 @@ birdnet:
   threshold: 0.8          # threshold for prediction confidence to report, 0.0 to 1.0
   overlap: 1.5            # overlap between chunks, 0.0 to 2.9
   threads: 0              # 0 to use all available CPU threads
-  locale: en              # language to use for labels
+  locale: en-us           # language to use for labels
   latitude: 00.000        # latitude of recording location for prediction filtering
   longitude: 00.000       # longitude of recording location for prediction filtering
   rangefilter:

--- a/internal/conf/defaults.go
+++ b/internal/conf/defaults.go
@@ -139,6 +139,7 @@ func setDefaultConfig() {
 	viper.SetDefault("realtime.mqtt.topic", "birdnet")
 	viper.SetDefault("realtime.mqtt.username", "")
 	viper.SetDefault("realtime.mqtt.password", "")
+	viper.SetDefault("realtime.mqtt.retain", false)
 	viper.SetDefault("realtime.mqtt.retrysettings.enabled", true)
 	viper.SetDefault("realtime.mqtt.retrysettings.maxretries", 5)
 	viper.SetDefault("realtime.mqtt.retrysettings.initialdelay", 30)

--- a/internal/httpcontroller/handlers/settings.go
+++ b/internal/httpcontroller/handlers/settings.go
@@ -707,7 +707,8 @@ func mqttSettingsChanged(oldSettings, currentSettings *conf.Settings) bool {
 		oldSettings.Realtime.MQTT.Broker != currentSettings.Realtime.MQTT.Broker ||
 		oldSettings.Realtime.MQTT.Topic != currentSettings.Realtime.MQTT.Topic ||
 		oldSettings.Realtime.MQTT.Username != currentSettings.Realtime.MQTT.Username ||
-		oldSettings.Realtime.MQTT.Password != currentSettings.Realtime.MQTT.Password
+		oldSettings.Realtime.MQTT.Password != currentSettings.Realtime.MQTT.Password ||
+		oldSettings.Realtime.MQTT.Retain != currentSettings.Realtime.MQTT.Retain
 }
 
 // birdWeatherSettingsChanged checks if BirdWeather integration settings have changed

--- a/internal/mqtt/client.go
+++ b/internal/mqtt/client.go
@@ -43,6 +43,7 @@ func NewClient(settings *conf.Settings, metrics *telemetry.Metrics) (Client, err
 	config.Username = settings.Realtime.MQTT.Username
 	config.Password = settings.Realtime.MQTT.Password
 	config.Topic = settings.Realtime.MQTT.Topic
+	config.Retain = settings.Realtime.MQTT.Retain
 
 	return &client{
 		config:        config,
@@ -185,7 +186,7 @@ func (c *client) Publish(ctx context.Context, topic, payload string) error {
 
 	go func() {
 		close(publishStarted)
-		token := c.internalClient.Publish(topic, defaultQoS, false, payload)
+		token := c.internalClient.Publish(topic, defaultQoS, c.config.Retain, payload)
 		if !token.WaitTimeout(c.config.PublishTimeout) {
 			done <- fmt.Errorf("publish timeout after %v", c.config.PublishTimeout)
 			return

--- a/internal/mqtt/mqtt.go
+++ b/internal/mqtt/mqtt.go
@@ -38,6 +38,7 @@ type Config struct {
 	Username          string
 	Password          string
 	Topic             string // Default topic for publishing messages
+	Retain            bool   // true to retain messages at the broker
 	ReconnectCooldown time.Duration
 	ReconnectDelay    time.Duration
 	// Connection timeouts

--- a/views/pages/settings/integrationSettings.html
+++ b/views/pages/settings/integrationSettings.html
@@ -104,6 +104,7 @@
         topic: '{{.Settings.Realtime.MQTT.Topic}}',
         username: '{{.Settings.Realtime.MQTT.Username}}',
         password: '{{.Settings.Realtime.MQTT.Password}}',
+        retain: {{.Settings.Realtime.MQTT.Retain}},
         testResults: [],
         isTesting: false,
         currentTestStage: null
@@ -137,6 +138,11 @@
         mqtt.currentTestStage = null;
     });
     $watch('mqtt.password', () => { 
+        hasChanges = true;
+        mqtt.testResults = [];
+        mqtt.currentTestStage = null;
+    });
+    $watch('mqtt.retain', () => { 
         hasChanges = true;
         mqtt.testResults = [];
         mqtt.currentTestStage = null;
@@ -203,8 +209,29 @@
                 "label" "Password"
                 "placeholder" ""
                 "tooltip" "The MQTT password."}}
+          
+            {{template "checkbox" dict
+                "id" "mqttRetain"
+                "model" "mqtt.retain"
+                "name" "realtime.mqtt.retain"
+                "label" "Retain Messages"
+                "tooltip" "When enabled, MQTT broker will keep the last message on each topic and deliver to new subscribers."}}
 
-            <!-- Multi-Stage Operation Component for MQTT Connection Test -->
+        </div>
+        
+        <!-- Note about MQTT Retain for HomeAssistant - full width -->
+        <div x-show="mqtt.enabled" class="text-sm my-4 px-4 py-3 bg-base-200 rounded-md">
+            <span class="text-info-content">
+                <i class="fa-solid fa-circle-info mr-1"></i><strong>Home Assistant Users:</strong> 
+                It's recommended to enable the retain flag for Home Assistant integration. Without retain, 
+                MQTT sensors will appear as 'unknown' when Home Assistant restarts. With retain enabled, 
+                Home Assistant can retrieve the last known state of the sensor. This is similar to how platforms 
+                like Zigbee2MQTT preserve sensor states across Home Assistant restarts.
+            </span>
+        </div>
+
+        <!-- Multi-Stage Operation Component for MQTT Connection Test -->
+        <div x-show="mqtt.enabled" class="mt-4">
             {{template "multiStageOperation" dict
                 "operationName" "MQTT Connection Test"
                 "apiEndpoint" "/api/v1/mqtt/test"
@@ -213,7 +240,7 @@
                 "buttonLoadingText" "Testing..."
                 "buttonDisabledCondition" "!mqtt.enabled || !mqtt.broker || isRunning"
                 "buttonTooltipMap" "!mqtt.enabled ? 'MQTT must be enabled to test' : !mqtt.broker ? 'MQTT broker must be specified' : isRunning ? 'Test in progress...' : 'Test MQTT connection'"
-                "payload" "{enabled: mqtt.enabled, broker: mqtt.broker, topic: mqtt.topic, username: mqtt.username, password: mqtt.password}"
+                "payload" "{enabled: mqtt.enabled, broker: mqtt.broker, topic: mqtt.topic, username: mqtt.username, password: mqtt.password, retain: mqtt.retain}"
                 "completionMessage" "Please remember to save settings to apply the changes permanently."
             }}
         </div>


### PR DESCRIPTION
Fixes feature request https://github.com/tphakala/birdnet-go/issues/639

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for configuring the MQTT retain flag, allowing messages to be optionally retained on the broker.
  - Introduced a "Retain Messages" checkbox in the MQTT settings UI with explanatory notes for users.
- **Improvements**
  - The MQTT connection test now considers the retain flag setting.
  - Enhanced DNS resolution issue detection for improved error handling.
  - Updated BirdNET model locale from "en" to "en-us" in configuration.
- **Bug Fixes**
  - MQTT settings change detection now includes the retain flag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->