### PR TITLE
refactor(processor): migrate Note field consumers to detection.Result (#1842)

### DIFF
--- a/internal/analysis/processor/execute_internal_test.go
+++ b/internal/analysis/processor/execute_internal_test.go
@@ -42,7 +42,6 @@ func createTestDetections(commonName string) Detections {
 		Result: detection.Result{
 			Species: detection.Species{CommonName: commonName},
 		},
-		Note: datastore.Note{CommonName: commonName},
 	}
 }
 
@@ -643,7 +642,6 @@ func TestParseCommandParams_EmptyParams(t *testing.T) {
 		Result: detection.Result{
 			Species: detection.Species{CommonName: "Test Bird"},
 		},
-		Note: datastore.Note{CommonName: "Test Bird"},
 	}
 
 	result := parseCommandParams([]string{}, det)
@@ -657,7 +655,6 @@ func TestParseCommandParams_NilParams(t *testing.T) {
 		Result: detection.Result{
 			Species: detection.Species{CommonName: "Test Bird"},
 		},
-		Note: datastore.Note{CommonName: "Test Bird"},
 	}
 
 	result := parseCommandParams(nil, det)
@@ -675,11 +672,6 @@ func TestParseCommandParams_ExtractsNoteFields(t *testing.T) {
 				ScientificName: "Turdus migratorius",
 			},
 		},
-		Note: datastore.Note{
-			CommonName:     "American Robin",
-			ScientificName: "Turdus migratorius",
-			Date:           "2024-01-15",
-		},
 	}
 
 	params := []string{"CommonName", "ScientificName", "Date"}
@@ -696,10 +688,6 @@ func TestParseCommandParams_ConfidenceNormalization(t *testing.T) {
 	det := &Detections{
 		Result: detection.Result{
 			Species:    detection.Species{CommonName: "Test Bird"},
-			Confidence: 0.95, // Stored as 0-1
-		},
-		Note: datastore.Note{
-			CommonName: "Test Bird",
 			Confidence: 0.95, // Stored as 0-1
 		},
 	}
@@ -721,7 +709,6 @@ func TestParseCommandParams_NonExistentField(t *testing.T) {
 		Result: detection.Result{
 			Species: detection.Species{CommonName: "Test Bird"},
 		},
-		Note: datastore.Note{CommonName: "Test Bird"},
 	}
 
 	params := []string{"NonExistentField"}
@@ -764,7 +751,6 @@ func TestExecuteCommandAction_InvalidCommand(t *testing.T) {
 		Result: detection.Result{
 			Species: detection.Species{CommonName: "Test Bird"},
 		},
-		Note: datastore.Note{CommonName: "Test Bird"},
 	}
 
 	err := action.Execute(det)
@@ -814,7 +800,6 @@ func TestExecuteCommandAction_ScriptFailure(t *testing.T) {
 		Result: detection.Result{
 			Species: detection.Species{CommonName: "Test Bird"},
 		},
-		Note: datastore.Note{CommonName: "Test Bird"},
 	}
 
 	err = action.Execute(det)
@@ -859,7 +844,6 @@ func TestExecuteCommandAction_Timeout(t *testing.T) {
 		Result: detection.Result{
 			Species: detection.Species{CommonName: "Test Bird"},
 		},
-		Note: datastore.Note{CommonName: "Test Bird"},
 	}
 
 	// Use a 1 second timeout - short enough to test timeout but long enough
@@ -914,7 +898,6 @@ func TestExecuteCommandAction_WithParameters(t *testing.T) {
 		Result: detection.Result{
 			Species: detection.Species{CommonName: "Test Bird"},
 		},
-		Note: datastore.Note{CommonName: "Test Bird"},
 	}
 
 	err = action.Execute(det)
@@ -976,7 +959,6 @@ func TestExecuteCommandAction_CommandInjectionPrevention(t *testing.T) {
 				Result: detection.Result{
 					Species: detection.Species{CommonName: "Test Bird"},
 				},
-				Note: datastore.Note{CommonName: "Test Bird"},
 			}
 
 			_ = action.Execute(det)
@@ -1044,7 +1026,6 @@ func TestExecuteCommandAction_UnicodeInParameters(t *testing.T) {
 		Result: detection.Result{
 			Species: detection.Species{CommonName: "Test Bird"},
 		},
-		Note: datastore.Note{CommonName: "Test Bird"},
 	}
 
 	err = action.Execute(det)
@@ -1054,7 +1035,7 @@ func TestExecuteCommandAction_UnicodeInParameters(t *testing.T) {
 	output, err := os.ReadFile(outputPath) //nolint:gosec // test file path is controlled
 	require.NoError(t, err)
 	assert.Contains(t, string(output), "Sparrow")
-	// Note: shell may handle emoji differently, just verify the script ran
+	// The shell may handle emoji differently, just verify the script ran
 }
 
 func TestExecuteCommandAction_LargeOutput(t *testing.T) {
@@ -1116,7 +1097,6 @@ func TestExecuteCommandAction_EnvironmentIsolation(t *testing.T) {
 		Result: detection.Result{
 			Species: detection.Species{CommonName: "Test Bird"},
 		},
-		Note: datastore.Note{CommonName: "Test Bird"},
 	}
 
 	err = action.Execute(det)

--- a/internal/analysis/processor/mqtt_occurrence_test.go
+++ b/internal/analysis/processor/mqtt_occurrence_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/analysis/jobqueue"
 	"github.com/tphakala/birdnet-go/internal/conf"
-	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/detection"
 	"github.com/tphakala/birdnet-go/internal/mqtt"
 )
@@ -80,18 +79,6 @@ func TestMqttAction_IncludesOccurrence(t *testing.T) {
 		},
 	}
 
