### PR TITLE
fix: handle IPv6 zone IDs in client IP parsing

### DIFF
--- a/internal/security/basic.go
+++ b/internal/security/basic.go
@@ -157,7 +157,7 @@ func (s *OAuth2Server) HandleBasicAuthToken(c echo.Context) error {
 	// Check if client is in local subnet and configure cookie store accordingly
 	// Only relax cookie security when subnet bypass is explicitly enabled
 	if s.Settings.Security.AllowSubnetBypass.Enabled {
-		if clientIP := net.ParseIP(c.RealIP()); IsInLocalSubnet(clientIP) {
+		if clientIP := parseIPWithZone(c.RealIP()); IsInLocalSubnet(clientIP) {
 			// For clients in the local subnet, allow non-HTTPS cookies
 			secLog.Info("Client is in local subnet, configuring cookie store for non-HTTPS")
 			s.configureLocalNetworkCookieStore()

--- a/internal/security/fuzz_test.go
+++ b/internal/security/fuzz_test.go
@@ -460,7 +460,7 @@ func FuzzIsRequestFromAllowedSubnet(f *testing.F) {
 
 		// If disabled, result must be false (unless loopback)
 		if !enabled {
-			parsedIP := net.ParseIP(ipStr)
+			parsedIP := parseIPWithZone(ipStr)
 			if parsedIP == nil || !parsedIP.IsLoopback() {
 				assert.False(t, result, "Disabled subnet bypass should return false")
 			}
@@ -470,7 +470,7 @@ func FuzzIsRequestFromAllowedSubnet(f *testing.F) {
 		if ipStr == "" {
 			assert.False(t, result, "Empty IP should return false")
 		}
-		if net.ParseIP(ipStr) == nil {
+		if parseIPWithZone(ipStr) == nil {
 			assert.False(t, result, "Invalid IP should return false")
 		}
 

--- a/internal/security/fuzz_test.go
+++ b/internal/security/fuzz_test.go
@@ -896,7 +896,7 @@ func TestAdvancedIPAddressEdgeCases(t *testing.T) {
 		{"Letters in IPv4", "192.168.a.1", false, false},
 
 		// Unusual but valid
-		{"IPv6 with zone", "fe80::1%eth0", false, false}, // ParseIP doesn't handle zones
+		{"IPv6 with zone", "fe80::1%eth0", false, false}, // net.ParseIP doesn't handle zones; use parseIPWithZone
 		{"Full IPv6", "2001:0db8:0000:0000:0000:0000:0000:0001", true, false},
 		{"Compressed IPv6", "2001:db8::1", true, false},
 

--- a/internal/security/ip_utils.go
+++ b/internal/security/ip_utils.go
@@ -10,8 +10,8 @@ import (
 // Go's net.ParseIP does not handle zone IDs (RFC 6874), so clients
 // connecting via IPv6 link-local addresses would otherwise fail to parse.
 func parseIPWithZone(ipStr string) net.IP {
-	if idx := strings.Index(ipStr, "%"); idx != -1 {
-		ipStr = ipStr[:idx]
+	if before, _, found := strings.Cut(ipStr, "%"); found {
+		ipStr = before
 	}
 	return net.ParseIP(ipStr)
 }

--- a/internal/security/ip_utils.go
+++ b/internal/security/ip_utils.go
@@ -1,0 +1,17 @@
+package security
+
+import (
+	"net"
+	"strings"
+)
+
+// parseIPWithZone parses an IP address string, stripping any IPv6 zone ID
+// (the "%interface" suffix, e.g., "%eth0", "%wlan0") before parsing.
+// Go's net.ParseIP does not handle zone IDs (RFC 6874), so clients
+// connecting via IPv6 link-local addresses would otherwise fail to parse.
+func parseIPWithZone(ipStr string) net.IP {
+	if idx := strings.Index(ipStr, "%"); idx != -1 {
+		ipStr = ipStr[:idx]
+	}
+	return net.ParseIP(ipStr)
+}

--- a/internal/security/ip_utils_test.go
+++ b/internal/security/ip_utils_test.go
@@ -1,0 +1,40 @@
+package security
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseIPWithZone(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   string
+		wantNil bool
+		wantStr string
+	}{
+		{"IPv4 unchanged", "192.168.1.1", false, "192.168.1.1"},
+		{"IPv6 without zone", "fe80::1", false, "fe80::1"},
+		{"IPv6 with zone ID eth0", "fe80::1%eth0", false, "fe80::1"},
+		{"IPv6 link-local with zone wlan0", "fe80::1cb6:63bc:5462:71c5%wlan0", false, "fe80::1cb6:63bc:5462:71c5"},
+		{"loopback unchanged", "::1", false, "::1"},
+		{"empty string returns nil", "", true, ""},
+		{"invalid IP with zone returns nil", "not-an-ip%zone", true, ""},
+		{"zone ID with numbers", "fe80::1%12", false, "fe80::1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := parseIPWithZone(tt.input)
+			if tt.wantNil {
+				assert.Nil(t, result, "parseIPWithZone(%q) should return nil", tt.input)
+			} else {
+				assert.NotNil(t, result, "parseIPWithZone(%q) should not return nil", tt.input)
+				assert.Equal(t, tt.wantStr, result.String(), "parseIPWithZone(%q)", tt.input)
+			}
+		})
+	}
+}

--- a/internal/security/oauth.go
+++ b/internal/security/oauth.go
@@ -570,7 +570,7 @@ func (s *OAuth2Server) UpdateProviders() {
 
 // IsUserAuthenticated checks if the user is authenticated
 func (s *OAuth2Server) IsUserAuthenticated(c echo.Context) bool {
-	clientIP := net.ParseIP(c.RealIP())
+	clientIP := parseIPWithZone(c.RealIP())
 	secLog := GetLogger().With(logger.String("client_ip", c.RealIP()))
 	secLog.Debug("Checking user authentication status")
 
@@ -884,7 +884,7 @@ func (s *OAuth2Server) IsRequestFromAllowedSubnet(ipStr string) bool {
 		return false
 	}
 
-	ip := net.ParseIP(ipStr)
+	ip := parseIPWithZone(ipStr)
 	if ip == nil {
 		authLog.Warn("Failed to parse IP address for allowed subnet check", logger.String("ip_string", ipStr))
 		return false


### PR DESCRIPTION
## Summary

Clients connecting via IPv6 link-local addresses with zone IDs (e.g., `fe80::1cb6:63bc:5462:71c5%wlan0`) were getting 401 Unauthorized because Go's `net.ParseIP()` doesn't handle zone IDs and returns nil.

Adds a `parseIPWithZone` helper that strips the `%interface` suffix before parsing, replacing `net.ParseIP` at all three authentication call sites:
- `IsUserAuthenticated` (oauth.go) — subnet bypass check
- `IsRequestFromAllowedSubnet` (oauth.go) — allowed subnet validation
- `HandleBasicAuthToken` (basic.go) — local network cookie configuration

Uses `strings.Cut` per project conventions. Fuzz test updated to use `parseIPWithZone` matching production behavior.

## Test Plan

- [x] 8 unit tests for `parseIPWithZone` covering IPv4, IPv6 with/without zone, empty, invalid
- [x] Full security test suite passes with `-race`
- [x] `golangci-lint` reports 0 issues
- [x] Fuzz test assertions updated to use `parseIPWithZone` instead of `net.ParseIP`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed IPv6 address handling in authentication and subnet-based security checks to properly support zone-suffixed IPv6 addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->