### PR TITLE
chore(frontend): vite config follow-ups from #2722

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -2,15 +2,41 @@ import { defineConfig } from 'vite'
 import { svelte } from '@sveltejs/vite-plugin-svelte'
 import tailwindcss from '@tailwindcss/vite'
 import { svelteTesting } from '@testing-library/svelte/vite'
-import { copyFileSync, mkdirSync, readdirSync, existsSync } from 'fs'
+import { copyFileSync, mkdirSync, readdirSync, readFileSync, existsSync } from 'fs'
 import { join } from 'path'
+import { createHash } from 'node:crypto'
+
+/**
+ * Compute a stable i18n cache version from the content of
+ * `static/messages/*.json`. This replaces `Date.now()` so two builds from
+ * identical sources produce identical bundle content hashes (reproducible
+ * builds) and the i18n localStorage cache only evicts when translations
+ * actually change.
+ *
+ * Returns 'dev' if the messages directory is missing or empty so dev/test
+ * runs still get a well-defined value.
+ */
+function computeI18nCacheVersion() {
+  const sourceDir = './static/messages'
+  if (!existsSync(sourceDir)) return 'dev'
+  const files = readdirSync(sourceDir)
+    .filter(f => f.endsWith('.json'))
+    .sort()
+  if (files.length === 0) return 'dev'
+  const hash = createHash('sha256')
+  for (const file of files) {
+    hash.update(file)
+    hash.update(readFileSync(join(sourceDir, file)))
+  }
+  return hash.digest('hex').slice(0, 8)
+}
 
 // https://vite.dev/config/
 export default defineConfig({
   base: '/ui/assets/',
   publicDir: 'static',
   define: {
-    __I18N_CACHE_VERSION__: JSON.stringify(Date.now().toString(36)),
+    __I18N_CACHE_VERSION__: JSON.stringify(computeI18nCacheVersion()),
   },
   plugins: [
     tailwindcss(),
@@ -80,10 +106,6 @@ export default defineConfig({
     chunkSizeWarningLimit: 1000,
     emptyOutDir: true,
     manifest: true, // Generates .vite/manifest.json for cache busting
-    // Watch mode uses Rolldown's default watcher options under Vite 8.
-    // The previous chokidar polling config was removed because Rolldown's
-    // WatcherOptions type no longer accepts a nested `chokidar` key.
-    watch: process.argv.includes('--watch') ? {} : null,
     rollupOptions: {
       output: {
         // Content hashes enable proper cache busting with CDNs like Cloudflare
@@ -92,7 +114,16 @@ export default defineConfig({
         assetFileNames: '[name]-[hash].[ext]',
         manualChunks(id) {
           if (id.includes('node_modules/svelte/')) return 'vendor';
-          if (id.includes('node_modules/chart.js/')) return 'charts';
+          if (
+            id.includes('node_modules/chart.js/') ||
+            id.includes('node_modules/chartjs-adapter-date-fns/')
+          )
+            return 'charts';
+          // `node_modules/d3` (no trailing slash) intentionally catches the
+          // whole d3 family: d3, d3-scale-chromatic, d3-time-format, etc.
+          if (id.includes('node_modules/d3')) return 'd3';
+          if (id.includes('node_modules/@sentry/')) return 'sentry';
+          if (id.includes('node_modules/maplibre-gl/')) return 'maps';
           return undefined;
         },
       },

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -2,9 +2,14 @@ import { defineConfig } from 'vite'
 import { svelte } from '@sveltejs/vite-plugin-svelte'
 import tailwindcss from '@tailwindcss/vite'
 import { svelteTesting } from '@testing-library/svelte/vite'
-import { copyFileSync, mkdirSync, readdirSync, readFileSync, existsSync } from 'fs'
-import { join } from 'path'
+import { copyFileSync, mkdirSync, readdirSync, readFileSync, existsSync } from 'node:fs'
+import { join } from 'node:path'
 import { createHash } from 'node:crypto'
+
+// Single source of truth for the translation files directory. Both the i18n
+// cache version helper and the copy-messages plugin reference this path so
+// they cannot drift apart.
+const MESSAGES_SOURCE_DIR = './static/messages'
 
 /**
  * Compute a stable i18n cache version from the content of
@@ -17,7 +22,7 @@ import { createHash } from 'node:crypto'
  * runs still get a well-defined value.
  */
 function computeI18nCacheVersion() {
-  const sourceDir = './static/messages'
+  const sourceDir = MESSAGES_SOURCE_DIR
   if (!existsSync(sourceDir)) return 'dev'
   const files = readdirSync(sourceDir)
     .filter(f => f.endsWith('.json'))
@@ -69,9 +74,9 @@ export default defineConfig({
           // Create messages directory in dist
           const messagesDir = './dist/messages';
           mkdirSync(messagesDir, { recursive: true });
-          
+
           // Copy all message files
-          const sourceDir = './static/messages';
+          const sourceDir = MESSAGES_SOURCE_DIR;
           
           // Check if source directory exists
           if (!existsSync(sourceDir)) {

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -24,9 +24,23 @@ function computeI18nCacheVersion() {
     .sort()
   if (files.length === 0) return 'dev'
   const hash = createHash('sha256')
+  // NUL-byte delimiter prevents collisions between (filename, content) pairs:
+  // without it, `a.json` containing `bc` and `ab.json` containing `c` both
+  // hash the byte stream `abc` and produce the same digest.
+  const delimiter = Buffer.from([0])
   for (const file of files) {
     hash.update(file)
-    hash.update(readFileSync(join(sourceDir, file)))
+    hash.update(delimiter)
+    try {
+      hash.update(readFileSync(join(sourceDir, file)))
+    } catch (/** @type {any} */ err) {
+      // Surface the failing file name then re-throw so the build fails loudly
+      // rather than silently producing a 'dev' cache version that masks the
+      // problem.
+      console.error(`[i18n-cache-version] Failed to read ${file}:`, err.message)
+      throw err
+    }
+    hash.update(delimiter)
   }
   return hash.digest('hex').slice(0, 8)
 }
@@ -119,9 +133,15 @@ export default defineConfig({
             id.includes('node_modules/chartjs-adapter-date-fns/')
           )
             return 'charts';
-          // `node_modules/d3` (no trailing slash) intentionally catches the
-          // whole d3 family: d3, d3-scale-chromatic, d3-time-format, etc.
-          if (id.includes('node_modules/d3')) return 'd3';
+          // Catch the whole d3 family: bare `d3/` and the `d3-*` packages
+          // (d3-scale-chromatic, d3-time-format, d3-array, etc.). Requiring
+          // a `/` or `-` after `d3` avoids matching unrelated packages like
+          // `d3x` or stray `d3.js` filenames inside other packages.
+          if (
+            id.includes('node_modules/d3/') ||
+            id.includes('node_modules/d3-')
+          )
+            return 'd3';
           if (id.includes('node_modules/@sentry/')) return 'sentry';
           if (id.includes('node_modules/maplibre-gl/')) return 'maps';
           return undefined;


### PR DESCRIPTION
## Summary

Three small follow-ups to the Vite 8 upgrade (#2722), all in `frontend/vite.config.js`:

1. **Reproducible builds + sane i18n cache eviction.** Replace `Date.now().toString(36)` in `__I18N_CACHE_VERSION__` with a sha256 content hash of `static/messages/*.json`. Two builds from identical sources now produce identical bundle content hashes (reproducible builds), and the i18n localStorage cache only evicts when translations actually change. NUL-byte delimiters in the hash stream prevent (filename, content) collisions.

2. **Expanded `manualChunks`.** Add explicit entries that `#2722` deferred to keep the Rolldown swap as the only variable under test. Now that the baseline is established:
   - `chartjs-adapter-date-fns` joins the existing `charts` chunk
   - The d3 family is consolidated into a new `d3` chunk (matched via `node_modules/d3/` || `node_modules/d3-` so unrelated `d3*` packages can't sneak in)
   - `@sentry/*` and `maplibre-gl` get explicit `sentry`/`maps` entries — Rolldown was already auto-splitting them, but explicit entries protect against future regressions where a code change accidentally hoists them back into `index`
   - Bundle delta vs main: **+149 bytes total**, pure reorganization

3. **Removed `watch: process.argv.includes('--watch') ? {} : null`.** Vite's CLI handles `--watch` natively under Rolldown; the conditional empty-object property was a no-op vestige of the pre-Rolldown chokidar polling config that #2722 already removed the nested key from. Inspecting `process.argv` from inside the config also breaks programmatic invocation and is sloppy string matching.

## Test Plan

- [x] Two consecutive `npm run build` runs produce byte-identical output (sha256 of every chunk verified)
- [x] Bundle sizes within noise of post-#2722 baseline (vendor 56kb, charts 254kb, sentry 78kb, d3 93kb [new], maps 1049kb, index 995kb)
- [x] `npm run check:all` passes (eslint + stylelint + svelte-check + ast-grep)
- [x] All 1823 frontend tests pass
- [x] Local CodeRabbit review: no findings
- [x] Local Gemini review: 8 findings, 3 fixed (hash delimiter, error handling, d3 match), 5 rejected as hypothetical or non-applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Internationalization cache now uses content-based, deterministic versioning for more reliable cache invalidation.
  * Centralized messages source constant to keep i18n cache and copy paths in sync.
  * Optimized code-splitting with dedicated bundles for charts, D3, error-tracking, and mapping libraries.
  * Simplified build/watch behavior by removing a custom watcher override, relying on default watcher semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->