### PR TITLE
fix: improve FFmpeg stream resilience with non-blocking reader and backoff resets

### DIFF
--- a/internal/audiocore/ffmpeg/manager.go
+++ b/internal/audiocore/ffmpeg/manager.go
@@ -462,7 +462,10 @@ func (m *Manager) checkForStuckStreams() {
 		// Determine how long the stream has been unhealthy.
 		var unhealthyFor time.Duration
 		if h.LastDataReceived.IsZero() {
-			unhealthyFor = time.Since(stream.streamCreatedAt)
+			stream.streamCreatedAtMu.RLock()
+			createdAt := stream.streamCreatedAt
+			stream.streamCreatedAtMu.RUnlock()
+			unhealthyFor = time.Since(createdAt)
 		} else {
 			unhealthyFor = time.Since(h.LastDataReceived)
 		}

--- a/internal/audiocore/ffmpeg/manager_test.go
+++ b/internal/audiocore/ffmpeg/manager_test.go
@@ -269,7 +269,9 @@ func TestManager_WatchdogForceReset(t *testing.T) {
 		// Advance the stream creation time so the watchdog considers it stuck.
 		mgr.mu.Lock()
 		stream := mgr.streams[sourceID]
+		stream.streamCreatedAtMu.Lock()
 		stream.streamCreatedAt = time.Now().Add(-(managerMaxUnhealthyDuration + time.Minute))
+		stream.streamCreatedAtMu.Unlock()
 		// Set process state to stopped so IsRestarting() returns false.
 		stream.processStateMu.Lock()
 		stream.processState = StateStopped

--- a/internal/audiocore/ffmpeg/stream.go
+++ b/internal/audiocore/ffmpeg/stream.go
@@ -461,7 +461,8 @@ type Stream struct {
 	dropLogMu       sync.Mutex
 
 	// Stream creation time for grace period calculation.
-	streamCreatedAt time.Time
+	streamCreatedAt   time.Time
+	streamCreatedAtMu sync.RWMutex
 
 	// Process state tracking.
 	processState     ProcessState
@@ -925,22 +926,14 @@ func (s *Stream) processAudio() error {
 	// loop handles a control signal.
 	readCh := make(chan readResult, 1)
 
+	// readerDone is closed when the main event loop exits to unblock the
+	// reader goroutine if readCh is full, preventing a goroutine leak.
+	readerDone := make(chan struct{})
+	defer close(readerDone)
+
 	// Launch a dedicated reader goroutine. It exits when stdout is closed
-	// (by cleanupProcess) or on a read error, which causes an EOF/error
-	// to be sent on readCh.
-	go func() {
-		for {
-			buf := make([]byte, ffmpegBufferSize)
-			n, err := stdout.Read(buf)
-			if n > 0 {
-				readCh <- readResult{data: buf[:n]}
-			}
-			if err != nil {
-				readCh <- readResult{err: err}
-				return
-			}
-		}
-	}()
+	// (by cleanupProcess), on a read error, or when readerDone is closed.
+	go s.readStdout(stdout, readCh, readerDone)
 
 	for {
 		if s.GetProcessState() == StateStopped {
@@ -999,6 +992,34 @@ func (s *Stream) processAudio() error {
 }
 
 // handleReadError processes an error returned by the reader goroutine.
+// readStdout is the body of the dedicated reader goroutine launched by
+// processAudio. It allocates a single buffer and copies data before sending
+// to avoid retaining references to a shared backing array. It exits when
+// stdout is closed (by cleanupProcess), on a read error, or when readerDone
+// is closed (main loop exited, preventing a goroutine leak).
+func (s *Stream) readStdout(stdout io.ReadCloser, readCh chan<- readResult, readerDone <-chan struct{}) {
+	buf := make([]byte, ffmpegBufferSize)
+	for {
+		n, err := stdout.Read(buf)
+		if n > 0 {
+			dataCopy := make([]byte, n)
+			copy(dataCopy, buf[:n])
+			select {
+			case readCh <- readResult{data: dataCopy}:
+			case <-readerDone:
+				return
+			}
+		}
+		if err != nil {
+			select {
+			case readCh <- readResult{err: err}:
+			case <-readerDone:
+			}
+			return
+		}
+	}
+}
+
 // It distinguishes quick-exit scenarios from normal EOF/cancel and general errors.
 func (s *Stream) handleReadError(readErr error, startTime time.Time) error {
 	if time.Since(startTime) < processQuickExitTime {
@@ -1560,7 +1581,9 @@ func (s *Stream) resetDataTracking() {
 	s.totalBytesReceived = 0
 	s.bytesReceivedMu.Unlock()
 
+	s.streamCreatedAtMu.Lock()
 	s.streamCreatedAt = time.Now()
+	s.streamCreatedAtMu.Unlock()
 }
 
 // logStreamHealth logs the current stream health status.

--- a/internal/audiocore/ffmpeg/stream_test.go
+++ b/internal/audiocore/ffmpeg/stream_test.go
@@ -109,6 +109,8 @@ func (s *Stream) getTotalBytesReceivedForTest() int64 {
 }
 
 func (s *Stream) getStreamCreatedAtForTest() time.Time {
+	s.streamCreatedAtMu.RLock()
+	defer s.streamCreatedAtMu.RUnlock()
 	return s.streamCreatedAt
 }
 
@@ -915,7 +917,9 @@ func TestStream_ZeroTimeHandling(t *testing.T) {
 	assert.False(t, health.IsReceivingData)
 
 	// After grace period: still not healthy.
+	stream.streamCreatedAtMu.Lock()
 	stream.streamCreatedAt = time.Now().Add(-2 * defaultGracePeriod)
+	stream.streamCreatedAtMu.Unlock()
 	health = stream.GetHealth()
 	assert.True(t, health.LastDataReceived.IsZero())
 	assert.False(t, health.IsHealthy)
@@ -1476,7 +1480,9 @@ func TestStream_ResetDataTrackingRefreshesStreamCreatedAt(t *testing.T) {
 
 	// Backdate streamCreatedAt to simulate an old stream.
 	oldCreatedAt := time.Now().Add(-1 * time.Hour)
+	stream.streamCreatedAtMu.Lock()
 	stream.streamCreatedAt = oldCreatedAt
+	stream.streamCreatedAtMu.Unlock()
 
 	stream.resetDataTracking()
 


### PR DESCRIPTION
## Summary
- Replace blocking `stdout.Read` with dedicated reader goroutine + channel-based `select` for recovery signal responsiveness
- Reset backoff counter on manual `RestartStream` to avoid unnecessary delays after operator intervention
- Reset `LastDataReceived` timestamp on stream restart to prevent stale health calculations
- Capture `processStartTime` before cleanup to preserve runtime metrics accuracy
- Clear circuit breaker `consecutiveFailures` when cooldown expires and retry begins

## Test plan
- [x] New `TestStreamReadLoop_NonBlocking` — verifies reader goroutine + select-based dispatch
- [x] New `TestRestartStream_ResetsBackoff` — manual restart clears failure counter
- [x] New `TestRestartStream_ResetsLastDataReceived` — timestamp refreshed on restart
- [x] New `TestProcessStartTime_PreservedBeforeCleanup` — runtime not zeroed
- [x] New `TestCircuitBreaker_CooldownResetsFailures` — counter cleared on retry
- [x] `golangci-lint run ./internal/audiocore/ffmpeg/...` — 0 issues
- [x] `go test -race ./internal/audiocore/ffmpeg/...` — all pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio stream responsiveness when the underlying process becomes unresponsive.
  * Enhanced stream restart behavior to properly reset failure counters and recovery state.
  * Refined circuit breaker cooldown mechanism for more reliable failure recovery.

* **Tests**
  * Added comprehensive test coverage for responsiveness, state management, and failure recovery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->