### PR TITLE
chore: upgrade Node.js from v20 to v24 across build environments

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -172,7 +172,7 @@
 			"version": "1.25.1"
 		},
 		"ghcr.io/devcontainers/features/node:1": {
-			"version": "20",
+			"version": "24",
 			"nodeGypDependencies": true,
 			"nvmInstallLts": true
 		},

--- a/.github/workflows/frontend-quality.yml
+++ b/.github/workflows/frontend-quality.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: 'frontend/package-lock.json'
       

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           
       - name: Build Frontend
         run: |

--- a/.github/workflows/golangci-test.yml
+++ b/.github/workflows/golangci-test.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           
       - name: Build Frontend
         run: |

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: 'frontend/package-lock.json'
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,8 @@ RUN apt-get update -q && apt-get install -q -y \
     gcc-aarch64-linux-gnu && \
     rm -rf /var/lib/apt/lists/*
 
-# Install Node.js v20 from NodeSource
-RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
+# Install Node.js v24 from NodeSource
+RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - && \
     apt-get install -y nodejs && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary
- Upgrade Node.js from v20 to v24 across all build environments
- Update Dockerfile to install Node.js v24 from NodeSource  
- Update all GitHub Actions workflows to use Node 24
- Update devcontainer configuration to use Node 24

## Motivation
- Node.js v20 reaches EOL in April 2026 (6 months from now)
- Node.js v24 is the current LTS version with extended support until 2027
- Proactive upgrade ensures continued security and compatibility

## Changes
- **Dockerfile**: Changed NodeSource setup from `setup_20.x` to `setup_24.x`
- **GitHub Workflows** (4 files): Updated `node-version: '20'` to `node-version: '24'`
  - `golangci-test.yml`
  - `frontend-quality.yml` 
  - `golangci-lint.yml`
  - `nightly-build.yml`
- **DevContainer**: Updated Node version from `"20"` to `"24"`

## Test plan
- [x] Frontend build passes with Node 24
- [x] Frontend linting and type checking passes (`npm run check:all`)
- [x] All quality checks pass (formatting, ESLint, Stylelint, ast-grep)
- [ ] Verify CI/CD pipelines pass with Node 24
- [ ] Verify Docker builds succeed with Node 24

🤖 Generated with [Claude Code](https://claude.ai/code)