### PR TITLE
fix(diskmanager): skip files with unexpected filename format gracefully

### DIFF
--- a/internal/diskmanager/file_utils.go
+++ b/internal/diskmanager/file_utils.go
@@ -23,6 +23,11 @@ import (
 // constant in the myaudio package.
 const tempFileExt = ".temp"
 
+// errUnrecognizedFilename is returned when a file's name does not match the
+// expected BirdNET naming pattern (species_confidence_timestamp). Such files
+// are silently skipped during cleanup rather than being reported as errors.
+var errUnrecognizedFilename = fmt.Errorf("unrecognized filename format")
+
 // allowedFileTypes is the list of file extensions that are allowed to be deleted
 var allowedFileTypes = []string{".wav", ".flac", ".aac", ".opus", ".mp3", ".m4a"}
 
@@ -176,6 +181,14 @@ func processFile(path string, info os.FileInfo, state *walkState) {
 	// Process valid file
 	fileInfo, err := parseFileInfo(path, info, state.allowedExts)
 	if err != nil {
+		// Files that don't match BirdNET naming pattern are expected in the
+		// recordings directory (e.g. user files, system files). Skip gracefully.
+		if errors.Is(err, errUnrecognizedFilename) {
+			GetLogger().Debug("Skipping file with unrecognized filename format",
+				logger.String("path", path),
+				logger.String("filename", fileName))
+			return
+		}
 		// Track first error and count without storing all errors
 		if state.firstParseError == nil {
 			state.firstParseError = err
@@ -333,14 +346,7 @@ func parseFileInfo(path string, info os.FileInfo, allowedExts []string) (FileInf
 
 	parts := strings.Split(nameWithoutExt, "_")
 	if len(parts) < 3 {
-		// Lightweight error with format guidance
-		descriptiveErr := errors.Newf("diskmanager: invalid filename format").
-			Component("diskmanager").
-			Category(errors.CategoryValidation).
-			Context("expected_format", "species_confidence_timestamp").
-			Context("filename", name).
-			Build()
-		return FileInfo{}, descriptiveErr
+		return FileInfo{}, errUnrecognizedFilename
 	}
 
 	// The species name might contain underscores, so we need to handle the last two parts separately

--- a/internal/diskmanager/file_utils_test.go
+++ b/internal/diskmanager/file_utils_test.go
@@ -1,23 +1,24 @@
 package diskmanager
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/tphakala/birdnet-go/internal/errors"
 )
 
 // TestInvalidFileNameErrorMessages tests that the error messages for invalid file names are detailed
 func TestInvalidFileNameErrorMessages(t *testing.T) {
-	// Test cases with invalid file names
+	// Test cases with invalid file names that have enough parts but bad data
 	testCases := []struct {
 		filename        string
 		expectedErrText string
 	}{
-		// Too few parts
-		{"bubo_bubo.wav", "diskmanager: invalid filename format"},
 		// This actually gets parsed as species="bubo", confidence="bubo", which fails at the confidence parsing step
 		{"bubo_bubo_80p.wav", "diskmanager: invalid confidence value"},
 
@@ -30,7 +31,6 @@ func TestInvalidFileNameErrorMessages(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.filename, func(t *testing.T) {
-			// Create a mock FileInfo
 			mockInfo := &MockFileInfo{
 				FileName:    tc.filename,
 				FileSize:    1024,
@@ -39,10 +39,84 @@ func TestInvalidFileNameErrorMessages(t *testing.T) {
 				FileIsDir:   false,
 			}
 
-			// Call parseFileInfo and check the error message
 			_, err := parseFileInfo("/test/"+tc.filename, mockInfo, allowedFileTypes)
 			require.Error(t, err, "Should return an error for invalid file name")
 			assert.Contains(t, err.Error(), tc.expectedErrText, "Error message should contain expected text")
+		})
+	}
+}
+
+// TestParseFileInfoReturnsUnrecognizedForBadFormat tests that files with too few
+// underscore-separated parts return errUnrecognizedFilename instead of an EnhancedError.
+func TestParseFileInfoReturnsUnrecognizedForBadFormat(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		filename string
+	}{
+		{"single word", "oout.aac"},
+		{"two parts only", "bubo_bubo.wav"},
+		{"no underscores", "recording.mp3"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			mockInfo := &MockFileInfo{
+				FileName:    tc.filename,
+				FileSize:    1024,
+				FileMode:    0o644,
+				FileModTime: parseTime("20210102T150405Z"),
+				FileIsDir:   false,
+			}
+
+			_, err := parseFileInfo("/test/"+tc.filename, mockInfo, allowedFileTypes)
+			require.ErrorIs(t, err, errUnrecognizedFilename)
+
+			// Must NOT be an EnhancedError (which would be reported to Sentry)
+			var enhanced *errors.EnhancedError
+			assert.False(t, errors.As(err, &enhanced), "should not be an EnhancedError")
+		})
+	}
+}
+
+// TestProcessFileSkipsUnrecognizedFilenames verifies that files with unrecognized
+// naming patterns are skipped without incrementing the parse error count.
+func TestProcessFileSkipsUnrecognizedFilenames(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		filename string
+	}{
+		{"issue 2199 - oout.aac", "oout.aac"},
+		{"two-part name", "some_file.wav"},
+		{"single word", "recording.mp3"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			state := &walkState{
+				ctx:            context.Background(),
+				allowedExts:    allowedFileTypes,
+				lockedSet:      make(map[string]struct{}),
+				maxParseErrors: 10,
+			}
+
+			mockInfo := &MockFileInfo{
+				FileName:  tc.filename,
+				FileSize:  512,
+				FileMode:  0o644,
+				FileIsDir: false,
+			}
+
+			processFile("/recordings/"+tc.filename, mockInfo, state)
+
+			assert.Empty(t, state.files, "unrecognized file should not be added")
+			assert.Equal(t, 0, state.parseErrorCount, "unrecognized file should not count as parse error")
+			assert.NoError(t, state.firstParseError, "unrecognized file should not set firstParseError")
 		})
 	}
 }
@@ -104,6 +178,52 @@ func TestParseFileInfoWithDurationSuffix(t *testing.T) {
 			assert.Equal(t, tt.confidence, info.Confidence)
 		})
 	}
