### PR TITLE
refactor: remove obsolete newUI setting

### DIFF
--- a/frontend/src/lib/desktop/features/settings/pages/MainSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/MainSettingsPage.svelte
@@ -173,10 +173,8 @@
           fallbackPolicy: 'all',
         },
         summaryLimit: 100,
-        newUI: false,
       }),
       locale: $dashboardSettings?.locale ?? (getLocale() as string),
-      newUI: $dashboardSettings?.newUI ?? false,
       spectrogram: $dashboardSettings?.spectrogram ?? DEFAULT_SPECTROGRAM_SETTINGS,
     },
     weather: $realtimeSettings?.weather || weatherDefaults,
@@ -209,14 +207,12 @@
       hasSettingsChanged(
         {
           locale: store.originalData.realtime?.dashboard?.locale,
-          newUI: store.originalData.realtime?.dashboard?.newUI,
           summaryLimit: store.originalData.realtime?.dashboard?.summaryLimit,
           thumbnails: store.originalData.realtime?.dashboard?.thumbnails,
           spectrogram: store.originalData.realtime?.dashboard?.spectrogram,
         },
         {
           locale: store.formData.realtime?.dashboard?.locale,
-          newUI: store.formData.realtime?.dashboard?.newUI,
           summaryLimit: store.formData.realtime?.dashboard?.summaryLimit,
           thumbnails: store.formData.realtime?.dashboard?.thumbnails,
           spectrogram: store.formData.realtime?.dashboard?.spectrogram,
@@ -1517,74 +1513,42 @@
       description={t('settings.main.sections.interface.description')}
       originalData={{
         locale: store.originalData.realtime?.dashboard?.locale,
-        newUI: store.originalData.realtime?.dashboard?.newUI,
         summaryLimit: store.originalData.realtime?.dashboard?.summaryLimit,
       }}
       currentData={{
         locale: store.formData.realtime?.dashboard?.locale,
-        newUI: store.formData.realtime?.dashboard?.newUI,
         summaryLimit: store.formData.realtime?.dashboard?.summaryLimit,
       }}
     >
       <div class="space-y-6">
-        <!-- Modern UI Toggle -->
-        <Checkbox
-          checked={settings.dashboard.newUI}
-          label={t('settings.main.sections.userInterface.interface.newUI.label')}
-          helpText={t('settings.main.sections.userInterface.interface.newUI.helpText')}
-          disabled={store.isLoading || store.isSaving}
-          onchange={value => updateDashboardSetting('newUI', value)}
-        />
-
-        <!-- Language Settings - Dependent on Modern UI -->
-        <fieldset
-          disabled={!settings.dashboard.newUI || store.isLoading || store.isSaving}
-          class="contents"
-          aria-describedby="locale-section-status"
-        >
-          <span id="locale-section-status" class="sr-only">
-            {settings.dashboard.newUI
-              ? t('settings.main.sections.userInterface.interface.locale.label')
-              : t('settings.main.sections.userInterface.interface.locale.requiresModernUI')}
-          </span>
-          <div class="transition-opacity duration-200" class:opacity-50={!settings.dashboard.newUI}>
-            <div class="grid grid-cols-1 md:grid-cols-2 gap-x-6">
-              <SelectDropdown
-                options={uiLocales}
-                value={settings.dashboard.locale}
-                label={t('settings.main.sections.userInterface.interface.locale.label')}
-                helpText={t('settings.main.sections.userInterface.interface.locale.helpText')}
-                disabled={!settings.dashboard.newUI || store.isLoading || store.isSaving}
-                variant="select"
-                groupBy={false}
-                onChange={value => updateUILocale(value as string)}
-              >
-                {#snippet renderOption(option)}
-                  {@const localeOption = option as LocaleOption}
-                  <div class="flex items-center gap-2">
-                    <FlagIcon locale={localeOption.localeCode} className="size-4" />
-                    <span>{localeOption.label}</span>
-                  </div>
-                {/snippet}
-                {#snippet renderSelected(options)}
-                  {@const localeOption = options[0] as LocaleOption}
-                  <span class="flex items-center gap-2">
-                    <FlagIcon locale={localeOption.localeCode} className="size-4" />
-                    <span>{localeOption.label}</span>
-                  </span>
-                {/snippet}
-              </SelectDropdown>
-            </div>
-
-            {#if !settings.dashboard.newUI}
-              <SettingsNote>
-                <span>
-                  {t('settings.main.sections.userInterface.interface.locale.requiresModernUI')}
-                </span>
-              </SettingsNote>
-            {/if}
-          </div>
-        </fieldset>
+        <!-- Language Settings -->
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-x-6">
+          <SelectDropdown
+            options={uiLocales}
+            value={settings.dashboard.locale}
+            label={t('settings.main.sections.userInterface.interface.locale.label')}
+            helpText={t('settings.main.sections.userInterface.interface.locale.helpText')}
+            disabled={store.isLoading || store.isSaving}
+            variant="select"
+            groupBy={false}
+            onChange={value => updateUILocale(value as string)}
+          >
+            {#snippet renderOption(option)}
+              {@const localeOption = option as LocaleOption}
+              <div class="flex items-center gap-2">
+                <FlagIcon locale={localeOption.localeCode} className="size-4" />
+                <span>{localeOption.label}</span>
+              </div>
+            {/snippet}
+            {#snippet renderSelected(options)}
+              {@const localeOption = options[0] as LocaleOption}
+              <span class="flex items-center gap-2">
+                <FlagIcon locale={localeOption.localeCode} className="size-4" />
+                <span>{localeOption.label}</span>
+              </span>
+            {/snippet}
+          </SelectDropdown>
+        </div>
 
         <!-- Summary Limit -->
         <div class="grid grid-cols-1 md:grid-cols-2 gap-x-6">

--- a/frontend/src/lib/desktop/features/settings/pages/UserInterfaceSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/UserInterfaceSettingsPage.svelte
@@ -1,25 +1,24 @@
 <!--
   User Interface Settings Page Component
-  
+
   Purpose: Configure all user interface related settings including language,
   dashboard display options, thumbnails, and UI preferences.
-  
+
   Features:
   - Language selection for the user interface
-  - Dashboard configuration (summary limits, new UI toggle)
+  - Dashboard configuration (summary limits)
   - Thumbnail display settings for different views
   - Image provider selection and fallback policies
-  
+
   Props: None - This is a page component that uses global settings stores
-  
+
   Performance Optimizations:
-  - Cached CSRF token with $derived to avoid repeated DOM queries
   - Reactive computed properties for change detection
   - Async API loading for non-critical data
 -->
 <script lang="ts">
-  import NumberField from '$lib/desktop/components/forms/NumberField.svelte';
   import Checkbox from '$lib/desktop/components/forms/Checkbox.svelte';
+  import NumberField from '$lib/desktop/components/forms/NumberField.svelte';
   import SelectField from '$lib/desktop/components/forms/SelectField.svelte';
   import SelectDropdown from '$lib/desktop/components/forms/SelectDropdown.svelte';
   import type { SelectOption } from '$lib/desktop/components/forms/SelectDropdown.types';
@@ -53,10 +52,8 @@
           fallbackPolicy: 'all',
         },
         summaryLimit: 100,
-        newUI: false,
       }),
       locale: $dashboardSettings?.locale ?? (getLocale() as string),
-      newUI: $dashboardSettings?.newUI ?? false,
       spectrogram: $dashboardSettings?.spectrogram ?? DEFAULT_SPECTROGRAM_SETTINGS,
     },
   });
@@ -96,11 +93,9 @@
     hasSettingsChanged(
       {
         locale: store.originalData.realtime?.dashboard?.locale,
-        newUI: store.originalData.realtime?.dashboard?.newUI,
       },
       {
         locale: store.formData.realtime?.dashboard?.locale,
-        newUI: store.formData.realtime?.dashboard?.newUI,
       }
     )
   );