-	// Legacy Note kept for backward compatibility during transition
-	testNote := datastore.Note{
-		CommonName:     "American Robin",
-		ScientificName: "Turdus migratorius",
-		Confidence:     0.95,
-		ClipName:       "test_clip.wav",
-		Date:           "2024-01-15",
-		Time:           "12:00:00",
-		Occurrence:     0.75,
-		Source:         testAudioSource(),
-	}
-
 	// Create mock MQTT client to capture published data
 	mockClient := &MockMqttClientWithCapture{
 		Connected: true,
@@ -124,7 +111,6 @@ func TestMqttAction_IncludesOccurrence(t *testing.T) {
 	action := &MqttAction{
 		Settings:       settings,
 		Result:         testResult, // Domain model (single source of truth)
-		Note:           testNote,   // Deprecated: kept temporarily
 		BirdImageCache: nil,        // No image cache for this test
 		MqttClient:     mockClient,
 		EventTracker:   eventTracker,
@@ -180,18 +166,6 @@ func TestMqttAction_OmitsOccurrenceWhenZero(t *testing.T) {
 		},
 	}
 
-	// Legacy Note kept for backward compatibility during transition
-	testNote := datastore.Note{
-		CommonName:     "House Sparrow",
-		ScientificName: "Passer domesticus",
-		Confidence:     0.85,
-		ClipName:       "test_clip2.wav",
-		Date:           "2024-01-15",
-		Time:           "14:00:00",
-		Occurrence:     0.0,
-		Source:         testAudioSource(),
-	}
-
 	// Create mock MQTT client to capture published data
 	mockClient := &MockMqttClientWithCapture{
 		Connected: true,
@@ -224,7 +198,6 @@ func TestMqttAction_OmitsOccurrenceWhenZero(t *testing.T) {
 	action := &MqttAction{
 		Settings:       settings,
 		Result:         testResult, // Domain model (single source of truth)
-		Note:           testNote,   // Deprecated: kept temporarily
 		BirdImageCache: nil,
 		MqttClient:     mockClient,
 		EventTracker:   eventTracker,

--- a/internal/analysis/processor/notification_timing_test.go
+++ b/internal/analysis/processor/notification_timing_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/datastore/mocks"
+	"github.com/tphakala/birdnet-go/internal/detection"
 )
 
 // setupMockDatastore creates a mock datastore with standard expectations for species tracker tests.
@@ -143,16 +144,19 @@ func TestNotificationTiming_BeginTimeUsed(t *testing.T) {
 	require.NotNil(t, tracker)
 	require.NoError(t, tracker.InitFromDatabase())
 
-	// Create a note with BeginTime set to a specific time
+	// Create a Result with BeginTime set to a specific time
 	// This simulates the detection time being different from processing time
 	beginTime := time.Date(2025, 6, 15, 14, 30, 0, 0, time.UTC)
 
-	note := datastore.Note{
-		CommonName:     "Great Tit",
-		ScientificName: "Parus major",
-		Confidence:     0.85,
-		BeginTime:      beginTime,
-		Source: datastore.AudioSource{
+	testResult := detection.Result{
+		Timestamp: beginTime,
+		BeginTime: beginTime,
+		Species: detection.Species{
+			CommonName:     "Great Tit",
+			ScientificName: "Parus major",
+		},
+		Confidence: 0.85,
+		AudioSource: detection.AudioSource{
 			ID:          "test-source",
 			SafeString:  "test-source",
 			DisplayName: "Test Source",
@@ -174,8 +178,8 @@ func TestNotificationTiming_BeginTimeUsed(t *testing.T) {
 			},
 		},
 		Ds:                mockDS,
-		Note:              note,
-		Results:           []datastore.Results{},
+		Result:            testResult,
+		Results:           nil, // No secondary predictions needed for this test
 		EventTracker:      eventTracker,
 		NewSpeciesTracker: tracker,
 		Description:       "Test Database Action",

--- a/internal/analysis/processor/test_helpers_test.go
+++ b/internal/analysis/processor/test_helpers_test.go
@@ -54,17 +54,6 @@ func testDetection() Detections {
 		Results: []detection.AdditionalResult{
 			{Species: detection.Species{ScientificName: "Testus birdus", CommonName: "Test Bird"}, Confidence: 0.95},
 		},
-		// Legacy Note kept for backward compatibility during transition
-		Note: datastore.Note{
-			CommonName:     "Test Bird",
-			ScientificName: "Testus birdus",
-			Confidence:     0.95,
-			Source:         testAudioSource(),
-			Date:           now.Format("2006-01-02"),
-			Time:           now.Format("15:04:05"),
-			BeginTime:      now,
-			EndTime:        now.Add(15 * time.Second),
-		},
 	}
 }
 
@@ -96,17 +85,6 @@ func testDetectionWithSpecies(commonName, scientificName string, confidence floa
 		},
 		Results: []detection.AdditionalResult{
 			{Species: detection.Species{ScientificName: scientificName, CommonName: commonName}, Confidence: confidence},
-		},
-		// Legacy Note kept for backward compatibility during transition
-		Note: datastore.Note{
-			CommonName:     commonName,
-			ScientificName: scientificName,
-			Confidence:     confidence,
-			Source:         testAudioSource(),
-			Date:           now.Format("2006-01-02"),
-			Time:           now.Format("15:04:05"),
-			BeginTime:      now,
-			EndTime:        now.Add(15 * time.Second),
 		},
 	}
 }

--- a/internal/analysis/processor/workers_test.go
+++ b/internal/analysis/processor/workers_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/analysis/jobqueue"
 	"github.com/tphakala/birdnet-go/internal/conf"
-	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/detection"
 	"github.com/tphakala/birdnet-go/internal/privacy"
 )
@@ -326,14 +325,6 @@ func TestEnqueueTask(t *testing.T) {
 							BeginTime:   now,
 							EndTime:     now.Add(15 * time.Second),
 						},
-						Note: datastore.Note{
-							CommonName:     "Test Bird",
-							ScientificName: "Testus birdus",
-							Confidence:     0.95,
-							Source:         testAudioSource(),
-							BeginTime:      now,
-							EndTime:        now.Add(15 * time.Second),
-						},
 					},
 					Action: tc.action,
 				}
@@ -375,14 +366,6 @@ func TestEnqueueTask(t *testing.T) {
 					AudioSource: detection.AudioSource{ID: "test-source", SafeString: "test-source", DisplayName: "test-source"},
 					BeginTime:   now,
 					EndTime:     now.Add(15 * time.Second),
-				},
-				Note: datastore.Note{
-					CommonName:     "Test Bird",
-					ScientificName: "Testus birdus",
-					Confidence:     0.95,
-					Source:         testAudioSource(),
-					BeginTime:      now,
-					EndTime:        now.Add(15 * time.Second),
 				},
 			},
 			Action: &MockAction{},
@@ -427,14 +410,6 @@ func TestEnqueueTask(t *testing.T) {
 						AudioSource: detection.AudioSource{ID: "test-source", SafeString: "test-source", DisplayName: "test-source"},
 						BeginTime:   now,
 						EndTime:     now.Add(15 * time.Second),
-					},
-					Note: datastore.Note{
-						CommonName:     fmt.Sprintf("Test Bird %d", i),
-						ScientificName: "Testus birdus",
-						Confidence:     0.95,
-						Source:         testAudioSource(),
-						BeginTime:      now,
-						EndTime:        now.Add(15 * time.Second),
 					},
 				},
 				Action: &MockAction{
@@ -497,14 +472,6 @@ func TestEnqueueTask(t *testing.T) {
 				},
 				Confidence: 0.95,
 				Model:      detection.DefaultModelInfo(),
-			},
-			Note: datastore.Note{
-				CommonName:     "Test Bird",
-				ScientificName: "Testus birdus",
-				Confidence:     0.95,
-				Source:         testAudioSource(),
-				BeginTime:      now,
-				EndTime:        now.Add(15 * time.Second),
 			},
 		}
 
