### PR TITLE
Add false_positive to search status filters

### DIFF
--- a/frontend/src/lib/desktop/views/Search.svelte
+++ b/frontend/src/lib/desktop/views/Search.svelte
@@ -59,7 +59,7 @@
     hasAudio: boolean;
   }
 
-  type VerifiedStatus = 'any' | 'verified' | 'unverified';
+  type VerifiedStatus = 'any' | 'verified' | 'unverified' | 'false_positive';
   type LockedStatus = 'any' | 'locked' | 'unlocked';
   type TimeOfDayFilter = 'any' | 'day' | 'night' | 'sunrise' | 'sunset';
   type SortBy = 'date_desc' | 'date_asc' | 'species_asc' | 'confidence_desc';
@@ -482,6 +482,7 @@
                   <option value="any">{t('search.verifiedOptions.any')}</option>
                   <option value="verified">{t('search.verifiedOptions.verified')}</option>
                   <option value="unverified">{t('search.verifiedOptions.unverified')}</option>
+                  <option value="false_positive">{t('common.review.status.falsePositive')}</option>
                 </select>
               </div>
 
@@ -773,7 +774,7 @@
                         {result.verified === 'correct'
                           ? t('search.statusBadges.verified')
                           : result.verified === 'false_positive'
-                            ? t('search.statusBadges.false')
+                            ? t('common.review.status.falsePositive')
                             : t('search.statusBadges.unverified')}
                       </div>
                       <div class="status-badge {result.locked ? 'locked' : 'unverified'}">
@@ -984,7 +985,7 @@
                         {result.verified === 'correct'
                           ? t('search.statusBadges.verified')
                           : result.verified === 'false_positive'
-                            ? t('search.statusBadges.false')
+                            ? t('common.review.status.falsePositive')
                             : t('search.statusBadges.unverified')}
                       </div>
                       <div class="status-badge {result.locked ? 'locked' : 'unverified'}">

