### PR TITLE
fix: read SummaryLimit from layout element to fix empty species/daily response

### DIFF
--- a/internal/conf/dashboard_migration.go
+++ b/internal/conf/dashboard_migration.go
@@ -46,3 +46,19 @@ func (s *Settings) MigrateDashboardLayout() bool {
 
 	return true
 }
+
+// GetEffectiveSummaryLimit returns the summary limit from the dashboard layout element,
+// falling back to the deprecated Dashboard.SummaryLimit field and then to a default.
+// This is needed because MigrateDashboardLayout zeroes the deprecated field after moving
+// the value into the layout element config.
+func (s *Settings) GetEffectiveSummaryLimit() int {
+	for _, el := range s.Realtime.Dashboard.Layout.Elements {
+		if el.Type == "daily-summary" && el.Summary != nil && el.Summary.SummaryLimit > 0 {
+			return el.Summary.SummaryLimit
+		}
+	}
+	if s.Realtime.Dashboard.SummaryLimit > 0 {
+		return s.Realtime.Dashboard.SummaryLimit
+	}
+	return defaultDashboardSummaryLimit
+}

--- a/internal/conf/dashboard_migration_test.go
+++ b/internal/conf/dashboard_migration_test.go
@@ -109,3 +109,76 @@ func TestSettings_MigrateDashboardLayout_Idempotent(t *testing.T) {
 	require.False(t, migrated2)
 	assert.Len(t, settings.Realtime.Dashboard.Layout.Elements, 3)
 }
+
+func TestSettings_GetEffectiveSummaryLimit(t *testing.T) {
+	tests := []struct {
+		name     string
+		settings Settings
+		expected int
+	}{
+		{
+			name: "reads from layout element after migration",
+			settings: Settings{
+				Realtime: RealtimeSettings{
+					Dashboard: Dashboard{
+						SummaryLimit: 0, // zeroed by migration
+						Layout: DashboardLayout{
+							Elements: []DashboardElement{
+								{
+									Type:    "daily-summary",
+									Enabled: true,
+									Summary: &DailySummaryConfig{SummaryLimit: 50},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: 50,
+		},
+		{
+			name: "falls back to deprecated field for pre-migration configs",
+			settings: Settings{
+				Realtime: RealtimeSettings{
+					Dashboard: Dashboard{
+						SummaryLimit: 75,
+					},
+				},
+			},
+			expected: 75,
+		},
+		{
+			name: "returns default when both are zero",
+			settings: Settings{
+				Realtime: RealtimeSettings{
+					Dashboard: Dashboard{
+						SummaryLimit: 0,
+					},
+				},
+			},
+			expected: defaultDashboardSummaryLimit,
+		},
+		{
+			name: "skips layout element with nil summary config",
+			settings: Settings{
+				Realtime: RealtimeSettings{
+					Dashboard: Dashboard{
+						SummaryLimit: 0,
+						Layout: DashboardLayout{
+							Elements: []DashboardElement{
+								{Type: "daily-summary", Summary: nil},
+							},
+						},
+					},
+				},
+			},
+			expected: defaultDashboardSummaryLimit,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.settings.GetEffectiveSummaryLimit())
+		})
+	}
+}

--- a/internal/datastore/interfaces.go
+++ b/internal/datastore/interfaces.go
@@ -520,7 +520,7 @@ func (ds *DataStore) GetTopBirdsData(selectedDate string, minConfidenceNormalize
 	// Use provided limit or fall back to config value
 	reportCount := limit
 	if reportCount <= 0 {
-		reportCount = conf.Setting().Realtime.Dashboard.SummaryLimit
+		reportCount = conf.Setting().GetEffectiveSummaryLimit()
 	}
 
 	// First, get the count and common names

--- a/internal/datastore/v2only/datastore.go
+++ b/internal/datastore/v2only/datastore.go
@@ -902,7 +902,7 @@ func (ds *Datastore) GetTopBirdsData(selectedDate string, minConfidenceNormalize
 	// Use provided limit or fall back to config value
 	reportCount := limit
 	if reportCount <= 0 {
-		reportCount = conf.Setting().Realtime.Dashboard.SummaryLimit
+		reportCount = conf.Setting().GetEffectiveSummaryLimit()
 	}
 
 	// Struct to hold aggregated results per species


### PR DESCRIPTION
## Summary

- The dashboard layout migration (#2265) moves `SummaryLimit` into `Layout.Elements[].Summary.SummaryLimit` and zeroes the deprecated `Dashboard.SummaryLimit` field
- Both legacy and v2only datastores still read the old zeroed-out field as fallback when no `?limit=` query param is provided, causing `GORM Limit(0)` to return zero rows
- Add `GetEffectiveSummaryLimit()` that reads from the layout element first, falls back to the deprecated field, then to the default (30)
- The frontend was unaffected because it always passes `?limit=` explicitly — only direct API consumers hit this

## Related Issues

Fixes #2352

## Test Plan

- [x] `TestSettings_GetEffectiveSummaryLimit` covers all fallback paths (layout element, deprecated field, default)
- [x] Existing `TestSettings_MigrateDashboardLayout` tests still pass
- [x] `golangci-lint` passes with zero issues
- [ ] CI passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal dashboard configuration handling to use a dedicated method for retrieving effective summary limits, ensuring consistency across current and legacy configuration formats.

* **Tests**
  * Added comprehensive test coverage for dashboard summary limit resolution, validating behavior across multiple configuration scenarios including fallback cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->