### PR TITLE
fix(imageprovider): short-circuit fallback chain for exhausted species

### DIFF
--- a/internal/imageprovider/exhausted_species_cache_test.go
+++ b/internal/imageprovider/exhausted_species_cache_test.go
@@ -1,0 +1,127 @@
+// exhausted_species_cache_test.go: unit tests for the registry-adjacent
+// "exhausted species" memory cache. These tests live in the internal package
+// so they can construct a minimal BirdImageCache and manipulate the
+// exhaustedSpecies map directly for TTL and concurrency edge cases.
+package imageprovider
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// newMinimalCache returns a BirdImageCache with just enough state to exercise
+// the exhausted-species helpers. It does not start background refresh and has
+// no datastore or file cache.
+func newMinimalCache(t *testing.T, providerName string) *BirdImageCache {
+	t.Helper()
+	return &BirdImageCache{
+		providerName: providerName,
+		quit:         make(chan struct{}),
+	}
+}
+
+// TestRecordSpeciesExhausted verifies that recordSpeciesExhausted stores a
+// timestamp that isSpeciesExhausted can observe.
+func TestRecordSpeciesExhausted(t *testing.T) {
+	t.Parallel()
+	c := newMinimalCache(t, "avicommons")
+
+	assert.False(t, c.isSpeciesExhausted("Siren"), "no entry should exist initially")
+
+	c.recordSpeciesExhausted("Siren")
+	assert.True(t, c.isSpeciesExhausted("Siren"), "entry should be observable after recording")
+	assert.False(t, c.isSpeciesExhausted("Turdus merula"), "unrelated species should be unaffected")
+}
+
+// TestRecordSpeciesExhaustedEmptyName verifies that empty scientific names are
+// silently ignored. This matches Get()'s empty-name guard and prevents poisoning
+// the map with an unusable key.
+func TestRecordSpeciesExhaustedEmptyName(t *testing.T) {
+	t.Parallel()
+	c := newMinimalCache(t, "avicommons")
+
+	c.recordSpeciesExhausted("")
+	assert.False(t, c.isSpeciesExhausted(""), "empty-name entries must not be stored")
+}
+
+// TestIsSpeciesExhaustedExpiresLazily backdates a stored entry past the TTL
+// and verifies that isSpeciesExhausted reports false and removes the entry.
+func TestIsSpeciesExhaustedExpiresLazily(t *testing.T) {
+	t.Parallel()
+	c := newMinimalCache(t, "avicommons")
+
+	// Record an entry manually with a backdated timestamp so we do not have
+	// to wait through a real TTL. This bypasses recordSpeciesExhausted
+	// because it stamps the entry with the current time.
+	stale := time.Now().Add(-exhaustedSpeciesTTL - time.Minute)
+	c.exhaustedSpecies.Store("Siren", stale)
+
+	assert.False(t, c.isSpeciesExhausted("Siren"), "stale entry must expire")
+
+	// The entry should have been deleted by the lazy-expiration path.
+	_, stillPresent := c.exhaustedSpecies.Load("Siren")
+	assert.False(t, stillPresent, "stale entry should be evicted from the map")
+}
+
+// TestIsSpeciesExhaustedRejectsBogusType is a defensive check: if something
+// stores a non-time.Time value in the map, isSpeciesExhausted must not panic
+// and must drop the bogus entry.
+func TestIsSpeciesExhaustedRejectsBogusType(t *testing.T) {
+	t.Parallel()
+	c := newMinimalCache(t, "avicommons")
+
+	c.exhaustedSpecies.Store("Siren", "not a timestamp")
+	assert.False(t, c.isSpeciesExhausted("Siren"))
+
+	_, stillPresent := c.exhaustedSpecies.Load("Siren")
+	assert.False(t, stillPresent, "bogus-type entry should be evicted")
+}
+
+// TestExhaustedSpeciesCacheConcurrentAccess verifies that concurrent callers
+// can record and query exhaustion state without panicking or racing. The
+// -race flag used by `go test -race` catches data races; the assertions
+// verify that at least one record operation is visible at the end.
+func TestExhaustedSpeciesCacheConcurrentAccess(t *testing.T) {
+	t.Parallel()
+	c := newMinimalCache(t, "avicommons")
+
+	const (
+		workers        = 64
+		iterations     = 200
+		scientificName = "Siren"
+	)
+
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for range workers {
+		go func() {
+			defer wg.Done()
+			for range iterations {
+				// Mix of record and query calls. If the map is not safe,
+				// -race will flag it; if the logic is wrong, the assertion
+				// after Wait will fail.
+				c.recordSpeciesExhausted(scientificName)
+				_ = c.isSpeciesExhausted(scientificName)
+			}
+		}()
+	}
+	wg.Wait()
+
+	assert.True(t, c.isSpeciesExhausted(scientificName),
+		"after concurrent writes the entry should be present")
+}
+
+// TestSynthesizeExhaustedResponse verifies the short-circuit response carries
+// ErrImageNotFound so callers can rely on the existing error type.
+func TestSynthesizeExhaustedResponse(t *testing.T) {
+	t.Parallel()
+	c := newMinimalCache(t, "avicommons")
+
+	img, err := c.synthesizeExhaustedResponse("Siren")
+	assert.Empty(t, img.URL, "response image should be empty")
+	assert.ErrorIs(t, err, ErrImageNotFound,
+		"response error must match ErrImageNotFound so existing callers unwrap correctly")
+}

