### PR TITLE
fix(frontend): resolve mobile audio playback failure on iOS Safari

### DIFF
--- a/frontend/src/lib/desktop/components/media/AudioPlayer.svelte
+++ b/frontend/src/lib/desktop/components/media/AudioPlayer.svelte
@@ -28,14 +28,31 @@
 -->
 
 <script lang="ts">
-  import { onMount, onDestroy } from 'svelte';
+  import { onMount } from 'svelte';
   import { cn } from '$lib/utils/cn.js';
   import { Play, Pause, Download, XCircle } from '@lucide/svelte';
   import AudioSettingsButton from '$lib/desktop/features/dashboard/components/AudioSettingsButton.svelte';
   import { t } from '$lib/i18n';
   import { loggers } from '$lib/utils/logger';
   import { useDelayedLoading } from '$lib/utils/delayedLoading.svelte.js';
-  import { applyPlaybackRate, dbToGain } from '$lib/utils/audio';
+  import {
+    applyPlaybackRate,
+    dbToGain,
+    PLAY_END_DELAY_MS,
+    CANPLAY_TIMEOUT_MS,
+    PROGRESS_UPDATE_INTERVAL_MS,
+    MIN_CONTROLS_WIDTH_PX,
+  } from '$lib/utils/audio';
+  import {
+    getAudioContext,
+    isAudioContextSupported,
+    releaseAudioContext,
+  } from '$lib/utils/audioContextManager';
+  import {
+    createAudioNodeChain,
+    disconnectAudioNodes,
+    type AudioNodeChain,
+  } from '$lib/utils/audioNodes';
 
   const logger = loggers.audio;
 
@@ -48,7 +65,7 @@
   };
 
   // Web Audio API types - these are built-in browser types
-  /* global AudioContext, MediaElementAudioSourceNode, GainNode, DynamicsCompressorNode, BiquadFilterNode, EventListener, ResizeObserver */
+  /* global Audio, AudioContext, EventListener, ResizeObserver */
 
   // Size type for spectrogram
   type SpectrogramSize = 'sm' | 'md' | 'lg' | 'xl';
@@ -126,6 +143,8 @@
   // Spectrogram retry state
   let spectrogramRetryCount = $state(0);
   let spectrogramRetryTimer: ReturnType<typeof setTimeout> | undefined;
+  // Cache key for forcing spectrogram reload via Svelte reactivity (instead of direct DOM manipulation)
+  let spectrogramCacheKey = $state(0);
 
   // Spectrogram generation status
   let spectrogramStatus = $state<{
@@ -137,29 +156,32 @@
   let statusPollStartTime: number | undefined;
   let statusPollAbortController: AbortController | undefined;
 
-  // User-requested spectrogram generation state
-  // TODO: Wire up UI components for generate button when spectrogramNeedsGeneration is true
-  // eslint-disable-next-line no-unused-vars
+  // ==========================================================================
+  // User-requested spectrogram generation (INCOMPLETE FEATURE)
+  // TODO: This feature allows users to manually trigger spectrogram generation
+  // when spectrogramMode is 'user-requested'. Currently the backend supports this
+  // but the UI (generate button) is not wired up. To complete:
+  // 1. Add a "Generate Spectrogram" button in the error state when spectrogramNeedsGeneration is true
+  // 2. Wire the button to call handleGenerateSpectrogram()
+  // 3. Show generationError if generation fails
+  // Related functions: checkSpectrogramMode(), handleGenerateSpectrogram()
+  // ==========================================================================
+  /* eslint-disable no-unused-vars */
   let spectrogramNeedsGeneration = $state(false);
   let isGeneratingSpectrogram = $state(false);
-  // eslint-disable-next-line no-unused-vars
   let generationError = $state<string | null>(null);
-  // Default to "auto" mode if backend doesn't specify
   let spectrogramMode = $state<string>('auto');
+  /* eslint-enable no-unused-vars */
 
   // Audio processing state
   let audioContext: AudioContext | null = null;
   let isInitializingContext = $state(false);
-  let audioNodes: {
-    source: MediaElementAudioSourceNode;
-    gain: GainNode;
-    compressor: DynamicsCompressorNode;
-    filters: { highPass: BiquadFilterNode };
-  } | null = null;
+  let audioNodes: AudioNodeChain | null = null;
 
   // Cleanup tracking for memory leak prevention
   let resizeObserver: ResizeObserver | null = null;
   let playEndTimeout: ReturnType<typeof setTimeout> | undefined;
+  let canplayTimeoutId: ReturnType<typeof setTimeout> | undefined;
   let eventListeners: Array<{
     element: HTMLElement | Document | Window;
     event: string;
@@ -177,14 +199,21 @@
   const GAIN_MAX_DB = 24;
   const FILTER_HP_MIN_FREQ = 20;
   const FILTER_HP_MAX_FREQ = 10000;
-  const FILTER_HP_DEFAULT_FREQ = 20;
-  const PLAY_END_DELAY_MS = 3000; // 3 second delay after audio stops before resuming updates
+  // PLAY_END_DELAY_MS imported from $lib/utils/audio
   // Spinner delay is now handled by useDelayedLoading utility
 
   // Computed values
-  const spectrogramUrl = $derived(
+  // Base URL without cache-busting parameters
+  const spectrogramBaseUrl = $derived(
     showSpectrogram
-      ? `/api/v2/spectrogram/${detectionId}?size=${spectrogramSize}${spectrogramRaw ? '&raw=true' : ''}`
+      ? `/api/v2/spectrogram/${encodeURIComponent(detectionId)}?size=${spectrogramSize}${spectrogramRaw ? '&raw=true' : ''}`
+      : null
+  );
+
+  // Active URL with cache-busting for reactive reloads (retry count + cache key)
+  const spectrogramUrl = $derived(
+    spectrogramBaseUrl
+      ? `${spectrogramBaseUrl}&cache=${spectrogramCacheKey}${spectrogramRetryCount > 0 ? `&retry=${spectrogramRetryCount}` : ''}`
       : null
   );
 
@@ -217,64 +246,20 @@
     }
   };
 
-  // Audio context setup
+  // Audio context setup - uses shared singleton manager
   const initializeAudioContext = async () => {
     try {
-      // Check if AudioContext is available (webkitAudioContext for Safari)
-      type WebkitWindow = Window & { webkitAudioContext?: typeof AudioContext };
-      const AudioContextClass = window.AudioContext || (window as WebkitWindow).webkitAudioContext;
-      if (!AudioContextClass) {
+      if (!isAudioContextSupported()) {
         throw new Error('AudioContext not supported');
       }
-
-      audioContext = new AudioContextClass();
-
-      if (audioContext.state === 'suspended') {
-        await audioContext.resume();
-      }
-
+      audioContext = await getAudioContext();
       audioContextAvailable = true;
       return audioContext;
-      // eslint-disable-next-line no-unused-vars
-    } catch (_e) {
+    } catch {
       logger.warn('Web Audio API is not supported in this browser');
       audioContextAvailable = false;
       return null;
     }
-  };
-
-  // Create audio processing nodes
-  const createAudioNodes = (audioContext: AudioContext, audio: HTMLAudioElement) => {
-    const audioSource = audioContext.createMediaElementSource(audio);
-    const gainNode = audioContext.createGain();
-    gainNode.gain.value = 1;
-
-    const highPassFilter = audioContext.createBiquadFilter();
-    highPassFilter.type = 'highpass';
-    highPassFilter.frequency.value = FILTER_HP_DEFAULT_FREQ;
-    highPassFilter.Q.value = 1;
-
-    const compressor = audioContext.createDynamicsCompressor();
-    compressor.threshold.value = -24;
-    compressor.knee.value = 30;
-    compressor.ratio.value = 12;
-    compressor.attack.value = 0.003;
-    compressor.release.value = 0.25;
-
-    audioSource
-      .connect(highPassFilter)
-      .connect(gainNode)
-      .connect(compressor)
-      .connect(audioContext.destination);
-
-    return {
-      source: audioSource,
-      gain: gainNode,
-      compressor,
-      filters: {
-        highPass: highPassFilter,
-      },
-    };
   };
 
   // Audio event handlers
@@ -292,7 +277,11 @@
           try {
             audioContext = await initializeAudioContext();
             if (audioContext && !audioNodes) {
-              audioNodes = createAudioNodes(audioContext, audioElement);
+              audioNodes = createAudioNodeChain(audioContext, audioElement, {
+                gainDb: gainValue,
+                highPassFreq: filterFreq,
+                includeCompressor: true,
+              });
             }
           } finally {
             isInitializingContext = false;
@@ -306,7 +295,7 @@
       }
     } catch (err) {
       logger.error('Error playing audio:', err);
-      error = 'Failed to play audio';
+      error = t('media.audio.playError');
     }
   };
 
