### PR TITLE
refactor(tests): standardize errors, httpclient, privacy tests with testify

### DIFF
--- a/internal/errors/errors_test.go
+++ b/internal/errors/errors_test.go
@@ -2,8 +2,9 @@ package errors
 
 import (
 	"fmt"
-	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestFastPathNoTelemetry(t *testing.T) {
@@ -17,18 +18,12 @@ func TestFastPathNoTelemetry(t *testing.T) {
 	err := fmt.Errorf("test error")
 	ee := New(err).Build()
 
-	if ee.Err.Error() != "test error" {
-		t.Errorf("Expected error message 'test error', got '%s'", ee.Err.Error())
-	}
+	assert.Equal(t, "test error", ee.Err.Error(), "expected error message 'test error'")
 
 	// Use production constant directly to ensure test stays in sync
-	if ee.GetComponent() != ComponentUnknown {
-		t.Errorf("Expected component '%s' in fast path, got '%s'", ComponentUnknown, ee.GetComponent())
-	}
+	assert.Equal(t, ComponentUnknown, ee.GetComponent(), "expected component to be unknown in fast path")
 
-	if ee.Category != CategoryGeneric {
-		t.Errorf("Expected category 'generic' in fast path, got '%s'", ee.Category)
-	}
+	assert.Equal(t, CategoryGeneric, ee.Category, "expected category 'generic' in fast path")
 }
 
 func TestRegexPrecompilation(t *testing.T) {
@@ -63,16 +58,14 @@ func TestRegexPrecompilation(t *testing.T) {
 			t.Parallel()
 			scrubbed := basicURLScrub(tt.input)
 
-			if tt.expected != "" && scrubbed != tt.expected {
-				t.Errorf("Expected: %s, got: %s", tt.expected, scrubbed)
+			if tt.expected != "" {
+				assert.Equal(t, tt.expected, scrubbed)
 			}
-			if tt.contains != "" && !strings.Contains(scrubbed, tt.contains) {
-				t.Errorf("Expected to contain '%s', got: %s", tt.contains, scrubbed)
+			if tt.contains != "" {
+				assert.Contains(t, scrubbed, tt.contains)
 			}
 			for _, exclude := range tt.excludes {
-				if strings.Contains(scrubbed, exclude) {
-					t.Errorf("Should not contain '%s', got: %s", exclude, scrubbed)
-				}
+				assert.NotContains(t, scrubbed, exclude)
 			}
 		})
 	}

--- a/internal/httpclient/client_helpers_test.go
+++ b/internal/httpclient/client_helpers_test.go
@@ -1,0 +1,44 @@
+package httpclient
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// newTestClient creates a Client with default configuration and registers cleanup.
+func newTestClient(t *testing.T) *Client {
+	t.Helper()
+	cfg := DefaultConfig()
+	client := New(&cfg)
+	t.Cleanup(func() { client.Close() })
+	return client
+}
+
+// newTestClientWithConfig creates a Client with custom configuration and registers cleanup.
+func newTestClientWithConfig(t *testing.T, cfg *Config) *Client {
+	t.Helper()
+	client := New(cfg)
+	t.Cleanup(func() { client.Close() })
+	return client
+}
+
+// newTestServer creates a test HTTP server and registers cleanup.
+func newTestServer(t *testing.T, handler http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(func() { server.Close() })
+	return server
+}
+
+// closeResponseBody safely closes a response body with error logging.
+// Use this with defer immediately after getting a response.
+func closeResponseBody(t *testing.T, resp *http.Response) {
+	t.Helper()
+	if resp == nil || resp.Body == nil {
+		return
+	}
+	if err := resp.Body.Close(); err != nil {
+		t.Logf("failed to close response body: %v", err)
+	}
+}

--- a/internal/httpclient/client_test.go
+++ b/internal/httpclient/client_test.go
@@ -2,15 +2,16 @@ package httpclient
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
-	"net/http/httptest"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNew(t *testing.T) {
@@ -18,15 +19,9 @@ func TestNew(t *testing.T) {
 		cfg := DefaultConfig()
 		client := New(&cfg)
 
-		if client == nil {
-			t.Fatal("expected non-nil client")
-		}
-		if client.defaultTimeout != DefaultTimeout {
-			t.Errorf("expected timeout %v, got %v", DefaultTimeout, client.defaultTimeout)
-		}
-		if client.userAgent != defaultUserAgent {
-			t.Errorf("expected user agent %q, got %q", defaultUserAgent, client.userAgent)
-		}
+		require.NotNil(t, client, "expected non-nil client")
+		assert.Equal(t, DefaultTimeout, client.defaultTimeout, "expected default timeout")
+		assert.Equal(t, defaultUserAgent, client.userAgent, "expected default user agent")
 	})
 
 	t.Run("custom config", func(t *testing.T) {
@@ -36,262 +31,159 @@ func TestNew(t *testing.T) {
 		}
 		client := New(&cfg)
 
-		if client.defaultTimeout != 5*time.Second {
-			t.Errorf("expected timeout 5s, got %v", client.defaultTimeout)
-		}
-		if client.userAgent != "TestAgent/1.0" {
-			t.Errorf("expected user agent 'TestAgent/1.0', got %q", client.userAgent)
-		}
+		assert.Equal(t, 5*time.Second, client.defaultTimeout, "expected timeout 5s")
+		assert.Equal(t, "TestAgent/1.0", client.userAgent, "expected user agent 'TestAgent/1.0'")
 	})
 
 	t.Run("zero values use defaults", func(t *testing.T) {
 		cfg := Config{} // All zero values
 		client := New(&cfg)
 
-		if client.defaultTimeout != DefaultTimeout {
-			t.Errorf("expected default timeout, got %v", client.defaultTimeout)
-		}
-		if client.userAgent == "" {
-			t.Error("expected non-empty user agent")
-		}
+		assert.Equal(t, DefaultTimeout, client.defaultTimeout, "expected default timeout")
+		assert.NotEmpty(t, client.userAgent, "expected non-empty user agent")
 	})
 }
 
 func TestDo_BasicRequest(t *testing.T) {
-	// Create test server
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodGet {
-			t.Errorf("expected GET, got %s", r.Method)
-		}
+	server := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method, "expected GET method")
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("success"))
-	}))
-	defer server.Close()
+	})
 
