### PR TITLE
feat(audio): apply per-source gain to capture pipeline

### DIFF
--- a/internal/analysis/audio_pipeline_service.go
+++ b/internal/analysis/audio_pipeline_service.go
@@ -429,10 +429,7 @@ func (p *AudioPipelineService) registerSoundLevelConsumers(sourceIDs []string, o
 	}
 	for _, sid := range sourceIDs {
 		// Look up per-source gain from the registry.
-		gainDB := 0.0
-		if src, found := p.engine.Registry().Get(sid); found {
-			gainDB = src.Gain
-		}
+		gainDB, _ := p.engine.Registry().GetGain(sid)
 
 		slProc, slErr := soundlevel.NewProcessor(sid, sid, conf.SampleRate, slInterval)
 		if slErr != nil {
@@ -504,10 +501,7 @@ func (p *AudioPipelineService) registerConsumersForSources(sourceIDs []string, s
 
 	for _, sid := range sourceIDs {
 		// Look up per-source gain from the registry.
-		gainDB := 0.0
-		if src, found := p.engine.Registry().Get(sid); found {
-			gainDB = src.Gain
-		}
+		gainDB, _ := p.engine.Registry().GetGain(sid)
 
 		// Resolve per-source model targets. Fall back to primary if the
 		// source has no configured models or none could be resolved.

--- a/internal/analysis/audio_pipeline_service.go
+++ b/internal/analysis/audio_pipeline_service.go
@@ -642,7 +642,7 @@ func (p *AudioPipelineService) reconfigureChangedSources(audioLevelChan chan aud
 					logger.Float64("old_gain_db", src.Gain),
 					logger.Float64("new_gain_db", scm.config.Gain),
 					logger.String("operation", "reconfigure_diff"))
-				src.Gain = scm.config.Gain
+				registry.UpdateGain(src.ID, scm.config.Gain)
 				gainChangedIDs = append(gainChangedIDs, src.ID)
 			}
 		} else {

--- a/internal/analysis/audio_pipeline_service.go
+++ b/internal/analysis/audio_pipeline_service.go
@@ -428,6 +428,12 @@ func (p *AudioPipelineService) registerSoundLevelConsumers(sourceIDs []string, o
 		slInterval = 10 // default 10-second aggregation window
 	}
 	for _, sid := range sourceIDs {
+		// Look up per-source gain from the registry.
+		gainDB := 0.0
+		if src, found := p.engine.Registry().Get(sid); found {
+			gainDB = src.Gain
+		}
+
 		slProc, slErr := soundlevel.NewProcessor(sid, sid, conf.SampleRate, slInterval)
 		if slErr != nil {
 			log.Warn("failed to create sound level processor",
@@ -444,7 +450,7 @@ func (p *AudioPipelineService) registerSoundLevelConsumers(sourceIDs []string, o
 				logger.String("operation", operation))
 			continue
 		}
-		if routeErr := p.engine.Router().AddRoute(sid, slc, conf.SampleRate, 0.0); routeErr != nil {
+		if routeErr := p.engine.Router().AddRoute(sid, slc, conf.SampleRate, gainDB); routeErr != nil {
 			log.Warn("failed to add sound level route",
 				logger.String("source_id", sid),
 				logger.Error(routeErr),
@@ -497,6 +503,12 @@ func (p *AudioPipelineService) registerConsumersForSources(sourceIDs []string, s
 	bufMgr := p.engine.BufferManager()
 
 	for _, sid := range sourceIDs {
+		// Look up per-source gain from the registry.
+		gainDB := 0.0
+		if src, found := p.engine.Registry().Get(sid); found {
+			gainDB = src.Gain
+		}
+
 		// Resolve per-source model targets. Fall back to primary if the
 		// source has no configured models or none could be resolved.
 		modelInfos := resolveModelTargets(sourceModelMap[sid], allModelInfos)
@@ -555,13 +567,13 @@ func (p *AudioPipelineService) registerConsumersForSources(sourceIDs []string, s
 				logger.String("source_id", sid), logger.Error(bcErr), logger.String("operation", operation))
 			continue
 		}
-		if routeErr := p.engine.Router().AddRoute(sid, bc, conf.SampleRate, 0.0); routeErr != nil {
+		if routeErr := p.engine.Router().AddRoute(sid, bc, conf.SampleRate, gainDB); routeErr != nil {
 			log.Warn("failed to add buffer route",
 				logger.String("source_id", sid), logger.Error(routeErr), logger.String("operation", operation))
 		}
 
 		alc, alcOutCh := NewAudioLevelConsumer("audio_level_"+sid, conf.SampleRate, conf.BitDepth, 1)
-		if routeErr := p.engine.Router().AddRoute(sid, alc, conf.SampleRate, 0.0); routeErr != nil {
+		if routeErr := p.engine.Router().AddRoute(sid, alc, conf.SampleRate, gainDB); routeErr != nil {
 			log.Warn("failed to add audio level route",
 				logger.String("source_id", sid), logger.Error(routeErr), logger.String("operation", operation))
 			continue

--- a/internal/analysis/audio_pipeline_service.go
+++ b/internal/analysis/audio_pipeline_service.go
@@ -526,6 +526,12 @@ func (p *AudioPipelineService) registerConsumersForSources(sourceIDs []string, s
 			if modelInfos[i].ID == primaryInfo.ID {
 				continue
 			}
+			// If the analysis buffer already exists (e.g., gain-only reconfigure),
+			// skip allocation and mark the model as usable.
+			if bufMgr.HasAnalysis(sid, modelInfos[i].ID) {
+				allocatedModels[modelInfos[i].ID] = true
+				continue
+			}
 			spec := modelInfos[i].Spec
 			clipBytes := spec.SampleRate * int(spec.ClipLength.Seconds()) * conf.NumChannels * (conf.BitDepth / 8)
 			overlapBytes := clipBytes / 2 // 50% overlap, matching primary model ratio

--- a/internal/analysis/audio_pipeline_service.go
+++ b/internal/analysis/audio_pipeline_service.go
@@ -444,7 +444,7 @@ func (p *AudioPipelineService) registerSoundLevelConsumers(sourceIDs []string, o
 				logger.String("operation", operation))
 			continue
 		}
-		if routeErr := p.engine.Router().AddRoute(sid, slc, conf.SampleRate); routeErr != nil {
+		if routeErr := p.engine.Router().AddRoute(sid, slc, conf.SampleRate, 0.0); routeErr != nil {
 			log.Warn("failed to add sound level route",
 				logger.String("source_id", sid),
 				logger.Error(routeErr),
@@ -555,13 +555,13 @@ func (p *AudioPipelineService) registerConsumersForSources(sourceIDs []string, s
 				logger.String("source_id", sid), logger.Error(bcErr), logger.String("operation", operation))
 			continue
 		}
-		if routeErr := p.engine.Router().AddRoute(sid, bc, conf.SampleRate); routeErr != nil {
+		if routeErr := p.engine.Router().AddRoute(sid, bc, conf.SampleRate, 0.0); routeErr != nil {
 			log.Warn("failed to add buffer route",
 				logger.String("source_id", sid), logger.Error(routeErr), logger.String("operation", operation))
 		}
 
 		alc, alcOutCh := NewAudioLevelConsumer("audio_level_"+sid, conf.SampleRate, conf.BitDepth, 1)
-		if routeErr := p.engine.Router().AddRoute(sid, alc, conf.SampleRate); routeErr != nil {
+		if routeErr := p.engine.Router().AddRoute(sid, alc, conf.SampleRate, 0.0); routeErr != nil {
 			log.Warn("failed to add audio level route",
 				logger.String("source_id", sid), logger.Error(routeErr), logger.String("operation", operation))
 			continue

--- a/internal/analysis/audio_pipeline_service.go
+++ b/internal/analysis/audio_pipeline_service.go
@@ -729,6 +729,7 @@ func (p *AudioPipelineService) buildSourceConfigsWithModels() []sourceConfigWith
 				SampleRate:       conf.SampleRate,
 				BitDepth:         conf.BitDepth,
 				Channels:         1,
+				Gain:             src.Gain,
 			},
 			modelIDs: src.Models,
 		})

--- a/internal/analysis/audio_pipeline_service.go
+++ b/internal/analysis/audio_pipeline_service.go
@@ -625,6 +625,7 @@ func (p *AudioPipelineService) reconfigureChangedSources(audioLevelChan chan aud
 	alreadyRunning := make(map[string]string) // connStr → sourceID (for sources that stay)
 	sourceModelMap := make(map[string][]string)
 	var newSourceIDs []string
+	var gainChangedIDs []string
 	var keptCount int
 
 	for connStr, scm := range desired {
@@ -633,6 +634,17 @@ func (p *AudioPipelineService) reconfigureChangedSources(audioLevelChan chan aud
 			alreadyRunning[connStr] = src.ID
 			sourceModelMap[src.ID] = scm.modelIDs
 			keptCount++
+
+			// Detect gain-only changes on kept sources.
+			if src.Gain != scm.config.Gain {
+				log.Info("gain changed for kept source, rebuilding routes",
+					logger.String("source_id", src.ID),
+					logger.Float64("old_gain_db", src.Gain),
+					logger.Float64("new_gain_db", scm.config.Gain),
+					logger.String("operation", "reconfigure_diff"))
+				src.Gain = scm.config.Gain
+				gainChangedIDs = append(gainChangedIDs, src.ID)
+			}
 		} else {
 			// New source — add it.
 			log.Info("adding new stream from config",
@@ -682,6 +694,17 @@ func (p *AudioPipelineService) reconfigureChangedSources(audioLevelChan chan aud
 		p.registerSoundLevelConsumers(newSourceIDs, "reconfigure_diff")
 	}
 
+	// Rebuild routes for sources whose gain changed. The capture device
+	// stays running — only the routes are torn down and re-created so
+	// drainRoute picks up the new gainLinear value.
+	if len(gainChangedIDs) > 0 {
+		for _, sid := range gainChangedIDs {
+			p.engine.Router().RemoveAllRoutes(sid)
+		}
+		p.registerConsumersForSources(gainChangedIDs, sourceModelMap, audioLevelChan, "gain_change")
+		p.registerSoundLevelConsumers(gainChangedIDs, "gain_change")
+	}
+
 	// Sync monitors for ALL active sources (kept + new) so UpdateMonitors
 	// receives the full desired state and removes stale monitors correctly.
 	allActiveIDs := slices.Collect(maps.Values(alreadyRunning))
@@ -697,6 +720,7 @@ func (p *AudioPipelineService) reconfigureChangedSources(audioLevelChan chan aud
 		logger.Int("kept", keptCount),
 		logger.Int("added", len(newSourceIDs)),
 		logger.Int("removed", removedCount),
+		logger.Int("gain_changed", len(gainChangedIDs)),
 		logger.String("operation", "reconfigure_diff"))
 }
 

--- a/internal/api/v2/audio_hls.go
+++ b/internal/api/v2/audio_hls.go
@@ -1532,8 +1532,15 @@ func (c *Controller) setupAudioCallback(sourceID string) (audioChan chan []byte,
 		channels: 1,
 	}
 
+	// Look up per-source gain from the registry so HLS listeners
+	// hear the same gain-adjusted audio as the analysis pipeline.
+	gainDB := 0.0
+	if src, found := c.engine.Registry().Get(sourceID); found {
+		gainDB = src.Gain
+	}
+
 	// Add route on the AudioRouter
-	if routeErr := c.engine.Router().AddRoute(sourceID, consumer, sampleRate, 0.0); routeErr != nil {
+	if routeErr := c.engine.Router().AddRoute(sourceID, consumer, sampleRate, gainDB); routeErr != nil {
 		return nil, nil, fmt.Errorf("failed to add HLS route: %w", routeErr)
 	}
 

--- a/internal/api/v2/audio_hls.go
+++ b/internal/api/v2/audio_hls.go
@@ -1533,7 +1533,7 @@ func (c *Controller) setupAudioCallback(sourceID string) (audioChan chan []byte,
 	}
 
 	// Add route on the AudioRouter
-	if routeErr := c.engine.Router().AddRoute(sourceID, consumer, sampleRate); routeErr != nil {
+	if routeErr := c.engine.Router().AddRoute(sourceID, consumer, sampleRate, 0.0); routeErr != nil {
 		return nil, nil, fmt.Errorf("failed to add HLS route: %w", routeErr)
 	}
 

--- a/internal/api/v2/audio_hls.go
+++ b/internal/api/v2/audio_hls.go
@@ -1534,10 +1534,7 @@ func (c *Controller) setupAudioCallback(sourceID string) (audioChan chan []byte,
 
 	// Look up per-source gain from the registry so HLS listeners
 	// hear the same gain-adjusted audio as the analysis pipeline.
-	gainDB := 0.0
-	if src, found := c.engine.Registry().Get(sourceID); found {
-		gainDB = src.Gain
-	}
+	gainDB, _ := c.engine.Registry().GetGain(sourceID)
 
 	// Add route on the AudioRouter
 	if routeErr := c.engine.Router().AddRoute(sourceID, consumer, sampleRate, gainDB); routeErr != nil {

--- a/internal/audiocore/buffer/manager.go
+++ b/internal/audiocore/buffer/manager.go
@@ -75,6 +75,15 @@ func (m *Manager) AllocateAnalysis(sourceID, modelID string, capacity, overlapSi
 	return nil
 }
 
+// HasAnalysis reports whether an analysis buffer has been allocated for
+// the given source and model pair. Safe for concurrent use.
+func (m *Manager) HasAnalysis(sourceID, modelID string) bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	_, exists := m.analysisBuffers[bufferKey{sourceID: sourceID, modelID: modelID}]
+	return exists
+}
+
 // AllocateCapture creates a CaptureBuffer for the given sourceID and stores it
 // in the Manager. Returns an error if a buffer for sourceID already exists or
 // if NewCaptureBuffer fails.

--- a/internal/audiocore/buffer/manager_test.go
+++ b/internal/audiocore/buffer/manager_test.go
@@ -228,6 +228,32 @@ func TestManager_AnalysisBuffers_ReturnsAllForSource(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// HasAnalysis tests
+// ---------------------------------------------------------------------------
+
+// TestManager_HasAnalysis verifies that HasAnalysis correctly reports whether
+// an analysis buffer has been allocated for a given (sourceID, modelID) pair.
+func TestManager_HasAnalysis(t *testing.T) {
+	t.Parallel()
+
+	m := buffer.NewManager(newTestLogger())
+
+	// Before allocation — should return false.
+	assert.False(t, m.HasAnalysis("source-1", "birdnet"))
+
+	// Allocate and check — should return true.
+	err := m.AllocateAnalysis("source-1", "birdnet", managerTestCapacity, managerTestOverlapSize, managerTestReadSize)
+	require.NoError(t, err)
+	assert.True(t, m.HasAnalysis("source-1", "birdnet"))
+
+	// Different model — should return false.
+	assert.False(t, m.HasAnalysis("source-1", "perch_v2"))
+
+	// Different source — should return false.
+	assert.False(t, m.HasAnalysis("source-2", "birdnet"))
+}
+
+// ---------------------------------------------------------------------------
 // Per-size Float32Pool tests
 // ---------------------------------------------------------------------------
 

--- a/internal/audiocore/router.go
+++ b/internal/audiocore/router.go
@@ -444,7 +444,8 @@ func (r *AudioRouter) drainRoute(route *Route) {
 				}
 			}
 			// Apply per-route gain when not unity (0 dB).
-			if route.gainLinear != 1.0 {
+			// Gain application requires 16-bit PCM; skip for other formats.
+			if route.gainLinear != 1.0 && frame.BitDepth == 16 {
 				gained, err := r.applyGain(frame, route)
 				if err != nil {
 					continue

--- a/internal/audiocore/router.go
+++ b/internal/audiocore/router.go
@@ -144,6 +144,11 @@ func (r *AudioRouter) AddRoute(sourceID string, consumer AudioConsumer, sourceSa
 		return fmt.Errorf("%w: source=%s consumer=%s", ErrRouteExists, sourceID, consumer.ID())
 	}
 
+	// Reject NaN/Inf gain values before conversion.
+	if math.IsNaN(gainDB) || math.IsInf(gainDB, 0) {
+		return fmt.Errorf("invalid gain value for source=%s consumer=%s: %f", sourceID, consumer.ID(), gainDB)
+	}
+
 	// Convert dB to linear gain. 0 dB -> 1.0 (no change).
 	gainLinear := math.Pow(10, gainDB/20)
 

--- a/internal/audiocore/router.go
+++ b/internal/audiocore/router.go
@@ -4,6 +4,7 @@ package audiocore
 import (
 	"context"
 	"fmt"
+	"math"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -45,6 +46,10 @@ type Route struct {
 
 	// sourceSampleRate is the sample rate of the source producing frames.
 	sourceSampleRate int
+
+	// gainLinear is the linear gain multiplier derived from the dB value.
+	// 1.0 means no gain (0 dB). Set at route creation time and immutable.
+	gainLinear float64
 
 	// resampler converts source-rate PCM to the consumer's expected rate.
 	// Nil when no rate conversion is required.
@@ -121,7 +126,7 @@ func NewAudioRouter(log logger.Logger) *AudioRouter {
 // the consumer ID for logging, metrics, and route lookup. Duplicate IDs on
 // different sources will not cause an error but may produce confusing log
 // output and make RemoveRoute ambiguous.
-func (r *AudioRouter) AddRoute(sourceID string, consumer AudioConsumer, sourceSampleRate int) error {
+func (r *AudioRouter) AddRoute(sourceID string, consumer AudioConsumer, sourceSampleRate int, gainDB float64) error {
 	// Reject routes after the router has been closed.
 	if r.ctx.Err() != nil {
 		return fmt.Errorf("router is closed: %w", r.ctx.Err())
@@ -138,10 +143,14 @@ func (r *AudioRouter) AddRoute(sourceID string, consumer AudioConsumer, sourceSa
 		return fmt.Errorf("%w: source=%s consumer=%s", ErrRouteExists, sourceID, consumer.ID())
 	}
 
+	// Convert dB to linear gain. 0 dB -> 1.0 (no change).
+	gainLinear := math.Pow(10, gainDB/20)
+
 	route := &Route{
 		SourceID:         sourceID,
 		Consumer:         consumer,
 		sourceSampleRate: sourceSampleRate,
+		gainLinear:       gainLinear,
 		inbox:            make(chan AudioFrame, routeInboxCapacity),
 		done:             make(chan struct{}),
 		stopped:          make(chan struct{}),

--- a/internal/audiocore/router.go
+++ b/internal/audiocore/router.go
@@ -9,6 +9,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/tphakala/birdnet-go/internal/audiocore/convert"
 	"github.com/tphakala/birdnet-go/internal/audiocore/resample"
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/logger"
@@ -437,6 +438,14 @@ func (r *AudioRouter) drainRoute(route *Route) {
 					Timestamp:  frame.Timestamp,
 				}
 			}
+			// Apply per-route gain when not unity (0 dB).
+			if route.gainLinear != 1.0 {
+				gained, err := r.applyGain(frame, route)
+				if err != nil {
+					continue
+				}
+				frame = gained
+			}
 			if err := route.Consumer.Write(frame); err != nil {
 				errCount := route.errors.Add(1)
 				if errCount%errorLogInterval == 1 {
@@ -453,4 +462,33 @@ func (r *AudioRouter) drainRoute(route *Route) {
 			return
 		}
 	}
+}
+
+// applyGain scales the PCM data in frame by the route's linear gain multiplier.
+// It converts S16 PCM bytes to float64, scales via SIMD, and converts back with
+// clamping. Returns the modified frame or an error if the back-conversion fails.
+func (r *AudioRouter) applyGain(frame AudioFrame, route *Route) (AudioFrame, error) { //nolint:gocritic // hugeParam: AudioFrame is large but copying is intentional
+	floats := convert.BytesToFloat64PCM16(frame.Data)
+	convert.ScaleFloat64Slice(floats, route.gainLinear)
+	out := make([]byte, len(floats)*2)
+	if err := convert.Float64ToBytesPCM16(floats, out); err != nil {
+		errCount := route.errors.Add(1)
+		if errCount%errorLogInterval == 1 {
+			r.log.Warn("gain conversion error",
+				logger.String("source_id", route.SourceID),
+				logger.String("consumer_id", route.Consumer.ID()),
+				logger.Int64("total_errors", errCount),
+				logger.Error(err))
+		}
+		return AudioFrame{}, err
+	}
+	return AudioFrame{
+		SourceID:   frame.SourceID,
+		SourceName: frame.SourceName,
+		Data:       out,
+		SampleRate: frame.SampleRate,
+		BitDepth:   frame.BitDepth,
+		Channels:   frame.Channels,
+		Timestamp:  frame.Timestamp,
+	}, nil
 }

--- a/internal/audiocore/router_test.go
+++ b/internal/audiocore/router_test.go
@@ -362,6 +362,130 @@ func (c *panicOnWriteConsumer) Write(_ AudioFrame) error { //nolint:gocritic // 
 	panic("consumer exploded")
 }
 
+// TestRouter_DrainRouteAppliesGain verifies that per-route gain amplifies,
+// attenuates, or leaves audio data unchanged depending on the dB value.
+func TestRouter_DrainRouteAppliesGain(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		gainDB     float64
+		inputPCM   []int16
+		wantScaled bool // true if output should differ from input
+	}{
+		{
+			name:       "positive_gain_amplifies",
+			gainDB:     6.0,
+			inputPCM:   []int16{1000, -1000, 500, -500},
+			wantScaled: true,
+		},
+		{
+			name:       "negative_gain_attenuates",
+			gainDB:     -6.0,
+			inputPCM:   []int16{1000, -1000, 500, -500},
+			wantScaled: true,
+		},
+		{
+			name:       "zero_gain_no_change",
+			gainDB:     0.0,
+			inputPCM:   []int16{1000, -1000, 500, -500},
+			wantScaled: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			router := NewAudioRouter(GetLogger())
+			defer router.Close()
+
+			consumer := newMockConsumer("c1")
+			err := router.AddRoute("src-1", consumer, 48000, tt.gainDB)
+			require.NoError(t, err)
+
+			// Build PCM byte data from int16 samples.
+			inputBytes := make([]byte, len(tt.inputPCM)*2)
+			for i, s := range tt.inputPCM {
+				inputBytes[i*2] = byte(s)
+				inputBytes[i*2+1] = byte(s >> 8)
+			}
+
+			router.Dispatch(AudioFrame{
+				SourceID:   "src-1",
+				SourceName: "Test",
+				Data:       inputBytes,
+				SampleRate: 48000,
+				BitDepth:   16,
+				Channels:   1,
+			})
+
+			var received AudioFrame
+			select {
+			case received = <-consumer.frames:
+			case <-time.After(2 * time.Second):
+				t.Fatal("timed out waiting for frame")
+			}
+
+			if tt.wantScaled {
+				assert.NotEqual(t, inputBytes, received.Data,
+					"gain %.1f dB should change the audio data", tt.gainDB)
+			} else {
+				assert.Equal(t, inputBytes, received.Data,
+					"0 dB gain should leave audio data unchanged")
+			}
+		})
+	}
+}
+
+// TestRouter_GainClipping verifies that high gain correctly clips signals
+// to the int16 range rather than producing corrupted output.
+func TestRouter_GainClipping(t *testing.T) {
+	t.Parallel()
+
+	router := NewAudioRouter(GetLogger())
+	defer router.Close()
+
+	consumer := newMockConsumer("c1")
+	// +40 dB is 100x linear — will clip a signal near max.
+	err := router.AddRoute("src-1", consumer, 48000, 40.0)
+	require.NoError(t, err)
+
+	// Input: near-max signal (30000 out of 32767).
+	inputPCM := []int16{30000, -30000}
+	inputBytes := make([]byte, len(inputPCM)*2)
+	for i, s := range inputPCM {
+		inputBytes[i*2] = byte(s)
+		inputBytes[i*2+1] = byte(s >> 8)
+	}
+
+	router.Dispatch(AudioFrame{
+		SourceID:   "src-1",
+		SourceName: "Test",
+		Data:       inputBytes,
+		SampleRate: 48000,
+		BitDepth:   16,
+		Channels:   1,
+	})
+
+	var received AudioFrame
+	select {
+	case received = <-consumer.frames:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for frame")
+	}
+
+	// Verify output is clipped to max int16 range, not corrupted.
+	require.Len(t, received.Data, 4)
+	sample0 := int16(received.Data[0]) | int16(received.Data[1])<<8
+	sample1 := int16(received.Data[2]) | int16(received.Data[3])<<8
+
+	// Float64ToBytesPCM16 clamps to [-1.0, 1.0] before conversion,
+	// so output should be at or near ±32767.
+	assert.InDelta(t, 32767, int(sample0), 1, "positive sample should clip to max")
+	assert.InDelta(t, -32767, int(sample1), 1, "negative sample should clip to min")
+}
+
 // TestRouter_AddRouteWithGain verifies that AddRoute correctly converts
 // a dB gain value to the corresponding linear multiplier and stores it
 // on the Route.

--- a/internal/audiocore/router_test.go
+++ b/internal/audiocore/router_test.go
@@ -87,7 +87,7 @@ func TestRouter_AddAndRemoveRoute(t *testing.T) {
 
 	consumer := newMockConsumer("consumer-1")
 
-	err := router.AddRoute("src-1", consumer, 48000)
+	err := router.AddRoute("src-1", consumer, 48000, 0.0)
 	require.NoError(t, err)
 	assert.True(t, router.HasConsumers("src-1"))
 
@@ -104,7 +104,7 @@ func TestRouter_DispatchSingleConsumer(t *testing.T) {
 	t.Cleanup(func() { router.Close() })
 
 	consumer := newMockConsumer("consumer-1")
-	err := router.AddRoute("src-1", consumer, 48000)
+	err := router.AddRoute("src-1", consumer, 48000, 0.0)
 	require.NoError(t, err)
 
 	frame := testFrame("src-1")
@@ -129,8 +129,8 @@ func TestRouter_DispatchFanOut(t *testing.T) {
 	c1 := newMockConsumer("consumer-1")
 	c2 := newMockConsumer("consumer-2")
 
-	require.NoError(t, router.AddRoute("src-1", c1, 48000))
-	require.NoError(t, router.AddRoute("src-1", c2, 48000))
+	require.NoError(t, router.AddRoute("src-1", c1, 48000, 0.0))
+	require.NoError(t, router.AddRoute("src-1", c2, 48000, 0.0))
 
 	frame := testFrame("src-1")
 	router.Dispatch(frame)
@@ -166,7 +166,7 @@ func TestRouter_DropOnFullInbox(t *testing.T) {
 	t.Cleanup(func() { router.Close() })
 
 	consumer := newBlockingConsumer("slow-consumer")
-	require.NoError(t, router.AddRoute("src-1", consumer, 48000))
+	require.NoError(t, router.AddRoute("src-1", consumer, 48000, 0.0))
 
 	// Fill the inbox buffer (capacity 64) plus extra to guarantee drops.
 	const totalFrames = 128
@@ -190,8 +190,8 @@ func TestRouter_RemoveAllRoutes(t *testing.T) {
 	c1 := newMockConsumer("consumer-1")
 	c2 := newMockConsumer("consumer-2")
 
-	require.NoError(t, router.AddRoute("src-1", c1, 48000))
-	require.NoError(t, router.AddRoute("src-1", c2, 48000))
+	require.NoError(t, router.AddRoute("src-1", c1, 48000, 0.0))
+	require.NoError(t, router.AddRoute("src-1", c2, 48000, 0.0))
 	assert.True(t, router.HasConsumers("src-1"))
 
 	router.RemoveAllRoutes("src-1")
@@ -210,9 +210,9 @@ func TestRouter_DuplicateRouteError(t *testing.T) {
 	c1 := newMockConsumer("consumer-1")
 	c2 := newMockConsumer("consumer-1") // same ID
 
-	require.NoError(t, router.AddRoute("src-1", c1, 48000))
+	require.NoError(t, router.AddRoute("src-1", c1, 48000, 0.0))
 
-	err := router.AddRoute("src-1", c2, 48000)
+	err := router.AddRoute("src-1", c2, 48000, 0.0)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrRouteExists)
 }
@@ -231,7 +231,7 @@ func TestRouter_DispatchWithResampling(t *testing.T) {
 	consumer.sampleRate = 32000
 
 	// Add route with source at 48kHz.
-	err := router.AddRoute("src-resample", consumer, 48000)
+	err := router.AddRoute("src-resample", consumer, 48000, 0.0)
 	require.NoError(t, err)
 
 	// Build a 48kHz frame with 4800 samples (100 ms of 16-bit PCM, 9600 bytes).
@@ -285,8 +285,8 @@ func TestRouter_ConcurrentDispatch(t *testing.T) {
 
 	c1 := newMockConsumer("consumer-1")
 	c2 := newMockConsumer("consumer-2")
-	require.NoError(t, router.AddRoute("src-1", c1, 48000))
-	require.NoError(t, router.AddRoute("src-1", c2, 48000))
+	require.NoError(t, router.AddRoute("src-1", c1, 48000, 0.0))
+	require.NoError(t, router.AddRoute("src-1", c2, 48000, 0.0))
 
 	const goroutines = 8
 	const framesPerGoroutine = 100
@@ -326,7 +326,7 @@ func TestDrainRoutePanicRecovery(t *testing.T) {
 		sampleRate: 48000,
 	}
 
-	err := router.AddRoute("src1", panicConsumer, 48000)
+	err := router.AddRoute("src1", panicConsumer, 48000, 0.0)
 	require.NoError(t, err)
 
 	// Dispatch a frame — the consumer will panic on Write.
@@ -360,4 +360,37 @@ func (c *panicOnWriteConsumer) Channels() int   { return 1 }
 func (c *panicOnWriteConsumer) Close() error    { return nil }
 func (c *panicOnWriteConsumer) Write(_ AudioFrame) error { //nolint:gocritic // hugeParam: signature required by AudioConsumer interface
 	panic("consumer exploded")
+}
+
+// TestRouter_AddRouteWithGain verifies that AddRoute correctly converts
+// a dB gain value to the corresponding linear multiplier and stores it
+// on the Route.
+func TestRouter_AddRouteWithGain(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name       string
+		gainDB     float64
+		wantLinear float64
+	}{
+		{"zero_dB_no_change", 0.0, 1.0},
+		{"positive_6dB", 6.0, 1.9953},
+		{"negative_6dB", -6.0, 0.5012},
+		{"max_40dB", 40.0, 100.0},
+		{"min_neg40dB", -40.0, 0.01},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			router := NewAudioRouter(GetLogger())
+			t.Cleanup(func() { router.Close() })
+			consumer := newMockConsumer("c1")
+			err := router.AddRoute("src-1", consumer, 48000, tt.gainDB)
+			require.NoError(t, err)
+			router.mu.RLock()
+			routes := router.routes["src-1"]
+			require.Len(t, routes, 1)
+			assert.InDelta(t, tt.wantLinear, routes[0].gainLinear, 0.01)
+			router.mu.RUnlock()
+		})
+	}
 }

--- a/internal/audiocore/source.go
+++ b/internal/audiocore/source.go
@@ -109,6 +109,9 @@ type AudioSource struct {
 	// Channels is the number of capture channels (e.g., 1 for mono).
 	Channels int `json:"channels"`
 
+	// Gain is the configured input gain in dB. 0 means no adjustment.
+	Gain float64 `json:"gain"`
+
 	// State is the current operational state of the source.
 	State SourceState `json:"state"`
 
@@ -196,4 +199,8 @@ type SourceConfig struct {
 
 	// Channels is the desired number of capture channels.
 	Channels int
+
+	// Gain is the input gain adjustment in dB. 0 means no adjustment.
+	// Positive values amplify, negative values attenuate.
+	Gain float64
 }

--- a/internal/audiocore/source_registry.go
+++ b/internal/audiocore/source_registry.go
@@ -239,6 +239,19 @@ func (r *SourceRegistry) UpdateState(sourceID string, state SourceState) error {
 	return nil
 }
 
+// UpdateGain updates the Gain field of the source with the given ID.
+// Returns false if the source does not exist.
+func (r *SourceRegistry) UpdateGain(sourceID string, gain float64) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	src, ok := r.sources[sourceID]
+	if !ok {
+		return false
+	}
+	src.Gain = gain
+	return true
+}
+
 // AddListener registers a callback that is called for every SourceEvent.
 // Callbacks are invoked synchronously; they must not block.
 func (r *SourceRegistry) AddListener(l SourceEventListener) {

--- a/internal/audiocore/source_registry.go
+++ b/internal/audiocore/source_registry.go
@@ -134,6 +134,7 @@ func (r *SourceRegistry) Register(cfg *SourceConfig) (*AudioSource, error) {
 		SampleRate:   cfg.SampleRate,
 		BitDepth:     cfg.BitDepth,
 		Channels:     cfg.Channels,
+		Gain:         cfg.Gain,
 		State:        SourceInactive,
 		RegisteredAt: time.Now(),
 		LastSeen:     time.Now(),

--- a/internal/audiocore/source_registry.go
+++ b/internal/audiocore/source_registry.go
@@ -252,6 +252,18 @@ func (r *SourceRegistry) UpdateGain(sourceID string, gain float64) bool {
 	return true
 }
 
+// GetGain returns the current gain (in dB) for the given source, under
+// the registry read lock. Returns 0.0 and false if the source does not exist.
+func (r *SourceRegistry) GetGain(sourceID string) (float64, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	src, ok := r.sources[sourceID]
+	if !ok {
+		return 0.0, false
+	}
+	return src.Gain, true
+}
+
 // AddListener registers a callback that is called for every SourceEvent.
 // Callbacks are invoked synchronously; they must not block.
 func (r *SourceRegistry) AddListener(l SourceEventListener) {

--- a/internal/audiocore/source_registry_test.go
+++ b/internal/audiocore/source_registry_test.go
@@ -231,6 +231,45 @@ func TestSourceRegistry_ConcurrentAccess(t *testing.T) {
 	assert.LessOrEqual(t, len(list), goroutines)
 }
 
+// TestSourceRegistry_RegisterCopiesGain verifies that the Gain field from SourceConfig
+// is correctly copied into the registered AudioSource.
+func TestSourceRegistry_RegisterCopiesGain(t *testing.T) {
+	t.Parallel()
+	r := newTestRegistry(t)
+
+	cfg := &SourceConfig{
+		ConnectionString: "hw:1,0",
+		Type:             SourceTypeAudioCard,
+		SampleRate:       48000,
+		BitDepth:         16,
+		Channels:         1,
+		Gain:             6.5,
+	}
+
+	src, err := r.Register(cfg)
+	require.NoError(t, err)
+	require.NotNil(t, src)
+	assert.InDelta(t, 6.5, src.Gain, 1e-9, "registered AudioSource.Gain must match SourceConfig.Gain")
+}
+
+// TestSourceRegistry_RegisterDefaultGain verifies that Gain defaults to 0 when not set.
+func TestSourceRegistry_RegisterDefaultGain(t *testing.T) {
+	t.Parallel()
+	r := newTestRegistry(t)
+
+	cfg := &SourceConfig{
+		ConnectionString: "rtsp://192.168.1.50/stream",
+		SampleRate:       48000,
+		BitDepth:         16,
+		Channels:         1,
+	}
+
+	src, err := r.Register(cfg)
+	require.NoError(t, err)
+	require.NotNil(t, src)
+	assert.InDelta(t, 0.0, src.Gain, 1e-9, "Gain should default to 0 when not specified")
+}
+
 // TestSourceRegistry_TypeDetection verifies that source types are detected from connection strings.
 func TestSourceRegistry_TypeDetection(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Summary

- Wire per-source audio gain (dB) from config through `SourceConfig` → `AudioSource` → `Route` in the audio router, applying it in `drainRoute()` after resampling using SIMD-accelerated conversion (BytesToFloat64PCM16 → ScaleFloat64Slice → Float64ToBytesPCM16 with clamping)
- 0 dB fast path skips all conversion; gain is immutable per route and thread-safe
- Hot-reload: `reconfigureChangedSources()` detects gain changes on kept sources, tears down routes, and re-registers consumers with new gain — capture device stays running
- HLS listeners also receive gain-adjusted audio via registry lookup
- `HasAnalysis` buffer helper prevents duplicate allocation during gain-only reconfigure
- Race condition fix: `UpdateGain()` method on SourceRegistry uses write lock for safe mutation

## Test Plan

- [x] `TestSourceRegistry_RegisterCopiesGain` / `RegisterDefaultGain` — verify Gain propagation through registry
- [x] `TestRouter_AddRouteWithGain` — 5-case table test for dB→linear conversion (0, ±6, ±40 dB)
- [x] `TestRouter_DrainRouteAppliesGain` — verify amplification, attenuation, and 0 dB no-op
- [x] `TestRouter_GainClipping` — verify +40 dB on near-max signal clips to ±32767
- [x] `TestManager_HasAnalysis` — verify buffer existence check
- [x] Full test suite passes with `-race` flag
- [x] `golangci-lint run -v` — zero issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Per-source input gain control: set independent gain (dB) per audio source.
  * Hot reconfiguration: gain updates apply to running sources without tearing down captures.

* **Bug Fixes**
  * Safer per-route gain scaling to avoid audio corruption and ensure proper clipping.

* **Tests**
  * Added coverage for per-source gain behavior and buffer analysis presence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->