@@ -320,7 +309,7 @@
 
   const startInterval = () => {
     if (updateInterval) clearInterval(updateInterval);
-    updateInterval = setInterval(updateProgress, 100);
+    updateInterval = setInterval(updateProgress, PROGRESS_UPDATE_INTERVAL_MS);
   };
 
   const stopInterval = () => {
@@ -365,7 +354,7 @@
   const updateFilter = (newFreq: number) => {
     filterFreq = Math.max(FILTER_HP_MIN_FREQ, Math.min(FILTER_HP_MAX_FREQ, newFreq));
     if (audioNodes) {
-      audioNodes.filters.highPass.frequency.value = filterFreq;
+      audioNodes.highPass.frequency.value = filterFreq;
     }
   };
 
@@ -377,18 +366,9 @@
     }
   };
 
+  // Part of user-requested spectrogram generation feature (see TODO above)
   // Check spectrogram mode on mount/URL change to avoid double-request pattern
-  // NOTE: Current implementation requires an initial network request to detect mode.
-  //
-  // Future optimization options:
-  // 1. Read from global settings store (if spectrogram mode is exposed frontend-wide)
-  // 2. Call dedicated /api/v2/spectrogram/:id/info endpoint for lightweight metadata
-  // 3. Use format query parameter (e.g., ?format=json) for explicit JSON responses
-  //
-  // The current approach is acceptable as it eliminates the previous double-request
-  // pattern where BOTH the <img> load AND a subsequent fetch() would fail before
-  // showing the generate button.
-  // eslint-disable-next-line no-unused-vars
+  /* eslint-disable no-unused-vars */
   const checkSpectrogramMode = async () => {
     if (!spectrogramUrl) {
       spectrogramMode = 'auto';
@@ -460,7 +440,7 @@
     // Create new AbortController for this poll request
     statusPollAbortController = new AbortController();
 
-    const statusUrl = `/api/v2/spectrogram/${detectionId}/status?size=${spectrogramSize}${spectrogramRaw ? '&raw=true' : ''}`;
+    const statusUrl = `/api/v2/spectrogram/${encodeURIComponent(detectionId)}/status?size=${spectrogramSize}${spectrogramRaw ? '&raw=true' : ''}`;
     debugLog('pollSpectrogramStatus: fetching', { url: statusUrl });
 
     try {
@@ -489,17 +469,13 @@
           status.status === 'completed' ||
           status.status === 'generated'
         ) {
-          // Spectrogram is ready, stop polling and try to load it
+          // Spectrogram is ready, stop polling and reload via reactive cache key
           debugLog('pollSpectrogramStatus: spectrogram ready, reloading image');
           clearStatusPollTimer();
           spectrogramStatus = null;
-          // Force reload the image using Svelte binding
-          if (spectrogramImage && spectrogramUrl) {
-            const url = new URL(spectrogramUrl, window.location.origin);
-            url.searchParams.set('t', Date.now().toString());
-            spectrogramImage.src = url.toString();
-            debugLog('pollSpectrogramStatus: image src updated', { src: url.toString() });
-          }
+          // Force reload by incrementing cache key (triggers Svelte reactivity)
+          spectrogramCacheKey++;
+          debugLog('pollSpectrogramStatus: cache key updated', { cacheKey: spectrogramCacheKey });
         } else if (status.status === 'queued' || status.status === 'generating') {
           // Still processing, continue polling
           debugLog('pollSpectrogramStatus: still processing, scheduling next poll');
@@ -596,17 +572,12 @@
         currentStatus: spectrogramStatus?.status,
       });
 
-      spectrogramRetryCount++;
-
-      // Schedule retry
+      // Schedule retry by incrementing retry count after delay
+      // (spectrogramUrl is derived from spectrogramRetryCount, so this triggers reload)
       clearSpectrogramRetryTimer();
       spectrogramRetryTimer = setTimeout(() => {
-        // Force reload by modifying URL with timestamp
-        const url = new URL(img.src);
-        url.searchParams.set('retry', spectrogramRetryCount.toString());
-        url.searchParams.set('t', Date.now().toString());
-        img.src = url.toString();
-        debugLog('handleSpectrogramError: retry attempted', { newSrc: url.toString() });
+        spectrogramRetryCount++;
+        debugLog('handleSpectrogramError: retry attempted', { retryCount: spectrogramRetryCount });
       }, retryDelay);
 
       return; // Don't set error state yet
@@ -646,9 +617,7 @@
     }
   };
 
