### PR TITLE
fix(sse): reset write deadline to prevent audio-level SSE disconnections

### DIFF
--- a/internal/api/v2/audio_level_write_deadline_test.go
+++ b/internal/api/v2/audio_level_write_deadline_test.go
@@ -90,9 +90,11 @@ func TestSendAudioLevelUpdateSetsWriteDeadline(t *testing.T) {
 		assert.False(t, mockWriter.writeCalledFirst.Load(),
 			"Write should not be called before SetWriteDeadline")
 
-		// Verify the deadline is in the future (at least a few seconds)
-		assert.True(t, mockWriter.lastDeadline.After(time.Now()),
-			"Write deadline should be set to a future time")
+		// Verify the deadline is set to approximately audioLevelWriteDeadline in the future
+		expectedDeadline := time.Now().Add(audioLevelWriteDeadline)
+		deadlineDiff := mockWriter.lastDeadline.Sub(expectedDeadline).Abs()
+		assert.Less(t, deadlineDiff, 100*time.Millisecond,
+			"Write deadline should be set to approximately %v in the future", audioLevelWriteDeadline)
 	})
 
 	t.Run("write deadline extends connection lifetime", func(t *testing.T) {


### PR DESCRIPTION
## Summary

- Fixes SSE audio-level endpoint disconnecting every ~30 seconds due to server WriteTimeout
- Adds write deadline reset before each SSE write operation
- Extracts heartbeat logic to separate testable method with write deadline handling
- Adds unit tests to prevent regression

## Root Cause

The audio-level SSE endpoint in `audio_level.go` was not calling `SetWriteDeadline` before writes, unlike the detection/soundlevel streams in `sse.go`. The server's `WriteTimeout = 30s` would terminate connections after 30 seconds from response start.

## Changes

| File | Change |
|------|--------|
| `audio_level.go` | Add `audioLevelWriteDeadline` constant, reset deadline in `sendAudioLevelUpdate`, extract `sendAudioLevelHeartbeat` method |
| `audio_level_write_deadline_test.go` | Unit tests verifying `SetWriteDeadline` is called before writes |

## Test Results

**Before fix:** 4 reconnections in 120s, max gap 1094ms, connections breaking every ~30s
**After fix:** 0 mid-stream disconnections, max gap 70ms, connection stable for full 120s

## Test plan

- [x] Unit tests pass: `go test -run WriteDeadline ./internal/api/v2/...`
- [x] Linter passes: `golangci-lint run ./internal/api/v2/...`
- [x] Manual verification with SSE analyzer tool confirmed fix

Fixes #1673

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio-level streaming reliability by ensuring write deadlines are set and refreshed before sending updates and heartbeats, preventing premature disconnections.

* **Tests**
  * Added tests validating write-deadline behavior and heartbeat delivery to ensure streaming stays connected and heartbeats are emitted as expected.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->