### PR TITLE
fix: FFmpeg stderr race, stream alert events, audio 404 headers

### DIFF
--- a/internal/api/v2/media.go
+++ b/internal/api/v2/media.go
@@ -567,17 +567,6 @@ func (c *Controller) ServeAudioByID(ctx echo.Context) error {
 	originalFilename := filepath.Base(clipPath)
 	ext := strings.ToLower(filepath.Ext(originalFilename))
 
-	// Verify file exists BEFORE setting audio-specific headers.
-	// Without this check, 404 responses carry Content-Type: audio/wav and
-	// Content-Disposition headers, confusing HTTP clients.
-	if _, statErr := c.SFS.StatRel(normalizedClipPath); statErr != nil {
-		return c.handleAudio404WithWait(ctx, normalizedClipPath, statErr,
-			logger.String("note_id", noteID),
-			logger.String("path", ctx.Request().URL.Path),
-			logger.String("ip", ctx.RealIP()),
-		)
-	}
-
 	// Set proper Content-Type for audio files BEFORE ServeRelativeFile.
 	// This ensures Safari recognizes the file as audio.
 	switch ext {
@@ -607,6 +596,22 @@ func (c *Controller) ServeAudioByID(ctx echo.Context) error {
 	// Serve the file using SecureFS.
 	err = c.SFS.ServeRelativeFile(ctx, normalizedClipPath)
 	if err != nil {
+		// Clear audio-specific headers before error handling so 404 responses
+		// don't carry Content-Type: audio/wav on JSON error bodies.
+		if !ctx.Response().Committed {
+			ctx.Response().Header().Del("Content-Type")
+			ctx.Response().Header().Del("Content-Disposition")
+			ctx.Response().Header().Del("Accept-Ranges")
+		}
+
+		var httpErr *echo.HTTPError
+		if errors.As(err, &httpErr) && httpErr.Code == http.StatusNotFound {
+			return c.handleAudio404WithWait(ctx, normalizedClipPath, err,
+				logger.String("note_id", noteID),
+				logger.String("path", ctx.Request().URL.Path),
+				logger.String("ip", ctx.RealIP()),
+			)
+		}
 		return c.translateSecureFSError(ctx, err, "Failed to serve audio clip due to an unexpected error")
 	}
 

--- a/internal/audiocore/ffmpeg/stream.go
+++ b/internal/audiocore/ffmpeg/stream.go
@@ -689,8 +689,10 @@ func (s *Stream) Run(parentCtx context.Context) {
 				isSilenceTimeout := strings.Contains(errorMsg, "silence timeout")
 
 				// Publish stream event for alerting rules.
+				// EOF returns nil from handleReadError and never reaches here,
+				// so only silence timeouts are classified as disconnections.
 				eventName := alerting.EventStreamError
-				if isSilenceTimeout || errors.Is(err, io.EOF) {
+				if isSilenceTimeout {
 					eventName = alerting.EventStreamDisconnected
 				}
 				alerting.TryPublish(&alerting.AlertEvent{


### PR DESCRIPTION
## Summary

Fixes three bugs discovered during QA testing:

- **FFmpeg stderr race (#362)**: `handleQuickExitError()` reads stderr before `cmd.Wait()` completes, producing empty error messages. Added a 500ms drain timeout after the primary 5s timeout so the process can flush stderr pipe buffers before the error context is extracted.

- **Stream alert rules never fire (#363)**: The built-in "Audio stream disconnected" and "Audio stream error" alert rules were configured but never triggered because `audiocore/ffmpeg` never published events to the alerting engine. Added `alerting.TryPublish()` calls when FFmpeg fails to start (`stream.error`) and when `processAudio()` returns an error (`stream.error` for failures, `stream.disconnected` for silence timeouts/EOF).

- **Audio 404 headers (#367)**: `/api/v2/audio/:id` set `Content-Type: audio/wav` and `Content-Disposition` headers before checking file existence, causing 404 responses to carry audio-specific headers. Added `SFS.StatRel()` check before setting headers — if the file doesn't exist, the response goes directly to the 404 handler with correct JSON Content-Type.

## Test plan

- [x] `golangci-lint run -v` — zero issues
- [x] `go test -race ./internal/audiocore/ffmpeg/` — all pass
- [x] `go test -race -run TestHealth ./internal/api/v2/` — passes
- [x] `go build ./internal/audiocore/ffmpeg/ ./internal/api/v2/` — compiles
- [ ] CI pipeline passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for audio requests so error responses no longer include stale audio headers.
  * More robust timeout handling for streaming processes to better detect and recover from quick-exit conditions.

* **New Features**
  * Added alerting for stream failures and disconnects to surface stream health issues more quickly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->