### PR TITLE
fix(spectrogram): always provide duration parameter to Sox

### DIFF
--- a/internal/spectrogram/generator_test.go
+++ b/internal/spectrogram/generator_test.go
@@ -98,15 +98,15 @@ func TestGenerator_GetSoxSpectrogramArgs(t *testing.T) {
 		raw          bool
 		ffmpegMajor  int
 		hasFfmpegVer bool
-		wantDuration bool // Whether we expect -d parameter
+		wantDuration bool // Whether we expect -d parameter (always true after #1484 fix)
 	}{
 		{
-			name:         "FFmpeg 7.x, no duration needed",
+			name:         "FFmpeg 7.x, duration always needed",
 			width:        800,
 			raw:          false,
 			ffmpegMajor:  7,
 			hasFfmpegVer: true,
-			wantDuration: false,
+			wantDuration: true, // Changed: duration now always required (fixes #1484)
 		},
 		{
 			name:         "FFmpeg 5.x, duration needed",
@@ -125,12 +125,12 @@ func TestGenerator_GetSoxSpectrogramArgs(t *testing.T) {
 			wantDuration: true,
 		},
 		{
-			name:         "Raw mode enabled",
+			name:         "Raw mode with duration",
 			width:        400,
 			raw:          true,
 			ffmpegMajor:  7,
 			hasFfmpegVer: true,
-			wantDuration: false,
+			wantDuration: true, // Changed: duration now always required (fixes #1484)
 		},
 	}
 


### PR DESCRIPTION

  ## Summary

  - Fixes spectrogram time scale issue where images showed truncated audio durations based on pixel width
  - Removes incorrect FFmpeg 7.x+ optimization that skipped the  (duration) parameter
  - Ensures spectrograms correctly represent the full audio duration regardless of image size

  ## Problem

  Spectrograms showed different amounts of audio time depending on image width:
  - 400px → only 4 seconds of audio
  - 800px → only 8 seconds of audio  
  - 1200px → only 12 seconds of audio

  But audio files are 15 seconds long, causing misalignment between spectrogram display and audio playback in the UI.

  ## Root Cause

  The FFmpeg 7.x+ code path incorrectly skipped the  duration parameter to Sox, assuming FFmpeg would pass duration 
  metadata through the sox protocol. Without , Sox interprets the  (width in pixels) as seconds of audio time.

  ## Changes

  - : Always provide  duration parameter to Sox
  - : Updated test expectations

  ## Test plan

  - [x] Unit tests pass (`go test -v ./internal/spectrogram/...`)
  - [x] Linter passes (`golangci-lint run -v`)
  - [x] Manual test: Verify spectrograms at different sizes show full 15s audio duration

  Fixes #1484

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved spectrogram generation to reliably handle audio duration parameters. Now includes consistent duration handling with automatic fallback to configured defaults when audio metadata is unavailable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->