### PR TITLE
fix: resolve image provider round-robin bug

### DIFF
--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -1119,6 +1119,44 @@ func SetTestSettings(settings *Settings) {
 	once = sync.Once{}
 }
 
+// GetTestSettings returns a copy of default settings suitable for testing.
+// This creates isolated settings that won't affect the global configuration.
+func GetTestSettings() *Settings {
+	settings := &Settings{}
+	
+	// Initialize with defaults
+	settings.Debug = false
+	settings.Main.Name = "BirdNET-Go-Test"
+	settings.Main.TimeAs24h = true
+	
+	// Set up minimal test configuration
+	settings.BirdNET.Sensitivity = 1.0
+	settings.BirdNET.Threshold = 0.8
+	settings.BirdNET.Overlap = 0.0
+	settings.BirdNET.Locale = "en"
+	
+	// Dashboard settings with thumbnails
+	settings.Realtime.Dashboard.Thumbnails.Debug = false
+	settings.Realtime.Dashboard.Thumbnails.Summary = false
+	settings.Realtime.Dashboard.Thumbnails.Recent = true
+	settings.Realtime.Dashboard.Thumbnails.ImageProvider = "avicommons"
+	settings.Realtime.Dashboard.Thumbnails.FallbackPolicy = "none"
+	
+	// Other realtime settings
+	settings.Realtime.Interval = 15
+	settings.Realtime.ProcessingTime = false
+	
+	// Web server settings
+	settings.WebServer.Enabled = false
+	settings.WebServer.Port = "8080"
+	
+	// Output settings
+	settings.Output.SQLite.Enabled = false
+	settings.Output.SQLite.Path = ":memory:"
+	
+	return settings
+}
+
 // Note: SendValidationWarningsAsNotifications function removed as it was unused
 
 // SaveYAMLConfig updates the YAML configuration file with new settings.

