### PR TITLE
fix: make basepath work consistently

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,11 +4,9 @@
     <meta charset="UTF-8" />
     <title>BirdNET-Go</title>
     <!-- Preload Inter font to prevent FOUT (Flash of Unstyled Text) -->
-    <!-- Note: In production, this preload may not match the served path, but the font
-         will still load correctly via CSS. This is a minor optimization trade-off. -->
     <link
       rel="preload"
-      href="/fonts/Inter-Variable.woff2"
+      href="/ui/assets/fonts/Inter-Variable.woff2"
       as="font"
       type="font/woff2"
       crossorigin

--- a/frontend/src/styles/tailwind.css
+++ b/frontend/src/styles/tailwind.css
@@ -189,7 +189,7 @@
     font-style: normal;
     font-weight: 100 900;
     font-display: swap;
-    src: url('/fonts/Inter-Variable.woff2') format('woff2');
+    src: url('/ui/assets/fonts/Inter-Variable.woff2') format('woff2');
   }
 
   @font-face {
@@ -197,7 +197,7 @@
     font-style: italic;
     font-weight: 100 900;
     font-display: swap;
-    src: url('/fonts/Inter-Variable-Italic.woff2') format('woff2');
+    src: url('/ui/assets/fonts/Inter-Variable-Italic.woff2') format('woff2');
   }
 
   *,

