### PR TITLE
fix(api): skip gzip compression for binary media and ranged responses

### DIFF
--- a/internal/api/middleware/compression.go
+++ b/internal/api/middleware/compression.go
@@ -1,6 +1,8 @@
 package middleware
 
 import (
+	"strings"
+
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
 )
@@ -9,20 +11,66 @@ import (
 const (
 	// DefaultGzipLevel is the default compression level (1-9, higher = more compression).
 	DefaultGzipLevel = 5
+
+	// headerRange is the canonical HTTP Range request header name. Echo does
+	// not export a constant for it, so we define one locally to avoid a
+	// magic string.
+	headerRange = "Range"
 )
 
+// binaryMediaRoutes is the set of Echo route templates whose responses are
+// binary media (audio, images) and must never be gzip-compressed.
+//
+// Compressing media responses is always wrong:
+//
+//  1. HTTP/1.1 applies Range requests after Content-Encoding, so ranged
+//     reads through http.ServeContent return slices of compressed bytes
+//     that browsers cannot reassemble. This alone breaks audio seeking.
+//  2. Chromium has rejected gzipped <audio>/<video> responses with
+//     ERR_CONTENT_DECODING_FAILED since crbug 47381 (2010). Firefox strips
+//     Accept-Encoding from media requests entirely (bz 614760). Only Safari
+//     is lenient, and intermediate proxies can still re-pack the doubly
+//     encoded response and make intermittent failures permanent.
+//
+// Lookup uses echo.Context.Path(), which is set by the router to the matched
+// route template (e.g. "/api/v2/audio/:id") before middleware runs. Matching
+// on the template rather than the raw URL prevents accidental matches on
+// JSON endpoints that share a prefix.
+var binaryMediaRoutes = map[string]struct{}{
+	"/api/v2/audio/:id":                         {},
+	"/api/v2/audio/:id/clip":                    {},
+	"/api/v2/audio/:id/process":                 {},
+	"/api/v2/media/audio/:filename":             {},
+	"/api/v2/media/audio":                       {},
+	"/api/v2/spectrogram/:id":                   {},
+	"/api/v2/spectrogram/:id/process":           {},
+	"/api/v2/media/spectrogram/:filename":       {},
+	"/api/v2/media/species-image":               {},
+	"/api/v2/media/image/:scientific_name":      {},
+	"/api/v2/media/bird-image/:scientific_name": {},
+}
+
+// hlsContentRoutePrefix matches token-based HLS playlist and segment routes.
+// The registered route template is /api/v2/streams/hls/t/:streamToken/* where
+// the trailing * is an Echo wildcard. We cannot lookup wildcard templates in
+// binaryMediaRoutes verbatim, so we match them with a prefix check instead.
+//
+// HLS segments are binary MPEG-TS and players range-request them, so they
+// suffer the same Range+gzip incompatibility as audio files.
+const hlsContentRoutePrefix = "/api/v2/streams/hls/t/"
+
 // NewGzip creates a gzip compression middleware with the default compression level.
-// It automatically skips compression for SSE endpoints.
+// It automatically skips compression for SSE, binary media, and ranged requests.
 func NewGzip() echo.MiddlewareFunc {
 	return NewGzipWithLevel(DefaultGzipLevel)
 }
 
 // NewGzipWithLevel creates a gzip compression middleware with a custom compression level.
-// It automatically skips compression for SSE endpoints.
+// It automatically skips compression for SSE, binary media, and ranged requests.
 func NewGzipWithLevel(level int) echo.MiddlewareFunc {
 	return middleware.GzipWithConfig(middleware.GzipConfig{
 		Level:   level,
-		Skipper: SSESkipper,
+		Skipper: DefaultGzipSkipper,
 	})
 }
 
@@ -34,7 +82,38 @@ func NewGzipWithSkipper(level int, skipper middleware.Skipper) echo.MiddlewareFu
 	})
 }
 
