### PR TITLE
fix: recalculate EndTime for non-extended-capture species at flush time

### DIFF
--- a/internal/analysis/processor/actions_database.go
+++ b/internal/analysis/processor/actions_database.go
@@ -152,10 +152,11 @@ func (a *DatabaseAction) ExecuteContext(ctx context.Context, _ any) error {
 			derivedLength := int(a.Result.EndTime.Sub(a.Result.BeginTime).Seconds()) + preCapture
 			if derivedLength > captureLength {
 				captureLength = derivedLength
-				GetLogger().Info("Using extended capture duration for audio export",
+				GetLogger().Info("Using derived capture duration from detection time span",
 					logger.String("detection_id", a.CorrelationID),
 					logger.String("species", a.Result.Species.CommonName),
 					logger.Int("duration_seconds", captureLength),
+					logger.Int("configured_length", a.Settings.Realtime.Audio.Export.Length),
 					logger.String("operation", "extended_capture_audio_export"))
 			}
 		}

--- a/internal/analysis/processor/extended_capture.go
+++ b/internal/analysis/processor/extended_capture.go
@@ -163,6 +163,44 @@ func resolveSpeciesFilter(configSpecies, labels []string, taxonomyDB *birdnet.Ta
 	return false, resolved
 }
 
+// normalizeDetectionTimes sets BeginTime/EndTime on an approved detection.
+// BeginTime is always backdated to FirstDetected so the audio clip starts from
+// the beginning of the event. EndTime handling depends on capture mode:
+//   - Extended captures: EndTime = LastUpdated + normal detection window (spans full session)
+//   - Normal captures: EndTime = FirstDetected + normal detection window (configured length)
+//
+// For extended captures the clip name is regenerated to reflect the actual duration.
+func (p *Processor) normalizeDetectionTimes(item *PendingDetection) {
+	item.Detection.Result.BeginTime = item.FirstDetected
+
+	captureLength := time.Duration(p.Settings.Realtime.Audio.Export.Length) * time.Second
+	preCaptureLength := time.Duration(p.Settings.Realtime.Audio.Export.PreCapture) * time.Second
+	normalDetectionWindow := max(time.Duration(0), captureLength-preCaptureLength)
+
+	if item.ExtendedCapture {
+		// For extended captures, EndTime reflects the last detection + normal detection window.
+		// LastUpdated is always initialized (set on creation and every re-detection).
+		item.Detection.Result.EndTime = item.LastUpdated.Add(normalDetectionWindow)
+
+		// Regenerate clip name with actual duration (unknown at createDetection time)
+		preCapture := p.Settings.Realtime.Audio.Export.PreCapture
+		durationSeconds := int(item.Detection.Result.EndTime.Sub(item.Detection.Result.BeginTime).Seconds()) + preCapture
+		item.Detection.Result.ClipName = p.generateClipNameWithDuration(
+			item.Detection.Result.Species.ScientificName,
+			float32(item.Confidence),
+			durationSeconds,
+			item.Detection.Result.Timestamp,
+		)
+	} else {
+		// For non-extended detections, recalculate EndTime to maintain the configured
+		// capture window. BeginTime was backdated to FirstDetected, but EndTime may
+		// come from a later higher-confidence detection that replaced the Detection
+		// struct during the pending window. Without this recalculation, the time span
+		// (EndTime - BeginTime) inflates beyond the configured capture length.
+		item.Detection.Result.EndTime = item.FirstDetected.Add(normalDetectionWindow)
+	}
+}
+
 // applyExtendedCapture applies extended capture logic to a pending detection.
 // It sets the ExtendedCapture flag, MaxDeadline, and calculates the scaled flush deadline.
 // This is called from processDetections after the pending detection is created/updated.

--- a/internal/analysis/processor/extended_capture_test.go
+++ b/internal/analysis/processor/extended_capture_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/birdnet"
 	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/detection"
 )
 
 func TestIsExtendedCaptureSpecies(t *testing.T) {
@@ -409,4 +410,115 @@ func TestCalculateExtendedFlushDeadline(t *testing.T) {
 				"wait time %v should be <= %v", waitTime, tt.expectedMaxWait)
 		})
 	}
