### PR TITLE
Optimize pairLabelsAndConfidence to reduce memory allocations

### DIFF
--- a/internal/birdnet/analyze_bench_test.go
+++ b/internal/birdnet/analyze_bench_test.go
@@ -1,0 +1,276 @@
+package birdnet
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/tphakala/birdnet-go/internal/datastore"
+)
+
+// BenchmarkPairLabelsAndConfidence measures the memory allocation and performance
+// of the pairLabelsAndConfidence function which shows up as a major memory consumer in pprof.
+func BenchmarkPairLabelsAndConfidence(b *testing.B) {
+	// Create realistic test data - BirdNET v2.4 has 6,522 bird species
+	speciesCount := 6522
+	labels := make([]string, speciesCount)
+	confidence := make([]float32, speciesCount)
+	
+	// Generate realistic species names and confidence values
+	for i := 0; i < speciesCount; i++ {
+		labels[i] = generateSpeciesName(i)
+		confidence[i] = float32(i%100) / 100.0 // 0.00 to 0.99
+	}
+	
+	// Reset timer to exclude setup time
+	b.ResetTimer()
+	
+	// Run benchmark
+	for i := 0; i < b.N; i++ {
+		results, err := pairLabelsAndConfidence(labels, confidence)
+		if err != nil {
+			b.Errorf("pairLabelsAndConfidence failed: %v", err)
+		}
+		
+		// Prevent compiler optimization by using the results
+		if len(results) != speciesCount {
+			b.Errorf("Expected %d results, got %d", speciesCount, len(results))
+		}
+	}
+}
+
+// BenchmarkPairLabelsAndConfidenceMemory specifically measures memory allocations
+// in the pairLabelsAndConfidence function.
+func BenchmarkPairLabelsAndConfidenceMemory(b *testing.B) {
+	speciesCount := 6522
+	labels := make([]string, speciesCount)
+	confidence := make([]float32, speciesCount)
+	
+	// Generate test data
+	for i := 0; i < speciesCount; i++ {
+		labels[i] = generateSpeciesName(i)
+		confidence[i] = float32(i%100) / 100.0
+	}
+	
+	// Reset timer and enable memory allocation tracking
+	b.ResetTimer()
+	b.ReportAllocs()
+	
+	// Benchmark with memory tracking
+	for i := 0; i < b.N; i++ {
+		results, err := pairLabelsAndConfidence(labels, confidence)
+		if err != nil {
+			b.Errorf("pairLabelsAndConfidence failed: %v", err)
+		}
+		
+		// Prevent compiler optimization
+		if results != nil {
+			_ = results[0].Species
+		}
+	}
+}
+
+// BenchmarkExtractPredictions measures the performance of extracting predictions
+// from TensorFlow Lite tensors.
+// NOTE: This benchmark is disabled as it requires complex TensorFlow Lite setup
+/*
+func BenchmarkExtractPredictions(b *testing.B) {
+	// Create a mock tensor with realistic size
+	mockTensor := createMockTensor(6522)
+	
+	b.ResetTimer()
+	b.ReportAllocs()
+	
+	for i := 0; i < b.N; i++ {
+		predictions := extractPredictions(mockTensor)
+		
+		// Prevent compiler optimization
+		if len(predictions) != 6522 {
+			b.Errorf("Expected 6522 predictions, got %d", len(predictions))
+		}
+	}
+}
+*/
+
+// BenchmarkApplySigmoidToPredictions measures the performance of applying sigmoid
+// to prediction values.
+func BenchmarkApplySigmoidToPredictions(b *testing.B) {
+	// Create test predictions array
+	predictions := make([]float32, 6522)
+	for i := range predictions {
+		predictions[i] = float32(i%200-100) / 100.0 // -1.0 to 1.0
+	}
+	
+	sensitivity := 1.0
+	
+	b.ResetTimer()
+	b.ReportAllocs()
+	
+	for i := 0; i < b.N; i++ {
+		confidence := applySigmoidToPredictions(predictions, sensitivity)
+		
+		// Prevent compiler optimization
+		if len(confidence) != 6522 {
+			b.Errorf("Expected 6522 confidence values, got %d", len(confidence))
+		}
+	}
+}
+
+// BenchmarkSortResults measures the performance of sorting results by confidence.
+func BenchmarkSortResults(b *testing.B) {
+	// Create test results with realistic data
+	results := make([]datastore.Results, 6522)
+	for i := range results {
+		results[i] = datastore.Results{
+			Species:    generateSpeciesName(i),
+			Confidence: float32(i%100) / 100.0,
+		}
+	}
+	
+	b.ResetTimer()
+	b.ReportAllocs()
+	
+	for i := 0; i < b.N; i++ {
+		// Make a copy to sort since sorting modifies the slice
+		testResults := make([]datastore.Results, len(results))
+		copy(testResults, results)
+		
+		sortResults(testResults)
+		
+		// Verify sorting worked (highest confidence first)
+		if len(testResults) > 1 && testResults[0].Confidence < testResults[1].Confidence {
+			b.Errorf("Results not sorted correctly")
+		}
+	}
+}
+
+// BenchmarkTrimResultsToMax measures the performance of trimming results to top N.
+func BenchmarkTrimResultsToMax(b *testing.B) {
+	// Create test results
+	results := make([]datastore.Results, 6522)
+	for i := range results {
+		results[i] = datastore.Results{
+			Species:    generateSpeciesName(i),
+			Confidence: float32(i%100) / 100.0,
+		}
+	}
+	
+	b.ResetTimer()
+	b.ReportAllocs()
+	
+	for i := 0; i < b.N; i++ {
+		trimmed := trimResultsToMax(results, 10)
+		
+		// Verify trimming worked
+		if len(trimmed) != 10 {
+			b.Errorf("Expected 10 results, got %d", len(trimmed))
+		}
+	}
+}
+
+// BenchmarkFullPredictionPipeline measures the complete prediction pipeline
+// excluding TensorFlow Lite inference (since we can't easily mock that).
+func BenchmarkFullPredictionPipeline(b *testing.B) {
+	speciesCount := 6522
+	labels := make([]string, speciesCount)
+	rawPredictions := make([]float32, speciesCount)
+	
+	// Generate realistic test data
+	for i := 0; i < speciesCount; i++ {
+		labels[i] = generateSpeciesName(i)
+		rawPredictions[i] = float32(i%200-100) / 100.0 // -1.0 to 1.0
+	}
+	
+	sensitivity := 1.0
+	
+	b.ResetTimer()
+	b.ReportAllocs()
+	
+	for i := 0; i < b.N; i++ {
+		// Step 1: Apply sigmoid to predictions
+		confidence := applySigmoidToPredictions(rawPredictions, sensitivity)
+		
+		// Step 2: Pair labels with confidence values
+		results, err := pairLabelsAndConfidence(labels, confidence)
+		if err != nil {
+			b.Errorf("pairLabelsAndConfidence failed: %v", err)
+		}
+		
+		// Step 3: Sort results by confidence
+		sortResults(results)
+		
+		// Step 4: Trim to top 10 results
+		finalResults := trimResultsToMax(results, 10)
+		
+		// Prevent compiler optimization
+		if len(finalResults) != 10 {
+			b.Errorf("Expected 10 final results, got %d", len(finalResults))
+		}
+	}
+}
+
+// BenchmarkPairLabelsAndConfidenceOptimized tests the optimized buffer reuse version
+func BenchmarkPairLabelsAndConfidenceOptimized(b *testing.B) {
+	speciesCount := 6522
+	labels := make([]string, speciesCount)
+	confidence := make([]float32, speciesCount)
+	buffer := make([]datastore.Results, speciesCount) // Pre-allocated buffer
+	
+	// Generate realistic data
+	for i := 0; i < speciesCount; i++ {
+		labels[i] = generateSpeciesName(i)
+		confidence[i] = float32(i%100) / 100.0
+	}
+	
+	b.ResetTimer()
+	b.ReportAllocs()
+	
+	for i := 0; i < b.N; i++ {
+		results, err := pairLabelsAndConfidenceReuse(labels, confidence, buffer)
+		if err != nil {
+			b.Errorf("pairLabelsAndConfidenceReuse failed: %v", err)
+		}
+		
+		// Prevent compiler optimization
+		if len(results) != speciesCount {
+			b.Errorf("Expected %d results, got %d", speciesCount, len(results))
+		}
+	}
+}
+
+// BenchmarkMemoryGrowthPattern measures memory growth during repeated predictions
+func BenchmarkMemoryGrowthPattern(b *testing.B) {
+	speciesCount := 6522
+	labels := make([]string, speciesCount)
+	
+	// Generate labels once
+	for i := 0; i < speciesCount; i++ {
+		labels[i] = generateSpeciesName(i)
+	}
+	
+	b.ResetTimer()
+	b.ReportAllocs()
+	
+	for i := 0; i < b.N; i++ {
+		// Simulate varying confidence values each iteration
+		confidence := make([]float32, speciesCount)
+		for j := range confidence {
+			confidence[j] = float32((i+j)%100) / 100.0
+		}
+		
+		// Run the memory-intensive pipeline
+		results, err := pairLabelsAndConfidence(labels, confidence)
+		if err != nil {
+			b.Errorf("pairLabelsAndConfidence failed: %v", err)
+		}
+		
+		// Sort and trim as in real usage
+		sortResults(results)
+		trimResultsToMax(results, 10)
+	}
+}
+
+// generateSpeciesName creates realistic species names for testing
+func generateSpeciesName(index int) string {
+	// Generate names like "Species_000001", "Species_000002", etc.
+	return fmt.Sprintf("Species_%06d", index+1)
+}

