### PR TITLE
fix: simplify alert notification titles and fix duplicate message bug

### DIFF
--- a/frontend/src/lib/i18n/types.generated.ts
+++ b/frontend/src/lib/i18n/types.generated.ts
@@ -340,8 +340,6 @@ export type TranslationKey =
   | 'notifications.content.cleanup.completeMessage' // params: space
   | 'notifications.content.cleanup.failedTitle'
   | 'notifications.content.cleanup.failedMessage' // params: error
-  | 'notifications.content.alert.firedTitleEvent' // params: rule_name, event_name
-  | 'notifications.content.alert.firedTitleMetric' // params: rule_name, metric_name
   | 'notifications.content.alert.firedTitle' // params: rule_name
   | 'notifications.loading'
   | 'search.title'
@@ -916,11 +914,18 @@ export type TranslationKey =
   | 'system.metrics.available'
   | 'system.metrics.min'
   | 'system.metrics.max'
+  | 'system.metrics.limit'
   | 'system.metrics.tempUnavailable'
   | 'system.metrics.online'
   | 'system.metrics.uptime'
   | 'system.metrics.host'
   | 'system.metrics.model'
+  | 'system.metrics.inference'
+  | 'system.metrics.avgTime'
+  | 'system.metrics.noInference'
+  | 'system.metrics.statusOk'
+  | 'system.metrics.statusWarning'
+  | 'system.metrics.statusCritical'
   | 'system.storage.title'
   | 'system.storage.used'
   | 'system.storage.free'
@@ -2564,14 +2569,6 @@ export type TranslationParams = {
   'notifications.content.migration.errorMessage': { error: string | number };
   'notifications.content.cleanup.completeMessage': { space: string | number };
   'notifications.content.cleanup.failedMessage': { error: string | number };
-  'notifications.content.alert.firedTitleEvent': {
-    rule_name: string | number;
-    event_name: string | number;
-  };
-  'notifications.content.alert.firedTitleMetric': {
-    rule_name: string | number;
-    metric_name: string | number;
-  };
   'notifications.content.alert.firedTitle': { rule_name: string | number };
   'search.resultsCountOther': { count: string | number };
   'search.detailsPanel.expandDetails': { species: string | number };

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -400,8 +400,6 @@
         "failedMessage": "Failed to remove legacy database: {error}"
       },
       "alert": {
-        "firedTitleEvent": "Alarm: {rule_name} ({event_name})",
-        "firedTitleMetric": "Alarm: {rule_name} ({metric_name})",
         "firedTitle": "Alarm: {rule_name}"
       }
     },

