### PR TITLE
feat(audio): dynamic audio device reconfiguration without restart

### DIFF
--- a/frontend/src/lib/i18n/types.generated.ts
+++ b/frontend/src/lib/i18n/types.generated.ts
@@ -332,7 +332,7 @@ export type TranslationKey =
   | 'notifications.content.settings.reconfiguringSpeciesTracking'
   | 'notifications.content.settings.webserverRestartRequired'
   | 'notifications.content.settings.reconfiguringSoundLevel'
-  | 'notifications.content.settings.audioDeviceRestartRequired'
+  | 'notifications.content.settings.reconfiguringAudioSources'
   | 'notifications.content.settings.extendedCaptureRestartRequired'
   | 'notifications.content.settings.equalizerUpdateFailed'
   | 'notifications.content.settings.equalizerUpdated'

--- a/frontend/static/messages/da.json
+++ b/frontend/static/messages/da.json
@@ -394,7 +394,7 @@
         "reconfiguringDynamicThresholds": "Genkonfigurerer dynamiske tærskler...",
         "webserverRestartRequired": "Webserverindstillinger ændret. Genstart påkrævet.",
         "reconfiguringSoundLevel": "Opdaterer lydniveauovervågning...",
-        "audioDeviceRestartRequired": "Lydenhed ændret. Genstart påkrævet.",
+        "reconfiguringAudioSources": "Genkonfigurerer lydkilder...",
         "rebuildingExtendedCapture": "Genopbygger udvidet optagelsesfilter...",
         "extendedCaptureRestartRequired": "Udvidede optagelsesindstillinger ændret. Genstart påkrævet.",
         "equalizerUpdateFailed": "Kunne ikke opdatere lyd-equalizerindstillinger",

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -395,7 +395,7 @@
         "reconfiguringDynamicThresholds": "Dynamische Schwellenwerte werden neu konfiguriert...",
         "webserverRestartRequired": "Webserver-Einstellungen geändert. Neustart erforderlich.",
         "reconfiguringSoundLevel": "Lautstärkeüberwachung wird aktualisiert...",
-        "audioDeviceRestartRequired": "Audiogerät geändert. Neustart erforderlich.",
+        "reconfiguringAudioSources": "Audioquellen werden neu konfiguriert...",
         "rebuildingExtendedCapture": "Erweiterter Aufnahmefilter wird neu aufgebaut...",
         "extendedCaptureRestartRequired": "Erweiterte Aufnahmeeinstellungen geändert. Neustart erforderlich.",
         "equalizerUpdateFailed": "Aktualisierung der Audio-Equalizer-Einstellungen fehlgeschlagen",

--- a/frontend/static/messages/en.json
+++ b/frontend/static/messages/en.json
@@ -395,7 +395,7 @@
         "reconfiguringDynamicThresholds": "Reconfiguring dynamic thresholds...",
         "webserverRestartRequired": "Web server settings changed. Restart required.",
         "reconfiguringSoundLevel": "Updating sound level monitoring...",
-        "audioDeviceRestartRequired": "Audio device changed. Restart required.",
+        "reconfiguringAudioSources": "Reconfiguring audio sources...",
         "rebuildingExtendedCapture": "Rebuilding extended capture filter...",
         "extendedCaptureRestartRequired": "Extended capture settings changed. Restart required.",
         "equalizerUpdateFailed": "Failed to update audio equalizer settings",

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -395,7 +395,7 @@
         "reconfiguringDynamicThresholds": "Reconfigurando umbrales dinámicos...",
         "webserverRestartRequired": "Los ajustes del servidor web han cambiado. Se requiere reinicio.",
         "reconfiguringSoundLevel": "Actualizando monitorización del nivel de sonido...",
