### PR TITLE
fix(telemetry): suppress capture-buffer warmup noise; tag Sentry events with process uptime

### DIFF
--- a/internal/audiocore/buffer/capture.go
+++ b/internal/audiocore/buffer/capture.go
@@ -1,16 +1,25 @@
 package buffer
 
 import (
+	"fmt"
 	"sync"
 	"time"
 
 	"github.com/tphakala/birdnet-go/internal/errors"
+	"github.com/tphakala/birdnet-go/internal/logger"
 )
 
 // captureBufferAlignment is the byte alignment used when sizing the backing
 // slice. Buffer sizes are rounded up to the nearest multiple of this value
 // to ensure PCM sample boundaries are always respected.
 const captureBufferAlignment = 2048
+
+// getLogger returns a module-scoped logger for capture buffer diagnostics.
+// It is fetched dynamically so it always reflects the currently configured
+// central logger (e.g. after SetGlobal during startup).
+func getLogger() logger.Logger {
+	return logger.Global().Module("audiocore").Module("buffer")
+}
 
 // ErrInsufficientData is returned by ReadSegment when the requested time range
 // extends beyond the data that has actually been written to the buffer. This
@@ -244,6 +253,22 @@ func (cb *CaptureBuffer) ReadSegment(startTime, endTime time.Time) ([]byte, erro
 	// Before the buffer is fully populated, regions beyond writtenBytes
 	// contain zero-filled memory which would produce silent audio.
 	if endByteOffset > cb.writtenBytes {
+		// Warmup window: the circular buffer has not completed its first
+		// lap, so a read beyond the written region is an expected outcome
+		// immediately after startup rather than a bug. Log at debug level
+		// with structured fields and return a plain wrapped error that
+		// still satisfies errors.Is(err, ErrInsufficientData) but is not
+		// routed to Sentry via the enhanced-error builder.
+		if !cb.wrapped {
+			getLogger().Debug("capture buffer read segment during warmup",
+				logger.String("source", cb.source),
+				logger.Int("requested_end_byte", endByteOffset),
+				logger.Int("written_bytes", cb.writtenBytes),
+				logger.Bool("wrapped", cb.wrapped),
+			)
+			return nil, fmt.Errorf("capture_buffer_read_segment during warmup: %w", ErrInsufficientData)
+		}
+
 		return nil, errors.New(ErrInsufficientData).
 			Component("audiocore").
 			Category(errors.CategoryValidation).

--- a/internal/audiocore/buffer/capture_test.go
+++ b/internal/audiocore/buffer/capture_test.go
@@ -1,6 +1,7 @@
 package buffer_test
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -8,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/tphakala/birdnet-go/internal/audiocore/buffer"
+	internalerrors "github.com/tphakala/birdnet-go/internal/errors"
 )
 
 // TestCaptureBuffer_WriteAndReadSegment writes PCM data and reads a time segment back.
@@ -317,10 +319,78 @@ func TestCaptureBuffer_ReadSegmentInsufficientData(t *testing.T) {
 	assert.Len(t, seg, 2*chunkSize)
 
 	// Request [0s, 5s] should fail: 5 seconds requested but only 2 written.
+	// Pre-wrap (warmup window), the error must satisfy errors.Is but MUST NOT
+	// carry the enhanced-error builder context (otherwise it would be routed
+	// to Sentry for every restart).
 	seg, err = cb.ReadSegment(bufStart, bufStart.Add(5*time.Second))
 	require.Error(t, err)
 	assert.Nil(t, seg)
-	assert.ErrorIs(t, err, buffer.ErrInsufficientData)
+	require.ErrorIs(t, err, buffer.ErrInsufficientData)
+
+	_, isEnhanced := errors.AsType[*internalerrors.EnhancedError](err)
+	assert.False(t, isEnhanced,
+		"warmup ErrInsufficientData must not be wrapped in EnhancedError (would trigger Sentry on every restart)")
+}
+
+// TestCaptureBuffer_ReadSegmentInsufficientDataAfterWrap verifies that once
+// the capture buffer has wrapped at least once, an ErrInsufficientData
+// condition still produces an EnhancedError so genuine bugs are reported to
+// telemetry.
+//
+// The condition is rare in production (writtenBytes equals bufferSize after
+// wrap) but can be provoked by asking for a time window further in the
+// future than the buffer's clock anchor. The test relies on the fact that
+// the wrapped buffer's startTime is pinned to time.Now()-bufferDuration on
+// each write; a request several seconds past the latest write therefore
+// exceeds writtenBytes once the requested endOffset in bytes crosses the
+// logical window.
+func TestCaptureBuffer_ReadSegmentInsufficientDataAfterWrap(t *testing.T) {
+	t.Parallel()
+
+	// Use a small buffer so the wrap-around completes quickly, and a sample
+	// rate that keeps offsets exact (no alignment padding).
+	const (
+		durationSeconds = 2
+		sampleRate      = 1024
+		bytesPerSample  = 2
+		chunkSize       = sampleRate * bytesPerSample // 2048 bytes = 1 second
+	)
+
+	cb, err := buffer.NewCaptureBuffer(durationSeconds, sampleRate, bytesPerSample, "wrap-insufficient-source")
+	require.NoError(t, err)
+
+	chunk := make([]byte, chunkSize)
+	// Write 3 seconds into a 2-second buffer to force wrap.
+	for range 3 {
+		require.NoError(t, cb.Write(chunk))
+	}
+
+	// After wrap, the logical window is durationSeconds. Requesting a window
+	// that lands past the buffer's rolling end triggers the
+	// endByteOffset > writtenBytes branch. We approximate this by asking
+	// for a future window relative to startTime.
+	bufStart := cb.StartTime()
+	// Ask for a window that extends past the buffer duration.
+	readStart := bufStart.Add(time.Duration(durationSeconds) * time.Second)
+	readEnd := readStart.Add(1 * time.Second)
+
+	seg, err := cb.ReadSegment(readStart, readEnd)
+	if err == nil {
+		// If the internal math aligns exactly, the read may just barely
+		// succeed. Skip the assertion in that unlikely case — the goal is
+		// to exercise the post-wrap branch, not enforce a specific timing
+		// outcome.
+		t.Skip("ReadSegment did not produce ErrInsufficientData on this run; timing-sensitive post-wrap branch")
+	}
+	require.Error(t, err)
+	assert.Nil(t, seg)
+	require.ErrorIs(t, err, buffer.ErrInsufficientData)
+
+	// Post-wrap failures MUST surface as EnhancedError so telemetry sees
+	// genuine bugs.
+	_, isEnhanced := errors.AsType[*internalerrors.EnhancedError](err)
+	assert.True(t, isEnhanced,
+		"post-wrap ErrInsufficientData must surface as EnhancedError for telemetry")
 }
 
 // TestCaptureBuffer_ReadSegmentFullBufferNoError verifies that reading from a

--- a/internal/audiocore/buffer/capture_test.go
+++ b/internal/audiocore/buffer/capture_test.go
@@ -374,15 +374,12 @@ func TestCaptureBuffer_ReadSegmentInsufficientDataAfterWrap(t *testing.T) {
 	readStart := bufStart.Add(time.Duration(durationSeconds) * time.Second)
 	readEnd := readStart.Add(1 * time.Second)
 
+	// The request ends 3 seconds past bufStart (6144 bytes at 1024 Hz × 2 B/sample),
+	// while writtenBytes is capped at 4096 after wrap — so the guard must fire.
+	// Any nil here would be a regression in the post-wrap branch, not timing
+	// variance, so assert failure directly instead of skipping.
 	seg, err := cb.ReadSegment(readStart, readEnd)
-	if err == nil {
-		// If the internal math aligns exactly, the read may just barely
-		// succeed. Skip the assertion in that unlikely case — the goal is
-		// to exercise the post-wrap branch, not enforce a specific timing
-		// outcome.
-		t.Skip("ReadSegment did not produce ErrInsufficientData on this run; timing-sensitive post-wrap branch")
-	}
-	require.Error(t, err)
+	require.Error(t, err, "expected ErrInsufficientData: readEnd=%s bufStart=%s", readEnd, bufStart)
 	assert.Nil(t, seg)
 	require.ErrorIs(t, err, buffer.ErrInsufficientData)
 

--- a/internal/telemetry/sentry.go
+++ b/internal/telemetry/sentry.go
@@ -107,11 +107,14 @@ func enrichEventWithUptime(event *sentry.Event) {
 	if event.Contexts == nil {
 		event.Contexts = make(map[string]sentry.Context)
 	}
-	// Truncate to integer seconds; fractional precision is not useful here
-	// and would needlessly inflate cardinality.
-	event.Contexts[uptimeContextKey] = sentry.Context{
-		uptimeContextField: int(uptime.Seconds()),
+	// Merge into any existing context under the same key rather than
+	// overwriting — another part of the system may already have added
+	// fields here. Truncate to integer seconds: fractional precision is
+	// not useful and would needlessly inflate cardinality.
+	if event.Contexts[uptimeContextKey] == nil {
+		event.Contexts[uptimeContextKey] = sentry.Context{}
 	}
+	event.Contexts[uptimeContextKey][uptimeContextField] = int(uptime.Seconds())
 }
 
 // sentryDSN is the Sentry DSN for the BirdNET-Go project

--- a/internal/telemetry/sentry.go
+++ b/internal/telemetry/sentry.go
@@ -25,6 +25,95 @@ const (
 	errorMessageMaxLen = 60
 )
 
+// Uptime bucket thresholds used to tag Sentry events with a coarse-grained
+// "how long has this process been running" label. The exact integer seconds
+// are attached as a context value; the bucket is exposed as a tag so Sentry
+// queries can filter "issues that happen during startup" without aggregating
+// over raw seconds.
+//
+// Boundaries are inclusive of the lower side: exactly 60s becomes "warmup",
+// exactly 600s becomes "running".
+const (
+	// uptimeStartupCutoff is the duration below which an event is tagged as
+	// happening during initial startup.
+	uptimeStartupCutoff = 60 * time.Second
+	// uptimeWarmupCutoff is the duration below which an event is tagged as
+	// happening during the post-startup warmup window.
+	uptimeWarmupCutoff = 10 * time.Minute
+
+	// uptimeBucketStartup is the tag value for events below uptimeStartupCutoff.
+	uptimeBucketStartup = "startup"
+	// uptimeBucketWarmup is the tag value for events at or above
+	// uptimeStartupCutoff but below uptimeWarmupCutoff.
+	uptimeBucketWarmup = "warmup"
+	// uptimeBucketRunning is the tag value for events at or above
+	// uptimeWarmupCutoff.
+	uptimeBucketRunning = "running"
+
+	// uptimeTagKey is the tag key attached to every Sentry event.
+	uptimeTagKey = "uptime_bucket"
+	// uptimeContextKey is the Sentry context block that carries the exact
+	// integer uptime seconds at the time the event was captured.
+	uptimeContextKey = "runtime_state"
+	// uptimeContextField is the field name inside uptimeContextKey that holds
+	// the integer uptime seconds.
+	uptimeContextField = "uptime_seconds"
+)
+
+// Process start time, captured once via sync.Once so repeated InitSentry
+// calls (e.g. from tests) do not reset the effective uptime seen by BeforeSend.
+var (
+	appStartTime     time.Time
+	appStartTimeOnce sync.Once
+)
+
+// initAppStartTime records the process start time. It is idempotent: repeated
+// calls are no-ops so test harnesses and reconfiguration flows do not rewind
+// the uptime clock observed by Sentry events.
+func initAppStartTime() {
+	appStartTimeOnce.Do(func() {
+		appStartTime = time.Now()
+	})
+}
+
+// uptimeBucket returns a coarse-grained label describing how long the process
+// has been running. Boundaries are inclusive of the lower side.
+func uptimeBucket(d time.Duration) string {
+	switch {
+	case d < uptimeStartupCutoff:
+		return uptimeBucketStartup
+	case d < uptimeWarmupCutoff:
+		return uptimeBucketWarmup
+	default:
+		return uptimeBucketRunning
+	}
+}
+
+// enrichEventWithUptime attaches the uptime bucket tag and integer uptime
+// seconds context to the given event. Safe to call with a nil event (no-op);
+// initializes Tags and Contexts maps if they are nil.
+func enrichEventWithUptime(event *sentry.Event) {
+	if event == nil {
+		return
+	}
+
+	uptime := time.Since(appStartTime)
+
+	if event.Tags == nil {
+		event.Tags = make(map[string]string)
+	}
+	event.Tags[uptimeTagKey] = uptimeBucket(uptime)
+
+	if event.Contexts == nil {
+		event.Contexts = make(map[string]sentry.Context)
+	}
+	// Truncate to integer seconds; fractional precision is not useful here
+	// and would needlessly inflate cardinality.
+	event.Contexts[uptimeContextKey] = sentry.Context{
+		uptimeContextField: int(uptime.Seconds()),
+	}
+}
+
 // sentryDSN is the Sentry DSN for the BirdNET-Go project
 // Defined at package level to avoid duplication across initialization functions
 const sentryDSN = "https://b9269b6c0f8fae154df65be5a97e0435@o4509553065525248.ingest.de.sentry.io/4509553112186960"
@@ -107,6 +196,10 @@ func collectPlatformInfo() PlatformInfo {
 // InitSentry initializes Sentry SDK with privacy-compliant settings
 // This function will only initialize Sentry if explicitly enabled by the user
 func InitSentry(settings *conf.Settings) error {
+	// Record process start time on first call so BeforeSend can annotate
+	// events with uptime. Repeat calls are no-ops.
+	initAppStartTime()
+
 	// Check if Sentry is explicitly enabled (opt-in)
 	if !settings.Sentry.Enabled {
 		GetLogger().Info("Sentry telemetry is disabled (opt-in required)")
@@ -181,13 +274,25 @@ func initializeSentrySDK(settings *conf.Settings) error {
 	return nil
 }
 
-// createBeforeSendHook creates the BeforeSend hook for privacy filtering
+// createBeforeSendHook creates the BeforeSend hook for privacy filtering and
+// uptime enrichment. Only one BeforeSend can be attached to the Sentry client,
+// so uptime annotation runs inside this hook after privacy filtering.
 func createBeforeSendHook(settings *conf.Settings) func(*sentry.Event, *sentry.EventHint) *sentry.Event {
 	return func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
+		var filtered *sentry.Event
 		if settings.Sentry.Debug {
-			return applyPrivacyFiltersWithLogging(event)
+			filtered = applyPrivacyFiltersWithLogging(event)
+		} else {
+			filtered = applyPrivacyFilters(event)
 		}
-		return applyPrivacyFilters(event)
+
+		// Annotate the event with process uptime so Sentry queries can tell
+		// "happened right after restart" apart from "happened after long
+		// runtime". Done last so privacy filtering cannot strip the newly
+		// added tag / context.
+		enrichEventWithUptime(filtered)
+
+		return filtered
 	}
 }
 

--- a/internal/telemetry/sentry.go
+++ b/internal/telemetry/sentry.go
@@ -62,10 +62,18 @@ const (
 
 // Process start time, captured once via sync.Once so repeated InitSentry
 // calls (e.g. from tests) do not reset the effective uptime seen by BeforeSend.
+// Initialized from the package `init()` below so the baseline reflects
+// actual process start, not the moment telemetry is configured — any delay
+// between binary start and InitSentry would otherwise under-report uptime
+// and misbucket early failures as `startup` (CodeRabbit review on #2762).
 var (
 	appStartTime     time.Time
 	appStartTimeOnce sync.Once
 )
+
+func init() {
+	initAppStartTime()
+}
 
 // initAppStartTime records the process start time. It is idempotent: repeated
 // calls are no-ops so test harnesses and reconfiguration flows do not rewind
@@ -199,10 +207,6 @@ func collectPlatformInfo() PlatformInfo {
 // InitSentry initializes Sentry SDK with privacy-compliant settings
 // This function will only initialize Sentry if explicitly enabled by the user
 func InitSentry(settings *conf.Settings) error {
-	// Record process start time on first call so BeforeSend can annotate
-	// events with uptime. Repeat calls are no-ops.
-	initAppStartTime()
-
 	// Check if Sentry is explicitly enabled (opt-in)
 	if !settings.Sentry.Enabled {
 		GetLogger().Info("Sentry telemetry is disabled (opt-in required)")
@@ -282,6 +286,14 @@ func initializeSentrySDK(settings *conf.Settings) error {
 // so uptime annotation runs inside this hook after privacy filtering.
 func createBeforeSendHook(settings *conf.Settings) func(*sentry.Event, *sentry.EventHint) *sentry.Event {
 	return func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
+		// Guard against a nil event before the privacy filters dereference
+		// it. `enrichEventWithUptime` is already nil-safe, but the filter
+		// helpers are not. Returning nil drops the event cleanly (CodeRabbit
+		// review on #2762).
+		if event == nil {
+			return nil
+		}
+
 		var filtered *sentry.Event
 		if settings.Sentry.Debug {
 			filtered = applyPrivacyFiltersWithLogging(event)

--- a/internal/telemetry/sentry_uptime_test.go
+++ b/internal/telemetry/sentry_uptime_test.go
@@ -123,6 +123,32 @@ func TestEnrichEventWithUptime_PreservesExistingTags(t *testing.T) {
 	assert.Equal(t, "BirdNET-Go", appCtx["name"])
 }
 
+// TestEnrichEventWithUptime_MergesExistingRuntimeContext verifies that if the
+// runtime_state context already has fields (added by another part of the
+// system in the future), enrichment adds uptime_seconds without dropping
+// those fields.
+func TestEnrichEventWithUptime_MergesExistingRuntimeContext(t *testing.T) {
+	initAppStartTime()
+
+	event := &sentry.Event{
+		Contexts: map[string]sentry.Context{
+			uptimeContextKey: {
+				"some_other_field": "preserved",
+			},
+		},
+	}
+
+	enrichEventWithUptime(event)
+
+	runtimeCtx, ok := event.Contexts[uptimeContextKey]
+	require.True(t, ok)
+	assert.Equal(t, "preserved", runtimeCtx["some_other_field"],
+		"existing context fields must survive uptime enrichment")
+
+	_, hasUptime := runtimeCtx[uptimeContextField]
+	assert.True(t, hasUptime, "uptime_seconds must be added alongside existing fields")
+}
+
 // TestInitAppStartTime_Idempotent verifies that calling initAppStartTime
 // multiple times does not rewind the clock.
 func TestInitAppStartTime_Idempotent(t *testing.T) {

--- a/internal/telemetry/sentry_uptime_test.go
+++ b/internal/telemetry/sentry_uptime_test.go
@@ -1,0 +1,138 @@
+package telemetry
+
+import (
+	"testing"
+	"time"
+
+	"github.com/getsentry/sentry-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestUptimeBucket verifies the bucket boundaries documented in the package
+// constants: values below uptimeStartupCutoff are "startup", values below
+// uptimeWarmupCutoff are "warmup", and anything else is "running".
+func TestUptimeBucket(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		duration time.Duration
+		want     string
+	}{
+		{"zero", 0, uptimeBucketStartup},
+		{"one second", 1 * time.Second, uptimeBucketStartup},
+		{"just below startup cutoff", 59 * time.Second, uptimeBucketStartup},
+		{"exactly startup cutoff", 60 * time.Second, uptimeBucketWarmup},
+		{"just below warmup cutoff", 599 * time.Second, uptimeBucketWarmup},
+		{"exactly warmup cutoff", 600 * time.Second, uptimeBucketRunning},
+		{"one hour", 1 * time.Hour, uptimeBucketRunning},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, uptimeBucket(tt.duration))
+		})
+	}
+}
+
+// TestEnrichEventWithUptime_SetsTagAndContext verifies that the enrichment
+// helper writes both the coarse uptime_bucket tag and the integer
+// uptime_seconds context value on a fresh event.
+func TestEnrichEventWithUptime_SetsTagAndContext(t *testing.T) {
+	// Ensure appStartTime is initialized. The sync.Once makes this idempotent,
+	// so the test does not disturb other tests in the package.
+	initAppStartTime()
+
+	event := &sentry.Event{}
+	enrichEventWithUptime(event)
+
+	require.NotNil(t, event.Tags, "Tags must be initialized by enrichEventWithUptime")
+	bucket, ok := event.Tags[uptimeTagKey]
+	require.True(t, ok, "event must carry %q tag", uptimeTagKey)
+	assert.Contains(t,
+		[]string{uptimeBucketStartup, uptimeBucketWarmup, uptimeBucketRunning},
+		bucket,
+		"bucket must be one of the documented values")
+
+	require.NotNil(t, event.Contexts, "Contexts must be initialized by enrichEventWithUptime")
+	runtimeCtx, ok := event.Contexts[uptimeContextKey]
+	require.True(t, ok, "event must carry %q context", uptimeContextKey)
+
+	rawSeconds, ok := runtimeCtx[uptimeContextField]
+	require.True(t, ok, "context must carry %q field", uptimeContextField)
+
+	secs, ok := rawSeconds.(int)
+	require.True(t, ok, "%s must be stored as int, got %T", uptimeContextField, rawSeconds)
+	assert.GreaterOrEqual(t, secs, 0, "uptime seconds must not be negative")
+}
+
+// TestEnrichEventWithUptime_NilSafe guards against panics when the event's
+// Tags / Contexts maps start out nil — a common case for freshly constructed
+// *sentry.Event values inside a BeforeSend hook.
+func TestEnrichEventWithUptime_NilSafe(t *testing.T) {
+	initAppStartTime()
+
+	event := &sentry.Event{
+		Tags:     nil,
+		Contexts: nil,
+	}
+
+	require.NotPanics(t, func() {
+		enrichEventWithUptime(event)
+	})
+
+	assert.NotNil(t, event.Tags, "Tags must be populated even when starting nil")
+	assert.NotNil(t, event.Contexts, "Contexts must be populated even when starting nil")
+}
+
+// TestEnrichEventWithUptime_NilEvent guards against panics when a nil event
+// is passed (defensive behavior so the hook never drops an unrelated event).
+func TestEnrichEventWithUptime_NilEvent(t *testing.T) {
+	t.Parallel()
+	require.NotPanics(t, func() {
+		enrichEventWithUptime(nil)
+	})
+}
+
+// TestEnrichEventWithUptime_PreservesExistingTags ensures enrichment does not
+// clobber tags already on the event (the privacy-filter pass may leave tags
+// in place that uptime enrichment must not remove).
+func TestEnrichEventWithUptime_PreservesExistingTags(t *testing.T) {
+	initAppStartTime()
+
+	event := &sentry.Event{
+		Tags: map[string]string{
+			"component": "test",
+		},
+		Contexts: map[string]sentry.Context{
+			"application": {
+				"name": "BirdNET-Go",
+			},
+		},
+	}
+
+	enrichEventWithUptime(event)
+
+	assert.Equal(t, "test", event.Tags["component"], "existing tags must survive enrichment")
+	assert.Contains(t, event.Tags, uptimeTagKey)
+
+	appCtx, ok := event.Contexts["application"]
+	require.True(t, ok, "existing contexts must survive enrichment")
+	assert.Equal(t, "BirdNET-Go", appCtx["name"])
+}
+
+// TestInitAppStartTime_Idempotent verifies that calling initAppStartTime
+// multiple times does not rewind the clock.
+func TestInitAppStartTime_Idempotent(t *testing.T) {
+	initAppStartTime()
+	first := appStartTime
+
+	// Force enough time to pass that a naive re-initialization would yield
+	// a later value.
+	time.Sleep(2 * time.Millisecond)
+
+	initAppStartTime()
+	assert.Equal(t, first, appStartTime, "sync.Once must prevent re-initialization")
+}

--- a/internal/telemetry/sentry_uptime_test.go
+++ b/internal/telemetry/sentry_uptime_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/getsentry/sentry-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/tphakala/birdnet-go/internal/conf"
 )
 
 // TestUptimeBucket verifies the bucket boundaries documented in the package
@@ -161,4 +163,61 @@ func TestInitAppStartTime_Idempotent(t *testing.T) {
 
 	initAppStartTime()
 	assert.Equal(t, first, appStartTime, "sync.Once must prevent re-initialization")
+}
+
+// TestAppStartTimeInitializedAtPackageInit verifies that the baseline is set
+// at package load time (via `init()`), not deferred until InitSentry runs. A
+// zero-value appStartTime here would signal that the init was moved or lost.
+func TestAppStartTimeInitializedAtPackageInit(t *testing.T) {
+	t.Parallel()
+	assert.False(t, appStartTime.IsZero(),
+		"appStartTime must be populated by package init() before any test runs")
+}
+
+// TestCreateBeforeSendHook_NilEvent verifies that the hook returned by
+// createBeforeSendHook handles a nil event safely (returns nil, no panic).
+// Without this guard, applyPrivacyFilters would dereference nil before
+// enrichEventWithUptime could clean up.
+func TestCreateBeforeSendHook_NilEvent(t *testing.T) {
+	t.Parallel()
+
+	settings := &conf.Settings{
+		Sentry: conf.SentrySettings{Enabled: true, Debug: false},
+	}
+	hook := createBeforeSendHook(settings)
+
+	var got *sentry.Event
+	require.NotPanics(t, func() {
+		got = hook(nil, nil)
+	})
+	assert.Nil(t, got, "hook must drop a nil event cleanly")
+
+	// Same guarantee in debug mode — the debug privacy filter also
+	// dereferences event and would panic without the guard.
+	settings.Sentry.Debug = true
+	hook = createBeforeSendHook(settings)
+	require.NotPanics(t, func() {
+		got = hook(nil, nil)
+	})
+	assert.Nil(t, got, "hook must drop a nil event cleanly (debug branch)")
+}
+
+// TestCreateBeforeSendHook_EnrichesEvent verifies the hook still annotates
+// non-nil events with uptime after privacy filtering, i.e. the nil guard
+// did not break the happy path.
+func TestCreateBeforeSendHook_EnrichesEvent(t *testing.T) {
+	t.Parallel()
+
+	settings := &conf.Settings{
+		Sentry: conf.SentrySettings{Enabled: true, Debug: false},
+	}
+	hook := createBeforeSendHook(settings)
+
+	event := &sentry.Event{}
+	got := hook(event, nil)
+	require.NotNil(t, got, "hook must not drop a non-nil event")
+	require.NotNil(t, got.Tags)
+	assert.Contains(t, got.Tags, uptimeTagKey, "hook must attach uptime_bucket tag")
+	require.NotNil(t, got.Contexts)
+	assert.Contains(t, got.Contexts, uptimeContextKey, "hook must attach runtime_state context")
 }


### PR DESCRIPTION
## Summary

Two small, related backend changes that cut Sentry noise without losing the ability to detect genuine regressions.

### Fix 1: Capture-buffer warmup suppression (`internal/audiocore/buffer/capture.go`)

`ReadSegment` can legitimately return `ErrInsufficientData` immediately after restart, before the circular buffer has completed its first lap. Today that condition is routed through the `internal/errors` builder and reported to Sentry on every restart (86 events on the latest nightly), producing noise without revealing a real bug.

When `!cb.wrapped`, emit a `logger.Debug` line with structured fields (`source`, `requested_end_byte`, `written_bytes`, `wrapped`) and return a plain `fmt.Errorf` that still satisfies `errors.Is(err, ErrInsufficientData)` but bypasses the telemetry-reporting builder path. Once the buffer has wrapped at least once, the existing `errors.New(...).Build()` path is preserved so genuine post-warmup failures still reach Sentry.

The `cb.wrapped` check runs inside `cb.lock`, which `ReadSegment` already holds, so the decision is race-free.

### Fix 2: Process uptime annotation in Sentry events (`internal/telemetry/sentry.go`)

Global Sentry scope currently tags events with `system_id`, `os`, `arch`, `container`, `board_model`, and `datastore_schema` — nothing about how long the process has been running. That makes "this happened right after restart" hard to tell apart from "this happened after days of uptime."

Extends the existing `createBeforeSendHook` (sentry-go only honours one BeforeSend) to:
- attach a low-cardinality `uptime_bucket` tag: `startup` (<60s), `warmup` (<600s), `running` (>=600s)
- attach the exact integer uptime seconds under `event.Contexts["runtime_state"]["uptime_seconds"]`

`appStartTime` is captured once via `sync.Once` inside `InitSentry` so repeated calls from test harnesses or reconfiguration flows do not rewind the clock. Enrichment runs **after** privacy filtering so filters cannot strip the annotation. Hook is a no-op on nil events and initialises `Tags`/`Contexts` maps when they are nil.

## Tests

- `capture_test.go`: extended `TestCaptureBuffer_ReadSegmentInsufficientData` to assert the pre-wrap error is NOT an `*EnhancedError` (telemetry skips it). Added `TestCaptureBuffer_ReadSegmentInsufficientDataAfterWrap` which forces a wrap and confirms the post-wrap path still surfaces an `*EnhancedError`.
- `sentry_uptime_test.go`: table-driven `TestUptimeBucket` covering 0, 1s, 59s, 60s, 599s, 600s, 1h; hook tests that verify tag and integer context are set, that nil maps are handled without panics, that nil events are safe, that existing tags are preserved, and that `initAppStartTime` is idempotent across repeat calls.

## Test plan

- [x] `golangci-lint run -v` clean (project-wide)
- [x] `go test -race ./internal/audiocore/buffer/... ./internal/telemetry/...` — all new tests pass
- [x] Gemini CLI review of the plan was completed before implementation; feedback integrated (single BeforeSend extension, tag/context split for cardinality, `sync.Once` init, always-return-event semantics)
- [ ] Local `coderabbit` / `gemini-cli` on the diff was deferred at commit time — both hit concurrent-use rate limits. PR-side CodeRabbit and Gemini bots will cover this PR.
- [ ] CI checks pass
- [ ] Automated reviewers (CodeRabbit, Gemini) pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added process uptime tracking and enrichment for telemetry events (startup/warmup/running), and ensured telemetry hook safely drops nil events.

* **Bug Fixes**
  * Made audio capture buffer read failures return consistent error types based on buffer state, improving error classification and observability.

* **Tests**
  * Added tests for audio buffer error scenarios and comprehensive uptime-enrichment behavior, including boundary, nil-safety, and idempotence checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->