### PR TITLE
fix(myaudio): prevent ingress path prefix from contaminating FFmpeg binary path

### DIFF
--- a/internal/api/v2/settings_audio.go
+++ b/internal/api/v2/settings_audio.go
@@ -48,6 +48,8 @@ func (c *Controller) handleEqualizerChange(settings *conf.Settings) error {
 // getAudioBlockedFields returns the blocked fields map for the audio section
 func getAudioBlockedFields() map[string]any {
 	return map[string]any{
+		"FfmpegPath":    true, // Runtime: validated at startup by ValidateToolPath, must not be overwritten by API
+		"SoxPath":       true, // Runtime: validated at startup by ValidateToolPath, must not be overwritten by API
 		"SoxAudioTypes": true, // Runtime list of supported audio types
 	}
 }

--- a/internal/api/v2/settings_audio_test.go
+++ b/internal/api/v2/settings_audio_test.go
@@ -1,0 +1,22 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetAudioBlockedFields(t *testing.T) {
+	t.Parallel()
+
+	blocked := getAudioBlockedFields()
+
+	// FfmpegPath must be blocked to prevent ingress/proxy path contamination
+	assert.Equal(t, true, blocked["FfmpegPath"], "FfmpegPath must be blocked from API updates")
+
+	// SoxPath must be blocked for the same reason
+	assert.Equal(t, true, blocked["SoxPath"], "SoxPath must be blocked from API updates")
+
+	// SoxAudioTypes was already blocked
+	assert.Equal(t, true, blocked["SoxAudioTypes"], "SoxAudioTypes must be blocked from API updates")
+}

--- a/internal/myaudio/ffmpeg_common.go
+++ b/internal/myaudio/ffmpeg_common.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -12,10 +13,21 @@ import (
 	"github.com/tphakala/birdnet-go/internal/conf"
 )
 
-// validateFFmpegPath checks if FFmpeg is available
+// validateFFmpegPath checks if the FFmpeg path is valid for execution.
+// It rejects empty paths and paths that appear to be HTTP/proxy URL prefixes
+// rather than filesystem paths (e.g., ingress path contamination).
 func validateFFmpegPath(ffmpegPath string) error {
 	if ffmpegPath == "" {
 		return fmt.Errorf("FFmpeg is not available")
+	}
+	// Reject paths contaminated by HTTP proxy/ingress prefixes.
+	// A valid FFmpeg binary path should be a clean filesystem path,
+	// not contain URL-like segments such as "/api/" or "/ingress/".
+	if !filepath.IsAbs(ffmpegPath) {
+		return fmt.Errorf("FFmpeg path must be absolute, got: %s", ffmpegPath)
+	}
+	if strings.Contains(ffmpegPath, "/api/") || strings.Contains(ffmpegPath, "/ingress/") {
+		return fmt.Errorf("FFmpeg path appears contaminated by proxy/ingress prefix: %s", ffmpegPath)
 	}
 	return nil
 }

--- a/internal/myaudio/ffmpeg_common_test.go
+++ b/internal/myaudio/ffmpeg_common_test.go
@@ -62,6 +62,75 @@ func TestGetAudioDuration(t *testing.T) {
 	}
 }
 
