### PR TITLE
fix: ensure spectrogram style setting is consistently applied

### DIFF
--- a/internal/api/v2/media.go
+++ b/internal/api/v2/media.go
@@ -793,7 +793,7 @@ func (c *Controller) handleUserRequestedMode(ctx echo.Context, noteID, clipPath 
 
 	if err == nil {
 		// Build spectrogram path
-		_, _, _, relSpectrogramPath := buildSpectrogramPaths(relAudioPath, params.width, params.raw)
+		_, _, _, relSpectrogramPath := buildSpectrogramPaths(relAudioPath, params.width, params.raw, c.Settings.Realtime.Dashboard.Spectrogram.Style)
 
 		// Check if spectrogram already exists
 		if _, statErr := c.SFS.StatRel(relSpectrogramPath); statErr == nil {
@@ -1142,7 +1142,7 @@ func (c *Controller) GetSpectrogramStatus(ctx echo.Context) error {
 	}
 
 	// Build spectrogram path and key
-	_, _, _, relSpectrogramPath := buildSpectrogramPaths(relAudioPath, params.width, params.raw)
+	_, _, _, relSpectrogramPath := buildSpectrogramPaths(relAudioPath, params.width, params.raw, c.Settings.Realtime.Dashboard.Spectrogram.Style)
 	spectrogramKey := buildSpectrogramKey(relSpectrogramPath, params.width, params.raw)
 
 	// Check queue status first (more volatile state)
@@ -1256,7 +1256,7 @@ func (c *Controller) GenerateSpectrogramByID(ctx echo.Context) error {
 	}
 
 	// Build spectrogram paths and key (path is validated at this point)
-	_, _, _, relSpectrogramPath := buildSpectrogramPaths(relAudioPath, params.width, params.raw)
+	_, _, _, relSpectrogramPath := buildSpectrogramPaths(relAudioPath, params.width, params.raw, c.Settings.Realtime.Dashboard.Spectrogram.Style)
 	spectrogramKey := buildSpectrogramKey(relSpectrogramPath, params.width, params.raw)
 
 	// Check if file already exists on disk
@@ -1464,18 +1464,26 @@ func getSpectrogramLogger() logger.Logger {
 
 // buildSpectrogramPaths constructs the spectrogram file paths from the audio path and parameters.
 // It returns the base filename, audio directory, spectrogram filename, and full relative spectrogram path.
-func buildSpectrogramPaths(relAudioPath string, width int, raw bool) (relBaseFilename, relAudioDir, spectrogramFilename, relSpectrogramPath string) {
+// The style parameter is included in the filename when it differs from "default" to ensure
+// spectrograms generated with different styles are cached separately (fixes #1937).
+func buildSpectrogramPaths(relAudioPath string, width int, raw bool, style string) (relBaseFilename, relAudioDir, spectrogramFilename, relSpectrogramPath string) {
 	// Get the base filename and directory relative to the secure root
 	relBaseFilename = strings.TrimSuffix(filepath.Base(relAudioPath), filepath.Ext(relAudioPath))
 	relAudioDir = filepath.Dir(relAudioPath)
 
+	// Build style suffix for non-default styles
+	styleSuffix := ""
+	if style != "" && style != conf.SpectrogramStyleDefault {
+		styleSuffix = "-" + style
+	}
+
 	// Generate spectrogram filename compatible with old HTMX API format
 	if raw {
-		// Raw spectrograms use format: filename_1026px.png
-		spectrogramFilename = fmt.Sprintf("%s_%dpx.png", relBaseFilename, width)
+		// Raw spectrograms use format: filename_1026px.png or filename_1026px-scientific_dark.png
+		spectrogramFilename = fmt.Sprintf("%s_%dpx%s.png", relBaseFilename, width, styleSuffix)
 	} else {
-		// Spectrograms with legends use suffix: filename_1026px-legend.png
-		spectrogramFilename = fmt.Sprintf("%s_%dpx-legend.png", relBaseFilename, width)
+		// Spectrograms with legends use suffix: filename_1026px-legend.png or filename_1026px-legend-scientific_dark.png
+		spectrogramFilename = fmt.Sprintf("%s_%dpx-legend%s.png", relBaseFilename, width, styleSuffix)
 	}
 
 	// Since we're constructing the spectrogram path from an already-validated audio path
@@ -2142,7 +2150,7 @@ func (c *Controller) generateSpectrogram(ctx context.Context, audioPath string, 
 	}
 
 	// Step 2: Calculate spectrogram paths early (needed for fast path check)
-	relBaseFilename, relAudioDir, spectrogramFilename, relSpectrogramPath := buildSpectrogramPaths(relAudioPath, width, raw)
+	relBaseFilename, relAudioDir, spectrogramFilename, relSpectrogramPath := buildSpectrogramPaths(relAudioPath, width, raw, c.Settings.Realtime.Dashboard.Spectrogram.Style)
 
 	getSpectrogramLogger().Debug("Spectrogram path constructed",
 		logger.String("audio_path", audioPath),

--- a/internal/spectrogram/prerenderer.go
+++ b/internal/spectrogram/prerenderer.go
@@ -183,7 +183,7 @@ func (pr *PreRenderer) Submit(jobDTO interface {
 	// - If created by on-demand generation: processJob() will skip it (redundant work avoided)
 	// - If created by another pre-render worker: processJob() will skip it (idempotent)
 	// - Impact: Job logged as "skipped" instead of caught here (no functional issue)
-	spectrogramPath, err := BuildSpectrogramPath(job.ClipPath)
+	spectrogramPath, err := BuildSpectrogramPath(job.ClipPath, pr.settings.Realtime.Dashboard.Spectrogram.Style)
 	if err != nil {
 		pr.logger.Error("Invalid clip path, rejecting job",
 			logger.Any("note_id", job.NoteID),
@@ -384,7 +384,7 @@ func (pr *PreRenderer) processJob(job *Job, workerID int) {
 		logger.Int("pcm_bytes", len(job.PCMData)))
 
 	// Build spectrogram path from clip path
-	spectrogramPath, err := BuildSpectrogramPath(job.ClipPath)
+	spectrogramPath, err := BuildSpectrogramPath(job.ClipPath, pr.settings.Realtime.Dashboard.Spectrogram.Style)
 	if err != nil {
 		pr.logger.Error("Failed to build spectrogram path",
 			logger.Int("worker_id", workerID),

--- a/internal/spectrogram/utils.go
+++ b/internal/spectrogram/utils.go
@@ -98,13 +98,14 @@ func GetValidSizes() []string {
 }
 
 // BuildSpectrogramPath constructs the spectrogram file path from the audio clip path.
-// It replaces the audio file extension with .png.
+// It replaces the audio file extension with .png, including a style suffix when the
+// style differs from "default" to ensure different styles are cached separately (fixes #1937).
 //
-// Example:
+// Examples:
 //
-//	"clips/2024-01-15/Bird_species/Bird_species.2024-01-15T10:00:00.wav"
-//	-> "clips/2024-01-15/Bird_species/Bird_species.2024-01-15T10:00:00.png"
-func BuildSpectrogramPath(clipPath string) (string, error) {
+//	"file.wav" with style="" or style="default" -> "file.png"
+//	"file.wav" with style="scientific_dark"     -> "file-scientific_dark.png"
+func BuildSpectrogramPath(clipPath, style string) (string, error) {
 	ext := filepath.Ext(clipPath)
 	if ext == "" {
 		return "", errors.Newf("clip path has no extension").
@@ -115,7 +116,15 @@ func BuildSpectrogramPath(clipPath string) (string, error) {
 			Build()
 	}
 
-	spectrogramPath := strings.TrimSuffix(clipPath, ext) + ".png"
+	baseName := strings.TrimSuffix(clipPath, ext)
+
+	// Include style in filename for non-default styles
+	styleSuffix := ""
+	if style != "" && style != "default" {
+		styleSuffix = "-" + style
+	}
+
+	spectrogramPath := baseName + styleSuffix + ".png"
 	return spectrogramPath, nil
 }
 

--- a/internal/spectrogram/utils_test.go
+++ b/internal/spectrogram/utils_test.go
@@ -160,50 +160,76 @@ func TestBuildSpectrogramPath(t *testing.T) {
 	tests := []struct {
 		name     string
 		clipPath string
+		style    string
 		want     string
 		wantErr  bool
 	}{
 		{
-			name:     "wav file",
+			name:     "wav file with default style",
 			clipPath: "clips/2024-01-15/Bird_species/Bird_species.2024-01-15T10:00:00.wav",
+			style:    "default",
 			want:     "clips/2024-01-15/Bird_species/Bird_species.2024-01-15T10:00:00.png",
-			wantErr:  false,
+		},
+		{
+			name:     "wav file with empty style",
+			clipPath: "clips/2024-01-15/Bird_species/Bird_species.2024-01-15T10:00:00.wav",
+			style:    "",
+			want:     "clips/2024-01-15/Bird_species/Bird_species.2024-01-15T10:00:00.png",
+		},
+		{
+			name:     "wav file with scientific_dark style",
+			clipPath: "clips/2024-01-15/Bird_species/Bird_species.2024-01-15T10:00:00.wav",
+			style:    "scientific_dark",
+			want:     "clips/2024-01-15/Bird_species/Bird_species.2024-01-15T10:00:00-scientific_dark.png",
+		},
+		{
+			name:     "wav file with high_contrast_dark style",
+			clipPath: "clips/test.wav",
+			style:    "high_contrast_dark",
+			want:     "clips/test-high_contrast_dark.png",
+		},
+		{
+			name:     "wav file with scientific style",
+			clipPath: "clips/test.wav",
+			style:    "scientific",
+			want:     "clips/test-scientific.png",
 		},
 		{
 			name:     "flac file",
 			clipPath: "clips/test.flac",
+			style:    "default",
 			want:     "clips/test.png",
-			wantErr:  false,
 		},
 		{
 			name:     "mp3 file",
 			clipPath: "/absolute/path/to/audio.mp3",
+			style:    "",
 			want:     "/absolute/path/to/audio.png",
-			wantErr:  false,
 		},
 		{
 			name:     "no extension",
 			clipPath: "clips/noextension",
+			style:    "default",
 			want:     "",
 			wantErr:  true,
 		},
 		{
 			name:     "multiple dots",
 			clipPath: "clips/file.with.dots.wav",
+			style:    "default",
 			want:     "clips/file.with.dots.png",
-			wantErr:  false,
 		},
 		{
 			name:     "hidden file",
 			clipPath: "clips/.hidden.wav",
+			style:    "default",
 			want:     "clips/.hidden.png",
-			wantErr:  false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := BuildSpectrogramPath(tt.clipPath)
+			got, err := BuildSpectrogramPath(tt.clipPath, tt.style)
 			if tt.wantErr {
 				require.Error(t, err)
 			} else {


### PR DESCRIPTION
## Summary
- Spectrogram style occasionally reverted to classic standard instead of the user-selected style (e.g., "scientific dark")
- Root cause: spectrogram filenames did not encode the style setting, so cached spectrograms generated with a previous style were served when the style changed. New detections rendered correctly but older cached ones showed the old style, making the issue appear intermittent.
- Fixed by including the style as a suffix in spectrogram filenames when it differs from "default" (e.g., `file_1026px-scientific_dark.png`), ensuring each style produces distinct cached files

Fixes #1937

## Test plan
- [ ] Set spectrogram style to "scientific dark" and verify all spectrograms render consistently
- [ ] Generate multiple spectrograms rapidly and verify no style reversion
- [ ] Change style back to "default" and verify old default-style spectrograms are still served
- [ ] Verify other spectrogram styles (high_contrast_dark, scientific) produce correct filenames
- [ ] Run `go test -race ./internal/spectrogram/... ./internal/api/v2/...` to confirm no regressions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed spectrogram rendering when using different style settings, ensuring proper cache separation and preventing display conflicts across style variants.

* **Tests**
  * Added comprehensive testing for spectrogram rendering with multiple style configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->