### PR TITLE
feat(spectrogram): add dedicated log file support

### DIFF
--- a/internal/logger/config.go
+++ b/internal/logger/config.go
@@ -58,6 +58,7 @@ const (
 	DefaultBirdweatherLogPath   = "logs/birdweather.log"
 	DefaultWeatherLogPath       = "logs/weather.log"
 	DefaultImageproviderLogPath = "logs/imageprovider.log"
+	DefaultSpectrogramLogPath   = "logs/spectrogram.log"
 	DefaultMaxSize              = 100   // MB before rotation
 	DefaultMaxAge               = 30    // days to keep rotated files
 	DefaultMaxRotatedFiles      = 10    // max number of rotated files
@@ -143,4 +144,8 @@ func applyConfigDefaults(cfg *LoggingConfig) {
 	ensureModuleOutput(cfg, "birdweather", DefaultBirdweatherLogPath)
 	ensureModuleOutput(cfg, "weather", DefaultWeatherLogPath)
 	ensureModuleOutput(cfg, "imageprovider", DefaultImageproviderLogPath)
+
+	// Spectrogram generation logs
+	ensureModuleOutput(cfg, "spectrogram", DefaultSpectrogramLogPath)
+	ensureModuleOutput(cfg, "spectrogram.prerenderer", DefaultSpectrogramLogPath) // Same file
 }

--- a/internal/spectrogram/generator.go
+++ b/internal/spectrogram/generator.go
@@ -126,10 +126,10 @@ type Generator struct {
 }
 
 // NewGenerator creates a new generator instance.
-// If logger is nil, logger.Global() is used to prevent nil pointer panics.
+// If logger is nil, GetLogger() is used to prevent nil pointer panics.
 func NewGenerator(settings *conf.Settings, sfs *securefs.SecureFS, log logger.Logger) *Generator {
 	if log == nil {
-		log = logger.Global().Module("spectrogram")
+		log = GetLogger()
 	}
 	return &Generator{
 		settings: settings,
@@ -547,19 +547,19 @@ func (g *Generator) generateWithSoxPCM(ctx context.Context, pcmData []byte, outp
 	// Build Sox arguments for PCM stdin
 	// PCM format parameters use constants from conf package for consistency
 	args := []string{
-		"-t", "raw",                             // Input type: raw/headerless PCM
-		"-r", strconv.Itoa(conf.SampleRate),     // Sample rate: 48kHz
-		"-e", "signed",                          // Encoding: signed integer
-		"-b", strconv.Itoa(conf.BitDepth),       // Bit depth: 16-bit
-		"-c", strconv.Itoa(conf.NumChannels),    // Channels: mono
-		"-",                                     // Read from stdin
-		"-n",                                    // No audio output (null output)
-		"rate", soxResampleRate,                 // Resample to 24kHz for spectrogram
-		"spectrogram",                           // Effect: spectrogram
-		"-x", strconv.Itoa(width),               // Width in pixels
+		"-t", "raw", // Input type: raw/headerless PCM
+		"-r", strconv.Itoa(conf.SampleRate), // Sample rate: 48kHz
+		"-e", "signed", // Encoding: signed integer
+		"-b", strconv.Itoa(conf.BitDepth), // Bit depth: 16-bit
+		"-c", strconv.Itoa(conf.NumChannels), // Channels: mono
+		"-",                     // Read from stdin
+		"-n",                    // No audio output (null output)
+		"rate", soxResampleRate, // Resample to 24kHz for spectrogram
+		"spectrogram",             // Effect: spectrogram
+		"-x", strconv.Itoa(width), // Width in pixels
 		"-y", strconv.Itoa(width / heightRatio), // Height in pixels (half of width)
-		"-z", g.getDynamicRange(),               // Dynamic range in dB
-		"-o", outputPath,                        // Output PNG file
+		"-z", g.getDynamicRange(), // Dynamic range in dB
+		"-o", outputPath, // Output PNG file
 	}
 
 	// Add raw flag if requested (no axes/legend)

--- a/internal/spectrogram/logger.go
+++ b/internal/spectrogram/logger.go
@@ -1,0 +1,17 @@
+// Package spectrogram provides logging utilities for spectrogram generation.
+package spectrogram
+
+import (
+	"github.com/tphakala/birdnet-go/internal/logger"
+)
+
+// GetLogger returns the spectrogram package logger scoped to the spectrogram module.
+// Fetched dynamically to ensure it uses the current centralized logger.
+func GetLogger() logger.Logger {
+	return logger.Global().Module("spectrogram")
+}
+
+// GetPreRendererLogger returns the logger for the pre-renderer subsystem.
+func GetPreRendererLogger() logger.Logger {
+	return logger.Global().Module("spectrogram.prerenderer")
+}

--- a/internal/spectrogram/prerenderer.go
+++ b/internal/spectrogram/prerenderer.go
@@ -83,10 +83,10 @@ type Stats struct {
 
 // NewPreRenderer creates a new pre-renderer instance.
 // The parentCtx is used for lifecycle management and cancellation.
-// If logger is nil, logger.Global() is used to prevent nil pointer panics.
+// If logger is nil, GetPreRendererLogger() is used to prevent nil pointer panics.
 func NewPreRenderer(parentCtx context.Context, settings *conf.Settings, sfs *securefs.SecureFS, log logger.Logger) *PreRenderer {
 	if log == nil {
-		log = logger.Global().Module("spectrogram.prerenderer")
+		log = GetPreRendererLogger()
 	}
 	ctx, cancel := context.WithCancel(parentCtx)
 
@@ -330,8 +330,8 @@ func (pr *PreRenderer) Submit(jobDTO interface {
 		// This provides visibility into the pre-rendering pipeline without debug mode
 		pr.logger.Info("Spectrogram generation queued",
 			logger.Any("note_id", job.NoteID),
-			logger.Int("queue_depth", currentQueueDepth),     // Current backlog (0-3 for default queue size)
-			logger.Int64("total_queued", totalQueued),        // Lifetime counter
+			logger.Int("queue_depth", currentQueueDepth), // Current backlog (0-3 for default queue size)
+			logger.Int64("total_queued", totalQueued),    // Lifetime counter
 			logger.String("operation", "spectrogram_queued"))
 		return nil
 	default:


### PR DESCRIPTION
## Summary
- Add ability to redirect spectrogram-related log messages to a dedicated log file (`logs/spectrogram.log`)
- Follows the established pattern used by weather, birdweather, and other packages

## Changes
- Add `DefaultSpectrogramLogPath` constant to `internal/logger/config.go`
- Register `spectrogram` and `spectrogram.prerenderer` modules in `applyConfigDefaults()`
- Create `internal/spectrogram/logger.go` with `GetLogger()` and `GetPreRendererLogger()` functions
- Update `NewGenerator()` and `NewPreRenderer()` to use package-level logger functions

## Configuration
After this change, spectrogram logging can be configured in `config.yaml`:

```yaml
logging:
  modules:
    spectrogram:
      enabled: true
      file_path: logs/spectrogram.log
      level: debug
      console_also: false
```

The default is `enabled: true` via existing `setModuleLogDefaults("spectrogram", true)` in `defaults.go`.

## Test plan
- [x] Run `go test ./internal/spectrogram/... -v` - all tests pass
- [x] Run `golangci-lint run -v ./internal/spectrogram/... ./internal/logger/...` - no issues
- [ ] Manual verification: start application, trigger spectrogram generation, verify logs appear in `logs/spectrogram.log`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal logging configuration and initialization for spectrogram modules with centralized logger setup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->