### PR TITLE
fix(sidebar): resolve mobile touch interaction blocked by overlay

### DIFF
--- a/frontend/src/lib/desktop/layouts/DesktopSidebar.svelte
+++ b/frontend/src/lib/desktop/layouts/DesktopSidebar.svelte
@@ -257,7 +257,7 @@ Performance Optimizations:
 
   <nav
     class={cn(
-      'flex flex-col h-dvh bg-base-100 border-r border-base-200/50 transition-all duration-200 ease-in-out',
+      'relative z-10 flex flex-col h-dvh bg-base-100 border-r border-base-200/50 transition-all duration-200 ease-in-out',
       isCollapsed ? 'w-16' : 'w-64'
     )}
   >


### PR DESCRIPTION
## Summary
- Fix mobile sidebar navigation being unresponsive to touch interactions
- Add `relative z-10` to nav element to ensure proper stacking above the drawer-overlay

## Root Cause
The `.drawer-overlay` element has `position: sticky` in CSS, which creates a stacking context. The `<nav>` element had no positioning set, causing CSS stacking rules to render it *below* the overlay. When the drawer opened on mobile, the overlay covered the entire navigation menu, blocking all touch interactions.

## Fix
Added `relative z-10` to the `<nav>` element:
- `relative` - establishes a positioning context
- `z-10` - ensures the nav appears above the overlay (which has implicit z-index of 0)

## Test plan
- [ ] Open BirdNET-Go web UI on mobile device (or resize browser to mobile width)
- [ ] Tap the hamburger menu to open the sidebar
- [ ] Verify all menu items are now clickable
- [ ] Verify clicking outside the sidebar still closes it (overlay still works)

Fixes #1580

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated desktop sidebar positioning and layering for improved visual presentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->