### PR TITLE
feat(frontend): Add debug logging to AudioPlayer for multi-session troubleshooting

### DIFF
--- a/frontend/src/lib/desktop/features/dashboard/components/RecentDetectionsCard.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/components/RecentDetectionsCard.svelte
@@ -345,6 +345,7 @@
                     className="w-full"
                     onPlayStart={onFreezeStart}
                     onPlayEnd={onFreezeEnd}
+                    debug={false}
                   />
                 </div>
               </div>


### PR DESCRIPTION
## Summary

Adds comprehensive debug logging system to AudioPlayer component to help diagnose spectrogram loading issues when multiple browser sessions access the dashboard simultaneously.

## Changes

### AudioPlayer Component
- Added optional `debug` prop (defaults to `false`)
- Created `debugLog` helper function that:
  - Only logs when `debug={true}` 
  - Prefixes logs with `[AudioPlayer:{detectionId}]` for easy tracking
  - Bypasses ESLint warnings with targeted `eslint-disable-next-line`

### Debug Logging Coverage
All critical paths now have debug logs:

**Component Lifecycle:**
- `onMount`: Initial state when component loads
- `onDestroy`: Cleanup state with active timers/polls

**Spectrogram Loading Flow:**
- `checkSpectrogramMode`: Mode detection (auto/user-requested)
- `pollSpectrogramStatus`: Status polling with queue position
- `handleSpectrogramLoad`: Successful image loads
- `handleSpectrogramError`: Retry logic, error conditions
- `handleGenerateSpectrogram`: User-triggered generation

**State Tracking:**
- `$effect` on URL changes: When spectrograms switch
- `$effect` on loader state: Loading/spinner/error states
- `$effect` on status: Queue position and generation progress

## Usage

Enable debug logging per instance:
```svelte
<AudioPlayer
  audioUrl="/api/v2/audio/{detection.id}"
  detectionId={detection.id.toString()}
  debug={true}
/>
```

Or conditionally in development:
```svelte
<AudioPlayer
  debug={import.meta.env.DEV}
  ...
/>
```

## Testing

- ✅ ESLint passes (no console.log warnings)
- ✅ Prettier formatting
- ✅ No runtime impact when `debug={false}` (default)
- ✅ All logs include unique `detectionId` prefix

## Benefits

- **Multi-session debugging**: Each AudioPlayer instance logs independently
- **No code removal needed**: Toggle with prop instead of removing debug statements
- **Production safe**: Debug disabled by default
- **Linter friendly**: Targeted ESLint disable only for console.log

## Testing Plan

To test multi-session issue:
1. Open dashboard in 5+ browser tabs
2. Enable `debug={true}` in RecentDetectionsCard
3. Watch browser console for spectrogram loading flow
4. Identify which detection IDs get stuck in loading state

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional debug mode to the audio player component for diagnostic logging during audio playback and spectrogram processing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->