### PR TITLE
fix(frontend): show scientific_name in imageprovider error notifications

### DIFF
--- a/frontend/src/lib/desktop/components/ui/NotificationBell.svelte
+++ b/frontend/src/lib/desktop/components/ui/NotificationBell.svelte
@@ -547,9 +547,9 @@
                   <p class="text-sm text-[var(--color-base-content)]/80 mt-1">
                     {sanitizeNotificationMessage(notification.message)}
                   </p>
-                  {#if getDisplayableContext(notification.metadata).length > 0}
+                  {#if getDisplayableContext(notification.metadata, notification.type).length > 0}
                     <p class="text-xs text-[var(--color-base-content)]/50 mt-1 font-mono">
-                      {getDisplayableContext(notification.metadata)
+                      {getDisplayableContext(notification.metadata, notification.type)
                         .map(c => `${c.key}: ${c.value}`)
                         .join(' | ')}
                     </p>

--- a/frontend/src/lib/desktop/components/ui/NotificationGroup.svelte
+++ b/frontend/src/lib/desktop/components/ui/NotificationGroup.svelte
@@ -254,9 +254,9 @@
               <p class="text-xs text-[var(--color-base-content)]/80">
                 {sanitizeNotificationMessage(translateNotification(notification).message)}
               </p>
-              {#if getDisplayableContext(notification.metadata).length > 0}
+              {#if getDisplayableContext(notification.metadata, notification.type).length > 0}
                 <p class="text-xs text-[var(--color-base-content)]/50 mt-0.5 font-mono">
-                  {getDisplayableContext(notification.metadata)
+                  {getDisplayableContext(notification.metadata, notification.type)
                     .map(c => `${c.key}: ${c.value}`)
                     .join(' | ')}
                 </p>

--- a/frontend/src/lib/desktop/views/Notifications.svelte
+++ b/frontend/src/lib/desktop/views/Notifications.svelte
@@ -600,9 +600,9 @@
                     <p class="text-xs text-[var(--color-base-content)]/80 mt-0.5 line-clamp-2">
                       {sanitizeNotificationMessage(translated.message)}
                     </p>
-                    {#if getDisplayableContext(notification.metadata).length > 0}
+                    {#if getDisplayableContext(notification.metadata, notification.type).length > 0}
                       <p class="text-xs text-[var(--color-base-content)]/50 mt-0.5 font-mono">
-                        {getDisplayableContext(notification.metadata)
+                        {getDisplayableContext(notification.metadata, notification.type)
                           .map(c => `${c.key}: ${c.value}`)
                           .join(' | ')}
                       </p>

--- a/frontend/src/lib/utils/notifications.ts
+++ b/frontend/src/lib/utils/notifications.ts
@@ -387,7 +387,7 @@ export function translateNotification(notification: Notification): {
 // Extracts displayable context from notification metadata for error details
 // ============================================================================
 
-/** Internal metadata keys that should not be shown as context */
+/** Internal metadata keys that should never be shown as context */
 const INTERNAL_METADATA_KEYS = new Set([
   // Notification system internals
   'note_id',
@@ -400,27 +400,35 @@ const INTERNAL_METADATA_KEYS = new Set([
   'toastId',
   'duration',
   'action',
-  // Detection notification metadata
+  // Stream worker metadata
+  'streamInfo',
+]);
+
+/** Detection-specific metadata keys hidden only for detection notifications
+ *  (these fields are already displayed elsewhere in the detection UI) */
+const DETECTION_METADATA_KEYS = new Set([
   'is_new_species',
   'species',
   'scientific_name',
   'confidence',
   'location',
   'days_since_first_seen',
-  // Stream worker metadata
-  'streamInfo',
 ]);
 
 /**
  * Extracts displayable context entries from notification metadata.
- * Filters out internal keys (note_id, is_new_species, etc.) and returns
- * remaining key-value pairs formatted for display.
+ * Filters out internal keys and detection-specific keys (only for detection
+ * notifications where those fields are shown elsewhere in the UI).
+ * For error/warning notifications, fields like scientific_name are shown
+ * as they provide critical diagnostic context.
  *
  * @param metadata - The notification metadata object
+ * @param notificationType - The notification type (e.g. 'error', 'detection')
  * @returns Array of {key, value} pairs for display, or empty array
  */
 export function getDisplayableContext(
-  metadata: Record<string, unknown> | undefined
+  metadata: Record<string, unknown> | undefined,
+  notificationType?: Notification['type']
 ): { key: string; value: string }[] {
   if (!metadata) return [];
 
@@ -428,6 +436,7 @@ export function getDisplayableContext(
   for (const [key, value] of Object.entries(metadata)) {
     if (
       INTERNAL_METADATA_KEYS.has(key) ||
+      (notificationType === 'detection' && DETECTION_METADATA_KEYS.has(key)) ||
       key.startsWith('bg_') ||
       value === undefined ||
       value === null


### PR DESCRIPTION
## Summary

- Fixed `getDisplayableContext()` filtering out `scientific_name` from **all** notification types, including imageprovider error notifications where it's the most critical diagnostic context
- Split the metadata blocklist into `INTERNAL_METADATA_KEYS` (always hidden) and `DETECTION_METADATA_KEYS` (hidden only for detection-type notifications)
- The function now accepts an optional `notificationType` parameter — backward-compatible, no breaking changes

## Problem

Imageprovider "image not found" notifications showed:
```
operation: db_cache_negative | provider: wikimedia
```

But hid the species name (`scientific_name: Siren`) because it was in a single blocklist alongside detection-specific keys. The backend was correctly storing the context — the frontend was filtering it out.

## After fix

```
scientific name: Siren | operation: db_cache_negative | provider: wikimedia
```

## Test plan

- [x] `npm run check:all` — 0 errors, 0 warnings
- [x] 1675 frontend tests passing
- [x] Gemini CLI review confirmed fix is correct and backward-compatible
- [ ] Manual verification: trigger an imageprovider error and confirm species name appears in notification UI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined notification context display to be type-aware. Detection notifications now filter technical metadata fields, while error and warning notifications retain complete diagnostic information for troubleshooting purposes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->