### PR TITLE
feat: add species guide provider with Wikipedia/eBird support

### DIFF
--- a/internal/analysis/realtime.go
+++ b/internal/analysis/realtime.go
@@ -29,7 +29,9 @@ import (
 	"github.com/tphakala/birdnet-go/internal/datastore/v2only"
 	"github.com/tphakala/birdnet-go/internal/detection"
 	"github.com/tphakala/birdnet-go/internal/diskmanager"
+	"github.com/tphakala/birdnet-go/internal/ebird"
 	"github.com/tphakala/birdnet-go/internal/errors"
+	"github.com/tphakala/birdnet-go/internal/guideprovider"
 	"github.com/tphakala/birdnet-go/internal/imageprovider"
 	"github.com/tphakala/birdnet-go/internal/logger"
 	"github.com/tphakala/birdnet-go/internal/monitor"
@@ -353,6 +355,12 @@ func realtimeAnalysisInternal(settings *conf.Settings, quitChan chan struct{}) e
 	// Initialize bird image cache if needed
 	birdImageCache := initializeBirdImageCacheIfNeeded(settings, dataStore, metrics)
 
+	// Initialize species guide cache if enabled
+	guideCache := initializeGuideCacheIfNeeded(settings, dataStore)
+	if guideCache != nil {
+		defer guideCache.Close()
+	}
+
 	// Initialize processor with analysis logger for hierarchical logging
 	proc := processor.New(settings, dataStore, bn, metrics, birdImageCache, GetLogger())
 
@@ -418,6 +426,7 @@ func realtimeAnalysisInternal(settings *conf.Settings, quitChan chan struct{}) e
 		settings,
 		api.WithDataStore(dataStore),
 		api.WithBirdImageCache(birdImageCache),
+		api.WithGuideCache(guideCache),
 		api.WithProcessor(proc),
 		api.WithMetrics(metrics),
 		api.WithControlChannel(controlChan),
@@ -1729,6 +1738,56 @@ func initializeBirdImageCacheIfNeeded(settings *conf.Settings, dataStore datasto
 	// even when thumbnails are disabled - the cache will just not be used for actual image fetching
 	GetLogger().Debug("initializing bird image cache for settings UI (thumbnails disabled)")
 	return initBirdImageCache(dataStore, metrics)
+}
+
+// initializeGuideCacheIfNeeded initializes the species guide cache if the feature is enabled.
+func initializeGuideCacheIfNeeded(settings *conf.Settings, dataStore datastore.Interface) *guideprovider.GuideCache {
+	if !settings.Realtime.Dashboard.SpeciesGuide.Enabled {
+		GetLogger().Debug("species guide feature disabled, skipping guide cache initialization")
+		return nil
+	}
+
+	log := GetLogger()
+
+	// Get the GORM DB from the datastore for the guide cache store
+	ds, ok := dataStore.(*datastore.DataStore)
+	if !ok {
+		log.Warn("cannot initialize guide cache: datastore is not a *DataStore")
+		return nil
+	}
+
+	store, err := guideprovider.NewGORMGuideStore(ds.DB)
+	if err != nil {
+		log.Error("failed to initialize guide cache store", logger.Any("error", err))
+		return nil
+	}
+
+	cache := guideprovider.NewGuideCache(store)
+
+	// Register Wikipedia provider (always available, no API key needed)
+	wikiProvider := guideprovider.NewWikipediaGuideProvider()
+	cache.RegisterProvider(guideprovider.WikipediaProviderName, wikiProvider)
+
+	// Register eBird provider if API key is configured
+	if settings.Realtime.EBird.Enabled && settings.Realtime.EBird.APIKey != "" {
+		ebirdClient, clientErr := ebird.NewClient(ebird.Config{
+			APIKey: settings.Realtime.EBird.APIKey,
+		})
+		if clientErr == nil {
+			ebirdProvider, provErr := guideprovider.NewEBirdGuideProvider(ebirdClient)
+			if provErr == nil {
+				cache.RegisterProvider(guideprovider.EBirdProviderName, ebirdProvider)
+				log.Info("registered eBird guide provider")
+			}
+		}
+	}
+
+	cache.Start()
+	log.Info("species guide cache initialized",
+		logger.String("provider", settings.Realtime.Dashboard.SpeciesGuide.Provider),
+		logger.String("fallback_policy", settings.Realtime.Dashboard.SpeciesGuide.FallbackPolicy))
+
+	return cache
 }
 
 // initializeAudioSources prepares and validates audio sources

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -24,6 +24,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/datastore"
 	datastoreV2 "github.com/tphakala/birdnet-go/internal/datastore/v2"
 	"github.com/tphakala/birdnet-go/internal/errors"
+	"github.com/tphakala/birdnet-go/internal/guideprovider"
 	"github.com/tphakala/birdnet-go/internal/imageprovider"
 	"github.com/tphakala/birdnet-go/internal/logger"
 	"github.com/tphakala/birdnet-go/internal/myaudio"
@@ -53,6 +54,7 @@ type Server struct {
 	dataStore      datastore.Interface
 	v2Manager      datastoreV2.Manager
 	birdImageCache *imageprovider.BirdImageCache
+	guideCache     *guideprovider.GuideCache
 	sunCalc        *suncalc.SunCalc
 	processor      *processor.Processor
 	oauth2Server   *security.OAuth2Server
@@ -115,6 +117,13 @@ func WithDataStore(ds datastore.Interface) ServerOption {
 func WithBirdImageCache(cache *imageprovider.BirdImageCache) ServerOption {
 	return func(s *Server) {
 		s.birdImageCache = cache
+	}
+}
+
+// WithGuideCache sets the species guide cache for the server.
+func WithGuideCache(gc *guideprovider.GuideCache) ServerOption {
+	return func(s *Server) {
+		s.guideCache = gc
 	}
 }
 
@@ -323,6 +332,7 @@ func (s *Server) setupRoutes() error {
 		apiv2.WithAuthMiddleware(s.authMiddleware),
 		apiv2.WithAuthService(s.authService),
 		apiv2.WithV2Manager(s.v2Manager),
+		apiv2.WithGuideCache(s.guideCache),
 		apiv2.WithMetricsStore(observability.NewMemoryStore(apiv2.MetricsHistoryMaxPoints)),
 	)
 	if err != nil {

--- a/internal/api/v2/README.md
+++ b/internal/api/v2/README.md
@@ -216,6 +216,7 @@ Lightweight connectivity check. Returns a minimal response with no database quer
 | GET    | `/species/all`             | `GetAllSpecies`       | ❌   | Get all BirdNET species labels (not filtered by location)         |
 | GET    | `/species/taxonomy`        | `GetSpeciesTaxonomy`  | ❌   | Get detailed taxonomy data with subspecies and hierarchy          |
 | GET    | `/species/:code/thumbnail` | `GetSpeciesThumbnail` | ❌   | Get bird thumbnail image by species code (redirects to image URL) |
+| GET    | `/species/:scientific_name/guide` | `GetSpeciesGuide` | ❌   | Get species guide text (description, conservation status, attribution) |
 
 ### Server-Sent Events (`sse.go`)
 

--- a/internal/api/v2/api.go
+++ b/internal/api/v2/api.go
@@ -23,6 +23,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/birdnet"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/datastore"
+	"github.com/tphakala/birdnet-go/internal/guideprovider"
 	datastoreV2 "github.com/tphakala/birdnet-go/internal/datastore/v2"
 	"github.com/tphakala/birdnet-go/internal/datastore/v2/repository"
 	"github.com/tphakala/birdnet-go/internal/ebird"
@@ -47,6 +48,7 @@ type Controller struct {
 	Repo                datastore.DetectionRepository // New: Preferred for detection CRUD operations
 	Settings            *conf.Settings
 	BirdImageCache      *imageprovider.BirdImageCache
+	GuideCache          *guideprovider.GuideCache
 	SunCalc             *suncalc.SunCalc
 	Processor           *processor.Processor
 	EBirdClient         *ebird.Client
@@ -147,6 +149,13 @@ func WithAuthService(svc auth.Service) Option {
 func WithMetricsStore(store observability.MetricsStore) Option {
 	return func(c *Controller) {
 		c.metricsStore = store
+	}
+}
+
+// WithGuideCache sets the species guide cache for the controller.
+func WithGuideCache(gc *guideprovider.GuideCache) Option {
+	return func(c *Controller) {
+		c.GuideCache = gc
 	}
 }
 

--- a/internal/api/v2/species.go
+++ b/internal/api/v2/species.go
@@ -4,6 +4,7 @@ package api
 import (
 	"context"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -12,6 +13,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/detection"
 	"github.com/tphakala/birdnet-go/internal/ebird"
 	"github.com/tphakala/birdnet-go/internal/errors"
+	"github.com/tphakala/birdnet-go/internal/guideprovider"
 	"github.com/tphakala/birdnet-go/internal/logger"
 )
 
@@ -96,6 +98,9 @@ func (c *Controller) initSpeciesRoutes() {
 
 	// RESTful thumbnail endpoint - uses species code from path
 	c.Group.GET("/species/:code/thumbnail", c.GetSpeciesThumbnail)
+
+	// Species guide endpoint
+	c.Group.GET("/species/:scientific_name/guide", c.GetSpeciesGuide)
 
 	// New taxonomy endpoints using local database
 	c.Group.GET("/taxonomy/genus/:genus", c.GetGenusSpecies)
@@ -627,4 +632,99 @@ func (c *Controller) GetSpeciesThumbnail(ctx echo.Context) error {
 	ctx.SetParamNames("scientific_name")
 	ctx.SetParamValues(scientificName)
 	return c.ServeSpeciesImageProxy(ctx)
+}
+
+// SpeciesGuideResponse represents the API response for a species guide.
+type SpeciesGuideResponse struct {
+	ScientificName     string                `json:"scientific_name"`
+	CommonName         string                `json:"common_name"`
+	Description        string                `json:"description"`
+	ConservationStatus string                `json:"conservation_status"`
+	Source             SpeciesGuideSource    `json:"source"`
+	Partial            bool                  `json:"partial"`
+	CachedAt           time.Time             `json:"cached_at"`
+}
+
+// SpeciesGuideSource represents the attribution for the guide data.
+type SpeciesGuideSource struct {
+	Provider   string `json:"provider"`
+	URL        string `json:"url"`
+	License    string `json:"license"`
+	LicenseURL string `json:"license_url"`
+}
+
+// GetSpeciesGuide retrieves guide text for a species.
+// @Summary Get species guide information
+// @Description Returns textual guide information (description, conservation status) for a species
+// @Tags species
+// @Produce json
+// @Param scientific_name path string true "Scientific name (URL-encoded)"
+// @Success 200 {object} SpeciesGuideResponse
+// @Failure 400 {object} ErrorResponse
+// @Failure 404 {object} ErrorResponse
+// @Failure 503 {object} ErrorResponse
+// @Router /api/v2/species/{scientific_name}/guide [get]
+func (c *Controller) GetSpeciesGuide(ctx echo.Context) error {
+	// Check if guide feature is enabled
+	if !c.Settings.Realtime.Dashboard.SpeciesGuide.Enabled {
+		return c.HandleError(ctx, errors.Newf("species guide feature is disabled").
+			Category(errors.CategoryConfiguration).
+			Component("api-species").
+			Build(), "Species guide feature is disabled", http.StatusNotFound)
+	}
+
+	// Check if guide cache is available
+	if c.GuideCache == nil {
+		return c.HandleError(ctx, errors.Newf("species guide not available").
+			Category(errors.CategoryConfiguration).
+			Component("api-species").
+			Build(), "Species guide service not available", http.StatusServiceUnavailable)
+	}
+
+	// Get and validate scientific name from path parameter
+	rawName := ctx.Param("scientific_name")
+	scientificName, err := url.PathUnescape(rawName)
+	if err != nil {
+		return c.HandleError(ctx, errors.Newf("invalid scientific name encoding").
+			Category(errors.CategoryValidation).
+			Component("api-species").
+			Build(), "Invalid scientific name", http.StatusBadRequest)
+	}
+
+	scientificName = strings.TrimSpace(scientificName)
+	if scientificName == "" {
+		return c.HandleError(ctx, errors.Newf("scientific_name parameter is required").
+			Category(errors.CategoryValidation).
+			Component("api-species").
+			Build(), "Missing required parameter", http.StatusBadRequest)
+	}
+
+	// Fetch guide from cache (memory → DB → providers)
+	guide, err := c.GuideCache.Get(ctx.Request().Context(), scientificName)
+	if err != nil {
+		if errors.Is(err, guideprovider.ErrGuideNotFound) {
+			return c.HandleError(ctx, err, "Species guide not found", http.StatusNotFound)
+		}
+		if errors.Is(err, guideprovider.ErrAllProvidersUnavailable) {
+			return c.HandleError(ctx, err, "Guide service temporarily unavailable", http.StatusServiceUnavailable)
+		}
+		return c.HandleError(ctx, err, "Failed to retrieve species guide", http.StatusInternalServerError)
+	}
+
+	response := SpeciesGuideResponse{
+		ScientificName:     guide.ScientificName,
+		CommonName:         guide.CommonName,
+		Description:        guide.Description,
+		ConservationStatus: guide.ConservationStatus,
+		Source: SpeciesGuideSource{
+			Provider:   guide.SourceProvider,
+			URL:        guide.SourceURL,
+			License:    guide.LicenseName,
+			LicenseURL: guide.LicenseURL,
+		},
+		Partial:  guide.Partial,
+		CachedAt: guide.CachedAt,
+	}
+
+	return ctx.JSON(http.StatusOK, response)
 }

--- a/internal/api/v2/species_test.go
+++ b/internal/api/v2/species_test.go
@@ -3,6 +3,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -12,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/guideprovider"
 )
 
 // TestCalculateRarityStatus tests the calculateRarityStatus helper function.
@@ -411,6 +413,132 @@ func TestTaxonomyInfoJSONSerialization(t *testing.T) {
 	subspecies, ok := parsed["subspecies"].([]any)
 	require.True(t, ok)
 	assert.Len(t, subspecies, 1)
+}
+
+// TestGetSpeciesGuide tests the GetSpeciesGuide endpoint.
+func TestGetSpeciesGuide(t *testing.T) {
+	t.Parallel()
+	t.Attr("component", "species")
+	t.Attr("type", "unit")
+	t.Attr("feature", "species-guide")
+
+	tests := []struct {
+		name           string
+		scientificName string
+		setupCtrl      func(*Controller)
+		expectedStatus int
+		expectedBody   string
+	}{
+		{
+			name:           "feature disabled",
+			scientificName: "Turdus merula",
+			setupCtrl: func(c *Controller) {
+				c.Settings = &conf.Settings{}
+				c.Settings.Realtime.Dashboard.SpeciesGuide.Enabled = false
+			},
+			expectedStatus: http.StatusNotFound,
+			expectedBody:   "Species guide feature is disabled",
+		},
+		{
+			name:           "nil guide cache",
+			scientificName: "Turdus merula",
+			setupCtrl: func(c *Controller) {
+				c.Settings = &conf.Settings{}
+				c.Settings.Realtime.Dashboard.SpeciesGuide.Enabled = true
+				c.GuideCache = nil
+			},
+			expectedStatus: http.StatusServiceUnavailable,
+			expectedBody:   "Species guide service not available",
+		},
+		{
+			name:           "empty scientific name",
+			scientificName: "",
+			setupCtrl: func(c *Controller) {
+				c.Settings = &conf.Settings{}
+				c.Settings.Realtime.Dashboard.SpeciesGuide.Enabled = true
+				c.GuideCache = guideprovider.NewGuideCache(nil)
+			},
+			expectedStatus: http.StatusBadRequest,
+			expectedBody:   "Missing required parameter",
+		},
+		{
+			name:           "species not found returns 404",
+			scientificName: "Nonexistent species",
+			setupCtrl: func(c *Controller) {
+				c.Settings = &conf.Settings{}
+				c.Settings.Realtime.Dashboard.SpeciesGuide.Enabled = true
+				c.Settings.Realtime.Dashboard.SpeciesGuide.Provider = guideprovider.WikipediaProviderName
+				c.Settings.Realtime.Dashboard.SpeciesGuide.FallbackPolicy = "none"
+				cache := guideprovider.NewGuideCache(nil)
+				// Register a provider that always returns not found
+				cache.RegisterProvider(guideprovider.WikipediaProviderName, &stubGuideProvider{
+					err: guideprovider.ErrGuideNotFound,
+				})
+				c.GuideCache = cache
+			},
+			expectedStatus: http.StatusNotFound,
+			expectedBody:   "Species guide not found",
+		},
+		{
+			name:           "success returns guide data",
+			scientificName: "Turdus merula",
+			setupCtrl: func(c *Controller) {
+				c.Settings = &conf.Settings{}
+				c.Settings.Realtime.Dashboard.SpeciesGuide.Enabled = true
+				c.Settings.Realtime.Dashboard.SpeciesGuide.Provider = guideprovider.WikipediaProviderName
+				c.Settings.Realtime.Dashboard.SpeciesGuide.FallbackPolicy = "none"
+				cache := guideprovider.NewGuideCache(nil)
+				cache.RegisterProvider(guideprovider.WikipediaProviderName, &stubGuideProvider{
+					guide: guideprovider.SpeciesGuide{
+						ScientificName: "Turdus merula",
+						CommonName:     "Common Blackbird",
+						Description:    "A species of true thrush.",
+						SourceProvider: guideprovider.WikipediaProviderName,
+						SourceURL:      "https://en.wikipedia.org/wiki/Common_blackbird",
+						LicenseName:    "CC BY-SA 4.0",
+						LicenseURL:     "https://creativecommons.org/licenses/by-sa/4.0/",
+						Partial:        true,
+					},
+				})
+				c.GuideCache = cache
+			},
+			expectedStatus: http.StatusOK,
+			expectedBody:   "Common Blackbird",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodGet, "/api/v2/species/"+tt.scientificName+"/guide", http.NoBody)
+			rec := httptest.NewRecorder()
+			ctx := e.NewContext(req, rec)
+			ctx.SetParamNames("scientific_name")
+			ctx.SetParamValues(tt.scientificName)
+
+			c := &Controller{Echo: e, Group: e.Group("/api/v2")}
+			tt.setupCtrl(c)
+
+			err := c.GetSpeciesGuide(ctx)
+			require.NoError(t, err, tt.name)
+			assert.Equal(t, tt.expectedStatus, rec.Code, tt.name)
+			assert.Contains(t, rec.Body.String(), tt.expectedBody, tt.name)
+		})
+	}
+}
+
+// stubGuideProvider is a test double for guideprovider.GuideProvider.
+type stubGuideProvider struct {
+	guide guideprovider.SpeciesGuide
+	err   error
+}
+
+func (s *stubGuideProvider) Fetch(_ context.Context, _ string) (guideprovider.SpeciesGuide, error) {
+	if s.err != nil {
+		return guideprovider.SpeciesGuide{}, s.err
+	}
+	return s.guide, nil
 }
 
 // TestGetAllSpecies tests the GetAllSpecies endpoint returns all BirdNET labels.

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -137,9 +137,17 @@ type CustomColors struct {
 	Accent  string `yaml:"accent,omitempty" json:"accent,omitempty"`   // accent hex color, e.g. "#0284c7"
 }
 
+// SpeciesGuideConfig holds configuration for the species guide provider.
+type SpeciesGuideConfig struct {
+	Enabled        bool   `yaml:"enabled" json:"enabled"`               // enable species guide feature
+	Provider       string `yaml:"provider" json:"provider"`             // preferred provider: "wikipedia", "auto"
+	FallbackPolicy string `yaml:"fallbackpolicy" json:"fallbackPolicy"` // fallback policy: "none", "all"
+}
+
 // Dashboard contains settings for the web dashboard.
 type Dashboard struct {
 	Thumbnails       Thumbnails           `yaml:"thumbnails" json:"thumbnails"`                         // thumbnails settings
+	SpeciesGuide     SpeciesGuideConfig   `yaml:"speciesguide" json:"speciesGuide"`                     // species guide provider settings
 	SummaryLimit     int                  `yaml:"summarylimit" json:"summaryLimit"`                     // limit for the number of species shown in the summary table
 	Locale           string               `yaml:"locale,omitempty" json:"locale,omitempty"`             // UI locale setting
 	Spectrogram      SpectrogramPreRender `yaml:"spectrogram" json:"spectrogram"`                       // Spectrogram pre-rendering settings
@@ -2232,6 +2240,13 @@ func (b *SettingsBuilder) WithRTSPHealthThreshold(seconds int) *SettingsBuilder 
 func (b *SettingsBuilder) WithImageProvider(provider, fallbackPolicy string) *SettingsBuilder {
 	b.settings.Realtime.Dashboard.Thumbnails.ImageProvider = provider
 	b.settings.Realtime.Dashboard.Thumbnails.FallbackPolicy = fallbackPolicy
+	return b
+}
+
+// WithSpeciesGuideProvider configures species guide provider settings.
+func (b *SettingsBuilder) WithSpeciesGuideProvider(provider, fallbackPolicy string) *SettingsBuilder {
+	b.settings.Realtime.Dashboard.SpeciesGuide.Provider = provider
+	b.settings.Realtime.Dashboard.SpeciesGuide.FallbackPolicy = fallbackPolicy
 	return b
 }
 

--- a/internal/conf/config.yaml
+++ b/internal/conf/config.yaml
@@ -220,7 +220,12 @@ realtime:
       recent: true        # show thumbnails on recent table
       imageprovider: avicommons # preferred image provider: avicommons, wikimedia, auto
       fallbackpolicy: none # fallback policy: none (no fallback), all (try all available providers)
- 
+
+    speciesguide:
+      enabled: true       # true to enable species guide text (description, attribution)
+      provider: wikipedia # preferred guide provider: wikipedia, auto
+      fallbackpolicy: all # fallback policy: none (primary only), all (try all providers)
+
   dynamicthreshold:
     enabled: true         # true to enable dynamic confidence threshold
     trigger: 0.90         # dynamic threshold is activated on detections at this confidence level

--- a/internal/conf/defaults.go
+++ b/internal/conf/defaults.go
@@ -140,6 +140,11 @@ func setDefaultConfig() {
 	viper.SetDefault("realtime.dashboard.thumbnails.recent", true)
 	viper.SetDefault("realtime.dashboard.thumbnails.imageprovider", "avicommons")
 	viper.SetDefault("realtime.dashboard.thumbnails.fallbackpolicy", "none")
+	// Species guide provider configuration
+	viper.SetDefault("realtime.dashboard.speciesguide.enabled", true)
+	viper.SetDefault("realtime.dashboard.speciesguide.provider", "wikipedia")
+	viper.SetDefault("realtime.dashboard.speciesguide.fallbackpolicy", "all")
+
 	viper.SetDefault("realtime.dashboard.summarylimit", 30)
 	viper.SetDefault("realtime.dashboard.locale", "en")               // Default UI locale
 	viper.SetDefault("realtime.dashboard.temperatureunit", "celsius") // Temperature display unit: "celsius" or "fahrenheit"

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -396,6 +396,7 @@ func init() {
 	RegisterComponent("ffmpeg-stream", "ffmpeg-stream")
 	RegisterComponent("datastore", "datastore")
 	RegisterComponent("imageprovider", "imageprovider")
+	RegisterComponent("guideprovider", "guideprovider")
 	RegisterComponent("diskmanager", "diskmanager")
 	RegisterComponent("ebird", "ebird")
 	RegisterComponent("mqtt", "mqtt")

--- a/internal/guideprovider/ebird.go
+++ b/internal/guideprovider/ebird.go
@@ -1,0 +1,65 @@
+package guideprovider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/tphakala/birdnet-go/internal/ebird"
+	"github.com/tphakala/birdnet-go/internal/errors"
+	"github.com/tphakala/birdnet-go/internal/logger"
+)
+
+// EBirdGuideProvider enriches species guide data using the eBird API.
+// It wraps the existing ebird.Client and provides taxonomy-based enrichment.
+type EBirdGuideProvider struct {
+	client *ebird.Client
+}
+
+// NewEBirdGuideProvider creates a new EBirdGuideProvider wrapping the given client.
+// Returns ErrProviderNotConfigured if the client is nil.
+func NewEBirdGuideProvider(client *ebird.Client) (*EBirdGuideProvider, error) {
+	if client == nil {
+		return nil, ErrProviderNotConfigured
+	}
+	return &EBirdGuideProvider{client: client}, nil
+}
+
+// Fetch retrieves species guide information from the eBird taxonomy API.
+// This provider only supplies taxonomy metadata (common name, extinction status).
+// It does not provide descriptions.
+func (p *EBirdGuideProvider) Fetch(ctx context.Context, scientificName string) (SpeciesGuide, error) {
+	log := GetLogger()
+
+	// Get taxonomy data
+	taxonomy, err := p.client.GetTaxonomy(ctx, "en")
+	if err != nil {
+		log.Debug("eBird taxonomy lookup failed",
+			logger.String("species", scientificName),
+			logger.Any("error", err))
+		return SpeciesGuide{}, errors.Newf("eBird taxonomy lookup: %w", err).
+			Component("guideprovider").
+			Category(errors.CategoryNetwork).
+			Build()
+	}
+
+	// Search for the species in the taxonomy
+	for _, entry := range taxonomy {
+		if entry.ScientificName == scientificName {
+			guide := SpeciesGuide{
+				ScientificName: scientificName,
+				CommonName:     entry.CommonName,
+				SourceProvider: EBirdProviderName,
+				Partial:        true, // eBird provides no descriptions
+			}
+
+			// Set conservation status for extinct species
+			if entry.Extinct {
+				guide.ConservationStatus = fmt.Sprintf("Extinct (%d)", entry.ExtinctYear)
+			}
+
+			return guide, nil
+		}
+	}
+
+	return SpeciesGuide{}, ErrGuideNotFound
+}

--- a/internal/guideprovider/guideprovider.go
+++ b/internal/guideprovider/guideprovider.go
@@ -1,0 +1,501 @@
+// Package guideprovider provides functionality for fetching and caching species guide text.
+package guideprovider
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/errors"
+	"github.com/tphakala/birdnet-go/internal/logger"
+	"golang.org/x/sync/singleflight"
+)
+
+// Provider name constants.
+const (
+	WikipediaProviderName = "wikipedia" // Wikipedia REST API provider
+	EBirdProviderName     = "ebird"     // eBird taxonomy enrichment provider
+)
+
+// Sentinel errors for guide operations.
+var (
+	// ErrGuideNotFound indicates the provider could not find guide data for the species.
+	ErrGuideNotFound = errors.Newf("species guide not found").
+				Component("guideprovider").
+				Category(errors.CategoryNotFound).
+				Context("error_type", "not_found").
+				Build()
+
+	// ErrProviderNotConfigured indicates the provider is disabled or missing credentials.
+	ErrProviderNotConfigured = errors.Newf("guide provider not configured").
+					Component("guideprovider").
+					Category(errors.CategoryConfiguration).
+					Context("error_type", "provider_not_configured").
+					Build()
+
+	// ErrAllProvidersUnavailable indicates all providers failed (circuit breakers open).
+	ErrAllProvidersUnavailable = errors.Newf("all guide providers unavailable").
+					Component("guideprovider").
+					Category(errors.CategoryNetwork).
+					Context("error_type", "all_unavailable").
+					Build()
+)
+
+const (
+	defaultCacheTTL     = 7 * 24 * time.Hour // 7 days for positive entries
+	negativeCacheTTL    = 30 * time.Minute   // 30 minutes for negative entries
+	refreshInterval     = 2 * time.Hour      // Check for stale entries every 2 hours
+	refreshBatchSize    = 10                 // Number of entries to refresh in one batch
+	refreshDelay        = 2 * time.Second    // Delay between refreshing individual entries
+	negativeEntryMarker = "__NOT_FOUND__"    // Sentinel marker for negative cache entries
+
+	fallbackPolicyAll = "all" // Fallback policy to try all providers
+
+	providerTimeout = 10 * time.Second // Per-provider fetch timeout
+
+	maxDescriptionLength = 2000 // Maximum description length to cache
+)
+
+// defaultProviderName is the provider used when settings are unavailable.
+const defaultProviderName = WikipediaProviderName
+
+// defaultFallbackOrder defines providers to try in order.
+var defaultFallbackOrder = []string{WikipediaProviderName, EBirdProviderName}
+
+// GetLogger returns the package logger for the guideprovider module.
+func GetLogger() logger.Logger {
+	return logger.Global().Module("guideprovider")
+}
+
+// SpeciesGuide represents cached species guide text with metadata and attribution.
+type SpeciesGuide struct {
+	ScientificName     string    // Lookup key, e.g. "Turdus merula"
+	CommonName         string    // e.g. "Common Blackbird"
+	Description        string    // Wikipedia extract (plain text)
+	ConservationStatus string    // e.g. "Least Concern" (if available)
+	SourceProvider     string    // Which provider supplied this data
+	SourceURL          string    // Attribution link
+	LicenseName        string    // e.g. "CC BY-SA 4.0"
+	LicenseURL         string    // URL to the license text
+	CachedAt           time.Time // When this entry was cached
+	Partial            bool      // True if only some fields populated
+}
+
+// IsNegativeEntry checks if this is a negative cache entry (not found).
+func (g *SpeciesGuide) IsNegativeEntry() bool {
+	return g.SourceProvider == negativeEntryMarker
+}
+
+// GuideProvider defines the interface for fetching species guide text.
+type GuideProvider interface {
+	// Fetch retrieves guide information for a species by scientific name.
+	// Returns a partial SpeciesGuide if some fields are unavailable.
+	// Returns ErrGuideNotFound if the species cannot be found at all.
+	Fetch(ctx context.Context, scientificName string) (SpeciesGuide, error)
+}
+
+// GuideStore defines the datastore interface needed by the guide cache.
+type GuideStore interface {
+	GetGuideCache(ctx context.Context, scientificName, providerName string) (*GuideCacheEntry, error)
+	SaveGuideCache(ctx context.Context, entry *GuideCacheEntry) error
+	GetAllGuideCaches(ctx context.Context, providerName string) ([]GuideCacheEntry, error)
+}
+
+// GuideCacheEntry represents a guide cache entry in the database.
+type GuideCacheEntry struct {
+	ID                 uint      `gorm:"primaryKey"`
+	ProviderName       string    `gorm:"uniqueIndex:idx_guidecache_provider_species;size:50;not null;default:wikipedia"`
+	ScientificName     string    `gorm:"uniqueIndex:idx_guidecache_provider_species;not null"`
+	SourceProvider     string    `gorm:"size:50;not null;default:wikipedia"`
+	CommonName         string    `gorm:"size:200"`
+	Description        string    `gorm:"type:text"`
+	ConservationStatus string    `gorm:"size:100"`
+	SourceURL          string    `gorm:"size:2048"`
+	LicenseName        string    `gorm:"size:200"`
+	LicenseURL         string    `gorm:"size:2048"`
+	CachedAt           time.Time `gorm:"index"`
+}
+
+// TableName returns the table name for GORM.
+func (GuideCacheEntry) TableName() string {
+	return "guide_caches"
+}
+
+// GuideCache manages species guide data with a two-tier cache (memory + database).
+type GuideCache struct {
+	providers map[string]GuideProvider
+	dataMap   sync.Map
+	store     GuideStore
+	sfGroup   singleflight.Group
+	quit      chan struct{}
+	mu        sync.RWMutex // protects providers map
+}
+
+// NewGuideCache creates a new GuideCache with the given store.
+func NewGuideCache(store GuideStore) *GuideCache {
+	return &GuideCache{
+		providers: make(map[string]GuideProvider),
+		store:     store,
+		quit:      make(chan struct{}),
+	}
+}
+
+// RegisterProvider adds a named provider to the cache.
+func (c *GuideCache) RegisterProvider(name string, provider GuideProvider) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.providers[name] = provider
+}
+
+// Start begins the background cache refresh routine.
+func (c *GuideCache) Start() {
+	c.loadFromDB()
+	c.startCacheRefresh()
+}
+
+// Close stops background routines.
+func (c *GuideCache) Close() {
+	close(c.quit)
+}
+
+// Get retrieves a species guide, checking memory cache, DB cache, and providers.
+func (c *GuideCache) Get(ctx context.Context, scientificName string) (*SpeciesGuide, error) {
+	// Tier 1: Memory cache
+	if cached, ok := c.dataMap.Load(scientificName); ok {
+		guide := cached.(*SpeciesGuide)
+		if guide.IsNegativeEntry() {
+			if !isCacheEntryStale(guide.CachedAt, true) {
+				return nil, ErrGuideNotFound
+			}
+			// Stale negative entry, fall through to re-fetch
+		} else if !isCacheEntryStale(guide.CachedAt, false) {
+			return guide, nil
+		}
+		// Stale positive entry, fall through to re-fetch
+	}
+
+	// Tier 2: DB cache
+	if c.store != nil {
+		settings := conf.GetSettings()
+		providerName := defaultProviderName
+		if settings != nil {
+			providerName = settings.Realtime.Dashboard.SpeciesGuide.Provider
+		}
+		entry, err := c.store.GetGuideCache(ctx, scientificName, providerName)
+		if err == nil && entry != nil {
+			guide := dbEntryToGuide(entry)
+			if !isCacheEntryStale(guide.CachedAt, guide.IsNegativeEntry()) {
+				c.dataMap.Store(scientificName, guide)
+				if guide.IsNegativeEntry() {
+					return nil, ErrGuideNotFound
+				}
+				return guide, nil
+			}
+		}
+	}
+
+	// Tier 3: Fetch from providers (deduplicated)
+	result, err, _ := c.sfGroup.Do(scientificName, func() (any, error) {
+		return c.fetchFromProviders(ctx, scientificName)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	guide := result.(*SpeciesGuide)
+	return guide, nil
+}
+
+// fetchFromProviders fetches guide data from configured providers with fallback.
+func (c *GuideCache) fetchFromProviders(ctx context.Context, scientificName string) (*SpeciesGuide, error) {
+	log := GetLogger()
+	settings := conf.GetSettings()
+
+	primaryProvider := defaultProviderName
+	fallbackPolicy := fallbackPolicyAll
+	if settings != nil {
+		primaryProvider = settings.Realtime.Dashboard.SpeciesGuide.Provider
+		fallbackPolicy = settings.Realtime.Dashboard.SpeciesGuide.FallbackPolicy
+	}
+
+	c.mu.RLock()
+	provider, hasPrimary := c.providers[primaryProvider]
+	c.mu.RUnlock()
+
+	var primaryResult *SpeciesGuide
+
+	// Try primary provider
+	if hasPrimary {
+		providerCtx, cancel := context.WithTimeout(ctx, providerTimeout)
+		guide, err := provider.Fetch(providerCtx, scientificName)
+		cancel()
+
+		if err == nil {
+			primaryResult = &guide
+			log.Debug("Primary provider returned guide",
+				logger.String("provider", primaryProvider),
+				logger.String("species", scientificName),
+				logger.Bool("partial", guide.Partial))
+		} else if !errors.Is(err, ErrGuideNotFound) {
+			log.Warn("Primary provider failed",
+				logger.String("provider", primaryProvider),
+				logger.String("species", scientificName),
+				logger.Any("error", err))
+		}
+	}
+
+	// Try fallback providers if policy allows
+	if fallbackPolicy == fallbackPolicyAll {
+		c.mu.RLock()
+		providers := make(map[string]GuideProvider, len(c.providers))
+		for k, v := range c.providers {
+			providers[k] = v
+		}
+		c.mu.RUnlock()
+
+		for _, name := range defaultFallbackOrder {
+			if name == primaryProvider {
+				continue
+			}
+			fbProvider, ok := providers[name]
+			if !ok {
+				continue
+			}
+
+			providerCtx, cancel := context.WithTimeout(ctx, providerTimeout)
+			guide, err := fbProvider.Fetch(providerCtx, scientificName)
+			cancel()
+
+			if err != nil {
+				continue
+			}
+
+			if primaryResult == nil {
+				primaryResult = &guide
+			} else {
+				merged := mergeGuides(*primaryResult, guide)
+				primaryResult = &merged
+			}
+		}
+	}
+
+	// Cache the result
+	if primaryResult != nil {
+		primaryResult.CachedAt = time.Now()
+		c.dataMap.Store(scientificName, primaryResult)
+		c.saveToDB(primaryResult, primaryProvider)
+		return primaryResult, nil
+	}
+
+	// All providers failed: cache negative entry
+	negative := &SpeciesGuide{
+		ScientificName: scientificName,
+		SourceProvider: negativeEntryMarker,
+		CachedAt:       time.Now(),
+	}
+	c.dataMap.Store(scientificName, negative)
+	c.saveToDB(negative, primaryProvider)
+	return nil, ErrGuideNotFound
+}
+
+// mergeGuides merges two guide results, with primary taking precedence.
+func mergeGuides(primary, secondary SpeciesGuide) SpeciesGuide {
+	result := primary
+	if result.Description == "" {
+		result.Description = secondary.Description
+	}
+	if result.CommonName == "" {
+		result.CommonName = secondary.CommonName
+	}
+	if result.ConservationStatus == "" {
+		result.ConservationStatus = secondary.ConservationStatus
+	}
+	if result.SourceURL == "" {
+		result.SourceURL = secondary.SourceURL
+	}
+	result.Partial = result.Description == ""
+	return result
+}
+
+// isCacheEntryStale checks if a cache entry has exceeded its TTL.
+func isCacheEntryStale(cachedAt time.Time, isNegative bool) bool {
+	ttl := defaultCacheTTL
+	if isNegative {
+		ttl = negativeCacheTTL
+	}
+	return time.Now().After(cachedAt.Add(ttl))
+}
+
+// dbEntryToGuide converts a database cache entry to a SpeciesGuide.
+func dbEntryToGuide(entry *GuideCacheEntry) *SpeciesGuide {
+	return &SpeciesGuide{
+		ScientificName:     entry.ScientificName,
+		CommonName:         entry.CommonName,
+		Description:        entry.Description,
+		ConservationStatus: entry.ConservationStatus,
+		SourceProvider:     entry.SourceProvider,
+		SourceURL:          entry.SourceURL,
+		LicenseName:        entry.LicenseName,
+		LicenseURL:         entry.LicenseURL,
+		CachedAt:           entry.CachedAt,
+		Partial:            entry.Description == "",
+	}
+}
+
+// saveToDB persists a guide entry to the database.
+func (c *GuideCache) saveToDB(guide *SpeciesGuide, providerName string) {
+	if c.store == nil {
+		return
+	}
+
+	entry := &GuideCacheEntry{
+		ProviderName:       providerName,
+		ScientificName:     guide.ScientificName,
+		SourceProvider:     guide.SourceProvider,
+		CommonName:         guide.CommonName,
+		Description:        guide.Description,
+		ConservationStatus: guide.ConservationStatus,
+		SourceURL:          guide.SourceURL,
+		LicenseName:        guide.LicenseName,
+		LicenseURL:         guide.LicenseURL,
+		CachedAt:           guide.CachedAt,
+	}
+
+	if err := c.store.SaveGuideCache(context.Background(), entry); err != nil {
+		GetLogger().Warn("Failed to save guide cache to database",
+			logger.String("species", guide.ScientificName),
+			logger.Any("error", err))
+	}
+}
+
+// loadFromDB loads all cached entries from the database into memory.
+func (c *GuideCache) loadFromDB() {
+	if c.store == nil {
+		return
+	}
+
+	settings := conf.GetSettings()
+	providerName := defaultProviderName
+	if settings != nil {
+		providerName = settings.Realtime.Dashboard.SpeciesGuide.Provider
+	}
+
+	entries, err := c.store.GetAllGuideCaches(context.Background(), providerName)
+	if err != nil {
+		GetLogger().Warn("Failed to load guide caches from database",
+			logger.Any("error", err))
+		return
+	}
+
+	loaded := 0
+	for i := range entries {
+		guide := dbEntryToGuide(&entries[i])
+		c.dataMap.Store(entries[i].ScientificName, guide)
+		loaded++
+	}
+
+	GetLogger().Info("Loaded guide cache entries from database",
+		logger.Int("count", loaded))
+}
+
+// startCacheRefresh starts the background cache refresh routine.
+func (c *GuideCache) startCacheRefresh() {
+	log := GetLogger()
+	log.Info("Starting guide cache refresh routine",
+		logger.Duration("ttl", defaultCacheTTL),
+		logger.Duration("interval", refreshInterval))
+
+	go func() {
+		ticker := time.NewTicker(refreshInterval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-c.quit:
+				log.Info("Stopping guide cache refresh routine")
+				return
+			case <-ticker.C:
+				c.refreshStaleEntries()
+			}
+		}
+	}()
+}
+
+// refreshStaleEntries refreshes cache entries that have exceeded their TTL.
+func (c *GuideCache) refreshStaleEntries() {
+	if c.store == nil {
+		return
+	}
+
+	log := GetLogger()
+	settings := conf.GetSettings()
+	providerName := defaultProviderName
+	if settings != nil {
+		providerName = settings.Realtime.Dashboard.SpeciesGuide.Provider
+	}
+
+	entries, err := c.store.GetAllGuideCaches(context.Background(), providerName)
+	if err != nil {
+		log.Warn("Failed to get guide caches for refresh", logger.Any("error", err))
+		return
+	}
+
+	var staleEntries []string
+	for i := range entries {
+		isNegative := entries[i].SourceProvider == negativeEntryMarker
+		if isCacheEntryStale(entries[i].CachedAt, isNegative) {
+			staleEntries = append(staleEntries, entries[i].ScientificName)
+		}
+	}
+
+	if len(staleEntries) == 0 {
+		return
+	}
+
+	log.Info("Found stale guide cache entries to refresh",
+		logger.Int("count", len(staleEntries)))
+
+	ctx := context.Background()
+	refreshed := 0
+	for i, name := range staleEntries {
+		if c.shouldQuit() {
+			break
+		}
+		if i > 0 && i%refreshBatchSize == 0 {
+			if c.waitWithQuit(refreshDelay) {
+				break
+			}
+		}
+
+		if _, err := c.fetchFromProviders(ctx, name); err == nil {
+			refreshed++
+		}
+	}
+
+	log.Info("Finished refreshing stale guide entries",
+		logger.Int("refreshed", refreshed),
+		logger.Int("total", len(staleEntries)))
+}
+
+// shouldQuit checks if the cache's quit channel has been signaled.
+func (c *GuideCache) shouldQuit() bool {
+	select {
+	case <-c.quit:
+		return true
+	default:
+		return false
+	}
+}
+
+// waitWithQuit waits for the specified duration, returning true if quit was signaled.
+func (c *GuideCache) waitWithQuit(d time.Duration) bool {
+	timer := time.NewTimer(d)
+	select {
+	case <-c.quit:
+		timer.Stop()
+		return true
+	case <-timer.C:
+		return false
+	}
+}

--- a/internal/guideprovider/guideprovider_test.go
+++ b/internal/guideprovider/guideprovider_test.go
@@ -1,0 +1,311 @@
+package guideprovider
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockGuideProvider is a test double for GuideProvider.
+type mockGuideProvider struct {
+	fetchFunc func(ctx context.Context, scientificName string) (SpeciesGuide, error)
+}
+
+func (m *mockGuideProvider) Fetch(ctx context.Context, scientificName string) (SpeciesGuide, error) {
+	return m.fetchFunc(ctx, scientificName)
+}
+
+// mockGuideStore is an in-memory test double for GuideStore.
+type mockGuideStore struct {
+	entries map[string]*GuideCacheEntry
+}
+
+func newMockGuideStore() *mockGuideStore {
+	return &mockGuideStore{entries: make(map[string]*GuideCacheEntry)}
+}
+
+func (s *mockGuideStore) GetGuideCache(_ context.Context, scientificName, providerName string) (*GuideCacheEntry, error) {
+	key := providerName + ":" + scientificName
+	entry, ok := s.entries[key]
+	if !ok {
+		return nil, nil
+	}
+	return entry, nil
+}
+
+func (s *mockGuideStore) SaveGuideCache(_ context.Context, entry *GuideCacheEntry) error {
+	key := entry.ProviderName + ":" + entry.ScientificName
+	s.entries[key] = entry
+	return nil
+}
+
+func (s *mockGuideStore) GetAllGuideCaches(_ context.Context, providerName string) ([]GuideCacheEntry, error) {
+	var result []GuideCacheEntry
+	for _, entry := range s.entries {
+		if entry.ProviderName == providerName {
+			result = append(result, *entry)
+		}
+	}
+	return result, nil
+}
+
+func TestSpeciesGuide_IsNegativeEntry(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		guide    SpeciesGuide
+		expected bool
+	}{
+		{
+			name:     "positive entry",
+			guide:    SpeciesGuide{SourceProvider: WikipediaProviderName},
+			expected: false,
+		},
+		{
+			name:     "negative entry",
+			guide:    SpeciesGuide{SourceProvider: negativeEntryMarker},
+			expected: true,
+		},
+		{
+			name:     "empty provider",
+			guide:    SpeciesGuide{SourceProvider: ""},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expected, tt.guide.IsNegativeEntry())
+		})
+	}
+}
+
+func TestIsCacheEntryStale(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		cachedAt   time.Time
+		isNegative bool
+		expected   bool
+	}{
+		{
+			name:       "fresh positive entry",
+			cachedAt:   time.Now().Add(-1 * time.Hour),
+			isNegative: false,
+			expected:   false,
+		},
+		{
+			name:       "stale positive entry",
+			cachedAt:   time.Now().Add(-8 * 24 * time.Hour),
+			isNegative: false,
+			expected:   true,
+		},
+		{
+			name:       "fresh negative entry",
+			cachedAt:   time.Now().Add(-5 * time.Minute),
+			isNegative: true,
+			expected:   false,
+		},
+		{
+			name:       "stale negative entry",
+			cachedAt:   time.Now().Add(-31 * time.Minute),
+			isNegative: true,
+			expected:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expected, isCacheEntryStale(tt.cachedAt, tt.isNegative))
+		})
+	}
+}
+
+func TestMergeGuides(t *testing.T) {
+	t.Parallel()
+
+	primary := SpeciesGuide{
+		ScientificName: "Turdus merula",
+		CommonName:     "Common Blackbird",
+		Description:    "A species of true thrush.",
+		SourceProvider: WikipediaProviderName,
+	}
+
+	secondary := SpeciesGuide{
+		ScientificName:     "Turdus merula",
+		CommonName:         "Eurasian Blackbird",
+		ConservationStatus: "Least Concern",
+		SourceProvider:     EBirdProviderName,
+	}
+
+	result := mergeGuides(primary, secondary)
+
+	// Primary fields take precedence
+	assert.Equal(t, "Common Blackbird", result.CommonName)
+	assert.Equal(t, "A species of true thrush.", result.Description)
+
+	// Secondary fills gaps
+	assert.Equal(t, "Least Concern", result.ConservationStatus)
+
+	// Partial is false because description is populated
+	assert.False(t, result.Partial)
+}
+
+func TestMergeGuides_PrimaryEmpty(t *testing.T) {
+	t.Parallel()
+
+	primary := SpeciesGuide{
+		ScientificName: "Turdus merula",
+	}
+
+	secondary := SpeciesGuide{
+		ScientificName: "Turdus merula",
+		CommonName:     "Common Blackbird",
+		Description:    "A bird.",
+	}
+
+	result := mergeGuides(primary, secondary)
+	assert.Equal(t, "Common Blackbird", result.CommonName)
+	assert.Equal(t, "A bird.", result.Description)
+	assert.False(t, result.Partial)
+}
+
+func TestDbEntryToGuide(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	entry := &GuideCacheEntry{
+		ScientificName:     "Turdus merula",
+		CommonName:         "Common Blackbird",
+		Description:        "A species.",
+		ConservationStatus: "Least Concern",
+		SourceProvider:     WikipediaProviderName,
+		SourceURL:          "https://en.wikipedia.org/wiki/Common_blackbird",
+		LicenseName:        "CC BY-SA 4.0",
+		LicenseURL:         "https://creativecommons.org/licenses/by-sa/4.0/",
+		CachedAt:           now,
+	}
+
+	guide := dbEntryToGuide(entry)
+	assert.Equal(t, "Turdus merula", guide.ScientificName)
+	assert.Equal(t, "Common Blackbird", guide.CommonName)
+	assert.Equal(t, "A species.", guide.Description)
+	assert.Equal(t, WikipediaProviderName, guide.SourceProvider)
+	assert.Equal(t, now, guide.CachedAt)
+	assert.False(t, guide.Partial) // Description is non-empty
+}
+
+func TestGuideCache_GetFromMemory(t *testing.T) {
+	t.Parallel()
+
+	cache := NewGuideCache(nil)
+	defer cache.Close()
+
+	// Pre-populate memory cache
+	guide := &SpeciesGuide{
+		ScientificName: "Turdus merula",
+		CommonName:     "Common Blackbird",
+		Description:    "A species.",
+		SourceProvider: WikipediaProviderName,
+		CachedAt:       time.Now(),
+	}
+	cache.dataMap.Store("Turdus merula", guide)
+
+	result, err := cache.Get(context.Background(), "Turdus merula")
+	require.NoError(t, err)
+	assert.Equal(t, "Common Blackbird", result.CommonName)
+}
+
+func TestGuideCache_NegativeMemoryCacheHit(t *testing.T) {
+	t.Parallel()
+
+	cache := NewGuideCache(nil)
+	defer cache.Close()
+
+	// Pre-populate with negative entry
+	negative := &SpeciesGuide{
+		ScientificName: "Unknown species",
+		SourceProvider: negativeEntryMarker,
+		CachedAt:       time.Now(),
+	}
+	cache.dataMap.Store("Unknown species", negative)
+
+	_, err := cache.Get(context.Background(), "Unknown species")
+	assert.ErrorIs(t, err, ErrGuideNotFound)
+}
+
+func TestGuideCache_FetchFromProvider(t *testing.T) {
+	t.Parallel()
+
+	store := newMockGuideStore()
+	cache := NewGuideCache(store)
+	defer cache.Close()
+
+	provider := &mockGuideProvider{
+		fetchFunc: func(_ context.Context, scientificName string) (SpeciesGuide, error) {
+			if scientificName == "Turdus merula" {
+				return SpeciesGuide{
+					ScientificName: "Turdus merula",
+					CommonName:     "Common Blackbird",
+					Description:    "A species of true thrush.",
+					SourceProvider: WikipediaProviderName,
+				}, nil
+			}
+			return SpeciesGuide{}, ErrGuideNotFound
+		},
+	}
+	cache.RegisterProvider(WikipediaProviderName, provider)
+
+	// First fetch should go to the provider
+	result, err := cache.Get(context.Background(), "Turdus merula")
+	require.NoError(t, err)
+	assert.Equal(t, "Common Blackbird", result.CommonName)
+	assert.Equal(t, "A species of true thrush.", result.Description)
+
+	// Verify it was cached in memory
+	cached, ok := cache.dataMap.Load("Turdus merula")
+	assert.True(t, ok)
+	assert.Equal(t, "Common Blackbird", cached.(*SpeciesGuide).CommonName)
+
+	// Verify it was saved to the store
+	entry, err := store.GetGuideCache(context.Background(), "Turdus merula", WikipediaProviderName)
+	require.NoError(t, err)
+	require.NotNil(t, entry)
+	assert.Equal(t, "A species of true thrush.", entry.Description)
+}
+
+func TestGuideCache_ProviderNotFound(t *testing.T) {
+	t.Parallel()
+
+	store := newMockGuideStore()
+	cache := NewGuideCache(store)
+	defer cache.Close()
+
+	provider := &mockGuideProvider{
+		fetchFunc: func(_ context.Context, _ string) (SpeciesGuide, error) {
+			return SpeciesGuide{}, ErrGuideNotFound
+		},
+	}
+	cache.RegisterProvider(WikipediaProviderName, provider)
+
+	_, err := cache.Get(context.Background(), "Nonexistent species")
+	assert.ErrorIs(t, err, ErrGuideNotFound)
+
+	// Verify negative entry was cached
+	cached, ok := cache.dataMap.Load("Nonexistent species")
+	assert.True(t, ok)
+	assert.True(t, cached.(*SpeciesGuide).IsNegativeEntry())
+}
+
+func TestGuideCacheEntry_TableName(t *testing.T) {
+	t.Parallel()
+	entry := GuideCacheEntry{}
+	assert.Equal(t, "guide_caches", entry.TableName())
+}

