### PR TITLE
fix: implement secure password hashing for basic authentication

### DIFF
--- a/internal/api/v2/auth_edge_cases_test.go
+++ b/internal/api/v2/auth_edge_cases_test.go
@@ -1,0 +1,539 @@
+// auth_edge_cases_test.go: Edge case tests for password update handling
+// Tests empty passwords, null values, and partial update payloads
+
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/bcrypt"
+)
+
+// TestEmptyPasswordUpdate tests various empty/null password scenarios
+func TestEmptyPasswordUpdate(t *testing.T) {
+	// Helper function to create a controller with hashed password
+	createControllerWithPassword := func(t *testing.T, password string) (*Controller, string) {
+		t.Helper()
+		hashedPassword, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+		require.NoError(t, err)
+		
+		settings := getTestSettings(t)
+		settings.Security.BasicAuth.Enabled = true
+		settings.Security.BasicAuth.ClientID = "testuser"
+		settings.Security.BasicAuth.Password = string(hashedPassword)
+		
+		e := echo.New()
+		controller := &Controller{
+			Echo:                e,
+			Settings:            settings,
+			controlChan:         make(chan string, 10),
+			DisableSaveSettings: true,
+			logger:              log.New(io.Discard, "TEST: ", log.LstdFlags),
+		}
+		
+		return controller, string(hashedPassword)
+	}
+
+	t.Run("Empty string password should preserve existing", func(t *testing.T) {
+		controller, originalHash := createControllerWithPassword(t, "CurrentPassword123")
+		
+		// Send update with empty string password
+		update := map[string]interface{}{
+			"basicAuth": map[string]interface{}{
+				"password": "",
+			},
+		}
+		
+		body, err := json.Marshal(update)
+		require.NoError(t, err)
+		
+		req := httptest.NewRequest(http.MethodPatch, "/api/v2/settings/security", bytes.NewReader(body))
+		req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+		rec := httptest.NewRecorder()
+		ctx := controller.Echo.NewContext(req, rec)
+		ctx.SetParamNames("section")
+		ctx.SetParamValues("security")
+		
+		err = controller.UpdateSectionSettings(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, rec.Code)
+		
+		// Password should remain unchanged
+		assert.Equal(t, originalHash, controller.Settings.Security.BasicAuth.Password,
+			"Empty string password should not change existing hash")
+	})
+
+	t.Run("Missing password field should preserve existing", func(t *testing.T) {
+		controller, originalHash := createControllerWithPassword(t, "CurrentPassword456")
+		
+		// Send update WITHOUT password field at all
+		update := map[string]interface{}{
+			"basicAuth": map[string]interface{}{
+				"enabled": true,
+				// no password field
+			},
+		}
+		
+		body, err := json.Marshal(update)
+		require.NoError(t, err)
+		
+		req := httptest.NewRequest(http.MethodPatch, "/api/v2/settings/security", bytes.NewReader(body))
+		req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+		rec := httptest.NewRecorder()
+		ctx := controller.Echo.NewContext(req, rec)
+		ctx.SetParamNames("section")
+		ctx.SetParamValues("security")
+		
+		err = controller.UpdateSectionSettings(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, rec.Code)
+		
+		// Password should remain unchanged
+		assert.Equal(t, originalHash, controller.Settings.Security.BasicAuth.Password,
+			"Missing password field should preserve existing hash")
+	})
+
+	t.Run("Null password in JSON should preserve existing", func(t *testing.T) {
+		controller, originalHash := createControllerWithPassword(t, "CurrentPassword789")
+		
+		// Send update with explicit null
+		jsonStr := `{"basicAuth": {"password": null, "enabled": true}}`
+		
+		req := httptest.NewRequest(http.MethodPatch, "/api/v2/settings/security", strings.NewReader(jsonStr))
+		req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+		rec := httptest.NewRecorder()
+		ctx := controller.Echo.NewContext(req, rec)
+		ctx.SetParamNames("section")
+		ctx.SetParamValues("security")
+		
+		err := controller.UpdateSectionSettings(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, rec.Code)
+		
+		// Password should remain unchanged
+		assert.Equal(t, originalHash, controller.Settings.Security.BasicAuth.Password,
+			"Null password should preserve existing hash")
+	})
+
+	t.Run("Whitespace-only password should preserve existing", func(t *testing.T) {
+		controller, _ := createControllerWithPassword(t, "CurrentPasswordXYZ")
+		
+		// Send update with whitespace-only password
+		update := map[string]interface{}{
+			"basicAuth": map[string]interface{}{
+				"password": "   \t\n  ",
+			},
+		}
+		
+		body, err := json.Marshal(update)
+		require.NoError(t, err)
+		
+		req := httptest.NewRequest(http.MethodPatch, "/api/v2/settings/security", bytes.NewReader(body))
+		req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+		rec := httptest.NewRecorder()
+		ctx := controller.Echo.NewContext(req, rec)
+		ctx.SetParamNames("section")
+		ctx.SetParamValues("security")
+		
+		err = controller.UpdateSectionSettings(ctx)
+		require.NoError(t, err)
+		
+		// Should get validation error for whitespace-only password
+		assert.Equal(t, http.StatusBadRequest, rec.Code,
+			"Whitespace-only password should be rejected")
+		assert.Contains(t, rec.Body.String(), "password cannot be only whitespace")
+	})
+
+	t.Run("Update from plaintext to empty should preserve plaintext", func(t *testing.T) {
+		// Start with plaintext password (legacy)
+		settings := getTestSettings(t)
+		settings.Security.BasicAuth.Enabled = true
+		settings.Security.BasicAuth.ClientID = "legacyuser"
+		settings.Security.BasicAuth.Password = "PlaintextPassword123" // Not hashed
+		
+		e := echo.New()
+		controller := &Controller{
+			Echo:                e,
+			Settings:            settings,
+			controlChan:         make(chan string, 10),
+			DisableSaveSettings: true,
+			logger:              log.New(io.Discard, "TEST: ", log.LstdFlags),
+		}
+		
+		// Send update with empty password
+		update := map[string]interface{}{
+			"basicAuth": map[string]interface{}{
+				"password": "",
+			},
+		}
+		
+		body, err := json.Marshal(update)
+		require.NoError(t, err)
+		
+		req := httptest.NewRequest(http.MethodPatch, "/api/v2/settings/security", bytes.NewReader(body))
+		req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+		rec := httptest.NewRecorder()
+		ctx := e.NewContext(req, rec)
+		ctx.SetParamNames("section")
+		ctx.SetParamValues("security")
+		
+		err = controller.UpdateSectionSettings(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, rec.Code)
+		
+		// Plaintext password should be preserved
+		assert.Equal(t, "PlaintextPassword123", controller.Settings.Security.BasicAuth.Password,
+			"Empty password update should preserve existing plaintext password")
+	})
+}
+
+// TestPartialBasicAuthUpdate tests partial update payloads
+func TestPartialBasicAuthUpdate(t *testing.T) {
+	t.Run("Update only enabled flag preserves password", func(t *testing.T) {
+		// Setup with hashed password
+		hashedPassword, err := bcrypt.GenerateFromPassword([]byte("SecurePass123"), bcrypt.DefaultCost)
+		require.NoError(t, err)
+		
+		settings := getTestSettings(t)
+		settings.Security.BasicAuth.Enabled = true
+		settings.Security.BasicAuth.ClientID = "testuser"
+		settings.Security.BasicAuth.ClientSecret = "testsecret"
+		settings.Security.BasicAuth.Password = string(hashedPassword)
+		
+		e := echo.New()
+		controller := &Controller{
+			Echo:                e,
+			Settings:            settings,
+			controlChan:         make(chan string, 10),
+			DisableSaveSettings: true,
+			logger:              log.New(io.Discard, "TEST: ", log.LstdFlags),
+		}
+		
+		// Update only enabled flag
+		update := map[string]interface{}{
+			"basicAuth": map[string]interface{}{
+				"enabled": false,
+				// No other fields
+			},
+		}
+		
+		body, err := json.Marshal(update)
+		require.NoError(t, err)
+		
+		req := httptest.NewRequest(http.MethodPatch, "/api/v2/settings/security", bytes.NewReader(body))
+		req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+		rec := httptest.NewRecorder()
+		ctx := e.NewContext(req, rec)
+		ctx.SetParamNames("section")
+		ctx.SetParamValues("security")
+		
+		err = controller.UpdateSectionSettings(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, rec.Code)
+		
+		// Check all fields
+		assert.False(t, controller.Settings.Security.BasicAuth.Enabled, "Enabled should be updated")
+		assert.Equal(t, string(hashedPassword), controller.Settings.Security.BasicAuth.Password,
+			"Password hash should be preserved")
+		assert.Equal(t, "testuser", controller.Settings.Security.BasicAuth.ClientID,
+			"ClientID should be preserved")
+		assert.Equal(t, "testsecret", controller.Settings.Security.BasicAuth.ClientSecret,
+			"ClientSecret should be preserved")
+	})
+
+	t.Run("Update only clientId preserves password", func(t *testing.T) {
+		hashedPassword, err := bcrypt.GenerateFromPassword([]byte("AnotherPass789"), bcrypt.DefaultCost)
+		require.NoError(t, err)
+		
+		settings := getTestSettings(t)
+		settings.Security.BasicAuth.Enabled = true
+		settings.Security.BasicAuth.ClientID = "olduser"
+		settings.Security.BasicAuth.Password = string(hashedPassword)
+		
+		e := echo.New()
+		controller := &Controller{
+			Echo:                e,
+			Settings:            settings,
+			controlChan:         make(chan string, 10),
+			DisableSaveSettings: true,
+			logger:              log.New(io.Discard, "TEST: ", log.LstdFlags),
+		}
+		
+		// Update only clientId
+		update := map[string]interface{}{
+			"basicAuth": map[string]interface{}{
+				"clientId": "newuser",
+			},
+		}
+		
+		body, err := json.Marshal(update)
+		require.NoError(t, err)
+		
+		req := httptest.NewRequest(http.MethodPatch, "/api/v2/settings/security", bytes.NewReader(body))
+		req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+		rec := httptest.NewRecorder()
+		ctx := e.NewContext(req, rec)
+		ctx.SetParamNames("section")
+		ctx.SetParamValues("security")
+		
+		err = controller.UpdateSectionSettings(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, rec.Code)
+		
+		// Verify updates
+		assert.Equal(t, "newuser", controller.Settings.Security.BasicAuth.ClientID,
+			"ClientID should be updated")
+		assert.Equal(t, string(hashedPassword), controller.Settings.Security.BasicAuth.Password,
+			"Password hash should be preserved")
+		assert.True(t, controller.Settings.Security.BasicAuth.Enabled,
+			"Enabled should be preserved")
+	})
+
+	t.Run("Empty basicAuth object preserves all fields", func(t *testing.T) {
+		hashedPassword, err := bcrypt.GenerateFromPassword([]byte("TestPass456"), bcrypt.DefaultCost)
+		require.NoError(t, err)
+		
+		settings := getTestSettings(t)
+		settings.Security.BasicAuth.Enabled = true
+		settings.Security.BasicAuth.ClientID = "testuser"
+		settings.Security.BasicAuth.ClientSecret = "secret123"
+		settings.Security.BasicAuth.Password = string(hashedPassword)
+		
+		e := echo.New()
+		controller := &Controller{
+			Echo:                e,
+			Settings:            settings,
+			controlChan:         make(chan string, 10),
+			DisableSaveSettings: true,
+			logger:              log.New(io.Discard, "TEST: ", log.LstdFlags),
+		}
+		
+		// Send empty basicAuth object
+		update := map[string]interface{}{
+			"basicAuth": map[string]interface{}{
+				// Completely empty
+			},
+		}
+		
+		body, err := json.Marshal(update)
+		require.NoError(t, err)
+		
+		req := httptest.NewRequest(http.MethodPatch, "/api/v2/settings/security", bytes.NewReader(body))
+		req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+		rec := httptest.NewRecorder()
+		ctx := e.NewContext(req, rec)
+		ctx.SetParamNames("section")
+		ctx.SetParamValues("security")
+		
+		err = controller.UpdateSectionSettings(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, rec.Code)
+		
+		// All fields should be preserved
+		assert.True(t, controller.Settings.Security.BasicAuth.Enabled)
+		assert.Equal(t, "testuser", controller.Settings.Security.BasicAuth.ClientID)
+		assert.Equal(t, "secret123", controller.Settings.Security.BasicAuth.ClientSecret)
+		assert.Equal(t, string(hashedPassword), controller.Settings.Security.BasicAuth.Password)
+	})
+
+	t.Run("Update other security settings preserves basicAuth", func(t *testing.T) {
+		hashedPassword, err := bcrypt.GenerateFromPassword([]byte("KeepThisPass"), bcrypt.DefaultCost)
+		require.NoError(t, err)
+		
+		settings := getTestSettings(t)
+		settings.Security.BasicAuth.Enabled = true
+		settings.Security.BasicAuth.ClientID = "keepuser"
+		settings.Security.BasicAuth.Password = string(hashedPassword)
+		settings.Security.GoogleAuth.Enabled = false
+		
+		e := echo.New()
+		controller := &Controller{
+			Echo:                e,
+			Settings:            settings,
+			controlChan:         make(chan string, 10),
+			DisableSaveSettings: true,
+			logger:              log.New(io.Discard, "TEST: ", log.LstdFlags),
+		}
+		
+		// Update only Google auth settings
+		update := map[string]interface{}{
+			"googleAuth": map[string]interface{}{
+				"enabled":  true,
+				"clientId": "google-client-123",
+				"clientSecret": "google-secret-123", // Need both for validation to pass
+			},
+			// No basicAuth in payload
+		}
+		
+		body, err := json.Marshal(update)
+		require.NoError(t, err)
+		
+		req := httptest.NewRequest(http.MethodPatch, "/api/v2/settings/security", bytes.NewReader(body))
+		req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+		rec := httptest.NewRecorder()
+		ctx := e.NewContext(req, rec)
+		ctx.SetParamNames("section")
+		ctx.SetParamValues("security")
+		
+		err = controller.UpdateSectionSettings(ctx)
+		if err != nil || rec.Code != http.StatusOK {
+			t.Logf("Update failed: status=%d, body=%s, error=%v", rec.Code, rec.Body.String(), err)
+		}
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, rec.Code)
+		
+		// BasicAuth should be completely unchanged
+		assert.True(t, controller.Settings.Security.BasicAuth.Enabled)
+		assert.Equal(t, "keepuser", controller.Settings.Security.BasicAuth.ClientID)
+		assert.Equal(t, string(hashedPassword), controller.Settings.Security.BasicAuth.Password)
+		
+		// GoogleAuth should be updated
+		assert.True(t, controller.Settings.Security.GoogleAuth.Enabled)
+		assert.Equal(t, "google-client-123", controller.Settings.Security.GoogleAuth.ClientID)
+	})
+
+	t.Run("Changing password while disabled still hashes", func(t *testing.T) {
+		settings := getTestSettings(t)
+		settings.Security.BasicAuth.Enabled = false // Start disabled
+		settings.Security.BasicAuth.Password = "oldplaintext"
+		
+		e := echo.New()
+		controller := &Controller{
+			Echo:                e,
+			Settings:            settings,
+			controlChan:         make(chan string, 10),
+			DisableSaveSettings: true,
+			logger:              log.New(io.Discard, "TEST: ", log.LstdFlags),
+		}
+		
+		// Update password while auth is disabled
+		update := map[string]interface{}{
+			"basicAuth": map[string]interface{}{
+				"password": "NewHashedPass123",
+				// Note: not changing enabled flag
+			},
+		}
+		
+		body, err := json.Marshal(update)
+		require.NoError(t, err)
+		
+		req := httptest.NewRequest(http.MethodPatch, "/api/v2/settings/security", bytes.NewReader(body))
+		req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+		rec := httptest.NewRecorder()
+		ctx := e.NewContext(req, rec)
+		ctx.SetParamNames("section")
+		ctx.SetParamValues("security")
+		
+		err = controller.UpdateSectionSettings(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, rec.Code)
+		
+		// Password should be hashed even though auth is disabled
+		assert.False(t, controller.Settings.Security.BasicAuth.Enabled,
+			"Enabled flag should remain false")
+		assert.True(t, strings.HasPrefix(controller.Settings.Security.BasicAuth.Password, "$2"),
+			"Password should be hashed even when basicAuth is disabled")
+		
+		// Verify the hash is valid
+		err = bcrypt.CompareHashAndPassword(
+			[]byte(controller.Settings.Security.BasicAuth.Password),
+			[]byte("NewHashedPass123"))
+		require.NoError(t, err, "Hash should be valid")
+	})
+}
+
+// TestPasswordUpdateWithComplexJSON tests complex/nested JSON scenarios
+func TestPasswordUpdateWithComplexJSON(t *testing.T) {
+	t.Run("Deeply nested null values", func(t *testing.T) {
+		hashedPassword, err := bcrypt.GenerateFromPassword([]byte("KeepMe123"), bcrypt.DefaultCost)
+		require.NoError(t, err)
+		
+		settings := getTestSettings(t)
+		settings.Security.BasicAuth.Enabled = true
+		settings.Security.BasicAuth.Password = string(hashedPassword)
+		settings.Security.BasicAuth.ClientID = "user1"
+		
+		e := echo.New()
+		controller := &Controller{
+			Echo:                e,
+			Settings:            settings,
+			controlChan:         make(chan string, 10),
+			DisableSaveSettings: true,
+			logger:              log.New(io.Discard, "TEST: ", log.LstdFlags),
+		}
+		
+		// Complex JSON with various null/empty combinations
+		jsonStr := `{
+			"basicAuth": {
+				"enabled": true,
+				"clientId": null,
+				"clientSecret": "",
+				"password": null
+			},
+			"googleAuth": null,
+			"allowSubnetBypass": {}
+		}`
+		
+		req := httptest.NewRequest(http.MethodPatch, "/api/v2/settings/security", strings.NewReader(jsonStr))
+		req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+		rec := httptest.NewRecorder()
+		ctx := e.NewContext(req, rec)
+		ctx.SetParamNames("section")
+		ctx.SetParamValues("security")
+		
+		err = controller.UpdateSectionSettings(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, rec.Code)
+		
+		// Password should be preserved
+		assert.Equal(t, string(hashedPassword), controller.Settings.Security.BasicAuth.Password,
+			"Password should be preserved with null value")
+		// ClientID might be cleared by null (depending on implementation)
+		// ClientSecret might be cleared by empty string
+		assert.True(t, controller.Settings.Security.BasicAuth.Enabled)
+	})
+
+	t.Run("Array or invalid type for password field", func(t *testing.T) {
+		settings := getTestSettings(t)
+		settings.Security.BasicAuth.Enabled = true
+		settings.Security.BasicAuth.Password = "keepthis"
+		
+		e := echo.New()
+		controller := &Controller{
+			Echo:                e,
+			Settings:            settings,
+			controlChan:         make(chan string, 10),
+			DisableSaveSettings: true,
+			logger:              log.New(io.Discard, "TEST: ", log.LstdFlags),
+		}
+		
+		// Send array instead of string for password
+		jsonStr := `{
+			"basicAuth": {
+				"password": ["not", "a", "string"]
+			}
+		}`
+		
+		req := httptest.NewRequest(http.MethodPatch, "/api/v2/settings/security", strings.NewReader(jsonStr))
+		req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+		rec := httptest.NewRecorder()
+		ctx := e.NewContext(req, rec)
+		ctx.SetParamNames("section")
+		ctx.SetParamValues("security")
+		
+		_ = controller.UpdateSectionSettings(ctx)
+		// Should get an error for invalid type
+		assert.Equal(t, http.StatusBadRequest, rec.Code,
+			"Should reject array value for password field")
+	})
+}

