### PR TITLE
refactor: migrate stdlib errors to internal/errors

### DIFF
--- a/internal/api/auth/service.go
+++ b/internal/api/auth/service.go
@@ -3,9 +3,9 @@ package auth
 
 import (
 	"context"
-	"errors"
 
 	"github.com/labstack/echo/v4"
+	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/logger"
 )
 
@@ -16,12 +16,12 @@ func GetLogger() logger.Logger {
 
 // Sentinel errors for authentication failures.
 var (
-	ErrInvalidCredentials = errors.New("invalid credentials")
-	ErrInvalidToken       = errors.New("invalid or expired token")
-	ErrSessionNotFound    = errors.New("session not found or expired")
-	ErrLogoutFailed       = errors.New("logout operation failed")
-	ErrBasicAuthDisabled  = errors.New("basic authentication is disabled")
-	ErrAuthCodeGeneration = errors.New("failed to generate authorization code")
+	ErrInvalidCredentials = errors.NewStd("invalid credentials")
+	ErrInvalidToken       = errors.NewStd("invalid or expired token")
+	ErrSessionNotFound    = errors.NewStd("session not found or expired")
+	ErrLogoutFailed       = errors.NewStd("logout operation failed")
+	ErrBasicAuthDisabled  = errors.NewStd("basic authentication is disabled")
+	ErrAuthCodeGeneration = errors.NewStd("failed to generate authorization code")
 )
 
 //go:generate go run golang.org/x/tools/cmd/stringer -type=AuthMethod

--- a/internal/api/v2/analytics.go
+++ b/internal/api/v2/analytics.go
@@ -2,7 +2,6 @@
 package api
 
 import (
-	"errors"
 	"fmt"
 	"net/http"
 	"regexp"
@@ -14,6 +13,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/tphakala/birdnet-go/internal/analysis/species"
 	"github.com/tphakala/birdnet-go/internal/datastore"
+	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/imageprovider"
 	"github.com/tphakala/birdnet-go/internal/logger"
 )
@@ -80,14 +80,14 @@ type NewSpeciesResponse struct {
 
 // Define standard errors for date validation
 var (
-	ErrInvalidStartDate = errors.New("invalid start_date format. Use YYYY-MM-DD")
-	ErrInvalidEndDate   = errors.New("invalid end_date format. Use YYYY-MM-DD")
-	ErrDateOrder        = errors.New("start_date cannot be after end_date")
+	ErrInvalidStartDate = errors.NewStd("invalid start_date format. Use YYYY-MM-DD")
+	ErrInvalidEndDate   = errors.NewStd("invalid end_date format. Use YYYY-MM-DD")
+	ErrDateOrder        = errors.NewStd("start_date cannot be after end_date")
 )
 
 // ErrResponseHandled is a sentinel error indicating the HTTP response has already been written.
 // Callers receiving this error should return it immediately without further processing.
-var ErrResponseHandled = errors.New("response already handled")
+var ErrResponseHandled = errors.NewStd("response already handled")
 
 // dateRegex ensures YYYY-MM-DD format
 var dateRegex = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}$`)

--- a/internal/api/v2/system.go
+++ b/internal/api/v2/system.go
@@ -4,7 +4,6 @@ package api
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -26,6 +25,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/analysis/processor"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/datastore"
+	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/logger"
 	"github.com/tphakala/birdnet-go/internal/myaudio"
 	"golang.org/x/text/cases"

--- a/internal/datastore/v2/repository/detection_impl.go
+++ b/internal/datastore/v2/repository/detection_impl.go
@@ -2,13 +2,13 @@ package repository
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"maps"
 	"slices"
 	"time"
 
 	"github.com/tphakala/birdnet-go/internal/datastore/v2/entities"
+	"github.com/tphakala/birdnet-go/internal/errors"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 )

--- a/internal/datastore/v2/repository/dual_write.go
+++ b/internal/datastore/v2/repository/dual_write.go
@@ -2,7 +2,6 @@ package repository
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strconv"
 	"sync"
@@ -12,7 +11,7 @@ import (
 	v2 "github.com/tphakala/birdnet-go/internal/datastore/v2"
 	"github.com/tphakala/birdnet-go/internal/datastore/v2/entities"
 	"github.com/tphakala/birdnet-go/internal/detection"
-	apperrors "github.com/tphakala/birdnet-go/internal/errors"
+	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/logger"
 )
 
@@ -182,7 +181,7 @@ func (dw *DualWriteRepository) reconcileDirtyIDs() {
 			// Fetch from legacy (source of truth)
 			result, err := dw.legacy.Get(ctx, idStr)
 			if err != nil {
-				if apperrors.IsNotFound(err) {
+				if errors.IsNotFound(err) {
 					// Record genuinely deleted from legacy — remove v2 ghost
 					if delErr := dw.v2.Delete(ctx, id); delErr != nil && !errors.Is(delErr, ErrDetectionNotFound) {
 						dw.logger.Warn("reconciliation: v2 delete failed", logger.Uint64("id", uint64(id)), logger.Error(delErr))

--- a/internal/datastore/v2/repository/errors.go
+++ b/internal/datastore/v2/repository/errors.go
@@ -2,69 +2,69 @@
 // for the normalized database schema.
 package repository
 
-import "errors"
+import "github.com/tphakala/birdnet-go/internal/errors"
 
 // Sentinel errors for repository operations.
 // These typed errors enable callers to distinguish between different
 // failure modes without relying on string matching or GORM-specific errors.
 var (
 	// ErrDetectionNotFound indicates the requested detection does not exist.
-	ErrDetectionNotFound = errors.New("detection not found")
+	ErrDetectionNotFound = errors.NewStd("detection not found")
 
 	// ErrLabelNotFound indicates the requested label does not exist.
-	ErrLabelNotFound = errors.New("label not found")
+	ErrLabelNotFound = errors.NewStd("label not found")
 
 	// ErrLabelTypeNotFound indicates the requested label type does not exist.
-	ErrLabelTypeNotFound = errors.New("label type not found")
+	ErrLabelTypeNotFound = errors.NewStd("label type not found")
 
 	// ErrTaxonomicClassNotFound indicates the requested taxonomic class does not exist.
-	ErrTaxonomicClassNotFound = errors.New("taxonomic class not found")
+	ErrTaxonomicClassNotFound = errors.NewStd("taxonomic class not found")
 
 	// ErrModelNotFound indicates the requested AI model does not exist.
-	ErrModelNotFound = errors.New("model not found")
+	ErrModelNotFound = errors.NewStd("model not found")
 
 	// ErrAudioSourceNotFound indicates the requested audio source does not exist.
-	ErrAudioSourceNotFound = errors.New("audio source not found")
+	ErrAudioSourceNotFound = errors.NewStd("audio source not found")
 
 	// ErrPredictionNotFound indicates the requested prediction does not exist.
-	ErrPredictionNotFound = errors.New("prediction not found")
+	ErrPredictionNotFound = errors.NewStd("prediction not found")
 
 	// ErrReviewNotFound indicates no review exists for the detection.
-	ErrReviewNotFound = errors.New("review not found")
+	ErrReviewNotFound = errors.NewStd("review not found")
 
 	// ErrCommentNotFound indicates the requested comment does not exist.
-	ErrCommentNotFound = errors.New("comment not found")
+	ErrCommentNotFound = errors.NewStd("comment not found")
 
 	// ErrLockNotFound indicates no lock exists for the detection.
-	ErrLockNotFound = errors.New("lock not found")
+	ErrLockNotFound = errors.NewStd("lock not found")
 
 	// ErrDuplicateKey indicates a unique constraint violation.
-	ErrDuplicateKey = errors.New("duplicate key")
+	ErrDuplicateKey = errors.NewStd("duplicate key")
 
 	// ErrDetectionLocked indicates the detection is locked and cannot be modified.
-	ErrDetectionLocked = errors.New("detection is locked")
+	ErrDetectionLocked = errors.NewStd("detection is locked")
 
 	// ErrInvalidInput indicates invalid input parameters.
-	ErrInvalidInput = errors.New("invalid input")
+	ErrInvalidInput = errors.NewStd("invalid input")
 
 	// ErrNoClipPath indicates the detection exists but has no associated clip path.
-	ErrNoClipPath = errors.New("detection has no clip path")
+	ErrNoClipPath = errors.NewStd("detection has no clip path")
 
 	// ErrDailyEventsNotFound indicates no daily events exist for the date.
-	ErrDailyEventsNotFound = errors.New("daily events not found")
+	ErrDailyEventsNotFound = errors.NewStd("daily events not found")
 
 	// ErrHourlyWeatherNotFound indicates no hourly weather data exists.
-	ErrHourlyWeatherNotFound = errors.New("hourly weather not found")
+	ErrHourlyWeatherNotFound = errors.NewStd("hourly weather not found")
 
 	// ErrImageCacheNotFound indicates the image cache entry was not found.
-	ErrImageCacheNotFound = errors.New("image cache not found")
+	ErrImageCacheNotFound = errors.NewStd("image cache not found")
 
 	// ErrDynamicThresholdNotFound indicates no dynamic threshold exists for the species.
-	ErrDynamicThresholdNotFound = errors.New("dynamic threshold not found")
+	ErrDynamicThresholdNotFound = errors.NewStd("dynamic threshold not found")
 
 	// ErrThresholdEventNotFound indicates no threshold event exists.
-	ErrThresholdEventNotFound = errors.New("threshold event not found")
+	ErrThresholdEventNotFound = errors.NewStd("threshold event not found")
 
 	// ErrNotificationHistoryNotFound indicates no notification history exists.
-	ErrNotificationHistoryNotFound = errors.New("notification history not found")
+	ErrNotificationHistoryNotFound = errors.NewStd("notification history not found")
 )

--- a/internal/datastore/v2/repository/filter_conversion.go
+++ b/internal/datastore/v2/repository/filter_conversion.go
@@ -4,7 +4,6 @@ package repository
 
 import (
 	"context"
-	"errors"
 	"maps"
 	"slices"
 	"strings"
@@ -12,6 +11,7 @@ import (
 
 	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/datastore/v2/entities"
+	"github.com/tphakala/birdnet-go/internal/errors"
 )
 
 // =============================================================================
@@ -345,7 +345,7 @@ func parseDateString(dateStr string, tz *time.Location, endOfDay bool) (*int64, 
 
 	t, err := time.ParseInLocation("2006-01-02", dateStr, tz)
 	if err != nil {
-		return nil, errors.New("invalid date format: expected YYYY-MM-DD, got " + dateStr)
+		return nil, errors.NewStd("invalid date format: expected YYYY-MM-DD, got " + dateStr)
 	}
 
 	if endOfDay {

--- a/internal/datastore/v2/repository/label_impl.go
+++ b/internal/datastore/v2/repository/label_impl.go
@@ -2,13 +2,13 @@ package repository
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"maps"
 	"slices"
 	"strings"
 
 	"github.com/tphakala/birdnet-go/internal/datastore/v2/entities"
+	"github.com/tphakala/birdnet-go/internal/errors"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 )

--- a/internal/logger/central_logger.go
+++ b/internal/logger/central_logger.go
@@ -2,7 +2,6 @@ package logger
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 	"math"
@@ -18,6 +17,8 @@ import (
 	// timezone data directly in the binary (~450KB), ensuring
 	// timezone operations work consistently on Linux, macOS, and Windows.
 	_ "time/tzdata"
+
+	"github.com/tphakala/birdnet-go/internal/errors"
 )
 
 // Constants for logger configuration

--- a/internal/notification/push_script.go
+++ b/internal/notification/push_script.go
@@ -3,7 +3,6 @@ package notification
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"maps"
 	"os"
@@ -11,6 +10,8 @@ import (
 	"slices"
 	"strings"
 	"time"
+
+	"github.com/tphakala/birdnet-go/internal/errors"
 )
 
 type ScriptProvider struct {

--- a/internal/securefs/errors.go
+++ b/internal/securefs/errors.go
@@ -3,7 +3,7 @@
 package securefs
 
 import (
-	"errors"
+	"github.com/tphakala/birdnet-go/internal/errors"
 )
 
 // Sentinel errors for the securefs package.
@@ -11,14 +11,14 @@ import (
 var (
 	// ErrPathTraversal indicates an attempt to access a path outside the allowed directory
 	// via relative path traversal (e.g., using "../" to escape the directory).
-	ErrPathTraversal = errors.New("security error: path attempts to traverse outside base directory")
+	ErrPathTraversal = errors.NewStd("security error: path attempts to traverse outside base directory")
 
 	// ErrInvalidPath indicates an invalid path specification (e.g., absolute path when relative is required)
-	ErrInvalidPath = errors.New("security error: invalid path specification")
+	ErrInvalidPath = errors.NewStd("security error: invalid path specification")
 
 	// ErrAccessDenied indicates a permission error when accessing a file or directory
-	ErrAccessDenied = errors.New("security error: access denied")
+	ErrAccessDenied = errors.NewStd("security error: access denied")
 
 	// ErrNotRegularFile indicates an attempt to access something that is not a regular file
-	ErrNotRegularFile = errors.New("security error: not a regular file")
+	ErrNotRegularFile = errors.NewStd("security error: not a regular file")
 )

--- a/internal/securefs/securefs.go
+++ b/internal/securefs/securefs.go
@@ -1,7 +1,6 @@
 package securefs
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -13,6 +12,7 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
+	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/logger"
 )
 
@@ -515,7 +515,7 @@ func (sfs *SecureFS) GetMaxReadFileSize() int64 {
 }
 
 // ErrFileTooLarge is returned when a file exceeds the configured size limit
-var ErrFileTooLarge = errors.New("file size exceeds maximum allowed size")
+var ErrFileTooLarge = errors.NewStd("file size exceeds maximum allowed size")
 
 // ReadFile reads a file with path validation and returns its contents.
 // If maxReadFileSize is set (> 0), files exceeding that size will return ErrFileTooLarge.

--- a/internal/security/basic.go
+++ b/internal/security/basic.go
@@ -3,10 +3,11 @@ package security
 import (
 	"context"
 	"crypto/subtle"
-	"errors"
 	"fmt"
 	"net"
 	"net/http"
+
+	"github.com/tphakala/birdnet-go/internal/errors"
 
 	"github.com/gorilla/sessions"
 	"github.com/labstack/echo/v4"

--- a/internal/security/util.go
+++ b/internal/security/util.go
@@ -1,12 +1,12 @@
 package security
 
 import (
-	"errors"
 	"fmt"
 	"net/url"
 	"path"
 	"strings"
 
+	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/logger"
 	"golang.org/x/text/unicode/norm"
 )
@@ -79,7 +79,7 @@ func ValidateRedirectURI(providedURIString string, expectedURI *url.URL) error {
 			expectedURI.Scheme, expectedURI.Hostname(), expectedPort, expectedPath)
 
 		// Construct the detailed error message first
-		mismatchErr := errors.New(mismatchDetail) // Use errors.New for a simple error string
+		mismatchErr := errors.NewStd(mismatchDetail)
 
 		// Wrap the detailed error using a constant format string
 		return fmt.Errorf("invalid redirect_uri: %w", mismatchErr)

--- a/main.go
+++ b/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"embed"
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -17,6 +16,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/analysis"
 	"github.com/tphakala/birdnet-go/internal/api"
 	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/imageprovider"
 	"github.com/tphakala/birdnet-go/internal/logger"
 	"github.com/tphakala/birdnet-go/internal/telemetry"


### PR DESCRIPTION
## Summary
- Replace standard library `"errors"` imports with `internal/errors` across 16 files
- Sentinel errors (`errors.New("...")`) migrated to `errors.NewStd("...")` for stdlib-compatible plain error values
- Passthrough functions (`Is`, `As`, `Join`) work identically via `internal/errors`
- Remove `apperrors` and `intErrors` aliases — all imports are now unaliased as `errors`

## Test plan
- [x] `golangci-lint run` — 0 issues
- [x] `go test ./...` — all pass (only pre-existing `TestNightFilterExcludesSunriseSunsetWindows` failure)
- [x] No circular dependencies — `internal/errors` has zero internal package imports

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for new authentication methods: None, Browser Session, API Key, and Local Subnet.

* **Chores**
  * Internal refactoring of error handling mechanisms across the application to improve code consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->