-  // Handle user-requested spectrogram generation
-  // TODO: Wire up to generate button in UI when spectrogramNeedsGeneration is true
-  // eslint-disable-next-line no-unused-vars
+  // Part of user-requested spectrogram generation feature (see TODO in state declarations)
   const handleGenerateSpectrogram = async () => {
     if (isGeneratingSpectrogram) {
       debugLog('handleGenerateSpectrogram: already generating, skipping');
@@ -664,7 +633,7 @@
     try {
       // Build POST URL using URL and URLSearchParams
       const generateUrl = new URL(
-        `/api/v2/spectrogram/${detectionId}/generate`,
+        `/api/v2/spectrogram/${encodeURIComponent(detectionId)}/generate`,
         window.location.origin
       );
       const params = new URLSearchParams();
@@ -709,18 +678,14 @@
         });
         debugLog('handleGenerateSpectrogram: immediate success', { path: data.path });
 
-        // Reset state and reload the spectrogram
+        // Reset state and reload the spectrogram via reactive cache key
         spectrogramNeedsGeneration = false;
         spectrogramRetryCount = 0;
         spectrogramLoader.setLoading(true);
 
-        // Reload the image with cache-busting parameter
-        if (spectrogramImage && spectrogramUrl) {
-          const url = new URL(spectrogramUrl, window.location.origin);
-          url.searchParams.set('t', Date.now().toString());
-          spectrogramImage.src = url.toString();
-          debugLog('handleGenerateSpectrogram: reloading image', { src: url.toString() });
-        }
+        // Reload by incrementing cache key (triggers Svelte reactivity)
+        spectrogramCacheKey++;
+        debugLog('handleGenerateSpectrogram: cache key updated', { cacheKey: spectrogramCacheKey });
       } else {
         // Error response
         let errorMessage = `Generation failed with status ${response.status}`;
@@ -747,26 +712,50 @@
       debugLog('handleGenerateSpectrogram: completed');
     }
   };
+  /* eslint-enable no-unused-vars */
 
-  // Track previous URL to avoid unnecessary resets
-  let previousSpectrogramUrl = $state<string | null>(null);
+  // Track previous base URL to detect when detection changes (not just cache key updates)
+  let previousSpectrogramBaseUrl = $state<string | null>(null);
 
-  // Handle spectrogram URL changes with proper loading state
+  // Handle spectrogram base URL changes (different detection) with proper loading state
   $effect(() => {
-    // Only reset loading state if URL actually changed
-    if (spectrogramUrl && spectrogramUrl !== previousSpectrogramUrl && !spectrogramLoader.error) {
-      debugLog('spectrogramUrl changed', {
-        from: previousSpectrogramUrl,
-        to: spectrogramUrl,
+    // Only reset loading state if base URL actually changed (new detection)
+    if (
+      spectrogramBaseUrl &&
+      spectrogramBaseUrl !== previousSpectrogramBaseUrl &&
+      !spectrogramLoader.error
+    ) {
+      debugLog('spectrogramBaseUrl changed', {
+        from: previousSpectrogramBaseUrl,
+        to: spectrogramBaseUrl,
       });
 
-      previousSpectrogramUrl = spectrogramUrl;
+      previousSpectrogramBaseUrl = spectrogramBaseUrl;
 
-      // Reset retry count and clear any pending retry timer for new spectrogram
+      // Reset retry/cache state for new spectrogram
       spectrogramRetryCount = 0;
+      spectrogramCacheKey = 0;
       clearSpectrogramRetryTimer();
       // Abort any in-flight status polling when URL changes
       clearStatusPollTimer();
+    }
+  });
+
+  // Sync audio source when URL changes (replaces template binding for iOS Safari compatibility)
+  $effect(() => {
+    if (audioElement && audioUrl) {
+      // Compare resolved URLs to avoid unnecessary reloads
+      const absoluteUrl = new URL(audioUrl, window.location.origin).href;
+      if (audioElement.src !== absoluteUrl) {
+        debugLog('audioUrl changed, updating src', { from: audioElement.src, to: audioUrl });
+        audioElement.src = audioUrl;
+        // Reset playback state for new audio
+        isPlaying = false;
+        currentTime = 0;
+        progress = 0;
+        duration = 0;
+        error = null;
+      }
     }
   });
 
@@ -778,13 +767,20 @@
       showSpectrogram,
     });
 
+    // Create audio element dynamically to avoid iOS Safari issues
+    // where DOM-bound audio elements don't fire canplay events
+    audioElement = new Audio();
+    audioElement.preload = 'metadata';
+    audioElement.src = audioUrl;
+    audioElement.id = audioId;
+
     // Check if mobile
     isMobile = 'ontouchstart' in window || navigator.maxTouchPoints > 0;
 
     // Check width for control visibility
     if (playerContainer) {
       const checkWidth = () => {
-        showControls = playerContainer.offsetWidth >= 175;
+        showControls = playerContainer.offsetWidth >= MIN_CONTROLS_WIDTH_PX;
       };
       checkWidth();
 
@@ -793,7 +789,8 @@
       resizeObserver.observe(playerContainer);
     }
 
-    if (audioElement) {
+    // audioElement is now guaranteed to exist (created above)
+    {
       // Add all audio event listeners with proper tracking
       addTrackedEventListener(audioElement, 'play', () => {
         isPlaying = true;
@@ -834,12 +831,37 @@
       addTrackedEventListener(audioElement, 'timeupdate', handleTimeUpdate);
       addTrackedEventListener(audioElement, 'loadedmetadata', handleLoadedMetadata);
 
+      // Safety timeout for canplay event (iOS Safari fallback)
+      // If canplay doesn't fire within 3 seconds of loadstart, assume ready
       addTrackedEventListener(audioElement, 'loadstart', () => {
         isLoading = true;
+        // Clear any existing timeout
+        if (canplayTimeoutId) clearTimeout(canplayTimeoutId);
+        // Set new timeout as fallback for iOS Safari
+        canplayTimeoutId = setTimeout(() => {
+          if (isLoading) {
+            logger.warn('canplay timeout - assuming audio ready', { detectionId });
+            isLoading = false;
+          }
+        }, CANPLAY_TIMEOUT_MS);
+      });
+
+      addTrackedEventListener(audioElement, 'canplay', () => {
+        // Clear timeout since canplay fired normally
+        if (canplayTimeoutId) {
+          clearTimeout(canplayTimeoutId);
+          canplayTimeoutId = undefined;
+        }
+        isLoading = false;
       });
 
       addTrackedEventListener(audioElement, 'error', () => {
-        error = 'Failed to load audio';
+        // Clear timeout on error
+        if (canplayTimeoutId) {
+          clearTimeout(canplayTimeoutId);
+          canplayTimeoutId = undefined;
+        }
+        error = t('media.audio.error');
         isLoading = false;
       });
 
@@ -862,6 +884,56 @@
       debugLog('onMount: spectrogram already loaded from cache');
       spectrogramLoader.setLoading(false);
     }
+
+    // Cleanup function (Svelte 5 pattern)
+    return () => {
+      debugLog('cleanup: component destroying', {
+        isPlaying,
+        spectrogramRetryCount,
+        hasStatusPollTimer: !!statusPollTimer,
+      });
+
+      // Stop any running intervals
+      stopInterval();
+
+      // Clear any pending timeouts
+      clearPlayEndTimeout();
+      clearSpectrogramRetryTimer();
+      clearStatusPollTimer();
+      spectrogramLoader.cleanup();
+
+      // Clear canplay safety timeout
+      if (canplayTimeoutId) {
+        clearTimeout(canplayTimeoutId);
+        canplayTimeoutId = undefined;
+      }
+
+      // Remove all tracked event listeners
+      eventListeners.forEach(({ element, event, handler }) => {
+        element.removeEventListener(event, handler);
+      });
+      eventListeners = [];
+
+      // Disconnect ResizeObserver
+      if (resizeObserver) {
+        resizeObserver.disconnect();
+        resizeObserver = null;
+      }
+
+      // Stop audio playback to prevent resource leaks
+      if (audioElement) {
+        audioElement.pause();
+        audioElement.src = '';
+      }
+
+      // Clean up Web Audio API resources using shared utilities
+      disconnectAudioNodes(audioNodes);
+      audioNodes = null;
+
+      // Release reference to shared audio context (doesn't close it - it's reused)
+      releaseAudioContext();
+      audioContext = null;
+    };
   });
 
   // Debug effect to track spectrogram loader state changes
@@ -883,64 +955,6 @@
       });
     }
   });
