### PR TITLE
fix: wire DatastoreMetrics into v2 repository layer

### DIFF
--- a/internal/analysis/realtime.go
+++ b/internal/analysis/realtime.go
@@ -1905,16 +1905,16 @@ func setupMigrationWorker(cfg *migrationSetupConfig) error {
 			Build()
 	}
 
-	labelRepo := repository.NewLabelRepository(v2DB, cfg.useV2Prefix, isMySQL)
-	modelRepo := repository.NewModelRepository(v2DB, cfg.useV2Prefix, isMySQL)
-	sourceRepo := repository.NewAudioSourceRepository(v2DB, cfg.useV2Prefix, isMySQL)
-	v2DetectionRepo := repository.NewDetectionRepository(v2DB, cfg.useV2Prefix, isMySQL)
+	labelRepo := repository.NewLabelRepository(v2DB, nil, cfg.useV2Prefix, isMySQL)
+	modelRepo := repository.NewModelRepository(v2DB, nil, cfg.useV2Prefix, isMySQL)
+	sourceRepo := repository.NewAudioSourceRepository(v2DB, nil, cfg.useV2Prefix, isMySQL)
+	v2DetectionRepo := repository.NewDetectionRepository(v2DB, nil, cfg.useV2Prefix, isMySQL)
 
 	// Create repositories for auxiliary data migration
-	weatherRepo := repository.NewWeatherRepository(v2DB, cfg.useV2Prefix, isMySQL)
-	imageCacheRepo := repository.NewImageCacheRepository(v2DB, labelRepo, cfg.useV2Prefix, isMySQL)
-	thresholdRepo := repository.NewDynamicThresholdRepository(v2DB, labelRepo, cfg.useV2Prefix, isMySQL)
-	notificationRepo := repository.NewNotificationHistoryRepository(v2DB, labelRepo, cfg.useV2Prefix, isMySQL)
+	weatherRepo := repository.NewWeatherRepository(v2DB, nil, cfg.useV2Prefix, isMySQL)
+	imageCacheRepo := repository.NewImageCacheRepository(v2DB, nil, labelRepo, cfg.useV2Prefix, isMySQL)
+	thresholdRepo := repository.NewDynamicThresholdRepository(v2DB, nil, labelRepo, cfg.useV2Prefix, isMySQL)
+	notificationRepo := repository.NewNotificationHistoryRepository(v2DB, nil, labelRepo, cfg.useV2Prefix, isMySQL)
 
 	// Create the legacy detection repository
 	legacyRepo := datastore.NewDetectionRepository(cfg.ds, time.Local)
@@ -2271,14 +2271,14 @@ func initializeV2OnlyMode(settings *conf.Settings) (*v2only.Datastore, error) {
 	// Create repositories
 	v2DB := v2Manager.DB()
 	isMySQL := settings.Output.MySQL.Enabled // Determine dialect from settings
-	detectionRepo := repository.NewDetectionRepository(v2DB, useV2Prefix, isMySQL)
-	labelRepo := repository.NewLabelRepository(v2DB, useV2Prefix, isMySQL)
-	modelRepo := repository.NewModelRepository(v2DB, useV2Prefix, isMySQL)
-	sourceRepo := repository.NewAudioSourceRepository(v2DB, useV2Prefix, isMySQL)
-	weatherRepo := repository.NewWeatherRepository(v2DB, useV2Prefix, isMySQL)
-	imageCacheRepo := repository.NewImageCacheRepository(v2DB, labelRepo, useV2Prefix, isMySQL)
-	thresholdRepo := repository.NewDynamicThresholdRepository(v2DB, labelRepo, useV2Prefix, isMySQL)
-	notificationRepo := repository.NewNotificationHistoryRepository(v2DB, labelRepo, useV2Prefix, isMySQL)
+	detectionRepo := repository.NewDetectionRepository(v2DB, nil, useV2Prefix, isMySQL)
+	labelRepo := repository.NewLabelRepository(v2DB, nil, useV2Prefix, isMySQL)
+	modelRepo := repository.NewModelRepository(v2DB, nil, useV2Prefix, isMySQL)
+	sourceRepo := repository.NewAudioSourceRepository(v2DB, nil, useV2Prefix, isMySQL)
+	weatherRepo := repository.NewWeatherRepository(v2DB, nil, useV2Prefix, isMySQL)
+	imageCacheRepo := repository.NewImageCacheRepository(v2DB, nil, labelRepo, useV2Prefix, isMySQL)
+	thresholdRepo := repository.NewDynamicThresholdRepository(v2DB, nil, labelRepo, useV2Prefix, isMySQL)
+	notificationRepo := repository.NewNotificationHistoryRepository(v2DB, nil, labelRepo, useV2Prefix, isMySQL)
 
 	// Load eBird taxonomy for species code lookups in analytics endpoints.
 	_, scientificIndex, taxonomyErr := birdnet.LoadTaxonomyData("")

--- a/internal/api/v2/alerts.go
+++ b/internal/api/v2/alerts.go
@@ -59,7 +59,7 @@ func (c *Controller) initAlertRoutes() {
 	}
 
 	// Initialize repository lazily from V2Manager
-	c.alertRuleRepo = repository.NewAlertRuleRepository(c.V2Manager.DB())
+	c.alertRuleRepo = repository.NewAlertRuleRepository(c.V2Manager.DB(), nil)
 
 	// Initialize the alerting engine — seeds default rules and starts event processing
 	alertTelemetry := alerting.NewAlertingTelemetry()

--- a/internal/api/v2/app.go
+++ b/internal/api/v2/app.go
@@ -81,6 +81,7 @@ func (c *Controller) initAppRoutes() {
 		}
 		c.appMetadataRepo = repository.NewAppMetadataRepository(
 			c.V2Manager.DB(),
+			nil,
 			useV2Prefix,
 			c.V2Manager.IsMySQL(),
 		)

--- a/internal/datastore/v2/migration/testutil/setup.go
+++ b/internal/datastore/v2/migration/testutil/setup.go
@@ -187,14 +187,14 @@ func (ctx *TestContext) setupV2DB(t *testing.T, tmpDir string) {
 
 	// Create repositories (useV2Prefix = false for direct table access in tests, isMySQL = false for SQLite)
 	db := mgr.DB()
-	ctx.DetectionRepo = repository.NewDetectionRepository(db, false, false)
-	ctx.LabelRepo = repository.NewLabelRepository(db, false, false)
-	ctx.ModelRepo = repository.NewModelRepository(db, false, false)
-	ctx.SourceRepo = repository.NewAudioSourceRepository(db, false, false)
-	ctx.WeatherRepo = repository.NewWeatherRepository(db, false, false)
-	ctx.ImageCacheRepo = repository.NewImageCacheRepository(db, ctx.LabelRepo, false, false)
-	ctx.ThresholdRepo = repository.NewDynamicThresholdRepository(db, ctx.LabelRepo, false, false)
-	ctx.NotificationRepo = repository.NewNotificationHistoryRepository(db, ctx.LabelRepo, false, false)
+	ctx.DetectionRepo = repository.NewDetectionRepository(db, nil, false, false)
+	ctx.LabelRepo = repository.NewLabelRepository(db, nil, false, false)
+	ctx.ModelRepo = repository.NewModelRepository(db, nil, false, false)
+	ctx.SourceRepo = repository.NewAudioSourceRepository(db, nil, false, false)
+	ctx.WeatherRepo = repository.NewWeatherRepository(db, nil, false, false)
+	ctx.ImageCacheRepo = repository.NewImageCacheRepository(db, nil, ctx.LabelRepo, false, false)
+	ctx.ThresholdRepo = repository.NewDynamicThresholdRepository(db, nil, ctx.LabelRepo, false, false)
+	ctx.NotificationRepo = repository.NewNotificationHistoryRepository(db, nil, ctx.LabelRepo, false, false)
 
 	// Populate lookup tables for V2 normalized schema
 	ctx.setupLookupTables(t)

--- a/internal/datastore/v2/repository/alert_rule_impl.go
+++ b/internal/datastore/v2/repository/alert_rule_impl.go
@@ -13,12 +13,14 @@ import (
 
 // alertRuleRepository implements AlertRuleRepository.
 type alertRuleRepository struct {
-	db *gorm.DB
+	db      *gorm.DB
+	metrics *datastore.Metrics
 }
 
 // NewAlertRuleRepository creates a new AlertRuleRepository.
-func NewAlertRuleRepository(db *gorm.DB) AlertRuleRepository {
-	return &alertRuleRepository{db: db}
+// metrics is optional (nil-safe) and enables retry observability.
+func NewAlertRuleRepository(db *gorm.DB, metrics *datastore.Metrics) AlertRuleRepository {
+	return &alertRuleRepository{db: db, metrics: metrics}
 }
 
 // ListRules returns alert rules matching the given filter.
@@ -65,7 +67,7 @@ func (r *alertRuleRepository) CreateRule(ctx context.Context, rule *entities.Ale
 			return fmt.Errorf("failed to create alert rule: %w", err)
 		}
 		return nil
-	}, nil)
+	}, r.metrics)
 }
 
 // UpdateRule replaces an alert rule, deleting existing conditions and actions first.
