### PR TITLE
feat(conf): add FFmpeg version detection for runtime decisions

### DIFF
--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -88,6 +88,9 @@ type SoundLevelSettings struct {
 type AudioSettings struct {
 	Source          string             `yaml:"source" mapstructure:"source" json:"source"`                   // audio source to use for analysis
 	FfmpegPath      string             `yaml:"ffmpegpath" mapstructure:"ffmpegpath" json:"ffmpegPath"`       // path to ffmpeg, runtime value
+	FfmpegVersion   string             `yaml:"-" json:"ffmpegVersion,omitempty"`                             // ffmpeg version string, runtime value
+	FfmpegMajor     int                `yaml:"-" json:"ffmpegMajor,omitempty"`                               // ffmpeg major version number, runtime value
+	FfmpegMinor     int                `yaml:"-" json:"ffmpegMinor,omitempty"`                               // ffmpeg minor version number, runtime value
 	SoxPath         string             `yaml:"soxpath" mapstructure:"soxpath" json:"soxPath"`                // path to sox, runtime value
 	SoxAudioTypes   []string           `yaml:"-" json:"-"`                                                   // supported audio types of sox, runtime value
 	StreamTransport string             `json:"streamTransport"`                                              // preferred transport for audio streaming: "auto", "sse", or "ws"
@@ -97,6 +100,21 @@ type AudioSettings struct {
 
 	Equalizer EqualizerSettings `json:"equalizer"` // equalizer settings
 }
+
+// NeedsFfprobeWorkaround returns true if the current FFmpeg version requires
+// using ffprobe to get audio file length for spectrograms (FFmpeg 5.x bug).
+// FFmpeg 7.x and later have this issue fixed.
+func (a *AudioSettings) NeedsFfprobeWorkaround() bool {
+	// FFmpeg 5.x has a bug that requires using ffprobe for audio duration
+	// FFmpeg 7.x and later have this fixed
+	return a.FfmpegMajor == 5
+}
+
+// HasFfmpegVersion returns true if FFmpeg version information has been detected and populated.
+func (a *AudioSettings) HasFfmpegVersion() bool {
+	return a.FfmpegVersion != "" && a.FfmpegMajor > 0
+}
+
 type Thumbnails struct {
 	Debug          bool   `json:"debug"`          // true to enable debug mode
 	Summary        bool   `json:"summary"`        // show thumbnails on summary table

--- a/internal/conf/config_test.go
+++ b/internal/conf/config_test.go
@@ -1,0 +1,118 @@
+package conf
+
+import "testing"
+
+func TestAudioSettings_NeedsFfprobeWorkaround(t *testing.T) {
+	tests := []struct {
+		name        string
+		audio       AudioSettings
+		wantWorkaround bool
+	}{
+		{
+			name: "FFmpeg 5.x needs workaround",
+			audio: AudioSettings{
+				FfmpegVersion: "5.1.7-0+deb12u1+rpt1",
+				FfmpegMajor:   5,
+				FfmpegMinor:   1,
+			},
+			wantWorkaround: true,
+		},
+		{
+			name: "FFmpeg 7.x does not need workaround",
+			audio: AudioSettings{
+				FfmpegVersion: "7.1.2-0+deb13u1",
+				FfmpegMajor:   7,
+				FfmpegMinor:   1,
+			},
+			wantWorkaround: false,
+		},
+		{
+			name: "FFmpeg 6.x does not need workaround",
+			audio: AudioSettings{
+				FfmpegVersion: "6.0",
+				FfmpegMajor:   6,
+				FfmpegMinor:   0,
+			},
+			wantWorkaround: false,
+		},
+		{
+			name: "FFmpeg 4.x does not need workaround",
+			audio: AudioSettings{
+				FfmpegVersion: "4.4.2",
+				FfmpegMajor:   4,
+				FfmpegMinor:   4,
+			},
+			wantWorkaround: false,
+		},
+		{
+			name: "Unknown version does not need workaround",
+			audio: AudioSettings{
+				FfmpegVersion: "",
+				FfmpegMajor:   0,
+				FfmpegMinor:   0,
+			},
+			wantWorkaround: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.audio.NeedsFfprobeWorkaround(); got != tt.wantWorkaround {
+				t.Errorf("AudioSettings.NeedsFfprobeWorkaround() = %v, want %v", got, tt.wantWorkaround)
+			}
+		})
+	}
+}
+
+func TestAudioSettings_HasFfmpegVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		audio   AudioSettings
+		wantHas bool
+	}{
+		{
+			name: "Valid version detected",
+			audio: AudioSettings{
+				FfmpegVersion: "7.1.2",
+				FfmpegMajor:   7,
+				FfmpegMinor:   1,
+			},
+			wantHas: true,
+		},
+		{
+			name: "No version detected",
+			audio: AudioSettings{
+				FfmpegVersion: "",
+				FfmpegMajor:   0,
+				FfmpegMinor:   0,
+			},
+			wantHas: false,
+		},
+		{
+			name: "Version string but no major version",
+			audio: AudioSettings{
+				FfmpegVersion: "unknown",
+				FfmpegMajor:   0,
+				FfmpegMinor:   0,
+			},
+			wantHas: false,
+		},
+		{
+			name: "Major version but no version string",
+			audio: AudioSettings{
+				FfmpegVersion: "",
+				FfmpegMajor:   7,
+				FfmpegMinor:   1,
+			},
+			wantHas: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.audio.HasFfmpegVersion(); got != tt.wantHas {
+				t.Errorf("AudioSettings.HasFfmpegVersion() = %v, want %v", got, tt.wantHas)
+			}
+		})
+	}
+}

