### PR TITLE
feat: Add Wikipedia species summaries to /api/v2/species endpoint

### DIFF
--- a/internal/api/v2/api.go
+++ b/internal/api/v2/api.go
@@ -33,6 +33,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/securefs"
 	"github.com/tphakala/birdnet-go/internal/spectrogram"
 	"github.com/tphakala/birdnet-go/internal/suncalc"
+	"github.com/tphakala/birdnet-go/internal/wikipedia"
 )
 
 // Tunnel provider constant for unknown providers
@@ -64,6 +65,7 @@ type Controller struct {
 	apiLogger            logger.Logger          // Structured logger for API operations
 	metrics              *observability.Metrics // Shared metrics instance
 	spectrogramGenerator *spectrogram.Generator // Shared spectrogram generator (initialized after SFS)
+	WikipediaClient      *wikipedia.Client      // Wikipedia species info client
 
 	// Auth related fields (injected from server via functional options)
 	authService    auth.Service        // Authentication service (injected from server)
@@ -330,6 +332,7 @@ func NewWithOptions(e *echo.Echo, ds datastore.Interface, settings *conf.Setting
 		cancel:               cancel,
 		spectrogramGenerator: spectrogram.NewGenerator(settings, sfs, getSpectrogramLogger()), // Initialize shared generator
 		detectionRateCache:   datastore.NewDetectionRateCache(detectionRateCacheTTL),
+		WikipediaClient:      wikipedia.NewClient(),
 	}
 
 	// Initialize audio processing cache and concurrency limiter

--- a/internal/api/v2/species.go
+++ b/internal/api/v2/species.go
@@ -41,7 +41,17 @@ type SpeciesInfo struct {
 	CommonName     string              `json:"common_name"`
 	Rarity         *SpeciesRarityInfo  `json:"rarity,omitempty"`
 	Taxonomy       *ebird.TaxonomyTree `json:"taxonomy,omitempty"`
+	Wikipedia      *WikipediaInfo      `json:"wikipedia,omitempty"`
 	Metadata       map[string]any      `json:"metadata,omitempty"`
+}
+
+// WikipediaInfo contains a species summary from Wikipedia
+type WikipediaInfo struct {
+	Title       string `json:"title"`
+	Extract     string `json:"extract"`
+	Description string `json:"description,omitempty"`
+	ArticleURL  string `json:"article_url,omitempty"`
+	ThumbnailURL string `json:"thumbnail_url,omitempty"`
 }
 
 // SpeciesRarityInfo contains rarity information for a species
@@ -236,6 +246,25 @@ func (c *Controller) getSpeciesInfo(ctx context.Context, scientificName string) 
 	if result := c.lookupTaxonomyTree(ctx, scientificName); result != nil {
 		info.Taxonomy = result.tree
 		info.Metadata["source"] = result.source
+	}
+
+	// Get Wikipedia summary (non-blocking — skip if unavailable)
+	if c.WikipediaClient != nil {
+		wikiSummary, err := c.WikipediaClient.GetSummary(ctx, commonName, scientificName)
+		if err != nil {
+			c.Debug("Wikipedia summary unavailable for %s: %v", commonName, err)
+		} else {
+			wikiInfo := &WikipediaInfo{
+				Title:       wikiSummary.Title,
+				Extract:     wikiSummary.Extract,
+				Description: wikiSummary.Description,
+				ArticleURL:  wikiSummary.ArticleURL(),
+			}
+			if wikiSummary.Thumbnail != nil {
+				wikiInfo.ThumbnailURL = wikiSummary.Thumbnail.Source
+			}
+			info.Wikipedia = wikiInfo
+		}
 	}
 
 	return info, nil

--- a/internal/wikipedia/client.go
+++ b/internal/wikipedia/client.go
@@ -1,0 +1,169 @@
+// Package wikipedia provides a client for fetching species summaries
+// from the Wikipedia REST API.
+package wikipedia
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/patrickmn/go-cache"
+	"github.com/tphakala/birdnet-go/internal/errors"
+	"github.com/tphakala/birdnet-go/internal/logger"
+)
+
+// DefaultCacheTTL is the default time-to-live for cached Wikipedia summaries.
+const DefaultCacheTTL = 24 * time.Hour
+
+// DefaultCacheCleanup is the interval for removing expired cache entries.
+const DefaultCacheCleanup = 1 * time.Hour
+
+// DefaultTimeout is the HTTP request timeout for Wikipedia API calls.
+const DefaultTimeout = 10 * time.Second
+
+// UserAgent identifies this application to Wikipedia per their API policy.
+// Wikipedia's REST API requires a user agent that looks like a real client.
+// Per https://meta.wikimedia.org/wiki/User-Agent_policy, bots must include
+// contact information. We include both a browser-compatible prefix and our
+// application identifier.
+const UserAgent = "Mozilla/5.0 (compatible; BirdNET-Go/1.0; +https://github.com/tphakala/birdnet-go)"
+
+// Summary represents a Wikipedia page summary from the REST API.
+type Summary struct {
+	Title       string      `json:"title"`
+	Extract     string      `json:"extract"`
+	Description string      `json:"description,omitempty"`
+	Thumbnail   *Thumbnail  `json:"thumbnail,omitempty"`
+	ContentURLs *ContentURL `json:"content_urls,omitempty"`
+}
+
+// Thumbnail represents a Wikipedia page thumbnail image.
+type Thumbnail struct {
+	Source string `json:"source"`
+	Width  int    `json:"width"`
+	Height int    `json:"height"`
+}
+
+// ContentURL contains links to the Wikipedia article.
+type ContentURL struct {
+	Desktop *PageURL `json:"desktop,omitempty"`
+	Mobile  *PageURL `json:"mobile,omitempty"`
+}
+
+// PageURL holds the full article URL.
+type PageURL struct {
+	Page string `json:"page,omitempty"`
+}
+
+// ArticleURL returns the best available article URL, preferring mobile.
+func (s *Summary) ArticleURL() string {
+	if s.ContentURLs != nil {
+		if s.ContentURLs.Mobile != nil && s.ContentURLs.Mobile.Page != "" {
+			return s.ContentURLs.Mobile.Page
+		}
+		if s.ContentURLs.Desktop != nil && s.ContentURLs.Desktop.Page != "" {
+			return s.ContentURLs.Desktop.Page
+		}
+	}
+	return ""
+}
+
+// Client fetches and caches species summaries from Wikipedia.
+type Client struct {
+	httpClient *http.Client
+	cache      *cache.Cache
+	lang       string
+}
+
+// GetLogger returns the package logger for the wikipedia module.
+func GetLogger() logger.Logger {
+	return logger.Global().Module("wikipedia")
+}
+
+// NewClient creates a new Wikipedia client with default settings.
+func NewClient() *Client {
+	return &Client{
+		httpClient: &http.Client{Timeout: DefaultTimeout},
+		cache:      cache.New(DefaultCacheTTL, DefaultCacheCleanup),
+		lang:       "en",
+	}
+}
+
+// GetSummary fetches a species summary, trying commonName first then scientificName.
+// Results are cached for 24 hours.
+func (c *Client) GetSummary(ctx context.Context, commonName, scientificName string) (*Summary, error) {
+	cacheKey := strings.ToLower(commonName)
+
+	// Check cache first
+	if cached, found := c.cache.Get(cacheKey); found {
+		if summary, ok := cached.(*Summary); ok {
+			return summary, nil
+		}
+	}
+
+	// Try common name first (Wikipedia articles are usually titled by common name)
+	summary, err := c.fetchSummary(ctx, commonName)
+	if err != nil {
+		// Fall back to scientific name
+		summary, err = c.fetchSummary(ctx, scientificName)
+		if err != nil {
+			return nil, errors.Newf("wikipedia summary not found for '%s' or '%s'", commonName, scientificName).
+				Category(errors.CategoryNotFound).
+				Component("wikipedia").
+				Build()
+		}
+	}
+
+	c.cache.Set(cacheKey, summary, cache.DefaultExpiration)
+	return summary, nil
+}
+
+// fetchSummary fetches a page summary from the Wikipedia REST API.
+func (c *Client) fetchSummary(ctx context.Context, title string) (*Summary, error) {
+	encoded := url.PathEscape(strings.ReplaceAll(title, " ", "_"))
+	apiURL := fmt.Sprintf("https://%s.wikipedia.org/api/rest_v1/page/summary/%s", c.lang, encoded)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
+	if err != nil {
+		return nil, errors.New(err).
+			Category(errors.CategorySystem).
+			Component("wikipedia").
+			Build()
+	}
+	req.Header.Set("User-Agent", UserAgent)
+	req.Header.Set("Api-User-Agent", UserAgent)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, errors.New(err).
+			Category(errors.CategoryNetwork).
+			Component("wikipedia").
+			Build()
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		// Drain body to allow connection reuse
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return nil, errors.Newf("wikipedia returned status %d for '%s'", resp.StatusCode, title).
+			Category(errors.CategoryNotFound).
+			Component("wikipedia").
+			Build()
+	}
+
+	var summary Summary
+	if err := json.NewDecoder(resp.Body).Decode(&summary); err != nil {
+		return nil, errors.New(err).
+			Category(errors.CategoryProcessing).
+			Component("wikipedia").
+			Build()
+	}
+
+	return &summary, nil
+}

