### PR TITLE
refactor: Reduce duplicated code in diskmanager packag, add KeepSpectrograms flag and modify minclips setting behavior for age retention policy

### DIFF
--- a/internal/api/v2/analytics_test.go
+++ b/internal/api/v2/analytics_test.go
@@ -351,20 +351,7 @@ func TestGetInvalidAnalyticsRequests(t *testing.T) {
 	appSettings := &conf.Settings{
 		Realtime: conf.RealtimeSettings{
 			Audio: conf.AudioSettings{
-				Export: struct {
-					Debug     bool
-					Enabled   bool
-					Path      string
-					Type      string
-					Bitrate   string
-					Retention struct {
-						Debug    bool
-						Policy   string
-						MaxAge   string
-						MaxUsage string
-						MinClips int
-					}
-				}{
+				Export: conf.ExportSettings{
 					Path: t.TempDir(),
 				},
 			},

--- a/internal/api/v2/test_utils.go
+++ b/internal/api/v2/test_utils.go
@@ -592,20 +592,7 @@ func setupTestEnvironment(t *testing.T) (*echo.Echo, *MockDataStore, *Controller
 		},
 		Realtime: conf.RealtimeSettings{
 			Audio: conf.AudioSettings{
-				Export: struct {
-					Debug     bool
-					Enabled   bool
-					Path      string // path to audio clip export directory
-					Type      string
-					Bitrate   string
-					Retention struct {
-						Debug    bool
-						Policy   string
-						MaxAge   string
-						MaxUsage string
-						MinClips int
-					}
-				}{
+				Export: conf.ExportSettings{
 					Path: t.TempDir(), // Set the required path
 				},
 			},

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -37,27 +37,33 @@ type EqualizerSettings struct {
 	Filters []EqualizerFilter // equalizer filter configuration
 }
 
+type ExportSettings struct {
+	Debug     bool              // true to enable audio export debug
+	Enabled   bool              // export audio clips containing indentified bird calls
+	Path      string            // path to audio clip export directory
+	Type      string            // audio file type, wav, mp3 or flac
+	Bitrate   string            // bitrate for audio export
+	Retention RetentionSettings // retention settings
+}
+
+type RetentionSettings struct {
+	Debug            bool   // true to enable retention debug
+	Policy           string // retention policy, "none", "age" or "usage"
+	MaxAge           string // maximum age of audio clips to keep
+	MaxUsage         string // maximum disk usage percentage before cleanup
+	MinClips         int    // minimum number of clips per species to keep
+	KeepSpectrograms bool   // true to keep spectrograms
+}
+
 // AudioSettings contains settings for audio processing and export.
 type AudioSettings struct {
-	Source          string   // audio source to use for analysis
-	FfmpegPath      string   // path to ffmpeg, runtime value
-	SoxPath         string   // path to sox, runtime value
-	SoxAudioTypes   []string `yaml:"-"` // supported audio types of sox, runtime value
-	StreamTransport string   // preferred transport for audio streaming: "auto", "sse", or "ws"
-	Export          struct {
-		Debug     bool   // true to enable audio export debug
-		Enabled   bool   // export audio clips containing indentified bird calls
-		Path      string // path to audio clip export directory
-		Type      string // audio file type, wav, mp3 or flac
-		Bitrate   string // bitrate for audio export
-		Retention struct {
-			Debug    bool   // true to enable retention debug
-			Policy   string // retention policy, "none", "age" or "usage"
-			MaxAge   string // maximum age of audio clips to keep
-			MaxUsage string // maximum disk usage percentage before cleanup
-			MinClips int    // minimum number of clips per species to keep
-		}
-	}
+	Source          string         // audio source to use for analysis
+	FfmpegPath      string         // path to ffmpeg, runtime value
+	SoxPath         string         // path to sox, runtime value
+	SoxAudioTypes   []string       `yaml:"-"` // supported audio types of sox, runtime value
+	StreamTransport string         // preferred transport for audio streaming: "auto", "sse", or "ws"
+	Export          ExportSettings // export settings
+
 	Equalizer EqualizerSettings // equalizer settings
 }
 type Thumbnails struct {

--- a/internal/conf/config.yaml
+++ b/internal/conf/config.yaml
@@ -56,6 +56,7 @@ realtime:
         maxage: 30d       # age policy: maximum age of clips to keep before starting evictions
         maxusage: 80%     # usage policy: percentage of disk usage to trigger eviction        
         minclips: 10      # minumum number of clips per species to keep before starting evictions
+        keepspectrograms: true # true to keep spectrograms even when clips are deleted
 
 
   dashboard:

--- a/internal/conf/defaults.go
+++ b/internal/conf/defaults.go
@@ -85,6 +85,7 @@ func setDefaultConfig() {
 	viper.SetDefault("realtime.audio.export.retention.maxusage", "80%")
 	viper.SetDefault("realtime.audio.export.retention.maxage", "30d")
 	viper.SetDefault("realtime.audio.export.retention.minclips", 10)
+	viper.SetDefault("realtime.audio.export.retention.keepspectrograms", true)
 
 	// Dynamic threshold configuration
 	viper.SetDefault("realtime.dynamicthreshold.enabled", true)

--- a/internal/diskmanager/disk_usage.go
+++ b/internal/diskmanager/disk_usage.go
@@ -1,0 +1,9 @@
+// disk_usage.go - Common definitions for disk usage calculations
+
+package diskmanager
+
+// DiskSpaceInfo holds detailed disk space information.
+type DiskSpaceInfo struct {
+	TotalBytes uint64
+	UsedBytes  uint64
+}

--- a/internal/diskmanager/disk_usage_unix.go
+++ b/internal/diskmanager/disk_usage_unix.go
@@ -20,7 +20,25 @@ func GetDiskUsage(path string) (float64, error) {
 	totalBlocks := stat.Blocks
 	freeBlocks := stat.Bfree
 	usedBlocks := totalBlocks - freeBlocks
-	usagePercentage := float64(usedBlocks) / float64(totalBlocks) * 100.0
+	usagePercent := float64(usedBlocks) / float64(totalBlocks) * 100.0
 
-	return usagePercentage, nil
+	return usagePercent, nil
+}
+
+// GetDetailedDiskUsage returns the total and used disk space in bytes for the filesystem containing the given path.
+func GetDetailedDiskUsage(path string) (DiskSpaceInfo, error) {
+	var stat syscall.Statfs_t
+	err := syscall.Statfs(path, &stat)
+	if err != nil {
+		return DiskSpaceInfo{}, fmt.Errorf("failed to statfs '%s': %w", path, err)
+	}
+
+	totalBytes := stat.Blocks * uint64(stat.Bsize)
+	freeBytes := stat.Bavail * uint64(stat.Bsize) // Available to non-root user
+	usedBytes := totalBytes - freeBytes
+
+	return DiskSpaceInfo{
+		TotalBytes: totalBytes,
+		UsedBytes:  usedBytes,
+	}, nil
 }

--- a/internal/diskmanager/disk_usage_windows.go
+++ b/internal/diskmanager/disk_usage_windows.go
@@ -4,6 +4,7 @@
 package diskmanager
 
 import (
+	"fmt"
 	"syscall"
 	"unsafe"
 )
@@ -33,4 +34,38 @@ func GetDiskUsage(baseDir string) (float64, error) {
 	used := totalNumberOfBytes - totalNumberOfFreeBytes
 
 	return (float64(used) / float64(totalNumberOfBytes)) * 100, nil
+}
+
+/*
+// DiskSpaceInfo holds detailed disk space information.
+type DiskSpaceInfo struct {
+	TotalBytes uint64
+	UsedBytes  uint64
+}
+*/
+// DiskSpaceInfo is defined in the unix counterpart, keep struct definition commented out here
+// to avoid redeclaration errors during build, but keep for reference.
+
+// GetDetailedDiskUsage returns the total and used disk space in bytes for the filesystem containing the given path.
+func GetDetailedDiskUsage(path string) (DiskSpaceInfo, error) {
+	h := syscall.MustLoadDLL("kernel32.dll")
+	c := h.MustFindProc("GetDiskFreeSpaceExW")
+
+	var freeBytesAvailable, totalNumberOfBytes, totalNumberOfFreeBytes int64
+
+	ret, _, err := c.Call(uintptr(unsafe.Pointer(syscall.StringToUTF16Ptr(path))),
+		uintptr(unsafe.Pointer(&freeBytesAvailable)),
+		uintptr(unsafe.Pointer(&totalNumberOfBytes)),
+		uintptr(unsafe.Pointer(&totalNumberOfFreeBytes)))
+
+	if ret == 0 {
+		return DiskSpaceInfo{}, fmt.Errorf("failed to get disk free space for '%s': %w", path, err)
+	}
+
+	usedBytes := uint64(totalNumberOfBytes - totalNumberOfFreeBytes)
+
+	return DiskSpaceInfo{
+		TotalBytes: uint64(totalNumberOfBytes),
+		UsedBytes:  usedBytes,
+	}, nil
 }

--- a/internal/diskmanager/policy_age.go
+++ b/internal/diskmanager/policy_age.go
@@ -4,7 +4,11 @@ package diskmanager
 import (
 	"fmt"
 	"log"
+	"os"
+	"path/filepath"
+	"runtime"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/tphakala/birdnet-go/internal/conf"
@@ -51,8 +55,8 @@ func AgeBasedCleanup(quit <-chan struct{}, db Interface) CleanupResult { // Use 
 		return CleanupResult{Err: nil, ClipsRemoved: 0, DiskUtilization: int(diskUsage)} // Use common result type
 	}
 
-	// Create a map to keep track of the number of files per species per subdirectory
-	speciesMonthCount := buildSpeciesSubDirCountMap(files)
+	// Create a map to keep track of the *total* number of files per species
+	speciesTotalCount := buildSpeciesTotalCountMap(files) // Use the new function
 
 	// Sort files: Oldest first, then lowest confidence first as a tie-breaker
 	sort.SliceStable(files, func(i, j int) bool {
@@ -65,28 +69,142 @@ func AgeBasedCleanup(quit <-chan struct{}, db Interface) CleanupResult { // Use 
 	// Calculate the expiration time for age-based cleanup
 	expirationTime := time.Now().Add(-time.Duration(retentionPeriodInHours) * time.Hour)
 
-	// Define the age-specific deletion check function
-	ageCheck := func(file *FileInfo) (bool, string) {
-		if file.Timestamp.Before(expirationTime) {
-			return true, "older than retention period"
-		}
-		return false, ""
-	}
-
-	// Max deletions per run (moved from old processFiles)
+	// Max deletions per run
 	maxDeletions := 1000
 
-	// Call the generic processing loop with the age check
-	deletedCount, err := processFilesGeneric(files, speciesMonthCount,
+	// Call the helper function to process files
+	deletedCount, loopErr := processAgeBasedDeletionLoop(files, speciesTotalCount,
 		minClipsPerSpecies, maxDeletions, debug, keepSpectrograms,
-		quit,
-		ageCheck)
+		quit, expirationTime)
 
-	// Get current disk utilization after cleanup
+	// Get final disk utilization
 	diskUsage, diskErr := GetDiskUsage(baseDir)
 	if diskErr != nil {
-		return CleanupResult{Err: fmt.Errorf("cleanup completed but failed to get disk usage: %w", diskErr), ClipsRemoved: deletedCount, DiskUtilization: 0} // Use common result type
+		// Combine errors if getting disk usage failed after the loop
+		finalErr := fmt.Errorf("cleanup completed but failed to get disk usage: %w (loop error: %w)", diskErr, loopErr)
+		return CleanupResult{Err: finalErr, ClipsRemoved: deletedCount, DiskUtilization: 0}
 	}
 
-	return CleanupResult{Err: err, ClipsRemoved: deletedCount, DiskUtilization: int(diskUsage)} // Use common result type
+	// Return the final result, including any error encountered during the loop
+	return CleanupResult{Err: loopErr, ClipsRemoved: deletedCount, DiskUtilization: int(diskUsage)}
+}
+
+// processAgeBasedDeletionLoop handles the core logic of iterating through files,
+// checking age and minimum species counts, and deleting files.
+func processAgeBasedDeletionLoop(files []FileInfo, speciesTotalCount map[string]int,
+	minClipsPerSpecies int, maxDeletions int, debug bool, keepSpectrograms bool,
+	quit <-chan struct{}, expirationTime time.Time) (deletedCount int, loopErr error) {
+
+	deletedCount = 0
+	errorCount := 0
+
+	for i := range files {
+		select {
+		case <-quit:
+			log.Printf("Age-based cleanup loop interrupted by quit signal\n")
+			return deletedCount, nil // Indicate interruption, but not necessarily an error from the loop itself
+		default:
+			// Check if max deletions reached
+			if deletedCount >= maxDeletions {
+				if debug {
+					log.Printf("Reached maximum number of deletions (%d) for age-based cleanup.", maxDeletions)
+				}
+				return deletedCount, nil // Max deletions reached is not an error
+			}
+
+			file := &files[i] // Use pointer
+
+			// 1. Check eligibility using the helper function
+			eligible, reason := isEligibleForAgeDeletion(file, expirationTime, speciesTotalCount, minClipsPerSpecies, debug)
+			if !eligible {
+				// Log reason if debug enabled and not simply locked or not old enough (those are common)
+				if debug && reason != "locked" && reason != "not old enough" {
+					log.Printf("Skipping file %s: %s", file.Path, reason)
+				}
+				continue
+			}
+
+			// 2. Perform deletion using the helper function
+			if delErr := deleteFileAndOptionalSpectrogram(file, reason, keepSpectrograms, debug); delErr != nil {
+				errorCount++
+				log.Printf("Failed to remove %s: %s\n", file.Path, delErr) // Log error here
+				if errorCount > 10 {
+					// Assign error to be returned by the function
+					loopErr = fmt.Errorf("too many errors (%d) during age-based cleanup, last error: %w", errorCount, delErr)
+					return deletedCount, loopErr // Stop processing after too many errors
+				}
+				continue // Continue with the next file even if one fails
+			}
+
+			// 3. Update state *after* successful deletion
+			speciesTotalCount[file.Species]-- // Decrement total count for the species
+			deletedCount++
+
+			// 4. Yield to other goroutines
+			runtime.Gosched()
+		}
+	}
+
+	// Loop finished normally or due to max deletions
+	return deletedCount, loopErr
+}
+
+// isEligibleForAgeDeletion checks if a file meets the criteria for deletion based on age policy.
+func isEligibleForAgeDeletion(file *FileInfo, expirationTime time.Time, speciesTotalCount map[string]int,
+	minClipsPerSpecies int, debug bool) (eligible bool, reason string) {
+
+	// 1. Check if locked (reuse common helper)
+	if checkLocked(file, debug) {
+		return false, "locked"
+	}
+
+	// 2. Check if older than retention period
+	if !file.Timestamp.Before(expirationTime) {
+		return false, "not old enough"
+	}
+
+	// 3. Check minimum *total* clips constraint
+	if count, exists := speciesTotalCount[file.Species]; exists && count <= minClipsPerSpecies {
+		if debug {
+			log.Printf("Total clip count for %s is at or below the minimum threshold (%d). Cannot delete older file: %s",
+				file.Species, minClipsPerSpecies, file.Path)
+		}
+		return false, "minimum clip count reached"
+	}
+
+	// If all checks pass, the file is eligible
+	return true, "older than retention period and minimum count allows"
+}
+
+// deleteFileAndOptionalSpectrogram handles the deletion of the audio file
+// and its associated spectrogram if required.
+func deleteFileAndOptionalSpectrogram(file *FileInfo, reason string, keepSpectrograms, debug bool) error {
+	// Throttle slightly before deletion
+	time.Sleep(100 * time.Millisecond)
+
+	// Log intent before deleting
+	if debug {
+		log.Printf("Deleting file based on age policy (%s): %s", reason, file.Path)
+	}
+
+	// Delete the audio file (reuse common helper)
+	if err := deleteAudioFile(file, debug); err != nil {
+		// Error logging happens in the calling function (processAgeBasedDeletionLoop)
+		return err // Return the error to be handled by the caller
+	}
+
+	// Optionally delete associated spectrogram PNG file
+	if !keepSpectrograms {
+		pngPath := strings.TrimSuffix(file.Path, filepath.Ext(file.Path)) + ".png"
+		if pngErr := os.Remove(pngPath); pngErr != nil {
+			// Log if the PNG deletion fails, but don't treat as critical error for the main deletion process
+			if debug && !os.IsNotExist(pngErr) {
+				log.Printf("Warning: Failed to remove associated spectrogram %s: %v", pngPath, pngErr)
+			}
+		} else if debug {
+			log.Printf("Deleted associated spectrogram %s", pngPath)
+		}
+	}
+
+	return nil // Deletion successful
 }

--- a/internal/diskmanager/policy_age.go
+++ b/internal/diskmanager/policy_age.go
@@ -122,6 +122,10 @@ func processAgeBasedDeletionLoop(files []FileInfo, speciesTotalCount map[string]
 
 			// 3. Update state *after* successful deletion
 			speciesTotalCount[file.Species]-- // Decrement total count for the species
+			// Prevent count from going negative (safety check)
+			if speciesTotalCount[file.Species] < 0 {
+				speciesTotalCount[file.Species] = 0
+			}
 			deletedCount++
 
 			// 4. Yield to other goroutines

--- a/internal/diskmanager/policy_age.go
+++ b/internal/diskmanager/policy_age.go
@@ -11,7 +11,69 @@ import (
 	"github.com/tphakala/birdnet-go/internal/conf"
 )
 
+// formatTimeForHumans converts a Unix timestamp to a human-readable string format.
+// It returns both a formatted date/time string in local timezone and a human-readable duration.
+// Uses the system's local timezone for display consistency with file timestamps.
+func formatTimeForHumans(unixTime int64) (formattedTime, ageDuration string) {
+	// Convert Unix timestamp to time.Time in local timezone
+	t := time.Unix(unixTime, 0)
+
+	// Format the time with timezone info (local timezone)
+	formattedTime = t.Format("2006-01-02 15:04:05 MST")
+
+	// Calculate and format duration since now
+	// Using local time for both so the duration is accurate
+	durSeconds := time.Now().Unix() - unixTime
+	duration := time.Duration(durSeconds) * time.Second
+
+	// Format the duration in a human-readable form
+	ageDuration = formatDuration(duration)
+
+	return formattedTime, ageDuration
+}
+
+// formatDuration formats a duration in a more human-readable form than the standard duration string.
+// It handles negative durations (for future dates) and breaks down time into days, hours, minutes, and seconds.
+// Returns a string like "2d 5h 3m 42s" or "-1h 20m 30s" for negative durations.
+func formatDuration(d time.Duration) string {
+	if d < 0 {
+		return fmt.Sprintf("-%s", formatDuration(-d))
+	}
+
+	seconds := int64(d.Seconds())
+
+	if seconds < 60 {
+		return fmt.Sprintf("%ds", seconds)
+	}
+
+	minutes := seconds / 60
+	seconds %= 60
+
+	if minutes < 60 {
+		return fmt.Sprintf("%dm %ds", minutes, seconds)
+	}
+
+	hours := minutes / 60
+	minutes %= 60
+
+	if hours < 24 {
+		return fmt.Sprintf("%dh %dm %ds", hours, minutes, seconds)
+	}
+
+	days := hours / 24
+	hours %= 24
+
+	return fmt.Sprintf("%dd %dh %dm %ds", days, hours, minutes, seconds)
+}
+
 // AgeBasedCleanup removes clips from the filesystem based on their age and the number of clips per species.
+// Age-based policy retains files that are newer than the specified retention period, while also
+// ensuring the minimum clips per species constraint is respected.
+// All time calculations use system local time to match file timestamps.
+//
+// IMPORTANT: File timestamps (including those in the filename with 'Z' suffix) are in local system time,
+// despite the 'Z' suffix normally indicating UTC/Zulu time. All time comparisons are done in local time.
+//
 // Returns a CleanupResult containing error, number of clips removed, and current disk utilization percentage.
 func AgeBasedCleanup(quit <-chan struct{}, db Interface) CleanupResult {
 	// Perform initial setup (get files, settings, check if proceed)
@@ -24,6 +86,8 @@ func AgeBasedCleanup(quit <-chan struct{}, db Interface) CleanupResult {
 	minClipsPerSpecies := retention.MinClips
 	retentionPeriodSetting := retention.MaxAge
 
+	// Convert string retention period setting to hours
+	// e.g., "48h", "30d", "2w", or "3m" into actual hours
 	retentionPeriodInHours, err := conf.ParseRetentionPeriod(retentionPeriodSetting)
 	if err != nil {
 		log.Printf("Invalid retention period '%s': %s\n", retentionPeriodSetting, err)
@@ -38,29 +102,42 @@ func AgeBasedCleanup(quit <-chan struct{}, db Interface) CleanupResult {
 
 	if debug {
 		log.Printf("Starting age-based cleanup. Base directory: %s, Retention period: %s (%d hours)", baseDir, retentionPeriodSetting, retentionPeriodInHours)
+		log.Printf("Note: File timestamps (including in filenames with 'Z' suffix like '20250429T160252Z.wav') are in local time, not UTC")
 	}
 
 	// Create a map to keep track of the *total* number of files per species
+	// This is used to enforce the minimum clips per species constraint
 	speciesTotalCount := buildSpeciesTotalCountMap(files)
 
 	// Sort files: Oldest first, then lowest confidence first as a tie-breaker
+	// This ensures we delete the oldest, least confident files first
 	sort.SliceStable(files, func(i, j int) bool {
-		if !files[i].Timestamp.Equal(files[j].Timestamp) {
-			return files[i].Timestamp.Before(files[j].Timestamp) // Oldest first
+		// Use Unix timestamps for consistent comparison
+		if files[i].Timestamp.Unix() != files[j].Timestamp.Unix() {
+			return files[i].Timestamp.Unix() < files[j].Timestamp.Unix() // Oldest first
 		}
 		return files[i].Confidence < files[j].Confidence // Lowest confidence first
 	})
 
-	// Calculate the expiration time for age-based cleanup
-	expirationTime := time.Now().Add(-time.Duration(retentionPeriodInHours) * time.Hour)
+	// Calculate the expiration time (oldest files that should be kept) in local time
+	// Any file with a timestamp BEFORE this cutoff is considered for deletion
+	// Files newer than this cutoff will be preserved regardless of other factors
+	retentionCutoff := time.Now().Add(-time.Duration(retentionPeriodInHours) * time.Hour)
+	retentionCutoffUnix := retentionCutoff.Unix()
 
-	// Max deletions per run
+	if debug {
+		cutoffFormatted, cutoffAge := formatTimeForHumans(retentionCutoffUnix)
+		log.Printf("Files older than %s (%s ago) will be considered for deletion", cutoffFormatted, cutoffAge)
+		log.Printf("Current system time: %s, Timezone: %s", time.Now().Format("2006-01-02 15:04:05 MST"), time.Now().Format("MST"))
+	}
+
+	// Max deletions per run to prevent excessive I/O impact in a single run
 	maxDeletions := 1000
 
 	// Call the helper function to process files
 	deletedCount, loopErr := processAgeBasedDeletionLoop(files, speciesTotalCount,
 		minClipsPerSpecies, maxDeletions, debug, keepSpectrograms,
-		quit, expirationTime)
+		quit, retentionCutoffUnix)
 
 	// Get final disk utilization
 	diskUsage, diskErr := GetDiskUsage(baseDir)
@@ -76,9 +153,13 @@ func AgeBasedCleanup(quit <-chan struct{}, db Interface) CleanupResult {
 
 // processAgeBasedDeletionLoop handles the core logic of iterating through files,
 // checking age and minimum species counts, and deleting files.
+// The loop continues until one of these conditions is met:
+// 1. All files have been processed
+// 2. Maximum deletion count is reached
+// 3. A quit signal is received
 func processAgeBasedDeletionLoop(files []FileInfo, speciesTotalCount map[string]int,
 	minClipsPerSpecies int, maxDeletions int, debug bool, keepSpectrograms bool,
-	quit <-chan struct{}, expirationTime time.Time) (deletedCount int, loopErr error) {
+	quit <-chan struct{}, retentionCutoffUnix int64) (deletedCount int, loopErr error) {
 
 	deletedCount = 0
 	errorCount := 0
@@ -100,7 +181,7 @@ func processAgeBasedDeletionLoop(files []FileInfo, speciesTotalCount map[string]
 			file := &files[i] // Use pointer
 
 			// 1. Check eligibility using the helper function
-			eligible, reason := isEligibleForAgeDeletion(file, expirationTime, speciesTotalCount, minClipsPerSpecies, debug)
+			eligible, reason := isEligibleForAgeDeletion(file, retentionCutoffUnix, speciesTotalCount, minClipsPerSpecies, debug)
 			if !eligible {
 				// Log reason if debug enabled and not simply locked or not old enough (those are common)
 				if debug && reason != "locked" && reason != "not old enough" {
@@ -121,14 +202,18 @@ func processAgeBasedDeletionLoop(files []FileInfo, speciesTotalCount map[string]
 			}
 
 			// 3. Update state *after* successful deletion
+			// Important: We must update counts after deletion to maintain accurate
+			// constraints for minimum clips per species
 			speciesTotalCount[file.Species]-- // Decrement total count for the species
 			// Prevent count from going negative (safety check)
+			// This should never happen with proper bookkeeping, but serves as a safeguard
 			if speciesTotalCount[file.Species] < 0 {
 				speciesTotalCount[file.Species] = 0
 			}
 			deletedCount++
 
 			// 4. Yield to other goroutines
+			// This prevents the cleanup process from monopolizing CPU resources
 			runtime.Gosched()
 		}
 	}
@@ -138,7 +223,11 @@ func processAgeBasedDeletionLoop(files []FileInfo, speciesTotalCount map[string]
 }
 
 // isEligibleForAgeDeletion checks if a file meets the criteria for deletion based on age policy.
-func isEligibleForAgeDeletion(file *FileInfo, expirationTime time.Time, speciesTotalCount map[string]int,
+// Files are eligible for deletion when ALL of these conditions are met:
+// 1. File is not locked (protected from deletion)
+// 2. File is older than the retention cutoff time (using Unix timestamps in local timezone)
+// 3. There are more than minClipsPerSpecies files for this species
+func isEligibleForAgeDeletion(file *FileInfo, retentionCutoffUnix int64, speciesTotalCount map[string]int,
 	minClipsPerSpecies int, debug bool) (eligible bool, reason string) {
 
 	// 1. Check if locked (reuse common helper)
@@ -146,18 +235,47 @@ func isEligibleForAgeDeletion(file *FileInfo, expirationTime time.Time, speciesT
 		return false, "locked"
 	}
 
-	// 2. Check if older than retention period
-	if !file.Timestamp.Before(expirationTime) {
+	// 2. Check if older than retention period using Unix epochs in local timezone
+	// Files older than retentionCutoff should be deleted
+	// Logic: If file timestamp is NOT before the cutoff, it's too new to delete
+	fileUnix := file.Timestamp.Unix()
+	if fileUnix >= retentionCutoffUnix {
+		if debug {
+			// Get human-readable timestamp and age for file in local timezone
+			fileFormatted, fileAge := formatTimeForHumans(fileUnix)
+
+			// Get human-readable timestamp and age for cutoff in local timezone
+			cutoffFormatted, cutoffAge := formatTimeForHumans(retentionCutoffUnix)
+
+			log.Printf("[DEBUG] Skipping file (not old enough): %s (Created: %s, %s old)",
+				file.Path,
+				fileFormatted,
+				fileAge)
+			log.Printf("[DEBUG] Retention cutoff: %s (%s ago)", cutoffFormatted, cutoffAge)
+		}
 		return false, "not old enough"
 	}
 
 	// 3. Check minimum *total* clips constraint
+	// We must maintain at least minClipsPerSpecies clips for each species
+	// If current count is at or below minimum, we can't delete more
 	if count, exists := speciesTotalCount[file.Species]; exists && count <= minClipsPerSpecies {
 		if debug {
-			log.Printf("Total clip count for %s is at or below the minimum threshold (%d). Cannot delete older file: %s",
-				file.Species, minClipsPerSpecies, file.Path)
+			// Include file timestamp in log for better context (in local timezone)
+			fileFormatted, fileAge := formatTimeForHumans(fileUnix)
+
+			log.Printf("Total clip count for %s is at or below the minimum threshold (%d). Cannot delete file: %s (Created: %s, %s old)",
+				file.Species, minClipsPerSpecies, file.Path, fileFormatted, fileAge)
 		}
 		return false, "minimum clip count reached"
+	}
+
+	// If all checks pass, the file is eligible
+	if debug {
+		// Log which files are eligible for deletion with human-readable dates in local timezone
+		fileFormatted, fileAge := formatTimeForHumans(fileUnix)
+		log.Printf("[DEBUG] Eligible for deletion: %s (Created: %s, %s old, Species: %s)",
+			file.Path, fileFormatted, fileAge, file.Species)
 	}
 
 	// If all checks pass, the file is eligible

--- a/internal/diskmanager/policy_age.go
+++ b/internal/diskmanager/policy_age.go
@@ -16,6 +16,7 @@ func AgeBasedCleanup(quit <-chan struct{}, db Interface) CleanupResult { // Use 
 	settings := conf.Setting()
 
 	debug := settings.Realtime.Audio.Export.Retention.Debug
+	keepSpectrograms := settings.Realtime.Audio.Export.Retention.KeepSpectrograms // Get the setting
 	baseDir := settings.Realtime.Audio.Export.Path
 	minClipsPerSpecies := settings.Realtime.Audio.Export.Retention.MinClips
 	retentionPeriod := settings.Realtime.Audio.Export.Retention.MaxAge
@@ -77,7 +78,8 @@ func AgeBasedCleanup(quit <-chan struct{}, db Interface) CleanupResult { // Use 
 
 	// Call the generic processing loop with the age check
 	deletedCount, err := processFilesGeneric(files, speciesMonthCount,
-		minClipsPerSpecies, maxDeletions, debug, quit,
+		minClipsPerSpecies, maxDeletions, debug, keepSpectrograms,
+		quit,
 		ageCheck)
 
 	// Get current disk utilization after cleanup

--- a/internal/diskmanager/policy_age.go
+++ b/internal/diskmanager/policy_age.go
@@ -4,7 +4,6 @@ package diskmanager
 import (
 	"fmt"
 	"log"
-	"os"
 	"path/filepath"
 	"runtime"
 	"time"
@@ -104,7 +103,7 @@ func processFiles(files []FileInfo, speciesMonthCount map[string]map[string]int,
 			return deletedFiles, nil
 		default:
 			file := &files[i]
-			if shouldSkipFile(file, debug) {
+			if checkLocked(file, debug) {
 				continue
 			}
 
@@ -116,11 +115,15 @@ func processFiles(files []FileInfo, speciesMonthCount map[string]map[string]int,
 			time.Sleep(100 * time.Millisecond)
 
 			subDir := filepath.Dir(file.Path)
-			if !canDeleteFile(file, subDir, speciesMonthCount, minClipsPerSpecies, debug) {
+			if !checkMinClips(file, subDir, speciesMonthCount, minClipsPerSpecies, debug) {
 				continue
 			}
 
-			if err := deleteFile(file, debug); err != nil {
+			if debug {
+				log.Printf("File %s is older than retention period, deleting.", file.Path)
+			}
+
+			if err := deleteAudioFile(file, debug); err != nil {
 				errorCount++
 				log.Printf("Failed to remove %s: %s\n", file.Path, err)
 				if errorCount > 10 {
@@ -152,6 +155,7 @@ func processFiles(files []FileInfo, speciesMonthCount map[string]map[string]int,
 }
 
 // shouldSkipFile checks if a file should be skipped (e.g., if it's locked)
+/* // Removed, moved to policy_common.go
 func shouldSkipFile(file *FileInfo, debug bool) bool {
 	if file.Locked {
 		if debug {
@@ -161,8 +165,10 @@ func shouldSkipFile(file *FileInfo, debug bool) bool {
 	}
 	return false
 }
+*/
 
 // canDeleteFile checks if a file can be deleted based on species count constraints
+/* // Removed, logic merged into processFiles using policy_common.go
 func canDeleteFile(file *FileInfo, subDir string, speciesMonthCount map[string]map[string]int,
 	minClipsPerSpecies int, debug bool) bool {
 
@@ -180,8 +186,10 @@ func canDeleteFile(file *FileInfo, subDir string, speciesMonthCount map[string]m
 
 	return true
 }
+*/
 
 // deleteFile removes a file from the filesystem
+/* // Removed, moved to policy_common.go
 func deleteFile(file *FileInfo, debug bool) error {
 	err := os.Remove(file.Path)
 	if err != nil {
@@ -194,3 +202,4 @@ func deleteFile(file *FileInfo, debug bool) error {
 
 	return nil
 }
+*/

--- a/internal/diskmanager/policy_age.go
+++ b/internal/diskmanager/policy_age.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"runtime"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/tphakala/birdnet-go/internal/conf"
@@ -86,9 +87,12 @@ func AgeBasedCleanup(quit <-chan struct{}, db Interface) CleanupResult {
 	minClipsPerSpecies := retention.MinClips
 	retentionPeriodSetting := retention.MaxAge
 
+	// Sanitize the input string first
+	retentionPeriodTrimmed := strings.TrimSpace(retentionPeriodSetting)
+
 	// Convert string retention period setting to hours
 	// e.g., "48h", "30d", "2w", or "3m" into actual hours
-	retentionPeriodInHours, err := conf.ParseRetentionPeriod(retentionPeriodSetting)
+	retentionPeriodInHours, err := conf.ParseRetentionPeriod(retentionPeriodTrimmed)
 	if err != nil {
 		log.Printf("Invalid retention period '%s': %s\n", retentionPeriodSetting, err)
 		// Try to get current disk usage for the result
@@ -97,6 +101,7 @@ func AgeBasedCleanup(quit <-chan struct{}, db Interface) CleanupResult {
 		if diskErr == nil {
 			utilization = int(currentUsage)
 		}
+		// Log the original, untrimmed setting in the error message
 		return CleanupResult{Err: fmt.Errorf("invalid retention period '%s': %w", retentionPeriodSetting, err), ClipsRemoved: 0, DiskUtilization: utilization}
 	}
 

--- a/internal/diskmanager/policy_age_test.go
+++ b/internal/diskmanager/policy_age_test.go
@@ -342,7 +342,7 @@ func testAgeBasedCleanupWithRealFiles(
 	initialDiskUtilization int,
 	minClipsPerSpecies int,
 	utilizationReductionPerFile int,
-) AgeCleanupResult {
+) CleanupResult {
 	// This implementation simulates the real AgeBasedCleanup function
 	// but with controlled inputs and outputs
 
@@ -431,5 +431,5 @@ func testAgeBasedCleanupWithRealFiles(
 	}
 
 	// Return the results with dynamic disk utilization
-	return AgeCleanupResult{Err: nil, ClipsRemoved: deletedCount, DiskUtilization: currentDiskUtilization}
+	return CleanupResult{Err: nil, ClipsRemoved: deletedCount, DiskUtilization: currentDiskUtilization}
 }

--- a/internal/diskmanager/policy_age_test.go
+++ b/internal/diskmanager/policy_age_test.go
@@ -261,10 +261,10 @@ func TestAgeBasedCleanupReturnValues(t *testing.T) {
 
 		audioPath := filepath.Join(testDir, baseName+".wav")
 		pngPath := filepath.Join(testDir, baseName+".png")
-		require.NoError(t, os.WriteFile(audioPath, []byte("audio"), 0o644), "Failed to create audio file")
-		require.NoError(t, os.WriteFile(pngPath, []byte("png"), 0o644), "Failed to create png file")
-		require.NoError(t, os.Chtimes(audioPath, modTime, modTime), "Failed to set audio time")
-		require.NoError(t, os.Chtimes(pngPath, modTime, modTime), "Failed to set png time")
+		require.NoError(t, os.WriteFile(audioPath, []byte("audio"), 0o644), "Failed to create audio file: %s", audioPath)
+		require.NoError(t, os.WriteFile(pngPath, []byte("png"), 0o644), "Failed to create png file: %s", pngPath)
+		require.NoError(t, os.Chtimes(audioPath, modTime, modTime), "Failed to set audio time: %s", audioPath)
+		require.NoError(t, os.Chtimes(pngPath, modTime, modTime), "Failed to set png time: %s", pngPath)
 		return audioPath, pngPath
 	}
 
@@ -363,12 +363,13 @@ func TestAgeBasedCleanupMinClipsGlobal(t *testing.T) {
 
 	// --- File Setup --- Helper to create audio files in specific subdirs
 	createTestFile := func(subdir, species string, confidence int, modTime time.Time) string {
-		require.NoError(t, os.MkdirAll(filepath.Join(testDir, subdir), 0o755), "Failed to create subdir")
+		subdirPath := filepath.Join(testDir, subdir)
+		require.NoError(t, os.MkdirAll(subdirPath, 0o755), "Failed to create subdirectory: %s", subdirPath)
 		timestampStr := modTime.UTC().Format("20060102T150405Z")
 		baseName := fmt.Sprintf("%s_%dp_%s", species, confidence, timestampStr)
 		audioPath := filepath.Join(testDir, subdir, baseName+".wav")
-		require.NoError(t, os.WriteFile(audioPath, []byte("audio"), 0o644), "Failed to create audio file")
-		require.NoError(t, os.Chtimes(audioPath, modTime, modTime), "Failed to set audio time")
+		require.NoError(t, os.WriteFile(audioPath, []byte("audio"), 0o644), "Failed to create audio file: %s", audioPath)
+		require.NoError(t, os.Chtimes(audioPath, modTime, modTime), "Failed to set time for audio file: %s", audioPath)
 		return audioPath
 	}
 
@@ -607,28 +608,6 @@ func simulateAgeBasedCleanup(
 	return CleanupResult{Err: nil, ClipsRemoved: deletedCount, DiskUtilization: currentDiskUtilization}
 }
 
-/*
-// Helper function to check if a slice contains a value
-func contains(slice []string, value string) bool {
-	for _, item := range slice {
-		if item == value {
-			return true
-		}
-	}
-	return false
-}
-
-// Helper function to create mock FileInfo for testing
-func createMockFileInfo(filename string, size int64) os.FileInfo {
-	return &mockFileInfo{
-		name:    filename,
-		size:    size,
-		mode:    0o644,
-		modTime: time.Now(),
-		isDir:   false,
-	}
-}
-*/
 // Mock implementation of os.FileInfo for testing
 type mockFileInfo struct {
 	name    string

--- a/internal/diskmanager/policy_common.go
+++ b/internal/diskmanager/policy_common.go
@@ -1,0 +1,80 @@
+// policy_common.go - shared code for cleanup policies
+package diskmanager
+
+import (
+	"log"
+	"os"
+	"path/filepath"
+)
+
+// buildSpeciesSubDirCountMap creates a map to track the number of files per species per subdirectory.
+func buildSpeciesSubDirCountMap(files []FileInfo) map[string]map[string]int {
+	speciesCount := make(map[string]map[string]int)
+	for _, file := range files {
+		subDir := filepath.Dir(file.Path)
+		if _, exists := speciesCount[file.Species]; !exists {
+			speciesCount[file.Species] = make(map[string]int)
+		}
+		speciesCount[file.Species][subDir]++
+	}
+	return speciesCount
+}
+
+// checkLocked checks if a file should be skipped because it's locked.
+func checkLocked(file *FileInfo, debug bool) bool {
+	if file.Locked {
+		if debug {
+			log.Printf("Skipping locked file: %s", file.Path)
+		}
+		return true // Indicates the file should be skipped
+	}
+	return false // Indicates the file should NOT be skipped
+}
+
+// checkMinClips checks if a file can be deleted based on the minimum clips per species constraint.
+// Returns true if deletion is allowed, false otherwise.
+func checkMinClips(file *FileInfo, subDir string, speciesCount map[string]map[string]int,
+	minClipsPerSpecies int, debug bool) bool {
+
+	// Ensure the species and subdirectory exist in the map
+	if speciesMap, ok := speciesCount[file.Species]; ok {
+		if count, ok := speciesMap[subDir]; ok {
+			if count <= minClipsPerSpecies {
+				if debug {
+					log.Printf("Species clip count for %s in %s is at the minimum threshold (%d). Skipping file deletion.",
+						file.Species, subDir, minClipsPerSpecies)
+				}
+				return false // Cannot delete
+			}
+		} else {
+			// Should not happen if map is built correctly, but handle defensively
+			if debug {
+				log.Printf("Warning: Subdirectory %s not found in species count map for species %s.", subDir, file.Species)
+			}
+			return false // Cannot determine count, safer not to delete
+		}
+	} else {
+		// Should not happen if map is built correctly, but handle defensively
+		if debug {
+			log.Printf("Warning: Species %s not found in species count map.", file.Species)
+		}
+		return false // Cannot determine count, safer not to delete
+	}
+
+	return true // Can delete
+}
+
+// deleteAudioFile removes a file from the filesystem and logs the action.
+func deleteAudioFile(file *FileInfo, debug bool) error {
+	err := os.Remove(file.Path)
+	if err != nil {
+		// Error logging happens in the calling function
+		return err
+	}
+
+	if debug {
+		log.Printf("File %s deleted", file.Path)
+	}
+
+	return nil
+}

--- a/internal/diskmanager/policy_common.go
+++ b/internal/diskmanager/policy_common.go
@@ -135,8 +135,12 @@ func deleteFileAndOptionalSpectrogram(file *FileInfo, reason string, keepSpectro
 			if debug && !os.IsNotExist(pngErrUpper) {
 				log.Printf("Warning: Failed to remove associated spectrogram %s: %v", pngPathUpper, pngErrUpper)
 			}
-		} else if debug && os.IsNotExist(os.Remove(pngPathLower)) { // Log success only if lowercase didn't already remove it
-			log.Printf("Deleted associated spectrogram %s", pngPathUpper)
+		} else if debug {
+			// Check if the lowercase file still exists (without deleting it again)
+			// Log success for uppercase only if lowercase wasn't successfully removed.
+			if _, statErr := os.Stat(pngPathLower); os.IsNotExist(statErr) {
+				log.Printf("Deleted associated spectrogram %s", pngPathUpper)
+			}
 		}
 	}
 

--- a/internal/diskmanager/policy_common.go
+++ b/internal/diskmanager/policy_common.go
@@ -24,6 +24,15 @@ func buildSpeciesSubDirCountMap(files []FileInfo) map[string]map[string]int {
 	return speciesCount
 }
 
+// buildSpeciesTotalCountMap creates a map to track the total number of files per species across all subdirectories.
+func buildSpeciesTotalCountMap(files []FileInfo) map[string]int {
+	speciesTotalCount := make(map[string]int)
+	for _, file := range files {
+		speciesTotalCount[file.Species]++
+	}
+	return speciesTotalCount
+}
+
 // checkLocked checks if a file should be skipped because it's locked.
 func checkLocked(file *FileInfo, debug bool) bool {
 	if file.Locked {

--- a/internal/diskmanager/policy_usage.go
+++ b/internal/diskmanager/policy_usage.go
@@ -22,6 +22,7 @@ func UsageBasedCleanup(quitChan chan struct{}, db Interface) CleanupResult { // 
 	settings := conf.Setting()
 
 	debug := settings.Realtime.Audio.Export.Retention.Debug
+	keepSpectrograms := settings.Realtime.Audio.Export.Retention.KeepSpectrograms // Get the setting
 	baseDir := settings.Realtime.Audio.Export.Path
 	minClipsPerSpecies := settings.Realtime.Audio.Export.Retention.MinClips
 
@@ -86,7 +87,8 @@ func UsageBasedCleanup(quitChan chan struct{}, db Interface) CleanupResult { // 
 
 		// Call the generic processing loop with the usage check
 		deletedFiles, err = processFilesGeneric(files, speciesMonthCount,
-			minClipsPerSpecies, maxDeletions, debug, quitChan,
+			minClipsPerSpecies, maxDeletions, debug, keepSpectrograms, // Pass keepSpectrograms
+			quitChan,
 			usageCheck)
 
 		if err != nil {

--- a/internal/diskmanager/policy_usage_test.go
+++ b/internal/diskmanager/policy_usage_test.go
@@ -257,7 +257,8 @@ func TestSortFiles(t *testing.T) {
 	}
 
 	// Sort the files
-	speciesCount := sortFiles(files, true)
+	speciesCount := buildSpeciesSubDirCountMap(files)
+	sortFilesForUsage(files, speciesCount, true)
 
 	// Verify sorting order (oldest first)
 	assert.Equal(t, "anas_platyrhynchos", files[0].Species, "Anas platyrhynchos should be first (oldest)")
@@ -327,7 +328,8 @@ func (c UsageBasedCleanupForTests) Cleanup(quitChan chan struct{}, db Interface)
 		}
 
 		// Sort files by priority
-		speciesCount := sortFiles(h.audioFiles, h.debug)
+		speciesCount := buildSpeciesSubDirCountMap(h.audioFiles)
+		sortFilesForUsage(h.audioFiles, speciesCount, h.debug)
 
 		// Process the files for cleanup
 		for i := range h.audioFiles {
@@ -749,7 +751,8 @@ func testUsageBasedCleanupWithRealFiles(
 
 	// Sort files by timestamp (oldest first) using the same sortFiles function
 	// used elsewhere in the codebase for consistency
-	speciesCount := sortFiles(files, false)
+	speciesCount := buildSpeciesSubDirCountMap(files)
+	sortFilesForUsage(files, speciesCount, false)
 
 	// Process files for deletion if disk usage is above threshold
 	deletedCount := 0

--- a/internal/diskmanager/policy_usage_test.go
+++ b/internal/diskmanager/policy_usage_test.go
@@ -705,7 +705,7 @@ func testUsageBasedCleanupWithRealFiles(
 	initialDiskUsage float64,
 	checkLockedFiles bool,
 	diskUsageReductionPerFile float64,
-) UsageCleanupResult {
+) CleanupResult {
 	// This implementation simulates the real UsageBasedCleanup function
 	// but with controlled inputs and outputs
 
@@ -793,7 +793,7 @@ func testUsageBasedCleanupWithRealFiles(
 	}
 
 	// Return the results with the actual current disk usage
-	return UsageCleanupResult{Err: nil, ClipsRemoved: deletedCount, DiskUtilization: int(currentDiskUsage)}
+	return CleanupResult{Err: nil, ClipsRemoved: deletedCount, DiskUtilization: int(currentDiskUsage)}
 }
 
 // TestUsageBasedCleanupBelowThreshold tests that no files are deleted when disk usage is below threshold

--- a/internal/httpcontroller/template_functions.go
+++ b/internal/httpcontroller/template_functions.go
@@ -31,6 +31,7 @@ func (s *Server) GetTemplateFunctions() template.FuncMap {
 		"mod":                   modFunc,
 		"seq":                   seqFunc,
 		"dict":                  dictFunc,
+		"list":                  listFunc,
 		"even":                  even,
 		"ge":                    geFunc,
 		"calcWidth":             calcWidth,
@@ -393,4 +394,10 @@ func geFunc(a, b interface{}) bool {
 // roundToNearest rounds a number to the nearest multiple of another number
 func roundToNearest(value, multiple int) int {
 	return int(math.Round(float64(value)/float64(multiple)) * float64(multiple))
+}
+
+// listFunc creates a list of interface values.
+// This is useful for creating ordered lists for templates.
+func listFunc(items ...interface{}) []interface{} {
+	return items
 }

--- a/views/components/selectField.html
+++ b/views/components/selectField.html
@@ -34,6 +34,11 @@
             {{range .providerOptionList}}
                 <option value="{{.Value}}">{{.Display}}</option>
             {{end}}
+        {{else if .orderedOptions}}
+            {{/* Handle ordered options list */}}
+            {{range .orderedOptions}}
+                <option value="{{.Value}}">{{.Label}}</option>
+            {{end}}
         {{else if .options}}
             {{/* Handle standard map options */}}
             {{range $value, $label := .options}}

--- a/views/pages/settings/audioSettings.html
+++ b/views/pages/settings/audioSettings.html
@@ -430,7 +430,8 @@ x-init="
              policy: '{{.Settings.Realtime.Audio.Export.Retention.Policy}}',
              maxage: '{{.Settings.Realtime.Audio.Export.Retention.MaxAge}}',
              maxusage: '{{.Settings.Realtime.Audio.Export.Retention.MaxUsage}}',
-             minclips: {{.Settings.Realtime.Audio.Export.Retention.MinClips}}
+             minclips: {{.Settings.Realtime.Audio.Export.Retention.MinClips}},
+             keepSpectrograms: {{.Settings.Realtime.Audio.Export.Retention.KeepSpectrograms}}
          },
          audioRetentionSettingsOpen: false,
          showTooltip: null,
@@ -460,11 +461,12 @@ x-init="
                     "name" "realtime.audio.export.retention.policy"
                     "label" "Retention Policy"
                     "tooltip" "Retention policy for audio clips."
-                    "options" (dict
-                        "none" "None"
-                        "age" "Age"
-                        "usage" "Usage"
-                    )}}
+                    "orderedOptions" (list 
+                        (dict "Value" "none" "Label" "None")
+                        (dict "Value" "age" "Label" "Age")
+                        (dict "Value" "usage" "Label" "Usage")
+                    )
+                }}
             </div>
 
             <!-- Max Age -->
@@ -499,6 +501,19 @@ x-init="
                     "tooltip" "Minimum number of clips per species to keep before starting evictions."}}
 
             </div>
+
+            <!-- Keep Spectrograms -->
+            <div class="form-control relative" x-show="audioRetention.policy !== 'none'">
+                <div class="flex items-center mt-8">
+                    {{template "checkbox" dict
+                        "id" "audioRetentionKeepSpectrograms"
+                        "model" "audioRetention.keepSpectrograms"
+                        "name" "realtime.audio.export.retention.keepspectrograms"
+                        "label" "Keep Spectrogram Images"
+                        "tooltip" "When enabled, spectrogram images (.png files) will be kept when audio files are deleted during cleanup. When disabled, spectrogram images will be deleted along with their audio files."}}
+                </div>
+            </div>
+
         </div>
     </div>
 </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a "Keep Spectrogram Images" checkbox to audio retention settings, allowing users to choose whether spectrogram PNG files are retained or deleted during audio file cleanup.
  - Audio retention policy options are now displayed in a consistent, ordered manner.
  - Added a new template function to facilitate creating ordered lists in templates.
  - Extended select field templates to support ordered option lists for improved UI consistency.
- **Bug Fixes**
  - Improved handling and testing of spectrogram file deletion to ensure correct behavior based on user settings.
- **Refactor**
  - Streamlined and modularized audio export and retention configuration for greater clarity and flexibility.
  - Unified and simplified file cleanup logic for both age-based and usage-based retention policies.
  - Enhanced disk usage reporting with detailed metrics for improved cleanup decisions.
  - Improved timestamp parsing to correctly interpret file timestamps as local time.
- **Tests**
  - Enhanced test coverage for cleanup scenarios, including spectrogram retention and global minimum clip enforcement.
- **Documentation**
  - Updated configuration documentation to include the new spectrogram retention setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->