### PR TITLE
Fix sound level processor registration for RTSP streams

### DIFF
--- a/internal/myaudio/errors.go
+++ b/internal/myaudio/errors.go
@@ -1,0 +1,16 @@
+package myaudio
+
+import (
+	"github.com/tphakala/birdnet-go/internal/errors"
+)
+
+// Error sentinel values for common myaudio errors
+var (
+	// ErrSoundLevelProcessorNotRegistered is returned when attempting to process sound level data
+	// for a source that hasn't been registered
+	ErrSoundLevelProcessorNotRegistered = errors.Newf("no sound level processor registered").
+		Component("myaudio").
+		Category(errors.CategoryValidation).
+		Context("operation", "process_sound_level_data").
+		Build()
+)

--- a/internal/myaudio/ffmpeg_stream.go
+++ b/internal/myaudio/ffmpeg_stream.go
@@ -592,11 +592,20 @@ func (s *FFmpegStream) handleAudioData(data []byte) error {
 	// Process sound level if enabled
 	if conf.Setting().Realtime.Audio.SoundLevel.Enabled {
 		if soundLevel, err := ProcessSoundLevelData(s.url, data); err != nil {
-			streamLogger.Debug("failed to process sound level data",
-				"url", privacy.SanitizeRTSPUrl(s.url),
-				"error", err,
-				"operation", "process_sound_level")
-			log.Printf("⚠️ Error processing sound level for %s: %v", s.url, err)
+			// Log as warning if it's a registration issue, debug otherwise
+			if strings.Contains(err.Error(), "no sound level processor registered") {
+				streamLogger.Warn("sound level processor not registered",
+					"url", privacy.SanitizeRTSPUrl(s.url),
+					"error", err,
+					"operation", "process_sound_level")
+				log.Printf("⚠️ Sound level processor not registered for %s: %v", privacy.SanitizeRTSPUrl(s.url), err)
+			} else {
+				streamLogger.Debug("failed to process sound level data",
+					"url", privacy.SanitizeRTSPUrl(s.url),
+					"error", err,
+					"operation", "process_sound_level")
+				log.Printf("⚠️ Error processing sound level for %s: %v", privacy.SanitizeRTSPUrl(s.url), err)
+			}
 		} else if soundLevel != nil {
 			unifiedData.SoundLevel = soundLevel
 		}

--- a/internal/myaudio/ffmpeg_stream.go
+++ b/internal/myaudio/ffmpeg_stream.go
@@ -593,7 +593,7 @@ func (s *FFmpegStream) handleAudioData(data []byte) error {
 	if conf.Setting().Realtime.Audio.SoundLevel.Enabled {
 		if soundLevel, err := ProcessSoundLevelData(s.url, data); err != nil {
 			// Log as warning if it's a registration issue, debug otherwise
-			if strings.Contains(err.Error(), "no sound level processor registered") {
+			if errors.Is(err, ErrSoundLevelProcessorNotRegistered) {
 				streamLogger.Warn("sound level processor not registered",
 					"url", privacy.SanitizeRTSPUrl(s.url),
 					"error", err,

--- a/internal/myaudio/soundlevel.go
+++ b/internal/myaudio/soundlevel.go
@@ -561,6 +561,15 @@ func RegisterSoundLevelProcessor(source, name string) error {
 	}
 
 	soundLevelProcessors[source] = processor
+	
+	// Log registration if debug is enabled
+	if logger := getSoundLevelLogger(); logger != nil && conf.Setting().Realtime.Audio.SoundLevel.Debug {
+		logger.Debug("registered sound level processor",
+			"source", source,
+			"name", name,
+			"total_processors", len(soundLevelProcessors))
+	}
+	
 	return nil
 }
 
@@ -569,6 +578,15 @@ func UnregisterSoundLevelProcessor(source string) {
 	soundLevelProcessorMutex.Lock()
 	defer soundLevelProcessorMutex.Unlock()
 
+	// Log unregistration if debug is enabled and processor exists
+	if _, exists := soundLevelProcessors[source]; exists {
+		if logger := getSoundLevelLogger(); logger != nil && conf.Setting().Realtime.Audio.SoundLevel.Debug {
+			logger.Debug("unregistering sound level processor",
+				"source", source,
+				"remaining_processors", len(soundLevelProcessors)-1)
+		}
+	}
+	
 	delete(soundLevelProcessors, source)
 }
 

--- a/internal/myaudio/soundlevel.go
+++ b/internal/myaudio/soundlevel.go
@@ -597,10 +597,7 @@ func ProcessSoundLevelData(source string, audioData []byte) (*SoundLevelData, er
 	soundLevelProcessorMutex.RUnlock()
 
 	if !exists {
-		return nil, errors.Newf("no sound level processor registered for source: %s", source).
-			Component("myaudio").
-			Category(errors.CategoryValidation).
-			Context("operation", "process_sound_level_data").
+		return nil, errors.New(ErrSoundLevelProcessorNotRegistered).
 			Context("source", source).
 			Build()
 	}


### PR DESCRIPTION
## Summary
- Ensures sound level processors are properly registered for all RTSP streams
- Fixes missing sound level data for streams started via FFmpegManager
- Adds proper cleanup to prevent memory leaks

## Problem
The sound level calculation was not working for RTSP streams started directly through `FFmpegManager.StartStream()`. The processor registration only happened in the legacy `CaptureAudioRTSP()` function, causing streams started via the manager to miss sound level processing even when enabled.

## Solution
1. **Moved registration to FFmpegManager** - Sound level processors are now registered in `StartStream()` ensuring all streams get processing
2. **Added proper cleanup** - Processors are unregistered in `StopStream()` and `Shutdown()` 
3. **Improved error visibility** - Registration failures are logged as warnings instead of debug messages
4. **Added debug logging** - Registration/unregistration operations are logged when debug is enabled

## Changes
- Modified `FFmpegManager.StartStream()` to register sound level processors when enabled
- Modified `FFmpegManager.StopStream()` and `Shutdown()` to unregister processors
- Updated error logging in `ffmpeg_stream.go` to use warning level for registration issues
- Added debug logging in `soundlevel.go` for registration/unregistration operations

## Testing
- [x] Linter passes with 0 issues
- [x] Existing tests pass (pre-existing race conditions in tests are unrelated)
- [x] Manual testing confirms sound level data is now collected for RTSP streams

## Impact
This fix ensures consistent sound level processing for all RTSP streams regardless of how they're started, preventing missing data and potential memory leaks from orphaned processors.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved management of sound level processing to ensure consistent registration and unregistration during stream lifecycle and shutdown.

* **Enhancements**
  * Refined log messages for sound level processing errors with clearer warning and debug distinctions.
  * Added detailed debug logs for registering and unregistering sound level processors, enhancing visibility into processor lifecycle events.
  * Introduced a helper function to streamline sound level processor registration based on configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->