### PR TITLE
chore: remove direct postcss dep, enable checkJs, fix type errors

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -52,7 +52,6 @@
         "lint-staged": "^16.1.2",
         "madge": "^8.0.0",
         "playwright": "^1.56.1",
-        "postcss": "^8.5.6",
         "postcss-html": "^1.8.0",
         "prettier": "^3.8.1",
         "prettier-plugin-svelte": "^3.5.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -108,7 +108,6 @@
     "lint-staged": "^16.1.2",
     "madge": "^8.0.0",
     "playwright": "^1.56.1",
-    "postcss": "^8.5.6",
     "postcss-html": "^1.8.0",
     "prettier": "^3.8.1",
     "prettier-plugin-svelte": "^3.5.0",

--- a/frontend/src/lib/desktop/components/ui/EmptyState.test.svelte
+++ b/frontend/src/lib/desktop/components/ui/EmptyState.test.svelte
@@ -1,6 +1,7 @@
 <script>
   import EmptyState from './EmptyState.svelte';
 
+  /** @type {{ showCustomIcon?: boolean, showChildren?: boolean, title?: string, description?: string, action?: { label: string, onClick: () => void }, [key: string]: any }} */
   let {
     showCustomIcon = false,
     showChildren = false,

--- a/frontend/src/lib/desktop/components/ui/ErrorAlert.test.svelte
+++ b/frontend/src/lib/desktop/components/ui/ErrorAlert.test.svelte
@@ -1,6 +1,7 @@
 <script>
   import ErrorAlert from './ErrorAlert.svelte';
 
+  /** @type {{ type?: 'error' | 'warning' | 'info' | 'success' | 'check', dismissible?: boolean, onDismiss?: () => void, showChildren?: boolean, [key: string]: any }} */
   let {
     type = 'error',
     dismissible = false,

--- a/frontend/src/lib/desktop/views/Notifications.svelte
+++ b/frontend/src/lib/desktop/views/Notifications.svelte
@@ -48,13 +48,16 @@
     }
   });
 
+  /** @type {import('$lib/utils/notifications').Notification[]} */
   let notifications = $state([]);
   let loading = $state(false);
   let currentPage = $state(1);
   let totalPages = $state(1);
   let pageSize = 20;
   let hasUnread = $state(false);
+  /** @type {string | null} */
   let pendingDeleteId = $state(null);
+  /** @type {string[] | null} */
   let pendingBulkDeleteIds = $state(null);
   // Element bindings should NOT use $state - causes showModal() to fail
   /** @type {HTMLDialogElement | null} */
@@ -117,7 +120,10 @@
       if (filters.type) params.append('type', filters.type);
       if (filters.priority) params.append('priority', filters.priority);
 
-      const data = await api.get(`/api/v2/notifications?${params}`);
+      const data =
+        /** @type {{ notifications?: import('$lib/utils/notifications').ApiNotification[], total?: number }} */ (
+          await api.get(`/api/v2/notifications?${params}`)
+        );
       // Map API notifications to frontend format (status -> read)
       // then apply deduplication to remove duplicate notifications
       const rawNotifications = data.notifications || [];
@@ -150,6 +156,7 @@
   }
 
   // Mark notification as read
