### PR TITLE
fix(imageprovider): cache network failures to avoid repeated broken DNS lookups

### DIFF
--- a/internal/imageprovider/network_failure_test.go
+++ b/internal/imageprovider/network_failure_test.go
@@ -1,0 +1,137 @@
+package imageprovider
+
+import (
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestIsNetworkError tests detection of DNS and network-level errors.
+func TestIsNetworkError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil error is not a network error",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "DNS error",
+			err: &net.DNSError{
+				Err:  "server misbehaving",
+				Name: "en.wikipedia.org",
+			},
+			want: true,
+		},
+		{
+			name: "net.OpError wrapping dial failure",
+			err: &net.OpError{
+				Op:  "dial",
+				Net: "tcp",
+				Err: fmt.Errorf("connection refused"),
+			},
+			want: true,
+		},
+		{
+			name: "error message containing dial tcp",
+			err:  fmt.Errorf("Get \"https://en.wikipedia.org\": dial tcp: lookup en.wikipedia.org: no such host"),
+			want: true,
+		},
+		{
+			name: "error message containing no such host",
+			err:  fmt.Errorf("lookup en.wikipedia.org: no such host"),
+			want: true,
+		},
+		{
+			name: "error message containing connection refused",
+			err:  fmt.Errorf("dial tcp 1.2.3.4:443: connection refused"),
+			want: true,
+		},
+		{
+			name: "HTTP 500 error is not a network error",
+			err:  fmt.Errorf("HTTP 500 Internal Server Error"),
+			want: false,
+		},
+		{
+			name: "JSON parsing error is not a network error",
+			err:  fmt.Errorf("invalid character '<' looking for beginning of value"),
+			want: false,
+		},
+		{
+			name: "generic error is not a network error",
+			err:  fmt.Errorf("something went wrong"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := isNetworkError(tt.err)
+			assert.Equal(t, tt.want, got, "isNetworkError(%v)", tt.err)
+		})
+	}
+}
+
+// TestNetworkErrorOpensCircuitBreaker tests that network/DNS failures open the circuit breaker.
+func TestNetworkErrorOpensCircuitBreaker(t *testing.T) {
+	t.Parallel()
+
+	provider := &wikiMediaProvider{
+		maxRetries: 1,
+	}
+
+	// Verify circuit is initially closed
+	open, _ := provider.isCircuitOpen()
+	assert.False(t, open, "circuit should start closed")
+
+	// Simulate a DNS error triggering circuit open
+	dnsErr := &net.DNSError{
+		Err:  "server misbehaving",
+		Name: "en.wikipedia.org",
+	}
+	provider.openCircuit(circuitBreakerNetworkDuration,
+		fmt.Sprintf("Network/DNS failure: %s", dnsErr.Error()))
+
+	// Verify circuit is now open
+	open, reason := provider.isCircuitOpen()
+	assert.True(t, open, "circuit should be open after network error")
+	assert.Contains(t, reason, "Network/DNS failure", "reason should mention network failure")
+	assert.Contains(t, reason, "server misbehaving", "reason should contain original error")
+}
+
+// TestNetworkErrorLogDowngrade tests that repeated network errors are downgraded to debug level.
+func TestNetworkErrorLogDowngrade(t *testing.T) {
+	t.Parallel()
+
+	provider := &wikiMediaProvider{}
+
+	// First call: CompareAndSwap(false, true) should succeed
+	swapped := provider.networkErrorLogged.CompareAndSwap(false, true)
+	assert.True(t, swapped, "first network error should log at Error level")
+
+	// Second call: CompareAndSwap(false, true) should fail (already true)
+	swapped = provider.networkErrorLogged.CompareAndSwap(false, true)
+	assert.False(t, swapped, "repeated network error should be downgraded to Debug level")
+
+	// Reset on circuit recovery
+	provider.resetCircuit()
+	swapped = provider.networkErrorLogged.CompareAndSwap(false, true)
+	assert.True(t, swapped, "after circuit reset, first error should log at Error level again")
+}
+
+// TestCircuitBreakerNetworkDuration tests the constant value is reasonable.
+func TestCircuitBreakerNetworkDuration(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, 2*time.Minute, circuitBreakerNetworkDuration,
+		"network circuit breaker duration should be 2 minutes")
+}

