### PR TITLE
fix(conf/diskmanager): complete ParsePercentage error context and extract config key constant

### DIFF
--- a/internal/conf/utils.go
+++ b/internal/conf/utils.go
@@ -281,7 +281,12 @@ func ParsePercentage(percentage, configKey string) (float64, error) {
 	if before, ok := strings.CutSuffix(percentage, "%"); ok {
 		value, err := strconv.ParseFloat(before, 64)
 		if err != nil {
-			return 0, err
+			return 0, errors.New(err).
+				Component("conf").
+				Category(errors.CategoryValidation).
+				Context("input", percentage).
+				Context("config_key", configKey).
+				Build()
 		}
 		return value, nil
 	}

--- a/internal/diskmanager/policy_common.go
+++ b/internal/diskmanager/policy_common.go
@@ -22,6 +22,9 @@ const deletionThrottleDelay = 100 * time.Millisecond
 // to prevent excessive I/O impact and allow other processes to use the disk
 const maxDeletionsPerRun = 1000
 
+// configKeyRetentionMaxUsage is the config key for the retention max usage percentage setting
+const configKeyRetentionMaxUsage = "retention.max_usage"
+
 // Package-level metrics with explicit synchronization
 var (
 	// Thread-safe diskMetrics with explicit synchronization
@@ -397,7 +400,7 @@ func categorizeFilePath(path string) string {
 //   - err: error if check failed (nil on success)
 func ShouldSkipUsageBasedCleanup(retention *conf.RetentionSettings, baseDir string) (skip bool, utilization int, err error) {
 	// Parse the threshold percentage
-	usageThresholdFloat, parseErr := conf.ParsePercentage(retention.MaxUsage, "retention.max_usage")
+	usageThresholdFloat, parseErr := conf.ParsePercentage(retention.MaxUsage, configKeyRetentionMaxUsage)
 	if parseErr != nil {
 		return false, 0, parseErr
 	}

--- a/internal/diskmanager/policy_usage.go
+++ b/internal/diskmanager/policy_usage.go
@@ -51,7 +51,7 @@ func UsageBasedCleanup(quit <-chan struct{}, db Interface) CleanupResult {
 
 	// Convert usage threshold string (e.g., "80%") to float64
 	// This determines at what disk usage percentage the cleanup should activate
-	usageThresholdFloat, err := conf.ParsePercentage(usageThresholdSetting, "retention.max_usage")
+	usageThresholdFloat, err := conf.ParsePercentage(usageThresholdSetting, configKeyRetentionMaxUsage)
 	if err != nil {
 		// Use the utilization from the initial result if available
 		GetLogger().Error("Usage-based cleanup failed",


### PR DESCRIPTION
## Summary

- Wrap `strconv.ParseFloat` error in `ParsePercentage` with structured error context (`Component("conf")`, `Category(errors.CategoryValidation)`, `config_key`) matching the existing missing-`%` suffix error path
- Extract duplicated `"retention.max_usage"` string literal from `policy_usage.go` and `policy_common.go` into a package-level constant `configKeyRetentionMaxUsage`

Fixes #2171

## Test plan

- [x] `go test -race -v ./internal/conf/` — passes
- [x] `go test -race -v ./internal/diskmanager/` — passes
- [x] `golangci-lint run -v ./internal/conf/ ./internal/diskmanager/` — 0 issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced error reporting for configuration validation with improved context information
  * Consolidated configuration key definitions for consistency across internal modules

<!-- end of auto-generated comment: release notes by coderabbit.ai -->