### PR TITLE
fix(api): populate species_code from eBird taxonomy in v2only datastore

### DIFF
--- a/internal/analysis/realtime.go
+++ b/internal/analysis/realtime.go
@@ -243,8 +243,10 @@ func realtimeAnalysisInternal(settings *conf.Settings, quitChan chan struct{}) e
 
 	case freshInstall:
 		// Fresh install: create at configured path with v2 schema
+		// Load eBird taxonomy for species code lookups in analytics endpoints.
+		_, freshSciIndex, _ := birdnet.LoadTaxonomyData("")
 		var err error
-		v2OnlyDatastore, err = v2only.InitializeFreshInstall(settings, GetLogger())
+		v2OnlyDatastore, err = v2only.InitializeFreshInstall(settings, GetLogger(), freshSciIndex)
 		if err != nil {
 			// Fresh install failed, fall back to legacy mode
 			GetLogger().Warn("fresh install failed, falling back to legacy mode",
@@ -2185,20 +2187,28 @@ func initializeV2OnlyMode(settings *conf.Settings) (*v2only.Datastore, error) {
 	thresholdRepo := repository.NewDynamicThresholdRepository(v2DB, labelRepo, useV2Prefix, isMySQL)
 	notificationRepo := repository.NewNotificationHistoryRepository(v2DB, labelRepo, useV2Prefix, isMySQL)
 
+	// Load eBird taxonomy for species code lookups in analytics endpoints.
+	_, scientificIndex, taxonomyErr := birdnet.LoadTaxonomyData("")
+	if taxonomyErr != nil {
+		log.Warn("failed to load taxonomy data for species codes",
+			logger.String("error", taxonomyErr.Error()))
+	}
+
 	// Create V2OnlyDatastore
 	ds, err := v2only.New(&v2only.Config{
-		Manager:      v2Manager,
-		Detection:    detectionRepo,
-		Label:        labelRepo,
-		Model:        modelRepo,
-		Source:       sourceRepo,
-		Weather:      weatherRepo,
-		ImageCache:   imageCacheRepo,
-		Threshold:    thresholdRepo,
-		Notification: notificationRepo,
-		Logger:       log,
-		Timezone:     time.Local,
-		Labels:       settings.BirdNET.Labels, // For GetThresholdEvents workaround (#1907)
+		Manager:        v2Manager,
+		Detection:      detectionRepo,
+		Label:          labelRepo,
+		Model:          modelRepo,
+		Source:         sourceRepo,
+		Weather:        weatherRepo,
+		ImageCache:     imageCacheRepo,
+		Threshold:      thresholdRepo,
+		Notification:   notificationRepo,
+		Logger:         log,
+		Timezone:       time.Local,
+		Labels:         settings.BirdNET.Labels, // For GetThresholdEvents workaround (#1907)
+		SpeciesCodeMap: scientificIndex,
 	})
 	if err != nil {
 		_ = v2Manager.Close()

--- a/internal/analysis/realtime_fresh_install_test.go
+++ b/internal/analysis/realtime_fresh_install_test.go
@@ -30,7 +30,7 @@ func TestFreshInstall_CreatesDBAtConfiguredPath(t *testing.T) {
 	require.True(t, state.FreshInstall, "should detect fresh install")
 
 	// Initialize fresh install
-	ds, err := v2only.InitializeFreshInstall(settings, nil)
+	ds, err := v2only.InitializeFreshInstall(settings, nil, nil)
 	require.NoError(t, err)
 	defer func() { _ = ds.Close() }()
 
@@ -59,7 +59,7 @@ func TestFreshInstall_CustomPathWithSubdirectory(t *testing.T) {
 	state := datastoreV2.CheckMigrationStateBeforeStartup(settings)
 	require.True(t, state.FreshInstall, "should detect fresh install with custom path")
 
-	ds, err := v2only.InitializeFreshInstall(settings, nil)
+	ds, err := v2only.InitializeFreshInstall(settings, nil, nil)
 	require.NoError(t, err)
 	defer func() { _ = ds.Close() }()
 
@@ -87,7 +87,7 @@ func TestFreshInstall_SetsEnhancedDatabaseMode(t *testing.T) {
 	// Before initialization, should not be enhanced
 	assert.False(t, datastoreV2.IsEnhancedDatabase(), "should not be enhanced before init")
 
-	ds, err := v2only.InitializeFreshInstall(settings, nil)
+	ds, err := v2only.InitializeFreshInstall(settings, nil, nil)
 	require.NoError(t, err)
 	defer func() { _ = ds.Close() }()
 
@@ -107,7 +107,7 @@ func TestFreshInstall_RestartDetectsExistingV2(t *testing.T) {
 	settings.Output.SQLite.Path = configuredPath
 
 	// First: fresh install
-	ds, err := v2only.InitializeFreshInstall(settings, nil)
+	ds, err := v2only.InitializeFreshInstall(settings, nil, nil)
 	require.NoError(t, err)
 	require.NoError(t, ds.Close())
 
@@ -160,7 +160,7 @@ func TestFreshInstall_InitializeV2OnlyModeCanOpenDB(t *testing.T) {
 	settings.Output.SQLite.Path = configuredPath
 
 	// Step 1: Fresh install creates DB at configured path
-	ds, err := v2only.InitializeFreshInstall(settings, nil)
+	ds, err := v2only.InitializeFreshInstall(settings, nil, nil)
 	require.NoError(t, err)
 
 	// Save a detection for later verification

--- a/internal/datastore/v2only/datastore.go
+++ b/internal/datastore/v2only/datastore.go
@@ -141,7 +141,7 @@ type Datastore struct {
 	commonNameMap map[string]string
 
 	// speciesCodeMap provides O(1) lookup from scientific name to eBird species code.
-	// Populated from 3-part label format "ScientificName_CommonName_SpeciesCode".
+	// Populated from the eBird taxonomy data passed via Config.SpeciesCodeMap.
 	speciesCodeMap map[string]string
 
 	// dbstatAvailable caches whether the dbstat virtual table exists.
@@ -175,6 +175,10 @@ type Config struct {
 	// Labels provides species label mappings in "ScientificName_CommonName" format.
 	// Used to build speciesMap for GetThresholdEvents workaround. See issue #1907.
 	Labels []string
+
+	// SpeciesCodeMap maps scientific names to eBird species codes.
+	// Built from taxonomy data (e.g., birdnet.CreateScientificNameIndex).
+	SpeciesCodeMap map[string]string
 }
 
 // New creates a new V2-only Datastore.
@@ -243,28 +247,25 @@ func New(cfg *Config) (*Datastore, error) {
 	}
 
 	// Build species name maps from labels.
-	// Labels are in "ScientificName_CommonName[_SpeciesCode]" format
-	// (e.g., "Turdus merula_Eurasian Blackbird_eurbla1").
+	// Labels are in "ScientificName_CommonName" format.
 	// See issue #1907 for context on speciesMap usage.
 	speciesMap := make(map[string]string)
 	commonNameMap := make(map[string]string)
-	speciesCodeMap := make(map[string]string)
 	for _, label := range cfg.Labels {
-		parts := strings.SplitN(label, "_", 3)
-		if len(parts) >= 2 {
-			scientificName := strings.TrimSpace(parts[0])
-			commonName := strings.TrimSpace(parts[1])
+		if scientificName, commonName, found := strings.Cut(label, "_"); found {
+			scientificName = strings.TrimSpace(scientificName)
+			commonName = strings.TrimSpace(commonName)
 			if commonName != "" && scientificName != "" {
 				speciesMap[strings.ToLower(commonName)] = scientificName
 				commonNameMap[scientificName] = commonName
-				if len(parts) == 3 {
-					code := strings.TrimSpace(parts[2])
-					if code != "" {
-						speciesCodeMap[scientificName] = code
-					}
-				}
 			}
 		}
+	}
+
+	// Use species code map from taxonomy data (injected via config).
+	speciesCodeMap := cfg.SpeciesCodeMap
+	if speciesCodeMap == nil {
+		speciesCodeMap = make(map[string]string)
 	}
 
 	return &Datastore{

--- a/internal/datastore/v2only/datastore_test.go
+++ b/internal/datastore/v2only/datastore_test.go
@@ -1090,16 +1090,24 @@ func TestV2OnlyDatastore_Save_DuplicatePredictionLabels(t *testing.T) {
 	assert.Len(t, preds, 2, "duplicate label should be collapsed to single prediction")
 }
 
-// TestGetTopBirdsData_SpeciesCode verifies that species codes from 3-part labels
+// TestGetTopBirdsData_SpeciesCode verifies that species codes from eBird taxonomy
 // are populated in the GetTopBirdsData response. Regression test for issue #2191.
 func TestGetTopBirdsData_SpeciesCode(t *testing.T) {
 	labels := []string{
-		"Corvus corax_Common Raven_comrav",
-		"Turdus merula_Eurasian Blackbird_eurbla1",
-		"Passer domesticus_House Sparrow", // 2-part label without species code
+		"Corvus corax_Common Raven",
+		"Turdus merula_Eurasian Blackbird",
+		"Passer domesticus_House Sparrow",
 	}
-	ds, cleanup := setupTestDatastoreWithLabels(t, labels)
-	defer cleanup()
+	speciesCodeMap := map[string]string{
+		"Corvus corax":  "comrav",
+		"Turdus merula": "eurbla1",
+		// Passer domesticus intentionally omitted
+	}
+	cfg, cfgCleanup := buildTestConfig(t, labels)
+	cfg.SpeciesCodeMap = speciesCodeMap
+	ds, err := New(cfg)
+	require.NoError(t, err)
+	defer func() { _ = ds.Close(); cfgCleanup() }()
 
 	now := time.Now().UTC()
 	dateStr := now.Format(time.DateOnly)
@@ -1125,19 +1133,25 @@ func TestGetTopBirdsData_SpeciesCode(t *testing.T) {
 		codeByScientific[n.ScientificName] = n.SpeciesCode
 	}
 
-	assert.Equal(t, "comrav", codeByScientific["Corvus corax"], "3-part label should have species code")
-	assert.Equal(t, "eurbla1", codeByScientific["Turdus merula"], "3-part label should have species code")
-	assert.Empty(t, codeByScientific["Passer domesticus"], "2-part label should have empty species code")
+	assert.Equal(t, "comrav", codeByScientific["Corvus corax"], "taxonomy species code should be populated")
+	assert.Equal(t, "eurbla1", codeByScientific["Turdus merula"], "taxonomy species code should be populated")
+	assert.Empty(t, codeByScientific["Passer domesticus"], "species not in taxonomy should have empty code")
 }
 
 // TestGetSpeciesSummaryData_NoDateFilter verifies that species summary returns
 // data when no date filter is provided. Regression test for issue #2191.
 func TestGetSpeciesSummaryData_NoDateFilter(t *testing.T) {
 	labels := []string{
-		"Corvus corax_Common Raven_comrav",
+		"Corvus corax_Common Raven",
 	}
-	ds, cleanup := setupTestDatastoreWithLabels(t, labels)
-	defer cleanup()
+	speciesCodeMap := map[string]string{
+		"Corvus corax": "comrav",
+	}
+	cfg, cfgCleanup := buildTestConfig(t, labels)
+	cfg.SpeciesCodeMap = speciesCodeMap
+	ds, err := New(cfg)
+	require.NoError(t, err)
+	defer func() { _ = ds.Close(); cfgCleanup() }()
 
 	now := time.Now().UTC()
 
@@ -1165,7 +1179,7 @@ func TestGetSpeciesSummaryData_NoDateFilter(t *testing.T) {
 // filters by date range.
 func TestGetSpeciesSummaryData_WithDateFilter(t *testing.T) {
 	labels := []string{
-		"Corvus corax_Common Raven_comrav",
+		"Corvus corax_Common Raven",
 	}
 	ds, cleanup := setupTestDatastoreWithLabels(t, labels)
 	defer cleanup()

--- a/internal/datastore/v2only/fresh_install.go
+++ b/internal/datastore/v2only/fresh_install.go
@@ -24,7 +24,7 @@ import (
 //   - User wants to start fresh with v2 schema
 //
 // The function also sets the global enhanced database flag via v2.SetEnhancedDatabaseMode().
-func InitializeFreshInstall(settings *conf.Settings, log logger.Logger) (*Datastore, error) {
+func InitializeFreshInstall(settings *conf.Settings, log logger.Logger, speciesCodeMap map[string]string) (*Datastore, error) {
 	if log == nil {
 		log = logger.Global().Module("datastore")
 	}
@@ -137,6 +137,7 @@ func InitializeFreshInstall(settings *conf.Settings, log logger.Logger) (*Datast
 		DefaultModelID:     defaultModel.ID,
 		SpeciesLabelTypeID: speciesLabelType.ID,
 		AvesClassID:        &avesClassID,
+		SpeciesCodeMap:     speciesCodeMap,
 	})
 	if err != nil {
 		_ = manager.Close()

--- a/internal/datastore/v2only/fresh_install_test.go
+++ b/internal/datastore/v2only/fresh_install_test.go
@@ -25,7 +25,7 @@ func TestInitializeFreshInstall_SQLite(t *testing.T) {
 	settings.Output.SQLite.Enabled = true
 	settings.Output.SQLite.Path = dbPath
 
-	ds, err := InitializeFreshInstall(settings, nil)
+	ds, err := InitializeFreshInstall(settings, nil, nil)
 	require.NoError(t, err)
 	defer func() { _ = ds.Close() }()
 
@@ -53,7 +53,7 @@ func TestInitializeFreshInstall_SQLite_CustomPath(t *testing.T) {
 	settings.Output.SQLite.Enabled = true
 	settings.Output.SQLite.Path = customPath
 
-	ds, err := InitializeFreshInstall(settings, nil)
+	ds, err := InitializeFreshInstall(settings, nil, nil)
 	require.NoError(t, err)
 	defer func() { _ = ds.Close() }()
 
@@ -78,7 +78,7 @@ func TestInitializeFreshInstall_MigrationStateCompleted(t *testing.T) {
 	settings.Output.SQLite.Enabled = true
 	settings.Output.SQLite.Path = dbPath
 
-	ds, err := InitializeFreshInstall(settings, nil)
+	ds, err := InitializeFreshInstall(settings, nil, nil)
 	require.NoError(t, err)
 	defer func() { _ = ds.Close() }()
 
@@ -103,7 +103,7 @@ func TestInitializeFreshInstall_CanSaveAndRetrieve(t *testing.T) {
 	settings.Output.SQLite.Enabled = true
 	settings.Output.SQLite.Path = dbPath
 
-	ds, err := InitializeFreshInstall(settings, nil)
+	ds, err := InitializeFreshInstall(settings, nil, nil)
 	require.NoError(t, err)
 	defer func() { _ = ds.Close() }()
 
@@ -131,7 +131,7 @@ func TestInitializeFreshInstall_NoDatabase(t *testing.T) {
 	settings := &conf.Settings{}
 	// No database configured
 
-	_, err := InitializeFreshInstall(settings, nil)
+	_, err := InitializeFreshInstall(settings, nil, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no database configured")
 }
@@ -144,7 +144,7 @@ func TestInitializeFreshInstall_EmptySQLitePath(t *testing.T) {
 	settings.Output.SQLite.Enabled = true
 	settings.Output.SQLite.Path = "" // Empty path
 
-	_, err := InitializeFreshInstall(settings, nil)
+	_, err := InitializeFreshInstall(settings, nil, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "sqlite path is empty")
 }


### PR DESCRIPTION
## Summary

Fixes #2191 — `species_code` missing from `/api/v2/analytics/species/daily` and `/api/v2/analytics/species/summary` responses.

**Root cause:** PR #2223 added a `speciesCodeMap` to the v2only datastore, but populated it by parsing label strings expecting a 3-part format (`ScientificName_CommonName_SpeciesCode`). All label files use 2-part format (`ScientificName_CommonName`) — the species code was never part of label strings. The map was always empty, and `omitempty` on the JSON tag silently dropped the field.

**Fix:** Species codes live in the eBird taxonomy data (`eBird_taxonomy_codes_2021E.json`), not in label strings. This PR:

- Adds a `SpeciesCodeMap` field to `v2only.Config` for dependency injection
- Calls `birdnet.LoadTaxonomyData()` to build a `ScientificNameIndex` (scientific name → eBird code) at both initialization paths:
  - Post-migration: `initializeV2OnlyMode()` in `realtime.go`
  - Fresh install: `InitializeFreshInstall()` call site in `realtime.go`
- Removes the dead 3-part label parsing code
- Modernizes label parsing to use `strings.Cut`

**Files changed:**
- `internal/datastore/v2only/datastore.go` — new `SpeciesCodeMap` config field, use injected map instead of broken label parsing
- `internal/datastore/v2only/fresh_install.go` — accept `speciesCodeMap` parameter
- `internal/analysis/realtime.go` — load taxonomy and pass species code map at both init paths
- Tests updated to reflect new approach

## Test plan

- [x] `TestGetTopBirdsData_SpeciesCode` — verifies species codes from taxonomy map appear in daily endpoint response
- [x] `TestGetSpeciesSummaryData_NoDateFilter` — verifies species codes appear in summary response
- [x] `TestGetSpeciesSummaryData_WithDateFilter` — verifies date filtering still works
- [x] All `TestInitializeFreshInstall_*` tests pass with new parameter
- [x] All `TestFreshInstall_*` tests pass with new parameter
- [x] Full lint: 0 issues