### PR TITLE
fix(media): Prevent nil pointer panic in spectrogram logger

### DIFF
--- a/internal/api/v2/media.go
+++ b/internal/api/v2/media.go
@@ -794,7 +794,12 @@ func getSpectrogramLogger() *slog.Logger {
 		return spectrogramLogger
 	}
 	// Emergency fallback if logger is somehow nil
-	return slog.Default()
+	defaultLogger := slog.Default()
+	if defaultLogger != nil {
+		return defaultLogger
+	}
+	// Ultimate fallback: create emergency logger to stderr (should never happen)
+	return slog.New(slog.NewTextHandler(os.Stderr, nil))
 }
 
 func init() {
@@ -825,7 +830,7 @@ func init() {
 		}
 		closeSpectrogramLogger = func() error { return nil }
 		// Log the error so we know why the file logger failed
-		if err != nil && spectrogramLogger != nil {
+		if err != nil {
 			getSpectrogramLogger().Error("Failed to initialize spectrogram generation file logger", "error", err)
 		}
 	}
@@ -836,14 +841,10 @@ func UpdateSpectrogramLogLevel(debugEnabled bool) {
 	if spectrogramLevelVar != nil {
 		if debugEnabled {
 			spectrogramLevelVar.Set(slog.LevelDebug)
-			if spectrogramLogger != nil {
-				getSpectrogramLogger().Info("Spectrogram logger set to DEBUG level")
-			}
+			getSpectrogramLogger().Info("Spectrogram logger set to DEBUG level")
 		} else {
 			spectrogramLevelVar.Set(slog.LevelInfo)
-			if spectrogramLogger != nil {
-				getSpectrogramLogger().Info("Spectrogram logger set to INFO level")
-			}
+			getSpectrogramLogger().Info("Spectrogram logger set to INFO level")
 		}
 	}
 }

--- a/internal/api/v2/media_test.go
+++ b/internal/api/v2/media_test.go
@@ -1248,3 +1248,40 @@ func TestIsValidFilename(t *testing.T) {
 		})
 	}
 }
+
+// TestGetSpectrogramLogger tests that the spectrogram logger is never nil
+func TestGetSpectrogramLogger(t *testing.T) {
+	// Test that getSpectrogramLogger always returns a non-nil logger
+	logger := getSpectrogramLogger()
+	require.NotNil(t, logger, "getSpectrogramLogger() must never return nil")
+
+	// Test that we can call logging methods without panic
+	assert.NotPanics(t, func() {
+		logger.Info("test message")
+		logger.Debug("test debug")
+		logger.Warn("test warning")
+		logger.Error("test error")
+	}, "Logger methods should not panic")
+}
+
+// TestGetSpectrogramLoggerWithNilPackageLogger tests fallback behavior
+func TestGetSpectrogramLoggerWithNilPackageLogger(t *testing.T) {
+	// Save original logger
+	originalLogger := spectrogramLogger
+	defer func() {
+		// Restore original logger
+		spectrogramLogger = originalLogger
+	}()
+
+	// Set package logger to nil to test fallback
+	spectrogramLogger = nil
+
+	// Get logger should still return a valid logger
+	logger := getSpectrogramLogger()
+	require.NotNil(t, logger, "getSpectrogramLogger() must return fallback when spectrogramLogger is nil")
+
+	// Test that we can call logging methods without panic
+	assert.NotPanics(t, func() {
+		logger.Info("fallback test")
+	}, "Fallback logger should work correctly")
+}


### PR DESCRIPTION
## Summary

Fixes a nil pointer dereference panic in spectrogram generation that occurred when the `spectrogramLogger` was nil.

**Error from telemetry:**
```
runtime.errorString: runtime error: invalid memory address or nil pointer dereference
  File "github.com/tphakala/birdnet-go/internal/httpcontroller/handlers/media.go", line 984, in getSoxSpectrogramArgs
```

## Changes

- **Added safe logger accessor**: `getSpectrogramLogger()` function ensures the logger is never nil, with fallback to `slog.Default()`
- **Enhanced init() fallback chain**: Added multi-level fallbacks (file logger → default logger → stdout logger)
- **Replaced all direct logger calls**: Changed `spectrogramLogger.Method()` to `getSpectrogramLogger().Method()` throughout the file
- **Added nil checks**: Protected logger calls in `UpdateSpectrogramLogLevel()` and error handling paths

## Root Cause

The `spectrogramLogger` could be nil in edge cases:
1. If `logging.NewFileLogger()` failed and returned nil
2. If `slog.Default()` also returned nil in the fallback path
3. If the logger was accessed before `init()` completed

## Test Plan

- [x] Code compiles successfully
- [x] Build passes for entire `internal/api/v2/` package
- [ ] Manual testing: Verify spectrogram generation still works
- [ ] Verify logs appear in `logs/spectrogram-generation.log`
- [ ] Test fallback behavior when log file cannot be created

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logging reliability during spectrogram operations to prevent rare crashes and ensure consistent logs during initialization and error handling.

* **Refactor**
  * Standardized logging calls to use a safe, always-available logger, improving consistency and resilience across spectrogram-related code paths.

* **Tests**
  * Added tests to confirm logging remains functional when the primary logger is unavailable and that logging calls do not panic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->