### PR TITLE
fix(spectrogram): improve Sox timeout handling and fallback logging

### DIFF
--- a/internal/spectrogram/generator.go
+++ b/internal/spectrogram/generator.go
@@ -25,7 +25,8 @@ import (
 
 const (
 	// defaultGenerationTimeout is the default timeout for spectrogram generation
-	defaultGenerationTimeout = 60 * time.Second
+	// Increased to 90s to accommodate slow storage (e.g., SD cards) under I/O pressure
+	defaultGenerationTimeout = 90 * time.Second
 
 	// ffmpegFallbackTimeout is the timeout for FFmpeg fallback when Sox fails.
 	// This is independent of the Sox timeout to ensure FFmpeg has adequate time
@@ -194,9 +195,10 @@ func (g *Generator) GenerateFromFile(ctx context.Context, audioPath, outputPath 
 
 	// Try Sox first (faster, direct processing)
 	if err := g.generateWithSoxFile(soxCtx, audioPath, outputPath, width, raw); err != nil {
-		g.logger.Debug("Sox generation failed, trying FFmpeg fallback",
+		g.logger.Warn("Sox spectrogram generation failed, falling back to FFmpeg (style settings may not be applied)",
 			logger.String("audio_path", audioPath),
-			logger.Error(err))
+			logger.Error(err),
+			logger.Int64("sox_duration_ms", time.Since(start).Milliseconds()))
 
 		// Create FRESH context for FFmpeg fallback with full timeout.
 		// This ensures FFmpeg has adequate time even if Sox consumed most of the


### PR DESCRIPTION
## Summary
- Increase Sox spectrogram generation timeout from 60s to 90s to accommodate slow storage (e.g., SD cards) under I/O pressure
- Change FFmpeg fallback log level from DEBUG to WARN to make it visible when style settings may not be applied
- Add `sox_duration_ms` field to fallback log message for diagnosing timeout issues

## Background
On systems with slow storage (SD cards), concurrent spectrogram generation can saturate I/O bandwidth, causing Sox to hit the 60-second timeout. When this happens, the FFmpeg fallback is triggered, but it doesn't apply user-configured spectrogram style settings, resulting in incorrect spectrogram appearance.

This change:
1. Gives Sox more time to complete on slow storage
2. Makes the fallback event visible at INFO/WARN log level so users can identify when it occurs

## Test plan
- [ ] Deploy on a system with slow storage
- [ ] Generate multiple spectrograms concurrently
- [ ] Verify WARN log appears when FFmpeg fallback is triggered
- [ ] Verify Sox has more time to complete before timeout

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Extended spectrogram generation timeout from 60 to 90 seconds to improve reliability when storage I/O is under heavy load.
  * Enhanced error logging to include elapsed time metrics when fallback audio processing mechanisms are triggered.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->