-        "audioDeviceRestartRequired": "Dispositivo de audio cambiado. Se requiere reinicio.",
+        "reconfiguringAudioSources": "Reconfigurando fuentes de audio...",
         "rebuildingExtendedCapture": "Reconstruyendo filtro de captura extendida...",
         "extendedCaptureRestartRequired": "Ajustes de captura extendida cambiados. Se requiere reinicio.",
         "equalizerUpdateFailed": "Error al actualizar los ajustes del ecualizador de audio",

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -395,7 +395,7 @@
         "reconfiguringDynamicThresholds": "Määritetään dynaamisia kynnysarvoja uudelleen...",
         "webserverRestartRequired": "Verkkopalvelimen asetukset muuttuivat. Uudelleenkäynnistys vaaditaan.",
         "reconfiguringSoundLevel": "Päivitetään äänitason seurantaa...",
-        "audioDeviceRestartRequired": "Äänilaite vaihdettu. Uudelleenkäynnistys vaaditaan.",
+        "reconfiguringAudioSources": "Määritetään äänilähteitä uudelleen...",
         "rebuildingExtendedCapture": "Rakennetaan laajennetun tallennuksen suodatinta uudelleen...",
         "extendedCaptureRestartRequired": "Laajennetun tallennuksen asetukset muuttuneet. Uudelleenkäynnistys vaaditaan.",
         "equalizerUpdateFailed": "Äänen taajuuskorjaimen asetusten päivitys epäonnistui",

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -395,7 +395,7 @@
         "reconfiguringDynamicThresholds": "Reconfiguration des seuils dynamiques...",
         "webserverRestartRequired": "Les paramètres du serveur web ont changé. Redémarrage requis.",
         "reconfiguringSoundLevel": "Mise à jour de la surveillance du niveau sonore...",
-        "audioDeviceRestartRequired": "Périphérique audio modifié. Redémarrage requis.",
+        "reconfiguringAudioSources": "Reconfiguration des sources audio...",
         "rebuildingExtendedCapture": "Reconstruction du filtre de capture étendue...",
         "extendedCaptureRestartRequired": "Paramètres de capture étendue modifiés. Redémarrage requis.",
         "equalizerUpdateFailed": "Échec de la mise à jour des paramètres de l'égaliseur audio",

--- a/frontend/static/messages/hu.json
+++ b/frontend/static/messages/hu.json
@@ -392,7 +392,7 @@
         "reconfiguringSpeciesTracking": "Faj követés frissítése...",
         "webserverRestartRequired": "Webszerver beállítások megváltoztak. Újraindítás szükséges.",
         "reconfiguringSoundLevel": "Hangszint monitorozás frissítése...",
-        "audioDeviceRestartRequired": "Hang eszköz megváltozott. Újraindítás szükséges.",
+        "reconfiguringAudioSources": "Hangforrások újrakonfigurálása...",
         "extendedCaptureRestartRequired": "Kiterjesztett rögzítés beállítások megváltoztak. Újraindítás szükséges.",
         "equalizerUpdateFailed": "A hang EQ beállítások frissítése sikertelen",
         "equalizerUpdated": "Hang EQ beállítások frissítve",

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -394,7 +394,7 @@
         "reconfiguringDynamicThresholds": "Riconfigurazione delle soglie dinamiche...",
         "webserverRestartRequired": "Impostazioni del server web modificate. Riavvio necessario.",
         "reconfiguringSoundLevel": "Aggiornamento del monitoraggio del livello sonoro...",
-        "audioDeviceRestartRequired": "Dispositivo audio modificato. Riavvio necessario.",
+        "reconfiguringAudioSources": "Riconfigurazione sorgenti audio...",
         "rebuildingExtendedCapture": "Ricostruzione del filtro di cattura estesa...",
         "extendedCaptureRestartRequired": "Impostazioni di cattura estesa modificate. Riavvio necessario.",
         "equalizerUpdateFailed": "Aggiornamento delle impostazioni dell'equalizzatore audio non riuscito",

