### PR TITLE
fix(ui): defensive guards for missing source.models and duplicate timeline keys

### DIFF
--- a/frontend/src/lib/desktop/components/forms/SoundCardCard.svelte
+++ b/frontend/src/lib/desktop/components/forms/SoundCardCard.svelte
@@ -96,7 +96,7 @@
 
   // Model display names (comma-separated for multiple)
   let modelDisplayName = $derived(
-    source.models.length > 0
+    (source.models?.length ?? 0) > 0
       ? source.models.map(id => modelOptions.find(m => m.value === id)?.label ?? id).join(', ')
       : (modelOptions[0]?.label ?? '')
   );
@@ -113,7 +113,7 @@
     editName = source.name;
     editDevice = source.device;
     editGain = source.gain;
-    editModels = source.models.length > 0 ? [...source.models] : getDefaultModels();
+    editModels = (source.models?.length ?? 0) > 0 ? [...source.models] : getDefaultModels();
     editEqualizer = source.equalizer
       ? { ...source.equalizer, filters: [...source.equalizer.filters] }
       : { enabled: false, filters: [] };

--- a/frontend/src/lib/desktop/components/forms/SoundCardCard.test.ts
+++ b/frontend/src/lib/desktop/components/forms/SoundCardCard.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { screen, cleanup } from '@testing-library/svelte';
 import { renderTyped } from '../../../../test/render-helpers';
 import SoundCardCard from './SoundCardCard.svelte';
@@ -30,6 +30,10 @@ describe('SoundCardCard defensive model guards', () => {
     device: 'sysdefault',
     gain: 0,
   };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
 
   afterEach(() => {
     cleanup();

--- a/frontend/src/lib/desktop/components/forms/SoundCardCard.test.ts
+++ b/frontend/src/lib/desktop/components/forms/SoundCardCard.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { screen, cleanup } from '@testing-library/svelte';
+import { renderTyped } from '../../../../test/render-helpers';
+import SoundCardCard from './SoundCardCard.svelte';
+import type { AudioSourceConfig } from '$lib/stores/settings';
+
+// Mocks for common form dependencies to keep the render lightweight.
+vi.mock('./SelectDropdown.svelte', () => ({
+  default: vi.fn(() => ({ $set: vi.fn(), $destroy: vi.fn(), $on: vi.fn() })),
+}));
+vi.mock('./InlineSlider.svelte', () => ({
+  default: vi.fn(() => ({ $set: vi.fn(), $destroy: vi.fn(), $on: vi.fn() })),
+}));
+vi.mock('./QuietHoursEditor.svelte', () => ({
+  default: vi.fn(() => ({ $set: vi.fn(), $destroy: vi.fn(), $on: vi.fn() })),
+}));
+vi.mock('$lib/desktop/features/settings/components/AudioEqualizerSettings.svelte', () => ({
+  default: vi.fn(() => ({ $set: vi.fn(), $destroy: vi.fn(), $on: vi.fn() })),
+}));
+
+describe('SoundCardCard defensive model guards', () => {
+  const audioDevices = [{ index: 0, name: 'Default Mic', id: 'sysdefault' }];
+  const modelOptions = [
+    { value: 'birdnet', label: 'BirdNET v2.4' },
+    { value: 'perch_v2', label: 'Perch v2' },
+  ];
+
+  const baseSource: Omit<AudioSourceConfig, 'models'> = {
+    name: 'Living room',
+    device: 'sysdefault',
+    gain: 0,
+  };
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  function renderWithModels(models: AudioSourceConfig['models'] | undefined | null) {
+    const source = {
+      ...baseSource,
+      models,
+    } as unknown as AudioSourceConfig;
+
+    return renderTyped(SoundCardCard, {
+      props: {
+        source,
+        index: 0,
+        sources: [source],
+        audioDevices,
+        modelOptions,
+        disabled: false,
+        onUpdate: vi.fn(() => true),
+        onDelete: vi.fn(),
+      },
+    });
+  }
+
+  it('renders without throwing when source.models is undefined', () => {
+    expect(() => renderWithModels(undefined)).not.toThrow();
+
+    // Falls back to the first model option's label.
+    expect(screen.getByText('BirdNET v2.4')).toBeInTheDocument();
+  });
+
+  it('renders without throwing when source.models is null', () => {
+    expect(() =>
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- legacy JSON deserializes omitted arrays as null
+      renderWithModels(null as any)
+    ).not.toThrow();
+
+    expect(screen.getByText('BirdNET v2.4')).toBeInTheDocument();
+  });
+
+  it('renders without throwing when source.models is an empty array', () => {
+    expect(() => renderWithModels([])).not.toThrow();
+
+    expect(screen.getByText('BirdNET v2.4')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/lib/desktop/components/forms/StreamTimeline.svelte
+++ b/frontend/src/lib/desktop/components/forms/StreamTimeline.svelte
@@ -26,10 +26,15 @@
     // errors). Precomputed during derivation so the template and aria-label
     // can access it without repeated union narrowing.
     discriminator: string;
+    // Per-(timestamp, type, discriminator) occurrence count, 0-based. Only
+    // > 0 for true duplicates (same data repeated in the same millisecond).
+    // Used both in the composite `key` and in the aria-label tiebreaker so
+    // screen-reader users can tell duplicate events apart.
+    ordinal: number;
     // Stable per-event key precomputed during derivation. Combines timestamp,
-    // type, discriminator, and a per-duplicate ordinal so multiple events
-    // with identical data still produce distinct keys without depending on
-    // the sliding render index (BIRDNET-GO-1A0).
+    // type, discriminator, and ordinal so multiple events with identical
+    // data still produce distinct keys without depending on the sliding
+    // render index (BIRDNET-GO-1A0).
     key: string;
   }
 
@@ -122,7 +127,7 @@
       const base = `${event.timestamp.getTime()}_${event.type}_${discriminator}`;
       const ordinal = occurrence.get(base) ?? 0;
       occurrence.set(base, ordinal + 1);
-      return { ...event, discriminator, key: `${base}_${ordinal}` };
+      return { ...event, discriminator, ordinal, key: `${base}_${ordinal}` };
     });
 
     // Limit to last 10 events; ordinals were assigned pre-slice so surviving
@@ -246,6 +251,11 @@
               }),
               event.type === 'error' ? t('settings.audio.streams.timeline.error') : '',
               event.discriminator,
+              // Tiebreaker for true duplicates (same timestamp + type +
+              // discriminator). Adds "(2)", "(3)", … so screen readers can
+              // tell otherwise-identical events apart. First occurrence
+              // (ordinal 0) omits the suffix to keep the common case clean.
+              event.ordinal > 0 ? `(${event.ordinal + 1})` : '',
             ]
               .filter(Boolean)
               .join(' — ')}

--- a/frontend/src/lib/desktop/components/forms/StreamTimeline.svelte
+++ b/frontend/src/lib/desktop/components/forms/StreamTimeline.svelte
@@ -33,6 +33,7 @@
 
   // Selected event for popover
   let selectedEvent = $state<TimelineEvent | null>(null);
+  let selectedIndex = $state<number>(-1);
   let selectedNodeEl = $state<HTMLElement | null>(null);
 
   // Format timestamp for display (24-hour format, using app locale)
@@ -118,19 +119,26 @@
     return toState === 'restarting' || toState === 'backoff';
   }
 
