### PR TITLE
fix(dashboard): improve daily summary grid sorting stability

### DIFF
--- a/frontend/src/lib/desktop/features/dashboard/components/DailySummaryCard.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/components/DailySummaryCard.svelte
@@ -416,12 +416,21 @@ Responsive Breakpoints:
   );
 
   // Optimized data sorting using $derived.by for better performance
+  // Two-tier sorting: primary by count, secondary by latest detection time
   const sortedData = $derived.by(() => {
     // Early return for empty data
     if (data.length === 0) return [];
 
-    // Use spread + sort for compatibility
-    return [...data].sort((a: DailySpeciesSummary, b: DailySpeciesSummary) => b.count - a.count);
+    // Use spread + sort with stable ordering
+    return [...data].sort((a: DailySpeciesSummary, b: DailySpeciesSummary) => {
+      // Primary sort: by detection count (descending)
+      if (b.count !== a.count) {
+        return b.count - a.count;
+      }
+      // Secondary sort: by latest detection time (descending - most recent first)
+      // This ensures stable ordering when counts are equal
+      return (b.latest_heard ?? '').localeCompare(a.latest_heard ?? '');
+    });
   });
 
   // Optimized max count calculations using $derived.by for better performance

--- a/internal/api/v2/analytics.go
+++ b/internal/api/v2/analytics.go
@@ -165,9 +165,15 @@ func (c *Controller) GetDailySpeciesSummary(ctx echo.Context) error {
 		return c.HandleError(ctx, err, "Failed to build response", http.StatusInternalServerError)
 	}
 
-	// 5. Sort by count
+	// 5. Sort by count first, then by latest detection time for stable ordering
 	sort.Slice(result, func(i, j int) bool {
-		return result[i].Count > result[j].Count
+		// Primary sort: by detection count (descending)
+		if result[i].Count != result[j].Count {
+			return result[i].Count > result[j].Count
+		}
+		// Secondary sort: by latest detection time (descending - most recent first)
+		// This ensures stable ordering when counts are equal
+		return result[i].LatestHeard > result[j].LatestHeard
 	})
 
 	// 6. Apply Limit
@@ -342,9 +348,15 @@ func (c *Controller) processSingleDateForBatch(selectedDate string, minConfidenc
 		return nil, err
 	}
 
-	// Sort by count
+	// Sort by count first, then by latest detection time for stable ordering
 	sort.Slice(result, func(i, j int) bool {
-		return result[i].Count > result[j].Count
+		// Primary sort: by detection count (descending)
+		if result[i].Count != result[j].Count {
+			return result[i].Count > result[j].Count
+		}
+		// Secondary sort: by latest detection time (descending - most recent first)
+		// This ensures stable ordering when counts are equal
+		return result[i].LatestHeard > result[j].LatestHeard
 	})
 
 	// Apply limit


### PR DESCRIPTION
## Summary
- Fix unstable sorting in daily species summary grid
- Implement two-tier sorting: detection count + latest detection time
- Eliminate random position switching for species with equal counts

## Changes
- **Backend**: Updated sorting logic in `GetDailySpeciesSummary` endpoints
- **Frontend**: Enhanced sorting in `DailySummaryCard.svelte`
- **Primary sort**: Detection count (descending - most detections first)
- **Secondary sort**: Latest detection time (descending - most recent first)

## Test plan
- [ ] Verify species with highest detection counts appear at top
- [ ] Check that species with equal counts are sorted by recency
- [ ] Confirm no random position switching on page reload
- [ ] Test both single date and batch endpoints

🤖 Generated with [Claude Code](https://claude.ai/code)