### PR TITLE
fix(review): correct API endpoint URL for detection review

### DIFF
--- a/frontend/src/lib/desktop/components/review/ReviewCard.svelte
+++ b/frontend/src/lib/desktop/components/review/ReviewCard.svelte
@@ -61,13 +61,12 @@
     try {
       const desiredLockState = detection.locked ? !lockDetection : lockDetection;
 
-      await fetchWithCSRF('/api/v2/detections/review', {
+      await fetchWithCSRF(`/api/v2/detections/${detection.id}/review`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({
-          id: detection.id,
           verified: reviewStatus,
           lock_detection: desiredLockState,
           ignore_species: ignoreSpecies ? detection.commonName : null,


### PR DESCRIPTION
## Summary
- Fix 404 error when reviewing detections (marking as correct/false positive)
- Change API call from `POST /api/v2/detections/review` to `POST /api/v2/detections/:id/review`
- Remove redundant `id` field from request body since it's now in the URL path

## Test plan
- [ ] Navigate to a detection detail page
- [ ] Go to the Review tab
- [ ] Mark detection as correct or false positive
- [ ] Verify the review saves successfully without 404 error