### PR TITLE
feat: reduce false positive detections

### DIFF
--- a/doc/wiki/guide.md
+++ b/doc/wiki/guide.md
@@ -777,7 +777,7 @@ birdnet:
   latitude: 60.1699
   longitude: 24.9384
   rangefilter:
-    threshold: 0.01 # Lower = more permissive, higher = more strict
+    threshold: 0.03 # Lower = more permissive, higher = more strict
 ```
 
 ### Stage 2: Confidence Threshold
@@ -860,7 +860,7 @@ realtime:
     enabled: true # Enable dynamic threshold adjustment (default: true)
     debug: false # Enable debug logging for threshold changes
     trigger: 0.90 # Confidence level that triggers threshold reduction
-    min: 0.20 # Minimum allowed threshold (safety floor)
+    min: 0.40 # Minimum allowed threshold (safety floor)
     validhours: 24 # Hours before threshold resets to base value
 ```
 
@@ -1146,16 +1146,17 @@ birdnet:
   rangefilter:
     debug: false # Enable debug logging
     model: "" # "" for V2 (default), "legacy" for V1
-    threshold: 0.01 # Species occurrence threshold (0.0-1.0)
+    threshold: 0.03 # Species occurrence threshold (0.0-1.0)
 ```
 
 > **Note**: The configuration uses `birdnet.rangefilter` in YAML, while CLI commands use the `range` group (e.g., `birdnet-go range print`). These refer to the same functionality.
 
 #### Understanding the Threshold Parameter
 
-The `threshold` parameter controls which species are included in analysis based on their occurrence probability. **The default value of 0.01 is recommended for most users and rarely needs to be changed** unless you have very specific requirements.
+The `threshold` parameter controls which species are included in analysis based on their occurrence probability. **The default value of 0.03 is recommended for most users and rarely needs to be changed** unless you have very specific requirements.
 
-- **Default (0.01)**: Permissive filtering that works well for most locations and use cases
+- **Default (0.03)**: Balanced filtering that works well for most locations and use cases
+- **Permissive values (0.01)**: Include more species, including those with very low occurrence probability
 - **Conservative values (0.05-0.1)**: Include fewer species, only those with higher occurrence probability
 - **Strict values (0.1-0.3)**: Include only species with strong occurrence probability
 - **Very strict values (0.5+)**: Include only the most common species for your area
@@ -1164,15 +1165,15 @@ The `threshold` parameter controls which species are included in analysis based 
 
 ### Configuration Examples
 
-#### Example 1: Default Permissive Filtering
+#### Example 1: Default Balanced Filtering
 
 ```yaml
 rangefilter:
-  threshold: 0.01 # Default - good for most users
+  threshold: 0.03 # Default - good for most users
 ```
 
-- Includes species with ≥1% occurrence probability
-- Captures most potential species including occasional visitors
+- Includes species with ≥3% occurrence probability
+- Captures most expected species while filtering out unlikely ones
 - Balanced approach suitable for most locations
 
 #### Example 2: Conservative Filtering

--- a/doc/wiki/guide.md
+++ b/doc/wiki/guide.md
@@ -800,7 +800,7 @@ birdnet:
   latitude: 60.1699
   longitude: 24.9384
   rangefilter:
-    threshold: 0.01 # Lower = more permissive, higher = more strict
+    threshold: 0.03 # Lower = more permissive, higher = more strict
 ```
 
 ### Stage 2: Confidence Threshold
@@ -883,7 +883,7 @@ realtime:
     enabled: true # Enable dynamic threshold adjustment (default: true)
     debug: false # Enable debug logging for threshold changes
     trigger: 0.90 # Confidence level that triggers threshold reduction
-    min: 0.20 # Minimum allowed threshold (safety floor)
+    min: 0.40 # Minimum allowed threshold (safety floor)
     validhours: 24 # Hours before threshold resets to base value
 ```
 
@@ -1169,16 +1169,17 @@ birdnet:
   rangefilter:
     debug: false # Enable debug logging
     model: "" # "" for V2 (default), "legacy" for V1
-    threshold: 0.01 # Species occurrence threshold (0.0-1.0)
+    threshold: 0.03 # Species occurrence threshold (0.0-1.0)
 ```
 
 > **Note**: The configuration uses `birdnet.rangefilter` in YAML, while CLI commands use the `range` group (e.g., `birdnet-go range print`). These refer to the same functionality.
 
 #### Understanding the Threshold Parameter
 
-The `threshold` parameter controls which species are included in analysis based on their occurrence probability. **The default value of 0.01 is recommended for most users and rarely needs to be changed** unless you have very specific requirements.
+The `threshold` parameter controls which species are included in analysis based on their occurrence probability. **The default value of 0.03 is recommended for most users and rarely needs to be changed** unless you have very specific requirements.
 
-- **Default (0.01)**: Permissive filtering that works well for most locations and use cases
+- **Default (0.03)**: Balanced filtering that works well for most locations and use cases
+- **Permissive values (0.01)**: Include more species, including those with very low occurrence probability
 - **Conservative values (0.05-0.1)**: Include fewer species, only those with higher occurrence probability
 - **Strict values (0.1-0.3)**: Include only species with strong occurrence probability
 - **Very strict values (0.5+)**: Include only the most common species for your area
@@ -1187,15 +1188,15 @@ The `threshold` parameter controls which species are included in analysis based 
 
 ### Configuration Examples
 
-#### Example 1: Default Permissive Filtering
+#### Example 1: Default Balanced Filtering
 
 ```yaml
 rangefilter:
-  threshold: 0.01 # Default - good for most users
+  threshold: 0.03 # Default - good for most users
 ```
 
-- Includes species with ≥1% occurrence probability
-- Captures most potential species including occasional visitors
+- Includes species with ≥3% occurrence probability
+- Captures most expected species while filtering out unlikely ones
 - Balanced approach suitable for most locations
 
 #### Example 2: Conservative Filtering