--- a/internal/api/auth/middleware.go
+++ b/internal/api/auth/middleware.go
@@ -249,30 +249,49 @@ func (m *Middleware) buildLoginRedirectURL(c echo.Context, ip string) string {
 // Uses the basePath value set in Echo context by the server's basepath middleware,
 // which already handles the priority chain: X-Ingress-Path > X-Forwarded-Prefix > config BasePath.
 // Falls back to checking proxy headers directly if the context value is not set.
+//
+// Header values are trimmed of trailing slashes before the safety check so that
+// real-world values like "/ingress/token///" are accepted (and normalized) while
+// embedded dangerous sequences like "//evil" or "/../admin" still get rejected.
 func requestBasePath(c echo.Context) string {
 	// Prefer the authoritative value from the basepath context middleware.
 	if bp, ok := c.Get("basePath").(string); ok && bp != "" {
 		return bp
 	}
 	// Fallback: check proxy headers directly (for cases where context middleware hasn't run).
-	if p := c.Request().Header.Get("X-Ingress-Path"); isSafePathPrefix(p) {
-		return strings.TrimRight(p, "/")
+	if p := strings.TrimRight(c.Request().Header.Get("X-Ingress-Path"), "/"); isSafePathPrefix(p) {
+		return p
 	}
-	if p := c.Request().Header.Get("X-Forwarded-Prefix"); isSafePathPrefix(p) {
-		return strings.TrimRight(p, "/")
+	if p := strings.TrimRight(c.Request().Header.Get("X-Forwarded-Prefix"), "/"); isSafePathPrefix(p) {
+		return p
 	}
 	return ""
 }
 
-// isSafePathPrefix validates that a path prefix is safe for use in redirects.
-// Rejects empty strings, protocol-relative URLs (//...), absolute URLs (://...),
-// and backslashes (browsers normalize "/\" to "//" producing protocol-relative URLs).
+// isSafePathPrefix validates that a path prefix (typically from a proxy header)
+// is safe for use in redirects. Must stay in sync with the copy in
+// internal/api/server.go. Rules align with validateBasePath() in
+// internal/conf/validate.go so header-supplied and YAML-configured basepaths
+// share the same rejection rules.
+//
+// Rejects:
+//   - empty strings
+//   - values not starting with "/"
+//   - protocol-relative URLs ("//...") and embedded "//" sequences
+//   - absolute URLs ("://")
+//   - backslashes ("/\..." normalizes to "//" in browsers)
+//   - path traversal ("..")
+//   - CR/LF/NUL injection
 func isSafePathPrefix(p string) bool {
-	return p != "" &&
-		strings.HasPrefix(p, "/") &&
-		!strings.HasPrefix(p, "//") &&
-		!strings.Contains(p, "://") &&
-		!strings.Contains(p, "\\")
+	if p == "" || !strings.HasPrefix(p, "/") {
+		return false
+	}
+	for _, bad := range []string{"//", "\\", "://", "..", "\n", "\r", "\x00"} {
+		if strings.Contains(p, bad) {
+			return false
+		}
+	}
+	return true
 }
 
 // getSafeRedirectPath validates and returns a safe redirect path.

--- a/internal/api/auth/middleware.go
+++ b/internal/api/auth/middleware.go
@@ -230,7 +230,8 @@ func (m *Middleware) redirectToLogin(c echo.Context, path, ip string) error {
 }
 
 // buildLoginRedirectURL constructs the login URL with a safe redirect parameter.
-// Supports reverse proxy prefixes via X-Ingress-Path / X-Forwarded-Prefix headers.
+// Supports reverse proxy prefixes via X-Ingress-Path / X-Forwarded-Prefix headers
+// and direct access with configured BasePath (via context set by basepath middleware).
 func (m *Middleware) buildLoginRedirectURL(c echo.Context, ip string) string {
 	const loginPath = "/login"
 
@@ -244,11 +245,16 @@ func (m *Middleware) buildLoginRedirectURL(c echo.Context, ip string) string {
 	return basePath + loginPath + "?redirect=" + url.QueryEscape(safeRedirectPath)
 }
 
-// requestBasePath returns the reverse proxy base path from request headers.
-// Priority: X-Ingress-Path > X-Forwarded-Prefix > empty.
-// Note: Unlike the version in api/v2/app.go, this does not fall back to config
-// BasePath because the auth context requires matching the actual request prefix.
+// requestBasePath returns the effective base path for the current request.
+// Uses the basePath value set in Echo context by the server's basepath middleware,
+// which already handles the priority chain: X-Ingress-Path > X-Forwarded-Prefix > config BasePath.
+// Falls back to checking proxy headers directly if the context value is not set.
 func requestBasePath(c echo.Context) string {
+	// Prefer the authoritative value from the basepath context middleware.
+	if bp, ok := c.Get("basePath").(string); ok && bp != "" {
+		return bp
+	}
+	// Fallback: check proxy headers directly (for cases where context middleware hasn't run).
 	if p := c.Request().Header.Get("X-Ingress-Path"); isSafePathPrefix(p) {
 		return strings.TrimRight(p, "/")
 	}

--- a/internal/api/auth/middleware.go
+++ b/internal/api/auth/middleware.go
@@ -265,9 +265,14 @@ func requestBasePath(c echo.Context) string {
 }
 
 // isSafePathPrefix validates that a path prefix is safe for use in redirects.
-// Rejects empty strings, protocol-relative URLs (//...), and absolute URLs (://...).
+// Rejects empty strings, protocol-relative URLs (//...), absolute URLs (://...),
+// and backslashes (browsers normalize "/\" to "//" producing protocol-relative URLs).
 func isSafePathPrefix(p string) bool {
-	return p != "" && strings.HasPrefix(p, "/") && !strings.HasPrefix(p, "//") && !strings.Contains(p, "://")
+	return p != "" &&
+		strings.HasPrefix(p, "/") &&
+		!strings.HasPrefix(p, "//") &&
+		!strings.Contains(p, "://") &&
+		!strings.Contains(p, "\\")
 }
 
 // getSafeRedirectPath validates and returns a safe redirect path.

--- a/internal/api/basepath_test.go
+++ b/internal/api/basepath_test.go
@@ -283,6 +283,7 @@ func TestBasePathContextMiddleware(t *testing.T) {
 
 	tests := []struct {
 		name             string
+		xIngressPath     string
 		xForwardedPrefix string
 		expectedBasePath string
 	}{
@@ -290,6 +291,39 @@ func TestBasePathContextMiddleware(t *testing.T) {
 			name:             "sets basePath from X-Forwarded-Prefix",
 			xForwardedPrefix: "/birdnet",
 			expectedBasePath: "/birdnet",
+		},
+		{
+			name:             "sets basePath from X-Ingress-Path",
+			xIngressPath:     "/api/hassio_ingress/TOKEN",
+			expectedBasePath: "/api/hassio_ingress/TOKEN",
+		},
+		{
+			name:             "X-Ingress-Path wins over X-Forwarded-Prefix",
+			xIngressPath:     "/api/hassio_ingress/TOKEN",
+			xForwardedPrefix: "/birdnet",
+			expectedBasePath: "/api/hassio_ingress/TOKEN",
+		},
+		{
+			name:             "rejects protocol-relative X-Forwarded-Prefix",
+			xForwardedPrefix: "//evil.example",
+			expectedBasePath: "",
+		},
+		{
+			name:             "rejects backslash-prefixed X-Forwarded-Prefix",
+			xForwardedPrefix: `/\evil.example`,
+			expectedBasePath: "",
+		},
+		{
+			// X-Ingress-Path is the higher-priority header (Home Assistant uses it), so
+			// guard it against the same backslash → protocol-relative URL trick.
+			name:             "rejects backslash-prefixed X-Ingress-Path",
+			xIngressPath:     `/\evil.example`,
+			expectedBasePath: "",
+		},
+		{
+			name:             "rejects scheme-embedded X-Forwarded-Prefix",
+			xForwardedPrefix: "/http://evil",
+			expectedBasePath: "",
 		},
 		{
 			name:             "empty basePath when no headers",
@@ -318,6 +352,9 @@ func TestBasePathContextMiddleware(t *testing.T) {
 			})
 
 			req := httptest.NewRequest(http.MethodGet, "/test", http.NoBody)
+			if tt.xIngressPath != "" {
+				req.Header.Set("X-Ingress-Path", tt.xIngressPath)
+			}
 			if tt.xForwardedPrefix != "" {
 				req.Header.Set("X-Forwarded-Prefix", tt.xForwardedPrefix)
 			}
@@ -327,6 +364,38 @@ func TestBasePathContextMiddleware(t *testing.T) {
 
 			require.Equal(t, http.StatusOK, rec.Code)
 			assert.Equal(t, tt.expectedBasePath, capturedBasePath)
+		})
+	}
+}
+
+// TestIsSafePathPrefix verifies the guard used by ingressPath/requestBasePath
+// for proxy-supplied path prefixes. This prevents header-driven open redirect
+// / DOM XSS when the rewritten value ends up as a URL prefix in HTML/JS.
+func TestIsSafePathPrefix(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{"empty is unsafe", "", false},
+		{"simple prefix is safe", "/birdnet", true},
+		{"multi-segment is safe", "/apps/birdnet", true},
+		{"hassio ingress prefix is safe", "/api/hassio_ingress/TOKEN", true},
+		{"trailing slash is safe", "/birdnet/", true},
+		{"no leading slash is unsafe", "birdnet", false},
+		{"protocol-relative // is unsafe", "//evil.example", false},
+		{"backslash is unsafe", `/\evil.example`, false},
+		{"backslash midpath is unsafe", `/birdnet\foo`, false},
+		{"scheme :// is unsafe", "/http://evil", false},
+		{"naked scheme prefix is unsafe", "https://evil", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, isSafePathPrefix(tt.input))
 		})
 	}
 }

--- a/internal/api/basepath_test.go
+++ b/internal/api/basepath_test.go
@@ -95,6 +95,7 @@ func TestBasePathStripMiddleware(t *testing.T) {
 
 			bp := tt.basePath
 			var capturedPath string
+			var capturedQuery string
 
 			e := echo.New()
 
@@ -102,7 +103,8 @@ func TestBasePathStripMiddleware(t *testing.T) {
 			e.Pre(func(next echo.HandlerFunc) echo.HandlerFunc {
 				return func(c echo.Context) error {
 					req := c.Request()
-					if req.Header.Get("X-Ingress-Path") != "" || req.Header.Get("X-Forwarded-Prefix") != "" {
+					hasProxyHeader := req.Header.Get("X-Ingress-Path") != "" || req.Header.Get("X-Forwarded-Prefix") != ""
+					if hasProxyHeader && !strings.HasPrefix(req.URL.Path, bp+"/") && req.URL.Path != bp {
 						return next(c)
 					}
 					path := req.URL.Path
@@ -122,6 +124,7 @@ func TestBasePathStripMiddleware(t *testing.T) {
 			// Catch-all handler to capture the routed path
 			e.Any("/*", func(c echo.Context) error {
 				capturedPath = c.Request().URL.Path
+				capturedQuery = c.Request().URL.RawQuery
 				return c.NoContent(http.StatusOK)
 			})
 
@@ -134,6 +137,9 @@ func TestBasePathStripMiddleware(t *testing.T) {
 			e.ServeHTTP(rec, req)
 
 			assert.Equal(t, tt.expectedPath, capturedPath, "path after stripping")
+			if strings.Contains(tt.requestPath, "?") {
+				assert.NotEmpty(t, capturedQuery, "query string should be preserved")
+			}
 		})
 	}
 }

--- a/internal/api/basepath_test.go
+++ b/internal/api/basepath_test.go
@@ -14,6 +14,37 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// stripMiddlewareForTest mirrors the production Pre middleware in setupMiddleware().
+// Kept in sync by hand. We can't easily instantiate a full Server in this package-level
+// unit test, so the stripping logic is duplicated here and exercised with the same
+// table-driven assertions production would see.
+func stripMiddlewareForTest(getBP func() string) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			bp := strings.TrimRight(getBP(), "/")
+			if bp == "" {
+				return next(c)
+			}
+			req := c.Request()
+			hasProxyHeader := req.Header.Get("X-Ingress-Path") != "" || req.Header.Get("X-Forwarded-Prefix") != ""
+			if hasProxyHeader && !strings.HasPrefix(req.URL.Path, bp+"/") && req.URL.Path != bp {
+				return next(c)
+			}
+			path := req.URL.Path
+			if strings.HasPrefix(path, bp) {
+				rest := path[len(bp):]
+				if rest == "" || rest[0] == '/' {
+					if rest == "" {
+						rest = "/"
+					}
+					req.URL.Path = rest
+				}
+			}
+			return next(c)
+		}
+	}
+}
+
 // TestBasePathStripMiddleware tests the Pre middleware that strips the configured
 // basepath prefix from incoming request URLs for direct access (no proxy).
 func TestBasePathStripMiddleware(t *testing.T) {
@@ -99,27 +130,8 @@ func TestBasePathStripMiddleware(t *testing.T) {
 
 			e := echo.New()
 
-			// Register the stripping middleware using the same logic as setupMiddleware
-			e.Pre(func(next echo.HandlerFunc) echo.HandlerFunc {
-				return func(c echo.Context) error {
-					req := c.Request()
-					hasProxyHeader := req.Header.Get("X-Ingress-Path") != "" || req.Header.Get("X-Forwarded-Prefix") != ""
-					if hasProxyHeader && !strings.HasPrefix(req.URL.Path, bp+"/") && req.URL.Path != bp {
-						return next(c)
-					}
-					path := req.URL.Path
-					if strings.HasPrefix(path, bp) {
-						rest := path[len(bp):]
-						if rest == "" || rest[0] == '/' {
-							if rest == "" {
-								rest = "/"
-							}
-							req.URL.Path = rest
-						}
-					}
-					return next(c)
-				}
-			})
+			// Exercise the strip middleware via the shared test helper that mirrors production.
+			e.Pre(stripMiddlewareForTest(func() string { return bp }))
 
 			// Catch-all handler to capture the routed path
 			e.Any("/*", func(c echo.Context) error {
@@ -386,10 +398,17 @@ func TestIsSafePathPrefix(t *testing.T) {
 		{"trailing slash is safe", "/birdnet/", true},
 		{"no leading slash is unsafe", "birdnet", false},
 		{"protocol-relative // is unsafe", "//evil.example", false},
+		{"embedded // is unsafe", "/birdnet//foo", false},
 		{"backslash is unsafe", `/\evil.example`, false},
 		{"backslash midpath is unsafe", `/birdnet\foo`, false},
 		{"scheme :// is unsafe", "/http://evil", false},
 		{"naked scheme prefix is unsafe", "https://evil", false},
+		{"path traversal leading is unsafe", "/../admin", false},
+		{"path traversal midpath is unsafe", "/birdnet/../admin", false},
+		{"lone dotdot segment is unsafe", "/..", false},
+		{"newline injection is unsafe", "/birdnet\nX-Injected: 1", false},
+		{"carriage return injection is unsafe", "/birdnet\rX-Injected: 1", false},
+		{"null byte is unsafe", "/birdnet\x00/evil", false},
 	}
 
 	for _, tt := range tests {
@@ -398,6 +417,60 @@ func TestIsSafePathPrefix(t *testing.T) {
 			assert.Equal(t, tt.want, isSafePathPrefix(tt.input))
 		})
 	}
+}
+
+// TestBasePathStripMiddleware_HotReload verifies that the strip middleware reads
+// the current basepath on every request rather than capturing it at setup time.
+// Regression guard: previously the middleware was registered conditionally and
+// captured bp in a closure, so changes to settings.WebServer.BasePath required
+// a server restart to take effect.
+func TestBasePathStripMiddleware_HotReload(t *testing.T) {
+	t.Parallel()
+
+	// Mutable basepath source, simulating settings.WebServer.BasePath being
+	// updated at runtime. Access is serialized through the test — no goroutines.
+	var currentBP string
+
+	e := echo.New()
+	e.Pre(stripMiddlewareForTest(func() string { return currentBP }))
+
+	var capturedPath string
+	e.Any("/*", func(c echo.Context) error {
+		capturedPath = c.Request().URL.Path
+		return c.NoContent(http.StatusOK)
+	})
+
+	do := func(path string) string {
+		req := httptest.NewRequest(http.MethodGet, path, http.NoBody)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+		require.Equal(t, http.StatusOK, rec.Code)
+		return capturedPath
+	}
+
+	// 1. No basepath configured: requests pass through untouched.
+	assert.Equal(t, "/ui/dashboard", do("/ui/dashboard"), "no basepath should pass through")
+	assert.Equal(t, "/birdnet/ui/dashboard", do("/birdnet/ui/dashboard"),
+		"no basepath should not strip anything")
+
+	// 2. Basepath set to /birdnet at runtime — middleware must pick it up immediately.
+	currentBP = "/birdnet"
+	assert.Equal(t, "/ui/dashboard", do("/birdnet/ui/dashboard"),
+		"strip should activate without restart after basepath is set")
+	assert.Equal(t, "/other", do("/other"),
+		"non-prefixed paths should still pass through unchanged")
+
+	// 3. Basepath changed to a different value at runtime.
+	currentBP = "/apps/birdnet"
+	assert.Equal(t, "/ui/dashboard", do("/apps/birdnet/ui/dashboard"),
+		"strip should follow runtime basepath changes")
+	assert.Equal(t, "/birdnet/ui/dashboard", do("/birdnet/ui/dashboard"),
+		"old basepath must no longer strip after change")
+
+	// 4. Basepath cleared — strip must disable again without restart.
+	currentBP = ""
+	assert.Equal(t, "/apps/birdnet/ui/dashboard", do("/apps/birdnet/ui/dashboard"),
+		"clearing basepath should restore pass-through behavior")
 }
 
 // TestIsRewritableAsset tests the file extension check for CSS/JS rewriting.

--- a/internal/api/basepath_test.go
+++ b/internal/api/basepath_test.go
@@ -1,0 +1,351 @@
+// basepath_test.go: Tests for base path support — prefix stripping middleware,
+// HTML asset URL rewriting, and manifest path rewriting.
+
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBasePathStripMiddleware tests the Pre middleware that strips the configured
+// basepath prefix from incoming request URLs for direct access (no proxy).
+func TestBasePathStripMiddleware(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		basePath         string
+		requestPath      string
+		xForwardedPrefix string // if set, middleware should skip stripping
+		expectedPath     string
+	}{
+		{
+			name:         "strips basepath prefix",
+			basePath:     "/birdnet",
+			requestPath:  "/birdnet/ui/dashboard",
+			expectedPath: "/ui/dashboard",
+		},
+		{
+			name:         "strips basepath from root",
+			basePath:     "/birdnet",
+			requestPath:  "/birdnet",
+			expectedPath: "/",
+		},
+		{
+			name:         "strips basepath with trailing slash",
+			basePath:     "/birdnet",
+			requestPath:  "/birdnet/",
+			expectedPath: "/",
+		},
+		{
+			name:         "passes through non-prefixed path",
+			basePath:     "/birdnet",
+			requestPath:  "/ui/dashboard",
+			expectedPath: "/ui/dashboard",
+		},
+		{
+			name:         "passes through root path",
+			basePath:     "/birdnet",
+			requestPath:  "/",
+			expectedPath: "/",
+		},
+		{
+			name:         "passes through API path",
+			basePath:     "/birdnet",
+			requestPath:  "/api/v2/health",
+			expectedPath: "/api/v2/health",
+		},
+		{
+			name:         "does not strip partial prefix match",
+			basePath:     "/bird",
+			requestPath:  "/birdnet/ui/dashboard",
+			expectedPath: "/birdnet/ui/dashboard",
+		},
+		{
+			name:             "skips stripping when X-Forwarded-Prefix header present",
+			basePath:         "/birdnet",
+			requestPath:      "/ui/dashboard",
+			xForwardedPrefix: "/birdnet",
+			expectedPath:     "/ui/dashboard",
+		},
+		{
+			name:         "multi-segment basepath",
+			basePath:     "/apps/birdnet",
+			requestPath:  "/apps/birdnet/ui/dashboard",
+			expectedPath: "/ui/dashboard",
+		},
+		{
+			name:         "preserves query string through stripping",
+			basePath:     "/birdnet",
+			requestPath:  "/birdnet/ui/dashboard?tab=detections",
+			expectedPath: "/ui/dashboard",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			bp := tt.basePath
+			var capturedPath string
+
+			e := echo.New()
+
+			// Register the stripping middleware using the same logic as setupMiddleware
+			e.Pre(func(next echo.HandlerFunc) echo.HandlerFunc {
+				return func(c echo.Context) error {
+					req := c.Request()
+					if req.Header.Get("X-Ingress-Path") != "" || req.Header.Get("X-Forwarded-Prefix") != "" {
+						return next(c)
+					}
+					path := req.URL.Path
+					if strings.HasPrefix(path, bp) {
+						rest := path[len(bp):]
+						if rest == "" || rest[0] == '/' {
+							if rest == "" {
+								rest = "/"
+							}
+							req.URL.Path = rest
+						}
+					}
+					return next(c)
+				}
+			})
+
+			// Catch-all handler to capture the routed path
+			e.Any("/*", func(c echo.Context) error {
+				capturedPath = c.Request().URL.Path
+				return c.NoContent(http.StatusOK)
+			})
+
+			req := httptest.NewRequest(http.MethodGet, tt.requestPath, http.NoBody)
+			if tt.xForwardedPrefix != "" {
+				req.Header.Set("X-Forwarded-Prefix", tt.xForwardedPrefix)
+			}
+			rec := httptest.NewRecorder()
+
+			e.ServeHTTP(rec, req)
+
+			assert.Equal(t, tt.expectedPath, capturedPath, "path after stripping")
+		})
+	}
+}
+
+// TestRewriteHTMLBasePath tests the HTML content rewriting for base path support.
+func TestRewriteHTMLBasePath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		basePath string
+		expected string
+	}{
+		{
+			name:     "no rewriting when basePath is empty",
+			input:    `<link href="/ui/assets/main.css">`,
+			basePath: "",
+			expected: `<link href="/ui/assets/main.css">`,
+		},
+		{
+			name:     "rewrites href attributes",
+			input:    `<link href="/ui/assets/main-abc.css" rel="stylesheet">`,
+			basePath: "/birdnet",
+			expected: `<link href="/birdnet/ui/assets/main-abc.css" rel="stylesheet">`,
+		},
+		{
+			name:     "rewrites src attributes",
+			input:    `<script type="module" src="/ui/assets/main-abc.js"></script>`,
+			basePath: "/birdnet",
+			expected: `<script type="module" src="/birdnet/ui/assets/main-abc.js"></script>`,
+		},
+		{
+			name:     "rewrites service worker registration",
+			input:    `navigator.serviceWorker.register('/sw.js', { scope: '/' })`,
+			basePath: "/birdnet",
+			expected: `navigator.serviceWorker.register('/birdnet/sw.js', { scope: '/birdnet/' })`,
+		},
+		{
+			name:     "rewrites multiple attributes in full HTML",
+			input:    `<link href="/ui/assets/fonts/Inter.woff2" as="font"><script src="/ui/assets/main.js"></script>`,
+			basePath: "/proxy",
+			expected: `<link href="/proxy/ui/assets/fonts/Inter.woff2" as="font"><script src="/proxy/ui/assets/main.js"></script>`,
+		},
+		{
+			name:     "rewrites favicon and manifest paths",
+			input:    `<link rel="icon" href="/favicon.ico"><link rel="manifest" href="/manifest.webmanifest">`,
+			basePath: "/birdnet",
+			expected: `<link rel="icon" href="/birdnet/favicon.ico"><link rel="manifest" href="/birdnet/manifest.webmanifest">`,
+		},
+		{
+			name:     "multi-segment basepath",
+			input:    `<script src="/ui/assets/main.js"></script>`,
+			basePath: "/apps/birdnet",
+			expected: `<script src="/apps/birdnet/ui/assets/main.js"></script>`,
+		},
+		{
+			name:     "idempotent: already-prefixed paths are not double-prefixed",
+			input:    `<link href="/birdnet/ui/assets/main.css"><script src="/birdnet/ui/assets/main.js"></script>`,
+			basePath: "/birdnet",
+			expected: `<link href="/birdnet/ui/assets/main.css"><script src="/birdnet/ui/assets/main.js"></script>`,
+		},
+		{
+			name:     "idempotent: mixed prefixed and unprefixed",
+			input:    `<link href="/birdnet/ui/assets/main.css"><link href="/favicon.ico">`,
+			basePath: "/birdnet",
+			expected: `<link href="/birdnet/ui/assets/main.css"><link href="/birdnet/favicon.ico">`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := rewriteHTMLBasePath([]byte(tt.input), tt.basePath)
+			assert.Equal(t, tt.expected, string(result))
+		})
+	}
+}
+
+// TestRewriteManifestBasePath tests the manifest.webmanifest rewriting.
+func TestRewriteManifestBasePath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		basePath string
+		expected string
+	}{
+		{
+			name:     "rewrites icon src paths",
+			input:    `{"icons":[{"src":"/ui/assets/icon.png"}]}`,
+			basePath: "/birdnet",
+			expected: `{"icons":[{"src":"/birdnet/ui/assets/icon.png"}]}`,
+		},
+		{
+			name:     "rewrites start_url and scope",
+			input:    `{"start_url":"../../","scope":"../../"}`,
+			basePath: "/birdnet",
+			expected: `{"start_url":"/birdnet/","scope":"/birdnet/"}`,
+		},
+		{
+			name: "rewrites full manifest",
+			input: `{
+  "name": "BirdNET-Go",
+  "start_url": "../../",
+  "scope": "../../",
+  "icons": [
+    {"src": "/ui/assets/apple-touch-icon.png"},
+    {"src": "/ui/assets/BirdNET-Go-logo.webp"}
+  ]
+}`,
+			basePath: "/birdnet",
+			expected: `{
+  "name": "BirdNET-Go",
+  "start_url": "/birdnet/",
+  "scope": "/birdnet/",
+  "icons": [
+    {"src": "/birdnet/ui/assets/apple-touch-icon.png"},
+    {"src": "/birdnet/ui/assets/BirdNET-Go-logo.webp"}
+  ]
+}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := rewriteManifestBasePath([]byte(tt.input), tt.basePath)
+			assert.Equal(t, tt.expected, string(result))
+		})
+	}
+}
+
+// TestBasePathContextMiddleware tests that the basePath context middleware
+// correctly sets the basePath value from ingressPath().
+func TestBasePathContextMiddleware(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		xForwardedPrefix string
+		expectedBasePath string
+	}{
+		{
+			name:             "sets basePath from X-Forwarded-Prefix",
+			xForwardedPrefix: "/birdnet",
+			expectedBasePath: "/birdnet",
+		},
+		{
+			name:             "empty basePath when no headers",
+			expectedBasePath: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			e := echo.New()
+			var capturedBasePath string
+
+			// Simulate the context middleware
+			e.Use(func(next echo.HandlerFunc) echo.HandlerFunc {
+				return func(c echo.Context) error {
+					c.Set("basePath", ingressPath(c, nil))
+					return next(c)
+				}
+			})
+
+			e.GET("/test", func(c echo.Context) error {
+				capturedBasePath, _ = c.Get("basePath").(string)
+				return c.NoContent(http.StatusOK)
+			})
+
+			req := httptest.NewRequest(http.MethodGet, "/test", http.NoBody)
+			if tt.xForwardedPrefix != "" {
+				req.Header.Set("X-Forwarded-Prefix", tt.xForwardedPrefix)
+			}
+			rec := httptest.NewRecorder()
+
+			e.ServeHTTP(rec, req)
+
+			require.Equal(t, http.StatusOK, rec.Code)
+			assert.Equal(t, tt.expectedBasePath, capturedBasePath)
+		})
+	}
+}
+
+// TestIsRewritableAsset tests the file extension check for CSS/JS rewriting.
+func TestIsRewritableAsset(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		path     string
+		expected bool
+	}{
+		{"main-abc123.css", true},
+		{"main-abc123.js", true},
+		{"chunk-abc123.mjs", true},
+		{"Inter-Variable.woff2", false},
+		{"logo.png", false},
+		{"data.json", false},
+		{"index.html", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expected, isRewritableAsset(tt.path))
+		})
+	}
+}

--- a/internal/api/pwa.go
+++ b/internal/api/pwa.go
@@ -1,23 +1,109 @@
 package api
 
 import (
+	"io"
+	"net/http"
+	"os"
+	"strings"
+
 	"github.com/labstack/echo/v4"
+	"github.com/tphakala/birdnet-go/frontend"
+	"github.com/tphakala/birdnet-go/internal/logger"
 )
 
 // registerPWARoutes registers routes for PWA support files.
 // The manifest and service worker must be served from root paths
 // so the service worker scope covers the entire application.
 func (s *Server) registerPWARoutes() {
-	// Serve manifest.webmanifest from root path
+	// Serve manifest.webmanifest from root path, with base path rewriting.
 	s.echo.GET("/manifest.webmanifest", func(c echo.Context) error {
-		return s.staticServer.handlePWAFile(c, "manifest.webmanifest")
+		basePath, _ := c.Get("basePath").(string)
+		return s.staticServer.serveManifest(c, basePath)
 	})
 
-	// Serve service worker from root path with Service-Worker-Allowed header
+	// Serve service worker from root path with Service-Worker-Allowed header.
 	s.echo.GET("/sw.js", func(c echo.Context) error {
-		c.Response().Header().Set("Service-Worker-Allowed", "/")
+		basePath, _ := c.Get("basePath").(string)
+		scope := "/"
+		if basePath != "" {
+			scope = basePath + "/"
+		}
+		c.Response().Header().Set("Service-Worker-Allowed", scope)
 		return s.staticServer.handlePWAFile(c, "sw.js")
 	})
+}
+
+// serveManifest serves manifest.webmanifest, rewriting paths when a base path is active.
+func (sfs *StaticFileServer) serveManifest(c echo.Context, basePath string) error {
+	sfs.initDevMode()
+
+	var content []byte
+	var err error
+
+	if sfs.devMode {
+		content, err = sfs.readPWAFromDisk("manifest.webmanifest")
+	} else {
+		content, err = sfs.readPWAFromEmbed("manifest.webmanifest")
+	}
+	if err != nil {
+		return err
+	}
+
+	// Rewrite absolute paths in the manifest JSON when base path is set.
+	if basePath != "" {
+		content = rewriteManifestBasePath(content, basePath)
+	}
+
+	c.Response().Header().Set("Content-Type", "application/manifest+json; charset=utf-8")
+	c.Response().Header().Set("Cache-Control", "no-cache")
+	return c.Blob(http.StatusOK, "application/manifest+json; charset=utf-8", content)
+}
+
+// rewriteManifestBasePath prefixes absolute paths in the manifest JSON
+// and updates start_url/scope to point to the base path root.
+func rewriteManifestBasePath(content []byte, basePath string) []byte {
+	s := string(content)
+	// Prefix absolute icon src paths: "/ui/assets/..." → "{basePath}/ui/assets/..."
+	s = strings.ReplaceAll(s, `"/ui/assets/`, `"`+basePath+`/ui/assets/`)
+	// Rewrite start_url and scope to base path root.
+	// The manifest uses relative "../../" which doesn't work behind a proxy.
+	s = strings.ReplaceAll(s, `"../../"`, `"`+basePath+`/"`)
+	return []byte(s)
+}
+
+// readPWAFromDisk reads a PWA file from the dev mode dist directory.
+func (sfs *StaticFileServer) readPWAFromDisk(filename string) ([]byte, error) {
+	root, err := os.OpenRoot(sfs.devModePath)
+	if err != nil {
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Failed to open dist directory")
+	}
+	defer sfs.closeWithLog(root, "root handle")
+
+	file, err := root.Open(filename)
+	if err != nil {
+		return nil, echo.NewHTTPError(http.StatusNotFound, "File not found")
+	}
+	defer sfs.closeFileWithLog(file, filename)
+
+	return io.ReadAll(file)
+}
+
+// readPWAFromEmbed reads a PWA file from the embedded filesystem.
+func (sfs *StaticFileServer) readPWAFromEmbed(filename string) ([]byte, error) {
+	log := GetLogger()
+	file, err := frontend.DistFS.Open(filename)
+	if err != nil {
+		return nil, echo.NewHTTPError(http.StatusNotFound, "File not found")
+	}
+	defer func() {
+		if closeErr := file.Close(); closeErr != nil {
+			log.Warn("Error closing embedded file",
+				logger.String("path", filename),
+				logger.Error(closeErr))
+		}
+	}()
+
+	return io.ReadAll(file)
 }
 
 // handlePWAFile serves a PWA file from the static file server (dev or embedded).

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -260,8 +260,56 @@ func (s *Server) setupMiddleware() {
 	// Go's net/http automatically suppresses the response body for HEAD.
 	s.echo.Pre(mw.NewHeadToGet())
 
+	// Base path prefix stripping — enables direct access when basepath is configured.
+	// When settings.WebServer.BasePath is "/birdnet", a request to /birdnet/ui/dashboard
+	// gets stripped to /ui/dashboard so existing route handlers match.
+	// Skipped when reverse proxy headers are present (the proxy already stripped it).
+	if bp := strings.TrimRight(s.settings.WebServer.BasePath, "/"); bp != "" {
+		s.echo.Pre(func(next echo.HandlerFunc) echo.HandlerFunc {
+			return func(c echo.Context) error {
+				// Skip stripping when a reverse proxy header is present —
+				// the proxy already removed the prefix before forwarding.
+				req := c.Request()
+				if req.Header.Get("X-Ingress-Path") != "" || req.Header.Get("X-Forwarded-Prefix") != "" {
+					return next(c)
+				}
+
+				path := req.URL.Path
+				if strings.HasPrefix(path, bp) {
+					rest := path[len(bp):]
+					if rest == "" || rest[0] == '/' {
+						if rest == "" {
+							rest = "/"
+						}
+						req.URL.Path = rest
+						// Also update RawPath if set (percent-encoded paths).
+						if req.URL.RawPath != "" && strings.HasPrefix(req.URL.RawPath, bp) {
+							raw := req.URL.RawPath[len(bp):]
+							if raw == "" {
+								raw = "/"
+							}
+							req.URL.RawPath = raw
+						}
+					}
+				}
+				return next(c)
+			}
+		})
+		s.slogger.Info("Base path prefix stripping enabled", logger.String("basePath", bp))
+	}
+
 	// Recovery middleware - should be first
 	s.echo.Use(echomw.Recover())
+
+	// Base path context — makes the effective base path available to all handlers
+	// via c.Get("basePath"). Computed per-request from ingressPath() which checks
+	// proxy headers and config in priority order.
+	s.echo.Use(func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			c.Set("basePath", ingressPath(c, s.settings))
+			return next(c)
+		}
+	})
 
 	// Request logging using custom middleware package (uses centralized logger)
 	s.echo.Use(mw.NewRequestLogger())

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -267,10 +267,13 @@ func (s *Server) setupMiddleware() {
 	if bp := strings.TrimRight(s.settings.WebServer.BasePath, "/"); bp != "" {
 		s.echo.Pre(func(next echo.HandlerFunc) echo.HandlerFunc {
 			return func(c echo.Context) error {
-				// Skip stripping when a reverse proxy header is present —
-				// the proxy already removed the prefix before forwarding.
+				// When a reverse proxy header is present, the proxy usually already
+				// stripped the prefix before forwarding. But only skip our stripping
+				// if the path does NOT start with the basepath — a client could send
+				// the header without an actual proxy, leaving the prefix intact.
 				req := c.Request()
-				if req.Header.Get("X-Ingress-Path") != "" || req.Header.Get("X-Forwarded-Prefix") != "" {
+				hasProxyHeader := req.Header.Get("X-Ingress-Path") != "" || req.Header.Get("X-Forwarded-Prefix") != ""
+				if hasProxyHeader && !strings.HasPrefix(req.URL.Path, bp+"/") && req.URL.Path != bp {
 					return next(c)
 				}
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -100,9 +100,14 @@ func ingressPath(c echo.Context, settings *conf.Settings) string {
 }
 
 // isSafePathPrefix validates that a path prefix is safe for use in redirects.
-// Rejects empty strings, protocol-relative URLs (//...), and absolute URLs (://...).
+// Rejects empty strings, protocol-relative URLs (//...), absolute URLs (://...),
+// and backslashes (browsers normalize "/\" to "//" producing protocol-relative URLs).
 func isSafePathPrefix(p string) bool {
-	return p != "" && strings.HasPrefix(p, "/") && !strings.HasPrefix(p, "//") && !strings.Contains(p, "://")
+	return p != "" &&
+		strings.HasPrefix(p, "/") &&
+		!strings.HasPrefix(p, "//") &&
+		!strings.Contains(p, "://") &&
+		!strings.Contains(p, "\\")
 }
 
 // ServerOption is a functional option for configuring the Server.

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -86,12 +86,16 @@ type Server struct {
 
 // ingressPath returns the effective base path prefix for the current request.
 // Priority: X-Ingress-Path header > X-Forwarded-Prefix header > config BasePath > empty.
+//
+// Header values are trimmed of trailing slashes before the safety check so that
+// real-world values like "/ingress/token///" are accepted (and normalized) while
+// embedded dangerous sequences like "//evil" or "/../admin" still get rejected.
 func ingressPath(c echo.Context, settings *conf.Settings) string {
-	if p := c.Request().Header.Get("X-Ingress-Path"); isSafePathPrefix(p) {
-		return strings.TrimRight(p, "/")
+	if p := strings.TrimRight(c.Request().Header.Get("X-Ingress-Path"), "/"); isSafePathPrefix(p) {
+		return p
 	}
-	if p := c.Request().Header.Get("X-Forwarded-Prefix"); isSafePathPrefix(p) {
-		return strings.TrimRight(p, "/")
+	if p := strings.TrimRight(c.Request().Header.Get("X-Forwarded-Prefix"), "/"); isSafePathPrefix(p) {
+		return p
 	}
 	if settings != nil && settings.WebServer.BasePath != "" {
 		return strings.TrimRight(settings.WebServer.BasePath, "/")
@@ -99,15 +103,29 @@ func ingressPath(c echo.Context, settings *conf.Settings) string {
 	return ""
 }
 
-// isSafePathPrefix validates that a path prefix is safe for use in redirects.
-// Rejects empty strings, protocol-relative URLs (//...), absolute URLs (://...),
-// and backslashes (browsers normalize "/\" to "//" producing protocol-relative URLs).
+// isSafePathPrefix validates that a path prefix (typically from a proxy header)
+// is safe for use in redirects and HTML asset rewriting. Rules align with
+// validateBasePath() in internal/conf/validate.go so that header-supplied and
+// YAML-configured basepaths share the same rejection rules.
+//
+// Rejects:
+//   - empty strings
+//   - values not starting with "/"
+//   - protocol-relative URLs ("//...") and embedded "//" sequences
+//   - absolute URLs ("://")
+//   - backslashes ("/\..." normalizes to "//" in browsers)
+//   - path traversal ("..")
+//   - CR/LF/NUL injection
 func isSafePathPrefix(p string) bool {
-	return p != "" &&
-		strings.HasPrefix(p, "/") &&
-		!strings.HasPrefix(p, "//") &&
-		!strings.Contains(p, "://") &&
-		!strings.Contains(p, "\\")
+	if p == "" || !strings.HasPrefix(p, "/") {
+		return false
+	}
+	for _, bad := range []string{"//", "\\", "://", "..", "\n", "\r", "\x00"} {
+		if strings.Contains(p, bad) {
+			return false
+		}
+	}
+	return true
 }
 
 // ServerOption is a functional option for configuring the Server.
@@ -269,41 +287,53 @@ func (s *Server) setupMiddleware() {
 	// When settings.WebServer.BasePath is "/birdnet", a request to /birdnet/ui/dashboard
 	// gets stripped to /ui/dashboard so existing route handlers match.
 	// Skipped when reverse proxy headers are present (the proxy already stripped it).
-	if bp := strings.TrimRight(s.settings.WebServer.BasePath, "/"); bp != "" {
-		s.echo.Pre(func(next echo.HandlerFunc) echo.HandlerFunc {
-			return func(c echo.Context) error {
-				// When a reverse proxy header is present, the proxy usually already
-				// stripped the prefix before forwarding. But only skip our stripping
-				// if the path does NOT start with the basepath — a client could send
-				// the header without an actual proxy, leaving the prefix intact.
-				req := c.Request()
-				hasProxyHeader := req.Header.Get("X-Ingress-Path") != "" || req.Header.Get("X-Forwarded-Prefix") != ""
-				if hasProxyHeader && !strings.HasPrefix(req.URL.Path, bp+"/") && req.URL.Path != bp {
-					return next(c)
-				}
-
-				path := req.URL.Path
-				if strings.HasPrefix(path, bp) {
-					rest := path[len(bp):]
-					if rest == "" || rest[0] == '/' {
-						if rest == "" {
-							rest = "/"
-						}
-						req.URL.Path = rest
-						// Also update RawPath if set (percent-encoded paths).
-						if req.URL.RawPath != "" && strings.HasPrefix(req.URL.RawPath, bp) {
-							raw := req.URL.RawPath[len(bp):]
-							if raw == "" {
-								raw = "/"
-							}
-							req.URL.RawPath = raw
-						}
-					}
-				}
+	//
+	// The effective basepath is read per-request from s.settings so changes to
+	// settings.WebServer.BasePath take effect without a server restart, matching
+	// the dynamic behavior of ingressPath() used by the context middleware below.
+	s.echo.Pre(func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			bp := strings.TrimRight(s.settings.WebServer.BasePath, "/")
+			if bp == "" {
 				return next(c)
 			}
-		})
-		s.slogger.Info("Base path prefix stripping enabled", logger.String("basePath", bp))
+
+			// When a reverse proxy header is present, the proxy usually already
+			// stripped the prefix before forwarding. But only skip our stripping
+			// if the path does NOT start with the basepath — a client could send
+			// the header without an actual proxy, leaving the prefix intact.
+			req := c.Request()
+			hasProxyHeader := req.Header.Get("X-Ingress-Path") != "" || req.Header.Get("X-Forwarded-Prefix") != ""
+			if hasProxyHeader && !strings.HasPrefix(req.URL.Path, bp+"/") && req.URL.Path != bp {
+				return next(c)
+			}
+
+			path := req.URL.Path
+			if strings.HasPrefix(path, bp) {
+				rest := path[len(bp):]
+				if rest == "" || rest[0] == '/' {
+					if rest == "" {
+						rest = "/"
+					}
+					req.URL.Path = rest
+					// Also update RawPath if set (percent-encoded paths).
+					if req.URL.RawPath != "" && strings.HasPrefix(req.URL.RawPath, bp) {
+						raw := req.URL.RawPath[len(bp):]
+						if raw == "" {
+							raw = "/"
+						}
+						req.URL.RawPath = raw
+					}
+				}
+			}
+			return next(c)
+		}
+	})
+	if initialBP := strings.TrimRight(s.settings.WebServer.BasePath, "/"); initialBP != "" {
+		s.slogger.Info("Base path prefix stripping enabled (hot-reloadable)",
+			logger.String("initialBasePath", initialBP))
+	} else {
+		s.slogger.Debug("Base path prefix stripping middleware installed (no basepath configured yet)")
 	}
 
 	// Recovery middleware - should be first

--- a/internal/api/spa.go
+++ b/internal/api/spa.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/labstack/echo/v4"
 	"github.com/tphakala/birdnet-go/frontend"
@@ -46,11 +47,46 @@ func NewSPAHandler(devMode bool, devModePath string) *SPAHandler {
 // ServeApp serves the SPA HTML shell for all frontend routes.
 // The HTML is served directly from Vite's build output.
 // Configuration is fetched by the frontend from /api/v2/app/config.
+// When a base path is set (reverse proxy or config), absolute asset URLs
+// in the HTML are rewritten to include the prefix.
 func (h *SPAHandler) ServeApp(c echo.Context) error {
 	if h.devMode {
 		return h.serveFromDisk(c)
 	}
 	return h.serveFromEmbed(c)
+}
+
+// rewriteHTMLBasePath prefixes absolute asset URLs in HTML content with the
+// given base path. This ensures the browser requests assets through the
+// reverse proxy (e.g., /birdnet/ui/assets/main.js instead of /ui/assets/main.js).
+//
+// The rewriting is idempotent: paths already containing the base path prefix
+// are not double-prefixed. This is important because some reverse proxies
+// (e.g., nginx sub_filter) may also rewrite paths in the response body.
+func rewriteHTMLBasePath(content []byte, basePath string) []byte {
+	if basePath == "" {
+		return content
+	}
+	s := string(content)
+
+	// Rewrite href="/..." and src="/..." attributes, but skip paths that
+	// already start with the base path to avoid double-prefixing.
+	s = strings.ReplaceAll(s, `href="`+basePath+`/`, "\x00HREF_PLACEHOLDER\x00")
+	s = strings.ReplaceAll(s, `src="`+basePath+`/`, "\x00SRC_PLACEHOLDER\x00")
+	s = strings.ReplaceAll(s, `href="/`, `href="`+basePath+`/`)
+	s = strings.ReplaceAll(s, `src="/`, `src="`+basePath+`/`)
+	s = strings.ReplaceAll(s, "\x00HREF_PLACEHOLDER\x00", `href="`+basePath+`/`)
+	s = strings.ReplaceAll(s, "\x00SRC_PLACEHOLDER\x00", `src="`+basePath+`/`)
+
+	// Rewrite service worker registration path and scope.
+	if !strings.Contains(s, `'`+basePath+`/sw.js'`) {
+		s = strings.ReplaceAll(s, `'/sw.js'`, `'`+basePath+`/sw.js'`)
+	}
+	if !strings.Contains(s, `scope: '`+basePath+`/'`) {
+		s = strings.ReplaceAll(s, `scope: '/'`, `scope: '`+basePath+`/'`)
+	}
+
+	return []byte(s)
 }
 
 // serveFromDisk serves index.html from the local filesystem (dev mode).
@@ -84,6 +120,10 @@ func (h *SPAHandler) serveFromDisk(c echo.Context) error {
 	c.Response().Header().Set("Pragma", "no-cache")
 	c.Response().Header().Set("Expires", "0")
 
+	// Rewrite absolute asset URLs when served behind a base path.
+	basePath, _ := c.Get("basePath").(string)
+	content = rewriteHTMLBasePath(content, basePath)
+
 	return c.HTMLBlob(http.StatusOK, content)
 }
 
@@ -110,6 +150,10 @@ func (h *SPAHandler) serveFromEmbed(c echo.Context) error {
 	c.Response().Header().Set(echo.HeaderCacheControl, cacheControlNoCache)
 	c.Response().Header().Set("Pragma", "no-cache")
 	c.Response().Header().Set("Expires", "0")
+
+	// Rewrite absolute asset URLs when served behind a base path.
+	basePath, _ := c.Get("basePath").(string)
+	content = rewriteHTMLBasePath(content, basePath)
 
 	return c.HTMLBlob(http.StatusOK, content)
 }

--- a/internal/api/static.go
+++ b/internal/api/static.go
@@ -76,13 +76,96 @@ func (sfs *StaticFileServer) RegisterRoutes(e *echo.Echo) {
 }
 
 // handleAssetRequest serves static assets based on dev/prod mode.
+// For text-based assets (CSS, JS) behind a base path, it rewrites absolute
+// /ui/assets/ references so the browser requests them through the proxy prefix.
 func (sfs *StaticFileServer) handleAssetRequest(c echo.Context) error {
 	path := c.Param("*")
+	basePath, _ := c.Get("basePath").(string)
+
+	// For text-based assets that may contain absolute /ui/assets/ references,
+	// read the content, rewrite paths, and serve the modified content.
+	if basePath != "" && isRewritableAsset(path) {
+		return sfs.serveRewrittenAsset(c, path, basePath)
+	}
 
 	if sfs.devMode {
 		return sfs.serveFromDisk(c, path)
 	}
 	return sfs.serveFromEmbed(c, path)
+}
+
+// isRewritableAsset returns true for text-based asset types that may contain
+// absolute /ui/assets/ references needing base path rewriting (CSS, JS).
+func isRewritableAsset(path string) bool {
+	return strings.HasSuffix(path, ".css") || strings.HasSuffix(path, ".js") || strings.HasSuffix(path, ".mjs")
+}
+
+// serveRewrittenAsset reads a text asset, rewrites /ui/assets/ references to
+// include the base path prefix, and serves the modified content.
+func (sfs *StaticFileServer) serveRewrittenAsset(c echo.Context, path, basePath string) error {
+	var content []byte
+	var err error
+
+	if sfs.devMode {
+		content, err = sfs.readAssetFromDisk(path)
+	} else {
+		content, err = sfs.readAssetFromEmbed(path)
+	}
+	if err != nil {
+		return err
+	}
+
+	// Replace absolute /ui/assets/ references with the prefixed version.
+	// This covers CSS url(/ui/assets/...) and JS dynamic imports.
+	// Idempotent: skip references already prefixed (e.g., by nginx sub_filter).
+	s := string(content)
+	s = strings.ReplaceAll(s, basePath+"/ui/assets/", "\x00ASSET_PLACEHOLDER\x00")
+	s = strings.ReplaceAll(s, "/ui/assets/", basePath+"/ui/assets/")
+	rewritten := strings.ReplaceAll(s, "\x00ASSET_PLACEHOLDER\x00", basePath+"/ui/assets/")
+
+	contentType := getMIMEType(path)
+	c.Response().Header().Set("Content-Type", contentType)
+	if isUnhashedAsset(path) {
+		c.Response().Header().Set("Cache-Control", "no-cache, must-revalidate")
+	} else {
+		c.Response().Header().Set("Cache-Control", "public, max-age=31536000, immutable")
+	}
+	return c.Blob(http.StatusOK, contentType, []byte(rewritten))
+}
+
+// readAssetFromDisk reads a static asset file from the dev mode dist directory.
+func (sfs *StaticFileServer) readAssetFromDisk(path string) ([]byte, error) {
+	root, err := sfs.openDevRoot()
+	if err != nil {
+		return nil, err
+	}
+	defer sfs.closeWithLog(root, "root handle")
+
+	file, err := sfs.openFileFromRoot(root, path)
+	if err != nil {
+		return nil, err
+	}
+	defer sfs.closeFileWithLog(file, path)
+
+	return io.ReadAll(file)
+}
+
+// readAssetFromEmbed reads a static asset file from the embedded filesystem.
+func (sfs *StaticFileServer) readAssetFromEmbed(path string) ([]byte, error) {
+	log := GetLogger()
+	file, err := frontend.DistFS.Open(path)
+	if err != nil {
+		return nil, echo.NewHTTPError(http.StatusNotFound, "File not found")
+	}
+	defer func() {
+		if closeErr := file.Close(); closeErr != nil {
+			log.Warn("Error closing embedded file",
+				logger.String("path", path),
+				logger.Error(closeErr))
+		}
+	}()
+
+	return io.ReadAll(file)
 }
 
 // serveFromDisk serves frontend assets from the local filesystem (dev mode).

--- a/internal/api/v2/app.go
+++ b/internal/api/v2/app.go
@@ -299,12 +299,16 @@ func (c *Controller) determineAccessAllowed(ctx echo.Context, securityEnabled bo
 
 // requestBasePath returns the effective base path prefix for the current request.
 // Priority: X-Ingress-Path header > X-Forwarded-Prefix header > config BasePath > empty.
+//
+// Header values are trimmed of trailing slashes before the safety check so that
+// real-world values like "/ingress/token///" are accepted (and normalized) while
+// embedded dangerous sequences like "//evil" or "/../admin" still get rejected.
 func requestBasePath(c echo.Context, settings *conf.Settings) string {
-	if p := c.Request().Header.Get("X-Ingress-Path"); isSafePathPrefix(p) {
-		return strings.TrimRight(p, "/")
+	if p := strings.TrimRight(c.Request().Header.Get("X-Ingress-Path"), "/"); isSafePathPrefix(p) {
+		return p
 	}
-	if p := c.Request().Header.Get("X-Forwarded-Prefix"); isSafePathPrefix(p) {
-		return strings.TrimRight(p, "/")
+	if p := strings.TrimRight(c.Request().Header.Get("X-Forwarded-Prefix"), "/"); isSafePathPrefix(p) {
+		return p
 	}
 	if settings != nil && settings.WebServer.BasePath != "" {
 		return strings.TrimRight(settings.WebServer.BasePath, "/")
@@ -312,8 +316,28 @@ func requestBasePath(c echo.Context, settings *conf.Settings) string {
 	return ""
 }
 
-// isSafePathPrefix validates that a path prefix is safe for use in redirects.
-// Rejects empty strings, protocol-relative URLs (//...), and absolute URLs (://...).
+// isSafePathPrefix validates that a path prefix (typically from a proxy header)
+// is safe for use in redirects. Must stay in sync with the copies in
+// internal/api/server.go and internal/api/auth/middleware.go. Rules align with
+// validateBasePath() in internal/conf/validate.go so header-supplied and
+// YAML-configured basepaths share the same rejection rules.
+//
+// Rejects:
+//   - empty strings
+//   - values not starting with "/"
+//   - protocol-relative URLs ("//...") and embedded "//" sequences
+//   - absolute URLs ("://")
+//   - backslashes ("/\..." normalizes to "//" in browsers)
+//   - path traversal ("..")
+//   - CR/LF/NUL injection
 func isSafePathPrefix(p string) bool {
-	return p != "" && strings.HasPrefix(p, "/") && !strings.HasPrefix(p, "//") && !strings.Contains(p, "://")
+	if p == "" || !strings.HasPrefix(p, "/") {
+		return false
+	}
+	for _, bad := range []string{"//", "\\", "://", "..", "\n", "\r", "\x00"} {
+		if strings.Contains(p, bad) {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/api/v2/auth.go
+++ b/internal/api/v2/auth.go
@@ -245,6 +245,11 @@ func (c *Controller) Login(ctx echo.Context) error {
 	// the reverse proxy (e.g., /birdnet/api/v2/auth/callback instead of /api/v2/auth/callback).
 	// URL-encode both code and redirect to prevent parameter injection and handle special characters.
 	requestBase, _ := ctx.Get("basePath").(string)
+	// Normalize finalRedirect against the request base path so the post-auth
+	// redirect goes through the proxy (e.g., /birdnet/ui/ instead of /ui/).
+	if requestBase != "" {
+		finalRedirect = ensurePathWithinBase(finalRedirect, requestBase+"/")
+	}
 	redirectURL := fmt.Sprintf("%s/api/v2/auth/callback?code=%s&redirect=%s", requestBase, url.QueryEscape(authCode), url.QueryEscape(finalRedirect))
 
 	c.logInfoIfEnabled("Returning successful login response with redirect",

--- a/internal/api/v2/auth.go
+++ b/internal/api/v2/auth.go
@@ -240,9 +240,12 @@ func (c *Controller) Login(ctx echo.Context) error {
 		}
 	}
 
-	// Construct the V2 OAuth callback URL with the validated redirect
-	// URL-encode both code and redirect to prevent parameter injection and handle special characters
-	redirectURL := fmt.Sprintf("/api/v2/auth/callback?code=%s&redirect=%s", url.QueryEscape(authCode), url.QueryEscape(finalRedirect))
+	// Construct the V2 OAuth callback URL with the validated redirect.
+	// Include the base path prefix so the browser follows the redirect through
+	// the reverse proxy (e.g., /birdnet/api/v2/auth/callback instead of /api/v2/auth/callback).
+	// URL-encode both code and redirect to prevent parameter injection and handle special characters.
+	requestBase, _ := ctx.Get("basePath").(string)
+	redirectURL := fmt.Sprintf("%s/api/v2/auth/callback?code=%s&redirect=%s", requestBase, url.QueryEscape(authCode), url.QueryEscape(finalRedirect))
 
 	c.logInfoIfEnabled("Returning successful login response with redirect",
 		logger.Username(req.Username),

--- a/internal/conf/pure_validation_test.go
+++ b/internal/conf/pure_validation_test.go
@@ -758,6 +758,66 @@ func TestValidateWebServerSettings_Valid(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "basepath empty (disabled)",
+			settings: WebServerSettings{
+				Enabled:  true,
+				Port:     "8080",
+				BasePath: "",
+				LiveStream: LiveStreamSettings{
+					BitRate:       128,
+					SegmentLength: 5,
+				},
+			},
+		},
+		{
+			name: "basepath simple prefix",
+			settings: WebServerSettings{
+				Enabled:  true,
+				Port:     "8080",
+				BasePath: "/birdnet",
+				LiveStream: LiveStreamSettings{
+					BitRate:       128,
+					SegmentLength: 5,
+				},
+			},
+		},
+		{
+			name: "basepath multi-segment",
+			settings: WebServerSettings{
+				Enabled:  true,
+				Port:     "8080",
+				BasePath: "/apps/birdnet",
+				LiveStream: LiveStreamSettings{
+					BitRate:       128,
+					SegmentLength: 5,
+				},
+			},
+		},
+		{
+			name: "basepath with trailing slash",
+			settings: WebServerSettings{
+				Enabled:  true,
+				Port:     "8080",
+				BasePath: "/birdnet/",
+				LiveStream: LiveStreamSettings{
+					BitRate:       128,
+					SegmentLength: 5,
+				},
+			},
+		},
+		{
+			name: "basepath with underscore and hyphen",
+			settings: WebServerSettings{
+				Enabled:  true,
+				Port:     "8080",
+				BasePath: "/my_bird-net",
+				LiveStream: LiveStreamSettings{
+					BitRate:       128,
+					SegmentLength: 5,
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -857,6 +917,114 @@ func TestValidateWebServerSettings_Invalid(t *testing.T) {
 				},
 			},
 			expectError: "segment length must be between 1 and 30 seconds",
+		},
+		{
+			name: "basepath missing leading slash",
+			settings: WebServerSettings{
+				Enabled: true,
+				Port:    "8080",
+				// Missing leading "/" is a common typo. Reject loudly so users notice before the
+				// server silently routes nothing through the subpath middleware.
+				BasePath: "birdnet",
+				LiveStream: LiveStreamSettings{
+					BitRate:       128,
+					SegmentLength: 5,
+				},
+			},
+			expectError: "basepath must start with",
+		},
+		{
+			name: "basepath is just slash",
+			settings: WebServerSettings{
+				Enabled:  true,
+				Port:     "8080",
+				BasePath: "/",
+				LiveStream: LiveStreamSettings{
+					BitRate:       128,
+					SegmentLength: 5,
+				},
+			},
+			expectError: "is meaningless",
+		},
+		{
+			name: "basepath protocol-relative",
+			settings: WebServerSettings{
+				Enabled: true,
+				Port:    "8080",
+				// Browsers treat "//host" as a protocol-relative URL — must not be allowed as a path prefix.
+				BasePath: "//evil.example",
+				LiveStream: LiveStreamSettings{
+					BitRate:       128,
+					SegmentLength: 5,
+				},
+			},
+			expectError: "disallowed sequence",
+		},
+		{
+			name: "basepath with backslash",
+			settings: WebServerSettings{
+				Enabled: true,
+				Port:    "8080",
+				// Browsers normalize "/\foo" to "//foo" (protocol-relative). Defensive reject.
+				BasePath: `/\evil.example`,
+				LiveStream: LiveStreamSettings{
+					BitRate:       128,
+					SegmentLength: 5,
+				},
+			},
+			expectError: "disallowed sequence",
+		},
+		{
+			name: "basepath path traversal",
+			settings: WebServerSettings{
+				Enabled:  true,
+				Port:     "8080",
+				BasePath: "/../etc/passwd",
+				LiveStream: LiveStreamSettings{
+					BitRate:       128,
+					SegmentLength: 5,
+				},
+			},
+			expectError: "disallowed sequence",
+		},
+		{
+			name: "basepath scheme injection",
+			settings: WebServerSettings{
+				Enabled:  true,
+				Port:     "8080",
+				BasePath: "/javascript://evil",
+				LiveStream: LiveStreamSettings{
+					BitRate:       128,
+					SegmentLength: 5,
+				},
+			},
+			expectError: "disallowed sequence",
+		},
+		{
+			name: "basepath with space",
+			settings: WebServerSettings{
+				Enabled:  true,
+				Port:     "8080",
+				BasePath: "/bird net",
+				LiveStream: LiveStreamSettings{
+					BitRate:       128,
+					SegmentLength: 5,
+				},
+			},
+			expectError: "disallowed character",
+		},
+		{
+			name: "basepath with HTML injection",
+			settings: WebServerSettings{
+				Enabled:  true,
+				Port:     "8080",
+				BasePath: "/<script>",
+				LiveStream: LiveStreamSettings{
+					BitRate:       128,
+					SegmentLength: 5,
+				},
+			},
+			expectError: "disallowed character",
 		},
 	}
 

--- a/internal/conf/validate.go
+++ b/internal/conf/validate.go
@@ -667,6 +667,13 @@ func ValidateWebServerSettings(settings *WebServerSettings) ValidationResult {
 		}
 	}
 
+	// Validate BasePath (reverse proxy subpath prefix).
+	// Empty is allowed (disables basepath). Non-empty must be a safe URL-path prefix.
+	if err := validateBasePath(settings.BasePath); err != nil {
+		result.Valid = false
+		result.Errors = append(result.Errors, err.Error())
+	}
+
 	// Validate LiveStream settings
 	if settings.LiveStream.BitRate < 16 || settings.LiveStream.BitRate > 320 {
 		result.Valid = false
@@ -682,6 +689,50 @@ func ValidateWebServerSettings(settings *WebServerSettings) ValidationResult {
 
 	result.Normalized = settings
 	return result
+}
+
+// validateBasePath verifies that a configured WebServer.BasePath is a safe URL-path prefix.
+// Empty is allowed and disables subpath routing. Non-empty values must start with "/",
+// contain only a restricted character set, and must not introduce path traversal,
+// protocol-relative URLs, backslashes, or scheme-like sequences.
+func validateBasePath(basePath string) error {
+	if basePath == "" {
+		return nil
+	}
+
+	if !strings.HasPrefix(basePath, "/") {
+		return fmt.Errorf("WebServer basepath must start with %q, got %q", "/", basePath)
+	}
+
+	// A single "/" is meaningless as a subpath prefix — require the caller to use empty instead.
+	if basePath == "/" {
+		return fmt.Errorf("WebServer basepath %q is meaningless; leave empty to disable subpath routing", basePath)
+	}
+
+	// Reject dangerous sequences outright. The sequence list aligns with the
+	// dangerous-pattern check in isValidBasePath (internal/api/v2/auth.go) so that
+	// YAML-configured and UI-supplied basepaths share the same rejection rules.
+	for _, bad := range []string{"..", "//", "\\", "://", "\n", "\r", "\x00"} {
+		if strings.Contains(basePath, bad) {
+			return fmt.Errorf("WebServer basepath contains disallowed sequence %q: %q", bad, basePath)
+		}
+	}
+
+	// Restrict to the same alphanumeric + /_- character set accepted elsewhere.
+	// This catches HTML/JS injection attempts, whitespace, and unicode surprises early.
+	for _, r := range basePath {
+		switch {
+		case r >= 'a' && r <= 'z',
+			r >= 'A' && r <= 'Z',
+			r >= '0' && r <= '9',
+			r == '/', r == '-', r == '_':
+			// allowed
+		default:
+			return fmt.Errorf("WebServer basepath contains disallowed character %q: %q", r, basePath)
+		}
+	}
+
+	return nil
 }
 
 // ValidateTelemetrySettings validates the telemetry endpoint configuration.


### PR DESCRIPTION
**Hi, thanks for a fantastic project!**

Tried to set this up on a server under a base path (`/birdnet`), but traefik which acts as reverse proxy doesn't have an equivalent of nginx's `sub_filter`. This makes it hard to function for a number of reasons:

1. **Direct access with config basepath doesn't work**
  Setting `basepath: /birdnet` in config and hitting `/` redirected to `/birdnet/ui/dashboard`, which returned 404. All routes are registered at root level (`/ui/dashboard`, `/api/v2/*`, etc.), so the prefixed path had no matching handler.

2. **Static assets failed to load behind a reverse proxy**
  With a reverse proxy setup that strips `/birdnet` and adds `X-Forwarded-Prefix: /birdnet`, the page HTML loaded fine, but all JS, CSS, and font files were requested from root paths (`/ui/assets/...`) instead of `/birdnet/ui/assets/...`. These requests bypassed the proxy route entirely, resulting in 404s for every asset. This is the path that doesn't work without something equivalent to nginx's `sub_filter` - the SPA handler served `index.html` verbatim with hardcoded absolute paths (`href="/ui/assets/..."`, `src="/ui/assets/..."`).

3. **CSS/JS files contained absolute paths that also bypassed the proxy**
  After fixing the HTML, CSS files contain `url(/ui/assets/...)` references (for fonts, etc.) and JS files contain dynamic import paths. These absolute URLs in served assets also need the base path prefix to route through the proxy correctly.

4. **Fonts never loaded in production**
  The CSS referenced fonts at `url('/fonts/Inter-Variable.woff2')` but no route existed for `/fonts/*`. The only static file route is `/ui/assets/*`. Fonts silently failed to load in embedded/production mode, falling back to system fonts.

5. **Auth middleware login redirects were broken for direct basepath access**
  The auth middleware's `requestBasePath()` intentionally skipped the config basepath fallback (only checking proxy headers). This meant login redirects for direct access (no proxy) omitted the basepath prefix, sending users to `/login` instead of `/birdnet/login`.

6. **Auth login callback URL missing backpath prefix**
  After successful password login, the backend returned a redirect URI without basepath prefix - the frontend set `window.location.href` to this URL directly, which bypassed the proxy route and 404'ed.

## Fixes

**Pre middleware for prefix stripping** (`server.go`): When `basepath` is configured, a new `Pre` middleware strips the prefix from incoming request URLs before routing. `/birdnet/ui/dashboard` becomes `/ui/dashboard`, matching existing handlers. The middleware is skipped when proxy headers are present (the proxy already stripped it).

**Context middleware for basepath propagation** (`server.go`): A new `Use` middleware sets the effective base path in the Echo context (`c.Set("basePath", ...)`) on every request via the existing `ingressPath()` priority chain. This makes the basepath available to all downstream handlers without threading settings through each one.

**HTML rewriting in SPA handler** (`spa.go`): When a base path is active, `rewriteHTMLBasePath()` prefixes all `href="/..."` and `src="/..."` attributes, plus the service worker registration path and scope.

**Manifest rewriting** (`pwa.go`): The `manifest.webmanifest` handler now reads the file content, rewrites icon `src` paths and `start_url`/`scope` when a base path is set, and serves the modified JSON. The `Service-Worker-Allowed` header also uses the base path.

**Static asset rewriting** (`static.go`): For CSS and JS files served via `/ui/assets/*`, when a base path is active, the server reads the file content and replaces `/ui/assets/` references with `{basePath}/ui/assets/`. This covers CSS `url()` references and JS dynamic imports.

**Font path fix** (`tailwind.css`, `index.html`): Changed font references from `/fonts/Inter-Variable.woff2` to `/ui/assets/fonts/Inter-Variable.woff2`, which is actually served by the existing `/ui/assets/*` route. This fixes font loading in production mode regardless of basepath.

**Auth middleware fix** (`auth/middleware.go`): Updated `requestBasePath()` to read from the Echo context (set by the basepath middleware) instead of only checking proxy headers. Falls back to header checks if the context value is not set.

**Idempotent rewriting**: All URL rewriting is idempotent. Paths already containing the basepath prefix are not double-prefixed. This prevents conflicts with reverse proxies like nginx that also rewrite response bodies via `sub_filter`.

**Auth callback URL fix**: Login handler now reads the basepath from the Echo context and includes it in the OAuth callback redirect URL.

## Tests

- [x] New tests in `basepath_test.go` covering prefix stripping, HTML rewriting, manifest rewriting, context middleware, asset type detection, and idempotency
- [x] Existing `TestIngressPath` tests still pass with no regressions
- [x] Existing reverse proxy test suite (nginx with `/birdnet/` subpath and `sub_filter`) should pass without changes thanks to idempotent rewriting
- [x] Manual test: set `basepath: /birdnet` in config, access `http://host:8080/birdnet/ui/dashboard` directly
- [x] Manual test: access behind reverse proxy with `X-Forwarded-Prefix: /birdnet` and prefix stripping (Traefik, nginx, or Caddy)
- [x] Verify fonts, JS, CSS, manifest, and service worker all load correctly in both scenarios
- [x] Verify login/auth redirects include the basepath prefix

## Notes

I don't love how many changes were required for this - if you have a better solution then feel free to modify as you want obviously, but I think it would be awesome if the app worked more fluently with base path - behind a reverse proxy or not! :) 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full support for serving the app under a non-root base path: assets, HTML, manifest, service worker scope, and auth redirects respect the effective base path (including proxy-aware contexts).

* **Bug Fixes**
  * Fixed font preload and CSS font URLs so typefaces load correctly with a base path.
  * Service worker and manifest responses return correct headers for base-path deployments.
  * Improved validation and safer handling of unsafe base-path values.

* **Tests**
  * Added comprehensive tests for base-path stripping, asset/HTML/manifest rewriting, and safety checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->