### PR TITLE
fix: reduce SSE heartbeat interval to prevent WriteTimeout race

### DIFF
--- a/internal/api/v2/notifications.go
+++ b/internal/api/v2/notifications.go
@@ -27,7 +27,7 @@ const (
 	// Connection timeouts
 	maxSSEConnectionDuration = 30 * time.Minute       // Maximum connection duration to prevent resource leaks
 	rateLimitWindow          = 1 * time.Minute        // Rate limiter time window
-	heartbeatInterval        = 30 * time.Second       // Heartbeat interval for keep-alive
+	heartbeatInterval        = 15 * time.Second       // Heartbeat interval for keep-alive (must be < server WriteTimeout)
 	eventLoopCheckInterval   = 100 * time.Millisecond // Event loop check interval
 
 	// Endpoints

--- a/internal/api/v2/sse.go
+++ b/internal/api/v2/sse.go
@@ -24,7 +24,7 @@ import (
 const (
 	// Connection timeouts
 	maxSSEStreamDuration = 30 * time.Minute      // Maximum stream duration to prevent resource leaks
-	sseHeartbeatInterval = 30 * time.Second      // Heartbeat interval for keep-alive
+	sseHeartbeatInterval = 15 * time.Second      // Heartbeat interval for keep-alive (must be < server WriteTimeout)
 	sseEventLoopSleep    = 10 * time.Millisecond // Sleep duration when no events
 	sseWriteDeadline     = 10 * time.Second      // Write deadline for SSE messages
 


### PR DESCRIPTION
## Summary

- Reduce SSE heartbeat interval from 30s to 15s for detection, notification, and health streams
- Fixes `ERR_INCOMPLETE_CHUNKED_ENCODING` errors caused by the server's `WriteTimeout` (30s) racing with the heartbeat interval (also 30s)

## Root Cause

The HTTP server's `WriteTimeout` is set to 30 seconds in `config.go`. SSE connections rely on periodic heartbeats to call `SetWriteDeadline()` which resets the server-level timeout. With both values at 30s, any scheduling delay causes the server to forcefully close the connection before the heartbeat write completes.

The audio level stream (`audio_level.go`) was already working because it uses a 10s heartbeat interval — well within the 30s timeout.

## Changes

| File | Constant | Before | After |
|------|----------|--------|-------|
| `internal/api/v2/sse.go` | `sseHeartbeatInterval` | 30s | 15s |
| `internal/api/v2/notifications.go` | `heartbeatInterval` | 30s | 15s |

## Test plan

- [x] `go vet ./internal/api/...` passes
- [x] `go test ./internal/api/v2/... -race` passes (43s, no races)
- [ ] Manual: open dashboard, confirm no `ERR_INCOMPLETE_CHUNKED_ENCODING` in console for 2+ minutes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved notification stream stability by increasing heartbeat frequency for server-sent event connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->