### PR TITLE
fix(datastore): prevent ghost legacy database file creation

### DIFF
--- a/internal/datastore/v2/startup_test.go
+++ b/internal/datastore/v2/startup_test.go
@@ -187,6 +187,13 @@ func TestCheckSQLiteHasV2Schema(t *testing.T) {
 		dbPath := filepath.Join(tmpDir, "nonexistent.db")
 
 		assert.False(t, CheckSQLiteHasV2Schema(dbPath), "should return false for non-existent")
+
+		// CRITICAL: Verify the file was NOT created during the check.
+		// This is a regression test for the bug where GORM/SQLite would create
+		// an empty file even when opened with mode=ro, causing the legacy
+		// database cleanup UI to appear after the legacy DB was manually deleted.
+		_, err := os.Stat(dbPath)
+		assert.True(t, os.IsNotExist(err), "checking non-existent file should not create it")
 	})
 
 	t.Run("empty file", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- Fixed bug where legacy database cleanup UI appeared after manually deleting the legacy database
- GORM/SQLite with `mode=ro` still creates an empty file when the file doesn't exist
- Added file existence check before attempting to open database with GORM
- Added regression test to ensure files aren't created during checks

## Test plan
- [x] Verified fix prevents ghost file creation
- [x] All existing datastore/v2 tests pass
- [x] Regression test added to catch future issues
- [ ] Manual test: delete legacy DB while app stopped, restart, verify cleanup UI doesn't appear

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Fixed a startup issue where the database schema validation process would inadvertently create empty files when checking non-existent database paths. The validation now properly verifies the database file exists before attempting to open it in read-only mode, preventing unwanted file creation as a side effect and eliminating unnecessary clutter during application initialization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->