### PR TITLE
fix(telemetry+backup): suppress operational throttling and transient signals from Sentry

### DIFF
--- a/internal/backup/backup.go
+++ b/internal/backup/backup.go
@@ -280,6 +280,17 @@ func (m *Manager) RunBackup(ctx context.Context) error {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
+	// When backup is enabled but neither sources nor targets have been
+	// registered, treat this as "user has not finished setting up backup"
+	// rather than a hard error. Scheduler-driven runs would otherwise
+	// flood Sentry with cadence-aligned noise from users who toggled the
+	// feature on but never configured it. Mirror the Start() semantics:
+	// the half-configured case (targets missing below) still fails fast.
+	if !m.config.Enabled || (len(m.sources) == 0 && len(m.targets) == 0) {
+		m.logger.Info("Backup run requested but no sources or targets configured; nothing to do")
+		return nil
+	}
+
 	// Add a timeout for the entire backup operation
 	ctx, cancel := context.WithTimeout(ctx, m.getBackupTimeout())
 	defer cancel()

--- a/internal/backup/backup.go
+++ b/internal/backup/backup.go
@@ -239,6 +239,17 @@ func (m *Manager) Start() error {
 		return nil
 	}
 
+	// When backup is enabled but no sources or targets have been registered,
+	// treat this as "user has not finished setting up backup" rather than a
+	// hard error. Emitting telemetry here floods Sentry with noise from
+	// users who toggled the feature on but never configured it. A stray
+	// half-configured manager (sources but no targets, or vice versa) is
+	// still treated as a misconfiguration below.
+	if len(m.sources) == 0 && len(m.targets) == 0 {
+		m.logger.Info("Backup manager enabled but no sources or targets configured; nothing to do")
+		return nil
+	}
+
 	// Validate that we have at least one source and target
 	if len(m.sources) == 0 {
 		return errors.Newf("no backup sources registered").

--- a/internal/backup/backup.go
+++ b/internal/backup/backup.go
@@ -280,15 +280,33 @@ func (m *Manager) RunBackup(ctx context.Context) error {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	// When backup is enabled but neither sources nor targets have been
-	// registered, treat this as "user has not finished setting up backup"
-	// rather than a hard error. Scheduler-driven runs would otherwise
-	// flood Sentry with cadence-aligned noise from users who toggled the
-	// feature on but never configured it. Mirror the Start() semantics:
-	// the half-configured case (targets missing below) still fails fast.
-	if !m.config.Enabled || (len(m.sources) == 0 && len(m.targets) == 0) {
+	// Early-return when backup is disabled. Scheduler-driven runs that land
+	// on a disabled manager must be a silent no-op, not a telemetry event.
+	if !m.config.Enabled {
+		m.logger.Info("Backup manager is disabled")
+		return nil
+	}
+
+	// Early-return when neither sources nor targets have been registered.
+	// Treat this as "user has not finished setting up backup" rather than a
+	// hard error. Scheduler-driven runs would otherwise flood Sentry with
+	// cadence-aligned noise from users who toggled the feature on but never
+	// configured it. Mirror the Start() semantics: the half-configured cases
+	// below still fail fast.
+	if len(m.sources) == 0 && len(m.targets) == 0 {
 		m.logger.Info("Backup run requested but no sources or targets configured; nothing to do")
 		return nil
+	}
+
+	// Validate that we have at least one source. This mirrors Start()'s
+	// independent sources/targets validation so the targets-only
+	// half-configured state fails fast instead of silently no-oping.
+	if len(m.sources) == 0 {
+		return errors.Newf("no backup sources registered, backup cannot proceed").
+			Component("backup").
+			Category(errors.CategoryValidation).
+			Context("operation", "perform_backup").
+			Build()
 	}
 
 	// Add a timeout for the entire backup operation

--- a/internal/backup/backup.go
+++ b/internal/backup/backup.go
@@ -239,26 +239,35 @@ func (m *Manager) Start() error {
 		return nil
 	}
 
+	// Snapshot source/target counts under a brief read lock so we don't race
+	// with concurrent RegisterSource/RegisterTarget callers (which take the
+	// write lock on m.mu). The lock is released immediately so the rest of
+	// Start() runs without blocking writers.
+	m.mu.RLock()
+	sourcesLen := len(m.sources)
+	targetsLen := len(m.targets)
+	m.mu.RUnlock()
+
 	// When backup is enabled but no sources or targets have been registered,
 	// treat this as "user has not finished setting up backup" rather than a
 	// hard error. Emitting telemetry here floods Sentry with noise from
 	// users who toggled the feature on but never configured it. A stray
 	// half-configured manager (sources but no targets, or vice versa) is
 	// still treated as a misconfiguration below.
-	if len(m.sources) == 0 && len(m.targets) == 0 {
+	if sourcesLen == 0 && targetsLen == 0 {
 		m.logger.Info("Backup manager enabled but no sources or targets configured; nothing to do")
 		return nil
 	}
 
 	// Validate that we have at least one source and target
-	if len(m.sources) == 0 {
+	if sourcesLen == 0 {
 		return errors.Newf("no backup sources registered").
 			Component("backup").
 			Category(errors.CategoryValidation).
 			Context("operation", "validate_config").
 			Build()
 	}
-	if len(m.targets) == 0 {
+	if targetsLen == 0 {
 		return errors.Newf("no backup targets registered").
 			Component("backup").
 			Category(errors.CategoryValidation).
@@ -277,15 +286,30 @@ func (m *Manager) Start() error {
 
 // RunBackup performs an immediate backup of all sources
 func (m *Manager) RunBackup(ctx context.Context) error {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-
 	// Early-return when backup is disabled. Scheduler-driven runs that land
 	// on a disabled manager must be a silent no-op, not a telemetry event.
+	// The Enabled flag is set once at construction so it does not need lock
+	// protection; the maps below do.
 	if !m.config.Enabled {
 		m.logger.Info("Backup manager is disabled")
 		return nil
 	}
+
+	// Snapshot the registered sources under a brief read lock and release
+	// immediately. Holding m.mu.RLock for the full RunBackup duration would
+	// (a) block any concurrent RegisterSource / RegisterTarget writer for
+	// the entire backup window (potentially many minutes of I/O), and
+	// (b) risk a deadlock if any nested call attempted to acquire m.mu
+	// because sync.RWMutex is not reentrant. Iterating over the snapshot
+	// is also safe against mid-run mutations of the live maps.
+	m.mu.RLock()
+	sourcesLen := len(m.sources)
+	targetsLen := len(m.targets)
+	sources := make(map[string]Source, sourcesLen)
+	for k, v := range m.sources {
+		sources[k] = v
+	}
+	m.mu.RUnlock()
 
 	// Early-return when neither sources nor targets have been registered.
 	// Treat this as "user has not finished setting up backup" rather than a
@@ -293,7 +317,7 @@ func (m *Manager) RunBackup(ctx context.Context) error {
 	// cadence-aligned noise from users who toggled the feature on but never
 	// configured it. Mirror the Start() semantics: the half-configured cases
 	// below still fail fast.
-	if len(m.sources) == 0 && len(m.targets) == 0 {
+	if sourcesLen == 0 && targetsLen == 0 {
 		m.logger.Info("Backup run requested but no sources or targets configured; nothing to do")
 		return nil
 	}
@@ -301,7 +325,7 @@ func (m *Manager) RunBackup(ctx context.Context) error {
 	// Validate that we have at least one source. This mirrors Start()'s
 	// independent sources/targets validation so the targets-only
 	// half-configured state fails fast instead of silently no-oping.
-	if len(m.sources) == 0 {
+	if sourcesLen == 0 {
 		return errors.Newf("no backup sources registered, backup cannot proceed").
 			Component("backup").
 			Category(errors.CategoryValidation).
@@ -316,7 +340,7 @@ func (m *Manager) RunBackup(ctx context.Context) error {
 	m.logger.Info("Starting backup process...")
 
 	// Validate that we have at least one target
-	if len(m.targets) == 0 {
+	if targetsLen == 0 {
 		return errors.Newf("no backup targets registered, backup cannot proceed").
 			Component("backup").
 			Category(errors.CategoryValidation).
@@ -333,8 +357,10 @@ func (m *Manager) RunBackup(ctx context.Context) error {
 	var allTempDirs []string
 	var errs []error
 
-	// Process each source
-	for sourceName, source := range m.sources {
+	// Process each source from the snapshot taken under the brief read lock
+	// above. Iterating the snapshot avoids holding the lock during long I/O
+	// and is safe against concurrent registration mutations.
+	for sourceName, source := range sources {
 		select {
 		case <-ctx.Done():
 			// Clean up temp dirs before returning

--- a/internal/backup/backup_test.go
+++ b/internal/backup/backup_test.go
@@ -133,6 +133,72 @@ func TestRunBackup_OnlySources_StillErrors(t *testing.T) {
 	assert.Contains(t, err.Error(), "no backup targets registered")
 }
 
+// TestRunBackup_OnlyTargets_StillErrors ensures that the mirror half-configured
+// case (targets registered but no sources) also fails fast with the structured
+// validation error, matching Start()'s independent sources/targets validation.
+// Without the explicit no-sources check, RunBackup would silently no-op when
+// the user registered targets but no sources.
+func TestRunBackup_OnlyTargets_StillErrors(t *testing.T) {
+	cfg := &conf.Settings{}
+	cfg.Backup.Enabled = true
+
+	m := &Manager{
+		config:     &cfg.Backup,
+		fullConfig: cfg,
+		sources:    make(map[string]Source),
+		targets: map[string]Target{
+			"dummy": dummyTarget{},
+		},
+		logger: GetLogger().Module("manager-test"),
+	}
+
+	err := m.RunBackup(t.Context())
+	require.Error(t, err,
+		"RunBackup should fail when targets are registered but sources are missing")
+	assert.Contains(t, err.Error(), "no backup sources registered")
+}
+
+// TestRunBackup_Disabled_NoError verifies that the explicit "manager disabled"
+// early-return path returns nil without touching telemetry. This pins the
+// split of the previously combined !Enabled || empty check into two separate
+// early-returns, each with its own log line.
+func TestRunBackup_Disabled_NoError(t *testing.T) {
+	// Not parallel: the errors package keeps the hook list as package state.
+	var (
+		mu          sync.Mutex
+		capturedErr []*errors.EnhancedError
+	)
+	errors.AddErrorHook(func(ee *errors.EnhancedError) {
+		mu.Lock()
+		defer mu.Unlock()
+		capturedErr = append(capturedErr, ee)
+	})
+	t.Cleanup(errors.ClearErrorHooks)
+
+	cfg := &conf.Settings{}
+	cfg.Backup.Enabled = false
+
+	m := &Manager{
+		config:     &cfg.Backup,
+		fullConfig: cfg,
+		sources: map[string]Source{
+			"dummy": dummySource{},
+		},
+		targets: map[string]Target{
+			"dummy": dummyTarget{},
+		},
+		logger: GetLogger().Module("manager-test"),
+	}
+
+	require.NoError(t, m.RunBackup(t.Context()),
+		"RunBackup should succeed as a silent no-op when the manager is disabled")
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Empty(t, capturedErr,
+		"no telemetry event should be emitted when the backup manager is disabled")
+}
+
 // dummySource is a minimal Source implementation used only for the
 // half-configured test cases. It is never actually invoked because Start
 // and RunBackup return before any source methods are called.
@@ -143,3 +209,14 @@ func (dummySource) Backup(_ context.Context) (io.ReadCloser, error) {
 	return nil, nil //nolint:nilnil // never invoked in this test
 }
 func (dummySource) Validate() error { return nil }
+
+// dummyTarget is a minimal Target implementation used only for the
+// half-configured test cases. It is never actually invoked because Start
+// and RunBackup return before any target methods are called.
+type dummyTarget struct{}
+
+func (dummyTarget) Name() string                                         { return "dummy" }
+func (dummyTarget) Store(_ context.Context, _ string, _ *Metadata) error { return nil }
+func (dummyTarget) List(_ context.Context) ([]BackupInfo, error)         { return nil, nil }
+func (dummyTarget) Delete(_ context.Context, _ string) error             { return nil }
+func (dummyTarget) Validate() error                                      { return nil }

--- a/internal/backup/backup_test.go
+++ b/internal/backup/backup_test.go
@@ -1,0 +1,83 @@
+package backup
+
+import (
+	"context"
+	"io"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/errors"
+)
+
+// TestStart_NoSourcesOrTargets_NoError verifies that calling Start on a
+// backup manager that is enabled but has no sources or targets registered
+// returns nil without emitting a telemetry event. This prevents Sentry
+// noise from users who toggled backup on but never finished configuring it.
+func TestStart_NoSourcesOrTargets_NoError(t *testing.T) {
+	// Install a hook that records any error reported while the test runs.
+	// Not parallel - the errors package keeps the hook list as package state.
+	var (
+		mu          sync.Mutex
+		capturedErr []*errors.EnhancedError
+	)
+	errors.AddErrorHook(func(ee *errors.EnhancedError) {
+		mu.Lock()
+		defer mu.Unlock()
+		capturedErr = append(capturedErr, ee)
+	})
+	t.Cleanup(errors.ClearErrorHooks)
+
+	cfg := &conf.Settings{}
+	cfg.Backup.Enabled = true
+
+	m := &Manager{
+		config:     &cfg.Backup,
+		fullConfig: cfg,
+		sources:    make(map[string]Source),
+		targets:    make(map[string]Target),
+		logger:     GetLogger().Module("manager-test"),
+	}
+
+	require.NoError(t, m.Start(), "Start should succeed when backup is enabled but no sources/targets are configured")
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Empty(t, capturedErr, "no telemetry event should be emitted for an unconfigured but enabled backup manager")
+}
+
+// TestStart_MissingTarget_StillErrors ensures that the half-configured
+// case (sources registered, no targets) continues to fail fast so users
+// get feedback when they only partially set up backup.
+func TestStart_MissingTarget_StillErrors(t *testing.T) {
+	cfg := &conf.Settings{}
+	cfg.Backup.Enabled = true
+
+	m := &Manager{
+		config:     &cfg.Backup,
+		fullConfig: cfg,
+		sources: map[string]Source{
+			"dummy": dummySource{},
+		},
+		targets: make(map[string]Target),
+		logger:  GetLogger().Module("manager-test"),
+	}
+
+	err := m.Start()
+	require.Error(t, err, "Start should fail when sources are registered but targets are missing")
+	assert.Contains(t, err.Error(), "no backup targets registered")
+}
+
+// dummySource is a minimal Source implementation used only for the
+// half-configured test case. It is never actually invoked because Start
+// returns before any source methods are called.
+type dummySource struct{}
+
+func (dummySource) Name() string { return "dummy" }
+func (dummySource) Backup(_ context.Context) (io.ReadCloser, error) {
+	return nil, nil //nolint:nilnil // never invoked in this test
+}
+func (dummySource) Validate() error { return nil }

--- a/internal/backup/backup_test.go
+++ b/internal/backup/backup_test.go
@@ -71,9 +71,71 @@ func TestStart_MissingTarget_StillErrors(t *testing.T) {
 	assert.Contains(t, err.Error(), "no backup targets registered")
 }
 
+// TestRunBackup_NoSourcesOrTargets_NoError verifies that scheduler-driven
+// RunBackup invocations on a manager with no registered sources or targets
+// return nil without emitting telemetry. This mirrors the Start() semantics
+// added alongside this fix and prevents Sentry noise from cron-triggered
+// runs hitting users who enabled backup but never finished configuring it.
+func TestRunBackup_NoSourcesOrTargets_NoError(t *testing.T) {
+	// Not parallel: the errors package keeps the hook list as package state.
+	var (
+		mu          sync.Mutex
+		capturedErr []*errors.EnhancedError
+	)
+	errors.AddErrorHook(func(ee *errors.EnhancedError) {
+		mu.Lock()
+		defer mu.Unlock()
+		capturedErr = append(capturedErr, ee)
+	})
+	t.Cleanup(errors.ClearErrorHooks)
+
+	cfg := &conf.Settings{}
+	cfg.Backup.Enabled = true
+
+	m := &Manager{
+		config:     &cfg.Backup,
+		fullConfig: cfg,
+		sources:    make(map[string]Source),
+		targets:    make(map[string]Target),
+		logger:     GetLogger().Module("manager-test"),
+	}
+
+	require.NoError(t, m.RunBackup(t.Context()),
+		"RunBackup should succeed when backup is enabled but no sources/targets are configured")
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Empty(t, capturedErr,
+		"no telemetry event should be emitted for an unconfigured but enabled backup manager")
+}
+
+// TestRunBackup_OnlySources_StillErrors ensures that the half-configured
+// case (sources registered but no targets) continues to surface the
+// existing validation error via RunBackup, so users get feedback when
+// they only partially set up backup. This parallels the Start() variant.
+func TestRunBackup_OnlySources_StillErrors(t *testing.T) {
+	cfg := &conf.Settings{}
+	cfg.Backup.Enabled = true
+
+	m := &Manager{
+		config:     &cfg.Backup,
+		fullConfig: cfg,
+		sources: map[string]Source{
+			"dummy": dummySource{},
+		},
+		targets: make(map[string]Target),
+		logger:  GetLogger().Module("manager-test"),
+	}
+
+	err := m.RunBackup(t.Context())
+	require.Error(t, err,
+		"RunBackup should fail when sources are registered but targets are missing")
+	assert.Contains(t, err.Error(), "no backup targets registered")
+}
+
 // dummySource is a minimal Source implementation used only for the
-// half-configured test case. It is never actually invoked because Start
-// returns before any source methods are called.
+// half-configured test cases. It is never actually invoked because Start
+// and RunBackup return before any source methods are called.
 type dummySource struct{}
 
 func (dummySource) Name() string { return "dummy" }

--- a/internal/errors/telemetry_integration.go
+++ b/internal/errors/telemetry_integration.go
@@ -211,6 +211,16 @@ func shouldReportToSentry(ee *EnhancedError) bool {
 		}
 	}
 
+	// RTSP silence timeouts are most often transient network glitches
+	// (flaky Wi-Fi, switch reboot, camera NTP hiccup). The stream layer
+	// already logs a warning and restarts, so forwarding a Sentry event
+	// per occurrence just floods the project with duplicates. A future
+	// enhancement can track consecutive timeouts inside stream.go and
+	// only escalate when the stream stays silent for multiple windows.
+	if ee.Category == CategoryRTSP && strings.Contains(errorMsg, "stream stopped producing data") {
+		return false
+	}
+
 	// Rate-limit disk-full errors — a single root cause creates cascading
 	// errors across many subsystems (database, FFmpeg, alerting, etc.)
 	if strings.Contains(errorMsg, "disk is full") ||

--- a/internal/errors/telemetry_integration.go
+++ b/internal/errors/telemetry_integration.go
@@ -41,6 +41,13 @@ var (
 // Set by the telemetry package to avoid circular imports.
 var ResourceSnapshotFunc func() map[string]any
 
+// rtspSilenceTimeoutSignature is the full, stable log message emitted by the
+// ffmpeg stream layer when an RTSP source has been silent for the silence
+// watchdog window. Using the complete signature (rather than a loose
+// substring) keeps unrelated "stream stopped producing data" wording from
+// future RTSP code paths reaching Sentry when they shouldn't be suppressed.
+const rtspSilenceTimeoutSignature = "stream stopped producing data for 90 seconds"
+
 var (
 	lastDiskFullReport atomic.Int64                           // Unix timestamp of last disk-full report
 	diskFullCooldown   = int64(5 * time.Minute / time.Second) // 5 minutes between disk-full reports
@@ -219,7 +226,9 @@ func shouldReportToSentry(ee *EnhancedError) bool {
 	// per occurrence just floods the project with duplicates. A future
 	// enhancement can track consecutive timeouts inside stream.go and
 	// only escalate when the stream stays silent for multiple windows.
-	if ee.Category == CategoryRTSP && strings.Contains(errorMsg, "stream stopped producing data") {
+	// Match the full signature (not just a prefix substring) so unrelated
+	// RTSP failures worded similarly are not accidentally suppressed.
+	if ee.Category == CategoryRTSP && strings.Contains(errorMsg, rtspSilenceTimeoutSignature) {
 		return false
 	}
 

--- a/internal/errors/telemetry_integration.go
+++ b/internal/errors/telemetry_integration.go
@@ -152,13 +152,15 @@ func shouldReportToSentry(ee *EnhancedError) bool {
 	}
 	errorMsg := strings.ToLower(ee.Err.Error())
 
-	// Throttling / rate-limit conditions are operational state, not bugs.
-	// Current producers of CategoryLimit: notification circuit breaker
-	// open/half-open, job queue full, spectrogram pre-render queue full.
-	// The interesting signal (state transitions, degraded mode) is already
-	// surfaced through dedicated telemetry paths, so the per-call errors
-	// are pure noise when forwarded to Sentry.
-	if ee.Category == CategoryLimit {
+	// Notification circuit-breaker open/half-open conditions are operational
+	// throttling state, not bugs. Suppress only that component — NOT all
+	// CategoryLimit producers. eBird API quota exhaustion, analysis job
+	// queue overflow, and spectrogram pre-render memory limits should still
+	// reach Sentry as legitimate signals. The notification state transitions
+	// themselves are already surfaced via the dedicated CircuitBreakerStateTransition
+	// telemetry path, so the per-call errors from that component are pure
+	// noise when forwarded to Sentry.
+	if ee.Category == CategoryLimit && ee.GetComponent() == "notification" {
 		return false
 	}
 

--- a/internal/errors/telemetry_integration.go
+++ b/internal/errors/telemetry_integration.go
@@ -152,6 +152,16 @@ func shouldReportToSentry(ee *EnhancedError) bool {
 	}
 	errorMsg := strings.ToLower(ee.Err.Error())
 
+	// Throttling / rate-limit conditions are operational state, not bugs.
+	// Current producers of CategoryLimit: notification circuit breaker
+	// open/half-open, job queue full, spectrogram pre-render queue full.
+	// The interesting signal (state transitions, degraded mode) is already
+	// surfaced through dedicated telemetry paths, so the per-call errors
+	// are pure noise when forwarded to Sentry.
+	if ee.Category == CategoryLimit {
+		return false
+	}
+
 	// Check for MQTT authentication/authorization errors (user config issues)
 	if ee.Category == CategoryMQTTConnection || ee.Category == CategoryMQTTAuth {
 		// Common MQTT authentication/authorization error patterns

--- a/internal/errors/telemetry_integration_test.go
+++ b/internal/errors/telemetry_integration_test.go
@@ -116,38 +116,51 @@ func TestShouldReportToSentry_AllowsNetworkCategoryCodeBugs(t *testing.T) {
 	assert.True(t, shouldReportToSentry(ee))
 }
 
-// TestShouldReportToSentry_FiltersCategoryLimit verifies that throttling and
-// rate-limit conditions are not forwarded to Sentry, regardless of the
-// specific message. These represent operational state (circuit breaker open,
-// queue full, etc.) and the interesting signal is covered by dedicated
-// telemetry paths.
-func TestShouldReportToSentry_FiltersCategoryLimit(t *testing.T) {
+// TestShouldReportToSentry_CategoryLimitNotificationOnly verifies that the
+// CategoryLimit suppression is scoped to the notification component only.
+// The notification circuit breaker produces high-volume [limit] state noise
+// that is already covered by the dedicated CircuitBreakerStateTransition
+// telemetry path. Other CategoryLimit producers (eBird API quota, analysis
+// job queue full, spectrogram pre-render memory limits) are legitimate
+// operational signals that ops needs to see and must still reach Sentry.
+func TestShouldReportToSentry_CategoryLimitNotificationOnly(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name      string
-		component string
-		err       error
+		name       string
+		component  string
+		err        error
+		wantReport bool
 	}{
 		{
-			name:      "notification circuit breaker open",
-			component: "notification",
-			err:       fmt.Errorf("circuit breaker is open"),
+			name:       "notification circuit breaker open is suppressed",
+			component:  "notification",
+			err:        fmt.Errorf("circuit breaker is open"),
+			wantReport: false,
 		},
 		{
-			name:      "notification circuit breaker half-open too many requests",
-			component: "notification",
-			err:       fmt.Errorf("circuit breaker is half-open, too many requests"),
+			name:       "notification circuit breaker half-open too many requests is suppressed",
+			component:  "notification",
+			err:        fmt.Errorf("circuit breaker is half-open, too many requests"),
+			wantReport: false,
 		},
 		{
-			name:      "analysis job queue full",
-			component: "analysis.jobqueue",
-			err:       fmt.Errorf("job queue is full"),
+			name:       "ebird API quota exhaustion is reported",
+			component:  "ebird",
+			err:        fmt.Errorf("ebird API quota exceeded"),
+			wantReport: true,
 		},
 		{
-			name:      "spectrogram prerender queue full",
-			component: "spectrogram",
-			err:       fmt.Errorf("pre-render queue full"),
+			name:       "analysis job queue full is reported",
+			component:  "jobqueue",
+			err:        fmt.Errorf("job queue is full"),
+			wantReport: true,
+		},
+		{
+			name:       "spectrogram prerender queue full is reported",
+			component:  "spectrogram",
+			err:        fmt.Errorf("pre-render queue full"),
+			wantReport: true,
 		},
 	}
 
@@ -158,8 +171,16 @@ func TestShouldReportToSentry_FiltersCategoryLimit(t *testing.T) {
 				Component(tt.component).
 				Category(CategoryLimit).
 				Build()
-			assert.False(t, shouldReportToSentry(ee),
-				"CategoryLimit errors must not be forwarded to Sentry")
+			got := shouldReportToSentry(ee)
+			if tt.wantReport {
+				assert.Truef(t, got,
+					"%s: CategoryLimit from %q must still be forwarded to Sentry",
+					tt.name, tt.component)
+			} else {
+				assert.Falsef(t, got,
+					"%s: CategoryLimit from %q must not be forwarded to Sentry",
+					tt.name, tt.component)
+			}
 		})
 	}
 }

--- a/internal/errors/telemetry_integration_test.go
+++ b/internal/errors/telemetry_integration_test.go
@@ -116,6 +116,54 @@ func TestShouldReportToSentry_AllowsNetworkCategoryCodeBugs(t *testing.T) {
 	assert.True(t, shouldReportToSentry(ee))
 }
 
+// TestShouldReportToSentry_FiltersCategoryLimit verifies that throttling and
+// rate-limit conditions are not forwarded to Sentry, regardless of the
+// specific message. These represent operational state (circuit breaker open,
+// queue full, etc.) and the interesting signal is covered by dedicated
+// telemetry paths.
+func TestShouldReportToSentry_FiltersCategoryLimit(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		component string
+		err       error
+	}{
+		{
+			name:      "notification circuit breaker open",
+			component: "notification",
+			err:       fmt.Errorf("circuit breaker is open"),
+		},
+		{
+			name:      "notification circuit breaker half-open too many requests",
+			component: "notification",
+			err:       fmt.Errorf("circuit breaker is half-open, too many requests"),
+		},
+		{
+			name:      "analysis job queue full",
+			component: "analysis.jobqueue",
+			err:       fmt.Errorf("job queue is full"),
+		},
+		{
+			name:      "spectrogram prerender queue full",
+			component: "spectrogram",
+			err:       fmt.Errorf("pre-render queue full"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ee := New(tt.err).
+				Component(tt.component).
+				Category(CategoryLimit).
+				Build()
+			assert.False(t, shouldReportToSentry(ee),
+				"CategoryLimit errors must not be forwarded to Sentry")
+		})
+	}
+}
+
 func TestShouldReportToSentry_RateLimitsDiskFull(t *testing.T) {
 	// Not parallel — mutates package-level state
 	lastDiskFullReport.Store(0)

--- a/internal/errors/telemetry_integration_test.go
+++ b/internal/errors/telemetry_integration_test.go
@@ -188,14 +188,47 @@ func TestShouldReportToSentry_CategoryLimitNotificationOnly(t *testing.T) {
 // TestShouldReportToSentry_FiltersRTSPSilenceTimeout verifies that the RTSP
 // silence-timeout warning emitted by the ffmpeg stream layer is not
 // forwarded to Sentry. These are transient network glitches, not bugs.
+// The full, stable signature from stream.go must match; a loose substring
+// without "for 90 seconds" is intentionally NOT suppressed so that future
+// RTSP failures worded similarly still reach Sentry.
 func TestShouldReportToSentry_FiltersRTSPSilenceTimeout(t *testing.T) {
 	t.Parallel()
-	ee := New(fmt.Errorf("stream stopped producing data for 90 seconds")).
-		Component("ffmpeg-stream").
-		Category(CategoryRTSP).
-		Context("operation", "silence_timeout").
-		Build()
-	assert.False(t, shouldReportToSentry(ee))
+
+	tests := []struct {
+		name       string
+		errMsg     string
+		wantReport bool
+	}{
+		{
+			name:       "exact silence-timeout signature is suppressed",
+			errMsg:     "stream stopped producing data for 90 seconds",
+			wantReport: false,
+		},
+		{
+			name:       "silence-timeout signature with wrapping context is suppressed",
+			errMsg:     "[rtsp-connection] stream stopped producing data for 90 seconds, restarting",
+			wantReport: false,
+		},
+		{
+			name:       "loose substring without full signature is reported",
+			errMsg:     "[rtsp-connection] stream stopped producing data",
+			wantReport: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ee := New(fmt.Errorf("%s", tt.errMsg)).
+				Component("ffmpeg-stream").
+				Category(CategoryRTSP).
+				Context("operation", "silence_timeout").
+				Build()
+			got := shouldReportToSentry(ee)
+			assert.Equal(t, tt.wantReport, got,
+				"shouldReportToSentry(%q) = %v, want %v", tt.errMsg, got, tt.wantReport)
+		})
+	}
 }
 
 // TestShouldReportToSentry_AllowsRTSPCodeBugs is a positive control that

--- a/internal/errors/telemetry_integration_test.go
+++ b/internal/errors/telemetry_integration_test.go
@@ -164,6 +164,33 @@ func TestShouldReportToSentry_FiltersCategoryLimit(t *testing.T) {
 	}
 }
 
+// TestShouldReportToSentry_FiltersRTSPSilenceTimeout verifies that the RTSP
+// silence-timeout warning emitted by the ffmpeg stream layer is not
+// forwarded to Sentry. These are transient network glitches, not bugs.
+func TestShouldReportToSentry_FiltersRTSPSilenceTimeout(t *testing.T) {
+	t.Parallel()
+	ee := New(fmt.Errorf("stream stopped producing data for 90 seconds")).
+		Component("ffmpeg-stream").
+		Category(CategoryRTSP).
+		Context("operation", "silence_timeout").
+		Build()
+	assert.False(t, shouldReportToSentry(ee))
+}
+
+// TestShouldReportToSentry_AllowsRTSPCodeBugs is a positive control that
+// pins the behavior for RTSP category errors that do NOT match the
+// known-noisy patterns. These must still reach Sentry so real bugs in the
+// RTSP stack remain visible.
+func TestShouldReportToSentry_AllowsRTSPCodeBugs(t *testing.T) {
+	t.Parallel()
+	ee := New(fmt.Errorf("ffmpeg produced invalid frame header at offset 42")).
+		Component("ffmpeg-stream").
+		Category(CategoryRTSP).
+		Build()
+	assert.True(t, shouldReportToSentry(ee),
+		"non-noise RTSP errors must still be forwarded to Sentry")
+}
+
 func TestShouldReportToSentry_RateLimitsDiskFull(t *testing.T) {
 	// Not parallel — mutates package-level state
 	lastDiskFullReport.Store(0)


### PR DESCRIPTION
## Summary

Three independent fixes that each silence a class of Sentry events that aren't bugs.

### Backup manager — silent no-op when nothing is configured

`internal/backup/backup.go`'s `Manager.Start()` and `Manager.RunBackup()` both validated that at least one source and one target were registered, returning enhanced errors that auto-reported to Sentry. The startup path fired on every boot for users who hadn't configured backup yet (~33 events from one Windows deployment alone). The cron-driven `RunBackup` path was missed by the original startup-only fix and would have continued spamming for users who enabled backup but never configured destinations.

Both paths now early-return `nil` when `Backup.Enabled=true` but `len(sources)==0 && len(targets)==0`. The half-configured cases (sources without targets, or vice versa) still return the existing validation error so genuine misconfig is still surfaced.

### `shouldReportToSentry` — suppress notification CategoryLimit

The notification subsystem's circuit breaker emits `[limit] circuit breaker is open` and `[limit] too many requests` enhanced errors via `Build()`, which auto-publishes to telemetry. One user produced 222 events in 17 days because every blocked notification attempt fired one event. Circuit-breaker-open is operational throttling state, not a bug — the actual delivery failures that tripped the breaker are what should be visible in Sentry.

The fix scopes the suppression strictly: `if ee.Category == CategoryLimit && ee.GetComponent() == \"notification\"`. eBird API quota errors, analysis job queue overflow, and spectrogram pre-render memory limits all also use `CategoryLimit` and continue to reach Sentry as legitimate signals — only the notification component is filtered.

### `shouldReportToSentry` — suppress RTSP silence-timeout

`internal/audiocore/ffmpeg/stream.go`'s 90-second silence-timeout watchdog emits `[rtsp-connection] stream stopped producing data for 90 seconds` and reports it as a Warning to Sentry. In practice this is most often a transient network glitch followed by a successful reconnect. 21 events in 13 days from one user.

The fix matches the substring inside `CategoryRTSP` errors and drops them. The detection itself is unchanged so the local logging and stream restart logic still fire — only the Sentry forward is suppressed.

## Test Plan

- [ ] `golangci-lint run -v ./internal/backup/... ./internal/errors/... ./internal/notification/...` — 0 issues
- [ ] `go test -race -count=1 ./internal/backup/... ./internal/errors/... ./internal/notification/...` — pass
- [ ] New tests: `TestStart_NoSourcesOrTargets_NoError`, `TestStart_MissingTarget_StillErrors`, `TestRunBackup_NoSourcesOrTargets_NoError`, `TestRunBackup_OnlySources_StillErrors`, `TestShouldReportToSentry_CategoryLimitNotificationOnly` (5 subtests covering notification/ebird/jobqueue/spectrogram), `TestShouldReportToSentry_FiltersRTSPSilenceTimeout`, `TestShouldReportToSentry_AllowsRTSPCodeBugs`.
- [ ] Manual: install fresh on a clean system without configuring backup. Verify no Sentry events from backup manager startup.
- [ ] Manual: trip the notification circuit breaker (e.g. broken webhook URL). Verify the actual webhook timeout is in Sentry but the subsequent `circuit breaker is open` events are not.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Backup: scheduled runs are a silent no-op when backup is disabled; when enabled but both sources and targets are empty, start/run return cleanly. Half-configured states (missing sources or missing targets) are now rejected to surface configuration errors earlier.
  * Telemetry: suppress noisy reports for notification rate-limiting and for repeated RTSP "stream stopped producing data for 90 seconds" messages.

* **Tests**
  * Added tests covering backup edge cases and the new telemetry filtering rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->