### PR TITLE
fix: add skeleton loading states to DetectionDetail to prevent layout shift

### DIFF
--- a/frontend/src/lib/desktop/components/media/AudioPlayer.svelte
+++ b/frontend/src/lib/desktop/components/media/AudioPlayer.svelte
@@ -2235,4 +2235,10 @@
       opacity: 0.5;
     }
   }
+
+  @media (prefers-reduced-motion: reduce) {
+    .spectrogram-skeleton {
+      animation: none;
+    }
+  }
 </style>

--- a/frontend/src/lib/desktop/views/DetectionDetail.svelte
+++ b/frontend/src/lib/desktop/views/DetectionDetail.svelte
@@ -718,8 +718,8 @@
   </div>
 
   {#if isLoadingDetection}
-    <!-- Loading skeleton matching real layout structure -->
-    <div class="detection-hero-grid" aria-label="Loading detection details">
+    <!-- Loading skeleton matching real layout structure (decorative, AT uses live region above) -->
+    <div class="detection-hero-grid" aria-hidden="true">
       <!-- Identity card skeleton -->
       <div class="hero-card hero-identity-card">
         <div class="skeleton-line w-20 h-3 mb-4"></div>
@@ -1488,7 +1488,6 @@
   .skeleton-line,
   .skeleton-block {
     background: var(--color-base-300);
-    opacity: 0.6;
     border-radius: var(--radius-selector);
     animation: skeleton-pulse 1.5s ease-in-out infinite;
   }
@@ -1500,11 +1499,18 @@
   @keyframes skeleton-pulse {
     0%,
     100% {
-      opacity: 0.6;
+      opacity: 1;
     }
 
     50% {
-      opacity: 0.3;
+      opacity: 0.5;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .skeleton-line,
+    .skeleton-block {
+      animation: none;
     }
   }
 </style>


### PR DESCRIPTION
## Summary

- AudioPlayer now reserves space with `aspect-ratio: 2/1` on responsive spectrogram containers and shows a pulsing skeleton background while the spectrogram image loads, preventing the container from collapsing to zero height
- DetectionDetail replaces the generic centered spinner with a structured skeleton that mirrors the actual layout (hero identity/metadata cards, media section with 2:1 spectrogram placeholder, tab bar), eliminating cumulative layout shift when detection data arrives

## Test plan

- [ ] Load a detection detail page and verify the skeleton layout appears immediately with correct proportions
- [ ] Verify no visible layout shift when detection data and spectrogram image load
- [ ] Test on different viewport widths (tablet, desktop) to confirm responsive skeleton sizing
- [ ] Verify the spectrogram area shows pulsing skeleton while image loads, then transitions cleanly to the loaded image
- [ ] Check that error states (failed spectrogram, failed detection load) still render correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * New skeleton placeholders and pulsing animations for audio player and detection detail to improve loading visuals
  * Audio player maintains proper aspect ratio when spectrograms are shown

* **Accessibility**
  * Respects prefers-reduced-motion by disabling pulsing animations for users who prefer reduced motion
<!-- end of auto-generated comment: release notes by coderabbit.ai -->