### PR TITLE
fix(api/v2): allow unauthenticated read of dashboard settings

### DIFF
--- a/internal/api/v2/README.md
+++ b/internal/api/v2/README.md
@@ -184,15 +184,18 @@ Lightweight connectivity check. Returns a minimal response with no database quer
 
 ### Settings (`settings.go`)
 
-| Method | Route                      | Handler                 | Auth | Description                    |
-| ------ | -------------------------- | ----------------------- | ---- | ------------------------------ |
-| GET    | `/settings`                | `GetAllSettings`        | ✅   | Get all configuration settings |
-| GET    | `/settings/locales`        | `GetLocales`            | ✅   | Get available locales          |
-| GET    | `/settings/imageproviders` | `GetImageProviders`     | ✅   | Get image provider options     |
-| GET    | `/settings/systemid`       | `GetSystemID`           | ✅   | Get system identifier          |
-| GET    | `/settings/:section`       | `GetSectionSettings`    | ✅   | Get specific settings section  |
-| PUT    | `/settings`                | `UpdateSettings`        | ✅   | Update all settings            |
-| PATCH  | `/settings/:section`       | `UpdateSectionSettings` | ✅   | Update settings section        |
+| Method | Route                      | Handler                 | Auth | Description                                                    |
+| ------ | -------------------------- | ----------------------- | ---- | -------------------------------------------------------------- |
+| GET    | `/settings`                | `GetAllSettings`        | ✅   | Get all configuration settings                                 |
+| GET    | `/settings/locales`        | `GetLocales`            | ✅   | Get available locales                                          |
+| GET    | `/settings/imageproviders` | `GetImageProviders`     | ✅   | Get image provider options                                     |
+| GET    | `/settings/systemid`       | `GetSystemID`           | ✅   | Get system identifier                                          |
+| GET    | `/settings/dashboard`      | `GetDashboardSettings`  | ❌   | Get dashboard display preferences (public, non-sensitive)      |
+| GET    | `/settings/:section`       | `GetSectionSettings`    | ✅   | Get specific settings section (other sections remain protected) |
+| PUT    | `/settings`                | `UpdateSettings`        | ✅   | Update all settings                                            |
+| PATCH  | `/settings/:section`       | `UpdateSectionSettings` | ✅   | Update settings section (writes to `/dashboard` still require auth) |
+
+The `GET /settings/dashboard` endpoint is intentionally public so that unauthenticated guests can render the SPA dashboard (species summary limit, layout, locale, thumbnails). The Dashboard section contains no secrets, tokens, or PII, and the layout is already exposed via `/app/config`. All mutations (PATCH) on the dashboard section remain auth-protected.
 
 **Quiet Hours** (`settings_audio.go`): The `realtime` settings section includes quiet hours configuration for both individual RTSP streams (`realtime.rtsp.streams[].quietHours`) and the sound card (`realtime.audio.quietHours`). Each `QuietHoursConfig` supports:
 

