### PR TITLE
refactor(frontend): centralize proxy-aware navigation in navigation store

### DIFF
--- a/frontend/src/lib/desktop/components/ui/NotificationBell.svelte
+++ b/frontend/src/lib/desktop/components/ui/NotificationBell.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { sseNotifications } from '$lib/stores/sseNotifications';
+  import { navigation } from '$lib/stores/navigation.svelte';
   import { cn } from '$lib/utils/cn';
   import { api, ApiError } from '$lib/utils/api';
   import { toastActions } from '$lib/stores/toast';
@@ -27,7 +28,7 @@
   const NOTIFICATION_VOLUME = 0.5;
   const NOTIFICATION_SOUND_PATH = '/ui/assets/sounds/notification.mp3';
   const NOTIFICATION_ICON_PATH = '/ui/assets/favicon-32x32.png';
-  const NOTIFICATIONS_PAGE_URL = '/notifications';
+  const NOTIFICATIONS_PAGE_URL = '/ui/notifications';
   const SOUND_ENABLED_KEY = 'notificationSound';
   const NOTIFICATIONS_LIMIT = 20;
   const BADGE_MAX_COUNT = 99;
@@ -244,7 +245,7 @@
     if (onNavigateToNotifications) {
       onNavigateToNotifications();
     } else {
-      globalThis.window.location.href = NOTIFICATIONS_PAGE_URL;
+      navigation.navigate(NOTIFICATIONS_PAGE_URL);
     }
   }
 

--- a/frontend/src/lib/desktop/features/dashboard/components/DetectionCardGrid.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/components/DetectionCardGrid.svelte
@@ -32,7 +32,7 @@
   import { t } from '$lib/i18n';
   import { loggers } from '$lib/utils/logger';
   import { cn } from '$lib/utils/cn';
-  import { buildAppUrl } from '$lib/utils/urlHelpers';
+  import { navigation } from '$lib/stores/navigation.svelte';
 
   const logger = loggers.ui;
 
