### PR TITLE
fix(birdweather,notification): circuit breaker for uploads, exponential backoff for suppressor reminders

### DIFF
--- a/internal/analysis/processor/actions_integrations.go
+++ b/internal/analysis/processor/actions_integrations.go
@@ -14,6 +14,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/imageprovider"
 	"github.com/tphakala/birdnet-go/internal/logger"
 	"github.com/tphakala/birdnet-go/internal/mqtt"
+	"github.com/tphakala/birdnet-go/internal/notification"
 	"github.com/tphakala/birdnet-go/internal/privacy"
 )
 
@@ -102,6 +103,27 @@ func (a *BirdWeatherAction) Execute(_ context.Context, data any) error {
 				logger.String("operation", "birdweather_upload"))
 			// Return nil - this is not an error condition worth retrying
 			return nil
+		}
+
+		// Circuit breaker open/half-open: the BirdWeather client's breaker
+		// has short-circuited this upload because the upstream service is
+		// currently flapping. This is an operational throttle state, not a
+		// code bug. Log at debug and return a retryable CategoryLimit error
+		// so the job queue backs off without generating Sentry noise.
+		if errors.Is(err, notification.ErrCircuitBreakerOpen) || errors.Is(err, notification.ErrTooManyRequests) {
+			GetLogger().Debug("BirdWeather upload short-circuited: circuit breaker open",
+				logger.String("component", "analysis.processor.actions"),
+				logger.String("detection_id", a.CorrelationID),
+				logger.String("species", a.Result.Species.CommonName),
+				logger.String("scientific_name", a.Result.Species.ScientificName),
+				logger.String("operation", "birdweather_upload_breaker_open"))
+			return errors.New(err).
+				Component("analysis.processor").
+				Category(errors.CategoryLimit).
+				Context("operation", "birdweather_upload").
+				Context("integration", "birdweather").
+				Context("retryable", true).
+				Build()
 		}
 
 		// Transient network errors (DNS, timeout, connection issues) are expected

