### PR TITLE
fix(lint): suppress gosec G204 for validated subprocess execution

### DIFF
--- a/internal/analysis/processor/execute.go
+++ b/internal/analysis/processor/execute.go
@@ -86,7 +86,7 @@ func (a ExecuteCommandAction) ExecuteContext(ctx context.Context, data any) erro
 	cmdCtx, cancel := context.WithTimeout(ctx, ExecuteCommandTimeout)
 	defer cancel()
 	
-	cmd := exec.CommandContext(cmdCtx, cmdPath, args...)
+	cmd := exec.CommandContext(cmdCtx, cmdPath, args...) //nolint:gosec // G204: cmdPath validated by validateCommandPath(), args by buildSafeArguments()
 
 	// Set a clean environment
 	cmd.Env = getCleanEnvironment()

--- a/internal/audiocore/utils/ffmpeg/process.go
+++ b/internal/audiocore/utils/ffmpeg/process.go
@@ -92,7 +92,7 @@ func (p *process) start() error {
 		"command", p.config.FFmpegPath,
 		"arg_count", len(args))
 	
-	p.cmd = exec.CommandContext(p.ctx, p.config.FFmpegPath, args...)
+	p.cmd = exec.CommandContext(p.ctx, p.config.FFmpegPath, args...) //nolint:gosec // G204: FFmpegPath from validated config, args built internally
 
 	// Set up pipes
 	var err error

--- a/internal/conf/utils.go
+++ b/internal/conf/utils.go
@@ -415,7 +415,7 @@ func GetFfmpegVersion() (version string, major, minor int) {
 	}
 
 	// Execute ffmpeg -version
-	cmd := exec.Command(ffmpegPath, "-version")
+	cmd := exec.Command(ffmpegPath, "-version") //nolint:gosec // G204: ffmpegPath resolved via exec.LookPath()
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return "", 0, 0
@@ -552,7 +552,7 @@ func IsSoxAvailable() (isAvailable bool, formats []string) {
 	}
 
 	// Execute SoX with the help flag to get its output
-	cmd := exec.Command(soxPath, "-h")
+	cmd := exec.Command(soxPath, "-h") //nolint:gosec // G204: soxPath resolved via exec.LookPath()
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return false, nil // Failed to execute SoX