--- a/frontend/static/messages/lv.json
+++ b/frontend/static/messages/lv.json
@@ -394,7 +394,7 @@
         "reconfiguringDynamicThresholds": "Pārkonfigurē dinamiskos sliekšņus...",
         "webserverRestartRequired": "Tīmekļa servera iestatījumi mainīti. Nepieciešama restartēšana.",
         "reconfiguringSoundLevel": "Atjaunina skaņas līmeņa uzraudzību...",
-        "audioDeviceRestartRequired": "Audio ierīce mainīta. Nepieciešama restartēšana.",
+        "reconfiguringAudioSources": "Audio avotu pārkonfigurēšana...",
         "rebuildingExtendedCapture": "Pārbūvē paplašinātās ierakstīšanas filtru...",
         "extendedCaptureRestartRequired": "Paplašinātās ierakstīšanas iestatījumi mainīti. Nepieciešama restartēšana.",
         "equalizerUpdateFailed": "Neizdevās atjaunināt audio ekvalaizera iestatījumus",

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -395,7 +395,7 @@
         "reconfiguringDynamicThresholds": "Dynamische drempels worden opnieuw geconfigureerd...",
         "webserverRestartRequired": "Webserverinstellingen gewijzigd. Herstart vereist.",
         "reconfiguringSoundLevel": "Geluidsniveaubewaking wordt bijgewerkt...",
-        "audioDeviceRestartRequired": "Audioapparaat gewijzigd. Herstart vereist.",
+        "reconfiguringAudioSources": "Audiobronnen worden opnieuw geconfigureerd...",
         "rebuildingExtendedCapture": "Filter voor uitgebreide opname wordt opnieuw opgebouwd...",
         "extendedCaptureRestartRequired": "Instellingen voor uitgebreide opname gewijzigd. Herstart vereist.",
         "equalizerUpdateFailed": "Bijwerken van audio-equalizerinstellingen mislukt",

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -395,7 +395,7 @@
         "reconfiguringDynamicThresholds": "Ponowna konfiguracja progów dynamicznych...",
         "webserverRestartRequired": "Ustawienia serwera WWW zmienione. Wymagany restart.",
         "reconfiguringSoundLevel": "Aktualizacja monitorowania poziomu dźwięku...",
-        "audioDeviceRestartRequired": "Zmieniono urządzenie audio. Wymagany restart.",
+        "reconfiguringAudioSources": "Ponowna konfiguracja źródeł audio...",
         "rebuildingExtendedCapture": "Przebudowa filtru rozszerzonego nagrywania...",
         "extendedCaptureRestartRequired": "Zmieniono ustawienia rozszerzonego nagrywania. Wymagany restart.",
         "equalizerUpdateFailed": "Nie udało się zaktualizować ustawień korektora dźwięku",

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -395,7 +395,7 @@
         "reconfiguringDynamicThresholds": "A reconfigurar limiares dinâmicos...",
         "webserverRestartRequired": "Definições do servidor web alteradas. Reinício necessário.",
         "reconfiguringSoundLevel": "A atualizar monitorização do nível de som...",
-        "audioDeviceRestartRequired": "Dispositivo de áudio alterado. Reinício necessário.",
+        "reconfiguringAudioSources": "A reconfigurar fontes de áudio...",
         "rebuildingExtendedCapture": "A reconstruir filtro de captura estendida...",
         "extendedCaptureRestartRequired": "Definições de captura estendida alteradas. Reinício necessário.",
         "equalizerUpdateFailed": "Falha ao atualizar definições do equalizador de áudio",

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -394,7 +394,7 @@
         "reconfiguringDynamicThresholds": "Prekonfigurovanie dynamických prahov...",
         "webserverRestartRequired": "Nastavenia webového servera zmenené. Vyžaduje sa reštart.",
         "reconfiguringSoundLevel": "Aktualizácia monitorovania úrovne zvuku...",
