### PR TITLE
test(e2e): add Playwright tests for color scheme switching

### DIFF
--- a/frontend/tests/e2e/settings/color-scheme.spec.ts
+++ b/frontend/tests/e2e/settings/color-scheme.spec.ts
@@ -41,6 +41,25 @@ const clearSchemeStorage = async (page: Page) => {
   });
 };
 
+/** Set the theme to dark mode. */
+const setDarkMode = async (page: Page) => {
+  await page.evaluate(() => {
+    localStorage.setItem('theme', 'dark');
+    document.documentElement.setAttribute('data-theme', 'dark');
+    document.documentElement.setAttribute('data-theme-controller', 'dark');
+  });
+};
+
+/** Set custom scheme colors in localStorage. */
+const setCustomColorsInStorage = async (
+  page: Page,
+  colors: { primary: string; accent: string }
+) => {
+  await page.evaluate(c => {
+    localStorage.setItem('custom-scheme-colors', JSON.stringify(c));
+  }, colors);
+};
+
 test.describe('Color Scheme Switching', () => {
   test.setTimeout(30000);
 
@@ -152,13 +171,7 @@ test.describe('Color Scheme with Dark Mode', () => {
   });
 
   test('scheme works in dark mode', async ({ page }) => {
-    // Set dark theme
-    await page.evaluate(() => {
-      localStorage.setItem('theme', 'dark');
-      document.documentElement.setAttribute('data-theme', 'dark');
-      document.documentElement.setAttribute('data-theme-controller', 'dark');
-    });
-
+    await setDarkMode(page);
     await navigateToSettings(page);
 
     // Select forest scheme
@@ -173,13 +186,7 @@ test.describe('Color Scheme with Dark Mode', () => {
   });
 
   test('scheme overrides dark mode defaults', async ({ page }) => {
-    // Set dark theme
-    await page.evaluate(() => {
-      localStorage.setItem('theme', 'dark');
-      document.documentElement.setAttribute('data-theme', 'dark');
-      document.documentElement.setAttribute('data-theme-controller', 'dark');
-    });
-
+    await setDarkMode(page);
     await navigateToSettings(page);
 
     // The default dark blue primary is #3b82f6
@@ -200,11 +207,7 @@ test.describe('Color Scheme with Dark Mode', () => {
     expect(await getDataScheme(page)).toBe('violet');
 
     // Switch to dark mode
-    await page.evaluate(() => {
-      localStorage.setItem('theme', 'dark');
-      document.documentElement.setAttribute('data-theme', 'dark');
-      document.documentElement.setAttribute('data-theme-controller', 'dark');
-    });
+    await setDarkMode(page);
 
     // Scheme should still be violet
     const scheme = await getDataScheme(page);
@@ -245,15 +248,7 @@ test.describe('Custom Color Scheme', () => {
     await navigateToSettings(page);
 
     // Set custom colors via localStorage before selecting custom scheme
-    await page.evaluate(() => {
-      localStorage.setItem(
-        'custom-scheme-colors',
-        JSON.stringify({
-          primary: '#ff5500',
-          accent: '#00aa55',
-        })
-      );
-    });
+    await setCustomColorsInStorage(page, { primary: '#ff5500', accent: '#00aa55' });
 
     await selectScheme(page, 'settings.appearance.schemeCustom');
 
@@ -269,15 +264,7 @@ test.describe('Custom Color Scheme', () => {
     await navigateToSettings(page);
 
     // Set custom colors and select custom scheme
-    await page.evaluate(() => {
-      localStorage.setItem(
-        'custom-scheme-colors',
-        JSON.stringify({
-          primary: '#cc3366',
-          accent: '#3366cc',
-        })
-      );
-    });
+    await setCustomColorsInStorage(page, { primary: '#cc3366', accent: '#3366cc' });
 
     await selectScheme(page, 'settings.appearance.schemeCustom');
     expect(await getDataScheme(page)).toBe('custom');


### PR DESCRIPTION
## Summary

- Adds comprehensive Playwright e2e tests for the color scheme system
- Tests run against the live application in the browser, validating actual CSS cascade behavior
- Stacked on `feat/color-scheme-foundation` (PR #2252)

## Test Coverage

| Category | Tests | What's validated |
|----------|-------|-----------------|
| **Scheme Switching** | 6 | Data attribute changes, CSS variable values, all 5 schemes, persistence across reload and navigation, localStorage |
| **Dark Mode** | 3 | Dark variants applied correctly, scheme overrides dark defaults, theme switch preserves scheme |
| **Custom Scheme** | 3 | Color pickers appear, custom CSS variables applied, persistence |
| **Accessibility** | 2 | Radiogroup pattern, aria-checked state |
| **FOUC Prevention** | 2 | Blocking script restores scheme before render, invalid values fall back to blue |

## Test Plan
- [ ] CI runs Playwright tests against the built application
- [ ] All 16 tests pass in chromium