--- a/internal/guideprovider/store.go
+++ b/internal/guideprovider/store.go
@@ -1,0 +1,74 @@
+package guideprovider
+
+import (
+	"context"
+
+	"github.com/tphakala/birdnet-go/internal/errors"
+	"github.com/tphakala/birdnet-go/internal/logger"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+	gormlogger "gorm.io/gorm/logger"
+)
+
+// GORMGuideStore implements GuideStore using a GORM database connection.
+type GORMGuideStore struct {
+	db *gorm.DB
+}
+
+// NewGORMGuideStore creates a new GORMGuideStore and runs auto-migration.
+func NewGORMGuideStore(db *gorm.DB) (*GORMGuideStore, error) {
+	if err := db.AutoMigrate(&GuideCacheEntry{}); err != nil {
+		return nil, errors.Newf("failed to migrate guide_caches table: %w", err).
+			Component("guideprovider").
+			Category(errors.CategoryDatabase).
+			Build()
+	}
+	return &GORMGuideStore{db: db}, nil
+}
+
+// GetGuideCache retrieves a guide cache entry by scientific name and provider.
+func (s *GORMGuideStore) GetGuideCache(ctx context.Context, scientificName, providerName string) (*GuideCacheEntry, error) {
+	var entry GuideCacheEntry
+	err := s.db.WithContext(ctx).
+		Session(&gorm.Session{Logger: gormlogger.Default.LogMode(gormlogger.Silent)}).
+		Where("scientific_name = ? AND provider_name = ?", scientificName, providerName).
+		First(&entry).Error
+
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &entry, nil
+}
+
+// SaveGuideCache saves or updates a guide cache entry (upsert).
+func (s *GORMGuideStore) SaveGuideCache(ctx context.Context, entry *GuideCacheEntry) error {
+	return s.db.WithContext(ctx).
+		Clauses(clause.OnConflict{
+			Columns:   []clause.Column{{Name: "provider_name"}, {Name: "scientific_name"}},
+			DoUpdates: clause.AssignmentColumns([]string{
+				"source_provider", "common_name", "description",
+				"conservation_status", "source_url", "license_name",
+				"license_url", "cached_at",
+			}),
+		}).
+		Create(entry).Error
+}
+
+// GetAllGuideCaches retrieves all guide cache entries for a specific provider.
+func (s *GORMGuideStore) GetAllGuideCaches(ctx context.Context, providerName string) ([]GuideCacheEntry, error) {
+	var entries []GuideCacheEntry
+	err := s.db.WithContext(ctx).
+		Session(&gorm.Session{Logger: gormlogger.Default.LogMode(gormlogger.Silent)}).
+		Where("provider_name = ?", providerName).
+		Find(&entries).Error
+	if err != nil {
+		GetLogger().Warn("Failed to query guide caches",
+			logger.String("provider", providerName),
+			logger.Any("error", err))
+		return nil, err
+	}
+	return entries, nil
+}

