### PR TITLE
fix: dashboard layout visibility for guests and width persistence

### DIFF
--- a/frontend/src/lib/desktop/features/dashboard/components/DashboardEditMode.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/components/DashboardEditMode.svelte
@@ -15,6 +15,10 @@
   import type { DashboardElementType } from '$lib/stores/settings';
   import DashboardElementWrapper from './DashboardElementWrapper.svelte';
   import { getElementLabel } from '$lib/desktop/features/dashboard/utils/elementLabels';
+  import {
+    getEffectiveWidth,
+    SUPPORTS_HALF,
+  } from '$lib/desktop/features/dashboard/utils/elementWidths';
   import { api } from '$lib/utils/api';
   import { getLogger } from '$lib/utils/logger';
   import { t } from '$lib/i18n';
@@ -106,7 +110,7 @@
         id: el.id,
         type: el.type,
         enabled: el.enabled,
-        ...(el.width && el.width !== 'full' ? { width: el.width } : {}),
+        ...(SUPPORTS_HALF.has(el.type) && el.width === 'half' ? { width: 'half' as const } : {}),
         ...(el.banner ? { banner: el.banner } : {}),
         ...(el.video ? { video: el.video } : {}),
         ...(el.summary ? { summary: el.summary } : {}),
@@ -171,12 +175,6 @@
         addDropdownOpen = false;
       }
     }
-  }
-
-  // Get effective width for an element
-  function getEffectiveWidth(el: DashboardElement): 'full' | 'half' {
-    if (el.type === 'daily-summary') return 'full';
-    return el.width ?? 'full';
   }
 </script>
 

--- a/frontend/src/lib/desktop/features/dashboard/components/DashboardElementWrapper.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/components/DashboardElementWrapper.svelte
@@ -13,12 +13,10 @@
   import { cn } from '$lib/utils/cn.js';
   import { t } from '$lib/i18n';
   import { getElementLabel } from '$lib/desktop/features/dashboard/utils/elementLabels';
-
-  // Element types that always require full width
-  const FULL_WIDTH_ONLY: string[] = ['daily-summary'];
-
-  // Element types that support half width
-  const SUPPORTS_HALF: string[] = ['banner', 'video-embed', 'currently-hearing', 'detections-grid'];
+  import {
+    FULL_WIDTH_ONLY,
+    SUPPORTS_HALF,
+  } from '$lib/desktop/features/dashboard/utils/elementWidths';
 
   interface Props {
     element: DashboardElement;
@@ -42,8 +40,8 @@
     settingsContent,
   }: Props = $props();
 
-  let canHalf = $derived(SUPPORTS_HALF.includes(element.type));
-  let isFullWidthOnly = $derived(FULL_WIDTH_ONLY.includes(element.type));
+  let canHalf = $derived(SUPPORTS_HALF.has(element.type));
+  let isFullWidthOnly = $derived(FULL_WIDTH_ONLY.has(element.type));
   let currentWidth = $derived(element.width ?? 'full');
   let settingsDropdownId = $derived(`settings-dropdown-${element.id ?? element.type}`);
 

--- a/frontend/src/lib/desktop/features/dashboard/pages/DashboardPage.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/pages/DashboardPage.svelte
@@ -64,6 +64,7 @@ Performance Optimizations:
   import { api } from '$lib/utils/api';
   import { buildAppUrl } from '$lib/utils/urlHelpers';
   import { navigation } from '$lib/stores/navigation.svelte';
+  import { appState } from '$lib/stores/appState.svelte';
   import { birdnetSettings, dashboardLayout, settingsStore } from '$lib/stores/settings';
   import type { Dashboard, DashboardElement, DashboardLayout } from '$lib/stores/settings';
   import { dashboardEditMode } from '$lib/stores/dashboardEditMode';
@@ -154,7 +155,12 @@ Performance Optimizations:
     { id: 'live-spectrogram-0', type: 'live-spectrogram', enabled: true },
     { id: 'detections-grid-0', type: 'detections-grid', enabled: true },
   ];
