### PR TITLE
fix: implement notification deduplication to prevent duplicate messages

### DIFF
--- a/internal/notification/deduplication_test.go
+++ b/internal/notification/deduplication_test.go
@@ -131,9 +131,8 @@ func testDuplicateWithinWindow(t *testing.T) {
 	store.SetDeduplicationWindow(5 * time.Minute)
 
 	// Create first notification
-	notif1 := NewNotification(TypeError, PriorityMedium, "Test Error", "Disk error occurred")
-	notif1.Component = "diskmanager"
-	notif1.ContentHash = notif1.GenerateContentHash()
+	notif1 := NewNotification(TypeError, PriorityMedium, "Test Error", "Disk error occurred").
+		WithComponent("diskmanager")
 
 	// Save first notification
 	err := store.Save(notif1)
@@ -142,9 +141,8 @@ func testDuplicateWithinWindow(t *testing.T) {
 	}
 
 	// Create duplicate notification
-	notif2 := NewNotification(TypeError, PriorityMedium, "Test Error", "Disk error occurred")
-	notif2.Component = "diskmanager"
-	notif2.ContentHash = notif2.GenerateContentHash()
+	notif2 := NewNotification(TypeError, PriorityMedium, "Test Error", "Disk error occurred").
+		WithComponent("diskmanager")
 
 	// Save duplicate - should deduplicate
 	err = store.Save(notif2)
@@ -175,9 +173,8 @@ func testDuplicateOutsideWindow(t *testing.T) {
 	store.SetDeduplicationWindow(100 * time.Millisecond) // Very short window for testing
 
 	// Create first notification with timestamp in the past
-	notif1 := NewNotification(TypeError, PriorityMedium, "Test Error", "Disk error occurred")
-	notif1.Component = "diskmanager"
-	notif1.ContentHash = notif1.GenerateContentHash()
+	notif1 := NewNotification(TypeError, PriorityMedium, "Test Error", "Disk error occurred").
+		WithComponent("diskmanager")
 	// Manually set timestamp to be in the past (outside deduplication window)
 	pastTime := time.Now().Add(-200 * time.Millisecond)
 	notif1.Timestamp = pastTime
@@ -189,9 +186,8 @@ func testDuplicateOutsideWindow(t *testing.T) {
 	}
 
 	// Create duplicate notification with current timestamp
-	notif2 := NewNotification(TypeError, PriorityMedium, "Test Error", "Disk error occurred")
-	notif2.Component = "diskmanager"
-	notif2.ContentHash = notif2.GenerateContentHash()
+	notif2 := NewNotification(TypeError, PriorityMedium, "Test Error", "Disk error occurred").
+		WithComponent("diskmanager")
 
 	// Save duplicate - should create new notification since window expired
 	err = store.Save(notif2)
@@ -224,9 +220,8 @@ func testPriorityEscalation(t *testing.T) {
 	store.SetDeduplicationWindow(5 * time.Minute)
 
 	// Create first notification with medium priority
-	notif1 := NewNotification(TypeError, PriorityMedium, "Test Error", "Disk error occurred")
-	notif1.Component = "diskmanager"
-	notif1.ContentHash = notif1.GenerateContentHash()
+	notif1 := NewNotification(TypeError, PriorityMedium, "Test Error", "Disk error occurred").
+		WithComponent("diskmanager")
 
 	err := store.Save(notif1)
 	if err != nil {
@@ -234,9 +229,8 @@ func testPriorityEscalation(t *testing.T) {
 	}
 
 	// Create duplicate with higher priority
-	notif2 := NewNotification(TypeError, PriorityHigh, "Test Error", "Disk error occurred")
-	notif2.Component = "diskmanager"
-	notif2.ContentHash = notif2.GenerateContentHash()
+	notif2 := NewNotification(TypeError, PriorityHigh, "Test Error", "Disk error occurred").
+		WithComponent("diskmanager")
 
 	err = store.Save(notif2)
 	if err != nil {
@@ -265,9 +259,8 @@ func testReadStatusReset(t *testing.T) {
 	store.SetDeduplicationWindow(5 * time.Minute)
 
 	// Create and save first notification
-	notif1 := NewNotification(TypeError, PriorityMedium, "Test Error", "Disk error occurred")
-	notif1.Component = "diskmanager"
-	notif1.ContentHash = notif1.GenerateContentHash()
+	notif1 := NewNotification(TypeError, PriorityMedium, "Test Error", "Disk error occurred").
+		WithComponent("diskmanager")
 
 	err := store.Save(notif1)
 	if err != nil {
@@ -286,9 +279,8 @@ func testReadStatusReset(t *testing.T) {
 	}
 
 	// Create duplicate notification
-	notif2 := NewNotification(TypeError, PriorityMedium, "Test Error", "Disk error occurred")
-	notif2.Component = "diskmanager"
-	notif2.ContentHash = notif2.GenerateContentHash()
+	notif2 := NewNotification(TypeError, PriorityMedium, "Test Error", "Disk error occurred").
+		WithComponent("diskmanager")
 
 	err = store.Save(notif2)
 	if err != nil {
@@ -323,9 +315,8 @@ func testHashIndexCleanup(t *testing.T) {
 	store.SetDeduplicationWindow(5 * time.Minute)
 
 	// Create and save notification
-	notif := NewNotification(TypeError, PriorityMedium, "Test Error", "Disk error occurred")
-	notif.Component = "diskmanager"
-	notif.ContentHash = notif.GenerateContentHash()
+	notif := NewNotification(TypeError, PriorityMedium, "Test Error", "Disk error occurred").
+		WithComponent("diskmanager")
 
 	err := store.Save(notif)
 	if err != nil {
@@ -361,17 +352,14 @@ func testMultipleDifferentNotifications(t *testing.T) {
 	store.SetDeduplicationWindow(5 * time.Minute)
 
 	// Create different notifications
-	notif1 := NewNotification(TypeError, PriorityMedium, "Error 1", "First error")
-	notif1.Component = "component1"
-	notif1.ContentHash = notif1.GenerateContentHash()
+	notif1 := NewNotification(TypeError, PriorityMedium, "Error 1", "First error").
+		WithComponent("component1")
 
-	notif2 := NewNotification(TypeWarning, PriorityLow, "Warning 1", "First warning")
-	notif2.Component = "component2"
-	notif2.ContentHash = notif2.GenerateContentHash()
+	notif2 := NewNotification(TypeWarning, PriorityLow, "Warning 1", "First warning").
+		WithComponent("component2")
 
-	notif3 := NewNotification(TypeInfo, PriorityLow, "Info 1", "Information")
-	notif3.Component = "component3"
-	notif3.ContentHash = notif3.GenerateContentHash()
+	notif3 := NewNotification(TypeInfo, PriorityLow, "Info 1", "Information").
+		WithComponent("component3")
 
 	// Save all notifications
 	for _, n := range []*Notification{notif1, notif2, notif3} {
@@ -407,14 +395,12 @@ func TestHashIndexCleanup(t *testing.T) {
 	store.SetDeduplicationWindow(100 * time.Millisecond) // Short window for testing
 
 	// Create notifications with old timestamps
-	oldNotif1 := NewNotification(TypeError, PriorityMedium, "Old Error 1", "Old error message 1")
-	oldNotif1.Component = "component1"
-	oldNotif1.ContentHash = oldNotif1.GenerateContentHash()
+	oldNotif1 := NewNotification(TypeError, PriorityMedium, "Old Error 1", "Old error message 1").
+		WithComponent("component1")
 	oldNotif1.Timestamp = time.Now().Add(-2 * time.Hour) // Way outside deduplication window
 
-	oldNotif2 := NewNotification(TypeError, PriorityMedium, "Old Error 2", "Old error message 2")
-	oldNotif2.Component = "component2"
-	oldNotif2.ContentHash = oldNotif2.GenerateContentHash()
+	oldNotif2 := NewNotification(TypeError, PriorityMedium, "Old Error 2", "Old error message 2").
+		WithComponent("component2")
 	oldNotif2.Timestamp = time.Now().Add(-2 * time.Hour) // Way outside deduplication window
 
 	// Save old notifications
@@ -446,9 +432,8 @@ func TestHashIndexCleanup(t *testing.T) {
 	store.forceCleanupTrigger()
 
 	// Create a new notification to trigger cleanup
-	newNotif := NewNotification(TypeInfo, PriorityLow, "New Info", "New message")
-	newNotif.Component = "component3"
-	newNotif.ContentHash = newNotif.GenerateContentHash()
+	newNotif := NewNotification(TypeInfo, PriorityLow, "New Info", "New message").
+		WithComponent("component3")
 
 	err = store.Save(newNotif)
 	if err != nil {

--- a/internal/notification/deduplication_test.go
+++ b/internal/notification/deduplication_test.go
@@ -135,7 +135,7 @@ func testDuplicateWithinWindow(t *testing.T) {
 		WithComponent("diskmanager")
 
 	// Save first notification
-	err := store.Save(notif1)
+	_, err := store.Save(notif1)
 	if err != nil {
 		t.Fatalf("Failed to save first notification: %v", err)
 	}
@@ -145,7 +145,7 @@ func testDuplicateWithinWindow(t *testing.T) {
 		WithComponent("diskmanager")
 
 	// Save duplicate - should deduplicate
-	err = store.Save(notif2)
+	_, err = store.Save(notif2)
 	if err != nil {
 		t.Fatalf("Failed to save duplicate notification: %v", err)
 	}
@@ -180,7 +180,7 @@ func testDuplicateOutsideWindow(t *testing.T) {
 	notif1.Timestamp = pastTime
 
 	// Save first notification
-	err := store.Save(notif1)
+	_, err := store.Save(notif1)
 	if err != nil {
 		t.Fatalf("Failed to save first notification: %v", err)
 	}
@@ -190,7 +190,7 @@ func testDuplicateOutsideWindow(t *testing.T) {
 		WithComponent("diskmanager")
 
 	// Save duplicate - should create new notification since window expired
-	err = store.Save(notif2)
+	_, err = store.Save(notif2)
 	if err != nil {
 		t.Fatalf("Failed to save duplicate notification: %v", err)
 	}
@@ -223,7 +223,7 @@ func testPriorityEscalation(t *testing.T) {
 	notif1 := NewNotification(TypeError, PriorityMedium, "Test Error", "Disk error occurred").
 		WithComponent("diskmanager")
 
-	err := store.Save(notif1)
+	_, err := store.Save(notif1)
 	if err != nil {
 		t.Fatalf("Failed to save first notification: %v", err)
 	}
@@ -232,7 +232,7 @@ func testPriorityEscalation(t *testing.T) {
 	notif2 := NewNotification(TypeError, PriorityHigh, "Test Error", "Disk error occurred").
 		WithComponent("diskmanager")
 
-	err = store.Save(notif2)
+	_, err = store.Save(notif2)
 	if err != nil {
 		t.Fatalf("Failed to save duplicate notification: %v", err)
 	}
@@ -262,7 +262,7 @@ func testReadStatusReset(t *testing.T) {
 	notif1 := NewNotification(TypeError, PriorityMedium, "Test Error", "Disk error occurred").
 		WithComponent("diskmanager")
 
-	err := store.Save(notif1)
+	_, err := store.Save(notif1)
 	if err != nil {
 		t.Fatalf("Failed to save first notification: %v", err)
 	}
@@ -282,7 +282,7 @@ func testReadStatusReset(t *testing.T) {
 	notif2 := NewNotification(TypeError, PriorityMedium, "Test Error", "Disk error occurred").
 		WithComponent("diskmanager")
 
-	err = store.Save(notif2)
+	_, err = store.Save(notif2)
 	if err != nil {
 		t.Fatalf("Failed to save duplicate notification: %v", err)
 	}
@@ -318,7 +318,7 @@ func testHashIndexCleanup(t *testing.T) {
 	notif := NewNotification(TypeError, PriorityMedium, "Test Error", "Disk error occurred").
 		WithComponent("diskmanager")
 
-	err := store.Save(notif)
+	_, err := store.Save(notif)
 	if err != nil {
 		t.Fatalf("Failed to save notification: %v", err)
 	}
@@ -363,7 +363,7 @@ func testMultipleDifferentNotifications(t *testing.T) {
 
 	// Save all notifications
 	for _, n := range []*Notification{notif1, notif2, notif3} {
-		err := store.Save(n)
+		_, err := store.Save(n)
 		if err != nil {
 			t.Fatalf("Failed to save notification: %v", err)
 		}
@@ -404,11 +404,11 @@ func TestHashIndexCleanup(t *testing.T) {
 	oldNotif2.Timestamp = time.Now().Add(-2 * time.Hour) // Way outside deduplication window
 
 	// Save old notifications
-	err := store.Save(oldNotif1)
+	_, err := store.Save(oldNotif1)
 	if err != nil {
 		t.Fatalf("Failed to save old notification 1: %v", err)
 	}
-	err = store.Save(oldNotif2)
+	_, err = store.Save(oldNotif2)
 	if err != nil {
 		t.Fatalf("Failed to save old notification 2: %v", err)
 	}
@@ -435,7 +435,7 @@ func TestHashIndexCleanup(t *testing.T) {
 	newNotif := NewNotification(TypeInfo, PriorityLow, "New Info", "New message").
 		WithComponent("component3")
 
-	err = store.Save(newNotif)
+	_, err = store.Save(newNotif)
 	if err != nil {
 		t.Fatalf("Failed to save new notification: %v", err)
 	}

--- a/internal/notification/deduplication_test.go
+++ b/internal/notification/deduplication_test.go
@@ -1,0 +1,454 @@
+package notification
+
+import (
+	"testing"
+	"time"
+)
+
+// TestGenerateContentHash verifies that content hash generation works correctly
+func TestGenerateContentHash(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		notif1   *Notification
+		notif2   *Notification
+		sameHash bool
+	}{
+		{
+			name: "identical notifications produce same hash",
+			notif1: &Notification{
+				Type:      TypeError,
+				Title:     "Error Title",
+				Message:   "Error message",
+				Component: "test",
+			},
+			notif2: &Notification{
+				Type:      TypeError,
+				Title:     "Error Title",
+				Message:   "Error message",
+				Component: "test",
+			},
+			sameHash: true,
+		},
+		{
+			name: "different messages produce different hashes",
+			notif1: &Notification{
+				Type:      TypeError,
+				Title:     "Error Title",
+				Message:   "Error message 1",
+				Component: "test",
+			},
+			notif2: &Notification{
+				Type:      TypeError,
+				Title:     "Error Title",
+				Message:   "Error message 2",
+				Component: "test",
+			},
+			sameHash: false,
+		},
+		{
+			name: "different components produce different hashes",
+			notif1: &Notification{
+				Type:      TypeError,
+				Title:     "Error Title",
+				Message:   "Error message",
+				Component: "component1",
+			},
+			notif2: &Notification{
+				Type:      TypeError,
+				Title:     "Error Title",
+				Message:   "Error message",
+				Component: "component2",
+			},
+			sameHash: false,
+		},
+		{
+			name: "component case normalization",
+			notif1: &Notification{
+				Type:      TypeError,
+				Title:     "Error Title",
+				Message:   "Error message",
+				Component: "DiskManager",
+			},
+			notif2: &Notification{
+				Type:      TypeError,
+				Title:     "Error Title",
+				Message:   "Error message",
+				Component: "diskmanager",
+			},
+			sameHash: true,
+		},
+		{
+			name: "whitespace trimming in message",
+			notif1: &Notification{
+				Type:      TypeError,
+				Title:     "Error Title",
+				Message:   "  Error message  ",
+				Component: "test",
+			},
+			notif2: &Notification{
+				Type:      TypeError,
+				Title:     "Error Title",
+				Message:   "Error message",
+				Component: "test",
+			},
+			sameHash: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hash1 := tt.notif1.GenerateContentHash()
+			hash2 := tt.notif2.GenerateContentHash()
+
+			if tt.sameHash && hash1 != hash2 {
+				t.Errorf("Expected same hash, got different: %s != %s", hash1, hash2)
+			}
+			if !tt.sameHash && hash1 == hash2 {
+				t.Errorf("Expected different hashes, got same: %s", hash1)
+			}
+		})
+	}
+}
+
+// TestInMemoryStoreDeduplication tests the deduplication logic in the store
+func TestInMemoryStoreDeduplication(t *testing.T) {
+	t.Parallel()
+
+	t.Run("duplicate within window increments count", func(t *testing.T) {
+		store := NewInMemoryStore(100)
+		store.SetDeduplicationWindow(5 * time.Minute)
+
+		// Create first notification
+		notif1 := NewNotification(TypeError, PriorityMedium, "Test Error", "Disk error occurred")
+		notif1.Component = "diskmanager"
+		notif1.ContentHash = notif1.GenerateContentHash()
+
+		// Save first notification
+		err := store.Save(notif1)
+		if err != nil {
+			t.Fatalf("Failed to save first notification: %v", err)
+		}
+
+		// Create duplicate notification
+		notif2 := NewNotification(TypeError, PriorityMedium, "Test Error", "Disk error occurred")
+		notif2.Component = "diskmanager"
+		notif2.ContentHash = notif2.GenerateContentHash()
+
+		// Save duplicate - should deduplicate
+		err = store.Save(notif2)
+		if err != nil {
+			t.Fatalf("Failed to save duplicate notification: %v", err)
+		}
+
+		// Verify only one notification exists
+		notifications, err := store.List(nil)
+		if err != nil {
+			t.Fatalf("Failed to list notifications: %v", err)
+		}
+
+		if len(notifications) != 1 {
+			t.Errorf("Expected 1 notification, got %d", len(notifications))
+		}
+
+		// Verify occurrence count was incremented
+		if notifications[0].OccurrenceCount != 2 {
+			t.Errorf("Expected occurrence count 2, got %d", notifications[0].OccurrenceCount)
+		}
+	})
+
+	t.Run("duplicate outside window creates new notification", func(t *testing.T) {
+		store := NewInMemoryStore(100)
+		store.SetDeduplicationWindow(100 * time.Millisecond) // Very short window for testing
+
+		// Create first notification
+		notif1 := NewNotification(TypeError, PriorityMedium, "Test Error", "Disk error occurred")
+		notif1.Component = "diskmanager"
+		notif1.ContentHash = notif1.GenerateContentHash()
+
+		// Save first notification
+		err := store.Save(notif1)
+		if err != nil {
+			t.Fatalf("Failed to save first notification: %v", err)
+		}
+
+		// Wait for deduplication window to expire
+		time.Sleep(150 * time.Millisecond)
+
+		// Create duplicate notification
+		notif2 := NewNotification(TypeError, PriorityMedium, "Test Error", "Disk error occurred")
+		notif2.Component = "diskmanager"
+		notif2.ContentHash = notif2.GenerateContentHash()
+
+		// Save duplicate - should create new notification since window expired
+		err = store.Save(notif2)
+		if err != nil {
+			t.Fatalf("Failed to save duplicate notification: %v", err)
+		}
+
+		// Verify two notifications exist
+		notifications, err := store.List(nil)
+		if err != nil {
+			t.Fatalf("Failed to list notifications: %v", err)
+		}
+
+		if len(notifications) != 2 {
+			t.Errorf("Expected 2 notifications, got %d", len(notifications))
+		}
+
+		// Both should have occurrence count of 1
+		for i, n := range notifications {
+			if n.OccurrenceCount != 1 {
+				t.Errorf("Notification %d: expected occurrence count 1, got %d", i, n.OccurrenceCount)
+			}
+		}
+	})
+
+	t.Run("priority escalation on duplicate", func(t *testing.T) {
+		store := NewInMemoryStore(100)
+		store.SetDeduplicationWindow(5 * time.Minute)
+
+		// Create first notification with medium priority
+		notif1 := NewNotification(TypeError, PriorityMedium, "Test Error", "Disk error occurred")
+		notif1.Component = "diskmanager"
+		notif1.ContentHash = notif1.GenerateContentHash()
+
+		err := store.Save(notif1)
+		if err != nil {
+			t.Fatalf("Failed to save first notification: %v", err)
+		}
+
+		// Create duplicate with higher priority
+		notif2 := NewNotification(TypeError, PriorityHigh, "Test Error", "Disk error occurred")
+		notif2.Component = "diskmanager"
+		notif2.ContentHash = notif2.GenerateContentHash()
+
+		err = store.Save(notif2)
+		if err != nil {
+			t.Fatalf("Failed to save duplicate notification: %v", err)
+		}
+
+		// Verify priority was escalated
+		notifications, err := store.List(nil)
+		if err != nil {
+			t.Fatalf("Failed to list notifications: %v", err)
+		}
+
+		if len(notifications) != 1 {
+			t.Errorf("Expected 1 notification, got %d", len(notifications))
+		}
+
+		if notifications[0].Priority != PriorityHigh {
+			t.Errorf("Expected priority to be escalated to high, got %s", notifications[0].Priority)
+		}
+	})
+
+	t.Run("read status reset on duplicate", func(t *testing.T) {
+		store := NewInMemoryStore(100)
+		store.SetDeduplicationWindow(5 * time.Minute)
+
+		// Create and save first notification
+		notif1 := NewNotification(TypeError, PriorityMedium, "Test Error", "Disk error occurred")
+		notif1.Component = "diskmanager"
+		notif1.ContentHash = notif1.GenerateContentHash()
+
+		err := store.Save(notif1)
+		if err != nil {
+			t.Fatalf("Failed to save first notification: %v", err)
+		}
+
+		// Get the notification from store and mark as read
+		savedNotif, err := store.Get(notif1.ID)
+		if err != nil {
+			t.Fatalf("Failed to get notification: %v", err)
+		}
+		savedNotif.MarkAsRead()
+		err = store.Update(savedNotif)
+		if err != nil {
+			t.Fatalf("Failed to update notification: %v", err)
+		}
+
+		// Create duplicate notification
+		notif2 := NewNotification(TypeError, PriorityMedium, "Test Error", "Disk error occurred")
+		notif2.Component = "diskmanager"
+		notif2.ContentHash = notif2.GenerateContentHash()
+
+		err = store.Save(notif2)
+		if err != nil {
+			t.Fatalf("Failed to save duplicate notification: %v", err)
+		}
+
+		// Verify status was reset to unread
+		notifications, err := store.List(nil)
+		if err != nil {
+			t.Fatalf("Failed to list notifications: %v", err)
+		}
+
+		if notifications[0].Status != StatusUnread {
+			t.Errorf("Expected status to be reset to unread, got %s", notifications[0].Status)
+		}
+
+		// Verify unread count
+		unreadCount, err := store.GetUnreadCount()
+		if err != nil {
+			t.Fatalf("Failed to get unread count: %v", err)
+		}
+
+		if unreadCount != 1 {
+			t.Errorf("Expected unread count 1, got %d", unreadCount)
+		}
+	})
+
+	t.Run("hash index cleanup on delete", func(t *testing.T) {
+		store := NewInMemoryStore(100)
+		store.SetDeduplicationWindow(5 * time.Minute)
+
+		// Create and save notification
+		notif := NewNotification(TypeError, PriorityMedium, "Test Error", "Disk error occurred")
+		notif.Component = "diskmanager"
+		notif.ContentHash = notif.GenerateContentHash()
+
+		err := store.Save(notif)
+		if err != nil {
+			t.Fatalf("Failed to save notification: %v", err)
+		}
+
+		// Verify it exists in hash index
+		existing, found := store.FindByContentHash(notif.ContentHash)
+		if !found {
+			t.Error("Expected to find notification in hash index")
+		}
+		if existing.ID != notif.ID {
+			t.Errorf("Expected notification ID %s, got %s", notif.ID, existing.ID)
+		}
+
+		// Delete notification
+		err = store.Delete(notif.ID)
+		if err != nil {
+			t.Fatalf("Failed to delete notification: %v", err)
+		}
+
+		// Verify it's removed from hash index
+		_, found = store.FindByContentHash(notif.ContentHash)
+		if found {
+			t.Error("Expected notification to be removed from hash index")
+		}
+	})
+
+	t.Run("multiple different notifications", func(t *testing.T) {
+		store := NewInMemoryStore(100)
+		store.SetDeduplicationWindow(5 * time.Minute)
+
+		// Create different notifications
+		notif1 := NewNotification(TypeError, PriorityMedium, "Error 1", "First error")
+		notif1.Component = "component1"
+		notif1.ContentHash = notif1.GenerateContentHash()
+
+		notif2 := NewNotification(TypeWarning, PriorityLow, "Warning 1", "First warning")
+		notif2.Component = "component2"
+		notif2.ContentHash = notif2.GenerateContentHash()
+
+		notif3 := NewNotification(TypeInfo, PriorityLow, "Info 1", "Information")
+		notif3.Component = "component3"
+		notif3.ContentHash = notif3.GenerateContentHash()
+
+		// Save all notifications
+		for _, n := range []*Notification{notif1, notif2, notif3} {
+			err := store.Save(n)
+			if err != nil {
+				t.Fatalf("Failed to save notification: %v", err)
+			}
+		}
+
+		// Verify all three exist
+		notifications, err := store.List(nil)
+		if err != nil {
+			t.Fatalf("Failed to list notifications: %v", err)
+		}
+
+		if len(notifications) != 3 {
+			t.Errorf("Expected 3 notifications, got %d", len(notifications))
+		}
+
+		// All should have occurrence count of 1
+		for i, n := range notifications {
+			if n.OccurrenceCount != 1 {
+				t.Errorf("Notification %d: expected occurrence count 1, got %d", i, n.OccurrenceCount)
+			}
+		}
+	})
+}
+
+// TestServiceDeduplication tests deduplication at the service level
+func TestServiceDeduplication(t *testing.T) {
+	t.Parallel()
+
+	t.Run("service deduplicates identical notifications", func(t *testing.T) {
+		config := &ServiceConfig{
+			MaxNotifications:    100,
+			CleanupInterval:     1 * time.Hour,
+			RateLimitWindow:     1 * time.Minute,
+			RateLimitMaxEvents:  100,
+			DeduplicationWindow: 5 * time.Minute,
+		}
+
+		service := NewService(config)
+		defer service.Stop()
+
+		// Create multiple identical notifications
+		for i := 0; i < 5; i++ {
+			_, err := service.CreateWithComponent(
+				TypeError,
+				PriorityMedium,
+				"diskmanager Issue",
+				"diskmanager: invalid audio filename format 'out.m4a' (has 1 parts, expected at least 3)",
+				"diskmanager",
+			)
+			if err != nil {
+				t.Fatalf("Failed to create notification %d: %v", i, err)
+			}
+		}
+
+		// List notifications
+		notifications, err := service.List(nil)
+		if err != nil {
+			t.Fatalf("Failed to list notifications: %v", err)
+		}
+
+		// Should have only 1 notification due to deduplication
+		if len(notifications) != 1 {
+			t.Errorf("Expected 1 notification after deduplication, got %d", len(notifications))
+		}
+
+		// Occurrence count should be 5
+		if notifications[0].OccurrenceCount != 5 {
+			t.Errorf("Expected occurrence count 5, got %d", notifications[0].OccurrenceCount)
+		}
+	})
+}
+
+// TestPriorityWeight tests the priority weight function
+func TestPriorityWeight(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		priority Priority
+		expected int
+	}{
+		{PriorityCritical, 4},
+		{PriorityHigh, 3},
+		{PriorityMedium, 2},
+		{PriorityLow, 1},
+		{Priority("unknown"), 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.priority), func(t *testing.T) {
+			weight := getPriorityWeight(tt.priority)
+			if weight != tt.expected {
+				t.Errorf("Expected weight %d for priority %s, got %d", tt.expected, tt.priority, weight)
+			}
+		})
+	}
+}

--- a/internal/notification/detection_consumer.go
+++ b/internal/notification/detection_consumer.go
@@ -80,7 +80,7 @@ func (c *DetectionNotificationConsumer) ProcessDetectionEvent(event events.Detec
 
 	// Add the notification through the service
 	// First save to store
-	if err := c.service.store.Save(notification); err != nil {
+	if _, err := c.service.store.Save(notification); err != nil {
 		c.logger.Error("failed to save new species notification",
 			"species", event.GetSpeciesName(),
 			"error", err,

--- a/internal/notification/metadata_test.go
+++ b/internal/notification/metadata_test.go
@@ -1,0 +1,109 @@
+package notification
+
+import (
+	"testing"
+)
+
+// TestUpdateNotificationFieldsMetadataDeepCopy tests that metadata is deep copied
+func TestUpdateNotificationFieldsMetadataDeepCopy(t *testing.T) {
+	t.Parallel()
+
+	store := NewInMemoryStore(100)
+
+	// Create and save original notification with metadata
+	original := NewNotification(TypeError, PriorityMedium, "Test", "Message").
+		WithComponent("test")
+	original.Metadata = map[string]any{
+		"key1": "value1",
+		"key2": 42,
+	}
+	
+	_, err := store.Save(original)
+	if err != nil {
+		t.Fatalf("Failed to save original notification: %v", err)
+	}
+
+	// Create update notification with different metadata
+	update := NewNotification(TypeError, PriorityMedium, "Test", "Message").
+		WithComponent("test")
+	update.ID = original.ID  // Use same ID to update
+	update.Metadata = map[string]any{
+		"key3": "value3",
+		"key4": 84,
+	}
+
+	// Update the notification
+	err = store.Update(update)
+	if err != nil {
+		t.Fatalf("Failed to update notification: %v", err)
+	}
+
+	// Modify the source metadata after update
+	update.Metadata["key5"] = "should not appear"
+	delete(update.Metadata, "key3")
+
+	// Get the stored notification
+	stored, err := store.Get(original.ID)
+	if err != nil {
+		t.Fatalf("Failed to get notification: %v", err)
+	}
+
+	// Verify the stored metadata is isolated from changes to source
+	if len(stored.Metadata) != 2 {
+		t.Errorf("Expected 2 metadata entries, got %d", len(stored.Metadata))
+	}
+
+	// Check that original keys were replaced
+	if _, exists := stored.Metadata["key1"]; exists {
+		t.Error("Original metadata key1 should have been replaced")
+	}
+
+	// Check that update keys exist
+	if val, exists := stored.Metadata["key3"]; !exists || val != "value3" {
+		t.Errorf("Expected key3=value3, got %v (exists: %v)", val, exists)
+	}
+	if val, exists := stored.Metadata["key4"]; !exists || val != 84 {
+		t.Errorf("Expected key4=84, got %v (exists: %v)", val, exists)
+	}
+
+	// Check that post-update modifications didn't affect stored metadata
+	if _, exists := stored.Metadata["key5"]; exists {
+		t.Error("Post-update modification should not affect stored metadata")
+	}
+}
+
+// TestUpdateNotificationFieldsNilMetadata tests handling of nil metadata
+func TestUpdateNotificationFieldsNilMetadata(t *testing.T) {
+	t.Parallel()
+
+	store := NewInMemoryStore(100)
+
+	// Create notification with metadata
+	notif := NewNotification(TypeError, PriorityMedium, "Test", "Message")
+	notif.Metadata = map[string]any{"key": "value"}
+	
+	_, err := store.Save(notif)
+	if err != nil {
+		t.Fatalf("Failed to save notification: %v", err)
+	}
+
+	// Update with nil metadata
+	update := NewNotification(TypeError, PriorityMedium, "Test", "Message")
+	update.ID = notif.ID
+	update.Metadata = nil
+
+	err = store.Update(update)
+	if err != nil {
+		t.Fatalf("Failed to update notification: %v", err)
+	}
+
+	// Verify metadata is now nil
+	stored, err := store.Get(notif.ID)
+	if err != nil {
+		t.Fatalf("Failed to get notification: %v", err)
+	}
+
+	if stored.Metadata != nil {
+		t.Errorf("Expected nil metadata, got %v", stored.Metadata)
+	}
+}

--- a/internal/notification/resource_consumer.go
+++ b/internal/notification/resource_consumer.go
@@ -64,8 +64,7 @@ func NewResourceEventWorker(service *Service, config *ResourceWorkerConfig) (*Re
 	logger = logger.With("component", "resource-worker")
 
 	// Copy resource throttles to avoid mutation
-	resourceThrottles := make(map[string]time.Duration)
-	maps.Copy(resourceThrottles, config.ResourceThrottles)
+	resourceThrottles := maps.Clone(config.ResourceThrottles)
 
 	worker := &ResourceEventWorker{
 		service:           service,

--- a/internal/notification/service_extensions.go
+++ b/internal/notification/service_extensions.go
@@ -41,7 +41,7 @@ func (s *Service) CreateWithMetadata(notification *Notification) error {
 	}
 
 	// Save to store
-	if err := s.store.Save(notification); err != nil {
+	if _, err := s.store.Save(notification); err != nil {
 		return errors.New(err).
 			Component("notification").
 			Category(errors.CategorySystem).

--- a/internal/notification/service_extensions_test.go
+++ b/internal/notification/service_extensions_test.go
@@ -270,9 +270,9 @@ type failingStore struct {
 	shouldFail bool
 }
 
-func (f *failingStore) Save(notification *Notification) error {
+func (f *failingStore) Save(notification *Notification) (string, error) {
 	if f.shouldFail {
-		return context.DeadlineExceeded // Simulate store failure
+		return "", context.DeadlineExceeded // Simulate store failure
 	}
 	return f.InMemoryStore.Save(notification)
 }

--- a/internal/notification/store_test.go
+++ b/internal/notification/store_test.go
@@ -38,7 +38,7 @@ func mustGetNotification(t *testing.T, store *InMemoryStore, id string) *Notific
 // mustSaveNotification saves a notification and fails the test if an error occurs
 func mustSaveNotification(t *testing.T, store *InMemoryStore, notif *Notification) {
 	t.Helper()
-	if err := store.Save(notif); err != nil {
+	if _, err := store.Save(notif); err != nil {
 		t.Fatalf("Failed to save notification: %v", err)
 	}
 }

--- a/internal/notification/store_test.go
+++ b/internal/notification/store_test.go
@@ -1,6 +1,7 @@
 package notification
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -178,10 +179,11 @@ func TestInMemoryStoreMaxSize(t *testing.T) {
 	store := NewInMemoryStore(3) // Small size for testing
 
 	// Create 4 notifications (more than max size)
+	// Make each notification unique to avoid deduplication
 	notifications := make([]*Notification, 4)
 	baseTime := time.Now()
 	for i := range 4 {
-		notifications[i] = NewNotification(TypeInfo, PriorityMedium, "Test", "Message")
+		notifications[i] = NewNotification(TypeInfo, PriorityMedium, fmt.Sprintf("Test %d", i), fmt.Sprintf("Message %d", i))
 		// Set timestamps deterministically to ensure ordering
 		notifications[i].Timestamp = baseTime.Add(time.Duration(i) * time.Second)
 		mustSaveNotification(t, store, notifications[i])

--- a/internal/notification/test_helpers_test.go
+++ b/internal/notification/test_helpers_test.go
@@ -1,0 +1,36 @@
+package notification
+
+import "time"
+
+// Test helper methods for InMemoryStore - only included in test builds
+// These methods provide access to internal state for testing purposes
+// and should not be available in production binaries.
+
+// forceHashIndexEntry adds an entry to the hash index (test helper)
+func (s *InMemoryStore) forceHashIndexEntry(hash string, notif *Notification) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.hashIndex[hash] = notif
+}
+
+// getHashIndexCount returns the number of entries in hash index (test helper)
+func (s *InMemoryStore) getHashIndexCount() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.hashIndex)
+}
+
+// hasHashIndexEntry checks if a hash exists in the index (test helper)
+func (s *InMemoryStore) hasHashIndexEntry(hash string) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	_, exists := s.hashIndex[hash]
+	return exists
+}
+
+// forceCleanupTrigger sets lastCleanup to trigger cleanup on next Save (test helper)
+func (s *InMemoryStore) forceCleanupTrigger() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.lastCleanup = time.Now().Add(-2 * time.Hour)
+}

--- a/internal/notification/types.go
+++ b/internal/notification/types.go
@@ -579,36 +579,6 @@ func (s *InMemoryStore) GetUnreadCount() (int, error) {
 	return s.unreadCount, nil
 }
 
-// Test helper methods - only for internal package testing
-
-// forceHashIndexEntry adds an entry to the hash index (test helper)
-func (s *InMemoryStore) forceHashIndexEntry(hash string, notif *Notification) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.hashIndex[hash] = notif
-}
-
-// getHashIndexCount returns the number of entries in hash index (test helper)
-func (s *InMemoryStore) getHashIndexCount() int {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	return len(s.hashIndex)
-}
-
-// hasHashIndexEntry checks if a hash exists in the index (test helper)
-func (s *InMemoryStore) hasHashIndexEntry(hash string) bool {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	_, exists := s.hashIndex[hash]
-	return exists
-}
-
-// forceCleanupTrigger sets lastCleanup to trigger cleanup on next Save (test helper)
-func (s *InMemoryStore) forceCleanupTrigger() {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.lastCleanup = time.Now().Add(-2 * time.Hour)
-}
 
 // sortNotificationsByTime sorts notifications by timestamp (newest first)
 func sortNotificationsByTime(notifications []*Notification) {

--- a/internal/notification/validation_test.go
+++ b/internal/notification/validation_test.go
@@ -1,0 +1,55 @@
+package notification
+
+import (
+	"testing"
+	"time"
+)
+
+// TestSetDeduplicationWindowValidation tests the validation logic in SetDeduplicationWindow
+func TestSetDeduplicationWindowValidation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		inputWindow    time.Duration
+		expectedWindow time.Duration
+	}{
+		{
+			name:           "positive duration is accepted",
+			inputWindow:    10 * time.Minute,
+			expectedWindow: 10 * time.Minute,
+		},
+		{
+			name:           "zero duration uses default",
+			inputWindow:    0,
+			expectedWindow: DefaultDeduplicationWindow,
+		},
+		{
+			name:           "negative duration uses default",
+			inputWindow:    -5 * time.Minute,
+			expectedWindow: DefaultDeduplicationWindow,
+		},
+		{
+			name:           "very large duration is accepted",
+			inputWindow:    24 * time.Hour,
+			expectedWindow: 24 * time.Hour,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := NewInMemoryStore(100)
+			store.SetDeduplicationWindow(tt.inputWindow)
+			
+			// Access the deduplicationWindow directly since we're in the same package
+			store.mu.RLock()
+			actualWindow := store.deduplicationWindow
+			store.mu.RUnlock()
+			
+			if actualWindow != tt.expectedWindow {
+				t.Errorf("SetDeduplicationWindow(%v): expected window %v, got %v",
+					tt.inputWindow, tt.expectedWindow, actualWindow)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Implements backend notification deduplication to prevent duplicate messages from flooding the UI
- Addresses issue where identical notifications (like diskmanager errors) appear multiple times
- Uses content-based hashing to identify and merge duplicate notifications within a configurable time window

## Changes
- **Content Hash Generation**: Added hash generation based on component, type, title, and message
- **Deduplication Logic**: Implemented in InMemoryStore with 5-minute default window
- **Occurrence Tracking**: Added occurrence count to track how many times a notification has been triggered
- **Priority Escalation**: Updates to highest priority when duplicates with higher priority arrive
- **Status Management**: Resets notifications to unread when duplicates occur
- **Comprehensive Tests**: Added full test coverage for deduplication scenarios

## Technical Details
- Notifications are identified by a SHA256 hash of their content (component + type + title + message)
- Deduplication window is configurable (default: 5 minutes)
- Both `notifications` and `hashIndex` maps maintain proper pointer references
- Update method modified to update fields in-place rather than replacing pointers

## Test Plan
- [x] Run `go test -race ./internal/notification` - all tests pass
- [x] Run `golangci-lint run -v` - no issues
- [x] Test with repeated diskmanager errors - should see single notification with occurrence count
- [ ] Verify frontend displays occurrence count correctly
- [ ] Test that notifications outside deduplication window create new entries

## Example
Before: Multiple identical "diskmanager: invalid audio filename format" notifications
After: Single notification with `occurrence_count: 5` showing it happened 5 times

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic deduplication of notifications based on content within a configurable time window, preventing duplicate notifications and aggregating their occurrence counts.
  * Notifications now display how many times they have occurred and track the timestamp of the first occurrence.
  * Notification priority escalates if a duplicate with higher priority is received, and read status resets on new duplicates.

* **Bug Fixes**
  * Improved notification storage to ensure unique notifications are not incorrectly deduplicated.

* **Tests**
  * Introduced comprehensive tests covering deduplication logic, priority escalation, occurrence counting, error handling, metadata handling, and internal cleanup mechanisms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->