### PR TITLE
fix: remove multi-line URLs from default notification message template

### DIFF
--- a/doc/wiki/guide.md
+++ b/doc/wiki/guide.md
@@ -2085,7 +2085,7 @@ notification:
 Each service has its own URL format. Common examples:
 
 - **Telegram**: `telegram://<bot_token>@telegram?chats=<chat_id>`
-- **Discord**: `discord://<webhook_token>@<webhook_id>`
+- **Discord**: `discord://<webhook_token>@<webhook_id>` (add `?splitLines=No` if using a custom multi-line message template to prevent each line from becoming a separate embed)
 - **Slack**: `slack://token-a/token-b/token-c`
 - **Email**: `smtp://username:password@host:port/?from=sender@example.com&to=recipient@example.com`
 - **Pushover**: `pushover://shoutrrr:<api_token>@<user_key>`

--- a/internal/conf/defaults.go
+++ b/internal/conf/defaults.go
@@ -394,7 +394,7 @@ func setDefaultConfig() {
 
 	// Notification templates
 	viper.SetDefault("notification.templates.newspecies.title", "New Species: {{.CommonName}}")
-	viper.SetDefault("notification.templates.newspecies.message", "{{.ImageURL}}\n\nFirst detection of {{.CommonName}} ({{.ScientificName}}) with {{.ConfidencePercent}}% confidence at {{.DetectionTime}}. \n{{.DetectionURL}}")
+	viper.SetDefault("notification.templates.newspecies.message", "First detection of {{.CommonName}} ({{.ScientificName}}) with {{.ConfidencePercent}}% confidence at {{.DetectionTime}}. {{.DetectionURL}}")
 }
 
 // setModuleLogDefaults sets default values for a module log configuration


### PR DESCRIPTION
## Summary

- Removes `{{.ImageURL}}` from the default new-species notification message template — it never rendered as an actual image via Shoutrrr (just raw URL text) and its presence on its own line caused Discord to split the message into multiple embed boxes
- Consolidates the template to a single line, fixing the root cause of each line appearing as a separate embed in Discord
- Keeps `{{.DetectionURL}}` inline at the end of the message
- Adds a note to the Shoutrrr Discord URL example in `doc/wiki/guide.md` explaining the `?splitLines=No` option for users with custom multi-line templates

## Root Cause

Shoutrrr's Discord service defaults to `splitLines=Yes`, which turns every non-empty line into a separate embedded Discord message. The previous default template produced 3 non-empty lines:

1. Image URL (raw text, never rendered as image)
2. Detection sentence
3. Detection URL

This resulted in 3 separate embed boxes in Discord instead of one.

## Test Plan

- [x] `go test ./internal/conf/...` passes
- [x] `go test ./internal/notification/...` passes
- [ ] For Discord Shoutrrr users: after removing the overridden template from `config.yaml`, notifications should appear as a single embed with the title in the embed header

Fixes #1953