@@ -91,7 +93,7 @@ func (r *alertRuleRepository) UpdateRule(ctx context.Context, rule *entities.Ale
 			return fmt.Errorf("failed to update alert rule: %w", err)
 		}
 		return nil
-	}, nil)
+	}, r.metrics)
 }
 
 // DeleteRule deletes an alert rule and its conditions/actions via cascade.
@@ -104,7 +106,7 @@ func (r *alertRuleRepository) DeleteRule(ctx context.Context, id uint) error {
 		}
 		rowsAffected = result.RowsAffected
 		return nil
-	}, nil)
+	}, r.metrics)
 	if err != nil {
 		return err
 	}
@@ -124,7 +126,7 @@ func (r *alertRuleRepository) ToggleRule(ctx context.Context, id uint, enabled b
 		}
 		rowsAffected = result.RowsAffected
 		return nil
-	}, nil)
+	}, r.metrics)
 	if err != nil {
 		return err
 	}
@@ -150,7 +152,7 @@ func (r *alertRuleRepository) DeleteBuiltInRules(ctx context.Context) (int64, er
 		}
 		rowsAffected = result.RowsAffected
 		return nil
-	}, nil)
+	}, r.metrics)
 	return rowsAffected, err
 }
 
@@ -161,7 +163,7 @@ func (r *alertRuleRepository) SaveHistory(ctx context.Context, history *entities
 			return fmt.Errorf("failed to save alert history: %w", err)
 		}
 		return nil
-	}, nil)
+	}, r.metrics)
 }
 
 // ListHistory returns alert history entries matching the filter with pagination.
@@ -203,7 +205,7 @@ func (r *alertRuleRepository) DeleteHistory(ctx context.Context) (int64, error) 
 		}
 		rowsAffected = result.RowsAffected
 		return nil
-	}, nil)
+	}, r.metrics)
 	return rowsAffected, err
 }
 
@@ -217,7 +219,7 @@ func (r *alertRuleRepository) DeleteHistoryBefore(ctx context.Context, before ti
 		}
 		rowsAffected = result.RowsAffected
 		return nil
-	}, nil)
+	}, r.metrics)
 	return rowsAffected, err
 }
 

