### PR TITLE
Separate the Finnish names for Carrion and Hooded Crows

### DIFF
--- a/internal/birdnet/data/labels/V2.4/BirdNET_GLOBAL_6K_V2.4_Labels_fi.txt
+++ b/internal/birdnet/data/labels/V2.4/BirdNET_GLOBAL_6K_V2.4_Labels_fi.txt
@@ -1577,7 +1577,7 @@ Corvus brachyrhynchos_amerikanvaris
 Corvus capensis_afrikanmustavaris
 Corvus corax_korppi
 Corvus cornix_varis
-Corvus corone_varis
+Corvus corone_nokivaris
 Corvus coronoides_australiankorppi
 Corvus cryptoleucus_aavikkokorppi
 Corvus dauuricus_idännaakka


### PR DESCRIPTION
The Finnish name for Hooded Crow (Corvus cornix) and Carrion Crow (Corvus corone) were both set to 'varis'. This made it impossible to separate them for example to configure species exclusions. Renamed Carrion Crow to 'nokivaris' which is the Finnish name for it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Finnish language label for bird species identification to ensure accurate localization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->