### PR TITLE
fix(frontend/i18n): preserve sidebar locale choice on unrelated saves

### DIFF
--- a/frontend/src/lib/stores/settings.test.ts
+++ b/frontend/src/lib/stores/settings.test.ts
@@ -451,3 +451,111 @@ describe('Settings Store - Model/Label Path Null Conversion', () => {
     );
   });
 });
+
+describe('Settings Store - UI Locale Preservation (#2756/#2760)', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    // Default mock behaviour: runtime locale = "en", all locales valid.
+    const { getLocale, setLocale, isValidLocale } = await import('$lib/i18n/index.js');
+    vi.mocked(getLocale).mockReturnValue('en');
+    vi.mocked(isValidLocale).mockReturnValue(true);
+    vi.mocked(setLocale).mockReset();
+  });
+
+  /**
+   * Helper: seed the store so formData and originalData share the same
+   * backend-loaded locale. Tests then mutate formData.realtime.dashboard.locale
+   * to simulate either (a) no locale change in this save session or (b) a
+   * genuine locale change via the Settings > UI Language page.
+   */
+  const seedStore = (backendLocale: string) => {
+    const snapshot: SettingsFormData = {
+      main: { name: 'TestNode' },
+      birdnet: {
+        modelPath: '/path/to/model.tflite',
+        labelPath: '/path/to/labels.txt',
+        sensitivity: 1.0,
+        threshold: 0.8,
+        overlap: 0.0,
+        locale: 'en',
+        threads: 4,
+        latitude: 0,
+        longitude: 0,
+        locationConfigured: true,
+        rangeFilter: { threshold: 0.03, speciesCount: null, species: [] },
+      },
+      realtime: {
+        dashboard: {
+          thumbnails: {
+            summary: false,
+            recent: false,
+            imageProvider: 'auto',
+            fallbackPolicy: 'all',
+          },
+          summaryLimit: 100,
+          locale: backendLocale,
+        },
+      },
+    } as unknown as SettingsFormData;
+
+    settingsStore.set({
+      formData: JSON.parse(JSON.stringify(snapshot)) as SettingsFormData,
+      originalData: JSON.parse(JSON.stringify(snapshot)) as SettingsFormData,
+      isLoading: false,
+      isSaving: false,
+      activeSection: 'main',
+      error: null,
+      restartRequired: false,
+    });
+  };
+
+  it('does NOT call setLocale when formData locale matches originalData, even if runtime locale differs (sidebar-set)', async () => {
+    // Backend loaded "en". Sidebar changed runtime locale to "hu" (localStorage
+    // only, not synced to backend). formData and originalData both still "en".
+    seedStore('en');
+    const { getLocale, setLocale } = await import('$lib/i18n/index.js');
+    vi.mocked(getLocale).mockReturnValue('hu');
+
+    await settingsActions.saveSettings();
+
+    // Critical: must NOT overwrite the sidebar-set runtime locale.
+    expect(setLocale).not.toHaveBeenCalled();
+  });
+
+  it('calls setLocale(newLocale) when user actually changed locale via the Settings UI', async () => {
+    seedStore('en');
+    // User selects German on the UI Language page.
+    settingsActions.updateSection('realtime', {
+      dashboard: {
+        thumbnails: { summary: false, recent: false, imageProvider: 'auto', fallbackPolicy: 'all' },
+        summaryLimit: 100,
+        locale: 'de',
+      },
+    });
+
+    const { setLocale } = await import('$lib/i18n/index.js');
+
+    await settingsActions.saveSettings();
+
+    expect(setLocale).toHaveBeenCalledTimes(1);
+    expect(setLocale).toHaveBeenCalledWith('de');
+  });
+
+  it('does NOT call setLocale when formData locale is invalid', async () => {
+    seedStore('en');
+    settingsActions.updateSection('realtime', {
+      dashboard: {
+        thumbnails: { summary: false, recent: false, imageProvider: 'auto', fallbackPolicy: 'all' },
+        summaryLimit: 100,
+        locale: 'xx-invalid',
+      },
+    });
+
+    const { isValidLocale, setLocale } = await import('$lib/i18n/index.js');
+    vi.mocked(isValidLocale).mockReturnValue(false);
+
+    await settingsActions.saveSettings();
+
+    expect(setLocale).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/lib/stores/settings.ts
+++ b/frontend/src/lib/stores/settings.ts
@@ -1265,11 +1265,13 @@ export const settingsActions = {
       }
 
       // Apply UI locale only when the user actually changed it in this save
-      // session. Comparing formData to currentState.originalData (the snapshot
-      // loaded from the backend) avoids clobbering a locale chosen via the
-      // sidebar LanguageSelector (which updates localStorage but not the
-      // backend) with whatever stale value the backend still holds.
-      const newLocale = currentState.formData.realtime?.dashboard?.locale;
+      // session. Read newLocale from coercedFormData (the value we actually
+      // persisted) and compare to originalData (the snapshot loaded from
+      // the backend). This avoids clobbering a locale chosen via the sidebar
+      // LanguageSelector — which updates localStorage but not the backend —
+      // with whatever stale value the backend still holds, and matches the
+      // coercedFormData-based comparison used by the TLS check below.
+      const newLocale = coercedFormData.realtime?.dashboard?.locale;
       const origLocale = currentState.originalData.realtime?.dashboard?.locale;
       if (newLocale && newLocale !== origLocale) {
         // Dynamically import i18n functions to avoid circular dependencies

--- a/frontend/src/lib/stores/settings.ts
+++ b/frontend/src/lib/stores/settings.ts
@@ -1264,13 +1264,17 @@ export const settingsActions = {
         logger.error('Failed to refresh restart status after settings save:', e);
       }
 
-      // Check if UI locale changed and apply it
+      // Apply UI locale only when the user actually changed it in this save
+      // session. Comparing formData to currentState.originalData (the snapshot
+      // loaded from the backend) avoids clobbering a locale chosen via the
+      // sidebar LanguageSelector (which updates localStorage but not the
+      // backend) with whatever stale value the backend still holds.
       const newLocale = currentState.formData.realtime?.dashboard?.locale;
-      if (newLocale) {
+      const origLocale = currentState.originalData.realtime?.dashboard?.locale;
+      if (newLocale && newLocale !== origLocale) {
         // Dynamically import i18n functions to avoid circular dependencies
-        const { getLocale, setLocale, isValidLocale } = await import('$lib/i18n/index.js');
-        const currentLocale = getLocale();
-        if (newLocale !== currentLocale && isValidLocale(newLocale)) {
+        const { isValidLocale, setLocale } = await import('$lib/i18n/index.js');
+        if (isValidLocale(newLocale)) {
           setLocale(newLocale);
         }
       }


### PR DESCRIPTION
## Summary

Fixes a bug where the UI locale silently reverts to the stale backend-saved value whenever the user saves any unrelated setting, after having changed the language via the sidebar \`LanguageSelector\`.

### Root cause

In \`saveSettings\` (\`frontend/src/lib/stores/settings.ts\`), the logic compared the locale we were about to save (from \`formData\`) with the runtime in-memory locale (\`getLocale()\`). When the sidebar language dropdown changes the locale, it updates the runtime store and \`localStorage\` but does **not** save to the backend. If the user then opens the Settings page (which reloads \`formData\` from the backend) and saves any unrelated setting, \`formData.realtime.dashboard.locale\` still carries the old backend value. The runtime-vs-formData mismatch then triggers \`setLocale(oldBackendValue)\`, clobbering \`localStorage\` and reverting the user's sidebar choice on the next refresh.

### Fix

Compare \`formData.realtime.dashboard.locale\` to \`originalData.realtime.dashboard.locale\` (the snapshot loaded from the backend) instead of to the runtime locale. \`setLocale\` is now only invoked when the user **actually changed** the UI Language field in this save session.

This preserves the documented behavior for users who do change the language in the Settings page dropdown: \`formData\` diverges from \`originalData\`, \`setLocale\` fires, and the locale is applied & persisted.

The sidebar's separate localStorage-vs-backend drift is intentional (lightweight locale preview without a full settings save) and is out of scope for this fix.

## Related Issues

Fixes #2756
Fixes #2760

## Test Plan

- [x] 3 new tests in \`frontend/src/lib/stores/settings.test.ts\` under \`Settings Store - UI Locale Preservation (#2756/#2760)\`:
  - formData.locale unchanged vs originalData → \`setLocale\` NOT called, even when runtime locale differs (sidebar scenario)
  - formData.locale changed vs originalData → \`setLocale(newLocale)\` called
  - Invalid locale in formData → \`setLocale\` NOT called
- [x] Red-green verified: the original (buggy) code fails test #1, the fix makes all three pass
- [x] \`npm test\` — 1855/1855 pass
- [x] \`npm run check:all\` — prettier, eslint, stylelint, svelte-check, ast-grep all clean
- [x] Local CodeRabbit review — no findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved locale handling when saving settings: the app now only applies a new language when the user actually changed it and the locale is valid, preventing unnecessary or incorrect locale resets.

* **Tests**
  * Added tests to verify locale preservation, user-initiated locale changes, and handling of invalid locale values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->