### PR TITLE
feat(sidebar): add collapsible desktop sidebar with icons-only mode

### DIFF
--- a/frontend/src/lib/components/LogoBadge.svelte
+++ b/frontend/src/lib/components/LogoBadge.svelte
@@ -1,0 +1,95 @@
+<!--
+LogoBadge.svelte - Stylized badge logo for BirdNET-Go
+
+A compact, stylized badge that can be used as an alternative to the bird image logo.
+Designed for use in collapsed sidebars or compact UI areas.
+
+Props:
+- size?: 'sm' | 'md' | 'lg' - Badge size (default: 'md')
+- variant?: 'sunset' | 'ocean' | 'forest' | 'aurora' - Color theme (default: 'sunset')
+- className?: string - Additional CSS classes
+-->
+<script lang="ts">
+  import { cn } from '$lib/utils/cn';
+  import { Bird } from '@lucide/svelte';
+
+  interface Props {
+    size?: 'sm' | 'md' | 'lg';
+    variant?: 'sunset' | 'ocean' | 'forest' | 'aurora';
+    className?: string;
+  }
+
+  let { size = 'md', variant = 'sunset', className = '' }: Props = $props();
+
+  // Size classes for badge dimensions and icon size
+  function getSizeClass(s: typeof size): string {
+    if (s === 'sm') return 'h-7 w-7';
+    if (s === 'lg') return 'h-11 w-11';
+    return 'h-9 w-9'; // md default
+  }
+
+  function getIconSize(s: typeof size): number {
+    if (s === 'sm') return 16;
+    if (s === 'lg') return 26;
+    return 22; // md default
+  }
+
+  // Vibrant gradient variants
+  function getVariantClass(v: typeof variant): string {
+    if (v === 'ocean') return 'logo-badge-ocean';
+    if (v === 'forest') return 'logo-badge-forest';
+    if (v === 'aurora') return 'logo-badge-aurora';
+    return 'logo-badge-sunset'; // sunset default
+  }
+</script>
+
+<div
+  class={cn(
+    'logo-badge flex items-center justify-center rounded-xl select-none shrink-0 transition-all duration-200',
+    getSizeClass(size),
+    getVariantClass(variant),
+    className
+  )}
+  aria-hidden="true"
+>
+  <Bird size={getIconSize(size)} strokeWidth={2.5} class="drop-shadow-sm" />
+</div>
+
+<style>
+  /* Base badge styles */
+  .logo-badge {
+    position: relative;
+    color: white;
+    box-shadow:
+      0 4px 14px -2px rgba(0, 0, 0, 0.25),
+      0 0 20px -5px var(--glow-color, rgba(255, 100, 50, 0.4));
+  }
+
+  /* Sunset gradient - warm oranges to pinks */
+  .logo-badge-sunset {
+    background: linear-gradient(135deg, #ff6b35 0%, #f72585 50%, #7209b7 100%);
+
+    --glow-color: rgba(247, 37, 133, 0.5);
+  }
+
+  /* Ocean gradient - teals to blues */
+  .logo-badge-ocean {
+    background: linear-gradient(135deg, #00d4aa 0%, #0096c7 50%, #023e8a 100%);
+
+    --glow-color: rgba(0, 150, 199, 0.5);
+  }
+
+  /* Forest gradient - greens to teals */
+  .logo-badge-forest {
+    background: linear-gradient(135deg, #84cc16 0%, #22c55e 50%, #059669 100%);
+
+    --glow-color: rgba(34, 197, 94, 0.5);
+  }
+
+  /* Aurora gradient - purples to cyans */
+  .logo-badge-aurora {
+    background: linear-gradient(135deg, #a855f7 0%, #6366f1 50%, #06b6d4 100%);
+
+    --glow-color: rgba(99, 102, 241, 0.5);
+  }
+</style>

--- a/frontend/src/lib/desktop/layouts/RootLayout.svelte
+++ b/frontend/src/lib/desktop/layouts/RootLayout.svelte
@@ -6,6 +6,7 @@
   import Sidebar from './DesktopSidebar.svelte';
   import { auth as authStore } from '$lib/stores/auth';
   import { csrf as csrfStore } from '$lib/stores/csrf';
+  import { sidebar } from '$lib/stores/sidebar';
   import ToastContainer from '$lib/desktop/components/ui/ToastContainer.svelte';
 
   interface Props {
@@ -30,6 +31,9 @@
 
   // Drawer state
   let drawerOpen = $state(false);
+
+  // Get sidebar collapsed state for dynamic grid layout ($ prefix auto-subscribes to store)
+  let isCollapsed = $derived($sidebar);
 
   // Initialize stores on mount
   onMount(() => {
@@ -82,7 +86,13 @@
   }
 </script>
 
-<div class={cn('drawer lg:drawer-open min-h-screen bg-base-200', className)}>
+<div
+  class={cn(
+    'drawer lg:drawer-open min-h-screen bg-base-200 transition-all duration-200',
+    isCollapsed ? 'sidebar-collapsed' : 'sidebar-expanded',
+    className
+  )}
+>
   <input id="my-drawer" type="checkbox" class="drawer-toggle" bind:checked={drawerOpen} />
 
   <div class="drawer-content">
@@ -166,12 +176,24 @@
   @media (min-width: 1024px) {
     :global(.drawer.lg\:drawer-open) {
       grid-template-columns: 256px 1fr;
+      transition: grid-template-columns 0.2s ease-in-out;
+    }
+
+    :global(.drawer.lg\:drawer-open.sidebar-collapsed) {
+      grid-template-columns: 64px 1fr;
     }
 
     :global(.drawer.lg\:drawer-open .drawer-side) {
       display: block;
       position: sticky;
       width: 256px;
+      transition: width 0.2s ease-in-out;
+      overflow: visible;
+    }
+
+    :global(.drawer.lg\:drawer-open.sidebar-collapsed .drawer-side) {
+      width: 64px;
+      overflow: visible;
     }
 
     :global(.drawer.lg\:drawer-open .drawer-content) {

--- a/frontend/src/lib/stores/sidebar.ts
+++ b/frontend/src/lib/stores/sidebar.ts
@@ -1,0 +1,95 @@
+/**
+ * Sidebar state store with localStorage persistence
+ *
+ * Manages the collapsed/expanded state of the desktop sidebar.
+ * Only applies to desktop viewports (≥1024px) - mobile uses drawer overlay.
+ */
+import { writable, get } from 'svelte/store';
+
+const STORAGE_KEY = 'sidebar-collapsed';
+
+// Check if we're in a browser environment
+const isBrowser = typeof window !== 'undefined';
+
+/**
+ * Get initial collapsed state from localStorage
+ * Defaults to false (expanded) if no preference is stored
+ */
+function getInitialState(): boolean {
+  if (!isBrowser) return false;
+
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored !== null) {
+      return stored === 'true';
+    }
+  } catch {
+    // localStorage not available (e.g., private browsing)
+  }
+
+  return false; // Default to expanded
+}
+
+/**
+ * Save collapsed state to localStorage
+ */
+function saveState(collapsed: boolean): void {
+  if (!isBrowser) return;
+
+  try {
+    localStorage.setItem(STORAGE_KEY, String(collapsed));
+  } catch {
+    // localStorage not available
+  }
+}
+
+function createSidebarStore() {
+  const store = writable<boolean>(getInitialState());
+  const { subscribe, set, update } = store;
+
+  // Auto-persist to localStorage whenever the store value changes
+  if (isBrowser) {
+    subscribe(saveState);
+  }
+
+  return {
+    subscribe,
+
+    /**
+     * Get current collapsed state (for non-reactive access)
+     */
+    get collapsed(): boolean {
+      return get(store);
+    },
+
+    /**
+     * Set collapsed state (auto-persisted via subscription)
+     */
+    setCollapsed(value: boolean) {
+      set(value);
+    },
+
+    /**
+     * Toggle collapsed state
+     */
+    toggle() {
+      update(collapsed => !collapsed);
+    },
+
+    /**
+     * Expand sidebar (set collapsed to false)
+     */
+    expand() {
+      set(false);
+    },
+
+    /**
+     * Collapse sidebar (set collapsed to true)
+     */
+    collapse() {
+      set(true);
+    },
+  };
+}
+
+export const sidebar = createSidebarStore();


### PR DESCRIPTION
## Summary

- Add sidebar collapse/expand functionality for desktop layout (≥1024px)
- Collapsed mode shows 64px wide sidebar with icons only
- Hover tooltips display menu item names when collapsed
- Flyout submenus for Analytics and Settings sections when collapsed
- State persists in localStorage across page reloads
- Mobile drawer overlay behavior remains unchanged

## New Components

- **LogoBadge.svelte**: Stylized gradient badge with Bird icon as alternative to image logo
  - 4 color variants: sunset, ocean, forest, aurora
  - Configurable via `LOGO_STYLE` constant in DesktopSidebar

- **sidebar.ts**: Svelte store for collapsed state with localStorage persistence

## Technical Details

- Smooth 200ms CSS transitions for width changes
- Flyout menus use fixed positioning to escape overflow containers
- CSS Grid layout adjusts dynamically based on collapsed state
- No changes to mobile behavior (drawer overlay)

## Test plan

- [ ] Toggle sidebar collapse/expand on desktop
- [ ] Verify tooltips appear on hover when collapsed
- [ ] Test flyout menus for Analytics and Settings
- [ ] Refresh page and verify state persists
- [ ] Test on mobile to ensure drawer still works
- [ ] Switch themes to verify badge colors adapt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Collapsible desktop sidebar with icons-only mode and flyout submenus for collapsed navigation.
  * New LogoBadge presentational component with selectable sizes and four gradient variants.
  * Sidebar state persists across sessions.

* **User Experience**
  * Smooth animated transitions for sidebar collapse/expand and responsive layout adjustments.
  * Improved collapsed-mode interactions: tooltips, flyout positioning, click-outside dismissal, and keyboard/mouse support.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->