### PR TITLE
fix(v2only): fix species tracking bugs in v2 datastore

### DIFF
--- a/internal/datastore/v2/repository/detection.go
+++ b/internal/datastore/v2/repository/detection.go
@@ -106,9 +106,10 @@ type DetectionRepository interface {
 	// modelID is optional; pass nil to include all models.
 	GetTopSpecies(ctx context.Context, start, end int64, minConfidence float64, modelID *uint, limit int) ([]SpeciesCount, error)
 
-	// GetHourlyOccurrences returns detection counts by hour (0-23) for a label.
+	// GetHourlyOccurrences returns detection counts by hour (0-23) for the given labels.
+	// Aggregates across all provided label IDs (multi-model support).
 	// minConfidence filters detections by minimum confidence threshold.
-	GetHourlyOccurrences(ctx context.Context, labelID uint, start, end int64, minConfidence float64) ([24]int, error)
+	GetHourlyOccurrences(ctx context.Context, labelIDs []uint, start, end int64, minConfidence float64) ([24]int, error)
 
 	// GetDailyOccurrences returns daily detection counts for a label.
 	GetDailyOccurrences(ctx context.Context, labelID uint, start, end int64) ([]DailyCount, error)

--- a/internal/datastore/v2only/datastore.go
+++ b/internal/datastore/v2only/datastore.go
@@ -800,19 +800,8 @@ func (ds *Datastore) GetHourlyOccurrences(date, commonName string, minConfidence
 	startTime := t.Unix()
 	endTime := t.Add(24 * time.Hour).Unix()
 
-	// Aggregate across all label IDs (multi-model support)
-	var combined [24]int
-	for _, labelID := range labelIDs {
-		result, err := ds.detection.GetHourlyOccurrences(ctx, labelID, startTime, endTime, minConfidenceNormalized)
-		if err != nil {
-			return hourly, err
-		}
-		for i := range 24 {
-			combined[i] += result[i]
-		}
-	}
-
-	return combined, nil
+	// Single query with IN clause for all label IDs (multi-model support)
+	return ds.detection.GetHourlyOccurrences(ctx, labelIDs, startTime, endTime, minConfidenceNormalized)
 }
 
 // SpeciesDetections retrieves detections for a species.


### PR DESCRIPTION
## Summary
- Fix multiple bugs in v2 datastore that caused incorrect species tracking results
- Ensure proper aggregation by `scientific_name` instead of `label_id` for cross-model species tracking
- Fix timezone handling and date boundary consistency
- Improve query performance for GetNewSpecies

## Changes

### Critical Fixes
1. **GetHourlyDistribution timezone fix** - Use `hourFromUnixExpr()` for proper local timezone conversion instead of raw integer division
2. **GetHourlyOccurrences minConfidence** - Add missing confidence filtering parameter
3. **GetHourlyOccurrences multi-label aggregation** - Aggregate across all label IDs for a species (was only using first label ID)

### Species Aggregation Fixes
4. **GetSpeciesSummary** - Group by `scientific_name` instead of `label_id`
5. **GetNewSpecies** - Group by `scientific_name` and use efficient derived table (O(n)) instead of correlated subquery (O(n²))
6. **GetSpeciesFirstDetectionInPeriod** - Partition by `scientific_name` instead of `label_id`

### Consistency Fix
7. **parseDateRange** - Use exclusive end time (`<`) consistently across all queries

## Test plan
- [x] Build passes (`go build ./...`)
- [x] Linter passes (`golangci-lint run -v`)
- [x] V2 datastore tests pass
- [x] Manual verification with running server

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for querying hourly detection counts across multiple label IDs and a new confidence-threshold filter.

* **Improvements**
  * Analytics now aggregate detections at the species level across models for more comprehensive insights.
  * Time-range handling updated to exclusive-end semantics for consistent, accurate hourly/daily analytics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->