-  function handleNodeClick(event: TimelineEvent, nodeEl: HTMLElement) {
-    // Compare by timestamp to avoid Svelte 5 proxy equality issues
-    if (selectedEvent?.timestamp.getTime() === event.timestamp.getTime()) {
+  function handleNodeClick(event: TimelineEvent, index: number, nodeEl: HTMLElement) {
+    // Compare by composite key so two events sharing a millisecond do not
+    // collide (BIRDNET-GO-1A0). Keys are stable within the derived list.
+    const sameNode =
+      selectedEvent != null &&
+      timelineEventKey(selectedEvent, selectedIndex) === timelineEventKey(event, index);
+    if (sameNode) {
       selectedEvent = null;
+      selectedIndex = -1;
       selectedNodeEl = null;
     } else {
       selectedEvent = event;
+      selectedIndex = index;
       selectedNodeEl = nodeEl;
     }
   }
 
   function handleClosePopover() {
     selectedEvent = null;
+    selectedIndex = -1;
     selectedNodeEl = null;
   }
 
@@ -138,6 +146,21 @@
     if (e.key === 'Escape') {
       handleClosePopover();
     }
+  }
+
+  // Build a composite key for {#each} that stays unique even when multiple
+  // events fire in the same millisecond (BIRDNET-GO-1A0). Primary uniqueness
+  // comes from timestamp + event type + discriminator (to_state / error_type);
+  // the list index is appended as a final tiebreaker for the rare case where
+  // two events with identical timestamp, type, and discriminator collide.
+  // `timelineEvents` is derived deterministically (sorted by timestamp), so
+  // the index is stable within a single render pass.
+  function timelineEventKey(event: TimelineEvent, index: number): string {
+    const discriminator =
+      event.type === 'error'
+        ? (event.data as ErrorContext).error_type
+        : (event.data as StateTransition).to_state;
+    return `${event.timestamp.getTime()}_${event.type}_${discriminator}_${index}`;
   }
 </script>
 
@@ -156,7 +179,7 @@
         ></div>
       {/if}
 
-      {#each timelineEvents as event, _idx (event.timestamp.getTime())}
+      {#each timelineEvents as event, _idx (timelineEventKey(event, _idx))}
         {@const colors = getNodeColor(event)}
         {@const hollow = isHollow(event)}
         <div class="flex flex-col items-center w-14 flex-shrink-0">
@@ -169,7 +192,7 @@
               colors.border,
               hollow ? 'bg-[var(--color-base-100)]' : colors.bg
             )}
-            onclick={e => handleNodeClick(event, e.currentTarget)}
+            onclick={e => handleNodeClick(event, _idx, e.currentTarget)}
             aria-label={t('settings.audio.streams.timeline.eventAt', {
               time: formatTime(event.timestamp),
             })}

--- a/frontend/src/lib/desktop/components/forms/StreamTimeline.svelte
+++ b/frontend/src/lib/desktop/components/forms/StreamTimeline.svelte
@@ -187,6 +187,28 @@
       handleClosePopover();
     }
   }
