### PR TITLE
fix(frontend): defer Settings map init until container is bound

### DIFF
--- a/frontend/src/lib/desktop/features/settings/pages/MainSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/MainSettingsPage.svelte
@@ -23,6 +23,7 @@
   @component
 -->
 <script lang="ts">
+  import { tick } from 'svelte';
   import NumberField from '$lib/desktop/components/forms/NumberField.svelte';
   import Checkbox from '$lib/desktop/components/forms/Checkbox.svelte';
   import SelectDropdown from '$lib/desktop/components/forms/SelectDropdown.svelte';
@@ -403,7 +404,13 @@
     loadInitialData();
   });
 
-  // LAZY LOADING: Initialize map only when Location tab becomes active
+  // LAZY LOADING: Initialize map only when Location tab becomes active.
+  // The Location tab panel is conditionally rendered via `{#if isActive}` in
+  // SettingsTabs.svelte, so the `bind:this={mapElement}` target may not be
+  // attached to the DOM in the same reactive round that flips `activeTab`.
+  // Await a tick so the DOM settles, then double-check the container is
+  // actually connected before handing it to MapLibre — otherwise MapLibre's
+  // internal `_resolveContainer` throws on a null/undefined element.
   $effect(() => {
     const isLocationTab = activeTab === 'location';
     const hasActualCoordinates =
@@ -411,17 +418,16 @@
       $birdnetSettings.latitude !== undefined &&
       $birdnetSettings.longitude !== undefined;
 
-    if (
-      isLocationTab &&
-      !store.isLoading &&
-      mapElement &&
-      !mapInitialized &&
-      hasActualCoordinates
-    ) {
+    if (!isLocationTab || store.isLoading || mapInitialized || !hasActualCoordinates) {
+      return;
+    }
+
+    tick().then(() => {
+      if (!mapElement || !mapElement.isConnected) return;
       logger.debug('Location tab active - initializing map lazily');
       initializeMap();
       mapInitialized = true;
-    }
+    });
   });
 
   let initialLoadComplete = $state(false);
