### PR TITLE
fix: add t.Helper() calls to test helper functions

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -27,6 +27,7 @@ linters:
     #- ireturn
     - nilnil
     - nilerr
+    - thelper
     #- goconst
     - gocyclo
     # Performance linters

--- a/internal/analysis/sound_level_publish_test.go
+++ b/internal/analysis/sound_level_publish_test.go
@@ -46,6 +46,7 @@ func TestSoundLevelJSONMarshaling(t *testing.T) {
 			},
 			shouldError: false,
 			checkJSON: func(t *testing.T, jsonData []byte) {
+				t.Helper()
 				var data map[string]any
 				err := json.Unmarshal(jsonData, &data)
 				require.NoError(t, err)
@@ -146,6 +147,7 @@ func TestSoundLevelJSONMarshaling(t *testing.T) {
 			},
 			shouldError: false,
 			checkJSON: func(t *testing.T, jsonData []byte) {
+				t.Helper()
 				var data map[string]any
 				err := json.Unmarshal(jsonData, &data)
 				require.NoError(t, err)
@@ -172,6 +174,7 @@ func TestSoundLevelJSONMarshaling(t *testing.T) {
 			},
 			shouldError: false,
 			checkJSON: func(t *testing.T, jsonData []byte) {
+				t.Helper()
 				var data map[string]any
 				err := json.Unmarshal(jsonData, &data)
 				require.NoError(t, err)
@@ -1185,6 +1188,7 @@ func TestMQTTPublishIntervalValidation(t *testing.T) {
 
 // runMQTTIntervalTest executes a single MQTT interval test
 func runMQTTIntervalTest(t *testing.T, tt mqttIntervalTest) {
+	t.Helper()
 	// Create test infrastructure
 	testSoundLevelChan := make(chan myaudio.SoundLevelData, 100)
 	publishEvents := make(chan publishEvent, 20)
@@ -1227,6 +1231,7 @@ func createMockProcessorWithEvents(publishEvents chan publishEvent) *processor.P
 // startMQTTPublisher starts the MQTT publisher goroutine
 func startMQTTPublisher(t *testing.T, wg *sync.WaitGroup, stopChan chan struct{}, 
 	testSoundLevelChan chan myaudio.SoundLevelData, mockProc *processor.Processor) {
+	t.Helper()
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
@@ -1243,6 +1248,7 @@ func startMQTTPublisher(t *testing.T, wg *sync.WaitGroup, stopChan chan struct{}
 
 // publishSoundLevelData publishes sound level data via mock MQTT
 func publishSoundLevelData(t *testing.T, soundData myaudio.SoundLevelData, mockProc *processor.Processor) {
+	t.Helper()
 	ctx := context.Background()
 	topic := "test/soundlevel"
 	
@@ -1283,6 +1289,7 @@ func convertToCompactFormat(soundData myaudio.SoundLevelData) CompactSoundLevelD
 // startSoundLevelDataGenerator starts generating sound level data at intervals
 func startSoundLevelDataGenerator(t *testing.T, interval int, stopChan chan struct{}, 
 	testSoundLevelChan chan myaudio.SoundLevelData, testStartTime time.Time) {
+	t.Helper()
 	go func() {
 		intervalTicker := time.NewTicker(time.Duration(interval) * time.Second)
 		defer intervalTicker.Stop()
@@ -1331,6 +1338,7 @@ func createTestSoundLevelData(interval int) myaudio.SoundLevelData {
 // collectPublishEvents collects publish events for the test duration
 func collectPublishEvents(t *testing.T, publishEvents chan publishEvent, 
 	testDuration time.Duration, testStartTime time.Time) []publishEvent {
+	t.Helper()
 	var events []publishEvent
 	testTimer := time.NewTimer(testDuration)
 	defer testTimer.Stop()
@@ -1357,6 +1365,7 @@ func collectPublishEvents(t *testing.T, publishEvents chan publishEvent,
 
 // verifyPublishResults verifies the publish events meet expectations
 func verifyPublishResults(t *testing.T, events []publishEvent, tt mqttIntervalTest, testStartTime time.Time) {
+	t.Helper()
 	// Verify publish count
 	assert.Equal(t, tt.expectedPublishes, len(events),
 		"Expected %d MQTT publishes but got %d", tt.expectedPublishes, len(events))
@@ -1370,6 +1379,7 @@ func verifyPublishResults(t *testing.T, events []publishEvent, tt mqttIntervalTe
 
 // verifyPublishTiming verifies a publish happened at the expected time
 func verifyPublishTiming(t *testing.T, event publishEvent, index, interval int, testStartTime time.Time) {
+	t.Helper()
 	expectedTime := testStartTime.Add(time.Duration((index+1)*interval) * time.Second)
 	actualDelay := event.timestamp.Sub(expectedTime)
 	
@@ -1382,6 +1392,7 @@ func verifyPublishTiming(t *testing.T, event publishEvent, index, interval int, 
 
 // verifyPublishPayload verifies the payload structure and content
 func verifyPublishPayload(t *testing.T, event publishEvent, index, interval int) {
+	t.Helper()
 	var compactData CompactSoundLevelData
 	err := json.Unmarshal([]byte(event.payload), &compactData)
 	require.NoError(t, err, "Failed to unmarshal payload %d", index+1)

--- a/internal/api/v2/detections_test.go
+++ b/internal/api/v2/detections_test.go
@@ -24,6 +24,7 @@ import (
 // decodePaginated is a helper to unmarshal a response body into a PaginatedResponse
 // and extract the data as a map slice for easier testing.
 func decodePaginated(t *testing.T, body []byte) ([]map[string]interface{}, PaginatedResponse) {
+	t.Helper()
 	var response PaginatedResponse
 	err := json.Unmarshal(body, &response)
 	assert.NoError(t, err, "Failed to unmarshal response body")
@@ -121,6 +122,7 @@ func TestGetDetections(t *testing.T) {
 			expectedStatus: http.StatusOK,
 			expectedCount:  2,
 			checkResponse: func(t *testing.T, testName string, rec *httptest.ResponseRecorder) {
+				t.Helper()
 				detections, _ := decodePaginated(t, rec.Body.Bytes())
 				assert.Equal(t, 2, len(detections))
 			},
@@ -142,6 +144,7 @@ func TestGetDetections(t *testing.T) {
 			expectedStatus: http.StatusOK,
 			expectedCount:  1,
 			checkResponse: func(t *testing.T, testName string, rec *httptest.ResponseRecorder) {
+				t.Helper()
 				detections, _ := decodePaginated(t, rec.Body.Bytes())
 				assert.Equal(t, 1, len(detections))
 			},
@@ -162,6 +165,7 @@ func TestGetDetections(t *testing.T) {
 			expectedStatus: http.StatusOK,
 			expectedCount:  1,
 			checkResponse: func(t *testing.T, testName string, rec *httptest.ResponseRecorder) {
+				t.Helper()
 				detections, _ := decodePaginated(t, rec.Body.Bytes())
 				assert.Equal(t, 1, len(detections))
 			},
@@ -181,6 +185,7 @@ func TestGetDetections(t *testing.T) {
 			expectedStatus: http.StatusOK,
 			expectedCount:  1,
 			checkResponse: func(t *testing.T, testName string, rec *httptest.ResponseRecorder) {
+				t.Helper()
 				detections, _ := decodePaginated(t, rec.Body.Bytes())
 				assert.Equal(t, 1, len(detections))
 			},
@@ -196,6 +201,7 @@ func TestGetDetections(t *testing.T) {
 			expectedStatus: http.StatusBadRequest, // Expecting 400 Bad Request
 			expectedCount:  0,                     // Not relevant for error case
 			checkResponse: func(t *testing.T, testName string, rec *httptest.ResponseRecorder) {
+				t.Helper()
 				// Check recorder status and body for the error
 				assert.Equal(t, http.StatusBadRequest, rec.Code, "Expected status code 400")
 
@@ -214,6 +220,7 @@ func TestGetDetections(t *testing.T) {
 			mockSetup:      func(m *mock.Mock) { /* No DB interaction expected */ },
 			expectedCount:  0, // Not relevant for error case
 			checkResponse: func(t *testing.T, testName string, rec *httptest.ResponseRecorder) {
+				t.Helper()
 				// Check recorder status and body for the error
 				assert.Equal(t, http.StatusBadRequest, rec.Code, "Expected status code 400")
 
@@ -238,6 +245,7 @@ func TestGetDetections(t *testing.T) {
 			expectedStatus: http.StatusOK, // Now expecting 200 OK
 			expectedCount:  0,
 			checkResponse: func(t *testing.T, testName string, rec *httptest.ResponseRecorder) {
+				t.Helper()
 				// Verify response is successful
 				var response PaginatedResponse
 				err := json.Unmarshal(rec.Body.Bytes(), &response)
@@ -255,6 +263,7 @@ func TestGetDetections(t *testing.T) {
 				// No DB interaction expected for bad request
 			},
 			checkResponse: func(t *testing.T, testName string, rec *httptest.ResponseRecorder) {
+				t.Helper()
 				// Check recorder status and body for the error
 				assert.Equal(t, http.StatusBadRequest, rec.Code, "Expected status code 400")
 
@@ -350,6 +359,7 @@ func TestGetDetection(t *testing.T) {
 			},
 			expectedStatus: http.StatusOK,
 			checkResponse: func(t *testing.T, rec *httptest.ResponseRecorder) {
+				t.Helper()
 				var response DetectionResponse
 				err := json.Unmarshal(rec.Body.Bytes(), &response)
 				assert.NoError(t, err)
@@ -371,6 +381,7 @@ func TestGetDetection(t *testing.T) {
 			},
 			expectedStatus: http.StatusNotFound,
 			checkResponse: func(t *testing.T, rec *httptest.ResponseRecorder) {
+				t.Helper()
 				var response map[string]string
 				err := json.Unmarshal(rec.Body.Bytes(), &response)
 				assert.NoError(t, err)
@@ -1119,6 +1130,7 @@ func TestGetNoteCommentsWithHandler(t *testing.T) {
 			expectedStatus: http.StatusOK,
 			expectedCount:  2,
 			checkResponse: func(t *testing.T, rec *httptest.ResponseRecorder) {
+				t.Helper()
 				var comments []datastore.NoteComment
 				err := json.Unmarshal(rec.Body.Bytes(), &comments)
 				assert.NoError(t, err)
@@ -1136,6 +1148,7 @@ func TestGetNoteCommentsWithHandler(t *testing.T) {
 			expectedStatus: http.StatusOK,
 			expectedCount:  0,
 			checkResponse: func(t *testing.T, rec *httptest.ResponseRecorder) {
+				t.Helper()
 				var comments []datastore.NoteComment
 				err := json.Unmarshal(rec.Body.Bytes(), &comments)
 				assert.NoError(t, err)
@@ -1151,6 +1164,7 @@ func TestGetNoteCommentsWithHandler(t *testing.T) {
 			expectedStatus: http.StatusNotFound,
 			expectedCount:  0,
 			checkResponse: func(t *testing.T, rec *httptest.ResponseRecorder) {
+				t.Helper()
 				var response map[string]string
 				err := json.Unmarshal(rec.Body.Bytes(), &response)
 				assert.NoError(t, err)

--- a/internal/api/v2/integrations_test.go
+++ b/internal/api/v2/integrations_test.go
@@ -131,6 +131,7 @@ func TestGetMQTTStatus(t *testing.T) {
 			mqttTopic:      "birdnet/detections",
 			expectedStatus: http.StatusOK,
 			validateResult: func(t *testing.T, result map[string]interface{}) {
+				t.Helper()
 				assert.False(t, result["connected"].(bool), "Connected should be false when MQTT is disabled")
 				assert.Equal(t, "tcp://mqtt.example.com:1883", result["broker"], "Broker should match configuration")
 				assert.Equal(t, "birdnet/detections", result["topic"], "Topic should match configuration")
@@ -145,6 +146,7 @@ func TestGetMQTTStatus(t *testing.T) {
 			mqttTopic:      "birdnet/detections",
 			expectedStatus: http.StatusOK,
 			validateResult: func(t *testing.T, result map[string]interface{}) {
+				t.Helper()
 				assert.False(t, result["connected"].(bool), "Connected should be false when MQTT connection fails")
 				assert.Contains(t, result["last_error"], "error:connection:mqtt_broker", "Error should mention connection failure")
 			},
@@ -205,6 +207,7 @@ func TestGetBirdWeatherStatus(t *testing.T) {
 			bwLocationAcc:  50.0,
 			expectedStatus: http.StatusOK,
 			validateResult: func(t *testing.T, result map[string]interface{}) {
+				t.Helper()
 				assert.False(t, result["enabled"].(bool), "Enabled should be false")
 				assert.Equal(t, "", result["station_id"], "Station ID should be empty")
 				assert.Equal(t, 0.7, result["threshold"], "Threshold should match configuration")
@@ -219,6 +222,7 @@ func TestGetBirdWeatherStatus(t *testing.T) {
 			bwLocationAcc:  100.0,
 			expectedStatus: http.StatusOK,
 			validateResult: func(t *testing.T, result map[string]interface{}) {
+				t.Helper()
 				assert.True(t, result["enabled"].(bool), "Enabled should be true")
 				assert.Equal(t, "ABC123", result["station_id"], "Station ID should match configuration")
 				assert.Equal(t, 0.8, result["threshold"], "Threshold should match configuration")

--- a/internal/api/v2/media_test.go
+++ b/internal/api/v2/media_test.go
@@ -478,6 +478,7 @@ func TestRangeHeaderHandling(t *testing.T) {
 			rangeHeader:    "",
 			expectedStatus: http.StatusOK,
 			validateFunc: func(t *testing.T, rec *httptest.ResponseRecorder) {
+				t.Helper()
 				assert.Equal(t, fileContent, rec.Body.Bytes())
 			},
 		},
@@ -486,6 +487,7 @@ func TestRangeHeaderHandling(t *testing.T) {
 			rangeHeader:    "bytes=0-99",
 			expectedStatus: http.StatusPartialContent,
 			validateFunc: func(t *testing.T, rec *httptest.ResponseRecorder) {
+				t.Helper()
 				assert.Equal(t, fileContent[0:100], rec.Body.Bytes())
 				assert.Equal(t, "bytes 0-99/1024", rec.Header().Get("Content-Range"))
 			},
@@ -495,6 +497,7 @@ func TestRangeHeaderHandling(t *testing.T) {
 			rangeHeader:    "bytes=100-199",
 			expectedStatus: http.StatusPartialContent,
 			validateFunc: func(t *testing.T, rec *httptest.ResponseRecorder) {
+				t.Helper()
 				assert.Equal(t, fileContent[100:200], rec.Body.Bytes())
 				assert.Equal(t, "bytes 100-199/1024", rec.Header().Get("Content-Range"))
 			},
@@ -504,6 +507,7 @@ func TestRangeHeaderHandling(t *testing.T) {
 			rangeHeader:    "bytes=-100",
 			expectedStatus: http.StatusPartialContent,
 			validateFunc: func(t *testing.T, rec *httptest.ResponseRecorder) {
+				t.Helper()
 				assert.Equal(t, fileContent[924:1024], rec.Body.Bytes())
 				assert.Equal(t, "bytes 924-1023/1024", rec.Header().Get("Content-Range"))
 			},
@@ -513,6 +517,7 @@ func TestRangeHeaderHandling(t *testing.T) {
 			rangeHeader:    "bytes=924-",
 			expectedStatus: http.StatusPartialContent,
 			validateFunc: func(t *testing.T, rec *httptest.ResponseRecorder) {
+				t.Helper()
 				assert.Equal(t, fileContent[924:1024], rec.Body.Bytes())
 				assert.Equal(t, "bytes 924-1023/1024", rec.Header().Get("Content-Range"))
 			},
@@ -522,6 +527,7 @@ func TestRangeHeaderHandling(t *testing.T) {
 			rangeHeader:    "bytes=invalid",
 			expectedStatus: http.StatusRequestedRangeNotSatisfiable,
 			validateFunc: func(t *testing.T, rec *httptest.ResponseRecorder) {
+				t.Helper()
 				assert.Len(t, rec.Body.Bytes(), 0, "416 responses should not include the file body")
 			},
 		},
@@ -530,6 +536,7 @@ func TestRangeHeaderHandling(t *testing.T) {
 			rangeHeader:    "bytes=2000-",
 			expectedStatus: http.StatusRequestedRangeNotSatisfiable,
 			validateFunc: func(t *testing.T, rec *httptest.ResponseRecorder) {
+				t.Helper()
 				// No body validation needed
 			},
 		},

--- a/internal/api/v2/test_utils.go
+++ b/internal/api/v2/test_utils.go
@@ -327,6 +327,7 @@ func (m *TestImageProvider) Fetch(scientificName string) (imageprovider.BirdImag
 
 // NewTestMetrics creates a new metrics instance for testing
 func NewTestMetrics(t *testing.T) *observability.Metrics {
+	t.Helper()
 	metrics, err := observability.NewMetrics()
 	if err != nil {
 		t.Fatalf("Failed to create test metrics: %v", err)
@@ -337,6 +338,7 @@ func NewTestMetrics(t *testing.T) *observability.Metrics {
 // setupAnalyticsTestEnvironment creates a test environment with Echo, MockDataStore, and Controller
 // for analytics tests
 func setupAnalyticsTestEnvironment(t *testing.T) (*echo.Echo, *MockDataStore, *Controller) {
+	t.Helper()
 	// Create a new Echo instance
 	e := echo.New()
 

--- a/internal/api/v2/weather_test.go
+++ b/internal/api/v2/weather_test.go
@@ -67,6 +67,7 @@ func TestGetDailyWeather(t *testing.T) {
 // setupWeatherTestEnvironment creates a test environment with Echo, MockDataStore, and Controller
 // specifically configured for weather API tests
 func setupWeatherTestEnvironment(t *testing.T) (*echo.Echo, *MockDataStore, *Controller) {
+	t.Helper()
 	// Create a new Echo instance
 	e := echo.New()
 

--- a/internal/birdnet/analyze_test.go
+++ b/internal/birdnet/analyze_test.go
@@ -26,6 +26,7 @@ func TestPairLabelsAndConfidence(t *testing.T) {
 			confidence: []float32{0.9, 0.7, 0.5},
 			wantErr:    false,
 			validate: func(t *testing.T, results []datastore.Results) {
+				t.Helper()
 				if len(results) != 3 {
 					t.Errorf("Expected 3 results, got %d", len(results))
 				}
@@ -67,6 +68,7 @@ func TestPairLabelsAndConfidence(t *testing.T) {
 			confidence: []float32{},
 			wantErr:    false,
 			validate: func(t *testing.T, results []datastore.Results) {
+				t.Helper()
 				if len(results) != 0 {
 					t.Errorf("Expected 0 results, got %d", len(results))
 				}
@@ -78,6 +80,7 @@ func TestPairLabelsAndConfidence(t *testing.T) {
 			confidence: []float32{0.95},
 			wantErr:    false,
 			validate: func(t *testing.T, results []datastore.Results) {
+				t.Helper()
 				if len(results) != 1 {
 					t.Errorf("Expected 1 result, got %d", len(results))
 				}
@@ -95,6 +98,7 @@ func TestPairLabelsAndConfidence(t *testing.T) {
 			confidence: generateTestConfidence(6522),
 			wantErr:    false,
 			validate: func(t *testing.T, results []datastore.Results) {
+				t.Helper()
 				if len(results) != 6522 {
 					t.Errorf("Expected 6522 results, got %d", len(results))
 				}
@@ -113,6 +117,7 @@ func TestPairLabelsAndConfidence(t *testing.T) {
 			confidence: []float32{0.0, 1.0, 0.5, 0.999},
 			wantErr:    false,
 			validate: func(t *testing.T, results []datastore.Results) {
+				t.Helper()
 				if results[0].Confidence != 0.0 {
 					t.Errorf("Expected confidence 0.0, got %f", results[0].Confidence)
 				}
@@ -167,6 +172,7 @@ func TestPairLabelsAndConfidenceReuseBuffer(t *testing.T) {
 			bufferSize: 3,
 			wantErr:    false,
 			validate: func(t *testing.T, buffer []datastore.Results, results []datastore.Results) {
+				t.Helper()
 				// Results should point to the same buffer
 				if &results[0] != &buffer[0] {
 					t.Error("Results should reference the same buffer")
@@ -221,6 +227,7 @@ func TestPairLabelsAndConfidenceReuseBuffer(t *testing.T) {
 			bufferSize: 0,
 			wantErr:    false,
 			validate: func(t *testing.T, buffer []datastore.Results, results []datastore.Results) {
+				t.Helper()
 				if len(results) != 0 {
 					t.Errorf("Expected 0 results, got %d", len(results))
 				}
@@ -233,6 +240,7 @@ func TestPairLabelsAndConfidenceReuseBuffer(t *testing.T) {
 			bufferSize: 3,
 			wantErr:    false,
 			validate: func(t *testing.T, buffer []datastore.Results, results []datastore.Results) {
+				t.Helper()
 				// First use
 				if results[0].Species != "Robin" || results[0].Confidence != 0.9 {
 					t.Errorf("First use failed")
@@ -529,6 +537,7 @@ func TestApplySigmoidToPredictions(t *testing.T) {
 			predictions: []float32{0, 0, 0},
 			sensitivity: 1.0,
 			validate: func(t *testing.T, results []float32) {
+				t.Helper()
 				for i, r := range results {
 					if math.Abs(float64(r)-0.5) > 0.0001 {
 						t.Errorf("Index %d: expected 0.5, got %f", i, r)
@@ -541,6 +550,7 @@ func TestApplySigmoidToPredictions(t *testing.T) {
 			predictions: []float32{-2, -1, 0, 1, 2},
 			sensitivity: 1.0,
 			validate: func(t *testing.T, results []float32) {
+				t.Helper()
 				// Sigmoid should be symmetric around 0.5
 				if math.Abs(float64(results[0]+results[4])-1.0) > 0.0001 {
 					t.Errorf("Sigmoid not symmetric: %f + %f != 1.0", results[0], results[4])
@@ -558,6 +568,7 @@ func TestApplySigmoidToPredictions(t *testing.T) {
 			predictions: []float32{1.0},
 			sensitivity: 2.0,
 			validate: func(t *testing.T, results []float32) {
+				t.Helper()
 				// Higher sensitivity should give higher confidence
 				sigmoid1 := 1.0 / (1.0 + math.Exp(-1.0))
 				sigmoid2 := 1.0 / (1.0 + math.Exp(-2.0))
@@ -574,6 +585,7 @@ func TestApplySigmoidToPredictions(t *testing.T) {
 			predictions: []float32{},
 			sensitivity: 1.0,
 			validate: func(t *testing.T, results []float32) {
+				t.Helper()
 				if len(results) != 0 {
 					t.Errorf("Expected empty result, got %d elements", len(results))
 				}
@@ -632,6 +644,7 @@ func TestApplySigmoidToPredictionsReuse(t *testing.T) {
 			sensitivity: 1.0,
 			bufferSize:  5,
 			validate: func(t *testing.T, original []float32, reuse []float32, buffer []float32) {
+				t.Helper()
 				if len(original) != len(reuse) {
 					t.Errorf("Length mismatch: %d vs %d", len(original), len(reuse))
 				}
@@ -653,6 +666,7 @@ func TestApplySigmoidToPredictionsReuse(t *testing.T) {
 			sensitivity: 1.0,
 			bufferSize:  2, // Smaller than predictions
 			validate: func(t *testing.T, original []float32, reuse []float32, buffer []float32) {
+				t.Helper()
 				if len(original) != len(reuse) {
 					t.Errorf("Length mismatch: %d vs %d", len(original), len(reuse))
 				}
@@ -674,6 +688,7 @@ func TestApplySigmoidToPredictionsReuse(t *testing.T) {
 			sensitivity: 1.0,
 			bufferSize:  0,
 			validate: func(t *testing.T, original []float32, reuse []float32, buffer []float32) {
+				t.Helper()
 				if len(original) != 0 || len(reuse) != 0 {
 					t.Error("Empty inputs should produce empty outputs")
 				}
@@ -685,6 +700,7 @@ func TestApplySigmoidToPredictionsReuse(t *testing.T) {
 			sensitivity: 2.0,
 			bufferSize:  5, // Larger than predictions
 			validate: func(t *testing.T, original []float32, reuse []float32, buffer []float32) {
+				t.Helper()
 				// Should fallback due to size mismatch
 				for i := range original {
 					if math.Abs(float64(original[i]-reuse[i])) > 0.0001 {
@@ -734,6 +750,7 @@ func TestGetTopKResults(t *testing.T) {
 			},
 			k: 3,
 			validate: func(t *testing.T, results []datastore.Results, k int) {
+				t.Helper()
 				if len(results) != k {
 					t.Errorf("Expected %d results, got %d", k, len(results))
 				}
@@ -762,6 +779,7 @@ func TestGetTopKResults(t *testing.T) {
 			},
 			k: 3,
 			validate: func(t *testing.T, results []datastore.Results, k int) {
+				t.Helper()
 				if len(results) != 3 {
 					t.Errorf("Expected 3 results, got %d", len(results))
 				}
@@ -779,6 +797,7 @@ func TestGetTopKResults(t *testing.T) {
 			},
 			k: 5,
 			validate: func(t *testing.T, results []datastore.Results, k int) {
+				t.Helper()
 				if len(results) != 2 {
 					t.Errorf("Expected 2 results (input length), got %d", len(results))
 				}
@@ -793,6 +812,7 @@ func TestGetTopKResults(t *testing.T) {
 			input: []datastore.Results{},
 			k:     5,
 			validate: func(t *testing.T, results []datastore.Results, k int) {
+				t.Helper()
 				if len(results) != 0 {
 					t.Errorf("Expected 0 results for empty input, got %d", len(results))
 				}
@@ -805,6 +825,7 @@ func TestGetTopKResults(t *testing.T) {
 			},
 			k: 0,
 			validate: func(t *testing.T, results []datastore.Results, k int) {
+				t.Helper()
 				if len(results) != 0 {
 					t.Errorf("Expected 0 results for k=0, got %d", len(results))
 				}
@@ -817,6 +838,7 @@ func TestGetTopKResults(t *testing.T) {
 			},
 			k: -1,
 			validate: func(t *testing.T, results []datastore.Results, k int) {
+				t.Helper()
 				if len(results) != 0 {
 					t.Errorf("Expected 0 results for negative k, got %d", len(results))
 				}
@@ -827,6 +849,7 @@ func TestGetTopKResults(t *testing.T) {
 			input: generateLargeTestResults(6522),
 			k: 10,
 			validate: func(t *testing.T, results []datastore.Results, k int) {
+				t.Helper()
 				if len(results) != 10 {
 					t.Errorf("Expected 10 results, got %d", len(results))
 				}

--- a/internal/conf/tls_test.go
+++ b/internal/conf/tls_test.go
@@ -18,6 +18,7 @@ import (
 
 // Helper function to generate a test certificate
 func generateTestCertificate(t *testing.T) (caCert, clientCert, clientKey string) {
+	t.Helper()
 	// Generate RSA private key
 	priv, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
@@ -382,6 +383,7 @@ func TestGetTLSManager(t *testing.T) {
 
 // Helper function to generate an EC private key
 func generateECKey(t *testing.T) string {
+	t.Helper()
 	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
 		t.Fatalf("Failed to generate EC key: %v", err)
@@ -397,6 +399,7 @@ func generateECKey(t *testing.T) string {
 
 // Helper function to generate a PKCS8 private key
 func generatePKCS8Key(t *testing.T) string {
+	t.Helper()
 	priv, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
 		t.Fatalf("Failed to generate RSA key: %v", err)

--- a/internal/datastore/interfaces_test.go
+++ b/internal/datastore/interfaces_test.go
@@ -9,6 +9,7 @@ import (
 // createDatabase initializes a temporary database for testing purposes.
 // It ensures the database connection is opened and handles potential errors.
 func createDatabase(t *testing.T, settings *conf.Settings) Interface {
+	t.Helper()
 	tempDir := t.TempDir()
 	settings.Output.SQLite.Enabled = true
 	settings.Output.SQLite.Path = tempDir + "/test.db"

--- a/internal/diskmanager/policy_usage_test.go
+++ b/internal/diskmanager/policy_usage_test.go
@@ -311,6 +311,7 @@ type UsageBasedTestHelper struct {
 
 // Execute runs the test with the given configuration
 func (h *UsageBasedTestHelper) Execute(t *testing.T) {
+	t.Helper()
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 

--- a/internal/monitor/system_monitor_test.go
+++ b/internal/monitor/system_monitor_test.go
@@ -23,6 +23,7 @@ func TestDiskMonitoring(t *testing.T) {
 			name:  "multiple paths",
 			paths: []string{"/", "/tmp"},
 			checkFunc: func(t *testing.T, monitor *SystemMonitor) {
+				t.Helper()
 				// Verify that validated paths include both configured paths
 				monitor.mu.RLock()
 				_, rootValidated := monitor.validatedPaths["/"]
@@ -46,6 +47,7 @@ func TestDiskMonitoring(t *testing.T) {
 			name:  "empty paths defaults to root",
 			paths: []string{},
 			checkFunc: func(t *testing.T, monitor *SystemMonitor) {
+				t.Helper()
 				// Verify that root path is validated
 				monitor.mu.RLock()
 				validated, exists := monitor.validatedPaths["/"]
@@ -58,6 +60,7 @@ func TestDiskMonitoring(t *testing.T) {
 			name:  "invalid path handling",
 			paths: []string{"/", "/this/path/does/not/exist"},
 			checkFunc: func(t *testing.T, monitor *SystemMonitor) {
+				t.Helper()
 				// Verify that valid path is marked as validated
 				monitor.mu.RLock()
 				rootValidated, rootExists := monitor.validatedPaths["/"]

--- a/internal/mqtt/client_test.go
+++ b/internal/mqtt/client_test.go
@@ -82,6 +82,7 @@ func isTestBrokerAvailable() bool {
 
 // Add debug logging helper
 func debugLog(t *testing.T, format string, args ...interface{}) {
+	t.Helper()
 	msg := fmt.Sprintf(format, args...)
 	log.Printf("[DEBUG] %s", msg)
 	t.Logf("[DEBUG] %s", msg)
@@ -468,6 +469,7 @@ func testMetricsCollection(t *testing.T) {
 
 // Add this helper function to get Histogram values
 func getHistogramValue(t *testing.T, histogram prometheus.Histogram) float64 {
+	t.Helper()
 	var metric dto.Metric
 	err := histogram.Write(&metric)
 	if err != nil {
@@ -478,6 +480,7 @@ func getHistogramValue(t *testing.T, histogram prometheus.Histogram) float64 {
 
 // Helper function to get the value of a Gauge metric
 func getGaugeValue(t *testing.T, gauge prometheus.Gauge) float64 {
+	t.Helper()
 	var metric dto.Metric
 	err := gauge.Write(&metric)
 	if err != nil {
@@ -488,6 +491,7 @@ func getGaugeValue(t *testing.T, gauge prometheus.Gauge) float64 {
 
 // Helper function to get the value of a Counter metric
 func getCounterValue(t *testing.T, counter prometheus.Counter) float64 {
+	t.Helper()
 	var metric dto.Metric
 	err := counter.Write(&metric)
 	if err != nil {
@@ -497,6 +501,7 @@ func getCounterValue(t *testing.T, counter prometheus.Counter) float64 {
 }
 
 func getCounterVecValue(t *testing.T, counterVec *prometheus.CounterVec) float64 {
+	t.Helper()
 	// Get all metric families
 	metricFamilies, err := prometheus.DefaultGatherer.Gather()
 	if err != nil {
@@ -713,11 +718,9 @@ func sanitizeClientID(id string) string {
 
 // createTestClient is a helper function that creates and configures an MQTT client for testing purposes.
 func createTestClient(t *testing.T, broker string) (Client, *observability.Metrics) {
+	t.Helper()
 	// Use test name as client ID to ensure uniqueness when running tests in parallel
-	clientID := "TestNode"
-	if t != nil {
-		clientID = sanitizeClientID(t.Name())
-	}
+	clientID := sanitizeClientID(t.Name())
 	
 	testSettings := &conf.Settings{
 		Main: struct {

--- a/internal/mqtt/client_tls_test.go
+++ b/internal/mqtt/client_tls_test.go
@@ -30,6 +30,7 @@ const (
 
 // skipIfNoTLSBroker skips the test if TLS brokers are not available
 func skipIfNoTLSBroker(t *testing.T) {
+	t.Helper()
 	if os.Getenv("SKIP_TLS_TESTS") == "true" {
 		t.Skip("Skipping TLS tests (SKIP_TLS_TESTS=true)")
 	}
@@ -502,6 +503,7 @@ func TestTLSConfigValidation(t *testing.T) {
 
 // skipIfNoTLSBrokerBench skips benchmarks if TLS brokers are not available
 func skipIfNoTLSBrokerBench(b *testing.B) {
+	b.Helper()
 	if os.Getenv("SKIP_TLS_TESTS") == "true" {
 		b.Skip("Skipping TLS tests (SKIP_TLS_TESTS=true)")
 	}

--- a/internal/notification/worker_test.go
+++ b/internal/notification/worker_test.go
@@ -222,6 +222,7 @@ func TestNotificationWorker_CircuitBreaker(t *testing.T) {
 	if stats.CircuitState == "open" {
 		// Create a test helper to wait for circuit recovery
 		waitForCircuitRecovery := func(t *testing.T, cb *CircuitBreaker, timeout time.Duration) bool {
+			t.Helper()
 			deadline := time.Now().Add(timeout)
 			ticker := time.NewTicker(10 * time.Millisecond)
 			defer ticker.Stop()

--- a/internal/security/oauth_test.go
+++ b/internal/security/oauth_test.go
@@ -122,6 +122,7 @@ func TestOAuth2Server(t *testing.T) {
 		{
 			name: "generate and validate auth code",
 			test: func(t *testing.T, s *OAuth2Server) {
+				t.Helper()
 				// Initialize settings
 				s.Settings = &conf.Settings{
 					Security: conf.Security{
@@ -157,6 +158,7 @@ func TestOAuth2Server(t *testing.T) {
 		{
 			name: "subnet bypass validation",
 			test: func(t *testing.T, s *OAuth2Server) {
+				t.Helper()
 				s.Settings.Security.AllowSubnetBypass = conf.AllowSubnetBypass{
 					Enabled: true,
 					Subnet:  "192.168.1.0/24",

--- a/internal/telemetry/channel_benchmark_test.go
+++ b/internal/telemetry/channel_benchmark_test.go
@@ -125,6 +125,7 @@ func BenchmarkChannelOperations(b *testing.B) {
 }
 
 func benchmarkBufferedChannel(b *testing.B, bufferSize int) {
+	b.Helper()
 	ch := make(chan ErrorEvent, bufferSize)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/internal/telemetry/worker_test.go
+++ b/internal/telemetry/worker_test.go
@@ -163,6 +163,7 @@ func TestTelemetryWorker_RateLimiting(t *testing.T) {
 	
 	// Wait for rate limit window to pass using a helper function
 	waitForRateLimitReset := func(t *testing.T, rl *RateLimiter, timeout time.Duration) bool {
+		t.Helper()
 		deadline := time.Now().Add(timeout)
 		ticker := time.NewTicker(10 * time.Millisecond)
 		defer ticker.Stop()
@@ -241,6 +242,7 @@ func TestTelemetryWorker_CircuitBreaker(t *testing.T) {
 	
 	// Create a test helper to wait for circuit recovery
 	waitForCircuitRecovery := func(t *testing.T, cb *CircuitBreaker, timeout time.Duration) bool {
+		t.Helper()
 		deadline := time.Now().Add(timeout)
 		ticker := time.NewTicker(10 * time.Millisecond)
 		defer ticker.Stop()


### PR DESCRIPTION
## Summary
- Fix all thelper linter errors by adding t.Helper() calls to test helper functions across the codebase
- Ensures proper test failure reporting by showing the correct source location when helper functions are involved

## Test plan
- [x] Run golangci-lint to verify all thelper errors are resolved
- [x] Ensure existing tests continue to pass
- [x] Verify test output shows correct source locations for failures

🤖 Generated with [Claude Code](https://claude.ai/code)