### PR TITLE
fix(api): strip header-only basepath for proxied callback routes (#2778)

### DIFF
--- a/internal/api/basepath_test.go
+++ b/internal/api/basepath_test.go
@@ -1,4 +1,4 @@
-// basepath_test.go: Tests for base path support — prefix stripping middleware,
+// basepath_test.go: Tests for base path support - prefix stripping middleware,
 // HTML asset URL rewriting, and manifest path rewriting.
 
 package api
@@ -12,16 +12,22 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/tphakala/birdnet-go/internal/conf"
 )
 
 // stripMiddlewareForTest mirrors the production Pre middleware in setupMiddleware().
 // Kept in sync by hand. We can't easily instantiate a full Server in this package-level
 // unit test, so the stripping logic is duplicated here and exercised with the same
 // table-driven assertions production would see.
-func stripMiddlewareForTest(getBP func() string) echo.MiddlewareFunc {
+//
+// The middleware resolves the effective basepath through ingressPath() so that
+// header-supplied basepaths strip the request prefix even when no config basepath
+// is set. getSettings may return nil when the test does not care about config.
+func stripMiddlewareForTest(getSettings func() *conf.Settings) echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
-			bp := strings.TrimRight(getBP(), "/")
+			bp := ingressPath(c, getSettings())
 			if bp == "" {
 				return next(c)
 			}
@@ -45,6 +51,14 @@ func stripMiddlewareForTest(getBP func() string) echo.MiddlewareFunc {
 	}
 }
 
