### PR TITLE
fix: display actual computed detection count in false positive filter UI

### DIFF
--- a/frontend/src/lib/desktop/features/settings/pages/MainSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/MainSettingsPage.svelte
@@ -1021,52 +1021,90 @@
   // Tolerance for floating-point comparison (overlap values have 1 decimal precision)
   const OVERLAP_COMPARISON_TOLERANCE = 0.001;
 
-  // Minimum overlap values must match backend: internal/analysis/processor/false_positive_filter.go
+  // Minimum overlap and threshold values must match backend:
+  // internal/analysis/processor/false_positive_filter.go
   const falsePositiveFilterLevels = [
     {
       value: 0,
       name: 'Off',
-      description: 'No filtering - accepts first detection immediately',
+      descriptionKey: 'settings.main.sections.falsePositiveFilter.levels.off',
       minOverlap: 0.0,
+      threshold: 0.0,
     },
     {
       value: 1,
       name: 'Lenient',
-      description: '~2 confirmations required. For low-quality audio (RTSP cameras, webcam mics)',
+      descriptionKey: 'settings.main.sections.falsePositiveFilter.levels.lenient',
       minOverlap: 2.0,
+      threshold: 0.2,
     },
     {
       value: 2,
       name: 'Moderate',
-      description: '~3 confirmations required. Balanced for typical hobby setups',
+      descriptionKey: 'settings.main.sections.falsePositiveFilter.levels.moderate',
       minOverlap: 2.2,
+      threshold: 0.3,
     },
     {
       value: 3,
       name: 'Balanced',
-      description: '~5 confirmations required. Original pre-Sept 2025 behavior',
+      descriptionKey: 'settings.main.sections.falsePositiveFilter.levels.balanced',
       minOverlap: 2.4,
+      threshold: 0.5,
     },
     {
       value: 4,
       name: 'Strict',
-      description: '~12 confirmations required. RPi 4+ needed. For high-quality microphones',
+      descriptionKey: 'settings.main.sections.falsePositiveFilter.levels.strict',
       minOverlap: 2.7,
+      threshold: 0.6,
     },
     {
       value: 5,
       name: 'Maximum',
-      description: '~21 confirmations required. RPi 4+ needed. For professional-grade microphones',
+      descriptionKey: 'settings.main.sections.falsePositiveFilter.levels.maximum',
       minOverlap: 2.8,
+      threshold: 0.7,
     },
   ];
+
+  // Constants matching backend: internal/analysis/processor/processor.go
+  const CHUNK_DURATION_SECONDS = 3.0;
+  const REFERENCE_WINDOW_SECONDS = 6.0;
+  const MIN_SEGMENT_LENGTH = 0.1;
+  const FLOAT_EPSILON = 1e-9;
+
+  // Calculates minimum required detections based on overlap and filter level.
+  // Must match backend: internal/analysis/processor/processor.go calculateMinDetectionsFromSettings()
+  function calculateMinDetections(level: number, overlap: number): number {
+    if (level === 0) return 1;
+
+    const levelData = safeArrayAccess(falsePositiveFilterLevels, level);
+    if (!levelData) return 1;
+
+    const segmentLength = Math.max(MIN_SEGMENT_LENGTH, CHUNK_DURATION_SECONDS - overlap);
+    const maxDetectionsIn6s = REFERENCE_WINDOW_SECONDS / segmentLength;
+    const required = maxDetectionsIn6s * levelData.threshold - FLOAT_EPSILON;
+    return Math.max(1, Math.ceil(required));
+  }
 
   function getFalsePositiveFilterLevelName(level: number): string {
     return safeArrayAccess(falsePositiveFilterLevels, level)?.name ?? 'Unknown';
   }
 