@@ -176,7 +176,7 @@
 
   // Action handlers
   function handleReview(detection: Detection) {
-    window.location.href = buildAppUrl(`/ui/detections/${detection.id}?tab=review`);
+    navigation.navigate(`/ui/detections/${detection.id}?tab=review`);
   }
 
   function handleToggleSpecies(detection: Detection) {

--- a/frontend/src/lib/desktop/features/dashboard/pages/DashboardPage.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/pages/DashboardPage.svelte
@@ -59,7 +59,7 @@ Performance Optimizations:
   import { getLogger } from '$lib/utils/logger';
   import { safeArrayAccess, isPlainObject } from '$lib/utils/security';
   import { api } from '$lib/utils/api';
-  import { buildAppUrl } from '$lib/utils/urlHelpers';
+  import { navigation } from '$lib/stores/navigation.svelte';
 
   const logger = getLogger('app');
 
@@ -1121,7 +1121,7 @@ Performance Optimizations:
   // eslint-disable-next-line no-unused-vars
   function _handleDetectionClick(detection: Detection) {
     // Navigate to detection detail view
-    window.location.href = buildAppUrl(`/ui/detections/${detection.id}`);
+    navigation.navigate(`/ui/detections/${detection.id}`);
   }
 </script>
 

--- a/frontend/src/lib/desktop/features/detections/DetectionsPage.svelte
+++ b/frontend/src/lib/desktop/features/detections/DetectionsPage.svelte
@@ -5,7 +5,7 @@
   import DetectionsCard from './components/DetectionsCard.svelte';
   import { getLogger } from '$lib/utils/logger';
   import { getLocalDateString } from '$lib/utils/date';
-  import { buildAppUrl } from '$lib/utils/urlHelpers';
+  import { navigation } from '$lib/stores/navigation.svelte';
 
   const logger = getLogger('app');
 
@@ -166,7 +166,7 @@
   // Handle details click
   function handleDetailsClick(id: number) {
     // Navigate to detection details page
-    window.location.href = buildAppUrl(`/ui/detections/${id}`);
+    navigation.navigate(`/ui/detections/${id}`);
   }
 
   // Listen for search updates from SearchBox

--- a/frontend/src/lib/desktop/features/detections/components/DetectionCardMobile.svelte
+++ b/frontend/src/lib/desktop/features/detections/components/DetectionCardMobile.svelte
@@ -5,7 +5,7 @@
   import { Volume2 } from '@lucide/svelte';
   import { t } from '$lib/i18n';
   import type { Detection } from '$lib/types/detection.types';
-  import { buildAppUrl } from '$lib/utils/urlHelpers';
+  import { navigation } from '$lib/stores/navigation.svelte';
 
   interface Props {
     detection: Detection;
@@ -36,7 +36,7 @@
     if (onDetailsClick) {
       onDetailsClick(detection.id);
     } else {
-      window.location.href = buildAppUrl(`/ui/detections/${detection.id}`);
+      navigation.navigate(`/ui/detections/${detection.id}`);
     }
   }
 </script>

--- a/frontend/src/lib/desktop/features/detections/components/DetectionRow.svelte
+++ b/frontend/src/lib/desktop/features/detections/components/DetectionRow.svelte
@@ -39,7 +39,7 @@
   import { fetchWithCSRF } from '$lib/utils/api';
   import { useImageDelayedLoading } from '$lib/utils/delayedLoading.svelte.js';
   import { loggers } from '$lib/utils/logger';
-  import { buildAppUrl } from '$lib/utils/urlHelpers';
+  import { navigation } from '$lib/stores/navigation.svelte';
 
   const logger = loggers.ui;
 
@@ -90,13 +90,13 @@
       onDetailsClick(detection.id);
     } else {
       // Default navigation to detection detail page
-      window.location.href = buildAppUrl(`/ui/detections/${detection.id}`);
+      navigation.navigate(`/ui/detections/${detection.id}`);
     }
   }
 
   // Action handlers
   function handleReview() {
-    window.location.href = buildAppUrl(`/ui/detections/${detection.id}?tab=review`);
+    navigation.navigate(`/ui/detections/${detection.id}?tab=review`);
   }
 
   function handleToggleSpecies() {

--- a/frontend/src/lib/desktop/layouts/DesktopHeader.svelte
+++ b/frontend/src/lib/desktop/layouts/DesktopHeader.svelte
@@ -4,6 +4,7 @@
   import AudioLevelIndicator from '$lib/desktop/components/ui/AudioLevelIndicator.svelte';
   import NotificationBell from '$lib/desktop/components/ui/NotificationBell.svelte';
   import ThemeToggle from '$lib/desktop/components/ui/ThemeToggle.svelte';
+  import { navigation } from '$lib/stores/navigation.svelte';
   import { Menu } from '@lucide/svelte';
   import { t } from '$lib/i18n';
 
@@ -66,8 +67,8 @@
     if (onNavigate) {
       onNavigate(url);
     } else {
-      // Default navigation
-      window.location.href = url;
+      // Fallback to navigation store for proxy-aware navigation
+      navigation.navigate(url);
     }
   }
 </script>
