### PR TITLE
feat(monitor): aggregate disk notifications by mount point

### DIFF
--- a/internal/monitor/mount_resolver.go
+++ b/internal/monitor/mount_resolver.go
@@ -1,0 +1,115 @@
+package monitor
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/shirou/gopsutil/v3/disk"
+	"github.com/tphakala/birdnet-go/internal/logger"
+)
+
+// MountGroup represents a group of paths sharing the same mount point
+type MountGroup struct {
+	MountPoint string   // The actual mount point (e.g., "/")
+	Device     string   // The device (e.g., "/dev/sda1")
+	Fstype     string   // Filesystem type (e.g., "ext4")
+	Paths      []string // All monitored paths on this mount
+}
+
+// getMountInfoFromPartitions returns mount point, device, and fstype for a path
+// Uses the provided partitions list to avoid repeated syscalls
+func getMountInfoFromPartitions(path string, partitions []disk.PartitionStat) (mountPoint, device, fstype string, err error) {
+	// Resolve symlinks first (critical for correct mount detection)
+	resolvedPath, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		// If symlink resolution fails, try with original path
+		if _, statErr := os.Stat(path); statErr != nil {
+			return "", "", "", fmt.Errorf("path does not exist: %s: %w", path, err)
+		}
+		resolvedPath = path
+	}
+
+	var bestMatch disk.PartitionStat
+	var bestLen int
+
+	for _, p := range partitions {
+		mp := p.Mountpoint
+		if strings.HasPrefix(resolvedPath, mp) {
+			if resolvedPath == mp || len(mp) == 1 || strings.HasPrefix(resolvedPath, mp+"/") {
+				if len(mp) > bestLen {
+					bestMatch = p
+					bestLen = len(mp)
+				}
+			}
+		}
+	}
+
+	if bestLen == 0 {
+		return "", "", "", fmt.Errorf("no mount point found for path: %s", path)
+	}
+
+	return bestMatch.Mountpoint, bestMatch.Device, bestMatch.Fstype, nil
+}
+
+// groupPathsByMountPoint groups paths by their underlying mount point
+// Calls disk.Partitions() once and reuses for all path resolutions
+func groupPathsByMountPoint(paths []string) ([]MountGroup, error) {
+	// Get partitions once for all paths (performance optimization)
+	partitions, err := disk.Partitions(false)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get partitions: %w", err)
+	}
+
+	return groupPathsWithPartitions(paths, partitions), nil
+}
+
+// groupPathsWithPartitions groups paths using provided partition list
+// This validates path existence and resolves symlinks
+func groupPathsWithPartitions(paths []string, partitions []disk.PartitionStat) []MountGroup {
+	groups := make(map[string]*MountGroup)
+
+	for _, path := range paths {
+		mountPoint, device, fstype, err := getMountInfoFromPartitions(path, partitions)
+		if err != nil {
+			// Log but skip invalid paths
+			GetLogger().Debug("Skipping path for mount grouping",
+				logger.String("path", path),
+				logger.Error(err),
+			)
+			continue
+		}
+
+		if group, exists := groups[mountPoint]; exists {
+			group.Paths = append(group.Paths, path)
+		} else {
+			groups[mountPoint] = &MountGroup{
+				MountPoint: mountPoint,
+				Device:     device,
+				Fstype:     fstype,
+				Paths:      []string{path},
+			}
+		}
+	}
+
+	return sortMountGroups(groups)
+}
+
+// sortMountGroups converts a map of groups to a sorted slice
+func sortMountGroups(groups map[string]*MountGroup) []MountGroup {
+	result := make([]MountGroup, 0, len(groups))
+	for _, group := range groups {
+		// Sort paths within group for consistent output
+		sort.Strings(group.Paths)
+		result = append(result, *group)
+	}
+
+	// Sort groups by mount point
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].MountPoint < result[j].MountPoint
+	})
+
+	return result
+}

