### PR TITLE
fix(datastore): handle pre-PR#2165 table name mismatch for v2 databases

### DIFF
--- a/internal/datastore/v2/manager.go
+++ b/internal/datastore/v2/manager.go
@@ -161,7 +161,9 @@ func NewSQLiteManager(cfg Config) (*SQLiteManager, error) {
 func (m *SQLiteManager) Initialize() error {
 	// Rename tables that changed names in PR #2165 (TableName() overrides removed).
 	// This must run BEFORE AutoMigrate to avoid creating duplicate tables.
-	m.renamePrePR2165Tables()
+	if err := m.renamePrePR2165Tables(); err != nil {
+		return err
+	}
 
 	// Remove orphaned columns added by legacy AutoMigrate when the app incorrectly
 	// fell back to legacy mode due to the PR #2165 table name mismatch.
@@ -235,7 +237,7 @@ func (m *SQLiteManager) Initialize() error {
 //   - alert_history → alert_histories
 //
 // This is safe to call on fresh databases (no-op if old tables don't exist).
-func (m *SQLiteManager) renamePrePR2165Tables() {
+func (m *SQLiteManager) renamePrePR2165Tables() error {
 	renames := [][2]string{
 		{"migration_state", "migration_states"},
 		{"alert_history", "alert_histories"},
@@ -253,8 +255,10 @@ func (m *SQLiteManager) renamePrePR2165Tables() {
 		}
 		if err := m.db.Exec("ALTER TABLE `" + oldName + "` RENAME TO `" + newName + "`").Error; err != nil {
 			reportInitFailure("sqlite", "renameTable_"+oldName, err, m.dbPath)
+			return fmt.Errorf("failed to rename table %s to %s: %w", oldName, newName, err)
 		}
 	}
+	return nil
 }
 
 // cleanupLegacySchemaContamination removes columns that were erroneously added to v2

--- a/internal/datastore/v2/mysql_manager.go
+++ b/internal/datastore/v2/mysql_manager.go
@@ -88,7 +88,9 @@ func NewMySQLManager(cfg *MySQLConfig) (*MySQLManager, error) {
 func (m *MySQLManager) Initialize() error {
 	// Rename tables that changed names in PR #2165 (TableName() overrides removed).
 	// This must run BEFORE AutoMigrate to avoid creating duplicate tables.
-	m.renamePrePR2165Tables()
+	if err := m.renamePrePR2165Tables(); err != nil {
+		return err
+	}
 
 	// Remove orphaned columns added by legacy AutoMigrate when the app incorrectly
 	// fell back to legacy mode due to the PR #2165 table name mismatch.
@@ -156,7 +158,7 @@ func (m *MySQLManager) Initialize() error {
 //   - alert_history → alert_histories
 //
 // The table prefix (empty or "v2_") is applied automatically.
-func (m *MySQLManager) renamePrePR2165Tables() {
+func (m *MySQLManager) renamePrePR2165Tables() error {
 	renames := [][2]string{
 		{"migration_state", "migration_states"},
 		{"alert_history", "alert_histories"},
@@ -174,8 +176,10 @@ func (m *MySQLManager) renamePrePR2165Tables() {
 		}
 		if err := m.db.Exec("ALTER TABLE `" + oldName + "` RENAME TO `" + newName + "`").Error; err != nil {
 			reportInitFailure("mysql", "renameTable_"+oldName, err, m.config.Host, m.config.Database, m.config.Username)
+			return fmt.Errorf("failed to rename table %s to %s: %w", oldName, newName, err)
 		}
 	}
+	return nil
 }
 
 // cleanupLegacySchemaContamination removes columns erroneously added by legacy AutoMigrate

--- a/internal/datastore/v2/startup.go
+++ b/internal/datastore/v2/startup.go
@@ -163,7 +163,7 @@ func checkSQLiteMigrationState(settings *conf.Settings) StartupState {
 	defer func() { _ = sqlDB.Close() }()
 
 	// Read migration state — try both table names (plural is current, singular is pre-PR #2165)
-	migrationTable := resolveTableName(db, "migration_states", "migration_state")
+	migrationTable := resolveSQLiteTableName(db, "migration_states", "migration_state")
 	if migrationTable == "" {
 		reportStartupError("sqlite", "readMigrationState", fmt.Errorf("migration state table not found"), v2MigrationPath)
 		return StartupState{
@@ -708,11 +708,11 @@ func CheckAndConsolidateAtStartup(configuredPath string, log logger.Logger) (con
 	return true, nil
 }
 
-// resolveTableName checks which of two possible SQLite table names exists.
-// Returns the first match or empty string if neither exists.
+// resolveSQLiteTableName checks which of the given SQLite table names exists.
+// Returns the first match or empty string if none exist.
 // This handles the migration_state→migration_states and alert_history→alert_histories
 // rename from PR #2165 where TableName() overrides were removed.
-func resolveTableName(db *gorm.DB, names ...string) string {
+func resolveSQLiteTableName(db *gorm.DB, names ...string) string {
 	for _, name := range names {
 		var count int64
 		if err := db.Raw("SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name=?", name).Scan(&count).Error; err == nil && count > 0 {


### PR DESCRIPTION
## Summary

**Critical bug fix** — v2 databases fail to start after PR #2165 removed `TableName()` overrides from entities.

- PR #2165 renamed `migration_state` → `migration_states` and `alert_history` → `alert_histories` (GORM auto-pluralization)
- Existing v2 databases still have the old singular table names
- `CheckSQLiteHasV2Schema()` only checked for the new plural name, failed to detect v2 databases
- App fell back to legacy mode and ran legacy `AutoMigrate` against v2 schema, crashing with `Cannot add a NOT NULL column with default value NULL`

### Changes
- Check both old (singular) and new (plural) table names in all startup state detection (SQLite + MySQL)
- Add `renamePrePR2165Tables()` to SQLite and MySQL `Initialize()` — renames old tables before `AutoMigrate`
- Add `resolveTableName()` helper for SQLite table name resolution

## Test plan
- [x] All existing v2 datastore tests pass (`go test -race ./internal/datastore/v2/...`)
- [x] All v2only tests pass (`go test -race ./internal/datastore/v2only/...`)
- [x] `golangci-lint run -v` — 0 issues
- [ ] Verify on affected Raspberry Pi (v2 fresh install database)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Database initialization now handles legacy vs. current table names during upgrades to prevent duplicate tables and migration failures.
  * Removes an orphaned legacy column that could cause schema contamination during migrations.
  * Startup now detects and reads migration state whether the old or new table name exists, improving upgrade and startup resilience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->