### PR TITLE
fix: replace manual refresh button with auto-refresh on system overview

### DIFF
--- a/frontend/src/lib/desktop/views/System.svelte
+++ b/frontend/src/lib/desktop/views/System.svelte
@@ -447,9 +447,11 @@
     };
   });
 
-  // Start/stop slow refresh based on active subpage
+  // Start/stop slow refresh based on active subpage.
+  // The active guard lives inside startSlowRefresh's tick(), so no need to
+  // check componentActive here — avoids an ordering dependency between effects.
   $effect(() => {
-    if (currentSubpage === 'overview' && componentActive.current) {
+    if (currentSubpage === 'overview') {
       startSlowRefresh(componentActive);
     }
 


### PR DESCRIPTION
## Summary

- Removes the standalone blue "Refresh Data" button from the system overview page — it was inconsistent with the rest of the UI (no other page has one)
- Adds a 30-second auto-refresh interval for slow-changing data (system info, disks, processes) that SSE doesn't cover
- SSE continues to handle fast-changing metrics (CPU, memory %, temperature, inference time) in real-time
- Removes unused `isLoading` state and `RefreshCw` import

## Test plan

- [ ] Open system overview page, verify no refresh button at bottom
- [ ] Wait 30+ seconds, verify uptime and process table update automatically
- [ ] Navigate away from system page and back — verify no stale intervals (cleanup works)
- [ ] Verify sparklines still update in real-time via SSE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * System info, disk usage, and process lists now auto-refresh on the overview page via a timed background refresh that avoids overlapping requests, works alongside existing live updates, and only runs when the overview is active.

* **Refactor**
  * Removed the manual refresh button and explicit loading indicator; background refresh starts/stops with component lifecycle and visibility for cleaner, more reliable behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->