### PR TITLE
fix: update QueueOverflow test for increased queue size

### DIFF
--- a/internal/spectrogram/prerenderer_integration_test.go
+++ b/internal/spectrogram/prerenderer_integration_test.go
@@ -195,9 +195,9 @@ func TestPreRenderer_QueueOverflow(t *testing.T) {
 	// Generate synthetic PCM data using shared helper
 	pcmData := generateTestPCMData(nil)
 
-	// Submit more jobs than queue size to trigger overflow
-	// Queue size is 3 (2 workers + 1 waiting), submit 20 jobs rapidly
-	numJobs := 20
+	// Submit more jobs than queue size (100) to trigger overflow.
+	// Workers will be busy with the first jobs, filling the buffered channel.
+	numJobs := 150
 	queueFull := 0
 	submitted := 0
 


### PR DESCRIPTION
## Summary

`TestPreRenderer_QueueOverflow` fails because batch 5 (#2600) increased `defaultQueueSize` from 3 to 100, but the test still sends only 20 jobs expecting overflow. Increase to 150 so the test properly exercises queue overflow behavior.

## Test plan

- [x] `golangci-lint run -v` passes
- [ ] CI testcontainer-tests pass