### PR TITLE
fix: prevent duplicate sound card selection and enforce default model

### DIFF
--- a/frontend/src/lib/desktop/components/forms/SoundCardCard.svelte
+++ b/frontend/src/lib/desktop/components/forms/SoundCardCard.svelte
@@ -47,9 +47,19 @@
     }>;
   }
 
+  // Default model ID — BirdNET v2.4 is the built-in default
+  const DEFAULT_MODEL_ID = 'birdnet';
+
+  function getDefaultModels(): string[] {
+    const defaultModel = modelOptions.find(m => m.value === DEFAULT_MODEL_ID);
+    if (defaultModel) return [DEFAULT_MODEL_ID];
+    return modelOptions.length > 0 ? [modelOptions[0].value] : [DEFAULT_MODEL_ID];
+  }
+
   interface Props {
     source: AudioSourceConfig;
     index: number;
+    sources: AudioSourceConfig[];
     audioDevices: Array<{ index: number; name: string; id: string }>;
     modelOptions: Array<{ value: string; label: string }>;
     disabled?: boolean;
@@ -60,6 +70,7 @@
   let {
     source,
     index,
+    sources,
     audioDevices,
     modelOptions,
     disabled = false,
@@ -90,15 +101,19 @@
       : (modelOptions[0]?.label ?? '')
   );
 
-  // Device dropdown options
-  let deviceOptions = $derived(audioDevices.map(d => ({ value: d.id, label: d.name })));
+  // Device dropdown options — show current source's device + devices not used by other sources
+  let deviceOptions = $derived(
+    audioDevices
+      .filter(d => d.id === source.device || !sources.some(s => s.device === d.id))
+      .map(d => ({ value: d.id, label: d.name }))
+  );
 
   // Edit mode functions
   function startEdit() {
     editName = source.name;
     editDevice = source.device;
     editGain = source.gain;
-    editModels = [...source.models];
+    editModels = source.models.length > 0 ? [...source.models] : getDefaultModels();
     editEqualizer = source.equalizer
       ? { ...source.equalizer, filters: [...source.equalizer.filters] }
       : { enabled: false, filters: [] };
@@ -114,6 +129,11 @@
   function saveEdit() {
     const trimmedName = editName.trim();
     if (!trimmedName || !editDevice) return;
+
+    // Ensure at least one model is selected
+    if (editModels.length === 0) {
+      editModels = getDefaultModels();
+    }
 
     // Transform equalizer filters to ensure all have an id (required by store type)
     const transformedEqualizer =

--- a/frontend/src/lib/desktop/components/forms/SoundCardManager.svelte
+++ b/frontend/src/lib/desktop/components/forms/SoundCardManager.svelte
@@ -53,6 +53,16 @@
 
   const logger = loggers.audio;
 
+  // Default model ID — BirdNET v2.4 is the built-in default
+  const DEFAULT_MODEL_ID = 'birdnet';
+
+  function getDefaultModels(): string[] {
+    if (availableModels.some(m => m.id === DEFAULT_MODEL_ID)) {
+      return [DEFAULT_MODEL_ID];
+    }
+    return availableModels.length > 0 ? [availableModels[0].id] : [DEFAULT_MODEL_ID];
+  }
+
   // Fetch available models from backend API
   interface BackendModel {
     id: string;
@@ -122,8 +132,12 @@
   let nameError = $state<string | null>(null);
   let deviceError = $state<string | null>(null);
 
-  // Device dropdown options
-  let deviceOptions = $derived(audioDevices.map(d => ({ value: d.id, label: d.name })));
+  // Device dropdown options — filter out devices already configured as sources
+  let deviceOptions = $derived(
+    audioDevices
+      .filter(d => !sources.some(s => s.device === d.id))
+      .map(d => ({ value: d.id, label: d.name }))
+  );
 
   // Clear form errors
   function clearErrors() {
@@ -136,12 +150,19 @@
     newName = '';
     newDevice = '';
     newGain = 0;
-    newModels = [];
+    newModels = getDefaultModels();
     newEqualizer = { enabled: false, filters: [] };
     newQuietHours = { ...defaultQuietHoursConfig };
     showNewEqualizer = false;
     clearErrors();
     showAddForm = false;
+  }
+
+  // Open add form with default model pre-selected
+  function openAddForm() {
+    if (disabled) return;
+    newModels = getDefaultModels();
+    showAddForm = true;
   }
 
   // Add new source
@@ -172,6 +193,11 @@
     if (sources.some(s => s.device === newDevice)) {
       deviceError = t('settings.audio.soundCards.errors.duplicateDevice');
       return;
+    }
+
+    // Ensure at least one model is selected
+    if (newModels.length === 0) {
+      newModels = getDefaultModels();
     }
 
     // Transform equalizer filters to ensure all have an id (required by store type)
@@ -290,7 +316,7 @@
         label: t('settings.audio.soundCards.addSource'),
         icon: Plus,
         onclick: () => {
-          if (!disabled) showAddForm = true;
+          openAddForm();
         },
       }}
     />
@@ -300,6 +326,7 @@
         <SoundCardCard
           {source}
           {index}
+          {sources}
           {audioDevices}
           {modelOptions}
           {disabled}
@@ -451,8 +478,8 @@
       <button
         type="button"
         class="w-full inline-flex items-center justify-center gap-2 h-8 px-3 text-sm rounded-lg border border-dashed border-[var(--border-200)] bg-transparent hover:bg-[var(--color-base-content)]/5 text-[var(--color-base-content)] transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-        onclick={() => (showAddForm = true)}
-        {disabled}
+        onclick={openAddForm}
+        disabled={disabled || deviceOptions.length === 0}
       >
         <Plus class="size-4" />
         {t('settings.audio.soundCards.addSource')}


### PR DESCRIPTION
## Summary

- Filter already-configured audio devices from the device dropdown in the Sound Card settings, preventing users from assigning the same device to multiple capture sources
- Enforce at least one detection model per source, defaulting to BirdNET v2.4 (`birdnet`) when no model is selected
- Disable the "Add Source" button when all available devices are already configured

## Changes

**SoundCardManager.svelte:**
- `deviceOptions` now filters out devices already used by existing sources
- Added `DEFAULT_MODEL_ID` constant and `getDefaultModels()` helper for consistent model defaulting
- Added `openAddForm()` that pre-selects the default model when opening the add form
- `addSource()` validates at least one model is selected before saving
- "Add Source" button disabled when no devices are available

**SoundCardCard.svelte:**
- New `sources` prop enables cross-source device filtering in edit mode
- Device dropdown shows current source's device plus unassigned devices only
- `startEdit()` auto-selects default model if source has empty models array
- `saveEdit()` validates at least one model before saving

## Test plan
- [ ] Add form: configured devices do not appear in device dropdown
- [ ] Add form: model defaults to BirdNET v2.4 on open
- [ ] Edit form: current device appears in dropdown, other configured devices do not
- [ ] Edit form: source with empty models auto-gets default on edit open
- [ ] Delete a source: its device reappears in dropdowns for other cards
- [ ] "Add Source" button disabled when all devices are configured

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Device dropdown now filters out devices already assigned to other audio sources, preventing duplicates.
- Audio models default to 'birdnet' when available.
- "Add Source" button is disabled when no available devices remain.

**Bug Fixes**
- Form now enforces that at least one model must be selected before saving changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->