### PR TITLE
refactor(diskmanager): reduce cognitive complexity and address code smells

### DIFF
--- a/internal/analysis/realtime.go
+++ b/internal/analysis/realtime.go
@@ -705,7 +705,7 @@ func clipCleanupMonitor(quitChan chan struct{}, dataStore datastore.Interface) {
 				baseDir := conf.Setting().Realtime.Audio.Export.Path
 
 				// Check if we can skip cleanup
-				skip, utilization, err := diskmanager.ShouldSkipUsageBasedCleanup(&retention, baseDir, retention.Debug)
+				skip, utilization, err := diskmanager.ShouldSkipUsageBasedCleanup(&retention, baseDir)
 
 				if err != nil {
 					diskManagerLogger.Warn("Failed to check disk usage for early exit via timer",


### PR DESCRIPTION
## Summary

- Extract helper functions to reduce cognitive complexity in cleanup policies
- Add package-level constants for `deletionThrottleDelay` and `maxDeletionsPerRun`
- Remove unused `debug` parameters from internal functions
- Use `sort.SliceStable` for deterministic sorting order
- Fix potential underflow in `updateUsageStateAfterDeletion`
- Standardize time comparisons to use `time.Time` methods (`Before`/`Equal`)
- Fix misleading `categorizeFilePath` label (`nested-path` vs `simple-filename`)
- Remove unused `mockFileInfo` struct from tests

## Results

- All 7 gocognit violations resolved (threshold: 20)
- 0 linter issues
- All tests pass with race detector

## Test Plan

- [x] `golangci-lint run internal/diskmanager/...` - 0 issues
- [x] `go test -race -v ./internal/diskmanager/...` - all pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reduced I/O impact of background cleanup via deletion rate limiting and centralized deletion flow
  * Simplified internal cleanup logic by removing debug toggles and consolidating eligibility checks and deletion helpers
  * Improved logging and metrics around cleanup operations

* **Tests**
  * Updated and consolidated test helpers to better simulate cleanup and concurrent pool behavior, improving reliability of test coverage

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->