### PR TITLE
fix: expose FFmpeg error context in console logs for RTSP diagnostics

### DIFF
--- a/internal/audiocore/ffmpeg/stream.go
+++ b/internal/audiocore/ffmpeg/stream.go
@@ -1848,6 +1848,8 @@ func (s *Stream) recordErrorContext(ctx *ErrorContext) {
 			logger.String("url", s.config.safeURL()),
 			logger.String("source_id", s.config.SourceID),
 			logger.String("error_type", ctx.ErrorType),
+			logger.String("target_host", targetHost),
+			logger.Int("target_port", ctx.TargetPort),
 			logger.String("steps", strings.Join(ctx.TroubleShooting, "; ")),
 			logger.String("component", "ffmpeg-stream"),
 			logger.String("operation", "error_troubleshooting"))
@@ -1856,6 +1858,8 @@ func (s *Stream) recordErrorContext(ctx *ErrorContext) {
 		log.Debug("FFmpeg raw error output",
 			logger.String("source_id", s.config.SourceID),
 			logger.String("error_type", ctx.ErrorType),
+			logger.String("target_host", targetHost),
+			logger.Int("target_port", ctx.TargetPort),
 			logger.String("ffmpeg_output", ctx.RawFFmpegOutput),
 			logger.String("component", "ffmpeg-stream"),
 			logger.String("operation", "error_raw_output"))


### PR DESCRIPTION
## Summary

- FFmpeg error detection extracted rich context (user-facing messages, troubleshooting steps, raw stderr output) but only exposed it via the `/api/v2/streams/health` API endpoint
- Console logs showed only the `error_type` field, making it impossible to diagnose RTSP connection failures from logs alone
- Users reported "no useful output/logging with debug: true" when RTSP streams failed

**Changes:**
- Add `user_message` and `source_id` to `recordErrorContext` error log
- Log troubleshooting steps at Info level when available (e.g. "Verify the camera is powered on and connected to the network")
- Log raw FFmpeg stderr output at Debug level for detailed diagnostics
- Add `primary_message`, `user_message`, `source_id` to early error detection logs

**Before:**
```
ERROR FFmpeg error detected error_type=connection_timeout url=rtsp://***@camera/stream
```

**After:**
```
ERROR FFmpeg error detected error_type=connection_timeout url=rtsp://***@camera/stream source_id=rtsp_abc123 primary_message="Connection timed out" user_message="Connection to camera timed out after 10s"
INFO  FFmpeg troubleshooting steps source_id=rtsp_abc123 error_type=connection_timeout steps="Verify the camera is powered on; Check network connectivity; Verify the RTSP port is open"
DEBUG FFmpeg raw error output source_id=rtsp_abc123 ffmpeg_output="tcp://camera:554: Connection timed out"
```

Closes #2562

## Test Plan

- [x] `go build ./...` compiles cleanly
- [x] `golangci-lint run -v` passes with 0 issues
- [ ] Verify with an unreachable RTSP stream that error context appears in logs