### PR TITLE
refactor(notification): add typed Count, fix toast-counted unread, add guest-path tests

### DIFF
--- a/internal/api/v2/dashboard_public_endpoints_test.go
+++ b/internal/api/v2/dashboard_public_endpoints_test.go
@@ -56,8 +56,19 @@ func assertUnauthorized(t *testing.T, rec *httptest.ResponseRecorder, method, pa
 }
 
 // guestGet executes an unauthenticated GET request through the echo instance.
-func guestGet(e *echo.Echo, path string) *httptest.ResponseRecorder {
-	req := httptest.NewRequest(http.MethodGet, path, http.NoBody)
+//
+// The request carries a short deadline so handlers that would otherwise
+// block forever (e.g. the SSE /notifications/stream handler, whose
+// disconnect path keys on the request context) return promptly once the
+// synchronous ServeHTTP call times out on the handler side. Without this,
+// tests that hit /stream hang indefinitely when the notification service
+// is initialized, previously masked because public-reads tests ran before
+// any test initialized the service and fell through to a 503.
+func guestGet(t *testing.T, e *echo.Echo, path string) *httptest.ResponseRecorder {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+	req := httptest.NewRequestWithContext(ctx, http.MethodGet, path, http.NoBody)
 	rec := httptest.NewRecorder()
 	e.ServeHTTP(rec, req)
 	return rec
@@ -93,7 +104,7 @@ func TestNotifications_PublicReadsAllowed(t *testing.T) {
 		"/api/v2/notifications/stream",
 	} {
 		t.Run(path, func(t *testing.T) {
-			rec := guestGet(e, path)
+			rec := guestGet(t, e, path)
 			assertNotUnauthorized(t, rec, path)
 		})
 	}
@@ -169,7 +180,7 @@ func TestNotifications_GuestListFiltersNonDetectionAndToasts(t *testing.T) {
 
 	e := newSettingsAuthTestEnv(t)
 
-	rec := guestGet(e, "/api/v2/notifications?limit=50")
+	rec := guestGet(t, e, "/api/v2/notifications?limit=50")
 	require.Equal(t, http.StatusOK, rec.Code,
 		"guest list must succeed, got: %s", rec.Body.String())
 
@@ -226,7 +237,7 @@ func TestNotifications_GuestUnreadCountIgnoresNonDetectionAndToasts(t *testing.T
 
 	e := newSettingsAuthTestEnv(t)
 
-	rec := guestGet(e, "/api/v2/notifications/unread/count")
+	rec := guestGet(t, e, "/api/v2/notifications/unread/count")
 	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
 
 	var payload struct {
@@ -237,7 +248,7 @@ func TestNotifications_GuestUnreadCountIgnoresNonDetectionAndToasts(t *testing.T
 	// The store may contain fixtures from other tests, so instead of an
 	// absolute equality we assert the count strictly matches the list the
 	// same guest would see.
-	listRec := guestGet(e, "/api/v2/notifications?status=unread&limit=1000")
+	listRec := guestGet(t, e, "/api/v2/notifications?status=unread&limit=1000")
 	require.Equal(t, http.StatusOK, listRec.Code)
 	var listPayload struct {
 		Notifications []*notification.Notification `json:"notifications"`
@@ -295,13 +306,21 @@ func TestNotifications_GuestSSEFiltersNonDetectionAndToasts(t *testing.T) {
 
 	e := newSettingsAuthTestEnv(t)
 	srv := httptest.NewServer(e)
-	t.Cleanup(srv.Close)
+	t.Cleanup(func() {
+		// Force-close active connections before srv.Close blocks waiting
+		// for handlers to return. The SSE handler only detects a client
+		// disconnect on its next heartbeat Write (15s) in HTTP/1.1, so a
+		// plain srv.Close can stall cleanup enough to trip the test
+		// timeout when many SSE tests run in the same process.
+		srv.CloseClientConnections()
+		srv.Close()
+	})
 
-	// cancel must run BEFORE t.Cleanup(wg.Wait) — otherwise the goroutine
+	// cancel must run before t.Cleanup(wg.Wait); otherwise the goroutine
 	// blocked on readSSEEvent would deadlock the cleanup. `defer` runs at
 	// function exit before any t.Cleanup callback, so the request context
-	// is canceled first, unblocking the read loop, then cleanups proceed in
-	// LIFO order (wg.Wait → resp.Body.Close → srv.Close).
+	// is canceled first, unblocking the read loop, then cleanups proceed
+	// in LIFO order (wg.Wait, resp.Body.Close, srv.Close).
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
@@ -358,6 +377,12 @@ func TestNotifications_GuestSSEFiltersNonDetectionAndToasts(t *testing.T) {
 	detectionToast := notification.NewNotification(notification.TypeDetection,
 		notification.PriorityLow, "SSE test toast", "toast body").
 		WithMetadata(notification.MetadataKeyIsToast, true)
+	// sendToastEvent emits the SSE toast id from Metadata["toastId"], not
+	// from the underlying notification ID. Mirror that here so
+	// extractNotificationID can recognize a leaked toast; without it,
+	// extraction returns "" and the fixture-ID gate below would swallow a
+	// regression silently.
+	detectionToast.Metadata["toastId"] = detectionToast.ID
 	require.NoError(t, svc.CreateWithMetadata(detectionToast))
 
 	t.Cleanup(func() {
@@ -467,7 +492,7 @@ func TestStreamsHealth_AllAuthProtected(t *testing.T) {
 		"/api/v2/streams/health/stream",
 	} {
 		t.Run(path, func(t *testing.T) {
-			rec := guestGet(e, path)
+			rec := guestGet(t, e, path)
 			assertUnauthorized(t, rec, http.MethodGet, path)
 		})
 	}
@@ -481,7 +506,7 @@ func TestStreamsHealth_AllAuthProtected(t *testing.T) {
 func TestQuietHours_PublicReadsAllowed(t *testing.T) {
 	e := newSettingsAuthTestEnv(t)
 
-	rec := guestGet(e, "/api/v2/streams/quiet-hours/status")
+	rec := guestGet(t, e, "/api/v2/streams/quiet-hours/status")
 	require.Equal(t, http.StatusOK, rec.Code,
 		"guest must be able to read quiet-hours status, got: %s", rec.Body.String())
 
@@ -513,7 +538,7 @@ func TestQuietHours_PublicReadsAllowed(t *testing.T) {
 func TestQuietHours_NoRawCredentialsInResponse(t *testing.T) {
 	e := newSettingsAuthTestEnv(t)
 
-	rec := guestGet(e, "/api/v2/streams/quiet-hours/status")
+	rec := guestGet(t, e, "/api/v2/streams/quiet-hours/status")
 	body := rec.Body.String()
 
 	// Walk every occurrence of a stream scheme and inspect the authority

--- a/internal/api/v2/dashboard_public_endpoints_test.go
+++ b/internal/api/v2/dashboard_public_endpoints_test.go
@@ -16,12 +16,18 @@
 package api
 
 import (
+	"bufio"
 	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
@@ -240,6 +246,208 @@ func TestNotifications_GuestUnreadCountIgnoresNonDetectionAndToasts(t *testing.T
 
 	assert.Equal(t, len(listPayload.Notifications), payload.UnreadCount,
 		"guest unread count must equal guest-visible unread list length")
+}
+
+// sseEvent is a parsed Server-Sent Event used by the guest SSE filter test.
+type sseEvent struct {
+	Event string
+	Data  string
+}
+
+// readSSEEvent reads one complete SSE event (lines up to the trailing blank
+// line) from r and returns it. Comment lines (":...") are ignored.
+func readSSEEvent(r *bufio.Reader) (sseEvent, error) {
+	var ev sseEvent
+	for {
+		line, err := r.ReadString('\n')
+		if err != nil {
+			return ev, err
+		}
+		trimmed := strings.TrimRight(line, "\r\n")
+		if trimmed == "" {
+			return ev, nil
+		}
+		switch {
+		case strings.HasPrefix(trimmed, ":"):
+			// SSE comment — ignore.
+		case strings.HasPrefix(trimmed, "event:"):
+			ev.Event = strings.TrimSpace(strings.TrimPrefix(trimmed, "event:"))
+		case strings.HasPrefix(trimmed, "data:"):
+			chunk := strings.TrimSpace(strings.TrimPrefix(trimmed, "data:"))
+			if ev.Data == "" {
+				ev.Data = chunk
+			} else {
+				ev.Data += "\n" + chunk
+			}
+		}
+	}
+}
+
+// TestNotifications_GuestSSEFiltersNonDetectionAndToasts drives the
+// /api/v2/notifications/stream handler over a real HTTP connection as a guest
+// and proves the in-loop filter (notifications.go runNotificationEventLoop)
+// drops TypeError and toast-flagged payloads. The list/count tests already
+// cover the REST path — this locks in the SSE path too so that a regression
+// in the guard condition (notif.Type != TypeDetection || isToast) is caught
+// before it reaches the dashboard.
+func TestNotifications_GuestSSEFiltersNonDetectionAndToasts(t *testing.T) {
+	svc := ensureNotificationServiceInitialized(t)
+
+	e := newSettingsAuthTestEnv(t)
+	srv := httptest.NewServer(e)
+	t.Cleanup(srv.Close)
+
+	// cancel must run BEFORE t.Cleanup(wg.Wait) — otherwise the goroutine
+	// blocked on readSSEEvent would deadlock the cleanup. `defer` runs at
+	// function exit before any t.Cleanup callback, so the request context
+	// is canceled first, unblocking the read loop, then cleanups proceed in
+	// LIFO order (wg.Wait → resp.Body.Close → srv.Close).
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet,
+		srv.URL+"/api/v2/notifications/stream", http.NoBody)
+	require.NoError(t, err)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = resp.Body.Close() })
+	require.Equal(t, http.StatusOK, resp.StatusCode,
+		"guest must be able to open SSE stream, got %d", resp.StatusCode)
+
+	events := make(chan sseEvent, 32)
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		defer close(events)
+		reader := bufio.NewReader(resp.Body)
+		for {
+			ev, err := readSSEEvent(reader)
+			if err != nil {
+				// EOF once the context is canceled is the expected exit path.
+				if !errorsIsEOFLike(err) {
+					t.Logf("SSE read stopped: %v", err)
+				}
+				return
+			}
+			select {
+			case events <- ev:
+			case <-ctx.Done():
+				return
+			}
+		}
+	})
+	t.Cleanup(wg.Wait)
+
+	// Wait for the initial handshake event so we know the subscriber is
+	// wired up before we publish fixtures. Without this, Create() may fire
+	// before Subscribe() registers the client and the notification is lost.
+	require.Eventually(t, func() bool {
+		select {
+		case ev := <-events:
+			return ev.Event == sseEventConnected
+		default:
+			return false
+		}
+	}, 2*time.Second, 10*time.Millisecond, "did not receive connected event")
+
+	detection, err := svc.Create(notification.TypeDetection, notification.PriorityHigh,
+		"SSE test detection", "guest-visible body")
+	require.NoError(t, err)
+	adminErr, err := svc.Create(notification.TypeError, notification.PriorityHigh,
+		"SSE test error", "admin-only body")
+	require.NoError(t, err)
+	detectionToast := notification.NewNotification(notification.TypeDetection,
+		notification.PriorityLow, "SSE test toast", "toast body").
+		WithMetadata(notification.MetadataKeyIsToast, true)
+	require.NoError(t, svc.CreateWithMetadata(detectionToast))
+
+	t.Cleanup(func() {
+		for _, n := range []*notification.Notification{detection, adminErr, detectionToast} {
+			if n == nil {
+				continue
+			}
+			_ = svc.Delete(n.ID)
+		}
+	})
+
+	fixtureIDs := map[string]bool{
+		detection.ID:      true,
+		adminErr.ID:       true,
+		detectionToast.ID: true,
+	}
+
+	var sawDetection bool
+	// Drain events until we see the detection or hit the deadline. Any
+	// non-detection fixture that leaks fails the test immediately.
+	deadline := time.After(2 * time.Second)
+drain:
+	for {
+		select {
+		case <-deadline:
+			break drain
+		case ev, ok := <-events:
+			if !ok {
+				break drain
+			}
+			// Only inspect notification/toast events for our fixtures.
+			if ev.Event != "notification" && ev.Event != "toast" {
+				continue
+			}
+			var payload map[string]any
+			if err := json.Unmarshal([]byte(ev.Data), &payload); err != nil {
+				continue
+			}
+			id := extractNotificationID(payload)
+			if id == "" || !fixtureIDs[id] {
+				continue
+			}
+			switch id {
+			case detection.ID:
+				assert.Equal(t, "notification", ev.Event,
+					"detection must arrive as a notification event")
+				sawDetection = true
+			case adminErr.ID:
+				t.Fatalf("guest SSE leaked TypeError notification (id=%s)", id)
+			case detectionToast.ID:
+				t.Fatalf("guest SSE leaked toast notification (id=%s)", id)
+			}
+			if sawDetection {
+				break drain
+			}
+		}
+	}
+
+	assert.True(t, sawDetection,
+		"guest SSE must deliver the plain TypeDetection notification")
+}
+
+// extractNotificationID pulls the notification UUID out of an SSE event
+// payload, handling both the nested "notification" shape used by
+// SSENotificationData and the flat toast payload shape.
+func extractNotificationID(payload map[string]any) string {
+	if id, ok := payload["id"].(string); ok && id != "" {
+		return id
+	}
+	if inner, ok := payload["notification"].(map[string]any); ok {
+		if id, ok := inner["id"].(string); ok {
+			return id
+		}
+	}
+	return ""
+}
+
+// errorsIsEOFLike returns true for the read errors we expect when the SSE
+// stream is closed via context cancellation. Keeps the read goroutine quiet
+// in the common happy path.
+func errorsIsEOFLike(err error) bool {
+	if err == nil {
+		return true
+	}
+	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) ||
+		errors.Is(err, context.Canceled) {
+		return true
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "use of closed network connection")
 }
 
 // ---- streams/health + streams/status (auth-protected) -----------------

--- a/internal/api/v2/notifications.go
+++ b/internal/api/v2/notifications.go
@@ -34,6 +34,9 @@ const (
 	// Endpoints
 	sseEndpoint = "/api/v2/notifications/stream"
 
+	// SSE event names.
+	sseEventConnected = "connected" // Initial handshake event name emitted to every subscriber.
+
 	// Buffer sizes
 	notificationChannelBuffer = 10 // Buffer size for notification channels
 
@@ -443,7 +446,7 @@ func (c *Controller) setupNotificationSSEClient(ctx echo.Context) (*Notification
 	}
 
 	// Send initial connection message
-	if err := c.sendSSEMessage(ctx, "connected", map[string]string{
+	if err := c.sendSSEMessage(ctx, sseEventConnected, map[string]string{
 		"clientId": clientID,
 		"message":  "Connected to notification stream",
 	}); err != nil {
@@ -452,7 +455,7 @@ func (c *Controller) setupNotificationSSEClient(ctx echo.Context) (*Notification
 	}
 
 	if c.metrics != nil && c.metrics.HTTP != nil {
-		c.metrics.HTTP.RecordSSEMessageSent(sseEndpoint, "connected")
+		c.metrics.HTTP.RecordSSEMessageSent(sseEndpoint, sseEventConnected)
 	}
 
 	// Log the connection

--- a/internal/api/v2/notifications.go
+++ b/internal/api/v2/notifications.go
@@ -40,11 +40,6 @@ const (
 	// Rate limits
 	rateLimitRequestsPerWindow = 10 // Maximum requests per rate limit window for notifications (increased from 1 to match other SSE endpoints)
 	rateLimitBurst             = 15 // Rate limit burst allowance (increased to handle quick navigation)
-
-	// guestUnreadCountPageSize is the page size used when counting unread
-	// detection notifications for unauthenticated dashboard viewers. Avoids
-	// the magic 1000 cap while keeping per-iteration memory bounded.
-	guestUnreadCountPageSize = 500
 )
 
 // Test notification constants
@@ -858,38 +853,17 @@ func (c *Controller) GetUnreadCount(ctx echo.Context) error {
 	service := notification.GetService()
 
 	if c.isGuestNotificationRequest(ctx) {
-		// Count unread detection non-toast notifications only. Paginate
-		// through service.List rather than relying on a single large Limit
-		// so the count is exact even if a user has thousands of unread
-		// detections. Toasts are excluded defensively (see processNotifi-
-		// cationEvent): today they are never TypeDetection, but guarding
-		// here avoids a regression if that changes.
-		total := 0
-		offset := 0
-		for {
-			notifications, err := service.List(&notification.FilterOptions{
-				Types:  []notification.Type{notification.TypeDetection},
-				Status: []notification.Status{notification.StatusUnread},
-				Limit:  guestUnreadCountPageSize,
-				Offset: offset,
-			})
-			if err != nil {
-				c.logErrorIfEnabled("failed to list detection notifications for guest count", logger.Error(err))
-				return c.HandleError(ctx, err, "Failed to get unread count", http.StatusInternalServerError)
-			}
-			for _, n := range notifications {
-				if n == nil {
-					continue
-				}
-				if isToast, _ := n.Metadata[notification.MetadataKeyIsToast].(bool); isToast {
-					continue
-				}
-				total++
-			}
-			if len(notifications) < guestUnreadCountPageSize {
-				break
-			}
-			offset += guestUnreadCountPageSize
+		// Count unread detection non-toast notifications only. The store's
+		// matchesFilter excludes toast-flagged entries, so no explicit toast
+		// filter is needed here. service.Count avoids allocating a result
+		// slice, which matters when NotificationBell polls this endpoint.
+		total, err := service.Count(&notification.FilterOptions{
+			Types:  []notification.Type{notification.TypeDetection},
+			Status: []notification.Status{notification.StatusUnread},
+		})
+		if err != nil {
+			c.logErrorIfEnabled("failed to count detection notifications for guest", logger.Error(err))
+			return c.HandleError(ctx, err, "Failed to get unread count", http.StatusInternalServerError)
 		}
 		return ctx.JSON(http.StatusOK, map[string]any{
 			"unreadCount": total,

--- a/internal/api/v2/quiet_hours_test.go
+++ b/internal/api/v2/quiet_hours_test.go
@@ -1,0 +1,166 @@
+// quiet_hours_test.go: Unit tests for buildSuppressedStreamsPayload — the
+// helper that powers the /api/v2/streams/quiet-hours/status response.
+//
+// The guest-facing path replaces raw URLs with opaque "stream-N"
+// placeholders so anonymous dashboard viewers cannot enumerate camera
+// hostnames/ports (PR #2775). These tests lock in:
+//   - the placeholder shape (stream-N with N starting at 1) and count,
+//   - stability across calls on the same input,
+//   - the documented index-shift behavior when a new URL that sorts before
+//     an existing one is added (future hash-based refactor needs to change
+//     this deliberately), and
+//   - that the authenticated path passes URLs through privacy.SanitizeStreamUrl
+//     without leaking credentials.
+
+package api
+
+import (
+	"maps"
+	"regexp"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/privacy"
+)
+
+// streamPlaceholderPattern matches the opaque placeholder keys that the
+// guest path emits. Centralized here so the shape is asserted once.
+var streamPlaceholderPattern = regexp.MustCompile(`^stream-[1-9]\d*$`)
+
+// TestBuildSuppressedStreamsPayload_GuestPlaceholderShape asserts every
+// guest-facing key matches stream-N and the count equals the input count.
+func TestBuildSuppressedStreamsPayload_GuestPlaceholderShape(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   map[string]bool
+	}{
+		{
+			name: "empty",
+			in:   map[string]bool{},
+		},
+		{
+			name: "single stream",
+			in: map[string]bool{
+				"rtsp://user:pass@cam1.lan/stream": true,
+			},
+		},
+		{
+			name: "multiple streams mixed state",
+			in: map[string]bool{
+				"rtsp://user:pass@cam1.lan/stream": true,
+				"rtsp://user:pass@cam2.lan/stream": false,
+				"rtsp://user:pass@cam3.lan/stream": true,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			out := buildSuppressedStreamsPayload(tc.in, true)
+			assert.Len(t, out, len(tc.in),
+				"guest payload must preserve entry count")
+			for key := range out {
+				assert.Regexp(t, streamPlaceholderPattern, key,
+					"guest key %q must match stream-N shape", key)
+				assert.NotContains(t, key, "://",
+					"guest key %q leaks URL scheme", key)
+				assert.NotContains(t, key, "@",
+					"guest key %q leaks userinfo", key)
+			}
+		})
+	}
+}
+
+// TestBuildSuppressedStreamsPayload_GuestStableWithinResponse asserts that
+// repeated calls on the same input return identical maps. This is the
+// contract the handler's comment promises (raw URL keys live in the
+// scheduler and do not change between polls).
+func TestBuildSuppressedStreamsPayload_GuestStableWithinResponse(t *testing.T) {
+	t.Parallel()
+
+	in := map[string]bool{
+		"rtsp://user:pass@cam-a.lan/stream": true,
+		"rtsp://user:pass@cam-b.lan/stream": false,
+		"rtsp://user:pass@cam-c.lan/stream": true,
+	}
+
+	first := buildSuppressedStreamsPayload(in, true)
+	second := buildSuppressedStreamsPayload(in, true)
+	assert.Equal(t, first, second,
+		"guest payload must be deterministic for a given input")
+}
+
+// TestBuildSuppressedStreamsPayload_GuestShiftsWhenPrependingSort documents
+// the current behavior: adding a URL that sorts before existing ones shifts
+// every existing placeholder index by one. Today this is benign — the
+// "Currently Hearing" dashboard card only counts true values and does not
+// key UI state on placeholder names. If a future consumer needs hash-stable
+// placeholders, this test will fail and force a deliberate refactor.
+func TestBuildSuppressedStreamsPayload_GuestShiftsWhenPrependingSort(t *testing.T) {
+	t.Parallel()
+
+	before := map[string]bool{
+		"rtsp://user:pass@cam-m.lan/stream": true,
+		"rtsp://user:pass@cam-z.lan/stream": false,
+	}
+	after := map[string]bool{
+		"rtsp://user:pass@cam-a.lan/stream": true, // sorts before both existing URLs
+		"rtsp://user:pass@cam-m.lan/stream": true,
+		"rtsp://user:pass@cam-z.lan/stream": false,
+	}
+
+	firstPayload := buildSuppressedStreamsPayload(before, true)
+	secondPayload := buildSuppressedStreamsPayload(after, true)
+
+	// The value for cam-m was true in both inputs. With the current
+	// sort-then-index scheme, the key that holds that value in `before`
+	// (stream-1) will now belong to cam-a in `after`, meaning cam-m has
+	// moved to stream-2. Assert both maps stay valid (no key collisions)
+	// and that the count is correct — but explicitly do NOT assert that
+	// stream-1's value is stable, documenting the shift.
+	require.Len(t, firstPayload, 2)
+	require.Len(t, secondPayload, 3)
+	for _, payload := range []map[string]bool{firstPayload, secondPayload} {
+		for key := range payload {
+			assert.Regexp(t, streamPlaceholderPattern, key)
+		}
+	}
+}
+
+// TestBuildSuppressedStreamsPayload_AuthenticatedSanitizesURLs asserts the
+// non-guest path passes URLs through privacy.SanitizeStreamUrl — credentials
+// are stripped but host/port remain visible to the settings UI.
+func TestBuildSuppressedStreamsPayload_AuthenticatedSanitizesURLs(t *testing.T) {
+	t.Parallel()
+
+	raw := "rtsp://user:pass@cam1.lan:8554/stream"
+	in := map[string]bool{raw: true}
+
+	out := buildSuppressedStreamsPayload(in, false)
+	require.Len(t, out, 1)
+
+	wantKey := privacy.SanitizeStreamUrl(raw)
+	got, exists := out[wantKey]
+	require.True(t, exists,
+		"authenticated path must key by SanitizeStreamUrl output, got keys: %v", mapKeys(out))
+	assert.True(t, got, "value must be preserved")
+
+	// Credential string must not survive sanitization.
+	for key := range out {
+		assert.NotContains(t, key, "user:pass",
+			"authenticated key %q leaks credentials", key)
+		assert.NotContains(t, key, "@cam1.lan",
+			"authenticated key %q retains userinfo", key)
+	}
+}
+
+// mapKeys returns a stable slice of map keys for assertion messages.
+func mapKeys[V any](m map[string]V) []string {
+	return slices.Collect(maps.Keys(m))
+}

--- a/internal/api/v2/quiet_hours_test.go
+++ b/internal/api/v2/quiet_hours_test.go
@@ -110,7 +110,10 @@ func TestBuildSuppressedStreamsPayload_GuestShiftsWhenPrependingSort(t *testing.
 		"rtsp://user:pass@cam-z.lan/stream": false,
 	}
 	after := map[string]bool{
-		"rtsp://user:pass@cam-a.lan/stream": true, // sorts before both existing URLs
+		// cam-a sorts before both existing URLs. Use a distinct value
+		// (false) so we can prove the shift by looking at stream-1's
+		// value across the two payloads.
+		"rtsp://user:pass@cam-a.lan/stream": false,
 		"rtsp://user:pass@cam-m.lan/stream": true,
 		"rtsp://user:pass@cam-z.lan/stream": false,
 	}
@@ -118,12 +121,6 @@ func TestBuildSuppressedStreamsPayload_GuestShiftsWhenPrependingSort(t *testing.
 	firstPayload := buildSuppressedStreamsPayload(before, true)
 	secondPayload := buildSuppressedStreamsPayload(after, true)
 
-	// The value for cam-m was true in both inputs. With the current
-	// sort-then-index scheme, the key that holds that value in `before`
-	// (stream-1) will now belong to cam-a in `after`, meaning cam-m has
-	// moved to stream-2. Assert both maps stay valid (no key collisions)
-	// and that the count is correct — but explicitly do NOT assert that
-	// stream-1's value is stable, documenting the shift.
 	require.Len(t, firstPayload, 2)
 	require.Len(t, secondPayload, 3)
 	for _, payload := range []map[string]bool{firstPayload, secondPayload} {
@@ -131,6 +128,18 @@ func TestBuildSuppressedStreamsPayload_GuestShiftsWhenPrependingSort(t *testing.
 			assert.Regexp(t, streamPlaceholderPattern, key)
 		}
 	}
+
+	// Assert the shift explicitly: before has cam-m at stream-1 (true);
+	// after, cam-a takes stream-1 (false) and cam-m shifts to stream-2
+	// (true). If a future refactor makes placeholders hash-stable, these
+	// assertions will fail and force a deliberate contract change rather
+	// than silently breaking any consumer that keyed by placeholder name.
+	require.Contains(t, firstPayload, "stream-1")
+	require.Contains(t, secondPayload, "stream-1")
+	require.Contains(t, secondPayload, "stream-2")
+	assert.True(t, firstPayload["stream-1"], "before: cam-m (true) maps to stream-1")
+	assert.False(t, secondPayload["stream-1"], "after: prepended cam-a (false) takes stream-1")
+	assert.True(t, secondPayload["stream-2"], "after: cam-m (true) shifts from stream-1 to stream-2")
 }
 
 // TestBuildSuppressedStreamsPayload_AuthenticatedSanitizesURLs asserts the
@@ -160,7 +169,8 @@ func TestBuildSuppressedStreamsPayload_AuthenticatedSanitizesURLs(t *testing.T) 
 	}
 }
 
-// mapKeys returns a stable slice of map keys for assertion messages.
+// mapKeys returns map keys in sorted order so assertion diagnostics are
+// deterministic (map iteration order is not).
 func mapKeys[V any](m map[string]V) []string {
-	return slices.Collect(maps.Keys(m))
+	return slices.Sorted(maps.Keys(m))
 }

--- a/internal/notification/mocks/mock_NotificationStore.go
+++ b/internal/notification/mocks/mock_NotificationStore.go
@@ -20,6 +20,62 @@ func (_m *MockNotificationStore) EXPECT() *MockNotificationStore_Expecter {
 	return &MockNotificationStore_Expecter{mock: &_m.Mock}
 }
 
+// Count provides a mock function with given fields: filter
+func (_m *MockNotificationStore) Count(filter *notification.FilterOptions) (int, error) {
+	ret := _m.Called(filter)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Count")
+	}
+
+	var r0 int
+	var r1 error
+	if rf, ok := ret.Get(0).(func(*notification.FilterOptions) (int, error)); ok {
+		return rf(filter)
+	}
+	if rf, ok := ret.Get(0).(func(*notification.FilterOptions) int); ok {
+		r0 = rf(filter)
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+
+	if rf, ok := ret.Get(1).(func(*notification.FilterOptions) error); ok {
+		r1 = rf(filter)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockNotificationStore_Count_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Count'
+type MockNotificationStore_Count_Call struct {
+	*mock.Call
+}
+
+// Count is a helper method to define mock.On call
+//   - filter *notification.FilterOptions
+func (_e *MockNotificationStore_Expecter) Count(filter interface{}) *MockNotificationStore_Count_Call {
+	return &MockNotificationStore_Count_Call{Call: _e.mock.On("Count", filter)}
+}
+
+func (_c *MockNotificationStore_Count_Call) Run(run func(filter *notification.FilterOptions)) *MockNotificationStore_Count_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(*notification.FilterOptions))
+	})
+	return _c
+}
+
+func (_c *MockNotificationStore_Count_Call) Return(_a0 int, _a1 error) *MockNotificationStore_Count_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockNotificationStore_Count_Call) RunAndReturn(run func(*notification.FilterOptions) (int, error)) *MockNotificationStore_Count_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Delete provides a mock function with given fields: id
 func (_m *MockNotificationStore) Delete(id string) error {
 	ret := _m.Called(id)

--- a/internal/notification/service.go
+++ b/internal/notification/service.go
@@ -201,6 +201,13 @@ func (s *Service) List(filter *FilterOptions) ([]*Notification, error) {
 	return s.store.List(filter)
 }
 
+// Count returns the number of notifications matching filter. Unlike List, no
+// result slice is allocated — use this for badge counts and similar callers.
+// filter.Limit and filter.Offset are ignored.
+func (s *Service) Count(filter *FilterOptions) (int, error) {
+	return s.store.Count(filter)
+}
+
 // MarkAsRead updates a notification's status to read
 func (s *Service) MarkAsRead(id string) error {
 	if id == "" {

--- a/internal/notification/store_test.go
+++ b/internal/notification/store_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -166,4 +167,83 @@ func TestInMemoryStoreDelete(t *testing.T) {
 	// Delete unread notification - count should decrease
 	mustStoreDelete(t, store, notif1.ID)
 	assertStoreUnreadCount(t, store, 0, "Unread count after deleting unread notification")
+}
+
+// TestInMemoryStoreUnreadCountExcludesToasts locks in that toast-flagged
+// notifications are not counted by GetUnreadCount. Regression guard: the
+// previous counter-based implementation blindly incremented on every Save,
+// which caused the guest NotificationBell badge to include ephemeral toasts
+// even though they never appeared in the list view.
+func TestInMemoryStoreUnreadCountExcludesToasts(t *testing.T) {
+	t.Parallel()
+
+	store := NewInMemoryStore(100)
+
+	regular := NewNotification(TypeDetection, PriorityHigh, "Detection", "body")
+	mustStoreSave(t, store, regular)
+
+	toast := NewNotification(TypeInfo, PriorityLow, "Toast", "toast body").
+		WithMetadata(MetadataKeyIsToast, true)
+	mustStoreSave(t, store, toast)
+
+	// GetUnreadCount must count only the non-toast unread notification.
+	assertStoreUnreadCount(t, store, 1, "toast must not be counted in unread")
+
+	// Opt-in via Count with IncludeToasts still sees the toast when asked.
+	total, err := store.Count(&FilterOptions{
+		Status:        []Status{StatusUnread},
+		IncludeToasts: true,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 2, total, "IncludeToasts must surface toast entries")
+}
+
+// TestInMemoryStoreCountWithFilter exercises the typed Count method directly,
+// covering the filter paths callers rely on (type-only, status-only, empty,
+// and IncludeToasts opt-in).
+func TestInMemoryStoreCountWithFilter(t *testing.T) {
+	t.Parallel()
+
+	store := NewInMemoryStore(100)
+
+	detectionUnread := NewNotification(TypeDetection, PriorityHigh, "Det unread", "body")
+	detectionRead := NewNotification(TypeDetection, PriorityHigh, "Det read", "body")
+	detectionRead.MarkAsRead()
+	errorUnread := NewNotification(TypeError, PriorityCritical, "Err", "body")
+	toast := NewNotification(TypeInfo, PriorityLow, "Toast", "body").
+		WithMetadata(MetadataKeyIsToast, true)
+
+	for _, n := range []*Notification{detectionUnread, detectionRead, errorUnread, toast} {
+		mustStoreSave(t, store, n)
+	}
+
+	cases := []struct {
+		name   string
+		filter *FilterOptions
+		want   int
+	}{
+		{"nil filter excludes toast", nil, 3},
+		{"empty filter excludes toast", &FilterOptions{}, 3},
+		{"detection only", &FilterOptions{Types: []Type{TypeDetection}}, 2},
+		{"unread only", &FilterOptions{Status: []Status{StatusUnread}}, 2},
+		{"detection + unread", &FilterOptions{
+			Types:  []Type{TypeDetection},
+			Status: []Status{StatusUnread},
+		}, 1},
+		{"include toasts", &FilterOptions{IncludeToasts: true}, 4},
+		{"include toasts + unread", &FilterOptions{
+			Status:        []Status{StatusUnread},
+			IncludeToasts: true,
+		}, 3},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := store.Count(tc.filter)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
 }

--- a/internal/notification/types.go
+++ b/internal/notification/types.go
@@ -399,7 +399,11 @@ func NewInMemoryStore(maxSize int) *InMemoryStore {
 	}
 }
 
-// Save stores a notification in memory
+// Save stores a notification in memory. A deep copy is made so later
+// mutations of the caller's notification (adding metadata, changing status)
+// do not leak into the store or into concurrent subscribers reading via
+// List/Count/Get. Broadcasting already clones before sending to subscribers,
+// so storing a clone keeps the store's copy independent from both.
 func (s *InMemoryStore) Save(notification *Notification) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -409,7 +413,7 @@ func (s *InMemoryStore) Save(notification *Notification) error {
 		s.removeOldest()
 	}
 
-	s.notifications[notification.ID] = notification
+	s.notifications[notification.ID] = notification.Clone()
 	return nil
 }
 
@@ -477,7 +481,10 @@ func (s *InMemoryStore) Count(filter *FilterOptions) (int, error) {
 	return count, nil
 }
 
-// Update modifies an existing notification
+// Update modifies an existing notification. Stores a deep copy for the same
+// reason as Save: the caller's pointer may continue to mutate after the call
+// returns (e.g. MarkAsRead builds a new status on the returned copy and
+// writes back; the store must not share map references with that copy).
 func (s *InMemoryStore) Update(notification *Notification) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -486,7 +493,7 @@ func (s *InMemoryStore) Update(notification *Notification) error {
 		return ErrNotificationNotFound
 	}
 
-	s.notifications[notification.ID] = notification
+	s.notifications[notification.ID] = notification.Clone()
 	return nil
 }
 

--- a/internal/notification/types.go
+++ b/internal/notification/types.go
@@ -370,6 +370,13 @@ type FilterOptions struct {
 	Limit int
 	// Offset for pagination
 	Offset int
+	// IncludeToasts, when true, allows toast-flagged notifications to appear
+	// in results. Toasts are ephemeral by design (short expiry, SSE-only
+	// delivery); the default (false) keeps them out of List/Count results so
+	// callers that inspect "the notifications view" cannot accidentally leak
+	// them — a concrete concern after the guest-visible endpoints widened in
+	// PR #2775. Set to true only when the caller truly needs toast metadata.
+	IncludeToasts bool
 }
 
 // InMemoryStore provides a thread-safe in-memory notification store
@@ -377,7 +384,6 @@ type InMemoryStore struct {
 	mu            sync.RWMutex
 	notifications map[string]*Notification
 	maxSize       int
-	unreadCount   int // Track unread count for optimization
 }
 
 // NewInMemoryStore creates a new in-memory notification store
@@ -404,12 +410,6 @@ func (s *InMemoryStore) Save(notification *Notification) error {
 	}
 
 	s.notifications[notification.ID] = notification
-
-	// Update unread count if this is a new unread notification
-	if notification.Status == StatusUnread {
-		s.unreadCount++
-	}
-
 	return nil
 }
 
@@ -482,16 +482,8 @@ func (s *InMemoryStore) Update(notification *Notification) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	oldNotif, exists := s.notifications[notification.ID]
-	if !exists {
+	if _, exists := s.notifications[notification.ID]; !exists {
 		return ErrNotificationNotFound
-	}
-
-	// Update unread count if status changed
-	if oldNotif.Status == StatusUnread && notification.Status != StatusUnread {
-		s.unreadCount--
-	} else if oldNotif.Status != StatusUnread && notification.Status == StatusUnread {
-		s.unreadCount++
 	}
 
 	s.notifications[notification.ID] = notification
@@ -502,13 +494,6 @@ func (s *InMemoryStore) Update(notification *Notification) error {
 func (s *InMemoryStore) Delete(id string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-
-	// Check if notification exists and is unread
-	if notif, exists := s.notifications[id]; exists {
-		if notif.Status == StatusUnread {
-			s.unreadCount--
-		}
-	}
 
 	delete(s.notifications, id)
 	return nil
@@ -521,9 +506,6 @@ func (s *InMemoryStore) DeleteExpired() error {
 
 	for id, notif := range s.notifications {
 		if notif.IsExpired() {
-			if notif.Status == StatusUnread {
-				s.unreadCount--
-			}
 			delete(s.notifications, id)
 		}
 	}
@@ -543,19 +525,16 @@ func (s *InMemoryStore) removeOldest() {
 	}
 
 	if oldestID != "" {
-		// Update unread count if removing an unread notification
-		if notif, exists := s.notifications[oldestID]; exists && notif.Status == StatusUnread {
-			s.unreadCount--
-		}
 		delete(s.notifications, oldestID)
 	}
 }
 
-// matchesFilter checks if a notification matches the filter criteria
+// matchesFilter checks if a notification matches the filter criteria.
+// Toast-flagged notifications are excluded by default (they are ephemeral
+// SSE-only payloads); callers that need toast metadata must opt in via
+// FilterOptions.IncludeToasts.
 func (s *InMemoryStore) matchesFilter(notif *Notification, filter *FilterOptions) bool {
-	// Always exclude toast notifications from lists
-	// Toast notifications should only be sent via SSE as ephemeral messages
-	if isToastNotification(notif) {
+	if isToastNotification(notif) && (filter == nil || !filter.IncludeToasts) {
 		return false
 	}
 
@@ -594,11 +573,12 @@ func (s *InMemoryStore) matchesTimeFilters(notif *Notification, filter *FilterOp
 	return true
 }
 
-// GetUnreadCount returns the count of unread notifications
+// GetUnreadCount returns the count of unread, non-toast notifications.
+// Toasts are ephemeral and are excluded so the count matches what callers
+// see via List. Iterates the store because a single cached counter cannot
+// correctly distinguish toast from non-toast saves at write time.
 func (s *InMemoryStore) GetUnreadCount() (int, error) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	return s.unreadCount, nil
+	return s.Count(&FilterOptions{Status: []Status{StatusUnread}})
 }
 
 // sortNotificationsByTime sorts notifications by timestamp (newest first)

--- a/internal/notification/types.go
+++ b/internal/notification/types.go
@@ -339,6 +339,9 @@ type NotificationStore interface {
 	Get(id string) (*Notification, error)
 	// List returns notifications with optional filtering
 	List(filter *FilterOptions) ([]*Notification, error)
+	// Count returns the number of notifications matching filter. filter.Limit
+	// and filter.Offset are ignored — pagination does not apply to a count.
+	Count(filter *FilterOptions) (int, error)
 	// Update modifies an existing notification
 	Update(notification *Notification) error
 	// Delete removes a notification
@@ -454,6 +457,24 @@ func (s *InMemoryStore) List(filter *FilterOptions) ([]*Notification, error) {
 	}
 
 	return results, nil
+}
+
+// Count returns the number of notifications matching filter. Reuses the same
+// matchesFilter predicate as List but avoids allocating a result slice, which
+// matters for callers that only need a badge count (e.g. NotificationBell
+// polling /notifications/unread/count). filter.Limit and filter.Offset are
+// ignored — a count is not paginated.
+func (s *InMemoryStore) Count(filter *FilterOptions) (int, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	count := 0
+	for _, notif := range s.notifications {
+		if s.matchesFilter(notif, filter) {
+			count++
+		}
+	}
+	return count, nil
 }
 
 // Update modifies an existing notification


### PR DESCRIPTION
## Summary

Four follow-up items surfaced during PR #2775 review, all related to the
notification system and the guest-visible dashboard endpoints:

- Add a typed `Count(filter *FilterOptions) (int, error)` method to
  `notification.Service` and `NotificationStore`. Replaces the guest
  `/notifications/unread/count` pagination loop with a single call.
- Fix a long-standing bug where `InMemoryStore.GetUnreadCount` counted
  toast-flagged notifications (the counter was blindly incremented in
  `Save`). Rewrite it to iterate through the same filter path `List` uses,
  so the count always matches what the list endpoint returns. Surface the
  behavior via a new `FilterOptions.IncludeToasts` opt-in.
- Add a direct regression test for the SSE-path guest filter using
  `httptest.NewServer` — the only coverage so far was by inspection.
- Add unit tests for `buildSuppressedStreamsPayload` to lock in the
  stream-N placeholder shape, stability across calls, documented index-
  shift behavior, and credential stripping on the authenticated path.

The Count method is strictly a new public surface; no existing caller
changes behavior except the guest unread-count loop (simpler, same
result) and `GetUnreadCount` (now correctly excludes toasts).

## Test plan

- [x] `go test -race ./internal/notification/...` (passes; new tests for `Count`, toast exclusion, `GetUnreadCount` match `List`)
- [x] `go test -race ./internal/api/v2/...` (passes; new SSE and quiet-hours tests)
- [x] SSE test re-run 5x under `-race` with no flakiness
- [x] `golangci-lint run -v` on both packages: zero issues
- [ ] Manual: guest unread-count badge on dashboard matches guest list length (covered by the existing `TestNotifications_GuestUnreadCountIgnoresNonDetectionAndToasts` test)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed unread notification count to properly exclude toast notifications.
  * Improved guest notification streams to filter internal notifications and toast events.

* **Tests**
  * Added comprehensive test coverage for guest notification filtering in real-time streams.
  * Added unit tests for quiet hours stream masking behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->