### PR TITLE
fix(spectrogram): lower priority for operational errors

### DIFF
--- a/internal/api/v2/media.go
+++ b/internal/api/v2/media.go
@@ -1789,11 +1789,7 @@ func (c *Controller) generateWithFallback(ctx context.Context, absAudioPath, abs
 	if err := c.spectrogramGenerator.GenerateFromFile(ctx, absAudioPath, absSpectrogramPath, width, raw); err != nil {
 		// Check if this is an expected operational error (context canceled, process killed)
 		// These are normal events during shutdown, timeout, or resource management
-		isOperationalError := errors.Is(err, context.Canceled) ||
-			errors.Is(err, context.DeadlineExceeded) ||
-			strings.Contains(err.Error(), "signal: killed")
-
-		if isOperationalError {
+		if spectrogram.IsOperationalError(err) {
 			// Log at Debug level for expected operational events
 			getSpectrogramLogger().Debug("Spectrogram generation canceled or interrupted",
 				logger.String("spectrogram_key", spectrogramKey),

--- a/internal/spectrogram/prerenderer.go
+++ b/internal/spectrogram/prerenderer.go
@@ -444,11 +444,7 @@ func (pr *PreRenderer) processJob(job *Job, workerID int) {
 	if err := pr.generator.GenerateFromPCM(ctx, job.PCMData, spectrogramPath, width, pr.settings.Realtime.Dashboard.Spectrogram.Raw); err != nil {
 		// Check if this is an expected operational error (context canceled, process killed)
 		// These are normal events during shutdown, timeout, or resource management
-		isOperationalError := errors.Is(err, context.Canceled) ||
-			errors.Is(err, context.DeadlineExceeded) ||
-			strings.Contains(err.Error(), "signal: killed")
-
-		if isOperationalError {
+		if IsOperationalError(err) {
 			// Log at Debug level for expected operational events
 			pr.logger.Debug("Spectrogram generation canceled or interrupted",
 				logger.Int("worker_id", workerID),

--- a/internal/spectrogram/utils.go
+++ b/internal/spectrogram/utils.go
@@ -3,6 +3,7 @@
 package spectrogram
 
 import (
+	"context"
 	"fmt"
 	"maps"
 	"path/filepath"
@@ -103,6 +104,18 @@ func BuildSpectrogramPath(clipPath string) (string, error) {
 
 	spectrogramPath := strings.TrimSuffix(clipPath, ext) + ".png"
 	return spectrogramPath, nil
+}
+
+// IsOperationalError checks if an error is an expected operational event rather than
+// a genuine failure. Operational errors include context cancellation, deadline exceeded,
+// and process kills (e.g. context-triggered SIGKILL).
+func IsOperationalError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return errors.Is(err, context.Canceled) ||
+		errors.Is(err, context.DeadlineExceeded) ||
+		strings.Contains(err.Error(), "signal: killed")
 }
 
 // BuildSpectrogramPathWithParams builds a spectrogram path with size/raw encoded in filename.


### PR DESCRIPTION
When the spectrogram generator hits an error, it calls `errors.Build()` which immediately fires the notification hook before the caller ever gets a chance to say "yo... this is just an operational hiccup, not a real problem." Since the error lands under `CategorySystem`, it gets tagged as `PriorityHigh`, and suddenly every routine "signal: killed" shows up on the dashboard as a "Critical System Error."

Fixes #1933.

Yay, my first PR here! I absolutely love this project so much. Thank you so much for continuing to develop it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling and classification for spectrogram generation failures with centralized operational error detection.
  * Operational errors (context cancellation, timeouts) are now properly identified and logged at appropriate severity levels.

* **Tests**
  * Added comprehensive unit tests for error classification covering various error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->