### PR TITLE
feat: implement detection list freeze during AudioPlayer playback

### DIFF
--- a/frontend/src/lib/desktop/components/media/AudioPlayer.svelte
+++ b/frontend/src/lib/desktop/components/media/AudioPlayer.svelte
@@ -50,9 +50,9 @@
     spectrogramSize?: SpectrogramSize;
     /** Display raw spectrogram without axes and legends */
     spectrogramRaw?: boolean;
-    /** Callback fired when audio starts playing (freezes detection updates) */
+    /** Fired when audio playback starts - freezes detection updates */
     onPlayStart?: () => void;
-    /** Callback fired when audio stops playing after delay (resumes detection updates) */
+    /** Fired 3 seconds after audio stops - resumes detection updates */
     onPlayEnd?: () => void;
   }
 

--- a/frontend/src/lib/desktop/features/dashboard/components/RecentDetectionsCard.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/components/RecentDetectionsCard.svelte
@@ -24,9 +24,9 @@
     onLimitChange?: (limit: number) => void;
     newDetectionIds?: Set<number>;
     detectionArrivalTimes?: Map<number, number>;
-    onMenuOpen?: () => void;
-    onMenuClose?: () => void;
-    hasOpenMenus?: boolean;
+    onFreezeStart?: () => void;
+    onFreezeEnd?: () => void;
+    updatesAreFrozen?: boolean;
   }
 
   let {
@@ -39,9 +39,9 @@
     onLimitChange,
     newDetectionIds = new Set(),
     detectionArrivalTimes: _detectionArrivalTimes = new Map(), // Reserved for future staggered animations
-    onMenuOpen,
-    onMenuClose,
-    hasOpenMenus = false,
+    onFreezeStart,
+    onFreezeEnd,
+    updatesAreFrozen = false,
   }: Props = $props();
 
   // State for number of detections to show
@@ -222,10 +222,10 @@
         <button
           onclick={onRefresh}
           class="btn btn-sm btn-ghost"