--- a/internal/imageprovider/exhausted_species_integration_test.go
+++ b/internal/imageprovider/exhausted_species_integration_test.go
@@ -1,0 +1,211 @@
+// exhausted_species_integration_test.go: end-to-end tests verifying that the
+// primary cache short-circuits the fallback chain once every registered
+// provider has returned "not found" for a given species. This addresses the
+// real-world symptom where species with no image (Siren, Human vocal, ...)
+// caused a SQLite read on every detection cycle through the fallback path.
+package imageprovider_test
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/datastore"
+	"github.com/tphakala/birdnet-go/internal/errors"
+	"github.com/tphakala/birdnet-go/internal/imageprovider"
+)
+
+// countingStore wraps mockStore and records how many times GetImageCache is
+// called for each provider name. This lets tests assert that the exhausted
+// short-circuit prevents repeated DB reads on the fallback chain.
+type countingStore struct {
+	*mockStore
+	totalGetCalls atomic.Int64
+}
+
+func newCountingStore() *countingStore {
+	return &countingStore{
+		mockStore: newMockStore(),
+	}
+}
+
+func (s *countingStore) GetImageCache(query datastore.ImageCacheQuery) (*datastore.ImageCache, error) {
+	s.totalGetCalls.Add(1)
+	return s.mockStore.GetImageCache(query)
+}
+
+func (s *countingStore) TotalGetCacheCalls() int64 {
+	return s.totalGetCalls.Load()
+}
+
+// countingNotFoundProvider returns ErrImageNotFound for every species and
+// records how many times Fetch was invoked.
+type countingNotFoundProvider struct {
+	callCount atomic.Int64
+}
+
+func (p *countingNotFoundProvider) Fetch(_ string) (imageprovider.BirdImage, error) {
+	p.callCount.Add(1)
+	return imageprovider.BirdImage{}, imageprovider.ErrImageNotFound
+}
+
+func (p *countingNotFoundProvider) Calls() int64 {
+	return p.callCount.Load()
+}
+
+// setupExhaustedCacheTest constructs a primary (avicommons) + fallback
+// (wikimedia) cache pair backed by a counting store. Both providers are
+// countingNotFoundProvider so every fetch yields ErrImageNotFound — the
+// conditions that trigger the exhaustion path.
+func setupExhaustedCacheTest(t *testing.T) (primary *imageprovider.BirdImageCache, primaryProv, fallbackProv *countingNotFoundProvider, trackedStore *countingStore) {
+	t.Helper()
+
+	settings := conf.GetTestSettings()
+	settings.Realtime.Dashboard.Thumbnails.ImageProvider = providerAvicommons
+	settings.Realtime.Dashboard.Thumbnails.FallbackPolicy = "all"
+	conf.SetTestSettings(settings)
+
+	trackedStore = newCountingStore()
+	primaryProv = &countingNotFoundProvider{}
+	fallbackProv = &countingNotFoundProvider{}
+
+	primary = imageprovider.InitCache(providerAvicommons, primaryProv, nil, trackedStore)
+	t.Cleanup(func() { assert.NoError(t, primary.Close()) })
+
+	fallbackCache := imageprovider.InitCache(providerWikimedia, fallbackProv, nil, trackedStore)
+	t.Cleanup(func() { assert.NoError(t, fallbackCache.Close()) })
+
+	registry := imageprovider.NewImageProviderRegistry()
+	require.NoError(t, registry.Register(providerAvicommons, primary))
+	require.NoError(t, registry.Register(providerWikimedia, fallbackCache))
+
+	primary.SetRegistry(registry)
+	fallbackCache.SetRegistry(registry)
+
+	return primary, primaryProv, fallbackProv, trackedStore
+}
+
+// TestExhaustedSpeciesCache_RecordsAfterFallbackFails verifies that after the
+// primary and fallback providers both return ErrImageNotFound, a subsequent
+// Get for the same species does not re-run the providers.
+func TestExhaustedSpeciesCache_RecordsAfterFallbackFails(t *testing.T) {
+	const species = "Siren"
+
+	primaryCache, primaryProvider, fallbackProvider, _ := setupExhaustedCacheTest(t)
+
+	_, err := primaryCache.Get(species)
+	require.Error(t, err, "first Get should fail because both providers return not-found")
+	assert.True(t, errors.Is(err, imageprovider.ErrImageNotFound),
+		"first Get error should be ErrImageNotFound, got %v", err)
+
+	// After the first call, the primary should have been tried and the
+	// fallback should have been tried via the registry.
+	primaryAfterFirst := primaryProvider.Calls()
+	fallbackAfterFirst := fallbackProvider.Calls()
+	assert.Equal(t, int64(1), primaryAfterFirst, "primary provider should be called exactly once on first Get")
+	assert.Equal(t, int64(1), fallbackAfterFirst, "fallback provider should be called exactly once on first Get")
+
+	// Second call: exhaustion cache should short-circuit the fallback chain.
+	_, err = primaryCache.Get(species)
+	require.Error(t, err, "second Get should still fail (negative cache hit)")
+	assert.True(t, errors.Is(err, imageprovider.ErrImageNotFound),
+		"second Get error should be ErrImageNotFound, got %v", err)
+
+	assert.Equal(t, primaryAfterFirst, primaryProvider.Calls(),
+		"primary provider must not be called again after exhaustion")
+	assert.Equal(t, fallbackAfterFirst, fallbackProvider.Calls(),
+		"fallback provider must not be called again after exhaustion")
+}
+
+// TestExhaustedSpeciesCache_ShortCircuitsRepeatedCalls verifies that several
+// repeated Get calls after exhaustion produce zero additional provider and
+// datastore lookups. This directly addresses the reported symptom of a
+// SQLite read every 1.5s for species like "Siren".
+func TestExhaustedSpeciesCache_ShortCircuitsRepeatedCalls(t *testing.T) {
+	const species = "Human vocal"
+
+	primaryCache, primaryProvider, fallbackProvider, store := setupExhaustedCacheTest(t)
+
+	// First call: primary tries, fails, fallback tries, fails. Exhaustion
+	// is recorded. The first call makes DB lookups for both providers.
+	_, err := primaryCache.Get(species)
+	require.Error(t, err)
+
+	baselineGetCalls := store.TotalGetCacheCalls()
+	baselinePrimary := primaryProvider.Calls()
+	baselineFallback := fallbackProvider.Calls()
+
+	require.Positive(t, baselineGetCalls, "first call should perform at least one GetImageCache lookup")
+	require.Equal(t, int64(1), baselinePrimary, "first call should hit primary provider once")
+	require.Equal(t, int64(1), baselineFallback, "first call should hit fallback provider once")
+
+	// Subsequent calls: should not touch providers or the datastore at all.
+	const repeats = 5
+	for i := range repeats {
+		_, err := primaryCache.Get(species)
+		require.Error(t, err, "repeat %d: expected ErrImageNotFound", i+1)
+		assert.True(t, errors.Is(err, imageprovider.ErrImageNotFound),
+			"repeat %d: error should be ErrImageNotFound, got %v", i+1, err)
+	}
+
+	assert.Equal(t, baselineGetCalls, store.TotalGetCacheCalls(),
+		"no additional GetImageCache calls should occur after exhaustion")
+	assert.Equal(t, baselinePrimary, primaryProvider.Calls(),
+		"no additional primary provider calls should occur after exhaustion")
+	assert.Equal(t, baselineFallback, fallbackProvider.Calls(),
+		"no additional fallback provider calls should occur after exhaustion")
+}
+
+// TestExhaustedSpeciesCache_ConcurrentGetCalls spawns many goroutines that
+// all call Get for the same exhausted species. With the fix, the provider
+// chain must run at most once overall (racing goroutines may each trigger
+// one provider call during the initial race, but repeated calls after
+// exhaustion is recorded must be zero).
+//
+// This test catches both race conditions (via `go test -race`) and
+// correctness regressions where the exhaustion cache fails to propagate.
+func TestExhaustedSpeciesCache_ConcurrentGetCalls(t *testing.T) {
+	const (
+		species    = "Noise"
+		goroutines = 32
+	)
+
+	primaryCache, primaryProvider, fallbackProvider, _ := setupExhaustedCacheTest(t)
+
+	// Prime the exhaustion cache with a single call so concurrent callers
+	// observe the short-circuit consistently. This is the steady-state
+	// behavior we care about — preventing the "every 1.5s SQLite read"
+	// symptom once the species has been marked exhausted.
+	_, err := primaryCache.Get(species)
+	require.Error(t, err, "priming call should return not-found")
+
+	baselinePrimary := primaryProvider.Calls()
+	baselineFallback := fallbackProvider.Calls()
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	errCh := make(chan error, goroutines)
+	for range goroutines {
+		go func() {
+			defer wg.Done()
+			_, err := primaryCache.Get(species)
+			errCh <- err
+		}()
+	}
+	wg.Wait()
+	close(errCh)
+
+	for e := range errCh {
+		require.Error(t, e, "every concurrent Get should return an error")
+		assert.True(t, errors.Is(e, imageprovider.ErrImageNotFound),
+			"concurrent Get should return ErrImageNotFound, got %v", e)
+	}
+
+	assert.Equal(t, baselinePrimary, primaryProvider.Calls(),
+		"concurrent Get calls must not re-invoke primary provider")
+	assert.Equal(t, baselineFallback, fallbackProvider.Calls(),
+		"concurrent Get calls must not re-invoke fallback provider")
+}

