### PR TITLE
feat(detections): fall back to settings for unresolved audio source names

### DIFF
--- a/frontend/src/lib/desktop/features/detections/components/DetectionCardMobile.svelte
+++ b/frontend/src/lib/desktop/features/detections/components/DetectionCardMobile.svelte
@@ -6,6 +6,8 @@
   import { t } from '$lib/i18n';
   import type { Detection } from '$lib/types/detection.types';
   import { navigation } from '$lib/stores/navigation.svelte';
+  import { settingsStore } from '$lib/stores/settings';
+  import { getFriendlyAudioSourceName } from '$lib/utils/audioSourceLabel';
 
   interface Props {
     detection: Detection;
@@ -24,6 +26,16 @@
 
   let spectrogramError = $state(false);
   let spectrogramUrl = $derived(`/api/v2/spectrogram/${detection.id}?size=md`);
+
+  // Resolve the audio source label, falling back to settings when the server
+  // payload lacks a displayName or carries a stale (renamed) source id.
+  let sourceLabel = $derived(
+    getFriendlyAudioSourceName(
+      detection.source,
+      $settingsStore.formData.realtime?.audio?.sources,
+      $settingsStore.formData.realtime?.rtsp?.streams
+    )
+  );
 
   function handlePlay() {
     const audioUrl = `/api/v2/audio/${detection.id}`;
@@ -64,10 +76,8 @@
         <div class="mt-1 text-xs opacity-70">
           {detection.date}
           {detection.time}
-          {#if detection.source?.displayName}
-            <span class="ml-1">· {detection.source.displayName}</span>
-          {:else if detection.source?.id}
-            <span class="ml-1">· {detection.source.id}</span>
+          {#if sourceLabel}
+            <span class="ml-1">· {sourceLabel}</span>
           {/if}
         </div>
       </div>

--- a/frontend/src/lib/desktop/features/detections/components/DetectionRow.svelte
+++ b/frontend/src/lib/desktop/features/detections/components/DetectionRow.svelte
@@ -36,8 +36,10 @@
   import { handleBirdImageError } from '$lib/desktop/components/ui/image-utils.js';
   import { t } from '$lib/i18n';
   import type { Detection } from '$lib/types/detection.types';
+  import { settingsStore } from '$lib/stores/settings';
   import { toastActions } from '$lib/stores/toast';
   import { fetchWithCSRF } from '$lib/utils/api';
+  import { getFriendlyAudioSourceName } from '$lib/utils/audioSourceLabel';
   import { useImageDelayedLoading } from '$lib/utils/delayedLoading.svelte.js';
   import { loggers } from '$lib/utils/logger';
   import { navigation } from '$lib/stores/navigation.svelte';
@@ -63,6 +65,22 @@
     onRefresh,
     onPlayMobileAudio,
   }: Props = $props();
+
+  // Resolve the audio source label, falling back to the current settings when
+  // the API payload lacks a displayName (e.g. v1 legacy reads) or when the
+  // recorded id has since been renamed in the configuration.
+  let sourceLabel = $derived(
+    getFriendlyAudioSourceName(
+      detection.source,
+      $settingsStore.formData.realtime?.audio?.sources,
+      $settingsStore.formData.realtime?.rtsp?.streams
+    )
+  );
+  // Dim the label when we had to fall back to the raw id (no friendly name
+  // resolved from settings and the server did not send a distinct displayName).
+  let sourceIsRawId = $derived(
+    sourceLabel !== null && sourceLabel === (detection.source?.id ?? '')
+  );
 
   // Modal states
   let showConfirmModal = $state(false);
@@ -266,13 +284,13 @@
 
 <!-- Source -->
 <td class="text-sm hidden lg:table-cell">
-  {#if detection.source?.displayName}
-    <span class="truncate max-w-32 inline-block" title={detection.source.displayName}>
-      {detection.source.displayName}
-    </span>
-  {:else if detection.source?.id}
-    <span class="truncate max-w-32 inline-block opacity-50" title={detection.source.id}>
-      {detection.source.id}
+  {#if sourceLabel}
+    <span
+      class="truncate max-w-32 inline-block"
+      class:opacity-50={sourceIsRawId}
+      title={sourceLabel}
+    >
+      {sourceLabel}
     </span>
   {/if}
 </td>

--- a/frontend/src/lib/utils/audioSourceLabel.test.ts
+++ b/frontend/src/lib/utils/audioSourceLabel.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from 'vitest';
+import { getFriendlyAudioSourceName, getAudioSourceDisplayFallback } from './audioSourceLabel';
+import type { AudioSourceConfig, StreamConfig } from '$lib/stores/settings';
+import type { SourceInfo } from '$lib/types/detection.types';
+
+const soundCards: AudioSourceConfig[] = [
+  { name: 'Front Yard Mic', device: 'hw:CARD=USB,DEV=0', gain: 0, models: ['birdnet'] },
+  { name: '', device: 'hw:CARD=Unnamed,DEV=0', gain: 0, models: ['birdnet'] },
+];
+
+const rtspStreams: StreamConfig[] = [
+  { name: 'Back Garden Cam', url: 'rtsp://cam.local/stream1', type: 'rtsp' },
+  { name: '', url: 'rtsp://unnamed.local/stream2', type: 'rtsp' },
+];
+
+describe('getFriendlyAudioSourceName', () => {
+  it('returns null when the source is null or undefined', () => {
+    expect(getFriendlyAudioSourceName(null, soundCards, rtspStreams)).toBeNull();
+    expect(getFriendlyAudioSourceName(undefined, soundCards, rtspStreams)).toBeNull();
+  });
+
+  it('returns displayName verbatim when it is present and distinct from the id', () => {
+    const source: SourceInfo = {
+      id: 'hw:CARD=USB,DEV=0',
+      displayName: 'Server-Resolved Name',
+    };
+    expect(getFriendlyAudioSourceName(source, soundCards, rtspStreams)).toBe(
+      'Server-Resolved Name'
+    );
+  });
+
+  it('falls back to sound card name when displayName equals the id and a device matches', () => {
+    const source: SourceInfo = {
+      id: 'hw:CARD=USB,DEV=0',
+      displayName: 'hw:CARD=USB,DEV=0',
+    };
+    expect(getFriendlyAudioSourceName(source, soundCards, rtspStreams)).toBe('Front Yard Mic');
+  });
+
+  it('falls back to RTSP stream name when displayName is empty and id matches a stream url', () => {
+    const source: SourceInfo = {
+      id: 'rtsp://cam.local/stream1',
+      displayName: '',
+    };
+    expect(getFriendlyAudioSourceName(source, soundCards, rtspStreams)).toBe('Back Garden Cam');
+  });
+
+  it('returns the id as last resort when displayName equals id and nothing matches in config', () => {
+    const source: SourceInfo = {
+      id: 'hw:CARD=Mystery,DEV=0',
+      displayName: 'hw:CARD=Mystery,DEV=0',
+    };
+    expect(getFriendlyAudioSourceName(source, soundCards, rtspStreams)).toBe(
+      'hw:CARD=Mystery,DEV=0'
+    );
+  });
+
+  it('falls back to sound card name when displayName is an empty string but the id matches a device', () => {
+    const source: SourceInfo = {
+      id: 'hw:CARD=USB,DEV=0',
+      displayName: '',
+    };
+    expect(getFriendlyAudioSourceName(source, soundCards, rtspStreams)).toBe('Front Yard Mic');
+  });
+
+  it('returns the id when audioSources and rtspStreams are empty and displayName is missing', () => {
+    const source: SourceInfo = { id: 'hw:CARD=USB,DEV=0' };
+    expect(getFriendlyAudioSourceName(source, [], [])).toBe('hw:CARD=USB,DEV=0');
+  });
+
+  it('returns null when the source has no displayName and no id', () => {
+    const source: SourceInfo = { id: '' };
+    expect(getFriendlyAudioSourceName(source, [], [])).toBeNull();
+  });
+
+  it('ignores sound card entries with an empty name and continues searching', () => {
+    const source: SourceInfo = { id: 'hw:CARD=Unnamed,DEV=0', displayName: '' };
+    // The only matching device has an empty name, so the id should be returned.
+    expect(getFriendlyAudioSourceName(source, soundCards, rtspStreams)).toBe(
+      'hw:CARD=Unnamed,DEV=0'
+    );
+  });
+
+  it('ignores stream entries with an empty name and falls back to the id', () => {
+    const source: SourceInfo = { id: 'rtsp://unnamed.local/stream2', displayName: '' };
+    expect(getFriendlyAudioSourceName(source, soundCards, rtspStreams)).toBe(
+      'rtsp://unnamed.local/stream2'
+    );
+  });
+
+  it('handles undefined audioSources and rtspStreams arguments', () => {
+    const source: SourceInfo = {
+      id: 'hw:CARD=USB,DEV=0',
+      displayName: 'Front Yard Mic',
+    };
+    expect(getFriendlyAudioSourceName(source, undefined, undefined)).toBe('Front Yard Mic');
+  });
+});
+
+describe('getAudioSourceDisplayFallback', () => {
+  it('returns the friendly name when resolved from config', () => {
+    const source: SourceInfo = {
+      id: 'hw:CARD=USB,DEV=0',
+      displayName: 'hw:CARD=USB,DEV=0',
+    };
+    expect(getAudioSourceDisplayFallback(source, soundCards, rtspStreams)).toBe('Front Yard Mic');
+  });
+
+  it('returns the raw id when no friendly name is available', () => {
+    const source: SourceInfo = {
+      id: 'hw:CARD=Mystery,DEV=0',
+      displayName: '',
+    };
+    expect(getAudioSourceDisplayFallback(source, [], [])).toBe('hw:CARD=Mystery,DEV=0');
+  });
+
+  it('returns an empty string when source is null', () => {
+    expect(getAudioSourceDisplayFallback(null, soundCards, rtspStreams)).toBe('');
+  });
+});

--- a/frontend/src/lib/utils/audioSourceLabel.ts
+++ b/frontend/src/lib/utils/audioSourceLabel.ts
@@ -1,0 +1,106 @@
+/**
+ * Audio source label resolution utilities.
+ *
+ * The backend populates `detection.source.displayName` when it can resolve a
+ * configured friendly name for the audio source (sound card `AudioSourceConfig.name`
+ * or RTSP `StreamConfig.name`). However there are cases where the server payload
+ * only contains the raw source id:
+ *
+ *   1. Legacy v1 datastore reads skip `Source` on the Note model (`gorm:"-"`),
+ *      so historical detections never carry a friendly name on read paths that
+ *      still use v1.
+ *   2. If a user renames a source in settings, existing detections keep the old
+ *      id/displayName written at save time.
+ *
+ * These helpers let the UI fall back to the current settings to look up the
+ * friendly name from the source id, without requiring an API change.
+ */
+import type { SourceInfo } from '$lib/types/detection.types';
+import type { AudioSourceConfig, StreamConfig } from '$lib/stores/settings';
+
+/**
+ * Resolve the friendly name for a detection audio source.
+ *
+ * Resolution order:
+ *   1. `source.displayName` when present and distinct from `source.id` (server
+ *      already resolved a friendly label).
+ *   2. A matching `AudioSourceConfig.device` in the current sound card list,
+ *      returning its configured `name` if non-empty.
+ *   3. A matching `StreamConfig.url` in the current RTSP stream list, returning
+ *      its configured `name` if non-empty.
+ *   4. `source.id` as a bare fallback (which equals `source.displayName` in
+ *      the remaining cases).
+ *
+ * @param source - The detection source payload (may be null/undefined).
+ * @param audioSources - Current sound card configuration (optional).
+ * @param rtspStreams - Current RTSP stream configuration (optional).
+ * @returns The best-effort friendly name, or `null` when nothing is known.
+ */
+export function getFriendlyAudioSourceName(
+  source: SourceInfo | null | undefined,
+  audioSources: AudioSourceConfig[] | undefined,
+  rtspStreams: StreamConfig[] | undefined
+): string | null {
+  if (source == null) {
+    return null;
+  }
+
+  const displayName = source.displayName ?? '';
+  const id = source.id;
+
+  // 1. Server already resolved a friendly name distinct from the id.
+  if (displayName !== '' && displayName !== id) {
+    return displayName;
+  }
+
+  // 2. Look up against configured sound cards by device path.
+  if (id !== '' && audioSources) {
+    for (const entry of audioSources) {
+      if (entry.device === id && entry.name !== '') {
+        return entry.name;
+      }
+    }
+  }
+
+  // 3. Look up against configured RTSP streams by url.
+  if (id !== '' && rtspStreams) {
+    for (const stream of rtspStreams) {
+      if (stream.url === id && stream.name !== '') {
+        return stream.name;
+      }
+    }
+  }
+
+  // 4. Last resort: the raw id (equals displayName in the remaining cases).
+  if (id !== '') {
+    return id;
+  }
+
+  // Nothing usable.
+  if (displayName !== '') {
+    return displayName;
+  }
+
+  return null;
+}
+
+/**
+ * Convenience wrapper that never returns null - returns the empty string when
+ * the source carries no usable information. Intended for direct use in
+ * templates.
+ *
+ * When a friendly name is resolved from settings, the returned string is the
+ * friendly name. Otherwise it returns the raw `source.id` (or an empty string
+ * when even the id is missing).
+ */
+export function getAudioSourceDisplayFallback(
+  source: SourceInfo | null | undefined,
+  audioSources: AudioSourceConfig[] | undefined,
+  rtspStreams: StreamConfig[] | undefined
+): string {
+  const resolved = getFriendlyAudioSourceName(source, audioSources, rtspStreams);
+  if (resolved != null) {
+    return resolved;
+  }
+  return source?.id ?? '';
+}

--- a/internal/analysis/processor/processor_test.go
+++ b/internal/analysis/processor/processor_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/audiocore"
 	"github.com/tphakala/birdnet-go/internal/datastore"
 )
 
@@ -125,6 +126,151 @@ func TestConvertToAdditionalResults_DeduplicatesByScientificName(t *testing.T) {
 					"duplicate scientific name in output: %s", r.Species.ScientificName)
 				seen[r.Species.ScientificName] = true
 			}
+		})
+	}
+}
+
+// TestProcessor_resolveAudioSource_EnrichesFromRegistry guards the enrichment
+// chain that links a configured SourceConfig.DisplayName through the
+// audiocore source registry to the detection.AudioSource.DisplayName stored
+// with every detection.
+//
+// The contract this test protects: resolveAudioSource must use the registry
+// (when set) to fill in the human-readable DisplayName and Type for the
+// detection, preferring a match by connection string (datastore.AudioSource.ID
+// == SourceInfo.ConnectionString) and falling back to a match by SourceInfo.ID.
+// When the registry is unset or has no match, the input must pass through
+// unchanged with Type derived from the SafeString.
+func TestProcessor_resolveAudioSource_EnrichesFromRegistry(t *testing.T) {
+	t.Parallel()
+	t.Attr("component", "processor")
+	t.Attr("feature", "source-enrichment")
+
+	// Connection strings used throughout the cases. Declared as named
+	// constants so the intent of each fixture is obvious and the project
+	// rule against magic strings is respected.
+	const (
+		alsaConnection = "hw:1,0"
+		alsaDisplay    = "Front Yard"
+		rtspID         = "rtsp_abc123"
+		rtspConnection = "rtsp://camera.local/stream"
+		rtspDisplay    = "Back Porch"
+		otherID        = "rtsp_other"
+		otherConn      = "rtsp://other.local/stream"
+	)
+
+	// registrySetup describes how to seed the registry before the test runs.
+	// A nil setup func means the processor is constructed without a registry,
+	// exercising the "registry not set" branch of resolveAudioSource.
+	type registrySetup func(t *testing.T, r *audiocore.SourceRegistry)
+
+	tests := []struct {
+		name            string
+		input           datastore.AudioSource
+		setup           registrySetup
+		wantID          string
+		wantSafeString  string
+		wantDisplayName string
+		wantType        string
+	}{
+		{
+			name: "sound_card_match_by_connection_string",
+			input: datastore.AudioSource{
+				ID:          alsaConnection,
+				SafeString:  alsaConnection,
+				DisplayName: alsaConnection,
+			},
+			setup: func(t *testing.T, r *audiocore.SourceRegistry) {
+				t.Helper()
+				_, err := r.Register(&audiocore.SourceConfig{
+					ID:               "audio_card_xyz",
+					ConnectionString: alsaConnection,
+					DisplayName:      alsaDisplay,
+					Type:             audiocore.SourceTypeAudioCard,
+				})
+				require.NoError(t, err)
+			},
+			wantID:          "audio_card_xyz",
+			wantSafeString:  alsaConnection,
+			wantDisplayName: alsaDisplay,
+			wantType:        "alsa",
+		},
+		{
+			name: "rtsp_match_by_id_fallback",
+			input: datastore.AudioSource{
+				ID:          rtspID,
+				SafeString:  rtspConnection,
+				DisplayName: rtspID,
+			},
+			setup: func(t *testing.T, r *audiocore.SourceRegistry) {
+				t.Helper()
+				_, err := r.Register(&audiocore.SourceConfig{
+					ID:               rtspID,
+					ConnectionString: rtspConnection,
+					DisplayName:      rtspDisplay,
+					Type:             audiocore.SourceTypeRTSP,
+				})
+				require.NoError(t, err)
+			},
+			wantID:          rtspID,
+			wantSafeString:  rtspConnection,
+			wantDisplayName: rtspDisplay,
+			wantType:        "rtsp",
+		},
+		{
+			name: "registry_not_set_pass_through",
+			input: datastore.AudioSource{
+				ID:          rtspID,
+				SafeString:  rtspConnection,
+				DisplayName: rtspID,
+			},
+			setup:           nil,
+			wantID:          rtspID,
+			wantSafeString:  rtspConnection,
+			wantDisplayName: rtspID,
+			wantType:        "rtsp",
+		},
+		{
+			name: "registry_has_no_match_pass_through",
+			input: datastore.AudioSource{
+				ID:          alsaConnection,
+				SafeString:  alsaConnection,
+				DisplayName: alsaConnection,
+			},
+			setup: func(t *testing.T, r *audiocore.SourceRegistry) {
+				t.Helper()
+				_, err := r.Register(&audiocore.SourceConfig{
+					ID:               otherID,
+					ConnectionString: otherConn,
+					DisplayName:      "Unrelated Source",
+					Type:             audiocore.SourceTypeRTSP,
+				})
+				require.NoError(t, err)
+			},
+			wantID:          alsaConnection,
+			wantSafeString:  alsaConnection,
+			wantDisplayName: alsaConnection,
+			wantType:        "alsa",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			p := &Processor{}
+			if tt.setup != nil {
+				registry := audiocore.NewSourceRegistry(audiocore.GetLogger())
+				tt.setup(t, registry)
+				p.SetRegistry(registry)
+			}
+
+			got := p.resolveAudioSource(tt.input)
+			assert.Equal(t, tt.wantID, got.ID, "resolved ID")
+			assert.Equal(t, tt.wantSafeString, got.SafeString, "resolved SafeString")
+			assert.Equal(t, tt.wantDisplayName, got.DisplayName,
+				"resolved DisplayName must flow from registry when available")
+			assert.Equal(t, tt.wantType, got.Type, "resolved Type")
 		})
 	}
 }

