### PR TITLE
fix: remove premature species tracker update in createDetection

### DIFF
--- a/internal/analysis/processor/processor.go
+++ b/internal/analysis/processor/processor.go
@@ -798,14 +798,12 @@ func (p *Processor) createDetection(item birdnet.Results, result datastore.Resul
 	// Exclude the primary species since it's already stored as Detection.LabelID.
 	additionalResults := convertToAdditionalResults(item.Results, scientificName)
 
-	// Update species tracker if enabled
-	p.speciesTrackerMu.RLock()
-	tracker := p.NewSpeciesTracker
-	p.speciesTrackerMu.RUnlock()
-
-	if tracker != nil {
-		tracker.UpdateSpecies(scientificName, item.StartTime)
-	}
+	// NOTE: Species tracker is NOT updated here. The tracker is updated solely
+	// through the atomic CheckAndUpdateSpecies() in DatabaseAction.ExecuteContext,
+	// which runs only when a detection is actually persisted to the database.
+	// Previously, UpdateSpecies() was called here during initial analysis (before
+	// false positive filtering and database save), which prematurely marked species
+	// as "seen" and prevented new-species notifications from firing (GitHub #2403).
 
 	// Generate unique correlation ID for detection tracking
 	correlationID := p.generateCorrelationID(commonName, item.StartTime)


### PR DESCRIPTION
## Summary

Relates to #2403

Removes a premature `tracker.UpdateSpecies()` call in `createDetection()` that ran during initial BirdNET analysis — before the detection passed false positive filtering or was saved to the database. This marked species as "seen" too early, causing `DatabaseAction.CheckAndUpdateSpecies()` to return `isNewSpecies=false`, which prevented new-species notifications from firing.

The species tracker is now updated solely through the atomic `CheckAndUpdateSpecies()` in `DatabaseAction.ExecuteContext`, which runs only when a detection is actually persisted.

Found by the QA automated fix agent while investigating #2403. The primary fix (wrong notification type) was merged in #2467; this is the secondary bug in the same notification pipeline.

## Test plan

- [x] Build passes
- [x] Linter passes
- [ ] Existing tests pass
- [ ] QA `task discord-test`: verify new species notifications fire on fresh install


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved species tracking accuracy by ensuring species information is recorded only when detections are confirmed and saved, preventing incomplete data from affecting tracking records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->