### PR TITLE
fix: telemetry tests failing in GitHub Actions when telemetry is disabled

### DIFF
--- a/internal/telemetry/eventbus_integration.go
+++ b/internal/telemetry/eventbus_integration.go
@@ -26,11 +26,13 @@ func init() {
 // InitializeEventBusIntegration sets up the telemetry worker as an event consumer
 // This should be called after both Sentry and event bus are initialized
 func InitializeEventBusIntegration() error {
-	// Check if Sentry is enabled
-	settings := conf.GetSettings()
-	if settings == nil || !settings.Sentry.Enabled {
-		logger.Info("Sentry telemetry disabled, skipping event bus integration")
-		return nil
+	// Check if Sentry is enabled (skip check in test mode)
+	if !testMode {
+		settings := conf.GetSettings()
+		if settings == nil || !settings.Sentry.Enabled {
+			logger.Info("Sentry telemetry disabled, skipping event bus integration")
+			return nil
+		}
 	}
 
 	// Check if event bus is initialized

--- a/internal/telemetry/eventbus_integration.go
+++ b/internal/telemetry/eventbus_integration.go
@@ -2,6 +2,7 @@ package telemetry
 
 import (
 	"fmt"
+	"sync/atomic"
 	"time"
 
 	"github.com/tphakala/birdnet-go/internal/conf"
@@ -27,7 +28,7 @@ func init() {
 // This should be called after both Sentry and event bus are initialized
 func InitializeEventBusIntegration() error {
 	// Check if Sentry is enabled (skip check in test mode)
-	if !testMode {
+	if atomic.LoadInt32(&testMode) == 0 {
 		settings := conf.GetSettings()
 		if settings == nil || !settings.Sentry.Enabled {
 			logger.Info("Sentry telemetry disabled, skipping event bus integration")

--- a/internal/telemetry/optimized_capture.go
+++ b/internal/telemetry/optimized_capture.go
@@ -13,7 +13,7 @@ var telemetryEnabled atomic.Bool
 // UpdateTelemetryEnabled updates the cached telemetry enabled state
 func UpdateTelemetryEnabled() {
 	// In test mode, telemetry is always enabled
-	if testMode {
+	if atomic.LoadInt32(&testMode) == 1 {
 		telemetryEnabled.Store(true)
 		return
 	}

--- a/internal/telemetry/optimized_capture.go
+++ b/internal/telemetry/optimized_capture.go
@@ -12,6 +12,12 @@ var telemetryEnabled atomic.Bool
 
 // UpdateTelemetryEnabled updates the cached telemetry enabled state
 func UpdateTelemetryEnabled() {
+	// In test mode, telemetry is always enabled
+	if testMode {
+		telemetryEnabled.Store(true)
+		return
+	}
+	
 	settings := conf.GetSettings()
 	if settings != nil && settings.Sentry.Enabled {
 		telemetryEnabled.Store(true)

--- a/internal/telemetry/sentry.go
+++ b/internal/telemetry/sentry.go
@@ -30,6 +30,7 @@ var (
 	deferredMessages   []DeferredMessage
 	deferredMutex      sync.Mutex
 	attachmentUploader *AttachmentUploader
+	testMode           bool // testMode allows tests to bypass settings checks
 )
 
 // PlatformInfo holds privacy-safe platform information for telemetry
@@ -195,9 +196,12 @@ func InitSentry(settings *conf.Settings) error {
 
 // CaptureError captures an error with privacy-compliant context
 func CaptureError(err error, component string) {
-	settings := conf.GetSettings()
-	if settings == nil || !settings.Sentry.Enabled {
-		return
+	// Skip settings check in test mode
+	if !testMode {
+		settings := conf.GetSettings()
+		if settings == nil || !settings.Sentry.Enabled {
+			return
+		}
 	}
 
 	// Create a scrubbed error for privacy
@@ -218,9 +222,12 @@ func CaptureError(err error, component string) {
 
 // CaptureMessage captures a message with privacy-compliant context
 func CaptureMessage(message string, level sentry.Level, component string) {
-	settings := conf.GetSettings()
-	if settings == nil || !settings.Sentry.Enabled {
-		return
+	// Skip settings check in test mode
+	if !testMode {
+		settings := conf.GetSettings()
+		if settings == nil || !settings.Sentry.Enabled {
+			return
+		}
 	}
 
 	// Scrub sensitive information from the message
@@ -236,9 +243,12 @@ func CaptureMessage(message string, level sentry.Level, component string) {
 // CaptureMessageDeferred captures a message for later processing if Sentry is not yet initialized
 // If Sentry is already initialized, it immediately sends the message
 func CaptureMessageDeferred(message string, level sentry.Level, component string) {
-	settings := conf.GetSettings()
-	if settings == nil || !settings.Sentry.Enabled {
-		return
+	// Skip settings check in test mode
+	if !testMode {
+		settings := conf.GetSettings()
+		if settings == nil || !settings.Sentry.Enabled {
+			return
+		}
 	}
 
 	deferredMutex.Lock()
@@ -263,9 +273,12 @@ func CaptureMessageDeferred(message string, level sentry.Level, component string
 
 // Flush ensures all buffered events are sent to Sentry
 func Flush(timeout time.Duration) {
-	settings := conf.GetSettings()
-	if settings == nil || !settings.Sentry.Enabled {
-		return
+	// Skip settings check in test mode
+	if !testMode {
+		settings := conf.GetSettings()
+		if settings == nil || !settings.Sentry.Enabled {
+			return
+		}
 	}
 
 	sentry.Flush(timeout)

--- a/internal/telemetry/test_helpers.go
+++ b/internal/telemetry/test_helpers.go
@@ -60,8 +60,12 @@ func InitForTesting(t TestingTB) (config *TestConfig, cleanup func()) {
 		t.Fatalf("Failed to initialize Sentry for testing: %v", err)
 	}
 
-	// Mark as initialized
+	// Mark as initialized and enable test mode
 	sentryInitialized = true
+	testMode = true
+	
+	// Update telemetry enabled state for test mode
+	UpdateTelemetryEnabled()
 
 	// Configure scope with test data
 	sentry.ConfigureScope(func(scope *sentry.Scope) {
@@ -112,6 +116,7 @@ func InitForTesting(t TestingTB) (config *TestConfig, cleanup func()) {
 
 		// Reset initialization state
 		sentryInitialized = false
+		testMode = false
 
 		// Clear deferred messages
 		deferredMutex.Lock()

--- a/internal/telemetry/test_helpers.go
+++ b/internal/telemetry/test_helpers.go
@@ -1,6 +1,7 @@
 package telemetry
 
 import (
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -62,7 +63,7 @@ func InitForTesting(t TestingTB) (config *TestConfig, cleanup func()) {
 
 	// Mark as initialized and enable test mode
 	sentryInitialized = true
-	testMode = true
+	atomic.StoreInt32(&testMode, 1)
 	
 	// Update telemetry enabled state for test mode
 	UpdateTelemetryEnabled()
@@ -116,7 +117,7 @@ func InitForTesting(t TestingTB) (config *TestConfig, cleanup func()) {
 
 		// Reset initialization state
 		sentryInitialized = false
-		testMode = false
+		atomic.StoreInt32(&testMode, 0)
 
 		// Clear deferred messages
 		deferredMutex.Lock()


### PR DESCRIPTION
## Summary
- Fixed telemetry tests that were failing in GitHub Actions when telemetry is disabled
- Tests now work correctly regardless of the global telemetry settings

## Problem
The telemetry tests were failing in GitHub Actions because:
1. Tests expected telemetry to work via `InitForTesting()` which sets up mock transport
2. But the actual capture functions (`CaptureError`, `CaptureMessage`) check global settings
3. In GitHub Actions, telemetry is disabled by default, causing early returns

## Solution
- Added a `testMode` flag that bypasses telemetry enabled checks during tests
- Updated all telemetry capture functions to check `testMode` before checking settings
- Test helper now enables `testMode` when initializing and disables it during cleanup
- Updated telemetry enabled cache to respect `testMode`

## Test plan
- [x] Run telemetry tests locally with telemetry enabled
- [x] Run telemetry tests locally with telemetry disabled (simulating GitHub Actions)
- [x] Verify linter passes with no issues
- [ ] Confirm tests pass in GitHub Actions CI

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced telemetry system to support a dedicated test mode, allowing telemetry features to operate independently of runtime settings during testing.

* **Chores**
  * Improved internal test setup and cleanup for telemetry, ensuring consistent behavior when running tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->