@@ -115,7 +116,7 @@
     {#if showNotifications}
       <NotificationBell
         {debugMode}
-        onNavigateToNotifications={() => handleNavigate('/notifications')}
+        onNavigateToNotifications={() => handleNavigate('/ui/notifications')}
       />
     {/if}
 

--- a/frontend/src/lib/desktop/layouts/DesktopSidebar.svelte
+++ b/frontend/src/lib/desktop/layouts/DesktopSidebar.svelte
@@ -42,6 +42,7 @@ Performance Optimizations:
   import { cn } from '$lib/utils/cn';
   import { auth as authStore } from '$lib/stores/auth';
   import { sidebar } from '$lib/stores/sidebar';
+  import { navigation } from '$lib/stores/navigation.svelte';
   import type { AuthConfig } from '../../../app.d';
   import {
     LayoutDashboard,
@@ -224,7 +225,8 @@ Performance Optimizations:
     if (onNavigate) {
       onNavigate(url);
     } else {
-      window.location.href = url;
+      // Fallback to navigation store for proxy-aware navigation
+      navigation.navigate(url);
     }
   }
 

--- a/frontend/src/lib/desktop/views/Notifications.svelte
+++ b/frontend/src/lib/desktop/views/Notifications.svelte
@@ -28,7 +28,7 @@
   import SelectDropdown from '$lib/desktop/components/forms/SelectDropdown.svelte';
   import { toastActions } from '$lib/stores/toast';
   import { api } from '$lib/utils/api';
-  import { buildAppUrl } from '$lib/utils/urlHelpers';
+  import { navigation } from '$lib/stores/navigation.svelte';
 
   // SPINNER CONTROL: Set to false to disable loading spinners (reduces flickering)
   // Change back to true to re-enable spinners for testing
@@ -178,7 +178,7 @@
         } catch {
           // Silently handle mark as read failures
         }
-        window.location.href = buildAppUrl(`/ui/detections/${noteId}`);
+        navigation.navigate(`/ui/detections/${noteId}`);
       }
     }
   }

--- a/frontend/src/lib/desktop/views/Search.svelte
+++ b/frontend/src/lib/desktop/views/Search.svelte
@@ -21,7 +21,7 @@
     Volume2,
     XCircle,
   } from '@lucide/svelte';
-  import { buildAppUrl } from '$lib/utils/urlHelpers';
+  import { navigation } from '$lib/stores/navigation.svelte';
 
   // SPINNER CONTROL: Set to false to disable loading spinners (reduces flickering)
   // Change back to true to re-enable spinners for testing
@@ -789,8 +789,7 @@
                       </button>
                       <button
                         class="btn btn-xs btn-square"
-                        onclick={() =>
-                          (window.location.href = buildAppUrl(`/ui/detections/${result.id}`))}
+                        onclick={() => navigation.navigate(`/ui/detections/${result.id}`)}
                         aria-label={t('search.detailsPanel.viewDetails', {
                           species: result.commonName || t('search.detailsPanel.unknownSpecies'),
                         })}
@@ -991,8 +990,7 @@
                     </button>
                     <button
                       class="btn btn-outline btn-sm"
-                      onclick={() =>
-                        (window.location.href = buildAppUrl(`/ui/detections/${result.id}`))}
+                      onclick={() => navigation.navigate(`/ui/detections/${result.id}`)}
                       aria-label={t('search.detailsPanel.viewDetails', {
                         species: result.commonName || t('search.detailsPanel.unknownSpecies'),
                       })}

--- a/frontend/src/lib/stores/navigation.svelte.ts
+++ b/frontend/src/lib/stores/navigation.svelte.ts
@@ -2,7 +2,19 @@
 /**
  * Navigation store for SPA client-side routing.
  * Manages route state and provides navigate() function using History API.
+ *
+ * Supports reverse proxy scenarios (Home Assistant Ingress, custom proxies)
+ * by using proxy-aware URL building for the browser address bar while
+ * maintaining internal paths without proxy prefix for routing.
  */
+
+import { buildAppUrl, getAppBasePath, extractRelativePath } from '$lib/utils/urlHelpers';
+
+/** Default path when no valid path is available */
+const DEFAULT_PATH = '/ui/dashboard';
+
+/** UI path prefix for the application */
+const UI_PREFIX = '/ui/';
 
 /**
  * Navigation store interface
@@ -14,15 +26,33 @@ export interface NavigationStore {
 }
 
 /**
- * Normalize URL path to /ui/ format
+ * Strip proxy prefix from a pathname for internal routing.
+ * Uses extractRelativePath from urlHelpers for consistency.
+ *
+ * @param pathname - Full pathname possibly including proxy prefix
+ * @returns Path without proxy prefix (e.g., '/ui/dashboard')
  */
