### PR TITLE
feat: add mandatory GitHub issue number requirement for support uploads

### DIFF
--- a/frontend/src/lib/desktop/features/settings/pages/SupportSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/SupportSettingsPage.svelte
@@ -81,6 +81,7 @@
     includeLogs: true,
     includeConfig: true,
     includeSystemInfo: true,
+    githubIssueNumber: '',
     userMessage: '',
     uploadToSentry: true,
   });
@@ -157,6 +158,16 @@
 
   // Support dump generation
   async function generateSupportDump() {
+    // Validate GitHub issue number if uploading
+    if (supportDump.uploadToSentry && !supportDump.githubIssueNumber) {
+      updateStatus(
+        t('settings.support.supportReport.statusMessages.githubIssueRequired'),
+        'error',
+        0
+      );
+      return;
+    }
+
     generating = true;
     statusMessage = '';
     statusType = 'info';
@@ -181,6 +192,9 @@
           include_logs: supportDump.includeLogs,
           include_config: supportDump.includeConfig,
           include_system_info: supportDump.includeSystemInfo,
+          github_issue_number: supportDump.githubIssueNumber
+            ? supportDump.githubIssueNumber.replace('#', '')
+            : '',
           user_message: supportDump.userMessage,
           upload_to_sentry: supportDump.uploadToSentry,
         }),
@@ -348,9 +362,17 @@
               {@html t('settings.support.supportReport.description.intro')}
             </p>
 
-            <p class="text-sm text-base-content/80">
-              {@html t('settings.support.supportReport.description.githubIssue')}
-            </p>
+            <div class="alert alert-warning shadow-sm">
+              <div class="h-6 w-6">{@html alertIconsSvg.warning}</div>
+              <div>
+                <h4 class="font-bold">
+                  {t('settings.support.supportReport.githubRequired.title')}
+                </h4>
+                <p class="text-sm">
+                  {@html t('settings.support.supportReport.githubRequired.description')}
+                </p>
+              </div>
+            </div>
 
             <div class="bg-base-100 rounded-lg p-3 border border-base-300">
               <h4 class="font-semibold text-sm mb-2">
@@ -409,60 +431,86 @@
               disabled={generating}
             />
 
