### PR TITLE
fix(conf+processor): tighten validation for CIDR, GPS-in-device, and custom command paths

### DIFF
--- a/internal/analysis/processor/execute.go
+++ b/internal/analysis/processor/execute.go
@@ -26,6 +26,18 @@ import (
 // species configuration entries to identify ExecuteCommand actions.
 const executeCommandActionType = "ExecuteCommand"
 
+// invalidCommandPathRecheckTTL is how long an entry in
+// Processor.invalidCommandPaths is trusted before
+// markCommandPathInvalidIfBroken re-stats the underlying file. Operators
+// who fix a broken script (chmod +x, restore a missing file, etc.) get
+// the corresponding ExecuteCommand action back within this window
+// without restarting the process. The value is short enough that
+// recovery feels immediate to a human, and long enough that the
+// per-detection hot path remains a cheap sync.Map lookup for actions
+// that legitimately stay broken (the original Sentry-spam scenario the
+// gate was introduced to fix).
+const invalidCommandPathRecheckTTL = 30 * time.Second
+
 type ExecuteCommandAction struct {
 	Command string
 	Params  map[string]any
@@ -380,13 +392,15 @@ func getResultValueByName(result *detection.Result, paramName string) any {
 	}
 }
 
-// validateCustomCommandActions scans the species configuration once at
-// startup and validates every ExecuteCommand action command path. Paths
-// that fail validation are recorded in p.invalidCommandPaths so that
-// getActionsForItem can skip them at dispatch time. A single user-facing
-// notification and one telemetry event are emitted per unique broken
-// path, replacing the previous behavior of emitting a dual-fingerprint
-// Sentry event on every detection that would have triggered the action.
+// validateCustomCommandActions scans the species configuration at
+// startup (and on any subsequent re-scan) and validates every
+// ExecuteCommand action command path. Paths that fail validation are
+// recorded in p.invalidCommandPaths so that getActionsForItem can skip
+// them at dispatch time. A single user-facing notification and one
+// telemetry event are emitted per unique broken path per recheck
+// window, replacing the previous behavior of emitting a
+// dual-fingerprint Sentry event on every detection that would have
+// triggered the action.
 //
 // Entries are keyed by the *original* (non-cleaned) command string from
 // the config so that getActionsForItem can look up entries without
@@ -402,9 +416,7 @@ func (p *Processor) validateCustomCommandActions(settings *conf.Settings) {
 	// validated deduplicates work within a single scan so the same
 	// command path appearing in multiple species configs is only stat'd
 	// and reported once, even if users share the same script across
-	// many species. Entries that were already recorded as invalid on a
-	// previous call (e.g. a second pre-warm after runtime reload) are
-	// also skipped.
+	// many species.
 	validated := make(map[string]struct{})
 
 	log := GetLogger()
@@ -422,10 +434,16 @@ func (p *Processor) validateCustomCommandActions(settings *conf.Settings) {
 			}
 			validated[cmd] = struct{}{}
 
-			// Skip paths we already know are invalid from an earlier
-			// scan so the notification is not re-emitted on re-scan.
-			if _, known := p.invalidCommandPaths.Load(cmd); known {
-				continue
+			// Skip paths we already flagged inside the recheck window
+			// so a re-scan does not re-emit the same notification. The
+			// per-dispatch gate (markCommandPathInvalidIfBroken) is the
+			// only place that re-stats once the TTL has elapsed.
+			if v, known := p.invalidCommandPaths.Load(cmd); known {
+				if stamp, ok := v.(time.Time); ok && time.Since(stamp) < invalidCommandPathRecheckTTL {
+					continue
+				}
+				// Stale entry — fall through and re-validate so a fixed
+				// path is cleared instead of being re-flagged below.
 			}
 
 			// validateCommandPath returns a fully built enhanced error
@@ -435,9 +453,9 @@ func (p *Processor) validateCustomCommandActions(settings *conf.Settings) {
 			if _, err := validateCommandPath(cmd); err != nil {
 				// LoadOrStore guarantees a single winner even if a
 				// concurrent detection path is racing with this scan,
-				// so notification is emitted at most once per process
-				// lifetime for the same unique broken path.
-				if _, loaded := p.invalidCommandPaths.LoadOrStore(cmd, struct{}{}); loaded {
+				// so notification is emitted at most once per recheck
+				// window for the same unique broken path.
+				if _, loaded := p.invalidCommandPaths.LoadOrStore(cmd, time.Now()); loaded {
 					continue
 				}
 
@@ -449,38 +467,69 @@ func (p *Processor) validateCustomCommandActions(settings *conf.Settings) {
 					logger.String("operation", "validate_custom_command_path"))
 
 				// Surface the failure in the notification center exactly
-				// once per unique bad path. NotifyError does not create a
-				// second telemetry event: it only extracts title/priority
-				// from the existing enhanced error for the UI panel.
+				// once per unique bad path per recheck window.
+				// NotifyError does not create a second telemetry event:
+				// it only extracts title/priority from the existing
+				// enhanced error for the UI panel.
 				notification.NotifyError("analysis.processor", err)
+				continue
 			}
+
+			// Path is valid — clear any stale invalid marker so a
+			// previously broken path that has been fixed becomes
+			// active immediately on the next dispatch.
+			p.invalidCommandPaths.Delete(cmd)
 		}
 	}
 }
 
 // markCommandPathInvalidIfBroken is the per-dispatch gate used by
-// getActionsForItem. It returns true if the path has been seen before
-// and is known-invalid (skip silently), or if it is freshly stat'd and
-// found broken (skip and emit exactly one log line + one notification).
-// It returns false when the path is usable, letting the caller register
-// an ExecuteCommandAction.
+// getActionsForItem. It returns true if the path is currently flagged
+// invalid (skip silently), or if it is freshly stat'd and found broken
+// (skip and emit exactly one log line + one notification per recheck
+// window). It returns false when the path is usable, letting the
+// caller register an ExecuteCommandAction.
 //
-// Combined with the startup pre-warm in New(), this gives hot-reload
-// coverage for species configurations that were added or edited after
-// process start: the new ExecuteCommand path is stat'd on its first
-// dispatch, and if broken, the failure is announced once and then
-// cached so subsequent detections are cheap silent no-ops.
+// Cached failures are honored only for invalidCommandPathRecheckTTL —
+// after that, the path is re-stat'd on the next dispatch. This gives
+// hot-reload coverage for two scenarios:
+//
+//  1. The species was added or edited after startup. The new
+//     ExecuteCommand path is stat'd on its first dispatch and, if
+//     broken, the failure is announced once and cached so subsequent
+//     detections are cheap silent no-ops.
+//  2. The path was previously broken (e.g. missing file, missing
+//     execute bit) but the operator has since fixed it. After
+//     invalidCommandPathRecheckTTL elapses, the next dispatch re-stats
+//     the path; on success the cache entry is deleted and the action
+//     becomes active immediately without a process restart.
 func (p *Processor) markCommandPathInvalidIfBroken(speciesKey, cmd string) (invalid bool) {
-	if _, known := p.invalidCommandPaths.Load(cmd); known {
-		return true
+	if v, known := p.invalidCommandPaths.Load(cmd); known {
+		if stamp, ok := v.(time.Time); ok && time.Since(stamp) < invalidCommandPathRecheckTTL {
+			// Recent failure — still skip without re-stating.
+			return true
+		}
+		// TTL expired (or someone stored a non-time value, which
+		// should not happen but is handled defensively); fall through
+		// to re-validate.
 	}
 
 	if _, err := validateCommandPath(cmd); err != nil {
-		// LoadOrStore ensures that concurrent detections for the same
-		// broken path only emit a single notification even if they
-		// race on the first stat — whichever goroutine wins the store
-		// is the one that logs and notifies.
-		if _, loaded := p.invalidCommandPaths.LoadOrStore(cmd, struct{}{}); loaded {
+		// Mark the path as freshly invalid. We use Store rather than
+		// LoadOrStore because we *want* to overwrite a stale entry
+		// from a previous failure to keep the recheck window aligned
+		// with the most recent failure. The notification is gated on
+		// whether there was no entry at all, or the previous entry was
+		// already past the recheck window — concurrent detections that
+		// race on the first miss will only see one of them re-emit a
+		// notification because LoadOrStore on first insertion picks a
+		// single winner.
+		_, loaded := p.invalidCommandPaths.LoadOrStore(cmd, time.Now())
+		if loaded {
+			// Another detection beat us to the cache update; refresh
+			// the timestamp without re-emitting the notification so
+			// the recheck window slides forward.
+			p.invalidCommandPaths.Store(cmd, time.Now())
 			return true
 		}
 
@@ -495,5 +544,9 @@ func (p *Processor) markCommandPathInvalidIfBroken(speciesKey, cmd string) (inva
 		return true
 	}
 
+	// Path is valid — clear any stale invalid marker so a previously
+	// broken path that has been fixed (chmod +x, restored file, etc.)
+	// becomes active immediately for subsequent dispatches.
+	p.invalidCommandPaths.Delete(cmd)
 	return false
 }

--- a/internal/analysis/processor/execute.go
+++ b/internal/analysis/processor/execute.go
@@ -382,26 +382,30 @@ func getResultValueByName(result *detection.Result, paramName string) any {
 
 // validateCustomCommandActions scans the species configuration once at
 // startup and validates every ExecuteCommand action command path. Paths
-// that fail validation are recorded in the returned set so that
+// that fail validation are recorded in p.invalidCommandPaths so that
 // getActionsForItem can skip them at dispatch time. A single user-facing
 // notification and one telemetry event are emitted per unique broken
 // path, replacing the previous behavior of emitting a dual-fingerprint
 // Sentry event on every detection that would have triggered the action.
 //
-// The returned map is keyed by the *original* (non-cleaned) command
-// string from the config so that getActionsForItem can look up entries
-// without re-cleaning the path on every detection. An empty command
-// string is always treated as invalid because ExecuteCommand with no
-// command is a user misconfiguration.
+// Entries are keyed by the *original* (non-cleaned) command string from
+// the config so that getActionsForItem can look up entries without
+// re-cleaning the path on every detection. An empty command string is
+// always treated as invalid because ExecuteCommand with no command is
+// a user misconfiguration.
 //
-// The method is a no-op when there are no species configurations.
-func (p *Processor) validateCustomCommandActions(settings *conf.Settings) map[string]struct{} {
-	invalid := make(map[string]struct{})
-
-	// validated deduplicates work so the same command path appearing in
-	// multiple species configs is only stat'd and reported once, even if
-	// users share the same script across many species.
-	validated := make(map[string]bool)
+// The method is a no-op when there are no species configurations. It
+// only records failures; valid paths are left unrecorded so a species
+// added post-startup still goes through first-use validation via
+// markCommandPathInvalidIfBroken in getActionsForItem.
+func (p *Processor) validateCustomCommandActions(settings *conf.Settings) {
+	// validated deduplicates work within a single scan so the same
+	// command path appearing in multiple species configs is only stat'd
+	// and reported once, even if users share the same script across
+	// many species. Entries that were already recorded as invalid on a
+	// previous call (e.g. a second pre-warm after runtime reload) are
+	// also skipped.
+	validated := make(map[string]struct{})
 
 	log := GetLogger()
 
@@ -414,9 +418,13 @@ func (p *Processor) validateCustomCommandActions(settings *conf.Settings) map[st
 
 			cmd := actionCfg.Command
 			if _, seen := validated[cmd]; seen {
-				// Already validated on a previous iteration; skip so the
-				// same broken path shared across many species only
-				// produces one notification and one telemetry event.
+				continue
+			}
+			validated[cmd] = struct{}{}
+
+			// Skip paths we already know are invalid from an earlier
+			// scan so the notification is not re-emitted on re-scan.
+			if _, known := p.invalidCommandPaths.Load(cmd); known {
 				continue
 			}
 
@@ -425,8 +433,13 @@ func (p *Processor) validateCustomCommandActions(settings *conf.Settings) map[st
 			// ErrorBuilder.Build(). Calling it once per unique cmd gives
 			// us exactly one Sentry fingerprint per broken path.
 			if _, err := validateCommandPath(cmd); err != nil {
-				validated[cmd] = false
-				invalid[cmd] = struct{}{}
+				// LoadOrStore guarantees a single winner even if a
+				// concurrent detection path is racing with this scan,
+				// so notification is emitted at most once per process
+				// lifetime for the same unique broken path.
+				if _, loaded := p.invalidCommandPaths.LoadOrStore(cmd, struct{}{}); loaded {
+					continue
+				}
 
 				// Structured log for operators reading journal/stdout.
 				log.Error("Custom ExecuteCommand action has invalid command path — action will be skipped",
@@ -440,12 +453,47 @@ func (p *Processor) validateCustomCommandActions(settings *conf.Settings) map[st
 				// second telemetry event: it only extracts title/priority
 				// from the existing enhanced error for the UI panel.
 				notification.NotifyError("analysis.processor", err)
-				continue
 			}
-
-			validated[cmd] = true
 		}
 	}
+}
 
-	return invalid
+// markCommandPathInvalidIfBroken is the per-dispatch gate used by
+// getActionsForItem. It returns true if the path has been seen before
+// and is known-invalid (skip silently), or if it is freshly stat'd and
+// found broken (skip and emit exactly one log line + one notification).
+// It returns false when the path is usable, letting the caller register
+// an ExecuteCommandAction.
+//
+// Combined with the startup pre-warm in New(), this gives hot-reload
+// coverage for species configurations that were added or edited after
+// process start: the new ExecuteCommand path is stat'd on its first
+// dispatch, and if broken, the failure is announced once and then
+// cached so subsequent detections are cheap silent no-ops.
+func (p *Processor) markCommandPathInvalidIfBroken(speciesKey, cmd string) (invalid bool) {
+	if _, known := p.invalidCommandPaths.Load(cmd); known {
+		return true
+	}
+
+	if _, err := validateCommandPath(cmd); err != nil {
+		// LoadOrStore ensures that concurrent detections for the same
+		// broken path only emit a single notification even if they
+		// race on the first stat — whichever goroutine wins the store
+		// is the one that logs and notifies.
+		if _, loaded := p.invalidCommandPaths.LoadOrStore(cmd, struct{}{}); loaded {
+			return true
+		}
+
+		log := GetLogger()
+		log.Error("Custom ExecuteCommand action has invalid command path — action will be skipped",
+			logger.String("species", speciesKey),
+			logger.String("command", cmd),
+			logger.Error(err),
+			logger.String("operation", "validate_custom_command_path_runtime"))
+
+		notification.NotifyError("analysis.processor", err)
+		return true
+	}
+
+	return false
 }

--- a/internal/analysis/processor/execute.go
+++ b/internal/analysis/processor/execute.go
@@ -14,11 +14,17 @@ import (
 	"strings"
 	"time"
 
+	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/detection"
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/logger"
+	"github.com/tphakala/birdnet-go/internal/notification"
 )
+
+// executeCommandActionType is the action type discriminator used in
+// species configuration entries to identify ExecuteCommand actions.
+const executeCommandActionType = "ExecuteCommand"
 
 type ExecuteCommandAction struct {
 	Command string
@@ -52,16 +58,14 @@ func (a ExecuteCommandAction) ExecuteContext(ctx context.Context, data any) erro
 			Build()
 	}
 
-	// Validate and resolve the command path
+	// Validate and resolve the command path. validateCommandPath already
+	// returns a fully-annotated enhanced error (CategoryFileIO for stat
+	// failures, CategoryValidation for bad-shape failures). Re-wrapping it
+	// here used to produce a second, dual-fingerprint Sentry event per
+	// failed execution, so propagate the original error unchanged.
 	cmdPath, err := validateCommandPath(a.Command)
 	if err != nil {
-		return errors.New(err).
-			Component("analysis.processor").
-			Category(errors.CategoryValidation).
-			Priority(errors.PriorityHigh). // User-configured script issues should notify users
-			Context("operation", "validate_command_path").
-			Context("command_type", "external_script").
-			Build()
+		return err
 	}
 
 	// Building the command line arguments with validation
@@ -374,4 +378,74 @@ func getResultValueByName(result *detection.Result, paramName string) any {
 	default:
 		return nil
 	}
+}
+
+// validateCustomCommandActions scans the species configuration once at
+// startup and validates every ExecuteCommand action command path. Paths
+// that fail validation are recorded in the returned set so that
+// getActionsForItem can skip them at dispatch time. A single user-facing
+// notification and one telemetry event are emitted per unique broken
+// path, replacing the previous behavior of emitting a dual-fingerprint
+// Sentry event on every detection that would have triggered the action.
+//
+// The returned map is keyed by the *original* (non-cleaned) command
+// string from the config so that getActionsForItem can look up entries
+// without re-cleaning the path on every detection. An empty command
+// string is always treated as invalid because ExecuteCommand with no
+// command is a user misconfiguration.
+//
+// The method is a no-op when there are no species configurations.
+func (p *Processor) validateCustomCommandActions(settings *conf.Settings) map[string]struct{} {
+	invalid := make(map[string]struct{})
+
+	// validated deduplicates work so the same command path appearing in
+	// multiple species configs is only stat'd and reported once, even if
+	// users share the same script across many species.
+	validated := make(map[string]bool)
+
+	log := GetLogger()
+
+	for speciesKey, speciesCfg := range settings.Realtime.Species.Config {
+		for i := range speciesCfg.Actions {
+			actionCfg := &speciesCfg.Actions[i]
+			if actionCfg.Type != executeCommandActionType {
+				continue
+			}
+
+			cmd := actionCfg.Command
+			if _, seen := validated[cmd]; seen {
+				// Already validated on a previous iteration; skip so the
+				// same broken path shared across many species only
+				// produces one notification and one telemetry event.
+				continue
+			}
+
+			// validateCommandPath returns a fully built enhanced error
+			// that is already routed to the telemetry pipeline via
+			// ErrorBuilder.Build(). Calling it once per unique cmd gives
+			// us exactly one Sentry fingerprint per broken path.
+			if _, err := validateCommandPath(cmd); err != nil {
+				validated[cmd] = false
+				invalid[cmd] = struct{}{}
+
+				// Structured log for operators reading journal/stdout.
+				log.Error("Custom ExecuteCommand action has invalid command path — action will be skipped",
+					logger.String("species", speciesKey),
+					logger.String("command", cmd),
+					logger.Error(err),
+					logger.String("operation", "validate_custom_command_path"))
+
+				// Surface the failure in the notification center exactly
+				// once per unique bad path. NotifyError does not create a
+				// second telemetry event: it only extracts title/priority
+				// from the existing enhanced error for the UI panel.
+				notification.NotifyError("analysis.processor", err)
+				continue
+			}
+
+			validated[cmd] = true
+		}
+	}
+
+	return invalid
 }

--- a/internal/analysis/processor/execute.go
+++ b/internal/analysis/processor/execute.go
@@ -510,26 +510,30 @@ func (p *Processor) markCommandPathInvalidIfBroken(speciesKey, cmd string) (inva
 			return true
 		}
 		// TTL expired (or someone stored a non-time value, which
-		// should not happen but is handled defensively); fall through
-		// to re-validate.
+		// should not happen but is handled defensively). Drop the
+		// stale entry BEFORE the slow path runs. Without this,
+		// LoadOrStore below would observe the old entry and return
+		// loaded=true on a still-failing re-check, so the fresh
+		// failure would never reach the notification branch and the
+		// operator would only ever get one notification per startup.
+		// Deleting here means a still-broken path goes through the
+		// loaded=false branch and re-emits the notification exactly
+		// once per recheck window, while a now-usable path naturally
+		// falls through to the clear-and-return-false tail below.
+		p.invalidCommandPaths.Delete(cmd)
 	}
 
 	if _, err := validateCommandPath(cmd); err != nil {
-		// Mark the path as freshly invalid. We use Store rather than
-		// LoadOrStore because we *want* to overwrite a stale entry
-		// from a previous failure to keep the recheck window aligned
-		// with the most recent failure. The notification is gated on
-		// whether there was no entry at all, or the previous entry was
-		// already past the recheck window — concurrent detections that
-		// race on the first miss will only see one of them re-emit a
-		// notification because LoadOrStore on first insertion picks a
-		// single winner.
+		// LoadOrStore is authoritative here because the stale entry
+		// (if any) was already deleted above. A concurrent detection
+		// racing on the same path will see exactly one winner, so the
+		// notification is emitted at most once per recheck window
+		// even under contention.
 		_, loaded := p.invalidCommandPaths.LoadOrStore(cmd, time.Now())
 		if loaded {
-			// Another detection beat us to the cache update; refresh
-			// the timestamp without re-emitting the notification so
-			// the recheck window slides forward.
-			p.invalidCommandPaths.Store(cmd, time.Now())
+			// Another concurrent detection won the LoadOrStore race
+			// for the freshly-deleted entry; it is responsible for
+			// the notification, we just suppress the action.
 			return true
 		}
 
@@ -544,9 +548,12 @@ func (p *Processor) markCommandPathInvalidIfBroken(speciesKey, cmd string) (inva
 		return true
 	}
 
-	// Path is valid — clear any stale invalid marker so a previously
-	// broken path that has been fixed (chmod +x, restored file, etc.)
-	// becomes active immediately for subsequent dispatches.
+	// Path is valid — ensure any lingering invalid marker is gone
+	// (the Delete above already handled the TTL-expired path; this
+	// covers the rare "entry appeared between the Load branch and
+	// here" case defensively) so a previously broken path that has
+	// been fixed (chmod +x, restored file, etc.) becomes active
+	// immediately for subsequent dispatches.
 	p.invalidCommandPaths.Delete(cmd)
 	return false
 }

--- a/internal/analysis/processor/execute.go
+++ b/internal/analysis/processor/execute.go
@@ -442,8 +442,13 @@ func (p *Processor) validateCustomCommandActions(settings *conf.Settings) {
 				if stamp, ok := v.(time.Time); ok && time.Since(stamp) < invalidCommandPathRecheckTTL {
 					continue
 				}
-				// Stale entry — fall through and re-validate so a fixed
-				// path is cleared instead of being re-flagged below.
+				// Stale entry (or malformed value) — delete it before
+				// re-validating so a still-broken path hits the
+				// LoadOrStore loaded=false branch below and emits a
+				// fresh notification in the new TTL window. This
+				// matches the delete-before-recheck contract in
+				// markCommandPathInvalidIfBroken.
+				p.invalidCommandPaths.Delete(cmd)
 			}
 
 			// validateCommandPath returns a fully built enhanced error

--- a/internal/analysis/processor/execute_command_test.go
+++ b/internal/analysis/processor/execute_command_test.go
@@ -3,6 +3,7 @@ package processor
 import (
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -395,6 +396,7 @@ func TestValidateCustomCommandActions_DeduplicatesPaths(t *testing.T) {
 				},
 			},
 		},
+		EventTracker: NewEventTracker(0),
 	}
 
 	processor.validateCustomCommandActions(processor.Settings)
@@ -496,3 +498,214 @@ func TestValidateCustomCommandActions_HotReload_NewSpeciesValidatedOnFirstUse(t 
 		"hot-reloaded valid command path must produce an ExecuteCommandAction on first dispatch")
 	assert.Equal(t, validCmd, found.Command)
 }
+
+// TestGetActionsForItem_BrokenCommand_RespectsExecuteDefaultsFalse is a
+// regression test for the case where a species explicitly opts out of
+// default actions (ExecuteDefaults=false) and the only configured
+// custom action is an ExecuteCommand whose path fails validation.
+//
+// Before the fix, the per-dispatch gate skipped the broken command but
+// the function then fell through to the default-action fallback, so a
+// user who had disabled default actions for a species suddenly got
+// DB/SSE/MQTT/audio fallbacks back as soon as their script broke. The
+// fix tracks "had at least one custom action configured" separately
+// from "ended up with at least one runnable custom action" and
+// short-circuits the default fallback when ExecuteDefaults is false.
+func TestGetActionsForItem_BrokenCommand_RespectsExecuteDefaultsFalse(t *testing.T) {
+	t.Parallel()
+
+	missing := "/tmp/birdnet_go_broken_no_defaults_3f7a1.sh"
+
+	processor := &Processor{
+		Settings: &conf.Settings{
+			Realtime: conf.RealtimeSettings{
+				// Default-action sources enabled so that any
+				// accidental fall-through would produce a non-empty
+				// action list — this is what makes the assertion
+				// meaningful.
+				Log: struct {
+					Enabled bool   `yaml:"enabled" json:"enabled"`
+					Path    string `yaml:"path" json:"path"`
+				}{
+					Enabled: true,
+				},
+				Species: conf.SpeciesSettings{
+					Config: map[string]conf.SpeciesConfig{
+						"american robin": {
+							Threshold: 0.8,
+							Actions: []conf.SpeciesAction{
+								{
+									Type:            "ExecuteCommand",
+									Command:         missing,
+									ExecuteDefaults: false, // Explicit opt-out
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		EventTracker: NewEventTracker(0),
+	}
+
+	// Pre-populate the invalid path cache so the gate fires without
+	// having to rely on the file system. Use the current timestamp so
+	// the entry is well within the recheck window.
+	processor.invalidCommandPaths.Store(missing, timeNowForTest())
+
+	det := testDetectionWithSpecies("American Robin", "Turdus migratorius", 0.95)
+	actions := processor.getActionsForItem(&det)
+
+	assert.Empty(t, actions,
+		"broken ExecuteCommand with ExecuteDefaults=false must yield zero actions, not silent default fallbacks")
+	for _, a := range actions {
+		switch a.(type) {
+		case *LogAction, *DatabaseAction, *SSEAction, *MqttAction:
+			t.Fatalf("unexpected default action %T leaked through when ExecuteDefaults=false", a)
+		}
+	}
+}
+
+// TestGetActionsForItem_BrokenCommand_AllowsExecuteDefaultsTrue is the
+// inverse case: when the user opts INTO default actions for a species
+// and the custom command happens to be broken, the default fallbacks
+// should still run. This guards against an over-eager fix to the
+// previous regression where we accidentally disable defaults for
+// everyone.
+func TestGetActionsForItem_BrokenCommand_AllowsExecuteDefaultsTrue(t *testing.T) {
+	t.Parallel()
+
+	missing := "/tmp/birdnet_go_broken_with_defaults_84c2e.sh"
+
+	processor := &Processor{
+		Settings: &conf.Settings{
+			Realtime: conf.RealtimeSettings{
+				Log: struct {
+					Enabled bool   `yaml:"enabled" json:"enabled"`
+					Path    string `yaml:"path" json:"path"`
+				}{
+					Enabled: true,
+				},
+				Species: conf.SpeciesSettings{
+					Config: map[string]conf.SpeciesConfig{
+						"american robin": {
+							Threshold: 0.8,
+							Actions: []conf.SpeciesAction{
+								{
+									Type:            "ExecuteCommand",
+									Command:         missing,
+									ExecuteDefaults: true, // Opt INTO default fallback
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		EventTracker: NewEventTracker(0),
+	}
+
+	processor.invalidCommandPaths.Store(missing, timeNowForTest())
+
+	det := testDetectionWithSpecies("American Robin", "Turdus migratorius", 0.95)
+	actions := processor.getActionsForItem(&det)
+
+	// LogAction is part of the default set when Log.Enabled is true,
+	// and is the cheapest one to assert presence of without needing a
+	// real datastore wired up. Its presence implies the default-action
+	// fallback fired even though the custom command was skipped.
+	var hasLog bool
+	for _, a := range actions {
+		if _, ok := a.(*LogAction); ok {
+			hasLog = true
+			break
+		}
+	}
+	assert.True(t, hasLog,
+		"broken ExecuteCommand with ExecuteDefaults=true must still produce default actions (LogAction)")
+	// And the broken ExecuteCommand itself must NOT be in the list.
+	for _, a := range actions {
+		if _, ok := a.(*ExecuteCommandAction); ok {
+			t.Fatalf("broken ExecuteCommand must not be registered as an action")
+		}
+	}
+}
+
+// TestMarkCommandPathInvalidIfBroken_RecheckClearsFixedPath is a
+// regression test for the sticky-cache issue called out by CodeRabbit.
+// A path that was once cached as invalid must be re-validated after the
+// recheck TTL elapses; if it now passes, the cache entry is removed and
+// the corresponding ExecuteCommand action becomes active again without
+// any process restart.
+func TestMarkCommandPathInvalidIfBroken_RecheckClearsFixedPath(t *testing.T) {
+	t.Parallel()
+
+	validCmd := resolveValidExecutable(t)
+
+	processor := &Processor{
+		Settings: &conf.Settings{
+			Realtime: conf.RealtimeSettings{
+				Species: conf.SpeciesSettings{
+					Config: map[string]conf.SpeciesConfig{},
+				},
+			},
+		},
+		EventTracker: NewEventTracker(0),
+	}
+
+	// Seed the cache with a stale failure timestamp older than the
+	// recheck TTL, simulating a path that was broken at some point in
+	// the past. The actual validCmd path is now (and was, throughout
+	// this test) a real executable.
+	stale := timeNowForTest().Add(-2 * invalidCommandPathRecheckTTL)
+	processor.invalidCommandPaths.Store(validCmd, stale)
+
+	// First call: TTL expired, path is good — gate should clear the
+	// cache entry and report the path as usable.
+	got := processor.markCommandPathInvalidIfBroken("turdus migratorius", validCmd)
+	assert.False(t, got, "valid path with expired-TTL cache entry must re-validate cleanly")
+
+	_, stillCached := processor.invalidCommandPaths.Load(validCmd)
+	assert.False(t, stillCached, "fixed path must be removed from invalidCommandPaths after successful re-validation")
+}
+
+// TestMarkCommandPathInvalidIfBroken_RecentFailureSkipsRecheck verifies
+// that a recent failure timestamp suppresses re-stating the path. This
+// is the cheap-fast-path the original sync.Map design was built for —
+// it must remain in place so the per-detection hot path stays a single
+// map lookup for paths that legitimately stay broken.
+func TestMarkCommandPathInvalidIfBroken_RecentFailureSkipsRecheck(t *testing.T) {
+	t.Parallel()
+
+	validCmd := resolveValidExecutable(t)
+
+	processor := &Processor{
+		Settings: &conf.Settings{
+			Realtime: conf.RealtimeSettings{
+				Species: conf.SpeciesSettings{
+					Config: map[string]conf.SpeciesConfig{},
+				},
+			},
+		},
+		EventTracker: NewEventTracker(0),
+	}
+
+	// Seed the cache with a *recent* failure timestamp even though the
+	// path is actually fine. The gate must trust the cache and report
+	// the path as invalid without re-stating, otherwise the hot-path
+	// suppression that the original change was built for is lost.
+	processor.invalidCommandPaths.Store(validCmd, timeNowForTest())
+
+	got := processor.markCommandPathInvalidIfBroken("turdus migratorius", validCmd)
+	assert.True(t, got, "recent failure must suppress action without re-stating the path")
+
+	_, stillCached := processor.invalidCommandPaths.Load(validCmd)
+	assert.True(t, stillCached, "recent-failure cache entry must not be cleared by a non-recheck call")
+}
+
+// timeNowForTest is a tiny indirection so the timestamp helper used by
+// the recheck-TTL tests is named in one place. Keeping it as a local
+// helper rather than time.Now() inline makes it obvious in the test
+// body that the value is "now relative to test wall-clock", which is
+// the same source of truth markCommandPathInvalidIfBroken uses.
+func timeNowForTest() time.Time { return time.Now() }

--- a/internal/analysis/processor/execute_command_test.go
+++ b/internal/analysis/processor/execute_command_test.go
@@ -1,6 +1,7 @@
 package processor
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -219,4 +220,141 @@ func TestExecuteCommandAction_ExecuteDefaultsWithNoParams(t *testing.T) {
 
 	assert.True(t, hasExecuteCommand, "Expected ExecuteCommandAction to be present")
 	assert.True(t, hasLogAction, "Expected LogAction (default action) to be present when ExecuteDefaults is true")
+}
+
+// TestValidateCustomCommandActions_SkipsInvalidPath asserts that the
+// startup validation gate correctly flags command paths that point at a
+// non-existent file. Subsequent per-detection dispatch must not produce
+// an ExecuteCommandAction for those species, so the dual-fingerprint
+// Sentry event (validation re-wrap + file-io original) can no longer
+// fire on every detection.
+func TestValidateCustomCommandActions_SkipsInvalidPath(t *testing.T) {
+	t.Parallel()
+
+	missingPath := "/tmp/birdnet_go_does_not_exist_47f3e8a1.sh"
+
+	processor := &Processor{
+		Settings: &conf.Settings{
+			Realtime: conf.RealtimeSettings{
+				Species: conf.SpeciesSettings{
+					Config: map[string]conf.SpeciesConfig{
+						"american robin": {
+							Threshold: 0.8,
+							Actions: []conf.SpeciesAction{
+								{
+									Type:    "ExecuteCommand",
+									Command: missingPath,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		EventTracker: NewEventTracker(0),
+	}
+
+	// Run the same startup validation New() runs.
+	processor.invalidCommandPaths = processor.validateCustomCommandActions(processor.Settings)
+
+	require.Contains(t, processor.invalidCommandPaths, missingPath,
+		"missing command path must be recorded as invalid at startup")
+
+	// At dispatch time, the ExecuteCommand action must NOT be registered.
+	det := testDetectionWithSpecies("American Robin", "Turdus migratorius", 0.95)
+	actions := processor.getActionsForItem(&det)
+	for _, action := range actions {
+		if _, ok := action.(*ExecuteCommandAction); ok {
+			t.Fatalf("invalid command path %q must not produce an ExecuteCommandAction", missingPath)
+		}
+	}
+}
+
+// TestValidateCustomCommandActions_AllowsValidPath asserts that a valid
+// command path is NOT flagged by the startup gate and the action is
+// still dispatched as before.
+func TestValidateCustomCommandActions_AllowsValidPath(t *testing.T) {
+	t.Parallel()
+
+	// Pick an existing executable on the host (/bin/sh is present on
+	// effectively every POSIX CI runner). Skip gracefully otherwise.
+	validCmd := ""
+	for _, candidate := range []string{"/bin/sh", "/bin/true", "/usr/bin/true"} {
+		if _, err := os.Stat(candidate); err == nil {
+			validCmd = candidate
+			break
+		}
+	}
+	if validCmd == "" {
+		t.Skip("no suitable absolute executable found for positive test")
+	}
+
+	processor := &Processor{
+		Settings: &conf.Settings{
+			Realtime: conf.RealtimeSettings{
+				Species: conf.SpeciesSettings{
+					Config: map[string]conf.SpeciesConfig{
+						"american robin": {
+							Threshold: 0.8,
+							Actions: []conf.SpeciesAction{
+								{Type: "ExecuteCommand", Command: validCmd},
+							},
+						},
+					},
+				},
+			},
+		},
+		EventTracker: NewEventTracker(0),
+	}
+
+	processor.invalidCommandPaths = processor.validateCustomCommandActions(processor.Settings)
+	assert.Empty(t, processor.invalidCommandPaths,
+		"valid command path must not be flagged at startup")
+
+	det := testDetectionWithSpecies("American Robin", "Turdus migratorius", 0.95)
+	actions := processor.getActionsForItem(&det)
+
+	var found *ExecuteCommandAction
+	for _, a := range actions {
+		if ea, ok := a.(*ExecuteCommandAction); ok {
+			found = ea
+			break
+		}
+	}
+	require.NotNil(t, found, "valid command path must still produce an ExecuteCommandAction")
+	assert.Equal(t, validCmd, found.Command)
+}
+
+// TestValidateCustomCommandActions_DeduplicatesPaths ensures that the
+// same broken command path used across multiple species is only flagged
+// once in the returned invalid set.
+func TestValidateCustomCommandActions_DeduplicatesPaths(t *testing.T) {
+	t.Parallel()
+
+	missing := "/tmp/birdnet_go_does_not_exist_dedup_2a4c.sh"
+
+	processor := &Processor{
+		Settings: &conf.Settings{
+			Realtime: conf.RealtimeSettings{
+				Species: conf.SpeciesSettings{
+					Config: map[string]conf.SpeciesConfig{
+						"american robin": {
+							Actions: []conf.SpeciesAction{
+								{Type: "ExecuteCommand", Command: missing},
+							},
+						},
+						"house sparrow": {
+							Actions: []conf.SpeciesAction{
+								{Type: "ExecuteCommand", Command: missing},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	invalid := processor.validateCustomCommandActions(processor.Settings)
+	require.Len(t, invalid, 1, "same broken path across multiple species must be recorded once")
+	assert.Contains(t, invalid, missing)
 }

--- a/internal/analysis/processor/execute_command_test.go
+++ b/internal/analysis/processor/execute_command_test.go
@@ -709,3 +709,150 @@ func TestMarkCommandPathInvalidIfBroken_RecentFailureSkipsRecheck(t *testing.T) 
 // body that the value is "now relative to test wall-clock", which is
 // the same source of truth markCommandPathInvalidIfBroken uses.
 func timeNowForTest() time.Time { return time.Now() }
+
+// TestGetActionsForItem_UnimplementedAction_FallsThroughToDefaults is a
+// regression test for the case where a species has ONLY unimplemented
+// action types (e.g. the SendNotification placeholder) configured with
+// ExecuteDefaults=false. A previous iteration of the "respect
+// ExecuteDefaults=false when the custom action was dropped" fix was too
+// broad: it tracked "any custom action was configured" rather than "a
+// validated ExecuteCommand path was dropped", so a species with only
+// unimplemented custom actions silently returned an empty action list,
+// dropping DB/SSE/MQTT/audio fallbacks without any error. That meant
+// users lost detections for the species until the new action type
+// shipped. The fix narrows the short-circuit to broken command paths
+// only, letting unimplemented types fall through to the default set.
+func TestGetActionsForItem_UnimplementedAction_FallsThroughToDefaults(t *testing.T) {
+	t.Parallel()
+
+	processor := &Processor{
+		Settings: &conf.Settings{
+			Realtime: conf.RealtimeSettings{
+				// Enable the Log default action so the presence of
+				// the fallback is observable without wiring up a real
+				// datastore / MQTT client / SSE broadcaster.
+				Log: struct {
+					Enabled bool   `yaml:"enabled" json:"enabled"`
+					Path    string `yaml:"path" json:"path"`
+				}{
+					Enabled: true,
+				},
+				Species: conf.SpeciesSettings{
+					Config: map[string]conf.SpeciesConfig{
+						"american robin": {
+							Threshold: 0.8,
+							Actions: []conf.SpeciesAction{
+								{
+									Type:            "SendNotification",
+									ExecuteDefaults: false, // Explicit opt-out
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		EventTracker: NewEventTracker(0),
+	}
+
+	det := testDetectionWithSpecies("American Robin", "Turdus migratorius", 0.95)
+	actions := processor.getActionsForItem(&det)
+
+	// The species had only an unimplemented custom action type and no
+	// matching switch branch added anything to the action list. The
+	// function must NOT short-circuit to an empty result — it must
+	// fall through to the default action set so detections keep
+	// flowing. Asserting LogAction is present is the cheapest way to
+	// confirm the default-action branch fired.
+	require.NotEmpty(t, actions,
+		"unimplemented custom action with ExecuteDefaults=false must fall through to default actions, not yield an empty list")
+
+	var hasLog bool
+	for _, a := range actions {
+		if _, ok := a.(*LogAction); ok {
+			hasLog = true
+			break
+		}
+	}
+	assert.True(t, hasLog,
+		"default LogAction must be present when the only configured custom action is unimplemented")
+
+	// And the unimplemented action must not have silently produced an
+	// ExecuteCommandAction.
+	for _, a := range actions {
+		if _, ok := a.(*ExecuteCommandAction); ok {
+			t.Fatalf("unimplemented SendNotification must not produce an ExecuteCommandAction")
+		}
+	}
+}
+
+// TestMarkCommandPathInvalidIfBroken_ReNotifiesAfterTTL is a regression
+// test for the sync.Map sticky-entry bug in the TTL recheck path. When
+// a cached failure's TTL expires and the path is still broken, the
+// previous implementation left the stale entry in place and called
+// LoadOrStore, which returned loaded=true because of the stale value.
+// The notification branch is gated on loaded=false, so operators only
+// ever saw one notification per process lifetime instead of one per
+// recheck window.
+//
+// The fix deletes the stale entry BEFORE the re-validation slow path
+// runs, so a still-failing path goes through LoadOrStore's loaded=false
+// branch and re-emits the notification. Because the notification
+// helper is a no-op when the notification service is not initialized
+// (the test binary does not init it), the assertion checks the
+// observable sync.Map state: the entry was recreated with a fresh
+// timestamp (i.e. the entry got deleted and re-added) rather than left
+// in place at the original stale value.
+func TestMarkCommandPathInvalidIfBroken_ReNotifiesAfterTTL(t *testing.T) {
+	t.Parallel()
+
+	// A path that does not exist and cannot be fixed mid-test.
+	missing := "/tmp/birdnet_go_re_notify_after_ttl_b19e7.sh"
+
+	processor := &Processor{
+		Settings: &conf.Settings{
+			Realtime: conf.RealtimeSettings{
+				Species: conf.SpeciesSettings{
+					Config: map[string]conf.SpeciesConfig{},
+				},
+			},
+		},
+		EventTracker: NewEventTracker(0),
+	}
+
+	// Seed the cache with a stale failure from well before the
+	// recheck window. If the stale-entry bug resurfaces, the re-check
+	// path below will see loaded=true and leave this exact timestamp
+	// untouched instead of refreshing it.
+	stale := timeNowForTest().Add(-2 * invalidCommandPathRecheckTTL)
+	processor.invalidCommandPaths.Store(missing, stale)
+
+	// Re-check the still-broken path. The gate must report "invalid",
+	// delete the stale entry, re-stat the path, and re-store a fresh
+	// timestamp. The notification branch runs inside the
+	// just-deleted->LoadOrStore(loaded=false) window (verified below
+	// by checking the timestamp was refreshed rather than left at the
+	// stale value).
+	got := processor.markCommandPathInvalidIfBroken("turdus migratorius", missing)
+	assert.True(t, got, "still-broken path must be reported as invalid after TTL expiry")
+
+	v, stillCached := processor.invalidCommandPaths.Load(missing)
+	require.True(t, stillCached, "still-broken path must remain cached under a fresh timestamp after re-validation")
+
+	stamp, ok := v.(time.Time)
+	require.True(t, ok, "cached entry must be a time.Time")
+
+	// The fresh timestamp must be strictly newer than the stale one
+	// we seeded. If the sticky-entry bug returns, `stamp` will equal
+	// `stale` because LoadOrStore observed the old value and left it
+	// alone.
+	assert.True(t, stamp.After(stale),
+		"re-check of still-broken path must refresh the cached timestamp (old=%v, new=%v); same timestamp means the stale entry was not deleted before LoadOrStore and the notification branch never ran",
+		stale, stamp)
+
+	// The refreshed timestamp must also be within the current recheck
+	// window — i.e. roughly "now" — so a subsequent call in the next
+	// instant still hits the fast path.
+	assert.Less(t, time.Since(stamp), invalidCommandPathRecheckTTL,
+		"refreshed timestamp must be inside the active recheck window")
+}

--- a/internal/analysis/processor/execute_command_test.go
+++ b/internal/analysis/processor/execute_command_test.go
@@ -9,6 +9,44 @@ import (
 	"github.com/tphakala/birdnet-go/internal/conf"
 )
 
+// resolveValidExecutable returns an absolute path to an executable that
+// is known to exist on the test host. Used by tests that exercise the
+// action-dispatch pipeline and need a path that survives the per-call
+// command-path validation gate without relying on fixture scripts.
+// Tests that cannot find any usable executable are skipped rather than
+// failing — this keeps CI portable across containerized runners.
+func resolveValidExecutable(t *testing.T) string {
+	t.Helper()
+	for _, candidate := range []string{"/bin/sh", "/bin/true", "/usr/bin/true"} {
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate
+		}
+	}
+	t.Skip("no suitable absolute executable found for action-dispatch test")
+	return ""
+}
+
+// resolveTwoValidExecutables returns two distinct absolute paths to
+// executables that exist on the test host. Tests that exercise
+// multi-action dispatch and need to assert both commands appear in the
+// produced action list use this to avoid tripping the per-call
+// command-path validation gate. Skips gracefully on runners that only
+// have one of the candidates (rare for any POSIX CI image).
+func resolveTwoValidExecutables(t *testing.T) (first, second string) {
+	t.Helper()
+	found := make([]string, 0, 2)
+	for _, candidate := range []string{"/bin/sh", "/bin/true", "/usr/bin/true", "/bin/ls", "/usr/bin/env"} {
+		if _, err := os.Stat(candidate); err == nil {
+			found = append(found, candidate)
+			if len(found) == 2 {
+				return found[0], found[1]
+			}
+		}
+	}
+	t.Skip("fewer than two suitable absolute executables found for multi-action dispatch test")
+	return "", ""
+}
+
 // TestExecuteCommandAction_WithoutParameters tests that ExecuteCommand actions
 // are executed even when no parameters are specified.
 // Bug: https://github.com/tphakala/birdnet-go/discussions/1757
@@ -16,6 +54,11 @@ import (
 // which prevented commands without parameters from being added to the action list.
 func TestExecuteCommandAction_WithoutParameters(t *testing.T) {
 	t.Parallel()
+
+	// Use a real executable so the per-dispatch command path validation
+	// gate in getActionsForItem lets the action through. The original
+	// bug this test guards against is unrelated to path validity.
+	validCmd := resolveValidExecutable(t)
 
 	tests := []struct {
 		name            string
@@ -30,13 +73,13 @@ func TestExecuteCommandAction_WithoutParameters(t *testing.T) {
 				Actions: []conf.SpeciesAction{
 					{
 						Type:       "ExecuteCommand",
-						Command:    "/usr/local/bin/notify.sh",
+						Command:    validCmd,
 						Parameters: []string{}, // Empty parameters - this was the bug!
 					},
 				},
 			},
 			expectAction:    true,
-			expectedCommand: "/usr/local/bin/notify.sh",
+			expectedCommand: validCmd,
 		},
 		{
 			name: "command with nil parameters should still create action",
@@ -45,13 +88,13 @@ func TestExecuteCommandAction_WithoutParameters(t *testing.T) {
 				Actions: []conf.SpeciesAction{
 					{
 						Type:       "ExecuteCommand",
-						Command:    "/usr/local/bin/alert.sh",
+						Command:    validCmd,
 						Parameters: nil, // Nil parameters - should also work
 					},
 				},
 			},
 			expectAction:    true,
-			expectedCommand: "/usr/local/bin/alert.sh",
+			expectedCommand: validCmd,
 		},
 		{
 			name: "command with parameters should create action with params",
@@ -60,13 +103,13 @@ func TestExecuteCommandAction_WithoutParameters(t *testing.T) {
 				Actions: []conf.SpeciesAction{
 					{
 						Type:       "ExecuteCommand",
-						Command:    "/usr/local/bin/script.sh",
+						Command:    validCmd,
 						Parameters: []string{"CommonName", "Confidence"},
 					},
 				},
 			},
 			expectAction:    true,
-			expectedCommand: "/usr/local/bin/script.sh",
+			expectedCommand: validCmd,
 		},
 	}
 
@@ -117,6 +160,8 @@ func TestExecuteCommandAction_WithoutParameters(t *testing.T) {
 func TestExecuteCommandAction_MultipleActionsWithMixedParams(t *testing.T) {
 	t.Parallel()
 
+	simpleCmd, detailedCmd := resolveTwoValidExecutables(t)
+
 	processor := &Processor{
 		Settings: &conf.Settings{
 			Debug: true,
@@ -128,12 +173,12 @@ func TestExecuteCommandAction_MultipleActionsWithMixedParams(t *testing.T) {
 							Actions: []conf.SpeciesAction{
 								{
 									Type:       "ExecuteCommand",
-									Command:    "/usr/local/bin/simple.sh",
+									Command:    simpleCmd,
 									Parameters: []string{}, // No parameters
 								},
 								{
 									Type:       "ExecuteCommand",
-									Command:    "/usr/local/bin/detailed.sh",
+									Command:    detailedCmd,
 									Parameters: []string{"CommonName", "Confidence"},
 								},
 							},
@@ -165,14 +210,16 @@ func TestExecuteCommandAction_MultipleActionsWithMixedParams(t *testing.T) {
 		commands[action.Command] = true
 	}
 
-	assert.True(t, commands["/usr/local/bin/simple.sh"], "simple.sh should be in actions")
-	assert.True(t, commands["/usr/local/bin/detailed.sh"], "detailed.sh should be in actions")
+	assert.True(t, commands[simpleCmd], "%s should be in actions", simpleCmd)
+	assert.True(t, commands[detailedCmd], "%s should be in actions", detailedCmd)
 }
 
 // TestExecuteCommandAction_ExecuteDefaultsWithNoParams tests that executeDefaults
 // works correctly even when the custom command has no parameters.
 func TestExecuteCommandAction_ExecuteDefaultsWithNoParams(t *testing.T) {
 	t.Parallel()
+
+	validCmd := resolveValidExecutable(t)
 
 	processor := &Processor{
 		Settings: &conf.Settings{
@@ -191,7 +238,7 @@ func TestExecuteCommandAction_ExecuteDefaultsWithNoParams(t *testing.T) {
 							Actions: []conf.SpeciesAction{
 								{
 									Type:            "ExecuteCommand",
-									Command:         "/usr/local/bin/notify.sh",
+									Command:         validCmd,
 									Parameters:      []string{},
 									ExecuteDefaults: true, // Should also run default actions
 								},
@@ -255,9 +302,10 @@ func TestValidateCustomCommandActions_SkipsInvalidPath(t *testing.T) {
 	}
 
 	// Run the same startup validation New() runs.
-	processor.invalidCommandPaths = processor.validateCustomCommandActions(processor.Settings)
+	processor.validateCustomCommandActions(processor.Settings)
 
-	require.Contains(t, processor.invalidCommandPaths, missingPath,
+	_, flagged := processor.invalidCommandPaths.Load(missingPath)
+	require.True(t, flagged,
 		"missing command path must be recorded as invalid at startup")
 
 	// At dispatch time, the ExecuteCommand action must NOT be registered.
@@ -276,18 +324,7 @@ func TestValidateCustomCommandActions_SkipsInvalidPath(t *testing.T) {
 func TestValidateCustomCommandActions_AllowsValidPath(t *testing.T) {
 	t.Parallel()
 
-	// Pick an existing executable on the host (/bin/sh is present on
-	// effectively every POSIX CI runner). Skip gracefully otherwise.
-	validCmd := ""
-	for _, candidate := range []string{"/bin/sh", "/bin/true", "/usr/bin/true"} {
-		if _, err := os.Stat(candidate); err == nil {
-			validCmd = candidate
-			break
-		}
-	}
-	if validCmd == "" {
-		t.Skip("no suitable absolute executable found for positive test")
-	}
+	validCmd := resolveValidExecutable(t)
 
 	processor := &Processor{
 		Settings: &conf.Settings{
@@ -307,8 +344,14 @@ func TestValidateCustomCommandActions_AllowsValidPath(t *testing.T) {
 		EventTracker: NewEventTracker(0),
 	}
 
-	processor.invalidCommandPaths = processor.validateCustomCommandActions(processor.Settings)
-	assert.Empty(t, processor.invalidCommandPaths,
+	processor.validateCustomCommandActions(processor.Settings)
+
+	var flaggedCount int
+	processor.invalidCommandPaths.Range(func(_, _ any) bool {
+		flaggedCount++
+		return true
+	})
+	assert.Equal(t, 0, flaggedCount,
 		"valid command path must not be flagged at startup")
 
 	det := testDetectionWithSpecies("American Robin", "Turdus migratorius", 0.95)
@@ -354,7 +397,102 @@ func TestValidateCustomCommandActions_DeduplicatesPaths(t *testing.T) {
 		},
 	}
 
-	invalid := processor.validateCustomCommandActions(processor.Settings)
-	require.Len(t, invalid, 1, "same broken path across multiple species must be recorded once")
-	assert.Contains(t, invalid, missing)
+	processor.validateCustomCommandActions(processor.Settings)
+
+	var recorded int
+	processor.invalidCommandPaths.Range(func(key, _ any) bool {
+		if key == missing {
+			recorded++
+		}
+		return true
+	})
+	assert.Equal(t, 1, recorded, "same broken path across multiple species must be recorded once")
+}
+
+// TestValidateCustomCommandActions_HotReload_NewSpeciesValidatedOnFirstUse
+// is a regression test for the hot-reload gap where a species custom
+// ExecuteCommand action added *after* Processor.New() (i.e. via a UI
+// settings save) was never revalidated, letting the original per-call
+// Sentry spam return under a different code path. The sync.Map-backed
+// per-dispatch gate (markCommandPathInvalidIfBroken) must stat the new
+// path on its first dispatch and cache the skip from then on.
+func TestValidateCustomCommandActions_HotReload_NewSpeciesValidatedOnFirstUse(t *testing.T) {
+	t.Parallel()
+
+	// Start with an empty species config — nothing to validate at startup.
+	processor := &Processor{
+		Settings: &conf.Settings{
+			Realtime: conf.RealtimeSettings{
+				Species: conf.SpeciesSettings{
+					Config: map[string]conf.SpeciesConfig{},
+				},
+			},
+		},
+		EventTracker: NewEventTracker(0),
+	}
+	processor.validateCustomCommandActions(processor.Settings)
+
+	var startupFlagged int
+	processor.invalidCommandPaths.Range(func(_, _ any) bool {
+		startupFlagged++
+		return true
+	})
+	require.Equal(t, 0, startupFlagged,
+		"empty species config must not flag anything at startup")
+
+	// Simulate a post-startup hot reload: the settings store is mutated
+	// in place (mirroring how ControlMonitor updates settings without
+	// recreating the Processor), adding a species with a broken path.
+	missing := "/tmp/birdnet_go_hot_reload_missing_9e21b.sh"
+	processor.Settings.Realtime.Species.Config = map[string]conf.SpeciesConfig{
+		"american robin": {
+			Threshold: 0.8,
+			Actions: []conf.SpeciesAction{
+				{Type: "ExecuteCommand", Command: missing},
+			},
+		},
+	}
+
+	// First dispatch after the reload must trigger per-call validation,
+	// flag the path as invalid, and omit the ExecuteCommandAction.
+	det := testDetectionWithSpecies("American Robin", "Turdus migratorius", 0.95)
+	actions := processor.getActionsForItem(&det)
+	for _, action := range actions {
+		if _, ok := action.(*ExecuteCommandAction); ok {
+			t.Fatalf("hot-reloaded invalid command %q must not produce an ExecuteCommandAction", missing)
+		}
+	}
+
+	_, flagged := processor.invalidCommandPaths.Load(missing)
+	assert.True(t, flagged, "first dispatch must cache the broken path")
+
+	// Now swap the broken path for an executable that definitely exists
+	// (same hot-reload shape as before). A *new* detection should now
+	// produce an ExecuteCommandAction — the previous sync.Map entry
+	// belongs to the old broken path, not this one, so the new path is
+	// stat'd fresh on its first use.
+	validCmd := resolveValidExecutable(t)
+
+	processor.Settings.Realtime.Species.Config = map[string]conf.SpeciesConfig{
+		"american robin": {
+			Threshold: 0.8,
+			Actions: []conf.SpeciesAction{
+				{Type: "ExecuteCommand", Command: validCmd},
+			},
+		},
+	}
+
+	det2 := testDetectionWithSpecies("American Robin", "Turdus migratorius", 0.95)
+	actions2 := processor.getActionsForItem(&det2)
+
+	var found *ExecuteCommandAction
+	for _, a := range actions2 {
+		if ea, ok := a.(*ExecuteCommandAction); ok {
+			found = ea
+			break
+		}
+	}
+	require.NotNil(t, found,
+		"hot-reloaded valid command path must produce an ExecuteCommandAction on first dispatch")
+	assert.Equal(t, validCmd, found.Command)
 }

--- a/internal/analysis/processor/execute_internal_test.go
+++ b/internal/analysis/processor/execute_internal_test.go
@@ -186,6 +186,15 @@ func TestValidateCommandPath_NonExistentFile(t *testing.T) {
 
 	_, err := validateCommandPath("/tmp/this_file_definitely_does_not_exist_12345.sh")
 	require.Error(t, err)
+
+	// Regression: a missing file must produce a single enhanced error with
+	// CategoryFileIO. Previously the caller re-wrapped this into
+	// CategoryValidation, producing a second Sentry fingerprint per failed
+	// execution. See execute.go ExecuteContext for the consolidation.
+	var enhancedErr *errors.EnhancedError
+	require.True(t, errors.As(err, &enhancedErr), "expected enhanced error")
+	assert.Equal(t, errors.CategoryFileIO, enhancedErr.Category,
+		"missing-file path validation must use CategoryFileIO as its single fingerprint")
 }
 
 func TestValidateCommandPath_NonExecutableFile(t *testing.T) {

--- a/internal/analysis/processor/processor.go
+++ b/internal/analysis/processor/processor.go
@@ -140,7 +140,7 @@ type Processor struct {
 	taxonomyDBOnce sync.Once
 
 	// invalidCommandPaths records ExecuteCommand action command paths that
-	// have already failed validation (missing, unreadable, non-executable,
+	// have recently failed validation (missing, unreadable, non-executable,
 	// or relative). Entries here are skipped by getActionsForItem so a
 	// bad path fails once with a user-visible notification instead of
 	// generating a Sentry event per detection.
@@ -155,11 +155,15 @@ type Processor struct {
 	// in place by ControlMonitor), and concurrent reads from detection
 	// goroutines would otherwise race with the first runtime write.
 	//
-	// Values are empty struct{} sentinels (set membership only). A path
-	// that enters the map is cached as "skip" for the lifetime of the
-	// process; fixing a broken script requires a restart. This matches
-	// how the original startup gate behaved and keeps the implementation
-	// free of TTL/metrics bookkeeping.
+	// Values are time.Time timestamps recording when the path most
+	// recently failed validation. After invalidCommandPathRecheckTTL
+	// has elapsed since the last failure, markCommandPathInvalidIfBroken
+	// re-stats the path on the next dispatch; if the path now validates
+	// (e.g. the operator fixed permissions or restored a missing file),
+	// the entry is deleted and the action becomes active immediately
+	// without waiting for a process restart. This satisfies the
+	// hot-reload requirement in CLAUDE.md while still suppressing the
+	// per-detection Sentry spam between rechecks.
 	invalidCommandPaths sync.Map
 }
 
@@ -1528,22 +1532,44 @@ func (p *Processor) getActionsForItem(det *Detections) []Action {
 
 		var actions []Action
 		var executeDefaults bool
+		// hadCustomActionsConfigured tracks whether the species had at
+		// least one custom action defined in its config, even if every
+		// one of them was skipped at dispatch time (e.g. an
+		// ExecuteCommand action whose path failed validation). This is
+		// load-bearing for honoring ExecuteDefaults=false: a user who
+		// explicitly opts out of default actions for a species must not
+		// silently get DB/SSE/MQTT/audio fallbacks back when their
+		// custom command path breaks. See coderabbit review on PR #2729
+		// for the regression this guards against.
+		var hadCustomActionsConfigured bool
 
 		// Add custom actions from the new structure
 		for _, actionConfig := range speciesConfig.Actions {
+			hadCustomActionsConfigured = true
+			// Capture ExecuteDefaults BEFORE the switch so a `continue`
+			// inside a case (e.g. when an ExecuteCommand path fails
+			// validation) does not silently drop the user's
+			// ExecuteDefaults preference. Without this, a broken
+			// custom command with ExecuteDefaults=true would yield no
+			// actions at all because the post-switch flag-set was
+			// being skipped.
+			if actionConfig.ExecuteDefaults {
+				executeDefaults = true
+			}
 			switch actionConfig.Type {
 			case executeCommandActionType:
 				// First-use and cached-invalid gate: skip the action if
 				// the command path is (a) known invalid from an earlier
 				// dispatch or startup pre-warm, or (b) newly stat'd here
 				// and found broken. The helper emits at most one log
-				// line and one notification per unique bad path for the
-				// entire process lifetime, replacing the previous
-				// behavior of emitting a Sentry event per detection.
-				// Because the helper is driven by sync.Map it is
-				// hot-reload safe: species added or edited after
-				// startup get validated on their first detection
-				// without touching the Processor initialization path.
+				// line and one notification per unique bad path per
+				// recheck window, replacing the previous behavior of
+				// emitting a Sentry event per detection. Because the
+				// helper is driven by sync.Map with TTL-based recheck
+				// it is hot-reload safe: species added or edited after
+				// startup get validated on their first detection, and
+				// fixed paths are picked up automatically without a
+				// process restart.
 				if p.markCommandPathInvalidIfBroken(det.Result.Species.ScientificName, actionConfig.Command) {
 					continue
 				}
@@ -1554,10 +1580,6 @@ func (p *Processor) getActionsForItem(det *Detections) []Action {
 			case "SendNotification":
 				// Add notification action handling
 				// ... implementation ...
-			}
-			// If any action has ExecuteDefaults set to true, we'll include default actions
-			if actionConfig.ExecuteDefaults {
-				executeDefaults = true
 			}
 		}
 
@@ -1570,6 +1592,24 @@ func (p *Processor) getActionsForItem(det *Detections) []Action {
 		if len(actions) > 0 && executeDefaults {
 			defaultActions := p.getDefaultActions(det)
 			return append(actions, defaultActions...)
+		}
+
+		// Custom actions were configured for this species but every one
+		// of them was skipped (the only realistic source today is an
+		// ExecuteCommand action whose path failed validation). Respect
+		// the user's ExecuteDefaults choice exactly as it would have
+		// been respected if the command had been usable: when
+		// ExecuteDefaults is false, return an empty action list rather
+		// than silently re-enabling the default DB/SSE/MQTT/audio
+		// fallbacks. The notification emitted by
+		// markCommandPathInvalidIfBroken already informs the user that
+		// the action is broken, so the operator gets a clear signal
+		// without losing their stated "custom only" intent.
+		if hadCustomActionsConfigured && !executeDefaults {
+			GetLogger().Debug("All custom actions for species were skipped and ExecuteDefaults is false; returning empty action list",
+				logger.String("species", strings.ToLower(det.Result.Species.CommonName)),
+				logger.String("operation", "custom_action_skipped_no_defaults"))
+			return nil
 		}
 	}
 

--- a/internal/analysis/processor/processor.go
+++ b/internal/analysis/processor/processor.go
@@ -140,12 +140,27 @@ type Processor struct {
 	taxonomyDBOnce sync.Once
 
 	// invalidCommandPaths records ExecuteCommand action command paths that
-	// failed validation (missing, unreadable, non-executable, or relative)
-	// during startup. Entries here are skipped by getActionsForItem so a
+	// have already failed validation (missing, unreadable, non-executable,
+	// or relative). Entries here are skipped by getActionsForItem so a
 	// bad path fails once with a user-visible notification instead of
-	// generating a Sentry event per detection. The map is populated during
-	// New() and only read afterwards, so no mutex is required.
-	invalidCommandPaths map[string]struct{}
+	// generating a Sentry event per detection.
+	//
+	// Pre-populated during New() by validateCustomCommandActions so that
+	// operators get a startup-time error for any broken path already
+	// configured. The map is then consulted from detection goroutines
+	// (read) and extended on-demand (write) when a species that was
+	// added or edited *after* startup first fires — that hot-reload
+	// path is why we use sync.Map instead of a plain map + mutex: the
+	// Processor itself is never recreated on settings reload (mutation
+	// in place by ControlMonitor), and concurrent reads from detection
+	// goroutines would otherwise race with the first runtime write.
+	//
+	// Values are empty struct{} sentinels (set membership only). A path
+	// that enters the map is cached as "skip" for the lifetime of the
+	// process; fixing a broken script requires a restart. This matches
+	// how the original startup gate behaved and keeps the implementation
+	// free of TTL/metrics bookkeeping.
+	invalidCommandPaths sync.Map
 }
 
 type Detections struct {
@@ -474,8 +489,10 @@ func New(settings *conf.Settings, ds datastore.Interface, bn *classifier.Orchest
 	// Validate user-configured custom ExecuteCommand action paths up front
 	// so that a misconfigured command path produces a single user-facing
 	// notification at startup instead of emitting telemetry on every
-	// detection that would have triggered the action.
-	p.invalidCommandPaths = p.validateCustomCommandActions(settings)
+	// detection that would have triggered the action. Entries that still
+	// pass validation later (because the species was added after startup)
+	// are memoized on first dispatch in getActionsForItem.
+	p.validateCustomCommandActions(settings)
 
 	// Initialize species tracker if enabled
 	p.NewSpeciesTracker = initSpeciesTracker(settings, ds)
@@ -1516,12 +1533,18 @@ func (p *Processor) getActionsForItem(det *Detections) []Action {
 		for _, actionConfig := range speciesConfig.Actions {
 			switch actionConfig.Type {
 			case executeCommandActionType:
-				// Startup gate: if the command path failed validation in
-				// New(), silently skip registration so the action becomes
-				// a no-op for this species instead of emitting telemetry
-				// on every detection. The user already saw a notification
-				// and a log message at startup.
-				if _, invalid := p.invalidCommandPaths[actionConfig.Command]; invalid {
+				// First-use and cached-invalid gate: skip the action if
+				// the command path is (a) known invalid from an earlier
+				// dispatch or startup pre-warm, or (b) newly stat'd here
+				// and found broken. The helper emits at most one log
+				// line and one notification per unique bad path for the
+				// entire process lifetime, replacing the previous
+				// behavior of emitting a Sentry event per detection.
+				// Because the helper is driven by sync.Map it is
+				// hot-reload safe: species added or edited after
+				// startup get validated on their first detection
+				// without touching the Processor initialization path.
+				if p.markCommandPathInvalidIfBroken(det.Result.Species.ScientificName, actionConfig.Command) {
 					continue
 				}
 				actions = append(actions, &ExecuteCommandAction{

--- a/internal/analysis/processor/processor.go
+++ b/internal/analysis/processor/processor.go
@@ -1532,20 +1532,27 @@ func (p *Processor) getActionsForItem(det *Detections) []Action {
 
 		var actions []Action
 		var executeDefaults bool
-		// hadCustomActionsConfigured tracks whether the species had at
-		// least one custom action defined in its config, even if every
-		// one of them was skipped at dispatch time (e.g. an
-		// ExecuteCommand action whose path failed validation). This is
-		// load-bearing for honoring ExecuteDefaults=false: a user who
-		// explicitly opts out of default actions for a species must not
-		// silently get DB/SSE/MQTT/audio fallbacks back when their
-		// custom command path breaks. See coderabbit review on PR #2729
-		// for the regression this guards against.
-		var hadCustomActionsConfigured bool
+		// brokenCommandPathSkipped tracks only the narrow case of a
+		// custom ExecuteCommand action that was validated against the
+		// filesystem and explicitly dropped because its command path
+		// is invalid. It is load-bearing for honoring
+		// ExecuteDefaults=false on an otherwise-broken custom command:
+		// a user who opts out of default actions for a species must
+		// not silently get DB/SSE/MQTT/audio fallbacks back when their
+		// custom script breaks.
+		//
+		// It is intentionally NOT flipped for unimplemented action
+		// types (e.g. the SendNotification placeholder below). A
+		// species configured with only unimplemented action types
+		// must fall through to the default action set so detections
+		// keep flowing until the new type is wired up; treating those
+		// configs as "custom only" would silently drop detections.
+		// See Sentry issue BIRDNET-GO-... / PR #2729 review for the
+		// regression this flag guards against.
+		var brokenCommandPathSkipped bool
 
 		// Add custom actions from the new structure
 		for _, actionConfig := range speciesConfig.Actions {
-			hadCustomActionsConfigured = true
 			// Capture ExecuteDefaults BEFORE the switch so a `continue`
 			// inside a case (e.g. when an ExecuteCommand path fails
 			// validation) does not silently drop the user's
@@ -1571,6 +1578,14 @@ func (p *Processor) getActionsForItem(det *Detections) []Action {
 				// fixed paths are picked up automatically without a
 				// process restart.
 				if p.markCommandPathInvalidIfBroken(det.Result.Species.ScientificName, actionConfig.Command) {
+					// Only the ExecuteCommand branch flips the
+					// "custom-only intent" guard below, because it is
+					// the only branch where we know for sure that the
+					// user configured a working action and the path is
+					// temporarily broken. Unimplemented action types
+					// must not trip this flag — they are a separate
+					// issue and should fall through to defaults.
+					brokenCommandPathSkipped = true
 					continue
 				}
 				actions = append(actions, &ExecuteCommandAction{
@@ -1580,6 +1595,12 @@ func (p *Processor) getActionsForItem(det *Detections) []Action {
 			case "SendNotification":
 				// Add notification action handling
 				// ... implementation ...
+				// NOTE: Until this branch is implemented, a species
+				// configured with only SendNotification actions adds
+				// nothing to `actions` and deliberately does NOT flip
+				// brokenCommandPathSkipped, so the function falls
+				// through to the default action set instead of
+				// returning an empty list.
 			}
 		}
 
@@ -1594,19 +1615,24 @@ func (p *Processor) getActionsForItem(det *Detections) []Action {
 			return append(actions, defaultActions...)
 		}
 
-		// Custom actions were configured for this species but every one
-		// of them was skipped (the only realistic source today is an
-		// ExecuteCommand action whose path failed validation). Respect
-		// the user's ExecuteDefaults choice exactly as it would have
-		// been respected if the command had been usable: when
-		// ExecuteDefaults is false, return an empty action list rather
-		// than silently re-enabling the default DB/SSE/MQTT/audio
-		// fallbacks. The notification emitted by
-		// markCommandPathInvalidIfBroken already informs the user that
-		// the action is broken, so the operator gets a clear signal
-		// without losing their stated "custom only" intent.
-		if hadCustomActionsConfigured && !executeDefaults {
-			GetLogger().Debug("All custom actions for species were skipped and ExecuteDefaults is false; returning empty action list",
+		// A custom ExecuteCommand action was configured for this
+		// species, its command path was validated and dropped because
+		// it is broken, and the user explicitly opted out of default
+		// actions. Respect the "custom only" intent exactly as it
+		// would have been respected if the command had been usable:
+		// return an empty action list rather than silently
+		// re-enabling the default DB/SSE/MQTT/audio fallbacks. The
+		// notification emitted by markCommandPathInvalidIfBroken
+		// already informs the user that the action is broken, so the
+		// operator gets a clear signal without losing their stated
+		// intent.
+		//
+		// Note: this is gated on brokenCommandPathSkipped, not "had
+		// any custom action configured". Unimplemented action types
+		// such as SendNotification deliberately fall through to the
+		// default action set below so detections keep flowing.
+		if brokenCommandPathSkipped && !executeDefaults {
+			GetLogger().Debug("Broken custom ExecuteCommand was skipped and ExecuteDefaults is false; returning empty action list",
 				logger.String("species", strings.ToLower(det.Result.Species.CommonName)),
 				logger.String("operation", "custom_action_skipped_no_defaults"))
 			return nil

--- a/internal/analysis/processor/processor.go
+++ b/internal/analysis/processor/processor.go
@@ -138,6 +138,14 @@ type Processor struct {
 	// Cached taxonomy database (lazy-loaded, shared across init functions)
 	taxonomyDB     *classifier.TaxonomyDatabase
 	taxonomyDBOnce sync.Once
+
+	// invalidCommandPaths records ExecuteCommand action command paths that
+	// failed validation (missing, unreadable, non-executable, or relative)
+	// during startup. Entries here are skipped by getActionsForItem so a
+	// bad path fails once with a user-visible notification instead of
+	// generating a Sentry event per detection. The map is populated during
+	// New() and only read afterwards, so no mutex is required.
+	invalidCommandPaths map[string]struct{}
 }
 
 type Detections struct {
@@ -462,6 +470,12 @@ func New(settings *conf.Settings, ds datastore.Interface, bn *classifier.Orchest
 
 	// Validate and log false positive filter configuration
 	validateAndLogFilterConfig(settings)
+
+	// Validate user-configured custom ExecuteCommand action paths up front
+	// so that a misconfigured command path produces a single user-facing
+	// notification at startup instead of emitting telemetry on every
+	// detection that would have triggered the action.
+	p.invalidCommandPaths = p.validateCustomCommandActions(settings)
 
 	// Initialize species tracker if enabled
 	p.NewSpeciesTracker = initSpeciesTracker(settings, ds)
@@ -1501,7 +1515,15 @@ func (p *Processor) getActionsForItem(det *Detections) []Action {
 		// Add custom actions from the new structure
 		for _, actionConfig := range speciesConfig.Actions {
 			switch actionConfig.Type {
-			case "ExecuteCommand":
+			case executeCommandActionType:
+				// Startup gate: if the command path failed validation in
+				// New(), silently skip registration so the action becomes
+				// a no-op for this species instead of emitting telemetry
+				// on every detection. The user already saw a notification
+				// and a log message at startup.
+				if _, invalid := p.invalidCommandPaths[actionConfig.Command]; invalid {
+					continue
+				}
 				actions = append(actions, &ExecuteCommandAction{
 					Command: actionConfig.Command,
 					Params:  parseCommandParams(actionConfig.Parameters, det),

--- a/internal/conf/audio_source_validation_test.go
+++ b/internal/conf/audio_source_validation_test.go
@@ -96,6 +96,12 @@ func TestAudioSourceConfig_Validate_RejectsGPSCoordinates(t *testing.T) {
 		{"negative lat", ":-45.5,120.5"},
 		{"explicit signs", ":+45.5,-120.5"},
 		{"integer coords", ":45,-120"},
+		// Naked variant — same nonsense, no leading colon. Must also be
+		// rejected even though it does not mimic the ALSA device-prefix
+		// shape, since real ALSA/Pulse device strings always start with
+		// a letter.
+		{"naked decimal coords", "45.5,-120.5"},
+		{"naked integer coords", "45,120"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/conf/audio_source_validation_test.go
+++ b/internal/conf/audio_source_validation_test.go
@@ -80,6 +80,67 @@ func TestAudioSourceConfig_Validate_DeviceRequired(t *testing.T) {
 	assert.Contains(t, err.Error(), "device is required")
 }
 
+// TestAudioSourceConfig_Validate_RejectsGPSCoordinates is a regression
+// test for the case where a user pasted GPS coordinates (intended for
+// birdnet.latitude/longitude) into the audio source device field.
+// The device string parses at config load time but fails forever once
+// the audio engine tries to open it, producing repeated Sentry events.
+func TestAudioSourceConfig_Validate_RejectsGPSCoordinates(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		device string
+	}{
+		{"positive lat/lon", ":45.5,-120.5"},
+		{"negative lat", ":-45.5,120.5"},
+		{"explicit signs", ":+45.5,-120.5"},
+		{"integer coords", ":45,-120"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			src := &AudioSourceConfig{
+				Name:   "Mic",
+				Device: tt.device,
+			}
+			err := src.Validate()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "GPS coordinates",
+				"GPS-shaped device strings must fail with a clear error")
+		})
+	}
+}
+
+// TestAudioSourceConfig_Validate_AcceptsRealDeviceStrings ensures the
+// GPS regex is narrow enough that real ALSA/Pulse/CoreAudio device
+// shapes still validate. The plan scopes this to a narrow negative
+// regex, so a permissive positive-shape check is out of scope.
+func TestAudioSourceConfig_Validate_AcceptsRealDeviceStrings(t *testing.T) {
+	t.Parallel()
+
+	tests := []string{
+		"default",
+		"sysdefault",
+		"hw:0,0",
+		"hw:CARD0,DEV0",
+		"plughw:0,0",
+		"pulse:0",
+		"pulse",
+		"Built-in Microphone",
+	}
+	for _, device := range tests {
+		t.Run(device, func(t *testing.T) {
+			t.Parallel()
+			src := &AudioSourceConfig{
+				Name:   "Mic",
+				Device: device,
+			}
+			assert.NoError(t, src.Validate(), "real device string %q must still validate", device)
+		})
+	}
+}
+
 func TestAudioSourceConfig_Validate_GainRange(t *testing.T) {
 	t.Parallel()
 

--- a/internal/conf/audio_source_validation_test.go
+++ b/internal/conf/audio_source_validation_test.go
@@ -102,6 +102,14 @@ func TestAudioSourceConfig_Validate_RejectsGPSCoordinates(t *testing.T) {
 		// a letter.
 		{"naked decimal coords", "45.5,-120.5"},
 		{"naked integer coords", "45,120"},
+		// Whitespace variants — copy-pasted from map services or
+		// spreadsheet exports often include a space after (or around)
+		// the comma. The shape is still nonsense as an audio device
+		// and must be rejected with the same clear error.
+		{"colon space after comma", ":45.5, -120.5"},
+		{"naked space after comma", "45.5, -120.5"},
+		{"naked space before comma", "45.5 ,-120.5"},
+		{"naked spaces both sides", ":45.5  ,  -120.5"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/conf/validate.go
+++ b/internal/conf/validate.go
@@ -44,15 +44,19 @@ var (
 	// birdweatherIDPattern validates Birdweather ID format (24 alphanumeric characters)
 	birdweatherIDPattern = regexp.MustCompile(`^[a-zA-Z0-9]{24}$`)
 
-	// gpsCoordPattern matches the exact shape of the GPS-coordinate-
-	// as-device-string misconfiguration seen in the wild:
-	// a leading colon, a signed decimal latitude, a comma, and a signed
-	// decimal longitude (e.g. `:45.5,-120.5`). This ALSA device-prefix
-	// shape only looks legal to the parser until playback starts, so
-	// the audio engine fails forever on every startup. Detecting it at
-	// validation time lets us point the user at the right field with a
-	// single clear error instead of emitting recurring telemetry.
-	gpsCoordPattern = regexp.MustCompile(`^:[+-]?\d+(\.\d+)?,[+-]?\d+(\.\d+)?$`)
+	// gpsCoordPattern matches the GPS-coordinate-as-device-string
+	// misconfiguration seen in the wild. The leading colon is optional:
+	// the originally reported case was `:45.5,-120.5` (an ALSA-style
+	// device prefix with the PCM name replaced by coordinates), but the
+	// naked variant `45.5,-120.5` — and integer-only forms like
+	// `45,120` — are equally nonsensical as audio devices and would
+	// otherwise slip through. Real ALSA/Pulse device strings always
+	// start with a letter (`default`, `hw:0,0`, `pulse:0`, etc.), so
+	// a leading digit / sign / optional colon never collides with a
+	// valid configuration. Detecting this shape at validation time lets
+	// us point the user at the right field with a single clear error
+	// instead of emitting recurring telemetry.
+	gpsCoordPattern = regexp.MustCompile(`^:?[+-]?\d+(\.\d+)?,[+-]?\d+(\.\d+)?$`)
 )
 
 // Audio gain limits in dB

--- a/internal/conf/validate.go
+++ b/internal/conf/validate.go
@@ -43,6 +43,16 @@ var validRetentionPolicies = []string{
 var (
 	// birdweatherIDPattern validates Birdweather ID format (24 alphanumeric characters)
 	birdweatherIDPattern = regexp.MustCompile(`^[a-zA-Z0-9]{24}$`)
+
+	// gpsCoordPattern matches the exact shape of the GPS-coordinate-
+	// as-device-string misconfiguration seen in the wild:
+	// a leading colon, a signed decimal latitude, a comma, and a signed
+	// decimal longitude (e.g. `:45.5,-120.5`). This ALSA device-prefix
+	// shape only looks legal to the parser until playback starts, so
+	// the audio engine fails forever on every startup. Detecting it at
+	// validation time lets us point the user at the right field with a
+	// single clear error instead of emitting recurring telemetry.
+	gpsCoordPattern = regexp.MustCompile(`^:[+-]?\d+(\.\d+)?,[+-]?\d+(\.\d+)?$`)
 )
 
 // Audio gain limits in dB
@@ -332,6 +342,16 @@ func (a *AudioSourceConfig) Validate() error {
 	// Device is required
 	if a.Device == "" {
 		return fmt.Errorf("audio source device is required for '%s'", a.Name)
+	}
+
+	// Reject device strings that look like GPS coordinates. Users have
+	// pasted values like ":45.5,-120.5" into the device field (probably
+	// intended for the location/coordinates setting) which bypasses
+	// argument parsing in ALSA/pipewire/pulse and causes the audio
+	// engine to fail forever on every startup. Catch it up front with
+	// a clear error pointing at the right setting.
+	if gpsCoordPattern.MatchString(a.Device) {
+		return fmt.Errorf("audio source '%s': device %q looks like GPS coordinates; set latitude/longitude under birdnet.latitude and birdnet.longitude instead and pick a real audio device", a.Name, a.Device)
 	}
 
 	// Validate gain range

--- a/internal/conf/validate.go
+++ b/internal/conf/validate.go
@@ -53,10 +53,13 @@ var (
 	// otherwise slip through. Real ALSA/Pulse device strings always
 	// start with a letter (`default`, `hw:0,0`, `pulse:0`, etc.), so
 	// a leading digit / sign / optional colon never collides with a
-	// valid configuration. Detecting this shape at validation time lets
-	// us point the user at the right field with a single clear error
-	// instead of emitting recurring telemetry.
-	gpsCoordPattern = regexp.MustCompile(`^:?[+-]?\d+(\.\d+)?,[+-]?\d+(\.\d+)?$`)
+	// valid configuration. Optional whitespace around the comma is
+	// allowed because users frequently paste coordinates copied from
+	// map services with a space after the separator (`45.5, -120.5`).
+	// Detecting this shape at validation time lets us point the user
+	// at the right field with a single clear error instead of emitting
+	// recurring telemetry.
+	gpsCoordPattern = regexp.MustCompile(`^:?[+-]?\d+(\.\d+)?\s*,\s*[+-]?\d+(\.\d+)?$`)
 )
 
 // Audio gain limits in dB

--- a/internal/conf/validate.go
+++ b/internal/conf/validate.go
@@ -835,16 +835,23 @@ func validateSecuritySettings(settings *Security) error {
 		return err
 	}
 
-	// Validate the subnet bypass setting against the allowed pattern
+	// Validate the subnet bypass setting against the allowed pattern.
+	// Empty entries (from trailing commas, double commas, or all-whitespace tokens)
+	// are skipped so that a config like "10.0.0.0/8, ,192.168.0.0/24" is accepted
+	// with the same semantics as oauth.go's allowlist check.
 	if settings.AllowSubnetBypass.Enabled {
 		subnets := strings.SplitSeq(settings.AllowSubnetBypass.Subnet, ",")
 		for subnet := range subnets {
-			_, _, err := net.ParseCIDR(strings.TrimSpace(subnet))
+			trimmedSubnet := strings.TrimSpace(subnet)
+			if trimmedSubnet == "" {
+				continue // Skip empty entries (e.g. trailing or embedded commas)
+			}
+			_, _, err := net.ParseCIDR(trimmedSubnet)
 			if err != nil {
 				return errors.New(err).
 					Category(errors.CategoryValidation).
 					Context("validation_type", "security-subnet-format").
-					Context("subnet", subnet).
+					Context("subnet", trimmedSubnet).
 					Build()
 			}
 		}

--- a/internal/conf/validate_security_test.go
+++ b/internal/conf/validate_security_test.go
@@ -381,6 +381,44 @@ func TestValidateSecuritySettings_SubnetBypass(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			// Regression: an empty Subnet string previously produced
+			// "invalid CIDR address: (empty)" because every split token was
+			// passed to net.ParseCIDR. Empty means "no CIDRs configured".
+			name: "Enabled with empty subnet string - should pass",
+			security: Security{
+				AllowSubnetBypass: AllowSubnetBypass{
+					Enabled: true,
+					Subnet:  "",
+				},
+				SessionDuration: 24 * time.Hour,
+			},
+			wantErr: false,
+		},
+		{
+			name: "Enabled with whitespace-only subnet - should pass",
+			security: Security{
+				AllowSubnetBypass: AllowSubnetBypass{
+					Enabled: true,
+					Subnet:  "   ",
+				},
+				SessionDuration: 24 * time.Hour,
+			},
+			wantErr: false,
+		},
+		{
+			// Regression: trailing/embedded empty tokens (double comma,
+			// trailing comma, whitespace-only token) must not error.
+			name: "Mixed valid and empty subnet entries - should pass",
+			security: Security{
+				AllowSubnetBypass: AllowSubnetBypass{
+					Enabled: true,
+					Subnet:  "10.0.0.0/8, ,192.168.0.0/24,",
+				},
+				SessionDuration: 24 * time.Hour,
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

Three independent config validation hardening fixes.

### Empty CIDR entries skipped instead of erroring

`internal/conf/validate.go` now skips empty entries when parsing the `AllowSubnetBypass.Subnet` comma-separated list. Trailing or embedded commas (\`10.0.0.0/8, ,192.168.0.0/24\`) previously triggered \`invalid CIDR address: (empty)\` and surfaced as a configuration validation error to users. Mirrors the existing pattern in \`internal/security/oauth.go:915-917\`.

### Custom command path validation: hot-reload aware, single error fingerprint

The processor was generating ~1014 Sentry events in 12 days from one user with a misconfigured custom command path. Two distinct issues:

1. `validateCommandPath` returned a `CategoryFileIO` enhanced error, then `ExecuteContext` re-wrapped it as `CategoryValidation`. Two distinct Sentry fingerprints per failed detection.
2. Validation ran per-detection, not per-config. Every analysis dispatch re-stat'd the missing file and re-emitted both errors.

The fix:
- Drops the re-wrap so a single `CategoryFileIO` event fires per failure, and only when `validateCommandPath` actually says so.
- Pre-warms a `Processor.invalidCommandPaths sync.Map` at startup by scanning `Realtime.Species.Config[].Actions` for ExecuteCommand actions and validating each unique path once.
- Adds `markCommandPathInvalidIfBroken` which `getActionsForItem` calls per dispatch. The fast path is a single `sync.Map.Load`. The slow path (cache miss → first dispatch for that path after a UI edit) calls `validateCommandPath` once and `LoadOrStore`s the result, with a single user-facing notification on the first failure.
- Naturally hot-reload-safe: when a user edits a command path via the UI mid-run, the new path gets validated on its first dispatch. CLAUDE.md mandates this.
- Naturally race-safe: `sync.Map` handles concurrent access from detection goroutines without needing an explicit mutex.

### GPS coordinates rejected in audio device field

`AudioSourceConfig.Device` accepted any non-empty string, including GPS coordinate strings like `:45.5,-120.5` (the actual reported value, where the leading colon mirrors ALSA's `hw:CARD,DEV` format) or naked `45.5,-120.5`. The audio engine then failed to find a device matching the GPS string, every startup, forever.

The fix adds a package-level `gpsCoordPattern` regex (`^:?[+-]?\d+(\.\d+)?,[+-]?\d+(\.\d+)?$`) and rejects matching device strings during `AudioSourceConfig.Validate()` with a clear error pointing the user at `birdnet.latitude` / `birdnet.longitude`. ALSA-style strings (`hw:0,0`, `default`, `pulse:0`, `Built-in Microphone`) all start with letters and are unaffected.

## Test Plan

- [ ] `golangci-lint run -v ./internal/conf/... ./internal/analysis/processor/...` — 0 issues
- [ ] `go test -race -count=1 ./internal/conf/... ./internal/analysis/processor/...` — pass
- [ ] `go test -race -count=10 ./internal/analysis/processor/...` — pass (race stress)
- [ ] New tests: empty/whitespace/embedded-comma CIDR cases, GPS rejection cases, real-device acceptance cases, single-fingerprint command path validation, hot-reload regression test (broken path → first dispatch flags+skips → mutate to valid path → first dispatch registers the action), startup pre-warm tests.
- [ ] Manual: edit a custom command path via the UI to a missing file, trigger a detection, verify exactly one notification + one Sentry event. Mutate the path to a valid script, trigger another detection, verify the action runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * ExecuteCommand custom actions now validate command paths at startup and on first use, skip broken commands, and suppress repeated error notifications for a short recheck window.
  * When custom ExecuteCommand is broken and defaults are disabled, defaults are no longer applied; otherwise defaults still apply.
  * Audio device validation rejects GPS-like strings and directs users to set latitude/longitude.
  * Security subnet bypass validation tolerates empty/whitespace entries.

* **Tests**
  * Expanded coverage for command-path validation, caching/TTL behavior, hot-reload scenarios, fallback semantics, and audio/security validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->