### PR TITLE
refactor(ui): replace DaisyUI-like classes with native Tailwind v4 in SelectDropdown

### DIFF
--- a/frontend/src/lib/desktop/components/forms/SelectDropdown.svelte
+++ b/frontend/src/lib/desktop/components/forms/SelectDropdown.svelte
@@ -106,6 +106,10 @@
     md: 'text-sm py-2 px-3',
   };
 
+  // Shared focus ring style (theme-aware via color-mix)
+  const focusRingClasses =
+    'focus:outline-none focus:border-[var(--color-primary)] focus:shadow-[0_0_0_3px_color-mix(in_srgb,var(--color-primary)_10%,transparent)]';
+
   // Trigger button classes based on variant
   let triggerClasses = $derived(
     variant === 'select'
@@ -115,7 +119,7 @@
           'border border-[var(--border-100)] rounded-[var(--radius-field)]',
           'transition-all',
           'hover:border-[var(--border-200)]',
-          'focus:outline-none focus:border-[var(--color-primary)] focus:shadow-[0_0_0_3px_rgba(37,99,235,0.1)]',
+          focusRingClasses,
           safeGet(sizeClasses, size, ''),
           disabled && 'opacity-50 cursor-not-allowed bg-[var(--color-base-200)] pointer-events-none'
         )
@@ -367,7 +371,7 @@
 
 <div class={cn('flex flex-col', className)}>
   {#if label}
-    <label class="flex items-center py-2 text-sm" for={fieldId} id="{fieldId}-label">
+    <label class="flex items-center py-2" for={fieldId} id="{fieldId}-label">
       <span class="text-sm font-medium text-[var(--color-base-content)]">
         {label}
         {#if required}
@@ -458,7 +462,10 @@
               bind:value={searchQuery}
               oninput={handleSearch}
               placeholder={t('common.ui.search')}
-              class="block w-full py-2 px-3 text-sm leading-5 bg-[var(--color-base-100)] text-[var(--color-base-content)] border border-[var(--border-100)] rounded-[var(--radius-field)] transition-all placeholder:text-[var(--color-base-content)] placeholder:opacity-50 hover:border-[var(--border-200)] focus:outline-none focus:border-[var(--color-primary)] focus:shadow-[0_0_0_3px_rgba(37,99,235,0.1)]"
+              class={cn(
+                'block w-full py-2 px-3 text-sm leading-5 bg-[var(--color-base-100)] text-[var(--color-base-content)] border border-[var(--border-100)] rounded-[var(--radius-field)] transition-all placeholder:text-[var(--color-base-content)] placeholder:opacity-50 hover:border-[var(--border-200)]',
+                focusRingClasses
+              )}
               aria-label={t('components.forms.select.searchOptions')}
               role="searchbox"
               aria-controls="{fieldId}-listbox"


### PR DESCRIPTION
## Summary
- Replace all DaisyUI-compatible component classes (`select`, `btn`, `input`, `checkbox`, `form-control`, `label`, `label-text`, `label-text-alt`) with explicit Tailwind v4 utility classes
- Makes SelectDropdown styling self-contained and independent of custom CSS component definitions
- Checkbox simplified from custom `appearance-none` styling to native with `accent-color`

## Class conversions
| Before | After |
|--------|-------|
| `select select-sm` | Explicit border, bg, padding, focus ring utilities |
| `btn btn-ghost btn-xs btn-circle` | `inline-flex p-1 rounded-full bg-transparent hover:bg-[color-mix(...)]` |
| `input input-sm` | Explicit form field utilities with focus/hover states |
| `checkbox checkbox-sm` | `size-4 accent-[var(--color-primary)]` |
| `form-control` | `flex flex-col` |
| `label` / `label-text` / `label-text-alt` | Explicit flex + typography utilities |

## Test plan
- [ ] Verify select dropdown renders correctly in alert rule editor
- [ ] Verify hover/focus states work on trigger button
- [ ] Verify clear button styling and interaction
- [ ] Verify search input in searchable mode
- [ ] Verify multi-select checkbox appearance
- [ ] Verify dropdown in notifications filter (with icons)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refined SelectDropdown styling: updated typography, spacing, and token-driven colors
  * Redesigned trigger appearance for select and button variants, including background, border, radius, transitions, hover/open/disabled states
  * Synchronized trigger and menu item sizing; added dedicated item-size mapping
  * Converted layout to a flex-column wrapper; updated label layout and required-indicator color
  * Restyled clear-action button, search input, option rows, checkboxes, group headers, and help text with theme-aware tokens and focus ring
  * Added font-family hint and adjusted icon/text coloring
<!-- end of auto-generated comment: release notes by coderabbit.ai -->