### PR TITLE
fix: move FFprobe validation inside singleflight to eliminate redundant subprocess spawns

### DIFF
--- a/internal/api/v2/media.go
+++ b/internal/api/v2/media.go
@@ -2473,7 +2473,11 @@ func (c *Controller) generateSpectrogram(ctx context.Context, audioPath string, 
 	getSpectrogramLogger().Debug("Starting singleflight generation",
 		logger.String("spectrogram_key", spectrogramKey))
 
-	_, err, shared := spectrogramGroup.Do(spectrogramKey, func() (any, error) {
+	// Use DoChan so callers can bail out early if their request context is
+	// cancelled (e.g. client disconnect) without blocking the handler goroutine.
+	// The shared work continues in the background using the controller-scoped
+	// context (c.ctx) and the next request will hit the fast path.
+	resultCh := spectrogramGroup.DoChan(spectrogramKey, func() (any, error) {
 		// Use a controller-scoped context with timeout instead of the request-scoped ctx.
 		// Since singleflight shares the result across all concurrent callers, using a
 		// request-scoped context would cause all waiters to fail if the winning request's
@@ -2518,6 +2522,22 @@ func (c *Controller) generateSpectrogram(ctx context.Context, audioPath string, 
 		}()
 		return c.performSpectrogramGeneration(sharedCtx, relSpectrogramPath, absAudioPath, absSpectrogramPath, spectrogramKey, width, raw)
 	})
+
+	// Wait for either the singleflight result or caller's context cancellation.
+	// If the caller's context is done (client disconnect), return immediately;
+	// the shared generation work continues in the background.
+	var shared bool
+	select {
+	case result := <-resultCh:
+		shared = result.Shared
+		err = result.Err
+	case <-ctx.Done():
+		getSpectrogramLogger().Debug("Caller context cancelled while waiting for spectrogram generation",
+			logger.String("spectrogram_key", spectrogramKey),
+			logger.Error(ctx.Err()),
+			logger.Int64("total_duration_ms", time.Since(start).Milliseconds()))
+		return "", ctx.Err()
+	}
 
 	if shared {
 		getSpectrogramLogger().Info("Spectrogram request coalesced via singleflight (duplicate avoided)",


### PR DESCRIPTION
## Summary

- Move audio file existence check (`checkAudioFileExists`) and FFprobe validation (`validateSpectrogramInputs`) inside the `singleflight.Do` group in `generateSpectrogram`, so concurrent requests for the same spectrogram share a single FFprobe subprocess (~300ms) instead of each spawning their own
- Log the `shared` return value from `singleflight.Do` to make request coalescing visible in logs
- Add INFO-level log when requests are coalesced via singleflight

## Problem

When multiple concurrent requests arrive for the same spectrogram (e.g. page load triggering list + detail views, or pre-renderer restart racing with on-demand requests), each request independently spawned an FFprobe validation subprocess before the singleflight deduplication could coalesce them. With 3 concurrent requests for the same file, 3 FFprobe processes were spawned unnecessarily (~1 second of wasted subprocess time).

**Before (from issue logs):**
```
19:15:43.391 Starting audio validation with FFprobe  key=96p_...  ← request 1
19:15:43.392 Starting audio validation with FFprobe  key=96p_...  ← request 2 (redundant)
19:15:43.393 Starting audio validation with FFprobe  key=96p_...  ← request 3 (redundant)
```

**After:** Only 1 FFprobe call runs; requests 2 and 3 wait on singleflight and share the result.

## Test plan

- [ ] Verify spectrograms still generate correctly on first load
- [ ] Verify cached/existing spectrograms still serve via fast path
- [ ] Check logs for "coalesced via singleflight" messages under concurrent load
- [ ] Verify FFprobe validation errors (audio not ready) still propagate correctly to all waiters

Fixes #2342

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented redundant spectrogram work for simultaneous requests by coalescing duplicate generation, improving efficiency and reducing wasted processing.
  * Reduced race conditions and timeouts during generation by moving validation and generation into the coalesced execution path.
  * Enhanced logging/status to indicate when requests were combined and whether generation was shared.
  * Caller cancellations now return immediately while allowing background generation to complete.
  * No changes to public APIs or integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->