### PR TITLE
fix: add Settings to bare Controller{} in API v2 tests

### DIFF
--- a/internal/api/v2/audio_hls_test.go
+++ b/internal/api/v2/audio_hls_test.go
@@ -523,7 +523,7 @@ func TestResolveClientID(t *testing.T) {
 	const testRemoteAddr = "192.168.1.100:12345"
 
 	t.Run("prefers session ID when provided", func(t *testing.T) {
-		c := &Controller{}
+		c := &Controller{Settings: newValidTestSettings()}
 		e := echo.New()
 		req := httptest.NewRequest(http.MethodPost, "/", http.NoBody)
 		req.RemoteAddr = testRemoteAddr
@@ -536,7 +536,7 @@ func TestResolveClientID(t *testing.T) {
 	})
 
 	t.Run("falls back to generateClientID when no session", func(t *testing.T) {
-		c := &Controller{}
+		c := &Controller{Settings: newValidTestSettings()}
 		e := echo.New()
 		req := httptest.NewRequest(http.MethodPost, "/", http.NoBody)
 		req.RemoteAddr = testRemoteAddr
@@ -550,7 +550,7 @@ func TestResolveClientID(t *testing.T) {
 	})
 
 	t.Run("different sessions from same IP get different IDs", func(t *testing.T) {
-		c := &Controller{}
+		c := &Controller{Settings: newValidTestSettings()}
 		e := echo.New()
 
 		req1 := httptest.NewRequest(http.MethodPost, "/", http.NoBody)
@@ -567,7 +567,7 @@ func TestResolveClientID(t *testing.T) {
 	})
 
 	t.Run("rejects invalid session ID format", func(t *testing.T) {
-		c := &Controller{}
+		c := &Controller{Settings: newValidTestSettings()}
 		e := echo.New()
 		req := httptest.NewRequest(http.MethodPost, "/", http.NoBody)
 		req.RemoteAddr = testRemoteAddr

--- a/internal/api/v2/audio_level_test.go
+++ b/internal/api/v2/audio_level_test.go
@@ -67,7 +67,7 @@ func TestAudioLevelSSEDataFormat(t *testing.T) {
 // TestIsSourceInactive tests the source inactivity detection logic
 func TestIsSourceInactive(t *testing.T) {
 	// Create a minimal controller for testing
-	controller := &Controller{}
+	controller := &Controller{Settings: newValidTestSettings()}
 
 	t.Run("new source is active", func(t *testing.T) {
 		lastUpdate := make(map[string]time.Time)
@@ -121,7 +121,7 @@ func TestIsSourceInactive(t *testing.T) {
 
 // TestCheckSourceActivity tests the source activity checking for multiple sources
 func TestCheckSourceActivity(t *testing.T) {
-	controller := &Controller{}
+	controller := &Controller{Settings: newValidTestSettings()}
 
 	t.Run("no inactive sources", func(t *testing.T) {
 		now := time.Now()
@@ -176,7 +176,7 @@ func TestCheckSourceActivity(t *testing.T) {
 
 // TestGetAnonymizedSourceNameFallback tests the fallback source name anonymization
 func TestGetAnonymizedSourceNameFallback(t *testing.T) {
-	controller := &Controller{}
+	controller := &Controller{Settings: newValidTestSettings()}
 
 	t.Run("audio card source", func(t *testing.T) {
 		name := controller.getAnonymizedSourceNameFallback("audio_card_default")

--- a/internal/api/v2/audio_level_write_deadline_test.go
+++ b/internal/api/v2/audio_level_write_deadline_test.go
@@ -67,7 +67,7 @@ func TestSendAudioLevelUpdateSetsWriteDeadline(t *testing.T) {
 		ctx.Response().Writer = mockWriter
 
 		// Create minimal controller
-		controller := &Controller{}
+		controller := &Controller{Settings: newValidTestSettings()}
 
 		// Create test audio level data
 		levels := map[string]audiocore.AudioLevelData{
@@ -107,7 +107,7 @@ func TestSendAudioLevelUpdateSetsWriteDeadline(t *testing.T) {
 		ctx := e.NewContext(req, rec)
 		ctx.Response().Writer = mockWriter
 
-		controller := &Controller{}
+		controller := &Controller{Settings: newValidTestSettings()}
 		levels := map[string]audiocore.AudioLevelData{
 			"test_source": {Level: 50, Name: "Test Source", Source: "test_source"},
 		}
@@ -139,7 +139,7 @@ func TestSendAudioLevelHeartbeatSetsWriteDeadline(t *testing.T) {
 		ctx.Response().Writer = mockWriter
 
 		// Create minimal controller
-		controller := &Controller{}
+		controller := &Controller{Settings: newValidTestSettings()}
 
 		// Call sendAudioLevelHeartbeat
 		err := controller.sendAudioLevelHeartbeat(ctx)

--- a/internal/api/v2/events_test.go
+++ b/internal/api/v2/events_test.go
@@ -41,7 +41,7 @@ func TestAggregateDetectionEvents(t *testing.T) {
 
 	t.Run("empty entries returns empty response", func(t *testing.T) {
 		t.Parallel()
-		c := &Controller{}
+		c := &Controller{Settings: newValidTestSettings()}
 
 		result := c.aggregateDetectionEvents(nil, baseTime)
 
@@ -56,7 +56,7 @@ func TestAggregateDetectionEvents(t *testing.T) {
 
 	t.Run("single approve creates one bucket and one species", func(t *testing.T) {
 		t.Parallel()
-		c := &Controller{}
+		c := &Controller{Settings: newValidTestSettings()}
 
 		entries := []reader.LogEntry{
 			makeEntry(baseTime, "approve_detection", "Robin", map[string]any{
@@ -94,7 +94,7 @@ func TestAggregateDetectionEvents(t *testing.T) {
 
 	t.Run("multiple operations same bucket same species accumulate", func(t *testing.T) {
 		t.Parallel()
-		c := &Controller{}
+		c := &Controller{Settings: newValidTestSettings()}
 
 		entries := []reader.LogEntry{
 			makeEntry(baseTime, "approve_detection", "Sparrow", map[string]any{"confidence": 0.7, "match_count": float64(1)}),
@@ -123,7 +123,7 @@ func TestAggregateDetectionEvents(t *testing.T) {
 
 	t.Run("multiple species same bucket grouped correctly", func(t *testing.T) {
 		t.Parallel()
-		c := &Controller{}
+		c := &Controller{Settings: newValidTestSettings()}
 
 		entries := []reader.LogEntry{
 			makeEntry(baseTime, "approve_detection", "Robin", map[string]any{"confidence": 0.9, "match_count": float64(2)}),
@@ -139,7 +139,7 @@ func TestAggregateDetectionEvents(t *testing.T) {
 
 	t.Run("multiple buckets separated by hour and sorted newest first", func(t *testing.T) {
 		t.Parallel()
-		c := &Controller{}
+		c := &Controller{Settings: newValidTestSettings()}
 
 		hour10 := time.Date(2024, 6, 15, 10, 15, 0, 0, time.UTC)
 		hour14 := time.Date(2024, 6, 15, 14, 45, 0, 0, time.UTC)
@@ -159,7 +159,7 @@ func TestAggregateDetectionEvents(t *testing.T) {
 
 	t.Run("pre-filters counted in bucket but not in species", func(t *testing.T) {
 		t.Parallel()
-		c := &Controller{}
+		c := &Controller{Settings: newValidTestSettings()}
 
 		entries := []reader.LogEntry{
 			makeEntry(baseTime, "dog_bark_filter", "", nil),
@@ -184,7 +184,7 @@ func TestAggregateDetectionEvents(t *testing.T) {
 
 	t.Run("pending count from create_pending_detection hourly array", func(t *testing.T) {
 		t.Parallel()
-		c := &Controller{}
+		c := &Controller{Settings: newValidTestSettings()}
 
 		entries := []reader.LogEntry{
 			makeEntry(time.Date(2024, 6, 15, 8, 0, 0, 0, time.UTC), "create_pending_detection", "", nil),
@@ -201,7 +201,7 @@ func TestAggregateDetectionEvents(t *testing.T) {
 
 	t.Run("species sorting approved first then by total descending", func(t *testing.T) {
 		t.Parallel()
-		c := &Controller{}
+		c := &Controller{Settings: newValidTestSettings()}
 
 		entries := []reader.LogEntry{
 			// Crow: 3 discards (no approvals)
@@ -228,7 +228,7 @@ func TestAggregateDetectionEvents(t *testing.T) {
 
 	t.Run("top discarded species top 3", func(t *testing.T) {
 		t.Parallel()
-		c := &Controller{}
+		c := &Controller{Settings: newValidTestSettings()}
 
 		entries := []reader.LogEntry{
 			// 5 discards for Alpha
@@ -261,7 +261,7 @@ func TestAggregateDetectionEvents(t *testing.T) {
 
 	t.Run("audio clip matching attached to correct species", func(t *testing.T) {
 		t.Parallel()
-		c := &Controller{}
+		c := &Controller{Settings: newValidTestSettings()}
 
 		entries := []reader.LogEntry{
 			makeEntry(baseTime, "approve_detection", "Robin", map[string]any{"confidence": 0.9, "match_count": float64(1)}),
@@ -293,7 +293,7 @@ func TestAggregateDetectionEvents(t *testing.T) {
 
 	t.Run("peak confidence tracks highest value", func(t *testing.T) {
 		t.Parallel()
-		c := &Controller{}
+		c := &Controller{Settings: newValidTestSettings()}
 
 		entries := []reader.LogEntry{
 			makeEntry(baseTime, "approve_detection", "Robin", map[string]any{"confidence": 0.7, "match_count": float64(1)}),
@@ -310,7 +310,7 @@ func TestAggregateDetectionEvents(t *testing.T) {
 
 	t.Run("max match count tracks highest value", func(t *testing.T) {
 		t.Parallel()
-		c := &Controller{}
+		c := &Controller{Settings: newValidTestSettings()}
 
 		entries := []reader.LogEntry{
 			makeEntry(baseTime, "approve_detection", "Robin", map[string]any{"confidence": 0.8, "match_count": float64(2)}),
@@ -327,7 +327,7 @@ func TestAggregateDetectionEvents(t *testing.T) {
 
 	t.Run("empty species name entries are skipped", func(t *testing.T) {
 		t.Parallel()
-		c := &Controller{}
+		c := &Controller{Settings: newValidTestSettings()}
 
 		entries := []reader.LogEntry{
 			makeEntry(baseTime, "approve_detection", "", map[string]any{"confidence": 0.9, "match_count": float64(1)}),
@@ -347,7 +347,7 @@ func TestAggregateDetectionEvents(t *testing.T) {
 
 	t.Run("approved per hour metric calculated correctly", func(t *testing.T) {
 		t.Parallel()
-		c := &Controller{}
+		c := &Controller{Settings: newValidTestSettings()}
 
 		hour10 := time.Date(2024, 6, 15, 10, 15, 0, 0, time.UTC)
 		hour14 := time.Date(2024, 6, 15, 14, 45, 0, 0, time.UTC)
@@ -367,7 +367,7 @@ func TestAggregateDetectionEvents(t *testing.T) {
 
 	t.Run("timestamps are recorded for approve and discard", func(t *testing.T) {
 		t.Parallel()
-		c := &Controller{}
+		c := &Controller{Settings: newValidTestSettings()}
 
 		approveTime := time.Date(2024, 6, 15, 10, 30, 0, 0, time.UTC)
 		discardTime := time.Date(2024, 6, 15, 10, 35, 0, 0, time.UTC)
@@ -388,7 +388,7 @@ func TestAggregateDetectionEvents(t *testing.T) {
 
 	t.Run("species summary sorted by total descending", func(t *testing.T) {
 		t.Parallel()
-		c := &Controller{}
+		c := &Controller{Settings: newValidTestSettings()}
 
 		entries := []reader.LogEntry{
 			// Robin: 3 total

--- a/internal/api/v2/notifications_new_species_test.go
+++ b/internal/api/v2/notifications_new_species_test.go
@@ -69,7 +69,7 @@ func TestCreateTestNewSpeciesNotification_Success(t *testing.T) {
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
 
-	controller := &Controller{}
+	controller := &Controller{Settings: newValidTestSettings()}
 	controller.Settings = &conf.Settings{}
 	controller.Settings.Security.Host = "localhost"
 	controller.Settings.WebServer.Port = "8080"

--- a/internal/api/v2/notifications_ntfy_check_test.go
+++ b/internal/api/v2/notifications_ntfy_check_test.go
@@ -22,7 +22,7 @@ func TestCheckNtfyServer_HTTPSuccess(t *testing.T) {
 	defer ts.Close()
 
 	e := echo.New()
-	ctrl := &Controller{}
+	ctrl := &Controller{Settings: newValidTestSettings()}
 	// ts.Listener.Addr().String() returns "127.0.0.1:PORT"
 	req := httptest.NewRequest(http.MethodGet, "/api/v2/notifications/check-ntfy-server?host="+ts.Listener.Addr().String(), http.NoBody)
 	rec := httptest.NewRecorder()
@@ -41,7 +41,7 @@ func TestCheckNtfyServer_HTTPSuccess(t *testing.T) {
 
 func TestCheckNtfyServer_MissingHost(t *testing.T) {
 	e := echo.New()
-	ctrl := &Controller{}
+	ctrl := &Controller{Settings: newValidTestSettings()}
 	req := httptest.NewRequest(http.MethodGet, "/api/v2/notifications/check-ntfy-server", http.NoBody)
 	rec := httptest.NewRecorder()
 	ctx := e.NewContext(req, rec)
@@ -53,7 +53,7 @@ func TestCheckNtfyServer_MissingHost(t *testing.T) {
 
 func TestCheckNtfyServer_InvalidHost_Unreachable(t *testing.T) {
 	e := echo.New()
-	ctrl := &Controller{}
+	ctrl := &Controller{Settings: newValidTestSettings()}
 	// Use a reserved/invalid IP that will not respond (TEST-NET-1, RFC 5737)
 	req := httptest.NewRequest(http.MethodGet, "/api/v2/notifications/check-ntfy-server?host=192.0.2.1", http.NoBody)
 	rec := httptest.NewRecorder()
@@ -79,7 +79,7 @@ func TestCheckNtfyServer_NonNtfyServerNotFalsePositive(t *testing.T) {
 	defer ts.Close()
 
 	e := echo.New()
-	ctrl := &Controller{}
+	ctrl := &Controller{Settings: newValidTestSettings()}
 	req := httptest.NewRequest(http.MethodGet, "/api/v2/notifications/check-ntfy-server?host="+ts.Listener.Addr().String(), http.NoBody)
 	rec := httptest.NewRecorder()
 	ctx := e.NewContext(req, rec)
@@ -95,7 +95,7 @@ func TestCheckNtfyServer_NonNtfyServerNotFalsePositive(t *testing.T) {
 
 func TestCheckNtfyServer_InjectionRejected(t *testing.T) {
 	e := echo.New()
-	ctrl := &Controller{}
+	ctrl := &Controller{Settings: newValidTestSettings()}
 	// Slash injection attempt
 	req := httptest.NewRequest(http.MethodGet, "/api/v2/notifications/check-ntfy-server?host=evil.com%2F%40good.com", http.NoBody)
 	rec := httptest.NewRecorder()
@@ -108,7 +108,7 @@ func TestCheckNtfyServer_InjectionRejected(t *testing.T) {
 
 func TestCheckNtfyServer_CloudMetadataBlocked(t *testing.T) {
 	e := echo.New()
-	ctrl := &Controller{}
+	ctrl := &Controller{Settings: newValidTestSettings()}
 	req := httptest.NewRequest(http.MethodGet, "/api/v2/notifications/check-ntfy-server?host=169.254.169.254", http.NoBody)
 	rec := httptest.NewRecorder()
 	ctx := e.NewContext(req, rec)
@@ -134,15 +134,15 @@ func TestIsValidNtfyHost(t *testing.T) {
 		{"", false},
 		{"evil.com/path", false},
 		{"evil.com@other.com", false},
-		{"169.254.169.254", false},         // cloud metadata
-		{"[169.254.169.254]", false},       // cloud metadata bracketed
-		{"fd00:ec2::254", false},           // cloud metadata IPv6
-		{"[fd00:ec2::254]", false},         // cloud metadata IPv6 bracketed
-		{"192.168.1.100:0", false},       // port 0 out of range
-		{"192.168.1.100:99999", false},   // port > 65535
-		{"192.168.1.100:-1", false},      // negative port
-		{"192.168.1.100:notaport", false},    // non-numeric port
-		{"http://ntfy.sh", false},            // scheme not allowed
+		{"169.254.169.254", false},            // cloud metadata
+		{"[169.254.169.254]", false},          // cloud metadata bracketed
+		{"fd00:ec2::254", false},              // cloud metadata IPv6
+		{"[fd00:ec2::254]", false},            // cloud metadata IPv6 bracketed
+		{"192.168.1.100:0", false},            // port 0 out of range
+		{"192.168.1.100:99999", false},        // port > 65535
+		{"192.168.1.100:-1", false},           // negative port
+		{"192.168.1.100:notaport", false},     // non-numeric port
+		{"http://ntfy.sh", false},             // scheme not allowed
 		{"https://192.168.1.100:8080", false}, // scheme not allowed
 	}
 	for _, tt := range tests {

--- a/internal/api/v2/ntfy_integration_test.go
+++ b/internal/api/v2/ntfy_integration_test.go
@@ -54,7 +54,7 @@ func TestCheckNtfyServer_RealContainer(t *testing.T) {
 	t.Run("handler_integration", func(t *testing.T) {
 		// Test the full CheckNtfyServer handler via Echo context
 		e := echo.New()
-		ctrl := &Controller{}
+		ctrl := &Controller{Settings: newValidTestSettings()}
 
 		req := httptest.NewRequest(http.MethodGet,
 			"/api/v2/notifications/check-ntfy-server?host="+host, http.NoBody)

--- a/internal/api/v2/prerequisites_test.go
+++ b/internal/api/v2/prerequisites_test.go
@@ -302,7 +302,7 @@ func TestCheckMemoryAvailable(t *testing.T) {
 	t.Attr("type", "unit")
 	t.Attr("feature", "prerequisites")
 
-	controller := &Controller{}
+	controller := &Controller{Settings: newValidTestSettings()}
 
 	check := controller.checkMemoryAvailable()
 

--- a/internal/api/v2/species_taxonomy_test.go
+++ b/internal/api/v2/species_taxonomy_test.go
@@ -25,6 +25,7 @@ func TestGetGenusSpecies(t *testing.T) {
 
 	// Create a minimal controller with taxonomy DB
 	c := &Controller{
+		Settings:   newValidTestSettings(),
 		TaxonomyDB: taxonomyDB,
 	}
 
@@ -124,6 +125,7 @@ func TestGetFamilySpecies(t *testing.T) {
 	require.NoError(t, err, "Failed to load taxonomy database")
 
 	c := &Controller{
+		Settings:   newValidTestSettings(),
 		TaxonomyDB: taxonomyDB,
 	}
 
@@ -204,6 +206,7 @@ func TestGetSpeciesTree(t *testing.T) {
 	require.NoError(t, err, "Failed to load taxonomy database")
 
 	c := &Controller{
+		Settings:   newValidTestSettings(),
 		TaxonomyDB: taxonomyDB,
 	}
 
@@ -308,6 +311,7 @@ func TestGetSpeciesTaxonomyLocalDB(t *testing.T) {
 	require.NoError(t, err, "Failed to load taxonomy database")
 
 	c := &Controller{
+		Settings:   newValidTestSettings(),
 		TaxonomyDB: taxonomyDB,
 		// No EBirdClient - testing local DB only
 		EBirdClient: nil,
@@ -364,6 +368,7 @@ func TestGetSpeciesTaxonomyWithoutLocalDB(t *testing.T) {
 	t.Parallel()
 
 	c := &Controller{
+		Settings: newValidTestSettings(),
 		// No TaxonomyDB and no EBirdClient
 		TaxonomyDB:  nil,
 		EBirdClient: nil,

--- a/internal/api/v2/weather_test.go
+++ b/internal/api/v2/weather_test.go
@@ -119,8 +119,9 @@ func setupWeatherTestEnvironment(t *testing.T) (*echo.Echo, *mocks.MockInterface
 
 	// Create a controller with the test datastore
 	controller := &Controller{
-		Group: e.Group("/api/v2"),
-		DS:    mockDS,
+		Settings: newValidTestSettings(),
+		Group:    e.Group("/api/v2"),
+		DS:       mockDS,
 	}
 
 	// We don't need to initialize routes for unit tests


### PR DESCRIPTION
## Summary

Replace bare `&Controller{}` with `&Controller{Settings: newValidTestSettings()}` in all API v2 test files that construct controllers without settings. This prevents nil-pointer panics if any handler under test later accesses `c.Settings`.

Extends the pattern from PR #2608 to 10 test files: audio_level_test, audio_level_write_deadline_test, audio_hls_test, events_test, notifications_ntfy_check_test, ntfy_integration_test, notifications_new_species_test, prerequisites_test, species_taxonomy_test, weather_test.

## Test Plan
- [x] `golangci-lint run -v ./internal/api/v2/...` — 0 issues
- [x] All affected tests pass with `-race` flag