### PR TITLE
fix: deduplicate system monitor notifications when alert engine active

### DIFF
--- a/internal/notification/resource_consumer.go
+++ b/internal/notification/resource_consumer.go
@@ -114,6 +114,12 @@ func (w *ResourceEventWorker) ProcessResourceEvent(event events.ResourceEvent) e
 	// When the alert engine is active, it handles system resource notifications
 	// via configurable rules. Skip to avoid duplicate notifications.
 	if IsAlertEngineActive() {
+		w.suppressedCount.Add(1)
+		if w.logger != nil {
+			w.logger.Debug("skipping resource notification because alert engine is active",
+				logger.String("resource_type", event.GetResourceType()),
+				logger.String("severity", event.GetSeverity()))
+		}
 		return nil
 	}
 

--- a/internal/notification/resource_consumer_test.go
+++ b/internal/notification/resource_consumer_test.go
@@ -255,11 +255,11 @@ func TestResourceEventWorker_SkipsWhenAlertEngineActive(t *testing.T) {
 	SetAlertEngineActive(true)
 
 	service := NewService(DefaultServiceConfig())
-	defer service.Stop()
+	t.Cleanup(service.Stop)
 
 	worker, err := NewResourceEventWorker(service, nil)
 	require.NoError(t, err)
-	defer worker.Stop()
+	t.Cleanup(worker.Stop)
 
 	// Process a valid resource event
 	event := events.NewResourceEvent(events.ResourceCPU, 90.0, 80.0, events.SeverityWarning)


### PR DESCRIPTION
## Summary
- Skip `ResourceEventWorker` notification creation when the alerting engine is active, using the same `IsAlertEngineActive()` guard already used by `DetectionNotificationConsumer`
- Eliminates duplicate notifications for the same resource condition (e.g., both "Low disk space" from alerting rules AND "High Disk (/) usage" from system-monitor appearing for the same disk threshold)
- The `ResourceEventWorker` still serves as a fallback when the alert engine is not active

## Test Plan
- [x] `go test -race ./internal/notification/...` passes
- [x] `go test -race ./internal/alerting/...` passes
- [x] `go test -race ./internal/monitor/...` passes
- [x] `golangci-lint` reports 0 issues
- [ ] Manual: trigger disk threshold, verify only one notification appears

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Eliminated duplicate notifications that were being generated when the alert engine is active, significantly improving overall notification delivery efficiency and preventing redundant alerts from reaching users during alert processing operations.

* **Tests**
  * Added comprehensive test coverage to verify that notifications are properly handled and not duplicated when the alert engine is active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->