### PR TITLE
fix: prevent duplicate key errors in dashboard daily summary

### DIFF
--- a/frontend/src/lib/desktop/features/dashboard/pages/DashboardPage.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/pages/DashboardPage.svelte
@@ -906,7 +906,7 @@ Performance Optimizations:
           }
         },
         1000,
-        `count-${detection.speciesCode}`
+        `count-${detection.scientificName}`
       );
     } else {
       // Add new species - sorting is handled by DailySummaryCard's sortedData derived value
@@ -969,7 +969,7 @@ Performance Optimizations:
           }
         },
         800,
-        `new-${detection.speciesCode}`
+        `new-${detection.scientificName}`
       );
     }
   }


### PR DESCRIPTION
## Summary

- Fix `each_key_duplicate` Svelte errors on the dashboard caused by SSE detection updates adding duplicate `scientific_name` entries to the daily summary
- The v2 schema does not store `species_code` (always empty/omitted), so SSE detections with actual species codes from BirdNET failed to match existing entries by `species_code`, falling through to add duplicates
- Add `scientific_name` fallback lookup in `updateDailySummary` when `species_code` misses
- Sync `species_code` onto matched entries so animation cleanup callbacks and future lookups work correctly
- Add defensive dedup by `id` in `fetchRecentDetections`

## Test plan

- [ ] Verify no `each_key_duplicate` errors in browser console on dashboard
- [ ] Verify daily summary species counts update correctly via SSE
- [ ] Verify count pulse animations appear and clear properly
- [ ] Verify spectrogram loading is not stuck on "Generating..."

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate recent detections from appearing.
  * Fixed update matching so records aren't missed when primary identifiers are empty.

* **Improvements**
  * Real-time and daily summaries now prefer stable scientific names, reducing missed or misattributed entries.
  * Detection updates backfill missing species identifiers to improve future matching and cleanup scheduling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->