+}
+
+func TestNormalizeDetectionTimes_NonExtendedCapture(t *testing.T) {
+	t.Parallel()
+
+	// Settings: captureLength=60, preCapture=6, normalWindow=54s
+	p := &Processor{
+		Settings: &conf.Settings{
+			Realtime: conf.RealtimeSettings{
+				Audio: conf.AudioSettings{
+					Export: conf.ExportSettings{Length: 60, PreCapture: 6},
+				},
+				ExtendedCapture: conf.ExtendedCaptureSettings{Enabled: false},
+			},
+		},
+	}
+
+	firstDetected := time.Date(2026, 3, 7, 8, 50, 0, 0, time.UTC)
+	captureWindow := 54 * time.Second // Length - PreCapture = 60 - 6
+
+	// Simulate: Detection struct was replaced by a higher-confidence detection
+	// that arrived 30s into the pending window. Its BeginTime/EndTime reflect
+	// the later analysis chunk, not the first detection.
+	laterStart := firstDetected.Add(30 * time.Second)
+	item := &PendingDetection{
+		Detection: Detections{
+			Result: detection.Result{
+				BeginTime: laterStart,
+				EndTime:   laterStart.Add(captureWindow),
+				Species: detection.Species{
+					CommonName:     "käpytikka",
+					ScientificName: "Dendrocopos major",
+				},
+			},
+		},
+		Confidence:      0.85,
+		Source:          "test_source",
+		FirstDetected:   firstDetected,
+		LastUpdated:     laterStart,
+		Count:           27,
+		ExtendedCapture: false,
+	}
+
+	p.normalizeDetectionTimes(item)
+
+	// BeginTime should be backdated to FirstDetected
+	assert.Equal(t, firstDetected, item.Detection.Result.BeginTime)
+
+	// EndTime should be recalculated: FirstDetected + (Length - PreCapture)
+	expectedEndTime := firstDetected.Add(captureWindow)
+	assert.Equal(t, expectedEndTime, item.Detection.Result.EndTime,
+		"EndTime should be recalculated from FirstDetected for non-extended species")
+
+	// The derived capture length should equal the configured length
+	preCapture := p.Settings.Realtime.Audio.Export.PreCapture
+	derivedLength := int(item.Detection.Result.EndTime.Sub(item.Detection.Result.BeginTime).Seconds()) + preCapture
+	assert.Equal(t, p.Settings.Realtime.Audio.Export.Length, derivedLength,
+		"derived capture length should match configured export length")
+}
+
+func TestNormalizeDetectionTimes_ExtendedCapture(t *testing.T) {
+	t.Parallel()
+
+	p := &Processor{
+		Settings: &conf.Settings{
+			Realtime: conf.RealtimeSettings{
+				Audio: conf.AudioSettings{
+					Export: conf.ExportSettings{Length: 60, PreCapture: 6},
+				},
+				ExtendedCapture: conf.ExtendedCaptureSettings{Enabled: true, MaxDuration: 600},
+			},
+		},
+	}
+
+	firstDetected := time.Date(2026, 3, 7, 20, 0, 0, 0, time.UTC)
+	lastUpdated := firstDetected.Add(3 * time.Minute)
+
+	item := &PendingDetection{
+		Detection: Detections{
+			Result: detection.Result{
+				BeginTime: firstDetected.Add(30 * time.Second),
+				EndTime:   firstDetected.Add(84 * time.Second),
+				Species: detection.Species{
+					CommonName:     "lehtopöllö",
+					ScientificName: "Strix aluco",
+				},
+			},
+		},
+		Confidence:      0.92,
+		Source:          "test_source",
+		FirstDetected:   firstDetected,
+		LastUpdated:     lastUpdated,
+		Count:           45,
+		ExtendedCapture: true,
+	}
+
+	p.normalizeDetectionTimes(item)
+
+	// BeginTime should be backdated to FirstDetected
+	assert.Equal(t, firstDetected, item.Detection.Result.BeginTime)
+
+	// EndTime should be LastUpdated + normalDetectionWindow (54s)
+	expectedEndTime := lastUpdated.Add(54 * time.Second)
+	assert.Equal(t, expectedEndTime, item.Detection.Result.EndTime,
+		"EndTime should span from LastUpdated + normal window for extended capture")
+
+	// Duration should be > configured length (this is the whole point of extended capture)
+	preCapture := p.Settings.Realtime.Audio.Export.PreCapture
+	derivedLength := int(item.Detection.Result.EndTime.Sub(item.Detection.Result.BeginTime).Seconds()) + preCapture
+	assert.Greater(t, derivedLength, p.Settings.Realtime.Audio.Export.Length,
+		"extended capture should produce longer duration than configured length")
 }

