### PR TITLE
feat: add noembed build option for Docker optimization

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -78,6 +78,11 @@ tasks:
 
   native-target:
     cmds:
+      - |
+        if [ "{{.OS}}" = "unsupported" ] || [ "{{.ARCH}}" = "unsupported" ]; then
+          echo "Error: Unsupported platform combination: OS={{.OS}}, ARCH={{.ARCH}}"
+          exit 1
+        fi
       - task: "{{OS}}_{{ARCH}}"
     vars:
       OS:
@@ -91,7 +96,7 @@ tasks:
         sh: |
           case "{{.UNAME_M}}" in
             x86_64) echo "amd64";;
-            aarch64) echo "arm64";;
+            aarch64|arm64) echo "arm64";;
             *) echo "unsupported";;
           esac
 
@@ -264,6 +269,11 @@ tasks:
 
   noembed-native-target:
     cmds:
+      - |
+        if [ "{{.OS}}" = "unsupported" ] || [ "{{.ARCH}}" = "unsupported" ]; then
+          echo "Error: Unsupported platform combination: OS={{.OS}}, ARCH={{.ARCH}}"
+          exit 1
+        fi
       - task: "noembed_{{OS}}_{{ARCH}}"
     vars:
       OS:
@@ -277,7 +287,7 @@ tasks:
         sh: |
           case "{{.UNAME_M}}" in
             x86_64) echo "amd64";;
-            aarch64) echo "arm64";;
+            aarch64|arm64) echo "arm64";;
             *) echo "unsupported";;
           esac
 
@@ -403,99 +413,93 @@ tasks:
       - task: ensure-tflite-symlinks
         vars: {LIB_DIR: '{{.TFLITE_LIB_DIR}}', LIB_FILENAME: '{{.LIB_FILENAME}}'}
 
-  noembed_linux_amd64:
-    desc: Build Linux AMD64 without embedded models
+  # Internal task for building noembed binaries across platforms
+  noembed_build:
+    internal: true
     deps: [check-tools, check-tensorflow, download-avicommons-data, frontend-build]
-    vars:
-      TFLITE_LIB_DIR: '{{.DOCKER_LIB_DIR | default .SYSTEM_LIB_DIR_AMD64}}'
-      TFLITE_LIB_ARCH: linux_amd64.tar.gz
-      TARGET: linux_amd64
     cmds:
       - task: download-tflite
-        vars: {TFLITE_LIB_DIR: '{{.TFLITE_LIB_DIR}}', TFLITE_LIB_ARCH: '{{.TFLITE_LIB_ARCH}}', TARGET: '{{.TARGET}}'}
+        vars: 
+          TFLITE_LIB_DIR: '{{.TFLITE_LIB_DIR}}'
+          TFLITE_LIB_ARCH: '{{.TFLITE_LIB_ARCH}}'
+          TARGET: '{{.TARGET}}'
+      - mkdir -p {{.BINARY_DIR}}
       - |
-        mkdir -p {{.BINARY_DIR}}
-        GOOS=linux GOARCH=amd64 {{.CGO_FLAGS}} \
+        {{if .CROSS_COMPILE_CHECK}}
+        if [ "$(uname -m)" != "{{.CROSS_COMPILE_CHECK}}" ]; then
+          export CC={{.CC}}
+        fi
+        {{else if .CC}}
+        export CC={{.CC}}
+        {{end}}
+        GOOS={{.GOOS}} GOARCH={{.GOARCH}} {{.CGO_FLAGS}} \
           CGO_LDFLAGS="-L{{.TFLITE_LIB_DIR}} -ltensorflowlite_c" \
-          go build -tags noembed {{.BUILD_FLAGS}} -o {{.BINARY_DIR}}/{{.BINARY_NAME}}-noembed
-      - 'echo "Built non-embedded binary: {{.BINARY_DIR}}/{{.BINARY_NAME}}-noembed"'
+          go build -tags noembed {{.BUILD_FLAGS}} -o {{.BINARY_DIR}}/{{.BINARY_NAME}}{{.BINARY_SUFFIX}}
+      - 'echo "Built non-embedded binary: {{.BINARY_DIR}}/{{.BINARY_NAME}}{{.BINARY_SUFFIX}}"'
       - 'echo "Note: This binary requires external model files to run"'
+
+  noembed_linux_amd64:
+    desc: Build Linux AMD64 without embedded models
+    cmds:
+      - task: noembed_build
+        vars:
+          TFLITE_LIB_DIR: '{{.DOCKER_LIB_DIR | default .SYSTEM_LIB_DIR_AMD64}}'
+          TFLITE_LIB_ARCH: linux_amd64.tar.gz
+          TARGET: linux_amd64
+          GOOS: linux
+          GOARCH: amd64
+          BINARY_SUFFIX: ''
 
   noembed_linux_arm64:
     desc: Build Linux ARM64 without embedded models
