### PR TITLE
fix(macos): add macOS support for air realtime and audio devices

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -30,13 +30,32 @@ tmp_dir = "tmp"  # Temporary directory for build artifacts
     # Enable CGO for TensorFlow Lite integration
     export CGO_ENABLED=1
     export CGO_CFLAGS="-I${HOME}/src/tensorflow"
-    export CGO_LDFLAGS="-L/usr/lib -ltensorflowlite_c"
+
+    # Set library paths based on OS
+    if [ "$(uname)" = "Darwin" ]; then
+      # macOS: use Homebrew lib path (works for both ARM64 and Intel)
+      TFLITE_LIB_DIR="/opt/homebrew/lib"
+      if [ ! -d "$TFLITE_LIB_DIR" ]; then
+        TFLITE_LIB_DIR="/usr/local/lib"
+      fi
+    else
+      # Linux
+      TFLITE_LIB_DIR="/usr/lib"
+    fi
+
+    export CGO_LDFLAGS="-L${TFLITE_LIB_DIR} -ltensorflowlite_c"
 
     # Build the Go application with version and build date
-    go build -v -x -ldflags "-s -w -r /usr/lib -r /usr/local/lib \
+    go build -ldflags "-s -w -r /usr/local/lib \
       -X 'main.buildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ)' \
       -X 'main.version=$(git describe --tags --always)'" \
       -o ./tmp/main .
+
+    # On macOS, add the Homebrew library path to rpath since Go's -r flag
+    # doesn't properly handle multiple rpaths
+    if [ "$(uname)" = "Darwin" ]; then
+      install_name_tool -add_rpath "${TFLITE_LIB_DIR}" ./tmp/main 2>/dev/null || true
+    fi
   """
 
   bin = "./tmp/main"  # Path to the compiled binary

--- a/internal/myaudio/capture.go
+++ b/internal/myaudio/capture.go
@@ -495,8 +495,9 @@ func selectCaptureSource(settings *conf.Settings) (captureSource, error) {
 
 // matchesDeviceSettings checks if the device matches the settings specified by the user.
 func matchesDeviceSettings(decodedID string, info *malgo.DeviceInfo, audioSource string) bool {
-	if runtime.GOOS == "windows" && audioSource == "sysdefault" {
-		// On Windows, there is no "sysdefault" device. Use miniaudio's default device instead.
+	// Handle "default" and "sysdefault" on Windows and macOS by selecting the system default device
+	if (runtime.GOOS == "windows" || runtime.GOOS == "darwin") &&
+		(audioSource == "sysdefault" || audioSource == "default") {
 		return info.IsDefault == 1
 	}
 	// Check if the decoded ID or device name matches the user's setting.


### PR DESCRIPTION
## Summary

- Add `install_name_tool` post-build step in `.air.toml` to fix TensorFlow Lite runtime library path on macOS
- Extend `matchesDeviceSettings()` to handle "default" and "sysdefault" audio sources on macOS

## Problem

On macOS, `air realtime` fails with:
1. **Library load error**: Go's `-r` linker flag doesn't properly handle multiple rpaths, so the TensorFlow Lite library at `/opt/homebrew/lib` isn't found at runtime
2. **Audio device not found**: The `matchesDeviceSettings()` function only handled "sysdefault" on Windows, causing macOS to fail when trying to use the default audio device

## Solution

1. **Build fix**: Added OS detection and `install_name_tool -add_rpath` post-build step on macOS to properly set the runtime library search path
2. **Audio fix**: Extended the device matching logic to handle both "default" and "sysdefault" on macOS by selecting the system default device (`info.IsDefault == 1`)

## Test plan

- [x] Verified `air realtime` builds successfully on macOS ARM64
- [x] Verified TensorFlow Lite library loads at runtime
- [x] Verified default audio device is detected and selected on macOS
- [x] Verified audio capture works with built-in microphone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Default audio device detection on macOS and Windows now treats both system default and default indicators equally.

* **Chores**
  * Build configuration now uses operating system-aware logic for library paths: `/opt/homebrew/lib` (fallback to `/usr/local/lib`) on macOS and `/usr/lib` on Linux.
  * Adjusted Go build flags and added macOS-specific post-build step for library path configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->