### PR TITLE
refactor(label_files): replace filepath.Join with path.Join for impro…

### DIFF
--- a/internal/birdnet/label_files.go
+++ b/internal/birdnet/label_files.go
@@ -5,6 +5,7 @@ import (
 	"embed"
 	"fmt"
 	"io/fs"
+	"path"
 	"path/filepath"
 	"strings"
 )
@@ -30,7 +31,7 @@ func GetLabelFileData(modelVersion, localeCode string) ([]byte, error) {
 	filePattern := fmt.Sprintf("%s_Labels_%s.txt", BirdNET_GLOBAL_6K_V2_4, normalizedLocale)
 
 	// Try to find the exact match
-	data, err := v24LabelFiles.ReadFile(filepath.Join("data", "labels", "V2.4", filePattern))
+	data, err := v24LabelFiles.ReadFile(path.Join("data", "labels", "V2.4", filePattern))
 	if err == nil {
 		return data, nil
 	}
@@ -43,7 +44,7 @@ func GetLabelFileData(modelVersion, localeCode string) ([]byte, error) {
 			altLocale = altLocale[:3] + strings.ToUpper(altLocale[3:])
 		}
 		filePattern = fmt.Sprintf("%s_Labels_%s.txt", BirdNET_GLOBAL_6K_V2_4, altLocale)
-		data, err = v24LabelFiles.ReadFile(filepath.Join("data", "labels", "V2.4", filePattern))
+		data, err = v24LabelFiles.ReadFile(path.Join("data", "labels", "V2.4", filePattern))
 		if err == nil {
 			return data, nil
 		}
@@ -52,7 +53,7 @@ func GetLabelFileData(modelVersion, localeCode string) ([]byte, error) {
 	// Fall back to English if requested locale isn't found
 	if normalizedLocale != "en" && normalizedLocale != "en-uk" {
 		filePattern = fmt.Sprintf("%s_Labels_en_uk.txt", BirdNET_GLOBAL_6K_V2_4)
-		data, err = v24LabelFiles.ReadFile(filepath.Join("data", "labels", "V2.4", filePattern))
+		data, err = v24LabelFiles.ReadFile(path.Join("data", "labels", "V2.4", filePattern))
 		if err == nil {
 			return data, nil
 		}


### PR DESCRIPTION
…ved cross-platform compatibility

- Updated the GetLabelFileData function to use path.Join instead of filepath.Join for constructing file paths.
- This change enhances compatibility across different operating systems, ensuring consistent behavior when accessing label files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved file path handling for reading embedded label files, ensuring more consistent behavior across different environments. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->