### PR TITLE
fix(datastore): restore species_code and fix empty summary in v2only analytics

### DIFF
--- a/internal/datastore/v2only/datastore.go
+++ b/internal/datastore/v2only/datastore.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"maps"
+	"math"
 	"slices"
 	"sort"
 	"strconv"
@@ -139,6 +140,10 @@ type Datastore struct {
 	// Used for display purposes in analytics and summary endpoints.
 	commonNameMap map[string]string
 
+	// speciesCodeMap provides O(1) lookup from scientific name to eBird species code.
+	// Populated from 3-part label format "ScientificName_CommonName_SpeciesCode".
+	speciesCodeMap map[string]string
+
 	// dbstatAvailable caches whether the dbstat virtual table exists.
 	// 0 = unchecked, 1 = available, -1 = not available.
 	dbstatAvailable int32
@@ -238,18 +243,26 @@ func New(cfg *Config) (*Datastore, error) {
 	}
 
 	// Build species name maps from labels.
-	// Labels are in "ScientificName_CommonName" format (e.g., "Turdus merula_Eurasian Blackbird").
+	// Labels are in "ScientificName_CommonName[_SpeciesCode]" format
+	// (e.g., "Turdus merula_Eurasian Blackbird_eurbla1").
 	// See issue #1907 for context on speciesMap usage.
 	speciesMap := make(map[string]string)
 	commonNameMap := make(map[string]string)
+	speciesCodeMap := make(map[string]string)
 	for _, label := range cfg.Labels {
-		parts := strings.SplitN(label, "_", 2)
-		if len(parts) == 2 {
+		parts := strings.SplitN(label, "_", 3)
+		if len(parts) >= 2 {
 			scientificName := strings.TrimSpace(parts[0])
 			commonName := strings.TrimSpace(parts[1])
 			if commonName != "" && scientificName != "" {
 				speciesMap[strings.ToLower(commonName)] = scientificName
 				commonNameMap[scientificName] = commonName
+				if len(parts) == 3 {
+					code := strings.TrimSpace(parts[2])
+					if code != "" {
+						speciesCodeMap[scientificName] = code
+					}
+				}
 			}
 		}
 	}
@@ -272,6 +285,7 @@ func New(cfg *Config) (*Datastore, error) {
 		avesClassID:        avesClassID,
 		speciesMap:         speciesMap,
 		commonNameMap:      commonNameMap,
+		speciesCodeMap:     speciesCodeMap,
 		dbCounters:         dbCounters,
 	}, nil
 }
@@ -946,6 +960,7 @@ func (ds *Datastore) GetTopBirdsData(selectedDate string, minConfidenceNormalize
 		note := datastore.Note{
 			ScientificName: sciName,
 			CommonName:     commonName,
+			SpeciesCode:    ds.speciesCodeMap[sciName],
 			Confidence:     r.MaxConfidence,
 			Date:           selectedDate,
 			Time:           latestTime.Format(time.TimeOnly),
@@ -2089,7 +2104,7 @@ func (ds *Datastore) GetAllImageCaches(providerName string) ([]datastore.ImageCa
 // ============================================================
 
 // parseDateRange parses start and end date strings to Unix timestamps.
-// Returns (0, 0) if no dates provided, meaning no date filtering.
+// When no dates are provided, returns (0, math.MaxInt64) to match all records.
 // The end time is exclusive (start of next day) to be used with < in queries.
 func (ds *Datastore) parseDateRange(startDate, endDate string) (start, end int64, err error) {
 	if startDate != "" {
@@ -2107,6 +2122,13 @@ func (ds *Datastore) parseDateRange(startDate, endDate string) (start, end int64
 		// End time is exclusive (start of next day) - use with < in queries
 		end = t.Add(24 * time.Hour).Unix()
 	}
+
+	// When no end date specified, use max int64 to include all records.
+	// Without this, WHERE detected_at >= 0 AND detected_at < 0 matches nothing.
+	if end == 0 {
+		end = math.MaxInt64
+	}
+
 	return start, end, nil
 }
 
@@ -2137,7 +2159,7 @@ func (ds *Datastore) GetSpeciesSummaryData(ctx context.Context, startDate, endDa
 		result = append(result, datastore.SpeciesSummaryData{
 			ScientificName: sciName,
 			CommonName:     commonName,
-			SpeciesCode:    "", // Not available in v2 schema
+			SpeciesCode:    ds.speciesCodeMap[sciName],
 			Count:          int(d.TotalDetections),
 			FirstSeen:      time.Unix(d.FirstDetection, 0).In(ds.timezone),
 			LastSeen:       time.Unix(d.LastDetection, 0).In(ds.timezone),

--- a/internal/datastore/v2only/datastore_test.go
+++ b/internal/datastore/v2only/datastore_test.go
@@ -1089,3 +1089,105 @@ func TestV2OnlyDatastore_Save_DuplicatePredictionLabels(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, preds, 2, "duplicate label should be collapsed to single prediction")
 }
+
+// TestGetTopBirdsData_SpeciesCode verifies that species codes from 3-part labels
+// are populated in the GetTopBirdsData response. Regression test for issue #2191.
+func TestGetTopBirdsData_SpeciesCode(t *testing.T) {
+	labels := []string{
+		"Corvus corax_Common Raven_comrav",
+		"Turdus merula_Eurasian Blackbird_eurbla1",
+		"Passer domesticus_House Sparrow", // 2-part label without species code
+	}
+	ds, cleanup := setupTestDatastoreWithLabels(t, labels)
+	defer cleanup()
+
+	now := time.Now().UTC()
+	dateStr := now.Format(time.DateOnly)
+
+	// Save detections for all three species
+	for _, sci := range []string{"Corvus corax", "Turdus merula", "Passer domesticus"} {
+		note := &datastore.Note{
+			Date:           dateStr,
+			Time:           now.Format(time.TimeOnly),
+			ScientificName: sci,
+			Confidence:     0.9,
+		}
+		require.NoError(t, ds.Save(note, nil))
+	}
+
+	topBirds, err := ds.GetTopBirdsData(dateStr, 0.0, 10)
+	require.NoError(t, err)
+	require.Len(t, topBirds, 3)
+
+	// Build lookup for easy assertion
+	codeByScientific := make(map[string]string)
+	for _, n := range topBirds {
+		codeByScientific[n.ScientificName] = n.SpeciesCode
+	}
+
+	assert.Equal(t, "comrav", codeByScientific["Corvus corax"], "3-part label should have species code")
+	assert.Equal(t, "eurbla1", codeByScientific["Turdus merula"], "3-part label should have species code")
+	assert.Empty(t, codeByScientific["Passer domesticus"], "2-part label should have empty species code")
+}
+
+// TestGetSpeciesSummaryData_NoDateFilter verifies that species summary returns
+// data when no date filter is provided. Regression test for issue #2191.
+func TestGetSpeciesSummaryData_NoDateFilter(t *testing.T) {
+	labels := []string{
+		"Corvus corax_Common Raven_comrav",
+	}
+	ds, cleanup := setupTestDatastoreWithLabels(t, labels)
+	defer cleanup()
+
+	now := time.Now().UTC()
+
+	// Save a detection
+	note := &datastore.Note{
+		Date:           now.Format(time.DateOnly),
+		Time:           now.Format(time.TimeOnly),
+		ScientificName: "Corvus corax",
+		CommonName:     "Common Raven",
+		Confidence:     0.9,
+	}
+	require.NoError(t, ds.Save(note, nil))
+
+	// Query with no date filter — this was returning empty before the fix
+	summaries, err := ds.GetSpeciesSummaryData(t.Context(), "", "")
+	require.NoError(t, err)
+	require.NotEmpty(t, summaries, "summary should return data when no date filter is provided")
+	assert.Equal(t, "Corvus corax", summaries[0].ScientificName)
+	assert.Equal(t, "Common Raven", summaries[0].CommonName)
+	assert.Equal(t, "comrav", summaries[0].SpeciesCode)
+	assert.Equal(t, 1, summaries[0].Count)
+}
+
+// TestGetSpeciesSummaryData_WithDateFilter verifies that species summary correctly
+// filters by date range.
+func TestGetSpeciesSummaryData_WithDateFilter(t *testing.T) {
+	labels := []string{
+		"Corvus corax_Common Raven_comrav",
+	}
+	ds, cleanup := setupTestDatastoreWithLabels(t, labels)
+	defer cleanup()
+
+	// Save detection on a specific date
+	note := &datastore.Note{
+		Date:           "2024-06-15",
+		Time:           "10:00:00",
+		ScientificName: "Corvus corax",
+		CommonName:     "Common Raven",
+		Confidence:     0.9,
+	}
+	require.NoError(t, ds.Save(note, nil))
+
+	// Query with matching date range
+	summaries, err := ds.GetSpeciesSummaryData(t.Context(), "2024-06-15", "2024-06-15")
+	require.NoError(t, err)
+	require.Len(t, summaries, 1)
+	assert.Equal(t, 1, summaries[0].Count)
+
+	// Query with non-matching date range
+	summaries, err = ds.GetSpeciesSummaryData(t.Context(), "2024-07-01", "2024-07-31")
+	require.NoError(t, err)
+	assert.Empty(t, summaries, "should return empty for dates with no detections")
+}


### PR DESCRIPTION
## Summary

Fixes two bugs in the v2only datastore affecting analytics API endpoints after database migration. Fixes #2191.

- **`species_code` missing from daily/summary endpoints**: Label parsing used `SplitN(_, 2)` which discarded the 3rd species code part from BirdNET's `ScientificName_CommonName_SpeciesCode` format. Added `speciesCodeMap` populated during initialization and used in `GetTopBirdsData` and `GetSpeciesSummaryData`.

- **Species summary returning empty array**: When no date params provided, `parseDateRange("","")` returned `(0,0)`, causing `WHERE detected_at >= 0 AND detected_at < 0` which matches nothing. Fixed by defaulting `end` to `math.MaxInt64` when unset, matching the legacy datastore behavior of returning all data.

## Root Cause

Both bugs only affect users who migrated to the v2 database schema. The legacy `DataStore` correctly includes `species_code` from the `notes` table and skips the date filter when dates are empty. The v2only `Datastore` was missing both behaviors.

## Test plan

- [x] Added `TestGetTopBirdsData_SpeciesCode` — verifies 3-part labels populate `species_code`
- [x] Added `TestGetSpeciesSummaryData_NoDateFilter` — regression test for empty summary
- [x] Added `TestGetSpeciesSummaryData_WithDateFilter` — verifies date filtering still works
- [x] All existing v2only tests pass (`go test -race -v ./internal/datastore/v2only/...`)
- [x] All API v2 tests pass (`go test -race -v ./internal/api/v2/...`)
- [x] Linter clean (`golangci-lint run -v` — 0 issues)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Species codes now included in bird and species data outputs for enhanced species identification.

* **Bug Fixes**
  * Improved date range handling in analytics queries to ensure all available records are included when no end date is specified.

* **Tests**
  * Added comprehensive test coverage for species code extraction and date filtering in analytics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->