### PR TITLE
fix(processor): remove detection window scaling from minDetections calculation

### DIFF
--- a/internal/analysis/processor/mindetections_test.go
+++ b/internal/analysis/processor/mindetections_test.go
@@ -55,14 +55,20 @@ func TestCalculateMinDetections(t *testing.T) {
 		{
 			name:        "extreme_overlap_2.7",
 			overlap:     2.7,
-			expectedMin: 6,
-			description: "Overlap 2.7: step=0.3s, max 10 detections per 3s, require 6 (ceil(50% of 10))",
+			expectedMin: 5,
+			description: "Overlap 2.7: step=0.3s, max 10 detections per 3s, require 5 (50% of 10)",
 		},
 		{
 			name:        "extreme_overlap_2.8",
 			overlap:     2.8,
 			expectedMin: 8,
-			description: "Overlap 2.8: step=0.2s, max 15 detections per 3s, require 8 (50% of 15)",
+			description: "Overlap 2.8: step=0.2s, max 15 detections per 3s, require 8 (ceil(50% of 15))",
+		},
+		{
+			name:        "extreme_overlap_2.85",
+			overlap:     2.85,
+			expectedMin: 10,
+			description: "Overlap 2.85: step=0.15s, max 20 detections per 3s, require 10 (50% of 20) - tests epsilon fix",
 		},
 		{
 			name:        "near_max_overlap_2.9",


### PR DESCRIPTION
Fixes #1314 

## Problem

The detection confirmation system became too aggressive with certain configurations, requiring an unreasonably high number of consecutive matches before accepting a bird detection.

### Background

The false positive filtering works by requiring multiple BirdNET detections of the same species within overlapping 3-second audio chunks. The old method was **functional but too strict** - it scaled `minDetections` by the audio clip length (detection window), which had unintended consequences:

**User example from issue #1314:**
- Config: `overlap=2.2`, `captureLength=60s`, `preCapture=15s`
- Old formula calculated: `minDetections = 14`
- Logs showed: `"matched 1/14 times"`, `"matched 3/14 times"` - all rejected
- **Result: System performed poorly, rejecting valid bird detections**

### Root Cause

PR #1335 scaled minDetections by detection window to handle variable clip lengths:

```go
// OLD (TOO AGGRESSIVE)
detectionWindow := captureLength - preCaptureLength  // 60 - 15 = 45s
scaleFactor := detectionWindow / 15.0                // 45 / 15 = 3.0
minDetections := baseMinDetections * scaleFactor     // 4.7 * 3.0 = 14
```

**The issue:** This made the system require proportionally more detections for longer clips, even though:
1. Birds don't vocalize proportionally more in longer windows
2. Clip length is a user preference for capturing complete songs, not a detection parameter
3. The overlap setting already determines how many times audio is analyzed

## Solution

Implemented overlap-only formula with 50% confirmation threshold that properly balances sensitivity and false positive filtering:

```go
// NEW (BALANCED)
segmentLength := 3.0 - overlap                       // 3.0 - 2.2 = 0.8s
maxDetectionsPerChunk := 3.0 / segmentLength         // 3.0 / 0.8 = 3.75
minDetections := ceil(maxDetectionsPerChunk * 0.5)   // ceil(1.875) = 2
```

### How It Works

1. **Overlap determines analysis frequency**: With overlap 2.2, each 3-second audio chunk is analyzed ~4 times with 0.8s steps
2. **Real birds = consistent detections**: A bird call triggers detections across overlapping analyses of the same audio
3. **False positives = random**: Noise/wind won't consistently trigger across multiple analyses of the same audio
4. **50% confirmation threshold**: Require half of possible detections to confirm (not dependent on clip length)

**Key change: Detection window (clip length) completely removed from calculation.**

## Results

### Impact on User's Config (overlap=2.2, 60s capture, 15s pre-capture)
- **Before:** minDetections = 14 (too aggressive, rejected real birds)
- **After:** minDetections = 2 (balanced, accepts birds with 2+ confirmations)

### Detection Threshold Comparison
| Overlap | Step Size | Max Detections/3s | Old minDetections | New minDetections |
|---------|-----------|-------------------|-------------------|-------------------|
| 0.0 | 3.0s | 1 | 1 | 1 |
| 1.5 | 1.5s | 2 | 1-2 | 1 |
| 2.0 | 1.0s | 3 | 2-3 | 2 |
| **2.2** | **0.8s** | **4** | **14** ❌ | **2** ✓ |
| 2.4 | 0.6s | 5 | 3-14 | 3 |
| 2.5 | 0.5s | 6 | 3-18 | 3 |

## Changes

### Modified Files
1. **[processor.go](internal/analysis/processor/processor.go#L755-L794)** 
   - Rewrote `calculateMinDetections()` with overlap-only logic
   - Added comprehensive documentation explaining the repeated detection confirmation concept
   - Removed detection window scaling that was causing overly aggressive filtering

2. **[mindetections_test.go](internal/analysis/processor/mindetections_test.go)**
   - Complete test suite rewrite with overlap-focused tests
   - Added `TestCalculateMinDetectionsIndependentOfClipLength` to verify clip length doesn't affect result
   - Added `TestCalculateMinDetectionsIssue1314` as regression test
   - All tests pass ✓

## Testing

```bash
$ go test -v ./internal/analysis/processor/ -run TestCalculateMinDetections
=== RUN   TestCalculateMinDetections
--- PASS: TestCalculateMinDetections (0.00s)
=== RUN   TestCalculateMinDetectionsIndependentOfClipLength  
--- PASS: TestCalculateMinDetectionsIndependentOfClipLength (0.00s)
=== RUN   TestCalculateMinDetectionsIssue1314
--- PASS: TestCalculateMinDetectionsIssue1314 (0.00s)
PASS
```

## Impact

✅ **Fixes overly aggressive detection filtering** for users with longer clip settings
✅ **Preserves the core concept:** Multiple BirdNET analyses of the same audio must agree to confirm
✅ **Audio clip length no longer affects detection sensitivity** - it's purely a user preference
✅ **Maintains false positive filtering** with reasonable 50% confirmation threshold
✅ **No breaking changes** for users with default/low overlap settings

## Migration Notes

Users who experienced poor detection performance with this issue should see immediate improvement:
- **No config changes needed** - system automatically adapts
- Detection threshold now correctly based only on overlap setting
- Longer audio clips (30-60s) no longer trigger aggressive filtering
- Birds with 2-3 consistent detections across overlapping analyses will be accepted

The original intent of the false positive filter is preserved: require repeated detection of the same species across multiple analyses of the same audio content, but now with appropriate thresholds that don't reject valid detections.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Resolved inflated detection thresholds on long clips (issue #1314).
  - Min detections now scale with overlap only, ensuring consistent behavior across clip lengths.
- Refactor
  - Simplified detection logic for more predictable, stable results.
- Tests
  - Added regression and consistency tests to validate overlap-based behavior and prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->