### PR TITLE
fix: clear SpeciesDetailModal cache on open to prevent stale data flash

### DIFF
--- a/frontend/src/lib/desktop/features/analytics/components/modals/SpeciesDetailModal.svelte
+++ b/frontend/src/lib/desktop/features/analytics/components/modals/SpeciesDetailModal.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { untrack } from 'svelte';
   import Modal from '$lib/desktop/components/ui/Modal.svelte';
   import { t } from '$lib/i18n';
   import { parseLocalDateString } from '$lib/utils/date';
@@ -26,6 +27,18 @@
   // Updated when a new species is provided, retained when species becomes null
   // while isOpen transitions to false.
   let cachedSpecies = $state<SpeciesData | null>(null);
+
+  // Clear stale cache when the modal opens so previous species data doesn't flash.
+  // The cache is only useful during the close transition (species becomes null while
+  // isOpen transitions to false), not during open.
+  let prevIsOpen = $state(false);
+  $effect(() => {
+    if (isOpen && !untrack(() => prevIsOpen)) {
+      cachedSpecies = null;
+    }
+    prevIsOpen = isOpen;
+  });
+
   $effect(() => {
     if (species) {
       cachedSpecies = species;


### PR DESCRIPTION
## Summary

`displaySpecies` fell back to `cachedSpecies` unconditionally, so reopening the modal briefly showed the previous species before new data loaded. Now the cache is cleared on the open transition using a `prevIsOpen` state variable with `untrack()` for idiomatic Svelte 5 dependency tracking.

Close-transition behavior is preserved: the cache still holds data during the close animation.

## Test plan

- [x] `npm run check:all` passes
- [x] Existing 5 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue in the species detail modal where previously cached data would display when reopening. The modal now correctly displays the current species information immediately upon opening.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->