### PR TITLE
feat: Add config for session duration with login sessions

### DIFF
--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -291,6 +291,7 @@ type Security struct {
 	GoogleAuth        SocialProvider    // Google OAuth2 configuration
 	GithubAuth        SocialProvider    // Github OAuth2 configuration
 	SessionSecret     string            // secret for session cookie
+	SessionDuration   time.Duration     // duration for browser session cookies
 }
 
 type WebServerSettings struct {

--- a/internal/conf/defaults.go
+++ b/internal/conf/defaults.go
@@ -209,6 +209,7 @@ func setDefaultConfig() {
 	viper.SetDefault("security.redirecttohttps", false)
 	viper.SetDefault("security.allowsubnetbypass.enabled", false)
 	viper.SetDefault("security.allowsubnetbypass.subnet", "")
+	viper.SetDefault("security.sessionduration", "168h") // 7 days
 
 	// Basic authentication configuration
 	viper.SetDefault("security.basicauth.enabled", false)

--- a/internal/conf/validate.go
+++ b/internal/conf/validate.go
@@ -166,6 +166,11 @@ func validateSecuritySettings(settings *Security) error {
 		}
 	}
 
+	// Validate session duration
+	if settings.SessionDuration <= 0 {
+		return fmt.Errorf("security.sessionduration must be a positive duration")
+	}
+
 	return nil
 }
 

--- a/internal/security/basic.go
+++ b/internal/security/basic.go
@@ -96,10 +96,18 @@ func (s *OAuth2Server) configureLocalNetworkCookieStore() {
 			SameSite: http.SameSiteLaxMode,
 		}
 	case *sessions.FilesystemStore:
+		// Calculate MaxAge in seconds from the configured session duration
+		// If not configured, default to 7 days
+		// Note: MaxAge in the cookie store options requires an integer in seconds
+		maxAge := 86400 * 7 // 7 days in seconds
+		if s.Settings.Security.SessionDuration > 0 {
+			maxAge = int(s.Settings.Security.SessionDuration.Seconds())
+		}
+
 		store.Options = &sessions.Options{
 			Path:     "/",
-			MaxAge:   86400 * 7, // 7 days
-			Secure:   false,     // Allow cookies to be sent over HTTP for local LAN access
+			MaxAge:   maxAge,
+			Secure:   false, // Allow cookies to be sent over HTTP for local LAN access
 			HttpOnly: true,
 			SameSite: http.SameSiteLaxMode,
 		}

--- a/internal/security/oauth.go
+++ b/internal/security/oauth.go
@@ -185,6 +185,9 @@ func InitializeGoth(settings *conf.Settings) {
 		// Configure session store options
 		store := gothic.Store.(*sessions.FilesystemStore)
 		maxAge := 86400 * 7 // 7 days
+		if settings.Security.SessionDuration > 0 {
+			maxAge = int(settings.Security.SessionDuration.Seconds())
+		}
 		secureCookie := settings.Security.RedirectToHTTPS
 		store.Options = &sessions.Options{
 			Path:     "/",


### PR DESCRIPTION
Adds a config option in the config.yaml file to allow a configurable session duration for basic auth and oauth. This allows setting a shorter (or longer) duration per user preferences or security preferences. 

Tested and working locally. I used 300h in my test, and I can see the new gothic_session expires 12 days from now.

![image](https://github.com/user-attachments/assets/8ece09dd-76db-47a3-985b-bd178b8c294d)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Added configurable session duration for browser session cookies across authentication methods.
- **Bug Fixes**
	- Improved validation to ensure session duration is always a positive value.
- **Chores**
	- Set default session duration to 7 days for enhanced session management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->