### PR TITLE
feat(mqtt): Add UI support for anonymous broker configuration

### DIFF
--- a/internal/conf/validate.go
+++ b/internal/conf/validate.go
@@ -175,7 +175,48 @@ func validateRealtimeSettings(settings *RealtimeSettings) error {
 	if settings.Interval < 0 {
 		return errors.New("Realtime interval must be non-negative")
 	}
+
+	// Validate MQTT settings
+	if err := validateMQTTSettings(&settings.MQTT); err != nil {
+		return err
+	}
+
 	// Add more realtime settings validation as needed
+	return nil
+}
+
+// validateMQTTSettings validates the MQTT-specific settings
+func validateMQTTSettings(settings *MQTTSettings) error {
+	if settings.Enabled {
+		// Check if broker is provided when enabled
+		if settings.Broker == "" {
+			return errors.New("MQTT broker URL is required when MQTT is enabled")
+		}
+
+		// Check if topic is provided when enabled
+		if settings.Topic == "" {
+			return errors.New("MQTT topic is required when MQTT is enabled")
+		}
+
+		// Explicitly support anonymous connections (empty username and password)
+		// No validation required for username/password - they can be empty for anonymous connections
+
+		// Validate retry settings if enabled
+		if settings.RetrySettings.Enabled {
+			if settings.RetrySettings.MaxRetries < 0 {
+				return errors.New("MQTT max retries must be non-negative")
+			}
+			if settings.RetrySettings.InitialDelay < 0 {
+				return errors.New("MQTT initial delay must be non-negative")
+			}
+			if settings.RetrySettings.MaxDelay < settings.RetrySettings.InitialDelay {
+				return errors.New("MQTT max delay must be greater than or equal to initial delay")
+			}
+			if settings.RetrySettings.BackoffMultiplier <= 0 {
+				return errors.New("MQTT backoff multiplier must be positive")
+			}
+		}
+	}
 	return nil
 }
 

--- a/internal/httpcontroller/handlers/settings.go
+++ b/internal/httpcontroller/handlers/settings.go
@@ -220,6 +220,16 @@ func (h *Handlers) updateAuthenticationSettings(settings *conf.Settings) {
 
 // updateSettingsFromForm updates the settings based on form values
 func updateSettingsFromForm(settings *conf.Settings, formValues map[string][]string) error {
+	// Check for anonymous MQTT connection option
+	if anonymousValues, exists := formValues["realtime.mqtt.anonymous"]; exists && len(anonymousValues) > 0 {
+		// If anonymous is enabled (value is "on" or "true"), ensure username and password are empty
+		if anonymousValues[0] == "on" || anonymousValues[0] == "true" {
+			// Explicitly set username and password to empty strings for anonymous connection
+			settings.Realtime.MQTT.Username = ""
+			settings.Realtime.MQTT.Password = ""
+		}
+	}
+
 	// Delegate the update process to updateStructFromForm
 	return updateStructFromForm(reflect.ValueOf(settings).Elem(), formValues, "")
 }

--- a/views/pages/settings/integrationSettings.html
+++ b/views/pages/settings/integrationSettings.html
@@ -115,6 +115,7 @@
         username: '{{.Settings.Realtime.MQTT.Username}}',
         password: '{{.Settings.Realtime.MQTT.Password}}',
         retain: {{.Settings.Realtime.MQTT.Retain}},
+        anonymous: {{if and (eq .Settings.Realtime.MQTT.Username "") (eq .Settings.Realtime.MQTT.Password "")}}true{{else}}false{{end}},
         testResults: [],
         isTesting: false,
         currentTestStage: null
@@ -157,6 +158,16 @@
         mqtt.testResults = [];
         mqtt.currentTestStage = null;
     });
+    $watch('mqtt.anonymous', () => {
+        hasChanges = true;
+        mqtt.testResults = [];
+        mqtt.currentTestStage = null;
+        if (mqtt.anonymous) {
+            // Clear username and password when anonymous is selected
+            mqtt.username = '';
+            mqtt.password = '';
+        }
+    });
 ">
 
     <!-- control collapse element open state and label visibility -->
@@ -184,7 +195,7 @@
             "tooltip" "Enable or disable integration with MQTT service."}}
 
         <div x-show="mqtt.enabled"
