### PR TITLE
fix(processor): resolve race condition between DatabaseAction and SSEAction (#1158)

### DIFF
--- a/internal/analysis/processor/execute.go
+++ b/internal/analysis/processor/execute.go
@@ -73,8 +73,7 @@ func (a ExecuteCommandAction) Execute(data any) error {
 	logger.Debug("Executing command with arguments", "command_path", cmdPath, "args", args)
 
 	// Create command with timeout to prevent hanging processes
-	// Use 5 minute timeout for external scripts
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), ExecuteCommandTimeout)
 	defer cancel()
 	
 	cmd := exec.CommandContext(ctx, cmdPath, args...)


### PR DESCRIPTION
## Summary
This PR fixes a critical race condition between `DatabaseAction` and `SSEAction` that was causing timeout errors on resource-constrained hardware, particularly Raspberry Pi systems with SD cards.

## Problem Description
When both database and SSE features were enabled, they executed concurrently via the job queue. `SSEAction` would attempt to query the database for records that `DatabaseAction` hadn't finished saving yet, resulting in:

- ❌ `database ID not assigned for Eastern Wood-Pewee after 10s timeout`
- ❌ `note not found in database`
- ❌ `audio file ... not ready after 5s timeout`

**Root Cause**: Tests confirmed SSE actions started 290-990ms before database operations completed, directly causing the timeout scenarios.

## Solution
Introduced a new `CompositeAction` pattern that:
- 🔄 **Sequential Execution**: Ensures `DatabaseAction` completes before `SSEAction` starts
- ⏱️ **Timeout Protection**: 30-second timeout per action prevents hanging
- 🛡️ **Panic Recovery**: Graceful handling of unexpected errors
- 🔒 **Thread-Safe**: Mutex protection for concurrent access
- 🎯 **Targeted Fix**: Only affects Database+SSE; other actions remain concurrent

## Key Changes

### 1. CompositeAction Implementation
```go
// Sequential execution with comprehensive error handling
type CompositeAction struct {
    Actions     []Action   // Execute in order
    Description string     
    mu          sync.Mutex // Thread-safe access
}
```

### 2. Smart Action Grouping
```go
// Only when BOTH database and SSE are enabled
if databaseAction != nil && sseAction != nil {
    compositeAction := &CompositeAction{
        Actions: []Action{databaseAction, sseAction},
    }
    actions = append(actions, compositeAction)
}
```

### 3. Timeout Constants
- Replaced magic numbers with named constants
- `CompositeActionTimeout = 30s` (generous for slow hardware)
- `SSEDatabaseIDTimeout = 10s`
- `SSEAudioFileTimeout = 5s`

## Test Coverage
- ✅ **Race Condition Tests**: Verify the fix prevents timing issues
- ✅ **Timeout Protection**: Ensures actions don't hang indefinitely  
- ✅ **Panic Recovery**: Graceful handling of action failures
- ✅ **Edge Cases**: Nil actions, empty lists, mixed scenarios
- ✅ **Integration**: Verifies processor creates CompositeAction correctly

## Performance Impact
- **✅ Positive**: Eliminates race condition timeout delays
- **✅ Minimal**: Only Database+SSE are sequential; MQTT, BirdWeather remain concurrent
- **✅ Hardware-Friendly**: Particularly beneficial for Raspberry Pi and slow storage

## Compatibility
- **✅ Backward Compatible**: No breaking changes to existing APIs
- **✅ Configuration**: Existing settings continue to work
- **✅ Graceful**: Handles cases where only database OR SSE is enabled

## Testing
```bash
# All tests pass with race detection
go test -race -v ./internal/analysis/processor/

# Zero linting issues  
golangci-lint run ./internal/analysis/processor/

# Successful build
go build ./cmd/...
```

## Verification
**Before**: SSE started 290-990ms before database completion  
**After**: SSE waits for database, eliminating timeout errors

This fix ensures reliable operation on all hardware, particularly benefiting users running BirdNET-Go on resource-constrained devices.

🤖 Generated with [Claude Code](https://claude.ai/code)