### PR TITLE
feat: add thread safety to diskMetrics global variable

### DIFF
--- a/internal/diskmanager/disk_usage_unix.go
+++ b/internal/diskmanager/disk_usage_unix.go
@@ -56,8 +56,8 @@ func GetDetailedDiskUsage(path string) (DiskSpaceInfo, error) {
 	startTime := time.Now()
 	defer func() {
 		// Always record disk check duration, even on error
-		if diskMetrics != nil {
-			diskMetrics.RecordDiskCheckDuration(time.Since(startTime).Seconds())
+		if m := getMetrics(); m != nil {
+			m.RecordDiskCheckDuration(time.Since(startTime).Seconds())
 		}
 	}()
 	

--- a/internal/diskmanager/disk_usage_windows.go
+++ b/internal/diskmanager/disk_usage_windows.go
@@ -69,8 +69,8 @@ func GetDetailedDiskUsage(path string) (DiskSpaceInfo, error) {
 	startTime := time.Now()
 	defer func() {
 		// Always record disk check duration, even on error
-		if diskMetrics != nil {
-			diskMetrics.RecordDiskCheckDuration(time.Since(startTime).Seconds())
+		if m := getMetrics(); m != nil {
+			m.RecordDiskCheckDuration(time.Since(startTime).Seconds())
 		}
 	}()
 	


### PR DESCRIPTION
This PR implements thread safety for the global `diskMetrics` variable in the diskmanager package to future-proof the code if the metrics implementation changes.

## Changes
- Add `sync.RWMutex` and `sync.Once` for thread-safe access
- Create `getMetrics()` helper function for safe access
- Update all 16 access points to use thread-safe pattern
- Document thread-safety guarantees in SetMetrics function

## Technical Details
- `sync.Once` ensures `SetMetrics()` is called only once to prevent race conditions
- `sync.RWMutex` provides efficient read/write protection for the global variable
- All existing nil checks are preserved for backward compatibility
- No breaking changes to the public API

Fixes #904

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved thread safety for disk usage metrics handling to prevent potential race conditions.
  * Updated internal logic for metrics access to use a safer retrieval method.

* **Chores**
  * Enhanced reliability of metrics recording during disk operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->