--- a/internal/conf/defaults.go
+++ b/internal/conf/defaults.go
@@ -79,8 +79,8 @@ func setDefaultConfig() {
 	viper.SetDefault("realtime.dashboard.thumbnails.debug", false)
 	viper.SetDefault("realtime.dashboard.thumbnails.summary", false)
 	viper.SetDefault("realtime.dashboard.thumbnails.recent", true)
-	viper.SetDefault("realtime.dashboard.thumbnails.imageprovider", "auto")
-	viper.SetDefault("realtime.dashboard.thumbnails.fallbackpolicy", "all")
+	viper.SetDefault("realtime.dashboard.thumbnails.imageprovider", "avicommons")
+	viper.SetDefault("realtime.dashboard.thumbnails.fallbackpolicy", "none")
 	viper.SetDefault("realtime.dashboard.summarylimit", 30)
 	viper.SetDefault("realtime.dashboard.locale", "en") // Default UI locale
 

--- a/internal/imageprovider/imageprovider.go
+++ b/internal/imageprovider/imageprovider.go
@@ -473,24 +473,31 @@ func (c *BirdImageCache) batchLoadFromDB(scientificNames []string) (map[string]B
 		logger.Debug("GetImageCacheBatch completed", "provider_name", c.providerName, "found_count", len(dbImages))
 	}
 
-	// If no images found with this provider, try fallback to other providers
+	// If no images found with this provider, check fallback policy
 	if len(dbImages) == 0 && len(scientificNames) > 0 {
-		if settings.Realtime.Dashboard.Thumbnails.Debug {
-			logger.Debug("No images found with primary provider, trying fallback providers")
-		}
-		// Try common provider names as fallback
-		fallbackProviders := []string{"avicommons", "wikimedia", "wikipedia"}
-		for _, fallbackProvider := range fallbackProviders {
-			if fallbackProvider == c.providerName {
-				continue // Skip our own provider name
+		// Only try fallback providers if FallbackPolicy is "all"
+		if settings.Realtime.Dashboard.Thumbnails.FallbackPolicy == "all" {
+			if settings.Realtime.Dashboard.Thumbnails.Debug {
+				logger.Debug("No images found with primary provider, trying fallback providers (policy: all)")
 			}
-			fallbackImages, fallbackErr := c.store.GetImageCacheBatch(fallbackProvider, scientificNames)
-			if fallbackErr == nil && len(fallbackImages) > 0 {
-				if settings.Realtime.Dashboard.Thumbnails.Debug {
-					logger.Info("Found images using fallback provider", "fallback_provider", fallbackProvider, "found_count", len(fallbackImages))
+			// Try common provider names as fallback
+			fallbackProviders := []string{"avicommons", "wikimedia"}
+			for _, fallbackProvider := range fallbackProviders {
+				if fallbackProvider == c.providerName {
+					continue // Skip our own provider name
 				}
-				dbImages = fallbackImages
-				break
+				fallbackImages, fallbackErr := c.store.GetImageCacheBatch(fallbackProvider, scientificNames)
+				if fallbackErr == nil && len(fallbackImages) > 0 {
+					if settings.Realtime.Dashboard.Thumbnails.Debug {
+						logger.Info("Found images using fallback provider", "fallback_provider", fallbackProvider, "found_count", len(fallbackImages))
+					}
+					dbImages = fallbackImages
+					break
+				}
+			}
+		} else {
+			if settings.Realtime.Dashboard.Thumbnails.Debug {
+				logger.Debug("No images found with primary provider, but fallback policy is 'none'")
 			}
 		}
 	}
@@ -734,20 +741,26 @@ func (c *BirdImageCache) Get(scientificName string) (BirdImage, error) {
 			}
 			logger.Error("Failed to initialize or fetch image (tryInitialize returned error)", "error", enhancedErr)
 		}
-		// Even if initialization failed, maybe a fallback provider has it?
-		// This requires the registry to be set.
-		registry := c.GetRegistry()
-		if registry != nil {
-			triedProviders := map[string]bool{c.providerName: true}
-			logger.Info("Primary provider failed, attempting fallback", "initial_error", err)
-			fallbackImg, found := c.tryFallbackProviders(scientificName, triedProviders)
-			if found {
-				logger.Info("Image found via fallback provider", "fallback_provider", fallbackImg.SourceProvider)
-				// Optionally store the fallback result in this cache's memory map?
-				// c.dataMap.Store(scientificName, &fallbackImg)
-				return fallbackImg, nil
+		// Check if fallback is allowed by policy
+		settings := conf.Setting()
+		if settings.Realtime.Dashboard.Thumbnails.FallbackPolicy == "all" {
+			// Even if initialization failed, maybe a fallback provider has it?
+			// This requires the registry to be set.
+			registry := c.GetRegistry()
+			if registry != nil {
+				triedProviders := map[string]bool{c.providerName: true}
+				logger.Info("Primary provider failed, attempting fallback (policy: all)", "initial_error", err)
+				fallbackImg, found := c.tryFallbackProviders(scientificName, triedProviders)
+				if found {
+					logger.Info("Image found via fallback provider", "fallback_provider", fallbackImg.SourceProvider)
+					// Optionally store the fallback result in this cache's memory map?
+					// c.dataMap.Store(scientificName, &fallbackImg)
+					return fallbackImg, nil
+				}
+				logger.Warn("Image not found via fallback providers either")
 			}
-			logger.Warn("Image not found via fallback providers either")
+		} else {
+			logger.Debug("Primary provider failed but fallback policy is 'none'", "initial_error", err)
 		}
 		// Return the original error if no fallback worked or registry wasn't set
 		return BirdImage{}, err

--- a/internal/imageprovider/imageprovider.go
+++ b/internal/imageprovider/imageprovider.go
@@ -363,9 +363,15 @@ func InitCache(providerName string, e ImageProvider, t *observability.Metrics, s
 	settings := conf.Setting()
 
 	quit := make(chan struct{})
+	
+	var imageProviderMetrics *metrics.ImageProviderMetrics
+	if t != nil {
+		imageProviderMetrics = t.ImageProvider
+	}
+	
 	cache := &BirdImageCache{
 		providerName: providerName, // Set provider name
-		metrics:      t.ImageProvider,
+		metrics:      imageProviderMetrics,
 		debug:        settings.Realtime.Dashboard.Thumbnails.Debug, // Keep for potential checks
 		store:        store,
 		// logger:       log.Default(), // Replaced by package logger
@@ -495,10 +501,8 @@ func (c *BirdImageCache) batchLoadFromDB(scientificNames []string) (map[string]B
 					break
 				}
 			}
-		} else {
-			if settings.Realtime.Dashboard.Thumbnails.Debug {
-				logger.Debug("No images found with primary provider, but fallback policy is 'none'")
-			}
+		} else if settings.Realtime.Dashboard.Thumbnails.Debug {
+			logger.Debug("No images found with primary provider, but fallback policy is 'none'")
 		}
 	}
 

--- a/internal/imageprovider/provider_policy_test.go
+++ b/internal/imageprovider/provider_policy_test.go
@@ -1,0 +1,240 @@
+package imageprovider_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/datastore"
+	"github.com/tphakala/birdnet-go/internal/imageprovider"
+)
+
+// TestProviderNameConsistency verifies that the Wikipedia provider uses
+// the correct name "wikimedia" to match configuration expectations
+func TestProviderNameConsistency(t *testing.T) {
+	t.Parallel()
+
+	settings := conf.GetTestSettings()
+	settings.Realtime.Dashboard.Thumbnails.ImageProvider = "wikimedia"
+	settings.Realtime.Dashboard.Thumbnails.FallbackPolicy = "none"
+	conf.SetTestSettings(settings)
+
+	// Create Wikipedia provider and verify it registers with the correct name
+	store := newMockStore()
+
+	// Use the real Wikipedia provider constructor
+	provider, err := imageprovider.NewWikiMediaProvider()
+	require.NoError(t, err, "Failed to create WikiMedia provider")
+
+	// Initialize cache with the provider (no metrics needed for testing)
+	cache := imageprovider.InitCache("wikimedia", provider, nil, store)
+	defer cache.Close()
+
+	// Create registry and register the cache
+	registry := imageprovider.NewImageProviderRegistry()
+	err = registry.Register("wikimedia", cache)
+	assert.NoError(t, err, "Failed to register wikimedia provider")
+
+	// Verify the provider is accessible with "wikimedia" name
+	_, found := registry.GetCache("wikimedia")
+	assert.True(t, found, "wikimedia provider should be found in registry")
+
+	// Verify "wikipedia" name is NOT registered
+	_, found = registry.GetCache("wikipedia")
+	assert.False(t, found, "wikipedia provider name should NOT be found in registry")
+}
+
+// TestFallbackPolicyEnforcement verifies that the fallback policy is respected
+// in both batchLoadFromDB and Get methods
+func TestFallbackPolicyEnforcement(t *testing.T) {
+	tests := []struct {
+		name           string
+		fallbackPolicy string
+		expectFallback bool
+	}{
+		{
+			name:           "fallback_policy_none_prevents_fallback",
+			fallbackPolicy: "none",
+			expectFallback: false,
+		},
+		{
+			name:           "fallback_policy_all_allows_fallback",
+			fallbackPolicy: "all",
+			expectFallback: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Test isolation with new settings for each subtest
+			settings := conf.GetTestSettings()
+			settings.Realtime.Dashboard.Thumbnails.ImageProvider = "avicommons"
+			settings.Realtime.Dashboard.Thumbnails.FallbackPolicy = tt.fallbackPolicy
+			conf.SetTestSettings(settings)
+
+			store := newMockStore()
+
+			// Create primary provider that will fail
+			primaryProvider := &mockImageProvider{shouldFail: true}
+			primaryCache := imageprovider.InitCache("avicommons", primaryProvider, nil, store)
+			defer primaryCache.Close()
+
+			// Create fallback provider that will succeed
+			fallbackProvider := &mockImageProvider{shouldFail: false}
+			fallbackCache := imageprovider.InitCache("wikimedia", fallbackProvider, nil, store)
+			defer fallbackCache.Close()
+
+			// Create and setup registry
+			registry := imageprovider.NewImageProviderRegistry()
+			require.NoError(t, registry.Register("avicommons", primaryCache))
+			require.NoError(t, registry.Register("wikimedia", fallbackCache))
+
+			// Set registry on primary cache to enable fallback
+			primaryCache.SetRegistry(registry)
+
+			// Test Get method
+			_, err := primaryCache.Get("Parus major")
+
+			if tt.expectFallback {
+				// With fallback enabled, the primary provider fails but fallback should work
+				// So we should get a result (no error or specific not found error)
+				assert.True(t, err == nil || isImageNotFoundError(err),
+					"Expected success or not found error with fallback enabled, got: %v", err)
+			} else {
+				// Without fallback, we should get an error from the primary provider
+				assert.Error(t, err, "Expected error when primary provider fails and fallback is disabled")
+			}
+		})
+	}
+}
+
+// TestBatchLoadFromDBFallbackPolicy verifies that batchLoadFromDB respects
+// the fallback policy setting
+func TestBatchLoadFromDBFallbackPolicy(t *testing.T) {
+	// Helper to test GetBatchCachedOnly which uses batchLoadFromDB internally
+	testCases := []struct {
+		name               string
+		fallbackPolicy     string
+		setupStore         func(*mockStore)
+		expectedProviders  map[string]bool
+		expectedImageCount int
+	}{
+		{
+			name:           "no_fallback_when_policy_none",
+			fallbackPolicy: "none",
+			setupStore: func(store *mockStore) {
+				// Add image only for wikimedia provider
+				store.SaveImageCache(&datastore.ImageCache{
+					ScientificName: "Parus major",
+					ProviderName:   "wikimedia",
+					URL:            "http://wiki.example.com/parus.jpg",
+					CachedAt:       time.Now(),
+				})
+			},
+			expectedProviders:  map[string]bool{"avicommons": true}, // Only avicommons should be checked
+			expectedImageCount: 0, // No images found because avicommons has none
+		},
+		{
+			name:           "fallback_when_policy_all",
+			fallbackPolicy: "all",
+			setupStore: func(store *mockStore) {
+				// Add image only for wikimedia provider
+				store.SaveImageCache(&datastore.ImageCache{
+					ScientificName: "Parus major",
+					ProviderName:   "wikimedia",
+					URL:            "http://wiki.example.com/parus.jpg",
+					CachedAt:       time.Now(),
+				})
+			},
+			expectedProviders:  map[string]bool{"avicommons": true, "wikimedia": true},
+			expectedImageCount: 1, // Should find the wikimedia image via fallback
+		},
+		{
+			name:           "primary_provider_has_image",
+			fallbackPolicy: "none",
+			setupStore: func(store *mockStore) {
+				// Add image for primary provider
+				store.SaveImageCache(&datastore.ImageCache{
+					ScientificName: "Parus major",
+					ProviderName:   "avicommons",
+					URL:            "http://avi.example.com/parus.jpg",
+					CachedAt:       time.Now(),
+				})
+			},
+			expectedProviders:  map[string]bool{"avicommons": true},
+			expectedImageCount: 1, // Should find avicommons image without fallback
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Set up test configuration
+			settings := conf.GetTestSettings()
+			settings.Realtime.Dashboard.Thumbnails.ImageProvider = "avicommons"
+			settings.Realtime.Dashboard.Thumbnails.FallbackPolicy = tc.fallbackPolicy
+			conf.SetTestSettings(settings)
+
+			// Create store and set up test data
+			store := newMockStoreWithTracking()
+			tc.setupStore(store.mockStore)
+
+			// Create cache for avicommons (primary provider)
+			mockProvider := &mockImageProvider{}
+			cache := imageprovider.InitCache("avicommons", mockProvider, nil, store)
+			defer cache.Close()
+
+			// Test GetBatchCachedOnly which internally uses batchLoadFromDB
+			species := []string{"Parus major"}
+			results := cache.GetBatchCachedOnly(species)
+
+			// Verify result count
+			assert.Equal(t, tc.expectedImageCount, len(results),
+				"Expected %d images but got %d", tc.expectedImageCount, len(results))
+
+			// Verify which providers were queried
+			for provider, expected := range tc.expectedProviders {
+				if expected {
+					assert.True(t, store.WasProviderQueried(provider),
+						"Expected provider %s to be queried", provider)
+				} else {
+					assert.False(t, store.WasProviderQueried(provider),
+						"Expected provider %s NOT to be queried", provider)
+				}
+			}
+		})
+	}
+}
+
+// isImageNotFoundError checks if an error is an image not found error
+func isImageNotFoundError(err error) bool {
+	return err != nil && err.Error() == "image not found by provider"
+}
+
+// mockStoreWithTracking extends mockStore to track which providers were queried
+type mockStoreWithTracking struct {
+	*mockStore
+	queriedProviders map[string]bool
+}
+
+func newMockStoreWithTracking() *mockStoreWithTracking {
+	return &mockStoreWithTracking{
+		mockStore:        newMockStore(),
+		queriedProviders: make(map[string]bool),
+	}
+}
+
+func (m *mockStoreWithTracking) GetImageCacheBatch(providerName string, scientificNames []string) (map[string]*datastore.ImageCache, error) {
+	m.mu.Lock()
+	m.queriedProviders[providerName] = true
+	m.mu.Unlock()
+	
+	return m.mockStore.GetImageCacheBatch(providerName, scientificNames)
+}
+
+func (m *mockStoreWithTracking) WasProviderQueried(providerName string) bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.queriedProviders[providerName]
+}

--- a/internal/imageprovider/provider_policy_test.go
+++ b/internal/imageprovider/provider_policy_test.go
@@ -134,6 +134,7 @@ func TestBatchLoadFromDBFallbackPolicy(t *testing.T) {
 			name:           "no_fallback_when_policy_none",
 			fallbackPolicy: "none",
 			setupStore: func(t *testing.T, store *mockStore) {
+				t.Helper()
 				// Add image only for wikimedia provider
 				err := store.SaveImageCache(&datastore.ImageCache{
 					ScientificName: "Parus major",
@@ -150,6 +151,7 @@ func TestBatchLoadFromDBFallbackPolicy(t *testing.T) {
 			name:           "fallback_when_policy_all",
 			fallbackPolicy: "all",
 			setupStore: func(t *testing.T, store *mockStore) {
+				t.Helper()
 				// Add image only for wikimedia provider
 				err := store.SaveImageCache(&datastore.ImageCache{
 					ScientificName: "Parus major",
@@ -166,6 +168,7 @@ func TestBatchLoadFromDBFallbackPolicy(t *testing.T) {
 			name:           "primary_provider_has_image",
 			fallbackPolicy: "none",
 			setupStore: func(t *testing.T, store *mockStore) {
+				t.Helper()
 				// Add image for primary provider
 				err := store.SaveImageCache(&datastore.ImageCache{
 					ScientificName: "Parus major",

--- a/internal/imageprovider/wikipedia.go
+++ b/internal/imageprovider/wikipedia.go
@@ -18,7 +18,7 @@ import (
 	"golang.org/x/time/rate"
 )
 
-const wikiProviderName = "wikipedia"
+const wikiProviderName = "wikimedia"
 
 // wikiMediaProvider implements the ImageProvider interface for Wikipedia.
 type wikiMediaProvider struct {


### PR DESCRIPTION
## Summary
- Fixed provider name mismatch between 'wikipedia' and 'wikimedia'
- Enforced FallbackPolicy setting to prevent unwanted provider rotation
- Changed default image provider to 'avicommons' with fallback policy 'none'

## Problem
The image provider setting was not working correctly - when users selected a specific provider like "avicommons", the system would still show images from other providers in a round-robin fashion. This was reported in discussion #402.

## Root Causes
1. **Provider name mismatch**: Wikipedia provider was registered as "wikipedia" but config expected "wikimedia"
2. **Aggressive fallback behavior**: `batchLoadFromDB` always tried fallback providers regardless of FallbackPolicy setting
3. **Cache contamination**: Images from different providers were being mixed

## Changes Made
- Changed provider name from "wikipedia" to "wikimedia" in `wikipedia.go`
- Added FallbackPolicy checks in `batchLoadFromDB` and `Get` methods
- Updated defaults: image provider now "avicommons", fallback policy "none"
- Added comprehensive tests to verify the fixes

## Test plan
- [x] Added test `TestProviderNameConsistency` to verify provider naming
- [x] Added test `TestFallbackPolicyEnforcement` to ensure policy is respected
- [x] Added test `TestBatchLoadFromDBFallbackPolicy` for batch operations
- [x] All tests passing
- [x] Zero linter warnings

Fixes #402