### PR TITLE
refactor: replace time format strings with stdlib constants

### DIFF
--- a/internal/analysis/processor/actions_integrations.go
+++ b/internal/analysis/processor/actions_integrations.go
@@ -311,7 +311,7 @@ func (a *UpdateRangeFilterAction) Execute(_ context.Context, data any) error {
 
 		GetLogger().Error("Failed to get probable species for range filter",
 			logger.Error(err),
-			logger.String("date", today.Format("2006-01-02")),
+			logger.String("date", today.Format(time.DateOnly)),
 			logger.String("operation", "update_range_filter"))
 		return err
 	}
@@ -328,7 +328,7 @@ func (a *UpdateRangeFilterAction) Execute(_ context.Context, data any) error {
 	if a.Settings.Debug {
 		GetLogger().Info("Range filter updated successfully",
 			logger.Int("species_count", len(includedSpecies)),
-			logger.String("date", today.Format("2006-01-02")),
+			logger.String("date", today.Format(time.DateOnly)),
 			logger.String("operation", "update_range_filter_success"))
 	}
 

--- a/internal/analysis/species/database.go
+++ b/internal/analysis/species/database.go
@@ -23,7 +23,7 @@ func (t *SpeciesTracker) InitFromDatabase() error {
 	now := time.Now()
 
 	getLog().Debug("Initializing species tracker from database",
-		logger.String("current_time", now.Format("2006-01-02 15:04:05")),
+		logger.String("current_time", now.Format(time.DateTime)),
 		logger.Bool("yearly_enabled", t.yearlyEnabled),
 		logger.Bool("seasonal_enabled", t.seasonalEnabled))
 
@@ -36,7 +36,7 @@ func (t *SpeciesTracker) InitFromDatabase() error {
 			Component("new-species-tracker").
 			Category(errors.CategoryDatabase).
 			Context("operation", "load_lifetime_data").
-			Context("sync_time", now.Format("2006-01-02 15:04:05")).
+			Context("sync_time", now.Format(time.DateTime)).
 			Build()
 	}
 
@@ -93,7 +93,7 @@ func (t *SpeciesTracker) InitFromDatabase() error {
 
 // loadLifetimeDataFromDatabase loads all-time first detection data
 func (t *SpeciesTracker) loadLifetimeDataFromDatabase(now time.Time) error {
-	endDate := now.Format("2006-01-02")
+	endDate := now.Format(time.DateOnly)
 	startDate := "1900-01-01" // Load from beginning of time to get all historical data
 
 	// TODO(graceful-shutdown): Accept context parameter to enable graceful cancellation during shutdown
@@ -118,7 +118,7 @@ func (t *SpeciesTracker) loadLifetimeDataFromDatabase(now time.Time) error {
 		t.speciesFirstSeen = make(map[string]time.Time, len(newSpeciesData))
 		for _, species := range newSpeciesData {
 			if species.FirstSeenDate != "" {
-				firstSeen, err := time.Parse("2006-01-02", species.FirstSeenDate)
+				firstSeen, err := time.Parse(time.DateOnly, species.FirstSeenDate)
 				if err != nil {
 					getLog().Debug("Failed to parse first seen date",
 						logger.String("species", species.ScientificName),
@@ -171,7 +171,7 @@ func (t *SpeciesTracker) loadYearlyDataFromDatabase(now time.Time) error {
 		t.speciesThisYear = make(map[string]time.Time, len(yearlyData))
 		for _, species := range yearlyData {
 			if species.FirstSeenDate != "" {
-				firstSeen, err := time.Parse("2006-01-02", species.FirstSeenDate)
+				firstSeen, err := time.Parse(time.DateOnly, species.FirstSeenDate)
 				if err != nil {
 					getLog().Debug("Failed to parse yearly first seen date",
 						logger.String("species", species.ScientificName),
@@ -230,7 +230,7 @@ func (t *SpeciesTracker) loadSingleSeasonData(seasonName string, now time.Time) 
 		if species.FirstSeenDate == "" {
 			continue
 		}
-		firstSeen, parseErr := time.Parse("2006-01-02", species.FirstSeenDate)
+		firstSeen, parseErr := time.Parse(time.DateOnly, species.FirstSeenDate)
 		if parseErr != nil {
 			getLog().Debug("Failed to parse seasonal first seen date",
 				logger.String("species", species.ScientificName),
@@ -304,7 +304,7 @@ func (t *SpeciesTracker) loadNotificationHistoryFromDatabase(now time.Time) erro
 	lookbackTime := now.Add(-2 * t.notificationSuppressionWindow)
 
 	getLog().Debug("Loading notification history from database",
-		logger.String("lookback_time", lookbackTime.Format("2006-01-02 15:04:05")),
+		logger.String("lookback_time", lookbackTime.Format(time.DateTime)),
 		logger.Duration("suppression_window", t.notificationSuppressionWindow))
 
 	// Get notification history from database
@@ -314,7 +314,7 @@ func (t *SpeciesTracker) loadNotificationHistoryFromDatabase(now time.Time) erro
 			Component("new-species-tracker").
 			Category(errors.CategoryDatabase).
 			Context("operation", "load_notification_history").
-			Context("lookback_time", lookbackTime.Format("2006-01-02 15:04:05")).
+			Context("lookback_time", lookbackTime.Format(time.DateTime)).
 			Build()
 	}
 
@@ -337,7 +337,7 @@ func (t *SpeciesTracker) loadNotificationHistoryFromDatabase(now time.Time) erro
 
 		getLog().Debug("Loaded notification history",
 			logger.String("species", histories[i].ScientificName),
-			logger.String("last_sent", histories[i].LastSent.Format("2006-01-02 15:04:05")),
+			logger.String("last_sent", histories[i].LastSent.Format(time.DateTime)),
 			logger.String("notification_type", histories[i].NotificationType))
 	}
 

--- a/internal/analysis/species/maintenance.go
+++ b/internal/analysis/species/maintenance.go
@@ -104,8 +104,8 @@ func (t *SpeciesTracker) pruneYearlyEntriesLocked(now time.Time) int {
 			pruned++
 			getLog().Debug("Pruned old yearly entry",
 				logger.String("species", scientificName),
-				logger.String("first_seen", firstSeen.Format("2006-01-02")),
-				logger.String("year_start", currentYearStart.Format("2006-01-02")))
+				logger.String("first_seen", firstSeen.Format(time.DateOnly)),
+				logger.String("year_start", currentYearStart.Format(time.DateOnly)))
 		}
 	}
 	return pruned
@@ -241,7 +241,7 @@ func (t *SpeciesTracker) RecordNotificationSent(scientificName string, sentTime 
 	// Log outside the critical section to reduce lock contention
 	getLog().Debug("Recorded notification sent",
 		logger.String("species", scientificName),
-		logger.String("sent_time", sentTime.Format("2006-01-02 15:04:05")))
+		logger.String("sent_time", sentTime.Format(time.DateTime)))
 
 	// Persist to database asynchronously to avoid blocking (BG-17 fix)
 	// This ensures notification suppression state survives application restarts
@@ -272,7 +272,7 @@ func (t *SpeciesTracker) RecordNotificationSent(scientificName string, sentTime 
 			} else {
 				getLog().Debug("Persisted notification history to database",
 					logger.String("species", scientificName),
-					logger.String("expires_at", expiresAt.Format("2006-01-02 15:04:05")))
+					logger.String("expires_at", expiresAt.Format(time.DateTime)))
 			}
 		})
 	}
@@ -297,7 +297,7 @@ func (t *SpeciesTracker) CleanupOldNotificationRecords(currentTime time.Time) in
 		cutoffTime := currentTime.Add(-t.notificationSuppressionWindow)
 		getLog().Debug("Cleaned up old notification records from memory",
 			logger.Int("removed_count", cleaned),
-			logger.String("cutoff_time", cutoffTime.Format("2006-01-02 15:04:05")))
+			logger.String("cutoff_time", cutoffTime.Format(time.DateTime)))
 	}
 
 	// Clean up database records asynchronously (BG-17 fix)
@@ -313,11 +313,11 @@ func (t *SpeciesTracker) CleanupOldNotificationRecords(currentTime time.Time) in
 			if err != nil {
 				getLog().Error("Failed to cleanup expired notification history from database",
 					logger.Error(err),
-					logger.String("current_time", currentTime.Format("2006-01-02 15:04:05")))
+					logger.String("current_time", currentTime.Format(time.DateTime)))
 			} else if deletedCount > 0 {
 				getLog().Debug("Cleaned up expired notification history from database",
 					logger.Int64("deleted_count", deletedCount),
-					logger.String("current_time", currentTime.Format("2006-01-02 15:04:05")))
+					logger.String("current_time", currentTime.Format(time.DateTime)))
 			}
 		})
 	}

--- a/internal/analysis/species/season.go
+++ b/internal/analysis/species/season.go
@@ -210,7 +210,7 @@ func (t *SpeciesTracker) calculateSeasonStartDate(seasonName string, seasonStart
 		seasonDate = time.Date(currentTime.Year()-1, time.Month(seasonStart.month), seasonStart.day, 0, 0, 0, 0, currentTime.Location())
 		getLog().Debug("Adjusting season to previous year",
 			logger.String("season", seasonName),
-			logger.String("adjusted_date", seasonDate.Format("2006-01-02")))
+			logger.String("adjusted_date", seasonDate.Format(time.DateOnly)))
 	}
 	return seasonDate
 }
@@ -218,7 +218,7 @@ func (t *SpeciesTracker) calculateSeasonStartDate(seasonName string, seasonStart
 // computeCurrentSeason performs the actual season calculation
 func (t *SpeciesTracker) computeCurrentSeason(currentTime time.Time) string {
 	getLog().Debug("Computing current season",
-		logger.String("input_time", currentTime.Format("2006-01-02 15:04:05")),
+		logger.String("input_time", currentTime.Format(time.DateTime)),
 		logger.Int("current_month", int(currentTime.Month())),
 		logger.Int("current_day", currentTime.Day()),
 		logger.Int("current_year", currentTime.Year()))
@@ -260,7 +260,7 @@ func (t *SpeciesTracker) computeCurrentSeason(currentTime time.Time) string {
 
 	getLog().Debug("Computed season result",
 		logger.String("season", currentSeason),
-		logger.String("season_start_date", latestDate.Format("2006-01-02")))
+		logger.String("season_start_date", latestDate.Format(time.DateOnly)))
 
 	return currentSeason
 }
@@ -277,7 +277,7 @@ func (t *SpeciesTracker) checkAndResetPeriods(currentTime time.Time) {
 		getLog().Debug("Reset yearly tracking",
 			logger.Int("old_year", oldYear),
 			logger.Int("new_year", t.currentYear),
-			logger.String("check_time", currentTime.Format("2006-01-02 15:04:05")))
+			logger.String("check_time", currentTime.Format(time.DateTime)))
 	}
 
 	// Check for seasonal reset
@@ -384,8 +384,8 @@ func (t *SpeciesTracker) getYearDateRange(now time.Time) (startDate, endDate str
 	nextYearReset := time.Date(trackingYear+1, time.Month(t.resetMonth), t.resetDay, 0, 0, 0, 0, now.Location())
 	yearEnd := nextYearReset.AddDate(0, 0, -1)
 
-	startDate = yearStart.Format("2006-01-02")
-	endDate = yearEnd.Format("2006-01-02")
+	startDate = yearStart.Format(time.DateOnly)
+	endDate = yearEnd.Format(time.DateOnly)
 
 	return startDate, endDate
 }
