### PR TITLE
fix(taxonomy): add BirdNET synonym mappings for reclassified species

### DIFF
--- a/internal/birdnet/genus.go
+++ b/internal/birdnet/genus.go
@@ -10,10 +10,114 @@ import (
 
 	"github.com/tphakala/birdnet-go/internal/ebird"
 	"github.com/tphakala/birdnet-go/internal/errors"
+	"github.com/tphakala/birdnet-go/internal/logger"
 )
 
 //go:embed data/genus_taxonomy.json
 var genusTaxonomyData []byte
+
+// birdnetSynonyms maps BirdNET model scientific names to their current eBird/Clements
+// taxonomy equivalents. The BirdNET model uses older taxonomic names for some species
+// that have since been reclassified in the eBird/Clements taxonomy (which is the source
+// for genus_taxonomy.json). Without these synonyms, genus lookups fail for affected
+// species because their BirdNET names don't exist in the eBird species index.
+//
+// Format: "birdnet name (lowercase)" → "ebird name (lowercase)"
+// All keys and values must be lowercase to match the normalized species index.
+var birdnetSynonyms = map[string]string{
+	// Cattle Egret: Bubulcus → Ardea (Ardeidae)
+	"bubulcus ibis": "ardea ibis",
+
+	// Bitterns: Ixobrychus → Botaurus (Ardeidae)
+	"ixobrychus cinnamomeus": "botaurus cinnamomeus",
+	"ixobrychus dubius":      "botaurus dubius",
+	"ixobrychus eurhythmus":  "botaurus eurhythmus",
+	"ixobrychus exilis":      "botaurus exilis",
+	"ixobrychus flavicollis": "botaurus flavicollis",
+	"ixobrychus involucris":  "botaurus involucris",
+	"ixobrychus minutus":     "botaurus minutus",
+	"ixobrychus sinensis":    "botaurus sinensis",
+
+	// Owls: Ciccaba → Strix (Strigidae)
+	"ciccaba albitarsis":   "strix albitarsis",
+	"ciccaba huhula":       "strix huhula",
+	"ciccaba nigrolineata": "strix nigrolineata",
+	"ciccaba virgata":      "strix virgata",
+
+	// Manakins: Antilophia → Chiroxiphia (Pipridae)
+	"antilophia bokermanni": "chiroxiphia bokermanni",
+	"antilophia galeata":    "chiroxiphia galeata",
+
+	// Bulbuls: Brachypodius → Microtarsus (Pycnonotidae)
+	"brachypodius eutilotus":      "microtarsus eutilotus",
+	"brachypodius melanocephalos": "microtarsus melanocephalos",
+	"brachypodius melanoleucos":   "microtarsus melanoleucos",
+	"brachypodius priocephalus":   "microtarsus priocephalus",
+	"brachypodius urostictus":     "microtarsus urostictus",
+
+	// Magpie-Jays and Jays: Calocitta/Psilorhinus → Cyanocorax (Corvidae)
+	"calocitta colliei": "cyanocorax colliei",
+	"psilorhinus morio": "cyanocorax morio",
+
+	// Caracaras: Milvago → Daptrius (Falconidae)
+	"milvago chimachima": "daptrius chimachima",
+	"milvago chimango":   "daptrius chimango",
+
+	// Turacos: Musophaga → Tauraco (Musophagidae)
+	"musophaga rossae": "tauraco rossae",
+
+	// Rails: Micropygia → Rufirallus (Rallidae)
+	"micropygia schomburgkii": "rufirallus schomburgkii",
+
+	// Thrushes: Otocichla/Psophocichla → Turdus (Turdidae)
+	"otocichla mupinensis":      "turdus mupinensis",
+	"psophocichla litsitsirupa": "turdus litsitsirupa",
+
+	// Parrotbills: Sinosuthora → Suthora (Sylviidae)
+	"sinosuthora webbiana": "suthora webbiana",
+
+	// Tanagers: Rhodothraupis → Periporphyrus (Cardinalidae)
+	"rhodothraupis celaeno": "periporphyrus celaeno",
+
+	// Australasian Robins: Tregellasia → Eopsaltria (Petroicidae)
+	"tregellasia capito": "eopsaltria capito",
+
+	// Australasian Robins: Peneothello → Melanodryas (Petroicidae)
+	"peneothello sigillata": "melanodryas sigillata",
+	"peneothello cyanus":    "melanodryas cyanus",
+
+	// Rails: Hapalocrex → Laterallus (Rallidae)
+	"hapalocrex flaviventer": "laterallus flaviventer",
+
+	// Cockatoos: Lophochroa → Cacatua (Cacatuidae)
+	"lophochroa leadbeateri": "cacatua leadbeateri",
+
+	// Lories: Pseudeos → Chalcopsitta (Psittaculidae)
+	"pseudeos cardinalis": "chalcopsitta cardinalis", //nolint:misspell // Latin species name, not English
+
+	// Go-away-birds: Corythaixoides → Crinifer (Musophagidae)
+	"corythaixoides concolor":    "crinifer concolor",
+	"corythaixoides leucogaster": "crinifer leucogaster",
+
+	// Hummingbirds: Leucolia → Ramosomyia (Trochilidae)
+	"leucolia violiceps": "ramosomyia violiceps",
+
+	// Hummingbirds: Clytolaema → Heliodoxa (Trochilidae)
+	"clytolaema rubricauda": "heliodoxa rubricauda",
+
+	// Woodpeckers: Reinwardtipicus → Chrysocolaptes (Picidae)
+	"reinwardtipicus validus": "chrysocolaptes validus",
+
+	// Eagles: Dryotriorchis → Circaetus (Accipitridae)
+	"dryotriorchis spectabilis": "circaetus spectabilis",
+
+	// Tyrant Flycatchers: Tumbezia → Ochthoeca (Tyrannidae)
+	"tumbezia salvini": "ochthoeca salvini",
+
+	// Mouse-Warblers: Crateroscelis → Origma (Acanthizidae)
+	"crateroscelis murina":  "origma murina",
+	"crateroscelis robusta": "origma robusta",
+}
 
 // TaxonomyDatabase represents the complete genus/family taxonomy database
 type TaxonomyDatabase struct {
@@ -83,6 +187,13 @@ func LoadTaxonomyDatabase() (*TaxonomyDatabase, error) {
 	db.SpeciesIndex = normalizeSpeciesIndexKeys(db.SpeciesIndex)
 	db.SpeciesIndex = normalizeSpeciesIndexValues(db.SpeciesIndex)
 
+	// Apply BirdNET taxonomy synonyms to the species index.
+	// This adds entries for BirdNET model names that map to the same genus
+	// as their current eBird equivalents, allowing genus lookup to succeed
+	// for species whose scientific names have changed since the BirdNET model
+	// was trained.
+	applyBirdNETSynonyms(db.SpeciesIndex)
+
 	return &db, nil
 }
 
@@ -140,6 +251,31 @@ func normalizeFamilyGeneraValues(families map[string]*FamilyMetadata) map[string
 		}
 	}
 	return normalized
