### PR TITLE
fix(datastore): v2 AutoMigrate fails on MySQL with legacy schema

### DIFF
--- a/internal/analysis/realtime.go
+++ b/internal/analysis/realtime.go
@@ -1984,24 +1984,26 @@ func initializeMigrationInfrastructure(settings *conf.Settings, ds datastore.Int
 
 // initializeMySQLMigrationInfrastructure sets up migration infrastructure for MySQL.
 // Unlike SQLite which uses a separate file, MySQL shares the same database.
-// V2 tables have different names from legacy (detections vs notes), so no prefix needed.
+// V2 tables use the v2_ prefix to avoid collisions with legacy auxiliary tables
+// (e.g., dynamic_thresholds, image_caches) that share the same base names.
 func initializeMySQLMigrationInfrastructure(settings *conf.Settings, ds datastore.Interface, log logger.Logger) error {
-	// Create v2 MySQL manager - no prefix needed since v2 table names differ from legacy
-	// (Entity TableName() methods override GORM NamingStrategy anyway)
+	// Create v2 MySQL manager with v2_ prefix to avoid collisions with legacy
+	// auxiliary tables that share the same base names. TableName() methods have
+	// been removed so NamingStrategy.TablePrefix now takes effect.
 	v2Manager, err := datastoreV2.NewMySQLManager(&datastoreV2.MySQLConfig{
 		Host:        settings.Output.MySQL.Host,
 		Port:        settings.Output.MySQL.Port,
 		Username:    settings.Output.MySQL.Username,
 		Password:    settings.Output.MySQL.Password,
 		Database:    settings.Output.MySQL.Database,
-		UseV2Prefix: false, // No prefix - v2 tables have different names from legacy
+		UseV2Prefix: true, // v2_ prefix avoids collisions with legacy auxiliary tables
 		Debug:       settings.Debug,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to create MySQL v2 manager: %w", err)
 	}
 
-	// Initialize the v2 schema (creates tables without prefix)
+	// Initialize the v2 schema (creates tables with v2_ prefix)
 	if err := v2Manager.Initialize(); err != nil {
 		if closeErr := v2Manager.Close(); closeErr != nil {
 			log.Warn("failed to close MySQL v2 manager after initialization failure",
@@ -2011,15 +2013,14 @@ func initializeMySQLMigrationInfrastructure(settings *conf.Settings, ds datastor
 		return fmt.Errorf("failed to initialize MySQL v2 schema: %w", err)
 	}
 
-	// Setup the migration worker using the common helper
-	// Note: useV2Prefix is false because entity TableName() methods override
-	// GORM's NamingStrategy, creating tables without prefix. Since v2 tables
-	// have different names from legacy (detections vs notes), prefix isn't needed.
+	// Setup the migration worker using the common helper.
+	// useV2Prefix is true so the migration worker creates v2_ prefixed tables,
+	// avoiding collisions with legacy auxiliary tables that share the same base names.
 	if err := setupMigrationWorker(&migrationSetupConfig{
 		manager:     v2Manager,
 		ds:          ds,
 		log:         log,
-		useV2Prefix: false, // Tables created without prefix due to TableName() methods
+		useV2Prefix: true, // v2_ prefix avoids collisions with legacy auxiliary tables
 		opName:      "initialize_mysql_migration",
 	}); err != nil {
 		if closeErr := v2Manager.Close(); closeErr != nil {

--- a/internal/api/v2/legacy_cleanup_test.go
+++ b/internal/api/v2/legacy_cleanup_test.go
@@ -258,12 +258,12 @@ func TestStartLegacyCleanup_SQLite_V2DatabaseSafetyCheck(t *testing.T) {
 	// For this test, we'll verify the safety check is called by checking error message
 	legacyPath := filepath.Join(tmpDir, "birdnet.db")
 
-	// Create a minimal SQLite database with migration_state table to simulate V2
+	// Create a minimal SQLite database with migration_states table to simulate V2
 	// The table structure must match what GORM expects for entities.MigrationState
 	db, err := sql.Open("sqlite3", legacyPath)
 	require.NoError(t, err)
 	_, err = db.Exec(`
-		CREATE TABLE migration_state (
+		CREATE TABLE migration_states (
 			id INTEGER PRIMARY KEY,
 			state TEXT NOT NULL DEFAULT 'completed',
 			current_phase TEXT NOT NULL DEFAULT '',
@@ -278,7 +278,7 @@ func TestStartLegacyCleanup_SQLite_V2DatabaseSafetyCheck(t *testing.T) {
 			related_data_error TEXT,
 			updated_at DATETIME
 		);
-		INSERT INTO migration_state (id, state) VALUES (1, 'completed');
+		INSERT INTO migration_states (id, state) VALUES (1, 'completed');
 	`)
 	require.NoError(t, err)
 	require.NoError(t, db.Close())

--- a/internal/datastore/v2/entities/ai_model.go
+++ b/internal/datastore/v2/entities/ai_model.go
@@ -21,8 +21,3 @@ type AIModel struct {
 	ClassifierPath *string   `gorm:"type:varchar(500)"` // path to custom classifier file
 	CreatedAt      time.Time `gorm:"autoCreateTime"`
 }
-
-// TableName returns the table name for GORM.
-func (AIModel) TableName() string {
-	return "ai_models"
-}

--- a/internal/datastore/v2/entities/alert_action.go
+++ b/internal/datastore/v2/entities/alert_action.go
@@ -10,8 +10,3 @@ type AlertAction struct {
 	TemplateMessage string `gorm:"size:2000;default:''" json:"template_message"`
 	SortOrder       int    `gorm:"default:0" json:"sort_order"`
 }
-
-// TableName returns the table name for GORM.
-func (AlertAction) TableName() string {
-	return "alert_actions"
-}

--- a/internal/datastore/v2/entities/alert_condition.go
+++ b/internal/datastore/v2/entities/alert_condition.go
@@ -11,8 +11,3 @@ type AlertCondition struct {
 	DurationSec int    `gorm:"default:0" json:"duration_sec"`
 	SortOrder   int    `gorm:"default:0" json:"sort_order"`
 }
-
-// TableName returns the table name for GORM.
-func (AlertCondition) TableName() string {
-	return "alert_conditions"
-}

--- a/internal/datastore/v2/entities/alert_history.go
+++ b/internal/datastore/v2/entities/alert_history.go
@@ -5,15 +5,10 @@ import "time"
 // AlertHistory records each time an alert rule fires.
 type AlertHistory struct {
 	ID        uint      `gorm:"primaryKey" json:"id"`
-	RuleID    uint      `gorm:"not null;index:idx_alert_history_rule_fired,priority:1" json:"rule_id"`
-	FiredAt   time.Time `gorm:"not null;index:idx_alert_history_rule_fired,priority:2" json:"fired_at"`
+	RuleID    uint      `gorm:"not null;index:idx_alert_histories_rule_fired,priority:1" json:"rule_id"`
+	FiredAt   time.Time `gorm:"not null;index:idx_alert_histories_rule_fired,priority:2" json:"fired_at"`
 	EventData string    `gorm:"type:text;default:''" json:"event_data"`
 	Actions   string    `gorm:"type:text;default:''" json:"actions"`
 	CreatedAt time.Time `gorm:"autoCreateTime" json:"created_at"`
 	Rule      AlertRule `gorm:"foreignKey:RuleID;constraint:OnDelete:CASCADE" json:"rule,omitzero"`
-}
-
-// TableName returns the table name for GORM.
-func (AlertHistory) TableName() string {
-	return "alert_history"
 }

--- a/internal/datastore/v2/entities/alert_rule.go
+++ b/internal/datastore/v2/entities/alert_rule.go
@@ -22,8 +22,3 @@ type AlertRule struct {
 	Conditions     []AlertCondition `gorm:"foreignKey:RuleID;constraint:OnDelete:CASCADE" json:"conditions"`
 	Actions        []AlertAction    `gorm:"foreignKey:RuleID;constraint:OnDelete:CASCADE" json:"actions"`
 }
-
-// TableName returns the table name for GORM.
-func (AlertRule) TableName() string {
-	return "alert_rules"
-}

--- a/internal/datastore/v2/entities/audio_source.go
+++ b/internal/datastore/v2/entities/audio_source.go
@@ -27,8 +27,3 @@ type AudioSource struct {
 	ConfigJSON  *string    `gorm:"type:text"`
 	CreatedAt   time.Time  `gorm:"autoCreateTime"`
 }
-
-// TableName returns the table name for GORM.
-func (AudioSource) TableName() string {
-	return "audio_sources"
-}

--- a/internal/datastore/v2/entities/daily_events.go
+++ b/internal/datastore/v2/entities/daily_events.go
@@ -10,8 +10,3 @@ type DailyEvents struct {
 	Country  string `gorm:"size:100"`
 	CityName string `gorm:"size:200"`
 }
-
-// TableName returns the table name for GORM.
-func (DailyEvents) TableName() string {
-	return "daily_events"
-}

--- a/internal/datastore/v2/entities/detection.go
+++ b/internal/datastore/v2/entities/detection.go
@@ -44,11 +44,6 @@ type Detection struct {
 	// We avoid GORM relationship tags here because they interfere with
 	// the CASCADE constraints defined in DetectionReview/DetectionLock.
 	Review   *DetectionReview    `gorm:"-"`
-	Lock     *DetectionLock     `gorm:"-"`
+	Lock     *DetectionLock      `gorm:"-"`
 	Comments []*DetectionComment `gorm:"-"`
-}
-
-// TableName returns the table name for GORM.
-func (Detection) TableName() string {
-	return "detections"
 }

--- a/internal/datastore/v2/entities/detection_comment.go
+++ b/internal/datastore/v2/entities/detection_comment.go
@@ -14,8 +14,3 @@ type DetectionComment struct {
 	// Relationship
 	Detection *Detection `gorm:"foreignKey:DetectionID;constraint:OnDelete:CASCADE,OnUpdate:CASCADE"`
 }
-
-// TableName returns the table name for GORM.
-func (DetectionComment) TableName() string {
-	return "detection_comments"
-}

--- a/internal/datastore/v2/entities/detection_lock.go
+++ b/internal/datastore/v2/entities/detection_lock.go
@@ -12,8 +12,3 @@ type DetectionLock struct {
 	// Relationship
 	Detection *Detection `gorm:"foreignKey:DetectionID;constraint:OnDelete:CASCADE,OnUpdate:CASCADE"`
 }
-
-// TableName returns the table name for GORM.
-func (DetectionLock) TableName() string {
-	return "detection_locks"
-}

--- a/internal/datastore/v2/entities/detection_prediction.go
+++ b/internal/datastore/v2/entities/detection_prediction.go
@@ -13,8 +13,3 @@ type DetectionPrediction struct {
 	Detection *Detection `gorm:"foreignKey:DetectionID;constraint:OnDelete:CASCADE,OnUpdate:CASCADE"`
 	Label     *Label     `gorm:"foreignKey:LabelID"`
 }
-
-// TableName returns the table name for GORM.
-func (DetectionPrediction) TableName() string {
-	return "detection_predictions"
-}

--- a/internal/datastore/v2/entities/detection_review.go
+++ b/internal/datastore/v2/entities/detection_review.go
@@ -22,8 +22,3 @@ type DetectionReview struct {
 	// Relationship
 	Detection *Detection `gorm:"foreignKey:DetectionID;constraint:OnDelete:CASCADE,OnUpdate:CASCADE"`
 }
-
-// TableName returns the table name for GORM.
-func (DetectionReview) TableName() string {
-	return "detection_reviews"
-}

--- a/internal/datastore/v2/entities/dynamic_threshold.go
+++ b/internal/datastore/v2/entities/dynamic_threshold.go
@@ -22,8 +22,3 @@ type DynamicThreshold struct {
 	// Relationship
 	Label *Label `gorm:"foreignKey:LabelID"`
 }
-
-// TableName returns the table name for GORM.
-func (DynamicThreshold) TableName() string {
-	return "dynamic_thresholds"
-}

--- a/internal/datastore/v2/entities/hourly_weather.go
+++ b/internal/datastore/v2/entities/hourly_weather.go
@@ -24,8 +24,3 @@ type HourlyWeather struct {
 	WeatherIcon   string    `gorm:"size:20"`
 	CreatedAt     time.Time `gorm:"autoCreateTime"`
 }
-
-// TableName returns the table name for GORM.
-func (HourlyWeather) TableName() string {
-	return "hourly_weathers"
-}

--- a/internal/datastore/v2/entities/image_cache.go
+++ b/internal/datastore/v2/entities/image_cache.go
@@ -21,8 +21,3 @@ type ImageCache struct {
 	// Relationship
 	Label *Label `gorm:"foreignKey:LabelID"`
 }
-
-// TableName returns the table name for GORM.
-func (ImageCache) TableName() string {
-	return "image_caches"
-}

--- a/internal/datastore/v2/entities/label.go
+++ b/internal/datastore/v2/entities/label.go
@@ -21,8 +21,3 @@ type Label struct {
 	LabelType      *LabelType      `gorm:"foreignKey:LabelTypeID"`
 	TaxonomicClass *TaxonomicClass `gorm:"foreignKey:TaxonomicClassID"`
 }
-
-// TableName returns the table name for GORM.
-func (Label) TableName() string {
-	return "labels"
-}

--- a/internal/datastore/v2/entities/label_type.go
+++ b/internal/datastore/v2/entities/label_type.go
@@ -8,11 +8,6 @@ type LabelType struct {
 	Name string `gorm:"size:30;uniqueIndex;not null"`
 }
 
-// TableName returns the table name for GORM.
-func (LabelType) TableName() string {
-	return "label_types"
-}
-
 // DefaultLabelTypes returns the default label type values to seed on initialization.
 func DefaultLabelTypes() []LabelType {
 	return []LabelType{

--- a/internal/datastore/v2/entities/migration_dirty_id.go
+++ b/internal/datastore/v2/entities/migration_dirty_id.go
@@ -8,8 +8,3 @@ type MigrationDirtyID struct {
 	DetectionID uint      `gorm:"primaryKey"`
 	CreatedAt   time.Time `gorm:"autoCreateTime"`
 }
-
-// TableName returns the table name for GORM.
-func (MigrationDirtyID) TableName() string {
-	return "migration_dirty_ids"
-}

--- a/internal/datastore/v2/entities/migration_state.go
+++ b/internal/datastore/v2/entities/migration_state.go
@@ -48,11 +48,6 @@ type MigrationState struct {
 	UpdatedAt        time.Time `gorm:"autoUpdateTime"`
 }
 
-// TableName returns the table name for GORM.
-func (MigrationState) TableName() string {
-	return "migration_state"
-}
-
 // Progress returns the migration progress as a percentage (0-100).
 func (m *MigrationState) Progress() float64 {
 	if m.TotalRecords == 0 {

--- a/internal/datastore/v2/entities/notification_history.go
+++ b/internal/datastore/v2/entities/notification_history.go
@@ -16,8 +16,3 @@ type NotificationHistory struct {
 	// Relationship
 	Label *Label `gorm:"foreignKey:LabelID"`
 }
-
-// TableName returns the table name for GORM.
-func (NotificationHistory) TableName() string {
-	return "notification_histories"
-}

--- a/internal/datastore/v2/entities/taxonomic_class.go
+++ b/internal/datastore/v2/entities/taxonomic_class.go
@@ -7,11 +7,6 @@ type TaxonomicClass struct {
 	Name string `gorm:"size:50;uniqueIndex;not null"`
 }
 
-// TableName returns the table name for GORM.
-func (TaxonomicClass) TableName() string {
-	return "taxonomic_classes"
-}
-
 // DefaultTaxonomicClasses returns the default taxonomic class values to seed on initialization.
 func DefaultTaxonomicClasses() []TaxonomicClass {
 	return []TaxonomicClass{

--- a/internal/datastore/v2/entities/threshold_event.go
+++ b/internal/datastore/v2/entities/threshold_event.go
@@ -18,8 +18,3 @@ type ThresholdEvent struct {
 	// Relationship
 	Label *Label `gorm:"foreignKey:LabelID"`
 }
-
-// TableName returns the table name for GORM.
-func (ThresholdEvent) TableName() string {
-	return "threshold_events"
-}

--- a/internal/datastore/v2/migration/mysql_integration_test.go
+++ b/internal/datastore/v2/migration/mysql_integration_test.go
@@ -68,7 +68,7 @@ func TestMySQL_MigrationInfrastructure_Initializes(t *testing.T) {
 	require.NoError(t, err, "failed to initialize MySQL v2 schema")
 
 	// Verify tables exist
-	require.True(t, manager.Exists(), "v2 migration_state table should exist")
+	require.True(t, manager.Exists(), "v2 migration_states table should exist")
 	require.True(t, manager.IsMySQL(), "should identify as MySQL")
 
 	t.Log("MySQL migration infrastructure initialized successfully")

--- a/internal/datastore/v2/mysql_manager.go
+++ b/internal/datastore/v2/mysql_manager.go
@@ -189,8 +189,13 @@ func (m *MySQLManager) Delete() error {
 		prefix + "ai_models",
 		prefix + "taxonomic_classes",
 		prefix + "label_types",
-		prefix + "migration_state",
+		prefix + "migration_states",
 		prefix + "migration_dirty_ids",
+		// Alert tables (drop children first)
+		prefix + "alert_histories",
+		prefix + "alert_actions",
+		prefix + "alert_conditions",
+		prefix + "alert_rules",
 		// Auxiliary tables
 		prefix + "hourly_weathers",
 		prefix + "daily_events",
@@ -212,9 +217,9 @@ func (m *MySQLManager) Delete() error {
 
 // Exists checks if v2 tables exist in the MySQL database.
 func (m *MySQLManager) Exists() bool {
-	// Check if the migration_state table exists as an indicator.
+	// Check if the migration_states table exists as an indicator.
 	// Must account for the v2_ prefix when in migration mode.
-	tableName := m.tablePrefix + "migration_state"
+	tableName := m.tablePrefix + "migration_states"
 	return m.db.Migrator().HasTable(tableName)
 }
 

--- a/internal/datastore/v2/mysql_manager_test.go
+++ b/internal/datastore/v2/mysql_manager_test.go
@@ -49,7 +49,7 @@ func TestV2TableName(t *testing.T) {
 	}{
 		{"labels", "v2_labels"},
 		{"detections", "v2_detections"},
-		{"migration_state", "v2_migration_state"},
+		{"migration_states", "v2_migration_states"},
 	}
 
 	for _, tt := range tests {
@@ -90,7 +90,7 @@ func TestMySQLManager_Initialize(t *testing.T) {
 	assert.True(t, mgr.db.Migrator().HasTable(V2TableName("labels")))
 	assert.True(t, mgr.db.Migrator().HasTable(V2TableName("ai_models")))
 	assert.True(t, mgr.db.Migrator().HasTable(V2TableName("detections")))
-	assert.True(t, mgr.db.Migrator().HasTable(V2TableName("migration_state")))
+	assert.True(t, mgr.db.Migrator().HasTable(V2TableName("migration_states")))
 }
 
 func TestMySQLManager_Initialize_SeedsBirdNETModel(t *testing.T) {
@@ -152,7 +152,7 @@ func TestMySQLManager_Delete(t *testing.T) {
 	// After deletion, v2 tables should not exist
 	assert.False(t, mgr.db.Migrator().HasTable(V2TableName("labels")))
 	assert.False(t, mgr.db.Migrator().HasTable(V2TableName("detections")))
-	assert.False(t, mgr.db.Migrator().HasTable(V2TableName("migration_state")))
+	assert.False(t, mgr.db.Migrator().HasTable(V2TableName("migration_states")))
 }
 
 func TestMySQLManager_Path(t *testing.T) {

--- a/internal/datastore/v2/repository/doc.go
+++ b/internal/datastore/v2/repository/doc.go
@@ -9,25 +9,17 @@
 //
 // The useV2Prefix constructor parameter controls this behavior.
 //
-// # IMPORTANT: Preload/Association Hazard
+// # Table Prefix Behavior
 //
-// When useV2Prefix is true (MySQL mode), DO NOT use GORM's automatic
-// Preload(), Joins(), or Association features without explicit table
-// configuration. The entity structs have hardcoded TableName() methods
-// returning standard names ("labels"), which will cause GORM to query
-// the wrong tables.
+// V2 entity structs no longer define TableName() methods. GORM's
+// NamingStrategy.TablePrefix (set via UseV2Prefix in MySQLConfig)
+// controls whether tables use the "v2_" prefix. This means standard
+// GORM operations (Preload, Joins, Find, etc.) automatically use
+// the correct prefixed table names when the db instance has the
+// prefix configured.
 //
-// WRONG (will query "labels" instead of "v2_labels"):
-//
-//	db.Preload("Label").Find(&detections)
-//
-// CORRECT (use explicit table names):
-//
-//	db.Table("v2_detections").
-//	    Joins("JOIN v2_labels ON v2_labels.id = v2_detections.label_id").
-//	    Find(&detections)
-//
-// Or use the repository methods which handle this correctly.
+// Repository implementations use explicit db.Table() calls with
+// constants from tables.go for clarity and consistency.
 //
 // # Error Handling
 //

--- a/internal/datastore/v2/repository/tables.go
+++ b/internal/datastore/v2/repository/tables.go
@@ -19,6 +19,11 @@ const (
 	tableDynamicThresholds   = "dynamic_thresholds"
 	tableThresholdEvents     = "threshold_events"
 	tableNotificationHistory = "notification_histories"
+	// Alert tables
+	tableAlertRules      = "alert_rules"
+	tableAlertConditions = "alert_conditions"
+	tableAlertActions    = "alert_actions"
+	tableAlertHistories  = "alert_histories"
 )
 
 // Table name constants for v2 prefixed schema (MySQL).
@@ -40,4 +45,9 @@ const (
 	tableV2DynamicThresholds   = "v2_dynamic_thresholds"
 	tableV2ThresholdEvents     = "v2_threshold_events"
 	tableV2NotificationHistory = "v2_notification_histories"
+	// Alert tables
+	tableV2AlertRules      = "v2_alert_rules"
+	tableV2AlertConditions = "v2_alert_conditions"
+	tableV2AlertActions    = "v2_alert_actions"
+	tableV2AlertHistories  = "v2_alert_histories"
 )

--- a/internal/datastore/v2/startup.go
+++ b/internal/datastore/v2/startup.go
@@ -250,9 +250,9 @@ func checkMySQLMigrationState(settings *conf.Settings) StartupState {
 	}
 	legacyExists := legacyCount > 0
 
-	// Check if v2_migration_state table exists (migration-era v2 tables)
+	// Check if v2_migration_states table exists (migration-era v2 tables)
 	var v2MigrationCount int64
-	tableName := v2TablePrefix + "migration_state"
+	tableName := v2TablePrefix + "migration_states"
 	err = db.Raw("SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = ? AND table_name = ?",
 		settings.Output.MySQL.Database, tableName).Scan(&v2MigrationCount).Error
 	if err != nil {
@@ -292,12 +292,26 @@ func checkMySQLMigrationState(settings *conf.Settings) StartupState {
 		}
 	}
 
-	// Fresh v2 exists (restart after fresh install) - no migration tables needed
-	if freshV2Exists && !v2MigrationExists {
+	// Fresh v2 exists WITHOUT legacy = genuine fresh install restart
+	if freshV2Exists && !v2MigrationExists && !legacyExists {
 		return StartupState{
 			MigrationStatus: entities.MigrationStatusCompleted,
 			V2Available:     true,
 			LegacyRequired:  false,
+			FreshInstall:    false,
+			Error:           nil,
+		}
+	}
+
+	// Fresh v2 exists WITH legacy = orphaned bare v2 tables from failed setup
+	// Clean up orphaned tables so migration infrastructure can start fresh
+	if freshV2Exists && !v2MigrationExists && legacyExists {
+		cleanupOrphanedBareV2Tables(db, settings.Output.MySQL.Database)
+		// After cleanup, treat as legacy-only mode
+		return StartupState{
+			MigrationStatus: entities.MigrationStatusIdle,
+			V2Available:     false,
+			LegacyRequired:  true,
 			FreshInstall:    false,
 			Error:           nil,
 		}
@@ -353,7 +367,7 @@ func ShouldSkipLegacyDatabase(settings *conf.Settings) bool {
 // CheckSQLiteHasV2Schema checks if a SQLite database at the given path is a fully initialized v2 database.
 // This is used to distinguish between a legacy database and a fresh v2 database.
 // Returns true only if the database has:
-//  1. The migration_state table (v2 schema indicator)
+//  1. The migration_states table (v2 schema indicator)
 //  2. A migration state record with COMPLETED status
 //
 // This prevents false positives from partially initialized databases.
@@ -381,9 +395,9 @@ func CheckSQLiteHasV2Schema(dbPath string) bool {
 	}
 	defer func() { _ = sqlDB.Close() }()
 
-	// Check if migration_state table exists (v2 schema indicator)
+	// Check if migration_states table exists (v2 schema indicator)
 	var tableCount int64
-	err = db.Raw("SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='migration_state'").Scan(&tableCount).Error
+	err = db.Raw("SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='migration_states'").Scan(&tableCount).Error
 	if err != nil || tableCount == 0 {
 		return false
 	}
@@ -401,7 +415,7 @@ func CheckSQLiteHasV2Schema(dbPath string) bool {
 
 // CheckMySQLHasFreshV2Schema checks if a MySQL database has fresh v2 tables (without v2_ prefix).
 // This is used to determine whether to use v2_ prefix for migration mode or no prefix for fresh installs.
-// Returns true if the fresh v2 schema exists (migration_state table without prefix).
+// Returns true if the fresh v2 schema exists (migration_states table without prefix).
 func CheckMySQLHasFreshV2Schema(settings *conf.Settings) bool {
 	// Build MySQL DSN
 	cfg := mysql.Config{
@@ -434,9 +448,9 @@ func CheckMySQLHasFreshV2Schema(settings *conf.Settings) bool {
 	}
 	defer func() { _ = sqlDB.Close() }()
 
-	// Check if fresh v2 migration_state table exists (no prefix)
+	// Check if fresh v2 migration_states table exists (no prefix)
 	var tableCount int64
-	err = db.Raw("SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = ? AND table_name = 'migration_state'",
+	err = db.Raw("SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = ? AND table_name = 'migration_states'",
 		settings.Output.MySQL.Database).Scan(&tableCount).Error
 	if err != nil || tableCount == 0 {
 		return false
@@ -444,11 +458,79 @@ func CheckMySQLHasFreshV2Schema(settings *conf.Settings) bool {
 
 	// Check if migration state is COMPLETED
 	var state entities.MigrationState
-	if err := db.Table("migration_state").First(&state).Error; err != nil {
+	if err := db.Table("migration_states").First(&state).Error; err != nil {
 		return false
 	}
 
 	return state.State == entities.MigrationStatusCompleted
+}
+
+// cleanupOrphanedBareV2Tables removes bare v2 tables that were created by a broken nightly
+// alongside existing legacy tables. These orphaned tables prevent the migration infrastructure
+// from starting fresh. Only v2-specific tables are dropped; legacy tables with real user data
+// (dynamic_thresholds, threshold_events, notification_histories, image_caches, daily_events,
+// hourly_weathers) are preserved.
+func cleanupOrphanedBareV2Tables(db *gorm.DB, database string) {
+	// Report discovery of orphaned tables to Sentry
+	sentry.WithScope(func(scope *sentry.Scope) {
+		scope.SetTag("component", "datastore-startup")
+		scope.SetTag("db_type", "mysql")
+		scope.SetTag("operation", "cleanupOrphanedBareV2Tables")
+		scope.SetFingerprint([]string{"datastore-startup", "mysql", "cleanupOrphanedBareV2Tables"})
+
+		telemetry.CaptureMessage(
+			"Orphaned bare v2 tables found alongside legacy data, cleaning up",
+			sentry.LevelWarning,
+			"datastore-startup",
+		)
+	})
+
+	// Bare v2-only tables that do NOT collide with legacy tables.
+	// Drop in reverse dependency order (children before parents) to avoid FK violations.
+	// Table names use the OLD singular forms (migration_state, alert_history) because
+	// the orphaned tables were created by code with TableName() overrides.
+	orphanedTables := []string{
+		// Alert children first, then parent
+		"alert_actions",
+		"alert_conditions",
+		"alert_history",
+		"alert_rules",
+		// Detection children first, then parent
+		"detection_locks",
+		"detection_comments",
+		"detection_reviews",
+		"detection_predictions",
+		"detections",
+		// Reference tables (labels referenced by detections, so drop after)
+		"audio_sources",
+		"ai_models",
+		"taxonomic_classes",
+		"label_types",
+		"labels",
+		// Migration tracking
+		"migration_dirty_ids",
+		"migration_state",
+	}
+
+	for _, table := range orphanedTables {
+		if err := db.Exec(fmt.Sprintf("DROP TABLE IF EXISTS `%s`", table)).Error; err != nil {
+			reportStartupError("mysql", "cleanupOrphanedTable_"+table, err, database)
+		}
+	}
+
+	// Report successful cleanup
+	sentry.WithScope(func(scope *sentry.Scope) {
+		scope.SetTag("component", "datastore-startup")
+		scope.SetTag("db_type", "mysql")
+		scope.SetTag("operation", "cleanupOrphanedBareV2TablesComplete")
+		scope.SetFingerprint([]string{"datastore-startup", "mysql", "cleanupOrphanedBareV2TablesComplete"})
+
+		telemetry.CaptureMessage(
+			"Orphaned bare v2 tables cleanup completed successfully",
+			sentry.LevelInfo,
+			"datastore-startup",
+		)
+	})
 }
 
 // CheckAndConsolidateAtStartup checks for and performs database consolidation at startup.


### PR DESCRIPTION
## Summary

Fixes #2149 — MySQL users with existing legacy databases cannot upgrade to builds containing the v2 schema because `AutoMigrate` fails on startup.

### Root Cause

All 22 v2 entity structs had hardcoded `TableName()` methods that override GORM's `NamingStrategy.TablePrefix`, making `UseV2Prefix` completely ineffective for `AutoMigrate`. Six auxiliary tables (`dynamic_thresholds`, `threshold_events`, `notification_histories`, `image_caches`, `daily_events`, `hourly_weathers`) share names with legacy tables, causing `NOT NULL` constraint failures when GORM tries to add `label_id` columns to existing legacy rows.

### Fix

- **Remove all `TableName()` methods** from 22 v2 entities — GORM auto-naming produces identical names for 20/22 entities; accept standard plural for the 2 mismatches (`migration_state` → `migration_states`, `alert_history` → `alert_histories`, pre-release safe)
- **Set `UseV2Prefix: true` in migration mode** — `NamingStrategy.TablePrefix` now takes effect, creating `v2_`-prefixed tables that don't collide with legacy
- **Fix startup detection** for orphaned bare v2 tables from failed `nightly-20260309` setup — add `legacyExists` guard and `cleanupOrphanedBareV2Tables()` to recover gracefully
- **Update `Delete()`** with correct table names and add missing alert tables
- **Add alert table constants** to `repository/tables.go`
- **Update `doc.go`** — Preload hazard is resolved by this change

### Impact

- SQLite unaffected (uses separate database file)
- Repository layer unaffected (uses explicit `db.Table()` with constants)
- Fresh MySQL installs unaffected (`UseV2Prefix: false`, auto-names match)

## Test plan

- [x] `go test -race ./internal/datastore/v2/...` — 6/6 packages pass
- [x] `go test -race -run TestLegacy ./internal/api/v2/...` — passes
- [x] `golangci-lint run ./internal/datastore/v2/...` — 0 issues
- [x] Pre-commit hooks pass (full project lint: 0 issues)
- [ ] Manual: Fresh MySQL install creates v2 tables without prefix
- [ ] Manual: MySQL with legacy `notes` table creates v2 tables with `v2_` prefix
- [ ] Manual: MySQL with orphaned bare v2 + legacy → cleanup + legacy mode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Simplified database entity definitions by removing explicit table name overrides, allowing the ORM to automatically apply naming conventions.

* **Bug Fixes**
  * Ensured v2 database tables are properly isolated using the v2_ prefix, preventing conflicts with legacy tables.
  * Added cleanup of orphaned v2-only tables during migration to legacy systems, preserving existing data integrity.
  * Standardized migration state table naming across the database layer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->