--- a/internal/conf/utils_test.go
+++ b/internal/conf/utils_test.go
@@ -1,0 +1,129 @@
+package conf
+
+import (
+	"testing"
+)
+
+func TestParseFfmpegVersion(t *testing.T) {
+	tests := []struct {
+		name          string
+		output        string
+		wantVersion   string
+		wantMajor     int
+		wantMinor     int
+	}{
+		{
+			name: "FFmpeg 7.1.2 Debian",
+			output: `ffmpeg version 7.1.2-0+deb13u1 Copyright (c) 2000-2025 the FFmpeg developers
+built with gcc 14 (Debian 14.2.0-19)`,
+			wantVersion: "7.1.2-0+deb13u1",
+			wantMajor:   7,
+			wantMinor:   1,
+		},
+		{
+			name: "FFmpeg 5.1.7 Raspberry Pi",
+			output: `ffmpeg version 5.1.7-0+deb12u1+rpt1 Copyright (c) 2000-2025 the FFmpeg developers
+built with gcc 12 (Debian 12.2.0-14+deb12u1)`,
+			wantVersion: "5.1.7-0+deb12u1+rpt1",
+			wantMajor:   5,
+			wantMinor:   1,
+		},
+		{
+			name: "FFmpeg 6.0",
+			output: `ffmpeg version 6.0 Copyright (c) 2000-2023 the FFmpeg developers
+built with gcc 11.3.0`,
+			wantVersion: "6.0",
+			wantMajor:   6,
+			wantMinor:   0,
+		},
+		{
+			name: "FFmpeg 4.4.2",
+			output: `ffmpeg version 4.4.2-2ubuntu1 Copyright (c) 2000-2022 the FFmpeg developers
+built with gcc 11 (Ubuntu 11.2.0-19ubuntu1)`,
+			wantVersion: "4.4.2-2ubuntu1",
+			wantMajor:   4,
+			wantMinor:   4,
+		},
+		{
+			name:          "Empty output",
+			output:        "",
+			wantVersion:   "",
+			wantMajor:     0,
+			wantMinor:     0,
+		},
+		{
+			name:          "Invalid format",
+			output:        "some random text",
+			wantVersion:   "",
+			wantMajor:     0,
+			wantMinor:     0,
+		},
+		{
+			name: "FFmpeg git build with libavutil",
+			output: `ffmpeg version N-121000-g7321e4b950 Copyright (c) 2000-2025 the FFmpeg developers
+built with gcc 11.4.0 (Ubuntu 11.4.0-1ubuntu1~22.04)
+configuration: --prefix=/usr/local
+libavutil      59.  8.100 / 59.  8.100
+libavcodec     61.  3.100 / 61.  3.100
+libavformat    61.  1.100 / 61.  1.100`,
+			wantVersion: "N-121000-g7321e4b950",
+			wantMajor:   7,
+			wantMinor:   8,
+		},
+		{
+			name: "FFmpeg 8.0 Windows (gyan.dev build)",
+			output: `ffmpeg version 8.0-essentials_build-www.gyan.dev Copyright (c) 2000-2025 the FFmpeg developers
+built with gcc 15.2.0 (Rev8, Built by MSYS2 project)
+configuration: --enable-gpl --enable-version3
+libavutil      60.  8.100 / 60.  8.100
+libavcodec     62. 11.100 / 62. 11.100
+libavformat    62.  3.100 / 62.  3.100`,
+			wantVersion: "8.0-essentials_build-www.gyan.dev",
+			wantMajor:   8,
+			wantMinor:   0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotVersion, gotMajor, gotMinor := ParseFfmpegVersion(tt.output)
+
+			if gotVersion != tt.wantVersion {
+				t.Errorf("ParseFfmpegVersion() version = %v, want %v", gotVersion, tt.wantVersion)
+			}
+			if gotMajor != tt.wantMajor {
+				t.Errorf("ParseFfmpegVersion() major = %v, want %v", gotMajor, tt.wantMajor)
+			}
+			if gotMinor != tt.wantMinor {
+				t.Errorf("ParseFfmpegVersion() minor = %v, want %v", gotMinor, tt.wantMinor)
+			}
+		})
+	}
+}
+
+func TestGetFfmpegVersion(t *testing.T) {
+	// This test will only work if ffmpeg is installed on the system
+	version, major, minor := GetFfmpegVersion()
+
+	// If ffmpeg is not available, the function should return empty values
+	if version == "" {
+		t.Skip("ffmpeg not available on system, skipping integration test")
+	}
+
+	// If we got a version, validate it has sensible values
+	// Note: For git builds, major version is derived from libavutil, so it should be valid
+	if major < 3 || major > 10 {
+		t.Errorf("GetFfmpegVersion() major version %d seems out of reasonable range (3-10 expected)", major)
+	}
+
+	if minor < 0 || minor > 99 {
+		t.Errorf("GetFfmpegVersion() minor version %d seems out of reasonable range (0-99 expected)", minor)
+	}
+
+	// Additional validation: if major is 0, something went wrong
+	if major == 0 {
+		t.Errorf("GetFfmpegVersion() failed to detect major version, got: version=%s, major=%d, minor=%d", version, major, minor)
+	}
+
+	t.Logf("Detected FFmpeg version: %s (major: %d, minor: %d)", version, major, minor)
+}

