### PR TITLE
fix(i18n): prevent race condition showing translation keys on first load

### DIFF
--- a/frontend/src/lib/i18n/store.svelte.ts
+++ b/frontend/src/lib/i18n/store.svelte.ts
@@ -21,10 +21,11 @@ const CRITICAL_FALLBACKS: Record<string, string> = {
   'common.error': 'Error',
   'common.retry': 'Retry',
   'common.retrying': 'Retrying',
-  'error.server.title': 'Server Error',
-  'error.server.description': 'Unable to connect to the server. Please try again.',
+  'error.server.title': 'Server Connection Error',
+  'error.server.description':
+    'Unable to connect to the server. Please check your connection and try again.',
   'error.generic.componentLoadError': 'Component Load Error',
-  'error.generic.failedToLoadComponent': 'Failed to load the requested component.',
+  'error.generic.failedToLoadComponent': 'Failed to load the requested component',
 };
 
 // Initialize locale from localStorage, browser preferences, or use default


### PR DESCRIPTION
## Summary

- Fix race condition where translation keys (e.g., `common.loading`) were shown instead of translated text on first page load without localStorage cache
- Add `CRITICAL_FALLBACKS` map with essential UI strings available immediately before async fetch completes
- Add `waitForTranslations()` Promise and `translationsReady()` function for components that need to wait
- Add comprehensive tests for race condition handling

## Root Cause

On first visit without localStorage cache:
1. App imports i18n module, which starts async `fetch()` for translations
2. Before fetch completes, components render and call `t()`
3. `t()` returned raw keys when `messages` was empty

## Test plan

- [x] All 28 i18n tests pass
- [x] All linters pass (`npm run check:all`)
- [x] Code reviewed for race conditions, resource leaks, security issues
- [ ] Manual test: Clear localStorage, refresh page, verify loading screen shows "Loading..." not "common.loading"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved startup experience with essential fallback translations to avoid raw keys during initial load.
  * New translation readiness detection and a way to wait for initial translations to finish, making locale switching safer.

* **Tests**
  * Added comprehensive tests covering translation loading, race conditions, fallback correctness, state checks, and locale switching behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->