### PR TITLE
fix: make cooldown check-and-set atomic to prevent TOCTOU race

### DIFF
--- a/internal/alerting/engine.go
+++ b/internal/alerting/engine.go
@@ -233,24 +233,37 @@ func (e *Engine) HandleEvent(event *AlertEvent) {
 	// Phase 2: Evaluate rules.
 	for i := range rules {
 		rule := &rules[i]
+		if !e.ruleMatches(rule, event) {
+			continue
+		}
+
 		cdKey := cooldownKey(rule, event)
-		if e.ruleMatches(rule, event) && e.tryAcquireCooldown(cdKey, rule.CooldownSec) {
-			// Check escalation suppression for metric rules with steps.
-			if rule.TriggerType == TriggerTypeMetric && len(rule.EscalationSteps) > 0 {
-				suppress, props := e.shouldSuppressEscalation(rule, event)
-				if suppress {
-					continue
-				}
-				augmentedEvent := &AlertEvent{
-					ObjectType: event.ObjectType,
-					EventName:  event.EventName,
-					MetricName: event.MetricName,
-					Properties: props,
-					Timestamp:  event.Timestamp,
-				}
-				e.fireRule(rule, augmentedEvent)
+
+		// Metric rules with escalation steps: check escalation BEFORE
+		// acquiring cooldown so a suppressed step doesn't consume the
+		// cooldown and block a later, legitimate escalated alert.
+		// The escalation path has its own atomic protection via
+		// shouldSuppressEscalation.
+		if rule.TriggerType == TriggerTypeMetric && len(rule.EscalationSteps) > 0 {
+			suppress, props := e.shouldSuppressEscalation(rule, event)
+			if suppress {
 				continue
 			}
+			if !e.tryAcquireCooldown(cdKey, rule.CooldownSec) {
+				continue
+			}
+			augmentedEvent := &AlertEvent{
+				ObjectType: event.ObjectType,
+				EventName:  event.EventName,
+				MetricName: event.MetricName,
+				Properties: props,
+				Timestamp:  event.Timestamp,
+			}
+			e.fireRule(rule, augmentedEvent)
+			continue
+		}
+
+		if e.tryAcquireCooldown(cdKey, rule.CooldownSec) {
 			e.fireRule(rule, event)
 		}
 	}
@@ -315,13 +328,13 @@ func (e *Engine) tryAcquireCooldown(key string, cooldownSec int) (acquired bool)
 	cooldownDuration := time.Duration(cooldownSec) * time.Second
 
 	e.cooldownsMu.Lock()
+	defer e.cooldownsMu.Unlock()
+
 	lastFired, exists := e.cooldowns[key]
 	if exists && time.Since(lastFired) < cooldownDuration {
-		e.cooldownsMu.Unlock()
 		return false // still in cooldown
 	}
 	e.cooldowns[key] = time.Now()
-	e.cooldownsMu.Unlock()
 	return true
 }
 

--- a/internal/alerting/engine_test.go
+++ b/internal/alerting/engine_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -595,6 +596,63 @@ func TestEngine_EscalationSteps_ResetOnRecovery(t *testing.T) {
 	assert.Equal(t, 2, fireCount, "re-breach after recovery should fire")
 }
 
+func TestEngine_EscalationWithCooldown_SuppressedStepDoesNotConsumeCooldown(t *testing.T) {
+	// Verifies that a suppressed escalation step does not start a new cooldown.
+	// Scenario: after cooldown expires, a same-step event is suppressed by
+	// escalation. Without the fix, tryAcquireCooldown would consume the cooldown
+	// before shouldSuppressEscalation runs, blocking a subsequent legitimate
+	// escalated alert that arrives immediately after.
+	rule := entities.AlertRule{
+		ID:              1,
+		Enabled:         true,
+		ObjectType:      ObjectTypeSystem,
+		TriggerType:     TriggerTypeMetric,
+		MetricName:      MetricDiskUsage,
+		CooldownSec:     300, // 5-minute cooldown
+		EscalationSteps: []float64{85, 90, 95},
+		Conditions: []entities.AlertCondition{
+			{Property: PropertyValue, Operator: OperatorGreaterThan, Value: "85", DurationSec: 0},
+		},
+	}
+
+	var fired []float64
+	repo := newMockRepo(rule)
+	engine := NewEngine(repo, func(_ *entities.AlertRule, e *AlertEvent) {
+		fired = append(fired, e.Properties[PropertyValue].(float64))
+	}, testLogger(), nil)
+	require.NoError(t, engine.RefreshRules(t.Context()))
+
+	emit := func(value float64) {
+		engine.HandleEvent(&AlertEvent{
+			ObjectType: ObjectTypeSystem,
+			MetricName: MetricDiskUsage,
+			Properties: map[string]any{PropertyValue: value, PropertyPath: "/"},
+			Timestamp:  time.Now(),
+		})
+	}
+
+	// Step 85 fires, cooldown starts.
+	emit(86)
+	assert.Equal(t, []float64{86}, fired)
+
+	// Expire cooldown manually.
+	engine.cooldownsMu.Lock()
+	for k := range engine.cooldowns {
+		engine.cooldowns[k] = time.Now().Add(-10 * time.Minute)
+	}
+	engine.cooldownsMu.Unlock()
+
+	// Same step (87% → still step 85) — suppressed by escalation.
+	// Must NOT start a new cooldown.
+	emit(87)
+	assert.Equal(t, []float64{86}, fired, "same step should be suppressed")
+
+	// Higher step (91% → step 90) arrives immediately after.
+	// Should fire because the suppressed event must not have consumed cooldown.
+	emit(91)
+	assert.Equal(t, []float64{86, 91}, fired, "escalated step should not be blocked by suppressed step's cooldown")
+}
+
 func TestEngine_EscalationSteps_MultiplePathsIndependent(t *testing.T) {
 	rule := entities.AlertRule{
 		ID:              1,
@@ -733,12 +791,9 @@ func TestEngine_CooldownAtomicUnderConcurrency(t *testing.T) {
 	}
 	repo := newMockRepo(rule)
 
-	var fireCount int64
-	var mu sync.Mutex
+	var fireCount atomic.Int64
 	engine := NewEngine(repo, func(_ *entities.AlertRule, _ *AlertEvent) {
-		mu.Lock()
-		fireCount++
-		mu.Unlock()
+		fireCount.Add(1)
 	}, testLogger(), nil)
 
 	require.NoError(t, engine.RefreshRules(t.Context()))
@@ -759,10 +814,7 @@ func TestEngine_CooldownAtomicUnderConcurrency(t *testing.T) {
 	}
 	wg.Wait()
 
-	mu.Lock()
-	count := fireCount
-	mu.Unlock()
-	assert.Equal(t, int64(1), count, "concurrent calls should fire exactly once with cooldown")
+	assert.Equal(t, int64(1), fireCount.Load(), "concurrent calls should fire exactly once with cooldown")
 }
 
 func TestEngine_MultipleRulesSameMetricNoDuplicateRecording(t *testing.T) {


### PR DESCRIPTION
## Summary

- Replace separate `isInCooldown` (RLock) + `fireRuleInternal` cooldown write (Lock) with a single `tryAcquireCooldown` method that atomically checks and records cooldown under one write lock
- Matches the pattern already used by `shouldSuppressEscalation` for the escalation path
- Remove redundant cooldown write and unused `cdKey` parameter from `fireRule`/`fireRuleInternal`
- Add `TestEngine_CooldownAtomicUnderConcurrency` (50 goroutines with `-race`)

Fixes #2447

## Test Plan

- [x] All existing alerting tests pass with `-race -count=5`
- [x] New concurrency test verifies exactly 1 fire from 50 concurrent goroutines
- [x] `golangci-lint` clean on `internal/alerting/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fix**
  * Suppressed escalation steps no longer consume cooldown, preventing unintended suppression of later escalation alerts.
  * Prevents duplicate alert firings under concurrent event delivery.

* **Refactor**
  * Consolidated and hardened cooldown handling to ensure atomic cooldown checks and updates.

* **Tests**
  * Added tests for escalation-with-cooldown scenarios and concurrency to validate reliable cooldown behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->