### PR TITLE
fix(frontend): make detection detail tabs scrollable on mobile

### DIFF
--- a/frontend/src/lib/desktop/views/DetectionDetail.svelte
+++ b/frontend/src/lib/desktop/views/DetectionDetail.svelte
@@ -763,7 +763,7 @@
       <div class="card-body">
         <h2 id="tabs-heading" class="sr-only">Detection information tabs</h2>
         <!-- Tab Navigation -->
-        <div class="tabs tabs-boxed mb-6" role="tablist" aria-label="Detection details tabs">
+        <div class="tabs tabs-boxed mb-6 overflow-x-auto flex-nowrap" role="tablist" aria-label="Detection details tabs">
           <button
             id="tab-overview"
             role="tab"


### PR DESCRIPTION
## Summary
- Fixed tabs not visible on mobile devices in detection details view
- Added `overflow-x-auto` and `flex-nowrap` to tabs container for horizontal scrolling
- All 5 tabs (Overview, Taxonomy, History, Notes, Review) now accessible on narrow screens

## Test plan
- [ ] Open detection detail page on mobile viewport (~400px width)
- [ ] Verify all tabs are accessible via horizontal scroll
- [ ] Verify tab switching still works correctly
- [ ] Test keyboard navigation (Arrow keys)

Fixes #1511

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved tab navigation scrolling and layout behavior in the Detection details view.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->