### PR TITLE
fix: use percentage lightness and degree hue in oklch values

### DIFF
--- a/frontend/src/lib/desktop/views/DetectionDetail.svelte
+++ b/frontend/src/lib/desktop/views/DetectionDetail.svelte
@@ -1144,19 +1144,19 @@
   }
 
   .tod-day {
-    background: oklch(0.8 0.1 85 / 0.4);
+    background: oklch(80% 0.1 85deg / 0.4);
   }
 
   .tod-night {
-    background: oklch(0.5 0.08 270 / 0.25);
+    background: oklch(50% 0.08 270deg / 0.25);
   }
 
   .tod-sunrise {
-    background: oklch(0.8 0.12 55 / 0.4);
+    background: oklch(80% 0.12 55deg / 0.4);
   }
 
   .tod-sunset {
-    background: oklch(0.78 0.12 30 / 0.4);
+    background: oklch(78% 0.12 30deg / 0.4);
   }
 
   /* Weather in metadata card — consistent typographic scale */


### PR DESCRIPTION
## Summary

Fix pre-existing stylelint errors in DetectionDetail.svelte that were causing the `Lint & Type Check` CI job to fail on main.

- `lightness-notation`: `0.8` → `80%`, `0.5` → `50%`, `0.78` → `78%`
- `hue-degree-notation`: `85` → `85deg`, `270` → `270deg`, `55` → `55deg`, `30` → `30deg`

## Test Plan

- [ ] `npx stylelint 'src/lib/desktop/views/DetectionDetail.svelte'` passes with 0 errors
- [ ] CI `Lint & Type Check` job passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated color value syntax formatting for time-of-day badges to improve code consistency. No visual changes to the user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->