+// DefaultGzipSkipper is the default skipper used by NewGzip and NewGzipWithLevel.
+// It skips compression for responses that must not be gzipped:
+//   - Server-Sent Events endpoints (see SSESkipper).
+//   - Binary media routes serving audio, images, or HLS content (see MediaPathSkipper).
+//   - Any request carrying a Range header, since gzip is incompatible with
+//     byte-range responses served via http.ServeContent.
+func DefaultGzipSkipper(c echo.Context) bool {
+	if SSESkipper(c) {
+		return true
+	}
+	if MediaPathSkipper(c) {
+		return true
+	}
+	return c.Request().Header.Get(headerRange) != ""
+}
+
 // SSESkipper is a skipper function that skips compression for Server-Sent Events endpoints.
 func SSESkipper(c echo.Context) bool {
 	return c.Request().Header.Get("Accept") == "text/event-stream"
+}
+
+// MediaPathSkipper returns true when the matched Echo route serves binary
+// media (audio, images, HLS segments) that must not be gzip-compressed.
+//
+// It uses echo.Context.Path(), which is the registered route template set
+// by the router before middleware runs, rather than the raw request URI.
+// Matching on the template prevents a JSON endpoint whose URL happens to
+// contain a media substring from being skipped accidentally.
+func MediaPathSkipper(c echo.Context) bool {
+	p := c.Path()
+	if _, ok := binaryMediaRoutes[p]; ok {
+		return true
+	}
+	return strings.HasPrefix(p, hlsContentRoutePrefix)
 }