--- a/internal/conf/validate.go
+++ b/internal/conf/validate.go
@@ -425,6 +425,18 @@ func validateAudioSettings(settings *AudioSettings) error {
 		settings.FfmpegPath = "" // Ensure path is empty if validation failed
 	} else {
 		settings.FfmpegPath = validatedFfmpegPath // Store the validated path (explicit or from PATH)
+
+		// Detect FFmpeg version for runtime decisions (e.g., FFmpeg 5.x bug workarounds)
+		version, major, minor := GetFfmpegVersion()
+		settings.FfmpegVersion = version
+		settings.FfmpegMajor = major
+		settings.FfmpegMinor = minor
+
+		if major > 0 {
+			log.Printf("Detected FFmpeg version: %s (major: %d, minor: %d)", version, major, minor)
+		} else {
+			log.Printf("Warning: Could not detect FFmpeg version from: %s", version)
+		}
 	}
 
 	// Validate and determine the effective SoX path


### PR DESCRIPTION
## Summary

Add FFmpeg version detection to enable runtime decisions based on the installed FFmpeg version. This addresses a bug in FFmpeg 5.x that requires using ffprobe to get audio file duration for creating spectrograms. FFmpeg 7.x and later have this issue fixed.

## Changes

### Core Implementation
- **AudioSettings struct enhancements** ([config.go](https://github.com/tphakala/birdnet-go/blob/feat/ffmpeg-version-detection/internal/conf/config.go#L91-L93)):
  - `FfmpegVersion` (string): Full version string
  - `FfmpegMajor` (int): Major version number  
  - `FfmpegMinor` (int): Minor version number

- **Helper methods** ([config.go](https://github.com/tphakala/birdnet-go/blob/feat/ffmpeg-version-detection/internal/conf/config.go#L104-L116)):
  - `NeedsFfprobeWorkaround()`: Returns true for FFmpeg 5.x
  - `HasFfmpegVersion()`: Checks if version detection succeeded

- **Version detection functions** ([utils.go](https://github.com/tphakala/birdnet-go/blob/feat/ffmpeg-version-detection/internal/conf/utils.go#L405-L543)):
  - `GetFfmpegVersion()`: Detects installed FFmpeg version
  - `ParseFfmpegVersion()`: Parses version from various formats
  - `parseLibavutilVersion()`: Handles git builds via libavutil mapping

- **Automatic detection** ([validate.go](https://github.com/tphakala/birdnet-go/blob/feat/ffmpeg-version-detection/internal/conf/validate.go#L429-L440)):
  - Version detected during configuration validation
  - Logs version on startup

### Testing
- Comprehensive test coverage with 8+ test cases
- Tests for standard releases, git builds, Windows builds
- Tests for helper methods
- All tests pass ✅
- Linter clean ✅

## Supported Version Formats

- **Standard releases**: `7.1.2-0+deb13u1`, `5.1.7-0+deb12u1+rpt1`
- **Git builds**: `N-121000-g7321e4b950` (uses libavutil version mapping)
- **Windows builds**: `8.0-essentials_build-www.gyan.dev`
- **Simple versions**: `6.0`, `4.4.2`

## Usage Example

```go
settings := conf.Setting()

if settings.Realtime.Audio.NeedsFfprobeWorkaround() {
    // Use ffprobe for audio duration (FFmpeg 5.x bug workaround)
    duration := getAudioDurationWithFfprobe(audioFile)
} else {
    // Use ffmpeg directly (FFmpeg 6.x, 7.x, or later)
    duration := getAudioDurationWithFfmpeg(audioFile)
}
```

## Test Results

```bash
$ go test -v ./internal/conf -run "TestParseFfmpegVersion|TestGetFfmpegVersion|TestAudioSettings"
=== RUN   TestParseFfmpegVersion
--- PASS: TestParseFfmpegVersion (0.00s)
=== RUN   TestGetFfmpegVersion
--- PASS: TestGetFfmpegVersion (0.00s)
=== RUN   TestAudioSettings_NeedsFfprobeWorkaround
--- PASS: TestAudioSettings_NeedsFfprobeWorkaround (0.00s)
=== RUN   TestAudioSettings_HasFfmpegVersion
--- PASS: TestAudioSettings_HasFfmpegVersion (0.00s)
PASS
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>