+func TestValidateFFmpegPath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		path    string
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "empty path",
+			path:    "",
+			wantErr: true,
+			errMsg:  "FFmpeg is not available",
+		},
+		{
+			name:    "valid absolute path",
+			path:    "/usr/bin/ffmpeg",
+			wantErr: false,
+		},
+		{
+			name:    "valid absolute path in local bin",
+			path:    "/usr/local/bin/ffmpeg",
+			wantErr: false,
+		},
+		{
+			name:    "relative path rejected",
+			path:    "ffmpeg",
+			wantErr: true,
+			errMsg:  "must be absolute",
+		},
+		{
+			name:    "HA ingress prefix contamination",
+			path:    "/api/hassio_ingress/abc123token/usr/bin/ffmpeg",
+			wantErr: true,
+			errMsg:  "contaminated by proxy/ingress prefix",
+		},
+		{
+			name:    "generic API prefix contamination",
+			path:    "/api/v2/usr/bin/ffmpeg",
+			wantErr: true,
+			errMsg:  "contaminated by proxy/ingress prefix",
+		},
+		{
+			name:    "ingress prefix without api",
+			path:    "/ingress/token123/usr/bin/ffmpeg",
+			wantErr: true,
+			errMsg:  "contaminated by proxy/ingress prefix",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := validateFFmpegPath(tt.path)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errMsg != "" {
+					assert.Contains(t, err.Error(), tt.errMsg)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestGetAudioDurationTimeout(t *testing.T) {
 	skipIfNoSox(t)
 

--- a/internal/myaudio/ffmpeg_export.go
+++ b/internal/myaudio/ffmpeg_export.go
@@ -53,16 +53,17 @@ func ExportAudioWithFFmpeg(pcmData []byte, outputPath string, settings *conf.Aud
 		return enhancedErr
 	}
 
-	if settings.FfmpegPath == "" {
-		enhancedErr := errors.Newf("FFmpeg path is not configured or invalid").
+	if err := validateFFmpegPath(settings.FfmpegPath); err != nil {
+		enhancedErr := errors.Newf("invalid FFmpeg path: %s", err).
 			Component("myaudio").
 			Category(errors.CategoryConfiguration).
 			Context("operation", "export_audio_ffmpeg").
+			Context("ffmpeg_path", settings.FfmpegPath).
 			Build()
 
 		if fileMetrics != nil {
 			fileMetrics.RecordFileOperation("export_ffmpeg", "unknown", "error")
-			fileMetrics.RecordFileOperationError("export_ffmpeg", "unknown", "missing_ffmpeg_path")
+			fileMetrics.RecordFileOperationError("export_ffmpeg", "unknown", "invalid_ffmpeg_path")
 		}
 		return enhancedErr
 	}
@@ -575,16 +576,17 @@ func ExportAudioWithCustomFFmpegArgsContext(ctx context.Context, pcmData []byte,
 		return nil, enhancedErr
 	}
 
-	if ffmpegPath == "" {
-		enhancedErr := errors.Newf("FFmpeg path provided is empty").
+	if err := validateFFmpegPath(ffmpegPath); err != nil {
+		enhancedErr := errors.Newf("invalid FFmpeg path: %s", err).
 			Component("myaudio").
 			Category(errors.CategoryConfiguration).
 			Context("operation", "export_custom_ffmpeg_context").
+			Context("ffmpeg_path", ffmpegPath).
 			Build()
 
 		if fileMetrics != nil {
 			fileMetrics.RecordFileOperation("export_custom_ffmpeg", "unknown", "error")
-			fileMetrics.RecordFileOperationError("export_custom_ffmpeg", "unknown", "empty_ffmpeg_path")
+			fileMetrics.RecordFileOperationError("export_custom_ffmpeg", "unknown", "invalid_ffmpeg_path")
 		}
 		return nil, enhancedErr
 	}
@@ -826,9 +828,8 @@ func AnalyzeAudioLoudness(pcmData []byte, ffmpegPath string) (*LoudnessStats, er
 // This is the context-aware version of AnalyzeAudioLoudness that allows timeout/cancellation
 func AnalyzeAudioLoudnessWithContext(ctx context.Context, pcmData []byte, ffmpegPath string) (*LoudnessStats, error) {
 	log := GetLogger()
-	// Assume ffmpegPath is valid (validated by caller, usually via conf.ValidateAudioSettings)
-	if ffmpegPath == "" {
-		return nil, fmt.Errorf("FFmpeg path provided is empty")
+	if err := validateFFmpegPath(ffmpegPath); err != nil {
+		return nil, fmt.Errorf("invalid FFmpeg path: %w", err)
 	}
 
 	// Get standard input format arguments

--- a/internal/myaudio/streamingtest/streaming_integration_test.go
+++ b/internal/myaudio/streamingtest/streaming_integration_test.go
@@ -98,7 +98,11 @@ func setupTestSettings(t *testing.T, streamURL, streamType, transport string) {
 	originalSettings := conf.GetTestSettings()
 
 	settings := conf.GetTestSettings()
-	settings.Realtime.Audio.FfmpegPath = "ffmpeg" // Use system FFmpeg
+	ffmpegPath, err := exec.LookPath("ffmpeg")
+	if err != nil {
+		t.Fatalf("FFmpeg not found in PATH: %v", err)
+	}
+	settings.Realtime.Audio.FfmpegPath = ffmpegPath // Use resolved absolute path
 	settings.Realtime.RTSP.Streams = []conf.StreamConfig{
 		{
 			Name:      "Integration Test Stream",


### PR DESCRIPTION
## Summary

- Block `FfmpegPath` and `SoxPath` from API settings updates to prevent proxy/ingress path contamination
- Enhance `validateFFmpegPath()` with absolute path and proxy-prefix detection as defense in depth
- Fix streaming integration test to use resolved absolute FFmpeg path

## Problem

When running behind Home Assistant's ingress proxy, the ingress path prefix (`/api/hassio_ingress/<token>/`) gets prepended to the FFmpeg binary path, producing `/api/hassio_ingress/<token>/usr/bin/ffmpeg` instead of `/usr/bin/ffmpeg`.

**Root cause**: `FfmpegPath` was not blocked from API settings updates. The HA ingress proxy can rewrite JSON response content, contaminating the path value. When the frontend saves settings back, the contaminated path overwrites the validated runtime value.

## Fix (two layers of defense)

### Layer 1: Block API updates (primary)
Added `FfmpegPath` and `SoxPath` to `getAudioBlockedFields()` — these are runtime values validated at startup by `ValidateToolPath` and must not be overwritten by the settings API.

### Layer 2: Path validation at exec point (defense in depth)
Enhanced `validateFFmpegPath()` to reject:
- Non-absolute paths (must start with `/`)
- Paths containing `/api/` or `/ingress/` (proxy contamination markers)

Applied this validation in `ExportAudioWithFFmpeg`, `ExportAudioWithCustomFFmpegArgsContext`, and `AnalyzeAudioLoudnessWithContext`.

## Test plan

- [x] `TestValidateFFmpegPath` — 7 table-driven subtests covering empty, valid, relative, and 3 contamination patterns
- [x] `TestGetAudioBlockedFields` — verifies FfmpegPath, SoxPath, SoxAudioTypes are all blocked
- [x] All existing FFmpeg tests pass (`go test -race -v -run FFmpeg ./internal/myaudio/`)
- [x] Linter clean (`golangci-lint run`)

Fixes #2195

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced audio configuration validation to reject invalid FFmpeg and Sox paths (empty, relative, or proxy-like paths).
  * Improved error messaging for invalid audio paths.

* **Bug Fixes**
  * Prevented accidental API overwriting of runtime-validated audio paths.

* **Tests**
  * Added comprehensive test coverage for audio settings validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->