### PR TITLE
fix(audio): ensure byte-aligned indices in capture buffer reads

### DIFF
--- a/internal/myaudio/capture_buffer.go
+++ b/internal/myaudio/capture_buffer.go
@@ -504,7 +504,9 @@ func (cb *CaptureBuffer) ReadSegment(requestedStartTime time.Time, duration int)
 		}
 
 		if startOffset < 0 {
-			if cb.writeIndex == 0 || cb.writeIndex+int(startOffset.Seconds()*float64(cb.sampleRate)*float64(cb.bytesPerSample)) > cb.bufferSize {
+			// Use sample-based calculation for consistency with the main index calculation
+			startOffsetBytes := int(startOffset.Seconds()*float64(cb.sampleRate)) * cb.bytesPerSample
+			if cb.writeIndex == 0 || cb.writeIndex+startOffsetBytes > cb.bufferSize {
 				cb.lock.Unlock()
 
 				enhancedErr := errors.Newf("requested start time is outside the buffer's current timeframe").

--- a/internal/myaudio/ffmpeg_export.go
+++ b/internal/myaudio/ffmpeg_export.go
@@ -106,6 +106,10 @@ func ExportAudioWithFFmpeg(pcmData []byte, outputPath string, settings *conf.Aud
 		var sumAbsSamples int64
 		numSamples := len(pcmData) / 2
 		if numSamples > 0 {
+			// Initialize min/max with first sample to handle all-positive or all-negative audio
+			firstSample := int16(pcmData[0]) | int16(pcmData[1])<<8
+			maxSample, minSample = firstSample, firstSample
+
 			for i := 0; i < len(pcmData)-1; i += 2 {
 				sample := int16(pcmData[i]) | int16(pcmData[i+1])<<8
 				if sample > maxSample {


### PR DESCRIPTION
## Summary

Fixes audio corruption (noise in spectrograms) introduced by PR #1689's precision fix.

- **Root cause**: The precision fix calculated byte indices directly from floating-point math, which could produce odd indices for 16-bit audio
- **Symptom**: Misaligned reads caused corrupted audio appearing as noise/yellow spectrograms
- **Fix**: Calculate sample indices first, then multiply by bytesPerSample to guarantee alignment

### Before (buggy)
```go
startIndex := int(startOffset.Seconds() * float64(cb.sampleRate) * float64(cb.bytesPerSample))
// Can produce odd numbers like 4513309
```

### After (fixed)
```go
startSampleIndex := int(startOffset.Seconds() * float64(cb.sampleRate))
startIndex := startSampleIndex * cb.bytesPerSample
// Always produces multiples of bytesPerSample
```

## Debug Logging

Added optional debug logging (enable with `realtime.audio.export.debug: true`):
- Capture buffer: logs byte indices, alignment status, timing offsets
- FFmpeg export: logs PCM statistics (min/max/avg samples) before encoding
- Warns on misaligned indices or unusual audio amplitude

## Test plan

- [x] Verified misalignment warning appears with buggy code
- [x] Confirmed fix produces aligned indices
- [ ] Deploy and verify no more corrupted audio spectrograms

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected audio buffer alignment calculations to prevent potential audio corruption.
  * Added quality monitoring that alerts when audio is near-silent or has unusually high amplitude.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->