-	cfg := DefaultConfig()
-	client := New(&cfg)
-	defer client.Close()
+	client := newTestClient(t)
 
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, server.URL, http.NoBody)
-	if err != nil {
-		t.Fatalf("failed to create request: %v", err)
-	}
+	require.NoError(t, err, "failed to create request")
 
 	resp, err := client.Do(context.Background(), req)
-	if err != nil {
-		t.Fatalf("request failed: %v", err)
-	}
-	defer func() {
-		if cerr := resp.Body.Close(); cerr != nil {
-			t.Logf("failed to close response body: %v", cerr)
-		}
-	}()
+	require.NoError(t, err, "request failed")
+	defer closeResponseBody(t, resp)
 
-	if resp.StatusCode != http.StatusOK {
-		t.Errorf("expected status 200, got %d", resp.StatusCode)
-	}
+	assert.Equal(t, http.StatusOK, resp.StatusCode, "expected status 200")
 
 	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		t.Fatalf("failed to read body: %v", err)
-	}
-	if string(body) != "success" {
-		t.Errorf("expected body 'success', got %q", string(body))
-	}
+	require.NoError(t, err, "failed to read body")
+	assert.Equal(t, "success", string(body), "expected body 'success'")
 }
 
 func TestDo_UserAgent(t *testing.T) {
 	receivedUA := ""
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		receivedUA = r.Header.Get("User-Agent")
 		w.WriteHeader(http.StatusOK)
-	}))
-	defer server.Close()
+	})
 
 	cfg := Config{UserAgent: "CustomAgent/2.0"}
-	client := New(&cfg)
-	defer client.Close()
+	client := newTestClientWithConfig(t, &cfg)
 
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, server.URL, http.NoBody)
-	if err != nil {
-		t.Fatalf("failed to create request: %v", err)
-	}
+	require.NoError(t, err, "failed to create request")
 
 	resp, err := client.Do(context.Background(), req)
-	if err != nil {
-		t.Fatalf("request failed: %v", err)
-	}
-	defer func() {
-		if cerr := resp.Body.Close(); cerr != nil {
-			t.Logf("failed to close response body: %v", cerr)
-		}
-	}()
+	require.NoError(t, err, "request failed")
+	defer closeResponseBody(t, resp)
 
