### PR TITLE
fix(streams): propagate stream label updates to MQTT events without restart

### DIFF
--- a/internal/analysis/control_monitor.go
+++ b/internal/analysis/control_monitor.go
@@ -295,7 +295,8 @@ func (cm *ControlMonitor) handleReconfigureStreams() {
 		registry := myaudio.GetRegistry()
 		if registry != nil {
 			for _, stream := range settings.Realtime.RTSP.Streams {
-				if streamSource := registry.GetOrCreateSource(stream.URL, myaudio.StreamTypeToSourceType(stream.Type)); streamSource != nil {
+				// Use GetOrCreateSourceWithName to ensure DisplayName is updated when stream name changes
+				if streamSource := registry.GetOrCreateSourceWithName(stream.URL, myaudio.StreamTypeToSourceType(stream.Type), stream.Name); streamSource != nil {
 					sources = append(sources, streamSource.ID)
 				} else {
 					GetLogger().Warn("Failed to get stream source ID from registry during reconfiguration",

--- a/internal/analysis/sound_level.go
+++ b/internal/analysis/sound_level.go
@@ -658,9 +658,10 @@ func registerSoundLevelProcessorsForActiveSources(settings *conf.Settings) error
 		configuredURLs[stream.URL] = true
 		totalSources++
 
-		// Get or create the stream source in the registry
+		// Get or create the stream source in the registry with display name
+		// This ensures the stream has the correct user-friendly name for logs and MQTT
 		registry := myaudio.GetRegistry()
-		audioSource := registry.GetOrCreateSource(stream.URL, myaudio.StreamTypeToSourceType(stream.Type))
+		audioSource := registry.GetOrCreateSourceWithName(stream.URL, myaudio.StreamTypeToSourceType(stream.Type), stream.Name)
 		if audioSource == nil {
 			errs = append(errs, errors.Newf("failed to get/create stream source").
 				Component("realtime-analysis").

--- a/internal/myaudio/source_registry.go
+++ b/internal/myaudio/source_registry.go
@@ -168,6 +168,12 @@ func (r *AudioSourceRegistry) GetSourceByConnection(connectionString string) (*A
 
 // GetOrCreateSource ensures a source exists and returns it
 func (r *AudioSourceRegistry) GetOrCreateSource(connectionString string, sourceType SourceType) *AudioSource {
+	return r.GetOrCreateSourceWithName(connectionString, sourceType, "")
+}
+
+// GetOrCreateSourceWithName ensures a source exists and returns it with an optional display name
+// If the source already exists and displayName is provided, it updates the DisplayName
+func (r *AudioSourceRegistry) GetOrCreateSourceWithName(connectionString string, sourceType SourceType, displayName string) *AudioSource {
 	// Auto-detect type if unknown or if detection yields a different type
 	actualType := sourceType
 	if sourceType == SourceTypeUnknown {
@@ -181,7 +187,8 @@ func (r *AudioSourceRegistry) GetOrCreateSource(connectionString string, sourceT
 	}
 
 	source, err := r.RegisterSource(connectionString, SourceConfig{
-		Type: actualType,
+		Type:        actualType,
+		DisplayName: displayName,
 	})
 	if err != nil {
 		r.logger.Error("Failed to register source", logger.Error(err))


### PR DESCRIPTION
  ### Description

  **Problem**

  After the stream labels feature was introduced in commit 1dda15ac, changing a stream's label in the settings UI did not update MQTT event messages until the application was restarted. MQTT events continued to use the old stream name even after saving the new label.

  **Root Cause**

  When stream settings were reconfigured (via `handleReconfigureStreams()` and `initializeSoundLevelMonitoring()`), the code was calling `GetOrCreateSource()` without passing the updated stream name. This meant the `DisplayName` field in the audio source registry was never updated during runtime reconfiguration.

  The detection event creation in `processor.go` (lines 1587-1591) retrieves the `DisplayName` from the registry when building the `Note` object, which is then used for MQTT notifications. Since the registry wasn't being updated, MQTT events continued using the stale name.

  **Solution**

  1. **Added `GetOrCreateSourceWithName()` method** (`internal/myaudio/source_registry.go`)
     - New method that accepts an optional `displayName` parameter
     - Passes the display name through to `RegisterSource()` via `SourceConfig`
     - `RegisterSource()` already had logic to update `DisplayName` if provided (line 106-108)
     - Maintains backward compatibility by keeping the original `GetOrCreateSource()` as a wrapper

  2. **Updated stream reconfiguration** (`internal/analysis/control_monitor.go:298`)
     - Changed from: `GetOrCreateSource(stream.URL, ...)`
     - Changed to: `GetOrCreateSourceWithName(stream.URL, ..., stream.Name)`
     - Ensures `DisplayName` is updated when settings are saved

  3. **Updated sound level monitoring** (`internal/analysis/sound_level.go:663`)
     - Same change as above for sound level processor registration
     - Ensures consistent naming across all subsystems

  **Changes**
  - `internal/myaudio/source_registry.go`: Added `GetOrCreateSourceWithName()` method
  - `internal/analysis/control_monitor.go`: Use new method with stream name in reconfiguration
  - `internal/analysis/sound_level.go`: Use new method with stream name in sound level init
  - `internal/analysis/realtime.go`: Added clarifying comment about DisplayName usage

  **Impact**

  - ✅ Stream label changes now take effect immediately without restart
  - ✅ MQTT event messages use updated stream names in real-time
  - ✅ Logs and UI display updated names immediately
  - ✅ Backward compatible - no breaking changes
  - ✅ No database changes required (DisplayName is runtime-only)

  **Home Assistant Integration**

  When stream labels are changed (either via this fix or after restart):
  - ✅ Home Assistant discovery topics automatically use the new stream name
  - ✅ Entity IDs reflect the updated name (e.g., `sensor.birdnet_go_new_name_species`)
  - ⚠️ **Note**: Renaming a stream creates new HA entities with new IDs
    - Old entities with previous names become unavailable
    - Users should update automations/dashboards to reference new entity IDs
    - This behavior is inherent to the stream labels feature, not specific to this fix
  - ℹ️ Discovery is republished automatically on next MQTT reconnect
  - ℹ️ Can manually trigger via: `POST /api/v2/integrations/mqtt/homeassistant/discovery`

  **Testing**

  To verify the fix:
  1. Change a stream's label in the settings UI
  2. Save the settings
  3. Trigger a detection on that stream
  4. Verify MQTT messages use the new label (no restart required)

  **Related**
  - Follows up on commit 1dda15ac (feat: stream labels)
  - Fixes regression where label updates required restart to take effect


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Stream sources now support explicit, user-friendly display names, improving visibility in logs and MQTT payloads.
  * Registry updates will apply display name changes to existing sources so renamed streams show correctly.
  * Logs now include the stream name when registry operations fail, making issues easier to identify.

* **Bug Fixes**
  * Better error context when source creation fails and failed stream registrations are skipped to avoid partial processing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->