### PR TITLE
fix(ui): improve mobile responsiveness for header dropdowns

### DIFF
--- a/frontend/src/lib/desktop/components/ui/AudioLevelIndicator.svelte
+++ b/frontend/src/lib/desktop/components/ui/AudioLevelIndicator.svelte
@@ -619,7 +619,7 @@
         bind:this={dropdownRef}
         role="menu"
         aria-label="Audio Source Selection"
-        class="absolute right-0 top-full mt-2 min-w-[18rem] max-w-[calc(100vw-1rem)] bg-base-100 rounded-lg shadow-xl border border-base-300 overflow-hidden flex flex-col z-50"
+        class="audio-dropdown absolute top-full mt-2 w-72 sm:w-80 max-w-[calc(100vw-2rem)] bg-base-100 rounded-lg shadow-xl border border-base-300 overflow-hidden flex flex-col z-50"
       >
         <!-- Header -->
         <div class="flex items-center justify-between p-4 border-b border-base-300">
@@ -739,3 +739,25 @@
     {/if}
   </div>
 </div>
+
+<style>
+  /* Mobile: fixed positioning centered horizontally to prevent overflow */
+  .audio-dropdown {
+    position: fixed;
+    left: 50%;
+    right: auto;
+    transform: translateX(-50%);
+    top: 4rem; /* Below header */
+  }
+
+  /* Desktop (sm+): absolute positioning aligned to button */
+  @media (min-width: 640px) {
+    .audio-dropdown {
+      position: absolute;
+      left: auto;
+      right: 0;
+      transform: none;
+      top: 100%;
+    }
+  }
+</style>

--- a/frontend/src/lib/desktop/components/ui/NotificationBell.svelte
+++ b/frontend/src/lib/desktop/components/ui/NotificationBell.svelte
@@ -493,7 +493,7 @@
       bind:this={dropdownRef}
       id="notification-dropdown"
       role={!loading && formattedNotifications.length > 0 ? 'menu' : undefined}
-      class="absolute right-0 top-full mt-2 min-w-md max-w-[calc(100vw-1rem)] max-h-128 bg-base-100 rounded-lg shadow-xl border border-base-300 overflow-hidden flex flex-col"
+      class="notification-dropdown absolute top-full mt-2 w-80 sm:w-96 max-w-[calc(100vw-2rem)] max-h-128 bg-base-100 rounded-lg shadow-xl border border-base-300 overflow-hidden flex flex-col"
       style:z-index={1010}
     >
       <!-- Header -->
@@ -633,5 +633,25 @@
 
   .animate-wiggle {
     animation: wiggle 0.3s ease-in-out 2;
+  }
+
+  /* Mobile: fixed positioning centered horizontally to prevent overflow */
+  .notification-dropdown {
+    position: fixed;
+    left: 50%;
+    right: auto;
+    transform: translateX(-50%);
+    top: 4rem; /* Below header */
+  }
+
+  /* Desktop (sm+): absolute positioning aligned to bell icon */
+  @media (min-width: 640px) {
+    .notification-dropdown {
+      position: absolute;
+      left: auto;
+      right: 0;
+      transform: none;
+      top: 100%;
+    }
   }
 </style>


### PR DESCRIPTION
## Summary
- Fix notification and audio source dropdown menus not scaling properly on mobile devices
- Replace invalid/old Tailwind classes with proper Tailwind v4 utilities
- Add responsive positioning to prevent viewport overflow on small screens

## Changes

### NotificationBell.svelte
- Replace invalid `min-w-md` class with `w-80 sm:w-96`
- Add CSS for responsive positioning (fixed centered on mobile, absolute right-aligned on desktop)

### AudioLevelIndicator.svelte
- Replace `min-w-[18rem]` with `w-72 sm:w-80`
- Add CSS for responsive positioning (fixed centered on mobile, absolute right-aligned on desktop)

## How it works
- **Mobile (<640px)**: Dropdowns use `position: fixed` with `left: 50%; transform: translateX(-50%)` to center horizontally, preventing overflow on either edge
- **Desktop (≥640px)**: Dropdowns use `position: absolute; right: 0` to align with their respective icon buttons
- Both have `max-w-[calc(100vw-2rem)]` as a safety constraint

## Test plan
- [ ] Open BirdNET-Go web UI on mobile device (or resize browser to mobile width)
- [ ] Click the notification bell icon - dropdown should be centered and not overflow
- [ ] Click the audio level indicator - dropdown should be centered and not overflow
- [ ] On desktop, verify dropdowns still align to the right of their icons