### PR TITLE
fix: use audioCapturedAt for MiniSpectrogram repeat hit label positioning

### DIFF
--- a/frontend/src/lib/desktop/features/dashboard/components/MiniSpectrogram.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/components/MiniSpectrogram.svelte
@@ -401,7 +401,11 @@
         lastSeenSpecies.set(det.species, nowUnix);
         const { slot, next } = nextYSlot(slotCounter, MAX_OVERLAY_SLOTS);
         slotCounter = next;
-        labelQueue.push({ text: det.species, firstDetected: det.firstDetected, ySlot: slot });
+        labelQueue.push({
+          text: det.species,
+          firstDetected: det.audioCapturedAt ?? det.firstDetected,
+          ySlot: slot,
+        });
       }
     }
     prevSnapshot = [...pendingDetections];

--- a/internal/analysis/processor/processor.go
+++ b/internal/analysis/processor/processor.go
@@ -1332,15 +1332,16 @@ func (p *Processor) flushPendingDetections(minDetections int) (pendingCount, flu
 			item := p.pendingDetections[key]
 			if item.Count >= threshold {
 				broadcastSnapshot = append(broadcastSnapshot, SSEPendingDetection{
-					Species:        item.Detection.Result.Species.CommonName,
-					ScientificName: item.Detection.Result.Species.ScientificName,
-					Thumbnail:      p.getThumbnailURL(item.Detection.Result.Species.ScientificName),
-					Status:         PendingStatusActive,
-					FirstDetected:  item.CreatedAt.Unix(),
-					LastUpdated:    item.LastUpdated.Unix(),
-					Source:         p.getDisplayNameForSource(item.Source),
-					SourceID:       item.Source,
-					HitCount:       item.Count,
+					Species:         item.Detection.Result.Species.CommonName,
+					ScientificName:  item.Detection.Result.Species.ScientificName,
+					Thumbnail:       p.getThumbnailURL(item.Detection.Result.Species.ScientificName),
+					Status:          PendingStatusActive,
+					FirstDetected:   item.CreatedAt.Unix(),
+					AudioCapturedAt: unixOrZero(item.AudioCapturedAt),
+					LastUpdated:     item.LastUpdated.Unix(),
+					Source:          p.getDisplayNameForSource(item.Source),
+					SourceID:        item.Source,
+					HitCount:        item.Count,
 				})
 			}
 		}


### PR DESCRIPTION
## Summary

- **MiniSpectrogram** used `det.firstDetected` (original detection time) for label positioning, causing repeat hit labels to stack at the same horizontal position as the original detection. Changed to `det.audioCapturedAt ?? det.firstDetected` to match LiveStreamPage behavior — labels now appear at the time each new hit occurred.
- **Backend flush snapshot** was missing `AudioCapturedAt` field in the inline `SSEPendingDetection` construction within `flushPendingDetections()`. Added the field so the frontend always receives accurate capture timestamps, even during flush broadcasts.

## Related Issues

Regression from #2457

## Test Plan

- [ ] Observe MiniSpectrogram on dashboard — repeat hit labels should appear at distinct time positions, not stacked
- [ ] Compare label behavior between LiveStreamPage and MiniSpectrogram — should now be consistent
- [ ] Verify flush events still include `audioCapturedAt` in SSE pending snapshots

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced detection label timing accuracy by refining timestamp handling. Detection labels now prioritize audio capture timestamps when queuing, ensuring more precise alignment with the spectrogram playback position. This improves synchronization between detected audio events and their visual representation on the spectrogram.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->