### PR TITLE
fix(telemetry): lower log level for harmless species validation errors

### DIFF
--- a/internal/birdweather/testing.go
+++ b/internal/birdweather/testing.go
@@ -812,7 +812,12 @@ func (b *BwClient) testDetectionPost(ctx context.Context, soundscapeID string) T
 		// Post the test detection
 		err := b.PostDetection(soundscapeID, timestamp, commonName, scientificName, confidence)
 		if err != nil {
-			log.Error("BirdWeather detection post failed", logger.Error(err))
+			// Check if this is a CategoryNotFound error (species not recognized)
+			if errors.IsNotFound(err) {
+				log.Debug("BirdWeather detection post skipped: species not recognized", logger.Error(err))
+			} else {
+				log.Error("BirdWeather detection post failed", logger.Error(err))
+			}
 			return fmt.Errorf("failed to post detection: %w", err)
 		}
 

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -710,3 +710,16 @@ func Unwrap(err error) error {
 func Join(errs ...error) error {
 	return stderrors.Join(errs...)
 }
+
+// IsCategory checks if an error is an EnhancedError with the specified category.
+// This is a convenience function to reduce boilerplate when checking error categories.
+func IsCategory(err error, category ErrorCategory) bool {
+	var enhancedErr *EnhancedError
+	return As(err, &enhancedErr) && enhancedErr.Category == category
+}
+
+// IsNotFound checks if an error is an EnhancedError with CategoryNotFound.
+// This is commonly used for expected conditions like unknown species or missing resources.
+func IsNotFound(err error) bool {
+	return IsCategory(err, CategoryNotFound)
+}

--- a/internal/errors/telemetry_integration.go
+++ b/internal/errors/telemetry_integration.go
@@ -268,6 +268,8 @@ func getErrorLevel(category ErrorCategory) sentry.Level {
 		return sentry.LevelWarning // Usually recoverable
 	case CategoryConfiguration, CategorySystem:
 		return sentry.LevelError // Environment issues
+	case CategoryNotFound:
+		return sentry.LevelInfo // Expected condition for unknown species/taxonomy lookups
 	default:
 		return sentry.LevelError
 	}


### PR DESCRIPTION
## Summary

- Reduce noise from expected error conditions that don't require user attention
- Birdweather 422 errors for invalid/unknown species now log at Debug level
- Genus/taxonomy lookup failures now report at Info level instead of Error

## Changes

- Add `CategoryNotFound` to telemetry with `LevelInfo` instead of `LevelError`
- Add `errors.IsNotFound()` and `errors.IsCategory()` helper functions to reduce boilerplate
- Improve 422 detection to check for species-related errors in response body
- Move error sanitization after `IsNotFound` check to avoid unnecessary allocation
- Update all callers to use new helper functions

## Context

These are harmless events that occur when BirdNET detects non-bird sounds (like "Clethrionomys glareolus" - bank vole) that Birdweather doesn't recognize. Previously these were surfaced as medium-severity issues to users.

## Test plan

- [x] Linter passes (`golangci-lint run -v`)
- [x] All tests pass (`go test -race ./internal/errors/... ./internal/birdweather/... ./internal/analysis/processor/...`)
- [ ] Manual verification: confirm harmless species errors no longer appear in user-facing logs