### PR TITLE
feat: improve config sanitization for support collection

### DIFF
--- a/internal/privacy/config_sanitizer.go
+++ b/internal/privacy/config_sanitizer.go
@@ -1,0 +1,304 @@
+// Package privacy provides privacy-focused utility functions for handling sensitive data
+package privacy
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	
+	"github.com/spf13/viper"
+)
+
+// ConfigSanitizer handles intelligent sanitization of configuration data
+type ConfigSanitizer struct {
+	sensitiveFields map[string]bool
+}
+
+// NewConfigSanitizer creates a new configuration sanitizer with predefined sensitive fields
+func NewConfigSanitizer() *ConfigSanitizer {
+	cs := &ConfigSanitizer{
+		sensitiveFields: make(map[string]bool),
+	}
+	
+	// Define explicitly sensitive field paths that should always be redacted
+	// These are full dot-notation paths from the root of the config
+	sensitiveFields := []string{
+		// API Keys and Tokens
+		"realtime.birdweather.id",
+		"realtime.ebird.apikey",
+		"realtime.weather.openweather.apikey",
+		"realtime.weather.wunderground.apikey",
+		"realtime.weather.wunderground.stationid",
+		
+		// MQTT Credentials (but NOT topic or broker which need special handling)
+		"realtime.mqtt.username",
+		"realtime.mqtt.password",
+		
+		// Database Credentials
+		"output.mysql.username",
+		"output.mysql.password",
+		"output.mysql.host",
+		
+		// OAuth Secrets (NOT client IDs which are public)
+		"security.basicauth.password",
+		"security.googleauth.clientsecret",
+		"security.googleauth.userid",
+		"security.githubauth.clientsecret",
+		"security.githubauth.userid",
+		
+		// Session and Encryption Secrets
+		"security.sessionsecret",
+		"backup.encryption_key",
+		
+		// Sentry DSN
+		"sentry.dsn",
+		
+		// Location data (only if not default 0.000)
+		"birdnet.latitude",
+		"birdnet.longitude",
+	}
+	
+	for _, field := range sensitiveFields {
+		cs.sensitiveFields[field] = true
+	}
+	
+	return cs
+}
+
+// SanitizeConfig intelligently sanitizes configuration data
+func (cs *ConfigSanitizer) SanitizeConfig(config map[string]interface{}) map[string]interface{} {
+	return cs.sanitizeMap(config, "")
+}
+
+// sanitizeMap recursively sanitizes a configuration map
+func (cs *ConfigSanitizer) sanitizeMap(data map[string]interface{}, prefix string) map[string]interface{} {
+	result := make(map[string]interface{})
+	
+	for key, value := range data {
+		// Build the full path for this key
+		fullPath := key
+		if prefix != "" {
+			fullPath = prefix + "." + key
+		}
+		
+		// Special handling for specific fields
+		switch fullPath {
+		case "realtime.mqtt.broker":
+			// Sanitize MQTT broker URL to remove credentials but keep the URL
+			if str, ok := value.(string); ok && str != "" {
+				result[key] = SanitizeURL(str) // Use generic URL sanitizer
+			} else {
+				result[key] = value
+			}
+		case "realtime.rtsp.urls":
+			// Sanitize RTSP URLs to remove credentials but keep URLs
+			switch v := value.(type) {
+			case []interface{}:
+				sanitized := make([]interface{}, len(v))
+				for i, url := range v {
+					if urlStr, ok := url.(string); ok {
+						sanitized[i] = SanitizeURL(urlStr) // Use generic URL sanitizer
+					} else {
+						sanitized[i] = url
+					}
+				}
+				result[key] = sanitized
+			case string:
+				result[key] = SanitizeURL(v)
+			default:
+				result[key] = value
+			}
+		default:
+			// Regular sensitive field check
+			if cs.shouldRedact(fullPath, value) {
+				result[key] = "[REDACTED]"
+			} else {
+				// Recursively process nested structures
+				switch v := value.(type) {
+				case map[string]interface{}:
+					result[key] = cs.sanitizeMap(v, fullPath)
+				case []interface{}:
+					result[key] = cs.sanitizeSlice(v, fullPath)
+				default:
+					result[key] = value
+				}
+			}
+		}
+	}
+	
+	return result
+}
+
+// sanitizeSlice recursively sanitizes a slice
+func (cs *ConfigSanitizer) sanitizeSlice(data []interface{}, prefix string) []interface{} {
+	result := make([]interface{}, len(data))
+	
+	for i, item := range data {
+		switch v := item.(type) {
+		case map[string]interface{}:
+			// For slices of maps, use the same prefix (don't add index)
+			result[i] = cs.sanitizeMap(v, prefix)
+		case []interface{}:
+			result[i] = cs.sanitizeSlice(v, prefix)
+		default:
+			if cs.shouldRedact(prefix, item) {
+				result[i] = "[REDACTED]"
+			} else {
+				result[i] = item
+			}
+		}
+	}
+	
+	return result
+}
+
+// shouldRedact determines if a value should be redacted
+func (cs *ConfigSanitizer) shouldRedact(path string, value interface{}) bool {
+	// Check if this is an explicitly sensitive field
+	if cs.sensitiveFields[path] {
+		// Check if value is empty - never redact empty values
+		if isEmpty(value) {
+			return false
+		}
+		
+		// Special handling for location data
+		if path == "birdnet.latitude" || path == "birdnet.longitude" {
+			// Don't redact default coordinates (0.000)
+			if floatVal, ok := toFloat64(value); ok {
+				// Check if it's effectively zero (within floating point tolerance)
+				if floatVal >= -0.001 && floatVal <= 0.001 {
+					return false
+				}
+			}
+			// Always redact non-zero coordinates
+			return true
+		}
+		
+		// For MySQL credentials, check against default values
+		if path == "output.mysql.username" || path == "output.mysql.password" {
+			// Get the default value from viper
+			defaultVal := viper.Get(path)
+			if defaultVal != nil {
+				// Check if value equals the default
+				if reflect.DeepEqual(value, defaultVal) {
+					return false // Don't redact default values
+				}
+			}
+		}
+		
+		// For other sensitive fields, redact if not empty
+		return true
+	}
+	
+	return false
+}
+
+// isEmpty checks if a value is considered empty
+func isEmpty(value interface{}) bool {
+	if value == nil {
+		return true
+	}
+	
+	switch v := value.(type) {
+	case string:
+		return v == ""
+	case []interface{}:
+		return len(v) == 0
+	case []string:
+		return len(v) == 0
+	case map[string]interface{}:
+		return len(v) == 0
+	case int, int32, int64:
+		return false // Numbers are never considered "empty" for our purposes
+	case float32, float64:
+		return false // Numbers are never considered "empty" for our purposes
+	case bool:
+		return false // Booleans are never considered "empty"
+	default:
+		// Use reflection for other types
+		rv := reflect.ValueOf(value)
+		switch rv.Kind() {
+		case reflect.Slice, reflect.Map, reflect.Array:
+			return rv.Len() == 0
+		case reflect.Ptr, reflect.Interface:
+			return rv.IsNil()
+		default:
+			// For all other types (Chan, Func, Struct, etc.), consider them non-empty
+			return false
+		}
+	}
+}
+
+// toFloat64 attempts to convert a value to float64
+func toFloat64(value interface{}) (float64, bool) {
+	switch v := value.(type) {
+	case float64:
+		return v, true
+	case float32:
+		return float64(v), true
+	case int:
+		return float64(v), true
+	case int32:
+		return float64(v), true
+	case int64:
+		return float64(v), true
+	default:
+		return 0, false
+	}
+}
+
+
+// SanitizeConfigValue sanitizes a single configuration value with context
+// This is useful for sanitizing individual values during runtime
+func SanitizeConfigValue(key string, value interface{}) interface{} {
+	cs := NewConfigSanitizer()
+	if cs.shouldRedact(key, value) {
+		return "[REDACTED]"
+	}
+	return value
+}
+
+// AddSensitiveField adds a field path to the list of sensitive fields
+func (cs *ConfigSanitizer) AddSensitiveField(fieldPath string) {
+	cs.sensitiveFields[fieldPath] = true
+}
+
+// RemoveSensitiveField removes a field path from the list of sensitive fields
+func (cs *ConfigSanitizer) RemoveSensitiveField(fieldPath string) {
+	delete(cs.sensitiveFields, fieldPath)
+}
+
+// IsSensitiveField checks if a field path is marked as sensitive
+func (cs *ConfigSanitizer) IsSensitiveField(fieldPath string) bool {
+	return cs.sensitiveFields[fieldPath]
+}
+
+// SanitizeForDisplay prepares configuration for display, showing redacted values
+// but preserving structure and non-sensitive information
+func (cs *ConfigSanitizer) SanitizeForDisplay(config map[string]interface{}) string {
+	sanitized := cs.SanitizeConfig(config)
+	return formatConfigForDisplay(sanitized, "", 0)
+}
+
+// formatConfigForDisplay formats the configuration map for human-readable display
+func formatConfigForDisplay(data interface{}, prefix string, indent int) string {
+	var result strings.Builder
+	indentStr := strings.Repeat("  ", indent)
+	
+	switch v := data.(type) {
+	case map[string]interface{}:
+		for key, value := range v {
+			result.WriteString(fmt.Sprintf("%s%s:\n", indentStr, key))
+			result.WriteString(formatConfigForDisplay(value, "", indent+1))
+		}
+	case []interface{}:
+		for i, item := range v {
+			result.WriteString(fmt.Sprintf("%s[%d]:\n", indentStr, i))
+			result.WriteString(formatConfigForDisplay(item, "", indent+1))
+		}
+	default:
+		result.WriteString(fmt.Sprintf("%s%v\n", indentStr, v))
+	}
+	
+	return result.String()
+}