+// settingsWithBasePath returns a *conf.Settings whose WebServer.BasePath is set
+// to the given value. Used as a compact helper for table-driven tests.
+func settingsWithBasePath(bp string) *conf.Settings {
+	s := &conf.Settings{}
+	s.WebServer.BasePath = bp
+	return s
+}
+
 // TestBasePathStripMiddleware tests the Pre middleware that strips the configured
 // basepath prefix from incoming request URLs for direct access (no proxy).
 func TestBasePathStripMiddleware(t *testing.T) {
@@ -55,6 +69,7 @@ func TestBasePathStripMiddleware(t *testing.T) {
 		basePath         string
 		requestPath      string
 		xForwardedPrefix string // if set, middleware should skip stripping
+		xIngressPath     string // if set, takes priority over X-Forwarded-Prefix
 		expectedPath     string
 	}{
 		{
@@ -118,20 +133,56 @@ func TestBasePathStripMiddleware(t *testing.T) {
 			requestPath:  "/birdnet/ui/dashboard?tab=detections",
 			expectedPath: "/ui/dashboard",
 		},
+		{
+			// Issue #2778: the login callback URL is built from the header-derived
+			// basepath, so the strip middleware must honor the same header when
+			// no config basepath is set, otherwise the returned callback 404s.
+			name:             "strips with X-Forwarded-Prefix header and no config basepath",
+			basePath:         "",
+			requestPath:      "/birdnet/api/v2/health",
+			xForwardedPrefix: "/birdnet",
+			expectedPath:     "/api/v2/health",
+		},
+		{
+			// Same scenario but via the Home Assistant ingress header.
+			name:         "strips with X-Ingress-Path header and no config basepath",
+			basePath:     "",
+			requestPath:  "/api/hassio_ingress/TOKEN/api/v2/health",
+			xIngressPath: "/api/hassio_ingress/TOKEN",
+			expectedPath: "/api/v2/health",
+		},
+		{
+			// When the proxy already stripped the prefix but still sent the header,
+			// the request path does not start with the basepath so stripping must
+			// be skipped to avoid breaking routing.
+			name:             "no strip when proxy header present and path already stripped",
+			basePath:         "",
+			requestPath:      "/api/v2/health",
+			xForwardedPrefix: "/birdnet",
+			expectedPath:     "/api/v2/health",
+		},
+		{
+			// No source of basepath at all: neither header nor config is set,
+			// so the middleware must be a no-op.
+			name:         "no strip when no basepath from any source",
+			basePath:     "",
+			requestPath:  "/api/v2/health",
+			expectedPath: "/api/v2/health",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			bp := tt.basePath
+			settings := settingsWithBasePath(tt.basePath)
 			var capturedPath string
 			var capturedQuery string
 
 			e := echo.New()
 
 			// Exercise the strip middleware via the shared test helper that mirrors production.
-			e.Pre(stripMiddlewareForTest(func() string { return bp }))
+			e.Pre(stripMiddlewareForTest(func() *conf.Settings { return settings }))
 
 			// Catch-all handler to capture the routed path
 			e.Any("/*", func(c echo.Context) error {
@@ -143,6 +194,9 @@ func TestBasePathStripMiddleware(t *testing.T) {
 			req := httptest.NewRequest(http.MethodGet, tt.requestPath, http.NoBody)
 			if tt.xForwardedPrefix != "" {
 				req.Header.Set("X-Forwarded-Prefix", tt.xForwardedPrefix)
+			}
+			if tt.xIngressPath != "" {
+				req.Header.Set("X-Ingress-Path", tt.xIngressPath)
 			}
 			rec := httptest.NewRecorder()
 
@@ -428,11 +482,11 @@ func TestBasePathStripMiddleware_HotReload(t *testing.T) {
 	t.Parallel()
 
 	// Mutable basepath source, simulating settings.WebServer.BasePath being
-	// updated at runtime. Access is serialized through the test — no goroutines.
+	// updated at runtime. Access is serialized through the test; no goroutines.
 	var currentBP string
 
 	e := echo.New()
-	e.Pre(stripMiddlewareForTest(func() string { return currentBP }))
+	e.Pre(stripMiddlewareForTest(func() *conf.Settings { return settingsWithBasePath(currentBP) }))
 
 	var capturedPath string
 	e.Any("/*", func(c echo.Context) error {

--- a/internal/api/basepath_test.go
+++ b/internal/api/basepath_test.go
@@ -44,6 +44,15 @@ func stripMiddlewareForTest(getSettings func() *conf.Settings) echo.MiddlewareFu
 						rest = "/"
 					}
 					req.URL.Path = rest
+					// Mirror production: also rewrite RawPath when set,
+					// so percent-encoded paths route correctly under test.
+					if req.URL.RawPath != "" && strings.HasPrefix(req.URL.RawPath, bp) {
+						raw := req.URL.RawPath[len(bp):]
+						if raw == "" {
+							raw = "/"
+						}
+						req.URL.RawPath = raw
+					}
 				}
 			}
 			return next(c)

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -283,25 +283,28 @@ func (s *Server) setupMiddleware() {
 	// Go's net/http automatically suppresses the response body for HEAD.
 	s.echo.Pre(mw.NewHeadToGet())
 
-	// Base path prefix stripping — enables direct access when basepath is configured.
-	// When settings.WebServer.BasePath is "/birdnet", a request to /birdnet/ui/dashboard
-	// gets stripped to /ui/dashboard so existing route handlers match.
-	// Skipped when reverse proxy headers are present (the proxy already stripped it).
+	// Base path prefix stripping - enables direct access when basepath is in effect.
+	// The effective basepath is resolved per-request via ingressPath(), which checks
+	// (in priority order) the X-Ingress-Path header, the X-Forwarded-Prefix header,
+	// and the settings.WebServer.BasePath config value. This matches the resolver
+	// used by the context middleware below, so a callback URL emitted by the login
+	// handler (which prefixes using the same chain) always maps back to a route
+	// even when the basepath comes only from a proxy header (no YAML config).
 	//
-	// The effective basepath is read per-request from s.settings so changes to
-	// settings.WebServer.BasePath take effect without a server restart, matching
-	// the dynamic behavior of ingressPath() used by the context middleware below.
+	// Resolving per-request also means settings.WebServer.BasePath changes take
+	// effect without a server restart.
 	s.echo.Pre(func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
-			bp := strings.TrimRight(s.settings.WebServer.BasePath, "/")
+			bp := ingressPath(c, s.settings)
 			if bp == "" {
 				return next(c)
 			}
 
 			// When a reverse proxy header is present, the proxy usually already
-			// stripped the prefix before forwarding. But only skip our stripping
-			// if the path does NOT start with the basepath — a client could send
-			// the header without an actual proxy, leaving the prefix intact.
+			// stripped the prefix before forwarding. Only skip our stripping when
+			// the path does NOT start with the basepath; a client (or a proxy that
+			// forwards paths verbatim) may send the header with the prefix still
+			// attached, in which case we must strip it ourselves.
 			req := c.Request()
 			hasProxyHeader := req.Header.Get("X-Ingress-Path") != "" || req.Header.Get("X-Forwarded-Prefix") != ""
 			if hasProxyHeader && !strings.HasPrefix(req.URL.Path, bp+"/") && req.URL.Path != bp {


### PR DESCRIPTION
## Summary
- Resolve the effective basepath inside the Echo Pre strip middleware via the shared `ingressPath()` helper, so requests that carry a basepath only in `X-Ingress-Path` or `X-Forwarded-Prefix` (no YAML `webserver.basepath`) get their prefix stripped and land on handlers.
- Fixes #2778: after PR #2731, the login handler emits callback URLs like `/birdnet/api/v2/auth/callback?...` derived from the same header-priority chain, but without this fix the returned URL 404s because the strip middleware only consulted `settings.WebServer.BasePath`. Reverse-proxy users who had not also set `webserver.basepath` saw the dashboard hang (login never completed) and the Overview never loaded.
- Preserves the existing short-circuit that skips stripping when a proxy header is present and the path does not start with the basepath (so proxies that already strip the prefix keep working), and keeps the `isSafePathPrefix` header guard from #2731 untouched.

## Validation
- QA run against a locally built fix image probed the bug scenarios and a baseline image. `X-Forwarded-Prefix: /birdnet` on `/birdnet/api/v2/health` flipped from 404 on baseline to 200 on the fix. Same flip for `X-Ingress-Path`. Login round-trip (POST `/api/v2/auth/login` with the proxy header, follow the returned `redirectUrl`) flipped from 404 to 302 to `/birdnet/ui/dashboard`.
- The existing 26-test Playwright basepath suite (`e2e/tests/basepath.spec.js`) still passes for the YAML-basepath scenario. One unrelated flake surfaced in the dashboard hourly-grid anchors (misses the basepath when detections exist) and is tracked separately; it is a frontend component bug, not a regression from this PR.

## Test plan
- [x] `go test -race ./internal/api/...` (includes new cases in `internal/api/basepath_test.go` for header-only basepath with both `X-Forwarded-Prefix` and `X-Ingress-Path`, the proxy-already-stripped short-circuit, and the fully empty case).
- [x] `golangci-lint run -v` on the full project - 0 issues.
- [x] `coderabbit review --plain --base main` - no findings.
- [x] Reverse-proxy simulation validated in QA (probes + login round-trip).
- [ ] Manual smoke: behind a real reverse proxy (Caddy/nginx/traefik) confirm dashboard loads and login completes.
- [ ] Manual regression check: `webserver.basepath` set in YAML still works without proxy headers.

Fixes #2778

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for base-path handling with additional scenarios covering proxy headers, config edge cases, and skip conditions.

* **Bug Fixes**
  * Preserve percent-encoded paths when base-path stripping occurs.
  * Ensure proxy headers are honored in the correct precedence when determining the base path.

* **Chores**
  * Compute base-path per-request for more accurate handling of proxied requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->