--- a/internal/api/v2/auth_integration_test.go
+++ b/internal/api/v2/auth_integration_test.go
@@ -1,0 +1,275 @@
+// auth_integration_test.go: End-to-end integration test for password hashing flow
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/bcrypt"
+)
+
+// TestPasswordHashingEndToEnd tests the complete flow:
+// 1. User submits new password via settings API
+// 2. Password is hashed before storage
+// 3. Hashed password can be used for authentication
+func TestPasswordHashingEndToEnd(t *testing.T) {
+	// Setup initial settings with a plaintext password
+	initialSettings := getTestSettings(t)
+	initialSettings.Security.BasicAuth.Enabled = true
+	initialSettings.Security.BasicAuth.Password = "oldPassword123"
+	initialSettings.Security.BasicAuth.ClientID = "testuser"
+	
+	// Create controller
+	e := echo.New()
+	controller := &Controller{
+		Echo:                e,
+		Settings:            initialSettings,
+		controlChan:         make(chan string, 10),
+		DisableSaveSettings: true,
+		logger:              log.New(io.Discard, "TEST: ", log.LstdFlags),
+	}
+	
+	// Step 1: Submit new password via API
+	newPassword := "MyNewSecurePassword456!"
+	updateRequest := map[string]interface{}{
+		"basicAuth": map[string]interface{}{
+			"enabled":  true,
+			"password": newPassword,
+		},
+	}
+	
+	body, err := json.Marshal(updateRequest)
+	require.NoError(t, err)
+	
+	req := httptest.NewRequest(http.MethodPatch, "/api/v2/settings/security", bytes.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+	ctx.SetParamNames("section")
+	ctx.SetParamValues("security")
+	
+	// Execute the update
+	err = controller.UpdateSectionSettings(ctx)
+	require.NoError(t, err, "Should successfully update security settings")
+	assert.Equal(t, http.StatusOK, rec.Code)
+	
+	// Step 2: Verify password was hashed
+	storedPassword := controller.Settings.Security.BasicAuth.Password
+	assert.True(t, strings.HasPrefix(storedPassword, "$2"), "Password should be hashed with bcrypt")
+	
+	// Verify it's a valid bcrypt hash
+	err = bcrypt.CompareHashAndPassword([]byte(storedPassword), []byte(newPassword))
+	require.NoError(t, err, "Stored hash should match the new password")
+	
+	// Step 3: Verify old password no longer works
+	err = bcrypt.CompareHashAndPassword([]byte(storedPassword), []byte("oldPassword123"))
+	require.Error(t, err, "Old password should not match new hash")
+	
+	// Verify the response contains success message
+	var response map[string]interface{}
+	err = json.Unmarshal(rec.Body.Bytes(), &response)
+	require.NoError(t, err)
+	assert.Contains(t, response["message"], "security settings updated successfully")
+	
+	// Additional verification: Ensure other security settings weren't affected
+	assert.Equal(t, "testuser", controller.Settings.Security.BasicAuth.ClientID)
+	assert.True(t, controller.Settings.Security.BasicAuth.Enabled)
+}
+
+// TestPasswordValidationIntegration tests password validation rules via the API
+func TestPasswordValidationIntegration(t *testing.T) {
+	testCases := []struct {
+		name          string
+		password      string
+		expectedCode  int
+		expectedError string
+	}{
+		{
+			name:         "Valid 12 character password",
+			password:     "ValidPass123",
+			expectedCode: http.StatusOK,
+		},
+		{
+			name:          "Too short (5 chars)",
+			password:      "short",
+			expectedCode:  http.StatusBadRequest,
+			expectedError: "password must be at least 8 characters",
+		},
+		{
+			name:          "Too long (73 chars)",
+			password:      strings.Repeat("a", 73),
+			expectedCode:  http.StatusBadRequest,
+			expectedError: "password must not exceed 72 characters",
+		},
+		{
+			name:         "Minimum length (8 chars)",
+			password:     "12345678",
+			expectedCode: http.StatusOK,
+		},
+		{
+			name:         "Maximum length (72 chars)",
+			password:     strings.Repeat("x", 72),
+			expectedCode: http.StatusOK,
+		},
+		{
+			name:         "Special characters and spaces",
+			password:     "P@ss w0rd!#$",
+			expectedCode: http.StatusOK,
+		},
+	}
+	
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Setup
+			settings := getTestSettings(t)
+			settings.Security.BasicAuth.Enabled = true
+			
+			e := echo.New()
+			controller := &Controller{
+				Echo:                e,
+				Settings:            settings,
+				controlChan:         make(chan string, 10),
+				DisableSaveSettings: true,
+				logger:              log.New(io.Discard, "TEST: ", log.LstdFlags),
+			}
+			
+			// Create request
+			update := map[string]interface{}{
+				"basicAuth": map[string]interface{}{
+					"enabled":  true,
+					"password": tc.password,
+				},
+			}
+			
+			body, err := json.Marshal(update)
+			require.NoError(t, err)
+			
+			req := httptest.NewRequest(http.MethodPatch, "/api/v2/settings/security", bytes.NewReader(body))
+			req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+			rec := httptest.NewRecorder()
+			ctx := e.NewContext(req, rec)
+			ctx.SetParamNames("section")
+			ctx.SetParamValues("security")
+			
+			// Execute
+			_ = controller.UpdateSectionSettings(ctx)
+			
+			// Verify
+			assert.Equal(t, tc.expectedCode, rec.Code, 
+				"Expected status %d but got %d for password: %s", 
+				tc.expectedCode, rec.Code, tc.password)
+			
+			if tc.expectedError != "" {
+				assert.Contains(t, rec.Body.String(), tc.expectedError)
+			}
+			
+			// If successful, verify password was hashed
+			if tc.expectedCode == http.StatusOK {
+				storedPassword := controller.Settings.Security.BasicAuth.Password
+				assert.True(t, strings.HasPrefix(storedPassword, "$2"), 
+					"Password should be hashed for: %s", tc.name)
+			}
+		})
+	}
+}
+
+// TestMixedPasswordFormats tests handling of both hashed and plaintext passwords
+func TestMixedPasswordFormats(t *testing.T) {
+	t.Run("Update already hashed password", func(t *testing.T) {
+		// Start with a pre-hashed password
+		existingPassword := "ExistingPass123"
+		existingHash, err := bcrypt.GenerateFromPassword([]byte(existingPassword), bcrypt.DefaultCost)
+		require.NoError(t, err)
+		
+		settings := getTestSettings(t)
+		settings.Security.BasicAuth.Enabled = true
+		settings.Security.BasicAuth.Password = string(existingHash)
+		
+		e := echo.New()
+		controller := &Controller{
+			Echo:                e,
+			Settings:            settings,
+			controlChan:         make(chan string, 10),
+			DisableSaveSettings: true,
+			logger:              log.New(io.Discard, "TEST: ", log.LstdFlags),
+		}
+		
+		// Try to update with the same hashed password (shouldn't re-hash)
+		update := map[string]interface{}{
+			"basicAuth": map[string]interface{}{
+				"password": string(existingHash),
+			},
+		}
+		
+		body, err := json.Marshal(update)
+		require.NoError(t, err)
+		
+		req := httptest.NewRequest(http.MethodPatch, "/api/v2/settings/security", bytes.NewReader(body))
+		req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+		rec := httptest.NewRecorder()
+		ctx := e.NewContext(req, rec)
+		ctx.SetParamNames("section")
+		ctx.SetParamValues("security")
+		
+		err = controller.UpdateSectionSettings(ctx)
+		require.NoError(t, err)
+		
+		// Password should remain the same hash (not double-hashed)
+		assert.Equal(t, string(existingHash), controller.Settings.Security.BasicAuth.Password,
+			"Already hashed password should not be re-hashed")
+	})
+	
+	t.Run("Preserve other fields during password update", func(t *testing.T) {
+		settings := getTestSettings(t)
+		settings.Security.BasicAuth.Enabled = true
+		settings.Security.BasicAuth.ClientID = "originaluser"
+		settings.Security.BasicAuth.ClientSecret = "originalsecret"
+		settings.Security.BasicAuth.Password = "originalpass"
+		
+		e := echo.New()
+		controller := &Controller{
+			Echo:                e,
+			Settings:            settings,
+			controlChan:         make(chan string, 10),
+			DisableSaveSettings: true,
+			logger:              log.New(io.Discard, "TEST: ", log.LstdFlags),
+		}
+		
+		// Update only password
+		update := map[string]interface{}{
+			"basicAuth": map[string]interface{}{
+				"password": "NewPassword789!",
+			},
+		}
+		
+		body, err := json.Marshal(update)
+		require.NoError(t, err)
+		
+		req := httptest.NewRequest(http.MethodPatch, "/api/v2/settings/security", bytes.NewReader(body))
+		req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+		rec := httptest.NewRecorder()
+		ctx := e.NewContext(req, rec)
+		ctx.SetParamNames("section")
+		ctx.SetParamValues("security")
+		
+		err = controller.UpdateSectionSettings(ctx)
+		require.NoError(t, err)
+		
+		// Verify other fields preserved
+		assert.Equal(t, "originaluser", controller.Settings.Security.BasicAuth.ClientID)
+		assert.Equal(t, "originalsecret", controller.Settings.Security.BasicAuth.ClientSecret)
+		assert.True(t, controller.Settings.Security.BasicAuth.Enabled)
+		
+		// Verify password was hashed
+		assert.True(t, strings.HasPrefix(controller.Settings.Security.BasicAuth.Password, "$2"))
+	})
+}

