### PR TITLE
fix(frontend): read verified status from detection.verified instead of detection.review

### DIFF
--- a/frontend/src/lib/desktop/components/modals/ReviewModal.svelte
+++ b/frontend/src/lib/desktop/components/modals/ReviewModal.svelte
@@ -37,7 +37,8 @@
   // Reset form when detection changes
   $effect(() => {
     if (detection) {
-      const verified = detection.review?.verified;
+      // Use detection.verified directly (from API response)
+      const verified = detection.verified;
       reviewStatus = verified === 'correct' || verified === 'false_positive' ? verified : 'correct';
       // Initialize lockDetection to false - user intent to lock, not current status
       lockDetection = false;

--- a/frontend/src/lib/desktop/components/modals/SpeciesBadges.svelte
+++ b/frontend/src/lib/desktop/components/modals/SpeciesBadges.svelte
@@ -87,13 +87,13 @@
 
 <div class={`flex items-center gap-2 flex-wrap ${className}`}>
   <!-- Verification Status Badge -->
-  <span class={`badge ${badgeSize} ${gapSize} ${getStatusBadgeClass(detection.review?.verified)}`}>
-    {#if detection.review?.verified === 'correct'}
+  <span class={`badge ${badgeSize} ${gapSize} ${getStatusBadgeClass(detection.verified)}`}>
+    {#if detection.verified === 'correct'}
       <CircleCheck class={iconSize} />
-    {:else if detection.review?.verified === 'false_positive'}
+    {:else if detection.verified === 'false_positive'}
       <X class={iconSize} />
     {/if}
-    {getStatusText(detection.review?.verified)}
+    {getStatusText(detection.verified)}
   </span>
 
   <!-- Lock Status Badge -->

--- a/frontend/src/lib/desktop/components/review/ReviewCard.svelte
+++ b/frontend/src/lib/desktop/components/review/ReviewCard.svelte
@@ -37,7 +37,8 @@
   // Initialize review form when detection changes
   $effect(() => {
     if (detection) {
-      const verified = detection.review?.verified;
+      // Use detection.verified directly (from API response), not detection.review?.verified
+      const verified = detection.verified;
       reviewStatus = verified === 'correct' || verified === 'false_positive' ? verified : 'correct';
       lockDetection = false;
       ignoreSpecies = false;
@@ -246,13 +247,13 @@
             <div class="flex justify-between">
               <span class="text-base-content/70">{t('common.review.form.reviewLabel')}:</span>
               <span>
-                {#if detection.review?.verified && detection.review.verified !== 'unverified'}
+                {#if detection.verified && detection.verified !== 'unverified'}
                   <span
                     class="badge badge-xs"
-                    class:badge-success={detection.review.verified === 'correct'}
-                    class:badge-error={detection.review.verified === 'false_positive'}
+                    class:badge-success={detection.verified === 'correct'}
+                    class:badge-error={detection.verified === 'false_positive'}
                   >
-                    {detection.review.verified === 'correct'
+                    {detection.verified === 'correct'
                       ? t('common.review.status.verifiedCorrect')
                       : t('common.review.status.falsePositive')}
                   </span>

--- a/frontend/src/lib/desktop/components/ui/ActionMenu.svelte
+++ b/frontend/src/lib/desktop/components/ui/ActionMenu.svelte
@@ -201,9 +201,9 @@
           <div class="flex items-center gap-2">
             <SquarePen class="size-4" />
             <span>Review detection</span>
-            {#if detection.review?.verified === 'correct'}
+            {#if detection.verified === 'correct'}
               <span class="badge badge-success badge-sm">✓</span>
-            {:else if detection.review?.verified === 'false_positive'}
+            {:else if detection.verified === 'false_positive'}
               <span class="badge badge-error badge-sm">✗</span>
             {/if}
           </div>

--- a/frontend/src/lib/desktop/components/ui/ActionMenu.test.ts
+++ b/frontend/src/lib/desktop/components/ui/ActionMenu.test.ts
@@ -274,7 +274,7 @@ describe('ActionMenu', () => {
     render(ActionMenu, {
       props: {
         detection: createMockDetection({
-          review: { verified: 'correct' },
+          verified: 'correct',
         }),
       },
     });
@@ -289,7 +289,7 @@ describe('ActionMenu', () => {
     render(ActionMenu, {
       props: {
         detection: createMockDetection({
-          review: { verified: 'false_positive' },
+          verified: 'false_positive',
         }),
       },
     });

--- a/frontend/src/lib/desktop/features/dashboard/components/CardActionMenu.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/components/CardActionMenu.svelte
@@ -168,9 +168,9 @@
         <button onclick={() => handleAction(onReview)} class="menu-item" role="menuitem">
           <SquarePen class="size-4" />
           <span>{t('dashboard.recentDetections.actions.review')}</span>
-          {#if detection.review?.verified === 'correct'}
+          {#if detection.verified === 'correct'}
             <span class="badge badge-success badge-sm">✓</span>
-          {:else if detection.review?.verified === 'false_positive'}
+          {:else if detection.verified === 'false_positive'}
             <span class="badge badge-error badge-sm">✗</span>
           {/if}
         </button>

--- a/frontend/src/lib/desktop/features/dashboard/components/SpeciesInfoBar.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/components/SpeciesInfoBar.svelte
@@ -32,13 +32,9 @@
   const detectionDateTime = $derived(getDetectionDateTime(detection.date, detection.time));
   const relativeTime = $derived(formatRelativeTime(detectionDateTime));
 
-  // Check verification status
-  const isVerified = $derived(
-    detection.verified === 'correct' || detection.review?.verified === 'correct'
-  );
-  const isFalsePositive = $derived(
-    detection.verified === 'false_positive' || detection.review?.verified === 'false_positive'
-  );
+  // Check verification status (API returns verified directly on detection)
+  const isVerified = $derived(detection.verified === 'correct');
+  const isFalsePositive = $derived(detection.verified === 'false_positive');
 
   // Thumbnail URL
   const thumbnailUrl = $derived(

--- a/frontend/src/lib/desktop/views/DetectionDetail.svelte
+++ b/frontend/src/lib/desktop/views/DetectionDetail.svelte
@@ -323,9 +323,7 @@
 
   // Handle review card completion
   function handleReviewComplete() {
-    // Switch back to overview tab after successful save
-    activeTab = 'overview';
-    // Refetch detection data to show updated status
+    // Stay on review tab - just refetch detection data to show updated status
     if (resolvedDetectionId) {
       fetchDetection();
     }

--- a/frontend/src/lib/types/detection.types.ts
+++ b/frontend/src/lib/types/detection.types.ts
@@ -31,9 +31,6 @@ export interface Detection {
   daysThisYear?: number; // Days since first this year
   daysThisSeason?: number; // Days since first this season
   currentSeason?: string; // Current season name
-  review?: {
-    verified: 'correct' | 'false_positive' | 'unverified';
-  };
 }
 
 export interface PaginatedDetectionResponse {


### PR DESCRIPTION
## Summary

- Fix review status not updating after saving a detection review
- Frontend was reading from non-existent `detection.review?.verified` instead of `detection.verified`
- Stay on Review tab after saving instead of switching to Overview

## Problem

When reviewing a detection and clicking Save, the status was not updating because:
1. The backend API returns verification status directly as `detection.verified`
2. Multiple frontend components were incorrectly reading from `detection.review?.verified`
3. This property was always `undefined` since the backend never sends a `review` object

## Changes

| File | Change |
|------|--------|
| ReviewCard.svelte | Read from `detection.verified` |
| ReviewModal.svelte | Read from `detection.verified` |
| SpeciesBadges.svelte | Read from `detection.verified` |
| ActionMenu.svelte | Read from `detection.verified` |
| CardActionMenu.svelte | Read from `detection.verified` |
| SpeciesInfoBar.svelte | Read from `detection.verified` |
| DetectionDetail.svelte | Stay on Review tab after save |
| detection.types.ts | Remove unused `review` property |
| ActionMenu.test.ts | Update tests |

## Test plan

- [x] All 1612 frontend tests pass
- [x] All linting checks pass (eslint, stylelint, svelte-check, ast-grep)
- [ ] Manual test: Navigate to detection detail, go to Review tab, save review, verify status updates
- [ ] Manual test: Verify status badge shows correctly in detection cards and action menus

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Verification status display logic has been updated for improved consistency across detection components.
  * Review tab now remains active after completing a review, keeping users on the review interface.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->