--- a/internal/imageprovider/exhausted_species_integration_test.go
+++ b/internal/imageprovider/exhausted_species_integration_test.go
@@ -18,6 +18,12 @@ import (
 	"github.com/tphakala/birdnet-go/internal/imageprovider"
 )
 
+// fallbackPolicyAllValue is the string value for the "try every provider"
+// fallback policy. Mirrors the unexported fallbackPolicyAll constant in the
+// production package; declared here so test files can reference it without
+// repeating the literal.
+const fallbackPolicyAllValue = "all"
+
 // countingStore wraps mockStore and records how many times GetImageCache is
 // called for each provider name. This lets tests assert that the exhausted
 // short-circuit prevents repeated DB reads on the fallback chain.
@@ -56,6 +62,29 @@ func (p *countingNotFoundProvider) Calls() int64 {
 	return p.callCount.Load()
 }
 
+// countingTransientFailureProvider returns a non-ErrImageNotFound error on
+// every fetch (simulating a network outage, DB error, or provider init
+// failure) and records how many times Fetch was invoked. Critically, the
+// returned error must NOT satisfy errors.Is(err, ErrImageNotFound).
+type countingTransientFailureProvider struct {
+	callCount atomic.Int64
+}
+
+func (p *countingTransientFailureProvider) Fetch(_ string) (imageprovider.BirdImage, error) {
+	p.callCount.Add(1)
+	// A plain sentinel error that is unrelated to ErrImageNotFound. This
+	// is exactly the kind of failure that historically poisoned the
+	// exhausted-species cache.
+	return imageprovider.BirdImage{}, errors.Newf("simulated transient network failure").
+		Component("imageprovider").
+		Category(errors.CategoryNetwork).
+		Build()
+}
+
+func (p *countingTransientFailureProvider) Calls() int64 {
+	return p.callCount.Load()
+}
+
 // setupExhaustedCacheTest constructs a primary (avicommons) + fallback
 // (wikimedia) cache pair backed by a counting store. Both providers are
 // countingNotFoundProvider so every fetch yields ErrImageNotFound — the