--- a/internal/imageprovider/wikipedia.go
+++ b/internal/imageprovider/wikipedia.go
@@ -7,11 +7,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"runtime"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/antonholmquist/jason"
@@ -39,6 +41,7 @@ const (
 	circuitBreakerBlockedDuration        = 5 * time.Minute  // Access blocked circuit breaker duration
 	circuitBreakerUserAgentDuration      = 10 * time.Minute // User-Agent violation circuit breaker duration
 	circuitBreakerServiceUnavailDuration = 30 * time.Second // Service unavailable circuit breaker duration
+	circuitBreakerNetworkDuration        = 2 * time.Minute  // Network/DNS failure circuit breaker duration
 
 	// HTTP client configuration
 	httpClientTimeout         = 30 * time.Second
@@ -94,6 +97,9 @@ type wikiMediaProvider struct {
 	circuitOpenUntil time.Time // When the circuit breaker can be closed again
 	circuitFailures  int       // Number of consecutive failures
 	circuitLastError string    // Last error message for logging
+
+	// Track whether a network error has been logged at Error level to avoid log spam
+	networkErrorLogged atomic.Bool
 }
 
 // wikiMediaAuthor represents the author information for a Wikipedia image.
@@ -145,6 +151,7 @@ func (l *wikiMediaProvider) resetCircuit() {
 	l.circuitOpenUntil = time.Time{}
 	l.circuitFailures = 0
 	l.circuitLastError = ""
+	l.networkErrorLogged.Store(false)
 }
 
 // makeAPIRequest performs a direct HTTP GET request to Wikipedia API with proper headers.
@@ -825,6 +832,28 @@ func logAPIError(category apiErrorCategory, reqID, species string, err error) {
 		logger.String("troubleshooting_hint", getTroubleshootingHint(category)))
 }
 
+// logNetworkError logs network errors, downgrading to debug level after the first occurrence
+// to avoid log spam when DNS/network is persistently broken.
+func (l *wikiMediaProvider) logNetworkError(category apiErrorCategory, reqID, species string, err error) {
+	fields := []logger.Field{
+		logger.String("provider", wikiProviderName),
+		logger.String("error_category", category.Type),
+		logger.String("error_description", category.Description),
+		logger.String("error_severity", category.Severity),
+		logger.Bool("actionable", category.Actionable),
+		logger.String("request_id", reqID),
+		logger.String("species_query", species),
+		logger.String("original_error", err.Error()),
+		logger.String("troubleshooting_hint", getTroubleshootingHint(category)),
+	}
+
+	if l.networkErrorLogged.CompareAndSwap(false, true) {
+		GetLogger().Error("Wikipedia API error - categorized for diagnostics", fields...)
+	} else {
+		GetLogger().Debug("Wikipedia API error (repeated, suppressed)", fields...)
+	}
+}
+
 // getTroubleshootingHint provides actionable troubleshooting advice based on error category
 func getTroubleshootingHint(category apiErrorCategory) string {
 	switch category.Type {
@@ -1001,6 +1030,22 @@ func buildRetryExhaustedError(lastErr error, reqID string, params map[string]str
 		Build()
 }
 
+// isNetworkError checks if an error is a network-level failure (DNS, dial, connection refused).
+func isNetworkError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var netErr *net.OpError
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) || errors.As(err, &netErr) {
+		return true
+	}
+	errMsg := err.Error()
+	return strings.Contains(errMsg, "dial tcp") ||
+		strings.Contains(errMsg, "no such host") ||
+		strings.Contains(errMsg, "connection refused")
+}
+
 // queryWithRetryAndLimiter performs a query with retry logic using the specified rate limiter.
 // The context is used for cancellation, deadlines, and rate limiting.
 func (l *wikiMediaProvider) queryWithRetryAndLimiter(ctx context.Context, reqID string, params map[string]string, limiter *rate.Limiter) (*jason.Object, error) {
@@ -1050,7 +1095,14 @@ func (l *wikiMediaProvider) queryWithRetryAndLimiter(ctx context.Context, reqID 
 		time.Sleep(waitDuration)
 	}
 
-	logAPIError(errorCategoryNetworkFailure, reqID, params["titles"], lastErr)
+	if isNetworkError(lastErr) {
+		l.openCircuit(circuitBreakerNetworkDuration,
+			fmt.Sprintf("Network/DNS failure: %s", lastErr.Error()))
+		l.logNetworkError(errorCategoryNetworkFailure, reqID, params["titles"], lastErr)
+	} else {
+		logAPIError(errorCategoryNetworkFailure, reqID, params["titles"], lastErr)
+	}
+
 	return nil, buildRetryExhaustedError(lastErr, reqID, params, l.maxRetries)
 }
 


### PR DESCRIPTION
## Summary
- Open circuit breaker (2min TTL) on network/DNS failures after retry exhaustion, preventing repeated lookups against broken resolvers
- Downgrade repeated network failure logs to debug level after the first occurrence to reduce log noise
- Add `isNetworkError()` helper to detect DNS, dial, and connection errors via `net.DNSError`/`net.OpError` unwrapping and string matching
- Reset log suppression flag when circuit breaker resets on recovery

## Test plan
- Added `TestIsNetworkError` with 9 table-driven subtests covering DNS errors, OpError, string-matched errors, nil, and non-network errors
- Added `TestNetworkErrorOpensCircuitBreaker` verifying circuit opens with correct reason on DNS failure
- Added `TestNetworkErrorLogDowngrade` verifying first-vs-repeated log level behavior and reset on recovery
- Added `TestCircuitBreakerNetworkDuration` verifying constant value
- All existing imageprovider tests pass with `-race`
- Zero golangci-lint issues

Fixes #2207

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive network failure handling tests for image provider

* **Bug Fixes**
  * Improved handling of network and DNS errors
  * Optimized logging to reduce spam from repeated network failures
  * Enhanced circuit breaker to detect and handle network-level failures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->