### PR TITLE
fix(frontend): address Tailwind v4/DaisyUI 5 migration review feedback

### DIFF
--- a/frontend/src/lib/components/ui/SpeciesSelector.svelte
+++ b/frontend/src/lib/components/ui/SpeciesSelector.svelte
@@ -495,7 +495,7 @@
             {placeholder}
             aria-label="Search species"
             class={cn(
-              'input  w-full',
+              'input w-full',
               /* eslint-disable-next-line security/detect-object-injection -- Safe: size prop is constrained to specific string literals */
               sizeConfig[size].input
             )}

--- a/frontend/src/lib/desktop/components/forms/FormField.test.ts
+++ b/frontend/src/lib/desktop/components/forms/FormField.test.ts
@@ -52,7 +52,7 @@ describe('FormField', () => {
       expect(onChange).toHaveBeenLastCalledWith('testuser');
     });
 
-    it('shows validation errors after blur-xs', async () => {
+    it('shows validation errors after blur', async () => {
       const user = userEvent.setup();
 
       formFieldTest.render({

--- a/frontend/src/lib/desktop/components/ui/Input.svelte
+++ b/frontend/src/lib/desktop/components/ui/Input.svelte
@@ -66,6 +66,6 @@
   {step}
   {pattern}
   {maxlength}
-  class={cn('input  w-full', className)}
+  class={cn('input w-full', className)}
   {...rest}
 />

--- a/frontend/src/lib/desktop/components/ui/LanguageSelector.svelte
+++ b/frontend/src/lib/desktop/components/ui/LanguageSelector.svelte
@@ -2,6 +2,7 @@
   import { getLocale, setLocale } from '$lib/i18n/store.svelte.js';
   import { LOCALES, type Locale } from '$lib/i18n/config.js';
   import { t } from '$lib/i18n';
+  import { cn } from '$lib/utils/cn';
 
   // Props
   interface Props {
@@ -33,12 +34,12 @@
 </script>
 
 <select
-  class="select select-sm {className}"
+  class={cn('select select-sm', className)}
   value={currentLocale}
   onchange={handleLanguageChange}
   aria-label={t('common.aria.selectLanguage')}
 >
-  {#each Object.entries(LOCALES) as [code, { name, flag }]}
+  {#each Object.entries(LOCALES) as [code, { name, flag }] (code)}
     <option value={code}>
       {flag}
       {name}

--- a/frontend/src/lib/desktop/components/ui/Select.svelte
+++ b/frontend/src/lib/desktop/components/ui/Select.svelte
@@ -26,12 +26,12 @@
   }: Props = $props();
 </script>
 
-<select {id} bind:value class={cn('select  w-full', className)} {disabled} {...rest}>
+<select {id} bind:value class={cn('select w-full', className)} {disabled} {...rest}>
   {#if placeholder}
     <option value="" disabled>{placeholder}</option>
   {/if}
 
-  {#each options as option}
+  {#each options as option (option.value)}
     <option value={option.value}>{option.label}</option>
   {/each}
 </select>

--- a/frontend/src/lib/desktop/features/analytics/pages/Species.svelte
+++ b/frontend/src/lib/desktop/features/analytics/pages/Species.svelte
@@ -439,7 +439,7 @@
         <h2 class="card-title">{t('analytics.species.speciesList')}</h2>
         <div class="join">
           <button
-            class="btn btn-sm"
+            class="btn btn-sm join-item"
             class:btn-active={viewMode === 'grid'}
             onclick={() => (viewMode = 'grid')}
             aria-label={t('analytics.species.switchToGrid')}
@@ -456,7 +456,7 @@
             </svg>
           </button>
           <button
-            class="btn btn-sm"
+            class="btn btn-sm join-item"
             class:btn-active={viewMode === 'list'}
             onclick={() => (viewMode = 'list')}
             aria-label={t('analytics.species.switchToList')}

--- a/frontend/src/lib/utils/z-index.ts
+++ b/frontend/src/lib/utils/z-index.ts
@@ -54,11 +54,11 @@ export const Z_INDEX = {
  * element.style.zIndex = Z_INDEX.MODAL.toString();
  * ```
  *
- * In Tailwind CSS classes:
+ * In Tailwind CSS classes (use arbitrary value syntax for non-standard values):
  * ```svelte
- * <div class="z-100">  <!-- Use Z_INDEX.DROPDOWN value -->
- * <div class="z-1000"> <!-- Use Z_INDEX.PORTAL_DROPDOWN value -->
- * <div class="z-1010"> <!-- Use Z_INDEX.NOTIFICATION_DROPDOWN value -->
+ * <div class="z-[100]">  <!-- Use Z_INDEX.DROPDOWN value -->
+ * <div class="z-[1000]"> <!-- Use Z_INDEX.PORTAL_DROPDOWN value -->
+ * <div class="z-[1010]"> <!-- Use Z_INDEX.NOTIFICATION_DROPDOWN value -->
  * ```
  *
  * In inline styles:


### PR DESCRIPTION
## Summary
Addresses code review feedback from the Tailwind v4.1 / DaisyUI 5 migration PR (#1532).

### Changes
- **DaisyUI 5 fix**: Add `join-item` class to view toggle buttons in Species.svelte for proper join styling
- **Test fix**: Correct test description typo "blur-xs" → "blur" in FormField.test.ts
- **Code cleanup**: Remove double spaces in CSS class strings (Input, Select, SpeciesSelector)
- **Documentation**: Update z-index.ts examples to use Tailwind arbitrary value syntax `z-[100]`
- **Consistency**: Use `cn()` helper for class composition in LanguageSelector.svelte
- **Performance**: Add missing keys to `{#each}` blocks for better Svelte 5 reconciliation

### Files Changed
- `frontend/src/lib/desktop/features/analytics/pages/Species.svelte`
- `frontend/src/lib/desktop/components/forms/FormField.test.ts`
- `frontend/src/lib/desktop/components/ui/Input.svelte`
- `frontend/src/lib/desktop/components/ui/Select.svelte`
- `frontend/src/lib/desktop/components/ui/LanguageSelector.svelte`
- `frontend/src/lib/components/ui/SpeciesSelector.svelte`
- `frontend/src/lib/utils/z-index.ts`

### Linear Issues
Closes BG-30, BG-31, BG-32, BG-33, BG-34, BG-35

## Test plan
- [x] All frontend quality checks pass (`npm run check:all`)
- [x] Svelte autofixer reports no issues
- [ ] Visual verification of join buttons in Species page
- [ ] Verify form validation still works correctly