### PR TITLE
fix: reduce console log verbosity — downgrade per-second detection results to debug

### DIFF
--- a/internal/analysis/processor/processor.go
+++ b/internal/analysis/processor/processor.go
@@ -2119,25 +2119,15 @@ func (p *Processor) logDetectionResults(source string, rawCount, filteredCount i
 	shouldLog, reason := p.logDedup.ShouldLog(source, rawCount, filteredCount)
 
 	if shouldLog {
-		// Only log at INFO level when there are actual filtered detections
-		// This prevents log spam from empty analysis cycles
-		if filteredCount > 0 {
-			GetLogger().Info("Detection processing results",
-				logger.String("source", p.getDisplayNameForSource(source)),
-				logger.Int("raw_results_count", rawCount),
-				logger.Int("filtered_detections_count", filteredCount),
-				logger.String("log_reason", reason),
-				logger.String("operation", "process_detections_summary"))
-		} else {
-			// Log zero-detection cycles at DEBUG level for troubleshooting
-			// without flooding INFO logs with noise
-			GetLogger().Debug("Detection processing results",
-				logger.String("source", p.getDisplayNameForSource(source)),
-				logger.Int("raw_results_count", rawCount),
-				logger.Int("filtered_detections_count", 0),
-				logger.String("log_reason", reason),
-				logger.String("operation", "process_detections_summary"))
-		}
+		// Log all processing results at DEBUG level to avoid flooding console.
+		// Actual detections are logged at INFO when they become pending/confirmed
+		// detections (see "Created new pending detection" log message).
+		GetLogger().Debug("Detection processing results",
+			logger.String("source", p.getDisplayNameForSource(source)),
+			logger.Int("raw_results_count", rawCount),
+			logger.Int("filtered_detections_count", filteredCount),
+			logger.String("log_reason", reason),
+			logger.String("operation", "process_detections_summary"))
 	}
 }
 

--- a/internal/conf/defaults.go
+++ b/internal/conf/defaults.go
@@ -419,5 +419,5 @@ func setModuleLogDefaults(module string, enabled bool) {
 	viper.SetDefault(prefix+".enabled", enabled)
 	viper.SetDefault(prefix+".file_path", "logs/"+module+".log")
 	viper.SetDefault(prefix+".level", "debug")
-	viper.SetDefault(prefix+".console_also", true)
+	viper.SetDefault(prefix+".console_also", false)
 }

--- a/internal/logger/config.go
+++ b/internal/logger/config.go
@@ -77,7 +77,7 @@ func ensureModuleOutput(cfg *LoggingConfig, module, filePath string) {
 		cfg.ModuleOutputs[module] = ModuleOutput{
 			Enabled:     true,
 			FilePath:    filePath,
-			ConsoleAlso: true,
+			ConsoleAlso: false,
 		}
 	}
 }


### PR DESCRIPTION
## Summary

The `next` branch is too verbose on console — "Detection processing results" logs fire at INFO every second per audio source, flooding journalctl and docker logs.

- Downgrade "Detection processing results" from INFO to DEBUG. Actual saved detections are still logged at INFO via "Created new pending detection"
- Revert `console_also` default from `true` back to `false` for module loggers (PR #2600 enabled it globally which caused all module output to hit console)

## Test plan

- [x] `golangci-lint run -v` passes
- [ ] Verify reduced log output on deployment