+}
+
+// applyBirdNETSynonyms adds BirdNET model names as aliases in the species index.
+// For each synonym, it looks up the eBird equivalent to find the genus, then adds
+// the BirdNET name pointing to the same genus. Synonyms whose eBird target does not
+// exist in the species index are skipped with a warning log.
+func applyBirdNETSynonyms(speciesIndex map[string]string) {
+	log := GetLogger()
+	applied := 0
+	for birdnetName, ebirdName := range birdnetSynonyms {
+		genus, exists := speciesIndex[ebirdName]
+		if !exists {
+			log.Warn("BirdNET synonym target not found in species index",
+				logger.String("target", ebirdName),
+				logger.String("synonym", birdnetName))
+			continue
+		}
+		// Only add if the BirdNET name is not already in the index
+		if _, alreadyExists := speciesIndex[birdnetName]; !alreadyExists {
+			speciesIndex[birdnetName] = genus
+			applied++
+		}
+	}
+	log.Debug("Applied BirdNET taxonomy synonyms to species index",
+		logger.Int("count", applied))
 }
 
 // GetGenusByScientificName retrieves genus metadata by scientific name

--- a/internal/birdnet/genus_test.go
+++ b/internal/birdnet/genus_test.go
@@ -505,6 +505,107 @@ func TestGetAllSpeciesInOrder_NotFound(t *testing.T) {
 	assert.Error(t, err)
 }
 