+}
+
+// TestGetAudioFilesSkipsNonBirdNETFiles verifies that files in the recordings
+// directory that don't match the BirdNET naming pattern are silently skipped
+// without reporting errors (issue #2199).
+func TestGetAudioFilesSkipsNonBirdNETFiles(t *testing.T) {
+	tempDir := t.TempDir()
+
+	// Valid BirdNET file
+	validFile := filepath.Join(tempDir, "bubo_bubo_80p_20210102T150405Z.wav")
+	require.NoError(t, os.WriteFile(validFile, []byte("audio"), 0o600))
+
+	// Non-BirdNET files that should be silently skipped
+	nonBirdNETFiles := []string{
+		"oout.aac",      // The exact file from issue #2199
+		"recording.mp3", // Single-word name
+		"my_notes.wav",  // Two-part name
+		"test.flac",     // Another single-word name
+	}
+	for _, name := range nonBirdNETFiles {
+		require.NoError(t, os.WriteFile(filepath.Join(tempDir, name), []byte("data"), 0o600))
+	}
+
+	mockDB := &MockDB{}
+	files, err := GetAudioFiles(tempDir, allowedFileTypes, mockDB, false)
+
+	require.NoError(t, err, "non-BirdNET files should not cause errors")
+	require.Len(t, files, 1)
+	assert.Equal(t, "bubo_bubo", files[0].Species)
+}
+
+// TestGetAudioFilesOnlyNonBirdNETFiles verifies that a directory containing
+// only non-BirdNET files returns nil without error (not a parse failure).
+func TestGetAudioFilesOnlyNonBirdNETFiles(t *testing.T) {
+	tempDir := t.TempDir()
+
+	nonBirdNETFiles := []string{"oout.aac", "notes.wav", "test.mp3"}
+	for _, name := range nonBirdNETFiles {
+		require.NoError(t, os.WriteFile(filepath.Join(tempDir, name), []byte("data"), 0o600))
+	}
+
+	mockDB := &MockDB{}
+	files, err := GetAudioFiles(tempDir, allowedFileTypes, mockDB, false)
+
+	require.NoError(t, err, "directory with only non-BirdNET files should not error")
+	assert.Empty(t, files)
 }
 
 // TestGetAudioFilesContinuesOnError tests that GetAudioFiles continues processing after encountering invalid files


### PR DESCRIPTION
## Summary
- Files in the recordings directory that don't match the BirdNET naming pattern (`species_confidence_timestamp`) are now silently skipped with a debug log instead of being reported as validation errors to Sentry
- Added sentinel error `errUnrecognizedFilename` to distinguish non-matching files from actual parse failures (bad confidence values, invalid timestamps)
- Non-matching files no longer increment the parse error counter, so a directory with only non-BirdNET files returns `nil, nil` instead of a wrapped parse error

## Test plan
- `TestParseFileInfoReturnsUnrecognizedForBadFormat`: verifies `parseFileInfo` returns the sentinel error (not an `EnhancedError`) for files with <3 underscore parts
- `TestProcessFileSkipsUnrecognizedFilenames`: verifies `processFile` skips unrecognized files without incrementing `parseErrorCount` or setting `firstParseError`
- `TestGetAudioFilesSkipsNonBirdNETFiles`: end-to-end test with "oout.aac" (the exact file from the issue) alongside a valid file
- `TestGetAudioFilesOnlyNonBirdNETFiles`: directory with only non-matching files returns no error
- All existing tests continue to pass

Fixes #2199

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of non-conforming files during cleanup operations—unrecognized files are now silently skipped instead of generating error reports, reducing noise in logs and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->