### PR TITLE
fix: resolve dashboard LRU cache initialization error

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -96,6 +96,41 @@ npm run test:a11y:watch   # Watch accessibility tests during development
 - Component type mismatches
 - Accessibility violations
 
+## TypeScript Best Practices
+
+**CRITICAL: Never bypass TypeScript's type checking system**
+
+- **❌ FORBIDDEN**: Using `any` type without proper justification and eslint-disable comment
+- **❌ FORBIDDEN**: Using type assertions (`as Type`) to bypass proper type safety
+- **❌ FORBIDDEN**: Using non-null assertions (`!`) without absolute certainty
+- **✅ REQUIRED**: Use proper type guards, conditional checks, and iterator validation
+- **✅ REQUIRED**: Handle undefined/null cases explicitly with proper checks
+- **✅ REQUIRED**: Use TypeScript's strict mode and compiler checks as intended
+
+**Examples:**
+
+```typescript
+// ❌ Bad: Type assertion bypasses safety
+const value = map.get(key) as string;
+
+// ❌ Bad: Non-null assertion without verification  
+const value = map.get(key)!;
+
+// ✅ Good: Proper type checking and iterator validation
+const result = iterator.next();
+if (!result.done && result.value !== undefined) {
+  // Safe to use result.value
+}
+
+// ✅ Good: Explicit null/undefined handling
+const value = map.get(key);
+if (value !== undefined) {
+  // Safe to use value
+}
+```
+
+TypeScript's type system exists to prevent runtime errors. Bypassing it defeats the purpose and introduces potential bugs.
+
 ## Development Tools
 
 ### UI Screenshots & Testing

--- a/frontend/src/lib/utils/LRUCache.ts
+++ b/frontend/src/lib/utils/LRUCache.ts
@@ -15,7 +15,8 @@ export class LRUCache<K, V> {
     if (!this.cache.has(key)) return undefined;
 
     // Move to end (most recently used)
-    const value = this.cache.get(key) as V;
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- Key existence already verified above
+    const value = this.cache.get(key)!;
     this.cache.delete(key);
     this.cache.set(key, value);
     return value;
@@ -27,9 +28,9 @@ export class LRUCache<K, V> {
       this.cache.delete(key);
     } else if (this.cache.size >= this.maxSize) {
       // Remove least recently used (first item)
-      const firstKey = this.cache.keys().next().value as K;
-      if (firstKey !== undefined) {
-        this.cache.delete(firstKey);
+      const firstKeyResult = this.cache.keys().next();
+      if (!firstKeyResult.done && firstKeyResult.value !== undefined) {
+        this.cache.delete(firstKeyResult.value);
       }
     }
 

--- a/frontend/src/lib/utils/LRUCache.ts
+++ b/frontend/src/lib/utils/LRUCache.ts
@@ -15,13 +15,10 @@ export class LRUCache<K, V> {
     if (!this.cache.has(key)) return undefined;
 
     // Move to end (most recently used)
-    const value = this.cache.get(key);
-    if (value !== undefined) {
-      this.cache.delete(key);
-      this.cache.set(key, value);
-      return value;
-    }
-    return undefined;
+    const value = this.cache.get(key) as V;
+    this.cache.delete(key);
+    this.cache.set(key, value);
+    return value;
   }
 
   set(key: K, value: V): void {

--- a/frontend/src/lib/utils/LRUCache.ts
+++ b/frontend/src/lib/utils/LRUCache.ts
@@ -1,0 +1,54 @@
+/**
+ * Simple LRU (Least Recently Used) cache implementation
+ * @template K - The type of the cache keys
+ * @template V - The type of the cache values
+ */
+export class LRUCache<K, V> {
+  private readonly cache: Map<K, V> = new Map();
+  private readonly maxSize: number;
+
+  constructor(maxSize: number) {
+    this.maxSize = maxSize;
+  }
+
+  get(key: K): V | undefined {
+    if (!this.cache.has(key)) return undefined;
+
+    // Move to end (most recently used)
+    const value = this.cache.get(key);
+    if (value !== undefined) {
+      this.cache.delete(key);
+      this.cache.set(key, value);
+      return value;
+    }
+    return undefined;
+  }
+
+  set(key: K, value: V): void {
+    // If key exists, delete it to update position
+    if (this.cache.has(key)) {
+      this.cache.delete(key);
+    } else if (this.cache.size >= this.maxSize) {
+      // Remove least recently used (first item)
+      const firstKey = this.cache.keys().next().value as K;
+      if (firstKey !== undefined) {
+        this.cache.delete(firstKey);
+      }
+    }
+
+    // Add to end (most recently used)
+    this.cache.set(key, value);
+  }
+
+  has(key: K): boolean {
+    return this.cache.has(key);
+  }
+
+  clear(): void {
+    this.cache.clear();
+  }
+
+  get size(): number {
+    return this.cache.size;
+  }
+}


### PR DESCRIPTION
## Summary
- Fixes "Cannot access 'A' before initialization" error in dashboard
- Extracts LRUCache class to separate utility module for better code organization

## Changes
- Created new `LRUCache` utility class in `src/lib/utils/LRUCache.ts`
- Removed duplicate inline LRUCache class from `DailySummaryCard.svelte`
- Added proper import for LRUCache in DailySummaryCard.svelte
- Marked cache property as readonly to satisfy ESLint requirements

## Test plan
- [x] Frontend builds successfully without TypeScript errors
- [x] Dashboard page loads without JavaScript initialization errors
- [x] LRU cache functionality preserved for sun times caching

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved code maintainability by replacing a local cache implementation with a shared, centralized caching utility. No changes to user-facing behavior.
* **Documentation**
  * Added a new section on TypeScript best practices emphasizing strict type checking and safe coding patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->