--- a/internal/guideprovider/wikipedia.go
+++ b/internal/guideprovider/wikipedia.go
@@ -1,0 +1,271 @@
+package guideprovider
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/tphakala/birdnet-go/internal/errors"
+	"github.com/tphakala/birdnet-go/internal/logger"
+	"golang.org/x/time/rate"
+)
+
+const (
+	wikipediaRESTBaseURL = "https://en.wikipedia.org/api/rest_v1/page/summary"
+
+	// User-Agent following Wikimedia policy
+	wikiUserAgent = "BirdNETGo/1.0 (https://github.com/tphakala/birdnet-go) Go-HTTP-Client"
+
+	// Circuit breaker durations
+	cbRateLimitDuration  = 60 * time.Second
+	cbBlockedDuration    = 5 * time.Minute
+	cbUnavailDuration    = 30 * time.Second
+	cbNetworkDuration    = 2 * time.Minute
+
+	// HTTP configuration
+	wikiHTTPTimeout     = 30 * time.Second
+	wikiIdleConnTimeout = 90 * time.Second
+
+	// Rate limiting
+	wikiRateLimitPerSec = 1
+
+	// Response limits
+	wikiMaxResponseBody = 512 * 1024 // 512KB max response body
+)
+
+// wikipediaSummaryResponse represents the Wikipedia REST API summary response.
+type wikipediaSummaryResponse struct {
+	Type        string `json:"type"`        // "standard", "disambiguation", "no-extract", etc.
+	Title       string `json:"title"`
+	DisplayName string `json:"displaytitle"`
+	Extract     string `json:"extract"`     // Plain text summary
+	Description string `json:"description"` // Short description
+	ContentURLs struct {
+		Desktop struct {
+			Page string `json:"page"`
+		} `json:"desktop"`
+	} `json:"content_urls"`
+}
+
+// WikipediaGuideProvider fetches species guide text from the Wikipedia REST API.
+type WikipediaGuideProvider struct {
+	httpClient *http.Client
+	limiter    *rate.Limiter
+
+	// Circuit breaker
+	circuitMu        sync.RWMutex
+	circuitOpenUntil time.Time
+	circuitFailures  int    // Number of consecutive failures
+	circuitLastError string // Last error message for logging
+
+	// testBaseURL overrides the Wikipedia API base URL for testing.
+	testBaseURL string
+}
+
+// NewWikipediaGuideProvider creates a new WikipediaGuideProvider.
+func NewWikipediaGuideProvider() *WikipediaGuideProvider {
+	transport := &http.Transport{
+		MaxIdleConns:       10,
+		IdleConnTimeout:    wikiIdleConnTimeout,
+		DisableCompression: false,
+	}
+
+	return &WikipediaGuideProvider{
+		httpClient: &http.Client{
+			Timeout:   wikiHTTPTimeout,
+			Transport: transport,
+		},
+		limiter: rate.NewLimiter(rate.Limit(wikiRateLimitPerSec), 1),
+	}
+}
+
+// Fetch retrieves species guide information from Wikipedia.
+func (p *WikipediaGuideProvider) Fetch(ctx context.Context, scientificName string) (SpeciesGuide, error) {
+	log := GetLogger()
+
+	// Check circuit breaker
+	if open, reason := p.isCircuitOpen(); open {
+		log.Debug("Wikipedia guide circuit breaker open",
+			logger.String("reason", reason),
+			logger.String("species", scientificName))
+		return SpeciesGuide{}, ErrAllProvidersUnavailable
+	}
+
+	// Rate limit
+	if err := p.limiter.Wait(ctx); err != nil {
+		return SpeciesGuide{}, errors.Newf("rate limiter: %w", err).
+			Component("guideprovider").
+			Category(errors.CategoryNetwork).
+			Build()
+	}
+
+	// Try scientific name first
+	guide, err := p.fetchSummary(ctx, scientificName)
+	if err == nil {
+		return guide, nil
+	}
+
+	// If not found or disambiguation, the species article might be under a different title
+	log.Debug("Wikipedia scientific name lookup failed, no common name fallback available",
+		logger.String("species", scientificName),
+		logger.Any("error", err))
+
+	return SpeciesGuide{}, ErrGuideNotFound
+}
+
+// fetchSummary fetches the Wikipedia REST API summary for a given title.
+func (p *WikipediaGuideProvider) fetchSummary(ctx context.Context, title string) (SpeciesGuide, error) {
+	// Build URL: replace spaces with underscores, URL-encode
+	baseURL := wikipediaRESTBaseURL
+	if p.testBaseURL != "" {
+		baseURL = p.testBaseURL
+	}
+	encodedTitle := url.PathEscape(strings.ReplaceAll(title, " ", "_"))
+	apiURL := fmt.Sprintf("%s/%s", baseURL, encodedTitle)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
+	if err != nil {
+		return SpeciesGuide{}, errors.Newf("creating request: %w", err).
+			Component("guideprovider").
+			Category(errors.CategoryNetwork).
+			Build()
+	}
+	req.Header.Set("User-Agent", wikiUserAgent)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := p.httpClient.Do(req)
+	if err != nil {
+		p.tripCircuitBreaker(cbNetworkDuration, "network error: "+err.Error())
+		return SpeciesGuide{}, errors.Newf("HTTP request failed: %w", err).
+			Component("guideprovider").
+			Category(errors.CategoryNetwork).
+			Build()
+	}
+	defer resp.Body.Close()
+
+	// Handle HTTP errors
+	switch {
+	case resp.StatusCode == http.StatusNotFound:
+		return SpeciesGuide{}, ErrGuideNotFound
+	case resp.StatusCode == http.StatusTooManyRequests:
+		p.tripCircuitBreaker(cbRateLimitDuration, "rate limited")
+		return SpeciesGuide{}, errors.Newf("Wikipedia rate limited").
+			Component("guideprovider").
+			Category(errors.CategoryNetwork).
+			Build()
+	case resp.StatusCode == http.StatusForbidden:
+		p.tripCircuitBreaker(cbBlockedDuration, "access blocked")
+		return SpeciesGuide{}, errors.Newf("Wikipedia access blocked").
+			Component("guideprovider").
+			Category(errors.CategoryNetwork).
+			Build()
+	case resp.StatusCode == http.StatusServiceUnavailable:
+		p.tripCircuitBreaker(cbUnavailDuration, "service unavailable")
+		return SpeciesGuide{}, errors.Newf("Wikipedia service unavailable").
+			Component("guideprovider").
+			Category(errors.CategoryNetwork).
+			Build()
+	case resp.StatusCode != http.StatusOK:
+		return SpeciesGuide{}, errors.Newf("Wikipedia returned status %d", resp.StatusCode).
+			Component("guideprovider").
+			Category(errors.CategoryNetwork).
+			Build()
+	}
+
+	// Reset circuit breaker on successful response
+	p.resetCircuit()
+
+	// Read response with size limit
+	body, err := io.ReadAll(io.LimitReader(resp.Body, wikiMaxResponseBody))
+	if err != nil {
+		return SpeciesGuide{}, errors.Newf("reading response: %w", err).
+			Component("guideprovider").
+			Category(errors.CategoryNetwork).
+			Build()
+	}
+
+	var summary wikipediaSummaryResponse
+	if err := json.Unmarshal(body, &summary); err != nil {
+		return SpeciesGuide{}, errors.Newf("parsing response: %w", err).
+			Component("guideprovider").
+			Category(errors.CategoryProcessing).
+			Build()
+	}
+
+	// Handle disambiguation pages
+	if summary.Type == "disambiguation" {
+		return SpeciesGuide{}, ErrGuideNotFound
+	}
+
+	// Check for empty extract
+	if summary.Extract == "" {
+		return SpeciesGuide{}, ErrGuideNotFound
+	}
+
+	// Truncate description if too long
+	description := summary.Extract
+	if len(description) > maxDescriptionLength {
+		description = description[:maxDescriptionLength] + "..."
+	}
+
+	guide := SpeciesGuide{
+		ScientificName: title,
+		CommonName:     summary.Title,
+		Description:    description,
+		SourceProvider: WikipediaProviderName,
+		SourceURL:      summary.ContentURLs.Desktop.Page,
+		LicenseName:    "CC BY-SA 4.0",
+		LicenseURL:     "https://creativecommons.org/licenses/by-sa/4.0/",
+		CachedAt:       time.Now(),
+		Partial:        true, // Wikipedia REST summary only provides description
+	}
+
+	return guide, nil
+}
+
+// isCircuitOpen checks if the circuit breaker is blocking requests.
+func (p *WikipediaGuideProvider) isCircuitOpen() (bool, string) {
+	p.circuitMu.RLock()
+	defer p.circuitMu.RUnlock()
+
+	if time.Now().Before(p.circuitOpenUntil) {
+		return true, p.circuitLastError
+	}
+	return false, ""
+}
+
+// tripCircuitBreaker opens the circuit breaker for the specified duration.
+func (p *WikipediaGuideProvider) tripCircuitBreaker(duration time.Duration, reason string) {
+	p.circuitMu.Lock()
+	defer p.circuitMu.Unlock()
+
+	p.circuitOpenUntil = time.Now().Add(duration)
+	p.circuitFailures++
+	p.circuitLastError = reason
+
+	GetLogger().Error("Opening Wikipedia guide circuit breaker",
+		logger.String("reason", reason),
+		logger.Duration("duration", duration),
+		logger.Int("consecutive_failures", p.circuitFailures))
+}
+
+// resetCircuit resets the circuit breaker on successful request.
+func (p *WikipediaGuideProvider) resetCircuit() {
+	p.circuitMu.Lock()
+	defer p.circuitMu.Unlock()
+
+	if p.circuitFailures > 0 {
+		GetLogger().Info("Resetting Wikipedia guide circuit breaker after successful request",
+			logger.Int("previous_failures", p.circuitFailures))
+	}
+
+	p.circuitOpenUntil = time.Time{}
+	p.circuitFailures = 0
+	p.circuitLastError = ""
+}

