### PR TITLE
fix: add required JSON body to BirdWeather integration tests

### DIFF
--- a/internal/api/v2/integrations_test.go
+++ b/internal/api/v2/integrations_test.go
@@ -546,8 +546,16 @@ func TestErrorHandlingForIntegrations(t *testing.T) {
 		controller.Settings.Realtime.Birdweather.Enabled = true
 		controller.Settings.Realtime.Birdweather.ID = "INVALID_ID"
 
-		// Create a test HTTP request
-		req := httptest.NewRequest(http.MethodPost, "/api/v2/integrations/birdweather/test", http.NoBody)
+		// Create JSON request body for BirdWeather test
+		requestBody := `{
+			"enabled": true,
+			"id": "INVALID_ID",
+			"threshold": 0.8,
+			"locationAccuracy": 50.0,
+			"debug": false
+		}`
+		req := httptest.NewRequest(http.MethodPost, "/api/v2/integrations/birdweather/test", strings.NewReader(requestBody))
+		req.Header.Set("Content-Type", "application/json")
 		rec := httptest.NewRecorder()
 		c := e.NewContext(req, rec)
 
@@ -601,8 +609,16 @@ func TestErrorHandlingForIntegrations(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		// Create a test HTTP request with the cancellable context
-		req := httptest.NewRequest(http.MethodPost, "/api/v2/integrations/birdweather/test", http.NoBody).WithContext(ctx)
+		// Create JSON request body for BirdWeather test
+		requestBody := `{
+			"enabled": true,
+			"id": "VALID_ID",
+			"threshold": 0.8,
+			"locationAccuracy": 50.0,
+			"debug": false
+		}`
+		req := httptest.NewRequest(http.MethodPost, "/api/v2/integrations/birdweather/test", strings.NewReader(requestBody)).WithContext(ctx)
+		req.Header.Set("Content-Type", "application/json")
 		rec := httptest.NewRecorder()
 		c := e.NewContext(req, rec)
 


### PR DESCRIPTION
## Summary
- Fixed failing integration tests that were sending empty POST requests to BirdWeather test endpoint
- Added proper JSON request bodies with required configuration parameters
- Added application/json Content-Type headers to BirdWeather test requests

## Test plan
- [x] Run integration tests multiple times to verify consistency
- [x] All tests in TestErrorHandlingForIntegrations now pass
- [x] golangci-lint passes with 0 issues
- [x] No regression in other test suites

🤖 Generated with [Claude Code](https://claude.ai/code)