### PR TITLE
fix: add retry with backoff for audio playback on 404

### DIFF
--- a/frontend/src/lib/desktop/features/dashboard/components/PlayOverlay.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/components/PlayOverlay.svelte
@@ -181,6 +181,9 @@
         isLoading = false;
       }
     } catch (err) {
+      // If a retry is already queued (handleError ran before play() rejected),
+      // don't overwrite the retry state with an error message.
+      if (audioRetryCount > 0) return;
       logger.error('Error playing audio:', err);
       error = t('media.audio.playError');
       isLoading = false;
@@ -375,6 +378,8 @@
 
       audioRetryTimer = setTimeout(() => {
         if (!audioElement) return;
+        // Ensure isLoading is true so subsequent retries can trigger
+        isLoading = true;
         // Cache-bust to avoid the browser serving the cached 404
         audioElement.src = `${audioUrl}?t=${String(Date.now())}`;
         audioElement.load();


### PR DESCRIPTION
## Summary

- When a new detection arrives via SSE, the audio clip may still be writing to disk
- If the user clicks play immediately, `/api/v2/audio/{id}` returns 404 and the player shows an error with no recovery
- Adds transparent retry logic (up to 3 attempts with 1s/2s/4s exponential backoff) when audio loading fails during an active play attempt
- Uses cache-bust query params to avoid browser serving the cached 404 response
- Retry count resets on each fresh user click or detection ID change

## Test plan

- [ ] Deploy and trigger a new detection
- [ ] Click play immediately on the new detection card
- [ ] Verify the player retries automatically instead of showing an error
- [ ] Verify that after 3 failed retries, the error message still appears
- [ ] Verify normal playback (non-404 case) is unaffected
- [ ] Verify switching between detection cards resets retry state

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * More reliable audio playback: automatic retry on load failures with incremental backoff and cache-busting, transparent to the user.
  * Retries reset when navigating or when a new play is started, preventing stale retry attempts.
  * Retries stop once playback succeeds or is cancelled, and duplicate or overlapping retries are avoided to reduce background resource use and errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->