### PR TITLE
fix: resolve TypeError when settings.config is null/undefined

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -141,6 +141,42 @@ const bad = base.include || []; // ❌ Converts 0, "", false to []
 const good = base.include ?? []; // ✅ Only null/undefined to []
 ```
 
+### Type Guards for Object Safety
+
+Always validate object types before using them, especially in settings derivation:
+
+```typescript
+// ✅ Define reusable type guard
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+// ✅ Use type guard for safe object assignment
+const settings = {
+  include: base.include ?? [],
+  exclude: base.exclude ?? [],
+  config: isPlainObject(base.config) ? base.config : {}, // Safe object validation
+};
+
+// ❌ Unsafe direct assignment (base.config could be array, null, etc.)
+const unsafe = {
+  config: base.config ?? {}, // Could assign [] or other non-plain objects
+};
+
+// ✅ Complete pattern for settings derivation
+let settings = $derived(
+  (() => {
+    const base = $speciesSettings ?? fallbackSettings; // Use ?? for root object
+
+    return {
+      include: base.include ?? [],
+      exclude: base.exclude ?? [],
+      config: isPlainObject(base.config) ? base.config : {}, // Type guard for objects
+    } as SettingsType;
+  })()
+);
+```
+
 ## Icon Usage
 
 ```svelte

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -102,6 +102,16 @@ const result = iterator.next();
 if (!result.done && result.value !== undefined) {
   // Safe to use result.value
 }
+
+// Nullish coalescing for defaults (preferred over logical OR)
+const settings = {
+  include: base.include ?? [], // Only null/undefined → []
+  exclude: base.exclude ?? [], // Only null/undefined → []
+  config: base.config ?? {}, // Only null/undefined → {}
+};
+
+// Use logical OR only when you want to handle falsy values
+const displayName = user.name || 'Anonymous'; // Handles "", null, undefined
 ```
 
 ### ❌ FORBIDDEN
@@ -110,6 +120,25 @@ if (!result.done && result.value !== undefined) {
 const value = map.get(key) as string; // Type assertion
 const value = map.get(key)!; // Non-null assertion
 let data: any; // Untyped
+
+// Avoid logical OR for object defaults (can cause issues with empty arrays/objects)
+const config = base.config || {}; // ❌ Converts [] to {}, 0 to {}, etc.
+```
+
+### Nullish Coalescing vs Logical OR
+
+```typescript
+// ✅ Use ?? when you only want to handle null/undefined
+const items = data.items ?? []; // Only null/undefined → []
+const config = settings.config ?? {}; // Only null/undefined → {}
+
+// ✅ Use || when you want to handle all falsy values
+const displayText = input || 'Default'; // "", 0, false, null, undefined → 'Default'
+const isEnabled = flag || false; // Any falsy → false
+
+// Common mistake in settings derivation:
+const bad = base.include || []; // ❌ Converts 0, "", false to []
+const good = base.include ?? []; // ✅ Only null/undefined to []
 ```
 
 ## Icon Usage

--- a/frontend/src/lib/desktop/features/settings/pages/SpeciesSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/SpeciesSettingsPage.svelte
@@ -43,6 +43,11 @@
 
   const logger = loggers.settings;
 
+  // Helper function to check if a value is a plain object
+  function isPlainObject(value: unknown): value is Record<string, unknown> {
+    return value !== null && typeof value === 'object' && !Array.isArray(value);
+  }
+
   // PERFORMANCE OPTIMIZATION: Cache CSRF token with $derived
   let csrfToken = $derived(
     (document.querySelector('meta[name="csrf-token"]') as HTMLElement)?.getAttribute('content') ||
@@ -52,7 +57,7 @@
   // PERFORMANCE OPTIMIZATION: Reactive settings with proper defaults
   let settings = $derived(
     (() => {
-      const base = $speciesSettings || {
+      const base = $speciesSettings ?? {
         include: [] as string[],
         exclude: [] as string[],
         config: {} as Record<string, SpeciesConfig>,
@@ -62,7 +67,7 @@
       return {
         include: base.include ?? [],
         exclude: base.exclude ?? [],
-        config: base.config ?? {},
+        config: isPlainObject(base.config) ? base.config : {},
       } as SpeciesSettings;
     })()
   );

--- a/frontend/src/lib/desktop/features/settings/pages/SpeciesSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/SpeciesSettingsPage.svelte
@@ -60,9 +60,9 @@
 
       // Ensure config is always a valid object to prevent Object.keys() errors
       return {
-        include: base.include || [],
-        exclude: base.exclude || [],
-        config: base.config || {},
+        include: base.include ?? [],
+        exclude: base.exclude ?? [],
+        config: base.config ?? {},
       } as SpeciesSettings;
     })()
   );

--- a/frontend/src/lib/desktop/features/settings/pages/SpeciesSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/SpeciesSettingsPage.svelte
@@ -51,12 +51,20 @@
 
   // PERFORMANCE OPTIMIZATION: Reactive settings with proper defaults
   let settings = $derived(
-    $speciesSettings ||
-      ({
+    (() => {
+      const base = $speciesSettings || {
         include: [] as string[],
         exclude: [] as string[],
         config: {} as Record<string, SpeciesConfig>,
-      } as SpeciesSettings)
+      };
+
+      // Ensure config is always a valid object to prevent Object.keys() errors
+      return {
+        include: base.include || [],
+        exclude: base.exclude || [],
+        config: base.config || {},
+      } as SpeciesSettings;
+    })()
   );
 
   let store = $derived($settingsStore);


### PR DESCRIPTION
## Summary
- Fixed TypeError in SpeciesSettingsPage when all settings are empty
- Modified settings derivation to ensure config property is always a valid object
- Added fallback empty objects to prevent Object.keys() errors

## Test plan
- [x] Run frontend type checking (`npm run check:all`)
- [x] Verify no TypeScript errors in SpeciesSettingsPage component
- [x] Test that settings page loads without errors when config is empty

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of settings by ensuring that certain properties are always properly initialized, preventing potential errors when accessing settings in the Species Settings page.

* **Documentation**
  * Enhanced guidance on using nullish coalescing versus logical OR for default values in TypeScript, with examples clarifying best practices and common pitfalls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->