### PR TITLE
fix(v2only): add deterministic secondary sort in GetTopBirdsData

### DIFF
--- a/internal/datastore/v2only/datastore.go
+++ b/internal/datastore/v2only/datastore.go
@@ -1,5 +1,19 @@
 // Package v2only provides a datastore implementation using only the v2 schema.
 // This is used after migration completes when the legacy database is no longer needed.
+//
+// # Data Model Architecture
+//
+// The v2 schema separates primary and secondary predictions:
+//
+//   - detections table: Contains the primary prediction (label_id, confidence).
+//     Use this for ALL queries: daily grids, summaries, aggregations, search, etc.
+//
+//   - detection_predictions table: Contains ONLY secondary/alternative predictions.
+//     Use ONLY for per-detection detail views showing "what else could this be?".
+//
+// IMPORTANT: Never join detection_predictions in aggregate queries. Doing so excludes
+// detections that have no secondary predictions, causing species to randomly disappear
+// from grids and summaries.
 package v2only
 
 import (


### PR DESCRIPTION
## Summary
- Add secondary sort by scientific_name ASC when ordering by count DESC
- Ensures consistent species ordering when detection counts are equal

## Problem
Species like Siren were randomly excluded from the daily summary grid because SQL ORDER BY with ties produces non-deterministic results.

## Solution
Changed `ORDER BY count DESC` to `ORDER BY count DESC, l.scientific_name ASC` for consistent results.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency of result ordering in data aggregations to ensure deterministic display when primary ranking values are equal.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->