### PR TITLE
fix: arm onSSEError watchdog to fire once per burst (#2272)

### DIFF
--- a/frontend/src/lib/stores/connectionState.svelte.ts
+++ b/frontend/src/lib/stores/connectionState.svelte.ts
@@ -55,6 +55,9 @@ let pingTimer: ReturnType<typeof setInterval> | null = null;
 /** Whether the watchdog has been activated (after app init) */
 let activated = false;
 
+/** Whether the error timeout has already been armed for the current burst */
+let errorTimeoutArmed = false;
+
 /**
  * Check if the backend is online (non-reactive, for use in polling guards).
  */
@@ -70,6 +73,7 @@ export function isBackendOnline(): boolean {
  */
 export function markOnline(): void {
   connectionState.lastContact = Date.now();
+  errorTimeoutArmed = false;
   if (!connectionState.isOnline) {
     logger.info('Backend connectivity restored');
     connectionState.isOnline = true;
@@ -101,6 +105,7 @@ function resetWatchdog(timeoutMs: number): void {
   }
 
   watchdogTimer = setTimeout(() => {
+    watchdogTimer = null;
     logger.warn('SSE heartbeat watchdog expired', {
       timeoutMs,
       lastContact: connectionState.lastContact,
@@ -121,9 +126,15 @@ export function onSSEActivity(): void {
 /**
  * Called when an explicit SSE error/disconnect occurs.
  * Shortens the watchdog timeout for faster offline detection.
+ * Uses a boolean guard so the shortened timeout only fires once per
+ * disconnect burst, preventing repeated timer resets from delaying
+ * offline detection.
  */
 export function onSSEError(): void {
   if (!activated) return;
+  if (!connectionState.isOnline) return;
+  if (errorTimeoutArmed) return;
+  errorTimeoutArmed = true;
   resetWatchdog(ERROR_TIMEOUT_MS);
 }
 
@@ -194,6 +205,7 @@ export function activateWatchdog(): void {
  */
 export function deactivateWatchdog(): void {
   activated = false;
+  errorTimeoutArmed = false;
   if (watchdogTimer !== null) {
     clearTimeout(watchdogTimer);
     watchdogTimer = null;


### PR DESCRIPTION
## Summary
- Added `errorTimeoutArmed` boolean guard to `onSSEError()` so the shortened 5s watchdog timeout fires only once per disconnect burst, preventing repeated timer resets from delaying offline detection
- Skip redundant timer scheduling when already offline (`!connectionState.isOnline` early return)
- Clear watchdog timer reference after natural expiration to avoid dangling references

Fixes #2272

## Test plan
- [ ] Verify watchdog fires only once during rapid SSE error bursts (first error arms the 5s timeout, subsequent errors are ignored)
- [ ] Verify watchdog still activates on genuine disconnections after recovery (errorTimeoutArmed resets in markOnline)
- [ ] Verify reconnection logic works correctly after watchdog fires
- [ ] Verify no redundant timers are scheduled while already offline

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Server-Sent Events connection stability with better error timeout handling during network interruptions and recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->