### PR TITLE
fix: correct misplaced doc comments from review

### DIFF
--- a/internal/analysis/processor/execute_internal_test.go
+++ b/internal/analysis/processor/execute_internal_test.go
@@ -22,13 +22,10 @@ const osWindows = "windows"
 // =============================================================================
 
 // createTestScript creates a temporary executable shell script with the given content.
-// Uses t.TempDir() for automatic cleanup. Explicitly syncs the file to disk before
-// closing to prevent ETXTBSY ("text file busy") races where the kernel still holds
-// a write reference when exec is called immediately after.
-//
-// After closing, the function verifies the file is stat-able as a final check
-// that the kernel has finished processing the file descriptor operations.
-// This prevents ETXTBSY errors on CI runners with slow I/O subsystems.
+// Uses t.TempDir() for automatic cleanup. Writes to a .tmp file first, then uses
+// os.Rename to atomically place the script at its final path. This avoids ETXTBSY
+// ("text file busy") on Linux CI runners with overlayfs, where the kernel may
+// retain an internal write reference after Close, causing exec to fail.
 func createTestScript(t *testing.T, name, content string) string {
 	t.Helper()
 	dir := t.TempDir()

--- a/internal/audiocore/ffmpeg/stream.go
+++ b/internal/audiocore/ffmpeg/stream.go
@@ -991,7 +991,6 @@ func (s *Stream) processAudio() error {
 	}
 }
 
-// handleReadError processes an error returned by the reader goroutine.
 // readStdout is the body of the dedicated reader goroutine launched by
 // processAudio. It allocates a single buffer and copies data before sending
 // to avoid retaining references to a shared backing array. It exits when
@@ -1020,6 +1019,7 @@ func (s *Stream) readStdout(stdout io.ReadCloser, readCh chan<- readResult, read
 	}
 }
 
+// handleReadError processes an error returned by the reader goroutine.
 // It distinguishes quick-exit scenarios from normal EOF/cancel and general errors.
 func (s *Stream) handleReadError(readErr error, startTime time.Time) error {
 	if time.Since(startTime) < processQuickExitTime {


### PR DESCRIPTION
## Summary
- Fix swapped doc comments on `readStdout` and `handleReadError` in stream.go (found during internal review)
- Update stale `createTestScript` doc comment to describe the current atomic-rename approach instead of the removed `Eventually` polling

## Test plan
- [x] `golangci-lint run` — 0 issues
- [x] Doc-only changes, no behavioral impact