### PR TITLE
fix: remove frontend repeat label generation — use backend hitCount only

### DIFF
--- a/frontend/src/lib/desktop/features/dashboard/components/MiniSpectrogram.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/components/MiniSpectrogram.svelte
@@ -35,7 +35,6 @@
     shouldDedup,
     promoteFromQueue,
     nextYSlot,
-    getRepeatLabels,
     STALE_DEDUP_PRUNE_SECONDS,
   } from '$lib/utils/detectionOverlay';
 
@@ -391,7 +390,7 @@
 
   // Diff incoming pending detections and queue new labels.
   // Always update prevSnapshot — even when pendingDetections is empty — so
-  // getRepeatLabels doesn't see stale species after detections stop.
+  // stale species are cleared after detections stop.
   $effect(() => {
     if (!activeSourceId) return;
     if (pendingDetections.length > 0) {
@@ -436,22 +435,6 @@
           labelQueue = remaining;
           overlayLabels = [...overlayLabels, ...promoted];
         }
-      }
-
-      // Generate repeat labels for species still actively detected.
-      // Use wall-clock time (not playhead time) for dedup tracking so it stays
-      // consistent with the pending diff $effect which also uses Date.now().
-      const nowUnix = Date.now() / 1000;
-      const repeats = getRepeatLabels(prevSnapshot, activeSourceId ?? '', lastSeenSpecies, nowUnix);
-      if (repeats.length > 0) {
-        const newLabels: Array<{ text: string; birthTime: number; ySlot: number }> = [];
-        for (const rep of repeats) {
-          lastSeenSpecies.set(rep.species, nowUnix);
-          const { slot, next } = nextYSlot(slotCounter, MAX_OVERLAY_SLOTS);
-          slotCounter = next;
-          newLabels.push({ text: rep.species, birthTime: now, ySlot: slot });
-        }
-        overlayLabels = [...overlayLabels, ...newLabels];
       }
 
       // Prune labels older than 60 seconds

--- a/frontend/src/lib/desktop/features/live-stream/pages/LiveStreamPage.svelte
+++ b/frontend/src/lib/desktop/features/live-stream/pages/LiveStreamPage.svelte
@@ -33,7 +33,6 @@
     shouldDedup,
     promoteFromQueue,
     nextYSlot,
-    getRepeatLabels,
     STALE_DEDUP_PRUNE_SECONDS,
   } from '$lib/utils/detectionOverlay';
 
@@ -718,27 +717,6 @@
           labelQueue = remaining;
           overlayLabels = [...overlayLabels, ...promoted];
         }
-      }
-
-      // Generate repeat labels for species still actively detected.
-      // Use wall-clock time (not playhead time) for dedup tracking so it stays
-      // consistent with the SSE handler which also uses Date.now().
-      const repeats = getRepeatLabels(prevSnapshot, activeSourceId ?? '', lastSeenSpecies, nowUnix);
-      if (repeats.length > 0) {
-        const newLabels: OverlayLabel[] = [];
-        for (const rep of repeats) {
-          lastSeenSpecies.set(rep.species, nowUnix);
-          const { slot, next } = nextYSlot(slotCounter, MAX_OVERLAY_SLOTS);
-          slotCounter = next;
-          newLabels.push({
-            text: rep.species,
-            birthTime: now,
-            ySlot: slot,
-            firstDetected: rep.firstDetected,
-            promotionDelta: 0, // Repeat labels are created at current time, no delay
-          });
-        }
-        overlayLabels = [...overlayLabels, ...newLabels];
       }
 
       // Prune labels older than LABEL_MAX_AGE_MS — runs regardless of playingDate

--- a/frontend/src/lib/utils/detectionOverlay.test.ts
+++ b/frontend/src/lib/utils/detectionOverlay.test.ts
@@ -4,7 +4,6 @@ import {
   shouldDedup,
   promoteFromQueue,
   nextYSlot,
-  getRepeatLabels,
   type QueuedLabel,
 } from './detectionOverlay';
 