-	if receivedUA != "CustomAgent/2.0" {
-		t.Errorf("expected User-Agent 'CustomAgent/2.0', got %q", receivedUA)
-	}
+	assert.Equal(t, "CustomAgent/2.0", receivedUA, "expected User-Agent 'CustomAgent/2.0'")
 }
 
 func TestDo_ContextCancellation(t *testing.T) {
-	// Server that delays response
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		time.Sleep(2 * time.Second)
 		w.WriteHeader(http.StatusOK)
-	}))
-	defer server.Close()
+	})
 
-	cfg := DefaultConfig()
-	client := New(&cfg)
-	defer client.Close()
+	client := newTestClient(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, server.URL, http.NoBody)
-	if err != nil {
-		t.Fatalf("failed to create request: %v", err)
-	}
+	require.NoError(t, err, "failed to create request")
 
 	// Cancel immediately
 	cancel()
 
 	resp, err := client.Do(ctx, req)
-	if resp != nil && resp.Body != nil {
-		defer func() {
-			if cerr := resp.Body.Close(); cerr != nil {
-				t.Logf("failed to close response body: %v", cerr)
-			}
-		}()
-	}
-	if err == nil {
-		t.Fatal("expected error from cancelled context")
-	}
+	defer closeResponseBody(t, resp)
 
-	if !errors.Is(err, context.Canceled) {
-		t.Errorf("expected context.Canceled error, got: %v", err)
-	}
+	require.Error(t, err, "expected error from cancelled context")
+	assert.ErrorIs(t, err, context.Canceled, "expected context.Canceled error")
 }
 
 func TestDo_ContextTimeout(t *testing.T) {
-	// Server that delays response
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		time.Sleep(500 * time.Millisecond)
 		w.WriteHeader(http.StatusOK)
-	}))
-	defer server.Close()
+	})
 
-	cfg := DefaultConfig()
-	client := New(&cfg)
-	defer client.Close()
+	client := newTestClient(t)
 
 	// Create context with very short timeout
 	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	defer cancel()
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, server.URL, http.NoBody)
-	if err != nil {
-		t.Fatalf("failed to create request: %v", err)
-	}
+	require.NoError(t, err, "failed to create request")
 
 	resp, err := client.Do(ctx, req)
-	if resp != nil && resp.Body != nil {
-		defer func() {
-			if cerr := resp.Body.Close(); cerr != nil {
-				t.Logf("failed to close response body: %v", cerr)
-			}
-		}()
-	}
-	if err == nil {
-		t.Fatal("expected timeout error")
-	}
+	defer closeResponseBody(t, resp)
 
-	if !errors.Is(err, context.DeadlineExceeded) {
-		t.Errorf("expected context.DeadlineExceeded error, got: %v", err)
-	}
+	require.Error(t, err, "expected timeout error")
+	assert.ErrorIs(t, err, context.DeadlineExceeded, "expected context.DeadlineExceeded error")
 }
 
 func TestDo_DefaultTimeout(t *testing.T) {
-	// Server that delays response
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		time.Sleep(200 * time.Millisecond)
 		w.WriteHeader(http.StatusOK)
-	}))
-	defer server.Close()
+	})
 
 	// Create client with very short default timeout
 	cfg := Config{DefaultTimeout: 50 * time.Millisecond}
-	client := New(&cfg)
-	defer client.Close()
+	client := newTestClientWithConfig(t, &cfg)
 
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, server.URL, http.NoBody)
-	if err != nil {
-		t.Fatalf("failed to create request: %v", err)
-	}
+	require.NoError(t, err, "failed to create request")
 
 	// Context has no deadline, so default timeout should apply
 	resp, err := client.Do(context.Background(), req)
-	if resp != nil && resp.Body != nil {
-		defer func() {
-			if cerr := resp.Body.Close(); cerr != nil {
-				t.Logf("failed to close response body: %v", cerr)
-			}
-		}()
-	}
-	if err == nil {
-		t.Fatal("expected timeout error")
-	}
+	defer closeResponseBody(t, resp)
 
-	if !errors.Is(err, context.DeadlineExceeded) {
-		t.Errorf("expected context.DeadlineExceeded error, got: %v", err)
-	}
+	require.Error(t, err, "expected timeout error")
+	assert.ErrorIs(t, err, context.DeadlineExceeded, "expected context.DeadlineExceeded error")
 }
 
 func TestDo_ContextTimeoutOverridesDefault(t *testing.T) {
-	// Server with minimal delay
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		time.Sleep(20 * time.Millisecond)
 		w.WriteHeader(http.StatusOK)
-	}))
-	defer server.Close()
+	})
 
 	// Client with very short default timeout
 	cfg := Config{DefaultTimeout: 10 * time.Millisecond}
