### PR TITLE
Fix hanging tests in internal/api/v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -70,6 +70,7 @@ require (
 	go.opentelemetry.io/otel v1.36.0 // indirect
 	go.opentelemetry.io/otel/metric v1.36.0 // indirect
 	go.opentelemetry.io/otel/trace v1.36.0 // indirect
+	go.uber.org/goleak v1.3.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250603155806-513f23925822 // indirect
 	google.golang.org/grpc v1.73.0 // indirect
 )

--- a/internal/api/v2/api_goroutine_test.go
+++ b/internal/api/v2/api_goroutine_test.go
@@ -1,0 +1,114 @@
+// api_goroutine_test.go: Tests for verifying goroutine cleanup in API v2
+
+package api
+
+import (
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/observability"
+)
+
+// TestControllerShutdownCleansUpGoroutines verifies that background goroutines
+// are properly cleaned up when the controller is shut down
+func TestControllerShutdownCleansUpGoroutines(t *testing.T) {
+	// Get baseline goroutine count before creating controller
+	runtime.GC() // Force GC to clean up any lingering goroutines
+	time.Sleep(100 * time.Millisecond) // Give time for cleanup
+	baselineCount := runtime.NumGoroutine()
+
+	// Create Echo instance
+	e := echo.New()
+
+	// Create mock datastore
+	mockDS := new(MockDataStore)
+
+	// Create settings with required paths
+	settings := &conf.Settings{
+		WebServer: conf.WebServerSettings{
+			Debug: true,
+		},
+		Realtime: conf.RealtimeSettings{
+			Audio: conf.AudioSettings{
+				Export: conf.ExportSettings{
+					Path: t.TempDir(),
+				},
+			},
+		},
+	}
+
+	// Create control channel
+	controlChan := make(chan string, 10)
+
+	// Create mock metrics
+	mockMetrics, _ := observability.NewMetrics()
+
+	// Create controller WITH route initialization to start background goroutines
+	controller, err := NewWithOptions(e, mockDS, settings, nil, nil, controlChan, nil, nil, mockMetrics, true)
+	require.NoError(t, err)
+
+	// Wait for goroutines to start
+	time.Sleep(200 * time.Millisecond)
+
+	// Get count with controller running
+	runningCount := runtime.NumGoroutine()
+	
+	// Should have more goroutines than baseline (CPU monitoring, support cleanup, cache janitors, etc.)
+	assert.Greater(t, runningCount, baselineCount, "Should have started background goroutines")
+
+	// Shutdown the controller
+	controller.Shutdown()
+
+	// Wait for goroutines to terminate
+	time.Sleep(500 * time.Millisecond)
+
+	// Force GC again to clean up
+	runtime.GC()
+	time.Sleep(100 * time.Millisecond)
+
+	// Get final count
+	finalCount := runtime.NumGoroutine()
+
+	// Should be back close to baseline (may have a few extra from the test framework itself)
+	// Allow some tolerance as the exact count can vary
+	tolerance := 5
+	assert.LessOrEqual(t, finalCount, baselineCount+tolerance, 
+		"Goroutine count after shutdown should be close to baseline. Baseline: %d, Final: %d", 
+		baselineCount, finalCount)
+
+	// The important check is that we have fewer goroutines than when running
+	assert.Less(t, finalCount, runningCount, 
+		"Should have fewer goroutines after shutdown. Running: %d, Final: %d",
+		runningCount, finalCount)
+}
+
+// TestGoroutineCleanupWithoutRoutes verifies that creating a controller without
+// routes doesn't start unnecessary goroutines
+func TestGoroutineCleanupWithoutRoutes(t *testing.T) {
+	// Get baseline goroutine count
+	runtime.GC()
+	time.Sleep(100 * time.Millisecond)
+	baselineCount := runtime.NumGoroutine()
+
+	// Setup test environment (which uses NewWithOptions with initializeRoutes=false)
+	_, _, controller := setupTestEnvironment(t)
+
+	// Wait a bit to ensure no goroutines are starting
+	time.Sleep(200 * time.Millisecond)
+
+	// Get count with controller
+	withControllerCount := runtime.NumGoroutine()
+
+	// Should not have significantly more goroutines (just the cache janitor)
+	// Allow for some variance due to test framework
+	assert.LessOrEqual(t, withControllerCount, baselineCount+3, 
+		"Should not start many goroutines without route initialization")
+
+	// Cleanup
+	controller.Shutdown()
+}

--- a/internal/api/v2/support.go
+++ b/internal/api/v2/support.go
@@ -232,7 +232,11 @@ func (c *Controller) initSupportRoutes() {
 
 	// Start cleanup goroutine for old support dumps with proper context
 	if c.ctx != nil {
-		go c.startSupportDumpCleanup(c.ctx)
+		c.wg.Add(1)
+		go func() {
+			defer c.wg.Done()
+			c.startSupportDumpCleanup(c.ctx)
+		}()
 	}
 }
 

--- a/internal/api/v2/system.go
+++ b/internal/api/v2/system.go
@@ -277,7 +277,11 @@ func (c *Controller) initSystemRoutes() {
 	}
 
 	// Start CPU usage monitoring in background with controller's context for controlled shutdown
