### PR TITLE
fix(frontend): correct review detection API endpoint path

### DIFF
--- a/frontend/src/lib/desktop/components/modals/ReviewModal.svelte
+++ b/frontend/src/lib/desktop/components/modals/ReviewModal.svelte
@@ -62,13 +62,12 @@
         const desiredLockState = detection.locked ? !lockDetection : lockDetection;
 
         // Default save implementation
-        await fetchWithCSRF('/api/v2/detections/review', {
+        await fetchWithCSRF(`/api/v2/detections/${detection.id}/review`, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
           },
           body: JSON.stringify({
-            id: detection.id,
             verified: reviewStatus,
             lock_detection: desiredLockState,
             ignore_species: ignoreSpecies ? detection.commonName : null,


### PR DESCRIPTION
## Summary
- Fixed 404 error when saving detection reviews in the modern UI
- Updated API endpoint URL from `/api/v2/detections/review` to `/api/v2/detections/:id/review`
- Removed `id` from request body (now in URL path as expected by backend)

## Test plan
- [ ] Navigate to dashboard
- [ ] Click three dots on a detection → "Review Detection"
- [ ] Select review status and click "Save Review"
- [ ] Verify no error and detection updates correctly

Fixes #1504

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated detection review API endpoint to use dynamic detection identifiers instead of static routes
  * Refined request payload by removing redundant identifiers to align with API specifications

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->