### PR TITLE
fix: prevent stale finally() from clearing active ntfy check promise

### DIFF
--- a/frontend/src/lib/desktop/features/settings/pages/NotificationsSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/NotificationsSettingsPage.svelte
@@ -1023,12 +1023,17 @@
       ntfyCheckPromise = undefined;
       return;
     }
-    ntfyCheckPromise = new Promise<void>(resolve => {
+    const promise = new Promise<void>(resolve => {
       ntfyAutoCheckTimer = setTimeout(() => {
         checkNtfyServer().finally(resolve);
       }, 800);
-    }).finally(() => {
-      ntfyCheckPromise = undefined;
+    });
+    ntfyCheckPromise = promise;
+    promise.finally(() => {
+      // Only clear if no newer check has replaced us
+      if (ntfyCheckPromise === promise) {
+        ntfyCheckPromise = undefined;
+      }
     });
   }
 


### PR DESCRIPTION
## Summary

Fix a secondary race condition in the ntfy protocol check where a completed check's `.finally()` would unconditionally clear `ntfyCheckPromise`, even if a newer check had replaced it. This could re-enable the save button while a subsequent check was still pending.

Captures the promise in a closure and only clears it if no newer check has taken its place.

Found by Sentry Seer review on #2560. Already applied to `next`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where notification checks could be interrupted by older background tasks, ensuring notification updates remain consistent and reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->