### PR TITLE
fix(analysis): silence MQTT flood and floor jobqueue stop timeout

### DIFF
--- a/internal/analysis/jobqueue/queue.go
+++ b/internal/analysis/jobqueue/queue.go
@@ -27,6 +27,15 @@ const (
 	// ActionStatsTargetSize is the target size after cleanup (with hysteresis margin)
 	// Set to 80% of max to avoid repeated cleanup triggers
 	ActionStatsTargetSize = int(MaxActionStatsEntries * 0.8)
+
+	// MinStopTimeout is the minimum grace period enforced inside
+	// StopWithTimeout when a caller passes a zero or negative timeout. The
+	// canonical caller (processor shutdown) already floors the timeout at
+	// its own MinJobQueueGracePeriod, but this constant provides a safety
+	// net for any future caller and prevents a 0s select-case fallthrough
+	// that would report "timed out waiting for jobs to complete after 0s"
+	// to telemetry even though the shutdown is behaving correctly.
+	MinStopTimeout = 500 * time.Millisecond
 )
 
 // JobQueue manages a queue of jobs that can be retried
@@ -125,8 +134,20 @@ func (q *JobQueue) Stop() error {
 	return q.StopWithTimeout(10 * time.Second)
 }
 
-// StopWithTimeout stops the job queue processing with a timeout
+// StopWithTimeout stops the job queue processing with a timeout.
+//
+// If the supplied timeout is zero or negative, it is silently floored to
+// MinStopTimeout. This matters during shutdown: callers commonly derive the
+// timeout from context.Deadline()-time.Now(), which can already be
+// non-positive by the time Stop runs. Without a floor, the select below
+// returns immediately with a "timed out waiting for jobs to complete after
+// 0s" error that gets reported to telemetry even though the shutdown is
+// behaving correctly.
 func (q *JobQueue) StopWithTimeout(timeout time.Duration) error {
+	if timeout <= 0 {
+		timeout = MinStopTimeout
+	}
+
 	q.mu.Lock()
 	if !q.isRunning {
 		q.mu.Unlock()

--- a/internal/analysis/jobqueue/stop_timeout_floor_test.go
+++ b/internal/analysis/jobqueue/stop_timeout_floor_test.go
@@ -17,56 +17,39 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestStopWithTimeout_ZeroTimeout_UsesFloor verifies that a zero timeout
-// is silently floored to MinStopTimeout rather than triggering an immediate
-// telemetry-noisy timeout error.
-func TestStopWithTimeout_ZeroTimeout_UsesFloor(t *testing.T) {
+// TestStopWithTimeout_FloorBehavior is a table-driven test verifying the
+// floor contract: zero or negative timeouts are silently floored to
+// MinStopTimeout, positive timeouts are honored (but still return promptly
+// when no jobs are queued). The elapsed-time assertions use MinStopTimeout
+// so the test stays tied to the production contract rather than a magic
+// number.
+func TestStopWithTimeout_FloorBehavior(t *testing.T) {
 	t.Parallel()
 
-	q := NewJobQueue()
-	q.Start()
+	tests := []struct {
+		name    string
+		timeout time.Duration
+	}{
+		{name: "zero_timeout_is_floored", timeout: 0},
+		{name: "negative_timeout_is_floored", timeout: -5 * time.Second},
+		{name: "positive_timeout_returns_promptly_without_jobs", timeout: 2 * time.Second},
+	}
 
-	start := time.Now()
-	err := q.StopWithTimeout(0)
-	elapsed := time.Since(start)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	// With no running jobs the shutdown completes immediately — the point of
-	// the test is that we did NOT get the "timed out after 0s" error.
-	require.NoError(t, err, "zero timeout must be floored, not propagated as 0s error")
-	// Sanity: should complete fast since there are no jobs to drain.
-	assert.Less(t, elapsed, MinStopTimeout, "with no running jobs, stop is near-instant")
-}
+			q := NewJobQueue()
+			q.Start()
 
-// TestStopWithTimeout_NegativeTimeout_UsesFloor verifies that a negative
-// timeout (which callers can produce with time.Until(past_deadline)) is
-// also floored.
-func TestStopWithTimeout_NegativeTimeout_UsesFloor(t *testing.T) {
-	t.Parallel()
+			start := time.Now()
+			err := q.StopWithTimeout(tt.timeout)
+			elapsed := time.Since(start)
 
-	q := NewJobQueue()
-	q.Start()
-
-	err := q.StopWithTimeout(-5 * time.Second)
-	require.NoError(t, err,
-		"negative timeout must be floored to MinStopTimeout, not propagated as a negative-duration error")
-}
-
-// TestStopWithTimeout_PositiveTimeout_Respected verifies that callers
-// passing a positive timeout still get the exact value (regression guard so
-// the floor does not silently widen large timeouts).
-func TestStopWithTimeout_PositiveTimeout_Respected(t *testing.T) {
-	t.Parallel()
-
-	q := NewJobQueue()
-	q.Start()
-
-	start := time.Now()
-	err := q.StopWithTimeout(2 * time.Second)
-	elapsed := time.Since(start)
-
-	require.NoError(t, err)
-	// No jobs queued so it returns quickly — we just confirm we didn't sleep
-	// for the full 2s waiting for some floor math.
-	assert.Less(t, elapsed, 500*time.Millisecond,
-		"with no running jobs, stop returns promptly regardless of timeout")
+			require.NoError(t, err,
+				"stop must not propagate a timeout error when the queue is idle, regardless of caller timeout")
+			assert.Less(t, elapsed, MinStopTimeout,
+				"with no running jobs, stop should complete faster than MinStopTimeout (got %v)", elapsed)
+		})
+	}
 }

