### PR TITLE
fix(api): allow unlocking locked detections

### DIFF
--- a/internal/api/v2/detections_test.go
+++ b/internal/api/v2/detections_test.go
@@ -839,7 +839,7 @@ func TestLockDetection(t *testing.T) {
 			requestBody: `{"locked": false}`,
 			mockSetup: func(m *mock.Mock) {
 				m.On("Get", "2").Return(datastore.Note{ID: 2, Locked: false}, nil)
-				m.On("IsNoteLocked", "2").Return(false, nil)
+				// Note: IsNoteLocked is NOT called when unlocking (req.Locked = false)
 				m.On("UnlockNote", "2").Return(nil)
 			},
 			expectedStatus: http.StatusNoContent,
@@ -853,6 +853,19 @@ func TestLockDetection(t *testing.T) {
 				m.On("IsNoteLocked", "3").Return(true, nil)
 			},
 			expectedStatus: http.StatusConflict,
+		},
+		{
+			name:        "Unlock a locked detection should succeed",
+			detectionID: "4",
+			requestBody: `{"locked": false}`,
+			mockSetup: func(m *mock.Mock) {
+				// Detection is currently locked (Locked: true)
+				m.On("Get", "4").Return(datastore.Note{ID: 4, Locked: true}, nil)
+				// Note: IsNoteLocked is NOT called when unlocking (req.Locked = false)
+				// Should call UnlockNote to unlock it
+				m.On("UnlockNote", "4").Return(nil)
+			},
+			expectedStatus: http.StatusNoContent,
 		},
 	}
 


### PR DESCRIPTION
## Summary

Fixes #1680

The `LockDetection` endpoint was checking if a detection was locked **before** parsing the request to determine whether we're locking or unlocking. This created a paradox: locked detections could never be unlocked because the lock check would reject the request.

**Root cause:** `checkAndHandleLock()` was called before parsing `req.Locked`, so when trying to unlock a locked detection, the function would return "detection is locked" error (409 Conflict).

**Fix:**
- Parse the request first to determine intent (lock vs unlock)
- Only check lock status when **locking** (not unlocking)
- This allows unlocking locked detections as expected

## Test plan

- [x] Added test case "Unlock a locked detection should succeed"
- [x] All existing LockDetection tests pass
- [x] Build verified with `task noembed`

---

Thanks to @mikeyk730 for the clear bug report with specific steps to reproduce!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling for detection lock operations with enhanced validation when locking/unlocking is requested.

* **Tests**
  * Expanded test coverage for unlock scenarios to ensure reliability of lock state management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->