-	client := New(&cfg)
-	defer client.Close()
+	client := newTestClientWithConfig(t, &cfg)
 
 	// But context has longer timeout - should succeed
 	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	defer cancel()
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, server.URL, http.NoBody)
-	if err != nil {
-		t.Fatalf("failed to create request: %v", err)
-	}
+	require.NoError(t, err, "failed to create request")
 
 	resp, err := client.Do(ctx, req)
-	if err != nil {
-		t.Fatalf("request should succeed with context timeout: %v", err)
-	}
-	defer func() {
-		if cerr := resp.Body.Close(); cerr != nil {
-			t.Logf("failed to close response body: %v", cerr)
-		}
-	}()
+	require.NoError(t, err, "request should succeed with context timeout")
+	defer closeResponseBody(t, resp)
 
-	if resp.StatusCode != http.StatusOK {
-		t.Errorf("expected status 200, got %d", resp.StatusCode)
-	}
+	assert.Equal(t, http.StatusOK, resp.StatusCode, "expected status 200")
 }
 
 func TestDo_ConcurrentRequests(t *testing.T) {
 	var requestCount atomic.Int32
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		requestCount.Add(1)
 		w.WriteHeader(http.StatusOK)
-	}))
-	defer server.Close()
+	})
 
-	cfg := DefaultConfig()
-	client := New(&cfg)
-	defer client.Close()
+	client := newTestClient(t)
 
 	// Launch 50 concurrent requests
 	concurrency := 50
@@ -332,24 +224,20 @@ func TestDo_ConcurrentRequests(t *testing.T) {
 
 	// Check for errors
 	for err := range errChan {
-		t.Errorf("concurrent request failed: %v", err)
+		require.NoError(t, err, "concurrent request failed")
 	}
 
 	// Verify all requests were received
-	if count := requestCount.Load(); count != int32(concurrency) {
-		t.Errorf("expected %d requests, got %d", concurrency, count)
-	}
+	count := requestCount.Load()
+	assert.Equal(t, int32(concurrency), count, "expected all requests to be received")
 }
 
 func TestDo_Hooks(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-	}))
-	defer server.Close()
+	})
 
-	cfg := DefaultConfig()
-	client := New(&cfg)
-	defer client.Close()
+	client := newTestClient(t)
 
 	var beforeCalled, afterCalled bool
 	var capturedResp *http.Response
@@ -357,9 +245,7 @@ func TestDo_Hooks(t *testing.T) {
 
 	client.SetBeforeRequestHook(func(r *http.Request) {
 		beforeCalled = true
-		if r.URL.String() != server.URL {
-			t.Errorf("before hook: unexpected URL %s", r.URL.String())
-		}
+		assert.Equal(t, server.URL, r.URL.String(), "before hook: unexpected URL")
 	})
 
 	client.SetAfterResponseHook(func(r *http.Request, resp *http.Response, err error) {
@@ -369,100 +255,53 @@ func TestDo_Hooks(t *testing.T) {
 	})
 
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, server.URL, http.NoBody)
-	if err != nil {
-		t.Fatalf("failed to create request: %v", err)
-	}
+	require.NoError(t, err, "failed to create request")
 
 	resp, err := client.Do(context.Background(), req)
-	if err != nil {
-		t.Fatalf("request failed: %v", err)
-	}
-	defer func() {
-		if cerr := resp.Body.Close(); cerr != nil {
-			t.Logf("failed to close response body: %v", cerr)
-		}
-	}()
+	require.NoError(t, err, "request failed")
+	defer closeResponseBody(t, resp)
 
-	if !beforeCalled {
-		t.Error("before hook was not called")
-	}
-	if !afterCalled {
-		t.Error("after hook was not called")
-	}
-	if capturedResp == nil {
-		t.Error("after hook did not capture response")
-	}
-	if capturedErr != nil {
-		t.Errorf("after hook captured unexpected error: %v", capturedErr)
-	}
+	assert.True(t, beforeCalled, "before hook was not called")
+	assert.True(t, afterCalled, "after hook was not called")
+	assert.NotNil(t, capturedResp, "after hook did not capture response")
+	assert.NoError(t, capturedErr, "after hook captured unexpected error")
 }
 
 func TestGet(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodGet {
-			t.Errorf("expected GET, got %s", r.Method)
-		}
+	server := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method, "expected GET method")
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("get success"))
-	}))
-	defer server.Close()
+	})
 