-    deps: [check-tools, check-tensorflow, download-avicommons-data, frontend-build]
-    vars:
-      TFLITE_LIB_DIR: '{{.DOCKER_LIB_DIR | default .SYSTEM_LIB_DIR_ARM64}}'
-      TFLITE_LIB_ARCH: linux_arm64.tar.gz
-      TARGET: linux_arm64
     cmds:
-      - task: download-tflite
-        vars: {TFLITE_LIB_DIR: '{{.TFLITE_LIB_DIR}}', TFLITE_LIB_ARCH: '{{.TFLITE_LIB_ARCH}}', TARGET: '{{.TARGET}}'}
-      - |
-        mkdir -p {{.BINARY_DIR}}
-        if [ "$(uname -m)" != "aarch64" ]; then
-          export CC=aarch64-linux-gnu-gcc
-        fi
-        GOOS=linux GOARCH=arm64 {{.CGO_FLAGS}} \
-          CGO_LDFLAGS="-L{{.TFLITE_LIB_DIR}} -ltensorflowlite_c" \
-          go build -tags noembed {{.BUILD_FLAGS}} -o {{.BINARY_DIR}}/{{.BINARY_NAME}}-noembed
-      - 'echo "Built non-embedded binary: {{.BINARY_DIR}}/{{.BINARY_NAME}}-noembed"'
-      - 'echo "Note: This binary requires external model files to run"'
+      - task: noembed_build
+        vars:
+          TFLITE_LIB_DIR: '{{.DOCKER_LIB_DIR | default .SYSTEM_LIB_DIR_ARM64}}'
+          TFLITE_LIB_ARCH: linux_arm64.tar.gz
+          TARGET: linux_arm64
+          GOOS: linux
+          GOARCH: arm64
+          CROSS_COMPILE_CHECK: 'aarch64'
+          CC: 'aarch64-linux-gnu-gcc'
+          BINARY_SUFFIX: ''
 
   noembed_windows_amd64:
     desc: Build Windows AMD64 without embedded models
-    deps: [check-tools, check-tensorflow, download-avicommons-data, frontend-build]
-    vars:
-      TFLITE_LIB_DIR: /usr/x86_64-w64-mingw32/lib
-      TFLITE_LIB_ARCH: windows_amd64.zip
-      TARGET: windows_amd64
     cmds:
-      - task: download-tflite
-        vars: {TFLITE_LIB_DIR: '{{.TFLITE_LIB_DIR}}', TFLITE_LIB_ARCH: '{{.TFLITE_LIB_ARCH}}', TARGET: '{{.TARGET}}'}
-      - |
-        mkdir -p {{.BINARY_DIR}}
-        GOOS=windows GOARCH=amd64 {{.CGO_FLAGS}} \
-          CC=x86_64-w64-mingw32-gcc \
-          CGO_LDFLAGS="-L{{.TFLITE_LIB_DIR}} -ltensorflowlite_c" \
-          go build -tags noembed {{.BUILD_FLAGS}} -o {{.BINARY_DIR}}/{{.BINARY_NAME}}-noembed.exe
-      - 'echo "Built non-embedded binary: {{.BINARY_DIR}}/{{.BINARY_NAME}}-noembed.exe"'
-      - 'echo "Note: This binary requires external model files to run"'
+      - task: noembed_build
+        vars:
+          TFLITE_LIB_DIR: /usr/x86_64-w64-mingw32/lib
+          TFLITE_LIB_ARCH: windows_amd64.zip
+          TARGET: windows_amd64
+          GOOS: windows
+          GOARCH: amd64
+          CC: x86_64-w64-mingw32-gcc
+          BINARY_SUFFIX: '.exe'
 
   noembed_darwin_amd64:
     desc: Build Darwin AMD64 without embedded models
-    deps: [check-tools, check-tensorflow, download-avicommons-data, frontend-build]
-    vars:
-      TFLITE_LIB_DIR: /opt/homebrew/lib
-      TFLITE_LIB_ARCH: darwin_amd64.tar.gz
-      TARGET: darwin_amd64
     cmds:
