### PR TITLE
refactor: modernize WaitGroup patterns to use Go 1.25 wg.Go()

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -51,6 +51,9 @@ linters:
         - style
         - diagnostic
         - performance
+      settings:
+        ruleguard:
+          rules: "rules/waitgroup.go"
     revive:
       rules:
         - name: unused-parameter

--- a/go.mod
+++ b/go.mod
@@ -64,6 +64,7 @@ require (
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/markbates/going v1.0.0 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
+	github.com/quasilyte/go-ruleguard/dsl v0.3.23 // indirect
 	github.com/stretchr/objx v0.5.3 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -163,6 +163,8 @@ github.com/prometheus/common v0.67.4 h1:yR3NqWO1/UyO1w2PhUvXlGQs/PtFmoveVO0KZ4+L
 github.com/prometheus/common v0.67.4/go.mod h1:gP0fq6YjjNCLssJCQp0yk4M8W6ikLURwkdd/YKtTbyI=
 github.com/prometheus/procfs v0.19.2 h1:zUMhqEW66Ex7OXIiDkll3tl9a1ZdilUOd/F6ZXw4Vws=
 github.com/prometheus/procfs v0.19.2/go.mod h1:M0aotyiemPhBCM0z5w87kL22CxfcH05ZpYlu+b4J7mw=
+github.com/quasilyte/go-ruleguard/dsl v0.3.23 h1:lxjt5B6ZCiBeeNO8/oQsegE6fLeCzuMRoVWSkXC4uvY=
+github.com/quasilyte/go-ruleguard/dsl v0.3.23/go.mod h1:KeCP03KrjuSO0H1kTuZQCWlQPulDV6YMIXmpQss17rU=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/internal/analysis/buffer_manager.go
+++ b/internal/analysis/buffer_manager.go
@@ -126,8 +126,7 @@ func (m *BufferManager) AddMonitor(source string) error {
 	monitorQuit = actual.(chan struct{})
 
 	// Start the monitor with error handling
-	m.wg.Add(1)
-	go func() {
+	m.wg.Go(func() {
 		defer func() {
 			// Panic recovery for the monitor goroutine
 			if r := recover(); r != nil {
@@ -137,7 +136,6 @@ func (m *BufferManager) AddMonitor(source string) error {
 					logger.String("component", "analysis.buffer"))
 			}
 
-			m.wg.Done()
 			// Clean up monitor from map if it exits unexpectedly
 			if quitChanIface, exists := m.monitors.Load(source); exists {
 				// Safe type assertion
@@ -156,7 +154,7 @@ func (m *BufferManager) AddMonitor(source string) error {
 
 		// Run the monitor
 		myaudio.AnalysisBufferMonitor(m.wg, m.bn, monitorQuit, source)
-	}()
+	})
 
 	return nil
 }

--- a/internal/myaudio/analysis_buffer.go
+++ b/internal/myaudio/analysis_buffer.go
@@ -615,13 +615,9 @@ func AnalysisBufferExists(sourceID string) bool {
 }
 
 // AnalysisBufferMonitor monitors the buffer and processes audio data when enough data is present.
-func AnalysisBufferMonitor(wg *sync.WaitGroup, bn *birdnet.BirdNET, quitChan chan struct{}, sourceID string) {
+// Note: This function is called from within a wg.Go() goroutine, so WaitGroup tracking is handled by the caller.
+func AnalysisBufferMonitor(_ *sync.WaitGroup, bn *birdnet.BirdNET, quitChan chan struct{}, sourceID string) {
 	log := GetLogger()
-
-	wg.Add(1)
-	defer func() {
-		wg.Done()
-	}()
 
 	// This is the offset to subtract from the begin time of the data to account for BirdNET prediction and
 	// processing delays, goal is to ensure that captured audio clip contains detection sound.

--- a/internal/myaudio/capture.go
+++ b/internal/myaudio/capture.go
@@ -341,7 +341,9 @@ func CaptureAudio(settings *conf.Settings, wg *sync.WaitGroup, quitChan, restart
 		}
 
 		// Device audio capture - pass source ID for buffer operations
-		go captureAudioMalgo(settings, selectedSource, source.ID, wg, quitChan, restartChan, unifiedAudioChan)
+		wg.Go(func() {
+			captureAudioMalgo(settings, selectedSource, source.ID, quitChan, restartChan, unifiedAudioChan)
+		})
 	}
 }
 
@@ -730,9 +732,7 @@ func handleDeviceStop(captureDevice *malgo.Device, quitChan, restartChan chan st
 	}
 }
 
-func captureAudioMalgo(settings *conf.Settings, source captureSource, sourceID string, wg *sync.WaitGroup, quitChan, restartChan chan struct{}, unifiedAudioChan chan UnifiedAudioData) {
-	wg.Add(1)
-	defer wg.Done()
+func captureAudioMalgo(settings *conf.Settings, source captureSource, sourceID string, quitChan, restartChan chan struct{}, unifiedAudioChan chan UnifiedAudioData) {
 
 	log := GetLogger()
 

--- a/rules/waitgroup.go
+++ b/rules/waitgroup.go
@@ -1,0 +1,47 @@
+//go:build ruleguard
+
+// Package gorules contains custom linting rules for golangci-lint via ruleguard.
+// These rules detect patterns that can be modernized for Go 1.25+.
+package gorules
+
+import "github.com/quasilyte/go-ruleguard/dsl"
+
+// WaitGroupModernize detects old WaitGroup patterns that can use the new Go 1.25 wg.Go() method.
+//
+// Old pattern (error-prone):
+//
+//	wg.Add(1)
+//	go func() {
+//	    defer wg.Done()
+//	    doSomething()
+//	}()
+//
+// New pattern (Go 1.25+):
+//
+//	wg.Go(func() {
+//	    doSomething()
+//	})
+func WaitGroupModernize(m dsl.Matcher) {
+	// Pattern 1: Detect go func with defer wg.Done() inside
+	// This is the most common pattern that should be modernized
+	m.Match(`go func() { defer $wg.Done(); $*_ }()`).
+		Where(m["wg"].Type.Is("*sync.WaitGroup")).
+		Report("Use $wg.Go(func() { ... }) instead of go func() { defer $wg.Done(); ... }() (Go 1.25+)").
+		Suggest("$wg.Go(func() { $*_ })")
+
+	// Pattern 2: Detect go func with wg.Done() at the end (without defer)
+	m.Match(`go func() { $*_; $wg.Done() }()`).
+		Where(m["wg"].Type.Is("*sync.WaitGroup")).
+		Report("Use $wg.Go(func() { ... }) instead of manual Done() call (Go 1.25+)")
+
+	// Pattern 3: Detect wg.Add(1) which often precedes the old pattern
+	// This helps catch cases where Add and go func are on separate lines
+	m.Match(`$wg.Add(1)`).
+		Where(m["wg"].Type.Is("*sync.WaitGroup")).
+		Report("Consider using $wg.Go() which calls Add(1) automatically (Go 1.25+)")
+
+	// Pattern 4: Detect wg.Add with literal > 1, suggesting multiple wg.Go calls
+	m.Match(`$wg.Add($n)`).
+		Where(m["wg"].Type.Is("*sync.WaitGroup") && m["n"].Const && m["n"].Value.Int() > 1).
+		Report("Consider using $wg.Go() for each goroutine instead of Add($n) (Go 1.25+)")
+}


### PR DESCRIPTION
## Summary

- Replace manual `wg.Add(1)` + `go func()` + `defer wg.Done()` patterns with Go 1.25's `sync.WaitGroup.Go()` method
- Remove redundant double-tracking in `AnalysisBufferMonitor` (was incrementing WaitGroup twice for single unit of work)
- Add custom ruleguard linter rule to detect old patterns and prevent regression

## Why

Go 1.25 introduced `WaitGroup.Go()` which:
- Eliminates common bugs (forgotten `Add(1)` or `Done()` calls)
- Guarantees `Done()` is called even on panic
- Reduces boilerplate

## Files Changed

| File | Change |
|------|--------|
| `internal/analysis/buffer_manager.go` | Use `wg.Go()` for monitor goroutine |
| `internal/myaudio/analysis_buffer.go` | Remove redundant internal tracking |
| `internal/myaudio/capture.go` | Use `wg.Go()` at call site, simplify signature |
| `rules/waitgroup.go` | New ruleguard rules to detect old patterns |
| `.golangci.yaml` | Enable ruleguard with new rules |

## Test plan

- [ ] Verify audio capture still works correctly
- [ ] Verify analysis buffer monitoring functions properly
- [ ] Run `golangci-lint run` to confirm no WaitGroup warnings