--- a/internal/api/middleware/compression_test.go
+++ b/internal/api/middleware/compression_test.go
@@ -1,0 +1,275 @@
+package middleware
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// dummyTextPayload is large enough to exceed any gzip MinLength buffering
+// threshold so the Echo gzip middleware actually emits Content-Encoding: gzip
+// when it decides to compress a response. The content is plain text rather
+// than JSON-shaped to keep testifylint from suggesting assert.JSONEq on the
+// decoded-body equality check below.
+var dummyTextPayload = strings.Repeat("value-ok-repeated-payload ", 200)
+
+// setPathForContext manually sets echo.Context.Path for skipper unit tests
+// that do not go through the router. Echo exposes SetPath() on its Context
+// interface, which is exactly what the router itself calls after Find().
+func setPathForContext(t *testing.T, c echo.Context, routeTemplate string) {
+	t.Helper()
+	c.SetPath(routeTemplate)
+}
+
+func TestSSESkipper(t *testing.T) {
+	t.Parallel()
+
+	t.Run("skips text/event-stream", func(t *testing.T) {
+		t.Parallel()
+		c, _ := newTestContext(t, http.MethodGet, "/anything")
+		c.Request().Header.Set("Accept", "text/event-stream")
+		assert.True(t, SSESkipper(c))
+	})
+
+	t.Run("does not skip JSON accept", func(t *testing.T) {
+		t.Parallel()
+		c, _ := newTestContext(t, http.MethodGet, "/anything")
+		c.Request().Header.Set("Accept", "application/json")
+		assert.False(t, SSESkipper(c))
+	})
+
+	t.Run("does not skip missing accept", func(t *testing.T) {
+		t.Parallel()
+		c, _ := newTestContext(t, http.MethodGet, "/anything")
+		assert.False(t, SSESkipper(c))
+	})
+}
+
+func TestMediaPathSkipper_SkipsBinaryRoutes(t *testing.T) {
+	t.Parallel()
+
+	for route := range binaryMediaRoutes {
+		t.Run(route, func(t *testing.T) {
+			t.Parallel()
+			c, _ := newTestContext(t, http.MethodGet, "/irrelevant")
+			setPathForContext(t, c, route)
+			assert.True(t, MediaPathSkipper(c),
+				"expected route %q to be skipped", route)
+		})
+	}
+}
+
+func TestMediaPathSkipper_SkipsHLSContentWildcard(t *testing.T) {
+	t.Parallel()
+
+	// The actual wildcard template Echo stores when /api/v2/streams/hls/t/:streamToken/*
+	// is registered. Prefix match on c.Path() must return true.
+	wildcardTemplate := "/api/v2/streams/hls/t/:streamToken/*"
+	c, _ := newTestContext(t, http.MethodGet, "/irrelevant")
+	setPathForContext(t, c, wildcardTemplate)
+	assert.True(t, MediaPathSkipper(c),
+		"expected HLS wildcard template to be skipped")
+
+	// Also the bare prefix with a token and segment, as Echo's c.Path()
+	// always returns the template, this guards against a future regression
+	// if someone accidentally switches the implementation to use the raw URI.
+	literalPath := "/api/v2/streams/hls/t/abc123/segment5.ts"
+	c2, _ := newTestContext(t, http.MethodGet, "/irrelevant")
+	setPathForContext(t, c2, literalPath)
+	assert.True(t, MediaPathSkipper(c2),
+		"expected literal HLS path to be skipped via prefix")
+}
+
+func TestMediaPathSkipper_DoesNotSkipJSONRoutes(t *testing.T) {
+	t.Parallel()
+
+	// These are real API routes on adjacent templates that return JSON and
+	// must continue to be compressed. If any of these start getting skipped,
+	// clients will see bloated payloads.
+	jsonRoutes := []string{
+		"/api/v2/spectrogram/:id/status",
+		"/api/v2/spectrogram/:id/generate",
+		"/api/v2/media/species-image/info",
+		"/api/v2/detections",
+		"/api/v2/health",
+		"/api/v2/streams/audio-level",
+		"",
+	}
+	for _, route := range jsonRoutes {
+		t.Run(route, func(t *testing.T) {
+			t.Parallel()
+			c, _ := newTestContext(t, http.MethodGet, "/irrelevant")
+			setPathForContext(t, c, route)
+			assert.False(t, MediaPathSkipper(c),
+				"expected route %q NOT to be skipped", route)
+		})
+	}
+}
+
+func TestDefaultGzipSkipper(t *testing.T) {
+	t.Parallel()
+
+	t.Run("skips SSE", func(t *testing.T) {
+		t.Parallel()
+		c, _ := newTestContext(t, http.MethodGet, "/api/v2/streams/audio-level")
+		c.Request().Header.Set("Accept", "text/event-stream")
+		setPathForContext(t, c, "/api/v2/streams/audio-level")
+		assert.True(t, DefaultGzipSkipper(c))
+	})
+
+	t.Run("skips binary media route", func(t *testing.T) {
+		t.Parallel()
+		c, _ := newTestContext(t, http.MethodGet, "/api/v2/audio/42")
+		setPathForContext(t, c, "/api/v2/audio/:id")
+		assert.True(t, DefaultGzipSkipper(c))
+	})
+
+	t.Run("skips range request on compressible route", func(t *testing.T) {
+		t.Parallel()
+		c, _ := newTestContext(t, http.MethodGet, "/api/v2/detections")
+		setPathForContext(t, c, "/api/v2/detections")
+		c.Request().Header.Set(headerRange, "bytes=0-1023")
+		assert.True(t, DefaultGzipSkipper(c))
+	})
+
+	t.Run("does not skip plain JSON route", func(t *testing.T) {
+		t.Parallel()
+		c, _ := newTestContext(t, http.MethodGet, "/api/v2/detections")
+		setPathForContext(t, c, "/api/v2/detections")
+		assert.False(t, DefaultGzipSkipper(c))
+	})
+}
+
+// TestNewGzip_EndToEnd_AudioRouteNotCompressed is a regression test for
+// tphakala/birdnet-go#2709. It drives a real Echo router with the gzip
+// middleware stack used in production and verifies that a matched audio
+// route is not wrapped in a gzip writer even when the client advertises
+// Accept-Encoding: gzip.
+func TestNewGzip_EndToEnd_AudioRouteNotCompressed(t *testing.T) {
+	t.Parallel()
+
+	e := echo.New()
+	e.Use(NewGzip())
+	// Large payload to ensure the middleware would otherwise compress.
+	e.GET("/api/v2/audio/:id", func(c echo.Context) error {
+		return c.String(http.StatusOK, strings.Repeat("RAW_WAV_BYTES", 2048))
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v2/audio/12345", http.NoBody)
+	req.Header.Set(echo.HeaderAcceptEncoding, "gzip")
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Empty(t, rec.Header().Get(echo.HeaderContentEncoding),
+		"audio route must not be gzip-compressed even when client asks for it")
+	// Sanity check: the raw body is not a gzip stream.
+	assert.False(t, bytes.HasPrefix(rec.Body.Bytes(), []byte{0x1f, 0x8b}),
+		"response body must not start with gzip magic bytes")
+}
+
+// TestNewGzip_EndToEnd_HLSContentNotCompressed verifies the HLS wildcard
+// route is also excluded.
+func TestNewGzip_EndToEnd_HLSContentNotCompressed(t *testing.T) {
+	t.Parallel()
+
+	e := echo.New()
+	e.Use(NewGzip())
+	e.GET("/api/v2/streams/hls/t/:streamToken/*", func(c echo.Context) error {
+		return c.String(http.StatusOK, strings.Repeat("TS_SEGMENT_BYTES", 2048))
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v2/streams/hls/t/tok/segment0.ts", http.NoBody)
+	req.Header.Set(echo.HeaderAcceptEncoding, "gzip")
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Empty(t, rec.Header().Get(echo.HeaderContentEncoding),
+		"HLS segment route must not be gzip-compressed")
+}
+
+// TestNewGzip_EndToEnd_JSONRouteStillCompressed is the negative regression:
+// the fix must not accidentally disable gzip for JSON endpoints.
+func TestNewGzip_EndToEnd_JSONRouteStillCompressed(t *testing.T) {
+	t.Parallel()
+
+	e := echo.New()
+	e.Use(NewGzip())
+	e.GET("/api/v2/detections", func(c echo.Context) error {
+		return c.String(http.StatusOK, dummyTextPayload)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v2/detections", http.NoBody)
+	req.Header.Set(echo.HeaderAcceptEncoding, "gzip")
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "gzip", rec.Header().Get(echo.HeaderContentEncoding),
+		"JSON route should still be gzip-compressed")
+
+	// Verify the body decompresses to the original payload.
+	gzr, err := gzip.NewReader(rec.Body)
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, gzr.Close())
+	}()
+	decoded, err := io.ReadAll(gzr)
+	require.NoError(t, err)
+	assert.Equal(t, dummyTextPayload, string(decoded))
+}
+
+// TestNewGzip_EndToEnd_RangeRequestNotCompressed verifies that any request
+// with a Range header is served without gzip, so http.ServeContent-style
+// range handling works unmodified.
+func TestNewGzip_EndToEnd_RangeRequestNotCompressed(t *testing.T) {
+	t.Parallel()
+
+	e := echo.New()
+	e.Use(NewGzip())
+	e.GET("/api/v2/detections", func(c echo.Context) error {
+		return c.String(http.StatusOK, dummyTextPayload)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v2/detections", http.NoBody)
+	req.Header.Set(echo.HeaderAcceptEncoding, "gzip")
+	req.Header.Set(headerRange, "bytes=0-1023")
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Empty(t, rec.Header().Get(echo.HeaderContentEncoding),
+		"ranged request must not be gzip-compressed")
+}
+
+// TestNewGzip_EndToEnd_SSEStillNotCompressed is a preservation test for the
+// original SSESkipper behavior.
+func TestNewGzip_EndToEnd_SSEStillNotCompressed(t *testing.T) {
+	t.Parallel()
+
+	e := echo.New()
+	e.Use(NewGzip())
+	e.GET("/api/v2/streams/audio-level", func(c echo.Context) error {
+		c.Response().Header().Set(echo.HeaderContentType, "text/event-stream")
+		return c.String(http.StatusOK, "data: {}\n\n")
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v2/streams/audio-level", http.NoBody)
+	req.Header.Set("Accept", "text/event-stream")
+	req.Header.Set(echo.HeaderAcceptEncoding, "gzip")
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Empty(t, rec.Header().Get(echo.HeaderContentEncoding),
+		"SSE endpoint must not be gzip-compressed")
+}


### PR DESCRIPTION
## Summary

The global gzip middleware applied to every API route, including binary audio served via `/api/v2/audio/:id` and adjacent media endpoints. Compressing media responses is incorrect for two independent reasons:

1. HTTP/1.1 applies `Range` requests after `Content-Encoding`, so ranged reads through `http.ServeContent` return slices of compressed bytes that browsers cannot reassemble. This alone breaks audio seeking.
2. Chromium has rejected gzipped `<audio>`/`<video>` responses with `ERR_CONTENT_DECODING_FAILED` since [crbug 47381](https://bugs.chromium.org/p/chromium/issues/detail?id=47381) (2010). Firefox strips `Accept-Encoding` from media requests entirely ([bugzilla 614760](https://bugzilla.mozilla.org/show_bug.cgi?id=614760)), which is why the bug was never reported from Firefox users. Safari is more lenient and masked the bug for those users. Intermediate proxies (Cloudflare, mobile carriers) can re-pack the doubly encoded response and turn intermittent failures into hard ones on certain network paths.

## Changes

Extend the gzip skipper to exclude:

- Registered binary media route templates matched against `echo.Context.Path()`: `/api/v2/audio/:id` and its `/clip` and `/process` subpaths, `/api/v2/media/audio/*`, `/api/v2/spectrogram/:id` and `/process`, `/api/v2/media/spectrogram/:filename`, `/api/v2/media/species-image`, `/api/v2/media/image/:scientific_name`, `/api/v2/media/bird-image/:scientific_name`.
- HLS playlist and segment routes under `/api/v2/streams/hls/t/` (prefix match for the wildcard route template).
- Any request carrying a `Range` header, so ranged responses served by `http.ServeContent` work unchanged.

JSON endpoints under the same prefixes (`/spectrogram/:id/status`, `/spectrogram/:id/generate`, `/media/species-image/info`, etc.) continue to be compressed.

Matching on `echo.Context.Path()` (the registered route template, populated by the router before middleware runs) avoids false matches on raw URL substrings.

## Related Issues

Fixes #2709

## Test Plan

- [x] `go test -race ./internal/api/middleware/...` passes (new compression_test.go drives the real middleware stack via `e.ServeHTTP`)
- [x] `golangci-lint run -v` reports 0 issues
- [x] Positive regression: audio route (`/api/v2/audio/:id`) returns no `Content-Encoding: gzip` when the client sends `Accept-Encoding: gzip`
- [x] Positive regression: HLS segment route returns no `Content-Encoding: gzip`
- [x] Positive regression: a request carrying a `Range` header returns no `Content-Encoding: gzip` on any route
- [x] Negative regression: a JSON route still returns `Content-Encoding: gzip` and the body round-trips through `gzip.NewReader`
- [x] Negative regression: SSE endpoints remain uncompressed (preservation of existing `SSESkipper` behavior)
- [ ] Manual smoke test with `curl -v http://localhost:8080/api/v2/audio/<id> -H 'Accept-Encoding: gzip'` should show no `Content-Encoding: gzip` response header

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved performance by preventing unnecessary gzip compression on audio files, HLS video streams, Server-Sent Events, and range-based requests.

* **Tests**
  * Added comprehensive test coverage for compression behavior across multiple response types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->