+// TestBirdNETSynonyms verifies that BirdNET model names that differ from
+// current eBird taxonomy are resolved correctly via the synonym mapping.
+func TestBirdNETSynonyms(t *testing.T) {
+	t.Parallel()
+	t.Attr("component", "birdnet-genus")
+	t.Attr("category", "synonyms")
+
+	db, err := LoadTaxonomyDatabase()
+	require.NoError(t, err, "Failed to load taxonomy database")
+
+	tests := []struct {
+		name           string
+		scientificName string
+		wantGenus      string
+		wantFamily     string
+	}{
+		{
+			name:           "cattle egret (Bubulcus → Ardea)",
+			scientificName: "Bubulcus ibis",
+			wantGenus:      "ardea",
+			wantFamily:     "Ardeidae",
+		},
+		{
+			name:           "yellow bittern (Ixobrychus → Botaurus)",
+			scientificName: "Ixobrychus sinensis",
+			wantGenus:      "botaurus",
+			wantFamily:     "Ardeidae",
+		},
+		{
+			name:           "mottled owl (Ciccaba → Strix)",
+			scientificName: "Ciccaba virgata",
+			wantGenus:      "strix",
+			wantFamily:     "Strigidae",
+		},
+		{
+			name:           "araripe manakin (Antilophia → Chiroxiphia)",
+			scientificName: "Antilophia bokermanni",
+			wantGenus:      "chiroxiphia",
+			wantFamily:     "Pipridae",
+		},
+		{
+			name:           "yellow-bellied caracara (Milvago → Daptrius)",
+			scientificName: "Milvago chimachima",
+			wantGenus:      "daptrius",
+			wantFamily:     "Falconidae",
+		},
+		{
+			name:           "ross turaco (Musophaga → Tauraco)",
+			scientificName: "Musophaga rossae",
+			wantGenus:      "tauraco",
+			wantFamily:     "Musophagidae",
+		},
+		{
+			name:           "groundscraper thrush (Psophocichla → Turdus)",
+			scientificName: "Psophocichla litsitsirupa",
+			wantGenus:      "turdus",
+			wantFamily:     "Turdidae",
+		},
+		{
+			name:           "major mitchell cockatoo (Lophochroa → Cacatua)",
+			scientificName: "Lophochroa leadbeateri",
+			wantGenus:      "cacatua",
+			wantFamily:     "Cacatuidae",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			genusName, metadata, err := db.GetGenusByScientificName(tt.scientificName)
+
+			require.NoError(t, err, "Synonym lookup should succeed for %s", tt.scientificName)
+			assert.Equal(t, tt.wantGenus, genusName)
+			require.NotNil(t, metadata)
+			assert.Equal(t, tt.wantFamily, metadata.Family)
+		})
+	}
+}
+
+// TestBirdNETSynonymCount verifies that the expected number of synonyms were applied.
+func TestBirdNETSynonymCount(t *testing.T) {
+	t.Parallel()
+	t.Attr("component", "birdnet-genus")
+	t.Attr("category", "synonyms")
+
+	db, err := LoadTaxonomyDatabase()
+	require.NoError(t, err, "Failed to load taxonomy database")
+
+	// Count how many BirdNET synonym keys are present in the species index
+	found := 0
+	for birdnetName := range birdnetSynonyms {
+		if _, exists := db.SpeciesIndex[birdnetName]; exists {
+			found++
+		}
+	}
+
+	assert.Equal(t, len(birdnetSynonyms), found,
+		"All BirdNET synonyms should be present in species index")
+}
+
 // BenchmarkLoadTaxonomyDatabase benchmarks database loading
 func BenchmarkLoadTaxonomyDatabase(b *testing.B) {
 	b.ReportAllocs()


### PR DESCRIPTION
## Summary

- Add synonym mapping layer for ~45 bird species whose BirdNET model names differ from current eBird/Clements taxonomy
- Species like 'Bubulcus ibis' (Cattle Egret) now resolve correctly — eBird reclassified it as 'Ardea ibis'
- Covers reclassifications across 20+ genera: Ixobrychus→Botaurus, Ciccaba→Strix, Milvago→Daptrius, Antilophia→Chiroxiphia, Brachypodius→Microtarsus, and others
- Synonyms are applied at taxonomy database load time, mapping BirdNET names to the same genus as their eBird equivalents
- Code-level approach (not JSON data modification) ensures synonyms survive taxonomy database regeneration

## Test plan

- [x] All existing genus tests pass (`go test -race -v ./internal/birdnet/`)
- [x] New `TestBirdNETSynonyms` validates 8 representative reclassifications with correct genus and family
- [x] New `TestBirdNETSynonymCount` verifies all synonyms are applied
- [x] `golangci-lint run` passes with zero issues
- [ ] CI passes

Fixes #2197

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved support for legacy BirdNET model names through enhanced taxonomy mapping to current eBird standards.

* **Tests**
  * Added test coverage for BirdNET synonym resolution and validation of taxonomy mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->