### PR TITLE
Add livestream settings with ffmpeg configuration

### DIFF
--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -284,6 +284,22 @@ type Security struct {
 	SessionSecret     string            // secret for session cookie
 }
 
+type WebServerSettings struct {
+	Debug      bool               // true to enable debug mode
+	Enabled    bool               // true to enable web server
+	Port       string             // port for web server
+	Log        LogConfig          // logging configuration for web server
+	LiveStream LiveStreamSettings // live stream configuration
+}
+
+type LiveStreamSettings struct {
+	Debug          bool   // true to enable debug mode
+	BitRate        int    // bitrate for live stream in kbps
+	SampleRate     int    // sample rate for live stream in Hz
+	SegmentLength  int    // length of each segment in seconds
+	FfmpegLogLevel string // log level for ffmpeg
+}
+
 // Settings contains all configuration options for the BirdNET-Go application.
 type Settings struct {
 	Debug bool // true to enable debug mode
@@ -302,16 +318,9 @@ type Settings struct {
 
 	Input InputConfig `yaml:"-"` // Input configuration for file and directory analysis
 
-	Realtime RealtimeSettings // Realtime processing settings
-
-	WebServer struct {
-		Debug   bool      // true to enable debug mode
-		Enabled bool      // true to enable web server
-		Port    string    // port for web server
-		Log     LogConfig // logging configuration for web server
-	}
-
-	Security Security // security configuration
+	Realtime  RealtimeSettings  // Realtime processing settings
+	WebServer WebServerSettings // web server configuration
+	Security  Security          // security configuration
 
 	Output struct {
 		File struct {

--- a/internal/conf/defaults.go
+++ b/internal/conf/defaults.go
@@ -174,6 +174,13 @@ func setDefaultConfig() {
 	viper.SetDefault("webserver.log.maxsize", 1048576)
 	viper.SetDefault("webserver.log.rotationday", time.Sunday)
 
+	// Live stream configuration
+	viper.SetDefault("webserver.livestream.debug", false)
+	viper.SetDefault("webserver.livestream.bitrate", 128)
+	viper.SetDefault("webserver.livestream.sampleRate", 48000)
+	viper.SetDefault("webserver.livestream.segmentLength", 2)
+	viper.SetDefault("webserver.livestream.ffmpegLogLevel", "info")
+
 	// File output configuration
 	viper.SetDefault("output.file.enabled", true)
 	viper.SetDefault("output.file.path", "output/")

--- a/internal/conf/validate.go
+++ b/internal/conf/validate.go
@@ -126,18 +126,22 @@ func validateBirdNETSettings(settings *BirdNETConfig) error {
 }
 
 // validateWebServerSettings validates the WebServer-specific settings
-func validateWebServerSettings(settings *struct {
-	Debug   bool
-	Enabled bool
-	Port    string
-	Log     LogConfig
-}) error {
+func validateWebServerSettings(settings *WebServerSettings) error {
 	if settings.Enabled {
 		// Check if port is provided when enabled
 		if settings.Port == "" {
 			return errors.New("WebServer port is required when enabled")
 		}
 		// You might want to add more specific port validation here
+	}
+
+	// Validate LiveStream settings
+	if settings.LiveStream.BitRate < 16 || settings.LiveStream.BitRate > 320 {
+		return fmt.Errorf("LiveStream bitrate must be between 16 and 320 kbps, got %d", settings.LiveStream.BitRate)
+	}
+
+	if settings.LiveStream.SegmentLength < 1 || settings.LiveStream.SegmentLength > 30 {
+		return fmt.Errorf("LiveStream segment length must be between 1 and 30 seconds, got %d", settings.LiveStream.SegmentLength)
 	}
 
 	return nil


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable live stream settings, including bitrate, sample rate, segment length, and FFmpeg log level, to the web server configuration.
- **Improvements**
  - Enhanced validation to ensure live stream settings are within recommended ranges.
  - FFmpeg arguments for audio streaming are now dynamically generated based on user-configured live stream settings.
- **Refactor**
  - Streamlined and organized web server and live stream configuration for easier management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->