### PR TITLE
fix(analysis): increase audio file readiness timeout for slow storage

### DIFF
--- a/internal/myaudio/validate.go
+++ b/internal/myaudio/validate.go
@@ -21,14 +21,18 @@ const (
 	// MinValidAudioSize is the minimum size for a valid audio file (1KB)
 	MinValidAudioSize int64 = 1024
 
-	// MaxValidationAttempts is the maximum number of validation attempts
-	MaxValidationAttempts = 3
+	// MaxValidationAttempts is the maximum number of validation attempts.
+	// Set to 5 to accommodate slow storage (SD cards, network drives) on
+	// resource-constrained devices like Raspberry Pi / arm64 containers.
+	MaxValidationAttempts = 5
 
-	// ValidationRetryDelay is the delay between validation attempts
-	ValidationRetryDelay = 100 * time.Millisecond
+	// ValidationRetryDelay is the base delay between validation attempts.
+	// Increased from 100ms to 500ms to give slow storage enough time between retries.
+	ValidationRetryDelay = 500 * time.Millisecond
 
-	// FileStabilityCheckDuration is how long to wait to confirm file size is stable
-	FileStabilityCheckDuration = 50 * time.Millisecond
+	// FileStabilityCheckDuration is how long to wait to confirm file size is stable.
+	// Increased from 50ms to 200ms to handle slow I/O on SD cards and network drives.
+	FileStabilityCheckDuration = 200 * time.Millisecond
 
 	// FFprobeTimeout is the maximum time to wait for ffprobe validation
 	FFprobeTimeout = 3 * time.Second


### PR DESCRIPTION
## Summary

- Increase `MaxValidationAttempts` from 3 to 5 and `ValidationRetryDelay` from 100ms to 500ms in `ValidateAudioFileWithRetry` to accommodate slow storage (SD cards, network drives) on resource-constrained devices (RPi, arm64 containers)
- Increase `FileStabilityCheckDuration` from 50ms to 200ms to handle slow I/O when checking file size stability
- Total retry wait increases from ~400ms to ~4-5s, staying well within the 30s `CompositeActionTimeout`

Fixes #2203

## Test plan

- [x] Existing `TestValidateAudioFileWithRetry` passes with `-race`
- [x] Existing `TestValidateAudioFileNoDurationCheck` passes
- [x] `golangci-lint` reports zero issues for the changed package
- [ ] Verify on RPi/arm64 container with SD card storage that timeout errors no longer occur

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio file validation reliability on constrained devices with slow storage (SD cards, network drives) by increasing retry attempts and adding longer delays for file stability checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->