### PR TITLE
feat(myaudio): Add human-readable time formatting for log messages

### DIFF
--- a/internal/myaudio/ffmpeg_stream.go
+++ b/internal/myaudio/ffmpeg_stream.go
@@ -1846,8 +1846,8 @@ func (s *FFmpegStream) isCircuitOpen() bool {
 		streamLogger.Warn("circuit breaker is open",
 			"url", privacy.SanitizeRTSPUrl(s.source.SafeString),
 			"consecutive_failures", s.consecutiveFailures,
-			"cooldown_remaining", remaining.Round(time.Second).String(),
-			"cooldown_total", circuitBreakerCooldown.String(),
+			"cooldown_remaining", FormatDuration(remaining),
+			"cooldown_total", FormatDuration(circuitBreakerCooldown),
 			"component", "ffmpeg-stream")
 		return true
 	}
@@ -1863,8 +1863,8 @@ func (s *FFmpegStream) isCircuitOpen() bool {
 		streamLogger.Info("circuit breaker closed after cooldown",
 			"url", privacy.SanitizeRTSPUrl(s.source.SafeString),
 			"previous_failures", previousFailures,
-			"open_duration", openDuration.Round(time.Second).String(),
-			"cooldown_period", circuitBreakerCooldown.String(),
+			"open_duration", FormatDuration(openDuration),
+			"cooldown_period", FormatDuration(circuitBreakerCooldown),
 			"component", "ffmpeg-stream")
 
 		// Report circuit breaker closure to telemetry
@@ -1884,8 +1884,8 @@ func (s *FFmpegStream) isCircuitOpen() bool {
 			streamLogger.Debug("circuit breaker closed after cooldown",
 				"url", privacy.SanitizeRTSPUrl(s.source.SafeString),
 				"previous_failures", previousFailures,
-				"open_duration", openDuration.Round(time.Second).String(),
-				"cooldown_period", circuitBreakerCooldown.String())
+				"open_duration", FormatDuration(openDuration),
+				"cooldown_period", FormatDuration(circuitBreakerCooldown))
 		}
 		_ = errorWithContext // Keep for telemetry reporting when enabled
 	}
@@ -1974,9 +1974,9 @@ func (s *FFmpegStream) recordFailure(runtime time.Duration) {
 		streamLogger.Error("circuit breaker opened",
 			"url", privacy.SanitizeRTSPUrl(s.source.SafeString),
 			"consecutive_failures", currentFailures,
-			"runtime", runtime.Round(time.Millisecond).String(),
+			"runtime", FormatDuration(runtime),
 			"reason", reason,
-			"cooldown_period", circuitBreakerCooldown.String(),
+			"cooldown_period", FormatDuration(circuitBreakerCooldown),
 			"component", "ffmpeg-stream")
 		log.Printf("🔒 Circuit breaker opened for %s after %d consecutive failures (%s, runtime: %s, cooldown: %s)",
 			privacy.SanitizeRTSPUrl(s.source.SafeString), currentFailures, reason, FormatDuration(runtime), FormatDuration(circuitBreakerCooldown))

--- a/internal/myaudio/time_format.go
+++ b/internal/myaudio/time_format.go
@@ -32,7 +32,12 @@ func FormatDuration(d time.Duration) string {
 
 	// Less than 1 minute: show seconds only (rounded, no decimals)
 	if d < time.Minute {
-		return fmt.Sprintf("%ds", int(d.Round(time.Second).Seconds()))
+		rounded := int(d.Round(time.Second).Seconds())
+		// Handle edge case where rounding brings us to exactly 60 seconds
+		if rounded >= 60 {
+			return "1m 0s"
+		}
+		return fmt.Sprintf("%ds", rounded)
 	}
 
 	// Less than 1 hour: show minutes and seconds (rounded to nearest second)

--- a/internal/myaudio/time_format_test.go
+++ b/internal/myaudio/time_format_test.go
@@ -136,9 +136,9 @@ func TestFormatDurationRounding(t *testing.T) {
 			want:     "12s",
 		},
 		{
-			name:     "59.5 seconds (rounds to 60s)",
+			name:     "59.5 seconds (rounds to 1m 0s)",
 			duration: 59*time.Second + 500*time.Millisecond,
-			want:     "60s",
+			want:     "1m 0s",
 		},
 		{
 			name:     "1m 29.4s (rounds to 1m 29s)",


### PR DESCRIPTION
## Summary

Cleans up time formatting in FFmpeg log prints to improve readability. Durations are now displayed without decimal precision on seconds and use appropriate units.

## Changes

### New Utilities (`time_format.go`)

- **`FormatDuration(d time.Duration)`** - Human-readable time formatting
  - `< 1 second`: shows milliseconds (e.g., `"450ms"`)
  - `1s - 59s`: shows seconds without decimals (e.g., `"11s"`)
  - `1m - 59m`: shows minutes and seconds (e.g., `"2m 30s"`)
  - `>= 1 hour`: shows hours, minutes, seconds (e.g., `"1h 23m 45s"`)

- **`FormatDurationCompact(d time.Duration)`** - Compact format for inline display

### Updated Log Messages

All time-related log prints in `ffmpeg_stream.go` now use the new formatter:

1. **State transition messages** (backoff, circuit breaker)
   - Before: `"restart #1: waiting 5.050966907s (base backoff: 5s)"`
   - After: `"restart #1: waiting 5s (base backoff: 5s)"`

2. **Process runtime messages**
   - Before: `"FFmpeg process ended for rtsp://... after 2m30.5s"`
   - After: `"FFmpeg process ended for rtsp://... after 2m 30s"`

3. **Timeout and restart wait messages**
   - Before: `⏳ Waiting 11.46157937s before restart...`
   - After: `⏳ Waiting 11s before restart...`

4. **Circuit breaker cooldown messages**
   - Before: `"circuit breaker cooldown: 15.234s remaining"`
   - After: `"circuit breaker cooldown: 15s remaining"`

## Testing

- Added comprehensive test coverage in `time_format_test.go` (29 test cases)
- All tests pass ✅
- Build successful ✅

## Example Output

### Before
```
2025/10/12 10:45:34 ⏳ Waiting 11.46157937s before restart attempt #2 for rtsp://localhost:8554/mystream
2025/10/12 10:51:47 🔄 State transition for rtsp://localhost:8554/mystream: running → backoff (restart #1: waiting 5.050966907s (base backoff: 5s))
```

### After
```
2025/10/12 10:45:34 ⏳ Waiting 11s before restart attempt #2 for rtsp://localhost:8554/mystream
2025/10/12 10:51:47 🔄 State transition for rtsp://localhost:8554/mystream: running → backoff (restart #1: waiting 5s (base backoff: 5s))
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Unified duration formatting across logs to display clear, human-readable times (ms, s, m, h) for startup, runtime, cooldowns, backoffs, timeouts, and no-data restarts.
  - Standardized messaging for health, restart and circuit-breaker events to improve consistency and readability.
- Tests
  - Added unit tests validating formatting and rounding behavior across ranges and edge cases (including negative, subsecond, and boundary rounding).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->