### PR TITLE
fix(species): update hemisphere seasons even when defaults exist

### DIFF
--- a/internal/analysis/species/species_tracker_hemisphere_bug_test.go
+++ b/internal/analysis/species/species_tracker_hemisphere_bug_test.go
@@ -1,0 +1,401 @@
+package species
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/conf"
+)
+
+// TestSouthernHemisphereSeasonBug_Issue1524 reproduces the bug reported in issue #1524
+// where users in the Southern hemisphere see Northern hemisphere seasons (e.g., "fall")
+// when they should see Southern hemisphere seasons (e.g., "spring").
+//
+// ROOT CAUSE IDENTIFIED:
+// GetSeasonalTrackingWithHemisphere only populates seasons if len(Seasons) == 0.
+// If a user already has Northern hemisphere seasons saved in their config (from before
+// the fix, or from initializeDefaultSeasons fallback), they won't be updated.
+//
+// This test reproduces the exact bug scenario:
+// 1. User has pre-existing Northern hemisphere seasons in config
+// 2. User is in Southern hemisphere
+// 3. GetSeasonalTrackingWithHemisphere is called but doesn't update seasons
+// 4. User sees incorrect seasons
+func TestSouthernHemisphereSeasonBug_Issue1524(t *testing.T) {
+	t.Parallel()
+
+	// Southern hemisphere latitude (e.g., Sydney, Australia)
+	southernLatitude := -33.8688
+
+	// THE BUG: User has Northern hemisphere seasons pre-saved in their config
+	// This happens when:
+	// - User upgraded from before the hemisphere fix
+	// - Config was initialized with Northern defaults before latitude was set
+	// - User imported someone else's config
+	northernHemisphereSeasons := map[string]conf.Season{
+		"spring": {StartMonth: 3, StartDay: 20},  // March 20 (Northern)
+		"summer": {StartMonth: 6, StartDay: 21},  // June 21 (Northern)
+		"fall":   {StartMonth: 9, StartDay: 22},  // September 22 (Northern)
+		"winter": {StartMonth: 12, StartDay: 21}, // December 21 (Northern)
+	}
+
+	testCases := []struct {
+		name           string
+		date           time.Time
+		expectedSeason string
+		description    string
+	}{
+		{
+			name:           "December25_ShouldBeSummer_NotWinter",
+			date:           time.Date(2025, 12, 25, 12, 0, 0, 0, time.UTC),
+			expectedSeason: "summer", // Expected for Southern hemisphere
+			description:    "December 25 in Southern hemisphere should be summer, not winter",
+		},
+		{
+			name:           "January_ShouldBeSummer_NotWinter",
+			date:           time.Date(2025, 1, 15, 12, 0, 0, 0, time.UTC),
+			expectedSeason: "summer",
+			description:    "January in Southern hemisphere should be summer, not winter",
+		},
+		{
+			name:           "April_ShouldBeFall_NotSpring",
+			date:           time.Date(2025, 4, 15, 12, 0, 0, 0, time.UTC),
+			expectedSeason: "fall",
+			description:    "April in Southern hemisphere should be fall, not spring",
+		},
+		{
+			name:           "July_ShouldBeWinter_NotSummer",
+			date:           time.Date(2025, 7, 15, 12, 0, 0, 0, time.UTC),
+			expectedSeason: "winter",
+			description:    "July in Southern hemisphere should be winter, not summer",
+		},
+		{
+			name:           "October_ShouldBeSpring_NotFall",
+			date:           time.Date(2025, 10, 15, 12, 0, 0, 0, time.UTC),
+			expectedSeason: "spring",
+			description:    "October in Southern hemisphere should be spring, not fall",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Step 1: Create settings with EXISTING Northern hemisphere seasons
+			// This simulates a user who has an old config with Northern seasons
+			settings := &conf.SpeciesTrackingSettings{
+				Enabled:              true,
+				NewSpeciesWindowDays: 14,
+				SyncIntervalMinutes:  60,
+				SeasonalTracking: conf.SeasonalTrackingSettings{
+					Enabled:    true,
+					WindowDays: 21,
+					Seasons:    northernHemisphereSeasons, // PRE-EXISTING Northern seasons!
+				},
+			}
+
+			// Step 2: Call GetSeasonalTrackingWithHemisphere with Southern latitude
+			// BUG: This should update seasons for Southern hemisphere, but it doesn't
+			// because len(settings.Seasons) > 0
+			hemisphereAwareSettings := *settings
+			if hemisphereAwareSettings.SeasonalTracking.Enabled {
+				hemisphereAwareSettings.SeasonalTracking = conf.GetSeasonalTrackingWithHemisphere(
+					hemisphereAwareSettings.SeasonalTracking,
+					southernLatitude,
+				)
+			}
+
+			// Step 3: Create tracker from hemisphere-aware settings
+			tracker := NewTrackerFromSettings(nil, &hemisphereAwareSettings)
+			require.NotNil(t, tracker)
+
+			// Step 4: Verify that seasons were correctly updated for Southern hemisphere
+			// BUG: The seasons are NOT updated because GetSeasonalTrackingWithHemisphere
+			// only sets seasons when len(Seasons) == 0
+			//
+			// Expected Southern hemisphere seasons:
+			// - Spring: September 22
+			// - Summer: December 21
+			// - Fall: March 20
+			// - Winter: June 21
+
+			// Step 5: Check the actual season detection
+			actualSeason := tracker.getCurrentSeason(tc.date)
+			assert.Equal(t, tc.expectedSeason, actualSeason,
+				"BUG #1524: %s - got %s instead of %s",
+				tc.description, actualSeason, tc.expectedSeason)
+		})
+	}
+}
+
+// TestGetSeasonalTrackingWithHemisphere_ShouldUpdateExistingSeasons tests that
+// GetSeasonalTrackingWithHemisphere correctly updates seasons even when seasons
+// already exist in the configuration.
+//
+// This is the core fix needed for issue #1524.
+func TestGetSeasonalTrackingWithHemisphere_ShouldUpdateExistingSeasons(t *testing.T) {
+	t.Parallel()
+
+	// Pre-existing Northern hemisphere seasons (the bug scenario)
+	northernSeasons := map[string]conf.Season{
+		"spring": {StartMonth: 3, StartDay: 20},
+		"summer": {StartMonth: 6, StartDay: 21},
+		"fall":   {StartMonth: 9, StartDay: 22},
+		"winter": {StartMonth: 12, StartDay: 21},
+	}
+
+	testCases := []struct {
+		name             string
+		latitude         float64
+		expectedSeasons  map[string]conf.Season
+		description      string
+	}{
+		{
+			name:     "SouthernHemisphere_ShouldOverrideNorthernSeasons",
+			latitude: -33.8688, // Sydney
+			expectedSeasons: map[string]conf.Season{
+				"spring": {StartMonth: 9, StartDay: 22},  // September
+				"summer": {StartMonth: 12, StartDay: 21}, // December
+				"fall":   {StartMonth: 3, StartDay: 20},  // March
+				"winter": {StartMonth: 6, StartDay: 21},  // June
+			},
+			description: "Southern hemisphere should have inverted seasons",
+		},
+		{
+			name:     "NorthernHemisphere_ShouldKeepNorthernSeasons",
+			latitude: 60.1699, // Helsinki
+			expectedSeasons: map[string]conf.Season{
+				"spring": {StartMonth: 3, StartDay: 20},
+				"summer": {StartMonth: 6, StartDay: 21},
+				"fall":   {StartMonth: 9, StartDay: 22},
+				"winter": {StartMonth: 12, StartDay: 21},
+			},
+			description: "Northern hemisphere should keep Northern seasons",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Start with Northern hemisphere seasons
+			settings := conf.SeasonalTrackingSettings{
+				Enabled:    true,
+				WindowDays: 21,
+				Seasons:    northernSeasons,
+			}
+
+			// Apply hemisphere detection
+			result := conf.GetSeasonalTrackingWithHemisphere(settings, tc.latitude)
+
+			// Verify seasons were correctly updated for the hemisphere
+			for seasonName, expectedSeason := range tc.expectedSeasons {
+				actualSeason, exists := result.Seasons[seasonName]
+				assert.True(t, exists, "Season %s should exist", seasonName)
+				assert.Equal(t, expectedSeason.StartMonth, actualSeason.StartMonth,
+					"%s: %s season should start in month %d, got %d",
+					tc.description, seasonName, expectedSeason.StartMonth, actualSeason.StartMonth)
+				assert.Equal(t, expectedSeason.StartDay, actualSeason.StartDay,
+					"%s: %s season should start on day %d, got %d",
+					tc.description, seasonName, expectedSeason.StartDay, actualSeason.StartDay)
+			}
+		})
+	}
+}
+
+// TestNorthernHemisphereSeasonDetection_Baseline verifies Northern hemisphere still works correctly
+// This is a baseline test to ensure we don't break existing functionality when fixing #1524
+func TestNorthernHemisphereSeasonDetection_Baseline(t *testing.T) {
+	t.Parallel()
+
+	// Northern hemisphere latitude (e.g., Helsinki, Finland)
+	northernLatitude := 60.1699
+
+	testCases := []struct {
+		name           string
+		date           time.Time
+		expectedSeason string
+	}{
+		{
+			name:           "December_ShouldBeWinter",
+			date:           time.Date(2025, 12, 25, 12, 0, 0, 0, time.UTC),
+			expectedSeason: "winter",
+		},
+		{
+			name:           "January_ShouldBeWinter",
+			date:           time.Date(2025, 1, 15, 12, 0, 0, 0, time.UTC),
+			expectedSeason: "winter",
+		},
+		{
+			name:           "April_ShouldBeSpring",
+			date:           time.Date(2025, 4, 15, 12, 0, 0, 0, time.UTC),
+			expectedSeason: "spring",
+		},
+		{
+			name:           "July_ShouldBeSummer",
+			date:           time.Date(2025, 7, 15, 12, 0, 0, 0, time.UTC),
+			expectedSeason: "summer",
+		},
+		{
+			name:           "October_ShouldBeFall",
+			date:           time.Date(2025, 10, 15, 12, 0, 0, 0, time.UTC),
+			expectedSeason: "fall",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			settings := &conf.SpeciesTrackingSettings{
+				Enabled:              true,
+				NewSpeciesWindowDays: 14,
+				SyncIntervalMinutes:  60,
+				SeasonalTracking: conf.SeasonalTrackingSettings{
+					Enabled:    true,
+					WindowDays: 21,
+					Seasons:    nil, // NO custom seasons
+				},
+			}
+
+			// Apply hemisphere detection
+			hemisphereAwareSettings := *settings
+			if hemisphereAwareSettings.SeasonalTracking.Enabled {
+				hemisphereAwareSettings.SeasonalTracking = conf.GetSeasonalTrackingWithHemisphere(
+					hemisphereAwareSettings.SeasonalTracking,
+					northernLatitude,
+				)
+			}
+
+			tracker := NewTrackerFromSettings(nil, &hemisphereAwareSettings)
+			require.NotNil(t, tracker)
+
+			actualSeason := tracker.getCurrentSeason(tc.date)
+			assert.Equal(t, tc.expectedSeason, actualSeason,
+				"Northern hemisphere: %s should be %s, got %s",
+				tc.date.Format("January"), tc.expectedSeason, actualSeason)
+		})
+	}
+}
+
+// TestEquatorialSeasonDetection_Baseline verifies Equatorial region still works correctly
+func TestEquatorialSeasonDetection_Baseline(t *testing.T) {
+	t.Parallel()
+
+	// Equatorial latitude (e.g., Singapore)
+	equatorialLatitude := 1.3521
+
+	testCases := []struct {
+		name           string
+		date           time.Time
+		expectedSeason string
+	}{
+		{
+			name:           "March_ShouldBeWet1",
+			date:           time.Date(2025, 3, 15, 12, 0, 0, 0, time.UTC),
+			expectedSeason: "wet1",
+		},
+		{
+			name:           "June_ShouldBeDry1",
+			date:           time.Date(2025, 6, 15, 12, 0, 0, 0, time.UTC),
+			expectedSeason: "dry1",
+		},
+		{
+			name:           "September_ShouldBeWet2",
+			date:           time.Date(2025, 9, 15, 12, 0, 0, 0, time.UTC),
+			expectedSeason: "wet2",
+		},
+		{
+			name:           "December_ShouldBeDry2",
+			date:           time.Date(2025, 12, 15, 12, 0, 0, 0, time.UTC),
+			expectedSeason: "dry2",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			settings := &conf.SpeciesTrackingSettings{
+				Enabled:              true,
+				NewSpeciesWindowDays: 14,
+				SyncIntervalMinutes:  60,
+				SeasonalTracking: conf.SeasonalTrackingSettings{
+					Enabled:    true,
+					WindowDays: 21,
+					Seasons:    nil, // NO custom seasons
+				},
+			}
+
+			// Apply hemisphere detection
+			hemisphereAwareSettings := *settings
+			if hemisphereAwareSettings.SeasonalTracking.Enabled {
+				hemisphereAwareSettings.SeasonalTracking = conf.GetSeasonalTrackingWithHemisphere(
+					hemisphereAwareSettings.SeasonalTracking,
+					equatorialLatitude,
+				)
+			}
+
+			tracker := NewTrackerFromSettings(nil, &hemisphereAwareSettings)
+			require.NotNil(t, tracker)
+
+			actualSeason := tracker.getCurrentSeason(tc.date)
+			assert.Equal(t, tc.expectedSeason, actualSeason,
+				"Equatorial: %s should be %s, got %s",
+				tc.date.Format("January"), tc.expectedSeason, actualSeason)
+		})
+	}
+}
+
+// TestSeasonOrderInitialization_SouthernHemisphere verifies that the season order cache
+// is correctly initialized for Southern hemisphere seasons
+func TestSeasonOrderInitialization_SouthernHemisphere(t *testing.T) {
+	t.Parallel()
+
+	// Create settings with Southern hemisphere seasons
+	southernSeasons := conf.GetDefaultSeasons(-45.0) // Southern hemisphere
+	settings := &conf.SpeciesTrackingSettings{
+		Enabled:              true,
+		NewSpeciesWindowDays: 14,
+		SyncIntervalMinutes:  60,
+		SeasonalTracking: conf.SeasonalTrackingSettings{
+			Enabled:    true,
+			WindowDays: 21,
+			Seasons:    southernSeasons,
+		},
+	}
+
+	tracker := NewTrackerFromSettings(nil, settings)
+	require.NotNil(t, tracker)
+
+	// Verify seasons were loaded correctly
+	assert.Len(t, tracker.seasons, 4, "Should have 4 seasons")
+
+	// Verify Southern hemisphere season dates
+	// Southern hemisphere:
+	// - Spring: September 22
+	// - Summer: December 21
+	// - Fall: March 20
+	// - Winter: June 21
+	spring, hasSpring := tracker.seasons["spring"]
+	assert.True(t, hasSpring, "Should have spring season")
+	assert.Equal(t, 9, spring.month, "Southern spring should start in September")
+	assert.Equal(t, 22, spring.day, "Southern spring should start on 22nd")
+
+	summer, hasSummer := tracker.seasons["summer"]
+	assert.True(t, hasSummer, "Should have summer season")
+	assert.Equal(t, 12, summer.month, "Southern summer should start in December")
+	assert.Equal(t, 21, summer.day, "Southern summer should start on 21st")
+
+	fall, hasFall := tracker.seasons["fall"]
+	assert.True(t, hasFall, "Should have fall season")
+	assert.Equal(t, 3, fall.month, "Southern fall should start in March")
+	assert.Equal(t, 20, fall.day, "Southern fall should start on 20th")
+
+	winter, hasWinter := tracker.seasons["winter"]
+	assert.True(t, hasWinter, "Should have winter season")
+	assert.Equal(t, 6, winter.month, "Southern winter should start in June")
+	assert.Equal(t, 21, winter.day, "Southern winter should start on 21st")
+}

