### PR TITLE
lint: add ruleguard rule for brittle error string matching

### DIFF
--- a/internal/api/v2/backup.go
+++ b/internal/api/v2/backup.go
@@ -429,7 +429,7 @@ func (c *Controller) StartBackupJob(ctx echo.Context) error {
 		// Job already exists
 		// NOTE: Ad-hoc response kept because the frontend reads existing_job_id
 		// to resume polling (see DatabaseStatsCard.svelte).
-		if strings.Contains(err.Error(), "already in progress") {
+		if strings.Contains(err.Error(), "already in progress") { //nolint:gocritic // our own error string; no typed error defined for backup-in-progress
 			existingJob, _ := backupJobManager.GetActiveJobByType(dbType)
 			return ctx.JSON(http.StatusConflict, map[string]any{
 				"error":           "Backup already in progress",
@@ -581,7 +581,7 @@ func (c *Controller) runBackupJob(job *BackupJob, gormDB *gorm.DB) {
 		}
 
 		// Check if it's a lock error
-		if !strings.Contains(lastErr.Error(), "locked") {
+		if !strings.Contains(lastErr.Error(), "locked") { //nolint:gocritic // SQLite error from VACUUM INTO exec; not a GORM error so sqlite3.ErrBusy is unavailable
 			break // Non-recoverable error
 		}
 

--- a/internal/api/v2/media.go
+++ b/internal/api/v2/media.go
@@ -535,7 +535,7 @@ func (c *Controller) ServeAudioByID(ctx echo.Context) error {
 	clipPath, err := c.DS.GetNoteClipPath(noteID)
 	if err != nil {
 		// Check if error is due to record not found
-		if errors.Is(err, os.ErrNotExist) || strings.Contains(err.Error(), "not found") { // Adapt based on datastore error type
+		if errors.Is(err, os.ErrNotExist) || strings.Contains(err.Error(), "not found") { //nolint:gocritic // datastore may return unwrapped "not found" strings; errors.Is covers the typed case // Adapt based on datastore error type
 			return c.HandleError(ctx, err, "No audio clip available for this note", http.StatusNotFound)
 		}
 		return c.HandleError(ctx, err, "Failed to get clip path for note", http.StatusInternalServerError)
@@ -650,7 +650,7 @@ func (c *Controller) ExtractAudioClipByID(ctx echo.Context) error {
 	// Resolve clip path from datastore
 	clipPath, err := c.DS.GetNoteClipPath(noteID)
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) || strings.Contains(err.Error(), "not found") {
+		if errors.Is(err, os.ErrNotExist) || strings.Contains(err.Error(), "not found") { //nolint:gocritic // datastore may return unwrapped "not found" strings; errors.Is covers the typed case
 			return c.HandleError(ctx, err, "No audio clip available for this note", http.StatusNotFound)
 		}
 		return c.HandleError(ctx, err, "Failed to get clip path for note", http.StatusInternalServerError)
@@ -782,7 +782,7 @@ func (c *Controller) ProcessAudioByID(ctx echo.Context) error {
 	// Resolve clip path (reuse same pattern as existing handlers like ServeAudioByID)
 	clipPath, err := c.DS.GetNoteClipPath(noteID)
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) || strings.Contains(err.Error(), "not found") {
+		if errors.Is(err, os.ErrNotExist) || strings.Contains(err.Error(), "not found") { //nolint:gocritic // datastore may return unwrapped "not found" strings; errors.Is covers the typed case
 			return c.HandleError(ctx, err, "No audio clip available", http.StatusNotFound)
 		}
 		return c.HandleError(ctx, err, "Failed to get clip path", http.StatusInternalServerError)
@@ -881,7 +881,7 @@ func (c *Controller) ProcessedSpectrogramByID(ctx echo.Context) error {
 	// Resolve clip path
 	clipPath, err := c.DS.GetNoteClipPath(noteID)
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) || strings.Contains(err.Error(), "not found") {
+		if errors.Is(err, os.ErrNotExist) || strings.Contains(err.Error(), "not found") { //nolint:gocritic // datastore may return unwrapped "not found" strings; errors.Is covers the typed case
 			return c.HandleError(ctx, err, "No audio clip available", http.StatusNotFound)
 		}
 		return c.HandleError(ctx, err, "Failed to get clip path", http.StatusInternalServerError)
@@ -1075,7 +1075,7 @@ func (c *Controller) validateNoteIDAndGetClipPath(ctx echo.Context) (noteID, cli
 			logger.Error(err),
 			logger.String("path", ctx.Request().URL.Path),
 			logger.String("ip", ctx.RealIP()))
-		if errors.Is(err, os.ErrNotExist) || strings.Contains(err.Error(), "not found") {
+		if errors.Is(err, os.ErrNotExist) || strings.Contains(err.Error(), "not found") { //nolint:gocritic // datastore may return unwrapped "not found" strings; errors.Is covers the typed case
 			_ = c.HandleError(ctx, err, "No audio clip available for this note", http.StatusNotFound)
 			return
 		}

--- a/internal/audiocore/ffmpeg/stream.go
+++ b/internal/audiocore/ffmpeg/stream.go
@@ -1329,7 +1329,7 @@ func (s *Stream) cleanupProcess() {
 
 		select {
 		case err := <-waitDone:
-			if err != nil && !strings.Contains(err.Error(), "signal: killed") && !strings.Contains(err.Error(), "signal: terminated") {
+			if err != nil && !strings.Contains(err.Error(), "signal: killed") && !strings.Contains(err.Error(), "signal: terminated") { //nolint:gocritic // fallback for non-ExitError types; exit code check is above
 				getStreamLogger().Warn("FFmpeg process wait error",
 					logger.String("url", s.config.safeURL()),
 					logger.Error(err),

--- a/internal/backup/targets/ftp.go
+++ b/internal/backup/targets/ftp.go
@@ -413,7 +413,7 @@ func (t *FTPTarget) List(ctx context.Context) ([]backup.BackupInfo, error) {
 	err := t.withRetry(ctx, func(conn *ftp.ServerConn) error {
 		entries, err := conn.List(t.config.BasePath)
 		if err != nil {
-			if strings.Contains(err.Error(), "No such file or directory") {
+			if strings.Contains(err.Error(), "No such file or directory") { //nolint:gocritic // jlaffaye/ftp does not wrap errors with os.ErrNotExist
 				return nil
 			}
 			return backup.NewError(backup.ErrIO, "ftp: failed to list backups", err)

--- a/internal/backup/targets/sftp.go
+++ b/internal/backup/targets/sftp.go
@@ -589,7 +589,7 @@ func (t *SFTPTarget) List(ctx context.Context) ([]backup.BackupInfo, error) {
 	err := t.withRetry(ctx, func(client *sftp.Client) error {
 		entries, err := client.ReadDir(t.config.BasePath)
 		if err != nil {
-			if strings.Contains(err.Error(), "no such file") {
+			if strings.Contains(err.Error(), "no such file") { //nolint:gocritic // pkg/sftp does not wrap errors with os.ErrNotExist
 				return nil
 			}
 			return errors.New(err).

--- a/internal/datastore/errors_helper.go
+++ b/internal/datastore/errors_helper.go
@@ -251,9 +251,9 @@ func getUserFriendlyMessage(operation string, err error) string {
 		return "The database is currently busy. Please try again in a moment."
 	case constraintPattern.MatchString(err.Error()):
 		return "This operation conflicts with existing data. Please check for duplicates."
-	case strings.Contains(strings.ToLower(err.Error()), "timeout"):
+	case strings.Contains(strings.ToLower(err.Error()), "timeout"): //nolint:gocritic // generic error classifier — timeout errors come from multiple drivers with no common typed error
 		return "The operation took too long. Please try again or contact support if the issue persists."
-	case strings.Contains(strings.ToLower(err.Error()), "not found"):
+	case strings.Contains(strings.ToLower(err.Error()), "not found"): //nolint:gocritic // generic error classifier — covers multiple "not found" sources without a common typed error
 		return "The requested item could not be found."
 	case corruptionPattern.MatchString(err.Error()):
 		return "Database integrity issue detected. Please contact support immediately."

--- a/internal/datastore/interfaces.go
+++ b/internal/datastore/interfaces.go
@@ -1666,7 +1666,7 @@ func (ds *DataStore) LockNote(noteID string) error {
 			FirstOrCreate(lock)
 
 		if result.Error != nil {
-			if strings.Contains(strings.ToLower(result.Error.Error()), "database is locked") {
+			if strings.Contains(strings.ToLower(result.Error.Error()), "database is locked") { //nolint:gocritic // GORM wraps SQLite errors; sqlite3.ErrBusy not reliably extractable through GORM's error chain
 				// Calculate exponential backoff with jitter
 				baseBackoff := baseDelay * time.Duration(attempt+1)
 				jitter := time.Duration(rand.Float64() * 0.25 * float64(baseBackoff)) //nolint:gosec // G404: math/rand is fine for jitter, not security-critical
@@ -1735,7 +1735,7 @@ func (ds *DataStore) UnlockNote(noteID string) error {
 
 		result := ds.DB.Where("note_id = ?", id).Delete(&NoteLock{})
 		if result.Error != nil {
-			if strings.Contains(strings.ToLower(result.Error.Error()), "database is locked") {
+			if strings.Contains(strings.ToLower(result.Error.Error()), "database is locked") { //nolint:gocritic // GORM wraps SQLite errors; sqlite3.ErrBusy not reliably extractable through GORM's error chain
 				// Calculate exponential backoff with jitter
 				baseBackoff := baseDelay * time.Duration(attempt+1)
 				jitter := time.Duration(rand.Float64() * 0.25 * float64(baseBackoff)) //nolint:gosec // G404: math/rand is fine for jitter, not security-critical

--- a/internal/datastore/manage.go
+++ b/internal/datastore/manage.go
@@ -183,7 +183,7 @@ func hasCorrectImageCacheIndexMySQL(db *gorm.DB, dbName string, debug bool) (boo
 
 	if err := db.Raw(query, dbName, targetTableName).Scan(&stats).Error; err != nil {
 		// Handle case where information_schema might not be accessible or table doesn't exist yet
-		if strings.Contains(err.Error(), "doesn't exist") {
+		if strings.Contains(err.Error(), "doesn't exist") { //nolint:gocritic // MySQL information_schema error; no typed error for missing schema metadata
 			return false, nil // Treat as schema incorrect/incomplete if table/schema info missing
 		}
 		return false, fmt.Errorf("failed to query index info from information_schema for %s.%s: %w", dbName, targetTableName, err)

--- a/internal/datastore/mysql.go
+++ b/internal/datastore/mysql.go
@@ -196,7 +196,7 @@ func (store *MySQLStore) Optimize(ctx context.Context) error {
 		// Run OPTIMIZE TABLE
 		if err := store.DB.Exec(fmt.Sprintf("OPTIMIZE TABLE `%s`", table)).Error; err != nil {
 			// MySQL may return a note/warning for InnoDB tables, which is not an error
-			if !strings.Contains(err.Error(), "Table does not support optimize") {
+			if !strings.Contains(err.Error(), "Table does not support optimize") { //nolint:gocritic // MySQL returns this as a note/warning, not a typed error code
 				optimizeLogger.Warn("Failed to optimize table",
 					logger.String("table", table),
 					logger.Error(err),

--- a/internal/imageprovider/wikipedia.go
+++ b/internal/imageprovider/wikipedia.go
@@ -996,7 +996,7 @@ func logSuccessfulAPIResponse(resp *jason.Object) {
 
 // handleJSONParsingErrorIfNeeded checks for JSON parsing errors and handles them appropriately.
 func (l *wikiMediaProvider) handleJSONParsingErrorIfNeeded(err error, reqID, fullURL string, attempt int) error {
-	if !strings.Contains(err.Error(), "invalid character") || !strings.Contains(err.Error(), "looking for beginning of value") {
+	if !strings.Contains(err.Error(), "invalid character") || !strings.Contains(err.Error(), "looking for beginning of value") { //nolint:gocritic // detecting non-JSON responses (HTML error pages); json.SyntaxError does not always contain these substrings
 		return nil
 	}
 

--- a/internal/spectrogram/utils.go
+++ b/internal/spectrogram/utils.go
@@ -147,7 +147,7 @@ func IsOperationalError(err error) bool {
 	}
 
 	// Fallback to string matching for compatibility with other error types
-	return strings.Contains(err.Error(), signalKilledMessage)
+	return strings.Contains(err.Error(), signalKilledMessage) //nolint:gocritic // fallback for non-ExitError types; exit code check is above
 }
 
 // BuildSpectrogramPathWithParams builds a spectrogram path with size/raw encoded in filename.

--- a/rules/error_strings.go
+++ b/rules/error_strings.go
@@ -1,0 +1,70 @@
+//go:build ruleguard
+
+package gorules
+
+import "github.com/quasilyte/go-ruleguard/dsl"
+
+// BrittleErrorStringMatch detects strings.Contains(err.Error(), ...) patterns
+// in production code and suggests using typed errors instead.
+//
+// The brittle pattern:
+//
+//	if strings.Contains(err.Error(), "database is locked") {
+//	    // retry
+//	}
+//
+// Better pattern:
+//
+//	var sqliteErr *sqlite3.Error
+//	if errors.As(err, &sqliteErr) && sqliteErr.Code == sqlite3.ErrBusy {
+//	    // retry
+//	}
+//
+// Why this matters:
+//   - Error message text can change between library versions
+//   - Messages may differ across database drivers or locales
+//   - errors.Is/errors.As are the Go-idiomatic way to classify errors
+//   - String matching silently breaks when upstream changes wording
+//
+// This rule only fires in production code (not test files), since
+// string matching in tests is acceptable for asserting error messages.
+//
+// False positive guidance:
+//   - Some errors (e.g., from exec.Command, net, certain DB drivers)
+//     genuinely lack typed error values. In those cases, add a comment
+//     explaining why string matching is necessary and use //nolint:gocritic.
+func BrittleErrorStringMatch(m dsl.Matcher) {
+	const validationNote = ". VALIDATE: check if the library/driver exposes a typed error or error code before fixing. " +
+		"If no typed error exists, suppress with //nolint:gocritic and a comment explaining why string matching is the only option"
+
+	// Pattern 1: strings.Contains(err.Error(), "...")
+	m.Match(
+		`strings.Contains($err.Error(), $msg)`,
+	).
+		Where(!m.File().Name.Matches(`_test\.go$`)).
+		Report("brittle error classification: strings.Contains($err.Error(), $msg) breaks if message text changes; " +
+			"prefer errors.Is(), errors.As(), or typed error codes" + validationNote)
+
+	// Pattern 2: strings.Contains(strings.ToLower(err.Error()), "...")
+	m.Match(
+		`strings.Contains(strings.ToLower($err.Error()), $msg)`,
+	).
+		Where(!m.File().Name.Matches(`_test\.go$`)).
+		Report("brittle error classification: string matching on lowercased error text is fragile; " +
+			"prefer errors.Is(), errors.As(), or typed error codes" + validationNote)
+
+	// Pattern 3: strings.HasPrefix/HasSuffix on err.Error()
+	m.Match(
+		`strings.HasPrefix($err.Error(), $msg)`,
+	).
+		Where(!m.File().Name.Matches(`_test\.go$`)).
+		Report("brittle error classification: strings.HasPrefix on error text is fragile; " +
+			"prefer errors.Is(), errors.As(), or typed error codes" + validationNote)
+
+	m.Match(
+		`strings.HasSuffix($err.Error(), $msg)`,
+	).
+		Where(!m.File().Name.Matches(`_test\.go$`)).
+		Report("brittle error classification: strings.HasSuffix on error text is fragile; " +
+			"prefer errors.Is(), errors.As(), or typed error codes" + validationNote)
+}


### PR DESCRIPTION
## Summary

Adds a gocritic/ruleguard rule (`rules/error_strings.go`) that detects brittle `strings.Contains(err.Error(), ...)` patterns in production code and suggests using typed errors (`errors.Is`, `errors.As`) instead.

All 18 existing occurrences are suppressed with `//nolint:gocritic` and justification comments. New code will be flagged.

### Suppressions by category

| Category | Count | Justification |
|----------|-------|---------------|
| Datastore lock detection | 3 | GORM wraps SQLite errors; `sqlite3.ErrBusy` not reliably extractable |
| Datastore "not found" fallback | 5 | `errors.Is(os.ErrNotExist)` is primary check; string match is fallback |
| Generic error classifier | 2 | Multi-driver timeout/not-found classification |
| Backup "already in progress" | 1 | Our own error string, no typed error defined |
| VACUUM INTO "locked" | 1 | SQLite error from exec, not GORM |
| FTP/SFTP path not found | 2 | Libraries don't wrap with `os.ErrNotExist` |
| MySQL server messages | 2 | MySQL notes/warnings, no typed error codes |
| FFmpeg/spectrogram signal detection | 2 | Fallback after exit code check |
| Wikipedia JSON detection | 1 | Detecting HTML error pages vs JSON |

## Test plan

- [x] `golangci-lint run`: 0 issues
- [x] `go build ./...`: compiles cleanly
- [ ] CI passes