### PR TITLE
fix: allocate secondary model buffers on watchdog stream reset

### DIFF
--- a/internal/analysis/audio_pipeline_service.go
+++ b/internal/analysis/audio_pipeline_service.go
@@ -165,13 +165,11 @@ func (p *AudioPipelineService) Start(_ context.Context) error {
 			logger.String("operation", "startup_audio_check"))
 	}
 
-	// Register watchdog reset callback so analysis buffers are allocated
-	// and monitors are recreated when the watchdog force-resets a stuck stream.
+	// Register watchdog reset callback so analysis monitors are recreated
+	// when the watchdog force-resets a stuck stream. Buffers are NOT
+	// deallocated during a reset — the source ID is reused and buffers
+	// remain allocated. Only the monitors need to be recreated.
 	p.engine.FFmpegManager().SetOnStreamReset(func(newSourceID string) {
-		// Allocate secondary model buffers for the new source. The engine's
-		// AddSource() only allocates the primary model buffer.
-		p.allocateSecondaryModelBuffers(newSourceID, "watchdog_reset")
-
 		if err := p.bufferMgr.AddMonitor(newSourceID); err != nil {
 			GetLogger().Warn("failed to add monitor after watchdog stream reset",
 				logger.String("source_id", newSourceID),


### PR DESCRIPTION
## Summary

- Extract `allocateSecondaryModelBuffers()` helper from inline code in `registerConsumersForSources()` to avoid duplication
- Call the helper from the FFmpeg watchdog reset callback before `AddMonitor()`
- Previously, when the watchdog force-reset a stuck stream, only the primary model buffer was re-allocated via `engine.AddSource()`, leaving secondary model monitors without buffers — they'd log "buffer not found" and exit

## Test Plan

- [ ] Verify `golangci-lint run -v` passes (0 issues)
- [ ] Verify `go test -race ./internal/analysis/...` passes
- [ ] Multi-model config with RTSP stream: trigger a watchdog reset and verify secondary model monitors restart successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved audio buffer allocation and reset behavior so stream resets preserve existing analysis buffers.
  * Unified allocation path for secondary models, reducing allocation logic duplication and unexpected exclusion of models.
  * Stream reset now reuses allocation logic, lowering allocation-related failures and surfacing clearer warnings when allocations fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->