### PR TITLE
fix(notification): prevent duplicate Telegram/Shoutrrr notifications on timeout

### DIFF
--- a/internal/notification/push_dispatcher.go
+++ b/internal/notification/push_dispatcher.go
@@ -509,13 +509,14 @@ func isTimeoutError(err error) bool {
 		return true
 	}
 
-	// Check for timeout-related error messages from Shoutrrr and HTTP layer
+	// Check for timeout-related error messages from Shoutrrr and HTTP layer.
+	// Note: "timeout" matches "Gateway Timeout", "gateway time-out" catches hyphenated variant.
 	errStr := strings.ToLower(err.Error())
 	timeoutPatterns := []string{
 		"timed out",         // Shoutrrr router timeout: "failed to send: timed out"
-		"timeout",           // Generic timeout errors
+		"timeout",           // Generic timeout errors, also matches "Gateway Timeout"
 		"status: 504",       // HTTP 504 in jsonclient errors: "got unexpected HTTP status: 504"
-		"gateway time",      // HTTP 504 Gateway Time-out
+		"gateway time-out",  // HTTP 504 Gateway Time-out (hyphenated variant)
 		"deadline exceeded", // Context deadline as string
 	}
 

--- a/internal/notification/push_shoutrrr_test.go
+++ b/internal/notification/push_shoutrrr_test.go
@@ -22,7 +22,6 @@ const (
 	testMaxRetries     = 3
 	testRetryDelay     = 10 * time.Millisecond
 	testDefaultTimeout = 200 * time.Millisecond
-	testSettleTime     = 100 * time.Millisecond // Time to wait for async operations
 )
 
 // MockTelegramServer simulates Telegram API for testing notification delivery.
@@ -171,9 +170,6 @@ func runRetryTest(t *testing.T, tc retryTestCase) {
 	ep := &d.providers[0]
 	d.retryLoop(ctx, notif, ep)
 
-	// Wait for async operations to settle
-	time.Sleep(testSettleTime)
-
 	assert.Equal(t, tc.expectedCount, int(sendAttempts.Load()), tc.description)
 }
 
@@ -288,6 +284,7 @@ func TestIsTimeoutError(t *testing.T) {
 		// False positive prevention - should NOT match as timeout
 		{"port_number_5040", fmt.Errorf("dial tcp 127.0.0.1:5040: connect: connection refused"), false},
 		{"error_code_504x", fmt.Errorf("error code 5041: invalid request"), false},
+		{"gateway_timestamp", fmt.Errorf("gateway timestamp mismatch: expected 2024-01-01"), false},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- Add `isTimeoutError()` function to detect timeout-related errors that should not trigger retries
- Timeout errors indicate the message may have been delivered but the response was not received - retrying causes duplicate notifications
- Add comprehensive tests for timeout detection and retry behavior

## Root Cause

When Shoutrrr sends a notification to Telegram, the HTTP POST may succeed (message delivered) but the response could timeout. The retry logic was treating all errors equally, causing 4 notifications (1 initial + 3 retries) instead of 1.

## Changes

### `push_dispatcher.go`
- New `isTimeoutError()` function detecting:
  - `context.DeadlineExceeded` and `context.Canceled`
  - Shoutrrr router timeout (`"failed to send: timed out"`)
  - HTTP 504 Gateway Timeout (`"status: 504"`)
  - Generic timeout/deadline exceeded strings
- Modified `shouldRetry()` to skip retries for timeout errors

### `push_shoutrrr_test.go` (new)
- `TestRetryLoop_TimeoutErrors` - verifies timeout errors are NOT retried
- `TestRetryLoop_RetryableErrors` - verifies real failures ARE retried
- `TestIsTimeoutError` - unit tests for all timeout patterns including false-positive prevention
- `MockTelegramServer` - thread-safe mock for integration testing
- `TestMockTelegramServer_ThreadSafety` - validates mock under concurrent load

## Test plan

- [x] All tests pass with `go test -race ./internal/notification/...`
- [x] Timeout errors (context.DeadlineExceeded, HTTP 504) result in single send attempt
- [x] Retryable errors (connection refused, DNS failure) are retried up to 3 times
- [x] False positives prevented (port 5040 not detected as 504 timeout)
- [x] `golangci-lint run -v` passes

Fixes #1706

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved notification delivery system to better handle timeout scenarios and prevent unnecessary retry attempts, ensuring more efficient notification processing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->