### PR TITLE
fix: replace hardcoded English strings with i18n translation keys

### DIFF
--- a/frontend/src/lib/desktop/components/media/AudioPlayer.svelte
+++ b/frontend/src/lib/desktop/components/media/AudioPlayer.svelte
@@ -1811,7 +1811,7 @@
       bind:this={spectrogramImage}
       id={`spectrogram-${detectionId}`}
       src={spectrogramUrl}
-      alt="Audio spectrogram"
+      alt={t('components.audio.spectrogramAlt')}
       decoding="async"
       class={responsive
         ? enableClipExtraction

--- a/frontend/src/lib/desktop/components/media/AudioPlayer.test.ts
+++ b/frontend/src/lib/desktop/components/media/AudioPlayer.test.ts
@@ -137,7 +137,7 @@ describe('AudioPlayer', () => {
       showSpectrogram: true,
     });
 
-    const img = screen.getByAltText('Audio spectrogram');
+    const img = screen.getByAltText('components.audio.spectrogramAlt');
     expect(img).toBeInTheDocument();
     // URL includes cache-busting parameter
     expect(img.getAttribute('src')).toMatch(/\/api\/v2\/spectrogram\/test-123\?size=md&cache=\d+/);
@@ -151,7 +151,7 @@ describe('AudioPlayer', () => {
       showSpectrogram: true,
     });
 
-    const img = screen.getByAltText('Audio spectrogram');
+    const img = screen.getByAltText('components.audio.spectrogramAlt');
     // URL includes cache-busting parameter
     expect(img.getAttribute('src')).toMatch(/\/api\/v2\/spectrogram\/123\?size=md&cache=\d+/);
   });
@@ -329,13 +329,13 @@ describe('AudioPlayer', () => {
 
     // Wait for the spectrogram to load
     await waitFor(() => {
-      const img = screen.getByAltText('Audio spectrogram');
+      const img = screen.getByAltText('components.audio.spectrogramAlt');
       expect(img).toBeInTheDocument();
     });
 
     // Since the component doesn't currently support clicking on spectrogram for seeking,
     // we'll test that the spectrogram is displayed correctly
-    const img = screen.getByAltText('Audio spectrogram');
+    const img = screen.getByAltText('components.audio.spectrogramAlt');
     // URL includes cache-busting parameter
     expect(img.getAttribute('src')).toMatch(/\/api\/v2\/spectrogram\/test-123\?size=md&cache=\d+/);
   });
@@ -400,7 +400,7 @@ describe('AudioPlayer', () => {
       showSpectrogram: false,
     });
 
