### PR TITLE
fix(mqtt): improve connection error handling and reconnection backoff

### DIFF
--- a/internal/errors/telemetry_integration.go
+++ b/internal/errors/telemetry_integration.go
@@ -56,6 +56,7 @@ var (
 		"network is unreachable",
 		"i/o timeout",
 		"tls handshake timeout",
+		"eof", // Connection lost (e.g., MQTT broker disconnect)
 	}
 )
 

--- a/internal/mqtt/client.go
+++ b/internal/mqtt/client.go
@@ -37,6 +37,11 @@ type client struct {
 	metrics           *metrics.MQTTMetrics
 	controlChan       chan string        // Channel for control signals
 	onConnectHandlers []OnConnectHandler // Handlers called on successful connection
+	// Reconnection backoff and error suppression state
+	reconnectAttempts  int       // consecutive failed reconnect attempts for backoff calculation
+	lastConnErrMsg     string    // last connection error message for deduplication
+	connErrCount       int       // count of consecutive identical connection errors
+	lastConnErrLogTime time.Time // when the repeated error was last logged
 }
 
 // NewClient creates a new MQTT client with the provided configuration.
@@ -784,6 +789,13 @@ func (c *client) onConnect(client mqtt.Client) {
 		logger.String("client_id", c.config.ClientID))
 	c.metrics.UpdateConnectionStatus(true)
 
