### PR TITLE
feat: add environment variable support for Docker model paths

### DIFF
--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -13,23 +13,27 @@ services:
       - BIRDNET_GID=${BIRDNET_GID:-1000}
       # Optional: uncomment to configure via environment variables
       # BirdNET Configuration
-      # - BIRDNET_LOCALE=en-us
-      # - BIRDNET_LATITUDE=60.192059
-      # - BIRDNET_LONGITUDE=24.945831
-      # - BIRDNET_SENSITIVITY=1.0
-      # - BIRDNET_THRESHOLD=0.8
-      # - BIRDNET_OVERLAP=1.5
-      # - BIRDNET_THREADS=0
-      # - BIRDNET_DEBUG=false
-      # - BIRDNET_USEXNNPACK=true
-      # Model Paths (for external models)
-      # - BIRDNET_MODELPATH=/path/to/model.tflite
-      # - BIRDNET_LABELPATH=/path/to/labels.txt
+      # - BIRDNET_LOCALE=en-us                      # Locale code (2-10 chars, e.g., "en" or "en-us")
+      # - BIRDNET_LATITUDE=60.192059                # Valid range: -90.0 to 90.0
+      # - BIRDNET_LONGITUDE=24.945831               # Valid range: -180.0 to 180.0
+      # - BIRDNET_SENSITIVITY=1.0                   # Valid range: 0.1 to 1.5 (higher = more sensitive)
+      # - BIRDNET_THRESHOLD=0.8                     # Valid range: 0.0 to 1.0 (confidence threshold)
+      # - BIRDNET_OVERLAP=1.5                       # Valid range: 0.0 to 2.9 seconds (audio chunk overlap)
+      # - BIRDNET_THREADS=0                         # 0 = auto (use all CPUs), or specify number of threads
+      # - BIRDNET_DEBUG=false                       # Enable debug logging (true/false)
+      # - BIRDNET_USEXNNPACK=true                   # Use XNNPACK acceleration (true/false)
+      # Model Paths (for external models - must be mounted from host)
+      # Note: External model files must be mounted into the container, e.g.:
+      #   volumes:
+      #     - ./models/custom.tflite:/models/custom.tflite
+      # Then reference the container path:
+      # - BIRDNET_MODELPATH=/models/custom.tflite   # Path to custom model file inside container
+      # - BIRDNET_LABELPATH=/models/labels.txt      # Path to custom labels file inside container
       # Range Filter Configuration
-      # - BIRDNET_RANGEFILTER_MODEL=latest
-      # - BIRDNET_RANGEFILTER_THRESHOLD=0.01
-      # - BIRDNET_RANGEFILTER_MODELPATH=/path/to/rangefilter.tflite
-      # - BIRDNET_RANGEFILTER_DEBUG=false
+      # - BIRDNET_RANGEFILTER_MODEL=latest          # Model version: "latest" or "legacy"
+      # - BIRDNET_RANGEFILTER_THRESHOLD=0.01        # Valid range: 0.0 to 1.0 (range filter threshold)
+      # - BIRDNET_RANGEFILTER_MODELPATH=/models/rangefilter.tflite # Path to custom range filter model
+      # - BIRDNET_RANGEFILTER_DEBUG=false           # Enable range filter debug logging (true/false)
     volumes:
       - ./config:/config
       - ./data:/data

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -12,11 +12,24 @@ services:
       - BIRDNET_UID=${BIRDNET_UID:-1000}
       - BIRDNET_GID=${BIRDNET_GID:-1000}
       # Optional: uncomment to configure via environment variables
+      # BirdNET Configuration
       # - BIRDNET_LOCALE=en-us
       # - BIRDNET_LATITUDE=60.192059
       # - BIRDNET_LONGITUDE=24.945831
       # - BIRDNET_SENSITIVITY=1.0
+      # - BIRDNET_THRESHOLD=0.8
       # - BIRDNET_OVERLAP=1.5
