### PR TITLE
Add API default-parameter regression tests (#2361)

### DIFF
--- a/internal/api/v2/api_defaults_regression_test.go
+++ b/internal/api/v2/api_defaults_regression_test.go
@@ -280,6 +280,7 @@ func TestSearchDetections_EmptyBody(t *testing.T) {
 	mockDS.On("SearchDetections", mock.MatchedBy(func(f *datastore.SearchFilters) bool {
 		return f.Page == 1 &&
 			f.PerPage == defaultPerPage &&
+			f.ConfidenceMin == 0.0 &&
 			f.ConfidenceMax == 1.0 // Normalized from 0 → 1
 	})).Return(mockResults, 1, nil).Once()
 


### PR DESCRIPTION
## Summary

- Add regression tests exercising every data-returning API v2 endpoint with no/minimal query parameters
- Catches config migration breakage like #2352 where `MigrateDashboardLayout` zeroed `Dashboard.SummaryLimit`, causing `GORM Limit(0)` → 0 rows
- Tests both pre-migration (deprecated field set) and post-migration (field zeroed by migration) config states
- Validates endpoints with required parameters return 400 (not 500 or panic)

Single new test file: `internal/api/v2/api_defaults_regression_test.go` (460 lines, 11 tests)

## Endpoints covered

| Endpoint | Default behavior tested |
|---|---|
| `GET /analytics/species/daily` | date=today, limit=0 (the #2352 bug) |
| `GET /analytics/species/summary` | empty start/end dates |
| `GET /analytics/species/detections/new` | last 30 days, limit=100 |
| `GET /analytics/time/distribution/hourly` | last 30 days, species="" |
| `GET /detections` | queryType="all", numResults=100 |
| `GET /detections/recent` | limit=10 |
| `POST /search` | empty body `{}` exercises all defaults |
| `GET /analytics/time/hourly` | required params → 400 |
| `GET /analytics/time/daily` | required params → 400 |
| `GET /analytics/species/daily/batch` | required params → 400 |

## Related Issues

Closes #2361

## Test Plan

- [x] All 11 new tests pass with `-race` flag
- [x] Full existing test suite passes (no regressions)
- [x] Zero lint issues (`golangci-lint run`)
- [x] Post-migration variant reproduces exact #2352 scenario

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a comprehensive regression test suite for API v2 validating default-parameter behavior across analytics and detection endpoints.
  * Covers empty-body searches, missing-required-parameter (BadRequest) scenarios, and pre/post-migration behavior.
  * Verifies non-empty responses, correct fallback defaults, effective summary limits, and interactions with mocked datastore expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->