### PR TITLE
fix: propagate DailyEventsID in v2only SaveDailyEvents

### DIFF
--- a/internal/datastore/v2only/datastore.go
+++ b/internal/datastore/v2only/datastore.go
@@ -1418,6 +1418,9 @@ func (ds *Datastore) SaveDailyEvents(dailyEvents *datastore.DailyEvents) error {
 	if err := ds.weather.SaveDailyEvents(ctx, v2Events); err != nil {
 		return err
 	}
+	if v2Events.ID == 0 {
+		return fmt.Errorf("SaveDailyEvents: repository returned success but entity ID was not populated")
+	}
 	// Propagate the auto-generated ID back to the caller so that
 	// subsequent SaveHourlyWeather calls can set DailyEventsID correctly.
 	dailyEvents.ID = v2Events.ID


### PR DESCRIPTION
## Summary

- Fixes missing weather icons on the dashboard when using the v2 database schema
- The v2only `SaveDailyEvents` adapter created a new `entities.DailyEvents` struct but never copied the GORM-assigned `ID` back to the caller's pointer, causing all `HourlyWeather` records to be saved with `DailyEventsID=0`
- The v2 `GetHourlyWeather` queries by `daily_events_id` foreign key, so records with `DailyEventsID=0` were never found, resulting in an empty weather array and hidden weather icons

## Root Cause

**Legacy path** (works): `DataStore.SaveDailyEvents` uses GORM's `FirstOrCreate` directly on the passed pointer, so `dailyEvents.ID` is populated in-place.

**V2 path** (broken): `v2only.Datastore.SaveDailyEvents` creates a separate `entities.DailyEvents`, passes it to GORM (which populates `v2Events.ID`), but never copies `v2Events.ID` back to `dailyEvents.ID`. The caller then uses `dailyEvents.ID` (still 0) as the foreign key for `HourlyWeather`.

## Fix

After the v2 repository save succeeds, copy `v2Events.ID` back to `dailyEvents.ID`.

## Note

Existing hourly weather records saved with `DailyEventsID=0` will remain orphaned. New weather polls after this fix will work correctly. A one-time data repair query can fix historical data:

```sql
UPDATE hourly_weathers
SET daily_events_id = (
  SELECT de.id FROM daily_events de
  WHERE de.date = DATE(hourly_weathers.time)
)
WHERE daily_events_id = 0;
```

## Test plan

- [x] `go build ./internal/datastore/v2only/...` compiles
- [x] `go test ./internal/weather/...` passes (53s, includes SaveWeatherData ID propagation tests)
- [x] `go test ./internal/datastore/v2only/...` passes
- [x] `golangci-lint run ./internal/datastore/v2only/...` — 0 issues
- [ ] Manual verification: deploy with v2 schema, confirm weather icons appear on dashboard

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed weather data saving so daily records reliably link to subsequent hourly weather entries.
  * Improved error handling during weather data persistence to ensure failures are reported.
  * Ensure generated record IDs are propagated back so created daily entries can be referenced by later operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->