### PR TITLE
fix(frontend): resolve all ESLint warnings and svelte-check a11y issues

### DIFF
--- a/frontend/src/lib/desktop/components/forms/ToggleField.svelte
+++ b/frontend/src/lib/desktop/components/forms/ToggleField.svelte
@@ -59,6 +59,7 @@
     md: 'w-12 h-6 before:w-5 before:h-5 checked:before:translate-x-6',
   };
 
+  // eslint-disable-next-line security/detect-object-injection -- size is typed as 'sm' | 'md'
   let toggleBaseClasses = $derived(`${toggleSharedClasses} ${toggleSizeClasses[size]}`);
 
   const toggleErrorClasses = 'checked:bg-[var(--color-error)]';

--- a/frontend/src/lib/desktop/components/media/AudioPlayer.svelte
+++ b/frontend/src/lib/desktop/components/media/AudioPlayer.svelte
@@ -692,6 +692,7 @@
 
       // Map format to container file extension (must match backend clipFileExtension)
       const extMap: Record<string, string> = { alac: 'm4a', aac: 'm4a', opus: 'ogg' };
+      // eslint-disable-next-line security/detect-object-injection -- extractionFormat is a controlled string from component props
       const ext = extMap[extractionFormat] ?? extractionFormat;
       // Sanitize label for filesystem safety (remove reserved chars, normalize whitespace)
       const safeLabel = clipLabel

--- a/frontend/src/lib/desktop/components/media/SpectrogramCanvas.svelte
+++ b/frontend/src/lib/desktop/components/media/SpectrogramCanvas.svelte
@@ -86,6 +86,7 @@
       const freqRatio = 1 - y / (height - 1 || 1);
       const freq = minFreq + freqRatio * (maxFreq - minFreq);
       const binIndex = Math.round((freq / nyquist) * (binCount - 1));
+      // eslint-disable-next-line security/detect-object-injection -- y is a loop counter bounded by canvas height
       map[y] = Math.max(0, Math.min(binCount - 1, binIndex));
     }
 
@@ -93,6 +94,7 @@
   });
 
   // Selected color LUT
+  // eslint-disable-next-line security/detect-object-injection -- colorMap is typed as ColorMapName
   let colorLUT = $derived(COLOR_MAPS[colorMap] ?? COLOR_MAPS[DEFAULT_COLOR_MAP]);
 
   // ResizeObserver with debouncing (100ms)
@@ -248,9 +250,11 @@
 
         for (let col = 0; col < pixelsToScroll; col++) {
           for (let y = 0; y < h; y++) {
+            /* eslint-disable security/detect-object-injection -- loop indices and typed array lookups */
             const binIndex = currentBinMap[y];
             const magnitude = frequencyData[binIndex];
             data[y * pixelsToScroll + col] = currentLUT[magnitude];
+            /* eslint-enable security/detect-object-injection */
           }
         }
 

--- a/frontend/src/lib/desktop/components/ui/LanguageSelector.svelte
+++ b/frontend/src/lib/desktop/components/ui/LanguageSelector.svelte
@@ -8,9 +8,10 @@
   // Props
   interface Props {
     className?: string;
+    id?: string;
   }
 
