### PR TITLE
fix: use settings store instead of redundant API call in BannerCard

### DIFF
--- a/frontend/src/lib/desktop/features/dashboard/components/BannerCard.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/components/BannerCard.svelte
@@ -56,11 +56,9 @@
 
   // Map user's temperature preference to TemperatureUnit format
   // Settings store uses 'celsius'/'fahrenheit', but formatters use 'metric'/'imperial'
-  let temperatureUnit = $derived.by((): TemperatureUnit => {
-    const setting = $dashboardSettings?.temperatureUnit;
-    if (setting === 'fahrenheit') return 'imperial';
-    return 'metric';
-  });
+  let temperatureUnit: TemperatureUnit = $derived(
+    $dashboardSettings?.temperatureUnit === 'fahrenheit' ? 'imperial' : 'metric'
+  );
 
   async function fetchWeather(signal?: AbortSignal) {
     if (!config.showWeather || editMode) return;


### PR DESCRIPTION
## Summary
- Replaced redundant `fetch('/api/v2/settings/dashboard')` call in `BannerCard.svelte` with the existing `dashboardSettings` store
- Temperature unit now reactively derives from the global settings store via `$derived.by()`
- Simplifies `fetchWeather()` from a `Promise.all` with two fetches to a single weather API call

Fixes #2317

## Test plan
- [ ] Dashboard banner displays correct temperature unit (metric/imperial)
- [ ] Changing temperature unit in settings immediately updates the banner
- [ ] Weather data still loads and displays correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed temperature unit display to properly respect user preferences (Fahrenheit/Celsius).

* **Refactor**
  * Simplified weather data fetch flow by consolidating concurrent requests into a single API call and improving error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->