### PR TITLE
fix(build): add lint task with TensorFlow CGO flags

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -59,6 +59,32 @@ tasks:
     vars:
       TEST_FLAGS: '{{default "" .CLI_ARGS}}'
 
+  # Go linting with CGO support for TensorFlow
+  lint:
+    desc: Run golangci-lint with TensorFlow CGO flags
+    cmds:
+      - |
+        # Determine library path based on OS
+        if [ "{{.UNAME_S}}" = "Darwin" ]; then
+          if [ "{{.UNAME_M}}" = "arm64" ]; then
+            LIB_DIR="/opt/homebrew/lib"
+          else
+            LIB_DIR="/usr/local/lib"
+          fi
+        else
+          LIB_DIR="/usr/lib"
+        fi
+        {{.CGO_FLAGS}} CGO_LDFLAGS="-L${LIB_DIR} -ltensorflowlite_c" \
+        golangci-lint run {{.CLI_ARGS}}
+    vars:
+      CLI_ARGS: '{{default "-v" .CLI_ARGS}}'
+
+  lint-fix:
+    desc: Run golangci-lint with auto-fix enabled
+    cmds:
+      - task: lint
+        vars: {CLI_ARGS: "--fix -v"}
+
   # New Task: Download Avicommons Data
   download-avicommons-data:
     desc: Download the Avicommons latest.json data file if it doesn't exist


### PR DESCRIPTION
## Summary

- Add `task lint` and `task lint-fix` commands that set CGO environment variables for TensorFlow Lite
- Fixes `typecheck` linter error: `fatal error: 'tensorflow/lite/c/c_api.h' file not found`
- Auto-detects platform (Darwin arm64/amd64, Linux) for correct library paths

## Changes

- Added `lint` task that runs golangci-lint with proper CGO_CFLAGS and CGO_LDFLAGS
- Added `lint-fix` convenience task for auto-fixing linter issues
- Reuses existing `CGO_FLAGS` variable from Taskfile for consistency

## Testing

- [x] `task lint` runs successfully without TensorFlow header errors
- [x] `task lint-fix` works correctly
- [x] Tasks appear in `task --list`

## Related Issues

Fixes development workflow issue where running `golangci-lint run -v` directly fails due to missing CGO flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `lint` task for executing code linting checks with customizable command-line arguments and verbose output enabled by default
  * Added `lint-fix` task to automatically fix code issues detected during the linting process
  * Both tasks include intelligent operating system detection to ensure proper configuration across different environments

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->