### PR TITLE
fix: configure MySQL connection pool to prevent resource exhaustion

### DIFF
--- a/internal/datastore/mysql.go
+++ b/internal/datastore/mysql.go
@@ -17,6 +17,16 @@ import (
 	gormlogger "gorm.io/gorm/logger"
 )
 
+// MySQL connection pool defaults. Tuned for BirdNET-Go's typical workload
+// (periodic detections, weather updates, daily events). Conservative relative
+// to MySQL's default max_connections (151), leaving headroom for admin tools.
+const (
+	mysqlMaxOpenConns    = 25
+	mysqlMaxIdleConns    = 10
+	mysqlConnMaxLifetime = 5 * time.Minute
+	mysqlConnMaxIdleTime = 3 * time.Minute
+)
+
 // validTableNameRegex matches valid table names: alphanumeric, underscores, and dashes only
 var validTableNameRegex = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
 
@@ -76,6 +86,23 @@ func (store *MySQLStore) Open() error {
 		GetLogger().Error("Failed to open MySQL database", logger.Error(err))
 		return fmt.Errorf("failed to open MySQL database: %w", err)
 	}
+
+	// Configure connection pool for MySQL.
+	// Unlike SQLite which serializes with MaxOpenConns(1), MySQL handles
+	// concurrent connections natively. These settings prevent resource
+	// exhaustion while keeping warm connections for latency.
+	sqlDB, err := db.DB()
+	if err != nil {
+		return errors.New(err).
+			Component("datastore").
+			Category(errors.CategoryDatabase).
+			Context("operation", "get_underlying_sqldb").
+			Build()
+	}
+	sqlDB.SetMaxOpenConns(mysqlMaxOpenConns)
+	sqlDB.SetMaxIdleConns(mysqlMaxIdleConns)
+	sqlDB.SetConnMaxLifetime(mysqlConnMaxLifetime)
+	sqlDB.SetConnMaxIdleTime(mysqlConnMaxIdleTime)
 
 	store.DB = db
 


### PR DESCRIPTION
## Summary

- Add MySQL connection pool configuration (MaxOpenConns, MaxIdleConns, ConnMaxLifetime, ConnMaxIdleTime) to `MySQLStore.Open()` that was previously missing
- Extract pool values to named constants per project conventions

## Changes

- `mysqlMaxOpenConns = 25` - stays well under MySQL's default `max_connections` (151)
- `mysqlMaxIdleConns = 10` - keeps warm connections for reduced latency
- `mysqlConnMaxLifetime = 5 min` - rotates connections to handle MySQL restarts
- `mysqlConnMaxIdleTime = 3 min` - cleans up unused idle connections
- Proper error wrapping using the project's structured error builder for `db.DB()` failure

## Test plan

- [x] golangci-lint clean on `./internal/datastore/...`
- [x] All datastore tests pass with `-race` flag
- [ ] Verify MySQL connections are properly pooled in a MySQL environment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Enhanced database connection pool configuration for improved performance and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->