### PR TITLE
fix: suppress Sentry noise for unregistered sound level processor

### DIFF
--- a/internal/myaudio/capture.go
+++ b/internal/myaudio/capture.go
@@ -708,8 +708,10 @@ func processAudioFrame(
 	// Process sound level data if enabled (use the safe bufferToUse) - this may be nil if 10-second window isn't complete
 	if conf.Setting().Realtime.Audio.SoundLevel.Enabled {
 		if soundLevelData, err := ProcessSoundLevelData(sourceID, bufferToUse); err != nil {
-			// Only log actual errors, not normal conditions
-			if !errors.Is(err, ErrIntervalIncomplete) && !errors.Is(err, ErrNoAudioData) {
+			// Only log actual errors, not normal conditions.
+			// ErrSoundLevelProcessorNotRegistered is expected during startup race
+			// or hot-reload windows and should be silently ignored (issue #2249).
+			if !errors.Is(err, ErrIntervalIncomplete) && !errors.Is(err, ErrNoAudioData) && !errors.Is(err, ErrSoundLevelProcessorNotRegistered) {
 				log.Warn("error processing sound level data",
 					logger.Error(err),
 					logger.String("source_id", sourceID))

--- a/internal/myaudio/soundlevel.go
+++ b/internal/myaudio/soundlevel.go
@@ -583,9 +583,10 @@ func ProcessSoundLevelData(source string, audioData []byte) (*SoundLevelData, er
 	soundLevelProcessorMutex.RUnlock()
 
 	if !exists {
-		return nil, errors.New(ErrSoundLevelProcessorNotRegistered).
-			Context("source", source).
-			Build()
+		// Return the sentinel error directly without Build() to avoid triggering
+		// Sentry telemetry. This is an expected condition during startup race or
+		// hot-reload windows, not a real error (issue #2249).
+		return nil, fmt.Errorf("%w: source=%s", ErrSoundLevelProcessorNotRegistered, source)
 	}
 
 	return processor.ProcessAudioData(audioData)


### PR DESCRIPTION
## Summary
- Stop `ErrSoundLevelProcessorNotRegistered` from flooding Sentry (BIRDNET-GO-QR, 28+ events) by removing the `Build()` call that triggers telemetry reporting in `ProcessSoundLevelData()` — this is an expected transient condition during startup race or hot-reload windows, not a real error
- Add `ErrSoundLevelProcessorNotRegistered` to the filtered error list in `processAudioFrame()` (malgo/audio-card path), matching the existing suppression in the ffmpeg_stream path

## Test plan
- [x] Existing sound level tests pass (`go test -race -v ./internal/myaudio/... -run SoundLevel`)
- [x] `golangci-lint` passes with zero issues
- [x] `errors.Is()` semantics preserved via `fmt.Errorf("%w", ...)` wrapping
- [ ] CI passes

Fixes #2249

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during application startup and hot-reload to reduce unnecessary log entries and false error alerts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->