### PR TITLE
fix: gate Search quick-review UI with review permission check

### DIFF
--- a/frontend/src/lib/desktop/views/Search.svelte
+++ b/frontend/src/lib/desktop/views/Search.svelte
@@ -26,7 +26,7 @@
   } from '@lucide/svelte';
   import { navigation } from '$lib/stores/navigation.svelte';
   import { dropdown } from '$lib/utils/transitions';
-  import { isAuthenticated } from '$lib/utils/auth';
+  import { hasReviewPermission, isAuthenticated } from '$lib/utils/auth';
   import { loggers } from '$lib/utils/logger';
 
   // SPINNER CONTROL: Set to false to disable loading spinners (reduces flickering)
@@ -70,7 +70,7 @@
   type SortBy = 'date_desc' | 'date_asc' | 'species_asc' | 'confidence_desc';
 
   let clipExtractionEnabled = $derived($isAuthenticated);
-  let canReview = $derived($isAuthenticated);
+  let canReview = $derived($hasReviewPermission);
 
   const logger = loggers.ui;
 


### PR DESCRIPTION
## Summary

The quick-review pen icon in Search.svelte was gated only on `isAuthenticated`, allowing signed-in users without review rights to see the menu and hit 403 errors. Changed to use `hasReviewPermission`, matching the pattern in DetectionDetail.svelte and DetectionRow.svelte.

## Test plan

- [x] `npm run check:all` passes
- [x] Verified `hasReviewPermission` import matches existing pattern

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated review permission logic to ensure the review functionality only appears when users have the appropriate permission to review, rather than being available to all authenticated users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->