--- a/internal/privacy/config_sanitizer_test.go
+++ b/internal/privacy/config_sanitizer_test.go
@@ -1,0 +1,645 @@
+package privacy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfigSanitizer_SanitizeConfig(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    map[string]interface{}
+		expected map[string]interface{}
+	}{
+		{
+			name: "should_redact_api_keys",
+			input: map[string]interface{}{
+				"realtime": map[string]interface{}{
+					"birdweather": map[string]interface{}{
+						"id":        "station-123",
+						"enabled":   true,
+						"threshold": 0.7,
+					},
+					"ebird": map[string]interface{}{
+						"apikey":  "secret-api-key",
+						"enabled": false,
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"realtime": map[string]interface{}{
+					"birdweather": map[string]interface{}{
+						"id":        "[REDACTED]",
+						"enabled":   true,
+						"threshold": 0.7,
+					},
+					"ebird": map[string]interface{}{
+						"apikey":  "[REDACTED]",
+						"enabled": false,
+					},
+				},
+			},
+		},
+		{
+			name: "should_not_redact_empty_api_keys",
+			input: map[string]interface{}{
+				"realtime": map[string]interface{}{
+					"birdweather": map[string]interface{}{
+						"id": "",
+					},
+					"ebird": map[string]interface{}{
+						"apikey": "",
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"realtime": map[string]interface{}{
+					"birdweather": map[string]interface{}{
+						"id": "",
+					},
+					"ebird": map[string]interface{}{
+						"apikey": "",
+					},
+				},
+			},
+		},
+		{
+			name: "should_not_redact_default_coordinates",
+			input: map[string]interface{}{
+				"birdnet": map[string]interface{}{
+					"latitude":  0.000,
+					"longitude": 0.000,
+				},
+			},
+			expected: map[string]interface{}{
+				"birdnet": map[string]interface{}{
+					"latitude":  0.000,
+					"longitude": 0.000,
+				},
+			},
+		},
+		{
+			name: "should_redact_non_default_coordinates",
+			input: map[string]interface{}{
+				"birdnet": map[string]interface{}{
+					"latitude":  37.7749,
+					"longitude": -122.4194,
+				},
+			},
+			expected: map[string]interface{}{
+				"birdnet": map[string]interface{}{
+					"latitude":  "[REDACTED]",
+					"longitude": "[REDACTED]",
+				},
+			},
+		},
+		{
+			name: "should_not_redact_equalizer_settings",
+			input: map[string]interface{}{
+				"realtime": map[string]interface{}{
+					"audio": map[string]interface{}{
+						"equalizer": map[string]interface{}{
+							"enabled": false,
+							"filters": []interface{}{
+								map[string]interface{}{
+									"type":      "HighPass",
+									"frequency": 100,
+									"q":         0.7,
+									"passes":    0,
+									"width":     10,
+								},
+								map[string]interface{}{
+									"type":      "LowPass",
+									"frequency": 15000,
+									"q":         0.7,
+									"passes":    0,
+									"width":     20,
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"realtime": map[string]interface{}{
+					"audio": map[string]interface{}{
+						"equalizer": map[string]interface{}{
+							"enabled": false,
+							"filters": []interface{}{
+								map[string]interface{}{
+									"type":      "HighPass",
+									"frequency": 100,
+									"q":         0.7,
+									"passes":    0,
+									"width":     10,
+								},
+								map[string]interface{}{
+									"type":      "LowPass",
+									"frequency": 15000,
+									"q":         0.7,
+									"passes":    0,
+									"width":     20,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "should_not_redact_dashboard_settings",
+			input: map[string]interface{}{
+				"realtime": map[string]interface{}{
+					"dashboard": map[string]interface{}{
+						"locale":       "en",
+						"newui":        false,
+						"summarylimit": 30,
+						"thumbnails": map[string]interface{}{
+							"debug":          false,
+							"fallbackpolicy": "all",
+							"imageprovider":  "avicommons",
+							"recent":         false,
+							"summary":        false,
+						},
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"realtime": map[string]interface{}{
+					"dashboard": map[string]interface{}{
+						"locale":       "en",
+						"newui":        false,
+						"summarylimit": 30,
+						"thumbnails": map[string]interface{}{
+							"debug":          false,
+							"fallbackpolicy": "all",
+							"imageprovider":  "avicommons",
+							"recent":         false,
+							"summary":        false,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "should_not_redact_dogbarkfilter_settings",
+			input: map[string]interface{}{
+				"realtime": map[string]interface{}{
+					"dogbarkfilter": map[string]interface{}{
+						"confidence": 0.1,
+						"debug":      false,
+						"enabled":    false,
+						"remember":   5,
+						"species":    []interface{}{},
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"realtime": map[string]interface{}{
+					"dogbarkfilter": map[string]interface{}{
+						"confidence": 0.1,
+						"debug":      false,
+						"enabled":    false,
+						"remember":   5,
+						"species":    []interface{}{},
+					},
+				},
+			},
+		},
+		{
+			name: "should_not_redact_dynamicthreshold_settings",
+			input: map[string]interface{}{
+				"realtime": map[string]interface{}{
+					"dynamicthreshold": map[string]interface{}{
+						"debug":      false,
+						"enabled":    false,
+						"min":        0.2,
+						"trigger":    0.9,
+						"validhours": 24,
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"realtime": map[string]interface{}{
+					"dynamicthreshold": map[string]interface{}{
+						"debug":      false,
+						"enabled":    false,
+						"min":        0.2,
+						"trigger":    0.9,
+						"validhours": 24,
+					},
+				},
+			},
+		},
+		{
+			name: "should_sanitize_mqtt_broker_and_redact_credentials",
+			input: map[string]interface{}{
+				"realtime": map[string]interface{}{
+					"mqtt": map[string]interface{}{
+						"enabled":  true,
+						"broker":   "tcp://user:pass@broker.example.com:1883",
+						"username": "mqtt_user",
+						"password": "mqtt_secret",
+						"topic":    "birdnet/detections",
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"realtime": map[string]interface{}{
+					"mqtt": map[string]interface{}{
+						"enabled":  true,
+						"broker":   "tcp://broker.example.com:1883", // Credentials removed from URL
+						"username": "[REDACTED]",
+						"password": "[REDACTED]",
+						"topic":    "birdnet/detections", // Topic NOT redacted
+					},
+				},
+			},
+		},
+		{
+			name: "should_redact_oauth_secrets_but_not_clientids",
+			input: map[string]interface{}{
+				"security": map[string]interface{}{
+					"googleauth": map[string]interface{}{
+						"enabled":       true,
+						"clientid":      "google-client-id",
+						"clientsecret":  "google-secret",
+						"userid":        "user@example.com",
+						"redirecturi":   "/settings",
+					},
+					"githubauth": map[string]interface{}{
+						"clientid":      "github-client-id",
+						"clientsecret":  "github-secret",
+						"userid":        "github-user",
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"security": map[string]interface{}{
+					"googleauth": map[string]interface{}{
+						"enabled":       true,
+						"clientid":      "google-client-id", // NOT redacted
+						"clientsecret":  "[REDACTED]",
+						"userid":        "[REDACTED]",
+						"redirecturi":   "/settings",
+					},
+					"githubauth": map[string]interface{}{
+						"clientid":      "github-client-id", // NOT redacted
+						"clientsecret":  "[REDACTED]",
+						"userid":        "[REDACTED]",
+					},
+				},
+			},
+		},
+		{
+			name: "should_sanitize_rtsp_urls_removing_credentials",
+			input: map[string]interface{}{
+				"realtime": map[string]interface{}{
+					"rtsp": map[string]interface{}{
+						"urls": []interface{}{
+							"rtsp://admin:password@192.168.1.100:554/stream",
+							"rtsp://camera.local/stream1",
+						},
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"realtime": map[string]interface{}{
+					"rtsp": map[string]interface{}{
+						"urls": []interface{}{
+							"rtsp://192.168.1.100:554/stream", // Credentials removed
+							"rtsp://camera.local/stream1",      // No credentials to remove
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "should_handle_mixed_sensitive_and_non_sensitive",
+			input: map[string]interface{}{
+				"main": map[string]interface{}{
+					"name":     "BirdNET-Go",
+					"timeas24h": true,
+				},
+				"output": map[string]interface{}{
+					"mysql": map[string]interface{}{
+						"enabled":  true,
+						"username": "dbuser",
+						"password": "dbpass",
+						"database": "birdnet",
+						"host":     "localhost",
+						"port":     3306,
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"main": map[string]interface{}{
+					"name":     "BirdNET-Go",
+					"timeas24h": true,
+				},
+				"output": map[string]interface{}{
+					"mysql": map[string]interface{}{
+						"enabled":  true,
+						"username": "[REDACTED]",
+						"password": "[REDACTED]",
+						"database": "birdnet",
+						"host":     "[REDACTED]",
+						"port":     3306,
+					},
+				},
+			},
+		},
+		{
+			name: "should_redact_new_sensitive_fields",
+			input: map[string]interface{}{
+				"backup": map[string]interface{}{
+					"encryption_key": "super-secret-key",
+				},
+				"security": map[string]interface{}{
+					"sessionsecret": "session-secret-value",
+				},
+			},
+			expected: map[string]interface{}{
+				"backup": map[string]interface{}{
+					"encryption_key": "[REDACTED]",
+				},
+				"security": map[string]interface{}{
+					"sessionsecret": "[REDACTED]",
+				},
+			},
+		},
+		{
+			name: "should_not_redact_empty_sensitive_fields",
+			input: map[string]interface{}{
+				"backup": map[string]interface{}{
+					"encryption_key": "",
+				},
+				"security": map[string]interface{}{
+					"sessionsecret": "",
+					"basicauth": map[string]interface{}{
+						"password": "",
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"backup": map[string]interface{}{
+					"encryption_key": "",
+				},
+				"security": map[string]interface{}{
+					"sessionsecret": "",
+					"basicauth": map[string]interface{}{
+						"password": "",
+					},
+				},
+			},
+		},
+		{
+			name: "should_not_redact_weather_provider_selection",
+			input: map[string]interface{}{
+				"realtime": map[string]interface{}{
+					"weather": map[string]interface{}{
+						"provider": "yrno",
+						"openweather": map[string]interface{}{
+							"apikey": "",
+						},
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"realtime": map[string]interface{}{
+					"weather": map[string]interface{}{
+						"provider": "yrno",
+						"openweather": map[string]interface{}{
+							"apikey": "",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cs := NewConfigSanitizer()
+			result := cs.SanitizeConfig(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestConfigSanitizer_AddRemoveSensitiveField(t *testing.T) {
+	cs := NewConfigSanitizer()
+	
+	// Test adding a new sensitive field
+	customField := "custom.sensitive.field"
+	assert.False(t, cs.IsSensitiveField(customField))
+	
+	cs.AddSensitiveField(customField)
+	assert.True(t, cs.IsSensitiveField(customField))
+	
+	// Test that it actually redacts the custom field
+	config := map[string]interface{}{
+		"custom": map[string]interface{}{
+			"sensitive": map[string]interface{}{
+				"field": "secret-value",
+			},
+		},
+	}
+	
+	result := cs.SanitizeConfig(config)
+	expected := map[string]interface{}{
+		"custom": map[string]interface{}{
+			"sensitive": map[string]interface{}{
+				"field": "[REDACTED]",
+			},
+		},
+	}
+	assert.Equal(t, expected, result)
+	
+	// Test removing the sensitive field
+	cs.RemoveSensitiveField(customField)
+	assert.False(t, cs.IsSensitiveField(customField))
+	
+	// After removal, it should not redact
+	result = cs.SanitizeConfig(config)
+	assert.Equal(t, config, result)
+}
+
+
+func TestConfigSanitizer_isEmpty(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    interface{}
+		expected bool
+	}{
+		{"nil_value", nil, true},
+		{"empty_string", "", true},
+		{"non_empty_string", "value", false},
+		{"empty_slice", []interface{}{}, true},
+		{"non_empty_slice", []interface{}{"item"}, false},
+		{"empty_map", map[string]interface{}{}, true},
+		{"non_empty_map", map[string]interface{}{"key": "value"}, false},
+		{"zero_int", 0, false},
+		{"non_zero_int", 42, false},
+		{"zero_float", 0.0, false},
+		{"non_zero_float", 3.14, false},
+		{"false_bool", false, false},
+		{"true_bool", true, false},
+	}
+	
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isEmpty(tt.value)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestConfigSanitizer_toFloat64(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    interface{}
+		expected float64
+		ok       bool
+	}{
+		{"float64", float64(3.14), 3.14, true},
+		{"float32", float32(2.5), 2.5, true},
+		{"int", int(42), 42.0, true},
+		{"int32", int32(100), 100.0, true},
+		{"int64", int64(200), 200.0, true},
+		{"string", "not_a_number", 0, false},
+		{"bool", true, 0, false},
+		{"nil", nil, 0, false},
+	}
+	
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, ok := toFloat64(tt.value)
+			assert.Equal(t, tt.ok, ok)
+			if ok {
+				// Use InEpsilon for non-zero values, InDelta for zero
+				if tt.expected == 0 {
+					assert.InDelta(t, tt.expected, result, 0.001)
+				} else {
+					assert.InEpsilon(t, tt.expected, result, 0.001)
+				}
+			}
+		})
+	}
+}
+
+func TestSanitizeConfigValue(t *testing.T) {
+	// Test that standalone function works
+	tests := []struct {
+		name     string
+		key      string
+		value    interface{}
+		expected interface{}
+	}{
+		{
+			name:     "should_redact_sensitive_key",
+			key:      "realtime.birdweather.id",
+			value:    "station-123",
+			expected: "[REDACTED]",
+		},
+		{
+			name:     "should_not_redact_empty_sensitive_key",
+			key:      "realtime.birdweather.id",
+			value:    "",
+			expected: "",
+		},
+		{
+			name:     "should_not_redact_non_sensitive_key",
+			key:      "realtime.dashboard.locale",
+			value:    "en",
+			expected: "en",
+		},
+	}
+	
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := SanitizeConfigValue(tt.key, tt.value)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestConfigSanitizer_ComplexNestedStructure(t *testing.T) {
+	// Test a complex nested structure with various data types
+	input := map[string]interface{}{
+		"level1": map[string]interface{}{
+			"level2": map[string]interface{}{
+				"normalField": "value",
+				"level3": map[string]interface{}{
+					"deepField": 123,
+				},
+			},
+			"arrayField": []interface{}{
+				map[string]interface{}{
+					"item": "one",
+				},
+				map[string]interface{}{
+					"item": "two",
+				},
+			},
+		},
+		"realtime": map[string]interface{}{
+			"birdweather": map[string]interface{}{
+				"id": "secret-id",
+				"nested": map[string]interface{}{
+					"deeper": map[string]interface{}{
+						"value": "should-be-redacted",
+					},
+				},
+			},
+		},
+	}
+	
+	cs := NewConfigSanitizer()
+	result := cs.SanitizeConfig(input)
+	
+	// Check that normal fields are preserved
+	level1 := result["level1"].(map[string]interface{})
+	level2 := level1["level2"].(map[string]interface{})
+	assert.Equal(t, "value", level2["normalField"])
+	
+	level3 := level2["level3"].(map[string]interface{})
+	assert.Equal(t, 123, level3["deepField"])
+	
+	// Check that sensitive field is redacted
+	realtime := result["realtime"].(map[string]interface{})
+	birdweather := realtime["birdweather"].(map[string]interface{})
+	assert.Equal(t, "[REDACTED]", birdweather["id"])
+	
+	// Check that nested fields under sensitive parent are preserved
+	nested := birdweather["nested"].(map[string]interface{})
+	deeper := nested["deeper"].(map[string]interface{})
+	assert.Equal(t, "should-be-redacted", deeper["value"])
+}
+
+
+func TestConfigSanitizer_SanitizeForDisplay(t *testing.T) {
+	cs := NewConfigSanitizer()
+	
+	config := map[string]interface{}{
+		"main": map[string]interface{}{
+			"name": "BirdNET-Go",
+		},
+		"realtime": map[string]interface{}{
+			"birdweather": map[string]interface{}{
+				"id": "secret-id",
+			},
+		},
+	}
+	
+	result := cs.SanitizeForDisplay(config)
+	
+	// Check that the display format contains expected elements
+	assert.Contains(t, result, "main:")
+	assert.Contains(t, result, "name:")
+	assert.Contains(t, result, "BirdNET-Go")
+	assert.Contains(t, result, "realtime:")
+	assert.Contains(t, result, "birdweather:")
+	assert.Contains(t, result, "[REDACTED]")
+}

--- a/internal/privacy/privacy.go
+++ b/internal/privacy/privacy.go
@@ -140,6 +140,25 @@ func SanitizeRTSPUrl(source string) string {
 	return parsedURL.String()
 }
 
+// SanitizeURL removes sensitive information from any URL and returns a display-friendly version
+// It strips credentials while preserving the host, port, and path for debugging
+func SanitizeURL(source string) string {
+	// Parse the URL using standard library
+	parsedURL, err := url.Parse(source)
+	if err != nil {
+		// If parsing fails, return original to avoid data loss
+		return source
+	}
+
+	// Remove user credentials from any URL scheme
+	parsedURL.User = nil
+	
+	// Keep path, query, and fragment for debugging purposes
+	
+	// Return sanitized URL
+	return parsedURL.String()
+}
+
 // SanitizeRTSPUrls finds and sanitizes all RTSP URLs in a given text
 // It uses regex pattern matching to identify RTSP URLs and replaces them with sanitized versions
 func SanitizeRTSPUrls(text string) string {

--- a/internal/support/collector.go
+++ b/internal/support/collector.go
@@ -428,15 +428,29 @@ func (c *Collector) collectConfig(scrub bool) (map[string]any, error) {
 
 // scrubConfig removes sensitive information from configuration
 func (c *Collector) scrubConfig(config map[string]any) map[string]any {
-	scrubbed := make(map[string]any)
+	// Use the new intelligent config sanitizer
+	sanitizer := privacy.NewConfigSanitizer()
+	
+	// Convert map[string]any to map[string]interface{} for the sanitizer
+	configInterface := make(map[string]interface{})
 	for k, v := range config {
-		scrubbed[k] = c.scrubValue(k, v, c.sensitiveKeys)
+		configInterface[k] = v
 	}
-
-	return scrubbed
+	
+	// Sanitize the configuration
+	sanitized := sanitizer.SanitizeConfig(configInterface)
+	
+	// Convert back to map[string]any
+	result := make(map[string]any)
+	for k, v := range sanitized {
+		result[k] = v
+	}
+	
+	return result
 }
 
-// scrubValue recursively scrubs sensitive values
+// scrubValue recursively scrubs sensitive values (kept for backward compatibility)
+// Deprecated: Use ConfigSanitizer instead
 func (c *Collector) scrubValue(key string, value any, sensitiveKeys []string) any {
 	// Check if key is sensitive
 	lowerKey := strings.ToLower(key)


### PR DESCRIPTION
## Summary
Enhanced config sanitization to avoid over-redacting non-sensitive values while properly protecting credentials and sensitive information.

## Problem Solved
Previously, the config sanitization used substring matching which caused over-redaction of non-sensitive fields:
- Fields like "width", "imageprovider", "confidence", "validhours" were being redacted because they contained "id" 
- This made troubleshooting unnecessarily difficult
- Default values and empty strings were being redacted when they shouldn't be

## Key Improvements
- **Intelligent field-specific sanitization**: Uses exact field paths instead of substring matching
- **Runtime viper queries**: Gets defaults from viper at runtime instead of hardcoding duplicates  
- **URL credential sanitization**: Removes credentials from MQTT/RTSP URLs while preserving debugging information
- **OAuth distinction**: Correctly handles public client IDs vs private secrets
- **Coordinate handling**: Properly redacts non-zero coordinates with floating point tolerance
- **Missing sensitive fields**: Added backup.encryption_key and security.sessionsecret

## Changes Made
- Added `ConfigSanitizer` with field-specific sanitization rules (303 lines)
- Added generic `SanitizeURL()` function for credential removal
- Updated support collector to use new sanitizer
- Comprehensive test suite (644 lines) covering all scenarios
- Fixed gocritic linter issue with type switch refactor

## Files Changed
- `internal/privacy/config_sanitizer.go` (303 lines) - New intelligent sanitizer
- `internal/privacy/config_sanitizer_test.go` (644 lines) - Comprehensive tests  
- `internal/privacy/privacy.go` (+19 lines) - Added SanitizeURL function
- `internal/support/collector.go` (+19/-5 lines) - Updated to use new sanitizer

## Testing
- ✅ All tests pass with race detection
- ✅ Zero linter issues  
- ✅ Covers edge cases: empty values, defaults, mixed types, nested structures
- ✅ Pre-commit hooks passed

## Before/After Examples

**Before**: Fields were over-redacted due to substring matching
```yaml
realtime:
  dashboard:
    thumbnails:
      width: "[REDACTED]"           # ❌ Wrong - contains "id"  
      imageprovider: "[REDACTED]"   # ❌ Wrong - contains "id"
  dogbarkfilter:
    confidence: "[REDACTED]"        # ❌ Wrong - contains "id"
  dynamicthreshold:
    validhours: "[REDACTED]"        # ❌ Wrong - contains "id"
```

**After**: Only actual sensitive fields are redacted
```yaml  
realtime:
  dashboard:
    thumbnails:
      width: 150                    # ✅ Preserved
      imageprovider: "avicommons"   # ✅ Preserved
  dogbarkfilter: 
    confidence: 0.1                 # ✅ Preserved
  dynamicthreshold:
    validhours: 24                  # ✅ Preserved
  ebird:
    apikey: "[REDACTED]"           # ✅ Properly redacted
  mqtt:
    broker: "tcp://localhost:1883"  # ✅ Credentials removed, URL preserved
```

## Test Coverage
The new sanitizer includes comprehensive tests for:
- API keys and OAuth secrets (redacted) vs client IDs (preserved)
- URL sanitization for MQTT broker and RTSP URLs  
- Empty and default value handling
- Coordinate redaction with floating point tolerance
- Complex nested structures
- Mixed data types and edge cases

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Centralized configuration sanitizer that redacts sensitive values across nested settings while preserving structure and non-sensitive defaults.
  - Safe display output for configurations, showing redacted values for easy sharing.
  - Generic URL sanitization that removes embedded credentials while keeping the address intact (e.g., MQTT/RTSP).
- Refactor
  - Support collector now uses the new sanitizer for consistent, comprehensive scrubbing; legacy per-key scrubbing is deprecated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->