### PR TITLE
feat(frontend): add Vite cache busting with content hashes

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -77,6 +77,7 @@ export default defineConfig({
     outDir: 'dist',
     chunkSizeWarningLimit: 1000,
     emptyOutDir: true,
+    manifest: true, // Generates .vite/manifest.json for cache busting
     // Watch mode disabled by default for CI/CD compatibility
     // When using --watch flag, chokidar options are applied for reliable file change detection
     watch: process.argv.includes('--watch')
@@ -89,13 +90,13 @@ export default defineConfig({
       : null,
     rollupOptions: {
       output: {
-        entryFileNames: '[name].js',
-        chunkFileNames: '[name].js',
-        assetFileNames: '[name].[ext]',
+        // Content hashes enable proper cache busting with CDNs like Cloudflare
+        entryFileNames: '[name]-[hash].js',
+        chunkFileNames: '[name]-[hash].js',
+        assetFileNames: '[name]-[hash].[ext]',
         manualChunks: {
           vendor: ['svelte'],
           charts: ['chart.js'],
-          ui: [/* UI library chunks */]
         }
       },
     },

--- a/internal/api/manifest.go
+++ b/internal/api/manifest.go
@@ -1,0 +1,82 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// ViteManifest represents the structure of Vite's manifest.json.
+// The manifest maps source file paths to their build outputs.
+type ViteManifest map[string]ViteManifestEntry
+
+// ViteManifestEntry represents a single entry in the Vite manifest.
+type ViteManifestEntry struct {
+	File    string   `json:"file"`              // The output filename with hash
+	Src     string   `json:"src,omitempty"`     // The source file path
+	IsEntry bool     `json:"isEntry,omitempty"` // True if this is an entry point
+	CSS     []string `json:"css,omitempty"`     // Associated CSS files
+	Imports []string `json:"imports,omitempty"` // Dynamic imports
+}
+
+// AssetPaths holds the resolved asset paths for the SPA template.
+type AssetPaths struct {
+	EntryJS  string   // Main JavaScript entry point (e.g., "index-a1b2c3d4.js")
+	EntryCSS []string // CSS files associated with the entry point
+}
+
+// manifestPath is the relative path to the Vite manifest within the dist directory.
+const manifestPath = ".vite/manifest.json"
+
+// LoadManifestFromFS loads and parses the Vite manifest from an embedded filesystem.
+func LoadManifestFromFS(fsys fs.FS) (*AssetPaths, error) {
+	data, err := fs.ReadFile(fsys, manifestPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read manifest from embedded FS: %w", err)
+	}
+	return parseManifest(data)
+}
+
+// LoadManifestFromDisk loads and parses the Vite manifest from the local filesystem.
+// The distDir is a trusted path from our own configuration (frontend/dist).
+func LoadManifestFromDisk(distDir string) (*AssetPaths, error) {
+	path := filepath.Join(distDir, manifestPath)
+	data, err := os.ReadFile(path) //nolint:gosec // path is constructed from trusted distDir + constant manifestPath
+	if err != nil {
+		return nil, fmt.Errorf("failed to read manifest from disk: %w", err)
+	}
+	return parseManifest(data)
+}
+
+// parseManifest parses the manifest JSON and extracts the entry point assets.
+// Note: This assumes a single entry point (standard SPA configuration). Vite produces
+// exactly one entry with isEntry: true for our build configuration (index.html).
+func parseManifest(data []byte) (*AssetPaths, error) {
+	var manifest ViteManifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return nil, fmt.Errorf("failed to parse manifest JSON: %w", err)
+	}
+
+	// Find the entry point - it's marked with isEntry: true
+	// Map iteration order is non-deterministic in Go, but Vite only produces
+	// one entry with isEntry: true for a standard SPA build.
+	for _, entry := range manifest {
+		if entry.IsEntry {
+			return &AssetPaths{
+				EntryJS:  entry.File,
+				EntryCSS: entry.CSS,
+			}, nil
+		}
+	}
+
+	return nil, fmt.Errorf("no entry point found in manifest")
+}
+
+// ManifestExistsOnDisk checks if the Vite manifest exists in the given dist directory.
+func ManifestExistsOnDisk(distDir string) bool {
+	path := filepath.Join(distDir, manifestPath)
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}

--- a/internal/api/static.go
+++ b/internal/api/static.go
@@ -44,9 +44,8 @@ func (sfs *StaticFileServer) initDevMode() {
 		// Check relative to current working directory
 		distPath := filepath.Join("frontend", "dist")
 
-		// Check if the directory exists and contains index.js (main entry point)
-		indexPath := filepath.Join(distPath, "index.js")
-		if info, err := os.Stat(indexPath); err == nil && !info.IsDir() {
+		// Check if the directory contains the Vite manifest (indicates a valid build)
+		if ManifestExistsOnDisk(distPath) {
 			sfs.devMode = true
 			sfs.devModePath = distPath
 			if sfs.logger != nil {
@@ -68,6 +67,16 @@ func (sfs *StaticFileServer) initDevMode() {
 func (sfs *StaticFileServer) IsDevMode() bool {
 	sfs.initDevMode()
 	return sfs.devMode
+}
+
+// DevModePath returns the path to the dev mode dist directory.
+// Returns empty string if not in dev mode.
+func (sfs *StaticFileServer) DevModePath() string {
+	sfs.initDevMode()
+	if sfs.devMode {
+		return sfs.devModePath
+	}
+	return ""
 }
 
 // RegisterRoutes registers the static file serving routes on the Echo instance.

--- a/internal/api/templates/spa.html
+++ b/internal/api/templates/spa.html
@@ -55,9 +55,9 @@
   <link rel="apple-touch-icon" sizes="180x180" href="/ui/assets/apple-touch-icon.png">
   <link rel="shortcut icon" href="/ui/assets/favicon.ico">
   <meta name="csrf-token" content="{{.CSRFToken}}">
-  <script type="module" crossorigin src="/ui/assets/index.js"></script>
-  <link rel="modulepreload" crossorigin href="/ui/assets/vendor.js">
-  <link rel="stylesheet" crossorigin href="/ui/assets/index.css">
+  <script type="module" crossorigin src="/ui/assets/{{.EntryJS}}"></script>
+  {{range .EntryCSS}}<link rel="stylesheet" crossorigin href="/ui/assets/{{.}}">
+  {{end}}
 </head>
 <body>
   <div id="app"></div>


### PR DESCRIPTION
## Summary

- Enable proper cache busting for frontend assets using Vite manifest and content hashes
- Fixes Cloudflare caching issues where stale assets were served after deployments
- Server now reads `.vite/manifest.json` at startup to discover hashed filenames

## Changes

| File | Description |
|------|-------------|
| `frontend/vite.config.js` | Enable manifest generation + content hashes (`[name]-[hash].js`) |
| `internal/api/manifest.go` | **New** - Parse Vite's manifest to extract hashed asset paths |
| `internal/api/server.go` | Load manifest at startup, pass asset paths to SPAHandler |
| `internal/api/spa.go` | Accept asset paths, inject into template data |
| `internal/api/static.go` | Use manifest presence for dev mode detection |
| `internal/api/templates/spa.html` | Use `{{.EntryJS}}` and `{{.EntryCSS}}` template variables |

## How It Works

1. **Build time**: Vite generates hashed filenames (`index-DNY6_Znn.js`) and `.vite/manifest.json`
2. **Server startup**: Go reads the manifest to discover the actual filenames
3. **Request time**: The SPA template renders with the correct hashed paths
4. **CDN behavior**: Cloudflare caches aggressively since URLs change on each deploy

## Example Output

```html
<script type="module" src="/ui/assets/index-DNY6_Znn.js"></script>
<link rel="stylesheet" href="/ui/assets/index-tfdMIw1Z.css">
```

## Test plan

- [x] Frontend builds successfully with `npm run build`
- [x] Manifest is generated at `dist/.vite/manifest.json`
- [x] Go code compiles with `go build ./...`
- [x] Linting passes with `golangci-lint run`
- [ ] Manual test: Start server, verify assets load with hashed URLs
- [ ] Manual test: Rebuild frontend, verify new hashes are used

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented cache-busting mechanism using content hashes in asset filenames for improved browser caching and automatic cache invalidation
  * Added Vite manifest integration to dynamically resolve frontend asset entry points at runtime instead of using hardcoded paths

* **Chores**
  * Enhanced build configuration with manifest generation and filename versioning strategies

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->