### PR TITLE
fix(mqtt): correct sound level template and truncate long device names

### DIFF
--- a/internal/mqtt/discovery.go
+++ b/internal/mqtt/discovery.go
@@ -67,10 +67,11 @@ func shortenDisplayName(name string) string {
 	}
 
 	// For RTSP-style IDs (rtsp_xxxxx...), keep the prefix and truncate
-	if strings.HasPrefix(name, "rtsp_") && len(name) > 13 {
-		// Keep "rtsp_" + first 8 chars of UUID = 13 chars
+	const rtspPrefix = "rtsp_"
+	const rtspShortenedLength = len(rtspPrefix) + 8 // "rtsp_" + 8 chars of UUID
+	if strings.HasPrefix(name, rtspPrefix) && len(name) > rtspShortenedLength {
 		// Example: "rtsp_a1b2c3d4-e5f6..." -> "rtsp_a1b2c3d4"
-		return name[:13]
+		return name[:rtspShortenedLength]
 	}
 
 	// For URLs or other long strings, truncate intelligently

--- a/internal/mqtt/discovery_test.go
+++ b/internal/mqtt/discovery_test.go
@@ -559,16 +559,12 @@ func TestSoundLevelValueTemplate_UsesCorrectBandKeyFormat(t *testing.T) {
 // of the source ID to keep sensor names manageable in Home Assistant.
 // =============================================================================
 
-// maxDeviceDisplayNameLength is the maximum length for the display name portion
-// of a device name. This keeps Home Assistant entity names manageable.
-const maxDeviceDisplayNameLength = 32
-
 // TestDeviceNaming_ShortDisplayNameWhenIDIsLong verifies that device names
 // remain short even when source IDs are long (e.g., RTSP streams).
 //
 // When DisplayName is empty and source.ID is long, the discovery should:
 // 1. Use a truncated/friendly version of the ID
-// 2. Keep the total display name portion under maxDeviceDisplayNameLength
+// 2. Keep the total display name portion under maxDisplayNameLength
 func TestDeviceNaming_ShortDisplayNameWhenIDIsLong(t *testing.T) {
 	t.Parallel()
 
@@ -634,14 +630,14 @@ func TestDeviceNaming_ShortDisplayNameWhenIDIsLong(t *testing.T) {
 
 	displayNamePortion := deviceName[len(prefix):]
 
-	assert.LessOrEqual(t, len(displayNamePortion), maxDeviceDisplayNameLength,
+	assert.LessOrEqual(t, len(displayNamePortion), maxDisplayNameLength,
 		"DEVICE NAMING BUG: Display name portion is too long (%d chars). "+
 			"When DisplayName is empty, should use a shortened version of source.ID. "+
 			"Got device name: %q, display portion: %q",
 		len(displayNamePortion), deviceName, displayNamePortion)
 
 	// Also verify the full device name doesn't exceed a reasonable total length
-	maxTotalDeviceNameLength := len(config.DeviceName) + 1 + maxDeviceDisplayNameLength
+	maxTotalDeviceNameLength := len(config.DeviceName) + 1 + maxDisplayNameLength
 	assert.LessOrEqual(t, len(deviceName), maxTotalDeviceNameLength,
 		"DEVICE NAMING BUG: Total device name is too long (%d chars). "+
 			"Maximum should be %d. Got: %q",


### PR DESCRIPTION
## Summary

Fixes two bugs reported in Discussion #1759 from PR #1749 (Home Assistant MQTT auto-discovery):

1. **Sound level not updating in Home Assistant**
   - The ValueTemplate used `'1000'` but `formatBandKey()` produces `'1.0_kHz'` for the 1000 Hz band
   - Fixed template to use the correct band key format

2. **Device names becoming excessively long**
   - RTSP sources with UUID-based IDs created unwieldy device names in Home Assistant
   - Added `shortenDisplayName()` helper to truncate long IDs to 32 characters
   - Truncates intelligently at natural boundaries (underscore, hyphen, slash)
   - Special handling for RTSP-style IDs (keeps `rtsp_` prefix + first 8 UUID chars)

## Changes

- `internal/mqtt/discovery.go`:
  - Added `maxDisplayNameLength = 32` constant
  - Added `shortenDisplayName()` function for intelligent truncation
  - Updated `publishSourceDiscovery()` to use shortened names when DisplayName is empty
  - Fixed sound level value template from `'1000'` to `'1.0_kHz'`

- `internal/mqtt/discovery_test.go`:
  - Added `TestSoundLevelValueTemplate_UsesCorrectBandKeyFormat`
  - Added `TestDeviceNaming_ShortDisplayNameWhenIDIsLong`
  - Added `TestDeviceNaming_PreservesShortDisplayName`
  - Added `TestShortenDisplayName` unit tests for all code paths

## Test plan

- [x] All new tests pass
- [x] All existing mqtt tests pass
- [x] Race detector passes
- [x] Linter passes
- [ ] Manual verification with Home Assistant (user testing)

Relates to: #1759, #1749

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Home Assistant device naming by automatically shortening overly long display names while intelligently preserving special prefixes.
  * Corrected Sound Level sensor band key format for proper data extraction and compatibility.

* **Tests**
  * Added comprehensive test coverage for device naming logic and sensor template validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->