### PR TITLE
fix: prevent ntfy save button race condition during protocol check

### DIFF
--- a/frontend/src/lib/desktop/features/settings/pages/NotificationsSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/NotificationsSettingsPage.svelte
@@ -835,7 +835,7 @@
 
   // Track an in-flight checkNtfyServer() promise so the save button stays
   // disabled during the debounce window, preventing a race condition.
-  let ntfyCheckPromise: Promise<void> | undefined;
+  let ntfyCheckPromise: Promise<void> | undefined = $state();
 
   function saveProvider() {
     if (!isServiceFormValid) return;


### PR DESCRIPTION
## Summary

- Fix race condition where clicking Save during the 800ms ntfy server protocol check debounce window could hang the UI forever. The old promise saveProvider was awaiting could be replaced by a subsequent keystroke, leaving the await stuck on a promise that would never resolve.
- Disable the save button whenever a protocol check is pending (debounce or active), removing the need for the await entirely.
- Make `ntfyCheckPromise` reactive with `$state()` so the disabled binding actually updates.

Found by Gemini review on #2558.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved the state management and control flow in the notifications settings page for better efficiency.

* **Bug Fixes**
  * Updated the Save button behavior in the ntfy notification service configuration to properly handle pending status checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->