### PR TITLE
fix(ui): remove form validation from support dump fields

### DIFF
--- a/frontend/src/lib/desktop/features/settings/pages/SupportSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/SupportSettingsPage.svelte
@@ -448,7 +448,6 @@
                   class:input-error={supportDump.uploadToSentry && !supportDump.githubIssueNumber}
                   placeholder={t('settings.support.supportReport.githubIssue.placeholder')}
                   pattern="#?[0-9]+"
-                  required={supportDump.uploadToSentry}
                   disabled={generating}
                 />
                 <div class="label">

--- a/views/pages/settings/supportSettings.html
+++ b/views/pages/settings/supportSettings.html
@@ -313,21 +313,18 @@
                     {{template "checkbox" dict
                         "id" "includeLogs"
                         "model" "supportDump.includeLogs"
-                        "name" "support.includeLogs"
                         "label" "Include recent logs"
                         "tooltip" "Include application logs from the last 24 hours to help diagnose issues"}}
 
                     {{template "checkbox" dict
                         "id" "includeConfig"
                         "model" "supportDump.includeConfig"
-                        "name" "support.includeConfig"
                         "label" "Include configuration (sensitive data removed)"
                         "tooltip" "Include your configuration file with all sensitive information automatically removed"}}
 
                     {{template "checkbox" dict
                         "id" "includeSystemInfo"
                         "model" "supportDump.includeSystemInfo"
-                        "name" "support.includeSystemInfo"
                         "label" "Include system information"
                         "tooltip" "Include basic system information like OS version, memory, and disk usage"}}
 
@@ -338,15 +335,14 @@
                             <span class="help-icon" @mouseenter="showTooltip = 'githubIssue'"
                                 @mouseleave="showTooltip = null">ⓘ</span>
                         </label>
-                        <input 
+                        <input
                             type="text"
                             id="githubIssueNumber"
-                            x-model="supportDump.githubIssueNumber" 
-                            class="input input-bordered input-sm text-base-content" 
+                            x-model="supportDump.githubIssueNumber"
+                            class="input input-bordered input-sm text-base-content"
                             :class="{'input-error': supportDump.uploadToSentry && !supportDump.githubIssueNumber}"
                             placeholder="e.g., 123 or #123"
-                            pattern="#?[0-9]+"
-                            :required="supportDump.uploadToSentry" />
+                            pattern="#?[0-9]+" />
                         
                         <!-- Tooltip -->
                         <div x-show="showTooltip === 'githubIssue'" x-cloak
@@ -395,7 +391,6 @@
                         {{template "checkbox" dict
                             "id" "uploadToSentry"
                             "model" "supportDump.uploadToSentry"
-                            "name" "support.uploadToSentry"
                             "label" "Upload to developers (recommended)"
                             "tooltip" "Upload the support report to developers for analysis via Sentry's secure cloud service. Requires a GitHub issue number."}}
                         <div class="pl-6 mt-2 space-y-2">


### PR DESCRIPTION
## Summary
- Fixes #1329 - "Can't save changes to 'Enable Error Tracking' checkbox without changes to rest of page"
- Removes form validation from support dump generation fields that was blocking settings save

## Problem
The support dump generation options (including GitHub issue number field) were interfering with saving persistent error tracking settings because:
1. Support dump checkboxes had `name` attributes making them part of the form submission
2. GitHub issue input had HTML5 `required` attribute that blocked form submission
3. The `uploadToSentry` checkbox defaults to true, making GitHub issue field required by default

## Solution
Support dump options are **temporary UI state** for one-time actions, not persistent settings. They should not be part of form validation or submission.

### Changes Made
1. **HTMX version** (supportSettings.html):
   - Removed `name` attributes from all support dump checkboxes
   - Removed `:required="supportDump.uploadToSentry"` from GitHub issue input

2. **Svelte version** (SupportSettingsPage.svelte):  
   - Removed `required={supportDump.uploadToSentry}` from GitHub issue input

## Why This Works
- Support dump options remain purely client-side state
- GitHub issue validation still happens when clicking "Generate & Upload" via JavaScript
- Error tracking settings can now be saved independently
- GitHub issue requirement is preserved for actual uploads

## Testing
- [ ] Can toggle "Enable Error Tracking" and save without filling support dump fields
- [ ] Support dump generation still requires GitHub issue when uploading
- [ ] Support dump can be downloaded without GitHub issue number
- [ ] All form validations work as expected

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Support Report upload flow: the GitHub issue field is no longer blocked by browser validation. Validation now occurs during generation, providing a clear error if uploading to Sentry without an issue number.

* **Refactor**
  * Cleaned up support settings checkboxes’ attributes with no impact on behavior or UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->