### PR TITLE
fix(datastore): implement GetAdditionalResults and fix code smells

### DIFF
--- a/internal/analysis/processor/threshold_persistence_test.go
+++ b/internal/analysis/processor/threshold_persistence_test.go
@@ -74,6 +74,9 @@ func (m *MockDatastore) SaveNoteReview(*datastore.NoteReview) error { return nil
 func (m *MockDatastore) GetNoteComments(string) ([]datastore.NoteComment, error) {
 	return make([]datastore.NoteComment, 0), nil
 }
+func (m *MockDatastore) GetNoteResults(string) ([]datastore.Results, error) {
+	return nil, nil
+}
 func (m *MockDatastore) SaveNoteComment(*datastore.NoteComment) error { return nil }
 func (m *MockDatastore) UpdateNoteComment(string, string) error       { return nil }
 func (m *MockDatastore) DeleteNoteComment(string) error               { return nil }

--- a/internal/datastore/interfaces.go
+++ b/internal/datastore/interfaces.go
@@ -92,6 +92,8 @@ type Interface interface {
 	GetNoteReview(noteID string) (*NoteReview, error)
 	SaveNoteReview(review *NoteReview) error
 	GetNoteComments(noteID string) ([]NoteComment, error)
+	// GetNoteResults returns the additional predictions for a note.
+	GetNoteResults(noteID string) ([]Results, error)
 	SaveNoteComment(comment *NoteComment) error
 	UpdateNoteComment(commentID string, entry string) error
 	DeleteNoteComment(commentID string) error
@@ -1093,6 +1095,31 @@ func (ds *DataStore) GetNoteComments(noteID string) ([]NoteComment, error) {
 	}
 
 	return comments, nil
+}
+
+// GetNoteResults returns the additional predictions for a note.
+func (ds *DataStore) GetNoteResults(noteID string) ([]Results, error) {
+	// Parse ID for consistency and MySQL compatibility
+	id, err := strconv.ParseUint(noteID, 10, 32)
+	if err != nil {
+		return nil, errors.New(err).
+			Component("datastore").
+			Category(errors.CategoryValidation).
+			Context("operation", "get_note_results").
+			Context("note_id", noteID).
+			Build()
+	}
+
+	var results []Results
+	if err := ds.DB.Where("note_id = ?", id).Find(&results).Error; err != nil {
+		return nil, errors.New(err).
+			Component("datastore").
+			Category(errors.CategoryDatabase).
+			Context("operation", "get_note_results").
+			Context("note_id", noteID).
+			Build()
+	}
+	return results, nil
 }
 
 // SaveNoteComment saves a new comment for a note

--- a/internal/datastore/mocks/mock_Interface.go
+++ b/internal/datastore/mocks/mock_Interface.go
@@ -2180,6 +2180,64 @@ func (_c *MockInterface_GetNoteComments_Call) RunAndReturn(run func(string) ([]d
 	return _c
 }
 
+// GetNoteResults provides a mock function with given fields: noteID
+func (_m *MockInterface) GetNoteResults(noteID string) ([]datastore.Results, error) {
+	ret := _m.Called(noteID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetNoteResults")
+	}
+
+	var r0 []datastore.Results
+	var r1 error
+	if rf, ok := ret.Get(0).(func(string) ([]datastore.Results, error)); ok {
+		return rf(noteID)
+	}
+	if rf, ok := ret.Get(0).(func(string) []datastore.Results); ok {
+		r0 = rf(noteID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]datastore.Results)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(noteID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockInterface_GetNoteResults_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetNoteResults'
+type MockInterface_GetNoteResults_Call struct {
+	*mock.Call
+}
+
+// GetNoteResults is a helper method to define mock.On call
+//   - noteID string
+func (_e *MockInterface_Expecter) GetNoteResults(noteID interface{}) *MockInterface_GetNoteResults_Call {
+	return &MockInterface_GetNoteResults_Call{Call: _e.mock.On("GetNoteResults", noteID)}
+}
+
+func (_c *MockInterface_GetNoteResults_Call) Run(run func(noteID string)) *MockInterface_GetNoteResults_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string))
+	})
+	return _c
+}
+
+func (_c *MockInterface_GetNoteResults_Call) Return(_a0 []datastore.Results, _a1 error) *MockInterface_GetNoteResults_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockInterface_GetNoteResults_Call) RunAndReturn(run func(string) ([]datastore.Results, error)) *MockInterface_GetNoteResults_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetNoteLock provides a mock function with given fields: noteID
 func (_m *MockInterface) GetNoteLock(noteID string) (*datastore.NoteLock, error) {
 	ret := _m.Called(noteID)

--- a/internal/imageprovider/imageprovider_test.go
+++ b/internal/imageprovider/imageprovider_test.go
@@ -190,6 +190,7 @@ func (m *mockStore) GetNoteReview(noteID string) (*datastore.NoteReview, error) 
 }
 func (m *mockStore) SaveNoteReview(review *datastore.NoteReview) error              { return nil }
 func (m *mockStore) GetNoteComments(noteID string) ([]datastore.NoteComment, error) { return nil, nil }
+func (m *mockStore) GetNoteResults(noteID string) ([]datastore.Results, error)      { return nil, nil }
 func (m *mockStore) SaveNoteComment(comment *datastore.NoteComment) error           { return nil }
 func (m *mockStore) UpdateNoteComment(commentID, entry string) error                { return nil }
 func (m *mockStore) DeleteNoteComment(commentID string) error                       { return nil }


### PR DESCRIPTION
## Summary

- Add `GetNoteResults` method to Interface for Results table lookup
- Implement `GetAdditionalResults` properly (was returning nil stub)
- Extract `parseDateWithDefault` helper to reduce duplication
- Add consistent error wrapping in `UpdateComment`, `DeleteComment`, `GetClipPath`
- Replace magic number with `allHoursDuration` constant
- Add test for `GetAdditionalResults` roundtrip

## Background

Fixes code smells identified in cross-referenced review (Claude + Gemini) of detection_repository.go.

## Test Plan

- [x] `go test -race -v ./internal/datastore/... -run TestGetAdditionalResults` passes
- [x] All existing tests pass
- [x] Linter clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added capability to retrieve additional results linked to notes.

* **Bug Fixes**
  * Enhanced error handling with contextual messages for comment and data operations.
  * Improved date filtering logic with better default behavior.

* **Tests**
  * Expanded test coverage for additional results retrieval functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->