### PR TITLE
fix: resolve model identity, harden buffer consumer, fix wizard device selection

### DIFF
--- a/frontend/src/lib/desktop/features/wizard/steps/AudioSourceStep.svelte
+++ b/frontend/src/lib/desktop/features/wizard/steps/AudioSourceStep.svelte
@@ -54,7 +54,7 @@
       .then(data => {
         // Use index as unique key to avoid duplicate name issues with ALSA sub-devices
         devices = (data ?? []).map(d => ({
-          value: d.name,
+          value: d.id,
           label: d.index >= 0 ? `${d.name} (#${d.index})` : d.name,
         }));
         if (devices.length === 0 && !selectedDevice) {

--- a/internal/analysis/buffer_consumer.go
+++ b/internal/analysis/buffer_consumer.go
@@ -87,10 +87,26 @@ func NewBufferConsumer(id string, bufferMgr *buffer.Manager, sampleRate, bitDept
 			Build()
 	}
 
+	// Filter out targets with invalid sample rates before grouping.
+	// A zero or negative rate would cause resampler creation to fail and
+	// indicates a misconfigured model (e.g., unrecognized custom model).
+	validTargets := make([]ModelTarget, 0, len(targets))
+	for _, t := range targets {
+		if t.SampleRate <= 0 {
+			GetLogger().Error("skipping model target with invalid sample rate",
+				logger.String("model_id", t.ModelID),
+				logger.Int("sample_rate", t.SampleRate),
+				logger.String("consumer_id", id),
+				logger.String("operation", "new_buffer_consumer"))
+			continue
+		}
+		validTargets = append(validTargets, t)
+	}
+
 	// Pre-compute grouped targets and create one resampler per unique
 	// non-native rate.
-	grouped := make(map[int][]ModelTarget, len(targets))
-	for _, t := range targets {
+	grouped := make(map[int][]ModelTarget, len(validTargets))
+	for _, t := range validTargets {
 		grouped[t.SampleRate] = append(grouped[t.SampleRate], t)
 	}
 
@@ -122,7 +138,7 @@ func NewBufferConsumer(id string, bufferMgr *buffer.Manager, sampleRate, bitDept
 		rate:           sampleRate,
 		depth:          bitDepth,
 		channels:       channels,
-		targets:        targets,
+		targets:        validTargets,
 		resamplers:     resamplers,
 		groupedTargets: grouped,
 	}, nil

--- a/internal/classifier/model_registry.go
+++ b/internal/classifier/model_registry.go
@@ -95,6 +95,7 @@ var filenamePatterns = map[string]string{
 	"birdnet-v24":            "BirdNET_V2.4",
 	"birdnet_v2.4":           "BirdNET_V2.4",
 	"birdnet-v2.4":           "BirdNET_V2.4",
+	"birdnet-go_classifier":  "BirdNET_V2.4", // custom-named classifier builds
 	"perch_v2":               "Perch_V2",
 	"perch-v2":               "Perch_V2",
 }

--- a/internal/classifier/model_registry_test.go
+++ b/internal/classifier/model_registry_test.go
@@ -104,6 +104,7 @@ func TestDetermineModelInfo_OnnxSupport(t *testing.T) {
 		{"onnx unrecognized returns Custom", "/path/to/unknown-model.onnx", "Custom"},
 		{"tflite with legacy name", "/path/to/BirdNET_GLOBAL_6K_V2.4_Model.tflite", "BirdNET_V2.4"},
 		{"tflite unrecognized returns Custom", "/path/to/some-model.tflite", "Custom"},
+		{"custom classifier build name", "/home/birdnet/BirdNET-Go_classifier_20260118.tflite", "BirdNET_V2.4"},
 		{"registry ID directly", "BirdNET_V2.4", "BirdNET_V2.4"},
 		{"registry ID Perch", "Perch_V2", "Perch_V2"},
 	}


### PR DESCRIPTION
## Summary

- **Model filename pattern**: `DetermineModelInfo` returned `Custom` (SampleRate=0) for BirdNET model files named `BirdNET-Go_classifier_*.tflite` because no filename pattern matched. Added `birdnet-go_classifier` to `filenamePatterns` so these resolve to `BirdNET_V2.4`.
- **Buffer consumer validation**: `NewBufferConsumer` failed entirely when a `ModelTarget` had `SampleRate<=0`, crashing resampler creation (48kHz→0Hz). Now filters invalid targets with an error log instead of failing the whole consumer.
- **Wizard device selection**: `AudioSourceStep.svelte` saved `d.name` (full device name) instead of `d.id` (ALSA device ID like `:0,0`), causing `matchesDevice()` to fail at capture time. Fixed to match `SoundCardManager.svelte` pattern.

## Test Plan
- [x] `go test -race -v ./internal/classifier/ -run TestDetermineModelInfo` — new test case passes
- [x] `go test -race -v ./internal/analysis/ -run TestBufferConsumer` — all pass
- [x] `golangci-lint run -v` — zero issues
- [x] `npm run check:all` (frontend) — zero issues
- [x] CodeRabbit local review — no findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed audio device selection to store device identifiers correctly.
  * Added validation to exclude audio targets with invalid sample rates.

* **New Features**
  * Improved recognition of BirdNET classifier model files.

* **Tests**
  * Added test coverage for model file recognition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->