--- a/internal/myaudio/ffmpeg_common.go
+++ b/internal/myaudio/ffmpeg_common.go
@@ -74,7 +74,7 @@ func GetAudioDuration(ctx context.Context, audioPath string) (float64, error) {
 	// -v error: suppress all output except errors
 	// -show_entries format=duration: only show duration from format section
 	// -of default=noprint_wrappers=1:nokey=1: output just the value, no formatting
-	cmd := exec.CommandContext(ctx, ffprobeBinary,
+	cmd := exec.CommandContext(ctx, ffprobeBinary, //nolint:gosec // G204: ffprobeBinary from conf.GetFfprobeBinaryName(), args are fixed
 		"-v", "error",
 		"-show_entries", "format=duration",
 		"-of", "default=noprint_wrappers=1:nokey=1",

--- a/internal/myaudio/ffmpeg_export.go
+++ b/internal/myaudio/ffmpeg_export.go
@@ -278,7 +278,7 @@ func runFFmpegCommand(ffmpegPath string, pcmData []byte, tempFilePath string, se
 	defer cancel()
 
 	// Create the FFmpeg command with context
-	cmd := exec.CommandContext(ctx, ffmpegPath, args...)
+	cmd := exec.CommandContext(ctx, ffmpegPath, args...) //nolint:gosec // G204: ffmpegPath from conf.GetFFmpegBinaryName(), args built internally
 
 	// Create a pipe to send PCM data to FFmpeg's stdin
 	stdin, err := cmd.StdinPipe()
@@ -592,7 +592,7 @@ func runCustomFFmpegCommandToBufferWithContext(ctx context.Context, ffmpegPath s
 	args = append(args, "pipe:1")
 
 	// Create the FFmpeg command with context
-	cmd := exec.CommandContext(ctx, ffmpegPath, args...)
+	cmd := exec.CommandContext(ctx, ffmpegPath, args...) //nolint:gosec // G204: ffmpegPath from conf.GetFFmpegBinaryName(), args built internally
 
 	// Create pipes for stdin and stdout
 	stdin, err := cmd.StdinPipe()
@@ -765,7 +765,7 @@ func AnalyzeAudioLoudnessWithContext(ctx context.Context, pcmData []byte, ffmpeg
 	}
 
 	// Create the FFmpeg command with context
-	cmd := exec.CommandContext(ctx, ffmpegPath, args...)
+	cmd := exec.CommandContext(ctx, ffmpegPath, args...) //nolint:gosec // G204: ffmpegPath from conf.GetFFmpegBinaryName(), args built internally
 
 	// Create a pipe to write PCM data to FFmpeg's stdin
 	stdin, err := cmd.StdinPipe()

--- a/internal/myaudio/ffmpeg_process_test.go
+++ b/internal/myaudio/ffmpeg_process_test.go
@@ -273,7 +273,7 @@ func TestFFmpegStream_ConcurrentCleanup(t *testing.T) {
 func createMockFFmpegCommand(tb testing.TB, duration time.Duration) *exec.Cmd {
 	tb.Helper()
 	// Use sleep as a mock ffmpeg process
-	cmd := exec.Command("sleep", fmt.Sprintf("%.3f", duration.Seconds()))
+	cmd := exec.Command("sleep", fmt.Sprintf("%.3f", duration.Seconds())) //nolint:gosec // G204: test helper with hardcoded command
 	return cmd
 }
 
@@ -337,7 +337,7 @@ func assertNoZombieProcess(t *testing.T, pid int) {
 // Helper function to get child processes of a parent PID
 func getChildProcesses(t *testing.T, parentPid int) []int {
 	t.Helper()
-	cmd := exec.Command("pgrep", "-P", fmt.Sprintf("%d", parentPid))
+	cmd := exec.Command("pgrep", "-P", fmt.Sprintf("%d", parentPid)) //nolint:gosec // G204: test helper with hardcoded command
 	output, err := cmd.Output()
 	if err != nil {
 		// No children found

--- a/internal/myaudio/ffmpeg_restart_patterns_test.go
+++ b/internal/myaudio/ffmpeg_restart_patterns_test.go
@@ -52,7 +52,7 @@ func TestFFmpegStream_RealWorldRestartPattern(t *testing.T) {
 			// Create a process that exits quickly (< 5 seconds)
 			// This simulates ffmpeg failing to connect or maintain RTSP stream
 			runtimeMs := 1000 + (i%4)*1000 // 1-4 seconds
-			mockCmd := exec.Command("sh", "-c", fmt.Sprintf("sleep %.3f", float64(runtimeMs)/1000.0))
+			mockCmd := exec.Command("sh", "-c", fmt.Sprintf("sleep %.3f", float64(runtimeMs)/1000.0)) //nolint:gosec // G204: test with hardcoded command
 
 			stream.cmdMu.Lock()
 			// Go 1.25: time.Now() returns fake time (starts at 2000-01-01 00:00:00 UTC)

--- a/internal/myaudio/ffmpeg_stream.go
+++ b/internal/myaudio/ffmpeg_stream.go
@@ -872,7 +872,7 @@ func (s *FFmpegStream) startProcess() error {
 	)
 
 	// Create FFmpeg command
-	s.cmd = exec.CommandContext(s.ctx, settings.FfmpegPath, args...)
+	s.cmd = exec.CommandContext(s.ctx, settings.FfmpegPath, args...) //nolint:gosec // G204: FfmpegPath from validated settings, args built internally
 
 	// Setup process group
 	setupProcessGroup(s.cmd)

--- a/internal/myaudio/validate.go
+++ b/internal/myaudio/validate.go
@@ -275,7 +275,7 @@ func executeFFprobe(ctx context.Context, audioPath string) (string, error) {
 	}
 
 	// Build ffprobe command to get format and stream information
-	cmd := exec.CommandContext(ctx, ffprobeBinary,
+	cmd := exec.CommandContext(ctx, ffprobeBinary, //nolint:gosec // G204: ffprobeBinary from conf.GetFfprobeBinaryName(), args are fixed
 		"-v", "error",
 		"-show_entries", "format=duration,bit_rate:stream=sample_rate,channels,codec_name",
 		"-of", "csv=p=0",

--- a/internal/support/collector.go
+++ b/internal/support/collector.go
@@ -695,7 +695,7 @@ func (c *Collector) collectJournalLogs(ctx context.Context, duration time.Durati
 		"maxLines", maxJournalLogLines)
 
 	// Run journalctl command with line limit
-	cmd := exec.CommandContext(ctx, "journalctl",
+	cmd := exec.CommandContext(ctx, "journalctl", //nolint:gosec // G204: hardcoded command, args are constants/formatted values
 		journalFlagUnit, systemdServiceName,
 		journalFlagSince, since,
 		journalFlagNoPager,
@@ -1513,7 +1513,7 @@ func (c *Collector) getJournaldLogs(ctx context.Context, duration time.Duration)
 	// Use same line limit as collectJournalLogs
 	const maxJournalLines = 5000
 
-	cmd := exec.CommandContext(ctx, "journalctl",
+	cmd := exec.CommandContext(ctx, "journalctl", //nolint:gosec // G204: hardcoded command, args are constants/formatted values
 		"-u", "birdnet-go.service",
 		"--since", since,
 		"--no-pager",


### PR DESCRIPTION
## Summary
Add `//nolint:gosec` comments for `exec.Command`/`exec.CommandContext` calls that are false positives - all command paths are validated, from configuration, or hardcoded.

## Analysis
All 15 G204 findings were reviewed and determined to be **safe**:

### Production Code (12 occurrences)

| File | Command Source | Why Safe |
|------|----------------|----------|
| `execute.go` | `validateCommandPath()` | Path explicitly validated before use |
| `ffmpeg/process.go` | `config.FFmpegPath` | From validated configuration |
| `conf/utils.go` | `exec.LookPath()` | Resolved from system PATH |
| `ffmpeg_common.go` | `conf.GetFfprobeBinaryName()` | Platform-specific constant |
| `ffmpeg_export.go` (3) | `conf.GetFFmpegBinaryName()` | Platform-specific constant |
| `ffmpeg_stream.go` | `settings.FfmpegPath` | From validated settings |
| `validate.go` | `conf.GetFfprobeBinaryName()` | Platform-specific constant |
| `collector.go` (2) | Hardcoded `"journalctl"` | Fixed command string |

### Test Files (3 occurrences)
All use hardcoded commands (`sleep`, `sh`, `pgrep`) for mocking.

## Why nolint instead of code changes?
- Command paths already come from trusted sources
- Adding redundant validation would complicate code without security benefit
- The G204 rule can't detect that validation already exists upstream

## Test plan
- [x] golangci-lint reports no G204 findings
- [x] All tests pass