--- a/internal/datastore/v2/repository/alert_rule_impl_test.go
+++ b/internal/datastore/v2/repository/alert_rule_impl_test.go
@@ -63,7 +63,7 @@ func createTestRule(t *testing.T, repo AlertRuleRepository, name, objectType, tr
 
 func TestAlertRuleRepository_CreateAndGet(t *testing.T) {
 	db := setupAlertTestDB(t)
-	repo := NewAlertRuleRepository(db)
+	repo := NewAlertRuleRepository(db, nil)
 	ctx := t.Context()
 
 	rule := &entities.AlertRule{
@@ -110,7 +110,7 @@ func TestAlertRuleRepository_CreateAndGet(t *testing.T) {
 
 func TestAlertRuleRepository_ListRules(t *testing.T) {
 	db := setupAlertTestDB(t)
-	repo := NewAlertRuleRepository(db)
+	repo := NewAlertRuleRepository(db, nil)
 	ctx := t.Context()
 
 	// Create rules with different object types and states
@@ -152,7 +152,7 @@ func TestAlertRuleRepository_ListRules(t *testing.T) {
 
 func TestAlertRuleRepository_UpdateRule(t *testing.T) {
 	db := setupAlertTestDB(t)
-	repo := NewAlertRuleRepository(db)
+	repo := NewAlertRuleRepository(db, nil)
 	ctx := t.Context()
 
 	rule := createTestRule(t, repo, "Original", "detection", "event", "detection.occurred")
@@ -181,7 +181,7 @@ func TestAlertRuleRepository_UpdateRule(t *testing.T) {
 
 func TestAlertRuleRepository_UpdateRule_WithExistingIDs(t *testing.T) {
 	db := setupAlertTestDB(t)
-	repo := NewAlertRuleRepository(db)
+	repo := NewAlertRuleRepository(db, nil)
 	ctx := t.Context()
 
 	rule := createTestRule(t, repo, "IDTest", "detection", "event", "detection.occurred")
@@ -216,7 +216,7 @@ func TestAlertRuleRepository_UpdateRule_WithExistingIDs(t *testing.T) {
 
 func TestAlertRuleRepository_DeleteRule(t *testing.T) {
 	db := setupAlertTestDB(t)
-	repo := NewAlertRuleRepository(db)
+	repo := NewAlertRuleRepository(db, nil)
 	ctx := t.Context()
 
 	rule := createTestRule(t, repo, "ToDelete", "stream", "event", "stream.error")
@@ -239,7 +239,7 @@ func TestAlertRuleRepository_DeleteRule(t *testing.T) {
 
 func TestAlertRuleRepository_ToggleRule(t *testing.T) {
 	db := setupAlertTestDB(t)
-	repo := NewAlertRuleRepository(db)
+	repo := NewAlertRuleRepository(db, nil)
 	ctx := t.Context()
 
 	rule := createTestRule(t, repo, "Toggle", "detection", "event", "detection.new_species")
@@ -262,7 +262,7 @@ func TestAlertRuleRepository_ToggleRule(t *testing.T) {
 
 func TestAlertRuleRepository_History(t *testing.T) {
 	db := setupAlertTestDB(t)
-	repo := NewAlertRuleRepository(db)
+	repo := NewAlertRuleRepository(db, nil)
 	ctx := t.Context()
 
 	rule := createTestRule(t, repo, "HistRule", "detection", "event", "detection.new_species")
@@ -325,7 +325,7 @@ func TestAlertRuleRepository_History(t *testing.T) {
 
 func TestAlertRuleRepository_GetEnabledRules(t *testing.T) {
 	db := setupAlertTestDB(t)
-	repo := NewAlertRuleRepository(db)
+	repo := NewAlertRuleRepository(db, nil)
 	ctx := t.Context()
 
 	// Create mix of enabled and disabled rules
@@ -347,7 +347,7 @@ func TestAlertRuleRepository_GetEnabledRules(t *testing.T) {
 
 func TestAlertRuleRepository_DeleteBuiltInRules(t *testing.T) {
 	db := setupAlertTestDB(t)
-	repo := NewAlertRuleRepository(db)
+	repo := NewAlertRuleRepository(db, nil)
 	ctx := t.Context()
 
 	// Create mix of built-in and custom rules
@@ -371,7 +371,7 @@ func TestAlertRuleRepository_DeleteBuiltInRules(t *testing.T) {
 
 func TestAlertRuleRepository_CountRulesByName(t *testing.T) {
 	db := setupAlertTestDB(t)
-	repo := NewAlertRuleRepository(db)
+	repo := NewAlertRuleRepository(db, nil)
 	ctx := t.Context()
 
 	createTestRule(t, repo, "Duplicate Test", "detection", "event", "detection.new_species")

--- a/internal/datastore/v2/repository/app_metadata_impl.go
+++ b/internal/datastore/v2/repository/app_metadata_impl.go
@@ -14,6 +14,7 @@ import (
 // appMetadataRepository implements AppMetadataRepository.
 type appMetadataRepository struct {
 	db          *gorm.DB
+	metrics     *datastore.Metrics
 	useV2Prefix bool
 	isMySQL     bool
 }
@@ -21,11 +22,13 @@ type appMetadataRepository struct {
 // NewAppMetadataRepository creates a new AppMetadataRepository.
 // Parameters:
 //   - db: GORM database connection
+//   - metrics: optional DatastoreMetrics for retry observability (nil-safe)
 //   - useV2Prefix: true to use v2_ table prefix (MySQL migration mode)
 //   - isMySQL: true for MySQL dialect (affects date/time SQL expressions)
-func NewAppMetadataRepository(db *gorm.DB, useV2Prefix, isMySQL bool) AppMetadataRepository {
+func NewAppMetadataRepository(db *gorm.DB, metrics *datastore.Metrics, useV2Prefix, isMySQL bool) AppMetadataRepository {
 	return &appMetadataRepository{
 		db:          db,
+		metrics:     metrics,
 		useV2Prefix: useV2Prefix,
 		isMySQL:     isMySQL,
 	}
@@ -71,5 +74,5 @@ func (r *appMetadataRepository) Set(ctx context.Context, key, value string) erro
 			return fmt.Errorf("set app metadata key %q: %w", key, err)
 		}
 		return nil
-	}, nil)
+	}, r.metrics)
 }

--- a/internal/datastore/v2/repository/app_metadata_test.go
+++ b/internal/datastore/v2/repository/app_metadata_test.go
@@ -34,7 +34,7 @@ func setupAppMetadataTestDB(t *testing.T) *gorm.DB {
 func TestAppMetadataRepository_GetEmpty(t *testing.T) {
 	t.Parallel()
 	db := setupAppMetadataTestDB(t)
-	repo := NewAppMetadataRepository(db, false, false)
+	repo := NewAppMetadataRepository(db, nil, false, false)
 	ctx := t.Context()
 
 	value, err := repo.Get(ctx, "nonexistent_key")
@@ -45,7 +45,7 @@ func TestAppMetadataRepository_GetEmpty(t *testing.T) {
 func TestAppMetadataRepository_SetThenGet(t *testing.T) {
 	t.Parallel()
 	db := setupAppMetadataTestDB(t)
-	repo := NewAppMetadataRepository(db, false, false)
+	repo := NewAppMetadataRepository(db, nil, false, false)
 	ctx := t.Context()
 
 	err := repo.Set(ctx, "my_key", "my_value")
@@ -59,7 +59,7 @@ func TestAppMetadataRepository_SetThenGet(t *testing.T) {
 func TestAppMetadataRepository_SetOverwrites(t *testing.T) {
 	t.Parallel()
 	db := setupAppMetadataTestDB(t)
-	repo := NewAppMetadataRepository(db, false, false)
+	repo := NewAppMetadataRepository(db, nil, false, false)
 	ctx := t.Context()
 
 	err := repo.Set(ctx, "version", "v1.0.0")
@@ -76,7 +76,7 @@ func TestAppMetadataRepository_SetOverwrites(t *testing.T) {
 func TestAppMetadataRepository_GetDifferentKeys(t *testing.T) {
 	t.Parallel()
 	db := setupAppMetadataTestDB(t)
-	repo := NewAppMetadataRepository(db, false, false)
+	repo := NewAppMetadataRepository(db, nil, false, false)
 	ctx := t.Context()
 
 	err := repo.Set(ctx, "key_a", "value_a")
@@ -101,7 +101,7 @@ func TestAppMetadataRepository_GetDifferentKeys(t *testing.T) {
 func TestAppMetadataRepository_SetEmptyValue(t *testing.T) {
 	t.Parallel()
 	db := setupAppMetadataTestDB(t)
-	repo := NewAppMetadataRepository(db, false, false)
+	repo := NewAppMetadataRepository(db, nil, false, false)
 	ctx := t.Context()
 
 	err := repo.Set(ctx, "empty_key", "")

--- a/internal/datastore/v2/repository/audio_source_impl.go
+++ b/internal/datastore/v2/repository/audio_source_impl.go
@@ -13,6 +13,7 @@ import (
 // audioSourceRepository implements AudioSourceRepository.
 type audioSourceRepository struct {
 	db          *gorm.DB
+	metrics     *datastore.Metrics
 	useV2Prefix bool
 	isMySQL     bool // For API consistency; currently unused here (used by detection_impl.go for dialect-specific SQL)
 }
@@ -20,11 +21,13 @@ type audioSourceRepository struct {
 // NewAudioSourceRepository creates a new AudioSourceRepository.
 // Parameters:
 //   - db: GORM database connection
+//   - metrics: optional DatastoreMetrics for retry observability (nil-safe)
 //   - useV2Prefix: true to use v2_ table prefix (MySQL migration mode)
 //   - isMySQL: true for MySQL dialect (affects date/time SQL expressions)
-func NewAudioSourceRepository(db *gorm.DB, useV2Prefix, isMySQL bool) AudioSourceRepository {
+func NewAudioSourceRepository(db *gorm.DB, metrics *datastore.Metrics, useV2Prefix, isMySQL bool) AudioSourceRepository {
 	return &audioSourceRepository{
 		db:          db,
+		metrics:     metrics,
 		useV2Prefix: useV2Prefix,
 		isMySQL:     isMySQL,
 	}
@@ -68,7 +71,7 @@ func (r *audioSourceRepository) GetOrCreate(ctx context.Context, sourceURI, node
 
 	createErr := datastore.RetryOnLock("v2_create_audio_source", func() error {
 		return r.db.WithContext(ctx).Table(r.tableName()).Create(&source).Error
-	}, nil)
+	}, r.metrics)
 	if createErr != nil {
 		// Handle race condition - another goroutine may have created it.
 		// Try to fetch the existing record; if that also fails, return the original create error.
@@ -194,7 +197,7 @@ func (r *audioSourceRepository) Delete(ctx context.Context, id uint) error {
 		}
 		rowsAffected = result.RowsAffected
 		return nil
-	}, nil)
+	}, r.metrics)
 	if err != nil {
 		return err
 	}
@@ -216,7 +219,7 @@ func (r *audioSourceRepository) Update(ctx context.Context, id uint, updates map
 		}
 		rowsAffected = result.RowsAffected
 		return nil
-	}, nil)
+	}, r.metrics)
 	if err != nil {
 		return err
 	}

--- a/internal/datastore/v2/repository/detection_impl.go
+++ b/internal/datastore/v2/repository/detection_impl.go
@@ -33,6 +33,7 @@ const defaultDBBatchSize = 500
 // detectionRepository implements DetectionRepository.
 type detectionRepository struct {
 	db          *gorm.DB
+	metrics     *datastore.Metrics
 	useV2Prefix bool
 	isMySQL     bool
 }
@@ -40,11 +41,13 @@ type detectionRepository struct {
 // NewDetectionRepository creates a new DetectionRepository.
 // Parameters:
 //   - db: GORM database connection
+//   - metrics: optional DatastoreMetrics for retry observability (nil-safe)
 //   - useV2Prefix: true to use v2_ table prefix (MySQL migration mode)
 //   - isMySQL: true for MySQL dialect (affects date/time SQL expressions)
-func NewDetectionRepository(db *gorm.DB, useV2Prefix, isMySQL bool) DetectionRepository {
+func NewDetectionRepository(db *gorm.DB, metrics *datastore.Metrics, useV2Prefix, isMySQL bool) DetectionRepository {
 	return &detectionRepository{
 		db:          db,
+		metrics:     metrics,
 		useV2Prefix: useV2Prefix,
 		isMySQL:     isMySQL,
 	}
@@ -135,7 +138,7 @@ func (r *detectionRepository) hourFromUnixExpr(column string) string {
 func (r *detectionRepository) Save(ctx context.Context, det *entities.Detection) error {
 	return datastore.RetryOnLock("v2_save_detection", func() error {
 		return r.db.WithContext(ctx).Table(r.tableName()).Create(det).Error
-	}, nil)
+	}, r.metrics)
 }
 
 // SaveWithID persists a detection with a specific ID (for migration).
@@ -143,7 +146,7 @@ func (r *detectionRepository) Save(ctx context.Context, det *entities.Detection)
 func (r *detectionRepository) SaveWithID(ctx context.Context, det *entities.Detection) error {
 	return datastore.RetryOnLock("v2_save_detection_with_id", func() error {
 		return r.db.WithContext(ctx).Table(r.tableName()).Create(det).Error
-	}, nil)
+	}, r.metrics)
 }
 
 // Get retrieves a detection by ID.
@@ -250,7 +253,7 @@ func (r *detectionRepository) Update(ctx context.Context, id uint, updates map[s
 		}
 		rowsAffected = result.RowsAffected
 		return nil
-	}, nil)
+	}, r.metrics)
 	if err != nil {
 		return err
 	}
@@ -284,7 +287,7 @@ func (r *detectionRepository) Delete(ctx context.Context, id uint) error {
 		}
 		rowsAffected = result.RowsAffected
 		return nil
-	}, nil)
+	}, r.metrics)
 	if err != nil {
 		return err
 	}
@@ -313,7 +316,7 @@ func (r *detectionRepository) SaveBatch(ctx context.Context, dets []*entities.De
 	}
 	return datastore.RetryOnLock("v2_save_detection_batch", func() error {
 		return r.db.WithContext(ctx).Table(r.tableName()).CreateInBatches(dets, defaultDBBatchSize).Error
-	}, nil)
+	}, r.metrics)
 }
 
 // DeleteBatch removes multiple detections by ID.
@@ -323,7 +326,7 @@ func (r *detectionRepository) DeleteBatch(ctx context.Context, ids []uint) error
 	}
 	return datastore.RetryOnLock("v2_delete_detection_batch", func() error {
 		return r.db.WithContext(ctx).Table(r.tableName()).Delete(&entities.Detection{}, ids).Error
-	}, nil)
+	}, r.metrics)
 }
 
 // SaveBatchWithIDs persists multiple detections with specific IDs (for migration).
@@ -334,7 +337,7 @@ func (r *detectionRepository) SaveBatchWithIDs(ctx context.Context, dets []*enti
 	}
 	return datastore.RetryOnLock("v2_save_detection_batch_with_ids", func() error {
 		return r.db.WithContext(ctx).Table(r.tableName()).CreateInBatches(dets, defaultDBBatchSize).Error
-	}, nil)
+	}, r.metrics)
 }
 
 // GetExistingAndLockedIDs checks which IDs exist and which are locked.
@@ -1010,7 +1013,7 @@ func (r *detectionRepository) SavePredictions(ctx context.Context, detectionID u
 
 	return datastore.RetryOnLock("v2_save_predictions", func() error {
 		return r.db.WithContext(ctx).Table(r.predictionsTable()).Create(&preds).Error
-	}, nil)
+	}, r.metrics)
 }
 
 // SavePredictionsBatch stores predictions for multiple detections efficiently.
@@ -1023,7 +1026,7 @@ func (r *detectionRepository) SavePredictionsBatch(ctx context.Context, preds []
 		return r.db.WithContext(ctx).Table(r.predictionsTable()).
 			Clauses(clause.OnConflict{DoNothing: true}).
 			CreateInBatches(preds, defaultDBBatchSize).Error
-	}, nil)
+	}, r.metrics)
 }
 
 // GetPredictions retrieves all predictions for a detection.
@@ -1042,7 +1045,7 @@ func (r *detectionRepository) DeletePredictions(ctx context.Context, detectionID
 		return r.db.WithContext(ctx).Table(r.predictionsTable()).
 			Where("detection_id = ?", detectionID).
 			Delete(&entities.DetectionPrediction{}).Error
-	}, nil)
+	}, r.metrics)
 }
 
 // ============================================================================
