### PR TITLE
fix(jobqueue): drop completed-job retention, reclaim ~130 MB steady-state memory

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -630,7 +630,6 @@ internal/analysis/jobqueue/
 - **Retry with Exponential Backoff**: Configurable retry policies per action type
 - **Graceful Degradation**: Failed jobs don't block new detections
 - **Queue Limits**: Bounded queue prevents memory exhaustion (default: 1000 jobs)
-- **Job Archival**: Completed/failed jobs archived for debugging (max 100)
 - **Statistics Tracking**: Per-action success/failure rates
 
 **Action Types** (internal/analysis/processor/actions.go):
@@ -661,7 +660,7 @@ Detection → ProcessDetection() → CreateActions() → EnqueueTask()
                                    ↓                                   ↓
                             Success/Failure            Exponential Backoff
                                    ↓                                   ↓
-                            Archive Job              Retry or Mark Failed
+                            Drop Job                 Retry or Mark Failed
 ```
 
 **Retry Configuration:**
@@ -684,8 +683,8 @@ type RetryConfig struct {
 2. EnqueueTask() adds job to queue (non-blocking)
 3. Job executes in background goroutine
 4. If upload fails (network error): retry after 5s, then 10s, then 20s
-5. If max retries exceeded: mark as failed, log error, archive job
-6. Success: archive job with success status
+5. If max retries exceeded: mark as failed, log error, drop job
+6. Success: drop job with success status
 
 **CompositeAction for Sequential Execution:**
 
@@ -798,7 +797,6 @@ BirdNET-Go uses a job queue system for concurrent action processing:
 // Initialize job queue with capacity and options
 processor.JobQueue = jobqueue.NewJobQueueWithOptions(
     1000,  // maxJobs: queue capacity
-    100,   // maxArchivedJobs: keep completed jobs for debugging
     false, // logAllSuccesses: only log retries by default
 )
 
@@ -828,7 +826,7 @@ The job queue runs a background goroutine that:
 1. Checks for jobs ready to execute (pending or retrying after backoff)
 2. Executes actions in separate goroutines (concurrent execution)
 3. Handles retry logic with exponential backoff on failure
-4. Archives completed/failed jobs for debugging
+4. Drops completed and failed jobs from the active queue so their Action payloads become GC-eligible
 5. Respects queue capacity limits to prevent memory exhaustion
 
 **Graceful Shutdown:**

--- a/internal/analysis/jobqueue/README.md
+++ b/internal/analysis/jobqueue/README.md
@@ -178,8 +178,7 @@ queue.Stop()
 
 1. **Queue Size**: Set appropriate queue size limits based on memory constraints
 2. **Retry Policy**: Configure retry policies based on the nature of the work
-3. **Archive Limits**: Set appropriate archive limits to prevent memory leaks
-4. **Processing Interval**: Adjust the processing interval based on workload characteristics
+3. **Processing Interval**: Adjust the processing interval based on workload characteristics
 
 ### Monitoring
 
@@ -209,7 +208,7 @@ backoff *= jitterFactor
 The queue implements several mechanisms to manage memory:
 
 1. **Maximum Queue Size**: Limits the number of pending jobs
-2. **Archive Limit**: Limits the number of completed/failed jobs kept in memory
+2. **Completed-Job Discard**: Completed and failed jobs are dropped from the active queue on the next cleanup tick, making their Action payloads eligible for garbage collection
 3. **Job Dropping**: Can drop oldest jobs when the queue is full
 
 ### Panic Recovery

--- a/internal/analysis/jobqueue/clock_test.go
+++ b/internal/analysis/jobqueue/clock_test.go
@@ -19,7 +19,7 @@ func TestRetryBackoffWithMockClock(t *testing.T) {
 	ctx := t.Context()
 
 	// Create a new job queue
-	queue := setupTestQueue(t, 100, 10, false)
+	queue := setupTestQueue(t, 100, false)
 	defer teardownTestQueue(t, queue)
 
 	// Create a mock clock with a known start time

--- a/internal/analysis/jobqueue/job.go
+++ b/internal/analysis/jobqueue/job.go
@@ -28,7 +28,6 @@ type JobStats struct {
 	SuccessfulJobs int
 	FailedJobs     int
 	StaleJobs      int
-	ArchivedJobs   int // Track number of archived jobs
 	DroppedJobs    int // Track number of jobs dropped due to queue full
 	RetryAttempts  int
 	ActionStats    map[string]ActionStats // Key is the type name of the action
@@ -41,7 +40,6 @@ type JobStatsSnapshot struct {
 	SuccessfulJobs int
 	FailedJobs     int
 	StaleJobs      int
-	ArchivedJobs   int
 	DroppedJobs    int
 	RetryAttempts  int
 
@@ -123,7 +121,6 @@ func (s *JobStatsSnapshot) toJSON(prettyPrint bool) (string, error) {
 			"successful":    s.SuccessfulJobs,
 			"failed":        s.FailedJobs,
 			"stale":         s.StaleJobs,
-			"archived":      s.ArchivedJobs,
 			"dropped":       s.DroppedJobs,
 			"retryAttempts": s.RetryAttempts,
 			"pending":       s.PendingJobs,

--- a/internal/analysis/jobqueue/queue.go
+++ b/internal/analysis/jobqueue/queue.go
@@ -60,8 +60,13 @@ func NewJobQueue() *JobQueue {
 	return NewJobQueueWithOptions(1000, false)
 }
 
-// NewJobQueueWithOptions creates a new job queue with custom settings
+// NewJobQueueWithOptions creates a new job queue with custom settings.
+// A non-positive maxJobs is clamped to 1 so callers cannot silently produce
+// a queue that rejects every Enqueue with ErrQueueFull.
 func NewJobQueueWithOptions(maxJobs int, logAllSuccesses bool) *JobQueue {
+	if maxJobs < 1 {
+		maxJobs = 1
+	}
 	return &JobQueue{
 		jobs:               make([]*Job, 0),
 		stopCh:             make(chan struct{}),

--- a/internal/analysis/jobqueue/queue.go
+++ b/internal/analysis/jobqueue/queue.go
@@ -363,11 +363,11 @@ func (q *JobQueue) processJobs(ctx context.Context) {
 	}
 }
 
-// cleanupStaleJobs drops completed and failed jobs from the active queue so
-// the Job struct, its Action, and any buffers it holds become eligible for
-// garbage collection on the next GC cycle. The per-action stats and queue-wide
-// counters (StaleJobs, FailedJobs, SuccessfulJobs) already record every
-// outcome, so no per-job state is preserved after completion.
+// cleanupStaleJobs drops terminal-state jobs (completed, failed, or cancelled)
+// from the active queue so the Job struct, its Action, and any buffers it holds
+// become eligible for garbage collection on the next GC cycle. The per-action
+// stats and queue-wide counters (StaleJobs, FailedJobs, SuccessfulJobs) already
+// record every outcome, so no per-job state is preserved after completion.
 func (q *JobQueue) cleanupStaleJobs(ctx context.Context) {
 	if ctx.Err() != nil {
 		return
@@ -376,12 +376,17 @@ func (q *JobQueue) cleanupStaleJobs(ctx context.Context) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 
-	// Compact in place: keep only jobs still pending, running, retrying, or
-	// cancelled. Completed and failed jobs are dropped entirely.
+	// Compact in place: keep only jobs still pending, running, or retrying.
+	// Completed, failed, and cancelled jobs are dropped entirely; leaving
+	// cancelled jobs in the active slice would otherwise pin their payloads
+	// and, because maxJobs caps the active queue, eventually cause legitimate
+	// Enqueue calls to fail with ErrQueueFull.
 	var staleCount int
 	kept := 0
 	for _, job := range q.jobs {
-		if job.Status == JobStatusCompleted || job.Status == JobStatusFailed {
+		if job.Status == JobStatusCompleted ||
+			job.Status == JobStatusFailed ||
+			job.Status == JobStatusCancelled {
 			staleCount++
 			continue
 		}

--- a/internal/analysis/jobqueue/queue.go
+++ b/internal/analysis/jobqueue/queue.go
@@ -41,13 +41,11 @@ const (
 // JobQueue manages a queue of jobs that can be retried
 type JobQueue struct {
 	jobs               []*Job
-	archivedJobs       []*Job // Store stale jobs here instead of discarding
 	mu                 sync.Mutex
 	stats              JobStats
 	stopCh             chan struct{}
 	runningJobs        sync.WaitGroup // Track running jobs for graceful shutdown
 	isRunning          bool
-	maxArchivedJobs    int  // Maximum number of archived jobs to keep
 	maxJobs            int  // Maximum number of pending jobs in the queue
 	droppedJobs        int  // Counter for jobs dropped due to queue full
 	logAllSuccesses    bool // Whether to log all successful jobs, not just retries
@@ -59,16 +57,14 @@ type JobQueue struct {
 
 // NewJobQueue creates a new job queue with default settings
 func NewJobQueue() *JobQueue {
-	return NewJobQueueWithOptions(1000, 100, false)
+	return NewJobQueueWithOptions(1000, false)
 }
 
 // NewJobQueueWithOptions creates a new job queue with custom settings
-func NewJobQueueWithOptions(maxJobs, maxArchivedJobs int, logAllSuccesses bool) *JobQueue {
+func NewJobQueueWithOptions(maxJobs int, logAllSuccesses bool) *JobQueue {
 	return &JobQueue{
 		jobs:               make([]*Job, 0),
-		archivedJobs:       make([]*Job, 0),
 		stopCh:             make(chan struct{}),
-		maxArchivedJobs:    maxArchivedJobs,
 		maxJobs:            maxJobs,
 		logAllSuccesses:    logAllSuccesses,
 		allowJobDropping:   true,            // Default to allowing job dropping when queue is full
@@ -362,9 +358,12 @@ func (q *JobQueue) processJobs(ctx context.Context) {
 	}
 }
 
-// cleanupStaleJobs moves completed and failed jobs to the archived jobs list
+// cleanupStaleJobs drops completed and failed jobs from the active queue so
+// the Job struct, its Action, and any buffers it holds become eligible for
+// garbage collection on the next GC cycle. The per-action stats and queue-wide
+// counters (StaleJobs, FailedJobs, SuccessfulJobs) already record every
+// outcome, so no per-job state is preserved after completion.
 func (q *JobQueue) cleanupStaleJobs(ctx context.Context) {
-	// Quick check for context cancellation
 	if ctx.Err() != nil {
 		return
 	}
@@ -372,32 +371,25 @@ func (q *JobQueue) cleanupStaleJobs(ctx context.Context) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 
-	var activeJobs []*Job
-	var staleJobs []*Job
-
-	// Identify stale jobs (completed or failed)
+	// Compact in place: keep only jobs still pending, running, retrying, or
+	// cancelled. Completed and failed jobs are dropped entirely.
+	var staleCount int
+	kept := 0
 	for _, job := range q.jobs {
 		if job.Status == JobStatusCompleted || job.Status == JobStatusFailed {
-			staleJobs = append(staleJobs, job)
-		} else {
-			activeJobs = append(activeJobs, job)
+			staleCount++
+			continue
 		}
+		q.jobs[kept] = job
+		kept++
 	}
-
-	// Update the jobs list to only include active jobs
-	q.jobs = activeJobs
-
-	// Add stale jobs to the archived jobs list
-	q.archivedJobs = append(q.archivedJobs, staleJobs...)
-	q.stats.StaleJobs += len(staleJobs)
-	q.stats.ArchivedJobs = len(q.archivedJobs)
-
-	// Trim archived jobs if needed
-	if len(q.archivedJobs) > q.maxArchivedJobs {
-		excess := len(q.archivedJobs) - q.maxArchivedJobs
-		q.archivedJobs = q.archivedJobs[excess:]
-		q.stats.ArchivedJobs = len(q.archivedJobs)
+	// Null out the tail so the discarded *Job pointers (and the Action plus
+	// any payload they reference) become eligible for garbage collection.
+	for i := kept; i < len(q.jobs); i++ {
+		q.jobs[i] = nil
 	}
+	q.jobs = q.jobs[:kept]
+	q.stats.StaleJobs += staleCount
 }
 
 // calculateBackoffDelay calculates the delay before the next retry attempt
@@ -857,7 +849,6 @@ func (q *JobQueue) GetStats() JobStatsSnapshot {
 		SuccessfulJobs: q.stats.SuccessfulJobs,
 		FailedJobs:     q.stats.FailedJobs,
 		StaleJobs:      q.stats.StaleJobs,
-		ArchivedJobs:   q.stats.ArchivedJobs,
 		DroppedJobs:    q.stats.DroppedJobs,
 		RetryAttempts:  q.stats.RetryAttempts,
 

--- a/internal/analysis/jobqueue/queue_test.go
+++ b/internal/analysis/jobqueue/queue_test.go
@@ -1806,30 +1806,46 @@ func TestCompletedJobIsGarbageCollectable(t *testing.T) {
 		time.Sleep(5 * time.Millisecond)
 	}
 
-	// Force GC. If the queue still retains the action (archive regression),
-	// the cleanup callback never runs.
-	for range 3 {
+	// Poll for the cleanup callback. runtime.AddCleanup is asynchronous with
+	// no fixed timing relative to runtime.GC(); the Go runtime may only queue
+	// callbacks during GC and run them later on a separate goroutine. Forcing
+	// GC plus yielding the scheduler on each iteration reliably drives the
+	// callback on slow CI where a fixed wait would flake.
+	require.Eventually(t, func() bool {
 		runtime.GC()
-	}
-
-	select {
-	case <-finalized:
-		// Action was reclaimed. Queue released its reference. Pass.
-	case <-time.After(2 * time.Second):
-		t.Fatalf("completed job action was not garbage-collected within 2s after cleanup; jobqueue is retaining it")
-	}
+		runtime.Gosched()
+		select {
+		case <-finalized:
+			return true
+		default:
+			return false
+		}
+	}, 2*time.Second, 25*time.Millisecond,
+		"completed job action was not garbage-collected after cleanup; jobqueue is retaining it")
 }
 
 // TestNewJobQueueWithOptions_ClampsNonPositiveMaxJobs verifies that passing
 // maxJobs <= 0 is clamped to 1 so the queue remains usable instead of silently
-// rejecting every Enqueue with ErrQueueFull.
+// rejecting every Enqueue with ErrQueueFull. Covers the field accessor AND the
+// observable Enqueue behavior, since the user-visible bug is queue-full
+// rejection rather than the internal counter.
 func TestNewJobQueueWithOptions_ClampsNonPositiveMaxJobs(t *testing.T) {
 	t.Parallel()
 
 	for _, maxJobs := range []int{0, -1, -100} {
-		q := NewJobQueueWithOptions(maxJobs, false)
-		assert.Equal(t, 1, q.GetMaxJobs(),
-			"maxJobs=%d should clamp to 1; got %d", maxJobs, q.GetMaxJobs())
+		t.Run(fmt.Sprintf("maxJobs=%d", maxJobs), func(t *testing.T) {
+			t.Parallel()
+
+			q := setupTestQueue(t, maxJobs, false)
+			t.Cleanup(func() { _ = q.StopWithTimeout(1 * time.Second) })
+
+			assert.Equal(t, 1, q.GetMaxJobs(),
+				"maxJobs=%d should clamp to 1; got %d", maxJobs, q.GetMaxJobs())
+
+			_, err := q.Enqueue(t.Context(), &MockAction{}, &TestData{ID: "smoke"}, RetryConfig{Enabled: false})
+			require.NoError(t, err,
+				"clamped queue should accept its first job instead of returning ErrQueueFull")
+		})
 	}
 }
 

--- a/internal/analysis/jobqueue/queue_test.go
+++ b/internal/analysis/jobqueue/queue_test.go
@@ -1837,7 +1837,10 @@ func TestNewJobQueueWithOptions_ClampsNonPositiveMaxJobs(t *testing.T) {
 			t.Parallel()
 
 			q := setupTestQueue(t, maxJobs, false)
-			t.Cleanup(func() { _ = q.StopWithTimeout(1 * time.Second) })
+			t.Cleanup(func() {
+				assert.NoError(t, q.StopWithTimeout(1*time.Second),
+					"StopWithTimeout should not error during test cleanup")
+			})
 
 			assert.Equal(t, 1, q.GetMaxJobs(),
 				"maxJobs=%d should clamp to 1; got %d", maxJobs, q.GetMaxJobs())

--- a/internal/analysis/jobqueue/queue_test.go
+++ b/internal/analysis/jobqueue/queue_test.go
@@ -175,9 +175,9 @@ type TestData struct {
 }
 
 // setupTestQueue creates a job queue for testing with custom options
-func setupTestQueue(t *testing.T, maxJobs, maxArchivedJobs int, logAllSuccesses bool) *JobQueue {
+func setupTestQueue(t *testing.T, maxJobs int, logAllSuccesses bool) *JobQueue {
 	t.Helper()
-	queue := NewJobQueueWithOptions(maxJobs, maxArchivedJobs, logAllSuccesses)
+	queue := NewJobQueueWithOptions(maxJobs, logAllSuccesses)
 	// Set a much shorter processing interval for faster test execution
 	queue.SetProcessingInterval(10 * time.Millisecond)
 	queue.Start()
@@ -195,7 +195,7 @@ func teardownTestQueue(t *testing.T, queue *JobQueue) {
 func TestBasicQueueFunctionality(t *testing.T) {
 	t.Parallel()
 	// Create a new job queue
-	queue := setupTestQueue(t, 100, 10, false)
+	queue := setupTestQueue(t, 100, false)
 	defer teardownTestQueue(t, queue)
 
 	// Create a mock action
@@ -241,7 +241,7 @@ func TestMultipleJobs(t *testing.T) {
 	ctx := t.Context()
 
 	// Create a new job queue
-	queue := setupTestQueue(t, 100, 10, false)
+	queue := setupTestQueue(t, 100, false)
 	defer teardownTestQueue(t, queue)
 
 	// Number of jobs to enqueue
@@ -323,7 +323,7 @@ func TestRetryProcess(t *testing.T) {
 	// Create a context for manual control
 	ctx := t.Context()
 
-	queue := setupTestQueue(t, 100, 10, false)
+	queue := setupTestQueue(t, 100, false)
 	defer teardownTestQueue(t, queue)
 
 	// Number of times the job should fail before succeeding
@@ -424,7 +424,7 @@ func TestRetryExhaustion(t *testing.T) {
 	ctx := t.Context()
 
 	// Create a new job queue
-	queue := setupTestQueue(t, 100, 10, false)
+	queue := setupTestQueue(t, 100, false)
 	defer teardownTestQueue(t, queue)
 
 	// Create a counter for tracking attempts
@@ -496,16 +496,16 @@ func TestRetryExhaustion(t *testing.T) {
 		}
 	}
 
-	// If not found in active jobs, check in archived jobs
+	queue.mu.Unlock()
+
 	if !jobFailed {
-		for _, j := range queue.archivedJobs {
-			if j.ID == job.ID && j.Status == JobStatusFailed {
-				jobFailed = true
-				break
-			}
+		// After cleanupStaleJobs runs, the job pointer is discarded. Observe
+		// the failure via the queue-wide counter instead.
+		stats := queue.GetStats()
+		if stats.FailedJobs > 0 {
+			jobFailed = true
 		}
 	}
-	queue.mu.Unlock()
 
 	assert.True(t, jobFailed, "Job should have failed permanently after exhausting retries")
 }
@@ -521,7 +521,7 @@ func TestRetryBackoff(t *testing.T) {
 	ctx := t.Context()
 
 	// Create a new job queue
-	queue := setupTestQueue(t, 100, 10, false)
+	queue := setupTestQueue(t, 100, false)
 	defer teardownTestQueue(t, queue)
 
 	// Create a counter for tracking attempts
@@ -618,16 +618,16 @@ func TestRetryBackoff(t *testing.T) {
 		}
 	}
 
-	// If not found in active jobs, check in archived jobs
+	queue.mu.Unlock()
+
 	if !jobFailed {
-		for _, j := range queue.archivedJobs {
-			if j.ID == job.ID && j.Status == JobStatusFailed {
-				jobFailed = true
-				break
-			}
+		// After cleanupStaleJobs runs, the job pointer is discarded. Observe
+		// the failure via the queue-wide counter instead.
+		stats := queue.GetStats()
+		if stats.FailedJobs > 0 {
+			jobFailed = true
 		}
 	}
-	queue.mu.Unlock()
 
 	assert.True(t, jobFailed, "Job should have failed permanently after exhausting retries")
 
@@ -656,11 +656,10 @@ func isClosed(ch <-chan time.Time) bool {
 	}
 }
 
-// TestJobExpiration tests that completed and failed jobs are moved to the archived jobs list
+// TestJobExpiration tests that completed and failed jobs are removed from the
+// active queue after cleanup so new jobs can be processed.
 func TestJobExpiration(t *testing.T) {
-	// Create a new job queue with a maximum archived jobs limit
-	maxArchivedJobs := 5
-	queue := setupTestQueue(t, 100, maxArchivedJobs, false)
+	queue := setupTestQueue(t, 100, false)
 	defer teardownTestQueue(t, queue)
 
 	// Create a wait group to wait for all jobs to complete
@@ -719,7 +718,9 @@ func TestJobExpiration(t *testing.T) {
 	assert.Equal(t, 3, stats.SuccessfulJobs, "Successful jobs should be 3")
 	assert.Equal(t, 2, stats.FailedJobs, "Failed jobs should be 2")
 	assert.Equal(t, 5, stats.StaleJobs, "Stale jobs should be 5")
-	assert.Equal(t, 5, stats.ArchivedJobs, "Archived jobs should be 5")
+	// Archive is gone: completed and failed jobs are discarded on the cleanup
+	// tick. The active queue should be empty after all jobs finish.
+	assert.Equal(t, 0, stats.PendingJobs, "Pending jobs should be 0 after cleanup")
 
 	// Enqueue a new job to verify that the active jobs list is empty
 	action := &MockAction{}
@@ -734,59 +735,6 @@ func TestJobExpiration(t *testing.T) {
 	assert.Equal(t, 1, action.GetExecuteCount(), "New job should have been executed")
 }
 
-// TestArchiveLimit tests that the archived jobs list is limited to the specified maximum size
-func TestArchiveLimit(t *testing.T) {
-	// Create a new job queue with a small maximum archived jobs limit
-	maxArchivedJobs := 3
-	queue := setupTestQueue(t, 100, maxArchivedJobs, false)
-	defer teardownTestQueue(t, queue)
-
-	// Create a wait group to wait for all jobs to complete
-	var wg sync.WaitGroup
-	wg.Add(6)
-
-	// Create retry config
-	config := RetryConfig{
-		Enabled:      false,
-		MaxRetries:   0,
-		InitialDelay: 10 * time.Millisecond,
-		MaxDelay:     100 * time.Millisecond,
-		Multiplier:   2.0,
-	}
-
-	// Enqueue 6 jobs
-	for i := range 6 {
-		action := &MockAction{
-			ExecuteFunc: func(data any) error {
-				defer wg.Done()
-				return nil
-			},
-		}
-		data := &TestData{ID: fmt.Sprintf("job-%d", i)}
-		_, err := queue.Enqueue(t.Context(), action, data, config)
-		require.NoError(t, err, "Failed to enqueue job")
-	}
-
-	// Wait for all jobs to complete
-	done := make(chan struct{})
-	go func() {
-		wg.Wait()
-		close(done)
-	}()
-
-	waitForChannel(t, done, DefaultTestTimeout, "Timed out waiting for jobs to complete")
-
-	// Wait for the cleanup to happen (cleanup happens on the 1-second ticker)
-	time.Sleep(3 * time.Second)
-
-	// Check job stats
-	stats := queue.GetStats()
-	assert.Equal(t, 6, stats.TotalJobs, "Total jobs should be 6")
-	assert.Equal(t, 6, stats.SuccessfulJobs, "Successful jobs should be 6")
-	assert.Equal(t, 0, stats.FailedJobs, "Failed jobs should be 0")
-	assert.Equal(t, maxArchivedJobs, stats.ArchivedJobs, "Archived jobs should be limited to maxArchivedJobs")
-}
-
 // TestQueueOverflow tests that jobs are rejected when the queue is full
 func TestQueueOverflow(t *testing.T) {
 	// Create a context for manual control
@@ -794,7 +742,7 @@ func TestQueueOverflow(t *testing.T) {
 
 	// Create a job queue with a small capacity
 	queueCapacity := 3
-	queue := setupTestQueue(t, queueCapacity, 5, false)
+	queue := setupTestQueue(t, queueCapacity, false)
 	defer teardownTestQueue(t, queue)
 
 	// Disable job dropping for this test
@@ -873,49 +821,20 @@ func TestQueueOverflow(t *testing.T) {
 	// Force cleanup of stale jobs to ensure accurate stats
 	queue.cleanupStaleJobs(ctx)
 
-	// Reset the queue stats to get accurate counts
-	queue.mu.Lock()
-	queue.stats.TotalJobs = 0
-	queue.stats.SuccessfulJobs = 0
-	queue.stats.FailedJobs = 0
-
-	// Count the jobs in the active and archived lists
-	for _, job := range queue.jobs {
-		queue.stats.TotalJobs++
-		switch job.Status {
-		case JobStatusCompleted:
-			queue.stats.SuccessfulJobs++
-		case JobStatusFailed:
-			queue.stats.FailedJobs++
-		case JobStatusPending, JobStatusRunning, JobStatusRetrying, JobStatusCancelled:
-			// These statuses don't affect success/failure counts
-		}
-	}
-
-	for _, job := range queue.archivedJobs {
-		queue.stats.TotalJobs++
-		switch job.Status {
-		case JobStatusCompleted:
-			queue.stats.SuccessfulJobs++
-		case JobStatusFailed:
-			queue.stats.FailedJobs++
-		case JobStatusPending, JobStatusRunning, JobStatusRetrying, JobStatusCancelled:
-			// These statuses don't affect success/failure counts
-		}
-	}
-	queue.mu.Unlock()
-
-	// Verify final counts
+	// The active queue is now empty because cleanupStaleJobs discards
+	// completed and failed jobs. The queue-wide counters still reflect every
+	// job that was ever enqueued or finished, so we check those directly.
 	stats := queue.GetStats()
 	assert.Equal(t, 4, stats.TotalJobs, "Total jobs should include all jobs processed")
 	assert.Equal(t, 4, stats.SuccessfulJobs, "All jobs should be successful")
+	assert.Equal(t, 0, stats.PendingJobs, "Active queue should be empty after cleanup")
 }
 
 // TestDropOldestJob tests that the oldest pending job is dropped when the queue is full
 func TestDropOldestJob(t *testing.T) {
 	// Create a queue with a capacity of 3 jobs
 	queueCapacity := 3
-	queue := NewJobQueueWithOptions(queueCapacity, 10, false)
+	queue := NewJobQueueWithOptions(queueCapacity, false)
 	queue.Start()
 	defer func() {
 		assert.NoError(t, queue.Stop(), "Failed to stop queue")
@@ -1023,7 +942,7 @@ func TestDropOldestJob(t *testing.T) {
 // TestHangingJobTimeout tests that hanging jobs are properly timed out
 func TestHangingJobTimeout(t *testing.T) {
 	// Create a new job queue
-	queue := setupTestQueue(t, 100, 10, false)
+	queue := setupTestQueue(t, 100, false)
 	defer teardownTestQueue(t, queue)
 
 	// Create a mock action that hangs indefinitely
@@ -1077,7 +996,7 @@ func TestHangingJobTimeout(t *testing.T) {
 // TestContextCancellation tests that jobs are properly cancelled when the context is cancelled
 func TestContextCancellation(t *testing.T) {
 	// Create a new job queue
-	queue := setupTestQueue(t, 100, 10, false)
+	queue := setupTestQueue(t, 100, false)
 
 	// Create a channel to track job execution
 	executionStarted := make(chan struct{})
@@ -1147,7 +1066,7 @@ func TestStressTest(t *testing.T) {
 
 	// Create a new job queue with large capacity
 	maxJobs := 100
-	queue := setupTestQueue(t, maxJobs, 50, false)
+	queue := setupTestQueue(t, maxJobs, false)
 	defer teardownTestQueue(t, queue)
 
 	// Number of jobs to enqueue - reduced for more reliable testing
@@ -1299,7 +1218,7 @@ func TestConcurrentJobSubmission(t *testing.T) {
 	ctx := t.Context()
 
 	// Create a new job queue with large capacity
-	queue := setupTestQueue(t, 1000, 50, false)
+	queue := setupTestQueue(t, 1000, false)
 	defer teardownTestQueue(t, queue)
 
 	numGoroutines := 10
@@ -1346,7 +1265,7 @@ func TestRecoveryFromPanic(t *testing.T) {
 	ctx := t.Context()
 
 	// Create a new job queue
-	queue := setupTestQueue(t, 100, 10, false)
+	queue := setupTestQueue(t, 100, false)
 	defer teardownTestQueue(t, queue)
 
 	// Create action that panics
@@ -1395,7 +1314,7 @@ func TestGracefulShutdownWithInProgressJobs(t *testing.T) {
 	ctx := t.Context()
 
 	// Create a new job queue
-	queue := setupTestQueue(t, 100, 10, false)
+	queue := setupTestQueue(t, 100, false)
 
 	// Create channels to track job states
 	jobStarted := make(chan struct{})
@@ -1444,7 +1363,7 @@ func TestGracefulShutdownWithInProgressJobs(t *testing.T) {
 // TestRateLimiting tests that the job queue properly limits the rate of job submissions
 func TestRateLimiting(t *testing.T) {
 	// Create a queue with a small size to test throttling
-	queue := setupTestQueue(t, 5, 10, false)
+	queue := setupTestQueue(t, 5, false)
 	defer teardownTestQueue(t, queue)
 
 	// Disable job dropping for this test to ensure rejections
@@ -1479,7 +1398,7 @@ func TestRateLimiting(t *testing.T) {
 // TestJobCancellation tests that jobs can be cancelled via context cancellation
 func TestJobCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
-	queue := NewJobQueueWithOptions(100, 10, false)
+	queue := NewJobQueueWithOptions(100, false)
 	queue.SetProcessingInterval(10 * time.Millisecond)
 	queue.StartWithContext(ctx)
 	defer func() {
@@ -1531,26 +1450,34 @@ func TestJobCancellation(t *testing.T) {
 	for _, j := range queue.jobs {
 		if j.ID == job.ID && j.Status == JobStatusFailed {
 			jobFailed = true
-			if j.LastError != nil && strings.Contains(j.LastError.Error(), "cancelled") {
+			if j.LastError != nil && strings.Contains(j.LastError.Error(), "cancel") {
 				jobHasCancellationError = true
 			}
 			break
 		}
 	}
+	queue.mu.Unlock()
 
-	// If not found in active jobs, check in archived jobs
 	if !jobFailed {
-		for _, j := range queue.archivedJobs {
-			if j.ID == job.ID && j.Status == JobStatusFailed {
-				jobFailed = true
-				if j.LastError != nil && strings.Contains(j.LastError.Error(), "cancelled") {
-					jobHasCancellationError = true
-				}
+		// After cleanupStaleJobs runs, the failed job pointer is discarded.
+		// Fall back to the queue-wide counter to observe the failure.
+		postStats := queue.GetStats()
+		if postStats.FailedJobs > 0 {
+			jobFailed = true
+		}
+	}
+	if !jobHasCancellationError {
+		// The dropped Job pointer no longer carries the error after cleanup.
+		// The per-action stats still record LastErrorMessage, which captures
+		// the cancellation error emitted by handleExecutionTimeout.
+		postStats := queue.GetStats()
+		for _, as := range postStats.ActionStats {
+			if strings.Contains(as.LastErrorMessage, "cancel") {
+				jobHasCancellationError = true
 				break
 			}
 		}
 	}
-	queue.mu.Unlock()
 
 	assert.True(t, jobFailed, "Job should be marked as failed after cancellation")
 	assert.True(t, jobHasCancellationError, "Job should have a cancellation error")
@@ -1561,7 +1488,7 @@ func TestLongRunningJobs(t *testing.T) {
 	// Create a context for manual control
 	ctx := t.Context()
 
-	queue := setupTestQueue(t, 100, 10, false)
+	queue := setupTestQueue(t, 100, false)
 	defer teardownTestQueue(t, queue)
 
 	// Create one long-running job
@@ -1618,7 +1545,7 @@ func TestJobTypeStatistics(t *testing.T) {
 	ctx := t.Context()
 
 	// Create a new job queue
-	queue := setupTestQueue(t, 100, 10, false)
+	queue := setupTestQueue(t, 100, false)
 	defer teardownTestQueue(t, queue)
 
 	// Create different action types for testing
@@ -1762,7 +1689,7 @@ func TestMemoryManagementWithLargeJobLoads(t *testing.T) {
 		t.Skip("Skipping memory management test in short mode")
 	}
 
-	queue := setupTestQueue(t, 1000, 100, false)
+	queue := setupTestQueue(t, 1000, false)
 	defer teardownTestQueue(t, queue)
 
 	var m runtime.MemStats
@@ -1818,13 +1745,88 @@ func TestMemoryManagementWithLargeJobLoads(t *testing.T) {
 		"Memory usage should not grow excessively after processing jobs")
 }
 
+// TestCompletedJobIsGarbageCollectable verifies that after a job completes and
+// the cleanup tick runs, the Job struct (and its Action) become reachable only
+// via GC, not via any queue field. This is a regression guard against the
+// archivedJobs retention that caused the 300 MB to 760 MB RSS audiocore
+// memory regression.
+func TestCompletedJobIsGarbageCollectable(t *testing.T) {
+	queue := setupTestQueue(t, 100, false)
+	defer teardownTestQueue(t, queue)
+
+	finalized := make(chan struct{}, 1)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	config := RetryConfig{
+		Enabled:      false,
+		MaxRetries:   0,
+		InitialDelay: 10 * time.Millisecond,
+		MaxDelay:     100 * time.Millisecond,
+		Multiplier:   2.0,
+	}
+
+	// Enqueue one job, then drop the local action reference so the queue holds
+	// the only remaining reference. After cleanup the queue must also drop it.
+	func() {
+		action := &MockAction{
+			ExecuteFunc: func(data any) error {
+				defer wg.Done()
+				return nil
+			},
+		}
+		runtime.AddCleanup(action, func(ch chan struct{}) {
+			select {
+			case ch <- struct{}{}:
+			default:
+			}
+		}, finalized)
+		data := &TestData{ID: "gc-target"}
+		_, err := queue.Enqueue(t.Context(), action, data, config)
+		require.NoError(t, err, "Failed to enqueue job")
+	}()
+
+	// Wait for the action to execute.
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+	waitForChannel(t, done, DefaultTestTimeout, "Timed out waiting for job to complete")
+
+	// Poll until cleanupStaleJobs has removed the completed job. Using a
+	// deterministic signal instead of a fixed sleep avoids CI flakes where
+	// scheduling pressure pushes the cleanup tick past the sleep window.
+	cleanupDeadline := time.Now().Add(2 * time.Second)
+	for queue.GetStats().StaleJobs == 0 {
+		if time.Now().After(cleanupDeadline) {
+			t.Fatalf("cleanupStaleJobs did not fire within 2s after job completion")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	// Force GC. If the queue still retains the action (archive regression),
+	// the cleanup callback never runs.
+	for range 3 {
+		runtime.GC()
+	}
+
+	select {
+	case <-finalized:
+		// Action was reclaimed. Queue released its reference. Pass.
+	case <-time.After(2 * time.Second):
+		t.Fatalf("completed job action was not garbage-collected within 2s after cleanup; jobqueue is retaining it")
+	}
+}
+
 // TestStatsToJSON tests the ToJSON method of JobStatsSnapshot
 func TestStatsToJSON(t *testing.T) {
 	// Create a context for manual control
 	ctx := t.Context()
 
 	// Create a new job queue
-	queue := setupTestQueue(t, 100, 10, false)
+	queue := setupTestQueue(t, 100, false)
 	defer teardownTestQueue(t, queue)
 
 	// Create actions with different descriptions

--- a/internal/analysis/jobqueue/queue_test.go
+++ b/internal/analysis/jobqueue/queue_test.go
@@ -1820,6 +1820,19 @@ func TestCompletedJobIsGarbageCollectable(t *testing.T) {
 	}
 }
 
+// TestNewJobQueueWithOptions_ClampsNonPositiveMaxJobs verifies that passing
+// maxJobs <= 0 is clamped to 1 so the queue remains usable instead of silently
+// rejecting every Enqueue with ErrQueueFull.
+func TestNewJobQueueWithOptions_ClampsNonPositiveMaxJobs(t *testing.T) {
+	t.Parallel()
+
+	for _, maxJobs := range []int{0, -1, -100} {
+		q := NewJobQueueWithOptions(maxJobs, false)
+		assert.Equal(t, 1, q.GetMaxJobs(),
+			"maxJobs=%d should clamp to 1; got %d", maxJobs, q.GetMaxJobs())
+	}
+}
+
 // TestStatsToJSON tests the ToJSON method of JobStatsSnapshot
 func TestStatsToJSON(t *testing.T) {
 	// Create a context for manual control

--- a/internal/analysis/processor/workers_test.go
+++ b/internal/analysis/processor/workers_test.go
@@ -381,7 +381,7 @@ func TestEnqueueTask(t *testing.T) {
 	t.Run("FullQueue", func(t *testing.T) {
 		t.Parallel()
 		// Create a queue with a very small capacity
-		tinyQueue := jobqueue.NewJobQueueWithOptions(2, 1, false)
+		tinyQueue := jobqueue.NewJobQueueWithOptions(2, false)
 		tinyQueue.Start()
 		defer func() {
 			assert.NoError(t, tinyQueue.Stop(), "Failed to stop queue")


### PR DESCRIPTION
## Summary

Removes the `archivedJobs []*Job` slice from `internal/analysis/jobqueue`. Completed and failed jobs are now discarded from the active queue on the next cleanup tick, so the `Job` struct, its `Action`, and any buffers the action holds (including the ~2.88 MB PCM buffer on `SaveAudioAction`) become eligible for garbage collection promptly.

The archive was never read outside the jobqueue package itself; the only externally visible surface was `JobStatsSnapshot.ArchivedJobs` (int count), which no metric, API route, or UI consumed. That field and its JSON key (`"archived"`) are removed from the stats surface.

## Memory impact

On a steady-state single-source deployment, the 100-slot archive pinned roughly 45-100 PCM buffers at 2.88 MB each (~130 MB to ~288 MB). Heap profile attributes ~127 MB of `inuse_space` to `CaptureBuffer.extractSegment` held via the archive. This change removes that retention floor.

## Behavior changes

- `NewJobQueueWithOptions(maxJobs, logAllSuccesses)` (was `(maxJobs, maxArchivedJobs, logAllSuccesses)`). Callers using `NewJobQueue()` are unaffected.
- `JobStats` and `JobStatsSnapshot` no longer carry `ArchivedJobs`.
- `"archived"` key removed from `JobStatsSnapshot.ToJSON` output.
- `cleanupStaleJobs` discards completed and failed jobs instead of archiving them; `stats.StaleJobs` still increments so the stale-job counter stays accurate. The function compacts the active slice in place and nils the tail slots so discarded pointers do not linger in the backing array.

## Regression guard

New `TestCompletedJobIsGarbageCollectable` uses `runtime.AddCleanup` to confirm a `MockAction` is reclaimed within 2 s after its job completes and the cleanup tick fires. Polls `stats.StaleJobs` for determinism rather than sleeping. The test fails on `main` (archive retains the action) and passes on this branch.

## Test plan

- [x] `go test -race -count=1 ./internal/analysis/jobqueue/...` passes.
- [x] `go test -race -count=1 ./internal/analysis/processor/...` passes.
- [x] `go test -race -count=5 -run TestCompletedJobIsGarbageCollectable ./internal/analysis/jobqueue/` passes 5x (no flakes).
- [x] `golangci-lint run -v ./internal/analysis/jobqueue/... ./internal/analysis/processor/...` reports 0 issues.
- [x] Local CodeRabbit review addressed.

## Non-goals (separate follow-up PRs)

- Allocation churn in the audiocore router (wiring `internal/audiocore/buffer/pool.go` into the hot path).
- PreRenderer worker scaling and queue-depth metric.

Each will be its own PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Job queue now drops completed, failed, and cancelled jobs from the active queue instead of archiving them.
  * Removed archived-jobs configuration; max-job input is clamped to a minimum of 1.
  * Job statistics no longer include archived-job metrics.

* **Documentation**
  * Architecture and queue docs updated to reflect discard behavior and removed archive limits.

* **Tests**
  * Tests adjusted and new tests added for discard behavior, GC eligibility of completed jobs, and max-job clamping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->