### PR TITLE
fix: keep CurrentlyHearingCard elapsed time running while offline

### DIFF
--- a/frontend/src/lib/desktop/features/dashboard/components/CurrentlyHearingCard.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/components/CurrentlyHearingCard.svelte
@@ -15,7 +15,6 @@ Props:
   import { Check, X } from '@lucide/svelte';
   import { fade } from 'svelte/transition';
   import { t } from '$lib/i18n';
-  import { connectionState } from '$lib/stores/connectionState.svelte';
   import type { PendingDetection } from '$lib/types/pending.types';
 
   interface Props {
@@ -97,7 +96,6 @@ Props:
   $effect(() => {
     if (!hasDisplayDetections) return;
     const interval = setInterval(() => {
-      if (!connectionState.isOnline) return;
       tick++;
     }, 1000);
     return () => clearInterval(interval);


### PR DESCRIPTION
## Summary
- Removed the `connectionState.isOnline` guard from the tick counter interval in `CurrentlyHearingCard.svelte`
- The tick counter is purely a UI timer for elapsed time display — it doesn't trigger any API calls, so it should keep incrementing regardless of backend connectivity
- Also removed the now-unused `connectionState` import

Fixes #2271

## Test plan
- [ ] Verify elapsed time continues counting when backend goes offline
- [ ] Verify elapsed time resets correctly when new detection arrives
- [ ] Verify no memory leaks from timer management

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved real-time update reliability by removing the connection requirement for detection display updates, ensuring consistent refreshing of detection information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->