### PR TITLE
feat(api): add CSRF middleware for new API server

### DIFF
--- a/internal/api/middleware/csrf.go
+++ b/internal/api/middleware/csrf.go
@@ -1,0 +1,145 @@
+package middleware
+
+import (
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"github.com/labstack/echo/v4"
+	"github.com/labstack/echo/v4/middleware"
+)
+
+// CSRFContextKey is the key used to store CSRF token in the context.
+// This must match what spa.go expects when retrieving the token.
+const CSRFContextKey = "csrf"
+
+// CSRFConfig holds configuration for the CSRF middleware.
+type CSRFConfig struct {
+	// Logger for structured logging of CSRF errors.
+	Logger *slog.Logger
+
+	// Skipper defines a function to skip the middleware.
+	// If nil, the default skipper is used which exempts common safe routes.
+	Skipper middleware.Skipper
+
+	// TokenLength is the length of the generated token.
+	// Default is 32.
+	TokenLength uint8
+
+	// TokenLookup is a string in the form of "<source>:<key>" or "<source>:<key>,<source>:<key>"
+	// that is used to extract token from the request.
+	// Default is "header:X-CSRF-Token,form:_csrf".
+	TokenLookup string
+
+	// CookieName is the name of the CSRF cookie.
+	// Default is "csrf".
+	CookieName string
+
+	// CookieMaxAge is the max age (in seconds) of the CSRF cookie.
+	// Default is 1800 (30 minutes).
+	CookieMaxAge int
+}
+
+// DefaultCSRFSkipper returns the default skipper function that exempts
+// static assets, media streams, SSE, and auth endpoints from CSRF protection.
+func DefaultCSRFSkipper(c echo.Context) bool {
+	path := c.Request().URL.Path
+
+	// Skip CSRF for static assets
+	if strings.HasPrefix(path, "/assets/") ||
+		strings.HasPrefix(path, "/ui/assets/") {
+		return true
+	}
+
+	// Skip for health check
+	if path == "/health" {
+		return true
+	}
+
+	// Skip for media and streaming endpoints (read-only)
+	if strings.HasPrefix(path, "/api/v2/media/") ||
+		strings.HasPrefix(path, "/api/v2/streams/") ||
+		strings.HasPrefix(path, "/api/v2/spectrogram/") ||
+		strings.HasPrefix(path, "/api/v2/audio/") {
+		return true
+	}
+
+	// Skip for auth endpoints (login handles auth, logout is low-risk)
+	if path == "/api/v2/auth/login" ||
+		path == "/api/v2/auth/logout" ||
+		strings.HasPrefix(path, "/api/v2/auth/callback") {
+		return true
+	}
+
+	return false
+}
+
+// NewCSRF creates a CSRF middleware with the given configuration.
+// If config is nil, sensible defaults are used that match the legacy implementation.
+func NewCSRF(config *CSRFConfig) echo.MiddlewareFunc {
+	// Apply defaults
+	if config == nil {
+		config = &CSRFConfig{}
+	}
+
+	skipper := config.Skipper
+	if skipper == nil {
+		skipper = DefaultCSRFSkipper
+	}
+
+	tokenLength := config.TokenLength
+	if tokenLength == 0 {
+		tokenLength = 32
+	}
+
+	tokenLookup := config.TokenLookup
+	if tokenLookup == "" {
+		tokenLookup = "header:X-CSRF-Token,form:_csrf"
+	}
+
+	cookieName := config.CookieName
+	if cookieName == "" {
+		cookieName = "csrf"
+	}
+
+	cookieMaxAge := config.CookieMaxAge
+	if cookieMaxAge == 0 {
+		cookieMaxAge = 1800 // 30 minutes
+	}
+
+	logger := config.Logger
+
+	return middleware.CSRFWithConfig(middleware.CSRFConfig{
+		Skipper:      skipper,
+		TokenLength:  tokenLength,
+		TokenLookup:  tokenLookup,
+		ContextKey:   CSRFContextKey,
+		CookieName:   cookieName,
+		CookiePath:   "/",
+		CookieHTTPOnly: false, // Allow JavaScript to read the cookie for hobby/LAN use
+		CookieSecure:   false, // Allow cookies over HTTP for non-HTTPS deployments
+		CookieSameSite: http.SameSiteLaxMode,
+		CookieMaxAge:   cookieMaxAge,
+		ErrorHandler: func(err error, c echo.Context) error {
+			// Log the CSRF error with structured logging if logger is available
+			if logger != nil {
+				logger.Warn("CSRF validation failed",
+					"method", c.Request().Method,
+					"path", c.Request().URL.Path,
+					"remote_ip", c.RealIP(),
+					"error", err.Error(),
+				)
+			}
+
+			return echo.NewHTTPError(http.StatusForbidden, "Invalid CSRF token")
+		},
+	})
+}
+
+// NewCSRFWithLogger creates a CSRF middleware with default configuration and the given logger.
+// This is a convenience function for the most common use case.
+func NewCSRFWithLogger(logger *slog.Logger) echo.MiddlewareFunc {
+	return NewCSRF(&CSRFConfig{
+		Logger: logger,
+	})
+}

--- a/internal/api/middleware/security.go
+++ b/internal/api/middleware/security.go
@@ -73,6 +73,7 @@ func NewCORS(config SecurityConfig) echo.MiddlewareFunc {
 			echo.HeaderAccept,
 			echo.HeaderAuthorization,
 			"X-Requested-With",
+			"X-CSRF-Token",
 			"HX-Request",
 			"HX-Target",
 			"HX-Current-URL",

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -279,6 +279,9 @@ func (s *Server) setupMiddleware() {
 	// CORS middleware
 	s.echo.Use(mw.NewCORS(securityConfig))
 
+	// CSRF protection middleware
+	s.echo.Use(mw.NewCSRFWithLogger(s.slogger))
+
 	// Body limit middleware
 	s.echo.Use(mw.NewBodyLimit(s.config.BodyLimit))
 


### PR DESCRIPTION
## Summary
- Add CSRF protection middleware to the new API server at `internal/api/`
- Mirror the legacy `httpcontroller` CSRF implementation for consistency
- Enable frontend CSRF handling (meta tag + api.ts) to work with new API server

## Changes
- **New file**: `internal/api/middleware/csrf.go` - Configurable CSRF middleware with default skipper
- **Modified**: `internal/api/middleware/security.go` - Allow `X-CSRF-Token` header in CORS
- **Modified**: `internal/api/server.go` - Integrate CSRF middleware into stack

## Features
- Token lookup from `X-CSRF-Token` header and `_csrf` form field
- Cookie-based token storage with `SameSite=Lax` protection
- 30-minute token lifetime
- Route exemptions for static assets, media streams, SSE, and auth endpoints
- Structured logging for security monitoring

## Test plan
- [ ] Verify CSRF cookie is set on page load
- [ ] Verify meta tag contains CSRF token in HTML source
- [ ] Test protected API endpoint returns 403 without token
- [ ] Test protected API endpoint succeeds with valid token
- [ ] Verify exempted routes (media, streams, auth) work without tokens

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced application security with CSRF (Cross-Site Request Forgery) protection. The system now validates requests to prevent unauthorized cross-site actions, with automatic token generation and validation configured across the application.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->