### PR TITLE
fix(wizard): persist UI locale choice to backend on setup

### DIFF
--- a/frontend/src/lib/desktop/features/wizard/steps/LocationLanguageStep.svelte
+++ b/frontend/src/lib/desktop/features/wizard/steps/LocationLanguageStep.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
   import { onMount, untrack } from 'svelte';
-  import { t } from '$lib/i18n';
+  import { t, getLocale } from '$lib/i18n';
   import { api } from '$lib/utils/api';
   import LanguageSelector from '$lib/desktop/components/ui/LanguageSelector.svelte';
   import SelectDropdown from '$lib/desktop/components/forms/SelectDropdown.svelte';
   import NumberField from '$lib/desktop/components/forms/NumberField.svelte';
   import LocationPickerMap from '../components/LocationPickerMap.svelte';
-  import { settingsActions, settingsStore } from '$lib/stores/settings';
+  import { settingsActions, settingsStore, type Dashboard } from '$lib/stores/settings';
   import { get } from 'svelte/store';
   import { MapPin } from '@lucide/svelte';
   import FlagIcon, { type FlagLocale } from '$lib/desktop/components/ui/FlagIcon.svelte';
@@ -28,6 +28,7 @@
   let geolocating = $state(false);
   let hasGeolocation = $state(false);
   let dirty = $state(false);
