### PR TITLE
Fix race conditions in jobqueue package

### DIFF
--- a/internal/analysis/jobqueue/queue_test.go
+++ b/internal/analysis/jobqueue/queue_test.go
@@ -588,6 +588,11 @@ func TestRetryBackoff(t *testing.T) {
 	queue.ProcessImmediately(ctx)
 	time.Sleep(30 * time.Millisecond)
 
+	// Stop the queue to ensure all goroutines complete
+	if err := queue.Stop(); err != nil {
+		t.Errorf("Failed to stop queue: %v", err)
+	}
+
 	// Close the channel and collect execution times
 	close(executionTimes)
 	// Pre-allocate slice with expected capacity (initial execution + retries)


### PR DESCRIPTION
## Summary
- Fixed two race conditions in the jobqueue package identified in issue #931
- All tests now pass with the `-race` flag enabled

## Changes Made

### 1. Fixed race condition in `executeJob` function (queue.go)
- **Problem**: The `err` variable was being written to by both the execution goroutine and the main goroutine without synchronization
- **Solution**: Used a channel (`resultChan`) to safely communicate the error from the execution goroutine

### 2. Fixed race condition in `TestRetryBackoff` test
- **Problem**: The `executionTimes` channel was being closed while the mock action's goroutine might still be trying to send to it
- **Solution**: Added `queue.Stop()` call before closing the channel to ensure all goroutines complete

## Test Results
- All tests pass successfully with `go test -race -v ./internal/analysis/jobqueue/...`
- No race conditions detected
- Linter passes with no issues

Fixes #931

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error and panic handling to ensure more reliable job execution and reporting.
* **Tests**
  * Enhanced test reliability by ensuring the job queue is properly stopped after test completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->