### PR TITLE
fix(api): return 404 instead of 500 for missing species images

### DIFF
--- a/internal/api/v2/media.go
+++ b/internal/api/v2/media.go
@@ -19,6 +19,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/errors"
+	"github.com/tphakala/birdnet-go/internal/imageprovider"
 	"github.com/tphakala/birdnet-go/internal/logger"
 	"github.com/tphakala/birdnet-go/internal/myaudio"
 	"github.com/tphakala/birdnet-go/internal/securefs"
@@ -97,7 +98,6 @@ var (
 	ErrSpectrogramGeneration = errors.NewStd("failed to generate spectrogram")
 
 	// Image errors
-	ErrImageNotFound             = errors.NewStd("image not found")
 	ErrImageProviderNotAvailable = errors.NewStd("image provider not available")
 
 	// Sentinel errors for nilnil cases
@@ -207,7 +207,7 @@ func (c *Controller) translateSecureFSError(ctx echo.Context, err error, userMsg
 			logger.String("tunnel_provider", tunnelProvider),
 		)
 		return c.HandleError(ctx, err, "Requested resource is not a regular file", http.StatusForbidden)
-	case errors.Is(err, os.ErrNotExist) || errors.Is(err, fs.ErrNotExist) || errors.Is(err, ErrAudioFileNotFound) || errors.Is(err, ErrImageNotFound):
+	case errors.Is(err, os.ErrNotExist) || errors.Is(err, fs.ErrNotExist) || errors.Is(err, ErrAudioFileNotFound) || errors.Is(err, imageprovider.ErrImageNotFound):
 		c.logInfoIfEnabled("Resource not found", // Info level as 404 is common
 			logger.Error(err),
 			logger.String("path", ctx.Request().URL.Path),
@@ -2000,7 +2000,7 @@ func (c *Controller) GetSpeciesImageInfo(ctx echo.Context) error {
 
 	birdImage, err := c.BirdImageCache.Get(scientificName)
 	if err != nil {
-		if errors.Is(err, ErrImageNotFound) {
+		if errors.Is(err, imageprovider.ErrImageNotFound) {
 			ctx.Response().Header().Set("Cache-Control", fmt.Sprintf("public, max-age=%d", NotFoundCacheSeconds))
 			return c.HandleError(ctx, err, "Image not found for species", http.StatusNotFound)
 		}
@@ -2047,7 +2047,7 @@ func (c *Controller) ServeSpeciesImageProxy(ctx echo.Context) error {
 	// Look up metadata to know which provider owns this image
 	birdImage, err := c.BirdImageCache.Get(scientificName)
 	if err != nil {
-		if errors.Is(err, ErrImageNotFound) {
+		if errors.Is(err, imageprovider.ErrImageNotFound) {
 			ctx.Response().Header().Set("Cache-Control", fmt.Sprintf("public, max-age=%d", NotFoundCacheSeconds))
 			return c.HandleError(ctx, err, "Image not found for species", http.StatusNotFound)
 		}
@@ -2057,7 +2057,7 @@ func (c *Controller) ServeSpeciesImageProxy(ctx echo.Context) error {
 	// Negative cache entries have no real image URL
 	if birdImage.IsNegativeEntry() || birdImage.URL == "" {
 		ctx.Response().Header().Set("Cache-Control", fmt.Sprintf("public, max-age=%d", NotFoundCacheSeconds))
-		return c.HandleError(ctx, ErrImageNotFound, "Image not found for species", http.StatusNotFound)
+		return c.HandleError(ctx, imageprovider.ErrImageNotFound, "Image not found for species", http.StatusNotFound)
 	}
 
 	// Get the file cache from the BirdImageCache

--- a/internal/api/v2/media_test.go
+++ b/internal/api/v2/media_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/datastore/mocks"
+	"github.com/tphakala/birdnet-go/internal/imageprovider"
 	"github.com/tphakala/birdnet-go/internal/securefs"
 )
 
@@ -1230,6 +1231,76 @@ func TestIsValidFilename(t *testing.T) {
 			result := isValidFilename(tt.filename)
 			assert.Equal(t, tt.expected, result,
 				"isValidFilename(%q) = %v, want %v", tt.filename, result, tt.expected)
+		})
+	}
+}
+
+// TestSpeciesImageNotFound_Returns404 verifies that image endpoints return HTTP 404
+// (not 500) when the image provider has no image for a species.
+// Regression test for GitHub issue #2201.
+func TestSpeciesImageNotFound_Returns404(t *testing.T) {
+	t.Attr("component", "media")
+	t.Attr("type", "regression")
+	t.Attr("issue", "2201")
+
+	// Setup test environment — the default mock provider returns images for any species
+	e, _, controller := setupTestEnvironment(t)
+
+	// Replace the mock provider with one that returns ErrImageNotFound for unknown species
+	notFoundProvider := &TestImageProvider{
+		FetchFunc: func(scientificName string) (imageprovider.BirdImage, error) {
+			return imageprovider.BirdImage{}, imageprovider.ErrImageNotFound
+		},
+	}
+	controller.BirdImageCache.SetImageProvider(notFoundProvider)
+
+	tests := []struct {
+		name    string
+		handler func(echo.Context) error
+		setup   func(*echo.Echo) echo.Context
+	}{
+		{
+			name:    "GetSpeciesImageInfo returns 404 for missing species image",
+			handler: controller.GetSpeciesImageInfo,
+			setup: func(e *echo.Echo) echo.Context {
+				req := httptest.NewRequest(http.MethodGet, "/api/v2/media/species-image/info?name=Nonexistus+fictus", http.NoBody)
+				rec := httptest.NewRecorder()
+				return e.NewContext(req, rec)
+			},
+		},
+		{
+			name:    "ServeSpeciesImageProxy returns 404 for missing species image",
+			handler: controller.ServeSpeciesImageProxy,
+			setup: func(e *echo.Echo) echo.Context {
+				req := httptest.NewRequest(http.MethodGet, "/api/v2/media/image/Nonexistus%20fictus", http.NoBody)
+				rec := httptest.NewRecorder()
+				c := e.NewContext(req, rec)
+				c.SetParamNames("scientific_name")
+				c.SetParamValues("Nonexistus fictus")
+				return c
+			},
+		},
+		{
+			name:    "GetSpeciesImage returns 404 for missing species image",
+			handler: controller.GetSpeciesImage,
+			setup: func(e *echo.Echo) echo.Context {
+				req := httptest.NewRequest(http.MethodGet, "/api/v2/media/species-image?name=Nonexistus+fictus", http.NoBody)
+				rec := httptest.NewRecorder()
+				return e.NewContext(req, rec)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := tt.setup(e)
+			_ = tt.handler(ctx)
+
+			rec := ctx.Response().Writer.(*httptest.ResponseRecorder)
+			assert.Equal(t, http.StatusNotFound, rec.Code,
+				"Expected 404 Not Found for missing species image, got %d", rec.Code)
+			assert.Contains(t, rec.Body.String(), "Image not found",
+				"Response body should indicate image was not found")
 		})
 	}
 }


### PR DESCRIPTION
## Summary

- **Root cause**: `internal/api/v2/media.go` defined a local `ErrImageNotFound` sentinel (`"image not found"`) that shadowed `imageprovider.ErrImageNotFound` (`"image not found by provider"`). The `errors.Is()` comparisons in `GetSpeciesImageInfo`, `ServeSpeciesImageProxy`, and `translateSecureFSError` never matched the error returned by `BirdImageCache.Get()`, so all "image not found" cases fell through to the HTTP 500 handler.
- **Fix**: Import `imageprovider` and use `imageprovider.ErrImageNotFound` in all comparisons and error constructions. Remove the unused local sentinel.
- **Affected endpoints**: `GET /media/species-image`, `GET /media/species-image/info`, `GET /media/image/:scientific_name`, `GET /media/bird-image/:scientific_name`

## Test plan

- Added `TestSpeciesImageNotFound_Returns404` regression test with 3 subtests covering `GetSpeciesImageInfo`, `ServeSpeciesImageProxy`, and `GetSpeciesImage` — all verify HTTP 404 response
- Full api/v2 test suite passes with `-race`
- `golangci-lint` passes with zero issues

Fixes #2201

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Image endpoints now return the correct 404 status code instead of 500 when a requested image is not found. This applies to species image retrieval, proxy, and image info endpoints, improving error handling and providing clearer feedback when images are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->