@@ -1061,7 +1064,7 @@ func (r *detectionRepository) SaveReview(ctx context.Context, review *entities.D
 		// Create new review
 		return datastore.RetryOnLock("v2_save_review", func() error {
 			return r.db.WithContext(ctx).Table(r.reviewsTable()).Create(review).Error
-		}, nil)
+		}, r.metrics)
 	}
 	if err != nil {
 		return err
@@ -1075,7 +1078,7 @@ func (r *detectionRepository) SaveReview(ctx context.Context, review *entities.D
 				"verified":   review.Verified,
 				"updated_at": time.Now(),
 			}).Error
-	}, nil)
+	}, r.metrics)
 }
 
 // GetReview retrieves the review for a detection.
@@ -1105,7 +1108,7 @@ func (r *detectionRepository) UpdateReview(ctx context.Context, detectionID uint
 		}
 		rowsAffected = result.RowsAffected
 		return nil
-	}, nil)
+	}, r.metrics)
 	if err != nil {
 		return err
 	}
@@ -1127,7 +1130,7 @@ func (r *detectionRepository) DeleteReview(ctx context.Context, detectionID uint
 		}
 		rowsAffected = result.RowsAffected
 		return nil
-	}, nil)
+	}, r.metrics)
 	if err != nil {
 		return err
 	}