-  let { className = '' }: Props = $props();
+  let { className = '', id }: Props = $props();
 
   // Extended option type for locale with typed locale code
   interface LocaleOption extends SelectOption {
@@ -55,6 +56,7 @@
   size="sm"
   groupBy={false}
   {className}
+  {id}
   onChange={handleLanguageChange}
 >
   {#snippet renderOption(option)}

--- a/frontend/src/lib/desktop/components/ui/Modal.svelte
+++ b/frontend/src/lib/desktop/components/ui/Modal.svelte
@@ -231,7 +231,12 @@
 >
   <div
     bind:this={modalElement}
-    class={cn(sizeClasses[size], { 'scale-100': isOpen }, className)}
+    class={cn(
+      // eslint-disable-next-line security/detect-object-injection -- size is typed as ModalSize
+      sizeClasses[size],
+      { 'scale-100': isOpen },
+      className
+    )}
     role="document"
     tabindex="-1"
   >
@@ -281,7 +286,11 @@
         </button>
         <button
           type="button"
-          class={cn(btnBase, confirmButtonStyles[confirmVariant])}
+          class={cn(
+            btnBase,
+            // eslint-disable-next-line security/detect-object-injection -- confirmVariant is typed union
+            confirmButtonStyles[confirmVariant]
+          )}
           onclick={handleConfirm}
           disabled={loading || isConfirming}
         >

--- a/frontend/src/lib/desktop/components/ui/StatusBanner.svelte
+++ b/frontend/src/lib/desktop/components/ui/StatusBanner.svelte
@@ -25,10 +25,13 @@
     info: 'bg-[var(--color-info)]/15 text-[var(--color-info)]',
     warning: 'bg-[var(--color-warning)]/15 text-[var(--color-warning)]',
   };
+
+  // eslint-disable-next-line security/detect-object-injection -- type is typed as StatusType
+  let typeStyle = $derived(styleMap[type]);
 </script>
 
 <div
-  class="flex items-center gap-2 rounded-lg p-3 text-sm {styleMap[type]} {className}"
+  class="flex items-center gap-2 rounded-lg p-3 text-sm {typeStyle} {className}"
   role={type === 'error' ? 'alert' : 'status'}
   aria-live={type === 'error' ? 'assertive' : 'polite'}
 >

--- a/frontend/src/lib/desktop/components/ui/WeatherSvgIcon.svelte
+++ b/frontend/src/lib/desktop/components/ui/WeatherSvgIcon.svelte
@@ -84,6 +84,7 @@
 
   let { icon, size = 32, className = '', title = '' }: Props = $props();
 
+  // eslint-disable-next-line security/detect-object-injection -- icon is a string prop used as key in a static icon map
   let svgContent = $derived(iconMap[icon] ?? iconMap['not-available']);
 </script>
 

--- a/frontend/src/lib/desktop/features/dashboard/components/CurrentlyHearingCard.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/components/CurrentlyHearingCard.svelte
@@ -44,10 +44,12 @@ Props:
     for (const d of detections) {
       const key = detectionKey(d);
       if ((d.status === 'approved' || d.status === 'rejected') && !(key in removalTimers)) {
+        /* eslint-disable security/detect-object-injection -- key is derived from detectionKey(), a controlled string */
         retainedData[key] = d;
         removalTimers[key] = setTimeout(() => {
           delete retainedData[key];
           delete removalTimers[key];
+          /* eslint-enable security/detect-object-injection */
           retainedKeys = retainedKeys.filter(k => k !== key);
         }, TERMINAL_RETENTION_MS);
         if (!untrack(() => retainedKeys).includes(key)) {
@@ -70,6 +72,7 @@ Props:
     const result: PendingDetection[] = [...detections];
     for (const key of retained) {
       if (!incomingByKey.has(key)) {
+        // eslint-disable-next-line security/detect-object-injection -- key is from retainedKeys, a controlled string array
         const data = retainedData[key];
         if (data) {
           result.push(data);
@@ -114,6 +117,11 @@ Props:
     return result;
   });
 
+  function getElapsedForKey(key: string): string {
+    // eslint-disable-next-line security/detect-object-injection -- key is a controlled detection key string
+    return elapsedTexts[key] ?? '';
+  }
+
   // Show source column only when multiple sources are present
   let hasMultipleSources = $derived(new Set(displayDetections.map(d => d.source)).size > 1);
 
@@ -121,6 +129,7 @@ Props:
   $effect(() => {
     return () => {
       for (const key in removalTimers) {
+        // eslint-disable-next-line security/detect-object-injection -- key is from for-in over own Record
         clearTimeout(removalTimers[key]);
       }
     };
@@ -145,6 +154,7 @@ Props:
     <div class="flex flex-wrap gap-3 p-4">
       {#each displayDetections as detection (`${detection.source}_${detection.scientificName}`)}
         {@const key = detection.source + detection.scientificName}
+        {@const elapsedText = getElapsedForKey(key)}
         <div
           class="flex items-center gap-2 rounded-lg px-3 py-2 transition-colors duration-300
             {detection.status === 'approved'
@@ -175,7 +185,7 @@ Props:
               {detection.species}
             </span>
             <span class="text-xs text-[var(--color-base-content)]/60">
-              {elapsedTexts[key] ?? ''}
+              {elapsedText}
               {#if hasMultipleSources}
                 · {detection.source}
               {/if}

--- a/frontend/src/lib/desktop/features/dashboard/components/DashboardEditMode.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/components/DashboardEditMode.svelte
@@ -67,6 +67,7 @@
   let missingTypes = $derived(
     ALL_ELEMENT_TYPES.filter(type => {
       const count = editElements.filter(el => el.type === type).length;
+      // eslint-disable-next-line security/detect-object-injection -- type is from ALL_ELEMENT_TYPES, a typed constant array
       const max = MAX_INSTANCES[type] ?? 1;
       return count < max;
     })

--- a/frontend/src/lib/desktop/features/dashboard/components/MiniSpectrogram.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/components/MiniSpectrogram.svelte
@@ -63,6 +63,7 @@
   let showDetectionLabels = $state(true);
 
   const gainLabel = $derived.by(() => {
+    // eslint-disable-next-line security/detect-object-injection -- gainPresetIndex is a numeric index bounded by GAIN_PRESETS.length
     const preset = GAIN_PRESETS[gainPresetIndex];
     return 'value' in preset ? t(preset.labelKey, { value: preset.value }) : t(preset.labelKey);
   });
@@ -378,6 +379,7 @@
 
   function cycleVolume() {
     gainPresetIndex = (gainPresetIndex + 1) % GAIN_PRESETS.length;
+    // eslint-disable-next-line security/detect-object-injection -- gainPresetIndex is a numeric index bounded by modulo
     const preset = GAIN_PRESETS[gainPresetIndex];
     spectro.setAudioOutput(preset.audio);
     if (preset.audio) {

--- a/frontend/src/lib/desktop/features/settings/components/AlertRuleEditor.svelte
+++ b/frontend/src/lib/desktop/features/settings/components/AlertRuleEditor.svelte
@@ -192,6 +192,7 @@
       integration: Globe,
       application: Server,
     };
+    // eslint-disable-next-line security/detect-object-injection -- typeName is from a controlled set of object type strings
     return icons[typeName] ?? Cpu;
   }
 
@@ -217,6 +218,7 @@
       application: { bg: 'bg-sky-500/10', text: 'text-sky-500' },
     };
     return (
+      // eslint-disable-next-line security/detect-object-injection -- typeName is from a controlled set of object type strings
       colors[typeName] ?? {
         bg: 'bg-[var(--color-base-300)]',
         text: 'text-[var(--color-base-content)]',

--- a/frontend/src/lib/desktop/features/settings/components/ColorSchemePicker.svelte
+++ b/frontend/src/lib/desktop/features/settings/components/ColorSchemePicker.svelte
@@ -72,6 +72,7 @@
 
   // Logo preview variant based on current style and scheme
   let logoPreviewVariant: LogoVariant = $derived(
+    // eslint-disable-next-line security/detect-object-injection -- $scheme is a controlled color scheme identifier
     $logoStyle === 'solid' ? 'solid' : (SCHEME_GRADIENT_MAP[$scheme] ?? 'scheme')
   );
 

--- a/frontend/src/lib/desktop/features/settings/components/SpeciesListCard.svelte
+++ b/frontend/src/lib/desktop/features/settings/components/SpeciesListCard.svelte
@@ -83,6 +83,7 @@
     teal: { bg: 'bg-teal-500/10', text: 'text-teal-500' },
   };
 
+  // eslint-disable-next-line security/detect-object-injection -- iconColorClass is a prop with a fixed set of color values
   let colors = $derived(colorMap[iconColorClass] ?? colorMap.emerald);
 
   type SortColumn = 'commonName' | 'scientificName';
@@ -164,7 +165,9 @@
   function handleKeydown(e: KeyboardEvent) {
     if (e.key === 'Enter') {
       e.preventDefault();
+      // eslint-disable-next-line security/detect-object-injection -- selectedPredictionIndex is a numeric index managed by keyboard navigation
       if (selectedPredictionIndex >= 0 && filteredPredictions[selectedPredictionIndex]) {
+        // eslint-disable-next-line security/detect-object-injection -- same numeric index, bounds-checked above
         selectPrediction(filteredPredictions[selectedPredictionIndex]);
       } else {
         handleAdd();

--- a/frontend/src/lib/desktop/features/settings/pages/IntegrationSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/IntegrationSettingsPage.svelte
@@ -76,6 +76,7 @@
     const redacted = Object.assign({}, obj) as Record<string, unknown>;
     for (const field of fields) {
       if (field in redacted) {
+        // eslint-disable-next-line security/detect-object-injection -- field is from a hardcoded allowlist of field names
         redacted[field] = redacted[field] ? REDACTED : '';
       }
     }

--- a/frontend/src/lib/desktop/features/settings/pages/NotificationsSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/NotificationsSettingsPage.svelte
@@ -291,6 +291,7 @@
 
   let templateFields = $derived(
     templateFieldKeys.map(key => ({
+      // eslint-disable-next-line security/detect-object-injection -- key iterates over templateFieldKeys, a hardcoded string array
       name: templateFieldNames[key],
       description: t(`settings.notifications.templates.fields.${key}`),
     }))
@@ -305,6 +306,7 @@
   let isServiceFormValid = $derived.by(() => {
     switch (selectedService) {
       case 'discord':
+        // eslint-disable-next-line security/detect-unsafe-regex -- no nested quantifiers; each segment is bounded by literal anchors
         return /^https?:\/\/(?:\w+\.)?discord\.com\/api\/webhooks\/\d+\/[A-Za-z0-9_-]+$/.test(
           serviceFormData.discordWebhookUrl
         );
@@ -1250,6 +1252,7 @@
       system: Cpu,
       integration: Globe,
     };
+    // eslint-disable-next-line security/detect-object-injection -- typeName is from a controlled set of object type strings
     return icons[typeName] ?? Cpu;
   }
 
@@ -1274,6 +1277,7 @@
       },
     };
     return (
+      // eslint-disable-next-line security/detect-object-injection -- typeName is from a controlled set of object type strings
       colors[typeName] ?? {
         bg: 'bg-[var(--color-base-300)]',
         text: 'text-[var(--color-base-content)]',

--- a/frontend/src/lib/desktop/features/system/TerminalPage.svelte
+++ b/frontend/src/lib/desktop/features/system/TerminalPage.svelte
@@ -13,6 +13,7 @@
 -->
 <script lang="ts">
   /* global WebSocket, ResizeObserver, Element */
+  /* eslint-disable security/detect-object-injection -- theme lookups use controlled TerminalThemeId keys */
   import { Terminal } from '@xterm/xterm';
   import { FitAddon } from '@xterm/addon-fit';
   import { t } from '$lib/i18n';

--- a/frontend/src/lib/desktop/features/wizard/steps/AudioSourceStep.svelte
+++ b/frontend/src/lib/desktop/features/wizard/steps/AudioSourceStep.svelte
@@ -116,9 +116,9 @@
 
 <div class="space-y-5">
   <div>
-    <label class="mb-2 block text-sm font-medium text-[var(--color-base-content)]">
+    <span class="mb-2 block text-sm font-medium text-[var(--color-base-content)]">
       {t('wizard.steps.audioSource.sourceTypeLabel')}
-    </label>
+    </span>
     <div
       class="grid grid-cols-2 gap-3"
       role="radiogroup"
@@ -160,7 +160,10 @@
 
   {#if sourceType === 'soundcard'}
     <div>
-      <label class="mb-1 block text-sm font-medium text-[var(--color-base-content)]">
+      <label
+        for="wizard-audio-device"
+        class="mb-1 block text-sm font-medium text-[var(--color-base-content)]"
+      >
         {t('wizard.steps.audioSource.deviceLabel')}
       </label>
       {#if devicesLoading}
@@ -173,6 +176,7 @@
         </p>
       {:else}
         <SelectDropdown
+          id="wizard-audio-device"
           options={devices}
           value={selectedDevice}
           searchable={true}
@@ -184,13 +188,17 @@
 
   {#if sourceType === 'rtsp'}
     <div>
-      <label class="mb-1 block text-sm font-medium text-[var(--color-base-content)]">
+      <label
+        for="wizard-rtsp-url"
+        class="mb-1 block text-sm font-medium text-[var(--color-base-content)]"
+      >
         {t('wizard.steps.audioSource.rtspUrlLabel')}
       </label>
       <p class="mb-2 text-xs text-[var(--color-base-content)] opacity-60">
         {t('wizard.steps.audioSource.rtspUrlHelp')}
       </p>
       <TextInput
+        id="wizard-rtsp-url"
         bind:value={rtspUrl}
         placeholder={t('wizard.steps.audioSource.rtspUrlPlaceholder')}
         oninput={() => {

--- a/frontend/src/lib/desktop/features/wizard/steps/LocationLanguageStep.svelte
+++ b/frontend/src/lib/desktop/features/wizard/steps/LocationLanguageStep.svelte
@@ -97,23 +97,30 @@
 
 <div class="space-y-5">
   <div>
-    <label class="mb-1 block text-sm font-medium text-[var(--color-base-content)]">
+    <label
+      for="wizard-ui-language"
+      class="mb-1 block text-sm font-medium text-[var(--color-base-content)]"
+    >
       {t('wizard.steps.locationLanguage.uiLanguageLabel')}
     </label>
     <p class="mb-2 text-xs text-[var(--color-base-content)] opacity-60">
       {t('wizard.steps.locationLanguage.uiLanguageHelp')}
     </p>
-    <LanguageSelector />
+    <LanguageSelector id="wizard-ui-language" />
   </div>
 
   <div>
-    <label class="mb-1 block text-sm font-medium text-[var(--color-base-content)]">
+    <label
+      for="wizard-species-locale"
+      class="mb-1 block text-sm font-medium text-[var(--color-base-content)]"
+    >
       {t('wizard.steps.locationLanguage.speciesLanguageLabel')}
     </label>
     <p class="mb-2 text-xs text-[var(--color-base-content)] opacity-60">
       {t('wizard.steps.locationLanguage.speciesLanguageHelp')}
     </p>
     <SelectDropdown
+      id="wizard-species-locale"
       options={localeOptions}
       value={speciesLocale}
       searchable={true}
@@ -130,9 +137,9 @@
   <div>
     <div class="mb-2 flex items-center justify-between">
       <div>
-        <label class="block text-sm font-medium text-[var(--color-base-content)]">
+        <span class="block text-sm font-medium text-[var(--color-base-content)]">
           {t('wizard.steps.locationLanguage.locationLabel')}
-        </label>
+        </span>
         <p class="text-xs text-[var(--color-base-content)] opacity-60">
           {t('wizard.steps.locationLanguage.locationHelp')}
         </p>

--- a/frontend/src/lib/desktop/features/wizard/wizardState.svelte.ts
+++ b/frontend/src/lib/desktop/features/wizard/wizardState.svelte.ts
@@ -14,6 +14,7 @@ let previousVersion = $state<string | null>(null);
 let currentVersion = $state<string | null>(null);
 
 const totalSteps = $derived(steps.length);
+// eslint-disable-next-line security/detect-object-injection -- currentStepIndex is a numeric index bounded by steps.length
 const currentStep = $derived(steps[currentStepIndex] ?? null);
 const isFirstStep = $derived(currentStepIndex === 0);
 const isLastStep = $derived(currentStepIndex === totalSteps - 1);

--- a/frontend/src/lib/desktop/layouts/DesktopSidebar.svelte
+++ b/frontend/src/lib/desktop/layouts/DesktopSidebar.svelte
@@ -106,6 +106,7 @@ Performance Optimizations:
 
   // Logo variant: solid uses flat color, gradient uses per-scheme handcrafted gradient
   let logoVariant: LogoVariant = $derived(
+    // eslint-disable-next-line security/detect-object-injection -- $scheme is a controlled color scheme identifier
     $logoStyle === 'solid' ? 'solid' : (SCHEME_GRADIENT_MAP[$scheme] ?? 'scheme')
   );
 

--- a/frontend/src/lib/utils/formatters.ts
+++ b/frontend/src/lib/utils/formatters.ts
@@ -100,6 +100,7 @@ export function formatBytesCompact(bytes: number): string {
   const units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB'];
   const i = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
   const value = bytes / Math.pow(1024, i);
+  // eslint-disable-next-line security/detect-object-injection -- i is a computed numeric index clamped to units.length
   return `${value < 10 ? value.toFixed(1) : Math.round(value)} ${units[i]}`;
 }
 

--- a/frontend/src/test/reverse-proxy-global-setup.ts
+++ b/frontend/src/test/reverse-proxy-global-setup.ts
@@ -86,6 +86,7 @@ function startNginxContainer(
   backendHost: string
 ): string {
   // Read and template the config
+  // eslint-disable-next-line security/detect-non-literal-fs-filename -- configPath is a hardcoded test fixture path
   let config = readFileSync(configPath, 'utf-8');
   config = config.replace(/BACKEND_HOST/g, backendHost);
   config = config.replace(/BACKEND_PORT/g, String(BACKEND_PORT));
@@ -95,6 +96,7 @@ function startNginxContainer(
     throw new Error('tmpDir not initialized');
   }
   const templatedPath = join(tmpDir, `${name}.conf`);
+  // eslint-disable-next-line security/detect-non-literal-fs-filename -- templatedPath is constructed from a controlled temp directory and test name
   writeFileSync(templatedPath, config);
 
   // Remove stale container from a previous crashed run (ignore errors if absent)

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -36,6 +36,7 @@ if (
     },
     key(index: number): string | null {
       const keys = [...store.keys()];
+      // eslint-disable-next-line security/detect-object-injection -- index is a numeric parameter from the Storage.key() API
       return keys[index] ?? null;
     },
   };

--- a/frontend/tests/e2e/dashboard/spectrogram-regression.spec.ts
+++ b/frontend/tests/e2e/dashboard/spectrogram-regression.spec.ts
@@ -214,7 +214,7 @@ test.describe('MiniSpectrogram — Effect Loop Regression', () => {
           '.col-span-12 h3, section h3, [class*="card"] h3'
         );
         return Array.from(headings)
-          .map(h => h.textContent?.trim())
+          .map(h => h.textContent.trim())
           .filter(Boolean);
       });
     };
@@ -223,6 +223,7 @@ test.describe('MiniSpectrogram — Effect Loop Regression', () => {
 
     // Skip if no cards found (backend might not serve layout config in CI)
     if (initialOrder.length === 0) {
+      // eslint-disable-next-line playwright/no-skipped-test -- intentionally skipped
       test.skip(true, 'No dashboard cards found — backend may not serve layout config');
       return;
     }


### PR DESCRIPTION
## Summary

- Fix 1 ESLint error: unnecessary optional chain in e2e spectrogram test
- Suppress 43 `security/detect-object-injection` warnings with inline disable comments and justifications
- Fix 6 svelte-check `a11y_label_has_associated_control` warnings in wizard step components by adding `for`/`id` associations and converting group labels to `<span>`
- Add `id` prop passthrough to `LanguageSelector` component
- Suppress 1 `detect-unsafe-regex`, 2 `detect-non-literal-fs-filename`, and 1 `playwright/no-skipped-test` warning

Result: `npm run check:all` passes with 0 errors, 0 warnings.

## Test Plan
- [x] `npm run check:all` passes clean (0 errors, 0 warnings)
- [x] `npx svelte-check` passes clean (0 errors, 0 warnings)
- [ ] CI checks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced form accessibility in the wizard with explicit label-for associations linking labels to audio device, RTSP URL, language, and species locale inputs.
  * Added optional ID support to the language selector component.

* **Bug Fixes**
  * Fixed potential null reference in dashboard test scenario.

* **Chores**
  * Updated ESLint suppression directives across components and utilities for improved linting configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->