### PR TITLE
fix: resolve API v2 test failures due to improper SunCalc initialization

### DIFF
--- a/internal/api/v2/detections_test.go
+++ b/internal/api/v2/detections_test.go
@@ -354,6 +354,7 @@ func TestGetDetection(t *testing.T) {
 			detectionID: "1",
 			mockSetup: func(m *mock.Mock) {
 				m.On("Get", "1").Return(mockNote, nil)
+				m.On("GetHourlyWeather", "2025-03-07").Return([]datastore.HourlyWeather{}, nil)
 			},
 			expectedStatus: http.StatusOK,
 			checkResponse: func(t *testing.T, rec *httptest.ResponseRecorder) {

--- a/internal/api/v2/test_utils.go
+++ b/internal/api/v2/test_utils.go
@@ -674,8 +674,8 @@ func setupTestEnvironment(t *testing.T) (*echo.Echo, *MockDataStore, *Controller
 	}
 	birdImageCache.SetImageProvider(mockImageProvider)
 
-	// Mock the sun calculator constructor
-	sunCalc := &suncalc.SunCalc{}
+	// Create sun calculator with test coordinates (Helsinki, Finland)
+	sunCalc := suncalc.NewSunCalc(60.1699, 24.9384)
 
 	// Create control channel with buffer to prevent blocking in tests
 	// Size 10 is sufficient for concurrent test scenarios (e.g., TestConcurrentControlRequests uses 5)


### PR DESCRIPTION
## Summary
- Fixes API v2 test panic: "assignment to entry in nil map" in SunCalc.GetSunEventTimes
- Resolves missing mock expectation for GetHourlyWeather in detection tests
- All internal/api/v2 tests now pass successfully

## Root Cause Analysis
The `setupTestEnvironment` function in `test_utils.go` was creating SunCalc incorrectly:
```go
sunCalc := &suncalc.SunCalc{}  // Wrong - nil cache map
```

This bypassed the proper constructor which initializes the cache map:
```go
sunCalc := suncalc.NewSunCalc(latitude, longitude)  // Correct
```

## Changes Made
1. **Fixed SunCalc initialization**: Use `suncalc.NewSunCalc(60.1699, 24.9384)` with Helsinki coordinates
2. **Added missing mock**: Include `GetHourlyWeather` expectation in `TestGetDetection`

## Test Results
- All API v2 tests now pass: ✅
- Linter passes with 0 issues: ✅
- Race condition testing enabled: ✅

## Test Plan
- [x] Run `go test -race -v ./internal/api/v2/...` - all tests pass
- [x] Run `golangci-lint run -v` - no issues
- [x] Verify no regression in other test suites

🤖 Generated with [Claude Code](https://claude.ai/code)