### PR TITLE
fix: update diskmanager test error message expectations

### DIFF
--- a/internal/diskmanager/file_utils_test.go
+++ b/internal/diskmanager/file_utils_test.go
@@ -16,7 +16,7 @@ func TestInvalidFileNameErrorMessages(t *testing.T) {
 		expectedErrText string
 	}{
 		// Too few parts
-		{"bubo_bubo.wav", "invalid file name format: bubo_bubo.wav (has 2 parts, expected at least 3)"},
+		{"bubo_bubo.wav", "diskmanager: invalid audio filename format 'bubo_bubo.wav' (has 2 parts, expected at least 3)"},
 		// This actually gets parsed as species="bubo", confidence="bubo_80p", which fails at the confidence parsing step
 		{"bubo_bubo_80p.wav", "strconv.Atoi: parsing \"bubo\": invalid syntax"},
 
@@ -132,7 +132,7 @@ func TestGetAudioFilesWithMixedFiles(t *testing.T) {
 
 	// Should return an error when all files are invalid
 	assert.Error(t, err, "Should return an error when all files are invalid")
-	assert.Contains(t, err.Error(), "failed to parse any files", "Error should indicate no valid files were found")
+	assert.Contains(t, err.Error(), "diskmanager: failed to parse any audio files", "Error should indicate no valid files were found")
 	assert.Len(t, files, 0, "Should return no files when all are invalid")
 }
 

--- a/internal/diskmanager/policy_usage_test.go
+++ b/internal/diskmanager/policy_usage_test.go
@@ -117,7 +117,7 @@ func TestFileTypesEligibleForDeletion(t *testing.T) {
 
 				// If the function returned an error, validate it's the right kind of error
 				if hasError {
-					assert.Contains(t, err.Error(), "file type not eligible for cleanup operation",
+					assert.Contains(t, err.Error(), "diskmanager: file type not eligible for cleanup",
 						"Error message should indicate file is not eligible for cleanup")
 				}
 			}


### PR DESCRIPTION
- Fixed TestInvalidFileNameErrorMessages to expect correct error format
- Fixed TestGetAudioFilesWithMixedFiles to match actual error message
- Fixed TestFileTypesEligibleForDeletion to match error format
- All diskmanager tests now pass successfully

The tests were failing because they expected different error message formats than what the code actually produces. Updated test expectations to match the actual error messages with "diskmanager:" prefix.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test assertions to expect error messages with a consistent "diskmanager:" prefix for invalid audio file names, parsing failures, and ineligible file types for cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->