-  function getFalsePositiveFilterDescription(level: number): string {
-    return safeArrayAccess(falsePositiveFilterLevels, level)?.description ?? '';
+  function getFalsePositiveFilterDescription(level: number, overlap: number): string {
+    const levelData = safeArrayAccess(falsePositiveFilterLevels, level);
+    if (!levelData) return '';
+
+    const minDet = calculateMinDetections(level, overlap);
+    const baseDescription = t(levelData.descriptionKey);
+
+    if (level === 0) return baseDescription;
+
+    return t('settings.main.sections.falsePositiveFilter.detectionCount', {
+      count: minDet.toString(),
+      description: baseDescription,
+    });
   }
 
   function getMinimumOverlapForLevel(level: number): number {
@@ -1582,7 +1620,10 @@
           />
           <div class="mt-1">
             <span class="text-xs text-[var(--color-base-content)] opacity-60">
-              {getFalsePositiveFilterDescription(settings.falsePositiveFilter.level)}
+              {getFalsePositiveFilterDescription(
+                settings.falsePositiveFilter.level,
+                settings.birdnet.overlap
+              )}
             </span>
           </div>
         </div>

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -1611,6 +1611,15 @@
           "level": {
             "label": "Filterstufe"
           },
+          "detectionCount": "{count} Bestätigungen erforderlich. {description}",
+          "levels": {
+            "off": "Keine Filterung - akzeptiert erste Erkennung sofort",
+            "lenient": "Für Audio niedriger Qualität (RTSP-Kameras, Webcam-Mikrofone)",
+            "moderate": "Ausgewogen für typische Hobby-Setups",
+            "balanced": "Ursprüngliches Verhalten vor September 2025",
+            "strict": "RPi 4+ erforderlich. Für hochwertige Mikrofone",
+            "maximum": "RPi 4+ erforderlich. Für professionelle Mikrofone"
+          },
           "hardwareNote": "Die Stufen \"Streng\" und \"Maximum\" erfordern höhere Überlappungseinstellungen und mehr CPU-Ressourcen. RPi 4 oder bessere Hardware ist für diese Stufen erforderlich.",
           "overlapAdjusted": "Überlappungseinstellung automatisch auf {overlap}s angepasst, um die Filteranforderungen zu erfüllen",
           "overlapReduced": "Überlappungseinstellung auf {overlap}s reduziert, um der Filterstufe zu entsprechen"

--- a/frontend/static/messages/en.json
+++ b/frontend/static/messages/en.json
@@ -1653,6 +1653,15 @@
           "level": {
             "label": "Filter Level"
           },
+          "detectionCount": "{count} confirmations required. {description}",
+          "levels": {
+            "off": "No filtering - accepts first detection immediately",
+            "lenient": "For low-quality audio (RTSP cameras, webcam mics)",
+            "moderate": "Balanced for typical hobby setups",
+            "balanced": "Original pre-Sept 2025 behavior",
+            "strict": "RPi 4+ needed. For high-quality microphones",
+            "maximum": "RPi 4+ needed. For professional-grade microphones"
+          },
           "hardwareNote": "Strict and Maximum levels require higher overlap settings and more CPU resources. RPi 4 or better hardware is required for these levels.",
           "overlapAdjusted": "Overlap setting automatically adjusted to {overlap}s to meet filter requirements",
           "overlapReduced": "Overlap setting reduced to {overlap}s to match filter level"

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -1611,6 +1611,15 @@
           "level": {
             "label": "Nivel del Filtro"
           },
+          "detectionCount": "{count} confirmaciones requeridas. {description}",
+          "levels": {
+            "off": "Sin filtrado - acepta la primera detección inmediatamente",
+            "lenient": "Para audio de baja calidad (cámaras RTSP, micrófonos de webcam)",
+            "moderate": "Equilibrado para configuraciones típicas de hobby",
+            "balanced": "Comportamiento original anterior a septiembre de 2025",
+            "strict": "RPi 4+ necesario. Para micrófonos de alta calidad",
+            "maximum": "RPi 4+ necesario. Para micrófonos de grado profesional"
+          },
           "hardwareNote": "Los niveles Estricto y Máximo requieren configuraciones de superposición más altas y más recursos de CPU. Se requiere RPi 4 o hardware superior para estos niveles.",
           "overlapAdjusted": "La configuración de superposición se ajustó automáticamente a {overlap}s para cumplir con los requisitos del filtro",
           "overlapReduced": "La configuración de superposición se redujo a {overlap}s para coincidir con el nivel del filtro"

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -1611,6 +1611,15 @@
           "level": {
             "label": "Suodatustaso"
           },
+          "detectionCount": "{count} vahvistusta vaaditaan. {description}",
+          "levels": {
+            "off": "Ei suodatusta - hyväksyy ensimmäisen havainnon välittömästi",
+            "lenient": "Heikkolaatuiselle äänelle (RTSP-kamerat, web-kameramikrofonit)",
+            "moderate": "Tasapainoinen tyypillisille harrastusasetuksille",
+            "balanced": "Alkuperäinen toiminta ennen syyskuuta 2025",
+            "strict": "RPi 4+ vaaditaan. Laadukkaille mikrofoneille",
+            "maximum": "RPi 4+ vaaditaan. Ammattitason mikrofoneille"
+          },
           "hardwareNote": "Tiukka- ja maksimitasot vaativat korkeampia päällekkäisyysasetuksia ja enemmän prosessoritehoa. RPi 4 tai parempi laitteisto vaaditaan näille tasoille.",
           "overlapAdjusted": "Päällekkäisyysasetus säädetty automaattisesti arvoon {overlap}s suodatinvaatimusten täyttämiseksi",
           "overlapReduced": "Päällekkäisyysasetus pienennetty arvoon {overlap}s vastaamaan suodatustasoa"

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -1611,6 +1611,15 @@
           "level": {
             "label": "Niveau du Filtre"
           },
+          "detectionCount": "{count} confirmations requises. {description}",
+          "levels": {
+            "off": "Pas de filtrage - accepte la première détection immédiatement",
+            "lenient": "Pour audio de basse qualité (caméras RTSP, micros webcam)",
+            "moderate": "Équilibré pour les configurations hobby typiques",
+            "balanced": "Comportement original d'avant septembre 2025",
+            "strict": "RPi 4+ requis. Pour microphones de haute qualité",
+            "maximum": "RPi 4+ requis. Pour microphones de qualité professionnelle"
+          },
           "hardwareNote": "Les niveaux Strict et Maximum nécessitent des paramètres de chevauchement plus élevés et plus de ressources CPU. Un RPi 4 ou un matériel supérieur est requis pour ces niveaux.",
           "overlapAdjusted": "Le paramètre de chevauchement a été automatiquement ajusté à {overlap}s pour répondre aux exigences du filtre",
           "overlapReduced": "Le paramètre de chevauchement a été réduit à {overlap}s pour correspondre au niveau du filtre"

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -1420,6 +1420,15 @@
           "level": {
             "label": "Livello Filtro"
           },
+          "detectionCount": "{count} conferme richieste. {description}",
+          "levels": {
+            "off": "Nessun filtraggio - accetta il primo rilevamento immediatamente",
+            "lenient": "Per audio di bassa qualità (telecamere RTSP, microfoni webcam)",
+            "moderate": "Equilibrato per configurazioni hobby tipiche",
+            "balanced": "Comportamento originale pre-settembre 2025",
+            "strict": "RPi 4+ necessario. Per microfoni di alta qualità",
+            "maximum": "RPi 4+ necessario. Per microfoni di grado professionale"
+          },
           "hardwareNote": "I livelli Rigoroso e Massimo richiedono impostazioni di sovrapposizione più alte e più risorse CPU. Hardware RPi 4 o migliore è richiesto per questi livelli.",
           "overlapAdjusted": "Impostazione sovrapposizione regolata automaticamente a {overlap}s per soddisfare i requisiti del filtro",
           "overlapReduced": "Impostazione sovrapposizione ridotta a {overlap}s per corrispondere al livello del filtro"

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -1611,6 +1611,15 @@
           "level": {
             "label": "Filterniveau"
           },
+          "detectionCount": "{count} bevestigingen vereist. {description}",
+          "levels": {
+            "off": "Geen filtering - accepteert eerste detectie onmiddellijk",
+            "lenient": "Voor audio van lage kwaliteit (RTSP-camera's, webcammicrofoons)",
+            "moderate": "Gebalanceerd voor typische hobbyopstellingen",
+            "balanced": "Origineel gedrag van voor september 2025",
+            "strict": "RPi 4+ vereist. Voor hoogwaardige microfoons",
+            "maximum": "RPi 4+ vereist. Voor professionele microfoons"
+          },
           "hardwareNote": "De niveaus \"Strikt\" en \"Maximum\" vereisen hogere overlap-instellingen en meer CPU-bronnen. RPi 4 of betere hardware is vereist voor deze niveaus.",
           "overlapAdjusted": "Overlap-instelling automatisch aangepast naar {overlap}s om aan de filtervereisten te voldoen",
           "overlapReduced": "Overlap-instelling verlaagd naar {overlap}s om overeen te komen met het filterniveau"

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -1623,6 +1623,15 @@
           "level": {
             "label": "Poziom Filtra"
           },
+          "detectionCount": "Wymagane {count} potwierdzeń. {description}",
+          "levels": {
+            "off": "Brak filtrowania - natychmiast akceptuje pierwszą detekcję",
+            "lenient": "Dla audio niskiej jakości (kamery RTSP, mikrofony kamer internetowych)",
+            "moderate": "Zrównoważony dla typowych konfiguracji hobbystycznych",
+            "balanced": "Oryginalne zachowanie sprzed września 2025",
+            "strict": "Wymagany RPi 4+. Dla mikrofonów wysokiej jakości",
+            "maximum": "Wymagany RPi 4+. Dla mikrofonów klasy profesjonalnej"
+          },
           "hardwareNote": "Poziomy Ścisły i Maksymalny wymagają wyższych ustawień nakładania i większych zasobów CPU. Dla tych poziomów wymagany jest RPi 4 lub lepszy sprzęt.",
           "overlapAdjusted": "Ustawienie nakładania automatycznie dostosowane do {overlap}s, aby spełnić wymagania filtra",
           "overlapReduced": "Ustawienie nakładania zmniejszono do {overlap}s, aby dopasować do poziomu filtra"

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -1611,6 +1611,15 @@
           "level": {
             "label": "Nível do Filtro"
           },
+          "detectionCount": "{count} confirmações necessárias. {description}",
+          "levels": {
+            "off": "Sem filtragem - aceita a primeira detecção imediatamente",
+            "lenient": "Para áudio de baixa qualidade (câmeras RTSP, microfones de webcam)",
+            "moderate": "Equilibrado para configurações típicas de hobby",
+            "balanced": "Comportamento original anterior a setembro de 2025",
+            "strict": "RPi 4+ necessário. Para microfones de alta qualidade",
+            "maximum": "RPi 4+ necessário. Para microfones de grau profissional"
+          },
           "hardwareNote": "Os níveis Rigoroso e Máximo requerem configurações de sobreposição mais altas e mais recursos de CPU. RPi 4 ou hardware superior é necessário para esses níveis.",
           "overlapAdjusted": "Configuração de sobreposição ajustada automaticamente para {overlap}s para atender aos requisitos do filtro",
           "overlapReduced": "A configuração de sobreposição foi reduzida para {overlap}s para corresponder ao nível do filtro"

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -1454,6 +1454,15 @@
           "level": {
             "label": "Úroveň filtra"
           },
+          "detectionCount": "Vyžadovaných {count} potvrdení. {description}",
+          "levels": {
+            "off": "Bez filtrovania - okamžite prijme prvú detekciu",
+            "lenient": "Pre nízku kvalitu zvuku (RTSP kamery, mikrofóny webkamier)",
+            "moderate": "Vyvážené pre typické hobby konfigurácie",
+            "balanced": "Pôvodné správanie pred septembrom 2025",
+            "strict": "Vyžaduje sa RPi 4+. Pre vysokokvalitné mikrofóny",
+            "maximum": "Vyžaduje sa RPi 4+. Pre mikrofóny profesionálnej triedy"
+          },
           "hardwareNote": "Prísne a maximálne úrovne vyžadujú vyššie nastavenia prekrytia a viac prostriedkov CPU. Pre tieto úrovne sa vyžaduje hardvér RPi 4 alebo lepší.",
           "overlapAdjusted": "Nastavenie prekrytia bolo automaticky upravené na {overlap}s, aby spĺňalo požiadavky filtra",
           "overlapReduced": "Nastavenie prekrytia bolo znížené na {overlap}s, aby zodpovedalo úrovni filtra"


### PR DESCRIPTION
## Summary
- False Positive Filter slider showed static approximate counts (e.g. "~2 confirmations") that didn't reflect the actual computed count
- The real required detection count depends on the overlap setting, causing user confusion (e.g. slider=2 with overlap=2.9 actually requires 12 detections)
- Replicated the backend `calculateMinDetectionsFromSettings()` calculation in the frontend so the slider dynamically shows the exact count based on the user's current overlap setting
- Updated all 10 translation files with new i18n keys for the dynamic description

Fixes #1699

## Test plan
- [ ] Change overlap setting and verify the displayed detection count updates accordingly
- [ ] Verify each filter level (0-5) shows the correct computed count matching the backend logic
- [ ] Check that the slider description updates in real-time when overlap changes
- [ ] Verify all 10 locales render the new translation keys correctly
- [ ] Confirm the false positive filter still works correctly with various overlap values

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced false positive filter with six new configurable levels (off, lenient, moderate, balanced, strict, maximum) for improved control over detection sensitivity
  * Dynamic detection confirmation requirements that adjust based on your selected filter level and audio overlap settings
  * Multilingual support for all new filter configurations across all supported languages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->