--- a/internal/birdnet/analyze_test.go
+++ b/internal/birdnet/analyze_test.go
@@ -1,0 +1,594 @@
+package birdnet
+
+import (
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/tphakala/birdnet-go/internal/datastore"
+)
+
+// TestPairLabelsAndConfidence tests the pairLabelsAndConfidence function
+func TestPairLabelsAndConfidence(t *testing.T) {
+	tests := []struct {
+		name        string
+		labels      []string
+		confidence  []float32
+		wantErr     bool
+		errContains string
+		validate    func(t *testing.T, results []datastore.Results)
+	}{
+		{
+			name:       "Valid pairing",
+			labels:     []string{"Robin", "Sparrow", "Eagle"},
+			confidence: []float32{0.9, 0.7, 0.5},
+			wantErr:    false,
+			validate: func(t *testing.T, results []datastore.Results) {
+				if len(results) != 3 {
+					t.Errorf("Expected 3 results, got %d", len(results))
+				}
+				expected := []struct {
+					species    string
+					confidence float32
+				}{
+					{"Robin", 0.9},
+					{"Sparrow", 0.7},
+					{"Eagle", 0.5},
+				}
+				for i, exp := range expected {
+					if results[i].Species != exp.species {
+						t.Errorf("Result %d: expected species %s, got %s", i, exp.species, results[i].Species)
+					}
+					if results[i].Confidence != exp.confidence {
+						t.Errorf("Result %d: expected confidence %f, got %f", i, exp.confidence, results[i].Confidence)
+					}
+				}
+			},
+		},
+		{
+			name:        "Mismatched lengths - more labels",
+			labels:      []string{"Robin", "Sparrow", "Eagle"},
+			confidence:  []float32{0.9, 0.7},
+			wantErr:     true,
+			errContains: "mismatched labels and predictions lengths: 3 vs 2",
+		},
+		{
+			name:        "Mismatched lengths - more confidence",
+			labels:      []string{"Robin", "Sparrow"},
+			confidence:  []float32{0.9, 0.7, 0.5},
+			wantErr:     true,
+			errContains: "mismatched labels and predictions lengths: 2 vs 3",
+		},
+		{
+			name:       "Empty slices",
+			labels:     []string{},
+			confidence: []float32{},
+			wantErr:    false,
+			validate: func(t *testing.T, results []datastore.Results) {
+				if len(results) != 0 {
+					t.Errorf("Expected 0 results, got %d", len(results))
+				}
+			},
+		},
+		{
+			name:       "Single element",
+			labels:     []string{"Robin"},
+			confidence: []float32{0.95},
+			wantErr:    false,
+			validate: func(t *testing.T, results []datastore.Results) {
+				if len(results) != 1 {
+					t.Errorf("Expected 1 result, got %d", len(results))
+				}
+				if results[0].Species != "Robin" {
+					t.Errorf("Expected species Robin, got %s", results[0].Species)
+				}
+				if results[0].Confidence != 0.95 {
+					t.Errorf("Expected confidence 0.95, got %f", results[0].Confidence)
+				}
+			},
+		},
+		{
+			name:       "Large dataset (BirdNET size)",
+			labels:     generateTestLabels(6522),
+			confidence: generateTestConfidence(6522),
+			wantErr:    false,
+			validate: func(t *testing.T, results []datastore.Results) {
+				if len(results) != 6522 {
+					t.Errorf("Expected 6522 results, got %d", len(results))
+				}
+				// Verify a few samples
+				if results[0].Species != "Species_000001" {
+					t.Errorf("First species incorrect: %s", results[0].Species)
+				}
+				if results[6521].Species != "Species_006522" {
+					t.Errorf("Last species incorrect: %s", results[6521].Species)
+				}
+			},
+		},
+		{
+			name:       "Confidence edge values",
+			labels:     []string{"A", "B", "C", "D"},
+			confidence: []float32{0.0, 1.0, 0.5, 0.999},
+			wantErr:    false,
+			validate: func(t *testing.T, results []datastore.Results) {
+				if results[0].Confidence != 0.0 {
+					t.Errorf("Expected confidence 0.0, got %f", results[0].Confidence)
+				}
+				if results[1].Confidence != 1.0 {
+					t.Errorf("Expected confidence 1.0, got %f", results[1].Confidence)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			results, err := pairLabelsAndConfidence(tt.labels, tt.confidence)
+			
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("Expected error containing '%s', got nil", tt.errContains)
+				} else if tt.errContains != "" && err.Error() != tt.errContains {
+					t.Errorf("Expected error '%s', got '%s'", tt.errContains, err.Error())
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+				if tt.validate != nil {
+					tt.validate(t, results)
+				}
+			}
+		})
+	}
+}
+
+// TestPairLabelsAndConfidenceReuseBuffer tests the buffer reuse function
+func TestPairLabelsAndConfidenceReuseBuffer(t *testing.T) {
+	tests := []struct {
+		name        string
+		labels      []string
+		confidence  []float32
+		bufferSize  int
+		wantErr     bool
+		errContains string
+		validate    func(t *testing.T, buffer []datastore.Results, results []datastore.Results)
+	}{
+		{
+			name:       "Valid buffer reuse",
+			labels:     []string{"Robin", "Sparrow", "Eagle"},
+			confidence: []float32{0.9, 0.7, 0.5},
+			bufferSize: 3,
+			wantErr:    false,
+			validate: func(t *testing.T, buffer []datastore.Results, results []datastore.Results) {
+				// Results should point to the same buffer
+				if &results[0] != &buffer[0] {
+					t.Error("Results should reference the same buffer")
+				}
+				// Check values
+				expected := []struct {
+					species    string
+					confidence float32
+				}{
+					{"Robin", 0.9},
+					{"Sparrow", 0.7},
+					{"Eagle", 0.5},
+				}
+				for i, exp := range expected {
+					if results[i].Species != exp.species {
+						t.Errorf("Result %d: expected species %s, got %s", i, exp.species, results[i].Species)
+					}
+					if results[i].Confidence != exp.confidence {
+						t.Errorf("Result %d: expected confidence %f, got %f", i, exp.confidence, results[i].Confidence)
+					}
+				}
+			},
+		},
+		{
+			name:        "Buffer too small",
+			labels:      []string{"Robin", "Sparrow", "Eagle"},
+			confidence:  []float32{0.9, 0.7, 0.5},
+			bufferSize:  2,
+			wantErr:     true,
+			errContains: "buffer size mismatch: 2 vs 3",
+		},
+		{
+			name:        "Buffer too large",
+			labels:      []string{"Robin", "Sparrow"},
+			confidence:  []float32{0.9, 0.7},
+			bufferSize:  3,
+			wantErr:     true,
+			errContains: "buffer size mismatch: 3 vs 2",
+		},
+		{
+			name:        "Mismatched labels and confidence",
+			labels:      []string{"Robin", "Sparrow", "Eagle"},
+			confidence:  []float32{0.9, 0.7},
+			bufferSize:  3,
+			wantErr:     true,
+			errContains: "mismatched labels and predictions lengths: 3 vs 2",
+		},
+		{
+			name:       "Empty data with empty buffer",
+			labels:     []string{},
+			confidence: []float32{},
+			bufferSize: 0,
+			wantErr:    false,
+			validate: func(t *testing.T, buffer []datastore.Results, results []datastore.Results) {
+				if len(results) != 0 {
+					t.Errorf("Expected 0 results, got %d", len(results))
+				}
+			},
+		},
+		{
+			name:       "Reuse buffer multiple times",
+			labels:     []string{"Robin", "Sparrow", "Eagle"},
+			confidence: []float32{0.9, 0.7, 0.5},
+			bufferSize: 3,
+			wantErr:    false,
+			validate: func(t *testing.T, buffer []datastore.Results, results []datastore.Results) {
+				// First use
+				if results[0].Species != "Robin" || results[0].Confidence != 0.9 {
+					t.Errorf("First use failed")
+				}
+				
+				// Reuse with different values
+				newLabels := []string{"Hawk", "Owl", "Crow"}
+				newConfidence := []float32{0.8, 0.6, 0.4}
+				results2, err := pairLabelsAndConfidenceReuse(newLabels, newConfidence, buffer)
+				if err != nil {
+					t.Errorf("Second use failed: %v", err)
+				}
+				
+				// Check that buffer was updated
+				if results2[0].Species != "Hawk" || results2[0].Confidence != 0.8 {
+					t.Errorf("Buffer reuse failed: got %s/%f", results2[0].Species, results2[0].Confidence)
+				}
+				
+				// Original results slice should also be updated (same underlying array)
+				if results[0].Species != "Hawk" || results[0].Confidence != 0.8 {
+					t.Errorf("Buffer update not reflected in original slice")
+				}
+			},
+		},
+	}
+	
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create buffer
+			buffer := make([]datastore.Results, tt.bufferSize)
+			
+			// Call function
+			results, err := pairLabelsAndConfidenceReuse(tt.labels, tt.confidence, buffer)
+			
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("Expected error containing '%s', got nil", tt.errContains)
+				} else if tt.errContains != "" && err.Error() != tt.errContains {
+					t.Errorf("Expected error '%s', got '%s'", tt.errContains, err.Error())
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+				if tt.validate != nil {
+					tt.validate(t, buffer, results)
+				}
+			}
+		})
+	}
+}
+
+// TestPairLabelsAndConfidenceReuse tests that the function works correctly with pre-allocated slices
+func TestPairLabelsAndConfidenceReuse(t *testing.T) {
+	labels := []string{"Robin", "Sparrow", "Eagle"}
+	confidence1 := []float32{0.9, 0.7, 0.5}
+	confidence2 := []float32{0.3, 0.6, 0.8}
+	
+	// First call
+	results1, err := pairLabelsAndConfidence(labels, confidence1)
+	if err != nil {
+		t.Fatalf("First call failed: %v", err)
+	}
+	
+	// Save first results
+	saved := make([]datastore.Results, len(results1))
+	for i, r := range results1 {
+		saved[i] = r.Copy()
+	}
+	
+	// Second call
+	results2, err := pairLabelsAndConfidence(labels, confidence2)
+	if err != nil {
+		t.Fatalf("Second call failed: %v", err)
+	}
+	
+	// Verify first results haven't changed
+	for i, r := range saved {
+		if results1[i].Species != r.Species || results1[i].Confidence != r.Confidence {
+			t.Errorf("First results were modified at index %d", i)
+		}
+	}
+	
+	// Verify second results are correct
+	expected2 := []float32{0.3, 0.6, 0.8}
+	for i, exp := range expected2 {
+		if results2[i].Confidence != exp {
+			t.Errorf("Second result %d: expected confidence %f, got %f", i, exp, results2[i].Confidence)
+		}
+	}
+}
+
+// TestSortResults tests the sortResults function
+func TestSortResults(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []datastore.Results
+		expected []datastore.Results
+	}{
+		{
+			name: "Already sorted",
+			input: []datastore.Results{
+				{Species: "A", Confidence: 0.9},
+				{Species: "B", Confidence: 0.7},
+				{Species: "C", Confidence: 0.5},
+			},
+			expected: []datastore.Results{
+				{Species: "A", Confidence: 0.9},
+				{Species: "B", Confidence: 0.7},
+				{Species: "C", Confidence: 0.5},
+			},
+		},
+		{
+			name: "Reverse order",
+			input: []datastore.Results{
+				{Species: "C", Confidence: 0.5},
+				{Species: "B", Confidence: 0.7},
+				{Species: "A", Confidence: 0.9},
+			},
+			expected: []datastore.Results{
+				{Species: "A", Confidence: 0.9},
+				{Species: "B", Confidence: 0.7},
+				{Species: "C", Confidence: 0.5},
+			},
+		},
+		{
+			name: "Random order",
+			input: []datastore.Results{
+				{Species: "B", Confidence: 0.7},
+				{Species: "A", Confidence: 0.9},
+				{Species: "D", Confidence: 0.3},
+				{Species: "C", Confidence: 0.5},
+			},
+			expected: []datastore.Results{
+				{Species: "A", Confidence: 0.9},
+				{Species: "B", Confidence: 0.7},
+				{Species: "C", Confidence: 0.5},
+				{Species: "D", Confidence: 0.3},
+			},
+		},
+		{
+			name:     "Empty slice",
+			input:    []datastore.Results{},
+			expected: []datastore.Results{},
+		},
+		{
+			name: "Single element",
+			input: []datastore.Results{
+				{Species: "A", Confidence: 0.9},
+			},
+			expected: []datastore.Results{
+				{Species: "A", Confidence: 0.9},
+			},
+		},
+		{
+			name: "Equal confidence values",
+			input: []datastore.Results{
+				{Species: "A", Confidence: 0.5},
+				{Species: "B", Confidence: 0.5},
+				{Species: "C", Confidence: 0.9},
+				{Species: "D", Confidence: 0.5},
+			},
+			expected: []datastore.Results{
+				{Species: "C", Confidence: 0.9},
+				{Species: "A", Confidence: 0.5}, // Order among equal values may vary
+				{Species: "B", Confidence: 0.5},
+				{Species: "D", Confidence: 0.5},
+			},
+		},
+	}
+	
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Make a copy to avoid modifying test data
+			results := make([]datastore.Results, len(tt.input))
+			copy(results, tt.input)
+			
+			sortResults(results)
+			
+			if len(results) != len(tt.expected) {
+				t.Fatalf("Length mismatch: expected %d, got %d", len(tt.expected), len(results))
+			}
+			
+			// For equal confidence values, we just check that they're sorted by confidence
+			for i := 0; i < len(results); i++ {
+				if i > 0 && results[i].Confidence > results[i-1].Confidence {
+					t.Errorf("Results not sorted correctly at index %d: %f > %f", 
+						i, results[i].Confidence, results[i-1].Confidence)
+				}
+			}
+		})
+	}
+}
+
+// TestTrimResultsToMax tests the trimResultsToMax function
+func TestTrimResultsToMax(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     []datastore.Results
+		maxCount  int
+		wantCount int
+	}{
+		{
+			name: "Trim to 3 from 5",
+			input: []datastore.Results{
+				{Species: "A", Confidence: 0.9},
+				{Species: "B", Confidence: 0.8},
+				{Species: "C", Confidence: 0.7},
+				{Species: "D", Confidence: 0.6},
+				{Species: "E", Confidence: 0.5},
+			},
+			maxCount:  3,
+			wantCount: 3,
+		},
+		{
+			name: "No trimming needed",
+			input: []datastore.Results{
+				{Species: "A", Confidence: 0.9},
+				{Species: "B", Confidence: 0.8},
+			},
+			maxCount:  5,
+			wantCount: 2,
+		},
+		{
+			name:      "Empty input",
+			input:     []datastore.Results{},
+			maxCount:  10,
+			wantCount: 0,
+		},
+		{
+			name: "Trim to 0",
+			input: []datastore.Results{
+				{Species: "A", Confidence: 0.9},
+				{Species: "B", Confidence: 0.8},
+			},
+			maxCount:  0,
+			wantCount: 0,
+		},
+		{
+			name: "Exact match",
+			input: []datastore.Results{
+				{Species: "A", Confidence: 0.9},
+				{Species: "B", Confidence: 0.8},
+				{Species: "C", Confidence: 0.7},
+			},
+			maxCount:  3,
+			wantCount: 3,
+		},
+	}
+	
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := trimResultsToMax(tt.input, tt.maxCount)
+			
+			if len(result) != tt.wantCount {
+				t.Errorf("Expected %d results, got %d", tt.wantCount, len(result))
+			}
+			
+			// Verify it returns the first N elements
+			for i := 0; i < len(result); i++ {
+				if result[i].Species != tt.input[i].Species {
+					t.Errorf("Result %d mismatch: expected %s, got %s", 
+						i, tt.input[i].Species, result[i].Species)
+				}
+			}
+		})
+	}
+}
+
+// TestApplySigmoidToPredictions tests the sigmoid application
+func TestApplySigmoidToPredictions(t *testing.T) {
+	tests := []struct {
+		name        string
+		predictions []float32
+		sensitivity float64
+		validate    func(t *testing.T, results []float32)
+	}{
+		{
+			name:        "Zero predictions",
+			predictions: []float32{0, 0, 0},
+			sensitivity: 1.0,
+			validate: func(t *testing.T, results []float32) {
+				for i, r := range results {
+					if math.Abs(float64(r)-0.5) > 0.0001 {
+						t.Errorf("Index %d: expected 0.5, got %f", i, r)
+					}
+				}
+			},
+		},
+		{
+			name:        "Positive and negative",
+			predictions: []float32{-2, -1, 0, 1, 2},
+			sensitivity: 1.0,
+			validate: func(t *testing.T, results []float32) {
+				// Sigmoid should be symmetric around 0.5
+				if math.Abs(float64(results[0]+results[4])-1.0) > 0.0001 {
+					t.Errorf("Sigmoid not symmetric: %f + %f != 1.0", results[0], results[4])
+				}
+				if math.Abs(float64(results[1]+results[3])-1.0) > 0.0001 {
+					t.Errorf("Sigmoid not symmetric: %f + %f != 1.0", results[1], results[3])
+				}
+				if math.Abs(float64(results[2])-0.5) > 0.0001 {
+					t.Errorf("Sigmoid(0) should be 0.5, got %f", results[2])
+				}
+			},
+		},
+		{
+			name:        "Sensitivity effect",
+			predictions: []float32{1.0},
+			sensitivity: 2.0,
+			validate: func(t *testing.T, results []float32) {
+				// Higher sensitivity should give higher confidence
+				sigmoid1 := 1.0 / (1.0 + math.Exp(-1.0))
+				sigmoid2 := 1.0 / (1.0 + math.Exp(-2.0))
+				if results[0] <= float32(sigmoid1) {
+					t.Errorf("Higher sensitivity should increase confidence: %f <= %f", results[0], sigmoid1)
+				}
+				if math.Abs(float64(results[0])-sigmoid2) > 0.0001 {
+					t.Errorf("Expected %f, got %f", sigmoid2, results[0])
+				}
+			},
+		},
+		{
+			name:        "Empty input",
+			predictions: []float32{},
+			sensitivity: 1.0,
+			validate: func(t *testing.T, results []float32) {
+				if len(results) != 0 {
+					t.Errorf("Expected empty result, got %d elements", len(results))
+				}
+			},
+		},
+	}
+	
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			results := applySigmoidToPredictions(tt.predictions, tt.sensitivity)
+			
+			if len(results) != len(tt.predictions) {
+				t.Fatalf("Length mismatch: expected %d, got %d", len(tt.predictions), len(results))
+			}
+			
+			if tt.validate != nil {
+				tt.validate(t, results)
+			}
+		})
+	}
+}
+
+// Helper functions for testing
+func generateTestLabels(count int) []string {
+	labels := make([]string, count)
+	for i := 0; i < count; i++ {
+		labels[i] = fmt.Sprintf("Species_%06d", i+1)
+	}
+	return labels
+}
+
+func generateTestConfidence(count int) []float32 {
+	confidence := make([]float32, count)
+	for i := 0; i < count; i++ {
+		confidence[i] = float32(i%100) / 100.0
+	}
+	return confidence
+}


