### PR TITLE
fix: cancel in-flight ping on watchdog deactivation (#2274)

### DIFF
--- a/frontend/src/lib/stores/connectionState.svelte.ts
+++ b/frontend/src/lib/stores/connectionState.svelte.ts
@@ -161,13 +161,15 @@ function stopPingPolling(): void {
  * Uses a module-level AbortController so deactivateWatchdog() can cancel in-flight requests.
  */
 async function pingOnce(): Promise<void> {
-  activePingController = new AbortController();
-  const timeoutId = setTimeout(() => activePingController?.abort(), PING_TIMEOUT_MS);
+  activePingController?.abort();
+  const controller = new AbortController();
+  activePingController = controller;
+  const timeoutId = setTimeout(() => controller.abort(), PING_TIMEOUT_MS);
 
   try {
     const response = await fetch(buildAppUrl(PING_ENDPOINT), {
       method: 'GET',
-      signal: activePingController.signal,
+      signal: controller.signal,
       credentials: 'same-origin',
     });
 
@@ -178,7 +180,9 @@ async function pingOnce(): Promise<void> {
     // Ping failed — stay offline, will retry on next interval
   } finally {
     clearTimeout(timeoutId);
-    activePingController = null;
+    if (activePingController === controller) {
+      activePingController = null;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- Added module-level `AbortController` (`activePingController`) to cancel in-flight ping requests when `deactivateWatchdog()` is called
- Added `activated` guard before `markOnline()` in `pingOnce()` to prevent stale responses from triggering state changes after deactivation
- `deactivateWatchdog()` now aborts any in-flight ping and clears the controller reference

Fixes #2274

## Test plan
- [ ] Verify in-flight pings are cancelled when watchdog deactivates
- [ ] Verify no stale ping responses affect state after deactivation
- [ ] Verify normal ping behavior works when watchdog is active

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection-state ping handling to cancel overlapping checks and enforce timeouts.
  * Fixed online status detection to require proper activation and a successful response before marking online.
  * Ensured cleanup of in-flight ping checks when stopping or deactivating monitoring to avoid stale requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->