### PR TITLE
fix(diskmanager): properly handle temp file race conditions during walk

### DIFF
--- a/internal/diskmanager/file_utils_bench_test.go
+++ b/internal/diskmanager/file_utils_bench_test.go
@@ -60,7 +60,7 @@ func BenchmarkParseFileInfo(b *testing.B) {
 	b.ReportAllocs()
 
 	for i := 0; i < b.N; i++ {
-		_, err := parseFileInfo(path, mockInfo)
+		_, err := parseFileInfo(path, mockInfo, allowedFileTypes)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/internal/diskmanager/file_utils_test.go
+++ b/internal/diskmanager/file_utils_test.go
@@ -40,7 +40,7 @@ func TestInvalidFileNameErrorMessages(t *testing.T) {
 			}
 
 			// Call parseFileInfo and check the error message
-			_, err := parseFileInfo("/test/"+tc.filename, mockInfo)
+			_, err := parseFileInfo("/test/"+tc.filename, mockInfo, allowedFileTypes)
 			require.Error(t, err, "Should return an error for invalid file name")
 			assert.Contains(t, err.Error(), tc.expectedErrText, "Error message should contain expected text")
 		})
@@ -289,4 +289,30 @@ func TestGetAudioFilesHandlesTempFileRaceCondition(t *testing.T) {
 	// We can verify this by checking that the function completes successfully
 	// even in concurrent scenarios (which would be tested in integration tests)
 	t.Log("Race condition handling is verified by continued operation despite temp file disappearance")
+}
+
+// TestHandleWalkError verifies that missing .temp entries during walk are ignored
+func TestHandleWalkError(t *testing.T) {
+	t.Parallel()
+	
+	tempDir := t.TempDir()
+	
+	// Test case 1: os.IsNotExist error for a .temp file should be ignored
+	err := handleWalkError(os.ErrNotExist, filepath.Join(tempDir, "foo.wav.temp"), true)
+	require.NoError(t, err, "missing .temp file should be ignored")
+	
+	// Test case 2: os.IsNotExist error for a .TEMP file (uppercase) should be ignored
+	err = handleWalkError(os.ErrNotExist, filepath.Join(tempDir, "bar.wav.TEMP"), true)
+	require.NoError(t, err, "missing .TEMP file (uppercase) should be ignored")
+	
+	// Test case 3: os.IsNotExist error for a non-temp file should propagate
+	err = handleWalkError(os.ErrNotExist, filepath.Join(tempDir, "baz.wav"), false)
+	require.Error(t, err, "missing non-temp file should not be ignored")
+	require.ErrorIs(t, err, os.ErrNotExist, "should return the original error")
+	
+	// Test case 4: Other errors should always propagate, even for temp files
+	permErr := os.ErrPermission
+	err = handleWalkError(permErr, filepath.Join(tempDir, "denied.wav.temp"), false)
+	require.Error(t, err, "permission error should propagate even for temp files")
+	require.ErrorIs(t, err, permErr, "should return the original error")
 }