-        "audioDeviceRestartRequired": "Audio zariadenie zmenené. Vyžaduje sa reštart.",
+        "reconfiguringAudioSources": "Prekonfigurovanie zvukových zdrojov...",
         "rebuildingExtendedCapture": "Prestavba filtra rozšíreného nahrávania...",
         "extendedCaptureRestartRequired": "Nastavenia rozšíreného nahrávania zmenené. Vyžaduje sa reštart.",
         "equalizerUpdateFailed": "Aktualizácia nastavení audio ekvalizéra zlyhala",

--- a/frontend/static/messages/sv.json
+++ b/frontend/static/messages/sv.json
@@ -394,7 +394,7 @@
         "reconfiguringDynamicThresholds": "Konfigurerar om dynamiska tröskelvärden...",
         "webserverRestartRequired": "Webbserverinställningar ändrade. Omstart krävs.",
         "reconfiguringSoundLevel": "Uppdaterar ljudnivååvervakning...",
-        "audioDeviceRestartRequired": "Ljudenhet ändrad. Omstart krävs.",
+        "reconfiguringAudioSources": "Konfigurerar om ljudkällor...",
         "rebuildingExtendedCapture": "Bygger om filter för utökad inspelning...",
         "extendedCaptureRestartRequired": "Inställningar för utökad inspelning ändrade. Omstart krävs.",
         "equalizerUpdateFailed": "Kunde inte uppdatera ljudequalizerinställningar",

