### PR TITLE
fix(e2e): harden alert-rules E2E tests and add v2 API availability check

### DIFF
--- a/frontend/tests/e2e/settings/alert-rules.spec.ts
+++ b/frontend/tests/e2e/settings/alert-rules.spec.ts
@@ -22,7 +22,10 @@ test.describe('Alert Rules Settings Page', () => {
         alertsAvailable = false;
       }
     } catch (error) {
-      console.warn('Alerts API check failed, skipping alert-rules tests:', error);
+      console.warn(
+        'Alerts API check failed, skipping alert-rules tests:',
+        (error as Error).message
+      );
       alertsAvailable = false;
     }
   });


### PR DESCRIPTION
Fixes 13 E2E test failures across three test specs:

- Harden locators to avoid flaky element selection
- Extract magic numbers into named constants
- Replace `waitForTimeout` with deterministic Playwright auto-waiting
- Improve error logging for better debugging
- Fix prettier formatting

Fixes #2439

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved alert-rules test resilience by using an environment-aware API base URL for availability probes.
  * Probe now handles network/request errors with try/catch so tests are skipped when the alert schema API is unreachable.
  * Added warning logs for probe failures to aid troubleshooting and reduce unexpected test failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->