@@ -236,75 +231,37 @@
     defaultOpen={true}
     originalData={{
       locale: store.originalData.realtime?.dashboard?.locale,
-      newUI: store.originalData.realtime?.dashboard?.newUI,
     }}
     currentData={{
       locale: store.formData.realtime?.dashboard?.locale,
-      newUI: store.formData.realtime?.dashboard?.newUI,
     }}
   >
-    <div class="space-y-4">
-      <!-- Modern UI Toggle - Primary setting -->
-      <Checkbox
-        checked={settings.dashboard.newUI}
-        label={t('settings.main.sections.userInterface.interface.newUI.label')}
-        helpText={t('settings.main.sections.userInterface.interface.newUI.helpText')}
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-x-6">
+      <SelectDropdown
+        options={uiLocales}
+        value={settings.dashboard.locale}
+        label={t('settings.main.sections.userInterface.interface.locale.label')}
+        helpText={t('settings.main.sections.userInterface.interface.locale.helpText')}
         disabled={store.isLoading || store.isSaving}
-        onchange={value => updateDashboardSetting('newUI', value)}
-      />
-
-      <!-- Language Settings - Dependent on Modern UI -->
-      <fieldset
-        disabled={!settings.dashboard.newUI || store.isLoading || store.isSaving}
-        class="contents"
-        aria-describedby="locale-section-status"
+        variant="select"
+        groupBy={false}
+        onChange={value => updateUILocale(value as string)}
       >