--- a/internal/wikipedia/client_test.go
+++ b/internal/wikipedia/client_test.go
@@ -1,0 +1,248 @@
+package wikipedia
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/patrickmn/go-cache"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestSummary() *Summary {
+	return &Summary{
+		Title:       "Masked Lapwing",
+		Extract:     "The masked lapwing is a large, common and conspicuous bird native to Australia.",
+		Description: "Species of bird in the family Charadriidae",
+		Thumbnail: &Thumbnail{
+			Source: "https://upload.wikimedia.org/test.jpg",
+			Width:  320,
+			Height: 240,
+		},
+		ContentURLs: &ContentURL{
+			Mobile:  &PageURL{Page: "https://en.m.wikipedia.org/wiki/Masked_lapwing"},
+			Desktop: &PageURL{Page: "https://en.wikipedia.org/wiki/Masked_lapwing"},
+		},
+	}
+}
+
+func newTestServer(t *testing.T, handler http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(handler)
+}
+
+func TestGetSummary_Success(t *testing.T) {
+	t.Parallel()
+
+	expected := newTestSummary()
+	server := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Contains(t, r.URL.Path, "Masked_Lapwing")
+		assert.Equal(t, UserAgent, r.Header.Get("User-Agent"))
+		w.Header().Set("Content-Type", "application/json")
+		err := json.NewEncoder(w).Encode(expected)
+		require.NoError(t, err)
+	})
+	defer server.Close()
+
+	client := &Client{
+		httpClient: server.Client(),
+		cache:      cache.New(DefaultCacheTTL, DefaultCacheCleanup),
+		lang:       "en",
+	}
+	// Override the fetch to use our test server
+	// We need to test with a real URL pattern, so we test fetchSummary directly
+	// with a modified client that points to our test server
+	client.httpClient = &http.Client{
+		Timeout: DefaultTimeout,
+		Transport: &rewriteTransport{
+			base:    http.DefaultTransport,
+			baseURL: server.URL,
+		},
+	}
+
+	summary, err := client.GetSummary(context.Background(), "Masked Lapwing", "Vanellus miles")
+	require.NoError(t, err)
+	assert.Equal(t, expected.Title, summary.Title)
+	assert.Equal(t, expected.Extract, summary.Extract)
+	assert.Equal(t, expected.Description, summary.Description)
+}
+
+func TestGetSummary_CacheHit(t *testing.T) {
+	t.Parallel()
+
+	expected := newTestSummary()
+	callCount := 0
+
+	server := newTestServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		callCount++
+		w.Header().Set("Content-Type", "application/json")
+		err := json.NewEncoder(w).Encode(expected)
+		require.NoError(t, err)
+	})
+	defer server.Close()
+
+	client := &Client{
+		httpClient: &http.Client{
+			Timeout: DefaultTimeout,
+			Transport: &rewriteTransport{
+				base:    http.DefaultTransport,
+				baseURL: server.URL,
+			},
+		},
+		cache: cache.New(DefaultCacheTTL, DefaultCacheCleanup),
+		lang:  "en",
+	}
+
+	// First call - should hit the server
+	_, err := client.GetSummary(context.Background(), "Masked Lapwing", "Vanellus miles")
+	require.NoError(t, err)
+	assert.Equal(t, 1, callCount)
+
+	// Second call - should hit cache
+	_, err = client.GetSummary(context.Background(), "Masked Lapwing", "Vanellus miles")
+	require.NoError(t, err)
+	assert.Equal(t, 1, callCount, "expected cache hit, but server was called again")
+}
+
+func TestGetSummary_FallbackToScientificName(t *testing.T) {
+	t.Parallel()
+
+	expected := newTestSummary()
+
+	server := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/rest_v1/page/summary/Unknown_Bird" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		// Scientific name should work
+		assert.Contains(t, r.URL.Path, "Vanellus_miles")
+		w.Header().Set("Content-Type", "application/json")
+		err := json.NewEncoder(w).Encode(expected)
+		require.NoError(t, err)
+	})
+	defer server.Close()
+
+	client := &Client{
+		httpClient: &http.Client{
+			Timeout: DefaultTimeout,
+			Transport: &rewriteTransport{
+				base:    http.DefaultTransport,
+				baseURL: server.URL,
+			},
+		},
+		cache: cache.New(DefaultCacheTTL, DefaultCacheCleanup),
+		lang:  "en",
+	}
+
+	summary, err := client.GetSummary(context.Background(), "Unknown Bird", "Vanellus miles")
+	require.NoError(t, err)
+	assert.Equal(t, expected.Title, summary.Title)
+}
+
+func TestGetSummary_NotFound(t *testing.T) {
+	t.Parallel()
+
+	server := newTestServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+	defer server.Close()
+
+	client := &Client{
+		httpClient: &http.Client{
+			Timeout: DefaultTimeout,
+			Transport: &rewriteTransport{
+				base:    http.DefaultTransport,
+				baseURL: server.URL,
+			},
+		},
+		cache: cache.New(DefaultCacheTTL, DefaultCacheCleanup),
+		lang:  "en",
+	}
+
+	_, err := client.GetSummary(context.Background(), "Nonexistent Bird", "Nonexistent species")
+	assert.Error(t, err)
+}
+
+func TestGetSummary_Timeout(t *testing.T) {
+	t.Parallel()
+
+	server := newTestServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(200 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	})
+	defer server.Close()
+
+	client := &Client{
+		httpClient: &http.Client{
+			Timeout: 50 * time.Millisecond,
+			Transport: &rewriteTransport{
+				base:    http.DefaultTransport,
+				baseURL: server.URL,
+			},
+		},
+		cache: cache.New(DefaultCacheTTL, DefaultCacheCleanup),
+		lang:  "en",
+	}
+
+	_, err := client.GetSummary(context.Background(), "Masked Lapwing", "Vanellus miles")
+	assert.Error(t, err)
+}
+
+func TestArticleURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		summary  Summary
+		expected string
+	}{
+		{
+			name: "prefers mobile URL",
+			summary: Summary{
+				ContentURLs: &ContentURL{
+					Mobile:  &PageURL{Page: "https://en.m.wikipedia.org/wiki/Test"},
+					Desktop: &PageURL{Page: "https://en.wikipedia.org/wiki/Test"},
+				},
+			},
+			expected: "https://en.m.wikipedia.org/wiki/Test",
+		},
+		{
+			name: "falls back to desktop URL",
+			summary: Summary{
+				ContentURLs: &ContentURL{
+					Desktop: &PageURL{Page: "https://en.wikipedia.org/wiki/Test"},
+				},
+			},
+			expected: "https://en.wikipedia.org/wiki/Test",
+		},
+		{
+			name:     "returns empty for nil content URLs",
+			summary:  Summary{},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expected, tt.summary.ArticleURL())
+		})
+	}
+}
+
+// rewriteTransport rewrites all requests to point to the test server.
+type rewriteTransport struct {
+	base    http.RoundTripper
+	baseURL string
+}
+
+func (t *rewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Rewrite the URL to point to test server, preserving the path
+	req.URL.Scheme = "http"
+	req.URL.Host = t.baseURL[len("http://"):]
+	return t.base.RoundTrip(req)
+}

