### PR TITLE
chore: remove dead code and unused variables across diskmanager, myaudio, conf

### DIFF
--- a/internal/conf/security_helpers_test.go
+++ b/internal/conf/security_helpers_test.go
@@ -10,14 +10,11 @@ import (
 // Test constants for Security helper methods.
 const (
 	// Test hostnames and domains
-	testHostExample     = "birdnet.example.com"
-	testHostIgnored     = "ignored.example.com"
-	testHostDifferent   = "different.example.com"
-	testHostSubdomain   = "my.birdnet.home.arpa"
-	testHostLocalhost   = "localhost"
-	testHostIP          = "192.168.1.100"
-	testHostIPv6        = "2001:db8::1"
-	testHostIPv6Bracket = "[2001:db8::1]"
+	testHostExample   = "birdnet.example.com"
+	testHostIgnored   = "ignored.example.com"
+	testHostSubdomain = "my.birdnet.home.arpa"
+	testHostIP        = "192.168.1.100"
+	testHostIPv6      = "2001:db8::1"
 
 	// Test ports
 	testPortCustom = "8080"

--- a/internal/conf/test_helpers_test.go
+++ b/internal/conf/test_helpers_test.go
@@ -1,7 +1,6 @@
 package conf
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -35,87 +34,4 @@ func assertValidationError(t *testing.T, err error, validationType string) {
 		assert.Equal(t, validationType, ctx,
 			"expected validation_type = %s, got %s", validationType, ctx)
 	}
-}
-
-// assertValidationPasses verifies that a ValidationResult indicates success.
-func assertValidationPasses(t *testing.T, result ValidationResult) {
-	t.Helper()
-	assert.True(t, result.Valid, "expected valid config, got errors: %v", result.Errors)
-	assert.Empty(t, result.Errors, "expected no errors")
-}
-
-// assertValidationFails verifies that a ValidationResult indicates failure.
-func assertValidationFails(t *testing.T, result ValidationResult) {
-	t.Helper()
-	assert.False(t, result.Valid, "expected invalid config to fail validation")
-	assert.NotEmpty(t, result.Errors, "expected validation errors but got none")
-}
-
-// assertErrorContains verifies that the ValidationResult contains an error
-// message that includes the expected substring.
-func assertErrorContains(t *testing.T, result ValidationResult, expectedSubstring string) {
-	t.Helper()
-	for _, err := range result.Errors {
-		if strings.Contains(err, expectedSubstring) {
-			return
-		}
-	}
-	assert.Fail(t, "expected error not found",
-		"expected error containing %q, got errors: %v", expectedSubstring, result.Errors)
-}
-
-// assertWarningContains verifies that the ValidationResult contains a warning
-// message that includes the expected substring.
-func assertWarningContains(t *testing.T, result ValidationResult, expectedSubstring string) {
-	t.Helper()
-	for _, warning := range result.Warnings {
-		if strings.Contains(warning, expectedSubstring) {
-			return
-		}
-	}
-	assert.Fail(t, "expected warning not found",
-		"expected warning containing %q, got warnings: %v", expectedSubstring, result.Warnings)
-}
-
-// assertNoWarnings verifies that the ValidationResult contains no warnings.
-func assertNoWarnings(t *testing.T, result ValidationResult) {
-	t.Helper()
-	assert.Empty(t, result.Warnings, "expected no warnings")
-}
-
-// assertSeasonExists verifies that a specific season exists in the seasonal tracking settings
-// and optionally checks its start month.
-func assertSeasonExists(t *testing.T, settings *Settings, seasonName string, expectedStartMonth int) {
-	t.Helper()
-	season, exists := settings.Realtime.SpeciesTracking.SeasonalTracking.Seasons[seasonName]
-	require.True(t, exists, "expected season %q to exist", seasonName)
-	if expectedStartMonth > 0 {
-		assert.Equal(t, expectedStartMonth, season.StartMonth,
-			"expected season %q to start in month %d", seasonName, expectedStartMonth)
-	}
-}
-
-// assertSeasonsCount verifies the number of seasons in seasonal tracking settings.
-func assertSeasonsCount(t *testing.T, settings *Settings, expectedCount int) {
-	t.Helper()
-	got := len(settings.Realtime.SpeciesTracking.SeasonalTracking.Seasons)
-	assert.Equal(t, expectedCount, got, "season count mismatch")
-}
-
-// assertMQTTEnabled verifies that MQTT is enabled in settings.
-func assertMQTTEnabled(t *testing.T, settings *Settings) {
-	t.Helper()
-	assert.True(t, settings.Realtime.MQTT.Enabled, "expected MQTT to be enabled")
-}
-
-// assertSpeciesTrackingEnabled verifies that species tracking is enabled in settings.
-func assertSpeciesTrackingEnabled(t *testing.T, settings *Settings) {
-	t.Helper()
-	assert.True(t, settings.Realtime.SpeciesTracking.Enabled, "expected species tracking to be enabled")
-}
-
-// assertAudioExportEnabled verifies that audio export is enabled in settings.
-func assertAudioExportEnabled(t *testing.T, settings *Settings) {
-	t.Helper()
-	assert.True(t, settings.Realtime.Audio.Export.Enabled, "expected audio export to be enabled")
 }

--- a/internal/diskmanager/file_utils.go
+++ b/internal/diskmanager/file_utils.go
@@ -142,7 +142,7 @@ func createWalkFunc(state *walkState) filepath.WalkFunc {
 }
 
 // handleWalkError handles errors during filepath.Walk, specifically temp file race conditions
-func handleWalkError(err error, path string, debug bool) error {
+func handleWalkError(err error, path string, _ bool) error {
 	// Handle race condition where temp files are renamed between directory
 	// listing and lstat call. If the error is "no such file or directory"
 	// and the path appears to be a temp file, continue walking.

--- a/internal/diskmanager/policy_age_test.go
+++ b/internal/diskmanager/policy_age_test.go
@@ -11,25 +11,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/logger"
 )
-
-// Define variables for mocking
-var (
-	// Function variables for mocking
-	diskUsageFunc            = GetDiskUsage
-	parseRetentionPeriodFunc = conf.ParseRetentionPeriod
-)
-
-// Mock functions
-func mockGetDiskUsage(path string, usage float64) (float64, error) {
-	return usage, nil
-}
-
-func mockParseRetentionPeriod(period string, hours int) (int, error) {
-	return hours, nil
-}
 
 // MockDB is a mock implementation of the database interface for testing
 type MockDB struct{}
@@ -515,8 +498,8 @@ func deleteTestFile(file *FileInfo, deletedFiles map[string]bool, speciesTotalCo
 // simulateAgeBasedCleanup is a test-specific helper that simulates the core logic
 // of AgeBasedCleanup using real files in a temporary directory.
 func simulateAgeBasedCleanup(
-	quit <-chan struct{},
-	db Interface,
+	_ <-chan struct{},
+	_ Interface,
 	baseDir string,
 	testFiles []string,
 	deletedFiles map[string]bool,

--- a/internal/diskmanager/policy_usage_test.go
+++ b/internal/diskmanager/policy_usage_test.go
@@ -13,14 +13,6 @@ import (
 	mock_diskmanager "github.com/tphakala/birdnet-go/internal/diskmanager/mocks"
 )
 
-// Original function signature references for testing
-var (
-	originalGetDiskUsage    = GetDiskUsage
-	originalGetAudioFiles   = GetAudioFiles
-	originalOsRemove        = osRemove
-	originalConfGetSettings = conf.GetSettings
-)
-
 // MockFileInfo implements os.FileInfo for testing
 type MockFileInfo struct {
 	FileName    string
@@ -818,9 +810,9 @@ func TestUsageBasedCleanupReturnValues(t *testing.T) {
 
 // testUsageBasedCleanupWithRealFiles is a test-specific implementation that uses real files
 func testUsageBasedCleanupWithRealFiles(
-	quitChan chan struct{},
+	_ chan struct{},
 	db Interface,
-	baseDir string,
+	_ string,
 	testFiles []string,
 	deletedFiles map[string]bool,
 	initialDiskUsage float64,

--- a/internal/myaudio/buffer_pool_test.go
+++ b/internal/myaudio/buffer_pool_test.go
@@ -56,7 +56,7 @@ func runPoolConcurrencyGeneric(t *testing.T, numWorkers, opsPerWorker int,
 }
 
 // runPoolConcurrencyWithStats runs pool concurrency tests and verifies stats
-func runPoolConcurrencyWithStats(t *testing.T, bufferSize, numWorkers, opsPerWorker int,
+func runPoolConcurrencyWithStats(t *testing.T, _, numWorkers, opsPerWorker int,
 	getOp func() any, putOp func(any), validateBuffer func(any),
 	getStats func() PoolStatsProvider) {
 	t.Helper()

--- a/internal/myaudio/capture.go
+++ b/internal/myaudio/capture.go
@@ -742,7 +742,7 @@ func processAudioFrame(
 
 // handleDeviceStop contains the logic for attempting to restart the audio device
 // when it stops unexpectedly.
-func handleDeviceStop(captureDevice *malgo.Device, quitChan, restartChan chan struct{}, settings *conf.Settings, restarting *atomic.Int32) {
+func handleDeviceStop(captureDevice *malgo.Device, quitChan, restartChan chan struct{}, _ *conf.Settings, restarting *atomic.Int32) {
 	log := GetLogger()
 	// Ensure the flag is reset when this attempt concludes.
 	defer restarting.Store(0)

--- a/internal/myaudio/encode.go
+++ b/internal/myaudio/encode.go
@@ -14,12 +14,6 @@ import (
 	"github.com/tphakala/birdnet-go/internal/logger"
 )
 
-// seekableBuffer extends bytes.Buffer to add a Seek method, making it compatible with io.WriteSeeker.
-type seekableBuffer struct {
-	bytes.Buffer
-	pos int64
-}
-
 // recordFileOperationError is a helper function to record file operation errors and return the enhanced error
 func recordFileOperationError(operation, format, errorType string, enhancedErr error) error {
 	if fileMetrics != nil {

--- a/internal/myaudio/ffmpeg_error_context.go
+++ b/internal/myaudio/ffmpeg_error_context.go
@@ -41,7 +41,6 @@ var (
 	// Capture full TCP URL including credentials, IPv6, query params
 	// Pattern: "Connection to tcp://..." - captures everything after "Connection to "
 	reConnectionToTCP = regexp.MustCompile(`Connection to (tcp://\S+)`)
-	reRTSPStatus      = regexp.MustCompile(`Server returned (\d+)`)
 	reSSLError        = regexp.MustCompile(`SSL.*error|TLS.*error|certificate.*error`)
 )
 
@@ -433,7 +432,7 @@ func (ctx *ErrorContext) buildAuthFailureMessage() {
 }
 
 // extractAuthForbidden parses forbidden access details
-func (ctx *ErrorContext) extractAuthForbidden(output string) {
+func (ctx *ErrorContext) extractAuthForbidden(_ string) {
 	ctx.HTTPStatus = 403
 	ctx.PrimaryMessage = "Access forbidden"
 }
@@ -662,7 +661,7 @@ func (ctx *ErrorContext) buildDNSErrorMessage() {
 }
 
 // extractInvalidData parses invalid data details
-func (ctx *ErrorContext) extractInvalidData(output string) {
+func (ctx *ErrorContext) extractInvalidData(_ string) {
 	ctx.PrimaryMessage = "Invalid or corrupted stream data"
 }
 

--- a/internal/myaudio/ffmpeg_export.go
+++ b/internal/myaudio/ffmpeg_export.go
@@ -545,14 +545,6 @@ func ExportAudioWithCustomFFmpegArgs(pcmData []byte, ffmpegPath string, customAr
 	return ExportAudioWithCustomFFmpegArgsContext(context.Background(), pcmData, ffmpegPath, customArgs)
 }
 
-// runCustomFFmpegCommandToBuffer executes FFmpeg, piping PCM input and capturing codec output to a buffer.
-//
-// Deprecated: Prefer runCustomFFmpegCommandToBufferWithContext for cancellation/timeout control.
-func runCustomFFmpegCommandToBuffer(ffmpegPath string, pcmData []byte, customArgs []string) (*bytes.Buffer, error) {
-	// Call the context-aware version with a background context
-	return runCustomFFmpegCommandToBufferWithContext(context.Background(), ffmpegPath, pcmData, customArgs)
-}
-
 // ExportAudioWithCustomFFmpegArgsContext exports PCM data using FFmpeg with custom arguments directly to a memory buffer.
 // This is the context-aware version of ExportAudioWithCustomFFmpegArgs that allows timeout/cancellation.
 // ffmpegPath is the path to the FFmpeg executable.

--- a/internal/myaudio/ffmpeg_stream.go
+++ b/internal/myaudio/ffmpeg_stream.go
@@ -2069,17 +2069,6 @@ func (s *FFmpegStream) logStreamHealth() {
 	}
 }
 
-// isCircuitOpen checks if the circuit breaker is open
-// isCircuitOpenSilent checks if the circuit breaker is open without logging.
-// This is used by IsRestarting() to avoid log spam during health checks.
-func (s *FFmpegStream) isCircuitOpenSilent() bool {
-	s.circuitMu.Lock()
-	defer s.circuitMu.Unlock()
-
-	// Check if circuit was opened and we're still in cooldown
-	return !s.circuitOpenTime.IsZero() && time.Since(s.circuitOpenTime) < circuitBreakerCooldown
-}
-
 // circuitCooldownRemaining returns (remaining, true) if the circuit is open, or (0, false) otherwise.
 // This allows waiting only for the remaining cooldown period instead of the full duration.
 func (s *FFmpegStream) circuitCooldownRemaining() (time.Duration, bool) {

--- a/internal/myaudio/process.go
+++ b/internal/myaudio/process.go
@@ -38,13 +38,6 @@ func SetProcessMetrics(myAudioMetrics *metrics.MyAudioMetrics) {
 	})
 }
 
-// getProcessMetrics returns the current metrics instance in a thread-safe manner
-func getProcessMetrics() *metrics.MyAudioMetrics {
-	processMetricsMutex.RLock()
-	defer processMetricsMutex.RUnlock()
-	return processMetrics
-}
-
 // InitFloat32Pool initializes the global float32 pool for audio conversion.
 // This should be called during application startup.
 func InitFloat32Pool() error {

--- a/internal/myaudio/test_helpers_test.go
+++ b/internal/myaudio/test_helpers_test.go
@@ -3,12 +3,10 @@
 package myaudio
 
 import (
-	"context"
 	"io"
 	"os"
 	"os/exec"
 	"testing"
-	"time"
 
 	"github.com/tphakala/birdnet-go/internal/logger"
 )
@@ -96,81 +94,4 @@ func newTestRegistry() *AudioSourceRegistry {
 		refCounts:     make(map[string]*int32),
 		logger:        getTestLogger(),
 	}
-}
-
-// --- Stream Helpers ---
-
-// TestStreamResult holds a test stream and its audio channel for cleanup.
-type TestStreamResult struct {
-	Stream    *FFmpegStream
-	AudioChan chan UnifiedAudioData
-	closed    bool
-}
-
-// Close cleans up the test stream and channel.
-// Safe to call multiple times.
-func (r *TestStreamResult) Close() {
-	if r.closed {
-		return
-	}
-	r.closed = true
-	if r.Stream != nil {
-		r.Stream.Stop()
-	}
-	if r.AudioChan != nil {
-		close(r.AudioChan)
-	}
-}
-
-// newTestStream creates a new FFmpegStream for testing with a default buffer size.
-// Returns a TestStreamResult that should be cleaned up with Close() or via t.Cleanup().
-func newTestStream(t *testing.T, url string) *TestStreamResult {
-	t.Helper()
-	return newTestStreamWithBuffer(t, url, 10)
-}
-
-// newTestStreamWithBuffer creates a new FFmpegStream for testing with a custom buffer size.
-func newTestStreamWithBuffer(t *testing.T, url string, bufferSize int) *TestStreamResult {
-	t.Helper()
-	audioChan := make(chan UnifiedAudioData, bufferSize)
-	stream := NewFFmpegStream(url, "tcp", audioChan)
-	result := &TestStreamResult{
-		Stream:    stream,
-		AudioChan: audioChan,
-	}
-	t.Cleanup(result.Close)
-	return result
-}
-
-// --- Context Helpers ---
-
-// testContextWithTimeout creates a context with the given timeout and registers cleanup.
-// Uses t.Cleanup() to ensure the cancel function is called.
-func testContextWithTimeout(t *testing.T, timeout time.Duration) context.Context {
-	t.Helper()
-	ctx, cancel := context.WithTimeout(t.Context(), timeout)
-	t.Cleanup(cancel)
-	return ctx
-}
-
-// testContext creates a context with a default 5-second timeout for tests.
-func testContext(t *testing.T) context.Context {
-	t.Helper()
-	return testContextWithTimeout(t, 5*time.Second)
-}
-
-// --- Source Config Helpers ---
-
-// newTestSourceConfig creates a SourceConfig for testing with common defaults.
-func newTestSourceConfig(id, displayName string, sourceType SourceType) SourceConfig {
-	return SourceConfig{
-		ID:          id,
-		DisplayName: displayName,
-		Type:        sourceType,
-	}
-}
-
-// newTestRTSPConfig creates a SourceConfig for RTSP sources with common defaults.
-func newTestRTSPConfig(id, displayName string) SourceConfig {
-	return newTestSourceConfig(id, displayName, SourceTypeRTSP)
 }


### PR DESCRIPTION
## Summary

- Remove unused functions, variables, types, and parameters across `diskmanager`, `myaudio`, and `conf` packages
- Rename unused function parameters to `_` where the function signature must be preserved
- Clean up orphaned imports (`conf`, `strings`, `context`, `time`) left by deletions
- Net reduction: **238 lines deleted**, 14 lines changed (param renames)

### Changes by package

**`internal/diskmanager/`**: Remove unused mock vars (`diskUsageFunc`, `parseRetentionPeriodFunc`), mock functions (`mockGetDiskUsage`, `mockParseRetentionPeriod`), original function refs (`originalGetDiskUsage`, etc.). Rename unused params in `simulateAgeBasedCleanup`, `testUsageBasedCleanupWithRealFiles`, `handleWalkError`.

**`internal/myaudio/`**: Remove unused regex `reRTSPStatus`, type `seekableBuffer`, functions `getProcessMetrics`, `runCustomFFmpegCommandToBuffer`, `isCircuitOpenSilent`, and test helpers (`newTestStream`, `testContext`, `newTestRTSPConfig` + their now-orphaned dependencies). Rename unused params in `extractAuthForbidden`, `extractInvalidData`, `handleDeviceStop`, `runPoolConcurrencyWithStats`.

**`internal/conf/`**: Remove unused test constants (`testHostDifferent`, `testHostLocalhost`, `testHostIPv6Bracket`) and 10 unused assertion helpers from `test_helpers_test.go`.

## Test plan

- [x] `go test -race ./internal/diskmanager/...` passes
- [x] `go test -race ./internal/myaudio/...` passes
- [x] `go test -race ./internal/conf/...` passes
- [x] `golangci-lint run -v` — 0 issues on affected packages
- [x] Pre-commit hooks pass (full project lint)

Fixes #2175

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unused internal test utilities and helper functions throughout the codebase.
  * Simplified internal function signatures by eliminating unused parameters.
  * Cleaned up unused type definitions and removed redundant internal utility functions.
  * Optimized import statements and removed obsolete code components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->