--- a/internal/analysis/jobqueue/stop_timeout_floor_test.go
+++ b/internal/analysis/jobqueue/stop_timeout_floor_test.go
@@ -1,0 +1,72 @@
+// stop_timeout_floor_test.go: tests for the StopWithTimeout zero-timeout
+// safety net.
+//
+// The processor shutdown path derives its timeout from a context deadline
+// that may already be in the past. Without a floor, the select inside
+// StopWithTimeout fires immediately and emits a "timed out waiting for jobs
+// to complete after 0s" telemetry event even though the shutdown is behaving
+// correctly. This test locks the floor contract in place so any caller
+// passing 0 or a negative duration still gets the minimum grace period.
+package jobqueue
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStopWithTimeout_ZeroTimeout_UsesFloor verifies that a zero timeout
+// is silently floored to MinStopTimeout rather than triggering an immediate
+// telemetry-noisy timeout error.
+func TestStopWithTimeout_ZeroTimeout_UsesFloor(t *testing.T) {
+	t.Parallel()
+
+	q := NewJobQueue()
+	q.Start()
+
+	start := time.Now()
+	err := q.StopWithTimeout(0)
+	elapsed := time.Since(start)
+
+	// With no running jobs the shutdown completes immediately — the point of
+	// the test is that we did NOT get the "timed out after 0s" error.
+	require.NoError(t, err, "zero timeout must be floored, not propagated as 0s error")
+	// Sanity: should complete fast since there are no jobs to drain.
+	assert.Less(t, elapsed, MinStopTimeout, "with no running jobs, stop is near-instant")
+}
+
+// TestStopWithTimeout_NegativeTimeout_UsesFloor verifies that a negative
+// timeout (which callers can produce with time.Until(past_deadline)) is
+// also floored.
+func TestStopWithTimeout_NegativeTimeout_UsesFloor(t *testing.T) {
+	t.Parallel()
+
+	q := NewJobQueue()
+	q.Start()
+
+	err := q.StopWithTimeout(-5 * time.Second)
+	require.NoError(t, err,
+		"negative timeout must be floored to MinStopTimeout, not propagated as a negative-duration error")
+}
+
+// TestStopWithTimeout_PositiveTimeout_Respected verifies that callers
+// passing a positive timeout still get the exact value (regression guard so
+// the floor does not silently widen large timeouts).
+func TestStopWithTimeout_PositiveTimeout_Respected(t *testing.T) {
+	t.Parallel()
+
+	q := NewJobQueue()
+	q.Start()
+
+	start := time.Now()
+	err := q.StopWithTimeout(2 * time.Second)
+	elapsed := time.Since(start)
+
+	require.NoError(t, err)
+	// No jobs queued so it returns quickly — we just confirm we didn't sleep
+	// for the full 2s waiting for some floor math.
+	assert.Less(t, elapsed, 500*time.Millisecond,
+		"with no running jobs, stop returns promptly regardless of timeout")
+}

