### PR TITLE
fix(spectrogram): prevent memory leak and context exhaustion

### DIFF
--- a/internal/spectrogram/export_test.go
+++ b/internal/spectrogram/export_test.go
@@ -1,0 +1,62 @@
+// Package spectrogram provides test helper functions for testing cache behavior.
+// These functions are only available in test builds.
+package spectrogram
+
+import "time"
+
+// ClearAudioDurationCache clears all entries from the audio duration cache.
+// This is exported for testing purposes to ensure test isolation.
+func ClearAudioDurationCache() {
+	audioDurationCache.Lock()
+	audioDurationCache.entries = make(map[string]*durationCacheEntry)
+	audioDurationCache.Unlock()
+}
+
+// GetMaxCacheEntries returns the maximum number of cache entries allowed.
+// This is exported for testing purposes.
+func GetMaxCacheEntries() int {
+	return maxCacheEntries
+}
+
+// GetAudioDurationCacheSize returns the current number of entries in the cache.
+// This is exported for testing purposes.
+func GetAudioDurationCacheSize() int {
+	audioDurationCache.RLock()
+	defer audioDurationCache.RUnlock()
+	return len(audioDurationCache.entries)
+}
+
+// AddToCacheForTest adds an entry to the cache for testing purposes.
+// The timestamp is set to the current time.
+func AddToCacheForTest(path string, duration float64, fileSize int64) {
+	AddToCacheForTestWithTimestamp(path, duration, fileSize, time.Now())
+}
+
+// AddToCacheForTestWithTimestamp adds an entry to the cache with a specific timestamp.
+// This is exported for testing purposes.
+func AddToCacheForTestWithTimestamp(path string, duration float64, fileSize int64, timestamp time.Time) {
+	audioDurationCache.Lock()
+	evictOldCacheEntriesLocked()
+	audioDurationCache.entries[path] = &durationCacheEntry{
+		duration:  duration,
+		timestamp: timestamp,
+		fileSize:  fileSize,
+		modTime:   timestamp,
+	}
+	audioDurationCache.Unlock()
+}
+
+// HasCacheEntry checks if a cache entry exists for the given path.
+// This is exported for testing purposes.
+func HasCacheEntry(path string) bool {
+	audioDurationCache.RLock()
+	defer audioDurationCache.RUnlock()
+	_, exists := audioDurationCache.entries[path]
+	return exists
+}
+
+// GetFFmpegFallbackTimeout returns the timeout duration for FFmpeg fallback.
+// This is exported for testing purposes.
+func GetFFmpegFallbackTimeout() time.Duration {
+	return ffmpegFallbackTimeout
+}


### PR DESCRIPTION
## Summary

Fixes #1503 - Spectrogram generation failing with "signal: killed" and "context canceled" after hours of operation.

- **Cache eviction**: `audioDurationCache` now has max 1000 entries with LRU-style eviction to prevent unbounded memory growth
- **Fresh FFmpeg context**: FFmpeg fallback gets independent 60s timeout instead of reusing Sox's potentially exhausted context
- **4 new tests** added following TDD methodology

## Root Cause Analysis

1. **"signal: killed"** - Sox process terminated by Linux OOM killer due to memory pressure
2. **"context canceled"** - FFmpeg fallback failed because it reused the same context Sox had nearly exhausted before being killed

## Changes

| File | Change |
|------|--------|
| `generator.go` | Added `maxCacheEntries`, `evictOldCacheEntriesLocked()`, `CreateFreshFFmpegContext()` |
| `generator_test.go` | 4 new tests for cache cleanup and fresh context behavior |

## Test plan

- [x] All 25 spectrogram tests pass
- [x] golangci-lint reports 0 issues
- [ ] Manual verification in Docker container over extended period (requires user testing)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced audio duration cache size limits with automatic eviction to prevent unbounded memory growth.
  * Improved FFmpeg fallback timeout handling by isolating its timeout from the primary audio processing timeout, reducing fallback failures.

* **Tests**
  * Added comprehensive tests covering cache eviction behavior and FFmpeg fallback timeout/context isolation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->