### PR TITLE
fix: resolve race condition in security logger access

### DIFF
--- a/internal/security/basic.go
+++ b/internal/security/basic.go
@@ -18,7 +18,7 @@ import (
 
 // IsInLocalSubnet checks if the given IP is in the same subnet as any local network interface
 func IsInLocalSubnet(clientIP net.IP) bool {
-	logger := securityLogger.With("ip", clientIP.String())
+	logger := logger().With("ip", clientIP.String())
 	if clientIP == nil {
 		logger.Debug("IsInLocalSubnet check failed: client IP is nil")
 		return false
@@ -83,7 +83,7 @@ func getIPv4Subnet(ip net.IP) net.IP {
 
 // configureLocalNetworkCookieStore configures the cookie store for local network access
 func (s *OAuth2Server) configureLocalNetworkCookieStore() {
-	securityLogger.Info("Configuring cookie store for local network access (allowing non-HTTPS cookies)")
+	logger().Info("Configuring cookie store for local network access (allowing non-HTTPS cookies)")
 	// Configure session options based on store type
 	switch store := gothic.Store.(type) {
 	case *sessions.CookieStore:
@@ -113,7 +113,7 @@ func (s *OAuth2Server) configureLocalNetworkCookieStore() {
 		}
 	default:
 		// Log the warning using structured logger
-		securityLogger.Warn("Unknown session store type, using default cookie store options", "store_type", fmt.Sprintf("%T", store))
+		logger().Warn("Unknown session store type, using default cookie store options", "store_type", fmt.Sprintf("%T", store))
 		// Create a default cookie store as fallback - only for reference, not actually used
 		// Use the configured session secret instead of a hardcoded value
 		sessionSecret := s.Settings.Security.SessionSecret
@@ -122,7 +122,7 @@ func (s *OAuth2Server) configureLocalNetworkCookieStore() {
 			// This is still not ideal but better than a hardcoded string
 			sessionSecret = fmt.Sprintf("birdnet-go-%d", time.Now().UnixNano())
 			// Log the warning using structured logger
-			securityLogger.Warn("No session secret configured, using temporary value")
+			logger().Warn("No session secret configured, using temporary value")
 		}
 
 		// Note: This store is not actually used, it's only created as a reference
@@ -136,7 +136,7 @@ func (s *OAuth2Server) configureLocalNetworkCookieStore() {
 func (s *OAuth2Server) HandleBasicAuthorize(c echo.Context) error {
 	clientID := c.QueryParam("client_id")
 	redirectURI := c.QueryParam("redirect_uri")
-	logger := securityLogger.With("client_id", clientID, "redirect_uri", redirectURI)
+	logger := logger().With("client_id", clientID, "redirect_uri", redirectURI)
 	logger.Info("Handling basic authorization request")
 
 	if clientID != s.Settings.Security.BasicAuth.ClientID {
@@ -169,7 +169,7 @@ func (s *OAuth2Server) HandleBasicAuthToken(c echo.Context) error {
 	// Verify client credentials from Authorization header
 	// Log the attempt, but DO NOT log the clientSecret
 	clientID, clientSecret, ok := c.Request().BasicAuth()
-	logger := securityLogger.With("client_id", clientID)
+	logger := logger().With("client_id", clientID)
 	logger.Info("Handling basic authorization token request")
 
 	if !ok {
@@ -259,7 +259,7 @@ func (s *OAuth2Server) HandleBasicAuthToken(c echo.Context) error {
 func (s *OAuth2Server) HandleBasicAuthCallback(c echo.Context) error {
 	code := c.QueryParam("code")
 	redirect := c.QueryParam("redirect")
-	logger := securityLogger.With("redirect", redirect)
+	logger := logger().With("redirect", redirect)
 	logger.Info("Handling basic authorization callback")
 
 	if code == "" {

--- a/internal/security/logging.go
+++ b/internal/security/logging.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"log/slog"
 	"path/filepath"
+	"sync"
 
 	"github.com/tphakala/birdnet-go/internal/logging"
 )
@@ -14,6 +15,7 @@ var (
 	securityLogger    *slog.Logger
 	securityLogCloser func() error         // Stores the closer function
 	securityLevelVar  = new(slog.LevelVar) // Dynamic level control
+	loggerMutex       sync.RWMutex         // Protects logger access
 )
 
 func init() {
@@ -24,37 +26,65 @@ func init() {
 	securityLevelVar.Set(initialLevel)
 
 	// Initialize the service-specific file logger, capturing the closer
-	securityLogger, securityLogCloser, err = logging.NewFileLogger(logFilePath, "security", securityLevelVar)
+	var newLogger *slog.Logger
+	newLogger, securityLogCloser, err = logging.NewFileLogger(logFilePath, "security", securityLevelVar)
 	if err != nil {
 		// Use standard log for this critical setup error
 		log.Printf("ERROR: Failed to initialize security file logger at %s: %v. Service logging disabled.", logFilePath, err)
 		// Fallback to a disabled logger to prevent nil panics
-		securityLogger = slog.New(slog.NewJSONHandler(io.Discard, &slog.HandlerOptions{Level: securityLevelVar}))
+		newLogger = slog.New(slog.NewJSONHandler(io.Discard, &slog.HandlerOptions{Level: securityLevelVar}))
 		securityLogCloser = func() error { return nil } // No-op closer for fallback
 	}
+	// Set the logger with proper locking
+	loggerMutex.Lock()
+	securityLogger = newLogger
+	loggerMutex.Unlock()
 }
 
 // LogInfo logs an informational message to the security log.
 func LogInfo(msg string, args ...any) {
-	securityLogger.Info(msg, args...)
+	logger().Info(msg, args...)
 }
 
 // LogWarn logs a warning message to the security log.
 func LogWarn(msg string, args ...any) {
-	securityLogger.Warn(msg, args...)
+	logger().Warn(msg, args...)
 }
 
 // LogError logs an error message to the security log.
 func LogError(msg string, args ...any) {
-	securityLogger.Error(msg, args...)
+	logger().Error(msg, args...)
 }
 
 // CloseLogger closes the security-specific file logger, if one was successfully initialized.
 // This should be called during graceful shutdown.
 func CloseLogger() error {
+	loggerMutex.Lock()
+	defer loggerMutex.Unlock()
 	if securityLogCloser != nil {
 		log.Println("Closing security file logger...")
 		return securityLogCloser()
 	}
 	return nil
+}
+
+// logger safely returns the current logger for internal use
+func logger() *slog.Logger {
+	loggerMutex.RLock()
+	defer loggerMutex.RUnlock()
+	return securityLogger
+}
+
+// setTestLogger sets a test-specific logger and returns a function to restore the original
+// This function should only be used in tests
+func setTestLogger(logger *slog.Logger) func() {
+	loggerMutex.Lock()
+	defer loggerMutex.Unlock()
+	original := securityLogger
+	securityLogger = logger
+	return func() {
+		loggerMutex.Lock()
+		defer loggerMutex.Unlock()
+		securityLogger = original
+	}
 }

--- a/internal/security/persistence_test.go
+++ b/internal/security/persistence_test.go
@@ -183,16 +183,17 @@ func TestConfigureLocalNetworkWithUnknownStore(t *testing.T) {
 
 	// Capture slog output
 	var logBuffer bytes.Buffer
-	// Store original logger and defer restoration
-	originalLogger := securityLogger // Assuming securityLogger is accessible; if not, need to use a setter or other mechanism
 	originalLevel := securityLevelVar.Level()
 
 	testHandler := slog.NewTextHandler(&logBuffer, &slog.HandlerOptions{Level: slog.LevelDebug})
-	securityLogger = slog.New(testHandler) // Temporarily replace package logger
+	testLogger := slog.New(testHandler)
+	
+	// Use the thread-safe setter to replace the logger
+	restore := setTestLogger(testLogger)
 	securityLevelVar.Set(slog.LevelDebug)  // Ensure debug logs are captured
 
 	defer func() {
-		securityLogger = originalLogger // Restore original logger
+		restore() // Restore original logger
 		securityLevelVar.Set(originalLevel)
 	}()
 
@@ -227,15 +228,17 @@ func TestConfigureLocalNetworkWithMissingSessionSecret(t *testing.T) {
 
 	// Capture slog output
 	var logBuffer bytes.Buffer
-	originalLogger := securityLogger
 	originalLevel := securityLevelVar.Level()
 
 	testHandler := slog.NewTextHandler(&logBuffer, &slog.HandlerOptions{Level: slog.LevelDebug})
-	securityLogger = slog.New(testHandler)
+	testLogger := slog.New(testHandler)
+	
+	// Use the thread-safe setter to replace the logger
+	restore := setTestLogger(testLogger)
 	securityLevelVar.Set(slog.LevelDebug)
 
 	defer func() {
-		securityLogger = originalLogger
+		restore()
 		securityLevelVar.Set(originalLevel)
 	}()
 


### PR DESCRIPTION
## Summary
- Fixes race condition in security package tests where global logger was accessed concurrently
- Implements thread-safe logger access using sync.RWMutex
- Updates tests to use safe logger replacement mechanism

## Test plan
- [x] Run `go test -race -v ./internal/security/...` multiple times to verify no race conditions
- [x] Run `golangci-lint run -v` to ensure code quality
- [x] All existing tests pass

Fixes #934

🤖 Generated with [Claude Code](https://claude.ai/code)