### PR TITLE
feat: sync spectrogram labels with HLS playhead via program_date_time

### DIFF
--- a/frontend/src/lib/desktop/components/media/SpectrogramCanvas.svelte
+++ b/frontend/src/lib/desktop/components/media/SpectrogramCanvas.svelte
@@ -18,6 +18,8 @@
   import { loggers } from '$lib/utils/logger';
 
   const logger = loggers.audio;
+  /** Interval between debug time markers on the waterfall (seconds) */
+  const DEBUG_MARKER_INTERVAL_SEC = 5;
 
   interface Props {
     /** AnalyserNode to read frequency data from */
@@ -39,9 +41,19 @@
     /** Additional CSS classes for the container */
     className?: string;
     /** Detection labels to render on the spectrogram */
-    overlayLabels?: Array<{ text: string; birthTime: number; ySlot: number }>;
+    overlayLabels?: Array<{
+      text: string;
+      birthTime: number;
+      ySlot: number;
+      firstDetected?: number;
+      promotionDelta?: number;
+    }>;
     /** Font size for overlay labels in CSS pixels (default: 11) */
     overlayFontSize?: number;
+    /** Enable debug overlay: time markers + label timestamps */
+    debug?: boolean;
+    /** Current wall-clock time at playhead (Unix seconds) — used for debug time markers */
+    wallClockAtPlayhead?: number;
   }
 
   let {
@@ -56,6 +68,8 @@
     className = '',
     overlayLabels = [],
     overlayFontSize = 11,
+    debug = false,
+    wallClockAtPlayhead = 0,
   }: Props = $props();
 
   let canvasEl: HTMLCanvasElement | undefined = $state();
@@ -222,6 +236,31 @@
     // Convert CSS px/s to device px/s
     const deviceScrollSpeed = scrollSpeed * dpr;
 
+    // Debug overlay: cache formatted time strings to avoid toLocaleTimeString() per frame.
+    // toLocaleTimeString invokes the Intl API which is expensive at 60fps.
+    const timeFormatCache = new Map<number, string>();
+    let lastCacheClearSec = 0;
+    function formatTimeCached(unixSeconds: number): string {
+      const intSec = Math.floor(unixSeconds);
+      let str = timeFormatCache.get(intSec);
+      if (str === undefined) {
+        str = new Date(intSec * 1000).toLocaleTimeString('en-GB', {
+          hour: '2-digit',
+          minute: '2-digit',
+          second: '2-digit',
+        });
+        timeFormatCache.set(intSec, str);
+      }
+      // Evict old entries every 30 seconds to prevent unbounded growth
+      if (intSec - lastCacheClearSec > 30) {
+        for (const key of timeFormatCache.keys()) {
+          if (key < intSec - 120) timeFormatCache.delete(key);
+        }
+        lastCacheClearSec = intSec;
+      }
+      return str;
+    }
+
     const loop = () => {
       const now = performance.now();
       const deltaTime = (now - lastFrameTime) / 1000;
@@ -262,31 +301,110 @@
         ctx.putImageData(imgData, w - pixelsToScroll, 0);
       }
 
