### PR TITLE
fix(tests): prevent ETXTBSY race in createTestScript helper

### DIFF
--- a/internal/analysis/processor/execute_internal_test.go
+++ b/internal/analysis/processor/execute_internal_test.go
@@ -22,13 +22,22 @@ const osWindows = "windows"
 // =============================================================================
 
 // createTestScript creates a temporary executable shell script with the given content.
-// Uses t.TempDir() for automatic cleanup and os.WriteFile for atomic write,
-// which avoids ETXTBSY ("text file busy") races on CI where Close() and exec
-// can overlap at the kernel level.
+// Uses t.TempDir() for automatic cleanup. Explicitly syncs the file to disk before
+// closing to prevent ETXTBSY ("text file busy") races where the kernel still holds
+// a write reference when exec is called immediately after.
 func createTestScript(t *testing.T, name, content string) string {
 	t.Helper()
 	scriptPath := filepath.Join(t.TempDir(), name)
-	require.NoError(t, os.WriteFile(scriptPath, []byte(content), 0o755)) //nolint:gosec // executable permission needed for test
+
+	f, err := os.OpenFile(scriptPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o755) //nolint:gosec // executable permission needed for test
+	require.NoError(t, err)
+
+	_, err = f.WriteString(content)
+	require.NoError(t, err)
+
+	require.NoError(t, f.Sync())
+	require.NoError(t, f.Close())
+
 	return scriptPath
 }
 


### PR DESCRIPTION
## Summary

- Replace `os.WriteFile` with explicit open/write/sync/close sequence in the `createTestScript` test helper
- `os.WriteFile` doesn't call `fsync()`, so the kernel may still hold a write reference when `exec` is called immediately after, causing intermittent `fork/exec: text file busy` (ETXTBSY) errors
- The explicit `f.Sync()` ensures the file data is flushed to disk before any subsequent exec

## Test plan

- [x] Ran `TestExecuteCommandAction_WithParameters` 20 times with `-race -count=1` — all pass
- [x] Full package tests pass: `go test -race -v ./internal/analysis/processor/...`
- [x] Linter clean: `golangci-lint run -v ./internal/analysis/processor/...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by enhancing file synchronization in test script execution to prevent potential race conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->