### PR TITLE
chore(deps): switch malgo dependency to upstream gen2brain/malgo

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/antonholmquist/jason v1.0.0
 	github.com/eclipse/paho.mqtt.golang v1.5.1
 	github.com/fatih/color v1.18.0
+	github.com/gen2brain/malgo v0.11.24
 	github.com/getsentry/sentry-go v0.40.0
 	github.com/go-audio/audio v1.0.0
 	github.com/go-audio/wav v1.1.0
@@ -27,7 +28,6 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/tphakala/flac v0.0.0-20241217200312-20d6d98f5ee3
 	github.com/tphakala/go-tflite v0.0.0-20241022031318-2dad4328ec9e
-	github.com/tphakala/malgo v0.11.22
 	github.com/tphakala/simd v1.0.22
 	go.uber.org/goleak v1.3.0
 	golang.org/x/crypto v0.46.0

--- a/go.sum
+++ b/go.sum
@@ -29,6 +29,8 @@ github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHk
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
+github.com/gen2brain/malgo v0.11.24 h1:hHcIJVfzWcEDHFdPl5Dl/CUSOjzOleY0zzAV8Kx+imE=
+github.com/gen2brain/malgo v0.11.24/go.mod h1:f9TtuN7DVrXMiV/yIceMeWpvanyVzJQMlBecJFVMxww=
 github.com/getsentry/sentry-go v0.40.0 h1:VTJMN9zbTvqDqPwheRVLcp0qcUcM+8eFivvGocAaSbo=
 github.com/getsentry/sentry-go v0.40.0/go.mod h1:eRXCoh3uvmjQLY6qu63BjUZnaBu5L5WhMV1RwYO8W5s=
 github.com/go-audio/audio v1.0.0 h1:zS9vebldgbQqktK4H0lUqWrG8P0NxCJVqcj7ZpNnwd4=
@@ -205,8 +207,6 @@ github.com/tphakala/go-tflite v0.0.0-20241022031318-2dad4328ec9e h1:/qmTC7Fy2iFd
 github.com/tphakala/go-tflite v0.0.0-20241022031318-2dad4328ec9e/go.mod h1:fDE48JMvNlDtdjhzShuhkEnikhmTvkom1jxuxP28atQ=
 github.com/tphakala/goth v0.0.0-20251225195455-a4b17a573e8f h1:cwFTLlrHXrfzgziEj6LFdpAiAPHrkYUfrRd081++lLc=
 github.com/tphakala/goth v0.0.0-20251225195455-a4b17a573e8f/go.mod h1:KFKsaAp/nxZJ/NY+1cVYnfpjQ+1eeptVkzxQYIPMy+o=
-github.com/tphakala/malgo v0.11.22 h1:3rSnGbCkDFrV04ERDqAlnX/XPGc9IHcN6e71xNA0TyE=
-github.com/tphakala/malgo v0.11.22/go.mod h1:PeoBfxQgha3ifttIUWxd0/FZeD4vot3G5njVldpZyqc=
 github.com/tphakala/simd v1.0.22 h1:3wHL91t4yvhCB0ycyTznvucTHax+QGpYkvOhqfraTYw=
 github.com/tphakala/simd v1.0.22/go.mod h1:8xsPUbOTnNI4WUdPlXVlWXt85Y8RCm3xqGAo8PLxYyA=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=

--- a/internal/myaudio/audio_conversion_alignment_test.go
+++ b/internal/myaudio/audio_conversion_alignment_test.go
@@ -3,7 +3,7 @@ package myaudio
 import (
 	"testing"
 
-	"github.com/tphakala/malgo"
+	"github.com/gen2brain/malgo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/myaudio/capture.go
+++ b/internal/myaudio/capture.go
@@ -15,7 +15,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/logger"
-	"github.com/tphakala/malgo"
+	"github.com/gen2brain/malgo"
 )
 
 // AudioDataCallback is a function that can be registered to receive audio data


### PR DESCRIPTION
## Summary
- Repoint malgo dependency from `github.com/tphakala/malgo` fork back to the original upstream `github.com/gen2brain/malgo`
- Update to latest version v0.11.24

## Test plan
- [x] Verified myaudio package compiles successfully with upstream malgo
- [ ] Full build verification on CI