--- a/internal/analysis/processor/actions_integrations.go
+++ b/internal/analysis/processor/actions_integrations.go
@@ -108,8 +108,10 @@ func (a *BirdWeatherAction) Execute(_ context.Context, data any) error {
 		// Circuit breaker open/half-open: the BirdWeather client's breaker
 		// has short-circuited this upload because the upstream service is
 		// currently flapping. This is an operational throttle state, not a
-		// code bug. Log at debug and return a retryable CategoryLimit error
-		// so the job queue backs off without generating Sentry noise.
+		// code bug. Return the sentinel unchanged so the job queue still
+		// retries (any non-nil error triggers retry with backoff) while
+		// shouldReportToSentry suppresses it via the notification-component
+		// filter — wrapping here would hide the sentinel from that filter.
 		if errors.Is(err, notification.ErrCircuitBreakerOpen) || errors.Is(err, notification.ErrTooManyRequests) {
 			GetLogger().Debug("BirdWeather upload short-circuited: circuit breaker open",
 				logger.String("component", "analysis.processor.actions"),
@@ -117,13 +119,7 @@ func (a *BirdWeatherAction) Execute(_ context.Context, data any) error {
 				logger.String("species", a.Result.Species.CommonName),
 				logger.String("scientific_name", a.Result.Species.ScientificName),
 				logger.String("operation", "birdweather_upload_breaker_open"))
-			return errors.New(err).
-				Component("analysis.processor").
-				Category(errors.CategoryLimit).
-				Context("operation", "birdweather_upload").
-				Context("integration", "birdweather").
-				Context("retryable", true).
-				Build()
+			return err
 		}
 
 		// Transient network errors (DNS, timeout, connection issues) are expected

--- a/internal/birdweather/birdweather_client.go
+++ b/internal/birdweather/birdweather_client.go
@@ -636,14 +636,20 @@ func (b *BwClient) UploadSoundscape(timestamp string, pcmData []byte) (soundscap
 		// stopping at the breaker boundary.
 		resp, httpErr := b.HTTPClient.Do(req.WithContext(ctx))
 		if httpErr != nil {
-			log.Error("Soundscape upload request failed",
-				logger.String("url", maskedURL),
-				logger.Error(httpErr))
+			// handleNetworkError logs at Warn with classified details
+			// (timeout/DNS/connection), and the caller (Publish) logs the
+			// final outcome — so no extra log.Error here.
 			return handleNetworkError(httpErr, maskedURL, httpClientTimeout, "soundscape upload")
 		}
 		if resp == nil {
-			log.Error("Soundscape upload received nil response", logger.String("url", maskedURL))
-			return fmt.Errorf("received nil response")
+			// Defensive: Go's http.Client should not return nil resp with nil
+			// err. If it happens, let the caller handle it — don't double-log.
+			return errors.Newf("received nil response from soundscape upload").
+				Component("birdweather").
+				Category(errors.CategoryNetwork).
+				Context("operation", "soundscape_upload").
+				Context("url", maskedURL).
+				Build()
 		}
 		defer closeResponseBody(resp)
 		log.Debug("Received soundscape upload response",
@@ -808,17 +814,18 @@ func (b *BwClient) PostDetection(soundscapeID, timestamp, commonName, scientific
 		req.Header.Set("User-Agent", "BirdNET-Go")
 		resp, httpErr := b.HTTPClient.Do(req)
 		if httpErr != nil {
-			log.Error("Detection post request failed",
-				logger.String("url", maskedDetectionURL),
-				logger.String("soundscape_id", soundscapeID),
-				logger.Error(httpErr))
+			// handleNetworkError + Publish already log; no extra log.Error.
 			return handleNetworkError(httpErr, maskedDetectionURL, httpClientTimeout, "detection post")
 		}
 		if resp == nil {
-			log.Error("Detection post received nil response",
-				logger.String("url", maskedDetectionURL),
-				logger.String("soundscape_id", soundscapeID))
-			return fmt.Errorf("received nil response")
+			// Defensive; caller handles reporting.
+			return errors.Newf("received nil response from detection post").
+				Component("birdweather").
+				Category(errors.CategoryNetwork).
+				Context("operation", "detection_post").
+				Context("soundscape_id", soundscapeID).
+				Context("url", maskedDetectionURL).
+				Build()
 		}
 		defer closeResponseBody(resp)
 		log.Debug("Received detection post response",

--- a/internal/birdweather/birdweather_client.go
+++ b/internal/birdweather/birdweather_client.go
@@ -624,6 +624,11 @@ func (b *BwClient) UploadSoundscape(timestamp string, pcmData []byte) (soundscap
 	var (
 		responseBody     []byte
 		soundscapeStatus int
+		// nonTransientErr carries business-logic errors (e.g. CategoryNotFound
+		// species validation 422s) out of the breaker closure without tripping
+		// the breaker. These are expected operational outcomes, not failures
+		// of the upstream service.
+		nonTransientErr error
 	)
 	cbErr := b.callWithCircuitBreaker(req.Context(), func(_ context.Context) error {
 		resp, httpErr := b.HTTPClient.Do(req)
@@ -644,15 +649,25 @@ func (b *BwClient) UploadSoundscape(timestamp string, pcmData []byte) (soundscap
 
 		body, handleErr := handleHTTPResponse(resp, http.StatusCreated, "soundscape upload", maskedURL)
 		if handleErr != nil {
+			if errors.IsCategory(handleErr, errors.CategoryNotFound) {
+				nonTransientErr = handleErr
+				return nil
+			}
 			return handleErr
 		}
 		responseBody = body
 		soundscapeStatus = resp.StatusCode
 		return nil
 	})
+	if nonTransientErr != nil {
+		return "", nonTransientErr
+	}
 	if cbErr != nil {
 		if isCircuitBreakerOpen(cbErr) {
-			log.Warn("Soundscape upload skipped: circuit breaker open",
+			// Debug-level only: Publish() already emits its own debug log for the
+			// breaker-open case (see handlePublishError), and a warn here would
+			// double-log a condition that is not actionable on a per-upload basis.
+			log.Debug("Soundscape upload skipped: circuit breaker open",
 				logger.String("url", maskedURL),
 				logger.String("timestamp", timestamp))
 		}
@@ -772,6 +787,10 @@ func (b *BwClient) PostDetection(soundscapeID, timestamp, commonName, scientific
 		logger.String("url", maskedDetectionURL),
 		logger.String("soundscape_id", soundscapeID),
 		logger.String("scientific_name", scientificName))
+	// nonTransientErr carries business-logic errors (e.g. CategoryNotFound
+	// species validation 422s from the detection post — the common case for
+	// non-bird species) out of the breaker closure without tripping it.
+	var nonTransientErr error
 	cbErr := b.callWithCircuitBreaker(context.Background(), func(_ context.Context) error {
 		resp, httpErr := b.HTTPClient.Post(detectionURL, "application/json", bytes.NewBuffer(postDataBytes))
 		if httpErr != nil {
@@ -795,19 +814,27 @@ func (b *BwClient) PostDetection(soundscapeID, timestamp, commonName, scientific
 
 		_, handleErr := handleHTTPResponse(resp, http.StatusCreated, "detection post", maskedDetectionURL)
 		if handleErr != nil {
-			// Add detection-specific context before the breaker observes the error.
+			// Add detection-specific context regardless of classification.
 			var enhancedErr *errors.EnhancedError
 			if errors.As(handleErr, &enhancedErr) {
 				enhancedErr.Context["soundscape_id"] = soundscapeID
 				enhancedErr.Context["scientific_name"] = scientificName
 			}
+			if errors.IsCategory(handleErr, errors.CategoryNotFound) {
+				nonTransientErr = handleErr
+				return nil
+			}
 			return handleErr
 		}
 		return nil
 	})
+	if nonTransientErr != nil {
+		return nonTransientErr
+	}
 	if cbErr != nil {
 		if isCircuitBreakerOpen(cbErr) {
-			log.Warn("Detection post skipped: circuit breaker open",
+			// Debug-level only: Publish() already logs this at debug.
+			log.Debug("Detection post skipped: circuit breaker open",
 				logger.String("url", maskedDetectionURL),
 				logger.String("soundscape_id", soundscapeID),
 				logger.String("scientific_name", scientificName))

--- a/internal/birdweather/birdweather_client.go
+++ b/internal/birdweather/birdweather_client.go
@@ -622,8 +622,7 @@ func (b *BwClient) UploadSoundscape(timestamp string, pcmData []byte) (soundscap
 		logger.String("url", maskedURL),
 		logger.String("format", audioExt))
 	var (
-		responseBody     []byte
-		soundscapeStatus int
+		responseBody []byte
 		// nonTransientErr carries business-logic errors (e.g. CategoryNotFound
 		// species validation 422s) out of the breaker closure without tripping
 		// the breaker. These are expected operational outcomes, not failures
@@ -665,7 +664,17 @@ func (b *BwClient) UploadSoundscape(timestamp string, pcmData []byte) (soundscap
 			return handleErr
 		}
 		responseBody = body
-		soundscapeStatus = resp.StatusCode
+
+		// Validate the response inside the closure so that malformed bodies
+		// (HTML with 201, invalid JSON, success:false payloads) count as
+		// failures against the circuit breaker — otherwise a degraded
+		// upstream could silently pass the closure and never trip the
+		// breaker.
+		id, parseErr := parseSoundscapeResponse(body, maskedURL, resp.StatusCode)
+		if parseErr != nil {
+			return parseErr
+		}
+		soundscapeID = id
 		return nil
 	})
 	if nonTransientErr != nil {
@@ -685,12 +694,6 @@ func (b *BwClient) UploadSoundscape(timestamp string, pcmData []byte) (soundscap
 
 	if b.Settings.Realtime.Birdweather.Debug {
 		log.Debug("Soundscape response body", logger.String("body", string(responseBody)))
-	}
-
-	// Parse and validate response
-	soundscapeID, err = parseSoundscapeResponse(responseBody, maskedURL, soundscapeStatus)
-	if err != nil {
-		return "", err
 	}
 
 	log.Info("Soundscape uploaded successfully",

--- a/internal/birdweather/birdweather_client.go
+++ b/internal/birdweather/birdweather_client.go
@@ -25,6 +25,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/logger"
+	"github.com/tphakala/birdnet-go/internal/notification"
 )
 
 // GetLogger returns the birdweather package logger
@@ -116,6 +117,13 @@ type BwClient struct {
 	Longitude     float64
 	HTTPClient    *http.Client
 	lastGainWarn  atomic.Int64 // unix timestamp of last WARN-level gain log
+
+	// circuitBreaker guards outbound HTTP calls to the BirdWeather API. When the
+	// remote endpoint starts failing consistently the breaker opens and subsequent
+	// calls return ErrCircuitBreakerOpen without hitting the network, protecting
+	// both the remote service and our telemetry pipeline from a flood of retries.
+	// May be nil in legacy construction paths (tests); see callWithCircuitBreaker.
+	circuitBreaker *notification.PushCircuitBreaker
 }
 
 // maskURL masks sensitive BirdWeatherID tokens in URLs for safe logging.
@@ -175,6 +183,18 @@ func New(settings *conf.Settings) (*BwClient, error) {
 		Longitude:     settings.BirdNET.Longitude,
 		HTTPClient:    &http.Client{Timeout: httpClientTimeout},
 	}
+
+	// Attach the circuit breaker. Metrics are intentionally nil for now — the
+	// BirdWeather integration is not wired into the notification Prometheus
+	// registry and we want to avoid reaching across package boundaries just to
+	// surface state transitions. The breaker degrades gracefully when metrics
+	// are nil (see internal/notification/circuit_breaker.go).
+	client.circuitBreaker = notification.NewPushCircuitBreaker(
+		defaultBirdWeatherCircuitBreakerConfig(),
+		nil,
+		bwCircuitBreakerProvider,
+	)
+
 	return client, nil
 }
 
@@ -593,30 +613,50 @@ func (b *BwClient) UploadSoundscape(timestamp string, pcmData []byte) (soundscap
 	req.Header.Set("Content-Type", "application/octet-stream")
 	req.Header.Set("User-Agent", "BirdNET-Go")
 
-	// Execute the request
+	// Execute the request through the circuit breaker. The breaker records
+	// transport-level failures (timeouts, DNS, TLS) AND non-2xx responses so
+	// a broken or rate-limited backend trips the breaker the same way a flaky
+	// network does. Success/failure classification mirrors the legacy behaviour
+	// the callers already expect.
 	log.Info("Uploading soundscape",
 		logger.String("url", maskedURL),
 		logger.String("format", audioExt))
-	resp, err := b.HTTPClient.Do(req)
-	if err != nil {
-		log.Error("Soundscape upload request failed",
+	var (
+		responseBody     []byte
+		soundscapeStatus int
+	)
+	cbErr := b.callWithCircuitBreaker(req.Context(), func(_ context.Context) error {
+		resp, httpErr := b.HTTPClient.Do(req)
+		if httpErr != nil {
+			log.Error("Soundscape upload request failed",
+				logger.String("url", maskedURL),
+				logger.Error(httpErr))
+			return handleNetworkError(httpErr, maskedURL, httpClientTimeout, "soundscape upload")
+		}
+		if resp == nil {
+			log.Error("Soundscape upload received nil response", logger.String("url", maskedURL))
+			return fmt.Errorf("received nil response")
+		}
+		defer closeResponseBody(resp)
+		log.Debug("Received soundscape upload response",
 			logger.String("url", maskedURL),
-			logger.Error(err))
-		return "", handleNetworkError(err, maskedURL, httpClientTimeout, "soundscape upload")
-	}
-	if resp == nil {
-		log.Error("Soundscape upload received nil response", logger.String("url", maskedURL))
-		return "", fmt.Errorf("received nil response")
-	}
-	defer closeResponseBody(resp)
-	log.Debug("Received soundscape upload response",
-		logger.String("url", maskedURL),
-		logger.Int("status_code", resp.StatusCode))
+			logger.Int("status_code", resp.StatusCode))
 
-	// Process the response using the new handler
-	responseBody, err := handleHTTPResponse(resp, http.StatusCreated, "soundscape upload", maskedURL)
-	if err != nil {
-		return "", err
+		body, handleErr := handleHTTPResponse(resp, http.StatusCreated, "soundscape upload", maskedURL)
+		if handleErr != nil {
+			return handleErr
+		}
+		responseBody = body
+		soundscapeStatus = resp.StatusCode
+		return nil
+	})
+	if cbErr != nil {
+		if isCircuitBreakerOpen(cbErr) {
+			log.Warn("Soundscape upload skipped: circuit breaker open",
+				logger.String("url", maskedURL),
+				logger.String("timestamp", timestamp))
+		}
+		return "", cbErr
 	}
 
 	if b.Settings.Realtime.Birdweather.Debug {
@@ -624,7 +664,7 @@ func (b *BwClient) UploadSoundscape(timestamp string, pcmData []byte) (soundscap
 	}
 
 	// Parse and validate response
-	soundscapeID, err = parseSoundscapeResponse(responseBody, maskedURL, resp.StatusCode)
+	soundscapeID, err = parseSoundscapeResponse(responseBody, maskedURL, soundscapeStatus)
 	if err != nil {
 		return "", err
 	}
@@ -724,41 +764,55 @@ func (b *BwClient) PostDetection(soundscapeID, timestamp, commonName, scientific
 		log.Debug("Detection JSON Payload", logger.String("payload", string(postDataBytes)))
 	}
 
-	// Execute POST request
+	// Execute POST request through the circuit breaker. A persistent BirdWeather
+	// outage used to produce one Sentry event per detection; the breaker now
+	// short-circuits retries once consecutive failures cross the configured
+	// threshold, letting the remote service recover without a retry storm.
 	log.Info("Posting detection",
 		logger.String("url", maskedDetectionURL),
 		logger.String("soundscape_id", soundscapeID),
 		logger.String("scientific_name", scientificName))
-	resp, err := b.HTTPClient.Post(detectionURL, "application/json", bytes.NewBuffer(postDataBytes))
-	if err != nil {
-		log.Error("Detection post request failed",
+	cbErr := b.callWithCircuitBreaker(context.Background(), func(_ context.Context) error {
+		resp, httpErr := b.HTTPClient.Post(detectionURL, "application/json", bytes.NewBuffer(postDataBytes))
+		if httpErr != nil {
+			log.Error("Detection post request failed",
+				logger.String("url", maskedDetectionURL),
+				logger.String("soundscape_id", soundscapeID),
+				logger.Error(httpErr))
+			return handleNetworkError(httpErr, maskedDetectionURL, httpClientTimeout, "detection post")
+		}
+		if resp == nil {
+			log.Error("Detection post received nil response",
+				logger.String("url", maskedDetectionURL),
+				logger.String("soundscape_id", soundscapeID))
+			return fmt.Errorf("received nil response")
+		}
+		defer closeResponseBody(resp)
+		log.Debug("Received detection post response",
 			logger.String("url", maskedDetectionURL),
 			logger.String("soundscape_id", soundscapeID),
-			logger.Error(err))
-		return handleNetworkError(err, maskedDetectionURL, httpClientTimeout, "detection post")
-	}
-	if resp == nil {
-		log.Error("Detection post received nil response",
-			logger.String("url", maskedDetectionURL),
-			logger.String("soundscape_id", soundscapeID))
-		return fmt.Errorf("received nil response")
-	}
-	defer closeResponseBody(resp)
-	log.Debug("Received detection post response",
-		logger.String("url", maskedDetectionURL),
-		logger.String("soundscape_id", soundscapeID),
-		logger.Int("status_code", resp.StatusCode))
+			logger.Int("status_code", resp.StatusCode))
 
-	// Handle response using the new handler
-	_, err = handleHTTPResponse(resp, http.StatusCreated, "detection post", maskedDetectionURL)
-	if err != nil {
-		// Add additional context for detection-specific error
-		var enhancedErr *errors.EnhancedError
-		if errors.As(err, &enhancedErr) {
-			enhancedErr.Context["soundscape_id"] = soundscapeID
-			enhancedErr.Context["scientific_name"] = scientificName
+		_, handleErr := handleHTTPResponse(resp, http.StatusCreated, "detection post", maskedDetectionURL)
+		if handleErr != nil {
+			// Add detection-specific context before the breaker observes the error.
+			var enhancedErr *errors.EnhancedError
+			if errors.As(handleErr, &enhancedErr) {
+				enhancedErr.Context["soundscape_id"] = soundscapeID
+				enhancedErr.Context["scientific_name"] = scientificName
+			}
+			return handleErr
 		}
-		return err
+		return nil
+	})
+	if cbErr != nil {
+		if isCircuitBreakerOpen(cbErr) {
+			log.Warn("Detection post skipped: circuit breaker open",
+				logger.String("url", maskedDetectionURL),
+				logger.String("soundscape_id", soundscapeID),
+				logger.String("scientific_name", scientificName))
+		}
+		return cbErr
 	}
 
 	log.Info("Detection posted successfully",
@@ -839,14 +893,23 @@ func (b *BwClient) Publish(note *datastore.Note, pcmData []byte) (err error) {
 	log.Debug("Calling UploadSoundscape", logger.String("timestamp", timestamp))
 	soundscapeID, err := b.UploadSoundscape(timestamp, pcmData)
 	if err != nil {
-		// Transient network errors (DNS, timeout, connection issues) are expected
-		// external failures, not code bugs. Log at warn level and skip alerting
-		// to avoid Sentry noise and unnecessary user notifications.
-		if errors.IsTransientNetworkError(err) {
+		switch {
+		case isCircuitBreakerOpen(err):
+			// Breaker is open — the upstream BirdWeather API is still considered
+			// unhealthy. This is an operational throttling state, not a code bug,
+			// so we log at debug level and skip alerting (which would otherwise
+			// fire once per detection during extended outages).
+			log.Debug("BirdWeather soundscape upload skipped: circuit breaker open",
+				logger.String("timestamp", timestamp),
+				logger.Error(err))
+		case errors.IsTransientNetworkError(err):
+			// Transient network errors (DNS, timeout, connection issues) are expected
+			// external failures, not code bugs. Log at warn level and skip alerting
+			// to avoid Sentry noise and unnecessary user notifications.
 			log.Warn("BirdWeather soundscape upload failed due to transient network issue",
 				logger.String("timestamp", timestamp),
 				logger.Error(err))
-		} else {
+		default:
 			log.Error("Publish failed: Error during soundscape upload",
 				logger.String("timestamp", timestamp),
 				logger.Error(err))
@@ -881,6 +944,15 @@ func (b *BwClient) Publish(note *datastore.Note, pcmData []byte) (err error) {
 				logger.String("scientific_name", note.ScientificName),
 				logger.Error(err))
 			return nil
+		case isCircuitBreakerOpen(err):
+			// Breaker is open — treat as a short-circuited skip. No alerting,
+			// no Sentry noise (handled by shouldReportToSentry), debug-level log.
+			log.Debug("BirdWeather detection post skipped: circuit breaker open",
+				logger.String("soundscape_id", soundscapeID),
+				logger.String("timestamp", timestamp),
+				logger.String("common_name", note.CommonName),
+				logger.String("scientific_name", note.ScientificName),
+				logger.Error(err))
 		case errors.IsTransientNetworkError(err):
 			// Transient network errors during detection post are expected
 			// external failures. Log at warn level and skip alerting.

--- a/internal/birdweather/birdweather_client.go
+++ b/internal/birdweather/birdweather_client.go
@@ -630,8 +630,11 @@ func (b *BwClient) UploadSoundscape(timestamp string, pcmData []byte) (soundscap
 		// of the upstream service.
 		nonTransientErr error
 	)
-	cbErr := b.callWithCircuitBreaker(req.Context(), func(_ context.Context) error {
-		resp, httpErr := b.HTTPClient.Do(req)
+	cbErr := b.callWithCircuitBreaker(req.Context(), func(ctx context.Context) error {
+		// Use the breaker callback's ctx so cancellation propagates through
+		// to the HTTP layer (e.g., the caller aborts mid-retry) rather than
+		// stopping at the breaker boundary.
+		resp, httpErr := b.HTTPClient.Do(req.WithContext(ctx))
 		if httpErr != nil {
 			log.Error("Soundscape upload request failed",
 				logger.String("url", maskedURL),
@@ -791,8 +794,19 @@ func (b *BwClient) PostDetection(soundscapeID, timestamp, commonName, scientific
 	// species validation 422s from the detection post — the common case for
 	// non-bird species) out of the breaker closure without tripping it.
 	var nonTransientErr error
-	cbErr := b.callWithCircuitBreaker(context.Background(), func(_ context.Context) error {
-		resp, httpErr := b.HTTPClient.Post(detectionURL, "application/json", bytes.NewBuffer(postDataBytes))
+	cbErr := b.callWithCircuitBreaker(context.Background(), func(ctx context.Context) error {
+		// Use http.NewRequestWithContext so the breaker callback's ctx
+		// propagates to the HTTP layer and honours cancellation. The
+		// previous HTTPClient.Post() call discarded ctx, leaving requests
+		// to run to HTTPClient.Timeout even after the breaker or caller
+		// signalled cancellation.
+		req, reqErr := http.NewRequestWithContext(ctx, http.MethodPost, detectionURL, bytes.NewBuffer(postDataBytes))
+		if reqErr != nil {
+			return fmt.Errorf("build detection post request: %w", reqErr)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("User-Agent", "BirdNET-Go")
+		resp, httpErr := b.HTTPClient.Do(req)
 		if httpErr != nil {
 			log.Error("Detection post request failed",
 				logger.String("url", maskedDetectionURL),
@@ -1180,6 +1194,19 @@ func trackOperationTiming(errPtr *error, operation string, startTime time.Time, 
 
 		duration := time.Since(startTime)
 		if *errPtr != nil {
+			// Circuit-breaker short-circuits are an operational throttle state,
+			// not a failure of the individual call. The breaker state transition
+			// is surfaced via dedicated telemetry; emitting a per-call WARN here
+			// would undo the Sentry-noise reduction the breaker exists to provide.
+			// Treat them like successful no-ops for timing-log purposes.
+			if isCircuitBreakerOpen(*errPtr) {
+				logArgs := append([]logger.Field{
+					logger.String("operation", operation),
+					logger.Int64("duration_ms", duration.Milliseconds()),
+				}, convertToFields(contextFields)...)
+				log.Debug(fmt.Sprintf("%s short-circuited: circuit breaker open", operation), logArgs...)
+				return
+			}
 			// Add timing context to error
 			var enhancedErr *errors.EnhancedError
 			if errors.As(*errPtr, &enhancedErr) {

--- a/internal/birdweather/circuit_breaker.go
+++ b/internal/birdweather/circuit_breaker.go
@@ -1,0 +1,86 @@
+// circuit_breaker.go provides circuit breaker integration for the BirdWeather API client.
+//
+// BirdWeather uploads depend on external connectivity (app.birdweather.com). Transient
+// outages, DNS failures, and TLS timeouts produced hundreds of Sentry events before this
+// was added because each detection triggered a full retry against an already-failing
+// endpoint. The circuit breaker short-circuits those attempts after a configurable
+// number of consecutive failures and lets the service recover on its own timer.
+//
+// The implementation reuses notification.PushCircuitBreaker so behaviour and metrics
+// match the webhook push path and we only have one state machine to reason about.
+package birdweather
+
+import (
+	"context"
+	"time"
+
+	"github.com/tphakala/birdnet-go/internal/errors"
+	"github.com/tphakala/birdnet-go/internal/notification"
+)
+
+// Circuit breaker tuning for outbound BirdWeather calls.
+//
+// These values are intentionally more relaxed than the webhook push defaults:
+//
+//   - BirdWeather uploads are scheduled one-per-detection (potentially many per minute),
+//     so MaxConsecutiveFailures=5 trips the breaker after ~5 consecutive bad uploads.
+//   - ResetTimeout=10 minutes keeps the service quiet while the remote API cools down,
+//     avoiding a thundering herd against a flapping endpoint while still recovering
+//     quickly once the network stabilises.
+const (
+	// BwMaxConsecutiveFailures is the consecutive failure count that trips the breaker.
+	BwMaxConsecutiveFailures = 5
+
+	// BwResetTimeout is how long the breaker stays open before allowing a probe request.
+	BwResetTimeout = 10 * time.Minute
+
+	// BwHalfOpenMaxRequests is the probe budget allowed while half-open. Conservative
+	// at 1 so we don't flood a still-recovering endpoint.
+	BwHalfOpenMaxRequests = 1
+
+	// bwCircuitBreakerProvider is the provider name used in log/metric tags.
+	bwCircuitBreakerProvider = "birdweather"
+)
+
+// defaultBirdWeatherCircuitBreakerConfig returns the circuit breaker configuration
+// used by BirdWeather clients unless tests override it.
+func defaultBirdWeatherCircuitBreakerConfig() notification.CircuitBreakerConfig {
+	return notification.CircuitBreakerConfig{
+		MaxFailures:         BwMaxConsecutiveFailures,
+		Timeout:             BwResetTimeout,
+		HalfOpenMaxRequests: BwHalfOpenMaxRequests,
+	}
+}
+
+// callWithCircuitBreaker wraps fn with the client's circuit breaker, if one is
+// attached. When the breaker is open it returns ErrCircuitBreakerOpen without
+// invoking fn. When the breaker is absent (legacy construction in tests), fn is
+// executed directly. The error returned by fn is also returned unchanged so the
+// caller can continue to classify BirdWeather-specific errors.
+//
+// ctx must already carry any per-operation timeout; this helper does not add one.
+func (b *BwClient) callWithCircuitBreaker(ctx context.Context, fn func(context.Context) error) error {
+	if b == nil || b.circuitBreaker == nil {
+		return fn(ctx)
+	}
+	return b.circuitBreaker.Call(ctx, fn)
+}
+
+// isCircuitBreakerOpen reports whether err was produced because the breaker is
+// open (or half-open and already saturated). The check unwraps wrapped errors
+// so callers can detect the condition even after additional context has been
+// layered on top by the telemetry integration.
+func isCircuitBreakerOpen(err error) bool {
+	return errors.Is(err, notification.ErrCircuitBreakerOpen) ||
+		errors.Is(err, notification.ErrTooManyRequests)
+}
+
+// CircuitBreakerState returns the current circuit breaker state. Exposed for
+// observability and tests. Returns StateClosed when no breaker is attached so
+// callers do not have to handle a nil breaker separately.
+func (b *BwClient) CircuitBreakerState() notification.CircuitState {
+	if b == nil || b.circuitBreaker == nil {
+		return notification.StateClosed
+	}
+	return b.circuitBreaker.State()
+}

--- a/internal/birdweather/circuit_breaker_test.go
+++ b/internal/birdweather/circuit_breaker_test.go
@@ -1,0 +1,182 @@
+package birdweather
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/notification"
+)
+
+// newCBTestClient returns a BwClient with a short-fused circuit breaker suited
+// for deterministic state transition tests. The HTTPClient is preconfigured to
+// point at server via a rewriting transport so the tests do not race on DNS or
+// network stacks.
+func newCBTestClient(t *testing.T, server *httptest.Server, cfg notification.CircuitBreakerConfig) *BwClient {
+	t.Helper()
+
+	client := &BwClient{
+		Settings:      MockSettings(),
+		BirdweatherID: "test-station-123",
+		HTTPClient: &http.Client{
+			Timeout:   5 * time.Second,
+			Transport: &mockTransport{server: server},
+		},
+		circuitBreaker: notification.NewPushCircuitBreaker(cfg, nil, bwCircuitBreakerProvider),
+	}
+	return client
+}
+
+// newCBTestConfig returns a tightened CircuitBreakerConfig that lets the tests
+// observe all three state transitions (closed → open → half-open → closed)
+// without touching real wall-clock durations.
+func newCBTestConfig() notification.CircuitBreakerConfig {
+	return notification.CircuitBreakerConfig{
+		MaxFailures:         3,
+		Timeout:             50 * time.Millisecond,
+		HalfOpenMaxRequests: 1,
+	}
+}
+
+// TestBwClient_CircuitBreaker_OpensAfterConsecutiveFailures verifies the
+// closed → open transition when the upstream BirdWeather API keeps failing.
+// The test asserts that once the breaker is open no further HTTP requests are
+// made (hit counter stops incrementing) and subsequent calls return the
+// sentinel ErrCircuitBreakerOpen.
+func TestBwClient_CircuitBreaker_OpensAfterConsecutiveFailures(t *testing.T) {
+	t.Parallel()
+
+	var hits atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = fmt.Fprint(w, `{"success":false}`)
+	}))
+	defer server.Close()
+
+	cfg := newCBTestConfig()
+	client := newCBTestClient(t, server, cfg)
+
+	// Drive the breaker to open by triggering MaxFailures failed detections.
+	for range cfg.MaxFailures {
+		err := client.PostDetection("1", "2024-01-01T00:00:00.000+0000", "Great Tit", "Parus major", 0.9)
+		require.Error(t, err, "expected upstream 500 to surface as error")
+	}
+
+	require.Equal(t, notification.StateOpen, client.CircuitBreakerState(),
+		"breaker should be OPEN after %d consecutive failures", cfg.MaxFailures)
+
+	before := hits.Load()
+
+	// Further calls must short-circuit: no HTTP request, error detected as CB-open.
+	err := client.PostDetection("1", "2024-01-01T00:00:00.000+0000", "Great Tit", "Parus major", 0.9)
+	require.Error(t, err, "call while breaker open must return an error")
+	assert.True(t, isCircuitBreakerOpen(err),
+		"error %v should be recognised as circuit-breaker open", err)
+	assert.Equal(t, before, hits.Load(),
+		"no HTTP request should be made while breaker is open")
+}
+
+// TestBwClient_CircuitBreaker_HalfOpenAllowsProbe verifies the open → half-open
+// transition after the configured reset timeout and the half-open → closed
+// transition once a probe request succeeds.
+func TestBwClient_CircuitBreaker_HalfOpenAllowsProbe(t *testing.T) {
+	t.Parallel()
+
+	var hits atomic.Int32
+	var succeedAfter atomic.Int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		n := hits.Add(1)
+		if n <= succeedAfter.Load() {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = fmt.Fprint(w, `{"success":false}`)
+			return
+		}
+		// Probe response — succeed to close the breaker.
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = fmt.Fprint(w, `{"success":true}`)
+	}))
+	defer server.Close()
+
+	cfg := newCBTestConfig()
+	succeedAfter.Store(int32(cfg.MaxFailures))
+	client := newCBTestClient(t, server, cfg)
+
+	// Fail enough times to open the breaker.
+	for range cfg.MaxFailures {
+		_ = client.PostDetection("42", "2024-01-01T00:00:00.000+0000", "Great Tit", "Parus major", 0.9)
+	}
+	require.Equal(t, notification.StateOpen, client.CircuitBreakerState())
+
+	// Wait past the reset timeout so the next call transitions to half-open.
+	time.Sleep(cfg.Timeout + 20*time.Millisecond)
+
+	// Probe request should succeed and close the breaker again.
+	err := client.PostDetection("42", "2024-01-01T00:00:00.000+0000", "Great Tit", "Parus major", 0.9)
+	require.NoError(t, err, "probe request should succeed with 201 response")
+	assert.Equal(t, notification.StateClosed, client.CircuitBreakerState(),
+		"breaker should close again after a successful probe")
+}
+
+// TestBwClient_CircuitBreaker_TransportErrorCountsAsFailure guards against a
+// prior bug where transport errors bypassed the breaker state machine. A
+// transport-level failure (closed connection, hijacked and aborted) must
+// trip the breaker after MaxFailures just like a 5xx response. We use an
+// aborted response because httptest.Server sits behind its own transport
+// which ignores http.Client.Timeout on the real client object — using a
+// forced network error is the most reliable way to exercise this path.
+func TestBwClient_CircuitBreaker_TransportErrorCountsAsFailure(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// Hijack the connection and close it without sending a valid
+		// response. The client will observe "EOF" / "connection reset"
+		// which surfaces as a net.Error.
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			t.Fatal("server does not support hijacking")
+		}
+		conn, _, err := hj.Hijack()
+		if err != nil {
+			t.Fatalf("hijack failed: %v", err)
+		}
+		_ = conn.Close()
+	}))
+	defer server.Close()
+
+	cfg := newCBTestConfig()
+	client := newCBTestClient(t, server, cfg)
+
+	for range cfg.MaxFailures {
+		err := client.PostDetection("7", "2024-01-01T00:00:00.000+0000", "Great Tit", "Parus major", 0.9)
+		require.Error(t, err, "transport error must surface as error from PostDetection")
+	}
+
+	assert.Equal(t, notification.StateOpen, client.CircuitBreakerState(),
+		"transport errors must trip the breaker exactly like upstream errors")
+}
+
+// TestBwClient_CircuitBreaker_Nil_OK verifies graceful behaviour when the
+// breaker has not been attached (e.g., legacy BwClient literal in existing
+// tests). The client must still function; the helper simply executes fn.
+func TestBwClient_CircuitBreaker_Nil_OK(t *testing.T) {
+	t.Parallel()
+
+	c := &BwClient{}
+	called := false
+	err := c.callWithCircuitBreaker(t.Context(), func(_ context.Context) error {
+		called = true
+		return nil
+	})
+	require.NoError(t, err)
+	assert.True(t, called, "fn must run when no breaker is attached")
+	assert.Equal(t, notification.StateClosed, c.CircuitBreakerState())
+}

--- a/internal/birdweather/circuit_breaker_test.go
+++ b/internal/birdweather/circuit_breaker_test.go
@@ -180,3 +180,34 @@ func TestBwClient_CircuitBreaker_Nil_OK(t *testing.T) {
 	assert.True(t, called, "fn must run when no breaker is attached")
 	assert.Equal(t, notification.StateClosed, c.CircuitBreakerState())
 }
+
+// TestBwClient_CircuitBreaker_NotFoundDoesNotTrip verifies that 422 species
+// validation errors (CategoryNotFound — expected when a non-bird species is
+// sent to BirdWeather) do NOT count toward the breaker. Without this guard
+// we would open the breaker simply because the user configured a non-bird
+// species in their detection list, suppressing legitimate later uploads.
+func TestBwClient_CircuitBreaker_NotFoundDoesNotTrip(t *testing.T) {
+	t.Parallel()
+
+	// Always respond with 422 + species error body — handleHTTPResponse tags
+	// this as CategoryNotFound.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_, _ = fmt.Fprint(w, `{"species":"unknown species","error":"invalid"}`)
+	}))
+	defer server.Close()
+
+	cfg := newCBTestConfig()
+	client := newCBTestClient(t, server, cfg)
+
+	// Post far more than MaxFailures detections — every one returns 422 but
+	// the breaker must stay closed because CategoryNotFound errors are
+	// business-logic, not transient failures.
+	for range cfg.MaxFailures * 3 {
+		err := client.PostDetection("n/a", "2024-01-01T00:00:00.000+0000", "Not A Bird", "notabird", 0.9)
+		require.Error(t, err, "422 species validation must still surface as an error to the caller")
+	}
+
+	assert.Equal(t, notification.StateClosed, client.CircuitBreakerState(),
+		"CategoryNotFound (species validation) must not trip the circuit breaker")
+}

--- a/internal/birdweather/circuit_breaker_test.go
+++ b/internal/birdweather/circuit_breaker_test.go
@@ -181,6 +181,35 @@ func TestBwClient_CircuitBreaker_Nil_OK(t *testing.T) {
 	assert.Equal(t, notification.StateClosed, c.CircuitBreakerState())
 }
 
+// TestBwClient_CircuitBreaker_MalformedUploadResponseTripsBreaker verifies
+// that parseSoundscapeResponse() failures (HTML served with 201, invalid
+// JSON, success:false payloads) count as breaker failures. Without this,
+// a degraded upstream returning 201s with broken bodies would silently pass
+// the closure's HTTP checks while clients kept hammering the endpoint.
+func TestBwClient_CircuitBreaker_MalformedUploadResponseTripsBreaker(t *testing.T) {
+	t.Parallel()
+
+	// Respond with 201 Created but an invalid JSON body — handleHTTPResponse
+	// accepts the status code, but parseSoundscapeResponse fails.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = fmt.Fprint(w, `<html><body>gateway timeout</body></html>`)
+	}))
+	defer server.Close()
+
+	cfg := newCBTestConfig()
+	client := newCBTestClient(t, server, cfg)
+
+	for range cfg.MaxFailures {
+		_, err := client.UploadSoundscape("2024-01-01T00:00:00.000+0000", []byte{0, 0, 0, 0})
+		require.Error(t, err, "malformed response must surface as error")
+	}
+
+	assert.Equal(t, notification.StateOpen, client.CircuitBreakerState(),
+		"parseSoundscapeResponse failures must trip the breaker — otherwise a degraded upstream returning 201s with broken bodies would silently pass the closure")
+}
+
 // TestBwClient_CircuitBreaker_NotFoundDoesNotTrip verifies that 422 species
 // validation errors (CategoryNotFound — expected when a non-bird species is
 // sent to BirdWeather) do NOT count toward the breaker. Without this guard

--- a/internal/birdweather/helpers_test.go
+++ b/internal/birdweather/helpers_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/errors"
+	"github.com/tphakala/birdnet-go/internal/notification"
 )
 
 // TestParseSoundscapeResponse tests the JSON response parsing helper
@@ -172,6 +173,26 @@ func TestTrackOperationTiming(t *testing.T) {
 		// The error should now be an EnhancedError
 		var enhancedErr *errors.EnhancedError
 		assert.True(t, errors.As(err, &enhancedErr), "error should be wrapped as EnhancedError")
+	})
+
+	t.Run("breaker-open error is not re-promoted to WARN or wrapped with CategoryNetwork", func(t *testing.T) {
+		t.Parallel()
+
+		// Start from the notification sentinel directly — this is what the
+		// BirdWeather client returns when its circuit breaker short-circuits.
+		var err error = notification.ErrCircuitBreakerOpen
+		startTime := time.Now()
+
+		cleanup := trackOperationTiming(&err, "short_circuit_test", startTime)
+		cleanup()
+
+		// The error passes through unchanged. The timing tracker must NOT
+		// wrap it with CategoryNetwork or otherwise mutate it — earlier review
+		// revealed the default path was promoting it to WARN which re-introduced
+		// the Sentry noise the breaker is supposed to suppress.
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, notification.ErrCircuitBreakerOpen),
+			"sentinel must pass through unchanged so callers can still detect it")
 	})
 }
 

--- a/internal/errors/telemetry_integration.go
+++ b/internal/errors/telemetry_integration.go
@@ -180,22 +180,20 @@ func shouldReportToSentry(ee *EnhancedError) bool {
 
 	errorMsg := strings.ToLower(ee.Err.Error())
 
-	// Circuit-breaker open/half-open conditions are operational throttling state,
-	// not bugs. Suppress CategoryLimit producers that emit these signals from
-	// components with a per-component breaker: notification (push webhooks) and
-	// birdweather (outbound uploads). The breaker state transitions themselves
-	// are already surfaced via the dedicated CircuitBreakerStateTransition
+	// Notification circuit-breaker open/half-open conditions are operational
+	// throttling state, not bugs. BirdWeather reuses the notification package's
+	// PushCircuitBreaker, whose sentinel ErrCircuitBreakerOpen is tagged with
+	// component="notification" regardless of the caller — so this single check
+	// also covers BirdWeather's breaker-open errors. The breaker state transitions
+	// themselves are surfaced via the dedicated CircuitBreakerStateTransition
 	// telemetry path, so the per-call "circuit breaker is open" errors are pure
 	// noise when forwarded to Sentry.
 	//
 	// Other CategoryLimit producers (eBird API quota exhaustion, analysis job
-	// queue overflow, spectrogram pre-render memory limits) are NOT filtered here
-	// and continue to reach Sentry as legitimate signals.
-	if ee.Category == CategoryLimit {
-		switch ee.GetComponent() {
-		case "notification", "birdweather":
-			return false
-		}
+	// queue overflow, spectrogram pre-render memory limits) use different
+	// components and continue to reach Sentry as legitimate signals.
+	if ee.Category == CategoryLimit && ee.GetComponent() == "notification" {
+		return false
 	}
 
 	// Check for MQTT authentication/authorization errors (user config issues)

--- a/internal/errors/telemetry_integration.go
+++ b/internal/errors/telemetry_integration.go
@@ -180,16 +180,22 @@ func shouldReportToSentry(ee *EnhancedError) bool {
 
 	errorMsg := strings.ToLower(ee.Err.Error())
 
-	// Notification circuit-breaker open/half-open conditions are operational
-	// throttling state, not bugs. Suppress only that component — NOT all
-	// CategoryLimit producers. eBird API quota exhaustion, analysis job
-	// queue overflow, and spectrogram pre-render memory limits should still
-	// reach Sentry as legitimate signals. The notification state transitions
-	// themselves are already surfaced via the dedicated CircuitBreakerStateTransition
-	// telemetry path, so the per-call errors from that component are pure
+	// Circuit-breaker open/half-open conditions are operational throttling state,
+	// not bugs. Suppress CategoryLimit producers that emit these signals from
+	// components with a per-component breaker: notification (push webhooks) and
+	// birdweather (outbound uploads). The breaker state transitions themselves
+	// are already surfaced via the dedicated CircuitBreakerStateTransition
+	// telemetry path, so the per-call "circuit breaker is open" errors are pure
 	// noise when forwarded to Sentry.
-	if ee.Category == CategoryLimit && ee.GetComponent() == "notification" {
-		return false
+	//
+	// Other CategoryLimit producers (eBird API quota exhaustion, analysis job
+	// queue overflow, spectrogram pre-render memory limits) are NOT filtered here
+	// and continue to reach Sentry as legitimate signals.
+	if ee.Category == CategoryLimit {
+		switch ee.GetComponent() {
+		case "notification", "birdweather":
+			return false
+		}
 	}
 
 	// Check for MQTT authentication/authorization errors (user config issues)

--- a/internal/errors/telemetry_integration_test.go
+++ b/internal/errors/telemetry_integration_test.go
@@ -117,12 +117,13 @@ func TestShouldReportToSentry_AllowsNetworkCategoryCodeBugs(t *testing.T) {
 }
 
 // TestShouldReportToSentry_CategoryLimitNotificationOnly verifies that the
-// CategoryLimit suppression is scoped to the notification component only.
-// The notification circuit breaker produces high-volume [limit] state noise
-// that is already covered by the dedicated CircuitBreakerStateTransition
-// telemetry path. Other CategoryLimit producers (eBird API quota, analysis
-// job queue full, spectrogram pre-render memory limits) are legitimate
-// operational signals that ops needs to see and must still reach Sentry.
+// CategoryLimit suppression is scoped to components that own a circuit breaker
+// (notification push providers and birdweather outbound uploads). The breakers
+// produce high-volume [limit] state noise that is already covered by the
+// dedicated CircuitBreakerStateTransition telemetry path. Other CategoryLimit
+// producers (eBird API quota, analysis job queue full, spectrogram pre-render
+// memory limits) are legitimate operational signals that ops needs to see and
+// must still reach Sentry.
 func TestShouldReportToSentry_CategoryLimitNotificationOnly(t *testing.T) {
 	t.Parallel()
 
@@ -142,6 +143,12 @@ func TestShouldReportToSentry_CategoryLimitNotificationOnly(t *testing.T) {
 			name:       "notification circuit breaker half-open too many requests is suppressed",
 			component:  "notification",
 			err:        fmt.Errorf("circuit breaker is half-open, too many requests"),
+			wantReport: false,
+		},
+		{
+			name:       "birdweather circuit breaker open is suppressed",
+			component:  "birdweather",
+			err:        fmt.Errorf("circuit breaker is open"),
 			wantReport: false,
 		},
 		{

--- a/internal/errors/telemetry_integration_test.go
+++ b/internal/errors/telemetry_integration_test.go
@@ -117,13 +117,14 @@ func TestShouldReportToSentry_AllowsNetworkCategoryCodeBugs(t *testing.T) {
 }
 
 // TestShouldReportToSentry_CategoryLimitNotificationOnly verifies that the
-// CategoryLimit suppression is scoped to components that own a circuit breaker
-// (notification push providers and birdweather outbound uploads). The breakers
-// produce high-volume [limit] state noise that is already covered by the
-// dedicated CircuitBreakerStateTransition telemetry path. Other CategoryLimit
-// producers (eBird API quota, analysis job queue full, spectrogram pre-render
-// memory limits) are legitimate operational signals that ops needs to see and
-// must still reach Sentry.
+// CategoryLimit suppression is scoped to the notification component. The
+// notification.PushCircuitBreaker's ErrCircuitBreakerOpen sentinel is tagged
+// component="notification", and that single sentinel is what every caller
+// (notification push providers AND birdweather uploads, which reuse the
+// same breaker) receives — so the notification-only filter suppresses both
+// in practice. Other CategoryLimit producers (eBird API quota, analysis job
+// queue full, spectrogram pre-render memory limits) are legitimate
+// operational signals that ops needs to see and must still reach Sentry.
 func TestShouldReportToSentry_CategoryLimitNotificationOnly(t *testing.T) {
 	t.Parallel()
 
@@ -143,12 +144,6 @@ func TestShouldReportToSentry_CategoryLimitNotificationOnly(t *testing.T) {
 			name:       "notification circuit breaker half-open too many requests is suppressed",
 			component:  "notification",
 			err:        fmt.Errorf("circuit breaker is half-open, too many requests"),
-			wantReport: false,
-		},
-		{
-			name:       "birdweather circuit breaker open is suppressed",
-			component:  "birdweather",
-			err:        fmt.Errorf("circuit breaker is open"),
 			wantReport: false,
 		},
 		{

--- a/internal/notification/error_suppressor.go
+++ b/internal/notification/error_suppressor.go
@@ -19,17 +19,11 @@ import (
 const (
 	// suppressionReminderInterval is the INITIAL interval between repeated
 	// reminders while a provider is still failing. The effective interval
-	// doubles on each reminder (see reminderIntervalMultiplier and
+	// doubles on each reminder (see nextReminderInterval and
 	// maxSuppressionReminderInterval) so a long-lived outage does not keep
 	// generating one Sentry event every five minutes. Starting at five minutes
 	// keeps the first reminder actionable for an operator.
 	suppressionReminderInterval = 5 * time.Minute
-
-	// reminderIntervalMultiplier controls how aggressively the reminder
-	// interval grows between successive reports. A value of 2 produces the
-	// classic 5m → 10m → 20m → 40m → ... schedule, which caps at the
-	// maxSuppressionReminderInterval ceiling below.
-	reminderIntervalMultiplier = 2
 
 	// maxSuppressionReminderInterval caps the exponential growth. Twenty-four
 	// hours keeps the rate of Sentry events at roughly once per day for long
@@ -158,9 +152,11 @@ func nextReminderInterval(reportCount int) time.Duration {
 		return suppressionReminderInterval
 	}
 
-	// Exponential growth in discrete steps via bit-shift. Cap the shift at
-	// a conservative bound to prevent integer overflow; beyond ~20 shifts we
-	// would already be far past maxSuppressionReminderInterval anyway.
+	// Exponential growth via bit-shift — multiplier is hard-coded to 2 for a
+	// 5m → 10m → 20m → 40m → ... schedule. Cap the shift at a bound that
+	// comfortably exceeds
+	// maxSuppressionReminderInterval to avoid any chance of signed-int
+	// overflow if reportCount grows unbounded during a very long outage.
 	const maxShift = 20
 	shift := reportCount - 1
 	if shift > maxShift {
@@ -168,19 +164,6 @@ func nextReminderInterval(reportCount int) time.Duration {
 	}
 
 	multiplier := int64(1) << shift
-	// Only allow the configured multiplier base to shape growth: e.g., with
-	// reminderIntervalMultiplier=2 the multiplier is exactly 2^shift. Keeping
-	// it configurable avoids hard-coding the factor in two places.
-	if reminderIntervalMultiplier != 2 && shift > 0 {
-		multiplier = 1
-		for range shift {
-			multiplier *= int64(reminderIntervalMultiplier)
-			if multiplier < 0 || time.Duration(multiplier)*suppressionReminderInterval > maxSuppressionReminderInterval {
-				return maxSuppressionReminderInterval
-			}
-		}
-	}
-
 	interval := time.Duration(multiplier) * suppressionReminderInterval
 	if interval <= 0 || interval > maxSuppressionReminderInterval {
 		return maxSuppressionReminderInterval

--- a/internal/notification/error_suppressor.go
+++ b/internal/notification/error_suppressor.go
@@ -17,10 +17,25 @@ import (
 )
 
 const (
-	// suppressionReminderInterval controls how often a reminder is logged/reported
-	// while errors are still being suppressed. This provides periodic visibility
-	// without flooding.
+	// suppressionReminderInterval is the INITIAL interval between repeated
+	// reminders while a provider is still failing. The effective interval
+	// doubles on each reminder (see reminderIntervalMultiplier and
+	// maxSuppressionReminderInterval) so a long-lived outage does not keep
+	// generating one Sentry event every five minutes. Starting at five minutes
+	// keeps the first reminder actionable for an operator.
 	suppressionReminderInterval = 5 * time.Minute
+
+	// reminderIntervalMultiplier controls how aggressively the reminder
+	// interval grows between successive reports. A value of 2 produces the
+	// classic 5m → 10m → 20m → 40m → ... schedule, which caps at the
+	// maxSuppressionReminderInterval ceiling below.
+	reminderIntervalMultiplier = 2
+
+	// maxSuppressionReminderInterval caps the exponential growth. Twenty-four
+	// hours keeps the rate of Sentry events at roughly once per day for long
+	// outages while still giving an operator periodic confirmation that the
+	// failure is ongoing.
+	maxSuppressionReminderInterval = 24 * time.Hour
 
 	// defaultStaleEntryMaxAge is the default duration after which an error state
 	// entry with no recent activity is considered stale and eligible for eviction.
@@ -33,6 +48,11 @@ const (
 type providerErrorState struct {
 	// consecutiveFailures counts failures since last success.
 	consecutiveFailures int
+
+	// reportCount tracks how many times we have already reported for this
+	// failure streak. Drives the exponential reminder backoff — see
+	// nextReminderInterval in error_suppressor.go.
+	reportCount int
 
 	// firstFailureTime is when the current failure streak started.
 	firstFailureTime time.Time
@@ -102,16 +122,70 @@ func (es *ErrorSuppressor) ShouldReport(providerName string) bool {
 		state.firstFailureTime = time.Now()
 		state.reported = true
 		state.lastReportTime = time.Now()
+		state.reportCount = 1
 		return true
 	}
 
-	// Check if enough time has passed for a periodic reminder
-	if time.Since(state.lastReportTime) >= suppressionReminderInterval {
+	// Check if enough time has passed for the next reminder. The interval
+	// grows exponentially with each reported reminder so a multi-hour outage
+	// does not keep emitting one Sentry event every suppressionReminderInterval.
+	if time.Since(state.lastReportTime) >= nextReminderInterval(state.reportCount) {
 		state.lastReportTime = time.Now()
+		state.reportCount++
 		return true
 	}
 
 	return false
+}
+
+// nextReminderInterval returns the wait time before the next reminder, given
+// how many reminders have already been emitted for the current failure streak.
+//
+// reportCount is 1 after the initial failure, which means the first *reminder*
+// (report 2) waits one base interval, the second reminder waits two base
+// intervals, and so on, capped at maxSuppressionReminderInterval.
+//
+// Schedule with defaults (5m base, 2x multiplier, 24h cap):
+//
+//	report 2: 5m  (5 * 2^0)
+//	report 3: 10m (5 * 2^1)
+//	report 4: 20m (5 * 2^2)
+//	report 5: 40m
+//	report 6: 80m
+//	...       capped at 24h
+func nextReminderInterval(reportCount int) time.Duration {
+	if reportCount < 1 {
+		return suppressionReminderInterval
+	}
+
+	// Exponential growth in discrete steps via bit-shift. Cap the shift at
+	// a conservative bound to prevent integer overflow; beyond ~20 shifts we
+	// would already be far past maxSuppressionReminderInterval anyway.
+	const maxShift = 20
+	shift := reportCount - 1
+	if shift > maxShift {
+		shift = maxShift
+	}
+
+	multiplier := int64(1) << shift
+	// Only allow the configured multiplier base to shape growth: e.g., with
+	// reminderIntervalMultiplier=2 the multiplier is exactly 2^shift. Keeping
+	// it configurable avoids hard-coding the factor in two places.
+	if reminderIntervalMultiplier != 2 && shift > 0 {
+		multiplier = 1
+		for range shift {
+			multiplier *= int64(reminderIntervalMultiplier)
+			if multiplier < 0 || time.Duration(multiplier)*suppressionReminderInterval > maxSuppressionReminderInterval {
+				return maxSuppressionReminderInterval
+			}
+		}
+	}
+
+	interval := time.Duration(multiplier) * suppressionReminderInterval
+	if interval <= 0 || interval > maxSuppressionReminderInterval {
+		return maxSuppressionReminderInterval
+	}
+	return interval
 }
 
 // RecordFailure records a failure for a provider without checking whether to report.

--- a/internal/notification/error_suppressor_test.go
+++ b/internal/notification/error_suppressor_test.go
@@ -2,6 +2,7 @@ package notification
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -142,6 +143,81 @@ func TestErrorSuppressor_SingleFailureRecoveryNoTelemetry(t *testing.T) {
 
 	// Should NOT have captured a recovery event (only 1 failure, no suppression)
 	assert.Empty(t, reporter.events)
+}
+
+// TestNextReminderInterval_ExponentialBackoff verifies the schedule produced
+// by nextReminderInterval against the documented 5m/10m/20m/40m/... ramp with
+// the configured 24h cap. Using a direct unit test here (instead of exercising
+// ShouldReport with synctest) keeps the assertions on the pure math, so a
+// regression in the formula will surface immediately.
+func TestNextReminderInterval_ExponentialBackoff(t *testing.T) {
+	t.Parallel()
+
+	// Expected schedule derived from the constants in error_suppressor.go:
+	// base = 5m, multiplier = 2, cap = 24h.
+	tests := []struct {
+		name        string
+		reportCount int
+		want        time.Duration
+	}{
+		{"below_minimum_returns_base", 0, suppressionReminderInterval},
+		{"first_reminder_is_base", 1, 5 * time.Minute},
+		{"second_reminder_doubles", 2, 10 * time.Minute},
+		{"third_reminder_doubles_again", 3, 20 * time.Minute},
+		{"fourth_reminder_doubles_again", 4, 40 * time.Minute},
+		{"very_high_count_caps_at_max", 100, maxSuppressionReminderInterval},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := nextReminderInterval(tc.reportCount)
+			assert.Equal(t, tc.want, got,
+				"reportCount=%d: want %v, got %v", tc.reportCount, tc.want, got)
+		})
+	}
+}
+
+// TestErrorSuppressor_BackoffGrowsPerReminder checks that ShouldReport defers
+// a second reminder until the exponential schedule has elapsed. We manipulate
+// lastReportTime directly because running for real would take 5+ minutes.
+func TestErrorSuppressor_BackoffGrowsPerReminder(t *testing.T) {
+	t.Parallel()
+
+	suppressor := NewErrorSuppressor(nil, &NoopTelemetryReporter{})
+
+	// First failure is always reported and sets reportCount=1.
+	require.True(t, suppressor.ShouldReport("webhook-1"))
+
+	// Second failure within the first interval stays suppressed.
+	require.False(t, suppressor.ShouldReport("webhook-1"),
+		"consecutive failures inside the base interval must be suppressed")
+
+	// Rewind lastReportTime so the base interval appears to have elapsed;
+	// reportCount is still 1 so the next allowed report is exactly at
+	// nextReminderInterval(1) = base.
+	suppressor.mu.Lock()
+	state := suppressor.states["webhook-1"]
+	require.NotNil(t, state, "state should exist after ShouldReport")
+	require.Equal(t, 1, state.reportCount)
+	state.lastReportTime = time.Now().Add(-suppressionReminderInterval - time.Second)
+	suppressor.mu.Unlock()
+
+	// Now the second reminder should fire, advancing reportCount to 2.
+	require.True(t, suppressor.ShouldReport("webhook-1"),
+		"reminder should fire once the base interval elapses")
+
+	// A third failure *just* after the base interval must still be suppressed
+	// because the schedule has doubled to 2*base for reportCount=2.
+	suppressor.mu.Lock()
+	state = suppressor.states["webhook-1"]
+	require.Equal(t, 2, state.reportCount,
+		"reportCount must advance after a reminder is emitted")
+	state.lastReportTime = time.Now().Add(-(suppressionReminderInterval + time.Second))
+	suppressor.mu.Unlock()
+
+	assert.False(t, suppressor.ShouldReport("webhook-1"),
+		"reminder must be deferred because the interval has doubled")
 }
 
 // captureTelemetryReporter captures telemetry events for testing.

--- a/internal/notification/error_suppressor_test.go
+++ b/internal/notification/error_suppressor_test.go
@@ -195,13 +195,16 @@ func TestErrorSuppressor_BackoffGrowsPerReminder(t *testing.T) {
 
 	// Rewind lastReportTime so the base interval appears to have elapsed;
 	// reportCount is still 1 so the next allowed report is exactly at
-	// nextReminderInterval(1) = base.
-	suppressor.mu.Lock()
-	state := suppressor.states["webhook-1"]
-	require.NotNil(t, state, "state should exist after ShouldReport")
-	require.Equal(t, 1, state.reportCount)
-	state.lastReportTime = time.Now().Add(-suppressionReminderInterval - time.Second)
-	suppressor.mu.Unlock()
+	// nextReminderInterval(1) = base. Scope the lock in a closure so defer
+	// releases it before the next ShouldReport call (which also takes the lock).
+	func() {
+		suppressor.mu.Lock()
+		defer suppressor.mu.Unlock()
+		state := suppressor.states["webhook-1"]
+		require.NotNil(t, state, "state should exist after ShouldReport")
+		require.Equal(t, 1, state.reportCount)
+		state.lastReportTime = time.Now().Add(-suppressionReminderInterval - time.Second)
+	}()
 
 	// Now the second reminder should fire, advancing reportCount to 2.
 	require.True(t, suppressor.ShouldReport("webhook-1"),
@@ -209,12 +212,14 @@ func TestErrorSuppressor_BackoffGrowsPerReminder(t *testing.T) {
 
 	// A third failure *just* after the base interval must still be suppressed
 	// because the schedule has doubled to 2*base for reportCount=2.
-	suppressor.mu.Lock()
-	state = suppressor.states["webhook-1"]
-	require.Equal(t, 2, state.reportCount,
-		"reportCount must advance after a reminder is emitted")
-	state.lastReportTime = time.Now().Add(-(suppressionReminderInterval + time.Second))
-	suppressor.mu.Unlock()
+	func() {
+		suppressor.mu.Lock()
+		defer suppressor.mu.Unlock()
+		state := suppressor.states["webhook-1"]
+		require.Equal(t, 2, state.reportCount,
+			"reportCount must advance after a reminder is emitted")
+		state.lastReportTime = time.Now().Add(-(suppressionReminderInterval + time.Second))
+	}()
 
 	assert.False(t, suppressor.ShouldReport("webhook-1"),
 		"reminder must be deferred because the interval has doubled")


### PR DESCRIPTION
## Summary

Two related changes that together reduce Sentry noise from external-service failures:

### BirdWeather circuit breaker
Wrap `UploadSoundscape` and `PostDetection` with the existing `notification.PushCircuitBreaker`. Transient upstream outages (DNS, TLS timeouts, 504s, connection resets) previously produced one Sentry event per detection — one live Sentry group alone surfaced 560+ events across six sub-groups.

Config: 5 consecutive failures trip the breaker, 10-minute reset, 1 probe in half-open. `Publish()` handles `ErrCircuitBreakerOpen` before transient-error classification so the short-circuit state logs at debug level and is suppressed from Sentry via `shouldReportToSentry`'s `CategoryLimit` filter (extended from `notification` to also cover `birdweather`).

### Webhook suppressor exponential backoff
`ErrorSuppressor` now grows the reminder interval exponentially per reported reminder (5m → 10m → 20m → … capped at 24h). A single consistently-failing webhook emitted 203 Sentry events over 90 days because the fixed 5-minute reminder kept re-firing for the entire outage. With exponential growth the same outage drops to roughly a dozen events.

## Details

- `internal/birdweather/circuit_breaker.go` (new): `callWithCircuitBreaker`, `isCircuitBreakerOpen`, `CircuitBreakerState()`. Named constants (`BwMaxConsecutiveFailures`, `BwResetTimeout`, `BwHalfOpenMaxRequests`). Reuses `notification.PushCircuitBreaker` — no duplicate state machine.
- `internal/birdweather/birdweather_client.go`: `BwClient` gains a `circuitBreaker` field attached in `New()`. Both upload paths wrap their `HTTPClient.Do`/`.Post` call in the helper; `nil`-breaker path degrades gracefully for legacy test literals.
- `internal/notification/error_suppressor.go`: `nextReminderInterval(reportCount)` (bit-shifted exponential with 24h cap). `providerErrorState` gains `reportCount` tracked under the existing suppressor mutex.
- `internal/errors/telemetry_integration.go`: extends `CategoryLimit` filter to include both `notification` and `birdweather` components. Other `CategoryLimit` producers (eBird quota, job queue overflow, spectrogram pre-render) still reach Sentry.

## Test Plan

- [x] `go test -race ./internal/birdweather/... ./internal/notification/... ./internal/errors/...` — PASS
- [x] Closed → Open → Half-Open → Closed state transitions verified
- [x] Transport-level failures (connection hijack) trip the breaker same as upstream 5xx
- [x] Exponential backoff schedule verified end-to-end via manipulated `lastReportTime`
- [x] `golangci-lint run -v` — 0 issues
- [x] CodeRabbit local review — 1 finding (manual mutex unlock in test) — addressed with scoped-defer closure
- [x] Downstream packages (`internal/analysis/processor`, `internal/api/v2`) — tests pass

## Out of scope (follow-up candidates)

Other outbound HTTP clients without circuit breakers: `weather` (openweather/yrno/wunderground), `imageprovider/wikipedia.go`, `ebird/client.go`. None are currently Sentry hotspots.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic circuit breaker for BirdWeather API calls to short‑circuit requests during upstream failures.

* **Improvements**
  * Treats validation (422) responses as non‑transient and doesn't trip the breaker.
  * Breaker-open and upstream rate-limit outcomes are logged at debug level and treated as retryable throttles, reducing noisy alerts.
  * Timing/telemetry now suppresses warn-level logs for short‑circuited calls; telemetry suppression expanded for notification-tagged breaker events.
  * Failure reminder backoff now grows exponentially.

* **Tests**
  * Added tests for breaker state transitions, failure handling, and exponential backoff.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->