### PR TITLE
merge: bring main fixes into next branch

### DIFF
--- a/frontend/src/lib/i18n/config.ts
+++ b/frontend/src/lib/i18n/config.ts
@@ -10,6 +10,7 @@ export const LOCALES = {
   es: { name: 'Espanol' },
   fi: { name: 'Suomi' },
   fr: { name: 'Francais' },
+  hu: { name: 'Magyar' },
   it: { name: 'Italiano' },
   lv: { name: 'Latviešu' },
   nl: { name: 'Nederlands' },

--- a/frontend/static/messages/da.json
+++ b/frontend/static/messages/da.json
@@ -377,8 +377,8 @@
         "application": "Applikationsfejl",
         "imageProvider": "Billedudbydermeddelelse",
         "categoryError": "{category}-fejl",
-        "burstTitle": "Multiple {component} errors",
-        "burstMessage": "{count} errors in the last {window_minutes} minutes: {sample_error}"
+        "burstTitle": "Flere {component}-fejl",
+        "burstMessage": "{count} fejl i de sidste {window_minutes} minutter: {sample_error}"
       },
       "settings": {
         "reloadingBirdnet": "Anvender nye analyseindstillinger...",
@@ -388,7 +388,7 @@
         "reconfiguringBirdweather": "Opdaterer BirdWeather-integration...",
         "reconfiguringStreams": "Opdaterer lydstreams...",
         "reconfiguringTelemetry": "Opdaterer telemetriindstillinger...",
-        "reconfiguringPushNotifications": "Reconfiguring push notification providers...",
+        "reconfiguringPushNotifications": "Omkonfigurerer push-notifikationsudbydere...",
         "reconfiguringSpeciesTracking": "Opdaterer artssporing...",
         "recalculatingThresholds": "Genberegner dynamiske tærskler for ny basisværdi",
         "reconfiguringDynamicThresholds": "Genkonfigurerer dynamiske tærskler...",
@@ -930,31 +930,31 @@
   },
   "spectrogram": {
     "controls": {
-      "frequencyRange": "Frequency Range",
-      "colorMap": "Color Map",
-      "gain": "Gain",
+      "frequencyRange": "Frekvensområde",
+      "colorMap": "Farvekort",
+      "gain": "Forstærkning",
       "gainTooltip": "Spektrogram visualiseringsforstærkning",
       "mute": "Slå lydudgang fra",
       "unmute": "Slå lydudgang til",
-      "frequencyRangeMin": "Minimum frequency",
-      "frequencyRangeMax": "Maximum frequency"
+      "frequencyRangeMin": "Minimumfrekvens",
+      "frequencyRangeMax": "Maksimumfrekvens"
     },
     "error": {
-      "unsupported": "Your browser does not support audio analysis",
-      "connectionFailed": "Failed to connect to live audio stream",
-      "accessDenied": "Live audio access requires authentication. Please log in to use this feature."
+      "unsupported": "Din browser understøtter ikke lydanalyse",
+      "connectionFailed": "Kunne ikke oprette forbindelse til live-lydstream",
+      "accessDenied": "Adgang til live-lyd kræver godkendelse. Log venligst ind for at bruge denne funktion."
     },
     "dashboard": {
-      "toggle": "Live Spectrogram",
-      "audioToggle": "Enable audio"
+      "toggle": "Live spektrogram",
+      "audioToggle": "Aktivér lyd"
     },
     "gain": {
       "muted": "Lydløs",
       "level": "Forstærkning: {value} dB"
     },
     "page": {
-      "title": "Live Audio",
-      "sourceLabel": "Audio Source",
+      "title": "Live-lyd",
+      "sourceLabel": "Lydkilde",
       "connected": "Forbundet",
       "enterFullscreen": "Fuld skærm",
       "exitFullscreen": "Afslut fuld skærm"
@@ -962,7 +962,10 @@
     "colorMaps": {
       "inferno": "Inferno",
       "viridis": "Viridis",
-      "grayscale": "Grayscale"
+      "grayscale": "Gråtone"
+    },
+    "labels": {
+      "toggle": "Skift detekteringsetiketter"
     }
   },
   "system": {
@@ -1265,7 +1268,7 @@
           "recordsInLegacy": "{count} poster i ældre database",
           "comparingRecords": "Sammenligner antal poster...",
           "validationFailed": "Validering mislykkedes",
-          "rate": "Rate",
+          "rate": "Hastighed",
           "recPerSec": "{rate} post/s",
           "dayAvg": "~{count} / dag gns.",
           "dayHistory": "30 dages historik"
@@ -3963,7 +3966,11 @@
       "hidePassword": "Skjul adgangskode",
       "copyToClipboard": "Kopiér til udklipsholder",
       "clearSelection": "Ryd valg",
-      "selectOption": "Vælg en mulighed"
+      "selectOption": "Vælg en mulighed",
+      "secretSet": "Indstillet",
+      "changeSecret": "Skift",
+      "cancelChange": "Annuller",
+      "enterNewSecret": "Indtast ny værdi"
     },
     "help": {
       "passwordStrength": "Adgangskodestyrke: {strength}",
@@ -4046,7 +4053,8 @@
       "seekProgress": "Søg i lydforløb: {current} / {total} sekunder",
       "playbackSpeed": "Afspilningshastighed",
       "speed": "Hastighed",
-      "loop": "Skift gentag"
+      "loop": "Skift gentag",
+      "player": "Lydafspiller"
     },
     "spectrogram": {
       "notGenerated": "Spektrogram er endnu ikke genereret",
@@ -4066,7 +4074,8 @@
       "spectrogramGeneratingAria": "Genererer spektrogram",
       "generating": "Genererer...",
       "queuePosition": "Kø: {position}",
-      "loadError": "Kunne ikke indlæse lyd"
+      "loadError": "Kunne ikke indlæse lyd",
+      "spectrogramAlt": "Lydspektrogram"
     },
     "forms": {
       "numberField": {
@@ -4323,77 +4332,77 @@
     },
     "steps": {
       "welcome": {
-        "title": "Welcome",
-        "heading": "Welcome to BirdNET-Go!",
-        "description": "BirdNET-Go is a real-time bird sound identification system. It listens to audio from your microphone or audio stream and uses the BirdNET AI model to identify bird species.",
-        "credit": "Powered by the BirdNET Analyzer developed by the K. Lisa Yang Center for Conservation Bioacoustics at the Cornell Lab of Ornithology and Chemnitz University of Technology.",
-        "cta": "Let's set up your bird monitoring station."
+        "title": "Velkommen",
+        "heading": "Velkommen til BirdNET-Go!",
+        "description": "BirdNET-Go er et realtids fuglelydsidentifikationssystem. Det lytter til lyd fra din mikrofon eller lydstream og bruger BirdNET AI-modellen til at identificere fuglearter.",
+        "credit": "Drevet af BirdNET Analyzer, udviklet af K. Lisa Yang Center for Conservation Bioacoustics ved Cornell Lab of Ornithology og Chemnitz University of Technology.",
+        "cta": "Lad os opsætte din fugleovervågningsstation."
       },
       "locationLanguage": {
-        "title": "Location & Language",
-        "uiLanguageLabel": "Interface Language",
-        "uiLanguageHelp": "Language used for the web interface",
-        "speciesLanguageLabel": "Species Name Language",
-        "speciesLanguageHelp": "Language used for bird species names in detections",
-        "locationLabel": "Station Location",
-        "locationHelp": "Your location helps filter species to those likely in your area",
-        "latitudeLabel": "Latitude",
-        "longitudeLabel": "Longitude",
-        "useMyLocation": "Use my location",
-        "locationDetected": "Location detected",
-        "locationError": "Could not detect location. Please enter coordinates manually.",
-        "locationDenied": "Location access denied. Please enter coordinates manually."
+        "title": "Placering og sprog",
+        "uiLanguageLabel": "Grænsefladesprog",
+        "uiLanguageHelp": "Sprog brugt til webgrænsefladen",
+        "speciesLanguageLabel": "Artsnavnsprog",
+        "speciesLanguageHelp": "Sprog brugt til fugleartnavne i detekteringer",
+        "locationLabel": "Stationsplacering",
+        "locationHelp": "Din placering hjælper med at filtrere arter til dem, der sandsynligvis findes i dit område",
+        "latitudeLabel": "Breddegrad",
+        "longitudeLabel": "Længdegrad",
+        "useMyLocation": "Brug min placering",
+        "locationDetected": "Placering registreret",
+        "locationError": "Kunne ikke registrere placering. Indtast venligst koordinater manuelt.",
+        "locationDenied": "Adgang til placering nægtet. Indtast venligst koordinater manuelt."
       },
       "audioSource": {
-        "title": "Audio Source",
-        "sourceTypeLabel": "Source Type",
-        "soundcard": "Microphone / Soundcard",
-        "rtspStream": "RTSP Stream",
-        "deviceLabel": "Audio Device",
-        "deviceLoading": "Loading audio devices...",
-        "noDevicesFound": "No audio devices detected. Try configuring an RTSP stream instead.",
-        "rtspUrlLabel": "Stream URL",
+        "title": "Lydkilde",
+        "sourceTypeLabel": "Kildetype",
+        "soundcard": "Mikrofon / Lydkort",
+        "rtspStream": "RTSP-stream",
+        "deviceLabel": "Lydenhed",
+        "deviceLoading": "Indlæser lydenheder...",
+        "noDevicesFound": "Ingen lydenheder fundet. Prøv at konfigurere en RTSP-stream i stedet.",
+        "rtspUrlLabel": "Stream-URL",
         "rtspUrlPlaceholder": "rtsp://user:password@host:port/stream",
-        "rtspUrlHelp": "Enter the URL of your RTSP audio stream",
-        "additionalSourcesHint": "You can add more audio sources later in Settings."
+        "rtspUrlHelp": "Indtast URL'en til din RTSP-lydstream",
+        "additionalSourcesHint": "Du kan tilføje flere lydkilder senere under Indstillinger."
       },
       "detection": {
-        "title": "Detection Threshold",
-        "description": "Choose how strict the bird identification should be. You can adjust this later in Settings.",
-        "balanced": "Balanced",
-        "balancedDesc": "Good balance of accuracy and sensitivity",
-        "balancedRecommended": "Recommended",
-        "highAccuracy": "High Accuracy",
-        "highAccuracyDesc": "Fewer false positives, may miss some birds",
-        "highSensitivity": "High Sensitivity",
-        "highSensitivityDesc": "More detections, more false positives",
-        "threshold": "Confidence threshold",
-        "fpFilterNote": "Once your system is running and proven, you can enable the false positive filter in Settings to further reduce incorrect detections."
+        "title": "Detekteringsgrænse",
+        "description": "Vælg hvor streng fugleidentifikationen skal være. Du kan justere dette senere under Indstillinger.",
+        "balanced": "Balanceret",
+        "balancedDesc": "God balance mellem nøjagtighed og følsomhed",
+        "balancedRecommended": "Anbefalet",
+        "highAccuracy": "Høj nøjagtighed",
+        "highAccuracyDesc": "Færre falske positiver, kan overse nogle fugle",
+        "highSensitivity": "Høj følsomhed",
+        "highSensitivityDesc": "Flere detekteringer, flere falske positiver",
+        "threshold": "Konfidensgrænse",
+        "fpFilterNote": "Når dit system kører og er afprøvet, kan du aktivere filteret for falske positiver under Indstillinger for yderligere at reducere forkerte detekteringer."
       },
       "integration": {
-        "title": "Privacy & Integration",
-        "privacyFilterLabel": "Enable privacy filter",
-        "privacyFilterHelp": "Filters out detections when human voices are detected near the microphone",
-        "birdweatherLabel": "Share detections with BirdWeather",
-        "birdweatherHelp": "Contribute your bird detections to the BirdWeather community network",
-        "birdweatherIdLabel": "BirdWeather Station ID",
-        "birdweatherIdPlaceholder": "Enter your BirdWeather station ID",
-        "errorReportingLabel": "Send anonymous error reports",
-        "errorReportingHelp": "Help improve BirdNET-Go by sending anonymous error reports when something goes wrong"
+        "title": "Privatliv og integration",
+        "privacyFilterLabel": "Aktivér privatlivsfilter",
+        "privacyFilterHelp": "Filtrerer detekteringer fra, når menneskestemmer registreres nær mikrofonen",
+        "birdweatherLabel": "Del detekteringer med BirdWeather",
+        "birdweatherHelp": "Bidrag med dine fugledetekteringer til BirdWeather-fællesskabsnetværket",
+        "birdweatherIdLabel": "BirdWeather stations-ID",
+        "birdweatherIdPlaceholder": "Indtast dit BirdWeather stations-ID",
+        "errorReportingLabel": "Send anonyme fejlrapporter",
+        "errorReportingHelp": "Hjælp med at forbedre BirdNET-Go ved at sende anonyme fejlrapporter, når noget går galt"
       },
       "responsibleUse": {
-        "title": "Using BirdNET-Go Responsibly",
-        "intro": "BirdNET-Go is a powerful tool that enhances your birding experience through AI-assisted identification. To ensure the best outcomes for both birding and conservation:",
-        "point1": "Review and verify detections before sharing observations",
-        "point2": "Use the confidence scores as a guide, not absolute truth",
-        "point3": "Cross-reference with field guides and local expertise",
-        "point4": "Consider seasonal patterns and habitat suitability",
-        "citizenScienceHeading": "When contributing to citizen science:",
-        "citizenPoint1": "Only submit observations you have personally verified",
-        "citizenPoint2": "Include notes about visual or behavioral confirmation",
-        "citizenPoint3": "Use AI detections as a starting point for your own observations",
-        "outro": "This approach ensures data quality for scientific research while maximizing your learning and enjoyment of birds.",
-        "acknowledge": "I understand"
+        "title": "Ansvarlig brug af BirdNET-Go",
+        "intro": "BirdNET-Go er et kraftfuldt værktøj, der forbedrer din fugleoplevelse gennem AI-assisteret identifikation. For at sikre de bedste resultater for både fuglekiggeri og naturbevarelse:",
+        "point1": "Gennemgå og verificér detekteringer, før du deler observationer",
+        "point2": "Brug konfidensscore som en vejledning, ikke som absolut sandhed",
+        "point3": "Krydsreferencér med felthåndbøger og lokal ekspertise",
+        "point4": "Overvej sæsonmønstre og habitategnethed",
+        "citizenScienceHeading": "Når du bidrager til borgervidenskab:",
+        "citizenPoint1": "Indsend kun observationer, du personligt har verificeret",
+        "citizenPoint2": "Medtag noter om visuel eller adfærdsmæssig bekræftelse",
+        "citizenPoint3": "Brug AI-detekteringer som udgangspunkt for dine egne observationer",
+        "outro": "Denne tilgang sikrer datakvalitet til videnskabelig forskning, samtidig med at den maksimerer din læring og glæde ved fugle.",
+        "acknowledge": "Jeg forstår"
       }
     }
   },

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -377,8 +377,8 @@
         "application": "Anwendungsfehler",
         "imageProvider": "Bildanbieter-Hinweis",
         "categoryError": "{category}-Fehler",
-        "burstTitle": "Multiple {component} errors",
-        "burstMessage": "{count} errors in the last {window_minutes} minutes: {sample_error}"
+        "burstTitle": "Mehrere {component}-Fehler",
+        "burstMessage": "{count} Fehler in den letzten {window_minutes} Minuten: {sample_error}"
       },
       "settings": {
         "reloadingBirdnet": "Neue Analyseeinstellungen werden angewendet...",
@@ -388,7 +388,7 @@
         "reconfiguringBirdweather": "BirdWeather-Integration wird aktualisiert...",
         "reconfiguringStreams": "Audiostreams werden aktualisiert...",
         "reconfiguringTelemetry": "Telemetrieeinstellungen werden aktualisiert...",
-        "reconfiguringPushNotifications": "Reconfiguring push notification providers...",
+        "reconfiguringPushNotifications": "Push-Benachrichtigungsanbieter werden neu konfiguriert...",
         "reconfiguringSpeciesTracking": "Artenverfolgung wird aktualisiert...",
         "recalculatingThresholds": "Dynamische Schwellenwerte werden für neuen Basiswert neu berechnet",
         "reconfiguringDynamicThresholds": "Dynamische Schwellenwerte werden neu konfiguriert...",
@@ -790,17 +790,17 @@
       "showing": "Zeige {from} bis {to} von {total} Ergebnissen"
     },
     "weather": {
-      "title": "Weather Information",
-      "noData": "No weather data",
-      "noDataAvailable": "No weather data available",
-      "loading": "Loading weather information...",
+      "title": "Wetterinformationen",
+      "noData": "Keine Wetterdaten",
+      "noDataAvailable": "Keine Wetterdaten verfügbar",
+      "loading": "Wetterinformationen werden geladen...",
       "labels": {
-        "temperature": "Temperature",
-        "weather": "Weather",
+        "temperature": "Temperatur",
+        "weather": "Wetter",
         "wind": "Wind",
-        "humidity": "Humidity",
-        "pressure": "Pressure",
-        "cloudCover": "Cloud Cover"
+        "humidity": "Luftfeuchtigkeit",
+        "pressure": "Luftdruck",
+        "cloudCover": "Bewölkung"
       },
       "units": {
         "temperature": "°C",
@@ -930,31 +930,31 @@
   },
   "spectrogram": {
     "controls": {
-      "frequencyRange": "Frequency Range",
-      "colorMap": "Color Map",
-      "gain": "Gain",
+      "frequencyRange": "Frequenzbereich",
+      "colorMap": "Farbkarte",
+      "gain": "Verstärkung",
       "gainTooltip": "Spektrogramm-Visualisierungsverstärkung",
       "mute": "Audioausgabe stummschalten",
       "unmute": "Audioausgabe aktivieren",
-      "frequencyRangeMin": "Minimum frequency",
-      "frequencyRangeMax": "Maximum frequency"
+      "frequencyRangeMin": "Minimale Frequenz",
+      "frequencyRangeMax": "Maximale Frequenz"
     },
     "error": {
-      "unsupported": "Your browser does not support audio analysis",
-      "connectionFailed": "Failed to connect to live audio stream",
-      "accessDenied": "Live audio access requires authentication. Please log in to use this feature."
+      "unsupported": "Ihr Browser unterstützt keine Audioanalyse",
+      "connectionFailed": "Verbindung zum Live-Audiostream fehlgeschlagen",
+      "accessDenied": "Der Zugriff auf Live-Audio erfordert eine Authentifizierung. Bitte melden Sie sich an, um diese Funktion zu nutzen."
     },
     "dashboard": {
-      "toggle": "Live Spectrogram",
-      "audioToggle": "Enable audio"
+      "toggle": "Live-Spektrogramm",
+      "audioToggle": "Audio aktivieren"
     },
     "gain": {
       "muted": "Stumm",
       "level": "Verstärkung: {value} dB"
     },
     "page": {
-      "title": "Live Audio",
-      "sourceLabel": "Audio Source",
+      "title": "Live-Audio",
+      "sourceLabel": "Audioquelle",
       "connected": "Verbunden",
       "enterFullscreen": "Vollbild",
       "exitFullscreen": "Vollbild beenden"
@@ -962,7 +962,7 @@
     "colorMaps": {
       "inferno": "Inferno",
       "viridis": "Viridis",
-      "grayscale": "Grayscale"
+      "grayscale": "Graustufen"
     },
     "labels": {
       "toggle": "Erkennungslabels umschalten"
@@ -1287,82 +1287,82 @@
         "fetchFailed": "Fehler beim Abrufen der Datenbankstatistiken"
       },
       "dashboard": {
-        "title": "Database Dashboard",
-        "fetchFailed": "Failed to fetch database overview",
+        "title": "Datenbank-Dashboard",
+        "fetchFailed": "Datenbankübersicht konnte nicht abgerufen werden",
         "metrics": {
-          "readLatency": "Read Latency",
-          "writeLatency": "Write Latency",
-          "queriesPerSec": "Queries/sec",
-          "database": "Database",
-          "avg": "avg",
-          "max": "max",
-          "lastHour": "{count} last hour",
-          "slowQueries": "{count} slow"
+          "readLatency": "Leselatenz",
+          "writeLatency": "Schreiblatenz",
+          "queriesPerSec": "Abfragen/Sek",
+          "database": "Datenbank",
+          "avg": "Durchschn.",
+          "max": "Max",
+          "lastHour": "{count} letzte Stunde",
+          "slowQueries": "{count} langsam"
         },
         "details": {
-          "title": "Database Details",
+          "title": "Datenbankdetails",
           "engine": "Engine",
           "journal": "Journal",
-          "pageSize": "Page size",
-          "cacheHit": "Cache hit",
-          "integrity": "Integrity",
-          "lastVacuum": "Last VACUUM"
+          "pageSize": "Seitengröße",
+          "cacheHit": "Cache-Treffer",
+          "integrity": "Integrität",
+          "lastVacuum": "Letztes VACUUM"
         },
         "locksWal": {
-          "title": "Locks & WAL",
-          "lockWaits": "Lock waits",
-          "lockTimeouts": "Lock timeouts",
-          "avgWait": "Avg wait",
-          "busyTimeouts": "Busy timeouts",
-          "walSize": "WAL size",
+          "title": "Sperren & WAL",
+          "lockWaits": "Sperrwartezeiten",
+          "lockTimeouts": "Sperr-Timeouts",
+          "avgWait": "Durchschn. Wartezeit",
+          "busyTimeouts": "Busy-Timeouts",
+          "walSize": "WAL-Größe",
           "checkpoints": "Checkpoints",
-          "freelistPages": "Freelist pages",
-          "cacheSize": "Cache size"
+          "freelistPages": "Freelist-Seiten",
+          "cacheSize": "Cache-Größe"
         },
         "connectionPool": {
-          "title": "Connection Pool",
-          "poolUsage": "Pool Usage",
-          "active": "active",
-          "idle": "idle",
-          "waiting": "waiting",
-          "totalCreated": "Total created",
-          "connErrors": "Conn errors",
+          "title": "Verbindungspool",
+          "poolUsage": "Pool-Auslastung",
+          "active": "aktiv",
+          "idle": "inaktiv",
+          "waiting": "wartend",
+          "totalCreated": "Gesamt erstellt",
+          "connErrors": "Verbindungsfehler",
           "threads": "Threads",
-          "running": "running",
-          "cached": "cached"
+          "running": "laufend",
+          "cached": "gecacht"
         },
         "innodb": {
-          "title": "InnoDB & Locks",
-          "bufferPoolHitRate": "Buffer pool hit rate",
-          "bufferPoolSize": "Buffer pool size",
-          "lockWaits": "Lock waits",
+          "title": "InnoDB & Sperren",
+          "bufferPoolHitRate": "Buffer-Pool-Trefferrate",
+          "bufferPoolSize": "Buffer-Pool-Größe",
+          "lockWaits": "Sperrwartezeiten",
           "deadlocks": "Deadlocks",
-          "avgLockWait": "Avg lock wait",
-          "tableLocksWaited": "Table locks waited",
-          "tableLocksImmediate": "Table locks immediate"
+          "avgLockWait": "Durchschn. Sperrwartezeit",
+          "tableLocksWaited": "Tabellensperren gewartet",
+          "tableLocksImmediate": "Tabellensperren sofort"
         },
         "detectionRate": {
-          "title": "Detection Rate (24h)",
-          "perHour": "/hr",
-          "min": "min",
-          "avg": "avg",
-          "max": "max",
-          "lastBackup": "Last backup",
-          "backupSize": "Backup size",
-          "createBackup": "Create Backup",
+          "title": "Erkennungsrate (24h)",
+          "perHour": "/Std",
+          "min": "Min",
+          "avg": "Durchschn.",
+          "max": "Max",
+          "lastBackup": "Letzte Sicherung",
+          "backupSize": "Sicherungsgröße",
+          "createBackup": "Sicherung erstellen",
           "mysqlHost": "Host",
           "mysqlBackupNote": "MySQL-Backups sollten über mysqldump oder Ihre MySQL-Administrationswerkzeuge verwaltet werden.",
           "chartLabel": "Erkennungsrate über 24 Stunden",
           "detectionsTooltip": "{count} Erkennungen"
         },
         "tables": {
-          "title": "Tables",
-          "total": "Total",
-          "table": "Table",
+          "title": "Tabellen",
+          "total": "Gesamt",
+          "table": "Tabelle",
           "engine": "Engine",
-          "rows": "Rows",
-          "size": "Size",
-          "usage": "Usage"
+          "rows": "Zeilen",
+          "size": "Größe",
+          "usage": "Nutzung"
         },
         "loading": "Laden..."
       },
@@ -2275,7 +2275,7 @@
           "pushover": "Pushover",
           "gotify": "Gotify",
           "ntfy": "ntfy",
-          "email": "Email",
+          "email": "E-Mail",
           "generic": "Shoutrrr",
           "numbered": "{service} #{number}"
         },
@@ -2535,29 +2535,29 @@
           "skipVerify": "Zertifikatsüberprüfung überspringen",
           "configNote": "<strong>TLS-Konfiguration:</strong><br />• Standard-TLS: Zertifikate für öffentliche Broker leer lassen<br />• Selbstsignierte Zertifikate: CA-Zertifikat bereitstellen<br />• Mutual TLS (mTLS): Alle drei Zertifikate bereitstellen",
           "certificates": {
-            "title": "Certificate Management",
-            "description": "Upload certificates for secure MQTT broker connections",
-            "caLabel": "CA Certificate",
+            "title": "Zertifikatsverwaltung",
+            "description": "Zertifikate für sichere MQTT-Broker-Verbindungen hochladen",
+            "caLabel": "CA-Zertifikat",
             "caPlaceholder": "-----BEGIN CERTIFICATE-----",
-            "caHelpText": "Certificate Authority certificate to verify the broker's identity",
-            "clientCertLabel": "Client Certificate",
+            "caHelpText": "Zertifizierungsstellenzertifikat zur Überprüfung der Broker-Identität",
+            "clientCertLabel": "Client-Zertifikat",
             "clientCertPlaceholder": "-----BEGIN CERTIFICATE-----",
-            "clientCertHelpText": "Client certificate for mutual TLS authentication",
-            "clientKeyLabel": "Client Private Key",
+            "clientCertHelpText": "Client-Zertifikat für gegenseitige TLS-Authentifizierung",
+            "clientKeyLabel": "Privater Client-Schlüssel",
             "clientKeyPlaceholder": "-----BEGIN PRIVATE KEY-----",
-            "clientKeyHelpText": "Private key matching the client certificate",
-            "uploadButton": "Upload Certificates",
-            "uploadSuccess": "MQTT TLS certificates uploaded successfully. Use Test Connection to verify.",
-            "uploadError": "Failed to upload MQTT TLS certificates",
-            "deleteConfirm": "Remove all MQTT TLS certificates? The MQTT client will need to reconnect.",
-            "deleteSuccess": "MQTT TLS certificates removed",
-            "deleteError": "Failed to remove MQTT TLS certificates",
-            "loadError": "Failed to load certificate information",
-            "reconnectNote": "Use the Test Connection button below to verify the new TLS configuration."
+            "clientKeyHelpText": "Zum Client-Zertifikat passender privater Schlüssel",
+            "uploadButton": "Zertifikate hochladen",
+            "uploadSuccess": "MQTT-TLS-Zertifikate erfolgreich hochgeladen. Verwenden Sie Verbindung testen zur Überprüfung.",
+            "uploadError": "Hochladen der MQTT-TLS-Zertifikate fehlgeschlagen",
+            "deleteConfirm": "Alle MQTT-TLS-Zertifikate entfernen? Der MQTT-Client muss sich neu verbinden.",
+            "deleteSuccess": "MQTT-TLS-Zertifikate entfernt",
+            "deleteError": "Entfernen der MQTT-TLS-Zertifikate fehlgeschlagen",
+            "loadError": "Laden der Zertifikatsinformationen fehlgeschlagen",
+            "reconnectNote": "Verwenden Sie die Schaltfläche Verbindung testen unten, um die neue TLS-Konfiguration zu überprüfen."
           }
         },
         "homeAssistant": {
-          "title": "Home Assistant Auto-Discovery",
+          "title": "Home Assistant Auto-Erkennung",
           "enable": "Home Assistant MQTT Discovery aktivieren",
           "description": "Wenn aktiviert, registriert BirdNET-Go automatisch Geräte und Sensoren bei Home Assistant über das MQTT-Discovery-Protokoll. Geräte erscheinen ohne manuelle YAML-Konfiguration in der Home Assistant-Geräteregistrierung.",
           "discoveryPrefix": {
@@ -2697,14 +2697,14 @@
           "helpText": "Wie lange Taxonomie-Daten von eBird zwischengespeichert werden. Da sich die Taxonomie selten ändert, reduzieren längere Cache-Zeiten die API-Aufrufe."
         },
         "note": "eBird stellt taxonomische Daten zur Artklassifizierung und für Einblicke bereit. Der API-Schlüssel ist kostenlos beim Cornell Lab of Ornithology erhältlich.",
-        "apiKeyInfo": "A personal eBird API key is required to use this integration. You can request a free key from <a href=\"https://ebird.org/api/keygen\" class=\"link link-primary\" target=\"_blank\" rel=\"noopener noreferrer\">ebird.org/api/keygen</a>.",
+        "apiKeyInfo": "Ein persönlicher eBird-API-Schlüssel ist erforderlich, um diese Integration zu nutzen. Sie können einen kostenlosen Schlüssel unter <a href=\"https://ebird.org/api/keygen\" class=\"link link-primary\" target=\"_blank\" rel=\"noopener noreferrer\">ebird.org/api/keygen</a> anfordern.",
         "test": {
-          "button": "Test eBird Connection",
-          "loading": "Testing...",
-          "enabledRequired": "Enable eBird integration first",
-          "apiKeyRequired": "API key is required",
-          "inProgress": "Test in progress...",
-          "description": "Test eBird API connectivity and authentication"
+          "button": "eBird-Verbindung testen",
+          "loading": "Wird getestet...",
+          "enabledRequired": "Aktivieren Sie zuerst die eBird-Integration",
+          "apiKeyRequired": "API-Schlüssel ist erforderlich",
+          "inProgress": "Test läuft...",
+          "description": "eBird-API-Konnektivität und Authentifizierung testen"
         }
       }
     },
@@ -3210,8 +3210,8 @@
             "source": "Quelle",
             "clearParameters": "Parameter löschen"
           },
-          "placeholder": "Click buttons below to add parameters or type manually",
-          "tooltip": "Use buttons below or type directly (comma-separated)"
+          "placeholder": "Klicken Sie auf die Schaltflächen unten, um Parameter hinzuzufügen, oder geben Sie sie manuell ein",
+          "tooltip": "Verwenden Sie die Schaltflächen unten oder geben Sie direkt ein (kommagetrennt)"
         },
         "executeDefaults": {
           "label": "Auch Standardaktionen ausführen (Datenbankspeicherung, Benachrichtigungen usw.)",
@@ -3363,7 +3363,7 @@
         "expand": "Ereignisverlauf anzeigen",
         "collapse": "Ereignisverlauf ausblenden"
       },
-      "suggestions": "Species suggestions"
+      "suggestions": "Artvorschläge"
     },
     "security": {
       "pageLabel": "Sicherheitseinstellungen",
@@ -3485,39 +3485,39 @@
           "userIdLabel": "Benutzer-ID"
         },
         "oidc": {
-          "title": "OIDC Provider",
-          "enableLabel": "Enable OIDC authentication",
-          "redirectUriTitle": "Redirect URI",
-          "getCredentialsLabel": "Configure in your Identity Provider",
+          "title": "OIDC-Anbieter",
+          "enableLabel": "OIDC-Authentifizierung aktivieren",
+          "redirectUriTitle": "Weiterleitungs-URI",
+          "getCredentialsLabel": "Bei Ihrem Identitätsanbieter konfigurieren",
           "clientIdLabel": "Client ID",
-          "clientIdHelpText": "The client ID from your OIDC identity provider",
+          "clientIdHelpText": "Die Client-ID von Ihrem OIDC-Identitätsanbieter",
           "clientSecretLabel": "Client Secret",
-          "clientSecretHelpText": "The client secret from your OIDC identity provider",
-          "userIdLabel": "Allowed User (email or sub claim)",
-          "issuerUrlLabel": "Issuer URL",
-          "issuerUrlHelpText": "The issuer URL of your OpenID Connect identity provider (e.g., https://auth.example.com)",
+          "clientSecretHelpText": "Das Client-Secret von Ihrem OIDC-Identitätsanbieter",
+          "userIdLabel": "Erlaubter Benutzer (E-Mail oder Sub-Claim)",
+          "issuerUrlLabel": "Aussteller-URL",
+          "issuerUrlHelpText": "Die Aussteller-URL Ihres OpenID Connect-Identitätsanbieters (z.B. https://auth.example.com)",
           "issuerUrlPlaceholder": "https://auth.example.com",
-          "issuerUrlRequired": "Issuer URL is required for OIDC providers",
-          "issuerUrlInvalid": "Issuer URL must be a valid HTTP or HTTPS URL",
+          "issuerUrlRequired": "Aussteller-URL ist für OIDC-Anbieter erforderlich",
+          "issuerUrlInvalid": "Aussteller-URL muss eine gültige HTTP- oder HTTPS-URL sein",
           "scopesLabel": "Scopes",
-          "scopesHelpText": "Comma-separated list of OIDC scopes (default: openid, profile, email)",
+          "scopesHelpText": "Kommagetrennte Liste von OIDC-Scopes (Standard: openid, profile, email)",
           "scopesPlaceholder": "openid, profile, email"
         }
       },
       "bypassAuthentication": {
         "title": "Authentifizierung umgehen",
         "description": "Zugriff auf Einstellungen ohne Authentifizierung erlauben",
-        "disabled": "Subnet bypass is disabled"
+        "disabled": "Subnetz-Umgehung ist deaktiviert"
       },
       "exceptions": {
-        "title": "Exceptions"
+        "title": "Ausnahmen"
       },
       "publicAccess": {
-        "title": "Public Access",
-        "description": "Allow specific features to be accessible without authentication.",
-        "liveAudioLabel": "Allow public live audio playback",
-        "liveAudioHelp": "When enabled, anyone can listen to live audio streams without logging in. Settings and deletion still require authentication.",
-        "warningText": "Enabling public access features exposes them to anyone who can reach this server. Only enable if you trust your network environment."
+        "title": "Öffentlicher Zugang",
+        "description": "Bestimmte Funktionen ohne Authentifizierung zugänglich machen.",
+        "liveAudioLabel": "Öffentliche Live-Audio-Wiedergabe erlauben",
+        "liveAudioHelp": "Wenn aktiviert, kann jeder Live-Audiostreams ohne Anmeldung anhören. Einstellungen und Löschungen erfordern weiterhin eine Authentifizierung.",
+        "warningText": "Die Aktivierung öffentlicher Zugangs-Funktionen macht diese für jeden zugänglich, der diesen Server erreichen kann. Aktivieren Sie dies nur, wenn Sie Ihrer Netzwerkumgebung vertrauen."
       },
       "placeholders": {
         "baseUrl": "https://birdnet.example.com:5500",
@@ -3534,64 +3534,64 @@
       },
       "tls": {
         "title": "TLS / HTTPS",
-        "description": "Configure TLS/HTTPS encryption for secure connections",
-        "modeLabel": "TLS Mode",
-        "modeNone": "None (HTTP)",
+        "description": "TLS/HTTPS-Verschlüsselung für sichere Verbindungen konfigurieren",
+        "modeLabel": "TLS-Modus",
+        "modeNone": "Keiner (HTTP)",
         "modeLetsEncrypt": "Let's Encrypt",
-        "modeManual": "Manual Certificate",
-        "modeSelfSigned": "Self-Signed",
-        "modeNoneDescription": "Plain HTTP without encryption",
-        "modeAutoTLSDescription": "Automatic certificate via Let's Encrypt",
-        "modeManualDescription": "Upload your own certificate and key",
-        "modeSelfSignedDescription": "Generate a self-signed certificate",
-        "portLabel": "HTTPS Port",
-        "portHelpText": "Port for HTTPS connections (default: 8443)",
-        "redirectToHttps": "Redirect HTTP to HTTPS",
-        "autoTLSRequirements": "Requires ports 80 and 443 to be accessible. On Linux, the process needs root or CAP_NET_BIND_SERVICE capability.",
-        "validityLabel": "Certificate Validity",
-        "validityHelpText": "How long the certificate should be valid",
-        "validity365d": "1 year",
-        "validity730d": "2 years",
-        "generateButton": "Generate Certificate",
-        "regenerateButton": "Regenerate Certificate",
-        "generating": "Generating...",
-        "certificateLabel": "Certificate (PEM)",
-        "privateKeyLabel": "Private Key (PEM)",
-        "caCertificateLabel": "CA Certificate (PEM, optional)",
-        "uploadButton": "Upload Certificate",
-        "uploading": "Uploading...",
-        "browseFile": "Browse...",
-        "plaintextWarning": "Warning: Your private key will be transmitted in plaintext over HTTP. Only upload certificates when connected via a trusted network or localhost.",
-        "certificateInstalled": "Installed Certificate",
-        "subject": "Subject",
-        "issuer": "Issuer",
-        "validFrom": "Valid From",
-        "validUntil": "Valid Until",
-        "daysRemaining": "Days Remaining",
-        "sans": "Subject Alternative Names",
-        "fingerprint": "Fingerprint",
-        "expiryWarning": "Certificate is expiring soon",
-        "loading": "Loading certificate info...",
-        "loadError": "Failed to load certificate info",
-        "generateSuccess": "Self-signed certificate generated successfully",
-        "generateError": "Failed to generate certificate",
-        "uploadSuccess": "Certificate uploaded successfully",
-        "uploadError": "Failed to upload certificate",
-        "deleteSuccess": "Certificate removed successfully",
-        "deleteError": "Failed to delete certificate",
-        "removeCertificate": "Remove Certificate",
-        "deleteConfirm": "Are you sure you want to remove the installed TLS certificate? The TLS mode will be reset to None.",
-        "restartRequired": "TLS changes require a server restart to take effect.",
-        "noCertificate": "No certificate installed",
-        "validity1825d": "5 years",
-        "autoTLSHostRequired": "A hostname is required for Let’s Encrypt. Enter your public domain name in the Host field above.",
-        "autoTLSNoIP": "Let’s Encrypt requires a domain name, not an IP address. Enter a public domain like birds.example.com.",
-        "autoTLSNeedsFQDN": "Let’s Encrypt requires a fully qualified domain name (e.g., birds.example.com), not a bare hostname.",
-        "autoTLSNoLocalhost": "Let’s Encrypt cannot issue certificates for localhost.",
-        "autoTLSPrivateTLD": "Let’s Encrypt cannot issue certificates for private domains ({tld} is not publicly resolvable).",
-        "downloadCertificate": "Download Certificate",
-        "downloadCertificateHelp": "Install this certificate in your operating system's trust store to avoid browser security warnings.",
-        "fileReadError": "Failed to read the selected file"
+        "modeManual": "Manuelles Zertifikat",
+        "modeSelfSigned": "Selbstsigniert",
+        "modeNoneDescription": "Einfaches HTTP ohne Verschlüsselung",
+        "modeAutoTLSDescription": "Automatisches Zertifikat über Let's Encrypt",
+        "modeManualDescription": "Eigenes Zertifikat und Schlüssel hochladen",
+        "modeSelfSignedDescription": "Ein selbstsigniertes Zertifikat generieren",
+        "portLabel": "HTTPS-Port",
+        "portHelpText": "Port für HTTPS-Verbindungen (Standard: 8443)",
+        "redirectToHttps": "HTTP zu HTTPS umleiten",
+        "autoTLSRequirements": "Erfordert, dass die Ports 80 und 443 erreichbar sind. Unter Linux benötigt der Prozess Root-Rechte oder die CAP_NET_BIND_SERVICE-Fähigkeit.",
+        "validityLabel": "Zertifikatsgültigkeit",
+        "validityHelpText": "Wie lange das Zertifikat gültig sein soll",
+        "validity365d": "1 Jahr",
+        "validity730d": "2 Jahre",
+        "generateButton": "Zertifikat generieren",
+        "regenerateButton": "Zertifikat neu generieren",
+        "generating": "Wird generiert...",
+        "certificateLabel": "Zertifikat (PEM)",
+        "privateKeyLabel": "Privater Schlüssel (PEM)",
+        "caCertificateLabel": "CA-Zertifikat (PEM, optional)",
+        "uploadButton": "Zertifikat hochladen",
+        "uploading": "Wird hochgeladen...",
+        "browseFile": "Durchsuchen...",
+        "plaintextWarning": "Warnung: Ihr privater Schlüssel wird im Klartext über HTTP übertragen. Laden Sie Zertifikate nur hoch, wenn Sie über ein vertrauenswürdiges Netzwerk oder localhost verbunden sind.",
+        "certificateInstalled": "Installiertes Zertifikat",
+        "subject": "Betreff",
+        "issuer": "Aussteller",
+        "validFrom": "Gültig ab",
+        "validUntil": "Gültig bis",
+        "daysRemaining": "Verbleibende Tage",
+        "sans": "Alternative Antragstellernamen",
+        "fingerprint": "Fingerabdruck",
+        "expiryWarning": "Zertifikat läuft bald ab",
+        "loading": "Zertifikatsinformationen werden geladen...",
+        "loadError": "Laden der Zertifikatsinformationen fehlgeschlagen",
+        "generateSuccess": "Selbstsigniertes Zertifikat erfolgreich generiert",
+        "generateError": "Zertifikat konnte nicht generiert werden",
+        "uploadSuccess": "Zertifikat erfolgreich hochgeladen",
+        "uploadError": "Zertifikat konnte nicht hochgeladen werden",
+        "deleteSuccess": "Zertifikat erfolgreich entfernt",
+        "deleteError": "Zertifikat konnte nicht gelöscht werden",
+        "removeCertificate": "Zertifikat entfernen",
+        "deleteConfirm": "Möchten Sie das installierte TLS-Zertifikat wirklich entfernen? Der TLS-Modus wird auf Keiner zurückgesetzt.",
+        "restartRequired": "TLS-Änderungen erfordern einen Neustart des Servers.",
+        "noCertificate": "Kein Zertifikat installiert",
+        "validity1825d": "5 Jahre",
+        "autoTLSHostRequired": "Ein Hostname ist für Let's Encrypt erforderlich. Geben Sie Ihren öffentlichen Domainnamen im Host-Feld oben ein.",
+        "autoTLSNoIP": "Let's Encrypt benötigt einen Domainnamen, keine IP-Adresse. Geben Sie eine öffentliche Domain wie birds.example.com ein.",
+        "autoTLSNeedsFQDN": "Let's Encrypt benötigt einen vollqualifizierten Domainnamen (z.B. birds.example.com), keinen einfachen Hostnamen.",
+        "autoTLSNoLocalhost": "Let's Encrypt kann keine Zertifikate für localhost ausstellen.",
+        "autoTLSPrivateTLD": "Let's Encrypt kann keine Zertifikate für private Domains ausstellen ({tld} ist nicht öffentlich auflösbar).",
+        "downloadCertificate": "Zertifikat herunterladen",
+        "downloadCertificateHelp": "Installieren Sie dieses Zertifikat im Vertrauensspeicher Ihres Betriebssystems, um Browser-Sicherheitswarnungen zu vermeiden.",
+        "fileReadError": "Ausgewählte Datei konnte nicht gelesen werden"
       }
     },
     "database": {
@@ -3838,7 +3838,7 @@
         "appearance": "Erscheinungsbild",
         "language": "Sprache & Region",
         "visualContent": "Visuelle Inhalte",
-        "audioPlayback": "Audio Playback"
+        "audioPlayback": "Audiowiedergabe"
       },
       "appearance": {
         "title": "Erscheinungsbild",
@@ -3853,14 +3853,14 @@
         "description": "Konfigurieren Sie Vogelbilder und Spektrogramm-Anzeigeeinstellungen"
       },
       "audioPlayback": {
-        "title": "Audio Playback",
-        "description": "Default settings for playing bird recordings.",
-        "defaultGain": "Default Volume Boost",
-        "defaultGainHelpText": "Initial gain applied when playing recordings. Bird sounds are often quiet, so a boost of 6-12 dB is recommended.",
+        "title": "Audiowiedergabe",
+        "description": "Standardeinstellungen für die Wiedergabe von Vogelaufnahmen.",
+        "defaultGain": "Standard-Lautstärkeverstärkung",
+        "defaultGainHelpText": "Anfangsverstärkung bei der Wiedergabe von Aufnahmen. Vogelstimmen sind oft leise, daher wird eine Verstärkung von 6-12 dB empfohlen.",
         "defaultGainUnit": "dB"
       }
     },
-    "restartRequired": "Some changes require a server restart to take effect. Please restart BirdNET-Go."
+    "restartRequired": "Einige Änderungen erfordern einen Neustart des Servers. Bitte starten Sie BirdNET-Go neu."
   },
   "auth": {
     "login": "Anmelden",
@@ -3881,7 +3881,7 @@
     "continueWithMicrosoft": "Weiter mit Microsoft",
     "continueWithLine": "Weiter mit LINE",
     "continueWithKakao": "Weiter mit Kakao",
-    "continueWithOidc": "Continue with OIDC",
+    "continueWithOidc": "Weiter mit OIDC",
     "errors": {
       "loginFailed": "Anmeldung fehlgeschlagen. Bitte überprüfen Sie Ihr Passwort und versuchen Sie es erneut.",
       "passwordRequired": "Passwort ist erforderlich.",
@@ -4029,7 +4029,7 @@
       "seekProgress": "Audio-Fortschritt: {current} / {total} Sekunden",
       "playbackSpeed": "Wiedergabegeschwindigkeit",
       "speed": "Tempo",
-      "loop": "Toggle loop",
+      "loop": "Wiederholung umschalten",
       "player": "Audioplayer"
     },
     "spectrogram": {
@@ -4108,36 +4108,36 @@
         "spectrogramFailed": "Spektrogramm konnte nicht erzeugt werden"
       },
       "clipExtraction": {
-        "selectRange": "Click and drag to select a range",
-        "playSelection": "Play selected range",
-        "pauseSelection": "Pause playback",
-        "reviewSelection": "Jump to start of selection",
-        "selectionStart": "Selection start handle",
-        "selectionEnd": "Selection end handle",
-        "lossless": "Lossless",
-        "lossy": "Lossy",
-        "extractClip": "Download selected clip",
-        "clearSelection": "Clear selection",
-        "extracting": "Extracting clip...",
-        "extractError": "Failed to extract clip",
+        "selectRange": "Klicken und ziehen, um einen Bereich auszuwählen",
+        "playSelection": "Ausgewählten Bereich abspielen",
+        "pauseSelection": "Wiedergabe pausieren",
+        "reviewSelection": "Zum Anfang der Auswahl springen",
+        "selectionStart": "Griff für Auswahlanfang",
+        "selectionEnd": "Griff für Auswahlende",
+        "lossless": "Verlustfrei",
+        "lossy": "Verlustbehaftet",
+        "extractClip": "Ausgewählten Clip herunterladen",
+        "clearSelection": "Auswahl löschen",
+        "extracting": "Clip wird extrahiert...",
+        "extractError": "Clip konnte nicht extrahiert werden",
         "formatLabel": "Format",
         "rangeLabel": "{start}s – {end}s"
       },
       "processing": {
-        "playSelection": "Play selection",
-        "skipToStart": "Skip to selection start",
-        "clearSelection": "Clear selection",
-        "gain": "Gain (dB)",
-        "denoise": "Denoise",
-        "denoiseOff": "Off",
-        "denoiseLight": "Light",
-        "denoiseMedium": "Medium",
-        "denoiseHeavy": "Heavy",
-        "normalize": "Normalize audio",
-        "normalizeTooltip": "EBU R128 Normalization",
-        "export": "Export",
+        "playSelection": "Auswahl abspielen",
+        "skipToStart": "Zum Auswahlanfang springen",
+        "clearSelection": "Auswahl löschen",
+        "gain": "Verstärkung (dB)",
+        "denoise": "Entrauschen",
+        "denoiseOff": "Aus",
+        "denoiseLight": "Leicht",
+        "denoiseMedium": "Mittel",
+        "denoiseHeavy": "Stark",
+        "normalize": "Audio normalisieren",
+        "normalizeTooltip": "EBU R128 Normalisierung",
+        "export": "Exportieren",
         "exportOriginal": "Original",
-        "processingActive": "Processing active"
+        "processingActive": "Verarbeitung aktiv"
       }
     },
     "weatherInfo": {
@@ -4146,20 +4146,20 @@
       }
     },
     "tls": {
-      "certificateInstalled": "Certificate Installed",
-      "browseFile": "Browse",
-      "subject": "Subject",
-      "issuer": "Issuer",
-      "sans": "Subject Alternative Names",
-      "validUntil": "Valid Until",
-      "daysRemaining": "Days Remaining",
-      "fingerprint": "Fingerprint",
-      "expiryWarning": "This certificate expires soon. Consider renewing it.",
-      "downloadCertificate": "Download Certificate",
-      "regenerateButton": "Regenerate",
-      "removeCertificate": "Remove Certificate",
-      "fileReadError": "Failed to read file",
-      "loading": "Loading certificate information..."
+      "certificateInstalled": "Zertifikat installiert",
+      "browseFile": "Durchsuchen",
+      "subject": "Betreff",
+      "issuer": "Aussteller",
+      "sans": "Alternative Antragstellernamen",
+      "validUntil": "Gültig bis",
+      "daysRemaining": "Verbleibende Tage",
+      "fingerprint": "Fingerabdruck",
+      "expiryWarning": "Dieses Zertifikat läuft bald ab. Erwägen Sie eine Erneuerung.",
+      "downloadCertificate": "Zertifikat herunterladen",
+      "regenerateButton": "Neu generieren",
+      "removeCertificate": "Zertifikat entfernen",
+      "fileReadError": "Datei konnte nicht gelesen werden",
+      "loading": "Zertifikatsinformationen werden geladen..."
     }
   },
   "connectivity": {
@@ -4332,77 +4332,77 @@
     },
     "steps": {
       "welcome": {
-        "title": "Welcome",
-        "heading": "Welcome to BirdNET-Go!",
-        "description": "BirdNET-Go is a real-time bird sound identification system. It listens to audio from your microphone or audio stream and uses the BirdNET AI model to identify bird species.",
-        "credit": "Powered by the BirdNET Analyzer developed by the K. Lisa Yang Center for Conservation Bioacoustics at the Cornell Lab of Ornithology and Chemnitz University of Technology.",
-        "cta": "Let's set up your bird monitoring station."
+        "title": "Willkommen",
+        "heading": "Willkommen bei BirdNET-Go!",
+        "description": "BirdNET-Go ist ein Echtzeit-Vogelstimmen-Erkennungssystem. Es lauscht dem Audio Ihres Mikrofons oder Audiostreams und verwendet das BirdNET-KI-Modell, um Vogelarten zu identifizieren.",
+        "credit": "Unterstützt vom BirdNET Analyzer, entwickelt vom K. Lisa Yang Center for Conservation Bioacoustics am Cornell Lab of Ornithology und der Technischen Universität Chemnitz.",
+        "cta": "Richten wir Ihre Vogelbeobachtungsstation ein."
       },
       "locationLanguage": {
-        "title": "Location & Language",
-        "uiLanguageLabel": "Interface Language",
-        "uiLanguageHelp": "Language used for the web interface",
-        "speciesLanguageLabel": "Species Name Language",
-        "speciesLanguageHelp": "Language used for bird species names in detections",
-        "locationLabel": "Station Location",
-        "locationHelp": "Your location helps filter species to those likely in your area",
-        "latitudeLabel": "Latitude",
-        "longitudeLabel": "Longitude",
-        "useMyLocation": "Use my location",
-        "locationDetected": "Location detected",
-        "locationError": "Could not detect location. Please enter coordinates manually.",
-        "locationDenied": "Location access denied. Please enter coordinates manually."
+        "title": "Standort & Sprache",
+        "uiLanguageLabel": "Oberflächensprache",
+        "uiLanguageHelp": "Sprache für die Weboberfläche",
+        "speciesLanguageLabel": "Sprache für Artnamen",
+        "speciesLanguageHelp": "Sprache für Vogelartnamen in Erkennungen",
+        "locationLabel": "Stationsstandort",
+        "locationHelp": "Ihr Standort hilft, Arten zu filtern, die in Ihrer Gegend wahrscheinlich vorkommen",
+        "latitudeLabel": "Breitengrad",
+        "longitudeLabel": "Längengrad",
+        "useMyLocation": "Meinen Standort verwenden",
+        "locationDetected": "Standort erkannt",
+        "locationError": "Standort konnte nicht ermittelt werden. Bitte geben Sie die Koordinaten manuell ein.",
+        "locationDenied": "Standortzugriff verweigert. Bitte geben Sie die Koordinaten manuell ein."
       },
       "audioSource": {
-        "title": "Audio Source",
-        "sourceTypeLabel": "Source Type",
-        "soundcard": "Microphone / Soundcard",
-        "rtspStream": "RTSP Stream",
-        "deviceLabel": "Audio Device",
-        "deviceLoading": "Loading audio devices...",
-        "noDevicesFound": "No audio devices detected. Try configuring an RTSP stream instead.",
-        "rtspUrlLabel": "Stream URL",
+        "title": "Audioquelle",
+        "sourceTypeLabel": "Quellentyp",
+        "soundcard": "Mikrofon / Soundkarte",
+        "rtspStream": "RTSP-Stream",
+        "deviceLabel": "Audiogerät",
+        "deviceLoading": "Audiogeräte werden geladen...",
+        "noDevicesFound": "Keine Audiogeräte erkannt. Versuchen Sie, stattdessen einen RTSP-Stream zu konfigurieren.",
+        "rtspUrlLabel": "Stream-URL",
         "rtspUrlPlaceholder": "rtsp://user:password@host:port/stream",
-        "rtspUrlHelp": "Enter the URL of your RTSP audio stream",
-        "additionalSourcesHint": "You can add more audio sources later in Settings."
+        "rtspUrlHelp": "Geben Sie die URL Ihres RTSP-Audiostreams ein",
+        "additionalSourcesHint": "Sie können später in den Einstellungen weitere Audioquellen hinzufügen."
       },
       "detection": {
-        "title": "Detection Threshold",
-        "description": "Choose how strict the bird identification should be. You can adjust this later in Settings.",
-        "balanced": "Balanced",
-        "balancedDesc": "Good balance of accuracy and sensitivity",
-        "balancedRecommended": "Recommended",
-        "highAccuracy": "High Accuracy",
-        "highAccuracyDesc": "Fewer false positives, may miss some birds",
-        "highSensitivity": "High Sensitivity",
-        "highSensitivityDesc": "More detections, more false positives",
-        "threshold": "Confidence threshold",
-        "fpFilterNote": "Once your system is running and proven, you can enable the false positive filter in Settings to further reduce incorrect detections."
+        "title": "Erkennungsschwelle",
+        "description": "Wählen Sie, wie streng die Vogelidentifizierung sein soll. Sie können dies später in den Einstellungen anpassen.",
+        "balanced": "Ausgewogen",
+        "balancedDesc": "Gute Balance zwischen Genauigkeit und Empfindlichkeit",
+        "balancedRecommended": "Empfohlen",
+        "highAccuracy": "Hohe Genauigkeit",
+        "highAccuracyDesc": "Weniger Fehlerkennungen, kann einige Vögel verpassen",
+        "highSensitivity": "Hohe Empfindlichkeit",
+        "highSensitivityDesc": "Mehr Erkennungen, mehr Fehlerkennungen",
+        "threshold": "Konfidenzschwelle",
+        "fpFilterNote": "Sobald Ihr System läuft und sich bewährt hat, können Sie den Falsch-Positiv-Filter in den Einstellungen aktivieren, um fehlerhafte Erkennungen weiter zu reduzieren."
       },
       "integration": {
-        "title": "Privacy & Integration",
-        "privacyFilterLabel": "Enable privacy filter",
-        "privacyFilterHelp": "Filters out detections when human voices are detected near the microphone",
-        "birdweatherLabel": "Share detections with BirdWeather",
-        "birdweatherHelp": "Contribute your bird detections to the BirdWeather community network",
-        "birdweatherIdLabel": "BirdWeather Station ID",
-        "birdweatherIdPlaceholder": "Enter your BirdWeather station ID",
-        "errorReportingLabel": "Send anonymous error reports",
-        "errorReportingHelp": "Help improve BirdNET-Go by sending anonymous error reports when something goes wrong"
+        "title": "Datenschutz & Integration",
+        "privacyFilterLabel": "Datenschutzfilter aktivieren",
+        "privacyFilterHelp": "Filtert Erkennungen heraus, wenn menschliche Stimmen in der Nähe des Mikrofons erkannt werden",
+        "birdweatherLabel": "Erkennungen mit BirdWeather teilen",
+        "birdweatherHelp": "Tragen Sie Ihre Vogelerkennungen zum BirdWeather-Community-Netzwerk bei",
+        "birdweatherIdLabel": "BirdWeather-Stations-ID",
+        "birdweatherIdPlaceholder": "Geben Sie Ihre BirdWeather-Stations-ID ein",
+        "errorReportingLabel": "Anonyme Fehlerberichte senden",
+        "errorReportingHelp": "Helfen Sie, BirdNET-Go zu verbessern, indem Sie anonyme Fehlerberichte senden, wenn etwas schiefgeht"
       },
       "responsibleUse": {
-        "title": "Using BirdNET-Go Responsibly",
-        "intro": "BirdNET-Go is a powerful tool that enhances your birding experience through AI-assisted identification. To ensure the best outcomes for both birding and conservation:",
-        "point1": "Review and verify detections before sharing observations",
-        "point2": "Use the confidence scores as a guide, not absolute truth",
-        "point3": "Cross-reference with field guides and local expertise",
-        "point4": "Consider seasonal patterns and habitat suitability",
-        "citizenScienceHeading": "When contributing to citizen science:",
-        "citizenPoint1": "Only submit observations you have personally verified",
-        "citizenPoint2": "Include notes about visual or behavioral confirmation",
-        "citizenPoint3": "Use AI detections as a starting point for your own observations",
-        "outro": "This approach ensures data quality for scientific research while maximizing your learning and enjoyment of birds.",
-        "acknowledge": "I understand"
+        "title": "Verantwortungsvolle Nutzung von BirdNET-Go",
+        "intro": "BirdNET-Go ist ein leistungsstarkes Werkzeug, das Ihre Vogelbeobachtungserfahrung durch KI-gestützte Identifizierung verbessert. Um die besten Ergebnisse sowohl für die Vogelbeobachtung als auch für den Naturschutz zu erzielen:",
+        "point1": "Überprüfen und verifizieren Sie Erkennungen, bevor Sie Beobachtungen teilen",
+        "point2": "Verwenden Sie die Konfidenzwerte als Orientierung, nicht als absolute Wahrheit",
+        "point3": "Vergleichen Sie mit Feldführern und lokalem Fachwissen",
+        "point4": "Berücksichtigen Sie saisonale Muster und Habitateignung",
+        "citizenScienceHeading": "Bei Beiträgen zur Bürgerwissenschaft:",
+        "citizenPoint1": "Reichen Sie nur Beobachtungen ein, die Sie persönlich verifiziert haben",
+        "citizenPoint2": "Fügen Sie Anmerkungen zur visuellen oder verhaltensbasierten Bestätigung hinzu",
+        "citizenPoint3": "Verwenden Sie KI-Erkennungen als Ausgangspunkt für Ihre eigenen Beobachtungen",
+        "outro": "Dieser Ansatz gewährleistet die Datenqualität für die wissenschaftliche Forschung und maximiert gleichzeitig Ihr Lernen und Ihre Freude an Vögeln.",
+        "acknowledge": "Ich verstehe"
       }
     }
   },

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -377,8 +377,8 @@
         "application": "Error de aplicación",
         "imageProvider": "Aviso del proveedor de imágenes",
         "categoryError": "Error de {category}",
-        "burstTitle": "Multiple {component} errors",
-        "burstMessage": "{count} errors in the last {window_minutes} minutes: {sample_error}"
+        "burstTitle": "Múltiples errores de {component}",
+        "burstMessage": "{count} errores en los últimos {window_minutes} minutos: {sample_error}"
       },
       "settings": {
         "reloadingBirdnet": "Aplicando nuevos ajustes de análisis...",
@@ -388,7 +388,7 @@
         "reconfiguringBirdweather": "Actualizando integración de BirdWeather...",
         "reconfiguringStreams": "Actualizando flujos de audio...",
         "reconfiguringTelemetry": "Actualizando ajustes de telemetría...",
-        "reconfiguringPushNotifications": "Reconfiguring push notification providers...",
+        "reconfiguringPushNotifications": "Reconfigurando proveedores de notificaciones push...",
         "reconfiguringSpeciesTracking": "Actualizando seguimiento de especies...",
         "recalculatingThresholds": "Recalculando umbrales dinámicos para nuevo valor base",
         "reconfiguringDynamicThresholds": "Reconfigurando umbrales dinámicos...",
@@ -790,17 +790,17 @@
       "showing": "Mostrando {from} a {to} de {total} resultados"
     },
     "weather": {
-      "title": "Weather Information",
-      "noData": "No weather data",
-      "noDataAvailable": "No weather data available",
-      "loading": "Loading weather information...",
+      "title": "Información meteorológica",
+      "noData": "Sin datos meteorológicos",
+      "noDataAvailable": "No hay datos meteorológicos disponibles",
+      "loading": "Cargando información meteorológica...",
       "labels": {
-        "temperature": "Temperature",
-        "weather": "Weather",
-        "wind": "Wind",
-        "humidity": "Humidity",
-        "pressure": "Pressure",
-        "cloudCover": "Cloud Cover"
+        "temperature": "Temperatura",
+        "weather": "Clima",
+        "wind": "Viento",
+        "humidity": "Humedad",
+        "pressure": "Presión",
+        "cloudCover": "Nubosidad"
       },
       "units": {
         "temperature": "°C",
@@ -930,31 +930,31 @@
   },
   "spectrogram": {
     "controls": {
-      "frequencyRange": "Frequency Range",
-      "colorMap": "Color Map",
-      "gain": "Gain",
+      "frequencyRange": "Rango de frecuencia",
+      "colorMap": "Mapa de colores",
+      "gain": "Ganancia",
       "gainTooltip": "Ganancia de visualización del espectrograma",
       "mute": "Silenciar salida de audio",
       "unmute": "Activar salida de audio",
-      "frequencyRangeMin": "Minimum frequency",
-      "frequencyRangeMax": "Maximum frequency"
+      "frequencyRangeMin": "Frecuencia mínima",
+      "frequencyRangeMax": "Frecuencia máxima"
     },
     "error": {
-      "unsupported": "Your browser does not support audio analysis",
-      "connectionFailed": "Failed to connect to live audio stream",
-      "accessDenied": "Live audio access requires authentication. Please log in to use this feature."
+      "unsupported": "Tu navegador no soporta el análisis de audio",
+      "connectionFailed": "Error al conectar con la transmisión de audio en vivo",
+      "accessDenied": "El acceso al audio en vivo requiere autenticación. Inicia sesión para usar esta función."
     },
     "dashboard": {
-      "toggle": "Live Spectrogram",
-      "audioToggle": "Enable audio"
+      "toggle": "Espectrograma en vivo",
+      "audioToggle": "Activar audio"
     },
     "gain": {
       "muted": "Silenciado",
       "level": "Ganancia: {value} dB"
     },
     "page": {
-      "title": "Live Audio",
-      "sourceLabel": "Audio Source",
+      "title": "Audio en vivo",
+      "sourceLabel": "Fuente de audio",
       "connected": "Conectado",
       "enterFullscreen": "Pantalla completa",
       "exitFullscreen": "Salir de pantalla completa"
@@ -962,7 +962,7 @@
     "colorMaps": {
       "inferno": "Inferno",
       "viridis": "Viridis",
-      "grayscale": "Grayscale"
+      "grayscale": "Escala de grises"
     },
     "labels": {
       "toggle": "Alternar etiquetas de detección"
@@ -1287,82 +1287,82 @@
         "fetchFailed": "Error al obtener las estadísticas de la base de datos"
       },
       "dashboard": {
-        "title": "Database Dashboard",
-        "fetchFailed": "Failed to fetch database overview",
+        "title": "Panel de base de datos",
+        "fetchFailed": "Error al obtener la información de la base de datos",
         "metrics": {
-          "readLatency": "Read Latency",
-          "writeLatency": "Write Latency",
-          "queriesPerSec": "Queries/sec",
-          "database": "Database",
-          "avg": "avg",
-          "max": "max",
-          "lastHour": "{count} last hour",
-          "slowQueries": "{count} slow"
+          "readLatency": "Latencia de lectura",
+          "writeLatency": "Latencia de escritura",
+          "queriesPerSec": "Consultas/seg",
+          "database": "Base de datos",
+          "avg": "prom",
+          "max": "máx",
+          "lastHour": "{count} última hora",
+          "slowQueries": "{count} lentas"
         },
         "details": {
-          "title": "Database Details",
-          "engine": "Engine",
+          "title": "Detalles de la base de datos",
+          "engine": "Motor",
           "journal": "Journal",
-          "pageSize": "Page size",
-          "cacheHit": "Cache hit",
-          "integrity": "Integrity",
-          "lastVacuum": "Last VACUUM"
+          "pageSize": "Tamaño de página",
+          "cacheHit": "Aciertos de caché",
+          "integrity": "Integridad",
+          "lastVacuum": "Último VACUUM"
         },
         "locksWal": {
-          "title": "Locks & WAL",
-          "lockWaits": "Lock waits",
-          "lockTimeouts": "Lock timeouts",
-          "avgWait": "Avg wait",
-          "busyTimeouts": "Busy timeouts",
-          "walSize": "WAL size",
+          "title": "Bloqueos y WAL",
+          "lockWaits": "Esperas de bloqueo",
+          "lockTimeouts": "Tiempos de espera agotados",
+          "avgWait": "Espera prom.",
+          "busyTimeouts": "Tiempos de espera por ocupado",
+          "walSize": "Tamaño WAL",
           "checkpoints": "Checkpoints",
-          "freelistPages": "Freelist pages",
-          "cacheSize": "Cache size"
+          "freelistPages": "Páginas libres",
+          "cacheSize": "Tamaño de caché"
         },
         "connectionPool": {
-          "title": "Connection Pool",
-          "poolUsage": "Pool Usage",
-          "active": "active",
-          "idle": "idle",
-          "waiting": "waiting",
-          "totalCreated": "Total created",
-          "connErrors": "Conn errors",
-          "threads": "Threads",
-          "running": "running",
-          "cached": "cached"
+          "title": "Pool de conexiones",
+          "poolUsage": "Uso del pool",
+          "active": "activas",
+          "idle": "inactivas",
+          "waiting": "en espera",
+          "totalCreated": "Total creadas",
+          "connErrors": "Errores de conexión",
+          "threads": "Hilos",
+          "running": "en ejecución",
+          "cached": "en caché"
         },
         "innodb": {
-          "title": "InnoDB & Locks",
-          "bufferPoolHitRate": "Buffer pool hit rate",
-          "bufferPoolSize": "Buffer pool size",
-          "lockWaits": "Lock waits",
+          "title": "InnoDB y bloqueos",
+          "bufferPoolHitRate": "Tasa de aciertos del buffer pool",
+          "bufferPoolSize": "Tamaño del buffer pool",
+          "lockWaits": "Esperas de bloqueo",
           "deadlocks": "Deadlocks",
-          "avgLockWait": "Avg lock wait",
-          "tableLocksWaited": "Table locks waited",
-          "tableLocksImmediate": "Table locks immediate"
+          "avgLockWait": "Espera prom. de bloqueo",
+          "tableLocksWaited": "Bloqueos de tabla esperados",
+          "tableLocksImmediate": "Bloqueos de tabla inmediatos"
         },
         "detectionRate": {
-          "title": "Detection Rate (24h)",
-          "perHour": "/hr",
-          "min": "min",
-          "avg": "avg",
-          "max": "max",
-          "lastBackup": "Last backup",
-          "backupSize": "Backup size",
-          "createBackup": "Create Backup",
+          "title": "Tasa de detección (24h)",
+          "perHour": "/h",
+          "min": "mín",
+          "avg": "prom",
+          "max": "máx",
+          "lastBackup": "Última copia de seguridad",
+          "backupSize": "Tamaño de la copia",
+          "createBackup": "Crear copia de seguridad",
           "mysqlHost": "Host",
           "mysqlBackupNote": "Las copias de seguridad de MySQL deben gestionarse mediante mysqldump o sus herramientas de administración de MySQL.",
           "chartLabel": "Tasa de detección en 24 horas",
           "detectionsTooltip": "{count} detecciones"
         },
         "tables": {
-          "title": "Tables",
+          "title": "Tablas",
           "total": "Total",
-          "table": "Table",
-          "engine": "Engine",
-          "rows": "Rows",
-          "size": "Size",
-          "usage": "Usage"
+          "table": "Tabla",
+          "engine": "Motor",
+          "rows": "Filas",
+          "size": "Tamaño",
+          "usage": "Uso"
         },
         "loading": "Cargando..."
       },
@@ -2285,32 +2285,32 @@
           "discord": {
             "name": "Discord",
             "webhookUrl": {
-              "label": "Discord Webhook URL",
+              "label": "URL del webhook de Discord",
               "placeholder": "https://discord.com/api/webhooks/...",
-              "helpText": "Paste your full Discord webhook URL"
+              "helpText": "Pega la URL completa de tu webhook de Discord"
             },
-            "invalidUrl": "Invalid Discord webhook URL. URL should contain discord.com/api/webhooks/"
+            "invalidUrl": "URL de webhook de Discord no válida. La URL debe contener discord.com/api/webhooks/"
           },
           "telegram": {
             "name": "Telegram",
             "botToken": {
-              "label": "Bot Token",
+              "label": "Token del bot",
               "placeholder": "123456789:ABCdef...",
-              "helpText": "Token from @BotFather"
+              "helpText": "Token de @BotFather"
             },
             "chatId": {
-              "label": "Chat ID",
-              "placeholder": "-1001234567890 or @channel",
-              "helpText": "Chat ID, group ID, or @username"
+              "label": "ID del chat",
+              "placeholder": "-1001234567890 o @channel",
+              "helpText": "ID del chat, ID del grupo o @nombreusuario"
             },
-            "incomplete": "Both bot token and chat ID are required"
+            "incomplete": "Se requieren tanto el token del bot como el ID del chat"
           },
           "ntfy": {
             "name": "ntfy",
             "server": {
-              "label": "Server",
+              "label": "Servidor",
               "placeholder": "ntfy.sh",
-              "helpText": "Leave as ntfy.sh for public server or enter your self-hosted server"
+              "helpText": "Deja ntfy.sh para el servidor público o ingresa tu servidor propio"
             },
             "protocol": {
               "label": "Protocolo"
@@ -2333,109 +2333,109 @@
               }
             },
             "topic": {
-              "label": "Topic",
+              "label": "Tema",
               "placeholder": "my-bird-alerts",
-              "helpText": "Topic name for your notifications"
+              "helpText": "Nombre del tema para tus notificaciones"
             },
-            "incomplete": "Topic is required"
+            "incomplete": "El tema es obligatorio"
           },
           "gotify": {
             "name": "Gotify",
             "server": {
-              "label": "Server URL",
+              "label": "URL del servidor",
               "placeholder": "gotify.example.com",
-              "helpText": "Your Gotify server hostname (without https://)"
+              "helpText": "Nombre de host de tu servidor Gotify (sin https://)"
             },
             "token": {
-              "label": "Application Token",
+              "label": "Token de aplicación",
               "placeholder": "A...",
-              "helpText": "Token from Gotify Apps page"
+              "helpText": "Token de la página de aplicaciones de Gotify"
             },
-            "incomplete": "Server and token are required"
+            "incomplete": "Se requieren el servidor y el token"
           },
           "pushover": {
             "name": "Pushover",
             "apiToken": {
-              "label": "API Token",
+              "label": "Token de API",
               "placeholder": "az...",
-              "helpText": "Application API token"
+              "helpText": "Token de API de la aplicación"
             },
             "userKey": {
-              "label": "User Key",
+              "label": "Clave de usuario",
               "placeholder": "u...",
-              "helpText": "Your user or group key"
+              "helpText": "Tu clave de usuario o grupo"
             },
-            "incomplete": "API token and user key are required"
+            "incomplete": "Se requieren el token de API y la clave de usuario"
           },
           "slack": {
             "name": "Slack",
             "webhookUrl": {
-              "label": "Slack Webhook URL",
+              "label": "URL del webhook de Slack",
               "placeholder": "https://hooks.slack.com/services/...",
-              "helpText": "Paste your full Slack webhook URL"
+              "helpText": "Pega la URL completa de tu webhook de Slack"
             },
-            "invalidUrl": "Invalid Slack webhook URL. URL should contain hooks.slack.com/services/"
+            "invalidUrl": "URL de webhook de Slack no válida. La URL debe contener hooks.slack.com/services/"
           },
           "ifttt": {
             "name": "IFTTT",
             "webhookKey": {
-              "label": "Webhook Key",
+              "label": "Clave del webhook",
               "placeholder": "abc123xyz...",
-              "helpText": "Your IFTTT Webhook key from Maker Webhooks settings"
+              "helpText": "Tu clave de webhook de IFTTT desde la configuración de Maker Webhooks"
             },
             "eventName": {
-              "label": "Event Name",
+              "label": "Nombre del evento",
               "placeholder": "bird_detected",
-              "helpText": "The event name to trigger in your IFTTT applet"
+              "helpText": "El nombre del evento a activar en tu applet de IFTTT"
             },
-            "incomplete": "Webhook key and event name are required"
+            "incomplete": "Se requieren la clave del webhook y el nombre del evento"
           },
           "webhook": {
             "name": "Webhook",
             "url": {
-              "label": "Webhook URL",
+              "label": "URL del webhook",
               "placeholder": "https://api.example.com/webhook",
-              "helpText": "The HTTP(S) endpoint to send notifications to"
+              "helpText": "El endpoint HTTP(S) para enviar notificaciones"
             },
             "method": {
-              "label": "HTTP Method",
-              "helpText": "HTTP method to use for the request (default: POST)"
+              "label": "Método HTTP",
+              "helpText": "Método HTTP a usar para la solicitud (por defecto: POST)"
             },
             "auth": {
-              "label": "Authentication",
-              "none": "None",
-              "bearer": "Bearer Token",
-              "basic": "Basic Auth",
-              "helpText": "Optional authentication for the webhook endpoint"
+              "label": "Autenticación",
+              "none": "Ninguna",
+              "bearer": "Token Bearer",
+              "basic": "Autenticación básica",
+              "helpText": "Autenticación opcional para el endpoint del webhook"
             },
             "bearerToken": {
-              "label": "Bearer Token",
+              "label": "Token Bearer",
               "placeholder": "your-api-token",
-              "helpText": "Token sent in Authorization: Bearer header"
+              "helpText": "Token enviado en el encabezado Authorization: Bearer"
             },
             "basicUser": {
-              "label": "Username",
+              "label": "Nombre de usuario",
               "placeholder": "username"
             },
             "basicPass": {
-              "label": "Password",
+              "label": "Contraseña",
               "placeholder": "password"
             },
             "basicAuth": {
-              "helpText": "Credentials sent using HTTP Basic Authentication"
+              "helpText": "Credenciales enviadas mediante autenticación HTTP básica"
             },
-            "invalidUrl": "Invalid URL. Must start with http:// or https://",
-            "tokenRequired": "Bearer token is required when using Bearer authentication",
-            "credentialsRequired": "Username and password are required when using Basic authentication"
+            "invalidUrl": "URL no válida. Debe comenzar con http:// o https://",
+            "tokenRequired": "Se requiere el token Bearer cuando se usa autenticación Bearer",
+            "credentialsRequired": "Se requieren nombre de usuario y contraseña cuando se usa autenticación básica"
           },
           "custom": {
-            "name": "Custom URL",
+            "name": "URL personalizada",
             "url": {
-              "label": "Shoutrrr URL",
+              "label": "URL de Shoutrrr",
               "placeholder": "service://credentials@host",
-              "helpText": "Enter a raw Shoutrrr URL for any supported service"
+              "helpText": "Ingresa una URL de Shoutrrr para cualquier servicio compatible"
             },
-            "invalidUrl": "Invalid URL format. URL should start with service://"
+            "invalidUrl": "Formato de URL no válido. La URL debe comenzar con service://"
           }
         }
       }
@@ -2485,7 +2485,7 @@
       "loading": "Cargando dispositivos de audio...",
       "tabs": {
         "soundCard": "Tarjeta de Sonido",
-        "streams": "Streams",
+        "streams": "Transmisiones",
         "processing": "Procesamiento",
         "recording": "Grabación",
         "retention": "Retención"
@@ -2753,7 +2753,7 @@
         "noStreamsConfigured": "No hay streams configurados"
       },
       "streams": {
-        "streamLabel": "Stream",
+        "streamLabel": "Transmisión",
         "nameLabel": "Nombre del Stream",
         "namePlaceholder": "ej. Comedero del Jardín",
         "nameHelp": "Un nombre descriptivo para identificar este stream de audio",
@@ -2877,29 +2877,29 @@
           "skipVerify": "Omitir verificación de certificado",
           "configNote": "<strong>Configuración TLS:</strong><br />• TLS estándar: Deje los certificados vacíos para brokers públicos<br />• Certificados autofirmados: Proporcione el certificado CA<br />• TLS mutuo (mTLS): Proporcione los tres certificados",
           "certificates": {
-            "title": "Certificate Management",
-            "description": "Upload certificates for secure MQTT broker connections",
-            "caLabel": "CA Certificate",
+            "title": "Gestión de certificados",
+            "description": "Sube certificados para conexiones seguras al broker MQTT",
+            "caLabel": "Certificado CA",
             "caPlaceholder": "-----BEGIN CERTIFICATE-----",
-            "caHelpText": "Certificate Authority certificate to verify the broker's identity",
-            "clientCertLabel": "Client Certificate",
+            "caHelpText": "Certificado de la autoridad de certificación para verificar la identidad del broker",
+            "clientCertLabel": "Certificado del cliente",
             "clientCertPlaceholder": "-----BEGIN CERTIFICATE-----",
-            "clientCertHelpText": "Client certificate for mutual TLS authentication",
-            "clientKeyLabel": "Client Private Key",
+            "clientCertHelpText": "Certificado del cliente para autenticación TLS mutua",
+            "clientKeyLabel": "Clave privada del cliente",
             "clientKeyPlaceholder": "-----BEGIN PRIVATE KEY-----",
-            "clientKeyHelpText": "Private key matching the client certificate",
-            "uploadButton": "Upload Certificates",
-            "uploadSuccess": "MQTT TLS certificates uploaded successfully. Use Test Connection to verify.",
-            "uploadError": "Failed to upload MQTT TLS certificates",
-            "deleteConfirm": "Remove all MQTT TLS certificates? The MQTT client will need to reconnect.",
-            "deleteSuccess": "MQTT TLS certificates removed",
-            "deleteError": "Failed to remove MQTT TLS certificates",
-            "loadError": "Failed to load certificate information",
-            "reconnectNote": "Use the Test Connection button below to verify the new TLS configuration."
+            "clientKeyHelpText": "Clave privada que coincide con el certificado del cliente",
+            "uploadButton": "Subir certificados",
+            "uploadSuccess": "Certificados TLS de MQTT subidos exitosamente. Usa la prueba de conexión para verificar.",
+            "uploadError": "Error al subir los certificados TLS de MQTT",
+            "deleteConfirm": "¿Eliminar todos los certificados TLS de MQTT? El cliente MQTT necesitará reconectarse.",
+            "deleteSuccess": "Certificados TLS de MQTT eliminados",
+            "deleteError": "Error al eliminar los certificados TLS de MQTT",
+            "loadError": "Error al cargar la información del certificado",
+            "reconnectNote": "Usa el botón de prueba de conexión para verificar la nueva configuración TLS."
           }
         },
         "homeAssistant": {
-          "title": "Home Assistant Auto-Discovery",
+          "title": "Descubrimiento automático de Home Assistant",
           "enable": "Habilitar Home Assistant MQTT Discovery",
           "description": "Cuando está habilitado, BirdNET-Go registra automáticamente dispositivos y sensores con Home Assistant a través del protocolo de descubrimiento MQTT. Los dispositivos aparecerán en el registro de dispositivos de Home Assistant sin configuración YAML manual.",
           "discoveryPrefix": {
@@ -3039,14 +3039,14 @@
           "helpText": "Cuánto tiempo se almacenan en caché los datos taxonómicos de eBird. La taxonomía cambia raramente, por lo que duraciones más largas reducen las llamadas a la API."
         },
         "note": "eBird proporciona datos taxonómicos utilizados para la clasificación de especies y análisis. La clave API se obtiene gratuitamente del Laboratorio de Ornitología de Cornell.",
-        "apiKeyInfo": "A personal eBird API key is required to use this integration. You can request a free key from <a href=\"https://ebird.org/api/keygen\" class=\"link link-primary\" target=\"_blank\" rel=\"noopener noreferrer\">ebird.org/api/keygen</a>.",
+        "apiKeyInfo": "Se requiere una clave personal de la API de eBird para usar esta integración. Puedes solicitar una clave gratuita en <a href=\"https://ebird.org/api/keygen\" class=\"link link-primary\" target=\"_blank\" rel=\"noopener noreferrer\">ebird.org/api/keygen</a>.",
         "test": {
-          "button": "Test eBird Connection",
-          "loading": "Testing...",
-          "enabledRequired": "Enable eBird integration first",
-          "apiKeyRequired": "API key is required",
-          "inProgress": "Test in progress...",
-          "description": "Test eBird API connectivity and authentication"
+          "button": "Probar conexión con eBird",
+          "loading": "Probando...",
+          "enabledRequired": "Activa primero la integración con eBird",
+          "apiKeyRequired": "Se requiere la clave de API",
+          "inProgress": "Prueba en progreso...",
+          "description": "Probar la conectividad y autenticación con la API de eBird"
         }
       }
     },
@@ -3210,8 +3210,8 @@
             "source": "Fuente",
             "clearParameters": "Limpiar parámetros"
           },
-          "placeholder": "Click buttons below to add parameters or type manually",
-          "tooltip": "Use buttons below or type directly (comma-separated)"
+          "placeholder": "Haz clic en los botones de abajo para agregar parámetros o escribe manualmente",
+          "tooltip": "Usa los botones de abajo o escribe directamente (separados por comas)"
         },
         "executeDefaults": {
           "label": "También ejecutar acciones predeterminadas (almacenamiento en base de datos, notificaciones, etc.)",
@@ -3363,7 +3363,7 @@
         "expand": "Mostrar historial de eventos",
         "collapse": "Ocultar historial de eventos"
       },
-      "suggestions": "Species suggestions"
+      "suggestions": "Sugerencias de especies"
     },
     "security": {
       "pageLabel": "Configuración de seguridad",
@@ -3467,9 +3467,9 @@
           "enableLabel": "Permitir inicio de sesión OAuth2 con LINE",
           "redirectUriTitle": "URI de redirección para LINE Developers Console:",
           "getCredentialsLabel": "Obtener credenciales desde LINE Developers Console",
-          "clientIdLabel": "Channel ID",
+          "clientIdLabel": "ID del canal",
           "clientIdHelpText": "El Channel ID obtenido de LINE Developers Console al configurar LINE Login.",
-          "clientSecretLabel": "Channel Secret",
+          "clientSecretLabel": "Secreto del canal",
           "clientSecretHelpText": "El Channel Secret obtenido de LINE Developers Console al configurar LINE Login.",
           "userIdLabel": "ID de usuario"
         },
@@ -3478,29 +3478,29 @@
           "enableLabel": "Permitir inicio de sesión OAuth2 con Kakao",
           "redirectUriTitle": "URI de redirección para Kakao Developers Console:",
           "getCredentialsLabel": "Obtener credenciales desde Kakao Developers Console",
-          "clientIdLabel": "REST API Key",
+          "clientIdLabel": "Clave de API REST",
           "clientIdHelpText": "El REST API Key obtenido de Kakao Developers Console al configurar Kakao Login.",
-          "clientSecretLabel": "Client Secret",
+          "clientSecretLabel": "Secreto del cliente",
           "clientSecretHelpText": "El Client Secret obtenido de Kakao Developers Console al configurar Kakao Login.",
           "userIdLabel": "ID de usuario"
         },
         "oidc": {
-          "title": "OIDC Provider",
-          "enableLabel": "Enable OIDC authentication",
-          "redirectUriTitle": "Redirect URI",
-          "getCredentialsLabel": "Configure in your Identity Provider",
-          "clientIdLabel": "Client ID",
-          "clientIdHelpText": "The client ID from your OIDC identity provider",
-          "clientSecretLabel": "Client Secret",
-          "clientSecretHelpText": "The client secret from your OIDC identity provider",
-          "userIdLabel": "Allowed User (email or sub claim)",
-          "issuerUrlLabel": "Issuer URL",
-          "issuerUrlHelpText": "The issuer URL of your OpenID Connect identity provider (e.g., https://auth.example.com)",
+          "title": "Proveedor OIDC",
+          "enableLabel": "Activar autenticación OIDC",
+          "redirectUriTitle": "URI de redirección",
+          "getCredentialsLabel": "Configurar en tu proveedor de identidad",
+          "clientIdLabel": "ID del cliente",
+          "clientIdHelpText": "El ID del cliente de tu proveedor de identidad OIDC",
+          "clientSecretLabel": "Secreto del cliente",
+          "clientSecretHelpText": "El secreto del cliente de tu proveedor de identidad OIDC",
+          "userIdLabel": "Usuario permitido (email o claim sub)",
+          "issuerUrlLabel": "URL del emisor",
+          "issuerUrlHelpText": "La URL del emisor de tu proveedor de identidad OpenID Connect (p. ej., https://auth.example.com)",
           "issuerUrlPlaceholder": "https://auth.example.com",
-          "issuerUrlRequired": "Issuer URL is required for OIDC providers",
-          "issuerUrlInvalid": "Issuer URL must be a valid HTTP or HTTPS URL",
+          "issuerUrlRequired": "La URL del emisor es obligatoria para proveedores OIDC",
+          "issuerUrlInvalid": "La URL del emisor debe ser una URL HTTP o HTTPS válida",
           "scopesLabel": "Scopes",
-          "scopesHelpText": "Comma-separated list of OIDC scopes (default: openid, profile, email)",
+          "scopesHelpText": "Lista de scopes OIDC separados por comas (por defecto: openid, profile, email)",
           "scopesPlaceholder": "openid, profile, email"
         }
       },
@@ -3510,14 +3510,14 @@
         "disabled": "El bypass de subred está deshabilitado"
       },
       "exceptions": {
-        "title": "Exceptions"
+        "title": "Excepciones"
       },
       "publicAccess": {
-        "title": "Public Access",
-        "description": "Allow specific features to be accessible without authentication.",
-        "liveAudioLabel": "Allow public live audio playback",
-        "liveAudioHelp": "When enabled, anyone can listen to live audio streams without logging in. Settings and deletion still require authentication.",
-        "warningText": "Enabling public access features exposes them to anyone who can reach this server. Only enable if you trust your network environment."
+        "title": "Acceso público",
+        "description": "Permitir que funciones específicas sean accesibles sin autenticación.",
+        "liveAudioLabel": "Permitir reproducción pública de audio en vivo",
+        "liveAudioHelp": "Cuando está activado, cualquiera puede escuchar las transmisiones de audio en vivo sin iniciar sesión. La configuración y la eliminación aún requieren autenticación.",
+        "warningText": "Activar las funciones de acceso público las expone a cualquiera que pueda acceder a este servidor. Actívalas solo si confías en tu entorno de red."
       },
       "placeholders": {
         "baseUrl": "https://birdnet.example.com:5500",
@@ -3534,64 +3534,64 @@
       },
       "tls": {
         "title": "TLS / HTTPS",
-        "description": "Configure TLS/HTTPS encryption for secure connections",
-        "modeLabel": "TLS Mode",
-        "modeNone": "None (HTTP)",
+        "description": "Configurar el cifrado TLS/HTTPS para conexiones seguras",
+        "modeLabel": "Modo TLS",
+        "modeNone": "Ninguno (HTTP)",
         "modeLetsEncrypt": "Let's Encrypt",
-        "modeManual": "Manual Certificate",
-        "modeSelfSigned": "Self-Signed",
-        "modeNoneDescription": "Plain HTTP without encryption",
-        "modeAutoTLSDescription": "Automatic certificate via Let's Encrypt",
-        "modeManualDescription": "Upload your own certificate and key",
-        "modeSelfSignedDescription": "Generate a self-signed certificate",
-        "portLabel": "HTTPS Port",
-        "portHelpText": "Port for HTTPS connections (default: 8443)",
-        "redirectToHttps": "Redirect HTTP to HTTPS",
-        "autoTLSRequirements": "Requires ports 80 and 443 to be accessible. On Linux, the process needs root or CAP_NET_BIND_SERVICE capability.",
-        "validityLabel": "Certificate Validity",
-        "validityHelpText": "How long the certificate should be valid",
-        "validity365d": "1 year",
-        "validity730d": "2 years",
-        "generateButton": "Generate Certificate",
-        "regenerateButton": "Regenerate Certificate",
-        "generating": "Generating...",
-        "certificateLabel": "Certificate (PEM)",
-        "privateKeyLabel": "Private Key (PEM)",
-        "caCertificateLabel": "CA Certificate (PEM, optional)",
-        "uploadButton": "Upload Certificate",
-        "uploading": "Uploading...",
-        "browseFile": "Browse...",
-        "plaintextWarning": "Warning: Your private key will be transmitted in plaintext over HTTP. Only upload certificates when connected via a trusted network or localhost.",
-        "certificateInstalled": "Installed Certificate",
-        "subject": "Subject",
-        "issuer": "Issuer",
-        "validFrom": "Valid From",
-        "validUntil": "Valid Until",
-        "daysRemaining": "Days Remaining",
-        "sans": "Subject Alternative Names",
-        "fingerprint": "Fingerprint",
-        "expiryWarning": "Certificate is expiring soon",
-        "loading": "Loading certificate info...",
-        "loadError": "Failed to load certificate info",
-        "generateSuccess": "Self-signed certificate generated successfully",
-        "generateError": "Failed to generate certificate",
-        "uploadSuccess": "Certificate uploaded successfully",
-        "uploadError": "Failed to upload certificate",
-        "deleteSuccess": "Certificate removed successfully",
-        "deleteError": "Failed to delete certificate",
-        "removeCertificate": "Remove Certificate",
-        "deleteConfirm": "Are you sure you want to remove the installed TLS certificate? The TLS mode will be reset to None.",
-        "restartRequired": "TLS changes require a server restart to take effect.",
-        "noCertificate": "No certificate installed",
-        "validity1825d": "5 years",
-        "autoTLSHostRequired": "A hostname is required for Let’s Encrypt. Enter your public domain name in the Host field above.",
-        "autoTLSNoIP": "Let’s Encrypt requires a domain name, not an IP address. Enter a public domain like birds.example.com.",
-        "autoTLSNeedsFQDN": "Let’s Encrypt requires a fully qualified domain name (e.g., birds.example.com), not a bare hostname.",
-        "autoTLSNoLocalhost": "Let’s Encrypt cannot issue certificates for localhost.",
-        "autoTLSPrivateTLD": "Let’s Encrypt cannot issue certificates for private domains ({tld} is not publicly resolvable).",
-        "downloadCertificate": "Download Certificate",
-        "downloadCertificateHelp": "Install this certificate in your operating system's trust store to avoid browser security warnings.",
-        "fileReadError": "Failed to read the selected file"
+        "modeManual": "Certificado manual",
+        "modeSelfSigned": "Autofirmado",
+        "modeNoneDescription": "HTTP sin cifrado",
+        "modeAutoTLSDescription": "Certificado automático mediante Let's Encrypt",
+        "modeManualDescription": "Sube tu propio certificado y clave",
+        "modeSelfSignedDescription": "Generar un certificado autofirmado",
+        "portLabel": "Puerto HTTPS",
+        "portHelpText": "Puerto para conexiones HTTPS (por defecto: 8443)",
+        "redirectToHttps": "Redirigir HTTP a HTTPS",
+        "autoTLSRequirements": "Requiere que los puertos 80 y 443 estén accesibles. En Linux, el proceso necesita root o la capacidad CAP_NET_BIND_SERVICE.",
+        "validityLabel": "Validez del certificado",
+        "validityHelpText": "Cuánto tiempo debe ser válido el certificado",
+        "validity365d": "1 año",
+        "validity730d": "2 años",
+        "generateButton": "Generar certificado",
+        "regenerateButton": "Regenerar certificado",
+        "generating": "Generando...",
+        "certificateLabel": "Certificado (PEM)",
+        "privateKeyLabel": "Clave privada (PEM)",
+        "caCertificateLabel": "Certificado CA (PEM, opcional)",
+        "uploadButton": "Subir certificado",
+        "uploading": "Subiendo...",
+        "browseFile": "Examinar...",
+        "plaintextWarning": "Advertencia: Tu clave privada se transmitirá en texto plano por HTTP. Solo sube certificados cuando estés conectado a través de una red de confianza o localhost.",
+        "certificateInstalled": "Certificado instalado",
+        "subject": "Sujeto",
+        "issuer": "Emisor",
+        "validFrom": "Válido desde",
+        "validUntil": "Válido hasta",
+        "daysRemaining": "Días restantes",
+        "sans": "Nombres alternativos del sujeto",
+        "fingerprint": "Huella digital",
+        "expiryWarning": "El certificado está por expirar",
+        "loading": "Cargando información del certificado...",
+        "loadError": "Error al cargar la información del certificado",
+        "generateSuccess": "Certificado autofirmado generado exitosamente",
+        "generateError": "Error al generar el certificado",
+        "uploadSuccess": "Certificado subido exitosamente",
+        "uploadError": "Error al subir el certificado",
+        "deleteSuccess": "Certificado eliminado exitosamente",
+        "deleteError": "Error al eliminar el certificado",
+        "removeCertificate": "Eliminar certificado",
+        "deleteConfirm": "¿Estás seguro de que quieres eliminar el certificado TLS instalado? El modo TLS se restablecerá a Ninguno.",
+        "restartRequired": "Los cambios de TLS requieren reiniciar el servidor para aplicarse.",
+        "noCertificate": "No hay certificado instalado",
+        "validity1825d": "5 años",
+        "autoTLSHostRequired": "Se requiere un nombre de host para Let's Encrypt. Ingresa tu nombre de dominio público en el campo Host arriba.",
+        "autoTLSNoIP": "Let's Encrypt requiere un nombre de dominio, no una dirección IP. Ingresa un dominio público como birds.example.com.",
+        "autoTLSNeedsFQDN": "Let's Encrypt requiere un nombre de dominio completo (p. ej., birds.example.com), no un nombre de host simple.",
+        "autoTLSNoLocalhost": "Let's Encrypt no puede emitir certificados para localhost.",
+        "autoTLSPrivateTLD": "Let's Encrypt no puede emitir certificados para dominios privados ({tld} no es resolvible públicamente).",
+        "downloadCertificate": "Descargar certificado",
+        "downloadCertificateHelp": "Instala este certificado en el almacén de confianza de tu sistema operativo para evitar advertencias de seguridad del navegador.",
+        "fileReadError": "Error al leer el archivo seleccionado"
       }
     },
     "database": {
@@ -3838,7 +3838,7 @@
         "appearance": "Apariencia",
         "language": "Idioma y regional",
         "visualContent": "Contenido visual",
-        "audioPlayback": "Audio Playback"
+        "audioPlayback": "Reproducción de audio"
       },
       "appearance": {
         "title": "Apariencia",
@@ -3853,14 +3853,14 @@
         "description": "Configura imágenes de aves y ajustes de visualización del espectrograma"
       },
       "audioPlayback": {
-        "title": "Audio Playback",
-        "description": "Default settings for playing bird recordings.",
-        "defaultGain": "Default Volume Boost",
-        "defaultGainHelpText": "Initial gain applied when playing recordings. Bird sounds are often quiet, so a boost of 6-12 dB is recommended.",
+        "title": "Reproducción de audio",
+        "description": "Configuración predeterminada para reproducir grabaciones de aves.",
+        "defaultGain": "Amplificación de volumen predeterminada",
+        "defaultGainHelpText": "Ganancia inicial aplicada al reproducir grabaciones. Los sonidos de aves suelen ser suaves, por lo que se recomienda una amplificación de 6-12 dB.",
         "defaultGainUnit": "dB"
       }
     },
-    "restartRequired": "Some changes require a server restart to take effect. Please restart BirdNET-Go."
+    "restartRequired": "Algunos cambios requieren reiniciar el servidor para aplicarse. Reinicia BirdNET-Go."
   },
   "auth": {
     "login": "Iniciar sesión",
@@ -3881,7 +3881,7 @@
     "continueWithMicrosoft": "Continuar con Microsoft",
     "continueWithLine": "Continuar con LINE",
     "continueWithKakao": "Continuar con Kakao",
-    "continueWithOidc": "Continue with OIDC",
+    "continueWithOidc": "Continuar con OIDC",
     "errors": {
       "loginFailed": "Error al iniciar sesión. Por favor verifica tu contraseña e inténtalo de nuevo.",
       "passwordRequired": "La contraseña es requerida.",
@@ -4029,7 +4029,7 @@
       "seekProgress": "Progreso de búsqueda de audio: {current} / {total} segundos",
       "playbackSpeed": "Velocidad de reproducción",
       "speed": "Velocidad",
-      "loop": "Toggle loop",
+      "loop": "Activar bucle",
       "player": "Reproductor de audio"
     },
     "spectrogram": {
@@ -4108,36 +4108,36 @@
         "spectrogramFailed": "Error al generar el espectrograma"
       },
       "clipExtraction": {
-        "selectRange": "Click and drag to select a range",
-        "playSelection": "Play selected range",
-        "pauseSelection": "Pause playback",
-        "reviewSelection": "Jump to start of selection",
-        "selectionStart": "Selection start handle",
-        "selectionEnd": "Selection end handle",
-        "lossless": "Lossless",
-        "lossy": "Lossy",
-        "extractClip": "Download selected clip",
-        "clearSelection": "Clear selection",
-        "extracting": "Extracting clip...",
-        "extractError": "Failed to extract clip",
-        "formatLabel": "Format",
+        "selectRange": "Haz clic y arrastra para seleccionar un rango",
+        "playSelection": "Reproducir rango seleccionado",
+        "pauseSelection": "Pausar reproducción",
+        "reviewSelection": "Ir al inicio de la selección",
+        "selectionStart": "Punto de inicio de la selección",
+        "selectionEnd": "Punto final de la selección",
+        "lossless": "Sin pérdida",
+        "lossy": "Con pérdida",
+        "extractClip": "Descargar clip seleccionado",
+        "clearSelection": "Borrar selección",
+        "extracting": "Extrayendo clip...",
+        "extractError": "Error al extraer el clip",
+        "formatLabel": "Formato",
         "rangeLabel": "{start}s – {end}s"
       },
       "processing": {
-        "playSelection": "Play selection",
-        "skipToStart": "Skip to selection start",
-        "clearSelection": "Clear selection",
-        "gain": "Gain (dB)",
-        "denoise": "Denoise",
-        "denoiseOff": "Off",
-        "denoiseLight": "Light",
-        "denoiseMedium": "Medium",
-        "denoiseHeavy": "Heavy",
-        "normalize": "Normalize audio",
-        "normalizeTooltip": "EBU R128 Normalization",
-        "export": "Export",
+        "playSelection": "Reproducir selección",
+        "skipToStart": "Ir al inicio de la selección",
+        "clearSelection": "Borrar selección",
+        "gain": "Ganancia (dB)",
+        "denoise": "Reducir ruido",
+        "denoiseOff": "Desactivado",
+        "denoiseLight": "Suave",
+        "denoiseMedium": "Medio",
+        "denoiseHeavy": "Fuerte",
+        "normalize": "Normalizar audio",
+        "normalizeTooltip": "Normalización EBU R128",
+        "export": "Exportar",
         "exportOriginal": "Original",
-        "processingActive": "Processing active"
+        "processingActive": "Procesamiento activo"
       }
     },
     "weatherInfo": {
@@ -4146,20 +4146,20 @@
       }
     },
     "tls": {
-      "certificateInstalled": "Certificate Installed",
-      "browseFile": "Browse",
-      "subject": "Subject",
-      "issuer": "Issuer",
-      "sans": "Subject Alternative Names",
-      "validUntil": "Valid Until",
-      "daysRemaining": "Days Remaining",
-      "fingerprint": "Fingerprint",
-      "expiryWarning": "This certificate expires soon. Consider renewing it.",
-      "downloadCertificate": "Download Certificate",
-      "regenerateButton": "Regenerate",
-      "removeCertificate": "Remove Certificate",
-      "fileReadError": "Failed to read file",
-      "loading": "Loading certificate information..."
+      "certificateInstalled": "Certificado instalado",
+      "browseFile": "Examinar",
+      "subject": "Sujeto",
+      "issuer": "Emisor",
+      "sans": "Nombres alternativos del sujeto",
+      "validUntil": "Válido hasta",
+      "daysRemaining": "Días restantes",
+      "fingerprint": "Huella digital",
+      "expiryWarning": "Este certificado expira pronto. Considera renovarlo.",
+      "downloadCertificate": "Descargar certificado",
+      "regenerateButton": "Regenerar",
+      "removeCertificate": "Eliminar certificado",
+      "fileReadError": "Error al leer el archivo",
+      "loading": "Cargando información del certificado..."
     }
   },
   "connectivity": {
@@ -4332,77 +4332,77 @@
     },
     "steps": {
       "welcome": {
-        "title": "Welcome",
-        "heading": "Welcome to BirdNET-Go!",
-        "description": "BirdNET-Go is a real-time bird sound identification system. It listens to audio from your microphone or audio stream and uses the BirdNET AI model to identify bird species.",
-        "credit": "Powered by the BirdNET Analyzer developed by the K. Lisa Yang Center for Conservation Bioacoustics at the Cornell Lab of Ornithology and Chemnitz University of Technology.",
-        "cta": "Let's set up your bird monitoring station."
+        "title": "Bienvenida",
+        "heading": "¡Bienvenido a BirdNET-Go!",
+        "description": "BirdNET-Go es un sistema de identificación de sonidos de aves en tiempo real. Escucha audio de tu micrófono o transmisión de audio y utiliza el modelo de IA BirdNET para identificar especies de aves.",
+        "credit": "Desarrollado con el BirdNET Analyzer del K. Lisa Yang Center for Conservation Bioacoustics en el Cornell Lab of Ornithology y la Chemnitz University of Technology.",
+        "cta": "Configuremos tu estación de monitoreo de aves."
       },
       "locationLanguage": {
-        "title": "Location & Language",
-        "uiLanguageLabel": "Interface Language",
-        "uiLanguageHelp": "Language used for the web interface",
-        "speciesLanguageLabel": "Species Name Language",
-        "speciesLanguageHelp": "Language used for bird species names in detections",
-        "locationLabel": "Station Location",
-        "locationHelp": "Your location helps filter species to those likely in your area",
-        "latitudeLabel": "Latitude",
-        "longitudeLabel": "Longitude",
-        "useMyLocation": "Use my location",
-        "locationDetected": "Location detected",
-        "locationError": "Could not detect location. Please enter coordinates manually.",
-        "locationDenied": "Location access denied. Please enter coordinates manually."
+        "title": "Ubicación e idioma",
+        "uiLanguageLabel": "Idioma de la interfaz",
+        "uiLanguageHelp": "Idioma utilizado para la interfaz web",
+        "speciesLanguageLabel": "Idioma de los nombres de especies",
+        "speciesLanguageHelp": "Idioma utilizado para los nombres de especies de aves en las detecciones",
+        "locationLabel": "Ubicación de la estación",
+        "locationHelp": "Tu ubicación ayuda a filtrar las especies probables en tu zona",
+        "latitudeLabel": "Latitud",
+        "longitudeLabel": "Longitud",
+        "useMyLocation": "Usar mi ubicación",
+        "locationDetected": "Ubicación detectada",
+        "locationError": "No se pudo detectar la ubicación. Ingresa las coordenadas manualmente.",
+        "locationDenied": "Acceso a la ubicación denegado. Ingresa las coordenadas manualmente."
       },
       "audioSource": {
-        "title": "Audio Source",
-        "sourceTypeLabel": "Source Type",
-        "soundcard": "Microphone / Soundcard",
-        "rtspStream": "RTSP Stream",
-        "deviceLabel": "Audio Device",
-        "deviceLoading": "Loading audio devices...",
-        "noDevicesFound": "No audio devices detected. Try configuring an RTSP stream instead.",
-        "rtspUrlLabel": "Stream URL",
+        "title": "Fuente de audio",
+        "sourceTypeLabel": "Tipo de fuente",
+        "soundcard": "Micrófono / tarjeta de sonido",
+        "rtspStream": "Transmisión RTSP",
+        "deviceLabel": "Dispositivo de audio",
+        "deviceLoading": "Cargando dispositivos de audio...",
+        "noDevicesFound": "No se detectaron dispositivos de audio. Intenta configurar una transmisión RTSP en su lugar.",
+        "rtspUrlLabel": "URL de la transmisión",
         "rtspUrlPlaceholder": "rtsp://user:password@host:port/stream",
-        "rtspUrlHelp": "Enter the URL of your RTSP audio stream",
-        "additionalSourcesHint": "You can add more audio sources later in Settings."
+        "rtspUrlHelp": "Ingresa la URL de tu transmisión de audio RTSP",
+        "additionalSourcesHint": "Puedes agregar más fuentes de audio después en Configuración."
       },
       "detection": {
-        "title": "Detection Threshold",
-        "description": "Choose how strict the bird identification should be. You can adjust this later in Settings.",
-        "balanced": "Balanced",
-        "balancedDesc": "Good balance of accuracy and sensitivity",
-        "balancedRecommended": "Recommended",
-        "highAccuracy": "High Accuracy",
-        "highAccuracyDesc": "Fewer false positives, may miss some birds",
-        "highSensitivity": "High Sensitivity",
-        "highSensitivityDesc": "More detections, more false positives",
-        "threshold": "Confidence threshold",
-        "fpFilterNote": "Once your system is running and proven, you can enable the false positive filter in Settings to further reduce incorrect detections."
+        "title": "Umbral de detección",
+        "description": "Elige qué tan estricta debe ser la identificación de aves. Puedes ajustarlo después en Configuración.",
+        "balanced": "Equilibrado",
+        "balancedDesc": "Buen equilibrio entre precisión y sensibilidad",
+        "balancedRecommended": "Recomendado",
+        "highAccuracy": "Alta precisión",
+        "highAccuracyDesc": "Menos falsos positivos, puede omitir algunas aves",
+        "highSensitivity": "Alta sensibilidad",
+        "highSensitivityDesc": "Más detecciones, más falsos positivos",
+        "threshold": "Umbral de confianza",
+        "fpFilterNote": "Una vez que tu sistema esté funcionando y comprobado, puedes activar el filtro de falsos positivos en Configuración para reducir aún más las detecciones incorrectas."
       },
       "integration": {
-        "title": "Privacy & Integration",
-        "privacyFilterLabel": "Enable privacy filter",
-        "privacyFilterHelp": "Filters out detections when human voices are detected near the microphone",
-        "birdweatherLabel": "Share detections with BirdWeather",
-        "birdweatherHelp": "Contribute your bird detections to the BirdWeather community network",
-        "birdweatherIdLabel": "BirdWeather Station ID",
-        "birdweatherIdPlaceholder": "Enter your BirdWeather station ID",
-        "errorReportingLabel": "Send anonymous error reports",
-        "errorReportingHelp": "Help improve BirdNET-Go by sending anonymous error reports when something goes wrong"
+        "title": "Privacidad e integración",
+        "privacyFilterLabel": "Activar filtro de privacidad",
+        "privacyFilterHelp": "Filtra las detecciones cuando se detectan voces humanas cerca del micrófono",
+        "birdweatherLabel": "Compartir detecciones con BirdWeather",
+        "birdweatherHelp": "Contribuye tus detecciones de aves a la red comunitaria de BirdWeather",
+        "birdweatherIdLabel": "ID de estación de BirdWeather",
+        "birdweatherIdPlaceholder": "Ingresa tu ID de estación de BirdWeather",
+        "errorReportingLabel": "Enviar reportes de error anónimos",
+        "errorReportingHelp": "Ayuda a mejorar BirdNET-Go enviando reportes de error anónimos cuando algo sale mal"
       },
       "responsibleUse": {
-        "title": "Using BirdNET-Go Responsibly",
-        "intro": "BirdNET-Go is a powerful tool that enhances your birding experience through AI-assisted identification. To ensure the best outcomes for both birding and conservation:",
-        "point1": "Review and verify detections before sharing observations",
-        "point2": "Use the confidence scores as a guide, not absolute truth",
-        "point3": "Cross-reference with field guides and local expertise",
-        "point4": "Consider seasonal patterns and habitat suitability",
-        "citizenScienceHeading": "When contributing to citizen science:",
-        "citizenPoint1": "Only submit observations you have personally verified",
-        "citizenPoint2": "Include notes about visual or behavioral confirmation",
-        "citizenPoint3": "Use AI detections as a starting point for your own observations",
-        "outro": "This approach ensures data quality for scientific research while maximizing your learning and enjoyment of birds.",
-        "acknowledge": "I understand"
+        "title": "Uso responsable de BirdNET-Go",
+        "intro": "BirdNET-Go es una herramienta potente que mejora tu experiencia de observación de aves mediante identificación asistida por IA. Para obtener los mejores resultados tanto para la observación como para la conservación:",
+        "point1": "Revisa y verifica las detecciones antes de compartir observaciones",
+        "point2": "Usa las puntuaciones de confianza como guía, no como verdad absoluta",
+        "point3": "Contrasta con guías de campo y experiencia local",
+        "point4": "Considera los patrones estacionales y la idoneidad del hábitat",
+        "citizenScienceHeading": "Al contribuir a la ciencia ciudadana:",
+        "citizenPoint1": "Solo envía observaciones que hayas verificado personalmente",
+        "citizenPoint2": "Incluye notas sobre confirmación visual o de comportamiento",
+        "citizenPoint3": "Usa las detecciones de IA como punto de partida para tus propias observaciones",
+        "outro": "Este enfoque garantiza la calidad de los datos para la investigación científica mientras maximiza tu aprendizaje y disfrute de las aves.",
+        "acknowledge": "Entendido"
       }
     }
   },

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -377,8 +377,8 @@
         "application": "Sovellusvirhe",
         "imageProvider": "Kuvantarjoajan ilmoitus",
         "categoryError": "{category}-virhe",
-        "burstTitle": "Multiple {component} errors",
-        "burstMessage": "{count} errors in the last {window_minutes} minutes: {sample_error}"
+        "burstTitle": "Useita {component}-virheitä",
+        "burstMessage": "{count} virhettä viimeisen {window_minutes} minuutin aikana: {sample_error}"
       },
       "settings": {
         "reloadingBirdnet": "Otetaan uusia analyysiasetuksia käyttöön...",
@@ -388,7 +388,7 @@
         "reconfiguringBirdweather": "Päivitetään BirdWeather-integraatiota...",
         "reconfiguringStreams": "Päivitetään äänistriimejä...",
         "reconfiguringTelemetry": "Päivitetään telemetria-asetuksia...",
-        "reconfiguringPushNotifications": "Reconfiguring push notification providers...",
+        "reconfiguringPushNotifications": "Määritetään push-ilmoitusten tarjoajia uudelleen...",
         "reconfiguringSpeciesTracking": "Päivitetään lajiseurantaa...",
         "recalculatingThresholds": "Lasketaan dynaamisia kynnysarvoja uudelleen uudelle perusarvolle",
         "reconfiguringDynamicThresholds": "Määritetään dynaamisia kynnysarvoja uudelleen...",
@@ -678,19 +678,19 @@
       "configFetch": "Etusivun asetusten haku epäonnistui: {status}"
     },
     "banner": {
-      "title": "Title",
-      "titlePlaceholder": "My Bird Station",
-      "description": "Description",
-      "descriptionPlaceholder": "A brief description of your bird monitoring station...",
-      "subElements": "Sub-elements",
-      "showImage": "Show custom image",
-      "imageUrl": "Image URL or path",
+      "title": "Otsikko",
+      "titlePlaceholder": "Oma lintuasema",
+      "description": "Kuvaus",
+      "descriptionPlaceholder": "Lyhyt kuvaus lintuseuranta-asemastasi...",
+      "subElements": "Alaelementit",
+      "showImage": "Näytä mukautettu kuva",
+      "imageUrl": "Kuvan URL tai polku",
       "imageUrlPlaceholder": "https://example.com/station-photo.jpg",
-      "imageUrlHelp": "Enter a URL to an image. Image upload will be available in a future update.",
-      "showLocationMap": "Show location map",
-      "showLocationMapHelp": "Displays a small map using the latitude/longitude from your main settings",
-      "showWeather": "Show current weather",
-      "showWeatherHelp": "Displays current weather conditions (requires weather integration to be enabled)",
+      "imageUrlHelp": "Syötä kuvan URL. Kuvan lataus tulee saataville tulevassa päivityksessä.",
+      "showLocationMap": "Näytä sijaintikartta",
+      "showLocationMapHelp": "Näyttää pienen kartan käyttäen pää-asetusten leveysaste- ja pituusastearvoja",
+      "showWeather": "Näytä nykyinen sää",
+      "showWeatherHelp": "Näyttää nykyiset säätiedot (edellyttää sääintegraation käyttöönottoa)",
       "timeFormat": "Aikamuoto",
       "mapZoom": "Kartan zoomaus",
       "showPin": "Näytä sijaintimerkki",
@@ -702,8 +702,8 @@
     "videoEmbed": {
       "youtubeUrl": "YouTube URL",
       "youtubeUrlPlaceholder": "https://www.youtube.com/watch?v=...",
-      "youtubeUrlHelp": "Paste any YouTube URL (watch, embed, or short link). It will be converted to a privacy-enhanced embed.",
-      "titleLabel": "Title (optional)",
+      "youtubeUrlHelp": "Liitä mikä tahansa YouTube-URL (katselu-, upotus- tai lyhytlinkki). Se muunnetaan yksityisyyttä suojaavaksi upotukseksi.",
+      "titleLabel": "Otsikko (valinnainen)",
       "titlePlaceholder": "Syötä videon otsikko (valinnainen)"
     },
     "editMode": {
@@ -737,12 +737,12 @@
       "resetting": "Palautetaan..."
     },
     "elements": {
-      "banner": "Dashboard Banner",
-      "dailySummary": "Daily Summary",
-      "currentlyHearing": "Currently Hearing",
-      "detectionsGrid": "Recent Detections",
+      "banner": "Kojelaudan banneri",
+      "dailySummary": "Päivittäinen yhteenveto",
+      "currentlyHearing": "Juuri nyt kuuluu",
+      "detectionsGrid": "Viimeisimmät havainnot",
       "liveSpectrogram": "Reaaliaikainen spektrogrammi",
-      "videoEmbed": "Video Embed"
+      "videoEmbed": "Videoupotus"
     }
   },
   "detections": {
@@ -799,17 +799,17 @@
       "fetchFailed": "Havaintojen hakeminen epäonnistui"
     },
     "weather": {
-      "title": "Weather Information",
-      "noData": "No weather data",
-      "noDataAvailable": "No weather data available",
-      "loading": "Loading weather information...",
+      "title": "Säätiedot",
+      "noData": "Ei säätietoja",
+      "noDataAvailable": "Säätietoja ei saatavilla",
+      "loading": "Ladataan säätietoja...",
       "labels": {
-        "temperature": "Temperature",
-        "weather": "Weather",
-        "wind": "Wind",
-        "humidity": "Humidity",
-        "pressure": "Pressure",
-        "cloudCover": "Cloud Cover"
+        "temperature": "Lämpötila",
+        "weather": "Sää",
+        "wind": "Tuuli",
+        "humidity": "Kosteus",
+        "pressure": "Ilmanpaine",
+        "cloudCover": "Pilvisyys"
       },
       "units": {
         "temperature": "°C",
@@ -930,31 +930,31 @@
   },
   "spectrogram": {
     "controls": {
-      "frequencyRange": "Frequency Range",
-      "colorMap": "Color Map",
-      "gain": "Gain",
+      "frequencyRange": "Taajuusalue",
+      "colorMap": "Värikartta",
+      "gain": "Vahvistus",
       "gainTooltip": "Spektrogrammin visualisoinnin vahvistus",
       "mute": "Mykistä äänilähtö",
       "unmute": "Palauta äänilähtö",
-      "frequencyRangeMin": "Minimum frequency",
-      "frequencyRangeMax": "Maximum frequency"
+      "frequencyRangeMin": "Minimitaajuus",
+      "frequencyRangeMax": "Maksimitaajuus"
     },
     "error": {
-      "unsupported": "Your browser does not support audio analysis",
-      "connectionFailed": "Failed to connect to live audio stream",
-      "accessDenied": "Live audio access requires authentication. Please log in to use this feature."
+      "unsupported": "Selaimesi ei tue äänianalyysiä",
+      "connectionFailed": "Yhteys reaaliaikaiseen äänilähetykseen epäonnistui",
+      "accessDenied": "Reaaliaikaisen äänen käyttö vaatii kirjautumisen. Kirjaudu sisään käyttääksesi tätä ominaisuutta."
     },
     "dashboard": {
-      "toggle": "Live Spectrogram",
-      "audioToggle": "Enable audio"
+      "toggle": "Reaaliaikainen spektrogrammi",
+      "audioToggle": "Ota ääni käyttöön"
     },
     "gain": {
       "muted": "Mykistetty",
       "level": "Vahvistus: {value} dB"
     },
     "page": {
-      "title": "Live Audio",
-      "sourceLabel": "Audio Source",
+      "title": "Reaaliaikainen ääni",
+      "sourceLabel": "Äänilähde",
       "connected": "Yhdistetty",
       "enterFullscreen": "Koko näyttö",
       "exitFullscreen": "Poistu koko näytöstä"
@@ -962,7 +962,7 @@
     "colorMaps": {
       "inferno": "Inferno",
       "viridis": "Viridis",
-      "grayscale": "Grayscale"
+      "grayscale": "Harmaasävy"
     },
     "labels": {
       "toggle": "Näytä/piilota tunnistusmerkinnät"
@@ -1287,82 +1287,82 @@
         "fetchFailed": "Tietokantatilastojen haku epäonnistui"
       },
       "dashboard": {
-        "title": "Database Dashboard",
-        "fetchFailed": "Failed to fetch database overview",
+        "title": "Tietokantapaneeli",
+        "fetchFailed": "Tietokannan yleiskatsauksen haku epäonnistui",
         "metrics": {
-          "readLatency": "Read Latency",
-          "writeLatency": "Write Latency",
-          "queriesPerSec": "Queries/sec",
-          "database": "Database",
-          "avg": "avg",
-          "max": "max",
-          "lastHour": "{count} last hour",
-          "slowQueries": "{count} slow"
+          "readLatency": "Lukuviive",
+          "writeLatency": "Kirjoitusviive",
+          "queriesPerSec": "Kyselyt/s",
+          "database": "Tietokanta",
+          "avg": "keskim.",
+          "max": "maks.",
+          "lastHour": "{count} viime tunti",
+          "slowQueries": "{count} hitaita"
         },
         "details": {
-          "title": "Database Details",
-          "engine": "Engine",
+          "title": "Tietokannan tiedot",
+          "engine": "Moottori",
           "journal": "Journal",
-          "pageSize": "Page size",
-          "cacheHit": "Cache hit",
-          "integrity": "Integrity",
-          "lastVacuum": "Last VACUUM"
+          "pageSize": "Sivukoko",
+          "cacheHit": "Välimuistiosumat",
+          "integrity": "Eheys",
+          "lastVacuum": "Viimeisin VACUUM"
         },
         "locksWal": {
-          "title": "Locks & WAL",
-          "lockWaits": "Lock waits",
-          "lockTimeouts": "Lock timeouts",
-          "avgWait": "Avg wait",
-          "busyTimeouts": "Busy timeouts",
-          "walSize": "WAL size",
-          "checkpoints": "Checkpoints",
-          "freelistPages": "Freelist pages",
-          "cacheSize": "Cache size"
+          "title": "Lukot ja WAL",
+          "lockWaits": "Lukitusodotukset",
+          "lockTimeouts": "Lukituksen aikakatkaisut",
+          "avgWait": "Keskim. odotus",
+          "busyTimeouts": "Varattuna-aikakatkaisut",
+          "walSize": "WAL-koko",
+          "checkpoints": "Tarkistuspisteet",
+          "freelistPages": "Vapaalistasivut",
+          "cacheSize": "Välimuistin koko"
         },
         "connectionPool": {
-          "title": "Connection Pool",
-          "poolUsage": "Pool Usage",
-          "active": "active",
-          "idle": "idle",
-          "waiting": "waiting",
-          "totalCreated": "Total created",
-          "connErrors": "Conn errors",
-          "threads": "Threads",
-          "running": "running",
-          "cached": "cached"
+          "title": "Yhteysvaranto",
+          "poolUsage": "Varannon käyttö",
+          "active": "aktiiviset",
+          "idle": "jouten",
+          "waiting": "odottavat",
+          "totalCreated": "Luotu yhteensä",
+          "connErrors": "Yhteysvirheet",
+          "threads": "Säikeet",
+          "running": "käynnissä",
+          "cached": "välimuistissa"
         },
         "innodb": {
-          "title": "InnoDB & Locks",
-          "bufferPoolHitRate": "Buffer pool hit rate",
-          "bufferPoolSize": "Buffer pool size",
-          "lockWaits": "Lock waits",
-          "deadlocks": "Deadlocks",
-          "avgLockWait": "Avg lock wait",
-          "tableLocksWaited": "Table locks waited",
-          "tableLocksImmediate": "Table locks immediate"
+          "title": "InnoDB ja lukot",
+          "bufferPoolHitRate": "Puskurialtaan osumataajuus",
+          "bufferPoolSize": "Puskurialtaan koko",
+          "lockWaits": "Lukitusodotukset",
+          "deadlocks": "Lukkiumat",
+          "avgLockWait": "Keskim. lukitusodotus",
+          "tableLocksWaited": "Taulukkolukitusten odotukset",
+          "tableLocksImmediate": "Välittömät taulukkolukitukset"
         },
         "detectionRate": {
-          "title": "Detection Rate (24h)",
-          "perHour": "/hr",
+          "title": "Havaintotaajuus (24h)",
+          "perHour": "/t",
           "min": "min",
-          "avg": "avg",
-          "max": "max",
-          "lastBackup": "Last backup",
-          "backupSize": "Backup size",
-          "createBackup": "Create Backup",
-          "mysqlHost": "Host",
+          "avg": "keskim.",
+          "max": "maks.",
+          "lastBackup": "Viimeisin varmuuskopio",
+          "backupSize": "Varmuuskopion koko",
+          "createBackup": "Luo varmuuskopio",
+          "mysqlHost": "Palvelin",
           "mysqlBackupNote": "MySQL-varmuuskopiot tulee hallita mysqldump-työkalulla tai MySQL-hallintatyökaluillasi.",
           "chartLabel": "Tunnistusmäärä 24 tunnin ajalta",
           "detectionsTooltip": "{count} tunnistusta"
         },
         "tables": {
-          "title": "Tables",
-          "total": "Total",
-          "table": "Table",
-          "engine": "Engine",
-          "rows": "Rows",
-          "size": "Size",
-          "usage": "Usage"
+          "title": "Taulukot",
+          "total": "Yhteensä",
+          "table": "Taulukko",
+          "engine": "Moottori",
+          "rows": "Rivit",
+          "size": "Koko",
+          "usage": "Käyttö"
         },
         "loading": "Ladataan..."
       },
@@ -2241,7 +2241,7 @@
           "pushover": "Pushover",
           "gotify": "Gotify",
           "ntfy": "ntfy",
-          "email": "Email",
+          "email": "Sähköposti",
           "generic": "Shoutrrr",
           "numbered": "{service} #{number}"
         },
@@ -2251,32 +2251,32 @@
           "discord": {
             "name": "Discord",
             "webhookUrl": {
-              "label": "Discord Webhook URL",
+              "label": "Discordin webhook-URL",
               "placeholder": "https://discord.com/api/webhooks/...",
-              "helpText": "Paste your full Discord webhook URL"
+              "helpText": "Liitä Discordin webhook-URL kokonaisuudessaan"
             },
-            "invalidUrl": "Invalid Discord webhook URL. URL should contain discord.com/api/webhooks/"
+            "invalidUrl": "Virheellinen Discordin webhook-URL. URL:n tulee sisältää discord.com/api/webhooks/"
           },
           "telegram": {
             "name": "Telegram",
             "botToken": {
-              "label": "Bot Token",
+              "label": "Botin token",
               "placeholder": "123456789:ABCdef...",
-              "helpText": "Token from @BotFather"
+              "helpText": "Token @BotFatherilta"
             },
             "chatId": {
-              "label": "Chat ID",
-              "placeholder": "-1001234567890 or @channel",
-              "helpText": "Chat ID, group ID, or @username"
+              "label": "Keskustelu-ID",
+              "placeholder": "-1001234567890 tai @channel",
+              "helpText": "Keskustelu-ID, ryhmä-ID tai @käyttäjänimi"
             },
-            "incomplete": "Both bot token and chat ID are required"
+            "incomplete": "Sekä botin token että keskustelu-ID vaaditaan"
           },
           "ntfy": {
             "name": "ntfy",
             "server": {
-              "label": "Server",
+              "label": "Palvelin",
               "placeholder": "ntfy.sh",
-              "helpText": "Leave as ntfy.sh for public server or enter your self-hosted server"
+              "helpText": "Jätä ntfy.sh julkiselle palvelimelle tai syötä oma palvelimesi"
             },
             "protocol": {
               "label": "Protokolla"
@@ -2299,109 +2299,109 @@
               }
             },
             "topic": {
-              "label": "Topic",
+              "label": "Aihe",
               "placeholder": "my-bird-alerts",
-              "helpText": "Topic name for your notifications"
+              "helpText": "Ilmoitustesi aiheen nimi"
             },
-            "incomplete": "Topic is required"
+            "incomplete": "Aihe vaaditaan"
           },
           "gotify": {
             "name": "Gotify",
             "server": {
-              "label": "Server URL",
+              "label": "Palvelimen URL",
               "placeholder": "gotify.example.com",
-              "helpText": "Your Gotify server hostname (without https://)"
+              "helpText": "Gotify-palvelimesi isäntänimi (ilman https://)"
             },
             "token": {
-              "label": "Application Token",
+              "label": "Sovelluksen token",
               "placeholder": "A...",
-              "helpText": "Token from Gotify Apps page"
+              "helpText": "Token Gotifyn sovellussivulta"
             },
-            "incomplete": "Server and token are required"
+            "incomplete": "Palvelin ja token vaaditaan"
           },
           "pushover": {
             "name": "Pushover",
             "apiToken": {
-              "label": "API Token",
+              "label": "API-token",
               "placeholder": "az...",
-              "helpText": "Application API token"
+              "helpText": "Sovelluksen API-token"
             },
             "userKey": {
-              "label": "User Key",
+              "label": "Käyttäjäavain",
               "placeholder": "u...",
-              "helpText": "Your user or group key"
+              "helpText": "Käyttäjä- tai ryhmäavaimesi"
             },
-            "incomplete": "API token and user key are required"
+            "incomplete": "API-token ja käyttäjäavain vaaditaan"
           },
           "slack": {
             "name": "Slack",
             "webhookUrl": {
-              "label": "Slack Webhook URL",
+              "label": "Slackin webhook-URL",
               "placeholder": "https://hooks.slack.com/services/...",
-              "helpText": "Paste your full Slack webhook URL"
+              "helpText": "Liitä Slackin webhook-URL kokonaisuudessaan"
             },
-            "invalidUrl": "Invalid Slack webhook URL. URL should contain hooks.slack.com/services/"
+            "invalidUrl": "Virheellinen Slackin webhook-URL. URL:n tulee sisältää hooks.slack.com/services/"
           },
           "ifttt": {
             "name": "IFTTT",
             "webhookKey": {
-              "label": "Webhook Key",
+              "label": "Webhook-avain",
               "placeholder": "abc123xyz...",
-              "helpText": "Your IFTTT Webhook key from Maker Webhooks settings"
+              "helpText": "IFTTT:n webhook-avaimesi Maker Webhooks -asetuksista"
             },
             "eventName": {
-              "label": "Event Name",
+              "label": "Tapahtuman nimi",
               "placeholder": "bird_detected",
-              "helpText": "The event name to trigger in your IFTTT applet"
+              "helpText": "IFTTT-appletin käynnistettävän tapahtuman nimi"
             },
-            "incomplete": "Webhook key and event name are required"
+            "incomplete": "Webhook-avain ja tapahtuman nimi vaaditaan"
           },
           "webhook": {
             "name": "Webhook",
             "url": {
-              "label": "Webhook URL",
+              "label": "Webhook-URL",
               "placeholder": "https://api.example.com/webhook",
-              "helpText": "The HTTP(S) endpoint to send notifications to"
+              "helpText": "HTTP(S)-päätepiste ilmoitusten lähettämistä varten"
             },
             "method": {
-              "label": "HTTP Method",
-              "helpText": "HTTP method to use for the request (default: POST)"
+              "label": "HTTP-metodi",
+              "helpText": "Pyynnössä käytettävä HTTP-metodi (oletus: POST)"
             },
             "auth": {
-              "label": "Authentication",
-              "none": "None",
-              "bearer": "Bearer Token",
-              "basic": "Basic Auth",
-              "helpText": "Optional authentication for the webhook endpoint"
+              "label": "Tunnistautuminen",
+              "none": "Ei mitään",
+              "bearer": "Bearer-token",
+              "basic": "Perustunnistautuminen",
+              "helpText": "Valinnainen tunnistautuminen webhook-päätepisteelle"
             },
             "bearerToken": {
-              "label": "Bearer Token",
+              "label": "Bearer-token",
               "placeholder": "your-api-token",
-              "helpText": "Token sent in Authorization: Bearer header"
+              "helpText": "Token lähetetään Authorization: Bearer -otsikossa"
             },
             "basicUser": {
-              "label": "Username",
+              "label": "Käyttäjänimi",
               "placeholder": "username"
             },
             "basicPass": {
-              "label": "Password",
+              "label": "Salasana",
               "placeholder": "password"
             },
             "basicAuth": {
-              "helpText": "Credentials sent using HTTP Basic Authentication"
+              "helpText": "Tunnistetiedot lähetetään HTTP-perustunnistautumisella"
             },
-            "invalidUrl": "Invalid URL. Must start with http:// or https://",
-            "tokenRequired": "Bearer token is required when using Bearer authentication",
-            "credentialsRequired": "Username and password are required when using Basic authentication"
+            "invalidUrl": "Virheellinen URL. Tulee alkaa http:// tai https://",
+            "tokenRequired": "Bearer-token vaaditaan käytettäessä Bearer-tunnistautumista",
+            "credentialsRequired": "Käyttäjänimi ja salasana vaaditaan käytettäessä perustunnistautumista"
           },
           "custom": {
             "name": "Mukautettu URL",
             "url": {
-              "label": "Shoutrrr URL",
+              "label": "Shoutrrr-URL",
               "placeholder": "service://credentials@host",
-              "helpText": "Enter a raw Shoutrrr URL for any supported service"
+              "helpText": "Syötä Shoutrrr-URL mille tahansa tuetulle palvelulle"
             },
-            "invalidUrl": "Invalid URL format. URL should start with service://"
+            "invalidUrl": "Virheellinen URL-muoto. URL:n tulee alkaa service://"
           }
         }
       },
@@ -2485,7 +2485,7 @@
       "loading": "Ladataan äänilaitteita...",
       "tabs": {
         "soundCard": "Äänikortti",
-        "streams": "Striimit",
+        "streams": "Lähetykset",
         "processing": "Käsittely",
         "recording": "Tallennus",
         "retention": "Säilytys"
@@ -2753,7 +2753,7 @@
         "noStreamsConfigured": "Striimejä ei ole määritetty"
       },
       "streams": {
-        "streamLabel": "Striimi",
+        "streamLabel": "Lähetys",
         "nameLabel": "Striimin nimi",
         "namePlaceholder": "esim. Etupihan ruokinta",
         "nameHelp": "Kuvaava nimi tämän äänistriimin tunnistamiseen",
@@ -2800,7 +2800,7 @@
           "error": "Virhe",
           "noHistory": "Ei tila- tai virhehistoriaa saatavilla.",
           "stateChange": "Tilamuutos",
-          "host": "Isäntä",
+          "host": "Palvelin",
           "troubleshooting": "Vianmääritys",
           "from": "Mistä",
           "to": "Mihin",
@@ -2877,29 +2877,29 @@
           "skipVerify": "Ohita varmenteen tarkistus",
           "configNote": "<strong>TLS-asetukset:</strong><br />• Vakio TLS: Jätä varmenteet tyhjäksi julkisille välittäjille<br />• Itse allekirjoitetut varmenteet: Anna CA-varmenne<br />• Molemminpuolinen TLS (mTLS): Anna kaikki kolme varmennetta",
           "certificates": {
-            "title": "Certificate Management",
-            "description": "Upload certificates for secure MQTT broker connections",
-            "caLabel": "CA Certificate",
+            "title": "Sertifikaattien hallinta",
+            "description": "Lataa sertifikaatit suojattuja MQTT-välittäjäyhteyksiä varten",
+            "caLabel": "CA-sertifikaatti",
             "caPlaceholder": "-----BEGIN CERTIFICATE-----",
-            "caHelpText": "Certificate Authority certificate to verify the broker's identity",
-            "clientCertLabel": "Client Certificate",
+            "caHelpText": "Varmenneviranomaisen sertifikaatti välittäjän identiteetin todentamiseksi",
+            "clientCertLabel": "Asiakassertifikaatti",
             "clientCertPlaceholder": "-----BEGIN CERTIFICATE-----",
-            "clientCertHelpText": "Client certificate for mutual TLS authentication",
-            "clientKeyLabel": "Client Private Key",
+            "clientCertHelpText": "Asiakassertifikaatti molemminpuolista TLS-tunnistautumista varten",
+            "clientKeyLabel": "Asiakkaan yksityinen avain",
             "clientKeyPlaceholder": "-----BEGIN PRIVATE KEY-----",
-            "clientKeyHelpText": "Private key matching the client certificate",
-            "uploadButton": "Upload Certificates",
-            "uploadSuccess": "MQTT TLS certificates uploaded successfully. Use Test Connection to verify.",
-            "uploadError": "Failed to upload MQTT TLS certificates",
-            "deleteConfirm": "Remove all MQTT TLS certificates? The MQTT client will need to reconnect.",
-            "deleteSuccess": "MQTT TLS certificates removed",
-            "deleteError": "Failed to remove MQTT TLS certificates",
-            "loadError": "Failed to load certificate information",
-            "reconnectNote": "Use the Test Connection button below to verify the new TLS configuration."
+            "clientKeyHelpText": "Yksityinen avain, joka vastaa asiakassertifikaattia",
+            "uploadButton": "Lataa sertifikaatit",
+            "uploadSuccess": "MQTT TLS -sertifikaatit ladattu onnistuneesti. Käytä yhteyden testausta varmistaaksesi.",
+            "uploadError": "MQTT TLS -sertifikaattien lataus epäonnistui",
+            "deleteConfirm": "Poistetaanko kaikki MQTT TLS -sertifikaatit? MQTT-asiakas tarvitsee uudelleenyhteyden.",
+            "deleteSuccess": "MQTT TLS -sertifikaatit poistettu",
+            "deleteError": "MQTT TLS -sertifikaattien poisto epäonnistui",
+            "loadError": "Sertifikaattitietojen lataus epäonnistui",
+            "reconnectNote": "Käytä alla olevaa yhteyden testauspainiketta varmistaaksesi uuden TLS-konfiguraation."
           }
         },
         "homeAssistant": {
-          "title": "Home Assistant Auto-Discovery",
+          "title": "Home Assistant -automaattitunnistus",
           "enable": "Ota käyttöön Home Assistant MQTT Discovery",
           "description": "Kun käytössä, BirdNET-Go rekisteröi automaattisesti laitteet ja anturit Home Assistantiin MQTT-discovery-protokollan kautta. Laitteet ilmestyvät Home Assistantin laiterekisteriin ilman manuaalista YAML-konfiguraatiota.",
           "discoveryPrefix": {
@@ -2995,7 +2995,7 @@
           "options": {
             "standard": "Vakio",
             "metric": "Metrinen",
-            "imperial": "Brittiläinen",
+            "imperial": "Imperiaalinen",
             "ukhybrid": "UK-hybridi"
           }
         },
@@ -3039,14 +3039,14 @@
           "helpText": "Kuinka kauan eBirdin taksonomiatietoja säilytetään välimuistissa. Taksonomia muuttuu harvoin, joten pidempi välimuistiaika vähentää API-kutsuja."
         },
         "note": "eBird tarjoaa taksonomiatietoja lajien luokitteluun ja analyyseihin. API-avain on saatavilla ilmaiseksi Cornellin ornitologian laboratoriosta.",
-        "apiKeyInfo": "A personal eBird API key is required to use this integration. You can request a free key from <a href=\"https://ebird.org/api/keygen\" class=\"link link-primary\" target=\"_blank\" rel=\"noopener noreferrer\">ebird.org/api/keygen</a>.",
+        "apiKeyInfo": "Henkilökohtainen eBird API -avain vaaditaan tämän integraation käyttöön. Voit pyytää ilmaisen avaimen osoitteesta <a href=\"https://ebird.org/api/keygen\" class=\"link link-primary\" target=\"_blank\" rel=\"noopener noreferrer\">ebird.org/api/keygen</a>.",
         "test": {
-          "button": "Test eBird Connection",
-          "loading": "Testing...",
-          "enabledRequired": "Enable eBird integration first",
-          "apiKeyRequired": "API key is required",
-          "inProgress": "Test in progress...",
-          "description": "Test eBird API connectivity and authentication"
+          "button": "Testaa eBird-yhteys",
+          "loading": "Testataan...",
+          "enabledRequired": "Ota ensin eBird-integraatio käyttöön",
+          "apiKeyRequired": "API-avain vaaditaan",
+          "inProgress": "Testi käynnissä...",
+          "description": "Testaa eBird API:n yhteyttä ja tunnistautumista"
         }
       }
     },
@@ -3210,8 +3210,8 @@
             "source": "Lähde",
             "clearParameters": "Tyhjennä parametrit"
           },
-          "placeholder": "Click buttons below to add parameters or type manually",
-          "tooltip": "Use buttons below or type directly (comma-separated)"
+          "placeholder": "Napsauta alla olevia painikkeita lisätäksesi parametreja tai kirjoita manuaalisesti",
+          "tooltip": "Käytä alla olevia painikkeita tai kirjoita suoraan (pilkuilla eroteltuina)"
         },
         "executeDefaults": {
           "label": "Suorita myös oletustoiminnot (tietokantatallennus, ilmoitukset jne.)",
@@ -3363,7 +3363,7 @@
         "expand": "Näytä tapahtumahistoria",
         "collapse": "Piilota tapahtumahistoria"
       },
-      "suggestions": "Species suggestions"
+      "suggestions": "Lajiehdotukset"
     },
     "security": {
       "pageLabel": "Turva-asetukset",
@@ -3467,9 +3467,9 @@
           "enableLabel": "Salli OAuth2-kirjautuminen LINE:llä",
           "redirectUriTitle": "Uudelleenohjaus-URI LINE Developers Consolea varten:",
           "getCredentialsLabel": "Hae tunnukset LINE Developers Consolesta",
-          "clientIdLabel": "Channel ID",
+          "clientIdLabel": "Kanava-ID",
           "clientIdHelpText": "LINE Developers Consolesta saatu Channel ID LINE Login -määrityksen yhteydessä.",
-          "clientSecretLabel": "Channel Secret",
+          "clientSecretLabel": "Kanavan salaisuus",
           "clientSecretHelpText": "LINE Developers Consolesta saatu Channel Secret LINE Login -määrityksen yhteydessä.",
           "userIdLabel": "Käyttäjätunnus"
         },
@@ -3478,29 +3478,29 @@
           "enableLabel": "Salli OAuth2-kirjautuminen Kakaolla",
           "redirectUriTitle": "Uudelleenohjaus-URI Kakao Developers Consolea varten:",
           "getCredentialsLabel": "Hae tunnukset Kakao Developers Consolesta",
-          "clientIdLabel": "REST API Key",
+          "clientIdLabel": "REST API -avain",
           "clientIdHelpText": "Kakao Developers Consolesta saatu REST API Key Kakao Login -määrityksen yhteydessä.",
-          "clientSecretLabel": "Client Secret",
+          "clientSecretLabel": "Asiakkaan salaisuus",
           "clientSecretHelpText": "Kakao Developers Consolesta saatu Client Secret Kakao Login -määrityksen yhteydessä.",
           "userIdLabel": "Käyttäjätunnus"
         },
         "oidc": {
-          "title": "OIDC Provider",
-          "enableLabel": "Enable OIDC authentication",
-          "redirectUriTitle": "Redirect URI",
-          "getCredentialsLabel": "Configure in your Identity Provider",
-          "clientIdLabel": "Client ID",
-          "clientIdHelpText": "The client ID from your OIDC identity provider",
-          "clientSecretLabel": "Client Secret",
-          "clientSecretHelpText": "The client secret from your OIDC identity provider",
-          "userIdLabel": "Allowed User (email or sub claim)",
-          "issuerUrlLabel": "Issuer URL",
-          "issuerUrlHelpText": "The issuer URL of your OpenID Connect identity provider (e.g., https://auth.example.com)",
+          "title": "OIDC-palveluntarjoaja",
+          "enableLabel": "Ota OIDC-tunnistautuminen käyttöön",
+          "redirectUriTitle": "Uudelleenohjaus-URI",
+          "getCredentialsLabel": "Määritä identiteettipalveluntarjoajassasi",
+          "clientIdLabel": "Asiakas-ID",
+          "clientIdHelpText": "Asiakas-ID OIDC-identiteettipalveluntarjoajaltasi",
+          "clientSecretLabel": "Asiakkaan salaisuus",
+          "clientSecretHelpText": "Asiakkaan salaisuus OIDC-identiteettipalveluntarjoajaltasi",
+          "userIdLabel": "Sallittu käyttäjä (sähköposti tai sub-väite)",
+          "issuerUrlLabel": "Myöntäjän URL",
+          "issuerUrlHelpText": "OpenID Connect -identiteettipalveluntarjoajasi myöntäjä-URL (esim. https://auth.example.com)",
           "issuerUrlPlaceholder": "https://auth.example.com",
-          "issuerUrlRequired": "Issuer URL is required for OIDC providers",
-          "issuerUrlInvalid": "Issuer URL must be a valid HTTP or HTTPS URL",
-          "scopesLabel": "Scopes",
-          "scopesHelpText": "Comma-separated list of OIDC scopes (default: openid, profile, email)",
+          "issuerUrlRequired": "Myöntäjän URL vaaditaan OIDC-palveluntarjoajille",
+          "issuerUrlInvalid": "Myöntäjän URL:n tulee olla kelvollinen HTTP- tai HTTPS-URL",
+          "scopesLabel": "Laajuudet",
+          "scopesHelpText": "Pilkuilla eroteltu lista OIDC-laajuuksista (oletus: openid, profile, email)",
           "scopesPlaceholder": "openid, profile, email"
         }
       },
@@ -3510,14 +3510,14 @@
         "disabled": "Aliverkon ohitus on poistettu käytöstä"
       },
       "exceptions": {
-        "title": "Exceptions"
+        "title": "Poikkeukset"
       },
       "publicAccess": {
-        "title": "Public Access",
-        "description": "Allow specific features to be accessible without authentication.",
-        "liveAudioLabel": "Allow public live audio playback",
-        "liveAudioHelp": "When enabled, anyone can listen to live audio streams without logging in. Settings and deletion still require authentication.",
-        "warningText": "Enabling public access features exposes them to anyone who can reach this server. Only enable if you trust your network environment."
+        "title": "Julkinen pääsy",
+        "description": "Salli tiettyjen ominaisuuksien käyttö ilman tunnistautumista.",
+        "liveAudioLabel": "Salli julkinen reaaliaikaisen äänen toisto",
+        "liveAudioHelp": "Kun käytössä, kuka tahansa voi kuunnella reaaliaikaisia äänilähetyksiä kirjautumatta. Asetukset ja poistaminen vaativat edelleen tunnistautumisen.",
+        "warningText": "Julkisen pääsyn ominaisuuksien käyttöönotto altistaa ne kaikille, jotka pääsevät tälle palvelimelle. Ota käyttöön vain, jos luotat verkkoympäristöösi."
       },
       "placeholders": {
         "baseUrl": "https://birdnet.example.com:5500",
@@ -3534,64 +3534,64 @@
       },
       "tls": {
         "title": "TLS / HTTPS",
-        "description": "Configure TLS/HTTPS encryption for secure connections",
-        "modeLabel": "TLS Mode",
-        "modeNone": "None (HTTP)",
+        "description": "Määritä TLS/HTTPS-salaus suojattuja yhteyksiä varten",
+        "modeLabel": "TLS-tila",
+        "modeNone": "Ei mitään (HTTP)",
         "modeLetsEncrypt": "Let's Encrypt",
-        "modeManual": "Manual Certificate",
-        "modeSelfSigned": "Self-Signed",
-        "modeNoneDescription": "Plain HTTP without encryption",
-        "modeAutoTLSDescription": "Automatic certificate via Let's Encrypt",
-        "modeManualDescription": "Upload your own certificate and key",
-        "modeSelfSignedDescription": "Generate a self-signed certificate",
-        "portLabel": "HTTPS Port",
-        "portHelpText": "Port for HTTPS connections (default: 8443)",
-        "redirectToHttps": "Redirect HTTP to HTTPS",
-        "autoTLSRequirements": "Requires ports 80 and 443 to be accessible. On Linux, the process needs root or CAP_NET_BIND_SERVICE capability.",
-        "validityLabel": "Certificate Validity",
-        "validityHelpText": "How long the certificate should be valid",
-        "validity365d": "1 year",
-        "validity730d": "2 years",
-        "generateButton": "Generate Certificate",
-        "regenerateButton": "Regenerate Certificate",
-        "generating": "Generating...",
-        "certificateLabel": "Certificate (PEM)",
-        "privateKeyLabel": "Private Key (PEM)",
-        "caCertificateLabel": "CA Certificate (PEM, optional)",
-        "uploadButton": "Upload Certificate",
-        "uploading": "Uploading...",
-        "browseFile": "Browse...",
-        "plaintextWarning": "Warning: Your private key will be transmitted in plaintext over HTTP. Only upload certificates when connected via a trusted network or localhost.",
-        "certificateInstalled": "Installed Certificate",
-        "subject": "Subject",
-        "issuer": "Issuer",
-        "validFrom": "Valid From",
-        "validUntil": "Valid Until",
-        "daysRemaining": "Days Remaining",
-        "sans": "Subject Alternative Names",
-        "fingerprint": "Fingerprint",
-        "expiryWarning": "Certificate is expiring soon",
-        "loading": "Loading certificate info...",
-        "loadError": "Failed to load certificate info",
-        "generateSuccess": "Self-signed certificate generated successfully",
-        "generateError": "Failed to generate certificate",
-        "uploadSuccess": "Certificate uploaded successfully",
-        "uploadError": "Failed to upload certificate",
-        "deleteSuccess": "Certificate removed successfully",
-        "deleteError": "Failed to delete certificate",
-        "removeCertificate": "Remove Certificate",
-        "deleteConfirm": "Are you sure you want to remove the installed TLS certificate? The TLS mode will be reset to None.",
-        "restartRequired": "TLS changes require a server restart to take effect.",
-        "noCertificate": "No certificate installed",
-        "validity1825d": "5 years",
-        "autoTLSHostRequired": "A hostname is required for Let’s Encrypt. Enter your public domain name in the Host field above.",
-        "autoTLSNoIP": "Let’s Encrypt requires a domain name, not an IP address. Enter a public domain like birds.example.com.",
-        "autoTLSNeedsFQDN": "Let’s Encrypt requires a fully qualified domain name (e.g., birds.example.com), not a bare hostname.",
-        "autoTLSNoLocalhost": "Let’s Encrypt cannot issue certificates for localhost.",
-        "autoTLSPrivateTLD": "Let’s Encrypt cannot issue certificates for private domains ({tld} is not publicly resolvable).",
-        "downloadCertificate": "Download Certificate",
-        "downloadCertificateHelp": "Install this certificate in your operating system's trust store to avoid browser security warnings.",
-        "fileReadError": "Failed to read the selected file"
+        "modeManual": "Manuaalinen sertifikaatti",
+        "modeSelfSigned": "Itseallekirjoitettu",
+        "modeNoneDescription": "Tavallinen HTTP ilman salausta",
+        "modeAutoTLSDescription": "Automaattinen sertifikaatti Let's Encryptin kautta",
+        "modeManualDescription": "Lataa oma sertifikaattisi ja avaimesi",
+        "modeSelfSignedDescription": "Luo itseallekirjoitettu sertifikaatti",
+        "portLabel": "HTTPS-portti",
+        "portHelpText": "HTTPS-yhteyksien portti (oletus: 8443)",
+        "redirectToHttps": "Ohjaa HTTP HTTPS:ään",
+        "autoTLSRequirements": "Vaatii porttien 80 ja 443 olevan saavutettavissa. Linuxissa prosessi tarvitsee root-oikeudet tai CAP_NET_BIND_SERVICE-kyvykkyyden.",
+        "validityLabel": "Sertifikaatin voimassaolo",
+        "validityHelpText": "Kuinka kauan sertifikaatin tulee olla voimassa",
+        "validity365d": "1 vuosi",
+        "validity730d": "2 vuotta",
+        "generateButton": "Luo sertifikaatti",
+        "regenerateButton": "Luo sertifikaatti uudelleen",
+        "generating": "Luodaan...",
+        "certificateLabel": "Sertifikaatti (PEM)",
+        "privateKeyLabel": "Yksityinen avain (PEM)",
+        "caCertificateLabel": "CA-sertifikaatti (PEM, valinnainen)",
+        "uploadButton": "Lataa sertifikaatti",
+        "uploading": "Ladataan...",
+        "browseFile": "Selaa...",
+        "plaintextWarning": "Varoitus: Yksityinen avaimesi lähetetään selkotekstinä HTTP:n yli. Lataa sertifikaatteja vain luotetun verkon tai localhosting kautta.",
+        "certificateInstalled": "Asennettu sertifikaatti",
+        "subject": "Kohde",
+        "issuer": "Myöntäjä",
+        "validFrom": "Voimassa alkaen",
+        "validUntil": "Voimassa asti",
+        "daysRemaining": "Päiviä jäljellä",
+        "sans": "Vaihtoehtoiset nimet",
+        "fingerprint": "Sormenjälki",
+        "expiryWarning": "Sertifikaatti vanhenee pian",
+        "loading": "Ladataan sertifikaattitietoja...",
+        "loadError": "Sertifikaattitietojen lataus epäonnistui",
+        "generateSuccess": "Itseallekirjoitettu sertifikaatti luotu onnistuneesti",
+        "generateError": "Sertifikaatin luonti epäonnistui",
+        "uploadSuccess": "Sertifikaatti ladattu onnistuneesti",
+        "uploadError": "Sertifikaatin lataus epäonnistui",
+        "deleteSuccess": "Sertifikaatti poistettu onnistuneesti",
+        "deleteError": "Sertifikaatin poisto epäonnistui",
+        "removeCertificate": "Poista sertifikaatti",
+        "deleteConfirm": "Haluatko varmasti poistaa asennetun TLS-sertifikaatin? TLS-tila palautetaan arvoon Ei mitään.",
+        "restartRequired": "TLS-muutokset vaativat palvelimen uudelleenkäynnistyksen astuakseen voimaan.",
+        "noCertificate": "Ei asennettua sertifikaattia",
+        "validity1825d": "5 vuotta",
+        "autoTLSHostRequired": "Let's Encrypt vaatii isäntänimen. Syötä julkinen verkkotunnuksesi yllä olevaan Host-kenttään.",
+        "autoTLSNoIP": "Let's Encrypt vaatii verkkotunnuksen, ei IP-osoitetta. Syötä julkinen verkkotunnus kuten birds.example.com.",
+        "autoTLSNeedsFQDN": "Let's Encrypt vaatii täydellisen verkkotunnuksen (esim. birds.example.com), ei pelkkää isäntänimeä.",
+        "autoTLSNoLocalhost": "Let's Encrypt ei voi myöntää sertifikaatteja localhostille.",
+        "autoTLSPrivateTLD": "Let's Encrypt ei voi myöntää sertifikaatteja yksityisille verkkotunnuksille ({tld} ei ole julkisesti selvitettävissä).",
+        "downloadCertificate": "Lataa sertifikaatti",
+        "downloadCertificateHelp": "Asenna tämä sertifikaatti käyttöjärjestelmäsi luottamusvarastoon välttääksesi selaimen turvallisuusvaroitukset.",
+        "fileReadError": "Valitun tiedoston lukeminen epäonnistui"
       }
     },
     "database": {
@@ -3838,7 +3838,7 @@
         "appearance": "Appearance",
         "language": "Language & Regional",
         "visualContent": "Visual Content",
-        "audioPlayback": "Audio Playback"
+        "audioPlayback": "Äänentoisto"
       },
       "appearance": {
         "title": "Appearance",
@@ -3853,14 +3853,14 @@
         "description": "Configure bird images and spectrogram display settings"
       },
       "audioPlayback": {
-        "title": "Audio Playback",
-        "description": "Default settings for playing bird recordings.",
-        "defaultGain": "Default Volume Boost",
-        "defaultGainHelpText": "Initial gain applied when playing recordings. Bird sounds are often quiet, so a boost of 6-12 dB is recommended.",
+        "title": "Äänentoisto",
+        "description": "Oletusasetukset lintuäänitteiden toistoon.",
+        "defaultGain": "Oletusäänenvahvistus",
+        "defaultGainHelpText": "Alkuvahvistus äänitteiden toistossa. Lintujen äänet ovat usein hiljaisia, joten 6-12 dB:n vahvistus on suositeltavaa.",
         "defaultGainUnit": "dB"
       }
     },
-    "restartRequired": "Some changes require a server restart to take effect. Please restart BirdNET-Go."
+    "restartRequired": "Jotkin muutokset vaativat palvelimen uudelleenkäynnistyksen astuakseen voimaan. Käynnistä BirdNET-Go uudelleen."
   },
   "auth": {
     "login": "Kirjaudu",
@@ -3881,7 +3881,7 @@
     "continueWithMicrosoft": "Jatka Microsoftilla",
     "continueWithLine": "Jatka LINE:llä",
     "continueWithKakao": "Jatka Kakaolla",
-    "continueWithOidc": "Continue with OIDC",
+    "continueWithOidc": "Jatka OIDC:llä",
     "errors": {
       "loginFailed": "Kirjautuminen epäonnistui. Tarkista salasanasi ja yritä uudelleen.",
       "passwordRequired": "Salasana vaaditaan.",
@@ -4029,7 +4029,7 @@
       "seekProgress": "Äänen eteneminen: {current} / {total} sekuntia",
       "playbackSpeed": "Toistonopeus",
       "speed": "Nopeus",
-      "loop": "Toggle loop",
+      "loop": "Vaihda silmukka",
       "player": "Äänisoitin"
     },
     "spectrogram": {
@@ -4073,7 +4073,7 @@
         "addNewStream": "Lisää uusi RTSP-striimi",
         "maxStreamsReached": "RTSP-striimien enimmäismäärä ({max}) saavutettu.",
         "cameraPlaceholder": "Kamera 1",
-        "urlPlaceholder": "rtsp://käyttäjänimi:salasana@192.168.1.100:554/stream"
+        "urlPlaceholder": "rtsp://username:password@192.168.1.100:554/stream"
       },
       "subnet": {
         "maxSubnetsReached": "Aliverkkojen enimmäismäärä ({max}) saavutettu."
@@ -4108,36 +4108,36 @@
         "spectrogramFailed": "Spektrogrammin luonti epäonnistui"
       },
       "clipExtraction": {
-        "selectRange": "Click and drag to select a range",
-        "playSelection": "Play selected range",
-        "pauseSelection": "Pause playback",
-        "reviewSelection": "Jump to start of selection",
-        "selectionStart": "Selection start handle",
-        "selectionEnd": "Selection end handle",
-        "lossless": "Lossless",
-        "lossy": "Lossy",
-        "extractClip": "Download selected clip",
-        "clearSelection": "Clear selection",
-        "extracting": "Extracting clip...",
-        "extractError": "Failed to extract clip",
-        "formatLabel": "Format",
+        "selectRange": "Napsauta ja vedä valitaksesi alueen",
+        "playSelection": "Toista valittu alue",
+        "pauseSelection": "Keskeytä toisto",
+        "reviewSelection": "Siirry valinnan alkuun",
+        "selectionStart": "Valinnan aloituskahva",
+        "selectionEnd": "Valinnan lopetuskahva",
+        "lossless": "Häviötön",
+        "lossy": "Häviöllinen",
+        "extractClip": "Lataa valittu leike",
+        "clearSelection": "Tyhjennä valinta",
+        "extracting": "Puretaan leikettä...",
+        "extractError": "Leikkeen purku epäonnistui",
+        "formatLabel": "Muoto",
         "rangeLabel": "{start}s – {end}s"
       },
       "processing": {
-        "playSelection": "Play selection",
-        "skipToStart": "Skip to selection start",
-        "clearSelection": "Clear selection",
-        "gain": "Gain (dB)",
-        "denoise": "Denoise",
-        "denoiseOff": "Off",
-        "denoiseLight": "Light",
-        "denoiseMedium": "Medium",
-        "denoiseHeavy": "Heavy",
-        "normalize": "Normalize audio",
-        "normalizeTooltip": "EBU R128 Normalization",
-        "export": "Export",
+        "playSelection": "Toista valinta",
+        "skipToStart": "Siirry valinnan alkuun",
+        "clearSelection": "Tyhjennä valinta",
+        "gain": "Vahvistus (dB)",
+        "denoise": "Kohinanpoisto",
+        "denoiseOff": "Pois",
+        "denoiseLight": "Kevyt",
+        "denoiseMedium": "Keskitaso",
+        "denoiseHeavy": "Voimakas",
+        "normalize": "Normalisoi ääni",
+        "normalizeTooltip": "EBU R128 -normalisointi",
+        "export": "Vie",
         "exportOriginal": "Alkuperäinen",
-        "processingActive": "Processing active"
+        "processingActive": "Käsittely käynnissä"
       }
     },
     "weatherInfo": {
@@ -4146,20 +4146,20 @@
       }
     },
     "tls": {
-      "certificateInstalled": "Certificate Installed",
-      "browseFile": "Browse",
-      "subject": "Subject",
-      "issuer": "Issuer",
-      "sans": "Subject Alternative Names",
-      "validUntil": "Valid Until",
-      "daysRemaining": "Days Remaining",
-      "fingerprint": "Fingerprint",
-      "expiryWarning": "This certificate expires soon. Consider renewing it.",
-      "downloadCertificate": "Download Certificate",
-      "regenerateButton": "Regenerate",
-      "removeCertificate": "Remove Certificate",
-      "fileReadError": "Failed to read file",
-      "loading": "Loading certificate information..."
+      "certificateInstalled": "Sertifikaatti asennettu",
+      "browseFile": "Selaa",
+      "subject": "Kohde",
+      "issuer": "Myöntäjä",
+      "sans": "Vaihtoehtoiset nimet",
+      "validUntil": "Voimassa asti",
+      "daysRemaining": "Päiviä jäljellä",
+      "fingerprint": "Sormenjälki",
+      "expiryWarning": "Tämä sertifikaatti vanhenee pian. Harkitse sen uusimista.",
+      "downloadCertificate": "Lataa sertifikaatti",
+      "regenerateButton": "Luo uudelleen",
+      "removeCertificate": "Poista sertifikaatti",
+      "fileReadError": "Tiedoston lukeminen epäonnistui",
+      "loading": "Ladataan sertifikaattitietoja..."
     }
   },
   "connectivity": {
@@ -4173,7 +4173,7 @@
     }
   },
   "terminal": {
-    "title": "Terminaali",
+    "title": "Pääte",
     "disabled": "Terminaali on poistettu käytöstä",
     "disabledDescription": "Selainpääte on poistettu käytöstä. Ota se käyttöön Asetukset → Turvallisuus -kohdassa käyttääksesi tätä ominaisuutta.",
     "connected": "Yhdistetty",
@@ -4332,77 +4332,77 @@
     },
     "steps": {
       "welcome": {
-        "title": "Welcome",
-        "heading": "Welcome to BirdNET-Go!",
-        "description": "BirdNET-Go is a real-time bird sound identification system. It listens to audio from your microphone or audio stream and uses the BirdNET AI model to identify bird species.",
-        "credit": "Powered by the BirdNET Analyzer developed by the K. Lisa Yang Center for Conservation Bioacoustics at the Cornell Lab of Ornithology and Chemnitz University of Technology.",
-        "cta": "Let's set up your bird monitoring station."
+        "title": "Tervetuloa",
+        "heading": "Tervetuloa BirdNET-Go:hon!",
+        "description": "BirdNET-Go on reaaliaikainen lintulajien tunnistusjärjestelmä. Se kuuntelee ääntä mikrofonistasi tai äänilähetyksestä ja käyttää BirdNET-tekoälymallia lintulajien tunnistamiseen.",
+        "credit": "Perustuu BirdNET Analyzeriin, jonka on kehittänyt K. Lisa Yang Center for Conservation Bioacoustics Cornellin yliopiston ornitologian laboratoriossa ja Chemnitzin teknillisessä yliopistossa.",
+        "cta": "Määritetään lintuseuranta-asemasi."
       },
       "locationLanguage": {
-        "title": "Location & Language",
-        "uiLanguageLabel": "Interface Language",
-        "uiLanguageHelp": "Language used for the web interface",
-        "speciesLanguageLabel": "Species Name Language",
-        "speciesLanguageHelp": "Language used for bird species names in detections",
-        "locationLabel": "Station Location",
-        "locationHelp": "Your location helps filter species to those likely in your area",
-        "latitudeLabel": "Latitude",
-        "longitudeLabel": "Longitude",
-        "useMyLocation": "Use my location",
-        "locationDetected": "Location detected",
-        "locationError": "Could not detect location. Please enter coordinates manually.",
-        "locationDenied": "Location access denied. Please enter coordinates manually."
+        "title": "Sijainti ja kieli",
+        "uiLanguageLabel": "Käyttöliittymän kieli",
+        "uiLanguageHelp": "Verkkoliittymässä käytettävä kieli",
+        "speciesLanguageLabel": "Lajinimien kieli",
+        "speciesLanguageHelp": "Lajinimissä havainnoissa käytettävä kieli",
+        "locationLabel": "Aseman sijainti",
+        "locationHelp": "Sijaintisi auttaa suodattamaan alueellasi todennäköiset lajit",
+        "latitudeLabel": "Leveysaste",
+        "longitudeLabel": "Pituusaste",
+        "useMyLocation": "Käytä sijaintiani",
+        "locationDetected": "Sijainti havaittu",
+        "locationError": "Sijaintia ei voitu havaita. Syötä koordinaatit manuaalisesti.",
+        "locationDenied": "Sijainnin käyttö estetty. Syötä koordinaatit manuaalisesti."
       },
       "audioSource": {
-        "title": "Audio Source",
-        "sourceTypeLabel": "Source Type",
-        "soundcard": "Microphone / Soundcard",
-        "rtspStream": "RTSP Stream",
-        "deviceLabel": "Audio Device",
-        "deviceLoading": "Loading audio devices...",
-        "noDevicesFound": "No audio devices detected. Try configuring an RTSP stream instead.",
-        "rtspUrlLabel": "Stream URL",
+        "title": "Äänilähde",
+        "sourceTypeLabel": "Lähteen tyyppi",
+        "soundcard": "Mikrofoni / äänikortti",
+        "rtspStream": "RTSP-lähetys",
+        "deviceLabel": "Äänilaite",
+        "deviceLoading": "Ladataan äänilaitteita...",
+        "noDevicesFound": "Äänilaitteita ei havaittu. Kokeile RTSP-lähetyksen määritystä.",
+        "rtspUrlLabel": "Lähetyksen URL",
         "rtspUrlPlaceholder": "rtsp://user:password@host:port/stream",
-        "rtspUrlHelp": "Enter the URL of your RTSP audio stream",
-        "additionalSourcesHint": "You can add more audio sources later in Settings."
+        "rtspUrlHelp": "Syötä RTSP-äänilähetyksesi URL",
+        "additionalSourcesHint": "Voit lisätä äänilähteitä myöhemmin Asetuksissa."
       },
       "detection": {
-        "title": "Detection Threshold",
-        "description": "Choose how strict the bird identification should be. You can adjust this later in Settings.",
-        "balanced": "Balanced",
-        "balancedDesc": "Good balance of accuracy and sensitivity",
-        "balancedRecommended": "Recommended",
-        "highAccuracy": "High Accuracy",
-        "highAccuracyDesc": "Fewer false positives, may miss some birds",
-        "highSensitivity": "High Sensitivity",
-        "highSensitivityDesc": "More detections, more false positives",
-        "threshold": "Confidence threshold",
-        "fpFilterNote": "Once your system is running and proven, you can enable the false positive filter in Settings to further reduce incorrect detections."
+        "title": "Tunnistuskynnys",
+        "description": "Valitse, kuinka tarkka lintutunnistuksen tulee olla. Voit säätää tätä myöhemmin Asetuksissa.",
+        "balanced": "Tasapainoinen",
+        "balancedDesc": "Hyvä tasapaino tarkkuuden ja herkkyyden välillä",
+        "balancedRecommended": "Suositeltu",
+        "highAccuracy": "Korkea tarkkuus",
+        "highAccuracyDesc": "Vähemmän vääriä havaintoja, saattaa ohittaa joitakin lintuja",
+        "highSensitivity": "Korkea herkkyys",
+        "highSensitivityDesc": "Enemmän havaintoja, enemmän vääriä positiivisia",
+        "threshold": "Luottamuskynnys",
+        "fpFilterNote": "Kun järjestelmäsi on toiminnassa ja todettu toimivaksi, voit ottaa väärien positiivisten suodattimen käyttöön Asetuksissa vähentääksesi virheellisiä havaintoja entisestään."
       },
       "integration": {
-        "title": "Privacy & Integration",
-        "privacyFilterLabel": "Enable privacy filter",
-        "privacyFilterHelp": "Filters out detections when human voices are detected near the microphone",
-        "birdweatherLabel": "Share detections with BirdWeather",
-        "birdweatherHelp": "Contribute your bird detections to the BirdWeather community network",
-        "birdweatherIdLabel": "BirdWeather Station ID",
-        "birdweatherIdPlaceholder": "Enter your BirdWeather station ID",
-        "errorReportingLabel": "Send anonymous error reports",
-        "errorReportingHelp": "Help improve BirdNET-Go by sending anonymous error reports when something goes wrong"
+        "title": "Yksityisyys ja integraatiot",
+        "privacyFilterLabel": "Ota yksityisyyssuodatin käyttöön",
+        "privacyFilterHelp": "Suodattaa havainnot, kun mikrofonin lähellä havaitaan ihmisen puhetta",
+        "birdweatherLabel": "Jaa havainnot BirdWeatheriin",
+        "birdweatherHelp": "Osallistu lintuhavainnoillasi BirdWeather-yhteisöverkkoon",
+        "birdweatherIdLabel": "BirdWeather-aseman ID",
+        "birdweatherIdPlaceholder": "Syötä BirdWeather-asemasi ID",
+        "errorReportingLabel": "Lähetä nimettömiä virheilmoituksia",
+        "errorReportingHelp": "Auta parantamaan BirdNET-Go:ta lähettämällä nimettömiä virheilmoituksia ongelmatilanteissa"
       },
       "responsibleUse": {
-        "title": "Using BirdNET-Go Responsibly",
-        "intro": "BirdNET-Go is a powerful tool that enhances your birding experience through AI-assisted identification. To ensure the best outcomes for both birding and conservation:",
-        "point1": "Review and verify detections before sharing observations",
-        "point2": "Use the confidence scores as a guide, not absolute truth",
-        "point3": "Cross-reference with field guides and local expertise",
-        "point4": "Consider seasonal patterns and habitat suitability",
-        "citizenScienceHeading": "When contributing to citizen science:",
-        "citizenPoint1": "Only submit observations you have personally verified",
-        "citizenPoint2": "Include notes about visual or behavioral confirmation",
-        "citizenPoint3": "Use AI detections as a starting point for your own observations",
-        "outro": "This approach ensures data quality for scientific research while maximizing your learning and enjoyment of birds.",
-        "acknowledge": "I understand"
+        "title": "BirdNET-Go:n vastuullinen käyttö",
+        "intro": "BirdNET-Go on tehokas työkalu, joka parantaa lintuhavaintokokemustasi tekoälyavusteisen tunnistuksen avulla. Parhaiden tulosten saavuttamiseksi sekä lintuharrastuksessa että luonnonsuojelussa:",
+        "point1": "Tarkista ja varmista havainnot ennen jakamista",
+        "point2": "Käytä luottamuspisteitä ohjeena, ei ehdottomana totuutena",
+        "point3": "Vertaa kenttäoppaisiin ja paikalliseen asiantuntemukseen",
+        "point4": "Huomioi vuodenaikaiset mallit ja elinympäristön sopivuus",
+        "citizenScienceHeading": "Kansalaistieteeseen osallistuessa:",
+        "citizenPoint1": "Lähetä vain henkilökohtaisesti varmistamasi havainnot",
+        "citizenPoint2": "Lisää huomioita visuaalisesta tai käyttäytymisen vahvistuksesta",
+        "citizenPoint3": "Käytä tekoälyhavaintoja omien havaintojesi lähtökohtana",
+        "outro": "Tämä lähestymistapa varmistaa tiedon laadun tieteelliseen tutkimukseen ja maksimoi lintuharrastuksesi oppimisen ja nautinnon.",
+        "acknowledge": "Ymmärrän"
       }
     }
   },

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -377,8 +377,8 @@
         "application": "Erreur d'application",
         "imageProvider": "Avis du fournisseur d'images",
         "categoryError": "Erreur {category}",
-        "burstTitle": "Multiple {component} errors",
-        "burstMessage": "{count} errors in the last {window_minutes} minutes: {sample_error}"
+        "burstTitle": "Erreurs multiples de {component}",
+        "burstMessage": "{count} erreurs au cours des dernières {window_minutes} minutes : {sample_error}"
       },
       "settings": {
         "reloadingBirdnet": "Application des nouveaux paramètres d'analyse...",
@@ -388,7 +388,7 @@
         "reconfiguringBirdweather": "Mise à jour de l'intégration BirdWeather...",
         "reconfiguringStreams": "Mise à jour des flux audio...",
         "reconfiguringTelemetry": "Mise à jour des paramètres de télémétrie...",
-        "reconfiguringPushNotifications": "Reconfiguring push notification providers...",
+        "reconfiguringPushNotifications": "Reconfiguration des fournisseurs de notifications push...",
         "reconfiguringSpeciesTracking": "Mise à jour du suivi des espèces...",
         "recalculatingThresholds": "Recalcul des seuils dynamiques pour la nouvelle valeur de base",
         "reconfiguringDynamicThresholds": "Reconfiguration des seuils dynamiques...",
@@ -776,17 +776,17 @@
       "showing": "Affichage de {from} à {to} sur {total} résultats"
     },
     "weather": {
-      "title": "Weather Information",
-      "noData": "No weather data",
-      "noDataAvailable": "No weather data available",
-      "loading": "Loading weather information...",
+      "title": "Informations météo",
+      "noData": "Aucune donnée météo",
+      "noDataAvailable": "Aucune donnée météo disponible",
+      "loading": "Chargement des informations météo...",
       "labels": {
-        "temperature": "Temperature",
-        "weather": "Weather",
-        "wind": "Wind",
-        "humidity": "Humidity",
-        "pressure": "Pressure",
-        "cloudCover": "Cloud Cover"
+        "temperature": "Température",
+        "weather": "Météo",
+        "wind": "Vent",
+        "humidity": "Humidité",
+        "pressure": "Pression",
+        "cloudCover": "Couverture nuageuse"
       },
       "units": {
         "temperature": "°C",
@@ -930,31 +930,31 @@
   },
   "spectrogram": {
     "controls": {
-      "frequencyRange": "Frequency Range",
-      "colorMap": "Color Map",
+      "frequencyRange": "Plage de fréquence",
+      "colorMap": "Carte de couleurs",
       "gain": "Gain",
       "gainTooltip": "Gain de visualisation du spectrogramme",
       "mute": "Couper la sortie audio",
       "unmute": "Activer la sortie audio",
-      "frequencyRangeMin": "Minimum frequency",
-      "frequencyRangeMax": "Maximum frequency"
+      "frequencyRangeMin": "Fréquence minimale",
+      "frequencyRangeMax": "Fréquence maximale"
     },
     "error": {
-      "unsupported": "Your browser does not support audio analysis",
-      "connectionFailed": "Failed to connect to live audio stream",
-      "accessDenied": "Live audio access requires authentication. Please log in to use this feature."
+      "unsupported": "Votre navigateur ne prend pas en charge l'analyse audio",
+      "connectionFailed": "Échec de la connexion au flux audio en direct",
+      "accessDenied": "L'accès au flux audio en direct nécessite une authentification. Veuillez vous connecter pour utiliser cette fonctionnalité."
     },
     "dashboard": {
-      "toggle": "Live Spectrogram",
-      "audioToggle": "Enable audio"
+      "toggle": "Spectrogramme en direct",
+      "audioToggle": "Activer l'audio"
     },
     "gain": {
       "muted": "Muet",
       "level": "Gain : {value} dB"
     },
     "page": {
-      "title": "Live Audio",
-      "sourceLabel": "Audio Source",
+      "title": "Audio en direct",
+      "sourceLabel": "Source audio",
       "connected": "Connecté",
       "enterFullscreen": "Plein écran",
       "exitFullscreen": "Quitter le plein écran"
@@ -962,7 +962,7 @@
     "colorMaps": {
       "inferno": "Inferno",
       "viridis": "Viridis",
-      "grayscale": "Grayscale"
+      "grayscale": "Niveaux de gris"
     },
     "labels": {
       "toggle": "Basculer les étiquettes de détection"
@@ -980,7 +980,7 @@
       "os": "Système d'exploitation",
       "hostname": "Nom d'hôte",
       "uptime": "Temps de fonctionnement",
-      "cpus": "Processeurs",
+      "cpus": "CPUs",
       "model": "Modèle système",
       "timezone": "Fuseau horaire",
       "temperature": "Température du processeur",
@@ -1287,70 +1287,70 @@
         "fetchFailed": "Échec de la récupération des statistiques de la base de données"
       },
       "dashboard": {
-        "title": "Database Dashboard",
-        "fetchFailed": "Failed to fetch database overview",
+        "title": "Tableau de bord de la base de données",
+        "fetchFailed": "Échec de la récupération de l'aperçu de la base de données",
         "metrics": {
-          "readLatency": "Read Latency",
-          "writeLatency": "Write Latency",
-          "queriesPerSec": "Queries/sec",
-          "database": "Database",
-          "avg": "avg",
+          "readLatency": "Latence de lecture",
+          "writeLatency": "Latence d'écriture",
+          "queriesPerSec": "Requêtes/sec",
+          "database": "Base de données",
+          "avg": "moy.",
           "max": "max",
-          "lastHour": "{count} last hour",
-          "slowQueries": "{count} slow"
+          "lastHour": "{count} dernière heure",
+          "slowQueries": "{count} lentes"
         },
         "details": {
-          "title": "Database Details",
-          "engine": "Engine",
+          "title": "Détails de la base de données",
+          "engine": "Moteur",
           "journal": "Journal",
-          "pageSize": "Page size",
-          "cacheHit": "Cache hit",
-          "integrity": "Integrity",
-          "lastVacuum": "Last VACUUM"
+          "pageSize": "Taille de page",
+          "cacheHit": "Taux de cache",
+          "integrity": "Intégrité",
+          "lastVacuum": "Dernier VACUUM"
         },
         "locksWal": {
-          "title": "Locks & WAL",
-          "lockWaits": "Lock waits",
-          "lockTimeouts": "Lock timeouts",
-          "avgWait": "Avg wait",
-          "busyTimeouts": "Busy timeouts",
-          "walSize": "WAL size",
-          "checkpoints": "Checkpoints",
-          "freelistPages": "Freelist pages",
-          "cacheSize": "Cache size"
+          "title": "Verrous et WAL",
+          "lockWaits": "Attentes de verrou",
+          "lockTimeouts": "Délais de verrou",
+          "avgWait": "Attente moy.",
+          "busyTimeouts": "Délais d'occupation",
+          "walSize": "Taille WAL",
+          "checkpoints": "Points de contrôle",
+          "freelistPages": "Pages libres",
+          "cacheSize": "Taille du cache"
         },
         "connectionPool": {
-          "title": "Connection Pool",
-          "poolUsage": "Pool Usage",
-          "active": "active",
-          "idle": "idle",
-          "waiting": "waiting",
-          "totalCreated": "Total created",
-          "connErrors": "Conn errors",
+          "title": "Pool de connexions",
+          "poolUsage": "Utilisation du pool",
+          "active": "actives",
+          "idle": "inactives",
+          "waiting": "en attente",
+          "totalCreated": "Total créées",
+          "connErrors": "Erreurs de connexion",
           "threads": "Threads",
-          "running": "running",
-          "cached": "cached"
+          "running": "en cours",
+          "cached": "en cache"
         },
         "innodb": {
-          "title": "InnoDB & Locks",
-          "bufferPoolHitRate": "Buffer pool hit rate",
-          "bufferPoolSize": "Buffer pool size",
-          "lockWaits": "Lock waits",
+          "title": "InnoDB et verrous",
+          "bufferPoolHitRate": "Taux de succès du buffer pool",
+          "bufferPoolSize": "Taille du buffer pool",
+          "lockWaits": "Attentes de verrou",
           "deadlocks": "Deadlocks",
-          "avgLockWait": "Avg lock wait",
-          "tableLocksWaited": "Table locks waited",
-          "tableLocksImmediate": "Table locks immediate"
+          "avgLockWait": "Attente moy. de verrou",
+          "tableLocksWaited": "Verrous de table en attente",
+          "tableLocksImmediate": "Verrous de table immédiats"
         },
         "detectionRate": {
-          "title": "Detection Rate (24h)",
-          "perHour": "/hr",
+          "title": "Taux de détection (24h)",
+          "perHour": "/h",
           "min": "min",
-          "avg": "avg",
+          "avg": "moy.",
           "max": "max",
-          "lastBackup": "Last backup",
-          "backupSize": "Backup size",
-          "createBackup": "Create Backup",
-          "mysqlHost": "Host",
+          "lastBackup": "Dernière sauvegarde",
+          "backupSize": "Taille de la sauvegarde",
+          "createBackup": "Créer une sauvegarde",
+          "mysqlHost": "Hôte",
           "mysqlBackupNote": "Les sauvegardes MySQL doivent être gérées via mysqldump ou vos outils d'administration MySQL.",
           "chartLabel": "Taux de détection sur 24 heures",
           "detectionsTooltip": "{count} détections"
@@ -1359,10 +1359,10 @@
           "title": "Tables",
           "total": "Total",
           "table": "Table",
-          "engine": "Engine",
-          "rows": "Rows",
-          "size": "Size",
-          "usage": "Usage"
+          "engine": "Moteur",
+          "rows": "Lignes",
+          "size": "Taille",
+          "usage": "Utilisation"
         },
         "loading": "Chargement..."
       },
@@ -2241,7 +2241,7 @@
           "pushover": "Pushover",
           "gotify": "Gotify",
           "ntfy": "ntfy",
-          "email": "Email",
+          "email": "E-mail",
           "generic": "Shoutrrr",
           "numbered": "{service} #{number}"
         },
@@ -2251,25 +2251,25 @@
           "discord": {
             "name": "Discord",
             "webhookUrl": {
-              "label": "URL Webhook Discord",
+              "label": "URL du webhook Discord",
               "placeholder": "https://discord.com/api/webhooks/...",
-              "helpText": "Collez votre URL webhook Discord complète"
+              "helpText": "Collez l'URL complète de votre webhook Discord"
             },
-            "invalidUrl": "URL webhook Discord invalide. L'URL doit contenir discord.com/api/webhooks/"
+            "invalidUrl": "URL de webhook Discord invalide. L'URL doit contenir discord.com/api/webhooks/"
           },
           "telegram": {
             "name": "Telegram",
             "botToken": {
               "label": "Token du bot",
               "placeholder": "123456789:ABCdef...",
-              "helpText": "Token fourni par @BotFather"
+              "helpText": "Token de @BotFather"
             },
             "chatId": {
-              "label": "ID de discussion",
-              "placeholder": "-1001234567890 ou @canal",
-              "helpText": "ID de discussion, ID de groupe ou @nomutilisateur"
+              "label": "ID du chat",
+              "placeholder": "-1001234567890 ou @channel",
+              "helpText": "ID du chat, ID du groupe ou @nomdutilisateur"
             },
-            "incomplete": "Le token du bot et l'ID de discussion sont tous deux requis"
+            "incomplete": "Le token du bot et l'ID du chat sont tous deux requis"
           },
           "ntfy": {
             "name": "ntfy",
@@ -2300,7 +2300,7 @@
             },
             "topic": {
               "label": "Sujet",
-              "placeholder": "mes-alertes-oiseaux",
+              "placeholder": "my-bird-alerts",
               "helpText": "Nom du sujet pour vos notifications"
             },
             "incomplete": "Le sujet est requis"
@@ -2309,13 +2309,13 @@
             "name": "Gotify",
             "server": {
               "label": "URL du serveur",
-              "placeholder": "gotify.exemple.com",
-              "helpText": "Le nom d'hôte de votre serveur Gotify (sans https://)"
+              "placeholder": "gotify.example.com",
+              "helpText": "Nom d'hôte de votre serveur Gotify (sans https://)"
             },
             "token": {
               "label": "Token d'application",
               "placeholder": "A...",
-              "helpText": "Token depuis la page Apps de Gotify"
+              "helpText": "Token de la page des applications Gotify"
             },
             "incomplete": "Le serveur et le token sont requis"
           },
@@ -2329,29 +2329,29 @@
             "userKey": {
               "label": "Clé utilisateur",
               "placeholder": "u...",
-              "helpText": "Votre clé d'utilisateur ou de groupe"
+              "helpText": "Votre clé utilisateur ou de groupe"
             },
             "incomplete": "Le token API et la clé utilisateur sont requis"
           },
           "slack": {
             "name": "Slack",
             "webhookUrl": {
-              "label": "URL Webhook Slack",
+              "label": "URL du webhook Slack",
               "placeholder": "https://hooks.slack.com/services/...",
-              "helpText": "Collez votre URL webhook Slack complète"
+              "helpText": "Collez l'URL complète de votre webhook Slack"
             },
-            "invalidUrl": "URL webhook Slack invalide. L'URL doit contenir hooks.slack.com/services/"
+            "invalidUrl": "URL de webhook Slack invalide. L'URL doit contenir hooks.slack.com/services/"
           },
           "ifttt": {
             "name": "IFTTT",
             "webhookKey": {
-              "label": "Clé Webhook",
+              "label": "Clé webhook",
               "placeholder": "abc123xyz...",
-              "helpText": "Votre clé Webhook IFTTT depuis les paramètres Maker Webhooks"
+              "helpText": "Votre clé webhook IFTTT depuis les paramètres Maker Webhooks"
             },
             "eventName": {
               "label": "Nom de l'événement",
-              "placeholder": "oiseau_detecte",
+              "placeholder": "bird_detected",
               "helpText": "Le nom de l'événement à déclencher dans votre applet IFTTT"
             },
             "incomplete": "La clé webhook et le nom de l'événement sont requis"
@@ -2359,9 +2359,9 @@
           "webhook": {
             "name": "Webhook",
             "url": {
-              "label": "URL Webhook",
-              "placeholder": "https://api.exemple.com/webhook",
-              "helpText": "Le point de terminaison HTTP(S) vers lequel envoyer les notifications"
+              "label": "URL du webhook",
+              "placeholder": "https://api.example.com/webhook",
+              "helpText": "Le point de terminaison HTTP(S) pour envoyer les notifications"
             },
             "method": {
               "label": "Méthode HTTP",
@@ -2372,23 +2372,23 @@
               "none": "Aucune",
               "bearer": "Token Bearer",
               "basic": "Authentification basique",
-              "helpText": "Authentification optionnelle pour le point de terminaison webhook"
+              "helpText": "Authentification optionnelle pour le point de terminaison du webhook"
             },
             "bearerToken": {
               "label": "Token Bearer",
-              "placeholder": "votre-token-api",
+              "placeholder": "your-api-token",
               "helpText": "Token envoyé dans l'en-tête Authorization: Bearer"
             },
             "basicUser": {
               "label": "Nom d'utilisateur",
-              "placeholder": "nom_utilisateur"
+              "placeholder": "username"
             },
             "basicPass": {
               "label": "Mot de passe",
-              "placeholder": "mot_de_passe"
+              "placeholder": "password"
             },
             "basicAuth": {
-              "helpText": "Identifiants envoyés en utilisant l'authentification HTTP basique"
+              "helpText": "Identifiants envoyés via l'authentification HTTP basique"
             },
             "invalidUrl": "URL invalide. Doit commencer par http:// ou https://",
             "tokenRequired": "Le token Bearer est requis lors de l'utilisation de l'authentification Bearer",
@@ -2398,8 +2398,8 @@
             "name": "URL personnalisée",
             "url": {
               "label": "URL Shoutrrr",
-              "placeholder": "service://identifiants@hote",
-              "helpText": "Entrez une URL Shoutrrr brute pour n'importe quel service pris en charge"
+              "placeholder": "service://credentials@host",
+              "helpText": "Entrez une URL Shoutrrr pour tout service pris en charge"
             },
             "invalidUrl": "Format d'URL invalide. L'URL doit commencer par service://"
           }
@@ -2535,29 +2535,29 @@
           "skipVerify": "Ignorer la vérification du certificat",
           "configNote": "<strong>Configuration TLS :</strong><br />• TLS standard : Laissez les certificats vides pour les courtiers publics<br />• Certificats auto-signés : Fournissez le certificat CA<br />• TLS mutuel (mTLS) : Fournissez les trois certificats",
           "certificates": {
-            "title": "Certificate Management",
-            "description": "Upload certificates for secure MQTT broker connections",
-            "caLabel": "CA Certificate",
+            "title": "Gestion des certificats",
+            "description": "Téléversez des certificats pour les connexions sécurisées au courtier MQTT",
+            "caLabel": "Certificat CA",
             "caPlaceholder": "-----BEGIN CERTIFICATE-----",
-            "caHelpText": "Certificate Authority certificate to verify the broker's identity",
-            "clientCertLabel": "Client Certificate",
+            "caHelpText": "Certificat de l'autorité de certification pour vérifier l'identité du courtier",
+            "clientCertLabel": "Certificat client",
             "clientCertPlaceholder": "-----BEGIN CERTIFICATE-----",
-            "clientCertHelpText": "Client certificate for mutual TLS authentication",
-            "clientKeyLabel": "Client Private Key",
+            "clientCertHelpText": "Certificat client pour l'authentification TLS mutuelle",
+            "clientKeyLabel": "Clé privée du client",
             "clientKeyPlaceholder": "-----BEGIN PRIVATE KEY-----",
-            "clientKeyHelpText": "Private key matching the client certificate",
-            "uploadButton": "Upload Certificates",
-            "uploadSuccess": "MQTT TLS certificates uploaded successfully. Use Test Connection to verify.",
-            "uploadError": "Failed to upload MQTT TLS certificates",
-            "deleteConfirm": "Remove all MQTT TLS certificates? The MQTT client will need to reconnect.",
-            "deleteSuccess": "MQTT TLS certificates removed",
-            "deleteError": "Failed to remove MQTT TLS certificates",
-            "loadError": "Failed to load certificate information",
-            "reconnectNote": "Use the Test Connection button below to verify the new TLS configuration."
+            "clientKeyHelpText": "Clé privée correspondant au certificat client",
+            "uploadButton": "Téléverser les certificats",
+            "uploadSuccess": "Certificats TLS MQTT téléversés avec succès. Utilisez le test de connexion pour vérifier.",
+            "uploadError": "Échec du téléversement des certificats TLS MQTT",
+            "deleteConfirm": "Supprimer tous les certificats TLS MQTT ? Le client MQTT devra se reconnecter.",
+            "deleteSuccess": "Certificats TLS MQTT supprimés",
+            "deleteError": "Échec de la suppression des certificats TLS MQTT",
+            "loadError": "Échec du chargement des informations du certificat",
+            "reconnectNote": "Utilisez le bouton de test de connexion ci-dessous pour vérifier la nouvelle configuration TLS."
           }
         },
         "homeAssistant": {
-          "title": "Home Assistant Auto-Discovery",
+          "title": "Découverte automatique Home Assistant",
           "enable": "Activer Home Assistant MQTT Discovery",
           "description": "Lorsqu'elle est activée, BirdNET-Go enregistre automatiquement les appareils et capteurs auprès de Home Assistant via le protocole de découverte MQTT. Les appareils apparaîtront dans le registre des appareils de Home Assistant sans configuration YAML manuelle.",
           "discoveryPrefix": {
@@ -2697,14 +2697,14 @@
           "helpText": "Durée de mise en cache des données taxonomiques d'eBird. La taxonomie change rarement, donc des durées plus longues réduisent les appels API."
         },
         "note": "eBird fournit des données taxonomiques utilisées pour la classification des espèces et les analyses. La clé API est gratuite et disponible auprès du Cornell Lab of Ornithology.",
-        "apiKeyInfo": "A personal eBird API key is required to use this integration. You can request a free key from <a href=\"https://ebird.org/api/keygen\" class=\"link link-primary\" target=\"_blank\" rel=\"noopener noreferrer\">ebird.org/api/keygen</a>.",
+        "apiKeyInfo": "Une clé API eBird personnelle est requise pour utiliser cette intégration. Vous pouvez demander une clé gratuite sur <a href=\"https://ebird.org/api/keygen\" class=\"link link-primary\" target=\"_blank\" rel=\"noopener noreferrer\">ebird.org/api/keygen</a>.",
         "test": {
-          "button": "Test eBird Connection",
-          "loading": "Testing...",
-          "enabledRequired": "Enable eBird integration first",
-          "apiKeyRequired": "API key is required",
-          "inProgress": "Test in progress...",
-          "description": "Test eBird API connectivity and authentication"
+          "button": "Tester la connexion eBird",
+          "loading": "Test en cours...",
+          "enabledRequired": "Activez d'abord l'intégration eBird",
+          "apiKeyRequired": "La clé API est requise",
+          "inProgress": "Test en cours...",
+          "description": "Tester la connectivité et l'authentification de l'API eBird"
         }
       }
     },
@@ -3152,9 +3152,9 @@
           "enableLabel": "Autoriser la connexion OAuth2 via LINE",
           "redirectUriTitle": "URI de redirection pour LINE Developers Console:",
           "getCredentialsLabel": "Obtenir vos identifiants depuis LINE Developers Console",
-          "clientIdLabel": "Channel ID",
+          "clientIdLabel": "ID du canal",
           "clientIdHelpText": "Le Channel ID obtenu depuis LINE Developers Console lors de la configuration de LINE Login.",
-          "clientSecretLabel": "Channel Secret",
+          "clientSecretLabel": "Secret du canal",
           "clientSecretHelpText": "Le Channel Secret obtenu depuis LINE Developers Console lors de la configuration de LINE Login.",
           "userIdLabel": "ID utilisateur"
         },
@@ -3163,29 +3163,29 @@
           "enableLabel": "Autoriser la connexion OAuth2 via Kakao",
           "redirectUriTitle": "URI de redirection pour Kakao Developers Console:",
           "getCredentialsLabel": "Obtenir vos identifiants depuis Kakao Developers Console",
-          "clientIdLabel": "REST API Key",
+          "clientIdLabel": "Clé API REST",
           "clientIdHelpText": "Le REST API Key obtenu depuis Kakao Developers Console lors de la configuration de Kakao Login.",
-          "clientSecretLabel": "Client Secret",
+          "clientSecretLabel": "Secret client",
           "clientSecretHelpText": "Le Client Secret obtenu depuis Kakao Developers Console lors de la configuration de Kakao Login.",
           "userIdLabel": "ID utilisateur"
         },
         "oidc": {
-          "title": "OIDC Provider",
-          "enableLabel": "Enable OIDC authentication",
-          "redirectUriTitle": "Redirect URI",
-          "getCredentialsLabel": "Configure in your Identity Provider",
-          "clientIdLabel": "Client ID",
-          "clientIdHelpText": "The client ID from your OIDC identity provider",
-          "clientSecretLabel": "Client Secret",
-          "clientSecretHelpText": "The client secret from your OIDC identity provider",
-          "userIdLabel": "Allowed User (email or sub claim)",
-          "issuerUrlLabel": "Issuer URL",
-          "issuerUrlHelpText": "The issuer URL of your OpenID Connect identity provider (e.g., https://auth.example.com)",
+          "title": "Fournisseur OIDC",
+          "enableLabel": "Activer l'authentification OIDC",
+          "redirectUriTitle": "URI de redirection",
+          "getCredentialsLabel": "Configurer dans votre fournisseur d'identité",
+          "clientIdLabel": "ID client",
+          "clientIdHelpText": "L'ID client de votre fournisseur d'identité OIDC",
+          "clientSecretLabel": "Secret client",
+          "clientSecretHelpText": "Le secret client de votre fournisseur d'identité OIDC",
+          "userIdLabel": "Utilisateur autorisé (email ou claim sub)",
+          "issuerUrlLabel": "URL de l'émetteur",
+          "issuerUrlHelpText": "L'URL de l'émetteur de votre fournisseur d'identité OpenID Connect (ex. : https://auth.example.com)",
           "issuerUrlPlaceholder": "https://auth.example.com",
-          "issuerUrlRequired": "Issuer URL is required for OIDC providers",
-          "issuerUrlInvalid": "Issuer URL must be a valid HTTP or HTTPS URL",
+          "issuerUrlRequired": "L'URL de l'émetteur est requise pour les fournisseurs OIDC",
+          "issuerUrlInvalid": "L'URL de l'émetteur doit être une URL HTTP ou HTTPS valide",
           "scopesLabel": "Scopes",
-          "scopesHelpText": "Comma-separated list of OIDC scopes (default: openid, profile, email)",
+          "scopesHelpText": "Liste de scopes OIDC séparés par des virgules (par défaut : openid, profile, email)",
           "scopesPlaceholder": "openid, profile, email"
         }
       },
@@ -3198,11 +3198,11 @@
         "title": "Exceptions"
       },
       "publicAccess": {
-        "title": "Public Access",
-        "description": "Allow specific features to be accessible without authentication.",
-        "liveAudioLabel": "Allow public live audio playback",
-        "liveAudioHelp": "When enabled, anyone can listen to live audio streams without logging in. Settings and deletion still require authentication.",
-        "warningText": "Enabling public access features exposes them to anyone who can reach this server. Only enable if you trust your network environment."
+        "title": "Accès public",
+        "description": "Permettre à certaines fonctionnalités d'être accessibles sans authentification.",
+        "liveAudioLabel": "Autoriser la lecture audio en direct publique",
+        "liveAudioHelp": "Lorsqu'activé, n'importe qui peut écouter les flux audio en direct sans se connecter. Les paramètres et la suppression nécessitent toujours une authentification.",
+        "warningText": "L'activation des fonctionnalités d'accès public les expose à quiconque peut accéder à ce serveur. N'activez que si vous faites confiance à votre environnement réseau."
       },
       "placeholders": {
         "baseUrl": "https://birdnet.example.com:5500",
@@ -3219,64 +3219,64 @@
       },
       "tls": {
         "title": "TLS / HTTPS",
-        "description": "Configure TLS/HTTPS encryption for secure connections",
-        "modeLabel": "TLS Mode",
-        "modeNone": "None (HTTP)",
+        "description": "Configurer le chiffrement TLS/HTTPS pour les connexions sécurisées",
+        "modeLabel": "Mode TLS",
+        "modeNone": "Aucun (HTTP)",
         "modeLetsEncrypt": "Let's Encrypt",
-        "modeManual": "Manual Certificate",
-        "modeSelfSigned": "Self-Signed",
-        "modeNoneDescription": "Plain HTTP without encryption",
-        "modeAutoTLSDescription": "Automatic certificate via Let's Encrypt",
-        "modeManualDescription": "Upload your own certificate and key",
-        "modeSelfSignedDescription": "Generate a self-signed certificate",
-        "portLabel": "HTTPS Port",
-        "portHelpText": "Port for HTTPS connections (default: 8443)",
-        "redirectToHttps": "Redirect HTTP to HTTPS",
-        "autoTLSRequirements": "Requires ports 80 and 443 to be accessible. On Linux, the process needs root or CAP_NET_BIND_SERVICE capability.",
-        "validityLabel": "Certificate Validity",
-        "validityHelpText": "How long the certificate should be valid",
-        "validity365d": "1 year",
-        "validity730d": "2 years",
-        "generateButton": "Generate Certificate",
-        "regenerateButton": "Regenerate Certificate",
-        "generating": "Generating...",
-        "certificateLabel": "Certificate (PEM)",
-        "privateKeyLabel": "Private Key (PEM)",
-        "caCertificateLabel": "CA Certificate (PEM, optional)",
-        "uploadButton": "Upload Certificate",
-        "uploading": "Uploading...",
-        "browseFile": "Browse...",
-        "plaintextWarning": "Warning: Your private key will be transmitted in plaintext over HTTP. Only upload certificates when connected via a trusted network or localhost.",
-        "certificateInstalled": "Installed Certificate",
-        "subject": "Subject",
-        "issuer": "Issuer",
-        "validFrom": "Valid From",
-        "validUntil": "Valid Until",
-        "daysRemaining": "Days Remaining",
-        "sans": "Subject Alternative Names",
-        "fingerprint": "Fingerprint",
-        "expiryWarning": "Certificate is expiring soon",
-        "loading": "Loading certificate info...",
-        "loadError": "Failed to load certificate info",
-        "generateSuccess": "Self-signed certificate generated successfully",
-        "generateError": "Failed to generate certificate",
-        "uploadSuccess": "Certificate uploaded successfully",
-        "uploadError": "Failed to upload certificate",
-        "deleteSuccess": "Certificate removed successfully",
-        "deleteError": "Failed to delete certificate",
-        "removeCertificate": "Remove Certificate",
-        "deleteConfirm": "Are you sure you want to remove the installed TLS certificate? The TLS mode will be reset to None.",
-        "restartRequired": "TLS changes require a server restart to take effect.",
-        "noCertificate": "No certificate installed",
-        "validity1825d": "5 years",
-        "autoTLSHostRequired": "A hostname is required for Let’s Encrypt. Enter your public domain name in the Host field above.",
-        "autoTLSNoIP": "Let’s Encrypt requires a domain name, not an IP address. Enter a public domain like birds.example.com.",
-        "autoTLSNeedsFQDN": "Let’s Encrypt requires a fully qualified domain name (e.g., birds.example.com), not a bare hostname.",
-        "autoTLSNoLocalhost": "Let’s Encrypt cannot issue certificates for localhost.",
-        "autoTLSPrivateTLD": "Let’s Encrypt cannot issue certificates for private domains ({tld} is not publicly resolvable).",
-        "downloadCertificate": "Download Certificate",
-        "downloadCertificateHelp": "Install this certificate in your operating system's trust store to avoid browser security warnings.",
-        "fileReadError": "Failed to read the selected file"
+        "modeManual": "Certificat manuel",
+        "modeSelfSigned": "Auto-signé",
+        "modeNoneDescription": "HTTP simple sans chiffrement",
+        "modeAutoTLSDescription": "Certificat automatique via Let's Encrypt",
+        "modeManualDescription": "Téléversez votre propre certificat et clé",
+        "modeSelfSignedDescription": "Générer un certificat auto-signé",
+        "portLabel": "Port HTTPS",
+        "portHelpText": "Port pour les connexions HTTPS (par défaut : 8443)",
+        "redirectToHttps": "Rediriger HTTP vers HTTPS",
+        "autoTLSRequirements": "Nécessite que les ports 80 et 443 soient accessibles. Sous Linux, le processus a besoin des droits root ou de la capacité CAP_NET_BIND_SERVICE.",
+        "validityLabel": "Validité du certificat",
+        "validityHelpText": "Durée de validité du certificat",
+        "validity365d": "1 an",
+        "validity730d": "2 ans",
+        "generateButton": "Générer le certificat",
+        "regenerateButton": "Régénérer le certificat",
+        "generating": "Génération...",
+        "certificateLabel": "Certificat (PEM)",
+        "privateKeyLabel": "Clé privée (PEM)",
+        "caCertificateLabel": "Certificat CA (PEM, optionnel)",
+        "uploadButton": "Téléverser le certificat",
+        "uploading": "Téléversement...",
+        "browseFile": "Parcourir...",
+        "plaintextWarning": "Avertissement : Votre clé privée sera transmise en clair via HTTP. Ne téléversez des certificats que lorsque vous êtes connecté via un réseau de confiance ou localhost.",
+        "certificateInstalled": "Certificat installé",
+        "subject": "Sujet",
+        "issuer": "Émetteur",
+        "validFrom": "Valide à partir de",
+        "validUntil": "Valide jusqu'au",
+        "daysRemaining": "Jours restants",
+        "sans": "Noms alternatifs du sujet",
+        "fingerprint": "Empreinte",
+        "expiryWarning": "Le certificat expire bientôt",
+        "loading": "Chargement des informations du certificat...",
+        "loadError": "Échec du chargement des informations du certificat",
+        "generateSuccess": "Certificat auto-signé généré avec succès",
+        "generateError": "Échec de la génération du certificat",
+        "uploadSuccess": "Certificat téléversé avec succès",
+        "uploadError": "Échec du téléversement du certificat",
+        "deleteSuccess": "Certificat supprimé avec succès",
+        "deleteError": "Échec de la suppression du certificat",
+        "removeCertificate": "Supprimer le certificat",
+        "deleteConfirm": "Êtes-vous sûr de vouloir supprimer le certificat TLS installé ? Le mode TLS sera réinitialisé à Aucun.",
+        "restartRequired": "Les modifications TLS nécessitent un redémarrage du serveur pour prendre effet.",
+        "noCertificate": "Aucun certificat installé",
+        "validity1825d": "5 ans",
+        "autoTLSHostRequired": "Un nom d'hôte est requis pour Let's Encrypt. Entrez votre nom de domaine public dans le champ Hôte ci-dessus.",
+        "autoTLSNoIP": "Let's Encrypt nécessite un nom de domaine, pas une adresse IP. Entrez un domaine public comme birds.example.com.",
+        "autoTLSNeedsFQDN": "Let's Encrypt nécessite un nom de domaine complet (ex. : birds.example.com), pas un simple nom d'hôte.",
+        "autoTLSNoLocalhost": "Let's Encrypt ne peut pas émettre de certificats pour localhost.",
+        "autoTLSPrivateTLD": "Let's Encrypt ne peut pas émettre de certificats pour les domaines privés ({tld} n'est pas résolvable publiquement).",
+        "downloadCertificate": "Télécharger le certificat",
+        "downloadCertificateHelp": "Installez ce certificat dans le magasin de confiance de votre système d'exploitation pour éviter les avertissements de sécurité du navigateur.",
+        "fileReadError": "Échec de la lecture du fichier sélectionné"
       }
     },
     "species": {
@@ -3439,8 +3439,8 @@
             "source": "Source",
             "clearParameters": "Effacer les paramètres"
           },
-          "placeholder": "Click buttons below to add parameters or type manually",
-          "tooltip": "Use buttons below or type directly (comma-separated)"
+          "placeholder": "Cliquez sur les boutons ci-dessous pour ajouter des paramètres ou saisissez manuellement",
+          "tooltip": "Utilisez les boutons ci-dessous ou saisissez directement (séparés par des virgules)"
         },
         "executeDefaults": {
           "label": "Exécuter également les actions par défaut (stockage en base de données, notifications, etc.)",
@@ -3592,7 +3592,7 @@
         "expand": "Afficher l'historique des événements",
         "collapse": "Masquer l'historique des événements"
       },
-      "suggestions": "Species suggestions"
+      "suggestions": "Suggestions d'espèces"
     },
     "database": {
       "sqlitePlaceholder": "Entrez le chemin de la base de données SQLite",
@@ -3755,7 +3755,7 @@
           "stream_url": "URL du flux",
           "device_name": "Nom de l'appareil",
           "error": "Message d'erreur",
-          "broker": "Broker"
+          "broker": "Courtier"
         },
         "operators": {
           "is": "est",
@@ -3838,7 +3838,7 @@
         "appearance": "Apparence",
         "language": "Langue et régional",
         "visualContent": "Contenu visuel",
-        "audioPlayback": "Audio Playback"
+        "audioPlayback": "Lecture audio"
       },
       "appearance": {
         "title": "Apparence",
@@ -3853,14 +3853,14 @@
         "description": "Configurez les images d'oiseaux et les paramètres d'affichage du spectrogramme"
       },
       "audioPlayback": {
-        "title": "Audio Playback",
-        "description": "Default settings for playing bird recordings.",
-        "defaultGain": "Default Volume Boost",
-        "defaultGainHelpText": "Initial gain applied when playing recordings. Bird sounds are often quiet, so a boost of 6-12 dB is recommended.",
+        "title": "Lecture audio",
+        "description": "Paramètres par défaut pour la lecture des enregistrements d'oiseaux.",
+        "defaultGain": "Amplification du volume par défaut",
+        "defaultGainHelpText": "Gain initial appliqué lors de la lecture des enregistrements. Les sons d'oiseaux sont souvent faibles, une amplification de 6 à 12 dB est recommandée.",
         "defaultGainUnit": "dB"
       }
     },
-    "restartRequired": "Some changes require a server restart to take effect. Please restart BirdNET-Go."
+    "restartRequired": "Certaines modifications nécessitent un redémarrage du serveur pour prendre effet. Veuillez redémarrer BirdNET-Go."
   },
   "auth": {
     "login": "Connexion",
@@ -3881,7 +3881,7 @@
     "continueWithMicrosoft": "Continuer avec Microsoft",
     "continueWithLine": "Continuer avec LINE",
     "continueWithKakao": "Continuer avec Kakao",
-    "continueWithOidc": "Continue with OIDC",
+    "continueWithOidc": "Continuer avec OIDC",
     "errors": {
       "loginFailed": "Échec de la connexion. Veuillez vérifier votre mot de passe et réessayer.",
       "passwordRequired": "Le mot de passe est requis.",
@@ -4029,7 +4029,7 @@
       "seekProgress": "Progression de la lecture audio : {current} / {total} secondes",
       "playbackSpeed": "Vitesse de lecture",
       "speed": "Vitesse",
-      "loop": "Toggle loop",
+      "loop": "Basculer la boucle",
       "player": "Lecteur audio"
     },
     "spectrogram": {
@@ -4108,36 +4108,36 @@
         "spectrogramFailed": "Échec de la génération du spectrogramme"
       },
       "clipExtraction": {
-        "selectRange": "Click and drag to select a range",
-        "playSelection": "Play selected range",
-        "pauseSelection": "Pause playback",
-        "reviewSelection": "Jump to start of selection",
-        "selectionStart": "Selection start handle",
-        "selectionEnd": "Selection end handle",
-        "lossless": "Lossless",
-        "lossy": "Lossy",
-        "extractClip": "Download selected clip",
-        "clearSelection": "Clear selection",
-        "extracting": "Extracting clip...",
-        "extractError": "Failed to extract clip",
+        "selectRange": "Cliquez et faites glisser pour sélectionner une plage",
+        "playSelection": "Lire la plage sélectionnée",
+        "pauseSelection": "Mettre en pause la lecture",
+        "reviewSelection": "Aller au début de la sélection",
+        "selectionStart": "Poignée de début de sélection",
+        "selectionEnd": "Poignée de fin de sélection",
+        "lossless": "Sans perte",
+        "lossy": "Avec perte",
+        "extractClip": "Télécharger le clip sélectionné",
+        "clearSelection": "Effacer la sélection",
+        "extracting": "Extraction du clip...",
+        "extractError": "Échec de l'extraction du clip",
         "formatLabel": "Format",
         "rangeLabel": "{start}s – {end}s"
       },
       "processing": {
-        "playSelection": "Play selection",
-        "skipToStart": "Skip to selection start",
-        "clearSelection": "Clear selection",
+        "playSelection": "Lire la sélection",
+        "skipToStart": "Aller au début de la sélection",
+        "clearSelection": "Effacer la sélection",
         "gain": "Gain (dB)",
-        "denoise": "Denoise",
-        "denoiseOff": "Off",
-        "denoiseLight": "Light",
-        "denoiseMedium": "Medium",
-        "denoiseHeavy": "Heavy",
-        "normalize": "Normalize audio",
-        "normalizeTooltip": "EBU R128 Normalization",
-        "export": "Export",
+        "denoise": "Réduction du bruit",
+        "denoiseOff": "Désactivé",
+        "denoiseLight": "Léger",
+        "denoiseMedium": "Moyen",
+        "denoiseHeavy": "Fort",
+        "normalize": "Normaliser l'audio",
+        "normalizeTooltip": "Normalisation EBU R128",
+        "export": "Exporter",
         "exportOriginal": "Original",
-        "processingActive": "Processing active"
+        "processingActive": "Traitement actif"
       }
     },
     "weatherInfo": {
@@ -4146,20 +4146,20 @@
       }
     },
     "tls": {
-      "certificateInstalled": "Certificate Installed",
-      "browseFile": "Browse",
-      "subject": "Subject",
-      "issuer": "Issuer",
-      "sans": "Subject Alternative Names",
-      "validUntil": "Valid Until",
-      "daysRemaining": "Days Remaining",
-      "fingerprint": "Fingerprint",
-      "expiryWarning": "This certificate expires soon. Consider renewing it.",
-      "downloadCertificate": "Download Certificate",
-      "regenerateButton": "Regenerate",
-      "removeCertificate": "Remove Certificate",
-      "fileReadError": "Failed to read file",
-      "loading": "Loading certificate information..."
+      "certificateInstalled": "Certificat installé",
+      "browseFile": "Parcourir",
+      "subject": "Sujet",
+      "issuer": "Émetteur",
+      "sans": "Noms alternatifs du sujet",
+      "validUntil": "Valide jusqu'au",
+      "daysRemaining": "Jours restants",
+      "fingerprint": "Empreinte",
+      "expiryWarning": "Ce certificat expire bientôt. Pensez à le renouveler.",
+      "downloadCertificate": "Télécharger le certificat",
+      "regenerateButton": "Régénérer",
+      "removeCertificate": "Supprimer le certificat",
+      "fileReadError": "Échec de la lecture du fichier",
+      "loading": "Chargement des informations du certificat..."
     }
   },
   "connectivity": {
@@ -4332,77 +4332,77 @@
     },
     "steps": {
       "welcome": {
-        "title": "Welcome",
-        "heading": "Welcome to BirdNET-Go!",
-        "description": "BirdNET-Go is a real-time bird sound identification system. It listens to audio from your microphone or audio stream and uses the BirdNET AI model to identify bird species.",
-        "credit": "Powered by the BirdNET Analyzer developed by the K. Lisa Yang Center for Conservation Bioacoustics at the Cornell Lab of Ornithology and Chemnitz University of Technology.",
-        "cta": "Let's set up your bird monitoring station."
+        "title": "Bienvenue",
+        "heading": "Bienvenue dans BirdNET-Go !",
+        "description": "BirdNET-Go est un système d'identification des sons d'oiseaux en temps réel. Il écoute l'audio de votre microphone ou flux audio et utilise le modèle IA BirdNET pour identifier les espèces d'oiseaux.",
+        "credit": "Propulsé par le BirdNET Analyzer développé par le K. Lisa Yang Center for Conservation Bioacoustics au Cornell Lab of Ornithology et la Chemnitz University of Technology.",
+        "cta": "Configurons votre station de surveillance d'oiseaux."
       },
       "locationLanguage": {
-        "title": "Location & Language",
-        "uiLanguageLabel": "Interface Language",
-        "uiLanguageHelp": "Language used for the web interface",
-        "speciesLanguageLabel": "Species Name Language",
-        "speciesLanguageHelp": "Language used for bird species names in detections",
-        "locationLabel": "Station Location",
-        "locationHelp": "Your location helps filter species to those likely in your area",
+        "title": "Emplacement et langue",
+        "uiLanguageLabel": "Langue de l'interface",
+        "uiLanguageHelp": "Langue utilisée pour l'interface web",
+        "speciesLanguageLabel": "Langue des noms d'espèces",
+        "speciesLanguageHelp": "Langue utilisée pour les noms d'espèces d'oiseaux dans les détections",
+        "locationLabel": "Emplacement de la station",
+        "locationHelp": "Votre emplacement aide à filtrer les espèces probables dans votre zone",
         "latitudeLabel": "Latitude",
         "longitudeLabel": "Longitude",
-        "useMyLocation": "Use my location",
-        "locationDetected": "Location detected",
-        "locationError": "Could not detect location. Please enter coordinates manually.",
-        "locationDenied": "Location access denied. Please enter coordinates manually."
+        "useMyLocation": "Utiliser ma position",
+        "locationDetected": "Position détectée",
+        "locationError": "Impossible de détecter la position. Veuillez saisir les coordonnées manuellement.",
+        "locationDenied": "Accès à la position refusé. Veuillez saisir les coordonnées manuellement."
       },
       "audioSource": {
-        "title": "Audio Source",
-        "sourceTypeLabel": "Source Type",
-        "soundcard": "Microphone / Soundcard",
-        "rtspStream": "RTSP Stream",
-        "deviceLabel": "Audio Device",
-        "deviceLoading": "Loading audio devices...",
-        "noDevicesFound": "No audio devices detected. Try configuring an RTSP stream instead.",
-        "rtspUrlLabel": "Stream URL",
+        "title": "Source audio",
+        "sourceTypeLabel": "Type de source",
+        "soundcard": "Microphone / carte son",
+        "rtspStream": "Flux RTSP",
+        "deviceLabel": "Périphérique audio",
+        "deviceLoading": "Chargement des périphériques audio...",
+        "noDevicesFound": "Aucun périphérique audio détecté. Essayez de configurer un flux RTSP à la place.",
+        "rtspUrlLabel": "URL du flux",
         "rtspUrlPlaceholder": "rtsp://user:password@host:port/stream",
-        "rtspUrlHelp": "Enter the URL of your RTSP audio stream",
-        "additionalSourcesHint": "You can add more audio sources later in Settings."
+        "rtspUrlHelp": "Entrez l'URL de votre flux audio RTSP",
+        "additionalSourcesHint": "Vous pourrez ajouter d'autres sources audio plus tard dans les Paramètres."
       },
       "detection": {
-        "title": "Detection Threshold",
-        "description": "Choose how strict the bird identification should be. You can adjust this later in Settings.",
-        "balanced": "Balanced",
-        "balancedDesc": "Good balance of accuracy and sensitivity",
-        "balancedRecommended": "Recommended",
-        "highAccuracy": "High Accuracy",
-        "highAccuracyDesc": "Fewer false positives, may miss some birds",
-        "highSensitivity": "High Sensitivity",
-        "highSensitivityDesc": "More detections, more false positives",
-        "threshold": "Confidence threshold",
-        "fpFilterNote": "Once your system is running and proven, you can enable the false positive filter in Settings to further reduce incorrect detections."
+        "title": "Seuil de détection",
+        "description": "Choisissez le niveau de rigueur de l'identification des oiseaux. Vous pourrez ajuster cela plus tard dans les Paramètres.",
+        "balanced": "Équilibré",
+        "balancedDesc": "Bon équilibre entre précision et sensibilité",
+        "balancedRecommended": "Recommandé",
+        "highAccuracy": "Haute précision",
+        "highAccuracyDesc": "Moins de faux positifs, peut manquer certains oiseaux",
+        "highSensitivity": "Haute sensibilité",
+        "highSensitivityDesc": "Plus de détections, plus de faux positifs",
+        "threshold": "Seuil de confiance",
+        "fpFilterNote": "Une fois votre système en marche et éprouvé, vous pouvez activer le filtre de faux positifs dans les Paramètres pour réduire davantage les détections incorrectes."
       },
       "integration": {
-        "title": "Privacy & Integration",
-        "privacyFilterLabel": "Enable privacy filter",
-        "privacyFilterHelp": "Filters out detections when human voices are detected near the microphone",
-        "birdweatherLabel": "Share detections with BirdWeather",
-        "birdweatherHelp": "Contribute your bird detections to the BirdWeather community network",
-        "birdweatherIdLabel": "BirdWeather Station ID",
-        "birdweatherIdPlaceholder": "Enter your BirdWeather station ID",
-        "errorReportingLabel": "Send anonymous error reports",
-        "errorReportingHelp": "Help improve BirdNET-Go by sending anonymous error reports when something goes wrong"
+        "title": "Confidentialité et intégration",
+        "privacyFilterLabel": "Activer le filtre de confidentialité",
+        "privacyFilterHelp": "Filtre les détections lorsque des voix humaines sont détectées à proximité du microphone",
+        "birdweatherLabel": "Partager les détections avec BirdWeather",
+        "birdweatherHelp": "Contribuez vos détections d'oiseaux au réseau communautaire BirdWeather",
+        "birdweatherIdLabel": "ID de station BirdWeather",
+        "birdweatherIdPlaceholder": "Entrez votre ID de station BirdWeather",
+        "errorReportingLabel": "Envoyer des rapports d'erreurs anonymes",
+        "errorReportingHelp": "Aidez à améliorer BirdNET-Go en envoyant des rapports d'erreurs anonymes lorsque quelque chose ne fonctionne pas"
       },
       "responsibleUse": {
-        "title": "Using BirdNET-Go Responsibly",
-        "intro": "BirdNET-Go is a powerful tool that enhances your birding experience through AI-assisted identification. To ensure the best outcomes for both birding and conservation:",
-        "point1": "Review and verify detections before sharing observations",
-        "point2": "Use the confidence scores as a guide, not absolute truth",
-        "point3": "Cross-reference with field guides and local expertise",
-        "point4": "Consider seasonal patterns and habitat suitability",
-        "citizenScienceHeading": "When contributing to citizen science:",
-        "citizenPoint1": "Only submit observations you have personally verified",
-        "citizenPoint2": "Include notes about visual or behavioral confirmation",
-        "citizenPoint3": "Use AI detections as a starting point for your own observations",
-        "outro": "This approach ensures data quality for scientific research while maximizing your learning and enjoyment of birds.",
-        "acknowledge": "I understand"
+        "title": "Utilisation responsable de BirdNET-Go",
+        "intro": "BirdNET-Go est un outil puissant qui enrichit votre expérience ornithologique grâce à l'identification assistée par IA. Pour garantir les meilleurs résultats tant pour l'observation que pour la conservation :",
+        "point1": "Vérifiez et validez les détections avant de partager des observations",
+        "point2": "Utilisez les scores de confiance comme guide, pas comme vérité absolue",
+        "point3": "Recoupez avec les guides de terrain et l'expertise locale",
+        "point4": "Tenez compte des schémas saisonniers et de l'adéquation de l'habitat",
+        "citizenScienceHeading": "En contribuant à la science citoyenne :",
+        "citizenPoint1": "Ne soumettez que des observations que vous avez personnellement vérifiées",
+        "citizenPoint2": "Incluez des notes sur la confirmation visuelle ou comportementale",
+        "citizenPoint3": "Utilisez les détections IA comme point de départ pour vos propres observations",
+        "outro": "Cette approche garantit la qualité des données pour la recherche scientifique tout en maximisant votre apprentissage et votre plaisir de l'observation des oiseaux.",
+        "acknowledge": "Je comprends"
       }
     }
   },

--- a/frontend/static/messages/hu.json
+++ b/frontend/static/messages/hu.json
@@ -1,0 +1,4421 @@
+{
+  "common": {
+    "loading": "Betöltés...",
+    "error": "Hiba",
+    "unknown": "Ismeretlen",
+    "retry": "Újra",
+    "retrying": "Újrapróbálás",
+    "save": "Mentés",
+    "cancel": "Mégse",
+    "confirm": "Megerősítés",
+    "reset": "Visszaállítás",
+    "refresh": "Frissítés",
+    "delete": "Törlés",
+    "edit": "Szerkesztés",
+    "search": "Keresés",
+    "filter": "Szűrés",
+    "sort": "Rendezés",
+    "settings": "Beállítások",
+    "close": "Bezárás",
+    "back": "Vissza",
+    "next": "Tovább",
+    "previous": "Előző",
+    "yes": "Igen",
+    "no": "Nem",
+    "ok": "OK",
+    "apply": "Alkalmazás",
+    "clear": "Törlés",
+    "done": "Kész",
+    "goToDashboard": "Ugrás az irányítópultra",
+    "reportIssue": "Hiba jelentése",
+    "loginToViewDetails": "Bejelentkezés a részletek megtekintéséhez",
+    "pageNotFound": "Az oldal nem található",
+    "internalServerError": "Belső szerverhiba",
+    "actions": {
+      "download": "Letöltés",
+      "review": "Áttekintés",
+      "play": "Lejátszás",
+      "view": "Megtekintés"
+    },
+    "buttons": {
+      "save": "Módosítások mentése",
+      "reset": "Visszaállítás",
+      "delete": "Törlés",
+      "cancel": "Mégse",
+      "apply": "Alkalmazás",
+      "confirm": "Megerősítés",
+      "edit": "Szerkesztés",
+      "close": "Bezárás",
+      "back": "Vissza",
+      "next": "Tovább",
+      "previous": "Előző",
+      "yes": "Igen",
+      "no": "Nem",
+      "ok": "OK",
+      "clear": "Törlés",
+      "edit-config": "Konfiguráció szerkesztése",
+      "add-action": "Művelet hozzáadása",
+      "learnMore": "További információ",
+      "create": "Létrehozás"
+    },
+    "ui": {
+      "loading": "Betöltés...",
+      "noData": "Nincs elérhető adat",
+      "empty": "Nincs találat",
+      "error": "Hiba történt",
+      "retry": "Próbálja újra",
+      "dismiss": "Elutasítás",
+      "showMore": "Több megjelenítése",
+      "showLess": "Kevesebb megjelenítése",
+      "selectAll": "Összes kijelölése",
+      "selectNone": "Kijelölés megszüntetése",
+      "required": "Kötelező",
+      "optional": "Opcionális",
+      "noAudioSources": "Nincs elérhető hangforrás",
+      "noNotifications": "Nincs értesítés",
+      "silent": "(csendes)",
+      "loadingSettings": "Beállítások betöltése...",
+      "settingsNotFound": "Beállítások nem találhatók",
+      "sectionNotFound": "A kért beállítások szekció \"{section}\" nem található.",
+      "loadingMap": "Térkép betöltése...",
+      "mapZoomHelp": "Tartsa lenyomva a Ctrl (Mac-en Cmd) billentyűt + görgetés a nagyításhoz. Kattintson a helyszín beállításához.",
+      "mapSetLocationHelp": "Kattintson a térképre vagy húzza a jelölőt a helyszín beállításához",
+      "imageNotAvailable": "Kép nem elérhető",
+      "search": "Keresés..."
+    },
+    "status": {
+      "success": "Sikeres",
+      "error": "Hiba",
+      "warning": "Figyelmeztetés",
+      "info": "Információ",
+      "pending": "Függőben",
+      "processing": "Feldolgozás alatt",
+      "completed": "Befejezve",
+      "failed": "Sikertelen"
+    },
+    "validation": {
+      "required": "Ez a mező kötelező",
+      "invalid": "Érvénytelen érték",
+      "minLength": "Legalább {min} karakter szükséges",
+      "maxLength": "Legfeljebb {max} karakter engedélyezett",
+      "minValue": "Legalább {min} kell legyen",
+      "maxValue": "Legfeljebb {max} lehet",
+      "email": "Érvénytelen e-mail cím",
+      "url": "Érvénytelen URL",
+      "pattern": "Érvénytelen formátum"
+    },
+    "aria": {
+      "closeModal": "Ablak bezárása",
+      "dismissAlert": "Értesítés elutasítása",
+      "closeNotification": "Értesítés bezárása",
+      "toggleDropdown": "Legördülő menü kapcsolása",
+      "sortAscending": "Növekvő rendezés",
+      "selectLanguage": "Nyelv kiválasztása",
+      "sortDescending": "Csökkenő rendezés",
+      "expandSection": "Szekció kibontása",
+      "collapseSection": "Szekció összecsukása",
+      "playAudio": "Hang lejátszása",
+      "pauseAudio": "Hang szüneteltetése",
+      "loading": "Tartalom betöltése",
+      "saveChanges": "Módosítások mentése",
+      "cancelEdit": "Szerkesztés megszakítása",
+      "editSpecies": "Faj szerkesztése",
+      "removeSpecies": "Faj eltávolítása",
+      "dismissError": "Hiba elutasítása",
+      "datePickerCalendar": "Dátumválasztó naptár",
+      "selectDate": "Dátum kiválasztása",
+      "previousMonth": "Előző hónap",
+      "nextMonth": "Következő hónap",
+      "selectToday": "Ma kiválasztása",
+      "dateSelected": "Kiválasztott dátum: {date}",
+      "calendarNavigation": "A naptárban a nyílbillentyűkkel navigálhat, Enter a kiválasztáshoz, Escape a bezáráshoz",
+      "downloadCsv": "Fajlista letöltése CSV formátumban",
+      "visitEbirdLink": "eBird.org megnyitása új lapon",
+      "learnEbirdTaxonomyLink": "eBird taxonómia megnyitása új lapon",
+      "resizeHandle": "Húzza az átméretezéshez"
+    },
+    "labels": {
+      "confidence": "Megbízhatóság",
+      "github": "GitHub"
+    },
+    "values": {
+      "yes": "Igen",
+      "no": "Nem",
+      "unknown": "Ismeretlen"
+    },
+    "modal": {
+      "confirmAction": "Művelet megerősítése",
+      "confirmMessage": "Biztosan végre szeretné hajtani ezt a műveletet?"
+    },
+    "review": {
+      "modalTitle": "Detektálás áttekintése: {species}",
+      "status": {
+        "verifiedCorrect": "Ellenőrizve - Helyes",
+        "falsePositive": "Hamis pozitív",
+        "notReviewed": "Nincs áttekintve",
+        "locked": "Zárolva"
+      },
+      "form": {
+        "correctDetection": "Helyes detektálás",
+        "falsePositiveLabel": "Hamis pozitív",
+        "reviewDetectionTitle": "Detektálás áttekintése",
+        "lockDetection": "Detektálás zárolása mentés után",
+        "lockDetectionHelp": "A detektálás zárolása megakadályozza a törlését a rendszeres karbantartás során.",
+        "unlockDetection": "Detektálás zárolásának feloldása mentés után",
+        "unlockDetectionHelp": "A zárolás feloldása lehetővé teszi a detektálás törlését a rendszeres karbantartás során.",
+        "ignoreSpecies": "Faj figyelmen kívül hagyása",
+        "ignoreSpeciesHelp": "A faj figyelmen kívül hagyása megakadályozza a jövőbeli detektálásokat. A meglévő detektálások nem törlődnek.",
+        "detectionLocked": "Ez a detektálás jelenleg zárolva van.",
+        "comment": "Megjegyzés",
+        "addComment": "Megjegyzés hozzáadása",
+        "hideComment": "Megjegyzés elrejtése",
+        "commentPlaceholder": "Adjon hozzá egy megjegyzést ehhez a detektáláshoz...",
+        "commentCount": "({chars} karakter)",
+        "chars": "karakter",
+        "commentsLabel": "Megjegyzések",
+        "currentStatusTitle": "Jelenlegi állapot",
+        "detectionStatusTitle": "Detektálás állapota",
+        "lockLabel": "Zárolás állapota",
+        "reviewLabel": "Áttekintés állapota",
+        "saveReview": "Áttekintés mentése"
+      },
+      "errors": {
+        "saveFailed": "Az áttekintés mentése sikertelen. Próbálja újra.",
+        "noAudio": "Ehhez a detektáláshoz nem érhető el hangfelvétel.",
+        "commentFailed": "A megjegyzés mentése sikertelen. Próbálja újra.",
+        "lockStatusFailed": "A zárolási állapot frissítése sikertelen. Próbálja újra.",
+        "verificationFailed": "Az ellenőrzési állapot frissítése sikertelen. Próbálja újra."
+      }
+    },
+    "errors": {
+      "unknownError": "Ismeretlen hiba történt"
+    },
+    "toggle": "Kapcsolás",
+    "image": "Kép",
+    "actionsColumn": "Műveletek",
+    "closeModal": "Ablak bezárása",
+    "hoursShort": "ó"
+  },
+  "pageTitle": {
+    "settings": "Beállítások - BirdNET-Go",
+    "pageNotFound": "404 - Az oldal nem található",
+    "serverError": "500 - Belső szerverhiba",
+    "componentError": "Komponens betöltési hiba",
+    "speciesAnalytics": "Faj elemzés",
+    "advancedAnalytics": "Speciális elemzés",
+    "detectionDetails": "Detektálás részletei",
+    "settingsNotAvailable": "Beállítások nem elérhetők"
+  },
+  "navigation": {
+    "dashboard": "Irányítópult",
+    "settingsMenu": "Beállítások menü",
+    "theme": "Téma",
+    "github": "GitHub",
+    "detections": "Detektálások",
+    "search": "Keresés",
+    "analytics": "Elemzés",
+    "notifications": "Értesítések",
+    "system": "Rendszer",
+    "settings": "Beállítások",
+    "about": "Névjény",
+    "toggleSidebar": "Oldalsáv menü kapcsolása",
+    "mainNavigation": "Fő navigáció",
+    "closeSidebar": "Oldalsáv bezárása",
+    "collapseSidebar": "Oldalsáv összecsukása",
+    "expandSidebar": "Oldalsáv kinyitása",
+    "analyticsSubmenu": "Elemzés almenü",
+    "settingsSubmenu": "Beállítások almenü",
+    "systemSubmenu": "Rendszer almenü",
+    "systemTerminal": "Terminál"
+  },
+  "about": {
+    "title": "BirdNET-Go",
+    "subtitle": "Modern felület valós idejű madárhang detektáláshoz és osztályozáshoz",
+    "logoAlt": "BirdNET-Go logó",
+    "overview": "Áttekintés",
+    "overviewText": "A BirdNET-Go egy Go-alapú megvalósítás valós idejű madárhang detektáláshoz és osztályozáshoz, amely a BirdNET projekt alapjaira épül. Ez az alkalmazás felhasználóbarát felületet biztosít a folyamatos madárhang megfigyeléshez és elemzéshez.",
+    "birdnetProject": "BirdNET projekt",
+    "birdnetDescription": "A BirdNET-Go nem lenne lehetséges a BirdNET projekt úttörő munkája nélkül. A BirdNET-Go detektálási képességeit működtető mesterséges intelligencia modell a BirdNET projekt innovatív kutatásának és fejlesztésének az eredménye.",
+    "developedBy": "Fejlesztette",
+    "developersText": "A Cornell Lab of Ornithology K. Lisa Yang Conservation Bioacoustics Központja a Chemnitzi Műszaki Egyetemmel együttműködésben:",
+    "visitBirdnetAnalyzer": "BirdNET-Analyzer projekt meglátogatása",
+    "visitBirdnetAnalyzerAriaLabel": "BirdNET-Analyzer GitHub tárhely meglátogatása",
+    "contributors": "Közreműködők",
+    "contributorsText": "A BirdNET-Go számos egyén közös erőfeszítésének köszönhetően nőtt és fejlődött. A kódbeli javításoktól kezdve a funkciójavaslatokig mindannyian felbecsülhetetlen értékű munkával járultak hozzá a projekt jobbá tételéhez.",
+    "mainDeveloper": "Fő fejlesztő",
+    "githubContributors": "GitHub közreműködők",
+    "contributorsNote": "Külön köszönet ezeknek a közreműködőknek az értékes munkájukért a BirdNET-Go fejlesztésében:",
+    "communityAcknowledgment": "Közösségi elismerés",
+    "communityText": "Szeretnénk megköszönni minden felhasználónak is, aki hozzájárult:",
+    "bugReports": "Hibajelentések és hibakövetés",
+    "featureSuggestions": "Funkciójavaslatok és visszajelzések",
+    "testing": "Tesztelés és validálás",
+    "documentation": "Dokumentáció fejlesztések",
+    "additionalCredits": "További elismerések",
+    "birdnetPiProject": "BirdNET-Pi projekt",
+    "birdnetPiDescription": "Külön köszönet Patrick McGuire-nek a BirdNET-Pi-n végzett inspiráló munkájáért, amely befolyásolta a BirdNET-Go fejlesztését. A BirdNET-Pi bemutatja a madárhang detektálás lehetőségeit beágyazott eszközökön, és magas mércét állított a közösségvezérelt fejlesztés számára.",
+    "visitBirdnetPi": "BirdNET-Pi projekt meglátogatása",
+    "labelTranslations": "BirdNET címke fordítások",
+    "labelTranslationsBy": "Patrick Levin által biztosítva a BirdNET-Pi projekt számára, Patrick McGuire tollából",
+    "patrickLevinGithub": "Patrick Levin GitHub",
+    "versionInformation": "Verzióinformáció",
+    "currentVersion": "Jelenlegi verzió",
+    "buildDate": "Build dátum",
+    "developmentBuild": "Fejlesztői build",
+    "unknown": "Ismeretlen",
+    "licenseInformation": "Licenc információ",
+    "licenseText": "A BirdNET AI modell és a BirdNET-Go is a",
+    "ccLicense": "Creative Commons Nevezd meg! - Ne add el! - Így add tovább! 4.0 Nemzetközi licenc",
+    "licenseDescription": "Ez a licenc lehetővé teszi mások számára, hogy átdolgozzák, adaptálják és fejlesszék ezt a munkát nem kereskedelmi célból, amennyiben megfelelő hivatkozást adnak és az új alkotásokat azonos feltételek mellett licencelik.",
+    "dependencyLicenses": "Függőségi licencek",
+    "taxonomyDataTitle": "Taxonómia adatok",
+    "taxonomyDataIntro": "A BirdNET-Go beágyazott madár taxonómia adatokat tartalmaz az eBird/Clements listából, amelyek gyors helyi nemzetség- és családbeli kereséseket biztosítanak.",
+    "source": "Forrás",
+    "ebirdApiV2": "eBird API v2",
+    "copyright": "Szerzői jog",
+    "coverage": "Lefedettség",
+    "taxonomyCoverage": "2 374 nemzetség, 254 család, 11 145 faj",
+    "visitEbird": "eBird.org meglátogatása",
+    "ebirdOrg": "eBird.org",
+    "learnEbirdTaxonomy": "Az eBird taxonómiáról",
+    "avicommonsTitle": "Madár miniatűrök",
+    "avicommonsDescription": "A BirdNET-Go kurátusi madárképeket használ az Avicommons könyvtárból, kézzel válogatott, körülvágott és tájékozott madárfényképek Creative Commons licencek alatt.",
+    "githubStarPrompt": "Ha hasznosnak találja a BirdNET-Go-t, kérjük, fontolja meg a projekt csillagozását a GitHub-on. A csillagok segítenek másoknak felfedezni ezt a projektet és támogatják a folyamatos fejlesztést.",
+    "viewOnGithub": "Projekt megtekintése a GitHub-on",
+    "visitGithubAriaLabel": "BirdNET-Go GitHub tárhely meglátogatása",
+    "visitAvicommonsGithub": "Avicommons GitHub tárhely meglátogatása"
+  },
+  "notifications": {
+    "title": "Értesítések",
+    "subtitle": "Összes rendszerértesítés megtekintése és kezelése",
+    "filters": {
+      "label": "Szűrők",
+      "allStatus": "Összes állapot",
+      "unread": "Olvasatlan",
+      "read": "Olvasott",
+      "acknowledged": "Elfogadott",
+      "allTypes": "Összes típus",
+      "errors": "Hibák",
+      "warnings": "Figyelmeztetések",
+      "info": "Információ",
+      "system": "Rendszer",
+      "detections": "Detektálások",
+      "allPriorities": "Összes prioritás",
+      "critical": "Kritikus",
+      "high": "Magas",
+      "medium": "Közepes",
+      "low": "Alacsony"
+    },
+    "actions": {
+      "markAllRead": "Összes olvasottnak jelölése",
+      "refresh": "Értesítések frissítése",
+      "markAsRead": "Olvasottnak jelölése",
+      "acknowledge": "Elfogadás",
+      "delete": "Törlés",
+      "confirmDelete": "Törlés megerősítése",
+      "deleteConfirmation": "Biztosan törölni szeretné ezt az értesítést?",
+      "viewAll": "Összes értesítés megtekintése"
+    },
+    "aria": {
+      "filterByStatus": "Szűrés állapot szerint",
+      "filterByType": "Szűrés típus szerint",
+      "filterByPriority": "Szűrés prioritás szerint"
+    },
+    "empty": {
+      "title": "Nincs találat",
+      "subtitle": "Állítsa be a szűrőket vagy nézzen vissza később"
+    },
+    "errors": {
+      "loadFailed": "Az értesítések betöltése sikertelen. Próbálja újra.",
+      "deleteFailed": "Az értesítés törlése sikertelen. Próbálja újra.",
+      "networkError": "Hálózati hiba történt. Próbálja újra.",
+      "markReadFailed": "Az olvasottnak jelölése sikertelen. Próbálja újra."
+    },
+    "timeAgo": {
+      "justNow": "Épp most",
+      "minutesAgo": "{minutes}p ezelőtt",
+      "hoursAgo": "{hours}ó ezelőtt",
+      "daysAgo": "{days}n ezelőtt"
+    },
+    "viewMode": {
+      "label": "Nézet mód",
+      "grouped": "Csoportosított nézet",
+      "flat": "Lapos nézet"
+    },
+    "groups": {
+      "markAllRead": "Összes olvasottnak",
+      "dismissAll": "Összes elutasítása",
+      "unread": "{count} olvasatlan",
+      "confirmBulkDelete": "Több értesítés törlése",
+      "bulkDeleteConfirmation": "Biztosan törölni szeretné {count} értesítést?"
+    },
+    "content": {
+      "startup": {
+        "title": "BirdNET-Go elindult",
+        "message": "Az alkalmazás sikeresen elindult (v{version})"
+      },
+      "shutdown": {
+        "title": "BirdNET-Go leáll",
+        "message": "Az alkalmazás szabályosan leáll"
+      },
+      "detection": {
+        "title": "Érzékelve: {species}",
+        "message": "Megbízhatóság: {confidence}%"
+      },
+      "integration": {
+        "failedTitle": "{integration} integráció sikertelen",
+        "failedMessage": "Nem sikerült csatlakozni a {integration}-hoz. Ellenőrizze a konfigurációt és a naplókat."
+      },
+      "resource": {
+        "highUsage": "Magas {resource} használat",
+        "criticalUsage": "Kritikus {resource} használat",
+        "recovered": "{resource} használat helyreállt",
+        "currentUsage": "Jelenlegi érték: {current}{unit} (küszöbérték: {threshold}{unit})"
+      },
+      "error": {
+        "criticalSystem": "Kritikus rendszerhiba",
+        "application": "Alkalmazáshiba",
+        "imageProvider": "Képszolgáltató értesítés",
+        "categoryError": "{category} hiba",
+        "burstTitle": "Többszörös {component} hibák",
+        "burstMessage": "{count} hiba az elmúlt {window_minutes} percben: {sample_error}"
+      },
+      "settings": {
+        "reloadingBirdnet": "Új elemzési beállítások alkalmazása...",
+        "rebuildingRangeFilter": "Faj tartomány szűrő újraépítése...",
+        "updatingIntervals": "Detektálási intervallumok frissítése...",
+        "reconfiguringMqtt": "MQTT kapcsolat frissítése...",
+        "reconfiguringBirdweather": "BirdWeather integráció frissítése...",
+        "reconfiguringStreams": "Hang streamek frissítése...",
+        "reconfiguringTelemetry": "Telemetria beállítások frissítése...",
+        "reconfiguringPushNotifications": "Push értesítési szolgáltatók újrakonfigurálása...",
+        "reconfiguringSpeciesTracking": "Faj követés frissítése...",
+        "webserverRestartRequired": "Webszerver beállítások megváltoztak. Újraindítás szükséges.",
+        "reconfiguringSoundLevel": "Hangszint monitorozás frissítése...",
+        "audioDeviceRestartRequired": "Hang eszköz megváltozott. Újraindítás szükséges.",
+        "extendedCaptureRestartRequired": "Kiterjesztett rögzítés beállítások megváltoztak. Újraindítás szükséges.",
+        "equalizerUpdateFailed": "A hang EQ beállítások frissítése sikertelen",
+        "equalizerUpdated": "Hang EQ beállítások frissítve",
+        "savedSuccessfully": "Beállítások sikeresen mentve",
+        "saveFailed": "A beállítások mentése sikertelen",
+        "recalculatingThresholds": "Dinamikus küszöbértékek újraszámítása az új alapértékhez",
+        "reconfiguringDynamicThresholds": "Dinamikus küszöbértékek újrakonfigurálása...",
+        "rebuildingExtendedCapture": "Kiterjesztett rögzítési szűrő újraépítése..."
+      },
+      "migration": {
+        "startedTitle": "Adatbázis migráció elkezdődött",
+        "startedMessage": "A migráció elkezdődött. Ez eltarthat egy ideig a detektálások számától függően.",
+        "pausedTitle": "Adatbázis migráció szüneteltetve",
+        "pausedMessage": "Az adatbázis migráció szüneteltetve van. Bármikor folytathatja az Adatbázis beállításokból.",
+        "cancelledTitle": "Adatbázis migráció megszakítva",
+        "cancelledMessage": "Az adatbázis migráció megszakítva. Bármikor indíthat új migrációt az Adatbázis beállításokból.",
+        "completedTitle": "Adatbázis migráció befejezve",
+        "completedMessage": "A migráció befejeződött. Kérjük, indítsa újra a BirdNET-Go-t az új adatbázis használatához.",
+        "errorTitle": "Adatbázis migráció hiba",
+        "errorMessage": "A migráció hibák miatt szünetelt. Ellenőrizze a naplókat és próbálja folytatni."
+      },
+      "cleanup": {
+        "completeTitle": "Régi adatbázis karbantartás befejezve",
+        "completeMessage": "{space} lemezterület felszabadítva.",
+        "failedTitle": "Régi adatbázis karbantartás sikertelen",
+        "failedMessage": "A régi adatbázis eltávolítása sikertelen. A részletekért ellenőrizze a naplókat."
+      },
+      "buffer": {
+        "overloadTitle": "Hang elemzés túlterhelve",
+        "overloadMessage": "A rendszere {dropRate}% hangmintát dob el a '{sourceName}' forrásból, mert nem bírja az elemzést. Csökkentse a BirdNET átfedési értékét a detektálási beállításokban, vagy fontoljon meg egy gyorsabb CPU-ra való váltást."
+      },
+      "alert": {
+        "firedTitle": "{rule_name}",
+        "metricExceeded": "Jelenlegi érték: {value}% (küszöbérték: {threshold}%)",
+        "detectionOccurred": "{species_name} érzékelve {confidence}% megbízhatósággal",
+        "errorOccurred": "{error}",
+        "disconnected": "{source_name} leválasztva",
+        "error": {
+          "authError": "Hitelesítés sikertelen — ellenőrizze az API kulcsot vagy a hitelesítési adatokat",
+          "rateLimited": "Díjszabás korlátozva — a kérések automatikusan lassulnak",
+          "gatewayTimeout": "A szolgáltatás nagy terhelés alatt lehet",
+          "serverError": "A szolgáltatás átmenetileg nem elérhető",
+          "connectionRefused": "A szolgáltatás nem érhető el — ellenőrizze a címet és hogy fut-e",
+          "dnsError": "A hostname feloldása sikertelen — ellenőrizze a címet",
+          "tlsError": "TLS/tanúsítvány hiba — ellenőrizze a biztonsági beállításokat",
+          "timeout": "A kapcsolat időtúllépés — a szolgáltatás lassú vagy nem elérhető",
+          "connectionInterrupted": "A kapcsolat megszakadt — automatikusan újrapróbálkozik",
+          "diskFull": "A lemez megtelt — szabadítson fel helyet",
+          "permissionDenied": "Engedély megtagadva — ellenőrizze a fájl vagy szolgáltatás engedélyeit"
+        }
+      }
+    },
+    "loading": "Értesítések betöltése..."
+  },
+  "search": {
+    "title": "Keresési szűrők",
+    "results": "Keresési eredmények",
+    "resultsCountZero": "Nincs találat",
+    "resultsCountOne": "1 találat",
+    "resultsCountOther": "{count} találat",
+    "noSearchPerformed": "Még nem végzett keresést",
+    "noSearchPerformedHint": "Használja a fenti keresési szűrőket madár detektálások kereséséhez",
+    "loadingResults": "Eredmények betöltése...",
+    "noResultsFound": "Nincs találat",
+    "noResultsHint": "Próbálja módosítani a keresési szűrőket",
+    "fields": {
+      "species": "Faj",
+      "speciesPlaceholder": "Adja meg a faj nevét",
+      "speciesHelp": "Adja meg a faj teljes vagy részleges nevét (nem érzékeny a nagybetűkre)",
+      "dateRange": "Dátumtartomány",
+      "dateRangeHelp": "Szűrés dátumtartomány szerint (üresen hagyva minden dátum)",
+      "from": "Ettől",
+      "to": "Eddig",
+      "confidenceRange": "Megbízhatósági tartomány (%)",
+      "confidenceMin": "Minimum megbízhatósági százalék",
+      "confidenceMax": "Maximum megbízhatósági százalék",
+      "verifiedStatus": "Ellenőrzött állapot",
+      "lockedStatus": "Zárolt állapot",
+      "timeOfDay": "Napszak"
+    },
+    "advancedFilters": "Speciális szűrők",
+    "showAdvancedFilters": "Speciális szűrők megjelenítése",
+    "hideAdvancedFilters": "Speciális szűrők elrejtése",
+    "verifiedOptions": {
+      "any": "Bármely állapot",
+      "verified": "Csak ellenőrzött",
+      "unverified": "Csak ellenőrizetlen"
+    },
+    "lockedOptions": {
+      "any": "Bármely állapot",
+      "locked": "Csak zárolt",
+      "unlocked": "Csak zárolatlan"
+    },
+    "timeOfDayOptions": {
+      "any": "Bármikor",
+      "day": "Csak nappal",
+      "night": "Csak éjjel",
+      "sunrise": "Napkelte +/- 30 perc",
+      "sunset": "Napnyugta +/- 30 perc"
+    },
+    "sortOptions": {
+      "dateDesc": "Dátum (Legújabb elöl)",
+      "dateAsc": "Dátum (Legrégebbi elöl)",
+      "speciesAsc": "Faj (A-Z)",
+      "confidenceDesc": "Megbízhatóság (Csökkenő)"
+    },
+    "tableHeaders": {
+      "dateTime": "Dátum és idő",
+      "timeOfDay": "Napszak",
+      "species": "Faj",
+      "confidence": "Megbízhatóság",
+      "status": "Állapot",
+      "actions": "Műveletek"
+    },
+    "statusBadges": {
+      "verified": "Ellenőrizve",
+      "false": "Hamis",
+      "unverified": "Ellenőrizetlen",
+      "locked": "Zárolva",
+      "unlocked": "Zárolatlan"
+    },
+    "detailsPanel": {
+      "audioPlayer": "Hang lejátszó",
+      "expandDetails": "Részletek kibontása: {species}",
+      "collapseDetails": "Részletek összecsukása: {species}",
+      "playAudio": "Hang lejátszása: {species}",
+      "viewDetails": "Részletek megtekintése: {species}",
+      "unknownSpecies": "Ismeretlen faj",
+      "clickToCollapse": "Kattintson az összecsukáshoz"
+    },
+    "errors": {
+      "searchFailed": "Keresés sikertelen: {error}",
+      "minMaxConfidence": "A minimum megbízhatóság nem lehet nagyobb a maximumnál."
+    },
+    "pagination": {
+      "page": "{current}. oldal / {total}",
+      "goToPrevious": "Előző oldal",
+      "goToNext": "Következő oldal"
+    },
+    "review": {
+      "review": "Ellenőrzés",
+      "reviewDetection": "Detektálás ellenőrzése: {species}",
+      "markCorrect": "Megjelölés helyesként",
+      "markFalsePositive": "Megjelölés téves pozitívként",
+      "markedCorrect": "Detektálás helyesként megjelölve",
+      "markedFalsePositive": "Detektálás téves pozitívként megjelölve",
+      "failed": "Az ellenőrzési állapot frissítése sikertelen"
+    }
+  },
+  "error": {
+    "404": {
+      "code": "404",
+      "title": "Az oldal nem található",
+      "goToDashboard": "Ugrás az irányítópultra"
+    },
+    "500": {
+      "code": "500",
+      "title": "Belső szerverhiba",
+      "defaultMessage": "Belső szerverhiba történt.",
+      "goToDashboard": "Ugrás az irányítópultra"
+    },
+    "server": {
+      "title": "Szerver kapcsolódási hiba",
+      "description": "Nem sikerült csatlakozni a szerverhez. Kérjük, ellenőrizze a kapcsolatát és próbálja újra."
+    },
+    "generic": {
+      "errorDetails": "Hiba részletei",
+      "stackTrace": "Hívási verem",
+      "goToDashboard": "Ugrás az irányítópultra",
+      "reportIssue": "Hiba jelentése",
+      "loginToViewDetails": "Bejelentkezés a részletek megtekintéséhez",
+      "componentLoadError": "Komponens betöltési hiba",
+      "failedToLoadComponent": "A kért komponens betöltése sikertelen"
+    }
+  },
+  "dashboard": {
+    "approved": "Jóváhagyva",
+    "currentlyHearing": {
+      "title": "Jelenleg hallható",
+      "subtitle": "Valós idejű azonosított fajok",
+      "empty": "Csend van — most nem észleltek madarakat"
+    },
+    "rejected": "Elutasítva",
+    "dailySummary": {
+      "title": "Napi aktivitás",
+      "subtitle": "Faj detektálások óránként",
+      "columns": {
+        "species": "Faj",
+        "detections": "Detektálások"
+      },
+      "daylight": {
+        "label": "Nappal",
+        "sunrise": "Napkelte: {time}",
+        "sunset": "Napnyugta: {time}"
+      },
+      "weather": {
+        "label": "Időjárás"
+      },
+      "legend": {
+        "less": "Kevesebb",
+        "more": "Több"
+      },
+      "navigation": {
+        "previousDay": "Előző nap",
+        "nextDay": "Következő nap",
+        "today": "Ma"
+      },
+      "tooltips": {
+        "viewHourly": "Összes detektálás megtekintése {hour}:00-kor",
+        "viewBiHourly": "Összes detektálás megtekintése {startHour}:00-{endHour}:00-kor",
+        "viewSixHourly": "Összes detektálás megtekintése {startHour}:00-{endHour}:00-kor",
+        "hourlyDetections": "{count} detektálás {hour}:00-kor - Kattintson a megtekintéshez",
+        "biHourlyDetections": "{count} detektálás {startHour}:00-{endHour}:00-kor - Kattintson a megtekintéshez",
+        "sixHourlyDetections": "{count} detektálás {startHour}:00-{endHour}:00-kor - Kattintson a megtekintéshez"
+      },
+      "loading": {
+        "preparing": "Adatok előkészítése...",
+        "fetching": "Detektálások betöltése...",
+        "error": "Az adatok betöltése sikertelen",
+        "complete": "Adatok sikeresen betöltve"
+      },
+      "noSpecies": "Ezen a napon nem észleltek fajokat"
+    },
+    "recentDetections": {
+      "title": "Legutóbbi detektálások",
+      "subtitle": "Legújabb azonosított fajok",
+      "controls": {
+        "show": "Megjelenítés:",
+        "refresh": "Detektálások frissítése",
+        "refreshPaused": "Frissítés szüneteltetve interakció közben"
+      },
+      "headers": {
+        "dateTime": "Dátum és idő",
+        "time": "Idő",
+        "commonName": "Közhasználatú név",
+        "species": "Faj",
+        "weather": "Időjárás",
+        "confidence": "Megbízhatóság",
+        "thumbnail": "Miniatűr",
+        "status": "Állapot",
+        "recording": "Felvétel",
+        "actions": "Műveletek"
+      },
+      "status": {
+        "verified": "Ellenőrizve",
+        "false": "Hamis",
+        "unverified": "Ellenőrizetlen",
+        "locked": "Zárolva"
+      },
+      "modals": {
+        "showSpecies": "{species} faj megjelenítése",
+        "ignoreSpecies": "{species} faj figyelmen kívül hagyása",
+        "showSpeciesConfirm": "Biztosan meg szeretné jeleníteni a {species} jövőbeli detektálásait?",
+        "ignoreSpeciesConfirm": "Biztosan figyelmen kívül szeretné hagyni a {species} jövőbeli detektálásait? Ez csak az új detektálásokat érinti — a meglévők az adatbázisban maradnak.",
+        "unlockDetection": "Detektálás zárolásának feloldása",
+        "lockDetection": "Detektálás zárolása",
+        "unlockDetectionConfirm": "Biztosan fel szeretné oldani a {species} detektálásának zárolását? Ez lehetővé teszi a törlését a rendszeres karbantartás során.",
+        "lockDetectionConfirm": "Biztosan zárolni szeretné a {species} detektálását? Ez megakadályozza a törlését a rendszeres karbantartás során.",
+        "deleteDetection": "{species} detektálásának törlése",
+        "deleteDetectionConfirm": "Biztosan törölni szeretné a {species} detektálását? Ez a művelet nem vonható vissza."
+      },
+      "actions": {
+        "menuLabel": "Műveletek: {species}",
+        "review": "Detektálás áttekintése",
+        "showSpecies": "Faj megjelenítése",
+        "ignoreSpecies": "Faj figyelmen kívül hagyása",
+        "lockDetection": "Detektálás zárolása",
+        "unlockDetection": "Detektálás zárolásának feloldása",
+        "deleteDetection": "Detektálás törlése"
+      },
+      "noDetections": "Nincs legutóbbi detektálás",
+      "errors": {
+        "toggleSpeciesFailed": "A faj kizárásának frissítése sikertelen. Próbálja újra.",
+        "toggleLockFailed": "A zárolási állapot frissítése sikertelen. Próbálja újra.",
+        "deleteFailed": "A detektálás törlése sikertelen. Próbálja újra."
+      }
+    },
+    "errors": {
+      "dailySummaryFetch": "A napi összefoglaló betöltése sikertelen: {status}",
+      "dailySummaryLoad": "A napi összefoglaló betöltése sikertelen",
+      "recentDetectionsFetch": "A legutóbbi detektálások betöltése sikertelen: {status}",
+      "recentDetectionsLoad": "A legutóbbi detektálások betöltése sikertelen",
+      "configFetch": "Az irányítópult konfigurációjának betöltése sikertelen: {status}"
+    },
+    "banner": {
+      "title": "Cím",
+      "titlePlaceholder": "A madár megfigyelő állomásom",
+      "description": "Leírás",
+      "descriptionPlaceholder": "Rövid leírása a madár megfigyelő állomásnak...",
+      "subElements": "Al-elemek",
+      "showImage": "Egyéni kép megjelenítése",
+      "imageUrl": "Kép URL vagy útvonal",
+      "imageUrlPlaceholder": "https://pelda.com/allomas-kep.jpg",
+      "imageUrlHelp": "Adja meg a kép URL-jét. A képfeltöltés egy későbbi frissítésben lesz elérhető.",
+      "showLocationMap": "Helyszín térkép megjelenítése",
+      "showLocationMapHelp": "A fő beállításokból származó szélesség/hosszúság alapján kis térképet jelenít meg",
+      "showWeather": "Aktuális időjárás megjelenítése",
+      "showWeatherHelp": "Az aktuális időjárási viszonyokat jeleníti meg (ehhez az időjárás integrációt engedélyezni kell)",
+      "timeFormat": "Időformátum",
+      "mapZoom": "Térkép nagyítás",
+      "showPin": "Helyszín jelölő megjelenítése",
+      "mapExpandable": "Térkép kibontás engedélyezése",
+      "expandMap": "Térkép kibontása",
+      "expandedMapLabel": "Kibontott helyszín térkép",
+      "closeExpandedMap": "Kibontott térkép bezárása"
+    },
+    "videoEmbed": {
+      "youtubeUrl": "YouTube URL",
+      "youtubeUrlPlaceholder": "https://www.youtube.com/watch?v=...",
+      "youtubeUrlHelp": "Illessze be bármely YouTube URL-t (watch, embed, vagy short link). Privacy-enhanced embed-re lesz konvertálva.",
+      "titleLabel": "Cím (opcionális)",
+      "titlePlaceholder": "Adja meg a videó címét (opcionális)"
+    },
+    "editMode": {
+      "editing": "Irányítópult szerkesztése",
+      "save": "Mentés",
+      "saving": "Mentés...",
+      "cancel": "Mégse",
+      "disabled": "rejtett",
+      "noConfig": "Még nem érhető el további konfigurációs opciók.",
+      "currentlyHearingNote": "Ez az elem a ma megtekintett dátum esetén a jelenleg észlelt madarakat mutatja. További konfiguráció nem szükséges.",
+      "notAvailable": "Az elemtípus konfigurációja még nem érhető el.",
+      "configureElement": "Elem konfigurálása",
+      "closeModal": "Bezárás",
+      "configureTitle": "{element} konfigurálása",
+      "weatherPlaceholder": "Az időjárási viszonyok itt jelennek meg, amikor elérhetők",
+      "stationBanner": "Állomás banner",
+      "liveBirdFeed": "Élő madár feed",
+      "hideElement": "Elem elrejtése",
+      "unhideElement": "Elem megjelenítése",
+      "deleteElement": "Elem eltávolítása",
+      "deleteConfirm": "Eltávolítja ezt az elemet? A konfigurációja elvész.",
+      "addElement": "Elem hozzáadása",
+      "noElementsAvailable": "Minden elemtípus már az irányítópulton van.",
+      "editDashboard": "Irányítópult szerkesztése",
+      "widthFull": "Teljes szélesség",
+      "widthHalf": "Fél szélesség",
+      "fullWidthOnly": "Csak teljes szélesség",
+      "settings": "Beállítások",
+      "resetDashboard": "Irányítópult visszaállítása",
+      "resetConfirm": "Visszaállítja az irányítópultot az alapértelmezett elrendezésre? Ez eltávolítja az összes testreszabást.",
+      "resetting": "Visszaállítás..."
+    },
+    "elements": {
+      "banner": "Irányítópult banner",
+      "dailySummary": "Napi összefoglaló",
+      "currentlyHearing": "Jelenleg hallható",
+      "detectionsGrid": "Legutóbbi detektálások",
+      "liveSpectrogram": "Élő spektrogram",
+      "videoEmbed": "Videó beágyazás"
+    }
+  },
+  "detections": {
+    "title": "Detektálások",
+    "titles": {
+      "hourly": "Órási eredmények {date}-án {hour}:00-kor",
+      "hourlyRange": "Órási eredmények {date}-án {startHour}:00 - {endHour}:00 között",
+      "species": "{species} eredményei {date}-án",
+      "search": "\"{query}\" keresési eredményei",
+      "allDetections": "Összes detektálás {date}-án"
+    },
+    "detail": {
+      "species": "Faj",
+      "observation": "Megfigyelés"
+    },
+    "headers": {
+      "dateTime": "Dátum és idő",
+      "weather": "Időjárás",
+      "species": "Faj",
+      "confidence": "Megbízhatóság",
+      "thumbnail": "Miniatűr",
+      "status": "Állapot",
+      "recording": "Felvétel",
+      "actions": "Műveletek"
+    },
+    "viewToggle": {
+      "label": "Nézet mód",
+      "table": "Táblázatos nézet",
+      "cards": "Kártyás nézet"
+    },
+    "status": {
+      "locked": "Zárolva"
+    },
+    "timeOfDay": {
+      "day": "Nappal",
+      "night": "Éjjel",
+      "sunrise": "Napkelte",
+      "sunset": "Napnyugta",
+      "any": "Bármikor",
+      "unknown": "Ismeretlen"
+    },
+    "table": {
+      "caption": "Madár detektálások listája dátummal, fajjal, megbízhatósággal és állapottal"
+    },
+    "empty": {
+      "title": "Nem található detektálás",
+      "description": "Próbálja módosítani a szűrőket vagy keresési feltételeket"
+    },
+    "pagination": {
+      "showing": "{from} - {to} / {total} találat"
+    },
+    "weather": {
+      "title": "Időjárási információ",
+      "noData": "Nincs időjárási adat",
+      "noDataAvailable": "Nem érhető el időjárási adat",
+      "loading": "Időjárási információ betöltése...",
+      "labels": {
+        "temperature": "Hőmérséklet",
+        "weather": "Időjárás",
+        "wind": "Szél",
+        "humidity": "Páratartalom",
+        "pressure": "Légnyomás",
+        "cloudCover": "Felhőborítottság"
+      },
+      "units": {
+        "temperature": "°C",
+        "temperatureFahrenheit": "°F",
+        "windSpeed": "m/s",
+        "windSpeedImperial": "mph",
+        "humidity": "%",
+        "pressure": "hPa"
+      },
+      "conditions": {
+        "clearsky_day": "Derült",
+        "clearsky_night": "Derült",
+        "fair_day": "Változóan felhős",
+        "fair_night": "Változóan felhős",
+        "partlycloudy_day": "Felhős",
+        "partlycloudy_night": "Felhős",
+        "cloudy": "Borult",
+        "rainshowers_day": "Záporok",
+        "rainshowers_night": "Záporok",
+        "rain": "Eső",
+        "thunder": "Zivatar",
+        "sleet": "Havaseső",
+        "snow": "Hó",
+        "fog": "Köd",
+        "unknown": "Ismeretlen"
+      }
+    },
+    "row": {
+      "viewDetails": "{species} részleteinek megtekintése"
+    },
+    "media": {
+      "title": "Felvétel és spektrogram",
+      "clipHint": "Kattintson és húzza a spektrogramon egy tartomány kijelöléséhez a kivágás exportálásához"
+    },
+    "tabs": {
+      "overview": "Áttekintés",
+      "taxonomy": "Taxonómia",
+      "history": "Előzmények",
+      "notes": "Megjegyzések"
+    },
+    "environmental": {
+      "title": "Környezeti feltételek"
+    },
+    "metadata": {
+      "title": "Detektálás metaadatok",
+      "source": "Forrás",
+      "duration": "Időtartam",
+      "status": "Állapot",
+      "locked": "Zárolva"
+    },
+    "history": {
+      "title": "Detektálás előzmények",
+      "comingSoon": "Az előzmények követése hamarosan..."
+    },
+    "notes": {
+      "title": "Megjegyzések és kommentek",
+      "noComments": "Nincs komment vagy megjegyzés ehhez a detektáláshoz."
+    },
+    "aria": {
+      "loading": "Detektálás részleteinek betöltése...",
+      "loaded": "Detektálás részletei betöltve: {species}",
+      "error": "Hiba a detektálás betöltésekor: {error}"
+    },
+    "errors": {
+      "notFound": "A detektálás nem található. Lehet, hogy törölték vagy az ID hibás.",
+      "noPermission": "Nincs jogosultsága megtekinteni ezt a detektálást.",
+      "loginRequired": "Kérjük, jelentkezzen be a detektálás megtekintéséhez.",
+      "serverError": "Szerver hiba. Kérjük, próbálja újra később, vagy ha a probléma fennáll, forduljon a támogatáshoz.",
+      "loadFailed": "A detektálás betöltése sikertelen ({status} hiba). Próbálja frissíteni az oldalt.",
+      "noIdProvided": "Nincs megadva detektálás ID.",
+      "fetchFailed": "A detektálások betöltése sikertelen"
+    }
+  },
+  "species": {
+    "rarity": {
+      "title": "Faj ritkasága",
+      "score": "Pontszám",
+      "basedOnLocation": "Helyszín alapján: {latitude}, {longitude}",
+      "statuses": {
+        "very_common": "Nagyon gyakori",
+        "common": "Gyakori",
+        "uncommon": "Ritka",
+        "rare": "Nagyon ritka",
+        "very_rare": "Rendkívül ritka",
+        "unknown": "Ismeretlen"
+      }
+    },
+    "taxonomy": {
+      "hierarchy": "Taxonómiai besorolás",
+      "subspecies": "Alfajok",
+      "noData": "Nem érhető el taxonómia adat.",
+      "labels": {
+        "kingdom": "Ország",
+        "phylum": "Törzs",
+        "class": "Osztály",
+        "order": "Rend",
+        "family": "Család",
+        "genus": "Nemzetség",
+        "species": "Faj"
+      }
+    },
+    "synonyms": {
+      "tabLabel": "Taxonómia szinonimák",
+      "description": "Felülbírálja a tudományos név leképezéseket a madár képkeresésekhez. A BirdNET 2021E taxonómiát használ, de a képek forrásai frissített neveket használhatnak. A beépített leképezések mindig betöltődnek; az Ön felülbírálásai hozzáadódnak vagy helyettesítik azokat.",
+      "birdnetName": "BirdNET név",
+      "updatedName": "Frissített név",
+      "addButton": "Szinonima hozzáadása",
+      "emptyState": "Nincs konfigurálva egyedi taxonómia szinonima sem.",
+      "errors": {
+        "unknownSpecies": "A faj nem található a BirdNET címkék között",
+        "duplicateKey": "Ehhez a fajhoz már létezik szinonima",
+        "emptyUpdatedName": "A frissített név kötelező"
+      }
+    },
+    "tracking": {
+      "title": "Faj követés",
+      "newSpecies": "Új faj",
+      "newThisYear": "Első az idén",
+      "newThisSeason": "Első ebben az évszakban",
+      "daysSinceFirst": "Napok az első észlelés óta"
+    }
+  },
+  "spectrogram": {
+    "controls": {
+      "frequencyRange": "Frekvencia tartomány",
+      "colorMap": "Színtérkép",
+      "gain": "Erősítés",
+      "mute": "Némítás",
+      "unmute": "Némítás feloldása",
+      "frequencyRangeMin": "Minimum frekvencia",
+      "frequencyRangeMax": "Maximum frekvencia",
+      "gainTooltip": "Spektrogram megjelenítési erősítés"
+    },
+    "error": {
+      "unsupported": "A böngészője nem támogatja a hang elemzést",
+      "connectionFailed": "Nem sikerült csatlakozni az élő hangstreamhez",
+      "accessDenied": "Az élő hang eléréshez hitelesítés szükséges. Kérjük, jelentkezzen be a funkció használatához."
+    },
+    "dashboard": {
+      "toggle": "Élő spektrogram",
+      "audioToggle": "Hang engedélyezése"
+    },
+    "gain": {
+      "muted": "Némítva",
+      "level": "Erősítés: {value} dB"
+    },
+    "page": {
+      "title": "Élő hang",
+      "sourceLabel": "Hangforrás",
+      "connected": "Csatlakoztatva",
+      "enterFullscreen": "Teljes képernyő",
+      "exitFullscreen": "Teljes képernyőből kilépés"
+    },
+    "colorMaps": {
+      "inferno": "Inferno",
+      "viridis": "Viridis",
+      "grayscale": "Szürkeárnyalatos"
+    },
+    "labels": {
+      "toggle": "Detektálási címkék kapcsolása"
+    }
+  },
+  "system": {
+    "title": "Rendszer irányítópult",
+    "refreshData": "Adatok frissítése",
+    "aria": {
+      "refreshData": "Rendszer adatok frissítése",
+      "dashboard": "Rendszer irányítópult teljesítmény metrikákkal és információkkal"
+    },
+    "systemInfo": {
+      "title": "Rendszer információ",
+      "os": "Operációs rendszer",
+      "hostname": "Gépnév",
+      "uptime": "Üzemidő",
+      "cpus": "CPU-k",
+      "model": "Rendszer modell",
+      "timezone": "Időzóna",
+      "temperature": "CPU hőmérséklet",
+      "temperatureValue": "{temp}°C",
+      "temperatureUnavailable": "Hőmérséklet adat nem elérhető",
+      "cpuCores": "CPU magok",
+      "cpuDetails": "CPU",
+      "environment": "Környezet"
+    },
+    "diskUsage": {
+      "title": "Lemezhasználat",
+      "emptyMessage": "Lemez információ nem elérhető"
+    },
+    "memoryUsage": {
+      "title": "Memória használat",
+      "ramUsage": "RAM használat",
+      "labels": {
+        "free": "Szabad",
+        "available": "Elérhető",
+        "buffCache": "Buff/Cache"
+      }
+    },
+    "progress": {
+      "labels": {
+        "overallProgress": "Teljes folyamat",
+        "progress": "Folyamat"
+      }
+    },
+    "processInfo": {
+      "title": "Folyamat információ",
+      "loading": "Folyamat információ betöltése...",
+      "noProcesses": "Folyamat információ nem elérhető",
+      "headers": {
+        "pid": "PID",
+        "name": "Név",
+        "status": "Állapot",
+        "cpu": "CPU",
+        "memory": "Memória",
+        "uptime": "Üzemidő",
+        "process": "Folyamat"
+      },
+      "showAll": "Összes folyamat megjelenítése",
+      "showBirdnetOnly": "Csak BirdNET megjelenítése",
+      "table": {
+        "process": "Folyamat",
+        "status": "Állapot",
+        "cpu": "CPU",
+        "memory": "Memória",
+        "uptime": "Üzemidő",
+        "showAllProcesses": "Összes folyamat megjelenítése"
+      }
+    },
+    "errors": {
+      "systemInfo": "A rendszer információ betöltése sikertelen: {error}",
+      "diskUsage": "A lemezhasználat betöltése sikertelen: {error}",
+      "memoryUsage": "A memória használat betöltése sikertelen: {error}",
+      "temperature": "A hőmérséklet betöltése sikertelen: {error}",
+      "processes": "A folyamat információ betöltése sikertelen: {error}"
+    },
+    "sections": {
+      "overview": "Áttekintés",
+      "database": "Adatbázis",
+      "terminal": "Terminál"
+    },
+    "database": {
+      "title": "Adatbázis kezelés",
+      "description": "Adatbázis sémaváltozás migráció kezelése",
+      "legacy": {
+        "title": "Régi adatbázis",
+        "fetchFailed": "A régi adatbázis állapotának betöltése sikertelen",
+        "cleanup": {
+          "title": "Régi adatbázis karbantartás",
+          "description": "Ez az adatbázis már nem aktív és nincs használatban. Az összes adat át lett migrálva a Fejlett adatbázisba.",
+          "recommendation": "Javasolt törölni ezt az adatbázist a lemezterület felszabadításához.",
+          "location": "Helyszín",
+          "size": "Méret",
+          "records": "Rekordok",
+          "detections": "detektálás",
+          "lastModified": "Utoljára módosítva",
+          "warning": "Figyelmeztetés: Ez a művelet nem vonható vissza",
+          "backupReminder": "Győződjön meg róla, hogy van biztonsági mentése mielőtt törli a régi adatbázist.",
+          "deleteButton": "Régi adatbázis törlése",
+          "inProgress": "Törlés...",
+          "success": "{size} lemezterület felszabadítva",
+          "failed": "Karbantartás sikertelen",
+          "notAvailable": "Karbantartás nem elérhető",
+          "confirmTitle": "Régi adatbázis törlése?",
+          "confirmMessage": "A régi adatbázis ({size}) végleges törlésére készül. Ez a művelet nem vonható vissza.",
+          "confirmCheckbox": "Megértem, hogy ez véglegesen törli a régi adatbázist",
+          "cancelButton": "Mégse",
+          "deleteConfirmButton": "Végleges törlés"
+        }
+      },
+      "v2": {
+        "title": "Fejlett adatbázis"
+      },
+      "stats": {
+        "connected": "Csatlakoztatva",
+        "disconnected": "Leválasztva",
+        "type": "Típus",
+        "location": "Helyszín",
+        "size": "Méret",
+        "detections": "Detektálások",
+        "fetchFailed": "Az adatbázis statisztikák betöltése sikertelen"
+      },
+      "dashboard": {
+        "title": "Adatbázis irányítópult",
+        "fetchFailed": "Az adatbázis áttekintés betöltése sikertelen",
+        "loading": "Betöltés...",
+        "metrics": {
+          "readLatency": "Olvasási késleltetés",
+          "writeLatency": "Írási késleltetés",
+          "queriesPerSec": "Lekérdezés/mp",
+          "database": "Adatbázis",
+          "avg": "átlag",
+          "max": "max",
+          "lastHour": "{count} utolsó órában",
+          "slowQueries": "{count} lassú"
+        },
+        "details": {
+          "title": "Adatbázis részletek",
+          "engine": "Motor",
+          "journal": "Napló",
+          "pageSize": "Oldal méret",
+          "cacheHit": "Gyorsítótár találat",
+          "integrity": "Integritás",
+          "lastVacuum": "Utolsó VACUUM"
+        },
+        "locksWal": {
+          "title": "Zárolások és WAL",
+          "lockWaits": "Zárolásra várakozások",
+          "lockTimeouts": "Zárolás időtúllépések",
+          "avgWait": "Átlag várakozás",
+          "busyTimeouts": "Foglalt időtúllépések",
+          "walSize": "WAL méret",
+          "checkpoints": "Ellenőrzőpontok",
+          "freelistPages": "Freelist oldalak",
+          "cacheSize": "Gyorsítótár méret"
+        },
+        "connectionPool": {
+          "title": "Kapcsolat pool",
+          "poolUsage": "Pool használat",
+          "active": "aktív",
+          "idle": "tétlen",
+          "waiting": "várakozó",
+          "totalCreated": "Összes létrehozva",
+          "connErrors": "Kapcsolati hibák",
+          "threads": "Szálak",
+          "running": "futó",
+          "cached": "gyorsítótárazott"
+        },
+        "innodb": {
+          "title": "InnoDB és zárolások",
+          "bufferPoolHitRate": "Buffer pool találati arány",
+          "bufferPoolSize": "Buffer pool méret",
+          "lockWaits": "Zárolásra várakozások",
+          "deadlocks": "Holtpontok",
+          "avgLockWait": "Átlag zárolási várakozás",
+          "tableLocksWaited": "Táblazárolásokra várva",
+          "tableLocksImmediate": "Azonnali táblazárolások"
+        },
+        "detectionRate": {
+          "title": "Detektálási arány (24ó)",
+          "chartLabel": "Detektálási arány 24 óra alatt",
+          "detectionsTooltip": "{count} detektálás",
+          "perHour": "/ó",
+          "min": "min",
+          "avg": "átlag",
+          "max": "max",
+          "lastBackup": "Utolsó biztonsági mentés",
+          "backupSize": "Mentés méret",
+          "createBackup": "Biztonsági mentés létrehozása",
+          "mysqlHost": "Gazdagép",
+          "mysqlBackupNote": "A MySQL biztonsági mentéseket a mysqldump vagy a MySQL admin eszközökkel kell kezelni."
+        },
+        "tables": {
+          "title": "Táblák",
+          "total": "Összes",
+          "table": "Tábla",
+          "engine": "Motor",
+          "rows": "Sorok",
+          "size": "Méret",
+          "usage": "Használat"
+        }
+      },
+      "backup": {
+        "download": "Mentés letöltése",
+        "downloading": "Letöltés...",
+        "starting": "Mentés indítása...",
+        "creating": "Mentés létrehozása...",
+        "cancel": "Mégse",
+        "retry": "Mentés újra",
+        "mysqlNote": "MySQL mentéshez külső eszközök szükségesek (mysqldump)",
+        "history": {
+          "title": "Mentés előzmények",
+          "creating": "Létrehozás...",
+          "createBackup": "Mentés létrehozása",
+          "noBackups": "Még nincs mentés",
+          "download": "Letöltés",
+          "failed": "Sikertelen",
+          "columns": {
+            "date": "Dátum",
+            "database": "Adatbázis",
+            "size": "Méret",
+            "status": "Állapot",
+            "actions": "Műveletek"
+          },
+          "status": {
+            "pending": "Függőben",
+            "in_progress": "Folyamatban",
+            "completed": "Befejezve",
+            "failed": "Sikertelen"
+          }
+        }
+      },
+      "notInitialized": "Nincs inicializálva",
+      "migration": {
+        "title": "Adatbázis migráció",
+        "description": "Migráció a régi sémáról a normalizált v2 sémára",
+        "requiredNote": "Az adatbázis migráció szükséges a közelgő BirdNET-Go funkciókhoz, amelyek az új normalizált adatbázis sémára támaszkodnak. Az új funkciók nem lesznek elérhetők, amíg a migráció be nem fejeződik.",
+        "completedTitle": "Migráció befejezve",
+        "completedNote": "Az adatbázisa sikeresen migrálva lett az új sémára. Kérjük, indítsa újra a BirdNET-Go-t az új adatbázis használatához. Megjegyzés: Az új adatbázis kisebb, mert hatékonyabban tárolja az adatokat - ez várható és minden adata megmarad.",
+        "starting": "Migráció indítása...",
+        "status": {
+          "idle": "Indításra kész",
+          "initializing": "Inicializálás",
+          "dual_write": "Dupla-írás aktív",
+          "migrating": "Elsődleges migrálása",
+          "migrating_predictions": "Másodlagos migrálása",
+          "paused": "Szüneteltetve",
+          "validating": "Validálás",
+          "cutover": "Átállás folyamatban",
+          "completed": "Migráció befejezve",
+          "failed": "Validálás sikertelen"
+        },
+        "progress": {
+          "title": "Migráció folyamat",
+          "records": "rekordok",
+          "paused": "Migráció szüneteltetve",
+          "percent": "{percent}%",
+          "rate": "{rate} rekord/mp",
+          "rateValue": "{rate} rek/mp",
+          "remaining": "Becsült hátralévő: {time}",
+          "eta": "Becsült hátralévő idő",
+          "dirtyIds": "{count} rekord vár újraszinkronizálásra",
+          "completedTitle": "Migráció befejezve",
+          "completedBody": "Összesen {count} rekord sikeresen migrálva lett a V2 adatbázisba. Az alkalmazás az újraindítás után a V2 adatbázist fogja használni elsődlegesként.",
+          "restartTitle": "Újraindítás szükséges",
+          "restartBody": "Indítsa újra az alkalmazást a V2 adatbázisra való átálláshoz. A régi adatbázis karbantartása az újraindítás után lesz elérhető.",
+          "fallbackError": "A rekordok száma nem egyezik a régi és V2 adatbázisok között. Egyes rekordok esetleg nem migrálódtak helyesen.",
+          "migrateInfo": "A migráció {count} rekordot fog átmásolni a régi adatbázisból az új V2 sémába. A dupla-írás mód biztosítja a nulla adatvesztést a migráció alatt.",
+          "sourceLegacy": "Forrás (Régi)",
+          "targetV2": "Cél (V2)",
+          "recordsLabel": "Rekordok",
+          "sizeLabel": "Méret",
+          "prerequisitesNotMet": "Előfeltételek nem teljesültek — hárítsa el az alábbi kritikus problémákat",
+          "validatingTitle": "Adatok validálása",
+          "validatingBody": "{count} régi rekord összehasonlítása a V2 adatbázissal...",
+          "dirtyRecordsCatchup": "{count} hibás rekord — egyeztetési kísérlet a validálás során",
+          "cutoverTitle": "Átállás befejezése",
+          "cutoverBody": "V2 adatbázisra való átállás véglegesítése...",
+          "migratingPhase": "{phase} migrálása",
+          "progressLabel": "Folyamat",
+          "ofRecords": "/ {count} rekord",
+          "percentComplete": "{percent}% kész",
+          "recordsPerSec": "{rate} rekord/mp",
+          "calculating": "Számítás...",
+          "dirtyWriteFailed": "{count} rekord írása sikertelen — egyeztetésre a validálás során"
+        },
+        "details": {
+          "title": "Adatbázis részletek",
+          "detections": "{count} detektálás",
+          "lastBackup": "Utolsó mentés: {date}",
+          "noBackups": "Nincs mentés",
+          "integrity": "Integritás: {status}"
+        },
+        "strip": {
+          "legacy": "Régi",
+          "v2Target": "V2 (Cél)",
+          "active": "Aktív",
+          "migration": "Migráció",
+          "complete": "Kész",
+          "recordsMigrated": "{count} rekord migrálva",
+          "readyToMigrate": "Migrálásra kész",
+          "recordsInLegacy": "{count} rekord a régiben",
+          "comparingRecords": "Rekordok összehasonlítása...",
+          "validationFailed": "Validálás sikertelen",
+          "rate": "Arány",
+          "recPerSec": "{rate} rek/mp",
+          "dayAvg": "~{count} / nap átlag",
+          "dayHistory": "30 napos előzmény"
+        },
+        "phase": {
+          "indicator": "{current}. fázis / {total}: ",
+          "detections": "Elsődleges detektálások migrálása",
+          "predictions": "Másodlagos detektálások migrálása",
+          "reviews": "Áttekintések migrálása",
+          "comments": "Kommentek migrálása",
+          "locks": "Zárolások migrálása"
+        },
+        "notes": {
+          "in_progress": "A rendszer normálisan használható a migráció háttérben való futása közben.",
+          "dual_write": "Migráció folyamatban. Az adatai biztonságban vannak — az összes új detektálás mindkét adatbázisba mentésre kerül.",
+          "migrating": "A meglévő detektálások másolása az új adatbázisba.",
+          "validating": "Az összes rekord helyes másolásának ellenőrzése. Majdnem kész!",
+          "cutover": "Az új adatbázisra való átállás. Ez csak egy pillanatig tart.",
+          "paused": "A migráció szüneteltetve van. Az adatai biztonságban vannak. Folytassa, amikor készen áll."
+        },
+        "actions": {
+          "start": "Migráció indítása",
+          "pause": "Szüneteltetés",
+          "resume": "Folytatás",
+          "cancel": "Mégse",
+          "rollback": "Visszaállítás",
+          "retryValidation": "Validálás újra"
+        },
+        "confirmDialog": {
+          "title": "Adatbázis migráció indítása",
+          "message": "A migráció átmásolja az Ön detektálási adatait a jelenlegi adatbázisból egy új normalizált adatbázisba. Az eredeti adatbázis változatlan marad. Azonban ajánlott biztonsági mentést készíteni a váratlan problémák esetére.",
+          "checkbox": "Megerősítem, hogy készítettem biztonsági mentést az adatbázisról, vagy megértem a mentés nélküli folytatás kockázatait.",
+          "note": "A fenti \"Mentés letöltése\" gombbal letöltheti a biztonsági mentést."
+        },
+        "confirmCancel": {
+          "title": "Migráció megszakítása?",
+          "message": "Ez leállítja a migrációt és visszatér a tétlen állapotba. Később biztonságosan újraindíthatja a migrációt — a rekordok nem fognak duplikálódni.",
+          "confirm": "Igen, megszakítás",
+          "dismiss": "Nem, futtatás tovább"
+        },
+        "confirmRollback": {
+          "title": "Migráció visszaállítása?",
+          "message": "Ez visszaáll a régi adatbázisra. Az új detektálások, amelyek a migráció óta rögzítésre kerültek, a fejlett adatbázisban megmaradnak, de nem lesznek láthatók, amíg a migráció újra nem fut.",
+          "confirm": "Igen, visszaállítás",
+          "dismiss": "Nem, fejlett megtartása"
+        },
+        "errors": {
+          "startFailed": "A migráció indítása sikertelen",
+          "pauseFailed": "A migráció szüneteltetése sikertelen",
+          "resumeFailed": "A migráció folytatása sikertelen",
+          "cancelFailed": "A migráció megszakítása sikertelen",
+          "rollbackFailed": "A migráció visszaállítása sikertelen",
+          "retryValidationFailed": "A validálás újrapróbálása sikertelen",
+          "fetchFailed": "A migráció állapotának betöltése sikertelen"
+        },
+        "worker": {
+          "running": "Worker fut",
+          "paused": "Worker szüneteltetve",
+          "stopped": "Worker leállítva"
+        },
+        "prerequisites": {
+          "title": "Migráció előtti ellenőrzések",
+          "rerunChecks": "Ellenőrzések újrafuttatása",
+          "critical": "Kritikus",
+          "allPassed": "Minden ellenőrzés sikeres - migrálásra kész",
+          "criticalIssues": "{count} kritikus probléma megoldása szükséges",
+          "warningsCount": "{count} figyelmeztetés",
+          "running": "Migráció előtti ellenőrzések futtatása...",
+          "checkingStep": "{current}. lépés / {total}",
+          "passedCount": "{passed}/{total} sikeres",
+          "criticalCount": "{count} kritikus",
+          "warningCount": "{count} figyelmeztetés",
+          "rerun": "Újrafuttatás",
+          "showDetails": "Részletek megjelenítése",
+          "hideDetails": "Részletek elrejtése",
+          "status": {
+            "passed": "Sikeres",
+            "failed": "Sikertelen",
+            "error": "Hiba",
+            "warning": "Figyelmeztetés",
+            "skipped": "Kihagyva"
+          },
+          "errors": {
+            "fetchFailed": "Az előfeltételek betöltése sikertelen"
+          },
+          "checks": {
+            "state_idle": {
+              "name": "Migráció állapot"
+            },
+            "disk_space": {
+              "name": "Lemezterület"
+            },
+            "legacy_accessible": {
+              "name": "Adatbázis kapcsolat"
+            },
+            "sqlite_integrity": {
+              "name": "Adatbázis integritás"
+            },
+            "mysql_table_health": {
+              "name": "Tábla állapot"
+            },
+            "write_permission": {
+              "name": "Írási engedély"
+            },
+            "mysql_permissions": {
+              "name": "MySQL jogosultságok"
+            },
+            "record_count": {
+              "name": "Rekord szám"
+            },
+            "existing_v2_data": {
+              "name": "Meglévő migrációs adatok"
+            },
+            "no_active_locks": {
+              "name": "Aktív zárolások"
+            },
+            "memory_available": {
+              "name": "Elérhető memória"
+            },
+            "mysql_max_packet": {
+              "name": "MySQL Max Packet"
+            },
+            "mysql_timeout": {
+              "name": "MySQL timeout"
+            }
+          }
+        }
+      }
+    },
+    "metrics": {
+      "cpu": "CPU",
+      "memory": "Memória",
+      "temperature": "Hőmérséklet",
+      "system": "Rendszer",
+      "cores": "mag",
+      "samples": "minták",
+      "available": "elérhető",
+      "min": "Min",
+      "max": "Max",
+      "limit": "Korlát",
+      "tempUnavailable": "Nem elérhető",
+      "online": "Online",
+      "uptime": "Üzemidő",
+      "host": "Gazdagép",
+      "model": "Modell",
+      "inference": "Következtetés",
+      "avgTime": "Átlag",
+      "noInference": "Még nincs adat",
+      "statusOk": "OK",
+      "statusWarning": "Figyelmeztetés",
+      "statusCritical": "Kritikus"
+    },
+    "storage": {
+      "title": "Tárolás",
+      "used": "használt",
+      "free": "szabad",
+      "ram": "RAM"
+    }
+  },
+  "terminal": {
+    "title": "Terminál",
+    "disabled": "A terminal le van tiltva",
+    "disabledDescription": "A böngésző terminal le van tiltva. Engedélyezze a Beállítások → Biztonság menüpontban a funkció használatához.",
+    "connected": "Csatlakoztatva",
+    "disconnected": "Leválasztva",
+    "connecting": "Csatlakozás...",
+    "connectionError": "Kapcsolódás sikertelen",
+    "connectionClosed": "Kapcsolat bezárva",
+    "securityWarning": "Figyelmeztetés: Ez a terminal közvetlen rendszerhéj hozzáférést biztosít a gazdagéphez. Csak megbízható hálózatokon engedélyezze.",
+    "copySelection": "Kijelölés másolása",
+    "expand": "Kibontás",
+    "collapse": "Összecsukás",
+    "fullscreen": "Teljes képernyő",
+    "exitFullscreen": "Teljes képernyőből kilépés",
+    "colorTheme": "Szín téma",
+    "themeDark": "Sötét",
+    "themeLight": "Világos",
+    "themeHighContrast": "Magas kontraszt",
+    "detach": "Megnyitás új ablakban",
+    "detached": "Terminal leválasztva",
+    "detachedDescription": "A terminal egy külön ablakban fut. Zárja be azt az ablakot a visszatéréshez.",
+    "reattach": "Újracsatlakozás"
+  },
+  "analytics": {
+    "title": "Áttekintés",
+    "loadingError": "Néhány analitikai adat betöltése sikertelen. Próbálja később újra.",
+    "stats": {
+      "totalDetections": "Összes detektálás",
+      "uniqueSpecies": "Egyedi fajok",
+      "avgConfidence": "Átl. megbízhatóság",
+      "mostCommon": "Leggyakoribb",
+      "none": "Nincs",
+      "detections": "detektálás",
+      "totalSpecies": "Összes faj",
+      "overallAverage": "Általános átlag"
+    },
+    "periods": {
+      "today": "Ma",
+      "lastWeek": "Utolsó 7 nap",
+      "lastMonth": "Utolsó 30 nap",
+      "last90Days": "Utolsó 90 nap",
+      "lastYear": "Utolsó 12 hónap",
+      "customRange": "Egyéni tartomány",
+      "allTime": "Minden idő"
+    },
+    "filters": {
+      "title": "Adatok szűrése",
+      "timePeriod": "Időszak",
+      "from": "Ettől",
+      "to": "Eddig",
+      "sortBy": "Rendezés",
+      "searchSpecies": "Faj keresése",
+      "searchPlaceholder": "Név alapján keresés...",
+      "reset": "Visszaállítás",
+      "applyFilters": "Szűrők alkalmazása",
+      "exportCsv": "CSV export",
+      "species": "faj",
+      "filtered": "(szűrve)"
+    },
+    "timePeriodOptions": {
+      "allTime": "Minden idő",
+      "today": "Ma",
+      "lastWeek": "Utolsó 7 nap",
+      "lastMonth": "Utolsó 30 nap",
+      "last90Days": "Utolsó 90 nap",
+      "lastYear": "Utolsó 12 hónap",
+      "customRange": "Egyéni tartomány"
+    },
+    "sortOptions": {
+      "mostDetections": "Legtöbb detektálás",
+      "fewestDetections": "Legkevesebb detektálás",
+      "nameAZ": "Név (A-Z)",
+      "nameZA": "Név (Z-A)",
+      "recentlyFirstSeen": "Legutóbb először látva",
+      "earliestFirstSeen": "Legrégebben először látva",
+      "recentlyLastSeen": "Legutóbb utoljára látva",
+      "highestConfidence": "Legmagasabb megbízhatóság"
+    },
+    "charts": {
+      "top10Species": "Top 10 faj",
+      "detectionsByTimeOfDay": "Detektálások napszak szerint",
+      "detectionTrends": "Detektálási trendek",
+      "newSpeciesDetected": "Új fajok észlelve",
+      "noNewSpecies": "Ebben az időszakban nem észleltek új fajokat.",
+      "noDataAvailable": "Nincs elérhető adat",
+      "numberOfDetections": "Detektálások száma",
+      "detections": "Detektálások",
+      "timePeriod": "Időszak",
+      "dailyDetections": "Napi detektálások",
+      "date": "Dátum",
+      "firstHeardOn": "Először hallva",
+      "firstHeardDate": "Első hallás dátuma",
+      "firstHeard": "Első hallás"
+    },
+    "recentDetections": {
+      "title": "Legutóbbi detektálások",
+      "headers": {
+        "dateTime": "Dátum és idő",
+        "species": "Faj",
+        "confidence": "Megbízhatóság",
+        "timeOfDay": "Napszak"
+      },
+      "noRecentDetections": "Nem található legutóbbi detektálás",
+      "unknownSpecies": "Ismeretlen",
+      "unknown": "Ismeretlen"
+    },
+    "species": {
+      "title": "Fajok",
+      "subtitle": "Az összes észlelt madárfaj átfogó listája",
+      "speciesList": "Fajlista",
+      "switchToGrid": "Rács nézetre váltás",
+      "switchToList": "Lista nézetre váltás",
+      "noSpeciesFound": "A szűrőknek megfelelő faj nem található.",
+      "headers": {
+        "species": "Faj",
+        "detections": "Detektálások",
+        "avgConfidence": "Átl. megbízhatóság",
+        "maxConfidence": "Max. megbízhatóság",
+        "firstDetected": "Először észlelve",
+        "lastDetected": "Utoljára észlelve"
+      },
+      "card": {
+        "detections": "Detektálások:",
+        "confidence": "Megbízhatóság:",
+        "first": "Első:"
+      }
+    },
+    "advanced": {
+      "title": "Speciális analitika",
+      "chartControls": "Diagram vezérlők",
+      "dateRange": "Dátumtartomány",
+      "chartOptions": "Diagram opciók",
+      "speciesSelection": "Faj kiválasztása ({count}/{max})",
+      "speciesSelectionHint": "Keresés vagy kattintson a chip-ekre alul",
+      "speciesPlaceholder": "Fajok keresése és kiválasztása elemzéshez...",
+      "noSpeciesFound": "A kiválasztott dátumtartományban nem található faj",
+      "detections": "{count} detektálás",
+      "dateRangeOptions": {
+        "week": "Utolsó hét",
+        "month": "Utolsó hónap",
+        "quarter": "Utolsó negyedév",
+        "year": "Utolsó év",
+        "custom": "Egyéni tartomány"
+      },
+      "options": {
+        "relativeTrends": "Relatív trendek",
+        "zoomPan": "Nagyítás és pásztázás",
+        "brushSelection": "Kefés kijelölés"
+      },
+      "charts": {
+        "timeOfDay": {
+          "title": "Detektálási minták napszak szerint",
+          "description": "A kiválasztott fajok detektálási átlaga mutatja a nap folyamán",
+          "noData": "Nincs elérhető napszak adat",
+          "noDataHint": "Válasszon fajokat és dátumtartományt a minták megtekintéséhez",
+          "axisTime": "Napszak",
+          "axisCount": "Detektálás szám"
+        },
+        "dailyTrend": {
+          "title": "Faj detektálási trendek",
+          "description": "A kiválasztott fajok detektálási trendje az idő függvényében",
+          "noData": "Nincs elérhető trend adat",
+          "noDataHint": "Válasszon fajokat és dátumtartományt a trendek megtekintéséhez",
+          "axisDate": "Dátum",
+          "axisCount": "Detektálás szám",
+          "axisPercentage": "Összes detektálás százaléka"
+        },
+        "diversity": {
+          "title": "Faj sokféleség az idő folyamán",
+          "description": "Az egyedi fajok számát mutatja naponta az összes detektálásból",
+          "noData": "Nincs elérhető sokféleség adat",
+          "noDataHint": "Válasszon dátumtartományt a faj sokféleség trendek megtekintéséhez",
+          "axisDate": "Dátum",
+          "axisUniqueSpecies": "Egyedi fajok"
+        },
+        "tooltips": {
+          "date": "Dátum",
+          "percentage": "Százalék",
+          "detections": "Detektálások",
+          "time": "Idő",
+          "species": "Faj"
+        }
+      },
+      "categories": {
+        "birds": "Madarak"
+      },
+      "filters": {
+        "startDate": "Kezdő dátum",
+        "endDate": "Záró dátum"
+      },
+      "aria": {
+        "startDate": "Kezdő dátum",
+        "endDate": "Záró dátum",
+        "loadingAnalytics": "Analitikai adatok betöltése",
+        "loadingTrends": "Trend adatok betöltése",
+        "loadingDiversity": "Sokféleség adatok betöltése"
+      }
+    },
+    "errors": {
+      "loadFailed": "Az analitikai adatok betöltése sikertelen. Próbálja újra."
+    }
+  },
+  "settings": {
+    "title": "Beállítások - BirdNET-Go",
+    "loading": "Beállítások betöltése...",
+    "sections": {
+      "node": "Általános",
+      "userinterface": "Felület",
+      "audio": "Hang",
+      "filters": "Szűrők",
+      "integration": "Integrációk",
+      "security": "Biztonság",
+      "species": "Fajok",
+      "notifications": "Értesítések",
+      "support": "Támogatás"
+    },
+    "notFound": {
+      "title": "Beállítások nem találhatók",
+      "message": "A kért beállítások szekció \"{section}\" nem található."
+    },
+    "actions": {
+      "save": "Módosítások mentése",
+      "saving": "Mentés...",
+      "reset": "Visszaállítás",
+      "resetAriaLabel": "Összes változtatás visszaállítása",
+      "saveAriaLabel": "Módosítások mentése",
+      "savingAriaLabel": "Módosítások mentése...",
+      "unsavedChanges": "Nem mentett változtatások",
+      "toolbar": "Beállítások műveletek"
+    },
+    "errors": {
+      "loadFailed": "A beállítások betöltése sikertelen",
+      "saveFailed": "A beállítások mentése sikertelen",
+      "databaseStatsFailed": "Az adatbázis statisztikák betöltése sikertelen",
+      "csvDownloadFailed": "A CSV letöltése sikertelen"
+    },
+    "card": {
+      "changed": "megváltozott",
+      "changedAriaLabel": "Beállítások megváltoztak"
+    },
+    "tabs": {
+      "navigation": "Beállítások navigációs lapok",
+      "hasChanges": "Ezen a lapon nem mentett változtatások vannak",
+      "setAsDefault": "Beállítás alapértelmezettként",
+      "defaultIndicator": "Alapértelmezett bemeneti forrás"
+    },
+    "restartRequired": "Néhány változtatáshoz szerver újraindítás szükséges. Kérjük, indítsa újra a BirdNET-Go-t.",
+    "main": {
+      "tabs": {
+        "general": "Általános",
+        "detection": "Detektálás",
+        "location": "Helyszín",
+        "database": "Adatbázis"
+      },
+      "sections": {
+        "main": {
+          "title": "Fő beállítások",
+          "description": "Fő alkalmazás beállítások konfigurálása"
+        },
+        "birdnet": {
+          "title": "BirdNET beállítások",
+          "description": "BirdNET AI modell specifikus beállítások konfigurálása"
+        },
+        "ui": {
+          "title": "Felhasználói felület beállítások",
+          "description": "Felhasználói felület testreszabása"
+        },
+        "customClassifier": {
+          "title": "Egyedi BirdNET osztályozó",
+          "description": "Speciális detektáláshoz egyedi BirdNET modell és címke fájlok konfigurálása",
+          "modelPath": {
+            "label": "Modell útvonal (alkalmazás újraindítást igényel)",
+            "placeholder": "Modell fájl útvonala",
+            "helpText": "Külső BirdNET modell fájl útvonala. Adjon meg abszolút vagy relatív útvonalat a birdnet-go binárishoz. Üresen hagyva az alapértelmezett beágyazott modellt használja."
+          },
+          "labelPath": {
+            "label": "Címke útvonal (alkalmazás újraindítást igényel)",
+            "placeholder": "Címkék fájl útvonala",
+            "helpText": "Külső modell címkék fájl útvonala, .zip vagy .txt fájl. Adjon meg abszolút vagy relatív útvonalat a birdnet-go binárishoz. Üresen hagyva az alapértelmezett beágyazott címkéket használja."
+          }
+        },
+        "dynamicThreshold": {
+          "title": "Dinamikus küszöbérték",
+          "description": "Automatikusan állítja a detektálási érzékenységet a korábbi megfigyelések alapján",
+          "enable": {
+            "label": "Dinamikus küszöbérték engedélyezése (BirdNET-Go specifikus funkció)",
+            "helpText": "Engedélyezi a dinamikus megbízhatósági küszöbérték funkciót az adaptívabb madárhang detektáláshoz."
+          },
+          "trigger": {
+            "label": "Trigger küszöbérték",
+            "helpText": "Az a megbízhatósági szint, amelyen a dinamikus küszöbérték aktiválódik. Ha egy madárhang ezen értéknél nagyobb megbízhatósággal észlelésre kerül, a pozitív egyezések küszöbértéke az azt követő hívásoknál csökkentésre kerül."
+          },
+          "minimum": {
+            "label": "Minimum dinamikus küszöbérték",
+            "helpText": "A minimális érték, amelyre a dinamikus küszöbérték csökkenthető. Ez biztosítja, hogy a küszöbérték ne essen egy nem kívánt szint alá."
+          },
+          "expireTime": {
+            "label": "Dinamikus küszöbérték lejárati idő (óra)",
+            "helpText": "Az órák száma, amely alatt a dinamikus küszöbérték módosítások érvényesek. Ez idő után a dinamikus küszöbérték visszaáll."
+          }
+        },
+        "falsePositiveFilter": {
+          "title": "Hamis pozitív szűrő",
+          "description": "Csökkenti a hamis detektálásokat több megerősítést követelve az átfedő hangszegmensekben",
+          "level": {
+            "label": "Szűrési szint"
+          },
+          "detectionCount": "{count} megerősítés szükséges. {description}",
+          "levels": {
+            "off": "Nincs szűrés - azonnal elfogadja az első detektálást",
+            "lenient": "Gyenge minőségű hanghoz (RTSP kamerák, webkamera mikrofonok)",
+            "moderate": "Kiegyensúlyozott tipikus hobbibeállításokhoz",
+            "balanced": "Eredeti viselkedés 2025 szeptember előtt",
+            "strict": "RPi 4+ szükséges. Kiváló minőségű mikrofonokhoz",
+            "maximum": "RPi 4+ szükséges. Professzionális minőségű mikrofonokhoz"
+          },
+          "hardwareNote": "A szigorú és maximális szintek nagyobb átfedési beállításokat és több CPU erőforrást igényelnek. Ezekhez a szintekhez RPi 4 vagy jobb hardver szükséges.",
+          "overlapAdjusted": "Az átfedési beállítás automatikusan {overlap}s-re állítva a szűrési követelményeknek megfelelően",
+          "overlapReduced": "Az átfedési beállítás {overlap}s-re csökkentve a szűrési szintnek megfelelően"
+        },
+        "rangeFilter": {
+          "title": "Tartomány szűrő",
+          "description": "A detektálást a földrajzi régióban valószínű fajokra korlátozza",
+          "stationLocation": {
+            "label": "Állomás helyszín",
+            "helpText": "Állomás helyszín, az időjárási adatokhoz és a madárfajoknak a régióban való valószínűségére való korlátozáshoz használva."
+          },
+          "latitude": {
+            "label": "Szélesség",
+            "helpText": "Állomás szélesség, az időjárási adatokhoz és a faj tartomány szűréséhez használva."
+          },
+          "longitude": {
+            "label": "Hosszúság",
+            "helpText": "Állomás hosszúság, az időjárási adatokhoz és a faj tartomány szűréséhez használva."
+          },
+          "model": {
+            "label": "Tartomány szűrő modell",
+            "helpText": "BirdNET tartomány szűrő modell verzió: legújabb vagy örökölt."
+          },
+          "threshold": {
+            "label": "Küszöbérték",
+            "helpText": "Szabályozza, hogy mely fajok kerülnek be a helyszíne és az évszak alapján. Az alapértelmezett (0.01) a legtöbb felhasználónak ajánlott. A magasabb értékek (0.05-0.3) kevesebb fajt tartalmaznak magasabb előfordulási valószínűséggel. A nagyon magas értékek (0.5+) csak a leggyakoribb fajokat tartalmazzák."
+          },
+          "speciesCount": {
+            "label": "Jelenlegi faj szám",
+            "helpText": "A tartomány szűrőbe bevont fajok száma. Automatikusan frissül, amikor a küszöbérték, szélesség vagy hosszúság megváltozik.",
+            "loading": "Betöltés...",
+            "viewSpecies": "Fajok megtekintése"
+          },
+          "downloadTitle": "Fajlista letöltése CSV-ként",
+          "csvDownloaded": "Fajlista sikeresen letöltve",
+          "csvDownloadFailed": "A fajlista letöltése sikertelen. Próbálja újra.",
+          "modal": {
+            "title": "Tartomány szűrő fajok",
+            "speciesCount": "Fajok száma:",
+            "threshold": "Küszöbérték:",
+            "latitude": "Szélesség:",
+            "longitude": "Hosszúság:",
+            "loadingSpecies": "Fajok betöltése...",
+            "noSpeciesFound": "A jelenlegi beállításokkal nem található faj",
+            "close": "Bezárás"
+          }
+        },
+        "database": {
+          "title": "Adatbázis beállítások",
+          "description": "Detektálások adatbázis beállításai",
+          "type": {
+            "label": "Adatbázis típus kiválasztása",
+            "helpText": "Válassza ki a detektálások tárolásához használt adatbázis típust."
+          },
+          "sqlite": {
+            "title": "SQLite konfiguráció",
+            "description": "SQLite adatbázis fájl helyének konfigurálása",
+            "note": "A SQLite a legtöbb felhasználónak ajánlott adatbázis típus.",
+            "path": {
+              "label": "SQLite adatbázis útvonal",
+              "placeholder": "Adja meg az SQLite adatbázis útvonalát",
+              "helpText": "Az SQLite adatbázis fájl útvonala az alkalmazás könyvtárhoz viszonyítva"
+            }
+          },
+          "mysql": {
+            "title": "MySQL konfiguráció",
+            "description": "MySQL adatbázis szerver kapcsolódási beállításainak konfigurálása",
+            "host": {
+              "label": "MySQL host",
+              "placeholder": "Adja meg a MySQL host-ot",
+              "helpText": "MySQL adatbázis host (IP vagy hostname)"
+            },
+            "port": {
+              "label": "MySQL port",
+              "helpText": "MySQL adatbázis port (alapértelmezett 3306/TCP)"
+            },
+            "username": {
+              "label": "MySQL felhasználónév",
+              "placeholder": "Adja meg a MySQL felhasználónevet",
+              "helpText": "MySQL adatbázis felhasználónév"
+            },
+            "password": {
+              "label": "MySQL jelszó",
+              "placeholder": "Adja meg a MySQL jelszót",
+              "helpText": "MySQL adatbázis jelszó"
+            },
+            "database": {
+              "label": "MySQL adatbázis",
+              "placeholder": "Adja meg a MySQL adatbázis nevét",
+              "helpText": "MySQL adatbázis név"
+            }
+          },
+          "stats": {
+            "title": "Adatbázis statisztikák",
+            "description": "Az adatbázis futásidejű információi",
+            "loading": "Adatbázis statisztikák betöltése...",
+            "retry": "Újra",
+            "refresh": "Frissítés",
+            "noData": "Nem érhető el adatbázis statisztika.",
+            "type": "Típus",
+            "status": "Állapot",
+            "size": "Méret",
+            "totalDetections": "Összes detektálás",
+            "location": "Helyszín",
+            "connected": "Csatlakoztatva",
+            "disconnected": "Leválasztva"
+          },
+          "errors": {
+            "backupStartFailed": "A mentés indítása sikertelen",
+            "backupStatusFailed": "A mentés állapotának lekérése sikertelen",
+            "backupFailed": "A mentés sikertelen",
+            "backupDownloadFailed": "A mentés letöltése sikertelen"
+          }
+        },
+        "interface": {
+          "title": "Felület",
+          "description": "Nyelv, megjelenítési beállítások és irányítópult korlátok konfigurálása"
+        },
+        "visualContent": {
+          "title": "Vizuális tartalom",
+          "description": "Madár képek és spektrogram megjelenítési opciók konfigurálása"
+        },
+        "userInterface": {
+          "title": "Felhasználói felület beállítások",
+          "description": "Felhasználói felület testreszabása",
+          "interface": {
+            "title": "Felület beállítások",
+            "description": "Válassza ki a preferált nyelvet",
+            "locale": {
+              "label": "Megjelenítési nyelv",
+              "helpText": "Válassza ki a felület nyelvét"
+            }
+          },
+          "language": {
+            "title": "Nyelv",
+            "description": "A felület megjelenítési nyelvének konfigurálása",
+            "locale": {
+              "label": "Felület nyelv",
+              "helpText": "Válassza ki a felület nyelvét"
+            }
+          },
+          "dashboard": {
+            "title": "Irányítópult megjelenítés",
+            "description": "A detektálások megjelenítésének konfigurálása az irányítópulton",
+            "displaySettings": {
+              "title": "Megjelenítési beállítások",
+              "description": "Általános irányítópult megjelenítési opciók konfigurálása, mint például faj korlátok."
+            },
+            "birdImages": {
+              "title": "Madár képek",
+              "description": "Madár faj miniatűr képek konfigurálása a detektálási listákhoz."
+            },
+            "spectrogramGeneration": {
+              "title": "Spektrogram generálás",
+              "description": "Konfigurálja, hogy és hogyan generálódnak a hang spektrogramok a detektálásokhoz."
+            },
+            "general": {
+              "title": "Általános beállítások"
+            },
+            "summaryLimit": {
+              "label": "Max fajok száma a napi összefoglaló táblázatban",
+              "helpText": "A napi összefoglaló táblázatban megjelenített fajok maximális száma (10 és 1000 közötti érték)"
+            },
+            "thumbnails": {
+              "title": "Miniatűr megjelenítés",
+              "summary": {
+                "label": "Miniatűrök megjelenítése a napi összefoglaló táblázatban",
+                "helpText": "Engedélyezze a észlelt fajok miniatűrjeinek megjelenítését a napi összefoglaló táblázatban"
+              },
+              "recent": {
+                "label": "Miniatűrök megjelenítése a legutóbbi detektálások listában",
+                "helpText": "Engedélyezze a észlelt fajok miniatűrjeinek megjelenítését a legutóbbi detektálások listában"
+              },
+              "imageProvider": {
+                "label": "Képszolgáltató",
+                "helpText": "Válassza ki a preferált képszolgáltatót a madár miniatűrökhöz"
+              },
+              "fallbackPolicy": {
+                "label": "Tartalék stratégia",
+                "helpText": "Válassza ki, mi történjen, ha a preferált szolgáltató nem talál képet",
+                "options": {
+                  "all": "Az összes szolgáltató kipróbálása sorrendben",
+                  "none": "Csak a kiválasztott szolgáltató használata"
+                }
+              }
+            },
+            "spectrogram": {
+              "title": "Spektrogram generálás",
+              "mode": {
+                "label": "Generálási mód",
+                "auto": {
+                  "label": "Automatikus (ajánlott)",
+                  "helpText": "A spektrogramok automatikusan generálódnak, amikor a detektálás megtekintésre kerül a felületen. A hosszú detektálási listákhoz a spektrogram generálás hosszú időt vehet igénybe korlátozott CPU erőforrásokkal rendelkező rendszereken."
+                },
+                "prerender": {
+                  "label": "Előrenderelés háttérben",
+                  "helpText": "Automatikusan generálja a spektrogramokat a hang klipek mentésekor. Erőforrás-korlátos rendszereken, mint a Raspberry Pi Zero vagy 3, ez reszponzívabb felületet biztosít, mivel a spektrogramok háttérben renderelődnek, azonban ez a mód több lemezterületet fogyaszt, mivel a spektrogramok minden detektáláshoz létrejönnek."
+                },
+                "userRequested": {
+                  "label": "Csak felhasználó által kért",
+                  "helpText": "Csak akkor generál spektrogramokat, amikor rákattint a generálás gombra. Tökéletes erőforrás-korlátos rendszerekhez (Raspberry Pi 3/Zero) - nulla automatikus terhelés, Ön szabályozza, hogy mikor használ CPU-t."
+                }
+              },
+              "style": {
+                "label": "Spektrogram stílus",
+                "helpText": "Válassza ki a generált spektrogramok vizuális megjelenését.",
+                "preview": "Előnézet",
+                "previewAlt": "Spektrogram stílus előnézet",
+                "options": {
+                  "default": "Alapértelmezett (színes)",
+                  "scientificDark": "Tudományos (sötét)",
+                  "highContrastDark": "Magas kontraszt (sötét)",
+                  "scientific": "Tudományos (világos)"
+                },
+                "descriptions": {
+                  "default": "Színes spektrogram sötét háttérrel",
+                  "scientificDark": "Szürkeárnyalatos Dolph ablakkal, sötét háttérrel",
+                  "highContrastDark": "Magas színtelítettség sötét háttérrel",
+                  "scientific": "Szürkeárnyalatos Dolph ablakkal, világos háttérrel (xeno-canto stílus)"
+                }
+              },
+              "dynamicRange": {
+                "label": "Dinamikus tartomány",
+                "helpText": "Szabályozza a kontrasztot - az alacsonyabb értékek jobban kiemelik a gyenge jeleket, a magasabb értékek több részletet mutatnak.",
+                "options": {
+                  "highContrast": "Magas kontraszt (80 dB)",
+                  "standard": "Standard (100 dB)",
+                  "extended": "Kiterjesztett (120 dB)"
+                },
+                "descriptions": {
+                  "highContrast": "Legjobb gyenge jelekhez. A madárhangok tisztán kiemelkednek a háttérzajból. Ajánlott tudományos/szürkeárnyalatos stílusokhoz.",
+                  "standard": "Alapértelmezett kiegyensúlyozott beállítás. A legtöbb felhasználási esethez jó.",
+                  "extended": "Több részlet látható, de alacsonyabb kontraszt. SoX alapértelmezett érték."
+                }
+              },
+              "enabled": {
+                "label": "Spektrogram előrenderelés engedélyezése",
+                "helpText": "ELAVULT: Használja helyette a Generálási módot. Generálja a spektrogramokat háttérben a detektálások mentésekor a UI lag megszüntetéséhez."
+              }
+            }
+          }
+        }
+      },
+      "fields": {
+        "nodeName": {
+          "label": "Csomópont neve",
+          "placeholder": "Adja meg a csomópont nevét",
+          "helpText": "A csomópont neve a forrás rendszer azonosítására szolgál több csomópontos beállításban, és az MQTT üzenetek azonosítójaként is használatos."
+        },
+        "sensitivity": {
+          "label": "Érzékenység",
+          "helpText": "Detektálási érzékenység. A magasabb értékek nagyobb érzékenységet eredményeznek. Értékek: 0.5, 1.5."
+        },
+        "threshold": {
+          "label": "Küszöbérték",
+          "helpText": "Minimális megbízhatósági küszöbérték. Értékek: 0.01, 0.99."
+        },
+        "overlap": {
+          "label": "Átfedés",
+          "helpText": "Az előrejelzési szegmensek átfedése. Értékek: 0.0, 2.9."
+        },
+        "locale": {
+          "label": "Területi beállítás",
+          "helpText": "A lefordított faj közhasználatú nevek területi beállítása."
+        },
+        "tensorflowThreads": {
+          "label": "TensorFlow CPU szálak",
+          "helpText": "CPU szálak száma. 0-ra állítva az összes elérhető szálat használja."
+        }
+      },
+      "errors": {
+        "localesLoadFailed": "A nyelvi opciók betöltése sikertelen. Alapértelmezettek használata.",
+        "providersLoadFailed": "A képszolgáltatók betöltése sikertelen. Alapértelmezettek használata.",
+        "rangeFilterTestFailed": "A tartomány szűrő beállítások tesztelése sikertelen",
+        "rangeFilterLoadFailed": "A faj lista betöltése sikertelen",
+        "rangeFilterCountFailed": "A faj szám betöltése sikertelen",
+        "mapLibraryLoadFailed": "A térkép könyvtár betöltése sikertelen. Kérjük, frissítse az oldalt.",
+        "mapLoadFailed": "A térkép betöltése sikertelen. Kérjük, próbálja frissíteni az oldalt.",
+        "modalMapLoadFailed": "A modal térkép betöltése sikertelen. Próbálja bezárni és újra megnyitni a modalt."
+      }
+    },
+    "support": {
+      "sections": {
+        "telemetry": {
+          "title": "Hibakövetés és telemetria",
+          "description": "Opcionális hibakövetés a BirdNET-Go megbízhatóságának és teljesítményének javításához"
+        },
+        "diagnostics": {
+          "title": "Támogatás és diagnosztika",
+          "description": "Segítsen a fejlesztőknek gyorsabban javítani a problémákat az alapvető diagnosztikai információk biztosításával"
+        }
+      },
+      "telemetry": {
+        "privacyNotice": "Adatvédelmi nyilatkozat",
+        "privacyPoints": {
+          "noPersonalData": "Személyes adat nem kerül gyűjtésre",
+          "anonymousData": "Minden telemetria adat névtelen",
+          "helpImprove": "A telemetria adatok segítenek a fejlesztőknek azonosítani és javítani a BirdNET-Go problémákat"
+        },
+        "enableTracking": "Hibakövetés engedélyezése (önkéntes)"
+      },
+      "systemId": {
+        "label": "Az Ön rendszer azonosítója",
+        "description": "Használja ezt az ID-t hibák jelentéséhez",
+        "copyButton": "Másolás",
+        "errorLoading": "Rendszer ID betöltése sikertelen"
+      },
+      "diagnostics": {
+        "includeRecentLogs": "Legutóbbi naplók belefoglalása",
+        "includeConfiguration": "Konfiguráció belefoglalása (személyes adatok eltávolítva)",
+        "includeSystemInfo": "Rendszer információ belefoglalása"
+      },
+      "supportReport": {
+        "title": "Támogatási jelentés generálása",
+        "description": {
+          "intro": "A támogatási jelentések **létfontosságúak a hibaelhárításhoz** és drámaian javítják a képességünket a problémák megoldásában. A fejlesztőknek kulcsfontosságú kontextust biztosítanak a rendszer konfigurációjáról, a közelmúltbeli alkalmazási naplókról és a hibamintákról, amelyeket másképp lehetetlen lenne diagnosztizálni."
+        },
+        "githubRequired": {
+          "title": "Szükséges: GitHub issue a támogatási feltöltésekhez",
+          "description": "<strong>A támogatási feltöltésekhez GitHub issue szám szükséges.</strong> Kérjük, <a href=\"https://github.com/tphakala/birdnet-go/issues/new\" target=\"_blank\" class=\"underline font-semibold\">hozzon létre egy GitHub issue-t</a>, amely leírja a problémáját <strong>megelőzőleg</strong> a támogatási jelentés generálását. A kapcsolódó issue nélkül a fejlesztők nem tudnak reagálni a támogatási adatokra."
+        },
+        "githubIssue": {
+          "label": "GitHub issue szám",
+          "placeholder": "pl., 123 vagy #123",
+          "helper": "<a href=\"https://github.com/tphakala/birdnet-go/issues\" target=\"_blank\" class=\"link link-primary\">Meglévő issue-k megtekintése</a> vagy <a href=\"https://github.com/tphakala/birdnet-go/issues/new\" target=\"_blank\" class=\"link link-primary\">új issue létrehozása</a> először"
+        },
+        "whatsIncluded": {
+          "title": "A jelentés tartalma:",
+          "applicationLogs": "**Alkalmazási naplók** - Legutóbbi hibák és debug információk",
+          "configuration": "**Konfiguráció** - Az Ön beállításai személyes adatok eltávolításával",
+          "systemInfo": "**Rendszer információ** - OS verzió, memória és futásidejű részletek",
+          "notIncluded": "**NEM tartalmazza** - Hang fájlok, madár detektálások vagy személyes adatok"
+        },
+        "userMessage": {
+          "label": "A probléma leírása",
+          "placeholder": "Kérjük, írja le a problémát és adja meg a GitHub issue linket, ha van (pl., #123)",
+          "githubTip": "💡 Tipp: Ha van GitHub issue-ja, kérjük, adja meg az issue számát (pl., #123) és említse a Rendszer ID-ját {systemId} a GitHub issue-ban, hogy a fejlesztők összekapcsolhassák az Ön támogatási adatait.",
+          "labelOptional": "További részletek (opcionális)",
+          "placeholderOptional": "Adjon meg további kontextust a problémáról, ami nincs benne a GitHub issue-jában",
+          "systemIdNote": "💡 Tipp: Az Ön Rendszer ID-ja {systemId} automatikusan belekerül a feltöltésbe"
+        },
+        "uploadOption": {
+          "label": "Feltöltés fejlesztőknek (ajánlott)",
+          "labelWithRequirement": "Feltöltés fejlesztőknek (GitHub issue szám szükséges)",
+          "details": {
+            "sentryUpload": "Az adatok a [Sentry](https://sentry.io) felhő szolgáltatásba töltődnek fel",
+            "euDataCenter": "EU adatközpontban tárolva (Frankfurt, Németország)",
+            "privacyCompliant": "Személyes adatok eltávolításával megfelel az adatvédelemnek",
+            "manualWarning": "Csak akkor törölje, ha manuálisan szeretné kezelni a támogatási fájlt"
+          }
+        },
+        "generateButton": {
+          "upload": "Generálás és feltöltés",
+          "download": "Generálás és letöltés"
+        },
+        "statusMessages": {
+          "preparing": "Támogatási dump előkészítése...",
+          "uploadSuccess": "A támogatási dump sikeresen feltöltve a fejlesztőknek!",
+          "uploadSuccessWithId": "A támogatási dump sikeresen feltöltve! Hivatkozási ID: {dumpId}",
+          "downloadSuccess": "A támogatási dump sikeresen generálva! Letöltés...",
+          "generateSuccess": "A támogatási dump sikeresen generálva!",
+          "generateFailed": "A támogatási dump generálása sikertelen: {message}",
+          "error": "Hiba: {message}",
+          "githubIssueRequired": "Kérjük, adja meg a GitHub issue számot a támogatási adatok feltöltéséhez"
+        }
+      }
+    },
+    "notifications": {
+      "tabs": {
+        "channels": "Csatornák",
+        "rules": "Szabályok",
+        "history": "Előzmények"
+      },
+      "rules": {
+        "summary": {
+          "active": "aktív",
+          "builtIn": "beépített",
+          "total": "összesen"
+        }
+      },
+      "sections": {
+        "testing": {
+          "title": "Értesítések tesztelése",
+          "description": "Teszt értesítések küldése az értesítési rendszer ellenőrzéséhez"
+        },
+        "info": {
+          "title": "Rendszer információ",
+          "description": "Tudnivalók az értesítések megtekintéséről és kezeléséről"
+        }
+      },
+      "templates": {
+        "title": "Értesítési sablonok",
+        "description": "Új faj detektálási értesítések üzeneteinek testreszabása sablon változókkal",
+        "newSpeciesTitle": "Új faj értesítési sablon",
+        "titleLabel": "Cím sablon",
+        "titlePlaceholder": "pl., Új faj: {{.CommonName}}",
+        "messageLabel": "Üzenet sablon",
+        "messagePlaceholder": "pl., {{.CommonName}} ({{.ScientificName}}) első detektálása {{.ConfidencePercent}}% megbízhatósággal",
+        "resetButton": "Visszaállítás",
+        "saveButton": "Sablonok mentése",
+        "saveButtonUnsaved": "Sablonok mentése *",
+        "testButton": "Teszt",
+        "savingButton": "Mentés...",
+        "sendingButton": "Küldés...",
+        "resetConfirm": "Sablonok visszaállítása alapértelmezettekre? Ez elveszi a jelenlegi változtatásokat és visszaállítja az alapértelmezett sablon értékeket.",
+        "unsavedChangesWarning": "Van nem mentett sablon változtatása. A teszt a jelenleg mentett sablonokat fogja használni, nem az Ön szerkesztéseit. Folytatja?",
+        "testWithUnsavedChanges": "Figyelmeztetés: Vannak nem mentett változtatások. A teszt a mentett sablonokat fogja használni.",
+        "testNormal": "Teszt értesítés küldése",
+        "saveSuccess": "Sablonok sikeresen mentve!",
+        "saveError": "Hiba: {message}",
+        "availableVariables": "Elérhető sablon változók",
+        "variablesDescription": "Használja ezeket a változókat a sablonjaiban ezzel a szintaxissal",
+        "loading": "Betöltés...",
+        "fields": {
+          "commonName": "Faj közhasználatú neve (pl., \"Sisakos cinege\")",
+          "scientificName": "Tudományos név (pl., \"Lophophanes cristatus\")",
+          "confidence": "Megbízhatósági érték (0.0 - 1.0)",
+          "confidencePercent": "Megbízhatóság százalékként (pl., \"99\")",
+          "detectionTime": "Detektálás ideje (pl., \"14:30:45\")",
+          "detectionDate": "Detektálás dátuma (pl., \"2024-10-05\")",
+          "latitude": "GPS szélesség koordináta",
+          "longitude": "GPS hosszúság koordináta",
+          "location": "Formázott koordináták (pl., \"42.360100, -71.058900\")",
+          "detectionId": "Detektálás ID szám (pl., \"1234\")",
+          "detectionPath": "Relatív útvonal a detektáláshoz (pl., \"/ui/detections/1234\")",
+          "detectionUrl": "Teljes URL a detektáláshoz a felületen",
+          "imageUrl": "Link a faj képéhez",
+          "daysSinceFirstSeen": "Napok száma az első detektálás óta"
+        }
+      },
+      "testNotification": {
+        "title": "Új faj teszt értesítés küldése",
+        "description": "Generál egy teszt értesítést egy új faj detektáláshoz az értesítési rendszer ellenőrzéséhez",
+        "whatHappens": "Mi történik a 'Teszt küldése' gombra kattintáskor:",
+        "sendButton": "Teszt küldése",
+        "sendingButton": "Küldés...",
+        "statusMessages": {
+          "sending": "Teszt értesítés küldése...",
+          "success": "Teszt értesítés sikeresen elküldve! Ellenőrizze az értesítési csengőjét.",
+          "error": "A teszt értesítés küldése sikertelen: {message}",
+          "serviceUnavailable": "Az értesítési szolgáltatás nem érhető el. Kérjük, ellenőrizze az értesítési beállításokat."
+        }
+      },
+      "statusMessages": {
+        "sending": "Teszt értesítés küldése...",
+        "success": "Teszt értesítés sikeresen elküldve!",
+        "error": "A teszt értesítés küldése sikertelen: {message}",
+        "serviceUnavailable": "Az értesítési szolgáltatás nem érhető el. Kérjük, ellenőrizze az értesítési beállításokat."
+      },
+      "systemInfo": {
+        "howToView": "Értesítések megtekintése:",
+        "technicalDetails": "Műszaki részletek a BirdNET-Go értesítéseiről:"
+      },
+      "privacy": {
+        "title": "Adatvédelmi nyilatkozat külső webhookokhoz",
+        "description": "A detektálási értesítések érzékeny adatokat tartalmazhatnak, amikor külső szolgáltatásokhoz küldésre kerülnek:",
+        "gps": "GPS koordináták",
+        "gpsDetails": "Pontos helyszín (szélesség/hosszúság), ha konfigurálva van",
+        "urls": "Detektálási URL-ek",
+        "urlsDetails": "Belső hálózati információkat tehet közzé",
+        "species": "Faj adatok",
+        "speciesDetails": "Milyen madarakat észleltek és mikor",
+        "recommendation": "Csak akkor engedélyezze a külső webhookokat, ha megbízik a fogadó szolgáltatásban, vagy önmagában tárolt/helyi szolgáltatásokat használ."
+      },
+      "push": {
+        "title": "Push értesítések",
+        "description": "Értesítések küldése külső szolgáltatásokba, mint Discord, Telegram, Slack és még sok más",
+        "enable": "Push értesítések engedélyezése",
+        "disabled": "A push értesítések le vannak tiltva",
+        "enabledDescription": "Push értesítések lesznek küldve az összes engedélyezett szolgáltatóhoz lent",
+        "filters": {
+          "title": "Detektálási szűrők",
+          "description": "Szabályozza, hogy mely madár detektálások váltsanak ki push értesítéseket",
+          "minConfidence": {
+            "label": "Minimális megbízhatóság",
+            "helpText": "Csak ennél a megbízhatósági szint felett küld értesítést. 0-ra állítva tilthatja."
+          },
+          "speciesCooldown": {
+            "label": "Faj hűtési idő",
+            "unit": "perc",
+            "helpText": "Megakadályozza az ismételt értesítéseket ugyanahhoz a fajhoz ebben az időablakban. 0-ra állítva tilthatja."
+          }
+        },
+        "noProviders": "Nincs szolgáltató konfigurálva",
+        "noProvidersDescription": "Adjon hozzá egy szolgáltatót a push értesítések fogadásához",
+        "providers": {
+          "title": "Értesítési szolgáltatók",
+          "addButton": "Szolgáltató hozzáadása",
+          "editButton": "Szerkesztés",
+          "deleteButton": "Törlés",
+          "enableToggle": "Szolgáltató engedélyezése",
+          "urlsPreview": "{count} URL konfigurálva",
+          "deleteConfirm": "Szolgáltató törlése \"{name}\"? Ez a művelet nem vonható vissza.",
+          "typeBadge": {
+            "shoutrrr": "Shoutrrr",
+            "webhook": "Webhook"
+          }
+        },
+        "form": {
+          "addTitle": "Értesítési szolgáltató hozzáadása",
+          "editTitle": "Értesítési szolgáltató szerkesztése",
+          "name": {
+            "label": "Szolgáltató neve",
+            "placeholder": "pl., Discord riasztások",
+            "helpText": "Egy barátságos név a szolgáltató azonosításához"
+          },
+          "urls": {
+            "label": "Szolgáltatás URL(ek)",
+            "placeholder": "discord://token@webhookid",
+            "helpText": "Adjon meg egy Shoutrrr URL-t soronként. Több URL több szolgáltatáshoz küld.",
+            "validation": {
+              "required": "Legalább egy URL szükséges",
+              "invalidFormat": "Érvénytelen URL formátum. Az URL-eknek szolgáltatás előtaggal kell kezdődniük (pl., discord://, telegram://)"
+            }
+          },
+          "notificationTypes": {
+            "label": "Értesítési típusok",
+            "helpText": "Válassza ki, hogy mely típusú értesítéseket küldje ehhez a szolgáltatóhoz",
+            "detection": "Madár detektálások",
+            "error": "Hibák",
+            "warning": "Figyelmeztetések",
+            "info": "Információ",
+            "system": "Rendszer események"
+          },
+          "urlFormats": {
+            "title": "Gyakori URL formátumok",
+            "discord": "Discord",
+            "discordFormat": "discord://token@webhookid",
+            "telegram": "Telegram",
+            "telegramFormat": "telegram://token@telegram?chats=@channel",
+            "slack": "Slack",
+            "slackFormat": "slack://token-a/token-b/token-c",
+            "pushover": "Pushover",
+            "pushoverFormat": "pushover://shoutrrr:apiToken@userKey",
+            "gotify": "Gotify",
+            "gotifyFormat": "gotify://hostname/token",
+            "ntfy": "ntfy",
+            "ntfyFormat": "ntfy://ntfy.sh/mytopic",
+            "moreServices": "Összes támogatott szolgáltatás megtekintése",
+            "shoutrrrDocs": "https://github.com/nicholas-fedor/shoutrrr?tab=readme-ov-file#supported-services"
+          },
+          "saveButton": "Szolgáltató mentése",
+          "savingButton": "Mentés...",
+          "cancelButton": "Mégse",
+          "testButton": "Teszt",
+          "testingButton": "Tesztelés..."
+        },
+        "test": {
+          "button": "Szolgáltató tesztelése",
+          "description": "Teszt értesítés küldése a szolgáltató működésének ellenőrzéséhez",
+          "success": "Teszt értesítés sikeresen elküldve!",
+          "error": "Teszt sikertelen: {message}",
+          "requiresUrl": "Adjon meg URL-t a teszthez",
+          "requiresEnabled": "Engedélyezze a szolgáltatót a teszthez"
+        },
+        "validation": {
+          "nameRequired": "A szolgáltató neve kötelező",
+          "urlRequired": "Legalább egy URL szükséges",
+          "invalidUrl": "Érvénytelen URL formátum"
+        },
+        "autoName": {
+          "discord": "Discord",
+          "telegram": "Telegram",
+          "slack": "Slack",
+          "pushover": "Pushover",
+          "gotify": "Gotify",
+          "ntfy": "ntfy",
+          "email": "E-mail",
+          "generic": "Shoutrrr",
+          "numbered": "{service} #{number}"
+        },
+        "services": {
+          "selectLabel": "Szolgáltatás",
+          "selectHelpText": "Válassza ki a konfigurálni kívánt értesítési szolgáltatást",
+          "discord": {
+            "name": "Discord",
+            "webhookUrl": {
+              "label": "Discord webhook URL",
+              "placeholder": "https://discord.com/api/webhooks/...",
+              "helpText": "Illessze be a teljes Discord webhook URL-t"
+            },
+            "invalidUrl": "Érvénytelen Discord webhook URL. Az URL-nek discord.com/api/webhooks/ kell, hogy tartalmazzon"
+          },
+          "telegram": {
+            "name": "Telegram",
+            "botToken": {
+              "label": "Bot token",
+              "placeholder": "123456789:ABCdef...",
+              "helpText": "Token a @BotFather-től"
+            },
+            "chatId": {
+              "label": "Chat ID",
+              "placeholder": "-1001234567890 vagy @channel",
+              "helpText": "Chat ID, csoport ID vagy @username"
+            },
+            "incomplete": "A bot token és chat ID egyaránt szükséges"
+          },
+          "ntfy": {
+            "name": "ntfy",
+            "server": {
+              "label": "Szerver",
+              "placeholder": "ntfy.sh",
+              "helpText": "Hagyja ntfy.sh-n a nyilvános szerverhez, vagy adja meg a saját önálló szerverét"
+            },
+            "protocol": {
+              "label": "Protokoll"
+            },
+            "testConnection": "Kapcsolat tesztelése",
+            "connectionOk": {
+              "https": "A HTTPS működik",
+              "http": "A HTTP működik — a szerver nem HTTPS-t használ"
+            },
+            "connectionFailed": "Nem sikerült csatlakozni — ellenőrizze a hostnevet és a szerver állapotát",
+            "auth": {
+              "label": "Hitelesítés (opcionális)",
+              "username": {
+                "label": "Felhasználónév",
+                "placeholder": "admin"
+              },
+              "password": {
+                "label": "Jelszó / Hozzáférési token",
+                "placeholder": "tk_AgQdq7mVBoFD37zQVN29RioLJNGht"
+              }
+            },
+            "topic": {
+              "label": "Téma",
+              "placeholder": "my-bird-alerts",
+              "helpText": "Téma neve az értesítéseihez"
+            },
+            "incomplete": "A téma kötelező"
+          },
+          "gotify": {
+            "name": "Gotify",
+            "server": {
+              "label": "Szerver URL",
+              "placeholder": "gotify.example.com",
+              "helpText": "A Gotify szerver hostname (https:// nélkül)"
+            },
+            "token": {
+              "label": "Alkalmazás token",
+              "placeholder": "A...",
+              "helpText": "Token a Gotify Alkalmazások oldaláról"
+            },
+            "incomplete": "A szerver és token egyaránt szükséges"
+          },
+          "pushover": {
+            "name": "Pushover",
+            "apiToken": {
+              "label": "API token",
+              "placeholder": "az...",
+              "helpText": "Alkalmazás API token"
+            },
+            "userKey": {
+              "label": "Felhasználói kulcs",
+              "placeholder": "u...",
+              "helpText": "Az Ön felhasználói vagy csoport kulcsa"
+            },
+            "incomplete": "Az API token és felhasználói kulcs egyaránt szükséges"
+          },
+          "slack": {
+            "name": "Slack",
+            "webhookUrl": {
+              "label": "Slack webhook URL",
+              "placeholder": "https://hooks.slack.com/services/...",
+              "helpText": "Illessze be a teljes Slack webhook URL-t"
+            },
+            "invalidUrl": "Érvénytelen Slack webhook URL. Az URL-nek hooks.slack.com/services/ kell, hogy tartalmazzon"
+          },
+          "ifttt": {
+            "name": "IFTTT",
+            "webhookKey": {
+              "label": "Webhook kulcs",
+              "placeholder": "abc123xyz...",
+              "helpText": "Az Ön IFTTT Webhook kulcsa a Maker Webhooks beállításokból"
+            },
+            "eventName": {
+              "label": "Esemény neve",
+              "placeholder": "bird_detected",
+              "helpText": "Az esemény neve az IFTTT applet aktiválásához"
+            },
+            "incomplete": "A webhook kulcs és esemény név egyaránt szükséges"
+          },
+          "webhook": {
+            "name": "Webhook",
+            "url": {
+              "label": "Webhook URL",
+              "placeholder": "https://api.example.com/webhook",
+              "helpText": "A HTTP(S) végpont az értesítések küldéséhez"
+            },
+            "method": {
+              "label": "HTTP metódus",
+              "helpText": "A kéréshez használandó HTTP metódus (alapértelmezett: POST)"
+            },
+            "auth": {
+              "label": "Hitelesítés",
+              "none": "Nincs",
+              "bearer": "Bearer token",
+              "basic": "Basic auth",
+              "helpText": "Opcionális hitelesítés a webhook végponthoz"
+            },
+            "bearerToken": {
+              "label": "Bearer token",
+              "placeholder": "your-api-token",
+              "helpText": "Token az Authorization: Bearer fejlécben küldve"
+            },
+            "basicUser": {
+              "label": "Felhasználónév",
+              "placeholder": "username"
+            },
+            "basicPass": {
+              "label": "Jelszó",
+              "placeholder": "password"
+            },
+            "basicAuth": {
+              "helpText": "Hitelesítési adatok HTTP Basic hitelesítéssel küldve"
+            },
+            "invalidUrl": "Érvénytelen URL. http:// vagy https:// kell, hogy kezdődjön",
+            "tokenRequired": "A Bearer token kötelező Bearer hitelesítés használatakor",
+            "credentialsRequired": "A felhasználónév és jelszó egyaránt szükséges Basic hitelesítés használatakor"
+          },
+          "custom": {
+            "name": "Egyedi URL",
+            "url": {
+              "label": "Shoutrrr URL",
+              "placeholder": "service://credentials@host",
+              "helpText": "Adjon meg egy nyers Shoutrrr URL-t bármely támogatott szolgáltatáshoz"
+            },
+            "invalidUrl": "Érvénytelen URL formátum. service:// kell, hogy legyen az elején"
+          }
+        }
+      }
+    },
+    "filters": {
+      "title": "Szűrők",
+      "privacyFiltering": {
+        "title": "Adatvédelmi szűrés",
+        "description": "Az adatvédelmi szűrés elkerüli a hang klipek mentését, amikor emberi hangokat érzékel",
+        "enable": "Adatvédelmi szűrés engedélyezése",
+        "disabled": "Az adatvédelmi szűrés le van tiltva",
+        "confidenceLabel": "Megbízhatósági küszöbérték az emberi detektáláshoz",
+        "confidenceHelp": "Állítsa be az emberi hang detektálás megbízhatósági szintjét, az alacsonyabb érték érzékenyebbé teszi a szűrőt"
+      },
+      "falsePositivePrevention": {
+        "title": "Hamis pozitív megelőzés",
+        "description": "Hamis detektálási szűrők konfigurálása",
+        "enableDogBark": "Kutyaugatás szűrő engedélyezése",
+        "disabled": "A kutyaugatás szűrő le van tiltva",
+        "confidenceLabel": "Megbízhatósági küszöbérték",
+        "confidenceHelp": "Állítsa be a kutyaugatás detektálás megbízhatósági szintjét, az alacsonyabb érték érzékenyebbé teszi a szűrőt",
+        "expireTimeLabel": "Kutyaugatás lejárati idő (perc)",
+        "expireTimeHelp": "Állítsa be, mennyi ideig jegyezze meg az észlelt kutyaugatást",
+        "addDogBarkSpeciesLabel": "Kutyaugatás fajok hozzáadása",
+        "addDogBarkSpeciesHelp": "Keresés és hozzáadás olyan fajokhoz, amelyek összetéveszthetők a kutyák ugatásával",
+        "addSpeciesButton": "Hozzáadás"
+      },
+      "speciesNamePlaceholder": "Faj neve",
+      "typeSpeciesName": "Adja meg a faj nevét...",
+      "dogBarkSpeciesList": "Kutyaugatás faj lista",
+      "daylightFilter": {
+        "title": "Nappali szűrő",
+        "description": "Szűrje ki az éjszakai fajok detektálásait a nappali órákban. A konfigurált helyszín civil hajnal/alkonyat határait használja.",
+        "enable": "Nappali szűrő engedélyezése",
+        "disabled": "A nappali szűrő le van tiltva",
+        "offsetLabel": "Nappali ablak eltolás (óra)",
+        "offsetHelp": "Állítsa be a nappali ablakot. A pozitív értékek csökkentik (engedékenyebb, pl. +1 = 1 órával napkelte után kezdődik). A negatív értékek bővítik (szigorúbb, pl. -1 = 1 órával napkelte előtt kezdődik).",
+        "speciesListLabel": "Éjszakai faj lista",
+        "addSpeciesLabel": "Éjszakai faj hozzáadása",
+        "addSpeciesHelp": "Keresés és hozzáadás olyan fajokhoz, nemzetségekhez, családokhoz vagy rendekhez, amelyeket nappal szűrni kell. Alapértelmezett: Strigiformes (minden bagoly). Megjegyzés: az üres lista letiltja a nappali faj szűrést."
+      },
+      "errors": {
+        "speciesLoadFailed": "A faj lista betöltése sikertelen. Próbálja újra."
+      }
+    },
+    "integration": {
+      "birdweather": {
+        "title": "BirdWeather",
+        "description": "Detektálások feltöltése a BirdWeather-re",
+        "ffmpegWarning": {
+          "title": "FFmpeg nem észlelhető",
+          "message": "Kérjük, telepítse az FFmpeg-et a FLAC kódolás támogatásához, a BirdWeather megszünteti a WAV feltöltéseket a tömörített FLAC hangfájlok javára."
+        },
+        "enable": "BirdWeather feltöltések engedélyezése",
+        "token": {
+          "label": "BirdWeather token",
+          "helpText": "Az Ön egyedi BirdWeather token-je."
+        },
+        "threshold": {
+          "label": "Feltöltési küszöbérték",
+          "helpText": "Minimális megbízhatósági küszöbérték a BirdWeather-re történő feltöltésekhez."
+        },
+        "test": {
+          "button": "BirdWeather kapcsolat tesztelése",
+          "loading": "Tesztelés...",
+          "enabledRequired": "A BirdWeather-t engedélyezni kell a teszthez",
+          "tokenRequired": "A BirdWeather token-t meg kell adni",
+          "inProgress": "Teszt folyamatban...",
+          "description": "BirdWeather kapcsolat tesztelése"
+        }
+      },
+      "mqtt": {
+        "title": "MQTT",
+        "description": "MQTT broker kapcsolat konfigurálása",
+        "enable": "MQTT integráció engedélyezése",
+        "broker": {
+          "label": "MQTT broker",
+          "placeholder": "mqtt://localhost:1883"
+        },
+        "topic": {
+          "label": "MQTT téma",
+          "placeholder": "birdnet/detections"
+        },
+        "authentication": {
+          "title": "Hitelesítés",
+          "username": {
+            "label": "Felhasználónév"
+          },
+          "password": {
+            "label": "Jelszó",
+            "helpText": "Az MQTT jelszó."
+          }
+        },
+        "tls": {
+          "title": "TLS/SSL biztonság",
+          "enable": "TLS/SSL engedélyezése",
+          "skipVerify": "Tanúsítvány ellenőrzés kihagyása",
+          "configNote": "<strong>TLS konfiguráció:</strong><br />• Szabványos TLS: A nyilvános broker-ekhez hagyja üresen a tanúsítványokat<br />• Önaláírt tanúsítványok: Add meg a CA tanúsítványt<br />• Közös TLS (mTLS): Add meg mind a három tanúsítványt",
+          "certificates": {
+            "title": "Tanúsítvány kezelés",
+            "description": "Tanúsítványok feltöltése biztonságos MQTT broker kapcsolatokhoz",
+            "caLabel": "CA tanúsítvány",
+            "caPlaceholder": "-----BEGIN CERTIFICATE-----",
+            "caHelpText": "Tanúsítvány hatóság tanúsítványa a broker identitásának ellenőrzéséhez",
+            "clientCertLabel": "Ügyfél tanúsítvány",
+            "clientCertPlaceholder": "-----BEGIN CERTIFICATE-----",
+            "clientCertHelpText": "Ügyfél tanúsítvány a kölcsönös TLS hitelesítéshez",
+            "clientKeyLabel": "Ügyfél privát kulcs",
+            "clientKeyPlaceholder": "-----BEGIN PRIVATE KEY-----",
+            "clientKeyHelpText": "Az ügyfél tanúsítvánnyal egyező privát kulcs",
+            "uploadButton": "Tanúsítványok feltöltése",
+            "uploadSuccess": "MQTT TLS tanúsítványok sikeresen feltöltve. Használja a kapcsolat teszt gombot az ellenőrzéshez.",
+            "uploadError": "Az MQTT TLS tanúsítványok feltöltése sikertelen",
+            "deleteConfirm": "Összes MQTT TLS tanúsítvány eltávolítása? Az MQTT kliensnek újra kell csatlakoznia.",
+            "deleteSuccess": "MQTT TLS tanúsítványok eltávolítva",
+            "deleteError": "Az MQTT TLS tanúsítványok eltávolítása sikertelen",
+            "loadError": "A tanúsítvány információ betöltése sikertelen",
+            "reconnectNote": "Használja a kapcsolat teszt gombot lent az új TLS konfiguráció ellenőrzéséhez."
+          }
+        },
+        "homeAssistant": {
+          "title": "Home Assistant auto-felfedezés",
+          "enable": "Home Assistant MQTT felfedezés engedélyezése",
+          "description": "Ha engedélyezve van, a BirdNET-Go automatikusan regisztrálja az eszközöket és érzékelőket a Home Assistant-nál az MQTT felfedezés protokollon keresztül. Az eszközök megjelennek a Home Assistant eszköz nyilvántartásában manuális YAML konfiguráció nélkül.",
+          "discoveryPrefix": {
+            "label": "Felfedezés előtag",
+            "helpText": "Az MQTT téma előtag a Home Assistant felfedezés üzenetekhez. Az alapértelmezett 'homeassistant'. Csak akkor változtassa meg, ha egyedi felfedezés előtagot konfigurált a Home Assistant-ban."
+          },
+          "deviceName": {
+            "label": "Eszköz név",
+            "helpText": "Az alap nevet az eszközökhöz, ahogy megjelennek a Home Assistant-ban. Minden hang forrásnak saját eszköze lesz, amely ehhez a fő BirdNET-Go eszközhöz lesz kapcsolva."
+          },
+          "sensorsNote": "<strong>Létrehozott érzékelők:</strong> Minden hang forráshoz a Home Assistant megkapja: Utolsó faj, Megbízhatóság, Tudományos név és Hangszint (ha engedélyezve van). A bridge eszköz tartalmazza az online/offline elérhetőségi állapotot.",
+          "discovery": {
+            "button": "Felfedezés küldése",
+            "success": "Felfedezés üzenetek elküldve a Home Assistant-nak",
+            "error": "A felfedezés üzenetek küldése sikertelen",
+            "saveFirst": "Mentse a beállításokat a felfedezés előtt"
+          },
+          "retain": {
+            "label": "Üzenetek megtartása",
+            "note": "<strong>Ajánlott:</strong> Engedélyezze a megtartás jelzőt a MQTT érzékelők értékeinek megjelenítéséhez a Home Assistant újraindítása után."
+          }
+        },
+        "test": {
+          "button": "MQTT kapcsolat tesztelése",
+          "loading": "Tesztelés...",
+          "enabledRequired": "Az MQTT-t engedélyezni kell a teszthez",
+          "brokerRequired": "Az MQTT broker-t meg kell adni",
+          "inProgress": "Teszt folyamatban...",
+          "description": "MQTT kapcsolat tesztelése"
+        }
+      },
+      "observability": {
+        "title": "Megfigyelhetőség",
+        "description": "A BirdNET-Go teljesítményének és madár detektálási metrikáinak monitorozása Prometheus-kompatibilis végponton keresztül",
+        "enable": "Megfigyelhetőség integráció engedélyezése",
+        "disabled": "A megfigyelhetőség integráció nincs engedélyezve",
+        "listenAddress": {
+          "label": "Figyelési cím",
+          "placeholder": "0.0.0.0:8090",
+          "ipLabel": "Bind cím",
+          "portLabel": "Port",
+          "allInterfaces": "Minden interfész",
+          "loopback": "Loopback",
+          "customAddress": "Egyedi cím",
+          "interfaceDown": "le"
+        }
+      },
+      "weather": {
+        "title": "Időjárás",
+        "description": "Időjárás adatgyűjtés konfigurálása",
+        "provider": {
+          "label": "Időjárás szolgáltató",
+          "options": {
+            "none": "Nincs",
+            "yrno": "Yr.no",
+            "openweather": "OpenWeather",
+            "wunderground": "Weather Underground"
+          }
+        },
+        "wunderground": {
+          "apiKey": {
+            "label": "Weather Underground API kulcs",
+            "helpText": "Adja meg a Weather Underground API kulcsát. Az időjárási adatokhoz szükséges."
+          },
+          "stationId": {
+            "label": "Állomás ID",
+            "helpText": "Az Ön Weather Underground PWS állomás ID-ja (pl., KCAOAKLA12)."
+          },
+          "endpoint": {
+            "label": "API végpont",
+            "helpText": "Felülbírálhatja az alapértelmezett Weather Underground API végpontot, ha szükséges. Ha üresen hagyja, az alapértelmezett https://api.weather.com/v2/pws/observations/current."
+          },
+          "units": {
+            "label": "Egységek",
+            "helpText": "Válassza ki a hőmérséklet és szélsebesség egységeit (m = Metrikus, e = Imperiális, h = UK hibrid)."
+          }
+        },
+        "notes": {
+          "none": "Nem lesz időjárási adat lekérve.",
+          "yrno": {
+            "description": "Az időjárás előrejelzési adatokat a Yr.no biztosítja, a Norwegian Meteorological Institute (met.no) és a Norwegian Broadcasting Corporation (NRK) közös szolgáltatása.",
+            "freeService": "Az Yr egy ingyenes időjárás adat szolgáltatás. További információkért látogasson el a <a href=\"https://hjelp.yr.no/hc/en-us/articles/206550539-Facts-about-Yr\" class=\"link link-primary\" target=\"_blank\" rel=\"noopener noreferrer\">Yr.no</a> oldalra."
+          },
+          "openweather": "Az OpenWeather használatához API kulcs szükséges, regisztráljon ingyenes API kulcsért a <a href=\"https://home.openweathermap.org/users/sign_up\" class=\"link link-primary\" target=\"_blank\" rel=\"noopener noreferrer\">OpenWeather</a> oldalon.",
+          "wunderground": "Weather Underground API kulcs és érvényes PWS állomás ID szükséges. Lásd <a href=\"https://www.wunderground.com/member/devices\" class=\"link link-primary\" target=\"_blank\" rel=\"noopener noreferrer\">Weather Underground</a> részletekért."
+        },
+        "apiKey": {
+          "label": "API kulcs",
+          "helpText": "Az Ön API kulcsa a kiválasztott időjárás szolgáltatóhoz. Tartsa titkosan!"
+        },
+        "units": {
+          "label": "Mérési egységek",
+          "options": {
+            "standard": "Standard",
+            "metric": "Metrikus",
+            "imperial": "Imperiális",
+            "ukhybrid": "UK hibrid"
+          }
+        },
+        "test": {
+          "button": "Időjárás szolgáltató tesztelése",
+          "loading": "Tesztelés...",
+          "noProvider": "Nincs időjárás szolgáltató kiválasztva",
+          "apiKeyRequired": "Az API kulcsot meg kell adni",
+          "inProgress": "Teszt folyamatban...",
+          "description": "Időjárás szolgáltató kapcsolat tesztelése"
+        },
+        "temperatureUnit": {
+          "label": "Hőmérséklet megjelenítési egység",
+          "helpText": "Válassza ki, hogyan jelenjenek meg a hőmérsékletek az alkalmazásban.",
+          "options": {
+            "celsius": "Celsius (°C)",
+            "fahrenheit": "Fahrenheit (°F)"
+          }
+        }
+      },
+      "errors": {
+        "connectionError": "Kapcsolódási hiba",
+        "responseStreamFailed": "A válasz stream olvasása sikertelen",
+        "configurationCheck": "Konfiguráció ellenőrzés",
+        "testStageFallback": "Teszt szint fallback"
+      },
+      "ebird": {
+        "title": "eBird",
+        "description": "Csatlakozás az eBird taxonómia adatbázishoz a gazdagított faj adatokhoz, beleértve a taxonómiai besorolást és alfaj információkat.",
+        "enable": "eBird integráció engedélyezése",
+        "enabledRequired": "Az eBird integráció nincs engedélyezve",
+        "apiKey": {
+          "label": "eBird API kulcs",
+          "helpText": "Az Ön eBird API kulcsa. Szerezze be az eBird API portálról."
+        },
+        "locale": {
+          "label": "Faj név nyelv"
+        },
+        "cacheTTL": {
+          "label": "Gyorsítótár időtartam (óra)",
+          "helpText": "Mennyi ideig gyorsítótárazza az eBird taxonómia adatokat. A taxonómia ritkán változik, így a hosszabb gyorsítótár időtartamok csökkentik az API hívásokat."
+        },
+        "note": "Az eBird taxonómiai adatokat biztosít a faj osztályozáshoz és betekintésekhez. Az API kulcs ingyenesen beszerezhető a Cornell Lab of Ornithology-tól.",
+        "apiKeyInfo": "Személyes eBird API kulcs szükséges ehhez az integrációhoz. Ingyenes kulcsot kérhet a <a href=\"https://ebird.org/api/keygen\" class=\"link link-primary\" target=\"_blank\" rel=\"noopener noreferrer\">ebird.org/api/keygen</a> oldalon.",
+        "test": {
+          "button": "eBird kapcsolat tesztelése",
+          "loading": "Tesztelés...",
+          "enabledRequired": "Először engedélyezze az eBird integrációt",
+          "apiKeyRequired": "Az API kulcs szükséges",
+          "inProgress": "Teszt folyamatban...",
+          "description": "eBird API kapcsolat és hitelesítés tesztelése"
+        }
+      }
+    },
+    "audio": {
+      "loading": "Hang eszközök betöltése...",
+      "tabs": {
+        "soundCard": "Hangszűrő kártya",
+        "streams": "Streamek",
+        "processing": "Feldolgozás",
+        "recording": "Rögzítés",
+        "retention": "Megőrzés"
+      },
+      "emptyStates": {
+        "soundCard": {
+          "title": "Nem észlelhető hangszűrő kártya",
+          "description": "Nem találtunk helyi hang bemeneti eszközöket ezen a rendszeren. Ez normális tároló vagy terminál nélküli szerver telepítéseknél.",
+          "errorTitle": "Eszközök betöltése sikertelen",
+          "hintsTitle": "A következőket teheti:",
+          "hints": {
+            "container": "Ez normális tároló/terminál nélküli telepítéseknél",
+            "streams": "A Streamek lapon konfiguráljon hálózati streameket",
+            "usb": "Csatlakoztasson USB mikrofont és frissítse a listát"
+          },
+          "refresh": "Eszközök frissítése",
+          "retry": "Újra"
+        },
+        "streams": {
+          "title": "Nincs stream konfigurálva",
+          "description": "Adjon hozzá RTSP vagy hálózati hang streameket IP kamerákból, mikrofon szerverekből vagy más streaming forrásokból.",
+          "hintsTitle": "Első lépések:",
+          "hints": {
+            "rtsp": "Adja meg az RTSP URL-eket ebben a formátumban: rtsp://ip:port/stream",
+            "multiple": "Több streamet is hozzáadhat különböző helyszínekhez",
+            "protocol": "Válassza a TCP-t a megbízhatóságért vagy az UDP-t az alacsonyabb késleltetésért"
+          }
+        }
+      },
+      "soundCard": {
+        "title": "Hangszűrő kártya",
+        "description": "Helyi hang bemeneti eszköz konfigurálása",
+        "audioSourceLabel": "Hang forrás (alkalmazás újraindítást igényel a érvénybe lépéshez)",
+        "audioSourceHelp": "Válassza ki a madárhang detektáláshoz használandó hang bemeneti eszközt. A változtatásokhoz alkalmazás újraindítás szükséges.",
+        "noSoundCardCapture": "Nincs hangszűrő kártya rögzítés",
+        "empty": {
+          "title": "Nem észlelhető hangszűrő kártya",
+          "description": "Nem találtunk helyi hang bemeneti eszközöket ezen a rendszeren. Ez normális tároló vagy terminál nélküli szerver telepítéseknél.",
+          "hintsTitle": "A következőket teheti:",
+          "hintStream": "A Streamek lapon konfiguráljon hálózati streameket",
+          "hintUsb": "Csatlakoztasson USB mikrofont és frissítse a listát",
+          "goToStreams": "Ugrás a Streamek-re",
+          "refresh": "Eszközök frissítése"
+        }
+      },
+      "noSources": {
+        "warning": "Nincs hang forrás konfigurálva",
+        "description": "A BirdNET-Go-nak hang bemenetre van szüksége a madarak érzékeléséhez. Kérjük, konfiguráljon legalább egy forrást a Hangszűrő kártya vagy Streamek lapon."
+      },
+      "audioCapture": {
+        "title": "Hangszűrő kártya konfiguráció",
+        "description": "Válassza ki a madárhang detektáláshoz használandó hang bemeneti eszközt. A változtatásokhoz alkalmazás újraindítás szükséges.",
+        "soundCardSource": "Hangszűrő kártya forrás",
+        "audioSourceLabel": "Hang forrás (alkalmazás újraindítást igényel a érvénybe lépéshez)",
+        "audioSourceHelp": "Válassza ki a madárhang detektáláshoz használandó hang bemeneti eszközt. A változtatásokhoz alkalmazás újraindítás szükséges.",
+        "noSoundCardCapture": "Nincs hangszűrő kártya rögzítés",
+        "noDeviceSelected": "Nincs hang eszköz kiválasztva",
+        "refreshDevices": "Frissítés",
+        "rtspSource": "RTSP forrás",
+        "rtspTransportLabel": "RTSP transport protokoll",
+        "rtspTransportHelp": "A TCP megbízhatóbb, de magasabb késleltetésű lehet. Az UDP gyorsabb, de rossz hálózatokon csomagvesztés lehet.",
+        "rtspUrlsLabel": "RTSP stream URL-ek",
+        "rtspUrlsHelp": "Adjon meg egy vagy több RTSP stream URL-t hálózati hang forrásokhoz. Formátum: rtsp://ip:port/stream. Megjegyzés: A hitelesítési adatokat külön kell konfigurálni az RTSP szerver beállításaiban a biztonság érdekében.",
+        "deviceSelected": "Hangszűrő kártya kiválasztva és készen a rögzítésre",
+        "availableDevices": "Elérhető hang eszközök",
+        "active": "Aktív",
+        "streamsConfigured": "{count} stream konfigurálva"
+      },
+      "quietHours": {
+        "title": "Csendes órák",
+        "sectionTitle": "Csendes órák",
+        "sectionDescription": "Szüneteltesse a hang rögzítést a konfigurált időablakokban a CPU használat csökkentéséhez, amikor a madarak valószínűleg nem aktívak.",
+        "modeLabel": "Ütemezési mód",
+        "modeFixed": "Rögzített idők",
+        "modeSolar": "Napkelte/Napnyugta",
+        "startTime": "Kezdés idő",
+        "endTime": "Befejezés idő",
+        "startEvent": "Kezdés esemény",
+        "endEvent": "Befejezés esemény",
+        "offsetMinutes": "Eltolás (perc)",
+        "sunrise": "Napkelte",
+        "sunset": "Napnyugta",
+        "fixedHint": "A rögzítés szünetel a kezdés és befejezés idők között naponta. Az éjszakai ablakok (pl. 22:00 - 06:00) támogatottak.",
+        "solarHint": "Az idők a konfigurált helyszín napkeléje/napnyugtája alapján számítódnak. Használjon negatív eltolásokat az esemény előtt, pozitívat az után.",
+        "badge": "Csendes",
+        "enabledBadge": "Csendes órák engedélyezve ehhez a streamhez"
+      },
+      "rtspStreams": {
+        "title": "Hang stream konfiguráció",
+        "description": "Hálózati hang streamek konfigurálása távoli hang rögzítéshez. Támogatja az RTSP, HTTP, HLS, RTMP és UDP protokollokat.",
+        "noStreamsConfigured": "Nincs stream konfigurálva"
+      },
+      "streams": {
+        "streamLabel": "Adatfolyam",
+        "nameLabel": "Stream neve",
+        "namePlaceholder": "pl., Elülső kert etető",
+        "nameHelp": "Egy leíró név a hang stream azonosításához",
+        "urlLabel": "Adatfolyam URL",
+        "urlHelp": "Adja meg a stream URL-t opcionális hitelesítéssel (pl. rtsp://host:port/path). A hitelesítéshez használjon környezeti változókat.",
+        "typeLabel": "Stream típus",
+        "typeHelp": "Stream protokoll - automatikusan észlelve az URL-ből",
+        "transportLabel": "Protokoll",
+        "summary": "{count} stream konfigurálva",
+        "healthy": "egészséges",
+        "unhealthy": "nem egészséges",
+        "unknown": "ismeretlen",
+        "refresh": "Frissítés",
+        "addStream": "Stream hozzáadása",
+        "deleteConfirm": "Eltávolítja ezt a streamet?",
+        "restartCount": "{count} alkalommal újraindítva",
+        "healthLoadError": "A stream egészségi állapot betöltése sikertelen",
+        "status": {
+          "connected": "Csatlakoztatva",
+          "connecting": "Csatlakozás",
+          "error": "Hiba",
+          "idle": "Tétlen",
+          "suppressed": "Csendes órák",
+          "unknown": "Ismeretlen"
+        },
+        "emptyState": {
+          "title": "Nincs stream konfigurálva",
+          "description": "Adjon hozzá hang streameket IP kamerákból, Icecast szerverekből vagy más hálózati forrásokból.",
+          "hintsTitle": "Első lépések",
+          "hints": {
+            "rtsp": "Támogatja az RTSP, HTTP, HLS, RTMP és UDP/RTP streameket",
+            "credentials": "A hitelesítés belefoglalható az URL-be vagy használhatók környezeti változók",
+            "protocol": "A TCP megbízhatóbb az RTSP-hez, az UDP alacsonyabb késleltetésű"
+          }
+        },
+        "errors": {
+          "nameRequired": "A stream neve kötelező",
+          "duplicateName": "Ezzel a névvel már létezik stream",
+          "urlRequired": "A stream URL kötelező",
+          "invalidUrl": "Érvénytelen stream URL formátum",
+          "duplicate": "Ez a stream URL már létezik"
+        },
+        "timeline": {
+          "error": "Hiba",
+          "noHistory": "Nincs elérhető állapot vagy hiba előzmény.",
+          "stateChange": "Állapot változás",
+          "host": "Gazdagép",
+          "troubleshooting": "Hibaelhárítás",
+          "from": "Ebből",
+          "to": "Ebbe",
+          "reason": "Ok",
+          "eventAt": "Esemény ekkor: {time}"
+        },
+        "diagnostics": {
+          "toggleDiagnostics": "Diagnosztika kapcsolása",
+          "processState": "Folyamat állapot",
+          "lastData": "Utolsó adat",
+          "restartCount": "Újraindítások száma",
+          "connection": "Kapcsolat",
+          "stateErrorHistory": "Állapot és hiba előzmények"
+        },
+        "connectionStatus": {
+          "stable": "Stabil",
+          "degraded": "Degradált",
+          "failed": "Sikertelen",
+          "unknown": "Ismeretlen"
+        }
+      },
+      "audioFilters": {
+        "title": "Hang szűrők",
+        "description": "Hang feldolgozási szűrők konfigurálása",
+        "enableEqualizer": "Hang equalizer engedélyezése",
+        "enableEqualizerHelp": "Frekvencia szűrést alkalmaz a madárhang detektálás javításához a nem kívánt zaj és frekvenciák csökkentésével.",
+        "filterType": "Szűrő típus",
+        "newFilterType": "Új szűrő típus",
+        "selectFilterType": "Válasszon szűrő típust",
+        "addFilter": "Szűrő hozzáadása",
+        "remove": "Eltávolítás",
+        "frequencyResponse": "Frekvencia válasz",
+        "cutoffFrequency": "Levágási frekvencia",
+        "cutoffFrequencyHelp": "Az a frekvencia, ahol a szűrő kezdi csökkenteni a jeleket. A madárhangok tipikusan 1-10 kHz tartományban vannak.",
+        "qFactor": "Q faktor",
+        "qFactorHelp": "A szűrő élességét szabályozza. Az alacsonyabb értékek (0.1-1) enyhébb meredekséget, a magasabb értékek (1-10) meredekebb levágást hoznak létre.",
+        "gain": "Erősítés",
+        "gainHelp": "Erősítés vagy csillapítás decibelben (dB).",
+        "attenuation": "Csillapítás",
+        "attenuationHelp": "A szűrő lecsengetési rátája. A magasabb értékek meredekebb csillapítást biztosítanak a szűrt frekvenciáknál.",
+        "attenuationLevels": {
+          "0db": "0dB",
+          "12db": "12dB",
+          "24db": "24dB",
+          "36db": "36dB",
+          "48db": "48dB"
+        },
+        "filterHelp": "Több szűrőt is hozzáadhat az optimális madár detektáláshoz a környezetében.",
+        "graph": {
+          "flatResponse": "Lapos válasz (nincs szűrő alkalmazva)",
+          "frequency": "Frekvencia (Hz)",
+          "gain": "Erősítés (dB)"
+        }
+      },
+      "soundLevelMonitoring": {
+        "title": "Hangszint monitorozás",
+        "description": "Környezeti hangszintek monitorozása és jelentése",
+        "enable": "Hangszint monitorozás engedélyezése",
+        "enableHelp": "A környezeti zaj szintek követése a felvételi környezet megértéséhez és a madár aktivitási mintákkal való korrelációhoz.",
+        "disabled": "A hangszint monitorozás le van tiltva",
+        "intervalLabel": "Mérési intervallum (másodperc)",
+        "intervalHelp": "Milyen gyakran mérje és jelentse a hangszinteket. Az alacsonyabb értékek részletesebb adatokat biztosítanak, de több erőforrást használnak. Minimum 5 másodperc, ajánlott 60 másodperc.",
+        "dataOutputTitle": "Hangszint adat kimenet",
+        "dataOutputDescription": "Ha engedélyezve van, a hangszint mérések publikálásra kerülnek:",
+        "mqttTopic": "MQTT téma:",
+        "sseEndpoint": "SSE végpont:",
+        "prometheusMetrics": "Prometheus metrikák:"
+      },
+      "clipSettings": {
+        "title": "Klips beállítások",
+        "description": "Az azonosított madárhangok hang kliprögzítésének és feldolgozásának konfigurálása"
+      },
+      "clipRecording": {
+        "title": "Klips rögzítés",
+        "description": "Konfigurálja, hogy és hogyan rögzülnek a hang klipek az észlelt madárhangokhoz.",
+        "enable": "Klips rögzítés engedélyezése",
+        "enableHelp": "Mentse a észlelt madárhangok hang klipeit áttekintéshez, megosztáshoz vagy egyedi adatkészletek építéséhez.",
+        "disabled": "A klips rögzítés le van tiltva",
+        "captureSettings": "Rögzítési beállítások",
+        "lengthLabel": "Rögzítési hossz",
+        "lengthHelp": "Az egyes detektálásokhoz rögzítendő hang időtartama (10-60 másodperc). A hosszabb klipek több kontextust adnak, de több tárhelyet használnak.",
+        "preCaptureLabel": "Detektálás előtti puffer",
+        "preCaptureHelp": "A madár észlelése előtti hang másodpercek száma (0-{max} másodperc). Biztosítja, hogy a teljes madárhang rögzítésre kerüljön a kezdetétől.",
+        "gainLabel": "Hang erősítés",
+        "gainHelp": "Hang erősítés decibelben a mentett klipekhez (0-20 dB). Hangosabbá teszi a mentett audio klipeket a könnyebb hallgatáshoz. Nem affectálja a detektálást. 0 dB azt jelenti, nincs erősítés.",
+        "normalization": "Hang normalizáció",
+        "normalizationEnable": "Hangosság normalizáció engedélyezése",
+        "normalizationHelp": "Automatikusan állítja a hang szinteket EBU R128 broadcast szabványra a konzisztens lejátszási hangerőhöz az összes klips között.",
+        "normalizationDisabled": "A hang normalizáció le van tiltva",
+        "targetLUFSLabel": "Cél hangosság (LUFS)",
+        "targetLUFSHelp": "Integrált hangosság cél értéke LUFS-ben (Loudness Units relative to Full Scale). A -23 LUFS az EBU R128 broadcast szabvány. Tartomány: -40 és -10 LUFS között.",
+        "loudnessRangeLabel": "Hangosság tartomány (LU)",
+        "loudnessRangeHelp": "Maximális hangerő variáció a klipsben (0-20 LU). Az alacsonyabb értékek konzisztensebb hangerőt hoznak létre, de csökkenthetik a dinamikát.",
+        "truePeakLabel": "True Peak limit (dBTP)",
+        "truePeakHelp": "Maximális true peak szint a digitális clipping megelőzéséhez (-10 és 0 dBTP között). A -2 dBTP biztonságos tartalékot biztosít a legtöbb lejátszó rendszerhez.",
+        "normalizationNote": "EBU R128 szabvány",
+        "normalizationNoteDescription": "A hang normalizáció az EBU R128 broadcast szabványt követi, biztosítva a konzisztens lejátszási szinteket a különböző eszközökön és megelőzve a clippinget.",
+        "fileSettings": "Fájl beállítások",
+        "pathLabel": "Klipek mappa",
+        "pathHelp": "A könyvtár, ahová a hang klipek mentésre kerülnek. A relatív útvonalak az alkalmazás könyvtárból számítódnak. Példa: 'clips/' vagy '/var/audio/birds/'",
+        "typeLabel": "Hang formátum",
+        "typeHelp": "Hang formátum a mentett klipekhez. A WAV és FLAC veszteségmentes (legjobb minőség, nagyobb fájlok). Az MP3, AAC és Opus veszteséges (kisebb fájlok, enyhe minőségvesztés).",
+        "bitrateLabel": "Bitráta",
+        "bitrateHelp": "Hang tömörítési bitráta a veszteséges formátumokhoz. Tartomány: {min}-{max} kbps. A magasabb értékek jobb minőséget, de nagyobb fájlokat eredményeznek.",
+        "losslessNote": "A veszteségmentes formátumok megőrzik az eredeti hangminőséget tömörítési artefaktusok nélkül.",
+        "disabledInfo": "Engedélyezze a klips rögzítést fenti a klips beállítások, fájl formátum és tárolási opciók konfigurálásához."
+      },
+      "extendedCapture": {
+        "title": "Kiterjesztett rögzítés",
+        "description": "Hosszabb hang klipek rögzítése, amikor egy faj ismételten hív, egyetlen kombinált felvételt eredményezve sok rövid klips helyett.",
+        "ramWarning": "A kiterjesztett rögzítés további RAM-ot igényel a hang pufferekhez. Nem ajánlott 512 MB RAM vagy kevesebb RAM-mal rendelkező eszközökhöz (pl. Raspberry Pi Zero).",
+        "enable": "Kiterjesztett rögzítés engedélyezése",
+        "enableHelp": "Ha engedélyezve van, a konfigurált fajok ismételt detektálásai egyetlen hosszabb felvételbe egyesülnek.",
+        "maxDurationLabel": "Max időtartam",
+        "maxDurationHelp": "A kiterjesztett rögzítés klips maximális hossza. A felvétel növekszik, ahogy a detektálások folytatódnak, eddig a limitig.",
+        "speciesListLabel": "Kiterjesztett rögzítés fajok",
+        "addSpeciesLabel": "Faj hozzáadása",
+        "addSpeciesHelp": "Fajok, amelyek kiterjesztett rögzítést váltanak ki. Támogatja a közhasználatú neveket, tudományos neveket és nemzetség szintű egyeztetést (pl. \"Strix\" egyeztet minden Strix bagollyal).",
+        "addSpeciesButton": "Hozzáadás",
+        "disabled": "A kiterjesztett rögzítés le van tiltva"
+      },
+      "fileSettings": {
+        "title": "Fájl beállítások",
+        "description": "Tárolási hely és hang formátum konfigurálása a mentett klipekhez.",
+        "pathLabel": "Klipek mappa",
+        "pathHelp": "A könyvtár, ahová a hang klipek mentésre kerülnek. A relatív útvonalak az alkalmazás könyvtárból számítódnak. Példa: 'clips/' vagy '/var/audio/birds/'",
+        "typeLabel": "Hang formátum",
+        "typeHelp": "Hang formátum a mentett klipekhez. A WAV és FLAC veszteségmentes (legjobb minőség, nagyobb fájlok). Az MP3, AAC és Opus veszteséges (kisebb fájlok, enyhe minőségvesztés).",
+        "bitrateLabel": "Bitráta",
+        "bitrateHelp": "Hang tömörítési bitráta a veszteséges formátumokhoz. Tartomány: {min}-{max} kbps. A magasabb értékek jobb minőséget, de nagyobb fájlokat eredményeznek.",
+        "losslessNote": "A veszteségmentes formátumok megőrzik az eredeti hangminőséget tömörítési artefaktusok nélkül."
+      },
+      "audioNormalization": {
+        "title": "Hang normalizáció",
+        "description": "Hangszint beállítás a konzisztens lejátszási hangerőhöz az összes klips között.",
+        "enable": "Hangosság normalizáció engedélyezése",
+        "enableHelp": "Automatikusan állítja a hang szinteket EBU R128 broadcast szabványra a konzisztens lejátszási hangerőhöz az összes klips között.",
+        "disabled": "A hang normalizáció le van tiltva",
+        "requiresRecording": "Engedélyezze a klips rögzítést a Rögzítés lapon a hang normalizáció használatához.",
+        "targetLUFSLabel": "Cél hangosság (LUFS)",
+        "targetLUFSHelp": "Integrált hangosság cél értéke LUFS-ben (Loudness Units relative to Full Scale). A -23 LUFS az EBU R128 broadcast szabvány. Tartomány: -40 és -10 LUFS között.",
+        "loudnessRangeLabel": "Hangosság tartomány (LU)",
+        "loudnessRangeHelp": "Maximális hangerő variáció a klipsben (0-20 LU). Az alacsonyabb értékek konzisztensebb hangerőt hoznak létre, de csökkenthetik a dinamikát.",
+        "truePeakLabel": "True Peak limit (dBTP)",
+        "truePeakHelp": "Maximális true peak szint a digitális clipping megelőzéséhez (-10 és 0 dBTP között). A -2 dBTP biztonságos tartalékot biztosít a legtöbb lejátszó rendszerhez.",
+        "noteTitle": "EBU R128 szabvány",
+        "noteDescription": "A hang normalizáció az EBU R128 broadcast szabványt követi, biztosítva a konzisztens lejátszási szinteket a különböző eszközökön és megelőzve a clippinget."
+      },
+      "audioClipRetention": {
+        "title": "Hang klips megőrzés",
+        "description": "Mentett hang klipek automatikus karbantartásának konfigurálása",
+        "policyLabel": "Megőrzési szabályzat",
+        "policyHelp": "Válassza ki, hogyan törlődnek automatikusan a hang klipek. Nincs: minden klips megtartása. Kor: régi klipek törlése. Használat: legrégibb klipek törlése, ha a lemez használat meghaladja a limitet.",
+        "maxAgeLabel": "Maximális kor",
+        "maxAgeHelp": "Törölje a megadott korú hang klipeket. Formátum: szám + egység (h=óra, d=nap, h=hét, m=hónap). Példák: '7d' 7 nap, '4w' 4 hét.",
+        "maxUsageLabel": "Maximális lemez használat",
+        "maxUsageHelp": "Törölje a legrégibb klipeket, ha a hang könyvtár a rendelkezésre álló lemezterület nagyobb százalékát használja.",
+        "minClipsLabel": "Minimum klipek fajonként",
+        "minClipsHelp": "Mindig tartson meg legalább ennyi klipet minden madár fajhoz, a kor vagy lemez használattól függetlenül. Segít megőrizni a ritka felvételeket.",
+        "keepSpectrograms": "Spektrogram képek megtartása",
+        "keepSpectrogramsHelp": "Tartsa meg a spektrogram képeket, még ha a hang klipek törlésre is kerülnek. A spektrogramok kevesebb helyet használnak és vizuális referenciát biztosítanak.",
+        "policies": {
+          "none": "Nincs - Mindet megtartja",
+          "age": "Kor alapú",
+          "usage": "Lemez használat alapú"
+        },
+        "noRetentionTitle": "Összes klips megtartva",
+        "noRetentionDescription": "A hang klipek határozatlan ideig meg lesznek tartva. Monitorozza a lemez használatot a tárolási problémák megelőzéséhez.",
+        "ageRetentionTitle": "Kor alapú karbantartás",
+        "ageRetentionDescription": "A megadott kornál régebbi klipek automatikusan törlésre kerülnek, miközben a fajonkénti minimum szám megőrzésre kerül.",
+        "usageRetentionTitle": "Használat alapú karbantartás",
+        "usageRetentionDescription": "Amikor a lemez használat meghaladja a küszöbértéket, a legrégibb klipek törlésre kerülnek, amíg a használat a limiteken belül nem lesz."
+      },
+      "formats": {
+        "wav": "WAV",
+        "flac": "FLAC",
+        "aac": "AAC",
+        "opus": "Opus",
+        "mp3": "MP3"
+      },
+      "transport": {
+        "tcp": "TCP",
+        "udp": "UDP"
+      },
+      "filterTypes": {
+        "lowpass": "Alul áteresztő szűrő",
+        "highpass": "Felül áteresztő szűrő",
+        "bandpass": "Sáv áteresztő szűrő",
+        "bandstop": "Sáv záró szűrő"
+      },
+      "errors": {
+        "devicesLoadFailed": "A hang eszközök betöltése sikertelen. Kérjük, ellenőrizze a rendszer engedélyeket.",
+        "invalidBitrate": "Érvénytelen bitráta érték",
+        "invalidRetentionPolicy": "Érvénytelen megőrzési szabályzat"
+      }
+    },
+    "security": {
+      "pageLabel": "Biztonsági beállítások",
+      "baseUrlLabel": "Alap URL",
+      "baseUrlHelp": "Teljes külső URL fordított proxy beállításokhoz. Ha beállítva, ez az URL használatos az értesítésekhez és OAuth átirányításokhoz, figyelmen kívül hagyva a Host és AutoTLS beállításokat.",
+      "baseUrlValidation": "Kérjük, adjon meg egy érvényes URL-t http:// vagy https:// kezdettel és hostname-t tartalmazva",
+      "hostLabel": "Host cím",
+      "allowSubnetBypassLabel": "Alhálózatból származó hozzáférés engedélyezése a hitelesítés megkerüléséhez",
+      "allowedSubnetsLabel": "Engedélyezett alhálózatok",
+      "allowedSubnetsHelp": "Engedélyezett hálózati tartományok a bejelentkezés megkerüléséhez (CIDR jelölés, vesszővel elválasztott lista)",
+      "securityWarningTitle": "Biztonsági figyelmeztetés:",
+      "subnetWarningText": "Ezen alhálózatokból származó eszközök korlátozás nélküli hozzáférést kapnak. Csak megbízható belső hálózatokat adjon meg.",
+      "httpsSettingsTitle": "HTTPS beállítások",
+      "httpsSettingsDescription": "Biztonságos hozzáférés SSL/TLS titkosítással",
+      "basicAuthTitle": "Alapvető hitelesítés",
+      "basicAuthDescription": "Biztonságos hozzáférés egyszerű jelszóval",
+      "serverConfiguration": {
+        "title": "Szerver konfiguráció",
+        "description": "HTTPS és SSL/TLS beállítások konfigurálása",
+        "autoTlsLabel": "Automatikus SSL tanúsítvány kezelés (AutoTLS)",
+        "autoTlsRequirements": {
+          "title": "AutoTLS követelmények:",
+          "domainRequired": "Regisztrált domain név szükséges",
+          "domainPointing": "A domainnek erre a szerverre kell mutatnia a nyilvános IP-re",
+          "portsAccessible": "A 80 és 443 portoknak elérhetőknek kell lenniük az internetről"
+        }
+      },
+      "basicAuthentication": {
+        "title": "Alapvető hitelesítés",
+        "description": "Biztonságos hozzáférés egyszerű jelszóval",
+        "enableLabel": "Jelszó hitelesítés engedélyezése",
+        "disabled": "A jelszó hitelesítés le van tiltva",
+        "passwordLabel": "Jelszó",
+        "passwordHelpText": "Korlátozza a beállításokhoz való hozzáférést jelszóval."
+      },
+      "oauth": {
+        "title": "Külső hitelesítés",
+        "description": "Bejelentkezés külső identitás szolgáltatóval vagy OIDC-vel",
+        "form": {
+          "editTitle": "OAuth szolgáltató szerkesztése",
+          "addTitle": "OAuth szolgáltató hozzáadása",
+          "providerLabel": "Szolgáltató",
+          "providerHelpText": "Válassza ki a konfigurálandó OAuth szolgáltatót",
+          "cancelButton": "Mégse",
+          "saveButton": "Mentés"
+        },
+        "providers": {
+          "title": "Konfigurált szolgáltatók",
+          "addButton": "Szolgáltató hozzáadása",
+          "enableToggle": "Szolgáltató engedélyezési állapot kapcsolása",
+          "editButton": "Szolgáltató beállítások szerkesztése",
+          "deleteButton": "Szolgáltató törlése",
+          "deleteConfirm": "Biztosan törli a {provider} OAuth szolgáltatót?"
+        },
+        "noProviders": "Nincs OAuth szolgáltató konfigurálva",
+        "noProvidersDescription": "Adjon hozzá egy szolgáltatót a bejelentkezés engedélyezéséhez Google, GitHub, Microsoft, LINE, Kakao vagy egyedi OIDC szolgáltatóval.",
+        "enableProviderLabel": "Engedélyezze ezt a szolgáltatót",
+        "getCredentialsLabel": "Szerezze be a hitelesítési adatait a {provider}-tól",
+        "redirectUriTitle": "Átirányítási URI:",
+        "clientIdLabel": "Kliens azonosító",
+        "clientIdHelpText": "Az OAuth 2.0 Client ID a szolgáltató fejlesztői konzoljáról",
+        "clientSecretLabel": "Kliens titok",
+        "clientSecretHelpText": "Az OAuth 2.0 Client Secret a szolgáltató fejlesztői konzoljáról",
+        "userIdLabel": "Felhasználói ID (opcionális)",
+        "userIdHelpText": "Korlátozza a hozzáférést egy adott felhasználói fiókhoz e-mail vagy ID szerint",
+        "google": {
+          "title": "Google OAuth",
+          "enableLabel": "Google OAuth2 bejelentkezés engedélyezése",
+          "redirectUriTitle": "Átirányítási URI a Google Cloud Console-hoz:",
+          "getCredentialsLabel": "Szerezze be a hitelesítési adatait a Google Cloud Console-ból",
+          "clientIdLabel": "Kliens azonosító",
+          "clientIdHelpText": "Az OAuth 2.0 Client ID, amelyet a Google Cloud Console-ban az OAuth hitelesítési adatok beállításakor kapott.",
+          "clientSecretLabel": "Kliens titok",
+          "clientSecretHelpText": "Az OAuth 2.0 Client Secret, amelyet a Google Cloud Console-ban az OAuth hitelesítési adatok beállításakor kapott.",
+          "userIdLabel": "Felhasználói ID"
+        },
+        "github": {
+          "title": "GitHub OAuth",
+          "enableLabel": "GitHub OAuth2 bejelentkezés engedélyezése",
+          "redirectUriTitle": "Átirányítási URI a GitHub Developer Settings-hez:",
+          "getCredentialsLabel": "Szerezze be a hitelesítési adatait a GitHub Developer Settings-ből",
+          "clientIdLabel": "Kliens azonosító",
+          "clientIdHelpText": "Az OAuth 2.0 Client ID, amelyet a GitHub Developer Settings-ben az OAuth hitelesítési adatok beállításakor kapott.",
+          "clientSecretLabel": "Kliens titok",
+          "clientSecretHelpText": "Az OAuth 2.0 Client Secret, amelyet a GitHub Developer Settings-ben az OAuth hitelesítési adatok beállításakor kapott.",
+          "userIdLabel": "Felhasználói ID"
+        },
+        "microsoft": {
+          "title": "Microsoft fiók",
+          "enableLabel": "Microsoft fiók OAuth2 bejelentkezés engedélyezése",
+          "redirectUriTitle": "Átirányítási URI az Azure App Registration-hez:",
+          "getCredentialsLabel": "Szerezze be a hitelesítési adatait az Azure Portal-ból",
+          "clientIdLabel": "Kliens azonosító",
+          "clientIdHelpText": "Az Application (client) ID, amelyet az Azure App Registration-ből kapott.",
+          "clientSecretLabel": "Kliens titok",
+          "clientSecretHelpText": "A client secret érték, amelyet az Azure App Registration-ből kapott.",
+          "userIdLabel": "Felhasználói ID"
+        },
+        "line": {
+          "title": "LINE bejelentkezés",
+          "enableLabel": "LINE OAuth2 bejelentkezés engedélyezése",
+          "redirectUriTitle": "Átirányítási URI a LINE Developers Console-hoz:",
+          "getCredentialsLabel": "Szerezze be a hitelesítési adatait a LINE Developers Console-ból",
+          "clientIdLabel": "Csatorna azonosító",
+          "clientIdHelpText": "A Channel ID, amelyet a LINE Developers Console-ban a LINE bejelentkezés beállításakor kapott.",
+          "clientSecretLabel": "Csatorna titok",
+          "clientSecretHelpText": "A Channel Secret, amelyet a LINE Developers Console-ban a LINE bejelentkezés beállításakor kapott.",
+          "userIdLabel": "Felhasználói ID"
+        },
+        "kakao": {
+          "title": "Kakao bejelentkezés",
+          "enableLabel": "Kakao OAuth2 bejelentkezés engedélyezése",
+          "redirectUriTitle": "Átirányítási URI a Kakao Developers Console-hoz:",
+          "getCredentialsLabel": "Szerezze be a hitelesítési adatait a Kakao Developers Console-ból",
+          "clientIdLabel": "REST API kulcs",
+          "clientIdHelpText": "A REST API kulcs, amelyet a Kakao Developers Console-ban a Kakao bejelentkezés beállításakor kapott.",
+          "clientSecretLabel": "Kliens titok",
+          "clientSecretHelpText": "A Client Secret, amelyet a Kakao Developers Console-ban a Kakao bejelentkezés beállításakor kapott.",
+          "userIdLabel": "Felhasználói ID"
+        },
+        "oidc": {
+          "title": "OIDC szolgáltató",
+          "enableLabel": "OIDC hitelesítés engedélyezése",
+          "redirectUriTitle": "Átirányítási URI",
+          "getCredentialsLabel": "Konfigurálja az Identitás szolgáltatójában",
+          "clientIdLabel": "Kliens azonosító",
+          "clientIdHelpText": "A client ID az OpenID Connect identitás szolgáltatójától",
+          "clientSecretLabel": "Kliens titok",
+          "clientSecretHelpText": "A client secret az OpenID Connect identitás szolgáltatójától",
+          "userIdLabel": "Engedélyezett felhasználó (e-mail vagy sub claim)",
+          "issuerUrlLabel": "Kibocsátó URL",
+          "issuerUrlHelpText": "Az OpenID Connect identitás szolgáltatójának issuer URL-je (pl., https://auth.example.com)",
+          "issuerUrlPlaceholder": "https://auth.example.com",
+          "issuerUrlRequired": "Az Issuer URL kötelező OIDC szolgáltatókhoz",
+          "issuerUrlInvalid": "Az Issuer URL-nek érvényes HTTP vagy HTTPS URL-nek kell lennie",
+          "scopesLabel": "Scopok",
+          "scopesHelpText": "Vesszővel elválasztott OIDC scope lista (alapértelmezett: openid, profile, email)",
+          "scopesPlaceholder": "openid, profile, email"
+        }
+      },
+      "bypassAuthentication": {
+        "title": "Hitelesítés megkerülése",
+        "description": "Hozzáférés engedélyezése a beállításokhoz hitelesítés nélkül",
+        "disabled": "Az alhálózat megkerülés le van tiltva"
+      },
+      "exceptions": {
+        "title": "Kivételek"
+      },
+      "publicAccess": {
+        "title": "Nyilvános hozzáférés",
+        "description": "Specifikus funkciók hozzáférhetőségének engedélyezése hitelesítés nélkül.",
+        "liveAudioLabel": "Élő hang lejátszás engedélyezése",
+        "liveAudioHelp": "Ha engedélyezve van, bárki hallgathatja az élő hang streameket bejelentkezés nélkül. A beállítások és törlés továbbra is hitelesítést igényel.",
+        "warningText": "A nyilvános hozzáférési funkciók engedélyezése kiteszi azokat bárkinek, aki elérheti ezt a szervert. Csak akkor engedélyezze, ha megbízik a hálózati környezetében."
+      },
+      "placeholders": {
+        "baseUrl": "https://birdnet.example.com:5500",
+        "host": "Például localhost:8080 vagy example.domain.com",
+        "allowedUsers": "Adjon meg egy vagy több engedélyezett felhasználói e-mailt",
+        "subnet": "Adjon meg egy CIDR alhálózatot (pl. 192.168.1.0/24)"
+      },
+      "terminal": {
+        "title": "Böngésző Terminal",
+        "enableLabel": "Böngésző terminal engedélyezése",
+        "enableHelpText": "Lehetővé teszi a rendszerhéj hozzáférését a gazdagép rendszerhez bármely hitelesített böngésző munkamenetből. Tiltsa le, ha nem használja.",
+        "securityWarning": "A böngésző terminal engedélyezése közvetlen rendszerhéj hozzáférést biztosít a gazdagép operációs rendszeréhez. Bárki érvényes hitelesítési adatokkal tetszőleges parancsokat futtathat. Csak megbízható hálózatokon engedélyezze ezt a funkciót. Tiltsa le, ha nem használja.",
+        "confirmEnable": "Biztosan engedélyezni szeretné a böngésző termnalt? Ez rendszerhéj hozzáférést biztosít a gazdagép rendszerhez. Csak megbízható hálózatokon tegye ezt."
+      },
+      "tls": {
+        "title": "TLS / HTTPS",
+        "description": "TLS/HTTPS titkosítás konfigurálása biztonságos kapcsolatokhoz",
+        "modeLabel": "TLS mód",
+        "modeNone": "Nincs (HTTP)",
+        "modeLetsEncrypt": "Let's Encrypt",
+        "modeManual": "Kézi tanúsítvány",
+        "modeSelfSigned": "Önaláírt",
+        "modeNoneDescription": "Titkosítás nélküli egyszerű HTTP",
+        "modeAutoTLSDescription": "Automatikus tanúsítvány a Let's Encrypt által",
+        "modeManualDescription": "Töltse fel a saját tanúsítványát és kulcsát",
+        "modeSelfSignedDescription": "Önaláírt tanúsítvány generálása",
+        "portLabel": "HTTPS port",
+        "portHelpText": "Port a HTTPS kapcsolatokhoz (alapértelmezett: 8443)",
+        "redirectToHttps": "HTTP átirányítása HTTPS-re",
+        "autoTLSRequirements": "A 80 és 443 portoknak elérhetőknek kell lenniük. Linuxon a folyamatnak root vagy CAP_NET_BIND_SERVICE képességre van szüksége.",
+        "validityLabel": "Tanúsítvány érvényesség",
+        "validityHelpText": "Mennyi ideig érvényes a tanúsítvány",
+        "validity365d": "1 év",
+        "validity730d": "2 év",
+        "generateButton": "Tanúsítvány generálása",
+        "regenerateButton": "Tanúsítvány újragenerálása",
+        "generating": "Generálás...",
+        "certificateLabel": "Tanúsítvány (PEM)",
+        "privateKeyLabel": "Privát kulcs (PEM)",
+        "caCertificateLabel": "CA tanúsítvány (PEM, opcionális)",
+        "uploadButton": "Tanúsítvány feltöltése",
+        "uploading": "Feltöltés...",
+        "browseFile": "Tallózás...",
+        "plaintextWarning": "Figyelmeztetés: Az Ön privát kulcsa titkosítatlanul lesz átvíve HTTP-n keresztül. Csak akkor töltse fel a tanúsítványokat, ha megbízható hálózaton vagy localhost-on keresztül csatlakozik.",
+        "certificateInstalled": "Telepített tanúsítvány",
+        "subject": "Tulajdonos",
+        "issuer": "Kibocsátó",
+        "validFrom": "Érvényes ettől",
+        "validUntil": "Érvényes eddig",
+        "daysRemaining": "Hátralévő napok",
+        "sans": "Alternatív nevek (SAN)",
+        "fingerprint": "Ujjlenyomat",
+        "expiryWarning": "A tanúsítvány hamarosan lejár",
+        "loading": "Tanúsítvány információ betöltése...",
+        "loadError": "A tanúsítvány információ betöltése sikertelen",
+        "generateSuccess": "Az önaláírt tanúsítvány sikeresen generálva",
+        "generateError": "A tanúsítvány generálása sikertelen",
+        "uploadSuccess": "A tanúsítvány sikeresen feltöltve",
+        "uploadError": "A tanúsítvány feltöltése sikertelen",
+        "deleteSuccess": "A tanúsítvány sikeresen eltávolítva",
+        "deleteError": "A tanúsítvány eltávolítása sikertelen",
+        "removeCertificate": "Tanúsítvány eltávolítása",
+        "deleteConfirm": "Biztosan el szeretné távolítani a telepített TLS tanúsítványt? A TLS mód visszaáll None-ra.",
+        "restartRequired": "A TLS változtatásokhoz szerver újraindítás szükséges az érvénybe lépéshez.",
+        "noCertificate": "Nincs tanúsítvány telepítve",
+        "validity1825d": "5 év",
+        "autoTLSHostRequired": "Hostnév szükséges a Let's Encrypt-hez. Adja meg a nyilvános domain nevét a Host mezőben fenti.",
+        "autoTLSNoIP": "A Let's Encrypt domain nevet igényel, nem IP címet. Adjon meg egy nyilvános domaint, mint birds.example.com.",
+        "autoTLSNeedsFQDN": "A Let's Encrypt teljes domain nevet igényel (pl., birds.example.com), nem csupán hostname-t.",
+        "autoTLSNoLocalhost": "A Let's Encrypt nem bocsáthat ki tanúsítványt localhost-ra.",
+        "autoTLSPrivateTLD": "A Let's Encrypt nem bocsáthat ki tanúsítványt privát domainekre ({tld} nem oldható fel nyilvánosan).",
+        "downloadCertificate": "Tanúsítvány letöltése",
+        "downloadCertificateHelp": "Telepítse ezt a tanúsítványt az operációs rendszere trust store-ába a böngésző biztonsági figyelmeztetéseinek elkerüléséhez.",
+        "fileReadError": "A kiválasztott fájl olvasása sikertelen"
+      }
+    },
+    "species": {
+      "pageLabel": "Faj beállítások",
+      "saveError": "A konfiguráció mentése sikertelen \"{species}\" számára. Kérjük, próbálja újra.",
+      "configUpdated": "Konfiguráció frissítve \"{species}\" számára",
+      "configAdded": "Konfiguráció hozzáadva \"{species}\" számára",
+      "duplicateConfigError": "A(z) \"{species}\" faj már rendelkezik konfigurációval. Kérjük, válasszon más nevet.",
+      "activeSpecies": {
+        "title": "Aktív fajok",
+        "tabLabel": "Aktív",
+        "description": "Azon fajok, amelyek az Ön jelenlegi helyszíne és szűrő beállításai alapján detektálásra kerülnek",
+        "stats": {
+          "species": "Faj",
+          "location": "Helyszín",
+          "threshold": "Küszöbérték",
+          "updated": "Frissítve",
+          "justNow": "Épp most",
+          "minutesAgo": "{count} perce",
+          "hoursAgo": "{count} órája"
+        },
+        "search": {
+          "placeholder": "Fajok keresése..."
+        },
+        "badges": {
+          "included": "Beleértve",
+          "configured": "Konfigurálva"
+        },
+        "empty": {
+          "title": "Nem található faj",
+          "description": "Konfigurálja a helyszínét a Fő beállításokban a rendelkezésre álló fajok megtekintéséhez"
+        },
+        "noResults": "Egyetlen faj sem felel meg a keresésnek",
+        "infoNote": "Ez a lista az Ön helyszíne és a tartomány szűrő küszöbértéke alapján készült. A manuálisan belefoglalt fajok mindig hozzáadásra kerülnek.",
+        "retry": "Újra",
+        "expand": "Lista kibontása",
+        "collapse": "Lista összecsukása",
+        "downloadCsv": "CSV letöltése",
+        "errors": {
+          "loadFailed": "Az aktív faj lista betöltése sikertelen"
+        },
+        "locationNotConfigured": {
+          "title": "Helyszín nincs konfigurálva",
+          "description": "Állítsa be a helyszínét a Fő beállításokban a környékén elérhető fajok megtekintéséhez. A tartomány szűrő az Ön helyszíne alapján határozza meg, mely fajok valószínűsíthetők a közelben.",
+          "action": "Helyszín konfigurálása"
+        },
+        "columns": {
+          "commonName": "Közhasználatú név",
+          "scientificName": "Tudományos név",
+          "score": "Pontszám",
+          "status": "Állapot"
+        }
+      },
+      "alwaysInclude": {
+        "title": "Mindig belefoglalt fajok",
+        "tabLabel": "Beleértés",
+        "description": "Az ebben a listában szereplő fajok mindig belefoglaltak a detektált fajok közé",
+        "noSpeciesMessage": "Nincs faj hozzáadva a belefoglalt listához"
+      },
+      "alwaysExclude": {
+        "title": "Mindig kizárt fajok",
+        "tabLabel": "Kizárás",
+        "description": "Az ebben a listában szereplő fajok mindig ki vannak zárva a detektálásból",
+        "noSpeciesMessage": "Nincs faj hozzáadva a kizárt listához"
+      },
+      "customConfiguration": {
+        "title": "Egyedi faj konfiguráció",
+        "tabLabel": "Egyedi",
+        "description": "Fajspecifikus küszöbértékek, detektálási intervallumok és műveletek",
+        "helpText": {
+          "intro": "Fajspecifikus beállítások konfigurálása:",
+          "threshold": "Küszöbérték: Minimális megbízhatósági pontszám (0-1) a detektáláshoz",
+          "interval": "Intervallum: Minimális idő másodpercekben az azonos faj egymást követő detektálásai között (0 = globális alapértelmezett használata)",
+          "actions": "Műveletek: Egyedi parancsok végrehajtása, amikor ez a faj detektálásra kerül"
+        },
+        "columnHeaders": {
+          "species": "Faj",
+          "settings": "Beállítások",
+          "actions": "Műveletek"
+        },
+        "badges": {
+          "threshold": "Küszöbérték: {value}",
+          "interval": "Intervallum: {value}s",
+          "customAction": "Egyedi művelet",
+          "executeDefaults": "+Alapértelmezettek"
+        },
+        "dropdown": {
+          "editConfig": "Konfiguráció szerkesztése",
+          "addAction": "Művelet hozzáadása",
+          "remove": "Eltávolítás"
+        },
+        "labels": {
+          "threshold": "Küszöbérték",
+          "interval": "Intervallum",
+          "intervalSeconds": "Intervallum (mp)",
+          "addButton": "Hozzáadás"
+        },
+        "noConfigurationsMessage": "Nincs egyedi faj konfiguráció hozzáadva",
+        "addForm": {
+          "speciesPlaceholder": "Faj neve",
+          "thresholdPlaceholder": "0.5",
+          "intervalPlaceholder": "0"
+        },
+        "addConfiguration": "Konfiguráció hozzáadása",
+        "newConfiguration": "Új konfiguráció",
+        "editing": "Szerkesztés: {species}",
+        "configuredCount": "{count} konfigurálva",
+        "searchPlaceholder": "Gépeljen a kereséshez...",
+        "saving": "Mentés...",
+        "save": "Mentés",
+        "cancel": "Mégse",
+        "configureActions": "Műveletek konfigurálása",
+        "actionsConfigured": "Konfigurálva",
+        "list": {
+          "threshold": "Küszöbérték:",
+          "interval": "Intervallum:",
+          "intervalNone": "Nincs",
+          "actionBadge": "Művelet",
+          "editTitle": "Konfiguráció szerkesztése",
+          "removeTitle": "Konfiguráció eltávolítása"
+        },
+        "emptyState": {
+          "title": "Még nincs konfiguráció.",
+          "description": "Kattintson a \"Konfiguráció hozzáadása\" gombra a faj detektálási beállítások testreszabásához."
+        }
+      },
+      "synonyms": {
+        "tabLabel": "Szinonimák",
+        "description": "BirdNET faj nevek leképezése az Ön preferált neveire. Amikor egy detektálás egyezik egy szinonimával, a frissített név kerül használatra.",
+        "birdnetName": "BirdNET név",
+        "updatedName": "Frissített név",
+        "addButton": "Szinonima hozzáadása",
+        "emptyState": "Nincs taxonómia szinonima konfigurálva",
+        "errors": {
+          "unknownSpecies": "A faj nem található a BirdNET címkék között",
+          "duplicateKey": "Ehhez a fajhoz már létezik szinonima",
+          "emptyUpdatedName": "A frissített név kötelező"
+        }
+      },
+      "actionsModal": {
+        "title": "Műveletek ehhez: {species}",
+        "actionType": {
+          "label": "Művelet típusa",
+          "executeCommand": "Parancs végrehajtása",
+          "onlySupported": "Jelenleg csak a Parancs végrehajtása művelet támogatott"
+        },
+        "command": {
+          "label": "Parancs",
+          "helpText": "Adja meg a végrehajtani kívánt parancs vagy szkript teljes útvonalát"
+        },
+        "parameters": {
+          "label": "Paraméterek",
+          "helpText": "Ezek az értékek sorrendben kerülnek átadásra a parancsának",
+          "placeholder": "Kattintson a lent található gombokra a paraméterek hozzáadásához vagy gépeljen manuálisan",
+          "tooltip": "Használja a lent található gombokat vagy gépeljen közvetlenül (vesszővel elválasztva)",
+          "availableTitle": "Elérhető paraméterek",
+          "buttons": {
+            "commonName": "KözhasználatúNév",
+            "scientificName": "TudományosNév",
+            "confidence": "Megbízhatóság",
+            "time": "Idő",
+            "source": "Forrás",
+            "clearParameters": "Paraméterek törlése"
+          }
+        },
+        "executeDefaults": {
+          "label": "Alapértelmezett műveletek futtatása is (adatbázis tárolás, értesítések stb.)",
+          "helpText": "Engedélyezéskor az Ön egyedi művelete és a rendszer alapértelmezett műveletei is futni fognak. Tiltsa le, ha csak az Ön egyedi művelete fusson."
+        }
+      },
+      "add": "Hozzáadás",
+      "remove": "Eltávolítás",
+      "suggestions": "Faj javaslatok",
+      "addSpeciesToInclude": "Faj hozzáadása a belefoglaltak közé",
+      "addSpeciesToIncludeLabel": "Új faj hozzáadása a belefoglaltak közé",
+      "addSpeciesToExclude": "Faj hozzáadása a kizártak közé",
+      "addSpeciesToExcludeLabel": "Új faj hozzáadása a kizártak közé",
+      "commandPathPlaceholder": "/az/ön/parancs/útvonala",
+      "parametersPlaceholder": "A paraméterek itt jelennek meg",
+      "errors": {
+        "speciesLoadFailed": "A faj lista betöltése sikertelen. Kérjük, próbálja újra."
+      },
+      "tracking": {
+        "title": "Faj követés",
+        "tabLabel": "Követés",
+        "description": "Új faj detektálások követésének konfigurálása időszakok alapján",
+        "enabled": {
+          "label": "Faj követés engedélyezése",
+          "helpText": "Engedélyezéskor a rendszer követi az új faj detektálásokat és küldhet értesítéseket"
+        },
+        "newSpeciesWindowDays": {
+          "label": "Új faj ablak (nap)",
+          "helpText": "Napok száma, ameddig egy faj 'újnak' minősül az első detektálás után (1-365)"
+        },
+        "syncIntervalMinutes": {
+          "label": "Szinkronizálási intervallum (perc)",
+          "helpText": "Milyen gyakran szinkronizálja a követési adatokat az adatbázissal (1-1440)"
+        },
+        "notificationSuppressionHours": {
+          "label": "Értesítés elnyomás (óra)",
+          "helpText": "Órák az azonos faj ismételt értesítéseinek elnyomásához (0-8760)"
+        },
+        "yearly": {
+          "title": "Éves követés",
+          "description": "Minden évben az első érkezések követése",
+          "enabled": {
+            "label": "Éves követés engedélyezése",
+            "helpText": "Követés és értesítés, amikor egy faj először detektálásra kerül minden évben"
+          },
+          "resetMonth": {
+            "label": "Visszaállítási hónap",
+            "helpText": "Hónap, amikor az éves követés visszaáll (1-12)"
+          },
+          "resetDay": {
+            "label": "Visszaállítási nap",
+            "helpText": "A hónap napja, amikor az éves követés visszaáll"
+          },
+          "windowDays": {
+            "label": "Ablak (nap)",
+            "helpText": "Napok az 'ezévben új' jelző megjelenítéséhez (1-365)"
+          }
+        },
+        "seasonal": {
+          "title": "Évszakos követés",
+          "description": "Minden évszakban az első érkezések követése",
+          "enabled": {
+            "label": "Évszakos követés engedélyezése",
+            "helpText": "Követés és értesítés, amikor egy faj először detektálásra kerül minden évszakban"
+          },
+          "windowDays": {
+            "label": "Ablak (nap)",
+            "helpText": "Napok az 'ebben az évszakban új' jelző megjelenítéséhez (1-365)"
+          },
+          "seasons": {
+            "title": "Évszak definíciók",
+            "description": "Adja meg, mikor kezdődik minden évszak. Az évszakok automatikusan az Ön helyszínének félgömbje alapján kerülnek beállításra.",
+            "spring": "Tavasz",
+            "summer": "Nyár",
+            "fall": "Ősz",
+            "winter": "Tél",
+            "wet1": "Esős évszak 1",
+            "dry1": "Száraz évszak 1",
+            "wet2": "Esős évszak 2",
+            "dry2": "Száraz évszak 2",
+            "startMonth": "Kezdési hónap",
+            "startDay": "Kezdési nap",
+            "hemisphereNote": "Az évszak dátumok automatikusan az Ön szélessége alapján kerülnek konfigurálásra. Az északi félgömb a szabványos évszakokat, a déli félgömb eltolódott dátumokat, az egyenlítői régiók pedig esős/száraz évszakokat használnak."
+          }
+        },
+        "months": {
+          "january": "Január",
+          "february": "Február",
+          "march": "Március",
+          "april": "Április",
+          "may": "Május",
+          "june": "Június",
+          "july": "Július",
+          "august": "Augusztus",
+          "september": "Szeptember",
+          "october": "Október",
+          "november": "November",
+          "december": "December"
+        },
+        "units": {
+          "days": "nap",
+          "min": "perc",
+          "hours": "óra"
+        }
+      },
+      "dynamicThreshold": {
+        "tabLabel": "Tanult",
+        "title": "Tanult küszöbértékek",
+        "description": "Ez az oldal a Dinamikus küszöbérték futásidejű adatait mutatja. Ha engedélyezve van a Fő beállítások → Detektálás menüpontban, a küszöbértékek több magas megbízhatóságú detektálás alapján automatikusan kerülnek beállításra. Az itt látható fajok feltételezhetően léteznek ezen a helyszínen.",
+        "stats": {
+          "active": "Aktív",
+          "atMinimum": "Minimumon",
+          "minThreshold": "Min küszöbérték",
+          "validityPeriod": "Érvényességi időszak"
+        },
+        "header": {
+          "species": "Faj",
+          "threshold": "Küszöbérték",
+          "expires": "Lejárat"
+        },
+        "searchPlaceholder": "Faj keresése...",
+        "threshold": "Küszöbérték",
+        "level": "Szint",
+        "expires": "Lejárat",
+        "expired": "Lejárt",
+        "confidence": "Megbízhatóság",
+        "requiredConfidence": "Szükséges megbízhatóság",
+        "resetAll": "Összes visszaállítása",
+        "resetSpecies": "Küszöbérték visszaállítása ehhez a fajhoz",
+        "noEvents": "Nincs küszöbérték változási előzmény",
+        "changeReason": {
+          "highConfidence": "Magas megbízhatóságú detektálás",
+          "expiry": "Küszöbérték lejárt",
+          "manualReset": "Manuális visszaállítás"
+        },
+        "note": "A magas megbízhatóságú detektálások megerősítik, mely fajok léteznek ezen a helyszínen. Több magas megbízhatóságú egyezés után a detektálási küszöbérték biztonságosan csökkentésre kerül a több hívás rögzítéséhez jelentős hamis pozitív kockázat nélkül. A küszöbértékek automatikusan visszaállnak a konfigurált érvényességi időszak után.",
+        "empty": {
+          "title": "Nincs tanult küszöbérték",
+          "description": "A magas megbízhatóságú detektálások automatikusan létrehozzák a fajok tanult küszöbértékeit"
+        },
+        "resetAllConfirm": {
+          "title": "Összes küszöbérték visszaállítása",
+          "message": "Ez visszaállítja az összes {count} tanult küszöbértéket. A fajoknak ismét magas megbízhatósággal kell detektálásra kerülniük a küszöbértékeik csökkentéséhez."
+        },
+        "loadError": "A dinamikus küszöbértékek betöltése sikertelen",
+        "resetSuccess": "Küszöbérték visszaállítva ehhez: {species}",
+        "resetError": "A küszöbérték visszaállítása sikertelen",
+        "resetAllSuccess": "{count} küszöbérték visszaállítva",
+        "resetAllError": "A küszöbértékek visszaállítása sikertelen",
+        "expand": "Esemény előzmények megjelenítése",
+        "collapse": "Esemény előzmények elrejtése"
+      }
+    },
+    "database": {
+      "sqlitePlaceholder": "SQLite adatbázis útvonal megadása",
+      "mysqlHostPlaceholder": "MySQL host megadása",
+      "mysqlUsernamePlaceholder": "MySQL felhasználónév megadása"
+    },
+    "alerts": {
+      "sections": {
+        "history": {
+          "title": "Értesítési előzmények",
+          "description": "Korábbi értesítési események és eredményeik megtekintése."
+        }
+      },
+      "filters": {
+        "objectType": "Objektum típus",
+        "status": "Állapot",
+        "allTypes": "Összes típus",
+        "allStates": "Összes állapot",
+        "enabled": "Engedélyezve",
+        "disabled": "Letiltva"
+      },
+      "builtIn": "Beépített",
+      "enabled": "Engedélyezve",
+      "disabled": "Letiltva",
+      "trigger": "Eseményindító",
+      "conditions": "Feltételek",
+      "actions": "Műveletek",
+      "cooldown": "Lehűlési idő",
+      "noConditions": "Nincs feltétel",
+      "noActions": "Nincs művelet",
+      "noRules": "Nincs riasztási szabály konfigurálva.",
+      "noMatchingRules": "Egyetlen szabály sem felel meg az aktuális szűrőknek.",
+      "noHistory": "Nincs értesítési előzmény.",
+      "confirmDelete": "Biztosan törölni szeretné a \"{name}\" szabályt?",
+      "newRule": "Új szabály",
+      "resetDefaults": "Alapértelmezettek visszaállítása",
+      "resetting": "Visszaállítás...",
+      "clearHistory": "Előzmények törlése",
+      "clearing": "Törlés...",
+      "historyCount": "{total} összes bejegyzés",
+      "actionsExecuted": "Végrehajtott műveletek",
+      "actionLabels": {
+        "edit": "Szabály szerkesztése",
+        "enable": "Szabály engedélyezése",
+        "disable": "Szabály letiltása",
+        "test": "Szabály tesztelése",
+        "delete": "Szabály törlése"
+      },
+      "status": {
+        "enabled": "Szabály engedélyezve",
+        "disabled": "Szabály letiltva",
+        "deleted": "Szabály törölve",
+        "testFired": "Teszt riasztás aktiválva",
+        "defaultsReset": "Alapértelmezettek visszaállítva",
+        "historyCleared": "Előzmények törölve",
+        "created": "Szabály létrehozva",
+        "updated": "Szabály frissítve",
+        "exported": "Szabályok exportálva",
+        "imported": "{imported} / {total} szabály importálva"
+      },
+      "errors": {
+        "loadFailed": "A riasztási szabályok betöltése sikertelen",
+        "historyFailed": "Az értesítési előzmények betöltése sikertelen",
+        "toggleFailed": "A szabály váltása sikertelen",
+        "deleteFailed": "A szabály törlése sikertelen",
+        "testFailed": "A szabály tesztelése sikertelen",
+        "resetFailed": "Az alapértelmezettek visszaállítása sikertelen",
+        "clearHistoryFailed": "Az előzmények törlése sikertelen",
+        "saveFailed": "A szabály mentése sikertelen",
+        "exportFailed": "A szabályok exportálása sikertelen",
+        "importFailed": "A szabályok importálása sikertelen",
+        "schemaLoadFailed": "A riasztási séma betöltése sikertelen. Kérjük, frissítse az oldalt."
+      },
+      "editor": {
+        "createTitle": "Riasztási szabály létrehozása",
+        "editTitle": "Riasztási szabály szerkesztése",
+        "name": "Név",
+        "namePlaceholder": "Szabály név megadása",
+        "description": "Leírás",
+        "descriptionPlaceholder": "Opcionális leírás",
+        "enabled": "Engedélyezve",
+        "triggerSection": "Eseményindító",
+        "objectType": "Objektum típus",
+        "triggerType": "Trigger típus",
+        "triggerEvent": "Esemény",
+        "triggerMetric": "Metrika",
+        "event": "Esemény",
+        "metric": "Metrika",
+        "conditionsSection": "Feltételek",
+        "property": "Tulajdonság",
+        "operator": "Operátor",
+        "value": "Érték",
+        "valuePlaceholder": "Érték megadása",
+        "duration": "Időtartam (s)",
+        "addCondition": "Feltétel hozzáadása",
+        "removeCondition": "Feltétel eltávolítása",
+        "actionsSection": "Műveletek",
+        "actionBell": "Alkalmazáson belüli értesítés",
+        "actionPush": "Push értesítés",
+        "optionsSection": "Opciók",
+        "cooldownSeconds": "Lehűlési idő (másodperc)",
+        "templateTitle": "Cím sablon",
+        "templateTitlePlaceholder": "Hagyja üresen az alapértelmezettért",
+        "templateMessage": "Üzenet sablon",
+        "templateMessagePlaceholder": "Hagyja üresen az alapértelmezettért",
+        "noConditionsEvent": "Nincs feltétel — a szabály minden eseménynél aktiválódik",
+        "noConditionsMetric": "Nincs feltétel — a szabály minden metrika frissítésnél aktiválódik",
+        "eventsCount": "esemény",
+        "metricsCount": "metrika",
+        "durationFor": "ennyi ideig",
+        "durationSec": "mp"
+      },
+      "export": "Exportálás",
+      "import": "Importálás",
+      "exporting": "Exportálás...",
+      "importing": "Importálás...",
+      "schema": {
+        "objectTypes": {
+          "stream": "Hang stream",
+          "detection": "Detektálás",
+          "application": "Alkalmazás",
+          "integration": "Integráció",
+          "device": "Eszköz",
+          "system": "Rendszer"
+        },
+        "events": {
+          "stream_connected": "Stream csatlakoztatva",
+          "stream_disconnected": "Stream leválasztva",
+          "stream_error": "Stream hiba",
+          "detection_new_species": "Új faj detektálva",
+          "detection_occurred": "Detektálás történt",
+          "application_started": "Alkalmazás indítva",
+          "application_stopped": "Alkalmazás leállítva",
+          "integration_birdweather_failed": "BirdWeather feltöltés sikertelen",
+          "integration_mqtt_connected": "MQTT csatlakoztatva",
+          "integration_mqtt_disconnected": "MQTT leválasztva",
+          "integration_mqtt_publish_failed": "MQTT publikálás sikertelen",
+          "device_started": "Eszköz indítva",
+          "device_stopped": "Eszköz leállítva",
+          "device_error": "Eszköz hiba"
+        },
+        "metrics": {
+          "system_cpu_usage": "CPU használat",
+          "system_memory_usage": "Memória használat",
+          "system_disk_usage": "Lemez használat"
+        },
+        "properties": {
+          "value": "Érték",
+          "species_name": "Faj neve",
+          "scientific_name": "Tudományos név",
+          "confidence": "Megbízhatóság",
+          "location": "Helyszín",
+          "stream_name": "Stream neve",
+          "stream_url": "Adatfolyam URL",
+          "device_name": "Eszköz neve",
+          "error": "Hibaüzenet",
+          "broker": "Broker"
+        },
+        "operators": {
+          "is": "egyenlő",
+          "is_not": "nem egyenlő",
+          "contains": "tartalmazza",
+          "not_contains": "nem tartalmazza",
+          "greater_than": "nagyobb mint",
+          "less_than": "kisebb mint",
+          "greater_or_equal": "nagyobb vagy egyenlő",
+          "less_or_equal": "kisebb vagy egyenlő"
+        }
+      },
+      "v2Required": "A riasztási szabályokhoz a bővített adatbázis séma szükséges. Az adatbázist a Rendszer alatti Adatbázis oldalról migrálhatja.",
+      "builtInRules": {
+        "newSpecies": {
+          "name": "Új faj detektálva",
+          "description": "Értesít, amikor egy faj először kerül detektálásra"
+        },
+        "streamDisconnected": {
+          "name": "Hang stream leválasztva",
+          "description": "Értesít, amikor egy RTSP vagy hang stream elveszíti a kapcsolatot"
+        },
+        "streamError": {
+          "name": "Hang stream hiba",
+          "description": "Értesít, amikor egy hang stream hibába ütközik"
+        },
+        "deviceError": {
+          "name": "Hang eszköz hiba",
+          "description": "Értesít, amikor egy helyi hangrögzítő eszköz hibába ütközik"
+        },
+        "highCpu": {
+          "name": "Magas CPU használat",
+          "description": "Értesít, amikor a CPU használat meghaladja a 90%-ot 5 percen keresztül"
+        },
+        "highMemory": {
+          "name": "Magas memória használat",
+          "description": "Értesít, amikor a memória használat meghaladja a 90%-ot 5 percen keresztül"
+        },
+        "lowDisk": {
+          "name": "Alacsony szabad lemezterület",
+          "description": "Értesít, amikor a lemez használat meghaladja a 85%-ot 5 percen keresztül"
+        },
+        "mqttDisconnected": {
+          "name": "MQTT leválasztva",
+          "description": "Értesít, amikor az MQTT broker kapcsolat megszakad"
+        },
+        "mqttPublishFailed": {
+          "name": "MQTT publikálás sikertelen",
+          "description": "Értesít, amikor egy MQTT üzenet publikálása sikertelen"
+        },
+        "birdWeatherFailed": {
+          "name": "BirdWeather feltöltés sikertelen",
+          "description": "Értesít, amikor egy BirdWeather feltöltés sikertelen"
+        }
+      },
+      "v2RequiredLink": "Rendszer adatbázis oldal."
+    },
+    "appearance": {
+      "colorScheme": "Szín séma",
+      "colorSchemeDescription": "Válasszon szín sémát a felülethez",
+      "schemeBlue": "Kék",
+      "schemeForest": "Erdő",
+      "schemeAmber": "Borostyán",
+      "schemeViolet": "Ibolya",
+      "schemeRose": "Rózsaszín",
+      "schemeCustom": "Egyéni",
+      "customPrimary": "Elsődleges szín",
+      "customAccent": "Kiemelő szín",
+      "logoGradient": "Színátmenetes logó",
+      "logoGradientDescription": "Színátmenet effektus használata az oldalsáv logóján"
+    },
+    "userInterface": {
+      "tabs": {
+        "appearance": "Megjelenés",
+        "language": "Nyelv és regionális",
+        "visualContent": "Vizuális tartalom",
+        "audioPlayback": "Hang lejátszás"
+      },
+      "appearance": {
+        "title": "Megjelenés",
+        "description": "A BirdNET-Go felület megjelenésének és hangulatának testreszabása"
+      },
+      "language": {
+        "title": "Nyelv és regionális",
+        "description": "Nyelv, hőmérsékleti egységek és regionális megjelenítési beállítások"
+      },
+      "visualContent": {
+        "title": "Vizuális tartalom",
+        "description": "Madár képek és spektrogram megjelenítési beállítások konfigurálása"
+      },
+      "audioPlayback": {
+        "title": "Hang lejátszás",
+        "description": "Alapértelmezett beállítások a madár hangfelvételek lejátszásához.",
+        "defaultGain": "Alapértelmezett hangerő növelés",
+        "defaultGainHelpText": "Kezdeti erősítés a felvételek lejátszásakor. A madár hangok gyakran halkak, ezért 6-12 dB erősítés ajánlott.",
+        "defaultGainUnit": "dB"
+      }
+    }
+  },
+  "auth": {
+    "login": "Bejelentkezés",
+    "logout": "Kijelentkezés",
+    "openLoginModal": "Bejelentkezési ablak megnyitása",
+    "loginTitle": "Bejelentkezés",
+    "loginSubtitle": "Hozzáférés a BirdNET-Go irányítópulthoz",
+    "password": "Jelszó",
+    "passwordPlaceholder": "Adja meg a jelszavát",
+    "enterPassword": "Adja meg a jelszavát",
+    "continue": "Folytatás",
+    "or": "vagy",
+    "loginWithGoogle": "Bejelentkezés Google-lal",
+    "loginWithGithub": "Bejelentkezés GitHub-bal",
+    "loginWithMicrosoft": "Bejelentkezés Microsoft-tal",
+    "continueWithGoogle": "Folytatás Google-lal",
+    "continueWithGithub": "Folytatás GitHub-bal",
+    "continueWithMicrosoft": "Folytatás Microsoft-tal",
+    "continueWithLine": "Folytatás LINE-nal",
+    "continueWithKakao": "Folytatás Kakao-val",
+    "continueWithOidc": "Folytatás OIDC-vel",
+    "errors": {
+      "loginFailed": "A bejelentkezés sikertelen. Kérjük, ellenőrizze a jelszavát és próbálja újra.",
+      "passwordRequired": "A jelszó kötelező.",
+      "passwordTooLong": "A jelszó túl hosszú.",
+      "invalidCharacters": "A jelszó érvénytelen karaktereket tartalmaz.",
+      "invalidCredentials": "Érvénytelen felhasználónév vagy jelszó.",
+      "tooManyAttempts": "Túl sok bejelentkezési kísérlet. Kérjük, próbálja később.",
+      "serverError": "Szerver hiba történt. Kérjük, próbálja újra később.",
+      "rateLimited": "Túl sok kísérlet. Kérjük, várjon {minutes} percet, mielőtt újra próbálkozik.",
+      "configurationError": "Hitelesítési konfigurációs hiba. Kérjük, forduljon a támogatáshoz.",
+      "invalidInput": "Érvénytelen bemenet."
+    }
+  },
+  "dataDisplay": {
+    "table": {
+      "noData": "Nincs elérhető adat",
+      "loading": "Adatok betöltése...",
+      "error": "Az adatok betöltése sikertelen",
+      "sortBy": "Rendezés: {column} szerint",
+      "rowsPerPage": "Sorok oldalanként",
+      "pageInfo": "Megjelenítés: {from} - {to} / {total} eredmény"
+    },
+    "pagination": {
+      "ariaLabel": "Lapozás navigáció",
+      "previous": "Előző",
+      "next": "Következő",
+      "page": "{current}. oldal / {total}",
+      "goToPage": "Ugrás {page}. oldalra",
+      "goToPreviousPage": "Ugrás az előző oldalra",
+      "goToNextPage": "Ugrás a következő oldalra",
+      "firstPage": "Első oldal",
+      "lastPage": "Utolsó oldal"
+    },
+    "stats": {
+      "total": "Összesen",
+      "average": "Átlag",
+      "min": "Minimum",
+      "max": "Maximum",
+      "count": "Darab"
+    }
+  },
+  "forms": {
+    "placeholders": {
+      "text": "{field} megadása",
+      "select": "{field} kiválasztása",
+      "search": "Keresés...",
+      "date": "Dátum kiválasztása",
+      "dateRange": "Dátumtartomány kiválasztása",
+      "number": "Szám megadása",
+      "password": "Jelszó megadása",
+      "url": "URL megadása",
+      "email": "E-mail megadása",
+      "selectFilterType": "Szűrőtípus kiválasztása",
+      "speciesName": "Faj neve"
+    },
+    "labels": {
+      "showPassword": "Jelszó megjelenítése",
+      "hidePassword": "Jelszó elrejtése",
+      "copyToClipboard": "Másolás vágólapra",
+      "clearSelection": "Kijelölés törlése",
+      "selectOption": "Opció kiválasztása",
+      "secretSet": "Beállítva",
+      "changeSecret": "Módosítás",
+      "cancelChange": "Mégse",
+      "enterNewSecret": "Új érték megadása"
+    },
+    "help": {
+      "passwordStrength": "Jelszó erőssége: {strength}",
+      "charactersRemaining": "{count} karakter maradt",
+      "dateFormat": "Formátum: {format}"
+    },
+    "password": {
+      "strength": {
+        "label": "Jelszó erőssége:",
+        "levels": {
+          "weak": "Gyenge",
+          "fair": "Közepes",
+          "good": "Jó",
+          "strong": "Erős"
+        },
+        "suggestions": {
+          "title": "Javaslatok:",
+          "minLength": "Legalább 8 karakter",
+          "mixedCase": "Nagy- és kisbetűk keveréke",
+          "number": "Legalább egy szám",
+          "special": "Legalább egy speciális karakter"
+        }
+      }
+    },
+    "errors": {
+      "radioValueRequired": "A radioValue prop kötelező a rádió gombokhoz"
+    },
+    "dateRange": {
+      "labels": {
+        "startDate": "Kezdő dátum",
+        "endDate": "Záró dátum",
+        "quickSelect": "Gyors kiválasztás",
+        "selected": "Kiválasztva: {startDate} - {endDate}"
+      },
+      "presets": {
+        "today": "Ma",
+        "yesterday": "Tegnap",
+        "last7Days": "Utolsó 7 nap",
+        "last30Days": "Utolsó 30 nap",
+        "thisMonth": "Ez a hónap",
+        "lastMonth": "Előző hónap",
+        "thisYear": "Ez az év"
+      },
+      "errors": {
+        "invalidStartDate": "Érvénytelen kezdő dátum",
+        "invalidEndDate": "Érvénytelen záró dátum",
+        "startAfterEnd": "A kezdő dátum nem lehet a záró dátum után",
+        "endBeforeStart": "A záró dátum nem lehet a kezdő dátum előtt"
+      }
+    },
+    "species": {
+      "placeholder": "Faj nevének megadása...",
+      "empty": "Nincs faj hozzáadva",
+      "maxReached": "Maximum {maxItems} faj érhető el",
+      "aria": {
+        "dragToReorder": "Húzás az átrendezéshez: {species}",
+        "edit": "Faj szerkesztése",
+        "remove": "Faj eltávolítása"
+      }
+    }
+  },
+  "media": {
+    "audio": {
+      "settings": "Hang beállítások",
+      "play": "Lejátszás",
+      "pause": "Szüneteltetés",
+      "stop": "Leállítás",
+      "volume": "Hangerő",
+      "mute": "Némítás",
+      "unmute": "Némítás feloldása",
+      "download": "Hang letöltése",
+      "currentTime": "{current} / {total}",
+      "loading": "Hang betöltése...",
+      "error": "A hang betöltése sikertelen",
+      "errorShort": "Hiba",
+      "playError": "A hang lejátszása sikertelen",
+      "volumeGain": "Hangerő növelés szabályozás: {value} dB",
+      "filterControl": "Szűrő szabályozás",
+      "highPassFilter": "Felül átengedő szűrő szabályozás: {freq} Hz",
+      "seekProgress": "Hang előre-hátra tekerés: {current} / {total} másodperc",
+      "playbackSpeed": "Lejátszási sebesség",
+      "speed": "Sebesség",
+      "loop": "Ismétlés be/ki",
+      "player": "Hang lejátszó"
+    },
+    "spectrogram": {
+      "notGenerated": "A spektrogram még nincs generálva",
+      "generate": "Spektrogram generálása",
+      "generateButton": "Generálás",
+      "generating": "Generálás...",
+      "generationFailed": "A spektrogram generálása sikertelen",
+      "generationSuccess": "A spektrogram sikeresen generálva"
+    }
+  },
+  "components": {
+    "audio": {
+      "spectrogramUnavailable": "Spektrogram nem elérhető",
+      "spectrogramLoading": "Spektrogram betöltése...",
+      "spectrogramLoaded": "Spektrogram betöltve",
+      "spectrogramLoadingAria": "Spektrogram betöltése",
+      "spectrogramAlt": "Hang spektrogram",
+      "spectrogramGeneratingAria": "Spektrogram generálása",
+      "generating": "Generálás...",
+      "queuePosition": "Sor: {position}",
+      "loadError": "A hang betöltése sikertelen"
+    },
+    "forms": {
+      "numberField": {
+        "adjustedToMinimum": "Az érték a minimumra ({value}) került beállításra",
+        "adjustedToMaximum": "Az érték a maximumra ({value}) került beállításra"
+      },
+      "rtsp": {
+        "addNewStream": "Új RTSP stream hozzáadása",
+        "maxStreamsReached": "Az RTSP stream-ek maximális száma ({max}) elérve.",
+        "cameraPlaceholder": "Kamera 1",
+        "urlPlaceholder": "rtsp://username:password@192.168.1.100:554/stream"
+      },
+      "subnet": {
+        "maxSubnetsReached": "Az alhálózatok maximális száma ({max}) elérve."
+      },
+      "species": {
+        "loadingSpecies": "Fajok betöltése...",
+        "typePlaceholder": "Faj nevének beírása...",
+        "suggestionsAvailable": "{count} faj javaslat érhető el. A nyílbillentyűkkel navigálhat.",
+        "noSuggestions": "Nincs elérhető faj javaslat."
+      },
+      "select": {
+        "searchPlaceholder": "Keresés...",
+        "searchOptions": "Opciók keresése",
+        "noOptions": "Nem található opció"
+      }
+    },
+    "datePicker": {
+      "today": "Ma",
+      "feedback": {
+        "endDateCleared": "A záró dátum törölve az érvényes tartomány fenntartásához",
+        "startDateCleared": "A kezdő dátum törölve az érvényes tartomány fenntartásához",
+        "invalidDateFormat": "Érvénytelen dátum formátum. Kérjük, használja az ÉÉÉÉ-HH-NN formátumot",
+        "dateOutOfRange": "A kiválasztott dátum a megengedett tartományon kívül van",
+        "futureDate": "A jövőbeli dátumok nem választhatók ki",
+        "pastDate": "A múltbeli dátumok nem választhatók ki"
+      },
+      "aria": {
+        "dateSelected": "{date} dátum kiválasztva",
+        "calendarOpened": "Naptár megnyitva a dátum kiválasztásához",
+        "calendarClosed": "Naptár bezárva",
+        "monthChanged": "{month} {year} megjelenítése",
+        "dayUnavailable": "{day}. nap nem választható ki",
+        "todayButton": "Ma kiválasztása: {today}"
+      },
+      "status": {
+        "loading": "Naptár betöltése...",
+        "error": "Hiba a naptár betöltése közben"
+      }
+    },
+    "audioPlayer": {
+      "errors": {
+        "generationFailedStatus": "A generálás sikertelen, állapot: {status}",
+        "spectrogramFailed": "A spektrogram generálása sikertelen"
+      },
+      "clipExtraction": {
+        "selectRange": "Kattintson és húzza a tartomány kijelöléséhez",
+        "playSelection": "Kijelölt tartomány lejátszása",
+        "pauseSelection": "Lejátszás szüneteltetése",
+        "reviewSelection": "Ugrás a kijelölés kezdetére",
+        "selectionStart": "Kijelölés kezdőpont fogantyúja",
+        "selectionEnd": "Kijelölés végpont fogantyúja",
+        "lossless": "veszteségmentes",
+        "lossy": "veszteséges",
+        "extractClip": "Kijelölt részlet letöltése",
+        "clearSelection": "Kijelölés törlése",
+        "extracting": "Részlet kivonása...",
+        "extractError": "A részlet kivonása sikertelen",
+        "formatLabel": "Formátum",
+        "rangeLabel": "{start}s – {end}s"
+      },
+      "processing": {
+        "playSelection": "Kijelölés lejátszása",
+        "skipToStart": "Ugrás a kijelölés kezdetére",
+        "clearSelection": "Kijelölés törlése",
+        "gain": "Erősítés (dB)",
+        "denoise": "Zajcsökkentés",
+        "denoiseOff": "Ki",
+        "denoiseLight": "Enyhe",
+        "denoiseMedium": "Közepes",
+        "denoiseHeavy": "Erős",
+        "normalize": "Hang normalizálása",
+        "normalizeTooltip": "EBU R128 normalizálás",
+        "export": "Exportálás",
+        "exportOriginal": "Eredeti",
+        "processingActive": "Feldolgozás aktív"
+      }
+    },
+    "weatherInfo": {
+      "errors": {
+        "loadFailed": "Az időjárási adatok betöltése sikertelen"
+      }
+    },
+    "tls": {
+      "certificateInstalled": "Tanúsítvány telepítve",
+      "browseFile": "Tallózás",
+      "subject": "Tárgy",
+      "issuer": "Kibocsátó",
+      "sans": "Alternatív tárgy nevek",
+      "validUntil": "Érvényes eddig",
+      "daysRemaining": "Hátralévő napok",
+      "fingerprint": "Ujjlenyomat",
+      "expiryWarning": "Ez a tanúsítvány hamarosan lejár. Fontolja meg a megújítását.",
+      "downloadCertificate": "Tanúsítvány letöltése",
+      "regenerateButton": "Újragenerálás",
+      "removeCertificate": "Tanúsítvány eltávolítása",
+      "fileReadError": "A fájl olvasása sikertelen",
+      "loading": "Tanúsítvány információ betöltése..."
+    }
+  },
+  "connectivity": {
+    "offline": "A kiszolgálóval való kapcsolat megszakadt. Újracsatlakozás..."
+  },
+  "detection": {
+    "actions": {
+      "back": "Vissza",
+      "review": "Áttekintés",
+      "download": "Letöltés"
+    }
+  },
+  "quietHours": {
+    "indicator": {
+      "tooltip": "Csendes órák aktívak — {count} forrás(ok) szüneteltetve"
+    }
+  },
+  "errors": {
+    "auth": {
+      "tooManyAttempts": "Túl sok bejelentkezési kísérlet. Kérjük, próbálja újra 15 perc múlva.",
+      "credentialsRequired": "A felhasználónév és jelszó kötelező",
+      "invalidCredentials": "Érvénytelen hitelesítési adatok",
+      "missingCode": "Hiányzó engedélyezési kód",
+      "serviceUnavailable": "A hitelesítési szolgáltatás nem elérhető. Kérjük, próbálja újra később.",
+      "timeout": "A bejelentkezés időtúllépés. Kérjük, próbálja újra.",
+      "exchangeFailed": "A bejelentkezés nem végezhető el jelenleg. Kérjük, próbálja újra.",
+      "sessionError": "Munkamenet hiba a bejelentkezés során. Kérjük, próbálja újra."
+    },
+    "alert": {
+      "v2Required": "A riasztási szabályokhoz a bővített (v2) adatbázis szükséges",
+      "invalidID": "Érvénytelen szabály ID",
+      "notFound": "Riasztási szabály nem található",
+      "invalidBody": "Érvénytelen kérés törzs",
+      "nameRequired": "A szabály neve kötelező",
+      "typesRequired": "Az objektum típus és trigger típus kötelező",
+      "duplicateName": "Ezzel a névvel már létezik szabály",
+      "invalidJSON": "Érvénytelen JSON",
+      "invalidEscalation": "Az eszkalációs lépések érvénytelenek"
+    },
+    "detection": {
+      "invalidDate": "Érvénytelen {paramName} formátum, használja az ÉÉÉÉ-HH-NN formátumot"
+    },
+    "backup": {
+      "invalidType": "A típusnak 'legacy' vagy 'v2'-nek kell lennie",
+      "alreadyRunning": "A mentés már folyamatban van",
+      "dbInfoFailed": "Az adatbázis info lekérése sikertelen",
+      "diskSpaceCheck": "A lemezterület ellenőrzése sikertelen",
+      "insufficientSpace": "Nincs elég lemezterület. Szükséges: {needed}, elérhető: {available}",
+      "createFailed": "A mentési feladat létrehozása sikertelen",
+      "notFound": "A mentési feladat nem található vagy lejárt",
+      "notReady": "A mentés nem áll készen a letöltésre",
+      "fileNotFound": "A mentési fájl nem található — a feladat lejárhatott",
+      "sqliteOnly": "A mentés csak SQLite adatbázisokhoz érhető el",
+      "dbNotConfigured": "Az adatbázis nincs konfigurálva",
+      "unsupportedType": "A mentés nem végezhető ezen az adattároló típuson",
+      "v2NotInitialized": "A V2 adatbázis nincs inicializálva"
+    },
+    "migration": {
+      "notConfigured": "A migráció nincs konfigurálva",
+      "preFlightFailed": "A előzetes ellenőrzések sikertelenek",
+      "invalidBody": "Érvénytelen kérés törzs",
+      "recordCountFailed": "Az összes rekord meghatározása sikertelen",
+      "startFailed": "A migráció indítása sikertelen",
+      "initFailed": "A migráció inicializálása sikertelen",
+      "resumeFailed": "A migráció folytatása sikertelen"
+    },
+    "cleanup": {
+      "noLegacyDB": "Nem található örökölt adatbázis",
+      "accessFailed": "Nem lehet hozzáférni az örökölt adatbázishoz",
+      "restartRequired": "Az alkalmazást újra kell indítani a migráció után, mielőtt a tisztítás elérhető",
+      "safetyCheck": "A célfájl V2 adatbázisnak tűnik — a tisztítás biztonsági okokból nem engedélyezett",
+      "noLegacyTables": "Nem található örökölt tábla",
+      "restartNeeded": "A tisztítás nem végezhető: Az alkalmazást újra kell indítani a migráció után",
+      "alreadyRunning": "A tisztítás már folyamatban van"
+    },
+    "integration": {
+      "mqttDisabled": "Az MQTT nincs engedélyezve a beállításokban",
+      "mqttNotConfigured": "Az MQTT broker nincs konfigurálva",
+      "mqttMetricsUnavailable": "A metrikus példány nem elérhető az MQTT teszthez",
+      "mqttClientFailed": "Az MQTT kliens létrehozása sikertelen",
+      "birdweatherDisabled": "A BirdWeather integráció nincs engedélyezve",
+      "birdweatherNotConfigured": "A BirdWeather állomás ID nincs konfigurálva",
+      "birdweatherClientFailed": "A BirdWeather kliens létrehozása sikertelen",
+      "noWeatherProvider": "Nincs időjárás szolgáltató kiválasztva",
+      "openWeatherKeyRequired": "Az OpenWeather API kulcs kötelező",
+      "processorUnavailable": "A processzor nem elérhető",
+      "discoveryFailed": "A Home Assistant felfedezés indítása sikertelen"
+    },
+    "notification": {
+      "serviceUnavailable": "Az értesítési szolgáltatás nem elérhető",
+      "idRequired": "Az értesítés ID kötelező",
+      "notFound": "Az értesítés nem található",
+      "hostRequired": "A host paraméter kötelező",
+      "invalidHost": "Érvénytelen host paraméter",
+      "rateLimit": "Túl sok értesítési stream csatlakozási kísérlet, kérjük, várjon, mielőtt újra próbálkozik"
+    },
+    "debug": {
+      "notEnabled": "A debug mód nincs engedélyezve"
+    },
+    "terminal": {
+      "disabled": "A terminál le van tiltva. Engedélyezze a beállításokban."
+    },
+    "api": {
+      "badRequest": "Érvénytelen kérés. Kérjük, ellenőrizze a bemenetét és próbálja újra.",
+      "unauthorized": "Hitelesítés szükséges. Kérjük, jelentkezzen be és próbálja újra.",
+      "forbidden": "Nincs jogosultsága ehhez a művelethez.",
+      "notFound": "A kért erőforrás nem található.",
+      "conflict": "Ez a művelet ütközik az aktuális állapottal. Kérjük, frissítsen és próbálja újra.",
+      "validationFailed": "Érvénytelen bemenet. Kérjük, ellenőrizze adatait és próbálja újra.",
+      "tooManyRequests": "Túl sok kérés. Kérjük, várjon, mielőtt újra próbálkozik.",
+      "serverError": "Szerver hiba történt. Kérjük, próbálja újra később.",
+      "clientError": "Kliens hiba történt. Kérjük, ellenőrizze kérését és próbálja újra.",
+      "unknownError": "Váratlan hiba történt. Kérjük, próbálja újra.",
+      "validationCheck": "Az érvényesítés sikertelen. Kérjük, ellenőrizze a bemenetét.",
+      "conflictData": "Ez a művelet ütközik a meglévő adatokkal.",
+      "requestTimeout": "A kérés időtúllépés.",
+      "networkError": "Hálózati hiba történt. Kérjük, ellenőrizze a kapcsolatát."
+    }
+  },
+  "weather": {
+    "moon": {
+      "newMoon": "Újhold",
+      "waxingCrescent": "Növekvő sarló",
+      "firstQuarter": "Első negyed",
+      "waxingGibbous": "Növekvő domború",
+      "fullMoon": "Telihold",
+      "waningGibbous": "Fogyó domború",
+      "lastQuarter": "Utolsó negyed",
+      "waningCrescent": "Fogyó sarló"
+    },
+    "birding": {
+      "excellent": "Szélcsend — kiváló a madárénekek hallgatásához",
+      "moderate": "Mérsékelt szél — néhány madárének nehezebben hallható",
+      "poor": "Erős szél — a madárénekek valószínűleg nem hallhatók"
+    }
+  },
+  "wizard": {
+    "skip": "Kihagyás",
+    "back": "Vissza",
+    "next": "Tovább",
+    "done": "Kész",
+    "progress": "{current}. lépés / {total}",
+    "progressLabel": "Varázsló előrehaladása",
+    "whatsNew": {
+      "title": "Újdonságok a {version} verzióban"
+    },
+    "steps": {
+      "welcome": {
+        "title": "Üdvözöljük",
+        "heading": "Üdvözöljük a BirdNET-Go-ban!",
+        "description": "A BirdNET-Go egy valós idejű madárhang azonosító rendszer. Meghallgatja a hangot a mikrofonjából vagy audio stream-jéből, és a BirdNET AI modellt használja a madárfajok azonosításához.",
+        "credit": "A BirdNET Analyzer által működtetve, amelyet a Cornell Lab of Ornithology K. Lisa Yang Center for Conservation Bioacoustics és a Chemnitz University of Technology fejlesztett ki.",
+        "cta": "Állítsuk be az Ön madármegfigyelő állomását."
+      },
+      "locationLanguage": {
+        "title": "Helyszín és nyelv",
+        "uiLanguageLabel": "Felület nyelve",
+        "uiLanguageHelp": "A webes felületen használt nyelv",
+        "speciesLanguageLabel": "Faj nevek nyelve",
+        "speciesLanguageHelp": "A detektálásokban használt madár faj nevek nyelve",
+        "locationLabel": "Állomás helyszíne",
+        "locationHelp": "Az Ön helyszíne segít szűrni a fajokat az Ön környékén valószínűek szerint",
+        "latitudeLabel": "Szélesség",
+        "longitudeLabel": "Hosszúság",
+        "useMyLocation": "Helyszínem használata",
+        "locationDetected": "Helyszín észlelve",
+        "locationError": "A helyszín nem észlelhető. Kérjük, adja meg manuálisan a koordinátákat.",
+        "locationDenied": "A helyszín hozzáférés megtagadva. Kérjük, adja meg manuálisan a koordinátákat."
+      },
+      "audioSource": {
+        "title": "Hang forrás",
+        "sourceTypeLabel": "Forrás típus",
+        "soundcard": "Mikrofon / Hangkártya",
+        "rtspStream": "RTSP stream",
+        "deviceLabel": "Hang eszköz",
+        "deviceLoading": "Hang eszközök betöltése...",
+        "noDevicesFound": "Nem észlelhető hang eszköz. Próbálja meg az RTSP stream konfigurálását.",
+        "rtspUrlLabel": "Adatfolyam URL",
+        "rtspUrlPlaceholder": "rtsp://user:password@host:port/stream",
+        "rtspUrlHelp": "Adja meg az RTSP audio stream URL-jét",
+        "additionalSourcesHint": "Később további hang forrásokat adhat hozzá a Beállításokban."
+      },
+      "detection": {
+        "title": "Detektálási küszöbérték",
+        "description": "Válassza ki, mennyire szigorú legyen a madár azonosítás. Ezt később módosíthatja a Beállításokban.",
+        "balanced": "Kiegyensúlyozott",
+        "balancedDesc": "Jó egyensúly a pontosság és az érzékenység között",
+        "balancedRecommended": "Ajánlott",
+        "highAccuracy": "Magas pontosság",
+        "highAccuracyDesc": "Kevesebb hamis pozitív, néhány madarat nem találhat meg",
+        "highSensitivity": "Magas érzékenység",
+        "highSensitivityDesc": "Több detektálás, több hamis pozitív",
+        "threshold": "Megbízhatósági küszöbérték",
+        "fpFilterNote": "Miután a rendszere működik és bevált, engedélyezheti a hamis pozitív szűrőt a Beállításokban a hibás detektálások további csökkentéséhez."
+      },
+      "integration": {
+        "title": "Adatvédelem és integráció",
+        "privacyFilterLabel": "Adatvédelmi szűrő engedélyezése",
+        "privacyFilterHelp": "Kiszűri a detektálásokat, amikor emberi hangok észlelhetők a mikrofon közelében",
+        "birdweatherLabel": "Detektálások megosztása a BirdWeather-rel",
+        "birdweatherHelp": " Ossza meg madár detektálásait a BirdWeather közösségi hálózattal",
+        "birdweatherIdLabel": "BirdWeather állomás ID",
+        "birdweatherIdPlaceholder": "Adja meg a BirdWeather állomás ID-jét",
+        "errorReportingLabel": "Névtelen hiba jelentések küldése",
+        "errorReportingHelp": "Segítsen fejleszteni a BirdNET-Go-t névtelen hiba jelentések küldésével, amikor valami hibásan működik"
+      },
+      "responsibleUse": {
+        "title": "A BirdNET-Go felelős használata",
+        "intro": "A BirdNET-Go egy hatékony eszköl, amely AI-asszisztált azonosítással javítja a madárlesési élményt. A madárlesés és a természetvédelem legjobb eredményeinek biztosításához:",
+        "point1": "Mielőtt megosztaná a megfigyeléseket, tekintse át és ellenőrizze a detektálásokat",
+        "point2": "A megbízhatósági pontszámokat útmutatóként használja, ne abszolút igazságként",
+        "point3": "Hasonlítsa össze a terepi útmutatókkal és a helyi szakértelemmel",
+        "point4": "Vegye figyelembe a szezonális mintákat és az élőhelyi alkalmasságot",
+        "citizenScienceHeading": "Amikor állampolgári tudományhoz járul hozzá:",
+        "citizenPoint1": "Csak személyesen ellenőrzött megfigyeléseket nyújtson be",
+        "citizenPoint2": "Tartalmazzon megjegyzéseket a vizuális vagy viselkedési megerősítésről",
+        "citizenPoint3": "Az AI detektálásokat kiindulópontként használja a saját megfigyeléseihez",
+        "outro": "Ez a megközelítés biztosítja az adatok minőségét a tudományos kutatáshoz, miközben maximalizálja a madarakkal kapcsolatos tanulást és élvezetet.",
+        "acknowledge": "Megértem"
+      }
+    }
+  },
+  "restart": {
+    "applicationRestart": "Alkalmazás újraindítása",
+    "containerRestart": "Konténer újraindítása",
+    "confirmTitle": "Újraindítás megerősítése",
+    "confirmApplicationMessage": "A kiszolgáló újraindul. Ideiglenesen le lesz kapcsolva.",
+    "confirmContainerMessage": "A konténer újraindul. Ideiglenesen le lesz kapcsolva.",
+    "inProgress": "Újraindítás...",
+    "bannerTitle": "Újraindítás szükséges",
+    "bannerMessage": "A konfigurációs változtatásokhoz újraindítás szükséges:",
+    "bannerAction": "Újraindítás most",
+    "restartFailed": "Az újraindítás kezdeményezése sikertelen"
+  }
+}

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -377,8 +377,8 @@
         "application": "Errore dell'applicazione",
         "imageProvider": "Avviso fornitore di immagini",
         "categoryError": "Errore {category}",
-        "burstTitle": "Multiple {component} errors",
-        "burstMessage": "{count} errors in the last {window_minutes} minutes: {sample_error}"
+        "burstTitle": "Errori multipli di {component}",
+        "burstMessage": "{count} errori negli ultimi {window_minutes} minuti: {sample_error}"
       },
       "settings": {
         "reloadingBirdnet": "Applicazione delle nuove impostazioni di analisi...",
@@ -388,7 +388,7 @@
         "reconfiguringBirdweather": "Aggiornamento dell'integrazione BirdWeather...",
         "reconfiguringStreams": "Aggiornamento dei flussi audio...",
         "reconfiguringTelemetry": "Aggiornamento delle impostazioni di telemetria...",
-        "reconfiguringPushNotifications": "Reconfiguring push notification providers...",
+        "reconfiguringPushNotifications": "Riconfigurazione dei provider di notifica push...",
         "reconfiguringSpeciesTracking": "Aggiornamento del monitoraggio delle specie...",
         "recalculatingThresholds": "Ricalcolo delle soglie dinamiche per il nuovo valore base",
         "reconfiguringDynamicThresholds": "Riconfigurazione delle soglie dinamiche...",
@@ -560,7 +560,7 @@
     },
     "generic": {
       "errorDetails": "Dettagli errore",
-      "stackTrace": "Stack Trace",
+      "stackTrace": "Traccia dello stack",
       "goToDashboard": "Vai alla Dashboard",
       "reportIssue": "Segnala problema",
       "loginToViewDetails": "Accedi per vedere i dettagli",
@@ -872,6 +872,11 @@
       "loadFailed": "Impossibile caricare il rilevamento (Errore {status}). Prova ad aggiornare la pagina.",
       "noIdProvided": "Nessun ID di rilevamento fornito.",
       "fetchFailed": "Recupero dei rilevamenti non riuscito"
+    },
+    "viewToggle": {
+      "label": "Modalità visualizzazione",
+      "table": "Vista tabella",
+      "cards": "Vista a schede"
     }
   },
   "species": {
@@ -914,35 +919,42 @@
         "duplicateKey": "Un sinonimo per questa specie esiste già",
         "emptyUpdatedName": "Il nome aggiornato è obbligatorio"
       }
+    },
+    "tracking": {
+      "title": "Tracciamento specie",
+      "newSpecies": "Nuova specie",
+      "newThisYear": "Prima volta quest'anno",
+      "newThisSeason": "Prima volta questa stagione",
+      "daysSinceFirst": "Giorni dalla prima osservazione"
     }
   },
   "spectrogram": {
     "controls": {
-      "frequencyRange": "Frequency Range",
-      "colorMap": "Color Map",
-      "gain": "Gain",
+      "frequencyRange": "Intervallo di frequenza",
+      "colorMap": "Mappa dei colori",
+      "gain": "Guadagno",
       "gainTooltip": "Guadagno visualizzazione spettrogramma",
       "mute": "Disattiva uscita audio",
       "unmute": "Attiva uscita audio",
-      "frequencyRangeMin": "Minimum frequency",
-      "frequencyRangeMax": "Maximum frequency"
+      "frequencyRangeMin": "Frequenza minima",
+      "frequencyRangeMax": "Frequenza massima"
     },
     "error": {
-      "unsupported": "Your browser does not support audio analysis",
-      "connectionFailed": "Failed to connect to live audio stream",
-      "accessDenied": "Live audio access requires authentication. Please log in to use this feature."
+      "unsupported": "Il tuo browser non supporta l'analisi audio",
+      "connectionFailed": "Impossibile connettersi allo stream audio dal vivo",
+      "accessDenied": "L'accesso all'audio dal vivo richiede l'autenticazione. Effettua l'accesso per utilizzare questa funzione."
     },
     "dashboard": {
-      "toggle": "Live Spectrogram",
-      "audioToggle": "Enable audio"
+      "toggle": "Spettrogramma dal vivo",
+      "audioToggle": "Abilita audio"
     },
     "gain": {
       "muted": "Disattivato",
       "level": "Guadagno: {value} dB"
     },
     "page": {
-      "title": "Live Audio",
-      "sourceLabel": "Audio Source",
+      "title": "Audio dal vivo",
+      "sourceLabel": "Sorgente audio",
       "connected": "Connesso",
       "enterFullscreen": "Schermo intero",
       "exitFullscreen": "Esci da schermo intero"
@@ -950,7 +962,7 @@
     "colorMaps": {
       "inferno": "Inferno",
       "viridis": "Viridis",
-      "grayscale": "Grayscale"
+      "grayscale": "Scala di grigi"
     },
     "labels": {
       "toggle": "Mostra/nascondi etichette di rilevamento"
@@ -966,7 +978,7 @@
     "systemInfo": {
       "title": "Informazioni di Sistema",
       "os": "Sistema Operativo",
-      "hostname": "Hostname",
+      "hostname": "Nome host",
       "uptime": "Tempo di attività",
       "cpus": "CPU",
       "model": "Modello Sistema",
@@ -1081,7 +1093,28 @@
         "creating": "Creazione backup...",
         "cancel": "Annulla",
         "retry": "Riprova Backup",
-        "mysqlNote": "Il backup MySQL richiede strumenti esterni (mysqldump)"
+        "mysqlNote": "Il backup MySQL richiede strumenti esterni (mysqldump)",
+        "history": {
+          "title": "Cronologia backup",
+          "creating": "Creazione in corso...",
+          "createBackup": "Crea backup",
+          "noBackups": "Nessun backup ancora",
+          "download": "Scarica",
+          "failed": "Fallito",
+          "columns": {
+            "date": "Data",
+            "database": "Database",
+            "size": "Dimensione",
+            "status": "Stato",
+            "actions": "Azioni"
+          },
+          "status": {
+            "pending": "In attesa",
+            "in_progress": "In corso",
+            "completed": "Completato",
+            "failed": "Fallito"
+          }
+        }
       },
       "notInitialized": "Non inizializzato",
       "migration": {
@@ -1100,7 +1133,8 @@
           "paused": "In Pausa",
           "validating": "Convalida",
           "cutover": "Passaggio in Corso",
-          "completed": "Migrazione Completata"
+          "completed": "Migrazione Completata",
+          "failed": "Validazione fallita"
         },
         "progress": {
           "title": "Progresso Migrazione",
@@ -1111,7 +1145,30 @@
           "rateValue": "{rate} rec/s",
           "remaining": "Stimato rimanente: {time}",
           "eta": "Tempo rimanente stimato",
-          "dirtyIds": "{count} record in attesa di ri-sincronizzazione"
+          "dirtyIds": "{count} record in attesa di ri-sincronizzazione",
+          "completedTitle": "Migrazione completata",
+          "completedBody": "Tutti i {count} record sono stati migrati con successo al database V2. L'applicazione utilizzerà V2 come database principale dopo il riavvio.",
+          "restartTitle": "Riavvio necessario",
+          "restartBody": "Riavvia l'applicazione per passare al database V2. La pulizia del database legacy sarà disponibile dopo il riavvio.",
+          "fallbackError": "Discrepanza nel conteggio dei record tra i database legacy e V2. Alcuni record potrebbero non essere stati migrati correttamente.",
+          "migrateInfo": "La migrazione trasferirà {count} record dal database legacy al nuovo schema V2. La modalità di scrittura doppia garantisce zero perdita di dati durante la migrazione.",
+          "sourceLegacy": "Sorgente (Legacy)",
+          "targetV2": "Destinazione (V2)",
+          "recordsLabel": "Record",
+          "sizeLabel": "Dimensione",
+          "prerequisitesNotMet": "Prerequisiti non soddisfatti — risolvi i problemi critici qui sotto",
+          "validatingTitle": "Validazione dati",
+          "validatingBody": "Confronto di {count} record legacy con il database V2...",
+          "dirtyRecordsCatchup": "{count} record non sincronizzati — verrà tentata la riconciliazione",
+          "cutoverTitle": "Completamento migrazione",
+          "cutoverBody": "Completamento della transizione al database V2...",
+          "migratingPhase": "Migrazione {phase}",
+          "progressLabel": "Avanzamento",
+          "ofRecords": "/ {count} record",
+          "percentComplete": "{percent}% completato",
+          "recordsPerSec": "{rate} record/sec",
+          "calculating": "Calcolo in corso...",
+          "dirtyWriteFailed": "{count} record non scritti — verranno riconciliati durante la validazione"
         },
         "phase": {
           "indicator": "Fase {current} di {total}: ",
@@ -1134,7 +1191,8 @@
           "pause": "Pausa",
           "resume": "Riprendi",
           "cancel": "Annulla",
-          "rollback": "Rollback"
+          "rollback": "Ripristino",
+          "retryValidation": "Riprova validazione"
         },
         "confirmDialog": {
           "title": "Avvia Migrazione Database",
@@ -1160,7 +1218,8 @@
           "resumeFailed": "Impossibile riprendere la migrazione",
           "cancelFailed": "Impossibile annullare la migrazione",
           "rollbackFailed": "Impossibile eseguire il rollback della migrazione",
-          "fetchFailed": "Impossibile recuperare lo stato della migrazione"
+          "fetchFailed": "Impossibile recuperare lo stato della migrazione",
+          "retryValidationFailed": "Impossibile riprovare la validazione"
         },
         "worker": {
           "running": "Worker In Esecuzione",
@@ -1214,12 +1273,128 @@
               "name": "Memoria Disponibile"
             },
             "mysql_max_packet": {
-              "name": "MySQL Max Packet"
+              "name": "Pacchetto massimo MySQL"
             },
             "mysql_timeout": {
-              "name": "MySQL Timeout"
+              "name": "Timeout MySQL"
             }
+          },
+          "passedCount": "{passed}/{total} superati",
+          "criticalCount": "{count} critici",
+          "warningCount": "{count} avviso/i",
+          "rerun": "Riesegui",
+          "showDetails": "Mostra dettagli",
+          "hideDetails": "Nascondi dettagli",
+          "status": {
+            "passed": "Superato",
+            "failed": "Fallito",
+            "error": "Errore",
+            "warning": "Avviso",
+            "skipped": "Saltato"
           }
+        },
+        "details": {
+          "title": "Dettagli database",
+          "detections": "{count} rilevamenti",
+          "lastBackup": "Ultimo backup: {date}",
+          "noBackups": "Nessun backup",
+          "integrity": "Integrità: {status}"
+        },
+        "strip": {
+          "legacy": "Legacy",
+          "v2Target": "V2 (Destinazione)",
+          "active": "Attivo",
+          "migration": "Migrazione",
+          "complete": "Completato",
+          "recordsMigrated": "{count} record migrati",
+          "readyToMigrate": "Pronto per la migrazione",
+          "recordsInLegacy": "{count} record nel legacy",
+          "comparingRecords": "Confronto conteggio record...",
+          "validationFailed": "Validazione fallita",
+          "rate": "Frequenza",
+          "recPerSec": "{rate} rec/s",
+          "dayAvg": "~{count} / media giornaliera",
+          "dayHistory": "Storico 30 giorni"
+        }
+      },
+      "dashboard": {
+        "title": "Dashboard database",
+        "fetchFailed": "Impossibile recuperare la panoramica del database",
+        "loading": "Caricamento...",
+        "metrics": {
+          "readLatency": "Latenza lettura",
+          "writeLatency": "Latenza scrittura",
+          "queriesPerSec": "Query/sec",
+          "database": "Database",
+          "avg": "media",
+          "max": "max",
+          "lastHour": "{count} nell'ultima ora",
+          "slowQueries": "{count} lenti"
+        },
+        "details": {
+          "title": "Dettagli database",
+          "engine": "Motore",
+          "journal": "Giornale",
+          "pageSize": "Dimensione pagina",
+          "cacheHit": "Cache hit",
+          "integrity": "Integrità",
+          "lastVacuum": "Ultimo VACUUM"
+        },
+        "locksWal": {
+          "title": "Blocchi e WAL",
+          "lockWaits": "Attese blocco",
+          "lockTimeouts": "Timeout blocco",
+          "avgWait": "Attesa media",
+          "busyTimeouts": "Timeout occupato",
+          "walSize": "Dimensione WAL",
+          "checkpoints": "Checkpoint",
+          "freelistPages": "Pagine freelist",
+          "cacheSize": "Dimensione cache"
+        },
+        "connectionPool": {
+          "title": "Pool di connessioni",
+          "poolUsage": "Utilizzo pool",
+          "active": "attivo",
+          "idle": "inattivo",
+          "waiting": "in attesa",
+          "totalCreated": "Totale creati",
+          "connErrors": "Errori di connessione",
+          "threads": "Thread",
+          "running": "in esecuzione",
+          "cached": "in cache"
+        },
+        "innodb": {
+          "title": "InnoDB e blocchi",
+          "bufferPoolHitRate": "Tasso di hit del buffer pool",
+          "bufferPoolSize": "Dimensione buffer pool",
+          "lockWaits": "Attese blocco",
+          "deadlocks": "Deadlock",
+          "avgLockWait": "Attesa media blocco",
+          "tableLocksWaited": "Blocchi tabella in attesa",
+          "tableLocksImmediate": "Blocchi tabella immediati"
+        },
+        "detectionRate": {
+          "title": "Tasso di rilevamento (24h)",
+          "chartLabel": "Tasso di rilevamento nelle ultime 24 ore",
+          "detectionsTooltip": "{count} rilevamenti",
+          "perHour": "/ora",
+          "min": "min",
+          "avg": "media",
+          "max": "max",
+          "lastBackup": "Ultimo backup",
+          "backupSize": "Dimensione backup",
+          "createBackup": "Crea backup",
+          "mysqlHost": "Host",
+          "mysqlBackupNote": "I backup MySQL devono essere gestiti tramite mysqldump o i tuoi strumenti di amministrazione MySQL."
+        },
+        "tables": {
+          "title": "Tabelle",
+          "total": "Totale",
+          "table": "Tabella",
+          "engine": "Motore",
+          "rows": "Righe",
+          "size": "Dimensione",
+          "usage": "Utilizzo"
         }
       }
     },
@@ -1384,20 +1559,48 @@
           "title": "Pattern di Rilevamento per Ora del Giorno",
           "description": "Mostra i conteggi medi di rilevamento durante il giorno per le specie selezionate",
           "noData": "Nessun dato sull'ora del giorno disponibile",
-          "noDataHint": "Seleziona specie e un intervallo di date per visualizzare i pattern"
+          "noDataHint": "Seleziona specie e un intervallo di date per visualizzare i pattern",
+          "axisTime": "Ora del giorno",
+          "axisCount": "Conteggio rilevamenti"
         },
         "dailyTrend": {
           "title": "Trend Rilevamento Specie",
           "description": "Mostra i trend di rilevamento nel tempo per le specie selezionate",
           "noData": "Nessun dato sui trend disponibile",
-          "noDataHint": "Seleziona specie e un intervallo di date per visualizzare i trend"
+          "noDataHint": "Seleziona specie e un intervallo di date per visualizzare i trend",
+          "axisDate": "Data",
+          "axisCount": "Conteggio rilevamenti",
+          "axisPercentage": "Percentuale del totale dei rilevamenti"
+        },
+        "diversity": {
+          "title": "Diversità delle specie nel tempo",
+          "description": "Mostra il numero di specie uniche rilevate al giorno tra tutti i rilevamenti",
+          "noData": "Nessun dato di diversità disponibile",
+          "noDataHint": "Seleziona un intervallo di date per visualizzare le tendenze della diversità delle specie",
+          "axisDate": "Data",
+          "axisUniqueSpecies": "Specie uniche"
+        },
+        "tooltips": {
+          "date": "Data",
+          "percentage": "Percentuale",
+          "detections": "Rilevamenti",
+          "time": "Ora",
+          "species": "Specie"
         }
       },
       "aria": {
         "startDate": "Data inizio",
         "endDate": "Data fine",
         "loadingAnalytics": "Caricamento dati analitici",
-        "loadingTrends": "Caricamento dati trend"
+        "loadingTrends": "Caricamento dati trend",
+        "loadingDiversity": "Caricamento dati di diversità"
+      },
+      "categories": {
+        "birds": "Uccelli"
+      },
+      "filters": {
+        "startDate": "Data inizio",
+        "endDate": "Data fine"
       }
     },
     "errors": {
@@ -2208,7 +2411,7 @@
               "label": "Autenticazione",
               "none": "Nessuna",
               "bearer": "Token Bearer",
-              "basic": "Basic Auth",
+              "basic": "Autenticazione base",
               "helpText": "Autenticazione opzionale per endpoint webhook"
             },
             "bearerToken": {
@@ -2338,29 +2541,29 @@
           "skipVerify": "Salta Verifica Certificato",
           "configNote": "<strong>Configurazione TLS:</strong><br />• TLS Standard: Lascia certificati vuoti per broker pubblici<br />• Certificati auto-firmati: Fornisci Certificato CA<br />• Mutual TLS (mTLS): Fornisci tutti e tre i certificati",
           "certificates": {
-            "title": "Certificate Management",
-            "description": "Upload certificates for secure MQTT broker connections",
-            "caLabel": "CA Certificate",
+            "title": "Gestione certificati",
+            "description": "Carica certificati per connessioni sicure al broker MQTT",
+            "caLabel": "Certificato CA",
             "caPlaceholder": "-----BEGIN CERTIFICATE-----",
-            "caHelpText": "Certificate Authority certificate to verify the broker's identity",
-            "clientCertLabel": "Client Certificate",
+            "caHelpText": "Certificato dell'autorità di certificazione per verificare l'identità del broker",
+            "clientCertLabel": "Certificato client",
             "clientCertPlaceholder": "-----BEGIN CERTIFICATE-----",
-            "clientCertHelpText": "Client certificate for mutual TLS authentication",
-            "clientKeyLabel": "Client Private Key",
+            "clientCertHelpText": "Certificato client per autenticazione TLS reciproca",
+            "clientKeyLabel": "Chiave privata client",
             "clientKeyPlaceholder": "-----BEGIN PRIVATE KEY-----",
-            "clientKeyHelpText": "Private key matching the client certificate",
-            "uploadButton": "Upload Certificates",
-            "uploadSuccess": "MQTT TLS certificates uploaded successfully. Use Test Connection to verify.",
-            "uploadError": "Failed to upload MQTT TLS certificates",
-            "deleteConfirm": "Remove all MQTT TLS certificates? The MQTT client will need to reconnect.",
-            "deleteSuccess": "MQTT TLS certificates removed",
-            "deleteError": "Failed to remove MQTT TLS certificates",
-            "loadError": "Failed to load certificate information",
-            "reconnectNote": "Use the Test Connection button below to verify the new TLS configuration."
+            "clientKeyHelpText": "Chiave privata corrispondente al certificato client",
+            "uploadButton": "Carica certificati",
+            "uploadSuccess": "Certificati TLS MQTT caricati con successo. Usa Test connessione per verificare.",
+            "uploadError": "Impossibile caricare i certificati TLS MQTT",
+            "deleteConfirm": "Rimuovere tutti i certificati TLS MQTT? Il client MQTT dovrà riconnettersi.",
+            "deleteSuccess": "Certificati TLS MQTT rimossi",
+            "deleteError": "Impossibile rimuovere i certificati TLS MQTT",
+            "loadError": "Impossibile caricare le informazioni del certificato",
+            "reconnectNote": "Usa il pulsante Test connessione qui sotto per verificare la nuova configurazione TLS."
           }
         },
         "homeAssistant": {
-          "title": "Home Assistant Auto-Discovery",
+          "title": "Auto-Discovery Home Assistant",
           "enable": "Abilita Home Assistant MQTT Discovery",
           "description": "Quando abilitato, BirdNET-Go registra automaticamente dispositivi e sensori su Home Assistant tramite protocollo MQTT discovery. I dispositivi appariranno nel registro dispositivi Home Assistant senza configurazione YAML manuale.",
           "discoveryPrefix": {
@@ -2500,14 +2703,14 @@
           "helpText": "Per quanto tempo memorizzare nella cache i dati tassonomici di eBird. La tassonomia cambia raramente, quindi durate più lunghe riducono le chiamate API."
         },
         "note": "eBird fornisce dati tassonomici utilizzati per la classificazione delle specie e le analisi. La chiave API è gratuita e disponibile presso il Cornell Lab of Ornithology.",
-        "apiKeyInfo": "A personal eBird API key is required to use this integration. You can request a free key from <a href=\"https://ebird.org/api/keygen\" class=\"link link-primary\" target=\"_blank\" rel=\"noopener noreferrer\">ebird.org/api/keygen</a>.",
+        "apiKeyInfo": "È necessaria una chiave API personale di eBird per utilizzare questa integrazione. Puoi richiedere una chiave gratuita su <a href=\"https://ebird.org/api/keygen\" class=\"link link-primary\" target=\"_blank\" rel=\"noopener noreferrer\">ebird.org/api/keygen</a>.",
         "test": {
-          "button": "Test eBird Connection",
-          "loading": "Testing...",
-          "enabledRequired": "Enable eBird integration first",
-          "apiKeyRequired": "API key is required",
-          "inProgress": "Test in progress...",
-          "description": "Test eBird API connectivity and authentication"
+          "button": "Test connessione eBird",
+          "loading": "Test in corso...",
+          "enabledRequired": "Abilita prima l'integrazione eBird",
+          "apiKeyRequired": "La chiave API è obbligatoria",
+          "inProgress": "Test in corso...",
+          "description": "Testa la connettività e l'autenticazione dell'API eBird"
         }
       }
     },
@@ -2940,7 +3143,7 @@
           "userIdLabel": "ID Utente"
         },
         "microsoft": {
-          "title": "Microsoft Account",
+          "title": "Account Microsoft",
           "enableLabel": "Consenti Login OAuth2 via Microsoft Account",
           "redirectUriTitle": "URI Redirect per Azure App Registration:",
           "getCredentialsLabel": "Ottieni credenziali da Azure Portal",
@@ -2973,22 +3176,22 @@
           "userIdLabel": "ID Utente"
         },
         "oidc": {
-          "title": "OIDC Provider",
-          "enableLabel": "Enable OIDC authentication",
-          "redirectUriTitle": "Redirect URI",
-          "getCredentialsLabel": "Configure in your Identity Provider",
-          "clientIdLabel": "Client ID",
-          "clientIdHelpText": "The client ID from your OIDC identity provider",
-          "clientSecretLabel": "Client Secret",
-          "clientSecretHelpText": "The client secret from your OIDC identity provider",
-          "userIdLabel": "Allowed User (email or sub claim)",
-          "issuerUrlLabel": "Issuer URL",
-          "issuerUrlHelpText": "The issuer URL of your OpenID Connect identity provider (e.g., https://auth.example.com)",
+          "title": "Provider OIDC",
+          "enableLabel": "Abilita autenticazione OIDC",
+          "redirectUriTitle": "URI di reindirizzamento",
+          "getCredentialsLabel": "Configura nel tuo Identity Provider",
+          "clientIdLabel": "ID client",
+          "clientIdHelpText": "L'ID client dal tuo provider di identità OIDC",
+          "clientSecretLabel": "Segreto client",
+          "clientSecretHelpText": "Il segreto client dal tuo provider di identità OIDC",
+          "userIdLabel": "Utente autorizzato (email o claim sub)",
+          "issuerUrlLabel": "URL emittente",
+          "issuerUrlHelpText": "L'URL dell'emittente del tuo provider di identità OpenID Connect (es. https://auth.example.com)",
           "issuerUrlPlaceholder": "https://auth.example.com",
-          "issuerUrlRequired": "Issuer URL is required for OIDC providers",
-          "issuerUrlInvalid": "Issuer URL must be a valid HTTP or HTTPS URL",
-          "scopesLabel": "Scopes",
-          "scopesHelpText": "Comma-separated list of OIDC scopes (default: openid, profile, email)",
+          "issuerUrlRequired": "L'URL dell'emittente è obbligatorio per i provider OIDC",
+          "issuerUrlInvalid": "L'URL dell'emittente deve essere un URL HTTP o HTTPS valido",
+          "scopesLabel": "Ambiti",
+          "scopesHelpText": "Elenco di scope OIDC separati da virgola (predefinito: openid, profile, email)",
           "scopesPlaceholder": "openid, profile, email"
         }
       },
@@ -2998,14 +3201,14 @@
         "disabled": "Bypass sottorete disabilitato"
       },
       "exceptions": {
-        "title": "Exceptions"
+        "title": "Eccezioni"
       },
       "publicAccess": {
-        "title": "Public Access",
-        "description": "Allow specific features to be accessible without authentication.",
-        "liveAudioLabel": "Allow public live audio playback",
-        "liveAudioHelp": "When enabled, anyone can listen to live audio streams without logging in. Settings and deletion still require authentication.",
-        "warningText": "Enabling public access features exposes them to anyone who can reach this server. Only enable if you trust your network environment."
+        "title": "Accesso pubblico",
+        "description": "Consenti l'accesso a funzionalità specifiche senza autenticazione.",
+        "liveAudioLabel": "Consenti la riproduzione audio dal vivo pubblica",
+        "liveAudioHelp": "Quando abilitato, chiunque può ascoltare gli stream audio dal vivo senza effettuare l'accesso. Le impostazioni e l'eliminazione richiedono comunque l'autenticazione.",
+        "warningText": "Abilitare le funzionalità di accesso pubblico le espone a chiunque possa raggiungere questo server. Abilita solo se ti fidi del tuo ambiente di rete."
       },
       "placeholders": {
         "baseUrl": "https://birdnet.esempio.com:5500",
@@ -3022,64 +3225,64 @@
       },
       "tls": {
         "title": "TLS / HTTPS",
-        "description": "Configure TLS/HTTPS encryption for secure connections",
-        "modeLabel": "TLS Mode",
-        "modeNone": "None (HTTP)",
+        "description": "Configura la crittografia TLS/HTTPS per connessioni sicure",
+        "modeLabel": "Modalità TLS",
+        "modeNone": "Nessuno (HTTP)",
         "modeLetsEncrypt": "Let's Encrypt",
-        "modeManual": "Manual Certificate",
-        "modeSelfSigned": "Self-Signed",
-        "modeNoneDescription": "Plain HTTP without encryption",
-        "modeAutoTLSDescription": "Automatic certificate via Let's Encrypt",
-        "modeManualDescription": "Upload your own certificate and key",
-        "modeSelfSignedDescription": "Generate a self-signed certificate",
-        "portLabel": "HTTPS Port",
-        "portHelpText": "Port for HTTPS connections (default: 8443)",
-        "redirectToHttps": "Redirect HTTP to HTTPS",
-        "autoTLSRequirements": "Requires ports 80 and 443 to be accessible. On Linux, the process needs root or CAP_NET_BIND_SERVICE capability.",
-        "validityLabel": "Certificate Validity",
-        "validityHelpText": "How long the certificate should be valid",
-        "validity365d": "1 year",
-        "validity730d": "2 years",
-        "generateButton": "Generate Certificate",
-        "regenerateButton": "Regenerate Certificate",
-        "generating": "Generating...",
-        "certificateLabel": "Certificate (PEM)",
-        "privateKeyLabel": "Private Key (PEM)",
-        "caCertificateLabel": "CA Certificate (PEM, optional)",
-        "uploadButton": "Upload Certificate",
-        "uploading": "Uploading...",
-        "browseFile": "Browse...",
-        "plaintextWarning": "Warning: Your private key will be transmitted in plaintext over HTTP. Only upload certificates when connected via a trusted network or localhost.",
-        "certificateInstalled": "Installed Certificate",
-        "subject": "Subject",
-        "issuer": "Issuer",
-        "validFrom": "Valid From",
-        "validUntil": "Valid Until",
-        "daysRemaining": "Days Remaining",
-        "sans": "Subject Alternative Names",
-        "fingerprint": "Fingerprint",
-        "expiryWarning": "Certificate is expiring soon",
-        "loading": "Loading certificate info...",
-        "loadError": "Failed to load certificate info",
-        "generateSuccess": "Self-signed certificate generated successfully",
-        "generateError": "Failed to generate certificate",
-        "uploadSuccess": "Certificate uploaded successfully",
-        "uploadError": "Failed to upload certificate",
-        "deleteSuccess": "Certificate removed successfully",
-        "deleteError": "Failed to delete certificate",
-        "removeCertificate": "Remove Certificate",
-        "deleteConfirm": "Are you sure you want to remove the installed TLS certificate? The TLS mode will be reset to None.",
-        "restartRequired": "TLS changes require a server restart to take effect.",
-        "noCertificate": "No certificate installed",
-        "validity1825d": "5 years",
-        "autoTLSHostRequired": "A hostname is required for Let’s Encrypt. Enter your public domain name in the Host field above.",
-        "autoTLSNoIP": "Let’s Encrypt requires a domain name, not an IP address. Enter a public domain like birds.example.com.",
-        "autoTLSNeedsFQDN": "Let’s Encrypt requires a fully qualified domain name (e.g., birds.example.com), not a bare hostname.",
-        "autoTLSNoLocalhost": "Let’s Encrypt cannot issue certificates for localhost.",
-        "autoTLSPrivateTLD": "Let’s Encrypt cannot issue certificates for private domains ({tld} is not publicly resolvable).",
-        "downloadCertificate": "Download Certificate",
-        "downloadCertificateHelp": "Install this certificate in your operating system's trust store to avoid browser security warnings.",
-        "fileReadError": "Failed to read the selected file"
+        "modeManual": "Certificato manuale",
+        "modeSelfSigned": "Autofirmato",
+        "modeNoneDescription": "HTTP semplice senza crittografia",
+        "modeAutoTLSDescription": "Certificato automatico tramite Let's Encrypt",
+        "modeManualDescription": "Carica il tuo certificato e la tua chiave",
+        "modeSelfSignedDescription": "Genera un certificato autofirmato",
+        "portLabel": "Porta HTTPS",
+        "portHelpText": "Porta per connessioni HTTPS (predefinita: 8443)",
+        "redirectToHttps": "Reindirizza HTTP a HTTPS",
+        "autoTLSRequirements": "Richiede che le porte 80 e 443 siano accessibili. Su Linux, il processo necessita di root o della capacità CAP_NET_BIND_SERVICE.",
+        "validityLabel": "Validità certificato",
+        "validityHelpText": "Per quanto tempo il certificato deve essere valido",
+        "validity365d": "1 anno",
+        "validity730d": "2 anni",
+        "generateButton": "Genera certificato",
+        "regenerateButton": "Rigenera certificato",
+        "generating": "Generazione in corso...",
+        "certificateLabel": "Certificato (PEM)",
+        "privateKeyLabel": "Chiave privata (PEM)",
+        "caCertificateLabel": "Certificato CA (PEM, opzionale)",
+        "uploadButton": "Carica certificato",
+        "uploading": "Caricamento in corso...",
+        "browseFile": "Sfoglia...",
+        "plaintextWarning": "Avviso: la tua chiave privata verrà trasmessa in chiaro tramite HTTP. Carica i certificati solo quando sei connesso tramite una rete fidata o localhost.",
+        "certificateInstalled": "Certificato installato",
+        "subject": "Oggetto",
+        "issuer": "Emittente",
+        "validFrom": "Valido da",
+        "validUntil": "Valido fino a",
+        "daysRemaining": "Giorni rimanenti",
+        "sans": "Nomi alternativi soggetto",
+        "fingerprint": "Impronta digitale",
+        "expiryWarning": "Il certificato sta per scadere",
+        "loading": "Caricamento informazioni certificato...",
+        "loadError": "Impossibile caricare le informazioni del certificato",
+        "generateSuccess": "Certificato autofirmato generato con successo",
+        "generateError": "Impossibile generare il certificato",
+        "uploadSuccess": "Certificato caricato con successo",
+        "uploadError": "Impossibile caricare il certificato",
+        "deleteSuccess": "Certificato rimosso con successo",
+        "deleteError": "Impossibile eliminare il certificato",
+        "removeCertificate": "Rimuovi certificato",
+        "deleteConfirm": "Sei sicuro di voler rimuovere il certificato TLS installato? La modalità TLS verrà reimpostata su Nessuna.",
+        "restartRequired": "Le modifiche TLS richiedono un riavvio del server per avere effetto.",
+        "noCertificate": "Nessun certificato installato",
+        "validity1825d": "5 anni",
+        "autoTLSHostRequired": "È necessario un nome host per Let’s Encrypt. Inserisci il tuo nome di dominio pubblico nel campo Host sopra.",
+        "autoTLSNoIP": "Let’s Encrypt richiede un nome di dominio, non un indirizzo IP. Inserisci un dominio pubblico come birds.example.com.",
+        "autoTLSNeedsFQDN": "Let’s Encrypt richiede un nome di dominio completo (es. birds.example.com), non un semplice hostname.",
+        "autoTLSNoLocalhost": "Let’s Encrypt non può emettere certificati per localhost.",
+        "autoTLSPrivateTLD": "Let’s Encrypt non può emettere certificati per domini privati ({tld} non è risolvibile pubblicamente).",
+        "downloadCertificate": "Scarica certificato",
+        "downloadCertificateHelp": "Installa questo certificato nell'archivio certificati del tuo sistema operativo per evitare avvisi di sicurezza del browser.",
+        "fileReadError": "Impossibile leggere il file selezionato"
       }
     },
     "species": {
@@ -3242,8 +3445,8 @@
             "source": "Sorgente",
             "clearParameters": "Pulisci Parametri"
           },
-          "placeholder": "Click buttons below to add parameters or type manually",
-          "tooltip": "Use buttons below or type directly (comma-separated)"
+          "placeholder": "Clicca i pulsanti qui sotto per aggiungere parametri o digita manualmente",
+          "tooltip": "Usa i pulsanti qui sotto o digita direttamente (separati da virgola)"
         },
         "executeDefaults": {
           "label": "Esegui anche azioni predefinite (archiviazione database, notifiche, ecc.)",
@@ -3395,7 +3598,7 @@
         "expand": "Mostra cronologia eventi",
         "collapse": "Nascondi cronologia eventi"
       },
-      "suggestions": "Species suggestions"
+      "suggestions": "Suggerimenti specie"
     },
     "database": {
       "sqlitePlaceholder": "Inserisci percorso database SQLite",
@@ -3635,7 +3838,7 @@
         "appearance": "Aspetto",
         "language": "Lingua e regionale",
         "visualContent": "Contenuti visivi",
-        "audioPlayback": "Audio Playback"
+        "audioPlayback": "Riproduzione audio"
       },
       "appearance": {
         "title": "Aspetto",
@@ -3650,14 +3853,14 @@
         "description": "Configura le immagini degli uccelli e le impostazioni di visualizzazione dello spettrogramma"
       },
       "audioPlayback": {
-        "title": "Audio Playback",
-        "description": "Default settings for playing bird recordings.",
-        "defaultGain": "Default Volume Boost",
-        "defaultGainHelpText": "Initial gain applied when playing recordings. Bird sounds are often quiet, so a boost of 6-12 dB is recommended.",
+        "title": "Riproduzione audio",
+        "description": "Impostazioni predefinite per la riproduzione delle registrazioni di uccelli.",
+        "defaultGain": "Amplificazione volume predefinita",
+        "defaultGainHelpText": "Guadagno iniziale applicato durante la riproduzione delle registrazioni. I suoni degli uccelli sono spesso deboli, quindi è consigliato un incremento di 6-12 dB.",
         "defaultGainUnit": "dB"
       }
     },
-    "restartRequired": "Some changes require a server restart to take effect. Please restart BirdNET-Go."
+    "restartRequired": "Alcune modifiche richiedono un riavvio del server per avere effetto. Riavvia BirdNET-Go."
   },
   "auth": {
     "login": "Accedi",
@@ -3678,7 +3881,7 @@
     "continueWithMicrosoft": "Continua con Microsoft",
     "continueWithLine": "Continua con LINE",
     "continueWithKakao": "Continua con Kakao",
-    "continueWithOidc": "Continue with OIDC",
+    "continueWithOidc": "Continua con OIDC",
     "errors": {
       "loginFailed": "Login fallito. Controlla la tua password e riprova.",
       "passwordRequired": "Password richiesta.",
@@ -3739,7 +3942,11 @@
       "hidePassword": "Nascondi password",
       "copyToClipboard": "Copia negli appunti",
       "clearSelection": "Pulisci selezione",
-      "selectOption": "Seleziona un'opzione"
+      "selectOption": "Seleziona un'opzione",
+      "secretSet": "Imposta",
+      "changeSecret": "Modifica",
+      "cancelChange": "Annulla",
+      "enterNewSecret": "Inserisci nuovo valore"
     },
     "help": {
       "passwordStrength": "Forza password: {strength}",
@@ -3806,7 +4013,7 @@
       "settings": "Impostazioni Audio",
       "play": "Riproduci",
       "pause": "Pausa",
-      "stop": "Stop",
+      "stop": "Ferma",
       "volume": "Volume",
       "mute": "Muto",
       "unmute": "Riattiva audio",
@@ -3822,7 +4029,7 @@
       "seekProgress": "Avanzamento audio: {current} / {total} secondi",
       "playbackSpeed": "Velocità riproduzione",
       "speed": "Velocità",
-      "loop": "Toggle loop",
+      "loop": "Attiva/disattiva ripetizione",
       "player": "Lettore audio"
     },
     "spectrogram": {
@@ -3854,7 +4061,7 @@
       "rtsp": {
         "addNewStream": "Aggiungi Nuovo Flusso RTSP",
         "maxStreamsReached": "Numero massimo flussi RTSP ({max}) raggiunto.",
-        "cameraPlaceholder": "Camera 1",
+        "cameraPlaceholder": "Telecamera 1",
         "urlPlaceholder": "rtsp://username:password@192.168.1.100:554/stream"
       },
       "subnet": {
@@ -3901,36 +4108,36 @@
         "spectrogramFailed": "Generazione dello spettrogramma non riuscita"
       },
       "clipExtraction": {
-        "selectRange": "Click and drag to select a range",
-        "playSelection": "Play selected range",
-        "pauseSelection": "Pause playback",
-        "reviewSelection": "Jump to start of selection",
-        "selectionStart": "Selection start handle",
-        "selectionEnd": "Selection end handle",
+        "selectRange": "Clicca e trascina per selezionare un intervallo",
+        "playSelection": "Riproduci intervallo selezionato",
+        "pauseSelection": "Metti in pausa",
+        "reviewSelection": "Vai all'inizio della selezione",
+        "selectionStart": "Maniglia di inizio selezione",
+        "selectionEnd": "Maniglia di fine selezione",
         "lossless": "Lossless",
         "lossy": "Lossy",
-        "extractClip": "Download selected clip",
-        "clearSelection": "Clear selection",
-        "extracting": "Extracting clip...",
-        "extractError": "Failed to extract clip",
-        "formatLabel": "Format",
+        "extractClip": "Scarica clip selezionata",
+        "clearSelection": "Cancella selezione",
+        "extracting": "Estrazione clip in corso...",
+        "extractError": "Impossibile estrarre il clip",
+        "formatLabel": "Formato",
         "rangeLabel": "{start}s – {end}s"
       },
       "processing": {
-        "playSelection": "Play selection",
-        "skipToStart": "Skip to selection start",
-        "clearSelection": "Clear selection",
-        "gain": "Gain (dB)",
-        "denoise": "Denoise",
-        "denoiseOff": "Off",
-        "denoiseLight": "Light",
-        "denoiseMedium": "Medium",
-        "denoiseHeavy": "Heavy",
-        "normalize": "Normalize audio",
-        "normalizeTooltip": "EBU R128 Normalization",
-        "export": "Export",
+        "playSelection": "Riproduci selezione",
+        "skipToStart": "Vai all'inizio della selezione",
+        "clearSelection": "Cancella selezione",
+        "gain": "Guadagno (dB)",
+        "denoise": "Riduzione rumore",
+        "denoiseOff": "Disattivato",
+        "denoiseLight": "Leggero",
+        "denoiseMedium": "Medio",
+        "denoiseHeavy": "Pesante",
+        "normalize": "Normalizza audio",
+        "normalizeTooltip": "Normalizzazione EBU R128",
+        "export": "Esporta",
         "exportOriginal": "Originale",
-        "processingActive": "Processing active"
+        "processingActive": "Elaborazione attiva"
       }
     },
     "weatherInfo": {
@@ -3939,20 +4146,20 @@
       }
     },
     "tls": {
-      "certificateInstalled": "Certificate Installed",
-      "browseFile": "Browse",
-      "subject": "Subject",
-      "issuer": "Issuer",
-      "sans": "Subject Alternative Names",
-      "validUntil": "Valid Until",
-      "daysRemaining": "Days Remaining",
-      "fingerprint": "Fingerprint",
-      "expiryWarning": "This certificate expires soon. Consider renewing it.",
-      "downloadCertificate": "Download Certificate",
-      "regenerateButton": "Regenerate",
-      "removeCertificate": "Remove Certificate",
-      "fileReadError": "Failed to read file",
-      "loading": "Loading certificate information..."
+      "certificateInstalled": "Certificato installato",
+      "browseFile": "Sfoglia",
+      "subject": "Oggetto",
+      "issuer": "Emittente",
+      "sans": "Nomi alternativi soggetto",
+      "validUntil": "Valido fino a",
+      "daysRemaining": "Giorni rimanenti",
+      "fingerprint": "Impronta digitale",
+      "expiryWarning": "Questo certificato scade presto. Considera di rinnovarlo.",
+      "downloadCertificate": "Scarica certificato",
+      "regenerateButton": "Rigenera",
+      "removeCertificate": "Rimuovi certificato",
+      "fileReadError": "Impossibile leggere il file",
+      "loading": "Caricamento informazioni certificato..."
     }
   },
   "connectivity": {
@@ -4125,77 +4332,77 @@
     },
     "steps": {
       "welcome": {
-        "title": "Welcome",
-        "heading": "Welcome to BirdNET-Go!",
-        "description": "BirdNET-Go is a real-time bird sound identification system. It listens to audio from your microphone or audio stream and uses the BirdNET AI model to identify bird species.",
-        "credit": "Powered by the BirdNET Analyzer developed by the K. Lisa Yang Center for Conservation Bioacoustics at the Cornell Lab of Ornithology and Chemnitz University of Technology.",
-        "cta": "Let's set up your bird monitoring station."
+        "title": "Benvenuto",
+        "heading": "Benvenuto in BirdNET-Go!",
+        "description": "BirdNET-Go è un sistema di identificazione dei suoni degli uccelli in tempo reale. Ascolta l'audio dal microfono o dallo stream audio e utilizza il modello IA BirdNET per identificare le specie di uccelli.",
+        "credit": "Basato su BirdNET Analyzer sviluppato dal K. Lisa Yang Center for Conservation Bioacoustics presso il Cornell Lab of Ornithology e la Chemnitz University of Technology.",
+        "cta": "Configuriamo la tua stazione di monitoraggio degli uccelli."
       },
       "locationLanguage": {
-        "title": "Location & Language",
-        "uiLanguageLabel": "Interface Language",
-        "uiLanguageHelp": "Language used for the web interface",
-        "speciesLanguageLabel": "Species Name Language",
-        "speciesLanguageHelp": "Language used for bird species names in detections",
-        "locationLabel": "Station Location",
-        "locationHelp": "Your location helps filter species to those likely in your area",
-        "latitudeLabel": "Latitude",
-        "longitudeLabel": "Longitude",
-        "useMyLocation": "Use my location",
-        "locationDetected": "Location detected",
-        "locationError": "Could not detect location. Please enter coordinates manually.",
-        "locationDenied": "Location access denied. Please enter coordinates manually."
+        "title": "Posizione e lingua",
+        "uiLanguageLabel": "Lingua interfaccia",
+        "uiLanguageHelp": "Lingua utilizzata per l'interfaccia web",
+        "speciesLanguageLabel": "Lingua dei nomi delle specie",
+        "speciesLanguageHelp": "Lingua utilizzata per i nomi delle specie di uccelli nei rilevamenti",
+        "locationLabel": "Posizione stazione",
+        "locationHelp": "La tua posizione aiuta a filtrare le specie probabili nella tua zona",
+        "latitudeLabel": "Latitudine",
+        "longitudeLabel": "Longitudine",
+        "useMyLocation": "Usa la mia posizione",
+        "locationDetected": "Posizione rilevata",
+        "locationError": "Impossibile rilevare la posizione. Inserisci le coordinate manualmente.",
+        "locationDenied": "Accesso alla posizione negato. Inserisci le coordinate manualmente."
       },
       "audioSource": {
-        "title": "Audio Source",
-        "sourceTypeLabel": "Source Type",
-        "soundcard": "Microphone / Soundcard",
-        "rtspStream": "RTSP Stream",
-        "deviceLabel": "Audio Device",
-        "deviceLoading": "Loading audio devices...",
-        "noDevicesFound": "No audio devices detected. Try configuring an RTSP stream instead.",
-        "rtspUrlLabel": "Stream URL",
+        "title": "Sorgente audio",
+        "sourceTypeLabel": "Tipo di sorgente",
+        "soundcard": "Microfono / Scheda audio",
+        "rtspStream": "Stream RTSP",
+        "deviceLabel": "Dispositivo audio",
+        "deviceLoading": "Caricamento dispositivi audio...",
+        "noDevicesFound": "Nessun dispositivo audio rilevato. Prova a configurare uno stream RTSP.",
+        "rtspUrlLabel": "URL stream",
         "rtspUrlPlaceholder": "rtsp://user:password@host:port/stream",
-        "rtspUrlHelp": "Enter the URL of your RTSP audio stream",
-        "additionalSourcesHint": "You can add more audio sources later in Settings."
+        "rtspUrlHelp": "Inserisci l'URL del tuo stream audio RTSP",
+        "additionalSourcesHint": "Puoi aggiungere altre sorgenti audio successivamente nelle Impostazioni."
       },
       "detection": {
-        "title": "Detection Threshold",
-        "description": "Choose how strict the bird identification should be. You can adjust this later in Settings.",
-        "balanced": "Balanced",
-        "balancedDesc": "Good balance of accuracy and sensitivity",
-        "balancedRecommended": "Recommended",
-        "highAccuracy": "High Accuracy",
-        "highAccuracyDesc": "Fewer false positives, may miss some birds",
-        "highSensitivity": "High Sensitivity",
-        "highSensitivityDesc": "More detections, more false positives",
-        "threshold": "Confidence threshold",
-        "fpFilterNote": "Once your system is running and proven, you can enable the false positive filter in Settings to further reduce incorrect detections."
+        "title": "Soglia di rilevamento",
+        "description": "Scegli quanto deve essere rigorosa l'identificazione degli uccelli. Puoi modificarlo successivamente nelle Impostazioni.",
+        "balanced": "Bilanciato",
+        "balancedDesc": "Buon equilibrio tra accuratezza e sensibilità",
+        "balancedRecommended": "Consigliato",
+        "highAccuracy": "Alta accuratezza",
+        "highAccuracyDesc": "Meno falsi positivi, potrebbe non rilevare alcuni uccelli",
+        "highSensitivity": "Alta sensibilità",
+        "highSensitivityDesc": "Più rilevamenti, più falsi positivi",
+        "threshold": "Soglia di confidenza",
+        "fpFilterNote": "Una volta che il tuo sistema è funzionante e collaudato, puoi abilitare il filtro dei falsi positivi nelle Impostazioni per ridurre ulteriormente i rilevamenti errati."
       },
       "integration": {
-        "title": "Privacy & Integration",
-        "privacyFilterLabel": "Enable privacy filter",
-        "privacyFilterHelp": "Filters out detections when human voices are detected near the microphone",
-        "birdweatherLabel": "Share detections with BirdWeather",
-        "birdweatherHelp": "Contribute your bird detections to the BirdWeather community network",
-        "birdweatherIdLabel": "BirdWeather Station ID",
-        "birdweatherIdPlaceholder": "Enter your BirdWeather station ID",
-        "errorReportingLabel": "Send anonymous error reports",
-        "errorReportingHelp": "Help improve BirdNET-Go by sending anonymous error reports when something goes wrong"
+        "title": "Privacy e integrazione",
+        "privacyFilterLabel": "Abilita filtro privacy",
+        "privacyFilterHelp": "Filtra i rilevamenti quando vengono rilevate voci umane vicino al microfono",
+        "birdweatherLabel": "Condividi rilevamenti con BirdWeather",
+        "birdweatherHelp": "Contribuisci con i tuoi rilevamenti alla rete comunitaria BirdWeather",
+        "birdweatherIdLabel": "ID stazione BirdWeather",
+        "birdweatherIdPlaceholder": "Inserisci l'ID della tua stazione BirdWeather",
+        "errorReportingLabel": "Invia segnalazioni di errore anonime",
+        "errorReportingHelp": "Aiuta a migliorare BirdNET-Go inviando segnalazioni di errore anonime quando qualcosa va storto"
       },
       "responsibleUse": {
-        "title": "Using BirdNET-Go Responsibly",
-        "intro": "BirdNET-Go is a powerful tool that enhances your birding experience through AI-assisted identification. To ensure the best outcomes for both birding and conservation:",
-        "point1": "Review and verify detections before sharing observations",
-        "point2": "Use the confidence scores as a guide, not absolute truth",
-        "point3": "Cross-reference with field guides and local expertise",
-        "point4": "Consider seasonal patterns and habitat suitability",
-        "citizenScienceHeading": "When contributing to citizen science:",
-        "citizenPoint1": "Only submit observations you have personally verified",
-        "citizenPoint2": "Include notes about visual or behavioral confirmation",
-        "citizenPoint3": "Use AI detections as a starting point for your own observations",
-        "outro": "This approach ensures data quality for scientific research while maximizing your learning and enjoyment of birds.",
-        "acknowledge": "I understand"
+        "title": "Usare BirdNET-Go in modo responsabile",
+        "intro": "BirdNET-Go è uno strumento potente che migliora la tua esperienza di birdwatching attraverso l'identificazione assistita dall'IA. Per garantire i migliori risultati sia per il birdwatching che per la conservazione:",
+        "point1": "Rivedi e verifica i rilevamenti prima di condividere le osservazioni",
+        "point2": "Usa i punteggi di confidenza come guida, non come verità assoluta",
+        "point3": "Verifica incrociata con guide da campo e competenze locali",
+        "point4": "Considera i modelli stagionali e l'idoneità dell'habitat",
+        "citizenScienceHeading": "Quando contribuisci alla citizen science:",
+        "citizenPoint1": "Invia solo osservazioni che hai verificato personalmente",
+        "citizenPoint2": "Includi note sulla conferma visiva o comportamentale",
+        "citizenPoint3": "Usa i rilevamenti IA come punto di partenza per le tue osservazioni",
+        "outro": "Questo approccio garantisce la qualità dei dati per la ricerca scientifica massimizzando il tuo apprendimento e il piacere dell'osservazione degli uccelli.",
+        "acknowledge": "Ho capito"
       }
     }
   },

--- a/frontend/static/messages/lv.json
+++ b/frontend/static/messages/lv.json
@@ -377,8 +377,8 @@
         "application": "Lietotnes kļūda",
         "imageProvider": "Attēlu nodrošinātāja paziņojums",
         "categoryError": "{category} kļūda",
-        "burstTitle": "Multiple {component} errors",
-        "burstMessage": "{count} errors in the last {window_minutes} minutes: {sample_error}"
+        "burstTitle": "Vairākas {component} kļūdas",
+        "burstMessage": "{count} kļūdas pēdējās {window_minutes} minūtēs: {sample_error}"
       },
       "settings": {
         "reloadingBirdnet": "Piemēro jaunos analīzes iestatījumus...",
@@ -388,7 +388,7 @@
         "reconfiguringBirdweather": "Atjaunina BirdWeather integrāciju...",
         "reconfiguringStreams": "Atjaunina audio straumes...",
         "reconfiguringTelemetry": "Atjaunina telemetrijas iestatījumus...",
-        "reconfiguringPushNotifications": "Reconfiguring push notification providers...",
+        "reconfiguringPushNotifications": "Pārkonfigurē push paziņojumu pakalpojumu sniedzējus...",
         "reconfiguringSpeciesTracking": "Atjaunina sugu izsekošanu...",
         "recalculatingThresholds": "Pārrēķina dinamiskos sliekšņus jaunai bāzes vērtībai",
         "reconfiguringDynamicThresholds": "Pārkonfigurē dinamiskos sliekšņus...",
@@ -930,31 +930,31 @@
   },
   "spectrogram": {
     "controls": {
-      "frequencyRange": "Frequency Range",
-      "colorMap": "Color Map",
-      "gain": "Gain",
+      "frequencyRange": "Frekvenču diapazons",
+      "colorMap": "Krāsu karte",
+      "gain": "Pastiprinājums",
       "gainTooltip": "Spektrogrammas vizualizācijas pastiprināšana",
       "mute": "Izslēgt audio izvadi",
       "unmute": "Ieslēgt audio izvadi",
-      "frequencyRangeMin": "Minimum frequency",
-      "frequencyRangeMax": "Maximum frequency"
+      "frequencyRangeMin": "Minimālā frekvence",
+      "frequencyRangeMax": "Maksimālā frekvence"
     },
     "error": {
-      "unsupported": "Your browser does not support audio analysis",
-      "connectionFailed": "Failed to connect to live audio stream",
-      "accessDenied": "Live audio access requires authentication. Please log in to use this feature."
+      "unsupported": "Jūsu pārlūkprogramma neatbalsta audio analīzi",
+      "connectionFailed": "Neizdevās izveidot savienojumu ar tiešraides audio straumi",
+      "accessDenied": "Tiešraides audio piekļuvei nepieciešama autentifikācija. Lūdzu, piesakieties, lai izmantotu šo funkciju."
     },
     "dashboard": {
-      "toggle": "Live Spectrogram",
-      "audioToggle": "Enable audio"
+      "toggle": "Tiešraides spektrogramma",
+      "audioToggle": "Ieslēgt audio"
     },
     "gain": {
       "muted": "Izslēgts",
       "level": "Pastiprinājums: {value} dB"
     },
     "page": {
-      "title": "Live Audio",
-      "sourceLabel": "Audio Source",
+      "title": "Tiešraides audio",
+      "sourceLabel": "Audio avots",
       "connected": "Savienots",
       "enterFullscreen": "Pilnekrāna režīms",
       "exitFullscreen": "Iziet no pilnekrāna"
@@ -962,7 +962,10 @@
     "colorMaps": {
       "inferno": "Inferno",
       "viridis": "Viridis",
-      "grayscale": "Grayscale"
+      "grayscale": "Pelēktoņu"
+    },
+    "labels": {
+      "toggle": "Pārslēgt noteikšanas etiķetes"
     }
   },
   "system": {
@@ -3963,7 +3966,11 @@
       "hidePassword": "Slēpt paroli",
       "copyToClipboard": "Kopēt starpliktuvē",
       "clearSelection": "Notīrīt atlasi",
-      "selectOption": "Izvēlieties opciju"
+      "selectOption": "Izvēlieties opciju",
+      "secretSet": "Iestatīts",
+      "changeSecret": "Mainīt",
+      "cancelChange": "Atcelt",
+      "enterNewSecret": "Ievadiet jaunu vērtību"
     },
     "help": {
       "passwordStrength": "Paroles stiprums: {strength}",
@@ -4046,7 +4053,8 @@
       "seekProgress": "Audio pārtīšanas progress: {current} / {total} sekundes",
       "playbackSpeed": "Atskaņošanas ātrums",
       "speed": "Ātrums",
-      "loop": "Pārslēgt cilpu"
+      "loop": "Pārslēgt cilpu",
+      "player": "Audio atskaņotājs"
     },
     "spectrogram": {
       "notGenerated": "Spektrogramma vēl nav ģenerēta",
@@ -4066,7 +4074,8 @@
       "spectrogramGeneratingAria": "Ģenerē spektrogrammu",
       "generating": "Ģenerē...",
       "queuePosition": "Rinda: {position}",
-      "loadError": "Neizdevās ielādēt audio"
+      "loadError": "Neizdevās ielādēt audio",
+      "spectrogramAlt": "Audio spektrogramma"
     },
     "forms": {
       "numberField": {
@@ -4323,77 +4332,77 @@
     },
     "steps": {
       "welcome": {
-        "title": "Welcome",
-        "heading": "Welcome to BirdNET-Go!",
-        "description": "BirdNET-Go is a real-time bird sound identification system. It listens to audio from your microphone or audio stream and uses the BirdNET AI model to identify bird species.",
-        "credit": "Powered by the BirdNET Analyzer developed by the K. Lisa Yang Center for Conservation Bioacoustics at the Cornell Lab of Ornithology and Chemnitz University of Technology.",
-        "cta": "Let's set up your bird monitoring station."
+        "title": "Sveicināti",
+        "heading": "Laipni lūdzam BirdNET-Go!",
+        "description": "BirdNET-Go ir reāllaika putnu skaņu identificēšanas sistēma. Tā klausās audio no jūsu mikrofona vai audio straumes un izmanto BirdNET mākslīgā intelekta modeli, lai identificētu putnu sugas.",
+        "credit": "Darbina BirdNET Analyzer, ko izstrādājis K. Lisa Yang Center for Conservation Bioacoustics Kornela Ornitoloģijas laboratorijā un Kemnicas Tehnoloģiju universitātē.",
+        "cta": "Iestatīsim jūsu putnu novērošanas staciju."
       },
       "locationLanguage": {
-        "title": "Location & Language",
-        "uiLanguageLabel": "Interface Language",
-        "uiLanguageHelp": "Language used for the web interface",
-        "speciesLanguageLabel": "Species Name Language",
-        "speciesLanguageHelp": "Language used for bird species names in detections",
-        "locationLabel": "Station Location",
-        "locationHelp": "Your location helps filter species to those likely in your area",
-        "latitudeLabel": "Latitude",
-        "longitudeLabel": "Longitude",
-        "useMyLocation": "Use my location",
-        "locationDetected": "Location detected",
-        "locationError": "Could not detect location. Please enter coordinates manually.",
-        "locationDenied": "Location access denied. Please enter coordinates manually."
+        "title": "Atrašanās vieta un valoda",
+        "uiLanguageLabel": "Saskarnes valoda",
+        "uiLanguageHelp": "Valoda, kas tiek izmantota tīmekļa saskarnē",
+        "speciesLanguageLabel": "Sugu nosaukumu valoda",
+        "speciesLanguageHelp": "Valoda, kas tiek izmantota putnu sugu nosaukumiem noteikšanā",
+        "locationLabel": "Stacijas atrašanās vieta",
+        "locationHelp": "Jūsu atrašanās vieta palīdz filtrēt sugas, kas, visticamāk, ir jūsu apkārtnē",
+        "latitudeLabel": "Platums",
+        "longitudeLabel": "Garums",
+        "useMyLocation": "Izmantot manu atrašanās vietu",
+        "locationDetected": "Atrašanās vieta noteikta",
+        "locationError": "Neizdevās noteikt atrašanās vietu. Lūdzu, ievadiet koordinātas manuāli.",
+        "locationDenied": "Piekļuve atrašanās vietai liegta. Lūdzu, ievadiet koordinātas manuāli."
       },
       "audioSource": {
-        "title": "Audio Source",
-        "sourceTypeLabel": "Source Type",
-        "soundcard": "Microphone / Soundcard",
-        "rtspStream": "RTSP Stream",
-        "deviceLabel": "Audio Device",
-        "deviceLoading": "Loading audio devices...",
-        "noDevicesFound": "No audio devices detected. Try configuring an RTSP stream instead.",
-        "rtspUrlLabel": "Stream URL",
+        "title": "Audio avots",
+        "sourceTypeLabel": "Avota tips",
+        "soundcard": "Mikrofons / Skaņas karte",
+        "rtspStream": "RTSP straume",
+        "deviceLabel": "Audio ierīce",
+        "deviceLoading": "Ielādē audio ierīces...",
+        "noDevicesFound": "Nav atrasta neviena audio ierīce. Mēģiniet konfigurēt RTSP straumi.",
+        "rtspUrlLabel": "Straumes URL",
         "rtspUrlPlaceholder": "rtsp://user:password@host:port/stream",
-        "rtspUrlHelp": "Enter the URL of your RTSP audio stream",
-        "additionalSourcesHint": "You can add more audio sources later in Settings."
+        "rtspUrlHelp": "Ievadiet RTSP audio straumes URL",
+        "additionalSourcesHint": "Papildu audio avotus varēsiet pievienot vēlāk iestatījumos."
       },
       "detection": {
-        "title": "Detection Threshold",
-        "description": "Choose how strict the bird identification should be. You can adjust this later in Settings.",
-        "balanced": "Balanced",
-        "balancedDesc": "Good balance of accuracy and sensitivity",
-        "balancedRecommended": "Recommended",
-        "highAccuracy": "High Accuracy",
-        "highAccuracyDesc": "Fewer false positives, may miss some birds",
-        "highSensitivity": "High Sensitivity",
-        "highSensitivityDesc": "More detections, more false positives",
-        "threshold": "Confidence threshold",
-        "fpFilterNote": "Once your system is running and proven, you can enable the false positive filter in Settings to further reduce incorrect detections."
+        "title": "Noteikšanas slieksnis",
+        "description": "Izvēlieties, cik stingrai jābūt putnu identificēšanai. Vēlāk to varēsiet pielāgot iestatījumos.",
+        "balanced": "Līdzsvarots",
+        "balancedDesc": "Labs precizitātes un jutīguma līdzsvars",
+        "balancedRecommended": "Ieteicams",
+        "highAccuracy": "Augsta precizitāte",
+        "highAccuracyDesc": "Mazāk kļūdaini pozitīvu, var palaist garām dažus putnus",
+        "highSensitivity": "Augsts jutīgums",
+        "highSensitivityDesc": "Vairāk noteikšanu, vairāk kļūdaini pozitīvu",
+        "threshold": "Ticamības slieksnis",
+        "fpFilterNote": "Kad sistēma darbojas un ir pierādījusi sevi, varat ieslēgt kļūdaini pozitīvo filtru iestatījumos, lai vēl vairāk samazinātu nepareizas noteikšanas."
       },
       "integration": {
-        "title": "Privacy & Integration",
-        "privacyFilterLabel": "Enable privacy filter",
-        "privacyFilterHelp": "Filters out detections when human voices are detected near the microphone",
-        "birdweatherLabel": "Share detections with BirdWeather",
-        "birdweatherHelp": "Contribute your bird detections to the BirdWeather community network",
-        "birdweatherIdLabel": "BirdWeather Station ID",
-        "birdweatherIdPlaceholder": "Enter your BirdWeather station ID",
-        "errorReportingLabel": "Send anonymous error reports",
-        "errorReportingHelp": "Help improve BirdNET-Go by sending anonymous error reports when something goes wrong"
+        "title": "Privātums un integrācija",
+        "privacyFilterLabel": "Ieslēgt privātuma filtru",
+        "privacyFilterHelp": "Filtrē noteikšanas, kad pie mikrofona tiek noteiktas cilvēku balsis",
+        "birdweatherLabel": "Dalīties ar noteikšanām BirdWeather",
+        "birdweatherHelp": "Sniedziet savu putnu noteikšanu ieguldījumu BirdWeather kopienas tīklā",
+        "birdweatherIdLabel": "BirdWeather stacijas ID",
+        "birdweatherIdPlaceholder": "Ievadiet savu BirdWeather stacijas ID",
+        "errorReportingLabel": "Sūtīt anonīmus kļūdu ziņojumus",
+        "errorReportingHelp": "Palīdziet uzlabot BirdNET-Go, sūtot anonīmus kļūdu ziņojumus, kad kaut kas noiet greizi"
       },
       "responsibleUse": {
-        "title": "Using BirdNET-Go Responsibly",
-        "intro": "BirdNET-Go is a powerful tool that enhances your birding experience through AI-assisted identification. To ensure the best outcomes for both birding and conservation:",
-        "point1": "Review and verify detections before sharing observations",
-        "point2": "Use the confidence scores as a guide, not absolute truth",
-        "point3": "Cross-reference with field guides and local expertise",
-        "point4": "Consider seasonal patterns and habitat suitability",
-        "citizenScienceHeading": "When contributing to citizen science:",
-        "citizenPoint1": "Only submit observations you have personally verified",
-        "citizenPoint2": "Include notes about visual or behavioral confirmation",
-        "citizenPoint3": "Use AI detections as a starting point for your own observations",
-        "outro": "This approach ensures data quality for scientific research while maximizing your learning and enjoyment of birds.",
-        "acknowledge": "I understand"
+        "title": "BirdNET-Go atbildīga lietošana",
+        "intro": "BirdNET-Go ir jaudīgs rīks, kas uzlabo jūsu putnu vērošanas pieredzi ar MI atbalstītu identifikāciju. Lai nodrošinātu labākos rezultātus gan putnu vērošanai, gan dabas aizsardzībai:",
+        "point1": "Pārskatiet un pārbaudiet noteikšanas pirms novērojumu kopīgošanas",
+        "point2": "Izmantojiet ticamības rādītājus kā vadlīniju, nevis absolūtu patiesību",
+        "point3": "Salīdziniet ar lauka noteicējiem un vietējo pieredzi",
+        "point4": "Ņemiet vērā sezonālos modeļus un biotopu piemērotību",
+        "citizenScienceHeading": "Sniedzot ieguldījumu pilsoņzinātnē:",
+        "citizenPoint1": "Iesniedziet tikai tādus novērojumus, kurus esat personīgi pārbaudījuši",
+        "citizenPoint2": "Iekļaujiet piezīmes par vizuālo vai uzvedības apstiprinājumu",
+        "citizenPoint3": "Izmantojiet MI noteikšanas kā sākumpunktu saviem novērojumiem",
+        "outro": "Šī pieeja nodrošina datu kvalitāti zinātniskiem pētījumiem, vienlaikus maksimāli palielinot jūsu mācīšanos un prieku par putniem.",
+        "acknowledge": "Es saprotu"
       }
     }
   },

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -231,10 +231,10 @@
   "about": {
     "title": "BirdNET-Go",
     "subtitle": "Een moderne interface voor real-time vogelgeluids herkenning en classificatie",
-    "logoAlt": "BirdNET-Go Logo",
+    "logoAlt": "BirdNET-Go-logo",
     "overview": "Overzicht",
     "overviewText": "BirdNET-Go is een Go-gebaseerde implementatie voor real-time vogelgeluids herkenning en classificatie, gebouwd op de basis van het BirdNET project. Deze applicatie biedt een gebruiksvriendelijke interface voor continue vogelgeluids monitoring en analyse.",
-    "birdnetProject": "BirdNET Project",
+    "birdnetProject": "BirdNET-project",
     "birdnetDescription": "BirdNET-Go zou niet mogelijk zijn zonder het baanbrekende werk van het BirdNET project. Het kunstmatige intelligentie model dat de herkenningsmogelijkheden van BirdNET-Go aandrijft is het resultaat van het innovatieve onderzoek en ontwikkeling van het BirdNET project.",
     "developedBy": "Ontwikkeld door",
     "developersText": "Het K. Lisa Yang Center for Conservation Bioacoustics van het Cornell Lab of Ornithology in samenwerking met de Technische Universiteit Chemnitz:",
@@ -252,12 +252,12 @@
     "testing": "Testen en validatie",
     "documentation": "Documentatie verbeteringen",
     "additionalCredits": "Aanvullende Credits",
-    "birdnetPiProject": "BirdNET-Pi Project",
+    "birdnetPiProject": "BirdNET-Pi-project",
     "birdnetPiDescription": "Speciale dank aan Patrick McGuire voor zijn inspirerende werk aan BirdNET-Pi, dat de ontwikkeling van BirdNET-Go heeft beïnvloed. BirdNET-Pi demonstreert het potentieel van vogelgeluids herkenning op embedded apparaten en heeft een hoge standaard gezet voor community-gedreven ontwikkeling.",
     "visitBirdnetPi": "Bezoek BirdNET-Pi Project",
     "labelTranslations": "BirdNET Label Vertalingen",
     "labelTranslationsBy": "Aangeleverd door Patrick Levin voor het BirdNET-Pi project van Patrick McGuire",
-    "patrickLevinGithub": "Patrick Levin's GitHub",
+    "patrickLevinGithub": "GitHub van Patrick Levin",
     "versionInformation": "Versie Informatie",
     "currentVersion": "Huidige Versie",
     "buildDate": "Build Datum",
@@ -377,8 +377,8 @@
         "application": "Applicatiefout",
         "imageProvider": "Melding afbeeldingprovider",
         "categoryError": "{category}-fout",
-        "burstTitle": "Multiple {component} errors",
-        "burstMessage": "{count} errors in the last {window_minutes} minutes: {sample_error}"
+        "burstTitle": "Meerdere {component}-fouten",
+        "burstMessage": "{count} fouten in de laatste {window_minutes} minuten: {sample_error}"
       },
       "settings": {
         "reloadingBirdnet": "Nieuwe analyse-instellingen worden toegepast...",
@@ -388,7 +388,7 @@
         "reconfiguringBirdweather": "BirdWeather-integratie wordt bijgewerkt...",
         "reconfiguringStreams": "Audiostreams worden bijgewerkt...",
         "reconfiguringTelemetry": "Telemetrie-instellingen worden bijgewerkt...",
-        "reconfiguringPushNotifications": "Reconfiguring push notification providers...",
+        "reconfiguringPushNotifications": "Pushmeldingsproviders herconfigureren...",
         "reconfiguringSpeciesTracking": "Soortentracering wordt bijgewerkt...",
         "recalculatingThresholds": "Dynamische drempels worden herberekend voor nieuwe basiswaarde",
         "reconfiguringDynamicThresholds": "Dynamische drempels worden opnieuw geconfigureerd...",
@@ -790,17 +790,17 @@
       "showing": "Toont {from} tot {to} van {total} resultaten"
     },
     "weather": {
-      "title": "Weather Information",
-      "noData": "No weather data",
-      "noDataAvailable": "No weather data available",
-      "loading": "Loading weather information...",
+      "title": "Weerinformatie",
+      "noData": "Geen weergegevens",
+      "noDataAvailable": "Geen weergegevens beschikbaar",
+      "loading": "Weerinformatie laden...",
       "labels": {
-        "temperature": "Temperature",
-        "weather": "Weather",
+        "temperature": "Temperatuur",
+        "weather": "Weer",
         "wind": "Wind",
-        "humidity": "Humidity",
-        "pressure": "Pressure",
-        "cloudCover": "Cloud Cover"
+        "humidity": "Luchtvochtigheid",
+        "pressure": "Luchtdruk",
+        "cloudCover": "Bewolking"
       },
       "units": {
         "temperature": "°C",
@@ -930,31 +930,31 @@
   },
   "spectrogram": {
     "controls": {
-      "frequencyRange": "Frequency Range",
-      "colorMap": "Color Map",
-      "gain": "Gain",
+      "frequencyRange": "Frequentiebereik",
+      "colorMap": "Kleurenkaart",
+      "gain": "Versterking",
       "gainTooltip": "Spectrogram visualisatieversterking",
       "mute": "Audio-uitvoer dempen",
       "unmute": "Audio-uitvoer inschakelen",
-      "frequencyRangeMin": "Minimum frequency",
-      "frequencyRangeMax": "Maximum frequency"
+      "frequencyRangeMin": "Minimale frequentie",
+      "frequencyRangeMax": "Maximale frequentie"
     },
     "error": {
-      "unsupported": "Your browser does not support audio analysis",
-      "connectionFailed": "Failed to connect to live audio stream",
-      "accessDenied": "Live audio access requires authentication. Please log in to use this feature."
+      "unsupported": "Je browser ondersteunt geen audio-analyse",
+      "connectionFailed": "Kan geen verbinding maken met de live audiostream",
+      "accessDenied": "Toegang tot live audio vereist authenticatie. Log in om deze functie te gebruiken."
     },
     "dashboard": {
-      "toggle": "Live Spectrogram",
-      "audioToggle": "Enable audio"
+      "toggle": "Live spectrogram",
+      "audioToggle": "Audio inschakelen"
     },
     "gain": {
       "muted": "Gedempt",
       "level": "Versterking: {value} dB"
     },
     "page": {
-      "title": "Live Audio",
-      "sourceLabel": "Audio Source",
+      "title": "Live audio",
+      "sourceLabel": "Audiobron",
       "connected": "Verbonden",
       "enterFullscreen": "Volledig scherm",
       "exitFullscreen": "Volledig scherm sluiten"
@@ -962,7 +962,7 @@
     "colorMaps": {
       "inferno": "Inferno",
       "viridis": "Viridis",
-      "grayscale": "Grayscale"
+      "grayscale": "Grijstinten"
     },
     "labels": {
       "toggle": "Detectielabels aan/uit"
@@ -1199,7 +1199,7 @@
               "name": "MySQL Max Packet"
             },
             "mysql_timeout": {
-              "name": "MySQL Timeout"
+              "name": "MySQL-timeout"
             }
           },
           "passedCount": "{passed}/{total} geslaagd",
@@ -1287,82 +1287,82 @@
         "fetchFailed": "Ophalen van databasestatistieken mislukt"
       },
       "dashboard": {
-        "title": "Database Dashboard",
-        "fetchFailed": "Failed to fetch database overview",
+        "title": "Database-dashboard",
+        "fetchFailed": "Kan database-overzicht niet ophalen",
         "metrics": {
-          "readLatency": "Read Latency",
-          "writeLatency": "Write Latency",
-          "queriesPerSec": "Queries/sec",
+          "readLatency": "Leeslatentie",
+          "writeLatency": "Schrijflatentie",
+          "queriesPerSec": "Query's/sec",
           "database": "Database",
-          "avg": "avg",
+          "avg": "gem",
           "max": "max",
-          "lastHour": "{count} last hour",
-          "slowQueries": "{count} slow"
+          "lastHour": "{count} afgelopen uur",
+          "slowQueries": "{count} traag"
         },
         "details": {
-          "title": "Database Details",
+          "title": "Databasedetails",
           "engine": "Engine",
-          "journal": "Journal",
-          "pageSize": "Page size",
-          "cacheHit": "Cache hit",
-          "integrity": "Integrity",
-          "lastVacuum": "Last VACUUM"
+          "journal": "Logboek",
+          "pageSize": "Paginagrootte",
+          "cacheHit": "Cache-treffer",
+          "integrity": "Integriteit",
+          "lastVacuum": "Laatste VACUUM"
         },
         "locksWal": {
-          "title": "Locks & WAL",
-          "lockWaits": "Lock waits",
-          "lockTimeouts": "Lock timeouts",
-          "avgWait": "Avg wait",
-          "busyTimeouts": "Busy timeouts",
-          "walSize": "WAL size",
-          "checkpoints": "Checkpoints",
-          "freelistPages": "Freelist pages",
-          "cacheSize": "Cache size"
+          "title": "Vergrendelingen en WAL",
+          "lockWaits": "Vergrendelingswachttijden",
+          "lockTimeouts": "Vergrendelingstimeouts",
+          "avgWait": "Gem. wachttijd",
+          "busyTimeouts": "Bezet-timeouts",
+          "walSize": "WAL-grootte",
+          "checkpoints": "Controlepunten",
+          "freelistPages": "Vrije-lijstpagina's",
+          "cacheSize": "Cachegrootte"
         },
         "connectionPool": {
-          "title": "Connection Pool",
-          "poolUsage": "Pool Usage",
-          "active": "active",
-          "idle": "idle",
-          "waiting": "waiting",
-          "totalCreated": "Total created",
-          "connErrors": "Conn errors",
+          "title": "Verbindingspool",
+          "poolUsage": "Poolgebruik",
+          "active": "actief",
+          "idle": "inactief",
+          "waiting": "wachtend",
+          "totalCreated": "Totaal aangemaakt",
+          "connErrors": "Verbindingsfouten",
           "threads": "Threads",
-          "running": "running",
-          "cached": "cached"
+          "running": "actief",
+          "cached": "gecached"
         },
         "innodb": {
-          "title": "InnoDB & Locks",
-          "bufferPoolHitRate": "Buffer pool hit rate",
-          "bufferPoolSize": "Buffer pool size",
-          "lockWaits": "Lock waits",
+          "title": "InnoDB en vergrendelingen",
+          "bufferPoolHitRate": "Buffer pool-trefpercentage",
+          "bufferPoolSize": "Buffer pool-grootte",
+          "lockWaits": "Vergrendelingswachttijden",
           "deadlocks": "Deadlocks",
-          "avgLockWait": "Avg lock wait",
-          "tableLocksWaited": "Table locks waited",
-          "tableLocksImmediate": "Table locks immediate"
+          "avgLockWait": "Gem. wachttijd vergrendeling",
+          "tableLocksWaited": "Gewachte tabelvergrendelingen",
+          "tableLocksImmediate": "Directe tabelvergrendelingen"
         },
         "detectionRate": {
-          "title": "Detection Rate (24h)",
-          "perHour": "/hr",
+          "title": "Detectiefrequentie (24u)",
+          "perHour": "/uur",
           "min": "min",
-          "avg": "avg",
+          "avg": "gem",
           "max": "max",
-          "lastBackup": "Last backup",
-          "backupSize": "Backup size",
-          "createBackup": "Create Backup",
+          "lastBackup": "Laatste back-up",
+          "backupSize": "Back-upgrootte",
+          "createBackup": "Back-up maken",
           "mysqlHost": "Host",
           "mysqlBackupNote": "MySQL-back-ups moeten worden beheerd via mysqldump of uw MySQL-beheertools.",
           "chartLabel": "Detectiepercentage over 24 uur",
           "detectionsTooltip": "{count} detecties"
         },
         "tables": {
-          "title": "Tables",
-          "total": "Total",
-          "table": "Table",
+          "title": "Tabellen",
+          "total": "Totaal",
+          "table": "Tabel",
           "engine": "Engine",
-          "rows": "Rows",
-          "size": "Size",
-          "usage": "Usage"
+          "rows": "Rijen",
+          "size": "Grootte",
+          "usage": "Gebruik"
         },
         "loading": "Laden..."
       },
@@ -1768,7 +1768,7 @@
           },
           "mysql": {
             "host": {
-              "label": "MySQL Host",
+              "label": "MySQL-host",
               "placeholder": "Voer MySQL host in",
               "helpText": "MySQL database host (IP of hostnaam)"
             },
@@ -1787,7 +1787,7 @@
               "helpText": "MySQL database wachtwoord"
             },
             "database": {
-              "label": "MySQL Database",
+              "label": "MySQL-database",
               "placeholder": "Voer MySQL database naam in",
               "helpText": "MySQL database naam"
             },
@@ -1968,7 +1968,7 @@
           "helpText": "Taalregio voor vertaalde soorten algemene namen."
         },
         "tensorflowThreads": {
-          "label": "TensorFlow CPU Threads",
+          "label": "TensorFlow CPU-threads",
           "helpText": "Aantal CPU threads. Zet op 0 om alle beschikbare threads te gebruiken."
         }
       },
@@ -2139,10 +2139,10 @@
         }
       },
       "push": {
-        "title": "Push Notifications",
-        "description": "Send notifications to external services like Discord, Telegram, Slack, and more",
-        "enable": "Enable Push Notifications",
-        "disabled": "Push notifications are disabled",
+        "title": "Pushmeldingen",
+        "description": "Meldingen verzenden naar externe diensten zoals Discord, Telegram, Slack en meer",
+        "enable": "Pushmeldingen inschakelen",
+        "disabled": "Pushmeldingen zijn uitgeschakeld",
         "enabledDescription": "Push-notificaties worden naar alle ingeschakelde providers hieronder verzonden",
         "filters": {
           "title": "Detectiefilters",
@@ -2158,48 +2158,48 @@
           }
         },
         "noProviders": "Geen providers geconfigureerd",
-        "noProvidersDescription": "Add a provider to start receiving push notifications",
+        "noProvidersDescription": "Voeg een provider toe om pushmeldingen te ontvangen",
         "providers": {
-          "title": "Notification Providers",
-          "addButton": "Add Provider",
-          "editButton": "Edit",
-          "deleteButton": "Delete",
-          "enableToggle": "Enable provider",
-          "urlsPreview": "{count} URL(s) configured",
-          "deleteConfirm": "Delete provider \"{name}\"? This action cannot be undone.",
+          "title": "Meldingsproviders",
+          "addButton": "Provider toevoegen",
+          "editButton": "Bewerken",
+          "deleteButton": "Verwijderen",
+          "enableToggle": "Provider inschakelen",
+          "urlsPreview": "{count} URL('s) geconfigureerd",
+          "deleteConfirm": "Provider \"{name}\" verwijderen? Deze actie kan niet ongedaan worden gemaakt.",
           "typeBadge": {
             "shoutrrr": "Shoutrrr",
             "webhook": "Webhook"
           }
         },
         "form": {
-          "addTitle": "Add Notification Provider",
-          "editTitle": "Edit Notification Provider",
+          "addTitle": "Meldingsprovider toevoegen",
+          "editTitle": "Meldingsprovider bewerken",
           "name": {
-            "label": "Provider Name",
-            "placeholder": "e.g., Discord Alerts",
-            "helpText": "A friendly name to identify this provider"
+            "label": "Providernaam",
+            "placeholder": "bijv. Discord Meldingen",
+            "helpText": "Een herkenbare naam om deze provider te identificeren"
           },
           "urls": {
-            "label": "Service URL(s)",
+            "label": "Service-URL('s)",
             "placeholder": "discord://token@webhookid",
-            "helpText": "Enter one Shoutrrr URL per line. Multiple URLs send to multiple services.",
+            "helpText": "Voer één Shoutrrr-URL per regel in. Meerdere URL's verzenden naar meerdere diensten.",
             "validation": {
-              "required": "At least one URL is required",
-              "invalidFormat": "Invalid URL format. URLs should start with a service prefix (e.g., discord://, telegram://)"
+              "required": "Er is ten minste één URL vereist",
+              "invalidFormat": "Ongeldig URL-formaat. URL's moeten beginnen met een serviceprefix (bijv. discord://, telegram://)"
             }
           },
           "notificationTypes": {
-            "label": "Notification Types",
-            "helpText": "Select which types of notifications to send to this provider",
-            "detection": "Bird detections",
-            "error": "Errors",
-            "warning": "Warnings",
-            "info": "Information",
-            "system": "System events"
+            "label": "Meldingstypen",
+            "helpText": "Selecteer welke typen meldingen naar deze provider verzonden moeten worden",
+            "detection": "Vogeldetecties",
+            "error": "Fouten",
+            "warning": "Waarschuwingen",
+            "info": "Informatie",
+            "system": "Systeemgebeurtenissen"
           },
           "urlFormats": {
-            "title": "Common URL Formats",
+            "title": "Veelgebruikte URL-formaten",
             "discord": "Discord",
             "discordFormat": "discord://token@webhookid",
             "telegram": "Telegram",
@@ -2212,27 +2212,27 @@
             "gotifyFormat": "gotify://hostname/token",
             "ntfy": "ntfy",
             "ntfyFormat": "ntfy://ntfy.sh/mytopic",
-            "moreServices": "View all supported services",
+            "moreServices": "Alle ondersteunde diensten bekijken",
             "shoutrrrDocs": "https://github.com/nicholas-fedor/shoutrrr?tab=readme-ov-file#supported-services"
           },
-          "saveButton": "Save Provider",
-          "savingButton": "Saving...",
-          "cancelButton": "Cancel",
+          "saveButton": "Provider opslaan",
+          "savingButton": "Opslaan...",
+          "cancelButton": "Annuleren",
           "testButton": "Test",
-          "testingButton": "Testing..."
+          "testingButton": "Testen..."
         },
         "test": {
-          "button": "Test Provider",
-          "description": "Send a test notification to verify this provider is working",
-          "success": "Test notification sent successfully!",
-          "error": "Test failed: {message}",
-          "requiresUrl": "Enter a URL to test",
-          "requiresEnabled": "Enable the provider to test"
+          "button": "Provider testen",
+          "description": "Stuur een testmelding om te controleren of deze provider werkt",
+          "success": "Testmelding succesvol verzonden!",
+          "error": "Test mislukt: {message}",
+          "requiresUrl": "Voer een URL in om te testen",
+          "requiresEnabled": "Schakel de provider in om te testen"
         },
         "validation": {
-          "nameRequired": "Provider name is required",
-          "urlRequired": "At least one URL is required",
-          "invalidUrl": "Invalid URL format"
+          "nameRequired": "Providernaam is vereist",
+          "urlRequired": "Er is ten minste één URL vereist",
+          "invalidUrl": "Ongeldig URL-formaat"
         },
         "autoName": {
           "discord": "Discord",
@@ -2241,42 +2241,42 @@
           "pushover": "Pushover",
           "gotify": "Gotify",
           "ntfy": "ntfy",
-          "email": "Email",
+          "email": "E-mail",
           "generic": "Shoutrrr",
           "numbered": "{service} #{number}"
         },
         "services": {
-          "selectLabel": "Service",
-          "selectHelpText": "Choose a notification service to configure",
+          "selectLabel": "Dienst",
+          "selectHelpText": "Kies een meldingsdienst om te configureren",
           "discord": {
             "name": "Discord",
             "webhookUrl": {
-              "label": "Discord Webhook URL",
+              "label": "Discord Webhook-URL",
               "placeholder": "https://discord.com/api/webhooks/...",
-              "helpText": "Paste your full Discord webhook URL"
+              "helpText": "Plak je volledige Discord webhook-URL"
             },
-            "invalidUrl": "Invalid Discord webhook URL. URL should contain discord.com/api/webhooks/"
+            "invalidUrl": "Ongeldige Discord webhook-URL. URL moet discord.com/api/webhooks/ bevatten"
           },
           "telegram": {
             "name": "Telegram",
             "botToken": {
-              "label": "Bot Token",
+              "label": "Bot-token",
               "placeholder": "123456789:ABCdef...",
-              "helpText": "Token from @BotFather"
+              "helpText": "Token van @BotFather"
             },
             "chatId": {
-              "label": "Chat ID",
-              "placeholder": "-1001234567890 or @channel",
-              "helpText": "Chat ID, group ID, or @username"
+              "label": "Chat-ID",
+              "placeholder": "-1001234567890 of @channel",
+              "helpText": "Chat-ID, groeps-ID of @gebruikersnaam"
             },
-            "incomplete": "Both bot token and chat ID are required"
+            "incomplete": "Zowel bot-token als chat-ID zijn vereist"
           },
           "ntfy": {
             "name": "ntfy",
             "server": {
               "label": "Server",
               "placeholder": "ntfy.sh",
-              "helpText": "Leave as ntfy.sh for public server or enter your self-hosted server"
+              "helpText": "Laat ntfy.sh staan voor de publieke server of voer je eigen server in"
             },
             "protocol": {
               "label": "Protocol"
@@ -2301,107 +2301,107 @@
             "topic": {
               "label": "Topic",
               "placeholder": "my-bird-alerts",
-              "helpText": "Topic name for your notifications"
+              "helpText": "Topicnaam voor je meldingen"
             },
-            "incomplete": "Topic is required"
+            "incomplete": "Topic is vereist"
           },
           "gotify": {
             "name": "Gotify",
             "server": {
-              "label": "Server URL",
+              "label": "Server-URL",
               "placeholder": "gotify.example.com",
-              "helpText": "Your Gotify server hostname (without https://)"
+              "helpText": "Je Gotify-server hostnaam (zonder https://)"
             },
             "token": {
-              "label": "Application Token",
+              "label": "Applicatietoken",
               "placeholder": "A...",
-              "helpText": "Token from Gotify Apps page"
+              "helpText": "Token van de Gotify Apps-pagina"
             },
-            "incomplete": "Server and token are required"
+            "incomplete": "Server en token zijn vereist"
           },
           "pushover": {
             "name": "Pushover",
             "apiToken": {
-              "label": "API Token",
+              "label": "API-token",
               "placeholder": "az...",
-              "helpText": "Application API token"
+              "helpText": "Applicatie API-token"
             },
             "userKey": {
-              "label": "User Key",
+              "label": "Gebruikerssleutel",
               "placeholder": "u...",
-              "helpText": "Your user or group key"
+              "helpText": "Je gebruikers- of groepssleutel"
             },
-            "incomplete": "API token and user key are required"
+            "incomplete": "API-token en gebruikerssleutel zijn vereist"
           },
           "slack": {
             "name": "Slack",
             "webhookUrl": {
-              "label": "Slack Webhook URL",
+              "label": "Slack Webhook-URL",
               "placeholder": "https://hooks.slack.com/services/...",
-              "helpText": "Paste your full Slack webhook URL"
+              "helpText": "Plak je volledige Slack webhook-URL"
             },
-            "invalidUrl": "Invalid Slack webhook URL. URL should contain hooks.slack.com/services/"
+            "invalidUrl": "Ongeldige Slack webhook-URL. URL moet hooks.slack.com/services/ bevatten"
           },
           "ifttt": {
             "name": "IFTTT",
             "webhookKey": {
-              "label": "Webhook Key",
+              "label": "Webhook-sleutel",
               "placeholder": "abc123xyz...",
-              "helpText": "Your IFTTT Webhook key from Maker Webhooks settings"
+              "helpText": "Je IFTTT Webhook-sleutel uit de Maker Webhooks-instellingen"
             },
             "eventName": {
-              "label": "Event Name",
+              "label": "Gebeurtenisnaam",
               "placeholder": "bird_detected",
-              "helpText": "The event name to trigger in your IFTTT applet"
+              "helpText": "De gebeurtenisnaam om te activeren in je IFTTT-applet"
             },
-            "incomplete": "Webhook key and event name are required"
+            "incomplete": "Webhook-sleutel en gebeurtenisnaam zijn vereist"
           },
           "webhook": {
             "name": "Webhook",
             "url": {
-              "label": "Webhook URL",
+              "label": "Webhook-URL",
               "placeholder": "https://api.example.com/webhook",
-              "helpText": "The HTTP(S) endpoint to send notifications to"
+              "helpText": "Het HTTP(S)-eindpunt om meldingen naar te verzenden"
             },
             "method": {
-              "label": "HTTP Method",
-              "helpText": "HTTP method to use for the request (default: POST)"
+              "label": "HTTP-methode",
+              "helpText": "HTTP-methode voor het verzoek (standaard: POST)"
             },
             "auth": {
-              "label": "Authentication",
-              "none": "None",
-              "bearer": "Bearer Token",
-              "basic": "Basic Auth",
-              "helpText": "Optional authentication for the webhook endpoint"
+              "label": "Authenticatie",
+              "none": "Geen",
+              "bearer": "Bearer-token",
+              "basic": "Basisauthenticatie",
+              "helpText": "Optionele authenticatie voor het webhook-eindpunt"
             },
             "bearerToken": {
-              "label": "Bearer Token",
+              "label": "Bearer-token",
               "placeholder": "your-api-token",
-              "helpText": "Token sent in Authorization: Bearer header"
+              "helpText": "Token verzonden in Authorization: Bearer-header"
             },
             "basicUser": {
-              "label": "Username",
-              "placeholder": "username"
+              "label": "Gebruikersnaam",
+              "placeholder": "gebruikersnaam"
             },
             "basicPass": {
-              "label": "Password",
-              "placeholder": "password"
+              "label": "Wachtwoord",
+              "placeholder": "wachtwoord"
             },
             "basicAuth": {
-              "helpText": "Credentials sent using HTTP Basic Authentication"
+              "helpText": "Inloggegevens verzonden via HTTP Basic Authentication"
             },
-            "invalidUrl": "Invalid URL. Must start with http:// or https://",
-            "tokenRequired": "Bearer token is required when using Bearer authentication",
-            "credentialsRequired": "Username and password are required when using Basic authentication"
+            "invalidUrl": "Ongeldige URL. Moet beginnen met http:// of https://",
+            "tokenRequired": "Bearer-token is vereist bij Bearer-authenticatie",
+            "credentialsRequired": "Gebruikersnaam en wachtwoord zijn vereist bij basisauthenticatie"
           },
           "custom": {
-            "name": "Custom URL",
+            "name": "Aangepaste URL",
             "url": {
-              "label": "Shoutrrr URL",
+              "label": "Shoutrrr-URL",
               "placeholder": "service://credentials@host",
-              "helpText": "Enter a raw Shoutrrr URL for any supported service"
+              "helpText": "Voer een ruwe Shoutrrr-URL in voor een ondersteunde dienst"
             },
-            "invalidUrl": "Invalid URL format. URL should start with service://"
+            "invalidUrl": "Ongeldig URL-formaat. URL moet beginnen met service://"
           }
         }
       },
@@ -2491,7 +2491,7 @@
         },
         "enable": "Schakel BirdWeather Uploads in",
         "token": {
-          "label": "BirdWeather token",
+          "label": "BirdWeather-token",
           "helpText": "Jouw unieke BirdWeather token."
         },
         "threshold": {
@@ -2512,11 +2512,11 @@
         "description": "Configureer MQTT broker verbinding",
         "enable": "Schakel MQTT Integratie in",
         "broker": {
-          "label": "MQTT Broker",
+          "label": "MQTT-broker",
           "placeholder": "mqtt://localhost:1883"
         },
         "topic": {
-          "label": "MQTT Topic",
+          "label": "MQTT-topic",
           "placeholder": "birdnet/detections"
         },
         "authentication": {
@@ -2535,25 +2535,25 @@
           "skipVerify": "Sla Certificaat Verificatie over",
           "configNote": "<strong>TLS Configuratie:</strong><br />• Standaard TLS: Laat certificaten leeg voor publieke brokers<br />• Self-signed certificaten: Geef CA Certificaat<br />• Wederzijdse TLS (mTLS): Geef alle drie certificaten",
           "certificates": {
-            "title": "Certificate Management",
-            "description": "Upload certificates for secure MQTT broker connections",
-            "caLabel": "CA Certificate",
+            "title": "Certificaatbeheer",
+            "description": "Upload certificaten voor beveiligde MQTT-brokerverbindingen",
+            "caLabel": "CA-certificaat",
             "caPlaceholder": "-----BEGIN CERTIFICATE-----",
-            "caHelpText": "Certificate Authority certificate to verify the broker's identity",
-            "clientCertLabel": "Client Certificate",
+            "caHelpText": "Certificaatautoriteit-certificaat om de identiteit van de broker te verifiëren",
+            "clientCertLabel": "Clientcertificaat",
             "clientCertPlaceholder": "-----BEGIN CERTIFICATE-----",
-            "clientCertHelpText": "Client certificate for mutual TLS authentication",
-            "clientKeyLabel": "Client Private Key",
+            "clientCertHelpText": "Clientcertificaat voor wederzijdse TLS-authenticatie",
+            "clientKeyLabel": "Privésleutel client",
             "clientKeyPlaceholder": "-----BEGIN PRIVATE KEY-----",
-            "clientKeyHelpText": "Private key matching the client certificate",
-            "uploadButton": "Upload Certificates",
-            "uploadSuccess": "MQTT TLS certificates uploaded successfully. Use Test Connection to verify.",
-            "uploadError": "Failed to upload MQTT TLS certificates",
-            "deleteConfirm": "Remove all MQTT TLS certificates? The MQTT client will need to reconnect.",
-            "deleteSuccess": "MQTT TLS certificates removed",
-            "deleteError": "Failed to remove MQTT TLS certificates",
-            "loadError": "Failed to load certificate information",
-            "reconnectNote": "Use the Test Connection button below to verify the new TLS configuration."
+            "clientKeyHelpText": "Privésleutel die overeenkomt met het clientcertificaat",
+            "uploadButton": "Certificaten uploaden",
+            "uploadSuccess": "MQTT TLS-certificaten succesvol geüpload. Gebruik Test verbinding om te verifiëren.",
+            "uploadError": "Kan MQTT TLS-certificaten niet uploaden",
+            "deleteConfirm": "Alle MQTT TLS-certificaten verwijderen? De MQTT-client zal opnieuw moeten verbinden.",
+            "deleteSuccess": "MQTT TLS-certificaten verwijderd",
+            "deleteError": "Kan MQTT TLS-certificaten niet verwijderen",
+            "loadError": "Kan certificaatinformatie niet laden",
+            "reconnectNote": "Gebruik de knop Test verbinding hieronder om de nieuwe TLS-configuratie te verifiëren."
           }
         },
         "homeAssistant": {
@@ -2561,7 +2561,7 @@
           "enable": "Schakel Home Assistant MQTT Discovery in",
           "description": "Wanneer ingeschakeld, registreert BirdNET-Go automatisch apparaten en sensoren bij Home Assistant via het MQTT discovery protocol. Apparaten verschijnen in het Home Assistant apparatenregister zonder handmatige YAML-configuratie.",
           "discoveryPrefix": {
-            "label": "Discovery Prefix",
+            "label": "Discovery-prefix",
             "helpText": "Het MQTT topic prefix voor Home Assistant discovery berichten. Standaard is 'homeassistant'. Wijzig dit alleen als je een aangepast discovery prefix hebt geconfigureerd in Home Assistant."
           },
           "deviceName": {
@@ -2623,11 +2623,11 @@
             "helpText": "Voer jouw Weather Underground API sleutel in. Vereist voor weer gegevens."
           },
           "stationId": {
-            "label": "Station ID",
+            "label": "Station-ID",
             "helpText": "Jouw Weather Underground PWS station ID (bijv., KCAOAKLA12)."
           },
           "endpoint": {
-            "label": "API Endpoint",
+            "label": "API-eindpunt",
             "helpText": "Overschrijf het standaard Weather Underground API endpoint indien nodig. Standaard https://api.weather.com/v2/pws/observations/current indien leeg gelaten."
           },
           "units": {
@@ -2653,8 +2653,8 @@
           "options": {
             "standard": "Standaard",
             "metric": "Metrisch",
-            "imperial": "Imperial",
-            "ukhybrid": "UK Hybrid"
+            "imperial": "Imperiaal",
+            "ukhybrid": "UK Hybride"
           }
         },
         "test": {
@@ -2697,14 +2697,14 @@
           "helpText": "Hoe lang taxonomiegegevens van eBird in de cache worden bewaard. Taxonomie verandert zelden, dus langere cachetijden verminderen API-aanroepen."
         },
         "note": "eBird levert taxonomische gegevens voor soortclassificatie en inzichten. De API-sleutel is gratis verkrijgbaar bij het Cornell Lab of Ornithology.",
-        "apiKeyInfo": "A personal eBird API key is required to use this integration. You can request a free key from <a href=\"https://ebird.org/api/keygen\" class=\"link link-primary\" target=\"_blank\" rel=\"noopener noreferrer\">ebird.org/api/keygen</a>.",
+        "apiKeyInfo": "Een persoonlijke eBird API-sleutel is vereist voor deze integratie. Je kunt een gratis sleutel aanvragen op <a href=\"https://ebird.org/api/keygen\" class=\"link link-primary\" target=\"_blank\" rel=\"noopener noreferrer\">ebird.org/api/keygen</a>.",
         "test": {
-          "button": "Test eBird Connection",
-          "loading": "Testing...",
-          "enabledRequired": "Enable eBird integration first",
-          "apiKeyRequired": "API key is required",
-          "inProgress": "Test in progress...",
-          "description": "Test eBird API connectivity and authentication"
+          "button": "eBird-verbinding testen",
+          "loading": "Testen...",
+          "enabledRequired": "Schakel eerst eBird-integratie in",
+          "apiKeyRequired": "API-sleutel is vereist",
+          "inProgress": "Test wordt uitgevoerd...",
+          "description": "Test eBird API-connectiviteit en authenticatie"
         }
       }
     },
@@ -2725,9 +2725,9 @@
         "audioSourceHelp": "Selecteer het audio invoer apparaat voor vogelgeluid detectie. Wijzigingen vereisen applicatie herstart om effect te hebben.",
         "noSoundCardCapture": "Geen geluidskaart opname",
         "rtspSource": "RTSP Bron",
-        "rtspTransportLabel": "RTSP Transport Protocol",
+        "rtspTransportLabel": "RTSP-transportprotocol",
         "rtspTransportHelp": "TCP is betrouwbaarder maar kan hogere latentie hebben. UDP is sneller maar kan pakketverlies ervaren op slechte netwerken.",
-        "rtspUrlsLabel": "RTSP Stream URLs",
+        "rtspUrlsLabel": "RTSP-stream-URL's",
         "rtspUrlsHelp": "Voer één of meer RTSP stream URLs in voor netwerk audio bronnen. Formaat: rtsp://ip:port/stream. Note: Authenticatie gegevens moeten apart worden geconfigureerd in jouw RTSP server instellingen voor beveiliging.",
         "noDeviceSelected": "Geen audio apparaat geselecteerd",
         "refreshDevices": "Vernieuwen",
@@ -2768,7 +2768,7 @@
         "frequencyResponse": "Frequentie Respons",
         "cutoffFrequency": "Afsnij Frequentie",
         "cutoffFrequencyHelp": "Frequentie waarbij de filter signalen begint te verzwakken. Vogelroepen variëren typisch van 1-10 kHz.",
-        "qFactor": "Q Factor",
+        "qFactor": "Q-factor",
         "qFactorHelp": "Kwaliteits factor bepaalt de scherpte van de filter. Lagere waarden (0.1-1) creëren zachtere hellingen, hogere waarden (1-10) creëren steilere afsnijdingen.",
         "gain": "Versterking",
         "gainHelp": "Versterking of verzwakking niveau in decibels (dB).",
@@ -2797,10 +2797,10 @@
         "intervalHelp": "Hoe vaak geluidsniveaus worden gemeten en gerapporteerd. Lagere waarden geven meer gedetailleerde gegevens maar gebruiken meer bronnen. Minimum 5 seconden, aanbevolen 60 seconden.",
         "dataOutputTitle": "Geluidsniveau Gegevens Output",
         "dataOutputDescription": "Wanneer ingeschakeld, worden geluidsniveau metingen gepubliceerd via:",
-        "mqttTopic": "MQTT topic:",
-        "sseEndpoint": "SSE endpoint:",
-        "prometheusMetrics": "Prometheus metrics:",
-        "disabled": "Sound level monitoring is disabled"
+        "mqttTopic": "MQTT-topic:",
+        "sseEndpoint": "SSE-eindpunt:",
+        "prometheusMetrics": "Prometheus-metrics:",
+        "disabled": "Geluidsniveaubewaking is uitgeschakeld"
       },
       "clipSettings": {
         "title": "Clip Instellingen",
@@ -2838,8 +2838,8 @@
         "bitrateLabel": "Bitrate",
         "bitrateHelp": "Audio compressie bitrate voor lossy formaten. Bereik: {min}-{max} kbps. Hogere waarden geven betere kwaliteit maar grotere bestanden.",
         "losslessNote": "Lossless formaten behouden originele audio kwaliteit zonder compressie artefacten.",
-        "normalizationDisabled": "Audio normalization is disabled",
-        "disabledInfo": "Enable clip recording above to configure clip settings, file format, and storage options."
+        "normalizationDisabled": "Audionormalisatie is uitgeschakeld",
+        "disabledInfo": "Schakel fragmentopname hierboven in om fragmentinstellingen, bestandsformaat en opslagopties te configureren."
       },
       "extendedCapture": {
         "title": "Uitgebreide opname",
@@ -2922,7 +2922,7 @@
         "lowpass": "Laagorlaat Filter",
         "highpass": "Hoogdoorlaat Filter",
         "bandpass": "Banddoorlaat Filter",
-        "bandstop": "Bandstop Filter"
+        "bandstop": "Bandsperfilter"
       },
       "errors": {
         "devicesLoadFailed": "Laden van audio apparaten mislukt. Controleer systeem permissies.",
@@ -3082,7 +3082,7 @@
         "enableLabel": "Schakel Wachtwoord Authenticatie In",
         "passwordLabel": "Wachtwoord",
         "passwordHelpText": "Beperk toegang tot instellingen met een wachtwoord.",
-        "disabled": "Password authentication is disabled"
+        "disabled": "Wachtwoordauthenticatie is uitgeschakeld"
       },
       "oauth": {
         "title": "Externe authenticatie",
@@ -3107,10 +3107,10 @@
         "noProvidersDescription": "Voeg een provider toe om inloggen met Google, GitHub, Microsoft, LINE, Kakao of een aangepaste OIDC-provider mogelijk te maken.",
         "enableProviderLabel": "Deze provider inschakelen",
         "getCredentialsLabel": "Verkrijg uw inloggegevens van {provider}",
-        "redirectUriTitle": "Redirect URI:",
+        "redirectUriTitle": "Omleidings-URI:",
         "clientIdLabel": "Client-ID",
         "clientIdHelpText": "De OAuth 2.0 Client-ID van de ontwikkelaarsconsole van uw provider",
-        "clientSecretLabel": "Client Secret",
+        "clientSecretLabel": "Clientgeheim",
         "clientSecretHelpText": "Het OAuth 2.0 Client Secret van de ontwikkelaarsconsole van uw provider",
         "userIdLabel": "Gebruikers-ID (optioneel)",
         "userIdHelpText": "Beperk toegang tot een specifiek gebruikersaccount via e-mail of ID",
@@ -3119,9 +3119,9 @@
           "enableLabel": "Sta OAuth2 Inloggen via Google toe",
           "redirectUriTitle": "Redirect URI voor Google Cloud Console:",
           "getCredentialsLabel": "Verkrijg uw inloggegevens van Google Cloud Console",
-          "clientIdLabel": "Client ID",
+          "clientIdLabel": "Client-ID",
           "clientIdHelpText": "Het OAuth 2.0 Client ID verkregen van Google Cloud Console bij het instellen van OAuth inloggegevens.",
-          "clientSecretLabel": "Client Secret",
+          "clientSecretLabel": "Clientgeheim",
           "clientSecretHelpText": "Het OAuth 2.0 Client Secret verkregen van Google Cloud Console bij het instellen van OAuth inloggegevens.",
           "userIdLabel": "Gebruikers ID"
         },
@@ -3130,9 +3130,9 @@
           "enableLabel": "Sta OAuth2 Inloggen via GitHub toe",
           "redirectUriTitle": "Redirect URI voor GitHub Developer Settings:",
           "getCredentialsLabel": "Verkrijg uw inloggegevens van GitHub Developer Settings",
-          "clientIdLabel": "Client ID",
+          "clientIdLabel": "Client-ID",
           "clientIdHelpText": "Het OAuth 2.0 Client ID verkregen van GitHub Developer Settings bij het instellen van OAuth inloggegevens.",
-          "clientSecretLabel": "Client Secret",
+          "clientSecretLabel": "Clientgeheim",
           "clientSecretHelpText": "Het OAuth 2.0 Client Secret verkregen van GitHub Developer Settings bij het instellen van OAuth inloggegevens.",
           "userIdLabel": "Gebruikers ID"
         },
@@ -3152,9 +3152,9 @@
           "enableLabel": "OAuth2-aanmelding via LINE toestaan",
           "redirectUriTitle": "Omleidings-URI voor LINE Developers Console:",
           "getCredentialsLabel": "Haal uw referenties op uit de LINE Developers Console",
-          "clientIdLabel": "Channel ID",
+          "clientIdLabel": "Kanaal-ID",
           "clientIdHelpText": "De Channel ID verkregen uit LINE Developers Console bij het instellen van LINE Login.",
-          "clientSecretLabel": "Channel Secret",
+          "clientSecretLabel": "Kanaalgeheim",
           "clientSecretHelpText": "Het Channel Secret verkregen uit LINE Developers Console bij het instellen van LINE Login.",
           "userIdLabel": "Gebruikers-ID"
         },
@@ -3163,46 +3163,46 @@
           "enableLabel": "OAuth2-aanmelding via Kakao toestaan",
           "redirectUriTitle": "Omleidings-URI voor Kakao Developers Console:",
           "getCredentialsLabel": "Haal uw referenties op uit de Kakao Developers Console",
-          "clientIdLabel": "REST API Key",
+          "clientIdLabel": "REST API-sleutel",
           "clientIdHelpText": "De REST API Key verkregen uit Kakao Developers Console bij het instellen van Kakao Login.",
-          "clientSecretLabel": "Client Secret",
+          "clientSecretLabel": "Clientgeheim",
           "clientSecretHelpText": "Het Client Secret verkregen uit Kakao Developers Console bij het instellen van Kakao Login.",
           "userIdLabel": "Gebruikers-ID"
         },
         "oidc": {
-          "title": "OIDC Provider",
-          "enableLabel": "Enable OIDC authentication",
-          "redirectUriTitle": "Redirect URI",
-          "getCredentialsLabel": "Configure in your Identity Provider",
-          "clientIdLabel": "Client ID",
-          "clientIdHelpText": "The client ID from your OIDC identity provider",
-          "clientSecretLabel": "Client Secret",
-          "clientSecretHelpText": "The client secret from your OIDC identity provider",
-          "userIdLabel": "Allowed User (email or sub claim)",
-          "issuerUrlLabel": "Issuer URL",
-          "issuerUrlHelpText": "The issuer URL of your OpenID Connect identity provider (e.g., https://auth.example.com)",
+          "title": "OIDC-provider",
+          "enableLabel": "OIDC-authenticatie inschakelen",
+          "redirectUriTitle": "Omleidings-URI",
+          "getCredentialsLabel": "Configureer in je identiteitsprovider",
+          "clientIdLabel": "Client-ID",
+          "clientIdHelpText": "De client-ID van je OIDC-identiteitsprovider",
+          "clientSecretLabel": "Clientgeheim",
+          "clientSecretHelpText": "Het clientgeheim van je OIDC-identiteitsprovider",
+          "userIdLabel": "Toegestane gebruiker (e-mail of sub claim)",
+          "issuerUrlLabel": "Uitgever-URL",
+          "issuerUrlHelpText": "De uitgever-URL van je OpenID Connect-identiteitsprovider (bijv. https://auth.example.com)",
           "issuerUrlPlaceholder": "https://auth.example.com",
-          "issuerUrlRequired": "Issuer URL is required for OIDC providers",
-          "issuerUrlInvalid": "Issuer URL must be a valid HTTP or HTTPS URL",
+          "issuerUrlRequired": "Uitgever-URL is vereist voor OIDC-providers",
+          "issuerUrlInvalid": "Uitgever-URL moet een geldige HTTP- of HTTPS-URL zijn",
           "scopesLabel": "Scopes",
-          "scopesHelpText": "Comma-separated list of OIDC scopes (default: openid, profile, email)",
+          "scopesHelpText": "Kommagescheiden lijst van OIDC-scopes (standaard: openid, profile, email)",
           "scopesPlaceholder": "openid, profile, email"
         }
       },
       "bypassAuthentication": {
         "title": "Omzeil Authenticatie",
         "description": "Sta toegang tot instellingen toe zonder authenticatie",
-        "disabled": "Subnet bypass is disabled"
+        "disabled": "Subnet-bypass is uitgeschakeld"
       },
       "exceptions": {
-        "title": "Exceptions"
+        "title": "Uitzonderingen"
       },
       "publicAccess": {
-        "title": "Public Access",
-        "description": "Allow specific features to be accessible without authentication.",
-        "liveAudioLabel": "Allow public live audio playback",
-        "liveAudioHelp": "When enabled, anyone can listen to live audio streams without logging in. Settings and deletion still require authentication.",
-        "warningText": "Enabling public access features exposes them to anyone who can reach this server. Only enable if you trust your network environment."
+        "title": "Openbare toegang",
+        "description": "Sta toe dat specifieke functies toegankelijk zijn zonder authenticatie.",
+        "liveAudioLabel": "Sta openbare live audio-weergave toe",
+        "liveAudioHelp": "Wanneer ingeschakeld, kan iedereen luisteren naar live audiostreams zonder in te loggen. Instellingen en verwijderen vereisen nog steeds authenticatie.",
+        "warningText": "Het inschakelen van openbare toegangsfuncties maakt ze beschikbaar voor iedereen die deze server kan bereiken. Schakel alleen in als je je netwerkomgeving vertrouwt."
       },
       "placeholders": {
         "baseUrl": "https://birdnet.example.com:5500",
@@ -3219,64 +3219,64 @@
       },
       "tls": {
         "title": "TLS / HTTPS",
-        "description": "Configure TLS/HTTPS encryption for secure connections",
-        "modeLabel": "TLS Mode",
-        "modeNone": "None (HTTP)",
+        "description": "Configureer TLS/HTTPS-versleuteling voor beveiligde verbindingen",
+        "modeLabel": "TLS-modus",
+        "modeNone": "Geen (HTTP)",
         "modeLetsEncrypt": "Let's Encrypt",
-        "modeManual": "Manual Certificate",
-        "modeSelfSigned": "Self-Signed",
-        "modeNoneDescription": "Plain HTTP without encryption",
-        "modeAutoTLSDescription": "Automatic certificate via Let's Encrypt",
-        "modeManualDescription": "Upload your own certificate and key",
-        "modeSelfSignedDescription": "Generate a self-signed certificate",
-        "portLabel": "HTTPS Port",
-        "portHelpText": "Port for HTTPS connections (default: 8443)",
-        "redirectToHttps": "Redirect HTTP to HTTPS",
-        "autoTLSRequirements": "Requires ports 80 and 443 to be accessible. On Linux, the process needs root or CAP_NET_BIND_SERVICE capability.",
-        "validityLabel": "Certificate Validity",
-        "validityHelpText": "How long the certificate should be valid",
-        "validity365d": "1 year",
-        "validity730d": "2 years",
-        "generateButton": "Generate Certificate",
-        "regenerateButton": "Regenerate Certificate",
-        "generating": "Generating...",
-        "certificateLabel": "Certificate (PEM)",
-        "privateKeyLabel": "Private Key (PEM)",
-        "caCertificateLabel": "CA Certificate (PEM, optional)",
-        "uploadButton": "Upload Certificate",
-        "uploading": "Uploading...",
-        "browseFile": "Browse...",
-        "plaintextWarning": "Warning: Your private key will be transmitted in plaintext over HTTP. Only upload certificates when connected via a trusted network or localhost.",
-        "certificateInstalled": "Installed Certificate",
-        "subject": "Subject",
-        "issuer": "Issuer",
-        "validFrom": "Valid From",
-        "validUntil": "Valid Until",
-        "daysRemaining": "Days Remaining",
-        "sans": "Subject Alternative Names",
-        "fingerprint": "Fingerprint",
-        "expiryWarning": "Certificate is expiring soon",
-        "loading": "Loading certificate info...",
-        "loadError": "Failed to load certificate info",
-        "generateSuccess": "Self-signed certificate generated successfully",
-        "generateError": "Failed to generate certificate",
-        "uploadSuccess": "Certificate uploaded successfully",
-        "uploadError": "Failed to upload certificate",
-        "deleteSuccess": "Certificate removed successfully",
-        "deleteError": "Failed to delete certificate",
-        "removeCertificate": "Remove Certificate",
-        "deleteConfirm": "Are you sure you want to remove the installed TLS certificate? The TLS mode will be reset to None.",
-        "restartRequired": "TLS changes require a server restart to take effect.",
-        "noCertificate": "No certificate installed",
-        "validity1825d": "5 years",
-        "autoTLSHostRequired": "A hostname is required for Let’s Encrypt. Enter your public domain name in the Host field above.",
-        "autoTLSNoIP": "Let’s Encrypt requires a domain name, not an IP address. Enter a public domain like birds.example.com.",
-        "autoTLSNeedsFQDN": "Let’s Encrypt requires a fully qualified domain name (e.g., birds.example.com), not a bare hostname.",
-        "autoTLSNoLocalhost": "Let’s Encrypt cannot issue certificates for localhost.",
-        "autoTLSPrivateTLD": "Let’s Encrypt cannot issue certificates for private domains ({tld} is not publicly resolvable).",
-        "downloadCertificate": "Download Certificate",
-        "downloadCertificateHelp": "Install this certificate in your operating system's trust store to avoid browser security warnings.",
-        "fileReadError": "Failed to read the selected file"
+        "modeManual": "Handmatig certificaat",
+        "modeSelfSigned": "Zelfondertekend",
+        "modeNoneDescription": "Gewoon HTTP zonder versleuteling",
+        "modeAutoTLSDescription": "Automatisch certificaat via Let's Encrypt",
+        "modeManualDescription": "Upload je eigen certificaat en sleutel",
+        "modeSelfSignedDescription": "Een zelfondertekend certificaat genereren",
+        "portLabel": "HTTPS-poort",
+        "portHelpText": "Poort voor HTTPS-verbindingen (standaard: 8443)",
+        "redirectToHttps": "HTTP naar HTTPS omleiden",
+        "autoTLSRequirements": "Vereist dat poorten 80 en 443 toegankelijk zijn. Op Linux heeft het proces root of CAP_NET_BIND_SERVICE nodig.",
+        "validityLabel": "Certificaatgeldigheid",
+        "validityHelpText": "Hoe lang het certificaat geldig moet zijn",
+        "validity365d": "1 jaar",
+        "validity730d": "2 jaar",
+        "generateButton": "Certificaat genereren",
+        "regenerateButton": "Certificaat opnieuw genereren",
+        "generating": "Genereren...",
+        "certificateLabel": "Certificaat (PEM)",
+        "privateKeyLabel": "Privésleutel (PEM)",
+        "caCertificateLabel": "CA-certificaat (PEM, optioneel)",
+        "uploadButton": "Certificaat uploaden",
+        "uploading": "Uploaden...",
+        "browseFile": "Bladeren...",
+        "plaintextWarning": "Waarschuwing: je privésleutel wordt in platte tekst via HTTP verzonden. Upload certificaten alleen via een vertrouwd netwerk of localhost.",
+        "certificateInstalled": "Geïnstalleerd certificaat",
+        "subject": "Onderwerp",
+        "issuer": "Uitgever",
+        "validFrom": "Geldig vanaf",
+        "validUntil": "Geldig tot",
+        "daysRemaining": "Resterende dagen",
+        "sans": "Alternatieve onderwerpnamen",
+        "fingerprint": "Vingerafdruk",
+        "expiryWarning": "Certificaat verloopt binnenkort",
+        "loading": "Certificaatinformatie laden...",
+        "loadError": "Kan certificaatinformatie niet laden",
+        "generateSuccess": "Zelfondertekend certificaat succesvol gegenereerd",
+        "generateError": "Kan certificaat niet genereren",
+        "uploadSuccess": "Certificaat succesvol geüpload",
+        "uploadError": "Kan certificaat niet uploaden",
+        "deleteSuccess": "Certificaat succesvol verwijderd",
+        "deleteError": "Kan certificaat niet verwijderen",
+        "removeCertificate": "Certificaat verwijderen",
+        "deleteConfirm": "Weet je zeker dat je het geïnstalleerde TLS-certificaat wilt verwijderen? De TLS-modus wordt gereset naar Geen.",
+        "restartRequired": "TLS-wijzigingen vereisen een herstart van de server.",
+        "noCertificate": "Geen certificaat geïnstalleerd",
+        "validity1825d": "5 jaar",
+        "autoTLSHostRequired": "Een hostnaam is vereist voor Let’s Encrypt. Voer je publieke domeinnaam in het Host-veld hierboven in.",
+        "autoTLSNoIP": "Let’s Encrypt vereist een domeinnaam, geen IP-adres. Voer een publiek domein in zoals birds.example.com.",
+        "autoTLSNeedsFQDN": "Let’s Encrypt vereist een volledig gekwalificeerde domeinnaam (bijv. birds.example.com), geen kale hostnaam.",
+        "autoTLSNoLocalhost": "Let’s Encrypt kan geen certificaten uitgeven voor localhost.",
+        "autoTLSPrivateTLD": "Let’s Encrypt kan geen certificaten uitgeven voor privédomeinen ({tld} is niet publiek oplosbaar).",
+        "downloadCertificate": "Certificaat downloaden",
+        "downloadCertificateHelp": "Installeer dit certificaat in het vertrouwensarchief van je besturingssysteem om beveiligingswaarschuwingen van de browser te voorkomen.",
+        "fileReadError": "Kan het geselecteerde bestand niet lezen"
       }
     },
     "species": {
@@ -3433,14 +3433,14 @@
           "availableTitle": "Beschikbare Parameters",
           "buttons": {
             "commonName": "CommonName",
-            "scientificName": "ScientificName",
-            "confidence": "Confidence",
-            "time": "Time",
-            "source": "Source",
+            "scientificName": "WetenschappelijkeNaam",
+            "confidence": "Betrouwbaarheid",
+            "time": "Tijd",
+            "source": "Bron",
             "clearParameters": "Wis Parameters"
           },
-          "placeholder": "Click buttons below to add parameters or type manually",
-          "tooltip": "Use buttons below or type directly (comma-separated)"
+          "placeholder": "Klik op de knoppen hieronder om parameters toe te voegen of typ handmatig",
+          "tooltip": "Gebruik de knoppen hieronder of typ direct (kommagescheiden)"
         },
         "executeDefaults": {
           "label": "Voer ook standaard acties uit (database opslag, meldingen, etc.)",
@@ -3592,7 +3592,7 @@
         "expand": "Gebeurtenisgeschiedenis tonen",
         "collapse": "Gebeurtenisgeschiedenis verbergen"
       },
-      "suggestions": "Species suggestions"
+      "suggestions": "Soortsuggesties"
     },
     "database": {
       "sqlitePlaceholder": "Voer SQLite database pad in",
@@ -3838,7 +3838,7 @@
         "appearance": "Uiterlijk",
         "language": "Taal en regionaal",
         "visualContent": "Visuele inhoud",
-        "audioPlayback": "Audio Playback"
+        "audioPlayback": "Audioweergave"
       },
       "appearance": {
         "title": "Uiterlijk",
@@ -3853,14 +3853,14 @@
         "description": "Configureer vogelafbeeldingen en spectrogramweergave-instellingen"
       },
       "audioPlayback": {
-        "title": "Audio Playback",
-        "description": "Default settings for playing bird recordings.",
-        "defaultGain": "Default Volume Boost",
-        "defaultGainHelpText": "Initial gain applied when playing recordings. Bird sounds are often quiet, so a boost of 6-12 dB is recommended.",
+        "title": "Audioweergave",
+        "description": "Standaardinstellingen voor het afspelen van vogelopnames.",
+        "defaultGain": "Standaard volumeversterking",
+        "defaultGainHelpText": "Initiële versterking bij het afspelen van opnames. Vogelgeluiden zijn vaak zacht, dus een versterking van 6-12 dB wordt aanbevolen.",
         "defaultGainUnit": "dB"
       }
     },
-    "restartRequired": "Some changes require a server restart to take effect. Please restart BirdNET-Go."
+    "restartRequired": "Sommige wijzigingen vereisen een herstart van de server. Herstart BirdNET-Go."
   },
   "auth": {
     "login": "Aanmelden",
@@ -3881,7 +3881,7 @@
     "continueWithMicrosoft": "Doorgaan met Microsoft",
     "continueWithLine": "Doorgaan met LINE",
     "continueWithKakao": "Doorgaan met Kakao",
-    "continueWithOidc": "Continue with OIDC",
+    "continueWithOidc": "Doorgaan met OIDC",
     "errors": {
       "loginFailed": "Aanmelding mislukt. Controleer je wachtwoord en probeer het opnieuw.",
       "passwordRequired": "Wachtwoord is verplicht.",
@@ -4029,7 +4029,7 @@
       "seekProgress": "Voortgang verder spoelen: {current} / {total} seconden",
       "playbackSpeed": "Afspeelsnelheid",
       "speed": "Snelheid",
-      "loop": "Toggle loop",
+      "loop": "Herhaling aan/uit",
       "player": "Audiospeler"
     },
     "spectrogram": {
@@ -4108,36 +4108,36 @@
         "spectrogramFailed": "Spectrogram kon niet worden gegenereerd"
       },
       "clipExtraction": {
-        "selectRange": "Click and drag to select a range",
-        "playSelection": "Play selected range",
-        "pauseSelection": "Pause playback",
-        "reviewSelection": "Jump to start of selection",
-        "selectionStart": "Selection start handle",
-        "selectionEnd": "Selection end handle",
-        "lossless": "Lossless",
-        "lossy": "Lossy",
-        "extractClip": "Download selected clip",
-        "clearSelection": "Clear selection",
-        "extracting": "Extracting clip...",
-        "extractError": "Failed to extract clip",
-        "formatLabel": "Format",
+        "selectRange": "Klik en sleep om een bereik te selecteren",
+        "playSelection": "Geselecteerd bereik afspelen",
+        "pauseSelection": "Afspelen pauzeren",
+        "reviewSelection": "Ga naar begin van selectie",
+        "selectionStart": "Handgreep begin selectie",
+        "selectionEnd": "Handgreep einde selectie",
+        "lossless": "Verliesvrij",
+        "lossy": "Met verlies",
+        "extractClip": "Geselecteerd fragment downloaden",
+        "clearSelection": "Selectie wissen",
+        "extracting": "Fragment extraheren...",
+        "extractError": "Kan fragment niet extraheren",
+        "formatLabel": "Formaat",
         "rangeLabel": "{start}s – {end}s"
       },
       "processing": {
-        "playSelection": "Play selection",
-        "skipToStart": "Skip to selection start",
-        "clearSelection": "Clear selection",
-        "gain": "Gain (dB)",
-        "denoise": "Denoise",
-        "denoiseOff": "Off",
-        "denoiseLight": "Light",
-        "denoiseMedium": "Medium",
-        "denoiseHeavy": "Heavy",
-        "normalize": "Normalize audio",
-        "normalizeTooltip": "EBU R128 Normalization",
-        "export": "Export",
+        "playSelection": "Selectie afspelen",
+        "skipToStart": "Ga naar begin van selectie",
+        "clearSelection": "Selectie wissen",
+        "gain": "Versterking (dB)",
+        "denoise": "Ruisonderdrukking",
+        "denoiseOff": "Uit",
+        "denoiseLight": "Licht",
+        "denoiseMedium": "Gemiddeld",
+        "denoiseHeavy": "Zwaar",
+        "normalize": "Audio normaliseren",
+        "normalizeTooltip": "EBU R128-normalisatie",
+        "export": "Exporteren",
         "exportOriginal": "Origineel",
-        "processingActive": "Processing active"
+        "processingActive": "Verwerking actief"
       }
     },
     "weatherInfo": {
@@ -4146,20 +4146,20 @@
       }
     },
     "tls": {
-      "certificateInstalled": "Certificate Installed",
-      "browseFile": "Browse",
-      "subject": "Subject",
-      "issuer": "Issuer",
-      "sans": "Subject Alternative Names",
-      "validUntil": "Valid Until",
-      "daysRemaining": "Days Remaining",
-      "fingerprint": "Fingerprint",
-      "expiryWarning": "This certificate expires soon. Consider renewing it.",
-      "downloadCertificate": "Download Certificate",
-      "regenerateButton": "Regenerate",
-      "removeCertificate": "Remove Certificate",
-      "fileReadError": "Failed to read file",
-      "loading": "Loading certificate information..."
+      "certificateInstalled": "Certificaat geïnstalleerd",
+      "browseFile": "Bladeren",
+      "subject": "Onderwerp",
+      "issuer": "Uitgever",
+      "sans": "Alternatieve onderwerpnamen",
+      "validUntil": "Geldig tot",
+      "daysRemaining": "Resterende dagen",
+      "fingerprint": "Vingerafdruk",
+      "expiryWarning": "Dit certificaat verloopt binnenkort. Overweeg het te vernieuwen.",
+      "downloadCertificate": "Certificaat downloaden",
+      "regenerateButton": "Opnieuw genereren",
+      "removeCertificate": "Certificaat verwijderen",
+      "fileReadError": "Kan bestand niet lezen",
+      "loading": "Certificaatinformatie laden..."
     }
   },
   "connectivity": {
@@ -4332,77 +4332,77 @@
     },
     "steps": {
       "welcome": {
-        "title": "Welcome",
-        "heading": "Welcome to BirdNET-Go!",
-        "description": "BirdNET-Go is a real-time bird sound identification system. It listens to audio from your microphone or audio stream and uses the BirdNET AI model to identify bird species.",
-        "credit": "Powered by the BirdNET Analyzer developed by the K. Lisa Yang Center for Conservation Bioacoustics at the Cornell Lab of Ornithology and Chemnitz University of Technology.",
-        "cta": "Let's set up your bird monitoring station."
+        "title": "Welkom",
+        "heading": "Welkom bij BirdNET-Go!",
+        "description": "BirdNET-Go is een realtime systeem voor het identificeren van vogelgeluiden. Het luistert naar audio van je microfoon of audiostream en gebruikt het BirdNET AI-model om vogelsoorten te identificeren.",
+        "credit": "Aangedreven door de BirdNET Analyzer, ontwikkeld door het K. Lisa Yang Center for Conservation Bioacoustics aan het Cornell Lab of Ornithology en de Chemnitz University of Technology.",
+        "cta": "Laten we je vogelmonitoringstation instellen."
       },
       "locationLanguage": {
-        "title": "Location & Language",
-        "uiLanguageLabel": "Interface Language",
-        "uiLanguageHelp": "Language used for the web interface",
-        "speciesLanguageLabel": "Species Name Language",
-        "speciesLanguageHelp": "Language used for bird species names in detections",
-        "locationLabel": "Station Location",
-        "locationHelp": "Your location helps filter species to those likely in your area",
-        "latitudeLabel": "Latitude",
-        "longitudeLabel": "Longitude",
-        "useMyLocation": "Use my location",
-        "locationDetected": "Location detected",
-        "locationError": "Could not detect location. Please enter coordinates manually.",
-        "locationDenied": "Location access denied. Please enter coordinates manually."
+        "title": "Locatie en taal",
+        "uiLanguageLabel": "Interfacetaal",
+        "uiLanguageHelp": "Taal die wordt gebruikt voor de webinterface",
+        "speciesLanguageLabel": "Taal van soortnamen",
+        "speciesLanguageHelp": "Taal die wordt gebruikt voor vogelsoortnamen bij detecties",
+        "locationLabel": "Stationlocatie",
+        "locationHelp": "Je locatie helpt om soorten te filteren naar die waarschijnlijk in je omgeving voorkomen",
+        "latitudeLabel": "Breedtegraad",
+        "longitudeLabel": "Lengtegraad",
+        "useMyLocation": "Gebruik mijn locatie",
+        "locationDetected": "Locatie gedetecteerd",
+        "locationError": "Locatie kon niet worden gedetecteerd. Voer de coördinaten handmatig in.",
+        "locationDenied": "Locatietoegang geweigerd. Voer de coördinaten handmatig in."
       },
       "audioSource": {
-        "title": "Audio Source",
-        "sourceTypeLabel": "Source Type",
-        "soundcard": "Microphone / Soundcard",
-        "rtspStream": "RTSP Stream",
-        "deviceLabel": "Audio Device",
-        "deviceLoading": "Loading audio devices...",
-        "noDevicesFound": "No audio devices detected. Try configuring an RTSP stream instead.",
-        "rtspUrlLabel": "Stream URL",
+        "title": "Audiobron",
+        "sourceTypeLabel": "Brontype",
+        "soundcard": "Microfoon / Geluidskaart",
+        "rtspStream": "RTSP-stream",
+        "deviceLabel": "Audioapparaat",
+        "deviceLoading": "Audioapparaten laden...",
+        "noDevicesFound": "Geen audioapparaten gedetecteerd. Probeer een RTSP-stream te configureren.",
+        "rtspUrlLabel": "Stream-URL",
         "rtspUrlPlaceholder": "rtsp://user:password@host:port/stream",
-        "rtspUrlHelp": "Enter the URL of your RTSP audio stream",
-        "additionalSourcesHint": "You can add more audio sources later in Settings."
+        "rtspUrlHelp": "Voer de URL van je RTSP-audiostream in",
+        "additionalSourcesHint": "Je kunt later meer audiobronnen toevoegen in Instellingen."
       },
       "detection": {
-        "title": "Detection Threshold",
-        "description": "Choose how strict the bird identification should be. You can adjust this later in Settings.",
-        "balanced": "Balanced",
-        "balancedDesc": "Good balance of accuracy and sensitivity",
-        "balancedRecommended": "Recommended",
-        "highAccuracy": "High Accuracy",
-        "highAccuracyDesc": "Fewer false positives, may miss some birds",
-        "highSensitivity": "High Sensitivity",
-        "highSensitivityDesc": "More detections, more false positives",
-        "threshold": "Confidence threshold",
-        "fpFilterNote": "Once your system is running and proven, you can enable the false positive filter in Settings to further reduce incorrect detections."
+        "title": "Detectiedrempel",
+        "description": "Kies hoe streng de vogelidentificatie moet zijn. Je kunt dit later aanpassen in Instellingen.",
+        "balanced": "Gebalanceerd",
+        "balancedDesc": "Goede balans tussen nauwkeurigheid en gevoeligheid",
+        "balancedRecommended": "Aanbevolen",
+        "highAccuracy": "Hoge nauwkeurigheid",
+        "highAccuracyDesc": "Minder fout-positieven, kan sommige vogels missen",
+        "highSensitivity": "Hoge gevoeligheid",
+        "highSensitivityDesc": "Meer detecties, meer fout-positieven",
+        "threshold": "Betrouwbaarheidsdrempel",
+        "fpFilterNote": "Zodra je systeem draait en bewezen is, kun je het fout-positievenfilter inschakelen in Instellingen om onjuiste detecties verder te verminderen."
       },
       "integration": {
-        "title": "Privacy & Integration",
-        "privacyFilterLabel": "Enable privacy filter",
-        "privacyFilterHelp": "Filters out detections when human voices are detected near the microphone",
-        "birdweatherLabel": "Share detections with BirdWeather",
-        "birdweatherHelp": "Contribute your bird detections to the BirdWeather community network",
-        "birdweatherIdLabel": "BirdWeather Station ID",
-        "birdweatherIdPlaceholder": "Enter your BirdWeather station ID",
-        "errorReportingLabel": "Send anonymous error reports",
-        "errorReportingHelp": "Help improve BirdNET-Go by sending anonymous error reports when something goes wrong"
+        "title": "Privacy en integratie",
+        "privacyFilterLabel": "Privacyfilter inschakelen",
+        "privacyFilterHelp": "Filtert detecties uit wanneer menselijke stemmen worden gedetecteerd bij de microfoon",
+        "birdweatherLabel": "Detecties delen met BirdWeather",
+        "birdweatherHelp": "Draag je vogeldetecties bij aan het BirdWeather-gemeenschapsnetwerk",
+        "birdweatherIdLabel": "BirdWeather Station-ID",
+        "birdweatherIdPlaceholder": "Voer je BirdWeather station-ID in",
+        "errorReportingLabel": "Anonieme foutrapporten verzenden",
+        "errorReportingHelp": "Help BirdNET-Go te verbeteren door anonieme foutrapporten te verzenden wanneer er iets misgaat"
       },
       "responsibleUse": {
-        "title": "Using BirdNET-Go Responsibly",
-        "intro": "BirdNET-Go is a powerful tool that enhances your birding experience through AI-assisted identification. To ensure the best outcomes for both birding and conservation:",
-        "point1": "Review and verify detections before sharing observations",
-        "point2": "Use the confidence scores as a guide, not absolute truth",
-        "point3": "Cross-reference with field guides and local expertise",
-        "point4": "Consider seasonal patterns and habitat suitability",
-        "citizenScienceHeading": "When contributing to citizen science:",
-        "citizenPoint1": "Only submit observations you have personally verified",
-        "citizenPoint2": "Include notes about visual or behavioral confirmation",
-        "citizenPoint3": "Use AI detections as a starting point for your own observations",
-        "outro": "This approach ensures data quality for scientific research while maximizing your learning and enjoyment of birds.",
-        "acknowledge": "I understand"
+        "title": "Verantwoord gebruik van BirdNET-Go",
+        "intro": "BirdNET-Go is een krachtig hulpmiddel dat je vogelervaring verbetert door AI-ondersteunde identificatie. Om de beste resultaten voor zowel vogelen als natuurbehoud te waarborgen:",
+        "point1": "Controleer en verifieer detecties voordat je waarnemingen deelt",
+        "point2": "Gebruik de betrouwbaarheidsscores als richtlijn, niet als absolute waarheid",
+        "point3": "Vergelijk met veldgidsen en lokale expertise",
+        "point4": "Houd rekening met seizoenspatronen en geschiktheid van het leefgebied",
+        "citizenScienceHeading": "Bij het bijdragen aan burgerwetenschap:",
+        "citizenPoint1": "Dien alleen waarnemingen in die je persoonlijk hebt geverifieerd",
+        "citizenPoint2": "Voeg notities toe over visuele of gedragsbevestiging",
+        "citizenPoint3": "Gebruik AI-detecties als startpunt voor je eigen waarnemingen",
+        "outro": "Deze aanpak waarborgt gegevenskwaliteit voor wetenschappelijk onderzoek en maximaliseert tegelijk je leerervaring en plezier bij het vogelen.",
+        "acknowledge": "Ik begrijp het"
       }
     }
   },

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -265,7 +265,7 @@
     "unknown": "Nieznany",
     "licenseInformation": "Informacje o Licencji",
     "licenseText": "Zarówno model AI BirdNET, jak i BirdNET-Go są objęte licencją",
-    "ccLicense": "Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License",
+    "ccLicense": "Licencja Creative Commons Uznanie autorstwa-Użycie niekomercyjne-Na tych samych warunkach 4.0 Międzynarodowa",
     "licenseDescription": "Ta licencja pozwala innym na remiks, adaptację i budowanie na tej pracy w sposób niekomercyjny, o ile zostanie podane odpowiednie uznanie autorstwa, a nowe utwory będą licencjonowane na identycznych warunkach.",
     "dependencyLicenses": "Licencje Zależności",
     "taxonomyDataTitle": "Dane Taksonomiczne",
@@ -377,8 +377,8 @@
         "application": "Błąd aplikacji",
         "imageProvider": "Powiadomienie dostawcy obrazów",
         "categoryError": "Błąd {category}",
-        "burstTitle": "Multiple {component} errors",
-        "burstMessage": "{count} errors in the last {window_minutes} minutes: {sample_error}"
+        "burstTitle": "Wiele błędów {component}",
+        "burstMessage": "{count} błędów w ciągu ostatnich {window_minutes} minut: {sample_error}"
       },
       "settings": {
         "reloadingBirdnet": "Stosowanie nowych ustawień analizy...",
@@ -388,7 +388,7 @@
         "reconfiguringBirdweather": "Aktualizacja integracji BirdWeather...",
         "reconfiguringStreams": "Aktualizacja strumieni audio...",
         "reconfiguringTelemetry": "Aktualizacja ustawień telemetrii...",
-        "reconfiguringPushNotifications": "Reconfiguring push notification providers...",
+        "reconfiguringPushNotifications": "Rekonfigurowanie dostawców powiadomień push...",
         "reconfiguringSpeciesTracking": "Aktualizacja śledzenia gatunków...",
         "recalculatingThresholds": "Przeliczanie progów dynamicznych dla nowej wartości bazowej",
         "reconfiguringDynamicThresholds": "Ponowna konfiguracja progów dynamicznych...",
@@ -790,17 +790,17 @@
       "showing": "Pokazywanie {from} do {to} z {total} wyników"
     },
     "weather": {
-      "title": "Weather Information",
-      "noData": "No weather data",
-      "noDataAvailable": "No weather data available",
-      "loading": "Loading weather information...",
+      "title": "Informacje o pogodzie",
+      "noData": "Brak danych o pogodzie",
+      "noDataAvailable": "Brak dostępnych danych o pogodzie",
+      "loading": "Ładowanie informacji o pogodzie...",
       "labels": {
-        "temperature": "Temperature",
-        "weather": "Weather",
-        "wind": "Wind",
-        "humidity": "Humidity",
-        "pressure": "Pressure",
-        "cloudCover": "Cloud Cover"
+        "temperature": "Temperatura",
+        "weather": "Pogoda",
+        "wind": "Wiatr",
+        "humidity": "Wilgotność",
+        "pressure": "Ciśnienie",
+        "cloudCover": "Zachmurzenie"
       },
       "units": {
         "temperature": "°C",
@@ -930,31 +930,31 @@
   },
   "spectrogram": {
     "controls": {
-      "frequencyRange": "Frequency Range",
-      "colorMap": "Color Map",
-      "gain": "Gain",
+      "frequencyRange": "Zakres częstotliwości",
+      "colorMap": "Mapa kolorów",
+      "gain": "Wzmocnienie",
       "gainTooltip": "Wzmocnienie wizualizacji spektrogramu",
       "mute": "Wycisz wyjście audio",
       "unmute": "Włącz wyjście audio",
-      "frequencyRangeMin": "Minimum frequency",
-      "frequencyRangeMax": "Maximum frequency"
+      "frequencyRangeMin": "Częstotliwość minimalna",
+      "frequencyRangeMax": "Częstotliwość maksymalna"
     },
     "error": {
-      "unsupported": "Your browser does not support audio analysis",
-      "connectionFailed": "Failed to connect to live audio stream",
-      "accessDenied": "Live audio access requires authentication. Please log in to use this feature."
+      "unsupported": "Twoja przeglądarka nie obsługuje analizy audio",
+      "connectionFailed": "Nie udało się połączyć ze strumieniem audio na żywo",
+      "accessDenied": "Dostęp do audio na żywo wymaga uwierzytelnienia. Zaloguj się, aby korzystać z tej funkcji."
     },
     "dashboard": {
-      "toggle": "Live Spectrogram",
-      "audioToggle": "Enable audio"
+      "toggle": "Spektrogram na żywo",
+      "audioToggle": "Włącz audio"
     },
     "gain": {
       "muted": "Wyciszony",
       "level": "Wzmocnienie: {value} dB"
     },
     "page": {
-      "title": "Live Audio",
-      "sourceLabel": "Audio Source",
+      "title": "Audio na żywo",
+      "sourceLabel": "Źródło audio",
       "connected": "Połączono",
       "enterFullscreen": "Pełny ekran",
       "exitFullscreen": "Zamknij pełny ekran"
@@ -962,7 +962,7 @@
     "colorMaps": {
       "inferno": "Inferno",
       "viridis": "Viridis",
-      "grayscale": "Grayscale"
+      "grayscale": "Skala szarości"
     },
     "labels": {
       "toggle": "Przełącz etykiety wykrywania"
@@ -1196,10 +1196,10 @@
               "name": "Dostępna pamięć"
             },
             "mysql_max_packet": {
-              "name": "MySQL Max Packet"
+              "name": "Maks. pakiet MySQL"
             },
             "mysql_timeout": {
-              "name": "MySQL Timeout"
+              "name": "Limit czasu MySQL"
             }
           },
           "passedCount": "{passed}/{total} zaliczonych",
@@ -1287,82 +1287,82 @@
         "fetchFailed": "Nie udało się pobrać statystyk bazy danych"
       },
       "dashboard": {
-        "title": "Database Dashboard",
-        "fetchFailed": "Failed to fetch database overview",
+        "title": "Panel bazy danych",
+        "fetchFailed": "Nie udało się pobrać przeglądu bazy danych",
         "metrics": {
-          "readLatency": "Read Latency",
-          "writeLatency": "Write Latency",
-          "queriesPerSec": "Queries/sec",
-          "database": "Database",
-          "avg": "avg",
-          "max": "max",
-          "lastHour": "{count} last hour",
-          "slowQueries": "{count} slow"
+          "readLatency": "Opóźnienie odczytu",
+          "writeLatency": "Opóźnienie zapisu",
+          "queriesPerSec": "Zapytania/sek",
+          "database": "Baza danych",
+          "avg": "średnia",
+          "max": "maks",
+          "lastHour": "{count} w ostatniej godzinie",
+          "slowQueries": "{count} wolnych"
         },
         "details": {
-          "title": "Database Details",
-          "engine": "Engine",
-          "journal": "Journal",
-          "pageSize": "Page size",
-          "cacheHit": "Cache hit",
-          "integrity": "Integrity",
-          "lastVacuum": "Last VACUUM"
+          "title": "Szczegóły bazy danych",
+          "engine": "Silnik",
+          "journal": "Dziennik",
+          "pageSize": "Rozmiar strony",
+          "cacheHit": "Trafienie cache",
+          "integrity": "Integralność",
+          "lastVacuum": "Ostatni VACUUM"
         },
         "locksWal": {
-          "title": "Locks & WAL",
-          "lockWaits": "Lock waits",
-          "lockTimeouts": "Lock timeouts",
-          "avgWait": "Avg wait",
-          "busyTimeouts": "Busy timeouts",
-          "walSize": "WAL size",
-          "checkpoints": "Checkpoints",
-          "freelistPages": "Freelist pages",
-          "cacheSize": "Cache size"
+          "title": "Blokady i WAL",
+          "lockWaits": "Oczekiwania na blokadę",
+          "lockTimeouts": "Limity czasu blokad",
+          "avgWait": "Średni czas oczekiwania",
+          "busyTimeouts": "Limity czasu zajętości",
+          "walSize": "Rozmiar WAL",
+          "checkpoints": "Punkty kontrolne",
+          "freelistPages": "Strony wolnej listy",
+          "cacheSize": "Rozmiar cache"
         },
         "connectionPool": {
-          "title": "Connection Pool",
-          "poolUsage": "Pool Usage",
-          "active": "active",
-          "idle": "idle",
-          "waiting": "waiting",
-          "totalCreated": "Total created",
-          "connErrors": "Conn errors",
-          "threads": "Threads",
-          "running": "running",
-          "cached": "cached"
+          "title": "Pula połączeń",
+          "poolUsage": "Wykorzystanie puli",
+          "active": "aktywny",
+          "idle": "bezczynny",
+          "waiting": "oczekujący",
+          "totalCreated": "Łącznie utworzonych",
+          "connErrors": "Błędy połączeń",
+          "threads": "Wątki",
+          "running": "działa",
+          "cached": "w cache"
         },
         "innodb": {
-          "title": "InnoDB & Locks",
-          "bufferPoolHitRate": "Buffer pool hit rate",
-          "bufferPoolSize": "Buffer pool size",
-          "lockWaits": "Lock waits",
-          "deadlocks": "Deadlocks",
-          "avgLockWait": "Avg lock wait",
-          "tableLocksWaited": "Table locks waited",
-          "tableLocksImmediate": "Table locks immediate"
+          "title": "InnoDB i blokady",
+          "bufferPoolHitRate": "Współczynnik trafień puli buforów",
+          "bufferPoolSize": "Rozmiar puli buforów",
+          "lockWaits": "Oczekiwania na blokadę",
+          "deadlocks": "Zakleszczenia",
+          "avgLockWait": "Średni czas oczekiwania na blokadę",
+          "tableLocksWaited": "Oczekiwane blokady tabel",
+          "tableLocksImmediate": "Natychmiastowe blokady tabel"
         },
         "detectionRate": {
-          "title": "Detection Rate (24h)",
-          "perHour": "/hr",
+          "title": "Częstość detekcji (24h)",
+          "perHour": "/godz",
           "min": "min",
-          "avg": "avg",
-          "max": "max",
-          "lastBackup": "Last backup",
-          "backupSize": "Backup size",
-          "createBackup": "Create Backup",
+          "avg": "średnia",
+          "max": "maks",
+          "lastBackup": "Ostatnia kopia zapasowa",
+          "backupSize": "Rozmiar kopii zapasowej",
+          "createBackup": "Utwórz kopię zapasową",
           "mysqlHost": "Host",
           "mysqlBackupNote": "Kopie zapasowe MySQL powinny być zarządzane za pomocą mysqldump lub narzędzi administracyjnych MySQL.",
           "chartLabel": "Wskaźnik wykryć w ciągu 24 godzin",
           "detectionsTooltip": "{count} wykryć"
         },
         "tables": {
-          "title": "Tables",
-          "total": "Total",
-          "table": "Table",
-          "engine": "Engine",
-          "rows": "Rows",
-          "size": "Size",
-          "usage": "Usage"
+          "title": "Tabele",
+          "total": "Razem",
+          "table": "Tabela",
+          "engine": "Silnik",
+          "rows": "Wiersze",
+          "size": "Rozmiar",
+          "usage": "Użycie"
         },
         "loading": "Ładowanie..."
       },
@@ -2145,10 +2145,10 @@
         }
       },
       "push": {
-        "title": "Push Notifications",
-        "description": "Send notifications to external services like Discord, Telegram, Slack, and more",
-        "enable": "Enable Push Notifications",
-        "disabled": "Push notifications are disabled",
+        "title": "Powiadomienia push",
+        "description": "Wysyłaj powiadomienia do zewnętrznych usług jak Discord, Telegram, Slack i inne",
+        "enable": "Włącz powiadomienia push",
+        "disabled": "Powiadomienia push są wyłączone",
         "enabledDescription": "Powiadomienia push będą wysyłane do wszystkich włączonych dostawców poniżej",
         "filters": {
           "title": "Filtry wykryć",
@@ -2164,40 +2164,40 @@
           }
         },
         "noProviders": "Brak skonfigurowanych dostawców",
-        "noProvidersDescription": "Add a provider to start receiving push notifications",
+        "noProvidersDescription": "Dodaj dostawcę, aby zacząć otrzymywać powiadomienia push",
         "providers": {
-          "title": "Notification Providers",
-          "addButton": "Add Provider",
-          "editButton": "Edit",
-          "deleteButton": "Delete",
-          "enableToggle": "Enable provider",
-          "urlsPreview": "{count} URL(s) configured",
-          "deleteConfirm": "Delete provider \"{name}\"? This action cannot be undone.",
+          "title": "Dostawcy powiadomień",
+          "addButton": "Dodaj dostawcę",
+          "editButton": "Edytuj",
+          "deleteButton": "Usuń",
+          "enableToggle": "Włącz dostawcę",
+          "urlsPreview": "{count} URL skonfigurowanych",
+          "deleteConfirm": "Usunąć dostawcę \"{name}\"? Tej operacji nie można cofnąć.",
           "typeBadge": {
             "shoutrrr": "Shoutrrr",
             "webhook": "Webhook"
           }
         },
         "form": {
-          "addTitle": "Add Notification Provider",
-          "editTitle": "Edit Notification Provider",
+          "addTitle": "Dodaj dostawcę powiadomień",
+          "editTitle": "Edytuj dostawcę powiadomień",
           "name": {
-            "label": "Provider Name",
-            "placeholder": "e.g., Discord Alerts",
-            "helpText": "A friendly name to identify this provider"
+            "label": "Nazwa dostawcy",
+            "placeholder": "np. Alerty Discord",
+            "helpText": "Przyjazna nazwa do identyfikacji tego dostawcy"
           },
           "urls": {
-            "label": "Service URL(s)",
+            "label": "URL usługi/usług",
             "placeholder": "discord://token@webhookid",
-            "helpText": "Enter one Shoutrrr URL per line. Multiple URLs send to multiple services.",
+            "helpText": "Wprowadź jeden URL Shoutrrr na wiersz. Wiele URL-i wysyła do wielu usług.",
             "validation": {
-              "required": "At least one URL is required",
-              "invalidFormat": "Invalid URL format. URLs should start with a service prefix (e.g., discord://, telegram://)"
+              "required": "Wymagany jest co najmniej jeden URL",
+              "invalidFormat": "Nieprawidłowy format URL. Adresy URL powinny zaczynać się od prefiksu usługi (np. discord://, telegram://)"
             }
           },
           "notificationTypes": {
-            "label": "Notification Types",
-            "helpText": "Select which types of notifications to send to this provider",
+            "label": "Typy powiadomień",
+            "helpText": "Wybierz, które typy powiadomień wysyłać do tego dostawcy",
             "detection": "Detekcje ptaków",
             "error": "Błędy",
             "warning": "Ostrzeżenia",
@@ -2205,7 +2205,7 @@
             "system": "Zdarzenia systemowe"
           },
           "urlFormats": {
-            "title": "Common URL Formats",
+            "title": "Typowe formaty URL",
             "discord": "Discord",
             "discordFormat": "discord://token@webhookid",
             "telegram": "Telegram",
@@ -2218,27 +2218,27 @@
             "gotifyFormat": "gotify://hostname/token",
             "ntfy": "ntfy",
             "ntfyFormat": "ntfy://ntfy.sh/mytopic",
-            "moreServices": "View all supported services",
+            "moreServices": "Zobacz wszystkie obsługiwane usługi",
             "shoutrrrDocs": "https://github.com/nicholas-fedor/shoutrrr?tab=readme-ov-file#supported-services"
           },
-          "saveButton": "Save Provider",
-          "savingButton": "Saving...",
-          "cancelButton": "Cancel",
+          "saveButton": "Zapisz dostawcę",
+          "savingButton": "Zapisywanie...",
+          "cancelButton": "Anuluj",
           "testButton": "Test",
-          "testingButton": "Testing..."
+          "testingButton": "Testowanie..."
         },
         "test": {
-          "button": "Test Provider",
-          "description": "Send a test notification to verify this provider is working",
-          "success": "Test notification sent successfully!",
-          "error": "Test failed: {message}",
-          "requiresUrl": "Enter a URL to test",
-          "requiresEnabled": "Enable the provider to test"
+          "button": "Test dostawcy",
+          "description": "Wyślij powiadomienie testowe, aby sprawdzić działanie tego dostawcy",
+          "success": "Powiadomienie testowe wysłane pomyślnie!",
+          "error": "Test nieudany: {message}",
+          "requiresUrl": "Wprowadź URL do przetestowania",
+          "requiresEnabled": "Włącz dostawcę do testowania"
         },
         "validation": {
-          "nameRequired": "Provider name is required",
-          "urlRequired": "At least one URL is required",
-          "invalidUrl": "Invalid URL format"
+          "nameRequired": "Nazwa dostawcy jest wymagana",
+          "urlRequired": "Wymagany jest co najmniej jeden URL",
+          "invalidUrl": "Nieprawidłowy format URL"
         },
         "autoName": {
           "discord": "Discord",
@@ -2252,37 +2252,37 @@
           "numbered": "{service} #{number}"
         },
         "services": {
-          "selectLabel": "Service",
-          "selectHelpText": "Choose a notification service to configure",
+          "selectLabel": "Usługa",
+          "selectHelpText": "Wybierz usługę powiadomień do skonfigurowania",
           "discord": {
             "name": "Discord",
             "webhookUrl": {
-              "label": "Discord Webhook URL",
+              "label": "URL Webhooka Discord",
               "placeholder": "https://discord.com/api/webhooks/...",
-              "helpText": "Paste your full Discord webhook URL"
+              "helpText": "Wklej pełny URL webhooka Discord"
             },
-            "invalidUrl": "Invalid Discord webhook URL. URL should contain discord.com/api/webhooks/"
+            "invalidUrl": "Nieprawidłowy URL webhooka Discord. URL powinien zawierać discord.com/api/webhooks/"
           },
           "telegram": {
             "name": "Telegram",
             "botToken": {
-              "label": "Bot Token",
+              "label": "Token bota",
               "placeholder": "123456789:ABCdef...",
-              "helpText": "Token from @BotFather"
+              "helpText": "Token od @BotFather"
             },
             "chatId": {
-              "label": "Chat ID",
-              "placeholder": "-1001234567890 or @channel",
-              "helpText": "Chat ID, group ID, or @username"
+              "label": "ID czatu",
+              "placeholder": "-1001234567890 lub @channel",
+              "helpText": "ID czatu, ID grupy lub @nazwa_użytkownika"
             },
-            "incomplete": "Both bot token and chat ID are required"
+            "incomplete": "Wymagany jest zarówno token bota, jak i ID czatu"
           },
           "ntfy": {
             "name": "ntfy",
             "server": {
-              "label": "Server",
+              "label": "Serwer",
               "placeholder": "ntfy.sh",
-              "helpText": "Leave as ntfy.sh for public server or enter your self-hosted server"
+              "helpText": "Zostaw ntfy.sh dla serwera publicznego lub wprowadź swój własny serwer"
             },
             "protocol": {
               "label": "Protokół"
@@ -2305,109 +2305,109 @@
               }
             },
             "topic": {
-              "label": "Topic",
+              "label": "Temat",
               "placeholder": "my-bird-alerts",
-              "helpText": "Topic name for your notifications"
+              "helpText": "Nazwa tematu dla twoich powiadomień"
             },
-            "incomplete": "Topic is required"
+            "incomplete": "Temat jest wymagany"
           },
           "gotify": {
             "name": "Gotify",
             "server": {
-              "label": "Server URL",
+              "label": "URL serwera",
               "placeholder": "gotify.example.com",
-              "helpText": "Your Gotify server hostname (without https://)"
+              "helpText": "Nazwa hosta twojego serwera Gotify (bez https://)"
             },
             "token": {
-              "label": "Application Token",
+              "label": "Token aplikacji",
               "placeholder": "A...",
-              "helpText": "Token from Gotify Apps page"
+              "helpText": "Token ze strony Gotify Apps"
             },
-            "incomplete": "Server and token are required"
+            "incomplete": "Serwer i token są wymagane"
           },
           "pushover": {
             "name": "Pushover",
             "apiToken": {
-              "label": "API Token",
+              "label": "Token API",
               "placeholder": "az...",
-              "helpText": "Application API token"
+              "helpText": "Token API aplikacji"
             },
             "userKey": {
-              "label": "User Key",
+              "label": "Klucz użytkownika",
               "placeholder": "u...",
-              "helpText": "Your user or group key"
+              "helpText": "Twój klucz użytkownika lub grupy"
             },
-            "incomplete": "API token and user key are required"
+            "incomplete": "Token API i klucz użytkownika są wymagane"
           },
           "slack": {
             "name": "Slack",
             "webhookUrl": {
-              "label": "Slack Webhook URL",
+              "label": "URL Webhooka Slack",
               "placeholder": "https://hooks.slack.com/services/...",
-              "helpText": "Paste your full Slack webhook URL"
+              "helpText": "Wklej pełny URL webhooka Slack"
             },
-            "invalidUrl": "Invalid Slack webhook URL. URL should contain hooks.slack.com/services/"
+            "invalidUrl": "Nieprawidłowy URL webhooka Slack. URL powinien zawierać hooks.slack.com/services/"
           },
           "ifttt": {
             "name": "IFTTT",
             "webhookKey": {
-              "label": "Webhook Key",
+              "label": "Klucz webhooka",
               "placeholder": "abc123xyz...",
-              "helpText": "Your IFTTT Webhook key from Maker Webhooks settings"
+              "helpText": "Twój klucz IFTTT Webhook z ustawień Maker Webhooks"
             },
             "eventName": {
-              "label": "Event Name",
+              "label": "Nazwa zdarzenia",
               "placeholder": "bird_detected",
-              "helpText": "The event name to trigger in your IFTTT applet"
+              "helpText": "Nazwa zdarzenia do wywołania w aplecie IFTTT"
             },
-            "incomplete": "Webhook key and event name are required"
+            "incomplete": "Klucz webhooka i nazwa zdarzenia są wymagane"
           },
           "webhook": {
             "name": "Webhook",
             "url": {
-              "label": "Webhook URL",
+              "label": "URL webhooka",
               "placeholder": "https://api.example.com/webhook",
-              "helpText": "The HTTP(S) endpoint to send notifications to"
+              "helpText": "Punkt końcowy HTTP(S) do wysyłania powiadomień"
             },
             "method": {
-              "label": "HTTP Method",
-              "helpText": "HTTP method to use for the request (default: POST)"
+              "label": "Metoda HTTP",
+              "helpText": "Metoda HTTP do użycia dla żądania (domyślnie: POST)"
             },
             "auth": {
-              "label": "Authentication",
-              "none": "None",
-              "bearer": "Bearer Token",
-              "basic": "Basic Auth",
-              "helpText": "Optional authentication for the webhook endpoint"
+              "label": "Uwierzytelnianie",
+              "none": "Brak",
+              "bearer": "Token Bearer",
+              "basic": "Uwierzytelnianie podstawowe",
+              "helpText": "Opcjonalne uwierzytelnianie dla punktu końcowego webhook"
             },
             "bearerToken": {
-              "label": "Bearer Token",
+              "label": "Token Bearer",
               "placeholder": "your-api-token",
-              "helpText": "Token sent in Authorization: Bearer header"
+              "helpText": "Token wysłany w nagłówku Authorization: Bearer"
             },
             "basicUser": {
-              "label": "Username",
+              "label": "Nazwa użytkownika",
               "placeholder": "username"
             },
             "basicPass": {
-              "label": "Password",
-              "placeholder": "password"
+              "label": "Hasło",
+              "placeholder": "hasło"
             },
             "basicAuth": {
-              "helpText": "Credentials sent using HTTP Basic Authentication"
+              "helpText": "Dane uwierzytelniające wysłane za pomocą HTTP Basic Authentication"
             },
-            "invalidUrl": "Invalid URL. Must start with http:// or https://",
-            "tokenRequired": "Bearer token is required when using Bearer authentication",
-            "credentialsRequired": "Username and password are required when using Basic authentication"
+            "invalidUrl": "Nieprawidłowy URL. Musi zaczynać się od http:// lub https://",
+            "tokenRequired": "Token Bearer jest wymagany przy uwierzytelnianiu Bearer",
+            "credentialsRequired": "Nazwa użytkownika i hasło są wymagane przy uwierzytelnianiu podstawowym"
           },
           "custom": {
-            "name": "Custom URL",
+            "name": "Niestandardowy URL",
             "url": {
-              "label": "Shoutrrr URL",
+              "label": "URL Shoutrrr",
               "placeholder": "service://credentials@host",
-              "helpText": "Enter a raw Shoutrrr URL for any supported service"
+              "helpText": "Wprowadź surowy URL Shoutrrr dla dowolnej obsługiwanej usługi"
             },
-            "invalidUrl": "Invalid URL format. URL should start with service://"
+            "invalidUrl": "Nieprawidłowy format URL. URL powinien zaczynać się od service://"
           }
         }
       },
@@ -2541,29 +2541,29 @@
           "skipVerify": "Pomiń Weryfikację Certyfikatu",
           "configNote": "<strong>Konfiguracja TLS:</strong><br />• Standardowe TLS: Zostaw certyfikaty puste dla publicznych brokerów<br />• Certyfikaty self-signed: Podaj Certyfikat CA<br />• Mutual TLS (mTLS): Podaj wszystkie trzy certyfikaty",
           "certificates": {
-            "title": "Certificate Management",
-            "description": "Upload certificates for secure MQTT broker connections",
-            "caLabel": "CA Certificate",
+            "title": "Zarządzanie certyfikatami",
+            "description": "Prześlij certyfikaty dla bezpiecznych połączeń z brokerem MQTT",
+            "caLabel": "Certyfikat CA",
             "caPlaceholder": "-----BEGIN CERTIFICATE-----",
-            "caHelpText": "Certificate Authority certificate to verify the broker's identity",
-            "clientCertLabel": "Client Certificate",
+            "caHelpText": "Certyfikat urzędu certyfikacji do weryfikacji tożsamości brokera",
+            "clientCertLabel": "Certyfikat klienta",
             "clientCertPlaceholder": "-----BEGIN CERTIFICATE-----",
-            "clientCertHelpText": "Client certificate for mutual TLS authentication",
-            "clientKeyLabel": "Client Private Key",
+            "clientCertHelpText": "Certyfikat klienta do wzajemnego uwierzytelniania TLS",
+            "clientKeyLabel": "Klucz prywatny klienta",
             "clientKeyPlaceholder": "-----BEGIN PRIVATE KEY-----",
-            "clientKeyHelpText": "Private key matching the client certificate",
-            "uploadButton": "Upload Certificates",
-            "uploadSuccess": "MQTT TLS certificates uploaded successfully. Use Test Connection to verify.",
-            "uploadError": "Failed to upload MQTT TLS certificates",
-            "deleteConfirm": "Remove all MQTT TLS certificates? The MQTT client will need to reconnect.",
-            "deleteSuccess": "MQTT TLS certificates removed",
-            "deleteError": "Failed to remove MQTT TLS certificates",
-            "loadError": "Failed to load certificate information",
-            "reconnectNote": "Use the Test Connection button below to verify the new TLS configuration."
+            "clientKeyHelpText": "Klucz prywatny pasujący do certyfikatu klienta",
+            "uploadButton": "Prześlij certyfikaty",
+            "uploadSuccess": "Certyfikaty TLS MQTT przesłane pomyślnie. Użyj Test połączenia, aby zweryfikować.",
+            "uploadError": "Nie udało się przesłać certyfikatów TLS MQTT",
+            "deleteConfirm": "Usunąć wszystkie certyfikaty TLS MQTT? Klient MQTT będzie musiał ponownie się połączyć.",
+            "deleteSuccess": "Certyfikaty TLS MQTT usunięte",
+            "deleteError": "Nie udało się usunąć certyfikatów TLS MQTT",
+            "loadError": "Nie udało się załadować informacji o certyfikacie",
+            "reconnectNote": "Użyj przycisku Test połączenia poniżej, aby zweryfikować nową konfigurację TLS."
           }
         },
         "homeAssistant": {
-          "title": "Home Assistant Auto-Discovery",
+          "title": "Auto-Discovery Home Assistant",
           "enable": "Włącz Home Assistant MQTT Discovery",
           "description": "Po włączeniu BirdNET-Go automatycznie rejestruje urządzenia i czujniki w Home Assistant poprzez protokół wykrywania MQTT. Urządzenia pojawią się w rejestrze urządzeń Home Assistant bez ręcznej konfiguracji YAML.",
           "discoveryPrefix": {
@@ -2660,7 +2660,7 @@
             "standard": "Standardowe",
             "metric": "Metryczne",
             "imperial": "Imperialne",
-            "ukhybrid": "UK Hybrid"
+            "ukhybrid": "Hybrydowy UK"
           }
         },
         "test": {
@@ -2703,14 +2703,14 @@
           "helpText": "Jak długo przechowywać dane taksonomiczne z eBird w pamięci podręcznej. Taksonomia zmienia się rzadko, więc dłuższy czas cache zmniejsza liczbę wywołań API."
         },
         "note": "eBird dostarcza dane taksonomiczne wykorzystywane do klasyfikacji gatunków i analiz. Klucz API jest bezpłatny i dostępny w Cornell Lab of Ornithology.",
-        "apiKeyInfo": "A personal eBird API key is required to use this integration. You can request a free key from <a href=\"https://ebird.org/api/keygen\" class=\"link link-primary\" target=\"_blank\" rel=\"noopener noreferrer\">ebird.org/api/keygen</a>.",
+        "apiKeyInfo": "Do korzystania z tej integracji wymagany jest osobisty klucz API eBird. Możesz bezpłatnie uzyskać klucz na <a href=\"https://ebird.org/api/keygen\" class=\"link link-primary\" target=\"_blank\" rel=\"noopener noreferrer\">ebird.org/api/keygen</a>.",
         "test": {
-          "button": "Test eBird Connection",
-          "loading": "Testing...",
-          "enabledRequired": "Enable eBird integration first",
-          "apiKeyRequired": "API key is required",
-          "inProgress": "Test in progress...",
-          "description": "Test eBird API connectivity and authentication"
+          "button": "Test połączenia eBird",
+          "loading": "Testowanie...",
+          "enabledRequired": "Najpierw włącz integrację eBird",
+          "apiKeyRequired": "Klucz API jest wymagany",
+          "inProgress": "Test w toku...",
+          "description": "Testuj łączność i uwierzytelnianie API eBird"
         }
       }
     },
@@ -3154,44 +3154,44 @@
           "userIdLabel": "Identyfikator użytkownika"
         },
         "line": {
-          "title": "LINE Login",
+          "title": "Logowanie LINE",
           "enableLabel": "Zezwól na logowanie OAuth2 przez LINE",
           "redirectUriTitle": "URI przekierowania dla LINE Developers Console:",
           "getCredentialsLabel": "Pobierz dane uwierzytelniające z LINE Developers Console",
-          "clientIdLabel": "Channel ID",
+          "clientIdLabel": "ID kanału",
           "clientIdHelpText": "Channel ID uzyskany z LINE Developers Console podczas konfigurowania LINE Login.",
-          "clientSecretLabel": "Channel Secret",
+          "clientSecretLabel": "Sekret kanału",
           "clientSecretHelpText": "Channel Secret uzyskany z LINE Developers Console podczas konfigurowania LINE Login.",
           "userIdLabel": "Identyfikator użytkownika"
         },
         "kakao": {
-          "title": "Kakao Login",
+          "title": "Logowanie Kakao",
           "enableLabel": "Zezwól na logowanie OAuth2 przez Kakao",
           "redirectUriTitle": "URI przekierowania dla Kakao Developers Console:",
           "getCredentialsLabel": "Pobierz dane uwierzytelniające z Kakao Developers Console",
-          "clientIdLabel": "REST API Key",
+          "clientIdLabel": "Klucz API REST",
           "clientIdHelpText": "REST API Key uzyskany z Kakao Developers Console podczas konfigurowania Kakao Login.",
-          "clientSecretLabel": "Client Secret",
+          "clientSecretLabel": "Sekret klienta",
           "clientSecretHelpText": "Client Secret uzyskany z Kakao Developers Console podczas konfigurowania Kakao Login.",
           "userIdLabel": "Identyfikator użytkownika"
         },
         "oidc": {
-          "title": "OIDC Provider",
-          "enableLabel": "Enable OIDC authentication",
-          "redirectUriTitle": "Redirect URI",
-          "getCredentialsLabel": "Configure in your Identity Provider",
-          "clientIdLabel": "Client ID",
-          "clientIdHelpText": "The client ID from your OIDC identity provider",
-          "clientSecretLabel": "Client Secret",
-          "clientSecretHelpText": "The client secret from your OIDC identity provider",
-          "userIdLabel": "Allowed User (email or sub claim)",
-          "issuerUrlLabel": "Issuer URL",
-          "issuerUrlHelpText": "The issuer URL of your OpenID Connect identity provider (e.g., https://auth.example.com)",
+          "title": "Dostawca OIDC",
+          "enableLabel": "Włącz uwierzytelnianie OIDC",
+          "redirectUriTitle": "URI przekierowania",
+          "getCredentialsLabel": "Skonfiguruj u swojego dostawcy tożsamości",
+          "clientIdLabel": "ID klienta",
+          "clientIdHelpText": "ID klienta od twojego dostawcy tożsamości OIDC",
+          "clientSecretLabel": "Sekret klienta",
+          "clientSecretHelpText": "Sekret klienta od twojego dostawcy tożsamości OIDC",
+          "userIdLabel": "Dozwolony użytkownik (email lub claim sub)",
+          "issuerUrlLabel": "URL wystawcy",
+          "issuerUrlHelpText": "URL wystawcy twojego dostawcy tożsamości OpenID Connect (np. https://auth.example.com)",
           "issuerUrlPlaceholder": "https://auth.example.com",
-          "issuerUrlRequired": "Issuer URL is required for OIDC providers",
-          "issuerUrlInvalid": "Issuer URL must be a valid HTTP or HTTPS URL",
-          "scopesLabel": "Scopes",
-          "scopesHelpText": "Comma-separated list of OIDC scopes (default: openid, profile, email)",
+          "issuerUrlRequired": "URL wystawcy jest wymagany dla dostawców OIDC",
+          "issuerUrlInvalid": "URL wystawcy musi być prawidłowym URL HTTP lub HTTPS",
+          "scopesLabel": "Zakresy",
+          "scopesHelpText": "Lista zakresów OIDC oddzielonych przecinkami (domyślnie: openid, profile, email)",
           "scopesPlaceholder": "openid, profile, email"
         }
       },
@@ -3201,14 +3201,14 @@
         "disabled": "Omijanie podsieci jest wyłączone"
       },
       "exceptions": {
-        "title": "Exceptions"
+        "title": "Wyjątki"
       },
       "publicAccess": {
-        "title": "Public Access",
-        "description": "Allow specific features to be accessible without authentication.",
-        "liveAudioLabel": "Allow public live audio playback",
-        "liveAudioHelp": "When enabled, anyone can listen to live audio streams without logging in. Settings and deletion still require authentication.",
-        "warningText": "Enabling public access features exposes them to anyone who can reach this server. Only enable if you trust your network environment."
+        "title": "Dostęp publiczny",
+        "description": "Zezwól na dostęp do określonych funkcji bez uwierzytelniania.",
+        "liveAudioLabel": "Zezwól na publiczne odtwarzanie audio na żywo",
+        "liveAudioHelp": "Po włączeniu każdy może słuchać strumieni audio na żywo bez logowania. Ustawienia i usuwanie nadal wymagają uwierzytelnienia.",
+        "warningText": "Włączenie funkcji dostępu publicznego udostępnia je każdemu, kto może połączyć się z tym serwerem. Włączaj tylko jeśli ufasz swojemu środowisku sieciowemu."
       },
       "placeholders": {
         "baseUrl": "https://birdnet.example.com:5500",
@@ -3225,64 +3225,64 @@
       },
       "tls": {
         "title": "TLS / HTTPS",
-        "description": "Configure TLS/HTTPS encryption for secure connections",
-        "modeLabel": "TLS Mode",
-        "modeNone": "None (HTTP)",
+        "description": "Skonfiguruj szyfrowanie TLS/HTTPS dla bezpiecznych połączeń",
+        "modeLabel": "Tryb TLS",
+        "modeNone": "Brak (HTTP)",
         "modeLetsEncrypt": "Let's Encrypt",
-        "modeManual": "Manual Certificate",
-        "modeSelfSigned": "Self-Signed",
-        "modeNoneDescription": "Plain HTTP without encryption",
-        "modeAutoTLSDescription": "Automatic certificate via Let's Encrypt",
-        "modeManualDescription": "Upload your own certificate and key",
-        "modeSelfSignedDescription": "Generate a self-signed certificate",
-        "portLabel": "HTTPS Port",
-        "portHelpText": "Port for HTTPS connections (default: 8443)",
-        "redirectToHttps": "Redirect HTTP to HTTPS",
-        "autoTLSRequirements": "Requires ports 80 and 443 to be accessible. On Linux, the process needs root or CAP_NET_BIND_SERVICE capability.",
-        "validityLabel": "Certificate Validity",
-        "validityHelpText": "How long the certificate should be valid",
-        "validity365d": "1 year",
-        "validity730d": "2 years",
-        "generateButton": "Generate Certificate",
-        "regenerateButton": "Regenerate Certificate",
-        "generating": "Generating...",
-        "certificateLabel": "Certificate (PEM)",
-        "privateKeyLabel": "Private Key (PEM)",
-        "caCertificateLabel": "CA Certificate (PEM, optional)",
-        "uploadButton": "Upload Certificate",
-        "uploading": "Uploading...",
-        "browseFile": "Browse...",
-        "plaintextWarning": "Warning: Your private key will be transmitted in plaintext over HTTP. Only upload certificates when connected via a trusted network or localhost.",
-        "certificateInstalled": "Installed Certificate",
-        "subject": "Subject",
-        "issuer": "Issuer",
-        "validFrom": "Valid From",
-        "validUntil": "Valid Until",
-        "daysRemaining": "Days Remaining",
-        "sans": "Subject Alternative Names",
-        "fingerprint": "Fingerprint",
-        "expiryWarning": "Certificate is expiring soon",
-        "loading": "Loading certificate info...",
-        "loadError": "Failed to load certificate info",
-        "generateSuccess": "Self-signed certificate generated successfully",
-        "generateError": "Failed to generate certificate",
-        "uploadSuccess": "Certificate uploaded successfully",
-        "uploadError": "Failed to upload certificate",
-        "deleteSuccess": "Certificate removed successfully",
-        "deleteError": "Failed to delete certificate",
-        "removeCertificate": "Remove Certificate",
-        "deleteConfirm": "Are you sure you want to remove the installed TLS certificate? The TLS mode will be reset to None.",
-        "restartRequired": "TLS changes require a server restart to take effect.",
-        "noCertificate": "No certificate installed",
-        "validity1825d": "5 years",
-        "autoTLSHostRequired": "A hostname is required for Let’s Encrypt. Enter your public domain name in the Host field above.",
-        "autoTLSNoIP": "Let’s Encrypt requires a domain name, not an IP address. Enter a public domain like birds.example.com.",
-        "autoTLSNeedsFQDN": "Let’s Encrypt requires a fully qualified domain name (e.g., birds.example.com), not a bare hostname.",
-        "autoTLSNoLocalhost": "Let’s Encrypt cannot issue certificates for localhost.",
-        "autoTLSPrivateTLD": "Let’s Encrypt cannot issue certificates for private domains ({tld} is not publicly resolvable).",
-        "downloadCertificate": "Download Certificate",
-        "downloadCertificateHelp": "Install this certificate in your operating system's trust store to avoid browser security warnings.",
-        "fileReadError": "Failed to read the selected file"
+        "modeManual": "Certyfikat ręczny",
+        "modeSelfSigned": "Samopodpisany",
+        "modeNoneDescription": "Zwykły HTTP bez szyfrowania",
+        "modeAutoTLSDescription": "Automatyczny certyfikat przez Let's Encrypt",
+        "modeManualDescription": "Prześlij własny certyfikat i klucz",
+        "modeSelfSignedDescription": "Wygeneruj samopodpisany certyfikat",
+        "portLabel": "Port HTTPS",
+        "portHelpText": "Port dla połączeń HTTPS (domyślnie: 8443)",
+        "redirectToHttps": "Przekieruj HTTP na HTTPS",
+        "autoTLSRequirements": "Wymaga dostępności portów 80 i 443. W systemie Linux proces wymaga uprawnień root lub CAP_NET_BIND_SERVICE.",
+        "validityLabel": "Ważność certyfikatu",
+        "validityHelpText": "Jak długo certyfikat powinien być ważny",
+        "validity365d": "1 rok",
+        "validity730d": "2 lata",
+        "generateButton": "Wygeneruj certyfikat",
+        "regenerateButton": "Regeneruj certyfikat",
+        "generating": "Generowanie...",
+        "certificateLabel": "Certyfikat (PEM)",
+        "privateKeyLabel": "Klucz prywatny (PEM)",
+        "caCertificateLabel": "Certyfikat CA (PEM, opcjonalny)",
+        "uploadButton": "Prześlij certyfikat",
+        "uploading": "Przesyłanie...",
+        "browseFile": "Przeglądaj...",
+        "plaintextWarning": "Ostrzeżenie: Twój klucz prywatny zostanie przesłany w postaci jawnej przez HTTP. Przesyłaj certyfikaty tylko przez zaufaną sieć lub localhost.",
+        "certificateInstalled": "Zainstalowany certyfikat",
+        "subject": "Temat",
+        "issuer": "Wystawca",
+        "validFrom": "Ważny od",
+        "validUntil": "Ważny do",
+        "daysRemaining": "Pozostałe dni",
+        "sans": "Alternatywne nazwy podmiotu",
+        "fingerprint": "Odcisk",
+        "expiryWarning": "Certyfikat wkrótce wygaśnie",
+        "loading": "Ładowanie informacji o certyfikacie...",
+        "loadError": "Nie udało się załadować informacji o certyfikacie",
+        "generateSuccess": "Samopodpisany certyfikat wygenerowany pomyślnie",
+        "generateError": "Nie udało się wygenerować certyfikatu",
+        "uploadSuccess": "Certyfikat przesłany pomyślnie",
+        "uploadError": "Nie udało się przesłać certyfikatu",
+        "deleteSuccess": "Certyfikat usunięty pomyślnie",
+        "deleteError": "Nie udało się usunąć certyfikatu",
+        "removeCertificate": "Usuń certyfikat",
+        "deleteConfirm": "Czy na pewno chcesz usunąć zainstalowany certyfikat TLS? Tryb TLS zostanie zresetowany na Brak.",
+        "restartRequired": "Zmiany TLS wymagają ponownego uruchomienia serwera.",
+        "noCertificate": "Nie zainstalowano certyfikatu",
+        "validity1825d": "5 lat",
+        "autoTLSHostRequired": "Nazwa hosta jest wymagana dla Let’s Encrypt. Wprowadź swoją publiczną nazwę domeny w polu Host powyżej.",
+        "autoTLSNoIP": "Let’s Encrypt wymaga nazwy domeny, a nie adresu IP. Wprowadź publiczną domenę jak birds.example.com.",
+        "autoTLSNeedsFQDN": "Let’s Encrypt wymaga pełnej nazwy domeny (np. birds.example.com), a nie samej nazwy hosta.",
+        "autoTLSNoLocalhost": "Let’s Encrypt nie może wystawiać certyfikatów dla localhost.",
+        "autoTLSPrivateTLD": "Let’s Encrypt nie może wystawiać certyfikatów dla prywatnych domen ({tld} nie jest publicznie rozwiązywalna).",
+        "downloadCertificate": "Pobierz certyfikat",
+        "downloadCertificateHelp": "Zainstaluj ten certyfikat w magazynie zaufanych certyfikatów systemu operacyjnego, aby uniknąć ostrzeżeń bezpieczeństwa przeglądarki.",
+        "fileReadError": "Nie udało się odczytać wybranego pliku"
       }
     },
     "species": {
@@ -3445,8 +3445,8 @@
             "source": "Źródło",
             "clearParameters": "Wyczyść Parametry"
           },
-          "placeholder": "Click buttons below to add parameters or type manually",
-          "tooltip": "Use buttons below or type directly (comma-separated)"
+          "placeholder": "Kliknij przyciski poniżej, aby dodać parametry lub wpisz ręcznie",
+          "tooltip": "Użyj przycisków poniżej lub wpisz bezpośrednio (oddzielone przecinkami)"
         },
         "executeDefaults": {
           "label": "Uruchom również domyślne akcje (przechowywanie w bazie danych, powiadomienia itp.)",
@@ -3598,7 +3598,7 @@
         "expand": "Pokaż historię zdarzeń",
         "collapse": "Ukryj historię zdarzeń"
       },
-      "suggestions": "Species suggestions"
+      "suggestions": "Sugestie gatunków"
     },
     "database": {
       "sqlitePlaceholder": "Wprowadź ścieżkę bazy danych SQLite",
@@ -3838,7 +3838,7 @@
         "appearance": "Wygląd",
         "language": "Język i regionalne",
         "visualContent": "Treści wizualne",
-        "audioPlayback": "Audio Playback"
+        "audioPlayback": "Odtwarzanie audio"
       },
       "appearance": {
         "title": "Wygląd",
@@ -3853,14 +3853,14 @@
         "description": "Konfiguruj obrazy ptaków i ustawienia wyświetlania spektrogramu"
       },
       "audioPlayback": {
-        "title": "Audio Playback",
-        "description": "Default settings for playing bird recordings.",
-        "defaultGain": "Default Volume Boost",
-        "defaultGainHelpText": "Initial gain applied when playing recordings. Bird sounds are often quiet, so a boost of 6-12 dB is recommended.",
+        "title": "Odtwarzanie audio",
+        "description": "Domyślne ustawienia odtwarzania nagrań ptaków.",
+        "defaultGain": "Domyślne wzmocnienie głośności",
+        "defaultGainHelpText": "Początkowe wzmocnienie stosowane podczas odtwarzania nagrań. Dźwięki ptaków są często ciche, dlatego zalecane jest wzmocnienie 6-12 dB.",
         "defaultGainUnit": "dB"
       }
     },
-    "restartRequired": "Some changes require a server restart to take effect. Please restart BirdNET-Go."
+    "restartRequired": "Niektóre zmiany wymagają ponownego uruchomienia serwera. Uruchom ponownie BirdNET-Go."
   },
   "auth": {
     "login": "Zaloguj",
@@ -3881,7 +3881,7 @@
     "continueWithMicrosoft": "Kontynuuj przez Microsoft",
     "continueWithLine": "Kontynuuj przez LINE",
     "continueWithKakao": "Kontynuuj przez Kakao",
-    "continueWithOidc": "Continue with OIDC",
+    "continueWithOidc": "Kontynuuj z OIDC",
     "errors": {
       "loginFailed": "Logowanie nie powiodło się. Sprawdź swoje hasło i spróbuj ponownie.",
       "passwordRequired": "Hasło jest wymagane.",
@@ -4029,7 +4029,7 @@
       "seekProgress": "Szukaj postępu audio: {current} / {total} sekund",
       "playbackSpeed": "Prędkość odtwarzania",
       "speed": "Prędkość",
-      "loop": "Toggle loop",
+      "loop": "Przełącz pętlę",
       "player": "Odtwarzacz audio"
     },
     "spectrogram": {
@@ -4108,36 +4108,36 @@
         "spectrogramFailed": "Nie udało się wygenerować spektrogramu"
       },
       "clipExtraction": {
-        "selectRange": "Click and drag to select a range",
-        "playSelection": "Play selected range",
-        "pauseSelection": "Pause playback",
-        "reviewSelection": "Jump to start of selection",
-        "selectionStart": "Selection start handle",
-        "selectionEnd": "Selection end handle",
-        "lossless": "Lossless",
-        "lossy": "Lossy",
-        "extractClip": "Download selected clip",
-        "clearSelection": "Clear selection",
-        "extracting": "Extracting clip...",
-        "extractError": "Failed to extract clip",
+        "selectRange": "Kliknij i przeciągnij, aby zaznaczyć zakres",
+        "playSelection": "Odtwórz wybrany zakres",
+        "pauseSelection": "Wstrzymaj odtwarzanie",
+        "reviewSelection": "Przejdź do początku zaznaczenia",
+        "selectionStart": "Uchwyt początku zaznaczenia",
+        "selectionEnd": "Uchwyt końca zaznaczenia",
+        "lossless": "Bezstratny",
+        "lossy": "Stratny",
+        "extractClip": "Pobierz wybrany klip",
+        "clearSelection": "Wyczyść zaznaczenie",
+        "extracting": "Wyodrębnianie klipu...",
+        "extractError": "Nie udało się wyodrębnić klipu",
         "formatLabel": "Format",
         "rangeLabel": "{start}s – {end}s"
       },
       "processing": {
-        "playSelection": "Play selection",
-        "skipToStart": "Skip to selection start",
-        "clearSelection": "Clear selection",
-        "gain": "Gain (dB)",
-        "denoise": "Denoise",
-        "denoiseOff": "Off",
-        "denoiseLight": "Light",
-        "denoiseMedium": "Medium",
-        "denoiseHeavy": "Heavy",
-        "normalize": "Normalize audio",
-        "normalizeTooltip": "EBU R128 Normalization",
-        "export": "Export",
+        "playSelection": "Odtwórz zaznaczenie",
+        "skipToStart": "Przejdź do początku zaznaczenia",
+        "clearSelection": "Wyczyść zaznaczenie",
+        "gain": "Wzmocnienie (dB)",
+        "denoise": "Odszumianie",
+        "denoiseOff": "Wyłączony",
+        "denoiseLight": "Lekki",
+        "denoiseMedium": "Średni",
+        "denoiseHeavy": "Ciężki",
+        "normalize": "Normalizuj audio",
+        "normalizeTooltip": "Normalizacja EBU R128",
+        "export": "Eksportuj",
         "exportOriginal": "Oryginalny",
-        "processingActive": "Processing active"
+        "processingActive": "Przetwarzanie aktywne"
       }
     },
     "weatherInfo": {
@@ -4146,20 +4146,20 @@
       }
     },
     "tls": {
-      "certificateInstalled": "Certificate Installed",
-      "browseFile": "Browse",
-      "subject": "Subject",
-      "issuer": "Issuer",
-      "sans": "Subject Alternative Names",
-      "validUntil": "Valid Until",
-      "daysRemaining": "Days Remaining",
-      "fingerprint": "Fingerprint",
-      "expiryWarning": "This certificate expires soon. Consider renewing it.",
-      "downloadCertificate": "Download Certificate",
-      "regenerateButton": "Regenerate",
-      "removeCertificate": "Remove Certificate",
-      "fileReadError": "Failed to read file",
-      "loading": "Loading certificate information..."
+      "certificateInstalled": "Certyfikat zainstalowany",
+      "browseFile": "Przeglądaj",
+      "subject": "Temat",
+      "issuer": "Wystawca",
+      "sans": "Alternatywne nazwy podmiotu",
+      "validUntil": "Ważny do",
+      "daysRemaining": "Pozostałe dni",
+      "fingerprint": "Odcisk",
+      "expiryWarning": "Ten certyfikat wkrótce wygaśnie. Rozważ jego odnowienie.",
+      "downloadCertificate": "Pobierz certyfikat",
+      "regenerateButton": "Regeneruj",
+      "removeCertificate": "Usuń certyfikat",
+      "fileReadError": "Nie udało się odczytać pliku",
+      "loading": "Ładowanie informacji o certyfikacie..."
     }
   },
   "connectivity": {
@@ -4332,77 +4332,77 @@
     },
     "steps": {
       "welcome": {
-        "title": "Welcome",
-        "heading": "Welcome to BirdNET-Go!",
-        "description": "BirdNET-Go is a real-time bird sound identification system. It listens to audio from your microphone or audio stream and uses the BirdNET AI model to identify bird species.",
-        "credit": "Powered by the BirdNET Analyzer developed by the K. Lisa Yang Center for Conservation Bioacoustics at the Cornell Lab of Ornithology and Chemnitz University of Technology.",
-        "cta": "Let's set up your bird monitoring station."
+        "title": "Witaj",
+        "heading": "Witaj w BirdNET-Go!",
+        "description": "BirdNET-Go to system identyfikacji dźwięków ptaków w czasie rzeczywistym. Nasłuchuje audio z mikrofonu lub strumienia audio i wykorzystuje model AI BirdNET do identyfikacji gatunków ptaków.",
+        "credit": "Oparte na analizatorze BirdNET opracowanym przez K. Lisa Yang Center for Conservation Bioacoustics w Cornell Lab of Ornithology i Chemnitz University of Technology.",
+        "cta": "Skonfigurujmy twoją stację monitorowania ptaków."
       },
       "locationLanguage": {
-        "title": "Location & Language",
-        "uiLanguageLabel": "Interface Language",
-        "uiLanguageHelp": "Language used for the web interface",
-        "speciesLanguageLabel": "Species Name Language",
-        "speciesLanguageHelp": "Language used for bird species names in detections",
-        "locationLabel": "Station Location",
-        "locationHelp": "Your location helps filter species to those likely in your area",
-        "latitudeLabel": "Latitude",
-        "longitudeLabel": "Longitude",
-        "useMyLocation": "Use my location",
-        "locationDetected": "Location detected",
-        "locationError": "Could not detect location. Please enter coordinates manually.",
-        "locationDenied": "Location access denied. Please enter coordinates manually."
+        "title": "Lokalizacja i język",
+        "uiLanguageLabel": "Język interfejsu",
+        "uiLanguageHelp": "Język używany dla interfejsu internetowego",
+        "speciesLanguageLabel": "Język nazw gatunków",
+        "speciesLanguageHelp": "Język używany dla nazw gatunków ptaków w detekcjach",
+        "locationLabel": "Lokalizacja stacji",
+        "locationHelp": "Twoja lokalizacja pomaga filtrować gatunki do tych prawdopodobnych w twoim regionie",
+        "latitudeLabel": "Szerokość geograficzna",
+        "longitudeLabel": "Długość geograficzna",
+        "useMyLocation": "Użyj mojej lokalizacji",
+        "locationDetected": "Lokalizacja wykryta",
+        "locationError": "Nie udało się wykryć lokalizacji. Wprowadź współrzędne ręcznie.",
+        "locationDenied": "Odmówiono dostępu do lokalizacji. Wprowadź współrzędne ręcznie."
       },
       "audioSource": {
-        "title": "Audio Source",
-        "sourceTypeLabel": "Source Type",
-        "soundcard": "Microphone / Soundcard",
-        "rtspStream": "RTSP Stream",
-        "deviceLabel": "Audio Device",
-        "deviceLoading": "Loading audio devices...",
-        "noDevicesFound": "No audio devices detected. Try configuring an RTSP stream instead.",
-        "rtspUrlLabel": "Stream URL",
+        "title": "Źródło audio",
+        "sourceTypeLabel": "Typ źródła",
+        "soundcard": "Mikrofon / Karta dźwiękowa",
+        "rtspStream": "Strumień RTSP",
+        "deviceLabel": "Urządzenie audio",
+        "deviceLoading": "Ładowanie urządzeń audio...",
+        "noDevicesFound": "Nie wykryto urządzeń audio. Spróbuj skonfigurować strumień RTSP.",
+        "rtspUrlLabel": "URL strumienia",
         "rtspUrlPlaceholder": "rtsp://user:password@host:port/stream",
-        "rtspUrlHelp": "Enter the URL of your RTSP audio stream",
-        "additionalSourcesHint": "You can add more audio sources later in Settings."
+        "rtspUrlHelp": "Wprowadź URL twojego strumienia audio RTSP",
+        "additionalSourcesHint": "Możesz dodać więcej źródeł audio później w Ustawieniach."
       },
       "detection": {
-        "title": "Detection Threshold",
-        "description": "Choose how strict the bird identification should be. You can adjust this later in Settings.",
-        "balanced": "Balanced",
-        "balancedDesc": "Good balance of accuracy and sensitivity",
-        "balancedRecommended": "Recommended",
-        "highAccuracy": "High Accuracy",
-        "highAccuracyDesc": "Fewer false positives, may miss some birds",
-        "highSensitivity": "High Sensitivity",
-        "highSensitivityDesc": "More detections, more false positives",
-        "threshold": "Confidence threshold",
-        "fpFilterNote": "Once your system is running and proven, you can enable the false positive filter in Settings to further reduce incorrect detections."
+        "title": "Próg detekcji",
+        "description": "Wybierz, jak rygorystyczna powinna być identyfikacja ptaków. Możesz to później zmienić w Ustawieniach.",
+        "balanced": "Zrównoważony",
+        "balancedDesc": "Dobra równowaga między dokładnością a czułością",
+        "balancedRecommended": "Zalecane",
+        "highAccuracy": "Wysoka dokładność",
+        "highAccuracyDesc": "Mniej fałszywych detekcji, może pominąć niektóre ptaki",
+        "highSensitivity": "Wysoka czułość",
+        "highSensitivityDesc": "Więcej detekcji, więcej fałszywych wyników",
+        "threshold": "Próg pewności",
+        "fpFilterNote": "Gdy system będzie działał i sprawdzony, możesz włączyć filtr fałszywych wyników w Ustawieniach, aby jeszcze bardziej ograniczyć błędne detekcje."
       },
       "integration": {
-        "title": "Privacy & Integration",
-        "privacyFilterLabel": "Enable privacy filter",
-        "privacyFilterHelp": "Filters out detections when human voices are detected near the microphone",
-        "birdweatherLabel": "Share detections with BirdWeather",
-        "birdweatherHelp": "Contribute your bird detections to the BirdWeather community network",
-        "birdweatherIdLabel": "BirdWeather Station ID",
-        "birdweatherIdPlaceholder": "Enter your BirdWeather station ID",
-        "errorReportingLabel": "Send anonymous error reports",
-        "errorReportingHelp": "Help improve BirdNET-Go by sending anonymous error reports when something goes wrong"
+        "title": "Prywatność i integracja",
+        "privacyFilterLabel": "Włącz filtr prywatności",
+        "privacyFilterHelp": "Odfiltrowuje detekcje, gdy w pobliżu mikrofonu wykryto głosy ludzkie",
+        "birdweatherLabel": "Udostępnij detekcje w BirdWeather",
+        "birdweatherHelp": "Udostępnij swoje detekcje ptaków w sieci społeczności BirdWeather",
+        "birdweatherIdLabel": "ID stacji BirdWeather",
+        "birdweatherIdPlaceholder": "Wprowadź ID twojej stacji BirdWeather",
+        "errorReportingLabel": "Wysyłaj anonimowe raporty o błędach",
+        "errorReportingHelp": "Pomóż ulepszyć BirdNET-Go wysyłając anonimowe raporty o błędach, gdy coś pójdzie nie tak"
       },
       "responsibleUse": {
-        "title": "Using BirdNET-Go Responsibly",
-        "intro": "BirdNET-Go is a powerful tool that enhances your birding experience through AI-assisted identification. To ensure the best outcomes for both birding and conservation:",
-        "point1": "Review and verify detections before sharing observations",
-        "point2": "Use the confidence scores as a guide, not absolute truth",
-        "point3": "Cross-reference with field guides and local expertise",
-        "point4": "Consider seasonal patterns and habitat suitability",
-        "citizenScienceHeading": "When contributing to citizen science:",
-        "citizenPoint1": "Only submit observations you have personally verified",
-        "citizenPoint2": "Include notes about visual or behavioral confirmation",
-        "citizenPoint3": "Use AI detections as a starting point for your own observations",
-        "outro": "This approach ensures data quality for scientific research while maximizing your learning and enjoyment of birds.",
-        "acknowledge": "I understand"
+        "title": "Odpowiedzialne korzystanie z BirdNET-Go",
+        "intro": "BirdNET-Go to potężne narzędzie, które wzbogaca doświadczenie obserwacji ptaków dzięki identyfikacji wspomaganej przez AI. Aby zapewnić najlepsze wyniki zarówno dla obserwacji, jak i ochrony przyrody:",
+        "point1": "Przejrzyj i zweryfikuj detekcje przed udostępnieniem obserwacji",
+        "point2": "Traktuj wyniki pewności jako wskazówkę, a nie absolutną prawdę",
+        "point3": "Porównaj z przewodnikami terenowymi i lokalną wiedzą ekspercką",
+        "point4": "Uwzględnij wzorce sezonowe i odpowiedniość siedliska",
+        "citizenScienceHeading": "Przyczyniając się do nauki obywatelskiej:",
+        "citizenPoint1": "Wysyłaj tylko obserwacje, które osobiście zweryfikowałeś",
+        "citizenPoint2": "Dołącz notatki o potwierdzeniu wizualnym lub behawioralnym",
+        "citizenPoint3": "Użyj detekcji AI jako punktu wyjścia dla własnych obserwacji",
+        "outro": "To podejście zapewnia jakość danych dla badań naukowych, jednocześnie maksymalizując naukę i przyjemność z obserwacji ptaków.",
+        "acknowledge": "Rozumiem"
       }
     }
   },

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -377,8 +377,8 @@
         "application": "Erro da aplicação",
         "imageProvider": "Aviso do fornecedor de imagens",
         "categoryError": "Erro de {category}",
-        "burstTitle": "Multiple {component} errors",
-        "burstMessage": "{count} errors in the last {window_minutes} minutes: {sample_error}"
+        "burstTitle": "Múltiplos erros de {component}",
+        "burstMessage": "{count} erros nos últimos {window_minutes} minutos: {sample_error}"
       },
       "settings": {
         "reloadingBirdnet": "A aplicar novas definições de análise...",
@@ -388,7 +388,7 @@
         "reconfiguringBirdweather": "A atualizar integração BirdWeather...",
         "reconfiguringStreams": "A atualizar fluxos de áudio...",
         "reconfiguringTelemetry": "A atualizar definições de telemetria...",
-        "reconfiguringPushNotifications": "Reconfiguring push notification providers...",
+        "reconfiguringPushNotifications": "A reconfigurar fornecedores de notificações push...",
         "reconfiguringSpeciesTracking": "A atualizar monitorização de espécies...",
         "recalculatingThresholds": "Recalculando limiares dinâmicos para novo valor base",
         "reconfiguringDynamicThresholds": "A reconfigurar limiares dinâmicos...",
@@ -799,17 +799,17 @@
       "showing": "Mostrando {from} a {to} de {total} resultados"
     },
     "weather": {
-      "title": "Weather Information",
-      "noData": "No weather data",
-      "noDataAvailable": "No weather data available",
-      "loading": "Loading weather information...",
+      "title": "Informações Meteorológicas",
+      "noData": "Sem dados meteorológicos",
+      "noDataAvailable": "Dados meteorológicos indisponíveis",
+      "loading": "A carregar informações meteorológicas...",
       "labels": {
-        "temperature": "Temperature",
-        "weather": "Weather",
-        "wind": "Wind",
-        "humidity": "Humidity",
-        "pressure": "Pressure",
-        "cloudCover": "Cloud Cover"
+        "temperature": "Temperatura",
+        "weather": "Meteorologia",
+        "wind": "Vento",
+        "humidity": "Humidade",
+        "pressure": "Pressão",
+        "cloudCover": "Cobertura de Nuvens"
       },
       "units": {
         "temperature": "°C",
@@ -930,31 +930,31 @@
   },
   "spectrogram": {
     "controls": {
-      "frequencyRange": "Frequency Range",
-      "colorMap": "Color Map",
-      "gain": "Gain",
+      "frequencyRange": "Gama de Frequências",
+      "colorMap": "Mapa de Cores",
+      "gain": "Ganho",
       "gainTooltip": "Ganho de visualização do espectrograma",
       "mute": "Silenciar saída de áudio",
       "unmute": "Ativar saída de áudio",
-      "frequencyRangeMin": "Minimum frequency",
-      "frequencyRangeMax": "Maximum frequency"
+      "frequencyRangeMin": "Frequência mínima",
+      "frequencyRangeMax": "Frequência máxima"
     },
     "error": {
-      "unsupported": "Your browser does not support audio analysis",
-      "connectionFailed": "Failed to connect to live audio stream",
-      "accessDenied": "Live audio access requires authentication. Please log in to use this feature."
+      "unsupported": "O seu navegador não suporta análise de áudio",
+      "connectionFailed": "Falha ao ligar à transmissão de áudio em direto",
+      "accessDenied": "O acesso ao áudio em direto requer autenticação. Por favor, inicie sessão para utilizar esta funcionalidade."
     },
     "dashboard": {
-      "toggle": "Live Spectrogram",
-      "audioToggle": "Enable audio"
+      "toggle": "Espectrograma em Direto",
+      "audioToggle": "Ativar áudio"
     },
     "gain": {
       "muted": "Silenciado",
       "level": "Ganho: {value} dB"
     },
     "page": {
-      "title": "Live Audio",
-      "sourceLabel": "Audio Source",
+      "title": "Áudio em Direto",
+      "sourceLabel": "Fonte de Áudio",
       "connected": "Conectado",
       "enterFullscreen": "Tela cheia",
       "exitFullscreen": "Sair da tela cheia"
@@ -962,7 +962,7 @@
     "colorMaps": {
       "inferno": "Inferno",
       "viridis": "Viridis",
-      "grayscale": "Grayscale"
+      "grayscale": "Escala de Cinzentos"
     },
     "labels": {
       "toggle": "Alternar rótulos de deteção"
@@ -1287,82 +1287,82 @@
         "fetchFailed": "Falha ao obter estatísticas da base de dados"
       },
       "dashboard": {
-        "title": "Database Dashboard",
-        "fetchFailed": "Failed to fetch database overview",
+        "title": "Painel da Base de Dados",
+        "fetchFailed": "Falha ao obter visão geral da base de dados",
         "metrics": {
-          "readLatency": "Read Latency",
-          "writeLatency": "Write Latency",
-          "queriesPerSec": "Queries/sec",
-          "database": "Database",
-          "avg": "avg",
-          "max": "max",
-          "lastHour": "{count} last hour",
-          "slowQueries": "{count} slow"
+          "readLatency": "Latência de Leitura",
+          "writeLatency": "Latência de Escrita",
+          "queriesPerSec": "Consultas/seg",
+          "database": "Base de Dados",
+          "avg": "méd",
+          "max": "máx",
+          "lastHour": "{count} última hora",
+          "slowQueries": "{count} lentas"
         },
         "details": {
-          "title": "Database Details",
-          "engine": "Engine",
-          "journal": "Journal",
-          "pageSize": "Page size",
-          "cacheHit": "Cache hit",
-          "integrity": "Integrity",
-          "lastVacuum": "Last VACUUM"
+          "title": "Detalhes da Base de Dados",
+          "engine": "Motor",
+          "journal": "Diário",
+          "pageSize": "Tamanho da página",
+          "cacheHit": "Acerto de cache",
+          "integrity": "Integridade",
+          "lastVacuum": "Último VACUUM"
         },
         "locksWal": {
-          "title": "Locks & WAL",
-          "lockWaits": "Lock waits",
-          "lockTimeouts": "Lock timeouts",
-          "avgWait": "Avg wait",
-          "busyTimeouts": "Busy timeouts",
-          "walSize": "WAL size",
+          "title": "Bloqueios e WAL",
+          "lockWaits": "Esperas por bloqueio",
+          "lockTimeouts": "Timeouts de bloqueio",
+          "avgWait": "Espera média",
+          "busyTimeouts": "Timeouts de ocupado",
+          "walSize": "Tamanho WAL",
           "checkpoints": "Checkpoints",
-          "freelistPages": "Freelist pages",
-          "cacheSize": "Cache size"
+          "freelistPages": "Páginas livres",
+          "cacheSize": "Tamanho da cache"
         },
         "connectionPool": {
-          "title": "Connection Pool",
-          "poolUsage": "Pool Usage",
-          "active": "active",
-          "idle": "idle",
-          "waiting": "waiting",
-          "totalCreated": "Total created",
-          "connErrors": "Conn errors",
+          "title": "Pool de Ligações",
+          "poolUsage": "Utilização do Pool",
+          "active": "ativas",
+          "idle": "inativas",
+          "waiting": "em espera",
+          "totalCreated": "Total criadas",
+          "connErrors": "Erros de ligação",
           "threads": "Threads",
-          "running": "running",
-          "cached": "cached"
+          "running": "em execução",
+          "cached": "em cache"
         },
         "innodb": {
-          "title": "InnoDB & Locks",
-          "bufferPoolHitRate": "Buffer pool hit rate",
-          "bufferPoolSize": "Buffer pool size",
-          "lockWaits": "Lock waits",
+          "title": "InnoDB e Bloqueios",
+          "bufferPoolHitRate": "Taxa de acerto do buffer pool",
+          "bufferPoolSize": "Tamanho do buffer pool",
+          "lockWaits": "Esperas por bloqueio",
           "deadlocks": "Deadlocks",
-          "avgLockWait": "Avg lock wait",
-          "tableLocksWaited": "Table locks waited",
-          "tableLocksImmediate": "Table locks immediate"
+          "avgLockWait": "Espera média por bloqueio",
+          "tableLocksWaited": "Bloqueios de tabela esperados",
+          "tableLocksImmediate": "Bloqueios de tabela imediatos"
         },
         "detectionRate": {
-          "title": "Detection Rate (24h)",
-          "perHour": "/hr",
-          "min": "min",
-          "avg": "avg",
-          "max": "max",
-          "lastBackup": "Last backup",
-          "backupSize": "Backup size",
-          "createBackup": "Create Backup",
+          "title": "Taxa de Deteção (24h)",
+          "perHour": "/h",
+          "min": "mín",
+          "avg": "méd",
+          "max": "máx",
+          "lastBackup": "Última cópia de segurança",
+          "backupSize": "Tamanho da cópia",
+          "createBackup": "Criar Cópia de Segurança",
           "mysqlHost": "Host",
           "mysqlBackupNote": "Os backups do MySQL devem ser geridos através do mysqldump ou das suas ferramentas de administração MySQL.",
           "chartLabel": "Taxa de detecção nas últimas 24 horas",
           "detectionsTooltip": "{count} detecções"
         },
         "tables": {
-          "title": "Tables",
+          "title": "Tabelas",
           "total": "Total",
-          "table": "Table",
-          "engine": "Engine",
-          "rows": "Rows",
-          "size": "Size",
-          "usage": "Usage"
+          "table": "Tabela",
+          "engine": "Motor",
+          "rows": "Linhas",
+          "size": "Tamanho",
+          "usage": "Utilização"
         },
         "loading": "Carregando..."
       },
@@ -1385,7 +1385,7 @@
             "date": "Data",
             "database": "Banco de dados",
             "size": "Tamanho",
-            "status": "Status",
+            "status": "Estado",
             "actions": "Ações"
           },
           "status": {
@@ -2371,7 +2371,7 @@
               "label": "Autenticação",
               "none": "Nenhuma",
               "bearer": "Token Bearer",
-              "basic": "Basic Auth",
+              "basic": "Autenticação Básica",
               "helpText": "Autenticação opcional para o endpoint do webhook"
             },
             "bearerToken": {
@@ -2753,7 +2753,7 @@
         "noStreamsConfigured": "Nenhum fluxo configurado"
       },
       "streams": {
-        "streamLabel": "Stream",
+        "streamLabel": "Transmissão",
         "nameLabel": "Nome do Stream",
         "namePlaceholder": "ex. Comedouro do Jardim",
         "nameHelp": "Um nome descritivo para identificar este stream de áudio",
@@ -2877,29 +2877,29 @@
           "skipVerify": "Ignorar verificação de certificado",
           "configNote": "<strong>Configuração TLS:</strong><br />• TLS padrão: Deixe os certificados vazios para brokers públicos<br />• Certificados autoassinados: Forneça o certificado CA<br />• TLS mútuo (mTLS): Forneça todos os três certificados",
           "certificates": {
-            "title": "Certificate Management",
-            "description": "Upload certificates for secure MQTT broker connections",
-            "caLabel": "CA Certificate",
+            "title": "Gestão de Certificados",
+            "description": "Carregar certificados para ligações seguras ao broker MQTT",
+            "caLabel": "Certificado CA",
             "caPlaceholder": "-----BEGIN CERTIFICATE-----",
-            "caHelpText": "Certificate Authority certificate to verify the broker's identity",
-            "clientCertLabel": "Client Certificate",
+            "caHelpText": "Certificado da Autoridade Certificadora para verificar a identidade do broker",
+            "clientCertLabel": "Certificado do Cliente",
             "clientCertPlaceholder": "-----BEGIN CERTIFICATE-----",
-            "clientCertHelpText": "Client certificate for mutual TLS authentication",
-            "clientKeyLabel": "Client Private Key",
+            "clientCertHelpText": "Certificado do cliente para autenticação TLS mútua",
+            "clientKeyLabel": "Chave Privada do Cliente",
             "clientKeyPlaceholder": "-----BEGIN PRIVATE KEY-----",
-            "clientKeyHelpText": "Private key matching the client certificate",
-            "uploadButton": "Upload Certificates",
-            "uploadSuccess": "MQTT TLS certificates uploaded successfully. Use Test Connection to verify.",
-            "uploadError": "Failed to upload MQTT TLS certificates",
-            "deleteConfirm": "Remove all MQTT TLS certificates? The MQTT client will need to reconnect.",
-            "deleteSuccess": "MQTT TLS certificates removed",
-            "deleteError": "Failed to remove MQTT TLS certificates",
-            "loadError": "Failed to load certificate information",
-            "reconnectNote": "Use the Test Connection button below to verify the new TLS configuration."
+            "clientKeyHelpText": "Chave privada correspondente ao certificado do cliente",
+            "uploadButton": "Carregar Certificados",
+            "uploadSuccess": "Certificados TLS MQTT carregados com sucesso. Use Testar Ligação para verificar.",
+            "uploadError": "Falha ao carregar certificados TLS MQTT",
+            "deleteConfirm": "Remover todos os certificados TLS MQTT? O cliente MQTT terá de reconectar.",
+            "deleteSuccess": "Certificados TLS MQTT removidos",
+            "deleteError": "Falha ao remover certificados TLS MQTT",
+            "loadError": "Falha ao carregar informações do certificado",
+            "reconnectNote": "Use o botão Testar Ligação abaixo para verificar a nova configuração TLS."
           }
         },
         "homeAssistant": {
-          "title": "Home Assistant Auto-Discovery",
+          "title": "Descoberta Automática do Home Assistant",
           "enable": "Ativar Home Assistant MQTT Discovery",
           "description": "Quando ativado, o BirdNET-Go registra automaticamente dispositivos e sensores no Home Assistant através do protocolo de descoberta MQTT. Os dispositivos aparecerão no registro de dispositivos do Home Assistant sem configuração YAML manual.",
           "discoveryPrefix": {
@@ -3039,14 +3039,14 @@
           "helpText": "Quanto tempo manter os dados taxonómicos do eBird em cache. A taxonomia muda raramente, portanto durações mais longas reduzem as chamadas à API."
         },
         "note": "O eBird fornece dados taxonómicos utilizados para classificação de espécies e análises. A chave API é gratuita e pode ser obtida no Cornell Lab of Ornithology.",
-        "apiKeyInfo": "A personal eBird API key is required to use this integration. You can request a free key from <a href=\"https://ebird.org/api/keygen\" class=\"link link-primary\" target=\"_blank\" rel=\"noopener noreferrer\">ebird.org/api/keygen</a>.",
+        "apiKeyInfo": "É necessária uma chave API pessoal do eBird para utilizar esta integração. Pode solicitar uma chave gratuita em <a href=\"https://ebird.org/api/keygen\" class=\"link link-primary\" target=\"_blank\" rel=\"noopener noreferrer\">ebird.org/api/keygen</a>.",
         "test": {
-          "button": "Test eBird Connection",
-          "loading": "Testing...",
-          "enabledRequired": "Enable eBird integration first",
-          "apiKeyRequired": "API key is required",
-          "inProgress": "Test in progress...",
-          "description": "Test eBird API connectivity and authentication"
+          "button": "Testar Ligação eBird",
+          "loading": "A testar...",
+          "enabledRequired": "Ative primeiro a integração eBird",
+          "apiKeyRequired": "Chave API é obrigatória",
+          "inProgress": "Teste em curso...",
+          "description": "Testar conectividade e autenticação da API eBird"
         }
       }
     },
@@ -3210,8 +3210,8 @@
             "source": "Fonte",
             "clearParameters": "Limpar parâmetros"
           },
-          "placeholder": "Click buttons below to add parameters or type manually",
-          "tooltip": "Use buttons below or type directly (comma-separated)"
+          "placeholder": "Clique nos botões abaixo para adicionar parâmetros ou escreva manualmente",
+          "tooltip": "Use os botões abaixo ou escreva diretamente (separados por vírgula)"
         },
         "executeDefaults": {
           "label": "Também executar ações padrão (armazenamento em banco de dados, notificações, etc.)",
@@ -3363,7 +3363,7 @@
         "expand": "Mostrar histórico de eventos",
         "collapse": "Ocultar histórico de eventos"
       },
-      "suggestions": "Species suggestions"
+      "suggestions": "Sugestões de espécies"
     },
     "security": {
       "pageLabel": "Configurações de segurança",
@@ -3472,22 +3472,22 @@
           "userIdLabel": "ID do usuário"
         },
         "oidc": {
-          "title": "OIDC Provider",
-          "enableLabel": "Enable OIDC authentication",
-          "redirectUriTitle": "Redirect URI",
-          "getCredentialsLabel": "Configure in your Identity Provider",
+          "title": "Fornecedor OIDC",
+          "enableLabel": "Ativar autenticação OIDC",
+          "redirectUriTitle": "URI de Redirecionamento",
+          "getCredentialsLabel": "Configurar no seu Fornecedor de Identidade",
           "clientIdLabel": "Client ID",
-          "clientIdHelpText": "The client ID from your OIDC identity provider",
+          "clientIdHelpText": "O client ID do seu fornecedor de identidade OIDC",
           "clientSecretLabel": "Client Secret",
-          "clientSecretHelpText": "The client secret from your OIDC identity provider",
-          "userIdLabel": "Allowed User (email or sub claim)",
-          "issuerUrlLabel": "Issuer URL",
-          "issuerUrlHelpText": "The issuer URL of your OpenID Connect identity provider (e.g., https://auth.example.com)",
+          "clientSecretHelpText": "O client secret do seu fornecedor de identidade OIDC",
+          "userIdLabel": "Utilizador Permitido (email ou sub claim)",
+          "issuerUrlLabel": "URL do Emissor",
+          "issuerUrlHelpText": "O URL do emissor do seu fornecedor de identidade OpenID Connect (ex: https://auth.example.com)",
           "issuerUrlPlaceholder": "https://auth.example.com",
-          "issuerUrlRequired": "Issuer URL is required for OIDC providers",
-          "issuerUrlInvalid": "Issuer URL must be a valid HTTP or HTTPS URL",
+          "issuerUrlRequired": "O URL do emissor é obrigatório para fornecedores OIDC",
+          "issuerUrlInvalid": "O URL do emissor deve ser um URL HTTP ou HTTPS válido",
           "scopesLabel": "Scopes",
-          "scopesHelpText": "Comma-separated list of OIDC scopes (default: openid, profile, email)",
+          "scopesHelpText": "Lista de scopes OIDC separados por vírgula (padrão: openid, profile, email)",
           "scopesPlaceholder": "openid, profile, email"
         }
       },
@@ -3497,14 +3497,14 @@
         "disabled": "Bypass de sub-rede está desativado"
       },
       "exceptions": {
-        "title": "Exceptions"
+        "title": "Exceções"
       },
       "publicAccess": {
-        "title": "Public Access",
-        "description": "Allow specific features to be accessible without authentication.",
-        "liveAudioLabel": "Allow public live audio playback",
-        "liveAudioHelp": "When enabled, anyone can listen to live audio streams without logging in. Settings and deletion still require authentication.",
-        "warningText": "Enabling public access features exposes them to anyone who can reach this server. Only enable if you trust your network environment."
+        "title": "Acesso Público",
+        "description": "Permitir que funcionalidades específicas fiquem acessíveis sem autenticação.",
+        "liveAudioLabel": "Permitir reprodução pública de áudio em direto",
+        "liveAudioHelp": "Quando ativado, qualquer pessoa pode ouvir transmissões de áudio em direto sem iniciar sessão. Definições e eliminação continuam a requerer autenticação.",
+        "warningText": "Ativar funcionalidades de acesso público expõe-nas a qualquer pessoa que consiga aceder a este servidor. Ative apenas se confia no seu ambiente de rede."
       },
       "baseUrlLabel": "URL Base",
       "baseUrlHelp": "URL externa completa para configurações de proxy reverso. Quando definida, esta URL é usada como está para notificações e redirecionamentos OAuth, ignorando as configurações de Host e AutoTLS.",
@@ -3534,64 +3534,64 @@
       },
       "tls": {
         "title": "TLS / HTTPS",
-        "description": "Configure TLS/HTTPS encryption for secure connections",
-        "modeLabel": "TLS Mode",
-        "modeNone": "None (HTTP)",
+        "description": "Configurar encriptação TLS/HTTPS para ligações seguras",
+        "modeLabel": "Modo TLS",
+        "modeNone": "Nenhum (HTTP)",
         "modeLetsEncrypt": "Let's Encrypt",
-        "modeManual": "Manual Certificate",
-        "modeSelfSigned": "Self-Signed",
-        "modeNoneDescription": "Plain HTTP without encryption",
-        "modeAutoTLSDescription": "Automatic certificate via Let's Encrypt",
-        "modeManualDescription": "Upload your own certificate and key",
-        "modeSelfSignedDescription": "Generate a self-signed certificate",
-        "portLabel": "HTTPS Port",
-        "portHelpText": "Port for HTTPS connections (default: 8443)",
-        "redirectToHttps": "Redirect HTTP to HTTPS",
-        "autoTLSRequirements": "Requires ports 80 and 443 to be accessible. On Linux, the process needs root or CAP_NET_BIND_SERVICE capability.",
-        "validityLabel": "Certificate Validity",
-        "validityHelpText": "How long the certificate should be valid",
-        "validity365d": "1 year",
-        "validity730d": "2 years",
-        "generateButton": "Generate Certificate",
-        "regenerateButton": "Regenerate Certificate",
-        "generating": "Generating...",
-        "certificateLabel": "Certificate (PEM)",
-        "privateKeyLabel": "Private Key (PEM)",
-        "caCertificateLabel": "CA Certificate (PEM, optional)",
-        "uploadButton": "Upload Certificate",
-        "uploading": "Uploading...",
-        "browseFile": "Browse...",
-        "plaintextWarning": "Warning: Your private key will be transmitted in plaintext over HTTP. Only upload certificates when connected via a trusted network or localhost.",
-        "certificateInstalled": "Installed Certificate",
-        "subject": "Subject",
-        "issuer": "Issuer",
-        "validFrom": "Valid From",
-        "validUntil": "Valid Until",
-        "daysRemaining": "Days Remaining",
-        "sans": "Subject Alternative Names",
-        "fingerprint": "Fingerprint",
-        "expiryWarning": "Certificate is expiring soon",
-        "loading": "Loading certificate info...",
-        "loadError": "Failed to load certificate info",
-        "generateSuccess": "Self-signed certificate generated successfully",
-        "generateError": "Failed to generate certificate",
-        "uploadSuccess": "Certificate uploaded successfully",
-        "uploadError": "Failed to upload certificate",
-        "deleteSuccess": "Certificate removed successfully",
-        "deleteError": "Failed to delete certificate",
-        "removeCertificate": "Remove Certificate",
-        "deleteConfirm": "Are you sure you want to remove the installed TLS certificate? The TLS mode will be reset to None.",
-        "restartRequired": "TLS changes require a server restart to take effect.",
-        "noCertificate": "No certificate installed",
-        "validity1825d": "5 years",
-        "autoTLSHostRequired": "A hostname is required for Let’s Encrypt. Enter your public domain name in the Host field above.",
-        "autoTLSNoIP": "Let’s Encrypt requires a domain name, not an IP address. Enter a public domain like birds.example.com.",
-        "autoTLSNeedsFQDN": "Let’s Encrypt requires a fully qualified domain name (e.g., birds.example.com), not a bare hostname.",
-        "autoTLSNoLocalhost": "Let’s Encrypt cannot issue certificates for localhost.",
-        "autoTLSPrivateTLD": "Let’s Encrypt cannot issue certificates for private domains ({tld} is not publicly resolvable).",
-        "downloadCertificate": "Download Certificate",
-        "downloadCertificateHelp": "Install this certificate in your operating system's trust store to avoid browser security warnings.",
-        "fileReadError": "Failed to read the selected file"
+        "modeManual": "Certificado Manual",
+        "modeSelfSigned": "Auto-assinado",
+        "modeNoneDescription": "HTTP simples sem encriptação",
+        "modeAutoTLSDescription": "Certificado automático via Let's Encrypt",
+        "modeManualDescription": "Carregar o seu próprio certificado e chave",
+        "modeSelfSignedDescription": "Gerar um certificado auto-assinado",
+        "portLabel": "Porta HTTPS",
+        "portHelpText": "Porta para ligações HTTPS (padrão: 8443)",
+        "redirectToHttps": "Redirecionar HTTP para HTTPS",
+        "autoTLSRequirements": "Requer que as portas 80 e 443 estejam acessíveis. No Linux, o processo necessita de root ou capacidade CAP_NET_BIND_SERVICE.",
+        "validityLabel": "Validade do Certificado",
+        "validityHelpText": "Durante quanto tempo o certificado deve ser válido",
+        "validity365d": "1 ano",
+        "validity730d": "2 anos",
+        "generateButton": "Gerar Certificado",
+        "regenerateButton": "Regenerar Certificado",
+        "generating": "A gerar...",
+        "certificateLabel": "Certificado (PEM)",
+        "privateKeyLabel": "Chave Privada (PEM)",
+        "caCertificateLabel": "Certificado CA (PEM, opcional)",
+        "uploadButton": "Carregar Certificado",
+        "uploading": "A carregar...",
+        "browseFile": "Procurar...",
+        "plaintextWarning": "Aviso: A sua chave privada será transmitida em texto simples via HTTP. Carregue certificados apenas quando ligado através de uma rede de confiança ou localhost.",
+        "certificateInstalled": "Certificado Instalado",
+        "subject": "Sujeito",
+        "issuer": "Emissor",
+        "validFrom": "Válido Desde",
+        "validUntil": "Válido Até",
+        "daysRemaining": "Dias Restantes",
+        "sans": "Nomes Alternativos do Sujeito",
+        "fingerprint": "Impressão Digital",
+        "expiryWarning": "O certificado está prestes a expirar",
+        "loading": "A carregar informações do certificado...",
+        "loadError": "Falha ao carregar informações do certificado",
+        "generateSuccess": "Certificado auto-assinado gerado com sucesso",
+        "generateError": "Falha ao gerar certificado",
+        "uploadSuccess": "Certificado carregado com sucesso",
+        "uploadError": "Falha ao carregar certificado",
+        "deleteSuccess": "Certificado removido com sucesso",
+        "deleteError": "Falha ao eliminar certificado",
+        "removeCertificate": "Remover Certificado",
+        "deleteConfirm": "Tem a certeza de que pretende remover o certificado TLS instalado? O modo TLS será reposto para Nenhum.",
+        "restartRequired": "As alterações TLS requerem um reinício do servidor para terem efeito.",
+        "noCertificate": "Nenhum certificado instalado",
+        "validity1825d": "5 anos",
+        "autoTLSHostRequired": "É necessário um nome de host para o Let's Encrypt. Introduza o seu nome de domínio público no campo Host acima.",
+        "autoTLSNoIP": "O Let's Encrypt requer um nome de domínio, não um endereço IP. Introduza um domínio público como birds.example.com.",
+        "autoTLSNeedsFQDN": "O Let's Encrypt requer um nome de domínio totalmente qualificado (ex: birds.example.com), não um nome de host simples.",
+        "autoTLSNoLocalhost": "O Let's Encrypt não pode emitir certificados para localhost.",
+        "autoTLSPrivateTLD": "O Let's Encrypt não pode emitir certificados para domínios privados ({tld} não é resolúvel publicamente).",
+        "downloadCertificate": "Transferir Certificado",
+        "downloadCertificateHelp": "Instale este certificado no armazenamento de confiança do seu sistema operativo para evitar avisos de segurança do navegador.",
+        "fileReadError": "Falha ao ler o ficheiro selecionado"
       }
     },
     "database": {
@@ -3838,7 +3838,7 @@
         "appearance": "Aparência",
         "language": "Idioma e regional",
         "visualContent": "Conteúdo visual",
-        "audioPlayback": "Audio Playback"
+        "audioPlayback": "Reprodução de Áudio"
       },
       "appearance": {
         "title": "Aparência",
@@ -3853,14 +3853,14 @@
         "description": "Configure imagens de aves e configurações de exibição do espectrograma"
       },
       "audioPlayback": {
-        "title": "Audio Playback",
-        "description": "Default settings for playing bird recordings.",
-        "defaultGain": "Default Volume Boost",
-        "defaultGainHelpText": "Initial gain applied when playing recordings. Bird sounds are often quiet, so a boost of 6-12 dB is recommended.",
+        "title": "Reprodução de Áudio",
+        "description": "Definições padrão para reprodução de gravações de aves.",
+        "defaultGain": "Amplificação de Volume Padrão",
+        "defaultGainHelpText": "Ganho inicial aplicado ao reproduzir gravações. Os sons de aves são frequentemente baixos, pelo que um reforço de 6-12 dB é recomendado.",
         "defaultGainUnit": "dB"
       }
     },
-    "restartRequired": "Some changes require a server restart to take effect. Please restart BirdNET-Go."
+    "restartRequired": "Algumas alterações requerem um reinício do servidor para terem efeito. Por favor, reinicie o BirdNET-Go."
   },
   "auth": {
     "login": "Entrar",
@@ -3881,7 +3881,7 @@
     "continueWithMicrosoft": "Continuar com Microsoft",
     "continueWithLine": "Continuar com LINE",
     "continueWithKakao": "Continuar com Kakao",
-    "continueWithOidc": "Continue with OIDC",
+    "continueWithOidc": "Continuar com OIDC",
     "errors": {
       "loginFailed": "Falha no login. Por favor, verifique sua senha e tente novamente.",
       "passwordRequired": "A senha é obrigatória.",
@@ -4029,7 +4029,7 @@
       "seekProgress": "Progresso de busca de áudio: {current} / {total} segundos",
       "playbackSpeed": "Velocidade de reprodução",
       "speed": "Velocidade",
-      "loop": "Toggle loop",
+      "loop": "Alternar repetição",
       "player": "Reprodutor de áudio"
     },
     "spectrogram": {
@@ -4108,36 +4108,36 @@
         "spectrogramFailed": "Falha ao gerar o espectrograma"
       },
       "clipExtraction": {
-        "selectRange": "Click and drag to select a range",
-        "playSelection": "Play selected range",
-        "pauseSelection": "Pause playback",
-        "reviewSelection": "Jump to start of selection",
-        "selectionStart": "Selection start handle",
-        "selectionEnd": "Selection end handle",
-        "lossless": "Lossless",
-        "lossy": "Lossy",
-        "extractClip": "Download selected clip",
-        "clearSelection": "Clear selection",
-        "extracting": "Extracting clip...",
-        "extractError": "Failed to extract clip",
-        "formatLabel": "Format",
+        "selectRange": "Clique e arraste para selecionar um intervalo",
+        "playSelection": "Reproduzir intervalo selecionado",
+        "pauseSelection": "Pausar reprodução",
+        "reviewSelection": "Saltar para o início da seleção",
+        "selectionStart": "Pega de início da seleção",
+        "selectionEnd": "Pega de fim da seleção",
+        "lossless": "Sem perdas",
+        "lossy": "Com perdas",
+        "extractClip": "Transferir clip selecionado",
+        "clearSelection": "Limpar seleção",
+        "extracting": "A extrair clip...",
+        "extractError": "Falha ao extrair clip",
+        "formatLabel": "Formato",
         "rangeLabel": "{start}s – {end}s"
       },
       "processing": {
-        "playSelection": "Play selection",
-        "skipToStart": "Skip to selection start",
-        "clearSelection": "Clear selection",
-        "gain": "Gain (dB)",
-        "denoise": "Denoise",
-        "denoiseOff": "Off",
-        "denoiseLight": "Light",
-        "denoiseMedium": "Medium",
-        "denoiseHeavy": "Heavy",
-        "normalize": "Normalize audio",
-        "normalizeTooltip": "EBU R128 Normalization",
-        "export": "Export",
+        "playSelection": "Reproduzir seleção",
+        "skipToStart": "Saltar para o início da seleção",
+        "clearSelection": "Limpar seleção",
+        "gain": "Ganho (dB)",
+        "denoise": "Remover ruído",
+        "denoiseOff": "Desligado",
+        "denoiseLight": "Ligeiro",
+        "denoiseMedium": "Médio",
+        "denoiseHeavy": "Intenso",
+        "normalize": "Normalizar áudio",
+        "normalizeTooltip": "Normalização EBU R128",
+        "export": "Exportar",
         "exportOriginal": "Original",
-        "processingActive": "Processing active"
+        "processingActive": "Processamento ativo"
       }
     },
     "weatherInfo": {
@@ -4146,20 +4146,20 @@
       }
     },
     "tls": {
-      "certificateInstalled": "Certificate Installed",
-      "browseFile": "Browse",
-      "subject": "Subject",
-      "issuer": "Issuer",
-      "sans": "Subject Alternative Names",
-      "validUntil": "Valid Until",
-      "daysRemaining": "Days Remaining",
-      "fingerprint": "Fingerprint",
-      "expiryWarning": "This certificate expires soon. Consider renewing it.",
-      "downloadCertificate": "Download Certificate",
-      "regenerateButton": "Regenerate",
-      "removeCertificate": "Remove Certificate",
-      "fileReadError": "Failed to read file",
-      "loading": "Loading certificate information..."
+      "certificateInstalled": "Certificado Instalado",
+      "browseFile": "Procurar",
+      "subject": "Sujeito",
+      "issuer": "Emissor",
+      "sans": "Nomes Alternativos do Sujeito",
+      "validUntil": "Válido Até",
+      "daysRemaining": "Dias Restantes",
+      "fingerprint": "Impressão Digital",
+      "expiryWarning": "Este certificado expira em breve. Considere renová-lo.",
+      "downloadCertificate": "Transferir Certificado",
+      "regenerateButton": "Regenerar",
+      "removeCertificate": "Remover Certificado",
+      "fileReadError": "Falha ao ler ficheiro",
+      "loading": "A carregar informações do certificado..."
     }
   },
   "connectivity": {
@@ -4332,77 +4332,77 @@
     },
     "steps": {
       "welcome": {
-        "title": "Welcome",
-        "heading": "Welcome to BirdNET-Go!",
-        "description": "BirdNET-Go is a real-time bird sound identification system. It listens to audio from your microphone or audio stream and uses the BirdNET AI model to identify bird species.",
-        "credit": "Powered by the BirdNET Analyzer developed by the K. Lisa Yang Center for Conservation Bioacoustics at the Cornell Lab of Ornithology and Chemnitz University of Technology.",
-        "cta": "Let's set up your bird monitoring station."
+        "title": "Bem-vindo",
+        "heading": "Bem-vindo ao BirdNET-Go!",
+        "description": "O BirdNET-Go é um sistema de identificação de sons de aves em tempo real. Escuta o áudio do seu microfone ou transmissão de áudio e utiliza o modelo de IA BirdNET para identificar espécies de aves.",
+        "credit": "Alimentado pelo BirdNET Analyzer, desenvolvido pelo K. Lisa Yang Center for Conservation Bioacoustics no Cornell Lab of Ornithology e pela Chemnitz University of Technology.",
+        "cta": "Vamos configurar a sua estação de monitorização de aves."
       },
       "locationLanguage": {
-        "title": "Location & Language",
-        "uiLanguageLabel": "Interface Language",
-        "uiLanguageHelp": "Language used for the web interface",
-        "speciesLanguageLabel": "Species Name Language",
-        "speciesLanguageHelp": "Language used for bird species names in detections",
-        "locationLabel": "Station Location",
-        "locationHelp": "Your location helps filter species to those likely in your area",
+        "title": "Localização e Idioma",
+        "uiLanguageLabel": "Idioma da Interface",
+        "uiLanguageHelp": "Idioma utilizado na interface web",
+        "speciesLanguageLabel": "Idioma dos Nomes de Espécies",
+        "speciesLanguageHelp": "Idioma utilizado para os nomes das espécies de aves nas deteções",
+        "locationLabel": "Localização da Estação",
+        "locationHelp": "A sua localização ajuda a filtrar espécies prováveis na sua área",
         "latitudeLabel": "Latitude",
         "longitudeLabel": "Longitude",
-        "useMyLocation": "Use my location",
-        "locationDetected": "Location detected",
-        "locationError": "Could not detect location. Please enter coordinates manually.",
-        "locationDenied": "Location access denied. Please enter coordinates manually."
+        "useMyLocation": "Usar a minha localização",
+        "locationDetected": "Localização detetada",
+        "locationError": "Não foi possível detetar a localização. Por favor, introduza as coordenadas manualmente.",
+        "locationDenied": "Acesso à localização negado. Por favor, introduza as coordenadas manualmente."
       },
       "audioSource": {
-        "title": "Audio Source",
-        "sourceTypeLabel": "Source Type",
-        "soundcard": "Microphone / Soundcard",
-        "rtspStream": "RTSP Stream",
-        "deviceLabel": "Audio Device",
-        "deviceLoading": "Loading audio devices...",
-        "noDevicesFound": "No audio devices detected. Try configuring an RTSP stream instead.",
-        "rtspUrlLabel": "Stream URL",
+        "title": "Fonte de Áudio",
+        "sourceTypeLabel": "Tipo de Fonte",
+        "soundcard": "Microfone / Placa de Som",
+        "rtspStream": "Transmissão RTSP",
+        "deviceLabel": "Dispositivo de Áudio",
+        "deviceLoading": "A carregar dispositivos de áudio...",
+        "noDevicesFound": "Nenhum dispositivo de áudio detetado. Tente configurar uma transmissão RTSP em alternativa.",
+        "rtspUrlLabel": "URL da Transmissão",
         "rtspUrlPlaceholder": "rtsp://user:password@host:port/stream",
-        "rtspUrlHelp": "Enter the URL of your RTSP audio stream",
-        "additionalSourcesHint": "You can add more audio sources later in Settings."
+        "rtspUrlHelp": "Introduza o URL da sua transmissão de áudio RTSP",
+        "additionalSourcesHint": "Pode adicionar mais fontes de áudio posteriormente nas Definições."
       },
       "detection": {
-        "title": "Detection Threshold",
-        "description": "Choose how strict the bird identification should be. You can adjust this later in Settings.",
-        "balanced": "Balanced",
-        "balancedDesc": "Good balance of accuracy and sensitivity",
-        "balancedRecommended": "Recommended",
-        "highAccuracy": "High Accuracy",
-        "highAccuracyDesc": "Fewer false positives, may miss some birds",
-        "highSensitivity": "High Sensitivity",
-        "highSensitivityDesc": "More detections, more false positives",
-        "threshold": "Confidence threshold",
-        "fpFilterNote": "Once your system is running and proven, you can enable the false positive filter in Settings to further reduce incorrect detections."
+        "title": "Limiar de Deteção",
+        "description": "Escolha quão rigorosa deve ser a identificação de aves. Pode ajustar isto posteriormente nas Definições.",
+        "balanced": "Equilibrado",
+        "balancedDesc": "Bom equilíbrio entre precisão e sensibilidade",
+        "balancedRecommended": "Recomendado",
+        "highAccuracy": "Alta Precisão",
+        "highAccuracyDesc": "Menos falsos positivos, pode perder algumas aves",
+        "highSensitivity": "Alta Sensibilidade",
+        "highSensitivityDesc": "Mais deteções, mais falsos positivos",
+        "threshold": "Limiar de confiança",
+        "fpFilterNote": "Quando o seu sistema estiver a funcionar e comprovado, pode ativar o filtro de falsos positivos nas Definições para reduzir ainda mais as deteções incorretas."
       },
       "integration": {
-        "title": "Privacy & Integration",
-        "privacyFilterLabel": "Enable privacy filter",
-        "privacyFilterHelp": "Filters out detections when human voices are detected near the microphone",
-        "birdweatherLabel": "Share detections with BirdWeather",
-        "birdweatherHelp": "Contribute your bird detections to the BirdWeather community network",
-        "birdweatherIdLabel": "BirdWeather Station ID",
-        "birdweatherIdPlaceholder": "Enter your BirdWeather station ID",
-        "errorReportingLabel": "Send anonymous error reports",
-        "errorReportingHelp": "Help improve BirdNET-Go by sending anonymous error reports when something goes wrong"
+        "title": "Privacidade e Integração",
+        "privacyFilterLabel": "Ativar filtro de privacidade",
+        "privacyFilterHelp": "Filtra deteções quando são detetadas vozes humanas perto do microfone",
+        "birdweatherLabel": "Partilhar deteções com o BirdWeather",
+        "birdweatherHelp": "Contribua com as suas deteções de aves para a rede comunitária BirdWeather",
+        "birdweatherIdLabel": "ID da Estação BirdWeather",
+        "birdweatherIdPlaceholder": "Introduza o ID da sua estação BirdWeather",
+        "errorReportingLabel": "Enviar relatórios de erros anónimos",
+        "errorReportingHelp": "Ajude a melhorar o BirdNET-Go enviando relatórios de erros anónimos quando algo corre mal"
       },
       "responsibleUse": {
-        "title": "Using BirdNET-Go Responsibly",
-        "intro": "BirdNET-Go is a powerful tool that enhances your birding experience through AI-assisted identification. To ensure the best outcomes for both birding and conservation:",
-        "point1": "Review and verify detections before sharing observations",
-        "point2": "Use the confidence scores as a guide, not absolute truth",
-        "point3": "Cross-reference with field guides and local expertise",
-        "point4": "Consider seasonal patterns and habitat suitability",
-        "citizenScienceHeading": "When contributing to citizen science:",
-        "citizenPoint1": "Only submit observations you have personally verified",
-        "citizenPoint2": "Include notes about visual or behavioral confirmation",
-        "citizenPoint3": "Use AI detections as a starting point for your own observations",
-        "outro": "This approach ensures data quality for scientific research while maximizing your learning and enjoyment of birds.",
-        "acknowledge": "I understand"
+        "title": "Utilização Responsável do BirdNET-Go",
+        "intro": "O BirdNET-Go é uma ferramenta poderosa que melhora a sua experiência de observação de aves através da identificação assistida por IA. Para garantir os melhores resultados tanto para a observação de aves como para a conservação:",
+        "point1": "Reveja e verifique as deteções antes de partilhar observações",
+        "point2": "Use as pontuações de confiança como guia, não como verdade absoluta",
+        "point3": "Faça referência cruzada com guias de campo e conhecimento local",
+        "point4": "Considere os padrões sazonais e a adequação do habitat",
+        "citizenScienceHeading": "Ao contribuir para a ciência cidadã:",
+        "citizenPoint1": "Submeta apenas observações que verificou pessoalmente",
+        "citizenPoint2": "Inclua notas sobre confirmação visual ou comportamental",
+        "citizenPoint3": "Use as deteções de IA como ponto de partida para as suas próprias observações",
+        "outro": "Esta abordagem garante a qualidade dos dados para investigação científica, maximizando a sua aprendizagem e prazer com as aves.",
+        "acknowledge": "Compreendo"
       }
     }
   },

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -265,7 +265,7 @@
     "unknown": "Neznáme",
     "licenseInformation": "Informácie o licencii",
     "licenseText": "Model BirdNET AI aj BirdNET-Go sú licencované pod",
-    "ccLicense": "Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License",
+    "ccLicense": "Creative Commons Uvedenie autora-Nekomerčné použitie-Zachovanie licencie 4.0 Medzinárodná licencia",
     "licenseDescription": "Táto licencia umožňuje ostatným upravovať, prispôsobovať a stavať na tomto diele nekomerčne, pokiaľ je uvedený náležitý kredit a nové výtvory sú licencované pod identickými podmienkami.",
     "dependencyLicenses": "Licencie závislostí",
     "taxonomyDataTitle": "Taxonomické údaje",
@@ -377,8 +377,8 @@
         "application": "Chyba aplikácie",
         "imageProvider": "Oznámenie poskytovateľa obrázkov",
         "categoryError": "Chyba {category}",
-        "burstTitle": "Multiple {component} errors",
-        "burstMessage": "{count} errors in the last {window_minutes} minutes: {sample_error}"
+        "burstTitle": "Viaceré chyby {component}",
+        "burstMessage": "{count} chýb za posledných {window_minutes} minút: {sample_error}"
       },
       "settings": {
         "reloadingBirdnet": "Aplikovanie nových nastavení analýzy...",
@@ -388,7 +388,7 @@
         "reconfiguringBirdweather": "Aktualizácia integrácie BirdWeather...",
         "reconfiguringStreams": "Aktualizácia audio streamov...",
         "reconfiguringTelemetry": "Aktualizácia nastavení telemetrie...",
-        "reconfiguringPushNotifications": "Reconfiguring push notification providers...",
+        "reconfiguringPushNotifications": "Rekonfigurácia poskytovateľov push notifikácií...",
         "reconfiguringSpeciesTracking": "Aktualizácia sledovania druhov...",
         "recalculatingThresholds": "Prepočítavanie dynamických prahov pre novú základnú hodnotu",
         "reconfiguringDynamicThresholds": "Prekonfigurovanie dynamických prahov...",
@@ -560,7 +560,7 @@
     },
     "generic": {
       "errorDetails": "Podrobnosti o chybe",
-      "stackTrace": "Stack Trace",
+      "stackTrace": "Zásobník volaní",
       "goToDashboard": "Prejsť na prehľad",
       "reportIssue": "Nahlásiť problém",
       "loginToViewDetails": "Prihláste sa pre podrobnosti",
@@ -872,6 +872,11 @@
       "loadFailed": "Nepodarilo sa načítať detekciu (Chyba {status}). Skúste obnoviť stránku.",
       "noIdProvided": "Nebolo poskytnuté žiadne ID detekcie.",
       "fetchFailed": "Nepodarilo sa načítať detekcie"
+    },
+    "viewToggle": {
+      "label": "Režim zobrazenia",
+      "table": "Zobrazenie tabuľky",
+      "cards": "Zobrazenie kariet"
     }
   },
   "species": {
@@ -925,31 +930,31 @@
   },
   "spectrogram": {
     "controls": {
-      "frequencyRange": "Frequency Range",
-      "colorMap": "Color Map",
-      "gain": "Gain",
+      "frequencyRange": "Frekvenčný rozsah",
+      "colorMap": "Farebná mapa",
+      "gain": "Zosilnenie",
       "gainTooltip": "Zosilnenie vizualizácie spektrogramu",
       "mute": "Stlmiť zvukový výstup",
       "unmute": "Zapnúť zvukový výstup",
-      "frequencyRangeMin": "Minimum frequency",
-      "frequencyRangeMax": "Maximum frequency"
+      "frequencyRangeMin": "Minimálna frekvencia",
+      "frequencyRangeMax": "Maximálna frekvencia"
     },
     "error": {
-      "unsupported": "Your browser does not support audio analysis",
-      "connectionFailed": "Failed to connect to live audio stream",
-      "accessDenied": "Live audio access requires authentication. Please log in to use this feature."
+      "unsupported": "Váš prehliadač nepodporuje analýzu zvuku",
+      "connectionFailed": "Nepodarilo sa pripojiť k živému audio streamu",
+      "accessDenied": "Prístup k živému zvuku vyžaduje overenie. Prihláste sa na používanie tejto funkcie."
     },
     "dashboard": {
-      "toggle": "Live Spectrogram",
-      "audioToggle": "Enable audio"
+      "toggle": "Živý spektrogram",
+      "audioToggle": "Povoliť zvuk"
     },
     "gain": {
       "muted": "Stlmené",
       "level": "Zosilnenie: {value} dB"
     },
     "page": {
-      "title": "Live Audio",
-      "sourceLabel": "Audio Source",
+      "title": "Živý zvuk",
+      "sourceLabel": "Zdroj zvuku",
       "connected": "Pripojené",
       "enterFullscreen": "Celá obrazovka",
       "exitFullscreen": "Ukončiť celú obrazovku"
@@ -957,7 +962,7 @@
     "colorMaps": {
       "inferno": "Inferno",
       "viridis": "Viridis",
-      "grayscale": "Grayscale"
+      "grayscale": "Odtiene šedej"
     },
     "labels": {
       "toggle": "Prepnúť štítky detekcie"
@@ -973,7 +978,7 @@
     "systemInfo": {
       "title": "Informácie o systéme",
       "os": "Operačný systém",
-      "hostname": "Hostname",
+      "hostname": "Názov hostiteľa",
       "uptime": "Doba prevádzky",
       "cpus": "Procesory (CPU)",
       "model": "Model systému",
@@ -1088,7 +1093,28 @@
         "creating": "Vytvára sa záloha...",
         "cancel": "Zrušiť",
         "retry": "Skúsiť zálohovanie znova",
-        "mysqlNote": "Záloha MySQL vyžaduje externé nástroje (mysqldump)"
+        "mysqlNote": "Záloha MySQL vyžaduje externé nástroje (mysqldump)",
+        "history": {
+          "title": "História záloh",
+          "creating": "Vytváranie...",
+          "createBackup": "Vytvoriť zálohu",
+          "noBackups": "Zatiaľ žiadne zálohy",
+          "download": "Stiahnuť",
+          "failed": "Zlyhané",
+          "columns": {
+            "date": "Dátum",
+            "database": "Databáza",
+            "size": "Veľkosť",
+            "status": "Stav",
+            "actions": "Akcie"
+          },
+          "status": {
+            "pending": "Čakajúce",
+            "in_progress": "Prebieha",
+            "completed": "Dokončené",
+            "failed": "Zlyhané"
+          }
+        }
       },
       "notInitialized": "Neinicializované",
       "migration": {
@@ -1107,7 +1133,8 @@
           "paused": "Pozastavené",
           "validating": "Overuje sa",
           "cutover": "Prebieha prepnutie",
-          "completed": "Migrácia dokončená"
+          "completed": "Migrácia dokončená",
+          "failed": "Validácia zlyhala"
         },
         "progress": {
           "title": "Priebeh migrácie",
@@ -1118,7 +1145,30 @@
           "rateValue": "{rate} záz./s",
           "remaining": "Odhadovaný zostávajúci čas: {time}",
           "eta": "Odhadovaný zostávajúci čas",
-          "dirtyIds": "{count} záznamov čaká na opätovnú synchronizáciu"
+          "dirtyIds": "{count} záznamov čaká na opätovnú synchronizáciu",
+          "completedTitle": "Migrácia dokončená",
+          "completedBody": "Všetkých {count} záznamov bolo úspešne migrovaných do databázy V2. Aplikácia bude po reštarte používať V2 ako primárnu databázu.",
+          "restartTitle": "Vyžaduje sa reštart",
+          "restartBody": "Reštartujte aplikáciu pre prepnutie na databázu V2. Vyčistenie starej databázy bude dostupné po reštarte.",
+          "fallbackError": "Nesúlad počtu záznamov medzi starou a V2 databázou. Niektoré záznamy sa možno nemigrovali správne.",
+          "migrateInfo": "Migrácia prenesie {count} záznamov zo starej databázy do nového schémy V2. Režim dvojitého zápisu zabezpečuje nulovú stratu dát počas migrácie.",
+          "sourceLegacy": "Zdroj (Legacy)",
+          "targetV2": "Cieľ (V2)",
+          "recordsLabel": "Záznamy",
+          "sizeLabel": "Veľkosť",
+          "prerequisitesNotMet": "Predpoklady nesplnené — vyriešte kritické problémy nižšie",
+          "validatingTitle": "Validácia dát",
+          "validatingBody": "Porovnávanie {count} starých záznamov s databázou V2...",
+          "dirtyRecordsCatchup": "{count} nesynchronizovaných záznamov — bude sa pokúšať o dodatočnú rekonciliáciu",
+          "cutoverTitle": "Dokončovanie prechodu",
+          "cutoverBody": "Dokončovanie prechodu na databázu V2...",
+          "migratingPhase": "Migrácia {phase}",
+          "progressLabel": "Priebeh",
+          "ofRecords": "/ {count} záznamov",
+          "percentComplete": "{percent}% dokončené",
+          "recordsPerSec": "{rate} záznamov/s",
+          "calculating": "Výpočet...",
+          "dirtyWriteFailed": "{count} záznamov sa nepodarilo zapísať — budú zosúladené počas validácie"
         },
         "phase": {
           "indicator": "Fáza {current} z {total}: ",
@@ -1141,7 +1191,8 @@
           "pause": "Pozastaviť",
           "resume": "Pokračovať",
           "cancel": "Zrušiť",
-          "rollback": "Rollback"
+          "rollback": "Vrátenie späť",
+          "retryValidation": "Zopakovať validáciu"
         },
         "confirmDialog": {
           "title": "Spustiť migráciu databázy",
@@ -1167,7 +1218,8 @@
           "resumeFailed": "Nepodarilo sa pokračovať v migrácii",
           "cancelFailed": "Nepodarilo sa zrušiť migráciu",
           "rollbackFailed": "Nepodarilo sa vykonať rollback migrácie",
-          "fetchFailed": "Nepodarilo sa získať stav migrácie"
+          "fetchFailed": "Nepodarilo sa získať stav migrácie",
+          "retryValidationFailed": "Nepodarilo sa zopakovať validáciu"
         },
         "worker": {
           "running": "Worker beží",
@@ -1226,7 +1278,123 @@
             "mysql_timeout": {
               "name": "MySQL Timeout"
             }
+          },
+          "passedCount": "{passed}/{total} úspešných",
+          "criticalCount": "{count} kritických",
+          "warningCount": "{count} upozornení",
+          "rerun": "Spustiť znova",
+          "showDetails": "Zobraziť podrobnosti",
+          "hideDetails": "Skryť podrobnosti",
+          "status": {
+            "passed": "Úspešné",
+            "failed": "Zlyhané",
+            "error": "Chyba",
+            "warning": "Upozornenie",
+            "skipped": "Preskočené"
           }
+        },
+        "details": {
+          "title": "Podrobnosti databázy",
+          "detections": "{count} detekcií",
+          "lastBackup": "Posledná záloha: {date}",
+          "noBackups": "Žiadne zálohy",
+          "integrity": "Integrita: {status}"
+        },
+        "strip": {
+          "legacy": "Legacy",
+          "v2Target": "V2 (Cieľ)",
+          "active": "Aktívny",
+          "migration": "Migrácia",
+          "complete": "Dokončené",
+          "recordsMigrated": "{count} záznamov migrovaných",
+          "readyToMigrate": "Pripravené na migráciu",
+          "recordsInLegacy": "{count} záznamov v legacy",
+          "comparingRecords": "Porovnávanie počtu záznamov...",
+          "validationFailed": "Validácia zlyhala",
+          "rate": "Frekvencia",
+          "recPerSec": "{rate} záz/s",
+          "dayAvg": "~{count} / denný priemer",
+          "dayHistory": "História za 30 dní"
+        }
+      },
+      "dashboard": {
+        "title": "Prehľad databázy",
+        "fetchFailed": "Nepodarilo sa načítať prehľad databázy",
+        "loading": "Načítavanie...",
+        "metrics": {
+          "readLatency": "Latencia čítania",
+          "writeLatency": "Latencia zápisu",
+          "queriesPerSec": "Dotazy/sek",
+          "database": "Databáza",
+          "avg": "priemer",
+          "max": "max",
+          "lastHour": "{count} za poslednú hodinu",
+          "slowQueries": "{count} pomalých"
+        },
+        "details": {
+          "title": "Podrobnosti databázy",
+          "engine": "Motor",
+          "journal": "Denník",
+          "pageSize": "Veľkosť stránky",
+          "cacheHit": "Zásah cache",
+          "integrity": "Integrita",
+          "lastVacuum": "Posledný VACUUM"
+        },
+        "locksWal": {
+          "title": "Zámky a WAL",
+          "lockWaits": "Čakania na zámok",
+          "lockTimeouts": "Časové limity zámkov",
+          "avgWait": "Priemer čakania",
+          "busyTimeouts": "Časové limity zaneprázdnenia",
+          "walSize": "Veľkosť WAL",
+          "checkpoints": "Kontrolné body",
+          "freelistPages": "Stránky voľného zoznamu",
+          "cacheSize": "Veľkosť cache"
+        },
+        "connectionPool": {
+          "title": "Pool pripojení",
+          "poolUsage": "Využitie poolu",
+          "active": "aktívny",
+          "idle": "nečinný",
+          "waiting": "čakajúci",
+          "totalCreated": "Celkom vytvorené",
+          "connErrors": "Chyby pripojenia",
+          "threads": "Vlákna",
+          "running": "beží",
+          "cached": "v cache"
+        },
+        "innodb": {
+          "title": "InnoDB a zámky",
+          "bufferPoolHitRate": "Úspešnosť buffer poolu",
+          "bufferPoolSize": "Veľkosť buffer poolu",
+          "lockWaits": "Čakania na zámok",
+          "deadlocks": "Deadlocky",
+          "avgLockWait": "Priemer čakania na zámok",
+          "tableLocksWaited": "Čakané zámky tabuliek",
+          "tableLocksImmediate": "Okamžité zámky tabuliek"
+        },
+        "detectionRate": {
+          "title": "Miera detekcií (24h)",
+          "chartLabel": "Miera detekcií za 24 hodín",
+          "detectionsTooltip": "{count} detekcií",
+          "perHour": "/hod",
+          "min": "min",
+          "avg": "priemer",
+          "max": "max",
+          "lastBackup": "Posledná záloha",
+          "backupSize": "Veľkosť zálohy",
+          "createBackup": "Vytvoriť zálohu",
+          "mysqlHost": "Hostiteľ",
+          "mysqlBackupNote": "MySQL zálohy by mali byť spravované cez mysqldump alebo vaše MySQL administračné nástroje."
+        },
+        "tables": {
+          "title": "Tabuľky",
+          "total": "Celkom",
+          "table": "Tabuľka",
+          "engine": "Motor",
+          "rows": "Riadky",
+          "size": "Veľkosť",
+          "usage": "Využitie"
         }
       }
     },
@@ -1243,7 +1411,7 @@
       "tempUnavailable": "Nedostupná",
       "online": "Online",
       "uptime": "Doba behu",
-      "host": "Host",
+      "host": "Hostiteľ",
       "model": "Model",
       "limit": "Limit",
       "inference": "Inferencia",
@@ -1431,7 +1599,8 @@
         "startDate": "Dátum začiatku",
         "endDate": "Dátum konca",
         "loadingAnalytics": "Načítavajú sa analytické dáta",
-        "loadingTrends": "Načítavajú sa dáta trendov"
+        "loadingTrends": "Načítavajú sa dáta trendov",
+        "loadingDiversity": "Načítavanie dát o diverzite"
       }
     },
     "errors": {
@@ -1613,7 +1782,7 @@
             "title": "Konfigurácia MySQL",
             "description": "Konfigurácia nastavení pripojenia pre databázový server MySQL",
             "host": {
-              "label": "MySQL Host",
+              "label": "MySQL Hostiteľ",
               "placeholder": "Zadajte MySQL host",
               "helpText": "Hostiteľ databázy MySQL (IP alebo hostname)"
             },
@@ -1622,12 +1791,12 @@
               "helpText": "Port databázy MySQL (predvolené 3306/TCP)"
             },
             "username": {
-              "label": "MySQL Username",
+              "label": "MySQL Používateľ",
               "placeholder": "Zadajte MySQL meno používateľa",
               "helpText": "Meno používateľa databázy MySQL"
             },
             "password": {
-              "label": "MySQL Password",
+              "label": "MySQL Heslo",
               "placeholder": "Zadajte MySQL heslo",
               "helpText": "Heslo databázy MySQL"
             },
@@ -2122,7 +2291,7 @@
           "discord": {
             "name": "Discord",
             "webhookUrl": {
-              "label": "Discord Webhook URL",
+              "label": "URL Discord Webhooku",
               "placeholder": "https://discord.com/api/webhooks/...",
               "helpText": "Vložte svoju plnú Discord webhook URL"
             },
@@ -2131,12 +2300,12 @@
           "telegram": {
             "name": "Telegram",
             "botToken": {
-              "label": "Bot Token",
+              "label": "Token bota",
               "placeholder": "123456789:ABCdef...",
               "helpText": "Token od @BotFather"
             },
             "chatId": {
-              "label": "Chat ID",
+              "label": "ID chatu",
               "placeholder": "-1001234567890 alebo @channel",
               "helpText": "Chat ID, ID skupiny alebo @username"
             },
@@ -2198,7 +2367,7 @@
               "helpText": "API token aplikácie"
             },
             "userKey": {
-              "label": "User Key",
+              "label": "Kľúč používateľa",
               "placeholder": "u...",
               "helpText": "Váš používateľský alebo skupinový kľúč"
             },
@@ -2230,7 +2399,7 @@
           "webhook": {
             "name": "Webhook",
             "url": {
-              "label": "Webhook URL",
+              "label": "URL webhooku",
               "placeholder": "https://api.example.com/webhook",
               "helpText": "Koncový bod HTTP(S), na ktorý sa majú odosielať upozornenia"
             },
@@ -2242,7 +2411,7 @@
               "label": "Autentifikácia",
               "none": "Žiadna",
               "bearer": "Bearer Token",
-              "basic": "Basic Auth",
+              "basic": "Základné overenie",
               "helpText": "Voliteľná autentifikácia pre koncový bod webhooku"
             },
             "bearerToken": {
@@ -2256,7 +2425,7 @@
             },
             "basicPass": {
               "label": "Heslo",
-              "placeholder": "password"
+              "placeholder": "heslo"
             },
             "basicAuth": {
               "helpText": "Prihlasovacie údaje odoslané pomocou HTTP Basic Authentication"
@@ -2372,25 +2541,25 @@
           "skipVerify": "Preskočiť overenie certifikátu",
           "configNote": "<strong>Konfigurácia TLS:</strong><br />• Štandardné TLS: Nechajte certifikáty prázdne pre verejných brokerov<br />• Self-signed certifikáty: Poskytnite CA certifikát<br />• Mutual TLS (mTLS): Poskytnite všetky tri certifikáty",
           "certificates": {
-            "title": "Certificate Management",
-            "description": "Upload certificates for secure MQTT broker connections",
-            "caLabel": "CA Certificate",
+            "title": "Správa certifikátov",
+            "description": "Nahrať certifikáty pre bezpečné pripojenia k MQTT brokeru",
+            "caLabel": "CA certifikát",
             "caPlaceholder": "-----BEGIN CERTIFICATE-----",
-            "caHelpText": "Certificate Authority certificate to verify the broker's identity",
-            "clientCertLabel": "Client Certificate",
+            "caHelpText": "Certifikát certifikačnej autority na overenie identity brokera",
+            "clientCertLabel": "Klientský certifikát",
             "clientCertPlaceholder": "-----BEGIN CERTIFICATE-----",
-            "clientCertHelpText": "Client certificate for mutual TLS authentication",
-            "clientKeyLabel": "Client Private Key",
+            "clientCertHelpText": "Klientský certifikát pre vzájomné TLS overenie",
+            "clientKeyLabel": "Súkromný kľúč klienta",
             "clientKeyPlaceholder": "-----BEGIN PRIVATE KEY-----",
-            "clientKeyHelpText": "Private key matching the client certificate",
-            "uploadButton": "Upload Certificates",
-            "uploadSuccess": "MQTT TLS certificates uploaded successfully. Use Test Connection to verify.",
-            "uploadError": "Failed to upload MQTT TLS certificates",
-            "deleteConfirm": "Remove all MQTT TLS certificates? The MQTT client will need to reconnect.",
-            "deleteSuccess": "MQTT TLS certificates removed",
-            "deleteError": "Failed to remove MQTT TLS certificates",
-            "loadError": "Failed to load certificate information",
-            "reconnectNote": "Use the Test Connection button below to verify the new TLS configuration."
+            "clientKeyHelpText": "Súkromný kľúč zodpovedajúci klientskému certifikátu",
+            "uploadButton": "Nahrať certifikáty",
+            "uploadSuccess": "MQTT TLS certifikáty úspešne nahrané. Použi Test pripojenia na overenie.",
+            "uploadError": "Nepodarilo sa nahrať MQTT TLS certifikáty",
+            "deleteConfirm": "Odstrániť všetky MQTT TLS certifikáty? MQTT klient sa bude musieť znova pripojiť.",
+            "deleteSuccess": "MQTT TLS certifikáty odstránené",
+            "deleteError": "Nepodarilo sa odstrániť MQTT TLS certifikáty",
+            "loadError": "Nepodarilo sa načítať informácie o certifikáte",
+            "reconnectNote": "Použite tlačidlo Test pripojenia nižšie na overenie novej TLS konfigurácie."
           }
         },
         "homeAssistant": {
@@ -2491,7 +2660,7 @@
             "standard": "Štandardné",
             "metric": "Metrické",
             "imperial": "Imperiálne",
-            "ukhybrid": "UK Hybrid"
+            "ukhybrid": "UK hybridný"
           }
         },
         "test": {
@@ -2534,14 +2703,14 @@
           "helpText": "Ako dlho uchovávať taxonomické údaje z eBird vo vyrovnávacej pamäti. Taxonómia sa mení zriedkavo, preto dlhšie doby cache znižujú počet volaní API."
         },
         "note": "eBird poskytuje taxonomické údaje používané na klasifikáciu druhov a analýzy. API kľúč je bezplatný a dostupný z Cornell Lab of Ornithology.",
-        "apiKeyInfo": "A personal eBird API key is required to use this integration. You can request a free key from <a href=\"https://ebird.org/api/keygen\" class=\"link link-primary\" target=\"_blank\" rel=\"noopener noreferrer\">ebird.org/api/keygen</a>.",
+        "apiKeyInfo": "Na použitie tejto integrácie je potrebný osobný kľúč API eBird. Bezplatný kľúč si môžete vyžiadať na <a href=\"https://ebird.org/api/keygen\" class=\"link link-primary\" target=\"_blank\" rel=\"noopener noreferrer\">ebird.org/api/keygen</a>.",
         "test": {
-          "button": "Test eBird Connection",
-          "loading": "Testing...",
-          "enabledRequired": "Enable eBird integration first",
-          "apiKeyRequired": "API key is required",
-          "inProgress": "Test in progress...",
-          "description": "Test eBird API connectivity and authentication"
+          "button": "Test pripojenia eBird",
+          "loading": "Testovanie...",
+          "enabledRequired": "Najprv povoľte integráciu eBird",
+          "apiKeyRequired": "API kľúč je povinný",
+          "inProgress": "Test prebieha...",
+          "description": "Otestovať pripojenie a overenie API eBird"
         }
       }
     },
@@ -2944,10 +3113,10 @@
         "noProvidersDescription": "Pridajte poskytovateľa na povolenie prihlásenia cez Google, GitHub, Microsoft, LINE, Kakao alebo vlastného poskytovateľa OIDC.",
         "enableProviderLabel": "Povoliť tohto poskytovateľa",
         "getCredentialsLabel": "Získajte svoje prihlasovacie údaje od {provider}",
-        "redirectUriTitle": "Redirect URI:",
-        "clientIdLabel": "Client ID",
+        "redirectUriTitle": "URI presmerovania:",
+        "clientIdLabel": "ID klienta",
         "clientIdHelpText": "OAuth 2.0 Client ID z vývojárskej konzoly vášho poskytovateľa",
-        "clientSecretLabel": "Client Secret",
+        "clientSecretLabel": "Tajný kľúč klienta",
         "clientSecretHelpText": "OAuth 2.0 Client Secret z vývojárskej konzoly vášho poskytovateľa",
         "userIdLabel": "ID používateľa (voliteľné)",
         "userIdHelpText": "Obmedziť prístup ku konkrétnemu používateľskému účtu podľa e-mailu alebo ID",
@@ -2956,9 +3125,9 @@
           "enableLabel": "Povoliť prihlásenie OAuth2 cez Google",
           "redirectUriTitle": "Redirect URI pre Google Cloud Console:",
           "getCredentialsLabel": "Získajte svoje prihlasovacie údaje z Google Cloud Console",
-          "clientIdLabel": "Client ID",
+          "clientIdLabel": "ID klienta",
           "clientIdHelpText": "OAuth 2.0 Client ID získané z Google Cloud Console pri nastavovaní poverení OAuth.",
-          "clientSecretLabel": "Client Secret",
+          "clientSecretLabel": "Tajný kľúč klienta",
           "clientSecretHelpText": "OAuth 2.0 Client Secret získané z Google Cloud Console pri nastavovaní poverení OAuth.",
           "userIdLabel": "ID používateľa"
         },
@@ -2967,9 +3136,9 @@
           "enableLabel": "Povoliť prihlásenie OAuth2 cez GitHub",
           "redirectUriTitle": "Redirect URI pre GitHub Developer Settings:",
           "getCredentialsLabel": "Získajte svoje prihlasovacie údaje z GitHub Developer Settings",
-          "clientIdLabel": "Client ID",
+          "clientIdLabel": "ID klienta",
           "clientIdHelpText": "OAuth 2.0 Client ID získané z GitHub Developer Settings pri nastavovaní poverení OAuth.",
-          "clientSecretLabel": "Client Secret",
+          "clientSecretLabel": "Tajný kľúč klienta",
           "clientSecretHelpText": "OAuth 2.0 Client Secret získané z GitHub Developer Settings pri nastavovaní poverení OAuth.",
           "userIdLabel": "ID používateľa"
         },
@@ -2978,51 +3147,51 @@
           "enableLabel": "Povoliť prihlásenie OAuth2 cez Microsoft účet",
           "redirectUriTitle": "Redirect URI pre Azure App Registration:",
           "getCredentialsLabel": "Získajte svoje prihlasovacie údaje z Azure Portal",
-          "clientIdLabel": "Client ID",
+          "clientIdLabel": "ID klienta",
           "clientIdHelpText": "Application (client) ID získané z Azure App Registration.",
-          "clientSecretLabel": "Client Secret",
+          "clientSecretLabel": "Tajný kľúč klienta",
           "clientSecretHelpText": "Hodnota kľúča klienta (client secret) získaná z Azure App Registration.",
           "userIdLabel": "ID používateľa"
         },
         "line": {
-          "title": "LINE Login",
+          "title": "Prihlásenie LINE",
           "enableLabel": "Povoliť prihlásenie OAuth2 cez LINE",
           "redirectUriTitle": "Redirect URI pre LINE Developers Console:",
           "getCredentialsLabel": "Získajte svoje prihlasovacie údaje z LINE Developers Console",
-          "clientIdLabel": "Channel ID",
+          "clientIdLabel": "ID kanála",
           "clientIdHelpText": "Channel ID získané z LINE Developers Console pri nastavovaní LINE Login.",
-          "clientSecretLabel": "Channel Secret",
+          "clientSecretLabel": "Tajný kľúč kanála",
           "clientSecretHelpText": "Channel Secret získané z LINE Developers Console pri nastavovaní LINE Login.",
           "userIdLabel": "ID používateľa"
         },
         "kakao": {
-          "title": "Kakao Login",
+          "title": "Prihlásenie Kakao",
           "enableLabel": "Povoliť prihlásenie OAuth2 cez Kakao",
           "redirectUriTitle": "Redirect URI pre Kakao Developers Console:",
           "getCredentialsLabel": "Získajte svoje prihlasovacie údaje z Kakao Developers Console",
-          "clientIdLabel": "REST API Key",
+          "clientIdLabel": "REST API kľúč",
           "clientIdHelpText": "REST API kľúč získaný z Kakao Developers Console pri nastavovaní Kakao Login.",
-          "clientSecretLabel": "Client Secret",
+          "clientSecretLabel": "Tajný kľúč klienta",
           "clientSecretHelpText": "Client Secret získaný z Kakao Developers Console pri nastavovaní Kakao Login.",
           "userIdLabel": "ID používateľa"
         },
         "oidc": {
-          "title": "OIDC Provider",
-          "enableLabel": "Enable OIDC authentication",
-          "redirectUriTitle": "Redirect URI",
-          "getCredentialsLabel": "Configure in your Identity Provider",
-          "clientIdLabel": "Client ID",
-          "clientIdHelpText": "The client ID from your OIDC identity provider",
-          "clientSecretLabel": "Client Secret",
-          "clientSecretHelpText": "The client secret from your OIDC identity provider",
-          "userIdLabel": "Allowed User (email or sub claim)",
-          "issuerUrlLabel": "Issuer URL",
-          "issuerUrlHelpText": "The issuer URL of your OpenID Connect identity provider (e.g., https://auth.example.com)",
+          "title": "OIDC Poskytovateľ",
+          "enableLabel": "Povoliť OIDC overenie",
+          "redirectUriTitle": "URI presmerovania",
+          "getCredentialsLabel": "Nakonfigurujte vo svojom poskytovateľovi identity",
+          "clientIdLabel": "ID klienta",
+          "clientIdHelpText": "ID klienta z vášho OIDC poskytovateľa identity",
+          "clientSecretLabel": "Tajný kľúč klienta",
+          "clientSecretHelpText": "Tajný kľúč klienta z vášho OIDC poskytovateľa identity",
+          "userIdLabel": "Povolený používateľ (email alebo sub claim)",
+          "issuerUrlLabel": "URL vydavateľa",
+          "issuerUrlHelpText": "URL vydavateľa vášho OpenID Connect poskytovateľa identity (napr. https://auth.example.com)",
           "issuerUrlPlaceholder": "https://auth.example.com",
-          "issuerUrlRequired": "Issuer URL is required for OIDC providers",
-          "issuerUrlInvalid": "Issuer URL must be a valid HTTP or HTTPS URL",
-          "scopesLabel": "Scopes",
-          "scopesHelpText": "Comma-separated list of OIDC scopes (default: openid, profile, email)",
+          "issuerUrlRequired": "URL vydavateľa je povinná pre OIDC poskytovateľov",
+          "issuerUrlInvalid": "URL vydavateľa musí byť platná HTTP alebo HTTPS URL",
+          "scopesLabel": "Rozsahy",
+          "scopesHelpText": "Zoznam OIDC rozsahov oddelených čiarkou (predvolené: openid, profile, email)",
           "scopesPlaceholder": "openid, profile, email"
         }
       },
@@ -3032,14 +3201,14 @@
         "disabled": "Obídenie subnetu je vypnuté"
       },
       "exceptions": {
-        "title": "Exceptions"
+        "title": "Výnimky"
       },
       "publicAccess": {
-        "title": "Public Access",
-        "description": "Allow specific features to be accessible without authentication.",
-        "liveAudioLabel": "Allow public live audio playback",
-        "liveAudioHelp": "When enabled, anyone can listen to live audio streams without logging in. Settings and deletion still require authentication.",
-        "warningText": "Enabling public access features exposes them to anyone who can reach this server. Only enable if you trust your network environment."
+        "title": "Verejný prístup",
+        "description": "Povoliť prístup k špecifickým funkciám bez overenia.",
+        "liveAudioLabel": "Povoliť verejné prehrávanie zvuku naživo",
+        "liveAudioHelp": "Keď je povolené, ktokoľvek môže počúvať živé audio streamy bez prihlásenia. Nastavenia a mazanie stále vyžadujú overenie.",
+        "warningText": "Povolenie funkcií verejného prístupu ich sprístupní komukoľvek, kto sa môže pripojiť k tomuto serveru. Povoľte iba ak dôverujete svojmu sieťovému prostrediu."
       },
       "placeholders": {
         "baseUrl": "https://birdnet.priklad.sk:5500",
@@ -3056,64 +3225,64 @@
       },
       "tls": {
         "title": "TLS / HTTPS",
-        "description": "Configure TLS/HTTPS encryption for secure connections",
-        "modeLabel": "TLS Mode",
-        "modeNone": "None (HTTP)",
+        "description": "Konfigurácia šifrovania TLS/HTTPS pre bezpečné pripojenia",
+        "modeLabel": "Režim TLS",
+        "modeNone": "Žiadny (HTTP)",
         "modeLetsEncrypt": "Let's Encrypt",
-        "modeManual": "Manual Certificate",
-        "modeSelfSigned": "Self-Signed",
-        "modeNoneDescription": "Plain HTTP without encryption",
-        "modeAutoTLSDescription": "Automatic certificate via Let's Encrypt",
-        "modeManualDescription": "Upload your own certificate and key",
-        "modeSelfSignedDescription": "Generate a self-signed certificate",
+        "modeManual": "Manuálny certifikát",
+        "modeSelfSigned": "Samopodpísaný",
+        "modeNoneDescription": "Obyčajné HTTP bez šifrovania",
+        "modeAutoTLSDescription": "Automatický certifikát cez Let's Encrypt",
+        "modeManualDescription": "Nahrať vlastný certifikát a kľúč",
+        "modeSelfSignedDescription": "Vygenerovať samopodpísaný certifikát",
         "portLabel": "HTTPS Port",
-        "portHelpText": "Port for HTTPS connections (default: 8443)",
-        "redirectToHttps": "Redirect HTTP to HTTPS",
-        "autoTLSRequirements": "Requires ports 80 and 443 to be accessible. On Linux, the process needs root or CAP_NET_BIND_SERVICE capability.",
-        "validityLabel": "Certificate Validity",
-        "validityHelpText": "How long the certificate should be valid",
-        "validity365d": "1 year",
-        "validity730d": "2 years",
-        "generateButton": "Generate Certificate",
-        "regenerateButton": "Regenerate Certificate",
-        "generating": "Generating...",
-        "certificateLabel": "Certificate (PEM)",
-        "privateKeyLabel": "Private Key (PEM)",
-        "caCertificateLabel": "CA Certificate (PEM, optional)",
-        "uploadButton": "Upload Certificate",
-        "uploading": "Uploading...",
-        "browseFile": "Browse...",
-        "plaintextWarning": "Warning: Your private key will be transmitted in plaintext over HTTP. Only upload certificates when connected via a trusted network or localhost.",
-        "certificateInstalled": "Installed Certificate",
-        "subject": "Subject",
-        "issuer": "Issuer",
-        "validFrom": "Valid From",
-        "validUntil": "Valid Until",
-        "daysRemaining": "Days Remaining",
-        "sans": "Subject Alternative Names",
-        "fingerprint": "Fingerprint",
-        "expiryWarning": "Certificate is expiring soon",
-        "loading": "Loading certificate info...",
-        "loadError": "Failed to load certificate info",
-        "generateSuccess": "Self-signed certificate generated successfully",
-        "generateError": "Failed to generate certificate",
-        "uploadSuccess": "Certificate uploaded successfully",
-        "uploadError": "Failed to upload certificate",
-        "deleteSuccess": "Certificate removed successfully",
-        "deleteError": "Failed to delete certificate",
-        "removeCertificate": "Remove Certificate",
-        "deleteConfirm": "Are you sure you want to remove the installed TLS certificate? The TLS mode will be reset to None.",
-        "restartRequired": "TLS changes require a server restart to take effect.",
-        "noCertificate": "No certificate installed",
-        "validity1825d": "5 years",
-        "autoTLSHostRequired": "A hostname is required for Let’s Encrypt. Enter your public domain name in the Host field above.",
-        "autoTLSNoIP": "Let’s Encrypt requires a domain name, not an IP address. Enter a public domain like birds.example.com.",
-        "autoTLSNeedsFQDN": "Let’s Encrypt requires a fully qualified domain name (e.g., birds.example.com), not a bare hostname.",
-        "autoTLSNoLocalhost": "Let’s Encrypt cannot issue certificates for localhost.",
-        "autoTLSPrivateTLD": "Let’s Encrypt cannot issue certificates for private domains ({tld} is not publicly resolvable).",
-        "downloadCertificate": "Download Certificate",
-        "downloadCertificateHelp": "Install this certificate in your operating system's trust store to avoid browser security warnings.",
-        "fileReadError": "Failed to read the selected file"
+        "portHelpText": "Port pre HTTPS pripojenia (predvolený: 8443)",
+        "redirectToHttps": "Presmerovať HTTP na HTTPS",
+        "autoTLSRequirements": "Vyžaduje dostupnosť portov 80 a 443. Na Linuxe proces potrebuje root alebo schopnosť CAP_NET_BIND_SERVICE.",
+        "validityLabel": "Platnosť certifikátu",
+        "validityHelpText": "Ako dlho by mal byť certifikát platný",
+        "validity365d": "1 rok",
+        "validity730d": "2 roky",
+        "generateButton": "Vygenerovať certifikát",
+        "regenerateButton": "Regenerovať certifikát",
+        "generating": "Generovanie...",
+        "certificateLabel": "Certifikát (PEM)",
+        "privateKeyLabel": "Súkromný kľúč (PEM)",
+        "caCertificateLabel": "CA certifikát (PEM, voliteľný)",
+        "uploadButton": "Nahrať certifikát",
+        "uploading": "Nahrávanie...",
+        "browseFile": "Prehľadávať...",
+        "plaintextWarning": "Upozornenie: Váš súkromný kľúč bude prenášaný v nešifrovanej forme cez HTTP. Nahrávajte certifikáty len cez dôveryhodnú sieť alebo localhost.",
+        "certificateInstalled": "Nainštalovaný certifikát",
+        "subject": "Predmet",
+        "issuer": "Vydavateľ",
+        "validFrom": "Platný od",
+        "validUntil": "Platný do",
+        "daysRemaining": "Zostávajúce dni",
+        "sans": "Alternatívne mená subjektu",
+        "fingerprint": "Odtlačok",
+        "expiryWarning": "Certifikát čoskoro vyprší",
+        "loading": "Načítavanie informácií o certifikáte...",
+        "loadError": "Nepodarilo sa načítať informácie o certifikáte",
+        "generateSuccess": "Samopodpísaný certifikát úspešne vygenerovaný",
+        "generateError": "Nepodarilo sa vygenerovať certifikát",
+        "uploadSuccess": "Certifikát úspešne nahraný",
+        "uploadError": "Nepodarilo sa nahrať certifikát",
+        "deleteSuccess": "Certifikát úspešne odstránený",
+        "deleteError": "Nepodarilo sa odstrániť certifikát",
+        "removeCertificate": "Odstrániť certifikát",
+        "deleteConfirm": "Ste si istí, že chcete odstrániť nainštalovaný TLS certifikát? Režim TLS bude obnovený na Žiadny.",
+        "restartRequired": "Zmeny TLS vyžadujú reštart servera.",
+        "noCertificate": "Žiadny nainštalovaný certifikát",
+        "validity1825d": "5 rokov",
+        "autoTLSHostRequired": "Pre Let’s Encrypt je potrebný názov hostiteľa. Zadajte svoj verejný názov domény do poľa Hostiteľ vyššie.",
+        "autoTLSNoIP": "Let’s Encrypt vyžaduje názov domény, nie IP adresu. Zadajte verejnú doménu ako birds.example.com.",
+        "autoTLSNeedsFQDN": "Let’s Encrypt vyžaduje plne kvalifikovaný názov domény (napr. birds.example.com), nie jednoduchý názov hostiteľa.",
+        "autoTLSNoLocalhost": "Let’s Encrypt nemôže vydávať certifikáty pre localhost.",
+        "autoTLSPrivateTLD": "Let’s Encrypt nemôže vydávať certifikáty pre súkromné domény ({tld} nie je verejne riešiteľná).",
+        "downloadCertificate": "Stiahnuť certifikát",
+        "downloadCertificateHelp": "Nainštalujte tento certifikát do úložiska dôveryhodných certifikátov vášho operačného systému, aby ste sa vyhli bezpečnostným upozorneniam prehliadača.",
+        "fileReadError": "Nepodarilo sa prečítať vybraný súbor"
       }
     },
     "species": {
@@ -3270,14 +3439,14 @@
           "availableTitle": "Dostupné parametre",
           "buttons": {
             "commonName": "CommonName",
-            "scientificName": "ScientificName",
-            "confidence": "Confidence",
-            "time": "Time",
-            "source": "Source",
+            "scientificName": "VedeckýNázov",
+            "confidence": "Spoľahlivosť",
+            "time": "Čas",
+            "source": "Zdroj",
             "clearParameters": "Vymazať parametre"
           },
-          "placeholder": "Click buttons below to add parameters or type manually",
-          "tooltip": "Use buttons below or type directly (comma-separated)"
+          "placeholder": "Kliknite na tlačidlá nižšie pre pridanie parametrov alebo zadajte ručne",
+          "tooltip": "Použite tlačidlá nižšie alebo zadajte priamo (oddelené čiarkou)"
         },
         "executeDefaults": {
           "label": "Spustiť aj predvolené akcie (uloženie do databázy, upozornenia atď.)",
@@ -3429,7 +3598,7 @@
         "expand": "Zobraziť históriu udalostí",
         "collapse": "Skryť históriu udalostí"
       },
-      "suggestions": "Species suggestions"
+      "suggestions": "Návrhy druhov"
     },
     "database": {
       "sqlitePlaceholder": "Zadajte cestu k databáze SQLite",
@@ -3669,7 +3838,7 @@
         "appearance": "Vzhľad",
         "language": "Jazyk a regionálne",
         "visualContent": "Vizuálny obsah",
-        "audioPlayback": "Audio Playback"
+        "audioPlayback": "Prehrávanie zvuku"
       },
       "appearance": {
         "title": "Vzhľad",
@@ -3684,14 +3853,14 @@
         "description": "Nakonfigurujte obrázky vtákov a nastavenia zobrazenia spektrogramu"
       },
       "audioPlayback": {
-        "title": "Audio Playback",
-        "description": "Default settings for playing bird recordings.",
-        "defaultGain": "Default Volume Boost",
-        "defaultGainHelpText": "Initial gain applied when playing recordings. Bird sounds are often quiet, so a boost of 6-12 dB is recommended.",
+        "title": "Prehrávanie zvuku",
+        "description": "Predvolené nastavenia pre prehrávanie nahrávok vtákov.",
+        "defaultGain": "Predvolené zosilnenie hlasitosti",
+        "defaultGainHelpText": "Počiatočné zosilnenie pri prehrávaní nahrávok. Zvuky vtákov sú často tiché, preto sa odporúča zosilnenie 6-12 dB.",
         "defaultGainUnit": "dB"
       }
     },
-    "restartRequired": "Some changes require a server restart to take effect. Please restart BirdNET-Go."
+    "restartRequired": "Niektoré zmeny vyžadujú reštart servera. Reštartujte BirdNET-Go."
   },
   "auth": {
     "login": "Prihlásenie",
@@ -3712,7 +3881,7 @@
     "continueWithMicrosoft": "Pokračovať cez Microsoft",
     "continueWithLine": "Pokračovať cez LINE",
     "continueWithKakao": "Pokračovať cez Kakao",
-    "continueWithOidc": "Continue with OIDC",
+    "continueWithOidc": "Pokračovať s OIDC",
     "errors": {
       "loginFailed": "Prihlásenie zlyhalo. Skontrolujte svoje heslo a skúste to znova.",
       "passwordRequired": "Heslo je povinné.",
@@ -3773,7 +3942,11 @@
       "hidePassword": "Skryť heslo",
       "copyToClipboard": "Kopírovať do schránky",
       "clearSelection": "Vymazať výber",
-      "selectOption": "Vyberte možnosť"
+      "selectOption": "Vyberte možnosť",
+      "secretSet": "Nastaviť",
+      "changeSecret": "Zmeniť",
+      "cancelChange": "Zrušiť",
+      "enterNewSecret": "Zadajte novú hodnotu"
     },
     "help": {
       "passwordStrength": "Sila hesla: {strength}",
@@ -3856,7 +4029,7 @@
       "seekProgress": "Posun v nahrávke: {current} / {total} sekúnd",
       "playbackSpeed": "Rýchlosť prehrávania",
       "speed": "Rýchlosť",
-      "loop": "Toggle loop",
+      "loop": "Prepnúť opakovanie",
       "player": "Prehrávač zvuku"
     },
     "spectrogram": {
@@ -3935,36 +4108,36 @@
         "spectrogramFailed": "Nepodarilo sa vygenerovať spektrogram"
       },
       "clipExtraction": {
-        "selectRange": "Click and drag to select a range",
-        "playSelection": "Play selected range",
-        "pauseSelection": "Pause playback",
-        "reviewSelection": "Jump to start of selection",
-        "selectionStart": "Selection start handle",
-        "selectionEnd": "Selection end handle",
-        "lossless": "Lossless",
-        "lossy": "Lossy",
-        "extractClip": "Download selected clip",
-        "clearSelection": "Clear selection",
-        "extracting": "Extracting clip...",
-        "extractError": "Failed to extract clip",
-        "formatLabel": "Format",
+        "selectRange": "Kliknite a ťahajte pre výber rozsahu",
+        "playSelection": "Prehrať vybraný rozsah",
+        "pauseSelection": "Pozastaviť prehrávanie",
+        "reviewSelection": "Preskočiť na začiatok výberu",
+        "selectionStart": "Rukoväť začiatku výberu",
+        "selectionEnd": "Rukoväť konca výberu",
+        "lossless": "Bezstratový",
+        "lossy": "Stratový",
+        "extractClip": "Stiahnuť vybraný klip",
+        "clearSelection": "Zrušiť výber",
+        "extracting": "Extrahovanie klipu...",
+        "extractError": "Nepodarilo sa extrahovať klip",
+        "formatLabel": "Formát",
         "rangeLabel": "{start}s – {end}s"
       },
       "processing": {
-        "playSelection": "Play selection",
-        "skipToStart": "Skip to selection start",
-        "clearSelection": "Clear selection",
-        "gain": "Gain (dB)",
-        "denoise": "Denoise",
-        "denoiseOff": "Off",
-        "denoiseLight": "Light",
-        "denoiseMedium": "Medium",
-        "denoiseHeavy": "Heavy",
-        "normalize": "Normalize audio",
-        "normalizeTooltip": "EBU R128 Normalization",
-        "export": "Export",
+        "playSelection": "Prehrať výber",
+        "skipToStart": "Preskočiť na začiatok výberu",
+        "clearSelection": "Zrušiť výber",
+        "gain": "Zosilnenie (dB)",
+        "denoise": "Odšumenie",
+        "denoiseOff": "Vypnuté",
+        "denoiseLight": "Ľahký",
+        "denoiseMedium": "Stredný",
+        "denoiseHeavy": "Ťažký",
+        "normalize": "Normalizovať zvuk",
+        "normalizeTooltip": "Normalizácia EBU R128",
+        "export": "Exportovať",
         "exportOriginal": "Originál",
-        "processingActive": "Processing active"
+        "processingActive": "Spracovanie aktívne"
       }
     },
     "weatherInfo": {
@@ -3973,20 +4146,20 @@
       }
     },
     "tls": {
-      "certificateInstalled": "Certificate Installed",
-      "browseFile": "Browse",
-      "subject": "Subject",
-      "issuer": "Issuer",
-      "sans": "Subject Alternative Names",
-      "validUntil": "Valid Until",
-      "daysRemaining": "Days Remaining",
-      "fingerprint": "Fingerprint",
-      "expiryWarning": "This certificate expires soon. Consider renewing it.",
-      "downloadCertificate": "Download Certificate",
-      "regenerateButton": "Regenerate",
-      "removeCertificate": "Remove Certificate",
-      "fileReadError": "Failed to read file",
-      "loading": "Loading certificate information..."
+      "certificateInstalled": "Certifikát nainštalovaný",
+      "browseFile": "Prehľadávať",
+      "subject": "Predmet",
+      "issuer": "Vydavateľ",
+      "sans": "Alternatívne mená subjektu",
+      "validUntil": "Platný do",
+      "daysRemaining": "Zostávajúce dni",
+      "fingerprint": "Odtlačok",
+      "expiryWarning": "Tento certifikát čoskoro vyprší. Zvážte jeho obnovenie.",
+      "downloadCertificate": "Stiahnuť certifikát",
+      "regenerateButton": "Regenerovať",
+      "removeCertificate": "Odstrániť certifikát",
+      "fileReadError": "Nepodarilo sa prečítať súbor",
+      "loading": "Načítavanie informácií o certifikáte..."
     }
   },
   "connectivity": {
@@ -4159,77 +4332,77 @@
     },
     "steps": {
       "welcome": {
-        "title": "Welcome",
-        "heading": "Welcome to BirdNET-Go!",
-        "description": "BirdNET-Go is a real-time bird sound identification system. It listens to audio from your microphone or audio stream and uses the BirdNET AI model to identify bird species.",
-        "credit": "Powered by the BirdNET Analyzer developed by the K. Lisa Yang Center for Conservation Bioacoustics at the Cornell Lab of Ornithology and Chemnitz University of Technology.",
-        "cta": "Let's set up your bird monitoring station."
+        "title": "Vitajte",
+        "heading": "Vitajte v BirdNET-Go!",
+        "description": "BirdNET-Go je systém na identifikáciu zvukov vtákov v reálnom čase. Počúva zvuk z mikrofónu alebo audio streamu a používa AI model BirdNET na identifikáciu druhov vtákov.",
+        "credit": "Založené na BirdNET Analyzer vyvinutom v K. Lisa Yang Center for Conservation Bioacoustics na Cornell Lab of Ornithology a Chemnitz University of Technology.",
+        "cta": "Poďme nastaviť vašu stanicu na monitorovanie vtákov."
       },
       "locationLanguage": {
-        "title": "Location & Language",
-        "uiLanguageLabel": "Interface Language",
-        "uiLanguageHelp": "Language used for the web interface",
-        "speciesLanguageLabel": "Species Name Language",
-        "speciesLanguageHelp": "Language used for bird species names in detections",
-        "locationLabel": "Station Location",
-        "locationHelp": "Your location helps filter species to those likely in your area",
-        "latitudeLabel": "Latitude",
-        "longitudeLabel": "Longitude",
-        "useMyLocation": "Use my location",
-        "locationDetected": "Location detected",
-        "locationError": "Could not detect location. Please enter coordinates manually.",
-        "locationDenied": "Location access denied. Please enter coordinates manually."
+        "title": "Poloha a jazyk",
+        "uiLanguageLabel": "Jazyk rozhrania",
+        "uiLanguageHelp": "Jazyk používaný pre webové rozhranie",
+        "speciesLanguageLabel": "Jazyk názvov druhov",
+        "speciesLanguageHelp": "Jazyk používaný pre názvy druhov vtákov v detekciách",
+        "locationLabel": "Poloha stanice",
+        "locationHelp": "Vaša poloha pomáha filtrovať druhy na tie, ktoré sú pravdepodobné vo vašej oblasti",
+        "latitudeLabel": "Zemepisná šírka",
+        "longitudeLabel": "Zemepisná dĺžka",
+        "useMyLocation": "Použiť moju polohu",
+        "locationDetected": "Poloha zistená",
+        "locationError": "Nepodarilo sa zistiť polohu. Zadajte súradnice ručne.",
+        "locationDenied": "Prístup k polohe zamietnutý. Zadajte súradnice ručne."
       },
       "audioSource": {
-        "title": "Audio Source",
-        "sourceTypeLabel": "Source Type",
-        "soundcard": "Microphone / Soundcard",
+        "title": "Zdroj zvuku",
+        "sourceTypeLabel": "Typ zdroja",
+        "soundcard": "Mikrofón / Zvuková karta",
         "rtspStream": "RTSP Stream",
-        "deviceLabel": "Audio Device",
-        "deviceLoading": "Loading audio devices...",
-        "noDevicesFound": "No audio devices detected. Try configuring an RTSP stream instead.",
-        "rtspUrlLabel": "Stream URL",
+        "deviceLabel": "Zvukové zariadenie",
+        "deviceLoading": "Načítavanie zvukových zariadení...",
+        "noDevicesFound": "Neboli detegované žiadne zvukové zariadenia. Skúste namiesto toho nakonfigurovať RTSP stream.",
+        "rtspUrlLabel": "URL streamu",
         "rtspUrlPlaceholder": "rtsp://user:password@host:port/stream",
-        "rtspUrlHelp": "Enter the URL of your RTSP audio stream",
-        "additionalSourcesHint": "You can add more audio sources later in Settings."
+        "rtspUrlHelp": "Zadajte URL vášho RTSP audio streamu",
+        "additionalSourcesHint": "Ďalšie zdroje zvuku môžete pridať neskôr v Nastaveniach."
       },
       "detection": {
-        "title": "Detection Threshold",
-        "description": "Choose how strict the bird identification should be. You can adjust this later in Settings.",
-        "balanced": "Balanced",
-        "balancedDesc": "Good balance of accuracy and sensitivity",
-        "balancedRecommended": "Recommended",
-        "highAccuracy": "High Accuracy",
-        "highAccuracyDesc": "Fewer false positives, may miss some birds",
-        "highSensitivity": "High Sensitivity",
-        "highSensitivityDesc": "More detections, more false positives",
-        "threshold": "Confidence threshold",
-        "fpFilterNote": "Once your system is running and proven, you can enable the false positive filter in Settings to further reduce incorrect detections."
+        "title": "Prah detekcie",
+        "description": "Vyberte, aká prísna má byť identifikácia vtákov. Toto môžete neskôr zmeniť v Nastaveniach.",
+        "balanced": "Vyvážený",
+        "balancedDesc": "Dobrý pomer presnosti a citlivosti",
+        "balancedRecommended": "Odporúčané",
+        "highAccuracy": "Vysoká presnosť",
+        "highAccuracyDesc": "Menej falošných detekcií, môže vynechať niektoré vtáky",
+        "highSensitivity": "Vysoká citlivosť",
+        "highSensitivityDesc": "Viac detekcií, viac falošných detekcií",
+        "threshold": "Prahová hodnota spoľahlivosti",
+        "fpFilterNote": "Keď váš systém beží a je overený, môžete povoliť filter falošných detekcií v Nastaveniach na ďalšie zníženie nesprávnych detekcií."
       },
       "integration": {
-        "title": "Privacy & Integration",
-        "privacyFilterLabel": "Enable privacy filter",
-        "privacyFilterHelp": "Filters out detections when human voices are detected near the microphone",
-        "birdweatherLabel": "Share detections with BirdWeather",
-        "birdweatherHelp": "Contribute your bird detections to the BirdWeather community network",
-        "birdweatherIdLabel": "BirdWeather Station ID",
-        "birdweatherIdPlaceholder": "Enter your BirdWeather station ID",
-        "errorReportingLabel": "Send anonymous error reports",
-        "errorReportingHelp": "Help improve BirdNET-Go by sending anonymous error reports when something goes wrong"
+        "title": "Súkromie a integrácie",
+        "privacyFilterLabel": "Povoliť filter súkromia",
+        "privacyFilterHelp": "Odfiltruje detekcie, keď sú pri mikrofóne detegované ľudské hlasy",
+        "birdweatherLabel": "Zdieľať detekcie s BirdWeather",
+        "birdweatherHelp": "Prispievajte svojimi detekciami vtákov do komunitnej siete BirdWeather",
+        "birdweatherIdLabel": "ID stanice BirdWeather",
+        "birdweatherIdPlaceholder": "Zadajte ID vašej stanice BirdWeather",
+        "errorReportingLabel": "Odosielať anonymné hlásenia o chybách",
+        "errorReportingHelp": "Pomôžte zlepšiť BirdNET-Go odosielaním anonymných hlásení o chybách, keď niečo zlyhá"
       },
       "responsibleUse": {
-        "title": "Using BirdNET-Go Responsibly",
-        "intro": "BirdNET-Go is a powerful tool that enhances your birding experience through AI-assisted identification. To ensure the best outcomes for both birding and conservation:",
-        "point1": "Review and verify detections before sharing observations",
-        "point2": "Use the confidence scores as a guide, not absolute truth",
-        "point3": "Cross-reference with field guides and local expertise",
-        "point4": "Consider seasonal patterns and habitat suitability",
-        "citizenScienceHeading": "When contributing to citizen science:",
-        "citizenPoint1": "Only submit observations you have personally verified",
-        "citizenPoint2": "Include notes about visual or behavioral confirmation",
-        "citizenPoint3": "Use AI detections as a starting point for your own observations",
-        "outro": "This approach ensures data quality for scientific research while maximizing your learning and enjoyment of birds.",
-        "acknowledge": "I understand"
+        "title": "Zodpovedné používanie BirdNET-Go",
+        "intro": "BirdNET-Go je výkonný nástroj, ktorý vylepšuje váš zážitok z pozorovania vtákov prostredníctvom identifikácie pomocou AI. Pre zabezpečenie najlepších výsledkov pre pozorovanie aj ochranu:",
+        "point1": "Skontrolujte a overte detekcie pred zdieľaním pozorovaní",
+        "point2": "Použite skóre spoľahlivosti ako vodítko, nie absolútnu pravdu",
+        "point3": "Krížové overenie s poľnými sprievodcami a miestnymi odborníkmi",
+        "point4": "Zvážte sezónne vzorce a vhodnosť biotopu",
+        "citizenScienceHeading": "Pri prispievaní do občianskej vedy:",
+        "citizenPoint1": "Odosielafjte iba pozorovania, ktoré ste osobne overili",
+        "citizenPoint2": "Zahrňte poznámky o vizuálnom alebo behaviorálnom potvrdení",
+        "citizenPoint3": "Použite AI detekcie ako východiskový bod pre vaše vlastné pozorovania",
+        "outro": "Tento prístup zabezpečuje kvalitu dát pre vedecký výskum a zároveň maximalizuje vaše učenie a radosť z pozorovania vtákov.",
+        "acknowledge": "Rozumiem"
       }
     }
   },

--- a/frontend/static/messages/sv.json
+++ b/frontend/static/messages/sv.json
@@ -377,8 +377,8 @@
         "application": "Applikationsfel",
         "imageProvider": "Bildleverantörsmeddelande",
         "categoryError": "{category}-fel",
-        "burstTitle": "Multiple {component} errors",
-        "burstMessage": "{count} errors in the last {window_minutes} minutes: {sample_error}"
+        "burstTitle": "Flera {component}-fel",
+        "burstMessage": "{count} fel de senaste {window_minutes} minuterna: {sample_error}"
       },
       "settings": {
         "reloadingBirdnet": "Tillämpar nya analysinställningar...",
@@ -388,7 +388,7 @@
         "reconfiguringBirdweather": "Uppdaterar BirdWeather-integration...",
         "reconfiguringStreams": "Uppdaterar ljudströmmar...",
         "reconfiguringTelemetry": "Uppdaterar telemetriinställningar...",
-        "reconfiguringPushNotifications": "Reconfiguring push notification providers...",
+        "reconfiguringPushNotifications": "Omkonfigurerar push-aviseringsleverantörer...",
         "reconfiguringSpeciesTracking": "Uppdaterar artspårning...",
         "recalculatingThresholds": "Beräknar om dynamiska tröskelvärden för nytt basvärde",
         "reconfiguringDynamicThresholds": "Konfigurerar om dynamiska tröskelvärden...",
@@ -930,31 +930,31 @@
   },
   "spectrogram": {
     "controls": {
-      "frequencyRange": "Frequency Range",
-      "colorMap": "Color Map",
-      "gain": "Gain",
+      "frequencyRange": "Frekvensomfång",
+      "colorMap": "Färgkarta",
+      "gain": "Förstärkning",
       "gainTooltip": "Spektrogramvisualisering förstärkning",
       "mute": "Stäng av ljudutgång",
       "unmute": "Aktivera ljudutgång",
-      "frequencyRangeMin": "Minimum frequency",
-      "frequencyRangeMax": "Maximum frequency"
+      "frequencyRangeMin": "Minsta frekvens",
+      "frequencyRangeMax": "Högsta frekvens"
     },
     "error": {
-      "unsupported": "Your browser does not support audio analysis",
-      "connectionFailed": "Failed to connect to live audio stream",
-      "accessDenied": "Live audio access requires authentication. Please log in to use this feature."
+      "unsupported": "Din webbläsare stöder inte ljudanalys",
+      "connectionFailed": "Kunde inte ansluta till live-ljudströmmen",
+      "accessDenied": "Åtkomst till live-ljud kräver autentisering. Logga in för att använda denna funktion."
     },
     "dashboard": {
-      "toggle": "Live Spectrogram",
-      "audioToggle": "Enable audio"
+      "toggle": "Live-spektrogram",
+      "audioToggle": "Aktivera ljud"
     },
     "gain": {
       "muted": "Tystad",
       "level": "Förstärkning: {value} dB"
     },
     "page": {
-      "title": "Live Audio",
-      "sourceLabel": "Audio Source",
+      "title": "Live-ljud",
+      "sourceLabel": "Ljudkälla",
       "connected": "Ansluten",
       "enterFullscreen": "Helskärm",
       "exitFullscreen": "Avsluta helskärm"
@@ -962,7 +962,10 @@
     "colorMaps": {
       "inferno": "Inferno",
       "viridis": "Viridis",
-      "grayscale": "Grayscale"
+      "grayscale": "Gråskala"
+    },
+    "labels": {
+      "toggle": "Växla detekteringsetiketter"
     }
   },
   "system": {
@@ -2590,7 +2593,7 @@
           }
         },
         "homeAssistant": {
-          "title": "Home Assistant automatisk identifiering",
+          "title": "Home Assistant Auto-Discovery",
           "enable": "Aktivera Home Assistant MQTT-identifiering",
           "description": "När aktiverat registrerar BirdNET-Go automatiskt enheter och sensorer hos Home Assistant genom MQTT-identifieringsprotokollet. Enheter visas i Home Assistants enhetsregister utan manuell YAML-konfiguration.",
           "discoveryPrefix": {
@@ -2603,7 +2606,7 @@
           },
           "sensorsNote": "<strong>Skapade sensorer:</strong> För varje ljudkälla tar Home Assistant emot: Senaste art, Konfidens, Vetenskapligt namn och Ljudnivå (om aktiverat). Bryggenheten inkluderar tillgänglighetsstatus online/offline.",
           "discovery": {
-            "button": "Skicka identifiering",
+            "button": "Skicka Discovery",
             "success": "Identifieringsmeddelanden skickade till Home Assistant",
             "error": "Kunde inte skicka identifieringsmeddelanden",
             "saveFirst": "Spara inställningar innan identifiering skickas"
@@ -3181,7 +3184,7 @@
           "userIdLabel": "Användar-ID"
         },
         "line": {
-          "title": "LINE-inloggning",
+          "title": "LINE Login",
           "enableLabel": "Tillåt OAuth2-inloggning via LINE",
           "redirectUriTitle": "Omdirigerings-URI för LINE Developers Console:",
           "getCredentialsLabel": "Hämta dina uppgifter från LINE Developers Console",
@@ -3192,7 +3195,7 @@
           "userIdLabel": "Användar-ID"
         },
         "kakao": {
-          "title": "Kakao-inloggning",
+          "title": "Kakao Login",
           "enableLabel": "Tillåt OAuth2-inloggning via Kakao",
           "redirectUriTitle": "Omdirigerings-URI för Kakao Developers Console:",
           "getCredentialsLabel": "Hämta dina uppgifter från Kakao Developers Console",
@@ -3963,7 +3966,11 @@
       "hidePassword": "Dölj lösenord",
       "copyToClipboard": "Kopiera till urklipp",
       "clearSelection": "Rensa val",
-      "selectOption": "Välj ett alternativ"
+      "selectOption": "Välj ett alternativ",
+      "secretSet": "Inställd",
+      "changeSecret": "Ändra",
+      "cancelChange": "Avbryt",
+      "enterNewSecret": "Ange nytt värde"
     },
     "help": {
       "passwordStrength": "Lösenordsstyrka: {strength}",
@@ -4046,7 +4053,8 @@
       "seekProgress": "Sök i ljudet: {current} / {total} sekunder",
       "playbackSpeed": "Uppspelningshastighet",
       "speed": "Hastighet",
-      "loop": "Växla upprepning"
+      "loop": "Växla upprepning",
+      "player": "Ljudspelare"
     },
     "spectrogram": {
       "notGenerated": "Spektrogrammet har inte genererats ännu",
@@ -4066,7 +4074,8 @@
       "spectrogramGeneratingAria": "Genererar spektrogram",
       "generating": "Genererar...",
       "queuePosition": "Kö: {position}",
-      "loadError": "Kunde inte ladda ljud"
+      "loadError": "Kunde inte ladda ljud",
+      "spectrogramAlt": "Ljudspektrogram"
     },
     "forms": {
       "numberField": {
@@ -4323,77 +4332,77 @@
     },
     "steps": {
       "welcome": {
-        "title": "Welcome",
-        "heading": "Welcome to BirdNET-Go!",
-        "description": "BirdNET-Go is a real-time bird sound identification system. It listens to audio from your microphone or audio stream and uses the BirdNET AI model to identify bird species.",
-        "credit": "Powered by the BirdNET Analyzer developed by the K. Lisa Yang Center for Conservation Bioacoustics at the Cornell Lab of Ornithology and Chemnitz University of Technology.",
-        "cta": "Let's set up your bird monitoring station."
+        "title": "Välkommen",
+        "heading": "Välkommen till BirdNET-Go!",
+        "description": "BirdNET-Go är ett realtidssystem för identifiering av fågelljud. Det lyssnar på ljud från din mikrofon eller ljudström och använder BirdNET AI-modellen för att identifiera fågelarter.",
+        "credit": "Drivs av BirdNET Analyzer, utvecklad av K. Lisa Yang Center for Conservation Bioacoustics vid Cornell Lab of Ornithology och Chemnitz University of Technology.",
+        "cta": "Låt oss konfigurera din fågelövervakningsstation."
       },
       "locationLanguage": {
-        "title": "Location & Language",
-        "uiLanguageLabel": "Interface Language",
-        "uiLanguageHelp": "Language used for the web interface",
-        "speciesLanguageLabel": "Species Name Language",
-        "speciesLanguageHelp": "Language used for bird species names in detections",
-        "locationLabel": "Station Location",
-        "locationHelp": "Your location helps filter species to those likely in your area",
-        "latitudeLabel": "Latitude",
-        "longitudeLabel": "Longitude",
-        "useMyLocation": "Use my location",
-        "locationDetected": "Location detected",
-        "locationError": "Could not detect location. Please enter coordinates manually.",
-        "locationDenied": "Location access denied. Please enter coordinates manually."
+        "title": "Plats och språk",
+        "uiLanguageLabel": "Gränssnittsspråk",
+        "uiLanguageHelp": "Språk som används för webbgränssnittet",
+        "speciesLanguageLabel": "Artnamnsspråk",
+        "speciesLanguageHelp": "Språk som används för fågelartnamn i detekteringar",
+        "locationLabel": "Stationsplats",
+        "locationHelp": "Din plats hjälper till att filtrera arter till de som troligen finns i ditt område",
+        "latitudeLabel": "Latitud",
+        "longitudeLabel": "Longitud",
+        "useMyLocation": "Använd min plats",
+        "locationDetected": "Plats identifierad",
+        "locationError": "Kunde inte identifiera plats. Ange koordinater manuellt.",
+        "locationDenied": "Platsåtkomst nekad. Ange koordinater manuellt."
       },
       "audioSource": {
-        "title": "Audio Source",
-        "sourceTypeLabel": "Source Type",
-        "soundcard": "Microphone / Soundcard",
-        "rtspStream": "RTSP Stream",
-        "deviceLabel": "Audio Device",
-        "deviceLoading": "Loading audio devices...",
-        "noDevicesFound": "No audio devices detected. Try configuring an RTSP stream instead.",
-        "rtspUrlLabel": "Stream URL",
+        "title": "Ljudkälla",
+        "sourceTypeLabel": "Källtyp",
+        "soundcard": "Mikrofon / Ljudkort",
+        "rtspStream": "RTSP-ström",
+        "deviceLabel": "Ljudenhet",
+        "deviceLoading": "Laddar ljudenheter...",
+        "noDevicesFound": "Inga ljudenheter hittades. Prova att konfigurera en RTSP-ström istället.",
+        "rtspUrlLabel": "Ström-URL",
         "rtspUrlPlaceholder": "rtsp://user:password@host:port/stream",
-        "rtspUrlHelp": "Enter the URL of your RTSP audio stream",
-        "additionalSourcesHint": "You can add more audio sources later in Settings."
+        "rtspUrlHelp": "Ange URL:en till din RTSP-ljudström",
+        "additionalSourcesHint": "Du kan lägga till fler ljudkällor senare under Inställningar."
       },
       "detection": {
-        "title": "Detection Threshold",
-        "description": "Choose how strict the bird identification should be. You can adjust this later in Settings.",
-        "balanced": "Balanced",
-        "balancedDesc": "Good balance of accuracy and sensitivity",
-        "balancedRecommended": "Recommended",
-        "highAccuracy": "High Accuracy",
-        "highAccuracyDesc": "Fewer false positives, may miss some birds",
-        "highSensitivity": "High Sensitivity",
-        "highSensitivityDesc": "More detections, more false positives",
-        "threshold": "Confidence threshold",
-        "fpFilterNote": "Once your system is running and proven, you can enable the false positive filter in Settings to further reduce incorrect detections."
+        "title": "Detekteringströskel",
+        "description": "Välj hur strikt fågelidentifieringen ska vara. Du kan justera detta senare under Inställningar.",
+        "balanced": "Balanserad",
+        "balancedDesc": "Bra balans mellan noggrannhet och känslighet",
+        "balancedRecommended": "Rekommenderad",
+        "highAccuracy": "Hög noggrannhet",
+        "highAccuracyDesc": "Färre falska positiva, kan missa vissa fåglar",
+        "highSensitivity": "Hög känslighet",
+        "highSensitivityDesc": "Fler detekteringar, fler falska positiva",
+        "threshold": "Konfidenströskel",
+        "fpFilterNote": "När ditt system är igång och beprövat kan du aktivera filtret för falska positiva under Inställningar för att ytterligare minska felaktiga detekteringar."
       },
       "integration": {
-        "title": "Privacy & Integration",
-        "privacyFilterLabel": "Enable privacy filter",
-        "privacyFilterHelp": "Filters out detections when human voices are detected near the microphone",
-        "birdweatherLabel": "Share detections with BirdWeather",
-        "birdweatherHelp": "Contribute your bird detections to the BirdWeather community network",
-        "birdweatherIdLabel": "BirdWeather Station ID",
-        "birdweatherIdPlaceholder": "Enter your BirdWeather station ID",
-        "errorReportingLabel": "Send anonymous error reports",
-        "errorReportingHelp": "Help improve BirdNET-Go by sending anonymous error reports when something goes wrong"
+        "title": "Integritet och integration",
+        "privacyFilterLabel": "Aktivera integritetsfilter",
+        "privacyFilterHelp": "Filtrerar bort detekteringar när mänskliga röster upptäcks nära mikrofonen",
+        "birdweatherLabel": "Dela detekteringar med BirdWeather",
+        "birdweatherHelp": "Bidra med dina fågeldetekteringar till BirdWeather-gemenskapsnätverket",
+        "birdweatherIdLabel": "BirdWeather stations-ID",
+        "birdweatherIdPlaceholder": "Ange ditt BirdWeather stations-ID",
+        "errorReportingLabel": "Skicka anonyma felrapporter",
+        "errorReportingHelp": "Hjälp till att förbättra BirdNET-Go genom att skicka anonyma felrapporter när något går fel"
       },
       "responsibleUse": {
-        "title": "Using BirdNET-Go Responsibly",
-        "intro": "BirdNET-Go is a powerful tool that enhances your birding experience through AI-assisted identification. To ensure the best outcomes for both birding and conservation:",
-        "point1": "Review and verify detections before sharing observations",
-        "point2": "Use the confidence scores as a guide, not absolute truth",
-        "point3": "Cross-reference with field guides and local expertise",
-        "point4": "Consider seasonal patterns and habitat suitability",
-        "citizenScienceHeading": "When contributing to citizen science:",
-        "citizenPoint1": "Only submit observations you have personally verified",
-        "citizenPoint2": "Include notes about visual or behavioral confirmation",
-        "citizenPoint3": "Use AI detections as a starting point for your own observations",
-        "outro": "This approach ensures data quality for scientific research while maximizing your learning and enjoyment of birds.",
-        "acknowledge": "I understand"
+        "title": "Ansvarsfull användning av BirdNET-Go",
+        "intro": "BirdNET-Go är ett kraftfullt verktyg som förbättrar din fågelskådning genom AI-assisterad identifiering. För att säkerställa bästa resultat för både fågelskådning och naturvård:",
+        "point1": "Granska och verifiera detekteringar innan du delar observationer",
+        "point2": "Använd konfidenspoängen som vägledning, inte som absolut sanning",
+        "point3": "Korskontrollera med fälthandböcker och lokal expertis",
+        "point4": "Beakta säsongsmönster och habitatlämplighet",
+        "citizenScienceHeading": "När du bidrar till medborgarforskning:",
+        "citizenPoint1": "Skicka bara in observationer du personligen har verifierat",
+        "citizenPoint2": "Inkludera anteckningar om visuell eller beteendemässig bekräftelse",
+        "citizenPoint3": "Använd AI-detekteringar som utgångspunkt för dina egna observationer",
+        "outro": "Detta tillvägagångssätt säkerställer datakvalitet för vetenskaplig forskning samtidigt som det maximerar ditt lärande och din glädje av fåglar.",
+        "acknowledge": "Jag förstår"
       }
     }
   },

--- a/frontend/tests/e2e/settings/locale-persistence.spec.ts
+++ b/frontend/tests/e2e/settings/locale-persistence.spec.ts
@@ -28,6 +28,7 @@ const LOCALE_DATA: {
   { code: 'fi', name: 'Suomi', settingsTranslation: 'Asetukset' },
   { code: 'fr', name: 'Francais', settingsTranslation: 'Paramètres' },
   { code: 'it', name: 'Italiano', settingsTranslation: 'Impostazioni' },
+  { code: 'hu', name: 'Magyar', settingsTranslation: 'Beállítások' },
   { code: 'nl', name: 'Nederlands', settingsTranslation: 'Instellingen' },
   { code: 'pl', name: 'Polski', settingsTranslation: 'Ustawienia' },
   { code: 'pt', name: 'Portugues', settingsTranslation: 'Configurações' },

--- a/internal/alerting/engine.go
+++ b/internal/alerting/engine.go
@@ -7,10 +7,10 @@ import (
 	"maps"
 	"runtime/debug"
 	"slices"
-	"strings"
 	"sync"
 	"time"
 
+	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/datastore/v2/entities"
 	"github.com/tphakala/birdnet-go/internal/datastore/v2/repository"
 	"github.com/tphakala/birdnet-go/internal/logger"
@@ -427,7 +427,7 @@ func (e *Engine) StartHistoryCleanup(retentionDays int) {
 			case <-ticker.C:
 				deleted, err := e.deleteHistoryWithRetry(retentionDays, stopCh)
 				if err != nil {
-					if isDBLockError(err) {
+					if datastore.IsTransientDBError(err) {
 						// Transient SQLite lock contention — the cleanup runs hourly,
 						// so it will succeed on the next tick. Log as warning only;
 						// do not report to Sentry.
@@ -480,7 +480,7 @@ func (e *Engine) deleteHistoryWithRetry(retentionDays int, stopCh <-chan struct{
 		lastErr = err
 
 		// Only retry on transient DB lock errors; bail immediately on other errors.
-		if !isDBLockError(err) || attempt == cleanupMaxRetries-1 {
+		if !datastore.IsTransientDBError(err) || attempt == cleanupMaxRetries-1 {
 			return 0, err
 		}
 
@@ -517,11 +517,4 @@ func (e *Engine) stopCleanup() {
 // Stop shuts down background goroutines (history cleanup).
 func (e *Engine) Stop() {
 	e.stopCleanup()
-}
-
-// isDBLockError checks if an error is a transient SQLite database lock error.
-func isDBLockError(err error) bool {
-	errStr := err.Error()
-	return strings.Contains(errStr, "database is locked") ||
-		strings.Contains(errStr, "SQLITE_BUSY")
 }

--- a/internal/alerting/engine_test.go
+++ b/internal/alerting/engine_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/datastore/v2/entities"
 	"github.com/tphakala/birdnet-go/internal/datastore/v2/repository"
 	"github.com/tphakala/birdnet-go/internal/logger"
@@ -754,7 +755,7 @@ func TestDeleteHistoryWithRetry_ExhaustsRetriesOnPersistentLock(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Equal(t, int64(0), deleted)
-	assert.True(t, isDBLockError(err), "error should be a DB lock error")
+	assert.True(t, datastore.IsTransientDBError(err), "error should be a DB lock error")
 	assert.Equal(t, int64(3), repo.deleteCalls.Load(), "should attempt exactly cleanupMaxRetries times")
 }
 
@@ -796,11 +797,11 @@ func TestDeleteHistoryWithRetry_AbortsOnStop(t *testing.T) {
 }
 
 func TestIsDBLockError(t *testing.T) {
-	assert.True(t, isDBLockError(fmt.Errorf("database is locked")))
-	assert.True(t, isDBLockError(fmt.Errorf("SQLITE_BUSY")))
-	assert.True(t, isDBLockError(fmt.Errorf("some context: database is locked")))
-	assert.False(t, isDBLockError(fmt.Errorf("disk I/O error")))
-	assert.False(t, isDBLockError(fmt.Errorf("connection refused")))
+	assert.True(t, datastore.IsTransientDBError(fmt.Errorf("database is locked")))
+	assert.True(t, datastore.IsTransientDBError(fmt.Errorf("SQLITE_BUSY")))
+	assert.True(t, datastore.IsTransientDBError(fmt.Errorf("some context: database is locked")))
+	assert.False(t, datastore.IsTransientDBError(fmt.Errorf("disk I/O error")))
+	assert.False(t, datastore.IsTransientDBError(fmt.Errorf("connection refused")))
 }
 
 func TestEngine_NoEscalationSteps_LegacyBehavior(t *testing.T) {

--- a/internal/analysis/database_migration.go
+++ b/internal/analysis/database_migration.go
@@ -76,16 +76,16 @@ func setupMigrationWorker(cfg *migrationSetupConfig) error {
 			Build()
 	}
 
-	labelRepo := repository.NewLabelRepository(v2DB, cfg.useV2Prefix, isMySQL)
-	modelRepo := repository.NewModelRepository(v2DB, cfg.useV2Prefix, isMySQL)
-	sourceRepo := repository.NewAudioSourceRepository(v2DB, cfg.useV2Prefix, isMySQL)
-	v2DetectionRepo := repository.NewDetectionRepository(v2DB, cfg.useV2Prefix, isMySQL)
+	labelRepo := repository.NewLabelRepository(v2DB, nil, cfg.useV2Prefix, isMySQL)
+	modelRepo := repository.NewModelRepository(v2DB, nil, cfg.useV2Prefix, isMySQL)
+	sourceRepo := repository.NewAudioSourceRepository(v2DB, nil, cfg.useV2Prefix, isMySQL)
+	v2DetectionRepo := repository.NewDetectionRepository(v2DB, nil, cfg.useV2Prefix, isMySQL)
 
 	// Create repositories for auxiliary data migration
-	weatherRepo := repository.NewWeatherRepository(v2DB, cfg.useV2Prefix, isMySQL)
-	imageCacheRepo := repository.NewImageCacheRepository(v2DB, labelRepo, cfg.useV2Prefix, isMySQL)
-	thresholdRepo := repository.NewDynamicThresholdRepository(v2DB, labelRepo, cfg.useV2Prefix, isMySQL)
-	notificationRepo := repository.NewNotificationHistoryRepository(v2DB, labelRepo, cfg.useV2Prefix, isMySQL)
+	weatherRepo := repository.NewWeatherRepository(v2DB, nil, cfg.useV2Prefix, isMySQL)
+	imageCacheRepo := repository.NewImageCacheRepository(v2DB, nil, labelRepo, cfg.useV2Prefix, isMySQL)
+	thresholdRepo := repository.NewDynamicThresholdRepository(v2DB, nil, labelRepo, cfg.useV2Prefix, isMySQL)
+	notificationRepo := repository.NewNotificationHistoryRepository(v2DB, nil, labelRepo, cfg.useV2Prefix, isMySQL)
 
 	// Create the legacy detection repository
 	legacyRepo := datastore.NewDetectionRepository(cfg.ds, time.Local)
@@ -437,14 +437,14 @@ func initializeV2OnlyMode(settings *conf.Settings) (*v2only.Datastore, error) {
 	// Create repositories
 	v2DB := v2Manager.DB()
 	isMySQL := settings.Output.MySQL.Enabled // Determine dialect from settings
-	detectionRepo := repository.NewDetectionRepository(v2DB, useV2Prefix, isMySQL)
-	labelRepo := repository.NewLabelRepository(v2DB, useV2Prefix, isMySQL)
-	modelRepo := repository.NewModelRepository(v2DB, useV2Prefix, isMySQL)
-	sourceRepo := repository.NewAudioSourceRepository(v2DB, useV2Prefix, isMySQL)
-	weatherRepo := repository.NewWeatherRepository(v2DB, useV2Prefix, isMySQL)
-	imageCacheRepo := repository.NewImageCacheRepository(v2DB, labelRepo, useV2Prefix, isMySQL)
-	thresholdRepo := repository.NewDynamicThresholdRepository(v2DB, labelRepo, useV2Prefix, isMySQL)
-	notificationRepo := repository.NewNotificationHistoryRepository(v2DB, labelRepo, useV2Prefix, isMySQL)
+	detectionRepo := repository.NewDetectionRepository(v2DB, nil, useV2Prefix, isMySQL)
+	labelRepo := repository.NewLabelRepository(v2DB, nil, useV2Prefix, isMySQL)
+	modelRepo := repository.NewModelRepository(v2DB, nil, useV2Prefix, isMySQL)
+	sourceRepo := repository.NewAudioSourceRepository(v2DB, nil, useV2Prefix, isMySQL)
+	weatherRepo := repository.NewWeatherRepository(v2DB, nil, useV2Prefix, isMySQL)
+	imageCacheRepo := repository.NewImageCacheRepository(v2DB, nil, labelRepo, useV2Prefix, isMySQL)
+	thresholdRepo := repository.NewDynamicThresholdRepository(v2DB, nil, labelRepo, useV2Prefix, isMySQL)
+	notificationRepo := repository.NewNotificationHistoryRepository(v2DB, nil, labelRepo, useV2Prefix, isMySQL)
 
 	// Load eBird taxonomy for species code lookups in analytics endpoints.
 	_, scientificIndex, taxonomyErr := birdnet.LoadTaxonomyData("")

--- a/internal/analysis/processor/actions_database.go
+++ b/internal/analysis/processor/actions_database.go
@@ -5,7 +5,6 @@ package processor
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
 	"time"
@@ -17,7 +16,6 @@ import (
 	"github.com/tphakala/birdnet-go/internal/detection"
 	"github.com/tphakala/birdnet-go/internal/events"
 	"github.com/tphakala/birdnet-go/internal/logger"
-	"github.com/tphakala/birdnet-go/internal/privacy"
 )
 
 // Execute logs the note to the log file.
@@ -140,8 +138,6 @@ func (a *DatabaseAction) ExecuteContext(ctx context.Context, _ any) error {
 	}
 
 	// Share the database ID with downstream actions (MQTT, SSE) immediately.
-	// This must happen before audio export so downstream actions get the ID
-	// even if audio export fails.
 	if a.DetectionCtx != nil {
 		a.DetectionCtx.NoteID.Store(uint64(a.Result.ID))
 	}
@@ -149,123 +145,15 @@ func (a *DatabaseAction) ExecuteContext(ctx context.Context, _ any) error {
 	// After successful save, publish detection event for new species
 	a.publishNewSpeciesDetectionEvent(isNewSpecies, daysSinceFirstSeen)
 
-	// Save audio clip to file if enabled.
-	// IMPORTANT: Audio export errors are logged but NOT returned.
-	// This allows downstream actions (SSE, MQTT) to proceed with the detection.
-	// The detection record is valuable even without audio - users integrating with
-	// Home Assistant want the detection event regardless of audio export status.
-	if a.Settings.Realtime.Audio.Export.Enabled {
-		captureLength := a.Settings.Realtime.Audio.Export.Length
-		if !a.Result.EndTime.IsZero() && !a.Result.BeginTime.IsZero() {
-			// Duration = EndTime - BeginTime + PreCapture (audio starts PreCapture seconds before BeginTime)
-			preCapture := a.Settings.Realtime.Audio.Export.PreCapture
-			derivedLength := int(a.Result.EndTime.Sub(a.Result.BeginTime).Seconds()) + preCapture
-			if derivedLength > captureLength {
-				captureLength = derivedLength
-				GetLogger().Info("Using derived capture duration from detection time span",
-					logger.String("detection_id", a.CorrelationID),
-					logger.String("species", a.Result.Species.CommonName),
-					logger.Int("duration_seconds", captureLength),
-					logger.Int("configured_length", a.Settings.Realtime.Audio.Export.Length),
-					logger.String("operation", "extended_capture_audio_export"))
-			}
-		}
-		// Cap at capture buffer size to prevent reading beyond buffer bounds.
-		// Determine actual buffer size: use extended capture buffer if configured,
-		// otherwise fall back to the default capture buffer.
-		bufferCap := conf.DefaultCaptureBufferSeconds
-		if a.Settings.Realtime.ExtendedCapture.Enabled && a.Settings.Realtime.ExtendedCapture.CaptureBufferSeconds > 0 {
-			bufferCap = a.Settings.Realtime.ExtendedCapture.CaptureBufferSeconds
-		}
-		if captureLength > bufferCap {
-			GetLogger().Warn("Capping capture length at buffer size",
-				logger.String("detection_id", a.CorrelationID),
-				logger.Int("requested_seconds", captureLength),
-				logger.Int("buffer_seconds", bufferCap),
-				logger.String("operation", "capture_buffer_cap"))
-			captureLength = bufferCap
-		}
-
-		// debug log note begin, end and capture length
-		GetLogger().Debug("Saving detection audio clip",
-			logger.String("component", "analysis.processor.actions"),
-			logger.String("detection_id", a.CorrelationID),
-			logger.Time("begin_time", a.Result.BeginTime),
-			logger.Time("end_time", a.Result.EndTime),
-			logger.Int("capture_length", captureLength),
-			logger.String("operation", "note_begin_end_capture_length"))
-
-		// handleAudioExportError logs the error.
-		// This helper reduces duplication between buffer read and save failures.
-		handleAudioExportError := func(err error, extraFields ...logger.Field) {
-			fields := make([]logger.Field, 0, 5+len(extraFields))
-			fields = append(fields,
-				logger.String("component", "analysis.processor.actions"),
-				logger.String("detection_id", a.CorrelationID),
-				logger.Error(err),
-				logger.String("species", a.Result.Species.CommonName),
-				logger.String("operation", "audio_export_non_fatal"),
-			)
-			fields = append(fields, extraFields...)
-			GetLogger().Error("Audio export failed (continuing with detection broadcast)", fields...)
-		}
-
-		// export audio clip from capture buffer
-		GetLogger().Debug("Reading capture buffer for audio clip",
-			logger.String("component", "analysis.processor.actions"),
-			logger.String("detection_id", a.CorrelationID),
-			logger.String("source_id", a.Result.AudioSource.ID),
-			logger.Time("begin_time", a.Result.BeginTime),
-			logger.Int("duration_seconds", captureLength),
-			logger.Bool("buffer_mgr_available", a.processor != nil && a.processor.BufferMgr != nil),
-			logger.String("operation", "capture_buffer_read"))
-		pcmData, err := a.readCaptureSegment(a.Result.AudioSource.ID, a.Result.BeginTime, captureLength)
-		if err != nil {
-			handleAudioExportError(err,
-				logger.String("source", a.Result.AudioSource.SafeString),
-				logger.Time("begin_time", a.Result.BeginTime),
-				logger.Int("duration_seconds", captureLength))
-		} else {
-			GetLogger().Debug("Capture buffer read successful",
-				logger.String("component", "analysis.processor.actions"),
-				logger.String("detection_id", a.CorrelationID),
-				logger.Int("pcm_bytes", len(pcmData)),
-				logger.String("operation", "capture_buffer_read_success"))
-			// Create a SaveAudioAction and execute it
-			saveAudioAction := &SaveAudioAction{
-				Settings:      a.Settings,
-				ClipName:      a.Result.ClipName,
-				pcmData:       pcmData,
-				NoteID:        a.Result.ID,
-				PreRenderer:   a.PreRenderer,
-				CorrelationID: a.CorrelationID,
-			}
-
-			if err := saveAudioAction.Execute(ctx, nil); err != nil {
-				handleAudioExportError(err, logger.String("clip_name", a.Result.ClipName))
-			} else {
-				// Signal downstream actions (MQTT, SSE) that the clip file exists.
-				// Without this flag, downstream actions would report a phantom ClipName
-				// for detections where the export failed (GitHub #107).
-				if a.DetectionCtx != nil {
-					a.DetectionCtx.ClipSaved.Store(true)
-				}
-
-				if a.Settings.Debug {
-					// Add structured logging
-					GetLogger().Debug("Saved audio clip successfully",
-						logger.String("component", "analysis.processor.actions"),
-						logger.String("detection_id", a.CorrelationID),
-						logger.String("species", a.Result.Species.CommonName),
-						logger.String("clip_name", a.Result.ClipName),
-						logger.String("detection_time", a.Result.Time()),
-						logger.Time("begin_time", a.Result.BeginTime),
-						logger.Time("end_time", time.Now()),
-						logger.String("operation", "save_audio_clip_debug"))
-				}
-			}
-		}
-	}
+	// NOTE: Audio export is intentionally NOT performed here.
+	// It runs as a separate action (SaveAudioAction) outside the CompositeAction
+	// that contains Database -> SSE -> MQTT. This prevents slow audio encoding
+	// (e.g., FFmpeg on Raspberry Pi) from blocking SSE/MQTT broadcasts and
+	// causing CompositeAction 30s timeouts (Sentry BIRDNET-GO-WD).
+	//
+	// The media API already handles the race where SSE broadcasts a ClipName
+	// before the audio file is on disk, using waitForAudioFile() with retries
+	// and 503 + Retry-After responses.
 
 	return nil
 }
@@ -394,23 +282,49 @@ func (a *DatabaseAction) publishNewSpeciesDetectionEvent(isNewSpecies bool, days
 	}
 }
 
-// readCaptureSegment reads PCM data from the audiocore capture buffer.
-// startTime is the segment start, duration is in seconds.
-func (a *DatabaseAction) readCaptureSegment(sourceID string, startTime time.Time, duration int) ([]byte, error) {
-	safeSource := privacy.SanitizeStreamUrl(sourceID)
-	if a.processor == nil || a.processor.BufferMgr == nil {
-		return nil, fmt.Errorf("buffer manager not available for source %s", safeSource)
-	}
-	cb, err := a.processor.BufferMgr.CaptureBuffer(sourceID)
-	if err != nil {
-		return nil, fmt.Errorf("no capture buffer for source %s: %w", safeSource, err)
-	}
-	endTime := startTime.Add(time.Duration(duration) * time.Second)
-	return cb.ReadSegment(startTime, endTime)
-}
-
 // Execute saves the audio clip to a file
 func (a *SaveAudioAction) Execute(ctx context.Context, _ any) error {
+	// Hot-reload guard: skip export if audio export was disabled at runtime.
+	// This mirrors the pattern used by MqttAction and BirdWeatherAction.
+	if !a.Settings.Realtime.Audio.Export.Enabled {
+		GetLogger().Debug("Skipping audio export: disabled at runtime",
+			logger.String("component", "analysis.processor.actions"),
+			logger.String("detection_id", a.CorrelationID),
+			logger.String("clip_name", a.ClipName),
+			logger.String("operation", "audio_export_disabled"))
+		return nil
+	}
+
+	// If PCM data was not captured (e.g., buffer read failed), skip export.
+	if len(a.pcmData) == 0 {
+		GetLogger().Warn("Skipping audio export: no PCM data available",
+			logger.String("component", "analysis.processor.actions"),
+			logger.String("detection_id", a.CorrelationID),
+			logger.String("clip_name", a.ClipName),
+			logger.String("operation", "audio_export_skip"))
+		return nil
+	}
+
+	// Resolve NoteID from DetectionContext (set by DatabaseAction).
+	if a.DetectionCtx != nil {
+		const noteIDWaitTimeout = 5 * time.Second
+		const noteIDPollInterval = 50 * time.Millisecond
+		deadline := time.Now().Add(noteIDWaitTimeout)
+		for time.Now().Before(deadline) {
+			if liveID := uint(a.DetectionCtx.NoteID.Load()); liveID > 0 {
+				a.NoteID = liveID
+				break
+			}
+			select {
+			case <-ctx.Done():
+			case <-time.After(noteIDPollInterval):
+			}
+			if ctx.Err() != nil {
+				break
+			}
+		}
+	}
+
 	// Get the full path by joining the export path with the relative clip name
 	outputPath := filepath.Join(a.Settings.Realtime.Audio.Export.Path, a.ClipName)
 
@@ -472,6 +386,12 @@ func (a *SaveAudioAction) Execute(ctx context.Context, _ any) error {
 		logger.Int64("file_size_bytes", fileSize),
 		logger.String("format", a.Settings.Realtime.Audio.Export.Type),
 		logger.String("operation", "audio_export_success"))
+
+	// Signal that the clip file exists on disk. This is used by any late
+	// consumers that check whether the audio was actually exported.
+	if a.DetectionCtx != nil {
+		a.DetectionCtx.ClipSaved.Store(true)
+	}
 
 	// Submit for pre-rendering if enabled
 	if a.Settings.Realtime.Dashboard.Spectrogram.Enabled && a.PreRenderer != nil {

--- a/internal/analysis/processor/actions_integrations.go
+++ b/internal/analysis/processor/actions_integrations.go
@@ -204,11 +204,12 @@ func (a *MqttAction) Execute(_ context.Context, data any) error {
 		note.ID = detectionID
 	}
 
-	// Clear ClipName if audio export did not succeed, to avoid reporting a phantom
-	// filename for clips that don't exist on disk (GitHub #107).
-	if a.DetectionCtx != nil && !a.DetectionCtx.ClipSaved.Load() {
-		note.ClipName = ""
-	}
+	// NOTE: ClipName is always included in the MQTT payload, even though the
+	// audio file may not be on disk yet. Audio export runs independently after
+	// the CompositeAction completes. Home Assistant and other MQTT consumers
+	// that construct audio URLs from ClipName should handle 404/503 responses
+	// gracefully, or use the detection ID-based audio endpoint which has
+	// built-in wait-for-encoding support.
 
 	// Wrap note with bird image and include detection ID and SourceID
 	noteWithBirdImage := NoteWithBirdImage{
@@ -382,11 +383,13 @@ func (a *SSEAction) Execute(_ context.Context, data any) error {
 	// Convert Result to Note for SSEBroadcaster (backward compatible SSE payload)
 	note := datastore.NoteFromResult(&a.Result)
 
-	// Clear ClipName if audio export did not succeed, to avoid reporting a phantom
-	// filename for clips that don't exist on disk (GitHub #107).
-	if a.DetectionCtx != nil && !a.DetectionCtx.ClipSaved.Load() {
-		note.ClipName = ""
-	}
+	// NOTE: ClipName is always included in the SSE payload, even though the audio
+	// file may not be on disk yet. Audio export runs as a separate independent
+	// action after the DB -> SSE -> MQTT composite completes. The media API
+	// handles this race gracefully: waitForAudioFile() polls for the file with
+	// retries, and returns 503 + Retry-After if it's still being encoded.
+	// This is better than clearing ClipName, which would prevent the frontend
+	// from ever showing the audio player for the detection.
 
 	// Broadcast the detection with error handling
 	if err := a.SSEBroadcaster(&note, &birdImage); err != nil {

--- a/internal/analysis/processor/actions_types.go
+++ b/internal/analysis/processor/actions_types.go
@@ -34,20 +34,21 @@ const (
 )
 
 // DetectionContext provides thread-safe shared state for detection pipeline actions.
-// This enables downstream actions (MQTT, SSE) to access data set by upstream actions
-// (Database) without polling, when used with CompositeAction for sequential execution.
+// This enables downstream actions (MQTT, SSE, SaveAudio) to access data set by
+// upstream actions (Database) without polling, when used with CompositeAction for
+// sequential execution.
 //
 // The context is created once per detection in getActionsForItem() and shared among
 // all actions that need access to the database-assigned detection ID.
 type DetectionContext struct {
 	// NoteID holds the database primary key after successful save.
-	// Use atomic operations: Store() in DatabaseAction, Load() in MqttAction/SSEAction.
+	// Use atomic operations: Store() in DatabaseAction, Load() in MqttAction/SSEAction/SaveAudioAction.
 	NoteID atomic.Uint64
 
 	// ClipSaved indicates whether the audio clip was successfully exported to disk.
-	// DatabaseAction sets this to true after successful audio export.
-	// Downstream actions (MQTT, SSE) check this to avoid reporting a phantom ClipName
-	// for detections where the audio export failed (GitHub #107).
+	// SaveAudioAction sets this to true after successful audio export.
+	// This flag is available for any late consumers that need to know whether the
+	// audio file exists on disk.
 	ClipSaved atomic.Bool
 }
 
@@ -83,8 +84,7 @@ type DatabaseAction struct {
 	EventTracker      *EventTracker
 	NewSpeciesTracker *species.SpeciesTracker // Add reference to new species tracker
 	processor         *Processor              // Add reference to processor for source name resolution
-	PreRenderer       PreRendererSubmit       // Spectrogram pre-renderer
-	DetectionCtx      *DetectionContext       // Shared context for downstream actions (MQTT, SSE)
+	DetectionCtx      *DetectionContext       // Shared context for downstream actions (MQTT, SSE, SaveAudio)
 	Description       string
 	CorrelationID     string     // Detection correlation ID for log tracking
 	mu                sync.Mutex // Protect concurrent access to Result and Results
@@ -93,9 +93,10 @@ type DatabaseAction struct {
 type SaveAudioAction struct {
 	Settings      *conf.Settings
 	ClipName      string
-	pcmData       []byte
+	pcmData       []byte            // Pre-read PCM data (set by buildSaveAudioAction)
 	NoteID        uint              // Note ID for correlation logging with pre-renderer
 	PreRenderer   PreRendererSubmit // Injected from processor
+	DetectionCtx  *DetectionContext // Shared context to signal ClipSaved to late consumers
 	EventTracker  *EventTracker
 	Description   string
 	CorrelationID string // Detection correlation ID for log tracking

--- a/internal/analysis/processor/mqtt_action_test.go
+++ b/internal/analysis/processor/mqtt_action_test.go
@@ -488,7 +488,7 @@ func TestMqttAction_Execute_DisabledAfterCreation(t *testing.T) {
 // TestMqttAction_Execute_ClearsClipNameWhenExportFailed verifies that MqttAction
 // clears ClipName in the MQTT payload when audio export did not succeed.
 // This prevents reporting phantom filenames for clips that don't exist (GitHub #107).
-func TestMqttAction_Execute_ClearsClipNameWhenExportFailed(t *testing.T) {
+func TestMqttAction_Execute_IncludesClipNameEvenBeforeExport(t *testing.T) {
 	t.Parallel()
 
 	mockClient := NewMockMQTTClient()
@@ -501,7 +501,9 @@ func TestMqttAction_Execute_ClearsClipNameWhenExportFailed(t *testing.T) {
 	det := testDetection()
 	det.Result.ClipName = "2024/01/parus_major_95p_20240115T120000Z.wav"
 
-	// DetectionContext with ClipSaved=false (default) simulates export failure
+	// DetectionContext with ClipSaved=false (default) - audio export hasn't run yet.
+	// MQTT should still include ClipName because audio export runs independently
+	// and consumers should handle missing files gracefully.
 	detectionCtx := &DetectionContext{}
 	detectionCtx.NoteID.Store(1)
 
@@ -520,8 +522,8 @@ func TestMqttAction_Execute_ClearsClipNameWhenExportFailed(t *testing.T) {
 	err = json.Unmarshal([]byte(mockClient.GetPublishedPayload()), &jsonMap)
 	require.NoError(t, err)
 
-	assert.Empty(t, jsonMap["ClipName"],
-		"ClipName should be empty when audio export failed (GitHub #107)")
+	assert.Equal(t, "2024/01/parus_major_95p_20240115T120000Z.wav", jsonMap["ClipName"],
+		"ClipName should always be included; audio export runs independently")
 }
 
 // TestMqttAction_Execute_PreservesClipNameWhenExportSucceeded verifies that MqttAction

--- a/internal/analysis/processor/processor.go
+++ b/internal/analysis/processor/processor.go
@@ -1569,8 +1569,7 @@ func (p *Processor) getDefaultActions(det *Detections) []Action {
 			Settings:          p.Settings,
 			EventTracker:      p.GetEventTracker(),
 			NewSpeciesTracker: tracker,
-			processor:         p, // Add processor reference for source name resolution
-			PreRenderer:       p.preRenderer,
+			processor:         p,            // Add processor reference for source name resolution
 			DetectionCtx:      detectionCtx, // Share context for downstream actions
 			Result:            det.Result,   // Domain model (single source of truth)
 			Results:           det.Results,  // Domain model - converted to legacy format at save time
@@ -1647,6 +1646,12 @@ func (p *Processor) getDefaultActions(det *Detections) []Action {
 	// - SSE/MQTT receive the correct detection ID for URL construction
 	// - No polling needed (eliminates the old 5-second sleep hack in SSE)
 	//
+	// IMPORTANT: Audio export is NOT included in this CompositeAction. It runs as a
+	// separate independent action to prevent slow FFmpeg encoding (especially on
+	// Raspberry Pi) from blocking SSE/MQTT broadcasts. The media API handles the
+	// race where a client requests audio before export completes, using server-side
+	// wait with retries and 503 + Retry-After responses.
+	//
 	// See: https://github.com/tphakala/birdnet-go/issues/1158 (race condition)
 	// See: https://github.com/tphakala/birdnet-go/issues/1748 (detection ID in MQTT)
 	var sequentialActions []Action
@@ -1671,6 +1676,16 @@ func (p *Processor) getDefaultActions(det *Detections) []Action {
 	} else if len(sequentialActions) == 1 {
 		// Only one action enabled, add it directly
 		actions = append(actions, sequentialActions[0])
+	}
+
+	// Add SaveAudioAction if audio export is enabled.
+	// This runs as an INDEPENDENT action (not inside the CompositeAction) so that
+	// slow audio encoding does not block the Database -> SSE -> MQTT pipeline.
+	// On resource-constrained hardware (RPi with SD cards), FFmpeg encoding can
+	// take 10-30+ seconds, which previously caused CompositeAction 30s timeouts
+	// (Sentry BIRDNET-GO-WD), preventing SSE/MQTT from ever firing.
+	if p.Settings.Realtime.Audio.Export.Enabled && databaseAction != nil {
+		actions = append(actions, p.buildSaveAudioAction(det, detectionCtx))
 	}
 
 	// Add BirdWeatherAction if enabled and client is initialized
@@ -1715,6 +1730,91 @@ func (p *Processor) getDefaultActions(det *Detections) []Action {
 	}
 
 	return actions
+}
+
+// buildSaveAudioAction creates a SaveAudioAction for the given detection.
+// It reads PCM data from the capture buffer eagerly (while the data is still
+// available) and returns an action that will encode and write the audio file
+// when executed by the job queue. This decouples the slow FFmpeg encoding
+// from the fast Database -> SSE -> MQTT pipeline.
+func (p *Processor) buildSaveAudioAction(det *Detections, detectionCtx *DetectionContext) *SaveAudioAction {
+	captureLength := p.Settings.Realtime.Audio.Export.Length
+	if !det.Result.EndTime.IsZero() && !det.Result.BeginTime.IsZero() {
+		preCapture := p.Settings.Realtime.Audio.Export.PreCapture
+		derivedLength := int(det.Result.EndTime.Sub(det.Result.BeginTime).Seconds()) + preCapture
+		if derivedLength > captureLength {
+			captureLength = derivedLength
+			GetLogger().Info("Using derived capture duration from detection time span",
+				logger.String("detection_id", det.CorrelationID),
+				logger.String("species", det.Result.Species.CommonName),
+				logger.Int("duration_seconds", captureLength),
+				logger.Int("configured_length", p.Settings.Realtime.Audio.Export.Length),
+				logger.String("operation", "extended_capture_audio_export"))
+		}
+	}
+
+	// Cap at capture buffer size to prevent reading beyond buffer bounds.
+	bufferCap := conf.DefaultCaptureBufferSeconds
+	if p.Settings.Realtime.ExtendedCapture.Enabled && p.Settings.Realtime.ExtendedCapture.CaptureBufferSeconds > 0 {
+		bufferCap = p.Settings.Realtime.ExtendedCapture.CaptureBufferSeconds
+	}
+	if captureLength > bufferCap {
+		GetLogger().Warn("Capping capture length at buffer size",
+			logger.String("detection_id", det.CorrelationID),
+			logger.Int("requested_seconds", captureLength),
+			logger.Int("buffer_seconds", bufferCap),
+			logger.String("operation", "capture_buffer_cap"))
+		captureLength = bufferCap
+	}
+
+	// Read PCM data from the capture buffer NOW, while the data is still in the
+	// ring buffer. By the time the job queue picks up the SaveAudioAction, the
+	// buffer may have been overwritten with newer audio data.
+	pcmData, err := p.readCaptureSegment(det.Result.AudioSource.ID, det.Result.BeginTime, captureLength)
+	if err != nil {
+		GetLogger().Error("Failed to read capture buffer for audio export",
+			logger.String("component", "analysis.processor.actions"),
+			logger.String("detection_id", det.CorrelationID),
+			logger.Error(err),
+			logger.String("source", det.Result.AudioSource.SafeString),
+			logger.Time("begin_time", det.Result.BeginTime),
+			logger.Int("duration_seconds", captureLength),
+			logger.String("operation", "capture_buffer_read_for_export"))
+		// Return an action with nil pcmData; Execute() will be a no-op
+		return &SaveAudioAction{
+			Settings:      p.Settings,
+			ClipName:      det.Result.ClipName,
+			NoteID:        det.Result.ID, // May be 0 here; updated after DB save via DetectionCtx
+			PreRenderer:   p.preRenderer,
+			DetectionCtx:  detectionCtx,
+			CorrelationID: det.CorrelationID,
+		}
+	}
+
+	return &SaveAudioAction{
+		Settings:      p.Settings,
+		ClipName:      det.Result.ClipName,
+		pcmData:       pcmData,
+		NoteID:        det.Result.ID, // May be 0 here; updated after DB save via DetectionCtx
+		PreRenderer:   p.preRenderer,
+		DetectionCtx:  detectionCtx,
+		CorrelationID: det.CorrelationID,
+	}
+}
+
+// readCaptureSegment reads PCM data from the audiocore capture buffer.
+// startTime is the segment start, duration is in seconds.
+func (p *Processor) readCaptureSegment(sourceID string, startTime time.Time, duration int) ([]byte, error) {
+	safeSource := privacy.SanitizeStreamUrl(sourceID)
+	if p.BufferMgr == nil {
+		return nil, fmt.Errorf("buffer manager not available for source %s", safeSource)
+	}
+	cb, err := p.BufferMgr.CaptureBuffer(sourceID)
+	if err != nil {
+		return nil, fmt.Errorf("no capture buffer for source %s: %w", safeSource, err)
+	}
+	endTime := startTime.Add(time.Duration(duration) * time.Second)
+	return cb.ReadSegment(startTime, endTime)
 }
 
 // GetBwClient safely returns the current BirdWeather client

--- a/internal/analysis/processor/sse_action_test.go
+++ b/internal/analysis/processor/sse_action_test.go
@@ -245,7 +245,7 @@ func TestSSEAction_Execute_ReturnsErrorOnBroadcastFailure(t *testing.T) {
 // TestSSEAction_Execute_ClearsClipNameWhenExportFailed verifies that SSEAction
 // clears ClipName in the broadcasted note when audio export did not succeed.
 // This prevents reporting phantom filenames for clips that don't exist (GitHub #107).
-func TestSSEAction_Execute_ClearsClipNameWhenExportFailed(t *testing.T) {
+func TestSSEAction_Execute_IncludesClipNameEvenBeforeExport(t *testing.T) {
 	t.Parallel()
 
 	mockBroadcaster := NewMockSSEBroadcaster()
@@ -255,7 +255,9 @@ func TestSSEAction_Execute_ClearsClipNameWhenExportFailed(t *testing.T) {
 	det := testDetection()
 	det.Result.ClipName = "2024/01/testus_birdus_95p_20240115T120000Z.wav"
 
-	// DetectionContext with ClipSaved=false (default) simulates export failure
+	// DetectionContext with ClipSaved=false (default) - audio export hasn't run yet.
+	// SSE should still include ClipName because audio export runs independently
+	// and the media API handles missing files with retries and 503 responses.
 	detectionCtx := &DetectionContext{}
 	detectionCtx.NoteID.Store(1)
 
@@ -272,8 +274,8 @@ func TestSSEAction_Execute_ClearsClipNameWhenExportFailed(t *testing.T) {
 
 	note := mockBroadcaster.GetLastNote()
 	require.NotNil(t, note)
-	assert.Empty(t, note.ClipName,
-		"ClipName should be empty when audio export failed (GitHub #107)")
+	assert.Equal(t, "2024/01/testus_birdus_95p_20240115T120000Z.wav", note.ClipName,
+		"ClipName should always be included; the media API handles missing files gracefully")
 }
 
 // TestSSEAction_Execute_NoClipNameBroadcastsQuickly verifies that SSEAction

--- a/internal/analysis/processor/threshold_persistence.go
+++ b/internal/analysis/processor/threshold_persistence.go
@@ -177,7 +177,7 @@ func (p *Processor) saveThresholdsWithRetry(dbThresholds []datastore.DynamicThre
 			return nil
 		}
 
-		if !isDBLockError(err) || attempt == maxRetries-1 {
+		if !datastore.IsTransientDBError(err) || attempt == maxRetries-1 {
 			GetLogger().Error("Failed to persist dynamic thresholds",
 				logger.Error(err),
 				logger.Int("threshold_count", len(dbThresholds)),
@@ -203,13 +203,6 @@ func (p *Processor) saveThresholdsWithRetry(dbThresholds []datastore.DynamicThre
 		}
 	}
 	return err
-}
-
-// isDBLockError checks if an error is a database lock error.
-func isDBLockError(err error) bool {
-	errStr := err.Error()
-	return strings.Contains(errStr, "database is locked") ||
-		strings.Contains(errStr, "SQLITE_BUSY")
 }
 
 // persistDynamicThresholds saves all current dynamic thresholds to the database

--- a/internal/api/v2/alerts.go
+++ b/internal/api/v2/alerts.go
@@ -59,7 +59,7 @@ func (c *Controller) initAlertRoutes() {
 	}
 
 	// Initialize repository lazily from V2Manager
-	c.alertRuleRepo = repository.NewAlertRuleRepository(c.V2Manager.DB())
+	c.alertRuleRepo = repository.NewAlertRuleRepository(c.V2Manager.DB(), nil)
 
 	// Initialize the alerting engine — seeds default rules and starts event processing
 	alertTelemetry := alerting.NewAlertingTelemetry()

--- a/internal/api/v2/app.go
+++ b/internal/api/v2/app.go
@@ -81,6 +81,7 @@ func (c *Controller) initAppRoutes() {
 		}
 		c.appMetadataRepo = repository.NewAppMetadataRepository(
 			c.V2Manager.DB(),
+			nil,
 			useV2Prefix,
 			c.V2Manager.IsMySQL(),
 		)

--- a/internal/conf/utils.go
+++ b/internal/conf/utils.go
@@ -5,6 +5,7 @@ import (
 	"bufio"
 	"fmt"
 	"io"
+	"math"
 	"net"
 	"os"
 	"os/exec"
@@ -276,11 +277,13 @@ func GetBoardModel() string {
 	return model
 }
 
-// ParsePercentage converts a percentage value to a float64 in the 0–100 range.
+// ParsePercentage converts a percentage value to a float64 in the 0-100 range.
 // Accepted formats:
-//   - "80%" or "99.5%" — explicit percentage suffix
-//   - "80" or "99.5"   — bare number, treated as a percentage (0–100)
-//   - "0.8"            — decimal in 0 < x < 1 range, auto-scaled to 0–100 (0.8 → 80)
+//   - "80%" or "99.5%" - explicit percentage suffix
+//   - "80" or "99.5"   - bare number, treated as a percentage (0-100)
+//   - "0.8"            - decimal in 0 < x < 1 range, auto-scaled to 0-100 (0.8 -> 80)
+//
+// Values outside [0, 100] (after auto-scaling) are rejected with a validation error.
 func ParsePercentage(percentage, configKey string) (float64, error) {
 	trimmed := strings.TrimSpace(percentage)
 	if trimmed == "" {
@@ -308,10 +311,32 @@ func ParsePercentage(percentage, configKey string) (float64, error) {
 			Build()
 	}
 
-	// Auto-scale fractional values (0 < x < 1) to the 0–100 range.
+	// Auto-scale fractional values (0 < x < 1) to the 0-100 range.
 	// A user writing "0.8" almost certainly means 80%, not 0.8%.
 	if value > 0 && value < 1 {
 		value *= 100
+	}
+
+	// Reject non-finite values (NaN, +Inf, -Inf) that strconv.ParseFloat
+	// accepts but are meaningless as percentages. NaN comparisons always
+	// return false, so the range check below would not catch it.
+	if math.IsNaN(value) || math.IsInf(value, 0) {
+		return 0, errors.Newf("invalid percentage format: value is not finite").
+			Component("conf").
+			Category(errors.CategoryValidation).
+			Context("input", percentage).
+			Context("config_key", configKey).
+			Build()
+	}
+
+	// Reject values outside the valid 0-100 range.
+	if value < 0 || value > 100 {
+		return 0, errors.Newf("invalid percentage format: value %.2f is outside the 0-100 range", value).
+			Component("conf").
+			Category(errors.CategoryValidation).
+			Context("input", percentage).
+			Context("config_key", configKey).
+			Build()
 	}
 
 	return value, nil

--- a/internal/conf/utils_test.go
+++ b/internal/conf/utils_test.go
@@ -105,25 +105,27 @@ func TestParsePercentage(t *testing.T) {
 	const testConfigKey = "disk_manager.retention_policy.min_disk_free"
 
 	tests := []struct {
-		name         string
-		input        string
-		wantValue    float64
-		wantErr      bool
-		wantParseErr bool // true = wrapped strconv.ParseFloat error
+		name             string
+		input            string
+		wantValue        float64
+		wantErr          bool
+		wantParseErr     bool // true = wrapped strconv.ParseFloat error
+		wantRangeErr     bool // true = out-of-range error
+		wantNonFiniteErr bool // true = NaN/Inf error
 	}{
 		// --- with % suffix ---
 		{name: "whole number with suffix", input: "85%", wantValue: 85.0},
 		{name: "zero percent", input: "0%", wantValue: 0.0},
 		{name: "one hundred percent", input: "100%", wantValue: 100.0},
 		{name: "fractional percent", input: "99.5%", wantValue: 99.5},
-		{name: "negative percent", input: "-10%", wantValue: -10.0},
 		// --- bare integers (no % suffix) ---
 		{name: "integer without suffix", input: "85", wantValue: 85.0},
 		{name: "hundred without suffix", input: "100", wantValue: 100.0},
 		{name: "zero without suffix", input: "0", wantValue: 0.0},
+		{name: "bare number 25", input: "25", wantValue: 25.0},
 		// --- bare decimals >= 1 ---
 		{name: "decimal without suffix", input: "99.5", wantValue: 99.5},
-		// --- fractional values auto-scaled (0 < x < 1 → x*100) ---
+		// --- fractional values auto-scaled (0 < x < 1 -> x*100) ---
 		{name: "fraction 0.8 scaled to 80", input: "0.8", wantValue: 80.0},
 		{name: "fraction 0.5 scaled to 50", input: "0.5", wantValue: 50.0},
 		{name: "fraction 0.01 scaled to 1", input: "0.01", wantValue: 1.0},
@@ -132,6 +134,15 @@ func TestParsePercentage(t *testing.T) {
 		{name: "leading whitespace trimmed", input: " 85%", wantValue: 85.0},
 		{name: "trailing whitespace trimmed", input: "85% ", wantValue: 85.0},
 		{name: "bare number with whitespace", input: " 80 ", wantValue: 80.0},
+		// --- out-of-range values ---
+		{name: "negative percent", input: "-10%", wantErr: true, wantRangeErr: true},
+		{name: "negative bare number", input: "-5", wantErr: true, wantRangeErr: true},
+		{name: "over 100 percent", input: "150%", wantErr: true, wantRangeErr: true},
+		{name: "over 100 bare number", input: "200", wantErr: true, wantRangeErr: true},
+		// --- non-finite values ---
+		{name: "NaN", input: "NaN", wantErr: true, wantNonFiniteErr: true},
+		{name: "positive infinity", input: "Inf", wantErr: true, wantNonFiniteErr: true},
+		{name: "negative infinity", input: "-Inf", wantErr: true, wantNonFiniteErr: true},
 		// --- invalid inputs ---
 		{name: "letters before suffix", input: "abc%", wantErr: true, wantParseErr: true},
 		{name: "empty before suffix", input: "%", wantErr: true, wantParseErr: true},
@@ -167,11 +178,18 @@ func TestParsePercentage(t *testing.T) {
 			assert.Equal(t, tt.input, ctx["input"], "context must carry the original input")
 			assert.Equal(t, testConfigKey, ctx["config_key"], "context must carry the config key")
 
-			if tt.wantParseErr {
-				assert.ErrorContains(t, err, "invalid syntax",
+			switch {
+			case tt.wantParseErr:
+				require.ErrorContains(t, err, "invalid syntax",
 					"parse errors must wrap the underlying ParseFloat error")
-			} else {
-				assert.ErrorContains(t, err, "invalid percentage format",
+			case tt.wantRangeErr:
+				require.ErrorContains(t, err, "outside the 0-100 range",
+					"range errors must indicate the value is out of bounds")
+			case tt.wantNonFiniteErr:
+				require.ErrorContains(t, err, "value is not finite",
+					"non-finite errors must indicate the value is NaN or Inf")
+			default:
+				require.ErrorContains(t, err, "invalid percentage format",
 					"format errors must carry the format-validation message")
 			}
 		})

--- a/internal/datastore/dynamic_threshold.go
+++ b/internal/datastore/dynamic_threshold.go
@@ -26,21 +26,24 @@ func (ds *DataStore) SaveDynamicThreshold(threshold *DynamicThreshold) error {
 	threshold.UpdatedAt = now
 
 	// Upsert: set FirstCreated only on INSERT; always update other fields
-	result := ds.DB.Where("species_name = ?", threshold.SpeciesName).
-		Attrs(DynamicThreshold{
-			FirstCreated: now, // Only set on INSERT
-		}).
-		Assign(*threshold).
-		FirstOrCreate(threshold)
+	return RetryOnLock("save_dynamic_threshold", func() error {
+		threshold.ID = 0 // Reset ID for retry safety with FirstOrCreate
+		result := ds.DB.Where("species_name = ?", threshold.SpeciesName).
+			Attrs(DynamicThreshold{
+				FirstCreated: now, // Only set on INSERT
+			}).
+			Assign(*threshold).
+			FirstOrCreate(threshold)
 
-	if result.Error != nil {
-		return dbError(result.Error, "save_dynamic_threshold", errors.PriorityMedium,
-			"species", threshold.SpeciesName,
-			"table", "dynamic_thresholds",
-			"action", "persist_learned_threshold")
-	}
+		if result.Error != nil {
+			return dbError(result.Error, "save_dynamic_threshold", errors.PriorityMedium,
+				"species", threshold.SpeciesName,
+				"table", "dynamic_thresholds",
+				"action", "persist_learned_threshold")
+		}
 
-	return nil
+		return nil
+	}, ds.getMetrics())
 }
 
 // GetDynamicThreshold retrieves a dynamic threshold for a specific species
@@ -99,34 +102,44 @@ func (ds *DataStore) DeleteDynamicThreshold(speciesName string) error {
 		return validationError("species name cannot be empty", "species_name", "")
 	}
 
-	result := ds.DB.Where("species_name = ?", speciesName).Delete(&DynamicThreshold{})
-	if result.Error != nil {
-		return dbError(result.Error, "delete_dynamic_threshold", errors.PriorityMedium,
-			"species", speciesName,
-			"action", "remove_learned_threshold")
-	}
-
-	return nil
+	return RetryOnLock("delete_dynamic_threshold", func() error {
+		result := ds.DB.Where("species_name = ?", speciesName).Delete(&DynamicThreshold{})
+		if result.Error != nil {
+			return dbError(result.Error, "delete_dynamic_threshold", errors.PriorityMedium,
+				"species", speciesName,
+				"action", "remove_learned_threshold")
+		}
+		return nil
+	}, ds.getMetrics())
 }
 
 // DeleteExpiredDynamicThresholds removes all dynamic thresholds that have expired
 // Returns the count of deleted thresholds
 // This is typically called periodically by a cleanup job
 func (ds *DataStore) DeleteExpiredDynamicThresholds(before time.Time) (int64, error) {
-	result := ds.DB.Where("expires_at < ?", before).Delete(&DynamicThreshold{})
-	if result.Error != nil {
-		return 0, dbError(result.Error, "delete_expired_dynamic_thresholds", errors.PriorityLow,
+	var rowsAffected int64
+	err := RetryOnLock("delete_expired_dynamic_thresholds", func() error {
+		result := ds.DB.Where("expires_at < ?", before).Delete(&DynamicThreshold{})
+		if result.Error != nil {
+			return result.Error
+		}
+		rowsAffected = result.RowsAffected
+		return nil
+	}, ds.getMetrics())
+
+	if err != nil {
+		return 0, dbError(err, "delete_expired_dynamic_thresholds", errors.PriorityLow,
 			"before", before.Format(time.RFC3339),
 			"action", "cleanup_expired_thresholds")
 	}
 
-	if result.RowsAffected > 0 {
+	if rowsAffected > 0 {
 		GetLogger().Info("Cleaned up expired dynamic thresholds",
-			logger.Int64("count", result.RowsAffected),
+			logger.Int64("count", rowsAffected),
 			logger.String("before", before.Format(time.RFC3339)))
 	}
 
-	return result.RowsAffected, nil
+	return rowsAffected, nil
 }
 
 // UpdateDynamicThresholdExpiry updates the expiry time for a specific species threshold
@@ -136,21 +149,30 @@ func (ds *DataStore) UpdateDynamicThresholdExpiry(speciesName string, expiresAt 
 		return validationError("species name cannot be empty", "species_name", "")
 	}
 
-	result := ds.DB.Model(&DynamicThreshold{}).
-		Where("species_name = ?", speciesName).
-		Updates(map[string]any{
-			"expires_at": expiresAt,
-			"updated_at": time.Now(),
-		})
+	var rowsAffected int64
+	err := RetryOnLock("update_dynamic_threshold_expiry", func() error {
+		result := ds.DB.Model(&DynamicThreshold{}).
+			Where("species_name = ?", speciesName).
+			Updates(map[string]any{
+				"expires_at": expiresAt,
+				"updated_at": time.Now(),
+			})
 
-	if result.Error != nil {
-		return dbError(result.Error, "update_dynamic_threshold_expiry", errors.PriorityMedium,
+		if result.Error != nil {
+			return result.Error
+		}
+		rowsAffected = result.RowsAffected
+		return nil
+	}, ds.getMetrics())
+
+	if err != nil {
+		return dbError(err, "update_dynamic_threshold_expiry", errors.PriorityMedium,
 			"species", speciesName,
 			"expires_at", expiresAt.Format(time.RFC3339),
 			"action", "extend_threshold_validity")
 	}
 
-	if result.RowsAffected == 0 {
+	if rowsAffected == 0 {
 		return errors.Newf("dynamic threshold not found").
 			Component("datastore").
 			Category(errors.CategoryNotFound).
@@ -221,18 +243,27 @@ func (ds *DataStore) GetDynamicThresholdStats() (totalCount, activeCount, atMini
 // Returns the count of deleted thresholds
 // BG-59: Used for "Reset All" functionality
 func (ds *DataStore) DeleteAllDynamicThresholds() (int64, error) {
-	result := ds.DB.Where("1 = 1").Delete(&DynamicThreshold{})
-	if result.Error != nil {
-		return 0, dbError(result.Error, "delete_all_dynamic_thresholds", errors.PriorityMedium,
+	var rowsAffected int64
+	err := RetryOnLock("delete_all_dynamic_thresholds", func() error {
+		result := ds.DB.Where("1 = 1").Delete(&DynamicThreshold{})
+		if result.Error != nil {
+			return result.Error
+		}
+		rowsAffected = result.RowsAffected
+		return nil
+	}, ds.getMetrics())
+
+	if err != nil {
+		return 0, dbError(err, "delete_all_dynamic_thresholds", errors.PriorityMedium,
 			"action", "reset_all_learned_thresholds")
 	}
 
-	if result.RowsAffected > 0 {
+	if rowsAffected > 0 {
 		GetLogger().Info("Reset all dynamic thresholds",
-			logger.Int64("count", result.RowsAffected))
+			logger.Int64("count", rowsAffected))
 	}
 
-	return result.RowsAffected, nil
+	return rowsAffected, nil
 }
 
 // SaveThresholdEvent saves a threshold change event to the database
@@ -250,14 +281,16 @@ func (ds *DataStore) SaveThresholdEvent(event *ThresholdEvent) error {
 		event.CreatedAt = time.Now()
 	}
 
-	if err := ds.DB.Create(event).Error; err != nil {
-		return dbError(err, "save_threshold_event", errors.PriorityMedium,
-			"species", event.SpeciesName,
-			"table", "threshold_events",
-			"action", "record_threshold_change")
-	}
+	return RetryOnLock("save_threshold_event", func() error {
+		if err := ds.DB.Create(event).Error; err != nil {
+			return dbError(err, "save_threshold_event", errors.PriorityMedium,
+				"species", event.SpeciesName,
+				"table", "threshold_events",
+				"action", "record_threshold_change")
+		}
 
-	return nil
+		return nil
+	}, ds.getMetrics())
 }
 
 // GetThresholdEvents retrieves threshold events for a specific species
@@ -310,32 +343,42 @@ func (ds *DataStore) DeleteThresholdEvents(speciesName string) error {
 		return validationError("species name cannot be empty", "species_name", "")
 	}
 
-	result := ds.DB.Where("species_name = ?", speciesName).Delete(&ThresholdEvent{})
-	if result.Error != nil {
-		return dbError(result.Error, "delete_threshold_events", errors.PriorityMedium,
-			"species", speciesName,
-			"action", "remove_threshold_history")
-	}
-
-	return nil
+	return RetryOnLock("delete_threshold_events", func() error {
+		result := ds.DB.Where("species_name = ?", speciesName).Delete(&ThresholdEvent{})
+		if result.Error != nil {
+			return dbError(result.Error, "delete_threshold_events", errors.PriorityMedium,
+				"species", speciesName,
+				"action", "remove_threshold_history")
+		}
+		return nil
+	}, ds.getMetrics())
 }
 
 // DeleteAllThresholdEvents removes all threshold events from the database
 // Returns the count of deleted events
 // BG-59: Used for "Reset All" functionality
 func (ds *DataStore) DeleteAllThresholdEvents() (int64, error) {
-	result := ds.DB.Where("1 = 1").Delete(&ThresholdEvent{})
-	if result.Error != nil {
-		return 0, dbError(result.Error, "delete_all_threshold_events", errors.PriorityMedium,
+	var rowsAffected int64
+	err := RetryOnLock("delete_all_threshold_events", func() error {
+		result := ds.DB.Where("1 = 1").Delete(&ThresholdEvent{})
+		if result.Error != nil {
+			return result.Error
+		}
+		rowsAffected = result.RowsAffected
+		return nil
+	}, ds.getMetrics())
+
+	if err != nil {
+		return 0, dbError(err, "delete_all_threshold_events", errors.PriorityMedium,
 			"action", "reset_all_threshold_history")
 	}
 
-	if result.RowsAffected > 0 {
+	if rowsAffected > 0 {
 		GetLogger().Info("Deleted all threshold events",
-			logger.Int64("count", result.RowsAffected))
+			logger.Int64("count", rowsAffected))
 	}
 
-	return result.RowsAffected, nil
+	return rowsAffected, nil
 }
 
 // BatchSaveDynamicThresholds saves multiple dynamic thresholds in a single transaction
@@ -353,12 +396,15 @@ func (ds *DataStore) BatchSaveDynamicThresholds(thresholds []DynamicThreshold) e
 		}
 	}
 
-	return ds.DB.Transaction(func(tx *gorm.DB) error {
+	return RetryTransactionOnLock(ds.DB, "batch_save_dynamic_thresholds", func(tx *gorm.DB) error {
 		now := time.Now()
 
 		// Prepare batch data - set FirstCreated for all entries
 		// (will only be used on INSERT, not UPDATE due to ON CONFLICT clause)
+		// Reset IDs at the start of each retry to prevent stale primary keys
+		// from GORM's Create() after a rolled-back transaction.
 		for i := range thresholds {
+			thresholds[i].ID = 0
 			thresholds[i].FirstCreated = now
 			thresholds[i].UpdatedAt = now
 		}
@@ -388,5 +434,5 @@ func (ds *DataStore) BatchSaveDynamicThresholds(thresholds []DynamicThreshold) e
 		}
 
 		return nil
-	})
+	}, ds.getMetrics())
 }

--- a/internal/datastore/errors_helper.go
+++ b/internal/datastore/errors_helper.go
@@ -32,7 +32,7 @@ func initRegexPatterns() {
 		diskFullPattern = regexp.MustCompile(`(?i)(disk full|no space|out of space)`)
 		deadlockPattern = regexp.MustCompile(`(?i)(deadlock detected|lock wait timeout|deadlock found)`)
 		corruptionPattern = regexp.MustCompile(`(?i)(corrupt|malformed|database disk image is malformed|file is not a database)`)
-		lockPattern = regexp.MustCompile(`(?i)(locked|database is locked|resource busy)`)
+		lockPattern = regexp.MustCompile(`(?i)(locked|database is locked|resource busy|SQLITE_BUSY)`)
 		constraintPattern = regexp.MustCompile(`(?i)(constraint|duplicate|unique constraint|foreign key)`)
 	})
 }

--- a/internal/datastore/interfaces.go
+++ b/internal/datastore/interfaces.go
@@ -15,7 +15,6 @@ package datastore
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"strconv"
 	"strings"
 	"sync"
@@ -313,7 +312,10 @@ func (ds *DataStore) SetSunCalcMetrics(suncalcMetrics any) {
 
 // Save stores a note and its associated results as a single transaction in the database.
 func (ds *DataStore) Save(note *Note, results []Results) error {
-	// Generate a unique transaction ID (first 8 chars of UUID)
+	if note == nil {
+		return validationError("note cannot be nil", "note", nil)
+	}
+
 	txID := fmt.Sprintf("tx-%s", uuid.New().String()[:8])
 	txStart := time.Now()
 	txLogger := GetLogger()
@@ -324,50 +326,81 @@ func (ds *DataStore) Save(note *Note, results []Results) error {
 		logger.String("note_scientific_name", note.ScientificName),
 		logger.Int("results_count", len(results)))
 
-	// Retry configuration
-	maxRetries := 5
-	baseDelay := 500 * time.Millisecond
+	metricsInstance := ds.getMetrics()
 
-	var lastErr error
-	for attempt := range maxRetries {
-		// Begin a transaction
-		tx := ds.DB.Begin()
-		if tx.Error != nil {
-			lastErr = dbError(tx.Error, "begin_transaction", errors.PriorityHigh,
-				"tx_id", txID,
-				"attempt", fmt.Sprintf("%d", attempt+1),
-				"action", "save_detection",
-				"table", "notes")
-
-			txLogger.Error("Failed to begin transaction",
-				logger.String("tx_id", txID),
-				logger.String("operation", "save_note"),
-				logger.Error(lastErr),
-				logger.Int("attempt", attempt+1))
-
-			continue
+	err := RetryTransactionOnLock(ds.DB, "save_note", func(tx *gorm.DB) error {
+		// Reset auto-generated IDs before each attempt so that retries after
+		// a rolled-back transaction do not try to re-use a stale primary key.
+		note.ID = 0
+		for i := range results {
+			results[i].ID = 0
+			results[i].NoteID = 0
 		}
 
-		// Execute transaction with rollback on error
-		transactionErr := ds.executeTransaction(tx, note, results, txID, attempt+1, txLogger)
-
-		if transactionErr != nil {
-			lastErr = transactionErr
-			if isDatabaseLocked(transactionErr) {
-				ds.handleDatabaseLockError(attempt, maxRetries, baseDelay, txLogger)
-				continue
+		// Omit Results to prevent GORM auto-save of associations.
+		// Results are saved separately below for explicit error handling.
+		if err := tx.Omit("Results").Create(note).Error; err != nil {
+			if metricsInstance != nil {
+				metricsInstance.RecordNoteOperation("save", "error")
+				metricsInstance.RecordDbOperationError("create", "notes", categorizeError(err))
 			}
-			// Non-retryable error
-			return transactionErr
+			return err
+		}
+		// Save the results, linking them to the note
+		for i := range results {
+			results[i].NoteID = note.ID
+			if err := tx.Create(&results[i]).Error; err != nil {
+				if metricsInstance != nil {
+					metricsInstance.RecordDbOperationError("create", "results", categorizeError(err))
+				}
+				return err
+			}
+		}
+		return nil
+	}, metricsInstance)
+
+	if err != nil {
+		txLogger.Error("Transaction failed",
+			logger.String("tx_id", txID),
+			logger.Error(err),
+			logger.Duration("total_duration", time.Since(txStart)))
+
+		if metricsInstance != nil {
+			// Only record retry-exhaustion metrics when retries were actually exhausted
+			// (transient error after all attempts), not for immediate non-retryable failures.
+			if IsTransientDBError(err) {
+				metricsInstance.RecordTransaction("timeout")
+				metricsInstance.RecordTransactionError("save_note", "max_retries_exhausted")
+			} else {
+				metricsInstance.RecordTransaction("rollback")
+				metricsInstance.RecordTransactionError("save_note", categorizeError(err))
+			}
 		}
 
-		// Success - record metrics
-		ds.recordTransactionSuccess(txStart, attempt+1, len(results), txLogger)
-		return nil
+		errState := "transaction_retry_exhausted"
+		if !IsTransientDBError(err) {
+			errState = "transaction_failed"
+		}
+		return stateError(err, "save_transaction", errState,
+			"tx_id", txID,
+			"action", "save_detection_data",
+			"total_duration_ms", time.Since(txStart).Milliseconds())
 	}
 
-	// All retries exhausted
-	return ds.handleMaxRetriesExhausted(lastErr, txID, txStart, txLogger)
+	// Success — record metrics.
+	duration := time.Since(txStart)
+	txLogger.Info("Transaction completed",
+		logger.String("tx_id", txID),
+		logger.Duration("duration", duration),
+		logger.Int("rows_affected", 1+len(results)))
+
+	if metricsInstance != nil {
+		metricsInstance.RecordNoteOperation("save", "success")
+		metricsInstance.RecordTransaction("committed")
+		metricsInstance.RecordTransactionDuration("save_note", duration.Seconds())
+	}
+
+	return nil
 }
 
 // Get retrieves a note by its ID from the database.
@@ -424,8 +457,8 @@ func (ds *DataStore) Delete(id string) error {
 			"action", "delete_detection_record")
 	}
 
-	// Perform the deletion within a transaction
-	return ds.DB.Transaction(func(tx *gorm.DB) error {
+	// Perform the deletion within a retryable transaction
+	return RetryTransactionOnLock(ds.DB, "delete_note", func(tx *gorm.DB) error {
 		// Delete the full results entry associated with the note
 		if err := tx.Where("note_id = ?", noteID).Delete(&Results{}).Error; err != nil {
 			return dbError(err, "delete_results", errors.PriorityMedium,
@@ -441,7 +474,7 @@ func (ds *DataStore) Delete(id string) error {
 				"action", "delete_detection_record")
 		}
 		return nil
-	})
+	}, ds.getMetrics())
 }
 
 // GetNoteClipPath retrieves the path to the audio clip associated with a note.
@@ -480,18 +513,18 @@ func (ds *DataStore) DeleteNoteClipPath(noteID string) error {
 	}
 
 	// Update the clip_name field to an empty string for the specified note ID
-	err := ds.DB.Model(&Note{}).Where("id = ?", noteID).Update("clip_name", "").Error
-	if err != nil {
-		return errors.New(err).
-			Component("datastore").
-			Category(errors.CategoryDatabase).
-			Context("operation", "delete_clip_path").
-			Context("note_id", noteID).
-			Build()
-	}
-
-	// Return nil if no errors occurred, indicating successful execution
-	return nil
+	return RetryOnLock("delete_note_clip_path", func() error {
+		err := ds.DB.Model(&Note{}).Where("id = ?", noteID).Update("clip_name", "").Error
+		if err != nil {
+			return errors.New(err).
+				Component("datastore").
+				Category(errors.CategoryDatabase).
+				Context("operation", "delete_clip_path").
+				Context("note_id", noteID).
+				Build()
+		}
+		return nil
+	}, ds.getMetrics())
 }
 
 // GetAllNotes retrieves all notes from the database.
@@ -899,21 +932,26 @@ func (ds *DataStore) SearchNotes(query string, sortAscending bool, limit, offset
 
 // SaveDailyEvents saves daily events data to the database.
 func (ds *DataStore) SaveDailyEvents(dailyEvents *DailyEvents) error {
-	// Use upsert to handle the unique date constraint
-	result := ds.DB.Where("date = ?", dailyEvents.Date).
-		Assign(*dailyEvents).
-		FirstOrCreate(dailyEvents)
-
-	if result.Error != nil {
-		return errors.New(result.Error).
-			Component("datastore").
-			Category(errors.CategoryDatabase).
-			Context("operation", "save_daily_events").
-			Context("date", dailyEvents.Date).
-			Build()
+	if dailyEvents == nil {
+		return validationError("daily events cannot be nil", "daily_events", nil)
 	}
+	return RetryOnLock("save_daily_events", func() error {
+		// Use upsert to handle the unique date constraint
+		result := ds.DB.Where("date = ?", dailyEvents.Date).
+			Assign(*dailyEvents).
+			FirstOrCreate(dailyEvents)
 
-	return nil
+		if result.Error != nil {
+			return errors.New(result.Error).
+				Component("datastore").
+				Category(errors.CategoryDatabase).
+				Context("operation", "save_daily_events").
+				Context("date", dailyEvents.Date).
+				Build()
+		}
+
+		return nil
+	}, ds.getMetrics())
 }
 
 // GetDailyEvents retrieves daily events data by date from the database.
@@ -963,6 +1001,9 @@ func (ds *DataStore) GetAllHourlyWeather() ([]HourlyWeather, error) {
 
 // SaveHourlyWeather saves hourly weather data to the database.
 func (ds *DataStore) SaveHourlyWeather(hourlyWeather *HourlyWeather) error {
+	if hourlyWeather == nil {
+		return validationError("hourly weather cannot be nil", "hourly_weather", nil)
+	}
 	// Basic validation
 	if hourlyWeather.Time.IsZero() {
 		return errors.Newf("invalid time value").
@@ -972,30 +1013,32 @@ func (ds *DataStore) SaveHourlyWeather(hourlyWeather *HourlyWeather) error {
 			Build()
 	}
 
-	// Use upsert to avoid duplicates for the same timestamp.
-	// Compare using Unix epoch seconds to handle legacy records with local
-	// timezone offsets alongside new UTC records.
-	var whereClause string
-	switch strings.ToLower(ds.Dialector().Name()) {
-	case DialectMySQL:
-		whereClause = "UNIX_TIMESTAMP(time) = UNIX_TIMESTAMP(?)"
-	default: // SQLite
-		whereClause = "strftime('%s', time) = strftime('%s', ?)"
-	}
+	return RetryOnLock("save_hourly_weather", func() error {
+		// Use upsert to avoid duplicates for the same timestamp.
+		// Compare using Unix epoch seconds to handle legacy records with local
+		// timezone offsets alongside new UTC records.
+		var whereClause string
+		switch strings.ToLower(ds.Dialector().Name()) {
+		case DialectMySQL:
+			whereClause = "UNIX_TIMESTAMP(time) = UNIX_TIMESTAMP(?)"
+		default: // SQLite
+			whereClause = "strftime('%s', time) = strftime('%s', ?)"
+		}
 
-	result := ds.DB.Where(whereClause, hourlyWeather.Time).
-		Assign(*hourlyWeather).
-		FirstOrCreate(hourlyWeather)
+		result := ds.DB.Where(whereClause, hourlyWeather.Time).
+			Assign(*hourlyWeather).
+			FirstOrCreate(hourlyWeather)
 
-	if result.Error != nil {
-		return errors.New(result.Error).
-			Component("datastore").
-			Category(errors.CategoryDatabase).
-			Context("operation", "save_hourly_weather").
-			Build()
-	}
+		if result.Error != nil {
+			return errors.New(result.Error).
+				Component("datastore").
+				Category(errors.CategoryDatabase).
+				Context("operation", "save_hourly_weather").
+				Build()
+		}
 
-	return nil
+		return nil
+	}, ds.getMetrics())
 }
 
 // GetHourlyWeather retrieves hourly weather data by date from the database.
@@ -1185,16 +1228,25 @@ func (ds *DataStore) UpdateNote(id string, updates map[string]any) error {
 			Build()
 	}
 
-	result := ds.DB.Model(&Note{}).Where("id = ?", id).Updates(updates)
-	if result.Error != nil {
-		return errors.New(result.Error).
+	var rowsAffected int64
+	err := RetryOnLock("update_note", func() error {
+		result := ds.DB.Model(&Note{}).Where("id = ?", id).Updates(updates)
+		if result.Error != nil {
+			return result.Error
+		}
+		rowsAffected = result.RowsAffected
+		return nil
+	}, ds.getMetrics())
+
+	if err != nil {
+		return errors.New(err).
 			Component("datastore").
 			Category(errors.CategoryDatabase).
 			Context("operation", "update_note").
 			Context("note_id", id).
 			Build()
 	}
-	if result.RowsAffected == 0 {
+	if rowsAffected == 0 {
 		return errors.Newf("note not found").
 			Component("datastore").
 			Category(errors.CategoryValidation).
@@ -1241,21 +1293,28 @@ func (ds *DataStore) GetNoteReview(noteID string) (*NoteReview, error) {
 
 // SaveNoteReview saves or updates a note review
 func (ds *DataStore) SaveNoteReview(review *NoteReview) error {
-	// Use upsert operation to either create or update the review
-	result := ds.DB.Where("note_id = ?", review.NoteID).
-		Assign(*review).
-		FirstOrCreate(review)
-
-	if result.Error != nil {
-		return errors.New(result.Error).
-			Component("datastore").
-			Category(errors.CategoryDatabase).
-			Context("operation", "save_note_review").
-			Context("note_id", fmt.Sprintf("%d", review.NoteID)).
-			Build()
+	if review == nil {
+		return validationError("review cannot be nil", "review", nil)
 	}
 
-	return nil
+	return RetryOnLock("save_note_review", func() error {
+		review.ID = 0 // Reset ID for retry safety with FirstOrCreate
+		// Use upsert operation to either create or update the review
+		result := ds.DB.Where("note_id = ?", review.NoteID).
+			Assign(*review).
+			FirstOrCreate(review)
+
+		if result.Error != nil {
+			return errors.New(result.Error).
+				Component("datastore").
+				Category(errors.CategoryDatabase).
+				Context("operation", "save_note_review").
+				Context("note_id", fmt.Sprintf("%d", review.NoteID)).
+				Build()
+		}
+
+		return nil
+	}, ds.getMetrics())
 }
 
 // GetNoteComments retrieves all comments for a note
@@ -1465,13 +1524,15 @@ func (ds *DataStore) SaveNoteComment(comment *NoteComment) error {
 		return validationError("comment entry exceeds maximum length", "entry_length", len(comment.Entry))
 	}
 
-	if err := ds.DB.Create(comment).Error; err != nil {
-		return dbError(err, "save_note_comment", errors.PriorityMedium,
-			"note_id", fmt.Sprintf("%d", comment.NoteID),
-			"table", "note_comments",
-			"action", "add_user_comment")
-	}
-	return nil
+	return RetryOnLock("save_note_comment", func() error {
+		if err := ds.DB.Create(comment).Error; err != nil {
+			return dbError(err, "save_note_comment", errors.PriorityMedium,
+				"note_id", fmt.Sprintf("%d", comment.NoteID),
+				"table", "note_comments",
+				"action", "add_user_comment")
+		}
+		return nil
+	}, ds.getMetrics())
 }
 
 // DeleteNoteComment deletes a comment
@@ -1486,15 +1547,17 @@ func (ds *DataStore) DeleteNoteComment(commentID string) error {
 			Build()
 	}
 
-	if err := ds.DB.Delete(&NoteComment{}, id).Error; err != nil {
-		return errors.New(err).
-			Component("datastore").
-			Category(errors.CategoryDatabase).
-			Context("operation", "delete_note_comment").
-			Context("comment_id", commentID).
-			Build()
-	}
-	return nil
+	return RetryOnLock("delete_note_comment", func() error {
+		if err := ds.DB.Delete(&NoteComment{}, id).Error; err != nil {
+			return errors.New(err).
+				Component("datastore").
+				Category(errors.CategoryDatabase).
+				Context("operation", "delete_note_comment").
+				Context("comment_id", commentID).
+				Build()
+		}
+		return nil
+	}, ds.getMetrics())
 }
 
 // UpdateNoteComment updates an existing comment's entry
@@ -1509,13 +1572,22 @@ func (ds *DataStore) UpdateNoteComment(commentID, entry string) error {
 			Build()
 	}
 
-	result := ds.DB.Model(&NoteComment{}).Where("id = ?", id).Updates(map[string]any{
-		"entry":      entry,
-		"updated_at": time.Now(),
-	})
+	var rowsAffected int64
+	err = RetryOnLock("update_note_comment", func() error {
+		result := ds.DB.Model(&NoteComment{}).Where("id = ?", id).Updates(map[string]any{
+			"entry":      entry,
+			"updated_at": time.Now(),
+		})
 
-	if result.Error != nil {
-		return errors.New(result.Error).
+		if result.Error != nil {
+			return result.Error
+		}
+		rowsAffected = result.RowsAffected
+		return nil
+	}, ds.getMetrics())
+
+	if err != nil {
+		return errors.New(err).
 			Component("datastore").
 			Category(errors.CategoryDatabase).
 			Context("operation", "update_note_comment").
@@ -1523,7 +1595,7 @@ func (ds *DataStore) UpdateNoteComment(commentID, entry string) error {
 			Build()
 	}
 
-	if result.RowsAffected == 0 {
+	if rowsAffected == 0 {
 		return errors.Newf("comment not found").
 			Component("datastore").
 			Category(errors.CategoryValidation).
@@ -1646,16 +1718,7 @@ func (ds *DataStore) LockNote(noteID string) error {
 			Build()
 	}
 
-	// Generate a unique transaction ID (first 8 chars of UUID)
-	txID := fmt.Sprintf("tx-%s", uuid.New().String()[:8])
-
-	// Retry configuration
-	maxRetries := 5
-	baseDelay := 500 * time.Millisecond
-
-	var lastErr error
-	for attempt := range maxRetries {
-		// Use upsert operation to either create or update the lock
+	err = RetryOnLock("lock_note", func() error {
 		lock := &NoteLock{
 			NoteID:   uint(id),
 			LockedAt: time.Now(),
@@ -1664,42 +1727,19 @@ func (ds *DataStore) LockNote(noteID string) error {
 		result := ds.DB.Where("note_id = ?", id).
 			Assign(*lock).
 			FirstOrCreate(lock)
-
 		if result.Error != nil {
-			if strings.Contains(strings.ToLower(result.Error.Error()), "database is locked") {
-				// Calculate exponential backoff with jitter
-				baseBackoff := baseDelay * time.Duration(attempt+1)
-				jitter := time.Duration(rand.Float64() * 0.25 * float64(baseBackoff)) //nolint:gosec // G404: math/rand is fine for jitter, not security-critical
-				delay := baseBackoff + jitter
-				GetLogger().Debug("Database locked, retrying",
-					logger.String("tx_id", txID),
-					logger.Duration("delay", delay),
-					logger.Int("attempt", attempt+1),
-					logger.Int("max_retries", maxRetries),
-					logger.Duration("jitter", jitter))
-				time.Sleep(delay)
-				lastErr = result.Error
-				continue
-			}
-			return stateError(result.Error, "lock_note", "note_lock_acquisition",
-				"note_id", noteID,
-				"action", "acquire_edit_lock")
-		}
-
-		// If we get here, the transaction was successful
-		if attempt > 0 {
-			GetLogger().Info("Database transaction successful after retries",
-				logger.String("tx_id", txID),
-				logger.Int("attempts", attempt+1))
+			// Let RetryOnLock decide whether this is transient or not.
+			return result.Error
 		}
 		return nil
-	}
+	}, ds.getMetrics())
 
-	return stateError(lastErr, "lock_note", "lock_retry_exhausted",
-		"note_id", noteID,
-		"transaction_id", txID,
-		"max_retries", fmt.Sprintf("%d", maxRetries),
-		"action", "acquire_edit_lock")
+	if err != nil {
+		return stateError(err, "lock_note", "note_lock_acquisition",
+			"note_id", noteID,
+			"action", "acquire_edit_lock")
+	}
+	return nil
 }
 
 // UnlockNote removes a lock from a note
@@ -1709,72 +1749,28 @@ func (ds *DataStore) UnlockNote(noteID string) error {
 		return validationError("invalid note ID format for unlock", "note_id", noteID)
 	}
 
-	// Generate a unique transaction ID (first 8 chars of UUID)
-	txID := fmt.Sprintf("tx-%s", uuid.New().String()[:8])
-
-	// Retry configuration
-	maxRetries := 5
-	baseDelay := 500 * time.Millisecond
-
-	var lastErr error
-	for attempt := range maxRetries {
-		// First check if the lock exists
-		exists, err := ds.IsNoteLocked(noteID)
-		if err != nil {
-			return errors.New(err).
-				Component("datastore").
-				Category(errors.CategoryDatabase).
-				Context("operation", "unlock_note_check_existence").
-				Context("note_id", noteID).
-				Build()
+	err = RetryOnLock("unlock_note", func() error {
+		// Check if the lock exists before attempting to delete.
+		exists, checkErr := ds.IsNoteLocked(noteID)
+		if checkErr != nil {
+			return checkErr
 		}
 		if !exists {
-			// Lock doesn't exist, nothing to unlock
 			return nil
 		}
 
-		result := ds.DB.Where("note_id = ?", id).Delete(&NoteLock{})
-		if result.Error != nil {
-			if strings.Contains(strings.ToLower(result.Error.Error()), "database is locked") {
-				// Calculate exponential backoff with jitter
-				baseBackoff := baseDelay * time.Duration(attempt+1)
-				jitter := time.Duration(rand.Float64() * 0.25 * float64(baseBackoff)) //nolint:gosec // G404: math/rand is fine for jitter, not security-critical
-				delay := baseBackoff + jitter
-				GetLogger().Debug("Database locked, retrying",
-					logger.String("tx_id", txID),
-					logger.Duration("delay", delay),
-					logger.Int("attempt", attempt+1),
-					logger.Int("max_retries", maxRetries),
-					logger.Duration("jitter", jitter))
-				time.Sleep(delay)
-				lastErr = result.Error
-				continue
-			}
-			return errors.New(result.Error).
-				Component("datastore").
-				Category(errors.CategoryDatabase).
-				Context("operation", "unlock_note").
-				Context("note_id", noteID).
-				Build()
-		}
+		return ds.DB.Where("note_id = ?", id).Delete(&NoteLock{}).Error
+	}, ds.getMetrics())
 
-		// If we get here, the transaction was successful
-		if attempt > 0 {
-			GetLogger().Info("Database transaction successful after retries",
-				logger.String("tx_id", txID),
-				logger.Int("attempts", attempt+1))
-		}
-		return nil
+	if err != nil {
+		return errors.New(err).
+			Component("datastore").
+			Category(errors.CategoryDatabase).
+			Context("operation", "unlock_note").
+			Context("note_id", noteID).
+			Build()
 	}
-
-	return errors.New(lastErr).
-		Component("datastore").
-		Category(errors.CategoryDatabase).
-		Context("operation", "unlock_note").
-		Context("note_id", noteID).
-		Context("transaction_id", txID).
-		Context("max_retries", fmt.Sprintf("%d", maxRetries)).
-		Build()
+	return nil
 }
 
 // GetImageCache retrieves an image cache entry by scientific name and provider
@@ -1819,39 +1815,36 @@ func (ds *DataStore) SaveImageCache(cache *ImageCache) error {
 		return err
 	}
 
-	// Use Clauses(clause.OnConflict...) to perform an UPSERT operation
-	// Update all columns except primary key on conflict
-	if err := ds.DB.Clauses(clause.OnConflict{
-		Columns:   []clause.Column{{Name: "provider_name"}, {Name: "scientific_name"}},
-		DoUpdates: clause.AssignmentColumns([]string{"url", "license_name", "license_url", "author_name", "author_url", "cached_at"}),
-	}).Create(cache).Error; err != nil {
-		// Detect constraint violations
-		if isConstraintViolation(err) {
-			// This is expected with UPSERT, log at debug level
-			GetLogger().Debug("Image cache UPSERT handled constraint",
-				logger.String("scientific_name", cache.ScientificName),
-				logger.String("provider", cache.ProviderName))
-		} else {
-			enhancedErr := dbError(err, "save_image_cache", errors.PriorityMedium,
+	err := RetryOnLock("save_image_cache", func() error {
+		// Use Clauses(clause.OnConflict...) to perform an UPSERT operation
+		// Update all columns except primary key on conflict
+		if err := ds.DB.Clauses(clause.OnConflict{
+			Columns:   []clause.Column{{Name: "provider_name"}, {Name: "scientific_name"}},
+			DoUpdates: clause.AssignmentColumns([]string{"url", "license_name", "license_url", "author_name", "author_url", "cached_at"}),
+		}).Create(cache).Error; err != nil {
+			return dbError(err, "save_image_cache", errors.PriorityMedium,
 				"table", "image_caches",
 				"scientific_name", cache.ScientificName,
 				"provider", cache.ProviderName,
 				"action", "cache_species_thumbnail")
-
-			GetLogger().Error("Failed to save image cache",
-				logger.Error(enhancedErr))
-
-			// Record error metric
-			ds.metricsMu.RLock()
-			metricsInstance := ds.metrics
-			ds.metricsMu.RUnlock()
-			if metricsInstance != nil {
-				metricsInstance.RecordImageCacheOperation("save", "error")
-				metricsInstance.RecordImageCacheDuration("save", time.Since(start).Seconds())
-			}
-
-			return enhancedErr
 		}
+		return nil
+	}, ds.getMetrics())
+
+	if err != nil {
+		GetLogger().Error("Failed to save image cache",
+			logger.Error(err))
+
+		// Record error metric
+		ds.metricsMu.RLock()
+		metricsInstance := ds.metrics
+		ds.metricsMu.RUnlock()
+		if metricsInstance != nil {
+			metricsInstance.RecordImageCacheOperation("save", "error")
+			metricsInstance.RecordImageCacheDuration("save", time.Since(start).Seconds())
+		}
+
+		return err
 	}
 
 	// Record success metric
@@ -2525,229 +2518,4 @@ func (ds *DataStore) getCachedSunTimes(dateStr string) (suncalc.SunEventTimes, b
 // cacheSunTimes caches sun times
 func (ds *DataStore) cacheSunTimes(dateStr string, sunTimes *suncalc.SunEventTimes) {
 	ds.sunTimesCache.Store(dateStr, *sunTimes)
-}
-
-// Helper functions for Save method to reduce cognitive complexity
-
-// saveNoteInTransaction saves a note within a transaction
-func (ds *DataStore) saveNoteInTransaction(tx *gorm.DB, note *Note, txID string, attempt int, txLogger logger.Logger) error {
-	// Omit Results to prevent GORM auto-save of associations.
-	// Results are saved separately in saveResultsInTransaction for explicit error handling.
-	if err := tx.Omit("Results").Create(note).Error; err != nil {
-		enhancedErr := errors.New(err).
-			Component("datastore").
-			Category(errors.CategoryDatabase).
-			Context("operation", "save_note").
-			Context("table", "notes").
-			Context("note_id", fmt.Sprintf("%d", note.ID)).
-			Context("tx_id", txID).
-			Context("attempt", fmt.Sprintf("%d", attempt)).
-			Build()
-
-		txLogger.Error("Failed to save note",
-			logger.Error(enhancedErr),
-			logger.Any("note_id", note.ID),
-			logger.String("scientific_name", note.ScientificName))
-
-		// Record error metric
-		ds.metricsMu.RLock()
-		metricsInstance := ds.metrics
-		ds.metricsMu.RUnlock()
-		if metricsInstance != nil {
-			metricsInstance.RecordNoteOperation("save", "error")
-			metricsInstance.RecordDbOperationError("create", "notes", categorizeError(err))
-		}
-
-		return enhancedErr
-	}
-
-	// Record success metric for note
-	ds.metricsMu.RLock()
-	metricsInstance := ds.metrics
-	ds.metricsMu.RUnlock()
-	if metricsInstance != nil {
-		metricsInstance.RecordNoteOperation("save", "success")
-	}
-
-	return nil
-}
-
-// saveResultsInTransaction saves results within a transaction
-func (ds *DataStore) saveResultsInTransaction(tx *gorm.DB, results []Results, noteID uint, txID string, attempt int, txLogger logger.Logger) error {
-	for i, result := range results {
-		result.NoteID = noteID
-		if err := tx.Create(&result).Error; err != nil {
-			enhancedErr := errors.New(err).
-				Component("datastore").
-				Category(errors.CategoryDatabase).
-				Context("operation", "save_result").
-				Context("note_id", fmt.Sprintf("%d", noteID)).
-				Context("result_index", fmt.Sprintf("%d", i)).
-				Context("tx_id", txID).
-				Context("attempt", fmt.Sprintf("%d", attempt)).
-				Build()
-
-			txLogger.Error("Failed to save result",
-				logger.Error(enhancedErr),
-				logger.Any("note_id", noteID),
-				logger.Int("result_index", i))
-
-			ds.metricsMu.RLock()
-			metricsInstance := ds.metrics
-			ds.metricsMu.RUnlock()
-			if metricsInstance != nil {
-				metricsInstance.RecordDbOperationError("create", "results", categorizeError(err))
-			}
-
-			return enhancedErr
-		}
-	}
-	return nil
-}
-
-// commitTransactionWithMetrics commits a transaction and records metrics
-func (ds *DataStore) commitTransactionWithMetrics(tx *gorm.DB, txID string, attempt int, txLogger logger.Logger) error {
-	if err := tx.Commit().Error; err != nil {
-		// Commit failures are critical as they can lead to data loss
-		priority := errors.PriorityHigh
-		if isDatabaseCorruption(err) {
-			priority = errors.PriorityCritical
-		}
-
-		enhancedErr := dbError(err, "commit_transaction", priority,
-			"tx_id", txID,
-			"attempt", fmt.Sprintf("%d", attempt),
-			"action", "finalize_detection_save")
-
-		txLogger.Error("Failed to commit transaction",
-			logger.Error(enhancedErr))
-
-		ds.metricsMu.RLock()
-		metricsInstance := ds.metrics
-		ds.metricsMu.RUnlock()
-		if metricsInstance != nil {
-			metricsInstance.RecordTransaction("rollback")
-			metricsInstance.RecordTransactionError("save_note", categorizeError(err))
-		}
-
-		return enhancedErr
-	}
-
-	// Record commit success
-	ds.metricsMu.RLock()
-	metricsInstance := ds.metrics
-	ds.metricsMu.RUnlock()
-	if metricsInstance != nil {
-		metricsInstance.RecordTransaction("committed")
-	}
-
-	return nil
-}
-
-// handleDatabaseLockError handles database lock errors with backoff
-func (ds *DataStore) handleDatabaseLockError(attempt, maxRetries int, baseDelay time.Duration, txLogger logger.Logger) {
-	// Calculate exponential backoff with jitter to avoid thundering herd
-	baseBackoff := baseDelay * time.Duration(attempt+1)
-	// Add 0-25% jitter to the base backoff
-	jitter := time.Duration(rand.Float64() * 0.25 * float64(baseBackoff)) //nolint:gosec // G404: math/rand is fine for jitter, not security-critical
-	delay := baseBackoff + jitter
-
-	txLogger.Warn("Database locked, scheduling retry",
-		logger.Int("attempt", attempt+1),
-		logger.Int("max_attempts", maxRetries),
-		logger.Int64("backoff_ms", delay.Milliseconds()),
-		logger.Int64("jitter_ms", jitter.Milliseconds()))
-
-	// Record retry metric
-	ds.metricsMu.RLock()
-	metricsInstance := ds.metrics
-	ds.metricsMu.RUnlock()
-	if metricsInstance != nil {
-		metricsInstance.RecordTransactionRetry("save_note", "database_locked")
-	}
-
-	time.Sleep(delay)
-}
-
-// executeTransaction executes the save operations within a transaction
-func (ds *DataStore) executeTransaction(tx *gorm.DB, note *Note, results []Results, txID string, attempt int, txLogger logger.Logger) error {
-	// Set up panic recovery with rollback
-	defer func() {
-		if r := recover(); r != nil {
-			tx.Rollback()
-		}
-	}()
-
-	// Save the note
-	if err := ds.saveNoteInTransaction(tx, note, txID, attempt, txLogger); err != nil {
-		tx.Rollback()
-		if isDatabaseLocked(err) {
-			return err
-		}
-		return err
-	}
-
-	// Save the results
-	if err := ds.saveResultsInTransaction(tx, results, note.ID, txID, attempt, txLogger); err != nil {
-		tx.Rollback()
-		if isDatabaseLocked(err) {
-			return err
-		}
-		return err
-	}
-
-	// Commit the transaction
-	if err := ds.commitTransactionWithMetrics(tx, txID, attempt, txLogger); err != nil {
-		if isDatabaseLocked(err) {
-			return err
-		}
-		return err
-	}
-
-	return nil
-}
-
-// recordTransactionSuccess records success metrics for a transaction
-func (ds *DataStore) recordTransactionSuccess(txStart time.Time, attempts, resultsCount int, txLogger logger.Logger) {
-	duration := time.Since(txStart)
-	txLogger.Info("Transaction completed",
-		logger.Duration("duration", duration),
-		logger.Int("attempts", attempts),
-		logger.Int("rows_affected", 1+resultsCount))
-
-	// Record success metrics
-	ds.metricsMu.RLock()
-	metricsInstance := ds.metrics
-	ds.metricsMu.RUnlock()
-	if metricsInstance != nil {
-		metricsInstance.RecordTransactionDuration("save_note", duration.Seconds())
-		if attempts > 1 {
-			metricsInstance.RecordLockContention("database", "retry_succeeded")
-		}
-	}
-}
-
-// handleMaxRetriesExhausted handles the case when all retries are exhausted
-func (ds *DataStore) handleMaxRetriesExhausted(lastErr error, txID string, txStart time.Time, txLogger logger.Logger) error {
-	enhancedErr := stateError(lastErr, "save_transaction", "transaction_retry_exhausted",
-		"tx_id", txID,
-		"max_retries_exhausted", "true",
-		"action", "save_detection_data",
-		"total_duration_ms", time.Since(txStart).Milliseconds())
-
-	txLogger.Error("Transaction failed after max retries",
-		logger.Error(enhancedErr),
-		logger.Duration("total_duration", time.Since(txStart)))
-
-	// Record failure metrics
-	ds.metricsMu.RLock()
-	metricsInstance := ds.metrics
-	ds.metricsMu.RUnlock()
-	if metricsInstance != nil {
-		metricsInstance.RecordTransaction("timeout")
-		metricsInstance.RecordTransactionError("save_note", "max_retries_exhausted")
-		metricsInstance.RecordLockContention("database", "max_retries_exhausted")
-	}
-
-	return enhancedErr
 }

--- a/internal/datastore/metrics.go
+++ b/internal/datastore/metrics.go
@@ -8,3 +8,12 @@ import (
 // Metrics is a type alias for the metrics.DatastoreMetrics
 // This allows us to use the metrics throughout the datastore package
 type Metrics = metrics.DatastoreMetrics
+
+// getMetrics returns the current metrics instance, or nil if none is set.
+// Safe for concurrent use.
+func (ds *DataStore) getMetrics() *Metrics {
+	ds.metricsMu.RLock()
+	m := ds.metrics
+	ds.metricsMu.RUnlock()
+	return m
+}

--- a/internal/datastore/mysql.go
+++ b/internal/datastore/mysql.go
@@ -17,6 +17,9 @@ import (
 	gormlogger "gorm.io/gorm/logger"
 )
 
+// MySQL connection pool constants are defined in mysql_pool.go and shared
+// with the v2 store to keep both within MySQL's max_connections budget.
+
 // validTableNameRegex matches valid table names: alphanumeric, underscores, and dashes only
 var validTableNameRegex = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
 
@@ -76,6 +79,23 @@ func (store *MySQLStore) Open() error {
 		GetLogger().Error("Failed to open MySQL database", logger.Error(err))
 		return fmt.Errorf("failed to open MySQL database: %w", err)
 	}
+
+	// Configure connection pool for MySQL.
+	// Unlike SQLite which serializes with MaxOpenConns(1), MySQL handles
+	// concurrent connections natively. These settings prevent resource
+	// exhaustion while keeping warm connections for latency.
+	sqlDB, err := db.DB()
+	if err != nil {
+		return errors.New(err).
+			Component("datastore").
+			Category(errors.CategoryDatabase).
+			Context("operation", "get_underlying_sqldb").
+			Build()
+	}
+	sqlDB.SetMaxOpenConns(MySQLMaxOpenConns)
+	sqlDB.SetMaxIdleConns(MySQLMaxIdleConns)
+	sqlDB.SetConnMaxLifetime(MySQLConnMaxLifetime)
+	sqlDB.SetConnMaxIdleTime(MySQLConnMaxIdleTime)
 
 	store.DB = db
 

--- a/internal/datastore/mysql_pool.go
+++ b/internal/datastore/mysql_pool.go
@@ -1,0 +1,18 @@
+package datastore
+
+import "time"
+
+// MySQL connection pool defaults shared by both v1 and v2 stores.
+// Tuned for BirdNET-Go's typical workload (periodic detections, weather
+// updates, daily events). Conservative relative to MySQL's default
+// max_connections (151), leaving headroom for admin tools and other clients.
+//
+// During migration both stores are active against the same server, so the
+// combined maximum is 2 * MySQLMaxOpenConns = 50 -- well within the 151
+// default limit.
+const (
+	MySQLMaxOpenConns    = 25
+	MySQLMaxIdleConns    = 10
+	MySQLConnMaxLifetime = 5 * time.Minute
+	MySQLConnMaxIdleTime = 3 * time.Minute
+)

--- a/internal/datastore/notification_history.go
+++ b/internal/datastore/notification_history.go
@@ -38,27 +38,29 @@ func (ds *DataStore) SaveNotificationHistory(history *NotificationHistory) error
 
 	// Upsert: Use GORM's OnConflict clause for efficient upsert
 	// This handles the composite unique index on (scientific_name, notification_type)
-	result := ds.DB.Clauses(clause.OnConflict{
-		Columns: []clause.Column{
-			{Name: "scientific_name"},
-			{Name: "notification_type"},
-		},
-		DoUpdates: clause.AssignmentColumns([]string{
-			"last_sent",
-			"expires_at",
-			"updated_at",
-		}),
-	}).Create(history)
+	return RetryOnLock("save_notification_history", func() error {
+		result := ds.DB.Clauses(clause.OnConflict{
+			Columns: []clause.Column{
+				{Name: "scientific_name"},
+				{Name: "notification_type"},
+			},
+			DoUpdates: clause.AssignmentColumns([]string{
+				"last_sent",
+				"expires_at",
+				"updated_at",
+			}),
+		}).Create(history)
 
-	if result.Error != nil {
-		return dbError(result.Error, "save_notification_history", errors.PriorityMedium,
-			"species", history.ScientificName,
-			"notification_type", history.NotificationType,
-			"table", "notification_histories",
-			"action", "persist_notification_suppression")
-	}
+		if result.Error != nil {
+			return dbError(result.Error, "save_notification_history", errors.PriorityMedium,
+				"species", history.ScientificName,
+				"notification_type", history.NotificationType,
+				"table", "notification_histories",
+				"action", "persist_notification_suppression")
+		}
 
-	return nil
+		return nil
+	}, ds.getMetrics())
 }
 
 // GetNotificationHistory retrieves a notification history record for a specific species and type
@@ -114,18 +116,27 @@ func (ds *DataStore) GetActiveNotificationHistory(after time.Time) ([]Notificati
 // Returns the count of deleted records
 // This is typically called periodically by a cleanup job
 func (ds *DataStore) DeleteExpiredNotificationHistory(before time.Time) (int64, error) {
-	result := ds.DB.Where("expires_at < ?", before).Delete(&NotificationHistory{})
-	if result.Error != nil {
-		return 0, dbError(result.Error, "delete_expired_notification_history", errors.PriorityLow,
+	var rowsAffected int64
+	err := RetryOnLock("delete_expired_notification_history", func() error {
+		result := ds.DB.Where("expires_at < ?", before).Delete(&NotificationHistory{})
+		if result.Error != nil {
+			return result.Error
+		}
+		rowsAffected = result.RowsAffected
+		return nil
+	}, ds.getMetrics())
+
+	if err != nil {
+		return 0, dbError(err, "delete_expired_notification_history", errors.PriorityLow,
 			"before", before.Format(time.RFC3339),
 			"action", "cleanup_expired_notifications")
 	}
 
-	if result.RowsAffected > 0 {
+	if rowsAffected > 0 {
 		GetLogger().Info("Cleaned up expired notification history",
-			logger.Int64("count", result.RowsAffected),
+			logger.Int64("count", rowsAffected),
 			logger.String("before", before.Format(time.RFC3339)))
 	}
 
-	return result.RowsAffected, nil
+	return rowsAffected, nil
 }

--- a/internal/datastore/retry.go
+++ b/internal/datastore/retry.go
@@ -1,0 +1,189 @@
+package datastore
+
+import (
+	"fmt"
+	"math/rand"
+	"strings"
+	"time"
+
+	"github.com/tphakala/birdnet-go/internal/errors"
+	"github.com/tphakala/birdnet-go/internal/logger"
+	"gorm.io/gorm"
+)
+
+const (
+	// retryMaxAttempts is the number of times to retry a write operation
+	// that fails with a transient database lock or deadlock error.
+	retryMaxAttempts = 5
+
+	// retryBaseDelay is the initial backoff delay between retries.
+	// Subsequent retries double the delay (exponential backoff).
+	retryBaseDelay = 500 * time.Millisecond
+)
+
+// IsTransientDBError checks if an error (or any error in its unwrap chain) is a
+// transient database lock or deadlock error that is safe to retry. Covers both
+// SQLite (database is locked, SQLITE_BUSY) and MySQL (deadlock detected, lock
+// wait timeout). Wrapped errors (e.g. EnhancedError) are unwrapped so the
+// underlying message is inspected at every level.
+func IsTransientDBError(err error) bool {
+	if err == nil {
+		return false
+	}
+	// Walk the error chain -- wrapped errors may hide the transient message.
+	for e := err; e != nil; e = errors.Unwrap(e) {
+		if isDatabaseLocked(e) || isDeadlock(e) {
+			return true
+		}
+	}
+	return false
+}
+
+// retryBackoff computes a jittered exponential backoff delay, logs a warning,
+// records the retry metric, and sleeps. It is called by RetryOnLock and
+// RetryTransactionOnLock when a real retry is about to happen.
+func retryBackoff(attempt int, operation string, lastErr error, m *Metrics) {
+	if m != nil {
+		m.RecordTransactionRetry(operation, "database_locked")
+	}
+	backoff := retryBaseDelay * time.Duration(1<<uint(attempt)) //nolint:gosec // G115: attempt bounded by retryMaxAttempts
+	// Add 0-25% jitter to avoid thundering herd when multiple writers contend.
+	jitter := time.Duration(rand.Float64() * 0.25 * float64(backoff)) //nolint:gosec // G404: math/rand is fine for jitter
+	delay := backoff + jitter
+	GetLogger().Warn("retrying after database lock error",
+		logger.String("operation", operation),
+		logger.Int("attempt", attempt+1),
+		logger.Int("max_attempts", retryMaxAttempts),
+		logger.Int64("backoff_ms", delay.Milliseconds()),
+		logger.Error(lastErr))
+	time.Sleep(delay)
+}
+
+// recordRetryExhaustion records metrics when all retry attempts have been
+// exhausted. Called by both RetryOnLock and RetryTransactionOnLock.
+func recordRetryExhaustion(m *Metrics, operation string, start time.Time) {
+	if m == nil {
+		return
+	}
+	m.RecordLockRetriesExhausted(operation)
+	m.RecordLockWaitTime("database", time.Since(start).Seconds())
+	m.RecordLockContention("database", "max_retries_exhausted")
+}
+
+// RetryOnLock executes fn and retries up to retryMaxAttempts times if the
+// error is a transient database lock or deadlock error. Uses exponential
+// backoff between retries. Returns the first non-transient error or the
+// last error after all retries are exhausted.
+//
+// If metrics is non-nil, each retry attempt and exhaustion are recorded.
+func RetryOnLock(operation string, fn func() error, metrics *Metrics) error {
+	start := time.Now()
+	var err error
+	for attempt := range retryMaxAttempts {
+		err = fn()
+		if err == nil {
+			if attempt > 0 && metrics != nil {
+				metrics.RecordLockWaitTime("database", time.Since(start).Seconds())
+				metrics.RecordLockContention("database", "retry_succeeded")
+			}
+			return nil
+		}
+
+		// Only retry on transient lock/deadlock errors; bail immediately on others.
+		if !IsTransientDBError(err) {
+			return err
+		}
+
+		// Only record the retry metric and sleep when there will be a real retry.
+		if attempt < retryMaxAttempts-1 {
+			retryBackoff(attempt, operation, err, metrics)
+		}
+	}
+
+	// All retries exhausted -- record the critical exhaustion metric.
+	recordRetryExhaustion(metrics, operation, start)
+	return err
+}
+
+// RetryTransactionOnLock wraps a transaction lifecycle (Begin/fn/Commit) inside
+// the standard retry loop. Each retry starts a fresh transaction so that a
+// failed attempt's rolled-back state does not leak into the next try.
+//
+// The caller-supplied fn receives the open *gorm.DB transaction and should
+// execute its queries on it. It must NOT call Commit or Rollback -- that is
+// handled by this helper.
+//
+// If metrics is non-nil, retry attempts, exhaustion, and lock wait duration
+// are recorded.
+func RetryTransactionOnLock(db *gorm.DB, operation string, fn func(tx *gorm.DB) error, metrics *Metrics) error {
+	start := time.Now()
+	var lastErr error
+
+	for attempt := range retryMaxAttempts {
+		tx := db.Begin()
+		if tx.Error != nil {
+			lastErr = tx.Error
+			if !IsTransientDBError(tx.Error) {
+				return tx.Error
+			}
+			// Begin itself hit a lock error; fall through to retry logic.
+		} else {
+			// Execute the caller's work inside the transaction with panic recovery.
+			fnErr := func() (retErr error) {
+				defer func() {
+					if r := recover(); r != nil {
+						tx.Rollback()
+						retErr = fmt.Errorf("panic in transaction: %v", r)
+					}
+				}()
+				return fn(tx)
+			}()
+
+			if fnErr != nil {
+				tx.Rollback()
+				lastErr = fnErr
+				if !IsTransientDBError(fnErr) {
+					return fnErr
+				}
+				// Transient error; fall through to retry logic.
+			} else {
+				// Commit the transaction.
+				if err := tx.Commit().Error; err != nil {
+					tx.Rollback() // Defensive rollback after failed commit.
+					lastErr = err
+					if !IsTransientDBError(err) {
+						return err
+					}
+					// Commit hit a lock error; fall through to retry logic.
+				} else {
+					// Success.
+					if attempt > 0 && metrics != nil {
+						metrics.RecordLockWaitTime("database", time.Since(start).Seconds())
+						metrics.RecordLockContention("database", "retry_succeeded")
+					}
+					return nil
+				}
+			}
+		}
+
+		// Only record the retry metric and sleep when there will be a real retry.
+		if attempt < retryMaxAttempts-1 {
+			retryBackoff(attempt, operation, lastErr, metrics)
+		}
+	}
+
+	// All retries exhausted -- record the critical exhaustion metric.
+	recordRetryExhaustion(metrics, operation, start)
+	return lastErr
+}
+
+// buildSQLiteDSN constructs a SQLite DSN string with pragma query parameters.
+// Handles the case where dbPath may already contain query parameters (e.g.,
+// "file::memory:?cache=shared") by using "&" instead of "?" as the separator.
+func buildSQLiteDSN(dbPath, pragmas string) string {
+	sep := "?"
+	if strings.Contains(dbPath, "?") {
+		sep = "&"
+	}
+	return dbPath + sep + pragmas
+}

--- a/internal/datastore/retry_test.go
+++ b/internal/datastore/retry_test.go
@@ -1,0 +1,425 @@
+package datastore
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/observability/metrics"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	gormlogger "gorm.io/gorm/logger"
+)
+
+// newTestMetrics creates a DatastoreMetrics instance backed by a fresh
+// Prometheus registry, suitable for isolated test assertions. Returns both
+// the registry (for gathering counters) and the metrics instance.
+func newTestMetrics(t *testing.T) (reg *prometheus.Registry, m *Metrics) {
+	t.Helper()
+	reg = prometheus.NewRegistry()
+	m, err := metrics.NewDatastoreMetrics(reg)
+	require.NoError(t, err)
+	return reg, m
+}
+
+// gatherCounter sums the counter value for the named metric family across all
+// label combinations in the given registry. Returns 0 when the metric has not
+// been observed yet.
+func gatherCounter(t *testing.T, reg *prometheus.Registry, name string) int {
+	t.Helper()
+	families, err := reg.Gather()
+	require.NoError(t, err)
+	for _, f := range families {
+		if f.GetName() != name {
+			continue
+		}
+		var total int
+		for _, m := range f.GetMetric() {
+			if m.GetCounter() != nil {
+				total += int(m.GetCounter().GetValue())
+			}
+		}
+		return total
+	}
+	return 0
+}
+
+// openRetryTestDB creates a file-backed SQLite database in t.TempDir() for
+// RetryTransactionOnLock tests. Each test gets its own isolated database.
+func openRetryTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+
+	dbPath := fmt.Sprintf("%s/retry_test.db", t.TempDir())
+	dsn := buildSQLiteDSN(dbPath, "_journal_mode=WAL&_busy_timeout=5000&_foreign_keys=ON")
+
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{
+		Logger: gormlogger.Discard,
+	})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&DailyEvents{}))
+
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sqlDB.Close() })
+
+	return db
+}
+
+func TestRetryOnLock(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		fn            func(calls *int) error
+		expectedCalls int
+		expectError   bool
+	}{
+		{
+			name: "succeeds immediately",
+			fn: func(_ *int) error {
+				return nil
+			},
+			expectedCalls: 1,
+			expectError:   false,
+		},
+		{
+			name: "retries on database is locked",
+			fn: func(calls *int) error {
+				if *calls < 3 {
+					return fmt.Errorf("database is locked")
+				}
+				return nil
+			},
+			expectedCalls: 3,
+			expectError:   false,
+		},
+		{
+			name: "retries on SQLITE_BUSY",
+			fn: func(calls *int) error {
+				if *calls < 2 {
+					return fmt.Errorf("SQLITE_BUSY (5)")
+				}
+				return nil
+			},
+			expectedCalls: 2,
+			expectError:   false,
+		},
+		{
+			name: "retries on deadlock detected",
+			fn: func(calls *int) error {
+				if *calls < 2 {
+					return fmt.Errorf("deadlock detected")
+				}
+				return nil
+			},
+			expectedCalls: 2,
+			expectError:   false,
+		},
+		{
+			name: "does not retry non-lock error",
+			fn: func(_ *int) error {
+				return fmt.Errorf("some other error")
+			},
+			expectedCalls: 1,
+			expectError:   true,
+		},
+		{
+			name: "exhausts all retries",
+			fn: func(_ *int) error {
+				return fmt.Errorf("database is locked")
+			},
+			expectedCalls: retryMaxAttempts,
+			expectError:   true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			calls := 0
+			err := RetryOnLock("test_op", func() error {
+				calls++
+				return tc.fn(&calls)
+			}, nil)
+
+			if tc.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tc.expectedCalls, calls)
+		})
+	}
+}
+
+func TestBuildSQLiteDSN(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		dbPath   string
+		pragmas  string
+		expected string
+	}{
+		{
+			name:     "plain path",
+			dbPath:   "/data/birdnet.db",
+			pragmas:  "_journal_mode=WAL&_busy_timeout=30000",
+			expected: "/data/birdnet.db?_journal_mode=WAL&_busy_timeout=30000",
+		},
+		{
+			name:     "path with existing query params",
+			dbPath:   "file::memory:?cache=shared",
+			pragmas:  "_journal_mode=WAL&_busy_timeout=30000",
+			expected: "file::memory:?cache=shared&_journal_mode=WAL&_busy_timeout=30000",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			result := buildSQLiteDSN(tc.dbPath, tc.pragmas)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestIsTransientDBError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{name: "nil error", err: nil, expected: false},
+		{name: "database is locked", err: fmt.Errorf("database is locked"), expected: true},
+		{name: "SQLITE_BUSY", err: fmt.Errorf("SQLITE_BUSY"), expected: true},
+		{name: "resource busy", err: fmt.Errorf("resource busy"), expected: true},
+		{name: "deadlock detected", err: fmt.Errorf("deadlock detected"), expected: true},
+		{name: "lock wait timeout", err: fmt.Errorf("lock wait timeout exceeded"), expected: true},
+		{name: "unrelated error", err: fmt.Errorf("connection refused"), expected: false},
+		{name: "wrapped database locked", err: fmt.Errorf("tx failed: %w", fmt.Errorf("database is locked")), expected: true},
+		{name: "double wrapped SQLITE_BUSY", err: fmt.Errorf("outer: %w", fmt.Errorf("inner: %w", fmt.Errorf("SQLITE_BUSY"))), expected: true},
+		{name: "wrapped non-transient", err: fmt.Errorf("outer: %w", fmt.Errorf("connection refused")), expected: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.expected, IsTransientDBError(tc.err))
+		})
+	}
+}
+
+func TestRetryOnLock_RecordsMetricsOnRetry(t *testing.T) {
+	t.Parallel()
+
+	reg, m := newTestMetrics(t)
+	calls := 0
+	err := RetryOnLock("test_metrics_retry", func() error {
+		calls++
+		if calls < 3 {
+			return fmt.Errorf("database is locked")
+		}
+		return nil
+	}, m)
+
+	require.NoError(t, err)
+	assert.Equal(t, 3, calls)
+
+	// 2 transient failures before success means 2 retries recorded.
+	assert.Equal(t, 2, gatherCounter(t, reg, "datastore_db_transaction_retries_total"))
+}
+
+func TestRetryOnLock_RecordsExhaustedMetric(t *testing.T) {
+	t.Parallel()
+
+	reg, m := newTestMetrics(t)
+	err := RetryOnLock("test_exhausted", func() error {
+		return fmt.Errorf("database is locked")
+	}, m)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "database is locked")
+
+	// Exactly 1 exhaustion event.
+	assert.Equal(t, 1, gatherCounter(t, reg, "datastore_lock_retries_exhausted_total"))
+}
+
+func TestRetryOnLock_NilMetricsDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	calls := 0
+	err := RetryOnLock("nil_metrics", func() error {
+		calls++
+		if calls < 2 {
+			return fmt.Errorf("database is locked")
+		}
+		return nil
+	}, nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, 2, calls)
+}
+
+func TestRetryTransactionOnLock_SucceedsImmediately(t *testing.T) {
+	t.Parallel()
+
+	db := openRetryTestDB(t)
+	calls := 0
+
+	err := RetryTransactionOnLock(db, "test_tx", func(tx *gorm.DB) error {
+		calls++
+		return tx.Create(&DailyEvents{Date: "2024-01-01", CityName: "Test"}).Error
+	}, nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, calls)
+
+	// Verify the row was actually persisted.
+	var count int64
+	require.NoError(t, db.Model(&DailyEvents{}).Count(&count).Error)
+	assert.Equal(t, int64(1), count)
+}
+
+func TestRetryTransactionOnLock_RetriesTransientError(t *testing.T) {
+	t.Parallel()
+
+	db := openRetryTestDB(t)
+	calls := 0
+
+	err := RetryTransactionOnLock(db, "test_tx_retry", func(tx *gorm.DB) error {
+		calls++
+		if calls < 3 {
+			return fmt.Errorf("database is locked")
+		}
+		return tx.Create(&DailyEvents{Date: "2024-02-01", CityName: "Retry"}).Error
+	}, nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, 3, calls)
+
+	var count int64
+	require.NoError(t, db.Model(&DailyEvents{}).Count(&count).Error)
+	assert.Equal(t, int64(1), count)
+}
+
+func TestRetryTransactionOnLock_DoesNotRetryNonTransient(t *testing.T) {
+	t.Parallel()
+
+	db := openRetryTestDB(t)
+	calls := 0
+
+	err := RetryTransactionOnLock(db, "test_tx_bail", func(_ *gorm.DB) error {
+		calls++
+		return fmt.Errorf("UNIQUE constraint failed")
+	}, nil)
+
+	require.Error(t, err)
+	assert.Equal(t, 1, calls)
+	assert.Contains(t, err.Error(), "UNIQUE constraint failed")
+}
+
+func TestRetryTransactionOnLock_ExhaustsRetries(t *testing.T) {
+	t.Parallel()
+
+	db := openRetryTestDB(t)
+	calls := 0
+
+	err := RetryTransactionOnLock(db, "test_tx_exhaust", func(_ *gorm.DB) error {
+		calls++
+		return fmt.Errorf("database is locked")
+	}, nil)
+
+	require.Error(t, err)
+	assert.Equal(t, retryMaxAttempts, calls)
+	assert.Contains(t, err.Error(), "database is locked")
+}
+
+func TestRetryTransactionOnLock_RollsBackOnError(t *testing.T) {
+	t.Parallel()
+
+	db := openRetryTestDB(t)
+
+	// The fn creates a row then returns a non-transient error.
+	// The row should NOT be persisted because the transaction is rolled back.
+	err := RetryTransactionOnLock(db, "test_rollback", func(tx *gorm.DB) error {
+		if createErr := tx.Create(&DailyEvents{Date: "2024-03-01", CityName: "Ghost"}).Error; createErr != nil {
+			return createErr
+		}
+		return fmt.Errorf("simulated application error")
+	}, nil)
+
+	require.Error(t, err)
+
+	var count int64
+	require.NoError(t, db.Model(&DailyEvents{}).Count(&count).Error)
+	assert.Equal(t, int64(0), count, "rolled-back rows should not be persisted")
+}
+
+func TestRetryTransactionOnLock_WithMetrics(t *testing.T) {
+	t.Parallel()
+
+	db := openRetryTestDB(t)
+	reg, m := newTestMetrics(t)
+	calls := 0
+
+	err := RetryTransactionOnLock(db, "test_tx_metrics", func(tx *gorm.DB) error {
+		calls++
+		if calls < 2 {
+			return fmt.Errorf("database is locked")
+		}
+		return tx.Create(&DailyEvents{Date: "2024-04-01", CityName: "MetricsTest"}).Error
+	}, m)
+
+	require.NoError(t, err)
+	assert.Equal(t, 2, calls)
+
+	var count int64
+	require.NoError(t, db.Model(&DailyEvents{}).Count(&count).Error)
+	assert.Equal(t, int64(1), count)
+
+	// 1 transient failure before success means 1 retry recorded.
+	assert.Equal(t, 1, gatherCounter(t, reg, "datastore_db_transaction_retries_total"))
+}
+
+func TestRetryTransactionOnLock_ExhaustedWithMetrics(t *testing.T) {
+	t.Parallel()
+
+	db := openRetryTestDB(t)
+	reg, m := newTestMetrics(t)
+
+	err := RetryTransactionOnLock(db, "test_tx_exhaust_metrics", func(_ *gorm.DB) error {
+		return fmt.Errorf("database is locked")
+	}, m)
+
+	require.Error(t, err)
+
+	// Exhaustion counter must be exactly 1.
+	assert.Equal(t, 1, gatherCounter(t, reg, "datastore_lock_retries_exhausted_total"))
+
+	// retryMaxAttempts is 5; retries happen for attempts 0..3 (4 retries), the
+	// last attempt (4) does not trigger a retry backoff.
+	assert.Equal(t, retryMaxAttempts-1, gatherCounter(t, reg, "datastore_db_transaction_retries_total"))
+}
+
+// --- Task 4: Begin/Commit transient error path tests ---
+//
+// Simulating db.Begin() returning a "database is locked" error is not feasible
+// without mocking GORM internals (Begin is not an interface method on *gorm.DB).
+// Similarly, injecting a transient error at Commit time without wrapping the
+// entire GORM Session/ConnPool is impractical.
+//
+// The existing TestRetryTransactionOnLock_RetriesTransientError and the
+// exhaustion tests already exercise the transient-error retry path via the fn
+// callback, which covers the most common production scenario. The Begin and
+// Commit branches are structurally identical (same IsTransientDBError +
+// retryBackoff calls) and are exercised by code review and the integration
+// tests in retry_integration_test.go.
+//
+// If GORM ever exposes an interface-based transaction API, these tests should
+// be revisited.

--- a/internal/datastore/sqlite.go
+++ b/internal/datastore/sqlite.go
@@ -216,8 +216,16 @@ func (s *SQLiteStore) Open() error {
 		gormLogger = NewGormLogger(500*time.Millisecond, gormlogger.Warn, s.metrics)
 	}
 
+	// Build DSN with pragmas as query parameters so they apply to every
+	// connection opened by the pool, not just the first one.  When pragmas
+	// are set via Exec() after gorm.Open(), only the connection that
+	// happens to execute the statement gets them; new pool connections
+	// remain at SQLite defaults and miss busy_timeout entirely, leading
+	// to immediate "database is locked" errors under concurrency.
+	dsn := buildSQLiteDSN(dbPath, "_journal_mode=WAL&_busy_timeout=30000&_foreign_keys=ON&_synchronous=NORMAL&_cache_size=-4000")
+
 	// Open SQLite database with GORM
-	db, err := gorm.Open(sqlite.Open(dbPath), &gorm.Config{
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{
 		Logger: gormLogger,
 	})
 	if err != nil {
@@ -236,7 +244,13 @@ func (s *SQLiteStore) Open() error {
 		return enhancedErr
 	}
 
-	// Set SQLite pragmas for better performance
+	// Configure connection pool for SQLite.
+	// SQLite only supports a single writer at a time.  With Go's
+	// database/sql connection pool, multiple goroutines can obtain
+	// separate connections and attempt concurrent writes, causing
+	// "database is locked" errors even with busy_timeout set.
+	// Limiting to one open connection serializes all database access
+	// through a single connection, eliminating write contention.
 	sqlDB, err := db.DB()
 	if err != nil {
 		return errors.New(err).
@@ -245,24 +259,7 @@ func (s *SQLiteStore) Open() error {
 			Context("operation", "get_underlying_sqldb").
 			Build()
 	}
-
-	// Set pragmas
-	pragmas := []string{
-		"PRAGMA foreign_keys=ON",    // required for foreign key constraints
-		"PRAGMA journal_mode=WAL",   // faster writes
-		"PRAGMA synchronous=NORMAL", // faster writes
-		"PRAGMA cache_size=-4000",   // increase cache size
-		"PRAGMA temp_store=MEMORY",  // faster writes
-		"PRAGMA busy_timeout=30000", // wait up to 30s for locks (critical for concurrent access)
-	}
-
-	for _, pragma := range pragmas {
-		if _, err := sqlDB.Exec(pragma); err != nil {
-			GetLogger().Warn("Failed to set pragma",
-				logger.String("pragma", pragma),
-				logger.Error(err))
-		}
-	}
+	sqlDB.SetMaxOpenConns(1)
 
 	// Store the database connection
 	s.DB = db

--- a/internal/datastore/v2/manager.go
+++ b/internal/datastore/v2/manager.go
@@ -156,8 +156,17 @@ func NewSQLiteManager(cfg Config) (*SQLiteManager, error) {
 		gormLogger = gorm_logger.Default.LogMode(gorm_logger.Silent)
 	}
 
-	// Build DSN with recommended SQLite pragmas
-	dsn := fmt.Sprintf("%s?_journal_mode=WAL&_busy_timeout=%d&_foreign_keys=ON", dbPath, sqliteBusyTimeoutMs)
+	// Build DSN with recommended SQLite pragmas.
+	// All pragmas are set via DSN query parameters so they apply to every
+	// connection created by the pool, not just the first one.
+	// Use safe separator in case dbPath already contains query parameters
+	// (e.g., "file::memory:?cache=shared" in tests).
+	pragmas := fmt.Sprintf("_journal_mode=WAL&_busy_timeout=%d&_foreign_keys=ON&_synchronous=NORMAL&_cache_size=-4000", sqliteBusyTimeoutMs)
+	sep := "?"
+	if strings.Contains(dbPath, "?") {
+		sep = "&"
+	}
+	dsn := dbPath + sep + pragmas
 
 	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{
 		Logger: gormLogger,
@@ -165,6 +174,17 @@ func NewSQLiteManager(cfg Config) (*SQLiteManager, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to open v2 database: %w", err)
 	}
+
+	// Limit to a single open connection to serialize all database access.
+	// SQLite only supports one writer at a time; with Go's connection pool,
+	// multiple goroutines can obtain separate connections and attempt
+	// concurrent writes, causing "database is locked" errors even with
+	// busy_timeout set.  A single connection eliminates this contention.
+	sqlDB, err := db.DB()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get underlying database: %w", err)
+	}
+	sqlDB.SetMaxOpenConns(1)
 
 	return &SQLiteManager{
 		db:     db,

--- a/internal/datastore/v2/migration/testutil/setup.go
+++ b/internal/datastore/v2/migration/testutil/setup.go
@@ -187,14 +187,14 @@ func (ctx *TestContext) setupV2DB(t *testing.T, tmpDir string) {
 
 	// Create repositories (useV2Prefix = false for direct table access in tests, isMySQL = false for SQLite)
 	db := mgr.DB()
-	ctx.DetectionRepo = repository.NewDetectionRepository(db, false, false)
-	ctx.LabelRepo = repository.NewLabelRepository(db, false, false)
-	ctx.ModelRepo = repository.NewModelRepository(db, false, false)
-	ctx.SourceRepo = repository.NewAudioSourceRepository(db, false, false)
-	ctx.WeatherRepo = repository.NewWeatherRepository(db, false, false)
-	ctx.ImageCacheRepo = repository.NewImageCacheRepository(db, ctx.LabelRepo, false, false)
-	ctx.ThresholdRepo = repository.NewDynamicThresholdRepository(db, ctx.LabelRepo, false, false)
-	ctx.NotificationRepo = repository.NewNotificationHistoryRepository(db, ctx.LabelRepo, false, false)
+	ctx.DetectionRepo = repository.NewDetectionRepository(db, nil, false, false)
+	ctx.LabelRepo = repository.NewLabelRepository(db, nil, false, false)
+	ctx.ModelRepo = repository.NewModelRepository(db, nil, false, false)
+	ctx.SourceRepo = repository.NewAudioSourceRepository(db, nil, false, false)
+	ctx.WeatherRepo = repository.NewWeatherRepository(db, nil, false, false)
+	ctx.ImageCacheRepo = repository.NewImageCacheRepository(db, nil, ctx.LabelRepo, false, false)
+	ctx.ThresholdRepo = repository.NewDynamicThresholdRepository(db, nil, ctx.LabelRepo, false, false)
+	ctx.NotificationRepo = repository.NewNotificationHistoryRepository(db, nil, ctx.LabelRepo, false, false)
 
 	// Populate lookup tables for V2 normalized schema
 	ctx.setupLookupTables(t)

--- a/internal/datastore/v2/mysql_manager.go
+++ b/internal/datastore/v2/mysql_manager.go
@@ -2,8 +2,8 @@ package v2
 
 import (
 	"fmt"
-	"time"
 
+	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/datastore/v2/entities"
 	"gorm.io/driver/mysql"
 	"gorm.io/gorm"
@@ -67,14 +67,17 @@ func NewMySQLManager(cfg *MySQLConfig) (*MySQLManager, error) {
 		return nil, fmt.Errorf("failed to open MySQL database for v2: %w", err)
 	}
 
-	// Configure connection pool
+	// Configure connection pool using shared constants (see datastore.MySQL*).
+	// Matches the v1 store so both stay within MySQL's max_connections budget
+	// during migration when both are active (combined max = 2 * 25 = 50).
 	sqlDB, err := db.DB()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get underlying database: %w", err)
 	}
-	sqlDB.SetMaxIdleConns(10)
-	sqlDB.SetMaxOpenConns(100)
-	sqlDB.SetConnMaxLifetime(time.Hour)
+	sqlDB.SetMaxOpenConns(datastore.MySQLMaxOpenConns)
+	sqlDB.SetMaxIdleConns(datastore.MySQLMaxIdleConns)
+	sqlDB.SetConnMaxLifetime(datastore.MySQLConnMaxLifetime)
+	sqlDB.SetConnMaxIdleTime(datastore.MySQLConnMaxIdleTime)
 
 	return &MySQLManager{
 		db:          db,

--- a/internal/datastore/v2/repository/alert_rule_impl.go
+++ b/internal/datastore/v2/repository/alert_rule_impl.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/datastore/v2/entities"
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"gorm.io/gorm"
@@ -12,12 +13,14 @@ import (
 
 // alertRuleRepository implements AlertRuleRepository.
 type alertRuleRepository struct {
-	db *gorm.DB
+	db      *gorm.DB
+	metrics *datastore.Metrics
 }
 
 // NewAlertRuleRepository creates a new AlertRuleRepository.
-func NewAlertRuleRepository(db *gorm.DB) AlertRuleRepository {
-	return &alertRuleRepository{db: db}
+// metrics is optional (nil-safe) and enables retry observability.
+func NewAlertRuleRepository(db *gorm.DB, metrics *datastore.Metrics) AlertRuleRepository {
+	return &alertRuleRepository{db: db, metrics: metrics}
 }
 
 // ListRules returns alert rules matching the given filter.
@@ -59,10 +62,12 @@ func (r *alertRuleRepository) GetRule(ctx context.Context, id uint) (*entities.A
 
 // CreateRule creates a new alert rule with its conditions and actions.
 func (r *alertRuleRepository) CreateRule(ctx context.Context, rule *entities.AlertRule) error {
-	if err := r.db.WithContext(ctx).Create(rule).Error; err != nil {
-		return fmt.Errorf("failed to create alert rule: %w", err)
-	}
-	return nil
+	return datastore.RetryOnLock("v2_create_alert_rule", func() error {
+		if err := r.db.WithContext(ctx).Create(rule).Error; err != nil {
+			return fmt.Errorf("failed to create alert rule: %w", err)
+		}
+		return nil
+	}, r.metrics)
 }
 
 // UpdateRule replaces an alert rule, deleting existing conditions and actions first.
@@ -70,14 +75,14 @@ func (r *alertRuleRepository) UpdateRule(ctx context.Context, rule *entities.Ale
 	if rule.ID == 0 {
 		return fmt.Errorf("failed to update alert rule: missing rule ID")
 	}
-	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+	return datastore.RetryTransactionOnLock(r.db.WithContext(ctx), "v2_update_alert_rule", func(tx *gorm.DB) error {
 		if err := tx.Where("rule_id = ?", rule.ID).Delete(&entities.AlertCondition{}).Error; err != nil {
 			return fmt.Errorf("failed to delete old conditions: %w", err)
 		}
 		if err := tx.Where("rule_id = ?", rule.ID).Delete(&entities.AlertAction{}).Error; err != nil {
 			return fmt.Errorf("failed to delete old actions: %w", err)
 		}
-		// Zero out IDs so GORM inserts new rows instead of trying to update deleted ones
+		// Reset IDs to prevent stale primary keys on retry
 		for i := range rule.Conditions {
 			rule.Conditions[i].ID = 0
 		}
@@ -88,16 +93,24 @@ func (r *alertRuleRepository) UpdateRule(ctx context.Context, rule *entities.Ale
 			return fmt.Errorf("failed to update alert rule: %w", err)
 		}
 		return nil
-	})
+	}, r.metrics)
 }
 
 // DeleteRule deletes an alert rule and its conditions/actions via cascade.
 func (r *alertRuleRepository) DeleteRule(ctx context.Context, id uint) error {
-	result := r.db.WithContext(ctx).Delete(&entities.AlertRule{}, id)
-	if result.Error != nil {
-		return fmt.Errorf("failed to delete alert rule %d: %w", id, result.Error)
+	var rowsAffected int64
+	err := datastore.RetryOnLock("v2_delete_alert_rule", func() error {
+		result := r.db.WithContext(ctx).Delete(&entities.AlertRule{}, id)
+		if result.Error != nil {
+			return fmt.Errorf("failed to delete alert rule %d: %w", id, result.Error)
+		}
+		rowsAffected = result.RowsAffected
+		return nil
+	}, r.metrics)
+	if err != nil {
+		return err
 	}
-	if result.RowsAffected == 0 {
+	if rowsAffected == 0 {
 		return ErrAlertRuleNotFound
 	}
 	return nil
@@ -105,11 +118,19 @@ func (r *alertRuleRepository) DeleteRule(ctx context.Context, id uint) error {
 
 // ToggleRule enables or disables an alert rule.
 func (r *alertRuleRepository) ToggleRule(ctx context.Context, id uint, enabled bool) error {
-	result := r.db.WithContext(ctx).Model(&entities.AlertRule{}).Where("id = ?", id).Update("enabled", enabled)
-	if result.Error != nil {
-		return fmt.Errorf("failed to toggle alert rule %d: %w", id, result.Error)
+	var rowsAffected int64
+	err := datastore.RetryOnLock("v2_toggle_alert_rule", func() error {
+		result := r.db.WithContext(ctx).Model(&entities.AlertRule{}).Where("id = ?", id).Update("enabled", enabled)
+		if result.Error != nil {
+			return fmt.Errorf("failed to toggle alert rule %d: %w", id, result.Error)
+		}
+		rowsAffected = result.RowsAffected
+		return nil
+	}, r.metrics)
+	if err != nil {
+		return err
 	}
-	if result.RowsAffected == 0 {
+	if rowsAffected == 0 {
 		return ErrAlertRuleNotFound
 	}
 	return nil
@@ -123,19 +144,26 @@ func (r *alertRuleRepository) GetEnabledRules(ctx context.Context) ([]entities.A
 
 // DeleteBuiltInRules deletes all built-in alert rules.
 func (r *alertRuleRepository) DeleteBuiltInRules(ctx context.Context) (int64, error) {
-	result := r.db.WithContext(ctx).Where("built_in = ?", true).Delete(&entities.AlertRule{})
-	if result.Error != nil {
-		return 0, fmt.Errorf("failed to delete built-in alert rules: %w", result.Error)
-	}
-	return result.RowsAffected, nil
+	var rowsAffected int64
+	err := datastore.RetryOnLock("v2_delete_built_in_rules", func() error {
+		result := r.db.WithContext(ctx).Where("built_in = ?", true).Delete(&entities.AlertRule{})
+		if result.Error != nil {
+			return fmt.Errorf("failed to delete built-in alert rules: %w", result.Error)
+		}
+		rowsAffected = result.RowsAffected
+		return nil
+	}, r.metrics)
+	return rowsAffected, err
 }
 
 // SaveHistory saves an alert history entry.
 func (r *alertRuleRepository) SaveHistory(ctx context.Context, history *entities.AlertHistory) error {
-	if err := r.db.WithContext(ctx).Create(history).Error; err != nil {
-		return fmt.Errorf("failed to save alert history: %w", err)
-	}
-	return nil
+	return datastore.RetryOnLock("v2_save_alert_history", func() error {
+		if err := r.db.WithContext(ctx).Create(history).Error; err != nil {
+			return fmt.Errorf("failed to save alert history: %w", err)
+		}
+		return nil
+	}, r.metrics)
 }
 
 // ListHistory returns alert history entries matching the filter with pagination.
@@ -169,20 +197,30 @@ func (r *alertRuleRepository) ListHistory(ctx context.Context, filter AlertHisto
 
 // DeleteHistory deletes all alert history entries.
 func (r *alertRuleRepository) DeleteHistory(ctx context.Context) (int64, error) {
-	result := r.db.WithContext(ctx).Where("1 = 1").Delete(&entities.AlertHistory{})
-	if result.Error != nil {
-		return 0, fmt.Errorf("failed to delete alert history: %w", result.Error)
-	}
-	return result.RowsAffected, nil
+	var rowsAffected int64
+	err := datastore.RetryOnLock("v2_delete_alert_history", func() error {
+		result := r.db.WithContext(ctx).Where("1 = 1").Delete(&entities.AlertHistory{})
+		if result.Error != nil {
+			return fmt.Errorf("failed to delete alert history: %w", result.Error)
+		}
+		rowsAffected = result.RowsAffected
+		return nil
+	}, r.metrics)
+	return rowsAffected, err
 }
 
 // DeleteHistoryBefore deletes alert history entries older than the given time.
 func (r *alertRuleRepository) DeleteHistoryBefore(ctx context.Context, before time.Time) (int64, error) {
-	result := r.db.WithContext(ctx).Where("fired_at < ?", before).Delete(&entities.AlertHistory{})
-	if result.Error != nil {
-		return 0, fmt.Errorf("failed to delete alert history before %v: %w", before, result.Error)
-	}
-	return result.RowsAffected, nil
+	var rowsAffected int64
+	err := datastore.RetryOnLock("v2_delete_alert_history_before", func() error {
+		result := r.db.WithContext(ctx).Where("fired_at < ?", before).Delete(&entities.AlertHistory{})
+		if result.Error != nil {
+			return fmt.Errorf("failed to delete alert history before %v: %w", before, result.Error)
+		}
+		rowsAffected = result.RowsAffected
+		return nil
+	}, r.metrics)
+	return rowsAffected, err
 }
 
 // CountRulesByName returns the number of rules with the given name.

--- a/internal/datastore/v2/repository/alert_rule_impl_test.go
+++ b/internal/datastore/v2/repository/alert_rule_impl_test.go
@@ -63,7 +63,7 @@ func createTestRule(t *testing.T, repo AlertRuleRepository, name, objectType, tr
 
 func TestAlertRuleRepository_CreateAndGet(t *testing.T) {
 	db := setupAlertTestDB(t)
-	repo := NewAlertRuleRepository(db)
+	repo := NewAlertRuleRepository(db, nil)
 	ctx := t.Context()
 
 	rule := &entities.AlertRule{
@@ -110,7 +110,7 @@ func TestAlertRuleRepository_CreateAndGet(t *testing.T) {
 
 func TestAlertRuleRepository_ListRules(t *testing.T) {
 	db := setupAlertTestDB(t)
-	repo := NewAlertRuleRepository(db)
+	repo := NewAlertRuleRepository(db, nil)
 	ctx := t.Context()
 
 	// Create rules with different object types and states
@@ -152,7 +152,7 @@ func TestAlertRuleRepository_ListRules(t *testing.T) {
 
 func TestAlertRuleRepository_UpdateRule(t *testing.T) {
 	db := setupAlertTestDB(t)
-	repo := NewAlertRuleRepository(db)
+	repo := NewAlertRuleRepository(db, nil)
 	ctx := t.Context()
 
 	rule := createTestRule(t, repo, "Original", "detection", "event", "detection.occurred")
@@ -181,7 +181,7 @@ func TestAlertRuleRepository_UpdateRule(t *testing.T) {
 
 func TestAlertRuleRepository_UpdateRule_WithExistingIDs(t *testing.T) {
 	db := setupAlertTestDB(t)
-	repo := NewAlertRuleRepository(db)
+	repo := NewAlertRuleRepository(db, nil)
 	ctx := t.Context()
 
 	rule := createTestRule(t, repo, "IDTest", "detection", "event", "detection.occurred")
@@ -216,7 +216,7 @@ func TestAlertRuleRepository_UpdateRule_WithExistingIDs(t *testing.T) {
 
 func TestAlertRuleRepository_DeleteRule(t *testing.T) {
 	db := setupAlertTestDB(t)
-	repo := NewAlertRuleRepository(db)
+	repo := NewAlertRuleRepository(db, nil)
 	ctx := t.Context()
 
 	rule := createTestRule(t, repo, "ToDelete", "stream", "event", "stream.error")
@@ -239,7 +239,7 @@ func TestAlertRuleRepository_DeleteRule(t *testing.T) {
 
 func TestAlertRuleRepository_ToggleRule(t *testing.T) {
 	db := setupAlertTestDB(t)
-	repo := NewAlertRuleRepository(db)
+	repo := NewAlertRuleRepository(db, nil)
 	ctx := t.Context()
 
 	rule := createTestRule(t, repo, "Toggle", "detection", "event", "detection.new_species")
@@ -262,7 +262,7 @@ func TestAlertRuleRepository_ToggleRule(t *testing.T) {
 
 func TestAlertRuleRepository_History(t *testing.T) {
 	db := setupAlertTestDB(t)
-	repo := NewAlertRuleRepository(db)
+	repo := NewAlertRuleRepository(db, nil)
 	ctx := t.Context()
 
 	rule := createTestRule(t, repo, "HistRule", "detection", "event", "detection.new_species")
@@ -325,7 +325,7 @@ func TestAlertRuleRepository_History(t *testing.T) {
 
 func TestAlertRuleRepository_GetEnabledRules(t *testing.T) {
 	db := setupAlertTestDB(t)
-	repo := NewAlertRuleRepository(db)
+	repo := NewAlertRuleRepository(db, nil)
 	ctx := t.Context()
 
 	// Create mix of enabled and disabled rules
@@ -347,7 +347,7 @@ func TestAlertRuleRepository_GetEnabledRules(t *testing.T) {
 
 func TestAlertRuleRepository_DeleteBuiltInRules(t *testing.T) {
 	db := setupAlertTestDB(t)
-	repo := NewAlertRuleRepository(db)
+	repo := NewAlertRuleRepository(db, nil)
 	ctx := t.Context()
 
 	// Create mix of built-in and custom rules
@@ -371,7 +371,7 @@ func TestAlertRuleRepository_DeleteBuiltInRules(t *testing.T) {
 
 func TestAlertRuleRepository_CountRulesByName(t *testing.T) {
 	db := setupAlertTestDB(t)
-	repo := NewAlertRuleRepository(db)
+	repo := NewAlertRuleRepository(db, nil)
 	ctx := t.Context()
 
 	createTestRule(t, repo, "Duplicate Test", "detection", "event", "detection.new_species")

--- a/internal/datastore/v2/repository/app_metadata_impl.go
+++ b/internal/datastore/v2/repository/app_metadata_impl.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/datastore/v2/entities"
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"gorm.io/gorm"
@@ -13,6 +14,7 @@ import (
 // appMetadataRepository implements AppMetadataRepository.
 type appMetadataRepository struct {
 	db          *gorm.DB
+	metrics     *datastore.Metrics
 	useV2Prefix bool
 	isMySQL     bool
 }
@@ -20,11 +22,13 @@ type appMetadataRepository struct {
 // NewAppMetadataRepository creates a new AppMetadataRepository.
 // Parameters:
 //   - db: GORM database connection
+//   - metrics: optional DatastoreMetrics for retry observability (nil-safe)
 //   - useV2Prefix: true to use v2_ table prefix (MySQL migration mode)
 //   - isMySQL: true for MySQL dialect (affects date/time SQL expressions)
-func NewAppMetadataRepository(db *gorm.DB, useV2Prefix, isMySQL bool) AppMetadataRepository {
+func NewAppMetadataRepository(db *gorm.DB, metrics *datastore.Metrics, useV2Prefix, isMySQL bool) AppMetadataRepository {
 	return &appMetadataRepository{
 		db:          db,
+		metrics:     metrics,
 		useV2Prefix: useV2Prefix,
 		isMySQL:     isMySQL,
 	}
@@ -60,13 +64,15 @@ func (r *appMetadataRepository) Set(ctx context.Context, key, value string) erro
 		Key:   key,
 		Value: value,
 	}
-	if err := r.db.WithContext(ctx).Table(r.tableName()).
-		Clauses(clause.OnConflict{
-			Columns:   []clause.Column{{Name: "key"}},
-			DoUpdates: clause.AssignmentColumns([]string{"value"}),
-		}).
-		Create(&meta).Error; err != nil {
-		return fmt.Errorf("set app metadata key %q: %w", key, err)
-	}
-	return nil
+	return datastore.RetryOnLock("v2_set_app_metadata", func() error {
+		if err := r.db.WithContext(ctx).Table(r.tableName()).
+			Clauses(clause.OnConflict{
+				Columns:   []clause.Column{{Name: "key"}},
+				DoUpdates: clause.AssignmentColumns([]string{"value"}),
+			}).
+			Create(&meta).Error; err != nil {
+			return fmt.Errorf("set app metadata key %q: %w", key, err)
+		}
+		return nil
+	}, r.metrics)
 }

--- a/internal/datastore/v2/repository/app_metadata_test.go
+++ b/internal/datastore/v2/repository/app_metadata_test.go
@@ -34,7 +34,7 @@ func setupAppMetadataTestDB(t *testing.T) *gorm.DB {
 func TestAppMetadataRepository_GetEmpty(t *testing.T) {
 	t.Parallel()
 	db := setupAppMetadataTestDB(t)
-	repo := NewAppMetadataRepository(db, false, false)
+	repo := NewAppMetadataRepository(db, nil, false, false)
 	ctx := t.Context()
 
 	value, err := repo.Get(ctx, "nonexistent_key")
@@ -45,7 +45,7 @@ func TestAppMetadataRepository_GetEmpty(t *testing.T) {
 func TestAppMetadataRepository_SetThenGet(t *testing.T) {
 	t.Parallel()
 	db := setupAppMetadataTestDB(t)
-	repo := NewAppMetadataRepository(db, false, false)
+	repo := NewAppMetadataRepository(db, nil, false, false)
 	ctx := t.Context()
 
 	err := repo.Set(ctx, "my_key", "my_value")
@@ -59,7 +59,7 @@ func TestAppMetadataRepository_SetThenGet(t *testing.T) {
 func TestAppMetadataRepository_SetOverwrites(t *testing.T) {
 	t.Parallel()
 	db := setupAppMetadataTestDB(t)
-	repo := NewAppMetadataRepository(db, false, false)
+	repo := NewAppMetadataRepository(db, nil, false, false)
 	ctx := t.Context()
 
 	err := repo.Set(ctx, "version", "v1.0.0")
@@ -76,7 +76,7 @@ func TestAppMetadataRepository_SetOverwrites(t *testing.T) {
 func TestAppMetadataRepository_GetDifferentKeys(t *testing.T) {
 	t.Parallel()
 	db := setupAppMetadataTestDB(t)
-	repo := NewAppMetadataRepository(db, false, false)
+	repo := NewAppMetadataRepository(db, nil, false, false)
 	ctx := t.Context()
 
 	err := repo.Set(ctx, "key_a", "value_a")
@@ -101,7 +101,7 @@ func TestAppMetadataRepository_GetDifferentKeys(t *testing.T) {
 func TestAppMetadataRepository_SetEmptyValue(t *testing.T) {
 	t.Parallel()
 	db := setupAppMetadataTestDB(t)
-	repo := NewAppMetadataRepository(db, false, false)
+	repo := NewAppMetadataRepository(db, nil, false, false)
 	ctx := t.Context()
 
 	err := repo.Set(ctx, "empty_key", "")

--- a/internal/datastore/v2/repository/audio_source_impl.go
+++ b/internal/datastore/v2/repository/audio_source_impl.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/datastore/v2/entities"
 	"gorm.io/gorm"
 )
@@ -12,6 +13,7 @@ import (
 // audioSourceRepository implements AudioSourceRepository.
 type audioSourceRepository struct {
 	db          *gorm.DB
+	metrics     *datastore.Metrics
 	useV2Prefix bool
 	isMySQL     bool // For API consistency; currently unused here (used by detection_impl.go for dialect-specific SQL)
 }
@@ -19,11 +21,13 @@ type audioSourceRepository struct {
 // NewAudioSourceRepository creates a new AudioSourceRepository.
 // Parameters:
 //   - db: GORM database connection
+//   - metrics: optional DatastoreMetrics for retry observability (nil-safe)
 //   - useV2Prefix: true to use v2_ table prefix (MySQL migration mode)
 //   - isMySQL: true for MySQL dialect (affects date/time SQL expressions)
-func NewAudioSourceRepository(db *gorm.DB, useV2Prefix, isMySQL bool) AudioSourceRepository {
+func NewAudioSourceRepository(db *gorm.DB, metrics *datastore.Metrics, useV2Prefix, isMySQL bool) AudioSourceRepository {
 	return &audioSourceRepository{
 		db:          db,
+		metrics:     metrics,
 		useV2Prefix: useV2Prefix,
 		isMySQL:     isMySQL,
 	}
@@ -65,7 +69,9 @@ func (r *audioSourceRepository) GetOrCreate(ctx context.Context, sourceURI, node
 		SourceType:  sourceType,
 	}
 
-	createErr := r.db.WithContext(ctx).Table(r.tableName()).Create(&source).Error
+	createErr := datastore.RetryOnLock("v2_create_audio_source", func() error {
+		return r.db.WithContext(ctx).Table(r.tableName()).Create(&source).Error
+	}, r.metrics)
 	if createErr != nil {
 		// Handle race condition - another goroutine may have created it.
 		// Try to fetch the existing record; if that also fails, return the original create error.
@@ -183,11 +189,19 @@ func (r *audioSourceRepository) Count(ctx context.Context) (int64, error) {
 
 // Delete removes an audio source by ID.
 func (r *audioSourceRepository) Delete(ctx context.Context, id uint) error {
-	result := r.db.WithContext(ctx).Table(r.tableName()).Delete(&entities.AudioSource{}, id)
-	if result.Error != nil {
-		return result.Error
+	var rowsAffected int64
+	err := datastore.RetryOnLock("v2_delete_audio_source", func() error {
+		result := r.db.WithContext(ctx).Table(r.tableName()).Delete(&entities.AudioSource{}, id)
+		if result.Error != nil {
+			return result.Error
+		}
+		rowsAffected = result.RowsAffected
+		return nil
+	}, r.metrics)
+	if err != nil {
+		return err
 	}
-	if result.RowsAffected == 0 {
+	if rowsAffected == 0 {
 		return ErrAudioSourceNotFound
 	}
 	return nil
@@ -195,13 +209,21 @@ func (r *audioSourceRepository) Delete(ctx context.Context, id uint) error {
 
 // Update modifies an audio source's fields.
 func (r *audioSourceRepository) Update(ctx context.Context, id uint, updates map[string]any) error {
-	result := r.db.WithContext(ctx).Table(r.tableName()).
-		Where("id = ?", id).
-		Updates(updates)
-	if result.Error != nil {
-		return result.Error
+	var rowsAffected int64
+	err := datastore.RetryOnLock("v2_update_audio_source", func() error {
+		result := r.db.WithContext(ctx).Table(r.tableName()).
+			Where("id = ?", id).
+			Updates(updates)
+		if result.Error != nil {
+			return result.Error
+		}
+		rowsAffected = result.RowsAffected
+		return nil
+	}, r.metrics)
+	if err != nil {
+		return err
 	}
-	if result.RowsAffected == 0 {
+	if rowsAffected == 0 {
 		return ErrAudioSourceNotFound
 	}
 	return nil

--- a/internal/datastore/v2/repository/detection_impl.go
+++ b/internal/datastore/v2/repository/detection_impl.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"maps"
 	"slices"
-	"strings"
 	"time"
 
+	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/datastore/v2/entities"
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"gorm.io/gorm"
@@ -33,6 +33,7 @@ const defaultDBBatchSize = 500
 // detectionRepository implements DetectionRepository.
 type detectionRepository struct {
 	db          *gorm.DB
+	metrics     *datastore.Metrics
 	useV2Prefix bool
 	isMySQL     bool
 }
@@ -40,11 +41,13 @@ type detectionRepository struct {
 // NewDetectionRepository creates a new DetectionRepository.
 // Parameters:
 //   - db: GORM database connection
+//   - metrics: optional DatastoreMetrics for retry observability (nil-safe)
 //   - useV2Prefix: true to use v2_ table prefix (MySQL migration mode)
 //   - isMySQL: true for MySQL dialect (affects date/time SQL expressions)
-func NewDetectionRepository(db *gorm.DB, useV2Prefix, isMySQL bool) DetectionRepository {
+func NewDetectionRepository(db *gorm.DB, metrics *datastore.Metrics, useV2Prefix, isMySQL bool) DetectionRepository {
 	return &detectionRepository{
 		db:          db,
+		metrics:     metrics,
 		useV2Prefix: useV2Prefix,
 		isMySQL:     isMySQL,
 	}
@@ -133,13 +136,17 @@ func (r *detectionRepository) hourFromUnixExpr(column string) string {
 
 // Save persists a new detection.
 func (r *detectionRepository) Save(ctx context.Context, det *entities.Detection) error {
-	return r.db.WithContext(ctx).Table(r.tableName()).Create(det).Error
+	return datastore.RetryOnLock("v2_save_detection", func() error {
+		return r.db.WithContext(ctx).Table(r.tableName()).Create(det).Error
+	}, r.metrics)
 }
 
 // SaveWithID persists a detection with a specific ID (for migration).
 // GORM's Create() respects pre-set IDs, so no special handling is needed.
 func (r *detectionRepository) SaveWithID(ctx context.Context, det *entities.Detection) error {
-	return r.db.WithContext(ctx).Table(r.tableName()).Create(det).Error
+	return datastore.RetryOnLock("v2_save_detection_with_id", func() error {
+		return r.db.WithContext(ctx).Table(r.tableName()).Create(det).Error
+	}, r.metrics)
 }
 
 // Get retrieves a detection by ID.
@@ -232,18 +239,25 @@ func (r *detectionRepository) GetWithRelations(ctx context.Context, id uint) (*e
 // Update modifies specific fields of a detection.
 // Uses atomic operation to prevent TOCTOU race with lock checks.
 func (r *detectionRepository) Update(ctx context.Context, id uint, updates map[string]any) error {
-	// Atomic update: only update if not locked
-	// Use WHERE NOT EXISTS to combine lock check with update
-	result := r.db.WithContext(ctx).Table(r.tableName()).
-		Where("id = ?", id).
-		Where(fmt.Sprintf("NOT EXISTS (SELECT 1 FROM %s WHERE %s.detection_id = ?)",
-			r.locksTable(), r.locksTable()), id).
-		Updates(updates)
-
-	if result.Error != nil {
-		return result.Error
+	var rowsAffected int64
+	err := datastore.RetryOnLock("v2_update_detection", func() error {
+		// Atomic update: only update if not locked
+		// Use WHERE NOT EXISTS to combine lock check with update
+		result := r.db.WithContext(ctx).Table(r.tableName()).
+			Where("id = ?", id).
+			Where(fmt.Sprintf("NOT EXISTS (SELECT 1 FROM %s WHERE %s.detection_id = ?)",
+				r.locksTable(), r.locksTable()), id).
+			Updates(updates)
+		if result.Error != nil {
+			return result.Error
+		}
+		rowsAffected = result.RowsAffected
+		return nil
+	}, r.metrics)
+	if err != nil {
+		return err
 	}
-	if result.RowsAffected == 0 {
+	if rowsAffected == 0 {
 		// Could be: not found OR locked. Check which.
 		exists, err := r.Exists(ctx, id)
 		if err != nil {
@@ -260,17 +274,24 @@ func (r *detectionRepository) Update(ctx context.Context, id uint, updates map[s
 // Delete removes a detection by ID.
 // Uses atomic operation to prevent TOCTOU race with lock checks.
 func (r *detectionRepository) Delete(ctx context.Context, id uint) error {
-	// Atomic delete: only delete if not locked
-	// Use raw SQL with NOT EXISTS to combine lock check with delete
-	result := r.db.WithContext(ctx).Exec(
-		fmt.Sprintf("DELETE FROM %s WHERE id = ? AND NOT EXISTS (SELECT 1 FROM %s WHERE %s.detection_id = ?)",
-			r.tableName(), r.locksTable(), r.locksTable()),
-		id, id)
-
-	if result.Error != nil {
-		return result.Error
+	var rowsAffected int64
+	err := datastore.RetryOnLock("v2_delete_detection", func() error {
+		// Atomic delete: only delete if not locked
+		// Use raw SQL with NOT EXISTS to combine lock check with delete
+		result := r.db.WithContext(ctx).Exec(
+			fmt.Sprintf("DELETE FROM %s WHERE id = ? AND NOT EXISTS (SELECT 1 FROM %s WHERE %s.detection_id = ?)",
+				r.tableName(), r.locksTable(), r.locksTable()),
+			id, id)
+		if result.Error != nil {
+			return result.Error
+		}
+		rowsAffected = result.RowsAffected
+		return nil
+	}, r.metrics)
+	if err != nil {
+		return err
 	}
-	if result.RowsAffected == 0 {
+	if rowsAffected == 0 {
 		// Could be: not found OR locked. Check which.
 		exists, err := r.Exists(ctx, id)
 		if err != nil {
@@ -293,7 +314,9 @@ func (r *detectionRepository) SaveBatch(ctx context.Context, dets []*entities.De
 	if len(dets) == 0 {
 		return nil
 	}
-	return r.db.WithContext(ctx).Table(r.tableName()).CreateInBatches(dets, defaultDBBatchSize).Error
+	return datastore.RetryOnLock("v2_save_detection_batch", func() error {
+		return r.db.WithContext(ctx).Table(r.tableName()).CreateInBatches(dets, defaultDBBatchSize).Error
+	}, r.metrics)
 }
 
 // DeleteBatch removes multiple detections by ID.
@@ -301,7 +324,9 @@ func (r *detectionRepository) DeleteBatch(ctx context.Context, ids []uint) error
 	if len(ids) == 0 {
 		return nil
 	}
-	return r.db.WithContext(ctx).Table(r.tableName()).Delete(&entities.Detection{}, ids).Error
+	return datastore.RetryOnLock("v2_delete_detection_batch", func() error {
+		return r.db.WithContext(ctx).Table(r.tableName()).Delete(&entities.Detection{}, ids).Error
+	}, r.metrics)
 }
 
 // SaveBatchWithIDs persists multiple detections with specific IDs (for migration).
@@ -310,7 +335,9 @@ func (r *detectionRepository) SaveBatchWithIDs(ctx context.Context, dets []*enti
 	if len(dets) == 0 {
 		return nil
 	}
-	return r.db.WithContext(ctx).Table(r.tableName()).CreateInBatches(dets, defaultDBBatchSize).Error
+	return datastore.RetryOnLock("v2_save_detection_batch_with_ids", func() error {
+		return r.db.WithContext(ctx).Table(r.tableName()).CreateInBatches(dets, defaultDBBatchSize).Error
+	}, r.metrics)
 }
 
 // GetExistingAndLockedIDs checks which IDs exist and which are locked.
@@ -984,7 +1011,9 @@ func (r *detectionRepository) SavePredictions(ctx context.Context, detectionID u
 		p.DetectionID = detectionID
 	}
 
-	return r.db.WithContext(ctx).Table(r.predictionsTable()).Create(&preds).Error
+	return datastore.RetryOnLock("v2_save_predictions", func() error {
+		return r.db.WithContext(ctx).Table(r.predictionsTable()).Create(&preds).Error
+	}, r.metrics)
 }
 
 // SavePredictionsBatch stores predictions for multiple detections efficiently.
@@ -993,9 +1022,11 @@ func (r *detectionRepository) SavePredictionsBatch(ctx context.Context, preds []
 	if len(preds) == 0 {
 		return nil
 	}
-	return r.db.WithContext(ctx).Table(r.predictionsTable()).
-		Clauses(clause.OnConflict{DoNothing: true}).
-		CreateInBatches(preds, defaultDBBatchSize).Error
+	return datastore.RetryOnLock("v2_save_predictions_batch", func() error {
+		return r.db.WithContext(ctx).Table(r.predictionsTable()).
+			Clauses(clause.OnConflict{DoNothing: true}).
+			CreateInBatches(preds, defaultDBBatchSize).Error
+	}, r.metrics)
 }
 
 // GetPredictions retrieves all predictions for a detection.
@@ -1010,9 +1041,11 @@ func (r *detectionRepository) GetPredictions(ctx context.Context, detectionID ui
 
 // DeletePredictions removes all predictions for a detection.
 func (r *detectionRepository) DeletePredictions(ctx context.Context, detectionID uint) error {
-	return r.db.WithContext(ctx).Table(r.predictionsTable()).
-		Where("detection_id = ?", detectionID).
-		Delete(&entities.DetectionPrediction{}).Error
+	return datastore.RetryOnLock("v2_delete_predictions", func() error {
+		return r.db.WithContext(ctx).Table(r.predictionsTable()).
+			Where("detection_id = ?", detectionID).
+			Delete(&entities.DetectionPrediction{}).Error
+	}, r.metrics)
 }
 
 // ============================================================================
@@ -1029,19 +1062,23 @@ func (r *detectionRepository) SaveReview(ctx context.Context, review *entities.D
 
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		// Create new review
-		return r.db.WithContext(ctx).Table(r.reviewsTable()).Create(review).Error
+		return datastore.RetryOnLock("v2_save_review", func() error {
+			return r.db.WithContext(ctx).Table(r.reviewsTable()).Create(review).Error
+		}, r.metrics)
 	}
 	if err != nil {
 		return err
 	}
 
 	// Update existing review
-	return r.db.WithContext(ctx).Table(r.reviewsTable()).
-		Where("detection_id = ?", review.DetectionID).
-		Updates(map[string]any{
-			"verified":   review.Verified,
-			"updated_at": time.Now(),
-		}).Error
+	return datastore.RetryOnLock("v2_save_review_update", func() error {
+		return r.db.WithContext(ctx).Table(r.reviewsTable()).
+			Where("detection_id = ?", review.DetectionID).
+			Updates(map[string]any{
+				"verified":   review.Verified,
+				"updated_at": time.Now(),
+			}).Error
+	}, r.metrics)
 }
 
 // GetReview retrieves the review for a detection.
@@ -1058,16 +1095,24 @@ func (r *detectionRepository) GetReview(ctx context.Context, detectionID uint) (
 
 // UpdateReview updates the verification status for a detection.
 func (r *detectionRepository) UpdateReview(ctx context.Context, detectionID uint, verified entities.VerificationStatus) error {
-	result := r.db.WithContext(ctx).Table(r.reviewsTable()).
-		Where("detection_id = ?", detectionID).
-		Updates(map[string]any{
-			"verified":   verified,
-			"updated_at": time.Now(),
-		})
-	if result.Error != nil {
-		return result.Error
+	var rowsAffected int64
+	err := datastore.RetryOnLock("v2_update_review", func() error {
+		result := r.db.WithContext(ctx).Table(r.reviewsTable()).
+			Where("detection_id = ?", detectionID).
+			Updates(map[string]any{
+				"verified":   verified,
+				"updated_at": time.Now(),
+			})
+		if result.Error != nil {
+			return result.Error
+		}
+		rowsAffected = result.RowsAffected
+		return nil
+	}, r.metrics)
+	if err != nil {
+		return err
 	}
-	if result.RowsAffected == 0 {
+	if rowsAffected == 0 {
 		return ErrReviewNotFound
 	}
 	return nil
@@ -1075,13 +1120,21 @@ func (r *detectionRepository) UpdateReview(ctx context.Context, detectionID uint
 
 // DeleteReview removes the review for a detection.
 func (r *detectionRepository) DeleteReview(ctx context.Context, detectionID uint) error {
-	result := r.db.WithContext(ctx).Table(r.reviewsTable()).
-		Where("detection_id = ?", detectionID).
-		Delete(&entities.DetectionReview{})
-	if result.Error != nil {
-		return result.Error
+	var rowsAffected int64
+	err := datastore.RetryOnLock("v2_delete_review", func() error {
+		result := r.db.WithContext(ctx).Table(r.reviewsTable()).
+			Where("detection_id = ?", detectionID).
+			Delete(&entities.DetectionReview{})
+		if result.Error != nil {
+			return result.Error
+		}
+		rowsAffected = result.RowsAffected
+		return nil
+	}, r.metrics)
+	if err != nil {
+		return err
 	}
-	if result.RowsAffected == 0 {
+	if rowsAffected == 0 {
 		return ErrReviewNotFound
 	}
 	return nil
@@ -1092,9 +1145,11 @@ func (r *detectionRepository) SaveReviewsBatch(ctx context.Context, reviews []*e
 	if len(reviews) == 0 {
 		return nil
 	}
-	return r.db.WithContext(ctx).Table(r.reviewsTable()).
-		Clauses(clause.OnConflict{DoNothing: true}).
-		CreateInBatches(reviews, defaultDBBatchSize).Error
+	return datastore.RetryOnLock("v2_save_reviews_batch", func() error {
+		return r.db.WithContext(ctx).Table(r.reviewsTable()).
+			Clauses(clause.OnConflict{DoNothing: true}).
+			CreateInBatches(reviews, defaultDBBatchSize).Error
+	}, r.metrics)
 }
 
 // GetReviewsByDetectionIDs retrieves reviews for multiple detections.
@@ -1130,7 +1185,9 @@ func (r *detectionRepository) GetReviewsByDetectionIDs(ctx context.Context, dete
 
 // SaveComment adds a comment to a detection.
 func (r *detectionRepository) SaveComment(ctx context.Context, comment *entities.DetectionComment) error {
-	return r.db.WithContext(ctx).Table(r.commentsTable()).Create(comment).Error
+	return datastore.RetryOnLock("v2_save_comment", func() error {
+		return r.db.WithContext(ctx).Table(r.commentsTable()).Create(comment).Error
+	}, r.metrics)
 }
 
 // GetComments retrieves all comments for a detection.
@@ -1145,16 +1202,24 @@ func (r *detectionRepository) GetComments(ctx context.Context, detectionID uint)
 
 // UpdateComment modifies a comment's content.
 func (r *detectionRepository) UpdateComment(ctx context.Context, commentID uint, entry string) error {
-	result := r.db.WithContext(ctx).Table(r.commentsTable()).
-		Where("id = ?", commentID).
-		Updates(map[string]any{
-			"entry":      entry,
-			"updated_at": time.Now(),
-		})
-	if result.Error != nil {
-		return result.Error
+	var rowsAffected int64
+	err := datastore.RetryOnLock("v2_update_comment", func() error {
+		result := r.db.WithContext(ctx).Table(r.commentsTable()).
+			Where("id = ?", commentID).
+			Updates(map[string]any{
+				"entry":      entry,
+				"updated_at": time.Now(),
+			})
+		if result.Error != nil {
+			return result.Error
+		}
+		rowsAffected = result.RowsAffected
+		return nil
+	}, r.metrics)
+	if err != nil {
+		return err
 	}
-	if result.RowsAffected == 0 {
+	if rowsAffected == 0 {
 		return ErrCommentNotFound
 	}
 	return nil
@@ -1162,11 +1227,19 @@ func (r *detectionRepository) UpdateComment(ctx context.Context, commentID uint,
 
 // DeleteComment removes a specific comment.
 func (r *detectionRepository) DeleteComment(ctx context.Context, commentID uint) error {
-	result := r.db.WithContext(ctx).Table(r.commentsTable()).Delete(&entities.DetectionComment{}, commentID)
-	if result.Error != nil {
-		return result.Error
+	var rowsAffected int64
+	err := datastore.RetryOnLock("v2_delete_comment", func() error {
+		result := r.db.WithContext(ctx).Table(r.commentsTable()).Delete(&entities.DetectionComment{}, commentID)
+		if result.Error != nil {
+			return result.Error
+		}
+		rowsAffected = result.RowsAffected
+		return nil
+	}, r.metrics)
+	if err != nil {
+		return err
 	}
-	if result.RowsAffected == 0 {
+	if rowsAffected == 0 {
 		return ErrCommentNotFound
 	}
 	return nil
@@ -1177,9 +1250,11 @@ func (r *detectionRepository) SaveCommentsBatch(ctx context.Context, comments []
 	if len(comments) == 0 {
 		return nil
 	}
-	return r.db.WithContext(ctx).Table(r.commentsTable()).
-		Clauses(clause.OnConflict{DoNothing: true}).
-		CreateInBatches(comments, defaultDBBatchSize).Error
+	return datastore.RetryOnLock("v2_save_comments_batch", func() error {
+		return r.db.WithContext(ctx).Table(r.commentsTable()).
+			Clauses(clause.OnConflict{DoNothing: true}).
+			CreateInBatches(comments, defaultDBBatchSize).Error
+	}, r.metrics)
 }
 
 // GetCommentsByDetectionIDs retrieves comments for multiple detections.
@@ -1232,54 +1307,20 @@ func (r *detectionRepository) Lock(ctx context.Context, detectionID uint) error 
 	}
 
 	lock := entities.DetectionLock{DetectionID: detectionID}
-	return r.db.WithContext(ctx).Table(r.locksTable()).Create(&lock).Error
+	return datastore.RetryOnLock("v2_lock_detection", func() error {
+		return r.db.WithContext(ctx).Table(r.locksTable()).Create(&lock).Error
+	}, r.metrics)
 }
 
 // Unlock removes the lock from a detection.
 // This operation is idempotent — unlocking an already-unlocked detection succeeds silently.
-// Uses retry with exponential backoff for transient SQLite lock contention.
+// Uses RetryOnLock for transient SQLite lock contention.
 func (r *detectionRepository) Unlock(ctx context.Context, detectionID uint) error {
-	const (
-		maxRetries = 5
-		baseDelay  = 500 * time.Millisecond
-	)
-
-	var lastErr error
-	for attempt := range maxRetries {
-		result := r.db.WithContext(ctx).Table(r.locksTable()).
+	return datastore.RetryOnLock("v2_unlock_detection", func() error {
+		return r.db.WithContext(ctx).Table(r.locksTable()).
 			Where("detection_id = ?", detectionID).
-			Delete(&entities.DetectionLock{})
-		if result.Error == nil {
-			return nil
-		}
-
-		lastErr = result.Error
-		if !isDBLockError(lastErr) || attempt == maxRetries-1 {
-			return fmt.Errorf("unlock detection %d: %w", detectionID, lastErr)
-		}
-
-		// Exponential backoff: 500ms, 1s, 2s, 4s — respect context cancellation
-		delay := baseDelay * time.Duration(1<<attempt)
-		select {
-		case <-ctx.Done():
-			return fmt.Errorf("unlock detection %d: %w", detectionID, ctx.Err())
-		case <-time.After(delay):
-		}
-	}
-	return fmt.Errorf("unlock detection %d after %d retries: %w", detectionID, maxRetries, lastErr)
-}
-
-// isDBLockError checks if an error is a transient database lock contention error.
-// Handles both SQLite and MySQL lock errors.
-func isDBLockError(err error) bool {
-	if err == nil {
-		return false
-	}
-	errStr := err.Error()
-	return strings.Contains(errStr, "database is locked") ||
-		strings.Contains(errStr, "SQLITE_BUSY") ||
-		strings.Contains(errStr, "Lock wait timeout exceeded") ||
-		strings.Contains(errStr, "Deadlock found")
+			Delete(&entities.DetectionLock{}).Error
+	}, r.metrics)
 }
 
 // IsLocked checks if a detection is locked.
@@ -1308,9 +1349,11 @@ func (r *detectionRepository) SaveLocksBatch(ctx context.Context, locks []*entit
 	if len(locks) == 0 {
 		return nil
 	}
-	return r.db.WithContext(ctx).Table(r.locksTable()).
-		Clauses(clause.OnConflict{DoNothing: true}).
-		CreateInBatches(locks, defaultDBBatchSize).Error
+	return datastore.RetryOnLock("v2_save_locks_batch", func() error {
+		return r.db.WithContext(ctx).Table(r.locksTable()).
+			Clauses(clause.OnConflict{DoNothing: true}).
+			CreateInBatches(locks, defaultDBBatchSize).Error
+	}, r.metrics)
 }
 
 // GetLocksByDetectionIDs retrieves lock status for multiple detections.

--- a/internal/datastore/v2/repository/dynamic_threshold_impl.go
+++ b/internal/datastore/v2/repository/dynamic_threshold_impl.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/datastore/v2/entities"
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"gorm.io/gorm"
@@ -13,6 +14,7 @@ import (
 // dynamicThresholdRepository implements DynamicThresholdRepository.
 type dynamicThresholdRepository struct {
 	db          *gorm.DB
+	metrics     *datastore.Metrics
 	labelRepo   LabelRepository
 	useV2Prefix bool
 	isMySQL     bool // For API consistency; currently unused here (used by detection_impl.go for dialect-specific SQL)
@@ -21,12 +23,14 @@ type dynamicThresholdRepository struct {
 // NewDynamicThresholdRepository creates a new DynamicThresholdRepository.
 // Parameters:
 //   - db: GORM database connection
+//   - metrics: optional DatastoreMetrics for retry observability (nil-safe)
 //   - labelRepo: LabelRepository for resolving species names to label IDs
 //   - useV2Prefix: true to use v2_ table prefix (MySQL migration mode)
 //   - isMySQL: true for MySQL dialect (affects date/time SQL expressions)
-func NewDynamicThresholdRepository(db *gorm.DB, labelRepo LabelRepository, useV2Prefix, isMySQL bool) DynamicThresholdRepository {
+func NewDynamicThresholdRepository(db *gorm.DB, metrics *datastore.Metrics, labelRepo LabelRepository, useV2Prefix, isMySQL bool) DynamicThresholdRepository {
 	return &dynamicThresholdRepository{
 		db:          db,
+		metrics:     metrics,
 		labelRepo:   labelRepo,
 		useV2Prefix: useV2Prefix,
 		isMySQL:     isMySQL,
@@ -62,12 +66,14 @@ func (r *dynamicThresholdRepository) SaveDynamicThreshold(ctx context.Context, t
 	if threshold.LabelID == 0 {
 		return errors.NewStd("dynamic threshold LabelID must be set before saving")
 	}
-	return r.db.WithContext(ctx).Table(r.thresholdTable()).
-		Clauses(clause.OnConflict{
-			Columns:   []clause.Column{{Name: "label_id"}},
-			UpdateAll: true,
-		}).
-		Create(threshold).Error
+	return datastore.RetryOnLock("v2_save_dynamic_threshold", func() error {
+		return r.db.WithContext(ctx).Table(r.thresholdTable()).
+			Clauses(clause.OnConflict{
+				Columns:   []clause.Column{{Name: "label_id"}},
+				UpdateAll: true,
+			}).
+			Create(threshold).Error
+	}, r.metrics)
 }
 
 // GetDynamicThreshold retrieves a threshold by species name (scientific name).
@@ -129,13 +135,21 @@ func (r *dynamicThresholdRepository) DeleteDynamicThreshold(ctx context.Context,
 		return ErrDynamicThresholdNotFound
 	}
 
-	result := r.db.WithContext(ctx).Table(r.thresholdTable()).
-		Where("label_id IN ?", labelIDs).
-		Delete(&entities.DynamicThreshold{})
-	if result.Error != nil {
-		return result.Error
+	var rowsAffected int64
+	err = datastore.RetryOnLock("v2_delete_dynamic_threshold", func() error {
+		result := r.db.WithContext(ctx).Table(r.thresholdTable()).
+			Where("label_id IN ?", labelIDs).
+			Delete(&entities.DynamicThreshold{})
+		if result.Error != nil {
+			return result.Error
+		}
+		rowsAffected = result.RowsAffected
+		return nil
+	}, r.metrics)
+	if err != nil {
+		return err
 	}
-	if result.RowsAffected == 0 {
+	if rowsAffected == 0 {
 		return ErrDynamicThresholdNotFound
 	}
 	return nil
@@ -143,10 +157,18 @@ func (r *dynamicThresholdRepository) DeleteDynamicThreshold(ctx context.Context,
 
 // DeleteExpiredDynamicThresholds deletes thresholds that have expired.
 func (r *dynamicThresholdRepository) DeleteExpiredDynamicThresholds(ctx context.Context, before time.Time) (int64, error) {
-	result := r.db.WithContext(ctx).Table(r.thresholdTable()).
-		Where("expires_at < ?", before).
-		Delete(&entities.DynamicThreshold{})
-	return result.RowsAffected, result.Error
+	var rowsAffected int64
+	err := datastore.RetryOnLock("v2_delete_expired_dynamic_thresholds", func() error {
+		result := r.db.WithContext(ctx).Table(r.thresholdTable()).
+			Where("expires_at < ?", before).
+			Delete(&entities.DynamicThreshold{})
+		if result.Error != nil {
+			return result.Error
+		}
+		rowsAffected = result.RowsAffected
+		return nil
+	}, r.metrics)
+	return rowsAffected, err
 }
 
 // UpdateDynamicThresholdExpiry updates the expiry time for thresholds.
@@ -164,13 +186,21 @@ func (r *dynamicThresholdRepository) UpdateDynamicThresholdExpiry(ctx context.Co
 		return ErrDynamicThresholdNotFound
 	}
 
-	result := r.db.WithContext(ctx).Table(r.thresholdTable()).
-		Where("label_id IN ?", labelIDs).
-		Update("expires_at", expiresAt)
-	if result.Error != nil {
-		return result.Error
+	var rowsAffected int64
+	err = datastore.RetryOnLock("v2_update_dynamic_threshold_expiry", func() error {
+		result := r.db.WithContext(ctx).Table(r.thresholdTable()).
+			Where("label_id IN ?", labelIDs).
+			Update("expires_at", expiresAt)
+		if result.Error != nil {
+			return result.Error
+		}
+		rowsAffected = result.RowsAffected
+		return nil
+	}, r.metrics)
+	if err != nil {
+		return err
 	}
-	if result.RowsAffected == 0 {
+	if rowsAffected == 0 {
 		return ErrDynamicThresholdNotFound
 	}
 	return nil
@@ -188,20 +218,30 @@ func (r *dynamicThresholdRepository) BatchSaveDynamicThresholds(ctx context.Cont
 			return errors.NewStd("all thresholds must have LabelID set before batch save")
 		}
 	}
-	return r.db.WithContext(ctx).Table(r.thresholdTable()).
-		Clauses(clause.OnConflict{
-			Columns:   []clause.Column{{Name: "label_id"}},
-			UpdateAll: true,
-		}).
-		CreateInBatches(thresholds, 100).Error
+	return datastore.RetryOnLock("v2_batch_save_dynamic_thresholds", func() error {
+		return r.db.WithContext(ctx).Table(r.thresholdTable()).
+			Clauses(clause.OnConflict{
+				Columns:   []clause.Column{{Name: "label_id"}},
+				UpdateAll: true,
+			}).
+			CreateInBatches(thresholds, 100).Error
+	}, r.metrics)
 }
 
 // DeleteAllDynamicThresholds deletes all thresholds.
 func (r *dynamicThresholdRepository) DeleteAllDynamicThresholds(ctx context.Context) (int64, error) {
-	result := r.db.WithContext(ctx).Table(r.thresholdTable()).
-		Where("1 = 1").
-		Delete(&entities.DynamicThreshold{})
-	return result.RowsAffected, result.Error
+	var rowsAffected int64
+	err := datastore.RetryOnLock("v2_delete_all_dynamic_thresholds", func() error {
+		result := r.db.WithContext(ctx).Table(r.thresholdTable()).
+			Where("1 = 1").
+			Delete(&entities.DynamicThreshold{})
+		if result.Error != nil {
+			return result.Error
+		}
+		rowsAffected = result.RowsAffected
+		return nil
+	}, r.metrics)
+	return rowsAffected, err
 }
 
 // GetDynamicThresholdStats returns statistics about dynamic thresholds.
@@ -252,7 +292,9 @@ func (r *dynamicThresholdRepository) SaveThresholdEvent(ctx context.Context, eve
 	if event.LabelID == 0 {
 		return errors.NewStd("threshold event LabelID must be set before saving")
 	}
-	return r.db.WithContext(ctx).Table(r.eventTable()).Create(event).Error
+	return datastore.RetryOnLock("v2_save_threshold_event", func() error {
+		return r.db.WithContext(ctx).Table(r.eventTable()).Create(event).Error
+	}, r.metrics)
 }
 
 // GetThresholdEvents retrieves events for a species (by scientific name).
@@ -310,15 +352,25 @@ func (r *dynamicThresholdRepository) DeleteThresholdEvents(ctx context.Context, 
 		return nil // Nothing to delete
 	}
 
-	return r.db.WithContext(ctx).Table(r.eventTable()).
-		Where("label_id IN ?", labelIDs).
-		Delete(&entities.ThresholdEvent{}).Error
+	return datastore.RetryOnLock("v2_delete_threshold_events", func() error {
+		return r.db.WithContext(ctx).Table(r.eventTable()).
+			Where("label_id IN ?", labelIDs).
+			Delete(&entities.ThresholdEvent{}).Error
+	}, r.metrics)
 }
 
 // DeleteAllThresholdEvents deletes all threshold events.
 func (r *dynamicThresholdRepository) DeleteAllThresholdEvents(ctx context.Context) (int64, error) {
-	result := r.db.WithContext(ctx).Table(r.eventTable()).
-		Where("1 = 1").
-		Delete(&entities.ThresholdEvent{})
-	return result.RowsAffected, result.Error
+	var rowsAffected int64
+	err := datastore.RetryOnLock("v2_delete_all_threshold_events", func() error {
+		result := r.db.WithContext(ctx).Table(r.eventTable()).
+			Where("1 = 1").
+			Delete(&entities.ThresholdEvent{})
+		if result.Error != nil {
+			return result.Error
+		}
+		rowsAffected = result.RowsAffected
+		return nil
+	}, r.metrics)
+	return rowsAffected, err
 }

--- a/internal/datastore/v2/repository/image_cache_impl.go
+++ b/internal/datastore/v2/repository/image_cache_impl.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"context"
 
+	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/datastore/v2/entities"
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"gorm.io/gorm"
@@ -12,6 +13,7 @@ import (
 // imageCacheRepository implements ImageCacheRepository.
 type imageCacheRepository struct {
 	db          *gorm.DB
+	metrics     *datastore.Metrics
 	labelRepo   LabelRepository
 	useV2Prefix bool
 	isMySQL     bool // For API consistency; currently unused here (used by detection_impl.go for dialect-specific SQL)
@@ -20,12 +22,14 @@ type imageCacheRepository struct {
 // NewImageCacheRepository creates a new ImageCacheRepository.
 // Parameters:
 //   - db: GORM database connection
+//   - metrics: optional DatastoreMetrics for retry observability (nil-safe)
 //   - labelRepo: LabelRepository for resolving scientific names to label IDs
 //   - useV2Prefix: true to use v2_ table prefix (MySQL migration mode)
 //   - isMySQL: true for MySQL dialect (affects date/time SQL expressions)
-func NewImageCacheRepository(db *gorm.DB, labelRepo LabelRepository, useV2Prefix, isMySQL bool) ImageCacheRepository {
+func NewImageCacheRepository(db *gorm.DB, metrics *datastore.Metrics, labelRepo LabelRepository, useV2Prefix, isMySQL bool) ImageCacheRepository {
 	return &imageCacheRepository{
 		db:          db,
+		metrics:     metrics,
 		labelRepo:   labelRepo,
 		useV2Prefix: useV2Prefix,
 		isMySQL:     isMySQL,
@@ -86,12 +90,14 @@ func (r *imageCacheRepository) SaveImageCache(ctx context.Context, cache *entiti
 	if cache.LabelID == 0 {
 		return errors.NewStd("image cache LabelID must be set before saving")
 	}
-	return r.db.WithContext(ctx).Table(r.tableName()).
-		Clauses(clause.OnConflict{
-			Columns:   []clause.Column{{Name: "provider_name"}, {Name: "label_id"}},
-			UpdateAll: true,
-		}).
-		Create(cache).Error
+	return datastore.RetryOnLock("v2_save_image_cache", func() error {
+		return r.db.WithContext(ctx).Table(r.tableName()).
+			Clauses(clause.OnConflict{
+				Columns:   []clause.Column{{Name: "provider_name"}, {Name: "label_id"}},
+				UpdateAll: true,
+			}).
+			Create(cache).Error
+	}, r.metrics)
 }
 
 // GetAllImageCaches retrieves all image cache entries for a provider.

--- a/internal/datastore/v2/repository/label_impl.go
+++ b/internal/datastore/v2/repository/label_impl.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/datastore/v2/entities"
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"gorm.io/gorm"
@@ -16,14 +17,17 @@ import (
 // labelRepository implements LabelRepository.
 type labelRepository struct {
 	db          *gorm.DB
+	metrics     *datastore.Metrics
 	useV2Prefix bool // For MySQL: use v2_ table prefix
 	isMySQL     bool // For MySQL dialect
 }
 
 // NewLabelRepository creates a new LabelRepository.
-func NewLabelRepository(db *gorm.DB, useV2Prefix, isMySQL bool) LabelRepository {
+// metrics is optional (nil-safe) and enables retry observability.
+func NewLabelRepository(db *gorm.DB, metrics *datastore.Metrics, useV2Prefix, isMySQL bool) LabelRepository {
 	return &labelRepository{
 		db:          db,
+		metrics:     metrics,
 		useV2Prefix: useV2Prefix,
 		isMySQL:     isMySQL,
 	}
@@ -67,7 +71,9 @@ func (r *labelRepository) GetOrCreate(ctx context.Context, scientificName string
 		TaxonomicClassID: taxonomicClassID,
 	}
 
-	createErr := r.db.WithContext(ctx).Table(r.tableName()).Create(&label).Error
+	createErr := datastore.RetryOnLock("v2_create_label", func() error {
+		return r.db.WithContext(ctx).Table(r.tableName()).Create(&label).Error
+	}, r.metrics)
 	if createErr != nil {
 		// Handle race condition - try to fetch the existing record
 		findErr := r.db.WithContext(ctx).Table(r.tableName()).
@@ -217,9 +223,11 @@ func (r *labelRepository) BatchGetOrCreate(ctx context.Context, scientificNames 
 		}
 	}
 
-	if err := r.db.WithContext(ctx).Table(r.tableName()).
-		Clauses(clause.OnConflict{DoNothing: true}).
-		CreateInBatches(newLabels, batchQuerySize).Error; err != nil {
+	if err := datastore.RetryOnLock("v2_batch_create_labels", func() error {
+		return r.db.WithContext(ctx).Table(r.tableName()).
+			Clauses(clause.OnConflict{DoNothing: true}).
+			CreateInBatches(newLabels, batchQuerySize).Error
+	}, r.metrics); err != nil {
 		return nil, fmt.Errorf("batch create labels: %w", err)
 	}
 
@@ -295,11 +303,19 @@ func (r *labelRepository) GetAll(ctx context.Context) ([]*entities.Label, error)
 
 // Delete removes a label by ID.
 func (r *labelRepository) Delete(ctx context.Context, id uint) error {
-	result := r.db.WithContext(ctx).Table(r.tableName()).Delete(&entities.Label{}, id)
-	if result.Error != nil {
-		return result.Error
+	var rowsAffected int64
+	err := datastore.RetryOnLock("v2_delete_label", func() error {
+		result := r.db.WithContext(ctx).Table(r.tableName()).Delete(&entities.Label{}, id)
+		if result.Error != nil {
+			return result.Error
+		}
+		rowsAffected = result.RowsAffected
+		return nil
+	}, r.metrics)
+	if err != nil {
+		return err
 	}
-	if result.RowsAffected == 0 {
+	if rowsAffected == 0 {
 		return ErrLabelNotFound
 	}
 	return nil
@@ -365,13 +381,16 @@ func (r *labelRepository) GetByScientificNames(ctx context.Context, names []stri
 // labelTypeRepository implements LabelTypeRepository.
 type labelTypeRepository struct {
 	db          *gorm.DB
+	metrics     *datastore.Metrics
 	useV2Prefix bool
 }
 
 // NewLabelTypeRepository creates a new LabelTypeRepository.
-func NewLabelTypeRepository(db *gorm.DB, useV2Prefix bool) LabelTypeRepository {
+// metrics is optional (nil-safe) and enables retry observability.
+func NewLabelTypeRepository(db *gorm.DB, metrics *datastore.Metrics, useV2Prefix bool) LabelTypeRepository {
 	return &labelTypeRepository{
 		db:          db,
+		metrics:     metrics,
 		useV2Prefix: useV2Prefix,
 	}
 }
@@ -431,10 +450,12 @@ func (r *labelTypeRepository) GetOrCreate(ctx context.Context, name string) (*en
 	}
 
 	lt = entities.LabelType{Name: name}
-	if err := r.db.WithContext(ctx).Table(r.tableName()).Create(&lt).Error; err != nil {
+	if createErr := datastore.RetryOnLock("v2_create_label_type", func() error {
+		return r.db.WithContext(ctx).Table(r.tableName()).Create(&lt).Error
+	}, r.metrics); createErr != nil {
 		// Race condition - try to fetch again
 		if findErr := r.db.WithContext(ctx).Table(r.tableName()).Where("name = ?", name).First(&lt).Error; findErr != nil {
-			return nil, err
+			return nil, createErr
 		}
 	}
 	return &lt, nil
@@ -443,13 +464,16 @@ func (r *labelTypeRepository) GetOrCreate(ctx context.Context, name string) (*en
 // taxonomicClassRepository implements TaxonomicClassRepository.
 type taxonomicClassRepository struct {
 	db          *gorm.DB
+	metrics     *datastore.Metrics
 	useV2Prefix bool
 }
 
 // NewTaxonomicClassRepository creates a new TaxonomicClassRepository.
-func NewTaxonomicClassRepository(db *gorm.DB, useV2Prefix bool) TaxonomicClassRepository {
+// metrics is optional (nil-safe) and enables retry observability.
+func NewTaxonomicClassRepository(db *gorm.DB, metrics *datastore.Metrics, useV2Prefix bool) TaxonomicClassRepository {
 	return &taxonomicClassRepository{
 		db:          db,
+		metrics:     metrics,
 		useV2Prefix: useV2Prefix,
 	}
 }
@@ -509,10 +533,12 @@ func (r *taxonomicClassRepository) GetOrCreate(ctx context.Context, name string)
 	}
 
 	tc = entities.TaxonomicClass{Name: name}
-	if err := r.db.WithContext(ctx).Table(r.tableName()).Create(&tc).Error; err != nil {
+	if createErr := datastore.RetryOnLock("v2_create_taxonomic_class", func() error {
+		return r.db.WithContext(ctx).Table(r.tableName()).Create(&tc).Error
+	}, r.metrics); createErr != nil {
 		// Race condition - try to fetch again
 		if findErr := r.db.WithContext(ctx).Table(r.tableName()).Where("name = ?", name).First(&tc).Error; findErr != nil {
-			return nil, err
+			return nil, createErr
 		}
 	}
 	return &tc, nil

--- a/internal/datastore/v2/repository/model_impl.go
+++ b/internal/datastore/v2/repository/model_impl.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 
+	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/datastore/v2/entities"
 	"gorm.io/gorm"
 )
@@ -11,14 +12,17 @@ import (
 // modelRepository implements ModelRepository.
 type modelRepository struct {
 	db          *gorm.DB
+	metrics     *datastore.Metrics
 	useV2Prefix bool
 	isMySQL     bool
 }
 
 // NewModelRepository creates a new ModelRepository.
-func NewModelRepository(db *gorm.DB, useV2Prefix, isMySQL bool) ModelRepository {
+// metrics is optional (nil-safe) and enables retry observability.
+func NewModelRepository(db *gorm.DB, metrics *datastore.Metrics, useV2Prefix, isMySQL bool) ModelRepository {
 	return &modelRepository{
 		db:          db,
+		metrics:     metrics,
 		useV2Prefix: useV2Prefix,
 		isMySQL:     isMySQL,
 	}
@@ -64,7 +68,9 @@ func (r *modelRepository) GetOrCreate(ctx context.Context, name, version, varian
 		ClassifierPath: classifierPath,
 	}
 
-	createErr := r.db.WithContext(ctx).Table(r.tableName()).Create(&model).Error
+	createErr := datastore.RetryOnLock("v2_create_model", func() error {
+		return r.db.WithContext(ctx).Table(r.tableName()).Create(&model).Error
+	}, r.metrics)
 	if createErr != nil {
 		// Handle race condition
 		findErr := r.db.WithContext(ctx).Table(r.tableName()).
@@ -134,11 +140,19 @@ func (r *modelRepository) CountLabels(ctx context.Context, modelID uint) (int64,
 
 // Delete removes a model by ID.
 func (r *modelRepository) Delete(ctx context.Context, id uint) error {
-	result := r.db.WithContext(ctx).Table(r.tableName()).Delete(&entities.AIModel{}, id)
-	if result.Error != nil {
-		return result.Error
+	var rowsAffected int64
+	err := datastore.RetryOnLock("v2_delete_model", func() error {
+		result := r.db.WithContext(ctx).Table(r.tableName()).Delete(&entities.AIModel{}, id)
+		if result.Error != nil {
+			return result.Error
+		}
+		rowsAffected = result.RowsAffected
+		return nil
+	}, r.metrics)
+	if err != nil {
+		return err
 	}
-	if result.RowsAffected == 0 {
+	if rowsAffected == 0 {
 		return ErrModelNotFound
 	}
 	return nil

--- a/internal/datastore/v2/repository/notification_history_impl.go
+++ b/internal/datastore/v2/repository/notification_history_impl.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/datastore/v2/entities"
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"gorm.io/gorm"
@@ -13,6 +14,7 @@ import (
 // notificationHistoryRepository implements NotificationHistoryRepository.
 type notificationHistoryRepository struct {
 	db          *gorm.DB
+	metrics     *datastore.Metrics
 	labelRepo   LabelRepository
 	useV2Prefix bool
 	isMySQL     bool // For API consistency; currently unused here (used by detection_impl.go for dialect-specific SQL)
@@ -21,12 +23,14 @@ type notificationHistoryRepository struct {
 // NewNotificationHistoryRepository creates a new NotificationHistoryRepository.
 // Parameters:
 //   - db: GORM database connection
+//   - metrics: optional DatastoreMetrics for retry observability (nil-safe)
 //   - labelRepo: LabelRepository for resolving scientific names to label IDs
 //   - useV2Prefix: true to use v2_ table prefix (MySQL migration mode)
 //   - isMySQL: true for MySQL dialect (affects date/time SQL expressions)
-func NewNotificationHistoryRepository(db *gorm.DB, labelRepo LabelRepository, useV2Prefix, isMySQL bool) NotificationHistoryRepository {
+func NewNotificationHistoryRepository(db *gorm.DB, metrics *datastore.Metrics, labelRepo LabelRepository, useV2Prefix, isMySQL bool) NotificationHistoryRepository {
 	return &notificationHistoryRepository{
 		db:          db,
+		metrics:     metrics,
 		labelRepo:   labelRepo,
 		useV2Prefix: useV2Prefix,
 		isMySQL:     isMySQL,
@@ -55,12 +59,14 @@ func (r *notificationHistoryRepository) SaveNotificationHistory(ctx context.Cont
 	if history.LabelID == 0 {
 		return errors.NewStd("notification history LabelID must be set before saving")
 	}
-	return r.db.WithContext(ctx).Table(r.tableName()).
-		Clauses(clause.OnConflict{
-			Columns:   []clause.Column{{Name: "label_id"}, {Name: "notification_type"}},
-			UpdateAll: true,
-		}).
-		Create(history).Error
+	return datastore.RetryOnLock("v2_save_notification_history", func() error {
+		return r.db.WithContext(ctx).Table(r.tableName()).
+			Clauses(clause.OnConflict{
+				Columns:   []clause.Column{{Name: "label_id"}, {Name: "notification_type"}},
+				UpdateAll: true,
+			}).
+			Create(history).Error
+	}, r.metrics)
 }
 
 // GetNotificationHistory retrieves a notification history entry by scientific name.
@@ -106,8 +112,16 @@ func (r *notificationHistoryRepository) GetActiveNotificationHistory(ctx context
 
 // DeleteExpiredNotificationHistory deletes expired entries.
 func (r *notificationHistoryRepository) DeleteExpiredNotificationHistory(ctx context.Context, before time.Time) (int64, error) {
-	result := r.db.WithContext(ctx).Table(r.tableName()).
-		Where("expires_at < ?", before).
-		Delete(&entities.NotificationHistory{})
-	return result.RowsAffected, result.Error
+	var rowsAffected int64
+	err := datastore.RetryOnLock("v2_delete_expired_notification_history", func() error {
+		result := r.db.WithContext(ctx).Table(r.tableName()).
+			Where("expires_at < ?", before).
+			Delete(&entities.NotificationHistory{})
+		if result.Error != nil {
+			return result.Error
+		}
+		rowsAffected = result.RowsAffected
+		return nil
+	}, r.metrics)
+	return rowsAffected, err
 }

--- a/internal/datastore/v2/repository/weather_impl.go
+++ b/internal/datastore/v2/repository/weather_impl.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/datastore/v2/entities"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
@@ -13,6 +14,7 @@ import (
 // weatherRepository implements WeatherRepository.
 type weatherRepository struct {
 	db          *gorm.DB
+	metrics     *datastore.Metrics
 	useV2Prefix bool
 	isMySQL     bool // Dialect flag: true for MySQL (UNIX_TIMESTAMP), false for SQLite (strftime)
 }
@@ -20,11 +22,13 @@ type weatherRepository struct {
 // NewWeatherRepository creates a new WeatherRepository.
 // Parameters:
 //   - db: GORM database connection
+//   - metrics: optional DatastoreMetrics for retry observability (nil-safe)
 //   - useV2Prefix: true to use v2_ table prefix (MySQL migration mode)
 //   - isMySQL: true for MySQL dialect (affects date/time SQL expressions)
-func NewWeatherRepository(db *gorm.DB, useV2Prefix, isMySQL bool) WeatherRepository {
+func NewWeatherRepository(db *gorm.DB, metrics *datastore.Metrics, useV2Prefix, isMySQL bool) WeatherRepository {
 	return &weatherRepository{
 		db:          db,
+		metrics:     metrics,
 		useV2Prefix: useV2Prefix,
 		isMySQL:     isMySQL,
 	}
@@ -46,12 +50,14 @@ func (r *weatherRepository) hourlyWeatherTable() string {
 
 // SaveDailyEvents saves or updates daily events (upsert).
 func (r *weatherRepository) SaveDailyEvents(ctx context.Context, events *entities.DailyEvents) error {
-	return r.db.WithContext(ctx).Table(r.dailyEventsTable()).
-		Clauses(clause.OnConflict{
-			Columns:   []clause.Column{{Name: "date"}},
-			UpdateAll: true,
-		}).
-		Create(events).Error
+	return datastore.RetryOnLock("v2_save_daily_events", func() error {
+		return r.db.WithContext(ctx).Table(r.dailyEventsTable()).
+			Clauses(clause.OnConflict{
+				Columns:   []clause.Column{{Name: "date"}},
+				UpdateAll: true,
+			}).
+			Create(events).Error
+	}, r.metrics)
 }
 
 // GetDailyEvents retrieves daily events by date.
@@ -71,7 +77,9 @@ func (r *weatherRepository) GetDailyEvents(ctx context.Context, date string) (*e
 
 // SaveHourlyWeather saves hourly weather data.
 func (r *weatherRepository) SaveHourlyWeather(ctx context.Context, weather *entities.HourlyWeather) error {
-	return r.db.WithContext(ctx).Table(r.hourlyWeatherTable()).Create(weather).Error
+	return datastore.RetryOnLock("v2_save_hourly_weather", func() error {
+		return r.db.WithContext(ctx).Table(r.hourlyWeatherTable()).Create(weather).Error
+	}, r.metrics)
 }
 
 // GetHourlyWeather retrieves hourly weather for a date.
@@ -162,12 +170,14 @@ func (r *weatherRepository) SaveAllDailyEvents(ctx context.Context, events []ent
 		end := min(i+batchSize, len(events))
 		batch := events[i:end]
 
-		err := r.db.WithContext(ctx).Table(r.dailyEventsTable()).
-			Clauses(clause.OnConflict{
-				Columns:   []clause.Column{{Name: "date"}},
-				DoNothing: true,
-			}).
-			Create(&batch).Error
+		err := datastore.RetryOnLock("v2_save_all_daily_events", func() error {
+			return r.db.WithContext(ctx).Table(r.dailyEventsTable()).
+				Clauses(clause.OnConflict{
+					Columns:   []clause.Column{{Name: "date"}},
+					DoNothing: true,
+				}).
+				Create(&batch).Error
+		}, r.metrics)
 		if err != nil {
 			return saved, err
 		}
@@ -192,8 +202,10 @@ func (r *weatherRepository) SaveAllHourlyWeather(ctx context.Context, weather []
 		end := min(i+batchSize, len(weather))
 		batch := weather[i:end]
 
-		err := r.db.WithContext(ctx).Table(r.hourlyWeatherTable()).
-			Create(&batch).Error
+		err := datastore.RetryOnLock("v2_save_all_hourly_weather", func() error {
+			return r.db.WithContext(ctx).Table(r.hourlyWeatherTable()).
+				Create(&batch).Error
+		}, r.metrics)
 		if err != nil {
 			return saved, err
 		}

--- a/internal/datastore/v2only/datastore_test.go
+++ b/internal/datastore/v2only/datastore_test.go
@@ -40,9 +40,9 @@ func buildTestConfig(t *testing.T, labels []string) (cfg *Config, cleanup func()
 
 	// Create lookup table entries for tests
 	// The LabelType and TaxonomicClass tables should be created by Initialize()
-	labelTypeRepo := repository.NewLabelTypeRepository(db, false)
-	taxClassRepo := repository.NewTaxonomicClassRepository(db, false)
-	modelRepo := repository.NewModelRepository(db, false, false)
+	labelTypeRepo := repository.NewLabelTypeRepository(db, nil, false)
+	taxClassRepo := repository.NewTaxonomicClassRepository(db, nil, false)
+	modelRepo := repository.NewModelRepository(db, nil, false, false)
 
 	ctx := t.Context()
 
@@ -61,13 +61,13 @@ func buildTestConfig(t *testing.T, labels []string) (cfg *Config, cleanup func()
 	avesClassID := avesClass.ID
 
 	// Create repositories (useV2Prefix = false for SQLite, isMySQL = false)
-	detectionRepo := repository.NewDetectionRepository(db, false, false)
-	labelRepo := repository.NewLabelRepository(db, false, false)
-	sourceRepo := repository.NewAudioSourceRepository(db, false, false)
-	weatherRepo := repository.NewWeatherRepository(db, false, false)
-	imageCacheRepo := repository.NewImageCacheRepository(db, labelRepo, false, false)
-	thresholdRepo := repository.NewDynamicThresholdRepository(db, labelRepo, false, false)
-	notificationRepo := repository.NewNotificationHistoryRepository(db, labelRepo, false, false)
+	detectionRepo := repository.NewDetectionRepository(db, nil, false, false)
+	labelRepo := repository.NewLabelRepository(db, nil, false, false)
+	sourceRepo := repository.NewAudioSourceRepository(db, nil, false, false)
+	weatherRepo := repository.NewWeatherRepository(db, nil, false, false)
+	imageCacheRepo := repository.NewImageCacheRepository(db, nil, labelRepo, false, false)
+	thresholdRepo := repository.NewDynamicThresholdRepository(db, nil, labelRepo, false, false)
+	notificationRepo := repository.NewNotificationHistoryRepository(db, nil, labelRepo, false, false)
 
 	cfg = &Config{
 		Manager:            manager,

--- a/internal/datastore/v2only/fresh_install.go
+++ b/internal/datastore/v2only/fresh_install.go
@@ -89,16 +89,16 @@ func InitializeFreshInstall(settings *conf.Settings, log logger.Logger, speciesC
 	db := manager.DB()
 	useV2Prefix := false         // Fresh installs use clean table names
 	isMySQL := manager.IsMySQL() // Derive dialect from actual manager, not settings
-	detectionRepo := repository.NewDetectionRepository(db, useV2Prefix, isMySQL)
-	labelRepo := repository.NewLabelRepository(db, useV2Prefix, isMySQL)
-	modelRepo := repository.NewModelRepository(db, useV2Prefix, isMySQL)
-	sourceRepo := repository.NewAudioSourceRepository(db, useV2Prefix, isMySQL)
-	weatherRepo := repository.NewWeatherRepository(db, useV2Prefix, isMySQL)
-	imageCacheRepo := repository.NewImageCacheRepository(db, labelRepo, useV2Prefix, isMySQL)
-	thresholdRepo := repository.NewDynamicThresholdRepository(db, labelRepo, useV2Prefix, isMySQL)
-	notificationRepo := repository.NewNotificationHistoryRepository(db, labelRepo, useV2Prefix, isMySQL)
-	labelTypeRepo := repository.NewLabelTypeRepository(db, useV2Prefix)
-	taxClassRepo := repository.NewTaxonomicClassRepository(db, useV2Prefix)
+	detectionRepo := repository.NewDetectionRepository(db, nil, useV2Prefix, isMySQL)
+	labelRepo := repository.NewLabelRepository(db, nil, useV2Prefix, isMySQL)
+	modelRepo := repository.NewModelRepository(db, nil, useV2Prefix, isMySQL)
+	sourceRepo := repository.NewAudioSourceRepository(db, nil, useV2Prefix, isMySQL)
+	weatherRepo := repository.NewWeatherRepository(db, nil, useV2Prefix, isMySQL)
+	imageCacheRepo := repository.NewImageCacheRepository(db, nil, labelRepo, useV2Prefix, isMySQL)
+	thresholdRepo := repository.NewDynamicThresholdRepository(db, nil, labelRepo, useV2Prefix, isMySQL)
+	notificationRepo := repository.NewNotificationHistoryRepository(db, nil, labelRepo, useV2Prefix, isMySQL)
+	labelTypeRepo := repository.NewLabelTypeRepository(db, nil, useV2Prefix)
+	taxClassRepo := repository.NewTaxonomicClassRepository(db, nil, useV2Prefix)
 
 	// Get or create required lookup table entries and cache their IDs
 	ctx := context.Background()

--- a/internal/datastore/write_contention_test.go
+++ b/internal/datastore/write_contention_test.go
@@ -1,0 +1,520 @@
+// write_contention_test.go: Integration tests for concurrent SQLite write contention.
+//
+// These tests verify that the retry logic and connection pool configuration
+// (MaxOpenConns=1, DSN pragmas) prevent silent data loss under concurrent
+// write pressure. The original problem (silent data loss from unretried lock
+// errors) was only caught in production.
+//
+// All tests use real SQLite databases (not mocks) to exercise actual
+// concurrency behavior.
+package datastore
+
+import (
+	"database/sql"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	gormlogger "gorm.io/gorm/logger"
+)
+
+// TestConcurrentSaveDailyEvents spawns N goroutines all calling SaveDailyEvents
+// with different dates simultaneously against a real SQLite database. Verifies
+// all records are persisted (no silent drops).
+func TestConcurrentSaveDailyEvents(t *testing.T) {
+	t.Parallel()
+
+	settings := createTestSettings(t)
+	ds := createDatabase(t, settings)
+
+	const numGoroutines = 20
+	errs := make(chan error, numGoroutines)
+	var wg sync.WaitGroup
+
+	for i := range numGoroutines {
+		wg.Go(func() {
+			event := &DailyEvents{
+				Date:             fmt.Sprintf("2024-01-%02d", i+1),
+				Sunrise:          int64(6*3600 + i*60),
+				Sunset:           int64(18*3600 + i*60),
+				Country:          "FI",
+				CityName:         fmt.Sprintf("City-%d", i),
+				MoonPhase:        float64(i) * 0.5,
+				MoonIllumination: float64(i) * 5.0,
+			}
+
+			if err := ds.SaveDailyEvents(event); err != nil {
+				errs <- fmt.Errorf("goroutine %d: %w", i, err)
+			}
+		})
+	}
+
+	wg.Wait()
+	close(errs)
+
+	// Collect and check errors
+	allErrors := make([]error, 0, numGoroutines)
+	for err := range errs {
+		allErrors = append(allErrors, err)
+	}
+	require.Empty(t, allErrors, "concurrent SaveDailyEvents should not fail: %v", allErrors)
+
+	// Verify all records were persisted
+	sqliteStore, ok := ds.(*SQLiteStore)
+	require.True(t, ok)
+
+	var count int64
+	err := sqliteStore.DB.Model(&DailyEvents{}).Count(&count).Error
+	require.NoError(t, err)
+	assert.Equal(t, int64(numGoroutines), count,
+		"all %d DailyEvents should be persisted, got %d (silent data loss?)", numGoroutines, count)
+
+	// Verify each date is present
+	for i := range numGoroutines {
+		date := fmt.Sprintf("2024-01-%02d", i+1)
+		events, err := ds.GetDailyEvents(date)
+		require.NoError(t, err, "GetDailyEvents(%s) failed", date)
+		assert.Equal(t, date, events.Date, "date mismatch for record %d", i)
+		assert.Equal(t, fmt.Sprintf("City-%d", i), events.CityName,
+			"CityName mismatch for record %d — wrong record persisted?", i)
+	}
+}
+
+// TestConcurrentMixedWrites combines SaveDailyEvents, SaveHourlyWeather,
+// SaveImageCache, and Save calls in parallel to simulate realistic production
+// load where different write paths compete for the database.
+func TestConcurrentMixedWrites(t *testing.T) {
+	t.Parallel()
+
+	settings := createTestSettings(t)
+	ds := createDatabase(t, settings)
+
+	const numPerType = 10
+	totalOps := numPerType * 4
+	errs := make(chan error, totalOps)
+	var wg sync.WaitGroup
+
+	// SaveDailyEvents goroutines
+	for i := range numPerType {
+		wg.Go(func() {
+			event := &DailyEvents{
+				Date:     fmt.Sprintf("2024-02-%02d", i+1),
+				Sunrise:  int64(6*3600 + i*60),
+				Sunset:   int64(18*3600 + i*60),
+				Country:  "FI",
+				CityName: fmt.Sprintf("Helsinki-%d", i),
+			}
+			if err := ds.SaveDailyEvents(event); err != nil {
+				errs <- fmt.Errorf("SaveDailyEvents goroutine %d: %w", i, err)
+			}
+		})
+	}
+
+	// SaveHourlyWeather goroutines
+	for i := range numPerType {
+		wg.Go(func() {
+			weather := &HourlyWeather{
+				Time:        time.Date(2024, 2, 1, i, 0, 0, 0, time.UTC),
+				Temperature: 20.0 + float64(i),
+				Humidity:    50 + i,
+				Pressure:    1013,
+				WindSpeed:   5.0,
+				WeatherMain: "Clear",
+			}
+			if err := ds.SaveHourlyWeather(weather); err != nil {
+				errs <- fmt.Errorf("SaveHourlyWeather goroutine %d: %w", i, err)
+			}
+		})
+	}
+
+	// SaveImageCache goroutines
+	for i := range numPerType {
+		wg.Go(func() {
+			cache := &ImageCache{
+				ProviderName:   "wikimedia",
+				ScientificName: fmt.Sprintf("Species testus %d", i),
+				URL:            fmt.Sprintf("https://example.com/bird_%d.jpg", i),
+				LicenseName:    "CC BY-SA 4.0",
+				AuthorName:     fmt.Sprintf("Author %d", i),
+				CachedAt:       time.Now(),
+			}
+			if err := ds.SaveImageCache(cache); err != nil {
+				errs <- fmt.Errorf("SaveImageCache goroutine %d: %w", i, err)
+			}
+		})
+	}
+
+	// Save (detection) goroutines
+	for i := range numPerType {
+		wg.Go(func() {
+			note := Note{
+				SourceNode:     fmt.Sprintf("node-%d", i),
+				Date:           "2024-02-15",
+				Time:           fmt.Sprintf("10:%02d:00", i),
+				ScientificName: fmt.Sprintf("Testus species%d", i),
+				CommonName:     fmt.Sprintf("Test Bird %d", i),
+				Confidence:     0.90,
+				ClipName:       fmt.Sprintf("clip_%03d.wav", i),
+			}
+			results := []Results{
+				{Species: fmt.Sprintf("Testus species%d_Test Bird %d", i, i), Confidence: 0.90},
+			}
+			if err := ds.Save(&note, results); err != nil {
+				errs <- fmt.Errorf("Save goroutine %d: %w", i, err)
+			}
+		})
+	}
+
+	wg.Wait()
+	close(errs)
+
+	// Collect and check errors
+	allErrors := make([]error, 0, totalOps)
+	for err := range errs {
+		allErrors = append(allErrors, err)
+	}
+	require.Empty(t, allErrors, "concurrent mixed writes should not fail: %v", allErrors)
+
+	// Verify record counts
+	sqliteStore, ok := ds.(*SQLiteStore)
+	require.True(t, ok)
+
+	var dailyCount int64
+	require.NoError(t, sqliteStore.DB.Model(&DailyEvents{}).Count(&dailyCount).Error)
+	assert.Equal(t, int64(numPerType), dailyCount, "DailyEvents count mismatch")
+
+	var weatherCount int64
+	require.NoError(t, sqliteStore.DB.Model(&HourlyWeather{}).Count(&weatherCount).Error)
+	assert.Equal(t, int64(numPerType), weatherCount, "HourlyWeather count mismatch")
+
+	var cacheCount int64
+	require.NoError(t, sqliteStore.DB.Model(&ImageCache{}).Count(&cacheCount).Error)
+	assert.Equal(t, int64(numPerType), cacheCount, "ImageCache count mismatch")
+
+	var noteCount int64
+	require.NoError(t, sqliteStore.DB.Model(&Note{}).Count(&noteCount).Error)
+	assert.Equal(t, int64(numPerType), noteCount, "Note count mismatch")
+
+	// Verify Results rows were also persisted (each Save call included 1 Result)
+	var resultsCount int64
+	require.NoError(t, sqliteStore.DB.Model(&Results{}).Count(&resultsCount).Error)
+	assert.Equal(t, int64(numPerType), resultsCount, "Results count mismatch — Save() dropped Results?")
+}
+
+// TestMaxOpenConnsEffectiveness validates that SetMaxOpenConns(1) prevents
+// database lock errors. Opens a database with MaxOpenConns > 1 and runs
+// concurrent writes to demonstrate lock errors can occur, then opens another
+// with MaxOpenConns = 1 (the production setting) and verifies no lock errors.
+func TestMaxOpenConnsEffectiveness(t *testing.T) {
+	t.Parallel()
+
+	const numGoroutines = 20
+
+	// --- Phase 1: MaxOpenConns > 1 should produce lock contention ---
+	// We open a raw GORM connection with MaxOpenConns=10 and no busy_timeout
+	// to maximize the chance of immediate lock errors.
+	unboundedDB := openRawSQLiteDB(t, "unbounded",
+		"_journal_mode=WAL&_busy_timeout=0&_foreign_keys=ON")
+	setMaxOpenConns(t, unboundedDB, numGoroutines)
+
+	require.NoError(t, unboundedDB.AutoMigrate(&DailyEvents{}))
+
+	unboundedErrs := make(chan error, numGoroutines)
+	var wgUnbounded sync.WaitGroup
+
+	for i := range numGoroutines {
+		wgUnbounded.Go(func() {
+			event := DailyEvents{
+				Date:     fmt.Sprintf("2024-03-%02d", i+1),
+				Sunrise:  int64(6*3600 + i*60),
+				Sunset:   int64(18*3600 + i*60),
+				CityName: fmt.Sprintf("Unbounded-%d", i),
+			}
+			// Direct GORM write, bypassing retry logic to expose raw lock errors
+			if err := unboundedDB.Create(&event).Error; err != nil {
+				unboundedErrs <- err
+			}
+		})
+	}
+	wgUnbounded.Wait()
+	close(unboundedErrs)
+
+	unboundedLockErrors := 0
+	for err := range unboundedErrs {
+		if isDatabaseLocked(err) {
+			unboundedLockErrors++
+		}
+	}
+	// We expect at least some lock errors with multiple connections and no busy_timeout.
+	// This is probabilistic — if it doesn't trigger, the test still passes but
+	// logs a note. The important assertion is in phase 2.
+	t.Logf("Phase 1 (MaxOpenConns=%d, busy_timeout=0): %d lock errors out of %d writes",
+		numGoroutines, unboundedLockErrors, numGoroutines)
+
+	// --- Phase 2: MaxOpenConns=1 (production config) should have zero errors ---
+	settings := createTestSettings(t)
+	ds := createDatabase(t, settings) // Uses MaxOpenConns(1) + busy_timeout=30s
+
+	serializedErrs := make(chan error, numGoroutines)
+	var wgSerialized sync.WaitGroup
+
+	for i := range numGoroutines {
+		wgSerialized.Go(func() {
+			event := &DailyEvents{
+				Date:     fmt.Sprintf("2024-04-%02d", i+1),
+				Sunrise:  int64(6*3600 + i*60),
+				Sunset:   int64(18*3600 + i*60),
+				CityName: fmt.Sprintf("Serialized-%d", i),
+			}
+			if err := ds.SaveDailyEvents(event); err != nil {
+				serializedErrs <- err
+			}
+		})
+	}
+	wgSerialized.Wait()
+	close(serializedErrs)
+
+	allErrors := make([]error, 0, numGoroutines)
+	for err := range serializedErrs {
+		allErrors = append(allErrors, err)
+	}
+	require.Empty(t, allErrors,
+		"MaxOpenConns=1 should prevent all lock errors, got %d: %v", len(allErrors), allErrors)
+
+	// Verify all records persisted
+	sqliteStore, ok := ds.(*SQLiteStore)
+	require.True(t, ok)
+
+	var count int64
+	require.NoError(t, sqliteStore.DB.Model(&DailyEvents{}).Count(&count).Error)
+	assert.Equal(t, int64(numGoroutines), count,
+		"all %d records should persist with MaxOpenConns=1", numGoroutines)
+}
+
+// TestRetryExhaustion verifies that when lock contention exceeds the retry
+// budget, the error is surfaced (not swallowed). Uses RetryOnLock directly
+// with a function that always returns a lock error.
+func TestRetryExhaustion(t *testing.T) {
+	t.Parallel()
+
+	callCount := 0
+	lockErr := fmt.Errorf("database is locked")
+
+	err := RetryOnLock("test_exhaustion", func() error {
+		callCount++
+		return lockErr
+	}, nil)
+
+	require.Error(t, err, "RetryOnLock should return an error after exhausting retries")
+	assert.Contains(t, err.Error(), "database is locked",
+		"the returned error should be the original lock error")
+	assert.Equal(t, retryMaxAttempts, callCount,
+		"RetryOnLock should have attempted exactly %d times", retryMaxAttempts)
+}
+
+// TestRetryExhaustion_NonTransientBailsImmediately verifies that non-transient
+// errors (e.g., constraint violations) are not retried.
+func TestRetryExhaustion_NonTransientBailsImmediately(t *testing.T) {
+	t.Parallel()
+
+	callCount := 0
+	constraintErr := fmt.Errorf("UNIQUE constraint failed: daily_events.date")
+
+	err := RetryOnLock("test_non_transient", func() error {
+		callCount++
+		return constraintErr
+	}, nil)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "UNIQUE constraint failed")
+	assert.Equal(t, 1, callCount,
+		"non-transient errors should bail after exactly 1 attempt, got %d", callCount)
+}
+
+// TestRetryExhaustion_IntegrationWithRealDB creates real lock contention by
+// holding a write transaction open while another goroutine tries to write,
+// verifying the error surfaces after retries are exhausted.
+func TestRetryExhaustion_IntegrationWithRealDB(t *testing.T) {
+	t.Parallel()
+
+	// Open a database with multiple connections and no busy_timeout
+	// so lock errors happen immediately without waiting.
+	db := openRawSQLiteDB(t, "retry_exhaust", "_journal_mode=WAL&_busy_timeout=0&_foreign_keys=ON")
+	setMaxOpenConns(t, db, 2)
+	require.NoError(t, db.AutoMigrate(&DailyEvents{}))
+
+	ds := &DataStore{DB: db}
+
+	// Hold a write transaction open to block other writers
+	tx := db.Begin()
+	require.NoError(t, tx.Error)
+	t.Cleanup(func() {
+		// Rollback is a no-op after Commit, but ensures cleanup if the
+		// test fails before reaching the explicit Commit call below.
+		_ = tx.Rollback().Error
+	})
+	require.NoError(t, tx.Create(&DailyEvents{
+		Date:     "2024-05-01",
+		CityName: "Blocker",
+	}).Error)
+	// Don't commit yet — keep the transaction open to hold the write lock
+
+	// Try to write from a different goroutine using RetryOnLock.
+	// With busy_timeout=0 and the lock held, every attempt should fail.
+	done := make(chan error, 1)
+	go func() {
+		event := &DailyEvents{
+			Date:     "2024-05-02",
+			CityName: "Blocked",
+		}
+		done <- RetryOnLock("blocked_write", func() error {
+			return ds.DB.Create(event).Error
+		}, nil)
+	}()
+
+	// Wait for retries to exhaust (with busy_timeout=0, each attempt fails
+	// immediately, so retries complete quickly)
+	err := <-done
+	require.Error(t, err, "write should fail when lock is held and retries exhaust")
+	assert.True(t, isDatabaseLocked(err),
+		"error should be a database lock error, got: %v", err)
+
+	// Clean up: commit the blocking transaction
+	require.NoError(t, tx.Commit().Error)
+}
+
+// TestDSNPragmaVerification opens a SQLite database with the production DSN
+// parameters and verifies that PRAGMA journal_mode and PRAGMA busy_timeout
+// report the expected values (WAL and 30000ms) from the connection pool.
+func TestDSNPragmaVerification(t *testing.T) {
+	t.Parallel()
+
+	settings := createTestSettings(t)
+	ds := createDatabase(t, settings)
+
+	sqliteStore, ok := ds.(*SQLiteStore)
+	require.True(t, ok)
+
+	sqlDB, err := sqliteStore.DB.DB()
+	require.NoError(t, err)
+
+	// Verify journal_mode is WAL
+	var journalMode string
+	err = sqlDB.QueryRow("PRAGMA journal_mode").Scan(&journalMode)
+	require.NoError(t, err)
+	assert.Equal(t, "wal", journalMode,
+		"journal_mode should be WAL, got %q", journalMode)
+
+	// Verify busy_timeout is 30000ms
+	var busyTimeout int
+	err = sqlDB.QueryRow("PRAGMA busy_timeout").Scan(&busyTimeout)
+	require.NoError(t, err)
+	assert.Equal(t, 30000, busyTimeout,
+		"busy_timeout should be 30000ms, got %d", busyTimeout)
+}
+
+// TestDSNPragmaVerification_AllPoolConnections verifies that DSN-embedded
+// pragmas apply to ALL connections in the pool, not just the first one.
+// This was the root cause of the original bug: pragmas set via Exec() only
+// applied to one connection, leaving new pool connections at SQLite defaults.
+//
+// Uses a barrier pattern: acquires and holds exactly MaxOpenConns connections
+// simultaneously, then verifies pragmas on all of them before releasing.
+func TestDSNPragmaVerification_AllPoolConnections(t *testing.T) {
+	t.Parallel()
+
+	const maxConns = 5
+
+	// Open with multiple pool connections to test pragma propagation
+	db := openRawSQLiteDB(t, "pragma_pool",
+		"_journal_mode=WAL&_busy_timeout=30000&_foreign_keys=ON&_synchronous=NORMAL&_cache_size=-4000")
+	setMaxOpenConns(t, db, maxConns)
+
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+
+	// Acquire and hold all MaxOpenConns connections simultaneously.
+	// This guarantees we test every distinct pool connection, not just
+	// reuse the same one. If pragmas were set via Exec() instead of DSN,
+	// some connections would report SQLite defaults.
+	type pragmaResult struct {
+		journalMode string
+		busyTimeout int
+	}
+
+	conns := make([]*sql.Conn, maxConns)
+	results := make([]pragmaResult, maxConns)
+
+	// Phase 1: Acquire all connections (barrier — hold them all open)
+	for i := range maxConns {
+		conn, connErr := sqlDB.Conn(t.Context())
+		require.NoError(t, connErr, "failed to acquire pool connection %d", i)
+		conns[i] = conn
+	}
+
+	// Phase 2: Query pragmas on all held connections
+	for i, conn := range conns {
+		var jm string
+		err := conn.QueryRowContext(t.Context(), "PRAGMA journal_mode").Scan(&jm)
+		require.NoError(t, err, "PRAGMA journal_mode failed on connection %d", i)
+
+		var bt int
+		err = conn.QueryRowContext(t.Context(), "PRAGMA busy_timeout").Scan(&bt)
+		require.NoError(t, err, "PRAGMA busy_timeout failed on connection %d", i)
+
+		results[i] = pragmaResult{journalMode: jm, busyTimeout: bt}
+	}
+
+	// Phase 3: Release all connections
+	for i, conn := range conns {
+		require.NoError(t, conn.Close(), "failed to close connection %d", i)
+	}
+
+	// Verify all connections reported correct pragmas
+	for i, pr := range results {
+		assert.Equal(t, "wal", pr.journalMode,
+			"pool connection %d should have journal_mode=WAL", i)
+		assert.Equal(t, 30000, pr.busyTimeout,
+			"pool connection %d should have busy_timeout=30000", i)
+	}
+}
+
+// --- Test helpers ---
+
+// openRawSQLiteDB opens a temporary SQLite database with GORM using the given
+// pragma string. Returns the GORM DB instance. The database file is created
+// in t.TempDir() and cleaned up automatically.
+func openRawSQLiteDB(t *testing.T, name, pragmas string) *gorm.DB {
+	t.Helper()
+
+	dbPath := fmt.Sprintf("%s/%s.db", t.TempDir(), name)
+	dsn := buildSQLiteDSN(dbPath, pragmas)
+
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{
+		Logger: gormlogger.Default.LogMode(gormlogger.Silent),
+	})
+	require.NoError(t, err, "failed to open SQLite database %s", name)
+
+	t.Cleanup(func() {
+		sqlDB, err := db.DB()
+		if err == nil {
+			_ = sqlDB.Close()
+		}
+	})
+
+	return db
+}
+
+// setMaxOpenConns sets the maximum number of open connections on a GORM DB.
+func setMaxOpenConns(t *testing.T, db *gorm.DB, n int) {
+	t.Helper()
+
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	sqlDB.SetMaxOpenConns(n)
+}

--- a/internal/diskmanager/policy_common.go
+++ b/internal/diskmanager/policy_common.go
@@ -25,6 +25,10 @@ const maxDeletionsPerRun = 1000
 // configKeyRetentionMaxUsage is the config key for the retention max usage percentage setting
 const configKeyRetentionMaxUsage = "retention.max_usage"
 
+// defaultMaxUsagePercent is the fallback when the user's config has an empty MaxUsage value.
+// Matches the viper default in conf/defaults.go.
+const defaultMaxUsagePercent = "80%"
+
 // Package-level metrics with explicit synchronization
 var (
 	// Thread-safe diskMetrics with explicit synchronization
@@ -399,8 +403,14 @@ func categorizeFilePath(path string) string {
 //   - utilization: current disk usage as integer percentage
 //   - err: error if check failed (nil on success)
 func ShouldSkipUsageBasedCleanup(retention *conf.RetentionSettings, baseDir string) (skip bool, utilization int, err error) {
+	// Apply default if the config value is empty (e.g. user cleared the field via the UI).
+	maxUsage := strings.TrimSpace(retention.MaxUsage)
+	if maxUsage == "" {
+		maxUsage = defaultMaxUsagePercent
+	}
+
 	// Parse the threshold percentage
-	usageThresholdFloat, parseErr := conf.ParsePercentage(retention.MaxUsage, configKeyRetentionMaxUsage)
+	usageThresholdFloat, parseErr := conf.ParsePercentage(maxUsage, configKeyRetentionMaxUsage)
 	if parseErr != nil {
 		return false, 0, parseErr
 	}

--- a/internal/diskmanager/policy_usage.go
+++ b/internal/diskmanager/policy_usage.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/tphakala/birdnet-go/internal/conf"
@@ -47,7 +48,12 @@ func UsageBasedCleanup(quit <-chan struct{}, db Interface) CleanupResult {
 	startTime := time.Now() // Track cleanup duration
 	keepSpectrograms := retention.KeepSpectrograms
 	minClipsPerSpecies := retention.MinClips
-	usageThresholdSetting := retention.MaxUsage
+
+	// Apply default if the config value is empty (e.g. user cleared the field via the UI).
+	usageThresholdSetting := strings.TrimSpace(retention.MaxUsage)
+	if usageThresholdSetting == "" {
+		usageThresholdSetting = defaultMaxUsagePercent
+	}
 
 	// Convert usage threshold string (e.g., "80%") to float64
 	// This determines at what disk usage percentage the cleanup should activate

--- a/internal/logger/central_logger.go
+++ b/internal/logger/central_logger.go
@@ -477,12 +477,21 @@ type moduleLogger struct {
 	fields   []Field
 }
 
+// isValid reports whether the moduleLogger is properly initialized with a
+// non-nil inner slog.Logger.  It is safe to call on a nil receiver.
+func (m *moduleLogger) isValid() bool {
+	return m != nil && m.logger != nil
+}
+
 // Module creates a sub-module logger.
 // The returned logger shares the parent's slog.Logger but gets its own copy of fields
 // to ensure immutability - modifications to parent fields won't affect children.
 func (m *moduleLogger) Module(name string) Logger {
 	if m == nil {
 		return nil
+	}
+	if !m.isValid() {
+		return m
 	}
 
 	return &moduleLogger{
@@ -496,7 +505,7 @@ func (m *moduleLogger) Module(name string) Logger {
 
 // Trace logs a trace message (most verbose level)
 func (m *moduleLogger) Trace(msg string, fields ...Field) {
-	if m == nil || m.level > traceLevelValue {
+	if !m.isValid() || m.level > traceLevelValue {
 		return
 	}
 	m.log(traceLevelValue, msg, fields...)
@@ -504,7 +513,7 @@ func (m *moduleLogger) Trace(msg string, fields ...Field) {
 
 // Debug logs a debug message
 func (m *moduleLogger) Debug(msg string, fields ...Field) {
-	if m == nil || m.level > slog.LevelDebug {
+	if !m.isValid() || m.level > slog.LevelDebug {
 		return
 	}
 	m.log(slog.LevelDebug, msg, fields...)
@@ -512,7 +521,7 @@ func (m *moduleLogger) Debug(msg string, fields ...Field) {
 
 // Info logs an info message
 func (m *moduleLogger) Info(msg string, fields ...Field) {
-	if m == nil || m.level > slog.LevelInfo {
+	if !m.isValid() || m.level > slog.LevelInfo {
 		return
 	}
 	m.log(slog.LevelInfo, msg, fields...)
@@ -520,7 +529,7 @@ func (m *moduleLogger) Info(msg string, fields ...Field) {
 
 // Warn logs a warning message
 func (m *moduleLogger) Warn(msg string, fields ...Field) {
-	if m == nil || m.level > slog.LevelWarn {
+	if !m.isValid() || m.level > slog.LevelWarn {
 		return
 	}
 	m.log(slog.LevelWarn, msg, fields...)
@@ -528,7 +537,7 @@ func (m *moduleLogger) Warn(msg string, fields ...Field) {
 
 // Error logs an error message
 func (m *moduleLogger) Error(msg string, fields ...Field) {
-	if m == nil {
+	if !m.isValid() {
 		return
 	}
 	m.log(slog.LevelError, msg, fields...)
@@ -536,7 +545,7 @@ func (m *moduleLogger) Error(msg string, fields ...Field) {
 
 // Log logs a message with explicit level
 func (m *moduleLogger) Log(level LogLevel, msg string, fields ...Field) {
-	if m == nil {
+	if !m.isValid() {
 		return
 	}
 	m.log(parseSlogLevel(level), msg, fields...)
@@ -546,6 +555,9 @@ func (m *moduleLogger) Log(level LogLevel, msg string, fields ...Field) {
 func (m *moduleLogger) With(fields ...Field) Logger {
 	if m == nil {
 		return nil
+	}
+	if !m.isValid() {
+		return m
 	}
 
 	return &moduleLogger{
@@ -561,6 +573,9 @@ func (m *moduleLogger) With(fields ...Field) Logger {
 func (m *moduleLogger) WithContext(ctx context.Context) Logger {
 	if m == nil {
 		return nil
+	}
+	if !m.isValid() {
+		return m
 	}
 
 	if ctx == nil {
@@ -585,7 +600,7 @@ func (m *moduleLogger) Flush() error {
 
 // log is the internal logging method
 func (m *moduleLogger) log(level slog.Level, msg string, fields ...Field) {
-	if m == nil {
+	if !m.isValid() {
 		return
 	}
 

--- a/internal/logger/slog_logger.go
+++ b/internal/logger/slog_logger.go
@@ -29,6 +29,12 @@ type SlogLogger struct {
 	mu         sync.RWMutex // protects logWriter and slogLogger
 }
 
+// isValid reports whether the SlogLogger is properly initialized with a
+// non-nil inner slog.Logger.  It is safe to call on a nil receiver.
+func (l *SlogLogger) isValid() bool {
+	return l != nil && l.slogLogger != nil
+}
+
 // NewSlogLogger creates a new slog-based logger with JSON output
 func NewSlogLogger(writer io.Writer, level LogLevel, timezone *time.Location) *SlogLogger {
 	if writer == nil {
@@ -143,6 +149,9 @@ func (l *SlogLogger) Module(name string) Logger {
 	if l == nil {
 		return nil
 	}
+	if !l.isValid() {
+		return l
+	}
 
 	moduleName := name
 	if l.module != "" {
@@ -163,10 +172,7 @@ func (l *SlogLogger) Module(name string) Logger {
 
 // Trace logs a trace message (most verbose level)
 func (l *SlogLogger) Trace(msg string, fields ...Field) {
-	if l == nil {
-		return
-	}
-	if l.level > traceLevelValue {
+	if !l.isValid() || l.level > traceLevelValue {
 		return
 	}
 	l.log(traceLevelValue, msg, fields...)
@@ -174,10 +180,7 @@ func (l *SlogLogger) Trace(msg string, fields ...Field) {
 
 // Debug logs a debug message
 func (l *SlogLogger) Debug(msg string, fields ...Field) {
-	if l == nil {
-		return
-	}
-	if l.level > slog.LevelDebug {
+	if !l.isValid() || l.level > slog.LevelDebug {
 		return
 	}
 	l.log(slog.LevelDebug, msg, fields...)
@@ -185,10 +188,7 @@ func (l *SlogLogger) Debug(msg string, fields ...Field) {
 
 // Info logs an info message
 func (l *SlogLogger) Info(msg string, fields ...Field) {
-	if l == nil {
-		return
-	}
-	if l.level > slog.LevelInfo {
+	if !l.isValid() || l.level > slog.LevelInfo {
 		return
 	}
 	l.log(slog.LevelInfo, msg, fields...)
@@ -196,10 +196,7 @@ func (l *SlogLogger) Info(msg string, fields ...Field) {
 
 // Warn logs a warning message
 func (l *SlogLogger) Warn(msg string, fields ...Field) {
-	if l == nil {
-		return
-	}
-	if l.level > slog.LevelWarn {
+	if !l.isValid() || l.level > slog.LevelWarn {
 		return
 	}
 	l.log(slog.LevelWarn, msg, fields...)
@@ -207,7 +204,7 @@ func (l *SlogLogger) Warn(msg string, fields ...Field) {
 
 // Error logs an error message
 func (l *SlogLogger) Error(msg string, fields ...Field) {
-	if l == nil {
+	if !l.isValid() {
 		return
 	}
 	l.log(slog.LevelError, msg, fields...)
@@ -215,7 +212,7 @@ func (l *SlogLogger) Error(msg string, fields ...Field) {
 
 // Log logs a message with explicit level
 func (l *SlogLogger) Log(level LogLevel, msg string, fields ...Field) {
-	if l == nil {
+	if !l.isValid() {
 		return
 	}
 	l.log(parseSlogLevel(level), msg, fields...)
@@ -225,6 +222,9 @@ func (l *SlogLogger) Log(level LogLevel, msg string, fields ...Field) {
 func (l *SlogLogger) With(fields ...Field) Logger {
 	if l == nil {
 		return nil
+	}
+	if !l.isValid() {
+		return l
 	}
 
 	return &SlogLogger{
@@ -243,6 +243,9 @@ func (l *SlogLogger) With(fields ...Field) Logger {
 func (l *SlogLogger) WithContext(ctx context.Context) Logger {
 	if l == nil {
 		return nil
+	}
+	if !l.isValid() {
+		return l
 	}
 	if ctx == nil {
 		return l
@@ -298,7 +301,7 @@ func (l *SlogLogger) Close() error {
 
 // log is the internal logging method
 func (l *SlogLogger) log(level slog.Level, msg string, fields ...Field) {
-	if l == nil {
+	if !l.isValid() {
 		return
 	}
 

--- a/internal/observability/metrics/datastore.go
+++ b/internal/observability/metrics/datastore.go
@@ -65,9 +65,10 @@ type DatastoreMetrics struct {
 	dbIndexSizeBytesGauge *prometheus.GaugeVec
 
 	// Lock contention metrics
-	lockContentionTotal   *prometheus.CounterVec
-	lockWaitTimeHistogram *prometheus.HistogramVec
-	activeLockCountGauge  prometheus.Gauge
+	lockContentionTotal       *prometheus.CounterVec
+	lockWaitTimeHistogram     *prometheus.HistogramVec
+	activeLockCountGauge      prometheus.Gauge
+	lockRetriesExhaustedTotal *prometheus.CounterVec
 
 	// Backup and maintenance metrics
 	backupOperationsTotal      *prometheus.CounterVec
@@ -374,6 +375,14 @@ func (m *DatastoreMetrics) initMetrics() error {
 		Help: "Current number of active locks",
 	})
 
+	m.lockRetriesExhaustedTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "datastore_lock_retries_exhausted_total",
+			Help: "Total number of operations that exhausted all lock retries, indicating potential data loss",
+		},
+		[]string{"operation"},
+	)
+
 	// Backup and maintenance metrics
 	m.backupOperationsTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
@@ -438,6 +447,7 @@ func (m *DatastoreMetrics) initMetrics() error {
 		m.lockContentionTotal,
 		m.lockWaitTimeHistogram,
 		m.activeLockCountGauge,
+		m.lockRetriesExhaustedTotal,
 		m.backupOperationsTotal,
 		m.backupDuration,
 		m.maintenanceOperationsTotal,
@@ -648,6 +658,12 @@ func (m *DatastoreMetrics) RecordLockWaitTime(lockType string, waitTime float64)
 // UpdateActiveLockCount updates the number of active locks
 func (m *DatastoreMetrics) UpdateActiveLockCount(count int) {
 	m.activeLockCountGauge.Set(float64(count))
+}
+
+// RecordLockRetriesExhausted records when an operation exhausts all lock retries.
+// This is a critical metric indicating potential data loss.
+func (m *DatastoreMetrics) RecordLockRetriesExhausted(operation string) {
+	m.lockRetriesExhaustedTotal.WithLabelValues(operation).Inc()
 }
 
 // Backup and maintenance methods


### PR DESCRIPTION
## Summary

Merge main into next to bring all recent fixes into the audiocore refactor branch.

Key changes from main:
- RetryOnLock for all v1/v2 database write paths (100% coverage)
- DatastoreMetrics wired into v2 repository layer
- Duplicate isDBLockError helpers removed, nil guards added
- SQLite write contention fixes and integration tests
- MySQL connection pool configuration
- Complete i18n translations for all 13 locales
- Audio export decoupled from detection broadcast pipeline
- Various bug fixes (ntfy, spectrogram, range filter, etc.)

### Conflict Resolutions

- **realtime.go**: Kept deleted (moved to database_migration.go on next)
- **control_monitor.go**: Kept `schedule.SignalReconfigureQuietHours`
- **actions_database.go**: Took main's decoupled audio export, removed dead code
- **processor.go**: Added `Processor.readCaptureSegment()` with privacy sanitization
- **database_migration.go**: Added nil metrics to repository constructors (PR #2580)
- **alerting/engine.go**: Took main's version (removed duplicate isDBLockError, PR #2579)
- **12 locale JSON files**: Took main's complete translations

## Test plan

- [ ] CI passes (build, lint, tests)
- [ ] Verify audio export still works (decoupled SaveAudioAction path)