-      - task: download-tflite
-        vars: {TFLITE_LIB_DIR: '{{.TFLITE_LIB_DIR}}', TFLITE_LIB_ARCH: '{{.TFLITE_LIB_ARCH}}', TARGET: '{{.TARGET}}'}
-      - |
-        mkdir -p {{.BINARY_DIR}}
-        GOOS=darwin GOARCH=amd64 {{.CGO_FLAGS}} \
-          CGO_LDFLAGS="-L{{.TFLITE_LIB_DIR}} -ltensorflowlite_c" \
-          go build -tags noembed {{.BUILD_FLAGS}} -o {{.BINARY_DIR}}/{{.BINARY_NAME}}-noembed
-      - 'echo "Built non-embedded binary: {{.BINARY_DIR}}/{{.BINARY_NAME}}-noembed"'
-      - 'echo "Note: This binary requires external model files to run"'
+      - task: noembed_build
+        vars:
+          TFLITE_LIB_DIR: /opt/homebrew/lib
+          TFLITE_LIB_ARCH: darwin_amd64.tar.gz
+          TARGET: darwin_amd64
+          GOOS: darwin
+          GOARCH: amd64
+          BINARY_SUFFIX: ''
 
   noembed_darwin_arm64:
     desc: Build Darwin ARM64 without embedded models
-    deps: [check-tools, check-tensorflow, download-avicommons-data, frontend-build]
-    vars:
-      TFLITE_LIB_DIR: /opt/homebrew/lib
-      TFLITE_LIB_ARCH: darwin_arm64.tar.gz
-      TARGET: darwin_arm64
     cmds:
-      - task: download-tflite
-        vars: {TFLITE_LIB_DIR: '{{.TFLITE_LIB_DIR}}', TFLITE_LIB_ARCH: '{{.TFLITE_LIB_ARCH}}', TARGET: '{{.TARGET}}'}
-      - |
-        mkdir -p {{.BINARY_DIR}}
-        GOOS=darwin GOARCH=arm64 {{.CGO_FLAGS}} \
-          CGO_LDFLAGS="-L{{.TFLITE_LIB_DIR}} -ltensorflowlite_c" \
-          go build -tags noembed {{.BUILD_FLAGS}} -o {{.BINARY_DIR}}/{{.BINARY_NAME}}-noembed
-      - 'echo "Built non-embedded binary: {{.BINARY_DIR}}/{{.BINARY_NAME}}-noembed"'
-      - 'echo "Note: This binary requires external model files to run"'
+      - task: noembed_build
+        vars:
+          TFLITE_LIB_DIR: /opt/homebrew/lib
+          TFLITE_LIB_ARCH: darwin_arm64.tar.gz
+          TARGET: darwin_arm64
+          GOOS: darwin
+          GOARCH: arm64
+          BINARY_SUFFIX: ''
 
   ensure-tflite-symlinks:
     internal: true

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -435,8 +435,8 @@ tasks:
         GOOS={{.GOOS}} GOARCH={{.GOARCH}} {{.CGO_FLAGS}} \
           CGO_LDFLAGS="-L{{.TFLITE_LIB_DIR}} -ltensorflowlite_c" \
           go build -tags noembed {{.BUILD_FLAGS}} -o {{.BINARY_DIR}}/{{.BINARY_NAME}}{{.BINARY_SUFFIX}}
-      - 'echo "Built non-embedded binary: {{.BINARY_DIR}}/{{.BINARY_NAME}}{{.BINARY_SUFFIX}}"'
-      - 'echo "Note: This binary requires external model files to run"'
+        echo "Built non-embedded binary: {{.BINARY_DIR}}/{{.BINARY_NAME}}{{.BINARY_SUFFIX}}"
+        echo "Note: This binary requires external model files to run"
 
   noembed_linux_amd64:
     desc: Build Linux AMD64 without embedded models

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -304,7 +304,7 @@ tasks:
         mkdir -p {{.TFLITE_LIB_DIR}}
         GOOS=linux GOARCH=amd64 {{.CGO_FLAGS}} \
         CGO_LDFLAGS="-L{{.TFLITE_LIB_DIR}} -ltensorflowlite_c" \
-        go build {{.BUILD_FLAGS}} -o {{.BINARY_DIR}}/{{.BINARY_NAME}}
+        go build -trimpath {{.BUILD_FLAGS}} -o {{.BINARY_DIR}}/{{.BINARY_NAME}}
 
   linux_arm64:
     deps: [check-tools, check-tensorflow, download-avicommons-data, frontend-build]
@@ -322,7 +322,7 @@ tasks:
         fi
         GOOS=linux GOARCH=arm64 {{.CGO_FLAGS}} \
         CGO_LDFLAGS="-L{{.TFLITE_LIB_DIR}} -ltensorflowlite_c" \
