### PR TITLE
fix(lint): resolve TypeScript and security linting errors

### DIFF
--- a/frontend/src/lib/desktop/features/settings/components/SettingsCard.test.ts
+++ b/frontend/src/lib/desktop/features/settings/components/SettingsCard.test.ts
@@ -133,7 +133,7 @@ describe('SettingsCard', () => {
       const bodyDivs = card.querySelectorAll('div');
 
       // Find the body div (contains our content)
-      const bodyDiv = Array.from(bodyDivs).find(div => div.textContent?.includes('Content'));
+      const bodyDiv = Array.from(bodyDivs).find(div => div.textContent.includes('Content'));
 
       expect(bodyDiv).toBeInTheDocument();
       // When padding is false, bodyClasses is empty string

--- a/frontend/src/lib/desktop/features/settings/pages/SettingsBinding.test.ts
+++ b/frontend/src/lib/desktop/features/settings/pages/SettingsBinding.test.ts
@@ -362,7 +362,7 @@ describe('Settings Binding Validation - Svelte 5 Fixes', () => {
           checkbox =>
             // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- Logical OR is correct here for falsy value handling
             checkbox.getAttribute('id')?.includes('equalizer') ||
-            checkbox.closest('label')?.textContent?.toLowerCase().includes('equalizer')
+            checkbox.closest('label')?.textContent.toLowerCase().includes('equalizer')
         );
 
         for (const checkbox of equalizerCheckboxes) {

--- a/frontend/src/lib/desktop/features/settings/pages/SettingsEdgeCases.test.ts
+++ b/frontend/src/lib/desktop/features/settings/pages/SettingsEdgeCases.test.ts
@@ -577,7 +577,7 @@ describe('Settings Pages - Edge Cases and Corner Cases', () => {
         // Search within the document body, as component container not directly accessible
         const scriptElements = document.body.querySelectorAll('script');
         const maliciousScripts = Array.from(scriptElements).filter(script =>
-          script.textContent?.includes('alert("xss")')
+          script.textContent.includes('alert("xss")')
         );
         expect(maliciousScripts.length).toBe(0); // No executable scripts should exist
 

--- a/frontend/src/lib/i18n/store.svelte.ts
+++ b/frontend/src/lib/i18n/store.svelte.ts
@@ -192,7 +192,7 @@ export function t(key: string, params?: Record<string, unknown>): string {
   const cacheKey = `${key}:${paramsKey}:${currentLocale}`;
 
   const cached = translationCache.get(cacheKey);
-  if (cached && cached.locale === currentLocale && cached.params === paramsKey) {
+  if (cached?.locale === currentLocale && cached.params === paramsKey) {
     return cached.value;
   }
 

--- a/frontend/src/lib/i18n/validateTranslations.ts
+++ b/frontend/src/lib/i18n/validateTranslations.ts
@@ -112,9 +112,9 @@ class TranslationValidator {
 
   private getValueByPath(obj: Record<string, unknown>, path: string): unknown {
     return path.split('.').reduce((current, key) => {
-      // eslint-disable-next-line security/detect-object-injection
       return current && typeof current === 'object'
-        ? (current as Record<string, unknown>)[key]
+        ? // eslint-disable-next-line security/detect-object-injection -- Safe: key from trusted path
+          (current as Record<string, unknown>)[key]
         : undefined;
     }, obj as unknown);
   }


### PR DESCRIPTION
## Summary
Fixes eslint errors that appeared after dependency updates, ensuring clean linting for CI.

## Changes

### Test Files
- [SettingsCard.test.ts:136](frontend/src/lib/desktop/features/settings/components/SettingsCard.test.ts#L136): Remove unnecessary optional chain on `textContent`
- [SettingsBinding.test.ts:365](frontend/src/lib/desktop/features/settings/pages/SettingsBinding.test.ts#L365): Remove unnecessary optional chain on `textContent`
- [SettingsEdgeCases.test.ts:580](frontend/src/lib/desktop/features/settings/pages/SettingsEdgeCases.test.ts#L580): Remove unnecessary optional chain on `textContent`

### i18n Files
- [store.svelte.ts:195](frontend/src/lib/i18n/store.svelte.ts#L195): Fix optional chain usage in translation cache check
- [validateTranslations.ts:115-117](frontend/src/lib/i18n/validateTranslations.ts#L115-L117): Add eslint-disable comment for safe object access pattern

## Rationale
- `textContent` on HTML elements always returns a string (never null/undefined), so optional chaining is unnecessary
- Translation cache check needed consistent null handling
- Object injection warning in `getValueByPath` is a false positive (key comes from trusted path string)

## Test plan
- [x] Run `npm run lint` - passes without errors
- [ ] Run `npm test` - all tests pass
- [ ] Verify CI linting check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated settings and edge case test assertions for improved reliability.

* **Refactor**
  * Optimized cache validation logic in internationalization store.

* **Chores**
  * Updated linting comment in translation validation utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->