+  let initialUILocale = $state('');
 
   $effect(() => {
     untrack(() => onValidChange?.(true));
@@ -42,6 +43,8 @@
       longitude = store.formData.birdnet.longitude ?? 0;
       speciesLocale = store.formData.birdnet.locale ?? 'en';
     }
+
+    initialUILocale = getLocale();
 
     api
       .get<Record<string, string>>('/api/v2/settings/locales')
@@ -98,12 +101,27 @@
   // Save on unmount — only if user made changes
   $effect(() => {
     return () => {
-      if (!dirty) return;
-      settingsActions.updateSection('birdnet', {
-        latitude,
-        longitude,
-        locale: speciesLocale,
-      });
+      const uiLocaleChanged = getLocale() !== initialUILocale;
+      if (!dirty && !uiLocaleChanged) return;
+
+      if (dirty) {
+        settingsActions.updateSection('birdnet', {
+          latitude,
+          longitude,
+          locale: speciesLocale,
+        });
+      }
+
+      if (uiLocaleChanged) {
+        const store = get(settingsStore);
+        const currentDashboard: Partial<Dashboard> = store?.formData?.realtime?.dashboard ?? {};
+        // Shallow merge preserves existing Dashboard fields so other settings are not wiped
+        const mergedDashboard = { ...currentDashboard, locale: getLocale() } as Dashboard;
+        settingsActions.updateSection('realtime', {
+          dashboard: mergedDashboard,
+        });
+      }
+
       settingsActions.saveSettings().catch(err => {
         logger.error('Failed to save location/language settings', err);
       });

--- a/frontend/src/lib/desktop/features/wizard/steps/LocationLanguageStep.svelte
+++ b/frontend/src/lib/desktop/features/wizard/steps/LocationLanguageStep.svelte
@@ -28,7 +28,22 @@
   let geolocating = $state(false);
   let hasGeolocation = $state(false);
   let dirty = $state(false);
-  let initialUILocale = $state('');
+
+  // Baseline the UI locale against the PERSISTED backend value (not the
+  // runtime locale). This has two effects:
+  //   1) If the user picks a different UI language in the wizard, the
+  //      unmount handler detects the change and writes it to the backend.
+  //   2) If runtime/localStorage has already drifted from the backend
+  //      before the wizard opens (e.g. a previous wizard run set
+  //      localStorage but failed to persist to config.yaml), unmounting
+  //      still writes the runtime value so the drift is healed rather
+  //      than silently preserved.
+  // Initializing at the declaration also avoids a false-positive on rapid
+  // unmount-before-onMount, which would otherwise compare getLocale()
+  // against an empty string and always trigger a save.
+  let initialUILocale = $state<string>(
+    get(settingsStore).formData?.realtime?.dashboard?.locale ?? getLocale()
+  );
 
   $effect(() => {
     untrack(() => onValidChange?.(true));
@@ -43,8 +58,6 @@
       longitude = store.formData.birdnet.longitude ?? 0;
       speciesLocale = store.formData.birdnet.locale ?? 'en';
     }
-
-    initialUILocale = getLocale();
 
     api
       .get<Record<string, string>>('/api/v2/settings/locales')
@@ -114,12 +127,19 @@
 
       if (uiLocaleChanged) {
         const store = get(settingsStore);
-        const currentDashboard: Partial<Dashboard> = store?.formData?.realtime?.dashboard ?? {};
-        // Shallow merge preserves existing Dashboard fields so other settings are not wiped
-        const mergedDashboard = { ...currentDashboard, locale: getLocale() } as Dashboard;
-        settingsActions.updateSection('realtime', {
-          dashboard: mergedDashboard,
-        });
+        const currentDashboard = store?.formData?.realtime?.dashboard;
+        // Only update when we have an existing Dashboard snapshot to merge
+        // into. settingsActions.updateSection does a shallow merge at the
+        // realtime level, so writing a locale-only stub here would wipe the
+        // rest of the dashboard. In practice createEmptySettings() always
+        // populates this object; the guard is defensive against future
+        // refactors.
+        if (currentDashboard) {
+          const mergedDashboard: Dashboard = { ...currentDashboard, locale: getLocale() };
+          settingsActions.updateSection('realtime', {
+            dashboard: mergedDashboard,
+          });
+        }
       }
 
       settingsActions.saveSettings().catch(err => {

--- a/frontend/src/lib/desktop/features/wizard/steps/LocationLanguageStep.svelte
+++ b/frontend/src/lib/desktop/features/wizard/steps/LocationLanguageStep.svelte
@@ -30,7 +30,7 @@
   let dirty = $state(false);
 
   // Baseline the UI locale against the PERSISTED backend value (not the
-  // runtime locale). This has two effects:
+  // runtime locale). This has three effects:
   //   1) If the user picks a different UI language in the wizard, the
   //      unmount handler detects the change and writes it to the backend.
   //   2) If runtime/localStorage has already drifted from the backend
@@ -38,11 +38,16 @@
   //      localStorage but failed to persist to config.yaml), unmounting
   //      still writes the runtime value so the drift is healed rather
   //      than silently preserved.
-  // Initializing at the declaration also avoids a false-positive on rapid
-  // unmount-before-onMount, which would otherwise compare getLocale()
-  // against an empty string and always trigger a save.
-  let initialUILocale = $state<string>(
-    get(settingsStore).formData?.realtime?.dashboard?.locale ?? getLocale()
+  //   3) On a fresh install the backend's Dashboard.Locale field is an
+  //      empty string (Go zero value), which the API serializes as
+  //      `undefined` thanks to the `omitempty` JSON tag. Leaving the
+  //      baseline as `undefined` makes `getLocale() !== initialUILocale`
+  //      true on unmount, so the runtime/browser-detected locale gets
+  //      persisted to the backend on first save — no user interaction
+  //      required. The rapid-unmount-before-load risk is mitigated by
+  //      the `isLoading` guard in the unmount effect below.
+  let initialUILocale = $state<string | undefined>(
+    get(settingsStore).formData?.realtime?.dashboard?.locale
   );
 
   $effect(() => {
@@ -114,6 +119,12 @@
   // Save on unmount — only if user made changes
   $effect(() => {
     return () => {
+      // Skip if settings are still loading: the baseline might not yet
+      // reflect the backend's real value, so any "change" we detect could
+      // be spurious and would clobber whatever the fetch is about to
+      // deliver.
+      if (get(settingsStore).isLoading) return;
+
       const uiLocaleChanged = getLocale() !== initialUILocale;
       if (!dirty && !uiLocaleChanged) return;
 

--- a/frontend/src/lib/desktop/features/wizard/steps/LocationLanguageStep.test.ts
+++ b/frontend/src/lib/desktop/features/wizard/steps/LocationLanguageStep.test.ts
@@ -186,6 +186,34 @@ describe('LocationLanguageStep - UI locale persistence on unmount', () => {
     expect(settingsActions.saveSettings).toHaveBeenCalledTimes(1);
   });
 
+  it('heals drift-on-entry: saves backend-merged locale when runtime differs from persisted at mount, even without interaction', async () => {
+    // Simulate runtime/localStorage drift: the i18n runtime already holds "hu"
+    // (e.g. a prior wizard run set localStorage but failed to persist to
+    // config.yaml). The backend still shows "en" (the default).
+    currentLocale = 'hu';
+
+    const { unmount } = render(LocationLanguageStep, { props: {} });
+    await flushAsync();
+
+    // User does NOT interact with the wizard — no setLocale, no field edits.
+    unmount();
+    await flushAsync();
+
+    // The unmount handler must still fire the realtime update so the backend
+    // is healed to match the runtime choice.
+    const realtimeCall = (
+      settingsActions.updateSection as unknown as ReturnType<typeof vi.fn>
+    ).mock.calls.find(([section]) => section === 'realtime');
+    expect(realtimeCall).toBeDefined();
+    const [, payload] = realtimeCall as [string, { dashboard: Record<string, unknown> }];
+    expect(payload.dashboard.locale).toBe('hu');
+    // Dashboard fields from the store snapshot must be preserved (shallow merge)
+    expect(payload.dashboard.summaryLimit).toBe(100);
+    expect(payload.dashboard.thumbnails).toBeDefined();
+
+    expect(settingsActions.saveSettings).toHaveBeenCalledTimes(1);
+  });
+
   it('does NOT save when UI locale is unchanged and dirty is false', async () => {
     const { unmount } = render(LocationLanguageStep, { props: {} });
     await flushAsync();

--- a/frontend/src/lib/desktop/features/wizard/steps/LocationLanguageStep.test.ts
+++ b/frontend/src/lib/desktop/features/wizard/steps/LocationLanguageStep.test.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, fireEvent } from '@testing-library/svelte';
+import type { SettingsFormData } from '$lib/stores/settings';
+
+// Mock API to prevent network calls during mount
+vi.mock('$lib/utils/api', () => ({
+  api: {
+    get: vi.fn().mockResolvedValue({ en: 'English', hu: 'Magyar' }),
+    post: vi.fn(),
+  },
+  ApiError: class ApiError extends Error {
+    status: number;
+    data?: unknown;
+    constructor(message: string, status: number, data?: unknown) {
+      super(message);
+      this.status = status;
+      this.data = data;
+    }
+  },
+}));
+
+// Mock LocationPickerMap (relies on maplibre-gl) to keep this test focused
+vi.mock('../components/LocationPickerMap.svelte');
+
+// Mock LanguageSelector - we manipulate the UI locale directly via getLocale() mock
+vi.mock('$lib/desktop/components/ui/LanguageSelector.svelte');
+
+// Controllable getLocale mock shared across tests
+let currentLocale = 'en';
+
+vi.mock('$lib/i18n', async () => {
+  return {
+    t: vi.fn((key: string) => key),
+    getLocale: vi.fn(() => currentLocale),
+    setLocale: vi.fn((locale: string) => {
+      currentLocale = locale;
+    }),
+    isValidLocale: vi.fn(() => true),
+  };
+});
+
+// Mock the settings module with a controllable store + tracked actions
+vi.mock('$lib/stores/settings', async () => {
+  const { writable } = await vi.importActual<typeof import('svelte/store')>('svelte/store');
+
+  const initialFormData = {
+    birdnet: {
+      latitude: 40,
+      longitude: -74,
+      locale: 'en',
+    },
+    realtime: {
+      dashboard: {
+        thumbnails: {
+          summary: true,
+          recent: true,
+          imageProvider: 'wikimedia',
+          fallbackPolicy: 'all',
+        },
+        summaryLimit: 100,
+        locale: 'en',
+      },
+    },
+  } as unknown as SettingsFormData;
+
+  const settingsStore = writable({
+    isLoading: false,
+    isSaving: false,
+    error: null,
+    restartRequired: false,
+    activeSection: 'main',
+    originalData: JSON.parse(JSON.stringify(initialFormData)) as SettingsFormData,
+    formData: JSON.parse(JSON.stringify(initialFormData)) as SettingsFormData,
+  });
+
+  const settingsActions = {
+    updateSection: vi.fn((section: string, data: Record<string, unknown>) => {
+      settingsStore.update(state => {
+        const formData = state.formData as unknown as Record<string, Record<string, unknown>>;
+        // eslint-disable-next-line security/detect-object-injection -- Safe: test mock with controlled section keys
+        const current = formData[section] ?? {};
+        // eslint-disable-next-line security/detect-object-injection -- Safe: test mock with controlled section keys
+        formData[section] = { ...current, ...data };
+        return state;
+      });
+    }),
+    saveSettings: vi.fn().mockResolvedValue(undefined),
+  };
+
+  return {
+    settingsStore,
+    settingsActions,
+  };
+});
+
+import LocationLanguageStep from './LocationLanguageStep.svelte';
+import { settingsActions, settingsStore } from '$lib/stores/settings';
+import { setLocale } from '$lib/i18n';
+
+// Helper to flush pending microtasks (e.g. onMount continuations)
+async function flushAsync() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe('LocationLanguageStep - UI locale persistence on unmount', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    currentLocale = 'en';
+
+    // Reset store to pristine state before every test
+    settingsStore.set({
+      isLoading: false,
+      isSaving: false,
+      error: null,
+      restartRequired: false,
+      activeSection: 'main',
+      originalData: {
+        birdnet: {
+          latitude: 40,
+          longitude: -74,
+          locale: 'en',
+        },
+        realtime: {
+          dashboard: {
+            thumbnails: {
+              summary: true,
+              recent: true,
+              imageProvider: 'wikimedia',
+              fallbackPolicy: 'all',
+            },
+            summaryLimit: 100,
+            locale: 'en',
+          },
+        },
+      } as unknown as SettingsFormData,
+      formData: {
+        birdnet: {
+          latitude: 40,
+          longitude: -74,
+          locale: 'en',
+        },
+        realtime: {
+          dashboard: {
+            thumbnails: {
+              summary: true,
+              recent: true,
+              imageProvider: 'wikimedia',
+              fallbackPolicy: 'all',
+            },
+            summaryLimit: 100,
+            locale: 'en',
+          },
+        },
+      } as unknown as SettingsFormData,
+    });
+  });
+
+  it('persists UI locale to realtime.dashboard when only the UI locale changed (dirty=false)', async () => {
+    const { unmount } = render(LocationLanguageStep, { props: {} });
+    await flushAsync();
+
+    // Simulate LanguageSelector invoking setLocale
+    setLocale('hu');
+
+    unmount();
+    await flushAsync();
+
+    // realtime update must be dispatched even though no other field is dirty
+    const realtimeCall = (
+      settingsActions.updateSection as unknown as ReturnType<typeof vi.fn>
+    ).mock.calls.find(([section]) => section === 'realtime');
+    expect(realtimeCall).toBeDefined();
+    const [, payload] = realtimeCall as [string, { dashboard: Record<string, unknown> }];
+    expect(payload.dashboard.locale).toBe('hu');
+    // Existing dashboard fields must be preserved (shallow merge)
+    expect(payload.dashboard.summaryLimit).toBe(100);
+    expect(payload.dashboard.thumbnails).toBeDefined();
+
+    // Birdnet section should NOT have been updated because dirty is false
+    const birdnetCall = (
+      settingsActions.updateSection as unknown as ReturnType<typeof vi.fn>
+    ).mock.calls.find(([section]) => section === 'birdnet');
+    expect(birdnetCall).toBeUndefined();
+
+    expect(settingsActions.saveSettings).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT save when UI locale is unchanged and dirty is false', async () => {
+    const { unmount } = render(LocationLanguageStep, { props: {} });
+    await flushAsync();
+
+    // No changes made whatsoever
+    unmount();
+    await flushAsync();
+
+    const realtimeCall = (
+      settingsActions.updateSection as unknown as ReturnType<typeof vi.fn>
+    ).mock.calls.find(([section]) => section === 'realtime');
+    expect(realtimeCall).toBeUndefined();
+    expect(settingsActions.saveSettings).not.toHaveBeenCalled();
+  });
+
+  it('dispatches both realtime and birdnet updates with a single save when both change', async () => {
+    const { unmount, container } = render(LocationLanguageStep, { props: {} });
+    await flushAsync();
+
+    // Change the latitude via the underlying NumberField input (triggers dirty=true)
+    const numberInputs = container.querySelectorAll('input[type="number"]');
+    expect(numberInputs.length).toBeGreaterThanOrEqual(1);
+    const latitudeInput = numberInputs[0] as HTMLInputElement;
+    await fireEvent.input(latitudeInput, { target: { value: '41.5' } });
+    await fireEvent.change(latitudeInput, { target: { value: '41.5' } });
+
+    // Change the UI locale via the mocked i18n store
+    setLocale('hu');
+
+    unmount();
+    await flushAsync();
+
+    const updateCalls = (settingsActions.updateSection as unknown as ReturnType<typeof vi.fn>).mock
+      .calls;
+    const realtimeCall = updateCalls.find(([section]) => section === 'realtime');
+    const birdnetCall = updateCalls.find(([section]) => section === 'birdnet');
+
+    expect(realtimeCall).toBeDefined();
+    expect(birdnetCall).toBeDefined();
+    const [, realtimePayload] = realtimeCall as [string, { dashboard: { locale: string } }];
+    expect(realtimePayload.dashboard.locale).toBe('hu');
+    expect(settingsActions.saveSettings).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/lib/desktop/features/wizard/steps/LocationLanguageStep.test.ts
+++ b/frontend/src/lib/desktop/features/wizard/steps/LocationLanguageStep.test.ts
@@ -97,7 +97,12 @@ import LocationLanguageStep from './LocationLanguageStep.svelte';
 import { settingsActions, settingsStore } from '$lib/stores/settings';
 import { setLocale } from '$lib/i18n';
 
-// Helper to flush pending microtasks (e.g. onMount continuations)
+// Helper to flush pending microtasks (e.g. onMount continuations).
+// Double Promise.resolve() processes both the immediate microtask and
+// any follow-up microtasks queued during the first flush. Svelte's
+// $effect cleanup and onMount initializers commonly chain a second
+// microtask, so a single await can miss them. Revisit if new async
+// layers are introduced and tests start flaking.
 async function flushAsync() {
   await Promise.resolve();
   await Promise.resolve();
@@ -212,6 +217,52 @@ describe('LocationLanguageStep - UI locale persistence on unmount', () => {
     expect(payload.dashboard.thumbnails).toBeDefined();
 
     expect(settingsActions.saveSettings).toHaveBeenCalledTimes(1);
+  });
+
+  it('heals drift-on-entry when backend locale is undefined (fresh-install case): runtime locale gets persisted without interaction', async () => {
+    // Fresh install scenario: backend Dashboard.Locale is the Go zero
+    // value "" which the API's `omitempty` tag serializes as undefined.
+    // The browser is in Hungarian, so the runtime locale is "hu".
+    currentLocale = 'hu';
+    settingsStore.update(state => {
+      const realtime = state.formData.realtime as Record<string, unknown>;
+      const dashboard = realtime.dashboard as Record<string, unknown>;
+      delete dashboard.locale;
+      return state;
+    });
+
+    const { unmount } = render(LocationLanguageStep, { props: {} });
+    await flushAsync();
+
+    // User does not interact.
+    unmount();
+    await flushAsync();
+
+    // Unmount must still persist the runtime locale so the backend is
+    // initialized to match what the user is seeing.
+    const realtimeCall = (
+      settingsActions.updateSection as unknown as ReturnType<typeof vi.fn>
+    ).mock.calls.find(([section]) => section === 'realtime');
+    expect(realtimeCall).toBeDefined();
+    const [, payload] = realtimeCall as [string, { dashboard: Record<string, unknown> }];
+    expect(payload.dashboard.locale).toBe('hu');
+    expect(payload.dashboard.summaryLimit).toBe(100);
+
+    expect(settingsActions.saveSettings).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT save when settings are still loading (avoids clobbering in-flight fetch)', async () => {
+    currentLocale = 'hu';
+    settingsStore.update(state => ({ ...state, isLoading: true }));
+
+    const { unmount } = render(LocationLanguageStep, { props: {} });
+    await flushAsync();
+
+    unmount();
+    await flushAsync();
+
+    expect(settingsActions.updateSection).not.toHaveBeenCalled();
+    expect(settingsActions.saveSettings).not.toHaveBeenCalled();
   });
 
   it('does NOT save when UI locale is unchanged and dirty is false', async () => {


### PR DESCRIPTION
## Summary

Follow-up to #2764. The setup wizard's Location & Language step has a UI Language dropdown rendered via `<LanguageSelector />`. That component calls `setLocale()`, which updates the runtime i18n store and `localStorage` but **never persists the choice to `realtime.dashboard.locale` in the backend**.

### Before this fix, the wizard could lose the UI locale two ways:

1. **localStorage/backend drift.** A fresh-install user who picks Hungarian in the wizard ended up with `localStorage="hu"` / runtime locale `"hu"` but `realtime.dashboard.locale="en"` (backend default). #2764 now tolerates that drift in the Settings save flow, but the drift itself was a latent foot-gun for any code path that trusts the backend value.
2. **Complete loss of the choice.** If the user changed _only_ the UI language in the wizard (no location / species-locale / lat-long edits), `dirty` stayed `false` and the unmount save was skipped entirely. On container restart the UI locale reverted to the backend default because it was never written to `config.yaml`.

### Change

- Capture the initial UI locale in \`onMount\` (after preloading settings) into a new \`initialUILocale\` state.
- Trigger the unmount save when either \`dirty\` is set OR the runtime locale has changed since mount.
- Split the save into two \`updateSection\` calls: \`birdnet\` only when \`dirty\`, \`realtime.dashboard\` only when the UI locale changed. Followed by a single \`saveSettings()\`.
- The \`realtime.dashboard\` update uses a shallow spread over the current \`dashboard\` snapshot from the store so other dashboard fields are preserved.

No changes to the shared \`LanguageSelector\` component.

## Related

Follow-up to #2764 (which only stopped the Settings save flow from clobbering the drift — this PR prevents the drift from being introduced).

## Test Plan

- [x] 3 new unit tests in \`frontend/src/lib/desktop/features/wizard/steps/LocationLanguageStep.test.ts\`:
  - UI locale-only change → \`realtime.dashboard\` updated and \`saveSettings\` invoked (despite \`dirty=false\`)
  - No changes at all → \`updateSection\` NOT called, no save
  - UI locale AND location both changed → both updates dispatched, single \`saveSettings()\`
- [x] \`npm test\` — 1855/1855 pass (97 test files)
- [x] \`npm run check:all\` — prettier, eslint, stylelint, svelte-check, ast-grep all clean
- [x] Local CodeRabbit review — no findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Setup wizard now reliably detects and persists UI locale changes, merging the locale into existing dashboard settings without overwriting other dashboard fields; non-language sections are saved only when actually modified and saves are skipped while settings are loading.
* **Tests**
  * Added tests verifying unmount-driven persistence across scenarios (locale drift, fresh installs, loading state, concurrent field changes) and that save is invoked exactly once when appropriate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->