@@ -1146,7 +1149,7 @@ func (r *detectionRepository) SaveReviewsBatch(ctx context.Context, reviews []*e
 		return r.db.WithContext(ctx).Table(r.reviewsTable()).
 			Clauses(clause.OnConflict{DoNothing: true}).
 			CreateInBatches(reviews, defaultDBBatchSize).Error
-	}, nil)
+	}, r.metrics)
 }
 
 // GetReviewsByDetectionIDs retrieves reviews for multiple detections.
@@ -1184,7 +1187,7 @@ func (r *detectionRepository) GetReviewsByDetectionIDs(ctx context.Context, dete
 func (r *detectionRepository) SaveComment(ctx context.Context, comment *entities.DetectionComment) error {
 	return datastore.RetryOnLock("v2_save_comment", func() error {
 		return r.db.WithContext(ctx).Table(r.commentsTable()).Create(comment).Error
-	}, nil)
+	}, r.metrics)
 }
 
 // GetComments retrieves all comments for a detection.
@@ -1212,7 +1215,7 @@ func (r *detectionRepository) UpdateComment(ctx context.Context, commentID uint,
 		}
 		rowsAffected = result.RowsAffected
 		return nil
-	}, nil)
+	}, r.metrics)
 	if err != nil {
 		return err
 	}
@@ -1232,7 +1235,7 @@ func (r *detectionRepository) DeleteComment(ctx context.Context, commentID uint)
 		}
 		rowsAffected = result.RowsAffected
 		return nil
-	}, nil)
+	}, r.metrics)
 	if err != nil {
 		return err
 	}
@@ -1251,7 +1254,7 @@ func (r *detectionRepository) SaveCommentsBatch(ctx context.Context, comments []
 		return r.db.WithContext(ctx).Table(r.commentsTable()).
 			Clauses(clause.OnConflict{DoNothing: true}).
 			CreateInBatches(comments, defaultDBBatchSize).Error
-	}, nil)
+	}, r.metrics)
 }
 
 // GetCommentsByDetectionIDs retrieves comments for multiple detections.
@@ -1306,7 +1309,7 @@ func (r *detectionRepository) Lock(ctx context.Context, detectionID uint) error 
 	lock := entities.DetectionLock{DetectionID: detectionID}
 	return datastore.RetryOnLock("v2_lock_detection", func() error {
 		return r.db.WithContext(ctx).Table(r.locksTable()).Create(&lock).Error
-	}, nil)
+	}, r.metrics)
 }
 
 // Unlock removes the lock from a detection.
@@ -1317,7 +1320,7 @@ func (r *detectionRepository) Unlock(ctx context.Context, detectionID uint) erro
 		return r.db.WithContext(ctx).Table(r.locksTable()).
 			Where("detection_id = ?", detectionID).
 			Delete(&entities.DetectionLock{}).Error
-	}, nil)
+	}, r.metrics)
 }
 
 // IsLocked checks if a detection is locked.
@@ -1350,7 +1353,7 @@ func (r *detectionRepository) SaveLocksBatch(ctx context.Context, locks []*entit
 		return r.db.WithContext(ctx).Table(r.locksTable()).
 			Clauses(clause.OnConflict{DoNothing: true}).
 			CreateInBatches(locks, defaultDBBatchSize).Error
-	}, nil)
+	}, r.metrics)
 }
 
 // GetLocksByDetectionIDs retrieves lock status for multiple detections.

--- a/internal/datastore/v2/repository/dynamic_threshold_impl.go
+++ b/internal/datastore/v2/repository/dynamic_threshold_impl.go
@@ -14,6 +14,7 @@ import (
 // dynamicThresholdRepository implements DynamicThresholdRepository.
 type dynamicThresholdRepository struct {
 	db          *gorm.DB
+	metrics     *datastore.Metrics
 	labelRepo   LabelRepository
 	useV2Prefix bool
 	isMySQL     bool // For API consistency; currently unused here (used by detection_impl.go for dialect-specific SQL)
@@ -22,12 +23,14 @@ type dynamicThresholdRepository struct {
 // NewDynamicThresholdRepository creates a new DynamicThresholdRepository.
 // Parameters:
 //   - db: GORM database connection
+//   - metrics: optional DatastoreMetrics for retry observability (nil-safe)
 //   - labelRepo: LabelRepository for resolving species names to label IDs
 //   - useV2Prefix: true to use v2_ table prefix (MySQL migration mode)
 //   - isMySQL: true for MySQL dialect (affects date/time SQL expressions)
-func NewDynamicThresholdRepository(db *gorm.DB, labelRepo LabelRepository, useV2Prefix, isMySQL bool) DynamicThresholdRepository {
+func NewDynamicThresholdRepository(db *gorm.DB, metrics *datastore.Metrics, labelRepo LabelRepository, useV2Prefix, isMySQL bool) DynamicThresholdRepository {
 	return &dynamicThresholdRepository{
 		db:          db,
+		metrics:     metrics,
 		labelRepo:   labelRepo,
 		useV2Prefix: useV2Prefix,
 		isMySQL:     isMySQL,
@@ -70,7 +73,7 @@ func (r *dynamicThresholdRepository) SaveDynamicThreshold(ctx context.Context, t
 				UpdateAll: true,
 			}).
 			Create(threshold).Error
-	}, nil)
+	}, r.metrics)
 }
 
 // GetDynamicThreshold retrieves a threshold by species name (scientific name).
@@ -142,7 +145,7 @@ func (r *dynamicThresholdRepository) DeleteDynamicThreshold(ctx context.Context,
 		}
 		rowsAffected = result.RowsAffected
 		return nil
-	}, nil)
+	}, r.metrics)
 	if err != nil {
 		return err
 	}
@@ -164,7 +167,7 @@ func (r *dynamicThresholdRepository) DeleteExpiredDynamicThresholds(ctx context.
 		}
 		rowsAffected = result.RowsAffected
 		return nil
-	}, nil)
+	}, r.metrics)
 	return rowsAffected, err
 }
 
@@ -193,7 +196,7 @@ func (r *dynamicThresholdRepository) UpdateDynamicThresholdExpiry(ctx context.Co
 		}
 		rowsAffected = result.RowsAffected
 		return nil
-	}, nil)
+	}, r.metrics)
 	if err != nil {
 		return err
 	}
@@ -222,7 +225,7 @@ func (r *dynamicThresholdRepository) BatchSaveDynamicThresholds(ctx context.Cont
 				UpdateAll: true,
 			}).
 			CreateInBatches(thresholds, 100).Error
