### PR TITLE
fix: lower priority of timeout errors to reduce notification noise

### DIFF
--- a/internal/birdweather/birdweather_client.go
+++ b/internal/birdweather/birdweather_client.go
@@ -284,9 +284,17 @@ func handleHTTPResponse(resp *http.Response, expectedStatus int, operation, mask
 				"status_code", resp.StatusCode,
 				"html_error", htmlError,
 				"response_preview", string(responseBody[:min(len(responseBody), 500)]))
+			
+			// Determine category based on status code
+			category := errors.CategoryNetwork
+			if resp.StatusCode == 408 || resp.StatusCode == 504 || resp.StatusCode == 524 {
+				// 408 Request Timeout, 504 Gateway Timeout, 524 Timeout (Cloudflare)
+				category = errors.CategoryTimeout
+			}
+			
 			return nil, errors.New(fmt.Errorf("%s failed: %s (status %d)", operation, htmlError, resp.StatusCode)).
 				Component("birdweather").
-				Category(errors.CategoryNetwork).
+				Category(category).
 				Context("response_type", "html").
 				Context("status_code", resp.StatusCode).
 				Context("operation", operation).

--- a/internal/notification/error_integration.go
+++ b/internal/notification/error_integration.go
@@ -78,7 +78,7 @@ func getNotificationPriority(category, explicitPriority string) Priority {
 	case string(errors.CategoryThreshold), string(errors.CategorySpeciesTracking):
 		return PriorityMedium // Important but not critical
 	case string(errors.CategoryTimeout), string(errors.CategoryRetry):
-		return PriorityMedium // Transient issues
+		return PriorityLow // Transient issues - don't bother users with these
 	case string(errors.CategoryCancellation), string(errors.CategoryBroadcast), string(errors.CategoryIntegration):
 		return PriorityMedium // General operational issues
 	case string(errors.CategoryValidation):

--- a/internal/notification/error_integration_test.go
+++ b/internal/notification/error_integration_test.go
@@ -28,8 +28,8 @@ func TestGetNotificationPriority(t *testing.T) {
 		// Medium priorities
 		{"Threshold", string(errors.CategoryThreshold), PriorityMedium},
 		{"SpeciesTracking", string(errors.CategorySpeciesTracking), PriorityMedium},
-		{"Timeout", string(errors.CategoryTimeout), PriorityMedium},
-		{"Retry", string(errors.CategoryRetry), PriorityMedium},
+		{"Timeout", string(errors.CategoryTimeout), PriorityLow},
+		{"Retry", string(errors.CategoryRetry), PriorityLow},
 		{"Cancellation", string(errors.CategoryCancellation), PriorityMedium},
 		{"Broadcast", string(errors.CategoryBroadcast), PriorityMedium},
 		{"Integration", string(errors.CategoryIntegration), PriorityMedium},


### PR DESCRIPTION
## Summary
- Lowered priority of timeout and retry errors from Medium to Low
- Fixed Birdweather 504 Gateway Timeout categorization (was CategoryNetwork, now CategoryTimeout)
- Also handles 408 Request Timeout and 524 Cloudflare Timeout errors

## Problem
Users were receiving medium-priority notifications for transient timeout errors:
- "context deadline exceeded" from jobqueue
- "504 Gateway Timeout" from Birdweather API

These are temporary network issues that typically resolve themselves and shouldn't bother users with notifications.

## Solution
1. Changed `CategoryTimeout` and `CategoryRetry` error priorities from `PriorityMedium` to `PriorityLow` in the notification system
2. Fixed Birdweather client to properly categorize HTTP timeout status codes (408, 504, 524) as `CategoryTimeout` instead of `CategoryNetwork`

## Test plan
- [x] All existing tests pass
- [x] Linter reports 0 issues
- [x] Build completes successfully
- [ ] Manual testing: Verify timeout errors no longer create user notifications

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved error classification: timeout HTTP statuses (408, 504, 524) are now correctly treated as timeouts rather than generic network errors, enabling clearer handling and messaging.
  - Reduced notification noise: timeout and retry-related issues are now surfaced as low-priority notifications to minimize unnecessary alerts.

- Tests
  - Updated tests to reflect the adjusted notification priority and refined timeout error categorization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->