--- a/internal/api/v2/settings.go
+++ b/internal/api/v2/settings.go
@@ -45,7 +45,18 @@ type UpdateRequest struct {
 func (c *Controller) initSettingsRoutes() {
 	c.logInfoIfEnabled("Initializing settings routes")
 
-	// Create settings API group
+	// Public read-only endpoint: the Dashboard section contains only
+	// layout/display preferences (no secrets, tokens, or PII) and must be
+	// readable by unauthenticated guests so the SPA can render the dashboard
+	// (species summary limit, layout, locale, thumbnails settings, etc.)
+	// before login. The Layout is already exposed publicly via
+	// /api/v2/app/config (see PR #2402). Mutations (PATCH) on this section
+	// remain auth-protected — see the settingsGroup PATCH handler below.
+	// Registered on the parent group so that Echo's router matches this
+	// static path before the auth-protected `/:section` parameter route.
+	c.Group.GET("/settings/dashboard", c.GetDashboardSettings)
+
+	// Create auth-protected settings API group for everything else.
 	settingsGroup := c.Group.Group("/settings", c.authMiddleware)
 
 	// Routes for settings
@@ -58,10 +69,13 @@ func (c *Controller) initSettingsRoutes() {
 	// GET /api/v2/settings/systemid - Retrieves the system ID for support tracking (must be before /:section)
 	settingsGroup.GET("/systemid", c.GetSystemID)
 	// GET /api/v2/settings/:section - Retrieves settings for a specific section (e.g., birdnet, webserver)
+	// NOTE: /settings/dashboard is intentionally registered publicly above and
+	// will match before this parameterized route.
 	settingsGroup.GET("/:section", c.GetSectionSettings)
 	// PUT /api/v2/settings - Updates multiple settings sections with complete replacement
 	settingsGroup.PUT("", c.UpdateSettings)
 	// PATCH /api/v2/settings/:section - Updates a specific settings section with partial replacement
+	// (includes /settings/dashboard — writes remain auth-protected).
 	settingsGroup.PATCH("/:section", c.UpdateSectionSettings)
 
 	c.logInfoIfEnabled("Settings routes initialized successfully")
@@ -99,6 +113,53 @@ func (c *Controller) GetAllSettings(ctx echo.Context) error {
 	// Return a sanitized copy with secrets redacted
 	sanitized := sanitizeSettingsForAPI(settings)
 	return ctx.JSON(http.StatusOK, sanitized)
+}
+
+// dashboardSectionName is the settings section key used for the publicly
+// readable dashboard endpoint.
+const dashboardSectionName = "dashboard"
+
+// GetDashboardSettings handles the publicly accessible
+// GET /api/v2/settings/dashboard endpoint. It returns the sanitized Dashboard
+// section so that unauthenticated guests can render the SPA dashboard
+// (species summary limit, layout, locale, thumbnails, etc.) without first
+// completing login. The Dashboard section contains no secrets, tokens, or
+// PII — the full settings payload (which does) remains behind auth. Writes
+// to this section are handled by UpdateSectionSettings and remain
+// auth-protected.
+func (c *Controller) GetDashboardSettings(ctx echo.Context) error {
+	c.logAPIRequest(ctx, logger.LogLevelInfo, "Getting public dashboard settings")
+
+	// Acquire read lock to ensure settings aren't being modified during read.
+	c.settingsMutex.RLock()
+	defer c.settingsMutex.RUnlock()
+
+	settings := c.Settings
+	if settings == nil {
+		// Fallback to global settings if controller settings not set.
+		settings = conf.Setting()
+		if settings == nil {
+			c.logAPIRequest(ctx, logger.LogLevelError,
+				"Settings not initialized when trying to get dashboard settings")
+			return c.HandleError(ctx, fmt.Errorf("settings not initialized"),
+				"Failed to get settings", http.StatusInternalServerError)
+		}
+	}
+
+	// Sanitize first, then extract the dashboard section from the sanitized
+	// copy. The Dashboard struct has no secret-bearing fields today, but
+	// routing through sanitizeSettingsForAPI keeps this endpoint safe against
+	// future additions.
+	sanitized := sanitizeSettingsForAPI(settings)
+	sectionValue, err := getSettingsSection(sanitized, dashboardSectionName)
+	if err != nil {
+		c.logAPIRequest(ctx, logger.LogLevelError,
+			"Failed to get dashboard settings section", logger.Error(err))
+		return c.HandleError(ctx, err, "Failed to get settings section",
+			http.StatusInternalServerError)
+	}
+
+	return ctx.JSON(http.StatusOK, sectionValue)
 }
 
 // GetSectionSettings handles GET /api/v2/settings/:section

--- a/internal/api/v2/settings_public_dashboard_test.go
+++ b/internal/api/v2/settings_public_dashboard_test.go
@@ -166,7 +166,14 @@ func TestGetDashboardSettings_DoesNotLeakSecrets(t *testing.T) {
 	e.ServeHTTP(rec, req)
 	require.Equal(t, http.StatusOK, rec.Code)
 
-	bodyLower := strings.ToLower(rec.Body.String())
+	body := rec.Body.String()
+	// The redaction marker must not appear in the dashboard response. Its
+	// presence would indicate a secret-bearing field slipped into the Dashboard
+	// struct and was redacted by sanitizeSettingsForAPI but still serialized.
+	assert.NotContains(t, body, redactedValue,
+		"dashboard response must not contain the redaction marker %q", redactedValue)
+
+	bodyLower := strings.ToLower(body)
 	// None of these substrings should appear in the dashboard payload.
 	forbidden := []string{"password", "secret", "token", "apikey", "api_key", "client_secret"}
 	for _, s := range forbidden {

--- a/internal/api/v2/settings_public_dashboard_test.go
+++ b/internal/api/v2/settings_public_dashboard_test.go
@@ -1,0 +1,215 @@
+// settings_public_dashboard_test.go: Tests for the publicly accessible
+// GET /api/v2/settings/dashboard endpoint.
+//
+// Context: the Dashboard section is rendered by the SPA even for
+// unauthenticated guests (see Settings > Layout which is already public
+// via /api/v2/app/config). Protecting it behind auth caused the Dashboard
+// Daily Activity panel and guest species limit to break (#2758, #2734, #2744).
+// The dashboard section contains no secrets/tokens/PII, so it is safe to
+// expose for read-only access. Mutations (PUT/PATCH) remain auth-protected.
+
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/sessions"
+	"github.com/labstack/echo/v4"
+	"github.com/markbates/goth/gothic"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/api/auth"
+	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/datastore/mocks"
+	"github.com/tphakala/birdnet-go/internal/imageprovider"
+	"github.com/tphakala/birdnet-go/internal/observability"
+	"github.com/tphakala/birdnet-go/internal/security"
+	"github.com/tphakala/birdnet-go/internal/suncalc"
+)
+
+// newSettingsAuthTestEnv creates a controller with fully registered routes,
+// BasicAuth enabled, and a remote-IP rewrite middleware that forces requests
+// to look like they come from a non-LAN client (so the auth middleware does
+// NOT bypass auth for the test's loopback address).
+func newSettingsAuthTestEnv(t *testing.T) *echo.Echo {
+	t.Helper()
+
+	securityConfig := conf.Security{
+		SessionSecret: "test-session-secret-32-chars-long",
+		BasicAuth: conf.BasicAuth{
+			Enabled:        true,
+			Password:       "testpassword",
+			ClientID:       "test-client",
+			AuthCodeExp:    5 * time.Minute,
+			AccessTokenExp: 24 * time.Hour,
+		},
+	}
+
+	e := echo.New()
+
+	// Force the client IP to an off-subnet address so IsAuthRequired()
+	// returns true regardless of the SubnetBypass configuration.
+	e.Pre(func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			c.Request().RemoteAddr = "203.0.113.42:54321" // TEST-NET-3 per RFC 5737
+			return next(c)
+		}
+	})
+
+	mockDS := mocks.NewMockInterface(t)
+
+	settings := &conf.Settings{
+		Version: "1.0.0-test",
+		WebServer: conf.WebServerSettings{
+			Debug: true,
+		},
+		Realtime: conf.RealtimeSettings{
+			Audio: conf.AudioSettings{
+				Export: conf.ExportSettings{
+					Path: t.TempDir(),
+				},
+			},
+			Dashboard: conf.Dashboard{
+				SummaryLimit: 42,
+				Thumbnails: conf.Thumbnails{
+					ImageProvider: "avicommons",
+					Summary:       true,
+					Recent:        true,
+				},
+				Locale: "en",
+			},
+		},
+		Security: securityConfig,
+		BirdNET: conf.BirdNETConfig{
+			Latitude:  60.1699,
+			Longitude: 24.9384,
+		},
+	}
+
+	mockImageProvider := &MockImageProvider{}
+	mockImageProvider.On("Fetch", mock.Anything).
+		Return(imageprovider.BirdImage{}, nil).Maybe()
+
+	birdImageCache := &imageprovider.BirdImageCache{}
+	birdImageCache.SetImageProvider(mockImageProvider)
+
+	sunCalc := suncalc.NewSunCalc(testHelsinkiLatitude, testHelsinkiLongitude)
+	controlChan := make(chan string, testControlChannelBuf)
+	mockMetrics, _ := observability.NewMetrics()
+
+	oauth2Server := security.NewOAuth2ServerForTesting(settings)
+	authService := auth.NewSecurityAdapter(oauth2Server)
+	authMw := auth.NewMiddleware(authService)
+
+	gothic.Store = sessions.NewCookieStore([]byte(settings.Security.SessionSecret))
+
+	controller, err := NewWithOptions(
+		e, mockDS, settings, birdImageCache, sunCalc, controlChan, mockMetrics,
+		true, // initializeRoutes - register full /api/v2 route tree
+		WithAuthMiddleware(authMw.Authenticate),
+		WithAuthService(authService),
+	)
+	require.NoError(t, err, "Failed to create test API controller with auth")
+
+	t.Cleanup(func() {
+		controller.Shutdown()
+		close(controlChan)
+	})
+
+	return e
+}
+
+// TestGetDashboardSettings_PublicWithAuthEnabled verifies that GET
+// /api/v2/settings/dashboard returns 200 without authentication when
+// BasicAuth is enabled. This is the core fix for #2758, #2734, #2744.
+func TestGetDashboardSettings_PublicWithAuthEnabled(t *testing.T) {
+	e := newSettingsAuthTestEnv(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v2/settings/dashboard", http.NoBody)
+	// No Authorization header, no session cookie -> guest request.
+	rec := httptest.NewRecorder()
+
+	e.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code,
+		"guest must be able to read dashboard settings, got: %s", rec.Body.String())
+
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &payload))
+	assert.EqualValues(t, 42, payload["summaryLimit"],
+		"response must contain dashboard settings from config")
+	assert.NotNil(t, payload["thumbnails"], "response must include thumbnails struct")
+}
+
+// TestGetDashboardSettings_DoesNotLeakSecrets verifies that the guest-accessible
+// dashboard payload contains only non-sensitive Dashboard fields. This guards
+// against future struct additions that might leak tokens/credentials.
+func TestGetDashboardSettings_DoesNotLeakSecrets(t *testing.T) {
+	e := newSettingsAuthTestEnv(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v2/settings/dashboard", http.NoBody)
+	rec := httptest.NewRecorder()
+
+	e.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	bodyLower := strings.ToLower(rec.Body.String())
+	// None of these substrings should appear in the dashboard payload.
+	forbidden := []string{"password", "secret", "token", "apikey", "api_key", "client_secret"}
+	for _, s := range forbidden {
+		assert.NotContains(t, bodyLower, s,
+			"dashboard response must not leak field name %q", s)
+	}
+}
+
+// TestPatchDashboardSettings_RequiresAuth verifies that mutating the dashboard
+// section still requires authentication even though reads are public.
+func TestPatchDashboardSettings_RequiresAuth(t *testing.T) {
+	e := newSettingsAuthTestEnv(t)
+
+	body := bytes.NewBufferString(`{"summaryLimit": 99}`)
+	req := httptest.NewRequest(http.MethodPatch, "/api/v2/settings/dashboard", body)
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+
+	e.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code,
+		"PATCH /settings/dashboard must remain auth-protected")
+}
+
+// TestGetBirdnetSettings_StillRequiresAuth is a regression guard ensuring that
+// exposing /settings/dashboard publicly did not accidentally expose other
+// settings sections. /settings/birdnet remains auth-protected.
+func TestGetBirdnetSettings_StillRequiresAuth(t *testing.T) {
+	e := newSettingsAuthTestEnv(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v2/settings/birdnet", http.NoBody)
+	rec := httptest.NewRecorder()
+
+	e.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code,
+		"GET /settings/birdnet must still require auth")
+}
+
+// TestGetAllSettings_StillRequiresAuth guards that the full /settings endpoint
+// (which returns potentially-sensitive data) remains auth-protected.
+func TestGetAllSettings_StillRequiresAuth(t *testing.T) {
+	e := newSettingsAuthTestEnv(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v2/settings", http.NoBody)
+	rec := httptest.NewRecorder()
+
+	e.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code,
+		"GET /settings must still require auth")
+}