--- a/internal/wikipedia/integration_test.go
+++ b/internal/wikipedia/integration_test.go
@@ -1,0 +1,43 @@
+package wikipedia
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestIntegration_RealWikipediaAPI tests against the real Wikipedia API.
+// Skipped unless WIKIPEDIA_INTEGRATION=1 is set.
+func TestIntegration_RealWikipediaAPI(t *testing.T) {
+	if os.Getenv("WIKIPEDIA_INTEGRATION") != "1" {
+		t.Skip("Skipping integration test (set WIKIPEDIA_INTEGRATION=1 to run)")
+	}
+
+	client := NewClient()
+	ctx := context.Background()
+
+	tests := []struct {
+		commonName     string
+		scientificName string
+	}{
+		{"Masked Lapwing", "Vanellus miles"},
+		{"Galah", "Eolophus roseicapilla"},
+		{"Barn Owl", "Tyto alba"},
+		{"Little Corella", "Cacatua sanguinea"},
+		{"Australian Magpie", "Gymnorhina tibicen"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.commonName, func(t *testing.T) {
+			summary, err := client.GetSummary(ctx, tt.commonName, tt.scientificName)
+			require.NoError(t, err, "Failed to fetch summary for %s", tt.commonName)
+			assert.NotEmpty(t, summary.Title, "Title should not be empty")
+			assert.NotEmpty(t, summary.Extract, "Extract should not be empty")
+			assert.NotEmpty(t, summary.ArticleURL(), "Article URL should not be empty")
+			t.Logf("✓ %s: %s (%.80s...)", tt.commonName, summary.Description, summary.Extract)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Adds Wikipedia species information to the existing `/api/v2/species` endpoint, enriching the response with a `wikipedia` field containing title, extract, description, article URL, and thumbnail URL.

## Motivation

Companion apps (e.g. iOS, Android) want to show users educational information about detected bird species. Rather than each client implementing their own Wikipedia integration, the server can provide cached summaries through the existing species API.

This is especially useful because:
- Server-side caching (24h TTL) reduces Wikipedia API load
- Clients get species info with a single API call they're already making
- The server has authoritative scientific names from its taxonomy data

## Changes

### New package: `internal/wikipedia/`
- **`client.go`** — Wikipedia REST API client with `go-cache` (24h TTL), common-name-first with scientific-name fallback, Mozilla-compatible User-Agent header
- **`client_test.go`** — 5 unit tests using httptest + rewriteTransport pattern (cache hit, fallback, not-found, timeout, article URL preference)
- **`integration_test.go`** — 5 integration tests gated behind `WIKIPEDIA_INTEGRATION=1` env var

### Extended: `internal/api/v2/`
- **`species.go`** — Added `WikipediaInfo` struct and `Wikipedia` field to `SpeciesInfo` response; fetches summary in `getSpeciesInfo()` after taxonomy lookup
- **`api.go`** — Added `WikipediaClient` field to Controller struct, initialized with default config

## API Response

The existing `/api/v2/species?scientific_name=Gymnorhina+tibicen` response now includes:

```json
{
  "scientific_name": "Gymnorhina tibicen",
  "common_name": "Australian Magpie",
  "wikipedia": {
    "title": "Australian magpie",
    "extract": "The Australian magpie is a black and white passerine bird...",
    "description": "Medium-sized black and white passerine bird",
    "article_url": "https://en.m.wikipedia.org/wiki/Australian_magpie",
    "thumbnail_url": "https://upload.wikimedia.org/..."
  }
}
```

The `wikipedia` field is omitted if the lookup fails (graceful degradation).

## Testing

```bash
# Unit tests (no network)
go test ./internal/wikipedia/ -v -race

# Integration tests (hits real Wikipedia API)
WIKIPEDIA_INTEGRATION=1 go test ./internal/wikipedia/ -v -run Integration
```

## Notes

- Uses `go-cache` consistent with existing caching patterns (e.g. eBird client)
- Uses `internal/errors` package per project conventions
- Wikipedia API requires Mozilla-compatible User-Agent (bare bot strings get 403)
- No new dependencies beyond `go-cache` which is already in go.mod
- TFLite build dependency means `go build ./internal/api/v2/` requires the C headers — but the wikipedia package builds and tests independently

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Species information endpoint now returns Wikipedia data including title, extract, description, article link, and thumbnail image.
  * Integrated in-memory caching for Wikipedia content lookups.

* **Tests**
  * Added comprehensive unit tests for Wikipedia client.
  * Added integration tests against live Wikipedia API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->