### PR TITLE
fix(lint): suppress gosec G115 for intentional integer conversions

### DIFF
--- a/internal/analysis/processor/threshold_persistence.go
+++ b/internal/analysis/processor/threshold_persistence.go
@@ -197,7 +197,7 @@ func (p *Processor) persistDynamicThresholds() error {
 		}
 
 		// Exponential backoff: 100ms, 200ms, 400ms
-		backoffDuration := baseDelay * time.Duration(1<<uint(attempt))
+		backoffDuration := baseDelay * time.Duration(1<<uint(attempt)) //nolint:gosec // G115: attempt is bounded by maxRetries (3), no overflow risk
 		GetLogger().Warn("Database locked, retrying after backoff",
 			"attempt", attempt+1,
 			"max_retries", maxRetries,

--- a/internal/audiocore/processors/gain.go
+++ b/internal/audiocore/processors/gain.go
@@ -159,7 +159,7 @@ func (gp *GainProcessor) applyGainS16LE(buffer []byte, gain float64) {
 	// Process in pairs of bytes (16-bit samples)
 	for i := 0; i < len(buffer)-1; i += 2 {
 		// Convert bytes to int16
-		sample := int16(binary.LittleEndian.Uint16(buffer[i : i+2]))
+		sample := int16(binary.LittleEndian.Uint16(buffer[i : i+2])) //nolint:gosec // G115: intentional uint16→int16 bit reinterpretation for PCM audio
 
 		// Apply gain with clipping
 		amplified := float64(sample) * gain
@@ -170,7 +170,7 @@ func (gp *GainProcessor) applyGainS16LE(buffer []byte, gain float64) {
 		}
 
 		// Convert back to bytes
-		binary.LittleEndian.PutUint16(buffer[i:i+2], uint16(int16(amplified)))
+		binary.LittleEndian.PutUint16(buffer[i:i+2], uint16(int16(amplified))) //nolint:gosec // G115: intentional int16→uint16 bit reinterpretation for PCM audio
 	}
 }
 

--- a/internal/audiocore/processors/gain_test.go
+++ b/internal/audiocore/processors/gain_test.go
@@ -80,10 +80,10 @@ func TestGainProcessorProcess(t *testing.T) {
 		buffer := make([]byte, 8)
 		var neg1000 int16 = -1000
 		var neg16000 int16 = -16000
-		binary.LittleEndian.PutUint16(buffer[0:2], uint16(int16(1000)))
-		binary.LittleEndian.PutUint16(buffer[2:4], uint16(neg1000))
-		binary.LittleEndian.PutUint16(buffer[4:6], uint16(int16(16000)))
-		binary.LittleEndian.PutUint16(buffer[6:8], uint16(neg16000))
+		binary.LittleEndian.PutUint16(buffer[0:2], uint16(int16(1000)))   //nolint:gosec // G115: intentional int16→uint16 for PCM test data
+		binary.LittleEndian.PutUint16(buffer[2:4], uint16(neg1000))     //nolint:gosec // G115: intentional int16→uint16 for PCM test data
+		binary.LittleEndian.PutUint16(buffer[4:6], uint16(int16(16000))) //nolint:gosec // G115: intentional int16→uint16 for PCM test data
+		binary.LittleEndian.PutUint16(buffer[6:8], uint16(neg16000))    //nolint:gosec // G115: intentional int16→uint16 for PCM test data
 
 		input := &audiocore.AudioData{
 			Buffer: buffer,
@@ -102,10 +102,10 @@ func TestGainProcessorProcess(t *testing.T) {
 		require.NotNil(t, output)
 
 		// Check output values
-		assert.Equal(t, int16(2000), int16(binary.LittleEndian.Uint16(output.Buffer[0:2])))
-		assert.Equal(t, int16(-2000), int16(binary.LittleEndian.Uint16(output.Buffer[2:4])))
-		assert.Equal(t, int16(32000), int16(binary.LittleEndian.Uint16(output.Buffer[4:6])))
-		assert.Equal(t, int16(-32000), int16(binary.LittleEndian.Uint16(output.Buffer[6:8])))
+		assert.Equal(t, int16(2000), int16(binary.LittleEndian.Uint16(output.Buffer[0:2])))   //nolint:gosec // G115: intentional uint16→int16 for PCM test verification
+		assert.Equal(t, int16(-2000), int16(binary.LittleEndian.Uint16(output.Buffer[2:4]))) //nolint:gosec // G115: intentional uint16→int16 for PCM test verification
+		assert.Equal(t, int16(32000), int16(binary.LittleEndian.Uint16(output.Buffer[4:6]))) //nolint:gosec // G115: intentional uint16→int16 for PCM test verification
+		assert.Equal(t, int16(-32000), int16(binary.LittleEndian.Uint16(output.Buffer[6:8]))) //nolint:gosec // G115: intentional uint16→int16 for PCM test verification
 	})
 
 	t.Run("PCM S16LE Clipping", func(t *testing.T) {
@@ -116,8 +116,8 @@ func TestGainProcessorProcess(t *testing.T) {
 		// Create test buffer with values that will clip
 		buffer := make([]byte, 4)
 		var neg20000 int16 = -20000
-		binary.LittleEndian.PutUint16(buffer[0:2], uint16(int16(20000)))
-		binary.LittleEndian.PutUint16(buffer[2:4], uint16(neg20000))
+		binary.LittleEndian.PutUint16(buffer[0:2], uint16(int16(20000))) //nolint:gosec // G115: intentional int16→uint16 for PCM test data
+		binary.LittleEndian.PutUint16(buffer[2:4], uint16(neg20000))  //nolint:gosec // G115: intentional int16→uint16 for PCM test data
 
 		input := &audiocore.AudioData{
 			Buffer: buffer,
@@ -136,8 +136,8 @@ func TestGainProcessorProcess(t *testing.T) {
 		require.NotNil(t, output)
 
 		// Check clipping
-		assert.Equal(t, int16(math.MaxInt16), int16(binary.LittleEndian.Uint16(output.Buffer[0:2])))
-		assert.Equal(t, int16(math.MinInt16), int16(binary.LittleEndian.Uint16(output.Buffer[2:4])))
+		assert.Equal(t, int16(math.MaxInt16), int16(binary.LittleEndian.Uint16(output.Buffer[0:2]))) //nolint:gosec // G115: intentional uint16→int16 for PCM test verification
+		assert.Equal(t, int16(math.MinInt16), int16(binary.LittleEndian.Uint16(output.Buffer[2:4]))) //nolint:gosec // G115: intentional uint16→int16 for PCM test verification
 	})
 
 	t.Run("PCM F32LE Processing", func(t *testing.T) {

--- a/internal/birdnet/genus_memory_test.go
+++ b/internal/birdnet/genus_memory_test.go
@@ -134,7 +134,7 @@ func TestMemoryLeaks(t *testing.T) {
 
 	// Calculate memory growth
 	allocGrowth := m2.TotalAlloc - m1.TotalAlloc
-	heapGrowth := int64(m2.HeapAlloc) - int64(m1.HeapAlloc)
+	heapGrowth := int64(m2.HeapAlloc) - int64(m1.HeapAlloc) //nolint:gosec // G115: heap alloc in bytes always fits int64 (max ~8 exabytes)
 
 	t.Logf("After %d iterations:", iterations)
 	t.Logf("  Total allocations: %d bytes", allocGrowth)

--- a/internal/datastore/resource_monitor.go
+++ b/internal/datastore/resource_monitor.go
@@ -254,8 +254,8 @@ func captureProcessInfo() (ProcessInfo, error) {
 	var memStats runtime.MemStats
 	runtime.ReadMemStats(&memStats)
 
-	info.HeapAllocMB = int64(memStats.HeapAlloc / 1024 / 1024)
-	info.HeapSysMB = int64(memStats.HeapSys / 1024 / 1024)
+	info.HeapAllocMB = int64(memStats.HeapAlloc / 1024 / 1024) //nolint:gosec // G115: memory in MB always fits int64 (max ~8 exabytes)
+	info.HeapSysMB = int64(memStats.HeapSys / 1024 / 1024)     //nolint:gosec // G115: memory in MB always fits int64 (max ~8 exabytes)
 
 	// Platform-specific process memory info will be implemented per OS
 	if procMem, err := getProcessMemoryUsage(); err == nil {

--- a/internal/datastore/resource_monitor_unix.go
+++ b/internal/datastore/resource_monitor_unix.go
@@ -171,7 +171,7 @@ func getProcessMemoryUsage() (*ProcessMemoryUsage, error) {
 	}
 
 	return &ProcessMemoryUsage{
-		ResidentMB: int64(vmRSS / 1024),
-		VirtualMB:  int64(vmSize / 1024),
+		ResidentMB: int64(vmRSS / 1024),  //nolint:gosec // G115: memory in MB always fits int64 (max ~8 exabytes)
+		VirtualMB:  int64(vmSize / 1024), //nolint:gosec // G115: memory in MB always fits int64 (max ~8 exabytes)
 	}, nil
 }

--- a/internal/diskmanager/pools_concurrent_test.go
+++ b/internal/diskmanager/pools_concurrent_test.go
@@ -49,7 +49,7 @@ func TestCurrentPoolSizeConcurrentDecrement(t *testing.T) {
 
 	// Verify final state
 	finalSize := poolMetrics.CurrentPoolSize.Load()
-	totalAttempts := uint64(numGoroutines * opsPerGoroutine)
+	totalAttempts := uint64(numGoroutines * opsPerGoroutine) //nolint:gosec // G115: test constants are small positive values
 
 	// The number of successful decrements should not exceed initial size
 	if successfulDecrements.Load() > initialSize {

--- a/internal/myaudio/audio_conversion_bench_test.go
+++ b/internal/myaudio/audio_conversion_bench_test.go
@@ -18,7 +18,7 @@ func BenchmarkConvert16BitToFloat32_Original(b *testing.B) {
 	// Fill with realistic audio pattern
 	for i := 0; i < len(testData); i += 2 {
 		// Simulate audio wave
-		value := int16(i % 32768)
+		value := int16(i % 32768) //nolint:gosec // G115: i%32768 is always in int16 range
 		testData[i] = byte(value & 0xFF)
 		testData[i+1] = byte(value >> 8)
 	}
@@ -55,7 +55,7 @@ func BenchmarkConvert16BitToFloat32_WithPool(b *testing.B) {
 	// Fill with realistic audio pattern
 	for i := 0; i < len(testData); i += 2 {
 		// Simulate audio wave
-		value := int16(i % 32768)
+		value := int16(i % 32768) //nolint:gosec // G115: i%32768 is always in int16 range
 		testData[i] = byte(value & 0xFF)
 		testData[i+1] = byte(value >> 8)
 	}
@@ -99,7 +99,7 @@ func BenchmarkConvert16BitToFloat32_Various_Sizes(b *testing.B) {
 			
 			// Fill with test pattern
 			for i := 0; i < len(testData); i += 2 {
-				value := int16(i % 32768)
+				value := int16(i % 32768) //nolint:gosec // G115: i%32768 is always in int16 range
 				testData[i] = byte(value & 0xFF)
 				testData[i+1] = byte(value >> 8)
 			}
@@ -128,7 +128,7 @@ func BenchmarkConvert16BitToFloat32_Concurrent(b *testing.B) {
 	// Create test data
 	testData := make([]byte, conf.BufferSize)
 	for i := 0; i < len(testData); i += 2 {
-		value := int16(i % 32768)
+		value := int16(i % 32768) //nolint:gosec // G115: i%32768 is always in int16 range
 		testData[i] = byte(value & 0xFF)
 		testData[i+1] = byte(value >> 8)
 	}
@@ -169,7 +169,7 @@ func benchmarkOriginalConversion(b *testing.B) {
 	// Fill with realistic audio pattern
 	for i := 0; i < len(testData); i += 2 {
 		// Simulate audio wave
-		value := int16(i % 32768)
+		value := int16(i % 32768) //nolint:gosec // G115: i%32768 is always in int16 range
 		testData[i] = byte(value & 0xFF)
 		testData[i+1] = byte(value >> 8)
 	}
@@ -205,7 +205,7 @@ func benchmarkPooledConversion(b *testing.B) {
 	// Fill with realistic audio pattern
 	for i := 0; i < len(testData); i += 2 {
 		// Simulate audio wave
-		value := int16(i % 32768)
+		value := int16(i % 32768) //nolint:gosec // G115: i%32768 is always in int16 range
 		testData[i] = byte(value & 0xFF)
 		testData[i+1] = byte(value >> 8)
 	}

--- a/internal/myaudio/audio_filters_test.go
+++ b/internal/myaudio/audio_filters_test.go
@@ -146,8 +146,8 @@ func TestBytesToFloat64_RoundTrip(t *testing.T) {
 
 	// The round trip may lose 1 LSB due to 32767 vs 32768 scaling
 	for i := 0; i < len(original); i += 2 {
-		origVal := int16(binary.LittleEndian.Uint16(original[i:]))
-		outVal := int16(binary.LittleEndian.Uint16(output[i:]))
+		origVal := int16(binary.LittleEndian.Uint16(original[i:])) //nolint:gosec // G115: intentional uint16→int16 for PCM test verification
+		outVal := int16(binary.LittleEndian.Uint16(output[i:]))    //nolint:gosec // G115: intentional uint16→int16 for PCM test verification
 		assert.InDelta(t, origVal, outVal, 1, "sample %d should round-trip within 1 LSB", i/2)
 	}
 }
@@ -308,8 +308,8 @@ func BenchmarkBytesToFloat64_Sizes(b *testing.B) {
 		bytes := make([]byte, sz.size*2)
 		// Fill with realistic audio pattern
 		for i := 0; i < sz.size; i++ {
-			val := int16(math.Sin(2*math.Pi*440.0*float64(i)/48000.0) * 32767)
-			binary.LittleEndian.PutUint16(bytes[i*2:], uint16(val))
+			val := int16(math.Sin(2*math.Pi*440.0*float64(i)/48000.0) * 32767) //nolint:gosec // G115: sin*32767 is always in int16 range
+			binary.LittleEndian.PutUint16(bytes[i*2:], uint16(val))            //nolint:gosec // G115: intentional int16→uint16 for PCM test data
 		}
 
 		b.Run(sz.name, func(b *testing.B) {
@@ -392,8 +392,8 @@ func BenchmarkApplyFilters_FullPipeline(b *testing.B) {
 	for _, sz := range sizes {
 		samples := make([]byte, sz.size*2)
 		for i := 0; i < sz.size; i++ {
-			val := int16(math.Sin(2*math.Pi*440.0*float64(i)/48000.0) * 32767)
-			binary.LittleEndian.PutUint16(samples[i*2:], uint16(val))
+			val := int16(math.Sin(2*math.Pi*440.0*float64(i)/48000.0) * 32767) //nolint:gosec // G115: sin*32767 is always in int16 range
+			binary.LittleEndian.PutUint16(samples[i*2:], uint16(val))          //nolint:gosec // G115: intentional int16→uint16 for PCM test data
 		}
 
 		b.Run(sz.name, func(b *testing.B) {

--- a/internal/myaudio/audio_utils.go
+++ b/internal/myaudio/audio_utils.go
@@ -91,7 +91,7 @@ func BytesToFloat64PCM16(samples []byte) []float64 {
 	floatSamples := make([]float64, sampleCount)
 	// Iterate by sample count to safely ignore any trailing odd byte
 	for i := range sampleCount {
-		floatSamples[i] = float64(int16(binary.LittleEndian.Uint16(samples[i*2:]))) / pcm16ScaleFactor
+		floatSamples[i] = float64(int16(binary.LittleEndian.Uint16(samples[i*2:]))) / pcm16ScaleFactor //nolint:gosec // G115: intentional uint16→int16 bit reinterpretation for PCM audio
 	}
 	return floatSamples
 }
@@ -130,7 +130,7 @@ func Float64ToBytesPCM16(floatSamples []float64, output []byte) error {
 	// Convert to bytes
 	for i, sample := range floatSamples {
 		intSample := int16(sample * pcm16MaxPositive)
-		binary.LittleEndian.PutUint16(output[i*2:], uint16(intSample))
+		binary.LittleEndian.PutUint16(output[i*2:], uint16(intSample)) //nolint:gosec // G115: intentional int16→uint16 bit reinterpretation for PCM audio
 	}
 	return nil
 }

--- a/internal/myaudio/audio_utils_test.go
+++ b/internal/myaudio/audio_utils_test.go
@@ -297,7 +297,7 @@ func TestFloat64ToBytesPCM16(t *testing.T) {
 		err := Float64ToBytesPCM16([]float64{1.0}, output)
 		require.NoError(t, err)
 		// Should be clamped to 32767
-		val := int16(binary.LittleEndian.Uint16(output))
+		val := int16(binary.LittleEndian.Uint16(output)) //nolint:gosec // G115: intentional uint16→int16 for PCM test verification
 		assert.Equal(t, int16(32767), val)
 	})
 
@@ -305,7 +305,7 @@ func TestFloat64ToBytesPCM16(t *testing.T) {
 		output := make([]byte, 2)
 		err := Float64ToBytesPCM16([]float64{-1.0}, output)
 		require.NoError(t, err)
-		val := int16(binary.LittleEndian.Uint16(output))
+		val := int16(binary.LittleEndian.Uint16(output)) //nolint:gosec // G115: intentional uint16→int16 for PCM test verification
 		assert.Equal(t, int16(-32767), val)
 	})
 
@@ -313,8 +313,8 @@ func TestFloat64ToBytesPCM16(t *testing.T) {
 		output := make([]byte, 2)
 		err := Float64ToBytesPCM16([]float64{1.5}, output)
 		require.NoError(t, err)
-		val := int16(binary.LittleEndian.Uint16(output))
-		assert.Equal(t, int16(32767), val) // Clamped to 1.0
+		val := int16(binary.LittleEndian.Uint16(output)) //nolint:gosec // G115: intentional uint16→int16 for PCM test verification
+		assert.Equal(t, int16(32767), val)               // Clamped to 1.0
 	})
 
 	t.Run("buffer_too_small", func(t *testing.T) {
@@ -444,8 +444,8 @@ func BenchmarkBytesToFloat64PCM16_Sizes(b *testing.B) {
 	for _, size := range sizes {
 		bytes := make([]byte, size*2)
 		for i := range size {
-			val := int16(math.Sin(2*math.Pi*440.0*float64(i)/48000.0) * 32767)
-			binary.LittleEndian.PutUint16(bytes[i*2:], uint16(val))
+			val := int16(math.Sin(2*math.Pi*440.0*float64(i)/48000.0) * 32767) //nolint:gosec // G115: sin*32767 is always in int16 range
+			binary.LittleEndian.PutUint16(bytes[i*2:], uint16(val))            //nolint:gosec // G115: intentional int16→uint16 for PCM test data
 		}
 
 		b.Run(formatSize(size), func(b *testing.B) {

--- a/internal/myaudio/buffer_pool_test.go
+++ b/internal/myaudio/buffer_pool_test.go
@@ -65,7 +65,7 @@ func runPoolConcurrencyWithStats(t *testing.T, bufferSize, numWorkers, opsPerWor
 
 	// Verify stats are consistent
 	stats := getStats()
-	totalOps := uint64(numWorkers * opsPerWorker)
+	totalOps := uint64(numWorkers * opsPerWorker) //nolint:gosec // G115: test constants are small positive values
 
 	hits := stats.GetHits()
 	misses := stats.GetMisses()

--- a/internal/myaudio/capture_buffer_bench_test.go
+++ b/internal/myaudio/capture_buffer_bench_test.go
@@ -283,7 +283,7 @@ func BenchmarkMemoryUsage(b *testing.B) {
 
 				// Calculate memory usage
 				memUsed := memStatsAfter.Alloc - memStatsBefore.Alloc
-				expectedSize := uint64(cfg.numSources * cfg.duration * cfg.sampleRate * cfg.bytesPerSample)
+				expectedSize := uint64(cfg.numSources * cfg.duration * cfg.sampleRate * cfg.bytesPerSample) //nolint:gosec // G115: test config values are small positive values
 
 				// Only log on first iteration to avoid spam
 				if i == 0 {

--- a/internal/myaudio/ffmpeg_restart_patterns_test.go
+++ b/internal/myaudio/ffmpeg_restart_patterns_test.go
@@ -313,7 +313,7 @@ func TestFFmpegStream_ExtendedBackoffPattern(t *testing.T) {
 		exponent := count - 1
 		exponent = min(exponent, maxBackoffExponent)
 
-		expectedBackoff := stream.backoffDuration * time.Duration(1<<uint(exponent))
+		expectedBackoff := stream.backoffDuration * time.Duration(1<<uint(exponent)) //nolint:gosec // G115: exponent is capped by maxBackoffExponent
 		expectedBackoff = min(expectedBackoff, stream.maxBackoff)
 
 		t.Logf("Restart count %d: backoff = %v", count, expectedBackoff)

--- a/internal/myaudio/ffmpeg_stream.go
+++ b/internal/myaudio/ffmpeg_stream.go
@@ -1609,7 +1609,7 @@ func (s *FFmpegStream) handleRestartBackoff() {
 	// Cap the exponent to prevent integer overflow
 	exponent := min(s.restartCount-1, maxBackoffExponent)
 
-	backoff := min(s.backoffDuration*time.Duration(1<<uint(exponent)), s.maxBackoff)
+	backoff := min(s.backoffDuration*time.Duration(1<<uint(exponent)), s.maxBackoff) //nolint:gosec // G115: exponent is capped by maxBackoffExponent (line 1610), no overflow risk
 
 	// Add rate limiting for very high restart counts to prevent runaway loops
 	if currentRestartCount > 50 {

--- a/internal/myaudio/ffmpeg_stream_test.go
+++ b/internal/myaudio/ffmpeg_stream_test.go
@@ -176,7 +176,7 @@ func TestFFmpegStream_BackoffCalculation(t *testing.T) {
 				// maxBackoffExponent constant
 				20)
 
-			backoff := min(stream.backoffDuration*time.Duration(1<<uint(exponent)), stream.maxBackoff)
+			backoff := min(stream.backoffDuration*time.Duration(1<<uint(exponent)), stream.maxBackoff) //nolint:gosec // G115: exponent is capped by min()
 
 			assert.Equal(t, tt.expectedWait, backoff)
 		})
@@ -456,7 +456,7 @@ func TestFFmpegStream_BackoffOverflowProtection(t *testing.T) {
 		// maxBackoffExponent constant
 		20)
 
-	expectedBackoff := min(stream.backoffDuration*time.Duration(1<<uint(exponent)), stream.maxBackoff)
+	expectedBackoff := min(stream.backoffDuration*time.Duration(1<<uint(exponent)), stream.maxBackoff) //nolint:gosec // G115: exponent is capped by min()
 
 	// The expected backoff should be the maximum allowed (2 minutes)
 	assert.Equal(t, 2*time.Minute, expectedBackoff)
@@ -464,7 +464,7 @@ func TestFFmpegStream_BackoffOverflowProtection(t *testing.T) {
 	// Verify the calculation doesn't panic or overflow
 	assert.NotPanics(t, func() {
 		// This should not panic due to overflow protection
-		testBackoff := stream.backoffDuration * time.Duration(1<<uint(exponent))
+		testBackoff := stream.backoffDuration * time.Duration(1<<uint(exponent)) //nolint:gosec // G115: exponent is capped by min()
 		_ = testBackoff
 	})
 }

--- a/internal/myaudio/source_registry_refcount_test.go
+++ b/internal/myaudio/source_registry_refcount_test.go
@@ -323,7 +323,7 @@ func TestReferenceCountingWithMultipleSources(t *testing.T) {
 
 	// Verify reference counts
 	for i, source := range sources {
-		expectedCount := int32(i + 1)
+		expectedCount := int32(i + 1) //nolint:gosec // G115: i is a small loop index (0-4)
 		if registry.refCounts[source.ID] == nil {
 			t.Errorf("Source %d: expected reference count %d, got nil", i, expectedCount)
 		} else if *registry.refCounts[source.ID] != expectedCount {

--- a/internal/myaudio/validate_test.go
+++ b/internal/myaudio/validate_test.go
@@ -113,13 +113,13 @@ func createTestWAVFileWithSize(t *testing.T, path string, size int64) {
 	dataSize := max(size-int64(len(wavHeader)), 0)
 
 	// Update chunk sizes in header
-	chunkSize := uint32(36 + dataSize)
+	chunkSize := uint32(36 + dataSize) //nolint:gosec // G115: test file sizes are small and fit in uint32
 	wavHeader[4] = byte(chunkSize)
 	wavHeader[5] = byte(chunkSize >> 8)
 	wavHeader[6] = byte(chunkSize >> 16)
 	wavHeader[7] = byte(chunkSize >> 24)
 
-	subchunk2Size := uint32(dataSize)
+	subchunk2Size := uint32(dataSize) //nolint:gosec // G115: test file sizes are small and fit in uint32
 	wavHeader[40] = byte(subchunk2Size)
 	wavHeader[41] = byte(subchunk2Size >> 8)
 	wavHeader[42] = byte(subchunk2Size >> 16)


### PR DESCRIPTION
## Summary
- Add nolint:gosec comments for 44 G115 (integer overflow conversion) false positives
- All flagged conversions are intentional and safe

## Categories Addressed

**PCM Audio Processing (int16↔uint16)**
- Standard bit reinterpretation for signed/unsigned audio samples
- Files: gain.go, audio_utils.go, and their tests

**Memory Statistics (uint64→int64)**
- Memory values in MB always fit in int64 (max ~8 exabytes)
- Files: resource_monitor.go, resource_monitor_unix.go

**Exponential Backoff (int→uint for bit shift)**
- Exponents are capped by constants or min() calls
- Files: threshold_persistence.go, ffmpeg_stream.go

**Test Files**
- Loop indices and test-specific calculations with known bounds
- Various *_test.go files

## Test plan
- [x] `golangci-lint run --enable=gosec` shows no G115 issues
- [x] All existing tests still pass