### PR TITLE
fix: allocate analysis buffers for secondary models in multi-model config

### DIFF
--- a/internal/analysis/audio_pipeline_service.go
+++ b/internal/analysis/audio_pipeline_service.go
@@ -473,6 +473,8 @@ func (p *AudioPipelineService) registerConsumersForSources(sourceIDs []string, s
 	primaryInfo := &p.bnAnalyzer.BirdNET().ModelInfo
 	primaryTargets := []classifier.ModelInfo{*primaryInfo}
 
+	bufMgr := p.engine.BufferManager()
+
 	for _, sid := range sourceIDs {
 		// Resolve per-source model targets. Fall back to primary if the
 		// source has no configured models or none could be resolved.
@@ -481,10 +483,38 @@ func (p *AudioPipelineService) registerConsumersForSources(sourceIDs []string, s
 			modelInfos = primaryTargets
 		}
 
-		// Convert to ModelTarget for the buffer consumer
-		targets := make([]ModelTarget, len(modelInfos))
+		// Allocate analysis buffers for secondary models. The engine
+		// already allocates a buffer for the primary model in AddSource(),
+		// so only non-primary models need allocation here. Track which
+		// models have usable buffers so we only create targets for them.
+		allocatedModels := make(map[string]bool, len(modelInfos))
+		allocatedModels[primaryInfo.ID] = true // pre-allocated by engine
 		for i := range modelInfos {
-			targets[i] = ModelTarget{ModelID: modelInfos[i].ID, SampleRate: modelInfos[i].Spec.SampleRate}
+			if modelInfos[i].ID == primaryInfo.ID {
+				continue
+			}
+			spec := modelInfos[i].Spec
+			clipBytes := spec.SampleRate * int(spec.ClipLength.Seconds()) * conf.NumChannels * (conf.BitDepth / 8)
+			overlapBytes := clipBytes / 2 // 50% overlap, matching primary model ratio
+			readSize := clipBytes - overlapBytes
+			if allocErr := bufMgr.AllocateAnalysis(sid, modelInfos[i].ID, clipBytes, overlapBytes, readSize); allocErr != nil {
+				log.Warn("failed to allocate analysis buffer for secondary model",
+					logger.String("source_id", sid),
+					logger.String("model_id", modelInfos[i].ID),
+					logger.Error(allocErr),
+					logger.String("operation", operation))
+				continue
+			}
+			allocatedModels[modelInfos[i].ID] = true
+		}
+
+		// Convert to ModelTarget for the buffer consumer, excluding
+		// models whose buffer allocation failed.
+		targets := make([]ModelTarget, 0, len(modelInfos))
+		for i := range modelInfos {
+			if allocatedModels[modelInfos[i].ID] {
+				targets = append(targets, ModelTarget{ModelID: modelInfos[i].ID, SampleRate: modelInfos[i].Spec.SampleRate})
+			}
 		}
 
 		bc, bcErr := NewBufferConsumer(

--- a/internal/analysis/buffer_consumer.go
+++ b/internal/analysis/buffer_consumer.go
@@ -3,6 +3,7 @@ package analysis
 import (
 	"encoding/binary"
 	"math"
+	"sync"
 	"sync/atomic"
 
 	"github.com/tphakala/birdnet-go/internal/audiocore"
@@ -43,6 +44,7 @@ type BufferConsumer struct {
 	targets        []ModelTarget
 	resamplers     map[int]*resample.Resampler // keyed by target rate
 	groupedTargets map[int][]ModelTarget       // targets grouped by rate, pre-computed
+	bufWarnOnce    sync.Map                    // modelID → struct{}, logs missing buffer once per model
 }
 
 // NewBufferConsumer creates a BufferConsumer that writes audio frames to the
@@ -183,14 +185,23 @@ func (c *BufferConsumer) Write(frame audiocore.AudioFrame) error { //nolint:gocr
 			data = resampled
 		}
 		for _, t := range targets {
-			if ab, abErr := c.bufferMgr.AnalysisBuffer(sourceID, t.ModelID); abErr == nil {
-				if writeErr := ab.Write(data); writeErr != nil {
-					GetLogger().Warn("failed to write to analysis buffer",
+			ab, abErr := c.bufferMgr.AnalysisBuffer(sourceID, t.ModelID)
+			if abErr != nil {
+				if _, loaded := c.bufWarnOnce.LoadOrStore(t.ModelID, struct{}{}); !loaded {
+					GetLogger().Warn("analysis buffer not found for model target",
 						logger.String("source_id", sourceID),
 						logger.String("model_id", t.ModelID),
-						logger.Error(writeErr),
+						logger.String("consumer_id", c.id),
 						logger.String("operation", "buffer_consumer_write"))
 				}
+				continue
+			}
+			if writeErr := ab.Write(data); writeErr != nil {
+				GetLogger().Warn("failed to write to analysis buffer",
+					logger.String("source_id", sourceID),
+					logger.String("model_id", t.ModelID),
+					logger.Error(writeErr),
+					logger.String("operation", "buffer_consumer_write"))
 			}
 		}
 	}

--- a/internal/analysis/buffer_manager.go
+++ b/internal/analysis/buffer_manager.go
@@ -386,6 +386,10 @@ func (m *BufferManager) analysisBufferMonitor(quitChan chan struct{}, cfg monito
 	// hardcoded constant that assumed BirdNET v2.4 parameters.
 	analysisWindowBytes := cfg.readSize
 
+	// Track whether we ever successfully accessed the buffer to
+	// distinguish "never allocated" from "removed after use".
+	hasReadBuffer := false
+
 	ticker := time.NewTicker(pollInterval)
 	defer ticker.Stop()
 
@@ -396,12 +400,18 @@ func (m *BufferManager) analysisBufferMonitor(quitChan chan struct{}, cfg monito
 		case <-ticker.C:
 			ab, err := m.bufferMgr.AnalysisBuffer(cfg.sourceID, cfg.modelID)
 			if err != nil {
-				// Buffer removed, exit gracefully
-				m.logger.Info("analysis buffer removed, stopping monitor",
-					logger.String("source_id", cfg.sourceID),
-					logger.String("model_id", cfg.modelID))
+				if hasReadBuffer {
+					m.logger.Info("analysis buffer removed, stopping monitor",
+						logger.String("source_id", cfg.sourceID),
+						logger.String("model_id", cfg.modelID))
+				} else {
+					m.logger.Warn("analysis buffer not found for monitor, may not be allocated",
+						logger.String("source_id", cfg.sourceID),
+						logger.String("model_id", cfg.modelID))
+				}
 				return
 			}
+			hasReadBuffer = true
 			data, readErr := ab.Read()
 			if readErr != nil {
 				m.logger.Error("buffer read error",


### PR DESCRIPTION
## Summary

- Allocate per-model analysis buffers for secondary models (e.g., Perch V2) in `registerConsumersForSources()`, using each model's `SampleRate` and `ClipLength` from `ModelSpec`
- Exclude models whose buffer allocation fails from buffer consumer targets to avoid silent data loss
- Add once-per-model warning log in `BufferConsumer.Write()` when an analysis buffer is missing (was previously completely silent)
- Distinguish "buffer not found (never allocated)" from "buffer removed" in `analysisBufferMonitor()` log messages

Previously, only the primary model (BirdNET) received an analysis buffer from `engine.AddSource()`. Secondary models configured via `models: [birdnet, perch_v2]` never got buffers allocated, causing their monitors to exit immediately and produce zero detections.

## Test Plan

- [ ] Verify `golangci-lint run -v` passes (0 issues)
- [ ] Verify `go test -race ./internal/analysis/...` passes
- [ ] Configure a source with `models: [birdnet, perch_v2]` and verify Perch V2 monitor starts and produces detections
- [ ] Verify hot-reload (`reconfigureChangedSources`) also allocates secondary buffers for new sources

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes & Improvements**
  * Improved audio analysis buffer allocation for secondary models to prevent processing failures
  * Enhanced error handling with one-time warnings per model to reduce log noise
  * Better distinction between missing and removed analysis buffers for more informative diagnostics

<!-- end of auto-generated comment: release notes by coderabbit.ai -->