### PR TITLE
feat(notifications): add detection id/path tmpl vars

### DIFF
--- a/frontend/src/lib/desktop/features/settings/pages/NotificationsSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/NotificationsSettingsPage.svelte
@@ -62,7 +62,10 @@
     { name: 'Longitude', description: 'GPS longitude coordinate' },
     { name: 'Location', description: 'Formatted coordinates (e.g., "42.360100, -71.058900")' },
     { name: 'DetectionID', description: 'Detection ID number (e.g., "1234")' },
-    { name: 'DetectionPath', description: 'Relative path to detection (e.g., "/ui/detections/1234")' },
+    {
+      name: 'DetectionPath',
+      description: 'Relative path to detection (e.g., "/ui/detections/1234")',
+    },
     { name: 'DetectionURL', description: 'Full URL to detection in UI' },
     { name: 'ImageURL', description: 'Link to species image' },
     { name: 'DaysSinceFirstSeen', description: 'Number of days since first detected' },

--- a/frontend/src/lib/desktop/features/settings/pages/NotificationsSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/NotificationsSettingsPage.svelte
@@ -61,7 +61,9 @@
     { name: 'Latitude', description: 'GPS latitude coordinate' },
     { name: 'Longitude', description: 'GPS longitude coordinate' },
     { name: 'Location', description: 'Formatted coordinates (e.g., "42.360100, -71.058900")' },
-    { name: 'DetectionURL', description: 'Link to detection in UI' },
+    { name: 'DetectionID', description: 'Detection ID number (e.g., "1234")' },
+    { name: 'DetectionPath', description: 'Relative path to detection (e.g., "/ui/detections/1234")' },
+    { name: 'DetectionURL', description: 'Full URL to detection in UI' },
     { name: 'ImageURL', description: 'Link to species image' },
     { name: 'DaysSinceFirstSeen', description: 'Number of days since first detected' },
   ];

--- a/internal/api/v2/notifications.go
+++ b/internal/api/v2/notifications.go
@@ -688,6 +688,8 @@ func (c *Controller) CreateTestNewSpeciesNotification(ctx echo.Context) error {
 		Latitude:           42.3601,
 		Longitude:          -71.0589,
 		Location:           "Test Location (Sample Data)",
+		DetectionID:        "test",
+		DetectionPath:      "/ui/detections/test",
 		DetectionURL:       baseURL + "/ui/detections/test",
 		ImageURL:           "https://static.avicommons.org/houfin-DzFZcHoKwyx9JOmg-320.jpg",
 		DaysSinceFirstSeen: 0,

--- a/internal/notification/helpers.go
+++ b/internal/notification/helpers.go
@@ -270,6 +270,8 @@ func EnrichWithTemplateData(notification *Notification, data *TemplateData) *Not
 	}
 
 	return notification.
+		WithMetadata("bg_detection_id", data.DetectionID).
+		WithMetadata("bg_detection_path", data.DetectionPath).
 		WithMetadata("bg_detection_url", data.DetectionURL).
 		WithMetadata("bg_image_url", data.ImageURL).
 		WithMetadata("bg_confidence_percent", data.ConfidencePercent).

--- a/internal/notification/helpers_test.go
+++ b/internal/notification/helpers_test.go
@@ -243,6 +243,8 @@ func TestEnrichWithTemplateData(t *testing.T) {
 			name:         "nil notification",
 			notification: nil,
 			templateData: &TemplateData{
+				DetectionID:       "1",
+				DetectionPath:     "/ui/detections/1",
 				DetectionURL:      "http://localhost/detections/1",
 				ImageURL:          "http://localhost/image.jpg",
 				ConfidencePercent: "95",
@@ -264,6 +266,8 @@ func TestEnrichWithTemplateData(t *testing.T) {
 			name:         "valid notification and template data",
 			notification: NewNotification(TypeDetection, PriorityHigh, "Test", "Test Message"),
 			templateData: &TemplateData{
+				DetectionID:       "1",
+				DetectionPath:     "/ui/detections/1",
 				DetectionURL:      "http://localhost/detections/1",
 				ImageURL:          "http://localhost/image.jpg",
 				ConfidencePercent: "95",
@@ -296,6 +300,8 @@ func TestEnrichWithTemplateData(t *testing.T) {
 			if tt.notification != nil && tt.templateData != nil && result != nil {
 				// Verify all field values match expected template data
 				expectedValues := map[string]interface{}{
+					"bg_detection_id":       tt.templateData.DetectionID,
+					"bg_detection_path":     tt.templateData.DetectionPath,
 					"bg_detection_url":      tt.templateData.DetectionURL,
 					"bg_image_url":          tt.templateData.ImageURL,
 					"bg_confidence_percent": tt.templateData.ConfidencePercent,

--- a/internal/notification/template_data.go
+++ b/internal/notification/template_data.go
@@ -21,6 +21,8 @@ type TemplateData struct {
 	Latitude           float64
 	Longitude          float64
 	Location           string
+	DetectionID        string
+	DetectionPath      string
 	DetectionURL       string
 	ImageURL           string
 	DaysSinceFirstSeen int
@@ -65,12 +67,14 @@ func NewTemplateData(event events.DetectionEvent, baseURL string, timeAs24h bool
 		noteID = fmt.Sprintf("%d", id)
 	}
 
-	var detectionURL string
+	var detectionPath string
 	if noteID != "" {
-		detectionURL = fmt.Sprintf("%s/ui/detections/%s", baseURL, noteID)
+		detectionPath = fmt.Sprintf("/ui/detections/%s", noteID)
 	} else {
-		detectionURL = fmt.Sprintf("%s/ui/detections", baseURL)
+		detectionPath = "/ui/detections"
 	}
+
+	detectionURL := baseURL + detectionPath
 
 	scientificName := event.GetScientificName()
 
@@ -95,6 +99,8 @@ func NewTemplateData(event events.DetectionEvent, baseURL string, timeAs24h bool
 		Latitude:           latitude,
 		Longitude:          longitude,
 		Location:           location,
+		DetectionID:        noteID,
+		DetectionPath:      detectionPath,
 		DetectionURL:       detectionURL,
 		ImageURL:           imageURL,
 		DaysSinceFirstSeen: event.GetDaysSinceFirstSeen(),


### PR DESCRIPTION
Useful if the user wants to make their own url instead of using DetectionURL (usually because server is proxied in some way)

As requested in https://github.com/tphakala/birdnet-go/discussions/1355#discussioncomment-14851879

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added DetectionID and DetectionPath as template variables for notification customization, enabling richer message composition.
  * DetectionURL now reflects a full URL format for consistent, clickable links in notifications.
  * Notifications now include the new detection metadata so templates and previews can surface direct detection links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->