### PR TITLE
fix: add reclassification for Bubulcus to Ardea in taxonomy synonyms

### DIFF
--- a/internal/imageprovider/taxonomy_synonyms.go
+++ b/internal/imageprovider/taxonomy_synonyms.go
@@ -28,6 +28,9 @@ var taxonomySynonyms = map[string]string{
 	// Streptopelia → Spilopelia reclassification
 	"Streptopelia senegalensis": "Spilopelia senegalensis",
 	"Streptopelia chinensis": "Spilopelia chinensis",
+
+	// Bubulcus → Ardea reclassification
+	"Bubulcus ibis": "Ardea coromanda",
 }
 
 // forwardSynonyms maps lowercase BirdNET names to updated names.


### PR DESCRIPTION
We really should have a config option for these. Added Bubulcus to Ardea in taxonomy synonyms

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded species name recognition to support additional scientific name variants, improving accuracy when searching or filtering by taxonomy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->