-	}, nil)
+	}, r.metrics)
 }
 
 // DeleteAllDynamicThresholds deletes all thresholds.
@@ -237,7 +240,7 @@ func (r *dynamicThresholdRepository) DeleteAllDynamicThresholds(ctx context.Cont
 		}
 		rowsAffected = result.RowsAffected
 		return nil
-	}, nil)
+	}, r.metrics)
 	return rowsAffected, err
 }
 
@@ -291,7 +294,7 @@ func (r *dynamicThresholdRepository) SaveThresholdEvent(ctx context.Context, eve
 	}
 	return datastore.RetryOnLock("v2_save_threshold_event", func() error {
 		return r.db.WithContext(ctx).Table(r.eventTable()).Create(event).Error
-	}, nil)
+	}, r.metrics)
 }
 
 // GetThresholdEvents retrieves events for a species (by scientific name).
@@ -353,7 +356,7 @@ func (r *dynamicThresholdRepository) DeleteThresholdEvents(ctx context.Context, 
 		return r.db.WithContext(ctx).Table(r.eventTable()).
 			Where("label_id IN ?", labelIDs).
 			Delete(&entities.ThresholdEvent{}).Error
-	}, nil)
+	}, r.metrics)
 }
 
 // DeleteAllThresholdEvents deletes all threshold events.
@@ -368,6 +371,6 @@ func (r *dynamicThresholdRepository) DeleteAllThresholdEvents(ctx context.Contex
 		}
 		rowsAffected = result.RowsAffected
 		return nil
-	}, nil)
+	}, r.metrics)
 	return rowsAffected, err
 }

--- a/internal/datastore/v2/repository/image_cache_impl.go
+++ b/internal/datastore/v2/repository/image_cache_impl.go
@@ -13,6 +13,7 @@ import (
 // imageCacheRepository implements ImageCacheRepository.
 type imageCacheRepository struct {
 	db          *gorm.DB
+	metrics     *datastore.Metrics
 	labelRepo   LabelRepository
 	useV2Prefix bool
 	isMySQL     bool // For API consistency; currently unused here (used by detection_impl.go for dialect-specific SQL)
@@ -21,12 +22,14 @@ type imageCacheRepository struct {
 // NewImageCacheRepository creates a new ImageCacheRepository.
 // Parameters:
 //   - db: GORM database connection
+//   - metrics: optional DatastoreMetrics for retry observability (nil-safe)
 //   - labelRepo: LabelRepository for resolving scientific names to label IDs
 //   - useV2Prefix: true to use v2_ table prefix (MySQL migration mode)
 //   - isMySQL: true for MySQL dialect (affects date/time SQL expressions)
-func NewImageCacheRepository(db *gorm.DB, labelRepo LabelRepository, useV2Prefix, isMySQL bool) ImageCacheRepository {
+func NewImageCacheRepository(db *gorm.DB, metrics *datastore.Metrics, labelRepo LabelRepository, useV2Prefix, isMySQL bool) ImageCacheRepository {
 	return &imageCacheRepository{
 		db:          db,
+		metrics:     metrics,
 		labelRepo:   labelRepo,
 		useV2Prefix: useV2Prefix,
 		isMySQL:     isMySQL,
@@ -94,7 +97,7 @@ func (r *imageCacheRepository) SaveImageCache(ctx context.Context, cache *entiti
 				UpdateAll: true,
 			}).
 			Create(cache).Error
-	}, nil)
+	}, r.metrics)
 }
 
 // GetAllImageCaches retrieves all image cache entries for a provider.

--- a/internal/datastore/v2/repository/label_impl.go
+++ b/internal/datastore/v2/repository/label_impl.go
@@ -17,14 +17,17 @@ import (
 // labelRepository implements LabelRepository.
 type labelRepository struct {
 	db          *gorm.DB
+	metrics     *datastore.Metrics
 	useV2Prefix bool // For MySQL: use v2_ table prefix
 	isMySQL     bool // For MySQL dialect
 }
 
 // NewLabelRepository creates a new LabelRepository.
-func NewLabelRepository(db *gorm.DB, useV2Prefix, isMySQL bool) LabelRepository {
+// metrics is optional (nil-safe) and enables retry observability.
+func NewLabelRepository(db *gorm.DB, metrics *datastore.Metrics, useV2Prefix, isMySQL bool) LabelRepository {
 	return &labelRepository{
 		db:          db,
+		metrics:     metrics,
 		useV2Prefix: useV2Prefix,
 		isMySQL:     isMySQL,
 	}
@@ -70,7 +73,7 @@ func (r *labelRepository) GetOrCreate(ctx context.Context, scientificName string
 
 	createErr := datastore.RetryOnLock("v2_create_label", func() error {
 		return r.db.WithContext(ctx).Table(r.tableName()).Create(&label).Error
-	}, nil)
+	}, r.metrics)
 	if createErr != nil {
 		// Handle race condition - try to fetch the existing record
 		findErr := r.db.WithContext(ctx).Table(r.tableName()).
@@ -224,7 +227,7 @@ func (r *labelRepository) BatchGetOrCreate(ctx context.Context, scientificNames 
 		return r.db.WithContext(ctx).Table(r.tableName()).
 			Clauses(clause.OnConflict{DoNothing: true}).
 			CreateInBatches(newLabels, batchQuerySize).Error
-	}, nil); err != nil {
+	}, r.metrics); err != nil {
 		return nil, fmt.Errorf("batch create labels: %w", err)
 	}
 
@@ -308,7 +311,7 @@ func (r *labelRepository) Delete(ctx context.Context, id uint) error {
 		}
 		rowsAffected = result.RowsAffected
 		return nil
-	}, nil)
+	}, r.metrics)
 	if err != nil {
 		return err
 	}