+            <!-- GitHub Issue Number (Required for Upload) -->
+            {#if supportDump.uploadToSentry}
+              <div class="form-control mt-4">
+                <label class="label" for="githubIssueNumber">
+                  <span class="label-text">
+                    {t('settings.support.supportReport.githubIssue.label')}
+                    <span class="text-error">*</span>
+                  </span>
+                </label>
+                <input
+                  type="text"
+                  id="githubIssueNumber"
+                  bind:value={supportDump.githubIssueNumber}
+                  class="input input-bordered input-sm text-base-content"
+                  class:input-error={supportDump.uploadToSentry && !supportDump.githubIssueNumber}
+                  placeholder={t('settings.support.supportReport.githubIssue.placeholder')}
+                  pattern="#?[0-9]+"
+                  required={supportDump.uploadToSentry}
+                  disabled={generating}
+                />
+                <div class="label">
+                  <span class="label-text-alt text-base-content/60">
+                    {@html t('settings.support.supportReport.githubIssue.helper')}
+                  </span>
+                </div>
+              </div>
+            {/if}
+
             <!-- User Message -->
             <div class="form-control mt-4">
               <label class="label" for="userMessage">
                 <span class="label-text"
-                  >{t('settings.support.supportReport.userMessage.label')}</span
+                  >{t('settings.support.supportReport.userMessage.labelOptional')}</span
                 >
               </label>
               <textarea
                 id="userMessage"
                 bind:value={supportDump.userMessage}
                 class="textarea textarea-bordered textarea-sm h-24 text-base-content"
-                placeholder={t('settings.support.supportReport.userMessage.placeholder')}
+                placeholder={t('settings.support.supportReport.userMessage.placeholderOptional')}
                 rows="4"
                 disabled={generating}
               ></textarea>
 
-              <!-- GitHub Issue Note -->
+              <!-- System ID Note -->
               <div class="label">
                 <span class="label-text-alt text-base-content/60">
-                  {t('settings.support.supportReport.userMessage.githubTip', { systemId })}
+                  {t('settings.support.supportReport.userMessage.systemIdNote', { systemId })}
                 </span>
               </div>
             </div>
 
-            <!-- Upload Option (only shown if telemetry is enabled) -->
-            {#if settings.sentry!.enabled}
-              <div class="mt-4">
-                <Checkbox
-                  bind:checked={supportDump.uploadToSentry}
-                  label={t('settings.support.supportReport.uploadOption.label')}
-                  disabled={generating}
-                />
-                <div class="pl-6 mt-2 space-y-2">
-                  <div class="text-xs text-base-content/60">
-                    <p class="flex items-start gap-1">
-                      {@html actionIcons.check}
-                      {@html t('settings.support.supportReport.uploadOption.details.sentryUpload')}
-                    </p>
-                    <p class="flex items-start gap-1">
-                      {@html systemIcons.globe}
-                      {t('settings.support.supportReport.uploadOption.details.euDataCenter')}
-                    </p>
-                    <p class="flex items-start gap-1">
-                      {@html systemIcons.shield}
-                      {t('settings.support.supportReport.uploadOption.details.privacyCompliant')}
-                    </p>
-                  </div>
-                  <div class="text-xs text-warning/80 flex items-center gap-1">
-                    {@html systemIcons.infoCircle}
-                    {t('settings.support.supportReport.uploadOption.details.manualWarning')}
-                  </div>
+            <!-- Upload Option (always available) -->
+            <div class="mt-4">
+              <Checkbox
+                bind:checked={supportDump.uploadToSentry}
+                label={t('settings.support.supportReport.uploadOption.labelWithRequirement')}
+                disabled={generating}
+              />
+              <div class="pl-6 mt-2 space-y-2">
+                <div class="text-xs text-base-content/60">
+                  <p class="flex items-start gap-1">
+                    {@html actionIcons.check}
+                    {@html t('settings.support.supportReport.uploadOption.details.sentryUpload')}
+                  </p>
+                  <p class="flex items-start gap-1">
+                    {@html systemIcons.globe}
+                    {t('settings.support.supportReport.uploadOption.details.euDataCenter')}
+                  </p>
+                  <p class="flex items-start gap-1">
+                    {@html systemIcons.shield}
+                    {t('settings.support.supportReport.uploadOption.details.privacyCompliant')}
+                  </p>
+                </div>
+                <div class="text-xs text-warning/80 flex items-center gap-1">
+                  {@html systemIcons.infoCircle}
+                  {t('settings.support.supportReport.uploadOption.details.manualWarning')}
                 </div>
               </div>
-            {/if}
+            </div>
           </div>
 
           <!-- Status Message -->
@@ -505,12 +553,14 @@
               disabled={generating ||
                 (!supportDump.includeLogs &&
                   !supportDump.includeConfig &&
-                  !supportDump.includeSystemInfo)}
+                  !supportDump.includeSystemInfo) ||
+                (supportDump.uploadToSentry && !supportDump.githubIssueNumber)}
               class="btn btn-primary"
               class:btn-disabled={generating ||
                 (!supportDump.includeLogs &&
                   !supportDump.includeConfig &&
-                  !supportDump.includeSystemInfo)}
+                  !supportDump.includeSystemInfo) ||
+                (supportDump.uploadToSentry && !supportDump.githubIssueNumber)}
             >
               {#if !generating}
                 <span class="flex items-center gap-2">

--- a/frontend/src/lib/desktop/features/settings/pages/SupportSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/SupportSettingsPage.svelte
@@ -362,15 +362,15 @@
               {@html t('settings.support.supportReport.description.intro')}
             </p>
 
-            <div class="alert alert-warning shadow-sm">
-              <div class="h-6 w-6">{@html alertIconsSvg.warning}</div>
-              <div>
-                <h4 class="font-bold">
+            <div class="alert alert-warning shadow-sm text-sm">
+              <div class="h-5 w-5 flex-shrink-0">{@html alertIconsSvg.warning}</div>
+              <div class="min-w-0">
+                <span class="font-semibold">
                   {t('settings.support.supportReport.githubRequired.title')}
-                </h4>
-                <p class="text-sm">
+                </span>
+                <div class="mt-1">
                   {@html t('settings.support.supportReport.githubRequired.description')}
-                </p>
+                </div>
               </div>
             </div>
 
@@ -515,29 +515,31 @@
 
           <!-- Status Message -->
           {#if statusMessage}
-            <div class="mt-4">
+            <div class="mt-3 max-w-2xl">
               <div
-                class="alert"
+                class="alert py-2 px-3 text-sm"
                 class:alert-info={statusType === 'info'}
                 class:alert-success={statusType === 'success'}
                 class:alert-error={statusType === 'error'}
               >
-                {#if statusType === 'info'}
-                  {@html alertIconsSvg.info}
-                {:else if statusType === 'success'}
-                  {@html alertIconsSvg.success}
-                {:else if statusType === 'error'}
-                  {@html alertIconsSvg.error}
-                {/if}
-                <span>{statusMessage}</span>
+                <div class="h-4 w-4 flex-shrink-0">
+                  {#if statusType === 'info'}
+                    {@html alertIconsSvg.info}
+                  {:else if statusType === 'success'}
+                    {@html alertIconsSvg.success}
+                  {:else if statusType === 'error'}
+                    {@html alertIconsSvg.error}
+                  {/if}
+                </div>
+                <span class="min-w-0 text-sm">{statusMessage}</span>
               </div>
 
               <!-- Progress Bar -->
               {#if generating && progressPercent > 0}
-                <div class="mt-2">
-                  <div class="w-full bg-base-300 rounded-full h-2">
+                <div class="mt-1">
+                  <div class="w-full bg-base-300 rounded-full h-1.5">
                     <div
-                      class="bg-primary h-2 rounded-full transition-all duration-500"
+                      class="bg-primary h-1.5 rounded-full transition-all duration-500"
                       style:width="{progressPercent}%"
                     ></div>
                   </div>

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -869,8 +869,16 @@
       "supportReport": {
         "title": "Support-Bericht erstellen",
         "description": {
-          "intro": "Support-Berichte sind **für die Fehlerbehebung unerlässlich** und verbessern unsere Fähigkeit, Probleme zu lösen, die Sie erleben, erheblich. Sie liefern Entwicklern entscheidenden Kontext über Ihre Systemkonfiguration, aktuelle Anwendungsprotokolle und Fehlermuster, die andernfalls unmöglich zu diagnostizieren wären.",
-          "githubIssue": "Bitte [erstellen Sie ein GitHub-Issue](https://github.com/tphakala/birdnet-go/issues/new), das Ihr Problem beschreibt, **bevor oder nachdem** Sie diesen Support-Bericht erstellen. Dies ermöglicht eine ordnungsgemäße Verfolgung und Kommunikation bezüglich Ihres Problems."
+          "intro": "Support-Berichte sind **für die Fehlerbehebung unerlässlich** und verbessern unsere Fähigkeit, Probleme zu lösen, die Sie erleben, erheblich. Sie liefern Entwicklern entscheidenden Kontext über Ihre Systemkonfiguration, aktuelle Anwendungsprotokolle und Fehlermuster, die andernfalls unmöglich zu diagnostizieren wären."
+        },
+        "githubRequired": {
+          "title": "Erforderlich: GitHub-Issue für Support-Uploads",
+          "description": "<strong>Support-Uploads erfordern eine GitHub-Issue-Nummer.</strong> Bitte <a href=\"https://github.com/tphakala/birdnet-go/issues/new\" target=\"_blank\" class=\"underline font-semibold\">erstellen Sie ein GitHub-Issue</a>, das Ihr Problem beschreibt, <strong>bevor</strong> Sie einen Support-Bericht erstellen. Ohne ein verknüpftes Issue können Entwickler Ihre Support-Daten nicht bearbeiten."
+        },
+        "githubIssue": {
+          "label": "GitHub-Issue-Nummer",
+          "placeholder": "z.B. 123 oder #123",
+          "helper": "<a href=\"https://github.com/tphakala/birdnet-go/issues\" target=\"_blank\" class=\"link link-primary\">Bestehende Issues anzeigen</a> oder <a href=\"https://github.com/tphakala/birdnet-go/issues/new\" target=\"_blank\" class=\"link link-primary\">neues Issue erstellen</a>"
         },
         "whatsIncluded": {
           "title": "Was im Bericht enthalten ist:",
@@ -882,10 +890,14 @@
         "userMessage": {
           "label": "Beschreiben Sie das Problem",
           "placeholder": "Bitte beschreiben Sie das Problem und fügen Sie den GitHub-Issue-Link hinzu, falls zutreffend (z.B. #123)",
-          "githubTip": "💡 Tipp: Wenn Sie ein GitHub-Issue haben, fügen Sie bitte die Issue-Nummer (z.B. #123) ein und erwähnen Sie Ihre System-ID {systemId} im GitHub-Issue, um Entwicklern zu helfen, Ihre Support-Daten zu verknüpfen."
+          "githubTip": "💡 Tipp: Wenn Sie ein GitHub-Issue haben, fügen Sie bitte die Issue-Nummer (z.B. #123) ein und erwähnen Sie Ihre System-ID {systemId} im GitHub-Issue, um Entwicklern zu helfen, Ihre Support-Daten zu verknüpfen.",
+          "labelOptional": "Zusätzliche Details (optional)",
+          "placeholderOptional": "Geben Sie zusätzlichen Kontext zum Problem an, der nicht in Ihrem GitHub-Issue enthalten ist",
+          "systemIdNote": "💡 Tipp: Ihre System-ID {systemId} wird automatisch in den Upload eingeschlossen"
         },
         "uploadOption": {
           "label": "An Entwickler hochladen (empfohlen)",
+          "labelWithRequirement": "An Entwickler hochladen (erfordert GitHub-Issue-Nummer)",
           "details": {
             "sentryUpload": "Daten werden zum [Sentry](https://sentry.io) Cloud-Service hochgeladen",
             "euDataCenter": "Gespeichert im EU-Rechenzentrum (Frankfurt, Deutschland)",
@@ -904,7 +916,8 @@
           "downloadSuccess": "Support-Bericht erfolgreich erstellt! Wird heruntergeladen...",
           "generateSuccess": "Support-Bericht erfolgreich erstellt!",
           "generateFailed": "Fehler beim Erstellen des Support-Berichts: {message}",
-          "error": "Fehler: {message}"
+          "error": "Fehler: {message}",
+          "githubIssueRequired": "Bitte geben Sie eine GitHub-Issue-Nummer ein, um Support-Daten hochzuladen"
         }
       }
     },

--- a/frontend/static/messages/en.json
+++ b/frontend/static/messages/en.json
@@ -965,8 +965,16 @@
       "supportReport": {
         "title": "Generate Support Report",
         "description": {
-          "intro": "Support reports are **essential for troubleshooting** and dramatically improve our ability to resolve issues you're experiencing. They provide developers with crucial context about your system configuration, recent application logs, and error patterns that would be impossible to diagnose otherwise.",
-          "githubIssue": "Please [create a GitHub issue](https://github.com/tphakala/birdnet-go/issues/new) describing your problem **before or after** generating this support report. This allows for proper tracking and communication about your issue."
+          "intro": "Support reports are **essential for troubleshooting** and dramatically improve our ability to resolve issues you're experiencing. They provide developers with crucial context about your system configuration, recent application logs, and error patterns that would be impossible to diagnose otherwise."
+        },
+        "githubRequired": {
+          "title": "Required: GitHub Issue for Support Uploads",
+          "description": "<strong>Support uploads require a GitHub issue number.</strong> Please <a href=\"https://github.com/tphakala/birdnet-go/issues/new\" target=\"_blank\" class=\"underline font-semibold\">create a GitHub issue</a> describing your problem <strong>before</strong> generating a support report. Without a linked issue, developers cannot act on your support data."
+        },
+        "githubIssue": {
+          "label": "GitHub Issue Number",
+          "placeholder": "e.g., 123 or #123",
+          "helper": "<a href=\"https://github.com/tphakala/birdnet-go/issues\" target=\"_blank\" class=\"link link-primary\">View existing issues</a> or <a href=\"https://github.com/tphakala/birdnet-go/issues/new\" target=\"_blank\" class=\"link link-primary\">create a new issue</a> first"
         },
         "whatsIncluded": {
           "title": "What's included in the report:",
@@ -978,10 +986,14 @@
         "userMessage": {
           "label": "Describe the issue",
           "placeholder": "Please describe the issue and include GitHub issue link if applicable (e.g., #123)",
-          "githubTip": "💡 Tip: If you have a GitHub issue, please include the issue number (e.g., #123) and mention your System ID {systemId} in the GitHub issue to help developers link your support data."
+          "githubTip": "💡 Tip: If you have a GitHub issue, please include the issue number (e.g., #123) and mention your System ID {systemId} in the GitHub issue to help developers link your support data.",
+          "labelOptional": "Additional details (optional)",
+          "placeholderOptional": "Provide any additional context about the issue that isn't in your GitHub issue",
+          "systemIdNote": "💡 Tip: Your System ID {systemId} will be automatically included in the upload"
         },
         "uploadOption": {
           "label": "Upload to developers (recommended)",
+          "labelWithRequirement": "Upload to developers (requires GitHub issue number)",
           "details": {
             "sentryUpload": "Data is uploaded to [Sentry](https://sentry.io) cloud service",
             "euDataCenter": "Stored in EU data center (Frankfurt, Germany)",
@@ -1000,7 +1012,8 @@
           "downloadSuccess": "Support dump generated successfully! Downloading...",
           "generateSuccess": "Support dump generated successfully!",
           "generateFailed": "Failed to generate support dump: {message}",
-          "error": "Error: {message}"
+          "error": "Error: {message}",
+          "githubIssueRequired": "Please enter a GitHub issue number to upload support data"
         }
       }
     },

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -869,8 +869,16 @@
       "supportReport": {
         "title": "Generar informe de soporte",
         "description": {
-          "intro": "Los informes de soporte son **esenciales para la solución de problemas** y mejoran drásticamente nuestra capacidad para resolver los problemas que estás experimentando. Proporcionan a los desarrolladores contexto crucial sobre la configuración de tu sistema, registros recientes de la aplicación y patrones de errores que serían imposibles de diagnosticar de otra manera.",
-          "githubIssue": "Por favor [crea un issue de GitHub](https://github.com/tphakala/birdnet-go/issues/new) describiendo tu problema **antes o después** de generar este informe de soporte. Esto permite un seguimiento y comunicación adecuados sobre tu problema."
+          "intro": "Los informes de soporte son **esenciales para la solución de problemas** y mejoran drásticamente nuestra capacidad para resolver los problemas que estás experimentando. Proporcionan a los desarrolladores contexto crucial sobre la configuración de tu sistema, registros recientes de la aplicación y patrones de errores que serían imposibles de diagnosticar de otra manera."
+        },
+        "githubRequired": {
+          "title": "Requerido: Issue de GitHub para cargas de soporte",
+          "description": "<strong>Las cargas de soporte requieren un número de issue de GitHub.</strong> Por favor <a href=\"https://github.com/tphakala/birdnet-go/issues/new\" target=\"_blank\" class=\"underline font-semibold\">crea un issue de GitHub</a> describiendo tu problema <strong>antes</strong> de generar un informe de soporte. Sin un issue vinculado, los desarrolladores no pueden actuar sobre tus datos de soporte."
+        },
+        "githubIssue": {
+          "label": "Número de issue de GitHub",
+          "placeholder": "p.ej., 123 o #123",
+          "helper": "<a href=\"https://github.com/tphakala/birdnet-go/issues\" target=\"_blank\" class=\"link link-primary\">Ver issues existentes</a> o <a href=\"https://github.com/tphakala/birdnet-go/issues/new\" target=\"_blank\" class=\"link link-primary\">crear un nuevo issue</a> primero"
         },
         "whatsIncluded": {
           "title": "Qué incluye el informe:",
@@ -882,10 +890,14 @@
         "userMessage": {
           "label": "Describe el problema",
           "placeholder": "Por favor describe el problema e incluye el enlace del issue de GitHub si aplica (ej., #123)",
-          "githubTip": "💡 Consejo: Si tienes un issue de GitHub, incluye el número del issue (ej., #123) y menciona tu ID de Sistema {systemId} en el issue de GitHub para ayudar a los desarrolladores a vincular tus datos de soporte."
+          "githubTip": "💡 Consejo: Si tienes un issue de GitHub, incluye el número del issue (ej., #123) y menciona tu ID de Sistema {systemId} en el issue de GitHub para ayudar a los desarrolladores a vincular tus datos de soporte.",
+          "labelOptional": "Detalles adicionales (opcional)",
+          "placeholderOptional": "Proporciona contexto adicional sobre el problema que no esté en tu issue de GitHub",
+          "systemIdNote": "💡 Consejo: Tu ID de sistema {systemId} se incluirá automáticamente en la carga"
         },
         "uploadOption": {
           "label": "Subir a los desarrolladores (recomendado)",
+          "labelWithRequirement": "Subir a los desarrolladores (requiere número de issue de GitHub)",
           "details": {
             "sentryUpload": "Los datos se suben al servicio en la nube [Sentry](https://sentry.io)",
             "euDataCenter": "Almacenados en el centro de datos de la UE (Frankfurt, Alemania)",
@@ -904,7 +916,8 @@
           "downloadSuccess": "¡Volcado de soporte generado exitosamente! Descargando...",
           "generateSuccess": "¡Volcado de soporte generado exitosamente!",
           "generateFailed": "Error al generar el volcado de soporte: {message}",
-          "error": "Error: {message}"
+          "error": "Error: {message}",
+          "githubIssueRequired": "Por favor ingresa un número de issue de GitHub para subir los datos de soporte"
         }
       }
     },

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -869,8 +869,16 @@
       "supportReport": {
         "title": "Luo tukiraportti",
         "description": {
-          "intro": "Tukiraportit ovat **olennaisia vianetsinnässä** ja parantavat dramaattisesti kykyämme ratkaista kohtaamiasi ongelmia. Ne tarjoavat kehittäjille tärkeää kontekstia järjestelmäsi asetuksista, viimeisimmistä sovelluslokeista ja virhemalleista, joita olisi muuten mahdotonta diagnosoida.",
-          "githubIssue": "[Luo GitHub-ongelmaraportti](https://github.com/tphakala/birdnet-go/issues/new) kuvaten ongelmasi **ennen tai jälkeen** tämän tukiraportin luomisen. Tämä mahdollistaa asianmukaisen seurannan ja viestinnän ongelmastasi."
+          "intro": "Tukiraportit ovat **olennaisia vianetsinnässä** ja parantavat dramaattisesti kykyämme ratkaista kohtaamiasi ongelmia. Ne tarjoavat kehittäjille tärkeää kontekstia järjestelmäsi asetuksista, viimeisimmistä sovelluslokeista ja virhemalleista, joita olisi muuten mahdotonta diagnosoida."
+        },
+        "githubRequired": {
+          "title": "Vaaditaan: GitHub-ongelmaraportti tukilähetyksille",
+          "description": "<strong>Tukilähetykset vaativat GitHub-ongelman numeron.</strong> Ole hyvä ja <a href=\"https://github.com/tphakala/birdnet-go/issues/new\" target=\"_blank\" class=\"underline font-semibold\">luo GitHub-ongelma</a> kuvaten ongelmasi <strong>ennen</strong> tukiraportin luomista. Ilman linkitettyä ongelmaa kehittäjät eivät voi käsitellä tukitietojasi."
+        },
+        "githubIssue": {
+          "label": "GitHub-ongelman numero",
+          "placeholder": "#123",
+          "helper": "<a href=\"https://github.com/tphakala/birdnet-go/issues\" target=\"_blank\" class=\"link link-primary\">Näytä olemassa olevat ongelmat</a> tai <a href=\"https://github.com/tphakala/birdnet-go/issues/new\" target=\"_blank\" class=\"link link-primary\">luo uusi ongelma</a> ensin"
         },
         "whatsIncluded": {
           "title": "Mitä raportti sisältää:",
@@ -881,11 +889,15 @@
         },
         "userMessage": {
           "label": "Kuvaile ongelma",
+          "labelOptional": "Kuvaile ongelma (valinnainen)",
           "placeholder": "Kuvaile ongelma ja sisällytä GitHub-ongelman linkki jos saatavilla (esim. #123)",
-          "githubTip": "💡 Vinkki: Jos sinulla on GitHub-ongelma, sisällytä ongelman numero (esim. #123) ja mainitse järjestelmätunnuksesi {systemId} GitHub-ongelmassa auttaaksesi kehittäjiä yhdistämään tukitietosi."
+          "placeholderOptional": "Lisää lisätietoja ongelmasta...",
+          "githubTip": "💡 Vinkki: Jos sinulla on GitHub-ongelma, sisällytä ongelman numero (esim. #123) ja mainitse järjestelmätunnuksesi {systemId} GitHub-ongelmassa auttaaksesi kehittäjiä yhdistämään tukitietosi.",
+          "systemIdNote": "Mainitse järjestelmätunnuksesi {systemId} GitHub-ongelmassa."
         },
         "uploadOption": {
           "label": "Lähetä kehittäjille (suositeltu)",
+          "labelWithRequirement": "Lähetä kehittäjille (GitHub-ongelma vaaditaan)",
           "details": {
             "sentryUpload": "Tiedot ladataan [Sentry](https://sentry.io) -pilvipalveluun",
             "euDataCenter": "Tallennetaan EU:n datakeskukseen (Frankfurt, Saksa)",
@@ -904,7 +916,8 @@
           "downloadSuccess": "Tukiraportti luotu onnistuneesti! Ladataan...",
           "generateSuccess": "Tukiraportti luotu onnistuneesti!",
           "generateFailed": "Tukiraportin luonti epäonnistui: {message}",
-          "error": "Virhe: {message}"
+          "error": "Virhe: {message}",
+          "githubIssueRequired": "GitHub-ongelman numero on pakollinen."
         }
       }
     },

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -885,8 +885,16 @@
       "supportReport": {
         "title": "Générer un rapport de support",
         "description": {
-          "intro": "Les rapports de support sont **essentiels pour le dépannage** et améliorent considérablement notre capacité à résoudre les problèmes que vous rencontrez. Ils fournissent aux développeurs un contexte crucial sur la configuration de votre système, les journaux d'application récents et les modèles d'erreur qui seraient impossibles à diagnostiquer autrement.",
-          "githubIssue": "Veuillez [créer un problème GitHub](https://github.com/tphakala/birdnet-go/issues/new) décrivant votre problème **avant ou après** la génération de ce rapport de support. Cela permet un suivi et une communication appropriés concernant votre problème."
+          "intro": "Les rapports de support sont **essentiels pour le dépannage** et améliorent considérablement notre capacité à résoudre les problèmes que vous rencontrez. Ils fournissent aux développeurs un contexte crucial sur la configuration de votre système, les journaux d'application récents et les modèles d'erreur qui seraient impossibles à diagnostiquer autrement."
+        },
+        "githubRequired": {
+          "title": "Requis : Problème GitHub pour les envois de support",
+          "description": "<strong>Les envois de support nécessitent un numéro de problème GitHub.</strong> Veuillez <a href=\"https://github.com/tphakala/birdnet-go/issues/new\" target=\"_blank\" class=\"underline font-semibold\">créer un problème GitHub</a> décrivant votre problème <strong>avant</strong> de générer un rapport de support. Sans problème lié, les développeurs ne peuvent pas traiter vos données de support."
+        },
+        "githubIssue": {
+          "label": "Numéro du problème GitHub",
+          "placeholder": "#123",
+          "helper": "<a href=\"https://github.com/tphakala/birdnet-go/issues\" target=\"_blank\" class=\"link link-primary\">Voir les problèmes existants</a> ou <a href=\"https://github.com/tphakala/birdnet-go/issues/new\" target=\"_blank\" class=\"link link-primary\">créer un nouveau problème</a> d'abord"
         },
         "whatsIncluded": {
           "title": "Ce qui est inclus dans le rapport :",
@@ -897,11 +905,15 @@
         },
         "userMessage": {
           "label": "Décrivez le problème",
+          "labelOptional": "Décrivez le problème (facultatif)",
           "placeholder": "Veuillez décrire le problème et inclure le lien du problème GitHub si applicable (par ex., #123)",
-          "githubTip": "💡 Conseil : Si vous avez un problème GitHub, veuillez inclure le numéro du problème (par ex., #123) et mentionner votre ID système {systemId} dans le problème GitHub pour aider les développeurs à lier vos données de support."
+          "placeholderOptional": "Ajoutez des détails supplémentaires sur le problème...",
+          "githubTip": "💡 Conseil : Si vous avez un problème GitHub, veuillez inclure le numéro du problème (par ex., #123) et mentionner votre ID système {systemId} dans le problème GitHub pour aider les développeurs à lier vos données de support.",
+          "systemIdNote": "Mentionnez votre ID système {systemId} dans le problème GitHub."
         },
         "uploadOption": {
           "label": "Télécharger vers les développeurs (recommandé)",
+          "labelWithRequirement": "Télécharger vers les développeurs (problème GitHub requis)",
           "details": {
             "sentryUpload": "Les données sont téléchargées vers le service cloud [Sentry](https://sentry.io)",
             "euDataCenter": "Stockées dans le centre de données UE (Francfort, Allemagne)",
@@ -920,7 +932,8 @@
           "downloadSuccess": "Rapport de support généré avec succès ! Téléchargement...",
           "generateSuccess": "Rapport de support généré avec succès !",
           "generateFailed": "Échec de la génération du rapport de support : {message}",
-          "error": "Erreur : {message}"
+          "error": "Erreur : {message}",
+          "githubIssueRequired": "Le numéro du problème GitHub est requis."
         }
       }
     },

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -868,8 +868,16 @@
       "supportReport": {
         "title": "Gerar relatório de suporte",
         "description": {
-          "intro": "Os relatórios de suporte são **essenciais para solução de problemas** e melhoram drasticamente nossa capacidade de resolver os problemas que você está enfrentando. Eles fornecem aos desenvolvedores contexto crucial sobre a configuração do seu sistema, logs recentes da aplicação e padrões de erro que seriam impossíveis de diagnosticar de outra forma.",
-          "githubIssue": "Por favor [crie um issue no GitHub](https://github.com/tphakala/birdnet-go/issues/new) descrevendo seu problema **antes ou depois** de gerar este relatório de suporte. Isso permite rastreamento e comunicação adequados sobre seu problema."
+          "intro": "Os relatórios de suporte são **essenciais para solução de problemas** e melhoram drasticamente nossa capacidade de resolver os problemas que você está enfrentando. Eles fornecem aos desenvolvedores contexto crucial sobre a configuração do seu sistema, logs recentes da aplicação e padrões de erro que seriam impossíveis de diagnosticar de outra forma."
+        },
+        "githubRequired": {
+          "title": "Obrigatório: Issue do GitHub para envios de suporte",
+          "description": "<strong>Envios de suporte requerem um número de issue do GitHub.</strong> Por favor <a href=\"https://github.com/tphakala/birdnet-go/issues/new\" target=\"_blank\" class=\"underline font-semibold\">crie um issue no GitHub</a> descrevendo seu problema <strong>antes</strong> de gerar um relatório de suporte. Sem um issue vinculado, os desenvolvedores não podem agir sobre seus dados de suporte."
+        },
+        "githubIssue": {
+          "label": "Número do issue do GitHub",
+          "placeholder": "#123",
+          "helper": "<a href=\"https://github.com/tphakala/birdnet-go/issues\" target=\"_blank\" class=\"link link-primary\">Ver issues existentes</a> ou <a href=\"https://github.com/tphakala/birdnet-go/issues/new\" target=\"_blank\" class=\"link link-primary\">criar um novo issue</a> primeiro"
         },
         "whatsIncluded": {
           "title": "O que está incluído no relatório:",
@@ -880,11 +888,15 @@
         },
         "userMessage": {
           "label": "Descreva o problema",
+          "labelOptional": "Descreva o problema (opcional)",
           "placeholder": "Por favor descreva o problema e inclua o link do issue do GitHub se aplicável (ex: #123)",
-          "githubTip": "💡 Dica: Se você tem um issue no GitHub, inclua o número do issue (ex: #123) e mencione seu ID do Sistema {systemId} no issue do GitHub para ajudar os desenvolvedores a vincular seus dados de suporte."
+          "placeholderOptional": "Adicione detalhes adicionais sobre o problema...",
+          "githubTip": "💡 Dica: Se você tem um issue no GitHub, inclua o número do issue (ex: #123) e mencione seu ID do Sistema {systemId} no issue do GitHub para ajudar os desenvolvedores a vincular seus dados de suporte.",
+          "systemIdNote": "Mencione seu ID do Sistema {systemId} no issue do GitHub."
         },
         "uploadOption": {
           "label": "Enviar para os desenvolvedores (recomendado)",
+          "labelWithRequirement": "Enviar para os desenvolvedores (issue do GitHub obrigatório)",
           "details": {
             "sentryUpload": "Os dados são enviados para o serviço na nuvem [Sentry](https://sentry.io)",
             "euDataCenter": "Armazenados no centro de dados da UE (Frankfurt, Alemanha)",
@@ -903,7 +915,8 @@
           "downloadSuccess": "Relatório de suporte gerado com sucesso! Baixando...",
           "generateSuccess": "Relatório de suporte gerado com sucesso!",
           "generateFailed": "Falha ao gerar relatório de suporte: {message}",
-          "error": "Erro: {message}"
+          "error": "Erro: {message}",
+          "githubIssueRequired": "O número do issue do GitHub é obrigatório."
         }
       }
     },

--- a/views/pages/settings/supportSettings.html
+++ b/views/pages/settings/supportSettings.html
@@ -39,8 +39,7 @@
          aria-labelledby="sentryDescription">
 
         <!-- Privacy Notice -->
-        <div class="alert alert-info mb-4 shadow-sm" role="alert">
-            <svg xmlns="http://www.w3.org/2000/svg" class="stroke-current shrink-0 h-6 w-6" fill="none" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
+        <div class="mt-4 p-4 bg-base-200 rounded-lg shadow-sm">
             <div>
                 <h3 class="font-bold">Privacy-First Error Tracking</h3>
                 <div class="text-sm mt-1">
@@ -132,6 +131,7 @@
             includeLogs: true,
             includeConfig: true,
             includeSystemInfo: true,
+            githubIssueNumber: '',
             userMessage: '',
             uploadToSentry: true  // Default to true for upload
         },
@@ -144,6 +144,12 @@
             }
         },
         generateSupportDump() {
+            // Validate GitHub issue number if uploading
+            if (this.supportDump.uploadToSentry && !this.supportDump.githubIssueNumber) {
+                this.updateStatus('Please enter a GitHub issue number to upload support data', 'error', 0);
+                return;
+            }
+            
             this.generating = true;
             this.statusMessage = '';
             this.statusType = '';
@@ -168,6 +174,7 @@
                     include_logs: this.supportDump.includeLogs,
                     include_config: this.supportDump.includeConfig,
                     include_system_info: this.supportDump.includeSystemInfo,
+                    github_issue_number: this.supportDump.githubIssueNumber ? this.supportDump.githubIssueNumber.replace('#', '') : '',
                     user_message: this.supportDump.userMessage,
                     upload_to_sentry: this.supportDump.uploadToSentry
                 })
@@ -271,9 +278,9 @@
                     <div class="alert alert-warning shadow-sm">
                         <svg xmlns="http://www.w3.org/2000/svg" class="stroke-current shrink-0 h-6 w-6" fill="none" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
                         <div>
-                            <h4 class="font-bold">Important: File a GitHub Issue</h4>
+                            <h4 class="font-bold">Required: GitHub Issue for Support Uploads</h4>
                             <p class="text-sm">
-                                Please <a href="https://github.com/tphakala/birdnet-go/issues/new" target="_blank" class="link link-primary font-semibold">create a GitHub issue</a> describing your problem <strong>before or after</strong> generating this support report. This allows for proper tracking and communication about your issue.
+                                <strong>Support uploads require a GitHub issue number.</strong> Please <a href="https://github.com/tphakala/birdnet-go/issues/new" target="_blank" class="underline font-semibold">create a GitHub issue</a> describing your problem <strong>before</strong> generating a support report. Without a linked issue, developers cannot act on your support data.
                             </p>
                         </div>
                     </div>
@@ -324,10 +331,41 @@
                         "label" "Include system information"
                         "tooltip" "Include basic system information like OS version, memory, and disk usage"}}
 
+                    <!-- GitHub Issue Number (Required for Upload) -->
+                    <div class="form-control mt-4" x-show="supportDump.uploadToSentry">
+                        <label class="label" for="githubIssueNumber">
+                            <span class="label-text">GitHub Issue Number <span class="text-error">*</span></span>
+                            <span class="help-icon" @mouseenter="showTooltip = 'githubIssue'"
+                                @mouseleave="showTooltip = null">ⓘ</span>
+                        </label>
+                        <input 
+                            type="text"
+                            id="githubIssueNumber"
+                            x-model="supportDump.githubIssueNumber" 
+                            class="input input-bordered input-sm text-base-content" 
+                            :class="{'input-error': supportDump.uploadToSentry && !supportDump.githubIssueNumber}"
+                            placeholder="e.g., 123 or #123"
+                            pattern="#?[0-9]+"
+                            :required="supportDump.uploadToSentry" />
+                        
+                        <!-- Tooltip -->
+                        <div x-show="showTooltip === 'githubIssue'" x-cloak
+                            class="tooltip">
+                            Enter the GitHub issue number (with or without #). Required for uploads so developers can link your support data to your issue.
+                        </div>
+                        
+                        <!-- Helper text -->
+                        <label class="label">
+                            <span class="label-text-alt text-base-content/60">
+                                <a href="https://github.com/tphakala/birdnet-go/issues" target="_blank" class="link link-primary">View existing issues</a> or <a href="https://github.com/tphakala/birdnet-go/issues/new" target="_blank" class="link link-primary">create a new issue</a> first
+                            </span>
+                        </label>
+                    </div>
+
                     <!-- User Message -->
                     <div class="form-control mt-4">
                         <label class="label" for="userMessage">
-                            <span class="label-text">Describe the issue</span>
+                            <span class="label-text">Additional details (optional)</span>
                             <span class="help-icon" @mouseenter="showTooltip = 'userMessage'"
                                 @mouseleave="showTooltip = null">ⓘ</span>
                         </label>
@@ -335,19 +373,19 @@
                             id="userMessage"
                             x-model="supportDump.userMessage" 
                             class="textarea textarea-bordered textarea-sm h-24 text-base-content" 
-                            placeholder="Please describe the issue and include GitHub issue link if applicable (e.g., #123)"
+                            placeholder="Provide any additional context about the issue that isn't in your GitHub issue"
                             rows="4"></textarea>
                         
                         <!-- Tooltip -->
                         <div x-show="showTooltip === 'userMessage'" x-cloak
                             class="tooltip">
-                            Provide details about the problem to help developers understand and fix the issue
+                            Add any additional details that might help developers understand your specific situation
                         </div>
                         
-                        <!-- GitHub Issue Note -->
+                        <!-- System ID Note -->
                         <label class="label">
                             <span class="label-text-alt text-base-content/60">
-                                💡 Tip: If you have a GitHub issue, please include the issue number (e.g., #123) and mention your System ID <span class="font-mono text-xs">{{.Settings.SystemID}}</span> in the GitHub issue to help developers link your support data.
+                                💡 Tip: Your System ID <span class="font-mono text-xs">{{.Settings.SystemID}}</span> will be automatically included in the upload
                             </span>
                         </label>
                     </div>
@@ -359,7 +397,7 @@
                             "model" "supportDump.uploadToSentry"
                             "name" "support.uploadToSentry"
                             "label" "Upload to developers (recommended)"
-                            "tooltip" "Upload the support report to developers for analysis via Sentry's secure cloud service."}}
+                            "tooltip" "Upload the support report to developers for analysis via Sentry's secure cloud service. Requires a GitHub issue number."}}
                         <div class="pl-6 mt-2 space-y-2">
                             <div class="text-xs text-base-content/60">
                                 <p class="flex items-start gap-1">
