### PR TITLE
fix(conf): add missing defaults for log deduplication settings

### DIFF
--- a/internal/conf/defaults.go
+++ b/internal/conf/defaults.go
@@ -158,6 +158,10 @@ func setDefaultConfig() {
 	viper.SetDefault("realtime.dynamicthreshold.min", 0.20)
 	viper.SetDefault("realtime.dynamicthreshold.validhours", 24)
 
+	// Log deduplication configuration
+	viper.SetDefault("realtime.logdeduplication.enabled", true)
+	viper.SetDefault("realtime.logdeduplication.healthcheckintervalseconds", 60)
+
 	// False positive filter configuration
 	// Level 0 = Off (no filtering, backward compatible default)
 	// Level 1 = Lenient, Level 2 = Moderate, Level 3 = Balanced (original behavior)


### PR DESCRIPTION
## Summary

- Adds missing viper defaults for `realtime.logdeduplication.enabled` (true) and `realtime.logdeduplication.healthcheckintervalseconds` (60) in `defaults.go`
- Without these defaults, users upgrading from older configs get Go zero values (`Enabled=false`, `HealthCheckIntervalSeconds=0`) since their config files lack the `realtime.logdeduplication` section

## Context

The `LogDeduplicationSettings` struct (config.go:593-597) was introduced without corresponding defaults in `defaults.go`. Every other realtime subsection (dynamic threshold, privacy filter, dog bark filter, etc.) has explicit defaults registered — log deduplication was the only one missing.

## Behavioral note

With `Enabled=false` (the previous implicit default), the deduplicator's `ShouldLog()` method returns `true` for every call — effectively disabling deduplication and allowing all log lines through. Setting `Enabled=true` activates intelligent deduplication that suppresses duplicate detection-summary messages while still logging on state changes and periodic health checks (every 60s). This prevents ~40,000+ identical zero-detection log lines per day.

Closes #1843

## Test plan

- [x] `golangci-lint run -v ./internal/conf/...` — 0 issues
- [x] `go test -race -v ./internal/conf/...` — all pass
- [x] `go test -race -v ./internal/analysis/processor/...` — all pass