### PR TITLE
fix(lint): suppress gosec G304 for trusted file path operations

### DIFF
--- a/internal/analysis/directory.go
+++ b/internal/analysis/directory.go
@@ -86,7 +86,7 @@ func isFileLocked(path string) bool {
 		flag = os.O_RDONLY | syscall.O_NONBLOCK
 	}
 
-	file, err := os.OpenFile(path, flag, 0o600)
+	file, err := os.OpenFile(path, flag, 0o600) //nolint:gosec // G304: path is from directory walking, not user input
 	if err != nil {
 		// File is probably locked by another process
 		return true
@@ -97,7 +97,7 @@ func isFileLocked(path string) bool {
 
 	// On Windows, also try write access to be sure
 	if runtime.GOOS == "windows" {
-		file, err = os.OpenFile(path, os.O_WRONLY, 0o600)
+		file, err = os.OpenFile(path, os.O_WRONLY, 0o600) //nolint:gosec // G304: path is from directory walking, not user input
 		if err != nil {
 			return true
 		}
@@ -208,7 +208,7 @@ func processFile(path string, settings *conf.Settings, processedFiles map[string
 	lockFile := outputPath + ".processing"
 
 	// Try to create lock file
-	f, err := os.OpenFile(lockFile, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	f, err := os.OpenFile(lockFile, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600) //nolint:gosec // G304: lockFile derived from settings.Output.File.Path
 	if err != nil {
 		// Another instance is processing this file
 		return false, nil

--- a/internal/analysis/file.go
+++ b/internal/analysis/file.go
@@ -124,7 +124,7 @@ func validateAudioFile(filePath string) error {
 	}
 
 	// Open the file to check if it's a valid audio file
-	file, err := os.Open(filePath)
+	file, err := os.Open(filePath) //nolint:gosec // G304: filePath is from CLI args or directory walking
 	if err != nil {
 		return fmt.Errorf("\033[31m❌ Error opening file %s: %w\033[0m", filepath.Base(filePath), err)
 	}

--- a/internal/birdnet/birdnet.go
+++ b/internal/birdnet/birdnet.go
@@ -266,7 +266,7 @@ func (bn *BirdNET) getMetaModelData() ([]byte, error) {
 		}
 
 		// Load model from external file
-		data, err := os.ReadFile(modelPath)
+		data, err := os.ReadFile(modelPath) //nolint:gosec // G304: modelPath is from application settings
 		if err != nil {
 			return nil, errors.New(err).
 				Category(errors.CategoryFileIO).
@@ -743,7 +743,7 @@ func tryLoadModelFromStandardPaths(modelName, modelType string) (data []byte, pa
 
 	// Attempt to read from each candidate path directly (no os.Stat to avoid TOCTOU)
 	for _, candidatePath := range candidatePaths {
-		fileData, readErr := os.ReadFile(candidatePath)
+		fileData, readErr := os.ReadFile(candidatePath) //nolint:gosec // G304: candidatePath built from known safe paths
 		if readErr == nil {
 			// Successfully loaded model
 			return fileData, candidatePath, nil
@@ -783,7 +783,7 @@ func (bn *BirdNET) loadModel() ([]byte, error) {
 			modelPath = filepath.Join(homeDir, modelPath[2:])
 		}
 
-		data, err := os.ReadFile(modelPath)
+		data, err := os.ReadFile(modelPath) //nolint:gosec // G304: modelPath is from application settings
 		if err != nil {
 			return nil, errors.New(err).
 				Category(errors.CategoryFileIO).

--- a/internal/birdnet/range_filter.go
+++ b/internal/birdnet/range_filter.go
@@ -317,7 +317,7 @@ func loadSpeciesFromCSV(fileName string) ([]string, error) {
 	// Try to open the file in one of the default config paths.
 	for _, path := range configPaths {
 		fullPath := filepath.Join(path, fileName)
-		file, err = os.Open(fullPath)
+		file, err = os.Open(fullPath) //nolint:gosec // G304: fullPath built from known config paths
 		if err == nil {
 			break
 		}

--- a/internal/birdnet/taxonomy.go
+++ b/internal/birdnet/taxonomy.go
@@ -28,7 +28,7 @@ func LoadTaxonomyData(customPath string) (TaxonomyMap, ScientificNameIndex, erro
 
 	if customPath != "" {
 		// Load from custom file if provided
-		data, err = os.ReadFile(customPath)
+		data, err = os.ReadFile(customPath) //nolint:gosec // G304: customPath is from application settings
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to read custom taxonomy file %s: %w", customPath, err)
 		}

--- a/internal/conf/config_species_integration_test.go
+++ b/internal/conf/config_species_integration_test.go
@@ -68,7 +68,7 @@ realtime:
 	require.NoError(t, err, "Failed to write initial config")
 
 	// Read and parse the config
-	configData, err := os.ReadFile(configPath)
+	configData, err := os.ReadFile(configPath) //nolint:gosec // G304: configPath is test fixture path
 	require.NoError(t, err, "Failed to read config")
 
 	var settings Settings
@@ -106,7 +106,7 @@ realtime:
 	require.NoError(t, err, "Failed to save modified config")
 
 	// Read the saved config back
-	savedData, err := os.ReadFile(configPath)
+	savedData, err := os.ReadFile(configPath) //nolint:gosec // G304: configPath is test fixture path
 	require.NoError(t, err, "Failed to read saved config")
 
 	// Parse the saved YAML to verify structure

--- a/internal/conf/config_species_test.go
+++ b/internal/conf/config_species_test.go
@@ -195,7 +195,7 @@ func TestSettingsSaveAndLoad(t *testing.T) {
 	require.NoError(t, err, "Failed to save settings")
 
 	// Read the raw YAML file to check field presence
-	yamlContent, err := os.ReadFile(configPath)
+	yamlContent, err := os.ReadFile(configPath) //nolint:gosec // G304: configPath is test fixture path
 	require.NoError(t, err, "Failed to read config file")
 
 	// Parse YAML to check structure
@@ -233,7 +233,7 @@ func TestSettingsSaveAndLoad(t *testing.T) {
 	assert.True(t, hasThreshold, "threshold field should be saved")
 
 	// Load settings back
-	loadedContent, err := os.ReadFile(configPath)
+	loadedContent, err := os.ReadFile(configPath) //nolint:gosec // G304: configPath is test fixture path
 	require.NoError(t, err, "Failed to read config for loading")
 
 	var loadedSettings Settings

--- a/internal/conf/utils.go
+++ b/internal/conf/utils.go
@@ -622,7 +622,7 @@ func moveFile(src, dst string) error {
 		return fmt.Errorf("error resolving destination path: %w", err)
 	}
 
-	srcFile, err := os.Open(srcAbs)
+	srcFile, err := os.Open(srcAbs) //nolint:gosec // G304: srcAbs is filepath.Abs resolved path
 	if err != nil {
 		return fmt.Errorf("error opening source file: %w", err)
 	}
@@ -632,7 +632,7 @@ func moveFile(src, dst string) error {
 		}
 	}() // Ensure the source file is closed when we're done
 
-	dstFile, err := os.Create(dstAbs)
+	dstFile, err := os.Create(dstAbs) //nolint:gosec // G304: dstAbs is filepath.Abs resolved path
 	if err != nil {
 		return fmt.Errorf("error creating destination file: %w", err)
 	}

--- a/internal/datastore/sqlite.go
+++ b/internal/datastore/sqlite.go
@@ -54,7 +54,7 @@ func getDiskSpace(path string) (uint64, error) {
 func checkWritePermission(path string) error {
 	// Create a temporary file to test write permissions
 	tempFile := filepath.Join(filepath.Dir(path), ".tmp_write_test")
-	f, err := os.OpenFile(tempFile, os.O_CREATE|os.O_WRONLY, 0o600)
+	f, err := os.OpenFile(tempFile, os.O_CREATE|os.O_WRONLY, 0o600) //nolint:gosec // G304: tempFile derived from database path
 	if err != nil {
 		return errors.New(err).
 			Component("datastore").
@@ -120,7 +120,7 @@ func (s *SQLiteStore) createBackup(dbPath string) error {
 	backupPath := fmt.Sprintf("%s.backup_%s", dbPath, timestamp)
 
 	// Open source file
-	source, err := os.Open(dbPath)
+	source, err := os.Open(dbPath) //nolint:gosec // G304: dbPath is from application settings
 	if err != nil {
 		return errors.New(err).
 			Component("datastore").
@@ -136,7 +136,7 @@ func (s *SQLiteStore) createBackup(dbPath string) error {
 	}()
 
 	// Create backup file
-	destination, err := os.Create(backupPath)
+	destination, err := os.Create(backupPath) //nolint:gosec // G304: backupPath derived from dbPath (application settings)
 	if err != nil {
 		return errors.New(err).
 			Component("datastore").

--- a/internal/diskmanager/file_utils.go
+++ b/internal/diskmanager/file_utils.go
@@ -43,7 +43,7 @@ type Interface interface {
 
 // LoadPolicy loads the cleanup policies from a CSV file
 func LoadPolicy(policyFile string) (*Policy, error) {
-	file, err := os.Open(policyFile)
+	file, err := os.Open(policyFile) //nolint:gosec // G304: policyFile is from application settings
 	if err != nil {
 		descriptiveErr := errors.New(fmt.Errorf("diskmanager: failed to open policy file: %w", err)).
 			Component("diskmanager").
@@ -400,7 +400,7 @@ func contains(slice []string, item string) bool {
 
 // WriteSortedFilesToFile writes the sorted list of files to a text file for investigation
 func WriteSortedFilesToFile(files []FileInfo, filePath string) error {
-	file, err := os.Create(filePath)
+	file, err := os.Create(filePath) //nolint:gosec // G304: filePath is programmatically constructed
 	if err != nil {
 		return fmt.Errorf("failed to create file: %w", err)
 	}

--- a/internal/ebird/test_helpers.go
+++ b/internal/ebird/test_helpers.go
@@ -88,7 +88,7 @@ func setupMockServer(tb testing.TB, responses map[string]mockResponse) *httptest
 func loadTestData(tb testing.TB, filename string) string {
 	tb.Helper()
 
-	data, err := os.ReadFile(filepath.Join("testdata", filename))
+	data, err := os.ReadFile(filepath.Join("testdata", filename)) //nolint:gosec // G304: test fixture path
 	require.NoError(tb, err)
 
 	return string(data)

--- a/internal/myaudio/encode.go
+++ b/internal/myaudio/encode.go
@@ -93,7 +93,7 @@ func SavePCMDataToWAV(filePath string, pcmData []byte) error {
 	}
 
 	// Open a new file for writing
-	outFile, err := os.Create(filePath)
+	outFile, err := os.Create(filePath) //nolint:gosec // G304: filePath is programmatically constructed from settings
 	if err != nil {
 		enhancedErr := errors.New(err).
 			Component("myaudio").

--- a/internal/myaudio/ffmpeg_common_test.go
+++ b/internal/myaudio/ffmpeg_common_test.go
@@ -104,7 +104,7 @@ func createTestWAVFile(path string, durationSec float64) error {
 	numSamples := int(float64(sampleRate) * durationSec)
 	dataSize := numSamples * 2 // 16-bit = 2 bytes per sample
 
-	file, err := os.Create(path)
+	file, err := os.Create(path) //nolint:gosec // G304: test fixture path
 	if err != nil {
 		return err
 	}

--- a/internal/myaudio/ffmpeg_process_test.go
+++ b/internal/myaudio/ffmpeg_process_test.go
@@ -311,7 +311,7 @@ func assertNoZombieProcess(t *testing.T, pid int) {
 	t.Helper()
 	// Check /proc/[pid]/stat for zombie state
 	statPath := fmt.Sprintf("/proc/%d/stat", pid)
-	data, err := os.ReadFile(statPath)
+	data, err := os.ReadFile(statPath) //nolint:gosec // G304: statPath is /proc path with pid
 	if err != nil {
 		// Process doesn't exist, which is fine (not a zombie)
 		return

--- a/internal/myaudio/ffmpeg_zombie_test.go
+++ b/internal/myaudio/ffmpeg_zombie_test.go
@@ -268,7 +268,7 @@ func TestFFmpegStream_CleanupGoroutineLeak(t *testing.T) {
 func isProcessZombie(t *testing.T, pid int) bool {
 	t.Helper()
 	statPath := fmt.Sprintf("/proc/%d/stat", pid)
-	data, err := os.ReadFile(statPath)
+	data, err := os.ReadFile(statPath) //nolint:gosec // G304: statPath built from test PID, not user input
 	if err != nil {
 		// Process doesn't exist
 		return false
@@ -349,7 +349,7 @@ func TestFFmpegStream_ProcessStateTransitions(t *testing.T) {
 func getProcessState(t *testing.T, pid int) string {
 	t.Helper()
 	statPath := fmt.Sprintf("/proc/%d/stat", pid)
-	data, err := os.ReadFile(statPath)
+	data, err := os.ReadFile(statPath) //nolint:gosec // G304: statPath built from test PID, not user input
 	if err != nil {
 		return ""
 	}

--- a/internal/myaudio/readfile.go
+++ b/internal/myaudio/readfile.go
@@ -80,7 +80,7 @@ func GetAudioInfo(filePath string) (AudioInfo, error) {
 	}
 
 	// Open the file
-	file, err := os.Open(filePath)
+	file, err := os.Open(filePath) //nolint:gosec // G304: filePath is from CLI args or directory walking
 	if err != nil {
 		enhancedErr := errors.New(err).
 			Component("myaudio").

--- a/internal/myaudio/validate.go
+++ b/internal/myaudio/validate.go
@@ -410,7 +410,7 @@ func QuickValidateAudioFile(audioPath string) (bool, error) {
 	}
 
 	// Check if file can be opened (basic accessibility check)
-	file, err := os.Open(audioPath)
+	file, err := os.Open(audioPath) //nolint:gosec // G304: audioPath is from directory walking
 	if err != nil {
 		return false, nil
 	}

--- a/internal/myaudio/validate_test.go
+++ b/internal/myaudio/validate_test.go
@@ -126,7 +126,7 @@ func createTestWAVFileWithSize(t *testing.T, path string, size int64) {
 	wavHeader[43] = byte(subchunk2Size >> 24)
 
 	// Create the file
-	file, err := os.Create(path)
+	file, err := os.Create(path) //nolint:gosec // G304: test fixture path
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/observation/logfile.go
+++ b/internal/observation/logfile.go
@@ -22,7 +22,7 @@ func LogNoteToFile(settings *conf.Settings, note *datastore.Note) error {
 	absoluteFilePath := filepath.Join(basePath, fileName)
 
 	// Open the log file for appending, creating it if it doesn't exist
-	file, err := os.OpenFile(absoluteFilePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	file, err := os.OpenFile(absoluteFilePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600) //nolint:gosec // G304: absoluteFilePath is from settings.Output.File.Path
 	if err != nil {
 		fmt.Printf("failed to open file '%s': %v\n", absoluteFilePath, err)
 		return fmt.Errorf("failed to open file '%s': %w", absoluteFilePath, err)

--- a/internal/observation/observation.go
+++ b/internal/observation/observation.go
@@ -137,7 +137,7 @@ func WriteNotesTable(settings *conf.Settings, notes []datastore.Note, filename s
 			filename += ".txt"
 		}
 		// Create or truncate the file with the specified filename.
-		file, err := os.Create(filename)
+		file, err := os.Create(filename) //nolint:gosec // G304: filename is from settings.Output.File.Path
 		if err != nil {
 			return fmt.Errorf("failed to create file: %w", err)
 		}
@@ -204,7 +204,7 @@ func WriteNotesCsv(settings *conf.Settings, notes []datastore.Note, filename str
 			filename += ".csv"
 		}
 		// Create or truncate the file with the given filename.
-		file, err := os.Create(filename)
+		file, err := os.Create(filename) //nolint:gosec // G304: filename is from settings.Output.File.Path
 		if err != nil {
 			return fmt.Errorf("failed to create file %s: %w", filename, err)
 		}

--- a/internal/securefs/fifo.go
+++ b/internal/securefs/fifo.go
@@ -143,7 +143,7 @@ func openPlatformSpecificFIFO(pipePath, fifoPath string, openFlags int, sfs *Sec
 		}
 		// For Windows, open the named pipe directly
 		// Named pipes on Windows have their own security model independent of file permissions
-		return os.OpenFile(pipePath, openFlags, 0o600)
+		return os.OpenFile(pipePath, openFlags, 0o600) //nolint:gosec // G304: pipePath validated to start with \\.\pipe\
 	}
 
 	// For Unix systems, use SecureFS to maintain security

--- a/internal/support/collector.go
+++ b/internal/support/collector.go
@@ -513,7 +513,7 @@ func (c *Collector) collectSystemInfo() SystemInfo {
 func (c *Collector) collectConfig(scrub bool) (map[string]any, error) {
 	// Load config file
 	configPath := filepath.Join(c.configPath, "config.yaml")
-	data, err := os.ReadFile(configPath)
+	data, err := os.ReadFile(configPath) //nolint:gosec // G304: configPath is from c.configPath (application config directory)
 	if err != nil {
 		return nil, errors.New(err).
 			Component("support").
@@ -935,7 +935,7 @@ func (c *Collector) collectLogFiles(duration time.Duration, maxSize int64, anony
 // parseLogFile parses a log file and extracts entries
 func (c *Collector) parseLogFile(path string, cutoffTime time.Time, maxSize int64, anonymizePII bool) (logs []LogEntry, totalSize int64) {
 
-	file, err := os.Open(path)
+	file, err := os.Open(path) //nolint:gosec // G304: path is from known log file locations
 	if err != nil {
 		// Log file might not exist or be inaccessible, which is fine
 		return logs, 0
@@ -1046,7 +1046,7 @@ func sortLogsByTime(logs []LogEntry) {
 // addConfigToArchive adds the config file to the archive in YAML format with scrubbing
 func (c *Collector) addConfigToArchive(w *zip.Writer, scrubSensitive bool) error {
 	configPath := filepath.Join(c.configPath, "config.yaml")
-	data, err := os.ReadFile(configPath)
+	data, err := os.ReadFile(configPath) //nolint:gosec // G304: configPath is from c.configPath (application config directory)
 	if err != nil {
 		return errors.New(err).
 			Component("support").
@@ -1426,7 +1426,7 @@ func (lfc *logFileCollector) addNoLogsNote(w *zip.Writer) {
 
 // addFileToArchive adds a single file to the zip archive
 func (c *Collector) addFileToArchive(w *zip.Writer, sourcePath, archivePath string) error {
-	file, err := os.Open(sourcePath)
+	file, err := os.Open(sourcePath) //nolint:gosec // G304: sourcePath is from known log/config file locations
 	if err != nil {
 		return err
 	}
@@ -1465,7 +1465,7 @@ func (c *Collector) addLogFileToArchive(w *zip.Writer, sourcePath, archivePath s
 	}
 
 	// Read the file content for anonymization
-	file, err := os.Open(sourcePath)
+	file, err := os.Open(sourcePath) //nolint:gosec // G304: sourcePath is from known log file locations
 	if err != nil {
 		return err
 	}

--- a/main.go
+++ b/main.go
@@ -56,7 +56,7 @@ func mainWithExitCode() int {
 		now := time.Now()
 		profilePath := fmt.Sprintf("profile_%s.pprof", now.Format("20060102_150405"))
 
-		f, err := os.Create(profilePath)
+		f, err := os.Create(profilePath) //nolint:gosec // G304: profilePath is programmatically constructed with timestamp
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating profile file: %v\n", err)
 			return 1


### PR DESCRIPTION
## Summary
- Adds nolint:gosec comments to 39 file inclusion (G304) warnings across 23 files
- All flagged paths come from trusted sources in this desktop/server application
- Completes gosec linter compliance (0 issues remaining)

## Context
G304 ("Potential file inclusion via variable") is designed to catch path traversal vulnerabilities in web applications where untrusted user input constructs file paths. This project is a desktop/server application where all file paths come from trusted sources:

| Source Type | Examples |
|-------------|----------|
| Configuration | `settings.BirdNET.ModelPath`, `settings.Output.File.Path` |
| Directory walking | `filepath.Walk` results passed to callbacks |
| CLI arguments | File analysis mode paths |
| Database paths | Derived from application settings |
| Test fixtures | `t.TempDir()`, programmatic paths |
| ML models | Known config locations (`~/.config/birdnet-go/`) |

## Files Modified
- `internal/analysis/` - directory.go, file.go (4 suppressions)
- `internal/birdnet/` - birdnet.go, range_filter.go, taxonomy.go (5 suppressions)
- `internal/conf/` - utils.go, config_species_*_test.go (6 suppressions)
- `internal/datastore/` - sqlite.go (3 suppressions)
- `internal/diskmanager/` - file_utils.go (2 suppressions)
- `internal/ebird/` - test_helpers.go (1 suppression)
- `internal/myaudio/` - encode.go, readfile.go, validate.go, *_test.go (8 suppressions)
- `internal/observation/` - logfile.go, observation.go (3 suppressions)
- `internal/securefs/` - fifo.go (1 suppression)
- `internal/support/` - collector.go (5 suppressions)
- `main.go` (1 suppression)

## Test plan
- [x] Verified `golangci-lint run --enable=gosec` returns 0 issues
- [ ] CI passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added static analysis lint directives across the codebase to suppress warnings on trusted file operations where paths originate from application settings, configuration, or internal sources. No functional changes to end-user features or behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->