-
-  onDestroy(() => {
-    debugLog('onDestroy: component destroying', {
-      isPlaying,
-      spectrogramRetryCount,
-      hasStatusPollTimer: !!statusPollTimer,
-    });
-
-    // Stop any running intervals
-    stopInterval();
-
-    // Clear any pending timeouts
-    clearPlayEndTimeout();
-    clearSpectrogramRetryTimer();
-    clearStatusPollTimer();
-    spectrogramLoader.cleanup();
-
-    // Remove all tracked event listeners
-    eventListeners.forEach(({ element, event, handler }) => {
-      element.removeEventListener(event, handler);
-    });
-    eventListeners = [];
-
-    // Disconnect ResizeObserver
-    if (resizeObserver) {
-      resizeObserver.disconnect();
-      resizeObserver = null;
-    }
-
-    // Clean up Web Audio API resources
-    if (audioNodes) {
-      try {
-        audioNodes.source.disconnect();
-        audioNodes.gain.disconnect();
-        audioNodes.compressor.disconnect();
-        audioNodes.filters.highPass.disconnect();
-        // eslint-disable-next-line no-unused-vars
-      } catch (_e) {
-        // Nodes may already be disconnected, ignore errors
-
-        logger.warn('Error disconnecting audio nodes during cleanup');
-      }
-      audioNodes = null;
-    }
-
-    // Close audio context
-    if (audioContext) {
-      try {
-        audioContext.close();
-        // eslint-disable-next-line no-unused-vars
-      } catch (_e) {
-        // Context may already be closed, ignore errors
-
-        logger.warn('Error closing audio context during cleanup');
-      }
-      audioContext = null;
-    }
-  });
 </script>
 
 <div
