### PR TITLE
fix: break infinite reactive loop in integration settings eBird validation

### DIFF
--- a/frontend/src/lib/desktop/features/settings/pages/IntegrationSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/IntegrationSettingsPage.svelte
@@ -169,10 +169,17 @@
     const needsError = ebirdEnabled && !ebirdApiKey;
 
     // Use .update() to avoid reading the store inside this effect,
-    // which would create an infinite reactive loop (read → write → re-trigger)
+    // which would create an infinite reactive loop (read → write → re-trigger).
+    // Return the original array reference when unchanged to skip subscriber notifications.
     settingsValidationErrors.update(errors => {
-      const filtered = errors.filter(e => e !== EBIRD_ERROR_KEY);
-      return needsError ? [...filtered, EBIRD_ERROR_KEY] : filtered;
+      const hasError = errors.includes(EBIRD_ERROR_KEY);
+      if (needsError && !hasError) {
+        return [...errors, EBIRD_ERROR_KEY];
+      }
+      if (!needsError && hasError) {
+        return errors.filter(e => e !== EBIRD_ERROR_KEY);
+      }
+      return errors;
     });
 
     return () => {


### PR DESCRIPTION
## Summary

Fixes #2474 — the Settings > Integrations page freezes the browser immediately on load.

The `$effect` for eBird API key validation read `$settingsValidationErrors` (creating a reactive subscription) then wrote back to it via `.set()` with a new array reference. Since `.filter()` always creates a new array, the store notified subscribers on every write, re-triggering the effect in an infinite loop that froze the browser.

The fix switches to `.update()` so the effect never subscribes to the store it mutates — it now only depends on the eBird settings values.

## Test plan

- [ ] Navigate to Settings > Integrations — page loads without freezing
- [ ] Enable eBird without an API key — validation error appears
- [ ] Fill in an eBird API key — validation error clears
- [ ] Disable eBird — validation error clears
- [ ] Other tabs (BirdWeather, MQTT, Prometheus) still function normally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved eBird API key validation handling: reduces redundant validation updates and avoids unnecessary UI-refresh notifications while preserving existing cleanup behavior when leaving the settings page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->