### PR TITLE
fix: store active OAuth provider in session for direct lookup

### DIFF
--- a/internal/api/auth/adapter.go
+++ b/internal/api/auth/adapter.go
@@ -258,9 +258,10 @@ func (a *SecurityAdapter) generateAuthCodeOnSuccess(username string) (string, er
 // Logout invalidates the current session/token
 func (a *SecurityAdapter) Logout(c echo.Context) error {
 	// Clear generic session values
-	gothic.StoreInSession("userId", "", c.Request(), c.Response())       //nolint:errcheck // Error checking not critical during logout
-	gothic.StoreInSession("access_token", "", c.Request(), c.Response()) //nolint:errcheck // Error checking not critical during logout
-	gothic.StoreInSession("id_token", "", c.Request(), c.Response())     //nolint:errcheck // Error checking not critical during logout
+	gothic.StoreInSession("userId", "", c.Request(), c.Response())                        //nolint:errcheck // Error checking not critical during logout
+	gothic.StoreInSession("access_token", "", c.Request(), c.Response())                  //nolint:errcheck // Error checking not critical during logout
+	gothic.StoreInSession("id_token", "", c.Request(), c.Response())                      //nolint:errcheck // Error checking not critical during logout
+	gothic.StoreInSession(security.SessionKeyAuthProvider, "", c.Request(), c.Response()) //nolint:errcheck // Error checking not critical during logout
 
 	// Clear all provider-specific session keys dynamically
 	for _, gothName := range security.ConfigToGothProvider {
@@ -276,7 +277,32 @@ func (a *SecurityAdapter) Logout(c echo.Context) error {
 func (a *SecurityAdapter) GetProviderLogoutURL(c echo.Context, postLogoutRedirectURI string) string {
 	log := a.log()
 
-	// Check each configured OAuth provider for an active session
+	// Try direct lookup via stored auth_provider session key first
+	if logoutURL := a.getProviderLogoutURLDirect(c, postLogoutRedirectURI, log); logoutURL != "" {
+		return logoutURL
+	}
+
+	// Fall back to iterating all providers for backward compatibility
+	// (existing sessions may not have the auth_provider key)
+	return a.getProviderLogoutURLFallback(c, postLogoutRedirectURI, log)
+}
+
+// getProviderLogoutURLDirect attempts to build the logout URL using the stored auth_provider session key.
+// Returns empty string if the key is missing or the provider doesn't support logout.
+func (a *SecurityAdapter) getProviderLogoutURLDirect(c echo.Context, postLogoutRedirectURI string, log logger.Logger) string {
+	activeProvider, err := gothic.GetFromSession(security.SessionKeyAuthProvider, c.Request())
+	if err != nil || activeProvider == "" {
+		log.Debug("No auth_provider key in session, will try fallback iteration")
+		return ""
+	}
+
+	log.Debug("Found active auth provider in session", logger.String("provider", activeProvider))
+	return a.buildProviderLogoutURL(c, activeProvider, postLogoutRedirectURI, log)
+}
+
+// getProviderLogoutURLFallback iterates all configured providers to find the active session.
+// This handles sessions created before the auth_provider key was introduced.
+func (a *SecurityAdapter) getProviderLogoutURLFallback(c echo.Context, postLogoutRedirectURI string, log logger.Logger) string {
 	for configProvider, gothProviderName := range security.ConfigToGothProvider {
 		provider := a.OAuth2Server.Settings.GetOAuthProvider(configProvider)
 		if provider == nil || !provider.Enabled {
@@ -289,40 +315,46 @@ func (a *SecurityAdapter) GetProviderLogoutURL(c echo.Context, postLogoutRedirec
 			continue
 		}
 
-		// Found active provider session — check if it supports logout
-		gothProvider, err := goth.GetProvider(gothProviderName)
-		if err != nil {
-			log.Debug("Could not get goth provider", logger.String("provider", gothProviderName), logger.Error(err))
-			continue
+		if logoutURL := a.buildProviderLogoutURL(c, gothProviderName, postLogoutRedirectURI, log); logoutURL != "" {
+			return logoutURL
 		}
+	}
+	return ""
+}
 
-		logoutProvider, ok := gothProvider.(goth.LogoutProvider)
-		if !ok {
-			log.Debug("Provider does not support RP-Initiated Logout", logger.String("provider", gothProviderName))
-			continue
-		}
-
-		// Get ID token from session for the hint
-		idToken, _ := gothic.GetFromSession("id_token", c.Request())
-
-		logoutURL, err := logoutProvider.EndSessionURL(idToken, postLogoutRedirectURI, "")
-		if err != nil {
-			log.Warn("Failed to build end-session URL", logger.String("provider", gothProviderName), logger.Error(err))
-			continue
-		}
-
-		// Validate the URL is HTTPS with a valid host
-		parsed, parseErr := url.Parse(logoutURL)
-		if parseErr != nil || parsed.Scheme != "https" || parsed.Host == "" {
-			log.Warn("Rejected invalid provider logout URL", logger.String("provider", gothProviderName))
-			continue
-		}
-
-		log.Info("Built RP-Initiated Logout URL", logger.String("provider", gothProviderName))
-		return parsed.String()
+// buildProviderLogoutURL builds the end-session URL for a specific goth provider.
+// Returns empty string if the provider doesn't support RP-Initiated Logout or URL validation fails.
+func (a *SecurityAdapter) buildProviderLogoutURL(c echo.Context, gothProviderName, postLogoutRedirectURI string, log logger.Logger) string {
+	gothProvider, err := goth.GetProvider(gothProviderName)
+	if err != nil {
+		log.Debug("Could not get goth provider", logger.String("provider", gothProviderName), logger.Error(err))
+		return ""
 	}
 
-	return ""
+	logoutProvider, ok := gothProvider.(goth.LogoutProvider)
+	if !ok {
+		log.Debug("Provider does not support RP-Initiated Logout", logger.String("provider", gothProviderName))
+		return ""
+	}
+
+	// Get ID token from session for the hint
+	idToken, _ := gothic.GetFromSession("id_token", c.Request())
+
+	logoutURL, err := logoutProvider.EndSessionURL(idToken, postLogoutRedirectURI, "")
+	if err != nil {
+		log.Warn("Failed to build end-session URL", logger.String("provider", gothProviderName), logger.Error(err))
+		return ""
+	}
+
+	// Validate the URL is HTTPS with a valid host
+	parsed, parseErr := url.Parse(logoutURL)
+	if parseErr != nil || parsed.Scheme != "https" || parsed.Host == "" {
+		log.Warn("Rejected invalid provider logout URL", logger.String("provider", gothProviderName))
+		return ""
+	}
+
+	log.Info("Built RP-Initiated Logout URL", logger.String("provider", gothProviderName))
+	return parsed.String()
 }
 
 // ExchangeAuthCode exchanges an authorization code for an access token.

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -776,6 +776,14 @@ func (s *Server) handleOAuthCallback(c echo.Context) error {
 		)
 	}
 
+	// Store active provider name for direct lookup (avoids iterating all providers)
+	if err := gothic.StoreInSession(security.SessionKeyAuthProvider, provider, req, c.Response()); err != nil {
+		s.slogger.Error("Failed to store active auth provider in session",
+			logger.Error(err),
+			logger.String("provider", provider),
+		)
+	}
+
 	// Store or clear ID token for RP-Initiated Logout (OIDC providers)
 	if user.IDToken != "" {
 		if err := gothic.StoreInSession("id_token", user.IDToken, req, c.Response()); err != nil {

--- a/internal/security/constants.go
+++ b/internal/security/constants.go
@@ -22,6 +22,10 @@ const (
 	ProviderKakao     = "kakao"           // Same as config
 	ProviderOIDC      = "openid-connect"  // Different from config!
 
+	// SessionKeyAuthProvider is the session key used to store the active OAuth provider name.
+	// This avoids iterating all providers when looking up the active session.
+	SessionKeyAuthProvider = "auth_provider"
+
 	// Session and cookie settings
 	DefaultSessionMaxAgeDays    = 7
 	DefaultSessionMaxAgeSeconds = 86400 * DefaultSessionMaxAgeDays // 7 days in seconds
@@ -71,6 +75,17 @@ var ConfigToGothProvider = map[string]string{
 	ConfigOIDC:      ProviderOIDC,
 }
 
+// GothToConfigProvider maps goth provider names back to config provider IDs.
+// This is the reverse of ConfigToGothProvider and is used when looking up
+// provider config from a stored goth provider name.
+var GothToConfigProvider = func() map[string]string {
+	m := make(map[string]string, len(ConfigToGothProvider))
+	for config, goth := range ConfigToGothProvider {
+		m[goth] = config
+	}
+	return m
+}()
+
 // GetGothProviderName converts a config provider ID to the goth provider name.
 // Falls back to the config ID if no mapping exists.
 func GetGothProviderName(configProvider string) string {
@@ -78,4 +93,13 @@ func GetGothProviderName(configProvider string) string {
 		return gothName
 	}
 	return configProvider
+}
+
+// gothToConfigProvider converts a goth provider name to a config provider ID.
+// Falls back to the goth name if no mapping exists (most providers use the same name).
+func gothToConfigProvider(gothProvider string) string {
+	if configName, ok := GothToConfigProvider[gothProvider]; ok {
+		return configName
+	}
+	return gothProvider
 }

--- a/internal/security/constants_test.go
+++ b/internal/security/constants_test.go
@@ -25,3 +25,56 @@ func TestGetGothProviderName_UnknownFallback(t *testing.T) {
 
 	assert.Equal(t, "unknown", GetGothProviderName("unknown"))
 }
+
+// TestGothToConfigProvider_ReverseMapping verifies the reverse map contains all entries.
+func TestGothToConfigProvider_ReverseMapping(t *testing.T) {
+	t.Parallel()
+
+	// Verify every entry in ConfigToGothProvider has a reverse mapping
+	for config, goth := range ConfigToGothProvider {
+		reverseConfig, ok := GothToConfigProvider[goth]
+		assert.True(t, ok, "GothToConfigProvider should contain mapping for goth name %q", goth)
+		assert.Equal(t, config, reverseConfig, "reverse mapping for %q should be %q", goth, config)
+	}
+
+	// Verify the maps have the same size
+	assert.Len(t, GothToConfigProvider, len(ConfigToGothProvider),
+		"GothToConfigProvider should have same number of entries as ConfigToGothProvider")
+}
+
+// TestGothToConfigProvider_SpecificMappings verifies the key reverse mappings.
+func TestGothToConfigProvider_SpecificMappings(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		gothProvider   string
+		configProvider string
+	}{
+		{name: "Microsoft reverse", gothProvider: ProviderMicrosoft, configProvider: ConfigMicrosoft},
+		{name: "OIDC reverse", gothProvider: ProviderOIDC, configProvider: ConfigOIDC},
+		{name: "Google reverse", gothProvider: ProviderGoogle, configProvider: ConfigGoogle},
+		{name: "GitHub reverse", gothProvider: ProviderGitHub, configProvider: ConfigGitHub},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.configProvider, gothToConfigProvider(tt.gothProvider))
+		})
+	}
+}
+
+// TestGothToConfigProvider_UnknownFallback verifies the fallback for unknown providers.
+func TestGothToConfigProvider_UnknownFallback(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "unknown-provider", gothToConfigProvider("unknown-provider"))
+}
+
+// TestSessionKeyAuthProviderConstant verifies the constant value.
+func TestSessionKeyAuthProviderConstant(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "auth_provider", SessionKeyAuthProvider)
+}

--- a/internal/security/oauth.go
+++ b/internal/security/oauth.go
@@ -608,7 +608,8 @@ func (s *OAuth2Server) checkBasicAuthToken(r *http.Request, log SecurityLogger) 
 }
 
 // checkSocialAuthSessions checks for valid OAuth authentication sessions.
-// It iterates over all configured OAuth providers to find a valid session.
+// It first tries a direct lookup using the stored auth_provider session key,
+// then falls back to iterating all configured providers for backward compatibility.
 func (s *OAuth2Server) checkSocialAuthSessions(r *http.Request, log SecurityLogger) bool {
 	userId, err := gothic.GetFromSession("userId", r)
 	if err != nil {
@@ -617,7 +618,45 @@ func (s *OAuth2Server) checkSocialAuthSessions(r *http.Request, log SecurityLogg
 		log.Debug("Found userId in session, checking provider sessions")
 	}
 
-	// Iterate over all configured providers to check for a valid session
+	// Try direct lookup via stored auth_provider session key first
+	if s.checkSocialAuthDirect(r, userId, log) {
+		return true
+	}
+
+	// Fall back to iterating all providers for backward compatibility
+	// (existing sessions may not have the auth_provider key)
+	return s.checkSocialAuthFallback(r, userId, log)
+}
+
+// checkSocialAuthDirect checks for a valid session using the stored auth_provider key.
+// Returns false if the key is missing or the provider session is invalid.
+func (s *OAuth2Server) checkSocialAuthDirect(r *http.Request, userId string, log SecurityLogger) bool {
+	activeProvider, err := gothic.GetFromSession(SessionKeyAuthProvider, r)
+	if err != nil || activeProvider == "" {
+		log.Debug("No auth_provider key in session, will try fallback iteration")
+		return false
+	}
+
+	log.Debug("Found active auth provider in session", logger.String("provider", activeProvider))
+
+	// Look up the config provider for this goth provider name
+	configProvider := gothToConfigProvider(activeProvider)
+	provider := s.Settings.GetOAuthProvider(configProvider)
+	if provider == nil || !provider.Enabled {
+		log.Debug("Active auth provider not enabled or not found in config", logger.String("provider", activeProvider))
+		return false
+	}
+
+	return s.checkProviderAuth(r, userId, log, providerAuthConfig{
+		providerName:   activeProvider,
+		enabled:        provider.Enabled,
+		allowedUserIds: provider.UserID,
+	})
+}
+
+// checkSocialAuthFallback iterates over all configured providers to find a valid session.
+// This handles sessions created before the auth_provider key was introduced.
+func (s *OAuth2Server) checkSocialAuthFallback(r *http.Request, userId string, log SecurityLogger) bool {
 	for configProvider, gothProvider := range ConfigToGothProvider {
 		provider := s.Settings.GetOAuthProvider(configProvider)
 		if provider == nil || !provider.Enabled {

--- a/internal/security/oauth_test.go
+++ b/internal/security/oauth_test.go
@@ -994,6 +994,217 @@ func TestCheckSocialAuthSessions(t *testing.T) {
 	}
 }
 
+// storeMultipleInSession stores multiple key-value pairs in the same Gothic session.
+// Each StoreInSession call requires the request cookie to be updated before the next call
+// so all values end up in the same session. Returns the final request with all cookies set.
+func storeMultipleInSession(t *testing.T, req *http.Request, pairs ...string) *http.Request {
+	t.Helper()
+	if len(pairs)%2 != 0 {
+		t.Fatal("storeMultipleInSession requires an even number of arguments (key-value pairs)")
+	}
+	for i := 0; i < len(pairs); i += 2 {
+		rec := httptest.NewRecorder()
+		_ = gothic.StoreInSession(pairs[i], pairs[i+1], req, rec)
+		req.Header.Set("Cookie", rec.Header().Get("Set-Cookie"))
+	}
+	return req
+}
+
+// TestCheckSocialAuthDirect tests the direct auth_provider session key lookup path.
+func TestCheckSocialAuthDirect(t *testing.T) {
+	tests := []struct {
+		name           string
+		providers      []conf.OAuthProviderConfig
+		setupSession   func(*testing.T, *http.Request) *http.Request
+		expectedResult bool
+	}{
+		{
+			name: "no auth_provider key in session returns false",
+			providers: []conf.OAuthProviderConfig{
+				{Provider: ConfigGoogle, Enabled: true, UserID: "user@example.com"},
+			},
+			setupSession:   func(_ *testing.T, req *http.Request) *http.Request { return req },
+			expectedResult: false,
+		},
+		{
+			name: "auth_provider points to valid enabled provider with matching session",
+			providers: []conf.OAuthProviderConfig{
+				{Provider: ConfigGoogle, Enabled: true, UserID: "user@example.com"},
+			},
+			setupSession: func(t *testing.T, req *http.Request) *http.Request {
+				t.Helper()
+				return storeMultipleInSession(t, req,
+					SessionKeyAuthProvider, ProviderGoogle,
+					"userId", "user@example.com",
+					ProviderGoogle, "12345",
+				)
+			},
+			expectedResult: true,
+		},
+		{
+			name: "auth_provider points to disabled provider returns false",
+			providers: []conf.OAuthProviderConfig{
+				{Provider: ConfigGoogle, Enabled: false, UserID: "user@example.com"},
+			},
+			setupSession: func(t *testing.T, req *http.Request) *http.Request {
+				t.Helper()
+				return storeMultipleInSession(t, req,
+					SessionKeyAuthProvider, ProviderGoogle,
+					"userId", "user@example.com",
+					ProviderGoogle, "12345",
+				)
+			},
+			expectedResult: false,
+		},
+		{
+			name: "auth_provider points to unconfigured provider returns false",
+			providers: []conf.OAuthProviderConfig{
+				{Provider: ConfigGitHub, Enabled: true, UserID: "user@example.com"},
+			},
+			setupSession: func(t *testing.T, req *http.Request) *http.Request {
+				t.Helper()
+				// Session says google, but only github is configured
+				return storeMultipleInSession(t, req,
+					SessionKeyAuthProvider, ProviderGoogle,
+					"userId", "user@example.com",
+					ProviderGoogle, "12345",
+				)
+			},
+			expectedResult: false,
+		},
+		{
+			name: "auth_provider key with microsoft provider (different config name)",
+			providers: []conf.OAuthProviderConfig{
+				{Provider: ConfigMicrosoft, Enabled: true, UserID: "user@example.com"},
+			},
+			setupSession: func(t *testing.T, req *http.Request) *http.Request {
+				t.Helper()
+				return storeMultipleInSession(t, req,
+					SessionKeyAuthProvider, ProviderMicrosoft,
+					"userId", "user@example.com",
+					ProviderMicrosoft, "12345",
+				)
+			},
+			expectedResult: true,
+		},
+		{
+			name: "auth_provider key with OIDC provider (different config name)",
+			providers: []conf.OAuthProviderConfig{
+				{Provider: ConfigOIDC, Enabled: true, UserID: "user@example.com"},
+			},
+			setupSession: func(t *testing.T, req *http.Request) *http.Request {
+				t.Helper()
+				return storeMultipleInSession(t, req,
+					SessionKeyAuthProvider, ProviderOIDC,
+					"userId", "user@example.com",
+					ProviderOIDC, "12345",
+				)
+			},
+			expectedResult: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gothic.Store = sessions.NewCookieStore([]byte("test-secret-32-bytes-minimum-len"))
+
+			server := &OAuth2Server{
+				Settings: &conf.Settings{
+					Security: conf.Security{
+						OAuthProviders: tt.providers,
+					},
+				},
+			}
+
+			req := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
+			req = tt.setupSession(t, req)
+
+			userId, _ := gothic.GetFromSession("userId", req)
+			result := server.checkSocialAuthDirect(req, userId, testLogger{})
+			assert.Equal(t, tt.expectedResult, result)
+		})
+	}
+}
+
+// TestCheckSocialAuthFallback tests the fallback path that iterates all providers.
+func TestCheckSocialAuthFallback(t *testing.T) {
+	tests := []struct {
+		name           string
+		providers      []conf.OAuthProviderConfig
+		setupSession   func(*testing.T, *http.Request) *http.Request
+		expectedResult bool
+	}{
+		{
+			name:           "no providers returns false",
+			providers:      nil,
+			setupSession:   func(_ *testing.T, req *http.Request) *http.Request { return req },
+			expectedResult: false,
+		},
+		{
+			name: "provider session without auth_provider key still works via fallback",
+			providers: []conf.OAuthProviderConfig{
+				{Provider: ConfigGoogle, Enabled: true, UserID: "user@example.com"},
+			},
+			setupSession: func(t *testing.T, req *http.Request) *http.Request {
+				t.Helper()
+				// No auth_provider key - simulating old session format
+				return storeMultipleInSession(t, req,
+					"userId", "user@example.com",
+					ProviderGoogle, "12345",
+				)
+			},
+			expectedResult: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gothic.Store = sessions.NewCookieStore([]byte("test-secret-32-bytes-minimum-len"))
+
+			server := &OAuth2Server{
+				Settings: &conf.Settings{
+					Security: conf.Security{
+						OAuthProviders: tt.providers,
+					},
+				},
+			}
+
+			req := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
+			req = tt.setupSession(t, req)
+
+			userId, _ := gothic.GetFromSession("userId", req)
+			result := server.checkSocialAuthFallback(req, userId, testLogger{})
+			assert.Equal(t, tt.expectedResult, result)
+		})
+	}
+}
+
+// TestCheckSocialAuthSessionsWithAuthProviderKey tests the full checkSocialAuthSessions
+// path with the auth_provider key set (new sessions).
+func TestCheckSocialAuthSessionsWithAuthProviderKey(t *testing.T) {
+	gothic.Store = sessions.NewCookieStore([]byte("test-secret-32-bytes-minimum-len"))
+
+	server := &OAuth2Server{
+		Settings: &conf.Settings{
+			Security: conf.Security{
+				OAuthProviders: []conf.OAuthProviderConfig{
+					{Provider: ConfigGoogle, Enabled: true, UserID: "user@example.com"},
+				},
+			},
+		},
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
+	req = storeMultipleInSession(t, req,
+		SessionKeyAuthProvider, ProviderGoogle,
+		"userId", "user@example.com",
+		ProviderGoogle, "12345",
+	)
+
+	result := server.checkSocialAuthSessions(req, testLogger{})
+	assert.True(t, result, "checkSocialAuthSessions should succeed with auth_provider key in session")
+}
+
 // TestCheckProviderAuth tests the generic provider auth validation function
 func TestCheckProviderAuth(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Summary

- Store the active OAuth provider name (`auth_provider`) in the session during `handleOAuthCallback`, enabling direct lookup instead of iterating all configured providers
- Refactor `GetProviderLogoutURL` and `checkSocialAuthSessions` to try direct session key lookup first, falling back to provider iteration for backward compatibility with existing sessions
- Add `GothToConfigProvider` reverse mapping and `gothToConfigProvider()` helper for resolving goth provider names back to config IDs (needed for `microsoftonline` -> `microsoft` and `openid-connect` -> `oidc`)

Fixes #2330

## Test plan

- [x] New tests for `checkSocialAuthDirect` covering: valid provider, disabled provider, unconfigured provider, Microsoft (different config name), OIDC (different config name)
- [x] New tests for `checkSocialAuthFallback` covering: backward compat with old sessions that lack `auth_provider` key
- [x] New tests for `GothToConfigProvider` reverse mapping correctness and `gothToConfigProvider` fallback
- [x] Full `internal/security` test suite passes with `-race` flag
- [x] `golangci-lint run ./...` passes with 0 issues (excluding pre-existing frontend embed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced provider logout URL resolution with automatic fallback support, ensuring seamless logout functionality for sessions created before recent updates and maintaining compatibility with all OAuth providers.

* **Improvements**
  * Optimized OAuth session management through streamlined provider tracking, reducing authentication lookup overhead and ensuring consistent, reliable behavior across multiple provider types and session states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->