### PR TITLE
fix(frontend): show "No audio sources" instead of infinite "Loading"

### DIFF
--- a/frontend/src/lib/desktop/features/live-stream/pages/LiveStreamPage.svelte
+++ b/frontend/src/lib/desktop/features/live-stream/pages/LiveStreamPage.svelte
@@ -775,7 +775,7 @@
           value={selectedSourceId}
           placeholder={sources.length === 0
             ? sourceDiscoveryDone
-              ? t('common.noAudioSources')
+              ? t('common.ui.noAudioSources')
               : t('common.loading') + '...'
             : t('spectrogram.page.sourceLabel')}
           variant="select"

--- a/frontend/src/lib/desktop/features/live-stream/pages/LiveStreamPage.svelte
+++ b/frontend/src/lib/desktop/features/live-stream/pages/LiveStreamPage.svelte
@@ -773,11 +773,11 @@
         <SelectDropdown
           options={sourceOptions}
           value={selectedSourceId}
-          placeholder={sources.length === 0
-            ? sourceDiscoveryDone
+          placeholder={sources.length > 0
+            ? t('spectrogram.page.sourceLabel')
+            : sourceDiscoveryDone
               ? t('common.ui.noAudioSources')
-              : t('common.loading') + '...'
-            : t('spectrogram.page.sourceLabel')}
+              : t('common.loading') + '...'}
           variant="select"
           size="sm"
           groupBy={false}

--- a/frontend/src/lib/desktop/features/live-stream/pages/LiveStreamPage.svelte
+++ b/frontend/src/lib/desktop/features/live-stream/pages/LiveStreamPage.svelte
@@ -856,9 +856,12 @@
           disabled={!selectedSourceId || sources.length === 0}
           class="flex h-full w-full flex-col items-center justify-center gap-3 bg-black text-[var(--color-base-content)]/60 transition-colors hover:text-[var(--color-base-content)]/80 disabled:cursor-not-allowed disabled:opacity-50"
         >
-          {#if sources.length === 0}
+          {#if sources.length === 0 && !sourceDiscoveryDone}
             <Loader2 class="size-8 animate-spin" />
             <span class="text-sm">{t('common.loading')}...</span>
+          {:else if sources.length === 0 && sourceDiscoveryDone}
+            <Mic class="size-8" />
+            <span class="text-sm">{t('common.ui.noAudioSources')}</span>
           {:else}
             <Play class="size-12" />
             <span class="text-sm">{t('spectrogram.page.sourceLabel')}</span>

--- a/frontend/src/lib/desktop/features/live-stream/pages/LiveStreamPage.svelte
+++ b/frontend/src/lib/desktop/features/live-stream/pages/LiveStreamPage.svelte
@@ -61,6 +61,7 @@
   // Source discovery
   let sources = $state<Array<{ id: string; name: string }>>([]);
   let selectedSourceId = $state<string>('');
+  let sourceDiscoveryDone = $state(false);
 
   // Connection state
   let connectionError = $state<string | null>(null);
@@ -117,6 +118,10 @@
                 name: level.name ?? id,
               })
             );
+
+            // Mark discovery as done after the first message from the backend.
+            // If levels is empty, there are no configured audio sources.
+            sourceDiscoveryDone = true;
 
             if (newSources.length > 0) {
               // Update sources if count changed or this is the first time
@@ -769,7 +774,9 @@
           options={sourceOptions}
           value={selectedSourceId}
           placeholder={sources.length === 0
-            ? t('common.loading') + '...'
+            ? sourceDiscoveryDone
+              ? t('common.noAudioSources')
+              : t('common.loading') + '...'
             : t('spectrogram.page.sourceLabel')}
           variant="select"
           size="sm"

--- a/frontend/src/lib/desktop/features/live-stream/pages/LiveStreamPage.svelte
+++ b/frontend/src/lib/desktop/features/live-stream/pages/LiveStreamPage.svelte
@@ -121,7 +121,9 @@
 
             // Mark discovery as done after the first message from the backend.
             // If levels is empty, there are no configured audio sources.
-            sourceDiscoveryDone = true;
+            if (!sourceDiscoveryDone) {
+              sourceDiscoveryDone = true;
+            }
 
             if (newSources.length > 0) {
               // Update sources if count changed or this is the first time


### PR DESCRIPTION
Minor: when no audio sources are configured, the "live audio" page shows "Loading……" indefinitely in the audio source dropdown. This changes it to say "No audio sources" instead if that is the case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Audio source dropdown now reflects discovery completion: shows "Loading..." while scanning and switches to "No Audio Sources" once initial audio-level data confirms no sources.
  * Start button empty-state displays a spinner during discovery and, once discovery completes, switches to a microphone icon and a "No Audio Sources" message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->