### PR TITLE
fix(frontend): prevent horizontal scrollbar when sidebar is collapsed

### DIFF
--- a/frontend/src/lib/desktop/layouts/DesktopSidebar.svelte
+++ b/frontend/src/lib/desktop/layouts/DesktopSidebar.svelte
@@ -130,6 +130,7 @@ Performance Optimizations:
 
   // Toggle flyout with position calculation
   function toggleAnalyticsFlyout() {
+    hideTooltip(); // Hide tooltip when opening flyout
     if (!analyticsFlyoutOpen && analyticsButtonRef) {
       const rect = analyticsButtonRef.getBoundingClientRect();
       analyticsFlyoutPosition = {
@@ -142,6 +143,7 @@ Performance Optimizations:
   }
 
   function toggleSettingsFlyout() {
+    hideTooltip(); // Hide tooltip when opening flyout
     if (!settingsFlyoutOpen && settingsButtonRef) {
       const rect = settingsButtonRef.getBoundingClientRect();
       settingsFlyoutPosition = {


### PR DESCRIPTION
## Summary
- Fix horizontal scrollbar appearing when the sidebar is collapsed to icons-only mode
- Add `overflow-x-hidden` to the navigation container to contain tooltip overflow

## Root Cause
The tooltips in the collapsed sidebar use `absolute left-full` positioning, which extends them beyond the sidebar width. When `overflow-y-auto` is set on a container without explicit `overflow-x`, the browser can create horizontal scrollbars when content overflows.

## Test plan
- [ ] Collapse the sidebar to icons-only mode
- [ ] Verify no horizontal scrollbar appears
- [ ] Verify the sidebar stays fixed when scrolling the main content
- [ ] Verify tooltips still appear on hover (note: they may be clipped at the sidebar edge)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved horizontal overflow handling in the Navigation Menu for better visual presentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->