--- a/internal/api/v2/settings.go
+++ b/internal/api/v2/settings.go
@@ -799,6 +799,13 @@ func handleSecuritySectionWithHashing(sectionPtr any, data json.RawMessage, skip
 					basicAuthMap["password"] = currentPasswordHash
 				}
 			}
+			
+			// Re-marshal the modified data since we changed the password
+			modifiedData, err := json.Marshal(updateData)
+			if err != nil {
+				return fmt.Errorf("failed to marshal modified security data: %w", err)
+			}
+			data = modifiedData
 		}
 	}
 


### PR DESCRIPTION
## Summary

This PR fixes a critical issue where users couldn't update passwords through the UI due to API validation blocking all security settings updates. It also implements secure bcrypt password hashing to replace plaintext storage.

## Changes Made

### 1. Fixed Security Settings API (Commit: 3bc41806)
- **Root cause**: `validateSecuritySection` was blocking ALL security updates with "security settings cannot be updated via API"
- **Fix**: Replaced blocking return with proper validation logic
- Added password strength validation (8-72 characters)
- Added CIDR subnet validation

### 2. Implemented Password Hashing (Commit: 3bc41806)
- Added bcrypt hashing when passwords are saved via settings API
- Updated authentication to support both bcrypt and legacy plaintext passwords
- Ensures backwards compatibility for existing installations
- Added `handleSecuritySectionWithHashing` function to hash passwords before storage