+      # - BIRDNET_THREADS=0
+      # - BIRDNET_DEBUG=false
+      # - BIRDNET_USEXNNPACK=true
+      # Model Paths (for external models)
+      # - BIRDNET_MODELPATH=/path/to/model.tflite
+      # - BIRDNET_LABELPATH=/path/to/labels.txt
+      # Range Filter Configuration
+      # - BIRDNET_RANGEFILTER_MODEL=latest
+      # - BIRDNET_RANGEFILTER_THRESHOLD=0.01
+      # - BIRDNET_RANGEFILTER_MODELPATH=/path/to/rangefilter.tflite
+      # - BIRDNET_RANGEFILTER_DEBUG=false
     volumes:
       - ./config:/config
       - ./data:/data

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -970,7 +970,8 @@ func initViper() error {
 
 	// Configure environment variable support
 	if err := configureEnvironmentVariables(); err != nil {
-		// Log any issues but don't fail startup
+		// Log any validation warnings but don't fail startup
+		// This allows the application to continue with config file/default values
 		log.Printf("Environment variable configuration warning: %v", err)
 	}
 

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -962,10 +962,17 @@ func Load() (*Settings, error) {
 	return settingsInstance, nil
 }
 
+
 // initViper initializes viper with default values and reads the configuration file.
 func initViper() error {
 	viper.SetConfigName("config")
 	viper.SetConfigType("yaml")
+
+	// Configure environment variable support
+	if err := configureEnvironmentVariables(); err != nil {
+		// Log any issues but don't fail startup
+		log.Printf("Environment variable configuration warning: %v", err)
+	}
 
 	// Get OS specific config paths
 	configPaths, err := GetDefaultConfigPaths()

--- a/internal/conf/env.go
+++ b/internal/conf/env.go
@@ -1,0 +1,196 @@
+// env.go - Environment variable configuration and validation for BirdNET-Go
+package conf
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/viper"
+)
+
+// envBinding holds metadata for environment variable bindings (internal use)
+type envBinding struct {
+	ConfigKey string             // Viper config key
+	EnvVar    string             // Environment variable name
+	Validate  func(string) error // Optional validation function
+}
+
+// getEnvBindings returns all environment variable bindings with validation
+func getEnvBindings() []envBinding {
+	return []envBinding{
+		// BirdNET Core Configuration
+		{"birdnet.locale", "BIRDNET_LOCALE", validateEnvLocale},
+		{"birdnet.latitude", "BIRDNET_LATITUDE", validateEnvLatitude},
+		{"birdnet.longitude", "BIRDNET_LONGITUDE", validateEnvLongitude},
+		{"birdnet.sensitivity", "BIRDNET_SENSITIVITY", validateEnvSensitivity},
+		{"birdnet.threshold", "BIRDNET_THRESHOLD", validateEnvThreshold},
+		{"birdnet.overlap", "BIRDNET_OVERLAP", validateEnvOverlap},
+		{"birdnet.threads", "BIRDNET_THREADS", validateEnvThreads},
+		{"birdnet.debug", "BIRDNET_DEBUG", nil}, // Bool validation handled by viper
+		{"birdnet.usexnnpack", "BIRDNET_USEXNNPACK", nil}, // Bool validation handled by viper
+		
+		// Model Paths
+		{"birdnet.modelpath", "BIRDNET_MODELPATH", validateEnvPath},
+		{"birdnet.labelpath", "BIRDNET_LABELPATH", validateEnvPath},
+		
+		// Range Filter Configuration
+		{"birdnet.rangefilter.model", "BIRDNET_RANGEFILTER_MODEL", validateEnvRangeFilterModel},
+		{"birdnet.rangefilter.threshold", "BIRDNET_RANGEFILTER_THRESHOLD", validateEnvRangeFilterThreshold},
+		{"birdnet.rangefilter.modelpath", "BIRDNET_RANGEFILTER_MODELPATH", validateEnvPath},
+		{"birdnet.rangefilter.debug", "BIRDNET_RANGEFILTER_DEBUG", nil}, // Bool validation handled by viper
+	}
+}
+
+// bindEnvVars sets up environment variable bindings with validation (internal)
+func bindEnvVars() error {
+	bindings := getEnvBindings()
+	var warnings []string
+
+	for _, binding := range bindings {
+		// Bind the environment variable to the config key
+		if err := viper.BindEnv(binding.ConfigKey, binding.EnvVar); err != nil {
+			warnings = append(warnings, fmt.Sprintf("Failed to bind %s: %v", binding.EnvVar, err))
+			continue
+		}
+
+		// Validate the value if it's set and validation function is provided
+		if binding.Validate != nil {
+			if envValue := os.Getenv(binding.EnvVar); envValue != "" {
+				if err := binding.Validate(envValue); err != nil {
+					warnings = append(warnings, fmt.Sprintf("Invalid %s value '%s': %v", binding.EnvVar, envValue, err))
+				}
+			}
+		}
+	}
+
+	if len(warnings) > 0 {
+		return fmt.Errorf("environment variable issues:\n  - %s", strings.Join(warnings, "\n  - "))
+	}
+
+	return nil
+}
+
+// Environment variable validation functions
+
+func validateEnvLocale(value string) error {
+	if len(value) < 2 || len(value) > 10 {
+		return fmt.Errorf("locale must be 2-10 characters, got %d", len(value))
+	}
+	return nil
+}
+
+func validateEnvLatitude(value string) error {
+	lat, err := strconv.ParseFloat(value, 64)
+	if err != nil {
+		return fmt.Errorf("invalid latitude: %w", err)
+	}
+	if lat < -90 || lat > 90 {
+		return fmt.Errorf("latitude must be between -90 and 90, got %g", lat)
+	}
+	return nil
+}
+
+func validateEnvLongitude(value string) error {
+	lng, err := strconv.ParseFloat(value, 64)
+	if err != nil {
+		return fmt.Errorf("invalid longitude: %w", err)
+	}
+	if lng < -180 || lng > 180 {
+		return fmt.Errorf("longitude must be between -180 and 180, got %g", lng)
+	}
+	return nil
+}
+
+func validateEnvSensitivity(value string) error {
+	sensitivity, err := strconv.ParseFloat(value, 64)
+	if err != nil {
+		return fmt.Errorf("invalid sensitivity: %w", err)
+	}
+	if sensitivity < 0.1 || sensitivity > 1.5 {
+		return fmt.Errorf("sensitivity must be between 0.1 and 1.5, got %g", sensitivity)
+	}
+	return nil
+}
+
+func validateEnvThreshold(value string) error {
+	threshold, err := strconv.ParseFloat(value, 64)
+	if err != nil {
+		return fmt.Errorf("invalid threshold: %w", err)
+	}
+	if threshold < 0.0 || threshold > 1.0 {
+		return fmt.Errorf("threshold must be between 0.0 and 1.0, got %g", threshold)
+	}
+	return nil
+}
+
+func validateEnvOverlap(value string) error {
+	overlap, err := strconv.ParseFloat(value, 64)
+	if err != nil {
+		return fmt.Errorf("invalid overlap: %w", err)
+	}
+	if overlap < 0.0 || overlap > 2.9 {
+		return fmt.Errorf("overlap must be between 0.0 and 2.9, got %g", overlap)
+	}
+	return nil
+}
+
+func validateEnvThreads(value string) error {
+	threads, err := strconv.Atoi(value)
+	if err != nil {
+		return fmt.Errorf("invalid threads: %w", err)
+	}
+	if threads < 0 {
+		return fmt.Errorf("threads must be non-negative, got %d", threads)
+	}
+	return nil
+}
+
+func validateEnvRangeFilterModel(value string) error {
+	validModels := []string{"latest", "legacy"}
+	for _, valid := range validModels {
+		if value == valid {
+			return nil
+		}
+	}
+	return fmt.Errorf("must be one of: %s", strings.Join(validModels, ", "))
+}
+
+func validateEnvRangeFilterThreshold(value string) error {
+	threshold, err := strconv.ParseFloat(value, 64)
+	if err != nil {
+		return fmt.Errorf("invalid range filter threshold: %w", err)
+	}
+	if threshold < 0.0 || threshold > 1.0 {
+		return fmt.Errorf("range filter threshold must be between 0.0 and 1.0, got %g", threshold)
+	}
+	return nil
+}
+
+func validateEnvPath(value string) error {
+	// Basic path traversal protection
+	if strings.Contains(value, "..") {
+		return fmt.Errorf("path traversal not allowed")
+	}
+	// Could add more path validation here (check if file exists, etc.)
+	return nil
+}
+
+// configureEnvironmentVariables sets up environment variable support for Viper
+func configureEnvironmentVariables() error {
+	// Enable automatic environment variable reading
+	viper.AutomaticEnv()
+	viper.SetEnvPrefix("BIRDNET")
+	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+	
+	// Bind specific environment variables with validation
+	if err := bindEnvVars(); err != nil {
+		// Log warnings but don't fail startup
+		// This allows the application to continue with config file/default values
+		log.Printf("Environment variable validation warnings: %v", err)
+	}
+	
+	return nil
+}

--- a/internal/conf/env.go
+++ b/internal/conf/env.go
@@ -303,18 +303,12 @@ func canonicalizeValue(configKey, envValue string) {
 	case ConfigKeyDebug, ConfigKeyUseXNNPACK, ConfigKeyRangeFilterDebug:
 		if parsed, err := strconv.ParseBool(strings.ToLower(trimmed)); err == nil {
 			viper.Set(configKey, parsed)
-		} else {
-			// Safe fallback: set trimmed string if parsing fails unexpectedly
-			viper.Set(configKey, trimmed)
 		}
 		
 	// Integer values
 	case ConfigKeyThreads:
 		if parsed, err := strconv.Atoi(trimmed); err == nil {
 			viper.Set(configKey, parsed)
-		} else {
-			// Safe fallback: set trimmed string if parsing fails unexpectedly
-			viper.Set(configKey, trimmed)
 		}
 		
 	// Float64 values
@@ -322,9 +316,6 @@ func canonicalizeValue(configKey, envValue string) {
 		 ConfigKeyThreshold, ConfigKeyOverlap, ConfigKeyRangeFilterThreshold:
 		if parsed, err := strconv.ParseFloat(trimmed, 64); err == nil {
 			viper.Set(configKey, parsed)
-		} else {
-			// Safe fallback: set trimmed string if parsing fails unexpectedly
-			viper.Set(configKey, trimmed)
 		}
 		
 	// String values (including locale with special handling)
@@ -334,10 +325,6 @@ func canonicalizeValue(configKey, envValue string) {
 		
 	case ConfigKeyModelPath, ConfigKeyLabelPath, ConfigKeyRangeFilterModel, ConfigKeyRangeFilterModelPath:
 		// Regular string values - just trim whitespace
-		viper.Set(configKey, trimmed)
-		
-	default:
-		// Safe fallback for any unhandled config keys - set trimmed string
 		viper.Set(configKey, trimmed)
 	}
 }

--- a/internal/conf/env.go
+++ b/internal/conf/env.go
@@ -13,6 +13,54 @@ import (
 	"github.com/spf13/viper"
 )
 
+// Configuration key constants
+const (
+	// BirdNET Core Configuration
+	ConfigKeyLocale      = "birdnet.locale"
+	ConfigKeyLatitude    = "birdnet.latitude"
+	ConfigKeyLongitude   = "birdnet.longitude"
+	ConfigKeySensitivity = "birdnet.sensitivity"
+	ConfigKeyThreshold   = "birdnet.threshold"
+	ConfigKeyOverlap     = "birdnet.overlap"
+	ConfigKeyThreads     = "birdnet.threads"
+	ConfigKeyDebug       = "birdnet.debug"
+	ConfigKeyUseXNNPack  = "birdnet.usexnnpack"
+
+	// Model Paths
+	ConfigKeyModelPath = "birdnet.modelpath"
+	ConfigKeyLabelPath = "birdnet.labelpath"
+
+	// Range Filter Configuration
+	ConfigKeyRangeFilterModel     = "birdnet.rangefilter.model"
+	ConfigKeyRangeFilterThreshold = "birdnet.rangefilter.threshold"
+	ConfigKeyRangeFilterModelPath = "birdnet.rangefilter.modelpath"
+	ConfigKeyRangeFilterDebug     = "birdnet.rangefilter.debug"
+)
+
+// Environment variable name constants
+const (
+	// BirdNET Core Configuration
+	EnvVarLocale      = "BIRDNET_LOCALE"
+	EnvVarLatitude    = "BIRDNET_LATITUDE"
+	EnvVarLongitude   = "BIRDNET_LONGITUDE"
+	EnvVarSensitivity = "BIRDNET_SENSITIVITY"
+	EnvVarThreshold   = "BIRDNET_THRESHOLD"
+	EnvVarOverlap     = "BIRDNET_OVERLAP"
+	EnvVarThreads     = "BIRDNET_THREADS"
+	EnvVarDebug       = "BIRDNET_DEBUG"
+	EnvVarUseXNNPack  = "BIRDNET_USEXNNPACK"
+
+	// Model Paths
+	EnvVarModelPath = "BIRDNET_MODELPATH"
+	EnvVarLabelPath = "BIRDNET_LABELPATH"
+
+	// Range Filter Configuration
+	EnvVarRangeFilterModel     = "BIRDNET_RANGEFILTER_MODEL"
+	EnvVarRangeFilterThreshold = "BIRDNET_RANGEFILTER_THRESHOLD"
+	EnvVarRangeFilterModelPath = "BIRDNET_RANGEFILTER_MODELPATH"
+	EnvVarRangeFilterDebug     = "BIRDNET_RANGEFILTER_DEBUG"
+)
+
 // envBinding holds metadata for environment variable bindings (internal use)
 type envBinding struct {
 	ConfigKey string             // Viper config key
@@ -24,25 +72,25 @@ type envBinding struct {
 func getEnvBindings() []envBinding {
 	return []envBinding{
 		// BirdNET Core Configuration
-		{"birdnet.locale", "BIRDNET_LOCALE", validateEnvLocale},
-		{"birdnet.latitude", "BIRDNET_LATITUDE", validateEnvLatitude},
-		{"birdnet.longitude", "BIRDNET_LONGITUDE", validateEnvLongitude},
-		{"birdnet.sensitivity", "BIRDNET_SENSITIVITY", validateEnvSensitivity},
-		{"birdnet.threshold", "BIRDNET_THRESHOLD", validateEnvThreshold},
-		{"birdnet.overlap", "BIRDNET_OVERLAP", validateEnvOverlap},
-		{"birdnet.threads", "BIRDNET_THREADS", validateEnvThreads},
-		{"birdnet.debug", "BIRDNET_DEBUG", validateEnvBool},
-		{"birdnet.usexnnpack", "BIRDNET_USEXNNPACK", validateEnvBool},
+		{ConfigKeyLocale, EnvVarLocale, validateEnvLocale},
+		{ConfigKeyLatitude, EnvVarLatitude, validateEnvLatitude},
+		{ConfigKeyLongitude, EnvVarLongitude, validateEnvLongitude},
+		{ConfigKeySensitivity, EnvVarSensitivity, validateEnvSensitivity},
+		{ConfigKeyThreshold, EnvVarThreshold, validateEnvThreshold},
+		{ConfigKeyOverlap, EnvVarOverlap, validateEnvOverlap},
+		{ConfigKeyThreads, EnvVarThreads, validateEnvThreads},
+		{ConfigKeyDebug, EnvVarDebug, validateEnvBool},
+		{ConfigKeyUseXNNPack, EnvVarUseXNNPack, validateEnvBool},
 		
 		// Model Paths
-		{"birdnet.modelpath", "BIRDNET_MODELPATH", validateEnvPath},
-		{"birdnet.labelpath", "BIRDNET_LABELPATH", validateEnvPath},
+		{ConfigKeyModelPath, EnvVarModelPath, validateEnvPath},
+		{ConfigKeyLabelPath, EnvVarLabelPath, validateEnvPath},
 		
 		// Range Filter Configuration
-		{"birdnet.rangefilter.model", "BIRDNET_RANGEFILTER_MODEL", validateEnvRangeFilterModel},
-		{"birdnet.rangefilter.threshold", "BIRDNET_RANGEFILTER_THRESHOLD", validateEnvRangeFilterThreshold},
-		{"birdnet.rangefilter.modelpath", "BIRDNET_RANGEFILTER_MODELPATH", validateEnvPath},
-		{"birdnet.rangefilter.debug", "BIRDNET_RANGEFILTER_DEBUG", validateEnvBool},
+		{ConfigKeyRangeFilterModel, EnvVarRangeFilterModel, validateEnvRangeFilterModel},
+		{ConfigKeyRangeFilterThreshold, EnvVarRangeFilterThreshold, validateEnvRangeFilterThreshold},
+		{ConfigKeyRangeFilterModelPath, EnvVarRangeFilterModelPath, validateEnvPath},
+		{ConfigKeyRangeFilterDebug, EnvVarRangeFilterDebug, validateEnvBool},
 	}
 }
 
@@ -194,7 +242,15 @@ func validateEnvRangeFilterThreshold(value string) error {
 }
 
 func validateEnvPath(value string) error {
-	// Clean the path first to normalize it
+	// Trim leading/trailing whitespace first
+	value = strings.TrimSpace(value)
+	
+	// Explicitly reject empty input
+	if value == "" {
+		return fmt.Errorf("path must not be empty")
+	}
+	
+	// Clean the path to normalize it
 	cleanedPath := filepath.Clean(value)
 	
 	// Require absolute paths for security

--- a/internal/conf/env_test.go
+++ b/internal/conf/env_test.go
@@ -1,0 +1,175 @@
+package conf
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateEnvBool(t *testing.T) {
+	t.Parallel()
+	
+	tests := []struct {
+		name    string
+		value   string
+		wantErr bool
+	}{
+		{"true", "true", false},
+		{"false", "false", false},
+		{"1", "1", false},
+		{"0", "0", false},
+		{"t", "t", false},
+		{"f", "f", false},
+		{"TRUE", "TRUE", false},
+		{"FALSE", "FALSE", false},
+		{"invalid", "maybe", true},
+		{"yes", "yes", true}, // strconv.ParseBool doesn't accept yes/no
+		{"no", "no", true},   // strconv.ParseBool doesn't accept yes/no
+		{"empty", "", true},
+	}
+	
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateEnvBool(tt.value)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "invalid boolean value")
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateEnvLocale(t *testing.T) {
+	t.Parallel()
+	
+	tests := []struct {
+		name    string
+		value   string
+		wantErr bool
+	}{
+		{"valid en", "en", false},
+		{"valid en-us", "en-us", false},
+		{"valid fr", "fr", false},
+		{"valid de-de", "de-de", false},
+		{"uppercase EN-US", "EN-US", false}, // Case insensitive
+		{"too short", "e", true},
+		{"too long", "verylonglocale", true},
+		{"invalid pattern", "en_us", true}, // Underscore not allowed
+		{"invalid pattern three parts", "en-us-uk", true},
+		{"numbers", "12-34", true},
+	}
+	
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateEnvLocale(tt.value)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateEnvPath(t *testing.T) {
+	// Create a temp file for testing
+	tmpFile := t.TempDir() + "/test.tflite"
+	err := os.WriteFile(tmpFile, []byte("test"), 0o600)
+	require.NoError(t, err)
+	
+	tests := []struct {
+		name    string
+		value   string
+		wantErr bool
+		errMsg  string
+	}{
+		{"absolute path exists", tmpFile, false, ""},
+		{"absolute path not exists", "/nonexistent/path/file.txt", false, "warning"}, // Warning, not error
+		{"relative path", "relative/path", true, "must be absolute"},
+		{"path traversal attempt", "/valid/../../../etc/passwd", false, ""}, // Clean normalizes this to /etc/passwd 
+		{"relative with dots", "../../../etc/passwd", true, "must be absolute"},
+		{"empty path", "", true, "must be absolute"},
+	}
+	
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateEnvPath(tt.value)
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errMsg != "" {
+					assert.Contains(t, err.Error(), tt.errMsg)
+				}
+			} else {
+				// Check for warning (file not exists is a warning, not a hard error)
+				if err != nil && tt.errMsg == "warning" {
+					assert.Contains(t, err.Error(), "warning")
+				} else if tt.errMsg == "" {
+					// No error expected at all (or just a warning which we accept)
+					if err != nil && !strings.Contains(err.Error(), "warning") {
+						t.Errorf("unexpected error: %v", err)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestConfigureEnvironmentVariables(t *testing.T) {
+	// Reset viper for clean test
+	viper.Reset()
+	
+	// Test with invalid boolean env var
+	t.Run("invalid boolean", func(t *testing.T) {
+		require.NoError(t, os.Setenv("BIRDNET_DEBUG", "maybe"))
+		defer func() { _ = os.Unsetenv("BIRDNET_DEBUG") }()
+		
+		err := configureEnvironmentVariables()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid boolean value")
+	})
+	
+	// Test with invalid locale
+	t.Run("invalid locale", func(t *testing.T) {
+		require.NoError(t, os.Setenv("BIRDNET_LOCALE", "invalid_locale"))
+		defer func() { _ = os.Unsetenv("BIRDNET_LOCALE") }()
+		
+		err := configureEnvironmentVariables()
+		require.Error(t, err)
+		// Check for the actual error message
+		assert.Contains(t, err.Error(), "expected pattern")
+	})
+	
+	// Test with multiple errors
+	t.Run("multiple errors", func(t *testing.T) {
+		require.NoError(t, os.Setenv("BIRDNET_DEBUG", "invalid"))
+		require.NoError(t, os.Setenv("BIRDNET_LOCALE", "x"))
+		defer func() { _ = os.Unsetenv("BIRDNET_DEBUG") }()
+		defer func() { _ = os.Unsetenv("BIRDNET_LOCALE") }()
+		
+		err := configureEnvironmentVariables()
+		require.Error(t, err)
+		// Should contain multiple error messages
+		errStr := err.Error()
+		assert.True(t, strings.Contains(errStr, "BIRDNET_DEBUG") || strings.Contains(errStr, "BIRDNET_LOCALE"))
+	})
+	
+	// Test with valid values
+	t.Run("valid values", func(t *testing.T) {
+		viper.Reset()
+		require.NoError(t, os.Setenv("BIRDNET_DEBUG", "true"))
+		require.NoError(t, os.Setenv("BIRDNET_LOCALE", "en-us"))
+		require.NoError(t, os.Setenv("BIRDNET_THREADS", "4"))
+		defer func() { _ = os.Unsetenv("BIRDNET_DEBUG") }()
+		defer func() { _ = os.Unsetenv("BIRDNET_LOCALE") }()
+		defer func() { _ = os.Unsetenv("BIRDNET_THREADS") }()
+		
+		err := configureEnvironmentVariables()
+		assert.NoError(t, err)
+	})
+}

--- a/internal/conf/env_test.go
+++ b/internal/conf/env_test.go
@@ -127,6 +127,7 @@ func TestConfigureEnvironmentVariables(t *testing.T) {
 	
 	// Test with invalid boolean env var
 	t.Run("invalid boolean", func(t *testing.T) {
+		viper.Reset()
 		t.Setenv("BIRDNET_DEBUG", "maybe")
 		
 		err := configureEnvironmentVariables()
@@ -136,6 +137,7 @@ func TestConfigureEnvironmentVariables(t *testing.T) {
 	
 	// Test with invalid locale
 	t.Run("invalid locale", func(t *testing.T) {
+		viper.Reset()
 		t.Setenv("BIRDNET_LOCALE", "invalid_locale")
 		
 		err := configureEnvironmentVariables()
@@ -146,6 +148,7 @@ func TestConfigureEnvironmentVariables(t *testing.T) {
 	
 	// Test with multiple errors
 	t.Run("multiple errors", func(t *testing.T) {
+		viper.Reset()
 		t.Setenv("BIRDNET_DEBUG", "invalid")
 		t.Setenv("BIRDNET_LOCALE", "x")
 		
@@ -174,6 +177,7 @@ func TestConfigureEnvironmentVariables_EmptyValuesValidated(t *testing.T) {
 	
 	// Test that empty-but-present env vars are validated
 	t.Run("empty threads value", func(t *testing.T) {
+		viper.Reset()
 		t.Setenv("BIRDNET_THREADS", "")
 		
 		err := configureEnvironmentVariables()
@@ -228,4 +232,31 @@ func TestValidateAndNormalizeRangeFilterModel(t *testing.T) {
 			assert.Equal(t, tt.expected, actual)
 		})
 	}
+}
+
+func TestLocaleCanonicalizations(t *testing.T) {
+	// Test that locale gets canonicalized to lowercase on successful validation
+	t.Run("uppercase locale gets canonicalized", func(t *testing.T) {
+		viper.Reset()
+		t.Setenv("BIRDNET_LOCALE", "EN-US")
+		
+		err := configureEnvironmentVariables()
+		require.NoError(t, err)
+		
+		// Check that the locale was canonicalized to lowercase
+		actual := viper.GetString("birdnet.locale")
+		assert.Equal(t, "en-us", actual)
+	})
+	
+	t.Run("mixed case locale gets canonicalized", func(t *testing.T) {
+		viper.Reset()
+		t.Setenv("BIRDNET_LOCALE", "De-DE")
+		
+		err := configureEnvironmentVariables()
+		require.NoError(t, err)
+		
+		// Check that the locale was canonicalized to lowercase
+		actual := viper.GetString("birdnet.locale")
+		assert.Equal(t, "de-de", actual)
+	})
 }


### PR DESCRIPTION
## Summary

This PR adds environment variable support for BirdNET-Go to enable Docker deployments with external model files. The primary focus is on model paths and core analysis parameters most useful in containerized environments.

**Note: This is a targeted implementation for Docker deployments, not aiming for 100% coverage of all settings.**

## Motivation

Docker users need the ability to:
- Mount custom TensorFlow Lite models as volumes
- Configure model paths without modifying config files inside containers
- Override core BirdNET settings at runtime
- Support different models for different deployment scenarios

## Changes

### New Features
- ✅ Environment variable support for 15 core BirdNET configuration options
- ✅ Input validation for all environment variables with clear error messages
- ✅ Non-blocking warnings (app continues with defaults if env vars are invalid)

### Supported Environment Variables

**Model Paths** (primary focus):
- `BIRDNET_MODELPATH` - Path to external BirdNET model file
- `BIRDNET_LABELPATH` - Path to external label file  
- `BIRDNET_RANGEFILTER_MODELPATH` - Path to range filter model
- `BIRDNET_RANGEFILTER_MODEL` - Model version (latest/legacy)

**Core Analysis Settings**:
- `BIRDNET_LOCALE` - Language/locale for labels
- `BIRDNET_LATITUDE` / `BIRDNET_LONGITUDE` - Location for species filtering
- `BIRDNET_SENSITIVITY` - Detection sensitivity (0.1-1.5)
- `BIRDNET_THRESHOLD` - Confidence threshold (0.0-1.0)
- `BIRDNET_OVERLAP` - Audio chunk overlap (0.0-2.9)
- `BIRDNET_THREADS` - CPU threads for analysis
- `BIRDNET_DEBUG` - Enable debug mode
- `BIRDNET_USEXNNPACK` - Enable XNNPACK acceleration

### Code Organization

- **New file**: `internal/conf/env.go` - All environment variable logic (196 lines)
- **Updated**: `internal/conf/config.go` - Reduced by ~160 lines, now calls `configureEnvironmentVariables()`
- **Updated**: `Docker/docker-compose.yml` - Documented all supported environment variables

### Validation Examples

```bash
# Valid
BIRDNET_MODELPATH="/models/custom.tflite"
BIRDNET_THRESHOLD="0.75"

# Invalid (app continues with defaults)
BIRDNET_LATITUDE="200"  # Warning: latitude must be between -90 and 90
BIRDNET_THRESHOLD="2.0" # Warning: threshold must be between 0.0 and 1.0
```

## Testing

- ✅ Zero linter errors (`golangci-lint run`)
- ✅ Builds successfully
- ✅ Validation tested with invalid values
- ✅ Docker Compose examples documented

## Docker Usage Example

```yaml
services:
  birdnet-go:
    image: ghcr.io/tphakala/birdnet-go:latest
    environment:
      - BIRDNET_MODELPATH=/models/custom_model.tflite
      - BIRDNET_RANGEFILTER_MODELPATH=/models/range_model.tflite
      - BIRDNET_LOCALE=en-us
      - BIRDNET_THRESHOLD=0.75
    volumes:
      - ./custom_models:/models:ro
```

## Future Considerations

While this PR focuses on Docker deployment needs, future enhancements could include:
- Additional environment variables as requested by users
- Secret management for API keys
- Automatic env var generation from struct tags
- Hot-reload of configuration

## Breaking Changes

None - fully backward compatible. Environment variables are optional and override config file values when set.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Environment-variable support for BirdNET settings (locale, coords, sensitivity, threshold, overlap, threads, debug, usexnnpack, model/label paths, range-filter options) with per-variable validation; validation issues are aggregated and logged as non-fatal warnings so startup continues.

* **Documentation**
  * Added a commented "BirdNET Configuration" block in Docker Compose documenting env vars, valid ranges, and guidance for mounting external models.

* **Tests**
  * Added comprehensive unit tests for validators, canonicalization, and environment setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->