--- a/internal/analysis/processor/base_threshold_test.go
+++ b/internal/analysis/processor/base_threshold_test.go
@@ -1,0 +1,66 @@
+package processor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tphakala/birdnet-go/internal/conf"
+)
+
+func TestGetBaseConfidenceThreshold(t *testing.T) {
+	tests := []struct {
+		name           string
+		globalThresh   float64
+		speciesConfig  map[string]conf.SpeciesConfig
+		commonName     string
+		scientificName string
+		expected       float64
+		message        string
+	}{
+		{
+			name:         "zero threshold falls through to global",
+			globalThresh: 0.75,
+			speciesConfig: map[string]conf.SpeciesConfig{
+				"american robin": {Threshold: 0}, // actions-only, no custom threshold
+			},
+			commonName:     "American Robin",
+			scientificName: "Turdus migratorius",
+			expected:       0.75,
+			message:        "Species with threshold:0 should fall through to global threshold, not return 0.0",
+		},
+		{
+			name:         "explicit threshold used",
+			globalThresh: 0.75,
+			speciesConfig: map[string]conf.SpeciesConfig{
+				"american robin": {Threshold: 0.90},
+			},
+			commonName:     "American Robin",
+			scientificName: "Turdus migratorius",
+			expected:       0.90,
+			message:        "Species with explicit threshold should use that value",
+		},
+		{
+			name:           "not in config uses global",
+			globalThresh:   0.75,
+			speciesConfig:  map[string]conf.SpeciesConfig{},
+			commonName:     "Unknown Bird",
+			scientificName: "Unknownus birdus",
+			expected:       0.75,
+			message:        "Species not in config should use global threshold",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := newTestProcessor()
+			p.Settings.BirdNET.Threshold = tt.globalThresh
+			p.Settings.Realtime.Species = conf.SpeciesSettings{
+				Config: tt.speciesConfig,
+			}
+
+			threshold := p.getBaseConfidenceThreshold(tt.commonName, tt.scientificName)
+
+			assert.InDelta(t, tt.expected, float64(threshold), 0.001, tt.message)
+		})
+	}
+}

--- a/internal/analysis/processor/base_threshold_test.go
+++ b/internal/analysis/processor/base_threshold_test.go
@@ -1,0 +1,68 @@
+package processor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tphakala/birdnet-go/internal/conf"
+)
+
+func TestGetBaseConfidenceThreshold(t *testing.T) {
+	tests := []struct {
+		name           string
+		globalThresh   float64
+		speciesConfig  map[string]conf.SpeciesConfig
+		commonName     string
+		scientificName string
+		expected       float64
+		message        string
+	}{
+		{
+			name:         "zero threshold falls through to global",
+			globalThresh: 0.75,
+			speciesConfig: map[string]conf.SpeciesConfig{
+				"american robin": {Threshold: 0}, // actions-only, no custom threshold
+			},
+			commonName:     "American Robin",
+			scientificName: "Turdus migratorius",
+			expected:       0.75,
+			message:        "Species with threshold:0 should fall through to global threshold, not return 0.0",
+		},
+		{
+			name:         "explicit threshold used",
+			globalThresh: 0.75,
+			speciesConfig: map[string]conf.SpeciesConfig{
+				"american robin": {Threshold: 0.90},
+			},
+			commonName:     "American Robin",
+			scientificName: "Turdus migratorius",
+			expected:       0.90,
+			message:        "Species with explicit threshold should use that value",
+		},
+		{
+			name:           "not in config uses global",
+			globalThresh:   0.75,
+			speciesConfig:  map[string]conf.SpeciesConfig{},
+			commonName:     "Unknown Bird",
+			scientificName: "Unknownus birdus",
+			expected:       0.75,
+			message:        "Species not in config should use global threshold",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := newTestProcessor()
+			p.Settings.BirdNET.Threshold = tt.globalThresh
+			p.Settings.Realtime.Species = conf.SpeciesSettings{
+				Config: tt.speciesConfig,
+			}
+
+			// modelID selects the global fallback; a plain BirdNET id resolves to
+			// settings.BirdNET.Threshold (see modelGlobalConfidenceThreshold).
+			threshold := p.getBaseConfidenceThreshold(p.Settings, tt.commonName, tt.scientificName, "BirdNET_V2.4")
+
+			assert.InDelta(t, tt.expected, float64(threshold), 0.001, tt.message)
+		})
+	}
+}

--- a/internal/analysis/processor/dynamic_threshold.go
+++ b/internal/analysis/processor/dynamic_threshold.go
@@ -8,12 +8,28 @@ import (
 	"github.com/tphakala/birdnet-go/internal/logger"
 )
 
+// Threshold levels used throughout the dynamic threshold system.
+const (
+	thresholdLevelBase = 0 // No reduction, base threshold
+	thresholdLevel1    = 1 // 25% reduction
+	thresholdLevel2    = 2 // 50% reduction
+	thresholdLevel3    = 3 // 75% reduction (maximum)
+)
+
 // Threshold level multipliers define how much the base threshold is reduced at each level.
 // Level 1: 25% reduction, Level 2: 50% reduction, Level 3: 75% reduction (maximum)
 const (
-	thresholdLevel1Multiplier = 0.75 // First high-confidence detection: 75% of base
-	thresholdLevel2Multiplier = 0.50 // Second high-confidence detection: 50% of base
-	thresholdLevel3Multiplier = 0.25 // Third+ high-confidence detection: 25% of base (minimum)
+	thresholdLevel1Multiplier = 0.75 // Level 1: 75% of base
+	thresholdLevel2Multiplier = 0.50 // Level 2: 50% of base
+	thresholdLevel3Multiplier = 0.25 // Level 3: 25% of base (minimum)
+)
+
+// Minimum approved detections required to reach each threshold level.
+// Requires sustained evidence before lowering thresholds.
+const (
+	thresholdLevel1MinDetections = 2 // 2 approved detections for Level 1
+	thresholdLevel2MinDetections = 4 // 4 approved detections for Level 2
+	thresholdLevel3MinDetections = 6 // 6 approved detections for Level 3
 )
 
 // Threshold change reason constants for event recording