+
+  // When live updates shift the 10-item window, the previously selected
+  // event may drop off (slice(-10)) and its DOM node detach. Without this,
+  // the popover would stay mounted against a stale node and show outdated
+  // data (CodeRabbit review on #2761). Reconcile on every derivation: if
+  // the selected key still has a matching event, refresh the cached
+  // reference; otherwise close the popover. Identity is tracked by
+  // `selectedKey` (string) — NOT by comparing `$state` proxies, which
+  // Svelte 5 warns against.
+  $effect(() => {
+    if (!selectedKey) return;
+
+    const next = timelineEvents.find(event => event.key === selectedKey);
+    if (!next) {
+      handleClosePopover();
+      return;
+    }
+    // Always refresh the cached reference so the popover sees the latest
+    // payload. Svelte's fine-grained reactivity makes repeated same-value
+    // assignments cheap.
+    selectedEvent = next;
+  });
 </script>
 
 <svelte:window onkeydown={handleKeydown} />

--- a/frontend/src/lib/desktop/components/forms/StreamTimeline.svelte
+++ b/frontend/src/lib/desktop/components/forms/StreamTimeline.svelte
@@ -22,6 +22,11 @@
     type: 'state' | 'error';
     timestamp: Date;
     data: StateTransition | ErrorContext;
+    // Stable per-event key precomputed during derivation. Combines timestamp,
+    // type, discriminator (to_state / error_type), and a per-duplicate ordinal
+    // so multiple events with identical data still produce distinct keys
+    // without depending on the sliding render index (BIRDNET-GO-1A0).
+    key: string;
   }
 
   interface Props {
@@ -31,9 +36,11 @@
 
   let { stateHistory = [], errorHistory = [] }: Props = $props();
 
-  // Selected event for popover
+  // Selected event for popover, tracked by its stable key so SSE-driven list
+  // changes (slice(-10)) cannot invalidate the selection before the user
+  // toggles it off.
   let selectedEvent = $state<TimelineEvent | null>(null);
-  let selectedIndex = $state<number>(-1);
+  let selectedKey = $state<string | null>(null);
   let selectedNodeEl = $state<HTMLElement | null>(null);
 
   // Format timestamp for display (24-hour format, using app locale)
@@ -52,15 +59,26 @@
     return isNaN(date.getTime()) ? null : date;
   }
 
