### PR TITLE
fix: consolidate model identity, fix locale check, improve cache eviction

### DIFF
--- a/internal/classifier/birdnet.go
+++ b/internal/classifier/birdnet.go
@@ -235,22 +235,10 @@ func (bn *BirdNET) initializeTFLiteModel() error {
 
 	bn.classifier = classifier
 
-	// Update model version based on custom model path if provided.
-	// Only derive the ID from the filename when the resolution chain did not
-	// already determine a specific model (i.e., ID is empty or still "Custom").
-	// After NewBirdNET's 4-tier resolution, ModelInfo.ID may already be set
-	// correctly and must not be overwritten here.
+	// Update the human-readable model version string for display when a custom
+	// model path is provided. Model identity (ModelInfo.ID) is never modified
+	// here — it was fully resolved by NewBirdNET's 4-tier resolution chain.
 	if bn.Settings.BirdNET.ModelPath != "" {
-		if bn.ModelInfo.ID == "" || bn.ModelInfo.ID == modelIDCustom {
-			// Extract model version from the file name if possible
-			fileName := filepath.Base(bn.Settings.BirdNET.ModelPath)
-			if strings.HasPrefix(fileName, "BirdNET_") && strings.Contains(fileName, "_Model_") {
-				parts := strings.Split(fileName, "_Model_")
-				bn.ModelInfo.ID = parts[0]
-			} else {
-				bn.ModelInfo.ID = modelIDCustom
-			}
-		}
 		bn.modelVersion = bn.Settings.BirdNET.ModelPath
 	}
 
@@ -592,8 +580,15 @@ func (bn *BirdNET) getCachedSpeciesScores(targetDate time.Time) (map[string]floa
 		bn.speciesCacheMu.Unlock()
 		return out, nil
 	}
-	// Keep cache bounded by clearing before setting new key
-	clear(bn.speciesCache)
+	// Keep cache bounded: evict one arbitrary entry when limit is reached.
+	// Each key encodes date+lat+lon+model, so a small limit is sufficient.
+	const maxSpeciesCacheEntries = 8
+	if len(bn.speciesCache) >= maxSpeciesCacheEntries {
+		for k := range bn.speciesCache {
+			delete(bn.speciesCache, k)
+			break
+		}
+	}
 	bn.speciesCache[cacheKey] = &speciesCacheEntry{
 		key:    cacheKey,
 		scores: scores,

--- a/internal/classifier/model_registry.go
+++ b/internal/classifier/model_registry.go
@@ -163,9 +163,10 @@ func ResolveConfigModelID(configID string) (string, bool) {
 
 // IsLocaleSupported checks if a locale is supported by the given model.
 func IsLocaleSupported(modelInfo *ModelInfo, locale string) bool {
-	// If it's a custom model with no specified locales, assume all are supported
+	// If it's a custom model with no specified locales, assume all are supported.
+	// Registered models with empty SupportedLocales genuinely have no locale support.
 	if len(modelInfo.SupportedLocales) == 0 {
-		return true
+		return modelInfo.ID == modelIDCustom
 	}
 
 	normalizedLocale := strings.ToLower(locale)

--- a/internal/classifier/model_registry_test.go
+++ b/internal/classifier/model_registry_test.go
@@ -153,3 +153,17 @@ func TestDetermineModelInfo_UnrecognizedNonModelFile(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unrecognized model")
 }
+
+func TestIsLocaleSupported_PerchHasNoLocales(t *testing.T) {
+	t.Parallel()
+
+	perchInfo := ModelRegistry["Perch_V2"]
+	assert.False(t, IsLocaleSupported(&perchInfo, "en-uk"), "Perch_V2 should not support any locale")
+}
+
+func TestIsLocaleSupported_CustomModelAcceptsAll(t *testing.T) {
+	t.Parallel()
+
+	customInfo := ModelInfo{ID: modelIDCustom, SupportedLocales: []string{}}
+	assert.True(t, IsLocaleSupported(&customInfo, "en-uk"), "Custom model should accept any locale")
+}


### PR DESCRIPTION
## Summary

- Remove filename-based ID derivation from `initializeTFLiteModel`; the 4-tier resolution chain in `NewBirdNET` is now the sole authority for `ModelInfo.ID`
- `IsLocaleSupported` now returns false for registered models with empty `SupportedLocales` (e.g., Perch_V2); only `Custom` models get the permissive behavior
- Replace `speciesCache` clear-on-miss with bounded eviction (max 8 entries); preserves cache across different days/locations

## Related Issues

Follow-ups from PR #2631 review findings (internal tracking).

## Test Plan

- [x] New tests for `IsLocaleSupported` Perch and Custom behavior
- [x] All classifier tests pass with `-race`
- [x] Zero linter issues
- [x] Local CodeRabbit review: no findings
- [ ] CI checks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed locale support validation to properly restrict unsupported locales for registered models.

* **Improvements**
  * Enhanced cache management with bounded memory allocation—single entries are now evicted when capacity is reached instead of clearing the entire cache.
  * Improved custom model initialization to preserve model identity while correctly handling custom model paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->