### PR TITLE
feat(api/v2): server-side live spectrogram SSE stream with axes, color-map persistence, and extended-capture fix

### DIFF
--- a/frontend/src/lib/desktop/components/media/SpectrogramCanvas.svelte
+++ b/frontend/src/lib/desktop/components/media/SpectrogramCanvas.svelte
@@ -96,8 +96,15 @@
   // CSS pixel dimensions (from ResizeObserver)
   let cssWidth = $state(800);
   let cssHeight = $state(300);
-  let queuedStreamColumns = $state<LiveSpectrogramColumn[]>([]);
-  let lastQueuedStreamUnixMs = $state(0);
+  // Non-reactive FIFO queue of pending stream columns. Held as a plain array
+  // with an integer head index so the animation loop can dequeue in O(1)
+  // instead of calling queuedStreamColumns.slice(1) on every drained column.
+  // Only the feed $effect and the animation loop touch these — neither path
+  // needs Svelte reactivity on this buffer.
+  let queuedStreamColumns: LiveSpectrogramColumn[] = [];
+  let queuedStreamHead = 0;
+  let lastQueuedStreamUnixMs = 0;
+  const QUEUED_STREAM_COMPACT_THRESHOLD = 256;
 
   // DPR tracking
   let dpr = $state(globalThis.devicePixelRatio ?? 1);
