### PR TITLE
fix(basepath): dashboard anchors, RawPath sync, settings hot-reload race

### DIFF
--- a/frontend/src/lib/desktop/features/dashboard/components/DailySummaryCard.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/components/DailySummaryCard.svelte
@@ -52,6 +52,11 @@ Responsive Breakpoints:
   import { t } from '$lib/i18n';
   import type { DailySpeciesSummary } from '$lib/types/detection.types';
   import { getLocalDateString, getLocalTimeString, parseLocalDateString } from '$lib/utils/date';
+  import {
+    buildHourlyDetectionUrl,
+    buildSpeciesDetectionUrl,
+    buildSpeciesHourUrl,
+  } from '$lib/utils/detectionUrls';
   import { buildAppUrl } from '$lib/utils/urlHelpers';
   import { loggers } from '$lib/utils/logger';
   import { LRUCache } from '$lib/utils/LRUCache';
@@ -610,14 +615,15 @@ Responsive Breakpoints:
     urlBuilders.species = (species: DailySpeciesSummary) => {
       const cacheKey = `species:${species.scientific_name}:${selectedDate}`;
       if (!urlCache.has(cacheKey)) {
-        const params = new URLSearchParams({
-          queryType: 'species',
-          species: species.scientific_name,
-          date: selectedDate,
-          numResults: CONFIG.QUERY.DEFAULT_NUM_RESULTS.toString(),
-          offset: '0',
-        });
-        urlCache.set(cacheKey, `/ui/detections?${params.toString()}`);
+        urlCache.set(
+          cacheKey,
+          buildSpeciesDetectionUrl(
+            species.scientific_name,
+            selectedDate,
+            CONFIG.QUERY.DEFAULT_NUM_RESULTS,
+            0
+          )
+        );
       }
       return urlCache.get(cacheKey)!;
     };
@@ -629,16 +635,17 @@ Responsive Breakpoints:
     ) => {
       const cacheKey = `species-hour:${species.scientific_name}:${selectedDate}:${hour}:${duration}`;
       if (!urlCache.has(cacheKey)) {
-        const params = new URLSearchParams({
-          queryType: 'species',
-          species: species.scientific_name,
-          date: selectedDate,
-          hour: hour.toString(),
-          duration: duration.toString(),
-          numResults: CONFIG.QUERY.DEFAULT_NUM_RESULTS.toString(),
-          offset: '0',
-        });
-        urlCache.set(cacheKey, `/ui/detections?${params.toString()}`);
+        urlCache.set(
+          cacheKey,
+          buildSpeciesHourUrl(
+            species.scientific_name,
+            selectedDate,
+            hour,
+            duration,
+            CONFIG.QUERY.DEFAULT_NUM_RESULTS,
+            0
+          )
+        );
       }
       return urlCache.get(cacheKey)!;
     };
@@ -646,15 +653,10 @@ Responsive Breakpoints:
     urlBuilders.hourly = (hour: number, duration: number = 1) => {
       const cacheKey = `hourly:${selectedDate}:${hour}:${duration}`;
       if (!urlCache.has(cacheKey)) {
-        const params = new URLSearchParams({
-          queryType: 'hourly',
-          date: selectedDate,
-          hour: hour.toString(),
-          duration: duration.toString(),
-          numResults: CONFIG.QUERY.DEFAULT_NUM_RESULTS.toString(),
-          offset: '0',
-        });
-        urlCache.set(cacheKey, `/ui/detections?${params.toString()}`);
+        urlCache.set(
+          cacheKey,
+          buildHourlyDetectionUrl(selectedDate, hour, duration, CONFIG.QUERY.DEFAULT_NUM_RESULTS, 0)
+        );
       }
       return urlCache.get(cacheKey)!;
     };

