### PR TITLE
fix(audio): copy frame data in hlsConsumer.Write before channel send

### DIFF
--- a/internal/api/v2/audio_hls.go
+++ b/internal/api/v2/audio_hls.go
@@ -1478,8 +1478,7 @@ func (h *hlsConsumer) Write(frame audiocore.AudioFrame) error { //nolint:gocriti
 	}
 
 	// Copy once up front. Both select arms below need an owned slice.
-	buf := make([]byte, len(frame.Data))
-	copy(buf, frame.Data)
+	buf := slices.Clone(frame.Data)
 
 	select {
 	case h.ch <- buf:

--- a/internal/api/v2/audio_hls.go
+++ b/internal/api/v2/audio_hls.go
@@ -1467,13 +1467,22 @@ func (h *hlsConsumer) BitDepth() int { return h.depth }
 func (h *hlsConsumer) Channels() int { return h.channels }
 
 // Write delivers audio frame data to the HLS channel.
+//
+// The frame data is copied before being sent so the caller (the audio router)
+// may safely reuse or recycle the underlying slice after Write returns. FFmpeg
+// reads asynchronously from the channel, so any retained slice header would
+// race with the caller's buffer reuse.
 func (h *hlsConsumer) Write(frame audiocore.AudioFrame) error { //nolint:gocritic // hugeParam: signature required by AudioConsumer interface
 	if h.closed.Load() {
 		return audiocore.ErrConsumerClosed
 	}
 
+	// Copy once up front. Both select arms below need an owned slice.
+	buf := make([]byte, len(frame.Data))
+	copy(buf, frame.Data)
+
 	select {
-	case h.ch <- frame.Data:
+	case h.ch <- buf:
 	default:
 		// Channel full, drop oldest to make room
 		dropped := false
@@ -1484,7 +1493,7 @@ func (h *hlsConsumer) Write(frame audiocore.AudioFrame) error { //nolint:gocriti
 		}
 		// Non-blocking send — drop if still full
 		select {
-		case h.ch <- frame.Data:
+		case h.ch <- buf:
 		default:
 		}
 

--- a/internal/api/v2/audio_hls_test.go
+++ b/internal/api/v2/audio_hls_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/tphakala/birdnet-go/internal/audiocore"
 )
 
 // TestHLSStreamInfoStruct tests the HLSStreamInfo struct
@@ -580,4 +582,48 @@ func TestResolveClientID(t *testing.T) {
 		assert.Contains(t, clientID, "Browser")
 		assert.NotContains(t, clientID, "not-a-valid-uuid")
 	})
+}
+
+// TestHLSConsumer_WriteDoesNotRetainFrameData verifies that hlsConsumer.Write
+// copies the frame data before forwarding it on the channel, so the caller's
+// buffer can be safely reused after Write returns. This is the correctness
+// invariant that lets the audiocore router pool its output slices without
+// racing against FFmpeg reads.
+func TestHLSConsumer_WriteDoesNotRetainFrameData(t *testing.T) {
+	t.Parallel()
+
+	ch := make(chan []byte, 1)
+	h := &hlsConsumer{
+		id:       "test",
+		sourceID: "src",
+		ch:       ch,
+		rate:     48000,
+		depth:    16,
+		channels: 1,
+	}
+
+	original := []byte{0x01, 0x02, 0x03, 0x04}
+	frame := audiocore.AudioFrame{
+		SourceID:   "src",
+		Data:       original,
+		SampleRate: 48000,
+		BitDepth:   16,
+		Channels:   1,
+	}
+
+	require.NoError(t, h.Write(frame))
+
+	// Mutate the caller's slice after Write returns. If hlsConsumer retained
+	// the slice header, the mutation would be visible on the channel.
+	for i := range original {
+		original[i] = 0xFF
+	}
+
+	select {
+	case received := <-ch:
+		assert.Equal(t, []byte{0x01, 0x02, 0x03, 0x04}, received,
+			"hlsConsumer must copy frame.Data, not retain the caller's slice")
+	case <-time.After(time.Second):
+		t.Fatal("no frame delivered to channel")
+	}
 }


### PR DESCRIPTION
## Summary

`hlsConsumer.Write` previously handed the caller's `frame.Data` slice header directly to a buffered channel read asynchronously by FFmpeg. Any upstream buffer reuse (for example, when the audiocore router eventually pools its output slices) would race with the FFmpeg reader and corrupt the live audio stream.

This PR copies `frame.Data` once at the top of `Write` so the consumer owns its payload for the lifetime of the channel enqueue. No behaviour change for the live HLS path (still drops oldest frame on channel saturation); cost is one owned copy per frame, orders of magnitude cheaper than the upstream allocations this unblocks pooling for.

Preparation for wiring the existing `buffer.BytePool` / new `Float64Pool` into the audiocore router hot path, which accounts for ~438 GB of 2-day allocation churn in production profiling.

## Test Plan

- [x] New `TestHLSConsumer_WriteDoesNotRetainFrameData` asserts post-Write mutation of the caller's slice is not visible on the channel (fails on main, passes with the fix).
- [x] `go test -race ./internal/api/v2/...` passes.
- [x] `go test -race ./internal/audiocore/... ./internal/analysis/...` passes.
- [x] `golangci-lint run -v` clean.
- [x] Local `coderabbit review --plain -t committed` reports no findings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented a potential race in HLS audio streaming by ensuring audio frame data is copied before asynchronous transmission, so buffers can be safely reused after sending.

* **Tests**
  * Added a unit test confirming transmitted audio frames are isolated from subsequent mutations of the original buffer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->