--- a/internal/guideprovider/wikipedia_test.go
+++ b/internal/guideprovider/wikipedia_test.go
@@ -1,0 +1,185 @@
+package guideprovider
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWikipediaGuideProvider_Fetch_Success(t *testing.T) {
+	t.Parallel()
+
+	// Create mock Wikipedia REST API server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		response := wikipediaSummaryResponse{
+			Type:    "standard",
+			Title:   "Common blackbird",
+			Extract: "The common blackbird is a species of true thrush.",
+		}
+		response.ContentURLs.Desktop.Page = "https://en.wikipedia.org/wiki/Common_blackbird"
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(response)
+	}))
+	defer server.Close()
+
+	provider := NewWikipediaGuideProvider()
+	// Override the base URL to use our test server
+	// We'll test by creating a custom fetch that uses our server URL
+	guide, err := fetchFromTestServer(t, server.URL, "Turdus merula")
+	require.NoError(t, err)
+
+	assert.Equal(t, "Common blackbird", guide.CommonName)
+	assert.Equal(t, "The common blackbird is a species of true thrush.", guide.Description)
+	assert.Equal(t, WikipediaProviderName, guide.SourceProvider)
+	assert.Equal(t, "CC BY-SA 4.0", guide.LicenseName)
+	assert.True(t, guide.Partial)
+
+	_ = provider // ensure provider is used
+}
+
+func TestWikipediaGuideProvider_Fetch_NotFound(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	_, err := fetchFromTestServer(t, server.URL, "Nonexistent species")
+	assert.ErrorIs(t, err, ErrGuideNotFound)
+}
+
+func TestWikipediaGuideProvider_Fetch_Disambiguation(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		response := wikipediaSummaryResponse{
+			Type:  "disambiguation",
+			Title: "Blackbird",
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(response)
+	}))
+	defer server.Close()
+
+	_, err := fetchFromTestServer(t, server.URL, "Blackbird")
+	assert.ErrorIs(t, err, ErrGuideNotFound)
+}
+
+func TestWikipediaGuideProvider_Fetch_RateLimited(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	provider := newTestWikipediaProvider(server.URL)
+	_, err := provider.fetchSummary(context.Background(), "Turdus merula")
+	assert.Error(t, err)
+
+	// Circuit breaker should be tripped
+	open, reason := provider.isCircuitOpen()
+	assert.True(t, open)
+	assert.Equal(t, "rate limited", reason)
+}
+
+func TestWikipediaGuideProvider_Fetch_EmptyExtract(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		response := wikipediaSummaryResponse{
+			Type:    "standard",
+			Title:   "Some page",
+			Extract: "",
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(response)
+	}))
+	defer server.Close()
+
+	_, err := fetchFromTestServer(t, server.URL, "Empty page")
+	assert.ErrorIs(t, err, ErrGuideNotFound)
+}
+
+func TestWikipediaGuideProvider_CircuitBreaker(t *testing.T) {
+	t.Parallel()
+
+	provider := NewWikipediaGuideProvider()
+
+	// Initially closed
+	open, _ := provider.isCircuitOpen()
+	assert.False(t, open)
+
+	// Trip it
+	provider.tripCircuitBreaker(1*time.Minute, "test reason")
+	open, reason := provider.isCircuitOpen()
+	assert.True(t, open)
+	assert.Equal(t, "test reason", reason)
+	assert.Equal(t, 1, provider.circuitFailures)
+
+	// Trip again to verify consecutive failure tracking
+	provider.tripCircuitBreaker(1*time.Minute, "second failure")
+	assert.Equal(t, 2, provider.circuitFailures)
+
+	// Reset on success
+	provider.resetCircuit()
+	open, _ = provider.isCircuitOpen()
+	assert.False(t, open)
+	assert.Equal(t, 0, provider.circuitFailures)
+	assert.Equal(t, "", provider.circuitLastError)
+}
+
+func TestWikipediaGuideProvider_DescriptionTruncation(t *testing.T) {
+	t.Parallel()
+
+	// Create a long description
+	longText := make([]byte, maxDescriptionLength+500)
+	for i := range longText {
+		longText[i] = 'a'
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		response := wikipediaSummaryResponse{
+			Type:    "standard",
+			Title:   "Test",
+			Extract: string(longText),
+		}
+		response.ContentURLs.Desktop.Page = "https://en.wikipedia.org/wiki/Test"
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(response)
+	}))
+	defer server.Close()
+
+	guide, err := fetchFromTestServer(t, server.URL, "Test")
+	require.NoError(t, err)
+
+	// Should be truncated to maxDescriptionLength + "..."
+	assert.Equal(t, maxDescriptionLength+3, len(guide.Description))
+	assert.True(t, len(guide.Description) <= maxDescriptionLength+3)
+}
+
+// fetchFromTestServer is a test helper that creates a provider pointing at a test server.
+func fetchFromTestServer(t *testing.T, serverURL, title string) (SpeciesGuide, error) {
+	t.Helper()
+	provider := newTestWikipediaProvider(serverURL)
+	return provider.fetchSummary(context.Background(), title)
+}
+
+// newTestWikipediaProvider creates a WikipediaGuideProvider pointing at a test server.
+func newTestWikipediaProvider(baseURL string) *WikipediaGuideProvider {
+	provider := NewWikipediaGuideProvider()
+	// We override the fetch by modifying the base URL constant via a closure.
+	// Since we can't modify the const, we create a provider that builds URLs
+	// using the test server URL instead.
+	provider.testBaseURL = baseURL
+	return provider
+}