-        go build {{.BUILD_FLAGS}} -o {{.BINARY_DIR}}/{{.BINARY_NAME}}
+        go build -trimpath {{.BUILD_FLAGS}} -o {{.BINARY_DIR}}/{{.BINARY_NAME}}
 
   windows_amd64:
     deps: [check-tools, check-tensorflow, download-avicommons-data, frontend-build]
@@ -337,12 +337,12 @@ tasks:
         GOOS=windows GOARCH=amd64 {{.CGO_FLAGS}} \
         CC=x86_64-w64-mingw32-gcc \
         CGO_LDFLAGS="-L{{.TFLITE_LIB_DIR}} -ltensorflowlite_c" \
-        go build {{.BUILD_FLAGS}} -o {{.BINARY_DIR}}/{{.BINARY_NAME}}.exe
+        go build -trimpath {{.BUILD_FLAGS}} -o {{.BINARY_DIR}}/{{.BINARY_NAME}}.exe
 
   darwin_amd64:
     deps: [check-tools, check-tensorflow, download-avicommons-data, frontend-build]
     vars:
-      TFLITE_LIB_DIR: /opt/homebrew/lib
+      TFLITE_LIB_DIR: /usr/local/lib
       TFLITE_LIB_ARCH: darwin_amd64.tar.gz
       TARGET: darwin_amd64
     cmds:
@@ -351,7 +351,7 @@ tasks:
       - |
         GOOS=darwin GOARCH=amd64 {{.CGO_FLAGS}} \
         CGO_LDFLAGS="-L{{.TFLITE_LIB_DIR}} -ltensorflowlite_c" \
-        go build {{.BUILD_FLAGS}} -o {{.BINARY_DIR}}/{{.BINARY_NAME}}
+        go build -trimpath {{.BUILD_FLAGS}} -o {{.BINARY_DIR}}/{{.BINARY_NAME}}
 
   darwin_arm64:
     deps: [check-tools, check-tensorflow, download-avicommons-data, frontend-build]
@@ -365,7 +365,7 @@ tasks:
       - |
         GOOS=darwin GOARCH=arm64 {{.CGO_FLAGS}} \
         CGO_LDFLAGS="-L{{.TFLITE_LIB_DIR}} -ltensorflowlite_c" \
-        go build {{.BUILD_FLAGS}} -o {{.BINARY_DIR}}/{{.BINARY_NAME}}
+        go build -trimpath {{.BUILD_FLAGS}} -o {{.BINARY_DIR}}/{{.BINARY_NAME}}
 
   download-tflite:
     internal: true
@@ -434,7 +434,7 @@ tasks:
         {{end}}
         GOOS={{.GOOS}} GOARCH={{.GOARCH}} {{.CGO_FLAGS}} \
           CGO_LDFLAGS="-L{{.TFLITE_LIB_DIR}} -ltensorflowlite_c" \
-          go build -tags noembed {{.BUILD_FLAGS}} -o {{.BINARY_DIR}}/{{.BINARY_NAME}}{{.BINARY_SUFFIX}}
+          go build -trimpath -tags noembed {{.BUILD_FLAGS}} -o {{.BINARY_DIR}}/{{.BINARY_NAME}}{{.BINARY_SUFFIX}}
         echo "Built non-embedded binary: {{.BINARY_DIR}}/{{.BINARY_NAME}}{{.BINARY_SUFFIX}}"
         echo "Note: This binary requires external model files to run"
 
@@ -482,7 +482,7 @@ tasks:
     cmds:
       - task: noembed_build
         vars:
-          TFLITE_LIB_DIR: /opt/homebrew/lib
+          TFLITE_LIB_DIR: /usr/local/lib
           TFLITE_LIB_ARCH: darwin_amd64.tar.gz
           TARGET: darwin_amd64
           GOOS: darwin

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -257,6 +257,30 @@ tasks:
       - rm -f {{.AVICOMMONS_DATA_DIR}}/{{.AVICOMMONS_JSON_FILE}}
       - rm -rf frontend/dist frontend/node_modules
 
+  # Non-embedded builds (without embedded models - smaller binary size)
+  noembed:
+    desc: Build for native platform without embedded models
+    deps: [noembed-native-target]
+
+  noembed-native-target:
+    cmds:
+      - task: "noembed_{{OS}}_{{ARCH}}"
+    vars:
+      OS:
+        sh: |
+          case "{{.UNAME_S}}" in
+            Linux) echo "linux";;
+            Darwin) echo "darwin";;
+            *) echo "unsupported";;
+          esac
+      ARCH:
+        sh: |
+          case "{{.UNAME_M}}" in
+            x86_64) echo "amd64";;
+            aarch64) echo "arm64";;
+            *) echo "unsupported";;
+          esac
+
   linux_amd64:
     deps: [check-tools, check-tensorflow, download-avicommons-data, frontend-build]
     vars:
