### PR TITLE
fix: cherry-pick ntfy save button race condition fix from main (#2559)

### DIFF
--- a/frontend/src/lib/desktop/features/settings/pages/NotificationsSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/NotificationsSettingsPage.svelte
@@ -1023,12 +1023,17 @@
       ntfyCheckPromise = undefined;
       return;
     }
-    ntfyCheckPromise = new Promise<void>(resolve => {
+    const promise = new Promise<void>(resolve => {
       ntfyAutoCheckTimer = setTimeout(() => {
         checkNtfyServer().finally(resolve);
       }, 800);
-    }).finally(() => {
-      ntfyCheckPromise = undefined;
+    });
+    ntfyCheckPromise = promise;
+    promise.finally(() => {
+      // Only clear if no newer check has replaced us
+      if (ntfyCheckPromise === promise) {
+        ntfyCheckPromise = undefined;
+      }
     });
   }
 


### PR DESCRIPTION
## Summary

Cherry-pick fix for ntfy save button race condition during protocol check from main into next.

- fix: prevent ntfy save button race condition during protocol check (#2559)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved state management for the notifications settings page, specifically refining how the Save button responds when configuring the ntfy service.
  * Enhanced the disabled state logic of the Save button to better reflect the status of in-flight notification server checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->