### PR TITLE
fix: resolve all linter errors with improved test assertions

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -66,6 +66,7 @@ linters:
       # Check exhaustiveness of enum switch statements
       default-signifies-exhaustive: true
 issues:
+  max-issues-per-linter: 0
   max-same-issues: 0
   uniq-by-line: true
   new: false

--- a/internal/analysis/jobqueue/queue_test.go
+++ b/internal/analysis/jobqueue/queue_test.go
@@ -882,7 +882,7 @@ func TestQueueOverflow(t *testing.T) {
 
 	// Try to enqueue one more job, which should fail with ErrQueueFull
 	_, err = queue.Enqueue(regularAction, &TestData{ID: "overflow-job"}, RetryConfig{Enabled: false})
-	assert.ErrorIs(t, err, ErrQueueFull, "Enqueue should fail with ErrQueueFull when queue is full")
+	require.ErrorIs(t, err, ErrQueueFull, "Enqueue should fail with ErrQueueFull when queue is full")
 
 	// Now unblock the first job to make room
 	close(jobBlock)
@@ -1092,8 +1092,8 @@ func TestHangingJobTimeout(t *testing.T) {
 	go func() {
 		// Enqueue the job
 		job, err := queue.Enqueue(action, data, config)
-		require.NoError(t, err, "Failed to enqueue job")
-		require.NotNil(t, job, "Job should not be nil")
+		assert.NoError(t, err, "Failed to enqueue job")
+		assert.NotNil(t, job, "Job should not be nil")
 
 		// Signal that the job has been enqueued
 		close(done)
@@ -1182,7 +1182,7 @@ func TestContextCancellation(t *testing.T) {
 
 	// The stop should succeed even though the job is still running
 	// because we're using a timeout
-	assert.NoError(t, err, "Queue stop should succeed with timeout")
+	require.NoError(t, err, "Queue stop should succeed with timeout")
 
 	// Check that the action was executed
 	assert.Equal(t, 1, action.GetExecuteCount(), "Action should have been executed once")
@@ -1374,7 +1374,7 @@ func TestConcurrentJobSubmission(t *testing.T) {
 				config := RetryConfig{Enabled: false}
 
 				_, err := queue.Enqueue(action, data, config)
-				require.NoError(t, err)
+				assert.NoError(t, err)
 			}
 		}(i)
 	}
@@ -1499,7 +1499,7 @@ func TestGracefulShutdownWithInProgressJobs(t *testing.T) {
 	// Check if shutdown completed without error
 	select {
 	case err := <-shutdownErr:
-		assert.NoError(t, err, "Graceful shutdown should complete without error")
+		require.NoError(t, err, "Graceful shutdown should complete without error")
 	case <-time.After(3 * time.Second):
 		t.Fatal("Shutdown didn't complete in time")
 	}
@@ -1542,7 +1542,7 @@ func TestRateLimiting(t *testing.T) {
 	}
 
 	t.Logf("Successfully enqueued: %d, Rejected: %d", successCount.Load(), rejectionCount.Load())
-	assert.Greater(t, rejectionCount.Load(), int32(0), "Some jobs should be rejected due to queue full")
+	assert.Positive(t, rejectionCount.Load(), "Some jobs should be rejected due to queue full")
 	assert.Equal(t, int32(5), successCount.Load(), "Only 5 jobs should be successfully enqueued")
 }
 
@@ -1832,7 +1832,7 @@ func TestJobTypeStatistics(t *testing.T) {
 	assert.Equal(t, 1, stats.FailedJobs, "Failed jobs should be 1")
 	assert.Equal(t, 0, stats.PendingJobs, "Pending jobs should be 0")
 	assert.Equal(t, 100, stats.MaxQueueSize, "Max queue size should be 100")
-	assert.Equal(t, 0.0, stats.QueueUtilization, "Queue utilization should be 0%")
+	assert.InDelta(t, 0.0, stats.QueueUtilization, 0.01, "Queue utilization should be 0%")
 }
 
 // TestMemoryManagementWithLargeJobLoads tests that the job queue properly manages memory

--- a/internal/analysis/processor/actions_test.go
+++ b/internal/analysis/processor/actions_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/analysis/jobqueue"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/datastore"
@@ -92,8 +92,8 @@ func TestMqttAction_Execute_NotConnected(t *testing.T) {
 	err := action.Execute(nil)
 
 	// Assert
-	assert.Error(t, err)
-	assert.ErrorContains(t, err, "MQTT client not connected")
+	require.Error(t, err)
+	require.ErrorContains(t, err, "MQTT client not connected")
 	mockClient.AssertExpectations(t)
 	mockClient.AssertNotCalled(t, "Connect", mock.Anything)
 	mockClient.AssertNotCalled(t, "Publish", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"))
@@ -145,7 +145,7 @@ func TestMqttAction_Execute_Connected(t *testing.T) {
 	err := action.Execute(nil)
 
 	// Assert
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	mockClient.AssertExpectations(t)
 	mockClient.AssertNotCalled(t, "Connect", mock.Anything)
 }

--- a/internal/analysis/sound_level_publish_test.go
+++ b/internal/analysis/sound_level_publish_test.go
@@ -53,9 +53,9 @@ func TestSoundLevelJSONMarshaling(t *testing.T) {
 
 				bands := data["octave_bands"].(map[string]any)
 				band := bands["1000_Hz"].(map[string]any)
-				assert.Equal(t, -60.5, band["min_db"])
-				assert.Equal(t, -40.2, band["max_db"])
-				assert.Equal(t, -50.3, band["mean_db"])
+				assert.InDelta(t, -60.5, band["min_db"], 0.01)
+				assert.InDelta(t, -40.2, band["max_db"], 0.01)
+				assert.InDelta(t, -50.3, band["mean_db"], 0.01)
 			},
 		},
 		{
@@ -181,7 +181,7 @@ func TestSoundLevelJSONMarshaling(t *testing.T) {
 
 				bands := data["octave_bands"].(map[string]any)
 				band := bands["1000_Hz"].(map[string]any)
-				assert.Equal(t, -200.0, band["min_db"])
+				assert.InDelta(t, -200.0, band["min_db"], 0.01)
 			},
 		},
 	}
@@ -193,9 +193,9 @@ func TestSoundLevelJSONMarshaling(t *testing.T) {
 			jsonData, err := json.Marshal(tt.soundData)
 
 			if tt.shouldError {
-				assert.Error(t, err, "Expected JSON marshaling to fail for %s", tt.name)
+				require.Error(t, err, "Expected JSON marshaling to fail for %s", tt.name)
 			} else {
-				assert.NoError(t, err, "Expected JSON marshaling to succeed for %s", tt.name)
+				require.NoError(t, err, "Expected JSON marshaling to succeed for %s", tt.name)
 				if tt.checkJSON != nil {
 					tt.checkJSON(t, jsonData)
 				}
@@ -436,7 +436,7 @@ func TestSoundLevelChannelFlow(t *testing.T) {
 		received = append(received, data)
 	}
 
-	assert.Equal(t, len(testData), len(received))
+	assert.Len(t, received, len(testData))
 	for i, data := range received {
 		assert.Equal(t, testData[i].Source, data.Source)
 		assert.Equal(t, testData[i].Name, data.Name)
@@ -746,7 +746,7 @@ func TestSoundLevelPublishIntervalSimulation(t *testing.T) {
 			wg.Wait()
 
 			// Verify publish count
-			assert.Equal(t, tt.expectedPublishCount, len(publishTimes),
+			assert.Len(t, publishTimes, tt.expectedPublishCount,
 				"Expected %d publishes but got %d", tt.expectedPublishCount, len(publishTimes))
 
 			// Verify publish timing
@@ -1118,7 +1118,7 @@ func TestSoundLevelPublishMultipleIntervals(t *testing.T) {
 	wg.Wait()
 
 	// Verify we got the expected number of publishes
-	assert.Equal(t, numIntervals, len(payloads),
+	assert.Len(t, payloads, numIntervals,
 		"Expected %d publishes but got %d", numIntervals, len(payloads))
 
 	// Verify each payload is valid and contains expected data
@@ -1133,7 +1133,7 @@ func TestSoundLevelPublishMultipleIntervals(t *testing.T) {
 
 		// Verify timestamp format
 		_, err = time.Parse(time.RFC3339, compactData.TS)
-		assert.NoError(t, err, "Invalid timestamp format in payload %d", i+1)
+		require.NoError(t, err, "Invalid timestamp format in payload %d", i+1)
 
 		t.Logf("Interval %d: Published %d bands at %s", i+1, len(compactData.Bands), compactData.TS)
 	}
@@ -1367,7 +1367,7 @@ func collectPublishEvents(t *testing.T, publishEvents chan publishEvent,
 func verifyPublishResults(t *testing.T, events []publishEvent, tt mqttIntervalTest, testStartTime time.Time) {
 	t.Helper()
 	// Verify publish count
-	assert.Equal(t, tt.expectedPublishes, len(events),
+	assert.Len(t, events, tt.expectedPublishes,
 		"Expected %d MQTT publishes but got %d", tt.expectedPublishes, len(events))
 
 	// Verify each publish
@@ -1399,7 +1399,7 @@ func verifyPublishPayload(t *testing.T, event publishEvent, index, interval int)
 	
 	assert.Equal(t, "test-device", compactData.Src)
 	assert.Equal(t, interval, compactData.Dur)
-	assert.Equal(t, 2, len(compactData.Bands))
+	assert.Len(t, compactData.Bands, 2)
 	assert.Contains(t, event.topic, "soundlevel")
 }
 
@@ -1584,7 +1584,7 @@ func TestMQTTPublishIntervalWithErrors(t *testing.T) {
 	}
 
 	// Verify all data was attempted to be published despite errors
-	assert.Equal(t, 4, len(attempts), "All data should be attempted to publish")
+	assert.Len(t, attempts, 4, "All data should be attempted to publish")
 
 	close(stopChan)
 	wg.Wait()

--- a/internal/api/v2/api_test.go
+++ b/internal/api/v2/api_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/datastore"
 )
 
@@ -36,7 +37,8 @@ func TestHealthCheck(t *testing.T) {
 	startTime := time.Now()
 
 	// Test
-	if assert.NoError(t, controller.HealthCheck(c)) {
+	require.NoError(t, controller.HealthCheck(c))
+	{
 		// Calculate response time
 		responseTime := time.Since(startTime)
 
@@ -52,7 +54,7 @@ func TestHealthCheck(t *testing.T) {
 		// Parse response body
 		var response map[string]interface{}
 		err := json.Unmarshal(rec.Body.Bytes(), &response)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		// Check required fields
 		assert.Equal(t, "healthy", response["status"], "Status should be 'healthy'")
@@ -116,7 +118,7 @@ func TestHealthCheck(t *testing.T) {
 
 		if timestamp, exists := response["timestamp"]; exists {
 			_, err := time.Parse(time.RFC3339, timestamp.(string))
-			assert.NoError(t, err, "Timestamp should be in RFC3339 format")
+			require.NoError(t, err, "Timestamp should be in RFC3339 format")
 		}
 	}
 
@@ -139,13 +141,13 @@ func TestHandleError(t *testing.T) {
 		"Error message", http.StatusBadRequest)
 
 	// Assertions
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 
 	// Parse response body
 	var response ErrorResponse
 	err = json.Unmarshal(rec.Body.Bytes(), &response)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Check response content
 	assert.Equal(t, "code=400, message=Test error", response.Error)

--- a/internal/api/v2/control_test.go
+++ b/internal/api/v2/control_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestGetAvailableActions tests the GetAvailableActions endpoint
@@ -30,7 +31,8 @@ func TestGetAvailableActions(t *testing.T) {
 	c.SetPath("/api/v2/control/actions")
 
 	// Test
-	if assert.NoError(t, controller.GetAvailableActions(c)) {
+	require.NoError(t, controller.GetAvailableActions(c))
+	{
 		// Check status code
 		assert.Equal(t, http.StatusOK, rec.Code)
 
@@ -40,10 +42,10 @@ func TestGetAvailableActions(t *testing.T) {
 		// Parse response body
 		var actions []ControlAction
 		err := json.Unmarshal(rec.Body.Bytes(), &actions)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		// Check response content
-		assert.Len(t, actions, 3, "Should have 3 control actions")
+		require.Len(t, actions, 3, "Should have 3 control actions")
 
 		// Verify actions include all expected types
 		var hasRestartAction, hasReloadAction, hasRebuildFilterAction bool
@@ -84,7 +86,8 @@ func TestRestartAnalysis(t *testing.T) {
 	c.SetPath("/api/v2/control/restart")
 
 	// Test
-	if assert.NoError(t, controller.RestartAnalysis(c)) {
+	require.NoError(t, controller.RestartAnalysis(c))
+	{
 		// Check status code
 		assert.Equal(t, http.StatusOK, rec.Code)
 
@@ -94,7 +97,7 @@ func TestRestartAnalysis(t *testing.T) {
 		// Parse response body
 		var result ControlResult
 		err := json.Unmarshal(rec.Body.Bytes(), &result)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		// Check response content
 		assert.True(t, result.Success)
@@ -128,7 +131,8 @@ func TestReloadModel(t *testing.T) {
 	c.SetPath("/api/v2/control/reload")
 
 	// Test
-	if assert.NoError(t, controller.ReloadModel(c)) {
+	require.NoError(t, controller.ReloadModel(c))
+	{
 		// Check status code
 		assert.Equal(t, http.StatusOK, rec.Code)
 
@@ -138,7 +142,7 @@ func TestReloadModel(t *testing.T) {
 		// Parse response body
 		var result ControlResult
 		err := json.Unmarshal(rec.Body.Bytes(), &result)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		// Check response content
 		assert.True(t, result.Success)
@@ -172,7 +176,8 @@ func TestRebuildFilter(t *testing.T) {
 	c.SetPath("/api/v2/control/rebuild-filter")
 
 	// Test
-	if assert.NoError(t, controller.RebuildFilter(c)) {
+	require.NoError(t, controller.RebuildFilter(c))
+	{
 		// Check status code
 		assert.Equal(t, http.StatusOK, rec.Code)
 
@@ -182,7 +187,7 @@ func TestRebuildFilter(t *testing.T) {
 		// Parse response body
 		var result ControlResult
 		err := json.Unmarshal(rec.Body.Bytes(), &result)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		// Check response content
 		assert.True(t, result.Success)
@@ -244,18 +249,18 @@ func TestControlActionsWithNilChannel(t *testing.T) {
 			err := tc.handler(c)
 
 			// Check that the error is properly handled by the controller
-			assert.NoError(t, err, "Handler should not return error even when control channel is nil")
+			require.NoError(t, err, "Handler should not return error even when control channel is nil")
 			assert.Equal(t, http.StatusInternalServerError, rec.Code, "Should return 500 Internal Server Error")
 
 			// Parse error response
 			var errorResp map[string]interface{}
 			err = json.Unmarshal(rec.Body.Bytes(), &errorResp)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			// Check error response content
 			assert.Contains(t, fmt.Sprint(errorResp["error"]), "control channel not initialized")
 			assert.Contains(t, errorResp["message"], "System control interface not available")
-			assert.Equal(t, float64(http.StatusInternalServerError), errorResp["code"])
+			assert.InDelta(t, float64(http.StatusInternalServerError), errorResp["code"], 0.01)
 		})
 	}
 }
@@ -305,12 +310,12 @@ func TestControlResultStructure(t *testing.T) {
 
 	// Marshal to JSON
 	jsonData, err := json.Marshal(result)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Verify JSON structure
 	var jsonMap map[string]interface{}
 	err = json.Unmarshal(jsonData, &jsonMap)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Check fields
 	assert.Equal(t, true, jsonMap["success"])
@@ -329,12 +334,12 @@ func TestControlActionStructure(t *testing.T) {
 
 	// Marshal to JSON
 	jsonData, err := json.Marshal(action)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Verify JSON structure
 	var jsonMap map[string]interface{}
 	err = json.Unmarshal(jsonData, &jsonMap)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Check fields
 	assert.Equal(t, ActionReloadModel, jsonMap["action"])
@@ -392,7 +397,7 @@ func TestControlEndpointsWithUserAuth(t *testing.T) {
 
 			// Call handler directly (bypass middleware)
 			err := h.handler(c)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			// Verify response
 			assert.Equal(t, http.StatusOK, rec.Code)
@@ -400,7 +405,7 @@ func TestControlEndpointsWithUserAuth(t *testing.T) {
 			// Parse response
 			var result ControlResult
 			err = json.Unmarshal(rec.Body.Bytes(), &result)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			// Check fields
 			assert.True(t, result.Success)
@@ -511,7 +516,7 @@ func TestConcurrentControlRequests(t *testing.T) {
 	wg.Wait()
 
 	// Verify that all signals were sent to the channel
-	assert.Equal(t, numRequests, len(controlChan), "All signals should be received")
+	assert.Len(t, controlChan, numRequests, "All signals should be received")
 
 	// Drain the channel
 	for i := 0; i < numRequests; i++ {
@@ -578,7 +583,7 @@ func TestControlEndpointsAuthScenarios(t *testing.T) {
 			if tc.expectedStatus == http.StatusOK {
 				var result ControlResult
 				err := json.Unmarshal(rec.Body.Bytes(), &result)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.True(t, result.Success)
 				assert.Equal(t, ActionRestartAnalysis, result.Action)
 			}
@@ -606,7 +611,7 @@ func TestInvalidPayloads(t *testing.T) {
 	err := controller.RestartAnalysis(c)
 
 	// The handler should still work with invalid payloads since it doesn't expect any
-	assert.NoError(t, err, "Handler should not return an error with invalid payload")
+	require.NoError(t, err, "Handler should not return an error with invalid payload")
 	assert.Equal(t, http.StatusOK, rec.Code, "Should return OK even with invalid payload")
 
 	// Verify the signal was sent
@@ -711,7 +716,7 @@ func TestConcurrentControlRequests_Advanced(t *testing.T) {
 	wg.Wait()
 
 	// Verify that all signals were sent to the channel
-	assert.Equal(t, numRequests, len(controlChan), "All signals should be received")
+	assert.Len(t, controlChan, numRequests, "All signals should be received")
 
 	// Drain the channel
 	for i := 0; i < numRequests; i++ {
@@ -768,7 +773,7 @@ func TestControlEndpointsAuthScenarios_Advanced(t *testing.T) {
 			if authValidator(token) {
 				// Call the handler directly
 				err := controller.RestartAnalysis(c)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 
 				// Verify successful response
 				assert.Equal(t, http.StatusOK, rec.Code)
@@ -776,7 +781,7 @@ func TestControlEndpointsAuthScenarios_Advanced(t *testing.T) {
 				// Parse response
 				var result ControlResult
 				err = json.Unmarshal(rec.Body.Bytes(), &result)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 
 				// Check fields
 				assert.True(t, result.Success)
@@ -821,7 +826,7 @@ func TestInvalidPayloads_Advanced(t *testing.T) {
 	err := controller.RestartAnalysis(c)
 
 	// The handler should still work with invalid payloads since it doesn't expect any
-	assert.NoError(t, err, "Handler should not return an error with invalid payload")
+	require.NoError(t, err, "Handler should not return an error with invalid payload")
 	assert.Equal(t, http.StatusOK, rec.Code, "Should return OK even with invalid payload")
 
 	// Verify the signal was sent

--- a/internal/api/v2/debug_test.go
+++ b/internal/api/v2/debug_test.go
@@ -86,7 +86,7 @@ func TestDebugTriggerError(t *testing.T) {
 			err := c.DebugTriggerError(ctx)
 			
 			if tt.wantCode == http.StatusOK {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, tt.wantCode, rec.Code)
 				
 				var resp DebugResponse
@@ -121,7 +121,7 @@ func TestDebugEndpointsRequireDebugMode(t *testing.T) {
 		ctx := e.NewContext(req, rec)
 		
 		err := c.DebugTriggerError(ctx)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, http.StatusForbidden, rec.Code)
 		
 		var resp map[string]string
@@ -139,7 +139,7 @@ func TestDebugEndpointsRequireDebugMode(t *testing.T) {
 		ctx := e.NewContext(req, rec)
 		
 		err := c.DebugTriggerNotification(ctx)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, http.StatusForbidden, rec.Code)
 	})
 	
@@ -151,7 +151,7 @@ func TestDebugEndpointsRequireDebugMode(t *testing.T) {
 		ctx := e.NewContext(req, rec)
 		
 		err := c.DebugSystemStatus(ctx)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, http.StatusForbidden, rec.Code)
 	})
 }

--- a/internal/api/v2/media_test.go
+++ b/internal/api/v2/media_test.go
@@ -375,7 +375,7 @@ func TestMediaEndpointsIntegration(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			// Make request to the HTTP server
 			resp, err := client.Get(server.URL + tc.endpoint)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			defer func() {
 				if err := resp.Body.Close(); err != nil {
 					t.Errorf("Failed to close response body: %v", err)
@@ -388,7 +388,7 @@ func TestMediaEndpointsIntegration(t *testing.T) {
 			// Check response body for successful requests
 			if tc.expectedStatus == http.StatusOK {
 				body, err := io.ReadAll(resp.Body)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, tc.expectedBody, string(body))
 			}
 		})
@@ -528,7 +528,7 @@ func TestRangeHeaderHandling(t *testing.T) {
 			expectedStatus: http.StatusRequestedRangeNotSatisfiable,
 			validateFunc: func(t *testing.T, rec *httptest.ResponseRecorder) {
 				t.Helper()
-				assert.Len(t, rec.Body.Bytes(), 0, "416 responses should not include the file body")
+				assert.Empty(t, rec.Body.Bytes(), "416 responses should not include the file body")
 			},
 		},
 		{
@@ -578,7 +578,7 @@ func TestRangeHeaderHandling(t *testing.T) {
 			// Handle potential handler errors (less likely now with http.ServeContent)
 			if tc.expectedStatus >= 400 {
 				if handlerErr != nil {
-					assert.Error(t, handlerErr)
+					require.Error(t, handlerErr)
 					// Use errors.As for robust error checking
 					var httpErr *echo.HTTPError
 					if errors.As(handlerErr, &httpErr) {
@@ -587,7 +587,7 @@ func TestRangeHeaderHandling(t *testing.T) {
 				}
 			} else {
 				// Expect no error from the handler itself on success
-				assert.NoError(t, handlerErr)
+				require.NoError(t, handlerErr)
 			}
 
 			// Run validation function for successful responses

--- a/internal/api/v2/range_test.go
+++ b/internal/api/v2/range_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/birdnet"
 )
 
@@ -83,13 +84,13 @@ func TestGetRangeFilterSpeciesCount(t *testing.T) {
 		// Parse response
 		var response RangeFilterSpeciesCount
 		err := json.Unmarshal(rec.Body.Bytes(), &response)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		// Check response content
 		assert.Equal(t, 3, response.Count)
-		assert.Equal(t, float32(0.01), response.Threshold)
-		assert.Equal(t, 60.1699, response.Location.Latitude)
-		assert.Equal(t, 24.9384, response.Location.Longitude)
+		assert.InDelta(t, float32(0.01), response.Threshold, 0.001)
+		assert.InDelta(t, 60.1699, response.Location.Latitude, 0.001)
+		assert.InDelta(t, 24.9384, response.Location.Longitude, 0.001)
 		assert.False(t, response.LastUpdated.IsZero())
 	}
 }
@@ -113,12 +114,12 @@ func TestGetRangeFilterSpeciesList(t *testing.T) {
 		// Parse response
 		var response RangeFilterSpeciesList
 		err := json.Unmarshal(rec.Body.Bytes(), &response)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		// Check response content
 		assert.Equal(t, 3, response.Count)
 		assert.Len(t, response.Species, 3)
-		assert.Equal(t, float32(0.01), response.Threshold)
+		assert.InDelta(t, float32(0.01), response.Threshold, 0.001)
 
 		// Check first species
 		firstSpecies := response.Species[0]
@@ -155,7 +156,7 @@ func TestTestRangeFilterWithoutProcessor(t *testing.T) {
 
 	// Test
 	err := controller.TestRangeFilter(c)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Check response code (should be 500 due to missing processor)
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
@@ -163,7 +164,7 @@ func TestTestRangeFilterWithoutProcessor(t *testing.T) {
 	// Parse error response
 	var response ErrorResponse
 	err = json.Unmarshal(rec.Body.Bytes(), &response)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Contains(t, response.Message, "BirdNET processor not available")
 }
 
@@ -262,7 +263,7 @@ func TestTestRangeFilterValidation(t *testing.T) {
 
 			// Test
 			err := controller.TestRangeFilter(c)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			// Check response code
 			assert.Equal(t, tt.expectedStatus, rec.Code)
@@ -270,7 +271,7 @@ func TestTestRangeFilterValidation(t *testing.T) {
 			// Parse error response
 			var response ErrorResponse
 			err = json.Unmarshal(rec.Body.Bytes(), &response)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Contains(t, response.Message, tt.expectedError)
 		})
 	}
@@ -292,7 +293,7 @@ func TestRebuildRangeFilterWithoutProcessor(t *testing.T) {
 
 	// Test
 	err := controller.RebuildRangeFilter(c)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Check response code (should be 500 due to missing processor)
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
@@ -300,6 +301,6 @@ func TestRebuildRangeFilterWithoutProcessor(t *testing.T) {
 	// Parse error response
 	var response ErrorResponse
 	err = json.Unmarshal(rec.Body.Bytes(), &response)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Contains(t, response.Message, "BirdNET processor not available")
 }

--- a/internal/api/v2/security_test.go
+++ b/internal/api/v2/security_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/datastore"
 )
 
@@ -93,7 +94,7 @@ func setPathParamsFromPath(c echo.Context, path string) {
 // assertSuccessfulResponse checks for expected 2xx status and optional body fragment.
 func assertSuccessfulResponse(t *testing.T, tcName string, expectedStatus int, rec *httptest.ResponseRecorder, handlerErr error, expectedBodyFragment string) {
 	t.Helper()
-	assert.NoErrorf(t, handlerErr, "tc=%s unexpected error", tcName)
+	require.NoErrorf(t, handlerErr, "tc=%s unexpected error", tcName)
 	assert.Equal(t, expectedStatus, rec.Code, "Test Case '%s': Unexpected status code for success case. Expected %d, got %d", tcName, expectedStatus, rec.Code)
 	if expectedBodyFragment != "" {
 		assert.Contains(t, rec.Body.String(), expectedBodyFragment, "Test Case '%s': Response body does not contain expected fragment '%s'", tcName, expectedBodyFragment)

--- a/internal/api/v2/weather_test.go
+++ b/internal/api/v2/weather_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/datastore"
 )
 
@@ -50,7 +51,7 @@ func TestGetDailyWeather(t *testing.T) {
 		// Parse response body
 		var response DailyWeatherResponse
 		err := json.Unmarshal(rec.Body.Bytes(), &response)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		// Check response content
 		assert.Equal(t, "2023-01-01", response.Date)
@@ -108,7 +109,7 @@ func TestGetDailyWeatherMissingDate(t *testing.T) {
 	err := controller.GetDailyWeather(c)
 
 	// The controller's HandleError method returns a JSON response, not an error
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Check response code
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
@@ -116,7 +117,7 @@ func TestGetDailyWeatherMissingDate(t *testing.T) {
 	// Parse error response
 	var errorResponse ErrorResponse
 	err = json.Unmarshal(rec.Body.Bytes(), &errorResponse)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Check error message
 	assert.Equal(t, "Date parameter is required", errorResponse.Message)
@@ -142,7 +143,7 @@ func TestGetDailyWeatherDatabaseError(t *testing.T) {
 	err := controller.GetDailyWeather(c)
 
 	// The controller's HandleError method returns a JSON response, not an error
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Check response code
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
@@ -150,7 +151,7 @@ func TestGetDailyWeatherDatabaseError(t *testing.T) {
 	// Parse error response
 	var errorResponse ErrorResponse
 	err = json.Unmarshal(rec.Body.Bytes(), &errorResponse)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Check error message
 	assert.Equal(t, "Failed to get daily weather data", errorResponse.Message)
@@ -217,23 +218,23 @@ func TestGetHourlyWeatherForDay(t *testing.T) {
 			Data []HourlyWeatherResponse `json:"data"`
 		}
 		err := json.Unmarshal(rec.Body.Bytes(), &response)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		// Check response content
 		assert.Len(t, response.Data, 2)
 
 		// Check first hour data
 		assert.Equal(t, "12:00:00", response.Data[0].Time)
-		assert.Equal(t, 5.5, response.Data[0].Temperature)
-		assert.Equal(t, 4.0, response.Data[0].FeelsLike)
-		assert.Equal(t, 3.2, response.Data[0].TempMin)
-		assert.Equal(t, 6.8, response.Data[0].TempMax)
+		assert.InDelta(t, 5.5, response.Data[0].Temperature, 0.01)
+		assert.InDelta(t, 4.0, response.Data[0].FeelsLike, 0.01)
+		assert.InDelta(t, 3.2, response.Data[0].TempMin, 0.01)
+		assert.InDelta(t, 6.8, response.Data[0].TempMax, 0.01)
 		assert.Equal(t, 1013, response.Data[0].Pressure)
 		assert.Equal(t, 75, response.Data[0].Humidity)
 		assert.Equal(t, 10000, response.Data[0].Visibility)
-		assert.Equal(t, 4.5, response.Data[0].WindSpeed)
+		assert.InDelta(t, 4.5, response.Data[0].WindSpeed, 0.01)
 		assert.Equal(t, 270, response.Data[0].WindDeg)
-		assert.Equal(t, 7.2, response.Data[0].WindGust)
+		assert.InDelta(t, 7.2, response.Data[0].WindGust, 0.01)
 		assert.Equal(t, 40, response.Data[0].Clouds)
 		assert.Equal(t, "Clouds", response.Data[0].WeatherMain)
 		assert.Equal(t, "scattered clouds", response.Data[0].WeatherDesc)
@@ -241,8 +242,8 @@ func TestGetHourlyWeatherForDay(t *testing.T) {
 
 		// Check second hour data
 		assert.Equal(t, "13:00:00", response.Data[1].Time)
-		assert.Equal(t, 6.0, response.Data[1].Temperature)
-		assert.Equal(t, 4.5, response.Data[1].FeelsLike)
+		assert.InDelta(t, 6.0, response.Data[1].Temperature, 0.01)
+		assert.InDelta(t, 4.5, response.Data[1].FeelsLike, 0.01)
 		assert.Equal(t, 70, response.Data[1].Humidity)
 		assert.Equal(t, "Clouds", response.Data[1].WeatherMain)
 		assert.Equal(t, "broken clouds", response.Data[1].WeatherDesc)
@@ -280,7 +281,7 @@ func TestGetHourlyWeatherForDayNoData(t *testing.T) {
 			Data    []HourlyWeatherResponse `json:"data"`
 		}
 		err := json.Unmarshal(rec.Body.Bytes(), &response)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		// Check response content
 		assert.Equal(t, "No weather data found for the specified date", response.Message)
@@ -321,7 +322,7 @@ func TestGetHourlyWeatherForDayFutureDate(t *testing.T) {
 			Data    []HourlyWeatherResponse `json:"data"`
 		}
 		err := json.Unmarshal(rec.Body.Bytes(), &response)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		// Check response content
 		assert.Equal(t, "No weather data available for future date", response.Message)
@@ -359,7 +360,7 @@ func TestGetHourlyWeatherForDayInvalidDate(t *testing.T) {
 			Data    []HourlyWeatherResponse `json:"data"`
 		}
 		err := json.Unmarshal(rec.Body.Bytes(), &response)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		// Check response content
 		assert.Equal(t, "No weather data found for the specified date", response.Message)
@@ -390,7 +391,7 @@ func TestGetHourlyWeatherForDayDatabaseError(t *testing.T) {
 	err := controller.GetHourlyWeatherForDay(c)
 
 	// The controller's HandleError method returns a JSON response, not an error
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Check response code
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
@@ -398,7 +399,7 @@ func TestGetHourlyWeatherForDayDatabaseError(t *testing.T) {
 	// Parse error response
 	var errorResponse ErrorResponse
 	err = json.Unmarshal(rec.Body.Bytes(), &errorResponse)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Check error message
 	assert.Equal(t, "Failed to get hourly weather data", errorResponse.Message)
@@ -456,14 +457,14 @@ func TestGetHourlyWeatherForHour(t *testing.T) {
 		// Parse response body
 		var response HourlyWeatherResponse
 		err := json.Unmarshal(rec.Body.Bytes(), &response)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		// Check response content for hour 13
 		assert.Equal(t, "13:00:00", response.Time)
-		assert.Equal(t, 6.0, response.Temperature)
-		assert.Equal(t, 4.5, response.FeelsLike)
-		assert.Equal(t, 3.5, response.TempMin)
-		assert.Equal(t, 7.0, response.TempMax)
+		assert.InDelta(t, 6.0, response.Temperature, 0.01)
+		assert.InDelta(t, 4.5, response.FeelsLike, 0.01)
+		assert.InDelta(t, 3.5, response.TempMin, 0.01)
+		assert.InDelta(t, 7.0, response.TempMax, 0.01)
 		assert.Equal(t, "Clear", response.WeatherMain)
 		assert.Equal(t, "clear sky", response.WeatherDesc)
 	}
@@ -503,7 +504,7 @@ func TestGetHourlyWeatherForHourNotFound(t *testing.T) {
 	err := controller.GetHourlyWeatherForHour(c)
 
 	// The controller's HandleError method returns a JSON response, not an error
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Check response code
 	assert.Equal(t, http.StatusNotFound, rec.Code)
@@ -511,7 +512,7 @@ func TestGetHourlyWeatherForHourNotFound(t *testing.T) {
 	// Parse error response
 	var errorResponse ErrorResponse
 	err = json.Unmarshal(rec.Body.Bytes(), &errorResponse)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Check error message
 	assert.Equal(t, "Weather data not found for specified hour", errorResponse.Message)
@@ -537,7 +538,7 @@ func TestGetHourlyWeatherForHourInvalidHour(t *testing.T) {
 	err := controller.GetHourlyWeatherForHour(c)
 
 	// The controller's HandleError method returns a JSON response, not an error
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Check response code
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
@@ -545,7 +546,7 @@ func TestGetHourlyWeatherForHourInvalidHour(t *testing.T) {
 	// Parse error response
 	var errorResponse ErrorResponse
 	err = json.Unmarshal(rec.Body.Bytes(), &errorResponse)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Check error message
 	assert.Equal(t, "Invalid hour format", errorResponse.Message)
@@ -605,7 +606,7 @@ func TestGetWeatherForDetection(t *testing.T) {
 		// Parse response body
 		var response DetectionWeatherResponse
 		err := json.Unmarshal(rec.Body.Bytes(), &response)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		// Check response content
 		// Daily weather
@@ -617,8 +618,8 @@ func TestGetWeatherForDetection(t *testing.T) {
 
 		// Hourly weather (closest to 12:30)
 		assert.Equal(t, "12:00:00", response.Hourly.Time)
-		assert.Equal(t, 5.5, response.Hourly.Temperature)
-		assert.Equal(t, 4.0, response.Hourly.FeelsLike)
+		assert.InDelta(t, 5.5, response.Hourly.Temperature, 0.01)
+		assert.InDelta(t, 4.0, response.Hourly.FeelsLike, 0.01)
 		assert.Equal(t, "Clouds", response.Hourly.WeatherMain)
 		assert.Equal(t, "scattered clouds", response.Hourly.WeatherDesc)
 	}
@@ -643,7 +644,7 @@ func TestGetWeatherForDetectionMissingID(t *testing.T) {
 	err := controller.GetWeatherForDetection(c)
 
 	// The controller's HandleError method returns a JSON response, not an error
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Check response code
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
@@ -651,7 +652,7 @@ func TestGetWeatherForDetectionMissingID(t *testing.T) {
 	// Parse error response
 	var errorResponse ErrorResponse
 	err = json.Unmarshal(rec.Body.Bytes(), &errorResponse)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Check error message
 	assert.Equal(t, "Detection ID is required", errorResponse.Message)
@@ -703,7 +704,7 @@ func TestGetLatestWeather(t *testing.T) {
 			Time   string                `json:"timestamp"`
 		}
 		err := json.Unmarshal(rec.Body.Bytes(), &response)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		// Check response content
 		// Daily weather should be present
@@ -716,8 +717,8 @@ func TestGetLatestWeather(t *testing.T) {
 
 		// Hourly weather
 		assert.Equal(t, "15:00:00", response.Hourly.Time)
-		assert.Equal(t, 7.5, response.Hourly.Temperature)
-		assert.Equal(t, 6.0, response.Hourly.FeelsLike)
+		assert.InDelta(t, 7.5, response.Hourly.Temperature, 0.01)
+		assert.InDelta(t, 6.0, response.Hourly.FeelsLike, 0.01)
 		assert.Equal(t, "Clear", response.Hourly.WeatherMain)
 		assert.Equal(t, "clear sky", response.Hourly.WeatherDesc)
 

--- a/internal/audiocore/adapter/myaudio_compat_test.go
+++ b/internal/audiocore/adapter/myaudio_compat_test.go
@@ -116,7 +116,7 @@ func TestCalculateAudioLevel(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := adapter.calculateAudioLevel(tt.buffer)
 			if tt.expected == 0 {
-				assert.Equal(t, float32(0), result, "Expected zero audio level")
+				assert.InDelta(t, float32(0), result, 0.001, "Expected zero audio level")
 			} else {
 				assert.InDelta(t, tt.expected, result, 0.001, "Audio level calculation mismatch")
 			}
@@ -164,7 +164,7 @@ func TestSoundLevelAnalyzer(t *testing.T) {
 		band, ok := result.OctaveBands["1000"]
 		assert.True(t, ok, "Expected 1000Hz octave band to be present")
 		if ok {
-			assert.Equal(t, 60.0, band.Mean, "Expected mean 60.0 for 1000Hz band")
+			assert.InDelta(t, 60.0, band.Mean, 0.01, "Expected mean 60.0 for 1000Hz band")
 		}
 	}
 }

--- a/internal/audiocore/buffer_test.go
+++ b/internal/audiocore/buffer_test.go
@@ -104,12 +104,12 @@ func TestBufferOperations(t *testing.T) {
 
 	t.Run("Resize", func(t *testing.T) {
 		err := buf.Resize(50)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, 50, buf.Len())
 
 		// Resize larger than capacity
 		err = buf.Resize(10000)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, 10000, buf.Len())
 		assert.GreaterOrEqual(t, buf.Cap(), 10000)
 
@@ -120,19 +120,19 @@ func TestBufferOperations(t *testing.T) {
 
 	t.Run("Slice", func(t *testing.T) {
 		err := buf.Resize(100)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		// Valid slice
 		slice, err := buf.Slice(10, 20)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Len(t, slice, 10)
 
 		// Invalid slices
 		_, err = buf.Slice(-1, 10)
-		assert.Error(t, err)
+		require.Error(t, err)
 
 		_, err = buf.Slice(0, 200)
-		assert.Error(t, err)
+		require.Error(t, err)
 
 		_, err = buf.Slice(20, 10)
 		assert.Error(t, err)

--- a/internal/audiocore/manager_test.go
+++ b/internal/audiocore/manager_test.go
@@ -62,19 +62,19 @@ func TestManagerCreateAndStart(t *testing.T) {
 	// Add a mock source
 	source := newMockSource("test-source", "Test Source")
 	err := manager.AddSource(source)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Start the manager
 	ctx := context.Background()
 	err = manager.Start(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Verify source is active
 	assert.True(t, source.IsActive())
 
 	// Stop the manager
 	err = manager.Stop()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Verify source is stopped
 	assert.False(t, source.IsActive())
@@ -91,12 +91,12 @@ func TestManagerAddDuplicateSource(t *testing.T) {
 	// Add first source
 	source1 := newMockSource("duplicate-id", "Source 1")
 	err := manager.AddSource(source1)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Try to add duplicate
 	source2 := newMockSource("duplicate-id", "Source 2")
 	err = manager.AddSource(source2)
-	assert.Error(t, err)
+	require.Error(t, err)
 	if err != nil {
 		assert.Contains(t, err.Error(), "already exists")
 	}
@@ -114,13 +114,13 @@ func TestManagerMaxSources(t *testing.T) {
 	for i := 0; i < 2; i++ {
 		source := newMockSource("source-"+strconv.Itoa(i), "Source")
 		err := manager.AddSource(source)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	}
 
 	// Try to exceed limit
 	source := newMockSource("extra-source", "Extra Source")
 	err := manager.AddSource(source)
-	assert.Error(t, err)
+	require.Error(t, err)
 	if err != nil {
 		assert.Contains(t, err.Error(), "max sources reached")
 	}
@@ -137,15 +137,15 @@ func TestManagerRemoveSource(t *testing.T) {
 	// Add a source
 	source := newMockSource("remove-test", "Test Source")
 	err := manager.AddSource(source)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Remove it
 	err = manager.RemoveSource("remove-test")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Try to remove non-existent
 	err = manager.RemoveSource("remove-test")
-	assert.Error(t, err)
+	require.Error(t, err)
 	if err != nil {
 		assert.Contains(t, err.Error(), "not found")
 	}
@@ -162,7 +162,7 @@ func TestManagerGetSource(t *testing.T) {
 	// Add a source
 	source := newMockSource("get-test", "Test Source")
 	err := manager.AddSource(source)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Get existing source
 	retrieved, exists := manager.GetSource("get-test")
@@ -185,16 +185,16 @@ func TestManagerProcessorChain(t *testing.T) {
 	// Add a source
 	source := newMockSource("chain-test", "Test Source")
 	err := manager.AddSource(source)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Set processor chain
 	chain := NewProcessorChain()
 	err = manager.SetProcessorChain("chain-test", chain)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Try to set chain for non-existent source
 	err = manager.SetProcessorChain("non-existent", chain)
-	assert.Error(t, err)
+	require.Error(t, err)
 	if err != nil {
 		assert.Contains(t, err.Error(), "not found")
 	}
@@ -212,12 +212,12 @@ func TestManagerStartupErrors(t *testing.T) {
 	source := newMockSource("fail-source", "Failing Source")
 	source.startErr = assert.AnError
 	err := manager.AddSource(source)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Start should fail
 	ctx := context.Background()
 	err = manager.Start(ctx)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestManagerAlreadyStarted(t *testing.T) {
@@ -231,18 +231,18 @@ func TestManagerAlreadyStarted(t *testing.T) {
 	// Start manager
 	ctx := context.Background()
 	err := manager.Start(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Try to start again
 	err = manager.Start(ctx)
-	assert.Error(t, err)
+	require.Error(t, err)
 	if err != nil {
 		assert.Contains(t, err.Error(), "already started")
 	}
 
 	// Clean up
 	err = manager.Stop()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestManagerNotStarted(t *testing.T) {
@@ -255,7 +255,7 @@ func TestManagerNotStarted(t *testing.T) {
 
 	// Try to stop without starting
 	err := manager.Stop()
-	assert.Error(t, err)
+	require.Error(t, err)
 	if err != nil {
 		assert.Contains(t, err.Error(), "not started")
 	}
@@ -273,12 +273,12 @@ func TestManagerAudioOutput(t *testing.T) {
 	// Add a source
 	source := newMockSource("output-test", "Test Source")
 	err := manager.AddSource(source)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Start manager
 	ctx := context.Background()
 	err = manager.Start(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Send some audio data
 	testData := AudioData{
@@ -330,5 +330,5 @@ func TestManagerAudioOutput(t *testing.T) {
 
 	// Clean up
 	err = manager.Stop()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }

--- a/internal/audiocore/processor_test.go
+++ b/internal/audiocore/processor_test.go
@@ -44,10 +44,10 @@ func TestProcessorChainAddRemove(t *testing.T) {
 	proc2 := &mockProcessor{id: "proc2"}
 
 	err := chain.AddProcessor(proc1)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = chain.AddProcessor(proc2)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Get processors
 	processors := chain.GetProcessors()
@@ -55,23 +55,23 @@ func TestProcessorChainAddRemove(t *testing.T) {
 
 	// Try to add duplicate
 	err = chain.AddProcessor(proc1)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "already exists")
 
 	// Try to add nil
 	err = chain.AddProcessor(nil)
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	// Remove processor
 	err = chain.RemoveProcessor("proc1")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	processors = chain.GetProcessors()
 	assert.Len(t, processors, 1)
 
 	// Remove non-existent
 	err = chain.RemoveProcessor("proc1")
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not found")
 }
 
@@ -88,7 +88,7 @@ func TestProcessorChainProcess(t *testing.T) {
 	}
 
 	output, err := chain.Process(ctx, input)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, input, output)
 
 	// Add processors that modify data
@@ -117,14 +117,14 @@ func TestProcessorChainProcess(t *testing.T) {
 	}
 
 	err = chain.AddProcessor(proc1)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = chain.AddProcessor(proc2)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Process through chain
 	output, err = chain.Process(ctx, input)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, output)
 
 	// Verify processing: (1,2,3,4) -> double -> (2,4,6,8) -> add 1 -> (3,5,7,9)
@@ -146,7 +146,7 @@ func TestProcessorChainProcessError(t *testing.T) {
 	}
 
 	err := chain.AddProcessor(proc)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	input := &AudioData{
 		Buffer:    []byte{1, 2, 3, 4},
@@ -155,7 +155,7 @@ func TestProcessorChainProcessError(t *testing.T) {
 	}
 
 	output, err := chain.Process(ctx, input)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Nil(t, output)
 }
 
@@ -167,7 +167,7 @@ func TestProcessorChainContextCancellation(t *testing.T) {
 	// Add a processor
 	proc := &mockProcessor{id: "proc"}
 	err := chain.AddProcessor(proc)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Cancel context
 	cancel()
@@ -179,7 +179,7 @@ func TestProcessorChainContextCancellation(t *testing.T) {
 	}
 
 	output, err := chain.Process(ctx, input)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Equal(t, context.Canceled, err)
 	assert.Nil(t, output)
 }
@@ -192,9 +192,9 @@ func TestProcessorChainGetProcessors(t *testing.T) {
 	proc2 := &mockProcessor{id: "proc2"}
 
 	err := chain.AddProcessor(proc1)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = chain.AddProcessor(proc2)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Get processors should return a copy
 	processors := chain.GetProcessors()

--- a/internal/audiocore/processors/gain_test.go
+++ b/internal/audiocore/processors/gain_test.go
@@ -16,22 +16,22 @@ func TestGainProcessorCreation(t *testing.T) {
 	t.Parallel()
 	// Valid gain
 	proc, err := NewGainProcessor("test-gain", 1.5)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, proc)
 
 	gainProc, ok := proc.(*GainProcessor)
 	require.True(t, ok, "Expected processor to be a *GainProcessor")
 	assert.Equal(t, "test-gain", gainProc.ID())
-	assert.Equal(t, 1.5, gainProc.GetGain())
+	assert.InDelta(t, 1.5, gainProc.GetGain(), 0.01)
 
 	// Invalid gain - too low
 	proc, err = NewGainProcessor("test", -1.0)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Nil(t, proc)
 
 	// Invalid gain - too high
 	proc, err = NewGainProcessor("test", 11.0)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Nil(t, proc)
 }
 
@@ -45,7 +45,7 @@ func TestGainProcessorProcess(t *testing.T) {
 		require.NoError(t, err)
 		
 		output, err := proc.Process(ctx, nil)
-		assert.Error(t, err)
+		require.Error(t, err)
 		assert.Nil(t, output)
 	})
 
@@ -67,7 +67,7 @@ func TestGainProcessorProcess(t *testing.T) {
 		}
 
 		output, err := proc.Process(ctx, input)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, input, output)
 	})
 
@@ -98,7 +98,7 @@ func TestGainProcessorProcess(t *testing.T) {
 		}
 
 		output, err := proc.Process(ctx, input)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		require.NotNil(t, output)
 
 		// Check output values
@@ -132,7 +132,7 @@ func TestGainProcessorProcess(t *testing.T) {
 		}
 
 		output, err := proc.Process(ctx, input)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		require.NotNil(t, output)
 
 		// Check clipping
@@ -165,7 +165,7 @@ func TestGainProcessorProcess(t *testing.T) {
 		}
 
 		output, err := proc.Process(ctx, input)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		require.NotNil(t, output)
 
 		// Check output values
@@ -198,12 +198,12 @@ func TestGainProcessorProcess(t *testing.T) {
 		}
 
 		output, err := proc.Process(ctx, input)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		require.NotNil(t, output)
 
 		// Check clipping to [-1.0, 1.0]
-		assert.Equal(t, float32(1.0), math.Float32frombits(binary.LittleEndian.Uint32(output.Buffer[0:4])))
-		assert.Equal(t, float32(-1.0), math.Float32frombits(binary.LittleEndian.Uint32(output.Buffer[4:8])))
+		assert.InDelta(t, float32(1.0), math.Float32frombits(binary.LittleEndian.Uint32(output.Buffer[0:4])), 0.01)
+		assert.InDelta(t, float32(-1.0), math.Float32frombits(binary.LittleEndian.Uint32(output.Buffer[4:8])), 0.01)
 	})
 
 	t.Run("Unsupported Encoding", func(t *testing.T) {
@@ -224,7 +224,7 @@ func TestGainProcessorProcess(t *testing.T) {
 		}
 
 		output, err := proc.Process(ctx, input)
-		assert.Error(t, err)
+		require.Error(t, err)
 		assert.Nil(t, output)
 	})
 
@@ -249,7 +249,7 @@ func TestGainProcessorProcess(t *testing.T) {
 		}
 
 		output, err := proc.Process(ctx, input)
-		assert.Error(t, err)
+		require.Error(t, err)
 		assert.Equal(t, context.Canceled, err)
 		assert.Nil(t, output)
 	})
@@ -265,18 +265,18 @@ func TestGainProcessorSetGain(t *testing.T) {
 
 	// Valid gain
 	err = gainProc.SetGain(1.5)
-	assert.NoError(t, err)
-	assert.Equal(t, 1.5, gainProc.GetGain())
+	require.NoError(t, err)
+	assert.InDelta(t, 1.5, gainProc.GetGain(), 0.01)
 
 	// Invalid gain - too low
 	err = gainProc.SetGain(-0.1)
-	assert.Error(t, err)
-	assert.Equal(t, 1.5, gainProc.GetGain()) // Should remain unchanged
+	require.Error(t, err)
+	assert.InDelta(t, 1.5, gainProc.GetGain(), 0.01) // Should remain unchanged
 
 	// Invalid gain - too high
 	err = gainProc.SetGain(10.1)
-	assert.Error(t, err)
-	assert.Equal(t, 1.5, gainProc.GetGain()) // Should remain unchanged
+	require.Error(t, err)
+	assert.InDelta(t, 1.5, gainProc.GetGain(), 0.01) // Should remain unchanged
 }
 
 func TestGainProcessorFormats(t *testing.T) {

--- a/internal/datastore/analytics_test.go
+++ b/internal/datastore/analytics_test.go
@@ -106,7 +106,7 @@ func TestGetSpeciesSummaryData(t *testing.T) {
 		assert.Equal(t, "amerob", robin.SpeciesCode)
 		assert.Equal(t, 2, robin.Count)
 		assert.InDelta(t, 0.875, robin.AvgConfidence, 0.001)
-		assert.Equal(t, 0.90, robin.MaxConfidence)
+		assert.InDelta(t, 0.90, robin.MaxConfidence, 0.01)
 
 		// Check Blue Jay summary (should have one species_code due to MAX aggregate)
 		blueJay := findSpeciesByScientificName(summaries, "Cyanocitta cristata")
@@ -115,7 +115,7 @@ func TestGetSpeciesSummaryData(t *testing.T) {
 		assert.Contains(t, []string{"blujay", "blujay1"}, blueJay.SpeciesCode) // MAX will pick one
 		assert.Equal(t, 2, blueJay.Count)
 		assert.InDelta(t, 0.775, blueJay.AvgConfidence, 0.001)
-		assert.Equal(t, 0.80, blueJay.MaxConfidence)
+		assert.InDelta(t, 0.80, blueJay.MaxConfidence, 0.01)
 
 		// Check Northern Cardinal summary
 		cardinal := findSpeciesByScientificName(summaries, "Cardinalis cardinalis") //nolint:misspell // This is the correct scientific name
@@ -123,8 +123,8 @@ func TestGetSpeciesSummaryData(t *testing.T) {
 		assert.Equal(t, "Northern Cardinal", cardinal.CommonName)
 		assert.Equal(t, "norcar", cardinal.SpeciesCode)
 		assert.Equal(t, 1, cardinal.Count)
-		assert.Equal(t, 0.95, cardinal.AvgConfidence)
-		assert.Equal(t, 0.95, cardinal.MaxConfidence)
+		assert.InDelta(t, 0.95, cardinal.AvgConfidence, 0.01)
+		assert.InDelta(t, 0.95, cardinal.MaxConfidence, 0.01)
 	})
 
 	t.Run("with start date filter", func(t *testing.T) {
@@ -229,7 +229,7 @@ func TestGetSpeciesSummaryData(t *testing.T) {
 		assert.Equal(t, "Poecile carolinensis", chickadee.ScientificName)
 		assert.Equal(t, 3, chickadee.Count)
 		assert.InDelta(t, 0.80, chickadee.AvgConfidence, 0.001)
-		assert.Equal(t, 0.90, chickadee.MaxConfidence)
+		assert.InDelta(t, 0.90, chickadee.MaxConfidence, 0.01)
 		// MAX() should pick one of the species codes
 		assert.Contains(t, []string{"carchi", "carchi2", "carchi3"}, chickadee.SpeciesCode)
 	})

--- a/internal/diskmanager/file_utils_test.go
+++ b/internal/diskmanager/file_utils_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestInvalidFileNameErrorMessages tests that the error messages for invalid file names are detailed
@@ -40,7 +41,7 @@ func TestInvalidFileNameErrorMessages(t *testing.T) {
 
 			// Call parseFileInfo and check the error message
 			_, err := parseFileInfo("/test/"+tc.filename, mockInfo)
-			assert.Error(t, err, "Should return an error for invalid file name")
+			require.Error(t, err, "Should return an error for invalid file name")
 			assert.Contains(t, err.Error(), tc.expectedErrText, "Error message should contain expected text")
 		})
 	}
@@ -57,10 +58,10 @@ func TestGetAudioFilesContinuesOnError(t *testing.T) {
 
 	// Create the files
 	err := os.WriteFile(validFile, []byte("test content"), 0o644) //nolint:gosec // G306: Test files don't require restrictive permissions
-	assert.NoError(t, err, "Should be able to create valid file")
+	require.NoError(t, err, "Should be able to create valid file")
 
 	err = os.WriteFile(invalidFile, []byte("test content"), 0o644) //nolint:gosec // G306: Test files don't require restrictive permissions
-	assert.NoError(t, err, "Should be able to create invalid file")
+	require.NoError(t, err, "Should be able to create invalid file")
 
 	// Create a mock DB
 	mockDB := &MockDB{}
@@ -69,7 +70,7 @@ func TestGetAudioFilesContinuesOnError(t *testing.T) {
 	files, err := GetAudioFiles(tempDir, allowedFileTypes, mockDB, true)
 
 	// Should not return an error as long as at least one file is valid
-	assert.NoError(t, err, "Should not return an error when at least one file is valid")
+	require.NoError(t, err, "Should not return an error when at least one file is valid")
 	assert.Len(t, files, 1, "Should return one valid file")
 	assert.Equal(t, "bubo_bubo", files[0].Species, "Should correctly parse the valid file")
 }
@@ -95,7 +96,7 @@ func TestGetAudioFilesWithMixedFiles(t *testing.T) {
 	// Create all the files
 	for _, file := range append(validFiles, invalidFiles...) {
 		err := os.WriteFile(file, []byte("test content"), 0o644) //nolint:gosec // G306: Test files don't require restrictive permissions
-		assert.NoError(t, err, "Should be able to create file: %s", file)
+		require.NoError(t, err, "Should be able to create file: %s", file)
 	}
 
 	// Create a mock DB
@@ -105,7 +106,7 @@ func TestGetAudioFilesWithMixedFiles(t *testing.T) {
 	files, err := GetAudioFiles(tempDir, allowedFileTypes, mockDB, true)
 
 	// Should not return an error as long as at least one file is valid
-	assert.NoError(t, err, "Should not return an error when at least one file is valid")
+	require.NoError(t, err, "Should not return an error when at least one file is valid")
 	assert.Len(t, files, len(validFiles), "Should return only the valid files")
 
 	// Verify that all valid files were processed correctly
@@ -124,16 +125,16 @@ func TestGetAudioFilesWithMixedFiles(t *testing.T) {
 		baseName := filepath.Base(file)
 		newPath := filepath.Join(invalidOnlyDir, baseName)
 		err := os.WriteFile(newPath, []byte("test content"), 0o644) //nolint:gosec // G306: Test files don't require restrictive permissions
-		assert.NoError(t, err, "Should be able to create file: %s", newPath)
+		require.NoError(t, err, "Should be able to create file: %s", newPath)
 	}
 
 	// Call GetAudioFiles with all invalid files
 	files, err = GetAudioFiles(invalidOnlyDir, allowedFileTypes, mockDB, true)
 
 	// Should return an error when all files are invalid
-	assert.Error(t, err, "Should return an error when all files are invalid")
+	require.Error(t, err, "Should return an error when all files are invalid")
 	assert.Contains(t, err.Error(), "diskmanager: failed to parse any audio files", "Error should indicate no valid files were found")
-	assert.Len(t, files, 0, "Should return no files when all are invalid")
+	assert.Empty(t, files, "Should return no files when all are invalid")
 }
 
 // TestGetDiskUsage tests that GetDiskUsage returns a valid disk usage percentage
@@ -145,7 +146,7 @@ func TestGetDiskUsage(t *testing.T) {
 	usage, err := GetDiskUsage(tempDir)
 
 	// Verify the return values
-	assert.NoError(t, err, "GetDiskUsage should not return an error")
+	require.NoError(t, err, "GetDiskUsage should not return an error")
 	assert.GreaterOrEqual(t, usage, 0.0, "Disk usage should be greater than or equal to 0%")
 	assert.LessOrEqual(t, usage, 100.0, "Disk usage should be less than or equal to 100%")
 }

--- a/internal/diskmanager/policy_age_test.go
+++ b/internal/diskmanager/policy_age_test.go
@@ -322,7 +322,7 @@ func TestAgeBasedCleanupReturnValues(t *testing.T) {
 		result := runTest(true)
 
 		// Verify return values (same checks as before)
-		assert.NoError(t, result.Err, "[KeepTrue] AgeBasedCleanup should not return an error")
+		require.NoError(t, result.Err, "[KeepTrue] AgeBasedCleanup should not return an error")
 		assert.Equal(t, 2, result.ClipsRemoved, "[KeepTrue] AgeBasedCleanup should remove 2 audio clips")
 		expectedDiskUtilization := 90 - (2 * 5)
 		assert.Equal(t, expectedDiskUtilization, result.DiskUtilization, "[KeepTrue] Incorrect disk utilization")
@@ -343,7 +343,7 @@ func TestAgeBasedCleanupReturnValues(t *testing.T) {
 		result := runTest(false)
 
 		// Verify return values (should be the same as KeepTrue)
-		assert.NoError(t, result.Err, "[KeepFalse] AgeBasedCleanup should not return an error")
+		require.NoError(t, result.Err, "[KeepFalse] AgeBasedCleanup should not return an error")
 		assert.Equal(t, 2, result.ClipsRemoved, "[KeepFalse] AgeBasedCleanup should remove 2 audio clips")
 		expectedDiskUtilization := 90 - (2 * 5)
 		assert.Equal(t, expectedDiskUtilization, result.DiskUtilization, "[KeepFalse] Incorrect disk utilization")
@@ -419,7 +419,7 @@ func TestAgeBasedCleanupMinClipsGlobal(t *testing.T) {
 	)
 
 	// --- Assertions --- Expected 2 deletions total (the 2 oldest bubo_bubo)
-	assert.NoError(t, result.Err, "Cleanup should not return an error")
+	require.NoError(t, result.Err, "Cleanup should not return an error")
 	assert.Equal(t, 2, result.ClipsRemoved, "Should remove 2 clips (oldest 2 of A), keeping 1 of A and 1 of B")
 	expectedDisk := initialDiskUtilization - (2 * utilizationReductionPerFile) // Only 2 deletions
 	assert.Equal(t, expectedDisk, result.DiskUtilization, "Incorrect final disk utilization")
@@ -484,7 +484,7 @@ func TestAgeBasedCleanupShortRetention(t *testing.T) {
 	)
 
 	// --- Assertions ---
-	assert.NoError(t, result.Err, "AgeBasedCleanup simulation should run without error")
+	require.NoError(t, result.Err, "AgeBasedCleanup simulation should run without error")
 	assert.Equal(t, 2, result.ClipsRemoved, "Should remove 2 clips (oldest bubo, old anas)")
 
 	// Verify file existence

--- a/internal/diskmanager/policy_usage_test.go
+++ b/internal/diskmanager/policy_usage_test.go
@@ -88,7 +88,7 @@ func TestFileTypesEligibleForDeletion(t *testing.T) {
 			fileInfo, err := parseFileInfo("/test/"+tc.filename, mockInfo)
 
 			if tc.eligibleForDeletion {
-				assert.NoError(t, err, "File should be eligible for deletion: %s", tc.description)
+				require.NoError(t, err, "File should be eligible for deletion: %s", tc.description)
 				assert.Equal(t, "bubo_bubo", fileInfo.Species, "Species should be correctly parsed")
 				assert.Equal(t, 80, fileInfo.Confidence, "Confidence should be correctly parsed")
 
@@ -148,7 +148,7 @@ func TestParseFileInfoWithDifferentExtensions(t *testing.T) {
 			fileInfo, err := parseFileInfo("/test/"+tc.filename, mockInfo)
 
 			if tc.shouldSucceed {
-				assert.NoError(t, err, "Should parse successfully")
+				require.NoError(t, err, "Should parse successfully")
 				assert.Equal(t, "bubo_bubo", fileInfo.Species)
 				assert.Equal(t, 80, fileInfo.Confidence)
 
@@ -173,7 +173,7 @@ func TestParseFileInfoMp3Extension(t *testing.T) {
 	fileInfo, err := parseFileInfo("/test/bubo_bubo_80p_20250130T184446Z.mp3", mockInfo)
 
 	// The bug would cause an error here because it only trims .wav extension
-	assert.NoError(t, err, "Should parse MP3 files correctly")
+	require.NoError(t, err, "Should parse MP3 files correctly")
 	assert.Equal(t, "bubo_bubo", fileInfo.Species)
 	assert.Equal(t, 80, fileInfo.Confidence)
 
@@ -240,7 +240,7 @@ func TestParseFileInfoProductionFormat(t *testing.T) {
 			fileInfo, err := parseFileInfo("/test/"+tc.filename, mockInfo)
 
 			if tc.shouldSucceed {
-				assert.NoError(t, err, "Should parse successfully: "+tc.description)
+				require.NoError(t, err, "Should parse successfully: "+tc.description)
 				assert.Equal(t, tc.expectedSpec, fileInfo.Species, "Species should be correctly parsed")
 				assert.Equal(t, tc.expectedConf, fileInfo.Confidence, "Confidence should be correctly parsed")
 
@@ -595,7 +595,7 @@ func TestUsageBasedCleanupWithAllFileTypes(t *testing.T) {
 	}
 
 	// Check that at least some file types were processed
-	assert.True(t, len(fileTypeProcessed) > 0, "Some files should have been deleted")
+	assert.NotEmpty(t, fileTypeProcessed, "Some files should have been deleted")
 
 	// Count how many bubo_bubo files were deleted to verify minClipsPerSpecies is respected
 	buboFilesDeleted := 0
@@ -806,7 +806,7 @@ func TestUsageBasedCleanupReturnValues(t *testing.T) {
 	expectedDiskUtilization := int(initialDiskUsage - (2 * diskUsageReductionPerFile))
 
 	// Verify the return values
-	assert.NoError(t, result.Err, "UsageBasedCleanup should not return an error")
+	require.NoError(t, result.Err, "UsageBasedCleanup should not return an error")
 	assert.Equal(t, 2, result.ClipsRemoved, "UsageBasedCleanup should remove 2 clips")
 	assert.Equal(t, expectedDiskUtilization, result.DiskUtilization,
 		"UsageBasedCleanup should return %d%% disk utilization", expectedDiskUtilization)
@@ -978,7 +978,7 @@ func TestUsageBasedCleanupBelowThreshold(t *testing.T) {
 	)
 
 	// Verify the return values
-	assert.NoError(t, result.Err, "UsageBasedCleanup should not return an error")
+	require.NoError(t, result.Err, "UsageBasedCleanup should not return an error")
 	assert.Equal(t, 0, result.ClipsRemoved, "UsageBasedCleanup should not remove any clips")
 	assert.Equal(t, int(initialDiskUsage), result.DiskUtilization,
 		"UsageBasedCleanup should return %d%% disk utilization", int(initialDiskUsage))
@@ -1053,7 +1053,7 @@ func TestUsageBasedCleanupLockedFiles(t *testing.T) {
 	expectedDiskUtilization := int(initialDiskUsage - (2 * diskUsageReductionPerFile))
 
 	// Verify the return values
-	assert.NoError(t, result.Err, "UsageBasedCleanup should not return an error")
+	require.NoError(t, result.Err, "UsageBasedCleanup should not return an error")
 	assert.Equal(t, 2, result.ClipsRemoved, "UsageBasedCleanup should remove 2 clips")
 	assert.Equal(t, expectedDiskUtilization, result.DiskUtilization,
 		"UsageBasedCleanup should return %d%% disk utilization", expectedDiskUtilization)

--- a/internal/monitor/critical_paths_test.go
+++ b/internal/monitor/critical_paths_test.go
@@ -168,7 +168,7 @@ func TestMergePaths(t *testing.T) {
 	}
 
 	// Should not have duplicates
-	assert.Equal(t, 4, len(merged), "Should have exactly 4 unique paths")
+	assert.Len(t, merged, 4, "Should have exactly 4 unique paths")
 }
 
 func TestSystemMonitorIntegration(t *testing.T) {

--- a/internal/myaudio/audio_conversion_test.go
+++ b/internal/myaudio/audio_conversion_test.go
@@ -132,10 +132,10 @@ func TestConvertToFloat32_AllBitDepths(t *testing.T) {
 			result, err := ConvertToFloat32(tt.input, tt.bitDepth)
 			
 			if tt.wantErr {
-				assert.Error(t, err)
+				require.Error(t, err)
 				assert.Nil(t, result)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.NotNil(t, result)
 				assert.Len(t, result, 1) // Should return single channel
 			}
@@ -188,7 +188,7 @@ func TestFloat32PoolIntegration(t *testing.T) {
 	finalStats := float32Pool.GetStats()
 	// sync.Pool behavior is non-deterministic and depends on GC pressure
 	// Just verify that the pool was used (had both hits and/or misses)
-	assert.Greater(t, finalStats.Hits+finalStats.Misses, uint64(0))
+	assert.Positive(t, finalStats.Hits+finalStats.Misses)
 }
 
 // TestConvert16BitToFloat32_NonStandardSize tests conversion with non-standard buffer sizes

--- a/internal/myaudio/buffer_pool_test.go
+++ b/internal/myaudio/buffer_pool_test.go
@@ -43,10 +43,10 @@ func TestNewBufferPool(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			pool, err := NewBufferPool(tt.size)
 			if tt.wantErr {
-				assert.Error(t, err)
+				require.Error(t, err)
 				assert.Nil(t, pool)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.NotNil(t, pool)
 				assert.Equal(t, tt.size, pool.size)
 			}
@@ -131,7 +131,7 @@ func TestBufferPoolConcurrency(t *testing.T) {
 			
 			for j := range opsPerWorker {
 				buf := pool.Get()
-				require.Len(t, buf, bufferSize)
+				assert.Len(t, buf, bufferSize)
 				
 				// Simulate some work with the buffer
 				buf[0] = byte(workerID)
@@ -173,7 +173,7 @@ func TestBufferPoolMemoryReuse(t *testing.T) {
 	// Verify stats show both hits and misses
 	stats := pool.GetStats()
 	// sync.Pool behavior is non-deterministic, so we just verify basic functionality
-	assert.Greater(t, stats.Misses, uint64(0)) // At least some allocations
+	assert.Positive(t, stats.Misses) // At least some allocations
 	// Don't assert on hits as sync.Pool may release buffers under memory pressure
 }
 
@@ -190,7 +190,7 @@ func TestBufferPoolClear(t *testing.T) {
 	}
 
 	initialStats := pool.GetStats()
-	assert.Greater(t, initialStats.Misses, uint64(0))
+	assert.Positive(t, initialStats.Misses)
 
 	// Clear the pool
 	pool.Clear()
@@ -265,8 +265,8 @@ func TestBufferPoolStress(t *testing.T) {
 	t.Logf("Hit rate: %.2f%%", float64(stats.Hits)/float64(stats.Hits+stats.Misses)*100)
 	t.Logf("Stats: %+v", stats)
 	
-	assert.Greater(t, ops, uint64(0))
+	assert.Positive(t, ops)
 	// Allow some variance due to sync.Pool's per-CPU sharding
 	assert.InDelta(t, float64(ops), float64(stats.Hits+stats.Misses), float64(numWorkers*2))
-	assert.Greater(t, stats.Hits, uint64(0)) // Should have some reuse
+	assert.Positive(t, stats.Hits) // Should have some reuse
 }

--- a/internal/myaudio/capture_buffer_lifecycle_test.go
+++ b/internal/myaudio/capture_buffer_lifecycle_test.go
@@ -33,12 +33,12 @@ func TestCaptureBufferSingleAllocation(t *testing.T) {
 
 			// Second allocation should fail
 			err = AllocateCaptureBuffer(tc.duration, tc.sampleRate, tc.bytesPerSample, tc.source)
-			assert.Error(t, err, "Second allocation should fail")
+			require.Error(t, err, "Second allocation should fail")
 			assert.Contains(t, err.Error(), "already exists")
 
 			// Using AllocateCaptureBufferIfNeeded should succeed without error
 			err = AllocateCaptureBufferIfNeeded(tc.duration, tc.sampleRate, tc.bytesPerSample, tc.source)
-			assert.NoError(t, err, "AllocateCaptureBufferIfNeeded should not error on existing buffer")
+			require.NoError(t, err, "AllocateCaptureBufferIfNeeded should not error on existing buffer")
 
 			// Clean up
 			err = RemoveCaptureBuffer(tc.source)
@@ -168,13 +168,13 @@ func TestBufferLifecycleWithErrors(t *testing.T) {
 			err := AllocateCaptureBuffer(tc.duration, tc.sampleRate, tc.bytesPerSample, tc.source)
 
 			if tc.expectError {
-				assert.Error(t, err)
+				require.Error(t, err)
 				assert.Contains(t, err.Error(), tc.errorContains)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				// Clean up successful allocation
 				err = RemoveCaptureBuffer(tc.source)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 		})
 	}
@@ -188,7 +188,7 @@ func TestInitCaptureBuffers(t *testing.T) {
 
 	// First initialization should succeed
 	err := InitCaptureBuffers(60, 48000, 2, sources)
-	assert.NoError(t, err, "Initial buffer initialization should succeed")
+	require.NoError(t, err, "Initial buffer initialization should succeed")
 
 	// Verify all buffers were created
 	for _, source := range sources {
@@ -197,7 +197,7 @@ func TestInitCaptureBuffers(t *testing.T) {
 
 	// Second initialization should also succeed (using AllocateCaptureBufferIfNeeded internally)
 	err = InitCaptureBuffers(60, 48000, 2, sources)
-	assert.NoError(t, err, "Repeated initialization should not error")
+	require.NoError(t, err, "Repeated initialization should not error")
 
 	// Verify buffers still exist
 	for _, source := range sources {

--- a/internal/myaudio/ffmpeg_manager_test.go
+++ b/internal/myaudio/ffmpeg_manager_test.go
@@ -23,11 +23,11 @@ func TestFFmpegManager_StartStop(t *testing.T) {
 
 	// Test starting a stream
 	err := manager.StartStream(url, transport, audioChan)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Test that we can't start the same stream twice
 	err = manager.StartStream(url, transport, audioChan)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "stream already exists")
 
 	// Verify stream is active
@@ -36,11 +36,11 @@ func TestFFmpegManager_StartStop(t *testing.T) {
 
 	// Test stopping the stream
 	err = manager.StopStream(url)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Test that we can't stop a non-existent stream
 	err = manager.StopStream(url)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no stream found")
 
 	// Verify stream is no longer active
@@ -77,7 +77,7 @@ func TestFFmpegManager_MultipleStreams(t *testing.T) {
 
 	// Stop one stream
 	err := manager.StopStream(urls[1])
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Verify correct streams remain
 	activeStreams = manager.GetActiveStreams()
@@ -103,7 +103,7 @@ func TestFFmpegManager_RestartStream(t *testing.T) {
 
 	// Test restarting the stream
 	err = manager.RestartStream(url)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Stream should still be active
 	activeStreams := manager.GetActiveStreams()
@@ -111,7 +111,7 @@ func TestFFmpegManager_RestartStream(t *testing.T) {
 
 	// Test restarting non-existent stream
 	err = manager.RestartStream("rtsp://nonexistent.example.com/stream")
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no stream found")
 }
 
@@ -188,7 +188,7 @@ func TestFFmpegManager_Shutdown(t *testing.T) {
 
 	// Verify no streams are active
 	activeStreams = manager.GetActiveStreams()
-	assert.Len(t, activeStreams, 0)
+	assert.Empty(t, activeStreams)
 
 	// Note: Starting new streams after shutdown might succeed
 	// The manager doesn't prevent new streams after shutdown in the current implementation
@@ -367,7 +367,7 @@ func TestFFmpegManager_ConcurrentStreamOperations(t *testing.T) {
 	health := manager.HealthCheck()
 	
 	// Health map should match active streams
-	assert.Equal(t, len(activeStreams), len(health))
+	assert.Len(t, health, len(activeStreams))
 	for _, url := range activeStreams {
 		_, exists := health[url]
 		assert.True(t, exists, "Health info should exist for active stream %s", url)
@@ -443,5 +443,5 @@ func TestFFmpegManager_StressTestWithHealthChecks(t *testing.T) {
 	// Verify final state
 	activeStreams := manager.GetActiveStreams()
 	health := manager.HealthCheck()
-	assert.Equal(t, len(activeStreams), len(health))
+	assert.Len(t, health, len(activeStreams))
 }

--- a/internal/myaudio/ffmpeg_stream_test.go
+++ b/internal/myaudio/ffmpeg_stream_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/conf"
 )
 
@@ -286,7 +287,7 @@ func TestFFmpegStream_HandleAudioData(t *testing.T) {
 	}
 	
 	err := stream.handleAudioData(testData)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	
 	// Check if data was sent to audio channel
 	select {
@@ -340,7 +341,7 @@ func TestFFmpegStream_DataRateCalculation(t *testing.T) {
 
 	// Calculate rate
 	rate, err := calc.getRate()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Greater(t, rate, 0.0)
 }
 
@@ -423,7 +424,7 @@ func TestFFmpegStream_ConcurrentHealthAndDataUpdates(t *testing.T) {
 	// Verify final state is consistent
 	health := stream.GetHealth()
 	assert.NotNil(t, health)
-	assert.Greater(t, health.TotalBytesReceived, int64(0))
+	assert.Positive(t, health.TotalBytesReceived)
 }
 
 func TestFFmpegStream_BackoffOverflowProtection(t *testing.T) {
@@ -571,7 +572,7 @@ func TestFFmpegStream_ValidateUserTimeout(t *testing.T) {
 			err := stream.validateUserTimeout(tt.timeoutStr)
 			
 			if tt.expectError {
-				assert.Error(t, err, "Expected error for timeout: %s", tt.timeoutStr)
+				require.Error(t, err, "Expected error for timeout: %s", tt.timeoutStr)
 				if tt.errorContains != "" {
 					assert.Contains(t, err.Error(), tt.errorContains, "Error should contain expected text")
 				}

--- a/internal/myaudio/float32_pool_test.go
+++ b/internal/myaudio/float32_pool_test.go
@@ -43,10 +43,10 @@ func TestNewFloat32Pool(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			pool, err := NewFloat32Pool(tt.size)
 			if tt.wantErr {
-				assert.Error(t, err)
+				require.Error(t, err)
 				assert.Nil(t, pool)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.NotNil(t, pool)
 				assert.Equal(t, tt.size, pool.size)
 			}
@@ -134,7 +134,7 @@ func TestFloat32PoolConcurrency(t *testing.T) {
 			
 			for j := range opsPerWorker {
 				buf := pool.Get()
-				require.Len(t, buf, bufferSize)
+				assert.Len(t, buf, bufferSize)
 				
 				// Simulate some work with the buffer
 				buf[0] = float32(workerID)
@@ -176,7 +176,7 @@ func TestFloat32PoolMemoryReuse(t *testing.T) {
 	// Verify stats show both hits and misses
 	stats := pool.GetStats()
 	// sync.Pool behavior is non-deterministic, so we just verify basic functionality
-	assert.Greater(t, stats.Misses, uint64(0)) // At least some allocations
+	assert.Positive(t, stats.Misses) // At least some allocations
 	// Don't assert on hits as sync.Pool may release buffers under memory pressure
 }
 
@@ -193,7 +193,7 @@ func TestFloat32PoolClear(t *testing.T) {
 	}
 
 	initialStats := pool.GetStats()
-	assert.Greater(t, initialStats.Misses, uint64(0))
+	assert.Positive(t, initialStats.Misses)
 
 	// Clear the pool
 	pool.Clear()
@@ -268,8 +268,8 @@ func TestFloat32PoolStress(t *testing.T) {
 	t.Logf("Hit rate: %.2f%%", float64(stats.Hits)/float64(stats.Hits+stats.Misses)*100)
 	t.Logf("Stats: %+v", stats)
 	
-	assert.Greater(t, ops, uint64(0))
+	assert.Positive(t, ops)
 	// Allow some variance due to sync.Pool's per-CPU sharding
 	assert.InDelta(t, float64(ops), float64(stats.Hits+stats.Misses), float64(numWorkers*2))
-	assert.Greater(t, stats.Hits, uint64(0)) // Should have some reuse
+	assert.Positive(t, stats.Hits) // Should have some reuse
 }

--- a/internal/myaudio/soundlevel_test.go
+++ b/internal/myaudio/soundlevel_test.go
@@ -135,7 +135,7 @@ func TestNewSoundLevelProcessor_BufferSizing(t *testing.T) {
 			require.NotNil(t, processor)
 
 			// Verify interval buffer is sized correctly
-			assert.Equal(t, tt.expectedBufferSize, len(processor.intervalBuffer.secondMeasurements),
+			assert.Len(t, processor.intervalBuffer.secondMeasurements, tt.expectedBufferSize,
 				"intervalBuffer should have space for %d second measurements", tt.expectedBufferSize)
 
 			// Verify each second measurement map is initialized
@@ -151,11 +151,11 @@ func TestNewSoundLevelProcessor_BufferSizing(t *testing.T) {
 					expectedFilters++
 				}
 			}
-			assert.Equal(t, expectedFilters, len(processor.filters),
+			assert.Len(t, processor.filters, expectedFilters,
 				"should have filters for all frequencies below Nyquist (%f Hz)", nyquistFreq)
 
 			// Verify second buffers are created for each filter
-			assert.Equal(t, len(processor.filters), len(processor.secondBuffers),
+			assert.Len(t, processor.secondBuffers, len(processor.filters),
 				"should have one second buffer per filter")
 
 			// Verify each second buffer is properly initialized
@@ -244,7 +244,7 @@ func TestSoundLevelProcessor_ThreadSafety(t *testing.T) {
 	wg.Wait()
 
 	// If we get here without panicking, thread safety is working
-	assert.True(t, true, "concurrent access should not cause panics")
+	// Test completed successfully if we reach this point without panics
 }
 
 
@@ -322,7 +322,7 @@ func TestProcessAudioData_IntervalCompletion(t *testing.T) {
 
 	// Process the 5th second - should now return data
 	result, err := processor.ProcessAudioData(oneSecondData)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, result, "should return data when interval completes")
 	
 	if result != nil {

--- a/internal/observability/metrics/myaudio_test.go
+++ b/internal/observability/metrics/myaudio_test.go
@@ -7,13 +7,14 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRecordAudioConversion(t *testing.T) {
 	// Create a new registry for testing
 	registry := prometheus.NewRegistry()
 	m, err := NewMyAudioMetrics(registry)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Test various bit depths
 	testCases := []struct {
@@ -42,7 +43,7 @@ func TestRecordAudioConversion(t *testing.T) {
 				strconv.Itoa(tc.bitDepth), // Updated implementation
 				tc.status,
 			))
-			assert.Equal(t, float64(1), count)
+			assert.InDelta(t, float64(1), count, 0.01)
 		})
 	}
 }
@@ -51,7 +52,7 @@ func TestRecordAudioConversionError(t *testing.T) {
 	// Create a new registry for testing
 	registry := prometheus.NewRegistry()
 	m, err := NewMyAudioMetrics(registry)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Test various error scenarios
 	testCases := []struct {
@@ -77,7 +78,7 @@ func TestRecordAudioConversionError(t *testing.T) {
 				strconv.Itoa(tc.bitDepth), // Updated implementation
 				tc.errorType,
 			))
-			assert.Equal(t, float64(1), count)
+			assert.InDelta(t, float64(1), count, 0.01)
 		})
 	}
 }
@@ -86,7 +87,7 @@ func TestRecordAudioConversionError(t *testing.T) {
 func BenchmarkRecordAudioConversion_FmtSprintf(b *testing.B) {
 	registry := prometheus.NewRegistry()
 	m, err := NewMyAudioMetrics(registry)
-	assert.NoError(b, err)
+	require.NoError(b, err)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -97,7 +98,7 @@ func BenchmarkRecordAudioConversion_FmtSprintf(b *testing.B) {
 func BenchmarkRecordAudioConversionError_FmtSprintf(b *testing.B) {
 	registry := prometheus.NewRegistry()
 	m, err := NewMyAudioMetrics(registry)
-	assert.NoError(b, err)
+	require.NoError(b, err)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -109,7 +110,7 @@ func TestRecordBufferAllocationAttempt(t *testing.T) {
 	// Create a new registry for testing
 	registry := prometheus.NewRegistry()
 	m, err := NewMyAudioMetrics(registry)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Test allocation attempt tracking scenarios
 	testCases := []struct {
@@ -136,7 +137,7 @@ func TestRecordBufferAllocationAttempt(t *testing.T) {
 				tc.source,
 				tc.result,
 			))
-			assert.Equal(t, tc.expected, count)
+			assert.InDelta(t, tc.expected, count, 0.01)
 		})
 	}
 	
@@ -158,16 +159,16 @@ func TestRecordBufferAllocationAttempt(t *testing.T) {
 		attemptedCount := testutil.ToFloat64(m.bufferAllocationAttempts.WithLabelValues(
 			"capture", source, "attempted",
 		))
-		assert.Equal(t, float64(4), attemptedCount, "Should have 4 attempted allocations")
+		assert.InDelta(t, float64(4), attemptedCount, 0.01, "Should have 4 attempted allocations")
 		
 		firstAllocCount := testutil.ToFloat64(m.bufferAllocationAttempts.WithLabelValues(
 			"capture", source, "first_allocation",
 		))
-		assert.Equal(t, float64(1), firstAllocCount, "Should have 1 successful first allocation")
+		assert.InDelta(t, float64(1), firstAllocCount, 0.01, "Should have 1 successful first allocation")
 		
 		blockedCount := testutil.ToFloat64(m.bufferAllocationAttempts.WithLabelValues(
 			"capture", source, "repeated_blocked",
 		))
-		assert.Equal(t, float64(3), blockedCount, "Should have 3 blocked repeated allocations")
+		assert.InDelta(t, float64(3), blockedCount, 0.01, "Should have 3 blocked repeated allocations")
 	})
 }

--- a/internal/observability/metrics/recorder_interface_test.go
+++ b/internal/observability/metrics/recorder_interface_test.go
@@ -35,12 +35,12 @@ func TestRecordDuration(t *testing.T) {
 
 	predDurations := recorder.GetDurations("prediction")
 	require.Len(t, predDurations, 2, "should have 2 prediction durations")
-	assert.Equal(t, 0.123, predDurations[0], "first prediction duration should be 0.123")
-	assert.Equal(t, 0.456, predDurations[1], "second prediction duration should be 0.456")
+	assert.InDelta(t, 0.123, predDurations[0], 0.01, "first prediction duration should be 0.123")
+	assert.InDelta(t, 0.456, predDurations[1], 0.01, "second prediction duration should be 0.456")
 
 	chunkDurations := recorder.GetDurations("chunk_process")
 	require.Len(t, chunkDurations, 1, "should have 1 chunk process duration")
-	assert.Equal(t, 0.789, chunkDurations[0], "chunk duration should be 0.789")
+	assert.InDelta(t, 0.789, chunkDurations[0], 0.01, "chunk duration should be 0.789")
 
 	// Test non-existent operation
 	durations := recorder.GetDurations("non_existent")
@@ -346,6 +346,6 @@ func TestRecorderUsageExample(t *testing.T) {
 
 	durations := testRecorder.GetDurations("work")
 	require.Len(t, durations, 1, "should have 1 duration recorded")
-	assert.Equal(t, simulatedDuration.Seconds(), durations[0], 
+	assert.InDelta(t, simulatedDuration.Seconds(), durations[0], 0.01, 
 		"recorded duration should match simulated duration")
 }

--- a/internal/support/collector_test.go
+++ b/internal/support/collector_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/privacy"
 )
 
@@ -490,7 +491,7 @@ func TestCollector_collectJournalLogs(t *testing.T) {
 		
 		// If journalctl is not available or service doesn't exist, we should get our sentinel error
 		if err != nil {
-			assert.ErrorIs(t, err, ErrJournalNotAvailable, "Expected ErrJournalNotAvailable when journal is not available")
+			require.ErrorIs(t, err, ErrJournalNotAvailable, "Expected ErrJournalNotAvailable when journal is not available")
 			assert.Nil(t, logs, "Expected nil logs when error is returned")
 		}
 		// If journalctl is available, logs might be returned or empty

--- a/internal/telemetry/system_init_manager_test.go
+++ b/internal/telemetry/system_init_manager_test.go
@@ -37,8 +37,8 @@ func TestSystemInitManager_ShutdownWithContext(t *testing.T) {
 		
 		// Shutdown should return context error immediately
 		err := manager.Shutdown(ctx)
-		assert.Error(t, err)
-		assert.Equal(t, context.DeadlineExceeded, err)
+		require.Error(t, err)
+		require.Equal(t, context.DeadlineExceeded, err)
 	})
 	
 	t.Run("Shutdown completes within timeout", func(t *testing.T) {
@@ -62,8 +62,8 @@ func TestSystemInitManager_ShutdownWithContext(t *testing.T) {
 		
 		// Shutdown should return context error
 		err := manager.Shutdown(ctx)
-		assert.Error(t, err)
-		assert.Equal(t, context.Canceled, err)
+		require.Error(t, err)
+		require.Equal(t, context.Canceled, err)
 	})
 }
 


### PR DESCRIPTION
## Summary
This PR resolves all linter errors in the BirdNET-Go codebase, achieving zero linter errors across the entire project.

## Changes Made

### 🔧 Fixed Linter Errors
- **3 gocritic errors**: Removed unnecessary code blocks in `internal/api/v2/detections_test.go`
- **100+ testifylint errors**: Systematically improved test assertions across all packages

### 🧪 Test Quality Improvements
- **require-error**: Changed `assert.NoError/Error` → `require.NoError/Error` for error assertions
- **float-compare**: Changed `assert.Equal` → `assert.InDelta` for float comparisons  
- **len**: Changed `assert.Equal(t, len, len(slice))` → `assert.Len(t, slice, len)`
- **empty**: Changed `assert.Len(t, slice, 0)` → `assert.Empty(t, slice)`
- **negative-positive**: Changed `assert.Greater(t, x, 0)` → `assert.Positive(t, x)`
- **bool-compare**: Changed `assert.Equal(t, true/false, x)` → `assert.True/False(t, x)`

### 📁 Files Modified (37 total)
- `internal/api/v2/` - All test files
- `internal/security/` - persistence_test.go
- `internal/analysis/` - All test files
- `internal/audiocore/` - All test files
- `internal/diskmanager/` - All test files
- `internal/myaudio/` - All test files
- `internal/monitor/` - critical_paths_test.go
- `internal/datastore/` - analytics_test.go
- `internal/observability/` - All test files
- `internal/support/` - collector_test.go
- `internal/telemetry/` - All test files

## Test plan
- [x] All existing tests pass
- [x] Linter runs clean with zero errors (`golangci-lint run`)
- [x] No functionality broken
- [x] Test reliability improved with better assertion patterns

## Benefits
- **Zero linter errors** across entire codebase
- **Improved test reliability** by using `require` for critical assertions
- **Better test semantics** with specific assertion methods
- **Follows Go testing best practices**

🤖 Generated with [Claude Code](https://claude.ai/code)