### PR DESCRIPTION
## Summary

- Add `internal/guideprovider/` package that fetches and caches species guide text (description, conservation status, attribution) from Wikipedia REST API and eBird taxonomy
- Follows existing `imageprovider` pluggable architecture: two-tier cache (sync.Map + SQLite), circuit breaker with failure tracking, rate limiting, singleflight dedup, negative cache entries
- New API endpoint: `GET /api/v2/species/:scientific_name/guide`
- Configurable via `realtime.dashboard.speciesguide` settings (enabled, provider, fallback policy)

## Test plan

- [x] 17 unit tests pass (`go test ./internal/guideprovider/...`)
- [x] Wikipedia provider tests cover: success, not found, disambiguation, rate limiting, empty extract, circuit breaker, description truncation
- [x] Cache tests cover: memory hits, negative entries, provider fetch, provider not found, merge logic, staleness
- [x] API endpoint tests cover: disabled feature, nil cache, empty name, not found, success
- [ ] CI lint and test pipeline
- [ ] Manual: `curl http://localhost:8080/api/v2/species/Turdus%20merula/guide` returns guide JSON
- [ ] Frontend integration (deferred to follow-up PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added species guide endpoint (`GET /species/:scientific_name/guide`) providing detailed species information including description, conservation status, and source attribution
  * Integrated multiple species information sources with configurable provider selection and fallback behavior
  * Implemented intelligent caching system with automatic refresh

* **Configuration**
  * Added new settings to enable/disable species guide feature and configure data sources

<!-- end of auto-generated comment: release notes by coderabbit.ai -->