### PR TITLE
fix: propagate database ID back to Note in v2only Save

### DIFF
--- a/internal/datastore/v2only/datastore.go
+++ b/internal/datastore/v2only/datastore.go
@@ -550,7 +550,7 @@ func (ds *Datastore) Save(note *datastore.Note, results []datastore.Results) err
 	// DIRECT DB WRITE: We use tx.Create directly instead of ds.detection.Save()
 	// to ensure both detection and predictions are in the same transaction.
 	// The repository doesn't currently support transaction injection.
-	return ds.manager.DB().WithContext(txCtx).Transaction(func(tx *gorm.DB) error {
+	if err := ds.manager.DB().WithContext(txCtx).Transaction(func(tx *gorm.DB) error {
 		if err := tx.Create(det).Error; err != nil {
 			return fmt.Errorf("failed to save detection: %w", err)
 		}
@@ -565,7 +565,16 @@ func (ds *Datastore) Save(note *datastore.Note, results []datastore.Results) err
 		}
 
 		return nil
-	})
+	}); err != nil {
+		return err
+	}
+
+	// Propagate database-assigned ID back to the caller's Note.
+	// Without this, detection_repository.Save() reads note.ID=0 and
+	// downstream actions (MQTT, SSE) publish detectionId=0 (GitHub #2453).
+	note.ID = det.ID
+
+	return nil
 }
 
 // buildDedupedPredictions deduplicates predictions by label_id, keeping the highest confidence


### PR DESCRIPTION
## Summary

Fixes #2453

**Root cause:** `v2only.Datastore.Save()` creates a local `*entities.Detection` for the GORM transaction. After `tx.Create(det)`, GORM assigns `det.ID`, but the method returns without copying it back to `note.ID`. This means `detection_repository.Save()` reads `note.ID=0`, `DetectionContext.NoteID` stores 0, and MQTT publishes `detectionId=0`.

**Fix:** Add `note.ID = det.ID` after the transaction succeeds.

This is a one-line data flow fix. The defensive warning added in #2459 confirmed this is the exact location where the ID is lost.

## Evidence

### Before fix (PR #2459 only)

```
FAIL: MQTT detection ID validation: 0/6 passed — 6 FAILED (issue #2453)
  MQTT messages collected: 6

WARN Detection ID is 0 after successful Repo.Save()
  species=varpuspöllö  operation=database_save_id_check
```

### After fix (this PR)

```
PASS: 6 MQTT messages validated. All detectionId values non-zero. API contract intact. (3m5s)
  MQTT messages collected: 6
  Detection ID check: MQTT detection ID validation: 6/6 passed
```

### QA Test Setup

Automated end-to-end validation using the Temporal-based QA framework:
- Audio: `varpuspöllö_86p.wav` streamed via MediaMTX RTSP
- MQTT: EMQX broker, subscribed to `birdnet-go-test/#`
- Validated: `detectionId > 0` for all 6 detection messages
- Cross-referenced: Database API confirms IDs 1-6 assigned

## Test plan

- [x] QA `task mqtt-validate`: 6/6 MQTT messages pass detectionId validation
- [x] Defensive warning from #2459 no longer fires
- [x] Linter passes (zero issues on changed package)
- [ ] Existing unit tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Notes now correctly receive their unique identifiers after being saved, enabling proper tracking and publishing of saved content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->