### PR TITLE
Add url encoding to user given city location

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3209,8 +3209,10 @@ configure_location() {
                     fi
                     
                     # Split input into city and country
-                    city=$(echo "$location" | cut -d',' -f1 | xargs)
-                    country=$(echo "$location" | cut -d',' -f2 | xargs)
+                    city_raw=$(echo "$location" | cut -d',' -f1 | xargs)
+                    country_raw=$(echo "$location" | cut -d',' -f2 | xargs)
+                    city=$(printf '%s' "$city_raw" | jq -Rs '@uri')
+                    country=$(printf '%s' "$country_raw" | jq -Rs '@uri')
                     
                     if [ -z "$city" ] || [ -z "$country" ]; then
                         print_message "❌ Invalid format. Please use format: 'City, Country'" "$RED"


### PR DESCRIPTION
Sometimes you just might live somewhere with eg. umlauts in the name :)  
"Piikkiö, Finland" resulted in `jq: parse error: Invalid numeric literal at line 1, column 8` because the curl would result in `Invalid HTTP request received` when not using url encoded strings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Setup configuration now URI-encodes city and country inputs before geocoding lookups, preventing malformed location queries.
  * Improves handling of locations with special characters, reducing failures or misrouting in external map/geocoding requests and making initial configuration more reliable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->