### PR TITLE
fix: add context.Context to RetryOnLock for cancellation-aware backoff

### DIFF
--- a/internal/datastore/dynamic_threshold.go
+++ b/internal/datastore/dynamic_threshold.go
@@ -2,6 +2,7 @@
 package datastore
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -26,7 +27,7 @@ func (ds *DataStore) SaveDynamicThreshold(threshold *DynamicThreshold) error {
 	threshold.UpdatedAt = now
 
 	// Upsert: set FirstCreated only on INSERT; always update other fields
-	return RetryOnLock("save_dynamic_threshold", func() error {
+	return RetryOnLock(context.Background(), "save_dynamic_threshold", func() error {
 		threshold.ID = 0 // Reset ID for retry safety with FirstOrCreate
 		result := ds.DB.Where("species_name = ?", threshold.SpeciesName).
 			Attrs(DynamicThreshold{
@@ -102,7 +103,7 @@ func (ds *DataStore) DeleteDynamicThreshold(speciesName string) error {
 		return validationError("species name cannot be empty", "species_name", "")
 	}
 
-	return RetryOnLock("delete_dynamic_threshold", func() error {
+	return RetryOnLock(context.Background(), "delete_dynamic_threshold", func() error {
 		result := ds.DB.Where("species_name = ?", speciesName).Delete(&DynamicThreshold{})
 		if result.Error != nil {
 			return dbError(result.Error, "delete_dynamic_threshold", errors.PriorityMedium,
@@ -118,7 +119,7 @@ func (ds *DataStore) DeleteDynamicThreshold(speciesName string) error {
 // This is typically called periodically by a cleanup job
 func (ds *DataStore) DeleteExpiredDynamicThresholds(before time.Time) (int64, error) {
 	var rowsAffected int64
-	err := RetryOnLock("delete_expired_dynamic_thresholds", func() error {
+	err := RetryOnLock(context.Background(), "delete_expired_dynamic_thresholds", func() error {
 		result := ds.DB.Where("expires_at < ?", before).Delete(&DynamicThreshold{})
 		if result.Error != nil {
 			return result.Error
@@ -150,7 +151,7 @@ func (ds *DataStore) UpdateDynamicThresholdExpiry(speciesName string, expiresAt 
 	}
 
 	var rowsAffected int64
-	err := RetryOnLock("update_dynamic_threshold_expiry", func() error {
+	err := RetryOnLock(context.Background(), "update_dynamic_threshold_expiry", func() error {
 		result := ds.DB.Model(&DynamicThreshold{}).
 			Where("species_name = ?", speciesName).
 			Updates(map[string]any{
@@ -244,7 +245,7 @@ func (ds *DataStore) GetDynamicThresholdStats() (totalCount, activeCount, atMini
 // BG-59: Used for "Reset All" functionality
 func (ds *DataStore) DeleteAllDynamicThresholds() (int64, error) {
 	var rowsAffected int64
-	err := RetryOnLock("delete_all_dynamic_thresholds", func() error {
+	err := RetryOnLock(context.Background(), "delete_all_dynamic_thresholds", func() error {
 		result := ds.DB.Where("1 = 1").Delete(&DynamicThreshold{})
 		if result.Error != nil {
 			return result.Error
@@ -281,7 +282,7 @@ func (ds *DataStore) SaveThresholdEvent(event *ThresholdEvent) error {
 		event.CreatedAt = time.Now()
 	}
 
-	return RetryOnLock("save_threshold_event", func() error {
+	return RetryOnLock(context.Background(), "save_threshold_event", func() error {
 		if err := ds.DB.Create(event).Error; err != nil {
 			return dbError(err, "save_threshold_event", errors.PriorityMedium,
 				"species", event.SpeciesName,
@@ -343,7 +344,7 @@ func (ds *DataStore) DeleteThresholdEvents(speciesName string) error {
 		return validationError("species name cannot be empty", "species_name", "")
 	}
 
-	return RetryOnLock("delete_threshold_events", func() error {
+	return RetryOnLock(context.Background(), "delete_threshold_events", func() error {
 		result := ds.DB.Where("species_name = ?", speciesName).Delete(&ThresholdEvent{})
 		if result.Error != nil {
 			return dbError(result.Error, "delete_threshold_events", errors.PriorityMedium,
@@ -359,7 +360,7 @@ func (ds *DataStore) DeleteThresholdEvents(speciesName string) error {
 // BG-59: Used for "Reset All" functionality
 func (ds *DataStore) DeleteAllThresholdEvents() (int64, error) {
 	var rowsAffected int64
-	err := RetryOnLock("delete_all_threshold_events", func() error {
+	err := RetryOnLock(context.Background(), "delete_all_threshold_events", func() error {
 		result := ds.DB.Where("1 = 1").Delete(&ThresholdEvent{})
 		if result.Error != nil {
 			return result.Error
@@ -396,7 +397,7 @@ func (ds *DataStore) BatchSaveDynamicThresholds(thresholds []DynamicThreshold) e
 		}
 	}
 
-	return RetryTransactionOnLock(ds.DB, "batch_save_dynamic_thresholds", func(tx *gorm.DB) error {
+	return RetryTransactionOnLock(context.Background(), ds.DB, "batch_save_dynamic_thresholds", func(tx *gorm.DB) error {
 		now := time.Now()
 
 		// Prepare batch data - set FirstCreated for all entries

--- a/internal/datastore/interfaces.go
+++ b/internal/datastore/interfaces.go
@@ -328,7 +328,7 @@ func (ds *DataStore) Save(note *Note, results []Results) error {
 
 	metricsInstance := ds.getMetrics()
 
-	err := RetryTransactionOnLock(ds.DB, "save_note", func(tx *gorm.DB) error {
+	err := RetryTransactionOnLock(context.Background(), ds.DB, "save_note", func(tx *gorm.DB) error {
 		// Reset auto-generated IDs before each attempt so that retries after
 		// a rolled-back transaction do not try to re-use a stale primary key.
 		note.ID = 0
@@ -458,7 +458,7 @@ func (ds *DataStore) Delete(id string) error {
 	}
 
 	// Perform the deletion within a retryable transaction
-	return RetryTransactionOnLock(ds.DB, "delete_note", func(tx *gorm.DB) error {
+	return RetryTransactionOnLock(context.Background(), ds.DB, "delete_note", func(tx *gorm.DB) error {
 		// Delete the full results entry associated with the note
 		if err := tx.Where("note_id = ?", noteID).Delete(&Results{}).Error; err != nil {
 			return dbError(err, "delete_results", errors.PriorityMedium,
@@ -513,7 +513,7 @@ func (ds *DataStore) DeleteNoteClipPath(noteID string) error {
 	}
 
 	// Update the clip_name field to an empty string for the specified note ID
-	return RetryOnLock("delete_note_clip_path", func() error {
+	return RetryOnLock(context.Background(), "delete_note_clip_path", func() error {
 		err := ds.DB.Model(&Note{}).Where("id = ?", noteID).Update("clip_name", "").Error
 		if err != nil {
 			return errors.New(err).
@@ -935,7 +935,7 @@ func (ds *DataStore) SaveDailyEvents(dailyEvents *DailyEvents) error {
 	if dailyEvents == nil {
 		return validationError("daily events cannot be nil", "daily_events", nil)
 	}
-	return RetryOnLock("save_daily_events", func() error {
+	return RetryOnLock(context.Background(), "save_daily_events", func() error {
 		// Use upsert to handle the unique date constraint
 		result := ds.DB.Where("date = ?", dailyEvents.Date).
 			Assign(*dailyEvents).
@@ -1013,7 +1013,7 @@ func (ds *DataStore) SaveHourlyWeather(hourlyWeather *HourlyWeather) error {
 			Build()
 	}
 
-	return RetryOnLock("save_hourly_weather", func() error {
+	return RetryOnLock(context.Background(), "save_hourly_weather", func() error {
 		// Use upsert to avoid duplicates for the same timestamp.
 		// Compare using Unix epoch seconds to handle legacy records with local
 		// timezone offsets alongside new UTC records.
@@ -1229,7 +1229,7 @@ func (ds *DataStore) UpdateNote(id string, updates map[string]any) error {
 	}
 
 	var rowsAffected int64
-	err := RetryOnLock("update_note", func() error {
+	err := RetryOnLock(context.Background(), "update_note", func() error {
 		result := ds.DB.Model(&Note{}).Where("id = ?", id).Updates(updates)
 		if result.Error != nil {
 			return result.Error
@@ -1297,7 +1297,7 @@ func (ds *DataStore) SaveNoteReview(review *NoteReview) error {
 		return validationError("review cannot be nil", "review", nil)
 	}
 
-	return RetryOnLock("save_note_review", func() error {
+	return RetryOnLock(context.Background(), "save_note_review", func() error {
 		review.ID = 0 // Reset ID for retry safety with FirstOrCreate
 		// Use upsert operation to either create or update the review
 		result := ds.DB.Where("note_id = ?", review.NoteID).
@@ -1524,7 +1524,7 @@ func (ds *DataStore) SaveNoteComment(comment *NoteComment) error {
 		return validationError("comment entry exceeds maximum length", "entry_length", len(comment.Entry))
 	}
 
-	return RetryOnLock("save_note_comment", func() error {
+	return RetryOnLock(context.Background(), "save_note_comment", func() error {
 		if err := ds.DB.Create(comment).Error; err != nil {
 			return dbError(err, "save_note_comment", errors.PriorityMedium,
 				"note_id", fmt.Sprintf("%d", comment.NoteID),
@@ -1547,7 +1547,7 @@ func (ds *DataStore) DeleteNoteComment(commentID string) error {
 			Build()
 	}
 
-	return RetryOnLock("delete_note_comment", func() error {
+	return RetryOnLock(context.Background(), "delete_note_comment", func() error {
 		if err := ds.DB.Delete(&NoteComment{}, id).Error; err != nil {
 			return errors.New(err).
 				Component("datastore").
@@ -1573,7 +1573,7 @@ func (ds *DataStore) UpdateNoteComment(commentID, entry string) error {
 	}
 
 	var rowsAffected int64
-	err = RetryOnLock("update_note_comment", func() error {
+	err = RetryOnLock(context.Background(), "update_note_comment", func() error {
 		result := ds.DB.Model(&NoteComment{}).Where("id = ?", id).Updates(map[string]any{
 			"entry":      entry,
 			"updated_at": time.Now(),
@@ -1718,7 +1718,7 @@ func (ds *DataStore) LockNote(noteID string) error {
 			Build()
 	}
 
-	err = RetryOnLock("lock_note", func() error {
+	err = RetryOnLock(context.Background(), "lock_note", func() error {
 		lock := &NoteLock{
 			NoteID:   uint(id),
 			LockedAt: time.Now(),
@@ -1749,7 +1749,7 @@ func (ds *DataStore) UnlockNote(noteID string) error {
 		return validationError("invalid note ID format for unlock", "note_id", noteID)
 	}
 
-	err = RetryOnLock("unlock_note", func() error {
+	err = RetryOnLock(context.Background(), "unlock_note", func() error {
 		// Check if the lock exists before attempting to delete.
 		exists, checkErr := ds.IsNoteLocked(noteID)
 		if checkErr != nil {
@@ -1815,7 +1815,7 @@ func (ds *DataStore) SaveImageCache(cache *ImageCache) error {
 		return err
 	}
 
-	err := RetryOnLock("save_image_cache", func() error {
+	err := RetryOnLock(context.Background(), "save_image_cache", func() error {
 		// Use Clauses(clause.OnConflict...) to perform an UPSERT operation
 		// Update all columns except primary key on conflict
 		if err := ds.DB.Clauses(clause.OnConflict{

--- a/internal/datastore/notification_history.go
+++ b/internal/datastore/notification_history.go
@@ -10,6 +10,7 @@
 package datastore
 
 import (
+	"context"
 	"time"
 
 	"github.com/tphakala/birdnet-go/internal/errors"
@@ -38,7 +39,7 @@ func (ds *DataStore) SaveNotificationHistory(history *NotificationHistory) error
 
 	// Upsert: Use GORM's OnConflict clause for efficient upsert
 	// This handles the composite unique index on (scientific_name, notification_type)
-	return RetryOnLock("save_notification_history", func() error {
+	return RetryOnLock(context.Background(), "save_notification_history", func() error {
 		result := ds.DB.Clauses(clause.OnConflict{
 			Columns: []clause.Column{
 				{Name: "scientific_name"},
@@ -117,7 +118,7 @@ func (ds *DataStore) GetActiveNotificationHistory(after time.Time) ([]Notificati
 // This is typically called periodically by a cleanup job
 func (ds *DataStore) DeleteExpiredNotificationHistory(before time.Time) (int64, error) {
 	var rowsAffected int64
-	err := RetryOnLock("delete_expired_notification_history", func() error {
+	err := RetryOnLock(context.Background(), "delete_expired_notification_history", func() error {
 		result := ds.DB.Where("expires_at < ?", before).Delete(&NotificationHistory{})
 		if result.Error != nil {
 			return result.Error

--- a/internal/datastore/retry.go
+++ b/internal/datastore/retry.go
@@ -1,6 +1,7 @@
 package datastore
 
 import (
+	"context"
 	"fmt"
 	"math/rand"
 	"strings"
@@ -42,9 +43,16 @@ func IsTransientDBError(err error) bool {
 // retryBackoff computes a jittered exponential backoff delay, logs a warning,
 // records the retry metric, and sleeps. It is called by RetryOnLock and
 // RetryTransactionOnLock when a real retry is about to happen.
-func retryBackoff(attempt int, operation string, lastErr error, m *Metrics) {
+//
+// Returns ctx.Err() if the context is cancelled during the backoff sleep,
+// or nil if the sleep completed normally.
+func retryBackoff(ctx context.Context, attempt int, operation string, lastErr error, m *Metrics) error {
 	if m != nil {
-		m.RecordTransactionRetry(operation, "database_locked")
+		reason := "database_locked"
+		if isDeadlock(lastErr) {
+			reason = "deadlock"
+		}
+		m.RecordTransactionRetry(operation, reason)
 	}
 	backoff := retryBaseDelay * time.Duration(1<<uint(attempt)) //nolint:gosec // G115: attempt bounded by retryMaxAttempts
 	// Add 0-25% jitter to avoid thundering herd when multiple writers contend.
@@ -56,7 +64,14 @@ func retryBackoff(attempt int, operation string, lastErr error, m *Metrics) {
 		logger.Int("max_attempts", retryMaxAttempts),
 		logger.Int64("backoff_ms", delay.Milliseconds()),
 		logger.Error(lastErr))
-	time.Sleep(delay)
+
+	// Context-aware sleep: return early if the caller's context is cancelled.
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(delay):
+	}
+	return nil
 }
 
 // recordRetryExhaustion records metrics when all retry attempts have been
@@ -75,8 +90,11 @@ func recordRetryExhaustion(m *Metrics, operation string, start time.Time) {
 // backoff between retries. Returns the first non-transient error or the
 // last error after all retries are exhausted.
 //
+// The ctx parameter enables cancellation-aware backoff: if the context is
+// cancelled during a backoff sleep, the retry loop exits early with ctx.Err().
+//
 // If metrics is non-nil, each retry attempt and exhaustion are recorded.
-func RetryOnLock(operation string, fn func() error, metrics *Metrics) error {
+func RetryOnLock(ctx context.Context, operation string, fn func() error, metrics *Metrics) error {
 	start := time.Now()
 	var err error
 	for attempt := range retryMaxAttempts {
@@ -96,7 +114,9 @@ func RetryOnLock(operation string, fn func() error, metrics *Metrics) error {
 
 		// Only record the retry metric and sleep when there will be a real retry.
 		if attempt < retryMaxAttempts-1 {
-			retryBackoff(attempt, operation, err, metrics)
+			if backoffErr := retryBackoff(ctx, attempt, operation, err, metrics); backoffErr != nil {
+				return backoffErr // context cancelled during backoff
+			}
 		}
 	}
 
@@ -113,14 +133,18 @@ func RetryOnLock(operation string, fn func() error, metrics *Metrics) error {
 // execute its queries on it. It must NOT call Commit or Rollback -- that is
 // handled by this helper.
 //
+// The ctx parameter enables cancellation-aware backoff and is propagated to
+// db.WithContext(ctx).Begin() so that each transaction attempt respects the
+// caller's deadline.
+//
 // If metrics is non-nil, retry attempts, exhaustion, and lock wait duration
 // are recorded.
-func RetryTransactionOnLock(db *gorm.DB, operation string, fn func(tx *gorm.DB) error, metrics *Metrics) error {
+func RetryTransactionOnLock(ctx context.Context, db *gorm.DB, operation string, fn func(tx *gorm.DB) error, metrics *Metrics) error {
 	start := time.Now()
 	var lastErr error
 
 	for attempt := range retryMaxAttempts {
-		tx := db.Begin()
+		tx := db.WithContext(ctx).Begin()
 		if tx.Error != nil {
 			lastErr = tx.Error
 			if !IsTransientDBError(tx.Error) {
@@ -168,7 +192,9 @@ func RetryTransactionOnLock(db *gorm.DB, operation string, fn func(tx *gorm.DB) 
 
 		// Only record the retry metric and sleep when there will be a real retry.
 		if attempt < retryMaxAttempts-1 {
-			retryBackoff(attempt, operation, lastErr, metrics)
+			if backoffErr := retryBackoff(ctx, attempt, operation, lastErr, metrics); backoffErr != nil {
+				return backoffErr // context cancelled during backoff
+			}
 		}
 	}
 

--- a/internal/datastore/retry_test.go
+++ b/internal/datastore/retry_test.go
@@ -140,7 +140,7 @@ func TestRetryOnLock(t *testing.T) {
 			t.Parallel()
 
 			calls := 0
-			err := RetryOnLock("test_op", func() error {
+			err := RetryOnLock(t.Context(), "test_op", func() error {
 				calls++
 				return tc.fn(&calls)
 			}, nil)
@@ -220,7 +220,7 @@ func TestRetryOnLock_RecordsMetricsOnRetry(t *testing.T) {
 
 	reg, m := newTestMetrics(t)
 	calls := 0
-	err := RetryOnLock("test_metrics_retry", func() error {
+	err := RetryOnLock(t.Context(), "test_metrics_retry", func() error {
 		calls++
 		if calls < 3 {
 			return fmt.Errorf("database is locked")
@@ -239,7 +239,7 @@ func TestRetryOnLock_RecordsExhaustedMetric(t *testing.T) {
 	t.Parallel()
 
 	reg, m := newTestMetrics(t)
-	err := RetryOnLock("test_exhausted", func() error {
+	err := RetryOnLock(t.Context(), "test_exhausted", func() error {
 		return fmt.Errorf("database is locked")
 	}, m)
 
@@ -254,7 +254,7 @@ func TestRetryOnLock_NilMetricsDoesNotPanic(t *testing.T) {
 	t.Parallel()
 
 	calls := 0
-	err := RetryOnLock("nil_metrics", func() error {
+	err := RetryOnLock(t.Context(), "nil_metrics", func() error {
 		calls++
 		if calls < 2 {
 			return fmt.Errorf("database is locked")
@@ -272,7 +272,7 @@ func TestRetryTransactionOnLock_SucceedsImmediately(t *testing.T) {
 	db := openRetryTestDB(t)
 	calls := 0
 
-	err := RetryTransactionOnLock(db, "test_tx", func(tx *gorm.DB) error {
+	err := RetryTransactionOnLock(t.Context(), db, "test_tx", func(tx *gorm.DB) error {
 		calls++
 		return tx.Create(&DailyEvents{Date: "2024-01-01", CityName: "Test"}).Error
 	}, nil)
@@ -292,7 +292,7 @@ func TestRetryTransactionOnLock_RetriesTransientError(t *testing.T) {
 	db := openRetryTestDB(t)
 	calls := 0
 
-	err := RetryTransactionOnLock(db, "test_tx_retry", func(tx *gorm.DB) error {
+	err := RetryTransactionOnLock(t.Context(), db, "test_tx_retry", func(tx *gorm.DB) error {
 		calls++
 		if calls < 3 {
 			return fmt.Errorf("database is locked")
@@ -314,7 +314,7 @@ func TestRetryTransactionOnLock_DoesNotRetryNonTransient(t *testing.T) {
 	db := openRetryTestDB(t)
 	calls := 0
 
-	err := RetryTransactionOnLock(db, "test_tx_bail", func(_ *gorm.DB) error {
+	err := RetryTransactionOnLock(t.Context(), db, "test_tx_bail", func(_ *gorm.DB) error {
 		calls++
 		return fmt.Errorf("UNIQUE constraint failed")
 	}, nil)
@@ -330,7 +330,7 @@ func TestRetryTransactionOnLock_ExhaustsRetries(t *testing.T) {
 	db := openRetryTestDB(t)
 	calls := 0
 
-	err := RetryTransactionOnLock(db, "test_tx_exhaust", func(_ *gorm.DB) error {
+	err := RetryTransactionOnLock(t.Context(), db, "test_tx_exhaust", func(_ *gorm.DB) error {
 		calls++
 		return fmt.Errorf("database is locked")
 	}, nil)
@@ -347,7 +347,7 @@ func TestRetryTransactionOnLock_RollsBackOnError(t *testing.T) {
 
 	// The fn creates a row then returns a non-transient error.
 	// The row should NOT be persisted because the transaction is rolled back.
-	err := RetryTransactionOnLock(db, "test_rollback", func(tx *gorm.DB) error {
+	err := RetryTransactionOnLock(t.Context(), db, "test_rollback", func(tx *gorm.DB) error {
 		if createErr := tx.Create(&DailyEvents{Date: "2024-03-01", CityName: "Ghost"}).Error; createErr != nil {
 			return createErr
 		}
@@ -368,7 +368,7 @@ func TestRetryTransactionOnLock_WithMetrics(t *testing.T) {
 	reg, m := newTestMetrics(t)
 	calls := 0
 
-	err := RetryTransactionOnLock(db, "test_tx_metrics", func(tx *gorm.DB) error {
+	err := RetryTransactionOnLock(t.Context(), db, "test_tx_metrics", func(tx *gorm.DB) error {
 		calls++
 		if calls < 2 {
 			return fmt.Errorf("database is locked")
@@ -393,7 +393,7 @@ func TestRetryTransactionOnLock_ExhaustedWithMetrics(t *testing.T) {
 	db := openRetryTestDB(t)
 	reg, m := newTestMetrics(t)
 
-	err := RetryTransactionOnLock(db, "test_tx_exhaust_metrics", func(_ *gorm.DB) error {
+	err := RetryTransactionOnLock(t.Context(), db, "test_tx_exhaust_metrics", func(_ *gorm.DB) error {
 		return fmt.Errorf("database is locked")
 	}, m)
 

--- a/internal/datastore/v2/repository/alert_rule_impl.go
+++ b/internal/datastore/v2/repository/alert_rule_impl.go
@@ -62,7 +62,7 @@ func (r *alertRuleRepository) GetRule(ctx context.Context, id uint) (*entities.A
 
 // CreateRule creates a new alert rule with its conditions and actions.
 func (r *alertRuleRepository) CreateRule(ctx context.Context, rule *entities.AlertRule) error {
-	return datastore.RetryOnLock("v2_create_alert_rule", func() error {
+	return datastore.RetryOnLock(ctx, "v2_create_alert_rule", func() error {
 		if err := r.db.WithContext(ctx).Create(rule).Error; err != nil {
 			return fmt.Errorf("failed to create alert rule: %w", err)
 		}
@@ -75,7 +75,7 @@ func (r *alertRuleRepository) UpdateRule(ctx context.Context, rule *entities.Ale
 	if rule.ID == 0 {
 		return fmt.Errorf("failed to update alert rule: missing rule ID")
 	}
-	return datastore.RetryTransactionOnLock(r.db.WithContext(ctx), "v2_update_alert_rule", func(tx *gorm.DB) error {
+	return datastore.RetryTransactionOnLock(ctx, r.db, "v2_update_alert_rule", func(tx *gorm.DB) error {
 		if err := tx.Where("rule_id = ?", rule.ID).Delete(&entities.AlertCondition{}).Error; err != nil {
 			return fmt.Errorf("failed to delete old conditions: %w", err)
 		}
@@ -99,7 +99,7 @@ func (r *alertRuleRepository) UpdateRule(ctx context.Context, rule *entities.Ale
 // DeleteRule deletes an alert rule and its conditions/actions via cascade.
 func (r *alertRuleRepository) DeleteRule(ctx context.Context, id uint) error {
 	var rowsAffected int64
-	err := datastore.RetryOnLock("v2_delete_alert_rule", func() error {
+	err := datastore.RetryOnLock(ctx, "v2_delete_alert_rule", func() error {
 		result := r.db.WithContext(ctx).Delete(&entities.AlertRule{}, id)
 		if result.Error != nil {
 			return fmt.Errorf("failed to delete alert rule %d: %w", id, result.Error)
@@ -119,7 +119,7 @@ func (r *alertRuleRepository) DeleteRule(ctx context.Context, id uint) error {
 // ToggleRule enables or disables an alert rule.
 func (r *alertRuleRepository) ToggleRule(ctx context.Context, id uint, enabled bool) error {
 	var rowsAffected int64
-	err := datastore.RetryOnLock("v2_toggle_alert_rule", func() error {
+	err := datastore.RetryOnLock(ctx, "v2_toggle_alert_rule", func() error {
 		result := r.db.WithContext(ctx).Model(&entities.AlertRule{}).Where("id = ?", id).Update("enabled", enabled)
 		if result.Error != nil {
 			return fmt.Errorf("failed to toggle alert rule %d: %w", id, result.Error)
@@ -145,7 +145,7 @@ func (r *alertRuleRepository) GetEnabledRules(ctx context.Context) ([]entities.A
 // DeleteBuiltInRules deletes all built-in alert rules.
 func (r *alertRuleRepository) DeleteBuiltInRules(ctx context.Context) (int64, error) {
 	var rowsAffected int64
-	err := datastore.RetryOnLock("v2_delete_built_in_rules", func() error {
+	err := datastore.RetryOnLock(ctx, "v2_delete_built_in_rules", func() error {
 		result := r.db.WithContext(ctx).Where("built_in = ?", true).Delete(&entities.AlertRule{})
 		if result.Error != nil {
 			return fmt.Errorf("failed to delete built-in alert rules: %w", result.Error)
@@ -158,7 +158,7 @@ func (r *alertRuleRepository) DeleteBuiltInRules(ctx context.Context) (int64, er
 
 // SaveHistory saves an alert history entry.
 func (r *alertRuleRepository) SaveHistory(ctx context.Context, history *entities.AlertHistory) error {
-	return datastore.RetryOnLock("v2_save_alert_history", func() error {
+	return datastore.RetryOnLock(ctx, "v2_save_alert_history", func() error {
 		if err := r.db.WithContext(ctx).Create(history).Error; err != nil {
 			return fmt.Errorf("failed to save alert history: %w", err)
 		}
@@ -198,7 +198,7 @@ func (r *alertRuleRepository) ListHistory(ctx context.Context, filter AlertHisto
 // DeleteHistory deletes all alert history entries.
 func (r *alertRuleRepository) DeleteHistory(ctx context.Context) (int64, error) {
 	var rowsAffected int64
-	err := datastore.RetryOnLock("v2_delete_alert_history", func() error {
+	err := datastore.RetryOnLock(ctx, "v2_delete_alert_history", func() error {
 		result := r.db.WithContext(ctx).Where("1 = 1").Delete(&entities.AlertHistory{})
 		if result.Error != nil {
 			return fmt.Errorf("failed to delete alert history: %w", result.Error)
@@ -212,7 +212,7 @@ func (r *alertRuleRepository) DeleteHistory(ctx context.Context) (int64, error) 
 // DeleteHistoryBefore deletes alert history entries older than the given time.
 func (r *alertRuleRepository) DeleteHistoryBefore(ctx context.Context, before time.Time) (int64, error) {
 	var rowsAffected int64
-	err := datastore.RetryOnLock("v2_delete_alert_history_before", func() error {
+	err := datastore.RetryOnLock(ctx, "v2_delete_alert_history_before", func() error {
 		result := r.db.WithContext(ctx).Where("fired_at < ?", before).Delete(&entities.AlertHistory{})
 		if result.Error != nil {
 			return fmt.Errorf("failed to delete alert history before %v: %w", before, result.Error)

--- a/internal/datastore/v2/repository/app_metadata_impl.go
+++ b/internal/datastore/v2/repository/app_metadata_impl.go
@@ -64,7 +64,7 @@ func (r *appMetadataRepository) Set(ctx context.Context, key, value string) erro
 		Key:   key,
 		Value: value,
 	}
-	return datastore.RetryOnLock("v2_set_app_metadata", func() error {
+	return datastore.RetryOnLock(ctx, "v2_set_app_metadata", func() error {
 		if err := r.db.WithContext(ctx).Table(r.tableName()).
 			Clauses(clause.OnConflict{
 				Columns:   []clause.Column{{Name: "key"}},

--- a/internal/datastore/v2/repository/audio_source_impl.go
+++ b/internal/datastore/v2/repository/audio_source_impl.go
@@ -69,7 +69,7 @@ func (r *audioSourceRepository) GetOrCreate(ctx context.Context, sourceURI, node
 		SourceType:  sourceType,
 	}
 
-	createErr := datastore.RetryOnLock("v2_create_audio_source", func() error {
+	createErr := datastore.RetryOnLock(ctx, "v2_create_audio_source", func() error {
 		return r.db.WithContext(ctx).Table(r.tableName()).Create(&source).Error
 	}, r.metrics)
 	if createErr != nil {
@@ -190,7 +190,7 @@ func (r *audioSourceRepository) Count(ctx context.Context) (int64, error) {
 // Delete removes an audio source by ID.
 func (r *audioSourceRepository) Delete(ctx context.Context, id uint) error {
 	var rowsAffected int64
-	err := datastore.RetryOnLock("v2_delete_audio_source", func() error {
+	err := datastore.RetryOnLock(ctx, "v2_delete_audio_source", func() error {
 		result := r.db.WithContext(ctx).Table(r.tableName()).Delete(&entities.AudioSource{}, id)
 		if result.Error != nil {
 			return result.Error
@@ -210,7 +210,7 @@ func (r *audioSourceRepository) Delete(ctx context.Context, id uint) error {
 // Update modifies an audio source's fields.
 func (r *audioSourceRepository) Update(ctx context.Context, id uint, updates map[string]any) error {
 	var rowsAffected int64
-	err := datastore.RetryOnLock("v2_update_audio_source", func() error {
+	err := datastore.RetryOnLock(ctx, "v2_update_audio_source", func() error {
 		result := r.db.WithContext(ctx).Table(r.tableName()).
 			Where("id = ?", id).
 			Updates(updates)

--- a/internal/datastore/v2/repository/detection_impl.go
+++ b/internal/datastore/v2/repository/detection_impl.go
@@ -136,7 +136,7 @@ func (r *detectionRepository) hourFromUnixExpr(column string) string {
 
 // Save persists a new detection.
 func (r *detectionRepository) Save(ctx context.Context, det *entities.Detection) error {
-	return datastore.RetryOnLock("v2_save_detection", func() error {
+	return datastore.RetryOnLock(ctx, "v2_save_detection", func() error {
 		return r.db.WithContext(ctx).Table(r.tableName()).Create(det).Error
 	}, r.metrics)
 }
@@ -144,7 +144,7 @@ func (r *detectionRepository) Save(ctx context.Context, det *entities.Detection)
 // SaveWithID persists a detection with a specific ID (for migration).
 // GORM's Create() respects pre-set IDs, so no special handling is needed.
 func (r *detectionRepository) SaveWithID(ctx context.Context, det *entities.Detection) error {
-	return datastore.RetryOnLock("v2_save_detection_with_id", func() error {
+	return datastore.RetryOnLock(ctx, "v2_save_detection_with_id", func() error {
 		return r.db.WithContext(ctx).Table(r.tableName()).Create(det).Error
 	}, r.metrics)
 }
@@ -240,7 +240,7 @@ func (r *detectionRepository) GetWithRelations(ctx context.Context, id uint) (*e
 // Uses atomic operation to prevent TOCTOU race with lock checks.
 func (r *detectionRepository) Update(ctx context.Context, id uint, updates map[string]any) error {
 	var rowsAffected int64
-	err := datastore.RetryOnLock("v2_update_detection", func() error {
+	err := datastore.RetryOnLock(ctx, "v2_update_detection", func() error {
 		// Atomic update: only update if not locked
 		// Use WHERE NOT EXISTS to combine lock check with update
 		result := r.db.WithContext(ctx).Table(r.tableName()).
@@ -275,7 +275,7 @@ func (r *detectionRepository) Update(ctx context.Context, id uint, updates map[s
 // Uses atomic operation to prevent TOCTOU race with lock checks.
 func (r *detectionRepository) Delete(ctx context.Context, id uint) error {
 	var rowsAffected int64
-	err := datastore.RetryOnLock("v2_delete_detection", func() error {
+	err := datastore.RetryOnLock(ctx, "v2_delete_detection", func() error {
 		// Atomic delete: only delete if not locked
 		// Use raw SQL with NOT EXISTS to combine lock check with delete
 		result := r.db.WithContext(ctx).Exec(
@@ -314,7 +314,7 @@ func (r *detectionRepository) SaveBatch(ctx context.Context, dets []*entities.De
 	if len(dets) == 0 {
 		return nil
 	}
-	return datastore.RetryOnLock("v2_save_detection_batch", func() error {
+	return datastore.RetryOnLock(ctx, "v2_save_detection_batch", func() error {
 		return r.db.WithContext(ctx).Table(r.tableName()).CreateInBatches(dets, defaultDBBatchSize).Error
 	}, r.metrics)
 }
@@ -324,7 +324,7 @@ func (r *detectionRepository) DeleteBatch(ctx context.Context, ids []uint) error
 	if len(ids) == 0 {
 		return nil
 	}
-	return datastore.RetryOnLock("v2_delete_detection_batch", func() error {
+	return datastore.RetryOnLock(ctx, "v2_delete_detection_batch", func() error {
 		return r.db.WithContext(ctx).Table(r.tableName()).Delete(&entities.Detection{}, ids).Error
 	}, r.metrics)
 }
@@ -335,7 +335,7 @@ func (r *detectionRepository) SaveBatchWithIDs(ctx context.Context, dets []*enti
 	if len(dets) == 0 {
 		return nil
 	}
-	return datastore.RetryOnLock("v2_save_detection_batch_with_ids", func() error {
+	return datastore.RetryOnLock(ctx, "v2_save_detection_batch_with_ids", func() error {
 		return r.db.WithContext(ctx).Table(r.tableName()).CreateInBatches(dets, defaultDBBatchSize).Error
 	}, r.metrics)
 }
@@ -1011,7 +1011,7 @@ func (r *detectionRepository) SavePredictions(ctx context.Context, detectionID u
 		p.DetectionID = detectionID
 	}
 
-	return datastore.RetryOnLock("v2_save_predictions", func() error {
+	return datastore.RetryOnLock(ctx, "v2_save_predictions", func() error {
 		return r.db.WithContext(ctx).Table(r.predictionsTable()).Create(&preds).Error
 	}, r.metrics)
 }
@@ -1022,7 +1022,7 @@ func (r *detectionRepository) SavePredictionsBatch(ctx context.Context, preds []
 	if len(preds) == 0 {
 		return nil
 	}
-	return datastore.RetryOnLock("v2_save_predictions_batch", func() error {
+	return datastore.RetryOnLock(ctx, "v2_save_predictions_batch", func() error {
 		return r.db.WithContext(ctx).Table(r.predictionsTable()).
 			Clauses(clause.OnConflict{DoNothing: true}).
 			CreateInBatches(preds, defaultDBBatchSize).Error
@@ -1041,7 +1041,7 @@ func (r *detectionRepository) GetPredictions(ctx context.Context, detectionID ui
 
 // DeletePredictions removes all predictions for a detection.
 func (r *detectionRepository) DeletePredictions(ctx context.Context, detectionID uint) error {
-	return datastore.RetryOnLock("v2_delete_predictions", func() error {
+	return datastore.RetryOnLock(ctx, "v2_delete_predictions", func() error {
 		return r.db.WithContext(ctx).Table(r.predictionsTable()).
 			Where("detection_id = ?", detectionID).
 			Delete(&entities.DetectionPrediction{}).Error
@@ -1062,7 +1062,7 @@ func (r *detectionRepository) SaveReview(ctx context.Context, review *entities.D
 
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		// Create new review
-		return datastore.RetryOnLock("v2_save_review", func() error {
+		return datastore.RetryOnLock(ctx, "v2_save_review", func() error {
 			return r.db.WithContext(ctx).Table(r.reviewsTable()).Create(review).Error
 		}, r.metrics)
 	}
@@ -1071,7 +1071,7 @@ func (r *detectionRepository) SaveReview(ctx context.Context, review *entities.D
 	}
 
 	// Update existing review
-	return datastore.RetryOnLock("v2_save_review_update", func() error {
+	return datastore.RetryOnLock(ctx, "v2_save_review_update", func() error {
 		return r.db.WithContext(ctx).Table(r.reviewsTable()).
 			Where("detection_id = ?", review.DetectionID).
 			Updates(map[string]any{
@@ -1096,7 +1096,7 @@ func (r *detectionRepository) GetReview(ctx context.Context, detectionID uint) (
 // UpdateReview updates the verification status for a detection.
 func (r *detectionRepository) UpdateReview(ctx context.Context, detectionID uint, verified entities.VerificationStatus) error {
 	var rowsAffected int64
-	err := datastore.RetryOnLock("v2_update_review", func() error {
+	err := datastore.RetryOnLock(ctx, "v2_update_review", func() error {
 		result := r.db.WithContext(ctx).Table(r.reviewsTable()).
 			Where("detection_id = ?", detectionID).
 			Updates(map[string]any{
@@ -1121,7 +1121,7 @@ func (r *detectionRepository) UpdateReview(ctx context.Context, detectionID uint
 // DeleteReview removes the review for a detection.
 func (r *detectionRepository) DeleteReview(ctx context.Context, detectionID uint) error {
 	var rowsAffected int64
-	err := datastore.RetryOnLock("v2_delete_review", func() error {
+	err := datastore.RetryOnLock(ctx, "v2_delete_review", func() error {
 		result := r.db.WithContext(ctx).Table(r.reviewsTable()).
 			Where("detection_id = ?", detectionID).
 			Delete(&entities.DetectionReview{})
@@ -1145,7 +1145,7 @@ func (r *detectionRepository) SaveReviewsBatch(ctx context.Context, reviews []*e
 	if len(reviews) == 0 {
 		return nil
 	}
-	return datastore.RetryOnLock("v2_save_reviews_batch", func() error {
+	return datastore.RetryOnLock(ctx, "v2_save_reviews_batch", func() error {
 		return r.db.WithContext(ctx).Table(r.reviewsTable()).
 			Clauses(clause.OnConflict{DoNothing: true}).
 			CreateInBatches(reviews, defaultDBBatchSize).Error
@@ -1185,7 +1185,7 @@ func (r *detectionRepository) GetReviewsByDetectionIDs(ctx context.Context, dete
 
 // SaveComment adds a comment to a detection.
 func (r *detectionRepository) SaveComment(ctx context.Context, comment *entities.DetectionComment) error {
-	return datastore.RetryOnLock("v2_save_comment", func() error {
+	return datastore.RetryOnLock(ctx, "v2_save_comment", func() error {
 		return r.db.WithContext(ctx).Table(r.commentsTable()).Create(comment).Error
 	}, r.metrics)
 }
@@ -1203,7 +1203,7 @@ func (r *detectionRepository) GetComments(ctx context.Context, detectionID uint)
 // UpdateComment modifies a comment's content.
 func (r *detectionRepository) UpdateComment(ctx context.Context, commentID uint, entry string) error {
 	var rowsAffected int64
-	err := datastore.RetryOnLock("v2_update_comment", func() error {
+	err := datastore.RetryOnLock(ctx, "v2_update_comment", func() error {
 		result := r.db.WithContext(ctx).Table(r.commentsTable()).
 			Where("id = ?", commentID).
 			Updates(map[string]any{
@@ -1228,7 +1228,7 @@ func (r *detectionRepository) UpdateComment(ctx context.Context, commentID uint,
 // DeleteComment removes a specific comment.
 func (r *detectionRepository) DeleteComment(ctx context.Context, commentID uint) error {
 	var rowsAffected int64
-	err := datastore.RetryOnLock("v2_delete_comment", func() error {
+	err := datastore.RetryOnLock(ctx, "v2_delete_comment", func() error {
 		result := r.db.WithContext(ctx).Table(r.commentsTable()).Delete(&entities.DetectionComment{}, commentID)
 		if result.Error != nil {
 			return result.Error
@@ -1250,7 +1250,7 @@ func (r *detectionRepository) SaveCommentsBatch(ctx context.Context, comments []
 	if len(comments) == 0 {
 		return nil
 	}
-	return datastore.RetryOnLock("v2_save_comments_batch", func() error {
+	return datastore.RetryOnLock(ctx, "v2_save_comments_batch", func() error {
 		return r.db.WithContext(ctx).Table(r.commentsTable()).
 			Clauses(clause.OnConflict{DoNothing: true}).
 			CreateInBatches(comments, defaultDBBatchSize).Error
@@ -1307,7 +1307,7 @@ func (r *detectionRepository) Lock(ctx context.Context, detectionID uint) error 
 	}
 
 	lock := entities.DetectionLock{DetectionID: detectionID}
-	return datastore.RetryOnLock("v2_lock_detection", func() error {
+	return datastore.RetryOnLock(ctx, "v2_lock_detection", func() error {
 		return r.db.WithContext(ctx).Table(r.locksTable()).Create(&lock).Error
 	}, r.metrics)
 }
@@ -1316,7 +1316,7 @@ func (r *detectionRepository) Lock(ctx context.Context, detectionID uint) error 
 // This operation is idempotent — unlocking an already-unlocked detection succeeds silently.
 // Uses RetryOnLock for transient SQLite lock contention.
 func (r *detectionRepository) Unlock(ctx context.Context, detectionID uint) error {
-	return datastore.RetryOnLock("v2_unlock_detection", func() error {
+	return datastore.RetryOnLock(ctx, "v2_unlock_detection", func() error {
 		return r.db.WithContext(ctx).Table(r.locksTable()).
 			Where("detection_id = ?", detectionID).
 			Delete(&entities.DetectionLock{}).Error
@@ -1349,7 +1349,7 @@ func (r *detectionRepository) SaveLocksBatch(ctx context.Context, locks []*entit
 	if len(locks) == 0 {
 		return nil
 	}
-	return datastore.RetryOnLock("v2_save_locks_batch", func() error {
+	return datastore.RetryOnLock(ctx, "v2_save_locks_batch", func() error {
 		return r.db.WithContext(ctx).Table(r.locksTable()).
 			Clauses(clause.OnConflict{DoNothing: true}).
 			CreateInBatches(locks, defaultDBBatchSize).Error

--- a/internal/datastore/v2/repository/dynamic_threshold_impl.go
+++ b/internal/datastore/v2/repository/dynamic_threshold_impl.go
@@ -66,7 +66,7 @@ func (r *dynamicThresholdRepository) SaveDynamicThreshold(ctx context.Context, t
 	if threshold.LabelID == 0 {
 		return errors.NewStd("dynamic threshold LabelID must be set before saving")
 	}
-	return datastore.RetryOnLock("v2_save_dynamic_threshold", func() error {
+	return datastore.RetryOnLock(ctx, "v2_save_dynamic_threshold", func() error {
 		return r.db.WithContext(ctx).Table(r.thresholdTable()).
 			Clauses(clause.OnConflict{
 				Columns:   []clause.Column{{Name: "label_id"}},
@@ -136,7 +136,7 @@ func (r *dynamicThresholdRepository) DeleteDynamicThreshold(ctx context.Context,
 	}
 
 	var rowsAffected int64
-	err = datastore.RetryOnLock("v2_delete_dynamic_threshold", func() error {
+	err = datastore.RetryOnLock(ctx, "v2_delete_dynamic_threshold", func() error {
 		result := r.db.WithContext(ctx).Table(r.thresholdTable()).
 			Where("label_id IN ?", labelIDs).
 			Delete(&entities.DynamicThreshold{})
@@ -158,7 +158,7 @@ func (r *dynamicThresholdRepository) DeleteDynamicThreshold(ctx context.Context,
 // DeleteExpiredDynamicThresholds deletes thresholds that have expired.
 func (r *dynamicThresholdRepository) DeleteExpiredDynamicThresholds(ctx context.Context, before time.Time) (int64, error) {
 	var rowsAffected int64
-	err := datastore.RetryOnLock("v2_delete_expired_dynamic_thresholds", func() error {
+	err := datastore.RetryOnLock(ctx, "v2_delete_expired_dynamic_thresholds", func() error {
 		result := r.db.WithContext(ctx).Table(r.thresholdTable()).
 			Where("expires_at < ?", before).
 			Delete(&entities.DynamicThreshold{})
@@ -187,7 +187,7 @@ func (r *dynamicThresholdRepository) UpdateDynamicThresholdExpiry(ctx context.Co
 	}
 
 	var rowsAffected int64
-	err = datastore.RetryOnLock("v2_update_dynamic_threshold_expiry", func() error {
+	err = datastore.RetryOnLock(ctx, "v2_update_dynamic_threshold_expiry", func() error {
 		result := r.db.WithContext(ctx).Table(r.thresholdTable()).
 			Where("label_id IN ?", labelIDs).
 			Update("expires_at", expiresAt)
@@ -218,7 +218,7 @@ func (r *dynamicThresholdRepository) BatchSaveDynamicThresholds(ctx context.Cont
 			return errors.NewStd("all thresholds must have LabelID set before batch save")
 		}
 	}
-	return datastore.RetryOnLock("v2_batch_save_dynamic_thresholds", func() error {
+	return datastore.RetryOnLock(ctx, "v2_batch_save_dynamic_thresholds", func() error {
 		return r.db.WithContext(ctx).Table(r.thresholdTable()).
 			Clauses(clause.OnConflict{
 				Columns:   []clause.Column{{Name: "label_id"}},
@@ -231,7 +231,7 @@ func (r *dynamicThresholdRepository) BatchSaveDynamicThresholds(ctx context.Cont
 // DeleteAllDynamicThresholds deletes all thresholds.
 func (r *dynamicThresholdRepository) DeleteAllDynamicThresholds(ctx context.Context) (int64, error) {
 	var rowsAffected int64
-	err := datastore.RetryOnLock("v2_delete_all_dynamic_thresholds", func() error {
+	err := datastore.RetryOnLock(ctx, "v2_delete_all_dynamic_thresholds", func() error {
 		result := r.db.WithContext(ctx).Table(r.thresholdTable()).
 			Where("1 = 1").
 			Delete(&entities.DynamicThreshold{})
@@ -292,7 +292,7 @@ func (r *dynamicThresholdRepository) SaveThresholdEvent(ctx context.Context, eve
 	if event.LabelID == 0 {
 		return errors.NewStd("threshold event LabelID must be set before saving")
 	}
-	return datastore.RetryOnLock("v2_save_threshold_event", func() error {
+	return datastore.RetryOnLock(ctx, "v2_save_threshold_event", func() error {
 		return r.db.WithContext(ctx).Table(r.eventTable()).Create(event).Error
 	}, r.metrics)
 }
@@ -352,7 +352,7 @@ func (r *dynamicThresholdRepository) DeleteThresholdEvents(ctx context.Context, 
 		return nil // Nothing to delete
 	}
 
-	return datastore.RetryOnLock("v2_delete_threshold_events", func() error {
+	return datastore.RetryOnLock(ctx, "v2_delete_threshold_events", func() error {
 		return r.db.WithContext(ctx).Table(r.eventTable()).
 			Where("label_id IN ?", labelIDs).
 			Delete(&entities.ThresholdEvent{}).Error
@@ -362,7 +362,7 @@ func (r *dynamicThresholdRepository) DeleteThresholdEvents(ctx context.Context, 
 // DeleteAllThresholdEvents deletes all threshold events.
 func (r *dynamicThresholdRepository) DeleteAllThresholdEvents(ctx context.Context) (int64, error) {
 	var rowsAffected int64
-	err := datastore.RetryOnLock("v2_delete_all_threshold_events", func() error {
+	err := datastore.RetryOnLock(ctx, "v2_delete_all_threshold_events", func() error {
 		result := r.db.WithContext(ctx).Table(r.eventTable()).
 			Where("1 = 1").
 			Delete(&entities.ThresholdEvent{})

--- a/internal/datastore/v2/repository/image_cache_impl.go
+++ b/internal/datastore/v2/repository/image_cache_impl.go
@@ -90,7 +90,7 @@ func (r *imageCacheRepository) SaveImageCache(ctx context.Context, cache *entiti
 	if cache.LabelID == 0 {
 		return errors.NewStd("image cache LabelID must be set before saving")
 	}
-	return datastore.RetryOnLock("v2_save_image_cache", func() error {
+	return datastore.RetryOnLock(ctx, "v2_save_image_cache", func() error {
 		return r.db.WithContext(ctx).Table(r.tableName()).
 			Clauses(clause.OnConflict{
 				Columns:   []clause.Column{{Name: "provider_name"}, {Name: "label_id"}},

--- a/internal/datastore/v2/repository/label_impl.go
+++ b/internal/datastore/v2/repository/label_impl.go
@@ -71,7 +71,7 @@ func (r *labelRepository) GetOrCreate(ctx context.Context, scientificName string
 		TaxonomicClassID: taxonomicClassID,
 	}
 
-	createErr := datastore.RetryOnLock("v2_create_label", func() error {
+	createErr := datastore.RetryOnLock(ctx, "v2_create_label", func() error {
 		return r.db.WithContext(ctx).Table(r.tableName()).Create(&label).Error
 	}, r.metrics)
 	if createErr != nil {
@@ -223,7 +223,7 @@ func (r *labelRepository) BatchGetOrCreate(ctx context.Context, scientificNames 
 		}
 	}
 
-	if err := datastore.RetryOnLock("v2_batch_create_labels", func() error {
+	if err := datastore.RetryOnLock(ctx, "v2_batch_create_labels", func() error {
 		return r.db.WithContext(ctx).Table(r.tableName()).
 			Clauses(clause.OnConflict{DoNothing: true}).
 			CreateInBatches(newLabels, batchQuerySize).Error
@@ -304,7 +304,7 @@ func (r *labelRepository) GetAll(ctx context.Context) ([]*entities.Label, error)
 // Delete removes a label by ID.
 func (r *labelRepository) Delete(ctx context.Context, id uint) error {
 	var rowsAffected int64
-	err := datastore.RetryOnLock("v2_delete_label", func() error {
+	err := datastore.RetryOnLock(ctx, "v2_delete_label", func() error {
 		result := r.db.WithContext(ctx).Table(r.tableName()).Delete(&entities.Label{}, id)
 		if result.Error != nil {
 			return result.Error
@@ -450,7 +450,7 @@ func (r *labelTypeRepository) GetOrCreate(ctx context.Context, name string) (*en
 	}
 
 	lt = entities.LabelType{Name: name}
-	if createErr := datastore.RetryOnLock("v2_create_label_type", func() error {
+	if createErr := datastore.RetryOnLock(ctx, "v2_create_label_type", func() error {
 		return r.db.WithContext(ctx).Table(r.tableName()).Create(&lt).Error
 	}, r.metrics); createErr != nil {
 		// Race condition - try to fetch again
@@ -533,7 +533,7 @@ func (r *taxonomicClassRepository) GetOrCreate(ctx context.Context, name string)
 	}
 
 	tc = entities.TaxonomicClass{Name: name}
-	if createErr := datastore.RetryOnLock("v2_create_taxonomic_class", func() error {
+	if createErr := datastore.RetryOnLock(ctx, "v2_create_taxonomic_class", func() error {
 		return r.db.WithContext(ctx).Table(r.tableName()).Create(&tc).Error
 	}, r.metrics); createErr != nil {
 		// Race condition - try to fetch again

--- a/internal/datastore/v2/repository/model_impl.go
+++ b/internal/datastore/v2/repository/model_impl.go
@@ -68,7 +68,7 @@ func (r *modelRepository) GetOrCreate(ctx context.Context, name, version, varian
 		ClassifierPath: classifierPath,
 	}
 
-	createErr := datastore.RetryOnLock("v2_create_model", func() error {
+	createErr := datastore.RetryOnLock(ctx, "v2_create_model", func() error {
 		return r.db.WithContext(ctx).Table(r.tableName()).Create(&model).Error
 	}, r.metrics)
 	if createErr != nil {
@@ -141,7 +141,7 @@ func (r *modelRepository) CountLabels(ctx context.Context, modelID uint) (int64,
 // Delete removes a model by ID.
 func (r *modelRepository) Delete(ctx context.Context, id uint) error {
 	var rowsAffected int64
-	err := datastore.RetryOnLock("v2_delete_model", func() error {
+	err := datastore.RetryOnLock(ctx, "v2_delete_model", func() error {
 		result := r.db.WithContext(ctx).Table(r.tableName()).Delete(&entities.AIModel{}, id)
 		if result.Error != nil {
 			return result.Error

--- a/internal/datastore/v2/repository/notification_history_impl.go
+++ b/internal/datastore/v2/repository/notification_history_impl.go
@@ -59,7 +59,7 @@ func (r *notificationHistoryRepository) SaveNotificationHistory(ctx context.Cont
 	if history.LabelID == 0 {
 		return errors.NewStd("notification history LabelID must be set before saving")
 	}
-	return datastore.RetryOnLock("v2_save_notification_history", func() error {
+	return datastore.RetryOnLock(ctx, "v2_save_notification_history", func() error {
 		return r.db.WithContext(ctx).Table(r.tableName()).
 			Clauses(clause.OnConflict{
 				Columns:   []clause.Column{{Name: "label_id"}, {Name: "notification_type"}},
@@ -113,7 +113,7 @@ func (r *notificationHistoryRepository) GetActiveNotificationHistory(ctx context
 // DeleteExpiredNotificationHistory deletes expired entries.
 func (r *notificationHistoryRepository) DeleteExpiredNotificationHistory(ctx context.Context, before time.Time) (int64, error) {
 	var rowsAffected int64
-	err := datastore.RetryOnLock("v2_delete_expired_notification_history", func() error {
+	err := datastore.RetryOnLock(ctx, "v2_delete_expired_notification_history", func() error {
 		result := r.db.WithContext(ctx).Table(r.tableName()).
 			Where("expires_at < ?", before).
 			Delete(&entities.NotificationHistory{})

--- a/internal/datastore/v2/repository/weather_impl.go
+++ b/internal/datastore/v2/repository/weather_impl.go
@@ -50,7 +50,7 @@ func (r *weatherRepository) hourlyWeatherTable() string {
 
 // SaveDailyEvents saves or updates daily events (upsert).
 func (r *weatherRepository) SaveDailyEvents(ctx context.Context, events *entities.DailyEvents) error {
-	return datastore.RetryOnLock("v2_save_daily_events", func() error {
+	return datastore.RetryOnLock(ctx, "v2_save_daily_events", func() error {
 		return r.db.WithContext(ctx).Table(r.dailyEventsTable()).
 			Clauses(clause.OnConflict{
 				Columns:   []clause.Column{{Name: "date"}},
@@ -77,7 +77,7 @@ func (r *weatherRepository) GetDailyEvents(ctx context.Context, date string) (*e
 
 // SaveHourlyWeather saves hourly weather data.
 func (r *weatherRepository) SaveHourlyWeather(ctx context.Context, weather *entities.HourlyWeather) error {
-	return datastore.RetryOnLock("v2_save_hourly_weather", func() error {
+	return datastore.RetryOnLock(ctx, "v2_save_hourly_weather", func() error {
 		return r.db.WithContext(ctx).Table(r.hourlyWeatherTable()).Create(weather).Error
 	}, r.metrics)
 }
@@ -170,7 +170,7 @@ func (r *weatherRepository) SaveAllDailyEvents(ctx context.Context, events []ent
 		end := min(i+batchSize, len(events))
 		batch := events[i:end]
 
-		err := datastore.RetryOnLock("v2_save_all_daily_events", func() error {
+		err := datastore.RetryOnLock(ctx, "v2_save_all_daily_events", func() error {
 			return r.db.WithContext(ctx).Table(r.dailyEventsTable()).
 				Clauses(clause.OnConflict{
 					Columns:   []clause.Column{{Name: "date"}},
@@ -202,7 +202,7 @@ func (r *weatherRepository) SaveAllHourlyWeather(ctx context.Context, weather []
 		end := min(i+batchSize, len(weather))
 		batch := weather[i:end]
 
-		err := datastore.RetryOnLock("v2_save_all_hourly_weather", func() error {
+		err := datastore.RetryOnLock(ctx, "v2_save_all_hourly_weather", func() error {
 			return r.db.WithContext(ctx).Table(r.hourlyWeatherTable()).
 				Create(&batch).Error
 		}, r.metrics)

--- a/internal/datastore/write_contention_test.go
+++ b/internal/datastore/write_contention_test.go
@@ -305,7 +305,7 @@ func TestRetryExhaustion(t *testing.T) {
 	callCount := 0
 	lockErr := fmt.Errorf("database is locked")
 
-	err := RetryOnLock("test_exhaustion", func() error {
+	err := RetryOnLock(t.Context(), "test_exhaustion", func() error {
 		callCount++
 		return lockErr
 	}, nil)
@@ -325,7 +325,7 @@ func TestRetryExhaustion_NonTransientBailsImmediately(t *testing.T) {
 	callCount := 0
 	constraintErr := fmt.Errorf("UNIQUE constraint failed: daily_events.date")
 
-	err := RetryOnLock("test_non_transient", func() error {
+	err := RetryOnLock(t.Context(), "test_non_transient", func() error {
 		callCount++
 		return constraintErr
 	}, nil)
@@ -372,7 +372,7 @@ func TestRetryExhaustion_IntegrationWithRealDB(t *testing.T) {
 			Date:     "2024-05-02",
 			CityName: "Blocked",
 		}
-		done <- RetryOnLock("blocked_write", func() error {
+		done <- RetryOnLock(t.Context(), "blocked_write", func() error {
 			return ds.DB.Create(event).Error
 		}, nil)
 	}()


### PR DESCRIPTION
## Summary

- Add `context.Context` as first parameter to `RetryOnLock` and `RetryTransactionOnLock`
- Context-aware backoff using `select` on `ctx.Done()` and `time.After(delay)` — retries stop immediately on context cancellation
- `RetryTransactionOnLock` now uses `db.WithContext(ctx).Begin()` to propagate caller deadlines
- Fix hardcoded `"database_locked"` retry reason label — now derives `"deadlock"` when `isDeadlock(err)` matches
- Update all 80+ call sites (v1: `context.Background()`, v2: pass through `ctx`, tests: `t.Context()`)

## Motivation

The v2 `detection.Unlock()` previously had context-aware backoff which was lost when migrating to the shared `RetryOnLock` helper in PR #2578. This restores that capability for all callers.

## Changes

| Area | Files | Call sites updated |
|------|-------|--------------------|
| Core retry | `retry.go` | Signatures + `retryBackoff` |
| V1 datastore | `interfaces.go`, `dynamic_threshold.go`, `notification_history.go` | 25 calls → `context.Background()` |
| V2 repository | 10 `*_impl.go` files | 57 calls → pass `ctx` |
| Tests | `retry_test.go`, `write_contention_test.go` | 14 calls → `t.Context()` |

## Test plan

- [x] All datastore tests pass with `-race`
- [x] All v2 repository tests pass
- [x] golangci-lint clean on both packages
- [ ] Verify context cancellation stops retries in practice

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Infrastructure & Reliability**
  * Enhanced system responsiveness by improving context propagation throughout database operations, enabling faster response to request cancellations and timeouts.
  * Strengthened database lock handling and retry mechanisms to better manage high-contention scenarios and improve overall system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->