### PR TITLE
fix(species): apply species tracking settings changes at runtime

### DIFF
--- a/internal/analysis/processor/processor.go
+++ b/internal/analysis/processor/processor.go
@@ -1407,6 +1407,20 @@ func (p *Processor) GetEventTracker() *EventTracker {
 	return p.EventTracker
 }
 
+// SetNewSpeciesTracker safely replaces the current SpeciesTracker
+func (p *Processor) SetNewSpeciesTracker(tracker *species.SpeciesTracker) {
+	p.speciesTrackerMu.Lock()
+	defer p.speciesTrackerMu.Unlock()
+	p.NewSpeciesTracker = tracker
+}
+
+// GetNewSpeciesTracker safely returns the current SpeciesTracker
+func (p *Processor) GetNewSpeciesTracker() *species.SpeciesTracker {
+	p.speciesTrackerMu.RLock()
+	defer p.speciesTrackerMu.RUnlock()
+	return p.NewSpeciesTracker
+}
+
 // GetJobQueueStats returns statistics about the job queue
 // This method is thread-safe as it delegates to JobQueue.GetStats() which handles locking internally
 func (p *Processor) GetJobQueueStats() jobqueue.JobStatsSnapshot {


### PR DESCRIPTION
## Summary
- Add hot reload support for species tracking settings so changes are applied immediately without restart
- Implement change detection for all species tracking configuration options (window days, sync interval, yearly/seasonal tracking, season dates)
- Add thread-safe species tracker replacement using existing mutex pattern

## Test plan
- [ ] Change species tracking settings via UI and verify they take effect immediately
- [ ] Toggle yearly tracking enabled/disabled and verify behavior changes
- [ ] Toggle seasonal tracking enabled/disabled and verify behavior changes
- [ ] Modify season start dates and verify seasonal detection uses new dates
- [ ] Verify species tracker reinitializes from database on reconfiguration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Species tracking can now be reconfigured live from settings, with immediate validation, notifications, and hemisphere-aware seasonal adjustments.
* **Improvements**
  * Safer, more reliable species-tracker updates to reduce interruptions and resource leaks when changing settings.
* **Bug Fixes**
  * Settings changes now reliably trigger reconfiguration actions and user toasts when species-tracking options are modified.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->