### PR TITLE
fix(detections): prevent species name disappearing at wide viewports

### DIFF
--- a/frontend/src/lib/desktop/components/media/AudioPlayer.svelte
+++ b/frontend/src/lib/desktop/components/media/AudioPlayer.svelte
@@ -964,7 +964,7 @@
 
 <div
   bind:this={playerContainer}
-  class={cn('relative group', className)}
+  class={cn('relative group overflow-hidden', className)}
   style={responsive
     ? ''
     : `width: ${typeof width === 'number' ? width + 'px' : width}; height: ${typeof height === 'number' ? height + 'px' : height};`}

--- a/frontend/src/lib/desktop/views/DetectionDetail.svelte
+++ b/frontend/src/lib/desktop/views/DetectionDetail.svelte
@@ -442,13 +442,13 @@
             <div class="flex-1 min-w-0">
               <h1
                 id="species-heading"
-                class="text-2xl md:text-3xl font-semibold text-base-content mb-1 truncate"
+                class="text-2xl md:text-3xl font-semibold text-base-content mb-1 break-words"
               >
                 {detection.commonName}
                 <span class="sr-only">detection details</span>
               </h1>
               <p
-                class="text-base md:text-lg text-base-content opacity-60 italic truncate"
+                class="text-base md:text-lg text-base-content opacity-60 italic break-words"
                 aria-label="Scientific name"
               >
                 {detection.scientificName}


### PR DESCRIPTION
## Summary

- Replace `truncate` with `break-words` on species common name and scientific name in the DetectionDetail hero section, so text wraps instead of collapsing to zero width when the flex layout distributes space to fixed-width right-side sections at the `md` breakpoint (~768px+)
- Add `overflow-hidden` to the AudioPlayer container to constrain absolutely positioned bottom controls (play/pause, progress bar) within the spectrogram frame bounds

## Test plan

- [ ] Open a detection detail page at viewport widths between 750px-900px and verify species name and scientific name remain visible
- [ ] Resize viewport from mobile to wide desktop and confirm the hero section layout adapts smoothly
- [ ] Verify audio player controls stay within the spectrogram container bounds at all viewport sizes
- [ ] Check that species names wrap naturally instead of being truncated with ellipsis

Closes #1734

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated audio player layout to prevent overflow of content within component boundaries
  * Improved detection details text handling by enabling line wrapping for species names and scientific nomenclature instead of truncation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->