@@ -378,6 +402,100 @@ tasks:
         fi
       - task: ensure-tflite-symlinks
         vars: {LIB_DIR: '{{.TFLITE_LIB_DIR}}', LIB_FILENAME: '{{.LIB_FILENAME}}'}
+
+  noembed_linux_amd64:
+    desc: Build Linux AMD64 without embedded models
+    deps: [check-tools, check-tensorflow, download-avicommons-data, frontend-build]
+    vars:
+      TFLITE_LIB_DIR: '{{.DOCKER_LIB_DIR | default .SYSTEM_LIB_DIR_AMD64}}'
+      TFLITE_LIB_ARCH: linux_amd64.tar.gz
+      TARGET: linux_amd64
+    cmds:
+      - task: download-tflite
+        vars: {TFLITE_LIB_DIR: '{{.TFLITE_LIB_DIR}}', TFLITE_LIB_ARCH: '{{.TFLITE_LIB_ARCH}}', TARGET: '{{.TARGET}}'}
+      - |
+        mkdir -p {{.BINARY_DIR}}
+        GOOS=linux GOARCH=amd64 {{.CGO_FLAGS}} \
+          CGO_LDFLAGS="-L{{.TFLITE_LIB_DIR}} -ltensorflowlite_c" \
+          go build -tags noembed {{.BUILD_FLAGS}} -o {{.BINARY_DIR}}/{{.BINARY_NAME}}-noembed
+      - 'echo "Built non-embedded binary: {{.BINARY_DIR}}/{{.BINARY_NAME}}-noembed"'
+      - 'echo "Note: This binary requires external model files to run"'
+
+  noembed_linux_arm64:
+    desc: Build Linux ARM64 without embedded models
+    deps: [check-tools, check-tensorflow, download-avicommons-data, frontend-build]
+    vars:
+      TFLITE_LIB_DIR: '{{.DOCKER_LIB_DIR | default .SYSTEM_LIB_DIR_ARM64}}'
+      TFLITE_LIB_ARCH: linux_arm64.tar.gz
+      TARGET: linux_arm64
+    cmds:
+      - task: download-tflite
+        vars: {TFLITE_LIB_DIR: '{{.TFLITE_LIB_DIR}}', TFLITE_LIB_ARCH: '{{.TFLITE_LIB_ARCH}}', TARGET: '{{.TARGET}}'}
+      - |
+        mkdir -p {{.BINARY_DIR}}
+        if [ "$(uname -m)" != "aarch64" ]; then
+          export CC=aarch64-linux-gnu-gcc
+        fi
+        GOOS=linux GOARCH=arm64 {{.CGO_FLAGS}} \
+          CGO_LDFLAGS="-L{{.TFLITE_LIB_DIR}} -ltensorflowlite_c" \
+          go build -tags noembed {{.BUILD_FLAGS}} -o {{.BINARY_DIR}}/{{.BINARY_NAME}}-noembed
+      - 'echo "Built non-embedded binary: {{.BINARY_DIR}}/{{.BINARY_NAME}}-noembed"'
+      - 'echo "Note: This binary requires external model files to run"'
+
+  noembed_windows_amd64:
+    desc: Build Windows AMD64 without embedded models
+    deps: [check-tools, check-tensorflow, download-avicommons-data, frontend-build]
+    vars:
+      TFLITE_LIB_DIR: /usr/x86_64-w64-mingw32/lib
+      TFLITE_LIB_ARCH: windows_amd64.zip
+      TARGET: windows_amd64
+    cmds:
+      - task: download-tflite
+        vars: {TFLITE_LIB_DIR: '{{.TFLITE_LIB_DIR}}', TFLITE_LIB_ARCH: '{{.TFLITE_LIB_ARCH}}', TARGET: '{{.TARGET}}'}
+      - |
+        mkdir -p {{.BINARY_DIR}}
+        GOOS=windows GOARCH=amd64 {{.CGO_FLAGS}} \
+          CC=x86_64-w64-mingw32-gcc \
+          CGO_LDFLAGS="-L{{.TFLITE_LIB_DIR}} -ltensorflowlite_c" \
+          go build -tags noembed {{.BUILD_FLAGS}} -o {{.BINARY_DIR}}/{{.BINARY_NAME}}-noembed.exe
+      - 'echo "Built non-embedded binary: {{.BINARY_DIR}}/{{.BINARY_NAME}}-noembed.exe"'
+      - 'echo "Note: This binary requires external model files to run"'
+
+  noembed_darwin_amd64:
+    desc: Build Darwin AMD64 without embedded models
+    deps: [check-tools, check-tensorflow, download-avicommons-data, frontend-build]
+    vars:
+      TFLITE_LIB_DIR: /opt/homebrew/lib
+      TFLITE_LIB_ARCH: darwin_amd64.tar.gz
+      TARGET: darwin_amd64
+    cmds:
+      - task: download-tflite
+        vars: {TFLITE_LIB_DIR: '{{.TFLITE_LIB_DIR}}', TFLITE_LIB_ARCH: '{{.TFLITE_LIB_ARCH}}', TARGET: '{{.TARGET}}'}
+      - |
+        mkdir -p {{.BINARY_DIR}}
+        GOOS=darwin GOARCH=amd64 {{.CGO_FLAGS}} \
+          CGO_LDFLAGS="-L{{.TFLITE_LIB_DIR}} -ltensorflowlite_c" \
+          go build -tags noembed {{.BUILD_FLAGS}} -o {{.BINARY_DIR}}/{{.BINARY_NAME}}-noembed
+      - 'echo "Built non-embedded binary: {{.BINARY_DIR}}/{{.BINARY_NAME}}-noembed"'
+      - 'echo "Note: This binary requires external model files to run"'
+
+  noembed_darwin_arm64:
+    desc: Build Darwin ARM64 without embedded models
+    deps: [check-tools, check-tensorflow, download-avicommons-data, frontend-build]
+    vars:
+      TFLITE_LIB_DIR: /opt/homebrew/lib
+      TFLITE_LIB_ARCH: darwin_arm64.tar.gz
+      TARGET: darwin_arm64
+    cmds:
+      - task: download-tflite
+        vars: {TFLITE_LIB_DIR: '{{.TFLITE_LIB_DIR}}', TFLITE_LIB_ARCH: '{{.TFLITE_LIB_ARCH}}', TARGET: '{{.TARGET}}'}
+      - |
+        mkdir -p {{.BINARY_DIR}}
+        GOOS=darwin GOARCH=arm64 {{.CGO_FLAGS}} \
+          CGO_LDFLAGS="-L{{.TFLITE_LIB_DIR}} -ltensorflowlite_c" \
+          go build -tags noembed {{.BUILD_FLAGS}} -o {{.BINARY_DIR}}/{{.BINARY_NAME}}-noembed
+      - 'echo "Built non-embedded binary: {{.BINARY_DIR}}/{{.BINARY_NAME}}-noembed"'
+      - 'echo "Note: This binary requires external model files to run"'
 
   ensure-tflite-symlinks:
     internal: true