@@ -63,9 +92,18 @@ func (p *countingNotFoundProvider) Calls() int64 {
 func setupExhaustedCacheTest(t *testing.T) (primary *imageprovider.BirdImageCache, primaryProv, fallbackProv *countingNotFoundProvider, trackedStore *countingStore) {
 	t.Helper()
 
+	// Capture and restore the global settings instance so tests in this
+	// package do not bleed into each other. conf.SetTestSettings replaces a
+	// process-wide singleton, so an unrestored mutation can flip the
+	// fallback policy for any later test that calls conf.Setting().
+	previousSettings := conf.GetSettings()
+	t.Cleanup(func() {
+		conf.SetTestSettings(previousSettings)
+	})
+
 	settings := conf.GetTestSettings()
 	settings.Realtime.Dashboard.Thumbnails.ImageProvider = providerAvicommons
-	settings.Realtime.Dashboard.Thumbnails.FallbackPolicy = "all"
+	settings.Realtime.Dashboard.Thumbnails.FallbackPolicy = fallbackPolicyAllValue
 	conf.SetTestSettings(settings)
 
 	trackedStore = newCountingStore()
@@ -86,6 +124,85 @@ func setupExhaustedCacheTest(t *testing.T) (primary *imageprovider.BirdImageCach
 	fallbackCache.SetRegistry(registry)
 
 	return primary, primaryProv, fallbackProv, trackedStore
+}
+
+// setupTransientFallbackTest constructs a primary cache that returns
+// ErrImageNotFound (a legitimate "not found" condition that triggers the
+// fallback chain) and a fallback cache whose provider returns a transient
+// non-not-found error on every fetch. This is the exact scenario CodeRabbit
+// flagged: a real outage on the fallback must NOT poison the
+// exhausted-species cache for the TTL window.
+func setupTransientFallbackTest(t *testing.T) (
+	primary *imageprovider.BirdImageCache,
+	primaryProv *countingNotFoundProvider,
+	fallbackProv *countingTransientFailureProvider,
+) {
+	t.Helper()
+
+	previousSettings := conf.GetSettings()
+	t.Cleanup(func() {
+		conf.SetTestSettings(previousSettings)
+	})
+
+	settings := conf.GetTestSettings()
+	settings.Realtime.Dashboard.Thumbnails.ImageProvider = providerAvicommons
+	settings.Realtime.Dashboard.Thumbnails.FallbackPolicy = fallbackPolicyAllValue
+	conf.SetTestSettings(settings)
+
+	store := newMockStore()
+	primaryProv = &countingNotFoundProvider{}
+	fallbackProv = &countingTransientFailureProvider{}
+
+	primary = imageprovider.InitCache(providerAvicommons, primaryProv, nil, store)
+	t.Cleanup(func() { assert.NoError(t, primary.Close()) })
+
+	fallbackCache := imageprovider.InitCache(providerWikimedia, fallbackProv, nil, store)
+	t.Cleanup(func() { assert.NoError(t, fallbackCache.Close()) })
+
+	registry := imageprovider.NewImageProviderRegistry()
+	require.NoError(t, registry.Register(providerAvicommons, primary))
+	require.NoError(t, registry.Register(providerWikimedia, fallbackCache))
+
+	primary.SetRegistry(registry)
+	fallbackCache.SetRegistry(registry)
+
+	return primary, primaryProv, fallbackProv
+}
+
+// TestExhaustedSpeciesCache_DoesNotRecordOnTransientFailure verifies the
+// CORRECTNESS gate added in response to CodeRabbit feedback: when the primary
+// returns ErrImageNotFound but a fallback fails with a non-not-found error
+// (network error, DB error, provider init failure), the species must NOT be
+// marked as exhausted. The next Get() must retry the fallback chain so the
+// transient failure self-heals instead of being masked for the TTL window.
+//
+// Indirect observation strategy: after the first call, call Get() a second
+// time. If the species had been incorrectly marked exhausted, the second
+// call would short-circuit and the fallback provider's call count would NOT
+// increase. With the fix in place, the fallback IS retried.
+func TestExhaustedSpeciesCache_DoesNotRecordOnTransientFailure(t *testing.T) {
+	const species = "Turdus merula"
+
+	primaryCache, primaryProvider, fallbackProvider := setupTransientFallbackTest(t)
+
+	// First call: primary returns not-found, fallback returns a transient
+	// network error. The first Get must surface an error.
+	_, err := primaryCache.Get(species)
+	require.Error(t, err, "first Get should return an error")
+
+	primaryAfterFirst := primaryProvider.Calls()
+	fallbackAfterFirst := fallbackProvider.Calls()
+	require.Equal(t, int64(1), primaryAfterFirst, "primary should be called once")
+	require.Equal(t, int64(1), fallbackAfterFirst, "fallback should be called once")
+
+	// Second call: because the fallback failure was transient (not
+	// ErrImageNotFound), the exhausted-species cache must NOT have been
+	// poisoned. The fallback chain must run again.
+	_, err = primaryCache.Get(species)
+	require.Error(t, err, "second Get should still return an error")
+
+	assert.Equal(t, int64(2), fallbackProvider.Calls(),
+		"fallback provider must be retried after a transient failure (not silently masked)")
 }
 
 // TestExhaustedSpeciesCache_RecordsAfterFallbackFails verifies that after the

--- a/internal/imageprovider/imageprovider.go
+++ b/internal/imageprovider/imageprovider.go
@@ -144,6 +144,13 @@ type BirdImageCache struct {
 	wg           sync.WaitGroup                        // Tracks in-flight DB and background operations
 	Initializing sync.Map                              // Track which species are being initialized
 	registry     atomic.Pointer[ImageProviderRegistry] // Use atomic pointer
+	// exhaustedSpecies tracks species whose primary + fallback providers have
+	// all returned "not found" within the current TTL window. It maps a
+	// scientific name to the time.Time the exhaustion was recorded. This lets
+	// Get() short-circuit the fallback chain for species like "Siren" or
+	// "Human vocal" that no image provider will ever resolve, eliminating
+	// repeated SQLite reads on every detection cycle.
+	exhaustedSpecies sync.Map
 }
 
 // GetFileCache returns the file cache instance, or nil if not configured.
@@ -1178,6 +1185,17 @@ func (c *BirdImageCache) Get(scientificName string) (BirdImage, error) {
 	img, foundInCache, err := c.tryInitialize(scientificName)
 	if err != nil {
 		c.logInitializeError(err, scientificName, log)
+		// If every provider has already been exhausted for this species
+		// within the TTL window, short-circuit the fallback chain instead
+		// of re-querying each fallback's database and provider on every
+		// call. The exhausted entry was recorded inside tryFallbackProviders
+		// the last time the chain ran to completion. Metrics are deliberately
+		// unchanged here to mirror the pre-fix behavior for the primary
+		// negative-cache path (which also did not emit a hit/miss metric).
+		if c.isSpeciesExhausted(scientificName) {
+			log.Debug("Species already exhausted by all providers, skipping fallback chain")
+			return c.synthesizeExhaustedResponse(scientificName)
+		}
 		if fallbackImg, found := c.tryFallbackOnGetError(err, scientificName, log); found {
 			return fallbackImg, nil
 		}
@@ -1475,6 +1493,67 @@ func (c *BirdImageCache) logSlowOperation(operation, scientificName string, dura
 	}
 }
 
+// exhaustedSpeciesTTL is the lifetime of an exhausted-species cache entry.
+// Reuses negativeCacheTTL so the two negative-cache layers stay in sync: an
+// entry remains short-circuited exactly as long as the underlying negative DB
+// entries remain valid. Using the existing constant avoids drift between
+// layers.
+const exhaustedSpeciesTTL = negativeCacheTTL
+
+// recordSpeciesExhausted marks a species as having exhausted every registered
+// image provider within the current TTL window. Subsequent Get() calls for
+// the same species will short-circuit the fallback chain until the entry
+// ages out.
+//
+// Concurrency: sync.Map.Store is safe for concurrent writes; racing callers
+// will simply overwrite each other's timestamp with near-identical values,
+// which is harmless because the TTL window is coarse (minutes).
+func (c *BirdImageCache) recordSpeciesExhausted(scientificName string) {
+	if scientificName == "" {
+		return
+	}
+	c.exhaustedSpecies.Store(scientificName, time.Now())
+}
+
+// isSpeciesExhausted reports whether the species has a live exhaustion entry.
+// It performs lazy expiration: if the stored timestamp is older than the TTL,
+// the entry is deleted and false is returned so the fallback chain can retry.
+//
+// Concurrency: sync.Map.Load/Delete are safe for concurrent access. A race
+// between "isSpeciesExhausted observed entry as fresh" and another goroutine
+// deleting it is fine — the caller just treats it as exhausted for this call,
+// and the next call will re-check. No double-fetch of providers can occur as
+// a result of this read, because recording only happens after all providers
+// have already been tried (see tryFallbackProviders).
+func (c *BirdImageCache) isSpeciesExhausted(scientificName string) bool {
+	if scientificName == "" {
+		return false
+	}
+	v, ok := c.exhaustedSpecies.Load(scientificName)
+	if !ok {
+		return false
+	}
+	stamp, ok := v.(time.Time)
+	if !ok {
+		// Defensive: unexpected type, drop the bogus entry.
+		c.exhaustedSpecies.Delete(scientificName)
+		return false
+	}
+	if time.Since(stamp) > exhaustedSpeciesTTL {
+		c.exhaustedSpecies.Delete(scientificName) // lazy expiration
+		return false
+	}
+	return true
+}
+
+// synthesizeExhaustedResponse returns the short-circuit response used when a
+// species is already known to be exhausted. It mirrors the value returned by
+// the primary-provider negative path so callers do not need to distinguish
+// the two.
+func (c *BirdImageCache) synthesizeExhaustedResponse(scientificName string) (BirdImage, error) {
+	return BirdImage{}, imageNotFoundFor(scientificName, c.providerName, "exhausted_species_cache")
+}
+
 // tryFallbackProviders attempts to get the image from other registered providers.
 func (c *BirdImageCache) tryFallbackProviders(scientificName string, triedProviders map[string]bool) (BirdImage, bool) {
 	log := GetLogger().With(logger.String("scientific_name", scientificName))
@@ -1533,6 +1612,12 @@ func (c *BirdImageCache) tryFallbackProviders(scientificName string, triedProvid
 		log.Debug("Fallback successful", logger.String("found_provider", foundImage.SourceProvider))
 	} else {
 		log.Debug("Fallback unsuccessful, image not found in any provider")
+		// Record exhaustion on the primary cache so future Get() calls for
+		// this species short-circuit before re-running the fallback chain.
+		// The entry is keyed by species only and does not preserve which
+		// provider failed; by construction, every registered provider has
+		// been tried for this species in this invocation.
+		c.recordSpeciesExhausted(scientificName)
 	}
 	return foundImage, found
 }

--- a/internal/imageprovider/imageprovider.go
+++ b/internal/imageprovider/imageprovider.go
@@ -1192,7 +1192,13 @@ func (c *BirdImageCache) Get(scientificName string) (BirdImage, error) {
 		// the last time the chain ran to completion. Metrics are deliberately
 		// unchanged here to mirror the pre-fix behavior for the primary
 		// negative-cache path (which also did not emit a hit/miss metric).
-		if c.isSpeciesExhausted(scientificName) {
+		//
+		// IMPORTANT: only short-circuit when the primary itself returned
+		// ErrImageNotFound. Transient failures (network errors, DB errors,
+		// provider initialization errors) must NOT be silently converted
+		// into a 15-minute "not found" response — those should still try
+		// the fallback chain so a working provider can serve the request.
+		if errors.Is(err, ErrImageNotFound) && c.isSpeciesExhausted(scientificName) {
 			log.Debug("Species already exhausted by all providers, skipping fallback chain")
 			return c.synthesizeExhaustedResponse(scientificName)
 		}
@@ -1567,6 +1573,16 @@ func (c *BirdImageCache) tryFallbackProviders(scientificName string, triedProvid
 	var foundImage BirdImage
 	found := false
 
+	// Track whether every fallback failure we observed was specifically
+	// ErrImageNotFound. Only when ALL fallbacks (and the primary, by virtue
+	// of having been tried before this function is called) report
+	// "not found" do we record the species as exhausted. Transient failures
+	// (network errors, DB errors, provider init failures) must not poison
+	// the exhausted-species cache for the TTL window — they should be
+	// retried on the next Get().
+	allFallbacksNotFound := true
+	anyFallbackTried := false
+
 	// Create a local copy of triedProviders to avoid modifying the caller's map
 	localTriedProviders := make(map[string]bool, len(triedProviders))
 	for provider := range triedProviders {
@@ -1581,11 +1597,16 @@ func (c *BirdImageCache) tryFallbackProviders(scientificName string, triedProvid
 
 		log.Debug("Attempting fallback fetch from provider", logger.String("provider", name))
 		localTriedProviders[name] = true // Mark as tried
+		anyFallbackTried = true
 
 		// Instead of calling Get (which would recursively try fallbacks), use fetchAndStore directly
 		// to avoid the fallback chain and potential infinite loop
 		img, err := cache.fetchAndStore(scientificName)
 		if err != nil {
+			if !errors.Is(err, ErrImageNotFound) {
+				// Transient/real error — do NOT mark species exhausted.
+				allFallbacksNotFound = false
+			}
 			// Log error but continue trying other fallbacks
 			log.Warn("Fallback provider failed to get image",
 				logger.String("provider", name),
@@ -1617,7 +1638,20 @@ func (c *BirdImageCache) tryFallbackProviders(scientificName string, triedProvid
 		// The entry is keyed by species only and does not preserve which
 		// provider failed; by construction, every registered provider has
 		// been tried for this species in this invocation.
-		c.recordSpeciesExhausted(scientificName)
+		//
+		// CORRECTNESS GATE: only record exhaustion when at least one
+		// fallback was actually tried AND every failure was an
+		// ErrImageNotFound. The caller (Get -> tryFallbackOnGetError) only
+		// invokes this function after the primary returned
+		// ErrImageNotFound, so by construction every observed error in
+		// this run is "not found" when allFallbacksNotFound is true.
+		// Without this gate, a transient outage on a fallback (network
+		// timeout, DB error, provider init failure) would mask the
+		// species for the full TTL window, hiding real issues and
+		// suppressing legitimate retries.
+		if anyFallbackTried && allFallbacksNotFound {
+			c.recordSpeciesExhausted(scientificName)
+		}
 	}
 	return foundImage, found
 }

--- a/internal/imageprovider/imageprovider.go
+++ b/internal/imageprovider/imageprovider.go
@@ -1714,7 +1714,9 @@ func (img *BirdImage) EstimateSize() int {
 	return size
 }
 
-// MemoryUsage estimates the total memory usage of the cache map.
+// MemoryUsage estimates the total memory usage of the cache maps.
+// Includes both the per-species image data map and the exhausted-species
+// short-circuit map so cache metrics reflect the full footprint.
 func (c *BirdImageCache) MemoryUsage() int {
 	totalSize := 0
 	c.dataMap.Range(func(key, value any) bool {
@@ -1724,6 +1726,16 @@ func (c *BirdImageCache) MemoryUsage() int {
 		if img, ok := value.(*BirdImage); ok && img != nil {
 			totalSize += img.EstimateSize() // Add value size
 		}
+		return true
+	})
+	c.exhaustedSpecies.Range(func(key, value any) bool {
+		if scientificName, ok := key.(string); ok {
+			totalSize += len(scientificName)
+		}
+		// Each entry stores a time.Time (24 bytes on 64-bit). Use a constant
+		// here to avoid an unsafe.Sizeof import for one constant value.
+		const timeStructBytes = 24
+		totalSize += timeStructBytes
 		return true
 	})
 	return totalSize


### PR DESCRIPTION
## Summary

In `internal/imageprovider/imageprovider.go`, fallback negative cache entries are stored in the DB with the **fallback** provider's `ProviderName` (e.g. `wikimedia`), but `loadFromDBCache` queries by the **primary** provider's `ProviderName` (e.g. `avicommons`) when the primary is asked. The two never match.

The visible result: every ~1.5 seconds the primary provider's lookup misses, the fallback chain runs again, the fallback provider hits its own in-memory negative entry but the primary still emits `WARN Fallback provider failed to get image`, and a SQLite `image_caches` read fires for any species without images. "Siren" alone produced 132 ERROR/WARN log entries in ~6 hours.

## Approach

Add a per-`BirdImageCache` `exhaustedSpecies sync.Map` keyed by scientific name with a `time.Time` TTL stamp. After `tryFallbackProviders` returns `found=false` (every registered provider has been tried for this species), record the species as exhausted on the primary cache. In `Get()`, after the local in-memory negative-cache lookup but before kicking off the fallback chain, check `isSpeciesExhausted` and short-circuit with `synthesizeExhaustedResponse` (which returns `BirdImage{}, ErrImageNotFound` — same shape as the primary negative path, no sentinel URL).

- TTL is `const exhaustedSpeciesTTL = negativeCacheTTL` (compile-time alias to the existing 15-minute negative-cache TTL — the two layers cannot drift).
- Race-safe via `sync.Map`. Lazy expiration on read. Concurrent `Get("Siren")` calls naturally deduplicate via the existing per-species `Initializing` mutex; if both reach `recordSpeciesExhausted`, `Store` is idempotent.
- Memory bounded by the BirdNET model class count (~6000), so the worst-case footprint is well under 1MB. No periodic sweeper added — lazy expiration is sufficient and matches the existing negative-cache layer's behavior.
- Placement on `BirdImageCache` rather than `ImageProviderRegistry`: the registry has no runtime state today, and threading state through `SetRegistry` would have non-trivial blast radius. The primary cache's `Get()` is the only entry point that runs the fallback chain, so coupling the exhausted map to it is the natural fit.

## Test Plan

- [ ] `golangci-lint run -v ./internal/imageprovider/...` — 0 issues
- [ ] `go test -race -count=1 ./internal/imageprovider/...` — pass
- [ ] `go test -race -count=10 ./internal/imageprovider/...` — pass (race stress, including a 64-goroutine concurrent access test)
- [ ] New unit tests: `TestRecordSpeciesExhausted`, `TestRecordSpeciesExhaustedEmptyName`, `TestIsSpeciesExhaustedExpiresLazily`, `TestIsSpeciesExhaustedRejectsBogusType`, `TestExhaustedSpeciesCacheConcurrentAccess` (64×200 iterations), `TestSynthesizeExhaustedResponse`.
- [ ] New integration tests: `TestExhaustedSpeciesCache_RecordsAfterFallbackFails`, `TestExhaustedSpeciesCache_ShortCircuitsRepeatedCalls` (asserts zero additional `GetImageCache` and zero additional provider calls after the first miss), `TestExhaustedSpeciesCache_ConcurrentGetCalls` (32 concurrent Get calls after priming).
- [ ] Manual: deploy on a system with an active species in the no-image set ("Siren", "Human vocal", etc.) and verify the WARN spam stops, the `image_caches` SQLite reads drop to zero between TTL windows, and provider rate limits are no longer being burned on hopeless lookups.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented negative caching to track species where images are unavailable, preventing redundant fallback chain traversals within a TTL window.

* **Tests**
  * Added comprehensive unit tests validating cache entry lifecycle, TTL expiration, and error handling, plus integration tests confirming fallback optimization and race-safe concurrent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->