### PR TITLE
fix(myaudio): Fix lastDataTime reset and zero time handling

### DIFF
--- a/internal/myaudio/ffmpeg_stream_test.go
+++ b/internal/myaudio/ffmpeg_stream_test.go
@@ -898,6 +898,33 @@ func TestSecondsSinceOrZero(t *testing.T) {
 	assert.Less(t, result, 3700.0, "Old time should be approximately 3600 seconds")
 }
 
+// TestFormatLastDataDescription tests the stream's helper function for formatting last data time
+func TestFormatLastDataDescription(t *testing.T) {
+	t.Parallel()
+
+	// Test 1: Zero time should return "never received data"
+	zeroTime := time.Time{}
+	result := formatLastDataDescription(zeroTime)
+	assert.Equal(t, "never received data", result, "Zero time should return 'never received data'")
+
+	// Test 2: Recent time should return "X.Xs ago" format
+	recentTime := time.Now().Add(-5 * time.Second)
+	result = formatLastDataDescription(recentTime)
+	assert.NotEqual(t, "never received data", result, "Recent time should not return 'never received data'")
+	assert.Contains(t, result, "ago", "Result should contain 'ago'")
+	assert.Contains(t, result, "s ago", "Result should contain seconds with 'ago'")
+	// Verify format is approximately "5.0s ago"
+	assert.Regexp(t, `^\d+\.\ds ago$`, result, "Result should match pattern 'X.Xs ago'")
+
+	// Test 3: Old time should also return "X.Xs ago" format with larger number
+	oldTime := time.Now().Add(-2 * time.Minute)
+	result = formatLastDataDescription(oldTime)
+	assert.NotEqual(t, "never received data", result, "Old time should not return 'never received data'")
+	assert.Contains(t, result, "ago", "Result should contain 'ago'")
+	// Verify the seconds value is approximately 120
+	assert.Regexp(t, `^1\d{2}\.\ds ago$`, result, "Result should be approximately '120.0s ago'")
+}
+
 // TestFormatTimeSinceData tests the manager's helper function for formatting time
 func TestFormatTimeSinceData(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Summary

Fixes confusing "inactive for 0 seconds" log messages and improves handling of streams that have never received data. Part of the FFmpeg improvements plan (PR #2).

## Changes

### 1. Explicit lastDataTime Reset in processAudio()
- **Location**: [ffmpeg_stream.go:933-938](internal/myaudio/ffmpeg_stream.go#L933-L938)
- Resets `lastDataTime` to zero time when starting new FFmpeg process
- Resets `totalBytesReceived` to ensure clean state
- Prevents confusing logs from previous process state carryover

**Before:**
```
⚠️ No data from rtsp://... for 0s, restarting stream
```

**After:**
```
⚠️ No data from rtsp://... (last data: never received data, timeout: 90s), restarting stream
```

### 2. Enhanced Zero Time Logging in GetHealth()
- **Location**: [ffmpeg_stream.go:1646-1668](internal/myaudio/ffmpeg_stream.go#L1646-L1668)
- Improved debug messages distinguish grace period vs expired states
- Added `"last_data": "never"` to structured logs
- Better observability for streams without data

### 3. Improved Silence Detection Logging
- **Location**: [ffmpeg_stream.go:1067-1093](internal/myaudio/ffmpeg_stream.go#L1067-L1093)
- Shows "never received data" instead of confusing duration strings
- Adds process runtime to logs for context
- Clearer user-facing messages with `lastDataDesc` helper

### 4. Comprehensive Test Coverage
- **Location**: [ffmpeg_stream_test.go:814-1015](internal/myaudio/ffmpeg_stream_test.go#L814-L1015)
- `TestFFmpegStream_LastDataTimeReset` - verifies reset behavior
- `TestFFmpegStream_ZeroTimeHandling` - tests grace period handling
- `TestSecondsSinceOrZero` - tests helper function
- `TestFormatTimeSinceData` - tests formatting helper
- `TestGetTimeSinceDataSeconds` - tests time calculation helper
- `TestFFmpegStream_HealthWithZeroTime` - ensures consistency
- `TestFFmpegStream_ConcurrentLastDataTimeAccess` - thread safety

## Benefits

✅ No more "inactive for 0 seconds" log noise  
✅ Clear distinction between "never" and "X seconds ago"  
✅ Better diagnostics for new streams  
✅ Thread-safe with comprehensive race detector testing  
✅ All tests pass: `go test -race ./internal/myaudio/...` (29.743s)  
✅ Linter clean: `golangci-lint run ./internal/myaudio/...` (0 issues)

## Testing

### Test Results
```bash
$ go test -race -v ./internal/myaudio/... -run "LastDataTime|ZeroTime"
PASS: TestFFmpegStream_LastDataTimeReset (0.00s)
PASS: TestFFmpegStream_ZeroTimeHandling (0.00s)
PASS: TestFFmpegStream_HealthWithZeroTime (0.00s)
PASS: TestFFmpegStream_ConcurrentLastDataTimeAccess (0.00s)
PASS: TestSecondsSinceOrZero (0.00s)
PASS: TestFormatTimeSinceData (0.00s)
PASS: TestGetTimeSinceDataSeconds (0.00s)
ok  	github.com/tphakala/birdnet-go/internal/myaudio	1.057s
```

### Linter Results
```bash
$ golangci-lint run -v ./internal/myaudio/...
0 issues
```

## Related

- **Issue**: Fixes #1264 (partially - improves log clarity for hung streams)
- **Plan**: Part of [FFmpeg Improvements Plan PR #2](ffmpeg-improvements-plan.local.md#pr-2-fix-lastdatatime-reset-and-zero-time-handling)
- **Depends On**: PR #1 state machine (merged) ✅
- **Follows**: PR #2.5 transport detection (merged) ✅
- **Next**: PR #3 watchdog for stuck streams

## Example Logs

### Before (Confusing)
```
⚠️ No data from rtsp://camera.local/stream for 0s, restarting stream
⚠️ Unhealthy stream detected: rtsp://... (last data: 0 seconds ago)
```

### After (Clear)
```
⚠️ No data from rtsp://camera.local/stream (last data: never received data, timeout: 90s), restarting stream
⚠️ Unhealthy stream detected: rtsp://... (last data: never received data)
```

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Reset data-reception tracking when starting a new audio process, improving initial health accuracy.
- Improvements
  - Standardized “last data” reporting with clearer descriptors (including “never”).
  - Enhanced health and debug logs around grace periods and initial data reception.
  - Added a runtime metric to silence-detection logs for better observability.
- Tests
  - Added comprehensive tests covering timing utilities, health reporting, concurrency, backoff, timeout handling, and logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->