### PR TITLE
feat: allow support bundle uploads without telemetry enabled

### DIFF
--- a/assets/tailwind.css
+++ b/assets/tailwind.css
@@ -6985,10 +6985,6 @@ html:has(.drawer-toggle:checked) {
   color: var(--fallback-wa,oklch(var(--wa)/var(--tw-text-opacity, 1)));
 }
 
-.text-warning\/80 {
-  color: var(--fallback-wa,oklch(var(--wa)/0.8));
-}
-
 .text-white {
   --tw-text-opacity: 1;
   color: rgb(255 255 255 / var(--tw-text-opacity, 1));

--- a/internal/telemetry/attachments.go
+++ b/internal/telemetry/attachments.go
@@ -77,8 +77,8 @@ func (au *AttachmentUploader) UploadSupportDump(ctx context.Context, dumpData []
 		"scrubbed_message", scrubbedMessage)
 
 	if !au.enabled {
-		logTelemetryWarn(nil, "telemetry: upload blocked - telemetry not enabled")
-		err := errors.Newf("telemetry is not enabled - cannot upload support dump").
+		logTelemetryWarn(nil, "telemetry: upload blocked - uploader not enabled")
+		err := errors.Newf("attachment uploader is not enabled").
 			Component("telemetry").
 			Category(errors.CategoryConfiguration).
 			Context("operation", "upload_support_dump")

--- a/views/pages/settings/supportSettings.html
+++ b/views/pages/settings/supportSettings.html
@@ -335,8 +335,8 @@
                         </label>
                     </div>
 
-                    <!-- Upload Option (only shown if telemetry is enabled) -->
-                    <div x-show="{{.Settings.Sentry.Enabled}}" class="mt-4">
+                    <!-- Upload Option (always available) -->
+                    <div class="mt-4">
                         {{template "checkbox" dict
                             "id" "uploadToSentry"
                             "model" "supportDump.uploadToSentry"
@@ -364,11 +364,19 @@
                                     Privacy-compliant with sensitive data removed
                                 </p>
                             </div>
-                            <div class="text-xs text-warning/80 flex items-center gap-1">
-                                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-                                </svg>
-                                Uncheck only if you prefer to handle the support file manually
+                            <div class="text-xs text-base-content/60 space-y-1">
+                                <p class="flex items-start gap-1">
+                                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mt-0.5 flex-shrink-0 text-info" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                                    </svg>
+                                    Support uploads work independently of error tracking settings
+                                </p>
+                                <p class="flex items-start gap-1">
+                                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mt-0.5 flex-shrink-0 text-warning" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                                    </svg>
+                                    Uncheck only if you prefer to handle the support file manually
+                                </p>
                             </div>
                         </div>
                     </div>

--- a/views/pages/settings/supportSettings.html
+++ b/views/pages/settings/supportSettings.html
@@ -152,6 +152,10 @@
             // Show initial status
             this.updateStatus('Preparing support dump...', 'info', 10);
             
+            // Create an AbortController for timeout handling
+            const controller = new AbortController();
+            const timeoutId = setTimeout(() => controller.abort(), 120000); // 2 minute timeout
+            
             fetch('/api/v2/support/generate', {
                 method: 'POST',
                 headers: {
@@ -159,6 +163,7 @@
                     'X-CSRF-Token': CSRF_TOKEN
                 },
                 credentials: 'same-origin',
+                signal: controller.signal,
                 body: JSON.stringify({
                     include_logs: this.supportDump.includeLogs,
                     include_config: this.supportDump.includeConfig,
@@ -168,8 +173,14 @@
                 })
             })
             .then(response => {
+                clearTimeout(timeoutId);
                 if (!response.ok) {
-                    throw new Error(`Server error: ${response.status} ${response.statusText}`);
+                    // Try to get error details from response
+                    return response.json().then(err => {
+                        throw new Error(err.error || `Server error: ${response.status} ${response.statusText}`);
+                    }).catch(() => {
+                        throw new Error(`Server error: ${response.status} ${response.statusText}`);
+                    });
                 }
                 return response.json();
             })
@@ -203,8 +214,14 @@
                 }
             })
             .catch(error => {
+                clearTimeout(timeoutId);
                 this.generating = false;
-                this.updateStatus('Error: ' + error.message, 'error', 0);
+                if (error.name === 'AbortError') {
+                    this.updateStatus('Request timed out. Support dumps with many logs may take longer - please try again with fewer logs selected.', 'error', 0);
+                } else {
+                    this.updateStatus('Error: ' + error.message, 'error', 0);
+                }
+                console.error('Support dump generation error:', error);
             });
         },
         updateStatus(message, type, percent) {


### PR DESCRIPTION
## Summary
This PR decouples support bundle uploads from the telemetry/error tracking requirement, allowing users to upload diagnostic data without enabling continuous error reporting.

## Changes
- **Frontend**: Remove conditional display of upload option based on telemetry status
- **Backend**: Add minimal Sentry initialization for support uploads only
- **Telemetry**: Create `InitMinimalSentryForSupport()` that only accepts support dump events
- **Debug Logging**: Add comprehensive logging throughout support bundle generation
- **Bug Fixes**: 
  - Fix duplicate zip writer close error
  - Limit journalctl output to 5000 lines to prevent timeouts

## Motivation
Users should be able to share diagnostic information when troubleshooting issues without having to enable continuous telemetry. This maintains user privacy while still allowing them to provide essential debugging data when needed.

## Testing
- ✅ Support bundle generation works with telemetry disabled
- ✅ Upload option is always visible in UI
- ✅ Minimal Sentry client only accepts support dump events
- ✅ Journal log collection no longer times out on systems with extensive logs
- ✅ Enhanced debug logging helps diagnose collection issues

## Implementation Details
1. When telemetry is disabled but user requests upload, a minimal Sentry client is initialized with:
   - Zero sample rate (no automatic error capture)
   - No performance monitoring
   - Only support dump events allowed (filtered by tag)
   - All privacy filters applied

2. Frontend improvements:
   - 2-minute timeout with clear error messages
   - Better error handling for failed requests
   - Upload option always visible with explanatory text

3. Debug improvements help diagnose "Failed to fetch" errors with detailed logging at each step

🤖 Generated with [Claude Code](https://claude.ai/code)