### PR TITLE
fix: make WAL checkpoint query cancelable on shutdown

### DIFF
--- a/internal/datastore/v2/manager.go
+++ b/internal/datastore/v2/manager.go
@@ -13,6 +13,7 @@ import (
 	"github.com/getsentry/sentry-go"
 	"github.com/tphakala/birdnet-go/internal/datastore/v2/entities"
 	"github.com/tphakala/birdnet-go/internal/detection"
+	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/logger"
 	"github.com/tphakala/birdnet-go/internal/privacy"
 	"github.com/tphakala/birdnet-go/internal/telemetry"
@@ -458,8 +459,9 @@ func (m *SQLiteManager) StartPeriodicCheckpoint() {
 			case <-m.walCtx.Done():
 				return
 			case <-ticker.C:
-				if err := m.db.Exec("PRAGMA wal_checkpoint(PASSIVE)").Error; err != nil {
-					if m.log != nil {
+				if err := m.db.WithContext(m.walCtx).Exec("PRAGMA wal_checkpoint(PASSIVE)").Error; err != nil {
+					// Suppress expected context.Canceled errors during shutdown
+					if m.log != nil && !errors.Is(err, context.Canceled) {
 						m.log.Warn("periodic WAL checkpoint failed",
 							logger.Error(err),
 							logger.String("operation", "periodic_wal_checkpoint"))


### PR DESCRIPTION
## Summary

The periodic WAL checkpoint goroutine called `m.db.Exec()` without a context. With `SetMaxOpenConns(1)`, a blocked checkpoint could hold the single SQLite connection and keep `Close()` waiting indefinitely.

Changed to `m.db.WithContext(m.walCtx).Exec()` so the checkpoint is cancelable when `StopPeriodicCheckpoint()` fires. Also filters `context.Canceled` errors from the warning log to avoid a spurious shutdown message.

## Test plan

- [x] `go test -race ./internal/datastore/v2/...` passes
- [x] `golangci-lint` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during database shutdown to reduce spurious warnings in logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->