### PR TITLE
fix(mqtt): add node name to sound level MQTT messages

### DIFF
--- a/internal/analysis/sound_level.go
+++ b/internal/analysis/sound_level.go
@@ -319,11 +319,12 @@ func validateSoundLevelData(data *myaudio.SoundLevelData) error {
 
 // CompactSoundLevelData is a space-efficient version for MQTT publishing
 type CompactSoundLevelData struct {
-	TS    string                     `json:"ts"`  // ISO8601 timestamp
-	Src   string                     `json:"src"` // Source
-	Name  string                     `json:"nm"`  // Name
-	Dur   int                        `json:"dur"` // Duration in seconds
-	Bands map[string]CompactBandData `json:"b"`   // Octave bands
+	TS    string                     `json:"ts"`   // ISO8601 timestamp
+	Node  string                     `json:"node"` // Node name (BirdNET-Go instance)
+	Src   string                     `json:"src"`  // Source
+	Name  string                     `json:"nm"`   // Name
+	Dur   int                        `json:"dur"`  // Duration in seconds
+	Bands map[string]CompactBandData `json:"b"`    // Octave bands
 }
 
 // CompactBandData is a compact representation of octave band data
@@ -335,9 +336,10 @@ type CompactBandData struct {
 }
 
 // toCompactFormat converts sound level data to compact format for MQTT
-func toCompactFormat(data myaudio.SoundLevelData) CompactSoundLevelData {
+func toCompactFormat(data myaudio.SoundLevelData, nodeName string) CompactSoundLevelData {
 	compact := CompactSoundLevelData{
 		TS:    data.Timestamp.Format(time.RFC3339),
+		Node:  nodeName,
 		Src:   data.Source,
 		Name:  data.Name,
 		Dur:   data.Duration,
@@ -425,7 +427,7 @@ func publishSoundLevelToMQTT(soundData myaudio.SoundLevelData, proc *processor.P
 	sanitizedData := sanitizeSoundLevelData(soundData)
 
 	// Convert to compact format for MQTT to reduce payload size
-	compactData := toCompactFormat(sanitizedData)
+	compactData := toCompactFormat(sanitizedData, settings.Main.Name)
 
 	// Marshal compact sound level data to JSON
 	jsonData, err := json.Marshal(compactData)

--- a/internal/analysis/sound_level_node_test.go
+++ b/internal/analysis/sound_level_node_test.go
@@ -1,0 +1,98 @@
+package analysis
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/myaudio"
+)
+
+// TestCompactSoundLevelData_IncludesNodeName tests that the node name is included in MQTT messages
+func TestCompactSoundLevelData_IncludesNodeName(t *testing.T) {
+	// Test data
+	nodeName := "BirdNET-Go-TestNode"
+	soundData := myaudio.SoundLevelData{
+		Timestamp: time.Now(),
+		Source:    "test-source",
+		Name:      "Test Audio Source",
+		Duration:  10,
+		OctaveBands: map[string]myaudio.OctaveBandData{
+			"125_Hz": {
+				CenterFreq:  125,
+				Min:         -60.5,
+				Max:         -40.2,
+				Mean:        -50.3,
+				SampleCount: 100,
+			},
+			"250_Hz": {
+				CenterFreq:  250,
+				Min:         -55.0,
+				Max:         -35.0,
+				Mean:        -45.0,
+				SampleCount: 100,
+			},
+		},
+	}
+
+	// Convert to compact format
+	compactData := toCompactFormat(soundData, nodeName)
+
+	// Verify node name is set
+	assert.Equal(t, nodeName, compactData.Node, "Node name should be included in compact data")
+	assert.Equal(t, soundData.Source, compactData.Src, "Source should be preserved")
+	assert.Equal(t, soundData.Name, compactData.Name, "Name should be preserved")
+	assert.Equal(t, soundData.Duration, compactData.Dur, "Duration should be preserved")
+
+	// Marshal to JSON to verify it's included in the output
+	jsonData, err := json.Marshal(compactData)
+	require.NoError(t, err, "Should marshal to JSON without error")
+
+	// Unmarshal to verify
+	var unmarshaled CompactSoundLevelData
+	err = json.Unmarshal(jsonData, &unmarshaled)
+	require.NoError(t, err, "Should unmarshal from JSON without error")
+
+	assert.Equal(t, nodeName, unmarshaled.Node, "Node name should survive JSON round-trip")
+	assert.Equal(t, compactData.Src, unmarshaled.Src, "Source should survive JSON round-trip")
+	assert.Equal(t, compactData.Name, unmarshaled.Name, "Name should survive JSON round-trip")
+
+	// Verify JSON contains the node field
+	jsonStr := string(jsonData)
+	assert.Contains(t, jsonStr, `"node":"BirdNET-Go-TestNode"`, "JSON should contain node field with correct value")
+}
+
+// TestCompactSoundLevelData_EmptyNodeName tests handling of empty node name
+func TestCompactSoundLevelData_EmptyNodeName(t *testing.T) {
+	soundData := myaudio.SoundLevelData{
+		Timestamp: time.Now(),
+		Source:    "test-source",
+		Name:      "Test Audio Source",
+		Duration:  10,
+		OctaveBands: map[string]myaudio.OctaveBandData{
+			"500_Hz": {
+				CenterFreq:  500,
+				Min:         -50.0,
+				Max:         -30.0,
+				Mean:        -40.0,
+				SampleCount: 100,
+			},
+		},
+	}
+
+	// Convert with empty node name
+	compactData := toCompactFormat(soundData, "")
+
+	// Empty node name should be preserved (not replaced with a default)
+	assert.Empty(t, compactData.Node, "Empty node name should be preserved")
+
+	// Marshal to JSON
+	jsonData, err := json.Marshal(compactData)
+	require.NoError(t, err, "Should marshal to JSON without error")
+
+	// Verify JSON contains empty node field
+	jsonStr := string(jsonData)
+	assert.Contains(t, jsonStr, `"node":""`, "JSON should contain node field even when empty")
+}


### PR DESCRIPTION
## Summary
- Added `node` field to sound level MQTT messages containing the BirdNET-Go instance name from `settings.Main.Name`
- Updated `CompactSoundLevelData` struct to include the node name field
- Added comprehensive tests to verify node name is properly included in MQTT payloads

## Problem
Sound level MQTT messages were missing the node name, making it impossible to distinguish between multiple BirdNET-Go instances publishing to the same MQTT broker. Bird detection messages already include this field as `SourceNode`.

## Solution
Modified the sound level MQTT publisher to include the node name, maintaining consistency with bird detection messages. The node name is now included as a `node` field in the JSON payload.

## Test plan
- [x] Added unit tests for node name inclusion
- [x] Verified tests pass with `go test -race`
- [x] Ran golangci-lint with zero issues
- [ ] Manual testing with MQTT broker to verify message format

Fixes #1262

🤖 Generated with [Claude Code](https://claude.ai/code)