### PR TITLE
fix: remove raw errMsg from ReportInitFailed CaptureMessage string

### DIFF
--- a/internal/alerting/telemetry.go
+++ b/internal/alerting/telemetry.go
@@ -71,7 +71,7 @@ func (at *AlertingTelemetry) ReportInitFailed(errMsg string) {
 		})
 
 		telemetry.CaptureMessage(
-			fmt.Sprintf("Alerting engine initialization failed: %s", errMsg),
+			"Alerting engine initialization failed",
 			sentry.LevelError,
 			telemetryComponent,
 		)


### PR DESCRIPTION
## Summary
- Remove `fmt.Sprintf` embedding raw `errMsg` in `ReportInitFailed`'s `CaptureMessage` call — use a static message string instead
- The scrubbed error is already available in `SetContext` data (line 70)
- Defense-in-depth consistency: matches the pattern used by all other error-reporting methods in the file (`ReportDBWriteFailed`, `ReportDispatchFailed`, `ReportBridgeRegistrationFailed`)

**Note:** `CaptureMessage` wrapper already scrubs via `privacy.ScrubMessage()` at `sentry.go:616`, so this is NOT a live privacy leak — it's a consistency fix.

Follow-up from PR #2137.

## Test Plan
- [x] `go build ./internal/alerting/...` passes
- [x] `go test -race ./internal/alerting/... -v -count=1` — all tests pass
- [x] `golangci-lint run -v` — 0 issues
- [x] Code review (manual + Gemini) — no issues found

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved alerting system telemetry message handling for consistency and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->