### PR TITLE
add HTTPS healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -168,7 +168,7 @@ LABEL usage.compose.podman="Use Podman/podman-compose.yml"
 # Add healthcheck to monitor container status
 # Extended start-period for low-power devices (e.g., Raspberry Pi)
 HEALTHCHECK --interval=30s --timeout=10s --start-period=120s --retries=3 \
-    CMD curl -fs --connect-timeout 2 http://localhost:8080/ || curl -fsk --connect-timeout 2 https://localhost:8443/ || curl -fsk --connect-timeout 2 https://localhost:443/ || exit 1
+    CMD curl -fs --connect-timeout 2 --max-time 3 http://localhost:8080/ || curl -fsk --connect-timeout 2 --max-time 3 https://localhost:8443/ || curl -fsk --connect-timeout 2 --max-time 3 https://localhost:443/ || exit 1
 
 # Container startup execution chain:
 # 1. entrypoint.sh - Sets up user permissions, timezone, device access, and performs


### PR DESCRIPTION
fixes #2667

This is a very minor fix to add check for the default HTTPS endpoint. A more comprehensive solution would require parsing the config file to account for non standard ports and protocols, but this will still help for now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved container health checks to perform a multi-step probe: primary HTTP check with short timeouts, falling back to secure endpoints and alternate ports if needed, reducing false failure reports.
  * Service startup behavior remains unchanged; removed an extraneous trailing newline in the container configuration file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->