### PR TITLE
feat: throttle cleanup process in disk manager

### DIFF
--- a/internal/diskmanager/policy_age.go
+++ b/internal/diskmanager/policy_age.go
@@ -112,6 +112,9 @@ func processFiles(files []FileInfo, speciesMonthCount map[string]map[string]int,
 				continue
 			}
 
+			// Sleep a while to throttle the cleanup
+			time.Sleep(100 * time.Millisecond)
+
 			subDir := filepath.Dir(file.Path)
 			if !canDeleteFile(file, subDir, speciesMonthCount, minClipsPerSpecies, debug) {
 				continue

--- a/internal/diskmanager/policy_usage.go
+++ b/internal/diskmanager/policy_usage.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"sort"
+	"time"
 
 	"github.com/tphakala/birdnet-go/internal/conf"
 )
@@ -136,6 +137,9 @@ func performCleanup(files []FileInfo, baseDir string, threshold float64, minClip
 				}
 				continue
 			}
+
+			// Sleep a while to throttle the cleanup
+			time.Sleep(100 * time.Millisecond)
 
 			// Delete the file
 			if debug {


### PR DESCRIPTION
- Added a sleep interval of 100 milliseconds in both processFiles and performCleanup functions to throttle the cleanup process, improving performance and reducing potential resource contention during file deletion.
- This change enhances the efficiency of file management operations within the disk manager.