-          class:opacity-50={hasOpenMenus}
-          disabled={loading || hasOpenMenus}
-          title={hasOpenMenus
-            ? 'Refresh paused while menu is open'
+          class:opacity-50={updatesAreFrozen}
+          disabled={loading || updatesAreFrozen}
+          title={updatesAreFrozen
+            ? 'Refresh paused while interaction is active'
             : t('dashboard.recentDetections.controls.refresh')}
           aria-label={t('dashboard.recentDetections.controls.refresh')}
         >
@@ -337,6 +337,8 @@
                     spectrogramSize="sm"
                     spectrogramRaw={true}
                     className="w-full"
+                    onPlayStart={onFreezeStart}
+                    onPlayEnd={onFreezeEnd}
                   />
                 </div>
               </div>
@@ -350,8 +352,8 @@
                   onToggleSpecies={() => handleToggleSpecies(detection)}
                   onToggleLock={() => handleToggleLock(detection)}
                   onDelete={() => handleDelete(detection)}
-                  {onMenuOpen}
-                  {onMenuClose}
+                  onMenuOpen={onFreezeStart}
+                  onMenuClose={onFreezeEnd}
                 />
               </div>
             </div>

--- a/frontend/src/lib/desktop/features/dashboard/pages/DashboardPage.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/pages/DashboardPage.svelte
@@ -41,8 +41,8 @@
   let newDetectionIds = $state(new Set<number>());
   let detectionArrivalTimes = $state(new Map<number, number>());
 
-  // Menu state tracking to prevent SSE updates during menu interactions
-  let openMenuCount = $state(0);
+  // Update freeze tracking to prevent SSE updates during user interactions (menus, audio playback, etc.)
+  let freezeCount = $state(0);
   let pendingDetectionQueue = $state<Detection[]>([]);
 
   // Debouncing for rapid daily summary updates
@@ -214,10 +214,10 @@
   let eventSource: ReconnectingEventSource | null = null;
   let connectionStatus = $state<'connecting' | 'connected' | 'error' | 'polling'>('connecting');
 
-  // Process new detection from SSE - queue if menus are open, otherwise process immediately
+  // Process new detection from SSE - queue if updates are frozen, otherwise process immediately
   function handleNewDetection(detection: Detection) {
-    // If any action menus are open, queue the detection for later processing
-    if (openMenuCount > 0) {
+    // If any interactions are active (menus, audio playback), queue the detection for later processing
+    if (freezeCount > 0) {
       // Avoid duplicate detections in queue - add null-safety check
       const isDuplicate = pendingDetectionQueue.some(pending => 
         pending?.id != null && detection?.id != null && pending.id === detection.id
@@ -228,7 +228,7 @@
       return;
     }
 
-    // Process immediately if no menus are open
+    // Process immediately if no interactions are active
     processDetectionUpdate(detection);
   }
 
@@ -614,18 +614,21 @@
     }
   }
 
-  // Menu state management
-  function handleMenuOpen() {
-    openMenuCount++;
+  // Update freeze state management
+  function handleFreezeStart() {
+    freezeCount++;
+    console.log(`Dashboard: freeze started, count now: ${freezeCount}`);
   }
 
-  function handleMenuClose() {
-    openMenuCount--;
+  function handleFreezeEnd() {
+    freezeCount--;
     // Clamp to prevent negative values due to unmount edge cases
-    openMenuCount = Math.max(0, openMenuCount);
+    freezeCount = Math.max(0, freezeCount);
+    console.log(`Dashboard: freeze ended, count now: ${freezeCount}`);
     
-    // Process pending detections when all menus are closed
-    if (openMenuCount === 0 && pendingDetectionQueue.length > 0) {
+    // Process pending detections when all interactions are complete
+    if (freezeCount === 0 && pendingDetectionQueue.length > 0) {
+      console.log(`Dashboard: processing ${pendingDetectionQueue.length} pending detections`);
       // Process all pending detections
       pendingDetectionQueue.forEach(detection => {
         processDetectionUpdate(detection);
@@ -679,8 +682,8 @@
     onRefresh={handleManualRefresh}
     {newDetectionIds}
     {detectionArrivalTimes}
-    onMenuOpen={handleMenuOpen}
-    onMenuClose={handleMenuClose}
-    hasOpenMenus={openMenuCount > 0}
+    onFreezeStart={handleFreezeStart}
+    onFreezeEnd={handleFreezeEnd}
+    updatesAreFrozen={freezeCount > 0}
   />
 </div>

--- a/frontend/src/lib/desktop/features/dashboard/pages/DashboardPage.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/pages/DashboardPage.svelte
@@ -617,18 +617,15 @@
   // Update freeze state management
   function handleFreezeStart() {
     freezeCount++;
-    console.log(`Dashboard: freeze started, count now: ${freezeCount}`);
   }
 
   function handleFreezeEnd() {
     freezeCount--;
     // Clamp to prevent negative values due to unmount edge cases
     freezeCount = Math.max(0, freezeCount);
-    console.log(`Dashboard: freeze ended, count now: ${freezeCount}`);
     
     // Process pending detections when all interactions are complete
     if (freezeCount === 0 && pendingDetectionQueue.length > 0) {
-      console.log(`Dashboard: processing ${pendingDetectionQueue.length} pending detections`);
       // Process all pending detections
       pendingDetectionQueue.forEach(detection => {
         processDetectionUpdate(detection);


### PR DESCRIPTION
## Summary
- Prevents SSE updates from disrupting audio playback by freezing detection list updates during AudioPlayer usage
- Adds 3-second delay after audio stops before resuming updates to avoid jarring UI changes
- Extends existing ActionMenu freeze mechanism to work with AudioPlayer

## Changes
- **AudioPlayer.svelte**: Added `onPlayStart` and `onPlayEnd` callback props with 3-second delay timeout
- **RecentDetectionsCard.svelte**: Connected AudioPlayer to freeze system via callback props
- **DashboardPage.svelte**: Renamed freeze state management from "menu" to "freeze" terminology for consistency

## Test Plan
- [ ] Play audio in recent detections - list should freeze during playback
- [ ] Pause/stop audio - list should remain frozen for 3 seconds then resume updates
- [ ] Verify ActionMenu freeze still works correctly
- [ ] Test that pending detections are queued and processed after freeze ends

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Audio playback now temporarily pauses live updates to prevent UI disruptions, resuming updates shortly after playback ends or is paused.
  * Added new options for responsive sizing and spectrogram display in the audio player.

* **Improvements**
  * User interactions such as opening menus or playing audio now consistently pause live updates, providing a smoother experience.
  * Enhanced tooltips and refresh button behavior to reflect when updates are paused due to active interactions.

* **Bug Fixes**
  * Prevented rapid toggling of updates during brief pauses in audio playback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->