### PR TITLE
feat(myaudio): add audio EQ filter timing diagnostics for RTSP streams

### DIFF
--- a/internal/myaudio/ffmpeg_stream.go
+++ b/internal/myaudio/ffmpeg_stream.go
@@ -87,6 +87,12 @@ const (
 	maxErrorHistorySize       = 100             // Maximum number of error contexts to store internally per stream
 	maxErrorHistoryExposed    = 10              // Number of most recent errors exposed via StreamHealth API
 	earlyErrorDetectionWindow = 5 * time.Second // Check stderr in first 5 seconds for early detection
+
+	// Audio EQ filter diagnostics settings
+	filterTimingWarmupCalls = 3   // Skip first N calls from slow-path stats (cache warming, pool alloc)
+	filterDiagInitialCalls  = 5   // Number of initial calls to log for diagnostics
+	filterDiagInterval      = 500 // Log every Nth call after initial burst
+	filterSlowLogInterval   = 100 // Log every Nth slow-filter occurrence to avoid log flooding
 )
 
 // getStreamLogger returns the logger for FFmpeg stream.
@@ -1416,33 +1422,36 @@ func (s *FFmpegStream) handleAudioData(data []byte) error {
 			}
 			filterDurUsec := time.Since(filterStart).Microseconds()
 			callNum := s.handleDataCount.Add(1)
+			warmedUp := callNum > filterTimingWarmupCalls
 
-			// Track max filter duration
-			for {
-				cur := s.maxFilterDurUsec.Load()
-				if filterDurUsec <= cur || s.maxFilterDurUsec.CompareAndSwap(cur, filterDurUsec) {
-					break
+			// Track max filter duration (single writer per stream — no CAS needed)
+			if warmedUp {
+				if cur := s.maxFilterDurUsec.Load(); filterDurUsec > cur {
+					s.maxFilterDurUsec.Store(filterDurUsec)
 				}
 			}
 
 			// Warn if filter processing exceeds the audio chunk's real-time budget
 			chunkDurationUs := int64(filterLen/2) * 1_000_000 / int64(conf.SampleRate)
-			if filterDurUsec > chunkDurationUs {
+			if warmedUp && filterDurUsec > chunkDurationUs {
 				slowCount := s.filterSlowCount.Add(1)
-				getStreamLogger().Warn("audio EQ filter exceeded real-time budget",
-					logger.String("source_id", s.source.ID),
-					logger.Int("data_bytes", len(data)),
-					logger.Int("samples", filterLen/2),
-					logger.Int64("filter_usec", filterDurUsec),
-					logger.Int64("budget_usec", chunkDurationUs),
-					logger.Int64("slow_count", slowCount),
-					logger.Int64("total_calls", callNum),
-					logger.String("component", "ffmpeg-stream"),
-					logger.String("operation", "filter_timing"))
+				// Rate-limit warnings to avoid log flooding on persistently slow streams
+				if slowCount <= filterDiagInitialCalls || slowCount%filterSlowLogInterval == 0 {
+					getStreamLogger().Warn("audio EQ filter exceeded real-time budget",
+						logger.String("source_id", s.source.ID),
+						logger.Int("data_bytes", len(data)),
+						logger.Int("samples", filterLen/2),
+						logger.Int64("filter_usec", filterDurUsec),
+						logger.Int64("budget_usec", chunkDurationUs),
+						logger.Int64("slow_count", slowCount),
+						logger.Int64("total_calls", callNum),
+						logger.String("component", "ffmpeg-stream"),
+						logger.String("operation", "filter_timing"))
+				}
 			}
 
-			// Periodic debug log: first 5 calls + every 500th call
-			if callNum <= 5 || callNum%500 == 0 {
+			// Periodic debug log: first N calls + every Nth call
+			if callNum <= filterDiagInitialCalls || callNum%filterDiagInterval == 0 {
 				getStreamLogger().Debug("audio EQ filter timing",
 					logger.String("source_id", s.source.ID),
 					logger.Int("data_bytes", len(data)),
@@ -2139,6 +2148,11 @@ func (s *FFmpegStream) resetDataTracking() {
 	s.bytesReceivedMu.Lock()
 	s.totalBytesReceived = 0
 	s.bytesReceivedMu.Unlock()
+
+	// Reset audio EQ filter diagnostics so metrics reflect current process health
+	s.handleDataCount.Store(0)
+	s.filterSlowCount.Store(0)
+	s.maxFilterDurUsec.Store(0)
 }
 
 // logStreamHealth logs the current stream health status


### PR DESCRIPTION
## Summary

- Add per-stream filter processing instrumentation to `handleAudioData` to detect if equalizer filtering causes audio pipeline stalls
- Track total calls, max filter duration (microseconds), and slow-count (filter exceeding real-time audio budget) using lock-free atomic counters
- Log a warning when filter processing exceeds the chunk's real-time duration
- Emit periodic debug-level timing summaries (first 5 calls + every 500th call)

## Context

Investigation of #2236 revealed that commits `dbc84212` and `1b74803c` (fixing #2148) correctly enabled equalizer filters for RTSP/FFmpeg streams for the first time. Before those commits, filters were silently skipped because the filter chain was never initialized for the FFmpeg code path.

Testing with two concurrent RTSP streams showed filter processing is well within budget (max 320μs for ~70ms of audio, 0.46% of real-time budget, zero slow-count across 1000+ calls). This instrumentation will help diagnose whether resource-constrained environments (e.g., Kubernetes pods with 1 core) experience filter-induced stalls.

## Related Issues

Related to #2236

## Test Plan

- [x] Verified with `golangci-lint run` — 0 issues
- [x] Tested with two concurrent RTSP streams, equalizer enabled (HighPass + LowPass, Q=0.1)
- [x] Confirmed `slow_count=0` across 500+ calls per stream over 60 seconds
- [x] Confirmed debug logs emit at expected intervals (first 5, every 500th)
- [x] Confirmed warning log triggers correctly when budget would be exceeded (synthetic test)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced audio processing diagnostics with per-stream performance metrics for filter timing and slow-operation counts.
  * Added runtime warnings when filter processing exceeds per-chunk budgets and periodic debug logging for timing and anomalies.
  * Diagnostics are tracked per stream and reset when processing restarts to keep monitoring current and relevant.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->