### PR TITLE
fix(security): harden file and directory permissions

### DIFF
--- a/internal/analysis/directory.go
+++ b/internal/analysis/directory.go
@@ -86,7 +86,7 @@ func isFileLocked(path string) bool {
 		flag = os.O_RDONLY | syscall.O_NONBLOCK
 	}
 
-	file, err := os.OpenFile(path, flag, 0o666)
+	file, err := os.OpenFile(path, flag, 0o600)
 	if err != nil {
 		// File is probably locked by another process
 		return true
@@ -97,7 +97,7 @@ func isFileLocked(path string) bool {
 
 	// On Windows, also try write access to be sure
 	if runtime.GOOS == "windows" {
-		file, err = os.OpenFile(path, os.O_WRONLY, 0o666)
+		file, err = os.OpenFile(path, os.O_WRONLY, 0o600)
 		if err != nil {
 			return true
 		}
@@ -208,7 +208,7 @@ func processFile(path string, settings *conf.Settings, processedFiles map[string
 	lockFile := outputPath + ".processing"
 
 	// Try to create lock file
-	f, err := os.OpenFile(lockFile, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o666)
+	f, err := os.OpenFile(lockFile, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
 	if err != nil {
 		// Another instance is processing this file
 		return false, nil
@@ -372,7 +372,7 @@ func DirectoryAnalysis(settings *conf.Settings, ctx context.Context) error {
 	if settings.Output.File.Path == "" {
 		settings.Output.File.Path = "."
 	}
-	if err := os.MkdirAll(settings.Output.File.Path, 0o755); err != nil {
+	if err := os.MkdirAll(settings.Output.File.Path, 0o750); err != nil {
 		log.Printf("Failed to create output directory: %v", err)
 		return err
 	}

--- a/internal/analysis/processor/actions.go
+++ b/internal/analysis/processor/actions.go
@@ -789,7 +789,7 @@ func (a *SaveAudioAction) Execute(data any) error {
 	outputPath := filepath.Join(a.Settings.Realtime.Audio.Export.Path, a.ClipName)
 
 	// Ensure the directory exists
-	if err := os.MkdirAll(filepath.Dir(outputPath), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(outputPath), 0o750); err != nil {
 		// Add structured logging
 		GetLogger().Error("Failed to create directory for audio clip",
 			"component", "analysis.processor.actions",

--- a/internal/analysis/processor/processor.go
+++ b/internal/analysis/processor/processor.go
@@ -1782,7 +1782,7 @@ func (p *Processor) initPreRenderer() {
 		}
 
 		// Verify export path exists and is writable
-		if err := os.MkdirAll(p.Settings.Realtime.Audio.Export.Path, 0o755); err != nil {
+		if err := os.MkdirAll(p.Settings.Realtime.Audio.Export.Path, 0o750); err != nil {
 			GetLogger().Error("Export path not writable, disabling pre-rendering",
 				"path", p.Settings.Realtime.Audio.Export.Path,
 				"error", err,

--- a/internal/birdnet/model_discovery_test.go
+++ b/internal/birdnet/model_discovery_test.go
@@ -40,7 +40,7 @@ func TestTryLoadModelFromStandardPaths_RelativeDirectory(t *testing.T) {
 	withTempWorkDir(t, func(tempDir string) {
 		// Create test file in relative model directory
 		modelPath := filepath.Join(DefaultModelDirectory, testModelName)
-		require.NoError(t, os.MkdirAll(DefaultModelDirectory, 0o755), "Failed to create model directory")
+		require.NoError(t, os.MkdirAll(DefaultModelDirectory, 0o750), "Failed to create model directory")
 		require.NoError(t, os.WriteFile(modelPath, []byte(testContent), 0o644), "Failed to create test file")
 
 		data, path, err := tryLoadModelFromStandardPaths(testModelName, "test")
@@ -61,7 +61,7 @@ func TestTryLoadModelFromStandardPaths_LegacyDataDirectory(t *testing.T) {
 	withTempWorkDir(t, func(tempDir string) {
 		// Create test file in legacy data/model directory  
 		modelPath := filepath.Join("data", DefaultModelDirectory, testModelName)
-		require.NoError(t, os.MkdirAll(filepath.Join("data", DefaultModelDirectory), 0o755), 
+		require.NoError(t, os.MkdirAll(filepath.Join("data", DefaultModelDirectory), 0o750), 
 			"Failed to create model directory")
 		require.NoError(t, os.WriteFile(modelPath, []byte(testContent), 0o644), 
 			"Failed to create test file")
@@ -86,11 +86,11 @@ func TestTryLoadModelFromStandardPaths_FirstHitWins(t *testing.T) {
 		secondPath := filepath.Join("data", DefaultModelDirectory, testModelName)
 
 		// Create first priority file
-		require.NoError(t, os.MkdirAll(DefaultModelDirectory, 0o755), "Failed to create first directory")
+		require.NoError(t, os.MkdirAll(DefaultModelDirectory, 0o750), "Failed to create first directory")
 		require.NoError(t, os.WriteFile(firstPath, []byte("first_priority"), 0o644), "Failed to create first file")
 
 		// Create second priority file
-		require.NoError(t, os.MkdirAll(filepath.Join("data", DefaultModelDirectory), 0o755), 
+		require.NoError(t, os.MkdirAll(filepath.Join("data", DefaultModelDirectory), 0o750), 
 			"Failed to create second directory")
 		require.NoError(t, os.WriteFile(secondPath, []byte("second_priority"), 0o644), 
 			"Failed to create second file")
@@ -140,7 +140,7 @@ func TestTryLoadModelFromStandardPaths_RangeFilterModels(t *testing.T) {
 			withTempWorkDir(t, func(tempDir string) {
 				// Create test file
 				modelPath := filepath.Join(DefaultModelDirectory, tc.modelName)
-				require.NoError(t, os.MkdirAll(DefaultModelDirectory, 0o755), "Failed to create model directory")
+				require.NoError(t, os.MkdirAll(DefaultModelDirectory, 0o750), "Failed to create model directory")
 				require.NoError(t, os.WriteFile(modelPath, []byte(testContent), 0o644), "Failed to create test file")
 
 				data, path, err := tryLoadModelFromStandardPaths(tc.modelName, "test")

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -1369,7 +1369,7 @@ func createDefaultConfig() error {
 	}
 
 	// Create directories for config file
-	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o750); err != nil {
 		return errors.New(err).
 			Category(errors.CategoryFileIO).
 			Context("operation", "create-config-dirs").

--- a/internal/conf/utils.go
+++ b/internal/conf/utils.go
@@ -108,7 +108,7 @@ func GetBasePath(path string) string {
 	// Check if the directory exists.
 	if _, err := os.Stat(basePath); os.IsNotExist(err) {
 		// Attempt to create the directory if it doesn't exist.
-		if err := os.MkdirAll(basePath, 0o755); err != nil {
+		if err := os.MkdirAll(basePath, 0o750); err != nil {
 			fmt.Printf("failed to create directory '%s': %v\n", basePath, err)
 			// Note: In a robust application, you might want to handle this error more gracefully.
 		}
@@ -149,7 +149,7 @@ func GetHLSDirectory() (string, error) {
 	}
 
 	// Create directory if it doesn't exist
-	if err := os.MkdirAll(absPath, 0o755); err != nil {
+	if err := os.MkdirAll(absPath, 0o750); err != nil {
 		return "", errors.New(err).
 			Category(errors.CategoryFileIO).
 			Context("operation", "hls-create-directory").

--- a/internal/datastore/sqlite.go
+++ b/internal/datastore/sqlite.go
@@ -54,7 +54,7 @@ func getDiskSpace(path string) (uint64, error) {
 func checkWritePermission(path string) error {
 	// Create a temporary file to test write permissions
 	tempFile := filepath.Join(filepath.Dir(path), ".tmp_write_test")
-	f, err := os.OpenFile(tempFile, os.O_CREATE|os.O_WRONLY, 0o666)
+	f, err := os.OpenFile(tempFile, os.O_CREATE|os.O_WRONLY, 0o600)
 	if err != nil {
 		return errors.New(err).
 			Component("datastore").
@@ -188,7 +188,7 @@ func (s *SQLiteStore) Open() error {
 		"path", dbPath)
 
 	// Create database directory if it doesn't exist
-	if err := os.MkdirAll(filepath.Dir(dbPath), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(dbPath), 0o750); err != nil {
 		return errors.New(err).
 			Component("datastore").
 			Category(errors.CategorySystem).

--- a/internal/diskmanager/policy_age_test.go
+++ b/internal/diskmanager/policy_age_test.go
@@ -372,7 +372,7 @@ func TestAgeBasedCleanupMinClipsGlobal(t *testing.T) {
 	// --- File Setup --- Helper to create audio files in specific subdirs
 	createTestFile := func(subdir, species string, confidence int, modTime time.Time) string {
 		subdirPath := filepath.Join(testDir, subdir)
-		require.NoError(t, os.MkdirAll(subdirPath, 0o755), "Failed to create subdirectory: %s", subdirPath)
+		require.NoError(t, os.MkdirAll(subdirPath, 0o750), "Failed to create subdirectory: %s", subdirPath)
 		timestampStr := modTime.UTC().Format("20060102T150405Z")
 		baseName := fmt.Sprintf("%s_%dp_%s", species, confidence, timestampStr)
 		audioPath := filepath.Join(testDir, subdir, baseName+".wav")

--- a/internal/myaudio/encode.go
+++ b/internal/myaudio/encode.go
@@ -81,7 +81,7 @@ func SavePCMDataToWAV(filePath string, pcmData []byte) error {
 	}
 
 	// Create the directory structure if it doesn't exist
-	if err := os.MkdirAll(filepath.Dir(filePath), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(filePath), 0o750); err != nil {
 		enhancedErr := errors.New(err).
 			Component("myaudio").
 			Category(errors.CategoryFileIO).

--- a/internal/myaudio/ffmpeg_export.go
+++ b/internal/myaudio/ffmpeg_export.go
@@ -169,7 +169,7 @@ func createTempFile(outputPath string) (string, error) {
 	}
 
 	outputDir := filepath.Dir(outputPath)
-	if err := os.MkdirAll(outputDir, 0o755); err != nil {
+	if err := os.MkdirAll(outputDir, 0o750); err != nil {
 		enhancedErr := errors.New(err).
 			Component("myaudio").
 			Category(errors.CategoryFileIO).

--- a/internal/observation/logfile.go
+++ b/internal/observation/logfile.go
@@ -22,7 +22,7 @@ func LogNoteToFile(settings *conf.Settings, note *datastore.Note) error {
 	absoluteFilePath := filepath.Join(basePath, fileName)
 
 	// Open the log file for appending, creating it if it doesn't exist
-	file, err := os.OpenFile(absoluteFilePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	file, err := os.OpenFile(absoluteFilePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
 	if err != nil {
 		fmt.Printf("failed to open file '%s': %v\n", absoluteFilePath, err)
 		return fmt.Errorf("failed to open file '%s': %w", absoluteFilePath, err)

--- a/internal/secrets/secrets_test.go
+++ b/internal/secrets/secrets_test.go
@@ -202,7 +202,7 @@ func TestReadFile(t *testing.T) {
 			name: "directory instead of file",
 			setup: func() string {
 				path := filepath.Join(tmpDir, "directory_secret")
-				if err := os.Mkdir(path, 0o755); err != nil {
+				if err := os.Mkdir(path, 0o750); err != nil {
 					t.Fatal(err)
 				}
 				return path

--- a/internal/securefs/realistic_benchmark_test.go
+++ b/internal/securefs/realistic_benchmark_test.go
@@ -25,7 +25,7 @@ func BenchmarkRepeatedStatOperationsWithoutCache(b *testing.B) {
 
 	for _, file := range testFiles {
 		fullPath := filepath.Join(tempDir, file)
-		if err := os.MkdirAll(filepath.Dir(fullPath), 0o755); err != nil {
+		if err := os.MkdirAll(filepath.Dir(fullPath), 0o750); err != nil {
 			b.Fatal(err)
 		}
 		if err := os.WriteFile(fullPath, []byte("test content"), 0o644); err != nil {
@@ -89,7 +89,7 @@ func BenchmarkRepeatedStatOperationsWithCache(b *testing.B) {
 
 	for _, file := range testFiles {
 		fullPath := filepath.Join(tempDir, file)
-		if err := os.MkdirAll(filepath.Dir(fullPath), 0o755); err != nil {
+		if err := os.MkdirAll(filepath.Dir(fullPath), 0o750); err != nil {
 			b.Fatal(err)
 		}
 		if err := os.WriteFile(fullPath, []byte("test content"), 0o644); err != nil {
@@ -208,7 +208,7 @@ func setupSpectrogramTestFiles(b *testing.B, tempDir string, files []string) {
 	b.Helper()
 	for _, file := range files {
 		fullPath := filepath.Join(tempDir, file)
-		if err := os.MkdirAll(filepath.Dir(fullPath), 0o755); err != nil {
+		if err := os.MkdirAll(filepath.Dir(fullPath), 0o750); err != nil {
 			b.Fatal(err)
 		}
 		if err := os.WriteFile(fullPath, []byte("fake audio content"), 0o644); err != nil {

--- a/internal/securefs/securefs_test.go
+++ b/internal/securefs/securefs_test.go
@@ -222,7 +222,7 @@ func TestSecureFSDirectoryOperations(t *testing.T) {
 
 	// Test MkdirAll
 	testDir := filepath.Join(tempDir, "subdir", "nested")
-	err := sfs.MkdirAll(testDir, 0o755)
+	err := sfs.MkdirAll(testDir, 0o750)
 	if err != nil {
 		t.Fatalf("MkdirAll failed: %v", err)
 	}
@@ -360,12 +360,12 @@ func setupSymlinkTest(t *testing.T, tempDir string) (outsideDir, symlinkPath str
 	t.Helper()
 
 	insideDir := filepath.Join(tempDir, "inside")
-	if err := os.Mkdir(insideDir, 0o755); err != nil {
+	if err := os.Mkdir(insideDir, 0o750); err != nil {
 		t.Fatalf("Failed to create test directory: %v", err)
 	}
 
 	outsideDir = filepath.Join(os.TempDir(), "securefs_test_outside")
-	if err := os.MkdirAll(outsideDir, 0o755); err != nil {
+	if err := os.MkdirAll(outsideDir, 0o750); err != nil {
 		t.Fatalf("Failed to create outside test directory: %v", err)
 	}
 	t.Cleanup(func() { _ = os.RemoveAll(outsideDir) })
@@ -484,7 +484,7 @@ func TestReadDir(t *testing.T) {
 	// Create some files and directories
 	_ = sfs.WriteFile(filepath.Join(tempDir, "file1.txt"), []byte("content1"), 0o644)
 	_ = sfs.WriteFile(filepath.Join(tempDir, "file2.txt"), []byte("content2"), 0o644)
-	_ = sfs.MkdirAll(filepath.Join(tempDir, "subdir"), 0o755)
+	_ = sfs.MkdirAll(filepath.Join(tempDir, "subdir"), 0o750)
 
 	// Read directory
 	entries, err := sfs.ReadDir(tempDir)
@@ -515,7 +515,7 @@ func TestParentPath(t *testing.T) {
 
 	// Create a nested directory
 	nested := filepath.Join(tempDir, "a", "b", "c")
-	if err := sfs.MkdirAll(nested, 0o755); err != nil {
+	if err := sfs.MkdirAll(nested, 0o750); err != nil {
 		t.Fatalf("MkdirAll failed: %v", err)
 	}
 


### PR DESCRIPTION
## Summary
- Address gosec G301/G302 security findings by restricting file and directory permissions
- Change directory permissions from 0o755 to 0o750 (removes world access)
- Change file permissions from 0o666/0o644 to 0o600 (owner-only access)

## Changes
| Category | Files | Change |
|----------|-------|--------|
| Lock files | `directory.go` | 0o666 → 0o600 |
| Log files | `logfile.go` | 0o644 → 0o600 |
| Temp files | `sqlite.go` | 0o666 → 0o600 |
| Directories | Multiple files | 0o755 → 0o750 |

## Security Impact
Reduces attack surface by ensuring:
- Created directories are not world-executable
- Created files are not world-readable/writable
- Lock and temporary files are only accessible by the owner

## Test plan
- [x] All existing tests pass with new permissions
- [x] golangci-lint reports no G301/G302 findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Enhanced file and directory permission controls. Configuration directories, log files, databases, and other application-created resources are now established with more restrictive permissions, limiting access to the application owner and designated group members. This change prevents unauthorized access to sensitive application files and system resources.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->