### PR TITLE
fix: add RetryOnLock to all v2 repository write paths

### DIFF
--- a/internal/datastore/v2/repository/alert_rule_impl.go
+++ b/internal/datastore/v2/repository/alert_rule_impl.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/datastore/v2/entities"
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"gorm.io/gorm"
@@ -59,10 +60,12 @@ func (r *alertRuleRepository) GetRule(ctx context.Context, id uint) (*entities.A
 
 // CreateRule creates a new alert rule with its conditions and actions.
 func (r *alertRuleRepository) CreateRule(ctx context.Context, rule *entities.AlertRule) error {
-	if err := r.db.WithContext(ctx).Create(rule).Error; err != nil {
-		return fmt.Errorf("failed to create alert rule: %w", err)
-	}
-	return nil
+	return datastore.RetryOnLock("v2_create_alert_rule", func() error {
+		if err := r.db.WithContext(ctx).Create(rule).Error; err != nil {
+			return fmt.Errorf("failed to create alert rule: %w", err)
+		}
+		return nil
+	}, nil)
 }
 
 // UpdateRule replaces an alert rule, deleting existing conditions and actions first.
@@ -70,14 +73,14 @@ func (r *alertRuleRepository) UpdateRule(ctx context.Context, rule *entities.Ale
 	if rule.ID == 0 {
 		return fmt.Errorf("failed to update alert rule: missing rule ID")
 	}
-	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+	return datastore.RetryTransactionOnLock(r.db.WithContext(ctx), "v2_update_alert_rule", func(tx *gorm.DB) error {
 		if err := tx.Where("rule_id = ?", rule.ID).Delete(&entities.AlertCondition{}).Error; err != nil {
 			return fmt.Errorf("failed to delete old conditions: %w", err)
 		}
 		if err := tx.Where("rule_id = ?", rule.ID).Delete(&entities.AlertAction{}).Error; err != nil {
 			return fmt.Errorf("failed to delete old actions: %w", err)
 		}
-		// Zero out IDs so GORM inserts new rows instead of trying to update deleted ones
+		// Reset IDs to prevent stale primary keys on retry
 		for i := range rule.Conditions {
 			rule.Conditions[i].ID = 0
 		}
@@ -88,16 +91,24 @@ func (r *alertRuleRepository) UpdateRule(ctx context.Context, rule *entities.Ale
 			return fmt.Errorf("failed to update alert rule: %w", err)
 		}
 		return nil
-	})
+	}, nil)
 }
 
 // DeleteRule deletes an alert rule and its conditions/actions via cascade.
 func (r *alertRuleRepository) DeleteRule(ctx context.Context, id uint) error {
-	result := r.db.WithContext(ctx).Delete(&entities.AlertRule{}, id)
-	if result.Error != nil {
-		return fmt.Errorf("failed to delete alert rule %d: %w", id, result.Error)
+	var rowsAffected int64
+	err := datastore.RetryOnLock("v2_delete_alert_rule", func() error {
+		result := r.db.WithContext(ctx).Delete(&entities.AlertRule{}, id)
+		if result.Error != nil {
+			return fmt.Errorf("failed to delete alert rule %d: %w", id, result.Error)
+		}
+		rowsAffected = result.RowsAffected
+		return nil
+	}, nil)
+	if err != nil {
+		return err
 	}
-	if result.RowsAffected == 0 {
+	if rowsAffected == 0 {
 		return ErrAlertRuleNotFound
 	}
 	return nil
@@ -105,11 +116,19 @@ func (r *alertRuleRepository) DeleteRule(ctx context.Context, id uint) error {
 
 // ToggleRule enables or disables an alert rule.
 func (r *alertRuleRepository) ToggleRule(ctx context.Context, id uint, enabled bool) error {
-	result := r.db.WithContext(ctx).Model(&entities.AlertRule{}).Where("id = ?", id).Update("enabled", enabled)
-	if result.Error != nil {
-		return fmt.Errorf("failed to toggle alert rule %d: %w", id, result.Error)
+	var rowsAffected int64
+	err := datastore.RetryOnLock("v2_toggle_alert_rule", func() error {
+		result := r.db.WithContext(ctx).Model(&entities.AlertRule{}).Where("id = ?", id).Update("enabled", enabled)
+		if result.Error != nil {
+			return fmt.Errorf("failed to toggle alert rule %d: %w", id, result.Error)
+		}
+		rowsAffected = result.RowsAffected
+		return nil
+	}, nil)
+	if err != nil {
+		return err
 	}
-	if result.RowsAffected == 0 {
+	if rowsAffected == 0 {
 		return ErrAlertRuleNotFound
 	}
 	return nil
@@ -123,19 +142,26 @@ func (r *alertRuleRepository) GetEnabledRules(ctx context.Context) ([]entities.A
 
 // DeleteBuiltInRules deletes all built-in alert rules.
 func (r *alertRuleRepository) DeleteBuiltInRules(ctx context.Context) (int64, error) {
-	result := r.db.WithContext(ctx).Where("built_in = ?", true).Delete(&entities.AlertRule{})
-	if result.Error != nil {
-		return 0, fmt.Errorf("failed to delete built-in alert rules: %w", result.Error)
-	}
-	return result.RowsAffected, nil
+	var rowsAffected int64
+	err := datastore.RetryOnLock("v2_delete_built_in_rules", func() error {
+		result := r.db.WithContext(ctx).Where("built_in = ?", true).Delete(&entities.AlertRule{})
+		if result.Error != nil {
+			return fmt.Errorf("failed to delete built-in alert rules: %w", result.Error)
+		}
+		rowsAffected = result.RowsAffected
+		return nil
+	}, nil)
+	return rowsAffected, err
 }
 
 // SaveHistory saves an alert history entry.
 func (r *alertRuleRepository) SaveHistory(ctx context.Context, history *entities.AlertHistory) error {
-	if err := r.db.WithContext(ctx).Create(history).Error; err != nil {
-		return fmt.Errorf("failed to save alert history: %w", err)
-	}
-	return nil
+	return datastore.RetryOnLock("v2_save_alert_history", func() error {
+		if err := r.db.WithContext(ctx).Create(history).Error; err != nil {
+			return fmt.Errorf("failed to save alert history: %w", err)
+		}
+		return nil
+	}, nil)
 }
 
 // ListHistory returns alert history entries matching the filter with pagination.
@@ -169,20 +195,30 @@ func (r *alertRuleRepository) ListHistory(ctx context.Context, filter AlertHisto
 
 // DeleteHistory deletes all alert history entries.
 func (r *alertRuleRepository) DeleteHistory(ctx context.Context) (int64, error) {
-	result := r.db.WithContext(ctx).Where("1 = 1").Delete(&entities.AlertHistory{})
-	if result.Error != nil {
-		return 0, fmt.Errorf("failed to delete alert history: %w", result.Error)
-	}
-	return result.RowsAffected, nil
+	var rowsAffected int64
+	err := datastore.RetryOnLock("v2_delete_alert_history", func() error {
+		result := r.db.WithContext(ctx).Where("1 = 1").Delete(&entities.AlertHistory{})
+		if result.Error != nil {
+			return fmt.Errorf("failed to delete alert history: %w", result.Error)
+		}
+		rowsAffected = result.RowsAffected
+		return nil
+	}, nil)
+	return rowsAffected, err
 }
 
 // DeleteHistoryBefore deletes alert history entries older than the given time.
 func (r *alertRuleRepository) DeleteHistoryBefore(ctx context.Context, before time.Time) (int64, error) {
-	result := r.db.WithContext(ctx).Where("fired_at < ?", before).Delete(&entities.AlertHistory{})
-	if result.Error != nil {
-		return 0, fmt.Errorf("failed to delete alert history before %v: %w", before, result.Error)
-	}
-	return result.RowsAffected, nil
+	var rowsAffected int64
+	err := datastore.RetryOnLock("v2_delete_alert_history_before", func() error {
+		result := r.db.WithContext(ctx).Where("fired_at < ?", before).Delete(&entities.AlertHistory{})
+		if result.Error != nil {
+			return fmt.Errorf("failed to delete alert history before %v: %w", before, result.Error)
+		}
+		rowsAffected = result.RowsAffected
+		return nil
+	}, nil)
+	return rowsAffected, err
 }
 
 // CountRulesByName returns the number of rules with the given name.

--- a/internal/datastore/v2/repository/app_metadata_impl.go
+++ b/internal/datastore/v2/repository/app_metadata_impl.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/datastore/v2/entities"
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"gorm.io/gorm"
@@ -60,13 +61,15 @@ func (r *appMetadataRepository) Set(ctx context.Context, key, value string) erro
 		Key:   key,
 		Value: value,
 	}
-	if err := r.db.WithContext(ctx).Table(r.tableName()).
-		Clauses(clause.OnConflict{
-			Columns:   []clause.Column{{Name: "key"}},
-			DoUpdates: clause.AssignmentColumns([]string{"value"}),
-		}).
-		Create(&meta).Error; err != nil {
-		return fmt.Errorf("set app metadata key %q: %w", key, err)
-	}
-	return nil
+	return datastore.RetryOnLock("v2_set_app_metadata", func() error {
+		if err := r.db.WithContext(ctx).Table(r.tableName()).
+			Clauses(clause.OnConflict{
+				Columns:   []clause.Column{{Name: "key"}},
+				DoUpdates: clause.AssignmentColumns([]string{"value"}),
+			}).
+			Create(&meta).Error; err != nil {
+			return fmt.Errorf("set app metadata key %q: %w", key, err)
+		}
+		return nil
+	}, nil)
 }

--- a/internal/datastore/v2/repository/audio_source_impl.go
+++ b/internal/datastore/v2/repository/audio_source_impl.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/datastore/v2/entities"
 	"gorm.io/gorm"
 )
@@ -65,7 +66,9 @@ func (r *audioSourceRepository) GetOrCreate(ctx context.Context, sourceURI, node
 		SourceType:  sourceType,
 	}
 
-	createErr := r.db.WithContext(ctx).Table(r.tableName()).Create(&source).Error
+	createErr := datastore.RetryOnLock("v2_create_audio_source", func() error {
+		return r.db.WithContext(ctx).Table(r.tableName()).Create(&source).Error
+	}, nil)
 	if createErr != nil {
 		// Handle race condition - another goroutine may have created it.
 		// Try to fetch the existing record; if that also fails, return the original create error.
@@ -183,11 +186,19 @@ func (r *audioSourceRepository) Count(ctx context.Context) (int64, error) {
 
 // Delete removes an audio source by ID.
 func (r *audioSourceRepository) Delete(ctx context.Context, id uint) error {
-	result := r.db.WithContext(ctx).Table(r.tableName()).Delete(&entities.AudioSource{}, id)
-	if result.Error != nil {
-		return result.Error
+	var rowsAffected int64
+	err := datastore.RetryOnLock("v2_delete_audio_source", func() error {
+		result := r.db.WithContext(ctx).Table(r.tableName()).Delete(&entities.AudioSource{}, id)
+		if result.Error != nil {
+			return result.Error
+		}
+		rowsAffected = result.RowsAffected
+		return nil
+	}, nil)
+	if err != nil {
+		return err
 	}
-	if result.RowsAffected == 0 {
+	if rowsAffected == 0 {
 		return ErrAudioSourceNotFound
 	}
 	return nil
@@ -195,13 +206,21 @@ func (r *audioSourceRepository) Delete(ctx context.Context, id uint) error {
 
 // Update modifies an audio source's fields.
 func (r *audioSourceRepository) Update(ctx context.Context, id uint, updates map[string]any) error {
-	result := r.db.WithContext(ctx).Table(r.tableName()).
-		Where("id = ?", id).
-		Updates(updates)
-	if result.Error != nil {
-		return result.Error
+	var rowsAffected int64
+	err := datastore.RetryOnLock("v2_update_audio_source", func() error {
+		result := r.db.WithContext(ctx).Table(r.tableName()).
+			Where("id = ?", id).
+			Updates(updates)
+		if result.Error != nil {
+			return result.Error
+		}
+		rowsAffected = result.RowsAffected
+		return nil
+	}, nil)
+	if err != nil {
+		return err
 	}
-	if result.RowsAffected == 0 {
+	if rowsAffected == 0 {
 		return ErrAudioSourceNotFound
 	}
 	return nil

--- a/internal/datastore/v2/repository/detection_impl.go
+++ b/internal/datastore/v2/repository/detection_impl.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"maps"
 	"slices"
-	"strings"
 	"time"
 
+	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/datastore/v2/entities"
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"gorm.io/gorm"
@@ -133,13 +133,17 @@ func (r *detectionRepository) hourFromUnixExpr(column string) string {
 
 // Save persists a new detection.
 func (r *detectionRepository) Save(ctx context.Context, det *entities.Detection) error {
-	return r.db.WithContext(ctx).Table(r.tableName()).Create(det).Error
+	return datastore.RetryOnLock("v2_save_detection", func() error {
+		return r.db.WithContext(ctx).Table(r.tableName()).Create(det).Error
+	}, nil)
 }
 
 // SaveWithID persists a detection with a specific ID (for migration).
 // GORM's Create() respects pre-set IDs, so no special handling is needed.
 func (r *detectionRepository) SaveWithID(ctx context.Context, det *entities.Detection) error {
-	return r.db.WithContext(ctx).Table(r.tableName()).Create(det).Error
+	return datastore.RetryOnLock("v2_save_detection_with_id", func() error {
+		return r.db.WithContext(ctx).Table(r.tableName()).Create(det).Error
+	}, nil)
 }
 
 // Get retrieves a detection by ID.
@@ -232,18 +236,25 @@ func (r *detectionRepository) GetWithRelations(ctx context.Context, id uint) (*e
 // Update modifies specific fields of a detection.
 // Uses atomic operation to prevent TOCTOU race with lock checks.
 func (r *detectionRepository) Update(ctx context.Context, id uint, updates map[string]any) error {
-	// Atomic update: only update if not locked
-	// Use WHERE NOT EXISTS to combine lock check with update
-	result := r.db.WithContext(ctx).Table(r.tableName()).
-		Where("id = ?", id).
-		Where(fmt.Sprintf("NOT EXISTS (SELECT 1 FROM %s WHERE %s.detection_id = ?)",
-			r.locksTable(), r.locksTable()), id).
-		Updates(updates)
-
-	if result.Error != nil {
-		return result.Error
+	var rowsAffected int64
+	err := datastore.RetryOnLock("v2_update_detection", func() error {
+		// Atomic update: only update if not locked
+		// Use WHERE NOT EXISTS to combine lock check with update
+		result := r.db.WithContext(ctx).Table(r.tableName()).
+			Where("id = ?", id).
+			Where(fmt.Sprintf("NOT EXISTS (SELECT 1 FROM %s WHERE %s.detection_id = ?)",
+				r.locksTable(), r.locksTable()), id).
+			Updates(updates)
+		if result.Error != nil {
+			return result.Error
+		}
+		rowsAffected = result.RowsAffected
+		return nil
+	}, nil)
+	if err != nil {
+		return err
 	}
-	if result.RowsAffected == 0 {
+	if rowsAffected == 0 {
 		// Could be: not found OR locked. Check which.
 		exists, err := r.Exists(ctx, id)
 		if err != nil {
@@ -260,17 +271,24 @@ func (r *detectionRepository) Update(ctx context.Context, id uint, updates map[s
 // Delete removes a detection by ID.
 // Uses atomic operation to prevent TOCTOU race with lock checks.
 func (r *detectionRepository) Delete(ctx context.Context, id uint) error {
-	// Atomic delete: only delete if not locked
-	// Use raw SQL with NOT EXISTS to combine lock check with delete
-	result := r.db.WithContext(ctx).Exec(
-		fmt.Sprintf("DELETE FROM %s WHERE id = ? AND NOT EXISTS (SELECT 1 FROM %s WHERE %s.detection_id = ?)",
-			r.tableName(), r.locksTable(), r.locksTable()),
-		id, id)
-
-	if result.Error != nil {
-		return result.Error
+	var rowsAffected int64
+	err := datastore.RetryOnLock("v2_delete_detection", func() error {
+		// Atomic delete: only delete if not locked
+		// Use raw SQL with NOT EXISTS to combine lock check with delete
+		result := r.db.WithContext(ctx).Exec(
+			fmt.Sprintf("DELETE FROM %s WHERE id = ? AND NOT EXISTS (SELECT 1 FROM %s WHERE %s.detection_id = ?)",
+				r.tableName(), r.locksTable(), r.locksTable()),
+			id, id)
+		if result.Error != nil {
+			return result.Error
+		}
+		rowsAffected = result.RowsAffected
+		return nil
+	}, nil)
+	if err != nil {
+		return err
 	}
-	if result.RowsAffected == 0 {
+	if rowsAffected == 0 {
 		// Could be: not found OR locked. Check which.
 		exists, err := r.Exists(ctx, id)
 		if err != nil {
@@ -293,7 +311,9 @@ func (r *detectionRepository) SaveBatch(ctx context.Context, dets []*entities.De
 	if len(dets) == 0 {
 		return nil
 	}
-	return r.db.WithContext(ctx).Table(r.tableName()).CreateInBatches(dets, defaultDBBatchSize).Error
+	return datastore.RetryOnLock("v2_save_detection_batch", func() error {
+		return r.db.WithContext(ctx).Table(r.tableName()).CreateInBatches(dets, defaultDBBatchSize).Error
+	}, nil)
 }
 
 // DeleteBatch removes multiple detections by ID.
@@ -301,7 +321,9 @@ func (r *detectionRepository) DeleteBatch(ctx context.Context, ids []uint) error
 	if len(ids) == 0 {
 		return nil
 	}
-	return r.db.WithContext(ctx).Table(r.tableName()).Delete(&entities.Detection{}, ids).Error
+	return datastore.RetryOnLock("v2_delete_detection_batch", func() error {
+		return r.db.WithContext(ctx).Table(r.tableName()).Delete(&entities.Detection{}, ids).Error
+	}, nil)
 }
 
 // SaveBatchWithIDs persists multiple detections with specific IDs (for migration).
@@ -310,7 +332,9 @@ func (r *detectionRepository) SaveBatchWithIDs(ctx context.Context, dets []*enti
 	if len(dets) == 0 {
 		return nil
 	}
-	return r.db.WithContext(ctx).Table(r.tableName()).CreateInBatches(dets, defaultDBBatchSize).Error
+	return datastore.RetryOnLock("v2_save_detection_batch_with_ids", func() error {
+		return r.db.WithContext(ctx).Table(r.tableName()).CreateInBatches(dets, defaultDBBatchSize).Error
+	}, nil)
 }
 
 // GetExistingAndLockedIDs checks which IDs exist and which are locked.
@@ -984,7 +1008,9 @@ func (r *detectionRepository) SavePredictions(ctx context.Context, detectionID u
 		p.DetectionID = detectionID
 	}
 
-	return r.db.WithContext(ctx).Table(r.predictionsTable()).Create(&preds).Error
+	return datastore.RetryOnLock("v2_save_predictions", func() error {
+		return r.db.WithContext(ctx).Table(r.predictionsTable()).Create(&preds).Error
+	}, nil)
 }
 
 // SavePredictionsBatch stores predictions for multiple detections efficiently.
@@ -993,9 +1019,11 @@ func (r *detectionRepository) SavePredictionsBatch(ctx context.Context, preds []
 	if len(preds) == 0 {
 		return nil
 	}
-	return r.db.WithContext(ctx).Table(r.predictionsTable()).
-		Clauses(clause.OnConflict{DoNothing: true}).
-		CreateInBatches(preds, defaultDBBatchSize).Error
+	return datastore.RetryOnLock("v2_save_predictions_batch", func() error {
+		return r.db.WithContext(ctx).Table(r.predictionsTable()).
+			Clauses(clause.OnConflict{DoNothing: true}).
+			CreateInBatches(preds, defaultDBBatchSize).Error
+	}, nil)
 }
 
 // GetPredictions retrieves all predictions for a detection.
@@ -1010,9 +1038,11 @@ func (r *detectionRepository) GetPredictions(ctx context.Context, detectionID ui
 
 // DeletePredictions removes all predictions for a detection.
 func (r *detectionRepository) DeletePredictions(ctx context.Context, detectionID uint) error {
-	return r.db.WithContext(ctx).Table(r.predictionsTable()).
-		Where("detection_id = ?", detectionID).
-		Delete(&entities.DetectionPrediction{}).Error
+	return datastore.RetryOnLock("v2_delete_predictions", func() error {
+		return r.db.WithContext(ctx).Table(r.predictionsTable()).
+			Where("detection_id = ?", detectionID).
+			Delete(&entities.DetectionPrediction{}).Error
+	}, nil)
 }
 
 // ============================================================================
@@ -1029,19 +1059,23 @@ func (r *detectionRepository) SaveReview(ctx context.Context, review *entities.D
 
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		// Create new review
-		return r.db.WithContext(ctx).Table(r.reviewsTable()).Create(review).Error
+		return datastore.RetryOnLock("v2_save_review", func() error {
+			return r.db.WithContext(ctx).Table(r.reviewsTable()).Create(review).Error
+		}, nil)
 	}
 	if err != nil {
 		return err
 	}
 
 	// Update existing review
-	return r.db.WithContext(ctx).Table(r.reviewsTable()).
-		Where("detection_id = ?", review.DetectionID).
-		Updates(map[string]any{
-			"verified":   review.Verified,
-			"updated_at": time.Now(),
-		}).Error
+	return datastore.RetryOnLock("v2_save_review_update", func() error {
+		return r.db.WithContext(ctx).Table(r.reviewsTable()).
+			Where("detection_id = ?", review.DetectionID).
+			Updates(map[string]any{
+				"verified":   review.Verified,
+				"updated_at": time.Now(),
+			}).Error
+	}, nil)
 }
 
 // GetReview retrieves the review for a detection.
@@ -1058,16 +1092,24 @@ func (r *detectionRepository) GetReview(ctx context.Context, detectionID uint) (
 
 // UpdateReview updates the verification status for a detection.
 func (r *detectionRepository) UpdateReview(ctx context.Context, detectionID uint, verified entities.VerificationStatus) error {
-	result := r.db.WithContext(ctx).Table(r.reviewsTable()).
-		Where("detection_id = ?", detectionID).
-		Updates(map[string]any{
-			"verified":   verified,
-			"updated_at": time.Now(),
-		})
-	if result.Error != nil {
-		return result.Error
+	var rowsAffected int64
+	err := datastore.RetryOnLock("v2_update_review", func() error {
+		result := r.db.WithContext(ctx).Table(r.reviewsTable()).
+			Where("detection_id = ?", detectionID).
+			Updates(map[string]any{
+				"verified":   verified,
+				"updated_at": time.Now(),
+			})
+		if result.Error != nil {
+			return result.Error
+		}
+		rowsAffected = result.RowsAffected
+		return nil
+	}, nil)
+	if err != nil {
+		return err
 	}
-	if result.RowsAffected == 0 {
+	if rowsAffected == 0 {
 		return ErrReviewNotFound
 	}
 	return nil
@@ -1075,13 +1117,21 @@ func (r *detectionRepository) UpdateReview(ctx context.Context, detectionID uint
 
 // DeleteReview removes the review for a detection.
 func (r *detectionRepository) DeleteReview(ctx context.Context, detectionID uint) error {
-	result := r.db.WithContext(ctx).Table(r.reviewsTable()).
-		Where("detection_id = ?", detectionID).
-		Delete(&entities.DetectionReview{})
-	if result.Error != nil {
-		return result.Error
+	var rowsAffected int64
+	err := datastore.RetryOnLock("v2_delete_review", func() error {
+		result := r.db.WithContext(ctx).Table(r.reviewsTable()).
+			Where("detection_id = ?", detectionID).
+			Delete(&entities.DetectionReview{})
+		if result.Error != nil {
+			return result.Error
+		}
+		rowsAffected = result.RowsAffected
+		return nil
+	}, nil)
+	if err != nil {
+		return err
 	}
-	if result.RowsAffected == 0 {
+	if rowsAffected == 0 {
 		return ErrReviewNotFound
 	}
 	return nil
@@ -1092,9 +1142,11 @@ func (r *detectionRepository) SaveReviewsBatch(ctx context.Context, reviews []*e
 	if len(reviews) == 0 {
 		return nil
 	}
-	return r.db.WithContext(ctx).Table(r.reviewsTable()).
-		Clauses(clause.OnConflict{DoNothing: true}).
-		CreateInBatches(reviews, defaultDBBatchSize).Error
+	return datastore.RetryOnLock("v2_save_reviews_batch", func() error {
+		return r.db.WithContext(ctx).Table(r.reviewsTable()).
+			Clauses(clause.OnConflict{DoNothing: true}).
+			CreateInBatches(reviews, defaultDBBatchSize).Error
+	}, nil)
 }
 
 // GetReviewsByDetectionIDs retrieves reviews for multiple detections.
@@ -1130,7 +1182,9 @@ func (r *detectionRepository) GetReviewsByDetectionIDs(ctx context.Context, dete
 
 // SaveComment adds a comment to a detection.
 func (r *detectionRepository) SaveComment(ctx context.Context, comment *entities.DetectionComment) error {
-	return r.db.WithContext(ctx).Table(r.commentsTable()).Create(comment).Error
+	return datastore.RetryOnLock("v2_save_comment", func() error {
+		return r.db.WithContext(ctx).Table(r.commentsTable()).Create(comment).Error
+	}, nil)
 }
 
 // GetComments retrieves all comments for a detection.
@@ -1145,16 +1199,24 @@ func (r *detectionRepository) GetComments(ctx context.Context, detectionID uint)
 
 // UpdateComment modifies a comment's content.
 func (r *detectionRepository) UpdateComment(ctx context.Context, commentID uint, entry string) error {
-	result := r.db.WithContext(ctx).Table(r.commentsTable()).
-		Where("id = ?", commentID).
-		Updates(map[string]any{
-			"entry":      entry,
-			"updated_at": time.Now(),
-		})
-	if result.Error != nil {
-		return result.Error
+	var rowsAffected int64
+	err := datastore.RetryOnLock("v2_update_comment", func() error {
+		result := r.db.WithContext(ctx).Table(r.commentsTable()).
+			Where("id = ?", commentID).
+			Updates(map[string]any{
+				"entry":      entry,
+				"updated_at": time.Now(),
+			})
+		if result.Error != nil {
+			return result.Error
+		}
+		rowsAffected = result.RowsAffected
+		return nil
+	}, nil)
+	if err != nil {
+		return err
 	}
-	if result.RowsAffected == 0 {
+	if rowsAffected == 0 {
 		return ErrCommentNotFound
 	}
 	return nil
@@ -1162,11 +1224,19 @@ func (r *detectionRepository) UpdateComment(ctx context.Context, commentID uint,
 
 // DeleteComment removes a specific comment.
 func (r *detectionRepository) DeleteComment(ctx context.Context, commentID uint) error {
-	result := r.db.WithContext(ctx).Table(r.commentsTable()).Delete(&entities.DetectionComment{}, commentID)
-	if result.Error != nil {
-		return result.Error
+	var rowsAffected int64
+	err := datastore.RetryOnLock("v2_delete_comment", func() error {
+		result := r.db.WithContext(ctx).Table(r.commentsTable()).Delete(&entities.DetectionComment{}, commentID)
+		if result.Error != nil {
+			return result.Error
+		}
+		rowsAffected = result.RowsAffected
+		return nil
+	}, nil)
+	if err != nil {
+		return err
 	}
-	if result.RowsAffected == 0 {
+	if rowsAffected == 0 {
 		return ErrCommentNotFound
 	}
 	return nil
@@ -1177,9 +1247,11 @@ func (r *detectionRepository) SaveCommentsBatch(ctx context.Context, comments []
 	if len(comments) == 0 {
 		return nil
 	}
-	return r.db.WithContext(ctx).Table(r.commentsTable()).
-		Clauses(clause.OnConflict{DoNothing: true}).
-		CreateInBatches(comments, defaultDBBatchSize).Error
+	return datastore.RetryOnLock("v2_save_comments_batch", func() error {
+		return r.db.WithContext(ctx).Table(r.commentsTable()).
+			Clauses(clause.OnConflict{DoNothing: true}).
+			CreateInBatches(comments, defaultDBBatchSize).Error
+	}, nil)
 }
 
 // GetCommentsByDetectionIDs retrieves comments for multiple detections.
@@ -1232,54 +1304,20 @@ func (r *detectionRepository) Lock(ctx context.Context, detectionID uint) error 
 	}
 
 	lock := entities.DetectionLock{DetectionID: detectionID}
-	return r.db.WithContext(ctx).Table(r.locksTable()).Create(&lock).Error
+	return datastore.RetryOnLock("v2_lock_detection", func() error {
+		return r.db.WithContext(ctx).Table(r.locksTable()).Create(&lock).Error
+	}, nil)
 }
 
 // Unlock removes the lock from a detection.
 // This operation is idempotent — unlocking an already-unlocked detection succeeds silently.
-// Uses retry with exponential backoff for transient SQLite lock contention.
+// Uses RetryOnLock for transient SQLite lock contention.
 func (r *detectionRepository) Unlock(ctx context.Context, detectionID uint) error {
-	const (
-		maxRetries = 5
-		baseDelay  = 500 * time.Millisecond
-	)
-
-	var lastErr error
-	for attempt := range maxRetries {
-		result := r.db.WithContext(ctx).Table(r.locksTable()).
+	return datastore.RetryOnLock("v2_unlock_detection", func() error {
+		return r.db.WithContext(ctx).Table(r.locksTable()).
 			Where("detection_id = ?", detectionID).
-			Delete(&entities.DetectionLock{})
-		if result.Error == nil {
-			return nil
-		}
-
-		lastErr = result.Error
-		if !isDBLockError(lastErr) || attempt == maxRetries-1 {
-			return fmt.Errorf("unlock detection %d: %w", detectionID, lastErr)
-		}
-
-		// Exponential backoff: 500ms, 1s, 2s, 4s — respect context cancellation
-		delay := baseDelay * time.Duration(1<<attempt)
-		select {
-		case <-ctx.Done():
-			return fmt.Errorf("unlock detection %d: %w", detectionID, ctx.Err())
-		case <-time.After(delay):
-		}
-	}
-	return fmt.Errorf("unlock detection %d after %d retries: %w", detectionID, maxRetries, lastErr)
-}
-
-// isDBLockError checks if an error is a transient database lock contention error.
-// Handles both SQLite and MySQL lock errors.
-func isDBLockError(err error) bool {
-	if err == nil {
-		return false
-	}
-	errStr := err.Error()
-	return strings.Contains(errStr, "database is locked") ||
-		strings.Contains(errStr, "SQLITE_BUSY") ||
-		strings.Contains(errStr, "Lock wait timeout exceeded") ||
-		strings.Contains(errStr, "Deadlock found")
+			Delete(&entities.DetectionLock{}).Error
+	}, nil)
 }
 
 // IsLocked checks if a detection is locked.
@@ -1308,9 +1346,11 @@ func (r *detectionRepository) SaveLocksBatch(ctx context.Context, locks []*entit
 	if len(locks) == 0 {
 		return nil
 	}
-	return r.db.WithContext(ctx).Table(r.locksTable()).
-		Clauses(clause.OnConflict{DoNothing: true}).
-		CreateInBatches(locks, defaultDBBatchSize).Error
+	return datastore.RetryOnLock("v2_save_locks_batch", func() error {
+		return r.db.WithContext(ctx).Table(r.locksTable()).
+			Clauses(clause.OnConflict{DoNothing: true}).
+			CreateInBatches(locks, defaultDBBatchSize).Error
+	}, nil)
 }
 
 // GetLocksByDetectionIDs retrieves lock status for multiple detections.

--- a/internal/datastore/v2/repository/dynamic_threshold_impl.go
+++ b/internal/datastore/v2/repository/dynamic_threshold_impl.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/datastore/v2/entities"
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"gorm.io/gorm"
@@ -62,12 +63,14 @@ func (r *dynamicThresholdRepository) SaveDynamicThreshold(ctx context.Context, t
 	if threshold.LabelID == 0 {
 		return errors.NewStd("dynamic threshold LabelID must be set before saving")
 	}
-	return r.db.WithContext(ctx).Table(r.thresholdTable()).
-		Clauses(clause.OnConflict{
-			Columns:   []clause.Column{{Name: "label_id"}},
-			UpdateAll: true,
-		}).
-		Create(threshold).Error
+	return datastore.RetryOnLock("v2_save_dynamic_threshold", func() error {
+		return r.db.WithContext(ctx).Table(r.thresholdTable()).
+			Clauses(clause.OnConflict{
+				Columns:   []clause.Column{{Name: "label_id"}},
+				UpdateAll: true,
+			}).
+			Create(threshold).Error
+	}, nil)
 }
 
 // GetDynamicThreshold retrieves a threshold by species name (scientific name).
@@ -129,13 +132,21 @@ func (r *dynamicThresholdRepository) DeleteDynamicThreshold(ctx context.Context,
 		return ErrDynamicThresholdNotFound
 	}
 
-	result := r.db.WithContext(ctx).Table(r.thresholdTable()).
-		Where("label_id IN ?", labelIDs).
-		Delete(&entities.DynamicThreshold{})
-	if result.Error != nil {
-		return result.Error
+	var rowsAffected int64
+	err = datastore.RetryOnLock("v2_delete_dynamic_threshold", func() error {
+		result := r.db.WithContext(ctx).Table(r.thresholdTable()).
+			Where("label_id IN ?", labelIDs).
+			Delete(&entities.DynamicThreshold{})
+		if result.Error != nil {
+			return result.Error
+		}
+		rowsAffected = result.RowsAffected
+		return nil
+	}, nil)
+	if err != nil {
+		return err
 	}
-	if result.RowsAffected == 0 {
+	if rowsAffected == 0 {
 		return ErrDynamicThresholdNotFound
 	}
 	return nil
@@ -143,10 +154,18 @@ func (r *dynamicThresholdRepository) DeleteDynamicThreshold(ctx context.Context,
 
 // DeleteExpiredDynamicThresholds deletes thresholds that have expired.
 func (r *dynamicThresholdRepository) DeleteExpiredDynamicThresholds(ctx context.Context, before time.Time) (int64, error) {
-	result := r.db.WithContext(ctx).Table(r.thresholdTable()).
-		Where("expires_at < ?", before).
-		Delete(&entities.DynamicThreshold{})
-	return result.RowsAffected, result.Error
+	var rowsAffected int64
+	err := datastore.RetryOnLock("v2_delete_expired_dynamic_thresholds", func() error {
+		result := r.db.WithContext(ctx).Table(r.thresholdTable()).
+			Where("expires_at < ?", before).
+			Delete(&entities.DynamicThreshold{})
+		if result.Error != nil {
+			return result.Error
+		}
+		rowsAffected = result.RowsAffected
+		return nil
+	}, nil)
+	return rowsAffected, err
 }
 
 // UpdateDynamicThresholdExpiry updates the expiry time for thresholds.
@@ -164,13 +183,21 @@ func (r *dynamicThresholdRepository) UpdateDynamicThresholdExpiry(ctx context.Co
 		return ErrDynamicThresholdNotFound
 	}
 
-	result := r.db.WithContext(ctx).Table(r.thresholdTable()).
-		Where("label_id IN ?", labelIDs).
-		Update("expires_at", expiresAt)
-	if result.Error != nil {
-		return result.Error
+	var rowsAffected int64
+	err = datastore.RetryOnLock("v2_update_dynamic_threshold_expiry", func() error {
+		result := r.db.WithContext(ctx).Table(r.thresholdTable()).
+			Where("label_id IN ?", labelIDs).
+			Update("expires_at", expiresAt)
+		if result.Error != nil {
+			return result.Error
+		}
+		rowsAffected = result.RowsAffected
+		return nil
+	}, nil)
+	if err != nil {
+		return err
 	}
-	if result.RowsAffected == 0 {
+	if rowsAffected == 0 {
 		return ErrDynamicThresholdNotFound
 	}
 	return nil
@@ -188,20 +215,30 @@ func (r *dynamicThresholdRepository) BatchSaveDynamicThresholds(ctx context.Cont
 			return errors.NewStd("all thresholds must have LabelID set before batch save")
 		}
 	}
-	return r.db.WithContext(ctx).Table(r.thresholdTable()).
-		Clauses(clause.OnConflict{
-			Columns:   []clause.Column{{Name: "label_id"}},
-			UpdateAll: true,
-		}).
-		CreateInBatches(thresholds, 100).Error
+	return datastore.RetryOnLock("v2_batch_save_dynamic_thresholds", func() error {
+		return r.db.WithContext(ctx).Table(r.thresholdTable()).
+			Clauses(clause.OnConflict{
+				Columns:   []clause.Column{{Name: "label_id"}},
+				UpdateAll: true,
+			}).
+			CreateInBatches(thresholds, 100).Error
+	}, nil)
 }
 
 // DeleteAllDynamicThresholds deletes all thresholds.
 func (r *dynamicThresholdRepository) DeleteAllDynamicThresholds(ctx context.Context) (int64, error) {
-	result := r.db.WithContext(ctx).Table(r.thresholdTable()).
-		Where("1 = 1").
-		Delete(&entities.DynamicThreshold{})
-	return result.RowsAffected, result.Error
+	var rowsAffected int64
+	err := datastore.RetryOnLock("v2_delete_all_dynamic_thresholds", func() error {
+		result := r.db.WithContext(ctx).Table(r.thresholdTable()).
+			Where("1 = 1").
+			Delete(&entities.DynamicThreshold{})
+		if result.Error != nil {
+			return result.Error
+		}
+		rowsAffected = result.RowsAffected
+		return nil
+	}, nil)
+	return rowsAffected, err
 }
 
 // GetDynamicThresholdStats returns statistics about dynamic thresholds.
@@ -252,7 +289,9 @@ func (r *dynamicThresholdRepository) SaveThresholdEvent(ctx context.Context, eve
 	if event.LabelID == 0 {
 		return errors.NewStd("threshold event LabelID must be set before saving")
 	}
-	return r.db.WithContext(ctx).Table(r.eventTable()).Create(event).Error
+	return datastore.RetryOnLock("v2_save_threshold_event", func() error {
+		return r.db.WithContext(ctx).Table(r.eventTable()).Create(event).Error
+	}, nil)
 }
 
 // GetThresholdEvents retrieves events for a species (by scientific name).
@@ -310,15 +349,25 @@ func (r *dynamicThresholdRepository) DeleteThresholdEvents(ctx context.Context, 
 		return nil // Nothing to delete
 	}
 
-	return r.db.WithContext(ctx).Table(r.eventTable()).
-		Where("label_id IN ?", labelIDs).
-		Delete(&entities.ThresholdEvent{}).Error
+	return datastore.RetryOnLock("v2_delete_threshold_events", func() error {
+		return r.db.WithContext(ctx).Table(r.eventTable()).
+			Where("label_id IN ?", labelIDs).
+			Delete(&entities.ThresholdEvent{}).Error
+	}, nil)
 }
 
 // DeleteAllThresholdEvents deletes all threshold events.
 func (r *dynamicThresholdRepository) DeleteAllThresholdEvents(ctx context.Context) (int64, error) {
-	result := r.db.WithContext(ctx).Table(r.eventTable()).
-		Where("1 = 1").
-		Delete(&entities.ThresholdEvent{})
-	return result.RowsAffected, result.Error
+	var rowsAffected int64
+	err := datastore.RetryOnLock("v2_delete_all_threshold_events", func() error {
+		result := r.db.WithContext(ctx).Table(r.eventTable()).
+			Where("1 = 1").
+			Delete(&entities.ThresholdEvent{})
+		if result.Error != nil {
+			return result.Error
+		}
+		rowsAffected = result.RowsAffected
+		return nil
+	}, nil)
+	return rowsAffected, err
 }

--- a/internal/datastore/v2/repository/image_cache_impl.go
+++ b/internal/datastore/v2/repository/image_cache_impl.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"context"
 
+	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/datastore/v2/entities"
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"gorm.io/gorm"
@@ -86,12 +87,14 @@ func (r *imageCacheRepository) SaveImageCache(ctx context.Context, cache *entiti
 	if cache.LabelID == 0 {
 		return errors.NewStd("image cache LabelID must be set before saving")
 	}
-	return r.db.WithContext(ctx).Table(r.tableName()).
-		Clauses(clause.OnConflict{
-			Columns:   []clause.Column{{Name: "provider_name"}, {Name: "label_id"}},
-			UpdateAll: true,
-		}).
-		Create(cache).Error
+	return datastore.RetryOnLock("v2_save_image_cache", func() error {
+		return r.db.WithContext(ctx).Table(r.tableName()).
+			Clauses(clause.OnConflict{
+				Columns:   []clause.Column{{Name: "provider_name"}, {Name: "label_id"}},
+				UpdateAll: true,
+			}).
+			Create(cache).Error
+	}, nil)
 }
 
 // GetAllImageCaches retrieves all image cache entries for a provider.

--- a/internal/datastore/v2/repository/label_impl.go
+++ b/internal/datastore/v2/repository/label_impl.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/datastore/v2/entities"
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"gorm.io/gorm"
@@ -67,7 +68,9 @@ func (r *labelRepository) GetOrCreate(ctx context.Context, scientificName string
 		TaxonomicClassID: taxonomicClassID,
 	}
 
-	createErr := r.db.WithContext(ctx).Table(r.tableName()).Create(&label).Error
+	createErr := datastore.RetryOnLock("v2_create_label", func() error {
+		return r.db.WithContext(ctx).Table(r.tableName()).Create(&label).Error
+	}, nil)
 	if createErr != nil {
 		// Handle race condition - try to fetch the existing record
 		findErr := r.db.WithContext(ctx).Table(r.tableName()).
@@ -217,9 +220,11 @@ func (r *labelRepository) BatchGetOrCreate(ctx context.Context, scientificNames 
 		}
 	}
 
-	if err := r.db.WithContext(ctx).Table(r.tableName()).
-		Clauses(clause.OnConflict{DoNothing: true}).
-		CreateInBatches(newLabels, batchQuerySize).Error; err != nil {
+	if err := datastore.RetryOnLock("v2_batch_create_labels", func() error {
+		return r.db.WithContext(ctx).Table(r.tableName()).
+			Clauses(clause.OnConflict{DoNothing: true}).
+			CreateInBatches(newLabels, batchQuerySize).Error
+	}, nil); err != nil {
 		return nil, fmt.Errorf("batch create labels: %w", err)
 	}
 
@@ -295,11 +300,19 @@ func (r *labelRepository) GetAll(ctx context.Context) ([]*entities.Label, error)
 
 // Delete removes a label by ID.
 func (r *labelRepository) Delete(ctx context.Context, id uint) error {
-	result := r.db.WithContext(ctx).Table(r.tableName()).Delete(&entities.Label{}, id)
-	if result.Error != nil {
-		return result.Error
+	var rowsAffected int64
+	err := datastore.RetryOnLock("v2_delete_label", func() error {
+		result := r.db.WithContext(ctx).Table(r.tableName()).Delete(&entities.Label{}, id)
+		if result.Error != nil {
+			return result.Error
+		}
+		rowsAffected = result.RowsAffected
+		return nil
+	}, nil)
+	if err != nil {
+		return err
 	}
-	if result.RowsAffected == 0 {
+	if rowsAffected == 0 {
 		return ErrLabelNotFound
 	}
 	return nil
@@ -431,10 +444,12 @@ func (r *labelTypeRepository) GetOrCreate(ctx context.Context, name string) (*en
 	}
 
 	lt = entities.LabelType{Name: name}
-	if err := r.db.WithContext(ctx).Table(r.tableName()).Create(&lt).Error; err != nil {
+	if createErr := datastore.RetryOnLock("v2_create_label_type", func() error {
+		return r.db.WithContext(ctx).Table(r.tableName()).Create(&lt).Error
+	}, nil); createErr != nil {
 		// Race condition - try to fetch again
 		if findErr := r.db.WithContext(ctx).Table(r.tableName()).Where("name = ?", name).First(&lt).Error; findErr != nil {
-			return nil, err
+			return nil, createErr
 		}
 	}
 	return &lt, nil
@@ -509,10 +524,12 @@ func (r *taxonomicClassRepository) GetOrCreate(ctx context.Context, name string)
 	}
 
 	tc = entities.TaxonomicClass{Name: name}
-	if err := r.db.WithContext(ctx).Table(r.tableName()).Create(&tc).Error; err != nil {
+	if createErr := datastore.RetryOnLock("v2_create_taxonomic_class", func() error {
+		return r.db.WithContext(ctx).Table(r.tableName()).Create(&tc).Error
+	}, nil); createErr != nil {
 		// Race condition - try to fetch again
 		if findErr := r.db.WithContext(ctx).Table(r.tableName()).Where("name = ?", name).First(&tc).Error; findErr != nil {
-			return nil, err
+			return nil, createErr
 		}
 	}
 	return &tc, nil

--- a/internal/datastore/v2/repository/model_impl.go
+++ b/internal/datastore/v2/repository/model_impl.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 
+	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/datastore/v2/entities"
 	"gorm.io/gorm"
 )
@@ -64,7 +65,9 @@ func (r *modelRepository) GetOrCreate(ctx context.Context, name, version, varian
 		ClassifierPath: classifierPath,
 	}
 
-	createErr := r.db.WithContext(ctx).Table(r.tableName()).Create(&model).Error
+	createErr := datastore.RetryOnLock("v2_create_model", func() error {
+		return r.db.WithContext(ctx).Table(r.tableName()).Create(&model).Error
+	}, nil)
 	if createErr != nil {
 		// Handle race condition
 		findErr := r.db.WithContext(ctx).Table(r.tableName()).
@@ -134,11 +137,19 @@ func (r *modelRepository) CountLabels(ctx context.Context, modelID uint) (int64,
 
 // Delete removes a model by ID.
 func (r *modelRepository) Delete(ctx context.Context, id uint) error {
-	result := r.db.WithContext(ctx).Table(r.tableName()).Delete(&entities.AIModel{}, id)
-	if result.Error != nil {
-		return result.Error
+	var rowsAffected int64
+	err := datastore.RetryOnLock("v2_delete_model", func() error {
+		result := r.db.WithContext(ctx).Table(r.tableName()).Delete(&entities.AIModel{}, id)
+		if result.Error != nil {
+			return result.Error
+		}
+		rowsAffected = result.RowsAffected
+		return nil
+	}, nil)
+	if err != nil {
+		return err
 	}
-	if result.RowsAffected == 0 {
+	if rowsAffected == 0 {
 		return ErrModelNotFound
 	}
 	return nil

--- a/internal/datastore/v2/repository/notification_history_impl.go
+++ b/internal/datastore/v2/repository/notification_history_impl.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/datastore/v2/entities"
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"gorm.io/gorm"
@@ -55,12 +56,14 @@ func (r *notificationHistoryRepository) SaveNotificationHistory(ctx context.Cont
 	if history.LabelID == 0 {
 		return errors.NewStd("notification history LabelID must be set before saving")
 	}
-	return r.db.WithContext(ctx).Table(r.tableName()).
-		Clauses(clause.OnConflict{
-			Columns:   []clause.Column{{Name: "label_id"}, {Name: "notification_type"}},
-			UpdateAll: true,
-		}).
-		Create(history).Error
+	return datastore.RetryOnLock("v2_save_notification_history", func() error {
+		return r.db.WithContext(ctx).Table(r.tableName()).
+			Clauses(clause.OnConflict{
+				Columns:   []clause.Column{{Name: "label_id"}, {Name: "notification_type"}},
+				UpdateAll: true,
+			}).
+			Create(history).Error
+	}, nil)
 }
 
 // GetNotificationHistory retrieves a notification history entry by scientific name.
@@ -106,8 +109,16 @@ func (r *notificationHistoryRepository) GetActiveNotificationHistory(ctx context
 
 // DeleteExpiredNotificationHistory deletes expired entries.
 func (r *notificationHistoryRepository) DeleteExpiredNotificationHistory(ctx context.Context, before time.Time) (int64, error) {
-	result := r.db.WithContext(ctx).Table(r.tableName()).
-		Where("expires_at < ?", before).
-		Delete(&entities.NotificationHistory{})
-	return result.RowsAffected, result.Error
+	var rowsAffected int64
+	err := datastore.RetryOnLock("v2_delete_expired_notification_history", func() error {
+		result := r.db.WithContext(ctx).Table(r.tableName()).
+			Where("expires_at < ?", before).
+			Delete(&entities.NotificationHistory{})
+		if result.Error != nil {
+			return result.Error
+		}
+		rowsAffected = result.RowsAffected
+		return nil
+	}, nil)
+	return rowsAffected, err
 }

--- a/internal/datastore/v2/repository/weather_impl.go
+++ b/internal/datastore/v2/repository/weather_impl.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/datastore/v2/entities"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
@@ -46,12 +47,14 @@ func (r *weatherRepository) hourlyWeatherTable() string {
 
 // SaveDailyEvents saves or updates daily events (upsert).
 func (r *weatherRepository) SaveDailyEvents(ctx context.Context, events *entities.DailyEvents) error {
-	return r.db.WithContext(ctx).Table(r.dailyEventsTable()).
-		Clauses(clause.OnConflict{
-			Columns:   []clause.Column{{Name: "date"}},
-			UpdateAll: true,
-		}).
-		Create(events).Error
+	return datastore.RetryOnLock("v2_save_daily_events", func() error {
+		return r.db.WithContext(ctx).Table(r.dailyEventsTable()).
+			Clauses(clause.OnConflict{
+				Columns:   []clause.Column{{Name: "date"}},
+				UpdateAll: true,
+			}).
+			Create(events).Error
+	}, nil)
 }
 
 // GetDailyEvents retrieves daily events by date.
@@ -71,7 +74,9 @@ func (r *weatherRepository) GetDailyEvents(ctx context.Context, date string) (*e
 
 // SaveHourlyWeather saves hourly weather data.
 func (r *weatherRepository) SaveHourlyWeather(ctx context.Context, weather *entities.HourlyWeather) error {
-	return r.db.WithContext(ctx).Table(r.hourlyWeatherTable()).Create(weather).Error
+	return datastore.RetryOnLock("v2_save_hourly_weather", func() error {
+		return r.db.WithContext(ctx).Table(r.hourlyWeatherTable()).Create(weather).Error
+	}, nil)
 }
 
 // GetHourlyWeather retrieves hourly weather for a date.
@@ -162,12 +167,14 @@ func (r *weatherRepository) SaveAllDailyEvents(ctx context.Context, events []ent
 		end := min(i+batchSize, len(events))
 		batch := events[i:end]
 
-		err := r.db.WithContext(ctx).Table(r.dailyEventsTable()).
-			Clauses(clause.OnConflict{
-				Columns:   []clause.Column{{Name: "date"}},
-				DoNothing: true,
-			}).
-			Create(&batch).Error
+		err := datastore.RetryOnLock("v2_save_all_daily_events", func() error {
+			return r.db.WithContext(ctx).Table(r.dailyEventsTable()).
+				Clauses(clause.OnConflict{
+					Columns:   []clause.Column{{Name: "date"}},
+					DoNothing: true,
+				}).
+				Create(&batch).Error
+		}, nil)
 		if err != nil {
 			return saved, err
 		}
@@ -192,8 +199,10 @@ func (r *weatherRepository) SaveAllHourlyWeather(ctx context.Context, weather []
 		end := min(i+batchSize, len(weather))
 		batch := weather[i:end]
 
-		err := r.db.WithContext(ctx).Table(r.hourlyWeatherTable()).
-			Create(&batch).Error
+		err := datastore.RetryOnLock("v2_save_all_hourly_weather", func() error {
+			return r.db.WithContext(ctx).Table(r.hourlyWeatherTable()).
+				Create(&batch).Error
+		}, nil)
 		if err != nil {
 			return saved, err
 		}


### PR DESCRIPTION
## Summary

Add `datastore.RetryOnLock` retry protection to all 56 write methods across 10 v2 repository implementations. Replace the manual retry in `detection.Unlock()` with the shared helper and remove the duplicate `isDBLockError` function.

**Depends on #2577** (exports retry functions from v1 package).

## Coverage

Before: 0/56 v2 write methods had retry protection (0%)
After: 56/56 v2 write methods have retry protection (100%)

### Files modified (10 repository implementations)

| Repository | Methods wrapped | Notable |
|---|---|---|
| detection_impl.go | 21 | Unlock manual retry replaced, isDBLockError removed |
| alert_rule_impl.go | 8 | UpdateRule uses RetryTransactionOnLock with ID resets |
| dynamic_threshold_impl.go | 9 | Batch save and threshold events |
| weather_impl.go | 4 | Including batch migration methods |
| label_impl.go | 5 | GetOrCreate race handling preserved |
| model_impl.go | 2 | GetOrCreate + Delete |
| audio_source_impl.go | 3 | GetOrCreate + Delete + Update |
| notification_history_impl.go | 2 | |
| image_cache_impl.go | 1 | |
| app_metadata_impl.go | 1 | |

## Bonus fix

Fixed pre-existing bug in `labelTypeRepository.GetOrCreate` and `taxonomicClassRepository.GetOrCreate` where race condition fallback returned the wrong error variable.

## Test plan

- [x] All v2 tests pass with `-race`
- [x] golangci-lint clean
- [x] Metrics parameter is nil (v2 has no metrics yet — safe, all nil-guarded)
- [ ] Verify under concurrent load

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved resilience of write operations to transient database lock conflicts, reducing failed or flaky saves/updates/deletes under concurrent load.
  * Deletion and update paths now more reliably report not-found vs retryable errors, improving consistency of data operations.
  * Upserts and batch writes are now more robust, decreasing chances of transient failures affecting user-facing data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->