-  let layoutElements = $derived($dashboardLayout?.elements ?? defaultElements);
+  // Priority: authenticated settings > public app config > hardcoded defaults
+  let layoutElements = $derived(
+    $dashboardLayout?.elements ??
+      (appState.layout?.elements as DashboardElement[] | undefined) ??
+      defaultElements
+  );
 
   // Current layout as a DashboardLayout object for DashboardEditMode
   let currentLayout = $derived<DashboardLayout>({ elements: layoutElements });

--- a/frontend/src/lib/desktop/features/dashboard/utils/elementWidths.ts
+++ b/frontend/src/lib/desktop/features/dashboard/utils/elementWidths.ts
@@ -1,0 +1,22 @@
+import type { DashboardElement } from '$lib/stores/settings';
+
+/** Element types that always require full width (no half-width toggle). */
+export const FULL_WIDTH_ONLY: ReadonlySet<string> = new Set(['daily-summary', 'live-spectrogram']);
+
+/** Element types that support half width (show width toggle in edit mode). */
+export const SUPPORTS_HALF: ReadonlySet<string> = new Set([
+  'banner',
+  'video-embed',
+  'currently-hearing',
+  'detections-grid',
+]);
+
+/**
+ * Returns the effective display width for a dashboard element.
+ * Full-width-only types always return 'full'.
+ * Other types return 'half' only when explicitly set; any other value defaults to 'full'.
+ */
+export function getEffectiveWidth(el: DashboardElement): 'full' | 'half' {
+  if (FULL_WIDTH_ONLY.has(el.type)) return 'full';
+  return el.width === 'half' ? 'half' : 'full';
+}

--- a/frontend/src/lib/stores/appState.svelte.ts
+++ b/frontend/src/lib/stores/appState.svelte.ts
@@ -64,6 +64,18 @@ interface AppConfigResponse {
   customColors?: { primary: string; accent: string };
   logoStyle?: string;
   liveSpectrogram?: boolean;
+  layout?: {
+    elements: {
+      id?: string;
+      type: string;
+      enabled: boolean;
+      width?: string;
+      banner?: Record<string, unknown>;
+      video?: Record<string, unknown>;
+      summary?: Record<string, unknown>;
+      grid?: Record<string, unknown>;
+    }[];
+  };
 }
 
 /**
@@ -84,6 +96,8 @@ interface AppState {
   version: string;
   /** Whether live spectrogram is enabled */
   liveSpectrogram: boolean;
