### PR TITLE
fix(build): update Air config for v1.63+ compatibility

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -39,18 +39,18 @@ tmp_dir = "tmp"  # Temporary directory for build artifacts
       -o ./tmp/main .
   """
 
-  bin = "./tmp/main"  # Path to the compiled binary
+  entrypoint = ["./tmp/main"]  # Path to the compiled binary
   delay = 1000  # Delay (in milliseconds) before restarting the app after a change
   rerun_delay = 5000
 
   # Directories to exclude from watching
   # Frontend is excluded - use 'task frontend-watch' for frontend changes
-  exclude_dir = ["tmp", "vendor", "testdata", "bin", "frontend", "node_modules"]
+  exclude_dir = ["tmp", "vendor", "testdata", "bin", "frontend", "node_modules", "dist", ".git"]
   exclude_file = []  # Files to exclude from watching (none specified)
   exclude_regex = ["_test.go"]  # Exclude test files
   exclude_unchanged = false  # Watch even files that haven't changed
   follow_symlink = false  # Don't follow symlinks
-  full_bin = ""  # Additional arguments when running the built binary
+  args_bin = []  # Additional arguments when running the built binary
   # Only watch Go backend files - frontend is handled by 'task frontend-watch'
   include_dir = ["views", "internal", "assets", "cmd", "pkg"]
   include_ext = ["go", "tpl", "tmpl", "html", "css"]  # File extensions to watch


### PR DESCRIPTION
## Summary

Updates `.air.toml` to use Air v1.63+ configuration format, fixing deprecation warnings.

## Changes

- Replace deprecated `bin` with `entrypoint` array format
- Replace deprecated `full_bin` with `args_bin`  
- Add `dist` and `.git` to exclude_dir for cleaner watching

## Testing

- Verified `air realtime` no longer shows deprecation warning
- Confirmed proper directory exclusions are working

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development configuration format for entry point handling from string to array structure
  * Expanded directory exclusions list for file watching to include additional folders

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->