### PR TITLE
fix(notification): resolve goconst and gosec linter issues

### DIFF
--- a/internal/notification/circuit_breaker.go
+++ b/internal/notification/circuit_breaker.go
@@ -31,16 +31,17 @@ const (
 )
 
 // String returns the string representation of CircuitState.
+// Uses constants from constants.go for consistent state names.
 func (s CircuitState) String() string {
 	switch s {
 	case StateClosed:
-		return "closed"
+		return circuitStateClosed
 	case StateHalfOpen:
-		return "half-open"
+		return circuitStateHalfOpen
 	case StateOpen:
-		return "open"
+		return circuitStateOpen
 	default:
-		return "unknown"
+		return circuitStateUnknown
 	}
 }
 

--- a/internal/notification/constants.go
+++ b/internal/notification/constants.go
@@ -1,0 +1,11 @@
+// Package notification provides shared constants for the notification system.
+package notification
+
+// Circuit breaker state string representations.
+// Used by both PushCircuitBreaker (circuit_breaker.go) and simpleCircuitBreaker (worker.go).
+const (
+	circuitStateClosed   = "closed"
+	circuitStateHalfOpen = "half-open"
+	circuitStateOpen     = "open"
+	circuitStateUnknown  = "unknown"
+)

--- a/internal/notification/helpers.go
+++ b/internal/notification/helpers.go
@@ -203,6 +203,12 @@ func NotifyShutdown() {
 
 // scrubContextMap sanitizes a context map for logging by removing sensitive data
 func scrubContextMap(ctx map[string]any) map[string]any {
+	// Metadata keys for context scrubbing
+	const (
+		keyMessage  = "message"
+		valRedacted = "[REDACTED]"
+	)
+
 	if ctx == nil {
 		return nil
 	}
@@ -213,7 +219,7 @@ func scrubContextMap(ctx map[string]any) map[string]any {
 		case "url", "endpoint", "uri", "rtsp_url", "stream_url":
 			// Scrub URLs
 			scrubbed[k] = privacy.AnonymizeURL(fmt.Sprint(v))
-		case "error", "message", "description", "reason":
+		case "error", keyMessage, "description", "reason":
 			// Scrub error messages
 			scrubbed[k] = privacy.ScrubMessage(fmt.Sprint(v))
 		case "ip", "client_ip", "remote_addr", "source_ip":
@@ -224,7 +230,7 @@ func scrubContextMap(ctx map[string]any) map[string]any {
 			scrubbed[k] = scrubPath(fmt.Sprint(v))
 		case "token", "api_key", "password", "secret":
 			// Never log sensitive credentials
-			scrubbed[k] = "[REDACTED]"
+			scrubbed[k] = valRedacted
 		default:
 			// Keep other values as-is
 			scrubbed[k] = v

--- a/internal/notification/helpers_test.go
+++ b/internal/notification/helpers_test.go
@@ -5,6 +5,9 @@ import (
 	"testing"
 )
 
+// Expected value for redacted credentials in scrubContextMap output
+const expectedRedactedValue = "[REDACTED]"
+
 func TestScrubContextMap(t *testing.T) {
 	t.Parallel()
 
@@ -77,9 +80,9 @@ func TestScrubContextMap(t *testing.T) {
 				"secret":   "confidential",
 			},
 			expected: func(result map[string]any) bool {
-				// All credentials should be "[REDACTED]"
+				// All credentials should be redacted
 				for k := range result {
-					if result[k] != "[REDACTED]" {
+					if result[k] != expectedRedactedValue {
 						return false
 					}
 				}
@@ -97,7 +100,7 @@ func TestScrubContextMap(t *testing.T) {
 			},
 			expected: func(result map[string]any) bool {
 				// URL should be anonymized, token redacted, others unchanged
-				return result["token"] == "[REDACTED]" &&
+				return result["token"] == expectedRedactedValue &&
 					result["count"] == 42 &&
 					result["enabled"] == true &&
 					result["metadata"] == "some data"

--- a/internal/notification/push_dispatcher.go
+++ b/internal/notification/push_dispatcher.go
@@ -521,11 +521,12 @@ func (d *pushDispatcher) waitForRetry(ctx context.Context, providerName string, 
 
 	// Add jitter: ±25% of the delay to prevent thundering herd
 	// Use math/rand/v2 for thread-safe random generation (Go 1.22+)
+	// G404: Cryptographic randomness not needed for retry jitter - this is for load distribution only
 	jitterRange := exponential * jitterPercent / 100
 	jitterMax := int64(jitterRange * 2)
 	var jitter time.Duration
 	if jitterMax > 0 {
-		jitter = time.Duration(rand.Int64N(jitterMax)) - jitterRange
+		jitter = time.Duration(rand.Int64N(jitterMax)) - jitterRange //nolint:gosec // Non-cryptographic use for load distribution
 	}
 
 	// Apply jitter and ensure final delay stays within bounds

--- a/internal/notification/push_dispatcher_test.go
+++ b/internal/notification/push_dispatcher_test.go
@@ -368,12 +368,12 @@ func TestPushDispatcher_ExponentialBackoff(t *testing.T) {
 					exponential = tt.maxDelay
 				}
 
-				// Add jitter
+				// Add jitter (mirrors production code for testing)
 				jitterRange := exponential * jitterPercent / 100
 				jitterMax := int64(jitterRange * 2)
 				var jitter time.Duration
 				if jitterMax > 0 {
-					jitter = time.Duration(rand.Int64N(jitterMax)) - jitterRange
+					jitter = time.Duration(rand.Int64N(jitterMax)) - jitterRange //nolint:gosec // Testing non-cryptographic jitter
 				}
 
 				delay := min(max(exponential+jitter, tt.baseDelay), tt.maxDelay)

--- a/internal/notification/push_script.go
+++ b/internal/notification/push_script.go
@@ -67,7 +67,9 @@ func (s *ScriptProvider) ValidateConfig() error {
 }
 
 func (s *ScriptProvider) Send(ctx context.Context, n *Notification) error {
-	cmd := exec.CommandContext(ctx, s.command, s.args...)
+	// G204: Command and args come from validated configuration, not user input.
+	// This is intentional design to allow administrators to configure custom notification scripts.
+	cmd := exec.CommandContext(ctx, s.command, s.args...) //nolint:gosec // Configuration-sourced command execution is intentional
 
 	// Environment variables
 	env := os.Environ()

--- a/internal/notification/race_test.go
+++ b/internal/notification/race_test.go
@@ -7,6 +7,9 @@ import (
 	"time"
 )
 
+// Test data constants
+const testMetadataValue1 = "value1"
+
 // TestBroadcastMetadataRace tests for the race condition where metadata is modified
 // after a notification has been broadcast to subscribers.
 //
@@ -267,7 +270,7 @@ func TestCloneProvidesSafeAccess(t *testing.T) {
 func TestCloneCreatesDeepCopy(t *testing.T) {
 	original := NewNotification(TypeInfo, PriorityMedium, "Original Title", "Original Message")
 	original.WithComponent("original-component")
-	original.WithMetadata("key1", "value1")
+	original.WithMetadata("key1", testMetadataValue1)
 	original.WithMetadata("key2", 42)
 	original.WithExpiry(time.Hour)
 
@@ -293,8 +296,8 @@ func TestCloneCreatesDeepCopy(t *testing.T) {
 	}
 
 	// Verify metadata is copied
-	if clone.Metadata["key1"] != "value1" {
-		t.Errorf("Metadata key1 mismatch: got %v, want value1", clone.Metadata["key1"])
+	if clone.Metadata["key1"] != testMetadataValue1 {
+		t.Errorf("Metadata key1 mismatch: got %v, want %s", clone.Metadata["key1"], testMetadataValue1)
 	}
 	if clone.Metadata["key2"] != 42 {
 		t.Errorf("Metadata key2 mismatch: got %v, want 42", clone.Metadata["key2"])
@@ -308,7 +311,7 @@ func TestCloneCreatesDeepCopy(t *testing.T) {
 	if original.Title != "Original Title" {
 		t.Error("Modifying clone should not affect original Title")
 	}
-	if original.Metadata["key1"] != "value1" {
+	if original.Metadata["key1"] != testMetadataValue1 {
 		t.Error("Modifying clone metadata should not affect original")
 	}
 	if _, exists := original.Metadata["newKey"]; exists {

--- a/internal/notification/service_extensions_test.go
+++ b/internal/notification/service_extensions_test.go
@@ -6,6 +6,12 @@ import (
 	"time"
 )
 
+// Test data constants
+const (
+	testValue1               = "value1"
+	expectedRateLimitErrMsg = "rate limit exceeded"
+)
+
 func TestService_CreateWithMetadata(t *testing.T) {
 	t.Parallel()
 
@@ -52,7 +58,7 @@ func testCreateWithMetadata(t *testing.T, service *Service) {
 	// Create a notification with metadata
 	notif := NewNotification(TypeInfo, PriorityLow, "Test Title", "Test Message").
 		WithComponent("test-component").
-		WithMetadata("key1", "value1").
+		WithMetadata("key1", testValue1).
 		WithMetadata("key2", 42).
 		WithMetadata("isToast", true)
 
@@ -105,8 +111,8 @@ func verifyStoredNotificationMetadata(t *testing.T, stored *Notification) {
 		t.Fatal("stored notification should have metadata")
 	}
 
-	if value, ok := stored.Metadata["key1"].(string); !ok || value != "value1" {
-		t.Errorf("metadata key1 = %v, want %v", value, "value1")
+	if value, ok := stored.Metadata["key1"].(string); !ok || value != testValue1 {
+		t.Errorf("metadata key1 = %v, want %v", value, testValue1)
 	}
 
 	if value, ok := stored.Metadata["key2"].(int); !ok || value != 42 {
@@ -193,7 +199,7 @@ func testRateLimitingWithMetadata(t *testing.T) {
 	}
 
 	// Error should indicate rate limit exceeded
-	if err2.Error() != "rate limit exceeded" {
+	if err2.Error() != expectedRateLimitErrMsg {
 		t.Errorf("Expected rate limit error, got: %v", err2)
 	}
 }

--- a/internal/notification/template_data.go
+++ b/internal/notification/template_data.go
@@ -120,9 +120,15 @@ func NewTemplateData(event events.DetectionEvent, baseURL string, timeAs24h bool
 // scheme or port (e.g., "birdnet.home.arpa" or "192.168.1.100"). The scheme and port
 // are determined by the autoTLS and port parameters.
 func BuildBaseURL(host, port string, autoTLS bool) string {
-	scheme := "http"
+	// URL scheme constants
+	const (
+		schemeHTTP  = "http"
+		schemeHTTPS = "https"
+	)
+
+	scheme := schemeHTTP
 	if autoTLS {
-		scheme = "https"
+		scheme = schemeHTTPS
 	}
 
 	// Priority 1: Use provided host from config (security.host)
@@ -141,7 +147,7 @@ func BuildBaseURL(host, port string, autoTLS bool) string {
 	}
 
 	// Omit default ports for cleaner URLs
-	if (scheme == "https" && port == "443") || (scheme == "http" && port == "80") {
+	if (scheme == schemeHTTPS && port == "443") || (scheme == schemeHTTP && port == "80") {
 		return fmt.Sprintf("%s://%s", scheme, host)
 	}
 


### PR DESCRIPTION
## Summary
- Replace repeated string literals with constants for circuit breaker states, webhook auth types, URL schemes, and test data values
- Add `nolint` directives with explanations for intentional gosec exceptions (G204 for trusted config script execution, G404 for non-cryptographic jitter)
- Create `constants.go` for shared circuit breaker state strings used by both `PushCircuitBreaker` and `simpleCircuitBreaker`

## Test plan
- [x] Run `golangci-lint run internal/notification/` - 0 issues
- [ ] Verify existing tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code consistency by standardizing circuit breaker state representations and authentication type handling using constants.
  * Enhanced code clarity with security-related comments and lint directives.

* **Bug Fixes**
  * Strengthened validation for custom webhook authentication to enforce stricter header and value requirements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->