### PR TITLE
fix: prevent analysis buffer overruns and ringbuffer full under load

### DIFF
--- a/internal/myaudio/analysis_buffer.go
+++ b/internal/myaudio/analysis_buffer.go
@@ -128,9 +128,6 @@ func AllocateAnalysisBuffer(capacity int, sourceID string) error {
 	// real-time audio: dropping stale samples is preferable to failing writes
 	// or dropping current samples.
 	ab := ringbuffer.New(capacity)
-	if ab != nil {
-		ab.SetOverwrite(true)
-	}
 	if ab == nil {
 		enhancedErr := errors.Newf("failed to allocate ring buffer memory for analysis buffer").
 			Component("myaudio").
@@ -146,6 +143,7 @@ func AllocateAnalysisBuffer(capacity int, sourceID string) error {
 		}
 		return enhancedErr
 	}
+	ab.SetOverwrite(true)
 
 	// Update global variables safely
 	abMutex.Lock()


### PR DESCRIPTION
## Summary
- Enable ringbuffer overwrite mode (`SetOverwrite(true)`) on analysis buffers so that when the buffer is full under load, new writes overwrite the oldest data instead of failing with `ErrIsFull`/`ErrTooMuchDataToWrite`
- Remove the retry loop (3 retries x 10ms delay) which was insufficient under sustained load and caused Sentry error floods
- For real-time audio processing, dropping stale samples is the correct backpressure behavior -- preferable to failing writes or dropping current samples entirely

## Root Cause
The `smallnest/ringbuffer` library defaults to non-overwrite mode, returning `ErrIsFull` when the buffer has no space. When BirdNET inference takes longer than the audio buffer duration (processing overrun), audio data accumulates faster than it can be consumed. The 3-retry mechanism with 10ms delays was insufficient under sustained load, leading to failed writes and Sentry error floods (BIRDNET-GO-VC, TK, TS, TY, TX).

## Test plan
- [x] `go test -race -v ./internal/myaudio/` passes with all analysis buffer tests
- [x] `golangci-lint run -v` passes with zero issues
- [ ] CI passes
- [ ] Verify no `ringbuffer is full` or `too much data to write` Sentry errors on nightly after deployment

Fixes #2245

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio buffer stability: the analysis buffer now auto-overwrites oldest data when full to prevent write failures and interruptions.
  * Safer buffer lifecycle: initialization and registry access are more robust to missing or existing resources.
  * Metrics and logging enhanced: write/read success and near-capacity events are logged and recorded with clearer context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->