### PR TITLE
fix(docker): add tzdata-legacy for Debian Trixie timezone support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -90,6 +90,7 @@ RUN apt-get update -q && apt-get install -q -y --no-install-recommends \
     vim \
     less \
     tzdata \
+    tzdata-legacy \
     jq \
     strace \
     lsof \


### PR DESCRIPTION
## Summary

Fixes #1418 - Restores timezone support for legacy timezone names (US/Mountain, US/Pacific, etc.) broken by Debian Trixie upgrade.

Related to #1416 - User-reported timezone issues where observations were incorrectly timestamped in UTC.

## Problem

The upgrade to Debian 13 Trixie moved legacy timezone names to a separate `tzdata-legacy` package. Users with configurations like `TZ=US/Mountain` experienced silent failures, with applications defaulting to UTC instead of the configured timezone.

## Solution

Implemented the hybrid approach recommended in #1418:

### 1. Backward Compatibility (Dockerfile)
- ✅ Added `tzdata-legacy` package installation (~60KB)
- ✅ Existing users with legacy timezone names continue working

### 2. Enhanced Error Handling (entrypoint.sh)
- ✅ Validates `TZ` environment variable against `/usr/share/zoneinfo/`
- ✅ Warns users about deprecated legacy formats (US/*, Etc/*)
- ✅ **Critical fix**: Actually configures UTC fallback when timezone validation fails (previous version only warned but didn't configure)
- ✅ Clear, actionable error messages

### 3. User Guidance (install.sh)
- ✅ Updated examples to show canonical IANA timezone formats:
  - America/New_York instead of US/Eastern
  - America/Denver instead of US/Mountain
  - America/Los_Angeles instead of US/Pacific
- ✅ Automatic detection of legacy format usage
- ✅ Interactive prompts offering canonical alternatives with automatic conversion
- ✅ **Code quality**: Refactored duplicate validation logic into reusable helper function (reduced 70 lines of duplication)

## Changes

| File | Changes |
|------|---------|
| `Dockerfile` | Added `tzdata-legacy` package |
| `Docker/entrypoint.sh` | Added timezone validation with UTC fallback configuration |
| `install.sh` | Updated timezone examples, added legacy detection, refactored duplicate code |

**Total**: +111 lines, -13 lines (net reduction of 70 lines duplication)

## Testing Checklist

- [x] Legacy timezone names work (US/Mountain, US/Pacific, etc.)
- [x] Canonical timezone names work (America/Denver, America/Los_Angeles, etc.)
- [x] Invalid timezone handling shows helpful error messages
- [x] UTC fallback is actually configured (not just warned about)
- [x] Works on both Debian 12 (Bookworm) and Debian 13 (Trixie)

## Screenshots/Examples

**Before**: Container would silently default to UTC
**After**: Users get clear warnings and guidance:

```
Timezone configuration: TZ=US/Mountain
⚠️  WARNING: Using legacy timezone format 'US/Mountain'
    Consider canonical format (e.g., 'America/Denver' instead of 'US/Mountain')
    Legacy names may be removed in future Debian releases
✓ Timezone configured: US/Mountain
```

## Impact

- **High Priority**: Fixes data integrity issue (wrong timestamps) reported in #1416
- **Backward Compatible**: Existing installations continue working
- **Future-Proof**: Guides new users toward canonical formats
- **User-Friendly**: Clear warnings and automatic migration options

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved timezone configuration with validation and automatic UTC fallback for invalid timezones
  * Enhanced installation guidance with updated timezone selection prompts featuring canonical format examples
  * Support for legacy timezone format detection with recommendations for modern alternatives

<!-- end of auto-generated comment: release notes by coderabbit.ai -->