### PR TITLE
fix: restrict COOP header to secure contexts and fix dashboard init effect

### DIFF
--- a/frontend/src/lib/desktop/features/dashboard/components/DailySummaryCard.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/components/DailySummaryCard.svelte
@@ -68,7 +68,7 @@ Responsive Breakpoints:
     type TemperatureUnit,
   } from '$lib/utils/formatters';
   import { ChevronLeft, ChevronRight, Star, Sunrise, Sunset, XCircle } from '@lucide/svelte';
-  import { untrack } from 'svelte';
+  import { onMount, untrack } from 'svelte';
   import AnimatedCounter from './AnimatedCounter.svelte';
   import BirdThumbnailPopup from './BirdThumbnailPopup.svelte';
 
@@ -239,8 +239,9 @@ Responsive Breakpoints:
     }
   }
 
-  // Fetch dashboard config on mount
-  $effect(() => {
+  // Fetch dashboard config on mount (onMount, not $effect, to avoid
+  // reactive dependency tracking that can cascade during initialization)
+  onMount(() => {
     fetchDashboardConfig();
   });
 

--- a/internal/api/middleware/security.go
+++ b/internal/api/middleware/security.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"net"
 	"net/http"
 	"strings"
 
@@ -133,13 +134,26 @@ func NewSecureHeaders(config *SecurityConfig) echo.MiddlewareFunc {
 		// Wrap next once at setup time, not per-request.
 		wrapped := echoSecure(next)
 		return func(c echo.Context) error {
-			// Set headers not supported by Echo's SecureConfig.
-			// COOP isolates the browsing context, preventing tabnabbing and cross-window attacks.
-			// Note: "same-origin" is safe here because OAuth uses redirects, not popups.
-			c.Response().Header().Set("Cross-Origin-Opener-Policy", "same-origin")
+			// Set COOP only on secure contexts (HTTPS or localhost).
+			// Browsers ignore COOP on non-trustworthy origins per
+			// https://www.w3.org/TR/powerful-features/#potentially-trustworthy-origin
+			if IsSecureRequest(c.Request()) || isLocalhost(c.Request()) {
+				c.Response().Header().Set("Cross-Origin-Opener-Policy", "same-origin")
+			}
 			return wrapped(c)
 		}
 	}
+}
+
+// isLocalhost returns true if the request's Host is a localhost address,
+// which browsers consider a trustworthy origin even over plain HTTP.
+func isLocalhost(r *http.Request) bool {
+	host := r.Host
+	// Strip port if present.
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		host = h
+	}
+	return host == "localhost" || host == "127.0.0.1" || host == "::1"
 }
 
 // NewBodyLimit creates a middleware that limits the request body size.

--- a/internal/api/middleware/security_test.go
+++ b/internal/api/middleware/security_test.go
@@ -56,15 +56,75 @@ func TestNewSecureHeaders_CrossOriginOpenerPolicy(t *testing.T) {
 	t.Parallel()
 
 	mw := NewSecureHeaders(DefaultSecurityConfig())
-	c, rec := newTestContext(t, http.MethodGet, "/")
 
-	handler := mw(func(c echo.Context) error {
-		return c.String(http.StatusOK, "ok")
+	t.Run("set on HTTPS request", func(t *testing.T) {
+		t.Parallel()
+		c, rec := newTestContext(t, http.MethodGet, "/")
+		c.Request().Header.Set("X-Forwarded-Proto", "https")
+
+		handler := mw(func(c echo.Context) error {
+			return c.String(http.StatusOK, "ok")
+		})
+
+		err := handler(c)
+		require.NoError(t, err)
+		assert.Equal(t, "same-origin", rec.Header().Get("Cross-Origin-Opener-Policy"))
 	})
 
-	err := handler(c)
-	require.NoError(t, err)
-	assert.Equal(t, "same-origin", rec.Header().Get("Cross-Origin-Opener-Policy"))
+	t.Run("set on localhost request", func(t *testing.T) {
+		t.Parallel()
+		c, rec := newTestContext(t, http.MethodGet, "/")
+		c.Request().Host = "localhost:8080"
+
+		handler := mw(func(c echo.Context) error {
+			return c.String(http.StatusOK, "ok")
+		})
+
+		err := handler(c)
+		require.NoError(t, err)
+		assert.Equal(t, "same-origin", rec.Header().Get("Cross-Origin-Opener-Policy"))
+	})
+
+	t.Run("omitted on plain HTTP non-localhost", func(t *testing.T) {
+		t.Parallel()
+		c, rec := newTestContext(t, http.MethodGet, "/")
+		c.Request().Host = "192.168.1.100:8080"
+
+		handler := mw(func(c echo.Context) error {
+			return c.String(http.StatusOK, "ok")
+		})
+
+		err := handler(c)
+		require.NoError(t, err)
+		assert.Empty(t, rec.Header().Get("Cross-Origin-Opener-Policy"))
+	})
+}
+
+func TestIsLocalhost(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		host     string
+		expected bool
+	}{
+		{"localhost no port", "localhost", true},
+		{"localhost with port", "localhost:8080", true},
+		{"127.0.0.1 no port", "127.0.0.1", true},
+		{"127.0.0.1 with port", "127.0.0.1:8080", true},
+		{"IPv6 loopback", "::1", true},
+		{"IPv6 loopback with port", "[::1]:8080", true},
+		{"LAN IP", "192.168.1.100:8080", false},
+		{"hostname", "birdnet.local:8080", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			r := &http.Request{Host: tt.host}
+			assert.Equal(t, tt.expected, isLocalhost(r))
+		})
+	}
 }
 
 func TestNewSecureHeaders_FrameAncestors(t *testing.T) {


### PR DESCRIPTION
## Summary
- **COOP header**: Only set `Cross-Origin-Opener-Policy: same-origin` on secure contexts (HTTPS or localhost). Browsers ignore it on non-trustworthy origins anyway, eliminating console warnings for LAN users on plain HTTP.
- **Svelte init**: Convert `DailySummaryCard.fetchDashboardConfig` from `$effect` to `onMount` — fire-once initialization should not use reactive effect tracking, which can cascade during startup.

Fixes regressions from #2421.

## Test plan
- [x] `go test -race ./internal/api/middleware/...` — all pass
- [x] `npm run check:all` — lint, typecheck, ast-grep all pass
- [x] New tests for `isLocalhost` and COOP subtests (HTTPS, localhost, plain HTTP)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced security header handling to conditionally set Cross-Origin-Opener-Policy for secure requests and localhost connections only.

* **Tests**
  * Expanded test coverage for security headers across various request environments and connection types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->