### PR TITLE
fix(lint): suppress gosec G404 for non-security random usage

### DIFF
--- a/internal/datastore/interfaces.go
+++ b/internal/datastore/interfaces.go
@@ -1248,7 +1248,7 @@ func (ds *DataStore) LockNote(noteID string) error {
 			if strings.Contains(strings.ToLower(result.Error.Error()), "database is locked") {
 				// Calculate exponential backoff with jitter
 				baseBackoff := baseDelay * time.Duration(attempt+1)
-				jitter := time.Duration(rand.Float64() * 0.25 * float64(baseBackoff))
+				jitter := time.Duration(rand.Float64() * 0.25 * float64(baseBackoff)) //nolint:gosec // G404: math/rand is fine for jitter, not security-critical
 				delay := baseBackoff + jitter
 				log.Printf("[%s] Database locked, retrying in %v (attempt %d/%d, jitter %v)", txID, delay, attempt+1, maxRetries, jitter)
 				time.Sleep(delay)
@@ -1310,7 +1310,7 @@ func (ds *DataStore) UnlockNote(noteID string) error {
 			if strings.Contains(strings.ToLower(result.Error.Error()), "database is locked") {
 				// Calculate exponential backoff with jitter
 				baseBackoff := baseDelay * time.Duration(attempt+1)
-				jitter := time.Duration(rand.Float64() * 0.25 * float64(baseBackoff))
+				jitter := time.Duration(rand.Float64() * 0.25 * float64(baseBackoff)) //nolint:gosec // G404: math/rand is fine for jitter, not security-critical
 				delay := baseBackoff + jitter
 				log.Printf("[%s] Database locked, retrying in %v (attempt %d/%d, jitter %v)", txID, delay, attempt+1, maxRetries, jitter)
 				time.Sleep(delay)
@@ -2187,7 +2187,7 @@ func (ds *DataStore) handleDatabaseLockError(attempt, maxRetries int, baseDelay 
 	// Calculate exponential backoff with jitter to avoid thundering herd
 	baseBackoff := baseDelay * time.Duration(attempt+1)
 	// Add 0-25% jitter to the base backoff
-	jitter := time.Duration(rand.Float64() * 0.25 * float64(baseBackoff))
+	jitter := time.Duration(rand.Float64() * 0.25 * float64(baseBackoff)) //nolint:gosec // G404: math/rand is fine for jitter, not security-critical
 	delay := baseBackoff + jitter
 
 	txLogger.Warn("Database locked, scheduling retry",

--- a/internal/myaudio/audio_filters_test.go
+++ b/internal/myaudio/audio_filters_test.go
@@ -268,10 +268,11 @@ func BenchmarkClampFloat64Slice_Sizes(b *testing.B) {
 			samples := make([]float64, sz.size)
 			for i := range samples {
 				// ~20% of samples need clamping (realistic for distorted audio)
+				//nolint:gosec // G404: math/rand is fine for test data generation
 				if rand.Float64() < 0.2 {
-					samples[i] = 1.0 + rand.Float64()
+					samples[i] = 1.0 + rand.Float64() //nolint:gosec // G404: test data
 				} else {
-					samples[i] = rand.Float64()*2 - 1
+					samples[i] = rand.Float64()*2 - 1 //nolint:gosec // G404: test data
 				}
 			}
 

--- a/internal/myaudio/audio_utils_test.go
+++ b/internal/myaudio/audio_utils_test.go
@@ -403,7 +403,7 @@ func BenchmarkMinMaxSumFloat64_Sizes(b *testing.B) {
 	for _, size := range sizes {
 		samples := make([]float64, size)
 		for i := range samples {
-			samples[i] = rand.Float64()*200 - 100 // -100 to +100
+			samples[i] = rand.Float64()*200 - 100 //nolint:gosec // G404: math/rand is fine for test data
 		}
 
 		b.Run(formatSize(size), func(b *testing.B) {
@@ -423,7 +423,7 @@ func BenchmarkScaleFloat64Slice_Sizes(b *testing.B) {
 	for _, size := range sizes {
 		samples := make([]float64, size)
 		for i := range samples {
-			samples[i] = rand.Float64()*2 - 1
+			samples[i] = rand.Float64()*2 - 1 //nolint:gosec // G404: math/rand is fine for test data
 		}
 
 		b.Run(formatSize(size), func(b *testing.B) {

--- a/internal/myaudio/equalizer/equalizer_test.go
+++ b/internal/myaudio/equalizer/equalizer_test.go
@@ -219,7 +219,7 @@ func TestFilterChain_ApplyBatch(t *testing.T) {
 	// Generate white noise
 	input := make([]float64, 48000)
 	for i := range input {
-		input[i] = rand.Float64()*2 - 1
+		input[i] = rand.Float64()*2 - 1 //nolint:gosec // G404: math/rand is fine for test data
 	}
 
 	fc.ApplyBatch(input)

--- a/internal/myaudio/soundlevel_rms_test.go
+++ b/internal/myaudio/soundlevel_rms_test.go
@@ -137,7 +137,7 @@ func TestCalculateRMS_AudioRealistic(t *testing.T) {
 		// Generate random values in [-1, 1]
 		samples := make([]float64, 48000)
 		for i := range samples {
-			samples[i] = rand.Float64()*2 - 1
+			samples[i] = rand.Float64()*2 - 1 //nolint:gosec // G404: math/rand is fine for test data
 		}
 		result := calculateRMS(samples)
 		// White noise RMS should be close to 1/sqrt(3) ≈ 0.577
@@ -227,7 +227,7 @@ func BenchmarkCalculateRMS_DataPatterns(b *testing.B) {
 			create: func() []float64 {
 				samples := make([]float64, size)
 				for i := range samples {
-					samples[i] = rand.Float64()*2 - 1
+					samples[i] = rand.Float64()*2 - 1 //nolint:gosec // G404: math/rand is fine for test data
 				}
 				return samples
 			},
@@ -310,7 +310,7 @@ func BenchmarkCalculateRMS_ThroughputPerSecond(b *testing.B) {
 	for i := range bands {
 		bands[i] = make([]float64, samplesPerBand)
 		for j := range bands[i] {
-			bands[i][j] = rand.Float64()*2 - 1
+			bands[i][j] = rand.Float64()*2 - 1 //nolint:gosec // G404: math/rand is fine for test data
 		}
 	}
 


### PR DESCRIPTION
## Summary
Add `//nolint:gosec` comments for `math/rand` usage that doesn't require cryptographic randomness.

## Analysis
All 12 G404 findings were reviewed and determined to be **non-security-critical**:

### Production Code (3 occurrences)
| File | Usage | Justification |
|------|-------|---------------|
| `datastore/interfaces.go` | Jitter for retry backoff | Randomness prevents thundering herd, no security impact |

### Test Files (9 occurrences)
| File | Usage |
|------|-------|
| `audio_filters_test.go` | Random audio samples for benchmarks |
| `audio_utils_test.go` | Random test data |
| `equalizer/equalizer_test.go` | White noise generation |
| `soundlevel_rms_test.go` | Random samples for RMS testing |

## Why nolint instead of crypto/rand?
- `crypto/rand` is significantly slower and unnecessary for non-security use cases
- Jitter for backoff timing doesn't need cryptographic strength
- Test data generation only needs statistical randomness, not unpredictability

## Test plan
- [x] golangci-lint reports no G404 findings
- [x] All tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced internal code quality and maintainability by strategically adding lint suppression directives across multiple systems. Updates affect database connection retry logic and audio processing test suites. These non-functional changes improve code standards while preserving all existing user-facing features and behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->