### PR TITLE
fix(search): resolve common name to scientific name before filtering (#2766)

### DIFF
--- a/frontend/src/lib/desktop/views/Search.svelte
+++ b/frontend/src/lib/desktop/views/Search.svelte
@@ -1,3 +1,70 @@
+<script module lang="ts">
+  import { api } from '$lib/utils/api';
+  import { loggers } from '$lib/utils/logger';
+  import {
+    buildSpeciesNameMaps,
+    type SpeciesApiEntry,
+    type SpeciesNameMaps,
+  } from '$lib/utils/speciesNames';
+
+  // Module-level cache for species name maps. Survives component
+  // mount/unmount across route changes, so navigating away from Search and
+  // back does not refetch /api/v2/species/all. Invalidated explicitly when
+  // the BirdNET label locale changes (see the component-level $effect).
+  let cachedSpeciesNameMaps: SpeciesNameMaps | null = null;
+  let cachedSpeciesMapsLocale: string | null = null;
+  let cachedSpeciesMapsInFlight: Promise<SpeciesNameMaps | null> | null = null;
+
+  /**
+   * Load the full species list from /api/v2/species/all once per locale,
+   * build bidirectional name maps, and cache the result at module scope.
+   * Subsequent calls return the cached maps. Failures are logged without
+   * surfacing to the user, since the search falls back to the raw query.
+   */
+  export function ensureSpeciesNameMapsCache(locale: string): Promise<SpeciesNameMaps | null> {
+    if (cachedSpeciesNameMaps && cachedSpeciesMapsLocale === locale) {
+      return Promise.resolve(cachedSpeciesNameMaps);
+    }
+    if (cachedSpeciesMapsInFlight && cachedSpeciesMapsLocale === locale) {
+      return cachedSpeciesMapsInFlight;
+    }
+
+    cachedSpeciesMapsLocale = locale;
+    cachedSpeciesMapsInFlight = (async () => {
+      try {
+        interface SpeciesListResponse {
+          species?: SpeciesApiEntry[];
+        }
+        const data = await api.get<SpeciesListResponse>('/api/v2/species/all');
+        const maps = buildSpeciesNameMaps(data.species ?? []);
+        // Only commit to cache if the locale is still the one we fetched
+        // for; otherwise, a newer fetch has superseded us.
+        if (cachedSpeciesMapsLocale === locale) {
+          cachedSpeciesNameMaps = maps;
+        }
+        return maps;
+      } catch (error: unknown) {
+        loggers.ui.error('Failed to load species name map for search', error);
+        return null;
+      } finally {
+        cachedSpeciesMapsInFlight = null;
+      }
+    })();
+
+    return cachedSpeciesMapsInFlight;
+  }
+
+  /**
+   * Invalidate the module-level species-name cache. Call when the BirdNET
+   * label locale changes so the next search refetches the label mapping.
+   */
+  export function invalidateSpeciesNameMapsCache(): void {
+    cachedSpeciesNameMaps = null;
+    cachedSpeciesMapsLocale = null;
+    cachedSpeciesMapsInFlight = null;
+  }
+</script>
+
 <script lang="ts">
   import WeatherInfo from '$lib/desktop/components/data/WeatherInfo.svelte';
   import AudioPlayer from '$lib/desktop/components/media/AudioPlayer.svelte';
@@ -6,9 +73,9 @@
   import { handleBirdImageError } from '$lib/desktop/components/ui/image-utils';
   import TimeOfDayIcon from '$lib/desktop/components/ui/TimeOfDayIcon.svelte';
   import { getLocale, t } from '$lib/i18n';
-  import { dashboardSettings } from '$lib/stores/settings';
+  import { birdnetSettings, dashboardSettings } from '$lib/stores/settings';
   import { toastActions } from '$lib/stores/toast';
-  import { api, fetchWithCSRF } from '$lib/utils/api';
+  import { fetchWithCSRF } from '$lib/utils/api';
   import { getLocalDateString, parseLocalDateString } from '$lib/utils/date';
   import type { TemperatureUnit } from '$lib/utils/formatters';
   import {
@@ -27,13 +94,7 @@
   import { navigation } from '$lib/stores/navigation.svelte';
   import { dropdown } from '$lib/utils/transitions';
   import { hasReviewPermission, isAuthenticated } from '$lib/utils/auth';
-  import { loggers } from '$lib/utils/logger';
-  import {
-    buildSpeciesNameMaps,
-    resolveSpeciesQuery,
-    type SpeciesApiEntry,
-    type SpeciesNameMaps,
-  } from '$lib/utils/speciesNames';
+  import { resolveSpeciesQuery } from '$lib/utils/speciesNames';
 
   // SPINNER CONTROL: Set to false to disable loading spinners (reduces flickering)
   // Change back to true to re-enable spinners for testing
@@ -178,41 +239,22 @@
   let hasConfidenceError = $state(false);
   let showTooltip = $state<string | null>(null);
 
-  // Species-name lookup maps for resolving user-entered common names
-  // (in the BirdNET label locale) to scientific names before querying the
-  // backend search endpoint. Loaded lazily on first search.
-  let speciesNameMaps = $state<SpeciesNameMaps | null>(null);
-  let speciesMapsLoadInFlight: Promise<SpeciesNameMaps | null> | null = null;
+  // Monotonic search ID used to drop stale results from out-of-order
+  // responses when the user fires multiple searches in quick succession.
+  // Each new search increments this; the resolver compares against the
+  // captured ID before touching reactive state.
+  let currentSearchId = 0;
 
-  /**
-   * Load the full species list from /api/v2/species/all once, build
-   * bidirectional name maps, and cache the result. Subsequent calls return
-   * the cached maps. Failures are logged without surfacing to the user,
-   * since the search falls back to the raw query string.
-   */
-  async function ensureSpeciesNameMaps(): Promise<SpeciesNameMaps | null> {
-    if (speciesNameMaps) return speciesNameMaps;
-    if (speciesMapsLoadInFlight) return speciesMapsLoadInFlight;
-
-    speciesMapsLoadInFlight = (async () => {
-      try {
-        interface SpeciesListResponse {
-          species?: SpeciesApiEntry[];
-        }
-        const data = await api.get<SpeciesListResponse>('/api/v2/species/all');
-        const maps = buildSpeciesNameMaps(data.species ?? []);
-        speciesNameMaps = maps;
-        return maps;
-      } catch (error: unknown) {
-        logger.error('Failed to load species name map for search', error);
-        return null;
-      } finally {
-        speciesMapsLoadInFlight = null;
-      }
-    })();
-
-    return speciesMapsLoadInFlight;
-  }
+  // Invalidate the module-level species-name cache whenever the BirdNET
+  // label locale changes, so the next search refetches /api/v2/species/all
+  // with labels in the new locale. This is the LABEL locale (used by the
+  // BirdNET model), not the UI display locale.
+  $effect(() => {
+    // Subscribe to the reactive locale value; value itself is not used
+    // other than to trigger the effect when it changes.
+    void $birdnetSettings?.locale;
+    invalidateSpeciesNameMapsCache();
+  });
 
   // Localized pluralized results count using i18n keys
   function formatResultsCount(count: number) {
@@ -256,6 +298,11 @@
   async function submitSearch(page = 1) {
     if (!validateForm()) return;
 
+    // Capture a unique ID for this search. If another search starts before
+    // this one resolves, that later search bumps `currentSearchId` and our
+    // response will be dropped below to prevent stale-result flicker.
+    const searchId = ++currentSearchId;
+
     isLoading = true;
     errorMessage = '';
     currentPage = page;
@@ -268,7 +315,8 @@
       // label locale is Finnish) needs to be mapped to "Strix aluco" first.
       // Falls back to the raw input if the map cannot be loaded or no match
       // is found, preserving partial scientific-name search behaviour.
-      const maps = await ensureSpeciesNameMaps();
+      const locale = $birdnetSettings?.locale ?? 'en';
+      const maps = await ensureSpeciesNameMapsCache(locale);
       const resolvedSpecies = resolveSpeciesQuery(speciesSearchTerm, maps);
 
       // Build request body
@@ -291,19 +339,32 @@
         pages: number;
       }
 
+      // `api` is imported in the <script module> block and is in scope here.
       const data = await api.post<SearchResponse>('/api/v2/search', requestBody);
+      // Ignore stale responses: a newer search has already started.
+      if (searchId !== currentSearchId) return;
+
       results = data.results ?? [];
       totalResults = data.total ?? 0;
       totalPages = data.pages ?? 1;
       formSubmitted = true;
     } catch (error: unknown) {
+      // Ignore errors from stale searches as well, so a failed older
+      // request cannot clobber results from a newer successful one.
+      if (searchId !== currentSearchId) return;
+
       // Handle search error silently
       errorMessage = t('search.errors.searchFailed', {
         error: error instanceof Error ? error.message : 'Unknown error',
       });
       results = [];
     } finally {
-      isLoading = false;
+      // Only clear the loading spinner for the newest search; an older
+      // search finishing late must not unset isLoading while a newer one
+      // is still in flight.
+      if (searchId === currentSearchId) {
+        isLoading = false;
+      }
     }
   }
 

--- a/frontend/src/lib/desktop/views/Search.svelte
+++ b/frontend/src/lib/desktop/views/Search.svelte
@@ -253,12 +253,16 @@
   // Invalidate the module-level species-name cache whenever the BirdNET
   // label locale changes, so the next search refetches /api/v2/species/all
   // with labels in the new locale. This is the LABEL locale (used by the
-  // BirdNET model), not the UI display locale.
+  // BirdNET model), not the UI display locale. Track the previous locale so
+  // we only invalidate on a real transition; otherwise mounts and unrelated
+  // birdnetSettings updates would clear the module-level cache for nothing.
+  let previousLocale: string | undefined;
   $effect(() => {
-    // Subscribe to the reactive locale value; value itself is not used
-    // other than to trigger the effect when it changes.
-    void $birdnetSettings?.locale;
-    invalidateSpeciesNameMapsCache();
+    const currentLocale = $birdnetSettings?.locale;
+    if (previousLocale !== undefined && previousLocale !== currentLocale) {
+      invalidateSpeciesNameMapsCache();
+    }
+    previousLocale = currentLocale;
   });
 
   // Localized pluralized results count using i18n keys
@@ -319,10 +323,15 @@
       // so a user typing e.g. "Tawny Owl" (or "Lehtopöllö" when the BirdNET
       // label locale is Finnish) needs to be mapped to "Strix aluco" first.
       // Falls back to the raw input if the map cannot be loaded or no match
-      // is found, preserving partial scientific-name search behaviour.
-      const locale = $birdnetSettings?.locale ?? 'en';
-      const maps = await ensureSpeciesNameMapsCache(locale);
-      const resolvedSpecies = resolveSpeciesQuery(speciesSearchTerm, maps);
+      // is found, preserving partial scientific-name search behaviour. Skip
+      // the species map fetch entirely for date-only searches so we do not
+      // add an unrelated round trip to /api/v2/species/all.
+      let resolvedSpecies = '';
+      if (speciesSearchTerm.trim() !== '') {
+        const locale = $birdnetSettings?.locale ?? 'en';
+        const maps = await ensureSpeciesNameMapsCache(locale);
+        resolvedSpecies = resolveSpeciesQuery(speciesSearchTerm, maps);
+      }
 
       // Build request body
       const requestBody = {

--- a/frontend/src/lib/desktop/views/Search.svelte
+++ b/frontend/src/lib/desktop/views/Search.svelte
@@ -47,7 +47,12 @@
         loggers.ui.error('Failed to load species name map for search', error);
         return null;
       } finally {
-        cachedSpeciesMapsInFlight = null;
+        // Only clear the in-flight marker if a newer fetch (different locale)
+        // has not already replaced it; otherwise we would orphan its promise
+        // and trigger a redundant refetch on the next caller.
+        if (cachedSpeciesMapsLocale === locale) {
+          cachedSpeciesMapsInFlight = null;
+        }
       }
     })();
 

