### PR TITLE
refactor: extract isValid() helper to reduce logger nil-guard duplication

### DIFF
--- a/internal/logger/central_logger.go
+++ b/internal/logger/central_logger.go
@@ -477,6 +477,12 @@ type moduleLogger struct {
 	fields   []Field
 }
 
+// isValid reports whether the moduleLogger is properly initialized with a
+// non-nil inner slog.Logger.  It is safe to call on a nil receiver.
+func (m *moduleLogger) isValid() bool {
+	return m != nil && m.logger != nil
+}
+
 // Module creates a sub-module logger.
 // The returned logger shares the parent's slog.Logger but gets its own copy of fields
 // to ensure immutability - modifications to parent fields won't affect children.
@@ -484,7 +490,7 @@ func (m *moduleLogger) Module(name string) Logger {
 	if m == nil {
 		return nil
 	}
-	if m.logger == nil {
+	if !m.isValid() {
 		return m
 	}
 
@@ -499,7 +505,7 @@ func (m *moduleLogger) Module(name string) Logger {
 
 // Trace logs a trace message (most verbose level)
 func (m *moduleLogger) Trace(msg string, fields ...Field) {
-	if m == nil || m.logger == nil || m.level > traceLevelValue {
+	if !m.isValid() || m.level > traceLevelValue {
 		return
 	}
 	m.log(traceLevelValue, msg, fields...)
@@ -507,7 +513,7 @@ func (m *moduleLogger) Trace(msg string, fields ...Field) {
 
 // Debug logs a debug message
 func (m *moduleLogger) Debug(msg string, fields ...Field) {
-	if m == nil || m.logger == nil || m.level > slog.LevelDebug {
+	if !m.isValid() || m.level > slog.LevelDebug {
 		return
 	}
 	m.log(slog.LevelDebug, msg, fields...)
@@ -515,7 +521,7 @@ func (m *moduleLogger) Debug(msg string, fields ...Field) {
 
 // Info logs an info message
 func (m *moduleLogger) Info(msg string, fields ...Field) {
-	if m == nil || m.logger == nil || m.level > slog.LevelInfo {
+	if !m.isValid() || m.level > slog.LevelInfo {
 		return
 	}
 	m.log(slog.LevelInfo, msg, fields...)
@@ -523,7 +529,7 @@ func (m *moduleLogger) Info(msg string, fields ...Field) {
 
 // Warn logs a warning message
 func (m *moduleLogger) Warn(msg string, fields ...Field) {
-	if m == nil || m.logger == nil || m.level > slog.LevelWarn {
+	if !m.isValid() || m.level > slog.LevelWarn {
 		return
 	}
 	m.log(slog.LevelWarn, msg, fields...)
@@ -531,7 +537,7 @@ func (m *moduleLogger) Warn(msg string, fields ...Field) {
 
 // Error logs an error message
 func (m *moduleLogger) Error(msg string, fields ...Field) {
-	if m == nil || m.logger == nil {
+	if !m.isValid() {
 		return
 	}
 	m.log(slog.LevelError, msg, fields...)
@@ -539,7 +545,7 @@ func (m *moduleLogger) Error(msg string, fields ...Field) {
 
 // Log logs a message with explicit level
 func (m *moduleLogger) Log(level LogLevel, msg string, fields ...Field) {
-	if m == nil || m.logger == nil {
+	if !m.isValid() {
 		return
 	}
 	m.log(parseSlogLevel(level), msg, fields...)
@@ -550,7 +556,7 @@ func (m *moduleLogger) With(fields ...Field) Logger {
 	if m == nil {
 		return nil
 	}
-	if m.logger == nil {
+	if !m.isValid() {
 		return m
 	}
 
@@ -568,7 +574,7 @@ func (m *moduleLogger) WithContext(ctx context.Context) Logger {
 	if m == nil {
 		return nil
 	}
-	if m.logger == nil {
+	if !m.isValid() {
 		return m
 	}
 
@@ -594,7 +600,7 @@ func (m *moduleLogger) Flush() error {
 
 // log is the internal logging method
 func (m *moduleLogger) log(level slog.Level, msg string, fields ...Field) {
-	if m == nil || m.logger == nil {
+	if !m.isValid() {
 		return
 	}
 

--- a/internal/logger/slog_logger.go
+++ b/internal/logger/slog_logger.go
@@ -29,6 +29,12 @@ type SlogLogger struct {
 	mu         sync.RWMutex // protects logWriter and slogLogger
 }
 
+// isValid reports whether the SlogLogger is properly initialized with a
+// non-nil inner slog.Logger.  It is safe to call on a nil receiver.
+func (l *SlogLogger) isValid() bool {
+	return l != nil && l.slogLogger != nil
+}
+
 // NewSlogLogger creates a new slog-based logger with JSON output
 func NewSlogLogger(writer io.Writer, level LogLevel, timezone *time.Location) *SlogLogger {
 	if writer == nil {
@@ -143,7 +149,7 @@ func (l *SlogLogger) Module(name string) Logger {
 	if l == nil {
 		return nil
 	}
-	if l.slogLogger == nil {
+	if !l.isValid() {
 		return l
 	}
 
@@ -166,10 +172,7 @@ func (l *SlogLogger) Module(name string) Logger {
 
 // Trace logs a trace message (most verbose level)
 func (l *SlogLogger) Trace(msg string, fields ...Field) {
-	if l == nil || l.slogLogger == nil {
-		return
-	}
-	if l.level > traceLevelValue {
+	if !l.isValid() || l.level > traceLevelValue {
 		return
 	}
 	l.log(traceLevelValue, msg, fields...)
@@ -177,10 +180,7 @@ func (l *SlogLogger) Trace(msg string, fields ...Field) {
 
 // Debug logs a debug message
 func (l *SlogLogger) Debug(msg string, fields ...Field) {
-	if l == nil || l.slogLogger == nil {
-		return
-	}
-	if l.level > slog.LevelDebug {
+	if !l.isValid() || l.level > slog.LevelDebug {
 		return
 	}
 	l.log(slog.LevelDebug, msg, fields...)
@@ -188,10 +188,7 @@ func (l *SlogLogger) Debug(msg string, fields ...Field) {
 
 // Info logs an info message
 func (l *SlogLogger) Info(msg string, fields ...Field) {
-	if l == nil || l.slogLogger == nil {
-		return
-	}
-	if l.level > slog.LevelInfo {
+	if !l.isValid() || l.level > slog.LevelInfo {
 		return
 	}
 	l.log(slog.LevelInfo, msg, fields...)
@@ -199,10 +196,7 @@ func (l *SlogLogger) Info(msg string, fields ...Field) {
 
 // Warn logs a warning message
 func (l *SlogLogger) Warn(msg string, fields ...Field) {
-	if l == nil || l.slogLogger == nil {
-		return
-	}
-	if l.level > slog.LevelWarn {
+	if !l.isValid() || l.level > slog.LevelWarn {
 		return
 	}
 	l.log(slog.LevelWarn, msg, fields...)
@@ -210,7 +204,7 @@ func (l *SlogLogger) Warn(msg string, fields ...Field) {
 
 // Error logs an error message
 func (l *SlogLogger) Error(msg string, fields ...Field) {
-	if l == nil || l.slogLogger == nil {
+	if !l.isValid() {
 		return
 	}
 	l.log(slog.LevelError, msg, fields...)
@@ -218,7 +212,7 @@ func (l *SlogLogger) Error(msg string, fields ...Field) {
 
 // Log logs a message with explicit level
 func (l *SlogLogger) Log(level LogLevel, msg string, fields ...Field) {
-	if l == nil || l.slogLogger == nil {
+	if !l.isValid() {
 		return
 	}
 	l.log(parseSlogLevel(level), msg, fields...)
@@ -229,7 +223,7 @@ func (l *SlogLogger) With(fields ...Field) Logger {
 	if l == nil {
 		return nil
 	}
-	if l.slogLogger == nil {
+	if !l.isValid() {
 		return l
 	}
 
@@ -250,7 +244,7 @@ func (l *SlogLogger) WithContext(ctx context.Context) Logger {
 	if l == nil {
 		return nil
 	}
-	if l.slogLogger == nil {
+	if !l.isValid() {
 		return l
 	}
 	if ctx == nil {
@@ -307,7 +301,7 @@ func (l *SlogLogger) Close() error {
 
 // log is the internal logging method
 func (l *SlogLogger) log(level slog.Level, msg string, fields ...Field) {
-	if l == nil || l.slogLogger == nil {
+	if !l.isValid() {
 		return
 	}
 


### PR DESCRIPTION
## Summary

- Adds `isValid()` method to both `moduleLogger` and `SlogLogger` that consolidates the repeated `receiver == nil || innerLogger == nil` nil-guard check
- Replaces the inline check across all 20 call sites in both types, reducing duplication without changing behavior

Follow-up to #2566 addressing [Gemini review feedback](https://github.com/tphakala/birdnet-go/pull/2566#discussion_r2990675170).

## Test plan

- [x] `go build ./internal/logger/...` passes
- [x] `go vet ./internal/logger/...` passes  
- [x] `go test ./internal/logger/ -count=1` passes (all 42 tests)
- [x] Pure refactor, no behavioral changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal logging code organization and maintainability through streamlined null-safety checks across logging methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->