--- a/internal/api/v2/search.go
+++ b/internal/api/v2/search.go
@@ -124,21 +124,22 @@ func (c *Controller) logValidatedRequest(path, ip string, req *SearchRequest) {
 // buildSearchFilters creates the datastore search filters from the request.
 func (c *Controller) buildSearchFilters(req *SearchRequest, ctxTimeout context.Context) datastore.SearchFilters {
 	return datastore.SearchFilters{
-		Species:        req.Species,
-		DateStart:      req.DateStart,
-		DateEnd:        req.DateEnd,
-		ConfidenceMin:  req.ConfidenceMin,
-		ConfidenceMax:  req.ConfidenceMax,
-		VerifiedOnly:   req.VerifiedStatus == "verified",
-		UnverifiedOnly: req.VerifiedStatus == "unverified",
-		LockedOnly:     req.LockedStatus == "locked",
-		UnlockedOnly:   req.LockedStatus == "unlocked",
-		Device:         req.DeviceFilter,
-		TimeOfDay:      req.TimeOfDay,
-		Page:           req.Page,
-		PerPage:        defaultPerPage,
-		SortBy:         req.SortBy,
-		Ctx:            ctxTimeout,
+		Species:           req.Species,
+		DateStart:         req.DateStart,
+		DateEnd:           req.DateEnd,
+		ConfidenceMin:     req.ConfidenceMin,
+		ConfidenceMax:     req.ConfidenceMax,
+		VerifiedOnly:      req.VerifiedStatus == "verified",
+		UnverifiedOnly:    req.VerifiedStatus == "unverified",
+		FalsePositiveOnly: req.VerifiedStatus == "false_positive",
+		LockedOnly:        req.LockedStatus == "locked",
+		UnlockedOnly:      req.LockedStatus == "unlocked",
+		Device:            req.DeviceFilter,
+		TimeOfDay:         req.TimeOfDay,
+		Page:              req.Page,
+		PerPage:           defaultPerPage,
+		SortBy:            req.SortBy,
+		Ctx:               ctxTimeout,
 	}
 }
 
@@ -224,12 +225,17 @@ func (c *Controller) validateSearchDates(path, ip string, req *SearchRequest) er
 
 // validateSearchStatusEnums validates VerifiedStatus and LockedStatus.
 func (c *Controller) validateSearchStatusEnums(path, ip string, req *SearchRequest) error {
-	validVerifiedStatus := map[string]bool{QueryValueAny: true, "verified": true, "unverified": true}
+	validVerifiedStatus := map[string]bool{
+		QueryValueAny:    true,
+		"verified":       true,
+		"unverified":     true,
+		"false_positive": true,
+	}
 	if req.VerifiedStatus == "" {
 		req.VerifiedStatus = QueryValueAny
 	} else if !validVerifiedStatus[req.VerifiedStatus] {
 		c.logErrorIfEnabled("Invalid verified status parameter", logger.String("verifiedStatus", req.VerifiedStatus), logger.String("path", path), logger.String("ip", ip))
-		return fmt.Errorf("invalid verified status '%s'. Use 'any', 'verified', or 'unverified'", req.VerifiedStatus)
+		return fmt.Errorf("invalid verified status '%s'. Use 'any', 'verified', 'unverified', or 'false_positive'", req.VerifiedStatus)
 	}
 
 	validLockedStatus := map[string]bool{QueryValueAny: true, "locked": true, "unlocked": true}

--- a/internal/datastore/interfaces.go
+++ b/internal/datastore/interfaces.go
@@ -1988,21 +1988,22 @@ func (ds *DataStore) CountHourlyDetections(date, hour string, duration int) (int
 
 // SearchFilters defines parameters for filtering detection records
 type SearchFilters struct {
-	Species        string
-	DateStart      string
-	DateEnd        string
-	ConfidenceMin  float64
-	ConfidenceMax  float64
-	VerifiedOnly   bool
-	UnverifiedOnly bool
-	LockedOnly     bool
-	UnlockedOnly   bool
-	Device         string
-	TimeOfDay      string // "any", "day", "night", "sunrise", "sunset"
-	Page           int
-	PerPage        int
-	SortBy         string
-	Ctx            context.Context // Add context for cancellation/timeout
+	Species           string
+	DateStart         string
+	DateEnd           string
+	ConfidenceMin     float64
+	ConfidenceMax     float64
+	VerifiedOnly      bool
+	UnverifiedOnly    bool
+	FalsePositiveOnly bool
+	LockedOnly        bool
+	UnlockedOnly      bool
+	Device            string
+	TimeOfDay         string // "any", "day", "night", "sunrise", "sunset"
+	Page              int
+	PerPage           int
+	SortBy            string
+	Ctx               context.Context // Add context for cancellation/timeout
 }
 
 // sanitise validates and normalises the search filters, returning an error for invalid combinations.
@@ -2026,8 +2027,18 @@ func (f *SearchFilters) sanitise() error {
 			Build()
 	}
 	// Validate mutually exclusive Verified flags
-	if f.VerifiedOnly && f.UnverifiedOnly {
-		return errors.Newf("verified_only and unverified_only cannot both be true").
+	verifiedFilterCount := 0
+	if f.VerifiedOnly {
+		verifiedFilterCount++
+	}
+	if f.UnverifiedOnly {
+		verifiedFilterCount++
+	}
+	if f.FalsePositiveOnly {
+		verifiedFilterCount++
+	}
+	if verifiedFilterCount > 1 {
+		return errors.Newf("verified_only, unverified_only, and false_positive_only are mutually exclusive").
 			Component("datastore").
 			Category(errors.CategoryValidation).
 			Build()
@@ -2081,6 +2092,8 @@ func applyCommonFilters(query *gorm.DB, filters *SearchFilters, ds *DataStore) *
 		// Handle NULL case explicitly for unverified
 		query = query.Where("(note_reviews.verified IS NULL OR (note_reviews.verified != ? AND note_reviews.verified != ?))",
 			string(entities.VerificationCorrect), string(entities.VerificationFalsePositive))
+	} else if filters.FalsePositiveOnly {
+		query = query.Where("note_reviews.verified = ?", string(entities.VerificationFalsePositive))
 	}
 
 	if filters.LockedOnly {

--- a/internal/datastore/logger_helpers.go
+++ b/internal/datastore/logger_helpers.go
@@ -227,6 +227,9 @@ func getAppliedFilters(filters *SearchFilters) map[string]any {
 	if filters.UnverifiedOnly {
 		applied["unverified_only"] = filters.UnverifiedOnly
 	}
+	if filters.FalsePositiveOnly {
+		applied["false_positive_only"] = filters.FalsePositiveOnly
+	}
 	if filters.LockedOnly {
 		applied["locked_only"] = filters.LockedOnly
 	}

--- a/internal/datastore/v2/repository/filter_conversion.go
+++ b/internal/datastore/v2/repository/filter_conversion.go
@@ -520,6 +520,9 @@ func ConvertSearchFilters(
 	} else if filters.UnverifiedOnly {
 		isReviewed := false
 		sf.IsReviewed = &isReviewed
+	} else if filters.FalsePositiveOnly {
+		verified := VerificationFilter(entities.VerificationFalsePositive)
+		sf.Verified = &verified
 	}
 
 	// Lock status

--- a/internal/datastore/v2/repository/filter_conversion_test.go
+++ b/internal/datastore/v2/repository/filter_conversion_test.go
@@ -850,6 +850,19 @@ func TestConvertSearchFilters(t *testing.T) {
 		assert.False(t, *result.IsReviewed)
 	})
 
+	t.Run("false positive only sets false_positive verification filter", func(t *testing.T) {
+		filters := &datastore.SearchFilters{
+			FalsePositiveOnly: true,
+		}
+
+		result, err := ConvertSearchFilters(ctx, filters, nil, tz)
+		require.NoError(t, err)
+
+		require.NotNil(t, result.Verified)
+		assert.Equal(t, VerificationFilter(entities.VerificationFalsePositive), *result.Verified)
+		assert.Nil(t, result.IsReviewed)
+	})
+
 	t.Run("locked only sets IsLocked true", func(t *testing.T) {
 		filters := &datastore.SearchFilters{
 			LockedOnly: true,


### PR DESCRIPTION
This PR adds False Positive to status drop down on the search page (and filters the results accordingly) 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "false positive" as a new verification status filter option, allowing users to filter search results by false positive classification
  * Updated result status badges to properly display false positive verification labels across all view formats

* **Tests**
  * Added test coverage for false positive filter functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->