### PR TITLE
feat(spectrogram): add HLS streaming debug diagnostics for audio gap analysis

### DIFF
--- a/frontend/src/lib/desktop/features/live-stream/pages/LiveStreamPage.svelte
+++ b/frontend/src/lib/desktop/features/live-stream/pages/LiveStreamPage.svelte
@@ -203,6 +203,7 @@
         });
       });
       audioElement.addEventListener('stalled', () => {
+        hasStalled = true;
         logger.warn('Audio element: stalled (network stall)', {
           currentTime: audioElement?.currentTime?.toFixed(3),
           buffered: describeBuffered(audioElement),

--- a/internal/api/v2/audio_hls.go
+++ b/internal/api/v2/audio_hls.go
@@ -1388,14 +1388,22 @@ func (c *Controller) feedAudioToFFmpeg(ctx context.Context, sourceID, pipePath s
 	var totalWrites int64
 	var slowWrites int64
 	var maxWriteDuration time.Duration
+	var lastSlowWriteLog time.Time
+
+	// Always log exit stats regardless of how the feed stops
+	defer func() {
+		GetLogger().Debug("Audio feed stats on exit",
+			logger.String("source_id", sanitizedID),
+			logger.Int64("total_fifo_writes", totalWrites),
+			logger.Int64("slow_fifo_writes", slowWrites),
+			logger.String("max_write_duration", maxWriteDuration.String()))
+	}()
+
 	for {
 		select {
 		case <-ctx.Done():
 			GetLogger().Debug("Audio feed stopped due to context cancellation",
-				logger.String("source_id", sanitizedID),
-				logger.Int64("total_fifo_writes", totalWrites),
-				logger.Int64("slow_fifo_writes", slowWrites),
-				logger.String("max_write_duration", maxWriteDuration.String()))
+				logger.String("source_id", sanitizedID))
 			return
 		case data, ok := <-audioChan:
 			if !ok {
@@ -1422,12 +1430,18 @@ func (c *Controller) feedAudioToFFmpeg(ctx context.Context, sourceID, pipePath s
 
 			if writeDuration > fifoWriteSlowThreshold {
 				slowWrites++
-				GetLogger().Warn("Slow FIFO write detected (possible I/O stall)",
-					logger.String("source_id", sanitizedID),
-					logger.String("write_duration", writeDuration.String()),
-					logger.Int("data_bytes", len(data)),
-					logger.Int64("slow_writes_total", slowWrites),
-					logger.Int64("total_writes", totalWrites))
+				// Rate-limit slow write warnings to avoid spamming logs
+				// during sustained I/O stalls (which would worsen the problem)
+				now := time.Now()
+				if now.Sub(lastSlowWriteLog) >= hlsDropLogInterval {
+					lastSlowWriteLog = now
+					GetLogger().Warn("Slow FIFO write detected (possible I/O stall)",
+						logger.String("source_id", sanitizedID),
+						logger.String("write_duration", writeDuration.String()),
+						logger.Int("data_bytes", len(data)),
+						logger.Int64("slow_writes_total", slowWrites),
+						logger.Int64("total_writes", totalWrites))
+				}
 			}
 
 			if !dataWritten {
@@ -1686,6 +1700,9 @@ func cleanupStreamTrackingData(sourceID string) {
 		return strings.HasPrefix(key, prefix)
 	})
 	hlsMgr.activityMu.Unlock()
+
+	// Clean up freshness check timestamp
+	lastFreshnessCheck.Delete(sourceID)
 }
 
 // waitForHLSPlaylist waits for the playlist file to be ready


### PR DESCRIPTION
## Summary

Adds comprehensive debug logging across the HLS audio streaming pipeline to diagnose intermittent audio gaps reported on Raspberry Pi 5 with SD card storage. The diagnostics cover every stage of the pipeline: audio callback → FIFO pipe → FFmpeg → segment files → HTTP serving → HLS.js → browser audio element.

### Backend (Go) — `internal/api/v2/audio_hls.go`
- **FIFO write timing**: warns when pipe writes exceed 100ms (indicates FFmpeg blocked on I/O)
- **Audio callback drop counting**: rate-limited logging when the audio channel is full and data is dropped
- **Segment freshness checking**: warns when newest segment file is older than 3× segment length (indicates FFmpeg stalled)
- **Serve duration timing**: measures playlist and segment file serving time (covers disk read + network write)
- **Feed shutdown stats**: logs total writes, slow writes, and max write duration when stream ends

### Frontend (Svelte) — `LiveStreamPage.svelte`
- **Fragment download timing**: warns when HLS fragment download exceeds 2s
- **Buffer health monitor**: 10s interval logging of buffer state, warns on degraded conditions (buffer < 2s or holes)
- **Buffer range visualization**: all stall/error events now include full buffered time ranges
- **Playback stall detection**: detects when `currentTime` stops advancing
- **Stall recovery tracking**: correlates `waiting` → `playing` events
- **HLS.js buffer stall categorization**: distinguishes `bufferStalledError`, `bufferNudgeOnStall`, `bufferSeekOverHole`

### Diagnostic correlation patterns
| Backend log | Frontend log | Likely cause |
|---|---|---|
| Slow FIFO write | — | FFmpeg blocked on SD card write |
| Stale segments | Slow fragment download | SD card write stall |
| Slow segment serve | Slow fragment download | SD card read stall |
| Audio data dropped | Buffer running low | Pipeline backpressure |

## Test Plan
- [ ] Start live spectrogram stream, observe browser console for periodic buffer health logs
- [ ] Monitor backend logs for FIFO write timing and segment freshness warnings
- [ ] Verify no new warnings appear during normal operation on fast storage
- [ ] Test on Raspberry Pi 5 with SD card to capture diagnostic evidence of gaps

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved HLS streaming diagnostics: fragment download timing, buffer-health snapshots, and playback stall detection.
  * Enhanced audio performance telemetry: slow write and callback-drop metrics with rate-limited warnings to surface bottlenecks.
  * Segment freshness checking with per-source rate limiting to detect and warn about stale segments, improving stream reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->