### PR TITLE
fix: add explicit permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -24,6 +24,10 @@ on:
       # Only run on push to main branch
       - main
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   # Lint is handled by golangci-test.yml workflow - no need to duplicate here
   build-and-push-docker-image:

--- a/.github/workflows/golangci-test.yml
+++ b/.github/workflows/golangci-test.yml
@@ -15,6 +15,9 @@ on:
       - 'go.sum'
       - '.golangci.yml'
 
+permissions:
+  contents: read
+
 jobs:
   golangci:
     uses: ./.github/workflows/golangci-lint.yml


### PR DESCRIPTION
## Summary
- Added explicit `permissions:` blocks to `golangci-test.yml` and `docker-build.yml`
- `golangci-test.yml`: `contents: read` (only needs code checkout)
- `docker-build.yml`: `contents: read` + `packages: write` (needs to push container images)
- `auto-approve.yml` does not exist as a standalone file; that functionality lives in `update-licenses.yml` which already has proper permissions

Resolves 5 open code scanning alerts.

Fixes #2315

## Test plan
- [ ] golangci-lint CI passes
- [ ] Docker build CI passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflows with enhanced permission configurations for improved security and operational control during build and testing processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->