-	cfg := DefaultConfig()
-	client := New(&cfg)
-	defer client.Close()
+	client := newTestClient(t)
 
 	resp, err := client.Get(context.Background(), server.URL)
-	if err != nil {
-		t.Fatalf("GET failed: %v", err)
-	}
-	defer func() {
-		if cerr := resp.Body.Close(); cerr != nil {
-			t.Logf("failed to close response body: %v", cerr)
-		}
-	}()
+	require.NoError(t, err, "GET failed")
+	defer closeResponseBody(t, resp)
 
-	if resp.StatusCode != http.StatusOK {
-		t.Errorf("expected status 200, got %d", resp.StatusCode)
-	}
+	assert.Equal(t, http.StatusOK, resp.StatusCode, "expected status 200")
 
 	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		t.Fatalf("failed to read body: %v", err)
-	}
-	if string(body) != "get success" {
-		t.Errorf("expected body 'get success', got %q", string(body))
-	}
+	require.NoError(t, err, "failed to read body")
+	assert.Equal(t, "get success", string(body), "expected body 'get success'")
 }
 
 func TestPost(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPost {
-			t.Errorf("expected POST, got %s", r.Method)
-		}
-		if ct := r.Header.Get("Content-Type"); ct != "application/json" {
-			t.Errorf("expected Content-Type application/json, got %q", ct)
-		}
+	server := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method, "expected POST method")
+		ct := r.Header.Get("Content-Type")
+		assert.Equal(t, "application/json", ct, "expected Content-Type application/json")
 		w.WriteHeader(http.StatusCreated)
-	}))
-	defer server.Close()
+	})
 
-	cfg := DefaultConfig()
-	client := New(&cfg)
-	defer client.Close()
+	client := newTestClient(t)
 
 	resp, err := client.Post(context.Background(), server.URL, "application/json", nil)
-	if err != nil {
-		t.Fatalf("POST failed: %v", err)
-	}
-	defer func() {
-		if cerr := resp.Body.Close(); cerr != nil {
-			t.Logf("failed to close response body: %v", cerr)
-		}
-	}()
+	require.NoError(t, err, "POST failed")
+	defer closeResponseBody(t, resp)
 
-	if resp.StatusCode != http.StatusCreated {
-		t.Errorf("expected status 201, got %d", resp.StatusCode)
-	}
+	assert.Equal(t, http.StatusCreated, resp.StatusCode, "expected status 201")
 }
 
 func TestClose(t *testing.T) {

--- a/internal/privacy/privacy_test.go
+++ b/internal/privacy/privacy_test.go
@@ -20,9 +20,7 @@ func runBooleanTests(t *testing.T, testFunc func(string) bool, tests []struct {
 			t.Parallel()
 
 			result := testFunc(tt.input)
-			if result != tt.expected {
-				t.Errorf("Expected %t, got %t for input %q", tt.expected, result, tt.input)
-			}
+			assert.Equal(t, tt.expected, result, "for input %q", tt.input)
 		})
 	}
 }
@@ -39,9 +37,7 @@ func runScrubTests(t *testing.T, testFunc func(string) string, tests []struct {
 			t.Parallel()
 
 			result := testFunc(tt.input)
-			if result != tt.expected {
-				t.Errorf("Expected %q, but got %q", tt.expected, result)
-			}
+			assert.Equal(t, tt.expected, result)
 		})
 	}
 }
@@ -112,15 +108,11 @@ func TestScrubMessage(t *testing.T) {
 			result := ScrubMessage(tt.input)
 
 			for _, expected := range tt.contains {
-				if !strings.Contains(result, expected) {
-					t.Errorf("Expected result to contain %q, but got: %s", expected, result)
-				}
+				assert.Contains(t, result, expected, "Expected result to contain %q", expected)
 			}
 
 			for _, unexpected := range tt.notContains {
-				if strings.Contains(result, unexpected) {
-					t.Errorf("Expected result to NOT contain %q, but got: %s", unexpected, result)
-				}
+				assert.NotContains(t, result, unexpected, "Expected result to NOT contain %q", unexpected)
 			}
 		})
 	}
