### PR TITLE
fix: resolve each_key_duplicate error on species settings page

### DIFF
--- a/frontend/src/lib/desktop/features/settings/pages/SpeciesSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/SpeciesSettingsPage.svelte
@@ -1183,7 +1183,7 @@
                 class:max-h-[32rem]={!isListExpanded}
                 class:max-h-[80vh]={isListExpanded}
               >
-                {#each filteredActiveSpecies as species (`${species.scientificName}_${species.commonName}`)}
+                {#each filteredActiveSpecies as species, index (`${species.scientificName}_${species.commonName}_${index}`)}
                   <div
                     class="flex items-center justify-between p-3 hover:bg-[var(--color-base-200)]/50 transition-colors"
                   >


### PR DESCRIPTION
## Summary

- Fixes Svelte `each_key_duplicate` runtime error on the Species Settings page (`/ui/settings/species`)
- The error occurred because the `{#each}` key used `scientificName_commonName` which isn't unique when custom classifiers append species that already exist in the default BirdNET model labels
- Added array index to the key to guarantee uniqueness while preserving all duplicate species entries from both default and custom classifiers

## Root Cause

Custom BirdNET models can append classifier labels that overlap with the default model's label file. The range filter API (`/api/v2/range/species/test`) correctly returns all entries (they represent different classifier instances), but the frontend `{#each}` block crashed because identical `scientificName_commonName` pairs produced duplicate keys.

## Test plan

- [x] Verified fix on live instance with custom model containing duplicate species labels
- [x] Frontend builds without errors
- [x] Pre-commit checks pass (prettier, eslint, svelte-check)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Active Species list rendering stability to better handle list item updates and prevent potential display issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->