### PR TITLE
fix: add AllowEmbedding option to allow iframe embedding

### DIFF
--- a/internal/api/config.go
+++ b/internal/api/config.go
@@ -45,6 +45,7 @@ type Config struct {
 	// Security settings
 	RedirectToHTTPS bool     // Redirect HTTP to HTTPS
 	AllowedOrigins  []string // CORS allowed origins
+	AllowEmbedding  bool     // Allow embedding in iframes (e.g., Home Assistant)
 
 	// Timeouts
 	ReadTimeout     time.Duration // Maximum duration for reading request
@@ -130,6 +131,9 @@ func ConfigFromSettings(settings *conf.Settings) *Config {
 	default:
 		// TLSModeNone — plain HTTP
 	}
+
+	// Embedding
+	cfg.AllowEmbedding = settings.WebServer.AllowEmbedding
 
 	// Debug mode
 	cfg.Debug = settings.WebServer.Debug || settings.Debug

--- a/internal/api/middleware/security.go
+++ b/internal/api/middleware/security.go
@@ -40,6 +40,10 @@ type SecurityConfig struct {
 	// ContentSecurityPolicy specifies the Content-Security-Policy header value.
 	// Leave empty to not set the header.
 	ContentSecurityPolicy string
+
+	// AllowEmbedding controls whether the application can be embedded in iframes.
+	// When true, the X-Frame-Options header is omitted, allowing embedding.
+	AllowEmbedding bool
 }
 
 // DefaultSecurityConfig returns a SecurityConfig with sensible defaults.
@@ -87,10 +91,15 @@ func NewCORS(config SecurityConfig) echo.MiddlewareFunc {
 
 // NewSecureHeaders creates a middleware that sets security-related HTTP headers.
 func NewSecureHeaders(config SecurityConfig) echo.MiddlewareFunc {
+	xFrameOptions := "SAMEORIGIN"
+	if config.AllowEmbedding {
+		xFrameOptions = ""
+	}
+
 	return middleware.SecureWithConfig(middleware.SecureConfig{
 		XSSProtection:         "1; mode=block",
 		ContentTypeNosniff:    "nosniff",
-		XFrameOptions:         "SAMEORIGIN",
+		XFrameOptions:         xFrameOptions,
 		HSTSMaxAge:            config.HSTSMaxAge,
 		HSTSExcludeSubdomains: config.HSTSExcludeSubdomains,
 		ContentSecurityPolicy: config.ContentSecurityPolicy,

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -252,6 +252,7 @@ func (s *Server) setupMiddleware() {
 		HSTSMaxAge:            mw.HSTSMaxAge,
 		HSTSExcludeSubdomains: false,
 		ContentSecurityPolicy: "",
+		AllowEmbedding:        s.config.AllowEmbedding,
 	}
 
 	// CORS middleware

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -1207,6 +1207,7 @@ type WebServerSettings struct {
 	Enabled        bool               `json:"enabled"`        // true to enable web server
 	Port           string             `json:"port"`           // port for web server
 	BasePath       string             `json:"basePath"`       // reverse proxy subpath prefix (e.g., "/birdnet")
+	AllowEmbedding bool               `json:"allowEmbedding"` // true to allow embedding in iframes (e.g., Home Assistant)
 	LiveStream     LiveStreamSettings `json:"liveStream"`     // live stream configuration
 	EnableTerminal bool               `json:"enableTerminal"` // Enable browser terminal (security risk)
 }

--- a/internal/conf/config.yaml
+++ b/internal/conf/config.yaml
@@ -341,6 +341,7 @@ realtime:
 webserver:
   enabled: true           # true to enable web server
   port: 8080              # port for web server
+  allowembedding: false   # true to allow embedding in iframes (e.g., Home Assistant)
   log:
     enabled: false        # true to enable log file
     path: webui.log       # path to log file


### PR DESCRIPTION
## Summary

Add a `webserver.allowembedding` config option that removes the `X-Frame-Options: SAMEORIGIN` header when enabled, allowing BirdNET-Go to be embedded in iframes such as Home Assistant dashboard cards.

When `allowembedding` is `false` (default), behavior is unchanged — the `X-Frame-Options: SAMEORIGIN` header is sent as before. When set to `true`, the header is omitted, allowing any origin to embed the page in an iframe.

**Changes:**
- Add `AllowEmbedding` field to `WebServerSettings`, `api.Config`, and `SecurityConfig`
- Thread the setting from config through to the secure headers middleware
- Conditionally omit `X-Frame-Options` header when embedding is allowed
- Add default config entry in `config.yaml`

## Related Issues

Closes #2290

## Test Plan

- [ ] Verify default behavior unchanged: `X-Frame-Options: SAMEORIGIN` header present when `allowembedding` is not set
- [ ] Set `webserver.allowembedding: true` and verify `X-Frame-Options` header is absent from responses
- [ ] Embed BirdNET-Go in an iframe from a different origin with embedding enabled

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new configuration option to control iframe embedding. When enabled via `webserver.allowembedding`, the application can be embedded in iframes (e.g., Home Assistant). Defaults to disabled for security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->