### PR TITLE
fix: Perch v2 detections silently dropped, metric description

### DIFF
--- a/internal/analysis/processor/processor.go
+++ b/internal/analysis/processor/processor.go
@@ -723,8 +723,9 @@ func (p *Processor) parseAndValidateSpecies(result datastore.Results, item class
 	// Use BirdNET's EnrichResultWithTaxonomy to get species information
 	scientificName, commonName, speciesCode = p.Bn.EnrichResultWithTaxonomy(result.Species)
 
-	// Skip processing if we couldn't parse the species properly (either name missing)
-	if commonName == "" || scientificName == "" {
+	// Skip processing if scientific name is missing. Common name may be empty
+	// for models like Perch v2 that return scientific-name-only labels.
+	if scientificName == "" {
 		if p.Settings.Debug {
 			GetLogger().Debug("Skipping species with invalid format",
 				logger.String("species", result.Species),
@@ -732,6 +733,11 @@ func (p *Processor) parseAndValidateSpecies(result datastore.Results, item class
 				logger.String("operation", "species_format_validation"))
 		}
 		return "", "", "", ""
+	}
+
+	// Use scientific name as fallback when common name is not available.
+	if commonName == "" {
+		commonName = scientificName
 	}
 
 	// Log placeholder taxonomy codes if using custom model

--- a/internal/classifier/perch_onnx.go
+++ b/internal/classifier/perch_onnx.go
@@ -6,6 +6,7 @@ package classifier
 import (
 	"context"
 	"fmt"
+	"math"
 	"os"
 	"sync"
 	"time"
@@ -118,13 +119,18 @@ func (p *Perch) Predict(ctx context.Context, samples [][]float32) ([]datastore.R
 			Build()
 	}
 
-	predictions, err := p.classifier.Predict(samples[0])
+	rawLogits, err := p.classifier.Predict(samples[0])
 	if err != nil {
 		return nil, errors.New(err).
 			Category(errors.CategoryAudio).
 			Context("model", "Perch_V2").
 			Build()
 	}
+
+	// Apply softmax to normalize raw logits into probabilities (0.0-1.0).
+	// The inference.Classifier interface returns pre-activation logits;
+	// BirdNET applies sigmoid in its own Predict path, Perch needs softmax.
+	predictions := perchSoftmax(rawLogits)
 
 	// Pair labels with predictions
 	results, err := pairLabelsAndConfidence(p.labels, predictions)
@@ -167,4 +173,27 @@ func (p *Perch) Close() error {
 		p.classifier = nil
 	}
 	return nil
+}
+
+// perchSoftmax normalizes raw logits into probabilities via the softmax function.
+func perchSoftmax(logits []float32) []float32 {
+	if len(logits) == 0 {
+		return logits
+	}
+	result := make([]float32, len(logits))
+	maxVal := logits[0]
+	for _, v := range logits[1:] {
+		if v > maxVal {
+			maxVal = v
+		}
+	}
+	var sum float32
+	for i, v := range logits {
+		result[i] = float32(math.Exp(float64(v - maxVal)))
+		sum += result[i]
+	}
+	for i := range result {
+		result[i] /= sum
+	}
+	return result
 }

--- a/internal/observability/metrics/birdnet.go
+++ b/internal/observability/metrics/birdnet.go
@@ -86,7 +86,7 @@ func (m *BirdNETMetrics) initMetrics() error {
 	m.ModelInvokeDuration = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name:    "birdnet_model_invoke_duration_seconds",
-			Help:    "Time taken for TensorFlow Lite model invocation",
+			Help:    "Time taken for model invocation",
 			Buckets: prometheus.ExponentialBuckets(BucketStart1ms, BucketFactor2, BucketCount8), // 1ms to ~256ms
 		},
 		[]string{"model"},


### PR DESCRIPTION
## Summary

Fixes the critical bug where **all Perch v2 detections are silently rejected** by the analysis processor, plus a minor Prometheus metric description fix.

- **Softmax normalization (#359)**: The `inference.Classifier` interface returns raw pre-activation logits. BirdNET applies sigmoid in its own `Predict()` path, but Perch v2's `Predict()` passed raw logits (e.g., 12.633) directly as confidence values, making thresholding meaningless. Now applies softmax before pairing with labels to produce valid probabilities (0.0-1.0).

- **Species format validation (#359)**: `parseAndValidateSpecies()` required both scientific AND common names, but Perch v2 labels contain only scientific names (e.g., `"Glaucidium passerinum"` without the BirdNET-style `"Scientific_Common"` underscore format). The validation rejected every single Perch detection. Now accepts scientific-name-only labels and falls back to using the scientific name as the display name when no common name is available.

- **Metric description (#368 partial)**: `birdnet_model_invoke_duration_seconds` Help text was hardcoded to "TensorFlow Lite model invocation" — incorrect when using ONNX backend. Changed to generic "model invocation".

## Test plan

- [x] `golangci-lint run -v` — zero issues
- [x] `go test -race ./internal/classifier/` — all pass
- [x] `go test -race ./internal/analysis/processor/` — all pass
- [x] `go test -race ./internal/observability/...` — all pass
- [ ] CI pipeline passes
- [ ] Verify Perch v2 detections appear in the database on a multi-model deployment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved confidence score accuracy in the Perch classifier by implementing proper probability normalization of raw model outputs.
  * Species validation now accepts entries with only scientific names (without common names), enabling better support for custom model outputs and improving processing reliability.
* **Documentation**
  * Clarified internal metric description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->