@@ -577,7 +583,15 @@
   const createMapStyle = createMapStyleFromConfig;
 
   async function initializeMap() {
-    if (!mapElement || mapInitialized) return;
+    // Belt-and-suspenders guard: the effect above already waits for a tick
+    // and checks `mapElement.isConnected`, but keep a local check so any
+    // future caller fails cleanly instead of crashing inside MapLibre's
+    // `_resolveContainer` when the container is null/undefined/detached.
+    if (!mapElement || !mapElement.isConnected) {
+      logger.warn('initializeMap called without a bound container');
+      return;
+    }
+    if (mapInitialized) return;
 
     try {
       if (!maplibregl) {

--- a/frontend/src/lib/desktop/features/settings/pages/MainSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/MainSettingsPage.svelte
@@ -397,11 +397,14 @@
   let modalMarker: import('maplibre-gl').Marker | null = null;
   let mapModalOpen = $state(false);
   let mapInitialized = $state(false);
-  // mapLoadError sticks after a hard failure (dynamic import network error,
-  // MapLibre constructor throw) so the effect below does NOT keep retrying
-  // on every reactive cycle. Recoverable failures (container detached during
-  // import) intentionally do NOT set this — the next visit to the Location
-  // tab will retry naturally.
+  // mapLoadError sticks during the current Location tab visit after a hard
+  // failure (dynamic import network error, MapLibre constructor throw) so the
+  // effect below does NOT infinite-retry on every reactive cycle. The flag is
+  // automatically reset when the user leaves the Location tab so the next
+  // visit gets a fresh attempt — making transient failures user-recoverable
+  // by toggling away and back, instead of permanently stuck until reload.
+  // Recoverable failures (container detached during import) intentionally do
+  // NOT set this and naturally retry on the next reactive cycle.
   let mapLoadError = $state(false);
   let mapLibraryLoading = $state(false);
 
@@ -419,16 +422,32 @@
   // internal `_resolveContainer` throws on a null/undefined element.
   $effect(() => {
     const isLocationTab = activeTab === 'location';
+
+    // Reset the sticky error flag when leaving the Location tab so the next
+    // visit gets a fresh init attempt. This makes a hard failure (e.g., a
+    // transient network error during the maplibre-gl import) recoverable
+    // by toggling away from the tab and back, rather than permanently
+    // blocking the map until full page reload.
+    if (!isLocationTab) {
+      if (mapLoadError) {
+        mapLoadError = false;
+      }
+      return;
+    }
+
     const hasActualCoordinates =
       $birdnetSettings &&
       $birdnetSettings.latitude !== undefined &&
       $birdnetSettings.longitude !== undefined;
 
+    // Include `mapLibraryLoading` in the guard so a reactive cycle that
+    // fires while the dynamic `import('maplibre-gl')` is in flight does NOT
+    // kick off a second concurrent `initializeMap()` call.
     if (
-      !isLocationTab ||
       store.isLoading ||
       mapInitialized ||
       mapLoadError ||
+      mapLibraryLoading ||
       !hasActualCoordinates
     ) {
       return;

--- a/frontend/src/lib/desktop/features/settings/pages/MainSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/MainSettingsPage.svelte
@@ -397,6 +397,12 @@
   let modalMarker: import('maplibre-gl').Marker | null = null;
   let mapModalOpen = $state(false);
   let mapInitialized = $state(false);
+  // mapLoadError sticks after a hard failure (dynamic import network error,
+  // MapLibre constructor throw) so the effect below does NOT keep retrying
+  // on every reactive cycle. Recoverable failures (container detached during
+  // import) intentionally do NOT set this — the next visit to the Location
+  // tab will retry naturally.
+  let mapLoadError = $state(false);
   let mapLibraryLoading = $state(false);
 
   // Load initial data
@@ -418,7 +424,13 @@
       $birdnetSettings.latitude !== undefined &&
       $birdnetSettings.longitude !== undefined;
 
-    if (!isLocationTab || store.isLoading || mapInitialized || !hasActualCoordinates) {
+    if (
+      !isLocationTab ||
+      store.isLoading ||
+      mapInitialized ||
+      mapLoadError ||
+      !hasActualCoordinates
+    ) {
       return;
     }
 
@@ -431,11 +443,15 @@
     const el = mapElement;
     if (!el) return;
 
-    tick().then(() => {
+    void tick().then(() => {
       if (!el.isConnected) return;
       logger.debug('Location tab active - initializing map lazily');
-      initializeMap();
-      mapInitialized = true;
+      // initializeMap() owns the `mapInitialized = true` flip after the
+      // MapLibre constructor returns successfully. Setting it here would
+      // mark the map as initialized even when initializeMap() aborts later
+      // (e.g., the tab unmounted during the dynamic import), permanently
+      // blocking future re-init attempts.
+      void initializeMap();
     });
   });
 
@@ -600,7 +616,7 @@
       logger.warn('initializeMap called without a bound container');
       return;
     }
-    if (mapInitialized) return;
+    if (mapInitialized || mapLoadError) return;
 
     try {
       if (!maplibregl) {
@@ -616,7 +632,9 @@
           mapLibraryLoading = false;
           logger.error('Failed to load MapLibre GL JS:', importError);
           toastActions.error(t('settings.main.errors.mapLibraryLoadFailed'));
-          mapInitialized = false;
+          // Hard failure: stick the error flag so the effect does NOT retry
+          // on every reactive cycle (each retry would re-import and re-toast).
+          mapLoadError = true;
           return;
         }
 
@@ -647,6 +665,13 @@
         pitchWithRotate: MAP_CONFIG.PITCH_WITH_ROTATE,
         touchZoomRotate: MAP_CONFIG.TOUCH_ZOOM_ROTATE,
       });
+
+      // Map construction succeeded — flip the flag here, AFTER the
+      // constructor returns. The previous design set this from the effect
+      // before initializeMap() ran, so an abort partway through (e.g., the
+      // post-import isConnected check above) would leave map=null but
+      // mapInitialized=true, permanently blocking re-init.
+      mapInitialized = true;
 
       map.on('load', () => {
         if (map) {
@@ -692,7 +717,10 @@
     } catch (error) {
       logger.error('Failed to initialize map:', error);
       toastActions.error(t('settings.main.errors.mapLoadFailed'));
-      mapInitialized = false;
+      // Hard failure: stick the error flag so the effect does NOT retry on
+      // every reactive cycle. mapInitialized was not yet set so we don't
+      // need to reset it.
+      mapLoadError = true;
     }
   }
 

--- a/frontend/src/lib/desktop/features/settings/pages/MainSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/MainSettingsPage.svelte
@@ -422,8 +422,17 @@
       return;
     }
 
+    // Synchronous read so Svelte tracks `mapElement` as a reactive dependency
+    // of this effect. Without this, the `mapElement` access inside the
+    // `tick().then(...)` microtask callback below is NOT tracked — effects
+    // only pick up dependencies read synchronously during the effect body —
+    // and the effect would never re-run when `bind:this` populates
+    // `mapElement` after the conditional `{#if isActive}` mounts the tab.
+    const el = mapElement;
+    if (!el) return;
+
     tick().then(() => {
-      if (!mapElement || !mapElement.isConnected) return;
+      if (!el.isConnected) return;
       logger.debug('Location tab active - initializing map lazily');
       initializeMap();
       mapInitialized = true;
@@ -608,6 +617,17 @@
           logger.error('Failed to load MapLibre GL JS:', importError);
           toastActions.error(t('settings.main.errors.mapLibraryLoadFailed'));
           mapInitialized = false;
+          return;
+        }
+
+        // Re-verify the container is still connected after the dynamic
+        // import. The user may have switched away from the Location tab
+        // while MapLibre was being imported, which unmounts `mapElement`
+        // (the tab panel is conditionally rendered via `{#if isActive}`).
+        // Without this check we'd hand a detached node to MapLibre and
+        // `_resolveContainer` would throw or create a zombie map.
+        if (!mapElement || !mapElement.isConnected) {
+          logger.warn('initializeMap aborted: container detached during import');
           return;
         }
       }


### PR DESCRIPTION
## Summary

Fix a MapLibre GL crash on the Settings page Location tab. The error `Invalid type: 'container' must be a String or HTMLElement` fired when `bind:this={mapElement}` had not yet completed by the time the `$effect` ran — the Location tab content is gated by `{#if isActive}` in `SettingsTabs.svelte`, and Svelte 5 only tracks dependencies read synchronously inside an `$effect` body.

- Read `mapElement` synchronously into a local at the top of the effect so Svelte 5 tracks it as a reactive dependency. Without this the original (positive-condition) read was the only thing keeping the effect re-running on bind.
- Defer the actual `initializeMap()` call to the next microtask via `tick()`, with an `isConnected` check to confirm the element is still in the DOM.
- Add a second `isConnected` check inside `initializeMap()` after `await Promise.all([...])` for the dynamic `maplibre-gl` import — the user can switch away from the Location tab while the import is in flight, unmounting the container before MapLibre tries to attach.
- Defensive guard inside `initializeMap()` itself so any future caller fails cleanly instead of crashing inside MapLibre's `_resolveContainer`.

Both fixes were prompted by Gemini code review and addressed before push.

## Test Plan

- [ ] `npm run check:all` — green (lint, prettier, stylelint, svelte-check 0 errors)
- [ ] Hard-refresh `/ui/settings/main` with latitude/longitude already configured.
- [ ] Switch rapidly between General / Detection / Location / Database tabs. Map should render on first Location visit. Console stays clean.
- [ ] Throttle DevTools network to Slow 3G, hard-refresh `/ui/settings/main`, click into Location and immediately back to General before `maplibre-gl` finishes downloading. Console should log `initializeMap aborted: container detached during import` and not crash. Returning to Location should still initialize the map.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of map initialization on the Location settings tab to prevent errors when the tab is first accessed or dynamically rendered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->