### PR TITLE
fix(v2only): implement SetSunCalcMetrics for observability

### DIFF
--- a/internal/datastore/v2only/datastore.go
+++ b/internal/datastore/v2only/datastore.go
@@ -16,6 +16,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/detection"
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/logger"
+	obmetrics "github.com/tphakala/birdnet-go/internal/observability/metrics"
 	"github.com/tphakala/birdnet-go/internal/suncalc"
 	"gorm.io/gorm"
 )
@@ -133,8 +134,14 @@ func (ds *Datastore) Manager() v2.Manager {
 	return ds.manager
 }
 
-// SetSunCalcMetrics sets the SunCalc metrics instance.
-func (ds *Datastore) SetSunCalcMetrics(_ any) {}
+// SetSunCalcMetrics sets the SunCalc metrics instance for observability.
+func (ds *Datastore) SetSunCalcMetrics(suncalcMetrics any) {
+	if ds.suncalc != nil && suncalcMetrics != nil {
+		if m, ok := suncalcMetrics.(*obmetrics.SunCalcMetrics); ok {
+			ds.suncalc.SetMetrics(m)
+		}
+	}
+}
 
 // Optimize performs database optimization.
 func (ds *Datastore) Optimize(ctx context.Context) error {


### PR DESCRIPTION
## Summary

- Implements the `SetSunCalcMetrics` method in the v2only datastore
- Method was an empty stub that ignored its argument, resulting in missing SunCalc observability metrics when running in v2-only mode
- Now properly forwards metrics to the SunCalc service, matching legacy datastore behavior

## Changes

- Added import with alias `obmetrics` to avoid shadowing the `metrics` parameter in `SetMetrics` method
- Implemented `SetSunCalcMetrics` to type-assert and delegate to `suncalc.SetMetrics()`

## Test Plan

- [x] Build passes
- [x] Lint passes (0 issues)
- [x] All v2only tests pass
- [x] Thread safety tests pass
- [x] Gemini review approved

Fixes #1884

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal observability infrastructure to improve metrics collection and monitoring capabilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->