### PR TITLE
fix: improve error message uniformity and deduplication

### DIFF
--- a/internal/myaudio/ffmpeg_stream_test.go
+++ b/internal/myaudio/ffmpeg_stream_test.go
@@ -340,7 +340,7 @@ func TestFFmpegStream_DataRateCalculation(t *testing.T) {
 	calc.addSample(1536)
 
 	// Calculate rate
-	rate, err := calc.getRate()
+	rate, err := calc.getRate("test://stream")
 	require.NoError(t, err)
 	assert.Greater(t, rate, 0.0)
 }

--- a/internal/myaudio/ffmpeg_stream_test.go
+++ b/internal/myaudio/ffmpeg_stream_test.go
@@ -340,7 +340,7 @@ func TestFFmpegStream_DataRateCalculation(t *testing.T) {
 	calc.addSample(1536)
 
 	// Calculate rate
-	rate, err := calc.getRate("test://stream")
+	rate, err := calc.getRate()
 	require.NoError(t, err)
 	assert.Greater(t, rate, 0.0)
 }

--- a/internal/notification/detection_consumer.go
+++ b/internal/notification/detection_consumer.go
@@ -60,10 +60,9 @@ func (c *DetectionNotificationConsumer) ProcessDetectionEvent(event events.Detec
 	// Create notification for new species
 	title := fmt.Sprintf("New Species Detected: %s", event.GetSpeciesName())
 	message := fmt.Sprintf(
-		"First detection of %s (%s) with %.1f%% confidence at %s",
+		"First detection of %s (%s) at %s",
 		event.GetSpeciesName(),
 		event.GetScientificName(),
-		event.GetConfidence()*100,
 		sanitizedLocation,
 	)
 

--- a/internal/notification/detection_consumer.go
+++ b/internal/notification/detection_consumer.go
@@ -59,6 +59,8 @@ func (c *DetectionNotificationConsumer) ProcessDetectionEvent(event events.Detec
 
 	// Create notification for new species
 	title := fmt.Sprintf("New Species Detected: %s", event.GetSpeciesName())
+	// Removed confidence from message to enable proper deduplication
+	// when same species detected with different confidence values
 	message := fmt.Sprintf(
 		"First detection of %s (%s) at %s",
 		event.GetSpeciesName(),

--- a/internal/notification/detection_consumer_test.go
+++ b/internal/notification/detection_consumer_test.go
@@ -64,6 +64,8 @@ func TestDetectionNotificationConsumer(t *testing.T) {
 	assert.Contains(t, notif.Message, "First detection of American Robin")
 	assert.Contains(t, notif.Message, "Turdus migratorius")
 	assert.Contains(t, notif.Message, "backyard-camera")
+	// Verify confidence percentage is not included to prevent regression
+	assert.NotContains(t, notif.Message, "%", "Message should not contain percentage symbol")
 	assert.Equal(t, "detection", notif.Component)
 
 	// Verify metadata

--- a/internal/notification/detection_consumer_test.go
+++ b/internal/notification/detection_consumer_test.go
@@ -62,7 +62,8 @@ func TestDetectionNotificationConsumer(t *testing.T) {
 	assert.Equal(t, PriorityHigh, notif.Priority)
 	assert.Contains(t, notif.Title, "New Species Detected: American Robin")
 	assert.Contains(t, notif.Message, "First detection of American Robin")
-	assert.Contains(t, notif.Message, "92.0% confidence")
+	assert.Contains(t, notif.Message, "Turdus migratorius")
+	assert.Contains(t, notif.Message, "backyard-camera")
 	assert.Equal(t, "detection", notif.Component)
 
 	// Verify metadata


### PR DESCRIPTION
## Summary
- Add `SanitizeFFmpegError()` function to remove memory addresses from FFmpeg error messages for proper deduplication
- Remove confidence values from new species notification messages to prevent duplicate notifications
- Add sanitized RTSP URLs to data rate error messages for better debugging context

## Changes Made

### 1. FFmpeg Error Message Sanitization
- Added new `SanitizeFFmpegError()` function in the privacy package
- Removes memory address prefixes like `[rtsp @ 0x55d4a4808980]` that cause message duplication
- Also sanitizes RTSP URLs to remove credentials
- Updated FFmpeg stream error handling to use this new function

**Before:**
```
FFmpeg process failed to start properly: [rtsp @ 0x55a57dbe9980] method DESCRIBE failed: 404 Not Found
FFmpeg process failed to start properly: [rtsp @ 0x55c4076ab980] method DESCRIBE failed: 404 Not Found
```

**After:**
```
FFmpeg process failed to start properly: method DESCRIBE failed: 404 Not Found
FFmpeg process failed to start properly: method DESCRIBE failed: 404 Not Found
```

### 2. New Species Notification Deduplication
- Removed confidence percentage from notification messages
- Prevents duplicate notifications when the same species is detected with different confidence values

**Before:**
```
First detection of ruokosirkkalintu (Locustella luscinioides) with 11.0% confidence at rtsp://192.168.44.6/Preview_01_sub
First detection of ruokosirkkalintu (Locustella luscinioides) with 11.5% confidence at rtsp://192.168.44.6/Preview_01_sub
```

**After:**
```
First detection of ruokosirkkalintu (Locustella luscinioides) at rtsp://192.168.44.6/Preview_01_sub
First detection of ruokosirkkalintu (Locustella luscinioides) at rtsp://192.168.44.6/Preview_01_sub
```

### 3. Enhanced Data Rate Error Messages
- Added sanitized RTSP URLs to data rate error messages for better debugging
- Updated `dataRateCalculator.getRate()` to accept URL parameter

**Before:**
```
no data received from RTSP source
```

**After:**
```
no data received from RTSP source: rtsp://192.168.44.6/Preview_01_sub
```

## Test plan
- [x] All existing tests pass
- [x] Added comprehensive tests for `SanitizeFFmpegError()` function
- [x] Updated notification tests to match new message format
- [x] Linter passes with 0 issues

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error message sanitization for FFmpeg errors to remove sensitive data and memory addresses.
  * Enhanced error context in data rate calculation error messages.

* **New Features**
  * Added advanced sanitization for FFmpeg error messages, protecting sensitive information in logs.

* **Tests**
  * Updated and expanded tests to verify improved sanitization and notification message changes.

* **Chores**
  * Removed the display of confidence percentage from detection notification messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->