### PR TITLE
feat: add hot reload support for metrics/telemetry endpoint

### DIFF
--- a/internal/analysis/realtime.go
+++ b/internal/analysis/realtime.go
@@ -238,11 +238,11 @@ func RealtimeAnalysis(settings *conf.Settings, notificationChan chan handlers.No
 		startWeatherPolling(&wg, settings, dataStore, metrics, quitChan)
 	}
 
-	// start telemetry endpoint
-	startTelemetryEndpoint(&wg, settings, metrics, quitChan)
+	// Telemetry endpoint initialization is now handled by control monitor for hot reload support
+	// startTelemetryEndpoint(&wg, settings, metrics, quitChan)
 
 	// start control monitor for hot reloads
-	startControlMonitor(&wg, controlChan, quitChan, restartChan, notificationChan, bufferManager, proc, httpServer)
+	startControlMonitor(&wg, controlChan, quitChan, restartChan, notificationChan, bufferManager, proc, httpServer, metrics)
 
 	// start quit signal monitor
 	monitorCtrlC(quitChan)
@@ -784,9 +784,10 @@ func initBirdImageCache(ds datastore.Interface, metrics *observability.Metrics) 
 }
 
 // startControlMonitor handles various control signals for realtime analysis mode
-func startControlMonitor(wg *sync.WaitGroup, controlChan chan string, quitChan, restartChan chan struct{}, notificationChan chan handlers.Notification, bufferManager *BufferManager, proc *processor.Processor, httpServer *httpcontroller.Server) {
+func startControlMonitor(wg *sync.WaitGroup, controlChan chan string, quitChan, restartChan chan struct{}, notificationChan chan handlers.Notification, bufferManager *BufferManager, proc *processor.Processor, httpServer *httpcontroller.Server, metrics *observability.Metrics) {
 	ctrlMonitor := NewControlMonitor(wg, controlChan, quitChan, restartChan, notificationChan, bufferManager, proc, audioLevelChan, soundLevelChan)
 	ctrlMonitor.httpServer = httpServer
+	ctrlMonitor.metrics = metrics
 	ctrlMonitor.Start()
 }
 


### PR DESCRIPTION
## Summary
- Adds hot reload support for the metrics/telemetry endpoint
- Users can now enable/disable metrics and change the listen address without restarting the application
- Follows the established hot reload pattern used for other integrations (MQTT, BirdWeather, etc.)

## Changes
- **Control Monitor Enhancement**: Added telemetry endpoint lifecycle management with graceful shutdown
- **Settings Handler**: Added detection for telemetry setting changes and triggers reconfiguration
- **Initialization**: Moved telemetry startup from `realtime.go` to control monitor for better lifecycle management

## Test Plan
- [ ] Start BirdNET-Go with telemetry disabled
- [ ] Enable telemetry via web UI and verify endpoint starts
- [ ] Change listen address and verify endpoint restarts on new address
- [ ] Disable telemetry and verify endpoint stops gracefully
- [ ] Re-enable with different settings and verify proper initialization

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to dynamically reconfigure telemetry and metrics endpoints at runtime without restarting the application.
  * Telemetry settings changes in the user interface now trigger immediate updates to telemetry endpoints.

* **Improvements**
  * Enhanced thread safety and reliability when managing telemetry endpoints.
  * Improved feedback with notifications when telemetry is reconfigured or disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->