### PR TITLE
test: add pre-refactor contract tests for external APIs

### DIFF
--- a/internal/api/v2/sse_contract_test.go
+++ b/internal/api/v2/sse_contract_test.go
@@ -1,0 +1,402 @@
+// sse_contract_test.go: Tests for SSE payload backward compatibility.
+//
+// IMPORTANT: These tests verify the SSE API contract. The JSON field names tested here
+// are part of the PUBLIC API consumed by the frontend.
+//
+// DO NOT MODIFY these expected field names without:
+// 1. Updating the frontend to handle the change
+// 2. Explicit approval from maintainers
+// 3. Documentation in release notes
+//
+// Breaking changes to these field names will break the frontend silently.
+package api
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/datastore"
+	"github.com/tphakala/birdnet-go/internal/imageprovider"
+)
+
+// =============================================================================
+// SSE API CONTRACT - FIELD NAMES
+// =============================================================================
+//
+// The following field names are part of the SSE API contract consumed by the
+// frontend. Changes to these names will break the UI.
+// =============================================================================
+
+// sseContractFields defines the expected JSON field names for SSE detection events.
+var sseContractFields = struct {
+	// Note fields (embedded, PascalCase from Go default marshaling)
+	ID             string
+	SourceNode     string
+	Date           string
+	Time           string
+	BeginTime      string
+	EndTime        string
+	SpeciesCode    string
+	ScientificName string
+	CommonName     string
+	Confidence     string
+	Latitude       string
+	Longitude      string
+	Threshold      string
+	Sensitivity    string
+	ClipName       string
+	ProcessingTime string
+
+	// SSE-specific fields (explicit JSON tags, camelCase)
+	BirdImage          string
+	Timestamp          string
+	EventType          string
+	IsNewSpecies       string
+	DaysSinceFirstSeen string
+
+	// BirdImage nested fields (PascalCase from Go default)
+	BirdImageURL            string
+	BirdImageScientificName string
+	BirdImageLicenseName    string
+	BirdImageLicenseURL     string
+	BirdImageAuthorName     string
+	BirdImageAuthorURL      string
+	BirdImageCachedAt       string
+	BirdImageSourceProvider string
+}{
+	// Note fields (PascalCase - Go default marshaling)
+	ID:             "ID",
+	SourceNode:     "SourceNode",
+	Date:           "Date",
+	Time:           "Time",
+	BeginTime:      "BeginTime",
+	EndTime:        "EndTime",
+	SpeciesCode:    "SpeciesCode",
+	ScientificName: "ScientificName",
+	CommonName:     "CommonName",
+	Confidence:     "Confidence",
+	Latitude:       "Latitude",
+	Longitude:      "Longitude",
+	Threshold:      "Threshold",
+	Sensitivity:    "Sensitivity",
+	ClipName:       "ClipName",
+	ProcessingTime: "ProcessingTime",
+
+	// SSE-specific fields (camelCase via json tags)
+	BirdImage:          "birdImage",
+	Timestamp:          "timestamp",
+	EventType:          "eventType",
+	IsNewSpecies:       "isNewSpecies",
+	DaysSinceFirstSeen: "daysSinceFirstSeen",
+
+	// BirdImage nested fields (PascalCase - Go default)
+	BirdImageURL:            "URL",
+	BirdImageScientificName: "ScientificName",
+	BirdImageLicenseName:    "LicenseName",
+	BirdImageLicenseURL:     "LicenseURL",
+	BirdImageAuthorName:     "AuthorName",
+	BirdImageAuthorURL:      "AuthorURL",
+	BirdImageCachedAt:       "CachedAt",
+	BirdImageSourceProvider: "SourceProvider",
+}
+
+// createTestNoteWithAllFields creates a Note with all fields populated for contract testing.
+// Test coordinates are Helsinki, Finland (60.1699°N, 24.9384°E).
+func createTestNoteWithAllFields() datastore.Note {
+	return datastore.Note{
+		ID:             12345,
+		SourceNode:     "test-node",
+		Date:           "2024-01-15",
+		Time:           "14:30:45",
+		BeginTime:      time.Date(2024, 1, 15, 14, 30, 45, 0, time.UTC),
+		EndTime:        time.Date(2024, 1, 15, 14, 30, 48, 0, time.UTC),
+		SpeciesCode:    "gretit1",
+		ScientificName: "Parus major",
+		CommonName:     "Great Tit",
+		Confidence:     0.85,
+		Latitude:       60.1699,
+		Longitude:      24.9384,
+		Threshold:      0.7,
+		Sensitivity:    1.0,
+		ClipName:       "clip_001.wav",
+		ProcessingTime: 150 * time.Millisecond,
+	}
+}
+
+// createTestSSEDetectionData creates an SSEDetectionData with all fields populated.
+func createTestSSEDetectionData() SSEDetectionData {
+	return SSEDetectionData{
+		Note: createTestNoteWithAllFields(),
+		BirdImage: imageprovider.BirdImage{
+			URL:            "https://example.com/bird.jpg",
+			ScientificName: "Parus major",
+			LicenseName:    "CC BY-SA 4.0",
+			LicenseURL:     "https://creativecommons.org/licenses/by-sa/4.0/",
+			AuthorName:     "Test Author",
+			AuthorURL:      "https://example.com/author",
+			CachedAt:       time.Date(2024, 1, 15, 12, 0, 0, 0, time.UTC),
+			SourceProvider: "wikimedia",
+		},
+		Timestamp:          time.Date(2024, 1, 15, 14, 30, 45, 0, time.UTC),
+		EventType:          "new_detection",
+		IsNewSpecies:       true,
+		DaysSinceFirstSeen: 0,
+	}
+}
+
+// TestSSEContract_DetectionPayload_FieldNames validates that SSE detection
+// events contain the expected JSON field names that the frontend depends on.
+func TestSSEContract_DetectionPayload_FieldNames(t *testing.T) {
+	t.Parallel()
+
+	detection := createTestSSEDetectionData()
+
+	// Serialize to JSON (same as SSE does)
+	jsonBytes, err := json.Marshal(detection)
+	require.NoError(t, err, "Failed to marshal SSEDetectionData to JSON")
+
+	// Parse back to map to check field names
+	var payload map[string]any
+	err = json.Unmarshal(jsonBytes, &payload)
+	require.NoError(t, err, "Failed to unmarshal JSON to map")
+
+	// Log the actual JSON for debugging
+	t.Logf("SSE JSON payload:\n%s", string(jsonBytes))
+
+	// ==========================================================================
+	// CONTRACT ASSERTIONS - DO NOT MODIFY EXPECTED VALUES
+	// ==========================================================================
+
+	t.Run("Note fields use PascalCase", func(t *testing.T) {
+		noteFields := []string{
+			sseContractFields.ID,
+			sseContractFields.SourceNode,
+			sseContractFields.Date,
+			sseContractFields.Time,
+			sseContractFields.SpeciesCode,
+			sseContractFields.ScientificName,
+			sseContractFields.CommonName,
+			sseContractFields.Confidence,
+			sseContractFields.Latitude,
+			sseContractFields.Longitude,
+			sseContractFields.ClipName,
+		}
+
+		for _, field := range noteFields {
+			assert.Contains(t, payload, field,
+				"SSE API CONTRACT VIOLATION: Note field '%s' must be present", field)
+		}
+	})
+
+	t.Run("SSE-specific fields use camelCase", func(t *testing.T) {
+		assert.Contains(t, payload, sseContractFields.BirdImage,
+			"SSE API CONTRACT VIOLATION: birdImage field must be present")
+		assert.Contains(t, payload, sseContractFields.Timestamp,
+			"SSE API CONTRACT VIOLATION: timestamp field must be present")
+		assert.Contains(t, payload, sseContractFields.EventType,
+			"SSE API CONTRACT VIOLATION: eventType field must be present")
+	})
+
+	t.Run("BirdImage nested structure is correct", func(t *testing.T) {
+		birdImageRaw, exists := payload[sseContractFields.BirdImage]
+		require.True(t, exists, "birdImage field must be present")
+
+		birdImage, ok := birdImageRaw.(map[string]any)
+		require.True(t, ok, "birdImage must be an object")
+
+		expectedBirdImageFields := []string{
+			sseContractFields.BirdImageURL,
+			sseContractFields.BirdImageScientificName,
+			sseContractFields.BirdImageLicenseName,
+			sseContractFields.BirdImageAuthorName,
+			sseContractFields.BirdImageSourceProvider,
+		}
+
+		for _, field := range expectedBirdImageFields {
+			assert.Contains(t, birdImage, field,
+				"SSE API CONTRACT VIOLATION: BirdImage.%s field must be present", field)
+		}
+	})
+
+	t.Run("New species tracking fields are present when populated", func(t *testing.T) {
+		// isNewSpecies should be present (true in our test data)
+		assert.Contains(t, payload, sseContractFields.IsNewSpecies,
+			"SSE API CONTRACT: isNewSpecies field must be present when true")
+	})
+}
+
+// TestSSEContract_DetectionPayload_DateTimeFormat validates date/time string formats.
+func TestSSEContract_DetectionPayload_DateTimeFormat(t *testing.T) {
+	t.Parallel()
+
+	note := createTestNoteWithAllFields()
+
+	// Date should be "YYYY-MM-DD"
+	assert.Regexp(t, `^\d{4}-\d{2}-\d{2}$`, note.Date,
+		"SSE API CONTRACT: Date must be in YYYY-MM-DD format")
+
+	// Time should be "HH:MM:SS"
+	assert.Regexp(t, `^\d{2}:\d{2}:\d{2}$`, note.Time,
+		"SSE API CONTRACT: Time must be in HH:MM:SS format")
+}
+
+// TestSSEContract_FrontendAccessPaths verifies the field access paths used by the frontend.
+func TestSSEContract_FrontendAccessPaths(t *testing.T) {
+	t.Parallel()
+
+	detection := createTestSSEDetectionData()
+
+	jsonBytes, err := json.Marshal(detection)
+	require.NoError(t, err)
+
+	var payload map[string]any
+	err = json.Unmarshal(jsonBytes, &payload)
+	require.NoError(t, err)
+
+	// ==========================================================================
+	// SIMULATE FRONTEND ACCESS PATTERNS
+	// ==========================================================================
+
+	t.Run("Frontend can access detection species info", func(t *testing.T) {
+		// Frontend accesses: data.CommonName, data.ScientificName
+		commonName, exists := payload["CommonName"]
+		require.True(t, exists, "FRONTEND BROKEN: Cannot access data.CommonName")
+		assert.Equal(t, "Great Tit", commonName)
+
+		sciName, exists := payload["ScientificName"]
+		require.True(t, exists, "FRONTEND BROKEN: Cannot access data.ScientificName")
+		assert.Equal(t, "Parus major", sciName)
+	})
+
+	t.Run("Frontend can access detection confidence", func(t *testing.T) {
+		// Frontend accesses: data.Confidence
+		confidence, exists := payload["Confidence"]
+		require.True(t, exists, "FRONTEND BROKEN: Cannot access data.Confidence")
+		assert.InDelta(t, 0.85, confidence, 0.001)
+	})
+
+	t.Run("Frontend can access bird image URL", func(t *testing.T) {
+		// Frontend accesses: data.birdImage.URL
+		birdImageRaw, exists := payload["birdImage"]
+		require.True(t, exists, "FRONTEND BROKEN: Cannot access data.birdImage")
+
+		birdImage, ok := birdImageRaw.(map[string]any)
+		require.True(t, ok, "FRONTEND BROKEN: data.birdImage is not an object")
+
+		url, exists := birdImage["URL"]
+		require.True(t, exists, "FRONTEND BROKEN: Cannot access data.birdImage.URL")
+		assert.Equal(t, "https://example.com/bird.jpg", url)
+	})
+
+	t.Run("Frontend can access detection ID", func(t *testing.T) {
+		// Frontend accesses: data.ID for navigation/links
+		id, exists := payload["ID"]
+		require.True(t, exists, "FRONTEND BROKEN: Cannot access data.ID")
+		assert.InDelta(t, float64(12345), id, 0.001)
+	})
+
+	t.Run("Frontend can access event type", func(t *testing.T) {
+		// Frontend accesses: data.eventType for event handling
+		eventType, exists := payload["eventType"]
+		require.True(t, exists, "FRONTEND BROKEN: Cannot access data.eventType")
+		assert.Equal(t, "new_detection", eventType)
+	})
+}
+
+// TestSSEContract_IsNewSpeciesOmittedWhenFalse verifies omitempty behavior.
+func TestSSEContract_IsNewSpeciesOmittedWhenFalse(t *testing.T) {
+	t.Parallel()
+
+	detection := SSEDetectionData{
+		Note:               createTestNoteWithAllFields(),
+		BirdImage:          imageprovider.BirdImage{},
+		Timestamp:          time.Now(),
+		EventType:          "new_detection",
+		IsNewSpecies:       false, // Should be omitted
+		DaysSinceFirstSeen: 0,     // Should be omitted
+	}
+
+	jsonBytes, err := json.Marshal(detection)
+	require.NoError(t, err)
+
+	var payload map[string]any
+	err = json.Unmarshal(jsonBytes, &payload)
+	require.NoError(t, err)
+
+	// isNewSpecies and daysSinceFirstSeen should be omitted when zero/false (omitempty)
+	_, hasIsNewSpecies := payload["isNewSpecies"]
+	assert.False(t, hasIsNewSpecies,
+		"SSE API CONTRACT: isNewSpecies should be omitted when false (omitempty)")
+
+	_, hasDaysSinceFirstSeen := payload["daysSinceFirstSeen"]
+	assert.False(t, hasDaysSinceFirstSeen,
+		"SSE API CONTRACT: daysSinceFirstSeen should be omitted when zero (omitempty)")
+}
+
+// TestSSEContract_AllExpectedFieldsPresent is a comprehensive check that all
+// expected fields are present in the SSE payload.
+func TestSSEContract_AllExpectedFieldsPresent(t *testing.T) {
+	t.Parallel()
+
+	detection := createTestSSEDetectionData()
+
+	jsonBytes, err := json.Marshal(detection)
+	require.NoError(t, err)
+
+	var payload map[string]any
+	err = json.Unmarshal(jsonBytes, &payload)
+	require.NoError(t, err)
+
+	// ==========================================================================
+	// EXPECTED ROOT-LEVEL FIELDS
+	// ==========================================================================
+	expectedRootFields := []string{
+		// From embedded Note (PascalCase)
+		"ID", "SourceNode", "Date", "Time",
+		"SpeciesCode", "ScientificName", "CommonName", "Confidence",
+		"Latitude", "Longitude", "Threshold", "Sensitivity",
+		"ClipName", "ProcessingTime",
+		// SSE-specific (camelCase)
+		"birdImage", "timestamp", "eventType",
+	}
+
+	for _, field := range expectedRootFields {
+		assert.Contains(t, payload, field,
+			"SSE API CONTRACT: Expected field '%s' not found in JSON payload", field)
+	}
+}
+
+// TestSSEContract_NoCamelCaseConversionForNoteFields verifies that Note fields
+// retain their PascalCase naming (Go default) and haven't been accidentally
+// converted to camelCase.
+func TestSSEContract_NoCamelCaseConversionForNoteFields(t *testing.T) {
+	t.Parallel()
+
+	detection := createTestSSEDetectionData()
+
+	jsonBytes, err := json.Marshal(detection)
+	require.NoError(t, err)
+
+	jsonStr := string(jsonBytes)
+
+	// These would be wrong if someone added json tags with camelCase
+	forbiddenFields := []struct {
+		wrong   string
+		correct string
+	}{
+		{"commonName", "CommonName"},
+		{"scientificName", "ScientificName"},
+		{"clipName", "ClipName"},
+		{"sourceNode", "SourceNode"},
+		{"speciesCode", "SpeciesCode"},
+		{"processingTime", "ProcessingTime"},
+	}
+
+	for _, f := range forbiddenFields {
+		assert.NotContains(t, jsonStr, `"`+f.wrong+`":`,
+			"SSE API CONTRACT VIOLATION: Found '%s' but should be '%s'", f.wrong, f.correct)
+	}
+}

