### PR TITLE
fix: temporarily disable error handler integrations to prevent startup deadlocks

### DIFF
--- a/internal/analysis/realtime.go
+++ b/internal/analysis/realtime.go
@@ -893,10 +893,17 @@ func initializeBackupSystem(settings *conf.Settings, backupLogger *slog.Logger) 
 // initializeNotificationService initializes the notification service with error integration
 func initializeNotificationService() {
 	notification.Initialize(nil)         // Use default configuration
-	notification.SetupErrorIntegration() // Set up error reporting integration
-	logging.Info("Notification service initialized with error integration",
+	
+	// TEMPORARILY DISABLED: The error integration is causing deadlocks during startup
+	// when the notification service tries to create errors that trigger its own hooks.
+	// This creates a circular dependency that blocks application startup.
+	// TODO: Implement proper initialization ordering and recursion prevention
+	// See: https://github.com/tphakala/birdnet-go/issues/825
+	// notification.SetupErrorIntegration() // Set up error reporting integration
+	
+	logging.Info("Notification service initialized",
 		"component", "notification",
-		"error_integration", "enabled")
+		"error_integration", "disabled")
 }
 
 // initializeSystemMonitor initializes and starts the system resource monitor if enabled

--- a/main.go
+++ b/main.go
@@ -110,7 +110,11 @@ func mainWithExitCode() int {
 	}
 
 	// Initialize error handling integration with telemetry
-	telemetry.InitializeErrorIntegration()
+	// TEMPORARILY DISABLED: This integration is causing deadlocks during startup
+	// when errors are reported before all services are fully initialized.
+	// TODO: Fix the circular dependency between error handler, telemetry, and notification services
+	// See: https://github.com/tphakala/birdnet-go/issues/825
+	// telemetry.InitializeErrorIntegration()
 
 	// Enable runtime profiling if debug mode is enabled
 	if settings.Debug {


### PR DESCRIPTION
## Summary

This PR temporarily disables error handler integrations with telemetry and notification services to resolve application startup deadlocks reported in #825.

## Problem

The application was failing to start due to deadlocks caused by:
- Errors being reported during startup before all services are fully initialized
- Circular dependencies between error handler, telemetry, and notification services
- The notification service creating errors that trigger its own hooks

## Temporary Solution

This PR comments out:
1. `telemetry.InitializeErrorIntegration()` in main.go
2. `notification.SetupErrorIntegration()` in realtime.go

Both are clearly marked with TODO comments explaining why they're disabled and referencing issue #825.

## Impact

- ✅ Application now starts successfully with all services
- ⚠️ Error reporting to Sentry is temporarily disabled
- ⚠️ Error notifications are temporarily disabled

## Next Steps

A follow-up PR will implement a proper fix that:
- Addresses initialization order issues
- Implements recursion prevention
- Restores full error reporting functionality

## Test Results

With these changes, the application starts successfully:
```
🐦 BirdNET-Go nightly-20250629-6-g65e427a (built: 2025-06-30T11:40:39Z)
HTTP server started on port 8080
⇨ http server started on [::]:8080
Listening on source: USB Audio Device, USB Audio (:0,0)
```

Fixes #825

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled error integration in notification and telemetry services to prevent startup deadlocks.
  * Updated logging to reflect that error integration is currently disabled.

* **Chores**
  * Added comments explaining the temporary disablement and referenced a related issue for future tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->