--- a/frontend/src/lib/utils/__tests__/detectionUrls.test.ts
+++ b/frontend/src/lib/utils/__tests__/detectionUrls.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import {
   buildHourlyDetectionUrl,
   buildSpeciesDetectionUrl,
@@ -6,88 +6,97 @@ import {
 } from '../detectionUrls';
 import { resetBasePath, setBasePath } from '../urlHelpers';
 
+// Shared test fixtures so a change to the date, basepath, or species value
+// only needs to happen in one place.
+const TEST_DATE = '2026-04-15';
+const TEST_BASE_PATH = '/birdnet';
+const TEST_SPECIES = 'Turdus merula';
+
 describe('detectionUrls', () => {
   beforeEach(() => {
+    vi.clearAllMocks();
     resetBasePath();
   });
 
   describe('buildHourlyDetectionUrl', () => {
     it('returns unprefixed URL when no basepath is set', () => {
-      const url = buildHourlyDetectionUrl('2026-04-15', 7, 1);
-      expect(url).toBe('/ui/detections?queryType=hourly&date=2026-04-15&hour=7&duration=1');
+      const url = buildHourlyDetectionUrl(TEST_DATE, 7, 1);
+      expect(url).toBe(`/ui/detections?queryType=hourly&date=${TEST_DATE}&hour=7&duration=1`);
     });
 
-    it('prepends /birdnet when setBasePath("/birdnet") is active', () => {
-      setBasePath('/birdnet');
-      const url = buildHourlyDetectionUrl('2026-04-15', 7, 1);
-      expect(url).toBe('/birdnet/ui/detections?queryType=hourly&date=2026-04-15&hour=7&duration=1');
+    it(`prepends ${TEST_BASE_PATH} when setBasePath(${TEST_BASE_PATH}) is active`, () => {
+      setBasePath(TEST_BASE_PATH);
+      const url = buildHourlyDetectionUrl(TEST_DATE, 7, 1);
+      expect(url).toBe(
+        `${TEST_BASE_PATH}/ui/detections?queryType=hourly&date=${TEST_DATE}&hour=7&duration=1`
+      );
     });
 
     it('prepends Home Assistant ingress basepath', () => {
       setBasePath('/api/hassio_ingress/TOKEN');
-      const url = buildHourlyDetectionUrl('2026-04-15', 7, 1);
+      const url = buildHourlyDetectionUrl(TEST_DATE, 7, 1);
       expect(url).toBe(
-        '/api/hassio_ingress/TOKEN/ui/detections?queryType=hourly&date=2026-04-15&hour=7&duration=1'
+        `/api/hassio_ingress/TOKEN/ui/detections?queryType=hourly&date=${TEST_DATE}&hour=7&duration=1`
       );
     });
 
     it('is idempotent when called twice with same args', () => {
-      setBasePath('/birdnet');
-      const a = buildHourlyDetectionUrl('2026-04-15', 7, 1);
-      const b = buildHourlyDetectionUrl('2026-04-15', 7, 1);
+      setBasePath(TEST_BASE_PATH);
+      const a = buildHourlyDetectionUrl(TEST_DATE, 7, 1);
+      const b = buildHourlyDetectionUrl(TEST_DATE, 7, 1);
       expect(a).toBe(b);
     });
 
     it('includes numResults and offset when provided', () => {
-      const url = buildHourlyDetectionUrl('2026-04-15', 7, 1, 50, 0);
+      const url = buildHourlyDetectionUrl(TEST_DATE, 7, 1, 50, 0);
       expect(url).toBe(
-        '/ui/detections?queryType=hourly&date=2026-04-15&hour=7&duration=1&numResults=50&offset=0'
+        `/ui/detections?queryType=hourly&date=${TEST_DATE}&hour=7&duration=1&numResults=50&offset=0`
       );
     });
   });
 
   describe('buildSpeciesDetectionUrl', () => {
     it('returns unprefixed URL with URL-encoded species name', () => {
-      const url = buildSpeciesDetectionUrl('Turdus merula', '2026-04-15');
-      expect(url).toBe('/ui/detections?queryType=species&species=Turdus+merula&date=2026-04-15');
+      const url = buildSpeciesDetectionUrl(TEST_SPECIES, TEST_DATE);
+      expect(url).toBe(`/ui/detections?queryType=species&species=Turdus+merula&date=${TEST_DATE}`);
     });
 
     it('prepends basepath when set', () => {
-      setBasePath('/birdnet');
-      const url = buildSpeciesDetectionUrl('Turdus merula', '2026-04-15');
+      setBasePath(TEST_BASE_PATH);
+      const url = buildSpeciesDetectionUrl(TEST_SPECIES, TEST_DATE);
       expect(url).toBe(
-        '/birdnet/ui/detections?queryType=species&species=Turdus+merula&date=2026-04-15'
+        `${TEST_BASE_PATH}/ui/detections?queryType=species&species=Turdus+merula&date=${TEST_DATE}`
       );
     });
 
     it('includes numResults and offset when provided', () => {
-      const url = buildSpeciesDetectionUrl('Turdus merula', '2026-04-15', 50, 10);
+      const url = buildSpeciesDetectionUrl(TEST_SPECIES, TEST_DATE, 50, 10);
       expect(url).toBe(
-        '/ui/detections?queryType=species&species=Turdus+merula&date=2026-04-15&numResults=50&offset=10'
+        `/ui/detections?queryType=species&species=Turdus+merula&date=${TEST_DATE}&numResults=50&offset=10`
       );
     });
   });
 
   describe('buildSpeciesHourUrl', () => {
     it('returns unprefixed URL with hour and duration', () => {
-      const url = buildSpeciesHourUrl('Turdus merula', '2026-04-15', 7, 2);
+      const url = buildSpeciesHourUrl(TEST_SPECIES, TEST_DATE, 7, 2);
       expect(url).toBe(
-        '/ui/detections?queryType=species&species=Turdus+merula&date=2026-04-15&hour=7&duration=2'
+        `/ui/detections?queryType=species&species=Turdus+merula&date=${TEST_DATE}&hour=7&duration=2`
       );
     });
 
     it('prepends basepath when set', () => {
-      setBasePath('/birdnet');
-      const url = buildSpeciesHourUrl('Turdus merula', '2026-04-15', 7, 2);
+      setBasePath(TEST_BASE_PATH);
+      const url = buildSpeciesHourUrl(TEST_SPECIES, TEST_DATE, 7, 2);
       expect(url).toBe(
-        '/birdnet/ui/detections?queryType=species&species=Turdus+merula&date=2026-04-15&hour=7&duration=2'
+        `${TEST_BASE_PATH}/ui/detections?queryType=species&species=Turdus+merula&date=${TEST_DATE}&hour=7&duration=2`
       );
     });
 
     it('encodes species names with non-ASCII characters', () => {
-      const url = buildSpeciesHourUrl('Pöllö lajinimi', '2026-04-15', 7, 1);
+      const url = buildSpeciesHourUrl('Pöllö lajinimi', TEST_DATE, 7, 1);
       expect(url).toBe(
-        '/ui/detections?queryType=species&species=P%C3%B6ll%C3%B6+lajinimi&date=2026-04-15&hour=7&duration=1'
+        `/ui/detections?queryType=species&species=P%C3%B6ll%C3%B6+lajinimi&date=${TEST_DATE}&hour=7&duration=1`
       );
     });
   });

--- a/frontend/src/lib/utils/__tests__/detectionUrls.test.ts
+++ b/frontend/src/lib/utils/__tests__/detectionUrls.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  buildHourlyDetectionUrl,
+  buildSpeciesDetectionUrl,
+  buildSpeciesHourUrl,
+} from '../detectionUrls';
+import { resetBasePath, setBasePath } from '../urlHelpers';
+
+describe('detectionUrls', () => {
+  beforeEach(() => {
+    resetBasePath();
+  });
+
+  describe('buildHourlyDetectionUrl', () => {
+    it('returns unprefixed URL when no basepath is set', () => {
+      const url = buildHourlyDetectionUrl('2026-04-15', 7, 1);
+      expect(url).toBe('/ui/detections?queryType=hourly&date=2026-04-15&hour=7&duration=1');
+    });
+
+    it('prepends /birdnet when setBasePath("/birdnet") is active', () => {
+      setBasePath('/birdnet');
+      const url = buildHourlyDetectionUrl('2026-04-15', 7, 1);
+      expect(url).toBe('/birdnet/ui/detections?queryType=hourly&date=2026-04-15&hour=7&duration=1');
+    });
+
+    it('prepends Home Assistant ingress basepath', () => {
+      setBasePath('/api/hassio_ingress/TOKEN');
+      const url = buildHourlyDetectionUrl('2026-04-15', 7, 1);
+      expect(url).toBe(
+        '/api/hassio_ingress/TOKEN/ui/detections?queryType=hourly&date=2026-04-15&hour=7&duration=1'
+      );
+    });
+
+    it('is idempotent when called twice with same args', () => {
+      setBasePath('/birdnet');
+      const a = buildHourlyDetectionUrl('2026-04-15', 7, 1);
+      const b = buildHourlyDetectionUrl('2026-04-15', 7, 1);
+      expect(a).toBe(b);
+    });
+
+    it('includes numResults and offset when provided', () => {
+      const url = buildHourlyDetectionUrl('2026-04-15', 7, 1, 50, 0);
+      expect(url).toBe(
+        '/ui/detections?queryType=hourly&date=2026-04-15&hour=7&duration=1&numResults=50&offset=0'
+      );
+    });
+  });
+
+  describe('buildSpeciesDetectionUrl', () => {
+    it('returns unprefixed URL with URL-encoded species name', () => {
+      const url = buildSpeciesDetectionUrl('Turdus merula', '2026-04-15');
+      expect(url).toBe('/ui/detections?queryType=species&species=Turdus+merula&date=2026-04-15');
+    });
+
+    it('prepends basepath when set', () => {
+      setBasePath('/birdnet');
+      const url = buildSpeciesDetectionUrl('Turdus merula', '2026-04-15');
+      expect(url).toBe(
+        '/birdnet/ui/detections?queryType=species&species=Turdus+merula&date=2026-04-15'
+      );
+    });
+
+    it('includes numResults and offset when provided', () => {
+      const url = buildSpeciesDetectionUrl('Turdus merula', '2026-04-15', 50, 10);
+      expect(url).toContain('numResults=50');
+      expect(url).toContain('offset=10');
+    });
+  });
+
+  describe('buildSpeciesHourUrl', () => {
+    it('returns unprefixed URL with hour and duration', () => {
+      const url = buildSpeciesHourUrl('Turdus merula', '2026-04-15', 7, 2);
+      expect(url).toBe(
+        '/ui/detections?queryType=species&species=Turdus+merula&date=2026-04-15&hour=7&duration=2'
+      );
+    });
+
+    it('prepends basepath when set', () => {
+      setBasePath('/birdnet');
+      const url = buildSpeciesHourUrl('Turdus merula', '2026-04-15', 7, 2);
+      expect(url.startsWith('/birdnet/ui/detections?')).toBe(true);
+      expect(url).toContain('species=Turdus+merula');
+    });
+
+    it('encodes species names with non-ASCII characters', () => {
+      const url = buildSpeciesHourUrl('Pöllö lajinimi', '2026-04-15', 7, 1);
+      expect(url).toContain('species=P%C3%B6ll%C3%B6+lajinimi');
+    });
+  });
+});

--- a/frontend/src/lib/utils/__tests__/detectionUrls.test.ts
+++ b/frontend/src/lib/utils/__tests__/detectionUrls.test.ts
@@ -62,8 +62,9 @@ describe('detectionUrls', () => {
 
     it('includes numResults and offset when provided', () => {
       const url = buildSpeciesDetectionUrl('Turdus merula', '2026-04-15', 50, 10);
-      expect(url).toContain('numResults=50');
-      expect(url).toContain('offset=10');
+      expect(url).toBe(
+        '/ui/detections?queryType=species&species=Turdus+merula&date=2026-04-15&numResults=50&offset=10'
+      );
     });
   });
 
@@ -78,13 +79,16 @@ describe('detectionUrls', () => {
     it('prepends basepath when set', () => {
       setBasePath('/birdnet');
       const url = buildSpeciesHourUrl('Turdus merula', '2026-04-15', 7, 2);
-      expect(url.startsWith('/birdnet/ui/detections?')).toBe(true);
-      expect(url).toContain('species=Turdus+merula');
+      expect(url).toBe(
+        '/birdnet/ui/detections?queryType=species&species=Turdus+merula&date=2026-04-15&hour=7&duration=2'
+      );
     });
 
     it('encodes species names with non-ASCII characters', () => {
       const url = buildSpeciesHourUrl('Pöllö lajinimi', '2026-04-15', 7, 1);
-      expect(url).toContain('species=P%C3%B6ll%C3%B6+lajinimi');
+      expect(url).toBe(
+        '/ui/detections?queryType=species&species=P%C3%B6ll%C3%B6+lajinimi&date=2026-04-15&hour=7&duration=1'
+      );
     });
   });
 });

--- a/frontend/src/lib/utils/detectionUrls.ts
+++ b/frontend/src/lib/utils/detectionUrls.ts
@@ -1,0 +1,78 @@
+/**
+ * Detection URL builders for the dashboard.
+ *
+ * These functions wrap buildAppUrl so every anchor the dashboard emits carries
+ * the current basepath (handles YAML webserver.basepath, X-Forwarded-Prefix, and
+ * Home Assistant X-Ingress-Path). Extracted from DailySummaryCard.svelte which
+ * previously built these URLs inline without the basepath wrap, causing
+ * hourly-grid and species-row anchors to 404 through reverse proxies when the
+ * DB had detection rows (Forgejo #446).
+ */
+
+import { buildAppUrl } from './urlHelpers';
+
+/**
+ * Builds a detection-list URL filtered to one hour (or a range) on the given date.
+ * Used by the dashboard hourly-grid cells at one, two, and six hour groupings.
+ */
+export function buildHourlyDetectionUrl(
+  date: string,
+  hour: number,
+  durationHours: number,
+  numResults?: number,
+  offset?: number
+): string {
+  const params = new URLSearchParams({
+    queryType: 'hourly',
+    date,
+    hour: hour.toString(),
+    duration: durationHours.toString(),
+  });
+  if (numResults !== undefined) params.set('numResults', numResults.toString());
+  if (offset !== undefined) params.set('offset', offset.toString());
+  return buildAppUrl(`/ui/detections?${params.toString()}`);
+}
+
+/**
+ * Builds a detection-list URL filtered to all detections of a species on a date.
+ * Used by the dashboard species-row anchors.
+ */
+export function buildSpeciesDetectionUrl(
+  scientificName: string,
+  date: string,
+  numResults?: number,
+  offset?: number
+): string {
+  const params = new URLSearchParams({
+    queryType: 'species',
+    species: scientificName,
+    date,
+  });
+  if (numResults !== undefined) params.set('numResults', numResults.toString());
+  if (offset !== undefined) params.set('offset', offset.toString());
+  return buildAppUrl(`/ui/detections?${params.toString()}`);
+}
+
+/**
+ * Builds a detection-list URL filtered to a species within a specific hour window.
+ * Used by the dashboard per-species hourly cells.
+ */
+export function buildSpeciesHourUrl(
+  scientificName: string,
+  date: string,
+  hour: number,
+  durationHours: number,
+  numResults?: number,
+  offset?: number
+): string {
+  const params = new URLSearchParams({
+    queryType: 'species',
+    species: scientificName,
+    date,
+    hour: hour.toString(),
+    duration: durationHours.toString(),
+  });
+  if (numResults !== undefined) params.set('numResults', numResults.toString());
+  if (offset !== undefined) params.set('offset', offset.toString());
+  return buildAppUrl(`/ui/detections?${params.toString()}`);
+}

--- a/internal/api/basepath_race_test.go
+++ b/internal/api/basepath_race_test.go
@@ -21,7 +21,10 @@ import (
 // writers on a clone and publishes via atomic.Pointer.Store; readers always
 // see one of the two valid snapshots.
 func TestIngressPath_RaceAgainstStoreSettings(t *testing.T) {
-	t.Parallel()
+	// Intentionally NOT t.Parallel(): this test mutates conf.settingsInstance
+	// via StoreSettings. A parallel sibling that publishes its own snapshot
+	// would make the "/alpha"/"/beta" assertion flaky even though the
+	// atomic.Pointer itself is race-safe.
 
 	const iterations = 5_000
 

--- a/internal/api/basepath_race_test.go
+++ b/internal/api/basepath_race_test.go
@@ -1,0 +1,67 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/tphakala/birdnet-go/internal/conf"
+)
+
+// TestIngressPath_RaceAgainstStoreSettings exercises the request-path reader
+// (ingressPath) concurrently with conf.StoreSettings publications. Must pass
+// under `go test -race`.
+//
+// Guards against a regression where the basepath strip Pre middleware again
+// starts reading fields off a pointer that can be mutated in place by a
+// settings writer. The new copy-on-write path in api/v2.UpdateSettings keeps
+// writers on a clone and publishes via atomic.Pointer.Store; readers always
+// see one of the two valid snapshots.
+func TestIngressPath_RaceAgainstStoreSettings(t *testing.T) {
+	t.Parallel()
+
+	const iterations = 5_000
+
+	// Capture the pre-test global snapshot so we can restore it after the
+	// test. Parallel tests in other files may depend on their own snapshot.
+	prev := conf.GetSettings()
+	t.Cleanup(func() { conf.StoreSettings(prev) })
+
+	a := &conf.Settings{}
+	a.WebServer.BasePath = "/alpha"
+	b := &conf.Settings{}
+	b.WebServer.BasePath = "/beta"
+
+	conf.StoreSettings(a)
+
+	e := echo.New()
+
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		for i := range iterations {
+			if i%2 == 0 {
+				conf.StoreSettings(a)
+			} else {
+				conf.StoreSettings(b)
+			}
+		}
+	})
+
+	wg.Go(func() {
+		for range iterations {
+			req := httptest.NewRequest(http.MethodGet, "/any", http.NoBody)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+			bp := ingressPath(c, conf.GetSettings())
+			if bp != "/alpha" && bp != "/beta" {
+				t.Errorf("unexpected basepath: %q", bp)
+				return
+			}
+		}
+	})
+
+	wg.Wait()
+}

--- a/internal/api/basepath_test.go
+++ b/internal/api/basepath_test.go
@@ -6,6 +6,7 @@ package api
 import (
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -44,14 +45,21 @@ func stripMiddlewareForTest(getSettings func() *conf.Settings) echo.MiddlewareFu
 						rest = "/"
 					}
 					req.URL.Path = rest
-					// Mirror production: also rewrite RawPath when set,
-					// so percent-encoded paths route correctly under test.
-					if req.URL.RawPath != "" && strings.HasPrefix(req.URL.RawPath, bp) {
-						raw := req.URL.RawPath[len(bp):]
-						if raw == "" {
-							raw = "/"
+					// Mirror production: also rewrite RawPath when set.
+					// Encode bp before the prefix check so encoded basepaths
+					// (spaces, non-ASCII) route correctly, and use the shared
+					// hasPercentEncodedPrefix helper so lowercase-hex proxy
+					// forms match. Kept in lockstep with the production
+					// middleware in internal/api/server.go by hand.
+					if req.URL.RawPath != "" {
+						encodedBP := (&url.URL{Path: bp}).EscapedPath()
+						if n := hasPercentEncodedPrefix(req.URL.RawPath, encodedBP); n >= 0 {
+							raw := req.URL.RawPath[n:]
+							if raw == "" {
+								raw = "/"
+							}
+							req.URL.RawPath = raw
 						}
-						req.URL.RawPath = raw
 					}
 				}
 			}
@@ -178,6 +186,32 @@ func TestBasePathStripMiddleware(t *testing.T) {
 			requestPath:  "/api/v2/health",
 			expectedPath: "/api/v2/health",
 		},
+		{
+			// Issue #447: RawPath is set on the parsed request only when the
+			// raw input differs from Go's default path encoding, e.g. when a
+			// proxy forwards non-canonical escape sequences (%2F for a slash
+			// or lowercase hex). In that case both URL.Path and URL.RawPath
+			// must be stripped in lockstep. Without the fix in Task 4 the
+			// HasPrefix check compares the decoded bp against the percent-
+			// encoded RawPath, fails for basepaths that require encoding, and
+			// leaves RawPath prefixed while Path is stripped.
+			//
+			// Space-in-basepath case: the %2F in the trailing segment forces
+			// RawPath to be non-empty so the bug path is actually exercised.
+			name:         "strips encoded basepath with space",
+			basePath:     "/birdnet go",
+			requestPath:  "/birdnet%20go/ui/a%2Fb",
+			expectedPath: "/ui/a/b",
+		},
+		{
+			// Non-ASCII basepath with lowercase hex encoding from the proxy.
+			// Go's default escape uses uppercase hex, so the raw input is
+			// non-canonical and RawPath is populated on the parsed request.
+			name:         "strips encoded basepath with non-ASCII",
+			basePath:     "/Übersicht",
+			requestPath:  "/%c3%9cbersicht/ui/dashboard",
+			expectedPath: "/ui/dashboard",
+		},
 	}
 
 	for _, tt := range tests {
@@ -186,6 +220,7 @@ func TestBasePathStripMiddleware(t *testing.T) {
 
 			settings := settingsWithBasePath(tt.basePath)
 			var capturedPath string
+			var capturedRawPath string
 			var capturedQuery string
 
 			e := echo.New()
@@ -196,6 +231,7 @@ func TestBasePathStripMiddleware(t *testing.T) {
 			// Catch-all handler to capture the routed path
 			e.Any("/*", func(c echo.Context) error {
 				capturedPath = c.Request().URL.Path
+				capturedRawPath = c.Request().URL.RawPath
 				capturedQuery = c.Request().URL.RawQuery
 				return c.NoContent(http.StatusOK)
 			})
@@ -212,6 +248,18 @@ func TestBasePathStripMiddleware(t *testing.T) {
 			e.ServeHTTP(rec, req)
 
 			assert.Equal(t, tt.expectedPath, capturedPath, "path after stripping")
+			// RawPath must stay in sync with Path once stripping runs; otherwise
+			// Echo's router sees mismatched values and can route inconsistently.
+			// RawPath preserves the original encoding (e.g. %2F stays as %2F),
+			// so compare the decoded form rather than a literal match. Only
+			// checked when RawPath was populated on the parsed request (which
+			// happens only for non-canonically encoded request paths).
+			if capturedRawPath != "" {
+				decoded, err := url.PathUnescape(capturedRawPath)
+				require.NoError(t, err, "URL.RawPath after stripping must decode")
+				assert.Equal(t, tt.expectedPath, decoded,
+					"URL.RawPath, decoded, must match Path after stripping")
+			}
 			if strings.Contains(tt.requestPath, "?") {
 				assert.NotEmpty(t, capturedQuery, "query string should be preserved")
 			}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -324,7 +324,11 @@ func (s *Server) setupMiddleware() {
 	// effect without a server restart.
 	s.echo.Pre(func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
-			bp := ingressPath(c, s.settings)
+			// Read the current *conf.Settings through the atomic pointer so a
+			// settings hot-reload (CoW publish via conf.StoreSettings) takes
+			// effect for the next request without restart, and so readers
+			// never observe a torn view of the basepath field.
+			bp := ingressPath(c, conf.GetSettings())
 			if bp == "" {
 				return next(c)
 			}
@@ -388,7 +392,7 @@ func (s *Server) setupMiddleware() {
 	// proxy headers and config in priority order.
 	s.echo.Use(func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
-			c.Set("basePath", ingressPath(c, s.settings))
+			c.Set("basePath", ingressPath(c, conf.GetSettings()))
 			return next(c)
 		}
 	})
@@ -724,7 +728,7 @@ func (s *Server) IsDevMode() bool {
 func (s *Server) registerSPARoutes() {
 	// Redirect root path to dashboard
 	s.echo.GET("/", func(c echo.Context) error {
-		return c.Redirect(http.StatusFound, ingressPath(c, s.settings)+"/ui/dashboard")
+		return c.Redirect(http.StatusFound, ingressPath(c, conf.GetSettings())+"/ui/dashboard")
 	})
 
 	// Public routes (no authentication required)
@@ -853,7 +857,7 @@ func (s *Server) handleOAuthBegin(c echo.Context) error {
 			logger.String("email", user.Email),
 		)
 		// User is already authenticated, redirect to dashboard
-		return c.Redirect(http.StatusFound, ingressPath(c, s.settings)+"/ui/dashboard")
+		return c.Redirect(http.StatusFound, ingressPath(c, conf.GetSettings())+"/ui/dashboard")
 	}
 
 	// Begin OAuth flow - this will redirect to the provider
@@ -958,7 +962,7 @@ func (s *Server) handleOAuthCallback(c echo.Context) error {
 	)
 
 	// Redirect to dashboard after successful authentication
-	return c.Redirect(http.StatusFound, ingressPath(c, s.settings)+"/ui/dashboard")
+	return c.Redirect(http.StatusFound, ingressPath(c, conf.GetSettings())+"/ui/dashboard")
 }
 
 // isValidOAuthProvider checks if the provider name is a valid goth provider name.

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"os/signal"
 	"strings"
@@ -101,6 +102,34 @@ func ingressPath(c echo.Context, settings *conf.Settings) string {
 		return strings.TrimRight(settings.WebServer.BasePath, "/")
 	}
 	return ""
+}
+
+// hasPercentEncodedPrefix reports whether rawPath begins with encodedPrefix,
+// matching the hex digits inside any %XX sequences case-insensitively so that
+// reverse proxies that forward lowercase hex (%c3%9c) still match Go's
+// canonical uppercase form (%C3%9C). All non-%-prefixed bytes are compared
+// byte-for-byte because URL path components are case-sensitive.
+// Returns the matched prefix length (in rawPath bytes), or -1 on mismatch.
+func hasPercentEncodedPrefix(rawPath, encodedPrefix string) int {
+	i := 0
+	for i < len(encodedPrefix) {
+		if i >= len(rawPath) {
+			return -1
+		}
+		if encodedPrefix[i] == '%' && rawPath[i] == '%' &&
+			i+2 < len(encodedPrefix) && i+2 < len(rawPath) {
+			if !strings.EqualFold(rawPath[i+1:i+3], encodedPrefix[i+1:i+3]) {
+				return -1
+			}
+			i += 3
+			continue
+		}
+		if rawPath[i] != encodedPrefix[i] {
+			return -1
+		}
+		i++
+	}
+	return i
 }
 
 // isSafePathPrefix validates that a path prefix (typically from a proxy header)
@@ -319,13 +348,25 @@ func (s *Server) setupMiddleware() {
 						rest = "/"
 					}
 					req.URL.Path = rest
-					// Also update RawPath if set (percent-encoded paths).
-					if req.URL.RawPath != "" && strings.HasPrefix(req.URL.RawPath, bp) {
-						raw := req.URL.RawPath[len(bp):]
-						if raw == "" {
-							raw = "/"
+					// Also update RawPath if set (percent-encoded paths). The
+					// decoded bp must be encoded before the prefix check
+					// because RawPath is always in escaped form; comparing a
+					// decoded prefix against an encoded string breaks for
+					// basepaths that require encoding (spaces, non-ASCII),
+					// leaving Path stripped and RawPath prefixed. Echo then
+					// sees mismatched Path/RawPath and may route inconsistently.
+					// hasPercentEncodedPrefix treats %XX hex digits
+					// case-insensitively so lowercase-hex-forwarding proxies
+					// also match. Fixes Forgejo #447.
+					if req.URL.RawPath != "" {
+						encodedBP := (&url.URL{Path: bp}).EscapedPath()
+						if n := hasPercentEncodedPrefix(req.URL.RawPath, encodedBP); n >= 0 {
+							raw := req.URL.RawPath[n:]
+							if raw == "" {
+								raw = "/"
+							}
+							req.URL.RawPath = raw
 						}
-						req.URL.RawPath = raw
 					}
 				}
 			}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -85,6 +85,19 @@ type Server struct {
 	startTime time.Time
 }
 
+// currentSettings returns the latest *conf.Settings snapshot published via
+// conf.StoreSettings, or the server's constructor-provided pointer when no
+// snapshot has been published yet (test harnesses that skip the global
+// publish, or early startup before the first Load). Routing the hot-path
+// middleware through this helper keeps the basepath resolution race-free
+// while still handling the uninitialised-global case gracefully.
+func (s *Server) currentSettings() *conf.Settings {
+	if cur := conf.GetSettings(); cur != nil {
+		return cur
+	}
+	return s.settings
+}
+
 // ingressPath returns the effective base path prefix for the current request.
 // Priority: X-Ingress-Path header > X-Forwarded-Prefix header > config BasePath > empty.
 //
@@ -327,8 +340,10 @@ func (s *Server) setupMiddleware() {
 			// Read the current *conf.Settings through the atomic pointer so a
 			// settings hot-reload (CoW publish via conf.StoreSettings) takes
 			// effect for the next request without restart, and so readers
-			// never observe a torn view of the basepath field.
-			bp := ingressPath(c, conf.GetSettings())
+			// never observe a torn view of the basepath field. Fall back to
+			// the constructor-provided pointer if no snapshot has been
+			// published yet (test harnesses that skip the global publish).
+			bp := ingressPath(c, s.currentSettings())
 			if bp == "" {
 				return next(c)
 			}
@@ -392,7 +407,7 @@ func (s *Server) setupMiddleware() {
 	// proxy headers and config in priority order.
 	s.echo.Use(func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
-			c.Set("basePath", ingressPath(c, conf.GetSettings()))
+			c.Set("basePath", ingressPath(c, s.currentSettings()))
 			return next(c)
 		}
 	})
@@ -728,7 +743,7 @@ func (s *Server) IsDevMode() bool {
 func (s *Server) registerSPARoutes() {
 	// Redirect root path to dashboard
 	s.echo.GET("/", func(c echo.Context) error {
-		return c.Redirect(http.StatusFound, ingressPath(c, conf.GetSettings())+"/ui/dashboard")
+		return c.Redirect(http.StatusFound, ingressPath(c, s.currentSettings())+"/ui/dashboard")
 	})
 
 	// Public routes (no authentication required)
@@ -857,7 +872,7 @@ func (s *Server) handleOAuthBegin(c echo.Context) error {
 			logger.String("email", user.Email),
 		)
 		// User is already authenticated, redirect to dashboard
-		return c.Redirect(http.StatusFound, ingressPath(c, conf.GetSettings())+"/ui/dashboard")
+		return c.Redirect(http.StatusFound, ingressPath(c, s.currentSettings())+"/ui/dashboard")
 	}
 
 	// Begin OAuth flow - this will redirect to the provider
@@ -962,7 +977,7 @@ func (s *Server) handleOAuthCallback(c echo.Context) error {
 	)
 
 	// Redirect to dashboard after successful authentication
-	return c.Redirect(http.StatusFound, ingressPath(c, conf.GetSettings())+"/ui/dashboard")
+	return c.Redirect(http.StatusFound, ingressPath(c, s.currentSettings())+"/ui/dashboard")
 }
 
 // isValidOAuthProvider checks if the provider name is a valid goth provider name.

--- a/internal/api/v2/api.go
+++ b/internal/api/v2/api.go
@@ -913,9 +913,20 @@ func (c *Controller) HandleErrorForTest(ctx echo.Context, err error, message str
 	return echo.NewHTTPError(code, fullMessage)
 }
 
-// Debug logs debug messages when debug mode is enabled
+// Debug logs debug messages when debug mode is enabled.
+//
+// Reads the debug flag via conf.GetSettings() rather than c.Settings so the
+// check is race-free against concurrent c.Settings writes in the settings
+// handlers: c.Settings is plain a *conf.Settings field with no locking on
+// the Debug read path, while conf.GetSettings() is a lock-free atomic.Load.
+// Falls back to c.Settings when the global snapshot has not been set (tests
+// that inject a standalone Controller without touching the global).
 func (c *Controller) Debug(format string, v ...any) {
-	if c.Settings.WebServer.Debug {
+	settings := conf.GetSettings()
+	if settings == nil {
+		settings = c.Settings
+	}
+	if settings != nil && settings.WebServer.Debug {
 		msg := fmt.Sprintf(format, v...)
 		c.logDebugIfEnabled(msg)
 	}

--- a/internal/api/v2/settings.go
+++ b/internal/api/v2/settings.go
@@ -306,14 +306,18 @@ func (c *Controller) UpdateSettings(ctx echo.Context) error {
 		return c.HandleError(ctx, err, "Failed to apply settings changes, rolled back to previous settings", http.StatusInternalServerError)
 	}
 
-	if err := conf.SaveSettings(); err != nil {
-		// Rollback in-memory; disk write never happened successfully.
-		if publishGlobal {
+	// Persist to disk only when this controller owns the global snapshot
+	// (production path) AND DisableSaveSettings is not set. conf.SaveSettings
+	// reads conf.GetSettings internally; persisting from a test that injected
+	// a standalone c.Settings would save an unrelated snapshot.
+	if publishGlobal && !c.DisableSaveSettings {
+		if err := conf.SaveSettings(); err != nil {
+			// Rollback in-memory; disk write never happened successfully.
 			conf.StoreSettings(current)
+			c.Settings = current
+			c.logAPIRequest(ctx, logger.LogLevelError, "Failed to save settings to disk, rolling back", logger.Error(err))
+			return c.HandleError(ctx, err, "Failed to save settings, rolled back to previous settings", http.StatusInternalServerError)
 		}
-		c.Settings = current
-		c.logAPIRequest(ctx, logger.LogLevelError, "Failed to save settings to disk, rolling back", logger.Error(err))
-		return c.HandleError(ctx, err, "Failed to save settings, rolled back to previous settings", http.StatusInternalServerError)
 	}
 
 	telemetry.UpdateTelemetryEnabled()
@@ -650,11 +654,13 @@ func (c *Controller) UpdateSectionSettings(ctx echo.Context) error {
 		return c.HandleError(ctx, err, "Failed to apply settings changes, rolled back to previous settings", http.StatusInternalServerError)
 	}
 
-	if !c.DisableSaveSettings {
+	// Persist to disk only when this controller owns the global snapshot
+	// AND the test did not disable save. conf.SaveSettings persists the
+	// conf.GetSettings value, which would be wrong under a standalone
+	// c.Settings injected by a test that bypassed the global publish.
+	if publishGlobal && !c.DisableSaveSettings {
 		if err := conf.SaveSettings(); err != nil {
-			if publishGlobal {
-				conf.StoreSettings(current)
-			}
+			conf.StoreSettings(current)
 			c.Settings = current
 			return c.HandleError(ctx, err, "Failed to save settings, rolled back to previous settings", http.StatusInternalServerError)
 		}

--- a/internal/api/v2/settings.go
+++ b/internal/api/v2/settings.go
@@ -282,11 +282,12 @@ func (c *Controller) UpdateSettings(ctx echo.Context) error {
 
 	// Publish the new snapshot. conf.StoreSettings publishes atomically to
 	// the global (readers via conf.GetSettings immediately see this version;
-	// existing pointer holders stay on the old). c.Settings updates the
-	// controller-cached pointer so read handlers that still dereference
-	// c.Settings (GetAllSettings, GetDashboardSettings, etc.) return the
-	// freshly published snapshot. The write is safe under c.settingsMutex
-	// which all c.Settings readers also acquire.
+	// existing pointer holders stay on the old). c.Settings keeps the
+	// controller-cached pointer in sync so read handlers that still
+	// dereference c.Settings return the freshly published snapshot. The
+	// write is safe under c.settingsMutex which all c.Settings readers
+	// also acquire, except for c.Debug which deliberately reads via
+	// conf.GetSettings() to stay race-free without grabbing the lock.
 	if publishGlobal {
 		conf.StoreSettings(updated)
 	}
@@ -633,7 +634,9 @@ func (c *Controller) UpdateSectionSettings(ctx echo.Context) error {
 			fmt.Sprintf("Invalid %s settings", section), http.StatusBadRequest)
 	}
 
-	// Publish the new snapshot atomically when we own the global.
+	// Publish the new snapshot atomically when we own the global; keep
+	// c.Settings in sync. See the matching comment in UpdateSettings for
+	// why c.Debug reads via conf.GetSettings() rather than c.Settings.
 	if publishGlobal {
 		conf.StoreSettings(updated)
 	}

--- a/internal/api/v2/settings.go
+++ b/internal/api/v2/settings.go
@@ -214,20 +214,26 @@ func (c *Controller) UpdateSettings(ctx echo.Context) error {
 	c.settingsMutex.Lock()
 	defer c.settingsMutex.Unlock()
 
-	current := conf.GetSettings()
+	// Read the controller-cached snapshot when set (tests inject this
+	// directly); fall back to the global publisher. In production these are
+	// the same pointer at boot and stay in sync because every successful
+	// publish below updates both c.Settings and conf.settingsInstance.
+	current := c.getSettingsOrFallback()
 	if current == nil {
-		// Fallback: initialise the global settings once if not yet loaded.
-		current = conf.Setting()
-		if current == nil {
-			c.logAPIRequest(ctx, logger.LogLevelError, "Settings not initialized during update attempt")
-			return c.HandleError(ctx, fmt.Errorf("settings not initialized"), "Failed to get settings", http.StatusInternalServerError)
-		}
+		c.logAPIRequest(ctx, logger.LogLevelError, "Settings not initialized during update attempt")
+		return c.HandleError(ctx, fmt.Errorf("settings not initialized"), "Failed to get settings", http.StatusInternalServerError)
 	}
 
 	// Build a mutable clone; never mutate current in place. Readers holding
 	// current through conf.GetSettings continue to see a consistent snapshot
 	// until StoreSettings publishes the new one.
 	updated := conf.CloneSettings(current)
+
+	// Only publish to the global atomic pointer when this controller is the
+	// one that owns it (production path). In tests that inject a controller-
+	// local *conf.Settings without touching the global, skip the publish so
+	// we don't leak state into other tests.
+	publishGlobal := current == conf.GetSettings()
 
 	// Parse the request body
 	var updatedSettings conf.Settings
@@ -274,23 +280,37 @@ func (c *Controller) UpdateSettings(ctx echo.Context) error {
 		return c.HandleError(ctx, err, "Invalid settings", http.StatusBadRequest)
 	}
 
-	// Publish the new snapshot atomically. Readers via conf.GetSettings
-	// immediately see this version; existing pointer holders stay on the old.
-	conf.StoreSettings(updated)
+	// Publish the new snapshot. conf.StoreSettings publishes atomically to
+	// the global (readers via conf.GetSettings immediately see this version;
+	// existing pointer holders stay on the old). c.Settings updates the
+	// controller-cached pointer so read handlers that still dereference
+	// c.Settings (GetAllSettings, GetDashboardSettings, etc.) return the
+	// freshly published snapshot. The write is safe under c.settingsMutex
+	// which all c.Settings readers also acquire.
+	if publishGlobal {
+		conf.StoreSettings(updated)
+	}
+	c.Settings = updated
 
 	// Run cross-field side-effects (interval tracking, telemetry toggles, etc.)
 	// against the published pair. handleSettingsChanges is read-only on both.
 	if err := c.handleSettingsChanges(current, updated); err != nil {
 		// Rollback: republish the previous snapshot so in-memory state matches
 		// what is on disk (which was never overwritten).
-		conf.StoreSettings(current)
+		if publishGlobal {
+			conf.StoreSettings(current)
+		}
+		c.Settings = current
 		c.logAPIRequest(ctx, logger.LogLevelError, "Failed to apply settings changes, rolling back", logger.Error(err))
 		return c.HandleError(ctx, err, "Failed to apply settings changes, rolled back to previous settings", http.StatusInternalServerError)
 	}
 
 	if err := conf.SaveSettings(); err != nil {
 		// Rollback in-memory; disk write never happened successfully.
-		conf.StoreSettings(current)
+		if publishGlobal {
+			conf.StoreSettings(current)
+		}
+		c.Settings = current
 		c.logAPIRequest(ctx, logger.LogLevelError, "Failed to save settings to disk, rolling back", logger.Error(err))
 		return c.HandleError(ctx, err, "Failed to save settings, rolled back to previous settings", http.StatusInternalServerError)
 	}
@@ -544,7 +564,13 @@ func parseAndValidateJSON(ctx echo.Context) (json.RawMessage, error) {
 	return requestBody, nil
 }
 
-// UpdateSectionSettings handles PATCH /api/v2/settings/:section
+// UpdateSectionSettings handles PATCH /api/v2/settings/:section.
+//
+// Uses the same copy-on-write flow as UpdateSettings: clone the current
+// *conf.Settings snapshot, apply the section merge to the clone, validate,
+// and publish via conf.StoreSettings. Rollback on failure republishes the
+// previous snapshot. Keeps PATCH race-free against basepath middleware reads
+// and any other reader that goes through conf.GetSettings().
 func (c *Controller) UpdateSectionSettings(ctx echo.Context) error {
 	c.settingsMutex.Lock()
 	defer c.settingsMutex.Unlock()
@@ -554,12 +580,19 @@ func (c *Controller) UpdateSectionSettings(ctx echo.Context) error {
 		return c.HandleError(ctx, fmt.Errorf("section not specified"), "Section parameter is required", http.StatusBadRequest)
 	}
 
-	settings := c.getSettingsOrFallback()
-	if settings == nil {
+	current := c.getSettingsOrFallback()
+	if current == nil {
 		return c.HandleError(ctx, fmt.Errorf("settings not initialized"), "Failed to get settings", http.StatusInternalServerError)
 	}
 
-	oldSettings := *settings
+	// Build a mutable clone; never mutate current in place. Readers holding
+	// current through conf.GetSettings keep seeing a consistent snapshot
+	// until StoreSettings publishes the new one.
+	updated := conf.CloneSettings(current)
+
+	// Only publish globally when the controller owns the global snapshot
+	// (production path); skip when tests inject a standalone c.Settings.
+	publishGlobal := current == conf.GetSettings()
 
 	requestBody, err := parseAndValidateJSON(ctx)
 	if err != nil {
@@ -567,49 +600,59 @@ func (c *Controller) UpdateSectionSettings(ctx echo.Context) error {
 	}
 
 	var skippedFields []string
-	if err := updateSettingsSectionWithTracking(settings, section, requestBody, &skippedFields); err != nil {
+	if err := updateSettingsSectionWithTracking(updated, section, requestBody, &skippedFields); err != nil {
 		if len(skippedFields) > 0 {
 			c.Debug("Protected fields that were skipped in update of section %s: %s", section, strings.Join(skippedFields, ", "))
 		}
 		return c.HandleError(ctx, err, fmt.Sprintf("Failed to update %s settings", section), http.StatusBadRequest)
 	}
 
-	// Restore redacted secret fields to their current values so the
-	// merge does not overwrite real secrets with the placeholder.
-	if err := restoreRedactedSecrets(&oldSettings, settings); err != nil {
-		*settings = oldSettings
+	// Restore redacted secret fields to their current values so the merge
+	// does not overwrite real secrets with the placeholder. current is the
+	// source of truth for the pre-update values.
+	if err := restoreRedactedSecrets(current, updated); err != nil {
 		c.logAPIRequest(ctx, logger.LogLevelWarn, "Redacted sentinel validation failed", logger.Error(err))
 		return c.HandleError(ctx, err, "Cannot save: some secret fields contain the redacted placeholder because their identifying key was changed while the secret was hidden. Re-enter the secret values.", http.StatusBadRequest)
 	}
 
 	// Ensure LocationConfigured is set when birdnet coordinates are present.
-	// This handles the case where the frontend sends coordinates without the flag,
-	// and provides backward compatibility with older frontend versions.
+	// Backward compatibility with older frontends that don't send the flag.
 	if strings.EqualFold(section, SettingsSectionBirdnet) {
-		if settings.BirdNET.Latitude != 0 || settings.BirdNET.Longitude != 0 {
-			settings.BirdNET.LocationConfigured = true
+		if updated.BirdNET.Latitude != 0 || updated.BirdNET.Longitude != 0 {
+			updated.BirdNET.LocationConfigured = true
 		}
 	}
 
-	// Migrate legacy single audio source if a cached frontend sent it
-	settings.MigrateAudioSourceConfig()
+	// Migrate legacy single audio source if a cached frontend sent it.
+	updated.MigrateAudioSourceConfig()
 
-	// Run full settings validation after section merge to catch invalid values
-	// (e.g., malformed telemetry listen address, invalid port ranges, etc.)
-	if err := conf.ValidateSettings(settings); err != nil {
-		*settings = oldSettings
+	// Validate the clone before publishing. No rollback needed on validation
+	// failure: we simply never publish.
+	if err := conf.ValidateSettings(updated); err != nil {
 		return c.HandleError(ctx, err,
 			fmt.Sprintf("Invalid %s settings", section), http.StatusBadRequest)
 	}
 
-	if err := c.handleSettingsChanges(&oldSettings, settings); err != nil {
-		*settings = oldSettings
+	// Publish the new snapshot atomically when we own the global.
+	if publishGlobal {
+		conf.StoreSettings(updated)
+	}
+	c.Settings = updated
+
+	if err := c.handleSettingsChanges(current, updated); err != nil {
+		if publishGlobal {
+			conf.StoreSettings(current)
+		}
+		c.Settings = current
 		return c.HandleError(ctx, err, "Failed to apply settings changes, rolled back to previous settings", http.StatusInternalServerError)
 	}
 
 	if !c.DisableSaveSettings {
 		if err := conf.SaveSettings(); err != nil {
-			*settings = oldSettings
+			if publishGlobal {
+				conf.StoreSettings(current)
+			}
+			c.Settings = current
 			return c.HandleError(ctx, err, "Failed to save settings, rolled back to previous settings", http.StatusInternalServerError)
 		}
 	}
@@ -617,7 +660,7 @@ func (c *Controller) UpdateSectionSettings(ctx echo.Context) error {
 	telemetry.UpdateTelemetryEnabled()
 
 	// Rebuild taxonomy synonym lookup cache if overrides changed
-	imageprovider.SetCustomSynonyms(settings.TaxonomySynonyms, settings.BirdNET.Labels)
+	imageprovider.SetCustomSynonyms(updated.TaxonomySynonyms, updated.BirdNET.Labels)
 
 	return ctx.JSON(http.StatusOK, map[string]any{
 		"message":       fmt.Sprintf("%s settings updated successfully", section),

--- a/internal/api/v2/settings.go
+++ b/internal/api/v2/settings.go
@@ -199,95 +199,104 @@ func (c *Controller) GetSectionSettings(ctx echo.Context) error {
 	return ctx.JSON(http.StatusOK, sectionValue)
 }
 
-// UpdateSettings handles PUT /api/v2/settings
+// UpdateSettings handles PUT /api/v2/settings.
+//
+// The flow is copy-on-write: we clone the current *conf.Settings snapshot,
+// apply the inbound update to the clone, validate, and atomically publish the
+// clone via conf.StoreSettings. Readers on the hot path (e.g. the basepath
+// strip middleware in internal/api/server.go) see either the old snapshot or
+// the new one, never a torn view. Rollback after a validation or disk-write
+// failure is a republish of the previous snapshot.
 func (c *Controller) UpdateSettings(ctx echo.Context) error {
 	c.logAPIRequest(ctx, logger.LogLevelInfo, "Attempting to update settings")
-	// Acquire write lock to prevent concurrent settings updates
+	// Serialise concurrent PUT /api/v2/settings calls; each must see the
+	// latest published snapshot as its baseline.
 	c.settingsMutex.Lock()
 	defer c.settingsMutex.Unlock()
 
-	settings := c.Settings
-	if settings == nil {
-		// Fallback to global settings if controller settings not set
-		settings = conf.Setting()
-		if settings == nil {
+	current := conf.GetSettings()
+	if current == nil {
+		// Fallback: initialise the global settings once if not yet loaded.
+		current = conf.Setting()
+		if current == nil {
 			c.logAPIRequest(ctx, logger.LogLevelError, "Settings not initialized during update attempt")
 			return c.HandleError(ctx, fmt.Errorf("settings not initialized"), "Failed to get settings", http.StatusInternalServerError)
 		}
 	}
 
-	// Create a backup of current settings for rollback if needed
-	oldSettings := *settings
+	// Build a mutable clone; never mutate current in place. Readers holding
+	// current through conf.GetSettings continue to see a consistent snapshot
+	// until StoreSettings publishes the new one.
+	updated := conf.CloneSettings(current)
 
 	// Parse the request body
 	var updatedSettings conf.Settings
 	if err := ctx.Bind(&updatedSettings); err != nil {
-		// Log binding error
 		c.logAPIRequest(ctx, logger.LogLevelError, "Failed to bind request body for settings update", logger.Error(err))
 		return c.HandleError(ctx, err, "Failed to parse request body", http.StatusBadRequest)
 	}
 
-	// Restore redacted secret fields to their current values so the
-	// update logic does not overwrite real secrets with the placeholder.
-	if err := restoreRedactedSecrets(settings, &updatedSettings); err != nil {
+	// Restore redacted secret fields to their current values so the update
+	// logic does not overwrite real secrets with the placeholder. Operate on
+	// updated (clone) as the canonical destination, not on current.
+	if err := restoreRedactedSecrets(updated, &updatedSettings); err != nil {
 		c.logAPIRequest(ctx, logger.LogLevelWarn, "Redacted sentinel validation failed", logger.Error(err))
 		return c.HandleError(ctx, err, "Cannot save: some secret fields contain the redacted placeholder because their identifying key was changed while the secret was hidden. Re-enter the secret values.", http.StatusBadRequest)
 	}
 
-	// Update only the fields that are allowed to be changed
-	skippedFields, err := updateAllowedSettingsWithTracking(settings, &updatedSettings)
+	// Apply allowed field updates to the clone.
+	skippedFields, err := updateAllowedSettingsWithTracking(updated, &updatedSettings)
 	if err != nil {
-		// Log error during field update attempt
 		c.logAPIRequest(ctx, logger.LogLevelError, "Error updating allowed settings fields", logger.Error(err), logger.Any("skipped_fields", skippedFields))
 		return c.HandleError(ctx, err, "Failed to update settings", http.StatusInternalServerError)
 	}
 	if len(skippedFields) > 0 {
-		// Log skipped fields at Debug level
 		c.logAPIRequest(ctx, logger.LogLevelDebug, "Skipped protected fields during settings update", logger.Any("skipped_fields", skippedFields))
 	}
 
-	// Normalize species config keys to lowercase for case-insensitive matching
-	if settings.Realtime.Species.Config != nil {
-		settings.Realtime.Species.Config = conf.NormalizeSpeciesConfigKeys(settings.Realtime.Species.Config)
+	// Normalize species config keys to lowercase for case-insensitive matching.
+	if updated.Realtime.Species.Config != nil {
+		updated.Realtime.Species.Config = conf.NormalizeSpeciesConfigKeys(updated.Realtime.Species.Config)
 	}
 
 	// Ensure LocationConfigured is set when birdnet coordinates are present.
-	// This provides backward compatibility with older frontend versions that
-	// don't send the locationConfigured flag.
-	if settings.BirdNET.Latitude != 0 || settings.BirdNET.Longitude != 0 {
-		settings.BirdNET.LocationConfigured = true
+	// Backward compatibility with older frontends that don't send the flag.
+	if updated.BirdNET.Latitude != 0 || updated.BirdNET.Longitude != 0 {
+		updated.BirdNET.LocationConfigured = true
 	}
 
-	// Migrate legacy single audio source if a cached frontend sent it
-	settings.MigrateAudioSourceConfig()
+	// Migrate legacy single audio source if a cached frontend sent it.
+	updated.MigrateAudioSourceConfig()
 
-	// Run full settings validation after field updates
-	if err := conf.ValidateSettings(settings); err != nil {
-		*settings = oldSettings
+	// Validate the clone before publishing. No rollback needed on validation
+	// failure: we simply never publish.
+	if err := conf.ValidateSettings(updated); err != nil {
 		return c.HandleError(ctx, err, "Invalid settings", http.StatusBadRequest)
 	}
 
-	// Check if any important settings have changed and trigger actions as needed
-	if err := c.handleSettingsChanges(&oldSettings, settings); err != nil {
-		// Attempt to rollback changes if applying them failed
-		*settings = oldSettings
+	// Publish the new snapshot atomically. Readers via conf.GetSettings
+	// immediately see this version; existing pointer holders stay on the old.
+	conf.StoreSettings(updated)
+
+	// Run cross-field side-effects (interval tracking, telemetry toggles, etc.)
+	// against the published pair. handleSettingsChanges is read-only on both.
+	if err := c.handleSettingsChanges(current, updated); err != nil {
+		// Rollback: republish the previous snapshot so in-memory state matches
+		// what is on disk (which was never overwritten).
+		conf.StoreSettings(current)
 		c.logAPIRequest(ctx, logger.LogLevelError, "Failed to apply settings changes, rolling back", logger.Error(err))
 		return c.HandleError(ctx, err, "Failed to apply settings changes, rolled back to previous settings", http.StatusInternalServerError)
 	}
 
-	// Save settings to disk
 	if err := conf.SaveSettings(); err != nil {
-		// Attempt to rollback changes if saving failed
-		*settings = oldSettings
+		// Rollback in-memory; disk write never happened successfully.
+		conf.StoreSettings(current)
 		c.logAPIRequest(ctx, logger.LogLevelError, "Failed to save settings to disk, rolling back", logger.Error(err))
 		return c.HandleError(ctx, err, "Failed to save settings, rolled back to previous settings", http.StatusInternalServerError)
 	}
 
-	// Update the cached telemetry state after settings change
 	telemetry.UpdateTelemetryEnabled()
-
-	// Rebuild taxonomy synonym lookup cache if overrides changed
-	imageprovider.SetCustomSynonyms(settings.TaxonomySynonyms, settings.BirdNET.Labels)
+	imageprovider.SetCustomSynonyms(updated.TaxonomySynonyms, updated.BirdNET.Labels)
 
 	c.logAPIRequest(ctx, logger.LogLevelInfo, "Settings updated and saved successfully", logger.Int("skipped_fields_count", len(skippedFields)))
 	return ctx.JSON(http.StatusOK, map[string]any{

--- a/internal/conf/clone.go
+++ b/internal/conf/clone.go
@@ -218,17 +218,71 @@ func cloneOAuthProviders(in []OAuthProviderConfig) []OAuthProviderConfig {
 }
 
 // cloneBackupTargets deep-copies the backup target slice, ensuring each
-// target's Settings map is independent.
+// target's Settings map is independent. The Settings map is type-deep-cloned
+// because backup-type-specific config (rsync options, S3 prefixes, etc.) can
+// nest slices or maps inside the any values; a plain maps.Clone would leave
+// those backing arrays shared between src and dst.
 func cloneBackupTargets(in []BackupTarget) []BackupTarget {
 	if in == nil {
 		return nil
 	}
 	out := make([]BackupTarget, len(in))
 	for i, t := range in {
-		t.Settings = maps.Clone(t.Settings)
+		t.Settings = cloneStringAnyMap(t.Settings)
 		out[i] = t
 	}
 	return out
+}
+
+// cloneStringAnyMap returns a deep copy of a map[string]any whose values may
+// themselves be maps or slices. Plain maps.Clone only copies the outer map;
+// a writer appending to a shared nested slice would race against readers
+// holding the previous snapshot. The copy is type-aware so numeric types
+// (viper unmarshals int/float64 from YAML) are preserved exactly; a JSON
+// round-trip would coerce int to float64 and break downstream consumers.
+func cloneStringAnyMap(m map[string]any) map[string]any {
+	if m == nil {
+		return nil
+	}
+	out := make(map[string]any, len(m))
+	for k, v := range m {
+		out[k] = cloneAnyValue(v)
+	}
+	return out
+}
+
+// cloneAnyValue walks a value that came out of map[string]any and returns a
+// deep copy for the composite cases (nested maps and slices). Scalar types
+// (string, numbers, bool, time.Time, etc.) are value-copied by the caller
+// when they are assigned through any, so they don't need special handling.
+func cloneAnyValue(v any) any {
+	switch val := v.(type) {
+	case map[string]any:
+		return cloneStringAnyMap(val)
+	case []any:
+		out := make([]any, len(val))
+		for i := range val {
+			out[i] = cloneAnyValue(val[i])
+		}
+		return out
+	case []string:
+		return slices.Clone(val)
+	case []int:
+		return slices.Clone(val)
+	case []int64:
+		return slices.Clone(val)
+	case []float64:
+		return slices.Clone(val)
+	case []bool:
+		return slices.Clone(val)
+	default:
+		// Scalar, typed struct, or pointer. For scalars (int, string, bool,
+		// float64, time.Time) the any box copies the value. For typed
+		// structs/pointers reaching this branch we trust the upstream
+		// producer: the mutation pattern in api/v2 settings handlers
+		// replaces whole any values rather than mutating through them.
+		return val
+	}
 }
 
 // cloneModuleOutputs deep-copies the module outputs map, including each
@@ -265,7 +319,7 @@ func clonePushProviders(in []PushProviderConfig) []PushProviderConfig {
 		p.Filter.Types = slices.Clone(p.Filter.Types)
 		p.Filter.Priorities = slices.Clone(p.Filter.Priorities)
 		p.Filter.Components = slices.Clone(p.Filter.Components)
-		p.Filter.MetadataFilters = maps.Clone(p.Filter.MetadataFilters)
+		p.Filter.MetadataFilters = cloneStringAnyMap(p.Filter.MetadataFilters)
 		out[i] = p
 	}
 	return out

--- a/internal/conf/clone.go
+++ b/internal/conf/clone.go
@@ -154,6 +154,18 @@ func cloneDashboardElements(in []DashboardElement) []DashboardElement {
 		e := in[i]
 		if e.Banner != nil {
 			b := *e.Banner
+			// BannerConfig carries two *bool fields (ShowPin,
+			// MapExpandable). Independently clone each so a future
+			// writer that toggles the boolean through the cloned
+			// pointer does not mutate the snapshot readers hold.
+			if b.ShowPin != nil {
+				showPin := *b.ShowPin
+				b.ShowPin = &showPin
+			}
+			if b.MapExpandable != nil {
+				mapExpandable := *b.MapExpandable
+				b.MapExpandable = &mapExpandable
+			}
 			e.Banner = &b
 		}
 		if e.Video != nil {
@@ -259,6 +271,8 @@ func cloneAnyValue(v any) any {
 	switch val := v.(type) {
 	case map[string]any:
 		return cloneStringAnyMap(val)
+	case map[string]string:
+		return maps.Clone(val)
 	case []any:
 		out := make([]any, len(val))
 		for i := range val {
@@ -266,6 +280,8 @@ func cloneAnyValue(v any) any {
 		}
 		return out
 	case []string:
+		return slices.Clone(val)
+	case []byte:
 		return slices.Clone(val)
 	case []int:
 		return slices.Clone(val)

--- a/internal/conf/clone.go
+++ b/internal/conf/clone.go
@@ -1,0 +1,287 @@
+// clone.go: deep-copy helpers for *Settings. The writer path in the UI PUT
+// handler uses CloneSettings before mutation so that concurrent readers
+// observing the prior snapshot through atomic.Pointer.Load() never see torn
+// or partially-updated values.
+
+package conf
+
+import (
+	"maps"
+	"slices"
+
+	"github.com/tphakala/birdnet-go/internal/logger"
+)
+
+// CloneSettings returns a deep copy of src that shares no slice or map backing
+// arrays with src. The returned pointer is safe to mutate before atomically
+// publishing via StoreSettings; readers holding the previous snapshot keep
+// seeing consistent values because src is never touched.
+//
+// Every slice and map field reachable from the Settings struct must be cloned
+// here. TestCloneSettings_DeepIndependence is the primary guardrail: any
+// slice/map field added to Settings or a nested struct in the future MUST
+// also get a clone line here and a matching assertion in the test, otherwise
+// the settings race reintroduces silently through the shared backing store.
+func CloneSettings(src *Settings) *Settings {
+	if src == nil {
+		return nil
+	}
+
+	// Shallow copy handles every value-type field (strings, ints, bools,
+	// nested structs whose fields are all value types).
+	dst := *src
+
+	// Root-level slices and maps.
+	dst.ValidationWarnings = slices.Clone(src.ValidationWarnings)
+	dst.TaxonomySynonyms = maps.Clone(src.TaxonomySynonyms)
+
+	// Logging.
+	dst.Logging.ModuleOutputs = cloneModuleOutputs(src.Logging.ModuleOutputs)
+	dst.Logging.ModuleLevels = maps.Clone(src.Logging.ModuleLevels)
+	if src.Logging.Console != nil {
+		c := *src.Logging.Console
+		dst.Logging.Console = &c
+	}
+	if src.Logging.FileOutput != nil {
+		f := *src.Logging.FileOutput
+		dst.Logging.FileOutput = &f
+	}
+
+	// BirdNET.
+	dst.BirdNET.Labels = slices.Clone(src.BirdNET.Labels)
+	dst.BirdNET.RangeFilter.Species = slices.Clone(src.BirdNET.RangeFilter.Species)
+
+	// Models.
+	dst.Models.Enabled = slices.Clone(src.Models.Enabled)
+
+	// Realtime.Audio.
+	dst.Realtime.Audio.Sources = cloneAudioSources(src.Realtime.Audio.Sources)
+	dst.Realtime.Audio.SoxAudioTypes = slices.Clone(src.Realtime.Audio.SoxAudioTypes)
+	dst.Realtime.Audio.Equalizer.Filters = slices.Clone(src.Realtime.Audio.Equalizer.Filters)
+
+	// Realtime.Dashboard.
+	if src.Realtime.Dashboard.CustomColors != nil {
+		c := *src.Realtime.Dashboard.CustomColors
+		dst.Realtime.Dashboard.CustomColors = &c
+	}
+	dst.Realtime.Dashboard.Layout.Elements = cloneDashboardElements(src.Realtime.Dashboard.Layout.Elements)
+
+	// Realtime.DogBarkFilter.
+	dst.Realtime.DogBarkFilter.Species = slices.Clone(src.Realtime.DogBarkFilter.Species)
+
+	// Realtime.DaylightFilter.
+	dst.Realtime.DaylightFilter.Species = slices.Clone(src.Realtime.DaylightFilter.Species)
+
+	// Realtime.RTSP.
+	dst.Realtime.RTSP.Streams = cloneStreamConfigs(src.Realtime.RTSP.Streams)
+	dst.Realtime.RTSP.URLs = slices.Clone(src.Realtime.RTSP.URLs)
+	dst.Realtime.RTSP.FFmpegParameters = slices.Clone(src.Realtime.RTSP.FFmpegParameters)
+
+	// Realtime.Monitoring.Disk.
+	dst.Realtime.Monitoring.Disk.Paths = slices.Clone(src.Realtime.Monitoring.Disk.Paths)
+
+	// Realtime.ExtendedCapture.
+	dst.Realtime.ExtendedCapture.Species = slices.Clone(src.Realtime.ExtendedCapture.Species)
+
+	// Realtime.Species.
+	dst.Realtime.Species.Include = slices.Clone(src.Realtime.Species.Include)
+	dst.Realtime.Species.Exclude = slices.Clone(src.Realtime.Species.Exclude)
+	dst.Realtime.Species.Config = cloneSpeciesConfigMap(src.Realtime.Species.Config)
+
+	// Realtime.SpeciesTracking.SeasonalTracking.Seasons: values are plain value
+	// structs (no nested slices/maps), so maps.Clone is sufficient.
+	dst.Realtime.SpeciesTracking.SeasonalTracking.Seasons = maps.Clone(src.Realtime.SpeciesTracking.SeasonalTracking.Seasons)
+
+	// Security.
+	dst.Security.OAuthProviders = cloneOAuthProviders(src.Security.OAuthProviders)
+
+	// Backup.
+	dst.Backup.Targets = cloneBackupTargets(src.Backup.Targets)
+	dst.Backup.Schedules = slices.Clone(src.Backup.Schedules)
+
+	// Notification.
+	dst.Notification.Push.Providers = clonePushProviders(src.Notification.Push.Providers)
+
+	return &dst
+}
+
+// cloneAudioSources deep-copies a slice of AudioSourceConfig so that the
+// returned slice, its Models string slices, and any per-source Equalizer
+// (with its Filters slice) share no backing storage with the input.
+func cloneAudioSources(in []AudioSourceConfig) []AudioSourceConfig {
+	if in == nil {
+		return nil
+	}
+	out := make([]AudioSourceConfig, len(in))
+	for i := range in {
+		s := in[i]
+		s.Models = slices.Clone(s.Models)
+		if s.Equalizer != nil {
+			eq := *s.Equalizer
+			eq.Filters = slices.Clone(eq.Filters)
+			s.Equalizer = &eq
+		}
+		out[i] = s
+	}
+	return out
+}
+
+// cloneStreamConfigs deep-copies a slice of StreamConfig, ensuring each
+// StreamConfig's Models slice is independent.
+func cloneStreamConfigs(in []StreamConfig) []StreamConfig {
+	if in == nil {
+		return nil
+	}
+	out := make([]StreamConfig, len(in))
+	for i := range in {
+		s := in[i]
+		s.Models = slices.Clone(s.Models)
+		out[i] = s
+	}
+	return out
+}
+
+// cloneDashboardElements deep-copies the dashboard layout elements slice
+// and each element's optional config pointers. Inner *bool fields inside
+// BannerConfig stay shared because the writer path replaces the parent
+// pointer rather than mutating through it.
+func cloneDashboardElements(in []DashboardElement) []DashboardElement {
+	if in == nil {
+		return nil
+	}
+	out := make([]DashboardElement, len(in))
+	for i := range in {
+		e := in[i]
+		if e.Banner != nil {
+			b := *e.Banner
+			e.Banner = &b
+		}
+		if e.Video != nil {
+			v := *e.Video
+			e.Video = &v
+		}
+		if e.Summary != nil {
+			s := *e.Summary
+			e.Summary = &s
+		}
+		if e.Grid != nil {
+			g := *e.Grid
+			e.Grid = &g
+		}
+		out[i] = e
+	}
+	return out
+}
+
+// cloneSpeciesConfigMap clones the per-species config map, deep-copying each
+// SpeciesConfig so that nested Actions slices (and their Parameters slices)
+// are independent.
+func cloneSpeciesConfigMap(m map[string]SpeciesConfig) map[string]SpeciesConfig {
+	if m == nil {
+		return nil
+	}
+	out := make(map[string]SpeciesConfig, len(m))
+	for k, v := range m {
+		v.Actions = cloneSpeciesActions(v.Actions)
+		out[k] = v
+	}
+	return out
+}
+
+// cloneSpeciesActions deep-copies a slice of SpeciesAction so that each
+// action's Parameters slice is independent.
+func cloneSpeciesActions(in []SpeciesAction) []SpeciesAction {
+	if in == nil {
+		return nil
+	}
+	out := make([]SpeciesAction, len(in))
+	for i, a := range in {
+		a.Parameters = slices.Clone(a.Parameters)
+		out[i] = a
+	}
+	return out
+}
+
+// cloneOAuthProviders deep-copies the OAuth provider slice, ensuring each
+// provider's Scopes slice is independent.
+func cloneOAuthProviders(in []OAuthProviderConfig) []OAuthProviderConfig {
+	if in == nil {
+		return nil
+	}
+	out := make([]OAuthProviderConfig, len(in))
+	for i := range in {
+		p := in[i]
+		p.Scopes = slices.Clone(p.Scopes)
+		out[i] = p
+	}
+	return out
+}
+
+// cloneBackupTargets deep-copies the backup target slice, ensuring each
+// target's Settings map is independent.
+func cloneBackupTargets(in []BackupTarget) []BackupTarget {
+	if in == nil {
+		return nil
+	}
+	out := make([]BackupTarget, len(in))
+	for i, t := range in {
+		t.Settings = maps.Clone(t.Settings)
+		out[i] = t
+	}
+	return out
+}
+
+// cloneModuleOutputs deep-copies the module outputs map, including each
+// module's optional *bool Compress pointer so writers that reassign the
+// pointer on the clone don't share storage with readers.
+func cloneModuleOutputs(m map[string]logger.ModuleOutput) map[string]logger.ModuleOutput {
+	if m == nil {
+		return nil
+	}
+	out := make(map[string]logger.ModuleOutput, len(m))
+	for k, v := range m {
+		if v.Compress != nil {
+			c := *v.Compress
+			v.Compress = &c
+		}
+		out[k] = v
+	}
+	return out
+}
+
+// clonePushProviders deep-copies push providers, including each provider's
+// URLs, Args, Environment, Endpoints, and Filter sub-fields.
+func clonePushProviders(in []PushProviderConfig) []PushProviderConfig {
+	if in == nil {
+		return nil
+	}
+	out := make([]PushProviderConfig, len(in))
+	for i := range in {
+		p := in[i]
+		p.URLs = slices.Clone(p.URLs)
+		p.Args = slices.Clone(p.Args)
+		p.Environment = maps.Clone(p.Environment)
+		p.Endpoints = cloneWebhookEndpoints(p.Endpoints)
+		p.Filter.Types = slices.Clone(p.Filter.Types)
+		p.Filter.Priorities = slices.Clone(p.Filter.Priorities)
+		p.Filter.Components = slices.Clone(p.Filter.Components)
+		p.Filter.MetadataFilters = maps.Clone(p.Filter.MetadataFilters)
+		out[i] = p
+	}
+	return out
+}
+
+// cloneWebhookEndpoints deep-copies webhook endpoints, ensuring each
+// endpoint's Headers map is independent.
+func cloneWebhookEndpoints(in []WebhookEndpointConfig) []WebhookEndpointConfig {
+	if in == nil {
+		return nil
+	}
+	out := make([]WebhookEndpointConfig, len(in))
+	for i := range in {
+		e := in[i]
+		e.Headers = maps.Clone(e.Headers)
+		out[i] = e
+	}
+	return out
+}

--- a/internal/conf/clone_test.go
+++ b/internal/conf/clone_test.go
@@ -1,0 +1,331 @@
+package conf
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tphakala/birdnet-go/internal/logger"
+)
+
+// mutated is the sentinel string the clone-independence test writes through
+// the clone. If it leaks back to src, assertSourceUnchanged catches it.
+const mutated = "MUTATED"
+
+// TestCloneSettings_Nil verifies that CloneSettings returns nil for a nil input
+// so callers can safely clone an uninitialised global.
+func TestCloneSettings_Nil(t *testing.T) {
+	t.Parallel()
+	assert.Nil(t, CloneSettings(nil))
+}
+
+// TestCloneSettings_NewPointer verifies that CloneSettings returns a fresh
+// *Settings, not an alias of src.
+func TestCloneSettings_NewPointer(t *testing.T) {
+	t.Parallel()
+	src := &Settings{}
+	dst := CloneSettings(src)
+	require.NotNil(t, dst)
+	require.NotSame(t, src, dst, "CloneSettings must return a new pointer")
+}
+
+// TestCloneSettings_DeepIndependence exercises every slice and map field
+// reachable from *Settings. It populates src, clones, mutates the clone, and
+// asserts the source is untouched. This test is the primary guardrail against
+// field drift: if a new slice or map is added to Settings (or a nested struct)
+// the test must grow a matching case, or CloneSettings will silently share a
+// backing array and reintroduce the settings race.
+func TestCloneSettings_DeepIndependence(t *testing.T) {
+	t.Parallel()
+
+	src := newPopulatedSettings()
+	dst := CloneSettings(src)
+	require.NotNil(t, dst)
+
+	mutateCloneEverywhere(dst)
+
+	// Assert every src slice/map still holds its original values.
+	assertSourceUnchanged(t, src)
+}
+
+// newPopulatedSettings returns a *Settings with every slice and map field
+// populated so the clone/mutate cycle has something to prove independence on.
+// Extend this helper whenever a new slice or map field is added to Settings.
+func newPopulatedSettings() *Settings {
+	compress := true
+	s := &Settings{}
+	s.ValidationWarnings = []string{"warn-1", "warn-2"}
+	s.TaxonomySynonyms = map[string]string{"American Robin": "Turdus migratorius"}
+
+	s.Logging.ModuleLevels = map[string]string{"audio": "debug"}
+	s.Logging.ModuleOutputs = map[string]logger.ModuleOutput{
+		"audio": {Enabled: true, FilePath: "logs/audio.log", Compress: &compress},
+	}
+	s.Logging.Console = &logger.ConsoleOutput{Enabled: true, Level: "info"}
+	s.Logging.FileOutput = &logger.FileOutput{Enabled: true, Path: "logs/app.log"}
+
+	s.BirdNET.Labels = []string{"alpha", "beta"}
+	s.BirdNET.RangeFilter.Species = []string{"Turdus merula", "Parus major"}
+
+	s.Models.Enabled = []string{"birdnet", "perch_v2"}
+
+	s.Realtime.Audio.Sources = []AudioSourceConfig{
+		{
+			Name:   "front",
+			Models: []string{"birdnet"},
+			Equalizer: &EqualizerSettings{
+				Enabled: true,
+				Filters: []EqualizerFilter{{Type: "LowPass", Frequency: 100}},
+			},
+		},
+	}
+	s.Realtime.Audio.SoxAudioTypes = []string{"wav", "flac"}
+	s.Realtime.Audio.Equalizer.Filters = []EqualizerFilter{{Type: "HighPass", Frequency: 200}}
+
+	s.Realtime.Dashboard.CustomColors = &CustomColors{Primary: "#2563eb"}
+	s.Realtime.Dashboard.Layout.Elements = []DashboardElement{
+		{
+			ID:      "banner-0",
+			Type:    "banner",
+			Enabled: true,
+			Banner:  &BannerConfig{Title: "Home"},
+			Video:   &VideoEmbedConfig{URL: "https://youtu.be/abc"},
+			Summary: &DailySummaryConfig{SummaryLimit: 30},
+			Grid:    &DetectionsGridConfig{},
+		},
+	}
+
+	s.Realtime.DogBarkFilter.Species = []string{"Canis familiaris"}
+	s.Realtime.DaylightFilter.Species = []string{"Strix aluco"}
+
+	s.Realtime.RTSP.Streams = []StreamConfig{
+		{Name: "front", URL: "rtsp://x", Models: []string{"birdnet"}},
+	}
+	s.Realtime.RTSP.URLs = []string{"rtsp://legacy"}
+	s.Realtime.RTSP.FFmpegParameters = []string{"-rtsp_transport", "tcp"}
+
+	s.Realtime.Monitoring.Disk.Paths = []string{"/", "/data"}
+
+	s.Realtime.ExtendedCapture.Species = []string{"Tyto alba"}
+
+	s.Realtime.Species.Include = []string{"Corvus corax"}
+	s.Realtime.Species.Exclude = []string{"Passer domesticus"}
+	s.Realtime.Species.Config = map[string]SpeciesConfig{
+		"Turdus merula": {
+			Threshold: 0.5,
+			Actions: []SpeciesAction{
+				{Type: "ExecuteCommand", Command: "/bin/echo", Parameters: []string{"hi"}},
+			},
+		},
+	}
+
+	s.Realtime.SpeciesTracking.SeasonalTracking.Seasons = map[string]Season{
+		"winter": {StartMonth: 12, StartDay: 1},
+	}
+
+	s.Security.OAuthProviders = []OAuthProviderConfig{
+		{Provider: "google", Scopes: []string{"openid", "email"}},
+	}
+
+	s.Backup.Targets = []BackupTarget{
+		{Type: "local", Enabled: true, Settings: map[string]any{"path": "/backups"}},
+	}
+	s.Backup.Schedules = []BackupScheduleConfig{{Enabled: true, Hour: 3}}
+
+	s.Notification.Push.Providers = []PushProviderConfig{
+		{
+			Type:        "webhook",
+			URLs:        []string{"https://hook.example/api"},
+			Args:        []string{"--flag"},
+			Environment: map[string]string{"API_KEY": "secret"},
+			Endpoints: []WebhookEndpointConfig{
+				{URL: "https://a", Headers: map[string]string{"X-Custom": "1"}},
+			},
+			Filter: PushFilterConfig{
+				Types:           []string{"new_species"},
+				Priorities:      []string{"high"},
+				Components:      []string{"detection"},
+				MetadataFilters: map[string]any{"location": "garden"},
+			},
+		},
+	}
+
+	return s
+}
+
+// mutateCloneEverywhere touches every slice, map, and owned pointer on dst so
+// that any accidental backing-store sharing with src surfaces as a leaked
+// mutation on src in assertSourceUnchanged.
+func mutateCloneEverywhere(dst *Settings) {
+	dst.ValidationWarnings[0] = mutated
+	dst.ValidationWarnings = append(dst.ValidationWarnings, "added")
+	dst.TaxonomySynonyms["American Robin"] = mutated
+	dst.TaxonomySynonyms["new-key"] = "value"
+
+	dst.Logging.ModuleLevels["audio"] = mutated
+	dst.Logging.ModuleLevels["added"] = "debug"
+	m := dst.Logging.ModuleOutputs["audio"]
+	m.Enabled = false
+	if m.Compress != nil {
+		*m.Compress = false
+	}
+	dst.Logging.ModuleOutputs["audio"] = m
+	dst.Logging.ModuleOutputs["added"] = logger.ModuleOutput{Enabled: true}
+	dst.Logging.Console.Level = mutated
+	dst.Logging.FileOutput.Path = mutated
+
+	dst.BirdNET.Labels[0] = mutated
+	dst.BirdNET.RangeFilter.Species = append(dst.BirdNET.RangeFilter.Species, "Corvus corax")
+
+	dst.Models.Enabled[0] = mutated
+
+	dst.Realtime.Audio.Sources[0].Name = mutated
+	dst.Realtime.Audio.Sources[0].Models[0] = mutated
+	dst.Realtime.Audio.Sources[0].Equalizer.Enabled = false
+	dst.Realtime.Audio.Sources[0].Equalizer.Filters[0].Type = mutated
+	dst.Realtime.Audio.SoxAudioTypes[0] = mutated
+	dst.Realtime.Audio.Equalizer.Filters[0].Type = mutated
+
+	dst.Realtime.Dashboard.CustomColors.Primary = mutated
+	dst.Realtime.Dashboard.Layout.Elements[0].Banner.Title = mutated
+	dst.Realtime.Dashboard.Layout.Elements[0].Video.URL = mutated
+	dst.Realtime.Dashboard.Layout.Elements[0].Summary.SummaryLimit = 0
+	dst.Realtime.Dashboard.Layout.Elements[0].ID = mutated
+	dst.Realtime.Dashboard.Layout.Elements = append(dst.Realtime.Dashboard.Layout.Elements,
+		DashboardElement{ID: "added"})
+
+	dst.Realtime.DogBarkFilter.Species[0] = mutated
+	dst.Realtime.DaylightFilter.Species[0] = mutated
+
+	dst.Realtime.RTSP.Streams[0].Models[0] = mutated
+	dst.Realtime.RTSP.URLs[0] = mutated
+	dst.Realtime.RTSP.FFmpegParameters[0] = mutated
+
+	dst.Realtime.Monitoring.Disk.Paths[0] = mutated
+
+	dst.Realtime.ExtendedCapture.Species[0] = mutated
+
+	dst.Realtime.Species.Include[0] = mutated
+	dst.Realtime.Species.Exclude[0] = mutated
+	sc := dst.Realtime.Species.Config["Turdus merula"]
+	sc.Threshold = 0.99
+	sc.Actions[0].Parameters[0] = mutated
+	dst.Realtime.Species.Config["Turdus merula"] = sc
+	dst.Realtime.Species.Config[mutated] = SpeciesConfig{Threshold: 0.1}
+
+	dst.Realtime.SpeciesTracking.SeasonalTracking.Seasons["winter"] = Season{StartMonth: 1}
+	dst.Realtime.SpeciesTracking.SeasonalTracking.Seasons[mutated] = Season{}
+
+	dst.Security.OAuthProviders[0].Scopes[0] = mutated
+
+	dst.Backup.Targets[0].Settings["path"] = mutated
+	dst.Backup.Schedules[0].Hour = 99
+
+	pp := dst.Notification.Push.Providers[0]
+	pp.URLs[0] = mutated
+	pp.Args[0] = mutated
+	pp.Environment["API_KEY"] = mutated
+	pp.Endpoints[0].URL = mutated
+	pp.Endpoints[0].Headers["X-Custom"] = mutated
+	pp.Filter.Types[0] = mutated
+	pp.Filter.Priorities[0] = mutated
+	pp.Filter.Components[0] = mutated
+	pp.Filter.MetadataFilters["location"] = mutated
+	dst.Notification.Push.Providers[0] = pp
+}
+
+// assertSourceUnchanged verifies that every field touched by
+// mutateCloneEverywhere still holds its original value on src.
+func assertSourceUnchanged(t *testing.T, src *Settings) {
+	t.Helper()
+
+	assert.Equal(t, []string{"warn-1", "warn-2"}, src.ValidationWarnings)
+	assert.Equal(t, map[string]string{"American Robin": "Turdus migratorius"}, src.TaxonomySynonyms)
+
+	assert.Equal(t, map[string]string{"audio": "debug"}, src.Logging.ModuleLevels)
+	require.Contains(t, src.Logging.ModuleOutputs, "audio")
+	assert.True(t, src.Logging.ModuleOutputs["audio"].Enabled)
+	require.NotNil(t, src.Logging.ModuleOutputs["audio"].Compress)
+	assert.True(t, *src.Logging.ModuleOutputs["audio"].Compress)
+	_, hasAdded := src.Logging.ModuleOutputs["added"]
+	assert.False(t, hasAdded, "module outputs on src must not contain the added key")
+	require.NotNil(t, src.Logging.Console)
+	assert.Equal(t, "info", src.Logging.Console.Level)
+	require.NotNil(t, src.Logging.FileOutput)
+	assert.Equal(t, "logs/app.log", src.Logging.FileOutput.Path)
+
+	assert.Equal(t, []string{"alpha", "beta"}, src.BirdNET.Labels)
+	assert.Equal(t, []string{"Turdus merula", "Parus major"}, src.BirdNET.RangeFilter.Species)
+
+	assert.Equal(t, []string{"birdnet", "perch_v2"}, src.Models.Enabled)
+
+	require.Len(t, src.Realtime.Audio.Sources, 1)
+	assert.Equal(t, "front", src.Realtime.Audio.Sources[0].Name)
+	assert.Equal(t, []string{"birdnet"}, src.Realtime.Audio.Sources[0].Models)
+	require.NotNil(t, src.Realtime.Audio.Sources[0].Equalizer)
+	assert.True(t, src.Realtime.Audio.Sources[0].Equalizer.Enabled)
+	require.Len(t, src.Realtime.Audio.Sources[0].Equalizer.Filters, 1)
+	assert.Equal(t, "LowPass", src.Realtime.Audio.Sources[0].Equalizer.Filters[0].Type)
+	assert.Equal(t, []string{"wav", "flac"}, src.Realtime.Audio.SoxAudioTypes)
+	require.Len(t, src.Realtime.Audio.Equalizer.Filters, 1)
+	assert.Equal(t, "HighPass", src.Realtime.Audio.Equalizer.Filters[0].Type)
+
+	require.NotNil(t, src.Realtime.Dashboard.CustomColors)
+	assert.Equal(t, "#2563eb", src.Realtime.Dashboard.CustomColors.Primary)
+	require.Len(t, src.Realtime.Dashboard.Layout.Elements, 1)
+	elem := src.Realtime.Dashboard.Layout.Elements[0]
+	assert.Equal(t, "banner-0", elem.ID)
+	require.NotNil(t, elem.Banner)
+	assert.Equal(t, "Home", elem.Banner.Title)
+	require.NotNil(t, elem.Video)
+	assert.Equal(t, "https://youtu.be/abc", elem.Video.URL)
+	require.NotNil(t, elem.Summary)
+	assert.Equal(t, 30, elem.Summary.SummaryLimit)
+
+	assert.Equal(t, []string{"Canis familiaris"}, src.Realtime.DogBarkFilter.Species)
+	assert.Equal(t, []string{"Strix aluco"}, src.Realtime.DaylightFilter.Species)
+
+	require.Len(t, src.Realtime.RTSP.Streams, 1)
+	assert.Equal(t, []string{"birdnet"}, src.Realtime.RTSP.Streams[0].Models)
+	assert.Equal(t, []string{"rtsp://legacy"}, src.Realtime.RTSP.URLs)
+	assert.Equal(t, []string{"-rtsp_transport", "tcp"}, src.Realtime.RTSP.FFmpegParameters)
+
+	assert.Equal(t, []string{"/", "/data"}, src.Realtime.Monitoring.Disk.Paths)
+
+	assert.Equal(t, []string{"Tyto alba"}, src.Realtime.ExtendedCapture.Species)
+
+	assert.Equal(t, []string{"Corvus corax"}, src.Realtime.Species.Include)
+	assert.Equal(t, []string{"Passer domesticus"}, src.Realtime.Species.Exclude)
+	sc, ok := src.Realtime.Species.Config["Turdus merula"]
+	require.True(t, ok)
+	assert.InDelta(t, 0.5, sc.Threshold, 0.0001)
+	require.Len(t, sc.Actions, 1)
+	assert.Equal(t, []string{"hi"}, sc.Actions[0].Parameters)
+	_, hasMutated := src.Realtime.Species.Config[mutated]
+	assert.False(t, hasMutated, "species config on src must not contain the mutated key")
+
+	assert.Equal(t, map[string]Season{"winter": {StartMonth: 12, StartDay: 1}},
+		src.Realtime.SpeciesTracking.SeasonalTracking.Seasons)
+
+	require.Len(t, src.Security.OAuthProviders, 1)
+	assert.Equal(t, []string{"openid", "email"}, src.Security.OAuthProviders[0].Scopes)
+
+	require.Len(t, src.Backup.Targets, 1)
+	assert.Equal(t, map[string]any{"path": "/backups"}, src.Backup.Targets[0].Settings)
+	require.Len(t, src.Backup.Schedules, 1)
+	assert.Equal(t, 3, src.Backup.Schedules[0].Hour)
+
+	require.Len(t, src.Notification.Push.Providers, 1)
+	pp := src.Notification.Push.Providers[0]
+	assert.Equal(t, []string{"https://hook.example/api"}, pp.URLs)
+	assert.Equal(t, []string{"--flag"}, pp.Args)
+	assert.Equal(t, map[string]string{"API_KEY": "secret"}, pp.Environment)
+	require.Len(t, pp.Endpoints, 1)
+	assert.Equal(t, "https://a", pp.Endpoints[0].URL)
+	assert.Equal(t, map[string]string{"X-Custom": "1"}, pp.Endpoints[0].Headers)
+	assert.Equal(t, []string{"new_species"}, pp.Filter.Types)
+	assert.Equal(t, []string{"high"}, pp.Filter.Priorities)
+	assert.Equal(t, []string{"detection"}, pp.Filter.Components)
+	assert.Equal(t, map[string]any{"location": "garden"}, pp.Filter.MetadataFilters)
+}

--- a/internal/conf/clone_test.go
+++ b/internal/conf/clone_test.go
@@ -128,8 +128,23 @@ func newPopulatedSettings() *Settings {
 		{Provider: "google", Scopes: []string{"openid", "email"}},
 	}
 
+	// Include nested slices and nested maps inside the Settings map[string]any
+	// so the clone test catches a regression if the deep copy ever degrades
+	// back to a plain maps.Clone on the outer map only. rsync-style options
+	// are the realistic case: a []string value shared through map[string]any.
 	s.Backup.Targets = []BackupTarget{
-		{Type: "local", Enabled: true, Settings: map[string]any{"path": "/backups"}},
+		{
+			Type:    "rsync",
+			Enabled: true,
+			Settings: map[string]any{
+				"path":    "/backups",
+				"options": []any{"--archive", "--compress"},
+				"ssh": map[string]any{
+					"keyPath": "/home/user/.ssh/id_rsa",
+					"ports":   []any{22, 2222},
+				},
+			},
+		},
 	}
 	s.Backup.Schedules = []BackupScheduleConfig{{Enabled: true, Hour: 3}}
 
@@ -143,10 +158,15 @@ func newPopulatedSettings() *Settings {
 				{URL: "https://a", Headers: map[string]string{"X-Custom": "1"}},
 			},
 			Filter: PushFilterConfig{
-				Types:           []string{"new_species"},
-				Priorities:      []string{"high"},
-				Components:      []string{"detection"},
-				MetadataFilters: map[string]any{"location": "garden"},
+				Types:      []string{"new_species"},
+				Priorities: []string{"high"},
+				Components: []string{"detection"},
+				// Nested slice inside MetadataFilters exercises the deep-clone
+				// path (same concern as BackupTarget.Settings above).
+				MetadataFilters: map[string]any{
+					"location": "garden",
+					"tags":     []any{"urgent", "bird-of-prey"},
+				},
 			},
 		},
 	}
@@ -220,6 +240,19 @@ func mutateCloneEverywhere(dst *Settings) {
 	dst.Security.OAuthProviders[0].Scopes[0] = mutated
 
 	dst.Backup.Targets[0].Settings["path"] = mutated
+	// Mutate nested slice and nested map inside the any-typed Settings so
+	// src keeps its original values only if cloneStringAnyMap walks the
+	// tree. If a future refactor degrades this to a plain maps.Clone the
+	// assertions in assertSourceUnchanged will flag the regression.
+	if opts, ok := dst.Backup.Targets[0].Settings["options"].([]any); ok {
+		opts[0] = mutated
+	}
+	if ssh, ok := dst.Backup.Targets[0].Settings["ssh"].(map[string]any); ok {
+		ssh["keyPath"] = mutated
+		if ports, ok := ssh["ports"].([]any); ok {
+			ports[0] = 0
+		}
+	}
 	dst.Backup.Schedules[0].Hour = 99
 
 	pp := dst.Notification.Push.Providers[0]
@@ -232,6 +265,9 @@ func mutateCloneEverywhere(dst *Settings) {
 	pp.Filter.Priorities[0] = mutated
 	pp.Filter.Components[0] = mutated
 	pp.Filter.MetadataFilters["location"] = mutated
+	if tags, ok := pp.Filter.MetadataFilters["tags"].([]any); ok {
+		tags[0] = mutated
+	}
 	dst.Notification.Push.Providers[0] = pp
 }
 
@@ -312,7 +348,18 @@ func assertSourceUnchanged(t *testing.T, src *Settings) {
 	assert.Equal(t, []string{"openid", "email"}, src.Security.OAuthProviders[0].Scopes)
 
 	require.Len(t, src.Backup.Targets, 1)
-	assert.Equal(t, map[string]any{"path": "/backups"}, src.Backup.Targets[0].Settings)
+	assert.Equal(t, "/backups", src.Backup.Targets[0].Settings["path"])
+	// Nested slice value through any survived the clone without leaking
+	// the mutation from dst back to src.
+	assert.Equal(t, []any{"--archive", "--compress"}, src.Backup.Targets[0].Settings["options"],
+		"nested []any inside Settings must be independently cloned")
+	// Nested map + its nested slice both stay pristine.
+	ssh, ok := src.Backup.Targets[0].Settings["ssh"].(map[string]any)
+	require.True(t, ok, "ssh sub-map must still be a map[string]any")
+	assert.Equal(t, "/home/user/.ssh/id_rsa", ssh["keyPath"],
+		"nested map[string]any inside Settings must be independently cloned")
+	assert.Equal(t, []any{22, 2222}, ssh["ports"],
+		"deeply nested []any inside nested map must be independently cloned")
 	require.Len(t, src.Backup.Schedules, 1)
 	assert.Equal(t, 3, src.Backup.Schedules[0].Hour)
 
@@ -327,5 +374,7 @@ func assertSourceUnchanged(t *testing.T, src *Settings) {
 	assert.Equal(t, []string{"new_species"}, pp.Filter.Types)
 	assert.Equal(t, []string{"high"}, pp.Filter.Priorities)
 	assert.Equal(t, []string{"detection"}, pp.Filter.Components)
-	assert.Equal(t, map[string]any{"location": "garden"}, pp.Filter.MetadataFilters)
+	assert.Equal(t, "garden", pp.Filter.MetadataFilters["location"])
+	assert.Equal(t, []any{"urgent", "bird-of-prey"}, pp.Filter.MetadataFilters["tags"],
+		"nested []any inside MetadataFilters must be independently cloned")
 }

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -1509,9 +1509,15 @@ var ConfigPath string
 // Store() in Load/StoreSettings/SetTestSettings; read via Load() in
 // GetSettings. Lock-free reads keep the request hot path fast while copy-on-
 // write writes in api/v2.UpdateSettings keep readers race-free.
+//
+// loadMu guards the on-demand Load() that Setting() performs when
+// settingsInstance is nil. A plain sync.Mutex is used rather than sync.Once
+// so that cleanup paths which call SetTestSettings(nil) can trigger a fresh
+// Load on the next Setting() call; sync.Once cannot be reset safely from a
+// parallel test without racing on the Once value itself.
 var (
 	settingsInstance atomic.Pointer[Settings]
-	once             sync.Once
+	loadMu           sync.Mutex
 )
 
 // persistMigration saves the config file after a successful migration.
@@ -2306,16 +2312,21 @@ func SaveSettings() error {
 			Build()
 	}
 
-	// Create a shallow copy of the settings
-	settingsCopy := *current
+	// Deep-clone the published snapshot before mutating it in
+	// prepareSettingsForSave. A shallow copy would leave slice and map
+	// backing arrays shared with concurrent readers that hold current;
+	// any transformation that mutates one of those nested fields would
+	// race against them.
+	settingsCopy := *CloneSettings(current)
 
-	// Create a separate copy of the species list with proper locking
-	// Note: This MUST stay here to maintain correct mutex semantics
+	// Refresh the species list under its dedicated lock so the runtime
+	// list (shared across Species.Include/Exclude updates) is captured
+	// atomically rather than via the clone that predates the save.
 	speciesListMutex.RLock()
 	settingsCopy.BirdNET.RangeFilter.Species = slices.Clone(current.BirdNET.RangeFilter.Species)
 	speciesListMutex.RUnlock()
 
-	// Apply data transformations (seasonal tracking, etc.)
+	// Apply data transformations (seasonal tracking, etc.) on the clone.
 	settingsCopy = prepareSettingsForSave(&settingsCopy, current.BirdNET.Latitude)
 
 	// Find the path of the current config file
@@ -2342,21 +2353,30 @@ func SaveSettings() error {
 
 // Setting returns the current settings instance, initializing it if necessary
 func Setting() *Settings {
-	once.Do(func() {
-		if settingsInstance.Load() == nil {
-			_, err := Load()
-			if err != nil {
-				// Fatal error loading settings - application cannot continue
-				enhancedErr := errors.New(err).
-					Category(errors.CategoryConfiguration).
-					Context("operation", "load-settings-init").
-					Build()
-				GetLogger().Error("Error loading settings", logger.Error(enhancedErr))
-				os.Exit(1)
-			}
-		}
-	})
-	return GetSettings()
+	// Fast path: settings already published.
+	if s := settingsInstance.Load(); s != nil {
+		return s
+	}
+	// Slow path: lazy-load from disk. Serialise concurrent first-callers
+	// through loadMu; the atomic check inside the lock collapses the extras.
+	loadMu.Lock()
+	if s := settingsInstance.Load(); s != nil {
+		loadMu.Unlock()
+		return s
+	}
+	if _, err := Load(); err != nil {
+		// Fatal error loading settings - application cannot continue.
+		// Release the lock explicitly because os.Exit does not run defers.
+		enhancedErr := errors.New(err).
+			Category(errors.CategoryConfiguration).
+			Context("operation", "load-settings-init").
+			Build()
+		GetLogger().Error("Error loading settings", logger.Error(enhancedErr))
+		loadMu.Unlock()
+		os.Exit(1)
+	}
+	loadMu.Unlock()
+	return settingsInstance.Load()
 }
 
 // SetTestSettings allows tests to inject their own settings instance.
@@ -2364,10 +2384,10 @@ func Setting() *Settings {
 // This is intended for testing purposes only.
 func SetTestSettings(settings *Settings) {
 	// Publish atomically; readers on the hot path see the new snapshot
-	// immediately via GetSettings. The sync.Once guarding Setting()'s one-
-	// shot Load() is not reset: its body is a no-op once settingsInstance
-	// holds a non-nil value, and resetting would introduce a data race on
-	// the Once itself when parallel tests each call SetTestSettings.
+	// immediately via GetSettings. Setting() will re-Load() from disk on
+	// the next call if settings is nil, so cleanup paths that restore a
+	// previously-nil snapshot do not leave downstream consumers with a
+	// nil dereference.
 	settingsInstance.Store(settings)
 }
 

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -12,6 +12,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/spf13/viper"
@@ -1504,10 +1505,13 @@ type AlertSettings struct {
 // Must be set before the first call to Setting() or Load().
 var ConfigPath string
 
+// settingsInstance holds the current *Settings snapshot. Published via
+// Store() in Load/StoreSettings/SetTestSettings; read via Load() in
+// GetSettings. Lock-free reads keep the request hot path fast while copy-on-
+// write writes in api/v2.UpdateSettings keep readers race-free.
 var (
-	settingsInstance *Settings
+	settingsInstance atomic.Pointer[Settings]
 	once             sync.Once
-	settingsMutex    sync.RWMutex
 )
 
 // persistMigration saves the config file after a successful migration.
@@ -1527,9 +1531,6 @@ func persistMigration(settings *Settings, label string) {
 //
 //nolint:gocognit // Config loading is inherently complex; splitting adds indirection without clarity.
 func Load() (*Settings, error) {
-	settingsMutex.Lock()
-	defer settingsMutex.Unlock()
-
 	// Create a new settings struct
 	settings := &Settings{}
 
@@ -1695,9 +1696,10 @@ func Load() (*Settings, error) {
 		}
 	}
 
-	// Save settings instance
-	settingsInstance = settings
-	return settingsInstance, nil
+	// Publish the loaded settings atomically. Readers calling GetSettings
+	// immediately after this point see this snapshot.
+	settingsInstance.Store(settings)
+	return settings, nil
 }
 
 // initViper initializes viper with default values and reads the configuration file.
@@ -1868,11 +1870,25 @@ func getDefaultConfig() string {
 	return string(data)
 }
 
-// GetSettings returns the current settings instance
+// GetSettings returns the current settings snapshot. Safe for concurrent use;
+// the returned pointer is published via atomic.Pointer.Store and never mutated
+// in place. Writers produce a new snapshot via CloneSettings + StoreSettings.
 func GetSettings() *Settings {
-	settingsMutex.RLock()
-	defer settingsMutex.RUnlock()
-	return settingsInstance
+	return settingsInstance.Load()
+}
+
+// StoreSettings publishes a new *Settings snapshot atomically. Callers must
+// not mutate the pointee after calling StoreSettings; readers may observe the
+// snapshot concurrently through GetSettings. The canonical writer pattern is:
+//
+//	current := conf.GetSettings()
+//	updated := conf.CloneSettings(current)
+//	// ... mutate updated ...
+//	conf.StoreSettings(updated)
+//
+// Passing nil is valid and clears the stored settings (mostly useful in tests).
+func StoreSettings(s *Settings) {
+	settingsInstance.Store(s)
 }
 
 // migrateLegacyProvider converts a legacy SocialProvider to the new OAuthProviderConfig format.
@@ -2280,20 +2296,27 @@ func prepareSettingsForSave(s *Settings, latitude float64) Settings {
 // SaveSettings saves the current settings to the configuration file.
 // It uses UpdateYAMLConfig to handle the atomic write process.
 func SaveSettings() error {
-	settingsMutex.RLock()
-	defer settingsMutex.RUnlock()
+	// Load the current snapshot through the atomic pointer; the pointee is
+	// immutable after publication so reading fields off it is race-free.
+	current := settingsInstance.Load()
+	if current == nil {
+		return errors.Newf("settings not initialized").
+			Category(errors.CategoryConfiguration).
+			Context("operation", "save-settings").
+			Build()
+	}
 
-	// Create a deep copy of the settings
-	settingsCopy := *settingsInstance
+	// Create a shallow copy of the settings
+	settingsCopy := *current
 
 	// Create a separate copy of the species list with proper locking
 	// Note: This MUST stay here to maintain correct mutex semantics
 	speciesListMutex.RLock()
-	settingsCopy.BirdNET.RangeFilter.Species = slices.Clone(settingsInstance.BirdNET.RangeFilter.Species)
+	settingsCopy.BirdNET.RangeFilter.Species = slices.Clone(current.BirdNET.RangeFilter.Species)
 	speciesListMutex.RUnlock()
 
 	// Apply data transformations (seasonal tracking, etc.)
-	settingsCopy = prepareSettingsForSave(&settingsCopy, settingsInstance.BirdNET.Latitude)
+	settingsCopy = prepareSettingsForSave(&settingsCopy, current.BirdNET.Latitude)
 
 	// Find the path of the current config file
 	configPath, err := FindConfigFile()
@@ -2320,7 +2343,7 @@ func SaveSettings() error {
 // Setting returns the current settings instance, initializing it if necessary
 func Setting() *Settings {
 	once.Do(func() {
-		if settingsInstance == nil {
+		if settingsInstance.Load() == nil {
 			_, err := Load()
 			if err != nil {
 				// Fatal error loading settings - application cannot continue
@@ -2340,11 +2363,12 @@ func Setting() *Settings {
 // This must be called before any call to Setting() to be effective.
 // This is intended for testing purposes only.
 func SetTestSettings(settings *Settings) {
-	settingsMutex.Lock()
-	defer settingsMutex.Unlock()
-	settingsInstance = settings
-	// Reset the sync.Once to allow reinitialization in tests
-	once = sync.Once{}
+	// Publish atomically; readers on the hot path see the new snapshot
+	// immediately via GetSettings. The sync.Once guarding Setting()'s one-
+	// shot Load() is not reset: its body is a no-op once settingsInstance
+	// holds a non-nil value, and resetting would introduce a data race on
+	// the Once itself when parallel tests each call SetTestSettings.
+	settingsInstance.Store(settings)
 }
 
 // GetTestSettings returns a copy of default settings suitable for testing.

--- a/internal/conf/config_race_test.go
+++ b/internal/conf/config_race_test.go
@@ -15,7 +15,12 @@ import (
 // update via atomic.Pointer, so readers always see one of the two valid
 // values.
 func TestSettings_GetStore_NoRace(t *testing.T) {
-	t.Parallel()
+	// Intentionally NOT t.Parallel(): this test mutates the package-global
+	// settingsInstance via StoreSettings. Running in parallel with any
+	// sibling test that touches the global (now or in the future) would
+	// race even though the atomic.Pointer is itself safe, because the
+	// sibling could publish a snapshot with WebServer.BasePath neither
+	// "/a" nor "/b" and the reader goroutine would flag a torn read.
 
 	const iterations = 10_000
 

--- a/internal/conf/config_race_test.go
+++ b/internal/conf/config_race_test.go
@@ -1,0 +1,56 @@
+package conf
+
+import (
+	"sync"
+	"testing"
+)
+
+// TestSettings_GetStore_NoRace runs a writer and a reader goroutine
+// concurrently and asserts the reader never observes a torn value. Must pass
+// under `go test -race`.
+//
+// The previous design (settingsInstance *Settings + RWMutex) guarded only the
+// pointer lookup; readers holding the pointer raced with writers mutating
+// fields in place. The new design publishes a new *Settings snapshot per
+// update via atomic.Pointer, so readers always see one of the two valid
+// values.
+func TestSettings_GetStore_NoRace(t *testing.T) {
+	t.Parallel()
+
+	const iterations = 10_000
+
+	// Capture the current snapshot so we can restore it after the test.
+	// Tests that set global state must not leak it to siblings.
+	prev := settingsInstance.Load()
+	t.Cleanup(func() { settingsInstance.Store(prev) })
+
+	base := &Settings{}
+	base.WebServer.BasePath = "/a"
+	StoreSettings(base)
+
+	var wg sync.WaitGroup
+
+	wg.Go(func() {
+		for i := range iterations {
+			cp := CloneSettings(GetSettings())
+			if i%2 == 0 {
+				cp.WebServer.BasePath = "/a"
+			} else {
+				cp.WebServer.BasePath = "/b"
+			}
+			StoreSettings(cp)
+		}
+	})
+
+	wg.Go(func() {
+		for range iterations {
+			bp := GetSettings().WebServer.BasePath
+			if bp != "/a" && bp != "/b" {
+				t.Errorf("torn read: %q", bp)
+				return
+			}
+		}
+	})
+
+	wg.Wait()
+}


### PR DESCRIPTION
## Summary

Three defects in the basepath handling pipeline, fixed as six commits on one branch:

### 1. Dashboard hourly-grid and species anchors drop the basepath prefix

`DailySummaryCard.svelte` built three `/ui/detections?...` URLs inline with `new URLSearchParams(...)` and skipped the `buildAppUrl` helper. Under `webserver.basepath: /birdnet` (or the equivalent `X-Forwarded-Prefix` / `X-Ingress-Path` reverse-proxy setup) every hourly-grid cell, species row, and per-species hour cell 404'd once the DB had detection rows.

- New `frontend/src/lib/utils/detectionUrls.ts` extracts `buildHourlyDetectionUrl`, `buildSpeciesDetectionUrl`, `buildSpeciesHourUrl`, each wrapping `buildAppUrl`.
- Vitest spec covers no-basepath, YAML `/birdnet` basepath, Home Assistant `/api/hassio_ingress/TOKEN` basepath, idempotency, and non-ASCII species name encoding.
- `DailySummaryCard.svelte` now delegates to the three helpers; the existing LRU URL cache and caller sites stay unchanged.

### 2. Basepath strip middleware desyncs `URL.Path` and `URL.RawPath` under percent-encoded basepaths

The Pre middleware compared the decoded basepath against the percent-encoded `req.URL.RawPath`. For basepaths containing characters that require encoding (a space, non-ASCII like `/Übersicht`) the `HasPrefix` check failed, `URL.Path` was stripped, and `URL.RawPath` was not. Echo's router then saw mismatched values and could miss the intended route.

- Encode the basepath via `(&url.URL{Path: bp}).EscapedPath()` before the prefix comparison.
- Run the comparison through a new `hasPercentEncodedPrefix` helper that matches `%XX` hex digits case-insensitively, so proxies forwarding lowercase `%c3%9c` still resolve against Go's canonical uppercase `%C3%9C`.
- `basepath_test.go`'s mirrored middleware picks up the same fix; regression rows cover a space-in-basepath case (`/birdnet go` with a `%2F` remainder forcing `RawPath` to be populated) and a non-ASCII lowercase-hex case (`/Übersicht` with `/%c3%9cbersicht/...`).

### 3. Settings hot-reload race between strip middleware reads and UI PUT writes

The basepath strip middleware reads `s.settings.WebServer.BasePath` via `ingressPath` on every request. The settings UI PUT/PATCH handlers were mutating `*conf.Settings` fields in place. The global storage was guarded by a pointer-lookup RWMutex, but once a caller held the pointer, field reads raced with in-place writes.

- `conf.settingsInstance` switches from `*Settings` + `RWMutex` to `sync/atomic.Pointer[Settings]`. Readers call `conf.GetSettings()` (lock-free atomic load); writers produce new snapshots and publish via a new `conf.StoreSettings`.
- New `internal/conf/clone.go` provides an explicit field-by-field `CloneSettings` (no reflection) that covers every slice and map reachable from `Settings`. `map[string]any` fields (`BackupTarget.Settings`, `PushFilterConfig.MetadataFilters`) go through a type-aware `cloneStringAnyMap` / `cloneAnyValue` pair so nested slices and maps are independently cloned without JSON round-tripping (which would coerce `int` to `float64` and break viper consumers).
- `TestCloneSettings_DeepIndependence` is the drift guardrail: every slice/map field added to `Settings` in the future must also grow a mutate+assert pair here, or a shared backing array silently reintroduces the race.
- `api/v2.UpdateSettings` (PUT) and `api/v2.UpdateSectionSettings` (PATCH) both follow a clone-validate-publish-rollback flow: clone the current snapshot, apply updates to the clone, validate, atomically publish via `StoreSettings`, and republish the previous snapshot on `handleSettingsChanges` or `SaveSettings` failure. Skip the global publish when the controller owns a standalone `c.Settings` (tests that inject without touching the global).
- `internal/api/server.go` basepath Pre middleware, per-request basePath context middleware, and the three OAuth callback redirects now read via `conf.GetSettings()` so every request picks up the freshly published snapshot with no lock.
- `c.Debug` routes through `conf.GetSettings()` rather than `c.Settings` so the async reconfig goroutine spawned by `handleSettingsChanges` does not race with concurrent writes to `c.Settings`.

### Known limitations (tracked separately)

Several other packages (`internal/notification/detection_consumer.go`, `internal/security/oauth.go`, assorted `internal/api/v2/*.go` handlers, `internal/imageprovider/*`, `internal/analysis/control_monitor.go`, and more) cache `*conf.Settings` pointers at construction time. After the CoW refactor those cached pointers still reference the boot-time snapshot and will observe stale data until they re-fetch. That is a dependency-injection audit, out of scope for this PR.

## Test plan

- [x] `go test -race ./internal/conf/... ./internal/api/...` all green, including the new `TestCloneSettings_DeepIndependence`, `TestSettings_GetStore_NoRace`, `TestIngressPath_RaceAgainstStoreSettings`, and the extended `TestBasePathStripMiddleware` rows.
- [x] `golangci-lint run -v` zero issues on `internal/conf/...`, `internal/api/...`, `internal/api/v2/...`.
- [x] `cd frontend && npm run check:all && npm test -- --run` all green, `detectionUrls.test.ts` covers all three basepath variants.
- [x] `task frontend-build` succeeds.
- [ ] Manual: start the service with `webserver.basepath: /birdnet` on a container with detection rows; hourly-grid and species anchors resolve without 404.
- [ ] Manual: set `webserver.basepath: "/birdnet go"`; `GET /birdnet%20go/api/v2/health` returns 200 with matching `URL.Path` and `URL.RawPath` after stripping.
- [ ] Manual: concurrent `PUT /api/v2/settings` bursts against live traffic do not produce torn-read errors in Sentry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced URL builder helpers for dashboard detection links to generate consistent, basepath-aware anchors.

* **Bug Fixes**
  * Fixed race conditions around runtime settings and basepath handling for reliable URL resolution and redirects.

* **Improvements**
  * Detection links now consistently percent‑encode spaces and non‑ASCII names; settings updates use copy‑on‑write and atomic publication for safer apply/rollback.

* **Tests**
  * Added tests covering URL builders, deep settings cloning, and concurrent settings access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->