### PR TITLE
refactor(tests): convert diskmanager and birdweather tests to testify

### DIFF
--- a/internal/birdweather/birdweather_client_test.go
+++ b/internal/birdweather/birdweather_client_test.go
@@ -252,7 +252,7 @@ func TestUploadSoundscape(t *testing.T) {
 		// Return success response
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
-		if _, err := fmt.Fprint(w, `{
+		_, err := fmt.Fprint(w, `{
 			"success": true,
 			"soundscape": {
 				"id": 12345,
@@ -263,9 +263,8 @@ func TestUploadSoundscape(t *testing.T) {
 				"extension": "flac",
 				"duration": 3.0
 			}
-		}`); err != nil {
-			t.Errorf("Failed to write response: %v", err)
-		}
+		}`)
+		assert.NoError(t, err, "Failed to write response")
 	}))
 	defer server.Close()
 
@@ -330,9 +329,8 @@ func TestUploadSoundscape_ServerError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusInternalServerError)
-		if _, err := fmt.Fprint(w, `{"success": false, "error": "Server error"}`); err != nil {
-			t.Errorf("Failed to write response: %v", err)
-		}
+		_, err := fmt.Fprint(w, `{"success": false, "error": "Server error"}`)
+		assert.NoError(t, err, "Failed to write response")
 	}))
 	defer server.Close()
 
@@ -370,8 +368,8 @@ func TestPostDetection(t *testing.T) {
 		// Check request body
 		var reqBody map[string]any
 		decoder := json.NewDecoder(r.Body)
-		if err := decoder.Decode(&reqBody); err != nil {
-			t.Errorf("Failed to decode request body: %v", err)
+		err := decoder.Decode(&reqBody)
+		if !assert.NoError(t, err, "Failed to decode request body") {
 			return
 		}
 
@@ -474,8 +472,7 @@ func TestPublish(t *testing.T) {
 	// Setup mock server for both upload and post
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// All requests should be POST
-		if r.Method != "POST" {
-			t.Errorf("Expected POST request, got %s", r.Method)
+		if !assert.Equal(t, "POST", r.Method, "Expected POST request") {
 			w.WriteHeader(http.StatusBadRequest)
 			return
 		}
@@ -487,7 +484,7 @@ func TestPublish(t *testing.T) {
 			// This is a soundscape upload
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusCreated)
-			if _, err := fmt.Fprint(w, `{
+			_, err := fmt.Fprint(w, `{
 				"success": true,
 				"soundscape": {
 					"id": 12345,
@@ -498,19 +495,17 @@ func TestPublish(t *testing.T) {
 					"extension": "flac",
 					"duration": 3.0
 				}
-			}`); err != nil {
-				t.Errorf("Failed to write response: %v", err)
-			}
+			}`)
+			assert.NoError(t, err, "Failed to write response")
 		case "application/json":
 			// This is a detection post
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusCreated)
-			if _, err := fmt.Fprint(w, `{"success": true}`); err != nil {
-				t.Errorf("Failed to write response: %v", err)
-			}
+			_, err := fmt.Fprint(w, `{"success": true}`)
+			assert.NoError(t, err, "Failed to write response")
 		default:
 			// Unexpected content type
-			t.Errorf("Unexpected Content-Type: %s", contentType)
+			assert.Failf(t, "Unexpected Content-Type", "got: %s", contentType)
 			w.WriteHeader(http.StatusBadRequest)
 		}
 	}))

--- a/internal/birdweather/helpers_test.go
+++ b/internal/birdweather/helpers_test.go
@@ -779,8 +779,7 @@ func TestGenerateTestPCMData(t *testing.T) {
 
 	// Data should be all zeros (silence)
 	for i, b := range data {
-		if b != 0 {
-			t.Errorf("Expected silence (0) at index %d, got %d", i, b)
+		if !assert.Equal(t, byte(0), b, "Expected silence (0) at index %d", i) {
 			break
 		}
 	}

--- a/internal/diskmanager/policy_usage_test.go
+++ b/internal/diskmanager/policy_usage_test.go
@@ -109,10 +109,9 @@ func TestFileTypesEligibleForDeletion(t *testing.T) {
 
 				// If the file has a disallowed extension but would be processed for deletion,
 				// fail the test with a security warning
-				if !isAllowedExt && !hasError {
-					t.Errorf("SECURITY ISSUE: %s file would be processed for deletion but should be protected: %s",
-						tc.extension, tc.description)
-				}
+				assert.True(t, isAllowedExt || hasError,
+					"SECURITY ISSUE: %s file would be processed for deletion but should be protected: %s",
+					tc.extension, tc.description)
 
 				// If the function returned an error, validate it's the right kind of error
 				if hasError {


### PR DESCRIPTION
## Summary
- Converts old assertion patterns (`t.Errorf`, `t.Fatalf`) to testify in:
  - `internal/diskmanager/policy_age_test.go` (12 patterns)
  - `internal/diskmanager/policy_usage_test.go` (1 pattern)
  - `internal/birdweather/birdweather_client_test.go` (7 patterns)
  - `internal/birdweather/helpers_test.go` (1 pattern)
- Continues the test standardization effort from PR #1645

## Test plan
- [x] All diskmanager tests pass
- [x] All birdweather tests pass
- [x] Linter passes with 0 issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Improved internal test infrastructure by standardizing assertion methods across test suites.

**Note:** This release contains no user-facing changes. Updates are limited to internal testing improvements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->