### PR TITLE
fix(frontend): resolve two post-Vite-8 frontend regressions

### DIFF
--- a/frontend/src/styles/custom.css
+++ b/frontend/src/styles/custom.css
@@ -212,11 +212,6 @@
   }
 }
 
-.settings-form-grid .form-control {
-  display: flex;
-  flex-direction: column;
-}
-
 /* Ensure labels have consistent height to align input fields.
    min-height: 2rem (32px) provides enough space for label text while
    preventing vertical misalignment when labels wrap or have different

--- a/frontend/src/styles/custom.css
+++ b/frontend/src/styles/custom.css
@@ -195,22 +195,37 @@
    Form Field Helpers
    ======================================================================== */
 
-/* Settings form grid alignment - ensures consistent field heights */
+/* Settings form grid alignment - ensures consistent field heights.
+   Plain CSS rather than Tailwind @apply: this file is imported via
+   @import url('./custom.css') layer(base) which puts it in its own CSS
+   processing context, so @apply directives are not resolved by Tailwind
+   and previously leaked through to the browser as literal at-rules. */
 .settings-form-grid {
-  @apply grid grid-cols-1 md:grid-cols-3 gap-6;
+  display: grid;
+  grid-template-columns: repeat(1, minmax(0, 1fr));
+  gap: 1.5rem;
+}
+
+@media (min-width: 768px) {
+  .settings-form-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
 }
 
 .settings-form-grid .form-control {
-  @apply flex flex-col;
+  display: flex;
+  flex-direction: column;
 }
 
-/* Ensure labels have consistent height to align input fields
-   min-h-[2rem] (32px) provides enough space for label text while preventing
-   vertical misalignment when labels wrap or have different heights.
-   This ensures all input fields in the same row start at the same vertical position. */
+/* Ensure labels have consistent height to align input fields.
+   min-height: 2rem (32px) provides enough space for label text while
+   preventing vertical misalignment when labels wrap or have different
+   heights, so all input fields in the same row start at the same
+   vertical position. */
 .settings-form-grid .form-control > label:first-child,
 .settings-form-grid .form-control > .label:first-child {
-  @apply min-h-8 items-start;
+  min-height: 2rem;
+  align-items: flex-start;
 }
 
 /* ========================================================================

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -148,7 +148,14 @@ export default defineConfig({
           )
             return 'd3';
           if (id.includes('node_modules/@sentry/')) return 'sentry';
-          if (id.includes('node_modules/maplibre-gl/')) return 'maps';
+          // Do NOT manually chunk maplibre-gl. It ships as UMD/CJS and
+          // Rolldown's manualChunks path emits a broken
+          //   export { maplibre_gl_exports as n, t }
+          // that references an undeclared `maplibre_gl_exports` identifier,
+          // throwing SyntaxError at module load. Letting Rolldown auto-chunk
+          // it (returning undefined) produces a working isolated chunk.
+          // See https://github.com/rolldown/rolldown/ — known UMD wrapping
+          // bug under manualChunks.
           return undefined;
         },
       },


### PR DESCRIPTION
## Summary

Two independent frontend bugs surfaced after the Vite 7 → 8 upgrade. They're unrelated to each other in mechanism but share the root cause of the Vite 8 toolchain swap (esbuild → lightningcss for CSS, Rollup → Rolldown for JS).

### 1. CSS `@apply` leak in `custom.css`

`.settings-form-grid` rules in `frontend/src/styles/custom.css` used Tailwind `@apply` directives, but the file is pulled in via `@import url('./custom.css') layer(base)` into `tailwind.css`, which puts it in its own CSS processing context where Tailwind's utility scope is not available. The `@apply` directives were never resolved — they leaked through the build pipeline as literal at-rules and silently failed in the browser.

**Symptom:** `.settings-form-grid` (used 4× in `AudioSettingsPage.svelte` for the Sound Card / Streams / Processing / Export sections) had no styling in production. The intended `md:grid-cols-3` desktop layout fell back to default block flow.

The bug existed before the Vite 8 upgrade but was masked by esbuild silently passing unknown at-rules through. Vite 8's lightningcss minifier warns about them, surfacing the issue.

**Fix:** Replace the three `@apply` rules with their resolved plain-CSS equivalents (`display: grid` + 768px media query, `display: flex` column, `min-height: 2rem` + `align-items: flex-start`). Tailwind v4's `@reference "tailwindcss"` directive was tried first but in this `layer()` import context it stripped the wrapping selectors and left the `@apply` at-rules orphaned at top level — worse than before.

### 2. Rolldown UMD chunking bug for `maplibre-gl`

Commit 80e45a65 added `maplibre-gl → 'maps'` to `vite.config.js` `manualChunks` defensively. Rolldown's UMD wrapping path under `manualChunks` emits a broken
```
export { maplibre_gl_exports as n, t }
```
that references an undeclared `maplibre_gl_exports` identifier, throwing
```
SyntaxError: Export 'maplibre_gl_exports' is not defined in module
```
at module load. The map fails to load anywhere it's dynamically imported — Settings → Main → Location, dashboard banner location map, wizard location picker.

`@sentry/*` is unaffected because it ships as native ES modules with proper named exports (verified — sentry chunk's `export {Dr as n,Nt as r,Ds as t}` references real local bindings, no synthetic `_exports` identifier).

**Fix:** Remove `maplibre-gl` from `manualChunks` and let Rolldown auto-chunk it. Per the original Vite 8 commit message, maplibre-gl "was already auto-split by Rolldown" before the explicit assignment was added — this just restores that prior, working behavior. The auto-chunked output uses `export default t();` which works correctly.

**Trade-off:** Loses the defensive guarantee that a stray static `import 'maplibre-gl'` could not be hoisted into the index chunk. All current usages are dynamic `import('maplibre-gl')`; a future static import would be a separate, easily caught regression.

## Test Plan

- [x] `task frontend-build` produces zero lightningcss `@apply` warnings
- [x] `dist/index-*.css` contains the resolved `.settings-form-grid` rules (`display: grid`, `gap: 1.5rem`, `repeat(3, ...)` inside `@media (min-width: 768px)`) with zero literal `@apply` directives
- [x] `dist/maplibre-gl-*.js` chunk ends in `export default t();` (no broken `maplibre_gl_exports` reference)
- [x] `npm run check:all` passes 5046 files with 0 errors and 0 warnings (stylelint, svelte-check, ast-grep)
- [x] Manual: Settings → Audio Settings → Sound Card / Streams / Processing / Export tabs render the intended 3-column grid at viewports ≥768px wide
- [x] Manual: Settings → Main → Location tab loads the MapLibre map without console errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved settings form layout and label spacing for clearer, more responsive presentation.

* **Bug Fixes**
  * Fixed a bundling/configuration issue that could prevent map functionality from loading correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->