### PR TITLE
fix: update birdweather test to match actual error message

### DIFF
--- a/internal/birdweather/audio_test.go
+++ b/internal/birdweather/audio_test.go
@@ -25,8 +25,8 @@ func TestEncodePCMtoWAV_EmptyInput(t *testing.T) {
 		t.Error("EncodePCMtoWAVWithContext should return an error with empty PCM data")
 	}
 
-	if err != nil && err.Error() != "PCM data is empty" {
-		t.Errorf("Expected error message 'PCM data is empty', got: %v", err)
+	if err != nil && err.Error() != "PCM data is empty for WAV encoding" {
+		t.Errorf("Expected error message 'PCM data is empty for WAV encoding', got: %v", err)
 	}
 }
 


### PR DESCRIPTION
Fix failing TestEncodePCMtoWAV_EmptyInput test by updating expected error message to match the actual error returned by the function

🤖 Generated with [Claude Code](https://claude.ai/code)