### PR TITLE
fix: validate healthcheck response to handle HTTPS redirects

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -186,11 +186,11 @@ LABEL usage.compose.docker="Use Docker/docker-compose.yml"
 LABEL usage.compose.podman="Use Podman/podman-compose.yml"
 
 # Add healthcheck to monitor container status
-# Uses /health endpoint and validates response body contains "healthy" to avoid
-# false positives from HTTP->HTTPS 308 redirects (curl treats 3xx as success).
+# Uses /health endpoint and validates JSON status via jq to avoid false positives
+# from HTTP->HTTPS 308 redirects (curl -f treats 3xx as success).
 # Extended start-period for low-power devices (e.g., Raspberry Pi)
 HEALTHCHECK --interval=30s --timeout=10s --start-period=120s --retries=3 \
-    CMD curl -sS --connect-timeout 2 --max-time 3 http://localhost:8080/health | grep -q '"status":"healthy"' || curl -sSk --connect-timeout 2 --max-time 3 https://localhost:8443/health | grep -q '"status":"healthy"' || curl -sSk --connect-timeout 2 --max-time 3 https://localhost:443/health | grep -q '"status":"healthy"' || exit 1
+    CMD curl -fs --connect-timeout 2 --max-time 3 http://localhost:8080/health | jq -e '.status == "healthy"' >/dev/null || curl -fsk --connect-timeout 2 --max-time 3 https://localhost:8443/health | jq -e '.status == "healthy"' >/dev/null || curl -fsk --connect-timeout 2 --max-time 3 https://localhost:443/health | jq -e '.status == "healthy"' >/dev/null || exit 1
 
 # Container startup execution chain:
 # 1. entrypoint.sh - Sets up user permissions, timezone, device access, and performs


### PR DESCRIPTION
## Summary
- Fixes false-positive healthcheck when `RedirectToHTTPS` is enabled — the HTTP server returns a 308 redirect which `curl -f` treats as success, so HTTPS endpoints were never verified
- Switches from `curl -f` (fails only on 4xx/5xx) to body validation via `grep -q healthy`, which correctly rejects 308 redirect responses
- Uses the existing `/health` endpoint instead of `/` for a more meaningful health signal

Follow-up to #2673.

## How it works

| Mode | Port 8080 | Port 8443 | Port 443 |
|------|-----------|-----------|----------|
| Plain HTTP | 200 + "healthy" → pass | conn refused → skip | conn refused → skip |
| Manual TLS (no redirect) | 200 + "healthy" → pass | — | — |
| Manual TLS + redirect | 308, no "healthy" → skip | 200 + "healthy" → pass | — |
| AutoTLS + redirect | 308, no "healthy" → skip | conn refused → skip | 200 + "healthy" → pass |

## Test plan
- [ ] Build Docker image and verify healthcheck passes in plain HTTP mode
- [ ] Enable TLS with `RedirectToHTTPS` and verify healthcheck correctly checks HTTPS
- [ ] Verify healthcheck fails when application is not responding

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved container health monitoring: health checks now probe the /health endpoint on configured ports (such as 8080, 8443 and 443) and require the JSON response to report status "healthy". Containers will be marked unhealthy unless at least one probe returns the expected JSON, improving automatic recovery and failure detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->