### PR TITLE
fix(security): restrict WriteFile permissions to 0600

### DIFF
--- a/internal/birdnet/model_discovery_test.go
+++ b/internal/birdnet/model_discovery_test.go
@@ -41,7 +41,7 @@ func TestTryLoadModelFromStandardPaths_RelativeDirectory(t *testing.T) {
 		// Create test file in relative model directory
 		modelPath := filepath.Join(DefaultModelDirectory, testModelName)
 		require.NoError(t, os.MkdirAll(DefaultModelDirectory, 0o750), "Failed to create model directory")
-		require.NoError(t, os.WriteFile(modelPath, []byte(testContent), 0o644), "Failed to create test file")
+		require.NoError(t, os.WriteFile(modelPath, []byte(testContent), 0o600), "Failed to create test file")
 
 		data, path, err := tryLoadModelFromStandardPaths(testModelName, "test")
 
@@ -63,7 +63,7 @@ func TestTryLoadModelFromStandardPaths_LegacyDataDirectory(t *testing.T) {
 		modelPath := filepath.Join("data", DefaultModelDirectory, testModelName)
 		require.NoError(t, os.MkdirAll(filepath.Join("data", DefaultModelDirectory), 0o750), 
 			"Failed to create model directory")
-		require.NoError(t, os.WriteFile(modelPath, []byte(testContent), 0o644), 
+		require.NoError(t, os.WriteFile(modelPath, []byte(testContent), 0o600), 
 			"Failed to create test file")
 
 		data, path, err := tryLoadModelFromStandardPaths(testModelName, "test")
@@ -87,12 +87,12 @@ func TestTryLoadModelFromStandardPaths_FirstHitWins(t *testing.T) {
 
 		// Create first priority file
 		require.NoError(t, os.MkdirAll(DefaultModelDirectory, 0o750), "Failed to create first directory")
-		require.NoError(t, os.WriteFile(firstPath, []byte("first_priority"), 0o644), "Failed to create first file")
+		require.NoError(t, os.WriteFile(firstPath, []byte("first_priority"), 0o600), "Failed to create first file")
 
 		// Create second priority file
 		require.NoError(t, os.MkdirAll(filepath.Join("data", DefaultModelDirectory), 0o750), 
 			"Failed to create second directory")
-		require.NoError(t, os.WriteFile(secondPath, []byte("second_priority"), 0o644), 
+		require.NoError(t, os.WriteFile(secondPath, []byte("second_priority"), 0o600), 
 			"Failed to create second file")
 
 		data, path, err := tryLoadModelFromStandardPaths(testModelName, "test")
@@ -141,7 +141,7 @@ func TestTryLoadModelFromStandardPaths_RangeFilterModels(t *testing.T) {
 				// Create test file
 				modelPath := filepath.Join(DefaultModelDirectory, tc.modelName)
 				require.NoError(t, os.MkdirAll(DefaultModelDirectory, 0o750), "Failed to create model directory")
-				require.NoError(t, os.WriteFile(modelPath, []byte(testContent), 0o644), "Failed to create test file")
+				require.NoError(t, os.WriteFile(modelPath, []byte(testContent), 0o600), "Failed to create test file")
 
 				data, path, err := tryLoadModelFromStandardPaths(tc.modelName, "test")
 

--- a/internal/diskmanager/file_utils_bench_test.go
+++ b/internal/diskmanager/file_utils_bench_test.go
@@ -24,7 +24,7 @@ func BenchmarkGetAudioFiles(b *testing.B) {
 
 	for _, file := range testFiles {
 		filePath := filepath.Join(tempDir, file)
-		err := os.WriteFile(filePath, []byte("test"), 0o644)
+		err := os.WriteFile(filePath, []byte("test"), 0o600)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -112,7 +112,7 @@ func BenchmarkMemoryProfile(b *testing.B) {
 			for i := 0; i < scenario.fileCount; i++ {
 				filename := filepath.Join(tempDir,
 					"species_80p_20210102T150405Z.wav")
-				err := os.WriteFile(filename, []byte("test"), 0o644)
+				err := os.WriteFile(filename, []byte("test"), 0o600)
 				if err != nil {
 					b.Fatal(err)
 				}
@@ -154,7 +154,7 @@ func BenchmarkPoolEffectiveness(b *testing.B) {
 	for range 100 {
 		filename := filepath.Join(tempDir,
 			"species_80p_20210102T150405Z.wav")
-		err := os.WriteFile(filename, []byte("test"), 0o644)
+		err := os.WriteFile(filename, []byte("test"), 0o600)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -202,7 +202,7 @@ func BenchmarkErrorHandling(b *testing.B) {
 
 	for _, file := range append(validFiles, invalidFiles...) {
 		filePath := filepath.Join(tempDir, file)
-		err := os.WriteFile(filePath, []byte("test"), 0o644)
+		err := os.WriteFile(filePath, []byte("test"), 0o600)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/internal/diskmanager/file_utils_test.go
+++ b/internal/diskmanager/file_utils_test.go
@@ -57,10 +57,10 @@ func TestGetAudioFilesContinuesOnError(t *testing.T) {
 	invalidFile := tempDir + "/invalid_file.wav"
 
 	// Create the files
-	err := os.WriteFile(validFile, []byte("test content"), 0o644) //nolint:gosec // G306: Test files don't require restrictive permissions
+	err := os.WriteFile(validFile, []byte("test content"), 0o600)
 	require.NoError(t, err, "Should be able to create valid file")
 
-	err = os.WriteFile(invalidFile, []byte("test content"), 0o644) //nolint:gosec // G306: Test files don't require restrictive permissions
+	err = os.WriteFile(invalidFile, []byte("test content"), 0o600)
 	require.NoError(t, err, "Should be able to create invalid file")
 
 	// Create a mock DB
@@ -95,7 +95,7 @@ func TestGetAudioFilesWithMixedFiles(t *testing.T) {
 
 	// Create all the files
 	for _, file := range append(validFiles, invalidFiles...) {
-		err := os.WriteFile(file, []byte("test content"), 0o644) //nolint:gosec // G306: Test files don't require restrictive permissions
+		err := os.WriteFile(file, []byte("test content"), 0o600)
 		require.NoError(t, err, "Should be able to create file: %s", file)
 	}
 
@@ -124,7 +124,7 @@ func TestGetAudioFilesWithMixedFiles(t *testing.T) {
 	for _, file := range invalidFiles {
 		baseName := filepath.Base(file)
 		newPath := filepath.Join(invalidOnlyDir, baseName)
-		err := os.WriteFile(newPath, []byte("test content"), 0o644) //nolint:gosec // G306: Test files don't require restrictive permissions
+		err := os.WriteFile(newPath, []byte("test content"), 0o600)
 		require.NoError(t, err, "Should be able to create file: %s", newPath)
 	}
 
@@ -217,14 +217,14 @@ func TestGetAudioFilesIgnoresTempFiles(t *testing.T) {
 	// Create valid files
 	for _, file := range validFiles {
 		filePath := filepath.Join(tempDir, file)
-		err := os.WriteFile(filePath, []byte("test content"), 0o644)
+		err := os.WriteFile(filePath, []byte("test content"), 0o600)
 		require.NoError(t, err, "Should be able to create valid file: %s", filePath)
 	}
 
 	// Create temp files
 	for _, file := range tempFiles {
 		filePath := filepath.Join(tempDir, file)
-		err := os.WriteFile(filePath, []byte("test content"), 0o644)
+		err := os.WriteFile(filePath, []byte("test content"), 0o600)
 		require.NoError(t, err, "Should be able to create temp file: %s", filePath)
 	}
 
@@ -264,7 +264,7 @@ func TestGetAudioFilesHandlesTempFileRaceCondition(t *testing.T) {
 	// Create a valid audio file
 	validFile := "bubo_bubo_80p_20210102T150405Z.wav"
 	validFilePath := filepath.Join(tempDir, validFile)
-	err := os.WriteFile(validFilePath, []byte("test content"), 0o644)
+	err := os.WriteFile(validFilePath, []byte("test content"), 0o600)
 	require.NoError(t, err, "Should be able to create valid file")
 
 	// Create a mock DB

--- a/internal/myaudio/validate_test.go
+++ b/internal/myaudio/validate_test.go
@@ -185,7 +185,7 @@ func TestQuickValidateAudioFile(t *testing.T) {
 		t.Parallel()
 		tmpDir := t.TempDir()
 		testFile := filepath.Join(tmpDir, "tiny.wav")
-		if err := os.WriteFile(testFile, []byte("small"), 0o644); err != nil {
+		if err := os.WriteFile(testFile, []byte("small"), 0o600); err != nil {
 			t.Fatal(err)
 		}
 
@@ -225,7 +225,7 @@ func TestValidateAudioFileWithRetry(t *testing.T) {
 		testFile := filepath.Join(tmpDir, "growing.wav")
 
 		// Start with a small file
-		if err := os.WriteFile(testFile, []byte("small"), 0o644); err != nil {
+		if err := os.WriteFile(testFile, []byte("small"), 0o600); err != nil {
 			t.Fatal(err)
 		}
 

--- a/internal/secrets/secrets_test.go
+++ b/internal/secrets/secrets_test.go
@@ -162,7 +162,7 @@ func TestReadFile(t *testing.T) {
 			name: "permissive permissions warning",
 			setup: func() string {
 				path := filepath.Join(tmpDir, "permissive_secret")
-				if err := os.WriteFile(path, []byte("secret"), 0o644); err != nil {
+				if err := os.WriteFile(path, []byte("secret"), 0o600); err != nil {
 					t.Fatal(err)
 				}
 				return path

--- a/internal/securefs/realistic_benchmark_test.go
+++ b/internal/securefs/realistic_benchmark_test.go
@@ -28,7 +28,7 @@ func BenchmarkRepeatedStatOperationsWithoutCache(b *testing.B) {
 		if err := os.MkdirAll(filepath.Dir(fullPath), 0o750); err != nil {
 			b.Fatal(err)
 		}
-		if err := os.WriteFile(fullPath, []byte("test content"), 0o644); err != nil {
+		if err := os.WriteFile(fullPath, []byte("test content"), 0o600); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -92,7 +92,7 @@ func BenchmarkRepeatedStatOperationsWithCache(b *testing.B) {
 		if err := os.MkdirAll(filepath.Dir(fullPath), 0o750); err != nil {
 			b.Fatal(err)
 		}
-		if err := os.WriteFile(fullPath, []byte("test content"), 0o644); err != nil {
+		if err := os.WriteFile(fullPath, []byte("test content"), 0o600); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -211,7 +211,7 @@ func setupSpectrogramTestFiles(b *testing.B, tempDir string, files []string) {
 		if err := os.MkdirAll(filepath.Dir(fullPath), 0o750); err != nil {
 			b.Fatal(err)
 		}
-		if err := os.WriteFile(fullPath, []byte("fake audio content"), 0o644); err != nil {
+		if err := os.WriteFile(fullPath, []byte("fake audio content"), 0o600); err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/internal/securefs/securefs_test.go
+++ b/internal/securefs/securefs_test.go
@@ -39,7 +39,7 @@ func TestSecureFSWriteFile(t *testing.T) {
 	t.Cleanup(func() { _ = sfs.Close() })
 
 	testFile := filepath.Join(tempDir, "test.txt")
-	if err := sfs.WriteFile(testFile, []byte("test data"), 0o644); err != nil {
+	if err := sfs.WriteFile(testFile, []byte("test data"), 0o600); err != nil {
 		t.Fatalf("WriteFile failed: %v", err)
 	}
 }
@@ -50,7 +50,7 @@ func TestSecureFSExists(t *testing.T) {
 	t.Cleanup(func() { _ = sfs.Close() })
 
 	testFile := filepath.Join(tempDir, "test.txt")
-	_ = sfs.WriteFile(testFile, []byte("test"), 0o644)
+	_ = sfs.WriteFile(testFile, []byte("test"), 0o600)
 
 	exists, err := sfs.Exists(testFile)
 	if err != nil {
@@ -68,7 +68,7 @@ func TestSecureFSReadFile(t *testing.T) {
 
 	testFile := filepath.Join(tempDir, "test.txt")
 	testData := []byte("test data")
-	_ = sfs.WriteFile(testFile, testData, 0o644)
+	_ = sfs.WriteFile(testFile, testData, 0o600)
 
 	data, err := sfs.ReadFile(testFile)
 	if err != nil {
@@ -91,7 +91,7 @@ func TestReadFileWithSizeLimit(t *testing.T) {
 	// Test 1: File within limit should be read successfully
 	smallFile := filepath.Join(tempDir, "small.txt")
 	smallContent := []byte("small content")
-	if err := sfs.WriteFile(smallFile, smallContent, 0o644); err != nil {
+	if err := sfs.WriteFile(smallFile, smallContent, 0o600); err != nil {
 		t.Fatalf("Failed to write small file: %v", err)
 	}
 
@@ -109,7 +109,7 @@ func TestReadFileWithSizeLimit(t *testing.T) {
 	for i := range largeContent {
 		largeContent[i] = 'x'
 	}
-	if err := sfs.WriteFile(largeFile, largeContent, 0o644); err != nil {
+	if err := sfs.WriteFile(largeFile, largeContent, 0o600); err != nil {
 		t.Fatalf("Failed to write large file: %v", err)
 	}
 
@@ -134,7 +134,7 @@ func TestReadFileSizeLimitZeroMeansUnlimited(t *testing.T) {
 	for i := range content {
 		content[i] = byte('a' + i%26)
 	}
-	if err := sfs.WriteFile(testFile, content, 0o644); err != nil {
+	if err := sfs.WriteFile(testFile, content, 0o600); err != nil {
 		t.Fatalf("Failed to write file: %v", err)
 	}
 
@@ -165,7 +165,7 @@ func TestSecureFSStat(t *testing.T) {
 
 	testFile := filepath.Join(tempDir, "test.txt")
 	testData := []byte("test data")
-	_ = sfs.WriteFile(testFile, testData, 0o644)
+	_ = sfs.WriteFile(testFile, testData, 0o600)
 
 	info, err := sfs.Stat(testFile)
 	if err != nil {
@@ -182,7 +182,7 @@ func TestSecureFSOpenFile(t *testing.T) {
 	t.Cleanup(func() { _ = sfs.Close() })
 
 	testFile := filepath.Join(tempDir, "test.txt")
-	_ = sfs.WriteFile(testFile, []byte("test"), 0o644)
+	_ = sfs.WriteFile(testFile, []byte("test"), 0o600)
 
 	file, err := sfs.OpenFile(testFile, os.O_RDONLY, 0)
 	if err != nil {
@@ -197,7 +197,7 @@ func TestSecureFSRemove(t *testing.T) {
 	t.Cleanup(func() { _ = sfs.Close() })
 
 	testFile := filepath.Join(tempDir, "test.txt")
-	_ = sfs.WriteFile(testFile, []byte("test"), 0o644)
+	_ = sfs.WriteFile(testFile, []byte("test"), 0o600)
 
 	if err := sfs.Remove(testFile); err != nil {
 		t.Fatalf("Remove failed: %v", err)
@@ -237,7 +237,7 @@ func TestSecureFSDirectoryOperations(t *testing.T) {
 	// Test file in nested directory
 	nestedFile := filepath.Join(testDir, "nested.txt")
 	nestedData := []byte("nested file data")
-	err = sfs.WriteFile(nestedFile, nestedData, 0o644)
+	err = sfs.WriteFile(nestedFile, nestedData, 0o600)
 	if err != nil {
 		t.Fatalf("WriteFile in nested dir failed: %v", err)
 	}
@@ -276,7 +276,7 @@ func TestSecureFSPathTraversalPrevention(t *testing.T) {
 	}
 
 	// Attempt to write outside the sandbox
-	err = sfs.WriteFile(traversalPath, []byte("should fail"), 0o644)
+	err = sfs.WriteFile(traversalPath, []byte("should fail"), 0o600)
 	if err == nil {
 		t.Fatal("WriteFile should have failed for path outside sandbox")
 	}
@@ -416,7 +416,7 @@ func TestReadlinkWithinSandbox(t *testing.T) {
 
 	// Create a target file within the sandbox
 	targetFile := filepath.Join(tempDir, "target.txt")
-	if err := os.WriteFile(targetFile, []byte("target content"), 0o644); err != nil {
+	if err := os.WriteFile(targetFile, []byte("target content"), 0o600); err != nil {
 		t.Fatalf("Failed to create target file: %v", err)
 	}
 
@@ -482,8 +482,8 @@ func TestReadDir(t *testing.T) {
 	t.Cleanup(func() { _ = sfs.Close() })
 
 	// Create some files and directories
-	_ = sfs.WriteFile(filepath.Join(tempDir, "file1.txt"), []byte("content1"), 0o644)
-	_ = sfs.WriteFile(filepath.Join(tempDir, "file2.txt"), []byte("content2"), 0o644)
+	_ = sfs.WriteFile(filepath.Join(tempDir, "file1.txt"), []byte("content1"), 0o600)
+	_ = sfs.WriteFile(filepath.Join(tempDir, "file2.txt"), []byte("content2"), 0o600)
 	_ = sfs.MkdirAll(filepath.Join(tempDir, "subdir"), 0o750)
 
 	// Read directory
@@ -548,7 +548,7 @@ func TestLstat(t *testing.T) {
 
 	// Create a file
 	testFile := filepath.Join(tempDir, "test.txt")
-	if err := sfs.WriteFile(testFile, []byte("test content"), 0o644); err != nil {
+	if err := sfs.WriteFile(testFile, []byte("test content"), 0o600); err != nil {
 		t.Fatalf("WriteFile failed: %v", err)
 	}
 
@@ -574,7 +574,7 @@ func TestStatRel(t *testing.T) {
 	t.Cleanup(func() { _ = sfs.Close() })
 
 	// Create a file
-	if err := sfs.WriteFile(filepath.Join(tempDir, "test.txt"), []byte("content"), 0o644); err != nil {
+	if err := sfs.WriteFile(filepath.Join(tempDir, "test.txt"), []byte("content"), 0o600); err != nil {
 		t.Fatalf("WriteFile failed: %v", err)
 	}
 
@@ -603,7 +603,7 @@ func TestCacheUtilities(t *testing.T) {
 
 	// Create a file to trigger some cache entries
 	testFile := filepath.Join(tempDir, "test.txt")
-	_ = sfs.WriteFile(testFile, []byte("content"), 0o644)
+	_ = sfs.WriteFile(testFile, []byte("content"), 0o600)
 	_, _ = sfs.Exists(testFile)
 
 	// Test GetCacheStats
@@ -630,7 +630,7 @@ func TestExistsNoErr(t *testing.T) {
 
 	// Create a file
 	testFile := filepath.Join(tempDir, "test.txt")
-	_ = sfs.WriteFile(testFile, []byte("content"), 0o644)
+	_ = sfs.WriteFile(testFile, []byte("content"), 0o600)
 
 	// Should return true for existing file
 	if !sfs.ExistsNoErr(testFile) {

--- a/scripts/update_taxonomy.go
+++ b/scripts/update_taxonomy.go
@@ -143,7 +143,7 @@ func main() {
 	}
 
 	outputFile := "/tmp/genus_taxonomy.json"
-	if err := os.WriteFile(outputFile, optimizedData2, 0o644); err != nil {
+	if err := os.WriteFile(outputFile, optimizedData2, 0o600); err != nil {
 		log.Fatalf("Failed to write optimized data: %v", err)
 	}
 


### PR DESCRIPTION
## Summary
- Address gosec G306 findings by changing `os.WriteFile` permissions from `0o644` to `0o600`
- Removes world-readable access from created files

## Changes
| File | Occurrences |
|------|-------------|
| `birdnet/model_discovery_test.go` | 5 |
| `diskmanager/file_utils_bench_test.go` | 4 |
| `diskmanager/file_utils_test.go` | 7 + removed 4 nolint comments |
| `myaudio/validate_test.go` | 2 |
| `secrets/secrets_test.go` | 1 |
| `securefs/realistic_benchmark_test.go` | 3 |
| `securefs/securefs_test.go` | 18 |
| `scripts/update_taxonomy.go` | 1 |

**Total: 41 permission changes across 8 files**

## Related
- Companion to #1612 (directory/file permission hardening)
- Addresses Gemini code review feedback on #1612

## Test plan
- [x] All existing tests pass
- [x] golangci-lint reports no G306 findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Tightened file creation permissions across tests and maintenance scripts from more permissive modes to restrict access (files created during test runs and tooling now use stricter permissions).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->