--- a/internal/monitor/mount_resolver_test.go
+++ b/internal/monitor/mount_resolver_test.go
@@ -1,0 +1,223 @@
+package monitor
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/shirou/gopsutil/v3/disk"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockPartitions returns a mock partition list for deterministic unit tests
+func mockPartitions() []disk.PartitionStat {
+	return []disk.PartitionStat{
+		{Device: "/dev/sda1", Mountpoint: "/", Fstype: "ext4"},
+		{Device: "/dev/sda2", Mountpoint: "/home", Fstype: "ext4"},
+		{Device: "/dev/sdb1", Mountpoint: "/mnt/data", Fstype: "ext4"},
+	}
+}
+
+// resolveMountPointFromPartitions is a test helper that skips path existence check
+// Used for deterministic unit tests with mock partitions
+func resolveMountPointFromPartitions(path string, partitions []disk.PartitionStat) (string, error) {
+	var bestMatch string
+	for _, p := range partitions {
+		mountpoint := p.Mountpoint
+		if strings.HasPrefix(path, mountpoint) {
+			if path == mountpoint || len(mountpoint) == 1 || strings.HasPrefix(path, mountpoint+"/") {
+				if len(mountpoint) > len(bestMatch) {
+					bestMatch = mountpoint
+				}
+			}
+		}
+	}
+
+	if bestMatch == "" {
+		return "", fmt.Errorf("no mount point found for path: %s", path)
+	}
+
+	return bestMatch, nil
+}
+
+// groupPathsWithPartitionsMock is a test helper that skips path existence checks
+// Used for deterministic unit tests with mock partitions
+func groupPathsWithPartitionsMock(paths []string, partitions []disk.PartitionStat) []MountGroup {
+	groups := make(map[string]*MountGroup)
+
+	for _, path := range paths {
+		mount, err := resolveMountPointFromPartitions(path, partitions)
+		if err != nil {
+			continue
+		}
+
+		// Find device and fstype from partitions
+		var device, fstype string
+		for _, p := range partitions {
+			if p.Mountpoint == mount {
+				device = p.Device
+				fstype = p.Fstype
+				break
+			}
+		}
+
+		if group, exists := groups[mount]; exists {
+			group.Paths = append(group.Paths, path)
+		} else {
+			groups[mount] = &MountGroup{
+				MountPoint: mount,
+				Device:     device,
+				Fstype:     fstype,
+				Paths:      []string{path},
+			}
+		}
+	}
+
+	return sortMountGroups(groups)
+}
+
+func TestResolveMountPointFromPartitions(t *testing.T) {
+	t.Parallel()
+
+	partitions := mockPartitions()
+
+	tests := []struct {
+		name     string
+		path     string
+		expected string
+	}{
+		{"root resolves to root", "/", "/"},
+		{"home resolves to home", "/home", "/home"},
+		{"home subdir resolves to home", "/home/user", "/home"},
+		{"var resolves to root", "/var", "/"},
+		{"etc resolves to root", "/etc", "/"},
+		{"mnt data resolves to mnt data", "/mnt/data", "/mnt/data"},
+		{"mnt data subdir resolves to mnt data", "/mnt/data/files", "/mnt/data"},
+		{"mnt without data resolves to root", "/mnt", "/"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			mount, err := resolveMountPointFromPartitions(tt.path, partitions)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, mount)
+		})
+	}
+}
+
+func TestResolveMountPointFromPartitionsNoMatch(t *testing.T) {
+	t.Parallel()
+
+	// Empty partitions list
+	partitions := []disk.PartitionStat{}
+	_, err := resolveMountPointFromPartitions("/some/path", partitions)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no mount point found")
+}
+
+func TestGroupPathsByMountPoint(t *testing.T) {
+	t.Parallel()
+
+	// Test with real filesystem - paths that exist
+	paths := []string{"/", "/tmp"}
+	groups, err := groupPathsByMountPoint(paths)
+	require.NoError(t, err)
+
+	// Should have at least one group
+	assert.NotEmpty(t, groups)
+
+	// Total paths in all groups should equal input paths
+	totalPaths := 0
+	for _, g := range groups {
+		totalPaths += len(g.Paths)
+	}
+	assert.Equal(t, 2, totalPaths)
+}
+
+func TestGroupPathsByMountPointWithInvalidPath(t *testing.T) {
+	t.Parallel()
+
+	// Invalid paths should be skipped, not cause error
+	paths := []string{"/", "/nonexistent/path/xyz/abc/123"}
+	groups, err := groupPathsByMountPoint(paths)
+	require.NoError(t, err)
+
+	// Should have group for valid path
+	assert.NotEmpty(t, groups)
+
+	// Only the valid path should be in groups
+	totalPaths := 0
+	for _, g := range groups {
+		totalPaths += len(g.Paths)
+	}
+	assert.Equal(t, 1, totalPaths)
+}
+
+func TestGroupPathsWithPartitionsAggregation(t *testing.T) {
+	t.Parallel()
+
+	partitions := mockPartitions()
+
+	// All these paths should be on root filesystem
+	paths := []string{"/var", "/etc", "/usr"}
+	groups := groupPathsWithPartitionsMock(paths, partitions)
+
+	// All three paths should be in one group (root)
+	require.Len(t, groups, 1)
+	assert.Equal(t, "/", groups[0].MountPoint)
+	assert.Equal(t, "/dev/sda1", groups[0].Device)
+	assert.Equal(t, "ext4", groups[0].Fstype)
+	assert.Len(t, groups[0].Paths, 3)
+	// Paths should be sorted
+	assert.Equal(t, []string{"/etc", "/usr", "/var"}, groups[0].Paths)
+}
+
+func TestGroupPathsWithPartitionsMultipleMounts(t *testing.T) {
+	t.Parallel()
+
+	partitions := mockPartitions()
+
+	// Paths on different mounts
+	paths := []string{"/var", "/home/user", "/mnt/data/files"}
+	groups := groupPathsWithPartitionsMock(paths, partitions)
+
+	// Should have 3 groups: /, /home, /mnt/data
+	require.Len(t, groups, 3)
+
+	// Verify groups are sorted by mount point
+	assert.Equal(t, "/", groups[0].MountPoint)
+	assert.Equal(t, "/home", groups[1].MountPoint)
+	assert.Equal(t, "/mnt/data", groups[2].MountPoint)
+
+	// Verify paths in each group
+	assert.Equal(t, []string{"/var"}, groups[0].Paths)
+	assert.Equal(t, []string{"/home/user"}, groups[1].Paths)
+	assert.Equal(t, []string{"/mnt/data/files"}, groups[2].Paths)
+}
+
+func TestGroupPathsWithPartitionsEmptyInput(t *testing.T) {
+	t.Parallel()
+
+	partitions := mockPartitions()
+	groups := groupPathsWithPartitionsMock([]string{}, partitions)
+
+	assert.Empty(t, groups)
+}
+
+func TestMountGroupFields(t *testing.T) {
+	t.Parallel()
+
+	partitions := mockPartitions()
+	paths := []string{"/home/user1", "/home/user2"}
+	groups := groupPathsWithPartitionsMock(paths, partitions)
+
+	require.Len(t, groups, 1)
+	group := groups[0]
+
+	assert.Equal(t, "/home", group.MountPoint)
+	assert.Equal(t, "/dev/sda2", group.Device)
+	assert.Equal(t, "ext4", group.Fstype)
+	assert.Equal(t, []string{"/home/user1", "/home/user2"}, group.Paths)
+}


### PR DESCRIPTION
## Summary

- Aggregate disk usage alerts by underlying mount point to prevent duplicate notifications
- Add mount point resolution using gopsutil to group paths by device
- Resolve symlinks for accurate mount detection
- Create aggregated disk events with multiple affected paths
- Extract magic numbers to named constants for maintainability
- Clean up code smells (unreachable code, log verbosity, string literals)

## Test plan

- [x] Unit tests for mount point resolution
- [x] Unit tests for path grouping by mount
- [x] Integration tests for aggregated disk events
- [x] All existing system monitor tests pass
- [x] Race detector passes (`go test -race`)
- [x] Linter passes (`golangci-lint run`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Alerts for resource constraints can now report multiple affected paths in a single notification, providing better visibility into system-wide issues.
  * Disk usage monitoring is now aggregated by storage mount point, delivering clearer and more organized alert reporting across different filesystem locations.

* **Tests**
  * Expanded test suite to validate multi-path resource alerts and mount point aggregation behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->