### PR TITLE
fix: replace conf.GetSettings() with dependency injection in API v2 handlers

### DIFF
--- a/internal/api/v2/api.go
+++ b/internal/api/v2/api.go
@@ -731,8 +731,9 @@ type ErrorResponse struct {
 	ErrorParams   map[string]any `json:"error_params,omitempty"` // Interpolation parameters for error_key
 }
 
-// NewErrorResponse creates a new API error response
-func NewErrorResponse(err error, message string, code int) *ErrorResponse {
+// newErrorResponse creates a new API error response using the controller's
+// injected settings to decide whether to expose raw error details.
+func (c *Controller) newErrorResponse(err error, message string, code int) *ErrorResponse {
 	// Generate a random correlation ID (8 characters should be sufficient)
 	correlationID := generateCorrelationID()
 
@@ -740,8 +741,7 @@ func NewErrorResponse(err error, message string, code int) *ErrorResponse {
 	// paths, SQL errors, stack traces, etc. In production, use the
 	// sanitized message parameter instead.
 	var errorStr string
-	settings := conf.GetSettings()
-	if err != nil && settings != nil && settings.WebServer.Debug {
+	if err != nil && c.Settings != nil && c.Settings.WebServer.Debug {
 		errorStr = err.Error()
 	} else {
 		errorStr = message
@@ -776,7 +776,7 @@ func generateCorrelationID() string {
 
 // handleErrorInternal is the shared implementation for HandleError and HandleErrorWithKey.
 func (c *Controller) handleErrorInternal(ctx echo.Context, err error, message string, code int, errorKey string, errorParams map[string]any) error {
-	errorResp := NewErrorResponse(err, message, code)
+	errorResp := c.newErrorResponse(err, message, code)
 	errorResp.ErrorKey = errorKey
 	errorResp.ErrorParams = errorParams
 

--- a/internal/api/v2/api_test.go
+++ b/internal/api/v2/api_test.go
@@ -172,29 +172,21 @@ func TestHandleError(t *testing.T) {
 // TestNewErrorResponseDebugMode verifies that raw err.Error() is exposed in the
 // Error field when web server debug mode is enabled, for developer diagnostics.
 func TestNewErrorResponseDebugMode(t *testing.T) {
-	// Save and restore global settings to avoid test interference
-	prevSettings := conf.GetSettings()
-	t.Cleanup(func() {
-		conf.SetTestSettings(prevSettings)
-	})
-
 	testErr := echo.NewHTTPError(http.StatusBadRequest, "Test error")
 
 	// Test 1: Non-debug mode — Error field should use sanitized message
-	conf.SetTestSettings(&conf.Settings{
+	c := &Controller{Settings: &conf.Settings{
 		WebServer: conf.WebServerSettings{Debug: false},
-	})
+	}}
 
-	resp := NewErrorResponse(testErr, "Safe message", http.StatusBadRequest)
+	resp := c.newErrorResponse(testErr, "Safe message", http.StatusBadRequest)
 	assert.Equal(t, "Safe message", resp.Error, "Non-debug mode should use sanitized message")
 	assert.Equal(t, "Safe message", resp.Message)
 
 	// Test 2: Debug mode — Error field should expose raw err.Error()
-	conf.SetTestSettings(&conf.Settings{
-		WebServer: conf.WebServerSettings{Debug: true},
-	})
+	c.Settings.WebServer.Debug = true
 
-	resp = NewErrorResponse(testErr, "Safe message", http.StatusBadRequest)
+	resp = c.newErrorResponse(testErr, "Safe message", http.StatusBadRequest)
 	assert.Equal(t, "code=400, message=Test error", resp.Error, "Debug mode should expose raw error")
 	assert.Equal(t, "Safe message", resp.Message)
 }

--- a/internal/api/v2/debug.go
+++ b/internal/api/v2/debug.go
@@ -191,7 +191,7 @@ func (c *Controller) DebugSystemStatus(ctx echo.Context) error {
 	}
 
 	// Get telemetry status
-	if telemetryStatus := getTelemetryStatus(); telemetryStatus != nil {
+	if telemetryStatus := getTelemetryStatus(c.Settings); telemetryStatus != nil {
 		status.Telemetry = telemetryStatus
 	}
 
@@ -225,14 +225,14 @@ func mapErrorCategory(category string) errors.ErrorCategory {
 	}
 }
 
-func getTelemetryStatus() map[string]any {
+func getTelemetryStatus(settings *conf.Settings) map[string]any {
 	// Get more detailed telemetry status
 	status := map[string]any{
 		"enabled": false, // Default to false for safety
 	}
 
-	// Check if settings are available via global conf
-	if settings := conf.GetSettings(); settings != nil {
+	// Check if settings are available
+	if settings != nil {
 		status["enabled"] = settings.Sentry.Enabled
 	}
 

--- a/internal/api/v2/detections.go
+++ b/internal/api/v2/detections.go
@@ -1451,7 +1451,7 @@ func (c *Controller) IgnoreSpecies(ctx echo.Context) error {
 
 // GetExcludedSpecies returns the list of excluded species
 func (c *Controller) GetExcludedSpecies(ctx echo.Context) error {
-	settings := conf.GetSettings()
+	settings := c.Settings
 
 	// Create a copy of the slice to avoid race conditions
 	c.speciesExcludeMutex.Lock()
@@ -1485,8 +1485,8 @@ func (c *Controller) toggleSpeciesInIgnoredList(species string) (action string, 
 	c.speciesExcludeMutex.Lock()
 	defer c.speciesExcludeMutex.Unlock()
 
-	// Access the latest settings using the settings accessor function
-	settings := conf.GetSettings()
+	// Access settings via dependency injection (not the global singleton)
+	settings := c.Settings
 
 	// Check if species is already in the excluded list
 	wasExcluded := slices.Contains(settings.Realtime.Species.Exclude, species)
@@ -1531,8 +1531,8 @@ func (c *Controller) addSpeciesToIgnoredList(species string) error {
 	c.speciesExcludeMutex.Lock()
 	defer c.speciesExcludeMutex.Unlock()
 
-	// Access the latest settings using the settings accessor function
-	settings := conf.GetSettings()
+	// Access settings via dependency injection (not the global singleton)
+	settings := c.Settings
 
 	// Check if species is already in the excluded list
 	isExcluded := slices.Contains(settings.Realtime.Species.Exclude, species)

--- a/internal/api/v2/detections_test.go
+++ b/internal/api/v2/detections_test.go
@@ -1359,11 +1359,11 @@ func TestLockDetection(t *testing.T) {
 	}
 }
 
-// clearExcludedSpeciesList is a test helper that clears the global excluded species list
-// to ensure test isolation. Call this at the beginning of tests that check list state.
-func clearExcludedSpeciesList(t *testing.T) {
+// clearExcludedSpeciesList is a test helper that clears the excluded species list
+// on the given settings to ensure test isolation. Call this at the beginning of
+// tests that check list state.
+func clearExcludedSpeciesList(t *testing.T, settings *conf.Settings) {
 	t.Helper()
-	settings := conf.GetSettings()
 	settings.Realtime.Species.Exclude = []string{}
 }
 
@@ -1372,7 +1372,7 @@ func TestIgnoreSpecies(t *testing.T) {
 	// Test cases for error scenarios
 	t.Run("Error cases", func(t *testing.T) {
 		e, _, controller := setupTestEnvironment(t)
-		clearExcludedSpeciesList(t)
+		clearExcludedSpeciesList(t, controller.Settings)
 
 		errorCases := []struct {
 			name           string
@@ -1425,7 +1425,7 @@ func TestIgnoreSpecies(t *testing.T) {
 	// Test toggle behavior: add then remove
 	t.Run("Toggle behavior - add species", func(t *testing.T) {
 		e, _, controller := setupTestEnvironment(t)
-		clearExcludedSpeciesList(t)
+		clearExcludedSpeciesList(t, controller.Settings)
 
 		// First request: add species (should not be in list initially)
 		req := httptest.NewRequest(http.MethodPost, "/api/v2/detections/ignore",
@@ -1448,7 +1448,7 @@ func TestIgnoreSpecies(t *testing.T) {
 
 	t.Run("Toggle behavior - remove species", func(t *testing.T) {
 		e, _, controller := setupTestEnvironment(t)
-		clearExcludedSpeciesList(t)
+		clearExcludedSpeciesList(t, controller.Settings)
 
 		// First, add the species
 		req1 := httptest.NewRequest(http.MethodPost, "/api/v2/detections/ignore",
@@ -1488,7 +1488,7 @@ func TestIgnoreSpecies(t *testing.T) {
 
 	t.Run("Multiple toggle operations", func(t *testing.T) {
 		e, _, controller := setupTestEnvironment(t)
-		clearExcludedSpeciesList(t)
+		clearExcludedSpeciesList(t, controller.Settings)
 		speciesName := "Northern Cardinal"
 
 		// Perform add-remove-add cycle
@@ -1513,7 +1513,7 @@ func TestIgnoreSpecies(t *testing.T) {
 
 	t.Run("Special characters in species name", func(t *testing.T) {
 		e, _, controller := setupTestEnvironment(t)
-		clearExcludedSpeciesList(t)
+		clearExcludedSpeciesList(t, controller.Settings)
 
 		// Test with special characters (properly JSON encoded)
 		// Note: Use proper JSON encoding for special chars
@@ -1541,7 +1541,7 @@ func TestIgnoreSpecies(t *testing.T) {
 
 	t.Run("Long species name", func(t *testing.T) {
 		e, _, controller := setupTestEnvironment(t)
-		clearExcludedSpeciesList(t)
+		clearExcludedSpeciesList(t, controller.Settings)
 
 		longName := strings.Repeat("Very Long Bird Name ", 50)
 		req := httptest.NewRequest(http.MethodPost, "/api/v2/detections/ignore",
@@ -1565,7 +1565,7 @@ func TestIgnoreSpecies(t *testing.T) {
 func TestGetExcludedSpecies(t *testing.T) {
 	t.Run("Empty excluded list", func(t *testing.T) {
 		e, _, controller := setupTestEnvironment(t)
-		clearExcludedSpeciesList(t)
+		clearExcludedSpeciesList(t, controller.Settings)
 
 		req := httptest.NewRequest(http.MethodGet, "/api/v2/detections/ignored", http.NoBody)
 		rec := httptest.NewRecorder()
@@ -1584,7 +1584,7 @@ func TestGetExcludedSpecies(t *testing.T) {
 
 	t.Run("Excluded list with species", func(t *testing.T) {
 		e, _, controller := setupTestEnvironment(t)
-		clearExcludedSpeciesList(t)
+		clearExcludedSpeciesList(t, controller.Settings)
 
 		// First add some species
 		speciesList := []string{"American Crow", "Red-bellied Woodpecker", "Blue Jay"}
@@ -1616,7 +1616,7 @@ func TestGetExcludedSpecies(t *testing.T) {
 
 	t.Run("Excluded list reflects toggle operations", func(t *testing.T) {
 		e, _, controller := setupTestEnvironment(t)
-		clearExcludedSpeciesList(t)
+		clearExcludedSpeciesList(t, controller.Settings)
 
 		// Add two species
 		for _, s := range []string{"Species A", "Species B"} {
@@ -1659,7 +1659,7 @@ func TestGetExcludedSpecies(t *testing.T) {
 // TestIgnoreSpeciesConcurrency tests concurrent access to the IgnoreSpecies endpoint
 func TestIgnoreSpeciesConcurrency(t *testing.T) {
 	e, _, controller := setupTestEnvironment(t)
-	clearExcludedSpeciesList(t)
+	clearExcludedSpeciesList(t, controller.Settings)
 
 	// Use WaitGroup.Go() for automatic Add/Done management (Go 1.25+)
 	var wg sync.WaitGroup

--- a/internal/api/v2/media.go
+++ b/internal/api/v2/media.go
@@ -1139,7 +1139,7 @@ func (c *Controller) returnSpectrogramNotGeneratedError(ctx echo.Context) (bool,
 	// Flow: <img> element's onerror handler triggers -> frontend makes fetch() call to same URL
 	// -> this JSON response is parsed by frontend -> mode field triggers UI to show "Generate" button
 	// Note: The <img> element doesn't parse this JSON; the error handler's fetch() call does.
-	errorResp := NewErrorResponse(
+	errorResp := c.newErrorResponse(
 		fmt.Errorf("spectrogram not generated"),
 		"Spectrogram has not been generated yet. Click 'Generate Spectrogram' to create it.",
 		http.StatusNotFound,

--- a/internal/api/v2/quiet_hours.go
+++ b/internal/api/v2/quiet_hours.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 
 	"github.com/labstack/echo/v4"
-	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/myaudio"
 	"github.com/tphakala/birdnet-go/internal/privacy"
 )
@@ -28,7 +27,7 @@ func (c *Controller) initQuietHoursRoutes() {
 
 // GetQuietHoursStatus returns the current quiet hours suppression state for all sources.
 func (c *Controller) GetQuietHoursStatus(ctx echo.Context) error {
-	settings := conf.GetSettings()
+	settings := c.Settings
 	scheduler := myaudio.GetGlobalScheduler()
 
 	response := QuietHoursStatusResponse{

--- a/internal/api/v2/streams_health.go
+++ b/internal/api/v2/streams_health.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
-	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/logger"
 	"github.com/tphakala/birdnet-go/internal/myaudio"
 	"github.com/tphakala/birdnet-go/internal/privacy"
@@ -152,10 +151,10 @@ type streamInfo struct {
 
 // getStreamInfo looks up stream name and type from config by URL.
 // Returns empty values if stream is not found in config.
-// Uses conf.GetSettings() to always get current config, avoiding stale data
-// after config reloads.
+// Uses c.Settings (injected via Controller constructor) which points to the
+// shared settings instance — mutations are visible immediately.
 func (c *Controller) getStreamInfo(rawURL string) streamInfo {
-	settings := conf.GetSettings()
+	settings := c.Settings
 	if settings == nil {
 		return streamInfo{}
 	}

--- a/internal/api/v2/support.go
+++ b/internal/api/v2/support.go
@@ -83,8 +83,8 @@ func (c *Controller) GenerateSupportDump(ctx echo.Context) error {
 		c.logDebugIfEnabled("Set default options for support dump")
 	}
 
-	// Get current settings
-	settings := conf.GetSettings()
+	// Get current settings via dependency injection
+	settings := c.Settings
 	if settings == nil {
 		return c.HandleError(ctx, nil, "Settings not available", http.StatusInternalServerError)
 	}
@@ -245,7 +245,7 @@ func (c *Controller) DownloadSupportDump(ctx echo.Context) error {
 
 // GetSupportStatus returns the current support/telemetry configuration status
 func (c *Controller) GetSupportStatus(ctx echo.Context) error {
-	settings := conf.GetSettings()
+	settings := c.Settings
 	if settings == nil {
 		return c.HandleError(ctx, nil, "Settings not available", http.StatusInternalServerError)
 	}

--- a/internal/api/v2/test_utils.go
+++ b/internal/api/v2/test_utils.go
@@ -27,8 +27,11 @@ const (
 
 // newMinimalController creates a Controller for simple validation tests.
 // Use this for tests that only need to call handler methods without database or full infrastructure.
+// Includes default settings to prevent nil pointer panics if a handler accesses c.Settings.
 func newMinimalController() *Controller {
-	return &Controller{}
+	return &Controller{
+		Settings: newValidTestSettings(),
+	}
 }
 
 // safeSlice is a helper for mock methods returning slices.
@@ -94,10 +97,12 @@ func setupAnalyticsTestEnvironment(t *testing.T) (*echo.Echo, *mocks.MockInterfa
 	// Create a test datastore
 	mockDS := mocks.NewMockInterface(t)
 
-	// Create a controller with the test datastore
+	// Create a controller with the test datastore and default settings
+	// to prevent nil pointer panics if a handler accesses c.Settings.
 	controller := &Controller{
-		Group: e.Group("/api/v2"),
-		DS:    mockDS,
+		Group:    e.Group("/api/v2"),
+		DS:       mockDS,
+		Settings: newValidTestSettings(),
 	}
 
 	// Don't initialize routes as it causes nil pointer dereference in tests
@@ -192,6 +197,9 @@ func setupTestEnvironment(t *testing.T) (*echo.Echo, *mocks.MockInterface, *Cont
 // newValidTestSettings returns a *conf.Settings populated with minimal values
 // that pass conf.ValidateSettings(). Tests that create inline Controller structs
 // should call this and then override the fields they care about.
+//
+// Debug defaults to false to match production behavior. Tests that specifically
+// need debug mode should set controller.Settings.WebServer.Debug = true.
 func newValidTestSettings() *conf.Settings {
 	return &conf.Settings{
 		BirdNET: conf.BirdNETConfig{
@@ -200,7 +208,7 @@ func newValidTestSettings() *conf.Settings {
 			Locale:      "en",
 		},
 		WebServer: conf.WebServerSettings{
-			Debug: true,
+			Debug: false,
 			LiveStream: conf.LiveStreamSettings{
 				BitRate:       128,
 				SegmentLength: 5,


### PR DESCRIPTION
## Summary

- Replace `conf.GetSettings()` global singleton calls with `c.Settings` (controller's injected reference) across 7 Controller methods in the API v2 package
- Convert `NewErrorResponse` from a standalone function to a Controller method (`c.newErrorResponse`) so it reads debug mode from `c.Settings` instead of the global
- Add `*conf.Settings` parameter to `getTelemetryStatus` helper function
- Harden test infrastructure: `newMinimalController()`, `setupAnalyticsTestEnvironment()` now include default settings; `newValidTestSettings()` defaults `Debug: false` to match production behavior

## Motivation

Multiple production methods on `Controller` used `conf.GetSettings()` instead of `c.Settings`. In production both point to the same object, but this creates two problems:

1. **Test fragility**: Tests must set global state even though the Controller has its own settings reference, and setting global state races with `t.Parallel()` tests
2. **Architectural inconsistency**: The Controller accepts settings via constructor but then bypasses its own DI reference in favor of a global

## Test plan

- [x] `go test -race -count=1 ./internal/api/v2/...` — all pass
- [x] `golangci-lint run -v ./internal/api/v2/...` — zero issues
- [x] Pre-commit hooks pass (full project lint)
- [x] No remaining `conf.GetSettings()` calls in v2 production code (only a comment in auth_integration_test.go)
- [x] Local CodeRabbit review — no findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved internal code architecture by restructuring configuration access patterns for better dependency management and reduced reliance on global state.

* **Tests**
  * Updated test utilities and infrastructure to align with internal code reorganization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->