### PR TITLE
chore(deps): update go-tflite to v0.2.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
 	github.com/tphakala/flac v0.0.0-20241217200312-20d6d98f5ee3
-	github.com/tphakala/go-tflite v0.1.1
+	github.com/tphakala/go-tflite v0.2.0
 	github.com/tphakala/simd v1.0.22
 	go.uber.org/goleak v1.3.0
 	golang.org/x/crypto v0.47.0

--- a/go.sum
+++ b/go.sum
@@ -205,8 +205,8 @@ github.com/tklauser/numcpus v0.11.0 h1:nSTwhKH5e1dMNsCdVBukSZrURJRoHbSEQjdEbY+9R
 github.com/tklauser/numcpus v0.11.0/go.mod h1:z+LwcLq54uWZTX0u/bGobaV34u6V7KNlTZejzM6/3MQ=
 github.com/tphakala/flac v0.0.0-20241217200312-20d6d98f5ee3 h1:hD7Uw+Js4mZXlfLYnMoxRnHSczcq8JZWvb1nJn9ZZLY=
 github.com/tphakala/flac v0.0.0-20241217200312-20d6d98f5ee3/go.mod h1:YEoLmuRHr0LG0zHpCWVkdGi4EqeiULta/nNCFntKMuc=
-github.com/tphakala/go-tflite v0.1.1 h1:HhP/ifkCNvJFJj+9zPD+3d2jvr2DMuX9nFoIw/XF5uE=
-github.com/tphakala/go-tflite v0.1.1/go.mod h1:fDE48JMvNlDtdjhzShuhkEnikhmTvkom1jxuxP28atQ=
+github.com/tphakala/go-tflite v0.2.0 h1:1CThXHjMTXbttqSsjMS/L0Mw9hzJO2Plp/0264zFWJ8=
+github.com/tphakala/go-tflite v0.2.0/go.mod h1:CswKd8GY0zI1dD0hHNHZoLrN4rUrwTQBwWZ1cM09hHQ=
 github.com/tphakala/goth v0.0.0-20251225195455-a4b17a573e8f h1:cwFTLlrHXrfzgziEj6LFdpAiAPHrkYUfrRd081++lLc=
 github.com/tphakala/goth v0.0.0-20251225195455-a4b17a573e8f/go.mod h1:KFKsaAp/nxZJ/NY+1cVYnfpjQ+1eeptVkzxQYIPMy+o=
 github.com/tphakala/simd v1.0.22 h1:3wHL91t4yvhCB0ycyTznvucTHax+QGpYkvOhqfraTYw=

--- a/internal/birdnet/birdnet.go
+++ b/internal/birdnet/birdnet.go
@@ -626,13 +626,10 @@ func (bn *BirdNET) getCachedSpeciesScores(targetDate time.Time) (map[string]floa
 }
 
 // Delete releases resources used by the TensorFlow Lite interpreters.
+// Note: With go-tflite v0.2.0+, interpreter cleanup is handled automatically by GC.
 func (bn *BirdNET) Delete() {
-	if bn.AnalysisInterpreter != nil {
-		bn.AnalysisInterpreter.Delete()
-	}
-	if bn.RangeInterpreter != nil {
-		bn.RangeInterpreter.Delete()
-	}
+	bn.AnalysisInterpreter = nil
+	bn.RangeInterpreter = nil
 	bn.clearSpeciesCache()
 }
 
@@ -912,11 +909,7 @@ func (bn *BirdNET) ReloadModel() error {
 
 	// Initialize new meta model
 	if err := bn.initializeMetaModel(); err != nil {
-		// Clean up the newly created analysis interpreter if meta model fails
-		if bn.AnalysisInterpreter != nil {
-			bn.AnalysisInterpreter.Delete()
-		}
-		// Restore the old interpreters
+		// Restore the old interpreters (new ones will be GC'd)
 		bn.AnalysisInterpreter = oldAnalysisInterpreter
 		bn.RangeInterpreter = oldRangeInterpreter
 		return fmt.Errorf("\033[31m❌ failed to reload meta model: %w\033[0m", err)
@@ -925,14 +918,7 @@ func (bn *BirdNET) ReloadModel() error {
 
 	// Reload labels
 	if err := bn.loadLabels(); err != nil {
-		// Clean up the newly created interpreters if label loading fails
-		if bn.AnalysisInterpreter != nil {
-			bn.AnalysisInterpreter.Delete()
-		}
-		if bn.RangeInterpreter != nil {
-			bn.RangeInterpreter.Delete()
-		}
-		// Restore the old interpreters
+		// Restore the old interpreters (new ones will be GC'd)
 		bn.AnalysisInterpreter = oldAnalysisInterpreter
 		bn.RangeInterpreter = oldRangeInterpreter
 		return fmt.Errorf("\033[31m❌ failed to reload labels: %w\033[0m", err)
@@ -941,26 +927,13 @@ func (bn *BirdNET) ReloadModel() error {
 
 	// Validate that the model and labels match
 	if err := bn.validateModelAndLabels(); err != nil {
-		// Clean up the newly created interpreters if validation fails
-		if bn.AnalysisInterpreter != nil {
-			bn.AnalysisInterpreter.Delete()
-		}
-		if bn.RangeInterpreter != nil {
-			bn.RangeInterpreter.Delete()
-		}
-		// Restore the old interpreters
+		// Restore the old interpreters (new ones will be GC'd)
 		bn.AnalysisInterpreter = oldAnalysisInterpreter
 		bn.RangeInterpreter = oldRangeInterpreter
 		return fmt.Errorf("\033[31m❌ model validation failed: %w\033[0m", err)
 	}
 
-	// Clean up old interpreters after successful reload
-	if oldAnalysisInterpreter != nil {
-		oldAnalysisInterpreter.Delete()
-	}
-	if oldRangeInterpreter != nil {
-		oldRangeInterpreter.Delete()
-	}
+	// Old interpreters will be cleaned up by GC now that they're unreferenced
 
 	// Clear species cache as model/labels have changed
 	bn.clearSpeciesCache()


### PR DESCRIPTION
## Summary
- Update go-tflite to v0.2.0 which uses automatic GC-based cleanup
- Remove manual `Delete()` calls on interpreters (no longer needed)
- Fixes build failure from v0.1.1 which incorrectly required `-lXNNPACK`

### Changes
| File | Change |
|------|--------|
| go.mod/go.sum | Bump go-tflite v0.1.1 → v0.2.0 |
| birdnet.go | Remove explicit `Delete()` calls, rely on GC cleanup |

### Reference
- [go-tflite PR #19](https://github.com/tphakala/go-tflite/pull/19) - GC-based cleanup

## Test plan
- [x] Build compiles successfully
- [ ] CI passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated go-tflite dependency to v0.2.0

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->