### PR TITLE
fix: use optional chaining for window.matchMedia calls

### DIFF
--- a/frontend/src/lib/stores/theme.ts
+++ b/frontend/src/lib/stores/theme.ts
@@ -58,7 +58,7 @@ function createThemeStore() {
     }
 
     // Check system preference
-    if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+    if (window.matchMedia?.('(prefers-color-scheme: dark)').matches) {
       return 'dark';
     }
 

--- a/frontend/src/lib/utils/theme-init.ts
+++ b/frontend/src/lib/utils/theme-init.ts
@@ -59,7 +59,7 @@ export function initializeTheme(): void {
 
   if (stored === 'dark' || stored === 'light') {
     theme = stored;
-  } else if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+  } else if (window.matchMedia?.('(prefers-color-scheme: dark)').matches) {
     theme = 'dark';
   }
 


### PR DESCRIPTION
## Summary
- Replace `window.matchMedia && window.matchMedia(...)` with `window.matchMedia?.(...)` in `theme.ts` and `theme-init.ts`
- Fixes `@typescript-eslint/prefer-optional-chain` lint errors that block dependabot PR #2371

## Test plan
- [x] ESLint passes on both files
- [x] Pre-commit hooks pass (prettier, eslint, svelte-check)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated theme detection logic to use modern JavaScript syntax. This may affect how the system detects and applies dark mode preferences in certain browser environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->