-    expect(screen.queryByAltText('Audio spectrogram')).not.toBeInTheDocument();
+    expect(screen.queryByAltText('components.audio.spectrogramAlt')).not.toBeInTheDocument();
   });
 
   it('calls event callbacks', async () => {
@@ -471,7 +471,7 @@ describe('AudioPlayer', () => {
     });
 
     // Get the spectrogram image
-    const img = screen.getByAltText('Audio spectrogram');
+    const img = screen.getByAltText('components.audio.spectrogramAlt');
     expect(img).toBeInTheDocument();
 
     // Trigger error and advance through all retry attempts

--- a/frontend/src/lib/desktop/features/detections/components/DetectionCardMobile.svelte
+++ b/frontend/src/lib/desktop/features/detections/components/DetectionCardMobile.svelte
@@ -45,7 +45,7 @@
   {#if spectrogramUrl && !spectrogramError}
     <img
       src={spectrogramUrl}
-      alt="Audio spectrogram"
+      alt={t('components.audio.spectrogramAlt')}
       class="absolute inset-0 w-full h-full object-cover opacity-20"
       onerror={() => (spectrogramError = true)}
     />

--- a/frontend/src/lib/desktop/features/detections/components/DetectionRow.svelte
+++ b/frontend/src/lib/desktop/features/detections/components/DetectionRow.svelte
@@ -102,12 +102,16 @@
   function handleToggleSpecies() {
     confirmModalConfig = {
       title: isExcluded
-        ? `Show Species ${detection.commonName}`
-        : `Ignore Species ${detection.commonName}`,
+        ? t('dashboard.recentDetections.modals.showSpecies', { species: detection.commonName })
+        : t('dashboard.recentDetections.modals.ignoreSpecies', { species: detection.commonName }),
       message: isExcluded
-        ? `Are you sure you want to show future detections of ${detection.commonName}?`
-        : `Are you sure you want to ignore future detections of ${detection.commonName}? This will only affect new detections - existing detections will remain in the database.`,
-      confirmLabel: 'Confirm',
+        ? t('dashboard.recentDetections.modals.showSpeciesConfirm', {
+            species: detection.commonName,
+          })
+        : t('dashboard.recentDetections.modals.ignoreSpeciesConfirm', {
+            species: detection.commonName,
+          }),
+      confirmLabel: t('common.confirm'),
       onConfirm: async () => {
         try {
           await fetchWithCSRF('/api/v2/detections/ignore', {
@@ -130,11 +134,17 @@
 
   function handleToggleLock() {
     confirmModalConfig = {
-      title: detection.locked ? 'Unlock Detection' : 'Lock Detection',
+      title: detection.locked
+        ? t('dashboard.recentDetections.modals.unlockDetection')
+        : t('dashboard.recentDetections.modals.lockDetection'),
       message: detection.locked
-        ? `Are you sure you want to unlock this detection of ${detection.commonName}? This will allow it to be deleted during regular cleanup.`
-        : `Are you sure you want to lock this detection of ${detection.commonName}? This will prevent it from being deleted during regular cleanup.`,
-      confirmLabel: 'Confirm',
+        ? t('dashboard.recentDetections.modals.unlockDetectionConfirm', {
+            species: detection.commonName,
+          })
+        : t('dashboard.recentDetections.modals.lockDetectionConfirm', {
+            species: detection.commonName,
+          }),
+      confirmLabel: t('common.confirm'),
       onConfirm: async () => {
         try {
           await fetchWithCSRF(`/api/v2/detections/${detection.id}/lock`, {
@@ -157,9 +167,13 @@
 
   function handleDelete() {
     confirmModalConfig = {
-      title: `Delete Detection of ${detection.commonName}`,
-      message: `Are you sure you want to delete detection of ${detection.commonName}? This action cannot be undone.`,
-      confirmLabel: 'Delete',
+      title: t('dashboard.recentDetections.modals.deleteDetection', {
+        species: detection.commonName,
+      }),
+      message: t('dashboard.recentDetections.modals.deleteDetectionConfirm', {
+        species: detection.commonName,
+      }),
+      confirmLabel: t('common.delete'),
       onConfirm: async () => {
         try {
           await fetchWithCSRF(`/api/v2/detections/${detection.id}`, {


### PR DESCRIPTION
## Summary

- Replace hardcoded `alt="Audio spectrogram"` in `AudioPlayer.svelte` and `DetectionCardMobile.svelte` with `t('components.audio.spectrogramAlt')` (key already exists in all 10 locale files)
- Replace hardcoded confirm dialog strings in `DetectionRow.svelte` (toggle species, toggle lock, delete) with existing `dashboard.recentDetections.modals.*` and `common.*` translation keys
- Update `AudioPlayer.test.ts` to match on the i18n key instead of hardcoded English text

## Test plan

- [x] AudioPlayer tests pass (21/21)
- [x] DetectionRow tests pass (3/3)
- [x] `npm run check:all` passes (prettier, eslint, ast-grep, svelte-check)
- [ ] Manual: verify confirm dialogs render correctly in non-English locale

Closes #2375, closes #2376, closes #2377, closes #2378, closes #2379, closes #2380, closes #2382

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Spectrogram accessibility labels updated to support translation.
  * Detection modal and confirmation dialog texts updated to support translation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->