### PR TITLE
fix(datastore): resolve MySQL syntax error in analytics datetime queries

### DIFF
--- a/internal/datastore/analytics.go
+++ b/internal/datastore/analytics.go
@@ -74,11 +74,16 @@ func (ds *DataStore) GetSpeciesSummaryData(startDate, endDate string) ([]Species
 	// Get database-specific datetime formatting
 	dateTimeFormat := ds.GetDateTimeFormat()
 	if dateTimeFormat == "" {
+		// Safely get database type for error context
+		dialectName := "unknown"
+		if d := ds.Dialector(); d != nil {
+			dialectName = d.Name()
+		}
 		return nil, errors.Newf("unsupported database type for datetime formatting").
 			Component("datastore").
 			Category(errors.CategoryConfiguration).
 			Context("operation", "get_species_summary_data").
-			Context("database_type", ds.Dialector().Name()).
+			Context("database_type", dialectName).
 			Build()
 	}
 

--- a/internal/datastore/analytics.go
+++ b/internal/datastore/analytics.go
@@ -73,6 +73,14 @@ func (ds *DataStore) GetSpeciesSummaryData(startDate, endDate string) ([]Species
 
 	// Get database-specific datetime formatting
 	dateTimeFormat := ds.GetDateTimeFormat()
+	if dateTimeFormat == "" {
+		return nil, errors.Newf("unsupported database type for datetime formatting").
+			Component("datastore").
+			Category(errors.CategoryConfiguration).
+			Context("operation", "get_species_summary_data").
+			Context("database_type", ds.Dialector().Name()).
+			Build()
+	}
 
 	// Start building query
 	queryStr := fmt.Sprintf(`

--- a/internal/datastore/analytics.go
+++ b/internal/datastore/analytics.go
@@ -71,19 +71,22 @@ func (ds *DataStore) GetSpeciesSummaryData(startDate, endDate string) ([]Species
 			"end_date", endDate)
 	}
 
+	// Get database-specific datetime formatting
+	dateTimeFormat := ds.GetDateTimeFormat()
+
 	// Start building query
-	queryStr := `
-		SELECT 
+	queryStr := fmt.Sprintf(`
+		SELECT
 			scientific_name,
 			MAX(common_name) as common_name,
 			MAX(species_code) as species_code,
 			COUNT(*) as count,
-			MIN(datetime(date || ' ' || time)) as first_seen,
-			MAX(datetime(date || ' ' || time)) as last_seen,
+			MIN(%s) as first_seen,
+			MAX(%s) as last_seen,
 			AVG(confidence) as avg_confidence,
 			MAX(confidence) as max_confidence
 		FROM notes
-	`
+	`, dateTimeFormat, dateTimeFormat)
 
 	// Add WHERE clause if date filters are provided
 	var whereClause string

--- a/internal/datastore/analytics.go
+++ b/internal/datastore/analytics.go
@@ -72,6 +72,7 @@ func (ds *DataStore) GetSpeciesSummaryData(startDate, endDate string) ([]Species
 	}
 
 	// Get database-specific datetime formatting
+	// TODO: Consider using GetDateTimeExpr("notes.date", "notes.time") for future JOIN support
 	dateTimeFormat := ds.GetDateTimeFormat()
 	if dateTimeFormat == "" {
 		// Safely get database type for error context
@@ -343,11 +344,16 @@ func (ds *DataStore) GetDetectionTrends(period string, limit int) ([]DailyAnalyt
 				Build()
 		}
 	default:
+		// Safely get database type for error context
+		dialectName := "unknown"
+		if d := ds.Dialector(); d != nil {
+			dialectName = d.Name()
+		}
 		return nil, errors.Newf("unsupported database dialect").
 			Component("datastore").
 			Category(errors.CategoryConfiguration).
 			Context("operation", "get_detection_trends").
-			Context("dialect", ds.DB.Dialector.Name()).
+			Context("dialect", dialectName).
 			Build()
 	}
 

--- a/internal/datastore/analytics_datetime_test.go
+++ b/internal/datastore/analytics_datetime_test.go
@@ -213,7 +213,7 @@ func TestGetDateTimeFormat(t *testing.T) {
 		ds := &DataStore{DB: nil} // No database initialized
 
 		format := ds.GetDateTimeFormat()
-		assert.Equal(t, "", format, "Should return empty string for nil dialector")
+		assert.Empty(t, format, "Should return empty string for nil dialector")
 	})
 
 	t.Run("unsupported database", func(t *testing.T) {
@@ -225,7 +225,7 @@ func TestGetDateTimeFormat(t *testing.T) {
 		// In practice, this would require mocking the dialector to return an unsupported type
 		format := ds.GetDateTimeFormat()
 		// With nil DB, should return empty string
-		assert.Equal(t, "", format, "Should return empty string for nil database")
+		assert.Empty(t, format, "Should return empty string for nil database")
 	})
 }
 
@@ -318,7 +318,7 @@ func TestGetDateFormat(t *testing.T) {
 		ds := &DataStore{DB: nil} // No database initialized
 
 		format := ds.GetDateFormat("time")
-		assert.Equal(t, "", format, "Should return empty string for nil dialector")
+		assert.Empty(t, format, "Should return empty string for nil dialector")
 	})
 }
 

--- a/internal/datastore/interfaces.go
+++ b/internal/datastore/interfaces.go
@@ -423,8 +423,13 @@ func (ds *DataStore) Dialector() gorm.Dialector {
 
 // GetHourFormat returns the database-specific SQL fragment for formatting a time column as hour.
 func (ds *DataStore) GetHourFormat() string {
+	dialector := ds.Dialector()
+	if dialector == nil {
+		return ""
+	}
+
 	// Handling for supported databases: SQLite and MySQL
-	switch strings.ToLower(ds.Dialector().Name()) {
+	switch strings.ToLower(dialector.Name()) {
 	case "sqlite":
 		return "strftime('%H', time)"
 	case "mysql":
@@ -437,8 +442,13 @@ func (ds *DataStore) GetHourFormat() string {
 
 // GetDateTimeFormat returns the database-specific SQL fragment for concatenating date and time columns into a datetime.
 func (ds *DataStore) GetDateTimeFormat() string {
+	dialector := ds.Dialector()
+	if dialector == nil {
+		return ""
+	}
+
 	// Handling for supported databases: SQLite and MySQL
-	switch strings.ToLower(ds.Dialector().Name()) {
+	switch strings.ToLower(dialector.Name()) {
 	case "sqlite":
 		return "datetime(date || ' ' || time)"
 	case "mysql":

--- a/internal/datastore/interfaces.go
+++ b/internal/datastore/interfaces.go
@@ -714,11 +714,16 @@ func (ds *DataStore) GetHourlyWeather(date string) ([]HourlyWeather, error) {
 	// Get database-specific date format
 	dateFormat := ds.GetDateFormat("time")
 	if dateFormat == "" {
+		// Safely get database type for error context
+		dialectName := "unknown"
+		if d := ds.Dialector(); d != nil {
+			dialectName = d.Name()
+		}
 		return nil, errors.Newf("unsupported database type for date formatting").
 			Component("datastore").
 			Category(errors.CategoryConfiguration).
 			Context("operation", "get_hourly_weather").
-			Context("database_type", ds.Dialector().Name()).
+			Context("database_type", dialectName).
 			Build()
 	}
 

--- a/internal/datastore/interfaces.go
+++ b/internal/datastore/interfaces.go
@@ -435,6 +435,20 @@ func (ds *DataStore) GetHourFormat() string {
 	}
 }
 
+// GetDateTimeFormat returns the database-specific SQL fragment for concatenating date and time columns into a datetime.
+func (ds *DataStore) GetDateTimeFormat() string {
+	// Handling for supported databases: SQLite and MySQL
+	switch strings.ToLower(ds.Dialector().Name()) {
+	case "sqlite":
+		return "datetime(date || ' ' || time)"
+	case "mysql":
+		return "STR_TO_DATE(CONCAT(date, ' ', time), '%Y-%m-%d %H:%i:%s')"
+	default:
+		// Log or handle unsupported database types
+		return ""
+	}
+}
+
 // GetHourlyOccurrences retrieves hourly occurrences of a specified bird species.
 func (ds *DataStore) GetHourlyOccurrences(date, commonName string, minConfidenceNormalized float64) ([24]int, error) {
 	var hourlyCounts [24]int


### PR DESCRIPTION
## Summary
Fixes MySQL/MariaDB SQL syntax error in analytics queries that was preventing the analytics site from displaying information.

## Problem
The `GetSpeciesSummaryData` function was using SQLite-specific syntax for datetime concatenation:
```sql
MIN(datetime(date || ' ' || time)) as first_seen,
MAX(datetime(date || ' ' || time)) as last_seen,
```

This caused "Error 1064: SQL syntax error" in MySQL/MariaDB because:
- `||` concatenation operator → MySQL uses `CONCAT()` function  
- `datetime()` function → MySQL uses `STR_TO_DATE()` function

## Solution
- Added `GetDateTimeFormat()` method for database-specific datetime formatting
- Updated analytics queries to use database-agnostic datetime concatenation
- SQLite: `datetime(date || ' ' || time)`
- MySQL: `STR_TO_DATE(CONCAT(date, ' ', time), '%Y-%m-%d %H:%i:%s')`

## Testing
- ✅ All existing SQLite tests pass (backward compatibility confirmed)
- ✅ Code builds successfully
- ✅ Follows established pattern of `GetHourFormat()` method

## Test plan
- [ ] Test analytics page with MariaDB/MySQL database
- [ ] Verify species summary data displays correctly
- [ ] Confirm SQLite installations remain unaffected

Fixes #1306

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Consistent, database-aware date/time formatting in analytics and weather queries, with safer handling for unsupported or nil database connectors.
* **Bug Fixes**
  * Corrected first/last seen timestamp calculations in species summaries.
  * Clearer, context-rich errors when running on unsupported databases or when date/time formatting is unavailable.
* **Tests**
  * Added comprehensive tests covering date/time formatting, query integration, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->