@@ -160,98 +159,5 @@ describe('nextYSlot', () => {
     expect(nextYSlot(0, 4)).toEqual({ slot: 0, next: 1 });
     expect(nextYSlot(1, 4)).toEqual({ slot: 1, next: 2 });
     expect(nextYSlot(4, 4)).toEqual({ slot: 0, next: 5 });
-  });
-});
-
-describe('getRepeatLabels', () => {
-  it('emits repeat label when species active for >6s since last label', () => {
-    const lastLabelled = new Map([['Blue Tit', 100]]);
-    const activePending = [
-      {
-        species: 'Blue Tit',
-        sourceID: 'src1',
-        firstDetected: 95,
-        lastUpdated: 106,
-        status: 'active' as const,
-      },
-    ];
-    const repeats = getRepeatLabels(activePending, 'src1', lastLabelled, 107);
-    expect(repeats).toHaveLength(1);
-    expect(repeats[0].species).toBe('Blue Tit');
-  });
-
-  it('does not emit when <6s since last label', () => {
-    const lastLabelled = new Map([['Blue Tit', 103]]);
-    const activePending = [
-      {
-        species: 'Blue Tit',
-        sourceID: 'src1',
-        firstDetected: 95,
-        lastUpdated: 106,
-        status: 'active' as const,
-      },
-    ];
-    const repeats = getRepeatLabels(activePending, 'src1', lastLabelled, 107);
-    expect(repeats).toHaveLength(0);
-  });
-
-  it('does not emit when species has no previous label', () => {
-    const lastLabelled = new Map<string, number>();
-    const activePending = [
-      {
-        species: 'Blue Tit',
-        sourceID: 'src1',
-        firstDetected: 95,
-        lastUpdated: 106,
-        status: 'active' as const,
-      },
-    ];
-    const repeats = getRepeatLabels(activePending, 'src1', lastLabelled, 107);
-    expect(repeats).toHaveLength(0);
-  });
-
-  it('does not emit for stale species (lastUpdated older than nowUnix - 6)', () => {
-    const lastLabelled = new Map([['Blue Tit', 90]]);
-    const activePending = [
-      {
-        species: 'Blue Tit',
-        sourceID: 'src1',
-        firstDetected: 85,
-        lastUpdated: 92,
-        status: 'active' as const,
-      },
-    ];
-    const repeats = getRepeatLabels(activePending, 'src1', lastLabelled, 107);
-    expect(repeats).toHaveLength(0);
-  });
-
-  it('filters by sourceID', () => {
-    const lastLabelled = new Map([['Blue Tit', 100]]);
-    const activePending = [
-      {
-        species: 'Blue Tit',
-        sourceID: 'src2',
-        firstDetected: 95,
-        lastUpdated: 106,
-        status: 'active' as const,
-      },
-    ];
-    const repeats = getRepeatLabels(activePending, 'src1', lastLabelled, 107);
-    expect(repeats).toHaveLength(0);
-  });
-
-  it('ignores rejected species', () => {
-    const lastLabelled = new Map([['Blue Tit', 100]]);
-    const activePending = [
-      {
-        species: 'Blue Tit',
-        sourceID: 'src1',
-        firstDetected: 95,
-        lastUpdated: 106,
-        status: 'rejected' as const,
-      },
-    ];
-    const repeats = getRepeatLabels(activePending, 'src1', lastLabelled, 107);
-    expect(repeats).toHaveLength(0);
   });
 });

--- a/frontend/src/lib/utils/detectionOverlay.ts
+++ b/frontend/src/lib/utils/detectionOverlay.ts
@@ -32,7 +32,6 @@ interface PendingEntry {
 }
 
 const DEDUP_INTERVAL_SECONDS = 6;
-const STALE_THRESHOLD_SECONDS = 6;
 
 /** How long (seconds) to keep a species in the dedup map after last label.
  *  Generous buffer beyond DEDUP_INTERVAL_SECONDS to avoid premature cleanup. */
@@ -115,39 +114,4 @@ export function promoteFromQueue(
 export function nextYSlot(counter: number, maxSlots: number): { slot: number; next: number } {
   const slot = counter % maxSlots;
   return { slot, next: counter + 1 };
-}
-
-/**
- * Generate repeat labels for species that are still actively detected.
- * A repeat label is emitted when:
- * 1. The species already has a previous label (exists in lastLabelledMap)
- * 2. More than DEDUP_INTERVAL_SECONDS have elapsed since the last label
- * 3. The species is still fresh (lastUpdated within STALE_THRESHOLD_SECONDS of nowUnix)
- *
- * Returns entries that should get new labels. The caller must update lastLabelledMap.
- */
-export function getRepeatLabels(
-  activePending: PendingEntry[],
-  activeSourceID: string,
-  lastLabelledMap: Map<string, number>,
-  nowUnix: number
-): PendingEntry[] {
-  const results: PendingEntry[] = [];
-
-  for (const entry of activePending) {
-    if (entry.sourceID !== activeSourceID || entry.status === 'rejected') continue;
-
-    const lastLabelTime = lastLabelledMap.get(entry.species);
-    if (lastLabelTime === undefined) continue; // No initial label yet — skip repeats
-
-    const lastUpdated = entry.lastUpdated ?? entry.firstDetected;
-    const isFresh = nowUnix - lastUpdated < STALE_THRESHOLD_SECONDS;
-    const intervalElapsed = nowUnix - lastLabelTime >= DEDUP_INTERVAL_SECONDS;
-
-    if (isFresh && intervalElapsed) {
-      results.push(entry);
-    }
-  }
-
-  return results;
 }


### PR DESCRIPTION
## Summary

- Remove `getRepeatLabels()` function and all its call sites from `LiveStreamPage.svelte` and `MiniSpectrogram.svelte`
- Frontend now creates detection labels ONLY when `diffPendingSnapshot` detects a `hitCount` increase from the backend SSE stream
- Previously, the frontend fabricated repeat labels on a 200ms client-side timer based on "freshness" heuristics, without any backend signal — this violated the principle that the backend is the single source of truth for detection events
- Remove `STALE_THRESHOLD_SECONDS` constant (only used by the removed function)
- Remove 6 associated tests from `detectionOverlay.test.ts`

## Motivation

The `getRepeatLabels()` function generated labels every 6 seconds for species the frontend considered "still active" based on `lastUpdated` freshness. This had multiple problems:
1. Labels appeared without any corresponding backend inference hit
2. Cross-clock comparison (client `Date.now()` vs server `lastUpdated`) caused drift-dependent behavior
3. Labels bypassed the label queue and `promoteFromQueue`, so they ignored HLS latency alignment

With `audioCapturedAt` from #2456, every backend `hitCount` increase now produces a correctly-timed label via `diffPendingSnapshot`. The 6-second `shouldDedup` interval naturally spaces out labels for continuously singing birds.

## Test Plan

- [x] 14 remaining `detectionOverlay` tests pass
- [x] Frontend typecheck: 0 errors, 0 warnings
- [x] CodeRabbit CLI review: no findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Repeat overlay labels for actively detected species are no longer displayed during live stream monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->