-      // --- Overlay detection labels on separate canvas (avoids self-blit smearing) ---
-      if (olCtx && overlayLabels.length > 0) {
+      // --- Overlay: detection labels + debug time markers ---
+      const hasOverlayContent = overlayLabels.length > 0 || debug;
+
+      if (olCtx && hasOverlayContent) {
         olCtx.clearRect(0, 0, deviceWidth, deviceHeight);
 
-        // Re-apply styles every frame (canvas state can be lost on resize)
-        olCtx.font = `bold ${fontSize}px sans-serif`;
-        olCtx.fillStyle = '#ffffff';
-        olCtx.shadowColor = 'rgba(0, 0, 0, 0.8)';
-        olCtx.shadowBlur = 3 * dpr;
-        olCtx.shadowOffsetX = 1 * dpr;
-        olCtx.shadowOffsetY = 1 * dpr;
-        olCtx.textBaseline = 'middle';
+        // --- Debug time markers: vertical lines every 5s with HH:MM:SS ---
+        if (debug && wallClockAtPlayhead > 0) {
+          const debugFontSize = Math.round(9 * dpr);
+          const visibleSeconds = deviceWidth / deviceScrollSpeed;
 
-        const maxSlots = Math.max(2, Math.floor(deviceHeight / (fontSize * 2.5)));
+          // Draw markers from right edge backwards
+          // Right edge = wallClockAtPlayhead, left edge = wallClockAtPlayhead - visibleSeconds
+          const rightEdgeTime = wallClockAtPlayhead;
+          // Find the nearest 5-second boundary at or before the right edge
+          const firstMarker =
+            Math.floor(rightEdgeTime / DEBUG_MARKER_INTERVAL_SEC) * DEBUG_MARKER_INTERVAL_SEC;
 
-        for (const label of overlayLabels) {
-          const labelAge = (now - label.birthTime) / 1000;
-          const x = deviceWidth - labelAge * deviceScrollSpeed;
+          olCtx.save();
+          olCtx.shadowColor = 'transparent';
+          olCtx.shadowBlur = 0;
+          olCtx.shadowOffsetX = 0;
+          olCtx.shadowOffsetY = 0;
 
-          if (x < -200 * dpr || x > deviceWidth) continue;
+          for (
+            let t = firstMarker;
+            t > rightEdgeTime - visibleSeconds - DEBUG_MARKER_INTERVAL_SEC;
+            t -= DEBUG_MARKER_INTERVAL_SEC
+          ) {
+            const ageSeconds = rightEdgeTime - t;
+            const x = deviceWidth - ageSeconds * deviceScrollSpeed;
+            if (x < 0 || x > deviceWidth) continue;
 
-          const slotHeight = deviceHeight / (maxSlots + 1);
-          const y = slotHeight * (1 + (label.ySlot % maxSlots));
+            // Vertical dashed line
+            olCtx.strokeStyle = 'rgba(255, 255, 0, 0.4)';
+            olCtx.lineWidth = 1 * dpr;
+            olCtx.setLineDash([4 * dpr, 4 * dpr]);
+            olCtx.beginPath();
+            olCtx.moveTo(x, 0);
+            olCtx.lineTo(x, deviceHeight);
+            olCtx.stroke();
+            olCtx.setLineDash([]);
 
-          olCtx.fillText(label.text, x, y);
+            // Time label at bottom
+            const timeStr = formatTimeCached(t);
+            olCtx.font = `${debugFontSize}px monospace`;
+            olCtx.fillStyle = 'rgba(255, 255, 0, 0.8)';
+            olCtx.textBaseline = 'bottom';
+            olCtx.fillText(timeStr, x + 2 * dpr, deviceHeight - 2 * dpr);
+          }
+
+          // Debug info panel (top-left corner)
+          olCtx.font = `${debugFontSize}px monospace`;
+          olCtx.fillStyle = 'rgba(255, 255, 0, 0.9)';
+          olCtx.textBaseline = 'top';
+          const playheadStr = formatTimeCached(wallClockAtPlayhead);
+          const nowStr = formatTimeCached(Date.now() / 1000);
+          const hlsDelay = (Date.now() / 1000 - wallClockAtPlayhead).toFixed(1);
+          olCtx.fillText(`playhead: ${playheadStr}`, 4 * dpr, 4 * dpr);
+          olCtx.fillText(
+            `wall: ${nowStr}  HLS lag: ${hlsDelay}s`,
+            4 * dpr,
+            4 * dpr + debugFontSize + 2 * dpr
+          );
+          olCtx.fillText(
+            `queue: ${overlayLabels.length} labels`,
+            4 * dpr,
+            4 * dpr + (debugFontSize + 2 * dpr) * 2
+          );
+
+          olCtx.restore();
+        }
+
+        // --- Detection labels ---
+        if (overlayLabels.length > 0) {
+          // Re-apply styles every frame (canvas state can be lost on resize)
+          olCtx.font = `bold ${fontSize}px sans-serif`;
+          olCtx.fillStyle = '#ffffff';
+          olCtx.shadowColor = 'rgba(0, 0, 0, 0.8)';
+          olCtx.shadowBlur = 3 * dpr;
+          olCtx.shadowOffsetX = 1 * dpr;
+          olCtx.shadowOffsetY = 1 * dpr;
+          olCtx.textBaseline = 'middle';
+
+          const maxSlots = Math.max(2, Math.floor(deviceHeight / (fontSize * 2.5)));
+
+          for (const label of overlayLabels) {
+            const labelAge = (now - label.birthTime) / 1000;
+            const x = deviceWidth - labelAge * deviceScrollSpeed;
+
+            if (x < -200 * dpr || x > deviceWidth) continue;
+
+            const slotHeight = deviceHeight / (maxSlots + 1);
+            const y = slotHeight * (1 + (label.ySlot % maxSlots));
+
+            if (debug && label.firstDetected) {
+              // Debug: show species name + firstDetected time + frozen promotion offset
+              const detStr = formatTimeCached(label.firstDetected);
+              const delta = label.promotionDelta?.toFixed(1) ?? '?';
+              olCtx.fillText(`${label.text} [${detStr} \u0394${delta}s]`, x, y);
+            } else {
+              olCtx.fillText(label.text, x, y);
+            }
+          }
         }
         overlayHadContent = true;
       } else if (olCtx && overlayHadContent) {

--- a/frontend/src/lib/desktop/features/live-stream/pages/LiveStreamPage.svelte
+++ b/frontend/src/lib/desktop/features/live-stream/pages/LiveStreamPage.svelte
@@ -40,6 +40,10 @@
   const logger = loggers.audio;
   const FFT_SIZE = 1024;
   const HEARTBEAT_INTERVAL = 20000;
+  /** How often (ms) to poll for label promotion and pruning */
+  const LABEL_POLL_INTERVAL_MS = 200;
+  /** Maximum label age (ms) before pruning from overlay */
+  const LABEL_MAX_AGE_MS = 60000;
 
   const sessionId = generateSessionId();
 
@@ -70,15 +74,14 @@
 
   // Detection overlay state
   let showDetectionLabels = $state(true);
+  let debugOverlay = $state(false);
   let overlayLabels = $state<OverlayLabel[]>([]);
   let labelQueue: QueuedLabel[] = [];
   let prevSnapshot: PendingDetection[] = [];
   let lastSeenSpecies = new Map<string, number>();
   let slotCounter = 0;
-  let streamEpochMs = $state(0);
-  let epochOffset = 0;
-  let epochOffsetCalibrated = false;
   let detectionEventSource: ReconnectingEventSource | null = null;
+  let currentWallClockAtPlayhead = $state(0);
   const MAX_OVERLAY_SLOTS = 7;
 
   // Internal state
@@ -174,7 +177,6 @@
         stream_token: string;
         playlist_url: string;
         playlist_ready: boolean;
-        stream_epoch?: string;
       }>(`/api/v2/streams/hls/${encodedSourceId}/start`, {
         method: 'POST',
         signal,
@@ -184,9 +186,6 @@
       if (signal.aborted) return;
 
       activeStreamToken = data.stream_token;
-      if (data.stream_epoch) {
-        streamEpochMs = new Date(data.stream_epoch).getTime();
-      }
       const hlsUrl = buildAppUrl(data.playlist_url);
 
       // Create audio element
@@ -512,9 +511,7 @@
 
     stopHeartbeat();
     disconnectDetectionStream();
-    streamEpochMs = 0;
-    epochOffset = 0;
-    epochOffsetCalibrated = false;
+    currentWallClockAtPlayhead = 0;
     spectro.disconnect();
 
     if (hls) {
@@ -592,6 +589,23 @@
     };
     document.addEventListener('fullscreenchange', handler);
     return () => document.removeEventListener('fullscreenchange', handler);
+  });
+
+  // Toggle debug overlay with D key
+  $effect(() => {
+    const handler = (e: KeyboardEvent) => {
+      // Ignore if any modifier key is held (browser shortcuts like Ctrl+D)
+      if (e.ctrlKey || e.metaKey || e.altKey) return;
+      if (e.key === 'd' || e.key === 'D') {
+        // Ignore if typing in an input/textarea
+        const tag = (e.target as HTMLElement)?.tagName;
+        if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
+        debugOverlay = !debugOverlay;
+        logger.info('Debug overlay', { enabled: debugOverlay });
+      }
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
   });
 
   // No auto-start — browsers block AudioContext and audio.play() without a
@@ -674,27 +688,27 @@
 
   // Promote queued detection labels when playhead catches up
   $effect(() => {
-    if (!audioElement || !streamEpochMs) return;
+    if (!audioElement || !hls) return;
 
     const interval = globalThis.setInterval(() => {
-      if (!audioElement || !streamEpochMs) return;
+      if (!audioElement || !hls) return;
 
-      // Calibrate epoch offset once when playback begins.
-      // streamEpoch is set at stream creation (before FFmpeg starts), so
-      // streamEpoch + currentTime lags behind real wall-clock by the FFmpeg
-      // startup delay. hls.latency bridges this gap.
-      if (!epochOffsetCalibrated && audioElement.currentTime > 0) {
-        const rawWallClock = streamEpochMs / 1000 + audioElement.currentTime;
-        const latency = hls ? hls.latency : 6;
-        epochOffset = Date.now() / 1000 - latency - rawWallClock;
-        epochOffsetCalibrated = true;
+      const now = globalThis.performance.now();
+      const nowUnix = Date.now() / 1000;
+
+      // Get wall-clock time at playhead from HLS program date time tags.
+      // FFmpeg embeds #EXT-X-PROGRAM-DATE-TIME in the playlist; hls.js
+      // interpolates the exact Date for the current playback position.
+      const playingDate = hls.playingDate;
+      const wallClockAtPlayhead = playingDate ? playingDate.getTime() / 1000 : 0;
+
+      // Update reactive state for debug display in SpectrogramCanvas
+      if (wallClockAtPlayhead > 0) {
+        currentWallClockAtPlayhead = wallClockAtPlayhead;
       }
 
-      const wallClockAtPlayhead = streamEpochMs / 1000 + audioElement.currentTime + epochOffset;
-      const now = globalThis.performance.now();
-
-      // Promote queued labels when playhead catches up
-      if (labelQueue.length > 0) {
+      // Promote queued labels when playhead is available
+      if (wallClockAtPlayhead > 0 && labelQueue.length > 0) {
         const { promoted, remaining } = promoteFromQueue(labelQueue, wallClockAtPlayhead, now);
         if (promoted.length > 0) {
           labelQueue = remaining;
@@ -705,31 +719,37 @@
       // Generate repeat labels for species still actively detected.
       // Use wall-clock time (not playhead time) for dedup tracking so it stays
       // consistent with the SSE handler which also uses Date.now().
-      const nowUnix = Date.now() / 1000;
       const repeats = getRepeatLabels(prevSnapshot, activeSourceId ?? '', lastSeenSpecies, nowUnix);
       if (repeats.length > 0) {
-        const newLabels: Array<{ text: string; birthTime: number; ySlot: number }> = [];
+        const newLabels: OverlayLabel[] = [];
         for (const rep of repeats) {
           lastSeenSpecies.set(rep.species, nowUnix);
           const { slot, next } = nextYSlot(slotCounter, MAX_OVERLAY_SLOTS);
           slotCounter = next;
-          newLabels.push({ text: rep.species, birthTime: now, ySlot: slot });
+          newLabels.push({
+            text: rep.species,
+            birthTime: now,
+            ySlot: slot,
+            firstDetected: rep.firstDetected,
+            promotionDelta: 0, // Repeat labels are created at current time, no delay
+          });
         }
         overlayLabels = [...overlayLabels, ...newLabels];
       }
 
-      // Prune labels older than 60 seconds
-      const cutoff = now - 60000;
+      // Prune labels older than LABEL_MAX_AGE_MS — runs regardless of playingDate
+      // availability so labels don't freeze on screen during buffer stalls
+      const cutoff = now - LABEL_MAX_AGE_MS;
       overlayLabels = overlayLabels.filter(l => l.birthTime >= cutoff);
 
-      // Prune stale dedup entries (older than 10s in media time — generous
-      // buffer beyond the 6s dedup window in shouldDedup)
+      // Prune stale dedup entries using client wall-clock time (consistent
+      // with SSE handler which also uses Date.now() for dedup tracking)
       for (const [species, time] of lastSeenSpecies) {
-        if (wallClockAtPlayhead - time > STALE_DEDUP_PRUNE_SECONDS) {
+        if (nowUnix - time > STALE_DEDUP_PRUNE_SECONDS) {
           lastSeenSpecies.delete(species);
         }
       }
-    }, 200);
+    }, LABEL_POLL_INTERVAL_MS);
 
     return () => globalThis.clearInterval(interval);
   });
@@ -826,6 +846,8 @@
           {colorMap}
           isActive={spectro.isActive}
           overlayLabels={showDetectionLabels ? overlayLabels : []}
+          debug={debugOverlay}
+          wallClockAtPlayhead={currentWallClockAtPlayhead}
           className="h-full w-full"
         />
       {:else}

--- a/frontend/src/lib/utils/detectionOverlay.test.ts
+++ b/frontend/src/lib/utils/detectionOverlay.test.ts
@@ -130,9 +130,21 @@ describe('promoteFromQueue', () => {
     const { promoted, remaining } = promoteFromQueue(queue, 105, 50000);
     expect(promoted).toHaveLength(1);
     expect(promoted[0].text).toBe('Blue Tit');
-    expect(promoted[0].birthTime).toBe(50000);
+    // birthTime is back-dated by (wallClockAtPlayhead - firstDetected) = (105 - 100) = 5s = 5000ms
+    expect(promoted[0].birthTime).toBe(50000 - 5000);
+    expect(promoted[0].firstDetected).toBe(100);
+    expect(promoted[0].promotionDelta).toBe(5);
     expect(remaining).toHaveLength(1);
     expect(remaining[0].text).toBe('Great Tit');
+  });
+
+  it('promotes with exact birthTime when playhead equals firstDetected', () => {
+    const queue: QueuedLabel[] = [{ text: 'Blue Tit', firstDetected: 100, ySlot: 0 }];
+    const { promoted } = promoteFromQueue(queue, 100, 50000);
+    expect(promoted).toHaveLength(1);
+    // No back-dating when playhead == firstDetected
+    expect(promoted[0].birthTime).toBe(50000);
+    expect(promoted[0].promotionDelta).toBe(0);
   });
 
   it('promotes nothing when playhead is behind all labels', () => {

--- a/frontend/src/lib/utils/detectionOverlay.ts
+++ b/frontend/src/lib/utils/detectionOverlay.ts
@@ -16,6 +16,8 @@ export interface OverlayLabel {
   text: string;
   birthTime: number; // performance.now() when promoted
   ySlot: number;
+  firstDetected?: number; // Unix seconds — original detection time (for debug display)
+  promotionDelta?: number; // seconds — frozen offset at promotion (wallClock - firstDetected)
 }
 
 /** Minimal pending detection shape for diffing. */
@@ -88,10 +90,15 @@ export function promoteFromQueue(
 
   for (const label of queue) {
     if (wallClockAtPlayheadUnix >= label.firstDetected) {
+      // Back-date birthTime so the label appears at the waterfall position
+      // corresponding to firstDetected, not at the right edge.
+      const ageOffsetSec = Math.max(0, wallClockAtPlayheadUnix - label.firstDetected);
       promoted.push({
         text: label.text,
-        birthTime: performanceNow,
+        birthTime: performanceNow - ageOffsetSec * 1000,
         ySlot: label.ySlot,
+        firstDetected: label.firstDetected,
+        promotionDelta: ageOffsetSec,
       });
     } else {
       remaining.push(label);

--- a/internal/api/v2/audio_hls.go
+++ b/internal/api/v2/audio_hls.go
@@ -1161,7 +1161,7 @@ func (c *Controller) buildFFmpegArgs(inputSource, outputDir, playlistPath string
 		"-f", "hls",
 		"-hls_time", fmt.Sprintf("%d", segmentLength),
 		"-hls_list_size", strconv.Itoa(hlsListSize),
-		"-hls_flags", "delete_segments+temp_file",
+		"-hls_flags", "delete_segments+temp_file+program_date_time",
 		"-hls_segment_type", "fmp4",
 		"-hls_fmp4_init_filename", "init.mp4",
 		"-hls_init_time", fmt.Sprintf("%d", segmentLength),


### PR DESCRIPTION
## Summary

- Add `program_date_time` to FFmpeg HLS flags so each segment gets a `#EXT-X-PROGRAM-DATE-TIME` tag with accurate wall-clock time
- Replace the old `streamEpoch + currentTime + epochOffset` calibration with `hls.playingDate` — a single getter that returns the exact playback position as a `Date`
- Back-date label `birthTime` by `wallClockAtPlayhead - firstDetected` so labels appear at the correct waterfall position instead of always at the right edge
- Add debug overlay (press **D** on Live Audio page) showing time markers, playhead/wall clock info, HLS lag, and per-label promotion delta

### Why

Detection labels were appearing ~20 seconds offset from their actual audio events on the waterfall. The root cause was inaccurate HLS playhead timing — `streamEpoch` was set before FFmpeg started, and the one-shot `hls.latency` calibration was imprecise. With `program_date_time`, FFmpeg embeds wall-clock timestamps directly in the playlist, and hls.js interpolates the exact time for any playback position.

### Review findings addressed

- Cache `toLocaleTimeString()` calls in RAF loop via `formatTimeCached()` to avoid Intl API overhead at 60fps
- Fix `lastSeenSpecies` pruning to use client wall-clock (`Date.now()`) consistently instead of mixing with `wallClockAtPlayhead` (different clock domain)
- Restructure interval so label pruning runs even when `hls.playingDate` is temporarily null (buffer stalls)
- Remove dead `stream_epoch` from response type
- Extract magic numbers to named constants (`LABEL_POLL_INTERVAL_MS`, `LABEL_MAX_AGE_MS`, `DEBUG_MARKER_INTERVAL_SEC`)

## Potential follow-up issues

- **MiniSpectrogram (dashboard widget)** still uses the old epoch-based timing — it doesn't benefit from `program_date_time`. Already known broken (layout + lifecycle), deferred to separate PR
- **`firstDetected` is `CreatedAt` not audio capture time** — the backend sets `firstDetected` to when the pending detection was created (first inference hit), not when the audio was captured (~3s earlier). Labels are placed ~3s to the right of the actual audio event. Would require backend changes to fix
- **Native HLS (Safari)** doesn't use hls.js so `hls.playingDate` is unavailable — detection overlay won't work on Safari's native HLS path (pre-existing limitation)
- **Repeat labels bypass back-dating** — repeat labels from `getRepeatLabels()` are placed at the right edge with `birthTime: now`, not back-dated. Pre-existing pattern

## Test plan

- [x] `svelte-check` — 0 errors
- [x] `vitest` — 39 tests pass (including updated `promoteFromQueue` tests)
- [x] `eslint` — clean
- [x] Go compilation — clean
- [ ] Manual: verify debug overlay shows accurate timestamps on Live Audio page (press D)
- [ ] Manual: verify labels appear near their audio events on the waterfall
- [ ] Manual: verify with different HLS segment lengths (1s, 2s)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added debug mode toggle (D key) to display detection metadata including timestamps and timing information on the spectrogram.
  * Implemented 5-second time markers with visual indicators on the spectrogram during debug mode.

* **Improvements**
  * Enhanced timestamp accuracy for wall-clock playhead synchronization.
  * Refined overlay label lifecycle management with configurable retention periods.

* **Tests**
  * Updated test expectations to validate new label timestamp back-dating and promotion timing logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->