@@ -416,8 +416,8 @@ func (t *SpeciesTracker) getSeasonDateRange(seasonName string, now time.Time) (s
 	// Add monthsPerSeason months, then subtract 1 day to get the last day of the final month
 	seasonEnd := seasonStart.AddDate(0, monthsPerSeason, 0).AddDate(0, 0, -1)
 
-	startDate = seasonStart.Format("2006-01-02")
-	endDate = seasonEnd.Format("2006-01-02")
+	startDate = seasonStart.Format(time.DateOnly)
+	endDate = seasonEnd.Format(time.DateOnly)
 
 	return startDate, endDate
 }

--- a/internal/analysis/species/species_tracker.go
+++ b/internal/analysis/species/species_tracker.go
@@ -184,7 +184,7 @@ func NewTrackerFromSettings(ds SpeciesDatastore, settings *conf.SpeciesTrackingS
 		logger.Int("window_days", settings.NewSpeciesWindowDays),
 		logger.Bool("yearly_enabled", settings.YearlyTracking.Enabled),
 		logger.Bool("seasonal_enabled", settings.SeasonalTracking.Enabled),
-		logger.String("current_time", now.Format("2006-01-02 15:04:05")))
+		logger.String("current_time", now.Format(time.DateTime)))
 
 	tracker := &SpeciesTracker{
 		// Lifetime tracking

--- a/internal/analysis/species/species_tracker_business_logic_reliability_test.go
+++ b/internal/analysis/species/species_tracker_business_logic_reliability_test.go
@@ -354,7 +354,7 @@ func TestComputeCurrentSeason_CriticalReliability(t *testing.T) {
 			actualSeason := tracker.getCurrentSeason(tt.currentTime)
 			assert.Equal(t, tt.expectedSeason, actualSeason,
 				"Season calculation incorrect for %v (expected %s, got %s)",
-				tt.currentTime.Format("2006-01-02"), tt.expectedSeason, actualSeason)
+				tt.currentTime.Format(time.DateOnly), tt.expectedSeason, actualSeason)
 
 			t.Logf("✓ Season correctly calculated: %s for %s", actualSeason, tt.currentTime.Format("2006-01-02 15:04"))
 

--- a/internal/analysis/species/species_tracker_critical_operations_test.go
+++ b/internal/analysis/species/species_tracker_critical_operations_test.go
@@ -247,7 +247,7 @@ func TestUpdateSpecies_CriticalReliability(t *testing.T) {
 			_, cacheExists := tracker.statusCache[tt.speciesName]
 			assert.False(t, cacheExists, "Cache should be invalidated after update")
 
-			t.Logf("✓ Update logic correct: isNew=%v, lifetime=%v", isNew, actualLifetime.Format("2006-01-02"))
+			t.Logf("✓ Update logic correct: isNew=%v, lifetime=%v", isNew, actualLifetime.Format(time.DateOnly))
 		})
 	}
 }