@@ -378,13 +381,16 @@ func (r *labelRepository) GetByScientificNames(ctx context.Context, names []stri
 // labelTypeRepository implements LabelTypeRepository.
 type labelTypeRepository struct {
 	db          *gorm.DB
+	metrics     *datastore.Metrics
 	useV2Prefix bool
 }
 
 // NewLabelTypeRepository creates a new LabelTypeRepository.
-func NewLabelTypeRepository(db *gorm.DB, useV2Prefix bool) LabelTypeRepository {
+// metrics is optional (nil-safe) and enables retry observability.
+func NewLabelTypeRepository(db *gorm.DB, metrics *datastore.Metrics, useV2Prefix bool) LabelTypeRepository {
 	return &labelTypeRepository{
 		db:          db,
+		metrics:     metrics,
 		useV2Prefix: useV2Prefix,
 	}
 }
@@ -446,7 +452,7 @@ func (r *labelTypeRepository) GetOrCreate(ctx context.Context, name string) (*en
 	lt = entities.LabelType{Name: name}
 	if createErr := datastore.RetryOnLock("v2_create_label_type", func() error {
 		return r.db.WithContext(ctx).Table(r.tableName()).Create(&lt).Error
-	}, nil); createErr != nil {
+	}, r.metrics); createErr != nil {
 		// Race condition - try to fetch again
 		if findErr := r.db.WithContext(ctx).Table(r.tableName()).Where("name = ?", name).First(&lt).Error; findErr != nil {
 			return nil, createErr
@@ -458,13 +464,16 @@ func (r *labelTypeRepository) GetOrCreate(ctx context.Context, name string) (*en
 // taxonomicClassRepository implements TaxonomicClassRepository.
 type taxonomicClassRepository struct {
 	db          *gorm.DB
+	metrics     *datastore.Metrics
 	useV2Prefix bool
 }
 
 // NewTaxonomicClassRepository creates a new TaxonomicClassRepository.
-func NewTaxonomicClassRepository(db *gorm.DB, useV2Prefix bool) TaxonomicClassRepository {
+// metrics is optional (nil-safe) and enables retry observability.
+func NewTaxonomicClassRepository(db *gorm.DB, metrics *datastore.Metrics, useV2Prefix bool) TaxonomicClassRepository {
 	return &taxonomicClassRepository{
 		db:          db,
+		metrics:     metrics,
 		useV2Prefix: useV2Prefix,
 	}
 }
@@ -526,7 +535,7 @@ func (r *taxonomicClassRepository) GetOrCreate(ctx context.Context, name string)
 	tc = entities.TaxonomicClass{Name: name}
 	if createErr := datastore.RetryOnLock("v2_create_taxonomic_class", func() error {
 		return r.db.WithContext(ctx).Table(r.tableName()).Create(&tc).Error
-	}, nil); createErr != nil {
+	}, r.metrics); createErr != nil {
 		// Race condition - try to fetch again
 		if findErr := r.db.WithContext(ctx).Table(r.tableName()).Where("name = ?", name).First(&tc).Error; findErr != nil {
 			return nil, createErr

--- a/internal/datastore/v2/repository/model_impl.go
+++ b/internal/datastore/v2/repository/model_impl.go
@@ -12,14 +12,17 @@ import (
 // modelRepository implements ModelRepository.
 type modelRepository struct {
 	db          *gorm.DB
+	metrics     *datastore.Metrics
 	useV2Prefix bool
 	isMySQL     bool
 }
 
 // NewModelRepository creates a new ModelRepository.
-func NewModelRepository(db *gorm.DB, useV2Prefix, isMySQL bool) ModelRepository {
+// metrics is optional (nil-safe) and enables retry observability.
+func NewModelRepository(db *gorm.DB, metrics *datastore.Metrics, useV2Prefix, isMySQL bool) ModelRepository {
 	return &modelRepository{
 		db:          db,
+		metrics:     metrics,
 		useV2Prefix: useV2Prefix,
 		isMySQL:     isMySQL,
 	}
@@ -67,7 +70,7 @@ func (r *modelRepository) GetOrCreate(ctx context.Context, name, version, varian
 
 	createErr := datastore.RetryOnLock("v2_create_model", func() error {
 		return r.db.WithContext(ctx).Table(r.tableName()).Create(&model).Error
-	}, nil)
+	}, r.metrics)
 	if createErr != nil {
 		// Handle race condition
 		findErr := r.db.WithContext(ctx).Table(r.tableName()).
@@ -145,7 +148,7 @@ func (r *modelRepository) Delete(ctx context.Context, id uint) error {
 		}
 		rowsAffected = result.RowsAffected
 		return nil
-	}, nil)
+	}, r.metrics)
 	if err != nil {
 		return err
 	}

--- a/internal/datastore/v2/repository/notification_history_impl.go
+++ b/internal/datastore/v2/repository/notification_history_impl.go
@@ -14,6 +14,7 @@ import (
 // notificationHistoryRepository implements NotificationHistoryRepository.
 type notificationHistoryRepository struct {
 	db          *gorm.DB
+	metrics     *datastore.Metrics
 	labelRepo   LabelRepository
 	useV2Prefix bool
 	isMySQL     bool // For API consistency; currently unused here (used by detection_impl.go for dialect-specific SQL)
@@ -22,12 +23,14 @@ type notificationHistoryRepository struct {
 // NewNotificationHistoryRepository creates a new NotificationHistoryRepository.
 // Parameters:
 //   - db: GORM database connection
+//   - metrics: optional DatastoreMetrics for retry observability (nil-safe)
 //   - labelRepo: LabelRepository for resolving scientific names to label IDs
 //   - useV2Prefix: true to use v2_ table prefix (MySQL migration mode)
 //   - isMySQL: true for MySQL dialect (affects date/time SQL expressions)
-func NewNotificationHistoryRepository(db *gorm.DB, labelRepo LabelRepository, useV2Prefix, isMySQL bool) NotificationHistoryRepository {
+func NewNotificationHistoryRepository(db *gorm.DB, metrics *datastore.Metrics, labelRepo LabelRepository, useV2Prefix, isMySQL bool) NotificationHistoryRepository {
 	return &notificationHistoryRepository{
 		db:          db,
+		metrics:     metrics,
 		labelRepo:   labelRepo,
 		useV2Prefix: useV2Prefix,
 		isMySQL:     isMySQL,
@@ -63,7 +66,7 @@ func (r *notificationHistoryRepository) SaveNotificationHistory(ctx context.Cont
 				UpdateAll: true,
 			}).
 			Create(history).Error
-	}, nil)
+	}, r.metrics)
 }
 
 // GetNotificationHistory retrieves a notification history entry by scientific name.
@@ -119,6 +122,6 @@ func (r *notificationHistoryRepository) DeleteExpiredNotificationHistory(ctx con
 		}
 		rowsAffected = result.RowsAffected
 		return nil
-	}, nil)
+	}, r.metrics)
 	return rowsAffected, err
 }

--- a/internal/datastore/v2/repository/weather_impl.go
+++ b/internal/datastore/v2/repository/weather_impl.go
@@ -14,6 +14,7 @@ import (
 // weatherRepository implements WeatherRepository.
 type weatherRepository struct {
 	db          *gorm.DB
+	metrics     *datastore.Metrics
 	useV2Prefix bool
 	isMySQL     bool // Dialect flag: true for MySQL (UNIX_TIMESTAMP), false for SQLite (strftime)
 }
@@ -21,11 +22,13 @@ type weatherRepository struct {
 // NewWeatherRepository creates a new WeatherRepository.
 // Parameters:
 //   - db: GORM database connection
+//   - metrics: optional DatastoreMetrics for retry observability (nil-safe)
 //   - useV2Prefix: true to use v2_ table prefix (MySQL migration mode)
 //   - isMySQL: true for MySQL dialect (affects date/time SQL expressions)
-func NewWeatherRepository(db *gorm.DB, useV2Prefix, isMySQL bool) WeatherRepository {
+func NewWeatherRepository(db *gorm.DB, metrics *datastore.Metrics, useV2Prefix, isMySQL bool) WeatherRepository {
 	return &weatherRepository{
 		db:          db,
+		metrics:     metrics,
 		useV2Prefix: useV2Prefix,
 		isMySQL:     isMySQL,
 	}
@@ -54,7 +57,7 @@ func (r *weatherRepository) SaveDailyEvents(ctx context.Context, events *entitie
 				UpdateAll: true,
 			}).
 			Create(events).Error
-	}, nil)
+	}, r.metrics)
 }
 
 // GetDailyEvents retrieves daily events by date.
