### PR TITLE
fix: add grace period wait for audio clip race condition

### DIFF
--- a/internal/api/v2/media.go
+++ b/internal/api/v2/media.go
@@ -395,6 +395,12 @@ func (c *Controller) waitForAudioFile(ctx echo.Context, relClipPath string) bool
 // yet, or has already atomically renamed it to the final path.
 // Returns true if the file appeared within the grace period.
 func (c *Controller) waitForAudioFileGrace(ctx echo.Context, relClipPath string) bool {
+	// Check immediately to avoid waiting one full poll interval when the file
+	// appears right after the initial 404.
+	if _, err := c.SFS.StatRel(relClipPath); err == nil {
+		return true
+	}
+
 	graceCtx, cancel := context.WithTimeout(ctx.Request().Context(), audioGracePeriod)
 	defer cancel()
 

--- a/internal/api/v2/media_test.go
+++ b/internal/api/v2/media_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -1462,16 +1463,15 @@ func TestServeAudioClipGraceWaitServesFile(t *testing.T) {
 
 	// No temp file — only the final file appears after a short delay.
 	// This simulates the race window where FFmpeg hasn't started yet.
-	errChan := make(chan error, 1)
-	go func() {
-		time.Sleep(400 * time.Millisecond)
-		errChan <- createTestAudioFile(t, audioFilePath)
-	}()
-	t.Cleanup(func() {
-		if bgErr := <-errChan; bgErr != nil {
-			t.Errorf("Background goroutine failed: %v", bgErr)
+	// Delay is derived from audioGracePeriod to stay aligned with production timing.
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		time.Sleep(audioGracePeriod / 2)
+		if err := createTestAudioFile(t, audioFilePath); err != nil {
+			t.Errorf("Background goroutine failed: %v", err)
 		}
 	})
+	t.Cleanup(wg.Wait)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v2/media/audio/"+audioFilename, http.NoBody)
 	rec := httptest.NewRecorder()


### PR DESCRIPTION
## Summary

- Fixes the race condition where audio clip 404s are returned ~400ms before FFmpeg finishes encoding, causing spurious "securefs issue" notifications
- Adds a 1-second grace period wait when no `.temp` file is visible, covering the timing gap where FFmpeg hasn't created the temp file yet or has already atomically renamed it
- Extracts duplicated 404-handling logic from `ServeAudioClip` and `ServeAudioByID` into a shared `handleAudio404WithWait` helper

## Root Cause (from issue #2355 investigation)

When a bird is detected, the DB record is committed before FFmpeg finishes encoding the audio clip. The dashboard polls for new detections and immediately requests the audio. The existing `isAudioBeingEncoded` check relies on a `.temp` file existing, but there's a ~400ms window where the temp file either hasn't been created yet or was already atomically renamed. During this window, a 404 is returned and triggers a user-visible "securefs issue" notification.

Evidence from support dump: all 137 securefs errors were race conditions — every file was successfully saved 300-500ms after the 404 was returned.

## Related Issues

Fixes #2355

## Test Plan

- [x] `TestServeAudioClipGraceWaitServesFile` — file appears 400ms after request, no temp file, served successfully via grace wait
- [x] `TestServeAudioClipWaitsForEncoding` — temp file exists, file appears during wait (existing, still passes)
- [x] `TestServeAudioClipReturns503AfterTimeout` — temp file exists but final never appears (existing, still passes)
- [x] `TestServeAudioClipNoTempFileReturns404` — no file ever appears, returns 404 after grace period (existing, still passes)
- [x] All tests pass with `-race` flag
- [x] Zero golangci-lint errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio serving reliability by adding a short server-side grace window that waits briefly for late-arriving audio, reducing false 404 responses and preserving existing retry semantics.
  * Consolidated audio 404 handling for more consistent responses and logging across endpoints.

* **Tests**
  * Added a test verifying the grace-window behavior serves files that appear shortly after the initial request.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->