### PR TITLE
fix(frontend): remove build.watch that causes npm run build to hang

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -77,13 +77,6 @@ export default defineConfig({
     outDir: 'dist',
     chunkSizeWarningLimit: 1000,
     emptyOutDir: true,
-    // Watch mode configuration for reliable file change detection
-    watch: {
-      chokidar: {
-        usePolling: true,
-        interval: 300,
-      },
-    },
     rollupOptions: {
       output: {
         entryFileNames: '[name].js',


### PR DESCRIPTION
## Summary

- Removes the `build.watch` configuration from vite.config.js that causes `npm run build` to hang indefinitely

## Problem

The `build.watch` configuration in the `build:` section of vite.config.js causes Vite to run in watch mode during production builds. This makes `npm run build` display "watching for file changes..." and never exit.

This was introduced in #1536 where the watch config was likely intended for development but was mistakenly placed in the `build:` section instead of `server:`.

## Fix

Remove the watch configuration from the build section entirely. The server section already handles dev server needs, and production builds should never watch for file changes.

## Test plan

- [x] Run `npm run build` - completes in ~10 seconds instead of hanging forever
- [x] Verify build output is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed polling-based file watching configuration from the build system.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->