### PR TITLE
fix(processor): prevent 'note not found in database' notifications (#1385)

### DIFF
--- a/internal/analysis/processor/actions.go
+++ b/internal/analysis/processor/actions.go
@@ -1401,8 +1401,9 @@ func (a *SSEAction) findNoteInDatabase() (*datastore.Note, error) {
 		// Include SourceNode to prevent matching wrong detection in high-activity periods
 		// Only compare SourceNode if both have values (handles legacy data)
 		sourceMatches := a.Note.SourceNode == "" || note.SourceNode == "" || note.SourceNode == a.Note.SourceNode
+		// Truncate to millisecond precision for comparison to handle potential database precision loss
 		if note.ScientificName == a.Note.ScientificName &&
-			note.BeginTime.Equal(a.Note.BeginTime) &&
+			note.BeginTime.Truncate(time.Millisecond).Equal(a.Note.BeginTime.Truncate(time.Millisecond)) &&
 			sourceMatches {
 			return note, nil
 		}


### PR DESCRIPTION
## Summary

- Skip SSE broadcast gracefully when database ID lookup times out instead of broadcasting with ID=0 (which breaks frontend API calls)
- Change timeout error to simple error to avoid triggering user-visible notifications
- Add SourceNode to database lookup matching to prevent false matches during high-activity periods
- Increase DatabaseSearchLimit from 10 to 50 for dawn chorus scenarios

Fixes #1385

## Changes

| Change | Rationale |
|--------|-----------|
| Skip broadcast on timeout | Frontend breaks with ID=0 (`/api/v2/spectrogram/0` fails) |
| Warn log instead of Debug | Observability for skipped broadcasts |
| `fmt.Errorf` instead of `errors.Newf` | Prevents notification system from showing user alerts |
| DatabaseSearchLimit 10→50 | Handles high-activity periods without missing notes |
| SourceNode robust matching | Handles legacy data with empty values |

## Test Plan

- [x] All existing tests pass
- [x] golangci-lint passes (0 issues)
- [ ] Manual test: Verify no "note not found in database" notifications appear
- [ ] Manual test: Verify SSE broadcasts work when database is responsive
- [ ] Manual test: Verify detection appears on page refresh if SSE broadcast was skipped