### PR TITLE
feat: Change BirdWeather soundscape uploads to FLAC format

### DIFF
--- a/internal/birdweather/README.md
+++ b/internal/birdweather/README.md
@@ -264,22 +264,23 @@ debug/
 
 ## Loudness Normalization Technical Details
 
-When FFmpeg is available, bird call audio is processed using the `loudnorm` filter to achieve these targets:
+When FFmpeg is available, bird call audio is processed using the `loudnorm` filter with a **two-pass** method to achieve these targets:
 
-- **Integrated Loudness (I)**: -14 LUFS - industry standard for streaming content
+- **Integrated Loudness (I)**: -23 LUFS - standard target for EBU R128 compliance
 - **True Peak (TP)**: -1 dB - prevents clipping during playback
 - **Loudness Range (LRA)**: 11 LU - maintains appropriate dynamic range
 
-The normalization process is performed in a **single FFmpeg step**:
-1. Reads raw PCM audio data from stdin
-2. Applies the `loudnorm` filter
-3. Encodes the normalized audio directly to FLAC format
+The normalization process involves:
+1.  **Pass 1 (Analysis)**: Reads raw PCM audio data and runs `loudnorm` in analysis mode (`print_format=json`) to measure the input audio's characteristics (I, LRA, TP, Threshold).
+2.  **Pass 2 (Normalization & Encoding)**: Reads the PCM data again, applies the `loudnorm` filter using the measured values from Pass 1 (`linear=true`, `measured_*` parameters), and encodes the normalized audio directly to FLAC format in a single step.
 
 Benefits:
-- Improves listening experience across different devices
-- Makes quiet bird calls more audible without clipping loud ones
-- Maintains audio quality through lossless compression
-- Efficient single-pass processing
+- Produces higher quality, more consistent normalization compared to single-pass, avoiding audible artifacts like "pumping".
+- Improves listening experience across different devices.
+- Makes quiet bird calls more audible without clipping loud ones.
+- Maintains audio quality through lossless compression.
+- Efficiently performs analysis on raw PCM data.
+- Falls back to single-pass normalization if the analysis pass fails.
 
 ## Testing
 

--- a/internal/birdweather/README.md
+++ b/internal/birdweather/README.md
@@ -8,7 +8,9 @@ BirdWeather is a service that allows sharing of bird detections and environmenta
 
 ## Features
 
-- **Audio Processing**: Convert PCM audio data to WAV format
+- **Audio Processing**: Convert PCM audio data to FLAC (preferred) or WAV format
+- **Format Selection**: Automatic selection between FLAC and WAV based on FFmpeg availability
+- **Loudness Normalization**: FLAC audio uploads are normalized to standard streaming loudness targets
 - **API Integration**: Connect to the BirdWeather API for data submission
 - **Location Privacy**: Randomize location coordinates to protect precise location data
 - **Error Handling**: Comprehensive network and API error handling