@@ -662,14 +629,6 @@ func TestEnqueueMultipleTasks(t *testing.T) {
 						BeginTime:   now,
 						EndTime:     now.Add(15 * time.Second),
 					},
-					Note: datastore.Note{
-						CommonName:     b.CommonName,
-						ScientificName: b.ScientificName,
-						Confidence:     b.Confidence,
-						Source:         testAudioSource(),
-						BeginTime:      now,
-						EndTime:        now.Add(15 * time.Second),
-					},
 				},
 				Action: &MockAction{},
 			}
@@ -763,14 +722,6 @@ func TestIntegrationWithJobQueue(t *testing.T) {
 				BeginTime:   now,
 				EndTime:     now.Add(15 * time.Second),
 			},
-			Note: datastore.Note{
-				CommonName:     "Test Bird",
-				ScientificName: "Testus birdus",
-				Confidence:     0.95,
-				Source:         testAudioSource(),
-				BeginTime:      now,
-				EndTime:        now.Add(15 * time.Second),
-			},
 		},
 		Action: mockAction,
 	}
@@ -822,14 +773,6 @@ func TestIntegrationWithJobQueue(t *testing.T) {
 				AudioSource: detection.AudioSource{ID: "test-source", SafeString: "test-source", DisplayName: "Test Source"},
 				BeginTime:   failNow,
 				EndTime:     failNow.Add(15 * time.Second),
-			},
-			Note: datastore.Note{
-				CommonName:     "Failing Bird",
-				ScientificName: "Failurus maximus",
-				Confidence:     0.90,
-				Source:         testAudioSource(),
-				BeginTime:      failNow,
-				EndTime:        failNow.Add(15 * time.Second),
 			},
 		},
 		Action: failingAction,
