### PR TITLE
fix: replace hardcoded English strings with i18n calls in integration test UI

### DIFF
--- a/frontend/src/lib/desktop/features/settings/pages/IntegrationSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/IntegrationSettingsPage.svelte
@@ -625,7 +625,7 @@
                 logger.debug('Handling initial error response:', stageResult);
                 testStates.birdweather.stages.push({
                   id: 'initial-error',
-                  title: 'Configuration Check',
+                  title: t('settings.integration.errors.configurationCheck'),
                   status: 'error',
                   message: stageResult.message,
                   error: stageResult.message,
@@ -651,7 +651,7 @@
 
             const stage = {
               id: stageId,
-              title: stageResult.stage || 'Test Stage',
+              title: stageResult.stage || t('settings.integration.errors.testStageFallback'),
               status,
               message: stageResult.message || '',
               error: stageResult.error || '',
@@ -860,7 +860,7 @@
 
             const stage = {
               id: stageId,
-              title: stageResult.stage || 'Test Stage',
+              title: stageResult.stage || t('settings.integration.errors.testStageFallback'),
               status,
               message: stageResult.message || '',
               error: stageResult.error || '',
@@ -1009,7 +1009,7 @@
 
             const stage: Stage = {
               id: stageResult.id,
-              title: stageResult.title || 'Test Stage',
+              title: stageResult.title || t('settings.integration.errors.testStageFallback'),
               status: stageResult.status || 'pending',
               message: stageResult.message || '',
               error: stageResult.error || '',
@@ -1045,7 +1045,7 @@
           if (stageResult.id) {
             const stage: Stage = {
               id: stageResult.id,
-              title: stageResult.title || 'Test Stage',
+              title: stageResult.title || t('settings.integration.errors.testStageFallback'),
               status: stageResult.status || 'pending',
               message: stageResult.message || '',
               error: stageResult.error || '',

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -2598,7 +2598,9 @@
       },
       "errors": {
         "connectionError": "Verbindungsfehler",
-        "responseStreamFailed": "Antwort-Stream konnte nicht gelesen werden"
+        "responseStreamFailed": "Antwort-Stream konnte nicht gelesen werden",
+        "configurationCheck": "Configuration Check",
+        "testStageFallback": "Test Stage"
       },
       "ebird": {
         "title": "eBird",

--- a/frontend/static/messages/en.json
+++ b/frontend/static/messages/en.json
@@ -2634,7 +2634,9 @@
       },
       "errors": {
         "connectionError": "Connection Error",
-        "responseStreamFailed": "Failed to read response stream"
+        "responseStreamFailed": "Failed to read response stream",
+        "configurationCheck": "Configuration Check",
+        "testStageFallback": "Test Stage"
       },
       "ebird": {
         "title": "eBird",

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -2940,7 +2940,9 @@
       },
       "errors": {
         "connectionError": "Error de conexión",
-        "responseStreamFailed": "Error al leer el flujo de respuesta"
+        "responseStreamFailed": "Error al leer el flujo de respuesta",
+        "configurationCheck": "Configuration Check",
+        "testStageFallback": "Test Stage"
       },
       "ebird": {
         "title": "eBird",

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -2940,7 +2940,9 @@
       },
       "errors": {
         "connectionError": "Yhteysvirhe",
-        "responseStreamFailed": "Vastausvirran lukeminen epäonnistui"
+        "responseStreamFailed": "Vastausvirran lukeminen epäonnistui",
+        "configurationCheck": "Configuration Check",
+        "testStageFallback": "Test Stage"
       },
       "ebird": {
         "title": "eBird",

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -2598,7 +2598,9 @@
       },
       "errors": {
         "connectionError": "Erreur de connexion",
-        "responseStreamFailed": "Échec de la lecture du flux de réponse"
+        "responseStreamFailed": "Échec de la lecture du flux de réponse",
+        "configurationCheck": "Configuration Check",
+        "testStageFallback": "Test Stage"
       },
       "ebird": {
         "title": "eBird",

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -2401,7 +2401,9 @@
       },
       "errors": {
         "connectionError": "Errore di connessione",
-        "responseStreamFailed": "Lettura del flusso di risposta non riuscita"
+        "responseStreamFailed": "Lettura del flusso di risposta non riuscita",
+        "configurationCheck": "Configuration Check",
+        "testStageFallback": "Test Stage"
       },
       "ebird": {
         "title": "eBird",

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -2598,7 +2598,9 @@
       },
       "errors": {
         "connectionError": "Verbindingsfout",
-        "responseStreamFailed": "Antwoordstroom kon niet worden gelezen"
+        "responseStreamFailed": "Antwoordstroom kon niet worden gelezen",
+        "configurationCheck": "Configuration Check",
+        "testStageFallback": "Test Stage"
       },
       "ebird": {
         "title": "eBird",

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -2604,7 +2604,9 @@
       },
       "errors": {
         "connectionError": "Błąd połączenia",
-        "responseStreamFailed": "Nie udało się odczytać strumienia odpowiedzi"
+        "responseStreamFailed": "Nie udało się odczytać strumienia odpowiedzi",
+        "configurationCheck": "Configuration Check",
+        "testStageFallback": "Test Stage"
       },
       "ebird": {
         "title": "eBird",

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -2940,7 +2940,9 @@
       },
       "errors": {
         "connectionError": "Erro de conexão",
-        "responseStreamFailed": "Falha ao ler o fluxo de resposta"
+        "responseStreamFailed": "Falha ao ler o fluxo de resposta",
+        "configurationCheck": "Configuration Check",
+        "testStageFallback": "Test Stage"
       },
       "ebird": {
         "title": "eBird",

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -2435,7 +2435,9 @@
       },
       "errors": {
         "connectionError": "Chyba pripojenia",
-        "responseStreamFailed": "Nepodarilo sa prečítať prúd odpovede"
+        "responseStreamFailed": "Nepodarilo sa prečítať prúd odpovede",
+        "configurationCheck": "Configuration Check",
+        "testStageFallback": "Test Stage"
       },
       "ebird": {
         "title": "eBird",


### PR DESCRIPTION
## Summary

- Replaced 5 hardcoded English strings in `IntegrationSettingsPage.svelte` with `t()` i18n calls so they get translated for non-English users
- Added 2 new i18n keys (`configurationCheck`, `testStageFallback`) under `settings.integration.errors` in all 10 locale files (en, de, es, fi, fr, it, nl, pl, pt, sk)
- Non-English locale files use English as placeholder values, ready for translation

### Strings replaced

| Line | Old value | New i18n key |
|------|-----------|-------------|
| 628 | `'Configuration Check'` | `settings.integration.errors.configurationCheck` |
| 654 | `'Test Stage'` | `settings.integration.errors.testStageFallback` |
| 863 | `'Test Stage'` | `settings.integration.errors.testStageFallback` |
| 1012 | `'Test Stage'` | `settings.integration.errors.testStageFallback` |
| 1048 | `'Test Stage'` | `settings.integration.errors.testStageFallback` |

Fixes #2295

## Test plan

- [ ] Verify BirdWeather connection test displays stage titles correctly in English
- [ ] Verify MQTT connection test displays stage titles correctly in English
- [ ] Verify eBird connection test displays stage titles correctly in English
- [ ] Switch to a non-English locale and verify the fallback strings use translated values

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Added internationalization support for error messages and default stage titles in integration settings.
  * Configuration check and test stage labels now display in the user's selected language across all supported language options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->