### 3. Comprehensive Integration Tests (Commit: 27f52bfb)
- Created `auth_integration_test.go` with end-to-end password flow tests
- Tests validate complete flow from API submission to secure storage
- All edge cases covered: validation, hashing, backwards compatibility
- Fixed issue where passwords weren't being re-marshaled after hashing

### 4. Edge Case Tests & Validation Fixes (Commit: 770f509a)
- Created `auth_edge_cases_test.go` with extensive edge case coverage
- **Issue found & fixed**: Whitespace-only passwords were being accepted
- **Issue found & fixed**: Password validation applied to already-hashed passwords
- Tests cover: empty/null passwords, partial updates, complex JSON scenarios

## Test Coverage

All tests pass successfully:
- ✅ Password updates via settings API
- ✅ Password hashing verification
- ✅ Authentication with hashed passwords
- ✅ Backwards compatibility with plaintext
- ✅ Empty/null password handling
- ✅ Partial update preservation
- ✅ Whitespace-only password rejection
- ✅ Complex JSON handling

## Impact

- Fixes password management functionality in UI
- Improves security by storing passwords as bcrypt hashes
- Maintains backwards compatibility for existing installations
- Comprehensive test coverage ensures robustness

## Files Changed

- `internal/api/v2/settings.go` - Fixed validation, added hashing
- `internal/api/v2/auth/adapter.go` - Updated auth for bcrypt
- `internal/httpcontroller/auth_routes.go` - Legacy auth bcrypt support
- `internal/api/v2/auth_integration_test.go` - Integration tests
- `internal/api/v2/auth_edge_cases_test.go` - Edge case tests

## Note

This PR is in draft mode for review. The context was compressed during development, so please review the commit logs for full implementation details.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>