### PR TITLE
fix: persist remaining buffer across chunks in streaming JSON parser

### DIFF
--- a/frontend/src/lib/desktop/features/settings/pages/IntegrationSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/IntegrationSettingsPage.svelte
@@ -522,17 +522,18 @@
         throw new Error(t('settings.integration.errors.responseStreamFailed'));
       }
 
+      let remaining = '';
+
       while (true) {
         const { done, value } = await reader.read();
         if (done) break;
 
-        // Parse each chunk as JSON
-        const chunk = decoder.decode(value);
-        logger.debug('Raw BirdWeather chunk received:', chunk);
+        // Append chunk to any leftover partial data from previous iteration
+        remaining += decoder.decode(value, { stream: true });
+        logger.debug('Raw BirdWeather chunk received:', remaining);
 
         // Split by both newlines and by '}{'  pattern to handle concatenated JSON objects
         const jsonObjects = [];
-        let remaining = chunk;
 
         while (remaining.trim()) {
           try {
@@ -739,17 +740,18 @@
         throw new Error(t('settings.integration.errors.responseStreamFailed'));
       }
 
+      let remaining = '';
+
       while (true) {
         const { done, value } = await reader.read();
         if (done) break;
 
-        // Parse each line as JSON
-        const chunk = decoder.decode(value);
-        logger.debug('Raw MQTT chunk received:', chunk);
+        // Append chunk to any leftover partial data from previous iteration
+        remaining += decoder.decode(value, { stream: true });
+        logger.debug('Raw MQTT chunk received:', remaining);
 
         // Split by both newlines and by '}{'  pattern to handle concatenated JSON objects
         const jsonObjects = [];
-        let remaining = chunk;
 
         while (remaining.trim()) {
           try {


### PR DESCRIPTION
## Summary

Fixes #2294

The streaming JSON parser in `IntegrationSettingsPage.svelte` declared `remaining` inside the read loop in both the BirdWeather and MQTT connection test functions. This reset `remaining` to only the current chunk on each iteration, silently discarding any partial JSON object left over from the previous chunk. As a result, test result stages could be missed in the UI when a chunk boundary fell mid-JSON-object.

- Moved `let remaining = ''` outside the `while (true)` read loop so partial data persists across iterations
- Changed to `remaining += decoder.decode(value, { stream: true })` to accumulate chunks and correctly handle multi-byte characters split across boundaries
- Applied the fix in both the BirdWeather and MQTT streaming parser sections

## Test plan

- [ ] Trigger a BirdWeather connection test and verify all stages render in the UI
- [ ] Trigger an MQTT connection test and verify all stages render in the UI
- [ ] Confirm no stages are skipped or missing when the server sends responses in small or split chunks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved reliability of streaming data parsing in integration settings. Fixed an issue where data arriving in multiple chunks was not being properly accumulated, ensuring complete data objects spanning multiple chunks are correctly processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->