### PR TITLE
fix: correct AutoTLS port handling and add proper validation

### DIFF
--- a/Docker/.env.autotls.example
+++ b/Docker/.env.autotls.example
@@ -1,0 +1,16 @@
+# BirdNET-Go AutoTLS Configuration Example
+# Copy this file to .env and configure it with your settings
+
+# Required: Your domain name for AutoTLS (Let's Encrypt)
+# This domain must point to your server's public IP address
+BIRDNET_HOST=birdnet.example.com
+
+# Timezone
+TZ=UTC
+
+# Optional: User/Group IDs for file permissions
+BIRDNET_UID=1000
+BIRDNET_GID=1000
+
+# Optional: Cloudflare Tunnel token (if using Cloudflare instead of AutoTLS)
+# CLOUDFLARE_TUNNEL_TOKEN=your-tunnel-token-here

--- a/Docker/docker-compose.autotls.yml
+++ b/Docker/docker-compose.autotls.yml
@@ -1,0 +1,65 @@
+version: '3.8'
+
+services:
+  birdnet-go:
+    image: ghcr.io/tphakala/birdnet-go:nightly
+    container_name: birdnet-go
+    restart: unless-stopped
+    ports:
+      - "80:80"      # Required for ACME HTTP-01 challenge
+      - "443:443"    # Required for HTTPS/AutoTLS
+    environment:
+      - TZ=${TZ:-UTC}
+      - BIRDNET_UID=${BIRDNET_UID:-1000}
+      - BIRDNET_GID=${BIRDNET_GID:-1000}
+      # Configure AutoTLS
+      - BIRDNET_SECURITY_AUTOTLS=true
+      - BIRDNET_SECURITY_HOST=${BIRDNET_HOST} # Required: Your domain name
+      # Optional: uncomment to configure other settings via environment variables
+      # - BIRDNET_LOCALE=en-us
+      # - BIRDNET_LATITUDE=60.192059
+      # - BIRDNET_LONGITUDE=24.945831
+      # - BIRDNET_SENSITIVITY=1.0
+      # - BIRDNET_OVERLAP=1.5
+    volumes:
+      - ./config:/config
+      - ./data:/data
+      - ./certs:/certs  # For Let's Encrypt certificates
+    # Mount HLS stream segment files directory as tmpfs (RAM disk)
+    tmpfs:
+      - /config/hls:exec,size=50M,uid=${BIRDNET_UID:-1000},gid=${BIRDNET_GID:-1000},mode=0755
+    # For ALSA audio input (sound card)
+    devices:
+      - /dev/snd:/dev/snd
+    # Required for privileged port binding
+    cap_add:
+      - NET_BIND_SERVICE
+    # Add any host mappings needed
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+ 
+  # Optional: Add Cloudflared for secure internet access through Cloudflare Tunnel
+  # This is an alternative to AutoTLS if you prefer Cloudflare's solution
+  # cloudflared:
+  #   image: cloudflare/cloudflared:latest
+  #   container_name: birdnet-cloudflared
+  #   restart: unless-stopped
+  #   # Two options for running cloudflared:
+  #   # 1. Using a tunnel token (recommended for most users)
+  #   command: tunnel run
+  #   environment:
+  #     - TUNNEL_TOKEN=${CLOUDFLARE_TUNNEL_TOKEN}
+  #   # 2. Alternative: Using config file (uncomment these and comment the above)
+  #   # command: tunnel --config /etc/cloudflared/config.yml run
+  #   # volumes:
+  #   #   - ./cloudflared:/etc/cloudflared
+  #   depends_on:
+  #     - birdnet-go
+      
+volumes:
+  config:
+    driver: local
+  data:
+    driver: local
+  certs:
+    driver: local

--- a/internal/conf/config.yaml
+++ b/internal/conf/config.yaml
@@ -154,9 +154,22 @@ webserver:
     rotationday: 0        # day of the week for weekly rotation, 0 = Sunday
 
 security:
-  host: ""                   # host and port for autoTLS and authentication
-  autotls: false             # true to enable auto TLS, only host is whitelisted
-  redirecttohttps: false     # true to redirect http to https
+  # host is required for AutoTLS and OAuth providers
+  # Must be a fully qualified domain name (e.g., "birdnet.example.com")
+  # The domain must point to this server's public IP address
+  host: ""
+  
+  # AutoTLS enables automatic TLS certificate management via Let's Encrypt
+  # REQUIREMENTS:
+  # - host must be set to a valid domain name
+  # - Ports 80 and 443 must be accessible from the internet
+  # - Domain must point to this server's IP address
+  # - When using Docker, use docker-compose.autotls.yml instead of docker-compose.yml
+  autotls: false
+  
+  # redirecttohttps forces HTTP connections to redirect to HTTPS
+  # Only works when autotls is enabled or manual TLS certificates are configured
+  redirecttohttps: false
   allowsubnetbypass:
     enabled: false           # true to disable OAuth in subnet
     subnet: ""               # comma-separated list of CIDR ranges (e.g., "192.168.1.0/24,10.0.0.0/8")

--- a/internal/conf/validate.go
+++ b/internal/conf/validate.go
@@ -204,6 +204,27 @@ func validateSecuritySettings(settings *Security) error {
 			Build()
 	}
 
+	// AutoTLS validation
+	if settings.AutoTLS {
+		// Host is required for AutoTLS
+		if settings.Host == "" {
+			return errors.New(fmt.Errorf("security.host must be set when AutoTLS is enabled")).
+				Category(errors.CategoryValidation).
+				Context("validation_type", "security-autotls-host").
+				Build()
+		}
+
+		// Warning about port requirements when running in container
+		if RunningInContainer() {
+			log.Println("WARNING: AutoTLS requires ports 80 and 443 to be exposed.")
+			log.Println("Ensure your Docker configuration maps these ports:")
+			log.Println("  ports:")
+			log.Println("    - \"80:80\"    # Required for ACME HTTP-01 challenge")
+			log.Println("    - \"443:443\"  # Required for HTTPS/AutoTLS")
+			log.Println("Consider using docker-compose.autotls.yml for proper AutoTLS configuration.")
+		}
+	}
+
 	// Validate the subnet bypass setting against the allowed pattern
 	if settings.AllowSubnetBypass.Enabled {
 		subnets := strings.Split(settings.AllowSubnetBypass.Subnet, ",")


### PR DESCRIPTION
- Fix AutoTLS to use standard ports 80/443 instead of configured WebServer.Port
- Add HTTP redirect server on port 80 for ACME challenges
- Implement pre-flight validation to check AutoTLS requirements
- Add graceful fallback to HTTP when AutoTLS fails
- Create docker-compose.autotls.yml with proper port mappings
- Add clear warnings about port requirements for Docker users
- Update configuration documentation with AutoTLS requirements
- Use enhanced error handling for better telemetry and debugging

Fixes #743

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added example environment and Docker Compose files to simplify AutoTLS and Cloudflare Tunnel setup for secure deployments.
  * Enhanced server startup to provide automatic TLS certificate management with Let's Encrypt, including HTTP-to-HTTPS redirection.

* **Documentation**
  * Improved configuration file comments with detailed instructions and requirements for AutoTLS and related security settings.

* **Bug Fixes**
  * Added validation to ensure required settings are present before enabling AutoTLS, with clear error messages and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->