### PR TITLE
fix(imageprovider+support): handle Avicommons license variants and skip journald in containers

### DIFF
--- a/internal/imageprovider/avicommons.go
+++ b/internal/imageprovider/avicommons.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/fs"
+	"regexp"
 	"strings"
 	"sync"
 
@@ -44,6 +45,10 @@ type AviCommonsProvider struct {
 var (
 	// loggedUnknownLicenses tracks unknown license codes to avoid repeated warnings.
 	loggedUnknownLicenses sync.Map
+
+	// aviCommonsVersionSuffix matches a trailing version number like " 3.0" or " 4"
+	// on license display names (e.g. "CC BY 3.0"). Compiled once at package load.
+	aviCommonsVersionSuffix = regexp.MustCompile(`\s+\d+(\.\d+)?$`)
 )
 
 // NewAviCommonsProvider creates a new provider instance using data from the provided filesystem.
@@ -215,11 +220,41 @@ func (p *AviCommonsProvider) Fetch(scientificName string) (BirdImage, error) {
 	}, nil
 }
 
-// mapAviCommonsLicense converts Avicommons license codes to names and URLs.
-// This is a basic implementation and might need refinement.
+// normalizeAviCommonsLicense converts raw license strings from the Avicommons
+// dataset into canonical slug form so the lookup switch works for both legacy
+// slug codes ("cc-by-nc") and display-name variants like "CC BY 3.0" or
+// "CC BY-NC-SA 4.0" observed in production data.
+//
+// The normalization pipeline is:
+//  1. Trim surrounding whitespace.
+//  2. Lowercase the whole string for case-insensitive matching.
+//  3. Strip any trailing version suffix (e.g. " 3.0", " 4").
+//  4. Replace remaining inner whitespace with hyphens.
+//
+// Examples:
+//
+//	"CC BY 3.0"       -> "cc-by"
+//	"CC BY-NC-SA 4.0" -> "cc-by-nc-sa"
+//	"CC0 3.0"         -> "cc0"
+//	"cc-by-nc"        -> "cc-by-nc" (unchanged)
+func normalizeAviCommonsLicense(code string) string {
+	normalized := strings.ToLower(strings.TrimSpace(code))
+	normalized = aviCommonsVersionSuffix.ReplaceAllString(normalized, "")
+	normalized = strings.TrimSpace(normalized)
+	// Collapse any internal whitespace runs to a single hyphen so
+	// "cc by  nc" becomes "cc-by-nc" rather than "cc-by--nc".
+	normalized = strings.Join(strings.Fields(normalized), "-")
+	return normalized
+}
+
+// mapAviCommonsLicense converts Avicommons license codes to display names and
+// canonical URLs. Both slug-style codes (e.g. "cc-by-nc") and display-name
+// variants (e.g. "CC BY-NC 4.0") are accepted — see normalizeAviCommonsLicense.
+// Unknown codes return the raw input as the name with an empty URL and log a
+// one-shot warning so the Sentry noise in bug reports stays bounded.
 func mapAviCommonsLicense(code string) (name, url string) {
 	// No logging needed here as it's a pure function
-	switch strings.ToLower(code) {
+	switch normalizeAviCommonsLicense(code) {
 	case "cc-by":
 		return "CC BY 4.0", "https://creativecommons.org/licenses/by/4.0/"
 	case "cc-by-sa":

--- a/internal/imageprovider/avicommons_test.go
+++ b/internal/imageprovider/avicommons_test.go
@@ -11,9 +11,13 @@ import (
 // codes and the display-name variants observed in production data. The
 // normalization helper should fold things like "CC BY 3.0" onto the same
 // canonical "cc-by" case so the switch returns proper names and URLs.
+//
+// Note: this test intentionally does NOT call t.Parallel() because
+// mapAviCommonsLicense mutates the package-global loggedUnknownLicenses
+// sync.Map via LoadOrStore when it encounters an unknown code. Per the
+// project coding guideline, tests that mutate global state must run
+// sequentially.
 func TestMapAviCommonsLicense(t *testing.T) {
-	t.Parallel()
-
 	const (
 		ccBYName        = "CC BY 4.0"
 		ccBYURL         = "https://creativecommons.org/licenses/by/4.0/"
@@ -70,8 +74,7 @@ func TestMapAviCommonsLicense(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
+			// No t.Parallel(): see note on the outer test.
 			gotName, gotURL := mapAviCommonsLicense(tt.input)
 			assert.Equal(t, tt.wantName, gotName, "license name mismatch for input %q", tt.input)
 			assert.Equal(t, tt.wantURL, gotURL, "license URL mismatch for input %q", tt.input)

--- a/internal/imageprovider/avicommons_test.go
+++ b/internal/imageprovider/avicommons_test.go
@@ -1,0 +1,109 @@
+// avicommons_test.go: unit tests for Avicommons license code normalization.
+package imageprovider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestMapAviCommonsLicense covers both the historical slug-style license
+// codes and the display-name variants observed in production data. The
+// normalization helper should fold things like "CC BY 3.0" onto the same
+// canonical "cc-by" case so the switch returns proper names and URLs.
+func TestMapAviCommonsLicense(t *testing.T) {
+	t.Parallel()
+
+	const (
+		ccBYName        = "CC BY 4.0"
+		ccBYURL         = "https://creativecommons.org/licenses/by/4.0/"
+		ccBYSAName      = "CC BY-SA 4.0"
+		ccBYSAURL       = "https://creativecommons.org/licenses/by-sa/4.0/"
+		ccBYNDName      = "CC BY-ND 4.0"
+		ccBYNDURL       = "https://creativecommons.org/licenses/by-nd/4.0/"
+		ccBYNCName      = "CC BY-NC 4.0"
+		ccBYNCURL       = "https://creativecommons.org/licenses/by-nc/4.0/"
+		ccBYNCSAName    = "CC BY-NC-SA 4.0"
+		ccBYNCSAURL     = "https://creativecommons.org/licenses/by-nc-sa/4.0/"
+		ccBYNCNDName    = "CC BY-NC-ND 4.0"
+		ccBYNCNDURL     = "https://creativecommons.org/licenses/by-nc-nd/4.0/"
+		cc0Name         = "CC0 1.0 Universal"
+		cc0URL          = "https://creativecommons.org/publicdomain/zero/1.0/"
+		unknownLicense  = "completely-bogus"
+		unknownLicense2 = ""
+	)
+
+	tests := []struct {
+		name     string
+		input    string
+		wantName string
+		wantURL  string
+	}{
+		// Legacy slug-style codes — must continue to work unchanged.
+		{name: "slug cc-by", input: "cc-by", wantName: ccBYName, wantURL: ccBYURL},
+		{name: "slug cc-by-sa", input: "cc-by-sa", wantName: ccBYSAName, wantURL: ccBYSAURL},
+		{name: "slug cc-by-nd", input: "cc-by-nd", wantName: ccBYNDName, wantURL: ccBYNDURL},
+		{name: "slug cc-by-nc", input: "cc-by-nc", wantName: ccBYNCName, wantURL: ccBYNCURL},
+		{name: "slug cc-by-nc-sa", input: "cc-by-nc-sa", wantName: ccBYNCSAName, wantURL: ccBYNCSAURL},
+		{name: "slug cc-by-nc-nd", input: "cc-by-nc-nd", wantName: ccBYNCNDName, wantURL: ccBYNCNDURL},
+		{name: "slug cc0", input: "cc0", wantName: cc0Name, wantURL: cc0URL},
+
+		// Production display-name variants that used to fall through to the
+		// WARN-logging default branch (Forgejo #387).
+		{name: "display CC BY 3.0", input: "CC BY 3.0", wantName: ccBYName, wantURL: ccBYURL},
+		{name: "display CC BY-NC 2.0", input: "CC BY-NC 2.0", wantName: ccBYNCName, wantURL: ccBYNCURL},
+		{name: "display CC BY-NC 3.0", input: "CC BY-NC 3.0", wantName: ccBYNCName, wantURL: ccBYNCURL},
+		{name: "display CC BY-NC-SA 4.0", input: "CC BY-NC-SA 4.0", wantName: ccBYNCSAName, wantURL: ccBYNCSAURL},
+		{name: "display CC BY-SA 4.0", input: "CC BY-SA 4.0", wantName: ccBYSAName, wantURL: ccBYSAURL},
+		{name: "display CC0 3.0", input: "CC0 3.0", wantName: cc0Name, wantURL: cc0URL},
+
+		// Edge cases.
+		{name: "whitespace around CC BY", input: "  CC BY  ", wantName: ccBYName, wantURL: ccBYURL},
+		{name: "high version cc-by-99.99", input: "cc-by 99.99", wantName: ccBYName, wantURL: ccBYURL},
+		{name: "mixed case CC-BY-NC", input: "CC-BY-NC", wantName: ccBYNCName, wantURL: ccBYNCURL},
+
+		// Unknowns: raw code returned as name, URL empty. The one-shot WARN
+		// logging path is exercised implicitly; we just assert the return.
+		{name: "unknown code", input: unknownLicense, wantName: unknownLicense, wantURL: ""},
+		{name: "empty string", input: unknownLicense2, wantName: unknownLicense2, wantURL: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotName, gotURL := mapAviCommonsLicense(tt.input)
+			assert.Equal(t, tt.wantName, gotName, "license name mismatch for input %q", tt.input)
+			assert.Equal(t, tt.wantURL, gotURL, "license URL mismatch for input %q", tt.input)
+		})
+	}
+}
+
+// TestNormalizeAviCommonsLicense pins the exact output of the normalization
+// helper so future changes don't silently shift the canonical form.
+func TestNormalizeAviCommonsLicense(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "already normalized", input: "cc-by-nc", want: "cc-by-nc"},
+		{name: "display variant", input: "CC BY 3.0", want: "cc-by"},
+		{name: "display compound", input: "CC BY-NC-SA 4.0", want: "cc-by-nc-sa"},
+		{name: "zero with version", input: "CC0 3.0", want: "cc0"},
+		{name: "extra whitespace", input: "  CC BY  ", want: "cc-by"},
+		{name: "no version", input: "CC BY", want: "cc-by"},
+		{name: "spaces collapsed", input: "cc  by  nc", want: "cc-by-nc"},
+		{name: "unknown preserved", input: "completely-bogus", want: "completely-bogus"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.want, normalizeAviCommonsLicense(tt.input))
+		})
+	}
+}

--- a/internal/support/collector.go
+++ b/internal/support/collector.go
@@ -50,12 +50,6 @@ const (
 	defaultDirPermissions  = 0o755
 	defaultFilePermissions = 0o644
 
-	// Container and system detection
-	dockerEnvFile       = "/.dockerenv"
-	procCGroupFile      = "/proc/1/cgroup"
-	containerDocker     = "docker"
-	containerContainerd = "containerd"
-
 	// SystemD and journal constants
 	systemdServiceName = "birdnet-go.service"
 	journalTimeFormat  = "2006-01-02 15:04:05"
@@ -101,31 +95,6 @@ const (
 	exitCodeGeneralFailure  = 1
 	exitCodeCommandNotFound = 127
 )
-
-// isRunningInDocker detects if the application is running inside a Docker container.
-// This is useful for adjusting log collection strategies, as Docker containers
-// often don't have systemd/journald available.
-//
-// Detection methods:
-//  1. Check for /.dockerenv file (standard Docker marker)
-//  2. Check /proc/1/cgroup for docker references
-//
-// Returns true if running in Docker, false otherwise.
-func isRunningInDocker() bool {
-	// Check for .dockerenv file
-	if _, err := os.Stat(dockerEnvFile); err == nil {
-		return true
-	}
-
-	// Check cgroup for docker references
-	if data, err := os.ReadFile(procCGroupFile); err == nil {
-		if strings.Contains(string(data), containerDocker) || strings.Contains(string(data), containerContainerd) {
-			return true
-		}
-	}
-
-	return false
-}
 
 // getLogger returns the support package logger.
 // Fetched dynamically to ensure it uses the current centralized logger.
@@ -817,13 +786,18 @@ func (c *Collector) collectLogs(ctx context.Context, duration time.Duration, max
 	var logs []LogEntry
 	var totalSize int64
 
-	// Try to collect from journald first (systemd systems)
-	// Skip journal collection if running in Docker as it's unlikely to be available
-	if isRunningInDocker() {
-		getLogger().Debug("support: running in Docker, skipping journal log collection")
+	// Try to collect from journald first (systemd systems).
+	// Skip journal collection in container runtimes (Docker, Podman, LXC,
+	// systemd-nspawn) where journald is typically unavailable. Uses
+	// sysinfo.IsContainer() so the check matches the same gate that
+	// addJournaldLogs uses on the archive path — keeping both journald
+	// collection paths consistent and removing the now-redundant local
+	// Docker-only helper.
+	if sysinfo.IsContainer() {
+		getLogger().Debug("support: running in a container runtime, skipping journal log collection")
 		diagnostics.JournalLogs.Attempted = false
 		diagnostics.JournalLogs.Details = map[string]any{
-			"skipped_reason": "running_in_docker",
+			"skipped_reason": "running_in_container",
 		}
 	} else {
 		getLogger().Debug("support: attempting to collect journal logs")

--- a/internal/support/collector.go
+++ b/internal/support/collector.go
@@ -24,6 +24,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/logger"
 	"github.com/tphakala/birdnet-go/internal/privacy"
+	"github.com/tphakala/birdnet-go/internal/sysinfo"
 	"gopkg.in/yaml.v3"
 )
 
@@ -1362,13 +1363,23 @@ func (c *Collector) addLogFilesToArchive(ctx context.Context, w *zip.Writer, dur
 		}
 	}
 
-	// Add journald logs
-	getLogger().Debug("support: attempting to add journald logs to archive")
-	if err := lfc.addJournaldLogs(w, duration); err == nil {
-		lfc.logsAdded++
-		getLogger().Debug("support: journald logs added successfully")
+	// Add journald logs when running on a host where systemd-journald is
+	// actually available. In container runtimes (Docker, Podman, LXC,
+	// systemd-nspawn, generic) the journalctl binary either does not exist
+	// or returns an error, which previously surfaced as a recurring Sentry
+	// event every time a support dump was generated. Use the shared
+	// sysinfo.IsContainer() detector so we cover all container flavours,
+	// not just Docker.
+	if sysinfo.IsContainer() {
+		getLogger().Debug("support: skipping journald collection (container runtime)")
 	} else {
-		getLogger().Debug("support: could not add journald logs", logger.Error(err))
+		getLogger().Debug("support: attempting to add journald logs to archive")
+		if err := lfc.addJournaldLogs(w, duration); err == nil {
+			lfc.logsAdded++
+			getLogger().Debug("support: journald logs added successfully")
+		} else {
+			getLogger().Debug("support: could not add journald logs", logger.Error(err))
+		}
 	}
 
 	// Add README if no logs found


### PR DESCRIPTION
## Summary

Two small, independent fixes that each address a recurring noise pattern.

### Avicommons license code mapping

`internal/imageprovider/avicommons.go`'s `mapAviCommonsLicense()` only ran `strings.ToLower` over the input before its switch. The Avicommons dataset also exposes display-name variants like `CC BY 3.0`, `CC BY-NC 2.0`, `CC BY-NC-SA 4.0`, and `CC0 3.0` — none of which match the existing slug-style cases (`cc-by`, `cc-by-nc`, etc.). They fell through to the default and logged a WARN per unknown code.

The fix introduces `normalizeAviCommonsLicense()` which trims, lowercases, strips a trailing version suffix via a package-level `regexp`, then converts spaces to hyphens. The switch is unchanged. Existing slug inputs and the unknown-code one-shot WARN path (`loggedUnknownLicenses sync.Map`) are preserved. New table-driven test covers all 6 production-observed variants plus edge cases.

### Journald collection in container runtimes

`internal/support/collector.go`'s support-bundle path called `addJournaldLogs(...)` unconditionally. In containers where journald is not available (Docker, Podman, LXC, systemd-nspawn), the call returned a `[system-resource] no journald logs available` enhanced error that propagated to Sentry as `Component=support, Category=system, Priority=low`.

The fix gates the call on `sysinfo.IsContainer()` (which already detects Docker/Podman/LXC/nspawn). The local helper `isRunningInDocker()` was narrower so the `sysinfo` package was the right choice. `addJournaldLogs` itself is untouched so any direct callers still get the explicit error.

## Test Plan

- [ ] `golangci-lint run -v ./internal/imageprovider/... ./internal/support/...` — 0 issues
- [ ] `go test -race -count=1 ./internal/imageprovider/... ./internal/support/...` — pass
- [ ] Manual: load the Avicommons data on a fresh start, verify no `Unknown Avicommons license code encountered` WARN for the listed variants.
- [ ] Manual: trigger a support dump from inside a Docker/Podman container, verify no `no journald logs available` event in Sentry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved license information handling to support both legacy and modern license format variants, enabling accurate recognition of diverse license metadata inputs.

* **Tests**
  * Added comprehensive unit tests to ensure reliable license mapping and normalization across various input formats.

* **Chores**
  * Optimized system log collection behavior for containerized deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->