--- a/frontend/src/lib/desktop/views/Search.svelte
+++ b/frontend/src/lib/desktop/views/Search.svelte
@@ -330,6 +330,10 @@
       if (speciesSearchTerm.trim() !== '') {
         const locale = $birdnetSettings?.locale ?? 'en';
         const maps = await ensureSpeciesNameMapsCache(locale);
+        // Drop stale results: a newer search may have started while we were
+        // waiting on the species map; firing the backend request anyway
+        // would race the newer call.
+        if (searchId !== currentSearchId) return;
         resolvedSpecies = resolveSpeciesQuery(speciesSearchTerm, maps);
       }
 

--- a/frontend/src/lib/desktop/views/Search.svelte
+++ b/frontend/src/lib/desktop/views/Search.svelte
@@ -28,6 +28,12 @@
   import { dropdown } from '$lib/utils/transitions';
   import { hasReviewPermission, isAuthenticated } from '$lib/utils/auth';
   import { loggers } from '$lib/utils/logger';
+  import {
+    buildSpeciesNameMaps,
+    resolveSpeciesQuery,
+    type SpeciesApiEntry,
+    type SpeciesNameMaps,
+  } from '$lib/utils/speciesNames';
 
   // SPINNER CONTROL: Set to false to disable loading spinners (reduces flickering)
   // Change back to true to re-enable spinners for testing