--- a/internal/conf/species_tracking_test.go
+++ b/internal/conf/species_tracking_test.go
@@ -132,20 +132,20 @@ func validateSeasonConfiguration(t *testing.T, latitude float64, expectedSeasons
 func TestGetDefaultSeasons(t *testing.T) {
 	t.Run("northern hemisphere", func(t *testing.T) {
 		t.Parallel()
-		
+
 		expectedSeasons := map[string]Season{
 			"spring": {StartMonth: 3, StartDay: 20},   // March 20
 			"summer": {StartMonth: 6, StartDay: 21},   // June 21
 			"fall":   {StartMonth: 9, StartDay: 22},   // September 22
 			"winter": {StartMonth: 12, StartDay: 21},  // December 21
 		}
-		
+
 		validateSeasonConfiguration(t, 45.0, expectedSeasons, "northern hemisphere")
 	})
 
 	t.Run("southern hemisphere", func(t *testing.T) {
 		t.Parallel()
-		
+
 		// Seasons shifted by 6 months for southern hemisphere
 		expectedSeasons := map[string]Season{
 			"spring": {StartMonth: 9, StartDay: 22},   // September 22
@@ -153,13 +153,13 @@ func TestGetDefaultSeasons(t *testing.T) {
 			"fall":   {StartMonth: 3, StartDay: 20},   // March 20
 			"winter": {StartMonth: 6, StartDay: 21},   // June 21
 		}
-		
+
 		validateSeasonConfiguration(t, -45.0, expectedSeasons, "southern hemisphere")
 	})
 
 	t.Run("equatorial region", func(t *testing.T) {
 		t.Parallel()
-		
+
 		// Wet/dry season cycle for equatorial regions
 		expectedSeasons := map[string]Season{
 			"wet1": {StartMonth: 3, StartDay: 1},   // March-May wet season
@@ -167,7 +167,227 @@ func TestGetDefaultSeasons(t *testing.T) {
 			"wet2": {StartMonth: 9, StartDay: 1},   // September-November wet season
 			"dry2": {StartMonth: 12, StartDay: 1},  // December-February dry season
 		}
-		
+
 		validateSeasonConfiguration(t, 0.0, expectedSeasons, "equatorial region")
+	})
+}
+
+// TestIsDefaultSeasonConfiguration tests the isDefaultSeasonConfiguration helper function
+func TestIsDefaultSeasonConfiguration(t *testing.T) {
+	tests := []struct {
+		name     string
+		seasons  map[string]Season
+		expected bool
+	}{
+		{
+			name: "traditional seasons",
+			seasons: map[string]Season{
+				"spring": {StartMonth: 3, StartDay: 20},
+				"summer": {StartMonth: 6, StartDay: 21},
+				"fall":   {StartMonth: 9, StartDay: 22},
+				"winter": {StartMonth: 12, StartDay: 21},
+			},
+			expected: true,
+		},
+		{
+			name: "equatorial seasons",
+			seasons: map[string]Season{
+				"wet1": {StartMonth: 3, StartDay: 1},
+				"dry1": {StartMonth: 6, StartDay: 1},
+				"wet2": {StartMonth: 9, StartDay: 1},
+				"dry2": {StartMonth: 12, StartDay: 1},
+			},
+			expected: true,
+		},
+		{
+			name: "custom seasons - different names",
+			seasons: map[string]Season{
+				"rainy":  {StartMonth: 6, StartDay: 1},
+				"cool":   {StartMonth: 10, StartDay: 1},
+				"hot":    {StartMonth: 2, StartDay: 1},
+				"windy":  {StartMonth: 12, StartDay: 1},
+			},
+			expected: false,
+		},
+		{
+			name: "partial traditional seasons",
+			seasons: map[string]Season{
+				"spring": {StartMonth: 3, StartDay: 20},
+				"summer": {StartMonth: 6, StartDay: 21},
+				"autumn": {StartMonth: 9, StartDay: 22}, // "autumn" instead of "fall"
+				"winter": {StartMonth: 12, StartDay: 21},
+			},
+			expected: false,
+		},
+		{
+			name:     "empty seasons",
+			seasons:  map[string]Season{},
+			expected: false,
+		},
+		{
+			name:     "nil seasons",
+			seasons:  nil,
+			expected: false,
+		},
+		{
+			name: "only 3 seasons",
+			seasons: map[string]Season{
+				"spring": {StartMonth: 3, StartDay: 20},
+				"summer": {StartMonth: 6, StartDay: 21},
+				"fall":   {StartMonth: 9, StartDay: 22},
+			},
+			expected: false,
+		},
+		{
+			name: "5 seasons",
+			seasons: map[string]Season{
+				"spring": {StartMonth: 3, StartDay: 20},
+				"summer": {StartMonth: 6, StartDay: 21},
+				"fall":   {StartMonth: 9, StartDay: 22},
+				"winter": {StartMonth: 12, StartDay: 21},
+				"extra":  {StartMonth: 1, StartDay: 1},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := isDefaultSeasonConfiguration(tt.seasons)
+			assert.Equal(t, tt.expected, got, "isDefaultSeasonConfiguration() returned unexpected result")
+		})
+	}
+}
+
+// TestGetSeasonalTrackingWithHemisphere_Issue1524 tests the fix for issue #1524
+// where users with pre-existing Northern hemisphere seasons would not get updated
+// to Southern hemisphere seasons when their latitude indicated Southern hemisphere.
+func TestGetSeasonalTrackingWithHemisphere_Issue1524(t *testing.T) {
+	t.Run("empty seasons get populated", func(t *testing.T) {
+		t.Parallel()
+
+		settings := SeasonalTrackingSettings{
+			Enabled:    true,
+			WindowDays: 21,
+			Seasons:    nil,
+		}
+
+		result := GetSeasonalTrackingWithHemisphere(settings, -33.8688) // Sydney
+		assert.Len(t, result.Seasons, 4, "Should have 4 seasons")
+		assert.Equal(t, 9, result.Seasons["spring"].StartMonth, "Southern spring should start in September")
+	})
+
+	t.Run("northern seasons updated to southern", func(t *testing.T) {
+		t.Parallel()
+
+		// Pre-existing Northern hemisphere seasons (the bug scenario)
+		settings := SeasonalTrackingSettings{
+			Enabled:    true,
+			WindowDays: 21,
+			Seasons: map[string]Season{
+				"spring": {StartMonth: 3, StartDay: 20},
+				"summer": {StartMonth: 6, StartDay: 21},
+				"fall":   {StartMonth: 9, StartDay: 22},
+				"winter": {StartMonth: 12, StartDay: 21},
+			},
+		}
+
+		// Apply to Southern hemisphere user
+		result := GetSeasonalTrackingWithHemisphere(settings, -33.8688) // Sydney
+
+		// Verify seasons were updated to Southern hemisphere
+		assert.Equal(t, 9, result.Seasons["spring"].StartMonth, "Southern spring should start in September")
+		assert.Equal(t, 12, result.Seasons["summer"].StartMonth, "Southern summer should start in December")
+		assert.Equal(t, 3, result.Seasons["fall"].StartMonth, "Southern fall should start in March")
+		assert.Equal(t, 6, result.Seasons["winter"].StartMonth, "Southern winter should start in June")
+	})
+
+	t.Run("southern seasons kept for southern hemisphere", func(t *testing.T) {
+		t.Parallel()
+
+		// Southern hemisphere seasons already set
+		settings := SeasonalTrackingSettings{
+			Enabled:    true,
+			WindowDays: 21,
+			Seasons: map[string]Season{
+				"spring": {StartMonth: 9, StartDay: 22},
+				"summer": {StartMonth: 12, StartDay: 21},
+				"fall":   {StartMonth: 3, StartDay: 20},
+				"winter": {StartMonth: 6, StartDay: 21},
+			},
+		}
+
+		result := GetSeasonalTrackingWithHemisphere(settings, -33.8688) // Sydney
+
+		// Should stay Southern
+		assert.Equal(t, 9, result.Seasons["spring"].StartMonth, "Southern spring should stay in September")
+	})
+
+	t.Run("northern seasons kept for northern hemisphere", func(t *testing.T) {
+		t.Parallel()
+
+		settings := SeasonalTrackingSettings{
+			Enabled:    true,
+			WindowDays: 21,
+			Seasons: map[string]Season{
+				"spring": {StartMonth: 3, StartDay: 20},
+				"summer": {StartMonth: 6, StartDay: 21},
+				"fall":   {StartMonth: 9, StartDay: 22},
+				"winter": {StartMonth: 12, StartDay: 21},
+			},
+		}
+
+		result := GetSeasonalTrackingWithHemisphere(settings, 60.1699) // Helsinki
+
+		// Should stay Northern
+		assert.Equal(t, 3, result.Seasons["spring"].StartMonth, "Northern spring should stay in March")
+	})
+
+	t.Run("custom seasons preserved", func(t *testing.T) {
+		t.Parallel()
+
+		// User has custom season names
+		settings := SeasonalTrackingSettings{
+			Enabled:    true,
+			WindowDays: 21,
+			Seasons: map[string]Season{
+				"rainy": {StartMonth: 6, StartDay: 1},
+				"cool":  {StartMonth: 10, StartDay: 1},
+				"hot":   {StartMonth: 2, StartDay: 1},
+				"windy": {StartMonth: 12, StartDay: 1},
+			},
+		}
+
+		result := GetSeasonalTrackingWithHemisphere(settings, -33.8688) // Sydney
+
+		// Custom seasons should be preserved
+		assert.Equal(t, 6, result.Seasons["rainy"].StartMonth, "Custom rainy season should be preserved")
+		_, exists := result.Seasons["spring"]
+		assert.False(t, exists, "Should not add default seasons when custom seasons exist")
+	})
+
+	t.Run("equatorial to traditional - update based on latitude", func(t *testing.T) {
+		t.Parallel()
+
+		// User has equatorial seasons but is at Northern latitude
+		settings := SeasonalTrackingSettings{
+			Enabled:    true,
+			WindowDays: 21,
+			Seasons: map[string]Season{
+				"wet1": {StartMonth: 3, StartDay: 1},
+				"dry1": {StartMonth: 6, StartDay: 1},
+				"wet2": {StartMonth: 9, StartDay: 1},
+				"dry2": {StartMonth: 12, StartDay: 1},
+			},
+		}
+
+		// Apply to Northern hemisphere user (outside equatorial zone)
+		result := GetSeasonalTrackingWithHemisphere(settings, 60.1699) // Helsinki
+
+		// Should be updated to Northern hemisphere traditional seasons
+		_, hasSpring := result.Seasons["spring"]
+		assert.True(t, hasSpring, "Should have traditional spring for Northern hemisphere")
+		assert.Equal(t, 3, result.Seasons["spring"].StartMonth, "Northern spring should start in March")
 	})
 }


### PR DESCRIPTION
## Summary
Fixes #1524 - Users in the Southern hemisphere were seeing Northern hemisphere seasons even though PR #1323 was supposed to fix hemisphere detection.

## Why Users Were Still Seeing This Issue

### The Bug Scenario
1. **User is in Southern hemisphere** (e.g., Sydney, latitude -33.8°)
2. **User has Northern hemisphere seasons in their config** - This happens when:
   - User upgraded from before the hemisphere fix (PR #1323)
   - Config was initialized with Northern defaults before latitude was set
   - User imported someone else's config
3. **`GetSeasonalTrackingWithHemisphere()` is called** during processor initialization
4. **Function sees `len(Seasons) > 0`** and returns WITHOUT updating
5. **User sees wrong seasons** - e.g., "winter" in December instead of "summer"

### Root Cause
The original fix in PR #1323 only populated hemisphere-appropriate seasons when `len(Seasons) == 0`:

```go
func GetSeasonalTrackingWithHemisphere(settings SeasonalTrackingSettings, latitude float64) SeasonalTrackingSettings {
    // BUG: Only updates if Seasons is completely empty!
    if len(settings.Seasons) == 0 {
        settings.Seasons = GetDefaultSeasons(latitude)
    }
    return settings
}
```

This meant that users with **any pre-existing seasons** (even if they were Northern defaults that should be updated to Southern) would never get the correct hemisphere seasons.

## The Fix
1. Added `isDefaultSeasonConfiguration()` helper to detect if existing seasons are:
   - Traditional seasons (spring/summer/fall/winter)
   - Equatorial seasons (wet1/dry1/wet2/dry2)
   - Or custom user-defined seasons (any other names)

2. Modified `GetSeasonalTrackingWithHemisphere()` to:
   - Always update default seasons based on user's latitude
   - Preserve custom season configurations (users who defined their own season names)

## Test Plan
- [x] Added failing test reproducing exact bug scenario (TDD RED)
- [x] Implemented fix (TDD GREEN)
- [x] Added unit tests for `isDefaultSeasonConfiguration` helper
- [x] Added tests for Northern → Southern transition
- [x] Added tests for Southern → Northern transition
- [x] Added tests for Equatorial → Traditional transition
- [x] Verified custom seasons are preserved
- [x] Full test suite passes with race detection: `go test -race ./internal/analysis/species/...`
- [x] Lint passes: `golangci-lint run ./internal/conf/...`

## Files Changed
- `internal/conf/config.go` - Fix for `GetSeasonalTrackingWithHemisphere` + new helper function
- `internal/conf/species_tracking_test.go` - Unit tests for new functions
- `internal/analysis/species/species_tracker_hemisphere_bug_test.go` - Integration tests for bug fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed seasonal tracking to correctly update default seasons based on detected hemisphere while preserving custom user-defined season configurations. The system now properly adjusts season mappings when hemisphere location is identified or changed, ensuring accurate seasonal data tracking across both hemispheres.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->