### PR TITLE
fix(dashboard): fetch more detections when pagination limit increases

### DIFF
--- a/frontend/src/lib/desktop/features/dashboard/pages/DashboardPage.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/pages/DashboardPage.svelte
@@ -729,8 +729,14 @@ Performance Optimizations:
   // Handle detection limit change from DetectionCardGrid
   function handleDetectionLimitChange(newLimit: number) {
     detectionLimit = newLimit;
-    // Trim existing detections to new limit
-    recentDetections = recentDetections.slice(0, newLimit);
+
+    if (newLimit > recentDetections.length) {
+      // Need more data than currently loaded - fetch from API
+      fetchRecentDetections();
+    } else {
+      // Just trim existing data to new limit
+      recentDetections = recentDetections.slice(0, newLimit);
+    }
   }
 
   // Derived state to check if we're viewing today's data


### PR DESCRIPTION
## Summary
- Fixes issue where changing detection limit from a smaller value to a larger one (e.g., 12 → 24) required a page reload to take effect
- The root cause was that `handleDetectionLimitChange` only trimmed the array with `.slice()`, which does nothing when the array is already smaller than the new limit

## Changes
- Modified `handleDetectionLimitChange` in `DashboardPage.svelte` to check if the new limit exceeds current data length
- If more data is needed, triggers `fetchRecentDetections()` to load additional items from the API
- If less data is needed, trims the existing array as before

## Test plan
- [ ] Change detection limit from 6 → 12 → verify 12 items appear without reload
- [ ] Change detection limit from 12 → 24 → verify 24 items appear without reload
- [ ] Change detection limit from 24 → 6 → verify only 6 items shown (trim behavior preserved)
- [ ] Verify SSE real-time updates still work correctly after limit change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection limit handling on the dashboard to fetch fresh data when needed, ensuring all available detections are displayed when increasing the limit.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->