### PR TITLE
fix: register birdweather component in error package

### DIFF
--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -239,6 +239,7 @@ func init() {
 	RegisterComponent("weather", "weather")
 	RegisterComponent("conf", "configuration")
 	RegisterComponent("telemetry", "telemetry")
+	RegisterComponent("birdweather", "birdweather")
 }
 
 // Helper functions for auto-detection and categorization


### PR DESCRIPTION
Add missing birdweather component registration to prevent incorrect telemetry tagging. Without this registration, birdweather errors could be incorrectly attributed to other components like imageprovider when the error passes through shared code paths.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for automatic detection of the "birdweather" component in enhanced error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->