### PR TITLE
fix: normalize dynamic threshold merge keys to prevent duplicate species

### DIFF
--- a/internal/api/v2/dynamic_thresholds.go
+++ b/internal/api/v2/dynamic_thresholds.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/labstack/echo/v4"
@@ -181,7 +182,9 @@ func (c *Controller) getMergedThresholdData() map[string]*DynamicThresholdRespon
 	return thresholdMap
 }
 
-// addDatabaseThresholds adds thresholds from the database to the map
+// addDatabaseThresholds adds thresholds from the database to the map.
+// Map keys are normalized to lowercase to ensure case-insensitive merging
+// with in-memory data (which uses lowercase species names).
 func (c *Controller) addDatabaseThresholds(thresholdMap map[string]*DynamicThresholdResponse) {
 	dbThresholds, err := c.DS.GetAllDynamicThresholds()
 	if err != nil {
@@ -192,7 +195,7 @@ func (c *Controller) addDatabaseThresholds(thresholdMap map[string]*DynamicThres
 	now := time.Now()
 	for i := range dbThresholds {
 		dt := &dbThresholds[i]
-		thresholdMap[dt.SpeciesName] = &DynamicThresholdResponse{
+		thresholdMap[strings.ToLower(dt.SpeciesName)] = &DynamicThresholdResponse{
 			SpeciesName:    dt.SpeciesName,
 			ScientificName: dt.ScientificName,
 			Level:          dt.Level,
@@ -218,12 +221,13 @@ func (c *Controller) addMemoryThresholds(thresholdMap map[string]*DynamicThresho
 	baseThreshold := c.Settings.BirdNET.Threshold
 
 	for _, dt := range memoryData {
-		if existing, exists := thresholdMap[dt.SpeciesName]; exists {
+		key := strings.ToLower(dt.SpeciesName)
+		if existing, exists := thresholdMap[key]; exists {
 			// Update existing entry with in-memory values
 			applyMemoryOverlay(existing, dt.Level, dt.HighConfCount, dt.CurrentValue, dt.ExpiresAt, dt.IsActive, dt.ScientificName)
 		} else {
 			// Add new entry from memory
-			thresholdMap[dt.SpeciesName] = &DynamicThresholdResponse{
+			thresholdMap[key] = &DynamicThresholdResponse{
 				SpeciesName:    dt.SpeciesName,
 				ScientificName: dt.ScientificName,
 				Level:          dt.Level,
@@ -305,7 +309,7 @@ func (c *Controller) GetDynamicThreshold(ctx echo.Context) error {
 	// Try to get more current data from processor memory
 	if c.Processor != nil {
 		for _, md := range c.Processor.GetDynamicThresholdData() {
-			if md.SpeciesName == species {
+			if strings.EqualFold(md.SpeciesName, species) {
 				applyMemoryOverlay(&response, md.Level, md.HighConfCount, md.CurrentValue, md.ExpiresAt, md.IsActive, md.ScientificName)
 				break
 			}

--- a/internal/api/v2/dynamic_thresholds_test.go
+++ b/internal/api/v2/dynamic_thresholds_test.go
@@ -1,0 +1,167 @@
+package api
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/analysis/processor"
+	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/datastore"
+	"github.com/tphakala/birdnet-go/internal/datastore/mocks"
+)
+
+func TestGetMergedThresholdData_NoDuplicates(t *testing.T) {
+	t.Parallel()
+
+	mockDS := mocks.NewMockInterface(t)
+	now := time.Now()
+	expires := now.Add(24 * time.Hour)
+
+	// Database returns Title Case species name (as resolveCommonName does)
+	mockDS.EXPECT().GetAllDynamicThresholds().Return([]datastore.DynamicThreshold{
+		{
+			SpeciesName:    "Tawny Owl",
+			ScientificName: "Strix aluco",
+			Level:          1,
+			CurrentValue:   0.45,
+			BaseThreshold:  0.6,
+			HighConfCount:  1,
+			ExpiresAt:      expires,
+		},
+	}, nil)
+
+	// Processor memory stores lowercase species name
+	proc := &processor.Processor{
+		Settings: &conf.Settings{
+			BirdNET: conf.BirdNETConfig{Threshold: 0.6},
+		},
+		DynamicThresholds: map[string]*processor.DynamicThreshold{
+			"tawny owl": {
+				Level:          2,
+				CurrentValue:   0.3,
+				Timer:          expires,
+				HighConfCount:  2,
+				ValidHours:     24,
+				ScientificName: "Strix aluco",
+			},
+		},
+	}
+
+	controller := &Controller{
+		DS:        mockDS,
+		Settings:  proc.Settings,
+		Processor: proc,
+	}
+
+	result := controller.getMergedThresholdData()
+
+	// Bug: before fix this returns 2 entries (one Title Case, one lowercase)
+	// After fix: should return exactly 1 entry with memory overlay applied
+	require.Len(t, result, 1, "should merge same species regardless of case")
+
+	// Find the single entry
+	var entry *DynamicThresholdResponse
+	for _, v := range result {
+		entry = v
+	}
+	require.NotNil(t, entry)
+
+	// Memory data should override database data (memory is more current)
+	assert.Equal(t, 2, entry.Level, "level should come from memory overlay")
+	assert.InDelta(t, 0.3, entry.CurrentValue, 0.001, "current value should come from memory overlay")
+	// Display name should be Title Case (from database, the proper display name)
+	assert.Equal(t, "Tawny Owl", entry.SpeciesName, "display name should be Title Case from database")
+}
+
+func TestGetMergedThresholdData_MemoryOnlySpecies(t *testing.T) {
+	t.Parallel()
+
+	mockDS := mocks.NewMockInterface(t)
+	expires := time.Now().Add(24 * time.Hour)
+
+	// Database returns no thresholds
+	mockDS.EXPECT().GetAllDynamicThresholds().Return([]datastore.DynamicThreshold{}, nil)
+
+	// Processor memory has a species not in the database
+	proc := &processor.Processor{
+		Settings: &conf.Settings{
+			BirdNET: conf.BirdNETConfig{Threshold: 0.6},
+		},
+		DynamicThresholds: map[string]*processor.DynamicThreshold{
+			"eurasian blue tit": {
+				Level:          1,
+				CurrentValue:   0.45,
+				Timer:          expires,
+				HighConfCount:  1,
+				ValidHours:     24,
+				ScientificName: "Cyanistes caeruleus",
+			},
+		},
+	}
+
+	controller := &Controller{
+		DS:        mockDS,
+		Settings:  proc.Settings,
+		Processor: proc,
+	}
+
+	result := controller.getMergedThresholdData()
+
+	require.Len(t, result, 1, "memory-only species should appear")
+	var entry *DynamicThresholdResponse
+	for _, v := range result {
+		entry = v
+	}
+	require.NotNil(t, entry)
+	assert.Equal(t, "eurasian blue tit", entry.SpeciesName)
+	assert.Equal(t, "Cyanistes caeruleus", entry.ScientificName)
+}
+
+func TestGetMergedThresholdData_DatabaseOnlySpecies(t *testing.T) {
+	t.Parallel()
+
+	mockDS := mocks.NewMockInterface(t)
+	now := time.Now()
+	expires := now.Add(24 * time.Hour)
+
+	// Database has a species
+	mockDS.EXPECT().GetAllDynamicThresholds().Return([]datastore.DynamicThreshold{
+		{
+			SpeciesName:    "Common Blackbird",
+			ScientificName: "Turdus merula",
+			Level:          1,
+			CurrentValue:   0.45,
+			BaseThreshold:  0.6,
+			HighConfCount:  1,
+			ExpiresAt:      expires,
+		},
+	}, nil)
+
+	// Processor has no thresholds (empty map)
+	proc := &processor.Processor{
+		Settings: &conf.Settings{
+			BirdNET: conf.BirdNETConfig{Threshold: 0.6},
+		},
+		DynamicThresholds: map[string]*processor.DynamicThreshold{},
+	}
+
+	controller := &Controller{
+		DS:        mockDS,
+		Settings:  proc.Settings,
+		Processor: proc,
+	}
+
+	result := controller.getMergedThresholdData()
+
+	require.Len(t, result, 1, "database-only species should appear")
+	var entry *DynamicThresholdResponse
+	for _, v := range result {
+		entry = v
+	}
+	require.NotNil(t, entry)
+	assert.Equal(t, "Common Blackbird", entry.SpeciesName)
+	assert.Equal(t, "Turdus merula", entry.ScientificName)
+	assert.Equal(t, 1, entry.Level)
+}


### PR DESCRIPTION
## Summary

Fixes #2412 — the "Learned" tab under Settings > Species was showing duplicate entries for each species: once in Title Case and once in lowercase.

- Root cause: `getMergedThresholdData()` uses a map to merge thresholds from two sources (database + processor memory), but the database returns Title Case species names (via `resolveCommonName()`) while the processor stores lowercase keys. The case-sensitive map lookup creates two entries for the same species.
- Fix: Normalize all merge map keys to `strings.ToLower()` while preserving the Title Case display name in the API response `SpeciesName` field.
- Also fixed a case-sensitive comparison in `GetDynamicThreshold` single-species endpoint using `strings.EqualFold()`.

**Note:** There is a related issue in `threshold_persistence.go:76` where `loadDynamicThresholdsFromDB` stores thresholds in the processor map using the DB's Title Case name instead of normalizing to lowercase. This can cause duplicates in the processor's own map after restart-then-detection. That is a separate bug to be addressed in a follow-up.

## Test plan

- [x] Added `TestGetMergedThresholdData_NoDuplicates` — reproduces the exact bug (Title Case DB + lowercase memory → verifies single merged entry)
- [x] Added `TestGetMergedThresholdData_MemoryOnlySpecies` — species only in processor memory appears correctly
- [x] Added `TestGetMergedThresholdData_DatabaseOnlySpecies` — species only in database appears correctly
- [x] All existing API v2 tests pass with `-race`
- [x] golangci-lint passes with zero issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed species name matching to be case-insensitive, preventing duplicate threshold entries when species names differ only in capitalization.

* **Tests**
  * Added unit tests validating threshold merge behavior for case-insensitive species matching and database-memory overlay scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->