--- a/internal/birdweather/contract_test.go
+++ b/internal/birdweather/contract_test.go
@@ -1,0 +1,325 @@
+// contract_test.go: Tests for BirdWeather API field contract.
+//
+// IMPORTANT: These tests verify that the BirdWeather integration extracts
+// the correct fields from Note for API submission. They serve as regression
+// tests for the model separation refactor.
+//
+// The BirdWeather API requires specific fields in specific formats. Changes
+// to how these fields are accessed or formatted will break the integration.
+package birdweather
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/datastore"
+)
+
+// =============================================================================
+// BIRDWEATHER API CONTRACT - REQUIRED FIELDS
+// =============================================================================
+//
+// The BirdWeather API requires the following fields from Note:
+// - Date: in "YYYY-MM-DD" format
+// - Time: in "HH:MM:SS" format
+// - CommonName: bird's common name
+// - ScientificName: bird's scientific name
+// - Confidence: detection confidence (0-1)
+//
+// The Publish function combines Date and Time to create a timestamp,
+// then calls PostDetection with the extracted fields.
+// =============================================================================
+
+// createTestNote creates a Note with all BirdWeather-required fields populated.
+// Test coordinates are Helsinki, Finland (60.1699°N, 24.9384°E).
+func createTestNote() *datastore.Note {
+	return &datastore.Note{
+		ID:             12345,
+		Date:           "2024-01-15",
+		Time:           "14:30:45",
+		ScientificName: "Parus major",
+		CommonName:     "Great Tit",
+		Confidence:     0.85,
+		Latitude:       60.1699,
+		Longitude:      24.9384,
+		ClipName:       "clip_001.wav",
+	}
+}
+
+// TestBirdWeatherContract_RequiredFields verifies that the Publish method
+// can access the correct fields from Note for BirdWeather API submission.
+func TestBirdWeatherContract_RequiredFields(t *testing.T) {
+	t.Parallel()
+
+	note := createTestNote()
+
+	// ==========================================================================
+	// CONTRACT ASSERTIONS - Required fields must be accessible
+	// ==========================================================================
+
+	// Date field (used to construct timestamp)
+	assert.NotEmpty(t, note.Date,
+		"BIRDWEATHER CONTRACT: Date field must be accessible and non-empty")
+	assert.Regexp(t, `^\d{4}-\d{2}-\d{2}$`, note.Date,
+		"BIRDWEATHER CONTRACT: Date must be in YYYY-MM-DD format")
+
+	// Time field (used to construct timestamp)
+	assert.NotEmpty(t, note.Time,
+		"BIRDWEATHER CONTRACT: Time field must be accessible and non-empty")
+	assert.Regexp(t, `^\d{2}:\d{2}:\d{2}$`, note.Time,
+		"BIRDWEATHER CONTRACT: Time must be in HH:MM:SS format")
+
+	// ScientificName (required by BirdWeather API)
+	assert.NotEmpty(t, note.ScientificName,
+		"BIRDWEATHER CONTRACT: ScientificName field must be accessible and non-empty")
+
+	// CommonName (required by BirdWeather API)
+	assert.NotEmpty(t, note.CommonName,
+		"BIRDWEATHER CONTRACT: CommonName field must be accessible and non-empty")
+
+	// Confidence (required by BirdWeather API)
+	assert.Greater(t, note.Confidence, 0.0,
+		"BIRDWEATHER CONTRACT: Confidence field must be accessible and > 0")
+	assert.LessOrEqual(t, note.Confidence, 1.0,
+		"BIRDWEATHER CONTRACT: Confidence must be <= 1.0")
+}
+
+// TestBirdWeatherContract_DateTimeFormat verifies the date/time format
+// matches what BirdWeather expects.
+func TestBirdWeatherContract_DateTimeFormat(t *testing.T) {
+	t.Parallel()
+
+	note := createTestNote()
+
+	// Simulate timestamp construction as done in Publish function
+	dateTimeString := note.Date + "T" + note.Time
+
+	// Parse should succeed with this format
+	parsedTime, err := time.ParseInLocation("2006-01-02T15:04:05", dateTimeString, time.Local)
+	require.NoError(t, err,
+		"BIRDWEATHER CONTRACT: Date+Time must parse with format 2006-01-02T15:04:05")
+
+	// Verify the parsed time components
+	assert.Equal(t, 2024, parsedTime.Year())
+	assert.Equal(t, time.January, parsedTime.Month())
+	assert.Equal(t, 15, parsedTime.Day())
+	assert.Equal(t, 14, parsedTime.Hour())
+	assert.Equal(t, 30, parsedTime.Minute())
+	assert.Equal(t, 45, parsedTime.Second())
+}
+
+// TestBirdWeatherContract_TimestampFormatForAPI verifies the timestamp format
+// required by BirdWeather API.
+func TestBirdWeatherContract_TimestampFormatForAPI(t *testing.T) {
+	t.Parallel()
+
+	note := createTestNote()
+
+	// Simulate timestamp construction as done in Publish function
+	dateTimeString := note.Date + "T" + note.Time
+	parsedTime, err := time.ParseInLocation("2006-01-02T15:04:05", dateTimeString, time.Local)
+	require.NoError(t, err)
+
+	// Format for BirdWeather API (with timezone)
+	timestamp := parsedTime.Format("2006-01-02T15:04:05.000-0700")
+
+	// Verify format
+	assert.Regexp(t, `^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}[-+]\d{4}$`, timestamp,
+		"BIRDWEATHER CONTRACT: Timestamp must be in ISO 8601 format with milliseconds and timezone")
+}
+
+// TestBirdWeatherContract_ConfidenceFormatForAPI verifies confidence is formatted
+// correctly for the API.
+func TestBirdWeatherContract_ConfidenceFormatForAPI(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name       string
+		confidence float64
+		expected   string
+	}{
+		{"high_confidence", 0.95, "0.95"},
+		{"medium_confidence", 0.50, "0.50"},
+		{"low_confidence", 0.10, "0.10"},
+		{"max_confidence", 1.00, "1.00"},
+		{"min_positive", 0.01, "0.01"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Simulate confidence formatting as done in PostDetection
+			formatted := formatConfidence(tc.confidence)
+
+			assert.Equal(t, tc.expected, formatted,
+				"BIRDWEATHER CONTRACT: Confidence %.2f should format as %s", tc.confidence, tc.expected)
+		})
+	}
+}
+
+// formatConfidence formats confidence as done in PostDetection.
+func formatConfidence(confidence float64) string {
+	return fmt.Sprintf("%.2f", confidence)
+}
+
+// TestBirdWeatherContract_FieldAccessPattern verifies the exact field access
+// pattern used in the Publish function.
+func TestBirdWeatherContract_FieldAccessPattern(t *testing.T) {
+	t.Parallel()
+
+	note := createTestNote()
+
+	// These field accesses verify the exact field names used in Publish and PostDetection.
+	// Any change to Note struct field names would break these accesses and this test.
+
+	// Accessed in Publish for timestamp construction
+	assert.NotEmpty(t, note.Date, "Date field must be accessible")
+	assert.NotEmpty(t, note.Time, "Time field must be accessible")
+
+	// Accessed in PostDetection call
+	assert.NotEmpty(t, note.CommonName, "CommonName field must be accessible")
+	assert.NotEmpty(t, note.ScientificName, "ScientificName field must be accessible")
+	assert.Greater(t, note.Confidence, 0.0, "Confidence field must be accessible")
+}
+
+// TestBirdWeatherContract_SpeciesNameFormats verifies species name handling.
+func TestBirdWeatherContract_SpeciesNameFormats(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name           string
+		scientificName string
+		commonName     string
+	}{
+		{
+			name:           "simple_names",
+			scientificName: "Parus major",
+			commonName:     "Great Tit",
+		},
+		{
+			name:           "subspecies",
+			scientificName: "Motacilla alba alba",
+			commonName:     "White Wagtail",
+		},
+		{
+			name:           "with_parentheses",
+			scientificName: "Sturnus vulgaris",
+			commonName:     "Common Starling (European)",
+		},
+		{
+			name:           "with_apostrophe",
+			scientificName: "Bonasa umbellus",
+			commonName:     "Ruffed Grouse",
+		},
+		{
+			name:           "with_hyphen",
+			scientificName: "Plectrophenax nivalis",
+			commonName:     "Snow Bunting",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			note := &datastore.Note{
+				Date:           "2024-01-15",
+				Time:           "14:30:45",
+				ScientificName: tc.scientificName,
+				CommonName:     tc.commonName,
+				Confidence:     0.85,
+			}
+
+			// BirdWeather API should accept these names
+			assert.NotEmpty(t, note.ScientificName)
+			assert.NotEmpty(t, note.CommonName)
+		})
+	}
+}
+
+// TestBirdWeatherContract_EdgeCaseConfidence verifies edge case confidence values.
+func TestBirdWeatherContract_EdgeCaseConfidence(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name       string
+		confidence float64
+		valid      bool
+	}{
+		{"max_valid", 1.0, true},
+		{"high", 0.99, true},
+		{"threshold", 0.70, true},
+		{"low", 0.01, true},
+		{"zero", 0.0, false},       // Zero confidence shouldn't be sent
+		{"negative", -0.5, false},  // Invalid
+		{"over_max", 1.5, false},   // Invalid
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.valid {
+				assert.GreaterOrEqual(t, tc.confidence, 0.0)
+				assert.LessOrEqual(t, tc.confidence, 1.0)
+				assert.Greater(t, tc.confidence, 0.0,
+					"Valid confidence must be > 0 (BirdWeather doesn't accept zero confidence)")
+			} else {
+				invalid := tc.confidence <= 0.0 || tc.confidence > 1.0
+				assert.True(t, invalid,
+					"Confidence %.2f should be invalid", tc.confidence)
+			}
+		})
+	}
+}
+
+// TestBirdWeatherContract_DateFormats verifies various date formats.
+func TestBirdWeatherContract_DateFormats(t *testing.T) {
+	t.Parallel()
+
+	validDates := []string{
+		"2024-01-01", // New Year
+		"2024-12-31", // End of year
+		"2024-02-29", // Leap year
+		"2023-06-15", // Mid-year
+	}
+
+	for _, date := range validDates {
+		t.Run(date, func(t *testing.T) {
+			note := &datastore.Note{
+				Date: date,
+				Time: "12:00:00",
+			}
+
+			dateTimeString := note.Date + "T" + note.Time
+			_, err := time.ParseInLocation("2006-01-02T15:04:05", dateTimeString, time.Local)
+			assert.NoError(t, err,
+				"BIRDWEATHER CONTRACT: Date %s should be valid", date)
+		})
+	}
+}
+
+// TestBirdWeatherContract_TimeFormats verifies various time formats.
+func TestBirdWeatherContract_TimeFormats(t *testing.T) {
+	t.Parallel()
+
+	validTimes := []string{
+		"00:00:00", // Midnight
+		"23:59:59", // End of day
+		"12:00:00", // Noon
+		"06:30:15", // Morning
+		"18:45:30", // Evening
+	}
+
+	for _, timeStr := range validTimes {
+		t.Run(timeStr, func(t *testing.T) {
+			note := &datastore.Note{
+				Date: "2024-01-15",
+				Time: timeStr,
+			}
+
+			dateTimeString := note.Date + "T" + note.Time
+			_, err := time.ParseInLocation("2006-01-02T15:04:05", dateTimeString, time.Local)
+			assert.NoError(t, err,
+				"BIRDWEATHER CONTRACT: Time %s should be valid", timeStr)
+		})
+	}
+}

