### PR TITLE
fix(myaudio): initialize filter chain for all audio sources, not just malgo

### DIFF
--- a/internal/myaudio/audio_filters.go
+++ b/internal/myaudio/audio_filters.go
@@ -316,23 +316,9 @@ func ApplyFilters(samples []byte) error {
 	filterMutex.RLock()
 	defer filterMutex.RUnlock()
 
-	// If no filters, return early
-	if filterChain == nil {
-		enhancedErr := errors.Newf("filter chain is not initialized").
-			Component("myaudio").
-			Category(errors.CategorySystem).
-			Context("operation", "apply_filters").
-			Build()
-
-		if m := getFilterMetrics(); m != nil {
-			m.RecordAudioProcessing("apply_filters", "filter", "error")
-			m.RecordAudioProcessingError("apply_filters", "filter", "uninitialized_chain")
-		}
-		return enhancedErr
-	}
-
-	if filterChain.Length() == 0 {
-		// No filters to apply - record success but no processing
+	// If no filter chain or no filters configured, return early (no-op).
+	// A nil chain is functionally equivalent to an empty chain.
+	if filterChain == nil || filterChain.Length() == 0 {
 		if m := getFilterMetrics(); m != nil {
 			duration := time.Since(start).Seconds()
 			m.RecordAudioProcessing("apply_filters", "filter", "success")

--- a/internal/myaudio/audio_filters_test.go
+++ b/internal/myaudio/audio_filters_test.go
@@ -167,7 +167,10 @@ func TestApplyFilters_OddByteCount(t *testing.T) {
 }
 
 func TestApplyFilters_NoFilterChain(t *testing.T) {
-	// Reset filter chain
+	// Reset filter chain to nil to simulate uninitialized state.
+	// A nil chain should be a no-op (equivalent to no filters configured),
+	// not an error. This is important for RTSP-only deployments where the
+	// malgo capture path (which previously initialized the chain) is never entered.
 	filterMutex.Lock()
 	oldChain := filterChain
 	filterChain = nil
@@ -179,9 +182,13 @@ func TestApplyFilters_NoFilterChain(t *testing.T) {
 		filterMutex.Unlock()
 	})
 
-	samples := make([]byte, 100)
+	samples := []byte{0x00, 0x40, 0x00, 0xC0} // Two 16-bit samples
+	original := make([]byte, len(samples))
+	copy(original, samples)
+
 	err := ApplyFilters(samples)
-	assert.Error(t, err)
+	require.NoError(t, err)
+	assert.Equal(t, original, samples, "samples should be unchanged when filter chain is nil")
 }
 
 func TestApplyFilters_EmptyFilterChain(t *testing.T) {

--- a/internal/myaudio/capture.go
+++ b/internal/myaudio/capture.go
@@ -321,6 +321,13 @@ func CaptureAudio(settings *conf.Settings, wg *sync.WaitGroup, quitChan, restart
 		return
 	}
 
+	// Initialize the audio equalizer filter chain before any audio source starts.
+	// This must happen before RTSP goroutines and sound card capture to avoid
+	// a race where ApplyFilters() is called before the chain is ready.
+	if err := InitializeFilterChain(settings); err != nil {
+		GetLogger().Warn("error initializing filter chain", logger.Error(err))
+	}
+
 	// Initialize RTSP sources - the FFmpegManager will handle buffer initialization
 	if len(settings.Realtime.RTSP.Streams) > 0 {
 		for i := range settings.Realtime.RTSP.Streams {
@@ -816,11 +823,6 @@ func captureAudioMalgo(settings *conf.Settings, source captureSource, sourceID s
 	deviceConfig.SampleRate = conf.SampleRate
 	deviceConfig.Alsa.NoMMap = 1
 	deviceConfig.Capture.DeviceID = source.Pointer
-
-	// Initialize the filter chain
-	if err := InitializeFilterChain(settings); err != nil {
-		log.Warn("error initializing filter chain", logger.Error(err))
-	}
 
 	// Initialize sound level processor for this source if enabled
 	if settings.Realtime.Audio.SoundLevel.Enabled {


### PR DESCRIPTION
## Summary

- Move `InitializeFilterChain()` from `captureAudioMalgo()` to `CaptureAudio()` so the equalizer filter chain is initialized before **any** audio source (RTSP/FFmpeg or sound card) begins processing
- Make `ApplyFilters()` treat a nil filter chain as a no-op (return `nil`) instead of returning an error — a nil chain is functionally equivalent to an empty chain (no filters configured)

## Problem

`InitializeFilterChain()` was only called from the malgo (sound card) capture path. RTSP/FFmpeg streams called `ApplyFilters()` but never initialized the filter chain, causing repeated `"filter chain is not initialized"` errors in Sentry (BIRDNET-GO-QD). This affected:

1. **RTSP-only deployments** — the filter chain global stayed `nil` because the malgo path was never entered
2. **Mixed deployments** — RTSP streams started as goroutines could receive audio data before the sound card path reached `InitializeFilterChain()`, creating a race window

## Changes

| File | Change |
|------|--------|
| `internal/myaudio/capture.go` | Move `InitializeFilterChain()` to top of `CaptureAudio()`, before RTSP goroutines launch; remove duplicate call from `captureAudioMalgo()` |
| `internal/myaudio/audio_filters.go` | `ApplyFilters()`: nil chain returns `nil` instead of error (defense-in-depth) |
| `internal/myaudio/audio_filters_test.go` | Update `TestApplyFilters_NoFilterChain` to verify nil chain is a no-op, not an error |

## Test plan

- [x] `golangci-lint run ./internal/myaudio/...` — 0 issues
- [x] `go test -race ./internal/myaudio/` — filter tests pass
- [x] `TestApplyFilters_NoFilterChain` verifies nil chain returns no error and leaves samples unchanged
- [x] `TestApplyFilters_EmptyFilterChain` continues to pass (empty initialized chain)

Fixes #2148

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced audio filter chain handling to gracefully treat uninitialized or empty filter chains as no-operations, eliminating error conditions and improving system robustness
  * Optimized audio filter chain initialization to occur earlier in the audio capture startup sequence, ensuring filters are ready before audio capture begins

<!-- end of auto-generated comment: release notes by coderabbit.ai -->