### PR TITLE
fix(diskmanager): ignore .temp files during directory walk

### DIFF
--- a/internal/analysis/directory.go
+++ b/internal/analysis/directory.go
@@ -287,6 +287,11 @@ func scanDirectory(watchDir string, settings *conf.Settings, processedFiles map[
 			return nil
 		}
 
+		// Skip temporary files that are currently being written
+		if strings.HasSuffix(strings.ToLower(d.Name()), ".temp") {
+			return nil
+		}
+
 		// Check for both .wav and .flac files (case-insensitive)
 		ext := strings.ToLower(filepath.Ext(d.Name()))
 		if ext == ".wav" || ext == ".flac" {

--- a/internal/diskmanager/file_utils.go
+++ b/internal/diskmanager/file_utils.go
@@ -115,7 +115,14 @@ func GetAudioFiles(baseDir string, allowedExts []string, db Interface, debug boo
 			return err
 		}
 		if !info.IsDir() {
-			ext := filepath.Ext(info.Name())
+			fileName := info.Name()
+
+			// Skip .temp files as they are currently being written
+			if strings.HasSuffix(fileName, ".temp") {
+				return nil
+			}
+
+			ext := filepath.Ext(fileName)
 			if contains(allowedExts, ext) {
 				fileInfo, err := parseFileInfo(path, info)
 				if err != nil {

--- a/internal/diskmanager/file_utils.go
+++ b/internal/diskmanager/file_utils.go
@@ -15,6 +15,12 @@ import (
 	"github.com/tphakala/birdnet-go/internal/errors"
 )
 
+// tempFileExt is the temporary file extension used during audio file creation.
+// Audio files are written with this suffix during recording and renamed upon
+// completion to ensure atomic file operations. This must match the TempExt
+// constant in the myaudio package.
+const tempFileExt = ".temp"
+
 // allowedFileTypes is the list of file extensions that are allowed to be deleted
 var allowedFileTypes = []string{".wav", ".flac", ".aac", ".opus", ".mp3", ".m4a"}
 
@@ -117,8 +123,11 @@ func GetAudioFiles(baseDir string, allowedExts []string, db Interface, debug boo
 		if !info.IsDir() {
 			fileName := info.Name()
 
-			// Skip .temp files as they are currently being written
-			if strings.HasSuffix(fileName, ".temp") {
+			// Skip temporary files that are currently being written.
+			// Audio files are written with .temp suffix during recording
+			// and renamed upon completion to ensure atomic file operations.
+			// Using case-insensitive check to handle edge cases.
+			if strings.HasSuffix(strings.ToLower(fileName), tempFileExt) {
 				return nil
 			}
 

--- a/internal/myaudio/ffmpeg_export.go
+++ b/internal/myaudio/ffmpeg_export.go
@@ -18,8 +18,10 @@ import (
 	"github.com/tphakala/birdnet-go/internal/errors"
 )
 
-// tempExt is the temporary file extension used when exporting audio with FFmpeg
-const tempExt = ".temp"
+// TempExt is the temporary file extension used when exporting audio with FFmpeg.
+// Audio files are written with this suffix during recording and renamed upon
+// completion to ensure atomic file operations.
+const TempExt = ".temp"
 
 // ExportAudioWithFFmpeg exports PCM data to the specified format using FFmpeg
 // outputPath is full path with audio file name and extension based on format
@@ -85,7 +87,7 @@ func ExportAudioWithFFmpeg(pcmData []byte, outputPath string, settings *conf.Aud
 		return enhancedErr
 	}
 
-	// Create a temporary file for FFmpeg output, returns full path with tempExt
+	// Create a temporary file for FFmpeg output, returns full path with TempExt
 	// temporary file is used to perform export as atomic file operation
 	tempFilePath, err := createTempFile(outputPath)
 	if err != nil {
@@ -182,7 +184,7 @@ func createTempFile(outputPath string) (string, error) {
 		return "", enhancedErr
 	}
 
-	tempFilePath := outputPath + tempExt
+	tempFilePath := outputPath + TempExt
 
 	// Record successful operation
 	if fileMetrics != nil {
@@ -194,7 +196,7 @@ func createTempFile(outputPath string) (string, error) {
 	return tempFilePath, nil
 }
 
-// finalizeOutput path removes tempExt from the file name completing atomic file operation
+// finalizeOutput path removes TempExt from the file name completing atomic file operation
 func finalizeOutput(tempFilePath string) error {
 	start := time.Now()
 
@@ -213,12 +215,12 @@ func finalizeOutput(tempFilePath string) error {
 		return enhancedErr
 	}
 
-	if !strings.HasSuffix(tempFilePath, tempExt) {
-		enhancedErr := errors.Newf("temp file path does not have expected temporary extension: %s", tempExt).
+	if !strings.HasSuffix(tempFilePath, TempExt) {
+		enhancedErr := errors.Newf("temp file path does not have expected temporary extension: %s", TempExt).
 			Component("myaudio").
 			Category(errors.CategoryValidation).
 			Context("operation", "finalize_output").
-			Context("expected_extension", tempExt).
+			Context("expected_extension", TempExt).
 			Build()
 
 		if fileMetrics != nil {
@@ -228,8 +230,8 @@ func finalizeOutput(tempFilePath string) error {
 		return enhancedErr
 	}
 
-	// Strip tempExt from the end of the path
-	finalOutputPath := tempFilePath[:len(tempFilePath)-len(tempExt)]
+	// Strip TempExt from the end of the path
+	finalOutputPath := tempFilePath[:len(tempFilePath)-len(TempExt)]
 
 	// Get file format from final output path
 	format := strings.ToLower(filepath.Ext(finalOutputPath))


### PR DESCRIPTION
## Summary
- Export TempExt constant from myaudio package for consistency across codebase
- Add case-insensitive checks for .temp files (.temp, .TEMP, .Temp) to handle edge cases
- Add comprehensive documentation explaining atomic file operations with temp files
- Handle temp files in analysis/directory.go for directory scanning operations
- Add unit test to verify temp files are properly ignored
- Ensure consistent temp file handling across all file processing code

## Changes
- `internal/myaudio/ffmpeg_export.go`: Export TempExt constant with documentation
- `internal/diskmanager/file_utils.go`: Add tempFileExt constant, case-insensitive check, and documentation
- `internal/analysis/directory.go`: Add temp file check in directory scanning
- `internal/diskmanager/file_utils_test.go`: Add comprehensive test for temp file handling

## Test plan
- [x] Verified no linter issues with golangci-lint
- [x] Confirmed gofmt formatting
- [x] Added and ran unit test for temp file handling (TestGetAudioFilesIgnoresTempFiles)
- [x] Verified case-insensitive handling of .temp, .TEMP, and .Temp extensions
- [ ] Test with audio recording to ensure .temp files are properly ignored in production
- [ ] Monitor logs to confirm error resolution

🤖 Generated with [Claude Code](https://claude.ai/code)