--- a/internal/diskmanager/policy_age_test.go
+++ b/internal/diskmanager/policy_age_test.go
@@ -93,7 +93,7 @@ func TestAgeBasedCleanupFileTypeEligibility(t *testing.T) {
 			mockInfo := createMockFileInfo(tc.name, 1024)
 
 			// Call parseFileInfo directly to test file extension checking
-			_, err := parseFileInfo(filepath.Join(testDir, tc.name), mockInfo)
+			_, err := parseFileInfo(filepath.Join(testDir, tc.name), mockInfo, allowedFileTypes)
 
 			// Debug logging
 			t.Logf("File: %s, Extension: %s, Error: %v",
@@ -535,7 +535,7 @@ func simulateAgeBasedCleanup(
 		}
 
 		// Parse the file info
-		fileData, err := parseFileInfo(filePath, fileInfo)
+		fileData, err := parseFileInfo(filePath, fileInfo, allowedFileTypes)
 		if err != nil {
 			continue
 		}

--- a/internal/diskmanager/policy_usage_test.go
+++ b/internal/diskmanager/policy_usage_test.go
@@ -85,7 +85,7 @@ func TestFileTypesEligibleForDeletion(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.filename, func(t *testing.T) {
 			mockInfo := createMockFileInfo(tc.filename, 1024)
-			fileInfo, err := parseFileInfo("/test/"+tc.filename, mockInfo)
+			fileInfo, err := parseFileInfo("/test/"+tc.filename, mockInfo, allowedFileTypes)
 
 			if tc.eligibleForDeletion {
 				require.NoError(t, err, "File should be eligible for deletion: %s", tc.description)
@@ -147,7 +147,7 @@ func TestParseFileInfoWithDifferentExtensions(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.filename, func(t *testing.T) {
 			mockInfo := createMockFileInfo(tc.filename, 1024)
-			fileInfo, err := parseFileInfo("/test/"+tc.filename, mockInfo)
+			fileInfo, err := parseFileInfo("/test/"+tc.filename, mockInfo, allowedFileTypes)
 
 			if tc.shouldSucceed {
 				require.NoError(t, err, "Should parse successfully")
@@ -172,7 +172,7 @@ func TestParseFileInfoMp3Extension(t *testing.T) {
 	// This test specifically targets the bug in the error message
 	mockInfo := createMockFileInfo("bubo_bubo_80p_20250130T184446Z.mp3", 1024)
 
-	fileInfo, err := parseFileInfo("/test/bubo_bubo_80p_20250130T184446Z.mp3", mockInfo)
+	fileInfo, err := parseFileInfo("/test/bubo_bubo_80p_20250130T184446Z.mp3", mockInfo, allowedFileTypes)
 
 	// The bug would cause an error here because it only trims .wav extension
 	require.NoError(t, err, "Should parse MP3 files correctly")
@@ -239,7 +239,7 @@ func TestParseFileInfoProductionFormat(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.filename, func(t *testing.T) {
 			mockInfo := createMockFileInfo(tc.filename, 1024)
-			fileInfo, err := parseFileInfo("/test/"+tc.filename, mockInfo)
+			fileInfo, err := parseFileInfo("/test/"+tc.filename, mockInfo, allowedFileTypes)
 
 			if tc.shouldSucceed {
 				require.NoError(t, err, "Should parse successfully: "+tc.description)
@@ -862,7 +862,7 @@ func testUsageBasedCleanupWithRealFiles(
 		}
 
 		// Parse the file info
-		fileData, err := parseFileInfo(filePath, fileInfo)
+		fileData, err := parseFileInfo(filePath, fileInfo, allowedFileTypes)
 		if err != nil {
 			continue
 		}


### PR DESCRIPTION
## Summary

- Fix race condition where temp files are renamed between directory listing and lstat call
- Add proper error handling for missing temp files in filepath.Walk  
- Refactor GetAudioFilesContext to reduce cognitive complexity
- Add comprehensive test for race condition handling

## Problem

The diskmanager was failing with "no such file or directory" errors when audio files were being written concurrently. This happened because:

1. `filepath.Walk` discovers a `.temp` file during directory listing
2. Audio recording finishes and renames the file from `.temp` to final name  
3. `filepath.Walk` tries to `lstat` the now-nonexistent `.temp` file and fails

## Solution

Added proper error handling in the walk function to:
- Detect "no such file or directory" errors for temp files specifically
- Continue walking instead of failing the entire operation
- Log debug messages when temp files disappear during processing

## Test plan

- [x] Existing diskmanager tests pass
- [x] New test verifies race condition handling
- [x] golangci-lint passes with zero issues
- [x] Manual testing shows no more temp file errors

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Directory scanning now cooperates with cancellation/timeouts for more responsive operations.

- Bug Fixes
  - Skips transient temp-file races when collecting audio files to avoid spurious errors.
  - Provides clearer, descriptive errors when parsing fails or no valid audio files are found.

- Refactor
  - More robust, state-driven directory walk and normalized, case-insensitive file-type checks.

- Tests
  - Added tests covering temp-file race conditions to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->