### PR TITLE
feat(api): report 5xx errors to Sentry telemetry via HandleError()

### DIFF
--- a/internal/api/v2/api.go
+++ b/internal/api/v2/api.go
@@ -741,7 +741,45 @@ func (c *Controller) handleErrorInternal(ctx echo.Context, err error, message st
 
 	c.logErrorIfEnabled("API Error", fields...)
 
+	// Report server-side errors (5xx) to Sentry telemetry.
+	// 4xx errors are client mistakes (bad input, not found) — not bugs — and are excluded.
+	if code >= http.StatusInternalServerError {
+		c.reportErrorToTelemetry(ctx, err, message, code)
+	}
+
 	return ctx.JSON(code, errorResp)
+}
+
+// reportErrorToTelemetry reports server-side errors (5xx) to Sentry telemetry.
+// Errors already reported by lower layers (e.g., datastore) are skipped to avoid
+// duplicate Sentry events. Privacy scrubbing and opt-in checks are handled by the
+// internal/errors and internal/telemetry packages.
+func (c *Controller) reportErrorToTelemetry(ctx echo.Context, err error, message string, code int) {
+	// Skip if the underlying error was already reported by a lower layer.
+	if err != nil {
+		var ee *errors.EnhancedError
+		if errors.As(err, &ee) && ee.IsReported() {
+			return
+		}
+	}
+
+	path := ctx.Request().URL.Path
+	method := ctx.Request().Method
+
+	var builder *errors.ErrorBuilder
+	if err != nil {
+		builder = errors.New(err)
+	} else {
+		builder = errors.Newf("%s", message)
+	}
+
+	_ = builder.
+		Component("api").
+		Category(errors.CategoryHTTP).
+		Context("http_status", code).
+		Context("endpoint", path).
+		Context("method", method).
+		Build()
 }
 
 // HandleError constructs and returns an appropriate error response

