### PR TITLE
fix: resolve OAuth callback URL mismatch causing 404 errors (#1192)

### DIFF
--- a/frontend/src/lib/desktop/components/modals/LoginModal.svelte
+++ b/frontend/src/lib/desktop/components/modals/LoginModal.svelte
@@ -222,17 +222,18 @@
 
   // SECURITY: Validate OAuth endpoints before redirect
   function handleOAuthLogin(provider: 'google' | 'github') {
-    // Use configurable endpoints or fallback to defaults
+    // Use clean OAuth routes (without /api/v1 prefix) for consistency
+    // Backend supports both /auth/:provider and /api/v1/auth/:provider
     const defaultEndpoints = {
-      google: '/api/v1/auth/google',
-      github: '/api/v1/auth/github',
+      google: '/auth/google',
+      github: '/auth/github',
     };
 
     const configuredEndpoints = authConfig.endpoints || {};
     const endpoint = safeGet(configuredEndpoints, provider) || safeGet(defaultEndpoints, provider);
 
-    // SECURITY: Basic endpoint validation
-    if (!endpoint || !endpoint.startsWith('/api/v1/auth/')) {
+    // SECURITY: Basic endpoint validation - accept both formats
+    if (!endpoint || (!endpoint.startsWith('/auth/') && !endpoint.startsWith('/api/v1/auth/'))) {
       error = 'Configuration error. Please contact your administrator.';
       return;
     }

--- a/frontend/src/lib/desktop/features/settings/pages/SecuritySettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/SecuritySettingsPage.svelte
@@ -121,6 +121,8 @@
         : 'https://your-domain.com'
   );
   
+  // Use clean OAuth callback URLs (without /api/v1 prefix) for better UX
+  // Backend supports both /auth/:provider/callback and /api/v1/auth/:provider/callback
   let googleRedirectURI = $derived(`${currentHost}/auth/google/callback`);
   let githubRedirectURI = $derived(`${currentHost}/auth/github/callback`);
 

--- a/internal/httpcontroller/auth_routes.go
+++ b/internal/httpcontroller/auth_routes.go
@@ -18,12 +18,17 @@ func (s *Server) initAuthRoutes() {
 	g := s.Echo.Group("")
 	g.Use(middleware.RateLimiter(middleware.NewRateLimiterMemoryStore(10)))
 
-	// OAuth2 routes
+	// OAuth2 routes (basic auth flow)
 	g.GET("/api/v1/oauth2/authorize", s.Handlers.WithErrorHandling(s.OAuth2Server.HandleBasicAuthorize))
 	g.POST("/api/v1/oauth2/token", s.Handlers.WithErrorHandling(s.OAuth2Server.HandleBasicAuthToken))
 	g.GET("/api/v1/oauth2/callback", s.Handlers.WithErrorHandling(s.OAuth2Server.HandleBasicAuthCallback))
 
-	// Social authentication routes
+	// Clean OAuth routes (preferred going forward - not versioned)
+	g.GET("/auth/:provider", s.Handlers.WithErrorHandling(handleGothProvider))
+	g.GET("/auth/:provider/callback", s.Handlers.WithErrorHandling(handleGothCallback))
+
+	// Legacy v1 API routes (kept for backward compatibility)
+	// TODO: Remove when v1 API is deprecated
 	g.GET("/api/v1/auth/:provider", s.Handlers.WithErrorHandling(handleGothProvider))
 	g.GET("/api/v1/auth/:provider/callback", s.Handlers.WithErrorHandling(handleGothCallback))
 


### PR DESCRIPTION
## Summary
Fixed OAuth callback URL mismatch that was causing "page not found" errors after OAuth authentication with GitHub and Google.

**Problem**: Users experienced 404 errors when redirected back from OAuth providers because:
- Frontend Settings page displayed callback URLs as `/auth/:provider/callback`
- Backend routes were at `/api/v1/auth/:provider/callback`
- Users configured OAuth apps with displayed URLs, causing mismatch

**Solution**: Implemented dual-route approach supporting both URL patterns:
- Added clean OAuth routes: `/auth/:provider` and `/auth/:provider/callback`
- Kept legacy `/api/v1/auth/:provider/*` routes for backward compatibility
- Updated frontend to use clean OAuth endpoints

## Changes
- **backend**: Add dual OAuth routes in `auth_routes.go`
- **frontend**: Update `LoginModal` to use clean endpoints (`/auth/google`, `/auth/github`)
- **frontend**: Add comments in `SecuritySettingsPage` explaining dual backend support

## Benefits
- ✅ Users can now use `/auth/:provider/callback` as displayed in settings
- ✅ Backward compatibility maintained for existing configurations
- ✅ Cleaner, more intuitive callback URLs align with v1 API deprecation plans

## Testing
- [ ] GitHub OAuth login works with `/auth/github/callback`
- [ ] Google OAuth login works with `/auth/google/callback`  
- [ ] Legacy `/api/v1/auth/:provider/callback` URLs still work
- [ ] Settings page displays correct callback URLs
- [ ] Login modal uses correct endpoints

## Configuration Example
**GitHub OAuth App**:
- Authorization callback URL: `http://YOUR_HOST:PORT/auth/github/callback`

**Google OAuth Credentials**:
- Authorized redirect URIs: `http://YOUR_HOST:PORT/auth/google/callback`

Fixes https://github.com/tphakala/birdnet-go/issues/1192

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added simplified social login routes (e.g., /auth/google, /auth/github) for a cleaner OAuth flow.
  * Maintains full backward compatibility with legacy /api/v1/auth/... endpoints.

* **Refactor**
  * Frontend defaults updated to prefer the new /auth/... routes while accepting both formats, ensuring seamless redirects and error handling.

* **Documentation**
  * Clarified guidance in settings about using clean OAuth callback URLs; noted backend support for both /auth/:provider/callback and /api/v1/auth/:provider/callback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->