### PR TITLE
security: sanitize RTSP credentials in detection notifications

### DIFF
--- a/internal/notification/detection_consumer_test.go
+++ b/internal/notification/detection_consumer_test.go
@@ -95,3 +95,93 @@ func TestDetectionNotificationConsumer(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, notifications, 1)
 }
+
+func TestDetectionNotificationConsumer_RTSPSanitization(t *testing.T) {
+	t.Parallel()
+
+	// Create notification service
+	config := &ServiceConfig{
+		MaxNotifications:   100,
+		CleanupInterval:    5 * time.Minute,
+		RateLimitWindow:    1 * time.Minute,
+		RateLimitMaxEvents: 100,
+	}
+	service := NewService(config)
+	require.NotNil(t, service)
+	defer service.Stop()
+
+	// Create detection consumer
+	consumer := NewDetectionNotificationConsumer(service)
+	require.NotNil(t, consumer)
+
+	// Test cases for RTSP URL sanitization
+	testCases := []struct {
+		name             string
+		rtspURL          string
+		expectedLocation string
+	}{
+		{
+			name:             "RTSP URL with credentials",
+			rtspURL:          "rtsp://admin:password123@192.168.1.100:554/stream1",
+			expectedLocation: "rtsp://192.168.1.100:554",
+		},
+		{
+			name:             "RTSP URL without credentials",
+			rtspURL:          "rtsp://192.168.1.100:554/stream1",
+			expectedLocation: "rtsp://192.168.1.100:554",
+		},
+		{
+			name:             "RTSP URL with IPv6 and credentials",
+			rtspURL:          "rtsp://user:pass@[2001:db8::1]:554/live",
+			expectedLocation: "rtsp://[2001:db8::1]:554",
+		},
+		{
+			name:             "Non-RTSP URL (should remain unchanged)",
+			rtspURL:          "backyard-camera",
+			expectedLocation: "backyard-camera",
+		},
+		{
+			name:             "HTTP URL (should remain unchanged)",
+			rtspURL:          "http://example.com/stream",
+			expectedLocation: "http://example.com/stream",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create a new species detection event with RTSP URL
+			event, err := events.NewDetectionEvent(
+				"Blue Jay",
+				"Cyanocitta cristata",
+				0.95,
+				tc.rtspURL,
+				true, // isNewSpecies
+				0,    // daysSinceFirstSeen
+			)
+			require.NoError(t, err)
+
+			// Process the event
+			err = consumer.ProcessDetectionEvent(event)
+			require.NoError(t, err)
+
+			// Get the latest notification
+			notifications, err := service.List(&FilterOptions{
+				Types: []Type{TypeDetection},
+				Limit: 1,
+			})
+			require.NoError(t, err)
+			require.Len(t, notifications, 1)
+
+			notif := notifications[0]
+			
+			// Verify the location in message is sanitized
+			assert.Contains(t, notif.Message, tc.expectedLocation)
+			assert.NotContains(t, notif.Message, "password123")
+			assert.NotContains(t, notif.Message, "admin:")
+			assert.NotContains(t, notif.Message, "user:pass")
+			
+			// Verify the location in metadata is sanitized
+			assert.Equal(t, tc.expectedLocation, notif.Metadata["location"])
+		})
+	}
+}


### PR DESCRIPTION
## Summary

This PR fixes a security vulnerability where RTSP URL credentials (username:password) were being exposed in new species detection notifications. The fix uses existing privacy utilities to sanitize RTSP URLs before displaying them to users.

### Changes Made

- **Detection Consumer**: Updated `ProcessDetectionEvent` to sanitize RTSP URLs using the existing `privacy.SanitizeRTSPUrl` function
- **Sanitization**: Applied to notification message, metadata, and logging output  
- **Test Coverage**: Added comprehensive test suite to verify RTSP URL sanitization for various scenarios

### Security Impact

**Before**: RTSP URLs like `rtsp://admin:password123@192.168.1.100:554/stream1` were displayed in notifications
**After**: URLs are sanitized to `rtsp://192.168.1.100:554` (credentials and path removed)

### Test Coverage

- ✅ RTSP URLs with credentials are properly sanitized
- ✅ RTSP URLs without credentials remain safe  
- ✅ IPv6 RTSP URLs are handled correctly
- ✅ Non-RTSP URLs are not modified
- ✅ No sensitive information leaks into notifications

### Verification

- All existing tests continue to pass
- New security-focused tests verify credential sanitization
- Code passes linting with no issues
- Uses existing `internal/privacy` utilities for consistency

🤖 Generated with [Claude Code](https://claude.ai/code)