### PR TITLE
fix: address code review findings for db-normalization

### DIFF
--- a/internal/datastore/v2/repository/dual_write.go
+++ b/internal/datastore/v2/repository/dual_write.go
@@ -279,6 +279,11 @@ func (dw *DualWriteRepository) Delete(ctx context.Context, id string) error {
 			if err := dw.v2.Delete(ctx, uid); err != nil {
 				if !errors.Is(err, ErrDetectionNotFound) {
 					dw.logger.Warn("v2 delete failed", logger.String("id", id), logger.Error(err))
+					// Track for reconciliation - V2 record may still exist after legacy deletion
+					// TODO: Ensure reconciliation job processes dirty IDs from live writes.
+					// Current dirty ID handling is primarily for migration phase failures.
+					// May need periodic "Retry Dirty IDs" task for dual-write failures.
+					dw.markDirty(uid)
 				}
 			}
 		}


### PR DESCRIPTION
## Summary
- Add mutex protection for package-level migration variables to prevent race conditions
- Wrap V2Only Save in GORM transaction for atomic detection + predictions writes
- Add dirty ID tracking when V2 delete fails for reconciliation
- Add nil check in detectionToNote to prevent potential panic

## Test plan
- [x] Run `go test -race ./internal/api/v2/...` - passes
- [x] Run `go test -race ./internal/datastore/...` - passes
- [ ] Manual testing of migration start/stop scenarios
- [ ] Manual testing of detection save with prediction failures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Migration operations now handle concurrent requests more reliably.
  * Failed deletion operations are automatically tracked for reconciliation and recovery.
  * Detection records and their associated predictions are now saved as a single atomic unit, ensuring data consistency and preventing partial updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->