### PR TITLE
fix: derive valid UI locales dynamically to fix Slovak persistence

### DIFF
--- a/frontend/tests/e2e/settings/locale-persistence.spec.ts
+++ b/frontend/tests/e2e/settings/locale-persistence.spec.ts
@@ -1,0 +1,291 @@
+import { test, expect, type Page } from '@playwright/test';
+
+/**
+ * Locale Persistence E2E Tests
+ *
+ * Validates that the language selector correctly:
+ * - Sets the locale via the LanguageSelector dropdown
+ * - Persists locale in localStorage as 'birdnet-locale'
+ * - Restores the correct locale after page reload
+ * - Displays translated text for every supported locale
+ *
+ * This test suite covers all 10 supported locales and specifically
+ * catches the bug where certain locales (e.g., Slovak) revert to
+ * English after reload due to backend validation resetting the value.
+ */
+
+// All supported locales with their display names and a known translated string.
+// We use "common.settings" (the translation for "Settings" in the navigation)
+// because it differs across every locale and is always visible in the sidebar.
+const LOCALE_DATA: {
+  code: string;
+  name: string;
+  settingsTranslation: string;
+}[] = [
+  { code: 'en', name: 'English', settingsTranslation: 'Settings' },
+  { code: 'de', name: 'Deutsch', settingsTranslation: 'Einstellungen' },
+  { code: 'es', name: 'Espanol', settingsTranslation: 'Configuración' },
+  { code: 'fi', name: 'Suomi', settingsTranslation: 'Asetukset' },
+  { code: 'fr', name: 'Francais', settingsTranslation: 'Paramètres' },
+  { code: 'it', name: 'Italiano', settingsTranslation: 'Impostazioni' },
+  { code: 'nl', name: 'Nederlands', settingsTranslation: 'Instellingen' },
+  { code: 'pl', name: 'Polski', settingsTranslation: 'Ustawienia' },
+  { code: 'pt', name: 'Portugues', settingsTranslation: 'Configurações' },
+  { code: 'sk', name: 'Slovenčina', settingsTranslation: 'Nastavenia' },
+];
+
+/** Clear the locale from localStorage to start with a clean state. */
+const clearLocaleStorage = async (page: Page) => {
+  await page.evaluate(() => {
+    localStorage.removeItem('birdnet-locale');
+    // Also clear cached message bundles that might interfere
+    for (let i = localStorage.length - 1; i >= 0; i--) {
+      const key = localStorage.key(i);
+      if (key?.startsWith('birdnet-messages')) {
+        localStorage.removeItem(key);
+      }
+    }
+  });
+};
+
+/** Get the stored locale value from localStorage. */
+const getStoredLocale = (page: Page): Promise<string | null> =>
+  page.evaluate(() => localStorage.getItem('birdnet-locale'));
+
+/**
+ * Select a locale using the LanguageSelector dropdown.
+ *
+ * The LanguageSelector uses SelectDropdown with variant="select".
+ * Interaction: click the trigger button to open the listbox,
+ * then click the option with the matching locale name.
+ */
+const selectLocale = async (page: Page, localeName: string) => {
+  // The LanguageSelector renders a SelectDropdown. The trigger is a <button>
+  // with aria-haspopup="listbox". We find it by looking for the button that
+  // currently shows a locale name (it renders the selected locale's name).
+  // There may be multiple buttons with aria-haspopup; we find the one inside
+  // a container that shows flag icons and locale names.
+
+  // Find the language selector button - it contains the flag and language name
+  // and has aria-haspopup="listbox"
+  const languageSelectorButton = page.locator('button[aria-haspopup="listbox"]').filter({
+    has: page.locator('img[alt*="flag"], svg, span'),
+  });
+
+  // If there are multiple matching buttons, use the first visible one
+  // that contains a known locale name
+  const allButtons = page.locator('button[aria-haspopup="listbox"]');
+  const buttonCount = await allButtons.count();
+
+  let selectorButton = languageSelectorButton.first();
+
+  // Fallback: iterate to find the button that contains a known locale name
+  if (buttonCount > 1) {
+    for (let i = 0; i < buttonCount; i++) {
+      const btn = allButtons.nth(i);
+      const text = await btn.textContent();
+      const isLocaleButton = LOCALE_DATA.some(l => text?.includes(l.name));
+      if (isLocaleButton) {
+        selectorButton = btn;
+        break;
+      }
+    }
+  }
+
+  await expect(selectorButton).toBeVisible();
+  await selectorButton.click();
+
+  // Wait for the dropdown listbox to appear
+  const listbox = page.locator('[role="listbox"]');
+  await expect(listbox).toBeVisible();
+
+  // Click the option with the target locale name
+  const option = listbox.locator('[role="option"]').filter({ hasText: localeName });
+  await expect(option).toBeVisible();
+  await option.click();
+
+  // Wait for the dropdown to close (single-select mode closes on selection)
+  await expect(listbox).toBeHidden();
+};
+
+/**
+ * Wait for translations to load after a locale change or page load.
+ * We poll for the expected translated text to appear, giving the async
+ * translation fetch time to complete.
+ */
+const waitForTranslation = async (page: Page, expectedText: string, timeout = 10000) => {
+  await expect(page.getByText(expectedText, { exact: false }).first()).toBeVisible({ timeout });
+};
+
+test.describe('Locale Persistence', () => {
+  test.setTimeout(60000);
+
+  test.beforeEach(async ({ page }) => {
+    // Navigate to a page first to access localStorage
+    await page.goto('/ui/dashboard', { timeout: 15000 });
+    await page.waitForLoadState('domcontentloaded', { timeout: 10000 });
+    await clearLocaleStorage(page);
+  });
+
+  for (const locale of LOCALE_DATA) {
+    test(`locale "${locale.code}" (${locale.name}) persists after page reload`, async ({
+      page,
+    }) => {
+      // Navigate to settings page where the LanguageSelector is accessible
+      await page.goto('/ui/settings', { timeout: 15000 });
+      await page.waitForLoadState('domcontentloaded', { timeout: 10000 });
+
+      // Select the target locale via the dropdown
+      await selectLocale(page, locale.name);
+
+      // Verify localStorage was set correctly
+      const storedLocale = await getStoredLocale(page);
+      expect(storedLocale, `localStorage should contain "${locale.code}"`).toBe(locale.code);
+
+      // Wait for translations to load and verify translated text appears
+      await waitForTranslation(page, locale.settingsTranslation);
+
+      // Reload the page
+      await page.reload({ waitUntil: 'domcontentloaded' });
+
+      // Verify localStorage still has the correct locale after reload
+      const storedLocaleAfterReload = await getStoredLocale(page);
+      expect(
+        storedLocaleAfterReload,
+        `localStorage should still contain "${locale.code}" after reload`
+      ).toBe(locale.code);
+
+      // Verify the translated text is still displayed after reload
+      // This catches the bug where the locale reverts to 'en' on reload
+      await waitForTranslation(page, locale.settingsTranslation);
+
+      // Double-check: the page should NOT show the English text (unless locale IS English)
+      if (locale.code !== 'en' && locale.settingsTranslation !== 'Settings') {
+        // Wait for translations to fully load, then verify we don't have English fallback
+        // showing as the primary navigation text. We check that the locale-specific
+        // translation exists rather than checking absence of English, since some
+        // UI elements may always show English text.
+        const translatedElements = page.getByText(locale.settingsTranslation, { exact: false });
+        const count = await translatedElements.count();
+        expect(
+          count,
+          `Expected translated text "${locale.settingsTranslation}" to appear`
+        ).toBeGreaterThan(0);
+      }
+    });
+  }
+});
+
+test.describe('Locale Default Behavior', () => {
+  test.setTimeout(30000);
+
+  test('fresh page load with no localStorage defaults to English or browser locale', async ({
+    page,
+  }) => {
+    // Navigate and clear any stored locale
+    await page.goto('/ui/dashboard', { timeout: 15000 });
+    await page.waitForLoadState('domcontentloaded', { timeout: 10000 });
+    await clearLocaleStorage(page);
+
+    // Reload to trigger fresh initialization
+    await page.reload({ waitUntil: 'domcontentloaded' });
+
+    // The locale should default to browser detection or English
+    // We just verify that some valid locale is set and translations load
+    const storedLocale = await getStoredLocale(page);
+
+    // On a fresh load without localStorage, the app uses browser detection.
+    // The stored value may be null (not yet persisted) or a valid locale.
+    if (storedLocale !== null) {
+      const validLocales = LOCALE_DATA.map(l => l.code);
+      expect(
+        validLocales,
+        `Stored locale "${storedLocale}" should be a valid locale code`
+      ).toContain(storedLocale);
+    }
+
+    // Verify that some translations loaded (page is not showing raw keys)
+    // Check for a common element that should always be translated
+    const hasTranslatedContent = await page.evaluate(() => {
+      // Check that the page body doesn't contain common raw translation keys
+      const bodyText = document.body.textContent || '';
+      // If we see "common.settings" as literal text, translations failed
+      return !bodyText.includes('common.settings') && !bodyText.includes('navigation.dashboard');
+    });
+    expect(hasTranslatedContent, 'Page should show translated text, not raw keys').toBe(true);
+  });
+
+  test('invalid locale in localStorage falls back gracefully', async ({ page }) => {
+    // Navigate to set up localStorage access
+    await page.goto('/ui/dashboard', { timeout: 15000 });
+    await page.waitForLoadState('domcontentloaded', { timeout: 10000 });
+
+    // Set an invalid locale value
+    await page.evaluate(() => {
+      localStorage.setItem('birdnet-locale', 'xx-invalid');
+    });
+
+    // Reload the page
+    await page.reload({ waitUntil: 'domcontentloaded' });
+
+    // The app should fall back to browser detection or English
+    // It should NOT crash or show raw translation keys
+    const hasTranslatedContent = await page.evaluate(() => {
+      const bodyText = document.body.textContent || '';
+      return !bodyText.includes('common.settings') && !bodyText.includes('navigation.dashboard');
+    });
+    expect(
+      hasTranslatedContent,
+      'Page should show translated text after invalid locale fallback'
+    ).toBe(true);
+
+    // The stored locale should either be corrected or remain invalid
+    // (the app's getInitialLocale skips invalid values)
+    const storedLocale = await getStoredLocale(page);
+    if (storedLocale !== null && storedLocale !== 'xx-invalid') {
+      const validLocales = LOCALE_DATA.map(l => l.code);
+      expect(validLocales).toContain(storedLocale);
+    }
+  });
+});
+
+test.describe('Locale Persistence via localStorage Direct Set', () => {
+  test.setTimeout(30000);
+
+  // This test verifies the reload path specifically: set locale in localStorage
+  // without using the UI, then reload and confirm it's picked up.
+  // This isolates the persistence/restoration logic from the selector UI.
+
+  for (const locale of LOCALE_DATA) {
+    test(`locale "${locale.code}" set in localStorage is restored on page load`, async ({
+      page,
+    }) => {
+      // Navigate to establish localStorage context
+      await page.goto('/ui/dashboard', { timeout: 15000 });
+      await page.waitForLoadState('domcontentloaded', { timeout: 10000 });
+
+      // Set the locale directly in localStorage
+      await page.evaluate((localeCode: string) => {
+        localStorage.setItem('birdnet-locale', localeCode);
+        // Clear message caches so fresh translations are fetched
+        for (let i = localStorage.length - 1; i >= 0; i--) {
+          const key = localStorage.key(i);
+          if (key?.startsWith('birdnet-messages')) {
+            localStorage.removeItem(key);
+          }
+        }
+      }, locale.code);
+
+      // Navigate to settings page (fresh navigation reads from localStorage)
+      await page.goto('/ui/settings', { timeout: 15000 });
+      await page.waitForLoadState('domcontentloaded', { timeout: 10000 });
+
+      // Verify the locale was picked up from localStorage
+      const storedLocale = await getStoredLocale(page);
+      expect(storedLocale).toBe(locale.code);
+
+      // Verify translated text appears
+      await waitForTranslation(page, locale.settingsTranslation);
+    });
+  }
+});

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -15,6 +15,7 @@ import (
 	"github.com/labstack/echo/v4"
 	echomw "github.com/labstack/echo/v4/middleware"
 	"github.com/markbates/goth/gothic"
+	"github.com/tphakala/birdnet-go/frontend"
 	"github.com/tphakala/birdnet-go/internal/analysis/processor"
 	"github.com/tphakala/birdnet-go/internal/api/auth"
 	mw "github.com/tphakala/birdnet-go/internal/api/middleware"
@@ -185,6 +186,10 @@ func New(settings *conf.Settings, opts ...ServerOption) (*Server, error) {
 	for _, opt := range opts {
 		opt(s)
 	}
+
+	// Populate valid UI locales from the embedded frontend message files.
+	// This must happen before any settings validation that checks locale values.
+	conf.SetValidUILocales(conf.DiscoverUILocales(frontend.DistFS))
 
 	// Initialize structured logger
 	s.slogger = GetLogger() // Uses Module("api")

--- a/internal/conf/locale.go
+++ b/internal/conf/locale.go
@@ -4,11 +4,14 @@ package conf
 
 import (
 	"fmt"
+	"io/fs"
 	"maps"
 	"slices"
 	"strings"
+	"sync"
 
 	"github.com/tphakala/birdnet-go/internal/errors"
+	"github.com/tphakala/birdnet-go/internal/logger"
 )
 
 // DefaultFallbackLocale is the default locale used when the requested locale is not supported
@@ -124,6 +127,76 @@ var LocaleCodes = map[string]string{
 	"tr":    "Turkish",
 	"uk":    "Ukrainian",
 	"vi-vn": "Vietnamese", // Vietnamese (Vietnam)
+}
+
+// defaultUILocales is the fallback list of valid UI locales, matching the frontend message files.
+// This is used when DiscoverUILocales has not been called or fails.
+var defaultUILocales = []string{"de", "en", "es", "fi", "fr", "it", "nl", "pl", "pt", "sk"}
+
+// validUILocales holds the currently active set of valid UI locale codes.
+// It is initialized to defaultUILocales and can be overridden by SetValidUILocales.
+var validUILocales = defaultUILocales
+
+// validUILocalesMu protects concurrent access to validUILocales.
+var validUILocalesMu sync.RWMutex
+
+// ValidUILocales returns the current list of valid UI locale codes.
+func ValidUILocales() []string {
+	validUILocalesMu.RLock()
+	defer validUILocalesMu.RUnlock()
+	return slices.Clone(validUILocales)
+}
+
+// SetValidUILocales overrides the valid UI locale list.
+// This should be called during server initialization after the embedded frontend FS is available.
+func SetValidUILocales(locales []string) {
+	validUILocalesMu.Lock()
+	defer validUILocalesMu.Unlock()
+	validUILocales = slices.Clone(locales)
+}
+
+// DiscoverUILocales reads the messages/ directory from the given filesystem
+// and returns locale codes extracted from {locale}.json filenames.
+// If reading fails, it returns the default locale list.
+// The result always includes "en" even if no en.json file exists.
+func DiscoverUILocales(fsys fs.FS) []string {
+	const messagesDir = "messages"
+
+	entries, err := fs.ReadDir(fsys, messagesDir)
+	if err != nil {
+		GetLogger().Warn("Failed to discover UI locales from embedded FS, using defaults",
+			logger.String("error", err.Error()))
+		return slices.Clone(defaultUILocales)
+	}
+
+	locales := make([]string, 0, len(entries))
+	hasEN := false
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if !strings.HasSuffix(name, ".json") {
+			continue
+		}
+		locale := strings.TrimSuffix(name, ".json")
+		if locale == "" {
+			continue
+		}
+		locales = append(locales, locale)
+		if locale == "en" {
+			hasEN = true
+		}
+	}
+
+	// Ensure "en" is always present as the fallback UI locale
+	if !hasEN {
+		locales = append(locales, "en")
+	}
+
+	slices.Sort(locales)
+	return locales
 }
 
 // GetLabelFilename returns the appropriate label filename for the given model version and locale code

--- a/internal/conf/locale_test.go
+++ b/internal/conf/locale_test.go
@@ -1,0 +1,110 @@
+package conf
+
+import (
+	"testing"
+	"testing/fstest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDiscoverUILocales(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		fs       fstest.MapFS
+		expected []string
+	}{
+		{
+			name: "discovers locales from json files",
+			fs: fstest.MapFS{
+				"messages/en.json": &fstest.MapFile{Data: []byte("{}")},
+				"messages/de.json": &fstest.MapFile{Data: []byte("{}")},
+				"messages/fr.json": &fstest.MapFile{Data: []byte("{}")},
+				"messages/sk.json": &fstest.MapFile{Data: []byte("{}")},
+			},
+			expected: []string{"de", "en", "fr", "sk"},
+		},
+		{
+			name: "adds en when missing",
+			fs: fstest.MapFS{
+				"messages/de.json": &fstest.MapFile{Data: []byte("{}")},
+				"messages/fr.json": &fstest.MapFile{Data: []byte("{}")},
+			},
+			expected: []string{"de", "en", "fr"},
+		},
+		{
+			name: "ignores non-json files",
+			fs: fstest.MapFS{
+				"messages/en.json":    &fstest.MapFile{Data: []byte("{}")},
+				"messages/README.md":  &fstest.MapFile{Data: []byte("readme")},
+				"messages/.gitkeep":   &fstest.MapFile{Data: []byte("")},
+				"messages/backup.bak": &fstest.MapFile{Data: []byte("")},
+			},
+			expected: []string{"en"},
+		},
+		{
+			name: "ignores directories inside messages",
+			fs: fstest.MapFS{
+				"messages/en.json":          &fstest.MapFile{Data: []byte("{}")},
+				"messages/archive/old.json": &fstest.MapFile{Data: []byte("{}")},
+			},
+			expected: []string{"en"},
+		},
+		{
+			name: "falls back to defaults when messages dir missing",
+			fs:   fstest.MapFS{},
+			expected: []string{
+				"de", "en", "es", "fi", "fr", "it", "nl", "pl", "pt", "sk",
+			},
+		},
+		{
+			name: "returns sorted locales",
+			fs: fstest.MapFS{
+				"messages/sk.json": &fstest.MapFile{Data: []byte("{}")},
+				"messages/de.json": &fstest.MapFile{Data: []byte("{}")},
+				"messages/en.json": &fstest.MapFile{Data: []byte("{}")},
+				"messages/fr.json": &fstest.MapFile{Data: []byte("{}")},
+				"messages/it.json": &fstest.MapFile{Data: []byte("{}")},
+			},
+			expected: []string{"de", "en", "fr", "it", "sk"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := DiscoverUILocales(tt.fs)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestSetValidUILocales(t *testing.T) {
+	// Save original and restore after test
+	original := ValidUILocales()
+	t.Cleanup(func() {
+		SetValidUILocales(original)
+	})
+
+	custom := []string{"en", "fi", "sk"}
+	SetValidUILocales(custom)
+
+	got := ValidUILocales()
+	require.Equal(t, custom, got)
+
+	// Verify returned slice is a copy (modifying it doesn't affect internal state)
+	got[0] = "xx"
+	assert.Equal(t, custom, ValidUILocales())
+}
+
+func TestValidUILocalesDefault(t *testing.T) {
+	// Verify the default includes all current frontend locales
+	locales := ValidUILocales()
+	assert.Contains(t, locales, "en")
+	assert.Contains(t, locales, "sk")
+	assert.Contains(t, locales, "it")
+	assert.Contains(t, locales, "nl")
+	assert.Contains(t, locales, "pl")
+}

--- a/internal/conf/validate.go
+++ b/internal/conf/validate.go
@@ -1251,8 +1251,7 @@ func validateDashboardSettings(settings *Dashboard) error {
 
 	// Validate UI locale if provided
 	if settings.Locale != "" {
-		validLocales := []string{"en", "de", "fr", "es", "fi", "pt"}
-		isValid := slices.Contains(validLocales, settings.Locale)
+		isValid := slices.Contains(ValidUILocales(), settings.Locale)
 		if !isValid {
 			// Log warning but don't fail - fallback to default
 			GetLogger().Warn("Invalid UI locale, will use default", logger.String("invalid_locale", settings.Locale), logger.String("fallback", "en"))


### PR DESCRIPTION
## Summary

Fixes #1944 — Slovak (`sk`) UI locale reverts to English after page reload.

**Root cause:** `internal/conf/validate.go` had a hardcoded allowlist of valid UI locales (`en, de, fr, es, fi, pt`) that was missing `it`, `nl`, `pl`, and `sk`. On settings save, the backend silently reset any unlisted locale to `"en"`. On reload, the frontend loaded `"en"` from the backend, reverting the UI to English.

**Fix:** Replace the hardcoded list with dynamic discovery — at server startup, scan the embedded frontend `messages/*.json` files to derive the valid locale set. Adding a new translation now only requires adding the JSON file and updating the frontend config; no Go changes needed.

### Changes

- **`internal/conf/locale.go`** — Add `DiscoverUILocales(fs.FS)`, `SetValidUILocales()`, `ValidUILocales()` with thread-safe access and sensible defaults
- **`internal/conf/validate.go`** — Replace hardcoded locale list with `ValidUILocales()` call
- **`internal/api/server.go`** — Populate valid UI locales from `frontend.DistFS` at startup
- **`internal/conf/locale_test.go`** — Tests for discovery (normal, missing en, non-json filtering, fallback)
- **`frontend/tests/e2e/settings/locale-persistence.spec.ts`** — Playwright e2e tests verifying all 10 locales persist after reload

## Test plan

- [x] `go test -race ./internal/conf/...` — all locale tests pass
- [x] `golangci-lint run -v` — zero issues
- [x] Frontend lint + typecheck pass
- [ ] CI passes
- [ ] Manual test: set Slovak locale, save, refresh — should persist