### PR TITLE
fix: redact sensitive credentials from browser console logging

### DIFF
--- a/frontend/src/lib/desktop/features/settings/pages/IntegrationSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/IntegrationSettingsPage.svelte
@@ -63,6 +63,24 @@
 
   const logger = loggers.settings;
 
+  /** Redaction placeholder for sensitive fields in debug logs. */
+  const REDACTED = '***';
+
+  /**
+   * Creates a copy of an object with specified fields redacted for safe logging.
+   * Fields that are present and truthy are replaced with REDACTED; empty/falsy
+   * fields are replaced with an empty string to indicate "not set".
+   */
+  function redactForLogging(obj: object, fields: string[]): Record<string, unknown> {
+    const redacted = Object.assign({}, obj) as Record<string, unknown>;
+    for (const field of fields) {
+      if (field in redacted) {
+        redacted[field] = redacted[field] ? REDACTED : '';
+      }
+    }
+    return redacted;
+  }
+
   // PERFORMANCE OPTIMIZATION: Reactive settings with proper defaults
   let settings = $derived(
     $integrationSettings || {
@@ -478,10 +496,11 @@
     try {
       // Get current form values (unsaved changes) instead of saved settings
       const currentBirdweather = store.formData?.realtime?.birdweather || settings.birdweather!;
-      logger.debug('BirdWeather test config:', {
-        ...currentBirdweather,
-        id: currentBirdweather.id ? '***' : '',
-      });
+      // Exclude latitude/longitude (PII) and redact station ID before logging
+      logger.debug(
+        'BirdWeather test config:',
+        redactForLogging(currentBirdweather, ['id', 'latitude', 'longitude'])
+      );
 
       // Prepare test payload
       const testPayload = {
@@ -502,10 +521,10 @@
         headers.set('X-CSRF-Token', token);
       }
 
-      logger.debug('Sending BirdWeather test request with payload:', {
-        ...testPayload,
-        id: testPayload.id ? '***' : '',
-      });
+      logger.debug(
+        'Sending BirdWeather test request with payload:',
+        redactForLogging(testPayload, ['id'])
+      );
 
       const response = await fetch(buildAppUrl('/api/v2/integrations/birdweather/test'), {
         method: 'POST',
@@ -694,11 +713,7 @@
     try {
       // Get current form values (unsaved changes) instead of saved settings
       const currentMqtt = store.formData?.realtime?.mqtt || settings.mqtt!;
-      logger.debug('MQTT test config:', {
-        ...currentMqtt,
-        password: currentMqtt.password ? '***' : '',
-        username: currentMqtt.username ? '***' : '',
-      });
+      logger.debug('MQTT test config:', redactForLogging(currentMqtt, ['password', 'username']));
 
       // Prepare test payload matching the MQTT handler's TestConfig structure
       const testPayload = {
@@ -726,11 +741,10 @@
         headers.set('X-CSRF-Token', token);
       }
 
-      logger.debug('Sending MQTT test request with payload:', {
-        ...testPayload,
-        password: testPayload.password ? '***' : '',
-        username: testPayload.username ? '***' : '',
-      });
+      logger.debug(
+        'Sending MQTT test request with payload:',
+        redactForLogging(testPayload, ['password', 'username'])
+      );
 
       const response = await fetch(buildAppUrl('/api/v2/integrations/mqtt/test'), {
         method: 'POST',


### PR DESCRIPTION
## Summary

Fixes #2293

Redacts sensitive credentials from `logger.debug()` calls in `IntegrationSettingsPage.svelte` that were logging MQTT passwords/usernames and BirdWeather station IDs in plain text to the browser console.

**Four `logger.debug()` calls redacted:**

- BirdWeather test config log (~line 481): redacted `id` (station ID)
- BirdWeather test request payload log (~line 505): redacted `id` (station ID)
- MQTT test config log (~line 691): redacted `password` and `username`
- MQTT test request payload log (~line 722): redacted `password` and `username`

Each redaction uses the spread operator to copy the payload, then replaces the sensitive field with `'***'` if a value is present, preserving debug usefulness while preventing credential exposure.

## Test plan

- [ ] Open Integration Settings page in the browser
- [ ] Configure MQTT with username/password and trigger a test connection
- [ ] Verify browser console shows `'***'` instead of actual credentials
- [ ] Configure BirdWeather with a station ID and trigger a test connection
- [ ] Verify browser console shows `'***'` instead of the actual station ID
- [ ] Verify non-sensitive fields (broker, topic, threshold, etc.) still appear normally in logs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced safer log redaction for integration tests to prevent exposure of sensitive fields in debug output.
* **Bug Fixes**
  * Debug logs for BirdWeather and MQTT integrations now mask credentials and location identifiers during testing, improving security without affecting test behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->