-             class="grid grid-cols-1 md:grid-cols-2 gap-x-6"
+             class="grid grid-cols-1 gap-4"
              id="mqttSettings"
              role="group" 
              aria-label="MQTT Connection Settings">
@@ -204,29 +215,52 @@
                 "label" "MQTT Topic"
                 "placeholder" "birdnet/detections"
                 "tooltip" "MQTT topic to publish detections to"}}
+            
+            <!-- Authentication Section -->
+            <div class="border-t border-base-300 pt-4 mt-2">
+                <h3 class="text-sm font-medium mb-3">Authentication</h3>
+                
+                {{template "checkbox" dict
+                    "id" "mqttAnonymous"
+                    "model" "mqtt.anonymous"
+                    "name" "realtime.mqtt.anonymous"
+                    "label" "Anonymous Connection"
+                    "tooltip" "Use anonymous connection without username/password."}}
+                
+                <!-- Note about Anonymous Connection when enabled -->
+                {{template "noteField" dict
+                    "condition" "mqtt.anonymous"
+                    "content" "<strong>Anonymous Connection:</strong> Authentication is disabled for this MQTT connection. Ensure your broker is configured to allow anonymous connections for the topics you're publishing to."}}
 
-            {{template "textField" dict
-                "id" "mqttUsername"
-                "model" "mqtt.username"
-                "name" "realtime.mqtt.username"
-                "label" "Username"
-                "tooltip" "The MQTT username."}}
+                <div x-show="!mqtt.anonymous" class="grid grid-cols-1 md:grid-cols-2 gap-4 mt-4">
+                    {{template "textField" dict
+                        "id" "mqttUsername"
+                        "model" "mqtt.username"
+                        "name" "realtime.mqtt.username"
+                        "label" "Username"
+                        "tooltip" "The MQTT username."}}
 
-            {{template "passwordField" dict
-                "id" "mqttPassword"
-                "model" "mqtt.password"
-                "name" "realtime.mqtt.password"
-                "label" "Password"
-                "placeholder" ""
-                "tooltip" "The MQTT password."}}
-          
-            {{template "checkbox" dict
-                "id" "mqttRetain"
-                "model" "mqtt.retain"
-                "name" "realtime.mqtt.retain"
-                "label" "Retain Messages"
-                "tooltip" "When enabled, MQTT broker will keep the last message on each topic and deliver to new subscribers."}}
-
+                    {{template "passwordField" dict
+                        "id" "mqttPassword"
+                        "model" "mqtt.password"
+                        "name" "realtime.mqtt.password"
+                        "label" "Password"
+                        "placeholder" ""
+                        "tooltip" "The MQTT password."}}
+                </div>
+            </div>
+            
+            <!-- Message Settings Section -->
+            <div class="border-t border-base-300 pt-4 mt-2">
+                <h3 class="text-sm font-medium mb-3">Message Settings</h3>
+                
+                {{template "checkbox" dict
+                    "id" "mqttRetain"
+                    "model" "mqtt.retain"
+                    "name" "realtime.mqtt.retain"
+                    "label" "Retain Messages"
+                    "tooltip" "When enabled, MQTT broker will keep the last message on each topic and deliver to new subscribers."}}
+            </div>
         </div>
         
         <!-- Note about MQTT Retain for HomeAssistant - full width -->


### PR DESCRIPTION
This PR adds support for configuring anonymous MQTT broker connections directly through the Integration Settings UI, addressing the issue where users previously had to manually edit the YAML file.

Changes include:
- Added an "Anonymous Connection" checkbox to the MQTT settings UI.
- Username/Password fields are hidden and cleared when anonymous is checked.
- Updated backend form handling (`settings.go`) to ensure username/password are cleared when anonymous is submitted.
- Added explicit validation for MQTT settings (`validate.go`), ensuring anonymous connections are allowed.
- Improved MQTT settings layout in the UI for clarity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for anonymous MQTT connections in the integration settings UI, including a new checkbox to enable anonymous mode and conditional display of authentication fields.
- **Bug Fixes**
	- Improved validation for MQTT settings, ensuring proper checks for broker URL, topic, and retry parameters.
- **Style**
	- Updated the MQTT settings layout for better organization, introducing dedicated sections for authentication and message settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->