@@ -167,15 +159,12 @@ func TestAnonymizeURL(t *testing.T) {
 
 			result := AnonymizeURL(tt.input)
 
-			if !strings.HasPrefix(result, tt.expectPrefix) {
-				t.Errorf("Expected result to start with %q, but got: %s", tt.expectPrefix, result)
-			}
+			assert.True(t, strings.HasPrefix(result, tt.expectPrefix),
+				"Expected result to start with %q, but got: %s", tt.expectPrefix, result)
 
 			// Ensure consistent anonymization - same input should produce same output
 			result2 := AnonymizeURL(tt.input)
-			if result != result2 {
-				t.Errorf("Expected consistent anonymization, but got different results: %s vs %s", result, result2)
-			}
+			assert.Equal(t, result, result2, "Expected consistent anonymization")
 		})
 	}
 }
@@ -230,9 +219,7 @@ func TestSanitizeRTSPUrl(t *testing.T) {
 			t.Parallel()
 
 			result := SanitizeRTSPUrl(tt.input)
-			if result != tt.expected {
-				t.Errorf("Expected %q, but got %q", tt.expected, result)
-			}
+			assert.Equal(t, tt.expected, result)
 		})
 	}
 }
@@ -282,9 +269,7 @@ func TestSanitizeRTSPUrls(t *testing.T) {
 			t.Parallel()
 
 			result := SanitizeRTSPUrls(tt.input)
-			if result != tt.expected {
-				t.Errorf("SanitizeRTSPUrls() = %q, want %q", result, tt.expected)
-			}
+			assert.Equal(t, tt.expected, result)
 		})
 	}
 }
@@ -296,29 +281,20 @@ func TestGenerateSystemID(t *testing.T) {
 	ids := make(map[string]bool)
 	for range 100 {
 		id, err := GenerateSystemID()
-		if err != nil {
-			t.Fatalf("GenerateSystemID failed: %v", err)
-		}
+		require.NoError(t, err, "GenerateSystemID failed")
 
 		// Check format
-		if !IsValidSystemID(id) {
-			t.Errorf("Generated ID %q is not valid", id)
-		}
+		assert.True(t, IsValidSystemID(id), "Generated ID %q is not valid", id)
 
 		// Check uniqueness
-		if ids[id] {
-			t.Errorf("Duplicate ID generated: %q", id)
-		}
+		assert.False(t, ids[id], "Duplicate ID generated: %q", id)
 		ids[id] = true
 
 		// Check format manually as well
-		if len(id) != 14 {
-			t.Errorf("Expected ID length 14, got %d for ID: %q", len(id), id)
-		}
+		assert.Len(t, id, 14, "Expected ID length 14 for ID: %q", id)
 
-		if id[4] != '-' || id[9] != '-' {
-			t.Errorf("Expected hyphens at positions 4 and 9, got: %q", id)
-		}
+		assert.Equal(t, byte('-'), id[4], "Expected hyphen at position 4, got: %q", id)
+		assert.Equal(t, byte('-'), id[9], "Expected hyphen at position 9, got: %q", id)
 	}
 }
 
@@ -382,9 +358,7 @@ func TestIsValidSystemID(t *testing.T) {
 			t.Parallel()
 
 			result := IsValidSystemID(tt.input)
-			if result != tt.valid {
-				t.Errorf("Expected IsValidSystemID(%q) = %v, got %v", tt.input, tt.valid, result)
-			}
+			assert.Equal(t, tt.valid, result, "IsValidSystemID(%q)", tt.input)
 		})
 	}
 }
@@ -474,9 +448,7 @@ func TestCategorizeHost(t *testing.T) {
 			t.Parallel()
 
 			result := categorizeHost(tt.input)
-			if result != tt.expected {
-				t.Errorf("Expected categorizeHost(%q) = %q, got %q", tt.input, tt.expected, result)
-			}
+			assert.Equal(t, tt.expected, result, "categorizeHost(%q)", tt.input)
 		})
 	}
 }
@@ -551,9 +523,7 @@ func TestIsPrivateIP(t *testing.T) {
 			t.Parallel()
 
 			result := IsPrivateIP(tt.input)
-			if result != tt.expected {
-				t.Errorf("Expected isPrivateIP(%q) = %v, got %v", tt.input, tt.expected, result)
-			}
+			assert.Equal(t, tt.expected, result, "IsPrivateIP(%q)", tt.input)
 		})
 	}
 }