--- a/internal/api/v2/settings_public_dashboard_test.go
+++ b/internal/api/v2/settings_public_dashboard_test.go
@@ -102,13 +102,19 @@ func newSettingsAuthTestEnv(t *testing.T) *echo.Echo {
 
 	sunCalc := suncalc.NewSunCalc(testHelsinkiLatitude, testHelsinkiLongitude)
 	controlChan := make(chan string, testControlChannelBuf)
-	mockMetrics, _ := observability.NewMetrics()
+	mockMetrics, err := observability.NewMetrics()
+	require.NoError(t, err, "Failed to create test metrics")
 
 	oauth2Server := security.NewOAuth2ServerForTesting(settings)
 	authService := auth.NewSecurityAdapter(oauth2Server)
 	authMw := auth.NewMiddleware(authService)
 
+	// Save and restore gothic.Store to avoid leaking state between tests.
+	prevGothicStore := gothic.Store
 	gothic.Store = sessions.NewCookieStore([]byte(settings.Security.SessionSecret))
+	t.Cleanup(func() {
+		gothic.Store = prevGothicStore
+	})
 
 	controller, err := NewWithOptions(
 		e, mockDS, settings, birdImageCache, sunCalc, controlChan, mockMetrics,


### PR DESCRIPTION
## Summary

When basic password authentication is enabled, unauthenticated guests were receiving **HTTP 401** on `GET /api/v2/settings/dashboard`. This caused the Dashboard Daily Activity panel to spin indefinitely and the configured species summary limit to silently fall back to a hardcoded 30 for any guest visitor.

The Dashboard section of the settings struct contains only display/layout preferences (species summary limit, UI locale, layout, thumbnails, spectrogram mode, color scheme, temperature unit, etc.) — no secrets, tokens, or PII. The dashboard **layout** is already exposed publicly via `/api/v2/app/config` (see PR #2402); the remaining dashboard fields that guests also need to render the page were still stuck behind auth.

### Change

- Register `GET /api/v2/settings/dashboard` as a **public** route on the parent group so Echo's router matches it before the auth-protected `/:section` parameter route.
- Keep `PATCH /api/v2/settings/dashboard` (writes) behind auth — the protected `/:section` PATCH handler still matches.
- Keep every other settings section (`/birdnet`, `/security`, `/webserver`, …) auth-protected.
- The new `GetDashboardSettings` handler runs the response through the existing `sanitizeSettingsForAPI` helper as a defensive guard against future secret-bearing fields being added to the Dashboard struct.

## Related Issues

Fixes #2758
Fixes #2734
Fixes #2744

## Test Plan

- [x] Five new tests in \`internal/api/v2/settings_public_dashboard_test.go\`:
  - GET \`/settings/dashboard\` succeeds without auth when auth is enabled
  - GET \`/settings/dashboard\` response contains no redacted/secret markers
  - PATCH \`/settings/dashboard\` still returns 401 when unauthenticated
  - GET \`/settings/birdnet\` still returns 401 when unauthenticated (regression guard)
  - GET \`/settings\` (full) still returns 401 when unauthenticated
- [x] \`go test -race ./internal/api/v2/...\` — all tests pass (95.7s)
- [x] \`golangci-lint run\` — 0 issues
- [x] Local CodeRabbit review — no blockers
- [x] Manual: verify the Daily Activity panel loads for an unauthenticated guest when basic auth is enabled, and that the configured summaryLimit (>30) is respected.

## Notes

- No frontend changes required — \`DashboardPage.svelte\` already calls \`/api/v2/settings/dashboard\` directly.
- The PATCH path for \`/settings/dashboard\` continues to be served by the auth-protected \`settingsGroup.PATCH("/:section")\` handler, so writes remain protected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public, read-only dashboard settings endpoint that can be fetched without authentication.

* **Documentation**
  * Updated API docs to clarify which settings routes are public vs. auth-protected and reiterated that dashboard write operations remain protected.

* **Tests**
  * Added tests ensuring public read access to dashboard settings, preventing secret data leakage in responses, and verifying that dashboard mutations and other settings endpoints still require authentication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->