--- a/internal/analysis/processor/mqtt.go
+++ b/internal/analysis/processor/mqtt.go
@@ -3,6 +3,7 @@ package processor
 
 import (
 	"context"
+	stderrors "errors"
 	"time"
 
 	"github.com/tphakala/birdnet-go/internal/audiocore"
@@ -19,6 +20,27 @@ const (
 	// discoveryPublishTimeout is the timeout for publishing discovery messages
 	discoveryPublishTimeout = 30 * time.Second
 )
+
+// ErrMQTTClientNotReady is returned by PublishMQTT when MQTT is enabled in
+// settings but no client reference is available. This happens when:
+//   - initializeMQTT() failed to connect at startup (broker unreachable,
+//     auth failure, TLS issue, etc.)
+//   - The client is between DisconnectMQTTClient() and SetMQTTClient() during
+//     runtime reconfiguration.
+//
+// Callers in streaming publish paths (sound level, etc.) should check for
+// this sentinel with errors.Is and treat it as a graceful no-op to avoid
+// flooding telemetry with identical "client not available" events while
+// the broker is unreachable. The detection pipeline already skips MQTT
+// action creation when the client is nil (see processor.go), so this
+// sentinel is primarily for streaming (non-detection) publishers.
+//
+// This sentinel error is intentionally a plain stderrors.New value so it has
+// no telemetry category attached. Wrapping layers must preserve it with
+// errors.Is-compatible wrapping (fmt.Errorf("...: %w", err) or the internal
+// errors builder's New() which chains cause) so callers can detect and
+// silently drop publishes while the broker is unreachable.
+var ErrMQTTClientNotReady = stderrors.New("MQTT client not ready")
 
 // GetMQTTClient safely returns the current MQTT client
 func (p *Processor) GetMQTTClient() mqtt.Client {
@@ -48,6 +70,17 @@ func (p *Processor) DisconnectMQTTClient() {
 
 // PublishMQTT safely publishes a message using the MQTT client if available.
 // Does NOT pre-check IsConnected() to avoid TOCTOU race (GitHub #2397).
+//
+// When MQTT is enabled in settings but no client reference is available
+// (initializeMQTT() failed at startup, or between disconnect and reconfigure),
+// this returns ErrMQTTClientNotReady. Streaming publishers that run on a
+// timer (sound level publisher, etc.) should check for this sentinel with
+// errors.Is and silently skip to avoid flooding telemetry. See
+// internal/analysis/sound_level.go for the canonical caller pattern.
+//
+// The returned error is intentionally NOT tagged with a telemetry category:
+// the sentinel is filtered at the caller, but if it leaks through, it still
+// has no CategoryMQTTPublish tag so it will not be reported to Sentry.
 func (p *Processor) PublishMQTT(ctx context.Context, topic, payload string) error {
 	p.mqttMutex.RLock()
 	client := p.MqttClient
@@ -56,11 +89,16 @@ func (p *Processor) PublishMQTT(ctx context.Context, topic, payload string) erro
 	if client != nil {
 		return client.Publish(ctx, topic, payload)
 	}
-	return errors.Newf("MQTT client not available").
-		Component("analysis.processor").
-		Category(errors.CategoryMQTTPublish).
-		Context("operation", "publish_mqtt").
-		Build()
+	// Emit a single warn log per process lifetime so operators learn MQTT is
+	// configured but not reachable. Subsequent attempts are silent — the
+	// sentinel is all the caller needs to decide to skip.
+	p.mqttNotReadyWarnOnce.Do(func() {
+		GetLogger().Warn(
+			"MQTT publish suppressed: client not ready (further suppressed publishes are silent)",
+			logger.String("topic", topic),
+			logger.String("operation", "publish_mqtt_not_ready"))
+	})
+	return ErrMQTTClientNotReady
 }
 
 // initializeMQTT initializes the MQTT client if enabled in settings

--- a/internal/analysis/processor/mqtt.go
+++ b/internal/analysis/processor/mqtt.go
@@ -21,8 +21,9 @@ const (
 	discoveryPublishTimeout = 30 * time.Second
 )
 
-// ErrMQTTClientNotReady is returned by PublishMQTT when MQTT is enabled in
-// settings but no client reference is available. This happens when:
+// ErrMQTTClientNotReady is returned by PublishMQTT whenever the MQTT client
+// reference is nil, regardless of whether MQTT is enabled in settings. In
+// practice this happens when MQTT is configured but:
 //   - initializeMQTT() failed to connect at startup (broker unreachable,
 //     auth failure, TLS issue, etc.)
 //   - The client is between DisconnectMQTTClient() and SetMQTTClient() during
@@ -71,10 +72,10 @@ func (p *Processor) DisconnectMQTTClient() {
 // PublishMQTT safely publishes a message using the MQTT client if available.
 // Does NOT pre-check IsConnected() to avoid TOCTOU race (GitHub #2397).
 //
-// When MQTT is enabled in settings but no client reference is available
-// (initializeMQTT() failed at startup, or between disconnect and reconfigure),
-// this returns ErrMQTTClientNotReady. Streaming publishers that run on a
-// timer (sound level publisher, etc.) should check for this sentinel with
+// When the MQTT client reference is nil (initializeMQTT() failed at startup,
+// or the client is between DisconnectMQTTClient() and SetMQTTClient()), this
+// returns ErrMQTTClientNotReady. Streaming publishers that run on a timer
+// (sound level publisher, etc.) should check for this sentinel with
 // errors.Is and silently skip to avoid flooding telemetry. See
 // internal/analysis/sound_level.go for the canonical caller pattern.
 //

--- a/internal/analysis/processor/mqtt_not_ready_test.go
+++ b/internal/analysis/processor/mqtt_not_ready_test.go
@@ -1,0 +1,99 @@
+// mqtt_not_ready_test.go: tests for the PublishMQTT sentinel-error path.
+//
+// When MQTT is enabled in settings but no client reference is available
+// (initial connect failed, or between disconnect and reconfigure),
+// PublishMQTT must return the ErrMQTTClientNotReady sentinel WITHOUT building
+// a telemetry-tagged error. Streaming publishers that run on a timer detect
+// the sentinel and silently skip to avoid flooding Sentry.
+package processor
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPublishMQTT_NilClient_ReturnsSentinel verifies that PublishMQTT returns
+// ErrMQTTClientNotReady (and not a category-tagged error) when no client
+// reference has been set. This is the core fix for the "MQTT client not
+// available" Sentry flood reported when the broker is unreachable at startup.
+func TestPublishMQTT_NilClient_ReturnsSentinel(t *testing.T) {
+	t.Parallel()
+
+	p := &Processor{}
+
+	err := p.PublishMQTT(t.Context(), "birdnet/topic", "payload")
+	require.Error(t, err, "PublishMQTT must return an error when client is nil")
+	assert.ErrorIs(t, err, ErrMQTTClientNotReady,
+		"error must be identifiable as ErrMQTTClientNotReady (got %v)", err)
+}
+
+// TestPublishMQTT_NilClient_WarnsOnlyOnce verifies that the one-shot warn
+// log fires at most once across concurrent callers. This prevents log floods
+// when the MQTT broker is unreachable but enabled in settings.
+func TestPublishMQTT_NilClient_WarnsOnlyOnce(t *testing.T) {
+	t.Parallel()
+
+	p := &Processor{}
+
+	// Fire many concurrent publish attempts — the sync.Once guarantee is the
+	// contract we are verifying. If race-detector complains here, we have
+	// a real concurrency bug.
+	const goroutines = 32
+	const callsPer = 50
+	var wg sync.WaitGroup
+	ctx := t.Context()
+	for range goroutines {
+		wg.Go(func() {
+			for range callsPer {
+				err := p.PublishMQTT(ctx, "t", "p")
+				assert.ErrorIs(t, err, ErrMQTTClientNotReady)
+			}
+		})
+	}
+	wg.Wait()
+
+	// Confirm the sentinel is still returned after the once has fired —
+	// the behavior must be idempotent and not degrade.
+	err := p.PublishMQTT(t.Context(), "t", "p")
+	assert.ErrorIs(t, err, ErrMQTTClientNotReady)
+}
+
+// TestPublishMQTT_WithClient_DelegatesToClient verifies that when a client
+// is set, PublishMQTT delegates rather than returning the sentinel. This is
+// a regression guard to make sure the fix doesn't accidentally short-circuit
+// the happy path.
+func TestPublishMQTT_WithClient_DelegatesToClient(t *testing.T) {
+	t.Parallel()
+
+	mockClient := NewMockMQTTClient()
+	p := &Processor{}
+	p.SetMQTTClient(mockClient)
+
+	err := p.PublishMQTT(t.Context(), "birdnet/topic", "hello")
+	require.NoError(t, err)
+	assert.Equal(t, 1, mockClient.GetPublishCalls(), "mock publish must be invoked once")
+	assert.Equal(t, "birdnet/topic", mockClient.GetPublishedTopic())
+	assert.Equal(t, "hello", mockClient.GetPublishedPayload())
+}
+
+// TestPublishMQTT_SetThenClear_ReturnsSentinel verifies the reconfigure-path
+// race (between DisconnectMQTTClient and SetMQTTClient) does not emit a
+// category-tagged error. The reconfigure window is exactly when bursts of
+// sound-level publishes would otherwise be misreported to Sentry.
+func TestPublishMQTT_SetThenClear_ReturnsSentinel(t *testing.T) {
+	t.Parallel()
+
+	p := &Processor{}
+	mockClient := NewMockMQTTClient()
+	p.SetMQTTClient(mockClient)
+
+	// Simulate DisconnectMQTTClient clearing the reference.
+	p.DisconnectMQTTClient()
+
+	err := p.PublishMQTT(t.Context(), "t", "p")
+	assert.ErrorIs(t, err, ErrMQTTClientNotReady,
+		"post-disconnect publishes must return the sentinel, not a telemetry error")
+}

--- a/internal/analysis/processor/processor.go
+++ b/internal/analysis/processor/processor.go
@@ -56,45 +56,46 @@ const MinJobQueueGracePeriod = 500 * time.Millisecond
 
 // Processor represents the main processing unit for audio analysis.
 type Processor struct {
-	Settings            *conf.Settings
-	Ds                  datastore.Interface           // Legacy - to be removed after migration
-	Repo                datastore.DetectionRepository // New - preferred for detection operations
-	Bn                  *classifier.Orchestrator
-	log                 logger.Logger // Logger inherited from analysis package with "processor" child module
-	BwClient            *birdweather.BwClient
-	bwClientMutex       sync.RWMutex // Mutex to protect BwClient access
-	MqttClient          mqtt.Client
-	mqttMutex           sync.RWMutex // Mutex to protect MQTT client access
-	BirdImageCache      *imageprovider.BirdImageCache
-	EventTracker        *EventTracker
-	eventTrackerMu      sync.RWMutex            // Mutex to protect EventTracker access
-	NewSpeciesTracker   *species.SpeciesTracker // Tracks new species detections
-	speciesTrackerMu    sync.RWMutex            // Mutex to protect NewSpeciesTracker access
-	lastSyncAttempt     time.Time               // Last time sync was attempted
-	syncMutex           sync.Mutex              // Mutex to protect sync operations
-	syncInProgress      atomic.Bool             // Flag to prevent overlapping syncs
-	LastDogDetection    map[string]time.Time    // keep track of dog barks per audio source
-	LastHumanDetection  map[string]time.Time    // keep track of human vocal per audio source
-	Metrics             *observability.Metrics
-	DynamicThresholds   map[string]*DynamicThreshold
-	thresholdsMutex     sync.RWMutex        // Mutex to protect access to DynamicThresholds
-	pendingResets       map[string]struct{} // Species names pending reset, protected by thresholdsMutex
-	pendingResetAll     bool                // True if a full reset is pending, protected by thresholdsMutex
-	pendingDetections   map[string]PendingDetection
-	pendingMutex        sync.RWMutex // RWMutex to protect access to pendingDetections (RLock for snapshots)
-	lastDogDetectionLog map[string]time.Time
-	dogDetectionMutex   sync.Mutex
-	detectionMutex      sync.RWMutex // Mutex to protect LastDogDetection and LastHumanDetection maps
-	controlChan         chan string
-	JobQueue            *jobqueue.JobQueue // Queue for managing job retries
-	workerCancel        context.CancelFunc // Function to cancel worker goroutines
-	thresholdsCtx       context.Context    // Context for threshold persistence/cleanup goroutines
-	thresholdsCancel    context.CancelFunc // Function to cancel threshold persistence/cleanup goroutines
-	flusherCtx          context.Context    // Context for pending detections flusher goroutine
-	flusherCancel       context.CancelFunc // Function to cancel flusher goroutine
-	preRenderer         PreRendererSubmit  // Spectrogram pre-renderer for background generation
-	preRendererOnce     sync.Once          // Ensures pre-renderer is initialized only once
-	startOnce           sync.Once          // Ensures Start() is called only once
+	Settings             *conf.Settings
+	Ds                   datastore.Interface           // Legacy - to be removed after migration
+	Repo                 datastore.DetectionRepository // New - preferred for detection operations
+	Bn                   *classifier.Orchestrator
+	log                  logger.Logger // Logger inherited from analysis package with "processor" child module
+	BwClient             *birdweather.BwClient
+	bwClientMutex        sync.RWMutex // Mutex to protect BwClient access
+	MqttClient           mqtt.Client
+	mqttMutex            sync.RWMutex // Mutex to protect MQTT client access
+	mqttNotReadyWarnOnce sync.Once    // Ensures the "client not ready" warning logs at most once per process to avoid flood
+	BirdImageCache       *imageprovider.BirdImageCache
+	EventTracker         *EventTracker
+	eventTrackerMu       sync.RWMutex            // Mutex to protect EventTracker access
+	NewSpeciesTracker    *species.SpeciesTracker // Tracks new species detections
+	speciesTrackerMu     sync.RWMutex            // Mutex to protect NewSpeciesTracker access
+	lastSyncAttempt      time.Time               // Last time sync was attempted
+	syncMutex            sync.Mutex              // Mutex to protect sync operations
+	syncInProgress       atomic.Bool             // Flag to prevent overlapping syncs
+	LastDogDetection     map[string]time.Time    // keep track of dog barks per audio source
+	LastHumanDetection   map[string]time.Time    // keep track of human vocal per audio source
+	Metrics              *observability.Metrics
+	DynamicThresholds    map[string]*DynamicThreshold
+	thresholdsMutex      sync.RWMutex        // Mutex to protect access to DynamicThresholds
+	pendingResets        map[string]struct{} // Species names pending reset, protected by thresholdsMutex
+	pendingResetAll      bool                // True if a full reset is pending, protected by thresholdsMutex
+	pendingDetections    map[string]PendingDetection
+	pendingMutex         sync.RWMutex // RWMutex to protect access to pendingDetections (RLock for snapshots)
+	lastDogDetectionLog  map[string]time.Time
+	dogDetectionMutex    sync.Mutex
+	detectionMutex       sync.RWMutex // Mutex to protect LastDogDetection and LastHumanDetection maps
+	controlChan          chan string
+	JobQueue             *jobqueue.JobQueue // Queue for managing job retries
+	workerCancel         context.CancelFunc // Function to cancel worker goroutines
+	thresholdsCtx        context.Context    // Context for threshold persistence/cleanup goroutines
+	thresholdsCancel     context.CancelFunc // Function to cancel threshold persistence/cleanup goroutines
+	flusherCtx           context.Context    // Context for pending detections flusher goroutine
+	flusherCancel        context.CancelFunc // Function to cancel flusher goroutine
+	preRenderer          PreRendererSubmit  // Spectrogram pre-renderer for background generation
+	preRendererOnce      sync.Once          // Ensures pre-renderer is initialized only once
+	startOnce            sync.Once          // Ensures Start() is called only once
 	// SSE related fields
 	SSEBroadcaster      func(note *datastore.Note, birdImage *imageprovider.BirdImage) error // Function to broadcast detection via SSE
 	sseBroadcasterMutex sync.RWMutex                                                         // Mutex to protect SSE broadcaster access

--- a/internal/analysis/sound_level.go
+++ b/internal/analysis/sound_level.go
@@ -3,6 +3,7 @@ package analysis
 import (
 	"context"
 	"encoding/json"
+	stderrors "errors"
 	"fmt"
 	"math"
 	"strconv"
@@ -392,6 +393,26 @@ func publishSoundLevelToMQTT(soundData soundlevel.SoundLevelData, proc *processo
 	defer cancel()
 
 	if err := proc.PublishMQTT(ctx, topic, string(jsonData)); err != nil {
+		// Sentinel case: MQTT enabled but client not ready (startup race or
+		// connect failure). Silently drop so we don't flood Sentry with
+		// identical "client not available" events every sound-level interval.
+		// The processor emits a single warn log on the first occurrence;
+		// subsequent drops are silent by design.
+		if stderrors.Is(err, processor.ErrMQTTClientNotReady) {
+			if settings.Realtime.Audio.SoundLevel.Debug {
+				getSoundLevelLogger().Debug("sound level MQTT publish skipped: client not ready",
+					logger.String("source", soundData.Source),
+					logger.String("name", soundData.Name),
+					logger.String("topic", topic))
+			}
+			// Record a lightweight metric so the condition is still observable
+			// via Prometheus without generating Sentry events.
+			if proc.Metrics != nil && proc.Metrics.SoundLevel != nil {
+				proc.Metrics.SoundLevel.RecordSoundLevelPublishingError(soundData.Source, soundData.Name, "mqtt", "client_not_ready")
+			}
+			return nil
+		}
+
 		// Record error metric
 		if proc.Metrics != nil && proc.Metrics.SoundLevel != nil {
 			proc.Metrics.SoundLevel.RecordSoundLevelPublishingError(soundData.Source, soundData.Name, "mqtt", "publish_error")

--- a/internal/analysis/sound_level_not_ready_test.go
+++ b/internal/analysis/sound_level_not_ready_test.go
@@ -1,0 +1,106 @@
+// sound_level_not_ready_test.go: tests that the sound-level MQTT publisher
+// silently skips when the processor reports MQTT as not ready.
+//
+// Without the fix, every sound-level interval would emit a telemetry-tagged
+// "MQTT client not available" error and flood Sentry (several hundred events
+// over weeks observed in production from faulty broker configurations).
+package analysis
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/analysis/processor"
+	"github.com/tphakala/birdnet-go/internal/audiocore/soundlevel"
+	"github.com/tphakala/birdnet-go/internal/conf"
+)
+
+// makeValidSoundLevelData returns a well-formed SoundLevelData value suitable
+// for driving publishSoundLevelToMQTT past validation.
+func makeValidSoundLevelData() soundlevel.SoundLevelData {
+	return soundlevel.SoundLevelData{
+		Timestamp: time.Now(),
+		Source:    "test-source",
+		Name:      "test-device",
+		Duration:  10,
+		OctaveBands: map[string]soundlevel.OctaveBandData{
+			"1000_Hz": {
+				CenterFreq:  1000,
+				Min:         -60.5,
+				Max:         -40.2,
+				Mean:        -50.3,
+				SampleCount: 100,
+			},
+		},
+	}
+}
+
+// TestPublishSoundLevelToMQTT_ClientNotReady_Silent verifies that when the
+// processor has no MQTT client (initializeMQTT failed or reconfiguration is
+// in progress), the sound-level publisher:
+//
+//  1. Returns nil (no error escalation to the caller's log.Error path)
+//  2. Does NOT wrap the sentinel with CategorySoundLevel (which would hit
+//     Sentry via the errors package telemetry integration)
+func TestPublishSoundLevelToMQTT_ClientNotReady_Silent(t *testing.T) {
+	// Not parallel: conf.SetTestSettings mutates package-global state.
+	settings := &conf.Settings{}
+	settings.Realtime.MQTT.Enabled = true
+	settings.Realtime.MQTT.Topic = "birdnet/test"
+	conf.SetTestSettings(settings)
+
+	// Build a processor whose MqttClient reference is nil (the exact startup
+	// failure condition reported by Sentry when the broker connect fails).
+	proc := &processor.Processor{
+		Settings: settings,
+	}
+
+	soundData := makeValidSoundLevelData()
+
+	err := publishSoundLevelToMQTT(soundData, proc)
+	require.NoError(t, err,
+		"publishSoundLevelToMQTT must return nil when client is not ready, "+
+			"not a category-tagged error that would flood Sentry")
+}
+
+// TestPublishSoundLevelToMQTT_ClientNotReady_Idempotent verifies that repeated
+// calls with a nil client remain silent and do not leak an error up to the
+// caller. This is the scenario that generates high-volume telemetry floods
+// when the broker stays unreachable.
+func TestPublishSoundLevelToMQTT_ClientNotReady_Idempotent(t *testing.T) {
+	// Not parallel: conf.SetTestSettings mutates package-global state.
+	settings := &conf.Settings{}
+	settings.Realtime.MQTT.Enabled = true
+	settings.Realtime.MQTT.Topic = "birdnet/test"
+	conf.SetTestSettings(settings)
+
+	proc := &processor.Processor{
+		Settings: settings,
+	}
+
+	// Simulate many sound-level intervals — each call must remain a silent
+	// no-op at the publisher level regardless of how many have come before.
+	for i := range 500 {
+		err := publishSoundLevelToMQTT(makeValidSoundLevelData(), proc)
+		assert.NoError(t, err, "call %d: must remain silent after first suppression", i)
+	}
+}
+
+// TestPublishSoundLevelToMQTT_MQTTDisabled_StillNoError verifies the
+// pre-existing "MQTT disabled" early return is not affected by the fix.
+func TestPublishSoundLevelToMQTT_MQTTDisabled_StillNoError(t *testing.T) {
+	// Not parallel: conf.SetTestSettings mutates package-global state.
+	settings := &conf.Settings{}
+	settings.Realtime.MQTT.Enabled = false // disabled
+	conf.SetTestSettings(settings)
+
+	proc := &processor.Processor{
+		Settings: settings,
+	}
+
+	err := publishSoundLevelToMQTT(makeValidSoundLevelData(), proc)
+	require.NoError(t, err,
+		"when MQTT is disabled the publisher returns nil (pre-existing behavior)")
+}

--- a/internal/analysis/sound_level_not_ready_test.go
+++ b/internal/analysis/sound_level_not_ready_test.go
@@ -46,6 +46,9 @@ func makeValidSoundLevelData() soundlevel.SoundLevelData {
 //     Sentry via the errors package telemetry integration)
 func TestPublishSoundLevelToMQTT_ClientNotReady_Silent(t *testing.T) {
 	// Not parallel: conf.SetTestSettings mutates package-global state.
+	prev := conf.GetSettings()
+	t.Cleanup(func() { conf.SetTestSettings(prev) })
+
 	settings := &conf.Settings{}
 	settings.Realtime.MQTT.Enabled = true
 	settings.Realtime.MQTT.Topic = "birdnet/test"
@@ -71,6 +74,9 @@ func TestPublishSoundLevelToMQTT_ClientNotReady_Silent(t *testing.T) {
 // when the broker stays unreachable.
 func TestPublishSoundLevelToMQTT_ClientNotReady_Idempotent(t *testing.T) {
 	// Not parallel: conf.SetTestSettings mutates package-global state.
+	prev := conf.GetSettings()
+	t.Cleanup(func() { conf.SetTestSettings(prev) })
+
 	settings := &conf.Settings{}
 	settings.Realtime.MQTT.Enabled = true
 	settings.Realtime.MQTT.Topic = "birdnet/test"
@@ -92,6 +98,9 @@ func TestPublishSoundLevelToMQTT_ClientNotReady_Idempotent(t *testing.T) {
 // pre-existing "MQTT disabled" early return is not affected by the fix.
 func TestPublishSoundLevelToMQTT_MQTTDisabled_StillNoError(t *testing.T) {
 	// Not parallel: conf.SetTestSettings mutates package-global state.
+	prev := conf.GetSettings()
+	t.Cleanup(func() { conf.SetTestSettings(prev) })
+
 	settings := &conf.Settings{}
 	settings.Realtime.MQTT.Enabled = false // disabled
 	conf.SetTestSettings(settings)


### PR DESCRIPTION
## Summary

Two surgical fixes for analysis-pipeline lifecycle edges:

### MQTT "client not available" flood
A live Sentry group surfaced 290 events/month with the pattern "MQTT client not available". Root cause: when `initializeMQTT()` fails at startup (broker unreachable, auth/TLS failure) or the client is between `DisconnectMQTTClient()` and `SetMQTTClient()` during reconfiguration, `p.MqttClient` is nil. Streaming publishers (sound level, publishing at 10-100/sec) called `PublishMQTT` which built a `CategoryMQTTPublish`-tagged error every time, forwarding each one to Sentry.

Fix: `PublishMQTT` now returns new sentinel `ErrMQTTClientNotReady` (plain `errors.New` — no telemetry category). The streaming publisher in `sound_level.go` checks the sentinel with `errors.Is` and silently drops (records a Prometheus metric `client_not_ready`, debug log only). A `sync.Once` emits a single warn on first occurrence so operators still learn MQTT is configured but unreachable; further attempts are silent by design.

The detection pipeline already gates `MqttAction` creation on `mqttClient != nil`, so this sentinel is only needed for streaming (non-detection) publishers.

### Job queue stop timeout floor
A live Sentry group surfaced the error "timed out waiting for jobs to complete after 0s" when `StopWithTimeout` was called with a zero or negative `time.Duration`. This happens when a caller derives the timeout from `context.Deadline()-time.Now()` and the parent context has already expired by the time `Stop` runs.

The canonical caller (processor shutdown) already floors the timeout at `MinJobQueueGracePeriod`. This PR adds a defensive `MinStopTimeout = 500ms` floor inside `StopWithTimeout` itself so any future caller gets the same safety net.

## Details

- `internal/analysis/processor/mqtt.go`: exported `ErrMQTTClientNotReady` sentinel, `PublishMQTT` returns it when client is nil with a once-per-process warn via new `Processor.mqttNotReadyWarnOnce sync.Once` field.
- `internal/analysis/sound_level.go`: sentinel detection via `errors.Is`, silent drop with Prometheus `publishing_errors{stage="client_not_ready"}` metric, debug log only.
- `internal/analysis/jobqueue/queue.go`: `StopWithTimeout(timeout)` floors `timeout <= 0` to `MinStopTimeout` (500ms).
- `internal/analysis/processor/processor.go`: one new `sync.Once` field on `Processor` — most of the diff is gofmt column realignment after the field insert.

## Test Plan

- [x] `go test -race ./internal/analysis/... ./internal/mqtt/...` — PASS
- [x] `TestPublishMQTT_NilClient_WarnsOnlyOnce` — 32 goroutines × 50 calls under `-race` verifies `sync.Once` contract
- [x] `TestPublishSoundLevelToMQTT_ClientNotReady_Idempotent` — 500 iterations stay silent
- [x] `TestStopWithTimeout_{Zero,Negative,Positive}Timeout` — floor contract
- [x] `golangci-lint run -v ./internal/analysis/... ./internal/mqtt/...` — 0 issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * MQTT publishing now degrades gracefully when the client is unavailable: emits a single warning and returns a non-fatal no-op instead of repeated errors.
  * Shutdown behavior improved with a minimum timeout floor to avoid edge-case blocking on immediate or non-positive timeouts.

* **Tests**
  * Added tests covering MQTT unavailability, one-time warning behavior, idempotent silent publishing, and shutdown timeout flooring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->