@@ -608,9 +578,7 @@ func TestIsIPAddress(t *testing.T) {
 			t.Parallel()
 
 			result := isIPAddress(tt.input)
-			if result != tt.expected {
-				t.Errorf("Expected isIPAddress(%q) = %v, got %v", tt.input, tt.expected, result)
-			}
+			assert.Equal(t, tt.expected, result, "isIPAddress(%q)", tt.input)
 		})
 	}
 }
@@ -786,9 +754,7 @@ func TestIsHexChar(t *testing.T) {
 			t.Parallel()
 
 			result := isHexChar(tt.input)
-			if result != tt.expected {
-				t.Errorf("Expected isHexChar(%q) = %v, got %v", tt.input, tt.expected, result)
-			}
+			assert.Equal(t, tt.expected, result, "isHexChar(%q)", tt.input)
 		})
 	}
 }
@@ -858,9 +824,7 @@ func TestCategorizeDomain(t *testing.T) {
 			t.Parallel()
 
 			result := categorizeDomain(tt.input)
-			if result != tt.expected {
-				t.Errorf("Expected categorizeDomain(%q) = %q, got %q", tt.input, tt.expected, result)
-			}
+			assert.Equal(t, tt.expected, result, "categorizeDomain(%q)", tt.input)
 		})
 	}
 }
@@ -1011,9 +975,7 @@ func TestScrubEmails(t *testing.T) {
 			t.Parallel()
 
 			result := ScrubEmails(tt.input)
-			if result != tt.expected {
-				t.Errorf("Expected %q, but got %q", tt.expected, result)
-			}
+			assert.Equal(t, tt.expected, result)
 		})
 	}
 }
@@ -1058,9 +1020,7 @@ func TestScrubUUIDs(t *testing.T) {
 			t.Parallel()
 
 			result := ScrubUUIDs(tt.input)
-			if result != tt.expected {
-				t.Errorf("Expected %q, but got %q", tt.expected, result)
-			}
+			assert.Equal(t, tt.expected, result)
 		})
 	}
 }
@@ -1113,15 +1073,11 @@ func TestScrubStandaloneIPs(t *testing.T) {
 			result := ScrubStandaloneIPs(tt.input)
 
 			for _, expected := range tt.contains {
-				if !strings.Contains(result, expected) {
-					t.Errorf("Expected result to contain %q, but got: %s", expected, result)
-				}
+				assert.Contains(t, result, expected, "Expected result to contain %q", expected)
 			}
 
 			for _, unexpected := range tt.notContains {
-				if strings.Contains(result, unexpected) {
-					t.Errorf("Expected result to NOT contain %q, but got: %s", unexpected, result)
-				}
+				assert.NotContains(t, result, unexpected, "Expected result to NOT contain %q", unexpected)
 			}
 		})
 	}
@@ -1157,9 +1113,7 @@ func TestBearerTokenScrubbing(t *testing.T) {
 			t.Parallel()
 
 			result := ScrubAPITokens(tt.input)
-			if result != tt.expected {
-				t.Errorf("Expected %q, but got %q", tt.expected, result)
-			}
+			assert.Equal(t, tt.expected, result)
 		})
 	}
 }


### PR DESCRIPTION
## Summary
- Replace manual assertion patterns (t.Errorf, t.Fatalf, if-then-error) with testify assert/require
- Add shared test helpers to httpclient to reduce duplication
- Net reduction: **172 lines** (345 deletions, 173 insertions)

## Changes
- **errors**: Use require.NoError/assert.Equal
- **httpclient**: 
  - Use require.NoError/assert.Equal/assert.Contains
  - Add `client_helpers_test.go` with shared helpers:
    - `newTestClient(t)` - creates client with cleanup
    - `newTestClientWithConfig(t, cfg)` - creates client with custom config
    - `newTestServer(t, handler)` - creates test server with cleanup
    - `closeResponseBody(t, resp)` - safely closes response body
- **privacy**: Use require.NoError/assert.Equal/assert.True (already had good helpers)

## Test plan
- [x] All tests pass: `go test ./internal/errors/... ./internal/httpclient/... ./internal/privacy/...`
- [x] No lint issues: `golangci-lint run`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated internal test suites with standardized assertion patterns and helper utilities for improved test infrastructure consistency across error handling, HTTP client, and privacy modules.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->