### PR TITLE
fix(container): restore web UI by separating frontend and model embed build tags

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -56,8 +56,8 @@ jobs:
           # Show only new issues by default
           only-new-issues: false
           # Additional args for better output (v2.5.0+ syntax)
-          # Use noembed tag to skip frontend embedding requirement
-          args: --build-tags=noembed --output.checkstyle.path=golangci-lint-report.xml
+          # Use noembed,skipfrontend tags to skip model and frontend embedding requirement
+          args: --build-tags=noembed,skipfrontend --output.checkstyle.path=golangci-lint-report.xml
 
       - name: Generate lint summary
         if: always()

--- a/.github/workflows/golangci-test.yml
+++ b/.github/workflows/golangci-test.yml
@@ -112,8 +112,8 @@ jobs:
           # Run tests with JSON output
           # Note: We must capture PIPESTATUS immediately after the pipeline
           # gotestfmt may return non-zero even when tests pass, so we only check go test's exit code
-          # Use noembed tag to skip frontend embedding requirement
-          go test -tags noembed -json -v -short -timeout 120s ./... 2>&1 | tee /tmp/gotest.log | gotestfmt -ci github; TEST_EXIT_CODE=${PIPESTATUS[0]}
+          # Use noembed,skipfrontend tags to skip model and frontend embedding requirement
+          go test -tags noembed,skipfrontend -json -v -short -timeout 120s ./... 2>&1 | tee /tmp/gotest.log | gotestfmt -ci github; TEST_EXIT_CODE=${PIPESTATUS[0]}
 
           if [ $TEST_EXIT_CODE -ne 0 ]; then
             echo "::error title=Test Failure::Unit tests failed - see job summary for details"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -36,8 +36,8 @@ tasks:
   test:
     desc: Run tests for the application
     cmds:
-      # Use noembed tag to skip frontend embedding requirement for faster tests
-      - go test -tags noembed ./... {{.TEST_FLAGS}}
+      # Use noembed,skipfrontend tags to skip model and frontend embedding for faster tests
+      - go test -tags noembed,skipfrontend ./... {{.TEST_FLAGS}}
     vars:
       TEST_FLAGS: '{{default "" .CLI_ARGS}}'
 
@@ -53,8 +53,8 @@ tasks:
     desc: Run tests with coverage report
     cmds:
       - mkdir -p coverage
-      # Use noembed tag to skip frontend embedding requirement for faster tests
-      - go test -tags noembed ./... -coverprofile=coverage/coverage.out {{.TEST_FLAGS}}
+      # Use noembed,skipfrontend tags to skip model and frontend embedding for faster tests
+      - go test -tags noembed,skipfrontend ./... -coverprofile=coverage/coverage.out {{.TEST_FLAGS}}
       - go tool cover -html=coverage/coverage.out -o coverage/coverage.html
     vars:
       TEST_FLAGS: '{{default "" .CLI_ARGS}}'
@@ -74,9 +74,9 @@ tasks:
         else
           LIB_DIR="/usr/lib"
         fi
-        # Use noembed tag to skip frontend embedding requirement for faster linting
+        # Use noembed,skipfrontend tags to skip model and frontend embedding for faster linting
         {{.CGO_FLAGS}} CGO_LDFLAGS="-L${LIB_DIR} -ltensorflowlite_c" \
-        golangci-lint run --build-tags=noembed {{.CLI_ARGS}}
+        golangci-lint run --build-tags=noembed,skipfrontend {{.CLI_ARGS}}
     vars:
       CLI_ARGS: '{{default "-v" .CLI_ARGS}}'
 

--- a/frontend/embed.go
+++ b/frontend/embed.go
@@ -1,4 +1,4 @@
-//go:build !noembed
+//go:build !skipfrontend
 
 package frontend
 

--- a/frontend/embed_skipfrontend.go
+++ b/frontend/embed_skipfrontend.go
@@ -1,7 +1,7 @@
-//go:build noembed
+//go:build skipfrontend
 
 // Package frontend provides the embedded frontend filesystem.
-// This file is used when building with -tags noembed (CI linting/testing).
+// This file is used when building with -tags skipfrontend (CI linting/testing).
 // It provides a stub filesystem that allows the code to compile without
 // building the actual frontend. This is NOT suitable for production use.
 package frontend
@@ -11,9 +11,9 @@ import (
 	"testing/fstest"
 )
 
-// DistFS is a stub filesystem for noembed builds (linting/testing).
+// DistFS is a stub filesystem for skipfrontend builds (linting/testing).
 // This allows the code to compile without building the frontend.
 // WARNING: This stub only contains a minimal index.html placeholder.
 var DistFS fs.FS = fstest.MapFS{
-	"index.html": &fstest.MapFile{Data: []byte("<!-- noembed stub -->")},
+	"index.html": &fstest.MapFile{Data: []byte("<!-- skipfrontend stub -->")},
 }


### PR DESCRIPTION
## Problem

Docker containers have been serving `<!-- skipfrontend stub -->` as the entire web UI instead of the real frontend. The app appeared to start successfully but the UI was completely non-functional.

## Root Cause

The `noembed` build tag conflated two unrelated concerns:

| Concern | CI/tests | Docker container |
|---|---|---|
| External model loading (no 200MB binary) | ✅ correct | ✅ correct |
| **Frontend stub (placeholder HTML)** | ✅ correct | ❌ **broken** |

PR #1191 switched Docker builds to `task noembed_*` to avoid embedding large TFLite model files into the binary. However, `noembed` also activated `frontend/embed_noembed.go` — a CI stub that returns a 25-byte placeholder as the entire web UI. The final Docker image only copies `bin/` from the build stage, so there is no `frontend/dist` fallback on disk either.

## Fix

Introduce a separate `skipfrontend` build tag for the frontend stub, decoupling it from model embedding:

- **`noembed`**: loads ML model files from disk (unchanged behaviour for Docker + CI)  
- **`skipfrontend`** (new): stubs the frontend filesystem — used only in CI tests/linting to avoid requiring a `frontend/dist` build

**Docker builds** (`task noembed_linux_amd64` etc.) use `-tags noembed` — models load from disk, but the real frontend is now properly embedded in the binary.

**CI tests/lint** use `-tags noembed,skipfrontend` — same fast build as before, no frontend build needed.

## Changes

- `frontend/embed.go`: build constraint `!noembed` → `!skipfrontend`
- `frontend/embed_noembed.go` → `embed_skipfrontend.go` with `skipfrontend` tag
- `Taskfile.yml`: test and lint tasks add `skipfrontend` alongside `noembed`
- `.github/workflows/golangci-lint.yml`: add `skipfrontend` to build tags
- `.github/workflows/golangci-test.yml`: add `skipfrontend` to test tags
- `Dockerfile`: **no changes needed** — already uses `task noembed_*` which will now correctly embed the frontend

## Verification

The fix can be verified by building the Docker image locally:
```bash
docker build --target build --platform linux/amd64 -t test-build .
docker run --rm test-build strings /home/dev-user/src/BirdNET-Go/bin/birdnet-go | grep -c "<!DOCTYPE html"
# Should output > 0 (frontend HTML present in binary)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build and test processes to optimize compilation workflows and reduce unnecessary embedding steps across CI/CD pipelines and local development environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->