### PR TITLE
fix(install): prevent broken systemd service on systems without /dev/snd

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3456,13 +3456,13 @@ generate_systemd_service_content() {
     # Check for /dev/snd/
     local audio_env_line=""
     if check_directory_exists "/dev/snd/"; then
-        audio_env_line="--device /dev/snd \\"
+        audio_env_line="--device /dev/snd"
     fi
 
     # Check for /sys/class/thermal, used for Raspberry Pi temperature reporting in system dashboard
     local thermal_volume_line=""
     if check_directory_exists "/sys/class/thermal"; then
-        thermal_volume_line="-v /sys/class/thermal:/sys/class/thermal \\"
+        thermal_volume_line="-v /sys/class/thermal:/sys/class/thermal"
     fi
 
     # Check if running on Raspberry Pi and add WiFi power save disable script
@@ -3488,8 +3488,8 @@ ExecStartPre=-/usr/bin/docker rm -f birdnet-go
 ExecStartPre=/bin/mkdir -p ${CONFIG_DIR}/hls
 # Mount tmpfs, the '|| true' ensures it doesn't fail if already mounted
 ExecStartPre=/bin/sh -c 'mount -t tmpfs -o size=50M,mode=0755,uid=${HOST_UID},gid=${HOST_GID},noexec,nosuid,nodev tmpfs ${CONFIG_DIR}/hls || true'
-${wifi_power_save_script}
-ExecStart=/usr/bin/docker run --rm \\
+${wifi_power_save_script:+${wifi_power_save_script}
+}ExecStart=/usr/bin/docker run --rm \\
     --name birdnet-go \\
     -p ${WEB_PORT}:8080 \\
     -p 80:80 \\
@@ -3498,11 +3498,11 @@ ExecStart=/usr/bin/docker run --rm \\
     --env TZ="${TZ}" \\
     --env BIRDNET_UID=${HOST_UID} \\
     --env BIRDNET_GID=${HOST_GID} \\
-    ${audio_env_line}
-    -v ${CONFIG_DIR}:/config \\
+${audio_env_line:+    ${audio_env_line} \\
+}    -v ${CONFIG_DIR}:/config \\
     -v ${DATA_DIR}:/data \\
-    ${thermal_volume_line}
-    ${BIRDNET_GO_IMAGE}
+${thermal_volume_line:+    ${thermal_volume_line} \\
+}    ${BIRDNET_GO_IMAGE}
 # Cleanup tasks on stop
 ExecStopPost=/bin/sh -c 'umount -f ${CONFIG_DIR}/hls || true'
 ExecStopPost=-/usr/bin/docker rm -f birdnet-go


### PR DESCRIPTION
## Summary

Fixes #1832

- Conditional variables (`audio_env_line`, `thermal_volume_line`, `wifi_power_save_script`) in `generate_systemd_service_content()` produced blank lines when empty, breaking shell backslash line continuations in the generated systemd service file
- Uses bash `${var:+$var}` conditional expansion so empty variables produce no output instead of blank lines
- Systems without `/dev/snd/`, `/sys/class/thermal`, or non-Raspberry Pi now generate valid service files

## Root cause

The heredoc template inserted these variables directly on their own lines. When empty, this produced blank lines that broke the `\` line continuation of the `docker run` command, causing:
- systemd: `Missing '='` errors
- docker: `"docker run" requires at least 1 argument`

## Test plan

- [ ] Verify generated service file on system **without** `/dev/snd/` — no blank lines in `ExecStart`
- [ ] Verify generated service file on system **with** `/dev/snd/` — `--device /dev/snd` included with proper continuation
- [ ] Verify generated service file on Raspberry Pi — WiFi power save `ExecStartPre` included
- [ ] Verify generated service file with `/sys/class/thermal` — thermal volume mount included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved installation script to conditionally include optional features (audio support, thermal monitoring, and WiFi power save) based on configuration, resulting in cleaner and more flexible installation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->