### PR DESCRIPTION
## Summary
- Optimizes the `pairLabelsAndConfidence` function to eliminate memory allocations during bird species predictions
- Addresses memory usage shown in pprof analysis where this function consumed 14.72MB (22% of heap)
- Implements buffer reuse pattern to achieve zero-allocation operation

## Changes
1. Added `resultsBuffer []datastore.Results` field to BirdNET struct
2. Created `pairLabelsAndConfidenceReuse` function that updates buffer in-place
3. Pre-allocate buffer during model validation
4. Updated `Predict` function to use the optimized version
5. Added comprehensive tests to ensure functional correctness
6. Added benchmarks to validate performance improvements

## Performance Impact
Based on benchmarks with 6,522 species (BirdNET v2.4 size):

**Memory Allocations:**
- Before: 262,150 bytes per prediction
- After: 0 bytes per prediction
- **100% reduction in allocations**

**Execution Speed:**
- Before: ~180,000 ns/op
- After: ~6,000 ns/op  
- **30x faster execution**

**Production Impact:**
- For a system processing 10 predictions/second per audio source
- Saves ~2.5MB/second of allocations
- Reduces GC pressure significantly
- Should eliminate ~14.72MB from heap usage

## Test Results
All tests pass, including:
- Correctness tests for various edge cases
- Buffer reuse tests
- Existing BirdNET tests remain passing

## Benchmark Results
```
BenchmarkPairLabelsAndConfidence-16             	  107370	    179721 ns/op	  262150 B/op	       1 allocs/op
BenchmarkPairLabelsAndConfidenceOptimized-16    	 1979150	      6061 ns/op	       0 B/op	       0 allocs/op
```

🤖 Generated with [Claude Code](https://claude.ai/code)