+  /** Dashboard layout from public config (available before auth) */
+  layout: AppConfigResponse['layout'] | null;
   /** Security configuration */
   security: {
     enabled: boolean;
@@ -106,6 +120,7 @@ const DEFAULT_STATE: AppState = {
   csrfToken: '',
   version: 'Development Build',
   liveSpectrogram: false,
+  layout: null,
   security: {
     enabled: false,
     accessAllowed: true,
@@ -207,6 +222,7 @@ export async function initApp(): Promise<boolean> {
       };
 
       appState.liveSpectrogram = config.liveSpectrogram ?? false;
+      appState.layout = config.layout ?? null;
 
       // Apply server-configured appearance settings
       if (config.colorScheme) {

--- a/frontend/src/lib/stores/settings.ts
+++ b/frontend/src/lib/stores/settings.ts
@@ -931,6 +931,7 @@ function createEmptySettings(): SettingsFormData {
               summary: { summaryLimit: 30 },
             },
             { id: 'currently-hearing-0', type: 'currently-hearing', enabled: true },
+            { id: 'live-spectrogram-0', type: 'live-spectrogram', enabled: true },
             { id: 'detections-grid-0', type: 'detections-grid', enabled: true },
           ],
         },

--- a/frontend/static/messages/da.json
+++ b/frontend/static/messages/da.json
@@ -911,7 +911,7 @@
       "connectionFailed": "Failed to connect to live audio stream"
     },
     "dashboard": {
-      "toggle": "Show live spectrogram",
+      "toggle": "Live Spectrogram",
       "audioToggle": "Enable audio"
     },
     "gain": {

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -911,7 +911,7 @@
       "connectionFailed": "Failed to connect to live audio stream"
     },
     "dashboard": {
-      "toggle": "Show live spectrogram",
+      "toggle": "Live Spectrogram",
       "audioToggle": "Enable audio"
     },
     "gain": {

--- a/frontend/static/messages/en.json
+++ b/frontend/static/messages/en.json
@@ -911,7 +911,7 @@
       "connectionFailed": "Failed to connect to live audio stream"
     },
     "dashboard": {
-      "toggle": "Show live spectrogram",
+      "toggle": "Live Spectrogram",
       "audioToggle": "Enable audio"
     },
     "gain": {

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -911,7 +911,7 @@
       "connectionFailed": "Failed to connect to live audio stream"
     },
     "dashboard": {
-      "toggle": "Show live spectrogram",
+      "toggle": "Live Spectrogram",
       "audioToggle": "Enable audio"
     },
     "gain": {

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -911,7 +911,7 @@
       "connectionFailed": "Failed to connect to live audio stream"
     },
     "dashboard": {
-      "toggle": "Show live spectrogram",
+      "toggle": "Live Spectrogram",
       "audioToggle": "Enable audio"
     },
     "gain": {

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -911,7 +911,7 @@
       "connectionFailed": "Failed to connect to live audio stream"
     },
     "dashboard": {
-      "toggle": "Show live spectrogram",
+      "toggle": "Live Spectrogram",
       "audioToggle": "Enable audio"
     },
     "gain": {

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -899,7 +899,7 @@
       "connectionFailed": "Failed to connect to live audio stream"
     },
     "dashboard": {
-      "toggle": "Show live spectrogram",
+      "toggle": "Live Spectrogram",
       "audioToggle": "Enable audio"
     },
     "gain": {

--- a/frontend/static/messages/lv.json
+++ b/frontend/static/messages/lv.json
@@ -911,7 +911,7 @@
       "connectionFailed": "Failed to connect to live audio stream"
     },
     "dashboard": {
-      "toggle": "Show live spectrogram",
+      "toggle": "Live Spectrogram",
       "audioToggle": "Enable audio"
     },
     "gain": {

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -911,7 +911,7 @@
       "connectionFailed": "Failed to connect to live audio stream"
     },
     "dashboard": {
-      "toggle": "Show live spectrogram",
+      "toggle": "Live Spectrogram",
       "audioToggle": "Enable audio"
     },
     "gain": {

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -911,7 +911,7 @@
       "connectionFailed": "Failed to connect to live audio stream"
     },
     "dashboard": {
-      "toggle": "Show live spectrogram",
+      "toggle": "Live Spectrogram",
       "audioToggle": "Enable audio"
     },
     "gain": {

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -911,7 +911,7 @@
       "connectionFailed": "Failed to connect to live audio stream"
     },
     "dashboard": {
-      "toggle": "Show live spectrogram",
+      "toggle": "Live Spectrogram",
       "audioToggle": "Enable audio"
     },
     "gain": {

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -906,7 +906,7 @@
       "connectionFailed": "Failed to connect to live audio stream"
     },
     "dashboard": {
-      "toggle": "Show live spectrogram",
+      "toggle": "Live Spectrogram",
       "audioToggle": "Enable audio"
     },
     "gain": {

--- a/frontend/static/messages/sv.json
+++ b/frontend/static/messages/sv.json
@@ -911,7 +911,7 @@
       "connectionFailed": "Failed to connect to live audio stream"
     },
     "dashboard": {
-      "toggle": "Show live spectrogram",
+      "toggle": "Live Spectrogram",
       "audioToggle": "Enable audio"
     },
     "gain": {

--- a/internal/api/v2/app.go
+++ b/internal/api/v2/app.go
@@ -20,14 +20,15 @@ const (
 // AppConfigResponse represents the application configuration returned to the frontend.
 // This replaces the server-side injected window.BIRDNET_CONFIG.
 type AppConfigResponse struct {
-	CSRFToken       string             `json:"csrfToken"`
-	Security        SecurityConfigDTO  `json:"security"`
-	Version         string             `json:"version"`
-	BasePath        string             `json:"basePath"`               // reverse proxy prefix for frontend URL construction
-	ColorScheme     string             `json:"colorScheme,omitempty"`  // admin-configured color scheme for all visitors
-	CustomColors    *conf.CustomColors `json:"customColors,omitempty"` // custom scheme hex colors (when colorScheme is "custom")
-	LogoStyle       string             `json:"logoStyle,omitempty"`    // admin-configured logo style: "gradient" or "solid"
-	LiveSpectrogram bool               `json:"liveSpectrogram"`        // auto-start live spectrogram on dashboard
+	CSRFToken       string                `json:"csrfToken"`
+	Security        SecurityConfigDTO     `json:"security"`
+	Version         string                `json:"version"`
+	BasePath        string                `json:"basePath"`               // reverse proxy prefix for frontend URL construction
+	ColorScheme     string                `json:"colorScheme,omitempty"`  // admin-configured color scheme for all visitors
+	CustomColors    *conf.CustomColors    `json:"customColors,omitempty"` // custom scheme hex colors (when colorScheme is "custom")
+	LogoStyle       string                `json:"logoStyle,omitempty"`    // admin-configured logo style: "gradient" or "solid"
+	LiveSpectrogram bool                  `json:"liveSpectrogram"`        // auto-start live spectrogram on dashboard
+	Layout          *conf.DashboardLayout `json:"layout,omitempty"`       // dashboard element layout for guest/pre-auth rendering
 }
 
 // SecurityConfigDTO represents the security configuration for the frontend.
@@ -116,6 +117,11 @@ func (c *Controller) GetAppConfig(ctx echo.Context) error {
 		CustomColors:    c.Settings.Realtime.Dashboard.CustomColors,
 		LogoStyle:       c.Settings.Realtime.Dashboard.LogoStyle,
 		LiveSpectrogram: c.Settings.Realtime.Dashboard.LiveSpectrogram,
+	}
+
+	// Include dashboard layout for guest/pre-auth rendering if configured
+	if len(c.Settings.Realtime.Dashboard.Layout.Elements) > 0 {
+		response.Layout = &c.Settings.Realtime.Dashboard.Layout
 	}
 
 	c.logDebugIfEnabled("Serving app config",


### PR DESCRIPTION
## Summary

- Include dashboard layout in the public `/api/v2/app/config` response so guest/unauthenticated users see the admin-configured layout instead of hardcoded defaults
- Centralize width logic into shared `elementWidths.ts` utility with `FULL_WIDTH_ONLY` and `SUPPORTS_HALF` sets, fixing inconsistency between `DashboardEditMode` and `DashboardElementWrapper`
- Force `live-spectrogram` to full-width only (was missing from both width control lists)
- Use strict `=== 'half'` check instead of `?? 'full'` so unexpected width values safely default to full-width
- Sync frontend default layout in `createEmptySettings()` to include `live-spectrogram`, matching the backend migration default
- Rename spectrogram dashboard card title from "Show live spectrogram" to "Live Spectrogram" across all locale files

## Test Plan

- [ ] Enable auth, configure a custom dashboard layout as admin, view dashboard as guest — should see the admin-configured layout
- [ ] Set currently-hearing to half-width, save, reload — should remain half-width; set back to full, save, reload — should remain full-width
- [ ] In edit mode, live-spectrogram should show "Full Width Only" label with no width toggle
- [ ] Clear config, restart server — frontend default and backend default should produce the same 4-element layout