--- a/internal/birdnet/birdnet.go
+++ b/internal/birdnet/birdnet.go
@@ -237,7 +237,10 @@ func (bn *BirdNET) getMetaModelData() ([]byte, error) {
 	if bn.Settings.BirdNET.RangeFilter.ModelPath != "" {
 		modelPath := bn.Settings.BirdNET.RangeFilter.ModelPath
 		
-		// Expand ~ to home directory if needed
+		// Expand environment variables first
+		modelPath = os.ExpandEnv(modelPath)
+		
+		// Then expand ~ to home directory if needed
 		if strings.HasPrefix(modelPath, "~/") {
 			homeDir, err := os.UserHomeDir()
 			if err != nil {
@@ -545,6 +548,21 @@ func (bn *BirdNET) loadModel() ([]byte, error) {
 	}
 
 	modelPath := bn.Settings.BirdNET.ModelPath
+	// Expand environment variables first
+	modelPath = os.ExpandEnv(modelPath)
+	
+	// Then expand ~ to home directory if needed
+	if strings.HasPrefix(modelPath, "~/") {
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return nil, errors.New(err).
+				Category(errors.CategoryFileIO).
+				Context("path", modelPath).
+				Build()
+		}
+		modelPath = filepath.Join(homeDir, modelPath[2:])
+	}
+	
 	data, err := os.ReadFile(modelPath)
 	if err != nil {
 		return nil, errors.New(err).

--- a/internal/birdnet/birdnet.go
+++ b/internal/birdnet/birdnet.go
@@ -27,19 +27,6 @@ import (
 // Default model version for the embedded model
 const DefaultModelVersion = "BirdNET_GLOBAL_6K_V2.4"
 
-// Embedded TensorFlow Lite model data.
-//
-//go:embed data/BirdNET_GLOBAL_6K_V2.4_Model_FP32.tflite
-var modelData []byte
-
-// Embedded TensorFlow Lite range filter model data.
-//
-//go:embed data/BirdNET_GLOBAL_6K_V2.4_MData_Model_FP16.tflite
-var metaModelDataV1 []byte
-
-//go:embed data/BirdNET_GLOBAL_6K_V2.4_MData_Model_V2_FP16.tflite
-var metaModelDataV2 []byte
-
 // Model version string, default is the embedded model version
 var modelVersion = "BirdNET GLOBAL 6K V2.4 FP32"
 
@@ -207,6 +194,10 @@ func (bn *BirdNET) initializeModel() error {
 	if status := bn.AnalysisInterpreter.AllocateTensors(); status != tflite.OK {
 		return fmt.Errorf("tensor allocation failed")
 	}
+	
+	// Force garbage collection to reclaim memory from model loading
+	// The model data is no longer needed as TFLite has created its own internal copy
+	runtime.GC()
 
 	// Update model version based on custom model path if provided
 	if bn.Settings.BirdNET.ModelPath != "" {
@@ -241,19 +232,65 @@ func (bn *BirdNET) initializeModel() error {
 }
 
 // getMetaModelData returns the appropriate meta model data based on the settings.
-func (bn *BirdNET) getMetaModelData() []byte {
-	if bn.Settings.BirdNET.RangeFilter.Model == "legacy" {
-		fmt.Printf("⚠️ Using legacy range filter model")
-		return metaModelDataV1
+func (bn *BirdNET) getMetaModelData() ([]byte, error) {
+	// Check if external model path is specified
+	if bn.Settings.BirdNET.RangeFilter.ModelPath != "" {
+		modelPath := bn.Settings.BirdNET.RangeFilter.ModelPath
+		
+		// Expand ~ to home directory if needed
+		if strings.HasPrefix(modelPath, "~/") {
+			homeDir, err := os.UserHomeDir()
+			if err != nil {
+				return nil, errors.New(err).
+					Category(errors.CategoryFileIO).
+					Context("path", modelPath).
+					Build()
+			}
+			modelPath = filepath.Join(homeDir, modelPath[2:])
+		}
+		
+		// Load model from external file
+		data, err := os.ReadFile(modelPath)
+		if err != nil {
+			return nil, errors.New(err).
+				Category(errors.CategoryFileIO).
+				Context("path", modelPath).
+				Context("range_filter_model", bn.Settings.BirdNET.RangeFilter.Model).
+				Build()
+		}
+		
+		fmt.Printf("📁 Loaded range filter model from: %s\n", modelPath)
+		return data, nil
 	}
-	return metaModelDataV2
+	
+	// Fall back to embedded models
+	var data []byte
+	if bn.Settings.BirdNET.RangeFilter.Model == "legacy" {
+		fmt.Printf("⚠️ Using legacy range filter model\n")
+		data = metaModelDataV1
+	} else {
+		data = metaModelDataV2
+	}
+	
+	if !hasEmbeddedModels || data == nil {
+		return nil, errors.Newf("range filter model not available (built with noembed tag, specify ModelPath in RangeFilter config)").
+			Category(errors.CategoryModelLoad).
+			Context("embedded_models", hasEmbeddedModels).
+			Context("range_filter_model", bn.Settings.BirdNET.RangeFilter.Model).
+			Build()
+	}
+	
+	return data, nil
 }
 
 // initializeMetaModel loads and initializes the meta model used for range filtering.
 func (bn *BirdNET) initializeMetaModel() error {
 	start := time.Now()
 
-	metaModelData := bn.getMetaModelData()
+	metaModelData, err := bn.getMetaModelData()
+	if err != nil {
+		return err
+	}
 
 	model := tflite.NewModel(metaModelData)
 	if model == nil {
@@ -290,6 +327,10 @@ func (bn *BirdNET) initializeMetaModel() error {
 			Timing("meta-model-allocate", time.Since(start)).
 			Build()
 	}
+	
+	// Force garbage collection to reclaim memory from meta model loading
+	// The model data is no longer needed as TFLite has created its own internal copy
+	runtime.GC()
 
 	return nil
 }
@@ -494,6 +535,12 @@ func (bn *BirdNET) loadModel() ([]byte, error) {
 	start := time.Now()
 
 	if bn.Settings.BirdNET.ModelPath == "" {
+		if !hasEmbeddedModels || modelData == nil {
+			return nil, errors.Newf("no model path specified and no embedded model available (built with noembed tag)").
+				Category(errors.CategoryModelLoad).
+				Context("embedded_models", hasEmbeddedModels).
+				Build()
+		}
 		return modelData, nil
 	}
 

--- a/internal/birdnet/models_embedded.go
+++ b/internal/birdnet/models_embedded.go
@@ -1,0 +1,26 @@
+//go:build !noembed
+
+package birdnet
+
+import (
+	_ "embed" // Embedding data directly into the binary.
+)
+
+// This file is included by default (when NOT using -tags noembed)
+// It provides the embedded TensorFlow Lite models for a monolithic build.
+
+// Embedded TensorFlow Lite model data.
+//
+//go:embed data/BirdNET_GLOBAL_6K_V2.4_Model_FP32.tflite
+var modelData []byte
+
+// Embedded TensorFlow Lite range filter model data.
+//
+//go:embed data/BirdNET_GLOBAL_6K_V2.4_MData_Model_FP16.tflite
+var metaModelDataV1 []byte
+
+//go:embed data/BirdNET_GLOBAL_6K_V2.4_MData_Model_V2_FP16.tflite
+var metaModelDataV2 []byte
+
+// hasEmbeddedModels indicates whether models are embedded in the binary
+const hasEmbeddedModels = true

--- a/internal/birdnet/models_embedded.go
+++ b/internal/birdnet/models_embedded.go
@@ -23,4 +23,5 @@ var metaModelDataV1 []byte
 var metaModelDataV2 []byte
 
 // hasEmbeddedModels indicates whether models are embedded in the binary
-const hasEmbeddedModels = true
+// This is a var instead of const to allow test overrides
+var hasEmbeddedModels = true

--- a/internal/birdnet/models_external.go
+++ b/internal/birdnet/models_external.go
@@ -16,4 +16,5 @@ var metaModelDataV1 []byte
 var metaModelDataV2 []byte
 
 // hasEmbeddedModels indicates whether models are embedded in the binary
-const hasEmbeddedModels = false
+// This is a var instead of const to allow test overrides
+var hasEmbeddedModels = false

--- a/internal/birdnet/models_external.go
+++ b/internal/birdnet/models_external.go
@@ -1,0 +1,19 @@
+//go:build noembed
+
+package birdnet
+
+// This file is included when building with -tags noembed
+// It provides empty model data variables for a non-monolithic build
+// where models must be loaded from external files.
+
+// modelData is nil when models are not embedded
+var modelData []byte
+
+// metaModelDataV1 is nil when models are not embedded
+var metaModelDataV1 []byte
+
+// metaModelDataV2 is nil when models are not embedded
+var metaModelDataV2 []byte
+
+// hasEmbeddedModels indicates whether models are embedded in the binary
+const hasEmbeddedModels = false

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -548,7 +548,8 @@ type BirdNETConfig struct {
 // RangeFilterSettings contains settings for the range filter
 type RangeFilterSettings struct {
 	Debug       bool      `json:"debug"`                          // true to enable debug mode
-	Model       string    `json:"model"`                          // range filter model model
+	Model       string    `json:"model"`                          // range filter model version: "legacy" for v1, or empty/default for v2
+	ModelPath   string    `json:"modelPath"`                      // path to external meta model file (empty for embedded)
 	Threshold   float32   `json:"threshold"`                      // rangefilter species occurrence threshold
 	Species     []string  `yaml:"-" json:"species,omitempty"`     // list of included species, runtime value
 	LastUpdated time.Time `yaml:"-" json:"lastUpdated,omitempty"` // last time the species list was updated, runtime value


### PR DESCRIPTION
## Summary
- Add support for building BirdNET-Go without embedded models to reduce binary size
- Refactor Taskfile to eliminate duplication and improve platform detection
- Enable external model loading for containerized deployments

## Changes
1. **Add noembed build tags**: New build tags allow compiling without embedded TFLite models
2. **Refactor Taskfile**: Consolidate 5 duplicated noembed_* tasks into single reusable internal task
3. **Improve architecture detection**: Fix ARCH mapping to properly support macOS arm64 and add platform validation
4. **Standardize binary naming**: Remove -noembed suffix for consistency with embedded builds

## Benefits
- Reduces Docker image size significantly (models can be mounted as volumes)
- Improves build maintainability with DRY principle
- Better cross-platform support with proper architecture detection

## Test Plan
- [ ] Build with embedded models (default) works as before
- [ ] Build with noembed tag produces functional binary
- [ ] External model loading works correctly
- [ ] All platform-specific builds complete successfully

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Optional build variant without embedded models; load models from external files.
  - New configuration option to set an external range-filter model path (supports legacy and v2).
  - Automatic download of required Avicommons data during build.

- Improvements
  - More robust platform detection with arm64 unification and early errors on unsupported OS/ARCH.
  - Clearer logs when using external or legacy range-filter models.
  - Reduced memory spikes via extra cleanup after model and meta‑model loading.
  - Build reproducibility tweaks for cross-platform builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->