--- a/internal/api/v2/telemetry_test.go
+++ b/internal/api/v2/telemetry_test.go
@@ -1,0 +1,170 @@
+// telemetry_test.go: Tests for API v2 Sentry telemetry integration.
+// Verifies that HandleError() reports 5xx errors to telemetry and excludes 4xx errors.
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/errors"
+)
+
+// captureHook is a helper that installs an error hook for the duration of a test
+// and returns the captured errors. Note: tests using this must NOT be run in
+// parallel because error hooks are global state.
+func captureHook(t *testing.T) *[]*errors.EnhancedError {
+	t.Helper()
+	captured := make([]*errors.EnhancedError, 0, 4)
+	errors.AddErrorHook(func(ee *errors.EnhancedError) {
+		captured = append(captured, ee)
+	})
+	t.Cleanup(errors.ClearErrorHooks)
+	return &captured
+}
+
+// newTestContext creates an echo.Context for use in telemetry tests.
+func newTestContext(t *testing.T, method, path string) (echo.Context, *httptest.ResponseRecorder) {
+	t.Helper()
+	e := echo.New()
+	req := httptest.NewRequest(method, path, http.NoBody)
+	rec := httptest.NewRecorder()
+	return e.NewContext(req, rec), rec
+}
+
+// TestHandleError_5xxReportedToTelemetry verifies that a 5xx HandleError call
+// publishes exactly one EnhancedError to the telemetry hook.
+// Note: Not parallel — modifies global error-hook state.
+func TestHandleError_5xxReportedToTelemetry(t *testing.T) {
+	captured := captureHook(t)
+
+	c := &Controller{Settings: getTestSettings(t)}
+	ctx, _ := newTestContext(t, http.MethodGet, "/api/v2/detections")
+
+	err := c.HandleError(ctx, fmt.Errorf("database failure"), "Internal server error", http.StatusInternalServerError)
+	require.NoError(t, err)
+
+	require.Len(t, *captured, 1, "expected exactly one telemetry event for 5xx error")
+	ee := (*captured)[0]
+	assert.Equal(t, "api", ee.GetComponent())
+	assert.Equal(t, errors.CategoryHTTP, ee.Category)
+	assert.Equal(t, http.StatusInternalServerError, ee.Context["http_status"])
+	assert.Equal(t, "/api/v2/detections", ee.Context["endpoint"])
+	assert.Equal(t, http.MethodGet, ee.Context["method"])
+}
+
+// TestHandleError_4xxNotReportedToTelemetry verifies that a 4xx HandleError call
+// produces no telemetry events (4xx errors are client mistakes, not server bugs).
+// Note: Not parallel — modifies global error-hook state.
+func TestHandleError_4xxNotReportedToTelemetry(t *testing.T) {
+	captured := captureHook(t)
+
+	c := &Controller{Settings: getTestSettings(t)}
+	ctx, _ := newTestContext(t, http.MethodPost, "/api/v2/settings")
+
+	err := c.HandleError(ctx, fmt.Errorf("missing field"), "Bad request", http.StatusBadRequest)
+	require.NoError(t, err)
+
+	assert.Empty(t, *captured, "expected no telemetry events for 4xx error")
+}
+
+// TestHandleError_NilError_5xxReported verifies that a nil underlying error with a
+// 5xx code still produces a telemetry event, using the message as the error text.
+// Note: Not parallel — modifies global error-hook state.
+func TestHandleError_NilError_5xxReported(t *testing.T) {
+	captured := captureHook(t)
+
+	c := &Controller{Settings: getTestSettings(t)}
+	ctx, _ := newTestContext(t, http.MethodGet, "/api/v2/health")
+
+	err := c.HandleError(ctx, nil, "Service unavailable", http.StatusServiceUnavailable)
+	require.NoError(t, err)
+
+	require.Len(t, *captured, 1, "expected one telemetry event even with nil error")
+	ee := (*captured)[0]
+	assert.Equal(t, "api", ee.GetComponent())
+	assert.Equal(t, errors.CategoryHTTP, ee.Category)
+	assert.Equal(t, http.StatusServiceUnavailable, ee.Context["http_status"])
+}
+
+// TestHandleErrorWithKey_5xxReportedToTelemetry verifies the i18n variant also
+// reports 5xx errors to telemetry.
+// Note: Not parallel — modifies global error-hook state.
+func TestHandleErrorWithKey_5xxReportedToTelemetry(t *testing.T) {
+	captured := captureHook(t)
+
+	c := &Controller{Settings: getTestSettings(t)}
+	ctx, _ := newTestContext(t, http.MethodDelete, "/api/v2/detections/123")
+
+	err := c.HandleErrorWithKey(
+		ctx,
+		fmt.Errorf("constraint violation"),
+		"Internal server error",
+		http.StatusInternalServerError,
+		"error.internal",
+		nil,
+	)
+	require.NoError(t, err)
+
+	require.Len(t, *captured, 1, "expected one telemetry event from HandleErrorWithKey")
+	assert.Equal(t, "api", (*captured)[0].GetComponent())
+}
+
+// TestHandleError_AlreadyReportedSkipsDuplicate verifies that an error already
+// reported by a lower layer (IsReported() == true) is not sent to Sentry again
+// from the API layer.
+// Note: Not parallel — modifies global error-hook state.
+func TestHandleError_AlreadyReportedSkipsDuplicate(t *testing.T) {
+	// Build and pre-report an EnhancedError to simulate a lower-layer report.
+	preReported := errors.Newf("db deadlock").
+		Component("datastore").
+		Category(errors.CategoryDatabase).
+		Build()
+	preReported.MarkReported()
+
+	// Now install the hook (after pre-reporting, so the Build() call above is not counted).
+	captured := captureHook(t)
+
+	c := &Controller{Settings: getTestSettings(t)}
+	ctx, _ := newTestContext(t, http.MethodGet, "/api/v2/detections")
+
+	err := c.HandleError(ctx, preReported, "Internal server error", http.StatusInternalServerError)
+	require.NoError(t, err)
+
+	assert.Empty(t, *captured, "expected no duplicate telemetry event for already-reported error")
+}
+
+// TestHandleError_404NotReportedToTelemetry verifies that 404 Not Found errors
+// are not reported (they are expected conditions for unknown resources).
+// Note: Not parallel — modifies global error-hook state.
+func TestHandleError_404NotReportedToTelemetry(t *testing.T) {
+	captured := captureHook(t)
+
+	c := &Controller{Settings: getTestSettings(t)}
+	ctx, _ := newTestContext(t, http.MethodGet, "/api/v2/detections/99999")
+
+	err := c.HandleError(ctx, fmt.Errorf("record not found"), "Not found", http.StatusNotFound)
+	require.NoError(t, err)
+
+	assert.Empty(t, *captured, "expected no telemetry events for 404 error")
+}
+
+// TestHandleError_502BadGatewayReportedToTelemetry verifies that non-500 5xx codes
+// (e.g., 502 Bad Gateway) are also reported as server errors.
+// Note: Not parallel — modifies global error-hook state.
+func TestHandleError_502BadGatewayReportedToTelemetry(t *testing.T) {
+	captured := captureHook(t)
+
+	c := &Controller{Settings: getTestSettings(t)}
+	ctx, _ := newTestContext(t, http.MethodGet, "/api/v2/system")
+
+	err := c.HandleError(ctx, fmt.Errorf("upstream timeout"), "Bad gateway", http.StatusBadGateway)
+	require.NoError(t, err)
+
+	require.Len(t, *captured, 1, "expected one telemetry event for 502 error")
+	assert.Equal(t, http.StatusBadGateway, (*captured)[0].Context["http_status"])
+}


### PR DESCRIPTION
## Summary

- Adds Sentry telemetry to `handleErrorInternal()`, the single choke point for all 75+ API v2 endpoint errors
- Wraps 5xx errors with `Component("api")`, `Category(CategoryHTTP)`, and context fields (`http_status`, `endpoint`, `method`) before publishing to the error event bus
- 4xx errors (client mistakes: bad input, not found, unauthorized) are explicitly excluded — they are not bugs
- Errors already reported by lower layers (e.g. datastore via `IsReported()`) are skipped to prevent duplicate Sentry events
- Privacy scrubbing and telemetry opt-in are handled transparently by the `internal/errors` and `internal/telemetry` packages

## Test plan

- [ ] `TestHandleError_5xxReportedToTelemetry` — 500 error produces one telemetry event with correct component/category/context
- [ ] `TestHandleError_4xxNotReportedToTelemetry` — 400 error produces no telemetry events
- [ ] `TestHandleError_NilError_5xxReported` — nil underlying error + 5xx still reports using message text
- [ ] `TestHandleErrorWithKey_5xxReportedToTelemetry` — i18n variant (`HandleErrorWithKey`) also reports
- [ ] `TestHandleError_AlreadyReportedSkipsDuplicate` — pre-reported `EnhancedError` is not double-reported
- [ ] `TestHandleError_404NotReportedToTelemetry` — 404 Not Found excluded
- [ ] `TestHandleError_502BadGatewayReportedToTelemetry` — non-500 5xx codes (502) are reported

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced server error monitoring—5xx errors are now automatically reported to telemetry, enabling faster issue detection and resolution.

* **Tests**
  * Added comprehensive test coverage for error reporting behavior, ensuring accurate telemetry capture across various error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->