### PR TITLE
fix: ensure AudioEngine.Stop() is called on application shutdown

### DIFF
--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -39,6 +39,7 @@ The "realtime" command is an alias for backward compatibility.`,
 			// after APIServerService.Start(), so it is set later via
 			// AudioEngine.SetScheduler().
 			audioEngine := engine.New(cmd.Context(), &engine.Config{}, nil)
+			defer audioEngine.Stop()
 
 			// Create services. Registration order determines start order;
 			// shutdown happens in reverse within each tier.


### PR DESCRIPTION
## Summary
Add `defer audioEngine.Stop()` after engine creation in serve.go. Without this, FFmpeg processes, device captures, router goroutines, and the scheduler would leak on every application restart.

Found by Sentry bot during PR #2506 review.

## Test plan
- [x] `golangci-lint run ./cmd/serve/...` — 0 issues
- [x] One-line change, no behavioral risk