### PR TITLE
fix: correct HLS PROGRAM_DATE_TIME offset from wall clock

### DIFF
--- a/internal/api/v2/audio_hls.go
+++ b/internal/api/v2/audio_hls.go
@@ -111,9 +111,9 @@ type HLSStreamInfo struct {
 	// wall-clock time. FFmpeg sets the PDT epoch at process init (av_gettime),
 	// which is ~1.5s before audio data actually arrives. This offset is computed
 	// once from the first playlist and applied when serving all subsequent playlists.
-	pdtOffset         time.Duration // Correction to add to FFmpeg's PDT values
-	pdtOffsetComputed atomic.Bool   // True once pdtOffset has been successfully computed
-	firstDataTime     atomic.Int64  // Wall-clock time (UnixNano) when first audio data was written to FIFO
+	pdtOffset         atomic.Int64 // Correction (nanoseconds) to add to FFmpeg's PDT values
+	pdtOffsetComputed atomic.Bool  // True once pdtOffset has been successfully computed
+	firstDataTime     atomic.Int64 // Wall-clock time (UnixNano) when first audio data was written to FIFO
 }
 
 // HLSStreamStatus represents the current status of an HLS stream (API response)
@@ -663,22 +663,23 @@ func (c *Controller) correctPlaylistPDT(stream *HLSStreamInfo, playlist string) 
 		offset := wallNow.Sub(hlsNow)
 		// Only the first goroutine to succeed sets the offset
 		if stream.pdtOffsetComputed.CompareAndSwap(false, true) {
-			stream.pdtOffset = offset
+			stream.pdtOffset.Store(int64(offset))
 			GetLogger().Info("HLS PDT correction computed",
 				logger.String("source_id", privacy.SanitizeRTSPUrl(stream.SourceID)),
 				logger.String("hls_head", hlsNow.UTC().Format(time.RFC3339Nano)),
 				logger.String("wall_clock", wallNow.UTC().Format(time.RFC3339Nano)),
-				logger.String("correction", stream.pdtOffset.String()))
+				logger.String("correction", offset.String()))
 		}
 	}
 
 	// No correction needed (zero offset or failed to parse)
-	if stream.pdtOffset == 0 {
+	correction := time.Duration(stream.pdtOffset.Load())
+	if correction == 0 {
 		return playlist
 	}
 
 	// Rewrite all PROGRAM_DATE_TIME tags with the correction
-	return rewritePDTTags(playlist, stream.pdtOffset)
+	return rewritePDTTags(playlist, correction)
 }
 
 // hlsSegment holds a parsed segment from an HLS playlist.
@@ -746,51 +747,33 @@ func parsePlaylistSegments(playlist string) []hlsSegment {
 func rewritePDTTags(playlist string, offset time.Duration) string {
 	const prefix = "#EXT-X-PROGRAM-DATE-TIME:"
 	var result strings.Builder
-	result.Grow(len(playlist) + 64) // slight overalloc for longer timestamps
+	result.Grow(len(playlist) + 64)
 
-	remaining := playlist
-	for {
-		idx := strings.Index(remaining, prefix)
-		if idx < 0 {
-			result.WriteString(remaining)
-			break
-		}
-
-		// Write everything before this tag
-		result.WriteString(remaining[:idx+len(prefix)])
-		remaining = remaining[idx+len(prefix):]
-
-		// Find end of line
-		eol := strings.IndexByte(remaining, '\n')
-		if eol < 0 {
-			result.WriteString(remaining)
-			break
-		}
-
-		dtStr := strings.TrimSpace(remaining[:eol])
-		corrected := false
-
-		// Try to parse, apply offset, and reformat
-		for _, layout := range pdtLayouts {
-			t, err := time.Parse(layout, dtStr)
-			if err != nil {
-				continue
+	lines := strings.Split(playlist, "\n")
+	for i, line := range lines {
+		if dtStr, ok := strings.CutPrefix(line, prefix); ok {
+			dtStr = strings.TrimSpace(dtStr)
+			corrected := false
+			for _, layout := range pdtLayouts {
+				t, err := time.Parse(layout, dtStr)
+				if err != nil {
+					continue
+				}
+				result.WriteString(prefix)
+				result.WriteString(t.Add(offset).Format(layout))
+				corrected = true
+				break
 			}
-			adjusted := t.Add(offset)
-			result.WriteString(adjusted.Format(layout))
+			if !corrected {
+				result.WriteString(line)
+			}
+		} else {
+			result.WriteString(line)
+		}
+		if i < len(lines)-1 {
 			result.WriteByte('\n')
-			corrected = true
-			break
 		}
-
-		if !corrected {
-			// Couldn't parse — pass through unchanged
-			result.WriteString(remaining[:eol+1])
-		}
-
-		remaining = remaining[eol+1:]
 	}
-
 	return result.String()
 }
 


### PR DESCRIPTION
## Summary

- Rewrite `PROGRAM_DATE_TIME` tags in HLS playlists to align with wall-clock time
- Refactor HLS audio feed startup to register callback before FFmpeg starts

## Motivation

FFmpeg sets `PROGRAM_DATE_TIME` from `av_gettime()` at HLS muxer init, which runs during process startup — before any audio data arrives. This creates a constant ~1.5-2.5s offset between HLS timestamps and wall clock. There is no FFmpeg option to control this (the `hls_init_prog_time` patch was proposed in 2016 but never merged).

The offset causes spectrogram waterfall labels to be misplaced relative to the audio playhead, compounding the issue addressed in #2456.

## Changes

**PDT correction (main fix):**
- On first playlist serve, compute the offset between FFmpeg's latest PDT end-time and `time.Now()`
- Apply this fixed correction to all `PROGRAM_DATE_TIME` tags in every subsequent `ServeHLSPlaylist` call
- Correction is computed once per stream via `sync.Once` — negligible overhead

**Startup refactor:**
- Split `feedAudioToFFmpeg()` into `prepareAudioFeed()` (setup) + `runAudioFeedLoop()` (feed loop)
- Audio callback registration and FIFO opening happen before `cmd.Start()`, so audio data starts buffering immediately
- Windows stdin path is unchanged

**New helpers:** `correctPlaylistPDT`, `parsePlaylistSegments`, `parsePDT`, `rewritePDTTags`

## Test Plan

Measured with a standalone HLS timestamp drift test tool against a test container (RTSP source via MediaMTX):

| Metric | Before | After |
|---|---|---|
| Absolute PDT offset (cold start) | ~1.5-2.5s | ~0.6-1.0s |
| Absolute PDT offset (warm) | ~1.5-2.5s | ~0.6s |
| Clock drift rate | ~0.15s/min | ~0.13s/min (unchanged, inherent to pipe-fed FFmpeg) |

- [x] `golangci-lint run -v` — 0 issues
- [x] Full build passes (`task`)
- [ ] Manual testing with live spectrogram waterfall

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Faster, more accurate HLS playlist delivery with on-the-fly PROGRAM_DATE_TIME adjustment to keep playlists aligned with live playback.
  * More robust audio feed startup and handling, improving stream stability and startup reliability.

* **Bug Fixes**
  * Fixed program date-time tag skew so playlists remain synchronized with live playback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->