@@ -948,14 +891,6 @@ func TestRetryLogic(t *testing.T) {
 				BeginTime:   retryNow,
 				EndTime:     retryNow.Add(15 * time.Second),
 			},
-			Note: datastore.Note{
-				CommonName:     "Retry Bird",
-				ScientificName: "Retryus maximus",
-				Confidence:     0.95,
-				Source:         testAudioSource(),
-				BeginTime:      retryNow,
-				EndTime:        retryNow.Add(15 * time.Second),
-			},
 		},
 		Action: mockAction,
 	}
@@ -1057,14 +992,6 @@ func TestRetryLogic(t *testing.T) {
 				AudioSource: detection.AudioSource{ID: "test-source", SafeString: "test-source", DisplayName: "Test Source"},
 				BeginTime:   exhaustNow,
 				EndTime:     exhaustNow.Add(15 * time.Second),
-			},
-			Note: datastore.Note{
-				CommonName:     "Exhausting Bird",
-				ScientificName: "Exhaustus maximus",
-				Confidence:     0.90,
-				Source:         testAudioSource(),
-				BeginTime:      exhaustNow,
-				EndTime:        exhaustNow.Add(15 * time.Second),
 			},
 		},
 		Action: exhaustingAction,

--- a/internal/datastore/interfaces.go
+++ b/internal/datastore/interfaces.go
@@ -2171,7 +2171,9 @@ func (ds *DataStore) cacheSunTimes(dateStr string, sunTimes *suncalc.SunEventTim
 
 // saveNoteInTransaction saves a note within a transaction
 func (ds *DataStore) saveNoteInTransaction(tx *gorm.DB, note *Note, txID string, attempt int, txLogger logger.Logger) error {
-	if err := tx.Create(note).Error; err != nil {
+	// Omit Results to prevent GORM auto-save of associations.
+	// Results are saved separately in saveResultsInTransaction for explicit error handling.
+	if err := tx.Omit("Results").Create(note).Error; err != nil {
 		enhancedErr := errors.New(err).
 			Component("datastore").
 			Category(errors.CategoryDatabase).

--- a/internal/datastore/note_conversion_test.go
+++ b/internal/datastore/note_conversion_test.go
@@ -54,14 +54,14 @@ func TestNoteFromResult(t *testing.T) {
 	assert.Equal(t, "amerob", note.SpeciesCode)
 	assert.Equal(t, "Turdus migratorius", note.ScientificName)
 	assert.Equal(t, "American Robin", note.CommonName)
-	assert.Equal(t, 0.95, note.Confidence)
-	assert.Equal(t, 42.0, note.Latitude)
-	assert.Equal(t, -71.0, note.Longitude)
-	assert.Equal(t, 0.8, note.Threshold)
-	assert.Equal(t, 1.0, note.Sensitivity)
+	assert.InDelta(t, 0.95, note.Confidence, 0.001)
+	assert.InDelta(t, 42.0, note.Latitude, 0.001)
+	assert.InDelta(t, -71.0, note.Longitude, 0.001)
+	assert.InDelta(t, 0.8, note.Threshold, 0.001)
+	assert.InDelta(t, 1.0, note.Sensitivity, 0.001)
 	assert.Equal(t, "test.wav", note.ClipName)
 	assert.Equal(t, 100*time.Millisecond, note.ProcessingTime)
-	assert.Equal(t, 0.85, note.Occurrence)
+	assert.InDelta(t, 0.85, note.Occurrence, 0.001)
 	assert.Equal(t, "correct", note.Verified)
 	assert.True(t, note.Locked)
 }
@@ -74,11 +74,11 @@ func TestNoteFromResult_ZeroValues(t *testing.T) {
 	note := datastore.NoteFromResult(&result)
 
 	assert.Equal(t, uint(0), note.ID)
-	assert.Equal(t, "", note.SourceNode)
+	assert.Empty(t, note.SourceNode)
 	assert.Equal(t, "2024-01-01", note.Date)
 	assert.Equal(t, "00:00:00", note.Time)
-	assert.Equal(t, "", note.CommonName)
-	assert.Equal(t, 0.0, note.Confidence)
+	assert.Empty(t, note.CommonName)
+	assert.InDelta(t, 0.0, note.Confidence, 0.001)
 }
 
 func TestAdditionalResultsToDatastoreResults(t *testing.T) {
@@ -105,7 +105,7 @@ func TestAdditionalResultsToDatastoreResults(t *testing.T) {
 
 		require.Len(t, result, 1)
 		assert.Equal(t, "Turdus merula_Common Blackbird", result[0].Species)
-		assert.Equal(t, float32(0.85), result[0].Confidence)
+		assert.InDelta(t, float32(0.85), result[0].Confidence, 0.001)
 	})
 
 	t.Run("converts results with species code", func(t *testing.T) {
@@ -124,7 +124,7 @@ func TestAdditionalResultsToDatastoreResults(t *testing.T) {
 
 		require.Len(t, result, 1)
 		assert.Equal(t, "Turdus migratorius_American Robin_amerob", result[0].Species)
-		assert.Equal(t, float32(0.92), result[0].Confidence)
+		assert.InDelta(t, float32(0.92), result[0].Confidence, 0.001)
 	})
 
 	t.Run("converts multiple results", func(t *testing.T) {
@@ -150,8 +150,8 @@ func TestAdditionalResultsToDatastoreResults(t *testing.T) {
 
 		require.Len(t, result, 2)
 		assert.Equal(t, "Turdus merula_Common Blackbird", result[0].Species)
-		assert.Equal(t, float32(0.85), result[0].Confidence)
+		assert.InDelta(t, float32(0.85), result[0].Confidence, 0.001)
 		assert.Equal(t, "Turdus philomelos_Song Thrush_sonthr", result[1].Species)
-		assert.Equal(t, float32(0.75), result[1].Confidence)
+		assert.InDelta(t, float32(0.75), result[1].Confidence, 0.001)
 	})
 }


### PR DESCRIPTION
## Summary

Phase 2 of the Note→Result migration (issue #1842). This refactors action structs to use `detection.Result` as the single source of truth instead of `datastore.Note`.

**Key changes:**
- Add `NoteFromResult()` conversion function for action structs that need legacy Note format
- Migrate all action structs (DatabaseAction, MqttAction, SSEAction, BirdWeatherAction, SaveAudioAction, LogAction) to use `Result` field
- Fix GORM auto-save bug that caused `UNIQUE constraint failed: results.id` errors
- Remove ~140 lines of deprecated polling code (`waitForDatabaseID`, `findNoteInDatabase`)
- Remove duplicate `convertToLegacyResults()` function

**GORM fix:** Added `Omit("Results")` in `saveNoteInTransaction` to prevent GORM from auto-saving the Results association, which was causing duplicate insertions when `saveResultsInTransaction` ran.

## Test plan

- [x] `go test -race ./internal/analysis/processor/...` passes
- [x] `go test -race ./internal/datastore/...` passes (excluding pre-existing TestNightFilter failure)
- [x] `golangci-lint run ./internal/analysis/processor/... ./internal/datastore/...` returns 0 issues
- [x] No functional changes to MQTT/SSE payloads
- [x] Contract tests verify external API stability

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated internal detection data handling to use a unified model throughout processor actions and storage operations for improved consistency and maintainability.
  * Streamlined database persistence, MQTT broadcasts, and real-time event delivery workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->