### PR TITLE
refactor(frontend): deduplicate subpage routing in App.svelte

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -299,7 +299,7 @@
       pageTitleKey = config.titleKey;
 
       for (const [subpath, titleKey] of Object.entries(subpagesMap)) {
-        if (path.includes(subpath)) {
+        if (path.endsWith(subpath)) {
           pageTitleKey = titleKey;
           break;
         }


### PR DESCRIPTION
## Summary
- Extract `handleSubpageRouting()` helper function from duplicate system/settings subpage routing blocks in `App.svelte`
- Both blocks were nearly identical (27 lines each), differing only in route name, prefix regex, subpage map, and error message key
- Replaces both blocks with one-liner calls, reducing 50 lines to 38 (net -12 lines)

Fixes #1869

## Test plan
- [ ] Verify system subpages (`/ui/system/database`, `/ui/system/terminal`) still route correctly and show proper page titles
- [ ] Verify settings subpages (`/ui/settings/main`, `/ui/settings/audio`, etc.) still route correctly and show proper page titles
- [ ] Verify 404 fallback works when system/settings route config is missing
- [ ] Run `npm run check:all` — all checks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal routing logic has been consolidated and reorganized to reduce duplication and unify subpage handling; no visible changes to the app's behavior.
* **Bug Fixes**
  * Error/404 handling and normal route behavior remain intact and continue to load the appropriate pages when needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->