### PR TITLE
fix(v2): address medium-priority code review issues

### DIFF
--- a/internal/datastore/v2only/datastore.go
+++ b/internal/datastore/v2only/datastore.go
@@ -1065,7 +1065,13 @@ func (ds *Datastore) GetNoteResults(noteID string) ([]datastore.Results, error) 
 
 	results := make([]datastore.Results, 0, len(preds))
 	for _, pred := range preds {
-		label, _ := ds.label.GetByID(ctx, pred.LabelID)
+		label, labelErr := ds.label.GetByID(ctx, pred.LabelID)
+		if labelErr != nil {
+			ds.log.Warn("failed to look up label for prediction",
+				logger.Uint64("label_id", uint64(pred.LabelID)),
+				logger.Uint64("prediction_id", uint64(pred.ID)),
+				logger.Error(labelErr))
+		}
 		scientificName := ""
 		if label != nil && label.ScientificName != "" {
 			scientificName = label.ScientificName


### PR DESCRIPTION
## Summary

Fixes 3 medium-priority issues from the [v2 datastore code review](docs/plans/2026-02-03-v2-datastore-code-review.md):

- **Issue #3 — Catch-up dirty ID optimization**: `runCatchUp` now processes known dirty IDs first (Phase 1) before falling back to a full legacy DB scan (Phase 2). Resolves most validation count mismatches without needing the full scan, critical for databases >1M records where the catch-up budget is insufficient.

- **Issue #4 — Multi-label species query**: `GetBySpecies` in dual-write now uses `Search()` with all label IDs instead of `GetByLabel()` with only the first. Multi-model deployments will correctly return detections from all models when querying by species.

- **Issue #5 — Label lookup error logging**: `GetNoteResults` now logs a warning when `label.GetByID` fails instead of silently swallowing the error. Graceful degradation (empty species name) is preserved.

- **Notification fix**: Migration completion notification now instructs users to restart BirdNET-Go to switch to the new database schema (matching the existing frontend i18n labels).

## Review notes

- Plan was reviewed and approved by Gemini before implementation
- Implementation was independently code-reviewed by both Claude and Gemini — no issues found
- Neither `Search()` nor `GetByLabel()` preloads relations — this is a pre-existing limitation, not a regression

## Test plan

- [x] `go test -race ./internal/datastore/v2/migration/` — PASS
- [x] `go test -race ./internal/datastore/v2/repository/` — PASS
- [x] `go test -race ./internal/datastore/v2only/` — PASS
- [x] `golangci-lint run -v` — 0 issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data migration with staged processing of previously failed ("dirty") records before a full scan.
  * Enhanced error handling and warning logs when associated metadata lookups fail, improving consistency.

* **Improvements**
  * Multi-model species lookup now queries across all available sources.
  * Notification text updated: users should restart the app to switch to the updated database.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->