### PR TITLE
refactor(frontend): use declarative $derived state in ListenAddressSelector

### DIFF
--- a/frontend/src/lib/desktop/features/settings/components/ListenAddressSelector.svelte
+++ b/frontend/src/lib/desktop/features/settings/components/ListenAddressSelector.svelte
@@ -80,8 +80,9 @@
   }
 
   // Derived state from listen prop — no $effect needed
-  let host = $derived(parseListen(listen).host);
-  let port = $derived(parseListen(listen).port);
+  const parsed = $derived(parseListen(listen));
+  let host = $derived(parsed.host);
+  let port = $derived(parsed.port);
 
   // Derived interface list: merge API results + defaults + current host
   let interfaces = $derived.by(() => {


### PR DESCRIPTION
## Summary

- Replace imperative `$effect` + `$state` mutations with `$derived` and `$derived.by` for `host`, `port`, and `interfaces`
- Only `apiInterfaces` remains as `$state` — populated by the single fetch side effect
- Remove `ensureCurrentHostInList()` — its logic is folded into the `$derived.by` computation
- Follows [Svelte 5 best practice](https://svelte.dev/docs/svelte/$effect#When-not-to-use-$effect): _"avoid using `$effect` to synchronise state"_

## Context

Follow-up code quality improvement from PR #2257 review. Gemini suggested refactoring the `ListenAddressSelector` state management to use declarative derived state. This PR implements that suggestion with correct Svelte 5 runes syntax.

## What changed

| Before | After |
|---|---|
| `host = $state()` updated by `$effect` | `host = $derived(parseListen(listen).host)` |
| `port = $state()` updated by `$effect` | `port = $derived(parseListen(listen).port)` |
| `interfaces = $state()` mutated from 3 places | `interfaces = $derived.by(merge(apiInterfaces, defaults, host))` |
| `ensureCurrentHostInList()` called from 2 paths | Removed — logic in `$derived.by` |
| `selectHost` sets local state then calls `onchange` | `selectHost` only calls `onchange` |
| 2 `$effect` blocks | 1 `$effect` block (fetch only) |

Net: -46 lines, +37 lines (9 fewer lines, cleaner data flow)

## Test Plan

- [ ] Verify IP dropdown shows network interfaces
- [ ] Verify selecting an IP calls `onchange` with correct `host:port`
- [ ] Verify port changes call `onchange` with correct `host:port`
- [ ] Verify component updates when parent `listen` prop changes async
- [ ] Verify custom host appears in dropdown when not in API results

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved Listen Address selector for more reliable behavior: IPv6 addresses are formatted with proper brackets and parsing now supports bracketed IPv6, bare IPv6, IPv4 and hostnames with/without ports.
  * Interface list is now driven from a single source with defaults merged in; custom or previous hosts are preserved.
  * Selection and port updates emit consistent address:port values, making dropdown and port flows more predictable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->