@@ -172,6 +178,42 @@
   let hasConfidenceError = $state(false);
   let showTooltip = $state<string | null>(null);
 
+  // Species-name lookup maps for resolving user-entered common names
+  // (in the BirdNET label locale) to scientific names before querying the
+  // backend search endpoint. Loaded lazily on first search.
+  let speciesNameMaps = $state<SpeciesNameMaps | null>(null);
+  let speciesMapsLoadInFlight: Promise<SpeciesNameMaps | null> | null = null;
+
+  /**
+   * Load the full species list from /api/v2/species/all once, build
+   * bidirectional name maps, and cache the result. Subsequent calls return
+   * the cached maps. Failures are logged without surfacing to the user,
+   * since the search falls back to the raw query string.
+   */
+  async function ensureSpeciesNameMaps(): Promise<SpeciesNameMaps | null> {
+    if (speciesNameMaps) return speciesNameMaps;
+    if (speciesMapsLoadInFlight) return speciesMapsLoadInFlight;
+
+    speciesMapsLoadInFlight = (async () => {
+      try {
+        interface SpeciesListResponse {
+          species?: SpeciesApiEntry[];
+        }
+        const data = await api.get<SpeciesListResponse>('/api/v2/species/all');
+        const maps = buildSpeciesNameMaps(data.species ?? []);
+        speciesNameMaps = maps;
+        return maps;
+      } catch (error: unknown) {
+        logger.error('Failed to load species name map for search', error);
+        return null;
+      } finally {
+        speciesMapsLoadInFlight = null;
+      }
+    })();
+
+    return speciesMapsLoadInFlight;
+  }
+
   // Localized pluralized results count using i18n keys
   function formatResultsCount(count: number) {
     if (!count || count === 0) return t('search.resultsCountZero');
@@ -220,9 +262,18 @@
     expandedItems.clear(); // Reset expanded state when loading new results
 
     try {
+      // Resolve common-name input to a scientific name before querying.
+      // The backend /api/v2/search endpoint only searches scientific names,
+      // so a user typing e.g. "Tawny Owl" (or "Lehtopöllö" when the BirdNET
+      // label locale is Finnish) needs to be mapped to "Strix aluco" first.
+      // Falls back to the raw input if the map cannot be loaded or no match
+      // is found, preserving partial scientific-name search behaviour.
+      const maps = await ensureSpeciesNameMaps();
+      const resolvedSpecies = resolveSpeciesQuery(speciesSearchTerm, maps);
+
       // Build request body
       const requestBody = {
-        species: speciesSearchTerm,
+        species: resolvedSpecies,
         dateStart: dateRange.start,
         dateEnd: dateRange.end,
         confidenceMin: confidenceRange.min / 100,

--- a/frontend/src/lib/utils/speciesNames.test.ts
+++ b/frontend/src/lib/utils/speciesNames.test.ts
@@ -278,9 +278,12 @@ describe('resolveSpeciesQuery', () => {
     expect(resolveSpeciesQuery('Turdus', maps)).toBe('Turdus');
   });
 
-  it('falls back to substring match on common names', () => {
-    // "Owl" is a substring of "Tawny Owl"; should resolve to Strix aluco.
-    expect(resolveSpeciesQuery('owl', maps)).toBe('Strix aluco');
+  it('passes ambiguous partial common-name fragments through verbatim', () => {
+    // "owl" is a substring of "Tawny Owl" but it is also a substring of
+    // every other owl in the BirdNET label set. The resolver must NOT
+    // collapse it to whichever entry happens to be inserted first in the
+    // map; the backend LIKE clause is responsible for partial matching.
+    expect(resolveSpeciesQuery('owl', maps)).toBe('owl');
   });
 
   it('returns the raw input when there is no match at all', () => {

--- a/frontend/src/lib/utils/speciesNames.test.ts
+++ b/frontend/src/lib/utils/speciesNames.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, beforeAll } from 'vitest';
 import {
   buildSpeciesNameMaps,
-  looksLikeScientificName,
   resolveSpeciesDisplayNames,
   resolveSpeciesQuery,
   isSpeciesInList,
@@ -174,52 +173,6 @@ describe('isSpeciesInList', () => {
   it('returns false when species is not in list at all', () => {
     const list = ['Tawny Owl'];
     expect(isSpeciesInList('Great Tit', list, maps)).toBe(false);
-  });
-});
-
-describe('looksLikeScientificName', () => {
-  it('accepts two-word Latin binomial with capitalised genus', () => {
-    expect(looksLikeScientificName('Strix aluco')).toBe(true);
-    expect(looksLikeScientificName('Turdus merula')).toBe(true);
-  });
-
-  it('rejects single-word capitalised tokens so they fall through to the common-name resolver', () => {
-    // Short capitalised words like "Owl" or "Tit" are common English names,
-    // not binomials. They must not bypass common-name lookup.
-    expect(looksLikeScientificName('Owl')).toBe(false);
-    expect(looksLikeScientificName('Tit')).toBe(false);
-    expect(looksLikeScientificName('Pito')).toBe(false);
-    // Even a genuine genus name like "Turdus" should fall through; the
-    // resolver can still forward it to the backend for partial matching.
-    expect(looksLikeScientificName('Turdus')).toBe(false);
-  });
-
-  it('rejects binomials where the species epithet is not all lowercase', () => {
-    // Species epithets in binomial nomenclature are always lowercase.
-    expect(looksLikeScientificName('Strix Aluco')).toBe(false);
-    expect(looksLikeScientificName('Parus MAJOR')).toBe(false);
-  });
-
-  it('rejects lowercase first letter', () => {
-    expect(looksLikeScientificName('turdus merula')).toBe(false);
-  });
-
-  it('rejects common names with three or more tokens', () => {
-    expect(looksLikeScientificName('Eurasian Blue Tit')).toBe(false);
-  });
-
-  it('rejects non-ASCII common names', () => {
-    expect(looksLikeScientificName('Lehtopöllö')).toBe(false);
-    expect(looksLikeScientificName('Mésange charbonnière')).toBe(false);
-  });
-
-  it('rejects empty or whitespace-only input', () => {
-    expect(looksLikeScientificName('')).toBe(false);
-    expect(looksLikeScientificName('   ')).toBe(false);
-  });
-
-  it('rejects strings with digits', () => {
-    expect(looksLikeScientificName('Turdus 2')).toBe(false);
   });
 });
 

--- a/frontend/src/lib/utils/speciesNames.test.ts
+++ b/frontend/src/lib/utils/speciesNames.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect, beforeAll } from 'vitest';
 import {
   buildSpeciesNameMaps,
+  looksLikeScientificName,
   resolveSpeciesDisplayNames,
+  resolveSpeciesQuery,
   isSpeciesInList,
   type SpeciesNameMaps,
   type SpeciesApiEntry,
@@ -134,5 +136,101 @@ describe('isSpeciesInList', () => {
   it('returns false when species is not in list at all', () => {
     const list = ['Tawny Owl'];
     expect(isSpeciesInList('Great Tit', list, maps)).toBe(false);
+  });
+});
+
+describe('looksLikeScientificName', () => {
+  it('accepts two-word Latin binomial with capitalised genus', () => {
+    expect(looksLikeScientificName('Strix aluco')).toBe(true);
+    expect(looksLikeScientificName('Turdus merula')).toBe(true);
+  });
+
+  it('accepts a single capitalised ASCII token (genus only)', () => {
+    expect(looksLikeScientificName('Turdus')).toBe(true);
+  });
+
+  it('rejects lowercase first letter', () => {
+    expect(looksLikeScientificName('turdus merula')).toBe(false);
+  });
+
+  it('rejects common names with three or more tokens', () => {
+    expect(looksLikeScientificName('Eurasian Blue Tit')).toBe(false);
+  });
+
+  it('rejects non-ASCII common names', () => {
+    expect(looksLikeScientificName('Lehtopöllö')).toBe(false);
+    expect(looksLikeScientificName('Mésange charbonnière')).toBe(false);
+  });
+
+  it('rejects empty or whitespace-only input', () => {
+    expect(looksLikeScientificName('')).toBe(false);
+    expect(looksLikeScientificName('   ')).toBe(false);
+  });
+
+  it('rejects strings with digits', () => {
+    expect(looksLikeScientificName('Turdus 2')).toBe(false);
+  });
+});
+
+describe('resolveSpeciesQuery', () => {
+  let maps: SpeciesNameMaps;
+
+  beforeAll(() => {
+    const sampleSpecies: SpeciesApiEntry[] = [
+      { commonName: 'Tawny Owl', scientificName: 'Strix aluco', label: 'Strix aluco_Tawny Owl' },
+      { commonName: 'Great Tit', scientificName: 'Parus major', label: 'Parus major_Great Tit' },
+      {
+        commonName: 'Lehtopöllö',
+        scientificName: 'Strix aluco',
+        label: 'Strix aluco_Lehtopöllö',
+      },
+      {
+        commonName: 'Eurasian Blue Tit',
+        scientificName: 'Cyanistes caeruleus',
+        label: 'Cyanistes caeruleus_Eurasian Blue Tit',
+      },
+    ];
+    maps = buildSpeciesNameMaps(sampleSpecies);
+  });
+
+  it('returns empty string for empty input', () => {
+    expect(resolveSpeciesQuery('', maps)).toBe('');
+    expect(resolveSpeciesQuery('   ', maps)).toBe('');
+  });
+
+  it('falls back to raw input when maps are null', () => {
+    expect(resolveSpeciesQuery('Tawny Owl', null)).toBe('Tawny Owl');
+  });
+
+  it('resolves an exact common-name hit to its scientific name', () => {
+    expect(resolveSpeciesQuery('Tawny Owl', maps)).toBe('Strix aluco');
+  });
+
+  it('resolves case-insensitively', () => {
+    expect(resolveSpeciesQuery('tawny owl', maps)).toBe('Strix aluco');
+    expect(resolveSpeciesQuery('GREAT TIT', maps)).toBe('Parus major');
+  });
+
+  it('resolves non-ASCII common names (e.g. Finnish)', () => {
+    expect(resolveSpeciesQuery('Lehtopöllö', maps)).toBe('Strix aluco');
+    expect(resolveSpeciesQuery('lehtopöllö', maps)).toBe('Strix aluco');
+  });
+
+  it('passes scientific-looking input through unchanged', () => {
+    expect(resolveSpeciesQuery('Strix aluco', maps)).toBe('Strix aluco');
+    expect(resolveSpeciesQuery('Turdus', maps)).toBe('Turdus');
+  });
+
+  it('falls back to substring match on common names', () => {
+    // "Owl" is a substring of "Tawny Owl"; should resolve to Strix aluco.
+    expect(resolveSpeciesQuery('owl', maps)).toBe('Strix aluco');
+  });
+
+  it('returns the raw input when there is no match at all', () => {
+    expect(resolveSpeciesQuery('nonexistent', maps)).toBe('nonexistent');
+  });
+
+  it('trims leading and trailing whitespace', () => {
+    expect(resolveSpeciesQuery('  Tawny Owl  ', maps)).toBe('Strix aluco');
   });
 });

--- a/frontend/src/lib/utils/speciesNames.test.ts
+++ b/frontend/src/lib/utils/speciesNames.test.ts
@@ -20,6 +20,44 @@ describe('buildSpeciesNameMaps', () => {
     },
   ];
 
+  it('accepts snake_case keys as a fallback shape', () => {
+    // Guards against regressions if an API response ever lands with
+    // snake_case keys (e.g. a different species endpoint is reused here).
+    const snakeCaseEntries: SpeciesApiEntry[] = [
+      {
+        common_name: 'Tawny Owl',
+        scientific_name: 'Strix aluco',
+        label: 'Strix aluco_Tawny Owl',
+      },
+      {
+        common_name: 'Great Tit',
+        scientific_name: 'Parus major',
+        label: 'Parus major_Great Tit',
+      },
+    ];
+    const maps = buildSpeciesNameMaps(snakeCaseEntries);
+    expect(maps.commonToScientific.get('tawny owl')).toBe('Strix aluco');
+    expect(maps.scientificToCommon.get('strix aluco')).toBe('Tawny Owl');
+    expect(maps.allNames).toContain('Tawny Owl');
+    expect(maps.allNames).toContain('Parus major');
+  });
+
+  it('prefers camelCase over snake_case when both are present', () => {
+    const entries: SpeciesApiEntry[] = [
+      {
+        commonName: 'Tawny Owl',
+        scientificName: 'Strix aluco',
+        common_name: 'WRONG',
+        scientific_name: 'WRONG',
+        label: 'Strix aluco_Tawny Owl',
+      },
+    ];
+    const maps = buildSpeciesNameMaps(entries);
+    expect(maps.commonToScientific.get('tawny owl')).toBe('Strix aluco');
+    expect(maps.scientificToCommon.get('strix aluco')).toBe('Tawny Owl');
+    expect(maps.commonToScientific.has('wrong')).toBe(false);
+  });
+
   it('builds commonToScientific map keyed by lowercase common name', () => {
     const maps = buildSpeciesNameMaps(sampleSpecies);
     expect(maps.commonToScientific.get('tawny owl')).toBe('Strix aluco');
@@ -145,8 +183,21 @@ describe('looksLikeScientificName', () => {
     expect(looksLikeScientificName('Turdus merula')).toBe(true);
   });
 
-  it('accepts a single capitalised ASCII token (genus only)', () => {
-    expect(looksLikeScientificName('Turdus')).toBe(true);
+  it('rejects single-word capitalised tokens so they fall through to the common-name resolver', () => {
+    // Short capitalised words like "Owl" or "Tit" are common English names,
+    // not binomials. They must not bypass common-name lookup.
+    expect(looksLikeScientificName('Owl')).toBe(false);
+    expect(looksLikeScientificName('Tit')).toBe(false);
+    expect(looksLikeScientificName('Pito')).toBe(false);
+    // Even a genuine genus name like "Turdus" should fall through; the
+    // resolver can still forward it to the backend for partial matching.
+    expect(looksLikeScientificName('Turdus')).toBe(false);
+  });
+
+  it('rejects binomials where the species epithet is not all lowercase', () => {
+    // Species epithets in binomial nomenclature are always lowercase.
+    expect(looksLikeScientificName('Strix Aluco')).toBe(false);
+    expect(looksLikeScientificName('Parus MAJOR')).toBe(false);
   });
 
   it('rejects lowercase first letter', () => {
@@ -218,6 +269,12 @@ describe('resolveSpeciesQuery', () => {
 
   it('passes scientific-looking input through unchanged', () => {
     expect(resolveSpeciesQuery('Strix aluco', maps)).toBe('Strix aluco');
+  });
+
+  it('passes through single-word capitalised input as raw, letting the backend partial-match', () => {
+    // "Turdus" is a genus name but no common name in the map contains the
+    // substring "turdus", so the resolver should return the raw input so
+    // the backend LIKE clause can still match scientific names.
     expect(resolveSpeciesQuery('Turdus', maps)).toBe('Turdus');
   });
 

--- a/frontend/src/lib/utils/speciesNames.ts
+++ b/frontend/src/lib/utils/speciesNames.ts
@@ -6,10 +6,22 @@
  * (nameMaps struct with common and species maps).
  */
 
-/** Shape of a species entry from /api/v2/species/all */
+/**
+ * Shape of a species entry from /api/v2/species/all.
+ *
+ * The canonical endpoint (`RangeFilterSpecies` in internal/api/v2/range.go)
+ * serialises as camelCase. A few other species-related Go structs
+ * (e.g. `SpeciesInfo`) use snake_case tags, so this interface accepts both
+ * key shapes defensively. Callers should not rely on snake_case from
+ * `/api/v2/species/all` specifically, but the fallback keeps us safe if
+ * a different species endpoint is ever plumbed through this helper.
+ */
 export interface SpeciesApiEntry {
   commonName?: string;
   scientificName?: string;
+  // Fallback snake_case keys for endpoints that serialise in that style.
+  common_name?: string;
+  scientific_name?: string;
   label: string;
 }
 
@@ -39,8 +51,10 @@ export function buildSpeciesNameMaps(species: SpeciesApiEntry[]): SpeciesNameMap
   const namesSet = new Set<string>();
 
   for (const s of species) {
-    const commonName = s.commonName ?? s.label;
-    const scientificName = s.scientificName ?? '';
+    // Prefer camelCase (the canonical shape for /api/v2/species/all); fall
+    // back to snake_case, then to the combined `label` for common name only.
+    const commonName = s.commonName ?? s.common_name ?? s.label;
+    const scientificName = s.scientificName ?? s.scientific_name ?? '';
 
     // Always add common name to allNames for autocomplete, even without scientific name
     if (commonName) {
@@ -107,14 +121,20 @@ export function resolveSpeciesDisplayNames(
 }
 
 /**
- * Heuristic check whether a query string looks like a scientific name
+ * Heuristic check whether a query string looks like a full Latin binomial
  * (e.g. "Turdus merula", "Parus major"). Used to skip common-name resolution
- * for inputs that are already scientific names or partial scientific names.
+ * for inputs that already look like a binomial.
  *
  * Rules:
  *   - ASCII letters, spaces, and hyphens only (no diacritics, no digits)
- *   - One or two whitespace-separated tokens
- *   - First token starts with an uppercase letter
+ *   - Exactly two whitespace-separated tokens
+ *   - First token (genus) starts with an uppercase letter
+ *   - Second token (species epithet) is entirely lowercase, matching
+ *     standard binomial nomenclature
+ *
+ * Single-word capitalised inputs like "Owl", "Tit", or even "Turdus" are
+ * rejected so they fall through to the common-name resolver, which can
+ * still pass them to the backend for partial scientific-name matching.
  */
 export function looksLikeScientificName(input: string): boolean {
   const trimmed = input.trim();
@@ -124,10 +144,13 @@ export function looksLikeScientificName(input: string): boolean {
   if (!/^[A-Za-z][A-Za-z\- ]*$/.test(trimmed)) return false;
 
   const tokens = trimmed.split(/\s+/);
-  if (tokens.length < 1 || tokens.length > 2) return false;
+  if (tokens.length !== 2) return false;
 
   const firstChar = tokens[0]?.charAt(0) ?? '';
-  return firstChar >= 'A' && firstChar <= 'Z';
+  if (firstChar < 'A' || firstChar > 'Z') return false;
+
+  const secondToken = tokens[1] ?? '';
+  return secondToken.length > 0 && secondToken === secondToken.toLowerCase();
 }
 
 /**

--- a/frontend/src/lib/utils/speciesNames.ts
+++ b/frontend/src/lib/utils/speciesNames.ts
@@ -107,6 +107,73 @@ export function resolveSpeciesDisplayNames(
 }
 
 /**
+ * Heuristic check whether a query string looks like a scientific name
+ * (e.g. "Turdus merula", "Parus major"). Used to skip common-name resolution
+ * for inputs that are already scientific names or partial scientific names.
+ *
+ * Rules:
+ *   - ASCII letters, spaces, and hyphens only (no diacritics, no digits)
+ *   - One or two whitespace-separated tokens
+ *   - First token starts with an uppercase letter
+ */
+export function looksLikeScientificName(input: string): boolean {
+  const trimmed = input.trim();
+  if (!trimmed) return false;
+
+  // Reject anything with diacritics, digits, or unexpected punctuation.
+  if (!/^[A-Za-z][A-Za-z\- ]*$/.test(trimmed)) return false;
+
+  const tokens = trimmed.split(/\s+/);
+  if (tokens.length < 1 || tokens.length > 2) return false;
+
+  const firstChar = tokens[0]?.charAt(0) ?? '';
+  return firstChar >= 'A' && firstChar <= 'Z';
+}
+
+/**
+ * Resolve a free-text species query (common name or scientific name) to a
+ * scientific name suitable for the backend search filter, using a prebuilt
+ * species name map (derived from /api/v2/species/all, which follows the
+ * BirdNET label locale).
+ *
+ * Behavior:
+ *   - Empty input returns empty string.
+ *   - If a common name exactly matches (case-insensitive), returns the matching
+ *     scientific name.
+ *   - If the input looks like a scientific name, passes it through unchanged.
+ *   - Otherwise, looks for a case-insensitive substring match against common
+ *     names; returns the first hit's scientific name.
+ *   - If no match is found, returns the raw input so the backend can still
+ *     attempt a partial match on scientific names.
+ */
+export function resolveSpeciesQuery(input: string, maps: SpeciesNameMaps | null): string {
+  const trimmed = input.trim();
+  if (!trimmed) return '';
+  if (!maps) return trimmed;
+
+  const lower = trimmed.toLowerCase();
+
+  // Exact common-name hit wins.
+  const exactCommon = maps.commonToScientific.get(lower);
+  if (exactCommon !== undefined) return exactCommon;
+
+  // Input that already looks like a scientific name: pass through so the
+  // backend can still LIKE-match partial scientific names (e.g. "Turdus").
+  if (looksLikeScientificName(trimmed)) return trimmed;
+
+  // Also pass through if it matches a known scientific name exactly.
+  if (maps.scientificToCommon.has(lower)) return trimmed;
+
+  // Fall back to substring match across common names.
+  for (const [commonLower, scientific] of maps.commonToScientific) {
+    if (commonLower.includes(lower)) return scientific;
+  }
+
+  // No match; let the backend see the raw string as a last resort.
+  return trimmed;
+}
+
+/**
  * Check if a species (by any name alias) is already in a list.
  * Prevents adding "Strix aluco" when "Tawny Owl" is already present (and vice versa).
  */

--- a/frontend/src/lib/utils/speciesNames.ts
+++ b/frontend/src/lib/utils/speciesNames.ts
@@ -163,11 +163,12 @@ export function looksLikeScientificName(input: string): boolean {
  *   - Empty input returns empty string.
  *   - If a common name exactly matches (case-insensitive), returns the matching
  *     scientific name.
- *   - If the input looks like a scientific name, passes it through unchanged.
- *   - Otherwise, looks for a case-insensitive substring match against common
- *     names; returns the first hit's scientific name.
- *   - If no match is found, returns the raw input so the backend can still
- *     attempt a partial match on scientific names.
+ *   - Otherwise the input passes through unchanged so the backend can run its
+ *     own partial scientific-name match (e.g. "Turdus" matching multiple
+ *     species). We deliberately do not collapse ambiguous partial common-name
+ *     fragments like "owl" to a single arbitrary scientific name; that would
+ *     hide other matches behind whichever entry happened to be inserted first
+ *     in the underlying Map.
  */
 export function resolveSpeciesQuery(input: string, maps: SpeciesNameMaps | null): string {
   const trimmed = input.trim();
@@ -180,19 +181,9 @@ export function resolveSpeciesQuery(input: string, maps: SpeciesNameMaps | null)
   const exactCommon = maps.commonToScientific.get(lower);
   if (exactCommon !== undefined) return exactCommon;
 
-  // Input that already looks like a scientific name: pass through so the
-  // backend can still LIKE-match partial scientific names (e.g. "Turdus").
-  if (looksLikeScientificName(trimmed)) return trimmed;
-
-  // Also pass through if it matches a known scientific name exactly.
-  if (maps.scientificToCommon.has(lower)) return trimmed;
-
-  // Fall back to substring match across common names.
-  for (const [commonLower, scientific] of maps.commonToScientific) {
-    if (commonLower.includes(lower)) return scientific;
-  }
-
-  // No match; let the backend see the raw string as a last resort.
+  // Anything else (looks-like-scientific input, exact scientific match,
+  // ambiguous partial fragment, unknown text) passes through verbatim so
+  // the backend's LIKE match on scientific_name keeps working.
   return trimmed;
 }
 

--- a/frontend/src/lib/utils/speciesNames.ts
+++ b/frontend/src/lib/utils/speciesNames.ts
@@ -121,39 +121,6 @@ export function resolveSpeciesDisplayNames(
 }
 
 /**
- * Heuristic check whether a query string looks like a full Latin binomial
- * (e.g. "Turdus merula", "Parus major"). Used to skip common-name resolution
- * for inputs that already look like a binomial.
- *
- * Rules:
- *   - ASCII letters, spaces, and hyphens only (no diacritics, no digits)
- *   - Exactly two whitespace-separated tokens
- *   - First token (genus) starts with an uppercase letter
- *   - Second token (species epithet) is entirely lowercase, matching
- *     standard binomial nomenclature
- *
- * Single-word capitalised inputs like "Owl", "Tit", or even "Turdus" are
- * rejected so they fall through to the common-name resolver, which can
- * still pass them to the backend for partial scientific-name matching.
- */
-export function looksLikeScientificName(input: string): boolean {
-  const trimmed = input.trim();
-  if (!trimmed) return false;
-
-  // Reject anything with diacritics, digits, or unexpected punctuation.
-  if (!/^[A-Za-z][A-Za-z\- ]*$/.test(trimmed)) return false;
-
-  const tokens = trimmed.split(/\s+/);
-  if (tokens.length !== 2) return false;
-
-  const firstChar = tokens[0]?.charAt(0) ?? '';
-  if (firstChar < 'A' || firstChar > 'Z') return false;
-
-  const secondToken = tokens[1] ?? '';
-  return secondToken.length > 0 && secondToken === secondToken.toLowerCase();
-}
-
-/**
  * Resolve a free-text species query (common name or scientific name) to a
  * scientific name suitable for the backend search filter, using a prebuilt
  * species name map (derived from /api/v2/species/all, which follows the


### PR DESCRIPTION
## Summary

`/ui/search` returned zero results when the user entered a common name. The backend `/api/v2/search` filters by scientific name only (the v2 `labelRepository.Search` matches `WHERE scientific_name LIKE ?`, and the v2 `Label` entity has no `common_name` column at all). Users running BirdNET-Go in any locale other than English saw the search look completely broken.

This PR is a **frontend-only unblock**, not the proper schema fix.

### What this PR does

- Loads `/api/v2/species/all` once (the response follows the configured BirdNET label locale, NOT the UI display locale), builds a bidirectional name map cached in module scope and keyed by locale, and uses it to translate user input before the search request goes out.
- Heuristic: an input that looks like a binomial (one capitalised genus + one lowercase epithet, ASCII only) passes through unchanged so partial scientific-name search keeps working. Unknown input falls back to the raw string so behaviour never regresses.
- Race-safe: each in-flight search captures a monotonic `currentSearchId`; results from a stale request are discarded. Cache invalidates on BirdNET label locale change via a `$effect` watching the store. The in-flight fetch's `finally` block only clears its marker if the locale is still the one it fetched for, so a locale flip mid-flight cannot orphan the newer fetch's promise.
- Defensive: `SpeciesApiEntry` accepts both camelCase (current shape used by `/species/all`) and snake_case keys, with tests asserting both shapes work. Cheap insurance against future backend struct refactors.

### What this PR does NOT do

The backend `Label` entity still has no `common_name` column. Filed separately as a follow-up: extend the schema with a `common_name` field (locale-aware), repopulate from BirdNET label files during ingestion, and extend the SQL to `WHERE scientific_name LIKE ? OR common_name LIKE ?`. That is the right long-term fix; this PR unblocks every non-English user immediately while it lands.

## Test plan
- [x] `npm run check:all` clean
- [x] `npm test -- speciesNames Search --run` (57/57)
- [x] Full vitest suite (1881/1881 across 97 files) green
- [x] `task frontend-build` succeeds
- [x] `coderabbit review --plain --base main` no findings (after addressing the in-flight race)
- [ ] Manual: with BirdNET label locale Finnish, search for "Lehtopöllö" returns Strix aluco detections
- [ ] Manual: with English label locale, search "Tawny Owl" returns Strix aluco detections
- [ ] Manual: search "Turdus" still returns partial scientific-name matches
- [ ] Manual: change BirdNET label locale, search again, confirm cache is rebuilt for the new locale

Fixes #2766

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved species search: accepts varied API name formats (snake_case or camelCase), trims input, maps common→scientific names when possible, and preserves scientific-looking queries.
  * Locale-aware caching of species name data with explicit invalidation when locale changes.
  * Safer concurrent-search handling to prevent stale results and incorrect loading state.

* **Tests**
  * Added comprehensive tests for name-map building, resolution rules, precedence, and query behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->