### PR TITLE
fix(ui): prevent comment section from collapsing when typing

### DIFF
--- a/frontend/src/lib/desktop/components/modals/ReviewModal.svelte
+++ b/frontend/src/lib/desktop/components/modals/ReviewModal.svelte
@@ -43,9 +43,11 @@
       lockDetection = false;
       ignoreSpecies = isExcluded;
       const firstComment = safeArrayAccess(detection.comments || [], 0);
-      comment = firstComment?.entry || '';
-      // Show comment section if there's already a comment
-      showCommentSection = !!comment;
+      const firstCommentValue = firstComment?.entry || '';
+      comment = firstCommentValue;
+      // Use firstCommentValue (local variable) instead of comment ($state) to avoid
+      // creating a reactive dependency that would reset the section when typing
+      showCommentSection = !!firstCommentValue;
     }
   });
 

--- a/frontend/src/lib/desktop/components/review/ReviewCard.svelte
+++ b/frontend/src/lib/desktop/components/review/ReviewCard.svelte
@@ -46,7 +46,9 @@
           ? detection.comments[0]?.entry || ''
           : '';
       comment = firstComment;
-      showCommentSection = !!comment;
+      // Use firstComment (local variable) instead of comment ($state) to avoid
+      // creating a reactive dependency that would reset the section when typing
+      showCommentSection = !!firstComment;
       reviewErrorMessage = null;
     }
   });

--- a/frontend/src/lib/desktop/components/review/ReviewCard.test.svelte
+++ b/frontend/src/lib/desktop/components/review/ReviewCard.test.svelte
@@ -1,0 +1,37 @@
+<!--
+  Test wrapper for ReviewCard component
+  Provides mock detection data for testing
+-->
+<script lang="ts">
+  import ReviewCard from './ReviewCard.svelte';
+  import type { Detection } from '$lib/types/detection.types';
+
+  interface Props {
+    detection?: Detection;
+    onSaveComplete?: () => void;
+  }
+
+  let { detection, onSaveComplete }: Props = $props();
+
+  // Default mock detection if not provided
+  const defaultDetection: Detection = {
+    id: 1,
+    date: '2024-12-30',
+    time: '12:00:00',
+    source: 'test',
+    beginTime: '12:00:00',
+    endTime: '12:00:03',
+    speciesCode: 'test',
+    scientificName: 'Testus birdus',
+    commonName: 'Test Bird',
+    confidence: 0.95,
+    verified: 'unverified',
+    locked: false,
+    comments: [],
+  };
+
+  // Use $derived to properly track detection prop changes
+  const actualDetection = $derived(detection ?? defaultDetection);
+</script>
+
+<ReviewCard detection={actualDetection} {onSaveComplete} />

--- a/frontend/src/lib/desktop/components/review/ReviewCard.test.ts
+++ b/frontend/src/lib/desktop/components/review/ReviewCard.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import ReviewCardTestWrapper from './ReviewCard.test.svelte';
+
+// Mock the i18n module
+vi.mock('$lib/i18n', () => ({
+  t: (key: string) => key,
+}));
+
+// Mock the api module
+vi.mock('$lib/utils/api', () => ({
+  fetchWithCSRF: vi.fn(),
+}));
+
+describe('ReviewCard', () => {
+  describe('comment section', () => {
+    it('should stay open when user types in comment textarea (issue #1683)', async () => {
+      const user = userEvent.setup();
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      render(ReviewCardTestWrapper as any);
+
+      // Find and click the button to expand the comment section
+      const expandButton = screen.getByRole('button', {
+        name: /common\.review\.form\.addComment/i,
+      });
+      await user.click(expandButton);
+
+      // Wait for the textarea to appear
+      const textarea = await waitFor(() => screen.getByRole('textbox'));
+      expect(textarea).toBeInTheDocument();
+
+      // Type in the textarea
+      await user.type(textarea, 'Test comment');
+
+      // The textarea should still be visible after typing
+      // This is the bug: the comment section collapses on first keystroke
+      expect(textarea).toBeInTheDocument();
+      expect(textarea).toHaveValue('Test comment');
+
+      // The expand button should now show "Hide Comment" (indicating section is still open)
+      const hideButton = screen.getByRole('button', {
+        name: /common\.review\.form\.hideComment/i,
+      });
+      expect(hideButton).toBeInTheDocument();
+    });
+
+    it('should preserve comment when user expands section with empty detection comments', async () => {
+      const user = userEvent.setup();
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      render(ReviewCardTestWrapper as any, {
+        props: {
+          detection: {
+            id: 1,
+            date: '2024-12-30',
+            time: '12:00:00',
+            source: 'test',
+            beginTime: '12:00:00',
+            endTime: '12:00:03',
+            speciesCode: 'test',
+            scientificName: 'Testus birdus',
+            commonName: 'Test Bird',
+            confidence: 0.95,
+            verified: 'unverified',
+            locked: false,
+            comments: [], // Empty comments
+          },
+        },
+      });
+
+      // Expand the comment section
+      const expandButton = screen.getByRole('button', {
+        name: /common\.review\.form\.addComment/i,
+      });
+      await user.click(expandButton);
+
+      // Wait for textarea and type
+      const textarea = await waitFor(() => screen.getByRole('textbox'));
+      await user.type(textarea, 'My new comment');
+
+      // After typing, textarea should still have the value
+      expect(textarea).toHaveValue('My new comment');
+
+      // Section should still be expanded (textarea visible)
+      expect(screen.getByRole('textbox')).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1683

When users tried to add a comment in the Review tab, the comment section would collapse on the first keystroke, making it impossible to add comments.

**Root cause:** In Svelte 5, `$effect` creates reactive dependencies on any `$state` variables that are READ during execution. The line `showCommentSection = !!comment` was reading the `comment` $state variable, creating a dependency. When the user typed (changing `comment`), the effect would re-run, resetting `comment` back to the original value from `detection.comments` and collapsing the section.

**Fix:** Use the local `firstComment` variable instead of the `comment` $state when setting `showCommentSection`. This avoids creating the reactive dependency while preserving the same behavior.

## Changes

- **ReviewCard.svelte**: Changed `showCommentSection = !!comment` to `showCommentSection = !!firstComment`
- **ReviewModal.svelte**: Same fix applied
- **Added tests**: `ReviewCard.test.ts` with tests that verify the comment section stays open when typing

## Test plan

- [x] Added regression test that fails before fix, passes after
- [x] Verified with `npm test -- --run src/lib/desktop/components/review/ReviewCard.test.ts` - 2 tests pass
- [x] Lint/format check passes

---

Thanks to @mikeyk730 for the clear bug report with screenshots!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where the comment section in the review modal would unintentionally reset or collapse while users were typing.

* **Tests**
  * Added comprehensive test coverage for comment persistence behavior during user input and empty detection scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->