### PR TITLE
fix: add missing ScientificName field in Wikipedia image provider

### DIFF
--- a/internal/imageprovider/wikipedia.go
+++ b/internal/imageprovider/wikipedia.go
@@ -328,11 +328,12 @@ func (l *wikiMediaProvider) fetchWithLimiter(scientificName string, limiter *rat
 	// }
 
 	result := BirdImage{
-		URL:         thumbnailURL,
-		AuthorName:  authorInfo.name,
-		AuthorURL:   authorInfo.URL,
-		LicenseName: authorInfo.licenseName,
-		LicenseURL:  authorInfo.licenseURL,
+		URL:            thumbnailURL,
+		ScientificName: scientificName,
+		AuthorName:     authorInfo.name,
+		AuthorURL:      authorInfo.URL,
+		LicenseName:    authorInfo.licenseName,
+		LicenseURL:     authorInfo.licenseURL,
 	}
 	logger.Info("Successfully fetched image and metadata from Wikipedia")
 	return result, nil


### PR DESCRIPTION
## Summary
- Fixes image caching failure for non-bird detections by adding the missing `ScientificName` field to the BirdImage struct
- Resolves issue #844 where images for non-bird detections (e.g., "Dog") were failing to cache with "scientific name cannot be empty" error
- Ensures all detection types can be properly cached in the database

## Problem
The Wikipedia image provider was creating BirdImage structs without populating the `ScientificName` field. This caused database save operations to fail because the scientific name is a required field for the image cache table.

## Solution
Added `ScientificName: scientificName` to the BirdImage struct initialization in the `fetchWithLimiter` method at `internal/imageprovider/wikipedia.go:332`.

## Test plan
- [x] Verified the fix locally - image caching now works for non-bird detections
- [x] Code passes all linter checks (`golangci-lint run -v` shows 0 issues)
- [x] Tested with both bird and non-bird detections to ensure caching works correctly

Fixes #844

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured that bird images now include the scientific name in their details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->