--- a/internal/analysis/species/species_tracker_database_reliability_test.go
+++ b/internal/analysis/species/species_tracker_database_reliability_test.go
@@ -23,9 +23,9 @@ func TestLoadLifetimeDataFromDatabase_CriticalReliability(t *testing.T) {
 	t.Parallel()
 
 	// Use recent dates to avoid pruning issues
-	recentDate := time.Now().AddDate(0, 0, -5).Format("2006-01-02")       // 5 days ago
-	olderRecentDate := time.Now().AddDate(0, 0, -10).Format("2006-01-02") // 10 days ago
-	newerRecentDate := time.Now().AddDate(0, 0, -2).Format("2006-01-02")  // 2 days ago
+	recentDate := time.Now().AddDate(0, 0, -5).Format(time.DateOnly)       // 5 days ago
+	olderRecentDate := time.Now().AddDate(0, 0, -10).Format(time.DateOnly) // 10 days ago
+	newerRecentDate := time.Now().AddDate(0, 0, -2).Format(time.DateOnly)  // 2 days ago
 
 	tests := []struct {
 		name          string
@@ -171,8 +171,8 @@ func TestLoadYearlyDataFromDatabase_CriticalReliability(t *testing.T) {
 	// Use current year and recent dates
 	currentYear := time.Now().Year()
 	currentTime := time.Now()
-	recentDate := currentTime.AddDate(0, 0, -5).Format("2006-01-02")       // 5 days ago
-	olderRecentDate := currentTime.AddDate(0, 0, -10).Format("2006-01-02") // 10 days ago
+	recentDate := currentTime.AddDate(0, 0, -5).Format(time.DateOnly)       // 5 days ago
+	olderRecentDate := currentTime.AddDate(0, 0, -10).Format(time.DateOnly) // 10 days ago
 
 	tests := []struct {
 		name          string
@@ -291,7 +291,7 @@ func TestLoadYearlyDataFromDatabase_CriticalReliability(t *testing.T) {
 				assert.True(t, isNew, "Yearly tracking should be functional after data loading")
 				assert.Equal(t, 0, days, "New species should have 0 days in new year context")
 
-				t.Logf("✓ Yearly data loading successful for time: %v", tt.currentTime.Format("2006-01-02"))
+				t.Logf("✓ Yearly data loading successful for time: %v", tt.currentTime.Format(time.DateOnly))
 			}
 
 			// Test system stability
@@ -385,8 +385,8 @@ func TestSyncIfNeeded_CriticalReliability(t *testing.T) {
 			ds := mocks.NewMockInterface(t)
 
 			// Setup mock data for initial load and sync calls with recent dates
-			recentDate := time.Now().AddDate(0, 0, -5).Format("2006-01-02")      // 5 days ago
-			newerRecentDate := time.Now().AddDate(0, 0, -2).Format("2006-01-02") // 2 days ago
+			recentDate := time.Now().AddDate(0, 0, -5).Format(time.DateOnly)      // 5 days ago
+			newerRecentDate := time.Now().AddDate(0, 0, -2).Format(time.DateOnly) // 2 days ago
 
 			initialData := []datastore.NewSpeciesData{
 				{ScientificName: "Initial_Species", FirstSeenDate: recentDate},
@@ -488,7 +488,7 @@ func generateLargeDataset(count int) []datastore.NewSpeciesData {
 		speciesName := fmt.Sprintf("Large_Dataset_Species_%06d", i)
 		// Spread across 10 days instead of full year to keep all data recent
 		detectionDate := baseDate.AddDate(0, 0, i%10)
-		dateStr := detectionDate.Format("2006-01-02")
+		dateStr := detectionDate.Format(time.DateOnly)
 
 		data[i] = datastore.NewSpeciesData{
 			ScientificName: speciesName,

--- a/internal/analysis/species/species_tracker_daterange_test.go
+++ b/internal/analysis/species/species_tracker_daterange_test.go
@@ -174,9 +174,9 @@ func TestGetYearDateRange_CriticalReliability(t *testing.T) {
 			startDate, endDate := tracker.getYearDateRange(tt.currentTime)
 
 			assert.Equal(t, tt.expectedStartDate, startDate,
-				"Start date mismatch for %s", tt.currentTime.Format("2006-01-02"))
+				"Start date mismatch for %s", tt.currentTime.Format(time.DateOnly))
 			assert.Equal(t, tt.expectedEndDate, endDate,
-				"End date mismatch for %s", tt.currentTime.Format("2006-01-02"))
+				"End date mismatch for %s", tt.currentTime.Format(time.DateOnly))
 
 			t.Logf("✓ Date range correct: %s to %s", startDate, endDate)
 		})
@@ -492,7 +492,7 @@ func TestIsWithinCurrentYear_CriticalReliability(t *testing.T) {
 			withinYear := tracker.isWithinCurrentYear(tt.detectionTime)
 
 			assert.Equal(t, tt.expectedWithin, withinYear,
-				"Within year mismatch for %s", tt.detectionTime.Format("2006-01-02"))
+				"Within year mismatch for %s", tt.detectionTime.Format(time.DateOnly))
 
 			t.Logf("✓ Correctly determined within year: %v", withinYear)
 		})
@@ -585,7 +585,7 @@ func TestShouldResetYear_CriticalReliability(t *testing.T) {
 
 			assert.Equal(t, tt.expectedReset, shouldReset,
 				"Reset mismatch for year %d at %s",
-				tt.trackerYear, tt.currentTime.Format("2006-01-02"))
+				tt.trackerYear, tt.currentTime.Format(time.DateOnly))
 
 			t.Logf("✓ Correctly determined reset: %v", shouldReset)
 		})

--- a/internal/analysis/species/species_tracker_fix_validation_test.go
+++ b/internal/analysis/species/species_tracker_fix_validation_test.go
@@ -65,7 +65,7 @@ func TestNegativeDaysFixValidation(t *testing.T) {
 		isNew, days := tracker.CheckAndUpdateSpecies(species, testTime)
 
 		t.Logf("Test %d: time=%v, isNew=%v, days=%d",
-			i+1, testTime.Format("15:04:05"), isNew, days)
+			i+1, testTime.Format(time.TimeOnly), isNew, days)
 
 		// Critical assertion: days should never be negative
 		assert.GreaterOrEqual(t, days, 0,

--- a/internal/analysis/species/species_tracker_periods_test.go
+++ b/internal/analysis/species/species_tracker_periods_test.go
@@ -243,7 +243,7 @@ func TestYearlyTrackingAcrossYearBoundary(t *testing.T) {
 
 	// Now detect it in 2024
 	isNew := tracker.UpdateSpecies("Turdus merula", jan2024)
-	t.Logf("UpdateSpecies returned isNew=%v for detection on %s", isNew, jan2024.Format("2006-01-02"))
+	t.Logf("UpdateSpecies returned isNew=%v for detection on %s", isNew, jan2024.Format(time.DateOnly))
 
 	// Check internal state directly
 	tracker.mu.RLock()
@@ -253,7 +253,7 @@ func TestYearlyTrackingAcrossYearBoundary(t *testing.T) {
 	tracker.mu.RUnlock()
 	yearTimeStr := testNilString
 	if inYearMap {
-		yearTimeStr = yearTime.Format("2006-01-02")
+		yearTimeStr = yearTime.Format(time.DateOnly)
 	}
 	t.Logf("After update: currentYear=%d, yearMapSize=%d, species in year map=%v, yearTime=%s", currentYear, yearMapSize, inYearMap, yearTimeStr)
 
@@ -734,7 +734,7 @@ func TestDefaultSeasonInitialization(t *testing.T) {
 		tracker.UpdateSpecies("Test species", test.date)
 		status := tracker.GetSpeciesStatus("Test species", test.date)
 		assert.Equal(t, test.season, status.CurrentSeason,
-			"Expected season '%s' for date %s", test.season, test.date.Format("2006-01-02"))
+			"Expected season '%s' for date %s", test.season, test.date.Format(time.DateOnly))
 	}
 }
 

--- a/internal/analysis/species/species_tracker_season_test.go
+++ b/internal/analysis/species/species_tracker_season_test.go
@@ -180,7 +180,7 @@ func TestSeasonDateRanges(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			tracker := createTestTracker(t)
-			testTime, err := time.Parse("2006-01-02", tt.currentDate)
+			testTime, err := time.Parse(time.DateOnly, tt.currentDate)
 			require.NoError(t, err)
 			testTime = testTime.Add(17*time.Hour + 42*time.Minute + 39*time.Second)
 
@@ -228,7 +228,7 @@ func TestCurrentSeasonDetection(t *testing.T) {
 		t.Run(tt.date+"_"+tt.expectedSeason, func(t *testing.T) {
 			t.Parallel()
 			tracker := createTestTracker(t)
-			testTime, err := time.Parse("2006-01-02", tt.date)
+			testTime, err := time.Parse(time.DateOnly, tt.date)
 			require.NoError(t, err)
 			testTime = testTime.Add(12 * time.Hour) // Noon
 
@@ -288,7 +288,7 @@ func TestDateValidation(t *testing.T) {
 	}
 
 	for _, dateStr := range testDates {
-		testTime, err := time.Parse("2006-01-02", dateStr)
+		testTime, err := time.Parse(time.DateOnly, dateStr)
 		require.NoError(t, err)
 
 		for seasonName := range tracker.seasons {
@@ -300,8 +300,8 @@ func TestDateValidation(t *testing.T) {
 				seasonName, dateStr, startDate, endDate)
 
 			// Ensure dates are valid format
-			_, err1 := time.Parse("2006-01-02", startDate)
-			_, err2 := time.Parse("2006-01-02", endDate)
+			_, err1 := time.Parse(time.DateOnly, startDate)
+			_, err2 := time.Parse(time.DateOnly, endDate)
 			assert.NoError(t, err1, "Start date should be valid: %s", startDate)
 			assert.NoError(t, err2, "End date should be valid: %s", endDate)
 		}
@@ -371,7 +371,7 @@ func TestSeasonBoundariesFixed(t *testing.T) {
 
 	for _, boundary := range seasonBoundaries {
 		t.Run(boundary.description, func(t *testing.T) {
-			testTime, err := time.Parse("2006-01-02", boundary.date)
+			testTime, err := time.Parse(time.DateOnly, boundary.date)
 			require.NoError(t, err)
 			testTime = testTime.Add(12 * time.Hour)
 

--- a/internal/analysis/species/species_tracker_test.go
+++ b/internal/analysis/species/species_tracker_test.go
@@ -32,12 +32,12 @@ func TestSpeciesTracker_NewSpecies(t *testing.T) {
 		{
 			ScientificName: testSpeciesParusMajor,
 			CommonName:     "Great Tit",
-			FirstSeenDate:  time.Now().Add(-oldSpeciesDays * 24 * time.Hour).Format("2006-01-02"),
+			FirstSeenDate:  time.Now().Add(-oldSpeciesDays * 24 * time.Hour).Format(time.DateOnly),
 		},
 		{
 			ScientificName: "Turdus merula",
 			CommonName:     "Common Blackbird",
-			FirstSeenDate:  time.Now().Add(-recentSpeciesDays * 24 * time.Hour).Format("2006-01-02"),
+			FirstSeenDate:  time.Now().Add(-recentSpeciesDays * 24 * time.Hour).Format(time.DateOnly),
 		},
 	}
 	ds.On("GetNewSpeciesDetections", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
@@ -190,7 +190,7 @@ func TestSpeciesTracker_EdgeCases(t *testing.T) {
 		historicalData := []datastore.NewSpeciesData{
 			{
 				ScientificName: testSpeciesParusMajor,
-				FirstSeenDate:  time.Now().Add(-14 * 24 * time.Hour).Format("2006-01-02"), // Exactly 14 days ago
+				FirstSeenDate:  time.Now().Add(-14 * 24 * time.Hour).Format(time.DateOnly), // Exactly 14 days ago
 			},
 		}
 		ds.On("GetNewSpeciesDetections", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
@@ -264,15 +264,15 @@ func TestSpeciesTracker_PruneOldEntries(t *testing.T) {
 	historicalData := []datastore.NewSpeciesData{
 		{
 			ScientificName: "Very Old Species",
-			FirstSeenDate:  time.Now().Add(-11 * 365 * 24 * time.Hour).Format("2006-01-02"), // 11 years ago (should be pruned)
+			FirstSeenDate:  time.Now().Add(-11 * 365 * 24 * time.Hour).Format(time.DateOnly), // 11 years ago (should be pruned)
 		},
 		{
 			ScientificName: "Old Species",
-			FirstSeenDate:  time.Now().Add(-30 * 24 * time.Hour).Format("2006-01-02"), // 30 days ago (should NOT be pruned)
+			FirstSeenDate:  time.Now().Add(-30 * 24 * time.Hour).Format(time.DateOnly), // 30 days ago (should NOT be pruned)
 		},
 		{
 			ScientificName: "Recent Species",
-			FirstSeenDate:  time.Now().Add(-5 * 24 * time.Hour).Format("2006-01-02"), // 5 days ago (should NOT be pruned)
+			FirstSeenDate:  time.Now().Add(-5 * 24 * time.Hour).Format(time.DateOnly), // 5 days ago (should NOT be pruned)
 		},
 	}
 	ds.On("GetNewSpeciesDetections", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("int"), mock.AnythingOfType("int")).
@@ -788,7 +788,7 @@ func TestSeasonDetection(t *testing.T) {
 			tracker.mu.Unlock()
 			assert.Equal(t, tc.expectedSeason, season,
 				"Expected season '%s' for date %s, got '%s'",
-				tc.expectedSeason, tc.date.Format("2006-01-02"), season)
+				tc.expectedSeason, tc.date.Format(time.DateOnly), season)
 		})
 	}
 }

--- a/internal/analysis/species/species_tracker_uncovered_test.go
+++ b/internal/analysis/species/species_tracker_uncovered_test.go
@@ -61,19 +61,19 @@ func TestSpeciesTracker_SetCurrentYearForTesting(t *testing.T) {
 	// Verify it affects year calculations
 	now := time.Now()
 	start, _ := tracker.getYearDateRange(now)
-	parsedStart, _ := time.Parse("2006-01-02", start)
+	parsedStart, _ := time.Parse(time.DateOnly, start)
 	assert.Equal(t, testYear, parsedStart.Year())
 
 	// Test with different year
 	tracker.SetCurrentYearForTesting(2025)
 	start, _ = tracker.getYearDateRange(now)
-	parsedStart, _ = time.Parse("2006-01-02", start)
+	parsedStart, _ = time.Parse(time.DateOnly, start)
 	assert.Equal(t, 2025, parsedStart.Year())
 
 	// Reset to 0 should use current year
 	tracker.SetCurrentYearForTesting(0)
 	start, _ = tracker.getYearDateRange(now)
-	parsedStart, _ = time.Parse("2006-01-02", start)
+	parsedStart, _ = time.Parse(time.DateOnly, start)
 	currentYear := time.Now().Year()
 	assert.Equal(t, currentYear, parsedStart.Year())
 }
@@ -146,12 +146,12 @@ func TestSpeciesTracker_loadYearlyDataFromDatabase(t *testing.T) {
 			{
 				ScientificName: "Robin",
 				CommonName:     "American Robin",
-				FirstSeenDate:  time.Now().Add(-10 * 24 * time.Hour).Format("2006-01-02"),
+				FirstSeenDate:  time.Now().Add(-10 * 24 * time.Hour).Format(time.DateOnly),
 			},
 			{
 				ScientificName: "Sparrow",
 				CommonName:     "House Sparrow",
-				FirstSeenDate:  time.Now().Add(-5 * 24 * time.Hour).Format("2006-01-02"),
+				FirstSeenDate:  time.Now().Add(-5 * 24 * time.Hour).Format(time.DateOnly),
 			},
 		}
 
@@ -238,12 +238,12 @@ func TestSpeciesTracker_loadSeasonalDataFromDatabase(t *testing.T) {
 			{
 				ScientificName: "Cardinal",
 				CommonName:     "Northern Cardinal",
-				FirstSeenDate:  time.Now().Add(-3 * 24 * time.Hour).Format("2006-01-02"),
+				FirstSeenDate:  time.Now().Add(-3 * 24 * time.Hour).Format(time.DateOnly),
 			},
 			{
 				ScientificName: "BlueJay",
 				CommonName:     "Blue Jay",
-				FirstSeenDate:  time.Now().Add(-1 * 24 * time.Hour).Format("2006-01-02"),
+				FirstSeenDate:  time.Now().Add(-1 * 24 * time.Hour).Format(time.DateOnly),
 			},
 		}
 

--- a/internal/analysis/species/status.go
+++ b/internal/analysis/species/status.go
@@ -42,7 +42,7 @@ func (t *SpeciesTracker) GetSpeciesStatus(scientificName string, currentTime tim
 	// Log computed status for debugging
 	getLog().Debug("Species status computed",
 		logger.String("species", scientificName),
-		logger.String("current_time", currentTime.Format("2006-01-02 15:04:05")),
+		logger.String("current_time", currentTime.Format(time.DateTime)),
 		logger.String("current_season", currentSeason),
 		logger.Bool("is_new", status.IsNew),
 		logger.Bool("is_new_this_year", status.IsNewThisYear),

--- a/internal/analysis/species/update.go
+++ b/internal/analysis/species/update.go
@@ -17,7 +17,7 @@ func (t *SpeciesTracker) updateLifetimeTrackingLocked(scientificName string, det
 		t.speciesFirstSeen[scientificName] = detectionTime
 		getLog().Debug("New lifetime species detected",
 			logger.String("species", scientificName),
-			logger.String("detection_time", detectionTime.Format("2006-01-02 15:04:05")))
+			logger.String("detection_time", detectionTime.Format(time.DateTime)))
 		return true
 	}
 
@@ -25,8 +25,8 @@ func (t *SpeciesTracker) updateLifetimeTrackingLocked(scientificName string, det
 		t.speciesFirstSeen[scientificName] = detectionTime
 		getLog().Debug("Updated lifetime first seen to earlier date",
 			logger.String("species", scientificName),
-			logger.String("old_date", firstSeen.Format("2006-01-02")),
-			logger.String("new_date", detectionTime.Format("2006-01-02")))
+			logger.String("old_date", firstSeen.Format(time.DateOnly)),
+			logger.String("new_date", detectionTime.Format(time.DateOnly)))
 	}
 	return false
 }
@@ -42,14 +42,14 @@ func (t *SpeciesTracker) updateYearlyTrackingLocked(scientificName string, detec
 		t.speciesThisYear[scientificName] = detectionTime
 		getLog().Debug("New species for this year",
 			logger.String("species", scientificName),
-			logger.String("detection_time", detectionTime.Format("2006-01-02 15:04:05")),
+			logger.String("detection_time", detectionTime.Format(time.DateTime)),
 			logger.Int("current_year", t.currentYear))
 	} else if detectionTime.Before(existingTime) {
 		t.speciesThisYear[scientificName] = detectionTime
 		getLog().Debug("Updated yearly first seen to earlier date",
 			logger.String("species", scientificName),
-			logger.String("old_date", existingTime.Format("2006-01-02")),
-			logger.String("new_date", detectionTime.Format("2006-01-02")),
+			logger.String("old_date", existingTime.Format(time.DateOnly)),
+			logger.String("new_date", detectionTime.Format(time.DateOnly)),
 			logger.Int("current_year", t.currentYear))
 	}
 }
@@ -70,7 +70,7 @@ func (t *SpeciesTracker) updateSeasonalTrackingLocked(scientificName string, det
 		getLog().Debug("New species for this season",
 			logger.String("species", scientificName),
 			logger.String("season", currentSeason),
-			logger.String("detection_time", detectionTime.Format("2006-01-02 15:04:05")))
+			logger.String("detection_time", detectionTime.Format(time.DateTime)))
 	}
 }
 

--- a/internal/api/v2/analytics.go
+++ b/internal/api/v2/analytics.go
@@ -314,7 +314,7 @@ func (c *Controller) parseDailySpeciesSummaryParams(ctx echo.Context) (selectedD
 	// Parse and validate date (defaults to today if not provided)
 	selectedDate = ctx.QueryParam("date")
 	if selectedDate == "" {
-		selectedDate = time.Now().Format("2006-01-02")
+		selectedDate = time.Now().Format(time.DateOnly)
 	} else if validErr := c.validateDateFormatWithResponse(ctx, selectedDate, "date", "daily species summary"); validErr != nil {
 		err = validErr
 		return
@@ -477,7 +477,7 @@ func parseStatusTimeFromDate(selectedDate string) time.Time {
 	if selectedDate == "" {
 		return time.Now()
 	}
-	parsedDate, err := time.Parse("2006-01-02", selectedDate)
+	parsedDate, err := time.Parse(time.DateOnly, selectedDate)
 	if err != nil {
 		return time.Now()
 	}
@@ -667,7 +667,7 @@ func formatTimeIfNotZero(t time.Time) string {
 	if t.IsZero() {
 		return ""
 	}
-	return t.Format("2006-01-02 15:04:05")
+	return t.Format(time.DateTime)
 }
 
 // getThumbnailURLFromBirdImage extracts URL from BirdImage map
@@ -811,8 +811,8 @@ func (c *Controller) GetDailyAnalytics(ctx echo.Context) error {
 
 	// Default end date if not provided
 	if endDate == "" {
-		startTime, _ := time.Parse("2006-01-02", startDate) // Regex ensures this parse succeeds
-		endDate = startTime.AddDate(0, 0, defaultAnalyticsDays).Format("2006-01-02")
+		startTime, _ := time.Parse(time.DateOnly, startDate) // Regex ensures this parse succeeds
+		endDate = startTime.AddDate(0, 0, defaultAnalyticsDays).Format(time.DateOnly)
 	}
 
 	c.logInfoIfEnabled("Retrieving daily analytics",
@@ -894,10 +894,10 @@ func (c *Controller) GetTimeOfDayDistribution(ctx echo.Context) error {
 	speciesParam := ctx.QueryParam("species")
 
 	if startDate == "" {
-		startDate = time.Now().AddDate(0, 0, -30).Format("2006-01-02")
+		startDate = time.Now().AddDate(0, 0, -30).Format(time.DateOnly)
 	}
 	if endDate == "" {
-		endDate = time.Now().Format("2006-01-02")
+		endDate = time.Now().Format(time.DateOnly)
 	}
 
 	// Validate date formats and chronological order
@@ -1052,7 +1052,7 @@ func parseAndValidateDateRange(startDateStr, endDateStr string) error {
 
 	// Validate start date format if provided
 	if startDateStr != "" {
-		start, err = time.Parse("2006-01-02", startDateStr)
+		start, err = time.Parse(time.DateOnly, startDateStr)
 		if err != nil {
 			// Return standard error
 			return fmt.Errorf("%w: %w", ErrInvalidStartDate, err)
@@ -1061,7 +1061,7 @@ func parseAndValidateDateRange(startDateStr, endDateStr string) error {
 
 	// Validate end date format if provided
 	if endDateStr != "" {
-		end, err = time.Parse("2006-01-02", endDateStr)
+		end, err = time.Parse(time.DateOnly, endDateStr)
 		if err != nil {
 			// Return standard error
 			return fmt.Errorf("%w: %w", ErrInvalidEndDate, err)
@@ -1313,8 +1313,8 @@ func (c *Controller) validateBatchDailyParams(ctx echo.Context, operation string
 
 	// Default end date if not provided
 	if endDate == "" {
-		startTime, _ := time.Parse("2006-01-02", startDate)
-		endDate = startTime.AddDate(0, 0, defaultAnalyticsDays).Format("2006-01-02")
+		startTime, _ := time.Parse(time.DateOnly, startDate)
+		endDate = startTime.AddDate(0, 0, defaultAnalyticsDays).Format(time.DateOnly)
 	}
 
 	uniqueSpecies = deduplicateSpeciesList(speciesParams)

--- a/internal/api/v2/detections.go
+++ b/internal/api/v2/detections.go
@@ -49,7 +49,7 @@ func validateDateParam(dateStr, paramName string) error {
 
 	// Try parsing the date to catch invalid dates like 2023-02-30
 	// This also catches dates with timezone annotations like 2024-04-05Z
-	_, err := time.Parse("2006-01-02", dateStr)
+	_, err := time.Parse(time.DateOnly, dateStr)
 	if err != nil {
 		return fmt.Errorf("invalid date value for %s: %w", paramName, err)
 	}
@@ -1467,15 +1467,15 @@ func (c *Controller) GetDetectionTimeOfDay(ctx echo.Context) error {
 // calculateTimeOfDay determines the time of day based on the detection time and sun events
 func calculateTimeOfDay(detectionTime time.Time, sunEvents *suncalc.SunEventTimes) string {
 	// Convert all times to the same format for comparison
-	detTime := detectionTime.Format("15:04:05")
-	sunriseTime := sunEvents.Sunrise.Format("15:04:05")
-	sunsetTime := sunEvents.Sunset.Format("15:04:05")
+	detTime := detectionTime.Format(time.TimeOnly)
+	sunriseTime := sunEvents.Sunrise.Format(time.TimeOnly)
+	sunsetTime := sunEvents.Sunset.Format(time.TimeOnly)
 
 	// Define sunrise/sunset window (30 minutes before and after)
-	sunriseStart := sunEvents.Sunrise.Add(-sunEventWindowMinutes * time.Minute).Format("15:04:05")
-	sunriseEnd := sunEvents.Sunrise.Add(sunEventWindowMinutes * time.Minute).Format("15:04:05")
-	sunsetStart := sunEvents.Sunset.Add(-sunEventWindowMinutes * time.Minute).Format("15:04:05")
-	sunsetEnd := sunEvents.Sunset.Add(sunEventWindowMinutes * time.Minute).Format("15:04:05")
+	sunriseStart := sunEvents.Sunrise.Add(-sunEventWindowMinutes * time.Minute).Format(time.TimeOnly)
+	sunriseEnd := sunEvents.Sunrise.Add(sunEventWindowMinutes * time.Minute).Format(time.TimeOnly)
+	sunsetStart := sunEvents.Sunset.Add(-sunEventWindowMinutes * time.Minute).Format(time.TimeOnly)
+	sunsetEnd := sunEvents.Sunset.Add(sunEventWindowMinutes * time.Minute).Format(time.TimeOnly)
 
 	switch {
 	case detTime >= sunriseStart && detTime <= sunriseEnd:

--- a/internal/api/v2/media.go
+++ b/internal/api/v2/media.go
@@ -1553,7 +1553,7 @@ func (c *Controller) checkAudioFileExists(relAudioPath string) error {
 		getSpectrogramLogger().Debug("Audio file exists",
 			logger.String("relative_audio_path", relAudioPath),
 			logger.Int64("size_bytes", audioStat.Size()),
-			logger.String("mod_time", audioStat.ModTime().Format("2006-01-02 15:04:05")))
+			logger.String("mod_time", audioStat.ModTime().Format(time.DateTime)))
 	}
 	return nil
 }
@@ -1830,7 +1830,7 @@ func (c *Controller) generateSpectrogram(ctx context.Context, audioPath string, 
 		logger.String("audio_path", audioPath),
 		logger.Int("width", width),
 		logger.Bool("raw", raw),
-		logger.String("request_time", start.Format("2006-01-02 15:04:05")))
+		logger.String("request_time", start.Format(time.DateTime)))
 
 	// Step 1: Normalize and validate path
 	relAudioPath, err := c.normalizeAndValidatePath(audioPath)

--- a/internal/api/v2/notifications.go
+++ b/internal/api/v2/notifications.go
@@ -674,7 +674,7 @@ func (c *Controller) CreateTestNewSpeciesNotification(ctx echo.Context) error {
 	now := time.Now()
 	var detectionTime string
 	if c.Settings.Main.TimeAs24h {
-		detectionTime = now.Format("15:04:05")
+		detectionTime = now.Format(time.TimeOnly)
 	} else {
 		detectionTime = now.Format("3:04:05 PM")
 	}
@@ -686,7 +686,7 @@ func (c *Controller) CreateTestNewSpeciesNotification(ctx echo.Context) error {
 		Confidence:         testNotificationConfidence,
 		ConfidencePercent:  "99",
 		DetectionTime:      detectionTime,
-		DetectionDate:      now.Format("2006-01-02"),
+		DetectionDate:      now.Format(time.DateOnly),
 		Latitude:           testNotificationLatitude,
 		Longitude:          testNotificationLongitude,
 		Location:           "Test Location (Sample Data)",

--- a/internal/api/v2/range.go
+++ b/internal/api/v2/range.go
@@ -47,7 +47,7 @@ func parseTestDate(dateStr string) (time.Time, error) {
 	if dateStr == "" {
 		return time.Now(), nil
 	}
-	return time.Parse("2006-01-02", dateStr)
+	return time.Parse(time.DateOnly, dateStr)
 }
 
 // calculateWeek calculates the BirdNET week number from a date.

--- a/internal/api/v2/species.go
+++ b/internal/api/v2/species.go
@@ -209,7 +209,7 @@ func (c *Controller) getSpeciesRarityInfo(bn *birdnet.BirdNET, speciesLabel stri
 
 	// Create rarity info
 	rarityInfo := &SpeciesRarityInfo{
-		Date:             today.Format("2006-01-02"),
+		Date:             today.Format(time.DateOnly),
 		LocationBased:    bn.Settings.BirdNET.Latitude != 0 || bn.Settings.BirdNET.Longitude != 0,
 		ThresholdApplied: float64(bn.Settings.BirdNET.RangeFilter.Threshold),
 	}

--- a/internal/api/v2/utils.go
+++ b/internal/api/v2/utils.go
@@ -231,7 +231,7 @@ func (c *Controller) validateDateFormatWithResponse(ctx echo.Context, dateStr, p
 	if dateStr == "" {
 		return nil // Empty is valid (optional parameter)
 	}
-	if _, err := time.Parse("2006-01-02", dateStr); err != nil {
+	if _, err := time.Parse(time.DateOnly, dateStr); err != nil {
 		c.logErrorIfEnabled("Invalid date format",
 			logger.String("parameter", paramName),
 			logger.String("value", dateStr),
@@ -402,7 +402,7 @@ func validateDateFormat(dateStr, paramName string) error {
 	if dateStr == "" {
 		return nil
 	}
-	if _, err := time.Parse("2006-01-02", dateStr); err != nil {
+	if _, err := time.Parse(time.DateOnly, dateStr); err != nil {
 		return fmt.Errorf("invalid %s format '%s', use YYYY-MM-DD", paramName, dateStr)
 	}
 	return nil
@@ -414,8 +414,8 @@ func validateDateOrder(startDate, endDate string) error {
 	if startDate == "" || endDate == "" {
 		return nil
 	}
-	start, _ := time.Parse("2006-01-02", startDate)
-	end, _ := time.Parse("2006-01-02", endDate)
+	start, _ := time.Parse(time.DateOnly, startDate)
+	end, _ := time.Parse(time.DateOnly, endDate)
 	if start.After(end) {
 		return fmt.Errorf("start date (%s) must be earlier than or equal to end date (%s)", startDate, endDate)
 	}
@@ -428,8 +428,8 @@ func (c *Controller) validateDateOrderWithResponse(ctx echo.Context, startDate, 
 	if startDate == "" || endDate == "" {
 		return nil // Empty dates are valid (handled elsewhere)
 	}
-	start, _ := time.Parse("2006-01-02", startDate)
-	end, _ := time.Parse("2006-01-02", endDate)
+	start, _ := time.Parse(time.DateOnly, startDate)
+	end, _ := time.Parse(time.DateOnly, endDate)
 	if start.After(end) {
 		c.logErrorIfEnabled("Invalid date range",
 			logger.String("start_date", startDate),
@@ -493,10 +493,10 @@ func getDefaultDateRange(startDate, endDate string, startDefault, endDefault int
 	start = startDate
 	end = endDate
 	if start == "" {
-		start = time.Now().AddDate(0, 0, startDefault).Format("2006-01-02")
+		start = time.Now().AddDate(0, 0, startDefault).Format(time.DateOnly)
 	}
 	if end == "" {
-		end = time.Now().AddDate(0, 0, endDefault).Format("2006-01-02")
+		end = time.Now().AddDate(0, 0, endDefault).Format(time.DateOnly)
 	}
 	return start, end
 }
@@ -521,7 +521,7 @@ func (c *Controller) parseCommaSeparatedDates(ctx echo.Context, paramName string
 			continue
 		}
 		// Validate date format
-		if _, err := time.Parse("2006-01-02", trimmed); err != nil {
+		if _, err := time.Parse(time.DateOnly, trimmed); err != nil {
 			return nil, fmt.Errorf("invalid date format: %s. Use YYYY-MM-DD", trimmed)
 		}
 		dates = append(dates, trimmed)
@@ -679,8 +679,8 @@ func parseDateRangeFilter(singleDate, startDate, endDate string) *DateRangeResul
 	}
 
 	if startDate != "" && endDate != "" {
-		start, err1 := time.Parse("2006-01-02", startDate)
-		end, err2 := time.Parse("2006-01-02", endDate)
+		start, err1 := time.Parse(time.DateOnly, startDate)
+		end, err2 := time.Parse(time.DateOnly, endDate)
 		if err1 == nil && err2 == nil {
 			// Reject inverted date ranges where start is after end
 			if start.After(end) {

--- a/internal/api/v2/weather.go
+++ b/internal/api/v2/weather.go
@@ -183,7 +183,7 @@ func (c *Controller) handleEmptyHourlyWeather(ctx echo.Context, date, ip, path s
 	}
 
 	// Check if it's a future date
-	requestedDate, parseErr := time.Parse("2006-01-02", date)
+	requestedDate, parseErr := time.Parse(time.DateOnly, date)
 	if parseErr != nil {
 		c.logErrorIfEnabled("Invalid date format in hourly weather request", logger.String("date", date), logger.Error(parseErr), logger.String("path", path), logger.String("ip", ip))
 		emptyResponse.Message = "No weather data found for the specified date"
@@ -435,7 +435,7 @@ func (c *Controller) findClosestHourlyWeather(detectionTime time.Time, hourlyWea
 // buildHourlyWeatherResponse creates an HourlyWeatherResponse from an HourlyWeather struct
 func (c *Controller) buildHourlyWeatherResponse(hw *datastore.HourlyWeather) HourlyWeatherResponse {
 	return HourlyWeatherResponse{
-		Time:        hw.Time.In(time.Local).Format("15:04:05"),
+		Time:        hw.Time.In(time.Local).Format(time.TimeOnly),
 		Temperature: hw.Temperature,
 		FeelsLike:   hw.FeelsLike,
 		TempMin:     hw.TempMin,
@@ -473,7 +473,7 @@ func (c *Controller) GetLatestWeather(ctx echo.Context) error {
 	}
 
 	// Get the date from the latest weather (convert to local time for correct date)
-	date := latestWeather.Time.In(time.Local).Format("2006-01-02")
+	date := latestWeather.Time.In(time.Local).Format(time.DateOnly)
 
 	// Build response with hourly data
 	response := struct {
@@ -516,15 +516,15 @@ func (c *Controller) GetLatestWeather(ctx echo.Context) error {
 // calculateTimeOfDay determines the time of day based on the detection time and sun events
 func (c *Controller) calculateTimeOfDay(detectionTime time.Time, sunEvents *suncalc.SunEventTimes) string {
 	// Convert all times to the same format for comparison
-	detTime := detectionTime.Format("15:04:05")
-	sunriseTime := sunEvents.Sunrise.Format("15:04:05")
-	sunsetTime := sunEvents.Sunset.Format("15:04:05")
+	detTime := detectionTime.Format(time.TimeOnly)
+	sunriseTime := sunEvents.Sunrise.Format(time.TimeOnly)
+	sunsetTime := sunEvents.Sunset.Format(time.TimeOnly)
 
 	// Define sunrise/sunset window (30 minutes before and after)
-	sunriseStart := sunEvents.Sunrise.Add(-weatherSunWindowMinute * time.Minute).Format("15:04:05")
-	sunriseEnd := sunEvents.Sunrise.Add(weatherSunWindowMinute * time.Minute).Format("15:04:05")
-	sunsetStart := sunEvents.Sunset.Add(-weatherSunWindowMinute * time.Minute).Format("15:04:05")
-	sunsetEnd := sunEvents.Sunset.Add(weatherSunWindowMinute * time.Minute).Format("15:04:05")
+	sunriseStart := sunEvents.Sunrise.Add(-weatherSunWindowMinute * time.Minute).Format(time.TimeOnly)
+	sunriseEnd := sunEvents.Sunrise.Add(weatherSunWindowMinute * time.Minute).Format(time.TimeOnly)
+	sunsetStart := sunEvents.Sunset.Add(-weatherSunWindowMinute * time.Minute).Format(time.TimeOnly)
+	sunsetEnd := sunEvents.Sunset.Add(weatherSunWindowMinute * time.Minute).Format(time.TimeOnly)
 
 	switch {
 	case detTime >= sunriseStart && detTime <= sunriseEnd:
@@ -560,7 +560,7 @@ func (c *Controller) GetSunTimes(ctx echo.Context) error {
 	}
 
 	// Validate date format
-	parsedDate, err := time.Parse("2006-01-02", date)
+	parsedDate, err := time.Parse(time.DateOnly, date)
 	if err != nil {
 		c.logErrorIfEnabled("Invalid date format in sun times request",
 			logger.String("date", date),

--- a/internal/api/v2/weather_test.go
+++ b/internal/api/v2/weather_test.go
@@ -310,7 +310,7 @@ func TestGetHourlyWeatherForDayFutureDate(t *testing.T) {
 	e, mockDS, controller := setupWeatherTestEnvironment(t)
 
 	// Get tomorrow's date
-	tomorrow := time.Now().AddDate(0, 0, 1).Format("2006-01-02")
+	tomorrow := time.Now().AddDate(0, 0, 1).Format(time.DateOnly)
 
 	// Setup mock expectations to return empty data
 	mockDS.On("GetHourlyWeather", tomorrow).Return([]datastore.HourlyWeather{}, nil)

--- a/internal/birdnet/birdnet.go
+++ b/internal/birdnet/birdnet.go
@@ -577,7 +577,7 @@ func (bn *BirdNET) clearSpeciesCache() {
 // getCachedSpeciesScores returns species occurrence scores with caching to avoid repeated calls within same day
 func (bn *BirdNET) getCachedSpeciesScores(targetDate time.Time) (map[string]float64, error) {
 	// Build composite cache key: date + rounded lat/lon + model
-	day := targetDate.Format("2006-01-02")
+	day := targetDate.Format(time.DateOnly)
 	cacheKey := fmt.Sprintf("%s|%.4f,%.4f|%s",
 		day,
 		bn.Settings.BirdNET.Latitude,

--- a/internal/birdnet/range_filter.go
+++ b/internal/birdnet/range_filter.go
@@ -44,7 +44,7 @@ func BuildRangeFilter(bn *BirdNET) error {
 	if err != nil {
 		return errors.New(err).
 			Category(errors.CategoryValidation).
-			Context("date", today.Format("2006-01-02")).
+			Context("date", today.Format(time.DateOnly)).
 			Context("latitude", bn.Settings.BirdNET.Latitude).
 			Context("longitude", bn.Settings.BirdNET.Longitude).
 			Timing("range-filter-build", time.Since(start)).
@@ -63,7 +63,7 @@ func BuildRangeFilter(bn *BirdNET) error {
 		debugFile := "debug_included_species.txt"
 		var content strings.Builder
 		content.WriteString(fmt.Sprintf("Updated at: %s\nSpecies count: %d\n\nSpecies list:\n",
-			time.Now().Format("2006-01-02 15:04:05"),
+			time.Now().Format(time.DateTime),
 			len(includedSpecies)))
 		for _, species := range includedSpecies {
 			content.WriteString(species + "\n")
@@ -104,7 +104,7 @@ func (bn *BirdNET) GetProbableSpecies(date time.Time, week float32) ([]SpeciesSc
 	if err != nil {
 		return nil, errors.New(err).
 			Category(errors.CategoryValidation).
-			Context("date", date.Format("2006-01-02")).
+			Context("date", date.Format(time.DateOnly)).
 			Context("week", week).
 			Context("model", bn.Settings.BirdNET.RangeFilter.Model).
 			Build()
@@ -369,7 +369,7 @@ func (bn *BirdNET) RunFilterProcess(dateStr string, week float32) {
 	var parsedDate time.Time
 	var err error
 	if dateStr != "" {
-		parsedDate, err = time.Parse("2006-01-02", dateStr)
+		parsedDate, err = time.Parse(time.DateOnly, dateStr)
 		if err != nil {
 			fmt.Printf("Error parsing date: %s\n", err)
 			return
@@ -394,7 +394,7 @@ func PrintSpeciesScores(date time.Time, speciesScores []SpeciesScore) {
 	lon := conf.Setting().BirdNET.Longitude
 
 	week := int(getWeekForFilter(date))
-	fmt.Printf("Included species for %v, %v on date %s, week %d, threshold %.6f\n\n", lat, lon, date.Format("2006-01-02"), week, threshold)
+	fmt.Printf("Included species for %v, %v on date %s, week %d, threshold %.6f\n\n", lat, lon, date.Format(time.DateOnly), week, threshold)
 
 	// Get number of species in speciesScores slice
 	numSpecies := len(speciesScores)

--- a/internal/conf/range_filter.go
+++ b/internal/conf/range_filter.go
@@ -68,8 +68,8 @@ func (s *Settings) ShouldUpdateRangeFilterToday() bool {
 		// Log the update decision for debugging
 		if s.Debug {
 			GetLogger().Debug("Scheduled range filter update",
-				logger.String("date", today.Format("2006-01-02")),
-				logger.String("last_updated", s.BirdNET.RangeFilter.LastUpdated.Format("2006-01-02 15:04:05")))
+				logger.String("date", today.Format(time.DateOnly)),
+				logger.String("last_updated", s.BirdNET.RangeFilter.LastUpdated.Format(time.DateTime)))
 		}
 
 		return true

--- a/internal/datastore/analytics.go
+++ b/internal/datastore/analytics.go
@@ -415,7 +415,7 @@ func (ds *DataStore) GetHourlyDistribution(ctx context.Context, startDate, endDa
 
 	// Only parse start date if provided
 	if startDate != "" {
-		parsedStartDate, err = time.Parse("2006-01-02", startDate)
+		parsedStartDate, err = time.Parse(time.DateOnly, startDate)
 		if err != nil {
 			return nil, errors.New(err).
 				Component("datastore").
@@ -428,7 +428,7 @@ func (ds *DataStore) GetHourlyDistribution(ctx context.Context, startDate, endDa
 
 	// Only parse end date if provided
 	if endDate != "" {
-		parsedEndDate, err = time.Parse("2006-01-02", endDate)
+		parsedEndDate, err = time.Parse(time.DateOnly, endDate)
 		if err != nil {
 			return nil, errors.New(err).
 				Component("datastore").

--- a/internal/datastore/analytics_test.go
+++ b/internal/datastore/analytics_test.go
@@ -665,7 +665,7 @@ func TestDatabasePerformance(t *testing.T) {
 		for j := range detectionsPerSpecies {
 			detectionDate := firstDetectionDate.AddDate(0, 0, j)
 			note := Note{
-				Date:           detectionDate.Format("2006-01-02"),
+				Date:           detectionDate.Format(time.DateOnly),
 				Time:           "12:00:00",
 				ScientificName: scientificName,
 				CommonName:     commonName,

--- a/internal/datastore/logger_helpers.go
+++ b/internal/datastore/logger_helpers.go
@@ -146,7 +146,7 @@ func calculateDateRangeComplexity(startDate, endDate string) float64 {
 	}
 
 	// Parse start date
-	start, err := time.Parse("2006-01-02", startDate)
+	start, err := time.Parse(time.DateOnly, startDate)
 	if err != nil {
 		// Try alternative date format
 		// IMPORTANT: Database stores local time strings, parse as local time
@@ -158,7 +158,7 @@ func calculateDateRangeComplexity(startDate, endDate string) float64 {
 	}
 
 	// Parse end date
-	end, err := time.Parse("2006-01-02", endDate)
+	end, err := time.Parse(time.DateOnly, endDate)
 	if err != nil {
 		// Try alternative date format
 		// IMPORTANT: Database stores local time strings, parse as local time

--- a/internal/datastore/search_advanced.go
+++ b/internal/datastore/search_advanced.go
@@ -175,7 +175,7 @@ func ParseDateShortcut(shortcut string) (time.Time, error) {
 		return time.Date(now.Year(), now.Month(), now.Day()-30, 0, 0, 0, 0, now.Location()), nil
 	default:
 		// Try parsing as a date
-		return time.Parse("2006-01-02", shortcut)
+		return time.Parse(time.DateOnly, shortcut)
 	}
 }
 
@@ -206,8 +206,8 @@ func applyDateRangeFilter(query *gorm.DB, dateRange *DateRange) *gorm.DB {
 		return query
 	}
 
-	startDate := dateRange.Start.Format("2006-01-02")
-	endDate := dateRange.End.Format("2006-01-02")
+	startDate := dateRange.Start.Format(time.DateOnly)
+	endDate := dateRange.End.Format(time.DateOnly)
 	return query.Where("date >= ? AND date <= ?", startDate, endDate)
 }
 

--- a/internal/datastore/time_of_day_test.go
+++ b/internal/datastore/time_of_day_test.go
@@ -38,20 +38,20 @@ func TestNightFilterExcludesSunriseSunsetWindows(t *testing.T) {
 	require.NoError(t, err, "Failed to calculate sun times")
 
 	// Log the calculated times for debugging
-	t.Logf("Test date: %s (timezone: %s)", testDate.Format("2006-01-02"), testDate.Location())
-	t.Logf("Calculated sunrise: %s", sunTimes.Sunrise.Format("15:04:05"))
-	t.Logf("Calculated sunset: %s", sunTimes.Sunset.Format("15:04:05"))
+	t.Logf("Test date: %s (timezone: %s)", testDate.Format(time.DateOnly), testDate.Location())
+	t.Logf("Calculated sunrise: %s", sunTimes.Sunrise.Format(time.TimeOnly))
+	t.Logf("Calculated sunset: %s", sunTimes.Sunset.Format(time.TimeOnly))
 
 	// Define the 30-minute window
 	window := 30 * time.Minute
 
 	// Log the windows for debugging
 	t.Logf("Sunrise window: %s to %s",
-		sunTimes.Sunrise.Add(-window).Format("15:04:05"),
-		sunTimes.Sunrise.Add(window).Format("15:04:05"))
+		sunTimes.Sunrise.Add(-window).Format(time.TimeOnly),
+		sunTimes.Sunrise.Add(window).Format(time.TimeOnly))
 	t.Logf("Sunset window: %s to %s",
-		sunTimes.Sunset.Add(-window).Format("15:04:05"),
-		sunTimes.Sunset.Add(window).Format("15:04:05"))
+		sunTimes.Sunset.Add(-window).Format(time.TimeOnly),
+		sunTimes.Sunset.Add(window).Format(time.TimeOnly))
 
 	// Dynamically generate test times based on calculated sunrise/sunset
 	// This makes the test work in any timezone
@@ -199,12 +199,12 @@ func TestNightFilterExcludesSunriseSunsetWindows(t *testing.T) {
 	}
 
 	// Insert test detections with dynamically calculated times
-	dateStr := testDate.Format("2006-01-02")
+	dateStr := testDate.Format(time.DateOnly)
 	insertedTimes := make(map[string]bool) // Track what we inserted
 
 	for _, tc := range testCases {
 		testTime := tc.reference.Add(tc.timeOffset)
-		timeStr := testTime.Format("15:04:05")
+		timeStr := testTime.Format(time.TimeOnly)
 
 		// Skip if we've already inserted this exact time (avoid duplicates)
 		if insertedTimes[timeStr] {
@@ -238,7 +238,7 @@ func TestNightFilterExcludesSunriseSunsetWindows(t *testing.T) {
 	// Create a map of returned timestamps for easy lookup
 	returnedTimes := make(map[string]bool)
 	for _, detection := range results {
-		timeStr := detection.Timestamp.Format("15:04:05")
+		timeStr := detection.Timestamp.Format(time.TimeOnly)
 		returnedTimes[timeStr] = true
 		t.Logf("Night filter returned: %s", timeStr)
 	}
@@ -254,7 +254,7 @@ func TestNightFilterExcludesSunriseSunsetWindows(t *testing.T) {
 	// Run subtests to verify Night filter behavior
 	for _, tc := range testCases {
 		testTime := tc.reference.Add(tc.timeOffset)
-		timeStr := testTime.Format("15:04:05")
+		timeStr := testTime.Format(time.TimeOnly)
 
 		// Skip duplicate time checks
 		if !insertedTimes[timeStr] {

--- a/internal/datastore/v2/migration/testutil/assertions.go
+++ b/internal/datastore/v2/migration/testutil/assertions.go
@@ -28,7 +28,7 @@ func AssertDetectionMatches(t *testing.T, legacy *datastore.Note, v2 *entities.D
 
 	// Timestamp comparison (legacy Date+Time -> v2 DetectedAt Unix timestamp)
 	// The V2 DetectedAt is Unix seconds, so compare within a reasonable window
-	legacyTime, err := time.Parse("2006-01-02 15:04:05", legacy.Date+" "+legacy.Time)
+	legacyTime, err := time.Parse(time.DateTime, legacy.Date+" "+legacy.Time)
 	if err == nil {
 		assert.InDelta(t, legacyTime.Unix(), v2.DetectedAt, 1, "detected_at should match legacy date+time")
 	}

--- a/internal/datastore/v2/migration/testutil/builders.go
+++ b/internal/datastore/v2/migration/testutil/builders.go
@@ -19,8 +19,8 @@ func NewDetectionBuilder() *DetectionBuilder {
 		note: datastore.Note{
 			ID:             1,
 			SourceNode:     "test-node",
-			Date:           now.Format("2006-01-02"),
-			Time:           now.Format("15:04:05"),
+			Date:           now.Format(time.DateOnly),
+			Time:           now.Format(time.TimeOnly),
 			BeginTime:      now,
 			EndTime:        now.Add(3 * time.Second),
 			SpeciesCode:    "turmig",
@@ -63,8 +63,8 @@ func (b *DetectionBuilder) WithTime(t string) *DetectionBuilder {
 
 // WithTimestamp sets both date and time from a time.Time value.
 func (b *DetectionBuilder) WithTimestamp(ts time.Time) *DetectionBuilder {
-	b.note.Date = ts.Format("2006-01-02")
-	b.note.Time = ts.Format("15:04:05")
+	b.note.Date = ts.Format(time.DateOnly)
+	b.note.Time = ts.Format(time.TimeOnly)
 	b.note.BeginTime = ts
 	b.note.EndTime = ts.Add(3 * time.Second)
 	return b
@@ -410,13 +410,13 @@ func (b *LockBuilder) BuildPtr() *datastore.NoteLock {
 
 // DailyEventsBuilder provides a fluent API for building test DailyEvents data.
 type DailyEventsBuilder struct {
-	event   datastore.DailyEvents
-	hourly  []datastore.HourlyWeather
+	event  datastore.DailyEvents
+	hourly []datastore.HourlyWeather
 }
 
 // NewDailyEventsBuilder creates a new DailyEventsBuilder with sensible defaults.
 func NewDailyEventsBuilder() *DailyEventsBuilder {
-	today := time.Now().Format("2006-01-02")
+	today := time.Now().Format(time.DateOnly)
 	return &DailyEventsBuilder{
 		event: datastore.DailyEvents{
 			ID:       1,
@@ -992,7 +992,7 @@ func GenerateDetections(count int) []datastore.Note {
 		confidence := 0.5 + (float64(i%50) / 100.0) // Vary between 0.50 and 0.99
 
 		notes[i] = NewDetectionBuilder().
-			WithID(uint(i + 1)). //nolint:gosec // G115: test data uses small values that cannot overflow
+			WithID(uint(i+1)). //nolint:gosec // G115: test data uses small values that cannot overflow
 			WithTimestamp(ts).
 			WithSpecies(species.Code, species.Scientific, species.Common).
 			WithConfidence(confidence).
@@ -1017,7 +1017,7 @@ func GenerateWeatherData(days int) ([]datastore.DailyEvents, []datastore.HourlyW
 		// Create daily events
 		dailyEvents[d] = NewDailyEventsBuilder().
 			WithID(dayID).
-			WithDate(date.Format("2006-01-02")).
+			WithDate(date.Format(time.DateOnly)).
 			WithSunrise(date.Add(6 * time.Hour).Unix()).
 			WithSunset(date.Add(18 * time.Hour).Unix()).
 			Build()
@@ -1038,7 +1038,7 @@ func GenerateWeatherData(days int) ([]datastore.DailyEvents, []datastore.HourlyW
 				WithDailyEventsID(dayID).
 				WithTime(hourTime).
 				WithTemperature(baseTemp).
-				WithFeelsLike(baseTemp - 1).
+				WithFeelsLike(baseTemp-1).
 				WithTempMinMax(baseTemp-5, baseTemp+5).
 				WithHumidity(50 + h%30).
 				Build()

--- a/internal/datastore/v2/migration/testutil/setup.go
+++ b/internal/datastore/v2/migration/testutil/setup.go
@@ -28,9 +28,9 @@ type TestContext struct {
 	TempDir string
 
 	// Legacy database components
-	LegacyDB   *sql.DB         // Raw SQL connection for seeding
-	LegacyGorm *gorm.DB        // GORM connection for queries
-	Seeder     *LegacySeeder   // Seeder for legacy data
+	LegacyDB   *sql.DB       // Raw SQL connection for seeding
+	LegacyGorm *gorm.DB      // GORM connection for queries
+	Seeder     *LegacySeeder // Seeder for legacy data
 
 	// V2 database components
 	V2Manager    *datastoreV2.SQLiteManager // V2 SQLite manager
@@ -485,7 +485,7 @@ func (r *testDetectionRepo) Search(_ context.Context, filters *datastore.Detecti
 // convertNoteToResult converts a legacy Note to a detection.Result.
 func convertNoteToResult(note *datastore.Note, _ []datastore.Results, review *datastore.NoteReview, comments []datastore.NoteComment, lock *datastore.NoteLock) *detection.Result {
 	// Parse date and time strings to timestamp
-	timestamp, _ := time.Parse("2006-01-02 15:04:05", note.Date+" "+note.Time)
+	timestamp, _ := time.Parse(time.DateTime, note.Date+" "+note.Time)
 
 	result := &detection.Result{
 		ID:        note.ID,
@@ -647,15 +647,15 @@ func (s *testLegacyInterface) GetAllHourlyWeather() ([]datastore.HourlyWeather, 
 // Stub implementations for unused datastore.Interface methods.
 // These are required by the interface but not used in migration tests.
 
-func (s *testLegacyInterface) Open() error                                      { return nil }
-func (s *testLegacyInterface) Close() error                                     { return nil }
+func (s *testLegacyInterface) Open() error                                         { return nil }
+func (s *testLegacyInterface) Close() error                                        { return nil }
 func (s *testLegacyInterface) Save(_ *datastore.Note, _ []datastore.Results) error { return nil }
-func (s *testLegacyInterface) Delete(_ string) error                            { return nil }
-func (s *testLegacyInterface) Get(_ string) (datastore.Note, error)             { return datastore.Note{}, nil }
-func (s *testLegacyInterface) SetMetrics(_ *datastore.Metrics)                  {}
-func (s *testLegacyInterface) SetSunCalcMetrics(_ any)                          {}
-func (s *testLegacyInterface) Optimize(_ context.Context) error                 { return nil }
-func (s *testLegacyInterface) GetAllNotes() ([]datastore.Note, error)           { return nil, nil }
+func (s *testLegacyInterface) Delete(_ string) error                               { return nil }
+func (s *testLegacyInterface) Get(_ string) (datastore.Note, error)                { return datastore.Note{}, nil }
+func (s *testLegacyInterface) SetMetrics(_ *datastore.Metrics)                     {}
+func (s *testLegacyInterface) SetSunCalcMetrics(_ any)                             {}
+func (s *testLegacyInterface) Optimize(_ context.Context) error                    { return nil }
+func (s *testLegacyInterface) GetAllNotes() ([]datastore.Note, error)              { return nil, nil }
 func (s *testLegacyInterface) GetTopBirdsData(_ string, _ float64) ([]datastore.Note, error) {
 	return nil, nil
 }
@@ -665,16 +665,16 @@ func (s *testLegacyInterface) GetHourlyOccurrences(_, _ string, _ float64) ([24]
 func (s *testLegacyInterface) SpeciesDetections(_, _, _ string, _ int, _ bool, _, _ int) ([]datastore.Note, error) {
 	return nil, nil
 }
-func (s *testLegacyInterface) GetLastDetections(_ int) ([]datastore.Note, error)   { return nil, nil }
-func (s *testLegacyInterface) GetAllDetectedSpecies() ([]datastore.Note, error)    { return nil, nil }
+func (s *testLegacyInterface) GetLastDetections(_ int) ([]datastore.Note, error) { return nil, nil }
+func (s *testLegacyInterface) GetAllDetectedSpecies() ([]datastore.Note, error)  { return nil, nil }
 func (s *testLegacyInterface) SearchNotes(_ string, _ bool, _, _ int) ([]datastore.Note, error) {
 	return nil, nil
 }
 func (s *testLegacyInterface) SearchNotesAdvanced(_ *datastore.AdvancedSearchFilters) ([]datastore.Note, int64, error) {
 	return nil, 0, nil
 }
-func (s *testLegacyInterface) GetNoteClipPath(_ string) (string, error)    { return "", nil }
-func (s *testLegacyInterface) DeleteNoteClipPath(_ string) error           { return nil }
+func (s *testLegacyInterface) GetNoteClipPath(_ string) (string, error)              { return "", nil }
+func (s *testLegacyInterface) DeleteNoteClipPath(_ string) error                     { return nil }
 func (s *testLegacyInterface) GetNoteReview(_ string) (*datastore.NoteReview, error) { return nil, nil } //nolint:nilnil // stub
 func (s *testLegacyInterface) SaveNoteReview(_ *datastore.NoteReview) error          { return nil }
 func (s *testLegacyInterface) GetNoteComments(_ string) ([]datastore.NoteComment, error) {
@@ -692,19 +692,21 @@ func (s *testLegacyInterface) SaveHourlyWeather(_ *datastore.HourlyWeather) erro
 func (s *testLegacyInterface) GetHourlyWeather(_ string) ([]datastore.HourlyWeather, error) {
 	return nil, nil
 }
-func (s *testLegacyInterface) LatestHourlyWeather() (*datastore.HourlyWeather, error) { return nil, nil } //nolint:nilnil // stub
+func (s *testLegacyInterface) LatestHourlyWeather() (*datastore.HourlyWeather, error) {
+	return nil, nil //nolint:nilnil // stub
+}
 func (s *testLegacyInterface) GetHourlyDetections(_, _ string, _, _, _ int) ([]datastore.Note, error) {
 	return nil, nil
 }
 func (s *testLegacyInterface) CountSpeciesDetections(_, _, _ string, _ int) (int64, error) {
 	return 0, nil
 }
-func (s *testLegacyInterface) CountSearchResults(_ string) (int64, error) { return 0, nil }
-func (s *testLegacyInterface) Transaction(_ func(tx *gorm.DB) error) error { return nil }
-func (s *testLegacyInterface) LockNote(_ string) error                    { return nil }
-func (s *testLegacyInterface) UnlockNote(_ string) error                  { return nil }
+func (s *testLegacyInterface) CountSearchResults(_ string) (int64, error)        { return 0, nil }
+func (s *testLegacyInterface) Transaction(_ func(tx *gorm.DB) error) error       { return nil }
+func (s *testLegacyInterface) LockNote(_ string) error                           { return nil }
+func (s *testLegacyInterface) UnlockNote(_ string) error                         { return nil }
 func (s *testLegacyInterface) GetNoteLock(_ string) (*datastore.NoteLock, error) { return nil, nil } //nolint:nilnil // stub
-func (s *testLegacyInterface) IsNoteLocked(_ string) (bool, error)        { return false, nil }
+func (s *testLegacyInterface) IsNoteLocked(_ string) (bool, error)               { return false, nil }
 func (s *testLegacyInterface) GetImageCache(_ datastore.ImageCacheQuery) (*datastore.ImageCache, error) {
 	return nil, nil //nolint:nilnil // stub
 }
@@ -744,7 +746,7 @@ func (s *testLegacyInterface) SaveDynamicThreshold(_ *datastore.DynamicThreshold
 func (s *testLegacyInterface) GetDynamicThreshold(_ string) (*datastore.DynamicThreshold, error) {
 	return nil, nil //nolint:nilnil // stub
 }
-func (s *testLegacyInterface) DeleteDynamicThreshold(_ string) error                   { return nil }
+func (s *testLegacyInterface) DeleteDynamicThreshold(_ string) error { return nil }
 func (s *testLegacyInterface) DeleteExpiredDynamicThresholds(_ time.Time) (int64, error) {
 	return 0, nil
 }
@@ -760,8 +762,8 @@ func (s *testLegacyInterface) SaveThresholdEvent(_ *datastore.ThresholdEvent) er
 func (s *testLegacyInterface) GetRecentThresholdEvents(_ int) ([]datastore.ThresholdEvent, error) {
 	return nil, nil
 }
-func (s *testLegacyInterface) DeleteThresholdEvents(_ string) error       { return nil }
-func (s *testLegacyInterface) DeleteAllThresholdEvents() (int64, error)   { return 0, nil }
+func (s *testLegacyInterface) DeleteThresholdEvents(_ string) error     { return nil }
+func (s *testLegacyInterface) DeleteAllThresholdEvents() (int64, error) { return 0, nil }
 func (s *testLegacyInterface) SaveNotificationHistory(_ *datastore.NotificationHistory) error {
 	return nil
 }

--- a/internal/datastore/v2/repository/dual_write.go
+++ b/internal/datastore/v2/repository/dual_write.go
@@ -561,7 +561,7 @@ func (dw *DualWriteRepository) GetHourly(ctx context.Context, date, hour string,
 			return dw.legacy.GetHourly(ctx, date, hour, duration, limit, offset)
 		}
 
-		t, err := time.Parse("2006-01-02", date)
+		t, err := time.Parse(time.DateOnly, date)
 		if err != nil {
 			return dw.legacy.GetHourly(ctx, date, hour, duration, limit, offset)
 		}

--- a/internal/datastore/v2only/datastore.go
+++ b/internal/datastore/v2only/datastore.go
@@ -496,8 +496,8 @@ func (ds *Datastore) detectionToNote(det *entities.Detection) datastore.Note {
 
 	// Convert Unix timestamp to date and time strings
 	t := time.Unix(det.DetectedAt, 0).In(ds.timezone)
-	dateStr := t.Format("2006-01-02")
-	timeStr := t.Format("15:04:05")
+	dateStr := t.Format(time.DateOnly)
+	timeStr := t.Format(time.TimeOnly)
 
 	return datastore.Note{
 		ID:             det.ID,
@@ -650,15 +650,15 @@ func (ds *Datastore) calculateTimeOfDay(timestamp time.Time, lat, lon float64) s
 	window := 30 * time.Minute
 
 	// Get detection time as string for comparison (format: "15:04:05")
-	detTime := timestamp.Format("15:04:05")
+	detTime := timestamp.Format(time.TimeOnly)
 
 	// Calculate window boundaries
-	sunriseStart := sunEvents.Sunrise.Add(-window).Format("15:04:05")
-	sunriseEnd := sunEvents.Sunrise.Add(window).Format("15:04:05")
-	sunsetStart := sunEvents.Sunset.Add(-window).Format("15:04:05")
-	sunsetEnd := sunEvents.Sunset.Add(window).Format("15:04:05")
-	sunriseTime := sunEvents.Sunrise.Format("15:04:05")
-	sunsetTime := sunEvents.Sunset.Format("15:04:05")
+	sunriseStart := sunEvents.Sunrise.Add(-window).Format(time.TimeOnly)
+	sunriseEnd := sunEvents.Sunrise.Add(window).Format(time.TimeOnly)
+	sunsetStart := sunEvents.Sunset.Add(-window).Format(time.TimeOnly)
+	sunsetEnd := sunEvents.Sunset.Add(window).Format(time.TimeOnly)
+	sunriseTime := sunEvents.Sunrise.Format(time.TimeOnly)
+	sunsetTime := sunEvents.Sunset.Format(time.TimeOnly)
 
 	// Determine time of day
 	switch {
@@ -753,7 +753,7 @@ func (ds *Datastore) GetTopBirdsData(selectedDate string, minConfidenceNormalize
 			CommonName:     commonName,
 			Confidence:     r.MaxConfidence,
 			Date:           selectedDate,
-			Time:           latestTime.Format("15:04:05"),
+			Time:           latestTime.Format(time.TimeOnly),
 		}
 		notes = append(notes, note)
 	}
@@ -1914,7 +1914,7 @@ func (ds *Datastore) convertToNewSpeciesData(_ context.Context, data []speciesFi
 			commonName = cn
 		}
 
-		firstSeenDate := time.Unix(d.FirstDetected, 0).In(ds.timezone).Format("2006-01-02")
+		firstSeenDate := time.Unix(d.FirstDetected, 0).In(ds.timezone).Format(time.DateOnly)
 		result = append(result, datastore.NewSpeciesData{
 			ScientificName: d.ScientificName,
 			CommonName:     commonName,

--- a/internal/datastore/weather_timezone_test.go
+++ b/internal/datastore/weather_timezone_test.go
@@ -36,7 +36,7 @@ func TestGetHourlyWeather_TimezoneHandling(t *testing.T) {
 		// In the system's local timezone, convert this to see what local date it falls on
 		utcTime := time.Date(2024, 1, 15, 12, 0, 0, 0, time.UTC)
 		localTime := utcTime.In(time.Local)
-		localDate := localTime.Format("2006-01-02")
+		localDate := localTime.Format(time.DateOnly)
 
 		weather := &HourlyWeather{
 			Time:        utcTime,
@@ -216,7 +216,7 @@ func TestGetHourlyWeather_TimezoneHandling(t *testing.T) {
 		// Create a date that will work in any timezone
 		// Use times that span a single local day regardless of timezone offset
 		baseDate := time.Date(2024, 6, 15, 0, 0, 0, 0, time.Local)
-		localDateStr := baseDate.Format("2006-01-02")
+		localDateStr := baseDate.Format(time.DateOnly)
 
 		// Create weather records within the local day
 		weatherRecords := []HourlyWeather{
@@ -352,7 +352,7 @@ func TestGetHourlyWeather_EdgeCases(t *testing.T) {
 		// February 29, 2024 (leap year) at 12:00 UTC
 		utcTime := time.Date(2024, 2, 29, 12, 0, 0, 0, time.UTC)
 		localTime := utcTime.In(time.Local)
-		localDate := localTime.Format("2006-01-02")
+		localDate := localTime.Format(time.DateOnly)
 
 		weather := &HourlyWeather{
 			Time:        utcTime,

--- a/internal/detection/result.go
+++ b/internal/detection/result.go
@@ -73,11 +73,11 @@ type AdditionalResult struct {
 // Date returns the detection date in YYYY-MM-DD format.
 // This is a convenience method for APIs that need the legacy date format.
 func (r *Result) Date() string {
-	return r.Timestamp.Format("2006-01-02")
+	return r.Timestamp.Format(time.DateOnly)
 }
 
 // Time returns the detection time in HH:MM:SS format.
 // This is a convenience method for APIs that need the legacy time format.
 func (r *Result) Time() string {
-	return r.Timestamp.Format("15:04:05")
+	return r.Timestamp.Format(time.TimeOnly)
 }

--- a/internal/notification/template_data.go
+++ b/internal/notification/template_data.go
@@ -40,8 +40,8 @@ func NewTemplateData(event events.DetectionEvent, baseURL string, timeAs24h bool
 		beginTime = event.GetTimestamp()
 	}
 
-	detectionTime := beginTime.Format("15:04:05")
-	detectionDate := beginTime.Format("2006-01-02")
+	detectionTime := beginTime.Format(time.TimeOnly)
+	detectionDate := beginTime.Format(time.DateOnly)
 	if !timeAs24h {
 		detectionTime = beginTime.Format("3:04:05 PM")
 	}

--- a/internal/suncalc/suncalc.go
+++ b/internal/suncalc/suncalc.go
@@ -32,10 +32,10 @@ type cacheEntry struct {
 
 // SunCalc handles caching and calculation of sun event times
 type SunCalc struct {
-	cache    map[string]cacheEntry      // Cache of sun event times for dates
-	lock     sync.RWMutex                // Lock for cache access
-	observer astral.Observer             // Observer for sun event calculations
-	metrics  *metrics.SunCalcMetrics     // Metrics for observability
+	cache    map[string]cacheEntry   // Cache of sun event times for dates
+	lock     sync.RWMutex            // Lock for cache access
+	observer astral.Observer         // Observer for sun event calculations
+	metrics  *metrics.SunCalcMetrics // Metrics for observability
 }
 
 // NewSunCalc creates a new SunCalc instance
@@ -56,9 +56,9 @@ func (sc *SunCalc) SetMetrics(m *metrics.SunCalcMetrics) {
 // GetSunEventTimes returns the sun event times for a given date, using cache if available
 func (sc *SunCalc) GetSunEventTimes(date time.Time) (SunEventTimes, error) {
 	start := time.Now()
-	
+
 	// Format the date as a string key for the cache
-	dateKey := date.Format("2006-01-02")
+	dateKey := date.Format(time.DateOnly)
 
 	// Acquire a read lock and check if the date is in the cache
 	sc.lock.RLock()
@@ -103,7 +103,7 @@ func (sc *SunCalc) GetSunEventTimes(date time.Time) (SunEventTimes, error) {
 	if sc.metrics != nil {
 		sc.metrics.RecordSunCalcOperation("get_sun_events", "success")
 		sc.metrics.RecordSunCalcDuration("get_sun_events", time.Since(start).Seconds())
-		
+
 		// Update sun time gauges for current day
 		// Compare dates in the same location to handle time zone correctly
 		now := time.Now()

--- a/internal/suncalc/suncalc_test.go
+++ b/internal/suncalc/suncalc_test.go
@@ -2,6 +2,7 @@ package suncalc
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -67,7 +68,7 @@ func TestCacheConsistency(t *testing.T) {
 	require.NoError(t, err, "failed to get initial sun event times")
 
 	// Verify cache entry exists
-	dateKey := date.Format("2006-01-02")
+	dateKey := date.Format(time.DateOnly)
 	sc.lock.RLock()
 	entry, exists := sc.cache[dateKey]
 	sc.lock.RUnlock()

--- a/internal/weather/weather.go
+++ b/internal/weather/weather.go
@@ -114,7 +114,7 @@ func (s *Service) SaveWeatherData(data *WeatherData) error {
 
 	// Create daily events data
 	dailyEvents := &datastore.DailyEvents{
-		Date:     localTime.Format("2006-01-02"),
+		Date:     localTime.Format(time.DateOnly),
 		Country:  data.Location.Country,
 		CityName: data.Location.City,
 	}

--- a/internal/weather/weather_test.go
+++ b/internal/weather/weather_test.go
@@ -156,8 +156,8 @@ func TestTimezoneConversionForWeatherStorage(t *testing.T) {
 		// Document the expected behavior
 		t.Logf("UTC time: %v", utcTime.Format(time.RFC3339))
 		t.Logf("Local time: %v", localTime.Format(time.RFC3339))
-		t.Logf("UTC date: %s", utcTime.Format("2006-01-02"))
-		t.Logf("Local date: %s", localTime.Format("2006-01-02"))
+		t.Logf("UTC date: %s", utcTime.Format(time.DateOnly))
+		t.Logf("Local date: %s", localTime.Format(time.DateOnly))
 	})
 }
 
@@ -206,14 +206,14 @@ func TestTimezoneAwareWeatherQuery_BugDemonstration(t *testing.T) {
 
 		// The expected date for this weather data should be 2026-01-13
 		expectedDate := "2026-01-13"
-		actualLocalDate := localMidnight.Format("2006-01-02")
+		actualLocalDate := localMidnight.Format(time.DateOnly)
 
 		assert.Equal(t, expectedDate, actualLocalDate,
 			"Local midnight should be associated with local date, not UTC date")
 
 		// Document the UTC equivalent
 		utcTime := localMidnight.UTC()
-		utcDate := utcTime.Format("2006-01-02")
+		utcDate := utcTime.Format(time.DateOnly)
 
 		t.Logf("Local time: %v (date: %s)", localMidnight.Format(time.RFC3339), actualLocalDate)
 		t.Logf("UTC time: %v (date: %s)", utcTime.Format(time.RFC3339), utcDate)
@@ -238,8 +238,8 @@ func TestTimezoneAwareWeatherQuery_BugDemonstration(t *testing.T) {
 			localTime := time.Date(2026, 1, 13, hour, 30, 0, 0, loc)
 			utcTime := localTime.UTC()
 
-			localDate := localTime.Format("2006-01-02")
-			utcDate := utcTime.Format("2006-01-02")
+			localDate := localTime.Format(time.DateOnly)
+			utcDate := utcTime.Format(time.DateOnly)
 
 			t.Logf("Hour %02d:30 local -> UTC date: %s, Local date: %s",
 				hour, utcDate, localDate)
@@ -266,8 +266,8 @@ func TestTimezoneAwareWeatherQuery_BugDemonstration(t *testing.T) {
 			localTime := time.Date(2026, 1, 13, hour, 30, 0, 0, loc)
 			utcTime := localTime.UTC()
 
-			localDate := localTime.Format("2006-01-02")
-			utcDate := utcTime.Format("2006-01-02")
+			localDate := localTime.Format(time.DateOnly)
+			utcDate := utcTime.Format(time.DateOnly)
 
 			if hour >= 2 { // In UTC+2, hours 02:00+ should have same date
 				assert.Equal(t, localDate, utcDate,
@@ -519,7 +519,7 @@ func TestService_SaveWeatherData(t *testing.T) {
 		require.NotNil(t, capturedHW)
 
 		// Verify date is in local time format
-		assert.Equal(t, expectedLocalTime.Format("2006-01-02"), capturedDE.Date)
+		assert.Equal(t, expectedLocalTime.Format(time.DateOnly), capturedDE.Date)
 
 		// Verify time stored is local time (same instant, different zone)
 		assert.True(t, capturedHW.Time.Equal(expectedLocalTime),


### PR DESCRIPTION
## Summary

- Replace hardcoded time format string literals (`"2006-01-02"`, `"2006-01-02 15:04:05"`, `"15:04:05"`) with Go standard library constants (`time.DateOnly`, `time.DateTime`, `time.TimeOnly`) across 47 files
- Add missing `time` package import in `internal/suncalc/suncalc_test.go`
- Add `//nolint:nilnil` suppression comment to test stub in `internal/datastore/v2/migration/testutil/setup.go`

## Test plan

- [x] `golangci-lint run` — 0 issues
- [x] `go test -race ./internal/analysis/species/` — PASS
- [x] `go test -race ./internal/api/v2/` — PASS
- [x] `go test -race ./internal/suncalc/` — PASS
- [x] `go test -race ./internal/datastore/v2/...` — PASS
- [x] `go test -race ./internal/weather/` — PASS
- [x] `go test -race ./internal/notification/` — PASS
- [x] Pre-existing `TestNightFilterExcludesSunriseSunsetWindows` failure (issue #961) verified on clean main — not caused by this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized date and time formatting throughout the codebase by replacing hard-coded format strings with Go standard library constants, improving code consistency and maintainability across date/time operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->