### PR TITLE
fix(api): add toggle support to v2 species ignore endpoint

### DIFF
--- a/internal/api/v2/README.md
+++ b/internal/api/v2/README.md
@@ -107,7 +107,8 @@ routeInitializers := []struct {
 | DELETE | `/detections/:id`             | `DeleteDetection`       | ✅   | Delete detection record     |
 | POST   | `/detections/:id/review`      | `ReviewDetection`       | ✅   | Review/verify detection     |
 | POST   | `/detections/:id/lock`        | `LockDetection`         | ✅   | Lock detection from changes |
-| POST   | `/detections/ignore`          | `IgnoreSpecies`         | ✅   | Add species to ignore list  |
+| POST   | `/detections/ignore`          | `IgnoreSpecies`         | ✅   | Toggle species in ignore list (add/remove) |
+| GET    | `/detections/ignored`         | `GetExcludedSpecies`    | ✅   | Get list of excluded species |
 
 ### Integrations (`integrations.go`)
 


### PR DESCRIPTION
## Summary

The v2 `/api/v2/detections/ignore` endpoint only supported adding species to the exclusion list but had no way to remove them. This broke the frontend's toggle functionality for ignoring/unignoring species.

**Changes:**
- `POST /api/v2/detections/ignore` now toggles species (adds if not present, removes if present), matching v1 behavior
- Returns a JSON response with `action` ("added" or "removed"), `common_name`, and `is_excluded` state
- Added `GET /api/v2/detections/ignored` endpoint to retrieve the current exclusion list
- Added comprehensive unit tests including toggle behavior, error cases, and concurrency tests

**Response Format (POST /api/v2/detections/ignore):**
```json
{
  "common_name": "American Crow",
  "action": "added",
  "is_excluded": true
}
```

**Response Format (GET /api/v2/detections/ignored):**
```json
{
  "species": ["American Crow", "House Sparrow"],
  "count": 2
}
```

## Test plan

- [x] Unit tests pass (`go test -race -run "TestIgnoreSpecies|TestGetExcludedSpecies" ./internal/api/v2/...`)
- [x] Linter passes (`golangci-lint run ./internal/api/v2/...`)
- [ ] Manual test: Toggle a species to ignored state
- [ ] Manual test: Toggle same species to remove from ignored
- [ ] Manual test: GET /api/v2/detections/ignored returns correct list

Fixes #1549