### PR TITLE
feat(i18n): add error_key to remaining handler responses

### DIFF
--- a/internal/api/v2/debug.go
+++ b/internal/api/v2/debug.go
@@ -66,7 +66,7 @@ func (c *Controller) initDebugRoutes() {
 func (c *Controller) DebugTriggerError(ctx echo.Context) error {
 	// Double-check debug mode using controller's settings
 	if c.Settings == nil || !c.Settings.Debug {
-		return c.HandleError(ctx, nil, "Debug mode not enabled", http.StatusForbidden)
+		return c.HandleErrorWithKey(ctx, nil, "Debug mode not enabled", http.StatusForbidden, notification.MsgErrDebugNotEnabled, nil)
 	}
 
 	var req DebugErrorRequest
@@ -127,7 +127,7 @@ func (c *Controller) DebugTriggerError(ctx echo.Context) error {
 func (c *Controller) DebugTriggerNotification(ctx echo.Context) error {
 	// Double-check debug mode using controller's settings
 	if c.Settings == nil || !c.Settings.Debug {
-		return c.HandleError(ctx, nil, "Debug mode not enabled", http.StatusForbidden)
+		return c.HandleErrorWithKey(ctx, nil, "Debug mode not enabled", http.StatusForbidden, notification.MsgErrDebugNotEnabled, nil)
 	}
 
 	var req DebugNotificationRequest
@@ -149,7 +149,7 @@ func (c *Controller) DebugTriggerNotification(ctx echo.Context) error {
 	// Get notification service
 	notificationService := notification.GetService()
 	if notificationService == nil {
-		return c.HandleError(ctx, nil, "Notification service not available", http.StatusServiceUnavailable)
+		return c.HandleErrorWithKey(ctx, nil, "Notification service not available", http.StatusServiceUnavailable, notification.MsgErrNotifServiceUnavailable, nil)
 	}
 
 	// Map string type to notification.Type
@@ -186,7 +186,7 @@ func (c *Controller) DebugTriggerNotification(ctx echo.Context) error {
 func (c *Controller) DebugSystemStatus(ctx echo.Context) error {
 	// Double-check debug mode using controller's settings
 	if c.Settings == nil || !c.Settings.Debug {
-		return c.HandleError(ctx, nil, "Debug mode not enabled", http.StatusForbidden)
+		return c.HandleErrorWithKey(ctx, nil, "Debug mode not enabled", http.StatusForbidden, notification.MsgErrDebugNotEnabled, nil)
 	}
 
 	status := DebugSystemStatus{

--- a/internal/api/v2/integrations.go
+++ b/internal/api/v2/integrations.go
@@ -15,6 +15,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/logger"
 	"github.com/tphakala/birdnet-go/internal/mqtt"
+	"github.com/tphakala/birdnet-go/internal/notification"
 	"github.com/tphakala/birdnet-go/internal/weather"
 )
 
@@ -499,12 +500,12 @@ func (c *Controller) TestWeatherConnection(ctx echo.Context) error {
 
 	// Validate provider
 	if request.Provider == "" || request.Provider == "none" {
-		return c.HandleError(ctx, nil, "No weather provider selected", http.StatusBadRequest)
+		return c.HandleErrorWithKey(ctx, nil, "No weather provider selected", http.StatusBadRequest, notification.MsgErrIntegNoWeatherProvider, nil)
 	}
 
 	// Validate OpenWeather specific requirements
 	if request.Provider == WeatherProviderOpenWeather && request.OpenWeather.APIKey == "" {
-		return c.HandleError(ctx, nil, "OpenWeather API key is required", http.StatusBadRequest)
+		return c.HandleErrorWithKey(ctx, nil, "OpenWeather API key is required", http.StatusBadRequest, notification.MsgErrIntegOWKeyRequired, nil)
 	}
 
 	// Set up streaming response
@@ -753,12 +754,12 @@ func (c *Controller) TriggerHomeAssistantDiscovery(ctx echo.Context) error {
 
 	// Check if processor is available
 	if c.Processor == nil {
-		return c.HandleError(ctx, nil, "Processor not available", http.StatusServiceUnavailable)
+		return c.HandleErrorWithKey(ctx, nil, "Processor not available", http.StatusServiceUnavailable, notification.MsgErrIntegProcessorUnavail, nil)
 	}
 
 	// Trigger discovery
 	if err := c.Processor.TriggerHomeAssistantDiscovery(ctx.Request().Context()); err != nil {
-		return c.HandleError(ctx, err, "Failed to trigger Home Assistant discovery", http.StatusBadRequest)
+		return c.HandleErrorWithKey(ctx, err, "Failed to trigger Home Assistant discovery", http.StatusBadRequest, notification.MsgErrIntegDiscoveryFailed, nil)
 	}
 
 	c.logInfoIfEnabled("Home Assistant discovery triggered successfully",

--- a/internal/api/v2/legacy_cleanup.go
+++ b/internal/api/v2/legacy_cleanup.go
@@ -22,6 +22,7 @@ type LegacyStatusResponse struct {
 	Exists       bool              `json:"exists"`
 	CanCleanup   bool              `json:"can_cleanup"`
 	Reason       string            `json:"reason,omitempty"`
+	ErrorKey     string            `json:"error_key,omitempty"`
 	SizeBytes    int64             `json:"size_bytes"`
 	TotalRecords int64             `json:"total_records"`
 	LastModified *time.Time        `json:"last_modified,omitempty"`
@@ -38,8 +39,9 @@ type LegacyTableInfo struct {
 
 // CleanupActionResponse represents the response for cleanup actions.
 type CleanupActionResponse struct {
-	Success bool   `json:"success"`
-	Message string `json:"message"`
+	Success  bool   `json:"success"`
+	Message  string `json:"message"`
+	ErrorKey string `json:"error_key,omitempty"`
 }
 
 // Cleanup state constants.
@@ -187,12 +189,14 @@ func (c *Controller) getLegacyStatusSQLite(ctx echo.Context, response *LegacySta
 		response.Exists = false
 		response.CanCleanup = false
 		response.Reason = "No legacy database found"
+		response.ErrorKey = notification.MsgErrCleanupNoLegacyDB
 		return ctx.JSON(http.StatusOK, response)
 	}
 	if err != nil {
 		response.Exists = false
 		response.CanCleanup = false
 		response.Reason = fmt.Sprintf("Cannot access legacy database: %v", err)
+		response.ErrorKey = notification.MsgErrCleanupAccessFailed
 		return ctx.JSON(http.StatusOK, response)
 	}
 
@@ -213,6 +217,7 @@ func (c *Controller) getLegacyStatusSQLite(ctx echo.Context, response *LegacySta
 	if !isV2OnlyMode {
 		response.CanCleanup = false
 		response.Reason = "Application must be restarted after migration before cleanup is available"
+		response.ErrorKey = notification.MsgErrCleanupRestartRequired
 		return ctx.JSON(http.StatusOK, response)
 	}
 
@@ -220,6 +225,7 @@ func (c *Controller) getLegacyStatusSQLite(ctx echo.Context, response *LegacySta
 	if datastoreV2.CheckSQLiteHasV2Schema(legacyPath) {
 		response.CanCleanup = false
 		response.Reason = "Target file appears to be a V2 database - cleanup not allowed for safety"
+		response.ErrorKey = notification.MsgErrCleanupSafetyCheck
 		return ctx.JSON(http.StatusOK, response)
 	}
 
@@ -250,6 +256,7 @@ func (c *Controller) getLegacyStatusMySQL(ctx echo.Context, response *LegacyStat
 		response.Exists = true // Assume exists for MySQL
 		response.CanCleanup = false
 		response.Reason = "Application must be restarted after migration before cleanup is available"
+		response.ErrorKey = notification.MsgErrCleanupRestartRequired
 		return ctx.JSON(http.StatusOK, response)
 	}
 
@@ -304,6 +311,7 @@ func (c *Controller) getLegacyStatusMySQL(ctx echo.Context, response *LegacyStat
 		response.Exists = false
 		response.CanCleanup = false
 		response.Reason = "No legacy tables found"
+		response.ErrorKey = notification.MsgErrCleanupNoLegacyTables
 		return ctx.JSON(http.StatusOK, response)
 	}
 
@@ -325,16 +333,18 @@ func (c *Controller) StartLegacyCleanup(ctx echo.Context) error {
 	// Check if we're in v2-only mode (check before trying to start)
 	if !isV2OnlyMode {
 		return ctx.JSON(http.StatusBadRequest, CleanupActionResponse{
-			Success: false,
-			Message: "Cannot cleanup: Application must be restarted after migration",
+			Success:  false,
+			Message:  "Cannot cleanup: Application must be restarted after migration",
+			ErrorKey: notification.MsgErrCleanupRestartNeeded,
 		})
 	}
 
 	// Atomically check and set cleanup state to prevent race conditions
 	if !c.cleanupStatus.TryStart() {
 		return ctx.JSON(http.StatusConflict, CleanupActionResponse{
-			Success: false,
-			Message: "Cleanup already in progress",
+			Success:  false,
+			Message:  "Cleanup already in progress",
+			ErrorKey: notification.MsgErrCleanupAlreadyRunning,
 		})
 	}
 

--- a/internal/api/v2/migration.go
+++ b/internal/api/v2/migration.go
@@ -218,8 +218,8 @@ func (c *Controller) GetMigrationStatus(ctx echo.Context) error {
 		}
 		c.logWarnIfEnabled("Migration state manager not available",
 			logger.String("path", path), logger.String("ip", ip))
-		return c.HandleError(ctx, fmt.Errorf("migration not configured"),
-			"Migration is not configured", http.StatusServiceUnavailable)
+		return c.HandleErrorWithKey(ctx, fmt.Errorf("migration not configured"),
+			"Migration is not configured", http.StatusServiceUnavailable, notification.MsgErrMigrationNotConfigured, nil)
 	}
 
 	// Get migration state
@@ -350,15 +350,15 @@ func (c *Controller) StartMigration(ctx echo.Context) error {
 	worker := getMigrationWorker()
 
 	if sm == nil {
-		return c.HandleError(ctx, fmt.Errorf("migration not configured"),
-			"Migration is not configured", http.StatusServiceUnavailable)
+		return c.HandleErrorWithKey(ctx, fmt.Errorf("migration not configured"),
+			"Migration is not configured", http.StatusServiceUnavailable, notification.MsgErrMigrationNotConfigured, nil)
 	}
 
 	// Run pre-flight checks
 	if err := c.runPreflightChecks(); err != nil {
 		c.logErrorIfEnabled("Pre-flight checks failed",
 			logger.Error(err), logger.String("path", path), logger.String("ip", ip))
-		return c.HandleError(ctx, err, "Pre-flight checks failed", http.StatusBadRequest)
+		return c.HandleErrorWithKey(ctx, err, "Pre-flight checks failed", http.StatusBadRequest, notification.MsgErrMigrationPreFlight, nil)
 	}
 
 	// Parse request body
@@ -366,7 +366,7 @@ func (c *Controller) StartMigration(ctx echo.Context) error {
 	if err := ctx.Bind(&req); err != nil {
 		c.logErrorIfEnabled("Failed to parse start request",
 			logger.Error(err), logger.String("path", path), logger.String("ip", ip))
-		return c.HandleError(ctx, err, "Invalid request body", http.StatusBadRequest)
+		return c.HandleErrorWithKey(ctx, err, "Invalid request body", http.StatusBadRequest, notification.MsgErrMigrationInvalidBody, nil)
 	}
 
 	// Count records if not provided
@@ -381,7 +381,7 @@ func (c *Controller) StartMigration(ctx echo.Context) error {
 		if err != nil {
 			c.logErrorIfEnabled("Failed to count legacy records",
 				logger.Error(err), logger.String("path", path), logger.String("ip", ip))
-			return c.HandleError(ctx, err, "Failed to determine total records", http.StatusInternalServerError)
+			return c.HandleErrorWithKey(ctx, err, "Failed to determine total records", http.StatusInternalServerError, notification.MsgErrMigrationRecordCount, nil)
 		}
 		totalRecords = count
 	}
@@ -390,7 +390,7 @@ func (c *Controller) StartMigration(ctx echo.Context) error {
 	if err := sm.StartMigration(totalRecords); err != nil {
 		c.logErrorIfEnabled("Failed to start migration",
 			logger.Error(err), logger.String("path", path), logger.String("ip", ip))
-		return c.HandleError(ctx, err, "Failed to start migration", http.StatusConflict)
+		return c.HandleErrorWithKey(ctx, err, "Failed to start migration", http.StatusConflict, notification.MsgErrMigrationStartFailed, nil)
 	}
 
 	// Transition to dual-write
@@ -402,7 +402,7 @@ func (c *Controller) StartMigration(ctx echo.Context) error {
 			c.logWarnIfEnabled("Failed to cancel after transition failure",
 				logger.Error(cancelErr))
 		}
-		return c.HandleError(ctx, err, "Failed to initialize migration", http.StatusInternalServerError)
+		return c.HandleErrorWithKey(ctx, err, "Failed to initialize migration", http.StatusInternalServerError, notification.MsgErrMigrationInitFailed, nil)
 	}
 
 	// Start the migration worker if available
@@ -480,15 +480,15 @@ func (c *Controller) ResumeMigration(ctx echo.Context) error {
 	worker := getMigrationWorker()
 
 	if sm == nil {
-		return c.HandleError(ctx, fmt.Errorf("migration not configured"),
-			"Migration is not configured", http.StatusServiceUnavailable)
+		return c.HandleErrorWithKey(ctx, fmt.Errorf("migration not configured"),
+			"Migration is not configured", http.StatusServiceUnavailable, notification.MsgErrMigrationNotConfigured, nil)
 	}
 
 	// Resume the state
 	if err := sm.Resume(); err != nil {
 		c.logErrorIfEnabled("Failed to resume migration",
 			logger.Error(err), logger.String("path", path), logger.String("ip", ip))
-		return c.HandleError(ctx, err, "Failed to resume migration", http.StatusConflict)
+		return c.HandleErrorWithKey(ctx, err, "Failed to resume migration", http.StatusConflict, notification.MsgErrMigrationResumeFailed, nil)
 	}
 
 	// Resume the worker if it was paused
@@ -539,8 +539,8 @@ func (c *Controller) RetryValidation(ctx echo.Context) error {
 	worker := getMigrationWorker()
 
 	if sm == nil {
-		return c.HandleError(ctx, fmt.Errorf("migration not configured"),
-			"Migration is not configured", http.StatusServiceUnavailable)
+		return c.HandleErrorWithKey(ctx, fmt.Errorf("migration not configured"),
+			"Migration is not configured", http.StatusServiceUnavailable, notification.MsgErrMigrationNotConfigured, nil)
 	}
 
 	// Transition FAILED → VALIDATING
@@ -591,8 +591,8 @@ func (c *Controller) CancelMigration(ctx echo.Context) error {
 	worker := getMigrationWorker()
 
 	if sm == nil {
-		return c.HandleError(ctx, fmt.Errorf("migration not configured"),
-			"Migration is not configured", http.StatusServiceUnavailable)
+		return c.HandleErrorWithKey(ctx, fmt.Errorf("migration not configured"),
+			"Migration is not configured", http.StatusServiceUnavailable, notification.MsgErrMigrationNotConfigured, nil)
 	}
 
 	// Stop the worker first if running
@@ -731,8 +731,8 @@ func (c *Controller) executeMigrationAction(ctx echo.Context, params *migrationA
 	c.logInfoIfEnabled(params.logStart, logger.String("path", path), logger.String("ip", ip))
 
 	if params.stateManager == nil {
-		return c.HandleError(ctx, fmt.Errorf("migration not configured"),
-			"Migration is not configured", http.StatusServiceUnavailable)
+		return c.HandleErrorWithKey(ctx, fmt.Errorf("migration not configured"),
+			"Migration is not configured", http.StatusServiceUnavailable, notification.MsgErrMigrationNotConfigured, nil)
 	}
 
 	// Perform worker action if worker is running

--- a/internal/api/v2/notifications.go
+++ b/internal/api/v2/notifications.go
@@ -103,12 +103,12 @@ type notificationAction struct {
 // check service initialization, validate ID, execute operation, handle errors.
 func (c *Controller) executeNotificationAction(ctx echo.Context, action notificationAction) error {
 	if !notification.IsInitialized() {
-		return c.HandleError(ctx, nil, "Notification service not available", http.StatusServiceUnavailable)
+		return c.HandleErrorWithKey(ctx, nil, "Notification service not available", http.StatusServiceUnavailable, notification.MsgErrNotifServiceUnavailable, nil)
 	}
 
 	id := ctx.Param("id")
 	if id == "" {
-		return c.HandleError(ctx, nil, "Notification ID is required", http.StatusBadRequest)
+		return c.HandleErrorWithKey(ctx, nil, "Notification ID is required", http.StatusBadRequest, notification.MsgErrNotifIDRequired, nil)
 	}
 
 	service := notification.GetService()
@@ -146,7 +146,7 @@ func (c *Controller) SetupNotificationRoutes() {
 			return ctx.RealIP(), nil
 		},
 		ErrorHandler: func(context echo.Context, err error) error {
-			return c.HandleError(context, err, "Too many notification stream connection attempts, please wait before trying again", http.StatusTooManyRequests)
+			return c.HandleErrorWithKey(context, err, "Too many notification stream connection attempts, please wait before trying again", http.StatusTooManyRequests, notification.MsgErrNotifRateLimit, nil)
 		},
 	}
 
@@ -196,11 +196,11 @@ type NtfyServerCheckResponse struct {
 func (c *Controller) CheckNtfyServer(ctx echo.Context) error {
 	host := ctx.QueryParam("host")
 	if host == "" {
-		return c.HandleError(ctx, nil, "host parameter is required", http.StatusBadRequest)
+		return c.HandleErrorWithKey(ctx, nil, "host parameter is required", http.StatusBadRequest, notification.MsgErrNotifHostRequired, nil)
 	}
 
 	if !isValidNtfyHost(host) {
-		return c.HandleError(ctx, nil, "invalid host parameter", http.StatusBadRequest)
+		return c.HandleErrorWithKey(ctx, nil, "invalid host parameter", http.StatusBadRequest, notification.MsgErrNotifInvalidHost, nil)
 	}
 
 	resp := probeNtfyServer(ctx.Request().Context(), host)
@@ -342,7 +342,7 @@ func probeNtfyServer(ctx context.Context, host string) NtfyServerCheckResponse {
 func (c *Controller) StreamNotifications(ctx echo.Context) error {
 	// Check if notification service is initialized
 	if !notification.IsInitialized() {
-		return c.HandleError(ctx, nil, "Notification service not available", http.StatusServiceUnavailable)
+		return c.HandleErrorWithKey(ctx, nil, "Notification service not available", http.StatusServiceUnavailable, notification.MsgErrNotifServiceUnavailable, nil)
 	}
 
 	// Track connection start time for metrics
@@ -637,7 +637,7 @@ func (c *Controller) logNotificationSent(clientID string, notif *notification.No
 // GetNotifications returns a list of notifications with optional filtering
 func (c *Controller) GetNotifications(ctx echo.Context) error {
 	if !notification.IsInitialized() {
-		return c.HandleError(ctx, nil, "Notification service not available", http.StatusServiceUnavailable)
+		return c.HandleErrorWithKey(ctx, nil, "Notification service not available", http.StatusServiceUnavailable, notification.MsgErrNotifServiceUnavailable, nil)
 	}
 
 	service := notification.GetService()
@@ -714,19 +714,19 @@ func (c *Controller) GetNotifications(ctx echo.Context) error {
 // GetNotification returns a single notification by ID
 func (c *Controller) GetNotification(ctx echo.Context) error {
 	if !notification.IsInitialized() {
-		return c.HandleError(ctx, nil, "Notification service not available", http.StatusServiceUnavailable)
+		return c.HandleErrorWithKey(ctx, nil, "Notification service not available", http.StatusServiceUnavailable, notification.MsgErrNotifServiceUnavailable, nil)
 	}
 
 	id := ctx.Param("id")
 	if id == "" {
-		return c.HandleError(ctx, nil, "Notification ID is required", http.StatusBadRequest)
+		return c.HandleErrorWithKey(ctx, nil, "Notification ID is required", http.StatusBadRequest, notification.MsgErrNotifIDRequired, nil)
 	}
 
 	service := notification.GetService()
 	notif, err := service.Get(id)
 	if err != nil {
 		if errors.Is(err, notification.ErrNotificationNotFound) {
-			return c.HandleError(ctx, err, "Notification not found", http.StatusNotFound)
+			return c.HandleErrorWithKey(ctx, err, "Notification not found", http.StatusNotFound, notification.MsgErrNotifNotFound, nil)
 		}
 		c.logErrorIfEnabled("failed to get notification",
 			logger.Error(err),
@@ -740,12 +740,12 @@ func (c *Controller) GetNotification(ctx echo.Context) error {
 // MarkNotificationRead marks a notification as read
 func (c *Controller) MarkNotificationRead(ctx echo.Context) error {
 	if !notification.IsInitialized() {
-		return c.HandleError(ctx, nil, "Notification service not available", http.StatusServiceUnavailable)
+		return c.HandleErrorWithKey(ctx, nil, "Notification service not available", http.StatusServiceUnavailable, notification.MsgErrNotifServiceUnavailable, nil)
 	}
 
 	id := ctx.Param("id")
 	if id == "" {
-		return c.HandleError(ctx, nil, "Notification ID is required", http.StatusBadRequest)
+		return c.HandleErrorWithKey(ctx, nil, "Notification ID is required", http.StatusBadRequest, notification.MsgErrNotifIDRequired, nil)
 	}
 
 	service := notification.GetService()
@@ -789,7 +789,7 @@ func (c *Controller) DeleteNotification(ctx echo.Context) error {
 // GetUnreadCount returns the count of unread notifications
 func (c *Controller) GetUnreadCount(ctx echo.Context) error {
 	if !notification.IsInitialized() {
-		return c.HandleError(ctx, nil, "Notification service not available", http.StatusServiceUnavailable)
+		return c.HandleErrorWithKey(ctx, nil, "Notification service not available", http.StatusServiceUnavailable, notification.MsgErrNotifServiceUnavailable, nil)
 	}
 
 	service := notification.GetService()
@@ -807,7 +807,7 @@ func (c *Controller) GetUnreadCount(ctx echo.Context) error {
 // CreateTestNewSpeciesNotification creates a test new species detection notification
 func (c *Controller) CreateTestNewSpeciesNotification(ctx echo.Context) error {
 	if !notification.IsInitialized() {
-		return c.HandleError(ctx, nil, "Notification service not available", http.StatusServiceUnavailable)
+		return c.HandleErrorWithKey(ctx, nil, "Notification service not available", http.StatusServiceUnavailable, notification.MsgErrNotifServiceUnavailable, nil)
 	}
 
 	if c.Settings == nil {

--- a/internal/api/v2/terminal.go
+++ b/internal/api/v2/terminal.go
@@ -13,6 +13,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/logger"
+	"github.com/tphakala/birdnet-go/internal/notification"
 )
 
 const (
@@ -66,7 +67,7 @@ func (c *Controller) initTerminalRoutes() {
 func (c *Controller) HandleTerminalWS(ctx echo.Context) error {
 	settings := conf.Setting()
 	if settings == nil || !settings.WebServer.EnableTerminal {
-		return c.HandleError(ctx, nil, "Terminal is disabled. Enable it in settings.", http.StatusForbidden)
+		return c.HandleErrorWithKey(ctx, nil, "Terminal is disabled. Enable it in settings.", http.StatusForbidden, notification.MsgErrTerminalDisabled, nil)
 	}
 
 	conn, err := terminalUpgrader.Upgrade(ctx.Response(), ctx.Request(), nil)


### PR DESCRIPTION
## Summary

- Convert `HandleError()` → `HandleErrorWithKey()` with i18n translation keys for medium/low-priority handlers: migration, legacy cleanup, integrations, notifications, debug, and terminal
- Add `ErrorKey` field to `CleanupActionResponse` and `LegacyStatusResponse` domain structs for frontend translation support
- All error key constants were already defined in `message_keys.go` (PR #2082); this PR wires them to the actual error responses

**Handlers covered:**
| File | Conversions | Notes |
|------|------------|-------|
| `migration.go` | 12 HandleError → HandleErrorWithKey | Includes executeMigrationAction helper |
| `legacy_cleanup.go` | 2 CleanupActionResponse + 7 LegacyStatusResponse | Added ErrorKey to both structs |
| `integrations.go` | 4 HandleError → HandleErrorWithKey | Weather/HA discovery errors |
| `notifications.go` | 10 HandleError → HandleErrorWithKey | Service availability, ID, rate limit, ntfy host |
| `debug.go` | 4 HandleError → HandleErrorWithKey | Debug mode + notification service checks |
| `terminal.go` | 1 HandleError → HandleErrorWithKey | Terminal disabled check |

**Intentionally skipped:**
- Generic internal server errors (500s) — adequately served by `getSecureErrorMessage(status)` 
- Custom domain structs (`MQTTTestResult`, `map[string]any`) in integration tests — deferred per plan
- `validateDateParameters` in detections.go — requires custom error type approach (deferred)

## Test plan

- [ ] Verify `golangci-lint run ./internal/api/v2/` passes with 0 issues
- [ ] Verify CI tests pass (local tests have pre-existing config validation failure)
- [ ] Verify frontend correctly translates error_key from these handlers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling and message consistency across multiple system features including debug tools, integrations, database cleanup, migration processes, notifications, and terminal access. The system now provides more standardized and informative error messages when operations fail, are unavailable, or encounter validation issues, delivering improved guidance to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->