### PR TITLE
Add whitespace-nowrap to CSS

### DIFF
--- a/views/fragments/birdsTable.html
+++ b/views/fragments/birdsTable.html
@@ -40,7 +40,7 @@
     {{range $index, $element := .NotesWithIndex}}
     <tr>
       <!-- Species row -->
-      <th scope="row" class="py-1 px-2 sm:px-4 font-medium">
+      <th scope="row" class="py-1 px-2 sm:px-4 font-medium whitespace-nowrap">
         <a href="#" hx-get="/api/v1/detections?species={{urlquery .Note.CommonName}}&date={{urlquery $.SelectedDate}}&queryType=species" hx-target="#mainContent" hx-trigger="click" hx-push-url="true">{{title .Note.CommonName}}
         </a>
       </th>


### PR DESCRIPTION
Add whitespace-nowrap to CSS to close #163. Tested with and w/o thumbnails in browser and mobile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved the display of species names in the birds table by preventing text from wrapping onto multiple lines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->