-	go UpdateCPUCache(c.ctx)
+	c.wg.Add(1)
+	go func() {
+		defer c.wg.Done()
+		UpdateCPUCache(c.ctx)
+	}()
 
 	if c.apiLogger != nil {
 		c.apiLogger.Info("Started CPU usage monitoring")

--- a/internal/api/v2/test_utils.go
+++ b/internal/api/v2/test_utils.go
@@ -670,6 +670,7 @@ func setupTestEnvironment(t *testing.T) (*echo.Echo, *MockDataStore, *Controller
 	sunCalc := &suncalc.SunCalc{}
 
 	// Create control channel with buffer to prevent blocking in tests
+	// Size 10 is sufficient for concurrent test scenarios (e.g., TestConcurrentControlRequests uses 5)
 	controlChan := make(chan string, 10)
 
 	// Create mock metrics for testing

--- a/internal/api/v2/test_utils.go
+++ b/internal/api/v2/test_utils.go
@@ -669,14 +669,14 @@ func setupTestEnvironment(t *testing.T) (*echo.Echo, *MockDataStore, *Controller
 	// Mock the sun calculator constructor
 	sunCalc := &suncalc.SunCalc{}
 
-	// Create control channel
-	controlChan := make(chan string)
+	// Create control channel with buffer to prevent blocking in tests
+	controlChan := make(chan string, 10)
 
 	// Create mock metrics for testing
 	mockMetrics, _ := observability.NewMetrics()
 
-	// Create API controller
-	controller, err := New(e, mockDS, settings, birdImageCache, sunCalc, controlChan, logger, nil, mockMetrics)
+	// Create API controller without initializing routes to avoid starting background goroutines
+	controller, err := NewWithOptions(e, mockDS, settings, birdImageCache, sunCalc, controlChan, logger, nil, mockMetrics, false)
 	if err != nil {
 		t.Fatalf("Failed to create test API controller: %v", err)
 	}


### PR DESCRIPTION
## Summary

This PR fixes the hanging test issues in the API v2 package that were causing test timeouts. The root cause was background goroutines that weren't properly cleaned up during test execution.

## Problem

When running tests in `./internal/api/v2/`, several tests would hang indefinitely due to:
- Background goroutines started during route initialization that continued running after tests completed
- The test process couldn't exit cleanly because these goroutines were still active
- Tests would eventually timeout after 30 seconds with goroutine stack traces

## Root Cause Analysis

The issue was traced to two main background goroutines:

1. **CPU monitoring goroutine** (`system.go`):
   - Started in `initSystemRoutes()` with `go UpdateCPUCache(ctx)`
   - Used its own context created with `context.WithCancel(context.Background())`
   - Stored cancel function in global variable `cpuMonitorCancel`

2. **Support dump cleanup goroutine** (`support.go`):
   - Started in `initSupportRoutes()` with `go c.startSupportDumpCleanup(c.ctx)`
   - Used controller's context but was started during route initialization

## Solution

### 1. Added Optional Route Initialization

Created `NewWithOptions()` function that allows creating controllers without initializing routes:

```go
func NewWithOptions(e *echo.Echo, ds datastore.Interface, settings *conf.Settings,
    birdImageCache *imageprovider.BirdImageCache, sunCalc *suncalc.SunCalc,
    controlChan chan string, logger *log.Logger, oauth2Server *security.OAuth2Server,
    metrics *observability.Metrics, initializeRoutes bool) (*Controller, error)
```

This prevents tests from starting unnecessary background goroutines.

### 2. Fixed CPU Monitoring Goroutine Management

- Removed global `cpuMonitorCancel` variable and `StopCPUMonitoring()` function
- Changed CPU monitoring to use controller's context: `go UpdateCPUCache(c.ctx)`
- Now properly shuts down when controller's context is cancelled

### 3. Improved Test Setup

- Updated `setupTestEnvironment()` to use `NewWithOptions()` with `initializeRoutes=false`
- Changed control channel from unbuffered to buffered (size 10) to prevent blocking
- Existing `t.Cleanup()` properly shuts down controller and cancels context

### 4. Updated Test Expectations

- Fixed test assertions to expect success (200) instead of timeout (408) with buffered channels
- Updated test helper functions to work with the new setup

## Testing

✅ All tests in `./internal/api/v2/...` now pass successfully
✅ No more hanging or timeout issues
✅ Proper cleanup of all goroutines
✅ Linter passes with 0 issues

## Test Results

```bash
$ go test -v -timeout 30s ./internal/api/v2/...
...
PASS
ok      github.com/tphakala/birdnet-go/internal/api/v2 1.389s
?       github.com/tphakala/birdnet-go/internal/api/v2/auth    [no test files]
```

## Benefits

1. **Reliable test execution** - Tests complete without hanging
2. **Proper resource management** - All goroutines terminate correctly
3. **Better test isolation** - Tests don't start unnecessary background processes
4. **Cleaner code** - Removed global state and improved lifecycle management
5. **Maintainable** - Clear separation between production and test initialization

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved controller creation flexibility by allowing optional route initialization.
  * Simplified shutdown process and removed explicit CPU monitoring stop.
  * Streamlined CPU monitoring to run within controller lifecycle.
* **Tests**
  * Updated test setup to prevent blocking and avoid starting background processes.
  * Enhanced control channel handling for more reliable and flexible testing.
  * Added tests verifying proper goroutine cleanup during controller shutdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->