### PR TITLE
Fix logging panic: resolve slog.LevelKey conflict (#1467)

### DIFF
--- a/internal/analysis/processor/threshold_persistence.go
+++ b/internal/analysis/processor/threshold_persistence.go
@@ -84,7 +84,7 @@ func (p *Processor) loadDynamicThresholdsFromDB() error {
 		if p.Settings.Realtime.DynamicThreshold.Debug {
 			GetLogger().Debug("Loaded dynamic threshold",
 				"species", dbThreshold.SpeciesName,
-				"level", dbThreshold.Level,
+				"threshold_level", dbThreshold.Level,
 				"current_value", dbThreshold.CurrentValue,
 				"expires_at", dbThreshold.ExpiresAt,
 				"operation", "load_dynamic_thresholds")
@@ -142,8 +142,8 @@ func (p *Processor) persistDynamicThresholds() error {
 			HighConfCount: threshold.HighConfCount,
 			ValidHours:    threshold.ValidHours,
 			ExpiresAt:     threshold.Timer,
-			LastTriggered: now,  // Track when we last saw activity
-			FirstCreated:  now,  // Will be preserved by upsert if record exists
+			LastTriggered: now, // Track when we last saw activity
+			FirstCreated:  now, // Will be preserved by upsert if record exists
 			UpdatedAt:     now,
 			TriggerCount:  threshold.HighConfCount, // Use HighConfCount as trigger count
 		})


### PR DESCRIPTION
## Description

Fixes the panic reported in #1467 where BirdNET-Go container crashes during startup with:
```
panic: interface conversion: interface {} is int64, not slog.Level
```

## Root Cause

The issue occurs because `"level"` is a **reserved key** in Go's `log/slog` package. When used as an attribute key, `slog` automatically treats it as the log level rather than a regular attribute.

### Reserved Keys in slog
```go
const (
    TimeKey    = "time"    // Reserved for log timestamp
    LevelKey   = "level"   // Reserved for log level ← This is the culprit!
    MessageKey = "msg"     // Reserved for log message  
    SourceKey  = "source"  // Reserved for source location
)
```

### The Problem
In `threshold_persistence.go:87`, the code was logging:
```go
GetLogger().Debug("Loaded dynamic threshold",
    "species", dbThreshold.SpeciesName,
    "level", dbThreshold.Level,  // ← Conflicts with slog.LevelKey!
    "current_value", dbThreshold.CurrentValue,
    // ...
)
```

When `slog` sees `"level"` as an attribute key, it assumes you're trying to set the log level to `dbThreshold.Level` (which is an `int`), but expects a `slog.Level` type. This causes the panic in `defaultReplaceAttr`:

```go
level := a.Value.Any().(slog.Level)  // ← Panic! int64 is not slog.Level
```

## Solution

### 1. Change Attribute Key
Changed `"level"` to `"threshold_level"` to avoid the collision with `slog.LevelKey`:

```go
GetLogger().Debug("Loaded dynamic threshold",
    "species", dbThreshold.SpeciesName,
    "threshold_level", dbThreshold.Level,  // ← Fixed!
    "current_value", dbThreshold.CurrentValue,
    // ...
)
```

### 2. Add Safety Check
Enhanced `defaultReplaceAttr` in `logging.go` to gracefully handle cases where `"level"` key contains non-`slog.Level` values:

```go
if a.Key == slog.LevelKey {
    // Safety check: ensure the value is actually a slog.Level
    if level, ok := a.Value.Any().(slog.Level); ok {
        levelLabel, exists := levelNames[level]
        if !exists {
            levelLabel = level.String()
        }
        a.Value = slog.StringValue(levelLabel)
    } else {
        // If it's not a slog.Level, convert it to string to avoid panic
        a.Value = slog.StringValue(fmt.Sprintf("%v", a.Value.Any()))
    }
}
```

## Testing

Created and verified a test case that reproduces the issue and confirms the fix works:

```go
// This would panic with the original code:
logger.Info("Testing fix", "level", 42)

// Output with fix:
// time=2025-10-28T18:07:31.724Z level=INFO msg="Testing fix" level=42
```

## Files Changed

- `internal/analysis/processor/threshold_persistence.go` - Changed `"level"` to `"threshold_level"`
- `internal/logging/logging.go` - Added safety check in `defaultReplaceAttr`

## Impact

- ✅ Fixes the startup panic in nightly-20251026
- ✅ Prevents future panics if other code accidentally uses `"level"` as attribute key
- ✅ Maintains backward compatibility
- ✅ No breaking changes

Fixes #1467

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced logging system stability to prevent potential crashes when handling certain data types.

* **Chores**
  * Updated internal threshold persistence logging structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->