@@ -203,18 +219,22 @@ func (p *Processor) LearnFromApprovedDetection(speciesLowercase, scientificName 
 	dt.HighConfCount++
 	dt.LastLearnedAt = now
 
-	// Adjust the dynamic threshold based on the number of high-confidence detections
-	switch dt.HighConfCount {
-	case 1:
-		dt.Level = 1
-		dt.CurrentValue = float64(baseThreshold * thresholdLevel1Multiplier)
-	case 2:
-		dt.Level = 2
-		dt.CurrentValue = float64(baseThreshold * thresholdLevel2Multiplier)
-	default:
-		// Level 3 is the maximum reduction; any count >= 3 stays at this level
-		dt.Level = 3
+	// Adjust the dynamic threshold based on the number of high-confidence detections.
+	// Requires sustained evidence before lowering thresholds.
+	switch {
+	case dt.HighConfCount >= thresholdLevel3MinDetections:
+		dt.Level = thresholdLevel3
 		dt.CurrentValue = float64(baseThreshold * thresholdLevel3Multiplier)
+	case dt.HighConfCount >= thresholdLevel2MinDetections:
+		dt.Level = thresholdLevel2
+		dt.CurrentValue = float64(baseThreshold * thresholdLevel2Multiplier)
+	case dt.HighConfCount >= thresholdLevel1MinDetections:
+		dt.Level = thresholdLevel1
+		dt.CurrentValue = float64(baseThreshold * thresholdLevel1Multiplier)
+	default:
+		// Not enough evidence yet — stay at base threshold
+		dt.Level = thresholdLevelBase
+		dt.CurrentValue = float64(baseThreshold)
 	}
 
 	// Apply minimum threshold clamp

--- a/internal/analysis/processor/dynamic_threshold.go
+++ b/internal/analysis/processor/dynamic_threshold.go
@@ -9,12 +9,28 @@ import (
 	"github.com/tphakala/birdnet-go/internal/logger"
 )
 
+// Threshold levels used throughout the dynamic threshold system.
+const (
+	thresholdLevelBase = 0 // No reduction, base threshold
+	thresholdLevel1    = 1 // 25% reduction
+	thresholdLevel2    = 2 // 50% reduction
+	thresholdLevel3    = 3 // 75% reduction (maximum)
+)
+
 // Threshold level multipliers define how much the base threshold is reduced at each level.
 // Level 1: 25% reduction, Level 2: 50% reduction, Level 3: 75% reduction (maximum)
 const (
-	thresholdLevel1Multiplier = 0.75 // First high-confidence detection: 75% of base
-	thresholdLevel2Multiplier = 0.50 // Second high-confidence detection: 50% of base
-	thresholdLevel3Multiplier = 0.25 // Third+ high-confidence detection: 25% of base (minimum)
+	thresholdLevel1Multiplier = 0.75 // Level 1: 75% of base
+	thresholdLevel2Multiplier = 0.50 // Level 2: 50% of base
+	thresholdLevel3Multiplier = 0.25 // Level 3: 25% of base (minimum)
+)
+
+// Minimum approved detections required to reach each threshold level.
+// Requires sustained evidence before lowering thresholds.
+const (
+	thresholdLevel1MinDetections = 2 // 2 approved detections for Level 1
+	thresholdLevel2MinDetections = 4 // 4 approved detections for Level 2
+	thresholdLevel3MinDetections = 6 // 6 approved detections for Level 3
 )
 
 // Threshold change reason constants for event recording
@@ -262,15 +278,23 @@ func (p *Processor) LearnFromApprovedDetection(speciesLowercase, scientificName 
 	dt.LastLearnedAt = now
 	dt.LastTriggered = now // real trigger time, persisted instead of the flush time (#4195)
 
-	// Adjust the dynamic threshold based on the number of high-confidence detections
-	switch dt.HighConfCount {
-	case 1:
-		dt.Level = 1
-	case 2:
-		dt.Level = 2
+	// Adjust the dynamic threshold based on the number of high-confidence detections.
+	// Requires sustained evidence before lowering thresholds: a single loud call is
+	// not enough to start reducing this species' threshold.
+	//
+	// Only the LEVEL is set here. The applied value is derived at read time by
+	// effectiveDynamicThreshold(BaseThreshold, Level, min), so there is no absolute
+	// value to keep in sync.
+	switch {
+	case dt.HighConfCount >= thresholdLevel3MinDetections:
+		dt.Level = thresholdLevel3
+	case dt.HighConfCount >= thresholdLevel2MinDetections:
+		dt.Level = thresholdLevel2
+	case dt.HighConfCount >= thresholdLevel1MinDetections:
+		dt.Level = thresholdLevel1
 	default:
-		// Level 3 is the maximum reduction; any count >= 3 stays at this level
-		dt.Level = 3
+		// Not enough evidence yet — stay at the base threshold
+		dt.Level = thresholdLevelBase
 	}
 
 	newValue := effectiveDynamicThreshold(dt.BaseThreshold, dt.Level, minThreshold)

--- a/internal/analysis/processor/dynamic_threshold_test.go
+++ b/internal/analysis/processor/dynamic_threshold_test.go
@@ -26,7 +26,7 @@ func newTestProcessor() *Processor {
 				DynamicThreshold: conf.DynamicThresholdSettings{
 					Enabled:    true,
 					Trigger:    0.90,
-					Min:        0.20,
+					Min:        0.40,
 					ValidHours: 24,
 				},
 			},
@@ -134,33 +134,45 @@ func TestGetAdjustedThresholdResetsExpiredThreshold(t *testing.T) {
 // =============================================================================
 
 // TestLearnFromApprovedDetectionLevels verifies the three levels of dynamic threshold
-// adjustment when approved detections are spaced apart (beyond the learning cooldown)
+// adjustment require 2/4/6 approved detections spaced apart (beyond the learning cooldown)
 func TestLearnFromApprovedDetectionLevels(t *testing.T) {
 	p := newTestProcessor()
 
 	baseThreshold := float32(0.80)
 	p.addSpeciesToDynamicThresholds("test species", "Testus speciesus", baseThreshold)
 
-	// Level 1: First approved high-confidence detection (75%)
+	// Detection 1: Not enough for Level 1 yet (need 2)
 	p.LearnFromApprovedDetection("test species", "Testus speciesus", 0.95)
-	assert.Equal(t, 1, p.DynamicThresholds["test species"].Level, "Level should be 1 after first learning")
+	assert.Equal(t, 0, p.DynamicThresholds["test species"].Level, "Level should be 0 after 1st detection")
+	assert.InDelta(t, 0.80, p.DynamicThresholds["test species"].CurrentValue, 0.001, "Value should remain at base")
+
+	// Detection 2: Now reaches Level 1 (75% of base)
+	p.DynamicThresholds["test species"].LastLearnedAt = time.Now().Add(-15 * time.Second)
+	p.LearnFromApprovedDetection("test species", "Testus speciesus", 0.95)
+	assert.Equal(t, 1, p.DynamicThresholds["test species"].Level, "Level should be 1 after 2nd detection")
 	assert.InDelta(t, 0.60, p.DynamicThresholds["test species"].CurrentValue, 0.001, "Value should be 75% of base")
 
-	// Simulate time passing beyond the learning cooldown
+	// Detection 3: Still Level 1 (need 4 for Level 2)
 	p.DynamicThresholds["test species"].LastLearnedAt = time.Now().Add(-15 * time.Second)
-
-	// Level 2: Second approved high-confidence detection (50%)
 	p.LearnFromApprovedDetection("test species", "Testus speciesus", 0.95)
-	assert.Equal(t, 2, p.DynamicThresholds["test species"].Level, "Level should be 2 after second learning")
+	assert.Equal(t, 1, p.DynamicThresholds["test species"].Level, "Level should still be 1 after 3rd detection")
+
+	// Detection 4: Now reaches Level 2 (50% of base)
+	p.DynamicThresholds["test species"].LastLearnedAt = time.Now().Add(-15 * time.Second)
+	p.LearnFromApprovedDetection("test species", "Testus speciesus", 0.95)
+	assert.Equal(t, 2, p.DynamicThresholds["test species"].Level, "Level should be 2 after 4th detection")
 	assert.InDelta(t, 0.40, p.DynamicThresholds["test species"].CurrentValue, 0.001, "Value should be 50% of base")
 
-	// Simulate more time passing
+	// Detection 5: Still Level 2 (need 6 for Level 3)
 	p.DynamicThresholds["test species"].LastLearnedAt = time.Now().Add(-15 * time.Second)
-
-	// Level 3: Third approved high-confidence detection (25%)
 	p.LearnFromApprovedDetection("test species", "Testus speciesus", 0.95)
-	assert.Equal(t, 3, p.DynamicThresholds["test species"].Level, "Level should be 3 after third learning")
-	assert.InDelta(t, 0.20, p.DynamicThresholds["test species"].CurrentValue, 0.001, "Value should be 25% of base")
+	assert.Equal(t, 2, p.DynamicThresholds["test species"].Level, "Level should still be 2 after 5th detection")
+
+	// Detection 6: Now reaches Level 3 (25% of base, clamped to min 0.40)
+	p.DynamicThresholds["test species"].LastLearnedAt = time.Now().Add(-15 * time.Second)
+	p.LearnFromApprovedDetection("test species", "Testus speciesus", 0.95)
+	assert.Equal(t, 3, p.DynamicThresholds["test species"].Level, "Level should be 3 after 6th detection")
+	assert.InDelta(t, 0.40, p.DynamicThresholds["test species"].CurrentValue, 0.001, "Value should be clamped to min 0.40")
 }
 
 // TestLearnFromApprovedDetectionCooldown verifies that rapid approved detections
@@ -171,19 +183,19 @@ func TestLearnFromApprovedDetectionCooldown(t *testing.T) {
 	baseThreshold := float32(0.80)
 	p.addSpeciesToDynamicThresholds("test species", "Testus speciesus", baseThreshold)
 
-	// First approved detection triggers Level 1
+	// First approved detection — not enough for Level 1 yet (need 2)
 	p.LearnFromApprovedDetection("test species", "Testus speciesus", 0.95)
-	assert.Equal(t, 1, p.DynamicThresholds["test species"].Level, "First approval should trigger Level 1")
+	assert.Equal(t, 0, p.DynamicThresholds["test species"].Level, "First approval not enough for Level 1 (need 2)")
 	assert.Equal(t, 1, p.DynamicThresholds["test species"].HighConfCount, "HighConfCount should be 1")
 
-	// Immediate second approval should NOT trigger Level 2 (cooldown not expired)
+	// Immediate second approval should NOT increment (cooldown not expired)
 	p.LearnFromApprovedDetection("test species", "Testus speciesus", 0.95)
-	assert.Equal(t, 1, p.DynamicThresholds["test species"].Level, "Level should stay at 1 during cooldown")
+	assert.Equal(t, 0, p.DynamicThresholds["test species"].Level, "Level should stay at 0 during cooldown")
 	assert.Equal(t, 1, p.DynamicThresholds["test species"].HighConfCount, "HighConfCount should stay at 1")
 
-	// Immediate third approval should also NOT trigger Level 3
+	// Immediate third approval should also NOT increment
 	p.LearnFromApprovedDetection("test species", "Testus speciesus", 0.95)
-	assert.Equal(t, 1, p.DynamicThresholds["test species"].Level, "Level should still be 1")
+	assert.Equal(t, 0, p.DynamicThresholds["test species"].Level, "Level should still be 0")
 	assert.Equal(t, 1, p.DynamicThresholds["test species"].HighConfCount, "HighConfCount should still be 1")
 }
 
@@ -233,7 +245,8 @@ func TestLearnFromApprovedDetectionMinimumFloor(t *testing.T) {
 	p.addSpeciesToDynamicThresholds("test species", "Testus speciesus", baseThreshold)
 
 	// Trigger Level 3 (25% of 0.80 = 0.20, which is below min of 0.30)
-	for i := range 3 {
+	// Now requires 6 approved detections for Level 3
+	for i := range 6 {
 		if i > 0 {
 			// Simulate time passing beyond cooldown for subsequent detections
 			p.DynamicThresholds["test species"].LastLearnedAt = time.Now().Add(-15 * time.Second)
@@ -253,9 +266,10 @@ func TestLearnFromApprovedDetectionInitializesIfMissing(t *testing.T) {
 	// Don't call addSpeciesToDynamicThresholds - let LearnFromApprovedDetection create it
 	p.LearnFromApprovedDetection("new species", "Newus speciesus", 0.95)
 
-	// Should have created the entry and learned
+	// Should have created the entry and counted detection (but not yet at Level 1)
 	assert.NotNil(t, p.DynamicThresholds["new species"], "Should create threshold entry")
-	assert.Equal(t, 1, p.DynamicThresholds["new species"].Level, "Level should be 1")
+	assert.Equal(t, 0, p.DynamicThresholds["new species"].Level, "Level should be 0 (need 2 for Level 1)")
+	assert.Equal(t, 1, p.DynamicThresholds["new species"].HighConfCount, "HighConfCount should be 1")
 	assert.Equal(t, "Newus speciesus", p.DynamicThresholds["new species"].ScientificName, "ScientificName should be set")
 }
 
@@ -335,10 +349,11 @@ func TestApprovedDetectionTriggersLearning(t *testing.T) {
 	adjusted := p.getAdjustedConfidenceThreshold("test species", baseThreshold, false)
 	assert.InDelta(t, 0.80, adjusted, 0.001, "Threshold at base during filtering")
 
-	// Step 2: Detection is approved
+	// Step 2: Detection is approved — 1st detection, not enough for Level 1
 	p.LearnFromApprovedDetection("test species", "Testus speciesus", 0.95)
 
-	// Final state: threshold should now be at Level 1
-	assert.Equal(t, 1, p.DynamicThresholds["test species"].Level, "Level should be 1 after approval")
-	assert.InDelta(t, 0.60, p.DynamicThresholds["test species"].CurrentValue, 0.001, "Value should be 75% of base")
+	// Final state: threshold should still be at base (need 2 detections for Level 1)
+	assert.Equal(t, 0, p.DynamicThresholds["test species"].Level, "Level should be 0 after 1st approval (need 2)")
+	assert.InDelta(t, 0.80, p.DynamicThresholds["test species"].CurrentValue, 0.001, "Value should remain at base")
+	assert.Equal(t, 1, p.DynamicThresholds["test species"].HighConfCount, "HighConfCount should be 1")
 }

--- a/internal/analysis/processor/dynamic_threshold_test.go
+++ b/internal/analysis/processor/dynamic_threshold_test.go
@@ -139,34 +139,47 @@ func TestGetAdjustedThresholdResetsExpiredThreshold(t *testing.T) {
 // =============================================================================
 
 // TestLearnFromApprovedDetectionLevels verifies the three levels of dynamic threshold
-// adjustment when approved detections are spaced apart (beyond the learning cooldown)
+// adjustment require 2/4/6 approved detections spaced apart (beyond the learning cooldown)
 func TestLearnFromApprovedDetectionLevels(t *testing.T) {
 	p := newTestProcessor()
 
 	baseThreshold := float32(0.80)
 	p.addSpeciesToDynamicThresholds("test species", "Testus speciesus", baseThreshold)
 
-	// Level 1: First approved high-confidence detection (75% of base)
+	// Detection 1: not enough for Level 1 yet (2 are required)
 	p.LearnFromApprovedDetection("test species", "Testus speciesus", 0.95, baseThreshold)
-	assert.Equal(t, 1, p.DynamicThresholds["test species"].Level, "Level should be 1 after first learning")
+	assert.Equal(t, thresholdLevelBase, p.DynamicThresholds["test species"].Level, "Level should be 0 after 1st detection")
+	assert.InDelta(t, 0.80, p.getAdjustedConfidenceThreshold("test species", baseThreshold, false), 0.001,
+		"Applied value should remain at base")
+
+	// Detection 2: now reaches Level 1 (75% of base)
+	p.DynamicThresholds["test species"].LastLearnedAt = time.Now().Add(-15 * time.Second)
+	p.LearnFromApprovedDetection("test species", "Testus speciesus", 0.95, baseThreshold)
+	assert.Equal(t, thresholdLevel1, p.DynamicThresholds["test species"].Level, "Level should be 1 after 2nd detection")
 	assert.InDelta(t, 0.60, p.getAdjustedConfidenceThreshold("test species", baseThreshold, false), 0.001,
 		"Applied value should be 75% of base")
 
-	// Simulate time passing beyond the learning cooldown
+	// Detection 3: Still Level 1 (need 4 for Level 2)
 	p.DynamicThresholds["test species"].LastLearnedAt = time.Now().Add(-15 * time.Second)
-
-	// Level 2: Second approved high-confidence detection (50% of base)
 	p.LearnFromApprovedDetection("test species", "Testus speciesus", 0.95, baseThreshold)
-	assert.Equal(t, 2, p.DynamicThresholds["test species"].Level, "Level should be 2 after second learning")
+	assert.Equal(t, thresholdLevel1, p.DynamicThresholds["test species"].Level, "Level should still be 1 after 3rd detection")
+
+	// Detection 4: now reaches Level 2 (50% of base)
+	p.DynamicThresholds["test species"].LastLearnedAt = time.Now().Add(-15 * time.Second)
+	p.LearnFromApprovedDetection("test species", "Testus speciesus", 0.95, baseThreshold)
+	assert.Equal(t, thresholdLevel2, p.DynamicThresholds["test species"].Level, "Level should be 2 after 4th detection")
 	assert.InDelta(t, 0.40, p.getAdjustedConfidenceThreshold("test species", baseThreshold, false), 0.001,
 		"Applied value should be 50% of base")
 
-	// Simulate more time passing
+	// Detection 5: Still Level 2 (need 6 for Level 3)
 	p.DynamicThresholds["test species"].LastLearnedAt = time.Now().Add(-15 * time.Second)
-
-	// Level 3: Third approved high-confidence detection (25% of base)
 	p.LearnFromApprovedDetection("test species", "Testus speciesus", 0.95, baseThreshold)
-	assert.Equal(t, 3, p.DynamicThresholds["test species"].Level, "Level should be 3 after third learning")
+	assert.Equal(t, thresholdLevel2, p.DynamicThresholds["test species"].Level, "Level should still be 2 after 5th detection")
+
+	// Detection 6: now reaches Level 3 (25% of base)
+	p.DynamicThresholds["test species"].LastLearnedAt = time.Now().Add(-15 * time.Second)
+	p.LearnFromApprovedDetection("test species", "Testus speciesus", 0.95, baseThreshold)
+	assert.Equal(t, thresholdLevel3, p.DynamicThresholds["test species"].Level, "Level should be 3 after 6th detection")
 	assert.InDelta(t, 0.20, p.getAdjustedConfidenceThreshold("test species", baseThreshold, false), 0.001,
 		"Applied value should be 25% of base")
 }
@@ -183,19 +196,19 @@ func TestLearnFromApprovedDetectionCooldown(t *testing.T) {
 	baseThreshold := float32(0.80)
 	p.addSpeciesToDynamicThresholds("test species", "Testus speciesus", baseThreshold)
 
-	// First approved detection triggers Level 1
+	// First approved detection — not enough for Level 1 yet (2 are required)
 	p.LearnFromApprovedDetection("test species", "Testus speciesus", 0.95, baseThreshold)
-	assert.Equal(t, 1, p.DynamicThresholds["test species"].Level, "First approval should trigger Level 1")
+	assert.Equal(t, thresholdLevelBase, p.DynamicThresholds["test species"].Level, "First approval is not enough for Level 1 (need 2)")
 	assert.Equal(t, 1, p.DynamicThresholds["test species"].HighConfCount, "HighConfCount should be 1")
 
-	// Immediate second approval should NOT trigger Level 2 (cooldown not expired)
+	// Immediate second approval must NOT increment (cooldown not expired)
 	p.LearnFromApprovedDetection("test species", "Testus speciesus", 0.95, baseThreshold)
-	assert.Equal(t, 1, p.DynamicThresholds["test species"].Level, "Level should stay at 1 during cooldown")
+	assert.Equal(t, thresholdLevelBase, p.DynamicThresholds["test species"].Level, "Level should stay at 0 during cooldown")
 	assert.Equal(t, 1, p.DynamicThresholds["test species"].HighConfCount, "HighConfCount should stay at 1")
 
-	// Immediate third approval should also NOT trigger Level 3
+	// Immediate third approval must NOT increment either
 	p.LearnFromApprovedDetection("test species", "Testus speciesus", 0.95, baseThreshold)
-	assert.Equal(t, 1, p.DynamicThresholds["test species"].Level, "Level should still be 1")
+	assert.Equal(t, thresholdLevelBase, p.DynamicThresholds["test species"].Level, "Level should still be 0")
 	assert.Equal(t, 1, p.DynamicThresholds["test species"].HighConfCount, "HighConfCount should still be 1")
 }
 
@@ -246,7 +259,8 @@ func TestLearnFromApprovedDetectionMinimumFloor(t *testing.T) {
 	p.addSpeciesToDynamicThresholds("test species", "Testus speciesus", baseThreshold)
 
 	// Trigger Level 3 (25% of 0.80 = 0.20, which is below min of 0.30)
-	for i := range 3 {
+	// Now requires 6 approved detections for Level 3
+	for i := range 6 {
 		if i > 0 {
 			// Simulate time passing beyond cooldown for subsequent detections
 			p.DynamicThresholds["test species"].LastLearnedAt = time.Now().Add(-15 * time.Second)
@@ -267,9 +281,10 @@ func TestLearnFromApprovedDetectionInitializesIfMissing(t *testing.T) {
 	// Don't call addSpeciesToDynamicThresholds - let LearnFromApprovedDetection create it
 	p.LearnFromApprovedDetection("new species", "Newus speciesus", 0.95, 0.80)
 
-	// Should have created the entry and learned
+	// Should have created the entry and counted detection (but not yet at Level 1)
 	assert.NotNil(t, p.DynamicThresholds["new species"], "Should create threshold entry")
-	assert.Equal(t, 1, p.DynamicThresholds["new species"].Level, "Level should be 1")
+	assert.Equal(t, 0, p.DynamicThresholds["new species"].Level, "Level should be 0 (need 2 for Level 1)")
+	assert.Equal(t, 1, p.DynamicThresholds["new species"].HighConfCount, "HighConfCount should be 1")
 	assert.Equal(t, "Newus speciesus", p.DynamicThresholds["new species"].ScientificName, "ScientificName should be set")
 }
 
@@ -349,13 +364,14 @@ func TestApprovedDetectionTriggersLearning(t *testing.T) {
 	adjusted := p.getAdjustedConfidenceThreshold("test species", baseThreshold, false)
 	assert.InDelta(t, 0.80, adjusted, 0.001, "Threshold at base during filtering")
 
-	// Step 2: Detection is approved
+	// Step 2: Detection is approved — the 1st, which is not enough for Level 1
 	p.LearnFromApprovedDetection("test species", "Testus speciesus", 0.95, baseThreshold)
 
-	// Final state: threshold should now be at Level 1
-	assert.Equal(t, 1, p.DynamicThresholds["test species"].Level, "Level should be 1 after approval")
-	assert.InDelta(t, 0.60, p.getAdjustedConfidenceThreshold("test species", baseThreshold, false), 0.001,
-		"Applied value should be 75% of base")
+	// Final state: still at base. Sustained evidence is required before reducing.
+	assert.Equal(t, thresholdLevelBase, p.DynamicThresholds["test species"].Level, "Level should be 0 after 1st approval (need 2)")
+	assert.InDelta(t, 0.80, p.getAdjustedConfidenceThreshold("test species", baseThreshold, false), 0.001,
+		"Applied value should remain at base")
+	assert.Equal(t, 1, p.DynamicThresholds["test species"].HighConfCount, "HighConfCount should be 1")
 }
 
 // =============================================================================
@@ -373,7 +389,10 @@ func TestDynamicThresholds_SharedAcrossModels(t *testing.T) {
 	const birdnetBase = float32(0.80)
 	const perchBase = float32(0.40)
 
-	// A single detection approved by the BirdNET model.
+	// Two detections approved by the BirdNET model. Level 1 now requires
+	// thresholdLevel1MinDetections approvals, spaced beyond the learning cooldown.
+	p.LearnFromApprovedDetection(species, "Turdus migratorius", 0.95, birdnetBase)
+	p.DynamicThresholds[species].LastLearnedAt = time.Now().Add(-15 * time.Second)
 	p.LearnFromApprovedDetection(species, "Turdus migratorius", 0.95, birdnetBase)
 
 	// Exactly one entry exists for the species (no per-model duplication).
@@ -382,7 +401,7 @@ func TestDynamicThresholds_SharedAcrossModels(t *testing.T) {
 	if !assert.NotNil(t, dt, "shared entry should exist") {
 		return
 	}
-	assert.Equal(t, 1, dt.Level, "one approval advances the shared level to 1")
+	assert.Equal(t, thresholdLevel1, dt.Level, "approvals advance the shared level to 1")
 
 	// The shared level (1 -> 0.75 multiplier) applies against each model's own base.
 	assert.InDelta(t, 0.60, p.getAdjustedConfidenceThreshold(species, birdnetBase, false), 0.001,
@@ -400,7 +419,8 @@ func TestLearnFromApprovedDetectionRecordsBase(t *testing.T) {
 
 	dt := p.DynamicThresholds["eurasian wren"]
 	if assert.NotNil(t, dt, "entry should be created") {
-		assert.Equal(t, 1, dt.Level, "first learning should reach level 1")
+		assert.Equal(t, thresholdLevelBase, dt.Level,
+			"one approval stays at base; level 1 needs thresholdLevel1MinDetections")
 		assert.InDelta(t, 0.40, dt.BaseThreshold, 0.001, "recorded base should be the caller's model base")
 	}
 }

--- a/internal/analysis/processor/processor.go
+++ b/internal/analysis/processor/processor.go
@@ -862,8 +862,9 @@ func (p *Processor) handleHumanDetection(item birdnet.Results, speciesLowercase 
 // getBaseConfidenceThreshold retrieves the confidence threshold for a species, using custom or global thresholds.
 // It supports lookup by both common name and scientific name for consistency with include/exclude matching.
 func (p *Processor) getBaseConfidenceThreshold(commonName, scientificName string) float32 {
-	// Check if species has a custom threshold using both common and scientific name lookup
-	if config, exists := lookupSpeciesConfig(p.Settings.Realtime.Species.Config, commonName, scientificName); exists {
+	// Check if species has a custom threshold using both common and scientific name lookup.
+	// Species with threshold: 0 (actions-only config) fall through to global threshold.
+	if config, exists := lookupSpeciesConfig(p.Settings.Realtime.Species.Config, commonName, scientificName); exists && config.Threshold > 0 {
 		if p.Settings.Debug {
 			GetLogger().Debug("using custom confidence threshold",
 				logger.String("commonName", commonName),

--- a/internal/analysis/processor/processor.go
+++ b/internal/analysis/processor/processor.go
@@ -1351,8 +1351,9 @@ func (p *Processor) handleHumanDetection(settings *conf.Settings, item classifie
 // The modelID parameter selects which global threshold to use when no per-species config exists;
 // see modelGlobalConfidenceThreshold for the per-model selection rules.
 func (p *Processor) getBaseConfidenceThreshold(settings *conf.Settings, commonName, scientificName, modelID string) float32 {
-	// Check if species has a custom threshold using both common and scientific name lookup
-	if config, exists := lookupSpeciesConfig(settings.Realtime.Species.Config, commonName, scientificName); exists {
+	// Check if species has a custom threshold using both common and scientific name lookup.
+	// Species with threshold: 0 (actions-only config) fall through to the global threshold.
+	if config, exists := lookupSpeciesConfig(settings.Realtime.Species.Config, commonName, scientificName); exists && config.Threshold > 0 {
 		if settings.Debug {
 			GetLogger().Debug("using custom confidence threshold",
 				logger.String("commonName", commonName),

--- a/internal/conf/config.yaml
+++ b/internal/conf/config.yaml
@@ -158,7 +158,7 @@ birdnet:
   longitude: 00.000       # longitude of recording location for prediction filtering
   rangefilter:
       model: latest       # model to use for range filter: "latest" or "legacy" for previous model
-      threshold: 0.01     # rangefilter species occurrence threshold
+      threshold: 0.03     # rangefilter species occurrence threshold
   modelpath: ""           # path to external model file (empty for embedded)
   labelpath: ""           # path to external label file (empty for embedded)
   usexnnpack: true        # true to use XNNPACK delegate for inference acceleration
@@ -208,7 +208,7 @@ realtime:
   dynamicthreshold:
     enabled: true         # true to enable dynamic confidence threshold
     trigger: 0.90         # dynamic threshold is activated on detections at this confidence level
-    min: 0.20             # dynamic threshold will not go lower than this
+    min: 0.40             # dynamic threshold will not go lower than this
     validhours: 24        # number of hours to consider for dynamic confidence
 
   rtsp:

--- a/internal/conf/config.yaml
+++ b/internal/conf/config.yaml
@@ -158,7 +158,7 @@ birdnet:
   longitude: 00.000       # longitude of recording location for prediction filtering
   rangefilter:
       model: latest       # model to use for range filter: "latest" or "legacy" for previous model
-      threshold: 0.01     # rangefilter species occurrence threshold
+      threshold: 0.03     # rangefilter species occurrence threshold
   modelpath: ""           # path to external model file (empty for embedded)
   labelpath: ""           # path to external label file (empty for embedded)
   modelregion: auto       # regional model preference: auto (from coordinates), global (all species), or a region slug (e.g. iberia)
@@ -231,7 +231,7 @@ realtime:
   dynamicthreshold:
     enabled: true         # true to enable dynamic confidence threshold
     trigger: 0.90         # dynamic threshold is activated on detections at this confidence level
-    min: 0.20             # dynamic threshold will not go lower than this
+    min: 0.40             # dynamic threshold will not go lower than this
     validhours: 24        # number of hours to consider for dynamic confidence
 
   rtsp:

--- a/internal/conf/defaults.go
+++ b/internal/conf/defaults.go
@@ -76,7 +76,7 @@ func setDefaultConfig() {
 	// Range filter configuration
 	viper.SetDefault("birdnet.rangefilter.debug", false)
 	viper.SetDefault("birdnet.rangefilter.model", "latest")
-	viper.SetDefault("birdnet.rangefilter.threshold", 0.01)
+	viper.SetDefault("birdnet.rangefilter.threshold", 0.03)
 
 	// Realtime configuration
 	viper.SetDefault("realtime.interval", 15)
@@ -155,7 +155,7 @@ func setDefaultConfig() {
 	viper.SetDefault("realtime.dynamicthreshold.enabled", true)
 	viper.SetDefault("realtime.dynamicthreshold.debug", false)
 	viper.SetDefault("realtime.dynamicthreshold.trigger", 0.90)
-	viper.SetDefault("realtime.dynamicthreshold.min", 0.20)
+	viper.SetDefault("realtime.dynamicthreshold.min", 0.40)
 	viper.SetDefault("realtime.dynamicthreshold.validhours", 24)
 
 	// Log deduplication configuration
@@ -163,10 +163,10 @@ func setDefaultConfig() {
 	viper.SetDefault("realtime.logdeduplication.healthcheckintervalseconds", 60)
 
 	// False positive filter configuration
-	// Level 0 = Off (no filtering, backward compatible default)
-	// Level 1 = Lenient, Level 2 = Moderate, Level 3 = Balanced (original behavior)
+	// Level 0 = Off, Level 1 = Lenient, Level 2 = Moderate (default)
+	// Level 3 = Balanced (original behavior)
 	// Level 4 = Strict (RPi 4+ required), Level 5 = Maximum (RPi 4+ required)
-	viper.SetDefault("realtime.falsepositivefilter.level", 0)
+	viper.SetDefault("realtime.falsepositivefilter.level", 2)
 
 	// Log configuration
 	viper.SetDefault("realtime.log.enabled", false)

--- a/internal/conf/defaults.go
+++ b/internal/conf/defaults.go
@@ -89,7 +89,7 @@ func setDefaultConfig() {
 	// Range filter configuration
 	viper.SetDefault("birdnet.rangefilter.debug", false)
 	viper.SetDefault("birdnet.rangefilter.model", RangeFilterModelLatest)
-	viper.SetDefault("birdnet.rangefilter.threshold", 0.01)
+	viper.SetDefault("birdnet.rangefilter.threshold", 0.03)
 
 	// Perch model configuration.
 	// OverrideThreshold defaults false so Perch follows birdnet.threshold until the
@@ -206,7 +206,7 @@ func setDefaultConfig() {
 	viper.SetDefault("realtime.dynamicthreshold.enabled", true)
 	viper.SetDefault("realtime.dynamicthreshold.debug", false)
 	viper.SetDefault("realtime.dynamicthreshold.trigger", 0.90)
-	viper.SetDefault("realtime.dynamicthreshold.min", 0.20)
+	viper.SetDefault("realtime.dynamicthreshold.min", 0.40)
 	viper.SetDefault("realtime.dynamicthreshold.validhours", DefaultDynamicThresholdValidHours)
 
 	// Log deduplication configuration
@@ -214,10 +214,10 @@ func setDefaultConfig() {
 	viper.SetDefault("realtime.logdeduplication.healthcheckintervalseconds", 60)
 
 	// False positive filter configuration
-	// Level 0 = Off (no filtering, backward compatible default)
-	// Level 1 = Lenient, Level 2 = Moderate, Level 3 = Balanced (original behavior)
+	// Level 0 = Off, Level 1 = Lenient, Level 2 = Moderate (default)
+	// Level 3 = Balanced (original behavior)
 	// Level 4 = Strict (RPi 4+ required), Level 5 = Maximum (RPi 4+ required)
-	viper.SetDefault("realtime.falsepositivefilter.level", 0)
+	viper.SetDefault("realtime.falsepositivefilter.level", 2)
 
 	// Log configuration
 	viper.SetDefault("realtime.log.enabled", false)


### PR DESCRIPTION
## Summary

- **Raise dynamic threshold minimum** from 0.20 to 0.40 — prevents near-random detections at lowest threshold level
- **Raise range filter threshold** from 0.01 to 0.03 — removes species with <3% occurrence probability
- **Slow dynamic threshold escalation** from 1/2/3 to 2/4/6 detections per level — prevents 3 lucky hits from maxing out reduction
- **Fix species config zero-threshold bug** — species with `threshold: 0` (actions-only) now fall through to global threshold instead of accepting everything
- **Enable false positive filter** at level 2 (Moderate) by default — requires 3 confirmations in a 6-second window

All changes are to default values only — existing user configs are unaffected. The escalation logic and zero-threshold bug fix are code changes that improve behavior for all users.

## Test plan

- [x] All dynamic threshold tests updated and passing with `-race` flag
- [x] New `base_threshold_test.go` with 3 tests covering zero-threshold bug
- [x] Full processor test suite passing
- [x] Conf package tests passing
- [ ] CI linter validation
- [ ] Manual testing on RPi 4 with real audio

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated threshold documentation and examples with new defaults, clarified range-filter and CLI terminology, and added guidance for per-species overrides.

* **Changes**
  * Raised the default range-filter threshold to 0.03.
  * Raised the dynamic-threshold minimum to 0.40, with more detections required for progression and cooldowns between adjustments.
  * Set the default false-positive filter level to Moderate.
  * Per-species thresholds set to 0 now use the global threshold.

* **Tests**
  * Added and updated coverage for threshold fallback and dynamic-threshold progression.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->