### PR TITLE
fix(mqtt): resolve automatic reconnection cooldown conflict

### DIFF
--- a/internal/mqtt/client.go
+++ b/internal/mqtt/client.go
@@ -130,19 +130,31 @@ func (c *client) SetDebug(debug bool) {
 // It holds the mutex only while checking state and creating the client instance,
 // releasing it before blocking network operations.
 func (c *client) Connect(ctx context.Context) error {
+	return c.connectWithOptions(ctx, false)
+}
+
+// connectWithOptions is the internal connect method that supports bypassing cooldown for automatic reconnects
+func (c *client) connectWithOptions(ctx context.Context, isAutoReconnect bool) error {
 	if err := ctx.Err(); err != nil { // Check context early
 		mqttLogger.Warn("Connect context already cancelled", "error", err)
 		return err
 	}
 
 	logger := mqttLogger.With("broker", c.config.Broker, "client_id", c.config.ClientID)
-	logger.Info("Attempting to connect to MQTT broker")
+	if isAutoReconnect {
+		logger.Info("Attempting automatic reconnect to MQTT broker")
+	} else {
+		logger.Info("Attempting to connect to MQTT broker")
+	}
 
 	// --- Lock acquisition START ---
 	c.mu.Lock()
-	if err := c.checkConnectionCooldownLocked(logger); err != nil {
-		c.mu.Unlock() // Unlock before returning
-		return err
+	// Only check cooldown for manual connection attempts, not automatic reconnects
+	if !isAutoReconnect {
+		if err := c.checkConnectionCooldownLocked(logger); err != nil {
+			c.mu.Unlock() // Unlock before returning
+			return err
+		}
 	}
 
 	// Disconnect existing client if needed - requires lock
@@ -364,16 +376,18 @@ func (c *client) checkConnectionCooldownLocked(logger *slog.Logger) error {
 	reconnectCooldown := c.config.ReconnectCooldown
 	broker := c.config.Broker
 	clientID := c.config.ClientID
-	
+
 	if time.Since(lastConnAttempt) < reconnectCooldown {
 		lastAttemptAgo := time.Since(lastConnAttempt)
-		logger.Warn("Connection attempt too recent", "last_attempt_ago", lastAttemptAgo, "cooldown", reconnectCooldown)
-		return errors.Newf("connection attempt too recent, last attempt was %v ago", lastAttemptAgo).
+		// Round to seconds for better readability
+		lastAttemptRounded := lastAttemptAgo.Round(time.Second)
+		logger.Warn("Connection attempt too recent", "last_attempt_ago", lastAttemptRounded, "cooldown", reconnectCooldown)
+		return errors.Newf("connection attempt too recent, last attempt was %v ago", lastAttemptRounded).
 			Component("mqtt").
 			Category(errors.CategoryMQTTConnection).
 			Context("broker", broker).
 			Context("client_id", clientID).
-			Context("last_attempt_ago", lastAttemptAgo).
+			Context("last_attempt_ago", lastAttemptRounded).
 			Context("cooldown", reconnectCooldown).
 			Build()
 	}
@@ -452,7 +466,7 @@ func (c *client) performDNSResolution(ctx context.Context, logger *slog.Logger) 
 				c.mu.Unlock()
 				return ctx.Err() // Return the original context error
 			}
-			
+
 			// Handle DNS-specific errors
 			logger.Error("Failed to resolve broker hostname", "host", host, "error", err)
 			var dnsErr *net.DNSError
@@ -469,7 +483,7 @@ func (c *client) performDNSResolution(ctx context.Context, logger *slog.Logger) 
 					Context("operation", "dns_resolution").
 					Build()
 			}
-			
+
 			// Handle other network errors
 			c.mu.Lock()
 			c.lastConnAttempt = time.Now()
@@ -515,7 +529,7 @@ func (c *client) performConnectionAttempt(ctx context.Context, clientToConnect m
 	timeoutDuration := c.config.ConnectTimeout + ConnectTimeoutGrace
 	timer := time.NewTimer(timeoutDuration)
 	defer timer.Stop() // Ensure timer cleanup
-	
+
 	select {
 	case <-opDone:
 		// Stop the timer since operation completed
@@ -526,7 +540,7 @@ func (c *client) performConnectionAttempt(ctx context.Context, clientToConnect m
 			default:
 			}
 		}
-		
+
 		connectErr = token.Error()
 		if connectErr == nil && !clientToConnect.IsConnected() {
 			// If token.Error() is nil but not connected, it implies Paho's WaitTimeout might have returned true
@@ -568,7 +582,7 @@ func (c *client) performConnectionAttempt(ctx context.Context, clientToConnect m
 		// Cancel the connection attempt to prevent the goroutine from leaking
 		if clientToConnect != nil {
 			cancelTimeout := c.calculateCancelTimeout()
-			logger.Debug("Calling Disconnect with dynamic timeout to cancel connection attempt and prevent goroutine leak", 
+			logger.Debug("Calling Disconnect with dynamic timeout to cancel connection attempt and prevent goroutine leak",
 				"timeout_ms", cancelTimeout,
 				"base_timeout", uint(CancelDisconnectTimeout.Milliseconds()),
 				"config_timeout_ms", c.config.DisconnectTimeout.Milliseconds())
@@ -583,13 +597,13 @@ func (c *client) performConnectionAttempt(ctx context.Context, clientToConnect m
 			default:
 			}
 		}
-		
+
 		connectErr = ctx.Err()
 		logger.Error("Context cancelled during MQTT connection wait", "error", connectErr)
 		// Cancel the connection attempt to prevent the goroutine from leaking
 		if clientToConnect != nil {
 			cancelTimeout := c.calculateCancelTimeout()
-			logger.Debug("Calling Disconnect with dynamic timeout to cancel connection attempt and prevent goroutine leak", 
+			logger.Debug("Calling Disconnect with dynamic timeout to cancel connection attempt and prevent goroutine leak",
 				"timeout_ms", cancelTimeout,
 				"base_timeout", uint(CancelDisconnectTimeout.Milliseconds()),
 				"config_timeout_ms", c.config.DisconnectTimeout.Milliseconds())
@@ -609,14 +623,14 @@ func (c *client) Disconnect() {
 	if c.config.ShutdownDisconnectTimeout > 0 {
 		timeout = c.config.ShutdownDisconnectTimeout
 	}
-	
+
 	// Normalize timeout to prevent zero or negative values that could cause underflow
 	// when converted to unsigned types
 	if timeout <= 0 {
 		// Fall back to a safe default if both timeouts are non-positive
 		timeout = GracefulDisconnectTimeout
 	}
-	
+
 	c.disconnectWithTimeout(timeout)
 }
 
@@ -742,7 +756,8 @@ func (c *client) reconnectWithBackoff() {
 		// Proceed with connect attempt
 	}
 
-	if err := c.Connect(ctx); err != nil {
+	// Use connectWithOptions with isAutoReconnect=true to bypass cooldown check
+	if err := c.connectWithOptions(ctx, true); err != nil {
 		logger.Error("Reconnect attempt failed", "error", err)
 
 		// Extract error category for metrics
@@ -780,12 +795,12 @@ func (c *client) createTLSConfig() (*tls.Config, error) {
 			Context("broker", c.config.Broker).
 			Build()
 	}
-	
+
 	hostname := u.Hostname()
-	
+
 	tlsConfig := &tls.Config{
-		ServerName:         hostname,
-		MinVersion:         tls.VersionTLS12,
+		ServerName: hostname,
+		MinVersion: tls.VersionTLS12,
 		// WARNING: InsecureSkipVerify disables certificate verification.
 		// This makes the connection vulnerable to man-in-the-middle attacks.
 		// Only use for testing or with self-signed certificates in trusted networks.
@@ -802,7 +817,7 @@ func (c *client) createTLSConfig() (*tls.Config, error) {
 				Context("ca_cert_path", c.config.TLS.CACert).
 				Build()
 		}
-		
+
 		caCert, err := os.ReadFile(c.config.TLS.CACert)
 		if err != nil {
 			return nil, errors.Newf("failed to read CA certificate file: %v", err).
@@ -834,7 +849,7 @@ func (c *client) createTLSConfig() (*tls.Config, error) {
 				Context("client_cert_path", c.config.TLS.ClientCert).
 				Build()
 		}
-		
+
 		// Check if client key exists
 		if _, err := os.Stat(c.config.TLS.ClientKey); os.IsNotExist(err) {
 			return nil, errors.Newf("client key file does not exist: %s", c.config.TLS.ClientKey).
@@ -843,7 +858,7 @@ func (c *client) createTLSConfig() (*tls.Config, error) {
 				Context("client_key_path", c.config.TLS.ClientKey).
 				Build()
 		}
-		
+
 		cert, err := tls.LoadX509KeyPair(c.config.TLS.ClientCert, c.config.TLS.ClientKey)
 		if err != nil {
 			return nil, errors.Newf("failed to load client certificate and key: %v", err).
@@ -854,7 +869,7 @@ func (c *client) createTLSConfig() (*tls.Config, error) {
 				Build()
 		}
 		tlsConfig.Certificates = []tls.Certificate{cert}
-		mqttLogger.Debug("Client certificate loaded", 
+		mqttLogger.Debug("Client certificate loaded",
 			"cert_path", c.config.TLS.ClientCert,
 			"key_path", c.config.TLS.ClientKey,
 		)


### PR DESCRIPTION
## Summary
- Fix MQTT automatic reconnection being blocked by cooldown timer
- Preserve cooldown protection for manual connections to prevent spamming
- Improve error message time formatting for better user experience

## Problem
The MQTT reconnection mechanism had a timing conflict where automatic reconnects were being blocked by the 5-second cooldown check that should only apply to manual connection attempts. This caused the "connection attempt too recent" error when the system tried to automatically reconnect after connection loss.

**Timeline conflict:**
- Connection lost → 1s ReconnectDelay → Automatic reconnect attempt
- But 5s ReconnectCooldown blocks the attempt → Error

## Solution
1. **Added `connectWithOptions()` internal method** that accepts an `isAutoReconnect` flag
2. **Bypass cooldown for automatic reconnects** while preserving it for manual attempts
3. **Round time values** in error messages to seconds for better readability (e.g., "4s ago" instead of "4.002917932s ago")

## Testing
- ✅ All MQTT package tests pass with race detection
- ✅ Zero linter issues with golangci-lint
- ✅ Manual connections still respect cooldown protection
- ✅ Automatic reconnects now work without cooldown blocking

## Test Plan
- [ ] Manual testing with Home Assistant MQTT integration
- [ ] Verify automatic reconnection works after network interruption
- [ ] Confirm manual connection attempts still respect cooldown

Fixes #1279

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added optional control-channel configuration to the MQTT client for external control integration.
* Bug Fixes
  * Automatic reconnection is no longer delayed by manual cooldown rules, improving connection reliability.
  * TLS now derives the server name from the broker hostname, enhancing compatibility with certificates.
* Refactor
  * Clearer, more informative logs distinguishing manual vs. automatic connection attempts.
  * Cooldown error messages now display rounded time values for readability.
* Tests
  * Added unit tests covering reconnection cooldown behavior and time-rounding edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->