+  /** @param {string} id @param {Event} [event] */
   async function markAsRead(id, event) {
     if (event) {
       event.stopPropagation();
@@ -168,6 +175,7 @@
   }
 
   // Handle notification click
+  /** @param {import('$lib/utils/notifications').Notification} notification */
   async function handleNotificationClick(notification) {
     // For detection notifications with note_id, navigate to detection detail page
     if (notification.type === 'detection' && notification.metadata?.note_id) {
@@ -191,11 +199,13 @@
   }
 
   // Mark multiple notifications as read (for group actions)
+  /** @param {string[]} ids */
   async function handleMarkGroupAsRead(ids) {
     await Promise.all(ids.map(id => markAsRead(id)));
   }
 
   // Dismiss/delete multiple notifications (for group actions)
+  /** @param {string[]} ids */
   function handleDismissGroup(ids) {
     pendingBulkDeleteIds = ids;
     bulkDeleteModal?.showModal();
@@ -251,6 +261,7 @@
   }
 
   // Acknowledge notification
+  /** @param {string} id @param {Event} [event] */
   async function acknowledge(id, event) {
     if (event) {
       event.stopPropagation();
@@ -267,6 +278,7 @@
   }
 
   // Delete notification
+  /** @param {string} id @param {Event} [event] */
   async function deleteNotification(id, event) {
     if (event) {
       event.stopPropagation();
@@ -330,6 +342,7 @@
   }
 
   // Get notification icon class (compact for flat view)
+  /** @param {import('$lib/utils/notifications').Notification} notification */
   function getNotificationIconClass(notification) {
     const baseClass = 'w-8 h-8 rounded-full flex items-center justify-center';
     const typeClasses = {
@@ -343,6 +356,7 @@
   }
 
   // Get notification card class
+  /** @param {import('$lib/utils/notifications').Notification} notification */
   function getNotificationCardClass(notification) {
     let classes =
       'card bg-base-100 shadow-2xs hover:shadow-md transition-shadow focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary';
@@ -360,11 +374,13 @@
   }
 
   // Check if notification is clickable
+  /** @param {import('$lib/utils/notifications').Notification} notification */
   function isClickable(notification) {
     return notification.type === 'detection' && notification.metadata?.note_id;
   }
 
   // Get priority badge class
+  /** @param {string} priority */
   function getPriorityBadgeClass(priority) {
     const classes = {
       critical: 'badge-error',
@@ -376,6 +392,7 @@
   }
 
   // Format timestamp
+  /** @param {string} timestamp */
   function formatTime(timestamp) {
     const date = new Date(timestamp);
     const now = new Date();

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -4,7 +4,7 @@ import './lib/styles/species-display.css';
 import App from './App.svelte';
 
 const app = mount(App, {
-  target: document.getElementById('app'),
+  target: /** @type {HTMLElement} */ (document.getElementById('app')),
 });
 
 export default app;

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -8,7 +8,7 @@
     "strict": true,
     "noEmit": true,
     "allowJs": true,
-    "checkJs": false,
+    "checkJs": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -47,14 +47,14 @@ export default defineConfig({
               try {
                 copyFileSync(join(sourceDir, file), join(messagesDir, file));
                 copiedCount++;
-              } catch (err) {
+              } catch (/** @type {any} */ err) {
                 console.error(`[copy-messages] Failed to copy ${file}:`, err.message);
               }
             }
           });
           
           console.log(`[copy-messages] Copied ${copiedCount} message files to dist/messages`);
-        } catch (err) {
+        } catch (/** @type {any} */ err) {
           console.error('[copy-messages] Error during message file copying:', err.message);
           // Don't fail the build, just log the error
         }
@@ -117,8 +117,7 @@ export default defineConfig({
     exclude: ['node_modules', 'dist', 'build', '.svelte-kit', 'coverage', '**/*.integration.{test,spec}.{js,ts}', '**/*.reverse-proxy.{test,spec}.{js,ts}', '**/*.browser.{test,spec}.{js,ts}'],
     // Performance optimizations - Vitest 4.x removed poolOptions, use top-level options
     pool: 'threads', // Faster than default 'forks' for many small tests
-    minWorkers: 2, // Keep minimum threads warm (renamed from poolOptions.threads.minThreads)
-    maxWorkers: 8, // Limit max threads to avoid overhead (renamed from poolOptions.threads.maxThreads)
+    maxWorkers: 8, // Limit max threads to avoid overhead
     // Increase concurrent test limit
     maxConcurrency: 20,
     // Optimize dependency handling


### PR DESCRIPTION
## Summary
Follow-up cleanup from #2095 (Tailwind PostCSS → Vite plugin migration):

- **Remove direct `postcss` dependency** — no longer needed as a direct dep since Tailwind now uses the Vite plugin; `postcss` is still available transitively via stylelint, eslint-plugin-svelte, etc.
- **Enable `checkJs: true` in tsconfig.json** — catches type errors in JS files (`main.js`, `vite.config.js`)
- **Add JSDoc type annotations** to satisfy `checkJs`:
  - `Notifications.svelte` — typed all untyped parameters and state variables
  - `main.js` — null assertion for `document.getElementById`
  - `vite.config.js` — typed `catch` error parameters
  - Test wrapper components — typed `$props()` destructuring
- **Remove invalid `minWorkers` vitest option** — not in Vitest 4.x types, was a no-op

## Test plan
- [x] `npm run check:all` passes (format, lint, stylelint, typecheck, ast-grep)
- [x] `npm run test:ci` — 85 test files, 1675 tests all passing
- [x] `npm run build` succeeds
- [x] `npm run lint:css` works without direct postcss dependency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Notifications now navigate to detection detail pages when marking notifications as read.

* **Refactor**
  * Enhanced type checking across the codebase for improved code reliability and developer experience.

* **Chores**
  * Removed unused dependency from project configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->