### PR TITLE
fix(birdweather): improve DNS timeout handling for multi-server environments

### DIFF
--- a/internal/birdweather/testing_test.go
+++ b/internal/birdweather/testing_test.go
@@ -40,9 +40,13 @@ func TestResolveDNSWithFallback(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel() // Safe - each subtest has independent hostname
 
-			// Set a reasonable timeout for the test
+			// Set a reasonable timeout for the test to prevent hangs on slow/flaky DNS
+			// 12s allows: system DNS (10s) + at least one fallback attempt (5s) with overhead
+			ctx, cancel := context.WithTimeout(context.Background(), 12*time.Second)
+			defer cancel()
+
 			start := time.Now()
-			ips, err := resolveDNSWithFallback(context.Background(), tc.hostname)
+			ips, err := resolveDNSWithFallback(ctx, tc.hostname)
 			duration := time.Since(start)
 
 			if tc.expectError {


### PR DESCRIPTION
## Summary

Fixes #1107 - BirdWeather API connectivity tests failing due to DNS resolution delays in Docker/containerized environments.

This PR addresses timeout issues when multiple DNS servers are configured and the first server(s) are unreachable, causing sequential timeout attempts that exceed test timeouts.

## Changes

### Timeout Adjustments
- **API Connectivity**: 5s → **15s** (handles multiple DNS server timeouts)
- **Authentication**: 5s → **15s** (handles multiple DNS server timeouts)  
- **Soundscape Upload**: 10s → **30s** (handles encoding + DNS delays)
- **Detection Post**: 5s → **15s** (handles multiple DNS server timeouts)

### DNS Resolution Improvements

**DNS Timeout Constants** (adjusted to match Linux defaults):
- `systemDNSTimeout`: **10s** - Maximum wait for system DNS (allows 2 × 5s server attempts)
- `dnsResolverTimeout`: **5s** - Per-server connection timeout (matches Linux DNS default)
- `dnsLookupTimeout`: **5s** - Per-lookup timeout (allows one full DNS server attempt)

**Key Fix**: Increased per-server timeouts from 3s to **5s** to match Linux's default DNS timeout. The previous 3s would cut off before the system could complete even one DNS server attempt.

**Context-based DNS Resolution** (Go 1.23+):
- Replaced uncancellable `net.LookupIP` with `net.DefaultResolver.LookupIP`
- Proper context-based cancellation support
- Eliminates potential goroutine leak from timeout wrapper
- Clean shutdown when DNS operations are cancelled

**Enhanced `resolveDNSWithFallback()`**:
- Uses context for timeout management
- Better error discrimination (timeout vs failure)
- Improved logging with specific error context
- Shorter timeouts per fallback DNS server (5s each)
- Actionable error messages for troubleshooting

### Go 1.23+ Features Leveraged

**DNS Error Handling Improvements**:
- `DNSError` now wraps `context.DeadlineExceeded` (Go 1.23 feature)
- New `isDNSTimeout()` helper uses `errors.Is(err, context.DeadlineExceeded)`
- Enhanced `isDNSError()` checks for `*net.DNSError` type first
- More reliable error classification and handling

### Error Message Improvements
- Timeout errors mention Docker DNS configuration issues
- Suggests checking `/etc/resolv.conf` for unreachable nameservers
- Provides clear guidance on DNS troubleshooting steps
- Example: *"If using Docker, this may be caused by DNS resolution delays from unreachable DNS servers in /etc/resolv.conf"*

### Testing & Validation

**Comprehensive Test Suite** (`testing_test.go`):
- ✅ `TestResolveDNSWithFallback` - DNS resolution with valid/invalid hostnames (max 27s)
- ✅ `TestAPIConnectivityTimeout` - Timeout behavior validation
- ✅ `TestTimeoutConstants` - Timeout values, relationships, and Linux compatibility
- ✅ `TestFallbackDNSResolvers` - Fallback DNS configuration
- ✅ `TestIsDNSError` - DNS error detection (5 test cases)
- ✅ `TestDNSLookupCancellation` - **NEW**: Context cancellation verification
- ✅ `TestIsDNSTimeout` - **ENHANCED**: Timeout detection with Go 1.23+ features (6 test cases + DNS error validation)

**Timeout Relationship Validation**:
- Verifies `uploadTimeout > apiTimeout` (encoding overhead)
- Checks total DNS time (25s) vs API timeout (15s) with detailed warnings
- Ensures DNS timeouts >= 5s (Linux default)
- Validates minimum timeout values for each stage

### Code Quality Improvements

Based on code review feedback, implemented 5 key improvements:

1. **Context-based DNS cancellation** - Eliminated goroutine leak by using `context.WithTimeout`
2. **Adjusted to Linux DNS defaults** - Increased per-server timeouts from 3s to 5s
3. **Comprehensive timeout rationale** - Added detailed comments explaining Linux DNS behavior
4. **Context cancellation testing** - Added `TestDNSLookupCancellation`
5. **Enhanced error validation** - Tests verify timeout errors are also classified as DNS errors

## Root Cause Analysis

The issue occurred because:

1. **Docker DNS configuration**: Containers often have multiple DNS servers in `/etc/resolv.conf`
2. **Linux DNS timeout**: System resolver uses **5 seconds per nameserver** by default
3. **Sequential timeout behavior**: When the first DNS server is unreachable, resolver waits 5s before trying the next
4. **Cumulative delays**: With multiple unreachable servers, total DNS resolution time = 5s × N servers
5. **Aggressive timeouts**: Original test timeout of 5 seconds was insufficient
6. **Tool differences**: Manual tools like `curl` worked because they have longer default timeouts (30s+)

Example scenario:
```
/etc/resolv.conf:
  nameserver 192.168.1.1  # Unreachable - 5s timeout (Linux default)
  nameserver 192.168.1.2  # Unreachable - 5s timeout (Linux default)
  nameserver 8.8.8.8      # Success
  
Total time: 10+ seconds
Original timeout: 5 seconds ❌
New timeout: 15 seconds ✅

Per-server timeout: 3s ❌ (cuts off mid-DNS-attempt)
Per-server timeout: 5s ✅ (matches Linux default)
```

## Test Results

```bash
$ go test ./internal/birdweather -timeout 120s
ok      github.com/tphakala/birdnet-go/internal/birdweather     0.840s

$ golangci-lint run ./internal/birdweather/...
0 issues.
```

All tests pass, including:
- Existing BirdWeather functionality tests
- New DNS fallback behavior tests  
- Enhanced timeout validation tests
- Go 1.23+ error handling tests
- Context cancellation tests

## Commit History

1. **fix(birdweather): improve DNS timeout handling for multi-server environments**
   - Initial timeout adjustments (5s → 15s)
   - DNS fallback improvements
   - Comprehensive test suite

2. **refactor(birdweather): address code quality improvements in DNS timeout handling**
   - Extracted magic numbers to constants
   - Enhanced timeout validation in tests
   - Improved test reliability (1ms → 10ms)

3. **feat(birdweather): leverage Go 1.23+ features for improved DNS handling**
   - Context-based DNS cancellation
   - Modern error wrapping with `errors.Is`
   - Enhanced error classification

4. **fix(birdweather): adjust DNS timeouts to match Linux 5s default**
   - **Critical fix**: 3s → 5s per-server timeouts
   - Added `TestDNSLookupCancellation`
   - Enhanced `TestIsDNSTimeout` with DNS error validation
   - Updated test duration expectations (18s → 27s max)

## Verification

The fix was verified by:

✅ All existing birdweather tests pass (0.840s)
✅ DNS resolution tested with valid/invalid hostnames  
✅ Timeout constants validated against Linux DNS defaults (5s)
✅ Linter passes with 0 issues  
✅ Timeout relationships and hierarchies validated  
✅ Go 1.23+ error wrapping features tested  
✅ Context cancellation verified with new test

## Migration Notes

This PR is **fully backward compatible**. The changes:
- Only increase timeout values (more permissive)
- Improve error handling and logging
- Add new test coverage
- No breaking API changes
- Aligns timeouts with Linux DNS defaults for better reliability

## References

- Linux `resolv.conf` default timeout: 5 seconds per nameserver
- See: `man 5 resolv.conf` (options timeout:n)
- Go 1.23 release notes: DNSError timeout wrapping
- Issue #1107: BirdWeather tests timing out in Docker

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added context-aware fallback DNS resolution with per-resolver and per-lookup timeouts, clearer distinction between DNS timeouts and other failures, and final errors reporting number of fallback servers.

* **Bug Fixes**
  * Improved timeout handling and messaging across connectivity and authentication flows to better surface DNS delays, cancellations, and per-resolver outcomes.

* **Tests**
  * Added comprehensive tests for DNS fallback behavior, timeout detection/cancellation, resolver configuration, and DNS error classification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->