### PR TITLE
fix: update HTTP response status for soundscape upload

### DIFF
--- a/internal/birdweather/birdweather_client.go
+++ b/internal/birdweather/birdweather_client.go
@@ -612,7 +612,7 @@ func (b *BwClient) UploadSoundscape(timestamp string, pcmData []byte) (soundscap
 	serviceLogger.Debug("Received soundscape upload response", "url", maskedURL, "status_code", resp.StatusCode)
 
 	// Process the response using the new handler
-	responseBody, err := handleHTTPResponse(resp, http.StatusOK, "soundscape upload", maskedURL)
+	responseBody, err := handleHTTPResponse(resp, http.StatusCreated, "soundscape upload", maskedURL)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
- Changed the expected HTTP response status from 200 OK to 201 Created for soundscape uploads.
- This adjustment aligns the response handling with the correct status code for successful resource creation.