### PR TITLE
fix: remove non-existent source_safe column from search query

### DIFF
--- a/internal/datastore/interfaces.go
+++ b/internal/datastore/interfaces.go
@@ -1738,7 +1738,7 @@ func (ds *DataStore) SearchDetections(filters *SearchFilters) ([]DetectionRecord
 
 	// Select necessary fields, including potentially null fields from joins
 	query = query.Select("notes.id, notes.date, notes.time, notes.scientific_name, notes.common_name, notes.confidence, " +
-		"notes.latitude, notes.longitude, notes.clip_name, notes.source_safe, notes.source_node, " +
+		"notes.latitude, notes.longitude, notes.clip_name, notes.source_node, " +
 		"note_reviews.verified AS review_verified, " + // Select review status
 		"note_locks.id IS NOT NULL AS is_locked") // Select lock status as boolean
 
@@ -1798,7 +1798,6 @@ func (ds *DataStore) SearchDetections(filters *SearchFilters) ([]DetectionRecord
 		Latitude       float64
 		Longitude      float64
 		ClipName       string
-		Source         string
 		SourceNode     string
 		ReviewVerified *string // Use pointer to handle NULL for review status
 		IsLocked       bool    // Boolean result from IS NOT NULL
@@ -1890,7 +1889,7 @@ func (ds *DataStore) SearchDetections(filters *SearchFilters) ([]DetectionRecord
 			Locked:         scanned.IsLocked, // Use derived status
 			HasAudio:       scanned.ClipName != "",
 			Device:         scanned.SourceNode,
-			Source:         scanned.Source,
+			Source:         "", // Source field was runtime-only, not stored in database
 			TimeOfDay:      timeOfDay, // Include calculated time of day
 		}
 


### PR DESCRIPTION
## Summary
Fixes issue #1220 where search functionality failed with "no such column: notes.source_safe" error on new installations.

## Root Cause
The search query was trying to SELECT a non-existent database column `notes.source_safe`. The `Source` field in the `Note` struct has `gorm:"-"` tag, making it runtime-only and never stored in the database.

## Changes
- Remove `notes.source_safe` from SELECT query in `SearchDetections` method
- Remove `Source` field from `ScannedResult` struct (no longer needed)
- Set `DetectionRecord.Source` to empty string (safe since frontend doesn't use this field)

## Test plan
- [x] Verified code compiles without errors
- [x] Analyzed frontend code - `SearchResult` interface doesn't include `source` field
- [x] No other references to `source_safe` found in codebase
- [x] All pre-commit checks passed (golangci-lint, etc.)

Closes #1220

🤖 Generated with [Claude Code](https://claude.ai/code)