### PR TITLE
fix(frontend): send CSRF token on audio POST + opt-out auto-add for synonym form (#2768, #2767)

### DIFF
--- a/frontend/src/lib/desktop/components/forms/SpeciesInput.svelte
+++ b/frontend/src/lib/desktop/components/forms/SpeciesInput.svelte
@@ -46,6 +46,13 @@
     maxPredictions?: number;
     minCharsForPredictions?: number;
     className?: string;
+    /**
+     * When true (default), selecting a prediction immediately triggers onAdd and
+     * clears the input. When false, selecting a prediction only populates the
+     * input so callers can read the current value (used for non-list inputs like
+     * the synonym BirdNET name field, which is submitted via a separate button).
+     */
+    addOnSelect?: boolean;
     onInput?: (_value: string) => void;
     onAdd?: (_value: string) => void;
     onPredictionSelect?: (_prediction: string) => void;
@@ -69,6 +76,7 @@
     maxPredictions = 10,
     minCharsForPredictions = 2,
     className = '',
+    addOnSelect = true,
     onInput,
     onAdd,
     onPredictionSelect,
@@ -358,10 +366,13 @@
     showPredictions = false;
 
     // Defer handleAdd to next event loop to ensure state updates (showPredictions = false)
-    // have propagated before triggering add operation
-    setTimeout(() => {
-      handleAdd();
-    }, 0);
+    // have propagated before triggering add operation. Skip when callers opt out
+    // of auto-add (e.g. inputs that feed a separate submit button).
+    if (addOnSelect) {
+      setTimeout(() => {
+        handleAdd();
+      }, 0);
+    }
   }
 
   function handlePredictionKeydown(event: KeyboardEvent, prediction: string, index: number) {

--- a/frontend/src/lib/desktop/components/forms/SpeciesInput.test.ts
+++ b/frontend/src/lib/desktop/components/forms/SpeciesInput.test.ts
@@ -181,6 +181,35 @@ describe('SpeciesInput', () => {
     });
   });
 
+  it('does not call onAdd or clear input when addOnSelect is false', async () => {
+    const onAdd = vi.fn();
+    const onPredictionSelect = vi.fn();
+
+    render(SpeciesInput, {
+      props: {
+        value: 'rob',
+        predictions: defaultPredictions,
+        addOnSelect: false,
+        onAdd,
+        onPredictionSelect,
+      },
+    });
+
+    const prediction = screen.getByText('American Robin');
+    await fireEvent.click(prediction);
+
+    expect(onPredictionSelect).toHaveBeenCalledWith('American Robin');
+
+    // Give any deferred work a chance to run, then assert onAdd stayed silent.
+    await new Promise(resolve => setTimeout(resolve, 10));
+    expect(onAdd).not.toHaveBeenCalled();
+
+    // Input value should remain populated with the selected prediction so
+    // callers can read it via bind:value or a separate submit button.
+    const input = screen.getByRole('combobox') as HTMLInputElement;
+    expect(input).toHaveValue('American Robin');
+  });
+
   it('calls onInput when input value changes', async () => {
     const onInput = vi.fn();
 

--- a/frontend/src/lib/desktop/components/media/AudioPlayer.svelte
+++ b/frontend/src/lib/desktop/components/media/AudioPlayer.svelte
@@ -57,10 +57,21 @@
     type AudioNodeChain,
   } from '$lib/utils/audioNodes';
   import { buildAppUrl } from '$lib/utils/urlHelpers';
+  import { getCsrfToken } from '$lib/utils/api';
   import { get } from 'svelte/store';
   import { dashboardSettings } from '$lib/stores/settings';
 
   const logger = loggers.audio;
+
+  // Build JSON headers with CSRF token (server rejects mutating requests without it).
+  function jsonHeadersWithCsrf(): Record<string, string> {
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    const csrfToken = getCsrfToken();
+    if (csrfToken) {
+      headers['X-CSRF-Token'] = csrfToken;
+    }
+    return headers;
+  }
 
   // Debug logging helper - bypasses linter warnings when debug flag is enabled
   const debugLog = (message: string, data?: unknown) => {
@@ -667,7 +678,7 @@
         buildAppUrl(`/api/v2/audio/${encodeURIComponent(detectionId)}/clip`),
         {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
+          headers: jsonHeadersWithCsrf(),
           body: JSON.stringify({
             start,
             end,
@@ -772,7 +783,7 @@
         buildAppUrl(`/api/v2/audio/${encodeURIComponent(detectionId)}/process`),
         {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
+          headers: jsonHeadersWithCsrf(),
           signal: controller.signal,
           body: JSON.stringify({
             normalize: processingNormalize,
@@ -850,7 +861,7 @@
         ),
         {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
+          headers: jsonHeadersWithCsrf(),
           signal,
           body: JSON.stringify({
             normalize: processingNormalize,
@@ -1332,9 +1343,7 @@
 
       const response = await fetch(generateUrl.toString(), {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: jsonHeadersWithCsrf(),
       });
 
       debugLog('handleGenerateSpectrogram: response', { status: response.status });

--- a/frontend/src/lib/desktop/features/settings/pages/SpeciesSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/SpeciesSettingsPage.svelte
@@ -1332,6 +1332,7 @@
             disabled={store.isLoading || store.isSaving}
             onInput={updateSynonymPredictions}
             onPredictionSelect={handleSynonymPredictionSelect}
+            addOnSelect={false}
             size="sm"
           />
           <TextInput


### PR DESCRIPTION
## Summary

Two unrelated frontend bug fixes bundled because both are tiny and in adjacent surface area.

### #2768 - Audio extract returns "Invalid CSRF token"
- `AudioPlayer.svelte` POSTs to `/api/v2/audio/:id/clip`, `/process`, `/spectrogram/:id/process`, and `/spectrogram/:id/generate` without an `X-CSRF-Token` header. The backend CSRF middleware exempts `/api/v2/audio/*` for safe methods only, so POSTs got rejected with 403.
- Fix: route every audio/spectrogram POST through a small local helper that pulls the token from `getCsrfToken()` (`$lib/utils/api`), matching the pattern already used by `spectrogramLoader`. Original-format download is a GET and was unaffected, which is why only conversions failed.

### #2767 - Species synonym form clears input on prediction select
- `SpeciesInput.svelte` is shared between several settings screens. Most callers want the "pick and add" pattern where the field clears after selection. The synonym form is the odd one out: the user needs the BirdNET name to stay populated so they can fill the second "updated name" field before submitting.
- Fix: add an opt-in `addOnSelect` prop (default `true`, preserving current behaviour). The synonym form passes `addOnSelect={false}`. Every other `SpeciesInput` consumer keeps its existing auto-add flow.

## Test plan
- [x] `npm run check:all` clean
- [x] `npm test -- SpeciesInput --run` (38/38, includes new `addOnSelect=false` case asserting input stays populated and `onAdd` never fires)
- [x] `task frontend-build` succeeds
- [x] `coderabbit review --plain --base main` no findings
- [ ] Manual: open a detection, click Extract Clip and pick WAV/MP3/MP4 - downloads without 403
- [ ] Manual: Settings > Species > Synonyms, type a BirdNET name, pick a prediction - value stays in the field, Add button submits with both fields populated
- [ ] Manual: Filter settings species lists still auto-add on prediction select (default behaviour preserved)

Fixes #2768
Fixes #2767

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Species selection autocomplete now supports configurable behavior for automatic addition, allowing different forms to control whether predictions immediately populate selections.

* **Security**
  * Added CSRF token authentication headers to API requests for audio processing, clip extraction, and spectrogram generation operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->