### PR TITLE
fix(test): eliminate ETXTBSY flakiness in TestExecuteCommandAction_SuccessfulExecution

### DIFF
--- a/internal/analysis/processor/execute_internal_test.go
+++ b/internal/analysis/processor/execute_internal_test.go
@@ -791,14 +791,19 @@ func TestExecuteCommandAction_SuccessfulExecution(t *testing.T) {
 	}
 	t.Parallel()
 
-	scriptPath := createTestScript(t, "test_script.sh", "#!/bin/sh\nexit 0\n")
+	// Use the system `true` binary (always exits with status 0), found via
+	// exec.LookPath for portability. Avoids ETXTBSY flakiness on overlayfs.
+	trueBin, err := exec.LookPath("true")
+	if err != nil {
+		t.Skip("true binary not found in PATH")
+	}
 
 	action := &ExecuteCommandAction{
-		Command: scriptPath,
+		Command: trueBin,
 		Params:  nil,
 	}
 
-	err := action.Execute(t.Context(), createTestDetections("Test Bird"))
+	err = action.Execute(t.Context(), createTestDetections("Test Bird"))
 	assert.NoError(t, err)
 }
 


### PR DESCRIPTION
## Summary

- Replace `test_script.sh` with `exec.LookPath("true")` in `TestExecuteCommandAction_SuccessfulExecution`
- Same pattern as the fix applied to `TestExecuteCommandAction_ScriptFailure` in #2653
- Eliminates intermittent "text file busy" (ETXTBSY) errors on Linux CI runners with overlayfs

## Root Cause

Same as #2653: the `createTestScript` helper creates a shell script and immediately exec's it. On overlayfs CI runners, the kernel can retain an internal write reference on the inode after `Close()`, causing ETXTBSY. The `/bin/true` binary always exits 0 and requires no file creation.

## Test Plan

- [ ] `go test -race -v ./internal/analysis/processor/ -run TestExecuteCommandAction_SuccessfulExecution` passes locally
- [ ] CI unit tests pass without ETXTBSY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test portability and reliability for command execution validation by leveraging system executables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->