### PR TITLE
refactor(privacy): centralize path anonymization from telemetry into privacy package

### DIFF
--- a/internal/privacy/privacy.go
+++ b/internal/privacy/privacy.go
@@ -89,6 +89,14 @@ const (
 const (
 	// minWindowsPathLen is the minimum length for a Windows drive path (e.g., "C:")
 	minWindowsPathLen = 2
+
+	// stacktracePathSegments is the number of trailing path segments preserved by
+	// AnonymizeStacktracePath for debugging context (e.g., "telemetry/sentry.go").
+	stacktracePathSegments = 2
+
+	// redactedPathPrefix is the prefix used to replace leading path segments in
+	// AnonymizeStacktracePath.
+	redactedPathPrefix = "<redacted>"
 )
 
 // Constants for user agent parsing
@@ -770,6 +778,25 @@ func AnonymizePath(path string) string {
 	}
 
 	return result
+}
+
+// AnonymizeStacktracePath strips absolute path prefixes from file paths used in
+// stacktraces, preserving only the last two segments for debugging context
+// (e.g., "/home/user/go/src/birdnet-go/internal/telemetry/sentry.go" becomes
+// "<redacted>/internal/telemetry"). Windows backslash separators are normalized
+// to forward slashes. Paths with two or fewer segments are returned as-is after
+// normalization, since they contain no sensitive directory information.
+func AnonymizeStacktracePath(path string) string {
+	if path == "" {
+		return path
+	}
+	// Normalize Windows paths
+	normalized := strings.ReplaceAll(path, windowsPathSeparator, unixPathSeparator)
+	parts := strings.Split(normalized, unixPathSeparator)
+	if len(parts) <= stacktracePathSegments {
+		return normalized // Short paths like "telemetry/sentry.go" are safe
+	}
+	return redactedPathPrefix + unixPathSeparator + strings.Join(parts[len(parts)-stacktracePathSegments:], unixPathSeparator)
 }
 
 // isBot checks if the user agent string indicates a bot, crawler, or spider

--- a/internal/privacy/privacy_test.go
+++ b/internal/privacy/privacy_test.go
@@ -2101,3 +2101,51 @@ func TestScrubMessage_ScrubbsFilePaths(t *testing.T) {
 		})
 	}
 }
+
+func TestAnonymizeStacktracePath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "empty path",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "short path with one segment",
+			input:    "sentry.go",
+			expected: "sentry.go",
+		},
+		{
+			name:     "short path with two segments",
+			input:    "telemetry/sentry.go",
+			expected: "telemetry/sentry.go",
+		},
+		{
+			name:     "absolute Unix path",
+			input:    "/home/user/go/src/birdnet-go/internal/telemetry/sentry.go",
+			expected: "<redacted>/telemetry/sentry.go",
+		},
+		{
+			name:     "three segments",
+			input:    "internal/telemetry/sentry.go",
+			expected: "<redacted>/telemetry/sentry.go",
+		},
+		{
+			name:     "Windows path",
+			input:    `C:\Users\John\go\src\birdnet-go\internal\telemetry\sentry.go`,
+			expected: "<redacted>/telemetry/sentry.go",
+		},
+		{
+			name:     "mixed separators",
+			input:    `C:\Users\John/internal\telemetry/sentry.go`,
+			expected: "<redacted>/telemetry/sentry.go",
+		},
+	}
+
+	runScrubTests(t, AnonymizeStacktracePath, tests)
+}

--- a/internal/telemetry/sentry.go
+++ b/internal/telemetry/sentry.go
@@ -234,26 +234,11 @@ func scrubStacktrace(st *sentry.Stacktrace) {
 	}
 	for j := range st.Frames {
 		frame := &st.Frames[j]
-		frame.AbsPath = anonymizeFilePath(frame.AbsPath)
+		frame.AbsPath = privacy.AnonymizeStacktracePath(frame.AbsPath)
 		if strings.Contains(frame.Filename, "/") || strings.Contains(frame.Filename, "\\") {
-			frame.Filename = anonymizeFilePath(frame.Filename)
+			frame.Filename = privacy.AnonymizeStacktracePath(frame.Filename)
 		}
 	}
-}
-
-// anonymizeFilePath replaces directory paths with generic markers, preserving
-// the last two path segments for debugging context (e.g., "telemetry/sentry.go").
-func anonymizeFilePath(path string) string {
-	if path == "" {
-		return path
-	}
-	// Normalize Windows paths
-	normalized := strings.ReplaceAll(path, "\\", "/")
-	parts := strings.Split(normalized, "/")
-	if len(parts) <= 2 {
-		return normalized // Short paths like "telemetry/sentry.go" are safe
-	}
-	return "<redacted>/" + strings.Join(parts[len(parts)-2:], "/")
 }
 
 // applyPrivacyFiltersWithLogging applies privacy filters and logs what was removed


### PR DESCRIPTION
## Summary

- Move `anonymizeFilePath()` from `internal/telemetry/sentry.go` into `internal/privacy` as `AnonymizeStacktracePath()`
- Add unit tests covering empty paths, short paths, absolute Unix/Windows paths, and mixed separators
- Update `scrubStacktrace()` in sentry.go to call the centralized function

**Design note:** `AnonymizeStacktracePath` preserves the last two path segments for debugging context (e.g., `telemetry/sentry.go`), which is intentionally different from the existing `AnonymizePath()` that hashes all segments. The stacktrace variant prioritizes debuggability over full anonymization since the preserved segments are source code paths (package/file), not user data.

## Test plan

- [x] `go test -race -v ./internal/privacy/` — new `TestAnonymizeStacktracePath` passes
- [x] `go test -race -v ./internal/telemetry/` — existing tests pass (no behavior change)
- [x] `golangci-lint run -v` — zero issues

Fixes #2172

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced file path redaction in error stacktraces to improve privacy protection with consistent path normalization across different operating systems.
  * Strengthened test coverage for path anonymization functionality to ensure reliable privacy protection across various path formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->