### PR TITLE
fix(ui): load dashboard config before fetching daily summary

### DIFF
--- a/frontend/src/lib/desktop/features/dashboard/pages/DashboardPage.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/pages/DashboardPage.svelte
@@ -119,6 +119,7 @@ Performance Optimizations:
   let detectionsError = $state<string | null>(null);
   let showThumbnails = $state(true); // Default to true for backward compatibility
   let summaryLimit = $state(30); // Default from backend (conf/defaults.go) - species count limit for daily summary
+  let configLoaded = $state(false); // Gates reactive preloading until config is loaded
 
   // SSE throttling timer
   let sseFetchTimer: ReturnType<typeof setTimeout> | null = null;
@@ -350,6 +351,8 @@ Performance Optimizations:
     } catch (error) {
       logger.error('Error fetching dashboard config:', error);
       // Keep default values on error
+    } finally {
+      configLoaded = true;
     }
   }
 
@@ -594,8 +597,7 @@ Performance Optimizations:
     // must return a sync cleanup function.
     fetchDashboardConfig().then(() => {
       fetchDailySummary();
-      // Preload adjacent dates after config is loaded so the correct limit is used
-      triggerAdjacentPreload(selectedDate);
+      // Adjacent date preloading is handled by the $effect gated on configLoaded
     });
     fetchRecentDetections();
 
@@ -1085,10 +1087,10 @@ Performance Optimizations:
     }, 150); // Wait 150ms for settling
   }
 
-  // Reactive preloading - triggers when selectedDate changes
+  // Reactive preloading - triggers when selectedDate changes or config finishes loading
   $effect(() => {
-    // Only preload if we have a valid selectedDate and not during initial load
-    if (selectedDate) {
+    // Gate on configLoaded to prevent preloading with default summaryLimit before config is fetched
+    if (selectedDate && configLoaded) {
       triggerAdjacentPreload(selectedDate);
     }
   });


### PR DESCRIPTION
## Summary
- **Fixes #1898** — Daily Summary shows 30 species instead of user-defined preference
- `fetchDailySummary()` and `triggerAdjacentPreload()` were firing before `fetchDashboardConfig()` completed in `onMount`, causing the initial API call to always use the default `summaryLimit` of 30
- Chains both calls after config loads via `.then()` so the user's configured limit is used from the first request
- Adjacent date preloading also moved into the `.then()` block to prevent caching truncated data

## Test plan
- [ ] Configure species limit to a value other than 30 (e.g., 55) in dashboard settings
- [ ] Navigate directly to a date via URL (e.g., `/ui/dashboard?date=2026-01-29`) — should show up to 55 species
- [ ] Verify the initial API call uses `limit=55` (check network tab)
- [ ] Navigate to adjacent dates via date picker — should also use correct limit
- [ ] Reload the page — should still use the configured limit on first load

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed dashboard initialization to load configuration first, then fetch the daily summary; deferred adjacent-date preloads until configuration is available to prevent premature requests and improve stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->