--- a/internal/datastore/model.go
+++ b/internal/datastore/model.go
@@ -22,7 +22,13 @@ type Note struct {
 	Date       string `gorm:"index:idx_notes_date;index:idx_notes_date_commonname_confidence;index:idx_notes_sciname_date;index:idx_notes_sciname_date_optimized,priority:2"`
 	Time       string `gorm:"index:idx_notes_time"`
 	//InputFile      string
-	Source      AudioSource         `gorm:"-"` // Runtime only, not stored in database
+	// Source is runtime-only: the AudioSource display metadata is built from
+	// the audiocore source registry during detection processing and persisted
+	// separately by the v2 datastore's AudioSource entity (see
+	// internal/datastore/v2/entities). On the legacy v1 datastore the field is
+	// never rehydrated on read, so the detections API returns a nil Source for
+	// historical detections saved through that path.
+	Source      AudioSource         `gorm:"-"`
 	Model       detection.ModelInfo `gorm:"-"` // Runtime only: model that produced this detection
 	BeginTime   time.Time
 	EndTime     time.Time


### PR DESCRIPTION
## Summary

Follow-up to #1681 (stream labels). When the detections API returns a source with no `displayName` (or where `displayName` equals `id`), the UI now looks up the friendly name from the current user settings instead of showing the raw device string or URL.

Two real-world scenarios where this matters:

- **Legacy v1 datastore**: `Note.Source` has `gorm:\"-\"`, so it is never rehydrated on read. Historical detections surface as a `nil` Source over the API.
- **Source renamed after save**: v2 persists `DisplayName` at save time; a later rename in settings leaves older detections tagged with the prior label.

## Changes

- **New utility** `frontend/src/lib/utils/audioSourceLabel.ts` with `getFriendlyAudioSourceName(source, audioSources, rtspStreams)` and `getAudioSourceDisplayFallback(...)`. Matches `source.id` against `AudioSourceConfig.device` (sound cards) then `StreamConfig.url` (RTSP streams), falling back to `source.displayName` or `source.id`. 14 vitest cases.
- **UI integration** in `DetectionRow.svelte` and `DetectionCardMobile.svelte` — `$derived` wrappers read from `settingsStore.formData.realtime.audio.sources` and `...rtsp.streams`. Source column updates reactively when the user edits a source. Preserves existing truncate/title/dim styling.
- **Backend regression test** `TestProcessor_resolveAudioSource_EnrichesFromRegistry` — seeds an `audiocore.SourceRegistry` with a fake source and asserts the processor's enrichment chain surfaces the registry's `DisplayName`. Covers sound cards (match by connection string), RTSP (match by ID fallback), nil-registry pass-through, and no-match pass-through.
- **Doc comment** on `datastore.Note.Source` expanded to call out the v1 rehydration gap and point at the v2 entity.

## Verification

- `go test -race ./internal/analysis/processor/` — passes
- `golangci-lint run` — 0 issues
- `npx vitest run src/lib/utils/audioSourceLabel.test.ts` — 14/14 passing
- `npx vitest run src/lib/desktop/features/detections/components/` — existing 6 tests still pass
- `npm run check:all` — prettier/eslint/stylelint/svelte-check/4x ast-grep clean
- Local CodeRabbit review on uncommitted diff — no findings

## Out of scope

- Shared `FindAudioSourceConfig` helper to dedupe existing four-site source lookup (separate cleanup).
- V1 save-time Source persistence (would require a schema change; users should migrate to v2).

## Test plan

- [ ] Rename a configured sound card in Settings -> Sound Cards; verify the change is reflected in the detections list without reloading historical data.
- [ ] On a v1 installation (legacy datastore), confirm the Source column renders the configured friendly name on historical detections instead of staying blank.
- [ ] Add an RTSP stream with a friendly name; verify it appears in the Source column for new detections.
- [ ] Confirm mobile detection cards show the same fallback name, prefixed with \`·\`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Audio sources in detection displays now resolve to friendly configured names, with intelligent fallback to device and stream labels when not explicitly set.

* **Tests**
  * Added test coverage for audio source label resolution logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->