### PR TITLE
fix(myaudio): handle missing analysis buffer during RTSP reconnection

### DIFF
--- a/internal/myaudio/analysis_buffer.go
+++ b/internal/myaudio/analysis_buffer.go
@@ -310,20 +310,11 @@ func WriteToAnalysisBuffer(sourceID string, data []byte) error {
 	abMutex.RUnlock()
 
 	if !exists {
-		enhancedErr := errors.Newf("no analysis buffer found for source ID: %s (%s)", sourceID, displayName).
-			Component("myaudio").
-			Category(errors.CategoryValidation).
-			Context("operation", "write_to_analysis_buffer").
-			Context("source_id", sourceID).
-			Context("display_name", displayName).
-			Context("data_size", len(data)).
-			Build()
-
 		if m := getAnalysisMetrics(); m != nil {
 			m.RecordBufferWrite("analysis", sourceID, "error")
 			m.RecordBufferWriteError("analysis", sourceID, "buffer_not_found")
 		}
-		return enhancedErr
+		return fmt.Errorf("%w: source ID %s (%s)", ErrBufferNotFound, sourceID, displayName)
 	}
 
 	// Get buffer capacity information
@@ -512,19 +503,11 @@ func ReadFromAnalysisBuffer(sourceID string) ([]byte, error) {
 	// Get the ring buffer for the given source ID
 	ab, exists := analysisBuffers[sourceID]
 	if !exists {
-		enhancedErr := errors.Newf("no analysis buffer found for source ID: %s (%s)", sourceID, displayName).
-			Component("myaudio").
-			Category(errors.CategoryValidation).
-			Context("operation", "read_from_analysis_buffer").
-			Context("source_id", sourceID).
-			Context("display_name", displayName).
-			Build()
-
 		if m := getAnalysisMetrics(); m != nil {
 			m.RecordBufferRead("analysis", sourceID, "error")
 			m.RecordBufferReadError("analysis", sourceID, "buffer_not_found")
 		}
-		return nil, enhancedErr
+		return nil, fmt.Errorf("%w: source ID %s (%s)", ErrBufferNotFound, sourceID, displayName)
 	}
 
 	// Calculate the number of bytes written to the buffer
@@ -641,6 +624,14 @@ func AnalysisBufferMonitor(_ *sync.WaitGroup, bn *birdnet.BirdNET, quitChan chan
 		case <-ticker.C: // Wait for the next tick
 			data, err := ReadFromAnalysisBuffer(sourceID)
 			if err != nil {
+				// If the buffer was removed (e.g., stream stopped), exit gracefully
+				// instead of retrying forever and flooding logs
+				if errors.Is(err, ErrBufferNotFound) {
+					log.Info("analysis buffer removed, stopping monitor",
+						logger.String("source_id", sourceID))
+					return
+				}
+
 				log.Error("buffer read error",
 					logger.String("source_id", sourceID),
 					logger.Error(err))

--- a/internal/myaudio/analysis_buffer_not_found_test.go
+++ b/internal/myaudio/analysis_buffer_not_found_test.go
@@ -1,0 +1,36 @@
+package myaudio
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/errors"
+)
+
+// TestWriteToAnalysisBuffer_NotFound verifies that writing to a non-existent
+// buffer returns ErrBufferNotFound, enabling callers to handle it gracefully.
+func TestWriteToAnalysisBuffer_NotFound(t *testing.T) {
+	t.Parallel()
+
+	err := WriteToAnalysisBuffer("nonexistent_source_id", []byte{0x01, 0x02})
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrBufferNotFound),
+		"expected ErrBufferNotFound sentinel, got: %v", err)
+	assert.Contains(t, err.Error(), "nonexistent_source_id")
+}
+
+// TestReadFromAnalysisBuffer_NotFound verifies that reading from a non-existent
+// buffer returns ErrBufferNotFound, enabling the monitor to exit gracefully.
+func TestReadFromAnalysisBuffer_NotFound(t *testing.T) {
+	t.Parallel()
+
+	data, err := ReadFromAnalysisBuffer("nonexistent_source_id")
+
+	require.Error(t, err)
+	assert.Nil(t, data)
+	assert.True(t, errors.Is(err, ErrBufferNotFound),
+		"expected ErrBufferNotFound sentinel, got: %v", err)
+	assert.Contains(t, err.Error(), "nonexistent_source_id")
+}

--- a/internal/myaudio/errors.go
+++ b/internal/myaudio/errors.go
@@ -9,8 +9,16 @@ var (
 	// ErrSoundLevelProcessorNotRegistered is returned when attempting to process sound level data
 	// for a source that hasn't been registered
 	ErrSoundLevelProcessorNotRegistered = errors.Newf("no sound level processor registered").
-		Component("myaudio").
-		Category(errors.CategoryValidation).
-		Context("operation", "process_sound_level_data").
-		Build()
+						Component("myaudio").
+						Category(errors.CategoryValidation).
+						Context("operation", "process_sound_level_data").
+						Build()
+
+	// ErrBufferNotFound is returned when an analysis or capture buffer does not exist
+	// for a given source ID. This typically occurs when a buffer has been removed
+	// during stream disconnection while reader goroutines still reference it.
+	ErrBufferNotFound = errors.Newf("buffer not found").
+				Component("myaudio").
+				Category(errors.CategoryBuffer).
+				Build()
 )

--- a/internal/myaudio/ffmpeg_manager.go
+++ b/internal/myaudio/ffmpeg_manager.go
@@ -162,14 +162,19 @@ func (m *FFmpegManager) StopStream(url string) error {
 			Build()
 	}
 
+	// Capture source ID before removing from map — buffers and processors
+	// are keyed by source ID (e.g., "rtsp_abcd1234"), not the raw URL.
+	sourceID := stream.source.ID
+
 	// Stop the stream and remove from map while holding lock
 	stream.Stop()
 	delete(m.streams, url)
 
-	// Unregister sound level processor while holding lock
-	UnregisterSoundLevelProcessor(url)
+	// Unregister sound level processor using source ID (registered with source ID)
+	UnregisterSoundLevelProcessor(sourceID)
 	getManagerLogger().Debug("unregistered sound level processor",
 		logger.String("url", privacy.SanitizeStreamUrl(url)),
+		logger.String("source_id", sourceID),
 		logger.String("operation", "stop_stream"))
 
 	// Clean up watchdog tracking for this stream to prevent memory leak
@@ -182,27 +187,30 @@ func (m *FFmpegManager) StopStream(url string) error {
 	// because goroutines waiting on the mutex are not durably blocked, preventing time advancement
 	m.streamsMu.Unlock()
 
-	// Clean up buffers for the stream
+	// Clean up buffers for the stream using source ID (buffers are keyed by source ID)
 	// Wait a short time for any in-flight writes to complete
 	// This sleep is now safe for synctest since mutex is released
 	time.Sleep(100 * time.Millisecond)
 
-	if err := RemoveAnalysisBuffer(url); err != nil {
+	if err := RemoveAnalysisBuffer(sourceID); err != nil {
 		getManagerLogger().Warn("failed to remove analysis buffer",
 			logger.String("url", privacy.SanitizeStreamUrl(url)),
+			logger.String("source_id", sourceID),
 			logger.Error(err),
 			logger.String("operation", "stop_stream_buffer_cleanup"))
 	}
 
-	if err := RemoveCaptureBuffer(url); err != nil {
+	if err := RemoveCaptureBuffer(sourceID); err != nil {
 		getManagerLogger().Warn("failed to remove capture buffer",
 			logger.String("url", privacy.SanitizeStreamUrl(url)),
+			logger.String("source_id", sourceID),
 			logger.Error(err),
 			logger.String("operation", "stop_stream_buffer_cleanup"))
 	}
 
 	getManagerLogger().Info("stopped FFmpeg stream",
 		logger.String("url", privacy.SanitizeStreamUrl(url)),
+		logger.String("source_id", sourceID),
 		logger.String("operation", "stop_stream"))
 	return nil
 }


### PR DESCRIPTION
## Summary

- **Root cause**: `StopStream()` used the raw RTSP URL for buffer and sound level processor cleanup, but these resources are keyed by source ID (e.g., `rtsp_abcd1234`). Cleanup always failed silently, leaking buffers and stale processors.
- **Resilience**: `AnalysisBufferMonitor` retried forever on buffer-not-found errors, flooding logs every second. Now exits gracefully.
- Adds `ErrBufferNotFound` sentinel error for clean detection via `errors.Is()`

## Test plan

- [x] New tests: `TestWriteToAnalysisBuffer_NotFound`, `TestReadFromAnalysisBuffer_NotFound` — verify sentinel wrapping
- [x] `go test -race -v ./internal/myaudio/...` passes
- [x] `golangci-lint run -v` — zero issues
- [ ] CI passes

Fixes #2198

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for missing audio buffers with clearer error messages.
  * Prevented log flooding and eliminated infinite retries when buffers are removed.
  * Enhanced graceful degradation for buffer removal scenarios.

* **Tests**
  * Added test coverage for missing buffer scenarios in read and write operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->