-function normalizePath(url: string): string {
-  // Handle root
-  if (url === '/' || url === '') {
-    return '/ui/dashboard';
+function stripProxyPrefix(pathname: string): string {
+  const basePath = getAppBasePath();
+  if (!basePath) return pathname;
+  return extractRelativePath(pathname, basePath);
+}
+
+/**
+ * Normalize URL path to ensure /ui/ prefix format.
+ * This is app-specific normalization for routing, distinct from
+ * urlHelpers.normalizePath which handles generic slash normalization.
+ *
+ * @param url - The URL to normalize
+ * @returns Path with /ui/ prefix (e.g., '/ui/dashboard')
+ */
+function normalizeUiPath(url: string): string {
+  // Handle root or empty (including /ui and /ui/)
+  if (url === '/' || url === '' || url === '/ui' || url === '/ui/') {
+    return DEFAULT_PATH;
   }
   // Already has /ui/ prefix
-  if (url.startsWith('/ui/')) {
+  if (url.startsWith(UI_PREFIX)) {
     return url;
   }
   // Add /ui/ prefix
@@ -32,33 +62,56 @@ function normalizePath(url: string): string {
 /**
  * Create a navigation store instance.
  * Used for testing and the singleton export.
+ *
+ * The store maintains `currentPath` as the internal path (without proxy prefix)
+ * for routing, while using proxy-aware URLs for the browser address bar.
  */
 export function createNavigation(): NavigationStore {
   let currentPath = $state(
     (() => {
-      if (typeof window === 'undefined') return '/ui/dashboard';
-      const path = normalizePath(window.location.pathname);
-      // Update URL if it was normalized (without creating history entry)
-      if (path !== window.location.pathname) {
-        window.history.replaceState({}, '', path);
+      if (typeof window === 'undefined') return DEFAULT_PATH;
+
+      // Strip proxy prefix from current pathname for internal routing
+      const pathname = stripProxyPrefix(window.location.pathname);
+      const path = normalizeUiPath(pathname);
+
+      // Update URL if normalization changed the path
+      // Use buildAppUrl to maintain proxy prefix in browser
+      if (path !== pathname) {
+        window.history.replaceState({}, '', buildAppUrl(path));
       }
       return path;
     })()
   );
 
+  /**
+   * Navigate to a new path using SPA navigation (no page reload).
+   * Updates both internal state and browser URL bar with proxy-aware URL.
+   *
+   * @param url - Path to navigate to (e.g., '/ui/detections/123')
+   */
   function navigate(url: string): void {
-    const normalizedPath = normalizePath(url);
+    // Normalize the path for internal state
+    const normalizedPath = normalizeUiPath(url);
     currentPath = normalizedPath;
 
     if (typeof window !== 'undefined') {
-      window.history.pushState({}, '', normalizedPath);
+      // Build proxy-aware URL for the browser address bar
+      const fullUrl = buildAppUrl(normalizedPath);
+      window.history.pushState({}, '', fullUrl);
     }
   }
 
+  /**
+   * Handle browser back/forward button navigation.
+   * Strips proxy prefix from pathname for internal routing.
+   */
   function handlePopState(): void {
-    if (typeof window !== 'undefined') {
-      currentPath = window.location.pathname;
-    }
+    if (typeof window === 'undefined') return;
+
+    // Get pathname and strip proxy prefix for internal routing
+    const pathname = stripProxyPrefix(window.location.pathname);
+    currentPath = normalizeUiPath(pathname);
   }
 
   return {

--- a/frontend/src/lib/stores/navigation.test.ts
+++ b/frontend/src/lib/stores/navigation.test.ts
@@ -1,13 +1,44 @@
 // frontend/src/lib/stores/navigation.test.ts
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { createNavigation } from './navigation.svelte';
 
+// Mock the urlHelpers module
+vi.mock('$lib/utils/urlHelpers', () => ({
+  buildAppUrl: vi.fn((path: string) => path),
+  getAppBasePath: vi.fn(() => ''),
+  extractRelativePath: vi.fn((fullPath: string, basePath: string) => {
+    if (!basePath) return fullPath;
+    if (fullPath.startsWith(basePath)) {
+      const relativePath = fullPath.substring(basePath.length);
+      return relativePath.startsWith('/') ? relativePath : '/' + relativePath;
+    }
+    return fullPath;
+  }),
+}));
+
 describe('navigation store', () => {
+  const originalLocation = window.location;
+
   beforeEach(() => {
     vi.clearAllMocks();
     // Mock history methods
     vi.spyOn(window.history, 'pushState').mockImplementation(() => {});
     vi.spyOn(window.history, 'replaceState').mockImplementation(() => {});
+    // Reset location mock
+    Object.defineProperty(window, 'location', {
+      value: { pathname: '/ui/dashboard' },
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    // Restore original location
+    Object.defineProperty(window, 'location', {
+      value: originalLocation,
+      writable: true,
+      configurable: true,
+    });
   });
 
   describe('navigate', () => {
@@ -34,13 +65,53 @@ describe('navigation store', () => {
       nav.navigate('/');
       expect(nav.currentPath).toBe('/ui/dashboard');
     });
+
+    it('should handle empty path', () => {
+      const nav = createNavigation();
+      nav.navigate('');
+      expect(nav.currentPath).toBe('/ui/dashboard');
+    });
+
+    it('should handle /ui path without trailing slash', () => {
+      const nav = createNavigation();
+      nav.navigate('/ui');
+      expect(nav.currentPath).toBe('/ui/dashboard');
+    });
+
+    it('should handle /ui/ path with trailing slash', () => {
+      const nav = createNavigation();
+      nav.navigate('/ui/');
+      expect(nav.currentPath).toBe('/ui/dashboard');
+    });
+
+    it('should handle paths without leading slash', () => {
+      const nav = createNavigation();
+      nav.navigate('settings');
+      expect(nav.currentPath).toBe('/ui/settings');
+    });
+
+    it('should preserve existing /ui/ prefix', () => {
+      const nav = createNavigation();
+      nav.navigate('/ui/detections/123');
+      expect(nav.currentPath).toBe('/ui/detections/123');
+    });
+
+    it('should handle nested paths correctly', () => {
+      const nav = createNavigation();
+      nav.navigate('/ui/settings/audio');
+      expect(nav.currentPath).toBe('/ui/settings/audio');
+    });
+
+    it('should handle paths with query parameters in internal state', () => {
+      const nav = createNavigation();
+      nav.navigate('/ui/detections?page=2');
+      expect(nav.currentPath).toBe('/ui/detections?page=2');
+    });
   });
 
   describe('handlePopState', () => {
     it('should update currentPath from window.location', () => {
-      const originalLocation = window.location;
       const nav = createNavigation();
-      // Simulate browser back by setting window.location.pathname
       Object.defineProperty(window, 'location', {
         value: { pathname: '/ui/about' },
         writable: true,
@@ -48,12 +119,89 @@ describe('navigation store', () => {
       });
       nav.handlePopState();
       expect(nav.currentPath).toBe('/ui/about');
-      // Restore original location to prevent test pollution
+    });
+
+    it('should normalize root path on popstate', () => {
+      const nav = createNavigation();
       Object.defineProperty(window, 'location', {
-        value: originalLocation,
+        value: { pathname: '/' },
         writable: true,
         configurable: true,
       });
+      nav.handlePopState();
+      expect(nav.currentPath).toBe('/ui/dashboard');
     });
+
+    it('should handle /ui path on popstate', () => {
+      const nav = createNavigation();
+      Object.defineProperty(window, 'location', {
+        value: { pathname: '/ui' },
+        writable: true,
+        configurable: true,
+      });
+      nav.handlePopState();
+      expect(nav.currentPath).toBe('/ui/dashboard');
+    });
+  });
+
+  describe('initial state', () => {
+    it('should initialize with normalized path', () => {
+      Object.defineProperty(window, 'location', {
+        value: { pathname: '/ui/dashboard' },
+        writable: true,
+        configurable: true,
+      });
+      const nav = createNavigation();
+      expect(nav.currentPath).toBe('/ui/dashboard');
+    });
+
+    it('should normalize root path on initialization', () => {
+      Object.defineProperty(window, 'location', {
+        value: { pathname: '/' },
+        writable: true,
+        configurable: true,
+      });
+      const nav = createNavigation();
+      expect(nav.currentPath).toBe('/ui/dashboard');
+      expect(window.history.replaceState).toHaveBeenCalled();
+    });
+  });
+});
+
+describe('navigation store with proxy prefix', () => {
+  const originalLocation = window.location;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(window.history, 'pushState').mockImplementation(() => {});
+    vi.spyOn(window.history, 'replaceState').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', {
+      value: originalLocation,
+      writable: true,
+      configurable: true,
+    });
+    vi.resetModules();
+  });
+
+  it('should use buildAppUrl for history.pushState', async () => {
+    const { buildAppUrl } = await import('$lib/utils/urlHelpers');
+
+    // Configure mock to add proxy prefix
+    vi.mocked(buildAppUrl).mockImplementation((path: string) => `/proxy${path}`);
+
+    Object.defineProperty(window, 'location', {
+      value: { pathname: '/proxy/ui/dashboard' },
+      writable: true,
+      configurable: true,
+    });
+
+    const nav = createNavigation();
+    nav.navigate('/ui/settings');
+
+    expect(buildAppUrl).toHaveBeenCalledWith('/ui/settings');
+    expect(window.history.pushState).toHaveBeenCalledWith({}, '', '/proxy/ui/settings');
   });
 });

--- a/frontend/src/lib/stores/sseNotifications.ts
+++ b/frontend/src/lib/stores/sseNotifications.ts
@@ -2,6 +2,7 @@ import ReconnectingEventSource from 'reconnecting-eventsource';
 import { toastActions } from './toast';
 import type { ToastType, ToastPosition } from './toast';
 import { loggers } from '$lib/utils/logger';
+import { buildAppUrl, isRelativePath } from '$lib/utils/urlHelpers';
 import {
   sanitizeNotificationMessage,
   isValidNotification,
@@ -195,7 +196,9 @@ class SSENotificationManager {
             label: toastData.action.label,
             onClick: () => {
               if (toastData.action?.url) {
-                window.location.href = toastData.action.url;
+                // Use buildAppUrl for internal URLs to support reverse proxy scenarios
+                const url = toastData.action.url;
+                window.location.href = isRelativePath(url) ? buildAppUrl(url) : url;
               } else if (toastData.action?.handler) {
                 // Handle custom actions if needed
                 logger.debug('Toast action handler:', toastData.action.handler);

--- a/frontend/src/lib/utils/urlHelpers.test.ts
+++ b/frontend/src/lib/utils/urlHelpers.test.ts
@@ -6,6 +6,7 @@ import {
   getAppBasePath,
   buildAppUrl,
 } from './urlHelpers';
+import { loggers } from './logger';
 
 describe('URL Helpers', () => {
   // Store original window.location descriptor for tests that mock it
@@ -375,26 +376,26 @@ describe('URL Helpers', () => {
       window.location = { pathname: '/ui/dashboard' };
 
       // Protocol-relative URLs should be rejected and return safe fallback
-      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-      expect(buildAppUrl('//evil.com/path')).toBe('/ui/');
-      expect(consoleSpy).toHaveBeenCalledWith(
+      const loggerSpy = vi.spyOn(loggers.ui, 'error').mockImplementation(() => {});
+      expect(buildAppUrl('//evil.com/path')).toBe('/ui/dashboard');
+      expect(loggerSpy).toHaveBeenCalledWith(
         'buildAppUrl was called with a non-relative path:',
         '//evil.com/path'
       );
-      consoleSpy.mockRestore();
+      loggerSpy.mockRestore();
     });
 
     it('should prevent open redirect with absolute URLs', () => {
       // @ts-expect-error - Mocking window.location
       window.location = { pathname: '/proxy/ui/dashboard' };
 
-      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-      expect(buildAppUrl('https://evil.com')).toBe('/proxy/ui/');
-      expect(consoleSpy).toHaveBeenCalledWith(
+      const loggerSpy = vi.spyOn(loggers.ui, 'error').mockImplementation(() => {});
+      expect(buildAppUrl('https://evil.com')).toBe('/proxy/ui/dashboard');
+      expect(loggerSpy).toHaveBeenCalledWith(
         'buildAppUrl was called with a non-relative path:',
         'https://evil.com'
       );
-      consoleSpy.mockRestore();
+      loggerSpy.mockRestore();
     });
   });
 

--- a/frontend/src/lib/utils/urlHelpers.ts
+++ b/frontend/src/lib/utils/urlHelpers.ts
@@ -2,6 +2,10 @@
  * URL manipulation utility functions
  */
 
+import { loggers } from './logger';
+
+const logger = loggers.ui;
+
 /**
  * Extracts a relative path from a full path by removing the base path prefix.
  * Ensures the resulting path always starts with '/'.
@@ -155,9 +159,9 @@ export function buildAppUrl(path: string): string {
   // Validate input to prevent open redirect vulnerabilities
   // Only allow relative paths (starting with / but not //)
   if (!isRelativePath(path)) {
-    console.error('buildAppUrl was called with a non-relative path:', path);
+    logger.error('buildAppUrl was called with a non-relative path:', path);
     // Return safe fallback to prevent open redirect
-    return basePath + '/ui/';
+    return basePath + '/ui/dashboard';
   }
 
   return basePath + path;


### PR DESCRIPTION
## Summary

Fixes #1816 

This PR centralizes all proxy-aware navigation through the navigation store, eliminating scattered `buildAppUrl()` + `window.location.href` patterns across components.

### Changes

- **Navigation store** (`navigation.svelte.ts`): Updated `navigate()` to be proxy-aware using `buildAppUrl()` for browser URL bar while maintaining internal paths for routing
- **Constants extracted**: `DEFAULT_PATH` (`/ui/dashboard`) and `UI_PREFIX` (`/ui/`) to eliminate magic strings
- **Function renamed**: `normalizePath` → `normalizeUiPath` to avoid collision with `urlHelpers.normalizePath`
- **13 files updated** to use `navigation.navigate()` instead of direct `window.location.href` assignments

### Components migrated

| Component | Change |
|-----------|--------|
| DetectionCardGrid | Use `navigation.navigate()` |
| DashboardPage | Use `navigation.navigate()` |
| DetectionRow | Use `navigation.navigate()` |
| DetectionCardMobile | Use `navigation.navigate()` with fallback |
| DetectionsPage | Use `navigation.navigate()` |
| Notifications | Use `navigation.navigate()` |
| Search | Use `navigation.navigate()` |
| NotificationBell | Use `navigation.navigate()`, fixed URL `/notifications` → `/ui/notifications` |
| DesktopSidebar | Use `navigation.navigate()` as fallback |
| DesktopHeader | Use `navigation.navigate()` as fallback |
| sseNotifications | Use `buildAppUrl()` for internal toast action URLs |
| urlHelpers | Changed `console.error` to proper logger |

### Intentional remaining `window.location.href` usages

These are intentional full-page navigations that should NOT use SPA navigation:
- **RootLayout**: HTTPS redirect and initial URL normalization
- **LoginModal**: OAuth redirects to external providers
- **SupportSettingsPage**: File download
- **auth.ts**: Post-logout full reload (uses `buildAppUrl`)

## Test plan

- [ ] Verify SPA navigation works for all migrated components
- [ ] Test navigation in reverse proxy environment (Home Assistant Ingress)
- [ ] Verify browser back/forward buttons work correctly
- [ ] Confirm OAuth login still redirects properly
- [ ] Test file downloads still work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized in-app navigation to use a centralized navigation store across the desktop UI.
  * Updated notification and detail navigation flows to use the unified router.

* **Bug Fix**
  * Added proxy-aware URL handling to ensure consistent routing behind reverse proxies and prevent broken redirects.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->