@@ -174,21 +181,24 @@
 
   function aggregateStreamColumns(
     columns: Array<number[] | Uint8Array<ArrayBuffer>>,
-    binCount: number
+    binCount: number,
+    start = 0,
+    end: number = columns.length
   ): Uint8Array<ArrayBuffer> {
     const aggregated = new Uint8Array(binCount);
-    if (columns.length === 0) return aggregated;
+    const count = end - start;
+    if (count <= 0) return aggregated;
 
     for (let bin = 0; bin < binCount; bin++) {
       let totalValue = 0;
-      for (const column of columns) {
-        /* eslint-disable security/detect-object-injection -- bin is a bounded loop index for dense FFT column arrays */
-        const value = column[bin] ?? 0;
+      for (let i = start; i < end; i++) {
+        /* eslint-disable security/detect-object-injection -- bin and i are bounded loop indices for dense FFT column arrays */
+        const value = columns[i][bin] ?? 0;
         /* eslint-enable security/detect-object-injection */
         totalValue += value;
       }
       /* eslint-disable security/detect-object-injection -- bin is a bounded loop index for dense FFT column arrays */
-      aggregated[bin] = Math.round(totalValue / columns.length);
+      aggregated[bin] = Math.round(totalValue / count);
       /* eslint-enable security/detect-object-injection */
     }
 
@@ -197,24 +207,37 @@
 
   $effect(() => {
     if (renderMode !== 'stream') {
-      queuedStreamColumns = [];
+      queuedStreamColumns.length = 0;
+      queuedStreamHead = 0;
       lastQueuedStreamUnixMs = 0;
       return;
     }
 
-    const nextColumns: LiveSpectrogramColumn[] = [];
+    let appended = 0;
     for (const column of streamColumns) {
       if (column.tUnixMs > lastQueuedStreamUnixMs) {
-        nextColumns.push(column);
+        queuedStreamColumns.push(column);
+        lastQueuedStreamUnixMs = column.tUnixMs;
+        appended++;
       }
     }
-    if (nextColumns.length === 0) return;
+    if (appended === 0) return;
 
-    queuedStreamColumns = [...queuedStreamColumns, ...nextColumns];
-    lastQueuedStreamUnixMs = nextColumns[nextColumns.length - 1].tUnixMs;
+    // Cap the queue to prevent unbounded growth if the animation loop
+    // stops draining (e.g., tab backgrounded). Trim from the unread head.
+    const live = queuedStreamColumns.length - queuedStreamHead;
+    if (live > 4096) {
+      queuedStreamHead += live - 4096;
+    }
 
-    if (queuedStreamColumns.length > 4096) {
-      queuedStreamColumns = queuedStreamColumns.slice(-4096);
+    // Periodically compact when the head has advanced far enough that
+    // the prefix of already-consumed columns dominates the array.
+    if (
+      queuedStreamHead > QUEUED_STREAM_COMPACT_THRESHOLD &&
+      queuedStreamHead * 2 > queuedStreamColumns.length
+    ) {
+      queuedStreamColumns = queuedStreamColumns.slice(queuedStreamHead);
+      queuedStreamHead = 0;
     }
   });
 
@@ -340,7 +363,11 @@
     // Track whether overlay was drawn last frame to avoid clearing an already-empty canvas
     let overlayHadContent = false;
     let lastStreamBins: number[] | Uint8Array<ArrayBuffer> | null = null;
+    // Head-indexed FIFO of FFT columns ready to paint. Append via push(),
+    // consume via head++ to avoid O(N) slice() calls per dequeue.
     let renderReadyColumns: Array<number[] | Uint8Array<ArrayBuffer>> = [];
+    let renderReadyHead = 0;
+    const RENDER_READY_COMPACT_THRESHOLD = 256;
     let streamColumnAccumulator = 0;
     let hasRenderedStreamColumns = false;
     let clearedStreamPrimingCanvas = false;
@@ -385,22 +412,37 @@
 
       if (renderMode === 'analyser') {
         analyser?.getByteFrequencyData(frequencyData);
-      } else if (queuedStreamColumns.length > 0) {
+      } else if (queuedStreamColumns.length - queuedStreamHead > 0) {
         const playheadUnixMs = wallClockAtPlayhead > 0 ? Math.floor(wallClockAtPlayhead * 1000) : 0;
 
+        // O(1) head-index dequeue — no slice() copies per column.
+        /* eslint-disable security/detect-object-injection -- queuedStreamHead is a monotonic index into an internal FIFO */
         while (
-          queuedStreamColumns.length > 0 &&
+          queuedStreamHead < queuedStreamColumns.length &&
           playheadUnixMs > 0 &&
-          queuedStreamColumns[0].tUnixMs <= playheadUnixMs
+          queuedStreamColumns[queuedStreamHead].tUnixMs <= playheadUnixMs
         ) {
-          dueStreamColumns.push(queuedStreamColumns[0]);
-          queuedStreamColumns = queuedStreamColumns.slice(1);
+          dueStreamColumns.push(queuedStreamColumns[queuedStreamHead]);
+          queuedStreamHead++;
+        }
+        /* eslint-enable security/detect-object-injection */
+        // Compact opportunistically once the consumed prefix is large
+        // enough to make the one-shot copy worth it.
+        if (
+          queuedStreamHead > QUEUED_STREAM_COMPACT_THRESHOLD &&
+          queuedStreamHead * 2 > queuedStreamColumns.length
+        ) {
+          queuedStreamColumns = queuedStreamColumns.slice(queuedStreamHead);
+          queuedStreamHead = 0;
         }
         if (dueStreamColumns.length > 0) {
           const dueBins = dueStreamColumns.map(column => column.bins);
           renderReadyColumns.push(...dueBins);
-          if (renderReadyColumns.length > MAX_RENDER_READY_COLUMNS) {
-            renderReadyColumns = renderReadyColumns.slice(-MAX_RENDER_READY_COLUMNS);
+          // Trim from the unread head instead of slicing — matches the
+          // queuedStreamColumns head-index pattern below.
+          const renderLive = renderReadyColumns.length - renderReadyHead;
+          if (renderLive > MAX_RENDER_READY_COLUMNS) {
+            renderReadyHead += renderLive - MAX_RENDER_READY_COLUMNS;
           }
           lastStreamBins = dueBins[dueBins.length - 1];
         }
@@ -483,31 +525,40 @@
             streamColumnAccumulator -= columnsToConsume;
           }
 
-          if (renderReadyColumns.length > 0 && columnsToConsume === 0) {
+          const renderReadyAvailable = renderReadyColumns.length - renderReadyHead;
+          if (renderReadyAvailable > 0 && columnsToConsume === 0) {
             columnsToConsume = 1;
           }
 
-          if (columnsToConsume > renderReadyColumns.length) {
-            columnsToConsume = renderReadyColumns.length;
+          if (columnsToConsume > renderReadyAvailable) {
+            columnsToConsume = renderReadyAvailable;
           }
 
           if (columnsToConsume > 0) {
             if (!hasRenderedStreamColumns) {
               pixelsToScroll = Math.min(pixelsToScroll, Math.max(1, columnsToConsume));
             }
-            const consumedColumns = renderReadyColumns.slice(0, columnsToConsume);
-            renderReadyColumns = renderReadyColumns.slice(columnsToConsume);
+            // View slice against the live head; advance head without copying.
+            const consumeStart = renderReadyHead;
+            const consumeEnd = renderReadyHead + columnsToConsume;
+            renderReadyHead = consumeEnd;
             hasRenderedStreamColumns = true;
             clearedStreamPrimingCanvas = false;
-            const columnsPerPixel = consumedColumns.length / pixelsToScroll;
+            const columnsPerPixel = columnsToConsume / pixelsToScroll;
 
             for (let col = 0; col < pixelsToScroll; col++) {
-              const start = Math.floor(col * columnsPerPixel);
-              const end = Math.max(start + 1, Math.floor((col + 1) * columnsPerPixel));
-              const slice = consumedColumns.slice(start, end);
+              const offsetStart = Math.floor(col * columnsPerPixel);
+              const offsetEnd = Math.max(offsetStart + 1, Math.floor((col + 1) * columnsPerPixel));
+              const sliceStart = consumeStart + offsetStart;
+              const sliceEnd = Math.min(consumeStart + offsetEnd, consumeEnd);
               streamPixels.push(
-                slice.length > 0
-                  ? aggregateStreamColumns(slice, frequencyData.length)
+                sliceEnd > sliceStart
+                  ? aggregateStreamColumns(
+                      renderReadyColumns,
+                      frequencyData.length,
+                      sliceStart,
+                      sliceEnd
+                    )
                   : (lastStreamBins ?? [])
               );
             }
@@ -515,6 +566,17 @@
             for (let col = 0; col < pixelsToScroll; col++) {
               streamPixels.push(lastStreamBins);
             }
+          }
+
+          // Compact the ready-column buffer once the consumed prefix
+          // dominates the backing array. Amortised O(1) per column since
+          // compaction only runs at threshold * 2 intervals.
+          if (
+            renderReadyHead > RENDER_READY_COMPACT_THRESHOLD &&
+            renderReadyHead * 2 > renderReadyColumns.length
+          ) {
+            renderReadyColumns = renderReadyColumns.slice(renderReadyHead);
+            renderReadyHead = 0;
           }
         }
 

--- a/frontend/src/lib/desktop/components/media/SpectrogramCanvas.svelte
+++ b/frontend/src/lib/desktop/components/media/SpectrogramCanvas.svelte
@@ -546,6 +546,16 @@
             clearedStreamPrimingCanvas = false;
             const columnsPerPixel = columnsToConsume / pixelsToScroll;
 
+            // In stream mode the bin count is dictated by the server's FFT
+            // size (streamed via the spectrogram-meta event and forwarded
+            // into the fftSize prop), not by frequencyData.length — which
+            // is fixed at the client's AnalyserNode fftSize/2 and exists
+            // only for the analyser-mode render path. If the server is
+            // configured with fftSize != 1024 the two numbers differ and
+            // aggregation would truncate the output, leaving the extra
+            // bins undefined and producing black unrendered bands in the
+            // waterfall (sentry-io flagged this on PR #2745).
+            const streamBinCount = fftSize / 2;
             for (let col = 0; col < pixelsToScroll; col++) {
               const offsetStart = Math.floor(col * columnsPerPixel);
               const offsetEnd = Math.max(offsetStart + 1, Math.floor((col + 1) * columnsPerPixel));
@@ -553,12 +563,7 @@
               const sliceEnd = Math.min(consumeStart + offsetEnd, consumeEnd);
               streamPixels.push(
                 sliceEnd > sliceStart
-                  ? aggregateStreamColumns(
-                      renderReadyColumns,
-                      frequencyData.length,
-                      sliceStart,
-                      sliceEnd
-                    )
+                  ? aggregateStreamColumns(renderReadyColumns, streamBinCount, sliceStart, sliceEnd)
                   : (lastStreamBins ?? [])
               );
             }

--- a/frontend/src/lib/desktop/components/media/SpectrogramCanvas.svelte
+++ b/frontend/src/lib/desktop/components/media/SpectrogramCanvas.svelte
@@ -496,7 +496,12 @@
         const w = plotWidth;
         const h = plotHeight;
 
-        // Self-blit: shift existing content left (GPU-composited)
+        // Self-blit: shift existing content left (GPU-composited).
+        // Always uses pixelsToScroll (not drawColumns below) so the
+        // canvas shift matches the logical scroll distance. This branch
+        // is mutually exclusive with the drawColumns clamp below: the
+        // clamp only runs when !hasRenderedStreamColumns, which is the
+        // same condition that skips the blit on the first priming frame.
         if (hasRenderedStreamColumns || renderMode === 'analyser') {
           ctx.drawImage(
             canvasEl!,
@@ -511,9 +516,18 @@
           );
         }
 
-        // Draw new column(s) at right edge using device pixel dimensions
-        const imgData = ctx.createImageData(pixelsToScroll, h);
-        const data = imgData.data;
+        // drawColumns is the final width of the new-content strip we
+        // draw at the right edge. Defaults to pixelsToScroll but may
+        // be clamped smaller below on priming frames when
+        // columnsToConsume < pixelsToScroll. All ImageData allocation,
+        // indexing, and placement below use drawColumns so the buffer
+        // stride always matches the loop's actual write width —
+        // previously the buffer was allocated with pixelsToScroll BEFORE
+        // the clamp and then indexed with the clamped value afterwards,
+        // producing a stride/offset mismatch that corrupted pixels on
+        // the very first frame with stream data (CodeRabbit flagged
+        // this on PR #2745).
+        let drawColumns = pixelsToScroll;
         const currentBinMap = pixelToBinMap;
         const currentLUT = colorLUT;
         let streamPixels: Array<number[] | Uint8Array<ArrayBuffer>> = [];
@@ -536,7 +550,7 @@
 
           if (columnsToConsume > 0) {
             if (!hasRenderedStreamColumns) {
-              pixelsToScroll = Math.min(pixelsToScroll, Math.max(1, columnsToConsume));
+              drawColumns = Math.min(drawColumns, Math.max(1, columnsToConsume));
             }
             // View slice against the live head; advance head without copying.
             const consumeStart = renderReadyHead;
@@ -544,7 +558,7 @@
             renderReadyHead = consumeEnd;
             hasRenderedStreamColumns = true;
             clearedStreamPrimingCanvas = false;
-            const columnsPerPixel = columnsToConsume / pixelsToScroll;
+            const columnsPerPixel = columnsToConsume / drawColumns;
 
             // In stream mode the bin count is dictated by the server's FFT
             // size (streamed via the spectrogram-meta event and forwarded
@@ -556,7 +570,7 @@
             // bins undefined and producing black unrendered bands in the
             // waterfall (sentry-io flagged this on PR #2745).
             const streamBinCount = fftSize / 2;
-            for (let col = 0; col < pixelsToScroll; col++) {
+            for (let col = 0; col < drawColumns; col++) {
               const offsetStart = Math.floor(col * columnsPerPixel);
               const offsetEnd = Math.max(offsetStart + 1, Math.floor((col + 1) * columnsPerPixel));
               const sliceStart = consumeStart + offsetStart;
@@ -568,7 +582,7 @@
               );
             }
           } else if (lastStreamBins) {
-            for (let col = 0; col < pixelsToScroll; col++) {
+            for (let col = 0; col < drawColumns; col++) {
               streamPixels.push(lastStreamBins);
             }
           }
@@ -585,7 +599,13 @@
           }
         }
 
-        for (let col = 0; col < pixelsToScroll; col++) {
+        // Allocate the ImageData here, AFTER drawColumns has been
+        // finalized inside the stream branch, so the buffer stride
+        // matches the write loop below.
+        const imgData = ctx.createImageData(drawColumns, h);
+        const data = imgData.data;
+
+        for (let col = 0; col < drawColumns; col++) {
           let columnBins: number[] | Uint8Array<ArrayBuffer> = frequencyData;
           if (renderMode === 'stream') {
             /* eslint-disable security/detect-object-injection -- col is a bounded loop index for the scroll buffer */
@@ -597,7 +617,7 @@
             const binIndex = currentBinMap[y];
             const magnitude = columnBins[binIndex] ?? 0;
             const rgba = currentLUT[magnitude];
-            const offset = (y * pixelsToScroll + col) * 4;
+            const offset = (y * drawColumns + col) * 4;
             data[offset] = rgba & 0xff;
             data[offset + 1] = (rgba >>> 8) & 0xff;
             data[offset + 2] = (rgba >>> 16) & 0xff;
@@ -606,8 +626,10 @@
           }
         }
 
-        // putImageData works in raw device pixel coordinates (no transform needed)
-        ctx.putImageData(imgData, plotOffsetX + w - pixelsToScroll, 0);
+        // putImageData works in raw device pixel coordinates (no transform needed).
+        // Placement uses drawColumns so the buffer's right edge lines up
+        // with the canvas's right edge regardless of any priming clamp.
+        ctx.putImageData(imgData, plotOffsetX + w - drawColumns, 0);
       }
 
       // --- Overlay: detection labels + debug time markers ---
@@ -652,7 +674,12 @@
 
           olCtx.textBaseline = 'top';
           olCtx.textAlign = 'left';
-          olCtx.fillText('kHz', 4 * dpr, 4 * dpr);
+          // Unit label routed through i18n per frontend/CLAUDE.md —
+          // "kHz" is the same string in every target locale but the
+          // key indirection satisfies the "no hardcoded user-facing
+          // text" rule enforced by CodeRabbit and gives a single
+          // place to change the label if ever needed.
+          olCtx.fillText(t('spectrogram.axis.kHz'), 4 * dpr, 4 * dpr);
           olCtx.restore();
         }
 

--- a/frontend/src/lib/desktop/components/media/SpectrogramCanvas.svelte
+++ b/frontend/src/lib/desktop/components/media/SpectrogramCanvas.svelte
@@ -15,9 +15,9 @@
     DEFAULT_COLOR_MAP,
     type ColorMapName,
   } from '$lib/utils/spectrogramColorMaps';
-  import { loggers } from '$lib/utils/logger';
+  import { t } from '$lib/i18n';
+  import type { LiveSpectrogramColumn } from '$lib/types/liveSpectrogram';
 
-  const logger = loggers.audio;
   /** Interval between debug time markers on the waterfall (seconds) */
   const DEBUG_MARKER_INTERVAL_SEC = 5;
 
@@ -54,6 +54,18 @@
     debug?: boolean;
     /** Current wall-clock time at playhead (Unix seconds) — used for debug time markers */
     wallClockAtPlayhead?: number;
+    /** Rendering mode: analyser bins or server-streamed bins */
+    renderMode?: 'analyser' | 'stream';
+    /** Timestamped FFT columns streamed from the backend */
+    streamColumns?: LiveSpectrogramColumn[];
+    /** Hop size for streamed FFT columns */
+    streamHopSize?: number;
+    /** Whether to show a frequency axis on the left side */
+    showFrequencyAxis?: boolean;
+    /** Frequency axis density mode */
+    frequencyAxisMode?: 'compact' | 'adaptive';
+    /** Whether to show a time axis along the bottom edge */
+    showTimeAxis?: boolean;
   }
 
   let {
@@ -70,6 +82,12 @@
     overlayFontSize = 11,
     debug = false,
     wallClockAtPlayhead = 0,
+    renderMode = 'analyser',
+    streamColumns = [],
+    streamHopSize = 128,
+    showFrequencyAxis = false,
+    frequencyAxisMode = 'adaptive',
+    showTimeAxis = false,
   }: Props = $props();
 
   let canvasEl: HTMLCanvasElement | undefined = $state();
@@ -78,6 +96,8 @@
   // CSS pixel dimensions (from ResizeObserver)
   let cssWidth = $state(800);
   let cssHeight = $state(300);
+  let queuedStreamColumns = $state<LiveSpectrogramColumn[]>([]);
+  let lastQueuedStreamUnixMs = $state(0);
 
   // DPR tracking
   let dpr = $state(globalThis.devicePixelRatio ?? 1);
@@ -85,6 +105,16 @@
   // Device pixel dimensions
   let deviceWidth = $derived(Math.round(cssWidth * dpr));
   let deviceHeight = $derived(Math.round(cssHeight * dpr));
+  let frequencyAxisWidthCss = $derived.by(() => {
+    if (!showFrequencyAxis) return 0;
+    return frequencyAxisMode === 'compact' ? 42 : 50;
+  });
+  let frequencyAxisWidth = $derived(Math.round(frequencyAxisWidthCss * dpr));
+  let plotOffsetX = $derived(showFrequencyAxis ? frequencyAxisWidth : 0);
+  let timeAxisHeightCss = $derived(showTimeAxis ? 22 : 0);
+  let timeAxisHeight = $derived(Math.round(timeAxisHeightCss * dpr));
+  let plotHeight = $derived(Math.max(1, deviceHeight - timeAxisHeight));
+  let plotWidth = $derived(Math.max(1, deviceWidth - plotOffsetX));
 
   // Precomputed bin-to-pixel mapping: maps each DEVICE pixel row to FFT bin index
   // y=0 is top of canvas = highest frequency
@@ -92,7 +122,7 @@
     const binCount = fftSize / 2;
     const nyquist = sampleRate / 2;
     const [minFreq, maxFreq] = frequencyRange;
-    const height = deviceHeight;
+    const height = plotHeight;
     const map = new Uint16Array(height);
 
     for (let y = 0; y < height; y++) {
@@ -110,6 +140,83 @@
   // Selected color LUT
   // eslint-disable-next-line security/detect-object-injection -- colorMap is typed as ColorMapName
   let colorLUT = $derived(COLOR_MAPS[colorMap] ?? COLOR_MAPS[DEFAULT_COLOR_MAP]);
+  const MAX_RENDER_READY_COLUMNS = 8192;
+
+  function getFrequencyTickCount(): number {
+    if (!showFrequencyAxis) return 0;
+    if (frequencyAxisMode === 'compact') return 3;
+    if (cssHeight < 260) return 3;
+    if (cssHeight < 520) return 5;
+    return 7;
+  }
+
+  function formatFrequencyLabel(hz: number): string {
+    const khz = hz / 1000;
+    const rounded = Math.round(khz * 10) / 10;
+    return Number.isInteger(rounded) ? String(rounded) : rounded.toFixed(1);
+  }
+
+  function buildFrequencyTicks(count: number): Array<{ y: number; label: string }> {
+    if (!showFrequencyAxis || count < 2 || plotHeight <= 0) return [];
+    const [minFreq, maxFreq] = frequencyRange;
+    const ticks: Array<{ y: number; label: string }> = [];
+    for (let i = 0; i < count; i++) {
+      const ratio = count === 1 ? 0 : i / (count - 1);
+      const freq = minFreq + ratio * (maxFreq - minFreq);
+      const y = plotHeight - ratio * plotHeight;
+      ticks.push({
+        y,
+        label: formatFrequencyLabel(freq),
+      });
+    }
+    return ticks;
+  }
+
+  function aggregateStreamColumns(
+    columns: Array<number[] | Uint8Array<ArrayBuffer>>,
+    binCount: number
+  ): Uint8Array<ArrayBuffer> {
+    const aggregated = new Uint8Array(binCount);
+    if (columns.length === 0) return aggregated;
+
+    for (let bin = 0; bin < binCount; bin++) {
+      let totalValue = 0;
+      for (const column of columns) {
+        /* eslint-disable security/detect-object-injection -- bin is a bounded loop index for dense FFT column arrays */
+        const value = column[bin] ?? 0;
+        /* eslint-enable security/detect-object-injection */
+        totalValue += value;
+      }
+      /* eslint-disable security/detect-object-injection -- bin is a bounded loop index for dense FFT column arrays */
+      aggregated[bin] = Math.round(totalValue / columns.length);
+      /* eslint-enable security/detect-object-injection */
+    }
+
+    return aggregated;
+  }
+
+  $effect(() => {
+    if (renderMode !== 'stream') {
+      queuedStreamColumns = [];
+      lastQueuedStreamUnixMs = 0;
+      return;
+    }
+
+    const nextColumns: LiveSpectrogramColumn[] = [];
+    for (const column of streamColumns) {
+      if (column.tUnixMs > lastQueuedStreamUnixMs) {
+        nextColumns.push(column);
+      }
+    }
+    if (nextColumns.length === 0) return;
+
+    queuedStreamColumns = [...queuedStreamColumns, ...nextColumns];
+    lastQueuedStreamUnixMs = nextColumns[nextColumns.length - 1].tUnixMs;
+
+    if (queuedStreamColumns.length > 4096) {
+      queuedStreamColumns = queuedStreamColumns.slice(-4096);
+    }
+  });
 
   // ResizeObserver with debouncing (100ms)
   $effect(() => {
@@ -184,7 +291,6 @@
             overlayCanvasEl.width = newW;
             overlayCanvasEl.height = newH;
           }
-          logger.debug('Canvas resized with content preserved', { oldW, oldH, newW, newH });
           return;
         }
       } catch {
@@ -203,7 +309,8 @@
 
   // Main animation loop
   $effect(() => {
-    if (!analyser || !isActive || !canvasEl) return;
+    if (!isActive || !canvasEl) return;
+    if (renderMode === 'analyser' && !analyser) return;
 
     const ctx = canvasEl.getContext('2d');
     if (!ctx) return;
@@ -232,6 +339,14 @@
     let frameId: number;
     // Track whether overlay was drawn last frame to avoid clearing an already-empty canvas
     let overlayHadContent = false;
+    let lastStreamBins: number[] | Uint8Array<ArrayBuffer> | null = null;
+    let renderReadyColumns: Array<number[] | Uint8Array<ArrayBuffer>> = [];
+    let streamColumnAccumulator = 0;
+    let hasRenderedStreamColumns = false;
+    let clearedStreamPrimingCanvas = false;
+    let wasStreamPriming = false;
+    const streamColumnsPerSecond =
+      renderMode === 'stream' ? sampleRate / Math.max(1, streamHopSize) : 0;
 
     // Convert CSS px/s to device px/s
     const deviceScrollSpeed = scrollSpeed * dpr;
@@ -265,52 +380,219 @@
       const now = performance.now();
       const deltaTime = (now - lastFrameTime) / 1000;
       lastFrameTime = now;
+      let dueStreamColumns: LiveSpectrogramColumn[] = [];
+      let streamPriming = false;
 
-      // Read frequency data from analyser
-      analyser.getByteFrequencyData(frequencyData);
+      if (renderMode === 'analyser') {
+        analyser?.getByteFrequencyData(frequencyData);
+      } else if (queuedStreamColumns.length > 0) {
+        const playheadUnixMs = wallClockAtPlayhead > 0 ? Math.floor(wallClockAtPlayhead * 1000) : 0;
+
+        while (
+          queuedStreamColumns.length > 0 &&
+          playheadUnixMs > 0 &&
+          queuedStreamColumns[0].tUnixMs <= playheadUnixMs
+        ) {
+          dueStreamColumns.push(queuedStreamColumns[0]);
+          queuedStreamColumns = queuedStreamColumns.slice(1);
+        }
+        if (dueStreamColumns.length > 0) {
+          const dueBins = dueStreamColumns.map(column => column.bins);
+          renderReadyColumns.push(...dueBins);
+          if (renderReadyColumns.length > MAX_RENDER_READY_COLUMNS) {
+            renderReadyColumns = renderReadyColumns.slice(-MAX_RENDER_READY_COLUMNS);
+          }
+          lastStreamBins = dueBins[dueBins.length - 1];
+        }
+      } else if (renderMode === 'stream' && wallClockAtPlayhead > 0) {
+        streamPriming = true;
+      }
+
+      if (
+        renderMode === 'stream' &&
+        !hasRenderedStreamColumns &&
+        dueStreamColumns.length === 0 &&
+        renderReadyColumns.length === 0
+      ) {
+        streamPriming = true;
+      }
+
+      if (streamPriming && !clearedStreamPrimingCanvas) {
+        ctx.clearRect(0, 0, deviceWidth, deviceHeight);
+        clearedStreamPrimingCanvas = true;
+      }
+
+      if (showFrequencyAxis && plotOffsetX > 0) {
+        ctx.fillStyle = '#000000';
+        ctx.fillRect(0, 0, plotOffsetX, plotHeight);
+      }
+      if (showTimeAxis && timeAxisHeight > 0) {
+        ctx.fillStyle = '#000000';
+        ctx.fillRect(plotOffsetX, plotHeight, plotWidth, timeAxisHeight);
+      }
 
       // Compute device pixels to scroll
       scrollAccumulator += deviceScrollSpeed * deltaTime;
-      const pixelsToScroll = Math.floor(scrollAccumulator);
-      scrollAccumulator -= pixelsToScroll;
+      let pixelsToScroll = Math.floor(scrollAccumulator);
+      if (streamPriming) {
+        scrollAccumulator = 0;
+        pixelsToScroll = 0;
+      } else {
+        if (wasStreamPriming) {
+          scrollAccumulator = 0;
+          streamColumnAccumulator = 0;
+          pixelsToScroll = 0;
+          if (!hasRenderedStreamColumns) {
+            ctx.clearRect(0, 0, deviceWidth, deviceHeight);
+          }
+        }
+        scrollAccumulator -= pixelsToScroll;
+      }
+      wasStreamPriming = streamPriming;
 
       if (pixelsToScroll > 0) {
-        const w = deviceWidth;
-        const h = deviceHeight;
+        const w = plotWidth;
+        const h = plotHeight;
 
         // Self-blit: shift existing content left (GPU-composited)
-        ctx.drawImage(canvasEl!, -pixelsToScroll, 0);
+        if (hasRenderedStreamColumns || renderMode === 'analyser') {
+          ctx.drawImage(
+            canvasEl!,
+            plotOffsetX + pixelsToScroll,
+            0,
+            Math.max(0, w - pixelsToScroll),
+            h,
+            plotOffsetX,
+            0,
+            Math.max(0, w - pixelsToScroll),
+            h
+          );
+        }
 
         // Draw new column(s) at right edge using device pixel dimensions
         const imgData = ctx.createImageData(pixelsToScroll, h);
-        const data = new Uint32Array(imgData.data.buffer);
+        const data = imgData.data;
         const currentBinMap = pixelToBinMap;
         const currentLUT = colorLUT;
+        let streamPixels: Array<number[] | Uint8Array<ArrayBuffer>> = [];
+
+        if (renderMode === 'stream') {
+          streamColumnAccumulator += streamColumnsPerSecond * deltaTime;
+          let columnsToConsume = Math.floor(streamColumnAccumulator);
+          if (columnsToConsume > 0) {
+            streamColumnAccumulator -= columnsToConsume;
+          }
+
+          if (renderReadyColumns.length > 0 && columnsToConsume === 0) {
+            columnsToConsume = 1;
+          }
+
+          if (columnsToConsume > renderReadyColumns.length) {
+            columnsToConsume = renderReadyColumns.length;
+          }
+
+          if (columnsToConsume > 0) {
+            if (!hasRenderedStreamColumns) {
+              pixelsToScroll = Math.min(pixelsToScroll, Math.max(1, columnsToConsume));
+            }
+            const consumedColumns = renderReadyColumns.slice(0, columnsToConsume);
+            renderReadyColumns = renderReadyColumns.slice(columnsToConsume);
+            hasRenderedStreamColumns = true;
+            clearedStreamPrimingCanvas = false;
+            const columnsPerPixel = consumedColumns.length / pixelsToScroll;
+
+            for (let col = 0; col < pixelsToScroll; col++) {
+              const start = Math.floor(col * columnsPerPixel);
+              const end = Math.max(start + 1, Math.floor((col + 1) * columnsPerPixel));
+              const slice = consumedColumns.slice(start, end);
+              streamPixels.push(
+                slice.length > 0
+                  ? aggregateStreamColumns(slice, frequencyData.length)
+                  : (lastStreamBins ?? [])
+              );
+            }
+          } else if (lastStreamBins) {
+            for (let col = 0; col < pixelsToScroll; col++) {
+              streamPixels.push(lastStreamBins);
+            }
+          }
+        }
 
         for (let col = 0; col < pixelsToScroll; col++) {
+          let columnBins: number[] | Uint8Array<ArrayBuffer> = frequencyData;
+          if (renderMode === 'stream') {
+            /* eslint-disable security/detect-object-injection -- col is a bounded loop index for the scroll buffer */
+            columnBins = streamPixels[col] ?? lastStreamBins ?? [];
+            /* eslint-enable security/detect-object-injection */
+          }
           for (let y = 0; y < h; y++) {
             /* eslint-disable security/detect-object-injection -- loop indices and typed array lookups */
             const binIndex = currentBinMap[y];
-            const magnitude = frequencyData[binIndex];
-            data[y * pixelsToScroll + col] = currentLUT[magnitude];
+            const magnitude = columnBins[binIndex] ?? 0;
+            const rgba = currentLUT[magnitude];
+            const offset = (y * pixelsToScroll + col) * 4;
+            data[offset] = rgba & 0xff;
+            data[offset + 1] = (rgba >>> 8) & 0xff;
+            data[offset + 2] = (rgba >>> 16) & 0xff;
+            data[offset + 3] = (rgba >>> 24) & 0xff;
             /* eslint-enable security/detect-object-injection */
           }
         }
 
         // putImageData works in raw device pixel coordinates (no transform needed)
-        ctx.putImageData(imgData, w - pixelsToScroll, 0);
+        ctx.putImageData(imgData, plotOffsetX + w - pixelsToScroll, 0);
       }
 
       // --- Overlay: detection labels + debug time markers ---
-      const hasOverlayContent = overlayLabels.length > 0 || debug;
+      const hasOverlayContent =
+        showFrequencyAxis || showTimeAxis || overlayLabels.length > 0 || debug || streamPriming;
 
       if (olCtx && hasOverlayContent) {
         olCtx.clearRect(0, 0, deviceWidth, deviceHeight);
 
+        if (showFrequencyAxis && plotOffsetX > 0) {
+          const axisFontSize = Math.max(
+            9,
+            Math.round((frequencyAxisMode === 'compact' ? 9 : 10) * dpr)
+          );
+          const ticks = buildFrequencyTicks(getFrequencyTickCount());
+
+          olCtx.save();
+          olCtx.shadowColor = 'transparent';
+          olCtx.shadowBlur = 0;
+          olCtx.strokeStyle = 'rgba(255, 255, 255, 0.26)';
+          olCtx.fillStyle = 'rgba(255, 255, 255, 0.78)';
+          olCtx.lineWidth = 1 * dpr;
+          olCtx.font = `${axisFontSize}px sans-serif`;
+          olCtx.textBaseline = 'middle';
+          olCtx.textAlign = 'right';
+
+          olCtx.beginPath();
+          olCtx.moveTo(plotOffsetX - 0.5 * dpr, 0);
+          olCtx.lineTo(plotOffsetX - 0.5 * dpr, plotHeight);
+          olCtx.stroke();
+
+          const topAxisPadding =
+            frequencyAxisMode === 'compact' ? axisFontSize * 1.1 : axisFontSize;
+          for (const tick of ticks) {
+            const y = Math.max(topAxisPadding, Math.min(plotHeight - axisFontSize, tick.y));
+            olCtx.beginPath();
+            olCtx.moveTo(plotOffsetX - 6 * dpr, y);
+            olCtx.lineTo(plotOffsetX - 1.5 * dpr, y);
+            olCtx.stroke();
+            olCtx.fillText(tick.label, plotOffsetX - 8 * dpr, y);
+          }
+
+          olCtx.textBaseline = 'top';
+          olCtx.textAlign = 'left';
+          olCtx.fillText('kHz', 4 * dpr, 4 * dpr);
+          olCtx.restore();
+        }
+
         // --- Debug time markers: vertical lines every 5s with HH:MM:SS ---
         if (debug && wallClockAtPlayhead > 0) {
           const debugFontSize = Math.round(9 * dpr);
-          const visibleSeconds = deviceWidth / deviceScrollSpeed;
+          const visibleSeconds = plotWidth / deviceScrollSpeed;
 
           // Draw markers from right edge backwards
           // Right edge = wallClockAtPlayhead, left edge = wallClockAtPlayhead - visibleSeconds
@@ -331,8 +613,8 @@
             t -= DEBUG_MARKER_INTERVAL_SEC
           ) {
             const ageSeconds = rightEdgeTime - t;
-            const x = deviceWidth - ageSeconds * deviceScrollSpeed;
-            if (x < 0 || x > deviceWidth) continue;
+            const x = plotOffsetX + plotWidth - ageSeconds * deviceScrollSpeed;
+            if (x < plotOffsetX || x > deviceWidth) continue;
 
             // Vertical dashed line
             olCtx.strokeStyle = 'rgba(255, 255, 0, 0.4)';
@@ -340,7 +622,7 @@
             olCtx.setLineDash([4 * dpr, 4 * dpr]);
             olCtx.beginPath();
             olCtx.moveTo(x, 0);
-            olCtx.lineTo(x, deviceHeight);
+            olCtx.lineTo(x, plotHeight);
             olCtx.stroke();
             olCtx.setLineDash([]);
 
@@ -349,7 +631,7 @@
             olCtx.font = `${debugFontSize}px monospace`;
             olCtx.fillStyle = 'rgba(255, 255, 0, 0.8)';
             olCtx.textBaseline = 'bottom';
-            olCtx.fillText(timeStr, x + 2 * dpr, deviceHeight - 2 * dpr);
+            olCtx.fillText(timeStr, x + 2 * dpr, plotHeight - 2 * dpr);
           }
 
           // Debug info panel (top-left corner)
@@ -359,17 +641,80 @@
           const playheadStr = formatTimeCached(wallClockAtPlayhead);
           const nowStr = formatTimeCached(Date.now() / 1000);
           const hlsDelay = (Date.now() / 1000 - wallClockAtPlayhead).toFixed(1);
-          olCtx.fillText(`playhead: ${playheadStr}`, 4 * dpr, 4 * dpr);
+          olCtx.fillText(`playhead: ${playheadStr}`, plotOffsetX + 4 * dpr, 4 * dpr);
           olCtx.fillText(
             `wall: ${nowStr}  HLS lag: ${hlsDelay}s`,
-            4 * dpr,
+            plotOffsetX + 4 * dpr,
             4 * dpr + debugFontSize + 2 * dpr
           );
           olCtx.fillText(
             `queue: ${overlayLabels.length} labels`,
-            4 * dpr,
+            plotOffsetX + 4 * dpr,
             4 * dpr + (debugFontSize + 2 * dpr) * 2
           );
+
+          olCtx.restore();
+        }
+
+        if (streamPriming) {
+          const primingFontSize = Math.max(10, Math.round(10 * dpr));
+          olCtx.save();
+          olCtx.shadowColor = 'transparent';
+          olCtx.shadowBlur = 0;
+          olCtx.fillStyle = 'rgba(255, 255, 255, 0.72)';
+          olCtx.font = `${primingFontSize}px sans-serif`;
+          olCtx.textBaseline = 'middle';
+          olCtx.textAlign = 'center';
+          olCtx.fillText(
+            t('spectrogram.page.syncingAudio'),
+            plotOffsetX + plotWidth / 2,
+            plotHeight / 2
+          );
+          olCtx.restore();
+        }
+
+        if (showTimeAxis && wallClockAtPlayhead > 0) {
+          const axisFontSize = Math.max(9, Math.round(10 * dpr));
+          const visibleSeconds = plotWidth / deviceScrollSpeed;
+          const leftEdgeTime = wallClockAtPlayhead - visibleSeconds;
+          const midpointTime = leftEdgeTime + visibleSeconds / 2;
+          const timeLabels = [
+            { x: plotOffsetX + 8 * dpr, time: leftEdgeTime, align: 'left' as const },
+            { x: plotOffsetX + plotWidth / 2, time: midpointTime, align: 'center' as const },
+            {
+              x: plotOffsetX + plotWidth - 8 * dpr,
+              time: wallClockAtPlayhead,
+              align: 'right' as const,
+            },
+          ];
+
+          olCtx.save();
+          olCtx.shadowColor = 'transparent';
+          olCtx.shadowBlur = 0;
+          olCtx.strokeStyle = 'rgba(255, 255, 255, 0.22)';
+          olCtx.fillStyle = 'rgba(255, 255, 255, 0.78)';
+          olCtx.lineWidth = 1 * dpr;
+          olCtx.font = `${axisFontSize}px sans-serif`;
+          olCtx.textBaseline = 'middle';
+          olCtx.textAlign = 'center';
+
+          olCtx.beginPath();
+          olCtx.moveTo(plotOffsetX, plotHeight + 0.5 * dpr);
+          olCtx.lineTo(plotOffsetX + plotWidth, plotHeight + 0.5 * dpr);
+          olCtx.stroke();
+
+          for (const label of timeLabels) {
+            olCtx.textAlign = label.align;
+            olCtx.beginPath();
+            olCtx.moveTo(label.x, plotHeight + 1.5 * dpr);
+            olCtx.lineTo(label.x, plotHeight + 6 * dpr);
+            olCtx.stroke();
+            olCtx.fillText(
+              formatTimeCached(label.time),
+              label.x,
+              plotHeight + timeAxisHeight / 2 + 1 * dpr
+            );
+          }
 
           olCtx.restore();
         }
@@ -385,15 +730,15 @@
           olCtx.shadowOffsetY = 1 * dpr;
           olCtx.textBaseline = 'middle';
 
-          const maxSlots = Math.max(2, Math.floor(deviceHeight / (fontSize * 2.5)));
+          const maxSlots = Math.max(2, Math.floor(plotHeight / (fontSize * 2.5)));
 
           for (const label of overlayLabels) {
             const labelAge = (now - label.birthTime) / 1000;
-            const x = deviceWidth - labelAge * deviceScrollSpeed;
+            const x = plotOffsetX + plotWidth - labelAge * deviceScrollSpeed;
 
-            if (x < -200 * dpr || x > deviceWidth) continue;
+            if (x < plotOffsetX - 200 * dpr || x > deviceWidth) continue;
 
-            const slotHeight = deviceHeight / (maxSlots + 1);
+            const slotHeight = plotHeight / (maxSlots + 1);
             const y = slotHeight * (1 + (label.ySlot % maxSlots));
 
             if (debug && label.firstDetected) {

--- a/frontend/src/lib/desktop/components/media/SpectrogramControls.svelte
+++ b/frontend/src/lib/desktop/components/media/SpectrogramControls.svelte
@@ -25,7 +25,7 @@
    * Uses callback props for state changes.
    */
 
-  import { Tag, Volume2, VolumeX } from '@lucide/svelte';
+  import { Clock3, Tag, Volume2, VolumeX } from '@lucide/svelte';
   import { t } from '$lib/i18n';
   import SelectDropdown from '$lib/desktop/components/forms/SelectDropdown.svelte';
   import type { SelectOption } from '$lib/desktop/components/forms/SelectDropdown.types';
@@ -57,8 +57,12 @@
     compact?: boolean;
     /** Whether detection labels are shown */
     showDetectionLabels?: boolean;
+    /** Whether time axis is shown */
+    showTimeAxis?: boolean;
     /** Toggle detection label visibility */
     onDetectionLabelsToggle?: () => void;
+    /** Toggle time axis visibility */
+    onTimeAxisToggle?: () => void;
     /** Callbacks */
     onFrequencyRangeChange?: (_range: [number, number]) => void;
     onColorMapChange?: (_map: ColorMapName) => void;
@@ -73,7 +77,9 @@
     audioOutput = false,
     compact = false,
     showDetectionLabels = true,
+    showTimeAxis = true,
     onDetectionLabelsToggle,
+    onTimeAxisToggle,
     onFrequencyRangeChange,
     onColorMapChange,
     onGainChange,
@@ -157,7 +163,7 @@
       size="xs"
       groupBy={false}
       onChange={handleColorMapChange}
-      className="w-36"
+      className="w-44"
     >
       {#snippet renderOption(option)}
         <div class="flex items-center gap-2">
@@ -240,6 +246,20 @@
       title={t('spectrogram.labels.toggle')}
     >
       <Tag class="size-4" />
+    </button>
+  {/if}
+
+  {#if onTimeAxisToggle}
+    <button
+      type="button"
+      onclick={onTimeAxisToggle}
+      class="rounded p-1.5 transition-colors {showTimeAxis
+        ? 'bg-[var(--color-primary)]/20 text-[var(--color-primary)]'
+        : 'text-[var(--color-base-content)]/60 hover:bg-[var(--color-base-200)]'}"
+      aria-label={t('spectrogram.labels.toggleTimeAxis')}
+      title={t('spectrogram.labels.toggleTimeAxis')}
+    >
+      <Clock3 class="size-4" />
     </button>
   {/if}
 </div>

--- a/frontend/src/lib/desktop/components/media/SpectrogramControls.svelte
+++ b/frontend/src/lib/desktop/components/media/SpectrogramControls.svelte
@@ -243,6 +243,7 @@
         ? 'bg-[var(--color-primary)]/20 text-[var(--color-primary)]'
         : 'text-[var(--color-base-content)]/60 hover:bg-[var(--color-base-200)]'}"
       aria-label={t('spectrogram.labels.toggle')}
+      aria-pressed={showDetectionLabels}
       title={t('spectrogram.labels.toggle')}
     >
       <Tag class="size-4" />
@@ -257,6 +258,7 @@
         ? 'bg-[var(--color-primary)]/20 text-[var(--color-primary)]'
         : 'text-[var(--color-base-content)]/60 hover:bg-[var(--color-base-200)]'}"
       aria-label={t('spectrogram.labels.toggleTimeAxis')}
+      aria-pressed={showTimeAxis}
       title={t('spectrogram.labels.toggleTimeAxis')}
     >
       <Clock3 class="size-4" />

--- a/frontend/src/lib/desktop/features/dashboard/components/MiniSpectrogram.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/components/MiniSpectrogram.svelte
@@ -6,7 +6,7 @@
    * audio source. Manages its own HLS.js connection, heartbeat, and access control.
    *
    * Key design:
-   * - Uses useSpectrogramAnalyser composable (no inline Web Audio graph)
+   * - Uses HLS for playback and the server-side FFT stream for rendering
    * - Source discovery via SSE audio-level stream
    * - Silent by default with speaker toggle
    * - Manual start/stop with localStorage persistence
@@ -24,10 +24,13 @@
   import { useSpectrogramAnalyser } from '$lib/utils/useSpectrogramAnalyser.svelte';
   import SpectrogramCanvas from '$lib/desktop/components/media/SpectrogramCanvas.svelte';
   import { fetchWithCSRF } from '$lib/utils/api';
+  import { primeAudioContext } from '$lib/utils/audioContextManager';
   import { buildAppUrl } from '$lib/utils/urlHelpers';
   import { generateSessionId } from '$lib/utils/session';
   import { loggers } from '$lib/utils/logger';
+  import { connectLiveSpectrogramStream } from '$lib/utils/liveSpectrogramStream';
   import type { ColorMapName } from '$lib/utils/spectrogramColorMaps';
+  import type { LiveSpectrogramColumn } from '$lib/types/liveSpectrogram';
   import type { PendingDetection } from '$lib/types/pending.types';
   import type { OverlayLabel, QueuedLabel } from '$lib/utils/detectionOverlay';
   import {
@@ -76,6 +79,11 @@
   });
   let colorMap = $state<ColorMapName>('inferno');
   let frequencyRange = $state<[number, number]>([0, 15000]);
+  let streamColumns = $state<LiveSpectrogramColumn[]>([]);
+  let currentWallClockAtPlayhead = $state(0);
+  let streamSampleRate = $state(48000);
+  let streamFFTSize = $state(FFT_SIZE);
+  let streamHopSize = $state(128);
 
   // Stream token state
   let activeStreamToken: string | null = null;
@@ -86,6 +94,7 @@
   let heartbeatTimer: ReturnType<typeof globalThis.setInterval> | null = null;
   let abortController: AbortController | null = null;
   let activeSourceId = $state<string | null>(null);
+  let closeLiveSpectrogramStream: (() => void) | null = null;
 
   // Detection overlay state
   let overlayLabels = $state<OverlayLabel[]>([]);
@@ -97,6 +106,30 @@
 
   // Initialize composable during component init (must be at top level for $effect cleanup)
   const spectro = useSpectrogramAnalyser({ fftSize: FFT_SIZE, audioOutput: false });
+
+  function startLiveSpectrogram(sourceId: string) {
+    closeLiveSpectrogramStream?.();
+    streamColumns = [];
+    closeLiveSpectrogramStream = connectLiveSpectrogramStream(sourceId, {
+      onMeta: meta => {
+        streamSampleRate = meta.sampleRate;
+        streamFFTSize = meta.fftSize;
+        streamHopSize = meta.hopSize;
+      },
+      onColumns: event => {
+        streamColumns = [...streamColumns, ...event.columns].slice(-1024);
+      },
+    });
+  }
+
+  function stopLiveSpectrogram() {
+    closeLiveSpectrogramStream?.();
+    closeLiveSpectrogramStream = null;
+    streamColumns = [];
+    streamSampleRate = 48000;
+    streamFFTSize = FFT_SIZE;
+    streamHopSize = 128;
+  }
 
   function shouldAutoStart(): boolean {
     if (appState.liveSpectrogram) return true;
@@ -181,6 +214,8 @@
     if (isActive || isConnecting) return;
     isConnecting = true;
 
+    await primeAudioContext();
+
     // Abort any previous in-flight operation
     abortController?.abort();
     const controller = new AbortController();
@@ -218,6 +253,11 @@
 
       audioElement = new globalThis.Audio();
       audioElement.crossOrigin = 'anonymous';
+      audioElement.muted = gainPresetIndex === 0;
+      // eslint-disable-next-line security/detect-object-injection -- gainPresetIndex is a numeric index bounded by modulo
+      const preset = GAIN_PRESETS[gainPresetIndex];
+      audioElement.volume =
+        'db' in preset ? Math.max(0, Math.min(1, Math.pow(10, preset.db / 20))) : 1;
 
       if (Hls.isSupported()) {
         hls = new Hls(HLS_AUDIO_CONFIG);
@@ -241,6 +281,9 @@
           isActive = true;
           isConnecting = false;
           persistToggleState(true);
+          if (activeSourceId) {
+            startLiveSpectrogram(activeSourceId);
+          }
 
           if (audioElement) {
             await spectro.connect(audioElement);
@@ -261,7 +304,7 @@
           }
         });
       } else if (audioElement.canPlayType('application/vnd.apple.mpegurl')) {
-        // Native HLS (Safari / iOS)
+        // Native HLS fallback path
         audioElement.src = hlsUrl;
         try {
           await audioElement.play();
@@ -276,9 +319,11 @@
         isConnecting = false;
         persistToggleState(true);
 
-        await spectro.connect(audioElement);
+        if (activeSourceId) {
+          startLiveSpectrogram(activeSourceId);
+        }
         if (signal.aborted) {
-          spectro.disconnect();
+          stopLiveSpectrogram();
         }
       } else {
         // Browser supports neither HLS.js nor native HLS — tear down
@@ -344,6 +389,8 @@
     }
 
     stopHeartbeat();
+    stopLiveSpectrogram();
+    currentWallClockAtPlayhead = 0;
     spectro.disconnect();
 
     if (hls) {
@@ -378,6 +425,12 @@
     gainPresetIndex = (gainPresetIndex + 1) % GAIN_PRESETS.length;
     // eslint-disable-next-line security/detect-object-injection -- gainPresetIndex is a numeric index bounded by modulo
     const preset = GAIN_PRESETS[gainPresetIndex];
+    if (audioElement) {
+      audioElement.muted = !preset.audio;
+      audioElement.volume = preset.audio
+        ? Math.max(0, Math.min(1, Math.pow(10, preset.db / 20)))
+        : 1;
+    }
     spectro.setAudioOutput(preset.audio);
     // Always update gain -- when muted (db: -Infinity), this resets the
     // spectrogram visualization to 0 dB instead of leaving it at max gain.
@@ -425,6 +478,10 @@
         hls?.playingDate ?? null,
         nowUnix
       );
+
+      if (wallClockAtPlayhead > 0) {
+        currentWallClockAtPlayhead = wallClockAtPlayhead;
+      }
 
       // Promote queued labels when playhead is available
       if (wallClockAtPlayhead > 0 && labelQueue.length > 0) {
@@ -526,25 +583,26 @@
       </div>
     </div>
 
-    {#if (isActive || isConnecting) && spectro.isActive}
+    {#if isActive || isConnecting}
       <SpectrogramCanvas
         analyser={spectro.analyser}
         frequencyData={spectro.frequencyData}
-        sampleRate={spectro.sampleRate}
-        fftSize={FFT_SIZE}
+        sampleRate={streamSampleRate}
+        fftSize={streamFFTSize}
+        showFrequencyAxis={true}
+        frequencyAxisMode="compact"
+        showTimeAxis={true}
         {frequencyRange}
         {colorMap}
-        isActive={spectro.isActive}
+        {isActive}
+        renderMode="stream"
+        {streamColumns}
+        {streamHopSize}
         overlayLabels={showDetectionLabels ? overlayLabels : []}
         overlayFontSize={9}
+        wallClockAtPlayhead={currentWallClockAtPlayhead}
         className="h-28 w-full"
       />
-    {:else if isActive || isConnecting}
-      <div class="flex h-28 items-center justify-center bg-black">
-        <div
-          class="h-5 w-5 animate-spin rounded-full border-2 border-[var(--color-primary)] border-t-transparent"
-        ></div>
-      </div>
     {/if}
   </div>
 {/if}

--- a/frontend/src/lib/desktop/features/dashboard/components/MiniSpectrogram.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/components/MiniSpectrogram.svelte
@@ -107,9 +107,11 @@
   // Initialize composable during component init (must be at top level for $effect cleanup)
   const spectro = useSpectrogramAnalyser({ fftSize: FFT_SIZE, audioOutput: false });
 
+  const STREAM_COLUMNS_MAX = 1024;
+
   function startLiveSpectrogram(sourceId: string) {
     closeLiveSpectrogramStream?.();
-    streamColumns = [];
+    streamColumns.length = 0;
     closeLiveSpectrogramStream = connectLiveSpectrogramStream(sourceId, {
       onMeta: meta => {
         streamSampleRate = meta.sampleRate;
@@ -117,7 +119,18 @@
         streamHopSize = meta.hopSize;
       },
       onColumns: event => {
-        streamColumns = [...streamColumns, ...event.columns].slice(-1024);
+        // Mutate in place: push new columns onto the reactive buffer and
+        // trim from the front if we exceed the rolling window. Avoids
+        // the per-event [...old, ...new].slice(-N) allocation (Svelte 5
+        // reactivity handles array mutations and coalesces updates in
+        // a single microtask).
+        for (const column of event.columns) {
+          streamColumns.push(column);
+        }
+        const overflow = streamColumns.length - STREAM_COLUMNS_MAX;
+        if (overflow > 0) {
+          streamColumns.splice(0, overflow);
+        }
       },
     });
   }
@@ -125,7 +138,7 @@
   function stopLiveSpectrogram() {
     closeLiveSpectrogramStream?.();
     closeLiveSpectrogramStream = null;
-    streamColumns = [];
+    streamColumns.length = 0;
     streamSampleRate = 48000;
     streamFFTSize = FFT_SIZE;
     streamHopSize = 128;

--- a/frontend/src/lib/desktop/features/live-stream/pages/LiveStreamPage.svelte
+++ b/frontend/src/lib/desktop/features/live-stream/pages/LiveStreamPage.svelte
@@ -151,9 +151,11 @@
     }
   }
 
+  const STREAM_COLUMNS_MAX = 2048;
+
   function startLiveSpectrogramStream(sourceId: string) {
     closeLiveSpectrogramStream?.();
-    streamColumns = [];
+    streamColumns.length = 0;
     closeLiveSpectrogramStream = connectLiveSpectrogramStream(sourceId, {
       onMeta: meta => {
         streamSampleRate = meta.sampleRate;
@@ -161,7 +163,17 @@
         streamHopSize = meta.hopSize;
       },
       onColumns: event => {
-        streamColumns = [...streamColumns, ...event.columns].slice(-2048);
+        // Mutate in place: push new columns onto the reactive buffer
+        // and trim from the front on overflow. Avoids the per-event
+        // [...old, ...new].slice(-N) allocation; Svelte 5 reactivity
+        // coalesces mutations within a single microtask.
+        for (const column of event.columns) {
+          streamColumns.push(column);
+        }
+        const overflow = streamColumns.length - STREAM_COLUMNS_MAX;
+        if (overflow > 0) {
+          streamColumns.splice(0, overflow);
+        }
       },
     });
   }
@@ -169,7 +181,7 @@
   function stopLiveSpectrogramStream() {
     closeLiveSpectrogramStream?.();
     closeLiveSpectrogramStream = null;
-    streamColumns = [];
+    streamColumns.length = 0;
     streamSampleRate = 48000;
     streamFFTSize = FFT_SIZE;
     streamHopSize = 128;

--- a/frontend/src/lib/desktop/features/live-stream/pages/LiveStreamPage.svelte
+++ b/frontend/src/lib/desktop/features/live-stream/pages/LiveStreamPage.svelte
@@ -1,10 +1,10 @@
 <!--
   LiveStreamPage.svelte — Full-page live audio spectrogram viewer
 
-  Connects to the HLS audio stream via hls.js, feeds it through the
-  useSpectrogramAnalyser composable, and renders a scrolling waterfall
-  spectrogram. Includes source picker (discovered via SSE audio-level stream),
-  spectrogram controls, and heartbeat mechanism to keep the backend stream alive.
+  Connects to the HLS audio stream for playback and renders a scrolling
+  waterfall spectrogram from the server-side FFT stream. Includes source picker
+  (discovered via SSE audio-level stream), spectrogram controls, and a
+  heartbeat mechanism to keep the backend stream alive.
 -->
 
 <script lang="ts">
@@ -19,6 +19,7 @@
   import SpectrogramCanvas from '$lib/desktop/components/media/SpectrogramCanvas.svelte';
   import SpectrogramControls from '$lib/desktop/components/media/SpectrogramControls.svelte';
   import SelectDropdown from '$lib/desktop/components/forms/SelectDropdown.svelte';
+  import { primeAudioContext } from '$lib/utils/audioContextManager';
   import type { SelectOption } from '$lib/desktop/components/forms/SelectDropdown.types';
   import { fetchWithCSRF } from '$lib/utils/api';
   import { buildAppUrl } from '$lib/utils/urlHelpers';
@@ -26,6 +27,8 @@
   import { loggers } from '$lib/utils/logger';
   import type { ColorMapName } from '$lib/utils/spectrogramColorMaps';
   import { hasLiveAudioAccess } from '$lib/stores/appState.svelte';
+  import { connectLiveSpectrogramStream } from '$lib/utils/liveSpectrogramStream';
+  import type { LiveSpectrogramColumn } from '$lib/types/liveSpectrogram';
   import type { PendingDetection } from '$lib/types/pending.types';
   import type { OverlayLabel, QueuedLabel } from '$lib/utils/detectionOverlay';
   import {
@@ -75,6 +78,7 @@
 
   // Detection overlay state
   let showDetectionLabels = $state(true);
+  let showTimeAxis = $state(true);
   let debugOverlay = $state(false);
   let overlayLabels = $state<OverlayLabel[]>([]);
   let labelQueue: QueuedLabel[] = [];
@@ -83,6 +87,10 @@
   let slotCounter = 0;
   let detectionEventSource: ReconnectingEventSource | null = null;
   let currentWallClockAtPlayhead = $state(0);
+  let streamColumns = $state<LiveSpectrogramColumn[]>([]);
+  let streamSampleRate = $state(48000);
+  let streamFFTSize = $state(FFT_SIZE);
+  let streamHopSize = $state(128);
   const MAX_OVERLAY_SLOTS = 7;
 
   // Internal state
@@ -93,6 +101,7 @@
   let abortController: AbortController | null = null;
   let activeStreamToken: string | null = null;
   let activeSourceId: string | null = null;
+  let closeLiveSpectrogramStream: (() => void) | null = null;
 
   // Initialize composable during component init (registers cleanup $effect)
   const spectro = useSpectrogramAnalyser({ fftSize: FFT_SIZE, audioOutput: true });
@@ -142,21 +151,34 @@
     }
   }
 
-  // Describe the buffered time ranges of an audio element for diagnostics.
-  // Returns a string like "0.00-4.12, 6.00-8.50" showing all buffered ranges,
-  // which helps identify buffer holes that cause audio gaps.
-  function describeBuffered(el: HTMLAudioElement | null): string {
-    if (!el?.buffered || el.buffered.length === 0) return 'empty';
-    const ranges: string[] = [];
-    for (let i = 0; i < el.buffered.length; i++) {
-      ranges.push(`${el.buffered.start(i).toFixed(2)}-${el.buffered.end(i).toFixed(2)}`);
-    }
-    return ranges.join(', ');
+  function startLiveSpectrogramStream(sourceId: string) {
+    closeLiveSpectrogramStream?.();
+    streamColumns = [];
+    closeLiveSpectrogramStream = connectLiveSpectrogramStream(sourceId, {
+      onMeta: meta => {
+        streamSampleRate = meta.sampleRate;
+        streamFFTSize = meta.fftSize;
+        streamHopSize = meta.hopSize;
+      },
+      onColumns: event => {
+        streamColumns = [...streamColumns, ...event.columns].slice(-2048);
+      },
+    });
+  }
+
+  function stopLiveSpectrogramStream() {
+    closeLiveSpectrogramStream?.();
+    closeLiveSpectrogramStream = null;
+    streamColumns = [];
+    streamSampleRate = 48000;
+    streamFFTSize = FFT_SIZE;
+    streamHopSize = 128;
   }
 
   async function startStream() {
     if (!selectedSourceId) return;
 
+    await primeAudioContext();
     await stopStream();
     isConnecting = true;
     connectionError = null;
@@ -192,129 +214,25 @@
       // Create audio element
       audioElement = new globalThis.Audio();
       audioElement.crossOrigin = 'anonymous';
-
-      // Audio element debug listeners for buffer underrun diagnosis
-      let hasStalled = false;
-      audioElement.addEventListener('waiting', () => {
-        hasStalled = true;
-        logger.warn('Audio element: waiting (buffer underrun)', {
-          currentTime: audioElement?.currentTime?.toFixed(3),
-          readyState: audioElement?.readyState,
-          networkState: audioElement?.networkState,
-          buffered: describeBuffered(audioElement),
-        });
-      });
-      audioElement.addEventListener('stalled', () => {
-        hasStalled = true;
-        logger.warn('Audio element: stalled (network stall)', {
-          currentTime: audioElement?.currentTime?.toFixed(3),
-          buffered: describeBuffered(audioElement),
-        });
-      });
-      audioElement.addEventListener('playing', () => {
-        if (!hasStalled) return; // Ignore initial play — only log stall recovery
-        hasStalled = false;
-        logger.warn('Audio element: resumed from stall', {
-          currentTime: audioElement?.currentTime?.toFixed(3),
-          buffered: describeBuffered(audioElement),
-        });
-      });
-      audioElement.addEventListener('error', () => {
-        const err = audioElement?.error;
-        logger.error('Audio element: error', {
-          code: err?.code,
-          message: err?.message,
-        });
-      });
+      audioElement.muted = !audioOutput;
+      audioElement.volume = Math.max(0, Math.min(1, Math.pow(10, gainDb / 20)));
 
       if (Hls.isSupported()) {
         hls = new Hls(HLS_AUDIO_CONFIG);
         hls.loadSource(hlsUrl);
         hls.attachMedia(audioElement);
-
         let fragmentsBuffered = 0;
         let playbackAttempted = false;
 
-        // Fragment load timing: track how long each fragment takes to download.
-        // Keyed by string to handle both numeric sn and 'initSegment'.
-        const fragLoadStartTimes = new Map<string, number>();
-
-        hls.on(Hls.Events.FRAG_LOADING, (_event, data) => {
-          if (signal.aborted) return;
-          const snKey = String(data.frag.sn);
-          fragLoadStartTimes.set(snKey, globalThis.performance.now());
-          // Cap map size to prevent leaks from abandoned loads
-          if (fragLoadStartTimes.size > 20) {
-            const oldest = fragLoadStartTimes.keys().next().value;
-            if (oldest !== undefined) fragLoadStartTimes.delete(oldest);
-          }
-          logger.debug('HLS frag loading', { sn: data.frag.sn, url: data.frag.relurl });
-        });
-
-        hls.on(Hls.Events.FRAG_LOADED, (_event, data) => {
-          if (signal.aborted) return;
-          const snKey = String(data.frag.sn);
-          const startTime = fragLoadStartTimes.get(snKey);
-          fragLoadStartTimes.delete(snKey);
-
-          const now = globalThis.performance.now();
-          const loadMs = startTime ? now - startTime : 0;
-          const loadDurationMs = startTime ? loadMs.toFixed(0) : '?';
-          const bytes = data.payload?.byteLength ?? data.frag.stats?.total ?? 0;
-          // Warn if fragment download took unusually long (>2s for a ~2s segment)
-          if (loadMs > 2000) {
-            logger.warn('Slow fragment download (possible network/server I/O stall)', {
-              sn: data.frag.sn,
-              loadDurationMs,
-              fragDuration: data.frag.duration?.toFixed(2),
-              bytes,
-            });
-          } else {
-            logger.debug('HLS frag loaded', { sn: data.frag.sn, loadDurationMs, bytes });
-          }
-        });
-
-        hls.on(Hls.Events.FRAG_BUFFERED, (_event, data) => {
+        hls.on(Hls.Events.FRAG_BUFFERED, () => {
           if (signal.aborted) return;
           fragmentsBuffered++;
-
-          // Buffer diagnostics
-          const bufferInfo = describeBuffered(audioElement);
-          const currentTime = audioElement?.currentTime ?? 0;
-          const buffered = audioElement?.buffered;
-          let bufferAhead = 0;
-          if (buffered && buffered.length > 0) {
-            bufferAhead = buffered.end(buffered.length - 1) - currentTime;
-          }
-
-          // Warn if buffer is getting dangerously low
-          if (playbackAttempted && bufferAhead < 1.0) {
-            logger.warn('HLS buffer running low', {
-              sn: data.frag.sn,
-              bufferAhead: bufferAhead.toFixed(2) + 's',
-              buffered: bufferInfo,
-              currentTime: currentTime.toFixed(3),
-            });
-          } else {
-            logger.debug('HLS frag buffered', {
-              sn: data.frag.sn,
-              total: fragmentsBuffered,
-              bufferAhead: bufferAhead.toFixed(2) + 's',
-            });
-          }
-
           if (
             !playbackAttempted &&
             fragmentsBuffered >= BUFFERING_STRATEGY.MIN_FRAGMENTS_BEFORE_PLAY
           ) {
             playbackAttempted = true;
-            audioElement?.play().catch((err: Error) => {
-              if (err.name === 'NotAllowedError') {
-                logger.warn('Autoplay blocked by browser');
-              } else {
-                logger.warn('Playback start error', err);
-              }
-            });
+            audioElement?.play().catch(() => {});
           }
         });
 
@@ -328,6 +246,9 @@
             spectro.disconnect();
             return;
           }
+          if (activeSourceId) {
+            startLiveSpectrogramStream(activeSourceId);
+          }
           startHeartbeat(activeStreamToken!);
           if (activeSourceId) {
             connectDetectionStream(activeSourceId);
@@ -340,63 +261,21 @@
           if (signal.aborted) return;
           if (data.fatal) {
             connectionError = t('spectrogram.error.connectionFailed');
-            logger.error('Fatal HLS error', {
-              type: data.type,
-              details: data.details,
-              buffered: describeBuffered(audioElement),
-              currentTime: audioElement?.currentTime?.toFixed(3),
-            });
+            logger.error('Fatal HLS error', { type: data.type, details: data.details });
             stopStream();
-          } else {
-            // Non-fatal errors — log for debugging buffer issues
-            const info: Record<string, unknown> = {
-              type: data.type,
-              details: data.details,
-              buffered: describeBuffered(audioElement),
-              currentTime: audioElement?.currentTime?.toFixed(3),
-            };
-            if ('frag' in data && data.frag) {
-              const fragSn = (data.frag as { sn?: number | string }).sn;
-              info.fragSn = fragSn;
-              // Clean up fragment timing entry on error (FRAG_LOADED won't fire)
-              fragLoadStartTimes.delete(String(fragSn));
-            }
-            // Buffer stall events are key diagnostic signals
-            if (
-              data.details === 'bufferStalledError' ||
-              data.details === 'bufferNudgeOnStall' ||
-              data.details === 'bufferSeekOverHole'
-            ) {
-              logger.warn('HLS buffer stall event', info);
-            } else {
-              logger.warn('HLS non-fatal error', info);
-            }
           }
         });
-
-        // Level/track switching diagnostics
-        hls.on(Hls.Events.BUFFER_FLUSHING, () => {
-          if (signal.aborted) return;
-          logger.warn('HLS buffer flushing', {
-            currentTime: audioElement?.currentTime?.toFixed(3),
-            buffered: describeBuffered(audioElement),
-          });
-        });
       } else if (audioElement.canPlayType('application/vnd.apple.mpegurl')) {
-        // Native HLS (Safari)
+        // Native HLS fallback path
         audioElement.src = hlsUrl;
         try {
           await audioElement.play();
-        } catch (e) {
-          if ((e as Error).name === 'NotAllowedError') {
-            logger.warn('Autoplay blocked by browser');
-          }
+        } catch {
+          // Native autoplay may be blocked until a user gesture occurs.
         }
         if (signal.aborted || !audioElement) return;
-        await spectro.connect(audioElement);
-        if (signal.aborted) {
-          spectro.disconnect();
-          return;
+        if (activeSourceId) {
+          startLiveSpectrogramStream(activeSourceId);
         }
         startHeartbeat(activeStreamToken!);
         if (activeSourceId) {
@@ -518,6 +397,7 @@
 
     stopHeartbeat();
     disconnectDetectionStream();
+    stopLiveSpectrogramStream();
     currentWallClockAtPlayhead = 0;
     spectro.disconnect();
 
@@ -553,12 +433,18 @@
 
   function handleAudioOutputToggle() {
     audioOutput = !audioOutput;
+    if (audioElement) {
+      audioElement.muted = !audioOutput;
+    }
     spectro.setAudioOutput(audioOutput);
   }
 
   function handleGainChange(db: number) {
     gainDb = db;
     spectro.setGain(db);
+    if (audioElement) {
+      audioElement.volume = Math.max(0, Math.min(1, Math.pow(10, db / 20)));
+    }
   }
 
   // Use onMount (NOT $effect) to avoid reactive dependency loops.
@@ -623,76 +509,6 @@
       startStream();
     }
   }
-
-  // Periodic buffer health monitor — logs buffer state every 10s to help
-  // diagnose intermittent audio gaps. Uses warn level so it appears in production.
-  $effect(() => {
-    if (!audioElement || !isStreaming) return;
-
-    let lastCurrentTime = audioElement.currentTime;
-    let lastCheckTime = globalThis.performance.now();
-    let stallCount = 0;
-
-    const interval = globalThis.setInterval(() => {
-      if (!audioElement) return;
-
-      const now = globalThis.performance.now();
-      const elapsed = (now - lastCheckTime) / 1000;
-      const currentTime = audioElement.currentTime;
-      const playbackDelta = currentTime - lastCurrentTime;
-
-      // Detect playback stall: if currentTime hasn't advanced in 10s while
-      // we're supposed to be streaming, something is wrong.
-      // Skip when paused (e.g., browser tab backgrounded) to avoid false positives.
-      if (elapsed > 9 && playbackDelta < 0.5 && currentTime > 0 && !audioElement.paused) {
-        stallCount++;
-        logger.warn('Playback stall detected: currentTime not advancing', {
-          currentTime: currentTime.toFixed(3),
-          expectedAdvance: elapsed.toFixed(1) + 's',
-          actualAdvance: playbackDelta.toFixed(3) + 's',
-          stallCount,
-          readyState: audioElement.readyState,
-          paused: audioElement.paused,
-          buffered: describeBuffered(audioElement),
-          hlsLatency: hls?.latency?.toFixed(2),
-        });
-      }
-
-      // Periodic buffer health snapshot (every 10s)
-      const buffered = audioElement.buffered;
-      let bufferAhead = 0;
-      let bufferRangeCount = 0;
-      if (buffered && buffered.length > 0) {
-        bufferAhead = buffered.end(buffered.length - 1) - currentTime;
-        bufferRangeCount = buffered.length;
-      }
-
-      const healthInfo = {
-        currentTime: currentTime.toFixed(3),
-        bufferAhead: bufferAhead.toFixed(2) + 's',
-        bufferRanges: bufferRangeCount,
-        buffered: describeBuffered(audioElement),
-        readyState: audioElement.readyState,
-        hlsLatency: hls?.latency?.toFixed(2),
-        hlsBandwidth: hls?.bandwidthEstimate
-          ? (hls.bandwidthEstimate / 1000).toFixed(0) + 'kbps'
-          : undefined,
-      };
-
-      // Use warn for unhealthy state (low buffer, multiple ranges = holes),
-      // debug for normal operation to avoid spamming production console
-      if (bufferAhead < 2.0 || bufferRangeCount > 1) {
-        logger.warn('HLS buffer health: degraded', healthInfo);
-      } else {
-        logger.debug('HLS buffer health', healthInfo);
-      }
-
-      lastCurrentTime = currentTime;
-      lastCheckTime = now;
-    }, 10000);
-
-    return () => globalThis.clearInterval(interval);
-  });
 
   // Promote queued detection labels when playhead catches up.
   // Prefers hls.playingDate (accurate), falls back to seekable-based
@@ -832,11 +648,17 @@
         <SpectrogramCanvas
           analyser={spectro.analyser}
           frequencyData={spectro.frequencyData}
-          sampleRate={spectro.sampleRate}
-          fftSize={spectro.fftSize}
+          sampleRate={streamSampleRate}
+          fftSize={streamFFTSize}
+          showFrequencyAxis={true}
+          frequencyAxisMode="adaptive"
+          {showTimeAxis}
           {frequencyRange}
           {colorMap}
-          isActive={spectro.isActive}
+          isActive={isStreaming}
+          renderMode="stream"
+          {streamColumns}
+          {streamHopSize}
           overlayLabels={showDetectionLabels ? overlayLabels : []}
           debug={debugOverlay}
           wallClockAtPlayhead={currentWallClockAtPlayhead}
@@ -868,12 +690,16 @@
         {gainDb}
         {audioOutput}
         {showDetectionLabels}
+        {showTimeAxis}
         onFrequencyRangeChange={range => (frequencyRange = range)}
         onColorMapChange={map => (colorMap = map)}
         onGainChange={handleGainChange}
         onAudioOutputToggle={handleAudioOutputToggle}
         onDetectionLabelsToggle={() => {
           showDetectionLabels = !showDetectionLabels;
+        }}
+        onTimeAxisToggle={() => {
+          showTimeAxis = !showTimeAxis;
         }}
       />
     </div>

--- a/frontend/src/lib/desktop/features/live-stream/pages/LiveStreamPage.svelte
+++ b/frontend/src/lib/desktop/features/live-stream/pages/LiveStreamPage.svelte
@@ -25,7 +25,11 @@
   import { buildAppUrl } from '$lib/utils/urlHelpers';
   import { generateSessionId } from '$lib/utils/session';
   import { loggers } from '$lib/utils/logger';
-  import type { ColorMapName } from '$lib/utils/spectrogramColorMaps';
+  import {
+    COLOR_MAPS,
+    DEFAULT_COLOR_MAP,
+    type ColorMapName,
+  } from '$lib/utils/spectrogramColorMaps';
   import { hasLiveAudioAccess } from '$lib/stores/appState.svelte';
   import { connectLiveSpectrogramStream } from '$lib/utils/liveSpectrogramStream';
   import type { LiveSpectrogramColumn } from '$lib/types/liveSpectrogram';
@@ -48,6 +52,41 @@
   const LABEL_POLL_INTERVAL_MS = 200;
   /** Maximum label age (ms) before pruning from overlay */
   const LABEL_MAX_AGE_MS = 60000;
+  /** localStorage key for persisting the user's Live Audio color map choice */
+  const COLOR_MAP_STORAGE_KEY = 'birdnet-live-audio-color-map';
+
+  /**
+   * Load the persisted color map from localStorage, validating it against
+   * the authoritative set of registered color maps. Falls back to the
+   * default if the key is unset, invalid, or localStorage is unavailable
+   * (private browsing, strict privacy modes). Scoped to the Live Audio
+   * page only — the dashboard widget and Recent Detections have their
+   * own rendering and are intentionally not affected.
+   */
+  function loadPersistedColorMap(): ColorMapName {
+    try {
+      const stored = globalThis.localStorage?.getItem(COLOR_MAP_STORAGE_KEY);
+      if (stored && stored in COLOR_MAPS) {
+        return stored as ColorMapName;
+      }
+    } catch {
+      /* localStorage not available — fall through to default */
+    }
+    return DEFAULT_COLOR_MAP;
+  }
+
+  /**
+   * Persist the user's color map choice for next visit. Swallows errors
+   * from localStorage being unavailable so the UI stays functional even
+   * in strict-privacy browser modes.
+   */
+  function persistColorMap(choice: ColorMapName): void {
+    try {
+      globalThis.localStorage?.setItem(COLOR_MAP_STORAGE_KEY, choice);
+    } catch {
+      /* localStorage not available — silent no-op */
+    }
+  }
 
   const sessionId = generateSessionId();
 
@@ -72,7 +111,14 @@
 
   // Spectrogram config
   let frequencyRange = $state<[number, number]>([0, 15000]);
-  let colorMap = $state<ColorMapName>('inferno');
+  let colorMap = $state<ColorMapName>(loadPersistedColorMap());
+
+  // Persist the color map whenever the user changes it. $effect fires on
+  // initial mount with the currently-loaded value, which is a safe no-op
+  // (writing the same value we just read).
+  $effect(() => {
+    persistColorMap(colorMap);
+  });
   let gainDb = $state(0);
   let audioOutput = $state(true);
 

--- a/frontend/src/lib/types/liveSpectrogram.ts
+++ b/frontend/src/lib/types/liveSpectrogram.ts
@@ -1,0 +1,24 @@
+export interface LiveSpectrogramColumn {
+  tUnixMs: number;
+  bins: number[];
+}
+
+export interface LiveSpectrogramMeta {
+  type: 'spectrogram-meta';
+  sourceId: string;
+  streamEpochUnixMs: number;
+  sampleRate: number;
+  fftSize: number;
+  hopSize: number;
+  window: string;
+  binCount: number;
+  minFrequencyHz: number;
+  maxFrequencyHz: number;
+  batchIntervalMs: number;
+}
+
+export interface LiveSpectrogramColumnsEvent {
+  type: 'spectrogram-columns';
+  sourceId: string;
+  columns: LiveSpectrogramColumn[];
+}

--- a/frontend/src/lib/utils/audioContextManager.ts
+++ b/frontend/src/lib/utils/audioContextManager.ts
@@ -80,6 +80,22 @@ export async function getAudioContext(): Promise<AudioContext> {
 }
 
 /**
+ * Prime the shared AudioContext as early as possible in a user gesture.
+ *
+ * Safari is stricter than Chrome about when AudioContext.resume() is allowed.
+ * Calling this before async boundaries (fetch/HLS setup) helps preserve the
+ * gesture-initiated activation needed for analyser output on native HLS.
+ */
+export async function primeAudioContext(): Promise<void> {
+  try {
+    await getAudioContext();
+  } catch {
+    // Ignore support/activation failures here; callers can continue and the
+    // analyser will retry later during full graph setup.
+  }
+}
+
+/**
  * Check if AudioContext is supported in this browser.
  * Use this for feature detection before attempting audio playback.
  *

--- a/frontend/src/lib/utils/liveSpectrogramStream.ts
+++ b/frontend/src/lib/utils/liveSpectrogramStream.ts
@@ -1,0 +1,46 @@
+import ReconnectingEventSource from 'reconnecting-eventsource';
+
+import { buildAppUrl } from '$lib/utils/urlHelpers';
+import { loggers } from '$lib/utils/logger';
+import type { LiveSpectrogramColumnsEvent, LiveSpectrogramMeta } from '$lib/types/liveSpectrogram';
+
+const logger = loggers.audio;
+
+interface LiveSpectrogramHandlers {
+  onMeta?: (_meta: LiveSpectrogramMeta) => void;
+  onColumns?: (_event: LiveSpectrogramColumnsEvent) => void;
+}
+
+export function connectLiveSpectrogramStream(
+  sourceId: string,
+  handlers: LiveSpectrogramHandlers
+): () => void {
+  const encodedSourceId = encodeURIComponent(sourceId);
+  const eventSource = new ReconnectingEventSource(
+    buildAppUrl(`/api/v2/streams/spectrogram/${encodedSourceId}`),
+    {
+      max_retry_time: 30000,
+      withCredentials: false,
+    }
+  );
+
+  eventSource.addEventListener('spectrogram-meta', (event: Event) => {
+    try {
+      const messageEvent = event as MessageEvent;
+      handlers.onMeta?.(JSON.parse(messageEvent.data) as LiveSpectrogramMeta);
+    } catch (error) {
+      logger.error('Failed to parse live spectrogram metadata', error);
+    }
+  });
+
+  eventSource.addEventListener('spectrogram-columns', (event: Event) => {
+    try {
+      const messageEvent = event as MessageEvent;
+      handlers.onColumns?.(JSON.parse(messageEvent.data) as LiveSpectrogramColumnsEvent);
+    } catch (error) {
+      logger.error('Failed to parse live spectrogram columns', error);
+    }
+  });
+
+  return () => eventSource.close();
+}

--- a/frontend/src/lib/utils/useSpectrogramAnalyser.svelte.ts
+++ b/frontend/src/lib/utils/useSpectrogramAnalyser.svelte.ts
@@ -20,6 +20,7 @@
 import {
   getAudioContext,
   isAudioContextSupported,
+  primeAudioContext,
   releaseAudioContext,
 } from './audioContextManager';
 import { dbToGain } from './audio';
@@ -86,6 +87,7 @@ export function useSpectrogramAnalyser(options?: SpectrogramAnalyserOptions) {
     }
 
     try {
+      await primeAudioContext();
       audioContext = await getAudioContext();
       sampleRate = audioContext.sampleRate;
 
@@ -131,12 +133,6 @@ export function useSpectrogramAnalyser(options?: SpectrogramAnalyserOptions) {
       frequencyData = new Uint8Array(analyserNode.frequencyBinCount);
       analyser = analyserNode;
       isActive = true;
-
-      logger.debug('Spectrogram analyser connected', {
-        fftSize,
-        sampleRate: audioContext.sampleRate,
-        audioOutput,
-      });
     } catch (error) {
       logger.error('Failed to connect spectrogram analyser', error);
       // Clean up any partially built graph

--- a/frontend/static/messages/da.json
+++ b/frontend/static/messages/da.json
@@ -957,6 +957,7 @@
       "title": "Live-lyd",
       "sourceLabel": "Lydkilde",
       "connected": "Forbundet",
+      "syncingAudio": "Synkroniserer live-lyd...",
       "enterFullscreen": "Fuld skærm",
       "exitFullscreen": "Afslut fuld skærm"
     },
@@ -966,7 +967,8 @@
       "grayscale": "Gråtone"
     },
     "labels": {
-      "toggle": "Skift detekteringsetiketter"
+      "toggle": "Skift detekteringsetiketter",
+      "toggleTimeAxis": "Skift tidsakse"
     }
   },
   "system": {

--- a/frontend/static/messages/da.json
+++ b/frontend/static/messages/da.json
@@ -969,6 +969,9 @@
     "labels": {
       "toggle": "Skift detekteringsetiketter",
       "toggleTimeAxis": "Skift tidsakse"
+    },
+    "axis": {
+      "kHz": "kHz"
     }
   },
   "system": {

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -970,6 +970,9 @@
     "labels": {
       "toggle": "Erkennungslabels umschalten",
       "toggleTimeAxis": "Zeitachse umschalten"
+    },
+    "axis": {
+      "kHz": "kHz"
     }
   },
   "system": {

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -958,6 +958,7 @@
       "title": "Live-Audio",
       "sourceLabel": "Audioquelle",
       "connected": "Verbunden",
+      "syncingAudio": "Live-Audio wird synchronisiert...",
       "enterFullscreen": "Vollbild",
       "exitFullscreen": "Vollbild beenden"
     },
@@ -967,7 +968,8 @@
       "grayscale": "Graustufen"
     },
     "labels": {
-      "toggle": "Erkennungslabels umschalten"
+      "toggle": "Erkennungslabels umschalten",
+      "toggleTimeAxis": "Zeitachse umschalten"
     }
   },
   "system": {

--- a/frontend/static/messages/en.json
+++ b/frontend/static/messages/en.json
@@ -958,6 +958,7 @@
       "title": "Live Audio",
       "sourceLabel": "Audio Source",
       "connected": "Connected",
+      "syncingAudio": "Syncing live audio...",
       "enterFullscreen": "Enter fullscreen",
       "exitFullscreen": "Exit fullscreen"
     },
@@ -967,7 +968,8 @@
       "grayscale": "Grayscale"
     },
     "labels": {
-      "toggle": "Toggle detection labels"
+      "toggle": "Toggle detection labels",
+      "toggleTimeAxis": "Toggle time axis"
     }
   },
   "system": {

--- a/frontend/static/messages/en.json
+++ b/frontend/static/messages/en.json
@@ -970,6 +970,9 @@
     "labels": {
       "toggle": "Toggle detection labels",
       "toggleTimeAxis": "Toggle time axis"
+    },
+    "axis": {
+      "kHz": "kHz"
     }
   },
   "system": {

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -970,6 +970,9 @@
     "labels": {
       "toggle": "Alternar etiquetas de detección",
       "toggleTimeAxis": "Alternar eje temporal"
+    },
+    "axis": {
+      "kHz": "kHz"
     }
   },
   "system": {

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -958,6 +958,7 @@
       "title": "Audio en vivo",
       "sourceLabel": "Fuente de audio",
       "connected": "Conectado",
+      "syncingAudio": "Sincronizando audio en vivo...",
       "enterFullscreen": "Pantalla completa",
       "exitFullscreen": "Salir de pantalla completa"
     },
@@ -967,7 +968,8 @@
       "grayscale": "Escala de grises"
     },
     "labels": {
-      "toggle": "Alternar etiquetas de detección"
+      "toggle": "Alternar etiquetas de detección",
+      "toggleTimeAxis": "Alternar eje temporal"
     }
   },
   "system": {

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -958,6 +958,7 @@
       "title": "Reaaliaikainen ääni",
       "sourceLabel": "Äänilähde",
       "connected": "Yhdistetty",
+      "syncingAudio": "Synkronoidaan reaaliaikaista ääntä...",
       "enterFullscreen": "Koko näyttö",
       "exitFullscreen": "Poistu koko näytöstä"
     },
@@ -967,7 +968,8 @@
       "grayscale": "Harmaasävy"
     },
     "labels": {
-      "toggle": "Näytä/piilota tunnistusmerkinnät"
+      "toggle": "Näytä/piilota tunnistusmerkinnät",
+      "toggleTimeAxis": "Näytä/piilota aikajana"
     }
   },
   "system": {

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -970,6 +970,9 @@
     "labels": {
       "toggle": "Näytä/piilota tunnistusmerkinnät",
       "toggleTimeAxis": "Näytä/piilota aikajana"
+    },
+    "axis": {
+      "kHz": "kHz"
     }
   },
   "system": {

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -958,6 +958,7 @@
       "title": "Audio en direct",
       "sourceLabel": "Source audio",
       "connected": "Connecté",
+      "syncingAudio": "Synchronisation de l'audio en direct...",
       "enterFullscreen": "Plein écran",
       "exitFullscreen": "Quitter le plein écran"
     },
@@ -967,7 +968,8 @@
       "grayscale": "Niveaux de gris"
     },
     "labels": {
-      "toggle": "Basculer les étiquettes de détection"
+      "toggle": "Basculer les étiquettes de détection",
+      "toggleTimeAxis": "Basculer l'axe du temps"
     }
   },
   "system": {

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -970,6 +970,9 @@
     "labels": {
       "toggle": "Basculer les étiquettes de détection",
       "toggleTimeAxis": "Basculer l'axe du temps"
+    },
+    "axis": {
+      "kHz": "kHz"
     }
   },
   "system": {

--- a/frontend/static/messages/hu.json
+++ b/frontend/static/messages/hu.json
@@ -969,6 +969,9 @@
     "labels": {
       "toggle": "Detektálási címkék kapcsolása",
       "toggleTimeAxis": "Időtengely kapcsolása"
+    },
+    "axis": {
+      "kHz": "kHz"
     }
   },
   "system": {

--- a/frontend/static/messages/hu.json
+++ b/frontend/static/messages/hu.json
@@ -957,6 +957,7 @@
       "title": "Élő hang",
       "sourceLabel": "Hangforrás",
       "connected": "Csatlakoztatva",
+      "syncingAudio": "Élő hang szinkronizálása...",
       "enterFullscreen": "Teljes képernyő",
       "exitFullscreen": "Teljes képernyőből kilépés"
     },
@@ -966,7 +967,8 @@
       "grayscale": "Szürkeárnyalatos"
     },
     "labels": {
-      "toggle": "Detektálási címkék kapcsolása"
+      "toggle": "Detektálási címkék kapcsolása",
+      "toggleTimeAxis": "Időtengely kapcsolása"
     }
   },
   "system": {

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -957,6 +957,7 @@
       "title": "Audio dal vivo",
       "sourceLabel": "Sorgente audio",
       "connected": "Connesso",
+      "syncingAudio": "Sincronizzazione audio dal vivo...",
       "enterFullscreen": "Schermo intero",
       "exitFullscreen": "Esci da schermo intero"
     },
@@ -966,7 +967,8 @@
       "grayscale": "Scala di grigi"
     },
     "labels": {
-      "toggle": "Mostra/nascondi etichette di rilevamento"
+      "toggle": "Mostra/nascondi etichette di rilevamento",
+      "toggleTimeAxis": "Mostra/nascondi asse temporale"
     }
   },
   "system": {

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -969,6 +969,9 @@
     "labels": {
       "toggle": "Mostra/nascondi etichette di rilevamento",
       "toggleTimeAxis": "Mostra/nascondi asse temporale"
+    },
+    "axis": {
+      "kHz": "kHz"
     }
   },
   "system": {

--- a/frontend/static/messages/lv.json
+++ b/frontend/static/messages/lv.json
@@ -969,6 +969,9 @@
     "labels": {
       "toggle": "Pārslēgt noteikšanas etiķetes",
       "toggleTimeAxis": "Pārslēgt laika asi"
+    },
+    "axis": {
+      "kHz": "kHz"
     }
   },
   "system": {

--- a/frontend/static/messages/lv.json
+++ b/frontend/static/messages/lv.json
@@ -957,6 +957,7 @@
       "title": "Tiešraides audio",
       "sourceLabel": "Audio avots",
       "connected": "Savienots",
+      "syncingAudio": "Sinhronizē tiešraides audio...",
       "enterFullscreen": "Pilnekrāna režīms",
       "exitFullscreen": "Iziet no pilnekrāna"
     },
@@ -966,7 +967,8 @@
       "grayscale": "Pelēktoņu"
     },
     "labels": {
-      "toggle": "Pārslēgt noteikšanas etiķetes"
+      "toggle": "Pārslēgt noteikšanas etiķetes",
+      "toggleTimeAxis": "Pārslēgt laika asi"
     }
   },
   "system": {

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -970,6 +970,9 @@
     "labels": {
       "toggle": "Detectielabels aan/uit",
       "toggleTimeAxis": "Tijdas aan/uit"
+    },
+    "axis": {
+      "kHz": "kHz"
     }
   },
   "system": {

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -958,6 +958,7 @@
       "title": "Live audio",
       "sourceLabel": "Audiobron",
       "connected": "Verbonden",
+      "syncingAudio": "Live-audio synchroniseren...",
       "enterFullscreen": "Volledig scherm",
       "exitFullscreen": "Volledig scherm sluiten"
     },
@@ -967,7 +968,8 @@
       "grayscale": "Grijstinten"
     },
     "labels": {
-      "toggle": "Detectielabels aan/uit"
+      "toggle": "Detectielabels aan/uit",
+      "toggleTimeAxis": "Tijdas aan/uit"
     }
   },
   "system": {

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -970,6 +970,9 @@
     "labels": {
       "toggle": "Przełącz etykiety wykrywania",
       "toggleTimeAxis": "Przełącz oś czasu"
+    },
+    "axis": {
+      "kHz": "kHz"
     }
   },
   "system": {

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -958,6 +958,7 @@
       "title": "Audio na żywo",
       "sourceLabel": "Źródło audio",
       "connected": "Połączono",
+      "syncingAudio": "Synchronizowanie dźwięku na żywo...",
       "enterFullscreen": "Pełny ekran",
       "exitFullscreen": "Zamknij pełny ekran"
     },
@@ -967,7 +968,8 @@
       "grayscale": "Skala szarości"
     },
     "labels": {
-      "toggle": "Przełącz etykiety wykrywania"
+      "toggle": "Przełącz etykiety wykrywania",
+      "toggleTimeAxis": "Przełącz oś czasu"
     }
   },
   "system": {

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -958,6 +958,7 @@
       "title": "Áudio em Direto",
       "sourceLabel": "Fonte de Áudio",
       "connected": "Conectado",
+      "syncingAudio": "A sincronizar áudio em direto...",
       "enterFullscreen": "Tela cheia",
       "exitFullscreen": "Sair da tela cheia"
     },
@@ -967,7 +968,8 @@
       "grayscale": "Escala de Cinzentos"
     },
     "labels": {
-      "toggle": "Alternar rótulos de deteção"
+      "toggle": "Alternar rótulos de deteção",
+      "toggleTimeAxis": "Alternar eixo temporal"
     }
   },
   "system": {

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -970,6 +970,9 @@
     "labels": {
       "toggle": "Alternar rótulos de deteção",
       "toggleTimeAxis": "Alternar eixo temporal"
+    },
+    "axis": {
+      "kHz": "kHz"
     }
   },
   "system": {

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -957,6 +957,7 @@
       "title": "Živý zvuk",
       "sourceLabel": "Zdroj zvuku",
       "connected": "Pripojené",
+      "syncingAudio": "Synchronizuje sa živý zvuk...",
       "enterFullscreen": "Celá obrazovka",
       "exitFullscreen": "Ukončiť celú obrazovku"
     },
@@ -966,7 +967,8 @@
       "grayscale": "Odtiene šedej"
     },
     "labels": {
-      "toggle": "Prepnúť štítky detekcie"
+      "toggle": "Prepnúť štítky detekcie",
+      "toggleTimeAxis": "Prepnúť časovú os"
     }
   },
   "system": {

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -969,6 +969,9 @@
     "labels": {
       "toggle": "Prepnúť štítky detekcie",
       "toggleTimeAxis": "Prepnúť časovú os"
+    },
+    "axis": {
+      "kHz": "kHz"
     }
   },
   "system": {

--- a/frontend/static/messages/sv.json
+++ b/frontend/static/messages/sv.json
@@ -969,6 +969,9 @@
     "labels": {
       "toggle": "Växla detekteringsetiketter",
       "toggleTimeAxis": "Växla tidsaxel"
+    },
+    "axis": {
+      "kHz": "kHz"
     }
   },
   "system": {

--- a/frontend/static/messages/sv.json
+++ b/frontend/static/messages/sv.json
@@ -957,6 +957,7 @@
       "title": "Live-ljud",
       "sourceLabel": "Ljudkälla",
       "connected": "Ansluten",
+      "syncingAudio": "Synkroniserar live-ljud...",
       "enterFullscreen": "Helskärm",
       "exitFullscreen": "Avsluta helskärm"
     },
@@ -966,7 +967,8 @@
       "grayscale": "Gråskala"
     },
     "labels": {
-      "toggle": "Växla detekteringsetiketter"
+      "toggle": "Växla detekteringsetiketter",
+      "toggleTimeAxis": "Växla tidsaxel"
     }
   },
   "system": {

--- a/internal/analysis/api_service.go
+++ b/internal/analysis/api_service.go
@@ -35,14 +35,16 @@ type APIServerService struct {
 	metrics    *observability.Metrics
 	engine     *engine.AudioEngine
 
-	server         *api.Server
-	proc           *processor.Processor
-	birdImageCache *imageprovider.BirdImageCache
-	sunCalc        *suncalc.SunCalc
-	oauth2Server   *security.OAuth2Server
-	systemMonitor  *monitor.SystemMonitor
-	controlChan    chan string
-	audioLevelChan chan audiocore.AudioLevelData
+	server              *api.Server
+	proc                *processor.Processor
+	birdImageCache      *imageprovider.BirdImageCache
+	sunCalc             *suncalc.SunCalc
+	oauth2Server        *security.OAuth2Server
+	systemMonitor       *monitor.SystemMonitor
+	controlChan         chan string
+	audioLevelChan      chan audiocore.AudioLevelData
+	liveSpectrogramChan chan apiv2.LiveSpectrogramBatch
+	liveSpectrogramMgr  *LiveSpectrogramManager
 }
 
 // NewAPIServerService creates a new APIServerService with the given dependencies.
@@ -153,6 +155,8 @@ func (s *APIServerService) Start(_ context.Context) error {
 	// Create channels.
 	s.controlChan = make(chan string, 1)
 	s.audioLevelChan = make(chan audiocore.AudioLevelData, 100)
+	s.liveSpectrogramChan = make(chan apiv2.LiveSpectrogramBatch, 100)
+	s.liveSpectrogramMgr = NewLiveSpectrogramManager(s.settings, s.engine, s.liveSpectrogramChan)
 
 	// Create OAuth2 server.
 	s.oauth2Server = security.NewOAuth2Server()
@@ -167,6 +171,8 @@ func (s *APIServerService) Start(_ context.Context) error {
 		api.WithMetrics(s.metrics),
 		api.WithControlChannel(s.controlChan),
 		api.WithAudioLevelChannel(s.audioLevelChan),
+		api.WithLiveSpectrogramChannel(s.liveSpectrogramChan),
+		api.WithLiveSpectrogramLifecycle(s.liveSpectrogramMgr.Acquire, s.liveSpectrogramMgr.Release),
 		api.WithOAuth2Server(s.oauth2Server),
 		api.WithSunCalc(s.sunCalc),
 		api.WithV2Manager(s.dbService.V2Manager()),
@@ -249,6 +255,14 @@ func (s *APIServerService) Stop(ctx context.Context) error {
 	if s.audioLevelChan != nil {
 		close(s.audioLevelChan)
 		s.audioLevelChan = nil
+	}
+	if s.liveSpectrogramMgr != nil {
+		s.liveSpectrogramMgr.Close()
+		s.liveSpectrogramMgr = nil
+	}
+	if s.liveSpectrogramChan != nil {
+		close(s.liveSpectrogramChan)
+		s.liveSpectrogramChan = nil
 	}
 
 	return nil

--- a/internal/analysis/live_spectrogram_manager.go
+++ b/internal/analysis/live_spectrogram_manager.go
@@ -6,6 +6,7 @@ import (
 
 	apiv2 "github.com/tphakala/birdnet-go/internal/api/v2"
 	"github.com/tphakala/birdnet-go/internal/audiocore/engine"
+	"github.com/tphakala/birdnet-go/internal/audiocore/equalizer"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/logger"
 	"github.com/tphakala/birdnet-go/internal/privacy"
@@ -77,13 +78,22 @@ func (m *LiveSpectrogramManager) Acquire(sourceID string) error {
 		return fmt.Errorf("failed to create live spectrogram consumer: %w", err)
 	}
 
-	if err := m.engine.Router().AddRoute(sourceID, consumer, targetSampleRate); err != nil {
+	// Look up per-source gain and EQ so the spectrogram reflects exactly
+	// what the user hears via HLS on the Live Audio page. The HLS
+	// consumer uses the same lookups (see audio_hls.go), so the visual
+	// waterfall stays in lockstep with the audible stream even after
+	// runtime gain/EQ changes.
+	gainDB, _ := m.engine.Registry().GetGain(sourceID)
+	liveSettings := conf.Setting()
+	audioSettings := &liveSettings.Realtime.Audio
+	srcCfg := audioSettings.FindSourceByID(sourceID)
+	eqChain := equalizer.BuildFilterChainForSource(srcCfg, audioSettings.Equalizer, targetSampleRate)
+
+	if err := m.engine.Router().AddRoute(sourceID, consumer, targetSampleRate, gainDB, eqChain); err != nil {
 		return fmt.Errorf("failed to add live spectrogram route: %w", err)
 	}
 
-	m.forwarders.Add(1)
-	go func() {
-		defer m.forwarders.Done()
+	m.forwarders.Go(func() {
 		var drops int64
 		for batch := range consumerOut {
 			select {
@@ -98,7 +108,7 @@ func (m *LiveSpectrogramManager) Acquire(sourceID string) error {
 				}
 			}
 		}
-	}()
+	})
 
 	m.sources[sourceID] = &liveSpectrogramSourceState{
 		refCount: 1,

--- a/internal/analysis/live_spectrogram_manager.go
+++ b/internal/analysis/live_spectrogram_manager.go
@@ -24,8 +24,9 @@ type LiveSpectrogramManager struct {
 	engine   *engine.AudioEngine
 	outChan  chan apiv2.LiveSpectrogramBatch
 
-	mu      sync.Mutex
-	sources map[string]*liveSpectrogramSourceState
+	mu         sync.Mutex
+	sources    map[string]*liveSpectrogramSourceState
+	forwarders sync.WaitGroup
 }
 
 func NewLiveSpectrogramManager(settings *conf.Settings, audioEngine *engine.AudioEngine, outChan chan apiv2.LiveSpectrogramBatch) *LiveSpectrogramManager {
@@ -59,10 +60,7 @@ func (m *LiveSpectrogramManager) Acquire(sourceID string) error {
 		return fmt.Errorf("live spectrogram streaming is disabled")
 	}
 
-	targetSampleRate := conf.SampleRate
-	if m.settings.WebServer.LiveStream.SampleRate > 0 {
-		targetSampleRate = m.settings.WebServer.LiveStream.SampleRate
-	}
+	targetSampleRate := m.settings.WebServer.LiveStream.EffectiveSampleRate()
 
 	consumerID := "spectrogram_" + sourceID
 	consumer, consumerOut, err := NewSpectrogramConsumer(
@@ -83,11 +81,21 @@ func (m *LiveSpectrogramManager) Acquire(sourceID string) error {
 		return fmt.Errorf("failed to add live spectrogram route: %w", err)
 	}
 
+	m.forwarders.Add(1)
 	go func() {
+		defer m.forwarders.Done()
+		var drops int64
 		for batch := range consumerOut {
 			select {
 			case m.outChan <- batch:
 			default:
+				drops++
+				if drops == 1 || drops%spectrogramDropLogInterval == 0 {
+					GetLogger().Warn("live spectrogram batch dropped at manager forwarder",
+						logger.String("source_id", privacy.SanitizeRTSPUrl(sourceID)),
+						logger.String("consumer_id", consumerID),
+						logger.Int64("total_drops", drops))
+				}
 			}
 		}
 	}()
@@ -134,16 +142,20 @@ func (m *LiveSpectrogramManager) Release(sourceID string) {
 		logger.String("consumer_id", "spectrogram_"+sourceID))
 }
 
+// Close tears down every active source and waits for the per-source
+// forwarding goroutines to exit. Callers must not close m.outChan until Close
+// has returned — otherwise the forwarders may send on a closed channel.
 func (m *LiveSpectrogramManager) Close() {
 	if m == nil {
 		return
 	}
 
 	m.mu.Lock()
-	defer m.mu.Unlock()
-
 	for sourceID, state := range m.sources {
 		state.cleanup()
 		delete(m.sources, sourceID)
 	}
+	m.mu.Unlock()
+
+	m.forwarders.Wait()
 }

--- a/internal/analysis/live_spectrogram_manager.go
+++ b/internal/analysis/live_spectrogram_manager.go
@@ -1,0 +1,149 @@
+package analysis
+
+import (
+	"fmt"
+	"sync"
+
+	apiv2 "github.com/tphakala/birdnet-go/internal/api/v2"
+	"github.com/tphakala/birdnet-go/internal/audiocore/engine"
+	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/logger"
+	"github.com/tphakala/birdnet-go/internal/privacy"
+)
+
+type liveSpectrogramSourceState struct {
+	refCount int
+	consumer *SpectrogramConsumer
+	cleanup  func()
+}
+
+// LiveSpectrogramManager attaches spectrogram FFT consumers only while there
+// is at least one active SSE viewer for a given source.
+type LiveSpectrogramManager struct {
+	settings *conf.Settings
+	engine   *engine.AudioEngine
+	outChan  chan apiv2.LiveSpectrogramBatch
+
+	mu      sync.Mutex
+	sources map[string]*liveSpectrogramSourceState
+}
+
+func NewLiveSpectrogramManager(settings *conf.Settings, audioEngine *engine.AudioEngine, outChan chan apiv2.LiveSpectrogramBatch) *LiveSpectrogramManager {
+	return &LiveSpectrogramManager{
+		settings: settings,
+		engine:   audioEngine,
+		outChan:  outChan,
+		sources:  make(map[string]*liveSpectrogramSourceState),
+	}
+}
+
+func (m *LiveSpectrogramManager) Acquire(sourceID string) error {
+	if m == nil || sourceID == "" {
+		return nil
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if state := m.sources[sourceID]; state != nil {
+		state.refCount++
+		return nil
+	}
+
+	if m.engine == nil || m.outChan == nil {
+		return fmt.Errorf("live spectrogram manager is not initialized")
+	}
+
+	cfg := m.settings.WebServer.LiveStream.Spectrogram
+	if !cfg.Enabled {
+		return fmt.Errorf("live spectrogram streaming is disabled")
+	}
+
+	targetSampleRate := conf.SampleRate
+	if m.settings.WebServer.LiveStream.SampleRate > 0 {
+		targetSampleRate = m.settings.WebServer.LiveStream.SampleRate
+	}
+
+	consumerID := "spectrogram_" + sourceID
+	consumer, consumerOut, err := NewSpectrogramConsumer(
+		consumerID,
+		targetSampleRate,
+		conf.BitDepth,
+		1,
+		cfg.FFTSize,
+		cfg.HopSize,
+		cfg.Window,
+		cfg.BatchIntervalMs,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create live spectrogram consumer: %w", err)
+	}
+
+	if err := m.engine.Router().AddRoute(sourceID, consumer, targetSampleRate); err != nil {
+		return fmt.Errorf("failed to add live spectrogram route: %w", err)
+	}
+
+	go func() {
+		for batch := range consumerOut {
+			select {
+			case m.outChan <- batch:
+			default:
+			}
+		}
+	}()
+
+	m.sources[sourceID] = &liveSpectrogramSourceState{
+		refCount: 1,
+		consumer: consumer,
+		cleanup: func() {
+			m.engine.Router().RemoveRoute(sourceID, consumerID)
+			_ = consumer.Close()
+		},
+	}
+
+	GetLogger().Debug("Registered live spectrogram route",
+		logger.String("source_id", privacy.SanitizeRTSPUrl(sourceID)),
+		logger.String("consumer_id", consumerID))
+
+	return nil
+}
+
+func (m *LiveSpectrogramManager) Release(sourceID string) {
+	if m == nil || sourceID == "" {
+		return
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	state := m.sources[sourceID]
+	if state == nil {
+		return
+	}
+
+	state.refCount--
+	if state.refCount > 0 {
+		return
+	}
+
+	state.cleanup()
+	delete(m.sources, sourceID)
+
+	GetLogger().Debug("Removed live spectrogram route",
+		logger.String("source_id", privacy.SanitizeRTSPUrl(sourceID)),
+		logger.String("consumer_id", "spectrogram_"+sourceID))
+}
+
+func (m *LiveSpectrogramManager) Close() {
+	if m == nil {
+		return
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for sourceID, state := range m.sources {
+		state.cleanup()
+		delete(m.sources, sourceID)
+	}
+}

--- a/internal/analysis/processor/actions_database.go
+++ b/internal/analysis/processor/actions_database.go
@@ -10,7 +10,6 @@ import (
 	"path/filepath"
 	"time"
 
-	audioBuffer "github.com/tphakala/birdnet-go/internal/audiocore/buffer"
 	"github.com/tphakala/birdnet-go/internal/audiocore/convert"
 	"github.com/tphakala/birdnet-go/internal/audiocore/ffmpeg"
 	"github.com/tphakala/birdnet-go/internal/conf"
@@ -310,9 +309,9 @@ func (a *SaveAudioAction) Execute(ctx context.Context, _ any) error {
 		endTime := a.beginTime.Add(time.Duration(a.duration) * time.Second)
 		pcmData, err := cb.ReadSegment(a.beginTime, endTime)
 		if err != nil {
-			if stderrors.Is(err, audioBuffer.ErrInsufficientData) {
-				return err
-			}
+			// Both ErrInsufficientData and any other read error unwind to
+			// the job-queue retry layer via save_audio_action.go's retry
+			// config. No special per-error handling needed here.
 			return err
 		}
 		a.pcmData = pcmData

--- a/internal/analysis/processor/actions_database.go
+++ b/internal/analysis/processor/actions_database.go
@@ -5,10 +5,12 @@ package processor
 
 import (
 	"context"
+	stderrors "errors"
 	"os"
 	"path/filepath"
 	"time"
 
+	audioBuffer "github.com/tphakala/birdnet-go/internal/audiocore/buffer"
 	"github.com/tphakala/birdnet-go/internal/audiocore/convert"
 	"github.com/tphakala/birdnet-go/internal/audiocore/ffmpeg"
 	"github.com/tphakala/birdnet-go/internal/conf"
@@ -293,6 +295,27 @@ func (a *SaveAudioAction) Execute(ctx context.Context, _ any) error {
 			logger.String("clip_name", a.ClipName),
 			logger.String("operation", "audio_export_disabled"))
 		return nil
+	}
+
+	if len(a.pcmData) == 0 && a.bufferMgr != nil && a.duration > 0 {
+		if wait := time.Until(a.readyAt); wait > 0 {
+			return stderrors.New("audio export deferred until capture tail is available")
+		}
+
+		cb, err := a.bufferMgr.CaptureBuffer(a.sourceID)
+		if err != nil {
+			return err
+		}
+
+		endTime := a.beginTime.Add(time.Duration(a.duration) * time.Second)
+		pcmData, err := cb.ReadSegment(a.beginTime, endTime)
+		if err != nil {
+			if stderrors.Is(err, audioBuffer.ErrInsufficientData) {
+				return err
+			}
+			return err
+		}
+		a.pcmData = pcmData
 	}
 
 	// If PCM data was not captured (e.g., buffer read failed), skip export.

--- a/internal/analysis/processor/actions_types.go
+++ b/internal/analysis/processor/actions_types.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/tphakala/birdnet-go/internal/analysis/jobqueue"
 	"github.com/tphakala/birdnet-go/internal/analysis/species"
+	"github.com/tphakala/birdnet-go/internal/audiocore/buffer"
 	"github.com/tphakala/birdnet-go/internal/birdweather"
 	"github.com/tphakala/birdnet-go/internal/classifier"
 	"github.com/tphakala/birdnet-go/internal/conf"
@@ -95,6 +96,11 @@ type SaveAudioAction struct {
 	Settings      *conf.Settings
 	ClipName      string
 	pcmData       []byte            // Pre-read PCM data (set by buildSaveAudioAction)
+	bufferMgr     *buffer.Manager   // Used for deferred buffer reads when extended capture tail is still in the future
+	sourceID      string            // Source used for deferred buffer reads
+	beginTime     time.Time         // Capture start used for deferred buffer reads
+	duration      int               // Capture length in seconds used for deferred buffer reads
+	readyAt       time.Time         // Earliest time deferred capture is expected to be fully available
 	NoteID        uint              // Note ID for correlation logging with pre-renderer
 	PreRenderer   PreRendererSubmit // Injected from processor
 	DetectionCtx  *DetectionContext // Shared context to signal ClipSaved to late consumers

--- a/internal/analysis/processor/processor.go
+++ b/internal/analysis/processor/processor.go
@@ -1898,6 +1898,23 @@ func (p *Processor) buildSaveAudioAction(det *Detections, detectionCtx *Detectio
 	// Read PCM data from the capture buffer NOW, while the data is still in the
 	// ring buffer. By the time the job queue picks up the SaveAudioAction, the
 	// buffer may have been overwritten with newer audio data.
+	captureEndTime := det.Result.BeginTime.Add(time.Duration(captureLength) * time.Second)
+	if captureEndTime.After(time.Now()) {
+		return &SaveAudioAction{
+			Settings:      p.Settings,
+			ClipName:      det.Result.ClipName,
+			bufferMgr:     p.BufferMgr,
+			sourceID:      det.Result.AudioSource.ID,
+			beginTime:     det.Result.BeginTime,
+			duration:      captureLength,
+			readyAt:       captureEndTime,
+			NoteID:        det.Result.ID,
+			PreRenderer:   p.preRenderer,
+			DetectionCtx:  detectionCtx,
+			CorrelationID: det.CorrelationID,
+		}
+	}
+
 	pcmData, err := p.readCaptureSegment(det.Result.AudioSource.ID, det.Result.BeginTime, captureLength)
 	if err != nil {
 		GetLogger().Error("Failed to read capture buffer for audio export",

--- a/internal/analysis/processor/save_audio_action_test.go
+++ b/internal/analysis/processor/save_audio_action_test.go
@@ -89,6 +89,15 @@ func TestGetJobQueueRetryConfig_SaveAudioDeferredRead(t *testing.T) {
 		readyAt:  time.Now().Add(time.Second),
 	})
 
+	// Lock the deferred-export retry contract to exact values so an
+	// accidental change to workers.go's retry policy (MaxRetries,
+	// InitialDelay, MaxDelay, or Multiplier) fails this test instead
+	// of silently altering production behavior. The previous
+	// GreaterOrEqual(MaxRetries, 1) assertion was too permissive to
+	// catch a regression.
 	assert.True(t, cfg.Enabled)
-	assert.GreaterOrEqual(t, cfg.MaxRetries, 1)
+	assert.Equal(t, 7, cfg.MaxRetries)
+	assert.Equal(t, time.Second, cfg.InitialDelay)
+	assert.Equal(t, 30*time.Second, cfg.MaxDelay)
+	assert.InEpsilon(t, 2.0, cfg.Multiplier, 0.001)
 }

--- a/internal/analysis/processor/save_audio_action_test.go
+++ b/internal/analysis/processor/save_audio_action_test.go
@@ -29,7 +29,11 @@ func TestSaveAudioActionExecute_DefersUntilCaptureReady(t *testing.T) {
 		sourceID:  "test-source",
 		beginTime: time.Now(),
 		duration:  2,
-		readyAt:   time.Now().Add(100 * time.Millisecond),
+		// 5 seconds is long enough to remain in the future even on a
+		// heavily-loaded CI runner that delays test dispatch, so the
+		// Execute call below reliably hits the deferred-retry code path.
+		// The previous 100ms was flaky under load.
+		readyAt: time.Now().Add(5 * time.Second),
 	}
 
 	err := action.Execute(t.Context(), nil)

--- a/internal/analysis/processor/save_audio_action_test.go
+++ b/internal/analysis/processor/save_audio_action_test.go
@@ -1,0 +1,91 @@
+package processor
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	audioBuffer "github.com/tphakala/birdnet-go/internal/audiocore/buffer"
+	"github.com/tphakala/birdnet-go/internal/conf"
+)
+
+func TestSaveAudioActionExecute_DefersUntilCaptureReady(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	settings := conf.NewTestSettings().
+		WithAudioExport(tmpDir, "wav", "192k").
+		Build()
+
+	mgr := audioBuffer.NewManager(GetLogger())
+
+	action := &SaveAudioAction{
+		Settings:  settings,
+		ClipName:  "deferred.wav",
+		bufferMgr: mgr,
+		sourceID:  "test-source",
+		beginTime: time.Now(),
+		duration:  2,
+		readyAt:   time.Now().Add(100 * time.Millisecond),
+	}
+
+	err := action.Execute(context.Background(), nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "deferred")
+}
+
+func TestSaveAudioActionExecute_ReadsDeferredCaptureWhenReady(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	settings := conf.NewTestSettings().
+		WithAudioExport(tmpDir, "wav", "192k").
+		Build()
+
+	mgr := audioBuffer.NewManager(GetLogger())
+	sourceID := "test-source"
+	require.NoError(t, mgr.AllocateCapture(sourceID, 10, conf.SampleRate, conf.BitDepth/8))
+
+	cb, err := mgr.CaptureBuffer(sourceID)
+	require.NoError(t, err)
+
+	chunk := make([]byte, 3*conf.SampleRate*(conf.BitDepth/8))
+	for i := range chunk {
+		chunk[i] = byte(i % 251)
+	}
+	require.NoError(t, cb.Write(chunk))
+
+	action := &SaveAudioAction{
+		Settings:  settings,
+		ClipName:  "deferred.wav",
+		bufferMgr: mgr,
+		sourceID:  sourceID,
+		beginTime: cb.StartTime(),
+		duration:  2,
+		readyAt:   time.Now().Add(-time.Second),
+	}
+
+	require.NoError(t, action.Execute(context.Background(), nil))
+
+	outputPath := filepath.Join(tmpDir, "deferred.wav")
+	info, err := os.Stat(outputPath)
+	require.NoError(t, err)
+	assert.Greater(t, info.Size(), int64(0))
+}
+
+func TestGetJobQueueRetryConfig_SaveAudioDeferredRead(t *testing.T) {
+	t.Parallel()
+
+	cfg := getJobQueueRetryConfig(&SaveAudioAction{
+		sourceID: "test-source",
+		duration: 10,
+		readyAt:  time.Now().Add(time.Second),
+	})
+
+	assert.True(t, cfg.Enabled)
+	assert.GreaterOrEqual(t, cfg.MaxRetries, 1)
+}

--- a/internal/analysis/processor/save_audio_action_test.go
+++ b/internal/analysis/processor/save_audio_action_test.go
@@ -1,7 +1,6 @@
 package processor
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -33,7 +32,7 @@ func TestSaveAudioActionExecute_DefersUntilCaptureReady(t *testing.T) {
 		readyAt:   time.Now().Add(100 * time.Millisecond),
 	}
 
-	err := action.Execute(context.Background(), nil)
+	err := action.Execute(t.Context(), nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "deferred")
 }
@@ -69,12 +68,12 @@ func TestSaveAudioActionExecute_ReadsDeferredCaptureWhenReady(t *testing.T) {
 		readyAt:   time.Now().Add(-time.Second),
 	}
 
-	require.NoError(t, action.Execute(context.Background(), nil))
+	require.NoError(t, action.Execute(t.Context(), nil))
 
 	outputPath := filepath.Join(tmpDir, "deferred.wav")
 	info, err := os.Stat(outputPath)
 	require.NoError(t, err)
-	assert.Greater(t, info.Size(), int64(0))
+	assert.Positive(t, info.Size())
 }
 
 func TestGetJobQueueRetryConfig_SaveAudioDeferredRead(t *testing.T) {

--- a/internal/analysis/processor/workers.go
+++ b/internal/analysis/processor/workers.go
@@ -96,6 +96,17 @@ func getJobQueueRetryConfig(action Action) jobqueue.RetryConfig {
 		return a.RetryConfig // Now directly returns jobqueue.RetryConfig
 	case *MqttAction:
 		return a.RetryConfig // Now directly returns jobqueue.RetryConfig
+	case *SaveAudioAction:
+		if !a.readyAt.IsZero() || (a.bufferMgr != nil && a.duration > 0) {
+			return jobqueue.RetryConfig{
+				Enabled:      true,
+				MaxRetries:   7,
+				InitialDelay: 1 * time.Second,
+				MaxDelay:     30 * time.Second,
+				Multiplier:   2.0,
+			}
+		}
+		return jobqueue.RetryConfig{Enabled: false}
 	default:
 		// Default no retry for actions that don't support it
 		return jobqueue.RetryConfig{Enabled: false}

--- a/internal/analysis/spectrogram_consumer.go
+++ b/internal/analysis/spectrogram_consumer.go
@@ -1,0 +1,229 @@
+package analysis
+
+import (
+	"math"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	apiv2 "github.com/tphakala/birdnet-go/internal/api/v2"
+	"github.com/tphakala/birdnet-go/internal/audiocore"
+	"github.com/tphakala/birdnet-go/internal/audiocore/convert"
+	"github.com/tphakala/birdnet-go/internal/errors"
+	"gonum.org/v1/gonum/dsp/fourier"
+)
+
+const spectrogramChanSize = 16
+
+type SpectrogramConsumer struct {
+	id              string
+	rate            int
+	depth           int
+	channels        int
+	fftSize         int
+	hopSize         int
+	window          string
+	batchIntervalMs int
+	closed          atomic.Bool
+	closeOnce       sync.Once
+	outCh           chan apiv2.LiveSpectrogramBatch
+
+	fft          *fourier.FFT
+	windowCoeffs []float64
+	rolling      []float64
+	rollingStart time.Time
+	batch        []apiv2.LiveSpectrogramColumn
+	lastFlush    time.Time
+	scratchPCM   []float64
+	scratchMono  []float64
+}
+
+func NewSpectrogramConsumer(id string, sampleRate, bitDepth, channels, fftSize, hopSize int, window string, batchIntervalMs int) (*SpectrogramConsumer, chan apiv2.LiveSpectrogramBatch, error) {
+	if sampleRate <= 0 || fftSize <= 0 || hopSize <= 0 {
+		return nil, nil, errors.Newf("invalid live spectrogram configuration").
+			Component("analysis.spectrogram_consumer").
+			Category(errors.CategoryValidation).
+			Context("operation", "new_spectrogram_consumer").
+			Build()
+	}
+	if fftSize&(fftSize-1) != 0 {
+		return nil, nil, errors.Newf("fft size must be power of 2: %d", fftSize).
+			Component("analysis.spectrogram_consumer").
+			Category(errors.CategoryValidation).
+			Context("operation", "new_spectrogram_consumer").
+			Build()
+	}
+	if hopSize > fftSize {
+		return nil, nil, errors.Newf("hop size must be <= fft size: hop=%d fft=%d", hopSize, fftSize).
+			Component("analysis.spectrogram_consumer").
+			Category(errors.CategoryValidation).
+			Context("operation", "new_spectrogram_consumer").
+			Build()
+	}
+	if batchIntervalMs <= 0 {
+		batchIntervalMs = 16
+	}
+
+	ch := make(chan apiv2.LiveSpectrogramBatch, spectrogramChanSize)
+	return &SpectrogramConsumer{
+		id:              id,
+		rate:            sampleRate,
+		depth:           bitDepth,
+		channels:        channels,
+		fftSize:         fftSize,
+		hopSize:         hopSize,
+		window:          window,
+		batchIntervalMs: batchIntervalMs,
+		outCh:           ch,
+		fft:             fourier.NewFFT(fftSize),
+		windowCoeffs:    buildWindow(window, fftSize),
+	}, ch, nil
+}
+
+func (c *SpectrogramConsumer) ID() string      { return c.id }
+func (c *SpectrogramConsumer) SampleRate() int { return c.rate }
+func (c *SpectrogramConsumer) BitDepth() int   { return c.depth }
+func (c *SpectrogramConsumer) Channels() int   { return c.channels }
+
+func (c *SpectrogramConsumer) Write(frame audiocore.AudioFrame) error { //nolint:gocritic
+	if c.closed.Load() {
+		return audiocore.ErrConsumerClosed
+	}
+	samples := c.decodeFrame(frame)
+	if len(samples) == 0 {
+		return nil
+	}
+	if c.rollingStart.IsZero() {
+		c.rollingStart = frame.Timestamp
+	}
+	c.rolling = append(c.rolling, samples...)
+
+	for len(c.rolling) >= c.fftSize {
+		c.batch = append(c.batch, c.makeColumn())
+		c.rolling = c.rolling[c.hopSize:]
+		c.rollingStart = c.rollingStart.Add(samplesDuration(c.hopSize, c.rate))
+	}
+
+	if len(c.batch) == 0 {
+		return nil
+	}
+	now := time.Now()
+	if c.lastFlush.IsZero() || now.Sub(c.lastFlush) >= time.Duration(c.batchIntervalMs)*time.Millisecond {
+		c.flush(frame.SourceID)
+		c.lastFlush = now
+	}
+	return nil
+}
+
+func (c *SpectrogramConsumer) Close() error {
+	c.closed.Store(true)
+	c.closeOnce.Do(func() {
+		close(c.outCh)
+	})
+	return nil
+}
+
+func (c *SpectrogramConsumer) decodeFrame(frame audiocore.AudioFrame) []float64 {
+	evenLen := len(frame.Data) &^ 1
+	if evenLen == 0 {
+		return nil
+	}
+	sampleCount := evenLen / 2
+	if cap(c.scratchPCM) < sampleCount {
+		c.scratchPCM = make([]float64, sampleCount)
+	}
+	pcm := c.scratchPCM[:sampleCount]
+	convert.BytesToFloat64PCM16Into(pcm, frame.Data[:evenLen])
+
+	if frame.Channels <= 1 {
+		out := make([]float64, len(pcm))
+		copy(out, pcm)
+		return out
+	}
+
+	monoCount := sampleCount / frame.Channels
+	if cap(c.scratchMono) < monoCount {
+		c.scratchMono = make([]float64, monoCount)
+	}
+	mono := c.scratchMono[:monoCount]
+	for i := 0; i < monoCount; i++ {
+		sum := 0.0
+		base := i * frame.Channels
+		for ch := 0; ch < frame.Channels; ch++ {
+			sum += pcm[base+ch]
+		}
+		mono[i] = sum / float64(frame.Channels)
+	}
+	out := make([]float64, monoCount)
+	copy(out, mono)
+	return out
+}
+
+func (c *SpectrogramConsumer) makeColumn() apiv2.LiveSpectrogramColumn {
+	windowed := make([]float64, c.fftSize)
+	for i := 0; i < c.fftSize; i++ {
+		windowed[i] = c.rolling[i] * c.windowCoeffs[i]
+	}
+
+	coeffs := c.fft.Coefficients(nil, windowed)
+	bins := make([]uint8, c.fftSize/2)
+	for i := 0; i < len(bins); i++ {
+		mag := math.Hypot(real(coeffs[i]), imag(coeffs[i]))
+		db := 20 * math.Log10(mag+1e-12)
+		scaled := ((db + 100) / 100) * 255
+		switch {
+		case scaled < 0:
+			scaled = 0
+		case scaled > 255:
+			scaled = 255
+		}
+		bins[i] = uint8(scaled)
+	}
+
+	centerTime := c.rollingStart.Add(samplesDuration(c.fftSize/2, c.rate))
+	return apiv2.LiveSpectrogramColumn{
+		TUnixMs: centerTime.UnixMilli(),
+		Bins:    apiv2.SpectrogramBins(bins),
+	}
+}
+
+func (c *SpectrogramConsumer) flush(sourceID string) {
+	if len(c.batch) == 0 {
+		return
+	}
+	batch := apiv2.LiveSpectrogramBatch{
+		SourceID:        sourceID,
+		SampleRate:      c.rate,
+		FFTSize:         c.fftSize,
+		HopSize:         c.hopSize,
+		Window:          c.window,
+		BatchIntervalMs: c.batchIntervalMs,
+		Columns:         append([]apiv2.LiveSpectrogramColumn(nil), c.batch...),
+	}
+	select {
+	case c.outCh <- batch:
+	default:
+	}
+	c.batch = c.batch[:0]
+}
+
+func buildWindow(window string, size int) []float64 {
+	coeffs := make([]float64, size)
+	switch window {
+	case "hann":
+		for i := 0; i < size; i++ {
+			coeffs[i] = 0.5 - 0.5*math.Cos((2*math.Pi*float64(i))/float64(size-1))
+		}
+	default:
+		for i := range coeffs {
+			coeffs[i] = 1
+		}
+	}
+	return coeffs
+}
+
+func samplesDuration(sampleCount, sampleRate int) time.Duration {
+	return time.Duration(float64(sampleCount) / float64(sampleRate) * float64(time.Second))
+}
+
+var _ audiocore.AudioConsumer = (*SpectrogramConsumer)(nil)

--- a/internal/analysis/spectrogram_consumer.go
+++ b/internal/analysis/spectrogram_consumer.go
@@ -2,6 +2,7 @@ package analysis
 
 import (
 	"math"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -113,7 +114,7 @@ func (c *SpectrogramConsumer) Write(frame audiocore.AudioFrame) error { //nolint
 	if c.closed.Load() {
 		return audiocore.ErrConsumerClosed
 	}
-	samples := c.decodeFrame(frame)
+	samples := c.decodeFrame(&frame)
 	if len(samples) == 0 {
 		return nil
 	}
@@ -155,8 +156,8 @@ func (c *SpectrogramConsumer) Close() error {
 // (Write) immediately appends the result into c.rolling, which copies, so
 // returning the scratch buffer directly is safe — the next Write call may
 // overwrite it. Multi-channel input is downmixed in place at the front of
-// the same buffer.
-func (c *SpectrogramConsumer) decodeFrame(frame audiocore.AudioFrame) []float64 {
+// the same buffer. Takes *AudioFrame to avoid copying the ~100-byte struct.
+func (c *SpectrogramConsumer) decodeFrame(frame *audiocore.AudioFrame) []float64 {
 	evenLen := len(frame.Data) &^ 1
 	if evenLen == 0 {
 		return nil
@@ -178,10 +179,10 @@ func (c *SpectrogramConsumer) decodeFrame(frame audiocore.AudioFrame) []float64 
 	// unread sample. Requires channels >= 2, which is guaranteed here.
 	monoCount := sampleCount / frame.Channels
 	invChannels := 1.0 / float64(frame.Channels)
-	for i := 0; i < monoCount; i++ {
+	for i := range monoCount {
 		sum := 0.0
 		base := i * frame.Channels
-		for ch := 0; ch < frame.Channels; ch++ {
+		for ch := range frame.Channels {
 			sum += c.scratchPCM[base+ch]
 		}
 		c.scratchPCM[i] = sum * invChannels
@@ -191,13 +192,13 @@ func (c *SpectrogramConsumer) decodeFrame(frame audiocore.AudioFrame) []float64 
 
 func (c *SpectrogramConsumer) makeColumn() apiv2.LiveSpectrogramColumn {
 	windowed := make([]float64, c.fftSize)
-	for i := 0; i < c.fftSize; i++ {
+	for i := range c.fftSize {
 		windowed[i] = c.rolling[i] * c.windowCoeffs[i]
 	}
 
 	coeffs := c.fft.Coefficients(nil, windowed)
 	bins := make([]uint8, c.fftSize/2)
-	for i := 0; i < len(bins); i++ {
+	for i := range bins {
 		mag := math.Hypot(real(coeffs[i]), imag(coeffs[i]))
 		db := 20 * math.Log10(mag+1e-12)
 		scaled := ((db + 100) / 100) * 255
@@ -232,7 +233,7 @@ func (c *SpectrogramConsumer) flush(sourceID string) {
 		HopSize:         c.hopSize,
 		Window:          c.window,
 		BatchIntervalMs: c.batchIntervalMs,
-		Columns:         append([]apiv2.LiveSpectrogramColumn(nil), c.batch...),
+		Columns:         slices.Clone(c.batch),
 	}
 	c.batch = c.batch[:0]
 
@@ -262,7 +263,7 @@ func buildWindow(window string, size int) []float64 {
 	coeffs := make([]float64, size)
 	switch window {
 	case "hann":
-		for i := 0; i < size; i++ {
+		for i := range size {
 			coeffs[i] = 0.5 - 0.5*math.Cos((2*math.Pi*float64(i))/float64(size-1))
 		}
 	default:

--- a/internal/analysis/spectrogram_consumer.go
+++ b/internal/analysis/spectrogram_consumer.go
@@ -10,10 +10,19 @@ import (
 	"github.com/tphakala/birdnet-go/internal/audiocore"
 	"github.com/tphakala/birdnet-go/internal/audiocore/convert"
 	"github.com/tphakala/birdnet-go/internal/errors"
+	"github.com/tphakala/birdnet-go/internal/logger"
+	"github.com/tphakala/birdnet-go/internal/privacy"
 	"gonum.org/v1/gonum/dsp/fourier"
 )
 
-const spectrogramChanSize = 16
+const (
+	spectrogramChanSize = 16
+	// spectrogramDropLogInterval controls how often drop warnings are emitted
+	// at each fan-out stage. One log line per this many consecutive drops,
+	// plus a single line on the very first drop so the operator is alerted
+	// as soon as loss starts.
+	spectrogramDropLogInterval int64 = 100
+)
 
 type SpectrogramConsumer struct {
 	id              string
@@ -26,16 +35,31 @@ type SpectrogramConsumer struct {
 	batchIntervalMs int
 	closed          atomic.Bool
 	closeOnce       sync.Once
-	outCh           chan apiv2.LiveSpectrogramBatch
+	// sendMu serializes the non-blocking send in flush with the channel
+	// close in Close. Without it, a Close racing with an in-flight flush
+	// could panic on "send on closed channel". In production the router
+	// drains the consumer before calling Close, so contention is effectively
+	// zero — this guard protects tests and future callers.
+	sendMu sync.Mutex
+	outCh  chan apiv2.LiveSpectrogramBatch
+	drops  atomic.Int64
 
 	fft          *fourier.FFT
 	windowCoeffs []float64
 	rolling      []float64
-	rollingStart time.Time
-	batch        []apiv2.LiveSpectrogramColumn
-	lastFlush    time.Time
-	scratchPCM   []float64
-	scratchMono  []float64
+	// streamEpoch is the wall-clock timestamp of sample index 0 (the first
+	// sample of the first frame). startSample is the absolute sample index
+	// of rolling[0] relative to streamEpoch. Using integer sample counts
+	// eliminates floating-point drift across long streams — centerTime is
+	// computed absolutely from the epoch rather than incremented per hop.
+	streamEpoch time.Time
+	startSample int64
+	batch       []apiv2.LiveSpectrogramColumn
+	lastFlush   time.Time
+	// scratchPCM is reused across decodeFrame calls to avoid reallocating
+	// the PCM buffer every frame. Mono downmix happens in place at the
+	// front of the same buffer.
+	scratchPCM []float64
 }
 
 func NewSpectrogramConsumer(id string, sampleRate, bitDepth, channels, fftSize, hopSize int, window string, batchIntervalMs int) (*SpectrogramConsumer, chan apiv2.LiveSpectrogramBatch, error) {
@@ -93,15 +117,16 @@ func (c *SpectrogramConsumer) Write(frame audiocore.AudioFrame) error { //nolint
 	if len(samples) == 0 {
 		return nil
 	}
-	if c.rollingStart.IsZero() {
-		c.rollingStart = frame.Timestamp
+	if c.streamEpoch.IsZero() {
+		c.streamEpoch = frame.Timestamp
+		c.startSample = 0
 	}
 	c.rolling = append(c.rolling, samples...)
 
 	for len(c.rolling) >= c.fftSize {
 		c.batch = append(c.batch, c.makeColumn())
 		c.rolling = c.rolling[c.hopSize:]
-		c.rollingStart = c.rollingStart.Add(samplesDuration(c.hopSize, c.rate))
+		c.startSample += int64(c.hopSize)
 	}
 
 	if len(c.batch) == 0 {
@@ -116,13 +141,21 @@ func (c *SpectrogramConsumer) Write(frame audiocore.AudioFrame) error { //nolint
 }
 
 func (c *SpectrogramConsumer) Close() error {
-	c.closed.Store(true)
 	c.closeOnce.Do(func() {
+		c.sendMu.Lock()
+		defer c.sendMu.Unlock()
+		c.closed.Store(true)
 		close(c.outCh)
 	})
 	return nil
 }
 
+// decodeFrame converts frame.Data from 16-bit little-endian PCM into float64
+// samples in c.scratchPCM and returns a slice referencing it. The caller
+// (Write) immediately appends the result into c.rolling, which copies, so
+// returning the scratch buffer directly is safe — the next Write call may
+// overwrite it. Multi-channel input is downmixed in place at the front of
+// the same buffer.
 func (c *SpectrogramConsumer) decodeFrame(frame audiocore.AudioFrame) []float64 {
 	evenLen := len(frame.Data) &^ 1
 	if evenLen == 0 {
@@ -131,32 +164,29 @@ func (c *SpectrogramConsumer) decodeFrame(frame audiocore.AudioFrame) []float64 
 	sampleCount := evenLen / 2
 	if cap(c.scratchPCM) < sampleCount {
 		c.scratchPCM = make([]float64, sampleCount)
+	} else {
+		c.scratchPCM = c.scratchPCM[:sampleCount]
 	}
-	pcm := c.scratchPCM[:sampleCount]
-	convert.BytesToFloat64PCM16Into(pcm, frame.Data[:evenLen])
+	convert.BytesToFloat64PCM16Into(c.scratchPCM, frame.Data[:evenLen])
 
 	if frame.Channels <= 1 {
-		out := make([]float64, len(pcm))
-		copy(out, pcm)
-		return out
+		return c.scratchPCM
 	}
 
+	// In-place downmix: write position i always lags the read positions
+	// [i*channels, i*channels+channels), so overwrites never corrupt an
+	// unread sample. Requires channels >= 2, which is guaranteed here.
 	monoCount := sampleCount / frame.Channels
-	if cap(c.scratchMono) < monoCount {
-		c.scratchMono = make([]float64, monoCount)
-	}
-	mono := c.scratchMono[:monoCount]
+	invChannels := 1.0 / float64(frame.Channels)
 	for i := 0; i < monoCount; i++ {
 		sum := 0.0
 		base := i * frame.Channels
 		for ch := 0; ch < frame.Channels; ch++ {
-			sum += pcm[base+ch]
+			sum += c.scratchPCM[base+ch]
 		}
-		mono[i] = sum / float64(frame.Channels)
+		c.scratchPCM[i] = sum * invChannels
 	}
-	out := make([]float64, monoCount)
-	copy(out, mono)
-	return out
+	return c.scratchPCM[:monoCount]
 }
 
 func (c *SpectrogramConsumer) makeColumn() apiv2.LiveSpectrogramColumn {
@@ -180,7 +210,11 @@ func (c *SpectrogramConsumer) makeColumn() apiv2.LiveSpectrogramColumn {
 		bins[i] = uint8(scaled)
 	}
 
-	centerTime := c.rollingStart.Add(samplesDuration(c.fftSize/2, c.rate))
+	// Center time is computed absolutely from the stream epoch plus the
+	// integer sample index of the FFT window's midpoint. This keeps
+	// timestamps stable over multi-hour streams — no per-hop float drift.
+	centerSample := c.startSample + int64(c.fftSize/2)
+	centerTime := c.streamEpoch.Add(sampleOffset(centerSample, c.rate))
 	return apiv2.LiveSpectrogramColumn{
 		TUnixMs: centerTime.UnixMilli(),
 		Bins:    apiv2.SpectrogramBins(bins),
@@ -200,11 +234,28 @@ func (c *SpectrogramConsumer) flush(sourceID string) {
 		BatchIntervalMs: c.batchIntervalMs,
 		Columns:         append([]apiv2.LiveSpectrogramColumn(nil), c.batch...),
 	}
+	c.batch = c.batch[:0]
+
+	// Serialize the send with Close so a concurrent Close cannot cause a
+	// "send on closed channel" panic. Both the lock window and the select
+	// are O(nanoseconds).
+	c.sendMu.Lock()
+	defer c.sendMu.Unlock()
+	if c.closed.Load() {
+		return
+	}
 	select {
 	case c.outCh <- batch:
 	default:
+		drops := c.drops.Add(1)
+		if drops == 1 || drops%spectrogramDropLogInterval == 0 {
+			GetLogger().Warn("live spectrogram batch dropped at consumer",
+				logger.String("source_id", privacy.SanitizeRTSPUrl(sourceID)),
+				logger.String("consumer_id", c.id),
+				logger.Int64("total_drops", drops),
+				logger.Int("columns", len(batch.Columns)))
+		}
 	}
-	c.batch = c.batch[:0]
 }
 
 func buildWindow(window string, size int) []float64 {
@@ -222,8 +273,18 @@ func buildWindow(window string, size int) []float64 {
 	return coeffs
 }
 
-func samplesDuration(sampleCount, sampleRate int) time.Duration {
-	return time.Duration(float64(sampleCount) / float64(sampleRate) * float64(time.Second))
+// sampleOffset returns the time.Duration that corresponds to the given
+// sample index at the given sample rate, using integer math. It splits
+// samples into whole seconds + remainder to keep the intermediate product
+// inside int64 even for very long streams (hundreds of years at 48 kHz).
+func sampleOffset(samples int64, sampleRate int) time.Duration {
+	if sampleRate <= 0 {
+		return 0
+	}
+	r := int64(sampleRate)
+	sec := samples / r
+	rem := samples % r
+	return time.Duration(sec)*time.Second + time.Duration(rem)*time.Second/time.Duration(r)
 }
 
 var _ audiocore.AudioConsumer = (*SpectrogramConsumer)(nil)

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -67,8 +67,11 @@ type Server struct {
 	engine *engine.AudioEngine
 
 	// Channels
-	controlChan    chan string
-	audioLevelChan chan audiocore.AudioLevelData
+	controlChan            chan string
+	audioLevelChan         chan audiocore.AudioLevelData
+	liveSpectrogramChan    chan apiv2.LiveSpectrogramBatch
+	acquireLiveSpectrogram func(string) error
+	releaseLiveSpectrogram func(string)
 
 	// API controller
 	apiController *apiv2.Controller
@@ -184,6 +187,22 @@ func WithControlChannel(ch chan string) ServerOption {
 func WithAudioLevelChannel(ch chan audiocore.AudioLevelData) ServerOption {
 	return func(s *Server) {
 		s.audioLevelChan = ch
+	}
+}
+
+// WithLiveSpectrogramChannel sets the live spectrogram channel for SSE streaming.
+func WithLiveSpectrogramChannel(ch chan apiv2.LiveSpectrogramBatch) ServerOption {
+	return func(s *Server) {
+		s.liveSpectrogramChan = ch
+	}
+}
+
+// WithLiveSpectrogramLifecycle sets callbacks that attach and detach the
+// server-side live spectrogram producer on demand.
+func WithLiveSpectrogramLifecycle(acquire func(string) error, release func(string)) ServerOption {
+	return func(s *Server) {
+		s.acquireLiveSpectrogram = acquire
+		s.releaseLiveSpectrogram = release
 	}
 }
 
@@ -422,6 +441,7 @@ func (s *Server) setupRoutes() error {
 		apiv2.WithV2Manager(s.v2Manager),
 		apiv2.WithMetricsStore(observability.NewMemoryStore(apiv2.MetricsHistoryMaxPoints)),
 		apiv2.WithAudioEngine(s.engine),
+		apiv2.WithLiveSpectrogramLifecycle(s.acquireLiveSpectrogram, s.releaseLiveSpectrogram),
 	)
 	if err != nil {
 		return fmt.Errorf("failed to initialize API v2: %w", err)
@@ -445,6 +465,9 @@ func (s *Server) setupRoutes() error {
 	// Set audio level channel if available
 	if s.audioLevelChan != nil {
 		s.apiController.SetAudioLevelChan(s.audioLevelChan)
+	}
+	if s.liveSpectrogramChan != nil {
+		s.apiController.SetLiveSpectrogramChan(s.liveSpectrogramChan)
 	}
 
 	// Register SPA routes (after API controller for auth middleware access)

--- a/internal/api/v2/README.md
+++ b/internal/api/v2/README.md
@@ -255,6 +255,59 @@ Lightweight connectivity check. Returns a minimal response with no database quer
 }
 ```
 
+### Live Spectrogram SSE (`audio_spectrogram.go`)
+
+| Method | Route                           | Handler                | Auth | Description                       |
+| ------ | ------------------------------- | ---------------------- | ---- | --------------------------------- |
+| GET    | `/streams/spectrogram/:sourceID` | `StreamLiveSpectrogram` | ❌   | Real-time live spectrogram SSE    |
+
+**Features:**
+
+- Server-side FFT/STFT generation for the live waterfall
+- Cross-browser live spectrogram rendering without relying on browser Web Audio analyzers
+- Viewer-driven lifecycle: FFT production is active only while clients are connected
+- Connection limiting: up to 5 concurrent connections per client IP
+- Heartbeat interval: 15 seconds
+
+**Event Types:**
+
+- `spectrogram-meta` - stream metadata sent immediately after connection
+- `spectrogram-columns` - batched FFT columns for waterfall rendering
+- `heartbeat` - keepalive event
+
+**Meta Event Format:**
+
+```json
+{
+  "type": "spectrogram-meta",
+  "sourceId": "audio_card_01",
+  "streamEpochUnixMs": 1712592000000,
+  "sampleRate": 48000,
+  "fftSize": 1024,
+  "hopSize": 128,
+  "window": "hann",
+  "binCount": 512,
+  "minFrequencyHz": 0,
+  "maxFrequencyHz": 24000,
+  "batchIntervalMs": 16
+}
+```
+
+**Columns Event Format:**
+
+```json
+{
+  "type": "spectrogram-columns",
+  "sourceId": "audio_card_01",
+  "columns": [
+    {
+      "tUnixMs": 1712592004123,
+      "bins": [0, 1, 3, 8, 14, 22, 19, 10]
+    }
+  ]
+}
+```
+
 ### HLS Streaming (`audio_hls.go`)
 
 | Method | Route                                            | Handler            | Auth                 | Description                    |

--- a/internal/api/v2/api.go
+++ b/internal/api/v2/api.go
@@ -97,6 +97,15 @@ type Controller struct {
 	liveSpectrogramChan    chan LiveSpectrogramBatch
 	acquireLiveSpectrogram func(string) error
 	releaseLiveSpectrogram func(string)
+	// liveSpectrogramMgr holds the SSE broadcaster state for the live
+	// spectrogram endpoint. It MUST live on the Controller, not at package
+	// scope — the embedded sync.Once for the broadcaster goroutine resets
+	// on each Controller construction, which is what allows a
+	// programmatic server restart to rebind a fresh broadcaster to a new
+	// liveSpectrogramChan. A package-level singleton would leave the
+	// broadcaster bound to the first channel forever and silently drop
+	// data after any restart (caught by Sentry on PR #2745).
+	liveSpectrogramMgr *liveSpectrogramManager
 
 	// engine provides access to the unified audio subsystem (sources, buffers, routing).
 	engine *engine.AudioEngine
@@ -374,6 +383,7 @@ func NewWithOptions(e *echo.Echo, ds datastore.Interface, settings *conf.Setting
 		cancel:               cancel,
 		spectrogramGenerator: spectrogram.NewGenerator(settings, sfs, getSpectrogramLogger()), // Initialize shared generator
 		detectionRateCache:   datastore.NewDetectionRateCache(detectionRateCacheTTL),
+		liveSpectrogramMgr:   newLiveSpectrogramManager(),
 	}
 
 	// Initialize audio processing cache and concurrency limiter

--- a/internal/api/v2/api.go
+++ b/internal/api/v2/api.go
@@ -93,7 +93,10 @@ type Controller struct {
 
 	// Audio level channel for SSE streaming
 	// TODO: Consider moving to a dedicated audio manager
-	audioLevelChan chan audiocore.AudioLevelData
+	audioLevelChan         chan audiocore.AudioLevelData
+	liveSpectrogramChan    chan LiveSpectrogramBatch
+	acquireLiveSpectrogram func(string) error
+	releaseLiveSpectrogram func(string)
 
 	// engine provides access to the unified audio subsystem (sources, buffers, routing).
 	engine *engine.AudioEngine
@@ -168,6 +171,15 @@ func WithV2Manager(mgr datastoreV2.Manager) Option {
 func WithAudioEngine(e *engine.AudioEngine) Option {
 	return func(c *Controller) {
 		c.engine = e
+	}
+}
+
+// WithLiveSpectrogramLifecycle injects callbacks that activate and release the
+// server-side live spectrogram producer for a source.
+func WithLiveSpectrogramLifecycle(acquire func(string) error, release func(string)) Option {
+	return func(c *Controller) {
+		c.acquireLiveSpectrogram = acquire
+		c.releaseLiveSpectrogram = release
 	}
 }
 
@@ -571,6 +583,7 @@ func (c *Controller) initRoutes() {
 		{"stream health routes", c.initStreamHealthRoutes},
 		{"quiet hours routes", c.initQuietHoursRoutes},
 		{"audio level routes", c.initAudioLevelRoutes},
+		{"audio spectrogram routes", c.initAudioSpectrogramRoutes},
 		{"hls streaming routes", c.initHLSRoutes},
 		{"integration routes", c.initIntegrationsRoutes},
 		{"control routes", c.initControlRoutes},

--- a/internal/api/v2/audio_spectrogram.go
+++ b/internal/api/v2/audio_spectrogram.go
@@ -2,12 +2,12 @@ package api
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net"
 	"net/http"
 	"os"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -33,14 +33,27 @@ type LiveSpectrogramColumn struct {
 
 type SpectrogramBins []uint8
 
-// MarshalJSON forces FFT bins to be emitted as a numeric JSON array instead
-// of the default []byte base64 encoding used by encoding/json for []uint8.
+// MarshalJSON emits FFT bins as a numeric JSON array. encoding/json would
+// base64-encode a []uint8 by default, so we override. The hand-written
+// digit serializer avoids the intermediate []int allocation (~4 KB per
+// column) and the reflection-based json.Marshal call — this runs at ~375
+// columns/s × N subscribers in the SSE fan-out, so cutting the per-column
+// allocation to a single output buffer is a meaningful win.
 func (b SpectrogramBins) MarshalJSON() ([]byte, error) {
-	values := make([]int, len(b))
-	for i, v := range b {
-		values[i] = int(v)
+	if len(b) == 0 {
+		return []byte("[]"), nil
 	}
-	return json.Marshal(values)
+	// Upper bound: '[' + len*4 (up to "255,") + ']'.
+	buf := make([]byte, 0, 2+len(b)*4)
+	buf = append(buf, '[')
+	for i, v := range b {
+		if i > 0 {
+			buf = append(buf, ',')
+		}
+		buf = strconv.AppendUint(buf, uint64(v), 10)
+	}
+	buf = append(buf, ']')
+	return buf, nil
 }
 
 type LiveSpectrogramBatch struct {

--- a/internal/api/v2/audio_spectrogram.go
+++ b/internal/api/v2/audio_spectrogram.go
@@ -102,6 +102,14 @@ type liveSpectrogramSubscriber struct {
 // interval so the three log streams line up.
 const liveSpectrogramDropLogInterval int64 = 100
 
+// liveSpectrogramManager holds per-Controller SSE broadcaster state for the
+// live spectrogram endpoint. Every Controller gets its own instance via
+// newLiveSpectrogramManager so the embedded sync.Once resets on each
+// Controller lifecycle — this is what lets a programmatic server restart
+// rebind a fresh broadcaster goroutine to the new liveSpectrogramChan.
+// A package-level singleton would leave the sync.Once permanently fired
+// after the first start and silently drop data on every subsequent
+// restart (Sentry flagged this on PR #2745).
 type liveSpectrogramManager struct {
 	activeConnections sync.Map
 	connectionMu      sync.Mutex
@@ -111,41 +119,49 @@ type liveSpectrogramManager struct {
 	broadcasterCancel context.CancelFunc
 }
 
-var liveSpectrogramMgr = &liveSpectrogramManager{
-	subscribers: make(map[string]map[*liveSpectrogramSubscriber]struct{}),
+// newLiveSpectrogramManager constructs a zero-initialized manager with an
+// empty subscribers map. Called once per Controller from api.go New().
+func newLiveSpectrogramManager() *liveSpectrogramManager {
+	return &liveSpectrogramManager{
+		subscribers: make(map[string]map[*liveSpectrogramSubscriber]struct{}),
+	}
 }
 
 func (c *Controller) SetLiveSpectrogramChan(ch chan LiveSpectrogramBatch) {
 	c.liveSpectrogramChan = ch
 	c.logInfoIfEnabled("Live spectrogram channel connected to API v2 controller")
 
-	liveSpectrogramMgr.broadcasterOnce.Do(func() {
+	c.liveSpectrogramMgr.broadcasterOnce.Do(func() {
 		ctx, cancel := context.WithCancel(c.ctx)
-		liveSpectrogramMgr.broadcasterCancel = cancel
-		go runLiveSpectrogramBroadcaster(ctx, ch)
+		c.liveSpectrogramMgr.broadcasterCancel = cancel
+		go c.liveSpectrogramMgr.runBroadcaster(ctx, ch)
 	})
 }
 
-func runLiveSpectrogramBroadcaster(ctx context.Context, sourceChan chan LiveSpectrogramBatch) {
+// runBroadcaster reads batches from sourceChan and fans them out to every
+// subscriber registered for the matching source ID. Exits when ctx is
+// cancelled or sourceChan is closed (draining the subscribers map in the
+// latter case).
+func (m *liveSpectrogramManager) runBroadcaster(ctx context.Context, sourceChan chan LiveSpectrogramBatch) {
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case data, ok := <-sourceChan:
 			if !ok {
-				liveSpectrogramMgr.subscribersMu.Lock()
-				for _, subscribers := range liveSpectrogramMgr.subscribers {
+				m.subscribersMu.Lock()
+				for _, subscribers := range m.subscribers {
 					for sub := range subscribers {
 						close(sub.ch)
 					}
 				}
-				liveSpectrogramMgr.subscribers = make(map[string]map[*liveSpectrogramSubscriber]struct{})
-				liveSpectrogramMgr.subscribersMu.Unlock()
+				m.subscribers = make(map[string]map[*liveSpectrogramSubscriber]struct{})
+				m.subscribersMu.Unlock()
 				return
 			}
 
-			liveSpectrogramMgr.subscribersMu.RLock()
-			for sub := range liveSpectrogramMgr.subscribers[data.SourceID] {
+			m.subscribersMu.RLock()
+			for sub := range m.subscribers[data.SourceID] {
 				select {
 				case sub.ch <- data:
 				default:
@@ -158,33 +174,37 @@ func runLiveSpectrogramBroadcaster(ctx context.Context, sourceChan chan LiveSpec
 					}
 				}
 			}
-			liveSpectrogramMgr.subscribersMu.RUnlock()
+			m.subscribersMu.RUnlock()
 		}
 	}
 }
 
-func subscribeToLiveSpectrogram(sourceID, clientIP string) *liveSpectrogramSubscriber {
+// subscribe registers a new SSE subscriber for the given source ID and
+// returns it. Safe to call concurrently with runBroadcaster.
+func (m *liveSpectrogramManager) subscribe(sourceID, clientIP string) *liveSpectrogramSubscriber {
 	sub := &liveSpectrogramSubscriber{
 		ch:       make(chan LiveSpectrogramBatch, liveSpectrogramChannelBuffer),
 		sourceID: sourceID,
 		clientIP: clientIP,
 	}
-	liveSpectrogramMgr.subscribersMu.Lock()
-	defer liveSpectrogramMgr.subscribersMu.Unlock()
-	if liveSpectrogramMgr.subscribers[sourceID] == nil {
-		liveSpectrogramMgr.subscribers[sourceID] = make(map[*liveSpectrogramSubscriber]struct{})
+	m.subscribersMu.Lock()
+	defer m.subscribersMu.Unlock()
+	if m.subscribers[sourceID] == nil {
+		m.subscribers[sourceID] = make(map[*liveSpectrogramSubscriber]struct{})
 	}
-	liveSpectrogramMgr.subscribers[sourceID][sub] = struct{}{}
+	m.subscribers[sourceID][sub] = struct{}{}
 	return sub
 }
 
-func unsubscribeFromLiveSpectrogram(sub *liveSpectrogramSubscriber) {
-	liveSpectrogramMgr.subscribersMu.Lock()
-	defer liveSpectrogramMgr.subscribersMu.Unlock()
-	if subscribers := liveSpectrogramMgr.subscribers[sub.sourceID]; subscribers != nil {
+// unsubscribe removes a subscriber from its source's subscriber set, and
+// removes the source key entirely if no subscribers remain.
+func (m *liveSpectrogramManager) unsubscribe(sub *liveSpectrogramSubscriber) {
+	m.subscribersMu.Lock()
+	defer m.subscribersMu.Unlock()
+	if subscribers := m.subscribers[sub.sourceID]; subscribers != nil {
 		delete(subscribers, sub)
 		if len(subscribers) == 0 {
-			delete(liveSpectrogramMgr.subscribers, sub.sourceID)
+			delete(m.subscribers, sub.sourceID)
 		}
 	}
 }
@@ -208,35 +228,36 @@ func (c *Controller) StreamLiveSpectrogram(ctx echo.Context) error {
 	defer c.releaseLiveSpectrogram(sourceID)
 
 	clientIP := c.extractRemoteAddr(ctx)
-	liveSpectrogramMgr.connectionMu.Lock()
-	countPtr, loaded := liveSpectrogramMgr.activeConnections.Load(clientIP)
+	mgr := c.liveSpectrogramMgr
+	mgr.connectionMu.Lock()
+	countPtr, loaded := mgr.activeConnections.Load(clientIP)
 	var count int32
 	if loaded {
 		count = atomic.LoadInt32(countPtr.(*int32))
 	}
 	if count >= liveSpectrogramMaxConnectionsPerIP {
-		liveSpectrogramMgr.connectionMu.Unlock()
+		mgr.connectionMu.Unlock()
 		return c.HandleError(ctx, nil, fmt.Sprintf("Maximum %d live spectrogram stream connections per client reached", liveSpectrogramMaxConnectionsPerIP), http.StatusTooManyRequests)
 	}
 	if !loaded {
 		var newCount int32 = 1
-		liveSpectrogramMgr.activeConnections.Store(clientIP, &newCount)
+		mgr.activeConnections.Store(clientIP, &newCount)
 	} else {
 		atomic.AddInt32(countPtr.(*int32), 1)
 	}
-	liveSpectrogramMgr.connectionMu.Unlock()
+	mgr.connectionMu.Unlock()
 
-	subscriber := subscribeToLiveSpectrogram(sourceID, clientIP)
+	subscriber := mgr.subscribe(sourceID, clientIP)
 	defer func() {
-		unsubscribeFromLiveSpectrogram(subscriber)
-		liveSpectrogramMgr.connectionMu.Lock()
-		if countPtr, ok := liveSpectrogramMgr.activeConnections.Load(clientIP); ok {
+		mgr.unsubscribe(subscriber)
+		mgr.connectionMu.Lock()
+		if countPtr, ok := mgr.activeConnections.Load(clientIP); ok {
 			newCount := atomic.AddInt32(countPtr.(*int32), -1)
 			if newCount <= 0 {
-				liveSpectrogramMgr.activeConnections.Delete(clientIP)
+				mgr.activeConnections.Delete(clientIP)
 			}
 		}
-		liveSpectrogramMgr.connectionMu.Unlock()
+		mgr.connectionMu.Unlock()
 	}()
 
 	resp := ctx.Response()

--- a/internal/api/v2/audio_spectrogram.go
+++ b/internal/api/v2/audio_spectrogram.go
@@ -24,6 +24,12 @@ const (
 	liveSpectrogramWriteDeadline       = 10 * time.Second
 	liveSpectrogramChannelBuffer       = 32
 	liveSpectrogramMaxConnectionsPerIP = 5
+	// liveSpectrogramMaxDuration caps the lifetime of a single SSE
+	// subscription. Matches the 30-minute cap in audio_level.go and
+	// prevents resource leaks from clients that never disconnect
+	// gracefully. After the cap expires the handler exits cleanly and
+	// the client can reconnect if they still want data.
+	liveSpectrogramMaxDuration = 30 * time.Minute
 )
 
 type LiveSpectrogramColumn struct {
@@ -271,7 +277,13 @@ func (c *Controller) StreamLiveSpectrogram(ctx echo.Context) error {
 		flusher.Flush()
 	}
 
-	if err := c.sendSSEMessage(ctx, "spectrogram-meta", c.buildLiveSpectrogramMeta(sourceID)); err != nil {
+	// Cap the total subscription lifetime. Prevents resource leaks when
+	// clients never disconnect gracefully and matches the 30-minute cap
+	// enforced by the sibling audio-level SSE endpoint in audio_level.go.
+	streamCtx, streamCancel := context.WithTimeout(req.Context(), liveSpectrogramMaxDuration)
+	defer streamCancel()
+
+	if err := c.sendLiveSpectrogramEvent(ctx, "spectrogram-meta", sourceID, c.buildLiveSpectrogramMeta(sourceID)); err != nil {
 		return nil
 	}
 
@@ -280,7 +292,7 @@ func (c *Controller) StreamLiveSpectrogram(ctx echo.Context) error {
 
 	for {
 		select {
-		case <-req.Context().Done():
+		case <-streamCtx.Done():
 			return nil
 		case <-c.ctx.Done():
 			return nil
@@ -288,28 +300,45 @@ func (c *Controller) StreamLiveSpectrogram(ctx echo.Context) error {
 			if !ok {
 				return nil
 			}
-			if conn, ok := resp.Writer.(WriteDeadlineSetter); ok {
-				_ = conn.SetWriteDeadline(time.Now().Add(liveSpectrogramWriteDeadline))
-			}
-			if err := c.sendSSEMessage(ctx, "spectrogram-columns", liveSpectrogramEvent{
+			if err := c.sendLiveSpectrogramEvent(ctx, "spectrogram-columns", sourceID, liveSpectrogramEvent{
 				Type:     "spectrogram-columns",
 				SourceID: batch.SourceID,
 				Columns:  batch.Columns,
 			}); err != nil {
-				c.logLiveSpectrogramWriteError(ctx, err, "spectrogram-columns", sourceID)
 				return nil
 			}
 		case <-heartbeat.C:
-			if err := c.sendSSEMessage(ctx, "heartbeat", liveSpectrogramEvent{
+			if err := c.sendLiveSpectrogramEvent(ctx, "heartbeat", sourceID, liveSpectrogramEvent{
 				Type:      "heartbeat",
 				SourceID:  sourceID,
 				Timestamp: time.Now().UnixMilli(),
 			}); err != nil {
-				c.logLiveSpectrogramWriteError(ctx, err, "heartbeat", sourceID)
 				return nil
 			}
 		}
 	}
+}
+
+// sendLiveSpectrogramEvent is the single code path for writing SSE events
+// to a live-spectrogram subscriber. It applies the per-write deadline
+// (checking the SetWriteDeadline error rather than silently dropping it)
+// before handing the payload to the generic SSE serializer, and routes
+// any write failure through logLiveSpectrogramWriteError so unexpected
+// errors are surfaced at warn level while client-disconnect noise stays
+// silent. Callers are expected to return nil on a non-nil return to
+// terminate the handler cleanly.
+func (c *Controller) sendLiveSpectrogramEvent(ctx echo.Context, event, sourceID string, payload any) error {
+	if conn, ok := ctx.Response().Writer.(WriteDeadlineSetter); ok {
+		if err := conn.SetWriteDeadline(time.Now().Add(liveSpectrogramWriteDeadline)); err != nil {
+			c.logLiveSpectrogramWriteError(ctx, err, event, sourceID)
+			return err
+		}
+	}
+	if err := c.sendSSEMessage(ctx, event, payload); err != nil {
+		c.logLiveSpectrogramWriteError(ctx, err, event, sourceID)
+		return err
+	}
+	return nil
 }
 
 func (c *Controller) buildLiveSpectrogramMeta(sourceID string) LiveSpectrogramMeta {

--- a/internal/api/v2/audio_spectrogram.go
+++ b/internal/api/v2/audio_spectrogram.go
@@ -1,0 +1,282 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	stderrors "errors"
+	"fmt"
+	"net"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/labstack/echo/v4"
+)
+
+const (
+	liveSpectrogramHeartbeatInterval   = 15 * time.Second
+	liveSpectrogramWriteDeadline       = 10 * time.Second
+	liveSpectrogramChannelBuffer       = 32
+	liveSpectrogramMaxConnectionsPerIP = 5
+)
+
+type LiveSpectrogramColumn struct {
+	TUnixMs int64           `json:"tUnixMs"`
+	Bins    SpectrogramBins `json:"bins"`
+}
+
+type SpectrogramBins []uint8
+
+// MarshalJSON forces FFT bins to be emitted as a numeric JSON array instead
+// of the default []byte base64 encoding used by encoding/json for []uint8.
+func (b SpectrogramBins) MarshalJSON() ([]byte, error) {
+	values := make([]int, len(b))
+	for i, v := range b {
+		values[i] = int(v)
+	}
+	return json.Marshal(values)
+}
+
+type LiveSpectrogramBatch struct {
+	SourceID        string                  `json:"sourceId"`
+	SampleRate      int                     `json:"sampleRate"`
+	FFTSize         int                     `json:"fftSize"`
+	HopSize         int                     `json:"hopSize"`
+	Window          string                  `json:"window"`
+	BatchIntervalMs int                     `json:"batchIntervalMs"`
+	Columns         []LiveSpectrogramColumn `json:"columns"`
+}
+
+type LiveSpectrogramMeta struct {
+	Type              string `json:"type"`
+	SourceID          string `json:"sourceId"`
+	StreamEpochUnixMs int64  `json:"streamEpochUnixMs"`
+	SampleRate        int    `json:"sampleRate"`
+	FFTSize           int    `json:"fftSize"`
+	HopSize           int    `json:"hopSize"`
+	Window            string `json:"window"`
+	BinCount          int    `json:"binCount"`
+	MinFrequencyHz    int    `json:"minFrequencyHz"`
+	MaxFrequencyHz    int    `json:"maxFrequencyHz"`
+	BatchIntervalMs   int    `json:"batchIntervalMs"`
+}
+
+type liveSpectrogramEvent struct {
+	Type      string                  `json:"type"`
+	SourceID  string                  `json:"sourceId"`
+	Timestamp int64                   `json:"timestamp,omitempty"`
+	Columns   []LiveSpectrogramColumn `json:"columns,omitempty"`
+}
+
+type liveSpectrogramManager struct {
+	activeConnections sync.Map
+	connectionMu      sync.Mutex
+	subscribers       map[string]map[chan LiveSpectrogramBatch]struct{}
+	subscribersMu     sync.RWMutex
+	broadcasterOnce   sync.Once
+	broadcasterCancel context.CancelFunc
+}
+
+var liveSpectrogramMgr = &liveSpectrogramManager{
+	subscribers: make(map[string]map[chan LiveSpectrogramBatch]struct{}),
+}
+
+func (c *Controller) SetLiveSpectrogramChan(ch chan LiveSpectrogramBatch) {
+	c.liveSpectrogramChan = ch
+	c.logInfoIfEnabled("Live spectrogram channel connected to API v2 controller")
+
+	liveSpectrogramMgr.broadcasterOnce.Do(func() {
+		ctx, cancel := context.WithCancel(c.ctx)
+		liveSpectrogramMgr.broadcasterCancel = cancel
+		go runLiveSpectrogramBroadcaster(ctx, ch)
+	})
+}
+
+func runLiveSpectrogramBroadcaster(ctx context.Context, sourceChan chan LiveSpectrogramBatch) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case data, ok := <-sourceChan:
+			if !ok {
+				liveSpectrogramMgr.subscribersMu.Lock()
+				for _, subscribers := range liveSpectrogramMgr.subscribers {
+					for ch := range subscribers {
+						close(ch)
+					}
+				}
+				liveSpectrogramMgr.subscribers = make(map[string]map[chan LiveSpectrogramBatch]struct{})
+				liveSpectrogramMgr.subscribersMu.Unlock()
+				return
+			}
+
+			liveSpectrogramMgr.subscribersMu.RLock()
+			for ch := range liveSpectrogramMgr.subscribers[data.SourceID] {
+				select {
+				case ch <- data:
+				default:
+				}
+			}
+			liveSpectrogramMgr.subscribersMu.RUnlock()
+		}
+	}
+}
+
+func subscribeToLiveSpectrogram(sourceID string) chan LiveSpectrogramBatch {
+	ch := make(chan LiveSpectrogramBatch, liveSpectrogramChannelBuffer)
+	liveSpectrogramMgr.subscribersMu.Lock()
+	defer liveSpectrogramMgr.subscribersMu.Unlock()
+	if liveSpectrogramMgr.subscribers[sourceID] == nil {
+		liveSpectrogramMgr.subscribers[sourceID] = make(map[chan LiveSpectrogramBatch]struct{})
+	}
+	liveSpectrogramMgr.subscribers[sourceID][ch] = struct{}{}
+	return ch
+}
+
+func unsubscribeFromLiveSpectrogram(sourceID string, ch chan LiveSpectrogramBatch) {
+	liveSpectrogramMgr.subscribersMu.Lock()
+	defer liveSpectrogramMgr.subscribersMu.Unlock()
+	if subscribers := liveSpectrogramMgr.subscribers[sourceID]; subscribers != nil {
+		delete(subscribers, ch)
+		if len(subscribers) == 0 {
+			delete(liveSpectrogramMgr.subscribers, sourceID)
+		}
+	}
+}
+
+func (c *Controller) initAudioSpectrogramRoutes() {
+	c.Group.GET("/streams/spectrogram/:sourceID", c.StreamLiveSpectrogram, c.publicLiveAudioAuth)
+}
+
+func (c *Controller) StreamLiveSpectrogram(ctx echo.Context) error {
+	if c.liveSpectrogramChan == nil || c.acquireLiveSpectrogram == nil || c.releaseLiveSpectrogram == nil {
+		return c.HandleError(ctx, nil, "Live spectrogram stream is not available", http.StatusServiceUnavailable)
+	}
+
+	sourceID, err := c.validateAndDecodeSourceID(ctx)
+	if err != nil {
+		return err
+	}
+	if err := c.acquireLiveSpectrogram(sourceID); err != nil {
+		return c.HandleError(ctx, err, "Live spectrogram stream is not available", http.StatusServiceUnavailable)
+	}
+	defer c.releaseLiveSpectrogram(sourceID)
+
+	clientIP := c.extractRemoteAddr(ctx)
+	liveSpectrogramMgr.connectionMu.Lock()
+	countPtr, loaded := liveSpectrogramMgr.activeConnections.Load(clientIP)
+	var count int32
+	if loaded {
+		count = atomic.LoadInt32(countPtr.(*int32))
+	}
+	if count >= liveSpectrogramMaxConnectionsPerIP {
+		liveSpectrogramMgr.connectionMu.Unlock()
+		return c.HandleError(ctx, nil, fmt.Sprintf("Maximum %d live spectrogram stream connections per client reached", liveSpectrogramMaxConnectionsPerIP), http.StatusTooManyRequests)
+	}
+	if !loaded {
+		var newCount int32 = 1
+		liveSpectrogramMgr.activeConnections.Store(clientIP, &newCount)
+	} else {
+		atomic.AddInt32(countPtr.(*int32), 1)
+	}
+	liveSpectrogramMgr.connectionMu.Unlock()
+
+	subscriberChan := subscribeToLiveSpectrogram(sourceID)
+	defer func() {
+		unsubscribeFromLiveSpectrogram(sourceID, subscriberChan)
+		liveSpectrogramMgr.connectionMu.Lock()
+		if countPtr, ok := liveSpectrogramMgr.activeConnections.Load(clientIP); ok {
+			newCount := atomic.AddInt32(countPtr.(*int32), -1)
+			if newCount <= 0 {
+				liveSpectrogramMgr.activeConnections.Delete(clientIP)
+			}
+		}
+		liveSpectrogramMgr.connectionMu.Unlock()
+	}()
+
+	resp := ctx.Response()
+	req := ctx.Request()
+	resp.Header().Set(echo.HeaderContentType, "text/event-stream")
+	resp.Header().Set(echo.HeaderCacheControl, "no-cache")
+	resp.Header().Set(echo.HeaderConnection, "keep-alive")
+	resp.Header().Set("X-Accel-Buffering", "no")
+	resp.WriteHeader(http.StatusOK)
+	if flusher, ok := resp.Writer.(http.Flusher); ok {
+		flusher.Flush()
+	}
+
+	if err := c.sendSSEMessage(ctx, "spectrogram-meta", c.buildLiveSpectrogramMeta(sourceID)); err != nil {
+		return nil
+	}
+
+	heartbeat := time.NewTicker(liveSpectrogramHeartbeatInterval)
+	defer heartbeat.Stop()
+
+	for {
+		select {
+		case <-req.Context().Done():
+			return nil
+		case <-c.ctx.Done():
+			return nil
+		case batch, ok := <-subscriberChan:
+			if !ok {
+				return nil
+			}
+			if conn, ok := resp.Writer.(WriteDeadlineSetter); ok {
+				_ = conn.SetWriteDeadline(time.Now().Add(liveSpectrogramWriteDeadline))
+			}
+			err := c.sendSSEMessage(ctx, "spectrogram-columns", liveSpectrogramEvent{
+				Type:     "spectrogram-columns",
+				SourceID: batch.SourceID,
+				Columns:  batch.Columns,
+			})
+			if isClosedNetworkError(err) {
+				return nil
+			}
+			if err != nil {
+				return nil
+			}
+		case <-heartbeat.C:
+			err := c.sendSSEMessage(ctx, "heartbeat", liveSpectrogramEvent{
+				Type:      "heartbeat",
+				SourceID:  sourceID,
+				Timestamp: time.Now().UnixMilli(),
+			})
+			if isClosedNetworkError(err) {
+				return nil
+			}
+			if err != nil {
+				return nil
+			}
+		}
+	}
+}
+
+func (c *Controller) buildLiveSpectrogramMeta(sourceID string) LiveSpectrogramMeta {
+	cfg := c.Settings.WebServer.LiveStream.Spectrogram
+	meta := LiveSpectrogramMeta{
+		Type:            "spectrogram-meta",
+		SourceID:        sourceID,
+		SampleRate:      c.Settings.WebServer.LiveStream.SampleRate,
+		FFTSize:         cfg.FFTSize,
+		HopSize:         cfg.HopSize,
+		Window:          cfg.Window,
+		BinCount:        cfg.FFTSize / 2,
+		MinFrequencyHz:  0,
+		MaxFrequencyHz:  c.Settings.WebServer.LiveStream.SampleRate / 2,
+		BatchIntervalMs: cfg.BatchIntervalMs,
+	}
+	if stream := c.getHLSStream(sourceID); stream != nil && !stream.streamEpoch.IsZero() {
+		meta.StreamEpochUnixMs = stream.streamEpoch.UnixMilli()
+	}
+	return meta
+}
+
+func isClosedNetworkError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var netErr *net.OpError
+	return stderrors.Is(err, context.Canceled) || stderrors.As(err, &netErr)
+}

--- a/internal/api/v2/audio_spectrogram.go
+++ b/internal/api/v2/audio_spectrogram.go
@@ -3,15 +3,20 @@ package api
 import (
 	"context"
 	"encoding/json"
-	stderrors "errors"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
+	"os"
 	"sync"
 	"sync/atomic"
+	"syscall"
 	"time"
 
 	"github.com/labstack/echo/v4"
+	"github.com/tphakala/birdnet-go/internal/errors"
+	"github.com/tphakala/birdnet-go/internal/logger"
+	"github.com/tphakala/birdnet-go/internal/privacy"
 )
 
 const (
@@ -69,17 +74,32 @@ type liveSpectrogramEvent struct {
 	Columns   []LiveSpectrogramColumn `json:"columns,omitempty"`
 }
 
+// liveSpectrogramSubscriber holds per-SSE-client state for the broadcaster.
+// drops is incremented (under the subscribersMu read lock) whenever the
+// bounded channel is full and the batch has to be skipped.
+type liveSpectrogramSubscriber struct {
+	ch       chan LiveSpectrogramBatch
+	sourceID string
+	clientIP string
+	drops    atomic.Int64
+}
+
+// liveSpectrogramDropLogInterval controls how often per-subscriber drop
+// warnings are emitted by the broadcaster. Matches the innermost consumer
+// interval so the three log streams line up.
+const liveSpectrogramDropLogInterval int64 = 100
+
 type liveSpectrogramManager struct {
 	activeConnections sync.Map
 	connectionMu      sync.Mutex
-	subscribers       map[string]map[chan LiveSpectrogramBatch]struct{}
+	subscribers       map[string]map[*liveSpectrogramSubscriber]struct{}
 	subscribersMu     sync.RWMutex
 	broadcasterOnce   sync.Once
 	broadcasterCancel context.CancelFunc
 }
 
 var liveSpectrogramMgr = &liveSpectrogramManager{
-	subscribers: make(map[string]map[chan LiveSpectrogramBatch]struct{}),
+	subscribers: make(map[string]map[*liveSpectrogramSubscriber]struct{}),
 }
 
 func (c *Controller) SetLiveSpectrogramChan(ch chan LiveSpectrogramBatch) {
@@ -102,20 +122,27 @@ func runLiveSpectrogramBroadcaster(ctx context.Context, sourceChan chan LiveSpec
 			if !ok {
 				liveSpectrogramMgr.subscribersMu.Lock()
 				for _, subscribers := range liveSpectrogramMgr.subscribers {
-					for ch := range subscribers {
-						close(ch)
+					for sub := range subscribers {
+						close(sub.ch)
 					}
 				}
-				liveSpectrogramMgr.subscribers = make(map[string]map[chan LiveSpectrogramBatch]struct{})
+				liveSpectrogramMgr.subscribers = make(map[string]map[*liveSpectrogramSubscriber]struct{})
 				liveSpectrogramMgr.subscribersMu.Unlock()
 				return
 			}
 
 			liveSpectrogramMgr.subscribersMu.RLock()
-			for ch := range liveSpectrogramMgr.subscribers[data.SourceID] {
+			for sub := range liveSpectrogramMgr.subscribers[data.SourceID] {
 				select {
-				case ch <- data:
+				case sub.ch <- data:
 				default:
+					drops := sub.drops.Add(1)
+					if drops == 1 || drops%liveSpectrogramDropLogInterval == 0 {
+						GetLogger().Warn("live spectrogram batch dropped at subscriber",
+							logger.String("source_id", privacy.SanitizeRTSPUrl(sub.sourceID)),
+							logger.String("client_ip", sub.clientIP),
+							logger.Int64("total_drops", drops))
+					}
 				}
 			}
 			liveSpectrogramMgr.subscribersMu.RUnlock()
@@ -123,24 +150,28 @@ func runLiveSpectrogramBroadcaster(ctx context.Context, sourceChan chan LiveSpec
 	}
 }
 
-func subscribeToLiveSpectrogram(sourceID string) chan LiveSpectrogramBatch {
-	ch := make(chan LiveSpectrogramBatch, liveSpectrogramChannelBuffer)
+func subscribeToLiveSpectrogram(sourceID, clientIP string) *liveSpectrogramSubscriber {
+	sub := &liveSpectrogramSubscriber{
+		ch:       make(chan LiveSpectrogramBatch, liveSpectrogramChannelBuffer),
+		sourceID: sourceID,
+		clientIP: clientIP,
+	}
 	liveSpectrogramMgr.subscribersMu.Lock()
 	defer liveSpectrogramMgr.subscribersMu.Unlock()
 	if liveSpectrogramMgr.subscribers[sourceID] == nil {
-		liveSpectrogramMgr.subscribers[sourceID] = make(map[chan LiveSpectrogramBatch]struct{})
+		liveSpectrogramMgr.subscribers[sourceID] = make(map[*liveSpectrogramSubscriber]struct{})
 	}
-	liveSpectrogramMgr.subscribers[sourceID][ch] = struct{}{}
-	return ch
+	liveSpectrogramMgr.subscribers[sourceID][sub] = struct{}{}
+	return sub
 }
 
-func unsubscribeFromLiveSpectrogram(sourceID string, ch chan LiveSpectrogramBatch) {
+func unsubscribeFromLiveSpectrogram(sub *liveSpectrogramSubscriber) {
 	liveSpectrogramMgr.subscribersMu.Lock()
 	defer liveSpectrogramMgr.subscribersMu.Unlock()
-	if subscribers := liveSpectrogramMgr.subscribers[sourceID]; subscribers != nil {
-		delete(subscribers, ch)
+	if subscribers := liveSpectrogramMgr.subscribers[sub.sourceID]; subscribers != nil {
+		delete(subscribers, sub)
 		if len(subscribers) == 0 {
-			delete(liveSpectrogramMgr.subscribers, sourceID)
+			delete(liveSpectrogramMgr.subscribers, sub.sourceID)
 		}
 	}
 }
@@ -182,9 +213,9 @@ func (c *Controller) StreamLiveSpectrogram(ctx echo.Context) error {
 	}
 	liveSpectrogramMgr.connectionMu.Unlock()
 
-	subscriberChan := subscribeToLiveSpectrogram(sourceID)
+	subscriber := subscribeToLiveSpectrogram(sourceID, clientIP)
 	defer func() {
-		unsubscribeFromLiveSpectrogram(sourceID, subscriberChan)
+		unsubscribeFromLiveSpectrogram(subscriber)
 		liveSpectrogramMgr.connectionMu.Lock()
 		if countPtr, ok := liveSpectrogramMgr.activeConnections.Load(clientIP); ok {
 			newCount := atomic.AddInt32(countPtr.(*int32), -1)
@@ -219,34 +250,28 @@ func (c *Controller) StreamLiveSpectrogram(ctx echo.Context) error {
 			return nil
 		case <-c.ctx.Done():
 			return nil
-		case batch, ok := <-subscriberChan:
+		case batch, ok := <-subscriber.ch:
 			if !ok {
 				return nil
 			}
 			if conn, ok := resp.Writer.(WriteDeadlineSetter); ok {
 				_ = conn.SetWriteDeadline(time.Now().Add(liveSpectrogramWriteDeadline))
 			}
-			err := c.sendSSEMessage(ctx, "spectrogram-columns", liveSpectrogramEvent{
+			if err := c.sendSSEMessage(ctx, "spectrogram-columns", liveSpectrogramEvent{
 				Type:     "spectrogram-columns",
 				SourceID: batch.SourceID,
 				Columns:  batch.Columns,
-			})
-			if isClosedNetworkError(err) {
-				return nil
-			}
-			if err != nil {
+			}); err != nil {
+				c.logLiveSpectrogramWriteError(ctx, err, "spectrogram-columns", sourceID)
 				return nil
 			}
 		case <-heartbeat.C:
-			err := c.sendSSEMessage(ctx, "heartbeat", liveSpectrogramEvent{
+			if err := c.sendSSEMessage(ctx, "heartbeat", liveSpectrogramEvent{
 				Type:      "heartbeat",
 				SourceID:  sourceID,
 				Timestamp: time.Now().UnixMilli(),
-			})
-			if isClosedNetworkError(err) {
-				return nil
-			}
-			if err != nil {
+			}); err != nil {
+				c.logLiveSpectrogramWriteError(ctx, err, "heartbeat", sourceID)
 				return nil
 			}
 		}
@@ -255,16 +280,19 @@ func (c *Controller) StreamLiveSpectrogram(ctx echo.Context) error {
 
 func (c *Controller) buildLiveSpectrogramMeta(sourceID string) LiveSpectrogramMeta {
 	cfg := c.Settings.WebServer.LiveStream.Spectrogram
+	// Use the same fallback the manager applies when creating the consumer so
+	// the reported sample rate matches the FFT that's actually running.
+	sampleRate := c.Settings.WebServer.LiveStream.EffectiveSampleRate()
 	meta := LiveSpectrogramMeta{
 		Type:            "spectrogram-meta",
 		SourceID:        sourceID,
-		SampleRate:      c.Settings.WebServer.LiveStream.SampleRate,
+		SampleRate:      sampleRate,
 		FFTSize:         cfg.FFTSize,
 		HopSize:         cfg.HopSize,
 		Window:          cfg.Window,
 		BinCount:        cfg.FFTSize / 2,
 		MinFrequencyHz:  0,
-		MaxFrequencyHz:  c.Settings.WebServer.LiveStream.SampleRate / 2,
+		MaxFrequencyHz:  sampleRate / 2,
 		BatchIntervalMs: cfg.BatchIntervalMs,
 	}
 	if stream := c.getHLSStream(sourceID); stream != nil && !stream.streamEpoch.IsZero() {
@@ -273,10 +301,42 @@ func (c *Controller) buildLiveSpectrogramMeta(sourceID string) LiveSpectrogramMe
 	return meta
 }
 
-func isClosedNetworkError(err error) bool {
+// isClientDisconnectError reports whether err indicates that the SSE client has
+// gone away (closed connection, reset peer, broken pipe, canceled request,
+// write deadline expired). Transient write failures such as DNS lookup or
+// dial-refused errors are NOT matched here — those are genuine faults and
+// should be logged rather than silently swallowed.
+func isClientDisconnectError(err error) bool {
 	if err == nil {
 		return false
 	}
-	var netErr *net.OpError
-	return stderrors.Is(err, context.Canceled) || stderrors.As(err, &netErr)
+	switch {
+	case errors.Is(err, context.Canceled),
+		errors.Is(err, context.DeadlineExceeded),
+		errors.Is(err, io.EOF),
+		errors.Is(err, io.ErrClosedPipe),
+		errors.Is(err, io.ErrUnexpectedEOF),
+		errors.Is(err, net.ErrClosed),
+		errors.Is(err, syscall.EPIPE),
+		errors.Is(err, syscall.ECONNRESET),
+		errors.Is(err, os.ErrDeadlineExceeded):
+		return true
+	}
+	// http.ErrAbortHandler surfaces when the client aborts the request.
+	if errors.Is(err, http.ErrAbortHandler) {
+		return true
+	}
+	return false
+}
+
+// logLiveSpectrogramWriteError logs unexpected SSE write errors at warn level
+// while staying silent for client-disconnect noise.
+func (c *Controller) logLiveSpectrogramWriteError(ctx echo.Context, err error, event, sourceID string) {
+	if isClientDisconnectError(err) {
+		return
+	}
+	c.logAPIRequest(ctx, logger.LogLevelWarn, "Live spectrogram SSE write failed",
+		logger.String("event", event),
+		logger.String("source_id", privacy.SanitizeRTSPUrl(sourceID)),
+		logger.Error(err))
 }

--- a/internal/api/v2/audio_spectrogram_test.go
+++ b/internal/api/v2/audio_spectrogram_test.go
@@ -1,0 +1,74 @@
+package api
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSpectrogramBinsMarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		bins SpectrogramBins
+		want string
+	}{
+		{"empty", SpectrogramBins{}, "[]"},
+		{"nil", nil, "[]"},
+		{"single_zero", SpectrogramBins{0}, "[0]"},
+		{"single_max", SpectrogramBins{255}, "[255]"},
+		{"three_values", SpectrogramBins{0, 128, 255}, "[0,128,255]"},
+		{"all_digit_widths", SpectrogramBins{1, 12, 123, 9, 99, 200}, "[1,12,123,9,99,200]"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := tt.bins.MarshalJSON()
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, string(got))
+
+			// Round-trip via the stdlib decoder to confirm the output is
+			// valid JSON and numerically identical to the input. Compare
+			// element-wise so a nil input matches an empty decoded slice.
+			var decoded []uint8
+			require.NoError(t, json.Unmarshal(got, &decoded))
+			assert.Equal(t, len(tt.bins), len(decoded))
+			for i := range tt.bins {
+				assert.Equal(t, tt.bins[i], decoded[i])
+			}
+		})
+	}
+}
+
+func TestSpectrogramBinsMarshalJSONLarge(t *testing.T) {
+	t.Parallel()
+
+	// Simulate a realistic column: fftSize=1024 → 512 bins.
+	bins := make(SpectrogramBins, 512)
+	for i := range bins {
+		bins[i] = uint8(i & 0xff)
+	}
+
+	got, err := bins.MarshalJSON()
+	require.NoError(t, err)
+
+	var decoded []uint8
+	require.NoError(t, json.Unmarshal(got, &decoded))
+	assert.Equal(t, []uint8(bins), decoded)
+}
+
+func BenchmarkSpectrogramBinsMarshalJSON(b *testing.B) {
+	bins := make(SpectrogramBins, 512)
+	for i := range bins {
+		bins[i] = uint8(i & 0xff)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = bins.MarshalJSON()
+	}
+}

--- a/internal/api/v2/audio_spectrogram_test.go
+++ b/internal/api/v2/audio_spectrogram_test.go
@@ -36,7 +36,7 @@ func TestSpectrogramBinsMarshalJSON(t *testing.T) {
 			// element-wise so a nil input matches an empty decoded slice.
 			var decoded []uint8
 			require.NoError(t, json.Unmarshal(got, &decoded))
-			assert.Equal(t, len(tt.bins), len(decoded))
+			assert.Len(t, decoded, len(tt.bins))
 			for i := range tt.bins {
 				assert.Equal(t, tt.bins[i], decoded[i])
 			}
@@ -68,7 +68,7 @@ func BenchmarkSpectrogramBinsMarshalJSON(b *testing.B) {
 	}
 	b.ReportAllocs()
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _ = bins.MarshalJSON()
 	}
 }

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -1264,11 +1264,20 @@ type WebServerSettings struct {
 }
 
 type LiveStreamSettings struct {
-	Debug          bool   `yaml:"debug" json:"debug"`                   // true to enable debug mode
-	BitRate        int    `yaml:"bitrate" json:"bitRate"`               // bitrate for live stream in kbps
-	SampleRate     int    `yaml:"samplerate" json:"sampleRate"`         // sample rate for live stream in Hz
-	SegmentLength  int    `yaml:"segmentlength" json:"segmentLength"`   // length of each segment in seconds
-	FfmpegLogLevel string `yaml:"ffmpegloglevel" json:"ffmpegLogLevel"` // log level for ffmpeg
+	Debug          bool                    `yaml:"debug" json:"debug"`                   // true to enable debug mode
+	BitRate        int                     `yaml:"bitrate" json:"bitRate"`               // bitrate for live stream in kbps
+	SampleRate     int                     `yaml:"samplerate" json:"sampleRate"`         // sample rate for live stream in Hz
+	SegmentLength  int                     `yaml:"segmentlength" json:"segmentLength"`   // length of each segment in seconds
+	FfmpegLogLevel string                  `yaml:"ffmpegloglevel" json:"ffmpegLogLevel"` // log level for ffmpeg
+	Spectrogram    LiveSpectrogramSettings `yaml:"spectrogram" json:"spectrogram"`       // live spectrogram stream configuration
+}
+
+type LiveSpectrogramSettings struct {
+	Enabled         bool   `yaml:"enabled" json:"enabled"`
+	FFTSize         int    `yaml:"fftsize" json:"fftSize"`
+	HopSize         int    `yaml:"hopsize" json:"hopSize"`
+	Window          string `yaml:"window" json:"window"`
+	BatchIntervalMs int    `yaml:"batchintervalms" json:"batchIntervalMs"`
 }
 
 // BackupRetention defines backup retention policy

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -1280,6 +1280,17 @@ type LiveSpectrogramSettings struct {
 	BatchIntervalMs int    `yaml:"batchintervalms" json:"batchIntervalMs"`
 }
 
+// EffectiveSampleRate returns the sample rate used for live streaming. If the
+// user-configured value is 0 or negative, it falls back to the project-wide
+// SampleRate constant. Producers and metadata-builders must call this so the
+// rate shown to clients matches what the FFT consumer actually runs at.
+func (ls LiveStreamSettings) EffectiveSampleRate() int {
+	if ls.SampleRate > 0 {
+		return ls.SampleRate
+	}
+	return SampleRate
+}
+
 // BackupRetention defines backup retention policy
 type BackupRetention struct {
 	MaxAge     string `yaml:"maxage" json:"maxAge"`         // Duration string for the maximum age of backups to keep (e.g., "30d" for 30 days, "6m" for 6 months, "1y" for 1 year). Backups older than this may be deleted.

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -1284,7 +1284,7 @@ type LiveSpectrogramSettings struct {
 // user-configured value is 0 or negative, it falls back to the project-wide
 // SampleRate constant. Producers and metadata-builders must call this so the
 // rate shown to clients matches what the FFT consumer actually runs at.
-func (ls LiveStreamSettings) EffectiveSampleRate() int {
+func (ls *LiveStreamSettings) EffectiveSampleRate() int {
 	if ls.SampleRate > 0 {
 		return ls.SampleRate
 	}

--- a/internal/conf/defaults.go
+++ b/internal/conf/defaults.go
@@ -333,6 +333,11 @@ func setDefaultConfig() {
 	viper.SetDefault("webserver.livestream.sampleRate", 48000)
 	viper.SetDefault("webserver.livestream.segmentLength", 2)
 	viper.SetDefault("webserver.livestream.ffmpegLogLevel", "warning")
+	viper.SetDefault("webserver.livestream.spectrogram.enabled", true)
+	viper.SetDefault("webserver.livestream.spectrogram.fftsize", 1024)
+	viper.SetDefault("webserver.livestream.spectrogram.hopsize", 128)
+	viper.SetDefault("webserver.livestream.spectrogram.window", "hann")
+	viper.SetDefault("webserver.livestream.spectrogram.batchintervalms", 16)
 
 	// File output configuration
 	viper.SetDefault("output.file.enabled", true)


### PR DESCRIPTION
## Summary

  Server-side FFT computation streamed to browsers via SSE, replacing
  client-side `AnalyserNode`-based spectrogram rendering. Fixes the
  blank-waterfall bug in Safari (macOS/iOS) and Chrome on iOS caused by
  a WebKit bug affecting Web Audio analysis of HLS-backed audio
  elements. Also adds frequency/time axis labels, color-map selection
  persistence, and several follow-up correctness/perf/integration fixes.

  Refs #2702 (proposal for upstreaming this work)
  Closes #1255 (feature request: More Detailed Spectrograms — x/y axes)

  ## Changes

  **`feat(api/v2)`: new `/api/v2/streams/spectrogram/:sourceID` SSE endpoint**
  - Server-side FFT producer (`SpectrogramConsumer`) attached to the
    audio router on-demand via a ref-counted `LiveSpectrogramManager`.
    Producer is attached only while at least one SSE subscriber is
    active, detached on the last release.
  - Clients receive a `spectrogram-meta` event followed by a stream of
    `spectrogram-columns` events with pre-computed FFT bins. The Svelte
    canvas renders these directly without calling the Web Audio API.
  - Works on Safari macOS, Safari iOS, Chrome iOS, Chrome macOS, and
    Firefox — validated in all five browsers during development.
  - Adds frequency (y-axis, kHz) labels plus a toggleable time
    (x-axis, wall-clock) axis to `SpectrogramCanvas`, wired into both
    the dashboard `MiniSpectrogram` widget and the Live Audio page.

  **`fix(analysis)`: concurrency, timing, and observability in live spectrogram**
  - Shutdown race: track forwarding goroutines in a WaitGroup so the
    SSE channel can be closed without racing in-flight sends (would
    otherwise panic on "send on closed channel").
  - SSE write errors: replace `*net.OpError` catch-all with
    `errors.Is` against real sentinels (`io.EOF`, `net.ErrClosed`,
    `syscall.EPIPE`, etc.). Log unexpected errors at warn level
    instead of swallowing.
  - Sample-rate consistency: add
    `LiveStreamSettings.EffectiveSampleRate()` and use from both the
    producer and the metadata builder so clients see the same rate
    the FFT actually runs at.
  - Drop visibility: sampled warn-level drop logging at all three
    fan-out stages (consumer flush, manager forwarder, SSE broadcaster)
    with sanitized source IDs and per-stage counters.
  - Write/Close race: serialize `flush` sends with `sendMu` so a
    concurrent `Close` cannot trigger "send on closed channel".
  - Timing drift: replace per-hop float-`Duration` increments with
    a `streamEpoch` + integer `startSample` counter and an
    overflow-safe `sampleOffset` helper. No accumulated float error
    across long streams.
  - Scratch allocations: reuse `scratchPCM` in place for
    multi-channel downmix; delete redundant `scratchMono` field.

  **`perf(api/v2,frontend)`: reduce allocation churn in hot paths**
  - Server: `SpectrogramBins.MarshalJSON` hand-written digit
    serializer using `strconv.AppendUint` instead of
    `make([]int, N)` + reflection-based `json.Marshal`. Benchmark:
    1 alloc / 2304 B/op / ~3.7 µs per 512-bin column.
  - Frontend (`SpectrogramCanvas.svelte`): convert
    `queuedStreamColumns` and `renderReadyColumns` from slice()-based
    dequeues to plain arrays with integer head indices. Eliminates
    O(N) element copies per drained column in the animation loop —
    noticeable smoothness improvement on Safari's JavaScriptCore
    where the allocation churn was visible as micro-stutter.
    `aggregateStreamColumns` now takes start/end indices instead of
    a sliced sub-array.
  - Frontend (`MiniSpectrogram`, `LiveStreamPage`): replace per-event
    `[...streamColumns, ...event.columns].slice(-N)` with in-place
    `push` + `splice` on overflow. Svelte 5 reactivity coalesces
    mutations into a single microtask, so the child effect still
    fires once per event.

  **`chore(analysis+api/v2)`: integrate upstream audio pipeline, adopt modern Go idioms**
  - Wire the spectrogram consumer into the new multi-argument
    `AudioRouter.AddRoute(gainDB, filterChain)` signature (upstream
    PRs #2737/#2738/#2739), matching the HLS consumer pattern so the
    spectrogram waterfall reflects the same gain-adjusted, EQ-filtered
    audio the user hears on the Live Audio page. Uses
    `engine.Registry().GetGain()` and
    `equalizer.BuildFilterChainForSource()` with per-request settings
    lookup for hot-reload support.
  - Adopt Go 1.22+ integer `range` loops (`for i := range n`).
  - Use `slices.Clone(batch)` instead of `append([]T(nil), src...)`.
  - Use `sync.WaitGroup.Go(func(){ ... })` (Go 1.25+) for the live
    spectrogram forwarder.
  - Switch `SpectrogramConsumer.decodeFrame` to take `*AudioFrame`
    to avoid passing a 104-byte struct by value every frame.
  - Switch `LiveStreamSettings.EffectiveSampleRate` to a pointer
    receiver.
  - Testifylint: `assert.Len` instead of `assert.Equal(len, len)`;
    benchmark uses `for b.Loop()` (Go 1.24+).

  **`fix(analysis/processor)`: defer audio export retry when capture tail not ready**
  - When a detection triggers extended capture
    (`duration_seconds > configured_length`), the export action runs
    immediately after approval but the capture buffer may not yet
    contain the full tail. Previously this failed silently with
    `"requested segment exceeds written data"` → no FLAC clip
    written → dashboard "Waiting" spinner stuck indefinitely.
  - Adds a job-queue retry mechanism: the save-audio-clip action is
    deferred and retried ~2s later with exponential backoff, up to 8
    attempts. In practice the retry succeeds on attempt 2 once the
    capture buffer has absorbed the tail.
  - Bundled with this PR because extended capture is enabled by
    default; without this retry the extended-capture path is broken
    end-to-end, blocking SSE regression testing for any user whose
    config uses it. Happy to split into its own PR if the maintainer
    prefers to review it independently.

  **`feat(frontend)`: persist Live Audio color map selection across visits**
  - The color map dropdown (Inferno / Viridis / Grayscale) previously
    reset to Inferno every time the user navigated away from Live
    Audio and came back. Now persisted to `localStorage` under the
    key `birdnet-live-audio-color-map`, validated against the
    authoritative `COLOR_MAPS` registry before trust, with graceful
    fallback to `DEFAULT_COLOR_MAP` when localStorage is unavailable
    (private browsing, strict privacy modes).
  - Scope is intentionally limited to the Live Audio page. Dashboard
    MiniSpectrogram widget and Recent Detections spectrograms are
    unaffected by design.

  ## Testing

  - [x] Go tests pass (`task test` on affected packages: `api/v2`,
        `analysis`, `analysis/processor`, `audiocore`, `conf`)
  - [x] Frontend tests pass (`npm test`: 1823/1823 passing across 94
        test files)
  - [x] Frontend quality gate (`npm run check:all`): Prettier, ESLint,
        Stylelint, svelte-check (0/0/0 errors/warnings), ast-grep ×4
  - [x] Go linting clean (`task lint`): **0 issues** full-project run
  - [x] Benchmark for `SpectrogramBins.MarshalJSON` included
        (1 alloc / 2304 B/op / ~3.7 µs per 512-bin column)
  - [x] Manual cross-browser smoke test of Live Audio + dashboard
        spectrogram on:
    - Safari macOS
    - Chrome macOS
    - Safari iOS
    - Chrome iOS
    - Firefox desktop
  - [x] Manual end-to-end verification of the deferred-export retry
        fix via a real extended-capture detection (Tufted Titmouse,
        0.87 confidence, 32s clip) showing the
        `Job scheduled for retry` → `Job retry execution starting
        attempt=2` → `Audio clip saved successfully` three-line log
        sequence
  - [x] Color-map persistence verified via browser DevTools → Storage
        → Local Storage → `birdnet-live-audio-color-map` key

  ## Related Issues

  - Refs #2702 — discussion issue where I asked whether this work
    was worth upstreaming
  - Closes #1255 — "Feature Request: More Detailed Spectrograms"
    (the x/y axes request)

  ## Notes for the reviewer

  - The commits are structured `feat → fix → perf → chore → fix → feat`
    telling a coherent story, but feel free to squash-merge if you'd
    prefer a single commit on `main`.
  - Every commit is authored by `Dave Haas <code@davehaas.com>` in
    conventional-commit format.
  - The `fix(analysis/processor)` deferred-export commit is
    operationally coupled to the SSE work (extended capture is
    broken end-to-end without it) but is architecturally independent.
    I can split it into its own PR if you prefer.
  - Happy to iterate on any feedback — this is my first contribution
    to `birdnet-go` so please be generous with review notes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Spectrogram can now stream live server-side FFT data and shows a “Syncing live audio...” status while priming.

* **UI Enhancements**
  * Toggleable time axis and optional frequency axis (kHz ticks) with formatted time labels.
  * Time-axis toggle added to controls; color map selection persisted.

* **Performance / Stability**
  * Bounded rolling buffer, priming/suppress-scroll behavior, and audio-context priming for smoother live playback.

* **Localization**
  * Added translations for new spectrogram UI strings.

* **Docs & Tests**
  * API SSE endpoint documented and serialization behavior covered by new tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->