### PR TITLE
fix: extract scientific name from concatenated prediction labels in v2 schema

### DIFF
--- a/internal/datastore/v2only/extract_scientific_name_test.go
+++ b/internal/datastore/v2only/extract_scientific_name_test.go
@@ -1,0 +1,48 @@
+package v2only
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractScientificName(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "concatenated scientific and common name",
+			input:    "Picus viridis_vihertikka",
+			expected: "Picus viridis",
+		},
+		{
+			name:     "concatenated with species code",
+			input:    "Parus major_Great Tit_gretit1",
+			expected: "Parus major",
+		},
+		{
+			name:     "scientific name only",
+			input:    "Turdus merula",
+			expected: "Turdus merula",
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "non-species label",
+			input:    "noise",
+			expected: "noise",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := extractScientificName(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Fix bug where `Results.Species` concatenated strings (e.g., `"Picus viridis_vihertikka"`) were stored as `Label.ScientificName` in the v2 schema, causing imageprovider cache lookups to fail
- Add `extractScientificName()` helper to split the legacy `"ScientificName_CommonName"` format before creating/looking up labels for prediction results
- Add unit tests for the new helper function

## Root cause

`AdditionalResultsToDatastoreResults` in `detection_repository.go` produces concatenated `"ScientificName_CommonName_Code"` strings in `Results.Species` for the legacy v1 `notes` table. When the v2only datastore's `Save` method processed these results, it passed the concatenated string directly to `BatchGetOrCreate`, which stored it verbatim as the label's `ScientificName`.

The imageprovider then loaded these concatenated names from the labels table and tried to look up images — AviCommons and other providers couldn't find matches because they index by pure scientific name only (e.g., `"Picus viridis"`, not `"Picus viridis_vihertikka"`).

Primary detections were unaffected because `note.ScientificName` is already a pure scientific name. Only secondary predictions (via `Results.Species`) had the issue.

## Test plan

- [x] `go build ./internal/datastore/v2only/...` passes
- [x] `go test ./internal/datastore/v2only/...` — 36/36 tests pass
- [x] `golangci-lint run ./internal/datastore/v2only/...` — 0 issues
- [ ] Deploy and verify imageprovider logs show pure scientific names during cache refresh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced species name extraction and resolution logic in the data save process to correctly parse legacy concatenated species data formats, ensuring accurate scientific name lookups and proper batch label operations.

* **Tests**
  * Added comprehensive unit tests validating species name extraction across concatenated formats, species codes, standalone names, empty inputs, and non-species labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->