### PR TITLE
fix: use fmt.Fprintf instead of WriteString(fmt.Sprintf(...))

### DIFF
--- a/internal/api/v2/range.go
+++ b/internal/api/v2/range.go
@@ -536,10 +536,10 @@ func (c *Controller) generateSpeciesCSV(species []RangeFilterSpecies, location L
 
 	// Write metadata headers as comments (not part of CSV data)
 	buf.WriteString("# BirdNET-Go Range Filter Species Export\n")
-	buf.WriteString(fmt.Sprintf("# Generated: %s\n", time.Now().Format(time.RFC3339)))
-	buf.WriteString(fmt.Sprintf("# Location: %.6f, %.6f\n", location.Latitude, location.Longitude))
-	buf.WriteString(fmt.Sprintf("# Threshold: %.2f\n", threshold))
-	buf.WriteString(fmt.Sprintf("# Total Species: %d\n", len(species)))
+	fmt.Fprintf(&buf, "# Generated: %s\n", time.Now().Format(time.RFC3339))
+	fmt.Fprintf(&buf, "# Location: %.6f, %.6f\n", location.Latitude, location.Longitude)
+	fmt.Fprintf(&buf, "# Threshold: %.2f\n", threshold)
+	fmt.Fprintf(&buf, "# Total Species: %d\n", len(species))
 	buf.WriteString("#\n")
 
 	// Create CSV writer

--- a/internal/birdnet/range_filter.go
+++ b/internal/birdnet/range_filter.go
@@ -62,9 +62,9 @@ func BuildRangeFilter(bn *BirdNET) error {
 		// Debug: Write included species to file
 		debugFile := "debug_included_species.txt"
 		var content strings.Builder
-		content.WriteString(fmt.Sprintf("Updated at: %s\nSpecies count: %d\n\nSpecies list:\n",
+		fmt.Fprintf(&content, "Updated at: %s\nSpecies count: %d\n\nSpecies list:\n",
 			time.Now().Format(time.DateTime),
-			len(includedSpecies)))
+			len(includedSpecies))
 		for _, species := range includedSpecies {
 			content.WriteString(species + "\n")
 		}

--- a/internal/myaudio/ffmpeg_error_context.go
+++ b/internal/myaudio/ffmpeg_error_context.go
@@ -719,7 +719,7 @@ func (ctx *ErrorContext) FormatForConsole() string {
 	if len(ctx.TroubleShooting) > 0 {
 		sb.WriteString("\n   Troubleshooting steps:\n")
 		for _, step := range ctx.TroubleShooting {
-			sb.WriteString(fmt.Sprintf("   • %s\n", step))
+			fmt.Fprintf(&sb, "   • %s\n", step)
 		}
 	}
 

--- a/internal/notification/worker.go
+++ b/internal/notification/worker.go
@@ -394,13 +394,13 @@ func (w *NotificationWorker) processEventGroup(key eventKey, groupEvents []event
 // buildAggregatedMessage builds an aggregated message from multiple events.
 func (w *NotificationWorker) buildAggregatedMessage(key eventKey, groupEvents []events.ErrorEvent) string {
 	var messageBuilder strings.Builder
-	messageBuilder.WriteString(fmt.Sprintf("Multiple %s errors in %s:\n", key.category, key.component))
+	fmt.Fprintf(&messageBuilder, "Multiple %s errors in %s:\n", key.category, key.component)
 
 	uniqueMessages := make(map[string]bool)
 	for _, event := range groupEvents {
 		msg := event.GetMessage()
 		if len(uniqueMessages) >= DefaultMaxSummaryMessages {
-			messageBuilder.WriteString(fmt.Sprintf("\n... and %d more errors", len(groupEvents)-len(uniqueMessages)))
+			fmt.Fprintf(&messageBuilder, "\n... and %d more errors", len(groupEvents)-len(uniqueMessages))
 			break
 		}
 		if !uniqueMessages[msg] {

--- a/internal/privacy/privacy_bench_test.go
+++ b/internal/privacy/privacy_bench_test.go
@@ -550,8 +550,8 @@ func BenchmarkStressTest(b *testing.B) {
 	// Generate a large message with many instances of sensitive data
 	var builder strings.Builder
 	for i := range 100 {
-		builder.WriteString(fmt.Sprintf("Entry %d: IP=%d.%d.%d.%d, Email=user%d@example.com, UUID=%08x-0000-0000-0000-000000000000\n",
-			i, i%256, (i+1)%256, (i+2)%256, (i+3)%256, i, i))
+		fmt.Fprintf(&builder, "Entry %d: IP=%d.%d.%d.%d, Email=user%d@example.com, UUID=%08x-0000-0000-0000-000000000000\n",
+			i, i%256, (i+1)%256, (i+2)%256, (i+3)%256, i, i)
 	}
 	largeMessage := builder.String()
 


### PR DESCRIPTION
## Summary

- Replace `buf.WriteString(fmt.Sprintf(...))` with `fmt.Fprintf(&buf, ...)` across 5 files to fix 9 staticcheck QF1012 warnings
- Avoids unnecessary intermediate string allocation by writing formatted output directly to the builder

## Files changed

- `internal/api/v2/range.go` (4 fixes)
- `internal/birdnet/range_filter.go` (1 fix)
- `internal/myaudio/ffmpeg_error_context.go` (1 fix)
- `internal/notification/worker.go` (2 fixes)
- `internal/privacy/privacy_bench_test.go` (1 fix)

## Test plan

- [x] `golangci-lint run` passes on all affected packages with 0 issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Internal performance optimizations to reduce memory allocations during string formatting operations across multiple modules. These maintenance improvements enhance system efficiency without affecting user-facing features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->