### PR TITLE
fix: set global test settings in setupTestEnvironment to prevent nil panic

### DIFF
--- a/internal/api/v2/test_utils.go
+++ b/internal/api/v2/test_utils.go
@@ -172,6 +172,10 @@ func setupTestEnvironment(t *testing.T) (*echo.Echo, *mocks.MockInterface, *Cont
 	// Create mock metrics for testing
 	mockMetrics, _ := observability.NewMetrics()
 
+	// Set test settings globally so helpers like clearExcludedSpeciesList can use conf.GetSettings().
+	oldSettings := conf.GetSettings()
+	conf.SetTestSettings(settings)
+
 	// Create API controller without initializing routes to avoid starting background goroutines
 	controller, err := NewWithOptions(e, mockDS, settings, birdImageCache, sunCalc, controlChan, mockMetrics, false)
 	if err != nil {
@@ -184,6 +188,8 @@ func setupTestEnvironment(t *testing.T) (*echo.Echo, *mocks.MockInterface, *Cont
 		controller.Shutdown()
 		// Close control channel to signal goroutines to exit
 		close(controlChan)
+		// Restore previous global settings
+		conf.SetTestSettings(oldSettings)
 	})
 
 	return e, mockDS, controller


### PR DESCRIPTION
## Summary

- Fix nil pointer dereference in `TestIgnoreSpecies/Error_cases` caused by `clearExcludedSpeciesList` calling `conf.GetSettings()` which returned nil
- `setupTestEnvironment()` passed settings to the Controller but never called `conf.SetTestSettings()`, leaving the global `settingsInstance` nil
- Added `conf.SetTestSettings(settings)` with `t.Cleanup` restore, consistent with the existing pattern in `TestNewErrorResponseDebugMode`

## Test plan
- [x] `go test -race -v -run TestIgnoreSpecies ./internal/api/v2/` passes locally
- [x] `coderabbit review --plain -t uncommitted` — no findings
- [x] `/code-review` — no issues found

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test environment setup to properly isolate and restore test configuration during test execution, enhancing test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->