### PR TITLE
fix(htmx): restore spectrogram generation in old HTMX UI

### DIFF
--- a/internal/httpcontroller/handlers/media.go
+++ b/internal/httpcontroller/handlers/media.go
@@ -538,7 +538,7 @@ func (h *Handlers) ServeSpectrogram(c echo.Context) error {
 		)
 		h.Debug("ServeSpectrogram: Successfully created spectrogram at: %s", absSpectrogramPath)
 
-		// Update spectrogramPath to use the absolute path for the final check
+		// Update spectrogramPath to absolute path for final check and serving
 		spectrogramPath = absSpectrogramPath
 	} else {
 		logger.Debug("Existing spectrogram found, serving cached version",


### PR DESCRIPTION
## Summary

Fixes spectrogram generation in the old HTMX UI after the consolidation of spectrogram generation code into `internal/spectrogram/`.

Fixes #1435

## Problem

The old HTMX UI was returning placeholder SVG images instead of generating spectrograms. After consolidating spectrogram generation logic, the HTMX handler was not updated to meet the generator's requirements.

## Root Cause

Two issues prevented spectrogram generation:

1. **Path Handling Error**: The generator requires absolute paths for security validation (via SecureFS), but the HTMX handler was passing relative paths like `clips/2025/10/...`, causing "output path must be absolute" errors.

2. **Wrong Spectrogram Type**: The handler was generating spectrograms with SoX axes/legends (`raw=false`) instead of raw spectrograms without decoration (`raw=true`), which is the expected behavior for the old UI.

## Changes

### Path Handling Fix ([media.go:488-506](internal/httpcontroller/handlers/media.go#L488-L506))
- Added `filepath.Abs()` conversion for both audio and spectrogram paths before calling the generator
- Ensures paths meet the generator's absolute path requirement for security validation

### Spectrogram Type Fix ([media.go:516](internal/httpcontroller/handlers/media.go#L516))
- Changed `raw=false` to `raw=true` to generate spectrograms without SoX axes/legends
- Matches the original HTMX UI behavior and user expectations

### Additional Improvements
- Added nil check for `spectrogramGenerator` to prevent potential panics
- Enhanced error visibility: changed all failure paths from DEBUG to ERROR level logging
- Added INFO-level logging for generation attempts with full parameter details
- Improved error context for easier troubleshooting

## Behavior Notes

- **HTMX UI Mode**: Always uses auto mode (on-demand generation) regardless of the `spectrogram.mode` configuration setting
- **Configuration Setting**: The `spectrogram.mode` setting only applies to the modern Svelte UI (API v2)
- **Backward Compatibility**: Raw spectrograms maintain consistency with existing cached spectrograms

## Testing

- [x] Verified spectrograms generate on-demand when missing
- [x] Confirmed raw spectrograms (no axes/legends) are produced  
- [x] Validated ERROR logs show detailed failure information
- [x] Checked absolute path conversion works correctly
- [x] Tested with multiple concurrent requests

## Logs Before Fix

```
ERROR Spectrogram generation returned error ... error="output path must be absolute"
```

## Logs After Fix

```
INFO Spectrogram not found, initiating on-demand generation
INFO Calling spectrogram generator audio_path=/full/path/... output_path=/full/path/... raw=true
INFO Spectrogram generation returned success duration_ms=150
```

## Related

- Consolidation PR: #1422 (Backend scalability improvements)
- Issue: #1435

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved spectrogram generator handling with fallback to placeholder on errors.
  * Enhanced path validation and resolution for audio and spectrogram files.
  * Refined on-demand spectrogram generation flow with better error recovery.

* **Improvements**
  * Expanded logging for improved troubleshooting and monitoring of spectrogram operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->