### PR TITLE
fix: preserve range filter settings during coordinate updates

### DIFF
--- a/frontend/src/lib/desktop/features/settings/pages/MainSettingsPage.range.test.ts
+++ b/frontend/src/lib/desktop/features/settings/pages/MainSettingsPage.range.test.ts
@@ -1,0 +1,307 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { get } from 'svelte/store';
+import { settingsStore, settingsActions } from '$lib/stores/settings';
+import type { BirdNetSettings } from '$lib/stores/settings';
+
+// Mock API module
+vi.mock('$lib/utils/api', () => ({
+  api: {
+    get: vi.fn(),
+    post: vi.fn(),
+  },
+  ApiError: class ApiError extends Error {
+    status: number;
+    data?: any;
+    constructor(message: string, status: number, data?: any) {
+      super(message);
+      this.status = status;
+      this.data = data;
+    }
+  },
+}));
+
+// Mock toast actions
+vi.mock('$lib/stores/toast', () => ({
+  toastActions: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+const { api } = await import('$lib/utils/api');
+
+describe('Settings Store - Range Filter Dynamic Updates', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Initialize store with complete settings
+    settingsStore.set({
+      formData: {
+        main: { name: 'TestNode' },
+        birdnet: {
+          modelPath: '',
+          labelPath: '',
+          sensitivity: 1.0,
+          threshold: 0.8,
+          overlap: 0.0,
+          locale: 'en',
+          threads: 4,
+          latitude: 40.7128,
+          longitude: -74.006,
+          dynamicThreshold: {
+            enabled: false,
+            debug: false,
+            trigger: 0.8,
+            min: 0.3,
+            validHours: 24,
+          },
+          rangeFilter: {
+            model: 'latest',
+            threshold: 0.03,
+            speciesCount: null,
+            species: [],
+          },
+          database: {
+            type: 'sqlite',
+            path: 'birds.db',
+            host: '',
+            port: 3306,
+            name: '',
+            username: '',
+            password: '',
+          },
+        },
+      },
+      originalData: {} as any,
+      isLoading: false,
+      isSaving: false,
+      activeSection: 'main',
+      error: null,
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should trigger range filter test when coordinates change', async () => {
+    // Verify initial state
+    const initialState = get(settingsStore);
+    expect(initialState.formData.birdnet?.latitude).toBe(40.7128);
+    expect(initialState.formData.birdnet?.longitude).toBe(-74.006);
+
+    // Update coordinates
+    settingsActions.updateSection('birdnet', {
+      latitude: 51.5074,
+      longitude: -0.1278,
+    });
+
+    // Verify coordinates were updated in the store
+    const updatedState = get(settingsStore);
+    expect(updatedState.formData.birdnet?.latitude).toBe(51.5074);
+    expect(updatedState.formData.birdnet?.longitude).toBe(-0.1278);
+
+    // Verify range filter settings were preserved
+    expect(updatedState.formData.birdnet?.rangeFilter.model).toBe('latest');
+    expect(updatedState.formData.birdnet?.rangeFilter.threshold).toBe(0.03);
+  });
+
+  it('should trigger range filter test when threshold changes', async () => {
+    // Update range filter threshold
+    settingsActions.updateSection('birdnet', {
+      rangeFilter: {
+        model: 'latest',
+        threshold: 0.05,
+        speciesCount: null,
+        species: [],
+      },
+    });
+
+    // Verify threshold was updated
+    const updatedState = get(settingsStore);
+    expect(updatedState.formData.birdnet?.rangeFilter.threshold).toBe(0.05);
+
+    // Verify coordinates were preserved
+    expect(updatedState.formData.birdnet?.latitude).toBe(40.7128);
+    expect(updatedState.formData.birdnet?.longitude).toBe(-74.006);
+  });
+
+  it('should trigger range filter test when model changes', async () => {
+    // Update range filter model
+    settingsActions.updateSection('birdnet', {
+      rangeFilter: {
+        model: 'legacy',
+        threshold: 0.03,
+        speciesCount: null,
+        species: [],
+      },
+    });
+
+    // Verify model was updated
+    const updatedState = get(settingsStore);
+    expect(updatedState.formData.birdnet?.rangeFilter.model).toBe('legacy');
+
+    // Verify other settings were preserved
+    expect(updatedState.formData.birdnet?.rangeFilter.threshold).toBe(0.03);
+    expect(updatedState.formData.birdnet?.latitude).toBe(40.7128);
+    expect(updatedState.formData.birdnet?.longitude).toBe(-74.006);
+  });
+
+  it('should handle multiple sequential updates correctly', async () => {
+    // Update coordinates
+    settingsActions.updateSection('birdnet', {
+      latitude: 48.8566,
+      longitude: 2.3522,
+    });
+
+    // Update range filter threshold
+    settingsActions.updateSection('birdnet', {
+      rangeFilter: {
+        model: 'latest',
+        threshold: 0.04,
+        speciesCount: null,
+        species: [],
+      },
+    });
+
+    // Update range filter model
+    settingsActions.updateSection('birdnet', {
+      rangeFilter: {
+        model: 'legacy',
+        threshold: 0.04,
+        speciesCount: null,
+        species: [],
+      },
+    });
+
+    // Verify all updates were applied
+    const finalState = get(settingsStore);
+    const birdnet = finalState.formData.birdnet as BirdNetSettings;
+
+    expect(birdnet.latitude).toBe(48.8566);
+    expect(birdnet.longitude).toBe(2.3522);
+    expect(birdnet.rangeFilter.model).toBe('legacy');
+    expect(birdnet.rangeFilter.threshold).toBe(0.04);
+  });
+
+  it('should not lose range filter data during coordinate updates', async () => {
+    // Set initial range filter with custom values
+    settingsActions.updateSection('birdnet', {
+      rangeFilter: {
+        model: 'latest' as any, // Testing with a different value
+        threshold: 0.1,
+        speciesCount: 250,
+        species: ['species1', 'species2'],
+      },
+    });
+
+    // Verify initial range filter state
+    const initialState = get(settingsStore);
+    expect(initialState.formData.birdnet?.rangeFilter.model).toBe('latest');
+    expect(initialState.formData.birdnet?.rangeFilter.threshold).toBe(0.1);
+    expect(initialState.formData.birdnet?.rangeFilter.speciesCount).toBe(250);
+    expect(initialState.formData.birdnet?.rangeFilter.species).toEqual(['species1', 'species2']);
+
+    // Update only coordinates
+    settingsActions.updateSection('birdnet', {
+      latitude: 35.6762,
+      longitude: 139.6503,
+    });
+
+    // Verify range filter data was preserved
+    const updatedState = get(settingsStore);
+    const birdnet = updatedState.formData.birdnet as BirdNetSettings;
+
+    expect(birdnet.latitude).toBe(35.6762);
+    expect(birdnet.longitude).toBe(139.6503);
+    expect(birdnet.rangeFilter.model).toBe('latest');
+    expect(birdnet.rangeFilter.threshold).toBe(0.1);
+    expect(birdnet.rangeFilter.speciesCount).toBe(250);
+    expect(birdnet.rangeFilter.species).toEqual(['species1', 'species2']);
+  });
+
+  it('should preserve other birdnet settings during range filter updates', async () => {
+    // Get initial values
+    const initialState = get(settingsStore);
+    const initialSensitivity = initialState.formData.birdnet?.sensitivity;
+    const initialThreshold = initialState.formData.birdnet?.threshold;
+
+    // Update range filter
+    settingsActions.updateSection('birdnet', {
+      rangeFilter: {
+        model: 'legacy' as any, // Testing update
+        threshold: 0.08,
+        speciesCount: null,
+        species: [],
+      },
+    });
+
+    // Verify only range filter changed
+    const updatedState = get(settingsStore);
+    const birdnet = updatedState.formData.birdnet as BirdNetSettings;
+
+    expect(birdnet.rangeFilter.model).toBe('legacy');
+    expect(birdnet.rangeFilter.threshold).toBe(0.08);
+    expect(birdnet.sensitivity).toBe(initialSensitivity);
+    expect(birdnet.threshold).toBe(initialThreshold);
+    expect(birdnet.locale).toBe('en');
+    expect(birdnet.threads).toBe(4);
+  });
+
+  it('should track changes that should trigger range filter updates', async () => {
+    // Track which values change
+    const changes = {
+      latitude: false,
+      longitude: false,
+      threshold: false,
+      model: false,
+    };
+
+    // Update latitude
+    settingsActions.updateSection('birdnet', {
+      latitude: 51.5074,
+    });
+    changes.latitude = true;
+    expect(changes).toEqual({ latitude: true, longitude: false, threshold: false, model: false });
+
+    // Update longitude
+    settingsActions.updateSection('birdnet', {
+      longitude: -0.1278,
+    });
+    changes.longitude = true;
+    expect(changes).toEqual({ latitude: true, longitude: true, threshold: false, model: false });
+
+    // Update range filter threshold
+    settingsActions.updateSection('birdnet', {
+      rangeFilter: {
+        model: 'latest',
+        threshold: 0.05,
+        speciesCount: null,
+        species: [],
+      },
+    });
+    changes.threshold = true;
+    expect(changes).toEqual({ latitude: true, longitude: true, threshold: true, model: false });
+
+    // Update range filter model
+    settingsActions.updateSection('birdnet', {
+      rangeFilter: {
+        model: 'legacy',
+        threshold: 0.05,
+        speciesCount: null,
+        species: [],
+      },
+    });
+    changes.model = true;
+    expect(changes).toEqual({ latitude: true, longitude: true, threshold: true, model: true });
+
+    // Verify final state has all changes
+    const finalState = get(settingsStore);
+    const birdnet = finalState.formData.birdnet as BirdNetSettings;
+
+    expect(birdnet.latitude).toBe(51.5074);
+    expect(birdnet.longitude).toBe(-0.1278);
+    expect(birdnet.rangeFilter.threshold).toBe(0.05);
+    expect(birdnet.rangeFilter.model).toBe('legacy');
+  });
+});

--- a/internal/api/v2/settings_merge_test.go
+++ b/internal/api/v2/settings_merge_test.go
@@ -32,10 +32,11 @@ func TestMergeJSONIntoStruct(t *testing.T) {
 				"longitude": -0.1278
 			}`,
 			validate: func(t *testing.T, result conf.BirdNETConfig) {
-				assert.Equal(t, 51.5074, result.Latitude)
-				assert.Equal(t, -0.1278, result.Longitude)
+				t.Helper()
+				assert.InDelta(t, 51.5074, result.Latitude, 0.0001)
+				assert.InDelta(t, -0.1278, result.Longitude, 0.0001)
 				assert.Equal(t, "latest", result.RangeFilter.Model)
-				assert.Equal(t, float32(0.03), result.RangeFilter.Threshold)
+				assert.InDelta(t, float32(0.03), result.RangeFilter.Threshold, 0.0001)
 			},
 		},
 		{
@@ -54,10 +55,11 @@ func TestMergeJSONIntoStruct(t *testing.T) {
 				}
 			}`,
 			validate: func(t *testing.T, result conf.BirdNETConfig) {
-				assert.Equal(t, 40.7128, result.Latitude)
-				assert.Equal(t, -74.0060, result.Longitude)
+				t.Helper()
+				assert.InDelta(t, 40.7128, result.Latitude, 0.0001)
+				assert.InDelta(t, -74.0060, result.Longitude, 0.0001)
 				assert.Equal(t, "latest", result.RangeFilter.Model)
-				assert.Equal(t, float32(0.05), result.RangeFilter.Threshold)
+				assert.InDelta(t, float32(0.05), result.RangeFilter.Threshold, 0.0001)
 			},
 		},
 		{
@@ -81,12 +83,13 @@ func TestMergeJSONIntoStruct(t *testing.T) {
 				}
 			}`,
 			validate: func(t *testing.T, result conf.BirdNETConfig) {
-				assert.Equal(t, 48.8566, result.Latitude)
-				assert.Equal(t, 2.3522, result.Longitude)
-				assert.Equal(t, 1.2, result.Sensitivity)
-				assert.Equal(t, 0.8, result.Threshold) // Should be preserved
+				t.Helper()
+				assert.InDelta(t, 48.8566, result.Latitude, 0.0001)
+				assert.InDelta(t, 2.3522, result.Longitude, 0.0001)
+				assert.InDelta(t, 1.2, result.Sensitivity, 0.0001)
+				assert.InDelta(t, 0.8, result.Threshold, 0.0001) // Should be preserved
 				assert.Equal(t, "latest", result.RangeFilter.Model)
-				assert.Equal(t, float32(0.02), result.RangeFilter.Threshold) // Should be preserved
+				assert.InDelta(t, float32(0.02), result.RangeFilter.Threshold, 0.0001) // Should be preserved
 			},
 		},
 	}

--- a/internal/api/v2/settings_merge_test.go
+++ b/internal/api/v2/settings_merge_test.go
@@ -1,0 +1,205 @@
+package api
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/conf"
+)
+
+// TestMergeJSONIntoStruct tests the mergeJSONIntoStruct function
+func TestMergeJSONIntoStruct(t *testing.T) {
+	tests := []struct {
+		name     string
+		initial  conf.BirdNETConfig
+		update   string
+		validate func(t *testing.T, result conf.BirdNETConfig)
+	}{
+		{
+			name: "Update coordinates preserves range filter",
+			initial: conf.BirdNETConfig{
+				Latitude:  40.7128,
+				Longitude: -74.0060,
+				RangeFilter: conf.RangeFilterSettings{
+					Model:     "latest",
+					Threshold: 0.03,
+				},
+			},
+			update: `{
+				"latitude": 51.5074,
+				"longitude": -0.1278
+			}`,
+			validate: func(t *testing.T, result conf.BirdNETConfig) {
+				assert.Equal(t, 51.5074, result.Latitude)
+				assert.Equal(t, -0.1278, result.Longitude)
+				assert.Equal(t, "latest", result.RangeFilter.Model)
+				assert.Equal(t, float32(0.03), result.RangeFilter.Threshold)
+			},
+		},
+		{
+			name: "Update range filter threshold preserves other fields",
+			initial: conf.BirdNETConfig{
+				Latitude:  40.7128,
+				Longitude: -74.0060,
+				RangeFilter: conf.RangeFilterSettings{
+					Model:     "latest",
+					Threshold: 0.03,
+				},
+			},
+			update: `{
+				"rangeFilter": {
+					"threshold": 0.05
+				}
+			}`,
+			validate: func(t *testing.T, result conf.BirdNETConfig) {
+				assert.Equal(t, 40.7128, result.Latitude)
+				assert.Equal(t, -74.0060, result.Longitude)
+				assert.Equal(t, "latest", result.RangeFilter.Model)
+				assert.Equal(t, float32(0.05), result.RangeFilter.Threshold)
+			},
+		},
+		{
+			name: "Complex update with nested partial objects",
+			initial: conf.BirdNETConfig{
+				Latitude:    40.7128,
+				Longitude:   -74.0060,
+				Sensitivity: 1.0,
+				Threshold:   0.8,
+				RangeFilter: conf.RangeFilterSettings{
+					Model:     "legacy",
+					Threshold: 0.02,
+				},
+			},
+			update: `{
+				"latitude": 48.8566,
+				"longitude": 2.3522,
+				"sensitivity": 1.2,
+				"rangeFilter": {
+					"model": "latest"
+				}
+			}`,
+			validate: func(t *testing.T, result conf.BirdNETConfig) {
+				assert.Equal(t, 48.8566, result.Latitude)
+				assert.Equal(t, 2.3522, result.Longitude)
+				assert.Equal(t, 1.2, result.Sensitivity)
+				assert.Equal(t, 0.8, result.Threshold) // Should be preserved
+				assert.Equal(t, "latest", result.RangeFilter.Model)
+				assert.Equal(t, float32(0.02), result.RangeFilter.Threshold) // Should be preserved
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Make a copy of initial settings
+			result := tt.initial
+
+			// Apply the merge
+			err := mergeJSONIntoStruct(json.RawMessage(tt.update), &result)
+			require.NoError(t, err)
+
+			// Validate the result
+			tt.validate(t, result)
+		})
+	}
+}
+
+// TestDeepMergeMaps tests the deep merge functionality
+func TestDeepMergeMaps(t *testing.T) {
+	tests := []struct {
+		name     string
+		dst      map[string]interface{}
+		src      map[string]interface{}
+		expected map[string]interface{}
+	}{
+		{
+			name: "Simple merge",
+			dst: map[string]interface{}{
+				"a": 1,
+				"b": 2,
+			},
+			src: map[string]interface{}{
+				"b": 3,
+				"c": 4,
+			},
+			expected: map[string]interface{}{
+				"a": 1,
+				"b": 3,
+				"c": 4,
+			},
+		},
+		{
+			name: "Nested merge",
+			dst: map[string]interface{}{
+				"top": map[string]interface{}{
+					"a": 1,
+					"b": 2,
+				},
+			},
+			src: map[string]interface{}{
+				"top": map[string]interface{}{
+					"b": 3,
+					"c": 4,
+				},
+			},
+			expected: map[string]interface{}{
+				"top": map[string]interface{}{
+					"a": 1,
+					"b": 3,
+					"c": 4,
+				},
+			},
+		},
+		{
+			name: "Preserve unmodified nested objects",
+			dst: map[string]interface{}{
+				"settings": map[string]interface{}{
+					"rangeFilter": map[string]interface{}{
+						"model":     "latest",
+						"threshold": 0.03,
+					},
+					"latitude": 40.0,
+				},
+			},
+			src: map[string]interface{}{
+				"settings": map[string]interface{}{
+					"latitude": 50.0,
+				},
+			},
+			expected: map[string]interface{}{
+				"settings": map[string]interface{}{
+					"rangeFilter": map[string]interface{}{
+						"model":     "latest",
+						"threshold": 0.03,
+					},
+					"latitude": 50.0,
+				},
+			},
+		},
+		{
+			name: "Handle nil values",
+			dst: map[string]interface{}{
+				"a": 1,
+				"b": 2,
+			},
+			src: map[string]interface{}{
+				"b": nil,
+				"c": 3,
+			},
+			expected: map[string]interface{}{
+				"a": 1,
+				"b": nil,
+				"c": 3,
+			},
+		},
+	}
+	
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := deepMergeMaps(tt.dst, tt.src)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Fixed range filter settings (model, threshold) being lost when updating coordinates
- Fixed species count not updating dynamically when settings change
- Fixed z-index issue with map showing in front of species list modal

## Problem
When updating coordinates in the BirdNET-Go settings UI, the range filter settings (model and threshold) were being reset to default values. Additionally, the species count wasn't updating reactively when these settings changed.

## Solution
### Backend
- Implemented `mergeJSONIntoStruct` and `deepMergeMaps` helper functions to properly merge partial updates
- Modified `handleBirdnetSection` to use the merge approach instead of direct JSON unmarshal
- This preserves existing nested fields when only partial data is sent from the frontend

### Frontend  
- Updated the `$effect` in MainSettingsPage.svelte to properly track all reactive dependencies
- Modified API calls to include the model parameter
- Fixed z-index issue by setting modal to `z-index: 9999`

## Test Plan
- [x] Added backend tests in `settings_merge_test.go` to verify partial updates preserve nested fields
- [x] Added frontend tests in `MainSettingsPage.range.test.ts` to verify settings preservation
- [x] Manually tested coordinate updates preserve range filter settings
- [x] Manually tested species count updates when changing threshold/model
- [x] Verified modal appears above map

Fixes #1030

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved settings update behavior to preserve existing range filter and nested BirdNET settings during partial updates.
  * Added support for specifying the BirdNET model in range filter species tests and species list loading.

* **Bug Fixes**
  * Fixed issue where range filter data could be lost when updating coordinates or other BirdNET settings.
  * Ensured UI shows a loading state after a failed range filter species test.

* **Style**
  * Updated modal dialog styling for better layering and interaction.

* **Tests**
  * Added comprehensive tests for dynamic updates to range filter and BirdNET settings.
  * Introduced tests for configuration merging logic to ensure data integrity during partial updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->