--- a/frontend/static/messages/en.json
+++ b/frontend/static/messages/en.json
@@ -400,8 +400,6 @@
         "failedMessage": "Failed to remove legacy database: {error}"
       },
       "alert": {
-        "firedTitleEvent": "Alert: {rule_name} ({event_name})",
-        "firedTitleMetric": "Alert: {rule_name} ({metric_name})",
         "firedTitle": "Alert: {rule_name}"
       }
     },

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -400,8 +400,6 @@
         "failedMessage": "Failed to remove legacy database: {error}"
       },
       "alert": {
-        "firedTitleEvent": "Alerta: {rule_name} ({event_name})",
-        "firedTitleMetric": "Alerta: {rule_name} ({metric_name})",
         "firedTitle": "Alerta: {rule_name}"
       }
     },

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -400,8 +400,6 @@
         "failedMessage": "Failed to remove legacy database: {error}"
       },
       "alert": {
-        "firedTitleEvent": "Hälytys: {rule_name} ({event_name})",
-        "firedTitleMetric": "Hälytys: {rule_name} ({metric_name})",
         "firedTitle": "Hälytys: {rule_name}"
       }
     },

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -400,8 +400,6 @@
         "failedMessage": "Failed to remove legacy database: {error}"
       },
       "alert": {
-        "firedTitleEvent": "Alerte : {rule_name} ({event_name})",
-        "firedTitleMetric": "Alerte : {rule_name} ({metric_name})",
         "firedTitle": "Alerte : {rule_name}"
       }
     },

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -400,8 +400,6 @@
         "failedMessage": "Failed to remove legacy database: {error}"
       },
       "alert": {
-        "firedTitleEvent": "Avviso: {rule_name} ({event_name})",
-        "firedTitleMetric": "Avviso: {rule_name} ({metric_name})",
         "firedTitle": "Avviso: {rule_name}"
       }
     },

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -400,8 +400,6 @@
         "failedMessage": "Failed to remove legacy database: {error}"
       },
       "alert": {
-        "firedTitleEvent": "Waarschuwing: {rule_name} ({event_name})",
-        "firedTitleMetric": "Waarschuwing: {rule_name} ({metric_name})",
         "firedTitle": "Waarschuwing: {rule_name}"
       }
     },

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -400,8 +400,6 @@
         "failedMessage": "Failed to remove legacy database: {error}"
       },
       "alert": {
-        "firedTitleEvent": "Alarm: {rule_name} ({event_name})",
-        "firedTitleMetric": "Alarm: {rule_name} ({metric_name})",
         "firedTitle": "Alarm: {rule_name}"
       }
     },

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -400,8 +400,6 @@
         "failedMessage": "Failed to remove legacy database: {error}"
       },
       "alert": {
-        "firedTitleEvent": "Alerta: {rule_name} ({event_name})",
-        "firedTitleMetric": "Alerta: {rule_name} ({metric_name})",
         "firedTitle": "Alerta: {rule_name}"
       }
     },

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -400,8 +400,6 @@
         "failedMessage": "Failed to remove legacy database: {error}"
       },
       "alert": {
-        "firedTitleEvent": "Upozornenie: {rule_name} ({event_name})",
-        "firedTitleMetric": "Upozornenie: {rule_name} ({metric_name})",
         "firedTitle": "Upozornenie: {rule_name}"
       }
     },

