### PR TITLE
Fix/standalone ci fixes

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -33,7 +33,7 @@ linters:
     - thelper
     - testifylint
     - gocyclo
-    - modernize
+    # - modernize  # Disabled: causes panic with Go 1.26 and atomic types (known bug in golangci-lint v2.11.4)
     - forbidigo  # Sensitive field name detection
     # Performance linters
     - prealloc

--- a/frontend/src/lib/desktop/components/forms/DateRangePicker.test.ts
+++ b/frontend/src/lib/desktop/components/forms/DateRangePicker.test.ts
@@ -63,7 +63,7 @@ describe('DateRangePicker', () => {
   beforeEach(() => {
     // Set a fixed date for consistent testing
     vi.useFakeTimers();
-    vi.setSystemTime(new Date('2024-01-15Z'));
+    vi.setSystemTime(new Date(2024, 0, 15));
   });
 
   afterEach(() => {


### PR DESCRIPTION
## Summary

Two pre-existing CI failures unrelated to any feature work:

- **golangci-lint panic** — the `modernize` linter causes a panic in golangci-lint v2.11.4 when analyzing Go 1.26 code that uses atomic types (known upstream bug). Disabled with a comment explaining the version and reason so it's easy to re-enable once a fixed release ships.
- **DateRangePicker test timezone failure** — `vi.setSystemTime(new Date('2024-01-15Z'))` sets UTC midnight, which resolves to Jan 14 local time in any negative-offset timezone (CST, EST, etc.). The component builds "today" using local date components (`getFullYear/getMonth/getDate`), so the test failed whenever run outside UTC. Fixed by using `new Date(2024, 0, 15)` (local midnight) to match the component's own date construction.

## Test plan

- [ ] `golangci-lint run -v` completes without panic
- [ ] `npm test` in `frontend/` — `DateRangePicker > Presets > applies preset when clicked` passes in all timezone environments


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated linter configuration to address compatibility issue
  * Updated test infrastructure for proper time initialization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->