### PR TITLE
fix(myaudio): preserve exponential backoff in audio file validation retries

### DIFF
--- a/internal/myaudio/validate.go
+++ b/internal/myaudio/validate.go
@@ -219,8 +219,9 @@ func ValidateAudioFileWithRetry(ctx context.Context, audioPath string) (*AudioVa
 			m.RecordFileOperation("validate_retry", result.Format, fmt.Sprintf("attempt_%d", attempt))
 		}
 
-		// If there's a specific retry suggestion, use it
-		if result.RetryAfter > 0 {
+		// Honor the retry suggestion only if it's longer than the current
+		// exponential backoff delay, so that backoff growth is preserved.
+		if result.RetryAfter > retryDelay {
 			retryDelay = result.RetryAfter
 		}
 


### PR DESCRIPTION
## Summary

- Follow-up from PR #2210: the exponential backoff in `ValidateAudioFileWithRetry` was effectively a no-op because `result.RetryAfter` unconditionally overwrote `retryDelay` on each iteration, resetting it to a constant value
- Changed the condition from `result.RetryAfter > 0` to `result.RetryAfter > retryDelay` so that the exponential backoff delay is preserved unless the retry suggestion is actually longer

## Test plan

- [x] Existing `TestValidateAudioFileWithRetry` tests pass with `-race`
- [x] `golangci-lint run -v ./internal/myaudio/...` clean
- [x] Gemini peer review confirms correctness

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved retry backoff logic to more intelligently adjust delays based on server-provided timing signals, preventing unnecessary increases while maintaining exponential backoff characteristics and optimizing recovery timing during transient failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->