--- a/internal/alerting/constants.go
+++ b/internal/alerting/constants.go
@@ -105,7 +105,5 @@ const (
 // These correspond to entries in the frontend i18n files under
 // "notifications.content.alert.*".
 const (
-	MsgAlertFiredTitleEvent  = "notifications.content.alert.firedTitleEvent"
-	MsgAlertFiredTitleMetric = "notifications.content.alert.firedTitleMetric"
-	MsgAlertFiredTitle       = "notifications.content.alert.firedTitle"
+	MsgAlertFiredTitle = "notifications.content.alert.firedTitle"
 )

--- a/internal/alerting/dispatcher.go
+++ b/internal/alerting/dispatcher.go
@@ -33,13 +33,13 @@ func NewActionDispatcher(notifCreator NotificationCreator, log logger.Logger) *A
 func (d *ActionDispatcher) Dispatch(rule *entities.AlertRule, event *AlertEvent) {
 	for i := range rule.Actions {
 		action := &rule.Actions[i]
-		title := renderTemplate(action.TemplateTitle, rule, event)
-		message := renderTemplate(action.TemplateMessage, rule, event)
+		title := renderTitle(action.TemplateTitle, rule, event)
+		message := renderMessage(action.TemplateMessage, rule, event)
 
 		switch action.Target {
 		case TargetBell:
 			hasCustomTemplate := action.TemplateTitle != "" || action.TemplateMessage != ""
-			d.dispatchBell(title, message, rule, event, hasCustomTemplate)
+			d.dispatchBell(title, message, rule, hasCustomTemplate)
 		default:
 			d.log.Warn("unknown alert action target",
 				logger.String("target", action.Target),
@@ -48,7 +48,7 @@ func (d *ActionDispatcher) Dispatch(rule *entities.AlertRule, event *AlertEvent)
 	}
 }
 
-func (d *ActionDispatcher) dispatchBell(title, message string, rule *entities.AlertRule, event *AlertEvent, hasCustomTemplate bool) {
+func (d *ActionDispatcher) dispatchBell(title, message string, rule *entities.AlertRule, hasCustomTemplate bool) {
 	if d.notifCreator == nil {
 		return
 	}
@@ -56,7 +56,7 @@ func (d *ActionDispatcher) dispatchBell(title, message string, rule *entities.Al
 	// When no custom template is set, use translation keys so the
 	// frontend can render the notification in the user's locale.
 	if !hasCustomTemplate {
-		titleKey, titleParams := defaultTitleKey(rule, event)
+		titleKey, titleParams := defaultTitleKey(rule)
 		if err := d.notifCreator.CreateAndBroadcastWithKeys(title, message, titleKey, titleParams, "", nil); err != nil {
 			d.log.Error("failed to create bell notification",
 				logger.Uint64("rule_id", uint64(rule.ID)),
@@ -73,50 +73,46 @@ func (d *ActionDispatcher) dispatchBell(title, message string, rule *entities.Al
 }
 
 // defaultTitleKey returns the i18n key and parameters for the default alert
-// notification title based on the event type.
-func defaultTitleKey(rule *entities.AlertRule, event *AlertEvent) (key string, params map[string]any) {
+// notification title.
+func defaultTitleKey(rule *entities.AlertRule) (key string, params map[string]any) {
 	params = map[string]any{
 		"rule_name": rule.Name,
 	}
 	if rule.NameKey != "" {
 		params["rule_name_key"] = rule.NameKey
 	}
-
-	if event.EventName != "" {
-		params["event_name"] = event.EventName
-		return MsgAlertFiredTitleEvent, params
-	}
-	if event.MetricName != "" {
-		params["metric_name"] = event.MetricName
-		return MsgAlertFiredTitleMetric, params
-	}
 	return MsgAlertFiredTitle, params
 }
 
-// renderTemplate substitutes template variables in the title/message strings.
-// Falls back to defaults if the template is empty.
-func renderTemplate(tmpl string, rule *entities.AlertRule, event *AlertEvent) string {
+// renderTitle substitutes template variables in the title string.
+// Falls back to a default title if the template is empty.
+func renderTitle(tmpl string, rule *entities.AlertRule, event *AlertEvent) string {
 	if tmpl == "" {
-		return defaultTemplate(rule, event)
+		return fmt.Sprintf("Alert: %s", rule.Name)
 	}
-	pairs := []string{
+	return renderTemplate(tmpl, rule, event)
+}
+
+// renderMessage substitutes template variables in the message string.
+// Returns an empty string if the template is empty (no default message).
+func renderMessage(tmpl string, rule *entities.AlertRule, event *AlertEvent) string {
+	if tmpl == "" {
+		return ""
+	}
+	return renderTemplate(tmpl, rule, event)
+}
+
+// renderTemplate substitutes template variables in a string.
+func renderTemplate(tmpl string, rule *entities.AlertRule, event *AlertEvent) string {
+	pairs := make([]string, 0, 8+len(event.Properties)*2)
+	pairs = append(pairs,
 		"{{rule_name}}", rule.Name,
 		"{{event_name}}", event.EventName,
 		"{{metric_name}}", event.MetricName,
 		"{{object_type}}", event.ObjectType,
-	}
+	)
 	for k, v := range event.Properties {
 		pairs = append(pairs, fmt.Sprintf("{{%s}}", k), fmt.Sprintf("%v", v))
 	}
 	return strings.NewReplacer(pairs...).Replace(tmpl)
-}
-
-func defaultTemplate(rule *entities.AlertRule, event *AlertEvent) string {
-	if event.EventName != "" {
-		return fmt.Sprintf("Alert: %s (%s)", rule.Name, event.EventName)
-	}
-	if event.MetricName != "" {
-		return fmt.Sprintf("Alert: %s (%s)", rule.Name, event.MetricName)
-	}
-	return fmt.Sprintf("Alert: %s", rule.Name)
 }

--- a/internal/alerting/dispatcher_test.go
+++ b/internal/alerting/dispatcher_test.go
@@ -90,11 +90,11 @@ func TestDispatcher_DefaultTemplate_UsesKeys(t *testing.T) {
 
 	assert.Empty(t, mock.calls, "default template should use CreateAndBroadcastWithKeys")
 	require.Len(t, mock.keyCalls, 1)
-	assert.Equal(t, MsgAlertFiredTitleMetric, mock.keyCalls[0].titleKey)
+	assert.Equal(t, MsgAlertFiredTitle, mock.keyCalls[0].titleKey)
 	assert.Equal(t, "CPU High", mock.keyCalls[0].titleParams["rule_name"])
 	assert.Equal(t, RuleKeyHighCPUName, mock.keyCalls[0].titleParams["rule_name_key"])
-	assert.Equal(t, MetricCPUUsage, mock.keyCalls[0].titleParams["metric_name"])
-	assert.Contains(t, mock.keyCalls[0].title, "CPU High")
+	assert.Equal(t, "Alert: CPU High", mock.keyCalls[0].title)
+	assert.Empty(t, mock.keyCalls[0].message, "default message should be empty, not duplicate the title")
 }
 
 func TestDispatcher_DefaultTemplate_EventKey(t *testing.T) {
@@ -118,10 +118,11 @@ func TestDispatcher_DefaultTemplate_EventKey(t *testing.T) {
 	dispatcher.Dispatch(rule, event)
 
 	require.Len(t, mock.keyCalls, 1)
-	assert.Equal(t, MsgAlertFiredTitleEvent, mock.keyCalls[0].titleKey)
+	assert.Equal(t, MsgAlertFiredTitle, mock.keyCalls[0].titleKey)
 	assert.Equal(t, "Species Alert", mock.keyCalls[0].titleParams["rule_name"])
 	assert.Equal(t, RuleKeyNewSpeciesName, mock.keyCalls[0].titleParams["rule_name_key"])
-	assert.Equal(t, EventDetectionNewSpecies, mock.keyCalls[0].titleParams["event_name"])
+	assert.Equal(t, "Alert: Species Alert", mock.keyCalls[0].title)
+	assert.Empty(t, mock.keyCalls[0].message, "default message should be empty, not duplicate the title")
 }
 
 func TestDispatcher_DefaultTemplate_FallbackKey(t *testing.T) {
@@ -146,6 +147,7 @@ func TestDispatcher_DefaultTemplate_FallbackKey(t *testing.T) {
 	assert.Equal(t, MsgAlertFiredTitle, mock.keyCalls[0].titleKey)
 	assert.Equal(t, "Generic", mock.keyCalls[0].titleParams["rule_name"])
 	assert.NotContains(t, mock.keyCalls[0].titleParams, "rule_name_key", "custom rule without NameKey should not have rule_name_key")
+	assert.Empty(t, mock.keyCalls[0].message, "default message should be empty, not duplicate the title")
 }
 
 func TestDispatcher_MultipleActions(t *testing.T) {


### PR DESCRIPTION
## Summary
- Remove raw machine identifiers (e.g., `system.disk_usage`, `detection.new_species`) from alert notification titles — now shows just "Alert: \<rule name\>"
- Fix bug where empty message templates produced a duplicate of the title text instead of an empty string
- Split `renderTemplate` into `renderTitle` (with default fallback) and `renderMessage` (empty default)
- Remove unused `MsgAlertFiredTitleEvent` and `MsgAlertFiredTitleMetric` constants and their i18n keys from all 10 language files
- Simplify `defaultTitleKey()` to always return a single `MsgAlertFiredTitle` key with `rule_name` param

## Test plan
- [x] `go test -race ./internal/alerting/...` — all tests pass
- [x] `golangci-lint run ./internal/alerting/...` — 0 issues
- [x] `npm run check:all` — all frontend checks pass
- [x] `npm run i18n:validate` — all language files consistent
- [ ] Manual: trigger an alert → verify bell notification shows "Alert: Low disk space" (not "Alert: Low disk space (system.disk_usage)")
- [ ] Manual: verify custom template actions still render correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified alert titles across all supported languages. Alert notifications now display only the rule name, with event and metric-specific details removed for a more consistent notification experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->