### PR TITLE
fix: handle case-insensitive database type comparison in schema validation

### DIFF
--- a/internal/datastore/manage.go
+++ b/internal/datastore/manage.go
@@ -379,7 +379,7 @@ func validateAndFixSchema(db *gorm.DB, dbType, connectionInfo string, debug bool
 	var schemaCorrect bool
 	var err error
 
-	switch dbType {
+	switch strings.ToLower(dbType) {
 	case "sqlite":
 		schemaCorrect, err = hasCorrectImageCacheIndexSQLite(db, debug)
 		if err != nil {


### PR DESCRIPTION
## Summary
- Fixed case-sensitive database type comparison that was preventing proper schema validation for SQLite databases
- The code expected lowercase "sqlite" but received "SQLite", causing validation to be skipped
- Made the comparison case-insensitive using `strings.ToLower()`

## Problem
The image_caches table automigration was failing with:
```
UNIQUE constraint failed: image_caches.scientific_name
```

This occurred because the schema validation code was being bypassed due to case mismatch:
- SQLite driver passes "SQLite" (capital S)
- Schema validation switch statement expected "sqlite" (lowercase)
- This caused the validation to fall through to the default case with the warning: "Unsupported database type for image_caches schema check"

## Solution
Changed the switch statement in `validateAndFixSchema()` to use `strings.ToLower(dbType)` for case-insensitive comparison.

## Test plan
- [x] Verified the fix resolves the UNIQUE constraint error
- [x] Schema validation now properly detects and fixes incorrect single-column unique constraint
- [x] ON CONFLICT clause works correctly after migration

🤖 Generated with [Claude Code](https://claude.ai/code)