### PR TITLE
fix(processor): scale minDetections with detection window duration

### DIFF
--- a/internal/analysis/processor/mindetections_test.go
+++ b/internal/analysis/processor/mindetections_test.go
@@ -1,0 +1,268 @@
+package processor
+
+import (
+	"testing"
+
+	"github.com/tphakala/birdnet-go/internal/conf"
+)
+
+// TestCalculateMinDetections verifies that the minimum detection threshold
+// scales correctly based on detection window duration and overlap settings.
+func TestCalculateMinDetections(t *testing.T) {
+	tests := []struct {
+		name             string
+		captureLength    int // seconds
+		preCaptureLength int // seconds
+		overlap          float64
+		expectedMin      int
+		description      string
+	}{
+		{
+			name:             "default_12s_window_high_overlap",
+			captureLength:    15,
+			preCaptureLength: 3,
+			overlap:          2.4,
+			expectedMin:      4,
+			description:      "Default settings: 15s clip - 3s pre-capture = 12s window, overlap 2.4 should require 4 detections",
+		},
+		{
+			name:             "default_15s_window_high_overlap",
+			captureLength:    15,
+			preCaptureLength: 0,
+			overlap:          2.4,
+			expectedMin:      5,
+			description:      "15s window with no pre-capture, overlap 2.4 should require 5 detections (baseline)",
+		},
+		{
+			name:             "no_overlap_default_window",
+			captureLength:    15,
+			preCaptureLength: 3,
+			overlap:          0.0,
+			expectedMin:      1,
+			description:      "No overlap should accept first detection regardless of window size",
+		},
+		{
+			name:             "no_overlap_15s_window",
+			captureLength:    15,
+			preCaptureLength: 0,
+			overlap:          0.0,
+			expectedMin:      1,
+			description:      "No overlap with 15s baseline window should require exactly 1 detection",
+		},
+		{
+			name:             "long_clip_30s_window",
+			captureLength:    60,
+			preCaptureLength: 30,
+			overlap:          2.4,
+			expectedMin:      10,
+			description:      "Long clips: 60s - 30s = 30s window (2x baseline) should require 10 detections",
+		},
+		{
+			name:             "short_clip_3s_window",
+			captureLength:    6,
+			preCaptureLength: 3,
+			overlap:          2.4,
+			expectedMin:      1,
+			description:      "Short clips: 6s - 3s = 3s window should require at least 1 detection",
+		},
+		{
+			name:             "very_short_clip_near_zero_window",
+			captureLength:    4,
+			preCaptureLength: 3,
+			overlap:          2.4,
+			expectedMin:      1,
+			description:      "Very short window (1s) should still require minimum 1 detection",
+		},
+		{
+			name:             "edge_case_zero_window",
+			captureLength:    3,
+			preCaptureLength: 3,
+			overlap:          2.4,
+			expectedMin:      1,
+			description:      "Edge case: captureLength == preCaptureLength results in 0s window, should require minimum 1",
+		},
+		{
+			name:             "edge_case_negative_window_clamped",
+			captureLength:    2,
+			preCaptureLength: 3,
+			overlap:          2.4,
+			expectedMin:      1,
+			description:      "Edge case: captureLength < preCaptureLength gets clamped to 0, should require minimum 1",
+		},
+		{
+			name:             "high_overlap_2.7",
+			captureLength:    15,
+			preCaptureLength: 3,
+			overlap:          2.7,
+			expectedMin:      8,
+			description:      "Very high overlap (2.7) with 12s window should require 8 detections",
+		},
+		{
+			name:             "high_overlap_2.9",
+			captureLength:    15,
+			preCaptureLength: 3,
+			overlap:          2.9,
+			expectedMin:      24,
+			description:      "Extreme overlap (2.9) with 12s window should require 24 detections",
+		},
+		{
+			name:             "medium_overlap_1.5",
+			captureLength:    15,
+			preCaptureLength: 3,
+			overlap:          1.5,
+			expectedMin:      2,
+			description:      "Medium overlap (1.5) with 12s window should require 2 detections",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create processor with test settings
+			p := &Processor{
+				Settings: &conf.Settings{
+					Realtime: conf.RealtimeSettings{
+						Audio: conf.AudioSettings{
+							Export: conf.ExportSettings{
+								Length:     tt.captureLength,
+								PreCapture: tt.preCaptureLength,
+							},
+						},
+					},
+					BirdNET: conf.BirdNETConfig{
+						Overlap: tt.overlap,
+					},
+				},
+			}
+
+			result := p.calculateMinDetections()
+
+			if result != tt.expectedMin {
+				t.Errorf("%s\nGot minDetections = %d, want %d\nSettings: captureLength=%ds, preCaptureLength=%ds, overlap=%.1f",
+					tt.description, result, tt.expectedMin, tt.captureLength, tt.preCaptureLength, tt.overlap)
+			}
+		})
+	}
+}
+
+// TestCalculateMinDetectionsScaling verifies that minDetections scales
+// proportionally with detection window duration.
+func TestCalculateMinDetectionsScaling(t *testing.T) {
+	tests := []struct {
+		name             string
+		baseCapture      int
+		basePreCapture   int
+		scaleCapture     int
+		scalePreCapture  int
+		overlap          float64
+		scaleFactor      float64 // Expected scale factor
+		description      string
+	}{
+		{
+			name:            "double_window_doubles_detections",
+			baseCapture:     15,
+			basePreCapture:  0,
+			scaleCapture:    30,
+			scalePreCapture: 0,
+			overlap:         2.4,
+			scaleFactor:     2.0,
+			description:     "30s window should require 2x the detections of 15s window",
+		},
+		{
+			name:            "half_window_halves_detections",
+			baseCapture:     15,
+			basePreCapture:  0,
+			scaleCapture:    8,
+			scalePreCapture: 0,
+			overlap:         2.4,
+			scaleFactor:     8.0 / 15.0,
+			description:     "8s window should require proportionally fewer detections",
+		},
+		{
+			name:            "triple_window_triples_detections",
+			baseCapture:     15,
+			basePreCapture:  0,
+			scaleCapture:    45,
+			scalePreCapture: 0,
+			overlap:         2.7,
+			scaleFactor:     3.0,
+			description:     "45s window should require 3x the detections of 15s window",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Calculate base minDetections
+			baseProcessor := &Processor{
+				Settings: &conf.Settings{
+					Realtime: conf.RealtimeSettings{
+						Audio: conf.AudioSettings{
+							Export: conf.ExportSettings{
+								Length:     tt.baseCapture,
+								PreCapture: tt.basePreCapture,
+							},
+						},
+					},
+					BirdNET: conf.BirdNETConfig{
+						Overlap: tt.overlap,
+					},
+				},
+			}
+			baseMin := baseProcessor.calculateMinDetections()
+
+			// Calculate scaled minDetections
+			scaledProcessor := &Processor{
+				Settings: &conf.Settings{
+					Realtime: conf.RealtimeSettings{
+						Audio: conf.AudioSettings{
+							Export: conf.ExportSettings{
+								Length:     tt.scaleCapture,
+								PreCapture: tt.scalePreCapture,
+							},
+						},
+					},
+					BirdNET: conf.BirdNETConfig{
+						Overlap: tt.overlap,
+					},
+				},
+			}
+			scaledMin := scaledProcessor.calculateMinDetections()
+
+			// Verify scaling is proportional
+			expectedScaled := int(float64(baseMin) * tt.scaleFactor)
+			// Allow for rounding differences (±1)
+			if scaledMin < expectedScaled-1 || scaledMin > expectedScaled+1 {
+				t.Errorf("%s\nBase: %d detections, Scaled: %d detections (expected ~%d)\nScale factor: %.2f",
+					tt.description, baseMin, scaledMin, expectedScaled, tt.scaleFactor)
+			}
+		})
+	}
+}
+
+// TestCalculateMinDetectionsConsistency verifies that calculateMinDetections
+// returns consistent results when called multiple times with same settings.
+func TestCalculateMinDetectionsConsistency(t *testing.T) {
+	p := &Processor{
+		Settings: &conf.Settings{
+			Realtime: conf.RealtimeSettings{
+				Audio: conf.AudioSettings{
+					Export: conf.ExportSettings{
+						Length:     15,
+						PreCapture: 3,
+					},
+				},
+			},
+			BirdNET: conf.BirdNETConfig{
+				Overlap: 2.4,
+			},
+		},
+	}
+
+	// Call multiple times and verify consistent results
+	first := p.calculateMinDetections()
+	for i := 0; i < 100; i++ {
+		result := p.calculateMinDetections()
+		if result != first {
+			t.Errorf("Inconsistent results: iteration %d returned %d, expected %d", i, result, first)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #1314 - Detection rate dropped to near zero after making clip length and pre-capture buffer configurable.

## Root Cause

The `minDetections` formula was calibrated for a hardcoded 15-second detection window. When configurable clip length was introduced in #1269, the detection window became `captureLength - preCaptureLength`, which defaults to **12 seconds** (15s - 3s).

The formula didn't scale with this change, requiring the same number of detections in a **20% shorter window**, making the threshold too strict. This caused legitimate bird calls to be discarded as false positives.

## Solution

Created a `calculateMinDetections()` method that:
1. Calculates the current detection window from runtime settings
2. Scales `minDetections` proportionally based on a 15-second baseline
3. Is called on each flusher iteration to support runtime config changes
4. Includes comprehensive edge case handling and documentation

```go
func (p *Processor) calculateMinDetections() int {
    captureLength := time.Duration(p.Settings.Realtime.Audio.Export.Length) * time.Second
    preCaptureLength := time.Duration(p.Settings.Realtime.Audio.Export.PreCapture) * time.Second
    detectionWindow := max(time.Duration(0), captureLength-preCaptureLength)

    segmentLength := math.Max(0.1, 3.0-p.Settings.BirdNET.Overlap)
    baseMinDetections := 3.0 / segmentLength

    // Scale based on 15-second baseline
    scaleFactor := detectionWindow.Seconds() / 15.0
    minDetections := int(math.Max(1, math.Round(baseMinDetections * scaleFactor)))

    return minDetections
}
```

## Key Features

✅ **Runtime Config Support**: Recalculates `minDetections` on each iteration (every 1 second)  
✅ **Config Change Logging**: Logs when minDetections value changes due to config updates  
✅ **Comprehensive Tests**: 12 unit tests covering default, edge cases, and scaling behavior  
✅ **Updated Documentation**: guide.md reflects actual behavior with correct examples  
✅ **Edge Case Handling**: Handles zero/negative windows, extreme overlap values  
✅ **Backward Compatible**: 15-second window maintains original behavior  
✅ **No Performance Impact**: Simple calculations, negligible overhead  

## Changes

### Code Changes
- **processor.go**: Added `calculateMinDetections()` method with full documentation
- **processor.go**: Modified `pendingDetectionsFlusher()` to recalculate and log changes
- **mindetections_test.go**: New test file with 3 test functions covering 12+ scenarios

### Documentation Changes
- **guide.md**: Updated Deep Detection section with correct formula and examples
- **guide.md**: Added runtime adaptability and configurable detection window notes
- **Code comments**: Detailed edge case documentation and inline explanations

## Impact Examples

**With overlap = 2.4 (common setting), default clip length:**
- Detection window: 12 seconds (15s - 3s)
- Before: `minDetections = 5` → required 5/20 detections = **25% hit rate**
- After: `minDetections = 4` → required 4/16 detections = **25% hit rate** (but with correct window calculation)

**With overlap = 0.0 (no overlap):**
- Before & After: `minDetections = 1` (unchanged, accepts first detection ✓)

**With longer clips (60s clip, 30s pre-capture):**
- Detection window: 30 seconds (60s - 30s)
- Before: `minDetections = 5` (too low for 30-second window)
- After: `minDetections = 10` (properly scaled)

**Runtime config change example:**
- User changes overlap from 2.4 → 0.0 via UI
- Before: Required restart for `minDetections` to update
- After: Updates automatically within 1 second, logs the change ✓

## Why Pre-Capture Buffer Deduction is Necessary

The detection window must be `captureLength - preCaptureLength` to prevent audio clip gaps. Example with 60s clip, 30s pre-capture:

- First detection at T=0s → clip covers T-30s to T+30s
- Detection window = 30s → next detection allowed at T+30s
- Next detection at T+35s → clip covers T+5s to T+65s
- **No gap**: clips overlap from T+5s to T+30s ✓

If we used the full `captureLength` as the detection window, there would be a 5-second gap between clips.

## Test Plan

- [x] Code linted with `golangci-lint run -v`
- [x] Refactored to support runtime config changes
- [x] Added comprehensive unit tests (12 test cases)
- [x] All tests pass
- [x] Updated guide.md documentation
- [x] Added config change logging
- [x] Enhanced code documentation with edge cases
- [ ] Manual testing with default settings (15s clip, 3s pre-capture, overlap 2.4)
- [ ] Verify detection rates return to normal
- [ ] Test with custom clip lengths (6s, 30s, 60s)
- [ ] Test runtime config changes (change overlap/clip length without restart)

## Test Results

```
=== RUN   TestCalculateMinDetections
=== RUN   TestCalculateMinDetections/default_12s_window_high_overlap
=== RUN   TestCalculateMinDetections/default_15s_window_high_overlap
=== RUN   TestCalculateMinDetections/no_overlap_default_window
=== RUN   TestCalculateMinDetections/no_overlap_15s_window
=== RUN   TestCalculateMinDetections/long_clip_30s_window
=== RUN   TestCalculateMinDetections/short_clip_3s_window
=== RUN   TestCalculateMinDetections/very_short_clip_near_zero_window
=== RUN   TestCalculateMinDetections/edge_case_zero_window
=== RUN   TestCalculateMinDetections/edge_case_negative_window_clamped
=== RUN   TestCalculateMinDetections/high_overlap_2.7
=== RUN   TestCalculateMinDetections/high_overlap_2.9
=== RUN   TestCalculateMinDetections/medium_overlap_1.5
--- PASS: TestCalculateMinDetections (0.00s)
=== RUN   TestCalculateMinDetectionsScaling
--- PASS: TestCalculateMinDetectionsScaling (0.00s)
=== RUN   TestCalculateMinDetectionsConsistency
--- PASS: TestCalculateMinDetectionsConsistency (0.00s)
PASS
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Detection window is now configurable (based on clip length and pre-capture), replacing the fixed 15s window.
  - Minimum detections dynamically adjust using the window and overlap, updating at runtime without restarting.

- Documentation
  - Deep Detection guide updated to reflect the configurable window, new calculation logic, and runtime behavior.
  - Added config snippets and expanded examples (e.g., 15s/30s clips) with revised timelines, metrics, and threshold guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->