### PR TITLE
Load .svg on missing Audio Files

### DIFF
--- a/views/pages/search.html
+++ b/views/pages/search.html
@@ -501,7 +501,7 @@
                                                         
                                                         <!-- Spectrogram Image -->
                                                         <img :src="'/api/v2/spectrogram/' + result.id + '?width=400'" alt="Spectrogram" 
-                                                            class="w-full rounded object-cover" loading="lazy" />
+                                                        class="w-full rounded object-cover" loading="lazy" onerror="this.onerror=null; this.src='/assets/images/spectrogram-placeholder.svg'"/>
                                                         
                                                         <!-- Play position indicator -->
                                                         <div :id="'position-indicator-' + result.id" class="absolute top-0 bottom-0 w-0.5 bg-primary pointer-events-none"


### PR DESCRIPTION
PR is to make a cosmetic update to the search page when the audio file/spectrogram fails to load. This utilizes the existing asset `/assets/images/spectrogram-placeholder.svg` to replace the alt text currently being displayed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Added a fallback image for the spectrogram in the audio player to ensure a placeholder is shown if the original image fails to load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->