--- a/internal/datastore/roundtrip_test.go
+++ b/internal/datastore/roundtrip_test.go
@@ -1,0 +1,438 @@
+// roundtrip_test.go: Tests for database round-trip behavior.
+//
+// IMPORTANT: These tests verify that Note data survives database save and load
+// without modification. They serve as regression tests for the model separation
+// refactor to ensure data integrity is preserved.
+//
+// These tests use real SQLite databases (not mocks) to ensure actual persistence
+// behavior is tested.
+package datastore
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/conf"
+)
+
+// createTestSettings creates minimal settings for database tests.
+// Test coordinates are Helsinki, Finland (60.1699°N, 24.9384°E).
+func createTestSettings(t *testing.T) *conf.Settings {
+	t.Helper()
+	settings := &conf.Settings{}
+	settings.BirdNET.Latitude = 60.1699
+	settings.BirdNET.Longitude = 24.9384
+	return settings
+}
+
+// TestDatabaseContract_NoteRoundTrip verifies all Note fields survive
+// database save and load without modification.
+func TestDatabaseContract_NoteRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	settings := createTestSettings(t)
+	ds := createDatabase(t, settings)
+
+	// Create Note with all fields that are persisted
+	beginTime := time.Date(2024, 1, 15, 14, 30, 45, 0, time.UTC)
+	endTime := beginTime.Add(3 * time.Second)
+
+	original := Note{
+		SourceNode:     "test-node",
+		Date:           "2024-01-15",
+		Time:           "14:30:45",
+		BeginTime:      beginTime,
+		EndTime:        endTime,
+		SpeciesCode:    "gretit1",
+		ScientificName: "Parus major",
+		CommonName:     "Great Tit",
+		Confidence:     0.85,
+		Latitude:       60.1699,
+		Longitude:      24.9384,
+		Threshold:      0.7,
+		Sensitivity:    1.0,
+		ClipName:       "clip_001.wav",
+		ProcessingTime: 150 * time.Millisecond,
+	}
+
+	// Save
+	err := ds.Save(&original, nil)
+	require.NoError(t, err, "Failed to save Note")
+	require.NotZero(t, original.ID, "Note ID should be assigned after save")
+
+	// Load
+	loaded, err := ds.Get(fmt.Sprintf("%d", original.ID))
+	require.NoError(t, err, "Failed to load Note")
+
+	// ==========================================================================
+	// CONTRACT ASSERTIONS - All fields must round-trip correctly
+	// ==========================================================================
+
+	assert.Equal(t, original.ID, loaded.ID, "ID mismatch")
+	assert.Equal(t, original.SourceNode, loaded.SourceNode, "SourceNode mismatch")
+	assert.Equal(t, original.Date, loaded.Date, "Date mismatch")
+	assert.Equal(t, original.Time, loaded.Time, "Time mismatch")
+	assert.Equal(t, original.SpeciesCode, loaded.SpeciesCode, "SpeciesCode mismatch")
+	assert.Equal(t, original.ScientificName, loaded.ScientificName, "ScientificName mismatch")
+	assert.Equal(t, original.CommonName, loaded.CommonName, "CommonName mismatch")
+	assert.InDelta(t, original.Confidence, loaded.Confidence, 0.0001, "Confidence mismatch")
+	assert.InDelta(t, original.Latitude, loaded.Latitude, 0.0001, "Latitude mismatch")
+	assert.InDelta(t, original.Longitude, loaded.Longitude, 0.0001, "Longitude mismatch")
+	assert.InDelta(t, original.Threshold, loaded.Threshold, 0.0001, "Threshold mismatch")
+	assert.InDelta(t, original.Sensitivity, loaded.Sensitivity, 0.0001, "Sensitivity mismatch")
+	assert.Equal(t, original.ClipName, loaded.ClipName, "ClipName mismatch")
+	assert.Equal(t, original.ProcessingTime, loaded.ProcessingTime, "ProcessingTime mismatch")
+
+	// Time fields (BeginTime, EndTime) need special handling due to timezone normalization
+	assert.True(t, original.BeginTime.Equal(loaded.BeginTime),
+		"BeginTime mismatch: got %v, want %v", loaded.BeginTime, original.BeginTime)
+	assert.True(t, original.EndTime.Equal(loaded.EndTime),
+		"EndTime mismatch: got %v, want %v", loaded.EndTime, original.EndTime)
+}
+
+// TestDatabaseContract_ResultsRelationship verifies Results are saved correctly.
+// Note: Results are NOT preloaded by the Get() function in the current implementation.
+// This test verifies that Results can be saved alongside a Note.
+func TestDatabaseContract_ResultsRelationship(t *testing.T) {
+	t.Parallel()
+
+	settings := createTestSettings(t)
+	ds := createDatabase(t, settings)
+
+	// Create Note
+	note := Note{
+		SourceNode:     "test-node",
+		Date:           "2024-01-15",
+		Time:           "14:30:45",
+		ScientificName: "Parus major",
+		CommonName:     "Great Tit",
+		Confidence:     0.85,
+		ClipName:       "clip_001.wav",
+	}
+
+	// Create additional predictions (Results)
+	results := []Results{
+		{Species: "Parus major", Confidence: 0.85},
+		{Species: "Cyanistes caeruleus", Confidence: 0.65},
+		{Species: "Poecile palustris", Confidence: 0.45},
+	}
+
+	// Save note with results - this should succeed
+	err := ds.Save(&note, results)
+	require.NoError(t, err, "Failed to save Note with Results")
+
+	// Verify Note was saved
+	require.NotZero(t, note.ID, "Note ID should be assigned after save")
+
+	// Note: Results are saved in the database but Get() does not preload them.
+	// This documents current behavior - Results need separate loading if needed.
+	loaded, err := ds.Get(fmt.Sprintf("%d", note.ID))
+	require.NoError(t, err, "Failed to load Note")
+
+	// Verify the Note itself was saved correctly
+	assert.Equal(t, note.ScientificName, loaded.ScientificName)
+	assert.Equal(t, note.CommonName, loaded.CommonName)
+
+	// Document that Results are not preloaded by Get() - this is current behavior
+	// If this test fails after refactor, it means Get() behavior changed
+	assert.Nil(t, loaded.Results, "CONTRACT: Get() does not preload Results (current behavior)")
+}
+
+// TestDatabaseContract_ReviewRelationship verifies Review relationship.
+func TestDatabaseContract_ReviewRelationship(t *testing.T) {
+	t.Parallel()
+
+	settings := createTestSettings(t)
+	ds := createDatabase(t, settings)
+
+	// Create and save Note
+	note := Note{
+		SourceNode:     "test-node",
+		Date:           "2024-01-15",
+		Time:           "14:30:45",
+		ScientificName: "Parus major",
+		CommonName:     "Great Tit",
+		Confidence:     0.85,
+		ClipName:       "clip_001.wav",
+	}
+
+	err := ds.Save(&note, nil)
+	require.NoError(t, err)
+
+	// Save a review for this note
+	review := &NoteReview{
+		NoteID:   note.ID,
+		Verified: "correct",
+	}
+	err = ds.SaveNoteReview(review)
+	require.NoError(t, err, "Failed to save NoteReview")
+
+	// Load note (should include Review via preload)
+	loaded, err := ds.Get(fmt.Sprintf("%d", note.ID))
+	require.NoError(t, err)
+
+	// Verify Review relationship
+	require.NotNil(t, loaded.Review, "Review should be preloaded")
+	assert.Equal(t, "correct", loaded.Review.Verified, "Review.Verified mismatch")
+	assert.Equal(t, note.ID, loaded.Review.NoteID, "Review.NoteID should match Note ID")
+}
+
+// TestDatabaseContract_CommentsRelationship verifies Comments relationship.
+func TestDatabaseContract_CommentsRelationship(t *testing.T) {
+	t.Parallel()
+
+	settings := createTestSettings(t)
+	ds := createDatabase(t, settings)
+
+	// Create and save Note
+	note := Note{
+		SourceNode:     "test-node",
+		Date:           "2024-01-15",
+		Time:           "14:30:45",
+		ScientificName: "Parus major",
+		CommonName:     "Great Tit",
+		Confidence:     0.85,
+		ClipName:       "clip_001.wav",
+	}
+
+	err := ds.Save(&note, nil)
+	require.NoError(t, err)
+
+	// Save comments for this note
+	testComments := []string{
+		"Beautiful song pattern",
+		"Confirmed by visual observation",
+	}
+
+	for _, comment := range testComments {
+		entry := NoteComment{
+			NoteID: note.ID,
+			Entry:  comment,
+		}
+		err = ds.SaveNoteComment(&entry)
+		require.NoError(t, err, "Failed to save NoteComment")
+	}
+
+	// Load note (should include Comments via preload)
+	loaded, err := ds.Get(fmt.Sprintf("%d", note.ID))
+	require.NoError(t, err)
+
+	// Verify Comments relationship
+	// Note: Comments are ordered by created_at DESC (newest first)
+	require.Len(t, loaded.Comments, 2, "Comments count mismatch")
+
+	// Collect comment entries to verify both exist (order depends on creation time)
+	commentEntries := make(map[string]bool)
+	for _, c := range loaded.Comments {
+		commentEntries[c.Entry] = true
+	}
+
+	for _, expectedComment := range testComments {
+		assert.True(t, commentEntries[expectedComment],
+			"Expected comment not found: %s", expectedComment)
+	}
+}
+
+// TestDatabaseContract_LockRelationship verifies Lock relationship.
+func TestDatabaseContract_LockRelationship(t *testing.T) {
+	t.Parallel()
+
+	settings := createTestSettings(t)
+	ds := createDatabase(t, settings)
+
+	// Create and save Note
+	note := Note{
+		SourceNode:     "test-node",
+		Date:           "2024-01-15",
+		Time:           "14:30:45",
+		ScientificName: "Parus major",
+		CommonName:     "Great Tit",
+		Confidence:     0.85,
+		ClipName:       "clip_001.wav",
+	}
+
+	err := ds.Save(&note, nil)
+	require.NoError(t, err)
+
+	// Lock the note
+	noteIDStr := fmt.Sprintf("%d", note.ID)
+	err = ds.LockNote(noteIDStr)
+	require.NoError(t, err, "Failed to lock note")
+
+	// Load note (should include Lock via preload)
+	loaded, err := ds.Get(fmt.Sprintf("%d", note.ID))
+	require.NoError(t, err)
+
+	// Verify Lock relationship
+	require.NotNil(t, loaded.Lock, "Lock should be preloaded")
+	assert.Equal(t, note.ID, loaded.Lock.NoteID, "Lock.NoteID should match Note ID")
+	assert.True(t, loaded.Locked, "Locked virtual field should be true")
+
+	// Unlock and verify
+	err = ds.UnlockNote(noteIDStr)
+	require.NoError(t, err, "Failed to unlock note")
+
+	loadedUnlocked, err := ds.Get(fmt.Sprintf("%d", note.ID))
+	require.NoError(t, err)
+	assert.Nil(t, loadedUnlocked.Lock, "Lock should be nil after unlock")
+	assert.False(t, loadedUnlocked.Locked, "Locked virtual field should be false")
+}
+
+// TestDatabaseContract_EmptyResults verifies behavior when no Results are saved.
+func TestDatabaseContract_EmptyResults(t *testing.T) {
+	t.Parallel()
+
+	settings := createTestSettings(t)
+	ds := createDatabase(t, settings)
+
+	// Create and save Note without Results
+	note := Note{
+		SourceNode:     "test-node",
+		Date:           "2024-01-15",
+		Time:           "14:30:45",
+		ScientificName: "Parus major",
+		CommonName:     "Great Tit",
+		Confidence:     0.85,
+		ClipName:       "clip_001.wav",
+	}
+
+	err := ds.Save(&note, nil)
+	require.NoError(t, err)
+
+	// Load note
+	loaded, err := ds.Get(fmt.Sprintf("%d", note.ID))
+	require.NoError(t, err)
+
+	// Note: Get() does not preload Results, so it will be nil
+	// This documents current behavior
+	assert.Nil(t, loaded.Results, "CONTRACT: Results is nil when Get() doesn't preload them")
+}
+
+// TestDatabaseContract_SpecialCharacters verifies that special characters in
+// string fields are handled correctly.
+func TestDatabaseContract_SpecialCharacters(t *testing.T) {
+	t.Parallel()
+
+	settings := createTestSettings(t)
+	ds := createDatabase(t, settings)
+
+	// Test with special characters that might cause issues
+	note := Note{
+		SourceNode:     "node with spaces & special 'chars'",
+		Date:           "2024-01-15",
+		Time:           "14:30:45",
+		ScientificName: "Motacilla alba alba", // Subspecies notation
+		CommonName:     "White Wagtail (European)",
+		Confidence:     0.85,
+		ClipName:       "clip with spaces & symbols!.wav",
+	}
+
+	err := ds.Save(&note, nil)
+	require.NoError(t, err)
+
+	loaded, err := ds.Get(fmt.Sprintf("%d", note.ID))
+	require.NoError(t, err)
+
+	assert.Equal(t, note.SourceNode, loaded.SourceNode)
+	assert.Equal(t, note.ScientificName, loaded.ScientificName)
+	assert.Equal(t, note.CommonName, loaded.CommonName)
+	assert.Equal(t, note.ClipName, loaded.ClipName)
+}
+
+// TestDatabaseContract_UnicodeCharacters verifies that unicode characters are
+// handled correctly (important for species names in different languages).
+func TestDatabaseContract_UnicodeCharacters(t *testing.T) {
+	t.Parallel()
+
+	settings := createTestSettings(t)
+	ds := createDatabase(t, settings)
+
+	note := Note{
+		SourceNode:     "北京鸟巢", // Chinese: Beijing Bird Nest
+		Date:           "2024-01-15",
+		Time:           "14:30:45",
+		ScientificName: "Parus major",
+		CommonName:     "Talitiainen", // Finnish name
+		Confidence:     0.85,
+		ClipName:       "havainto_päivä.wav", // Finnish with special chars
+	}
+
+	err := ds.Save(&note, nil)
+	require.NoError(t, err)
+
+	loaded, err := ds.Get(fmt.Sprintf("%d", note.ID))
+	require.NoError(t, err)
+
+	assert.Equal(t, note.SourceNode, loaded.SourceNode)
+	assert.Equal(t, note.CommonName, loaded.CommonName)
+	assert.Equal(t, note.ClipName, loaded.ClipName)
+}
+
+// TestDatabaseContract_ZeroValues verifies handling of zero/empty values.
+func TestDatabaseContract_ZeroValues(t *testing.T) {
+	t.Parallel()
+
+	settings := createTestSettings(t)
+	ds := createDatabase(t, settings)
+
+	// Create Note with minimal required fields, zeros for everything else
+	note := Note{
+		Date:           "2024-01-15",
+		Time:           "00:00:00",
+		ScientificName: "Parus major",
+		CommonName:     "Great Tit",
+		Confidence:     0.0, // Zero confidence
+		Latitude:       0.0, // Equator
+		Longitude:      0.0, // Prime meridian
+		Threshold:      0.0,
+		Sensitivity:    0.0,
+	}
+
+	err := ds.Save(&note, nil)
+	require.NoError(t, err)
+
+	loaded, err := ds.Get(fmt.Sprintf("%d", note.ID))
+	require.NoError(t, err)
+
+	// Zero values should be preserved, not converted to defaults
+	assert.InDelta(t, 0.0, loaded.Confidence, 0.0001, "Zero Confidence should be preserved")
+	assert.InDelta(t, 0.0, loaded.Latitude, 0.0001, "Zero Latitude should be preserved")
+	assert.InDelta(t, 0.0, loaded.Longitude, 0.0001, "Zero Longitude should be preserved")
+	assert.Equal(t, "00:00:00", loaded.Time, "Midnight Time should be preserved")
+}
+
+// TestDatabaseContract_MaxValues verifies handling of extreme values.
+func TestDatabaseContract_MaxValues(t *testing.T) {
+	t.Parallel()
+
+	settings := createTestSettings(t)
+	ds := createDatabase(t, settings)
+
+	note := Note{
+		Date:           "2024-01-15",
+		Time:           "23:59:59",
+		ScientificName: "Parus major",
+		CommonName:     "Great Tit",
+		Confidence:     1.0,   // Max confidence
+		Latitude:       90.0,  // North pole
+		Longitude:      180.0, // International date line
+		Threshold:      1.0,
+		Sensitivity:    3.0,   // Max sensitivity
+		ProcessingTime: 10 * time.Second,
+	}
+
+	err := ds.Save(&note, nil)
+	require.NoError(t, err)
+
+	loaded, err := ds.Get(fmt.Sprintf("%d", note.ID))
+	require.NoError(t, err)
+
+	assert.InDelta(t, 1.0, loaded.Confidence, 0.0001)
+	assert.InDelta(t, 90.0, loaded.Latitude, 0.0001)
+	assert.InDelta(t, 180.0, loaded.Longitude, 0.0001)
+	assert.Equal(t, "23:59:59", loaded.Time)
+	assert.Equal(t, 10*time.Second, loaded.ProcessingTime)
+}


### PR DESCRIPTION
## Summary
- Add SSE payload contract tests to verify JSON field names consumed by frontend
- Add database round-trip tests to verify Note data survives save/load cycles
- Add BirdWeather field contract tests to verify API field requirements

These tests serve as regression tests before the model separation refactor, ensuring external API contracts are maintained.

## Test Coverage
- **SSE**: 6 tests validating JSON field naming (PascalCase for Note, camelCase for SSE-specific)
- **Database**: 10 tests for round-trip behavior including relationships, unicode, edge cases
- **BirdWeather**: 9 tests for date/time formats, confidence formatting, field access patterns

## Test plan
- [x] All 25 tests pass with race detection: `go test -race -v ./internal/birdweather/... ./internal/datastore/... ./internal/api/v2/... -run "Contract"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests
* Added regression test suites validating API data contracts including field naming conventions, data formats (dates, times, confidence values), and JSON structure expectations.
* Added database persistence tests verifying complete data integrity across save/load cycles, including relationships, special characters, unicode content, and boundary values.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->