### PR TITLE
fix(test): eliminate ETXTBSY flakiness in TestExecuteCommandAction_ScriptFailure

### DIFF
--- a/internal/analysis/processor/execute_internal_test.go
+++ b/internal/analysis/processor/execute_internal_test.go
@@ -3,6 +3,7 @@ package processor
 import (
 	"context"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -807,15 +808,13 @@ func TestExecuteCommandAction_ScriptFailure(t *testing.T) {
 	}
 	t.Parallel()
 
-	// Use /bin/false (or /usr/bin/false) which always exits with status 1.
-	// This avoids creating a script file entirely, sidestepping ETXTBSY
-	// ("text file busy") flakiness on Linux CI runners with overlayfs.
-	falseBin := "/bin/false"
-	if _, err := os.Stat(falseBin); os.IsNotExist(err) {
-		falseBin = "/usr/bin/false"
-		if _, err := os.Stat(falseBin); os.IsNotExist(err) {
-			t.Skip("neither /bin/false nor /usr/bin/false found")
-		}
+	// Use the system `false` binary (always exits with status 1), found via
+	// exec.LookPath for portability. This avoids creating a script file
+	// entirely, sidestepping ETXTBSY ("text file busy") flakiness on Linux
+	// CI runners with overlayfs.
+	falseBin, err := exec.LookPath("false")
+	if err != nil {
+		t.Skip("false binary not found in PATH")
 	}
 
 	action := &ExecuteCommandAction{
@@ -829,7 +828,7 @@ func TestExecuteCommandAction_ScriptFailure(t *testing.T) {
 		},
 	}
 
-	err := action.Execute(t.Context(), det)
+	err = action.Execute(t.Context(), det)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "exit")
 }


### PR DESCRIPTION
## Summary

- Replace `fail_script.sh` helper script with `/bin/false` in `TestExecuteCommandAction_ScriptFailure`
- `/bin/false` is a standard POSIX binary that always exits with status 1, requiring no file creation
- This eliminates the intermittent "text file busy" (ETXTBSY) error that occurs on Linux CI runners with overlayfs

## Root Cause

The test was creating a small shell script and immediately exec'ing it. On Linux CI runners using overlayfs (Docker containers), the kernel can retain an internal write reference on the inode after `Close()`, causing `exec` to fail with ETXTBSY even though the file was properly written, synced, and closed. The existing `createTestScript` helper already uses a write-to-temp-then-rename workaround, but this is unreliable across kernel/overlayfs versions.

## Fix

Using `/bin/false` (fallback to `/usr/bin/false`) avoids creating any file at all, so the ETXTBSY race cannot occur. The `assert.Contains(t, err.Error(), "exit")` assertion still passes since `/bin/false` produces `"exit status 1"`.

## Test Plan

- [ ] `go test -race -v ./internal/analysis/processor/ -run TestExecuteCommandAction_ScriptFailure` passes locally
- [ ] CI unit tests pass without the ETXTBSY error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by replacing temporary failing scripts with a system-provided command for failure scenarios.
  * Tests now gracefully skip when that system command isn't available, reducing flakiness and platform-specific failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->