-  // Merge and sort state and error history into unified timeline
+  // Returns the discriminator string for an event (state name for transitions,
+  // error type for errors). Used in the composite key and aria-label.
+  function eventDiscriminator(event: Omit<TimelineEvent, 'key'>): string {
+    return event.type === 'error'
+      ? ((event.data as ErrorContext).error_type ?? '')
+      : ((event.data as StateTransition).to_state ?? '');
+  }
+
+  // Merge and sort state and error history into unified timeline, assigning
+  // a stable composite key to each event. The per-duplicate ordinal is
+  // computed over the sorted list (pre-slice) so an event's key does not
+  // change when the sliding window drops older events.
   let timelineEvents = $derived.by(() => {
-    const events: TimelineEvent[] = [];
+    const raw: Omit<TimelineEvent, 'key'>[] = [];
 
     // Add state transitions (filter invalid timestamps)
     for (const state of stateHistory ?? []) {
       const timestamp = parseTimestamp(state.timestamp);
       if (timestamp) {
-        events.push({
+        raw.push({
           type: 'state',
           timestamp,
           data: state,
@@ -72,7 +90,7 @@
     for (const error of errorHistory ?? []) {
       const timestamp = parseTimestamp(error.timestamp);
       if (timestamp) {
-        events.push({
+        raw.push({
           type: 'error',
           timestamp,
           data: error,
@@ -81,10 +99,22 @@
     }
 
     // Sort by timestamp ascending (oldest first)
-    events.sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
+    raw.sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
 
-    // Limit to last 10 events
-    return events.slice(-10);
+    // Assign a deterministic per-(timestamp,type,discriminator) ordinal so
+    // true duplicate events still produce unique keys without relying on
+    // the sliding-window render index (Gemini / Sentry / CodeRabbit review).
+    const occurrence = new Map<string, number>();
+    const keyed: TimelineEvent[] = raw.map(event => {
+      const base = `${event.timestamp.getTime()}_${event.type}_${eventDiscriminator(event)}`;
+      const ordinal = occurrence.get(base) ?? 0;
+      occurrence.set(base, ordinal + 1);
+      return { ...event, key: `${base}_${ordinal}` };
+    });
+
+    // Limit to last 10 events; ordinals were assigned pre-slice so surviving
+    // events keep their keys when older events drop off.
+    return keyed.slice(-10);
   });
 
   // Get node color based on event type and data
@@ -119,26 +149,23 @@
     return toState === 'restarting' || toState === 'backoff';
   }
 
-  function handleNodeClick(event: TimelineEvent, index: number, nodeEl: HTMLElement) {
-    // Compare by composite key so two events sharing a millisecond do not
-    // collide (BIRDNET-GO-1A0). Keys are stable within the derived list.
-    const sameNode =
-      selectedEvent != null &&
-      timelineEventKey(selectedEvent, selectedIndex) === timelineEventKey(event, index);
-    if (sameNode) {
+  function handleNodeClick(event: TimelineEvent, nodeEl: HTMLElement) {
+    // Compare by the event's stable key so SSE-driven list updates cannot
+    // stale the selection (BIRDNET-GO-1A0).
+    if (selectedKey === event.key) {
       selectedEvent = null;
-      selectedIndex = -1;
+      selectedKey = null;
       selectedNodeEl = null;
     } else {
       selectedEvent = event;
-      selectedIndex = index;
+      selectedKey = event.key;
       selectedNodeEl = nodeEl;
     }
   }
 
   function handleClosePopover() {
     selectedEvent = null;
-    selectedIndex = -1;
+    selectedKey = null;
     selectedNodeEl = null;
   }
 
@@ -146,21 +173,6 @@
     if (e.key === 'Escape') {
       handleClosePopover();
     }
-  }
-
-  // Build a composite key for {#each} that stays unique even when multiple
-  // events fire in the same millisecond (BIRDNET-GO-1A0). Primary uniqueness
-  // comes from timestamp + event type + discriminator (to_state / error_type);
-  // the list index is appended as a final tiebreaker for the rare case where
-  // two events with identical timestamp, type, and discriminator collide.
-  // `timelineEvents` is derived deterministically (sorted by timestamp), so
-  // the index is stable within a single render pass.
-  function timelineEventKey(event: TimelineEvent, index: number): string {
-    const discriminator =
-      event.type === 'error'
-        ? (event.data as ErrorContext).error_type
-        : (event.data as StateTransition).to_state;
-    return `${event.timestamp.getTime()}_${event.type}_${discriminator}_${index}`;
   }
 </script>
 
@@ -179,9 +191,10 @@
         ></div>
       {/if}
 
-      {#each timelineEvents as event, _idx (timelineEventKey(event, _idx))}
+      {#each timelineEvents as event (event.key)}
         {@const colors = getNodeColor(event)}
         {@const hollow = isHollow(event)}
+        {@const discriminator = eventDiscriminator(event)}
         <div class="flex flex-col items-center w-14 flex-shrink-0">
           <!-- Node -->
           <button
@@ -192,10 +205,10 @@
               colors.border,
               hollow ? 'bg-[var(--color-base-100)]' : colors.bg
             )}
-            onclick={e => handleNodeClick(event, _idx, e.currentTarget)}
-            aria-label={t('settings.audio.streams.timeline.eventAt', {
+            onclick={e => handleNodeClick(event, e.currentTarget)}
+            aria-label={`${t('settings.audio.streams.timeline.eventAt', {
               time: formatTime(event.timestamp),
-            })}
+            })} — ${event.type === 'error' ? t('settings.audio.streams.timeline.error') : ''} ${discriminator}`.trim()}
           ></button>
 
           <!-- Timestamp -->

--- a/frontend/src/lib/desktop/components/forms/StreamTimeline.svelte
+++ b/frontend/src/lib/desktop/components/forms/StreamTimeline.svelte
@@ -22,10 +22,14 @@
     type: 'state' | 'error';
     timestamp: Date;
     data: StateTransition | ErrorContext;
+    // Data discriminator (`to_state` for state transitions, `error_type` for
+    // errors). Precomputed during derivation so the template and aria-label
+    // can access it without repeated union narrowing.
+    discriminator: string;
     // Stable per-event key precomputed during derivation. Combines timestamp,
-    // type, discriminator (to_state / error_type), and a per-duplicate ordinal
-    // so multiple events with identical data still produce distinct keys
-    // without depending on the sliding render index (BIRDNET-GO-1A0).
+    // type, discriminator, and a per-duplicate ordinal so multiple events
+    // with identical data still produce distinct keys without depending on
+    // the sliding render index (BIRDNET-GO-1A0).
     key: string;
   }
 
@@ -60,19 +64,27 @@
   }
 
   // Returns the discriminator string for an event (state name for transitions,
-  // error type for errors). Used in the composite key and aria-label.
-  function eventDiscriminator(event: Omit<TimelineEvent, 'key'>): string {
-    return event.type === 'error'
-      ? ((event.data as ErrorContext).error_type ?? '')
-      : ((event.data as StateTransition).to_state ?? '');
+  // error type for errors). Used when building the derived list.
+  function eventDiscriminator(
+    type: 'state' | 'error',
+    data: StateTransition | ErrorContext
+  ): string {
+    return type === 'error'
+      ? ((data as ErrorContext).error_type ?? '')
+      : ((data as StateTransition).to_state ?? '');
   }
 
   // Merge and sort state and error history into unified timeline, assigning
-  // a stable composite key to each event. The per-duplicate ordinal is
-  // computed over the sorted list (pre-slice) so an event's key does not
-  // change when the sliding window drops older events.
+  // a stable composite key and precomputed discriminator to each event. The
+  // per-duplicate ordinal is computed over the sorted list (pre-slice) so an
+  // event's key does not change when the sliding window drops older events.
   let timelineEvents = $derived.by(() => {
-    const raw: Omit<TimelineEvent, 'key'>[] = [];
+    type RawEvent = {
+      type: 'state' | 'error';
+      timestamp: Date;
+      data: StateTransition | ErrorContext;
+    };
+    const raw: RawEvent[] = [];
 
     // Add state transitions (filter invalid timestamps)
     for (const state of stateHistory ?? []) {
@@ -106,10 +118,11 @@
     // the sliding-window render index (Gemini / Sentry / CodeRabbit review).
     const occurrence = new Map<string, number>();
     const keyed: TimelineEvent[] = raw.map(event => {
-      const base = `${event.timestamp.getTime()}_${event.type}_${eventDiscriminator(event)}`;
+      const discriminator = eventDiscriminator(event.type, event.data);
+      const base = `${event.timestamp.getTime()}_${event.type}_${discriminator}`;
       const ordinal = occurrence.get(base) ?? 0;
       occurrence.set(base, ordinal + 1);
-      return { ...event, key: `${base}_${ordinal}` };
+      return { ...event, discriminator, key: `${base}_${ordinal}` };
     });
 
     // Limit to last 10 events; ordinals were assigned pre-slice so surviving
@@ -194,7 +207,6 @@
       {#each timelineEvents as event (event.key)}
         {@const colors = getNodeColor(event)}
         {@const hollow = isHollow(event)}
-        {@const discriminator = eventDiscriminator(event)}
         <div class="flex flex-col items-center w-14 flex-shrink-0">
           <!-- Node -->
           <button
@@ -206,9 +218,15 @@
               hollow ? 'bg-[var(--color-base-100)]' : colors.bg
             )}
             onclick={e => handleNodeClick(event, e.currentTarget)}
-            aria-label={`${t('settings.audio.streams.timeline.eventAt', {
-              time: formatTime(event.timestamp),
-            })} — ${event.type === 'error' ? t('settings.audio.streams.timeline.error') : ''} ${discriminator}`.trim()}
+            aria-label={[
+              t('settings.audio.streams.timeline.eventAt', {
+                time: formatTime(event.timestamp),
+              }),
+              event.type === 'error' ? t('settings.audio.streams.timeline.error') : '',
+              event.discriminator,
+            ]
+              .filter(Boolean)
+              .join(' — ')}
           ></button>
 
           <!-- Timestamp -->

--- a/frontend/src/lib/desktop/components/forms/StreamTimeline.test.ts
+++ b/frontend/src/lib/desktop/components/forms/StreamTimeline.test.ts
@@ -409,6 +409,32 @@ describe('StreamTimeline', () => {
       expect(buttons.length).toBe(2);
     });
 
+    it('gives identical-tuple duplicates distinct accessible names', () => {
+      // Screen-reader regression (CodeRabbit round-3): when timestamp, type,
+      // and discriminator all match, aria-label must include an ordinal
+      // tiebreaker so the duplicates are distinguishable. First occurrence
+      // keeps the plain label; subsequent ones get "(2)", "(3)", …
+      const errorHistory: ErrorContext[] = [
+        createErrorContext('connection_failed', 'Connection refused', SHARED_TIMESTAMP),
+        createErrorContext('connection_failed', 'Connection refused', SHARED_TIMESTAMP),
+        createErrorContext('connection_failed', 'Connection refused', SHARED_TIMESTAMP),
+      ];
+
+      timelineTest.render({ errorHistory });
+
+      const buttons = screen.getAllByRole('button');
+      expect(buttons.length).toBe(3);
+
+      const labels = buttons.map(btn => btn.getAttribute('aria-label'));
+      const unique = new Set(labels);
+      expect(unique.size).toBe(3);
+
+      // First duplicate has no tiebreaker; second and third have (2) / (3).
+      expect(labels[0]).not.toMatch(/\(\d+\)$/);
+      expect(labels[1]).toMatch(/\(2\)$/);
+      expect(labels[2]).toMatch(/\(3\)$/);
+    });
+
     it('toggles the popover on click for events sharing a timestamp', async () => {
       // Regression: earlier implementation used the render index in the
       // composite key and stored the clicked index, so clicking two events

--- a/frontend/src/lib/desktop/components/forms/StreamTimeline.test.ts
+++ b/frontend/src/lib/desktop/components/forms/StreamTimeline.test.ts
@@ -484,5 +484,43 @@ describe('StreamTimeline', () => {
       const survivorAfter = afterButtons[8];
       expect(survivorAfter).toBe(survivorBefore);
     });
+
+    // Regression: earlier revisions left `selectedKey` / `selectedEvent`
+    // set after the selected event dropped out of the sliding window, so
+    // the popover remained mounted against a detached node (CodeRabbit
+    // round-3). The $effect must reconcile the selection and close the
+    // popover when the selected event is no longer in the visible window.
+    it('closes the popover when the selected event drops out of the window', async () => {
+      const base = new Date('2026-04-14T10:00:00.000Z').getTime();
+      const ts = (offset: number) => new Date(base + offset).toISOString();
+
+      const initialHistory: StateTransition[] = Array.from({ length: 10 }, (_, i) =>
+        createStateTransition('idle', `state${i}`, ts(i * 1000))
+      );
+      const rendered = timelineTest.render({ stateHistory: initialHistory });
+
+      // Open the popover on the OLDEST visible event — the one that will
+      // drop off when a new event arrives.
+      const initialButtons = screen.getAllByRole('button');
+      await fireEvent.click(initialButtons[0]);
+      await waitFor(() => {
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+      });
+
+      // Push 3 new events so the original oldest falls outside slice(-10).
+      const withShift: StateTransition[] = [
+        ...initialHistory,
+        createStateTransition('idle', 'state10', ts(10 * 1000)),
+        createStateTransition('idle', 'state11', ts(11 * 1000)),
+        createStateTransition('idle', 'state12', ts(12 * 1000)),
+      ];
+      rendered.rerender({ stateHistory: withShift });
+
+      // The selected event is gone — the popover must close automatically
+      // rather than linger against a detached DOM node.
+      await waitFor(() => {
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+      });
+    });
   });
 });

--- a/frontend/src/lib/desktop/components/forms/StreamTimeline.test.ts
+++ b/frontend/src/lib/desktop/components/forms/StreamTimeline.test.ts
@@ -330,4 +330,83 @@ describe('StreamTimeline', () => {
       expect(stateLabels[2]).toHaveTextContent('state2');
     });
   });
+
+  describe('Duplicate Timestamps', () => {
+    // Regression coverage for BIRDNET-GO-1A0: Svelte 5 threw `each_key_duplicate`
+    // when multiple events shared the same millisecond timestamp and the #each
+    // key was `event.timestamp.getTime()`. The composite key must include the
+    // event type and data discriminator to stay unique.
+    const SHARED_TIMESTAMP = '2026-04-14T10:00:00.000Z';
+
+    it('renders a state transition and an error sharing the same timestamp', () => {
+      const stateHistory: StateTransition[] = [
+        createStateTransition('idle', 'running', SHARED_TIMESTAMP),
+      ];
+      const errorHistory: ErrorContext[] = [
+        createErrorContext('connection_failed', 'Connection refused', SHARED_TIMESTAMP),
+      ];
+
+      expect(() =>
+        timelineTest.render({
+          stateHistory,
+          errorHistory,
+        })
+      ).not.toThrow();
+
+      // Both events should be rendered as distinct nodes.
+      const buttons = screen.getAllByRole('button');
+      expect(buttons.length).toBe(2);
+    });
+
+    it('renders two state events with identical timestamp but different to_state', () => {
+      const stateHistory: StateTransition[] = [
+        createStateTransition('idle', 'running', SHARED_TIMESTAMP),
+        createStateTransition('running', 'restarting', SHARED_TIMESTAMP),
+      ];
+
+      expect(() =>
+        timelineTest.render({
+          stateHistory,
+        })
+      ).not.toThrow();
+
+      const buttons = screen.getAllByRole('button');
+      expect(buttons.length).toBe(2);
+    });
+
+    it('renders two error events with identical timestamp but different error_type', () => {
+      const errorHistory: ErrorContext[] = [
+        createErrorContext('connection_failed', 'Connection refused', SHARED_TIMESTAMP),
+        createErrorContext('timeout', 'Operation timed out', SHARED_TIMESTAMP),
+      ];
+
+      expect(() =>
+        timelineTest.render({
+          errorHistory,
+        })
+      ).not.toThrow();
+
+      const buttons = screen.getAllByRole('button');
+      expect(buttons.length).toBe(2);
+    });
+
+    it('renders identical events sharing timestamp, type, and discriminator', () => {
+      // Worst case: two events with timestamp, type, and discriminator all
+      // identical. The list-index tiebreaker in the composite key keeps each
+      // block entry unique.
+      const errorHistory: ErrorContext[] = [
+        createErrorContext('connection_failed', 'Connection refused', SHARED_TIMESTAMP),
+        createErrorContext('connection_failed', 'Connection refused', SHARED_TIMESTAMP),
+      ];
+
+      expect(() =>
+        timelineTest.render({
+          errorHistory,
+        })
+      ).not.toThrow();
+
+      const buttons = screen.getAllByRole('button');
+      expect(buttons.length).toBe(2);
+    });
+  });
 });

--- a/frontend/src/lib/desktop/components/forms/StreamTimeline.test.ts
+++ b/frontend/src/lib/desktop/components/forms/StreamTimeline.test.ts
@@ -392,8 +392,8 @@ describe('StreamTimeline', () => {
 
     it('renders identical events sharing timestamp, type, and discriminator', () => {
       // Worst case: two events with timestamp, type, and discriminator all
-      // identical. The list-index tiebreaker in the composite key keeps each
-      // block entry unique.
+      // identical. The per-duplicate ordinal in the composite key keeps each
+      // block entry unique without relying on the sliding-window render index.
       const errorHistory: ErrorContext[] = [
         createErrorContext('connection_failed', 'Connection refused', SHARED_TIMESTAMP),
         createErrorContext('connection_failed', 'Connection refused', SHARED_TIMESTAMP),
@@ -407,6 +407,82 @@ describe('StreamTimeline', () => {
 
       const buttons = screen.getAllByRole('button');
       expect(buttons.length).toBe(2);
+    });
+
+    it('toggles the popover on click for events sharing a timestamp', async () => {
+      // Regression: earlier implementation used the render index in the
+      // composite key and stored the clicked index, so clicking two events
+      // that collided on timestamp could fail to close the popover.
+      const stateHistory: StateTransition[] = [
+        createStateTransition('idle', 'running', SHARED_TIMESTAMP),
+      ];
+      const errorHistory: ErrorContext[] = [
+        createErrorContext('connection_failed', 'Connection refused', SHARED_TIMESTAMP),
+      ];
+
+      timelineTest.render({ stateHistory, errorHistory });
+
+      const buttons = screen.getAllByRole('button');
+      expect(buttons.length).toBe(2);
+
+      // Click the first node — popover opens.
+      await fireEvent.click(buttons[0]);
+      await waitFor(() => {
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+      });
+
+      // Click the same node again — popover closes (composite-key equality).
+      await fireEvent.click(buttons[0]);
+      await waitFor(() => {
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+      });
+
+      // Click the second node — popover opens for the other event.
+      await fireEvent.click(buttons[1]);
+      await waitFor(() => {
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Sliding-window key stability', () => {
+    // Regression: earlier implementation included the render index in the
+    // each-key. Because timelineEvents is capped at the last 10 events, any
+    // new event shifts the indices of all older survivors and forces Svelte
+    // to recreate their DOM nodes. This test confirms two events that
+    // survive a window shift keep stable keys and therefore stable elements.
+    it('keeps surviving events on stable keys as older events drop off', async () => {
+      const base = new Date('2026-04-14T10:00:00.000Z').getTime();
+      const ts = (offset: number) => new Date(base + offset).toISOString();
+
+      // Render with 10 events so the window is full.
+      const initialHistory: StateTransition[] = Array.from({ length: 10 }, (_, i) =>
+        createStateTransition('idle', `state${i}`, ts(i * 1000))
+      );
+      const rendered = timelineTest.render({ stateHistory: initialHistory });
+
+      const initialButtons = screen.getAllByRole('button');
+      expect(initialButtons.length).toBe(10);
+      const survivorBefore = initialButtons[9]; // newest at the end
+
+      // Append one more event — the oldest drops off.
+      const withShift: StateTransition[] = [
+        ...initialHistory,
+        createStateTransition('idle', 'state10', ts(10 * 1000)),
+      ];
+      rendered.rerender({ stateHistory: withShift });
+
+      await waitFor(() => {
+        const after = screen.getAllByRole('button');
+        expect(after.length).toBe(10);
+      });
+
+      const afterButtons = screen.getAllByRole('button');
+      // state10 is now the newest; the previously-newest survivor (state9)
+      // should still be represented by the same DOM node because its key
+      // did not change.
+      const survivorAfter = afterButtons[8];
+      expect(survivorAfter).toBe(survivorBefore);
     });
   });
 });

--- a/frontend/src/lib/desktop/components/forms/TimelinePopover.test.ts
+++ b/frontend/src/lib/desktop/components/forms/TimelinePopover.test.ts
@@ -34,6 +34,7 @@ describe('TimelinePopover', () => {
       timestamp: timestamp.toISOString(),
       reason,
     } as StateTransition,
+    key: `${timestamp.getTime()}_state_${toState}_0`,
   });
 
   const createErrorEvent = (
@@ -56,6 +57,7 @@ describe('TimelinePopover', () => {
       target_host: options.target_host,
       target_port: options.target_port,
     } as ErrorContext,
+    key: `${timestamp.getTime()}_error_${errorType}_0`,
   });
 
   let mockAnchorEl: HTMLElement;

--- a/frontend/src/lib/desktop/components/forms/TimelinePopover.test.ts
+++ b/frontend/src/lib/desktop/components/forms/TimelinePopover.test.ts
@@ -34,6 +34,7 @@ describe('TimelinePopover', () => {
       timestamp: timestamp.toISOString(),
       reason,
     } as StateTransition,
+    discriminator: toState,
     key: `${timestamp.getTime()}_state_${toState}_0`,
   });
 
@@ -57,6 +58,7 @@ describe('TimelinePopover', () => {
       target_host: options.target_host,
       target_port: options.target_port,
     } as ErrorContext,
+    discriminator: errorType,
     key: `${timestamp.getTime()}_error_${errorType}_0`,
   });
 

--- a/frontend/src/lib/desktop/components/forms/TimelinePopover.test.ts
+++ b/frontend/src/lib/desktop/components/forms/TimelinePopover.test.ts
@@ -35,6 +35,7 @@ describe('TimelinePopover', () => {
       reason,
     } as StateTransition,
     discriminator: toState,
+    ordinal: 0,
     key: `${timestamp.getTime()}_state_${toState}_0`,
   });
 
@@ -59,6 +60,7 @@ describe('TimelinePopover', () => {
       target_port: options.target_port,
     } as ErrorContext,
     discriminator: errorType,
+    ordinal: 0,
     key: `${timestamp.getTime()}_error_${errorType}_0`,
   });
 


### PR DESCRIPTION
## Summary

Two tiny defensive fixes for frontend crashes surfaced in Sentry telemetry. Both are verified against current `main` and affect the same feature area (`frontend/src/lib/desktop/components/forms/`).

### Fix 1: `SoundCardCard.svelte` null-guard on `source.models`

Sentry was reporting `TypeError: undefined is not an object (evaluating 't.source.models.length')` when rendering a source whose backend config omits the `models` array. The TypeScript type declares `models: string[]` (non-optional), but legacy backend payloads can omit it, and older JSON may deserialize omitted arrays as `null`.

Change: wrap the access with nullish coalescing at both call sites so `undefined`, `null`, and `[]` all fall back to the first model option (`BirdNET v2.4`).

### Fix 2: `StreamTimeline.svelte` composite `#each` key + equality

Sentry was reporting Svelte 5 `each_key_duplicate` when two events shared a millisecond timestamp. The old key was just `event.timestamp.getTime()`.

The new key is `${timestamp}_${type}_${discriminator}_${index}` — timestamp + event type + data discriminator (`to_state` / `error_type`) + list index as a final tiebreaker for the worst case where all three primary fields collide. `handleNodeClick` was also updated to compare by the same composite key rather than timestamp equality, so popovers open and close the correct node during high-frequency events.

## Tests

Added tests for all the edge cases a real deployment may hit:

- `SoundCardCard.test.ts` (new): renders with `models: undefined`, `models: null`, and `models: []`; verifies fallback to the first model option label.
- `StreamTimeline.test.ts`: events at the same millisecond across types; two state events with different `to_state`; two error events with different `error_type`; worst case — two events identical in timestamp, type, and discriminator.

All 27 tests pass. `npm run check:all` is clean.

## Related issues

- Related to #2679 (web UI audio-source editor). PR 1 only hardens the UI against malformed/legacy source configs; it does NOT fix the root-cause config corruption in #2679.

## Test plan

- [x] `npm run check:all` clean
- [x] `npm test` on the two affected files — 27/27 pass
- [x] Local `coderabbit review --plain -t uncommitted` — no findings
- [x] Gemini CLI review of plan + implementation — feedback integrated (index tiebreaker, data-based discriminator, test gap for identical events, and `handleNodeClick` equality update)
- [ ] CI checks pass
- [ ] Automated reviewers (CodeRabbit, Gemini) pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added null-safe checks for missing model lists to prevent runtime errors and preserve fallback model display.
  * Made timeline event keys and selection deterministic so duplicate timestamps are disambiguated; popover now closes if the selected event leaves the visible window and accessibility labels include event discriminators and ordinals.

* **Tests**
  * Added tests for missing/empty model data and fallback model selection.
  * Added regression tests for duplicate-timestamp events, aria-label disambiguation, and sliding-window key stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->