### PR TITLE
fix: align v1/v2 MySQL connection pool constants

### DIFF
--- a/internal/datastore/mysql.go
+++ b/internal/datastore/mysql.go
@@ -17,15 +17,8 @@ import (
 	gormlogger "gorm.io/gorm/logger"
 )
 
-// MySQL connection pool defaults. Tuned for BirdNET-Go's typical workload
-// (periodic detections, weather updates, daily events). Conservative relative
-// to MySQL's default max_connections (151), leaving headroom for admin tools.
-const (
-	mysqlMaxOpenConns    = 25
-	mysqlMaxIdleConns    = 10
-	mysqlConnMaxLifetime = 5 * time.Minute
-	mysqlConnMaxIdleTime = 3 * time.Minute
-)
+// MySQL connection pool constants are defined in mysql_pool.go and shared
+// with the v2 store to keep both within MySQL's max_connections budget.
 
 // validTableNameRegex matches valid table names: alphanumeric, underscores, and dashes only
 var validTableNameRegex = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
@@ -99,10 +92,10 @@ func (store *MySQLStore) Open() error {
 			Context("operation", "get_underlying_sqldb").
 			Build()
 	}
-	sqlDB.SetMaxOpenConns(mysqlMaxOpenConns)
-	sqlDB.SetMaxIdleConns(mysqlMaxIdleConns)
-	sqlDB.SetConnMaxLifetime(mysqlConnMaxLifetime)
-	sqlDB.SetConnMaxIdleTime(mysqlConnMaxIdleTime)
+	sqlDB.SetMaxOpenConns(MySQLMaxOpenConns)
+	sqlDB.SetMaxIdleConns(MySQLMaxIdleConns)
+	sqlDB.SetConnMaxLifetime(MySQLConnMaxLifetime)
+	sqlDB.SetConnMaxIdleTime(MySQLConnMaxIdleTime)
 
 	store.DB = db
 

--- a/internal/datastore/mysql_pool.go
+++ b/internal/datastore/mysql_pool.go
@@ -1,0 +1,18 @@
+package datastore
+
+import "time"
+
+// MySQL connection pool defaults shared by both v1 and v2 stores.
+// Tuned for BirdNET-Go's typical workload (periodic detections, weather
+// updates, daily events). Conservative relative to MySQL's default
+// max_connections (151), leaving headroom for admin tools and other clients.
+//
+// During migration both stores are active against the same server, so the
+// combined maximum is 2 * MySQLMaxOpenConns = 50 -- well within the 151
+// default limit.
+const (
+	MySQLMaxOpenConns    = 25
+	MySQLMaxIdleConns    = 10
+	MySQLConnMaxLifetime = 5 * time.Minute
+	MySQLConnMaxIdleTime = 3 * time.Minute
+)

--- a/internal/datastore/v2/mysql_manager.go
+++ b/internal/datastore/v2/mysql_manager.go
@@ -2,8 +2,8 @@ package v2
 
 import (
 	"fmt"
-	"time"
 
+	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/datastore/v2/entities"
 	"gorm.io/driver/mysql"
 	"gorm.io/gorm"
@@ -67,14 +67,17 @@ func NewMySQLManager(cfg *MySQLConfig) (*MySQLManager, error) {
 		return nil, fmt.Errorf("failed to open MySQL database for v2: %w", err)
 	}
 
-	// Configure connection pool
+	// Configure connection pool using shared constants (see datastore.MySQL*).
+	// Matches the v1 store so both stay within MySQL's max_connections budget
+	// during migration when both are active (combined max = 2 * 25 = 50).
 	sqlDB, err := db.DB()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get underlying database: %w", err)
 	}
-	sqlDB.SetMaxIdleConns(10)
-	sqlDB.SetMaxOpenConns(100)
-	sqlDB.SetConnMaxLifetime(time.Hour)
+	sqlDB.SetMaxOpenConns(datastore.MySQLMaxOpenConns)
+	sqlDB.SetMaxIdleConns(datastore.MySQLMaxIdleConns)
+	sqlDB.SetConnMaxLifetime(datastore.MySQLConnMaxLifetime)
+	sqlDB.SetConnMaxIdleTime(datastore.MySQLConnMaxIdleTime)
 
 	return &MySQLManager{
 		db:          db,


### PR DESCRIPTION
## Summary

- Extract MySQL pool constants to shared `mysql_pool.go` so both v1 and v2 stores use identical settings
- Align v2 pool to v1's conservative values (25 max open conns, 5min lifetime)
- Add missing `ConnMaxIdleTime` to v2 store (was not set, connections idled indefinitely)

## Behavioral changes

The v2 MySQL store pool settings change significantly:
- `MaxOpenConns`: 100 → 25 (4x reduction — 100 was excessive for home-user workload)
- `ConnMaxLifetime`: 1 hour → 5 minutes (prevents stale connections after MySQL restarts)
- `ConnMaxIdleTime`: unset → 3 minutes (new — cleans up idle connections)

During migration when both stores are active, combined max is now 50 (25+25) instead of 125 (25+100), well within MySQL's default `max_connections` of 151.

## Test plan

- [x] golangci-lint clean
- [x] All datastore tests pass with `-race`
- [x] No circular import (v2 already imports from parent datastore package)
- [ ] Verify MySQL pool behavior in a MySQL environment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Centralized MySQL connection pool configuration to standardize settings across internal datastores, improving consistency in database connection handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->