### PR TITLE
fix(datastore): increase slow query threshold to 500ms

### DIFF
--- a/internal/datastore/mysql.go
+++ b/internal/datastore/mysql.go
@@ -62,10 +62,10 @@ func (store *MySQLStore) Open() error {
 	var gormLogger gormlogger.Interface
 	if store.Settings.Debug {
 		// Use debug log level with lower slow threshold
-		gormLogger = NewGormLogger(100*time.Millisecond, gormlogger.Info, store.metrics)
+		gormLogger = NewGormLogger(500*time.Millisecond, gormlogger.Info, store.metrics)
 	} else {
 		// Use default settings with metrics
-		gormLogger = NewGormLogger(200*time.Millisecond, gormlogger.Warn, store.metrics)
+		gormLogger = NewGormLogger(500*time.Millisecond, gormlogger.Warn, store.metrics)
 	}
 
 	// Open the MySQL database

--- a/internal/datastore/sqlite.go
+++ b/internal/datastore/sqlite.go
@@ -200,10 +200,10 @@ func (s *SQLiteStore) Open() error {
 	var gormLogger gormlogger.Interface
 	if s.Settings.Debug {
 		// Use debug log level with lower slow threshold
-		gormLogger = NewGormLogger(100*time.Millisecond, gormlogger.Info, s.metrics)
+		gormLogger = NewGormLogger(500*time.Millisecond, gormlogger.Info, s.metrics)
 	} else {
 		// Use default settings with metrics
-		gormLogger = NewGormLogger(200*time.Millisecond, gormlogger.Warn, s.metrics)
+		gormLogger = NewGormLogger(500*time.Millisecond, gormlogger.Warn, s.metrics)
 	}
 
 	// Open SQLite database with GORM

--- a/internal/datastore/v2/manager.go
+++ b/internal/datastore/v2/manager.go
@@ -17,7 +17,7 @@ import (
 )
 
 // defaultGormSlowThreshold is the duration above which GORM queries are logged as slow.
-const defaultGormSlowThreshold = 200 * time.Millisecond
+const defaultGormSlowThreshold = 500 * time.Millisecond
 
 // Manager defines the interface for v2 database operations.
 type Manager interface {


### PR DESCRIPTION
## Summary
- Increase GORM slow query warning threshold from 100-200ms to 500ms
- Reduces log spam during migration on slower storage (e.g., SD cards on RPi)
- Applies to SQLite, MySQL, and v2 database connections

## Test plan
- [ ] Deploy on RPi 5 with SD card storage
- [ ] Run migration and verify reduced slow query warnings