--- a/internal/analysis/processor/processor.go
+++ b/internal/analysis/processor/processor.go
@@ -1095,29 +1095,7 @@ func (p *Processor) processApprovedDetection(item *PendingDetection, speciesName
 	// Note: speciesName is already lowercase (lowered in flushPendingDetections)
 	p.LearnFromApprovedDetection(speciesName, item.Detection.Result.Species.ScientificName, confidence)
 
-	// Set BeginTime to the first detection time for all approved detections.
-	// This ensures the audio clip starts from the beginning of the event.
-	item.Detection.Result.BeginTime = item.FirstDetected
-
-	if item.ExtendedCapture {
-		// For extended captures, EndTime reflects the last detection + normal detection window.
-		// LastUpdated is always initialized (set on creation and every re-detection).
-		lastDetection := item.LastUpdated
-		captureLength := time.Duration(p.Settings.Realtime.Audio.Export.Length) * time.Second
-		preCaptureLength := time.Duration(p.Settings.Realtime.Audio.Export.PreCapture) * time.Second
-		normalDetectionWindow := max(time.Duration(0), captureLength-preCaptureLength)
-		item.Detection.Result.EndTime = lastDetection.Add(normalDetectionWindow)
-
-		// Regenerate clip name with actual duration (unknown at createDetection time)
-		preCapture := p.Settings.Realtime.Audio.Export.PreCapture
-		durationSeconds := int(item.Detection.Result.EndTime.Sub(item.Detection.Result.BeginTime).Seconds()) + preCapture
-		item.Detection.Result.ClipName = p.generateClipNameWithDuration(
-			item.Detection.Result.Species.ScientificName,
-			float32(item.Confidence),
-			durationSeconds,
-			item.Detection.Result.Timestamp,
-		)
-	}
+	p.normalizeDetectionTimes(item)
 
 	actionList := p.getActionsForItem(&item.Detection)
 	for _, action := range actionList {


### PR DESCRIPTION
## Summary

- Fix bug where non-extended-capture species get inflated audio capture durations (e.g., 84s instead of configured 60s)
- Extract `normalizeDetectionTimes()` helper from `processApprovedDetection` for testability
- Add `else` branch to recalculate EndTime for non-extended detections, maintaining the configured capture window
- Improve misleading log message in audio export path

## Root Cause

When pending detections accumulate multiple hits over the ~54s detection window, higher-confidence detections replace the `Detection` struct (including BeginTime/EndTime). At flush time, BeginTime is backdated to `FirstDetected` for all species, but EndTime was only recalculated for extended capture species. This inflated the time span for normal species, causing the audio export to use longer-than-configured capture durations.

Introduced by #2104 — the `derivedLength = EndTime - BeginTime + PreCapture` logic trusts timestamps to be consistent, but the EndTime consistency was only ensured for the extended capture code path.

## Evidence from production logs

Config extended capture species: `Strigidae`, `korppi`, `varis`

Incorrectly inflated captures observed for:
- `käpytikka` (Great Spotted Woodpecker): 84-89s instead of 60s
- `närhi` (Siberian Jay): 65-80s
- `talitiainen` (Great Tit): 61-110s
- `pyy` (Hazel Grouse): 61-112s

## Test plan

- [x] New test: `TestNormalizeDetectionTimes_NonExtendedCapture` — verifies EndTime recalculation for normal species
- [x] New test: `TestNormalizeDetectionTimes_ExtendedCapture` — verifies extended capture behavior preserved
- [x] All existing extended capture tests pass
- [x] Full processor test suite passes with `-race`
- [x] golangci-lint: 0 issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Improvements**
- Enhanced logging for audio export operations to provide clearer visibility into capture duration calculations. Output now displays derived duration from detection timing and shows configured length information when extended capture is used.
- Improved accuracy of detection time normalization for real-time audio capture scenarios, ensuring more reliable and consistent timing calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->