### PR TITLE
chore: remove stale eslint no-undef directives and clean up stylelint config

### DIFF
--- a/frontend/.stylelintrc.json
+++ b/frontend/.stylelintrc.json
@@ -4,19 +4,7 @@
     "at-rule-no-unknown": [
       true,
       {
-        "ignoreAtRules": [
-          "tailwind",
-          "apply",
-          "variants",
-          "responsive",
-          "screen",
-          "layer",
-          "plugin",
-          "theme",
-          "property",
-          "utility",
-          "config"
-        ]
+        "ignoreAtRules": ["apply", "layer", "theme", "property", "utility"]
       }
     ],
     "at-rule-empty-line-before": [
@@ -24,7 +12,7 @@
       {
         "except": ["blockless-after-same-name-blockless", "first-nested"],
         "ignore": ["after-comment"],
-        "ignoreAtRules": ["import", "plugin", "theme"]
+        "ignoreAtRules": ["import", "theme"]
       }
     ],
     "import-notation": null,

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -140,6 +140,8 @@ export default [
       globals: {
         ...browserGlobals,
         ...svelteRuneGlobals,
+        // Vite define constants injected at build time
+        __I18N_CACHE_VERSION__: 'readonly',
       },
     },
     plugins: {

--- a/frontend/src/lib/desktop/features/detections/composables/useDetectionActions.svelte.ts
+++ b/frontend/src/lib/desktop/features/detections/composables/useDetectionActions.svelte.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-undef */
 /**
  * useDetectionActions.svelte.ts
  *

--- a/frontend/src/lib/i18n/store.svelte.ts
+++ b/frontend/src/lib/i18n/store.svelte.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-undef */
 import { DEFAULT_LOCALE, type Locale, isValidLocale } from './config.js';
 import { detectBrowserLocale } from './utils.js';
 import { parsePlural } from './pluralParser.js';
@@ -61,7 +60,6 @@ const CACHE_KEY_PREFIX = 'birdnet-messages';
 function cacheKey(locale: string): string {
   return `${CACHE_KEY_PREFIX}-${locale}-${I18N_CACHE_VERSION}`;
 }
-/* eslint-enable no-undef */
 
 // Promise that resolves when translations are first loaded
 let initialLoadResolver: (() => void) | null = null;

--- a/frontend/src/lib/stores/appState.svelte.ts
+++ b/frontend/src/lib/stores/appState.svelte.ts
@@ -22,7 +22,6 @@
  *   // For API utilities:
  *   const token = getCsrfToken();
  */
-/* eslint-disable no-undef */
 import type { AuthConfig } from '../../app.d';
 import { getLogger } from '../utils/logger';
 import { buildAppUrl, setBasePath } from '../utils/urlHelpers';

--- a/frontend/src/lib/stores/navigation.svelte.ts
+++ b/frontend/src/lib/stores/navigation.svelte.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-undef */
 /**
  * Navigation store for SPA client-side routing.
  * Manages route state and provides navigate() function using History API.

--- a/frontend/src/lib/utils/delayedLoading.svelte.ts
+++ b/frontend/src/lib/utils/delayedLoading.svelte.ts
@@ -53,11 +53,8 @@ export function useDelayedLoading(options: DelayedLoadingOptions = {}) {
   const { delayMs = 150, timeoutMs = 15000, onTimeout } = options;
 
   // State management
-  // eslint-disable-next-line no-undef
   let loading = $state(false);
-  // eslint-disable-next-line no-undef
   let showSpinner = $state(false);
-  // eslint-disable-next-line no-undef
   let error = $state(false);
 
   // Timeout tracking

--- a/frontend/src/lib/utils/spectrogramLoader.svelte.ts
+++ b/frontend/src/lib/utils/spectrogramLoader.svelte.ts
@@ -73,17 +73,11 @@ export function createSpectrogramLoader(userConfig: SpectrogramLoaderConfig = {}
   const config = { ...DEFAULT_CONFIG, ...userConfig };
 
   // Reactive state (Svelte 5 runes)
-  // eslint-disable-next-line no-undef -- Svelte 5 runes are globally available in .svelte.ts files
   let state = $state<SpectrogramLoadState>('idle');
-  // eslint-disable-next-line no-undef -- Svelte 5 rune
   let spectrogramUrl = $state('');
-  // eslint-disable-next-line no-undef -- Svelte 5 rune
   let showSpinner = $state(false);
-  // eslint-disable-next-line no-undef -- Svelte 5 rune
   let hasError = $state(false);
-  // eslint-disable-next-line no-undef -- Svelte 5 rune
   let currentDetectionId = $state<number | undefined>(undefined);
-  // eslint-disable-next-line no-undef -- Svelte 5 rune
   let serverStatus = $state<SpectrogramStatus | undefined>(undefined);
 
   // Internal state (not reactive)


### PR DESCRIPTION
## Summary

- Remove stale `/* eslint-disable no-undef */` directives from 6 `.svelte.ts` files — Svelte rune globals (`$state`, `$derived`, etc.) are already declared in `eslint.config.js`, making these per-file disables unnecessary
- Add `__I18N_CACHE_VERSION__` Vite define constant as a global in the `.svelte.ts` ESLint config block instead of relying on inline disable
- Clean up `.stylelintrc.json` by removing stale Tailwind v3 at-rules (`tailwind`, `variants`, `responsive`, `screen`, `plugin`, `config`) and keeping only v4 directives (`apply`, `layer`, `theme`, `property`, `utility`)

## Test plan

- [x] `npm run check:all` passes (0 errors, only pre-existing warnings)
- [x] All 1675 unit tests pass
- [x] Production build succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated linting configuration settings.
  * Removed internal linting directives from codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->