--- a/internal/analysis/control_monitor.go
+++ b/internal/analysis/control_monitor.go
@@ -225,6 +225,8 @@ func (cm *ControlMonitor) handleControlSignal(signal string) {
 		cm.handleReconfigurePushNotifications()
 	case "rebuild_extended_capture":
 		cm.handleRebuildExtendedCapture()
+	case "reconfigure_audio_sources":
+		cm.handleReconfigureAudioSources()
 	case "recalculate_dynamic_thresholds":
 		cm.handleRecalculateDynamicThresholds()
 	case "reconfigure_dynamic_thresholds":
@@ -706,6 +708,31 @@ func (cm *ControlMonitor) handleRebuildExtendedCapture() {
 
 	GetLogger().Info("Extended capture species filter rebuilt successfully")
 	cm.notifySuccess("Extended capture species filter rebuilt successfully")
+}
+
+// handleReconfigureAudioSources reconfigures audio capture sources (sound cards)
+// when their settings (device, gain, model) change. It delegates to the same
+// diff-based reconfiguration used for RTSP stream changes.
+func (cm *ControlMonitor) handleReconfigureAudioSources() {
+	GetLogger().Info("Reconfiguring audio sources")
+
+	defer func() {
+		if r := recover(); r != nil {
+			GetLogger().Error("panic during audio source reconfiguration",
+				logger.Any("panic", r))
+		}
+	}()
+
+	cm.reconfigureSourcesFn()
+
+	// Re-evaluate quiet hours after reconfiguration to ensure
+	// newly added sources respect their quiet hours settings.
+	if cm.quietHoursScheduler != nil {
+		cm.quietHoursScheduler.Evaluate()
+	}
+
+	GetLogger().Info("Audio sources reconfigured successfully")
+	cm.notifySuccess("Audio sources reconfigured successfully")
 }
 
 // handleRecalculateDynamicThresholds recalculates all dynamic threshold CurrentValue entries

--- a/internal/analysis/control_monitor.go
+++ b/internal/analysis/control_monitor.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"runtime/debug"
 	"strconv"
 	"sync"
 	"time"
@@ -718,8 +719,14 @@ func (cm *ControlMonitor) handleReconfigureAudioSources() {
 
 	defer func() {
 		if r := recover(); r != nil {
-			GetLogger().Error("panic during audio source reconfiguration",
-				logger.Any("panic", r))
+			var err error
+			if e, ok := r.(error); ok {
+				err = fmt.Errorf("panic during audio source reconfiguration: %w", e)
+			} else {
+				err = fmt.Errorf("panic during audio source reconfiguration: %v", r)
+			}
+			GetLogger().Error(err.Error(),
+				logger.String("stack", string(debug.Stack())))
 		}
 	}()
 

--- a/internal/api/v2/settings_audio.go
+++ b/internal/api/v2/settings_audio.go
@@ -117,10 +117,10 @@ func (c *Controller) handleAudioSettingsChanges(oldSettings, currentSettings *co
 
 	// Check audio device settings
 	if audioDeviceSettingChanged(oldSettings, currentSettings) {
-		c.Debug("Audio device changed. A restart will be required.")
-		// Send toast notification about restart requirement
-		_ = c.SendToastWithKey("Audio device changed. Restart required to apply changes.", "warning", toastDurationExtended,
-			notification.MsgSettingsAudioDeviceRestart, nil)
+		c.Debug("Audio device settings changed, triggering reconfiguration")
+		reconfigActions = append(reconfigActions, "reconfigure_audio_sources")
+		_ = c.SendToastWithKey("Reconfiguring audio sources...", "info", toastDurationMedium,
+			notification.MsgSettingsReconfiguringAudioSources, nil)
 	}
 
 	// Check extended capture filter settings (hot-reloadable: Enabled, Species, MaxDuration)

--- a/internal/notification/message_keys.go
+++ b/internal/notification/message_keys.go
@@ -45,7 +45,7 @@ const (
 
 	// Audio settings toasts
 	MsgSettingsReconfiguringSoundLevel   = "notifications.content.settings.reconfiguringSoundLevel"
-	MsgSettingsAudioDeviceRestart        = "notifications.content.settings.audioDeviceRestartRequired"
+	MsgSettingsReconfiguringAudioSources = "notifications.content.settings.reconfiguringAudioSources"
 	MsgSettingsRebuildingExtendedCapture = "notifications.content.settings.rebuildingExtendedCapture"
 	MsgSettingsExtendedCaptureRestart    = "notifications.content.settings.extendedCaptureRestartRequired"
 	MsgSettingsEqualizerFailed           = "notifications.content.settings.equalizerUpdateFailed"


### PR DESCRIPTION
## Summary

- Replace the "restart required" warning toast for audio device changes with runtime reconfiguration
- Audio source settings (device, gain, model) changes now take effect immediately via the existing `reconfigureChangedSources()` diff pipeline
- Add `handleReconfigureAudioSources()` control monitor handler with `recover()` guard and quiet hours re-evaluation
- Update all 14 locale files with new "reconfiguring audio sources" message

## Details

The audiocore engine already had `ReconfigureSource()` and `ReconfigureDevice()` methods, and the `reconfigureChangedSources()` function already handled both RTSP streams and audio cards. The only missing piece was the signal wiring: `audioDeviceSettingChanged()` showed a "restart required" toast instead of dispatching a control signal.

This PR:
1. Dispatches `reconfigure_audio_sources` control signal when audio device settings change
2. Adds a handler that delegates to the same diff-based reconfiguration pipeline used for RTSP streams
3. Replaces the warning toast with an info toast ("Reconfiguring audio sources...")

Audio buffers are dropped during reconfiguration (by design — they are not valuable).

## Test Plan

- [x] `golangci-lint run -v` — zero issues
- [x] `go test -race ./internal/api/v2/... ./internal/analysis/... ./internal/notification/...` — all pass
- [x] `npm run check:all` — frontend checks pass
- [x] CodeRabbit local review — no findings
- [ ] Manual test: change sound card in Settings > Audio, verify reconfiguration without restart

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Audio device changes now trigger automatic reconfiguration of audio sources in-app instead of prompting the user to restart; notifications and toasts reflect an in-progress reconfiguration status.
  
* **Localization**
  * Updated translated notification strings across supported languages to replace "restart required" phrasing with "reconfiguring audio sources..." for the audio-settings/status message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->