### PR TITLE
fix(monitor): handle missing mount point gracefully in containers

### DIFF
--- a/internal/monitor/mount_resolver.go
+++ b/internal/monitor/mount_resolver.go
@@ -89,12 +89,25 @@ func groupPathsWithPartitions(paths []string, partitions []disk.PartitionStat) [
 	for _, path := range paths {
 		mountPoint, device, fstype, err := getMountInfoFromPartitions(path, partitions)
 		if err != nil {
-			// Log but skip invalid paths
-			GetLogger().Debug("Skipping path for mount grouping",
-				logger.String("path", path),
-				logger.Error(err),
-			)
-			continue
+			// Mount point detection failed — common in containers with overlay filesystems.
+			// If the path is accessible, use it directly as its own mount group so that
+			// disk.Usage() can still report usage stats.
+			if _, statErr := os.Stat(path); statErr == nil {
+				GetLogger().Debug("Mount point detection failed, monitoring path directly",
+					logger.String("path", path),
+					logger.Error(err),
+				)
+				mountPoint = path
+				device = ""
+				fstype = ""
+			} else {
+				GetLogger().Debug("Skipping inaccessible path for mount grouping",
+					logger.String("path", path),
+					logger.Error(err),
+					logger.String("stat_error", statErr.Error()),
+				)
+				continue
+			}
 		}
 
 		if group, exists := groups[mountPoint]; exists {

--- a/internal/monitor/mount_resolver_test.go
+++ b/internal/monitor/mount_resolver_test.go
@@ -229,6 +229,38 @@ func TestGetMountInfoFromPartitions_NoMatch(t *testing.T) {
 	}
 }
 
+func TestGroupPathsWithPartitions_FallbackForAccessiblePath(t *testing.T) {
+	t.Parallel()
+
+	// Simulate a container environment: the path exists but no partition matches it
+	tempDir := t.TempDir()
+	partitions := []disk.PartitionStat{
+		{Device: "overlay", Mountpoint: "/mnt/nonexistent", Fstype: "overlay"},
+	}
+
+	groups := groupPathsWithPartitions([]string{tempDir}, partitions)
+
+	// The accessible path should still appear as a fallback group
+	require.Len(t, groups, 1)
+	assert.Equal(t, tempDir, groups[0].MountPoint)
+	assert.Empty(t, groups[0].Device)
+	assert.Empty(t, groups[0].Fstype)
+	assert.Equal(t, []string{tempDir}, groups[0].Paths)
+}
+
+func TestGroupPathsWithPartitions_SkipsInaccessiblePath(t *testing.T) {
+	t.Parallel()
+
+	// An inaccessible path with no matching partition should be skipped entirely
+	partitions := []disk.PartitionStat{
+		{Device: "overlay", Mountpoint: "/mnt/nonexistent", Fstype: "overlay"},
+	}
+
+	groups := groupPathsWithPartitions([]string{"/nonexistent/path/xyz/abc"}, partitions)
+
+	assert.Empty(t, groups)
+}
+
 func TestMountGroupFields(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- When `disk.Partitions()` doesn't return a partition matching a monitored path (common in container environments with overlay filesystems), fall back to using the path directly as its own mount group
- `disk.Usage()` uses `statfs` which works on any valid directory, so monitoring continues to function correctly even without partition detection
- Inaccessible paths are still skipped with a debug log including the stat error for diagnostics

Fixes #2200

## Test plan

- [x] Existing tests pass (`go test -race -v ./internal/monitor/...`)
- [x] New test `TestGroupPathsWithPartitions_FallbackForAccessiblePath` verifies accessible paths get a fallback mount group when no partition matches
- [x] New test `TestGroupPathsWithPartitions_SkipsInaccessiblePath` verifies truly inaccessible paths are still skipped
- [x] Linter clean (`golangci-lint run -v ./internal/monitor/...`)
- [ ] Verify in Docker container with overlay filesystem that disk monitoring for `/` works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Improved disk monitoring resilience in containerized and overlay storage environments. When mount information lookup fails, the system now monitors accessible paths individually as fallback groups, enabling disk usage reporting. Inaccessible paths remain unmonitored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->