-        <span id="locale-section-status" class="sr-only">
-          {settings.dashboard.newUI
-            ? t('settings.main.sections.userInterface.interface.locale.label')
-            : t('settings.main.sections.userInterface.interface.locale.requiresModernUI')}
-        </span>
-        <div
-          class="space-y-4 transition-opacity duration-200"
-          class:opacity-50={!settings.dashboard.newUI}
-        >
-          <div class="grid grid-cols-1 md:grid-cols-2 gap-x-6">
-            <SelectDropdown
-              options={uiLocales}
-              value={settings.dashboard.locale}
-              label={t('settings.main.sections.userInterface.interface.locale.label')}
-              helpText={t('settings.main.sections.userInterface.interface.locale.helpText')}
-              disabled={!settings.dashboard.newUI || store.isLoading || store.isSaving}
-              variant="select"
-              groupBy={false}
-              onChange={value => updateUILocale(value as string)}
-            >
-              {#snippet renderOption(option)}
-                {@const localeOption = option as LocaleOption}
-                <div class="flex items-center gap-2">
-                  <FlagIcon locale={localeOption.localeCode} className="size-4" />
-                  <span>{localeOption.label}</span>
-                </div>
-              {/snippet}
-              {#snippet renderSelected(options)}
-                {@const localeOption = options[0] as LocaleOption}
-                <span class="flex items-center gap-2">
-                  <FlagIcon locale={localeOption.localeCode} className="size-4" />
-                  <span>{localeOption.label}</span>
-                </span>
-              {/snippet}
-            </SelectDropdown>
+        {#snippet renderOption(option)}
+          {@const localeOption = option as LocaleOption}
+          <div class="flex items-center gap-2">
+            <FlagIcon locale={localeOption.localeCode} className="size-4" />
+            <span>{localeOption.label}</span>
           </div>
-
-          {#if !settings.dashboard.newUI}
-            <SettingsNote>
-              <span>
-                {t('settings.main.sections.userInterface.interface.locale.requiresModernUI')}
-              </span>
-            </SettingsNote>
-          {/if}
-        </div>
-      </fieldset>
+        {/snippet}
+        {#snippet renderSelected(options)}
+          {@const localeOption = options[0] as LocaleOption}
+          <span class="flex items-center gap-2">
+            <FlagIcon locale={localeOption.localeCode} className="size-4" />
+            <span>{localeOption.label}</span>
+          </span>
+        {/snippet}
+      </SelectDropdown>
     </div>
   </SettingsSection>
 {/snippet}

--- a/frontend/src/lib/desktop/features/settings/pages/UserInterfaceSettingsPage.test.ts
+++ b/frontend/src/lib/desktop/features/settings/pages/UserInterfaceSettingsPage.test.ts
@@ -41,14 +41,10 @@ vi.mock('$lib/stores/toast', () => ({
 vi.mock('$lib/i18n', () => ({
   t: createI18nMock({
     'settings.main.sections.userInterface.interface.title': 'Interface Settings',
-    'settings.main.sections.userInterface.interface.description':
-      'Choose your preferred language and interface version',
+    'settings.main.sections.userInterface.interface.description': 'Choose your preferred language',
     'settings.main.sections.userInterface.interface.locale.label': 'Language',
     'settings.main.sections.userInterface.interface.locale.helpText':
       'Select your preferred language',
-    'settings.main.sections.userInterface.interface.newUI.label': 'Use New User Interface',
-    'settings.main.sections.userInterface.interface.newUI.helpText':
-      'Enable redirect from old HTMX UI to new Svelte UI',
     'settings.main.sections.userInterface.dashboard.title': 'Dashboard Display',
     'settings.main.sections.userInterface.dashboard.description':
       'Configure how information is displayed on the dashboard',
@@ -245,7 +241,6 @@ describe('UserInterfaceSettingsPage', () => {
           },
           summaryLimit: 100,
           locale: 'en',
-          newUI: false,
         },
       },
     };
@@ -284,9 +279,6 @@ describe('UserInterfaceSettingsPage', () => {
       await waitFor(() => {
         // Language selector
         expect(screen.getByLabelText('Language')).toBeInTheDocument();
-
-        // New UI checkbox
-        expect(screen.getByLabelText('Use New User Interface')).toBeInTheDocument();
       });
     });
 
@@ -326,31 +318,6 @@ describe('UserInterfaceSettingsPage', () => {
       await waitFor(() => {
         // Language label is rendered (SelectDropdown uses custom button-based UI)
         expect(screen.getByText('Language')).toBeInTheDocument();
-
-        // New UI checkbox uses standard label
-        expect(screen.getByLabelText('Use New User Interface')).toBeInTheDocument();
-      });
-    });
-
-    it('updates newUI setting when checkbox is toggled', async () => {
-      testFactory.render();
-
-      await waitFor(() => {
-        const checkbox = screen.getByLabelText('Use New User Interface') as HTMLInputElement;
-        expect(checkbox).toBeInTheDocument();
-      });
-
-      const checkbox = screen.getByLabelText('Use New User Interface') as HTMLInputElement;
-      expect(checkbox.checked).toBe(false);
-
-      // Toggle checkbox
-      checkbox.click();
-
-      await waitFor(() => {
-        const store = get(settingsStore);
-
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        expect((store.formData as any)?.realtime?.dashboard?.newUI).toBe(true);
       });
     });
   });
@@ -485,7 +452,7 @@ describe('UserInterfaceSettingsPage', () => {
       // Mock to return true for interface settings
       mockHasSettingsChanged.mockImplementation((_original, current) => {
         // Check if this is the interface settings comparison
-        if (current?.locale !== undefined || current?.newUI !== undefined) {
+        if (current?.locale !== undefined) {
           return true;
         }
         return false;
@@ -606,7 +573,6 @@ describe('UserInterfaceSettingsPage', () => {
       await waitFor(() => {
         // Check interface form controls are disabled
         expect(screen.getByLabelText('Language')).toBeDisabled();
-        expect(screen.getByLabelText('Use New User Interface')).toBeDisabled();
       });
     });
 
@@ -637,7 +603,6 @@ describe('UserInterfaceSettingsPage', () => {
       await waitFor(() => {
         // Check interface form controls are disabled
         expect(screen.getByLabelText('Language')).toBeDisabled();
-        expect(screen.getByLabelText('Use New User Interface')).toBeDisabled();
       });
 
       // Switch to Dashboard tab
@@ -689,10 +654,6 @@ describe('UserInterfaceSettingsPage', () => {
       testFactory.render();
 
       await waitFor(() => {
-        // Check default value on Interface tab - checkbox uses standard label
-        const newUICheckbox = screen.getByLabelText('Use New User Interface') as HTMLInputElement;
-        expect(newUICheckbox.checked).toBe(false);
-
         // Language selector is rendered (uses custom SelectDropdown)
         expect(screen.getByText('Language')).toBeInTheDocument();
       });
@@ -808,7 +769,6 @@ describe('UserInterfaceSettingsPage', () => {
         expect(dashboard?.summaryLimit).toBe(100);
         expect(dashboard?.thumbnails?.summary).toBe(true);
         expect(dashboard?.thumbnails?.recent).toBe(true);
-        expect(dashboard?.newUI).toBe(false);
         expect(dashboard?.locale).toBe('en');
 
         // Language selector is rendered (SelectDropdown uses custom button-based UI)

--- a/frontend/src/lib/stores/settings.test.ts
+++ b/frontend/src/lib/stores/settings.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { get } from 'svelte/store';
 import { settingsStore, settingsActions } from './settings';
-import type { BirdNetSettings, RealtimeSettings, SettingsFormData, Dashboard } from './settings';
+import type { BirdNetSettings, RealtimeSettings, SettingsFormData } from './settings';
 import { settingsAPI } from '$lib/utils/settingsApi.js';
 
 // Mock the settings API
@@ -228,115 +228,6 @@ describe('Settings Store - Dynamic Threshold and Range Filter', () => {
 
     expect(birdnetData).not.toHaveProperty('dynamicThreshold');
     expect(state.formData.realtime?.dynamicThreshold).toBeDefined();
-  });
-});
-
-describe('Dashboard Settings - New UI Field', () => {
-  beforeEach(() => {
-    // Reset store to initial state with dashboard settings
-    settingsStore.set({
-      formData: {
-        main: { name: 'TestNode' },
-        birdnet: {
-          modelPath: '',
-          labelPath: '',
-          sensitivity: 1.0,
-          threshold: 0.8,
-          overlap: 0.0,
-          locale: 'en',
-          threads: 4,
-          latitude: 40.7128,
-          longitude: -74.006,
-          rangeFilter: {
-            threshold: 0.03,
-            speciesCount: null,
-            species: [],
-          },
-        },
-        realtime: {
-          dashboard: {
-            thumbnails: {
-              summary: true,
-              recent: true,
-              imageProvider: 'wikimedia',
-              fallbackPolicy: 'all',
-            },
-            summaryLimit: 100,
-            newUI: false, // New UI field
-          },
-        },
-      },
-      originalData: {} as SettingsFormData,
-      isLoading: false,
-      isSaving: false,
-      activeSection: 'main',
-      error: null,
-    });
-  });
-
-  it('should have newUI field in dashboard settings', () => {
-    const state = get(settingsStore);
-    const dashboard = state.formData.realtime?.dashboard as Dashboard | undefined;
-
-    expect(dashboard).toBeDefined();
-    expect(dashboard?.newUI).toBeDefined();
-    expect(dashboard?.newUI).toBe(false);
-  });
-
-  it('should update newUI setting correctly', () => {
-    // Enable new UI
-    settingsActions.updateSection('realtime', {
-      dashboard: {
-        thumbnails: {
-          summary: true,
-          recent: true,
-          imageProvider: 'wikimedia',
-          fallbackPolicy: 'all',
-        },
-        summaryLimit: 100,
-        newUI: true, // Enable new UI
-      },
-    });
-
-    const state = get(settingsStore);
-    const dashboard = state.formData.realtime?.dashboard as Dashboard | undefined;
-
-    expect(dashboard?.newUI).toBe(true);
-  });
-
-  it('should preserve other dashboard settings when updating newUI', () => {
-    const initialState = get(settingsStore);
-    const initialDashboard = initialState.formData.realtime?.dashboard as Dashboard | undefined;
-
-    // Update only newUI
-    settingsActions.updateSection('realtime', {
-      dashboard: {
-        ...(initialDashboard ?? {
-          thumbnails: {
-            summary: true,
-            recent: true,
-            imageProvider: 'wikimedia',
-            fallbackPolicy: 'all',
-          },
-          summaryLimit: 100,
-          newUI: false,
-        }),
-        newUI: true,
-      },
-    });
-
-    const updatedState = get(settingsStore);
-    const updatedDashboard = updatedState.formData.realtime?.dashboard as Dashboard | undefined;
-
-    // Verify newUI was updated
-    expect(updatedDashboard?.newUI).toBe(true);
-
-    // Verify other settings were preserved
-    expect(updatedDashboard?.summaryLimit).toBe(100);
-    expect(updatedDashboard?.thumbnails.summary).toBe(true);
-    expect(updatedDashboard?.thumbnails.recent).toBe(true);
-    expect(updatedDashboard?.thumbnails.imageProvider).toBe('wikimedia');
-    expect(updatedDashboard?.thumbnails.fallbackPolicy).toBe('all');
   });
 });
 

--- a/frontend/src/lib/stores/settings.ts
+++ b/frontend/src/lib/stores/settings.ts
@@ -408,7 +408,6 @@ export interface Dashboard {
   thumbnails: Thumbnails;
   summaryLimit: number;
   locale?: string; // UI locale setting
-  newUI?: boolean; // Enable redirect from old HTMX UI to new Svelte UI
   spectrogram?: SpectrogramPreRender; // Spectrogram pre-rendering settings
 }
 
@@ -721,7 +720,6 @@ function createEmptySettings(): SettingsFormData {
           fallbackPolicy: 'all',
         },
         summaryLimit: 100,
-        newUI: false,
         spectrogram: DEFAULT_SPECTROGRAM_SETTINGS,
       },
     },

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -1058,15 +1058,10 @@
           "description": "Benutzeroberfläche anpassen",
           "interface": {
             "title": "Schnittstelleneinstellungen",
-            "description": "Wählen Sie Ihre bevorzugte Sprache und Oberflächenversion",
+            "description": "Wählen Sie Ihre bevorzugte Sprache",
             "locale": {
               "label": "Anzeigesprache",
-              "helpText": "Wählen Sie die Sprache für die Benutzeroberfläche",
-              "requiresModernUI": "Die Sprachauswahl ist nur bei Verwendung der modernen Benutzeroberfläche verfügbar."
-            },
-            "newUI": {
-              "label": "Moderne Oberfläche verwenden",
-              "helpText": "Aktiviert die neue Svelte-basierte Oberfläche mit verbesserter Leistung und Funktionen. Bei Deaktivierung wird die klassische HTMX-Oberfläche verwendet."
+              "helpText": "Wählen Sie die Sprache für die Benutzeroberfläche"
             }
           },
           "language": {
@@ -1098,10 +1093,6 @@
             "summaryLimit": {
               "label": "Maximale Anzahl von Arten in der täglichen Übersichtstabelle",
               "helpText": "Maximale Anzahl der in der täglichen Übersichtstabelle angezeigten Arten (Wert zwischen 10 und 1000)"
-            },
-            "newUI": {
-              "label": "Neue Benutzeroberfläche verwenden",
-              "helpText": "Umleitung von der alten HTMX-Benutzeroberfläche zur neuen Svelte-Benutzeroberfläche aktivieren"
             },
             "thumbnails": {
               "title": "Miniaturbildanzeige",

--- a/frontend/static/messages/en.json
+++ b/frontend/static/messages/en.json
@@ -1070,15 +1070,10 @@
           "description": "Customize user interface",
           "interface": {
             "title": "Interface Settings",
-            "description": "Choose your preferred language and interface version",
+            "description": "Choose your preferred language",
             "locale": {
               "label": "Display Language",
-              "helpText": "Select the language for the user interface",
-              "requiresModernUI": "Language selection is only available when using the Modern Interface."
-            },
-            "newUI": {
-              "label": "Use Modern Interface",
-              "helpText": "Enable the new Svelte-based interface with improved performance and features. When disabled, uses the classic HTMX interface."
+              "helpText": "Select the language for the user interface"
             }
           },
           "language": {
@@ -1110,10 +1105,6 @@
             "summaryLimit": {
               "label": "Max Number of Species on Daily Summary Table",
               "helpText": "Max number of species shown in the daily summary table (Value between 10 and 1000)"
-            },
-            "newUI": {
-              "label": "Use New User Interface",
-              "helpText": "Enable redirect from old HTMX UI to new Svelte UI"
             },
             "thumbnails": {
               "title": "Thumbnail Display",

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -1058,15 +1058,10 @@
           "description": "Personalizar la interfaz de usuario",
           "interface": {
             "title": "Configuración de interfaz",
-            "description": "Elija su idioma e interfaz preferidos",
+            "description": "Elija su idioma preferido",
             "locale": {
               "label": "Idioma de visualización",
-              "helpText": "Seleccione el idioma para la interfaz de usuario",
-              "requiresModernUI": "La selección de idioma solo está disponible al usar la interfaz moderna."
-            },
-            "newUI": {
-              "label": "Usar interfaz moderna",
-              "helpText": "Activa la nueva interfaz basada en Svelte con rendimiento y características mejoradas. Cuando está desactivada, usa la interfaz HTMX clásica."
+              "helpText": "Seleccione el idioma para la interfaz de usuario"
             }
           },
           "language": {
@@ -1098,10 +1093,6 @@
             "summaryLimit": {
               "label": "Número máximo de especies en la tabla de resumen diario",
               "helpText": "Número máximo de especies mostradas en la tabla de resumen diario (valor entre 10 y 1000)"
-            },
-            "newUI": {
-              "label": "Usar nueva interfaz de usuario",
-              "helpText": "Habilitar redirección de la interfaz HTMX antigua a la nueva interfaz Svelte"
             },
             "thumbnails": {
               "title": "Visualización de miniaturas",

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -1058,15 +1058,10 @@
           "description": "Mukauta käyttöliittymää",
           "interface": {
             "title": "Käyttöliittymän asetukset",
-            "description": "Valitse haluamasi kieli ja käyttöliittymäversio",
+            "description": "Valitse haluamasi kieli",
             "locale": {
               "label": "Näyttökieli",
-              "helpText": "Valitse käyttöliittymän kieli",
-              "requiresModernUI": "Kielen valinta on saatavilla vain modernia käyttöliittymää käytettäessä."
-            },
-            "newUI": {
-              "label": "Käytä modernia käyttöliittymää",
-              "helpText": "Ottaa käyttöön uuden Svelte-pohjaisen käyttöliittymän, jossa on parempi suorituskyky ja ominaisuudet. Kun poistettu käytöstä, käytetään klassista HTMX-käyttöliittymää."
+              "helpText": "Valitse käyttöliittymän kieli"
             }
           },
           "language": {
@@ -1098,10 +1093,6 @@
             "summaryLimit": {
               "label": "Lajien enimmäismäärä päivittäisessä yhteenvetotaulukossa",
               "helpText": "Päivittäisessä yhteenvetotaulukossa näytettävien lajien enimmäismäärä (arvo välillä 10-1000)"
-            },
-            "newUI": {
-              "label": "Käytä uutta käyttöliittymää",
-              "helpText": "Ota käyttöön uudelleenohjaus vanhasta HTMX-käyttöliittymästä uuteen Svelte-käyttöliittymään"
             },
             "thumbnails": {
               "title": "Pikkukuvien näyttö",

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -1058,15 +1058,10 @@
           "description": "Personnaliser l'interface utilisateur",
           "interface": {
             "title": "Paramètres d'interface",
-            "description": "Choisissez votre langue préférée et la version de l'interface",
+            "description": "Choisissez votre langue préférée",
             "locale": {
               "label": "Langue d'affichage",
-              "helpText": "Sélectionnez la langue de l'interface utilisateur",
-              "requiresModernUI": "La sélection de la langue est uniquement disponible lors de l'utilisation de l'interface moderne."
-            },
-            "newUI": {
-              "label": "Utiliser l'interface moderne",
-              "helpText": "Activer la nouvelle interface basée sur Svelte avec des performances et fonctionnalités améliorées. Lorsque désactivée, utilise l'interface classique HTMX."
+              "helpText": "Sélectionnez la langue de l'interface utilisateur"
             }
           },
           "language": {
@@ -1098,10 +1093,6 @@
             "summaryLimit": {
               "label": "Nombre maximum d'espèces dans le tableau de résumé quotidien",
               "helpText": "Nombre maximum d'espèces affichées dans le tableau de résumé quotidien (valeur entre 10 et 1000)"
-            },
-            "newUI": {
-              "label": "Utiliser la nouvelle interface utilisateur",
-              "helpText": "Activer la redirection de l'ancienne interface HTMX vers la nouvelle interface Svelte"
             },
             "thumbnails": {
               "title": "Affichage des miniatures",

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -1058,15 +1058,10 @@
           "description": "Pas de gebruikers beleving aan",
           "interface": {
             "title": "Presentatie instellingen",
-            "description": "Kies de weergave taal en de presentatie versie",
+            "description": "Kies de weergave taal",
             "locale": {
               "label": "Weergave taal",
-              "helpText": "Selecteer de taal voor de presentatie",
-              "requiresModernUI": "Taalselectie is alleen beschikbaar bij gebruik van de moderne interface."
-            },
-            "newUI": {
-              "label": "Gebruik de moderne versie",
-              "helpText": "Aktiveer voor de nieuwe Svelte-gebaseerde presentatie met verbeterde prestaties en mogelijkheden. Wanneer niet aktief, gebruik de verouderde HTMX presentatie."
+              "helpText": "Selecteer de taal voor de presentatie"
             }
           },
           "language": {
@@ -1098,10 +1093,6 @@
             "summaryLimit": {
               "label": "Maximum aantal soorten in de Dagelijks overzicht tabel",
               "helpText": "Maximum aantal soorten dat wordt getoond in de Dagelijks overzicht tabel (waarde tussen 10 en 1000)"
-            },
-            "newUI": {
-              "label": "Gebruik de nieuwe presentatie",
-              "helpText": "Aktiveer de omleiding van de verouderde HTMX UI naar de nieuwe Svelte UI"
             },
             "thumbnails": {
               "title": "Afbeelding weergave",

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -1070,15 +1070,10 @@
           "description": "Dostosuj interfejs użytkownika",
           "interface": {
             "title": "Ustawienia Interfejsu",
-            "description": "Wybierz preferowany język i wersję interfejsu",
+            "description": "Wybierz preferowany język",
             "locale": {
               "label": "Język Wyświetlania",
-              "helpText": "Wybierz język dla interfejsu użytkownika",
-              "requiresModernUI": "Wybór języka jest dostępny tylko przy używaniu Nowoczesnego Interfejsu."
-            },
-            "newUI": {
-              "label": "Użyj Nowoczesnego Interfejsu",
-              "helpText": "Włącz nowy interfejs oparty na Svelte z ulepszoną wydajnością i funkcjami. Po wyłączeniu używa klasycznego interfejsu HTMX."
+              "helpText": "Wybierz język dla interfejsu użytkownika"
             }
           },
           "language": {
@@ -1110,10 +1105,6 @@
             "summaryLimit": {
               "label": "Maksymalna Liczba Gatunków w Tabeli Podsumowania Dziennego",
               "helpText": "Maksymalna liczba gatunków wyświetlanych w tabeli podsumowania dziennego (Wartość między 10 a 1000)"
-            },
-            "newUI": {
-              "label": "Użyj Nowego Interfejsu Użytkownika",
-              "helpText": "Włącz przekierowanie ze starego interfejsu HTMX do nowego interfejsu Svelte"
             },
             "thumbnails": {
               "title": "Wyświetlanie Miniatur",

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -1069,15 +1069,10 @@
           },
           "interface": {
             "title": "Configurações de interface",
-            "description": "Escolha seu idioma e versão de interface preferidos",
+            "description": "Escolha seu idioma preferido",
             "locale": {
               "label": "Idioma de exibição",
-              "helpText": "Selecione o idioma para a interface do usuário",
-              "requiresModernUI": "A seleção de idioma está disponível apenas ao usar a interface moderna."
-            },
-            "newUI": {
-              "label": "Usar interface moderna",
-              "helpText": "Ativa a nova interface baseada em Svelte com desempenho e recursos aprimorados. Quando desativada, usa a interface HTMX clássica."
+              "helpText": "Selecione o idioma para a interface do usuário"
             }
           },
           "dashboard": {
@@ -1101,10 +1096,6 @@
             "summaryLimit": {
               "label": "Número máximo de espécies na tabela de resumo diário",
               "helpText": "Número máximo de espécies mostradas na tabela de resumo diário (valor entre 10 e 1000)"
-            },
-            "newUI": {
-              "label": "Usar nova interface do usuário",
-              "helpText": "Ativar redirecionamento da interface HTMX antiga para a nova interface Svelte"
             },
             "thumbnails": {
               "title": "Exibição de miniaturas",

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -130,7 +130,6 @@ type Dashboard struct {
 	Thumbnails   Thumbnails           `json:"thumbnails"`       // thumbnails settings
 	SummaryLimit int                  `json:"summaryLimit"`     // limit for the number of species shown in the summary table
 	Locale       string               `json:"locale,omitempty"` // UI locale setting
-	NewUI        bool                 `json:"newUI"`            // Enable redirect from old HTMX UI to new Svelte UI
 	Spectrogram  SpectrogramPreRender `json:"spectrogram"`      // Spectrogram pre-rendering settings
 }
 

--- a/internal/conf/defaults.go
+++ b/internal/conf/defaults.go
@@ -92,7 +92,6 @@ func setDefaultConfig() {
 	viper.SetDefault("realtime.dashboard.thumbnails.fallbackpolicy", "none")
 	viper.SetDefault("realtime.dashboard.summarylimit", 30)
 	viper.SetDefault("realtime.dashboard.locale", "en") // Default UI locale
-	viper.SetDefault("realtime.dashboard.newui", false) // Enable redirect from old HTMX UI to new Svelte UI
 
 	// Spectrogram pre-rendering configuration
 	viper.SetDefault("realtime.dashboard.spectrogram.enabled", false) // Opt-in for safety


### PR DESCRIPTION
## Summary
- Removes the obsolete `newUI` setting from the entire codebase
- The legacy HTMX UI has been removed, making this toggle unnecessary

## Changes
- **Go Backend**: Removed `NewUI` field from Dashboard struct and viper defaults
- **Frontend Store**: Removed `newUI` from Dashboard interface and settings initialization
- **UI Components**: Simplified MainSettingsPage and UserInterfaceSettingsPage by removing the newUI checkbox and related change tracking logic
- **i18n**: Removed newUI translations from all 8 locale files (en, de, nl, es, fr, pl, pt, fi)
- **Tests**: Cleaned up all newUI-related test cases

## Test plan
- [x] Go tests pass (`go test ./internal/conf/...`)
- [x] Frontend linters pass (`npm run check`)
- [x] All 1402 frontend tests pass (`npm test`)
- [x] No remaining references to `newUI` in codebase

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed the Modern UI toggle option from interface settings, simplifying configuration.
  * Interface settings now focus exclusively on language selection.
  * Updated setting descriptions across English, German, Spanish, Finnish, French, Dutch, Polish, and Portuguese translations.
  * Removed related configuration defaults and associated test coverage.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->