@@ -426,9 +464,9 @@
                 <div class="card-actions justify-end mt-6">
                     <button 
                         @click="generateSupportDump()"
-                        :disabled="generating || (!supportDump.includeLogs && !supportDump.includeConfig && !supportDump.includeSystemInfo)"
+                        :disabled="generating || (!supportDump.includeLogs && !supportDump.includeConfig && !supportDump.includeSystemInfo) || (supportDump.uploadToSentry && !supportDump.githubIssueNumber)"
                         class="btn btn-primary"
-                        :class="{'btn-disabled': generating || (!supportDump.includeLogs && !supportDump.includeConfig && !supportDump.includeSystemInfo)}">
+                        :class="{'btn-disabled': generating || (!supportDump.includeLogs && !supportDump.includeConfig && !supportDump.includeSystemInfo) || (supportDump.uploadToSentry && !supportDump.githubIssueNumber)}">
                         <span x-show="!generating" class="flex items-center gap-2">
                             <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M9 19l3 3m0 0l3-3m-3 3V10" />
@@ -437,28 +475,6 @@
                         </span>
                         <span x-show="generating" class="loading loading-spinner loading-sm"></span>
                     </button>
-                </div>
-            </div>
-        </div>
-
-        <!-- Privacy Notice -->
-        <div class="alert alert-info mt-4" role="alert">
-            <svg xmlns="http://www.w3.org/2000/svg" class="stroke-current shrink-0 h-6 w-6" fill="none" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
-            <div>
-                <h3 class="font-bold">Privacy & Data Protection</h3>
-                <div class="text-sm mt-1">
-                    <p>Support reports are designed to protect your privacy:</p>
-                    <ul class="list-disc list-inside mt-2 space-y-1">
-                        <li>Passwords, API keys, and tokens are automatically removed</li>
-                        <li>No audio recordings or bird detection data is included</li>
-                        <li>Only application logs and scrubbed configuration are collected</li>
-                        <li>Data is encrypted in transit and at rest</li>
-                        <li>Uploaded data is retained for 90 days in Sentry's EU data center</li>
-                        <li>You can download the report locally before deciding to upload</li>
-                    </ul>
-                    <p class="mt-2 text-xs">
-                        Learn more about <a href="https://docs.sentry.io/organization/data-storage-location/" target="_blank" class="link link-primary">Sentry's data storage</a> and <a href="https://sentry.io/security/" target="_blank" class="link link-primary">security practices</a>.
-                    </p>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- Added mandatory GitHub issue number field for support uploads
- Implemented client-side validation to prevent uploads without issue numbers  
- Updated both HTML template and Svelte component with consistent functionality
- Added comprehensive translations for all 6 supported languages
- Improved link contrast in warning messages for better accessibility

## Test plan
- [ ] Verify GitHub issue number field appears when "Upload to developers" is checked
- [ ] Test validation prevents upload when issue number is missing
- [ ] Confirm field accepts both "#123" and "123" formats (strips # before API call)
- [ ] Check translations display correctly in all supported languages
- [ ] Verify links in warning messages are clickable and accessible
- [ ] Test download functionality still works when upload is unchecked

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Support uploads now require a GitHub issue number; new input with pattern validation and helper links.
  - Generate button is disabled when uploading without a valid issue number; issue number included in submissions.
  - Upload option is always visible with updated labeling; added privacy-first error tracking panel and clearer “what’s included” guidance.
  - User message is now optional with updated placeholder and system ID note.

- Chores
  - Updated translations (EN, DE, ES, FI, FR, PT) to include new GitHub requirement messaging, labels, helpers, status messages, and privacy/contents guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->