### PR TITLE
fix(processor): only add species to dynamic thresholds when learning occurs

### DIFF
--- a/internal/analysis/processor/processor.go
+++ b/internal/analysis/processor/processor.go
@@ -543,11 +543,6 @@ func (p *Processor) processResults(item birdnet.Results) []Detections {
 			continue
 		}
 
-		// Add species to dynamic thresholds if enabled and passed filters
-		if p.Settings.Realtime.DynamicThreshold.Enabled {
-			p.addSpeciesToDynamicThresholds(speciesLowercase, scientificName, baseThreshold)
-		}
-
 		// Create the detection
 		detection := p.createDetection(item, result, scientificName, commonName, speciesCode)
 		detections = append(detections, detection)


### PR DESCRIPTION
## Summary

- Fixes incorrect population of the "Learned" species list in the Dynamic Thresholds UI tab
- Species with custom thresholds and species that never exceeded the trigger threshold were incorrectly appearing in the learned list

## Problem

The `addSpeciesToDynamicThresholds` call at `processor.go:548` was adding ALL detected species to the dynamic thresholds map at Level 0, regardless of whether:
1. The species had a custom threshold (should never be dynamically adjusted)
2. The detection confidence ever exceeded the trigger threshold (no learning would occur)

This caused the "Learned" tab to show species that hadn't actually had any threshold learning applied.

## Solution

Removed the premature `addSpeciesToDynamicThresholds` call from `processResults()`. Species are now only added when `LearnFromApprovedDetection()` is called for approved high-confidence detections that:
- Exceed the configured trigger threshold
- Don't have user-configured custom thresholds

The existing test `TestLearnFromApprovedDetectionInitializesIfMissing` validates that learning works correctly without pre-populated entries.

## Test plan

- [x] All existing dynamic threshold tests pass
- [x] Tests pass with `-race` flag (no race conditions)
- [x] Linter shows 0 issues
- [x] Code review (Gemini + manual) confirmed fix is safe