@@ -953,7 +967,9 @@
   {#if spectrogramUrl}
     <!-- Screen reader announcement for loading state -->
     <div class="sr-only" role="status" aria-live="polite">
-      {spectrogramLoader.loading ? 'Loading spectrogram...' : 'Spectrogram loaded'}
+      {spectrogramLoader.loading
+        ? t('components.audio.spectrogramLoading')
+        : t('components.audio.spectrogramLoaded')}
     </div>
 
     <!-- Loading spinner overlay -->
@@ -964,7 +980,7 @@
         <div
           class="loading loading-spinner loading-sm md:loading-md text-primary"
           role="status"
-          aria-label="Loading spectrogram"
+          aria-label={t('components.audio.spectrogramLoadingAria')}
         ></div>
       </div>
     {/if}
@@ -979,7 +995,9 @@
       >
         <div class="text-center p-2">
           <XCircle class="size-6 sm:size-8 mx-auto mb-1 text-base-content/30" aria-hidden="true" />
-          <span class="text-xs sm:text-sm text-base-content/50">Spectrogram unavailable</span>
+          <span class="text-xs sm:text-sm text-base-content/50"
+            >{t('components.audio.spectrogramUnavailable')}</span
+          >
         </div>
       </div>
     {:else if spectrogramStatus?.status === 'queued' || spectrogramStatus?.status === 'generating'}
@@ -990,13 +1008,17 @@
         <div
           class="loading loading-spinner loading-xs sm:loading-sm md:loading-md"
           role="status"
-          aria-label="Generating spectrogram"
+          aria-label={t('components.audio.spectrogramGeneratingAria')}
         ></div>
         <div class="text-xs sm:text-sm text-base-content mt-1" role="status" aria-live="polite">
           {#if spectrogramStatus.status === 'queued'}
-            <span>Queue: {spectrogramStatus.queuePosition}</span>
+            <span
+              >{t('components.audio.queuePosition', {
+                position: spectrogramStatus.queuePosition,
+              })}</span
+            >
           {:else}
-            <span>Generating...</span>
+            <span>{t('components.audio.generating')}</span>
           {/if}
         </div>
         {#if spectrogramStatus.message}
@@ -1028,10 +1050,7 @@
     {/if}
   {/if}
 
-  <!-- Audio element -->
-  <audio bind:this={audioElement} id={audioId} src={audioUrl} preload="metadata" class="hidden">
-    <track kind="captions" />
-  </audio>
+  <!-- Audio element is created dynamically in onMount for iOS Safari compatibility -->
 
   <!-- Audio settings button (top-right) -->
   {#if showControls}

--- a/frontend/src/lib/desktop/features/dashboard/components/PlayOverlay.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/components/PlayOverlay.svelte
@@ -15,16 +15,32 @@
   - onAudioContextAvailable?: (available: boolean) => void - Callback for audio context status
 -->
 <script lang="ts">
-  import { onMount, onDestroy } from 'svelte';
+  import { onMount } from 'svelte';
   import { Play, Pause, Loader2 } from '@lucide/svelte';
   import { cn } from '$lib/utils/cn';
   import { loggers } from '$lib/utils/logger';
   import { t } from '$lib/i18n';
-  import { applyPlaybackRate, dbToGain } from '$lib/utils/audio';
+  import {
+    applyPlaybackRate,
+    dbToGain,
+    PLAY_END_DELAY_MS,
+    CANPLAY_TIMEOUT_MS,
+    PROGRESS_UPDATE_INTERVAL_MS,
+  } from '$lib/utils/audio';
+  import {
+    getAudioContext,
+    isAudioContextSupported,
+    releaseAudioContext,
+  } from '$lib/utils/audioContextManager';
+  import {
+    createAudioNodeChain,
+    disconnectAudioNodes,
+    type AudioNodeChain,
+  } from '$lib/utils/audioNodes';
 
   const logger = loggers.audio;
 
-  /* global AudioContext, MediaElementAudioSourceNode, GainNode, BiquadFilterNode */
+  /* global Audio, AudioContext */
 
   interface Props {
     detectionId: number;
@@ -55,21 +71,18 @@
   let duration = $state(0);
   let currentTime = $state(0);
   let isDragging = $state(false);
+  let hasEverPlayed = $state(false);
   let playEndTimeout: ReturnType<typeof setTimeout> | undefined;
+  let canplayTimeoutId: ReturnType<typeof setTimeout> | undefined;
   let updateInterval: ReturnType<typeof setInterval> | undefined;
 
   // Web Audio API
   let audioContext: AudioContext | null = null;
   let isInitializingContext = $state(false);
-  let audioNodes = $state<{
-    source: MediaElementAudioSourceNode;
-    gain: GainNode;
-    highPass: BiquadFilterNode;
-  } | null>(null);
+  let audioNodes = $state<AudioNodeChain | null>(null);
+  // PLAY_END_DELAY_MS imported from $lib/utils/audio
 
-  const PLAY_END_DELAY_MS = 3000;
-
-  const audioUrl = $derived(`/api/v2/audio/${detectionId}`);
+  const audioUrl = $derived(`/api/v2/audio/${encodeURIComponent(detectionId)}`);
 
   // Update audio nodes when gain/filter props change
   // Read values unconditionally to ensure they're tracked as dependencies
@@ -97,6 +110,24 @@
     }
   });
 
+  // Sync audio source when URL changes (replaces template binding for iOS Safari compatibility)
+  $effect(() => {
+    if (audioElement && audioUrl) {
+      // Compare resolved URLs to avoid unnecessary reloads
+      const absoluteUrl = new URL(audioUrl, window.location.origin).href;
+      if (audioElement.src !== absoluteUrl) {
+        audioElement.src = audioUrl;
+        // Reset playback state for new audio
+        isPlaying = false;
+        currentTime = 0;
+        progress = 0;
+        duration = 0;
+        error = null;
+        hasEverPlayed = false;
+      }
+    }
+  });
+
   async function handlePlayPause(event: MouseEvent) {
     event.stopPropagation();
 
@@ -114,9 +145,12 @@
         if (!audioContext && !isInitializingContext) {
           isInitializingContext = true;
           try {
-            audioContext = await initializeAudioContext();
+            audioContext = await initializeAudioContextWrapper();
             if (audioContext && !audioNodes) {
-              audioNodes = createAudioNodes(audioContext, audioElement);
+              audioNodes = createAudioNodeChain(audioContext, audioElement, {
+                gainDb: gainValue,
+                highPassFreq: filterFreq,
+              });
             }
           } finally {
             isInitializingContext = false;
@@ -146,6 +180,7 @@
 
   function handlePlay() {
     isPlaying = true;
+    hasEverPlayed = true;
     startProgressInterval();
     clearPlayEndTimeout();
 
@@ -188,7 +223,7 @@
 
   function startProgressInterval() {
     if (updateInterval) clearInterval(updateInterval);
-    updateInterval = setInterval(updateProgress, 50); // 50ms for smooth updates
+    updateInterval = setInterval(updateProgress, PROGRESS_UPDATE_INTERVAL_MS);
   }
 
   function stopProgressInterval() {
@@ -219,13 +254,21 @@
     const newTime = clickPercent * duration;
 
     audioElement.currentTime = Math.max(0, Math.min(newTime, duration));
-    progress = clickPercent * 100;
+    progress = Math.max(0, Math.min(clickPercent * 100, 100));
   }
 
   // Handle mouse down for drag seeking
   function handleMouseDown(event: MouseEvent) {
     // Only handle left click
     if (event.button !== 0) return;
+
+    // On first interaction, treat any tap as play request instead of seek
+    // This prevents accidental repositioning when user is trying to start playback
+    // (especially important on iOS where first tap satisfies user gesture requirement)
+    if (!hasEverPlayed) {
+      handlePlayPause(event);
+      return;
+    }
 
     isDragging = true;
     handleSeek(event);
@@ -255,117 +298,113 @@
     return `${mins}:${secs.toString().padStart(2, '0')}`;
   }
 
-  async function initializeAudioContext(): Promise<AudioContext | null> {
+  async function initializeAudioContextWrapper(): Promise<AudioContext | null> {
+    if (!isAudioContextSupported()) {
+      logger.warn('Web Audio API not supported');
+      onAudioContextAvailable?.(false);
+      return null;
+    }
+
     try {
-      const AudioContextClass =
-        window.AudioContext ||
-        (window as unknown as { webkitAudioContext: typeof AudioContext }).webkitAudioContext;
-      if (!AudioContextClass) {
-        throw new Error('AudioContext not supported');
-      }
-
-      const ctx = new AudioContextClass();
-      if (ctx.state === 'suspended') {
-        await ctx.resume();
-      }
-
+      const ctx = await getAudioContext();
       onAudioContextAvailable?.(true);
       return ctx;
     } catch (err) {
-      logger.warn('Web Audio API not supported:', err);
+      logger.warn('Failed to initialize audio context:', err);
       onAudioContextAvailable?.(false);
       return null;
     }
   }
 
-  function createAudioNodes(ctx: AudioContext, audio: HTMLAudioElement) {
-    const source = ctx.createMediaElementSource(audio);
-    const gain = ctx.createGain();
-    gain.gain.value = dbToGain(gainValue);
-
-    const highPass = ctx.createBiquadFilter();
-    highPass.type = 'highpass';
-    highPass.frequency.value = filterFreq;
-    highPass.Q.value = 1;
-
-    // Connect: source -> highpass -> gain -> destination
-    source.connect(highPass).connect(gain).connect(ctx.destination);
-
-    return { source, gain, highPass };
-  }
-
   function handleLoadStart() {
-    // With preload="metadata", browser loads metadata only
     error = null;
+    // Clear any existing timeout
+    if (canplayTimeoutId) clearTimeout(canplayTimeoutId);
+    // Set safety timeout for iOS Safari canplay issue
+    canplayTimeoutId = setTimeout(() => {
+      if (isLoading) {
+        logger.warn('canplay timeout - assuming audio ready', { detectionId });
+        isLoading = false;
+      }
+    }, CANPLAY_TIMEOUT_MS);
   }
 
   function handleCanPlay() {
+    // Clear timeout since canplay fired normally
+    if (canplayTimeoutId) {
+      clearTimeout(canplayTimeoutId);
+      canplayTimeoutId = undefined;
+    }
     isLoading = false;
   }
 
   function handleError() {
+    // Clear timeout on error
+    if (canplayTimeoutId) {
+      clearTimeout(canplayTimeoutId);
+      canplayTimeoutId = undefined;
+    }
     error = t('media.audio.error');
     isLoading = false;
   }
 
   onMount(() => {
-    if (audioElement) {
-      audioElement.addEventListener('play', handlePlay);
-      audioElement.addEventListener('pause', handlePause);
-      audioElement.addEventListener('ended', handleEnded);
-      audioElement.addEventListener('timeupdate', handleTimeUpdate);
-      audioElement.addEventListener('loadedmetadata', handleLoadedMetadata);
-      audioElement.addEventListener('loadstart', handleLoadStart);
-      audioElement.addEventListener('canplay', handleCanPlay);
-      audioElement.addEventListener('error', handleError);
-    }
-  });
+    // Create audio element dynamically to avoid iOS Safari issues
+    // where DOM-bound audio elements don't fire canplay events
+    audioElement = new Audio();
+    audioElement.preload = 'metadata';
+    audioElement.src = audioUrl;
 
-  onDestroy(() => {
-    clearPlayEndTimeout();
-    stopProgressInterval();
-    // Clean up drag listeners if component unmounts while dragging
-    document.removeEventListener('mousemove', handleMouseMove);
-    document.removeEventListener('mouseup', handleMouseUp);
+    // Attach all event listeners
+    audioElement.addEventListener('play', handlePlay);
+    audioElement.addEventListener('pause', handlePause);
+    audioElement.addEventListener('ended', handleEnded);
+    audioElement.addEventListener('timeupdate', handleTimeUpdate);
+    audioElement.addEventListener('loadedmetadata', handleLoadedMetadata);
+    audioElement.addEventListener('loadstart', handleLoadStart);
+    audioElement.addEventListener('canplay', handleCanPlay);
+    audioElement.addEventListener('error', handleError);
 
-    if (audioElement) {
-      audioElement.removeEventListener('play', handlePlay);
-      audioElement.removeEventListener('pause', handlePause);
-      audioElement.removeEventListener('ended', handleEnded);
-      audioElement.removeEventListener('timeupdate', handleTimeUpdate);
-      audioElement.removeEventListener('loadedmetadata', handleLoadedMetadata);
-      audioElement.removeEventListener('loadstart', handleLoadStart);
-      audioElement.removeEventListener('canplay', handleCanPlay);
-      audioElement.removeEventListener('error', handleError);
-    }
+    // Cleanup function (Svelte 5 pattern)
+    return () => {
+      clearPlayEndTimeout();
+      stopProgressInterval();
 
-    // Clean up Web Audio API
-    if (audioNodes) {
-      try {
-        audioNodes.source.disconnect();
-        audioNodes.gain.disconnect();
-        audioNodes.highPass.disconnect();
-      } catch {
-        // Nodes may already be disconnected
+      // Clear canplay safety timeout
+      if (canplayTimeoutId) {
+        clearTimeout(canplayTimeoutId);
+        canplayTimeoutId = undefined;
       }
+
+      // Clean up drag listeners if component unmounts while dragging
+      document.removeEventListener('mousemove', handleMouseMove);
+      document.removeEventListener('mouseup', handleMouseUp);
+
+      if (audioElement) {
+        audioElement.removeEventListener('play', handlePlay);
+        audioElement.removeEventListener('pause', handlePause);
+        audioElement.removeEventListener('ended', handleEnded);
+        audioElement.removeEventListener('timeupdate', handleTimeUpdate);
+        audioElement.removeEventListener('loadedmetadata', handleLoadedMetadata);
+        audioElement.removeEventListener('loadstart', handleLoadStart);
+        audioElement.removeEventListener('canplay', handleCanPlay);
+        audioElement.removeEventListener('error', handleError);
+
+        // Stop audio playback to prevent resource leaks
+        audioElement.pause();
+        audioElement.src = '';
+      }
+
+      // Clean up Web Audio API using shared utilities
+      disconnectAudioNodes(audioNodes);
       audioNodes = null;
-    }
-
-    if (audioContext) {
-      try {
-        audioContext.close();
-      } catch {
-        // Context may already be closed
-      }
+      releaseAudioContext();
       audioContext = null;
-    }
+    };
   });
 </script>
 
-<!-- Audio element (hidden) -->
-<audio bind:this={audioElement} src={audioUrl} preload="metadata" class="hidden">
-  <track kind="captions" />
-</audio>
+<!-- Audio element is created dynamically in onMount for iOS Safari compatibility -->
 
 <!-- Seek area - covers the full card for click-to-seek -->
 <div

--- a/frontend/src/lib/utils/audio.ts
+++ b/frontend/src/lib/utils/audio.ts
@@ -2,6 +2,26 @@
  * Audio utility functions for playback control.
  */
 
+// =============================================================================
+// Timing Constants
+// =============================================================================
+
+/** Delay before signaling play end after pause/stop (prevents UI flicker) */
+export const PLAY_END_DELAY_MS = 3000;
+
+/** Safety timeout for iOS Safari canplay event fallback */
+export const CANPLAY_TIMEOUT_MS = 3000;
+
+/** Progress update interval for smooth playhead animation */
+export const PROGRESS_UPDATE_INTERVAL_MS = 50;
+
+/** Minimum width in pixels to show full audio controls */
+export const MIN_CONTROLS_WIDTH_PX = 175;
+
+// =============================================================================
+// Playback Speed
+// =============================================================================
+
 /**
  * Playback speed options available in the UI.
  * These are discrete steps chosen for accessibility:

--- a/frontend/src/lib/utils/audioContextManager.ts
+++ b/frontend/src/lib/utils/audioContextManager.ts
@@ -1,0 +1,98 @@
+/**
+ * Singleton AudioContext Manager
+ *
+ * Browsers enforce a hard limit (~6) on active AudioContext instances.
+ * This module provides a shared AudioContext for all audio components,
+ * preventing the "Maximum number of AudioContexts reached" error.
+ *
+ * Usage:
+ *   const ctx = await getAudioContext();
+ *   // Use ctx for audio processing
+ *   // Call releaseAudioContext() in onDestroy (optional, for tracking)
+ */
+
+interface WebkitWindow extends Window {
+  webkitAudioContext?: typeof AudioContext;
+}
+
+let sharedContext: AudioContext | null = null;
+
+/**
+ * Get the AudioContext constructor, accounting for vendor prefixes.
+ * Returns null if AudioContext is not supported or in SSR context.
+ */
+function getAudioContextConstructor(): typeof AudioContext | null {
+  // SSR guard - window is not available during server-side rendering
+  if (typeof window === 'undefined') {
+    return null;
+  }
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- browser compatibility check
+  if (window.AudioContext) {
+    return window.AudioContext;
+  }
+  const webkitContext = (window as WebkitWindow).webkitAudioContext;
+  if (webkitContext) {
+    return webkitContext;
+  }
+  return null;
+}
+
+/**
+ * Get the shared AudioContext instance.
+ * Creates a new context if none exists or if the previous one was closed.
+ * Automatically resumes suspended contexts (required after user gesture on mobile).
+ *
+ * @returns Promise resolving to the AudioContext
+ * @throws Error if AudioContext is not supported in this browser
+ */
+export async function getAudioContext(): Promise<AudioContext> {
+  const AudioContextClass = getAudioContextConstructor();
+
+  if (!AudioContextClass) {
+    throw new Error('AudioContext not supported in this browser');
+  }
+
+  // Create new context if none exists or previous was closed
+  if (!sharedContext || sharedContext.state === 'closed') {
+    sharedContext = new AudioContextClass();
+  }
+
+  // Resume if suspended (required for autoplay policies)
+  if (sharedContext.state === 'suspended') {
+    await sharedContext.resume();
+  }
+
+  return sharedContext;
+}
+
+/**
+ * Check if AudioContext is supported in this browser.
+ * Use this for feature detection before attempting audio playback.
+ *
+ * @returns true if AudioContext is available
+ */
+export function isAudioContextSupported(): boolean {
+  return getAudioContextConstructor() !== null;
+}
+
+/**
+ * Release reference to the shared AudioContext.
+ * Call this in onDestroy for cleanup tracking.
+ * Note: The context itself is not closed - it's reused across components.
+ */
+export function releaseAudioContext(): void {
+  // Currently a no-op, but available for future reference counting
+  // if we need to track active users and close idle contexts
+}
+
+/**
+ * Force close the shared AudioContext.
+ * Only use this for cleanup during app shutdown or testing.
+ * Normal components should use releaseAudioContext() instead.
+ */
+export async function closeAudioContext(): Promise<void> {
+  if (sharedContext && sharedContext.state !== 'closed') {
+    await sharedContext.close();
+    sharedContext = null;
+  }
+}

--- a/frontend/src/lib/utils/audioNodes.ts
+++ b/frontend/src/lib/utils/audioNodes.ts
@@ -1,0 +1,127 @@
+/**
+ * Web Audio API node chain utilities.
+ *
+ * Provides reusable audio processing node creation for consistent
+ * audio enhancement across all player components.
+ */
+
+import { dbToGain } from './audio';
+
+/**
+ * Audio processing node chain structure.
+ * Contains all nodes needed for gain control, filtering, and optional compression.
+ */
+export interface AudioNodeChain {
+  source: MediaElementAudioSourceNode;
+  gain: GainNode;
+  highPass: BiquadFilterNode;
+  compressor?: DynamicsCompressorNode;
+}
+
+/**
+ * Options for creating an audio node chain.
+ */
+export interface AudioNodeOptions {
+  /** Initial gain in decibels (default: 0) */
+  gainDb?: number;
+  /** High-pass filter cutoff frequency in Hz (default: 20) */
+  highPassFreq?: number;
+  /** Include dynamics compressor for loud audio (default: false) */
+  includeCompressor?: boolean;
+}
+
+/** Default high-pass filter frequency (20 Hz - below audible range) */
+export const DEFAULT_HIGH_PASS_FREQ = 20;
+
+/** Maximum high-pass filter frequency (10 kHz) */
+export const MAX_HIGH_PASS_FREQ = 10000;
+
+/** Maximum gain boost in decibels */
+export const MAX_GAIN_DB = 24;
+
+/**
+ * Create a complete audio processing node chain.
+ *
+ * Chain: source -> highPass -> gain -> [compressor] -> destination
+ *
+ * @param ctx - AudioContext to create nodes in
+ * @param audioElement - HTML audio element to use as source
+ * @param options - Configuration options
+ * @returns AudioNodeChain with all connected nodes
+ */
+export function createAudioNodeChain(
+  ctx: AudioContext,
+  audioElement: HTMLAudioElement,
+  options: AudioNodeOptions = {}
+): AudioNodeChain {
+  const { gainDb = 0, highPassFreq = DEFAULT_HIGH_PASS_FREQ, includeCompressor = false } = options;
+
+  // Create source from audio element
+  const source = ctx.createMediaElementSource(audioElement);
+
+  // Create gain node for volume control
+  const gain = ctx.createGain();
+  gain.gain.value = dbToGain(gainDb);
+
+  // Create high-pass filter to reduce low-frequency noise
+  const highPass = ctx.createBiquadFilter();
+  highPass.type = 'highpass';
+  highPass.frequency.value = highPassFreq;
+  highPass.Q.value = 1;
+
+  if (includeCompressor) {
+    // Create dynamics compressor for consistent volume
+    const compressor = ctx.createDynamicsCompressor();
+    compressor.threshold.value = -24;
+    compressor.knee.value = 30;
+    compressor.ratio.value = 12;
+    compressor.attack.value = 0.003;
+    compressor.release.value = 0.25;
+
+    // Connect chain with compressor
+    source.connect(highPass).connect(gain).connect(compressor).connect(ctx.destination);
+
+    return { source, gain, highPass, compressor };
+  }
+
+  // Connect chain without compressor
+  source.connect(highPass).connect(gain).connect(ctx.destination);
+
+  return { source, gain, highPass };
+}
+
+/**
+ * Safely disconnect all nodes in an audio chain.
+ * Handles cases where nodes may already be disconnected.
+ *
+ * @param nodes - AudioNodeChain to disconnect
+ */
+export function disconnectAudioNodes(nodes: AudioNodeChain | null): void {
+  if (!nodes) return;
+
+  try {
+    nodes.source.disconnect();
+  } catch {
+    // Node may already be disconnected
+  }
+
+  try {
+    nodes.gain.disconnect();
+  } catch {
+    // Node may already be disconnected
+  }
+
+  try {
+    nodes.highPass.disconnect();
+  } catch {
+    // Node may already be disconnected
+  }
+
+  if (nodes.compressor) {
+    try {
+      nodes.compressor.disconnect();
+    } catch {
+      // Node may already be disconnected
+    }
+  }
+}

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -2775,8 +2775,13 @@
   "components": {
     "audio": {
       "spectrogramUnavailable": "Spektrogramm nicht verfügbar",
+      "spectrogramLoading": "Spektrogramm wird geladen...",
+      "spectrogramLoaded": "Spektrogramm geladen",
+      "spectrogramLoadingAria": "Spektrogramm wird geladen",
+      "spectrogramGeneratingAria": "Spektrogramm wird generiert",
       "generating": "Wird generiert...",
-      "queuePosition": "Warteschlange: {position}"
+      "queuePosition": "Warteschlange: {position}",
+      "loadError": "Audio konnte nicht geladen werden"
     },
     "forms": {
       "numberField": {

--- a/frontend/static/messages/en.json
+++ b/frontend/static/messages/en.json
@@ -2765,8 +2765,13 @@
   "components": {
     "audio": {
       "spectrogramUnavailable": "Spectrogram unavailable",
+      "spectrogramLoading": "Loading spectrogram...",
+      "spectrogramLoaded": "Spectrogram loaded",
+      "spectrogramLoadingAria": "Loading spectrogram",
+      "spectrogramGeneratingAria": "Generating spectrogram",
       "generating": "Generating...",
-      "queuePosition": "Queue: {position}"
+      "queuePosition": "Queue: {position}",
+      "loadError": "Failed to load audio"
     },
     "forms": {
       "numberField": {

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -2775,8 +2775,13 @@
   "components": {
     "audio": {
       "spectrogramUnavailable": "Espectrograma no disponible",
+      "spectrogramLoading": "Cargando espectrograma...",
+      "spectrogramLoaded": "Espectrograma cargado",
+      "spectrogramLoadingAria": "Cargando espectrograma",
+      "spectrogramGeneratingAria": "Generando espectrograma",
       "generating": "Generando...",
-      "queuePosition": "Cola: {position}"
+      "queuePosition": "Cola: {position}",
+      "loadError": "Error al cargar audio"
     },
     "forms": {
       "numberField": {

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -2775,8 +2775,13 @@
   "components": {
     "audio": {
       "spectrogramUnavailable": "Spektrogrammi ei saatavilla",
+      "spectrogramLoading": "Ladataan spektrogrammia...",
+      "spectrogramLoaded": "Spektrogrammi ladattu",
+      "spectrogramLoadingAria": "Ladataan spektrogrammia",
+      "spectrogramGeneratingAria": "Luodaan spektrogrammia",
       "generating": "Luodaan...",
-      "queuePosition": "Jono: {position}"
+      "queuePosition": "Jono: {position}",
+      "loadError": "Äänitiedoston lataaminen epäonnistui"
     },
     "forms": {
       "numberField": {

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -2773,6 +2773,16 @@
     }
   },
   "components": {
+    "audio": {
+      "spectrogramUnavailable": "Spectrogramme non disponible",
+      "spectrogramLoading": "Chargement du spectrogramme...",
+      "spectrogramLoaded": "Spectrogramme chargé",
+      "spectrogramLoadingAria": "Chargement du spectrogramme",
+      "spectrogramGeneratingAria": "Génération du spectrogramme",
+      "generating": "Génération...",
+      "queuePosition": "File d'attente: {position}",
+      "loadError": "Échec du chargement audio"
+    },
     "forms": {
       "numberField": {
         "adjustedToMinimum": "Valeur ajustée au minimum ({value})",
@@ -2798,11 +2808,6 @@
       "subnet": {
         "maxSubnetsReached": "Maximum number of subnets ({max}) reached."
       }
-    },
-    "audio": {
-      "spectrogramUnavailable": "Spectrogramme non disponible",
-      "generating": "Génération en cours...",
-      "queuePosition": "File d'attente : {position}"
     },
     "datePicker": {
       "today": "Aujourd'hui",

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -2775,8 +2775,13 @@
   "components": {
     "audio": {
       "spectrogramUnavailable": "Spectrogram niet beschikbaar",
+      "spectrogramLoading": "Spectrogram laden...",
+      "spectrogramLoaded": "Spectrogram geladen",
+      "spectrogramLoadingAria": "Spectrogram laden",
+      "spectrogramGeneratingAria": "Spectrogram genereren",
       "generating": "Genereren...",
-      "queuePosition": "Wachtrij: {position}"
+      "queuePosition": "Wachtrij: {position}",
+      "loadError": "Kan audio niet laden"
     },
     "forms": {
       "numberField": {

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -2775,8 +2775,13 @@
   "components": {
     "audio": {
       "spectrogramUnavailable": "Spektrogram niedostępny",
+      "spectrogramLoading": "Ładowanie spektrogramu...",
+      "spectrogramLoaded": "Spektrogram załadowany",
+      "spectrogramLoadingAria": "Ładowanie spektrogramu",
+      "spectrogramGeneratingAria": "Generowanie spektrogramu",
       "generating": "Generowanie...",
-      "queuePosition": "Kolejka: {position}"
+      "queuePosition": "Kolejka: {position}",
+      "loadError": "Nie udało się załadować audio"
     },
     "forms": {
       "numberField": {

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -2775,8 +2775,13 @@
   "components": {
     "audio": {
       "spectrogramUnavailable": "Espectrograma não disponível",
+      "spectrogramLoading": "Carregando espectrograma...",
+      "spectrogramLoaded": "Espectrograma carregado",
+      "spectrogramLoadingAria": "Carregando espectrograma",
+      "spectrogramGeneratingAria": "Gerando espectrograma",
       "generating": "Gerando...",
-      "queuePosition": "Fila: {position}"
+      "queuePosition": "Fila: {position}",
+      "loadError": "Falha ao carregar áudio"
     },
     "forms": {
       "numberField": {


### PR DESCRIPTION
## Summary

Fixes audio playback on iOS Safari (iPhone/iPad) where the play button would appear stuck loading indefinitely.

**Root cause**: iOS Safari doesn't reliably fire `canplay` events on audio elements that are bound in the DOM template. The fix creates audio elements dynamically in `onMount` instead.

**Changes**:
- Create audio element dynamically in `onMount` instead of template binding
- Add canplay timeout fallback (3s) for iOS Safari edge cases  
- Extract shared `AudioContext` singleton manager to prevent browser limits
- Extract audio node chain utilities for consistent Web Audio API setup
- Use Svelte 5 cleanup pattern (return from `onMount`) instead of `onDestroy`
- Stop audio playback on component unmount to prevent resource leaks
- Replace magic numbers with shared constants
- Add i18n strings for audio error states

## Test Plan

- [x] Tested audio playback on iPhone (iOS Safari)
- [x] Tested audio playback on desktop browser
- [x] Verified no console errors on component mount/unmount
- [x] Lints and type checks pass

Fixes #1747

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved playback controls (responsive layout, playback-speed options) and more stable audio playback behavior
  * Spectrogram reload/retry UI and user-triggered spectrogram generation groundwork

* **Bug Fixes**
  * More reliable startup and error handling on iOS Safari and more thorough audio resource cleanup

* **Localization**
  * Added spectrogram and audio load/error ARIA and status messages in multiple languages

* **Tests**
  * Updated tests to use a mocked audio instance and validate retry/cache behavior

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->