### PR TITLE
fix(telemetry): suppress context.Canceled noise for database ops

### DIFF
--- a/internal/errors/telemetry_integration.go
+++ b/internal/errors/telemetry_integration.go
@@ -3,7 +3,6 @@ package errors
 
 import (
 	"context"
-	stderrors "errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -154,11 +153,10 @@ func (sr *SentryReporter) IsEnabled() bool {
 }
 
 // isContextCancellation reports whether err (or any wrapped error in its
-// chain) is context.Canceled or context.DeadlineExceeded. Uses stderrors.Is
-// directly so that wrapped EnhancedError chains are unwrapped correctly.
+// chain) is context.Canceled or context.DeadlineExceeded. Uses the package's
+// Is wrapper so wrapped EnhancedError chains are unwrapped correctly.
 func isContextCancellation(err error) bool {
-	return stderrors.Is(err, context.Canceled) ||
-		stderrors.Is(err, context.DeadlineExceeded)
+	return Is(err, context.Canceled) || Is(err, context.DeadlineExceeded)
 }
 
 // shouldReportToSentry determines if an error should be sent to Sentry

--- a/internal/errors/telemetry_integration.go
+++ b/internal/errors/telemetry_integration.go
@@ -2,6 +2,8 @@
 package errors
 
 import (
+	"context"
+	stderrors "errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -151,12 +153,33 @@ func (sr *SentryReporter) IsEnabled() bool {
 	return sr.enabled
 }
 
+// isContextCancellation reports whether err (or any wrapped error in its
+// chain) is context.Canceled or context.DeadlineExceeded. Uses stderrors.Is
+// directly so that wrapped EnhancedError chains are unwrapped correctly.
+func isContextCancellation(err error) bool {
+	return stderrors.Is(err, context.Canceled) ||
+		stderrors.Is(err, context.DeadlineExceeded)
+}
+
 // shouldReportToSentry determines if an error should be sent to Sentry
 // It filters out operational/configuration errors that aren't code bugs
 func shouldReportToSentry(ee *EnhancedError) bool {
 	if ee.Err == nil {
 		return true
 	}
+
+	// Database operations frequently observe context.Canceled and
+	// context.DeadlineExceeded during graceful shutdown and request-timeout
+	// conditions (e.g. an HTTP client disconnects mid-query, or a caller's
+	// ctx.Done() fires while a long row iteration is in progress). These are
+	// not code bugs — the query layer correctly surfaces the cancellation to
+	// the caller, and the caller is expected to handle it. Suppressing here
+	// prevents hundreds of duplicate "[database] context canceled" events
+	// per day from drowning legitimate database errors.
+	if ee.Category == CategoryDatabase && isContextCancellation(ee.Err) {
+		return false
+	}
+
 	errorMsg := strings.ToLower(ee.Err.Error())
 
 	// Notification circuit-breaker open/half-open conditions are operational

--- a/internal/errors/telemetry_integration_test.go
+++ b/internal/errors/telemetry_integration_test.go
@@ -270,3 +270,74 @@ func TestShouldReportToSentry_DiskFullCooldownExpiry(t *testing.T) {
 
 	assert.True(t, shouldReportToSentry(ee), "disk-full should be reported after cooldown expires")
 }
+
+// TestShouldReportToSentry_FiltersDatabaseContextCancellation verifies that
+// context.Canceled and context.DeadlineExceeded errors from CategoryDatabase
+// operations are not forwarded to Sentry. These happen routinely during
+// graceful shutdown and request-timeout conditions (e.g. HTTP client
+// disconnects mid-query), and they are not code bugs. Prior behavior forwarded
+// every row-iterator cancellation to Sentry, creating hundreds of duplicate
+// "[database] context canceled" events per day.
+func TestShouldReportToSentry_FiltersDatabaseContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		err        error
+		wantReport bool
+	}{
+		{
+			name:       "context.Canceled wrapped in dbError is suppressed",
+			err:        fmt.Errorf("iterate rows: %w", context.Canceled),
+			wantReport: false,
+		},
+		{
+			name:       "context.DeadlineExceeded wrapped in dbError is suppressed",
+			err:        fmt.Errorf("query timed out: %w", context.DeadlineExceeded),
+			wantReport: false,
+		},
+		{
+			name:       "plain context.Canceled is suppressed",
+			err:        context.Canceled,
+			wantReport: false,
+		},
+		{
+			name:       "plain context.DeadlineExceeded is suppressed",
+			err:        context.DeadlineExceeded,
+			wantReport: false,
+		},
+		{
+			name:       "real database error is still reported",
+			err:        fmt.Errorf("no such table: notes"),
+			wantReport: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ee := New(tt.err).
+				Component("datastore").
+				Category(CategoryDatabase).
+				Context("operation", "iterate_species_summary_rows").
+				Build()
+			got := shouldReportToSentry(ee)
+			assert.Equal(t, tt.wantReport, got,
+				"shouldReportToSentry for %q = %v, want %v", tt.name, got, tt.wantReport)
+		})
+	}
+}
+
+// TestShouldReportToSentry_AllowsNonDatabaseContextCancellation verifies that
+// the database-specific context-cancellation filter does not leak into other
+// categories where a canceled context may indicate a real bug (e.g. a
+// worker's supervisor cancelling at an unexpected time).
+func TestShouldReportToSentry_AllowsNonDatabaseContextCancellation(t *testing.T) {
+	t.Parallel()
+	ee := New(fmt.Errorf("worker loop exited: %w", context.Canceled)).
+		Component("birdnet").
+		Category(CategoryWorker).
+		Build()
+	assert.True(t, shouldReportToSentry(ee),
+		"context.Canceled outside CategoryDatabase should still be forwarded to Sentry")
+}


### PR DESCRIPTION
## Summary

Suppress `context.Canceled` and `context.DeadlineExceeded` errors from `CategoryDatabase` in the Sentry filter. These happen routinely during graceful shutdown and request-timeout conditions (e.g., HTTP client disconnects mid-query, graceful shutdown fires while a long row iteration is in progress). They are not code bugs — the query layer correctly surfaces cancellation to the caller, and the caller is expected to handle it.

One live Sentry group alone (`IterateSpeciesSummaryRows`) emitted 150+ events over 3 months from this pattern, drowning out legitimate database errors.

## Details

- New `isContextCancellation(err)` helper uses `errors.Is` to unwrap `EnhancedError` chains and detect both `context.Canceled` and `context.DeadlineExceeded`.
- `shouldReportToSentry` early-returns `false` when `Category == CategoryDatabase` AND `isContextCancellation(err)`.
- Filter is narrowly scoped to `CategoryDatabase` only — `CategoryWorker`, `CategoryRTSP`, etc. continue to report cancellation as a legitimate signal (verified by `TestShouldReportToSentry_AllowsNonDatabaseContextCancellation`).

## Test Plan

- [x] `go test -race ./internal/errors/... ./internal/datastore/...` — PASS
- [x] `golangci-lint run -v ./internal/errors/...` — 0 issues
- [x] New test would fail on `git revert` (TDD verified)
- [x] CodeRabbit local review — 0 findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduce noisy alerts by skipping reporting for database-related errors that are cancellations or deadline/timeouts, preventing false positives for expected aborts.

* **Tests**
  * Added coverage verifying that cancellation/timeouts are filtered for database events while still reported for other categories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->