### PR TITLE
fix: add error logging for audio card capture failures

### DIFF
--- a/internal/analysis/audio_pipeline_service.go
+++ b/internal/analysis/audio_pipeline_service.go
@@ -352,8 +352,9 @@ func (p *AudioPipelineService) setupAudioSources(audioLevelChan chan audiocore.A
 	var sourceIDs []string
 	for _, cfg := range sourceConfigs {
 		if addErr := p.engine.AddSource(cfg); addErr != nil {
-			log.Warn("failed to add audio source",
+			log.Error("failed to add audio source",
 				logger.String("source_id", cfg.ID),
+				logger.String("source_type", string(cfg.Type)),
 				logger.String("connection", privacy.SanitizeStreamUrl(cfg.ConnectionString)),
 				logger.Error(addErr),
 				logger.String("operation", operation))

--- a/internal/audiocore/capture.go
+++ b/internal/audiocore/capture.go
@@ -188,11 +188,22 @@ func startCapture(
 	// Find the device matching deviceID.
 	var selectedInfo *malgo.DeviceInfo
 	var selectedDevInfo DeviceInfo
+	log.Info("enumerating capture devices",
+		logger.String("source_id", sourceID),
+		logger.String("requested_device", deviceID),
+		logger.Int("device_count", len(infos)))
 	for i := range infos {
 		decodedID, decErr := hexToASCII(infos[i].ID.String())
 		if decErr != nil {
+			log.Warn("failed to decode device ID",
+				logger.Int("device_index", i),
+				logger.Error(decErr))
 			continue
 		}
+		log.Debug("found capture device",
+			logger.Int("index", i),
+			logger.String("name", infos[i].Name()),
+			logger.String("decoded_id", decodedID))
 		if matchesDevice(decodedID, &infos[i], deviceID) {
 			selectedInfo = &infos[i]
 			selectedDevInfo = DeviceInfo{

--- a/internal/audiocore/engine/engine.go
+++ b/internal/audiocore/engine/engine.go
@@ -295,7 +295,17 @@ func (e *AudioEngine) AddSource(cfg *audiocore.SourceConfig) error {
 			BitDepth:   cfg.BitDepth,
 			Channels:   cfg.Channels,
 		}
+		e.logger.Info("starting audio card capture",
+			logger.String("source_id", sourceID),
+			logger.String("device_id", cfg.ConnectionString),
+			logger.Int("sample_rate", sampleRate),
+			logger.Int("bit_depth", cfg.BitDepth),
+			logger.Int("channels", cfg.Channels))
 		if err := e.deviceMgr.StartCapture(sourceID, cfg.ConnectionString, devCfg); err != nil {
+			e.logger.Error("audio card capture failed",
+				logger.String("source_id", sourceID),
+				logger.String("device_id", cfg.ConnectionString),
+				logger.Error(err))
 			e.bufferMgr.DeallocateSource(sourceID)
 			_ = e.registry.Unregister(sourceID)
 			return fmt.Errorf("start device capture for %s: %w", sourceID, err)


### PR DESCRIPTION
## Summary

- Audio card capture failures were completely silent. The error was returned from `engine.AddSource` but the caller logged at WARN level, which was filtered by default log settings. Users got no indication why their sound card wasn't working.
- Device enumeration provided zero context when a device wasn't found, making it impossible to debug matching issues without code changes.

**Changes:**
- Promote "failed to add audio source" from Warn to Error level, add `source_type` field
- Add Info log when starting audio card capture (device_id, sample_rate, bit_depth, channels)
- Add Error log when audio card capture fails (device_id, error detail)
- Add device enumeration logging: Info with count on entry, Debug for each discovered device, Warn on decode failures

## Test Plan

- [x] Verified with ALSA Loopback device -- capture starts and logs device enumeration correctly
- [x] Verified with missing device -- error now logged at ERROR level with device name and failure reason
- [x] `golangci-lint run -v` passes with 0 issues
- [x] `go build ./...` compiles cleanly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced diagnostic logging in audio subsystem: elevated error reporting levels, added source-type identification, and expanded device enumeration and initialization logging for improved system observability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->