@@ -48,11 +50,25 @@ type BwClient struct {
 
 ### Audio Processing
 
-The package includes functionality to convert PCM audio data to WAV format for upload:
+The package includes functionality to convert PCM audio data to FLAC or WAV format for upload:
 
 ```go
+// FLAC encoding using FFmpeg (preferred) with loudness normalization
+func encodeFlacUsingFFmpeg(pcmData []byte, settings *conf.Settings) (*bytes.Buffer, error)
+
+// WAV encoding as fallback
 func encodePCMtoWAV(pcmData []byte) (*bytes.Buffer, error)
 ```
+
+### Loudness Normalization
+
+When FFmpeg is available, the package applies loudness normalization to FLAC audio files to ensure consistent playback quality:
+
+- **Target Loudness**: -14 LUFS (Loudness Units Full Scale) - optimal for web streaming
+- **True Peak Maximum**: -1 dB - prevents clipping in different playback environments
+- **Loudness Range**: 11 LU - balanced dynamic range
+
+The normalization makes bird vocalizations easier to hear across different devices and platforms while preserving audio quality through the lossless FLAC format.
 
 ### Location Randomization
 
@@ -88,6 +104,9 @@ func main() {
             Birdweather: conf.Birdweather{
                 ID:               "your-station-id",
                 LocationAccuracy: 1000, // Accuracy in meters
+            },
+            Audio: conf.AudioSettings{
+                FfmpegPath: "/path/to/ffmpeg", // Path to FFmpeg binary
             },
         },
         BirdNET: conf.BirdNET{
@@ -152,11 +171,14 @@ func testConnection(client *birdweather.BwClient) {
 
 ## Cross-Platform Compatibility
 
-This package is designed to work across Linux, macOS, and Windows platforms. The package handles:
+This package is designed to work across Linux, macOS, and Windows platforms. The Go code itself handles OS differences, but relies on external dependencies:
 
-- Network connectivity differences between platforms
-- Proper error handling for platform-specific network issues
-- Fallback DNS resolution for network problems
+- **FFmpeg Dependency**: The primary cross-platform requirement is the **installation and proper configuration of FFmpeg** on each target system. The path to the `ffmpeg` executable must be set correctly in the application configuration or be available in the system's `PATH`.
+- Network connectivity differences between platforms are handled internally.
+- Proper error handling for platform-specific network issues is implemented.
+- Fallback DNS resolution for network problems is used.
+- FFmpeg detection and usage for FLAC encoding with loudness normalization is performed.
+- WAV fallback when FFmpeg is not available ensures basic functionality.
 
 ## Error Handling
 
@@ -167,6 +189,8 @@ The package implements robust error handling, including:
 - Request timeout management
 - API response validation
 - Rate limiting for testing functions
+- Graceful fallback to WAV if FLAC encoding fails
+- Fallback to unnormalized FLAC if loudness normalization fails
 
 ## Resource Management
 
@@ -175,6 +199,8 @@ Client connections are properly managed to prevent resource leaks:
 - HTTP client timeouts to prevent hanging connections
 - Proper cleanup of resources in the `Close()` method
 - Idle connection cleanup
+- **In-Memory Processing**: Audio export via FFmpeg now occurs entirely in memory to reduce disk I/O, especially beneficial for systems using SD cards. However, be mindful that very large audio inputs could lead to increased memory consumption during this process.
+- Temporary files and directories are properly cleaned up
 
 ## Debug Capabilities
 
@@ -194,9 +220,9 @@ When debug mode is enabled (`Settings.Realtime.Birdweather.Debug = true`), the f
     - Audio specifications (sample rate, bit depth, etc.)
     - Expected duration
 
-- **WAV Audio Files**: Saves the processed WAV audio files
-  - Stored in `debug/birdweather/wav/` directory
-  - Filename format: `bw_debug_*.wav`
+- **Audio Files**: Saves the processed FLAC or WAV audio files
+  - Stored in `debug/birdweather/flac/` or `debug/birdweather/wav/` directory
+  - Filename format: `bw_debug_*.flac` or `bw_debug_*.wav`
   - Includes metadata in accompanying `.txt` file:
     - Timestamp information
     - File sizes (total file, buffer, PCM data)
@@ -228,10 +254,32 @@ debug/
 │   ├── pcm/                      # Raw PCM audio data
 │   │   ├── bw_pcm_debug_*.raw    # Raw PCM files
 │   │   └── bw_pcm_debug_*.txt    # Metadata files
-│   └── wav/                      # Processed WAV files
+│   ├── flac/                     # Processed FLAC files (when FFmpeg is available)
+│   │   ├── bw_debug_*.flac       # FLAC audio files
+│   │   └── bw_debug_*.txt        # Metadata files
+│   └── wav/                      # Processed WAV files (when FFmpeg is not available)
 │       ├── bw_debug_*.wav        # WAV audio files
 │       └── bw_debug_*.txt        # Metadata files
 ```
+
+## Loudness Normalization Technical Details
+
+When FFmpeg is available, bird call audio is processed using the `loudnorm` filter to achieve these targets:
+
+- **Integrated Loudness (I)**: -14 LUFS - industry standard for streaming content
+- **True Peak (TP)**: -1 dB - prevents clipping during playback
+- **Loudness Range (LRA)**: 11 LU - maintains appropriate dynamic range
+
+The normalization process is performed in a **single FFmpeg step**:
+1. Reads raw PCM audio data from stdin
+2. Applies the `loudnorm` filter
+3. Encodes the normalized audio directly to FLAC format
+
+Benefits:
+- Improves listening experience across different devices
+- Makes quiet bird calls more audible without clipping loud ones
+- Maintains audio quality through lossless compression
+- Efficient single-pass processing
 
 ## Testing
 
@@ -241,6 +289,7 @@ Comprehensive tests are provided for all key functionality:
 - API connectivity tests
 - Mock server tests for API interactions
 - Error handling tests
+- Loudness normalization validation
 
 ## Limitations
 
@@ -248,12 +297,16 @@ Comprehensive tests are provided for all key functionality:
 - Location accuracy is limited to 4 decimal places
 - Network connectivity is required for all API operations
 - **Location coordinates** are currently ignored by BirdWeather's API. Despite the location randomization feature, BirdWeather always uses the coordinates assigned to your station ID/token rather than the coordinates submitted with detections.
+- FLAC encoding requires **FFmpeg to be installed and configured correctly** on the host system (Linux, macOS, Windows).
+- Loudness normalization requires FFmpeg with the `loudnorm` filter (available in most modern FFmpeg builds).
+- **Memory Usage**: The in-memory FFmpeg processing, while reducing disk writes, might consume significant memory for very long audio inputs.
 
 ## Dependencies
 
 - Standard library packages (`net/http`, `encoding/binary`, etc.)
 - Internal `datastore` package for detection data structures
 - Internal `conf` package for configuration settings
+- Internal `myaudio` package for FFmpeg integration
 
 ## Thread Safety
 

--- a/internal/birdweather/audio.go
+++ b/internal/birdweather/audio.go
@@ -61,9 +61,9 @@ func encodePCMtoWAV(pcmData []byte) (*bytes.Buffer, error) {
 	return buffer, nil
 }
 
-// saveBufferToWAV writes a bytes.Buffer containing WAV data to a file, along with
-// timestamp information for debugging purposes.
-func saveBufferToWAV(buffer *bytes.Buffer, filename string, startTime, endTime time.Time) error {
+// saveBufferToFile writes a bytes.Buffer containing audio data to a file, along with
+// timestamp and format information for debugging purposes.
+func saveBufferToFile(buffer *bytes.Buffer, filename string, startTime, endTime time.Time) error {
 	// Validate input parameters
 	if buffer == nil {
 		return fmt.Errorf("buffer is nil")
@@ -78,7 +78,7 @@ func saveBufferToWAV(buffer *bytes.Buffer, filename string, startTime, endTime t
 		return fmt.Errorf("error creating directory: %w", err)
 	}
 
-	// Save the WAV file
+	// Save the audio file
 	file, err := os.Create(filename)
 	if err != nil {
 		return fmt.Errorf("error creating file: %w", err)
@@ -95,10 +95,10 @@ func saveBufferToWAV(buffer *bytes.Buffer, filename string, startTime, endTime t
 	if err != nil {
 		log.Printf("Warning: couldn't get file size: %v", err)
 	}
-	actualFileSize := fileInfo.Size()
-
-	// Calculate the actual PCM data size (total size minus 44 bytes for the WAV header)
-	pcmDataSize := actualFileSize - WAVHeaderSize
+	actualFileSize := int64(0)
+	if fileInfo != nil {
+		actualFileSize = fileInfo.Size()
+	}
 
 	// Create a metadata file with the same name but .txt extension
 	metaFilename := filename[:len(filename)-len(filepath.Ext(filename))] + ".txt"
@@ -110,15 +110,26 @@ func saveBufferToWAV(buffer *bytes.Buffer, filename string, startTime, endTime t
 	defer metaFile.Close()
 
 	// Write timestamp information to the metadata file
+	fileExt := filepath.Ext(filename)
 	metaInfo := fmt.Sprintf("File: %s\n", filepath.Base(filename))
+	metaInfo += fmt.Sprintf("Format: %s\n", fileExt)
 	metaInfo += fmt.Sprintf("Start Time: %s\n", startTime.Format(time.RFC3339))
 	metaInfo += fmt.Sprintf("End Time: %s\n", endTime.Format(time.RFC3339))
 	metaInfo += fmt.Sprintf("Duration: %s\n", endTime.Sub(startTime))
-	metaInfo += fmt.Sprintf("Total File Size: %d bytes\n", actualFileSize)
+	metaInfo += fmt.Sprintf("File Size: %d bytes\n", actualFileSize)
 	metaInfo += fmt.Sprintf("Buffer Size: %d bytes\n", bufferSize)
-	metaInfo += fmt.Sprintf("PCM Data Size: %d bytes\n", pcmDataSize)
-	metaInfo += fmt.Sprintf("Expected Audio Duration: %.3f seconds\n",
-		float64(pcmDataSize)/(48000.0*2.0))
+
+	// Add format-specific info if known (basic for now)
+	if fileExt == ".wav" {
+		// Calculate estimated PCM data size for WAV
+		pcmDataSize := actualFileSize - WAVHeaderSize
+		if pcmDataSize < 0 {
+			pcmDataSize = 0
+		}
+		metaInfo += fmt.Sprintf("Estimated PCM Data Size: %d bytes\n", pcmDataSize)
+		metaInfo += fmt.Sprintf("Expected Audio Duration (PCM): %.3f seconds\n",
+			float64(pcmDataSize)/(48000.0*2.0))
+	}
 	metaInfo += "Sample Rate: 48000 Hz\n"
 	metaInfo += "Bits Per Sample: 16\n"
 	metaInfo += "Channels: 1\n"

--- a/internal/birdweather/audio_test.go
+++ b/internal/birdweather/audio_test.go
@@ -272,7 +272,9 @@ func TestEncodeFlacUsingFFmpeg(t *testing.T) {
 	}
 
 	// Encode PCM to FLAC with normalization
-	flacBuffer, err := encodeFlacUsingFFmpeg(pcmData, settings)
+	// Pass a background context since this test doesn't need timeout control itself
+	ctx := context.Background()
+	flacBuffer, err := encodeFlacUsingFFmpeg(ctx, pcmData, settings)
 	if err != nil {
 		t.Errorf("encodeFlacUsingFFmpeg failed with valid input: %v", err)
 		return

--- a/internal/birdweather/audio_test.go
+++ b/internal/birdweather/audio_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"errors"
 	"io"
 	"math"
 	"os"
@@ -234,7 +235,7 @@ func TestContextTimeout(t *testing.T) {
 	if err == nil {
 		t.Error("Expected context timeout error, got nil")
 	}
-	if err != context.DeadlineExceeded {
+	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Errorf("Expected context.DeadlineExceeded error, got: %v", err)
 	}
 }

--- a/internal/birdweather/audio_test.go
+++ b/internal/birdweather/audio_test.go
@@ -271,10 +271,13 @@ func TestEncodeFlacUsingFFmpeg(t *testing.T) {
 		binary.LittleEndian.PutUint16(pcmData[i*2:], uint16(value))
 	}
 
+	// Determine the ffmpeg path for the test
+	ffmpegPathForTest := getFFmpegPath()
+
 	// Encode PCM to FLAC with normalization
 	// Pass a background context since this test doesn't need timeout control itself
 	ctx := context.Background()
-	flacBuffer, err := encodeFlacUsingFFmpeg(ctx, pcmData, settings)
+	flacBuffer, err := encodeFlacUsingFFmpeg(ctx, pcmData, ffmpegPathForTest, settings)
 	if err != nil {
 		t.Errorf("encodeFlacUsingFFmpeg failed with valid input: %v", err)
 		return

--- a/internal/birdweather/birdweather_client.go
+++ b/internal/birdweather/birdweather_client.go
@@ -324,7 +324,7 @@ func (b *BwClient) UploadSoundscape(timestamp string, pcmData []byte) (soundscap
 
 	// Create and execute the POST request
 	soundscapeURL := fmt.Sprintf("https://app.birdweather.com/api/v1/stations/%s/soundscapes?timestamp=%s&type=%s",
-		b.BirdweatherID, timestamp, audioExt)
+		b.BirdweatherID, url.QueryEscape(timestamp), audioExt)
 	req, err := http.NewRequest("POST", soundscapeURL, &gzipAudioData)
 	if err != nil {
 		log.Printf("❌ Failed to create POST request: %v\n", err)

--- a/internal/birdweather/birdweather_client.go
+++ b/internal/birdweather/birdweather_client.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/tphakala/birdnet-go/internal/conf"
@@ -213,7 +214,7 @@ func encodeFlacUsingFFmpeg(ctx context.Context, pcmData []byte, ffmpegPath strin
 
 // parseDouble safely parses a string to float64, returning defaultValue on error.
 func parseDouble(s string, defaultValue float64) float64 {
-	val, err := strconv.ParseFloat(s, 64)
+	val, err := strconv.ParseFloat(strings.TrimSpace(s), 64)
 	if err != nil {
 		return defaultValue
 	}

--- a/internal/birdweather/birdweather_client_test.go
+++ b/internal/birdweather/birdweather_client_test.go
@@ -297,7 +297,10 @@ func TestUploadSoundscape_ServerError(t *testing.T) {
 	// Create client with mocked URL
 	settings := MockSettings()
 	client, _ := New(settings)
-	client.HTTPClient = server.Client()
+	// Use the same mockTransport as the successful test to redirect the request
+	client.HTTPClient.Transport = &mockTransport{
+		server: server,
+	}
 
 	// Create test PCM data
 	pcmData := make([]byte, 48000)

--- a/internal/conf/utils.go
+++ b/internal/conf/utils.go
@@ -393,7 +393,7 @@ func IsSoxAvailable() (isAvailable bool, formats []string) {
 
 // ValidateToolPath checks if a tool is available, either at an explicit path or in the system PATH.
 // It returns the validated path to the tool if found, or an empty string and an error otherwise.
-func ValidateToolPath(configuredPath string, toolName string) (string, error) {
+func ValidateToolPath(configuredPath, toolName string) (string, error) {
 	if configuredPath != "" {
 		// Check if the explicitly configured path exists and is a file
 		if info, err := os.Stat(configuredPath); err == nil && !info.IsDir() {

--- a/internal/myaudio/ffmpeg_export.go
+++ b/internal/myaudio/ffmpeg_export.go
@@ -1,7 +1,9 @@
 package myaudio
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -17,7 +19,7 @@ const tempExt = ".temp"
 // pcmData is the PCM data to export
 func ExportAudioWithFFmpeg(pcmData []byte, outputPath string, settings *conf.AudioSettings) error {
 	// Validate the FFmpeg path
-	if err := validateFFmpegPath(settings.FfmpegPath); err != nil {
+	if err := validateFFmpegPathInternal(settings.FfmpegPath); err != nil {
 		return err
 	}
 
@@ -164,4 +166,123 @@ func getMaxBitrate(format, requestedBitrate string) string {
 		}
 	}
 	return requestedBitrate
+}
+
+// ExportAudioWithCustomFFmpegArgs exports PCM data using FFmpeg with custom arguments directly to a memory buffer.
+// This avoids writing temporary files to disk.
+// ffmpegPath is the path to the FFmpeg executable.
+// customArgs is a slice of strings representing additional FFmpeg arguments (including output format/codec).
+func ExportAudioWithCustomFFmpegArgs(pcmData []byte, ffmpegPath string, customArgs []string) (*bytes.Buffer, error) {
+	// Validate the FFmpeg path
+	if err := validateFFmpegPathInternal(ffmpegPath); err != nil {
+		return nil, err
+	}
+
+	// Run the FFmpeg command, capturing output to a buffer
+	outputBuffer, err := runCustomFFmpegCommandToBuffer(ffmpegPath, pcmData, customArgs)
+	if err != nil {
+		return nil, err // Error already includes FFmpeg output if execution failed
+	}
+
+	// Return the buffer containing the exported audio data
+	return outputBuffer, nil
+}
+
+// runCustomFFmpegCommandToBuffer executes FFmpeg, piping PCM input and capturing codec output to a buffer.
+func runCustomFFmpegCommandToBuffer(ffmpegPath string, pcmData []byte, customArgs []string) (*bytes.Buffer, error) {
+	// Get standard input format arguments
+	ffmpegSampleRate, ffmpegNumChannels, ffmpegFormat := getFFmpegFormat(conf.SampleRate, conf.NumChannels, conf.BitDepth)
+
+	// Build the base arguments for PCM input from stdin
+	args := []string{
+		"-f", ffmpegFormat, // Input format based on bit depth
+		"-ar", ffmpegSampleRate, // Sample rate
+		"-ac", ffmpegNumChannels, // Number of channels
+		"-i", "-", // Read from stdin
+	}
+
+	// Append the custom arguments provided by the caller (should include codec, filters, format)
+	args = append(args, customArgs...)
+
+	// Append the output destination: pipe:1 (stdout)
+	args = append(args, "pipe:1")
+
+	// Create the FFmpeg command
+	cmd := exec.Command(ffmpegPath, args...)
+
+	// Create pipes for stdin and stdout
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create stdin pipe: %w", err)
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create stdout pipe: %w", err)
+	}
+
+	// Capture stderr for better error reporting
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	// Start the FFmpeg command
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("failed to start FFmpeg: %w, stderr: %s", err, stderr.String())
+	}
+
+	// Use a separate goroutine to write PCM data to prevent blocking
+	// and capture potential write errors
+	writeErrChan := make(chan error, 1)
+	go func() {
+		defer stdin.Close() // Close stdin when writing is done
+		_, writeErr := stdin.Write(pcmData)
+		writeErrChan <- writeErr
+	}()
+
+	// Read stdout into a buffer
+	outputBuffer := bytes.NewBuffer(nil)
+	readDoneChan := make(chan error, 1)
+	go func() {
+		_, readErr := io.Copy(outputBuffer, stdout)
+		readDoneChan <- readErr
+	}()
+
+	// Wait for the command to finish
+	waitErr := cmd.Wait()
+
+	// Check for errors from writing, reading, and waiting
+	writeErr := <-writeErrChan
+	readErr := <-readDoneChan
+
+	if writeErr != nil {
+		return nil, fmt.Errorf("error writing PCM data to FFmpeg stdin: %w, stderr: %s", writeErr, stderr.String())
+	}
+	if readErr != nil {
+		return nil, fmt.Errorf("error reading FFmpeg stdout: %w, stderr: %s", readErr, stderr.String())
+	}
+	if waitErr != nil {
+		return nil, fmt.Errorf("FFmpeg failed: %w, stderr: %s", waitErr, stderr.String())
+	}
+
+	// Return the buffer if everything succeeded
+	return outputBuffer, nil
+}
+
+// validateFFmpegPathInternal checks if the provided FFmpeg path is valid and executable.
+func validateFFmpegPathInternal(ffmpegPath string) error {
+	if ffmpegPath == "" {
+		return fmt.Errorf("FFmpeg path is not configured")
+	}
+	// Check if the file exists
+	if _, err := os.Stat(ffmpegPath); os.IsNotExist(err) {
+		// If not found at the specified path, try looking in PATH
+		if _, pathErr := exec.LookPath(ffmpegPath); pathErr != nil {
+			return fmt.Errorf("FFmpeg not found at path '%s' or in system PATH: %w", ffmpegPath, err)
+		}
+		// If found in PATH, we can proceed (the path might just be the binary name)
+	} else if err != nil {
+		// Another error occurred during stat (e.g., permission denied)
+		return fmt.Errorf("error accessing FFmpeg path '%s': %w", ffmpegPath, err)
+	}
+	// Basic check passed (exists either at path or in system PATH)
+	return nil
 }

--- a/internal/myaudio/ffmpeg_export.go
+++ b/internal/myaudio/ffmpeg_export.go
@@ -24,9 +24,9 @@ const tempExt = ".temp"
 // outputPath is full path with audio file name and extension based on format
 // pcmData is the PCM data to export
 func ExportAudioWithFFmpeg(pcmData []byte, outputPath string, settings *conf.AudioSettings) error {
-	// Validate the FFmpeg path
-	if err := validateFFmpegPathInternal(settings.FfmpegPath); err != nil {
-		return err
+	// Assume settings.FfmpegPath is validated by conf.ValidateAudioSettings
+	if settings.FfmpegPath == "" {
+		return fmt.Errorf("FFmpeg path is not configured or invalid")
 	}
 
 	// Create a temporary file for FFmpeg output, returns full path with tempExt
@@ -238,9 +238,9 @@ func runCustomFFmpegCommandToBuffer(ffmpegPath string, pcmData []byte, customArg
 // ffmpegPath is the path to the FFmpeg executable.
 // customArgs is a slice of strings representing additional FFmpeg arguments (including output format/codec).
 func ExportAudioWithCustomFFmpegArgsContext(ctx context.Context, pcmData []byte, ffmpegPath string, customArgs []string) (*bytes.Buffer, error) {
-	// Validate the FFmpeg path
-	if err := validateFFmpegPathInternal(ffmpegPath); err != nil {
-		return nil, err
+	// Assume ffmpegPath is valid (validated by caller, usually via conf.ValidateAudioSettings)
+	if ffmpegPath == "" {
+		return nil, fmt.Errorf("FFmpeg path provided is empty")
 	}
 
 	// Run the FFmpeg command, capturing output to a buffer
@@ -362,7 +362,7 @@ func runCustomFFmpegCommandToBufferWithContext(ctx context.Context, ffmpegPath s
 
 // validateFFmpegPathInternal checks if the provided FFmpeg path is valid and executable.
 // If ffmpegPath is empty, it checks if "ffmpeg" is available in the system PATH.
-func validateFFmpegPathInternal(ffmpegPath string) error {
+/* func validateFFmpegPathInternal(ffmpegPath string) error {
 	if ffmpegPath == "" {
 		// If no path provided, check if "ffmpeg" is in the system PATH
 		if _, err := exec.LookPath("ffmpeg"); err != nil {
@@ -389,7 +389,7 @@ func validateFFmpegPathInternal(ffmpegPath string) error {
 
 	// Path exists and is accessible
 	return nil
-}
+} */
 
 // LoudnessStats holds the measured loudness statistics from FFmpeg's loudnorm filter.
 type LoudnessStats struct {
@@ -415,9 +415,9 @@ func AnalyzeAudioLoudness(pcmData []byte, ffmpegPath string) (*LoudnessStats, er
 // AnalyzeAudioLoudnessWithContext analyzes audio loudness using FFmpeg's loudnorm filter in analyze mode
 // This is the context-aware version of AnalyzeAudioLoudness that allows timeout/cancellation
 func AnalyzeAudioLoudnessWithContext(ctx context.Context, pcmData []byte, ffmpegPath string) (*LoudnessStats, error) {
-	// Validate the FFmpeg path
-	if err := validateFFmpegPathInternal(ffmpegPath); err != nil {
-		return nil, err
+	// Assume ffmpegPath is valid (validated by caller, usually via conf.ValidateAudioSettings)
+	if ffmpegPath == "" {
+		return nil, fmt.Errorf("FFmpeg path provided is empty")
 	}
 
 	// Get standard input format arguments

--- a/internal/myaudio/ffmpeg_export.go
+++ b/internal/myaudio/ffmpeg_export.go
@@ -177,212 +177,15 @@ func getMaxBitrate(format, requestedBitrate string) string {
 // ffmpegPath is the path to the FFmpeg executable.
 // customArgs is a slice of strings representing additional FFmpeg arguments (including output format/codec).
 func ExportAudioWithCustomFFmpegArgs(pcmData []byte, ffmpegPath string, customArgs []string) (*bytes.Buffer, error) {
-	// Validate the FFmpeg path
-	if err := validateFFmpegPathInternal(ffmpegPath); err != nil {
-		return nil, err
-	}
-
-	// Run the FFmpeg command, capturing output to a buffer
-	outputBuffer, err := runCustomFFmpegCommandToBuffer(ffmpegPath, pcmData, customArgs)
-	if err != nil {
-		return nil, err // Error already includes FFmpeg output if execution failed
-	}
-
-	// Return the buffer containing the exported audio data
-	return outputBuffer, nil
+	// Call the context-aware version with a background context
+	return ExportAudioWithCustomFFmpegArgsContext(context.Background(), pcmData, ffmpegPath, customArgs)
 }
 
 // runCustomFFmpegCommandToBuffer executes FFmpeg, piping PCM input and capturing codec output to a buffer.
+// Deprecated: Prefer runCustomFFmpegCommandToBufferWithContext for cancellation/timeout control.
 func runCustomFFmpegCommandToBuffer(ffmpegPath string, pcmData []byte, customArgs []string) (*bytes.Buffer, error) {
-	// Get standard input format arguments
-	ffmpegSampleRate, ffmpegNumChannels, ffmpegFormat := getFFmpegFormat(conf.SampleRate, conf.NumChannels, conf.BitDepth)
-
-	// Build the base arguments for PCM input from stdin
-	args := []string{
-		"-f", ffmpegFormat, // Input format based on bit depth
-		"-ar", ffmpegSampleRate, // Sample rate
-		"-ac", ffmpegNumChannels, // Number of channels
-		"-i", "-", // Read from stdin
-	}
-
-	// Append the custom arguments provided by the caller (should include codec, filters, format)
-	args = append(args, customArgs...)
-
-	// Append the output destination: pipe:1 (stdout)
-	args = append(args, "pipe:1")
-
-	// Create the FFmpeg command
-	cmd := exec.Command(ffmpegPath, args...)
-
-	// Create pipes for stdin and stdout
-	stdin, err := cmd.StdinPipe()
-	if err != nil {
-		return nil, fmt.Errorf("failed to create stdin pipe: %w", err)
-	}
-	stdout, err := cmd.StdoutPipe()
-	if err != nil {
-		return nil, fmt.Errorf("failed to create stdout pipe: %w", err)
-	}
-
-	// Capture stderr for better error reporting
-	var stderr bytes.Buffer
-	cmd.Stderr = &stderr
-
-	// Start the FFmpeg command
-	if err := cmd.Start(); err != nil {
-		return nil, fmt.Errorf("failed to start FFmpeg: %w, stderr: %s", err, stderr.String())
-	}
-
-	// Use a separate goroutine to write PCM data to prevent blocking
-	// and capture potential write errors
-	writeErrChan := make(chan error, 1)
-	go func() {
-		defer stdin.Close() // Close stdin when writing is done
-		_, writeErr := stdin.Write(pcmData)
-		writeErrChan <- writeErr
-	}()
-
-	// Read stdout into a buffer
-	outputBuffer := bytes.NewBuffer(nil)
-	readDoneChan := make(chan error, 1)
-	go func() {
-		_, readErr := io.Copy(outputBuffer, stdout)
-		readDoneChan <- readErr
-	}()
-
-	// Wait for the command to finish
-	waitErr := cmd.Wait()
-
-	// Check for errors from writing, reading, and waiting
-	writeErr := <-writeErrChan
-	readErr := <-readDoneChan
-
-	if writeErr != nil {
-		return nil, fmt.Errorf("error writing PCM data to FFmpeg stdin: %w, stderr: %s", writeErr, stderr.String())
-	}
-	if readErr != nil {
-		return nil, fmt.Errorf("error reading FFmpeg stdout: %w, stderr: %s", readErr, stderr.String())
-	}
-	if waitErr != nil {
-		return nil, fmt.Errorf("FFmpeg failed: %w, stderr: %s", waitErr, stderr.String())
-	}
-
-	// Return the buffer if everything succeeded
-	return outputBuffer, nil
-}
-
-// validateFFmpegPathInternal checks if the provided FFmpeg path is valid and executable.
-func validateFFmpegPathInternal(ffmpegPath string) error {
-	if ffmpegPath == "" {
-		return fmt.Errorf("FFmpeg path is not configured")
-	}
-	// Check if the file exists
-	if _, err := os.Stat(ffmpegPath); os.IsNotExist(err) {
-		// If not found at the specified path, try looking in PATH
-		if _, pathErr := exec.LookPath(ffmpegPath); pathErr != nil {
-			return fmt.Errorf("FFmpeg not found at path '%s' or in system PATH: %w", ffmpegPath, err)
-		}
-		// If found in PATH, we can proceed (the path might just be the binary name)
-	} else if err != nil {
-		// Another error occurred during stat (e.g., permission denied)
-		return fmt.Errorf("error accessing FFmpeg path '%s': %w", ffmpegPath, err)
-	}
-	// Basic check passed (exists either at path or in system PATH)
-	return nil
-}
-
-// LoudnessStats holds the measured loudness statistics from FFmpeg's loudnorm filter.
-type LoudnessStats struct {
-	InputI            string `json:"input_i"`
-	InputTP           string `json:"input_tp"`
-	InputLRA          string `json:"input_lra"`
-	InputThresh       string `json:"input_thresh"`
-	OutputI           string `json:"output_i"`      // Not used for 2-pass, but part of JSON
-	OutputTP          string `json:"output_tp"`     // Not used for 2-pass
-	OutputLRA         string `json:"output_lra"`    // Not used for 2-pass
-	OutputThresh      string `json:"output_thresh"` // Not used for 2-pass
-	NormalizationType string `json:"normalization_type"`
-	TargetOffset      string `json:"target_offset"` // Not used for 2-pass
-}
-
-// AnalyzeAudioLoudness runs the first pass of FFmpeg's loudnorm filter to get audio statistics.
-func AnalyzeAudioLoudness(pcmData []byte, ffmpegPath string) (*LoudnessStats, error) {
-	// Validate the FFmpeg path
-	if err := validateFFmpegPathInternal(ffmpegPath); err != nil {
-		return nil, err
-	}
-
-	// Get standard input format arguments
-	ffmpegSampleRate, ffmpegNumChannels, ffmpegFormat := getFFmpegFormat(conf.SampleRate, conf.NumChannels, conf.BitDepth)
-
-	// Build arguments for Pass 1 analysis
-	args := []string{
-		"-f", ffmpegFormat, // Input format
-		"-ar", ffmpegSampleRate, // Sample rate
-		"-ac", ffmpegNumChannels, // Channels
-		"-i", "-", // Read from stdin
-		"-af", "loudnorm=print_format=json", // Loudnorm filter in analysis mode
-		"-f", "null", // Null output format
-		"-", // Null output destination
-	}
-
-	cmd := exec.Command(ffmpegPath, args...)
-
-	// Create pipe for stdin
-	stdin, err := cmd.StdinPipe()
-	if err != nil {
-		return nil, fmt.Errorf("loudness analysis: failed to create stdin pipe: %w", err)
-	}
-
-	// Capture stderr, as loudnorm prints JSON there
-	var stderr bytes.Buffer
-	cmd.Stderr = &stderr
-
-	// Start command
-	if err := cmd.Start(); err != nil {
-		return nil, fmt.Errorf("loudness analysis: failed to start ffmpeg: %w", err)
-	}
-
-	// Write PCM data in a goroutine
-	writeErrChan := make(chan error, 1)
-	go func() {
-		defer stdin.Close()
-		_, writeErr := stdin.Write(pcmData)
-		writeErrChan <- writeErr
-	}()
-
-	// Wait for command completion and check write error
-	waitErr := cmd.Wait()
-	writeErr := <-writeErrChan
-
-	if writeErr != nil {
-		return nil, fmt.Errorf("loudness analysis: error writing PCM data to ffmpeg: %w, stderr: %s", writeErr, stderr.String())
-	}
-	// Even if waitErr is nil, loudnorm might print JSON, so we continue.
-	// If waitErr is not nil, it indicates a more serious FFmpeg problem.
-	if waitErr != nil && stderr.Len() == 0 { // Only return error if FFmpeg truly failed AND didn't print JSON
-		return nil, fmt.Errorf("loudness analysis: ffmpeg failed: %w, stderr: %s", waitErr, stderr.String())
-	}
-
-	// Extract JSON from stderr
-	// The JSON output is usually the last part of the stderr.
-	stderrStr := stderr.String()
-	jsonStart := strings.LastIndex(stderrStr, "{")
-	jsonEnd := strings.LastIndex(stderrStr, "}")
-
-	if jsonStart == -1 || jsonEnd == -1 || jsonStart > jsonEnd {
-		return nil, fmt.Errorf("loudness analysis: failed to find JSON in ffmpeg stderr. Output: %s", stderrStr)
-	}
-
-	jsonOutput := stderrStr[jsonStart : jsonEnd+1]
-
-	// Parse JSON
-	var stats LoudnessStats
-	if err := json.Unmarshal([]byte(jsonOutput), &stats); err != nil {
-		return nil, fmt.Errorf("loudness analysis: failed to parse JSON from ffmpeg: %w, json: %s", err, jsonOutput)
-	}
-
-	return &stats, nil
+	// Call the context-aware version with a background context
+	return runCustomFFmpegCommandToBufferWithContext(context.Background(), ffmpegPath, pcmData, customArgs)
 }
 
 // ExportAudioWithCustomFFmpegArgsContext exports PCM data using FFmpeg with custom arguments directly to a memory buffer.
@@ -510,6 +313,47 @@ func runCustomFFmpegCommandToBufferWithContext(ctx context.Context, ffmpegPath s
 
 	// Return the buffer containing the exported audio data
 	return outputBuffer, nil
+}
+
+// validateFFmpegPathInternal checks if the provided FFmpeg path is valid and executable.
+func validateFFmpegPathInternal(ffmpegPath string) error {
+	if ffmpegPath == "" {
+		return fmt.Errorf("FFmpeg path is not configured")
+	}
+	// Check if the file exists
+	if _, err := os.Stat(ffmpegPath); os.IsNotExist(err) {
+		// If not found at the specified path, try looking in PATH
+		if _, pathErr := exec.LookPath(ffmpegPath); pathErr != nil {
+			return fmt.Errorf("FFmpeg not found at path '%s' or in system PATH: %w", ffmpegPath, err)
+		}
+		// If found in PATH, we can proceed (the path might just be the binary name)
+	} else if err != nil {
+		// Another error occurred during stat (e.g., permission denied)
+		return fmt.Errorf("error accessing FFmpeg path '%s': %w", ffmpegPath, err)
+	}
+	// Basic check passed (exists either at path or in system PATH)
+	return nil
+}
+
+// LoudnessStats holds the measured loudness statistics from FFmpeg's loudnorm filter.
+type LoudnessStats struct {
+	InputI            string `json:"input_i"`
+	InputTP           string `json:"input_tp"`
+	InputLRA          string `json:"input_lra"`
+	InputThresh       string `json:"input_thresh"`
+	OutputI           string `json:"output_i"`      // Not used for 2-pass, but part of JSON
+	OutputTP          string `json:"output_tp"`     // Not used for 2-pass
+	OutputLRA         string `json:"output_lra"`    // Not used for 2-pass
+	OutputThresh      string `json:"output_thresh"` // Not used for 2-pass
+	NormalizationType string `json:"normalization_type"`
+	TargetOffset      string `json:"target_offset"` // Not used for 2-pass
+}
+
+// AnalyzeAudioLoudness runs the first pass of FFmpeg's loudnorm filter to get audio statistics.
+// Deprecated: Prefer AnalyzeAudioLoudnessWithContext for cancellation/timeout control.
+func AnalyzeAudioLoudness(pcmData []byte, ffmpegPath string) (*LoudnessStats, error) {
+	// Call the context-aware version with a background context
+	return AnalyzeAudioLoudnessWithContext(context.Background(), pcmData, ffmpegPath)
 }
 
 // AnalyzeAudioLoudnessWithContext analyzes audio loudness using FFmpeg's loudnorm filter in analyze mode

--- a/views/pages/settings/integrationSettings.html
+++ b/views/pages/settings/integrationSettings.html
@@ -15,7 +15,7 @@
         threshold: {{.Settings.Realtime.Birdweather.Threshold}},
         locationAccuracy: {{.Settings.Realtime.Birdweather.LocationAccuracy}}
     },
-    ffmpegAvailable: {{.IsFfmpegAvailable}},
+    ffmpegAvailable: {{ ffmpegAvailable }},
     birdweatherSettingsOpen: false,
     showTooltip: null,
     hasChanges: false,
@@ -46,11 +46,11 @@
          aria-labelledby="birdweatherDescription">
 
         <!-- FFmpeg availability notice -->
-        <div x-show="!ffmpegAvailable" class="alert alert-warning mb-4 shadow-sm">
+        <div x-show="!ffmpegAvailable" class="alert alert-warning mb-4 shadow-sm" x-cloak>
             <svg xmlns="http://www.w3.org/2000/svg" class="stroke-current shrink-0 h-6 w-6" fill="none" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" /></svg>
             <div>
                 <h3 class="font-bold">FFmpeg not detected</h3>
-                <p class="text-sm">Please install FFmpeg to enable high-quality FLAC uploads. Without FFmpeg, BirdWeather will use WAV format which results in larger file sizes and no audio normalization.</p>
+                <p class="text-sm">Please install FFmpeg to enable FLAC encoding support, BirdWeather is deprecating WAV uploads in favor of compressed FLAC audio files.</p>
             </div>
         </div>
 

--- a/views/pages/settings/integrationSettings.html
+++ b/views/pages/settings/integrationSettings.html
@@ -46,7 +46,7 @@
          aria-labelledby="birdweatherDescription">
 
         <!-- FFmpeg availability notice -->
-        <div x-show="!ffmpegAvailable" class="alert alert-warning mb-4 shadow-sm" x-cloak>
+        <div x-show="!ffmpegAvailable" class="alert alert-warning mb-4 shadow-sm" role="alert" aria-live="assertive" x-cloak>
             <svg xmlns="http://www.w3.org/2000/svg" class="stroke-current shrink-0 h-6 w-6" fill="none" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" /></svg>
             <div>
                 <h3 class="font-bold">FFmpeg not detected</h3>

--- a/views/pages/settings/integrationSettings.html
+++ b/views/pages/settings/integrationSettings.html
@@ -15,6 +15,7 @@
         threshold: {{.Settings.Realtime.Birdweather.Threshold}},
         locationAccuracy: {{.Settings.Realtime.Birdweather.LocationAccuracy}}
     },
+    ffmpegAvailable: {{.IsFfmpegAvailable}},
     birdweatherSettingsOpen: false,
     showTooltip: null,
     hasChanges: false,
@@ -43,6 +44,15 @@
          id="birdweatherSettingsContent" 
          role="group" 
          aria-labelledby="birdweatherDescription">
+
+        <!-- FFmpeg availability notice -->
+        <div x-show="!ffmpegAvailable" class="alert alert-warning mb-4 shadow-sm">
+            <svg xmlns="http://www.w3.org/2000/svg" class="stroke-current shrink-0 h-6 w-6" fill="none" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" /></svg>
+            <div>
+                <h3 class="font-bold">FFmpeg not detected</h3>
+                <p class="text-sm">Please install FFmpeg to enable high-quality FLAC uploads. Without FFmpeg, BirdWeather will use WAV format which results in larger file sizes and no audio normalization.</p>
+            </div>
+        </div>
 
         {{template "checkbox" dict
             "id" "birdweatherEnabled"


### PR DESCRIPTION
BirdWeather is deprecating WAV submissions in favor of the compressed FLAC file format. This PR changes BirdWeather submissions to use FLAC format. Additionally, the loudness of submitted audio files is adjusted to the broadcast standard of -23 LUFS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Audio uploads now use FLAC encoding with loudness normalization when FFmpeg is available, improving audio quality and reducing file size. If FFmpeg is not detected, uploads fall back to WAV format.
  - The settings page displays an alert if FFmpeg is unavailable, explaining the impact on audio uploads.
  - Added context-aware FFmpeg audio export with timeout and cancellation support, enhancing reliability.

- **Bug Fixes**
  - Enhanced error handling and fallback mechanisms for audio encoding and normalization processes.
  - Improved tool path validation for FFmpeg and SoX executables to ensure correct configuration.

- **Documentation**
  - Updated BirdWeather documentation to detail new audio processing workflows, dependencies, and testing coverage.

- **Tests**
  - Added tests to verify FLAC encoding, loudness normalization, and context-aware audio processing with FFmpeg.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->