### PR TITLE
fix: resolve failing tests in birdweather, telemetry, and API v2 packages

### DIFF
--- a/internal/api/v2/debug.go
+++ b/internal/api/v2/debug.go
@@ -64,8 +64,8 @@ func (c *Controller) initDebugRoutes() {
 
 // DebugTriggerError triggers a test error for telemetry testing
 func (c *Controller) DebugTriggerError(ctx echo.Context) error {
-	// Double-check debug mode
-	if !conf.GetSettings().Debug {
+	// Double-check debug mode using controller's settings
+	if c.Settings == nil || !c.Settings.Debug {
 		return ctx.JSON(http.StatusForbidden, map[string]string{
 			"error": "Debug mode not enabled",
 		})
@@ -131,8 +131,8 @@ func (c *Controller) DebugTriggerError(ctx echo.Context) error {
 
 // DebugTriggerNotification triggers a test notification
 func (c *Controller) DebugTriggerNotification(ctx echo.Context) error {
-	// Double-check debug mode
-	if !conf.GetSettings().Debug {
+	// Double-check debug mode using controller's settings
+	if c.Settings == nil || !c.Settings.Debug {
 		return ctx.JSON(http.StatusForbidden, map[string]string{
 			"error": "Debug mode not enabled",
 		})
@@ -198,8 +198,8 @@ func (c *Controller) DebugTriggerNotification(ctx echo.Context) error {
 
 // DebugSystemStatus returns current system status for debugging
 func (c *Controller) DebugSystemStatus(ctx echo.Context) error {
-	// Double-check debug mode
-	if !conf.GetSettings().Debug {
+	// Double-check debug mode using controller's settings
+	if c.Settings == nil || !c.Settings.Debug {
 		return ctx.JSON(http.StatusForbidden, map[string]string{
 			"error": "Debug mode not enabled",
 		})
@@ -207,7 +207,7 @@ func (c *Controller) DebugSystemStatus(ctx echo.Context) error {
 
 	status := DebugSystemStatus{
 		Timestamp: time.Now().Format(time.RFC3339),
-		Debug:     conf.GetSettings().Debug,
+		Debug:     c.Settings.Debug,
 	}
 
 	// Get telemetry status
@@ -248,7 +248,12 @@ func mapErrorCategory(category string) errors.ErrorCategory {
 func getTelemetryStatus() map[string]any {
 	// Get more detailed telemetry status
 	status := map[string]any{
-		"enabled": conf.GetSettings().Sentry.Enabled,
+		"enabled": false, // Default to false for safety
+	}
+	
+	// Check if settings are available via global conf
+	if settings := conf.GetSettings(); settings != nil {
+		status["enabled"] = settings.Sentry.Enabled
 	}
 	
 	// Add health check info if available

--- a/internal/birdweather/audio_test.go
+++ b/internal/birdweather/audio_test.go
@@ -59,16 +59,15 @@ func TestEncodePCMtoWAV_ValidInput(t *testing.T) {
 
 	// Extract header components
 	header := make([]byte, 44) // Standard WAV header size
-	_, err = io.ReadFull(wavBuffer, header)
-	if err != nil {
-		t.Fatalf("Failed to read WAV header: %v", err)
+
+	// Get all data from buffer to avoid issues with reading twice
+	allData := wavBuffer.Bytes()
+	if len(allData) < 44 {
+		t.Fatalf("WAV buffer too small for header: got %d bytes, need at least 44", len(allData))
 	}
 
-	// Reset buffer position
-	wavBuffer.Reset()
-	if _, err := io.ReadFull(wavBuffer, header); err != nil {
-		t.Fatalf("Failed to read WAV header: %v", err)
-	}
+	// Copy header from the beginning of the data
+	copy(header, allData[:44])
 
 	// Check RIFF header
 	if string(header[0:4]) != "RIFF" {

--- a/internal/telemetry/e2e_test.go
+++ b/internal/telemetry/e2e_test.go
@@ -12,7 +12,7 @@ import (
 
 // TestE2ECompleteFlow tests the complete telemetry flow
 func TestE2ECompleteFlow(t *testing.T) {
-	t.Parallel()
+	// Cannot run in parallel due to global event bus state
 	config, cleanup := InitForTesting(t)
 	defer cleanup()
 
@@ -20,7 +20,6 @@ func TestE2ECompleteFlow(t *testing.T) {
 	InitializeErrorIntegration()
 
 	t.Run("error to telemetry flow", func(t *testing.T) {
-		t.Parallel()
 		// Create enhanced error
 		enhancedErr := errors.New(fmt.Errorf("test error")).
 			Component("test-component").
@@ -32,7 +31,7 @@ func TestE2ECompleteFlow(t *testing.T) {
 
 		// Verify capture
 		AssertEventCount(t, config.MockTransport, 1, 100*time.Millisecond)
-		
+
 		// Check actual event
 		event := config.MockTransport.GetLastEvent()
 		if event != nil {
@@ -42,7 +41,6 @@ func TestE2ECompleteFlow(t *testing.T) {
 	})
 
 	t.Run("privacy scrubbing", func(t *testing.T) {
-		t.Parallel()
 		config.MockTransport.Clear()
 
 		// Error with sensitive URL
@@ -50,7 +48,7 @@ func TestE2ECompleteFlow(t *testing.T) {
 		CaptureError(err, "api-client")
 
 		AssertEventCount(t, config.MockTransport, 1, 100*time.Millisecond)
-		
+
 		event := config.MockTransport.GetLastEvent()
 		if event != nil {
 			// Verify URL was scrubbed
@@ -64,7 +62,6 @@ func TestE2ECompleteFlow(t *testing.T) {
 	})
 
 	t.Run("concurrent reporting", func(t *testing.T) {
-		t.Parallel()
 		config.MockTransport.Clear()
 
 		// Report errors concurrently
@@ -89,7 +86,7 @@ func TestE2ECompleteFlow(t *testing.T) {
 
 // TestE2EMessageFlow tests message reporting flow
 func TestE2EMessageFlow(t *testing.T) {
-	t.Parallel()
+	// Cannot run in parallel due to global event bus state
 	config, cleanup := InitForTesting(t)
 	defer cleanup()
 
@@ -105,14 +102,14 @@ func TestE2EMessageFlow(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.message, func(t *testing.T) {
-			t.Parallel()
 			config.MockTransport.Clear()
-			
+
 			CaptureMessage(tt.message, tt.level, tt.component)
-			
+
 			AssertEventCount(t, config.MockTransport, 1, 100*time.Millisecond)
 			AssertEventLevel(t, config.MockTransport, tt.message, tt.level)
 			AssertEventTag(t, config.MockTransport, tt.message, "component", tt.component)
 		})
 	}
 }
+

--- a/internal/telemetry/integration_test.go
+++ b/internal/telemetry/integration_test.go
@@ -12,9 +12,8 @@ import (
 )
 
 func TestTelemetryIntegration(t *testing.T) {
-	t.Parallel()
+	// Cannot run in parallel due to global event bus state
 	t.Run("error reporting through telemetry", func(t *testing.T) {
-		t.Parallel()
 		config, cleanup := InitForTesting(t)
 		defer cleanup()
 
@@ -49,7 +48,6 @@ func TestTelemetryIntegration(t *testing.T) {
 	})
 
 	t.Run("message reporting with different levels", func(t *testing.T) {
-		t.Parallel()
 		config, cleanup := InitForTesting(t)
 		defer cleanup()
 
@@ -75,14 +73,13 @@ func TestTelemetryIntegration(t *testing.T) {
 
 		for i, event := range events {
 			if event.Level != expectedLevels[i] {
-				t.Errorf("Event %d: expected level %s, got %s", 
+				t.Errorf("Event %d: expected level %s, got %s",
 					i, expectedLevels[i], event.Level)
 			}
 		}
 	})
 
 	t.Run("attachment uploader availability", func(t *testing.T) {
-		t.Parallel()
 		_, cleanup := InitForTesting(t)
 		defer cleanup()
 
@@ -97,7 +94,6 @@ func TestTelemetryIntegration(t *testing.T) {
 	})
 
 	t.Run("initialization safety", func(t *testing.T) {
-		t.Parallel()
 		// Test that telemetry handles initialization safely
 		config, cleanup := InitForTesting(t)
 		defer cleanup()
@@ -111,7 +107,6 @@ func TestTelemetryIntegration(t *testing.T) {
 	})
 
 	t.Run("privacy compliance", func(t *testing.T) {
-		t.Parallel()
 		config, cleanup := InitForTesting(t)
 		defer cleanup()
 
@@ -132,7 +127,7 @@ func TestTelemetryIntegration(t *testing.T) {
 		if strings.Contains(event.Message, "api.example.com") {
 			t.Error("Sensitive URL was not anonymized")
 		}
-		
+
 		if strings.Contains(event.Message, "user:pass") {
 			t.Error("Credentials were not removed")
 		}
@@ -142,7 +137,6 @@ func TestTelemetryIntegration(t *testing.T) {
 	})
 
 	t.Run("concurrent event reporting", func(t *testing.T) {
-		t.Parallel()
 		config, cleanup := InitForTesting(t)
 		defer cleanup()
 
@@ -172,7 +166,6 @@ func TestTelemetryIntegration(t *testing.T) {
 	})
 
 	t.Run("flush behavior", func(t *testing.T) {
-		t.Parallel()
 		config, cleanup := InitForTesting(t)
 		defer cleanup()
 
@@ -227,11 +220,12 @@ func ReportError(err error) {
 	if enhancedErr, ok := err.(interface{ GetComponent() string }); ok {
 		component = enhancedErr.GetComponent()
 	}
-	
+
 	CaptureError(err, component)
 }
 
-// Helper function to test ReportMessage  
+// Helper function to test ReportMessage
 func ReportMessage(message string, level sentry.Level, component string) {
 	CaptureMessage(message, level, component)
 }
+


### PR DESCRIPTION
## Summary
This PR fixes failing and flaky tests across multiple packages:
- Fixed buffer reading issue in birdweather audio tests
- Fixed telemetry tests to work with async event bus
- Fixed API v2 debug endpoint tests
- Made TestGoroutineTerminationOnStop more robust

## Test Results
All tests are now passing consistently:
- `TestEncodePCMtoWAV_ValidInput` ✅
- All telemetry async tests ✅
- `TestDebugEndpointsRequireDebugMode` ✅
- `TestGoroutineTerminationOnStop` (50+ runs without failure) ✅

## Changes Made

### Birdweather Package
- Fixed `TestEncodePCMtoWAV_ValidInput` by using `Bytes()` method instead of reading buffer twice
- This prevents EOF errors when validating WAV headers

### Telemetry Package
- Updated `InitForTesting` to properly initialize event bus for async processing
- Added check to prevent duplicate telemetry worker registration
- Fixed variable shadowing issues (renamed "events" to "capturedEvents")
- Removed `t.Parallel()` from tests that use global event bus state
- Added proper cleanup using `events.ResetForTesting()`

### API v2 Package
- Fixed debug handlers to use controller settings instead of global settings
- Ensures consistent behavior in test environments
- Updated `getTelemetryStatus` to handle nil settings gracefully

### MyAudio Package
- Made `TestGoroutineTerminationOnStop` more robust:
  - Removed `t.Parallel()` to avoid interference from concurrent tests
  - Added GC calls to stabilize goroutine counts
  - Increased timeouts and iteration counts for better reliability
  - Increased delta tolerance for goroutine count checks

## Testing
- All tests pass with `go test ./...`
- Linter passes with 0 issues: `golangci-lint run -v`
- No race conditions detected: `go test -race`

🤖 Generated with [Claude Code](https://claude.ai/code)