### PR TITLE
fix: replace setInterval with recursive setTimeout to prevent polling pile-up

### DIFF
--- a/frontend/src/lib/desktop/components/database/DatabaseManagement.svelte
+++ b/frontend/src/lib/desktop/components/database/DatabaseManagement.svelte
@@ -239,19 +239,32 @@
     }
   }
 
-  // Polling effect - uses local variable to avoid reactivity loop
+  // Polling effect - recursive setTimeout to prevent pile-up
   $effect(() => {
     if (!isActive) return;
+    let cancelled = false;
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+    async function poll() {
+      if (cancelled) return;
 
-    // Start polling when migration is active
-    const interval = setInterval(() => {
-      if (!connectionState.isOnline) return;
-      fetchMigrationStatus();
-      fetchV2Stats(); // Also refresh v2 stats to show growing detection count
-    }, STATUS_POLL_INTERVAL_MS);
+      if (!connectionState.isOnline) {
+        // Skip API calls but keep the polling loop alive
+        if (!cancelled) {
+          timeoutId = setTimeout(poll, STATUS_POLL_INTERVAL_MS);
+        }
+        return;
+      }
 
-    // Cleanup when isActive becomes false or component unmounts
-    return () => clearInterval(interval);
+      await Promise.all([fetchMigrationStatus(), fetchV2Stats()]);
+      if (!cancelled) {
+        timeoutId = setTimeout(poll, STATUS_POLL_INTERVAL_MS);
+      }
+    }
+    timeoutId = setTimeout(poll, STATUS_POLL_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      if (timeoutId) clearTimeout(timeoutId);
+    };
   });
 
   // Initial fetch
@@ -269,17 +282,32 @@
     }
   });
 
-  // Poll during cleanup
+  // Poll during cleanup (recursive setTimeout to prevent pile-up)
   $effect(() => {
     if (!isCleanupActive) return;
+    let cancelled = false;
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+    async function poll() {
+      if (cancelled) return;
 
-    const interval = setInterval(() => {
-      if (!connectionState.isOnline) return;
-      fetchMigrationStatus();
-      fetchLegacyStatus();
-    }, STATUS_POLL_INTERVAL_MS);
+      if (!connectionState.isOnline) {
+        // Skip API calls but keep the polling loop alive
+        if (!cancelled) {
+          timeoutId = setTimeout(poll, STATUS_POLL_INTERVAL_MS);
+        }
+        return;
+      }
 
-    return () => clearInterval(interval);
+      await Promise.all([fetchMigrationStatus(), fetchLegacyStatus()]);
+      if (!cancelled) {
+        timeoutId = setTimeout(poll, STATUS_POLL_INTERVAL_MS);
+      }
+    }
+    timeoutId = setTimeout(poll, STATUS_POLL_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      if (timeoutId) clearTimeout(timeoutId);
+    };
   });
 </script>
 

--- a/frontend/src/lib/desktop/components/database/DatabaseStatsCard.svelte
+++ b/frontend/src/lib/desktop/components/database/DatabaseStatsCard.svelte
@@ -63,7 +63,7 @@
   let backupBytesWritten = $state(0);
   let backupTotalBytes = $state(0);
   let backupError = $state<string | null>(null);
-  let pollInterval: ReturnType<typeof setInterval> | null = null;
+  let pollTimeout: ReturnType<typeof setTimeout> | null = null;
 
   // Polling interval in milliseconds
   const POLL_INTERVAL_MS = 1500;
@@ -166,20 +166,33 @@
     }
   }
 
-  // Start polling for job status
+  // Start polling for job status (recursive setTimeout to prevent pile-up)
   function startPolling() {
-    if (pollInterval) return;
+    if (pollTimeout) return;
 
-    pollInterval = setInterval(pollJobStatus, POLL_INTERVAL_MS);
-    // Also poll immediately
+    // Poll immediately, then schedule next after completion
     pollJobStatus();
+    scheduleNextPoll();
+  }
+
+  // Schedule the next poll after POLL_INTERVAL_MS
+  function scheduleNextPoll() {
+    if (pollTimeout) return;
+    pollTimeout = setTimeout(async () => {
+      pollTimeout = null;
+      await pollJobStatus();
+      // Continue polling if we still have an active job
+      if (backupJobId && backupStatus !== 'completed' && backupStatus !== 'failed') {
+        scheduleNextPoll();
+      }
+    }, POLL_INTERVAL_MS);
   }
 
   // Stop polling
   function stopPolling() {
-    if (pollInterval) {
-      clearInterval(pollInterval);
-      pollInterval = null;
+    if (pollTimeout) {
+      clearTimeout(pollTimeout);
+      pollTimeout = null;
     }
   }
 

--- a/frontend/src/lib/stores/quietHours.svelte.ts
+++ b/frontend/src/lib/stores/quietHours.svelte.ts
@@ -34,7 +34,7 @@ export interface QuietHoursStatus {
 }
 
 let status = $state<QuietHoursStatus | null>(null);
-let timer: ReturnType<typeof setInterval> | null = null;
+let timer: ReturnType<typeof setTimeout> | null = null;
 let refCount = 0;
 
 async function fetchStatus() {
@@ -53,11 +53,22 @@ async function fetchStatus() {
  * Uses reference counting so multiple consumers can call startPolling/stopPolling
  * independently — polling only stops when all consumers have stopped.
  */
+function scheduleNextPoll() {
+  timer = setTimeout(async () => {
+    timer = null;
+    await fetchStatus();
+    // Continue polling only if there are still active consumers
+    if (refCount > 0) {
+      scheduleNextPoll();
+    }
+  }, POLL_INTERVAL_MS);
+}
+
 function startPolling() {
   refCount++;
   if (refCount === 1 && typeof window !== 'undefined') {
     fetchStatus();
-    timer = setInterval(fetchStatus, POLL_INTERVAL_MS);
+    scheduleNextPoll();
   }
 }
 
@@ -65,7 +76,7 @@ function startPolling() {
 function stopPolling() {
   refCount = Math.max(0, refCount - 1);
   if (refCount === 0 && timer !== null) {
-    clearInterval(timer);
+    clearTimeout(timer);
     timer = null;
   }
 }


### PR DESCRIPTION
## Summary

Closes #2270

- Convert `setInterval` polling loops to recursive `setTimeout` in three files that were missed in the original DatabaseDashboard.svelte fix
- **DatabaseManagement.svelte**: Two `$effect` blocks (migration polling + cleanup polling) now use the `cancelled` flag + recursive `setTimeout` pattern
- **DatabaseStatsCard.svelte**: `startPolling`/`stopPolling` for backup job status now use `scheduleNextPoll` with recursive `setTimeout`
- **quietHours.svelte.ts**: `startPolling`/`stopPolling` for quiet hours status now use `scheduleNextPoll` with recursive `setTimeout`

This prevents request pile-up when async API calls take longer than the poll interval, since `setInterval` fires on a fixed cadence regardless of whether the previous call has completed.

## Test plan

- [ ] Verify migration polling still updates UI during active migration
- [ ] Verify cleanup polling still updates UI during legacy cleanup
- [ ] Verify database backup progress polling works correctly
- [ ] Verify quiet hours status polling works when navigating between pages
- [ ] Verify no `setInterval` or `clearInterval` remains in the three changed files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved polling mechanisms for database management, backup monitoring, and quiet hours to enhance reliability and reduce resource overhead.
  * Enhanced offline state handling to ensure consistent behavior during connectivity issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->