### PR TITLE
fix: show common names and fix delete in v2 dynamic thresholds

### DIFF
--- a/internal/datastore/v2only/datastore.go
+++ b/internal/datastore/v2only/datastore.go
@@ -2334,8 +2334,8 @@ func thresholdScientificName(t *entities.DynamicThreshold) string {
 
 // resolveCommonName maps a scientific name to its common name using the
 // pre-built commonNameMap. Falls back to the scientific name if no mapping exists.
-// This follows the same pattern used in detectionToNote (line 520),
-// detectionToRecord (line 643), and daily aggregation (line 861).
+// This follows the same pattern used in detectionToNote, detectionToRecord,
+// and GetTopBirdsData for common-name display.
 func (ds *Datastore) resolveCommonName(scientificName string) string {
 	if cn, ok := ds.commonNameMap[scientificName]; ok {
 		return cn
@@ -2347,7 +2347,7 @@ func (ds *Datastore) resolveCommonName(scientificName string) string {
 // or scientific name) to a scientific name for v2 label lookups.
 // Uses the pre-built speciesMap (lowercase common name → scientific name).
 // Falls back to the input unchanged if no mapping is found.
-// This follows the same pattern used in GetHourlyOccurrences (line 881).
+// This follows the same pattern used in GetHourlyOccurrences.
 func (ds *Datastore) resolveToScientificName(name string) string {
 	normalized := strings.ToLower(strings.TrimSpace(name))
 	if sci, ok := ds.speciesMap[normalized]; ok {
@@ -2682,6 +2682,10 @@ func (ds *Datastore) GetRecentThresholdEvents(limit int) ([]datastore.ThresholdE
 }
 
 // DeleteThresholdEvents deletes threshold events for a species.
+// NOTE: This only deletes events by the resolved scientific name. GetThresholdEvents
+// queries both common-name and scientific-name labels (WORKAROUND #1907). Legacy events
+// saved with common-name labels may survive this delete. Full dual-delete cleanup
+// should be added when the #1907 workaround is removed.
 func (ds *Datastore) DeleteThresholdEvents(speciesName string) error {
 	if ds.threshold == nil {
 		return nil

--- a/internal/datastore/v2only/datastore_test.go
+++ b/internal/datastore/v2only/datastore_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/tphakala/birdnet-go/internal/logger"
 )
 
-// setupTestDatastore creates a V2OnlyDatastore with an in-memory SQLite database for testing.
-func setupTestDatastore(t *testing.T) (ds *Datastore, cleanup func()) {
+// buildTestConfig constructs the shared repositories and Config for in-memory test datastores.
+func buildTestConfig(t *testing.T, labels []string) (cfg *Config, cleanup func()) {
 	t.Helper()
 
 	// Create temp directory for test (auto-cleaned by testing framework)
@@ -66,81 +66,7 @@ func setupTestDatastore(t *testing.T) (ds *Datastore, cleanup func()) {
 	thresholdRepo := repository.NewDynamicThresholdRepository(db, labelRepo, false, false)
 	notificationRepo := repository.NewNotificationHistoryRepository(db, labelRepo, false, false)
 
-	// Create datastore with cached lookup table IDs
-	var err2 error
-	ds, err2 = New(&Config{
-		Manager:            manager,
-		Detection:          detectionRepo,
-		Label:              labelRepo,
-		Model:              modelRepo,
-		Source:             sourceRepo,
-		Weather:            weatherRepo,
-		ImageCache:         imageCacheRepo,
-		Threshold:          thresholdRepo,
-		Notification:       notificationRepo,
-		Logger:             testLogger,
-		Timezone:           time.UTC,
-		DefaultModelID:     defaultModel.ID,
-		SpeciesLabelTypeID: speciesLabelType.ID,
-		AvesClassID:        &avesClassID,
-	})
-	require.NoError(t, err2)
-
-	cleanup = func() {
-		_ = ds.Close()
-		// tempDir is auto-cleaned by t.TempDir()
-	}
-
-	return ds, cleanup
-}
-
-// setupTestDatastoreWithLabels creates a V2OnlyDatastore with species label mappings for testing.
-// Labels provide the species map (common name → scientific name) and
-// common name map (scientific name → common name) used by dynamic threshold methods.
-func setupTestDatastoreWithLabels(t *testing.T, labels []string) (ds *Datastore, cleanup func()) {
-	t.Helper()
-
-	tempDir := t.TempDir()
-	testLogger := logger.NewConsoleLogger("v2only_test", logger.LogLevelDebug)
-
-	manager, err := v2.NewSQLiteManager(v2.Config{
-		DataDir: tempDir,
-		Debug:   false,
-		Logger:  testLogger,
-	})
-	require.NoError(t, err)
-
-	err = manager.Initialize()
-	require.NoError(t, err)
-
-	db := manager.DB()
-
-	labelTypeRepo := repository.NewLabelTypeRepository(db, false)
-	taxClassRepo := repository.NewTaxonomicClassRepository(db, false)
-	modelRepo := repository.NewModelRepository(db, false, false)
-
-	ctx := t.Context()
-
-	speciesLabelType, err := labelTypeRepo.GetOrCreate(ctx, "species")
-	require.NoError(t, err)
-
-	avesClass, err := taxClassRepo.GetOrCreate(ctx, "Aves")
-	require.NoError(t, err)
-
-	defaultModel, err := modelRepo.GetByNameVersionVariant(ctx, "BirdNET", "2.4", "default")
-	require.NoError(t, err)
-
-	avesClassID := avesClass.ID
-
-	detectionRepo := repository.NewDetectionRepository(db, false, false)
-	labelRepo := repository.NewLabelRepository(db, false, false)
-	sourceRepo := repository.NewAudioSourceRepository(db, false, false)
-	weatherRepo := repository.NewWeatherRepository(db, false, false)
-	imageCacheRepo := repository.NewImageCacheRepository(db, labelRepo, false, false)
-	thresholdRepo := repository.NewDynamicThresholdRepository(db, labelRepo, false, false)
-	notificationRepo := repository.NewNotificationHistoryRepository(db, labelRepo, false, false)
-
-	ds, err2 := New(&Config{
+	cfg = &Config{
 		Manager:            manager,
 		Detection:          detectionRepo,
 		Label:              labelRepo,
@@ -156,14 +82,30 @@ func setupTestDatastoreWithLabels(t *testing.T, labels []string) (ds *Datastore,
 		SpeciesLabelTypeID: speciesLabelType.ID,
 		AvesClassID:        &avesClassID,
 		Labels:             labels,
-	})
-	require.NoError(t, err2)
-
-	cleanup = func() {
-		_ = ds.Close()
 	}
 
-	return ds, cleanup
+	// tempDir is auto-cleaned by t.TempDir(); no additional cleanup needed
+	return cfg, func() {}
+}
+
+// setupTestDatastore creates a V2OnlyDatastore with an in-memory SQLite database for testing.
+func setupTestDatastore(t *testing.T) (ds *Datastore, cleanup func()) {
+	t.Helper()
+	cfg, cfgCleanup := buildTestConfig(t, nil)
+	ds, err := New(cfg)
+	require.NoError(t, err)
+	return ds, func() { _ = ds.Close(); cfgCleanup() }
+}
+
+// setupTestDatastoreWithLabels creates a V2OnlyDatastore with species label mappings for testing.
+// Labels provide the species map (common name → scientific name) and
+// common name map (scientific name → common name) used by dynamic threshold methods.
+func setupTestDatastoreWithLabels(t *testing.T, labels []string) (ds *Datastore, cleanup func()) {
+	t.Helper()
+	cfg, cfgCleanup := buildTestConfig(t, labels)
+	ds, err := New(cfg)
+	require.NoError(t, err)
+	return ds, func() { _ = ds.Close(); cfgCleanup() }
 }
 
 func TestV2OnlyDatastore_Open(t *testing.T) {
@@ -443,6 +385,92 @@ func TestV2OnlyDatastore_DynamicThreshold_FallbackWithoutMapping(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "Passer domesticus", retrieved.SpeciesName, "should fallback to scientific name")
 	assert.Equal(t, "Passer domesticus", retrieved.ScientificName)
+}
+
+// TestV2OnlyDatastore_DynamicThreshold_UpdateExpiryByCommonName verifies that
+// UpdateDynamicThresholdExpiry works when called with a common name.
+func TestV2OnlyDatastore_DynamicThreshold_UpdateExpiryByCommonName(t *testing.T) {
+	labels := []string{"Parus major_Great Tit"}
+	ds, cleanup := setupTestDatastoreWithLabels(t, labels)
+	defer cleanup()
+
+	threshold := &datastore.DynamicThreshold{
+		SpeciesName:    "Parus major",
+		ScientificName: "Parus major",
+		Level:          1,
+		CurrentValue:   0.6,
+		BaseThreshold:  0.8,
+		ValidHours:     12,
+		ExpiresAt:      time.Now().Add(12 * time.Hour),
+		LastTriggered:  time.Now(),
+		FirstCreated:   time.Now(),
+		UpdatedAt:      time.Now(),
+	}
+	err := ds.SaveDynamicThreshold(threshold)
+	require.NoError(t, err)
+
+	// Update expiry using lowercase common name
+	newExpiry := time.Now().Add(48 * time.Hour)
+	err = ds.UpdateDynamicThresholdExpiry("great tit", newExpiry)
+	require.NoError(t, err, "UpdateDynamicThresholdExpiry should work with common name")
+
+	// Verify the expiry was updated
+	retrieved, err := ds.GetDynamicThreshold("Parus major")
+	require.NoError(t, err)
+	assert.WithinDuration(t, newExpiry, retrieved.ExpiresAt, time.Second, "expiry should be updated")
+}
+
+// TestV2OnlyDatastore_DynamicThreshold_DeleteEventsByCommonName verifies that
+// DeleteThresholdEvents works when called with a common name.
+func TestV2OnlyDatastore_DynamicThreshold_DeleteEventsByCommonName(t *testing.T) {
+	labels := []string{"Parus major_Great Tit"}
+	ds, cleanup := setupTestDatastoreWithLabels(t, labels)
+	defer cleanup()
+
+	// Save a threshold first (needed for event's label resolution)
+	threshold := &datastore.DynamicThreshold{
+		SpeciesName:    "Parus major",
+		ScientificName: "Parus major",
+		Level:          1,
+		CurrentValue:   0.6,
+		BaseThreshold:  0.8,
+		ValidHours:     12,
+		ExpiresAt:      time.Now().Add(12 * time.Hour),
+		LastTriggered:  time.Now(),
+		FirstCreated:   time.Now(),
+		UpdatedAt:      time.Now(),
+	}
+	err := ds.SaveDynamicThreshold(threshold)
+	require.NoError(t, err)
+
+	// Save an event using scientific name (as the processor does after #1907)
+	event := &datastore.ThresholdEvent{
+		SpeciesName:    "great tit",
+		ScientificName: "Parus major",
+		PreviousLevel:  0,
+		NewLevel:       1,
+		PreviousValue:  0.8,
+		NewValue:       0.6,
+		ChangeReason:   "high_confidence",
+		Confidence:     0.95,
+		CreatedAt:      time.Now(),
+	}
+	err = ds.SaveThresholdEvent(event)
+	require.NoError(t, err)
+
+	// Verify event exists
+	events, err := ds.GetThresholdEvents("Parus major", 10)
+	require.NoError(t, err)
+	require.NotEmpty(t, events, "event should exist before delete")
+
+	// Delete events using lowercase common name
+	err = ds.DeleteThresholdEvents("great tit")
+	require.NoError(t, err, "DeleteThresholdEvents should work with common name")
+
+	// Verify events are deleted
+	events, err = ds.GetThresholdEvents("Parus major", 10)
+	require.NoError(t, err)
+	assert.Empty(t, events, "events should be deleted when using common name")
 }
 
 func TestV2OnlyDatastore_ImageCache(t *testing.T) {


### PR DESCRIPTION
## Summary

- **Display bug**: Dynamic Threshold tab showed scientific names (e.g., "Parus major") instead of common names (e.g., "Great Tit") when using v2 schema
- **Delete bug**: Deleting learned species entries did nothing on v2 schema — the processor's in-memory map uses common names as keys but received scientific names from the API
- Both bugs fixed by adding `resolveCommonName` and `resolveToScientificName` helpers to the v2only datastore, following the same pattern already used by 6+ other methods in the same file

## Test plan

- [x] 4 new tests covering common name display, delete by common name, get by common name, and fallback behavior
- [x] All existing v2only, v2, api/v2, and processor tests pass with `-race`
- [x] Zero linter issues
- [x] Frontend checks pass (no frontend changes needed)
- [ ] Manual verification: Dynamic Threshold tab shows common names and delete works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dynamic thresholds accept and resolve species by common name for retrieve, delete, and update operations.
  * Threshold views display common names when mappings exist, with automatic fallback to scientific names for unmapped species.
* **Tests**
  * Added tests covering common-name lookups, updates, deletions, display behavior, and fallback scenarios to ensure consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->