### PR TITLE
fix(birdweather): include Audio and BirdNET settings in test connection

### DIFF
--- a/internal/api/v2/integrations.go
+++ b/internal/api/v2/integrations.go
@@ -402,7 +402,12 @@ func (c *Controller) TestBirdWeatherConnection(ctx echo.Context) error {
 
 	// Create temporary settings for the test
 	testSettings := &conf.Settings{
+		BirdNET: conf.BirdNETConfig{
+			Latitude:  c.Settings.BirdNET.Latitude,
+			Longitude: c.Settings.BirdNET.Longitude,
+		},
 		Realtime: conf.RealtimeSettings{
+			Audio: c.Settings.Realtime.Audio, // Required for FFmpeg path (FLAC encoding)
 			Birdweather: conf.BirdweatherSettings{
 				Enabled:          request.Enabled,
 				ID:               request.ID,


### PR DESCRIPTION
## Summary

- Fixes BirdWeather test connection failing to find FFmpeg on systems with working FFmpeg
- Copies `Realtime.Audio` settings (contains validated `FfmpegPath` for FLAC encoding)
- Copies `BirdNET` settings (contains `Latitude`/`Longitude` used by the client)

## Root Cause

The `TestBirdWeatherConnection` handler created temporary settings that only copied Birdweather-specific config, missing the Audio settings where the validated FFmpeg path is stored. This caused `settings.Realtime.Audio.FfmpegPath` to be empty even though FFmpeg was correctly detected at `/usr/local/bin/ffmpeg` during application startup.

## Test plan

- [ ] Verify BirdWeather connection test works on a system with FFmpeg installed
- [ ] Confirm soundscape upload succeeds (requires FLAC encoding via FFmpeg)

Fixes #1665

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test configuration for BirdWeather integration to ensure comprehensive validation with complete coordinate and audio settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->