### PR TITLE
refactor: remove duplicate isDBLockError and add nil guards to write methods

### DIFF
--- a/internal/alerting/engine.go
+++ b/internal/alerting/engine.go
@@ -7,10 +7,10 @@ import (
 	"maps"
 	"runtime/debug"
 	"slices"
-	"strings"
 	"sync"
 	"time"
 
+	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/datastore/v2/entities"
 	"github.com/tphakala/birdnet-go/internal/datastore/v2/repository"
 	"github.com/tphakala/birdnet-go/internal/logger"
@@ -427,7 +427,7 @@ func (e *Engine) StartHistoryCleanup(retentionDays int) {
 			case <-ticker.C:
 				deleted, err := e.deleteHistoryWithRetry(retentionDays, stopCh)
 				if err != nil {
-					if isDBLockError(err) {
+					if datastore.IsTransientDBError(err) {
 						// Transient SQLite lock contention — the cleanup runs hourly,
 						// so it will succeed on the next tick. Log as warning only;
 						// do not report to Sentry.
@@ -480,7 +480,7 @@ func (e *Engine) deleteHistoryWithRetry(retentionDays int, stopCh <-chan struct{
 		lastErr = err
 
 		// Only retry on transient DB lock errors; bail immediately on other errors.
-		if !isDBLockError(err) || attempt == cleanupMaxRetries-1 {
+		if !datastore.IsTransientDBError(err) || attempt == cleanupMaxRetries-1 {
 			return 0, err
 		}
 
@@ -517,11 +517,4 @@ func (e *Engine) stopCleanup() {
 // Stop shuts down background goroutines (history cleanup).
 func (e *Engine) Stop() {
 	e.stopCleanup()
-}
-
-// isDBLockError checks if an error is a transient SQLite database lock error.
-func isDBLockError(err error) bool {
-	errStr := err.Error()
-	return strings.Contains(errStr, "database is locked") ||
-		strings.Contains(errStr, "SQLITE_BUSY")
 }

--- a/internal/alerting/engine_test.go
+++ b/internal/alerting/engine_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/datastore/v2/entities"
 	"github.com/tphakala/birdnet-go/internal/datastore/v2/repository"
 	"github.com/tphakala/birdnet-go/internal/logger"
@@ -754,7 +755,7 @@ func TestDeleteHistoryWithRetry_ExhaustsRetriesOnPersistentLock(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Equal(t, int64(0), deleted)
-	assert.True(t, isDBLockError(err), "error should be a DB lock error")
+	assert.True(t, datastore.IsTransientDBError(err), "error should be a DB lock error")
 	assert.Equal(t, int64(3), repo.deleteCalls.Load(), "should attempt exactly cleanupMaxRetries times")
 }
 
@@ -796,11 +797,11 @@ func TestDeleteHistoryWithRetry_AbortsOnStop(t *testing.T) {
 }
 
 func TestIsDBLockError(t *testing.T) {
-	assert.True(t, isDBLockError(fmt.Errorf("database is locked")))
-	assert.True(t, isDBLockError(fmt.Errorf("SQLITE_BUSY")))
-	assert.True(t, isDBLockError(fmt.Errorf("some context: database is locked")))
-	assert.False(t, isDBLockError(fmt.Errorf("disk I/O error")))
-	assert.False(t, isDBLockError(fmt.Errorf("connection refused")))
+	assert.True(t, datastore.IsTransientDBError(fmt.Errorf("database is locked")))
+	assert.True(t, datastore.IsTransientDBError(fmt.Errorf("SQLITE_BUSY")))
+	assert.True(t, datastore.IsTransientDBError(fmt.Errorf("some context: database is locked")))
+	assert.False(t, datastore.IsTransientDBError(fmt.Errorf("disk I/O error")))
+	assert.False(t, datastore.IsTransientDBError(fmt.Errorf("connection refused")))
 }
 
 func TestEngine_NoEscalationSteps_LegacyBehavior(t *testing.T) {

--- a/internal/analysis/processor/threshold_persistence.go
+++ b/internal/analysis/processor/threshold_persistence.go
@@ -177,7 +177,7 @@ func (p *Processor) saveThresholdsWithRetry(dbThresholds []datastore.DynamicThre
 			return nil
 		}
 
-		if !isDBLockError(err) || attempt == maxRetries-1 {
+		if !datastore.IsTransientDBError(err) || attempt == maxRetries-1 {
 			GetLogger().Error("Failed to persist dynamic thresholds",
 				logger.Error(err),
 				logger.Int("threshold_count", len(dbThresholds)),
@@ -203,13 +203,6 @@ func (p *Processor) saveThresholdsWithRetry(dbThresholds []datastore.DynamicThre
 		}
 	}
 	return err
-}
-
-// isDBLockError checks if an error is a database lock error.
-func isDBLockError(err error) bool {
-	errStr := err.Error()
-	return strings.Contains(errStr, "database is locked") ||
-		strings.Contains(errStr, "SQLITE_BUSY")
 }
 
 // persistDynamicThresholds saves all current dynamic thresholds to the database

--- a/internal/datastore/interfaces.go
+++ b/internal/datastore/interfaces.go
@@ -312,6 +312,10 @@ func (ds *DataStore) SetSunCalcMetrics(suncalcMetrics any) {
 
 // Save stores a note and its associated results as a single transaction in the database.
 func (ds *DataStore) Save(note *Note, results []Results) error {
+	if note == nil {
+		return validationError("note cannot be nil", "note", nil)
+	}
+
 	txID := fmt.Sprintf("tx-%s", uuid.New().String()[:8])
 	txStart := time.Now()
 	txLogger := GetLogger()
@@ -1289,6 +1293,10 @@ func (ds *DataStore) GetNoteReview(noteID string) (*NoteReview, error) {
 
 // SaveNoteReview saves or updates a note review
 func (ds *DataStore) SaveNoteReview(review *NoteReview) error {
+	if review == nil {
+		return validationError("review cannot be nil", "review", nil)
+	}
+
 	return RetryOnLock("save_note_review", func() error {
 		review.ID = 0 // Reset ID for retry safety with FirstOrCreate
 		// Use upsert operation to either create or update the review


### PR DESCRIPTION
## Summary

- Remove duplicate `isDBLockError` from `internal/alerting/engine.go` and `internal/analysis/processor/threshold_persistence.go` — replaced with the exported `datastore.IsTransientDBError` which handles error unwrapping, MySQL deadlocks, and compiled regex
- Add nil guards to pointer-accepting write methods (`Save`, `SaveNoteReview`) to prevent panics before the retry helper runs

## Changes

### Duplicate removal
- `alerting/engine.go`: Replaced 2 call sites, deleted local function, removed unused `strings` import
- `analysis/processor/threshold_persistence.go`: Replaced 1 call site, deleted local function
- `alerting/engine_test.go`: Updated test assertions to use exported function

### Nil guards
- `interfaces.go`: Added nil check for `note` in `Save()` and `review` in `SaveNoteReview()`

## Test plan

- [x] All tests pass with `-race` across datastore, alerting, and analysis packages
- [x] golangci-lint clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced database lock error detection to ensure reliable operation during concurrent database access.
  * Added validation checks to prevent processing of null or invalid data entries.

* **Refactor**
  * Consolidated error handling logic for improved consistency throughout the application.

* **Tests**
  * Updated test coverage to verify improved error classification behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->