+	// Reset reconnection backoff state on successful connection
+	c.mu.Lock()
+	c.reconnectAttempts = 0
+	c.connErrCount = 0
+	c.lastConnErrMsg = ""
+	c.mu.Unlock()
+
 	// Publish MQTT connected alert event
 	alerting.TryPublish(&alerting.AlertEvent{
 		ObjectType: alerting.ObjectTypeIntegration,
@@ -829,19 +841,12 @@ func (c *client) onConnect(client mqtt.Client) {
 }
 
 func (c *client) onConnectionLost(client mqtt.Client, err error) {
-	// Enhance the connection lost error
-	enhancedErr := errors.New(err).
-		Component("mqtt").
-		Category(errors.CategoryMQTTConnection).
-		Context("broker", c.config.Broker).
-		Context("client_id", c.config.ClientID).
-		Context("operation", "connection_lost").
-		Build()
-
-	GetLogger().Error("Connection to MQTT broker lost",
+	// Connection loss is expected for long-running MQTT connections (EOF, network changes).
+	// Log as warning, not error, to avoid Sentry noise.
+	GetLogger().Warn("Connection to MQTT broker lost",
 		logger.String("broker", c.config.Broker),
 		logger.String("client_id", c.config.ClientID),
-		logger.Error(enhancedErr))
+		logger.Error(err))
 	c.metrics.UpdateConnectionStatus(false)
 	c.metrics.IncrementErrorsWithCategory("mqtt-connection", "connection_lost")
 
@@ -878,8 +883,12 @@ func (c *client) startReconnectTimer() {
 		c.reconnectTimer.Stop()
 	}
 
-	reconnectDelay := c.config.ReconnectDelay
-	GetLogger().Info("Starting reconnect timer", logger.Duration("delay", reconnectDelay))
+	// Calculate delay with exponential backoff: baseDelay * 2^attempts, capped at MaxReconnectDelay
+	reconnectDelay := calculateBackoffDelay(c.config.ReconnectDelay, c.reconnectAttempts)
+
+	GetLogger().Info("Starting reconnect timer",
+		logger.Duration("delay", reconnectDelay),
+		logger.Int("attempt", c.reconnectAttempts+1))
 	c.reconnectTimer = time.AfterFunc(reconnectDelay, func() {
 		select {
 		case <-c.reconnectStop: // Check if disconnect was called before timer fired
@@ -914,15 +923,7 @@ func (c *client) reconnectWithBackoff() {
 
 	// Use connectWithOptions with isAutoReconnect=true to bypass cooldown check
 	if err := c.connectWithOptions(ctx, true); err != nil {
-		log.Error("Reconnect attempt failed", logger.Error(err))
-
-		// Extract error category for metrics
-		errorCategory := "generic"
-		var enhancedErr *errors.EnhancedError
-		if errors.As(err, &enhancedErr) {
-			errorCategory = enhancedErr.GetCategory()
-		}
-		c.metrics.IncrementErrorsWithCategory(errorCategory, "reconnect_failed")
+		c.handleReconnectFailure(log, err)
 
 		// Check if stopped *after* failed attempt before rescheduling
 		select {
@@ -930,14 +931,72 @@ func (c *client) reconnectWithBackoff() {
 			log.Info("Reconnect mechanism stopped after failed attempt, not rescheduling")
 			return
 		default:
-			// Schedule next attempt
-			c.startReconnectTimer() // Reschedule another attempt after delay
+			// Schedule next attempt with backoff
+			c.startReconnectTimer()
 		}
 	} else {
 		// Connection successful, logged by onConnect
 		log.Info("Reconnect successful")
-		// No need to call startReconnectTimer here, connection is established
 	}
+}
+
+// handleReconnectFailure processes a failed reconnect attempt, tracking attempts
+// for backoff and suppressing repeated identical errors.
+func (c *client) handleReconnectFailure(log logger.Logger, err error) {
+	errMsg := err.Error()
+
+	c.mu.Lock()
+	c.reconnectAttempts++
+	attempt := c.reconnectAttempts
+
+	// Check if this is the same error as last time
+	isSameError := c.lastConnErrMsg == errMsg
+	if isSameError {
+		c.connErrCount++
+	} else {
+		c.lastConnErrMsg = errMsg
+		c.connErrCount = 1
+		c.lastConnErrLogTime = time.Time{} // Reset to force immediate log
+	}
+
+	connErrCount := c.connErrCount
+	lastLogTime := c.lastConnErrLogTime
+	c.mu.Unlock()
+
+	// Determine whether to log this error
+	shouldLog := !isSameError || // Always log new/different errors
+		connErrCount == 1 || // Always log first occurrence
+		time.Since(lastLogTime) >= RepeatedErrorLogInterval // Periodic reminder
+
+	if shouldLog {
+		if connErrCount > 1 {
+			log.Warn("Reconnect attempt failed (repeated error)",
+				logger.Error(err),
+				logger.Int("attempt", attempt),
+				logger.Int("consecutive_same_errors", connErrCount))
+		} else {
+			log.Warn("Reconnect attempt failed",
+				logger.Error(err),
+				logger.Int("attempt", attempt))
+		}
+
+		c.mu.Lock()
+		c.lastConnErrLogTime = time.Now()
+		c.mu.Unlock()
+	} else {
+		log.Debug("Reconnect attempt failed (suppressed repeated error)",
+			logger.Error(err),
+			logger.Int("attempt", attempt),
+			logger.Int("consecutive_same_errors", connErrCount))
+	}
+
+	// Extract error category for metrics (always track, even when log is suppressed)
+	errorCategory := "generic"
+	var enhancedErr *errors.EnhancedError
+	if errors.As(err, &enhancedErr) {
+		errorCategory = enhancedErr.GetCategory()
+	}
+	c.metrics.IncrementErrorsWithCategory(errorCategory, "reconnect_failed")
 }
 
 // createTLSConfig creates a TLS configuration based on the client settings

--- a/internal/mqtt/client_test.go
+++ b/internal/mqtt/client_test.go
@@ -1275,3 +1275,164 @@ func TestTimeRoundingEdgeCase(t *testing.T) {
 		})
 	}
 }
+
+// TestCalculateBackoffDelay verifies exponential backoff delay calculation
+func TestCalculateBackoffDelay(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		baseDelay time.Duration
+		attempts  int
+		expected  time.Duration
+	}{
+		{
+			name:      "Zero attempts returns base delay",
+			baseDelay: 1 * time.Second,
+			attempts:  0,
+			expected:  1 * time.Second,
+		},
+		{
+			name:      "One attempt doubles delay",
+			baseDelay: 1 * time.Second,
+			attempts:  1,
+			expected:  2 * time.Second,
+		},
+		{
+			name:      "Two attempts quadruples delay",
+			baseDelay: 1 * time.Second,
+			attempts:  2,
+			expected:  4 * time.Second,
+		},
+		{
+			name:      "Three attempts gives 8x delay",
+			baseDelay: 1 * time.Second,
+			attempts:  3,
+			expected:  8 * time.Second,
+		},
+		{
+			name:      "Large attempts cap at MaxReconnectDelay",
+			baseDelay: 1 * time.Second,
+			attempts:  100,
+			expected:  MaxReconnectDelay,
+		},
+		{
+			name:      "Caps at boundary",
+			baseDelay: 1 * time.Second,
+			attempts:  20, // 2^20 seconds = ~1048576s, way past 5 min
+			expected:  MaxReconnectDelay,
+		},
+		{
+			name:      "Custom base delay",
+			baseDelay: 500 * time.Millisecond,
+			attempts:  1,
+			expected:  1 * time.Second,
+		},
+		{
+			name:      "Custom base delay caps correctly",
+			baseDelay: 2 * time.Minute,
+			attempts:  2, // 2min * 4 = 8min > MaxReconnectDelay (5min)
+			expected:  MaxReconnectDelay,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := calculateBackoffDelay(tt.baseDelay, tt.attempts)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// TestHandleReconnectFailureErrorSuppression verifies that repeated identical
+// connection errors are suppressed after the first occurrence.
+func TestHandleReconnectFailureErrorSuppression(t *testing.T) {
+	t.Parallel()
+
+	metrics, err := observability.NewMetrics()
+	require.NoError(t, err)
+
+	config := DefaultConfig()
+	config.Broker = testExampleBroker
+	config.ClientID = testClientID
+
+	c := &client{
+		config:        config,
+		metrics:       metrics.MQTT,
+		reconnectStop: make(chan struct{}),
+	}
+
+	testLog := GetLogger().With(
+		logger.String("broker", config.Broker),
+		logger.String("client_id", config.ClientID))
+
+	testErr := errors.New("connection refused")
+
+	// First failure should set state
+	c.handleReconnectFailure(testLog, testErr)
+
+	c.mu.RLock()
+	assert.Equal(t, 1, c.reconnectAttempts, "First failure should increment attempts")
+	assert.Equal(t, testErr.Error(), c.lastConnErrMsg, "Should store error message")
+	assert.Equal(t, 1, c.connErrCount, "First occurrence count should be 1")
+	assert.False(t, c.lastConnErrLogTime.IsZero(), "Should record log time")
+	c.mu.RUnlock()
+
+	// Second failure with same error should increment count
+	c.handleReconnectFailure(testLog, testErr)
+
+	c.mu.RLock()
+	assert.Equal(t, 2, c.reconnectAttempts, "Second failure should increment attempts")
+	assert.Equal(t, 2, c.connErrCount, "Same error should increment count")
+	c.mu.RUnlock()
+
+	// Failure with different error should reset suppression state
+	differentErr := errors.New("no route to host")
+	c.handleReconnectFailure(testLog, differentErr)
+
+	c.mu.RLock()
+	assert.Equal(t, 3, c.reconnectAttempts, "Third failure should increment attempts")
+	assert.Equal(t, differentErr.Error(), c.lastConnErrMsg, "Should update to new error message")
+	assert.Equal(t, 1, c.connErrCount, "Different error should reset count to 1")
+	c.mu.RUnlock()
+}
+
+// TestOnConnectResetsBackoffState verifies that successful connection resets
+// all reconnection backoff state.
+func TestOnConnectResetsBackoffState(t *testing.T) {
+	t.Parallel()
+
+	metrics, err := observability.NewMetrics()
+	require.NoError(t, err)
+
+	config := DefaultConfig()
+	config.Broker = testExampleBroker
+	config.ClientID = testClientID
+
+	c := &client{
+		config:             config,
+		metrics:            metrics.MQTT,
+		reconnectStop:      make(chan struct{}),
+		reconnectAttempts:  5,
+		lastConnErrMsg:     "some error",
+		connErrCount:       3,
+		lastConnErrLogTime: time.Now(),
+	}
+
+	// Create a mock paho client that reports as connected
+	opts := paho.NewClientOptions()
+	opts.AddBroker(testExampleBroker)
+	opts.SetAutoReconnect(false)
+	mockClient := paho.NewClient(opts)
+
+	// Call onConnect (will fail to publish LWT since we're not really connected,
+	// but it should still reset backoff state)
+	c.onConnect(mockClient)
+
+	c.mu.RLock()
+	assert.Equal(t, 0, c.reconnectAttempts, "Should reset reconnect attempts")
+	assert.Equal(t, 0, c.connErrCount, "Should reset error count")
+	assert.Empty(t, c.lastConnErrMsg, "Should clear last error message")
+	c.mu.RUnlock()
+}

--- a/internal/mqtt/mqtt.go
+++ b/internal/mqtt/mqtt.go
@@ -31,7 +31,24 @@ const (
 	MinConnectTimeout = 500 * time.Millisecond
 	// ReconnectContextGrace is the additional time beyond ConnectTimeout for reconnect context
 	ReconnectContextGrace = 10 * time.Second
+	// MaxReconnectDelay is the maximum delay between reconnection attempts (backoff cap)
+	MaxReconnectDelay = 5 * time.Minute
+	// RepeatedErrorLogInterval controls how often repeated identical connection errors are logged
+	RepeatedErrorLogInterval = 5 * time.Minute
 )
+
+// calculateBackoffDelay computes the reconnect delay with exponential backoff.
+// The delay doubles with each attempt, capped at MaxReconnectDelay.
+func calculateBackoffDelay(baseDelay time.Duration, attempts int) time.Duration {
+	delay := baseDelay
+	for range attempts {
+		delay *= 2
+		if delay >= MaxReconnectDelay {
+			return MaxReconnectDelay
+		}
+	}
+	return delay
+}
 
 // durationToMillisUint safely converts a time.Duration to uint milliseconds.
 // Returns 0 for negative durations. This prevents integer overflow when


### PR DESCRIPTION
## Summary
- Downgrade "connection lost" from error to warning — connection drops are expected for long-running MQTT and were generating Sentry noise (EOF errors, 4 occurrences)
- Add exponential backoff for reconnection attempts (1s → 2s → 4s → ... capped at 5 minutes) — previously used a fixed 1s delay
- Suppress repeated identical connection errors — log first occurrence immediately, then only every 5 minutes to reduce log noise
- Add `eof` to Sentry network noise patterns to filter connection-lost errors from telemetry
- Reset all backoff state on successful reconnection

## Test plan
- [x] `TestCalculateBackoffDelay` — 8 subtests verifying exponential growth, capping at MaxReconnectDelay, custom base delays
- [x] `TestHandleReconnectFailureErrorSuppression` — verifies first error logged, same error suppressed, different error resets state
- [x] `TestOnConnectResetsBackoffState` — verifies reconnect attempts, error count, and last error message are reset on connect
- [x] All existing MQTT tests pass with `-race` flag
- [x] `golangci-lint` passes with 0 issues
- [x] Gemini peer review approved

Fixes #2205

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * MQTT client now implements exponential backoff for reconnection attempts.

* **Bug Fixes**
  * Improved error deduplication to reduce duplicate logging and telemetry noise from repeated connection issues.
  * Enhanced network disconnection handling and error recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->