### PR TITLE
fix: address pre-existing issues found during relocation review

### DIFF
--- a/internal/analysis/api_service.go
+++ b/internal/analysis/api_service.go
@@ -355,22 +355,14 @@ func initializeSystemMonitor(settings *conf.Settings) *monitor.SystemMonitor {
 	)
 
 	if !settings.Realtime.Monitoring.Enabled {
-		GetLogger().Warn("System monitoring is disabled in settings")
+		GetLogger().Info("system monitoring is disabled")
 		return nil
 	}
 
-	GetLogger().Info("Creating system monitor instance")
 	systemMonitor := monitor.NewSystemMonitor(settings)
-	if systemMonitor == nil {
-		GetLogger().Error("Failed to create system monitor instance")
-		return nil
-	}
-
-	GetLogger().Info("Starting system monitor")
 	systemMonitor.Start()
 
-	GetLogger().Info("System resource monitoring initialized",
-		logger.String("component", "monitor"),
+	GetLogger().Info("system resource monitoring initialized",
 		logger.Int("interval", settings.Realtime.Monitoring.CheckInterval))
 	return systemMonitor
 }

--- a/internal/analysis/audio_pipeline_service.go
+++ b/internal/analysis/audio_pipeline_service.go
@@ -25,6 +25,9 @@ import (
 // audioPipelineServiceName is the service name used for logging and diagnostics.
 const audioPipelineServiceName = "audio-pipeline"
 
+// hlsCleanupTimeout is the maximum time allowed for HLS file cleanup during shutdown.
+const hlsCleanupTimeout = 2 * time.Second
+
 // policyNone is the sentinel value indicating no retention/provider policy is configured.
 const policyNone = "none"
 
@@ -619,8 +622,7 @@ func cleanupHLSWithTimeout(ctx context.Context) {
 		cleanupDone <- cleanupHLSStreamingFiles()
 	}()
 
-	// Create a timeout context for cleanup operation (2 seconds max)
-	cleanupCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	cleanupCtx, cancel := context.WithTimeout(ctx, hlsCleanupTimeout)
 	defer cancel()
 
 	log := GetLogger()
@@ -633,7 +635,7 @@ func cleanupHLSWithTimeout(ctx context.Context) {
 		}
 	case <-cleanupCtx.Done():
 		log.Warn("HLS cleanup timeout exceeded, continuing shutdown",
-			logger.Duration("timeout", 2*time.Second),
+			logger.Duration("timeout", hlsCleanupTimeout),
 			logger.String("operation", "cleanup_hls_files"))
 	}
 }
@@ -782,15 +784,20 @@ func initializeAudioSources(settings *conf.Settings) ([]string, error) {
 			// Register the audio device in the source registry and use its ID
 			// This ensures consistent UUID-based IDs like RTSP sources
 			registry := myaudio.GetRegistry()
-			source, err := registry.RegisterSource(settings.Realtime.Audio.Source, myaudio.SourceConfig{
-				Type: myaudio.SourceTypeAudioCard,
-			})
-			if err != nil {
-				log.Warn("failed to register audio device source",
-					logger.String("source", settings.Realtime.Audio.Source),
-					logger.Error(err))
+			if registry == nil {
+				log.Warn("audio source registry not available, skipping audio device registration",
+					logger.String("source", settings.Realtime.Audio.Source))
 			} else {
-				sources = append(sources, source.ID)
+				source, err := registry.RegisterSource(settings.Realtime.Audio.Source, myaudio.SourceConfig{
+					Type: myaudio.SourceTypeAudioCard,
+				})
+				if err != nil {
+					log.Warn("failed to register audio device source",
+						logger.String("source", settings.Realtime.Audio.Source),
+						logger.Error(err))
+				} else {
+					sources = append(sources, source.ID)
+				}
 			}
 		}
 

--- a/internal/analysis/startup.go
+++ b/internal/analysis/startup.go
@@ -30,25 +30,24 @@ func PrintSystemDetails(settings *conf.Settings) {
 	// Get system details with gopsutil
 	info, err := host.Info()
 	if err != nil {
-		log.Warn("Failed to retrieve host info", logger.Error(err))
+		log.Warn("failed to retrieve host info", logger.Error(err))
 	}
 
 	var hwModel string
-	// Print SBC hardware details
 	if conf.IsLinuxArm64() {
-		hwModel = conf.GetBoardModel()
-		// remove possible new line from hwModel
-		hwModel = strings.TrimSpace(hwModel)
+		hwModel = strings.TrimSpace(conf.GetBoardModel())
 	} else {
 		hwModel = "unknown"
 	}
 
-	// Log system details
-	log.Info("System details",
-		logger.String("os", info.OS),
-		logger.String("platform", info.Platform),
-		logger.String("platform_version", info.PlatformVersion),
-		logger.String("hardware", hwModel))
+	// Log system details (guard against nil info from host.Info failure)
+	if info != nil {
+		log.Info("system details",
+			logger.String("os", info.OS),
+			logger.String("platform", info.Platform),
+			logger.String("platform_version", info.PlatformVersion),
+			logger.String("hardware", hwModel))
+	}
 
 	// Log the start of BirdNET-Go Analyzer in realtime mode and its configurations.
 	log.Info("Starting analyzer in realtime mode",


### PR DESCRIPTION
## Summary
Fixes 5 pre-existing issues flagged by automated reviewers during the realtime.go decomposition:

- Fix nil pointer dereference in `PrintSystemDetails` when `host.Info()` fails
- Add nil check for audio source registry before device registration
- Change disabled monitoring log from `Warn` to `Info` (valid config, not a problem)
- Remove redundant nil check on `NewSystemMonitor` (always returns valid instance)
- Extract hardcoded 2s HLS cleanup timeout to `hlsCleanupTimeout` constant

## Test plan
- [x] `go build ./internal/analysis/` compiles clean
- [x] `go test ./internal/analysis/... -count=1 -short` all pass
- [ ] Manual: start server, verify startup logs look correct