@@ -76,7 +79,7 @@ func (r *weatherRepository) GetDailyEvents(ctx context.Context, date string) (*e
 func (r *weatherRepository) SaveHourlyWeather(ctx context.Context, weather *entities.HourlyWeather) error {
 	return datastore.RetryOnLock("v2_save_hourly_weather", func() error {
 		return r.db.WithContext(ctx).Table(r.hourlyWeatherTable()).Create(weather).Error
-	}, nil)
+	}, r.metrics)
 }
 
 // GetHourlyWeather retrieves hourly weather for a date.
@@ -174,7 +177,7 @@ func (r *weatherRepository) SaveAllDailyEvents(ctx context.Context, events []ent
 					DoNothing: true,
 				}).
 				Create(&batch).Error
-		}, nil)
+		}, r.metrics)
 		if err != nil {
 			return saved, err
 		}
@@ -202,7 +205,7 @@ func (r *weatherRepository) SaveAllHourlyWeather(ctx context.Context, weather []
 		err := datastore.RetryOnLock("v2_save_all_hourly_weather", func() error {
 			return r.db.WithContext(ctx).Table(r.hourlyWeatherTable()).
 				Create(&batch).Error
-		}, nil)
+		}, r.metrics)
 		if err != nil {
 			return saved, err
 		}

--- a/internal/datastore/v2only/datastore_test.go
+++ b/internal/datastore/v2only/datastore_test.go
@@ -40,9 +40,9 @@ func buildTestConfig(t *testing.T, labels []string) (cfg *Config, cleanup func()
 
 	// Create lookup table entries for tests
 	// The LabelType and TaxonomicClass tables should be created by Initialize()
-	labelTypeRepo := repository.NewLabelTypeRepository(db, false)
-	taxClassRepo := repository.NewTaxonomicClassRepository(db, false)
-	modelRepo := repository.NewModelRepository(db, false, false)
+	labelTypeRepo := repository.NewLabelTypeRepository(db, nil, false)
+	taxClassRepo := repository.NewTaxonomicClassRepository(db, nil, false)
+	modelRepo := repository.NewModelRepository(db, nil, false, false)
 
 	ctx := t.Context()
 
@@ -61,13 +61,13 @@ func buildTestConfig(t *testing.T, labels []string) (cfg *Config, cleanup func()
 	avesClassID := avesClass.ID
 
 	// Create repositories (useV2Prefix = false for SQLite, isMySQL = false)
-	detectionRepo := repository.NewDetectionRepository(db, false, false)
-	labelRepo := repository.NewLabelRepository(db, false, false)
-	sourceRepo := repository.NewAudioSourceRepository(db, false, false)
-	weatherRepo := repository.NewWeatherRepository(db, false, false)
-	imageCacheRepo := repository.NewImageCacheRepository(db, labelRepo, false, false)
-	thresholdRepo := repository.NewDynamicThresholdRepository(db, labelRepo, false, false)
-	notificationRepo := repository.NewNotificationHistoryRepository(db, labelRepo, false, false)
+	detectionRepo := repository.NewDetectionRepository(db, nil, false, false)
+	labelRepo := repository.NewLabelRepository(db, nil, false, false)
+	sourceRepo := repository.NewAudioSourceRepository(db, nil, false, false)
+	weatherRepo := repository.NewWeatherRepository(db, nil, false, false)
+	imageCacheRepo := repository.NewImageCacheRepository(db, nil, labelRepo, false, false)
+	thresholdRepo := repository.NewDynamicThresholdRepository(db, nil, labelRepo, false, false)
+	notificationRepo := repository.NewNotificationHistoryRepository(db, nil, labelRepo, false, false)
 
 	cfg = &Config{
 		Manager:            manager,

--- a/internal/datastore/v2only/fresh_install.go
+++ b/internal/datastore/v2only/fresh_install.go
@@ -89,16 +89,16 @@ func InitializeFreshInstall(settings *conf.Settings, log logger.Logger, speciesC
 	db := manager.DB()
 	useV2Prefix := false         // Fresh installs use clean table names
 	isMySQL := manager.IsMySQL() // Derive dialect from actual manager, not settings
-	detectionRepo := repository.NewDetectionRepository(db, useV2Prefix, isMySQL)
-	labelRepo := repository.NewLabelRepository(db, useV2Prefix, isMySQL)
-	modelRepo := repository.NewModelRepository(db, useV2Prefix, isMySQL)
-	sourceRepo := repository.NewAudioSourceRepository(db, useV2Prefix, isMySQL)
-	weatherRepo := repository.NewWeatherRepository(db, useV2Prefix, isMySQL)
-	imageCacheRepo := repository.NewImageCacheRepository(db, labelRepo, useV2Prefix, isMySQL)
-	thresholdRepo := repository.NewDynamicThresholdRepository(db, labelRepo, useV2Prefix, isMySQL)
-	notificationRepo := repository.NewNotificationHistoryRepository(db, labelRepo, useV2Prefix, isMySQL)
-	labelTypeRepo := repository.NewLabelTypeRepository(db, useV2Prefix)
-	taxClassRepo := repository.NewTaxonomicClassRepository(db, useV2Prefix)
+	detectionRepo := repository.NewDetectionRepository(db, nil, useV2Prefix, isMySQL)
+	labelRepo := repository.NewLabelRepository(db, nil, useV2Prefix, isMySQL)
+	modelRepo := repository.NewModelRepository(db, nil, useV2Prefix, isMySQL)
+	sourceRepo := repository.NewAudioSourceRepository(db, nil, useV2Prefix, isMySQL)
+	weatherRepo := repository.NewWeatherRepository(db, nil, useV2Prefix, isMySQL)
+	imageCacheRepo := repository.NewImageCacheRepository(db, nil, labelRepo, useV2Prefix, isMySQL)
+	thresholdRepo := repository.NewDynamicThresholdRepository(db, nil, labelRepo, useV2Prefix, isMySQL)
+	notificationRepo := repository.NewNotificationHistoryRepository(db, nil, labelRepo, useV2Prefix, isMySQL)
+	labelTypeRepo := repository.NewLabelTypeRepository(db, nil, useV2Prefix)
+	taxClassRepo := repository.NewTaxonomicClassRepository(db, nil, useV2Prefix)
 
 	// Get or create required lookup table entries and cache their IDs
 	ctx := context.Background()


### PR DESCRIPTION
## Summary

Add `*datastore.Metrics` field to all 12 v2 repository structs and thread it through constructors, so retry events are visible to Prometheus monitoring.

## Changes

- Added `metrics *datastore.Metrics` to all 12 repository structs and constructors
- Replaced `nil` with `r.metrics` in all 57 `RetryOnLock`/`RetryTransactionOnLock` calls
- Updated 8 caller files to pass the new parameter (currently `nil` — wiring the live metrics instance is the next step)

## Scope

The plumbing is in place. All callers currently pass `nil` so behavior is unchanged. Once the manager/datastore layer threads a real `*Metrics` instance, all v2 retry events will automatically appear in Prometheus.

## Test plan

- [x] All v2 tests pass with `-race`
- [x] golangci-lint clean
- [ ] Verify metrics appear after live wiring

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced internal metrics tracking for database lock and retry operations across repositories, enabling better observability of database contention and performance monitoring without impacting user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->