### PR TITLE
feat(ui/notifications): new species config

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -88,6 +88,7 @@
     '/integrations': 'Integrations',
     '/security': 'Security Settings',
     '/species': 'Species Settings',
+    '/notifications': 'Notifications Settings',
     '/support': 'Support',
   };
 

--- a/frontend/src/lib/desktop/components/ui/NotificationBell.svelte
+++ b/frontend/src/lib/desktop/components/ui/NotificationBell.svelte
@@ -11,6 +11,7 @@
     isValidNotification,
     isExistingNotification,
     shouldShowNotification,
+    sanitizeNotificationMessage,
   } from '$lib/utils/notifications';
 
   const logger = loggers.ui;
@@ -376,7 +377,7 @@
   function showBrowserNotification(notification: Notification) {
     if ('Notification' in globalThis.window && globalThis.Notification.permission === 'granted') {
       new globalThis.Notification(notification.title, {
-        body: notification.message,
+        body: sanitizeNotificationMessage(notification.message),
         icon: '/assets/images/favicon-32x32.png',
         tag: notification.id,
       });
@@ -586,7 +587,9 @@
                       {notification.timeAgo}
                     </time>
                   </div>
-                  <p class="text-sm text-base-content/80 mt-1">{notification.message}</p>
+                  <p class="text-sm text-base-content/80 mt-1">
+                    {sanitizeNotificationMessage(notification.message)}
+                  </p>
                   <div class="flex items-center gap-2 mt-2">
                     {#if notification.component}
                       <span class="badge badge-sm badge-ghost">{notification.component}</span>

--- a/frontend/src/lib/desktop/features/settings/pages/NotificationsSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/NotificationsSettingsPage.svelte
@@ -69,7 +69,7 @@
   const defaultTemplate = {
     title: 'New Species: {{.CommonName}}',
     message:
-      'First detection of {{.CommonName}} ({{.ScientificName}}) with {{.ConfidencePercent}}% confidence at {{.DetectionTime}}.\n[View Detection]({{.DetectionURL}})',
+      '{{.ImageURL}}\n\nFirst detection of {{.CommonName}} ({{.ScientificName}}) with {{.ConfidencePercent}}% confidence at {{.DetectionTime}}.\n\n{{.DetectionURL}}',
   };
 
   async function loadTemplateConfig() {
@@ -155,10 +155,15 @@
   }
 
   function resetTemplates() {
-    if (templateConfig) {
-      editedTitle = templateConfig.title;
-      editedMessage = templateConfig.message;
+    const confirmReset = window.confirm(
+      'Reset templates to defaults? This will discard your current changes and restore the default template values.'
+    );
+    if (!confirmReset) {
+      return;
     }
+
+    editedTitle = defaultTemplate.title;
+    editedMessage = defaultTemplate.message;
   }
 
   async function sendTestNewSpeciesNotification() {
@@ -280,7 +285,7 @@
                   id="template-message"
                   bind:value={editedMessage}
                   class="textarea textarea-bordered w-full font-mono text-sm"
-                  rows="3"
+                  rows="5"
                   placeholder="e.g., First detection of &#123;&#123;.CommonName&#125;&#125; (&#123;&#123;.ScientificName&#125;&#125;) with &#123;&#123;.ConfidencePercent&#125;&#125;% confidence"
                 ></textarea>
               </div>
@@ -326,7 +331,7 @@
                 <button
                   onclick={resetTemplates}
                   class="btn btn-ghost btn-sm"
-                  disabled={savingTemplate || generating || !hasUnsavedChanges}
+                  disabled={savingTemplate || generating}
                 >
                   Reset
                 </button>

--- a/frontend/src/lib/desktop/features/settings/pages/NotificationsSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/NotificationsSettingsPage.svelte
@@ -80,8 +80,8 @@
         const data = await response.json();
         if (data.templates?.newSpecies) {
           templateConfig = {
-            title: data.templates.newSpecies.title || defaultTemplate.title,
-            message: data.templates.newSpecies.message || defaultTemplate.message,
+            title: data.templates.newSpecies.title ?? defaultTemplate.title,
+            message: data.templates.newSpecies.message ?? defaultTemplate.message,
           };
           editedTitle = templateConfig.title;
           editedMessage = templateConfig.message;

--- a/frontend/src/lib/desktop/features/settings/pages/NotificationsSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/NotificationsSettingsPage.svelte
@@ -1,0 +1,277 @@
+<!--
+  Notifications Settings Page Component
+  
+  Purpose: Configure notification testing and debugging features for BirdNET-Go
+  including test notification generation for new species detections.
+  
+  Features:
+  - Test new species notification generation
+  - Notification system debugging and testing
+  - API endpoint testing functionality
+  
+  Props: None - This is a page component that uses global settings stores
+  
+  Performance Optimizations:
+  - Cached CSRF token to avoid repeated DOM queries
+  - API state management for notification testing
+  - Reactive change detection with $derived
+  - Progress tracking for test notification generation
+  
+  @component
+-->
+<script lang="ts">
+  import SettingsSection from '$lib/desktop/features/settings/components/SettingsSection.svelte';
+  import { alertIconsSvg, systemIcons } from '$lib/utils/icons'; // Centralized icons - see icons.ts
+  import { t } from '$lib/i18n';
+
+  // PERFORMANCE OPTIMIZATION: Cache CSRF token with $derived
+  let csrfToken = $derived(
+    (document.querySelector('meta[name="csrf-token"]') as HTMLElement)?.getAttribute('content') ||
+      ''
+  );
+
+  // Test notification generation state
+  let generating = $state(false);
+  let statusMessage = $state('');
+  let statusType = $state<'info' | 'success' | 'error'>('info');
+
+  // Test new species notification
+  async function sendTestNewSpeciesNotification() {
+    generating = true;
+    statusMessage = '';
+    statusType = 'info';
+
+    updateStatus(t('settings.notifications.testNotification.statusMessages.sending'), 'info');
+
+    try {
+      const headers = new Headers({
+        'Content-Type': 'application/json',
+      });
+
+      if (csrfToken) {
+        headers.set('X-CSRF-Token', csrfToken);
+      }
+
+      const response = await fetch('/api/v2/notifications/test/new-species', {
+        method: 'POST',
+        headers,
+        credentials: 'same-origin',
+      });
+
+      if (!response.ok) {
+        if (response.status === 503) {
+          throw new Error(
+            t('settings.notifications.testNotification.statusMessages.serviceUnavailable')
+          );
+        }
+        throw new Error(`Server error: ${response.status} ${response.statusText}`);
+      }
+
+      const data = await response.json();
+      generating = false;
+
+      updateStatus(
+        t('settings.notifications.testNotification.statusMessages.success', {
+          species: data.title || 'Northern Cardinal',
+        }),
+        'success'
+      );
+
+      // Clear status after 5 seconds
+      setTimeout(() => {
+        statusMessage = '';
+        statusType = 'info';
+      }, 5000);
+    } catch (error) {
+      generating = false;
+      updateStatus(
+        t('settings.notifications.testNotification.statusMessages.error', {
+          message: (error as Error).message,
+        }),
+        'error'
+      );
+
+      // Clear error after 10 seconds
+      setTimeout(() => {
+        statusMessage = '';
+        statusType = 'info';
+      }, 10000);
+    }
+  }
+
+  function updateStatus(message: string, type: 'info' | 'success' | 'error') {
+    statusMessage = message;
+    statusType = type;
+  }
+</script>
+
+<div class="space-y-4 settings-page-content">
+  <!-- Notification Testing Section -->
+  <SettingsSection
+    title={t('settings.notifications.sections.testing.title')}
+    description={t('settings.notifications.sections.testing.description')}
+    defaultOpen={true}
+  >
+    <div class="space-y-4">
+      <!-- Test New Species Notification -->
+      <div class="card bg-base-200">
+        <div class="card-body">
+          <h3 class="card-title text-lg">{t('settings.notifications.testNotification.title')}</h3>
+
+          <!-- Description -->
+          <div class="space-y-3 mb-4">
+            <p class="text-sm text-base-content/80">
+              {t('settings.notifications.testNotification.description')}
+            </p>
+
+            <div class="bg-base-100 rounded-lg p-3 border border-base-300">
+              <h4 class="font-semibold text-sm mb-2">
+                {t('settings.notifications.testNotification.whatHappens.title')}
+              </h4>
+              <ul class="text-xs space-y-1 text-base-content/70">
+                <li class="flex items-center gap-2">
+                  <div class="h-4 w-4 text-success flex-shrink-0">
+                    {@html alertIconsSvg.success}
+                  </div>
+                  <span
+                    >{t(
+                      'settings.notifications.testNotification.whatHappens.createsNotification'
+                    )}</span
+                  >
+                </li>
+                <li class="flex items-center gap-2">
+                  <div class="h-4 w-4 text-success flex-shrink-0">
+                    {@html alertIconsSvg.success}
+                  </div>
+                  <span
+                    >{t(
+                      'settings.notifications.testNotification.whatHappens.appearsInStream'
+                    )}</span
+                  >
+                </li>
+                <li class="flex items-center gap-2">
+                  <div class="h-4 w-4 text-success flex-shrink-0">
+                    {@html alertIconsSvg.success}
+                  </div>
+                  <span
+                    >{t(
+                      'settings.notifications.testNotification.whatHappens.matchesRealDetection'
+                    )}</span
+                  >
+                </li>
+                <li class="flex items-center gap-2">
+                  <div class="h-4 w-4 text-info flex-shrink-0">
+                    {@html systemIcons.infoCircle}
+                  </div>
+                  <span
+                    >{t('settings.notifications.testNotification.whatHappens.expires24Hours')}</span
+                  >
+                </li>
+              </ul>
+            </div>
+          </div>
+
+          <!-- Status Message -->
+          {#if statusMessage}
+            <div class="mt-3 max-w-2xl">
+              <div
+                class="alert py-2 px-3 text-sm"
+                class:alert-info={statusType === 'info'}
+                class:alert-success={statusType === 'success'}
+                class:alert-error={statusType === 'error'}
+              >
+                <div class="h-4 w-4 flex-shrink-0">
+                  {#if statusType === 'info'}
+                    {@html alertIconsSvg.info}
+                  {:else if statusType === 'success'}
+                    {@html alertIconsSvg.success}
+                  {:else if statusType === 'error'}
+                    {@html alertIconsSvg.error}
+                  {/if}
+                </div>
+                <span class="min-w-0 text-sm">{statusMessage}</span>
+              </div>
+            </div>
+          {/if}
+
+          <!-- Send Test Notification Button -->
+          <div class="card-actions justify-end mt-6">
+            <button
+              onclick={sendTestNewSpeciesNotification}
+              disabled={generating}
+              class="btn btn-primary"
+              class:btn-disabled={generating}
+            >
+              {#if !generating}
+                <span class="flex items-center gap-2">
+                  {@html systemIcons.bell}
+                  <span>{t('settings.notifications.testNotification.sendButton')}</span>
+                </span>
+              {:else}
+                <span class="loading loading-spinner loading-sm"></span>
+                <span>{t('settings.notifications.testNotification.sendingButton')}</span>
+              {/if}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </SettingsSection>
+
+  <!-- Notification System Info Section -->
+  <SettingsSection
+    title={t('settings.notifications.sections.info.title')}
+    description={t('settings.notifications.sections.info.description')}
+    defaultOpen={false}
+  >
+    <div class="space-y-4">
+      <div class="alert alert-info text-sm">
+        <div class="h-5 w-5 flex-shrink-0">{@html alertIconsSvg.info}</div>
+        <div class="min-w-0">
+          <div class="font-semibold mb-1">
+            {t('settings.notifications.systemInfo.howToView.title')}
+          </div>
+          <div class="space-y-1 text-xs">
+            <p>{t('settings.notifications.systemInfo.howToView.step1')}</p>
+            <p>{t('settings.notifications.systemInfo.howToView.step2')}</p>
+            <p>{t('settings.notifications.systemInfo.howToView.step3')}</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="bg-base-200 rounded-lg p-4">
+        <h4 class="font-semibold text-sm mb-3">
+          {t('settings.notifications.systemInfo.technicalDetails.title')}
+        </h4>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 text-xs">
+          <div>
+            <div class="font-medium text-base-content/80 mb-1">
+              {t('settings.notifications.systemInfo.technicalDetails.endpoint')}
+            </div>
+            <code class="text-primary bg-base-100 px-2 py-1 rounded"
+              >POST /api/v2/notifications/test/new-species</code
+            >
+          </div>
+          <div>
+            <div class="font-medium text-base-content/80 mb-1">
+              {t('settings.notifications.systemInfo.technicalDetails.type')}
+            </div>
+            <span class="bg-base-100 px-2 py-1 rounded">TypeDetection</span>
+          </div>
+          <div>
+            <div class="font-medium text-base-content/80 mb-1">
+              {t('settings.notifications.systemInfo.technicalDetails.priority')}
+            </div>
+            <span class="bg-base-100 px-2 py-1 rounded">PriorityHigh</span>
+          </div>
+          <div>
+            <div class="font-medium text-base-content/80 mb-1">
+              {t('settings.notifications.systemInfo.technicalDetails.expiry')}
+            </div>
+            <span class="bg-base-100 px-2 py-1 rounded">24 hours</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </SettingsSection>
+</div>

--- a/frontend/src/lib/desktop/features/settings/pages/NotificationsSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/NotificationsSettingsPage.svelte
@@ -285,7 +285,7 @@
                   id="template-message"
                   bind:value={editedMessage}
                   class="textarea textarea-bordered w-full font-mono text-sm"
-                  rows="5"
+                  rows="6"
                   placeholder="e.g., First detection of &#123;&#123;.CommonName&#125;&#125; (&#123;&#123;.ScientificName&#125;&#125;) with &#123;&#123;.ConfidencePercent&#125;&#125;% confidence"
                 ></textarea>
               </div>

--- a/frontend/src/lib/desktop/features/settings/pages/NotificationsSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/NotificationsSettingsPage.svelte
@@ -1,22 +1,22 @@
 <!--
   Notifications Settings Page Component
-  
+
   Purpose: Configure notification testing and debugging features for BirdNET-Go
   including test notification generation for new species detections.
-  
+
   Features:
   - Test new species notification generation
   - Notification system debugging and testing
   - API endpoint testing functionality
-  
+
   Props: None - This is a page component that uses global settings stores
-  
+
   Performance Optimizations:
   - Cached CSRF token to avoid repeated DOM queries
   - API state management for notification testing
   - Reactive change detection with $derived
   - Progress tracking for test notification generation
-  
+
   @component
 -->
 <script lang="ts">

--- a/frontend/src/lib/desktop/layouts/DesktopSidebar.svelte
+++ b/frontend/src/lib/desktop/layouts/DesktopSidebar.svelte
@@ -87,6 +87,7 @@ Performance Optimizations:
       settingsIntegrations: currentRoute === '/ui/settings/integrations',
       settingsSecurity: currentRoute === '/ui/settings/security',
       settingsSpecies: currentRoute === '/ui/settings/species',
+      settingsNotifications: currentRoute === '/ui/settings/notifications',
       settingsSupport: currentRoute === '/ui/settings/support',
       settingsUserInterface: currentRoute === '/ui/settings/userinterface',
     };
@@ -116,6 +117,7 @@ Performance Optimizations:
     settingsIntegrations: onNavigate ? '/settings/integrations' : '/ui/settings/integrations',
     settingsSecurity: onNavigate ? '/settings/security' : '/ui/settings/security',
     settingsSpecies: onNavigate ? '/settings/species' : '/ui/settings/species',
+    settingsNotifications: onNavigate ? '/settings/notifications' : '/ui/settings/notifications',
     settingsSupport: onNavigate ? '/settings/support' : '/ui/settings/support',
     settingsUserInterface: onNavigate ? '/settings/userinterface' : '/ui/settings/userinterface',
   });
@@ -328,6 +330,15 @@ Performance Optimizations:
                     role="menuitem"
                   >
                     {t('settings.sections.species')}
+                  </button>
+                </li>
+                <li role="none">
+                  <button
+                    onclick={() => navigate(navigationUrls.settingsNotifications)}
+                    class={cn({ active: routeCache().settingsNotifications })}
+                    role="menuitem"
+                  >
+                    {t('settings.sections.notifications')}
                   </button>
                 </li>
                 <li role="none">

--- a/frontend/src/lib/desktop/views/Notifications.svelte
+++ b/frontend/src/lib/desktop/views/Notifications.svelte
@@ -3,7 +3,7 @@
   import { actionIcons, alertIconsSvg, systemIcons } from '$lib/utils/icons';
   import { t } from '$lib/i18n';
   import { safeGet, safeArrayAccess } from '$lib/utils/security';
-  import { deduplicateNotifications } from '$lib/utils/notifications';
+  import { deduplicateNotifications, sanitizeNotificationMessage } from '$lib/utils/notifications';
 
   // SPINNER CONTROL: Set to false to disable loading spinners (reduces flickering)
   // Change back to true to re-enable spinners for testing
@@ -236,19 +236,6 @@
     return date.toLocaleDateString();
   }
 
-  // Sanitize notification message for UI display by removing URLs
-  function sanitizeMessage(message) {
-    if (!message) return '';
-    return message
-      .split('\n')
-      .filter(line => {
-        const trimmed = line.trim();
-        return !trimmed.startsWith('http://') && !trimmed.startsWith('https://');
-      })
-      .join('\n')
-      .trim();
-  }
-
   onMount(() => {
     loadNotifications();
   });
@@ -370,7 +357,9 @@
                 <div class="flex items-start justify-between gap-4">
                   <div>
                     <h3 class="font-semibold text-lg">{notification.title}</h3>
-                    <p class="text-base-content/80 mt-1">{sanitizeMessage(notification.message)}</p>
+                    <p class="text-base-content/80 mt-1">
+                      {sanitizeNotificationMessage(notification.message)}
+                    </p>
 
                     <!-- Metadata -->
                     <div class="flex flex-wrap items-center gap-2 mt-3">

--- a/frontend/src/lib/desktop/views/Notifications.svelte
+++ b/frontend/src/lib/desktop/views/Notifications.svelte
@@ -236,6 +236,19 @@
     return date.toLocaleDateString();
   }
 
+  // Sanitize notification message for UI display by removing URLs
+  function sanitizeMessage(message) {
+    if (!message) return '';
+    return message
+      .split('\n')
+      .filter(line => {
+        const trimmed = line.trim();
+        return !trimmed.startsWith('http://') && !trimmed.startsWith('https://');
+      })
+      .join('\n')
+      .trim();
+  }
+
   onMount(() => {
     loadNotifications();
   });
@@ -357,7 +370,7 @@
                 <div class="flex items-start justify-between gap-4">
                   <div>
                     <h3 class="font-semibold text-lg">{notification.title}</h3>
-                    <p class="text-base-content/80 mt-1">{notification.message}</p>
+                    <p class="text-base-content/80 mt-1">{sanitizeMessage(notification.message)}</p>
 
                     <!-- Metadata -->
                     <div class="flex flex-wrap items-center gap-2 mt-3">

--- a/frontend/src/lib/desktop/views/Settings.svelte
+++ b/frontend/src/lib/desktop/views/Settings.svelte
@@ -14,6 +14,7 @@
   import SecuritySettingsSection from '$lib/desktop/features/settings/pages/SecuritySettingsPage.svelte';
   import SupportSettingsSection from '$lib/desktop/features/settings/pages/SupportSettingsPage.svelte';
   import SpeciesSettingsSection from '$lib/desktop/features/settings/pages/SpeciesSettingsPage.svelte';
+  import NotificationsSettingsSection from '$lib/desktop/features/settings/pages/NotificationsSettingsPage.svelte';
   import SettingsActions from '$lib/desktop/features/settings/components/SettingsActions.svelte';
   import ErrorAlert from '$lib/desktop/components/ui/ErrorAlert.svelte';
   import LoadingSpinner from '$lib/desktop/components/ui/LoadingSpinner.svelte';
@@ -35,6 +36,7 @@
       integrations: 'integration',
       security: 'security',
       species: 'species',
+      notifications: 'notifications',
       support: 'support',
     };
 
@@ -117,6 +119,8 @@
         <SecuritySettingsSection />
       {:else if currentSection === 'species'}
         <SpeciesSettingsSection />
+      {:else if currentSection === 'notifications'}
+        <NotificationsSettingsSection />
       {:else if currentSection === 'support'}
         <SupportSettingsSection />
       {:else}

--- a/frontend/src/lib/stores/sseNotifications.ts
+++ b/frontend/src/lib/stores/sseNotifications.ts
@@ -2,6 +2,7 @@ import ReconnectingEventSource from 'reconnecting-eventsource';
 import { toastActions } from './toast';
 import type { ToastType, ToastPosition } from './toast';
 import { loggers } from '$lib/utils/logger';
+import { sanitizeNotificationMessage } from '$lib/utils/notifications';
 
 const logger = loggers.sse;
 
@@ -125,7 +126,7 @@ class SSENotificationManager {
     // Show toast with appropriate duration
     const duration = notification.type === 'error' ? null : 5000; // Errors don't auto-dismiss
 
-    toastActions.show(notification.message, toastType, {
+    toastActions.show(sanitizeNotificationMessage(notification.message), toastType, {
       duration,
       showIcon: true,
     });
@@ -152,7 +153,7 @@ class SSENotificationManager {
         ]
       : undefined;
 
-    toastActions.show(toastData.message, toastData.type, {
+    toastActions.show(sanitizeNotificationMessage(toastData.message), toastData.type, {
       duration: toastData.duration ?? 5000,
       position: 'top-right' as ToastPosition,
       actions,

--- a/frontend/src/lib/utils/notifications.ts
+++ b/frontend/src/lib/utils/notifications.ts
@@ -207,3 +207,22 @@ export function deduplicateNotifications(
 
   return deduped;
 }
+
+/**
+ * Sanitize notification message for UI display by removing URLs
+ * This removes image URLs and detection links that are meant for push notifications
+ * but should not be displayed in the UI's bell icon or toast notifications
+ * @param message - The message to sanitize
+ * @returns The sanitized message with URLs removed
+ */
+export function sanitizeNotificationMessage(message: string): string {
+  if (!message) return '';
+  return message
+    .split('\n')
+    .filter(line => {
+      const trimmed = line.trim();
+      return !trimmed.startsWith('http://') && !trimmed.startsWith('https://');
+    })
+    .join('\n')
+    .trim();
+}

--- a/frontend/static/messages/en.json
+++ b/frontend/static/messages/en.json
@@ -684,6 +684,7 @@
       "integration": "Integrations",
       "security": "Security",
       "species": "Species",
+      "notifications": "Notifications",
       "support": "Support"
     },
     "notFound": {
@@ -1015,6 +1016,35 @@
           "error": "Error: {message}",
           "githubIssueRequired": "Please enter a GitHub issue number to upload support data"
         }
+      }
+    },
+    "notifications": {
+      "sections": {
+        "testing": {
+          "title": "Test Notifications",
+          "description": "Send test notifications to verify your notification system is working correctly"
+        },
+        "info": {
+          "title": "System Information",
+          "description": "Learn how to view and manage your notifications"
+        }
+      },
+      "testNotification": {
+        "title": "Send Test New Species Notification",
+        "description": "Generate a test notification for a new species detection to verify your notification system is working",
+        "whatHappens": "What happens when you click 'Send Test':",
+        "sendButton": "Send Test",
+        "sendingButton": "Sending..."
+      },
+      "statusMessages": {
+        "sending": "Sending test notification...",
+        "success": "Test notification sent successfully!",
+        "error": "Failed to send test notification: {message}",
+        "serviceUnavailable": "Notification service is not available. Please check your notification settings."
+      },
+      "systemInfo": {
+        "howToView": "How to view notifications:",
+        "technicalDetails": "Technical details about notifications in BirdNET-Go:"
       }
     },
     "filters": {

--- a/internal/analysis/processor/actions.go
+++ b/internal/analysis/processor/actions.go
@@ -704,6 +704,14 @@ func (a *DatabaseAction) publishNewSpeciesDetectionEvent(isNewSpecies bool, days
 	metadata["longitude"] = a.Note.Longitude
 	metadata["begin_time"] = a.Note.BeginTime
 
+	// Get bird image URL from cache and add to metadata
+	if a.processor != nil && a.processor.BirdImageCache != nil {
+		birdImage, err := a.processor.BirdImageCache.Get(a.Note.ScientificName)
+		if err == nil && birdImage.URL != "" {
+			metadata["image_url"] = birdImage.URL
+		}
+	}
+
 	// Publish the detection event
 	if published := eventBus.TryPublishDetection(detectionEvent); published {
 		// Only record notification as sent if publishing succeeded

--- a/internal/analysis/processor/actions.go
+++ b/internal/analysis/processor/actions.go
@@ -697,6 +697,13 @@ func (a *DatabaseAction) publishNewSpeciesDetectionEvent(isNewSpecies bool, days
 		return
 	}
 
+	// Add location, time, and note ID to metadata for template rendering
+	metadata := detectionEvent.GetMetadata()
+	metadata["note_id"] = a.Note.ID
+	metadata["latitude"] = a.Note.Latitude
+	metadata["longitude"] = a.Note.Longitude
+	metadata["begin_time"] = a.Note.BeginTime
+
 	// Publish the detection event
 	if published := eventBus.TryPublishDetection(detectionEvent); published {
 		// Only record notification as sent if publishing succeeded

--- a/internal/api/v2/notifications.go
+++ b/internal/api/v2/notifications.go
@@ -674,7 +674,7 @@ func (c *Controller) CreateTestNewSpeciesNotification(ctx echo.Context) error {
 		Longitude:          -71.0589,
 		Location:           "Fake Test Location",
 		DetectionURL:       baseURL + "/ui/detections/test",
-		ImageURL:           baseURL + "/api/v2/media/species-image?scientific_name=Testus%20birdicus",
+		ImageURL:           "https://static.avicommons.org/houfin-DzFZcHoKwyx9JOmg-320.jpg",
 		DaysSinceFirstSeen: 0,
 	}
 
@@ -684,6 +684,8 @@ func (c *Controller) CreateTestNewSpeciesNotification(ctx echo.Context) error {
 
 	// Render notification using templates (same pattern as detection_consumer.go)
 	var title, message string
+	var titleSet, messageSet bool
+
 	if titleTemplate != "" {
 		var err error
 		title, err = notification.RenderTemplate("title", titleTemplate, testTemplateData)
@@ -691,8 +693,12 @@ func (c *Controller) CreateTestNewSpeciesNotification(ctx echo.Context) error {
 			if c.apiLogger != nil {
 				c.apiLogger.Error("failed to render title template, using default", "error", err)
 			}
-			title = ""
+		} else {
+			titleSet = true
 		}
+	} else {
+		// Empty template means user wants no title
+		titleSet = true
 	}
 
 	if messageTemplate != "" {
@@ -702,15 +708,19 @@ func (c *Controller) CreateTestNewSpeciesNotification(ctx echo.Context) error {
 			if c.apiLogger != nil {
 				c.apiLogger.Error("failed to render message template, using default", "error", err)
 			}
-			message = ""
+		} else {
+			messageSet = true
 		}
+	} else {
+		// Empty template means user wants no message
+		messageSet = true
 	}
 
-	// Use defaults if template is empty or rendering failed
-	if title == "" {
+	// Use defaults only if template rendering failed
+	if !titleSet {
 		title = "New Species Detected: Test Bird Species"
 	}
-	if message == "" {
+	if !messageSet {
 		message = "First detection of Test Bird Species (Testus birdicus) at Fake Test Location"
 	}
 

--- a/internal/api/v2/notifications_new_species_test.go
+++ b/internal/api/v2/notifications_new_species_test.go
@@ -1,0 +1,120 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/notification"
+)
+
+// resetServiceForTesting safely resets the notification service instance for testing
+func resetServiceForTesting() {
+	// Access the internal state using reflection pattern from manager.go
+	// This is safe for testing as we control the test environment
+	mu := &sync.RWMutex{}
+	mu.Lock()
+	defer mu.Unlock()
+
+	// Reset the global instance by setting to nil
+	// Note: In real implementation we'd need to access the unexported vars
+	// For now, we'll test around the existing service if present
+}
+
+// parseJSONResponse unmarshals JSON response body into target struct
+func parseJSONResponse(body []byte, target interface{}) error {
+	return json.Unmarshal(body, target)
+}
+
+func TestCreateTestNewSpeciesNotification_ServiceNotInitialized(t *testing.T) {
+	// Test when no service exists
+	// Since we can't easily reset the global service, we'll test the error path
+	// by ensuring IsInitialized returns false condition
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/v2/notifications/test/new-species", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	controller := &Controller{}
+
+	// If a service exists from other tests, this will pass
+	// If no service exists, this will return 503
+	err := controller.CreateTestNewSpeciesNotification(c)
+	require.NoError(t, err)
+
+	// Check for either success (if service exists) or service unavailable
+	if rec.Code == http.StatusServiceUnavailable {
+		assert.Contains(t, rec.Body.String(), "Notification service not available")
+	} else {
+		// Service exists, should be 200
+		assert.Equal(t, http.StatusOK, rec.Code)
+	}
+}
+
+func TestCreateTestNewSpeciesNotification_Success(t *testing.T) {
+	// Initialize notification service for testing using correct API
+	config := &notification.ServiceConfig{
+		Debug:              true,
+		MaxNotifications:   100,
+		CleanupInterval:    30 * time.Minute,
+		RateLimitWindow:    1 * time.Minute,
+		RateLimitMaxEvents: 10,
+	}
+
+	// Try to set up isolated service for testing
+	service := notification.NewService(config)
+	err := notification.SetServiceForTesting(service)
+	if err != nil {
+		// Service already exists, use it
+		service = notification.GetService()
+		require.NotNil(t, service, "Expected notification service to be available")
+	}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/v2/notifications/test/new-species", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	controller := &Controller{}
+
+	err = controller.CreateTestNewSpeciesNotification(c)
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// Parse response to verify notification structure
+	var response notification.Notification
+	err = parseJSONResponse(rec.Body.Bytes(), &response)
+	require.NoError(t, err)
+
+	// Verify notification fields match detection_consumer.go patterns
+	assert.Equal(t, notification.TypeDetection, response.Type)
+	assert.Equal(t, notification.PriorityHigh, response.Priority)
+	assert.Equal(t, "detection", response.Component)
+	assert.Equal(t, notification.StatusUnread, response.Status)
+	assert.Equal(t, "New Species Detected: Test Bird Species", response.Title)
+	assert.Equal(t, "First detection of Test Bird Species (Testus birdicus) at Fake Test Location", response.Message)
+	assert.NotEmpty(t, response.ID)
+	assert.False(t, response.Timestamp.IsZero())
+
+	// Verify metadata fields match detection_consumer.go
+	require.NotNil(t, response.Metadata)
+	assert.Equal(t, "Test Bird Species", response.Metadata["species"])
+	assert.Equal(t, "Testus birdicus", response.Metadata["scientific_name"])
+	assert.Equal(t, 0.99, response.Metadata["confidence"])
+	assert.Equal(t, "Fake Test Location", response.Metadata["location"])
+	assert.Equal(t, true, response.Metadata["is_new_species"])
+	assert.Equal(t, 0, response.Metadata["days_since_first_seen"])
+
+	// Verify 24-hour expiry
+	require.NotNil(t, response.ExpiresAt)
+	expectedExpiry := response.Timestamp.Add(24 * time.Hour)
+	assert.WithinDuration(t, expectedExpiry, *response.ExpiresAt, time.Second)
+}

--- a/internal/api/v2/settings.go
+++ b/internal/api/v2/settings.go
@@ -710,6 +710,8 @@ func getSettingsSectionValue(settings *conf.Settings, section string) (any, erro
 		return &settings.Realtime.Telemetry, nil
 	case "sentry":
 		return &settings.Sentry, nil
+	case "notification":
+		return &settings.Notification, nil
 	default:
 		return nil, fmt.Errorf("unknown settings section: %s", section)
 	}
@@ -1093,13 +1095,13 @@ func validateSpeciesSection(data json.RawMessage) error {
 		if config.Interval < 0 {
 			return fmt.Errorf("species config for '%s': interval must be non-negative, got %d", speciesName, config.Interval)
 		}
-		
+
 		// Check if threshold is within valid range
 		if config.Threshold < 0 || config.Threshold > 1 {
 			return fmt.Errorf("species config for '%s': threshold must be between 0 and 1, got %f", speciesName, config.Threshold)
 		}
 	}
-	
+
 	return nil
 }
 
@@ -1116,13 +1118,13 @@ func validateRealtimeSection(data json.RawMessage) error {
 		if config.Interval < 0 {
 			return fmt.Errorf("species config for '%s': interval must be non-negative, got %d", speciesName, config.Interval)
 		}
-		
+
 		// Check if threshold is within valid range
 		if config.Threshold < 0 || config.Threshold > 1 {
 			return fmt.Errorf("species config for '%s': threshold must be between 0 and 1, got %f", speciesName, config.Threshold)
 		}
 	}
-	
+
 	return nil
 }
 

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -180,19 +180,19 @@ type WeatherSettings struct {
 
 // NotificationConfig is the root for notification-specific settings.
 type NotificationConfig struct {
-	Push      PushSettings          `json:"push"`
-	Templates NotificationTemplates `json:"templates"`
+	Push      PushSettings          `json:"push" yaml:"push"`
+	Templates NotificationTemplates `json:"templates" yaml:"templates"`
 }
 
 // NotificationTemplates contains customizable notification message templates.
 type NotificationTemplates struct {
-	NewSpecies NewSpeciesTemplate `json:"newSpecies"`
+	NewSpecies NewSpeciesTemplate `json:"newSpecies" yaml:"newspecies"`
 }
 
 // NewSpeciesTemplate contains templates for new species detection notifications.
 type NewSpeciesTemplate struct {
-	Title   string `json:"title"`
-	Message string `json:"message"`
+	Title   string `json:"title" yaml:"title"`
+	Message string `json:"message" yaml:"message"`
 }
 
 // PushSettings controls global push delivery and provider list.

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -180,7 +180,19 @@ type WeatherSettings struct {
 
 // NotificationConfig is the root for notification-specific settings.
 type NotificationConfig struct {
-	Push PushSettings `json:"push"`
+	Push      PushSettings          `json:"push"`
+	Templates NotificationTemplates `json:"templates"`
+}
+
+// NotificationTemplates contains customizable notification message templates.
+type NotificationTemplates struct {
+	NewSpecies NewSpeciesTemplate `json:"newSpecies"`
+}
+
+// NewSpeciesTemplate contains templates for new species detection notifications.
+type NewSpeciesTemplate struct {
+	Title   string `json:"title"`
+	Message string `json:"message"`
 }
 
 // PushSettings controls global push delivery and provider list.

--- a/internal/conf/config.yaml
+++ b/internal/conf/config.yaml
@@ -249,6 +249,10 @@ sentry:
 
 # Notification settings
 notification:
+  templates:
+    newspecies:
+      title: "New Species: {{.CommonName}}"
+      message: "First detection of {{.CommonName}} ({{.ScientificName}}) with {{.ConfidencePercent}}% confidence at {{.DetectionTime}}. View: {{.DetectionURL}}"
   push:
     enabled: false
     default_timeout: 30s

--- a/internal/conf/defaults.go
+++ b/internal/conf/defaults.go
@@ -341,5 +341,5 @@ func setDefaultConfig() {
 
 	// Notification templates
 	viper.SetDefault("notification.templates.newspecies.title", "New Species: {{.CommonName}}")
-	viper.SetDefault("notification.templates.newspecies.message", "First detection of {{.CommonName}} ({{.ScientificName}}) with {{.ConfidencePercent}}% confidence at {{.DetectionTime}}. View: {{.DetectionURL}}")
+	viper.SetDefault("notification.templates.newspecies.message", "{{.ImageURL}}\n\nFirst detection of {{.CommonName}} ({{.ScientificName}}) with {{.ConfidencePercent}}% confidence at {{.DetectionTime}}. \n{{.DetectionURL}}")
 }

--- a/internal/conf/defaults.go
+++ b/internal/conf/defaults.go
@@ -338,4 +338,8 @@ func setDefaultConfig() {
 	viper.SetDefault("notification.push.rate_limiting.burst_size", 10)
 
 	viper.SetDefault("notification.push.providers", []map[string]any{})
+
+	// Notification templates
+	viper.SetDefault("notification.templates.newspecies.title", "New Species: {{.CommonName}}")
+	viper.SetDefault("notification.templates.newspecies.message", "First detection of {{.CommonName}} ({{.ScientificName}}) with {{.ConfidencePercent}}% confidence at {{.DetectionTime}}. View: {{.DetectionURL}}")
 }

--- a/internal/httpcontroller/htmx_routes.go
+++ b/internal/httpcontroller/htmx_routes.go
@@ -92,6 +92,7 @@ func (s *Server) initRoutes() {
 		"/ui/settings/audio":            {Path: "/ui/settings/audio", TemplateName: "svelte-standalone", Title: "Audio Settings", Authorized: true},
 		"/ui/settings/detectionfilters": {Path: "/ui/settings/detectionfilters", TemplateName: "svelte-standalone", Title: "Detection Filters", Authorized: true},
 		"/ui/settings/integrations":     {Path: "/ui/settings/integrations", TemplateName: "svelte-standalone", Title: "Integration Settings", Authorized: true},
+		"/ui/settings/notifications":    {Path: "/ui/settings/notifications", TemplateName: "svelte-standalone", Title: "Notifications Settings", Authorized: true},
 		"/ui/settings/security":         {Path: "/ui/settings/security", TemplateName: "svelte-standalone", Title: "Security Settings", Authorized: true},
 		"/ui/settings/species":          {Path: "/ui/settings/species", TemplateName: "svelte-standalone", Title: "Species Settings", Authorized: true},
 		"/ui/settings/support":          {Path: "/ui/settings/support", TemplateName: "svelte-standalone", Title: "Support", Authorized: true},

--- a/internal/notification/README.md
+++ b/internal/notification/README.md
@@ -291,3 +291,65 @@ unreadCount, _ := service.GetUnreadCount()
 3. **Monitor dropped events**: May indicate rate limiting
 4. **Use error context**: It becomes notification metadata
 5. **Handle initialization order**: Event bus must be initialized first
+
+## Customizable Notification Templates
+
+New species detection notifications support customizable templates configured in `config.yaml`.
+
+### Configuration
+
+```yaml
+notification:
+  templates:
+    newspecies:
+      title: "New Species: {{.CommonName}}"
+      message: "First detection of {{.CommonName}} ({{.ScientificName}}) with {{.ConfidencePercent}}% confidence at {{.DetectionTime}}. View: {{.DetectionURL}}"
+```
+
+### Available Template Variables
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `{{.CommonName}}` | Bird common name | "American Robin" |
+| `{{.ScientificName}}` | Scientific name | "Turdus migratorius" |
+| `{{.Confidence}}` | Confidence as float (0-1) | 0.92 |
+| `{{.ConfidencePercent}}` | Confidence as percentage | "92" |
+| `{{.DetectionTime}}` | Time of detection | "15:04:05" or "3:04:05 PM" |
+| `{{.DetectionDate}}` | Date of detection | "2025-10-05" |
+| `{{.Latitude}}` | GPS latitude | 45.123456 |
+| `{{.Longitude}}` | GPS longitude | -122.987654 |
+| `{{.Location}}` | Formatted coordinates | "45.123456, -122.987654" |
+| `{{.DetectionURL}}` | Link to detection details | "http://host:port/ui/detections/123" |
+| `{{.ImageURL}}` | Link to species image | "http://host:port/api/v2/media/species-image?..." |
+| `{{.DaysSinceFirstSeen}}` | Days since first detection | 0 for new species |
+
+### Template Examples
+
+```yaml
+# Simple notification
+notification:
+  templates:
+    newspecies:
+      title: "New: {{.CommonName}}"
+      message: "Detected {{.CommonName}} at {{.DetectionTime}}"
+
+# Detailed notification with GPS
+notification:
+  templates:
+    newspecies:
+      title: "🐦 New Species Alert"
+      message: "{{.CommonName}} ({{.ScientificName}}) detected with {{.ConfidencePercent}}% confidence at {{.Location}}. Time: {{.DetectionTime}}"
+
+# Notification with link
+notification:
+  templates:
+    newspecies:
+      title: "New Species: {{.CommonName}}"
+      message: "First detection! View details: {{.DetectionURL}}"
+```
+
+### Error Handling
+
+- If templates fail to render, notifications fall back to default messages
+- Invalid template syntax is logged but doesn't prevent notifications
+- Template variables are populated from detection event data (no database queries)

--- a/internal/notification/detection_consumer.go
+++ b/internal/notification/detection_consumer.go
@@ -45,6 +45,7 @@ func (c *DetectionNotificationConsumer) ProcessDetectionEvent(event events.Detec
 	}
 
 	var title, message string
+	var titleSet, messageSet bool
 
 	settings := conf.GetSettings()
 	if settings != nil {
@@ -64,8 +65,12 @@ func (c *DetectionNotificationConsumer) ProcessDetectionEvent(event events.Detec
 					"error", err,
 					"template", titleTemplate,
 				)
-				title = ""
+			} else {
+				titleSet = true
 			}
+		} else {
+			// Empty template means user wants no title
+			titleSet = true
 		}
 
 		// Render message template
@@ -78,16 +83,20 @@ func (c *DetectionNotificationConsumer) ProcessDetectionEvent(event events.Detec
 					"error", err,
 					"template", messageTemplate,
 				)
-				message = ""
+			} else {
+				messageSet = true
 			}
+		} else {
+			// Empty template means user wants no message (unlikely but allowed)
+			messageSet = true
 		}
 	}
 
-	// Use defaults if settings not available or template rendering failed
-	if title == "" {
+	// Use defaults only if settings not available or template rendering failed
+	if !titleSet {
 		title = fmt.Sprintf("New Species Detected: %s", event.GetSpeciesName())
 	}
-	if message == "" {
+	if !messageSet {
 		message = fmt.Sprintf(
 			"First detection of %s (%s) at %s",
 			event.GetSpeciesName(),

--- a/internal/notification/template_data.go
+++ b/internal/notification/template_data.go
@@ -1,0 +1,114 @@
+package notification
+
+import (
+	"fmt"
+	"net/url"
+	"time"
+
+	"github.com/tphakala/birdnet-go/internal/events"
+)
+
+type TemplateData struct {
+	CommonName         string
+	ScientificName     string
+	Confidence         float64
+	ConfidencePercent  string
+	DetectionTime      string
+	DetectionDate      string
+	Latitude           float64
+	Longitude          float64
+	Location           string
+	DetectionURL       string
+	ImageURL           string
+	DaysSinceFirstSeen int
+}
+
+func NewTemplateData(event events.DetectionEvent, baseURL string, timeAs24h bool) *TemplateData {
+	metadata := event.GetMetadata()
+
+	// Get begin_time from metadata
+	var beginTime time.Time
+	if bt, ok := metadata["begin_time"].(time.Time); ok {
+		beginTime = bt
+	} else {
+		// Fallback to event timestamp if begin_time not in metadata
+		beginTime = event.GetTimestamp()
+	}
+
+	detectionTime := beginTime.Format("15:04:05")
+	detectionDate := beginTime.Format("2006-01-02")
+	if !timeAs24h {
+		detectionTime = beginTime.Format("3:04:05 PM")
+	}
+
+	confidence := event.GetConfidence()
+	confidencePercent := fmt.Sprintf("%.0f", confidence*100)
+
+	// Get lat/lon from metadata
+	var latitude, longitude float64
+	if lat, ok := metadata["latitude"].(float64); ok {
+		latitude = lat
+	}
+	if lon, ok := metadata["longitude"].(float64); ok {
+		longitude = lon
+	}
+	location := fmt.Sprintf("%.6f, %.6f", latitude, longitude)
+
+	// Get note ID from metadata for detection URL
+	var noteID string
+	if id, ok := metadata["note_id"].(uint); ok {
+		noteID = fmt.Sprintf("%d", id)
+	}
+
+	var detectionURL string
+	if noteID != "" {
+		detectionURL = fmt.Sprintf("%s/ui/detections/%s", baseURL, noteID)
+	} else {
+		detectionURL = fmt.Sprintf("%s/ui/detections", baseURL)
+	}
+
+	scientificName := event.GetScientificName()
+
+	// Get image URL from metadata if available (direct URL from image provider)
+	// Fall back to proxy URL if not available
+	var imageURL string
+	if imgURL, ok := metadata["image_url"].(string); ok && imgURL != "" {
+		imageURL = imgURL
+	} else {
+		// Fallback to proxy URL if direct URL not available
+		encodedScientificName := url.QueryEscape(scientificName)
+		imageURL = fmt.Sprintf("%s/api/v2/media/species-image?scientific_name=%s", baseURL, encodedScientificName)
+	}
+
+	return &TemplateData{
+		CommonName:         event.GetSpeciesName(),
+		ScientificName:     scientificName,
+		Confidence:         confidence,
+		ConfidencePercent:  confidencePercent,
+		DetectionTime:      detectionTime,
+		DetectionDate:      detectionDate,
+		Latitude:           latitude,
+		Longitude:          longitude,
+		Location:           location,
+		DetectionURL:       detectionURL,
+		ImageURL:           imageURL,
+		DaysSinceFirstSeen: event.GetDaysSinceFirstSeen(),
+	}
+}
+
+func BuildBaseURL(host string, port string, autoTLS bool) string {
+	scheme := "http"
+	if autoTLS {
+		scheme = "https"
+	}
+
+	if host == "" {
+		host = "localhost"
+	}
+
+	if (scheme == "https" && port == "443") || (scheme == "http" && port == "80") {
+		return fmt.Sprintf("%s://%s", scheme, host)
+	}
+
+	return fmt.Sprintf("%s://%s:%s", scheme, host, port)
+}


### PR DESCRIPTION
Add support for customizing the content of the new species notification, with UI.

A few notes:
- urls are stripped from in-app notifications (bell icon, toast, notification list).
- you need to set your server address in settings -> security for the detection link to work (otherwise it'll just be localhost)

<img width="1315" height="968" alt="Screenshot 2025-10-07 at 11 23 29" src="https://github.com/user-attachments/assets/3c5bf584-f292-49cf-842c-f0315a7f1fac" />

<img width="350" height="404" alt="Screenshot 2025-10-07 at 11 38 24" src="https://github.com/user-attachments/assets/b1e66e77-5bbb-463b-9961-72cedb7da497" />
