### PR TITLE
refactor(audiocore): pool router hot-path allocations via buffer.Manager

### DIFF
--- a/internal/analysis/process.go
+++ b/internal/analysis/process.go
@@ -195,7 +195,7 @@ func ProcessData(ctx context.Context, bn *classifier.Orchestrator, bufMgr *buffe
 	// Orchestrator are required to honour this contract; see
 	// internal/classifier for the implementing side.
 	if conf.BitDepth == 16 && len(sampleData) > 0 {
-		if pool := bufMgr.Float32Pool(len(sampleData[0])); pool != nil {
+		if pool := bufMgr.Float32PoolFor(len(sampleData[0])); pool != nil {
 			pool.Put(sampleData[0])
 		}
 	}
@@ -341,7 +341,7 @@ func convertToFloat32WithPool(bufMgr *buffer.Manager, sample []byte, bitDepth in
 // Float32Pool on first use, so any length the pipeline produces is pooled.
 func convert16BitToFloat32WithPool(bufMgr *buffer.Manager, sample []byte) []float32 {
 	length := len(sample) / 2
-	pool := bufMgr.Float32Pool(length)
+	pool := bufMgr.Float32PoolFor(length)
 
 	var float32Data []float32
 	if pool != nil {

--- a/internal/analysis/process_alloc_test.go
+++ b/internal/analysis/process_alloc_test.go
@@ -74,7 +74,7 @@ func TestConvert16BitToFloat32WithPool_ZeroAllocs(t *testing.T) {
 			assert.InDelta(t, expectedFirst, warm[0], 1e-6,
 				"first converted sample should match scalar decode of pcm[0..2]")
 
-			if p := mgr.Float32Pool(len(warm)); p != nil {
+			if p := mgr.Float32PoolFor(len(warm)); p != nil {
 				p.Put(warm)
 			}
 
@@ -83,7 +83,7 @@ func TestConvert16BitToFloat32WithPool_ZeroAllocs(t *testing.T) {
 			allocs := testing.AllocsPerRun(100, func() {
 				out := convert16BitToFloat32WithPool(mgr, pcm)
 				sink = out
-				if p := mgr.Float32Pool(len(out)); p != nil {
+				if p := mgr.Float32PoolFor(len(out)); p != nil {
 					p.Put(out)
 				}
 			})

--- a/internal/audiocore/audiocore.go
+++ b/internal/audiocore/audiocore.go
@@ -60,6 +60,14 @@ type AudioConsumer interface {
 
 	// Write delivers an audio frame to this consumer.
 	// Implementations must not modify frame.Data.
+	//
+	// Buffer ownership contract:
+	// Implementations MUST NOT retain frame.Data after Write returns. The
+	// caller may recycle the underlying slice into a buffer pool immediately
+	// after Write completes, so any asynchronous use (channel send, goroutine
+	// hand-off, queue enqueue) MUST copy the data first. See hlsConsumer.Write
+	// in internal/api/v2/audio_hls.go for an example of correct
+	// copy-before-enqueue behaviour.
 	Write(frame AudioFrame) error
 
 	// Close releases resources held by this consumer.

--- a/internal/audiocore/buffer/manager.go
+++ b/internal/audiocore/buffer/manager.go
@@ -32,6 +32,10 @@ type Manager struct {
 	bytePool        *BytePool
 	float32Pools    map[int]*Float32Pool
 	float32PoolMu   sync.Mutex // protects float32Pools; separate from mu to avoid contention
+	bytePools       map[int]*BytePool
+	bytePoolMu      sync.Mutex // protects bytePools; separate from mu to avoid contention
+	float64Pools    map[int]*Float64Pool
+	float64PoolMu   sync.Mutex // protects float64Pools; separate from mu to avoid contention
 	mu              sync.RWMutex
 	logger          logger.Logger
 }
@@ -50,6 +54,8 @@ func NewManager(log logger.Logger) *Manager {
 		captureBuffers:  make(map[string]*CaptureBuffer),
 		bytePool:        bytePool,
 		float32Pools:    make(map[int]*Float32Pool),
+		bytePools:       make(map[int]*BytePool),
+		float64Pools:    make(map[int]*Float64Pool),
 		logger:          log,
 	}
 }
@@ -188,5 +194,49 @@ func (m *Manager) Float32Pool(size int) *Float32Pool {
 		return nil
 	}
 	m.float32Pools[size] = pool
+	return pool
+}
+
+// BytePoolFor returns a BytePool for the given buffer size, creating one
+// lazily if needed. Returns nil for non-positive sizes. Thread-safe via a
+// dedicated mutex.
+func (m *Manager) BytePoolFor(size int) *BytePool {
+	if size <= 0 {
+		return nil
+	}
+	m.bytePoolMu.Lock()
+	defer m.bytePoolMu.Unlock()
+	if pool, ok := m.bytePools[size]; ok {
+		return pool
+	}
+	pool, err := NewBytePool(size)
+	if err != nil {
+		m.logger.Error("failed to create BytePool",
+			logger.Int("size", size), logger.Error(err))
+		return nil
+	}
+	m.bytePools[size] = pool
+	return pool
+}
+
+// Float64PoolFor returns a Float64Pool for the given slice length, creating
+// one lazily if needed. Returns nil for non-positive sizes. Thread-safe via a
+// dedicated mutex.
+func (m *Manager) Float64PoolFor(size int) *Float64Pool {
+	if size <= 0 {
+		return nil
+	}
+	m.float64PoolMu.Lock()
+	defer m.float64PoolMu.Unlock()
+	if pool, ok := m.float64Pools[size]; ok {
+		return pool
+	}
+	pool, err := NewFloat64Pool(size)
+	if err != nil {
+		m.logger.Error("failed to create Float64Pool",
+			logger.Int("size", size), logger.Error(err))
+		return nil
+	}
+	m.float64Pools[size] = pool
 	return pool
 }

--- a/internal/audiocore/buffer/manager.go
+++ b/internal/audiocore/buffer/manager.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/tphakala/birdnet-go/internal/audiocore"
 	"github.com/tphakala/birdnet-go/internal/logger"
 )
 
@@ -128,7 +127,7 @@ func (m *Manager) DeallocateSource(sourceID string) {
 }
 
 // AnalysisBuffer returns the AnalysisBuffer allocated for the given
-// (sourceID, modelID) pair. Returns audiocore.ErrBufferNotFound if no buffer
+// (sourceID, modelID) pair. Returns ErrBufferNotFound if no buffer
 // has been allocated for that composite key.
 func (m *Manager) AnalysisBuffer(sourceID, modelID string) (*AnalysisBuffer, error) {
 	m.mu.RLock()
@@ -136,7 +135,7 @@ func (m *Manager) AnalysisBuffer(sourceID, modelID string) (*AnalysisBuffer, err
 	m.mu.RUnlock()
 
 	if !ok {
-		return nil, audiocore.ErrBufferNotFound
+		return nil, ErrBufferNotFound
 	}
 	return ab, nil
 }
@@ -158,7 +157,7 @@ func (m *Manager) AnalysisBuffers(sourceID string) map[string]*AnalysisBuffer {
 }
 
 // CaptureBuffer returns the CaptureBuffer allocated for the given sourceID.
-// Returns audiocore.ErrBufferNotFound if no buffer has been allocated for
+// Returns ErrBufferNotFound if no buffer has been allocated for
 // sourceID.
 func (m *Manager) CaptureBuffer(sourceID string) (*CaptureBuffer, error) {
 	m.mu.RLock()
@@ -166,7 +165,7 @@ func (m *Manager) CaptureBuffer(sourceID string) (*CaptureBuffer, error) {
 	m.mu.RUnlock()
 
 	if !ok {
-		return nil, audiocore.ErrBufferNotFound
+		return nil, ErrBufferNotFound
 	}
 	return cb, nil
 }

--- a/internal/audiocore/buffer/manager.go
+++ b/internal/audiocore/buffer/manager.go
@@ -41,9 +41,10 @@ type Manager struct {
 }
 
 // NewManager creates a Manager with a shared BytePool pre-allocated at the
-// default size and an empty Float32Pool map that lazily creates pools on first
-// request for each size. The provided logger is forwarded to each
-// AnalysisBuffer created by AllocateAnalysis.
+// default size and empty per-size maps for BytePool, Float32Pool, and
+// Float64Pool that lazily create pools on first request for each size. The
+// provided logger is forwarded to each AnalysisBuffer created by
+// AllocateAnalysis.
 func NewManager(log logger.Logger) *Manager {
 	// Errors from the pool constructors are only possible when size <= 0, which
 	// cannot happen with compile-time positive constants.
@@ -175,10 +176,10 @@ func (m *Manager) BytePool() *BytePool {
 	return m.bytePool
 }
 
-// Float32Pool returns a pool for the given buffer size, creating one lazily if
-// needed. Thread-safe via a dedicated mutex separate from the Manager's main
-// RWMutex.
-func (m *Manager) Float32Pool(size int) *Float32Pool {
+// Float32PoolFor returns a Float32Pool for the given slice length, creating
+// one lazily if needed. Returns nil for non-positive sizes. Thread-safe via a
+// dedicated mutex.
+func (m *Manager) Float32PoolFor(size int) *Float32Pool {
 	if size <= 0 {
 		return nil
 	}

--- a/internal/audiocore/buffer/manager_test.go
+++ b/internal/audiocore/buffer/manager_test.go
@@ -120,7 +120,7 @@ func TestBufferManager_PoolAccessors(t *testing.T) {
 	m := buffer.NewManager(newTestLogger())
 
 	assert.NotNil(t, m.BytePool())
-	assert.NotNil(t, m.Float32Pool(2048))
+	assert.NotNil(t, m.Float32PoolFor(2048))
 }
 
 // ---------------------------------------------------------------------------
@@ -257,23 +257,23 @@ func TestManager_HasAnalysis(t *testing.T) {
 // Per-size Float32Pool tests
 // ---------------------------------------------------------------------------
 
-// TestManager_Float32Pool_LazySizes verifies that Float32Pool returns distinct
-// pools for different sizes and the same pool for the same size.
-func TestManager_Float32Pool_LazySizes(t *testing.T) {
+// TestManager_Float32PoolFor_LazySizes verifies that Float32PoolFor returns
+// distinct pools for different sizes and the same pool for the same size.
+func TestManager_Float32PoolFor_LazySizes(t *testing.T) {
 	t.Parallel()
 	m := buffer.NewManager(newTestLogger())
 
 	// Request two different sizes.
-	pool1 := m.Float32Pool(144384)
+	pool1 := m.Float32PoolFor(144384)
 	require.NotNil(t, pool1)
 
-	pool2 := m.Float32Pool(160000)
+	pool2 := m.Float32PoolFor(160000)
 	require.NotNil(t, pool2)
 
 	assert.NotSame(t, pool1, pool2, "different sizes must have distinct pools")
 
 	// Same size returns same pool.
-	pool1Again := m.Float32Pool(144384)
+	pool1Again := m.Float32PoolFor(144384)
 	assert.Same(t, pool1, pool1Again, "same size must return same pool")
 }
 

--- a/internal/audiocore/buffer/manager_test.go
+++ b/internal/audiocore/buffer/manager_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/tphakala/birdnet-go/internal/audiocore"
 	"github.com/tphakala/birdnet-go/internal/audiocore/buffer"
 )
 
@@ -70,11 +69,11 @@ func TestBufferManager_DeallocateSource(t *testing.T) {
 	m.DeallocateSource("source-3")
 
 	ab, err := m.AnalysisBuffer("source-3", managerTestModelID)
-	require.ErrorIs(t, err, audiocore.ErrBufferNotFound)
+	require.ErrorIs(t, err, buffer.ErrBufferNotFound)
 	assert.Nil(t, ab)
 
 	cb, err := m.CaptureBuffer("source-3")
-	require.ErrorIs(t, err, audiocore.ErrBufferNotFound)
+	require.ErrorIs(t, err, buffer.ErrBufferNotFound)
 	assert.Nil(t, cb)
 }
 
@@ -190,13 +189,13 @@ func TestManager_DeallocateSource_RemovesAllModels(t *testing.T) {
 	m.DeallocateSource(source)
 
 	_, err := m.AnalysisBuffer(source, "birdnet-v2.4")
-	require.ErrorIs(t, err, audiocore.ErrBufferNotFound)
+	require.ErrorIs(t, err, buffer.ErrBufferNotFound)
 
 	_, err = m.AnalysisBuffer(source, "perch-v2")
-	require.ErrorIs(t, err, audiocore.ErrBufferNotFound)
+	require.ErrorIs(t, err, buffer.ErrBufferNotFound)
 
 	_, err = m.CaptureBuffer(source)
-	require.ErrorIs(t, err, audiocore.ErrBufferNotFound)
+	require.ErrorIs(t, err, buffer.ErrBufferNotFound)
 
 	// AnalysisBuffers should return an empty map.
 	assert.Empty(t, m.AnalysisBuffers(source))

--- a/internal/audiocore/buffer/manager_test.go
+++ b/internal/audiocore/buffer/manager_test.go
@@ -276,3 +276,63 @@ func TestManager_Float32Pool_LazySizes(t *testing.T) {
 	pool1Again := m.Float32Pool(144384)
 	assert.Same(t, pool1, pool1Again, "same size must return same pool")
 }
+
+// ---------------------------------------------------------------------------
+// Per-size BytePool tests
+// ---------------------------------------------------------------------------
+
+// TestManager_BytePoolFor_LazyPerSize verifies that BytePoolFor returns
+// distinct pools for different sizes and the same pool for the same size.
+func TestManager_BytePoolFor_LazyPerSize(t *testing.T) {
+	t.Parallel()
+	m := buffer.NewManager(newTestLogger())
+
+	pool1 := m.BytePoolFor(144384)
+	require.NotNil(t, pool1)
+
+	pool2 := m.BytePoolFor(288000)
+	require.NotNil(t, pool2)
+	assert.NotSame(t, pool1, pool2, "different sizes must yield different pools")
+
+	pool1Again := m.BytePoolFor(144384)
+	assert.Same(t, pool1, pool1Again, "same size must yield same pool")
+}
+
+// TestManager_BytePoolFor_NonPositiveReturnsNil verifies that BytePoolFor
+// returns nil for zero and negative sizes.
+func TestManager_BytePoolFor_NonPositiveReturnsNil(t *testing.T) {
+	t.Parallel()
+	m := buffer.NewManager(newTestLogger())
+	assert.Nil(t, m.BytePoolFor(0))
+	assert.Nil(t, m.BytePoolFor(-1))
+}
+
+// ---------------------------------------------------------------------------
+// Per-size Float64Pool tests
+// ---------------------------------------------------------------------------
+
+// TestManager_Float64PoolFor_LazyPerSize verifies that Float64PoolFor returns
+// distinct pools for different sizes and the same pool for the same size.
+func TestManager_Float64PoolFor_LazyPerSize(t *testing.T) {
+	t.Parallel()
+	m := buffer.NewManager(newTestLogger())
+
+	pool1 := m.Float64PoolFor(72192)
+	require.NotNil(t, pool1)
+
+	pool2 := m.Float64PoolFor(80000)
+	require.NotNil(t, pool2)
+	assert.NotSame(t, pool1, pool2, "different sizes must yield different pools")
+
+	pool1Again := m.Float64PoolFor(72192)
+	assert.Same(t, pool1, pool1Again, "same size must yield same pool")
+}
+
+// TestManager_Float64PoolFor_NonPositiveReturnsNil verifies that Float64PoolFor
+// returns nil for zero and negative sizes.
+func TestManager_Float64PoolFor_NonPositiveReturnsNil(t *testing.T) {
+	t.Parallel()
+	m := buffer.NewManager(newTestLogger())
+	assert.Nil(t, m.Float64PoolFor(0))
+	assert.Nil(t, m.Float64PoolFor(-1))
+}

--- a/internal/audiocore/buffer/pool.go
+++ b/internal/audiocore/buffer/pool.go
@@ -231,3 +231,110 @@ func (fp *Float32Pool) GetStats() Float32PoolStats {
 func (fp *Float32Pool) Clear() {
 	fp.pool.Store(fp.newPool())
 }
+
+// Float64Pool provides a thread-safe pool of float64 slices to reduce
+// allocations during audio processing operations. Slices with incorrect lengths
+// are discarded to maintain pool integrity.
+//
+// The pool field is an atomic.Value holding a *sync.Pool, allowing lock-free
+// Get/Put operations. Clear atomically swaps to a new *sync.Pool instance.
+type Float64Pool struct {
+	pool      atomic.Value // stores *sync.Pool
+	size      int
+	gets      atomic.Uint64
+	news      atomic.Uint64
+	discarded atomic.Uint64
+}
+
+// Float64PoolStats holds usage statistics for a Float64Pool.
+type Float64PoolStats struct {
+	Hits      uint64 // Successful reuses (Gets - News)
+	Misses    uint64 // New allocations (News)
+	Discarded uint64 // Slices discarded due to size mismatch
+}
+
+// NewFloat64Pool creates a Float64Pool where every slice has the given length.
+// Returns an error if size is not positive.
+func NewFloat64Pool(size int) (*Float64Pool, error) {
+	if size <= 0 {
+		return nil, errors.Newf("invalid float64 pool size: %d, must be greater than 0", size).
+			Component("audiocore").
+			Category(errors.CategoryValidation).
+			Context("operation", "create_float64_pool").
+			Context("requested_size", size).
+			Build()
+	}
+
+	fp := &Float64Pool{
+		size: size,
+	}
+	fp.pool.Store(fp.newPool())
+
+	return fp, nil
+}
+
+// newPool creates a fresh *sync.Pool with the correct New function.
+func (fp *Float64Pool) newPool() *sync.Pool {
+	return &sync.Pool{
+		New: func() any {
+			fp.news.Add(1)
+			return make([]float64, fp.size)
+		},
+	}
+}
+
+// Get retrieves a float64 slice from the pool. If the pool is empty, a new
+// slice is allocated. The returned slice always has the length specified in
+// NewFloat64Pool. Get is safe for concurrent use, including during Clear.
+func (fp *Float64Pool) Get() []float64 {
+	fp.gets.Add(1)
+
+	p := fp.pool.Load().(*sync.Pool) //nolint:forcetypeassert // pool always stores *sync.Pool
+	buf := p.Get().([]float64)       //nolint:forcetypeassert // pool.New always returns []float64
+	if len(buf) == fp.size {
+		return buf
+	}
+
+	// Size mismatch - discard and allocate a fresh slice.
+	fp.discarded.Add(1)
+	fp.news.Add(1)
+
+	return make([]float64, fp.size)
+}
+
+// Put returns a float64 slice to the pool for future reuse.
+// Nil slices and slices with incorrect lengths are silently discarded.
+// Put is safe for concurrent use, including during Clear.
+func (fp *Float64Pool) Put(buf []float64) {
+	if buf == nil || len(buf) != fp.size {
+		fp.discarded.Add(1)
+		return
+	}
+
+	p := fp.pool.Load().(*sync.Pool) //nolint:forcetypeassert // pool always stores *sync.Pool
+	//nolint:staticcheck // SA6002: accepted trade-off - allocation savings outweigh interface boxing overhead
+	p.Put(buf)
+}
+
+// GetStats returns a snapshot of the pool's usage statistics.
+func (fp *Float64Pool) GetStats() Float64PoolStats {
+	gets := fp.gets.Load()
+	news := fp.news.Load()
+
+	hits := uint64(0)
+	if gets > news {
+		hits = gets - news
+	}
+
+	return Float64PoolStats{
+		Hits:      hits,
+		Misses:    news,
+		Discarded: fp.discarded.Load(),
+	}
+}
+
+// Clear replaces the internal sync.Pool with a fresh one, allowing all pooled
+// slices to be garbage-collected. Clear is safe for concurrent use.
+func (fp *Float64Pool) Clear() {
+	fp.pool.Store(fp.newPool())
+}

--- a/internal/audiocore/buffer/pool.go
+++ b/internal/audiocore/buffer/pool.go
@@ -14,6 +14,11 @@ import (
 	"github.com/tphakala/birdnet-go/internal/errors"
 )
 
+// ErrBufferNotFound is returned by Manager when a requested buffer has not
+// been allocated for the given source or model key.
+var ErrBufferNotFound = errors.Newf("buffer not found").
+	Component("audiocore").Category(errors.CategoryBuffer).Build()
+
 // BytePool provides a thread-safe pool of byte slices to reduce allocations.
 // It uses sync.Pool internally and validates buffer sizes on return to ensure
 // correctness. Buffers that do not match the expected size are discarded.

--- a/internal/audiocore/buffer/pool_test.go
+++ b/internal/audiocore/buffer/pool_test.go
@@ -274,3 +274,61 @@ func TestFloat32Pool_ClearConcurrent(t *testing.T) {
 		assert.Equal(t, size, bufLen, "all slices must have correct size")
 	}
 }
+
+func TestNewFloat64Pool_InvalidSize(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		size int
+	}{
+		{"zero", 0},
+		{"negative", -1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			pool, err := buffer.NewFloat64Pool(tt.size)
+			require.Error(t, err)
+			assert.Nil(t, pool)
+		})
+	}
+}
+
+func TestFloat64Pool_GetReturnsCorrectSize(t *testing.T) {
+	t.Parallel()
+	const size = 72192
+	pool, err := buffer.NewFloat64Pool(size)
+	require.NoError(t, err)
+
+	buf := pool.Get()
+	assert.Len(t, buf, size)
+
+	pool.Put(buf)
+
+	stats := pool.GetStats()
+	assert.Equal(t, uint64(1), stats.Misses, "first Get allocates")
+}
+
+func TestFloat64Pool_ReuseAfterPut(t *testing.T) {
+	t.Parallel()
+	pool, err := buffer.NewFloat64Pool(1024)
+	require.NoError(t, err)
+
+	buf := pool.Get()
+	pool.Put(buf)
+
+	buf2 := pool.Get()
+	assert.Len(t, buf2, 1024)
+}
+
+func TestFloat64Pool_PutDiscardsWrongSize(t *testing.T) {
+	t.Parallel()
+	pool, err := buffer.NewFloat64Pool(1024)
+	require.NoError(t, err)
+
+	pool.Put(make([]float64, 512))
+	pool.Put(nil)
+
+	stats := pool.GetStats()
+	assert.Equal(t, uint64(2), stats.Discarded)
+}

--- a/internal/audiocore/engine/engine.go
+++ b/internal/audiocore/engine/engine.go
@@ -165,8 +165,8 @@ func New(ctx context.Context, cfg *Config, scheduler *schedule.QuietHoursSchedul
 
 	engineCtx, cancel := context.WithCancelCause(ctx)
 
-	router := audiocore.NewAudioRouter(log)
 	bufMgr := buffer.NewManager(log)
+	router := audiocore.NewAudioRouter(log, bufMgr)
 	ffmpegMgr := ffmpeg.NewManager(engineCtx, func(frame audiocore.AudioFrame) {
 		router.Dispatch(frame)
 	}, nil, log)

--- a/internal/audiocore/errors.go
+++ b/internal/audiocore/errors.go
@@ -1,14 +1,17 @@
 package audiocore
 
-import "github.com/tphakala/birdnet-go/internal/errors"
+import (
+	"github.com/tphakala/birdnet-go/internal/audiocore/buffer"
+	"github.com/tphakala/birdnet-go/internal/errors"
+)
 
 // ErrSourceNotFound is returned when a source ID is not found in the registry.
 var ErrSourceNotFound = errors.Newf("source not found").
 	Component("audiocore").Category(errors.CategoryNotFound).Build()
 
-// ErrBufferNotFound is returned when a buffer is not found for a source.
-var ErrBufferNotFound = errors.Newf("buffer not found").
-	Component("audiocore").Category(errors.CategoryBuffer).Build()
+// ErrBufferNotFound is an alias for buffer.ErrBufferNotFound so that errors.Is
+// checks behave identically whether callers import the parent or the subpackage.
+var ErrBufferNotFound = buffer.ErrBufferNotFound
 
 // ErrRouteExists is returned when attempting to add a duplicate route.
 var ErrRouteExists = errors.Newf("route already exists").

--- a/internal/audiocore/router.go
+++ b/internal/audiocore/router.go
@@ -451,59 +451,103 @@ func (r *AudioRouter) drainRoute(route *Route) {
 	for {
 		select {
 		case frame := <-route.inbox:
-			// Apply per-route resampling when rates differ.
-			if route.resampler != nil {
-				resampled, err := route.resampler.ResampleInto(frame.Data)
-				if err != nil {
-					errCount := route.errors.Add(1)
-					if errCount%errorLogInterval == 1 {
-						r.log.Warn("resampler error",
-							logger.String("source_id", route.SourceID),
-							logger.String("consumer_id", route.Consumer.ID()),
-							logger.Int64("total_errors", errCount),
-							logger.Error(err))
-					}
-					continue
-				}
-				// Copy resampled bytes: the Resampler reuses its internal buffer,
-				// so we must not hand the slice to the consumer directly.
-				out := make([]byte, len(resampled))
-				copy(out, resampled)
-				frame = AudioFrame{
-					SourceID:   frame.SourceID,
-					SourceName: frame.SourceName,
-					Data:       out,
-					SampleRate: route.Consumer.SampleRate(),
-					BitDepth:   frame.BitDepth,
-					Channels:   frame.Channels,
-					Timestamp:  frame.Timestamp,
-				}
-			}
-			// Apply per-route EQ filtering and/or gain adjustment.
-			// Both require 16-bit PCM; skip for other formats.
-			chain := route.filterChain.Load()
-			if frame.BitDepth == 16 && (chain != nil || route.gainLinear != 1.0) {
-				processed, err := r.applyProcessing(frame, route, chain)
-				if err != nil {
-					continue
-				}
-				frame = processed
-			}
-			if err := route.Consumer.Write(frame); err != nil {
-				errCount := route.errors.Add(1)
-				if errCount%errorLogInterval == 1 {
-					r.log.Warn("consumer write error",
-						logger.String("source_id", route.SourceID),
-						logger.String("consumer_id", route.Consumer.ID()),
-						logger.Int64("total_errors", errCount),
-						logger.Error(err))
-				}
-			}
+			r.handleRouteFrame(frame, route)
 		case <-route.done:
 			return
 		case <-r.ctx.Done():
 			return
 		}
+	}
+}
+
+// handleRouteFrame applies optional resampling and processing to frame, then
+// writes it to the route's consumer. It is called from drainRoute's select loop
+// and is extracted to keep drainRoute under the cognitive-complexity limit.
+//
+// Pool discipline for the resample buffer:
+//   - Allocated from the pool before the consumer write, returned after.
+//   - If processing replaces frame.Data, the resample buffer is returned before
+//     reassignment so the wrong (processed) slice is never put back.
+//   - If resampling or processing fails, the buffer is returned before continue.
+func (r *AudioRouter) handleRouteFrame(frame AudioFrame, route *Route) { //nolint:gocritic // hugeParam: AudioFrame is large but copying is intentional
+	var resamplePool *buffer.BytePool // nil when not pooled
+
+	// Apply per-route resampling when rates differ.
+	if route.resampler != nil {
+		resampled, err := route.resampler.ResampleInto(frame.Data)
+		if err != nil {
+			errCount := route.errors.Add(1)
+			if errCount%errorLogInterval == 1 {
+				r.log.Warn("resampler error",
+					logger.String("source_id", route.SourceID),
+					logger.String("consumer_id", route.Consumer.ID()),
+					logger.Int64("total_errors", errCount),
+					logger.Error(err))
+			}
+			return
+		}
+		// Copy resampled bytes into an owned buffer (Resampler reuses its
+		// internal slice). When a buffer.Manager is wired, the copy lands
+		// in a pooled slice keyed by length; otherwise fall back to make().
+		if r.bufMgr != nil {
+			resamplePool = r.bufMgr.BytePoolFor(len(resampled))
+		}
+		var out []byte
+		if resamplePool != nil {
+			out = resamplePool.Get()
+		} else {
+			out = make([]byte, len(resampled))
+		}
+		copy(out, resampled)
+		frame = AudioFrame{
+			SourceID:   frame.SourceID,
+			SourceName: frame.SourceName,
+			Data:       out,
+			SampleRate: route.Consumer.SampleRate(),
+			BitDepth:   frame.BitDepth,
+			Channels:   frame.Channels,
+			Timestamp:  frame.Timestamp,
+		}
+	}
+	// Apply per-route EQ filtering and/or gain adjustment.
+	// Both require 16-bit PCM; skip for other formats.
+	chain := route.filterChain.Load()
+	if frame.BitDepth == 16 && (chain != nil || route.gainLinear != 1.0) {
+		processed, err := r.applyProcessing(frame, route, chain)
+		if err != nil {
+			// Release the resample buffer on error before skipping the frame.
+			// applyProcessing owns its own output buffer, so frame.Data still
+			// points to the resample slice here.
+			if resamplePool != nil {
+				resamplePool.Put(frame.Data)
+			}
+			return
+		}
+		// Release the resample buffer BEFORE frame.Data is reassigned to the
+		// processing output, otherwise the trailing guard below would Put a
+		// processed (possibly wrong-sized) slice into the resample pool. Nil
+		// out the pointer so the trailing guard is a no-op.
+		if resamplePool != nil {
+			resamplePool.Put(frame.Data)
+			resamplePool = nil
+		}
+		frame = processed
+	}
+	if err := route.Consumer.Write(frame); err != nil {
+		errCount := route.errors.Add(1)
+		if errCount%errorLogInterval == 1 {
+			r.log.Warn("consumer write error",
+				logger.String("source_id", route.SourceID),
+				logger.String("consumer_id", route.Consumer.ID()),
+				logger.Int64("total_errors", errCount),
+				logger.Error(err))
+		}
+	}
+	// Release the resample buffer after Consumer.Write returns. All in-tree
+	// consumers copy synchronously, so the slice is safe to recycle. When
+	// processing succeeded, resamplePool was nilled above and this is a no-op.
+	if resamplePool != nil {
+		resamplePool.Put(frame.Data)
 	}
 }
 

--- a/internal/audiocore/router.go
+++ b/internal/audiocore/router.go
@@ -544,6 +544,8 @@ func (r *AudioRouter) handleRouteFrame(frame AudioFrame, route *Route) { //nolin
 		frame = result.Frame
 		procResult = result
 	}
+	// See AudioConsumer.Write for the buffer ownership contract the
+	// consumer must honour so the pool recycling below is safe.
 	if err := route.Consumer.Write(frame); err != nil {
 		errCount := route.errors.Add(1)
 		if errCount%errorLogInterval == 1 {
@@ -615,6 +617,24 @@ func (r *AudioRouter) applyProcessing(frame AudioFrame, route *Route, chain *equ
 	} else {
 		floatBuf = make([]float64, sampleCount)
 	}
+
+	// releasePools guards both pool buffers. It returns them on any early
+	// exit; the success path disarms both flags before returning so the
+	// caller owns the buffers (releasing them after Consumer.Write via
+	// processingResult.release()).
+	releaseFloat := true
+	releaseOut := true
+	var outPool *buffer.BytePool
+	var out []byte
+	defer func() {
+		if releaseFloat && floatPool != nil {
+			floatPool.Put(floatBuf)
+		}
+		if releaseOut && outPool != nil {
+			outPool.Put(out)
+		}
+	}()
+
 	convert.BytesToFloat64PCM16Into(floatBuf, frame.Data[:evenLen])
 
 	// EQ first - filters operate on the original signal shape.
@@ -628,11 +648,9 @@ func (r *AudioRouter) applyProcessing(frame AudioFrame, route *Route, chain *equ
 	}
 
 	outLen := sampleCount * 2
-	var outPool *buffer.BytePool
 	if r.bufMgr != nil {
 		outPool = r.bufMgr.BytePoolFor(outLen)
 	}
-	var out []byte
 	if outPool != nil {
 		out = outPool.Get()
 	} else {
@@ -648,16 +666,13 @@ func (r *AudioRouter) applyProcessing(frame AudioFrame, route *Route, chain *equ
 				logger.Int64("total_errors", errCount),
 				logger.Error(convErr))
 		}
-		// Release the buffers we obtained; caller will see a zero-value result.
-		if floatPool != nil {
-			floatPool.Put(floatBuf)
-		}
-		if outPool != nil {
-			outPool.Put(out)
-		}
+		// defer releases both buffers; caller sees zero-value result.
 		return processingResult{}, convErr
 	}
 
+	// Success: disarm the defer so the caller owns the buffers.
+	releaseFloat = false
+	releaseOut = false
 	return processingResult{
 		Frame: AudioFrame{
 			SourceID:   frame.SourceID,

--- a/internal/audiocore/router.go
+++ b/internal/audiocore/router.go
@@ -605,6 +605,20 @@ func (p *processingResult) release() {
 // that construct routers with a nil Manager.
 func (r *AudioRouter) applyProcessing(frame AudioFrame, route *Route, chain *equalizer.FilterChain) (processingResult, error) { //nolint:gocritic // hugeParam: AudioFrame is large but copying is intentional
 	evenLen := len(frame.Data) &^ 1
+	if evenLen != len(frame.Data) {
+		// Odd-length PCM16 input: convert/pcm.go silently truncates the trailing
+		// byte, which can hide upstream producer bugs. Throttled via the shared
+		// route.errors counter (one log per errorLogInterval events) so we stay
+		// visible without spamming the log on a persistent misbehaving source.
+		errCount := route.errors.Add(1)
+		if errCount%errorLogInterval == 1 {
+			r.log.Info("odd-length PCM16 frame truncated",
+				logger.String("source_id", route.SourceID),
+				logger.String("consumer_id", route.Consumer.ID()),
+				logger.Int("frame_bytes", len(frame.Data)),
+				logger.Int64("total_errors", errCount))
+		}
+	}
 	sampleCount := evenLen / 2
 
 	var floatPool *buffer.Float64Pool

--- a/internal/audiocore/router.go
+++ b/internal/audiocore/router.go
@@ -464,13 +464,24 @@ func (r *AudioRouter) drainRoute(route *Route) {
 // writes it to the route's consumer. It is called from drainRoute's select loop
 // and is extracted to keep drainRoute under the cognitive-complexity limit.
 //
-// Pool discipline for the resample buffer:
-//   - Allocated from the pool before the consumer write, returned after.
-//   - If processing replaces frame.Data, the resample buffer is returned before
-//     reassignment so the wrong (processed) slice is never put back.
-//   - If resampling or processing fails, the buffer is returned before continue.
+// Pool discipline:
+//   - Resample buffer: allocated before resampling, returned after Write (or on error).
+//     When processing follows, the resample buffer is returned before frame.Data is
+//     reassigned so the wrong (processed) slice is never put back to the resample pool.
+//   - Processing float64 scratch and output byte buffers: allocated inside
+//     applyProcessing, returned at the trailing guards after Write returns.
+//   - processingOutPool and resamplePool cannot both be non-nil at the trailing
+//     guards by construction, so the two trailing Puts are mutually exclusive.
 func (r *AudioRouter) handleRouteFrame(frame AudioFrame, route *Route) { //nolint:gocritic // hugeParam: AudioFrame is large but copying is intentional
 	var resamplePool *buffer.BytePool // nil when not pooled
+
+	// Declare processing pool handles here so they are in scope for the
+	// trailing release guards below.
+	var (
+		processingFloatPool *buffer.Float64Pool
+		processingFloatBuf  []float64
+		processingOutPool   *buffer.BytePool
+	)
 
 	// Apply per-route resampling when rates differ.
 	if route.resampler != nil {
@@ -513,11 +524,10 @@ func (r *AudioRouter) handleRouteFrame(frame AudioFrame, route *Route) { //nolin
 	// Both require 16-bit PCM; skip for other formats.
 	chain := route.filterChain.Load()
 	if frame.BitDepth == 16 && (chain != nil || route.gainLinear != 1.0) {
-		processed, err := r.applyProcessing(frame, route, chain)
+		processed, floatPool, floatBuf, outPool, err := r.applyProcessing(frame, route, chain)
 		if err != nil {
-			// Release the resample buffer on error before skipping the frame.
-			// applyProcessing owns its own output buffer, so frame.Data still
-			// points to the resample slice here.
+			// applyProcessing already released its own pool buffers on error.
+			// Release the resample buffer (frame.Data still points to it here).
 			if resamplePool != nil {
 				resamplePool.Put(frame.Data)
 			}
@@ -532,6 +542,9 @@ func (r *AudioRouter) handleRouteFrame(frame AudioFrame, route *Route) { //nolin
 			resamplePool = nil
 		}
 		frame = processed
+		processingFloatPool = floatPool
+		processingFloatBuf = floatBuf
+		processingOutPool = outPool
 	}
 	if err := route.Consumer.Write(frame); err != nil {
 		errCount := route.errors.Add(1)
@@ -543,9 +556,18 @@ func (r *AudioRouter) handleRouteFrame(frame AudioFrame, route *Route) { //nolin
 				logger.Error(err))
 		}
 	}
-	// Release the resample buffer after Consumer.Write returns. All in-tree
-	// consumers copy synchronously, so the slice is safe to recycle. When
-	// processing succeeded, resamplePool was nilled above and this is a no-op.
+	// Release processing output buffer (frame.Data when processing ran).
+	// All in-tree consumers copy synchronously, so the slice is safe to recycle.
+	if processingOutPool != nil {
+		processingOutPool.Put(frame.Data)
+	}
+	// Release processing float scratch buffer.
+	if processingFloatPool != nil {
+		processingFloatPool.Put(processingFloatBuf)
+	}
+	// Release resample buffer when processing did NOT run (processing branch
+	// nilled resamplePool before reassigning frame.Data). When processing ran,
+	// resamplePool is nil here and this is a no-op.
 	if resamplePool != nil {
 		resamplePool.Put(frame.Data)
 	}
@@ -554,32 +576,76 @@ func (r *AudioRouter) handleRouteFrame(frame AudioFrame, route *Route) { //nolin
 // applyProcessing applies EQ filtering and/or gain scaling to a frame in a
 // single float64 conversion pass. The chain may be nil (EQ disabled); gain
 // at 1.0 means no scaling. At least one must be active for this to be called.
-func (r *AudioRouter) applyProcessing(frame AudioFrame, route *Route, chain *equalizer.FilterChain) (AudioFrame, error) { //nolint:gocritic // hugeParam: AudioFrame is large but copying is intentional
-	floats := convert.BytesToFloat64PCM16(frame.Data)
+//
+// Return contract: on success, the caller owns floatPool/floatBuf and outPool
+// and must Put them after Consumer.Write returns. On error, applyProcessing has
+// already released both buffers internally and zeroed the returned pointers, so
+// the caller must NOT Put them again. This means the caller should Put only when
+// err == nil.
+//
+// When bufMgr is nil or a pool lookup returns nil, the function falls back to
+// make() with no corresponding Put, preserving legacy behaviour for unit tests
+// that construct routers with a nil Manager.
+func (r *AudioRouter) applyProcessing(frame AudioFrame, route *Route, chain *equalizer.FilterChain) (processed AudioFrame, floatPool *buffer.Float64Pool, floatBuf []float64, outPool *buffer.BytePool, err error) { //nolint:gocritic // hugeParam: AudioFrame is large but copying is intentional
+	evenLen := len(frame.Data) &^ 1
+	sampleCount := evenLen / 2
 
-	// EQ first — filters operate on the original signal shape.
+	if r.bufMgr != nil {
+		floatPool = r.bufMgr.Float64PoolFor(sampleCount)
+	}
+	if floatPool != nil {
+		floatBuf = floatPool.Get()
+	} else {
+		floatBuf = make([]float64, sampleCount)
+	}
+	convert.BytesToFloat64PCM16Into(floatBuf, frame.Data[:evenLen])
+
+	// EQ first - filters operate on the original signal shape.
 	if chain != nil {
-		chain.ApplyBatch(floats)
+		chain.ApplyBatch(floatBuf)
 	}
 
-	// Gain second — scales the (possibly filtered) signal.
+	// Gain second - scales the (possibly filtered) signal.
 	if route.gainLinear != 1.0 {
-		convert.ScaleFloat64Slice(floats, route.gainLinear)
+		convert.ScaleFloat64Slice(floatBuf, route.gainLinear)
 	}
 
-	out := make([]byte, len(floats)*2)
-	if err := convert.Float64ToBytesPCM16(floats, out); err != nil {
+	outLen := sampleCount * 2
+	var out []byte
+	if r.bufMgr != nil {
+		outPool = r.bufMgr.BytePoolFor(outLen)
+	}
+	if outPool != nil {
+		out = outPool.Get()
+	} else {
+		out = make([]byte, outLen)
+	}
+
+	if convErr := convert.Float64ToBytesPCM16(floatBuf, out); convErr != nil {
 		errCount := route.errors.Add(1)
 		if errCount%errorLogInterval == 1 {
 			r.log.Warn("audio processing conversion error",
 				logger.String("source_id", route.SourceID),
 				logger.String("consumer_id", route.Consumer.ID()),
 				logger.Int64("total_errors", errCount),
-				logger.Error(err))
+				logger.Error(convErr))
 		}
-		return AudioFrame{}, err
+		// Return buffers on error so pools do not leak.
+		if floatPool != nil {
+			floatPool.Put(floatBuf)
+		}
+		if outPool != nil {
+			outPool.Put(out)
+		}
+		// Zero the return values so the caller does not try to Put again.
+		floatPool = nil
+		floatBuf = nil
+		outPool = nil
+		err = convErr
+		return
 	}
-	return AudioFrame{
+
+	processed = AudioFrame{
 		SourceID:   frame.SourceID,
 		SourceName: frame.SourceName,
 		Data:       out,
@@ -587,5 +653,6 @@ func (r *AudioRouter) applyProcessing(frame AudioFrame, route *Route, chain *equ
 		BitDepth:   frame.BitDepth,
 		Channels:   frame.Channels,
 		Timestamp:  frame.Timestamp,
-	}, nil
+	}
+	return
 }

--- a/internal/audiocore/router.go
+++ b/internal/audiocore/router.go
@@ -637,9 +637,10 @@ func (r *AudioRouter) applyProcessing(frame AudioFrame, route *Route, chain *equ
 		floatBuf = make([]float64, sampleCount)
 	}
 
-	// releasePools guards both pool buffers. It returns them on any early
-	// exit; the success path disarms both flags before returning so the
-	// caller owns the buffers (releasing them after Consumer.Write via
+	// The deferred closure below guards both pool buffers via the
+	// releaseFloat / releaseOut flags. It returns them on any early exit;
+	// the success path disarms both flags before returning so the caller
+	// owns the buffers (to be released after Consumer.Write via
 	// processingResult.release()).
 	releaseFloat := true
 	releaseOut := true

--- a/internal/audiocore/router.go
+++ b/internal/audiocore/router.go
@@ -464,24 +464,24 @@ func (r *AudioRouter) drainRoute(route *Route) {
 // writes it to the route's consumer. It is called from drainRoute's select loop
 // and is extracted to keep drainRoute under the cognitive-complexity limit.
 //
-// Pool discipline:
-//   - Resample buffer: allocated before resampling, returned after Write (or on error).
-//     When processing follows, the resample buffer is returned before frame.Data is
-//     reassigned so the wrong (processed) slice is never put back to the resample pool.
+// Pool discipline (three release sites, seven scenarios):
+//   - Resample buffer: allocated before resampling, returned after Write (or on
+//     error). When processing follows, the resample buffer is returned before
+//     frame.Data is reassigned so the wrong (processed) slice is never put back
+//     to the resample pool; resamplePool is nilled so the trailing guard is a
+//     no-op.
 //   - Processing float64 scratch and output byte buffers: allocated inside
-//     applyProcessing, returned at the trailing guards after Write returns.
-//   - processingOutPool and resamplePool cannot both be non-nil at the trailing
-//     guards by construction, so the two trailing Puts are mutually exclusive.
+//     applyProcessing, bundled in procResult. procResult.release() is called
+//     unconditionally in the trailing guards; it is a no-op on a zero-value
+//     result (processing never ran or errored with internal cleanup).
+//   - procResult.OutPool and resamplePool cannot both be non-nil at the trailing
+//     guards by construction, so their Put calls are mutually exclusive.
 func (r *AudioRouter) handleRouteFrame(frame AudioFrame, route *Route) { //nolint:gocritic // hugeParam: AudioFrame is large but copying is intentional
 	var resamplePool *buffer.BytePool // nil when not pooled
 
-	// Declare processing pool handles here so they are in scope for the
-	// trailing release guards below.
-	var (
-		processingFloatPool *buffer.Float64Pool
-		processingFloatBuf  []float64
-		processingOutPool   *buffer.BytePool
-	)
+	// procResult holds the processing output and pool handles. Zero value is
+	// safe: release() is a no-op when all pool pointers are nil.
+	var procResult processingResult
 
 	// Apply per-route resampling when rates differ.
 	if route.resampler != nil {
@@ -524,7 +524,7 @@ func (r *AudioRouter) handleRouteFrame(frame AudioFrame, route *Route) { //nolin
 	// Both require 16-bit PCM; skip for other formats.
 	chain := route.filterChain.Load()
 	if frame.BitDepth == 16 && (chain != nil || route.gainLinear != 1.0) {
-		processed, floatPool, floatBuf, outPool, err := r.applyProcessing(frame, route, chain)
+		result, err := r.applyProcessing(frame, route, chain)
 		if err != nil {
 			// applyProcessing already released its own pool buffers on error.
 			// Release the resample buffer (frame.Data still points to it here).
@@ -541,10 +541,8 @@ func (r *AudioRouter) handleRouteFrame(frame AudioFrame, route *Route) { //nolin
 			resamplePool.Put(frame.Data)
 			resamplePool = nil
 		}
-		frame = processed
-		processingFloatPool = floatPool
-		processingFloatBuf = floatBuf
-		processingOutPool = outPool
+		frame = result.Frame
+		procResult = result
 	}
 	if err := route.Consumer.Write(frame); err != nil {
 		errCount := route.errors.Add(1)
@@ -556,15 +554,10 @@ func (r *AudioRouter) handleRouteFrame(frame AudioFrame, route *Route) { //nolin
 				logger.Error(err))
 		}
 	}
-	// Release processing output buffer (frame.Data when processing ran).
-	// All in-tree consumers copy synchronously, so the slice is safe to recycle.
-	if processingOutPool != nil {
-		processingOutPool.Put(frame.Data)
-	}
-	// Release processing float scratch buffer.
-	if processingFloatPool != nil {
-		processingFloatPool.Put(processingFloatBuf)
-	}
+	// Release processing buffers (output byte slice and float64 scratch).
+	// Safe to call unconditionally: no-op when procResult is zero value.
+	// All in-tree consumers copy synchronously, so recycling is safe here.
+	procResult.release()
 	// Release resample buffer when processing did NOT run (processing branch
 	// nilled resamplePool before reassigning frame.Data). When processing ran,
 	// resamplePool is nil here and this is a no-op.
@@ -573,26 +566,50 @@ func (r *AudioRouter) handleRouteFrame(frame AudioFrame, route *Route) { //nolin
 	}
 }
 
+// processingResult carries an EQ / gain processed frame plus the pooled
+// buffers that must be returned to their pools after the consumer has
+// synchronously observed the frame. A zero-value result (all pools nil)
+// is safe: release() is a no-op.
+type processingResult struct {
+	Frame     AudioFrame
+	FloatPool *buffer.Float64Pool
+	FloatBuf  []float64
+	OutPool   *buffer.BytePool
+}
+
+// release returns the processing pool buffers to their pools. Safe to call
+// on a zero-value result. Callers invoke this after the consumer's Write
+// returns so the recycled slices are not concurrently read.
+func (p *processingResult) release() {
+	if p.FloatPool != nil {
+		p.FloatPool.Put(p.FloatBuf)
+	}
+	if p.OutPool != nil {
+		p.OutPool.Put(p.Frame.Data)
+	}
+}
+
 // applyProcessing applies EQ filtering and/or gain scaling to a frame in a
 // single float64 conversion pass. The chain may be nil (EQ disabled); gain
 // at 1.0 means no scaling. At least one must be active for this to be called.
 //
-// Return contract: on success, the caller owns floatPool/floatBuf and outPool
-// and must Put them after Consumer.Write returns. On error, applyProcessing has
-// already released both buffers internally and zeroed the returned pointers, so
-// the caller must NOT Put them again. This means the caller should Put only when
-// err == nil.
+// Return contract: on success, the caller owns the returned processingResult
+// and must call release() after Consumer.Write returns. On error, applyProcessing
+// releases both buffers internally and returns a zero-value result, so
+// release() on the zero value is always safe (it is a no-op).
 //
 // When bufMgr is nil or a pool lookup returns nil, the function falls back to
 // make() with no corresponding Put, preserving legacy behaviour for unit tests
 // that construct routers with a nil Manager.
-func (r *AudioRouter) applyProcessing(frame AudioFrame, route *Route, chain *equalizer.FilterChain) (processed AudioFrame, floatPool *buffer.Float64Pool, floatBuf []float64, outPool *buffer.BytePool, err error) { //nolint:gocritic // hugeParam: AudioFrame is large but copying is intentional
+func (r *AudioRouter) applyProcessing(frame AudioFrame, route *Route, chain *equalizer.FilterChain) (processingResult, error) { //nolint:gocritic // hugeParam: AudioFrame is large but copying is intentional
 	evenLen := len(frame.Data) &^ 1
 	sampleCount := evenLen / 2
 
+	var floatPool *buffer.Float64Pool
 	if r.bufMgr != nil {
 		floatPool = r.bufMgr.Float64PoolFor(sampleCount)
 	}
+	var floatBuf []float64
 	if floatPool != nil {
 		floatBuf = floatPool.Get()
 	} else {
@@ -611,10 +628,11 @@ func (r *AudioRouter) applyProcessing(frame AudioFrame, route *Route, chain *equ
 	}
 
 	outLen := sampleCount * 2
-	var out []byte
+	var outPool *buffer.BytePool
 	if r.bufMgr != nil {
 		outPool = r.bufMgr.BytePoolFor(outLen)
 	}
+	var out []byte
 	if outPool != nil {
 		out = outPool.Get()
 	} else {
@@ -630,29 +648,28 @@ func (r *AudioRouter) applyProcessing(frame AudioFrame, route *Route, chain *equ
 				logger.Int64("total_errors", errCount),
 				logger.Error(convErr))
 		}
-		// Return buffers on error so pools do not leak.
+		// Release the buffers we obtained; caller will see a zero-value result.
 		if floatPool != nil {
 			floatPool.Put(floatBuf)
 		}
 		if outPool != nil {
 			outPool.Put(out)
 		}
-		// Zero the return values so the caller does not try to Put again.
-		floatPool = nil
-		floatBuf = nil
-		outPool = nil
-		err = convErr
-		return
+		return processingResult{}, convErr
 	}
 
-	processed = AudioFrame{
-		SourceID:   frame.SourceID,
-		SourceName: frame.SourceName,
-		Data:       out,
-		SampleRate: frame.SampleRate,
-		BitDepth:   frame.BitDepth,
-		Channels:   frame.Channels,
-		Timestamp:  frame.Timestamp,
-	}
-	return
+	return processingResult{
+		Frame: AudioFrame{
+			SourceID:   frame.SourceID,
+			SourceName: frame.SourceName,
+			Data:       out,
+			SampleRate: frame.SampleRate,
+			BitDepth:   frame.BitDepth,
+			Channels:   frame.Channels,
+			Timestamp:  frame.Timestamp,
+		},
+		FloatPool: floatPool,
+		FloatBuf:  floatBuf,
+		OutPool:   outPool,
+	}, nil
 }

--- a/internal/audiocore/router.go
+++ b/internal/audiocore/router.go
@@ -9,6 +9,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/tphakala/birdnet-go/internal/audiocore/buffer"
 	"github.com/tphakala/birdnet-go/internal/audiocore/convert"
 	"github.com/tphakala/birdnet-go/internal/audiocore/equalizer"
 	"github.com/tphakala/birdnet-go/internal/audiocore/resample"
@@ -107,17 +108,26 @@ type AudioRouter struct {
 	// log is the router's logger.
 	log logger.Logger
 
+	// bufMgr is the shared buffer manager used to obtain per-size pools on the
+	// hot path. When nil (legacy constructions / test mockery), the router falls
+	// back to plain make() allocations.
+	bufMgr *buffer.Manager
+
 	// ctx and cancel control the lifetime of all drainer goroutines.
 	ctx    context.Context
 	cancel context.CancelFunc
 }
 
-// NewAudioRouter creates an AudioRouter ready to accept routes and dispatch frames.
-func NewAudioRouter(log logger.Logger) *AudioRouter {
+// NewAudioRouter creates an AudioRouter ready to accept routes and dispatch
+// frames. bufMgr is the shared buffer.Manager used to obtain per-size pools on
+// the hot path; when nil (legacy constructions or test mockery), the router
+// falls back to plain make() allocations.
+func NewAudioRouter(log logger.Logger, bufMgr *buffer.Manager) *AudioRouter {
 	ctx, cancel := context.WithCancel(context.Background())
 	return &AudioRouter{
 		routes: make(map[string][]*Route),
 		log:    log.With(logger.String("component", "audio_router")),
+		bufMgr: bufMgr,
 		ctx:    ctx,
 		cancel: cancel,
 	}

--- a/internal/audiocore/router.go
+++ b/internal/audiocore/router.go
@@ -72,6 +72,12 @@ type Route struct {
 	// errors counts Write failures reported by the consumer.
 	errors atomic.Int64
 
+	// truncations counts odd-length PCM16 frames observed on this route.
+	// Kept separate from errors so RouteInfo.Errors retains its "real error"
+	// semantics for operators; a misbehaving upstream does not inflate that
+	// metric.
+	truncations atomic.Int64
+
 	// done is closed to signal the drainer goroutine to exit.
 	done chan struct{}
 
@@ -606,17 +612,16 @@ func (p *processingResult) release() {
 func (r *AudioRouter) applyProcessing(frame AudioFrame, route *Route, chain *equalizer.FilterChain) (processingResult, error) { //nolint:gocritic // hugeParam: AudioFrame is large but copying is intentional
 	evenLen := len(frame.Data) &^ 1
 	if evenLen != len(frame.Data) {
-		// Odd-length PCM16 input: convert/pcm.go silently truncates the trailing
-		// byte, which can hide upstream producer bugs. Throttled via the shared
-		// route.errors counter (one log per errorLogInterval events) so we stay
-		// visible without spamming the log on a persistent misbehaving source.
-		errCount := route.errors.Add(1)
-		if errCount%errorLogInterval == 1 {
+		// Separate counter: this is a diagnostic for upstream producer bugs,
+		// not a true local error. Keeping it out of route.errors preserves the
+		// meaning of RouteInfo.Errors for operators.
+		truncCount := route.truncations.Add(1)
+		if truncCount%errorLogInterval == 1 {
 			r.log.Info("odd-length PCM16 frame truncated",
 				logger.String("source_id", route.SourceID),
 				logger.String("consumer_id", route.Consumer.ID()),
 				logger.Int("frame_bytes", len(frame.Data)),
-				logger.Int64("total_errors", errCount))
+				logger.Int64("total_truncations", truncCount))
 		}
 	}
 	sampleCount := evenLen / 2

--- a/internal/audiocore/router_test.go
+++ b/internal/audiocore/router_test.go
@@ -84,7 +84,7 @@ func testFrame(sourceID string) AudioFrame {
 // removed, with HasConsumers reflecting the correct state at each step.
 func TestRouter_AddAndRemoveRoute(t *testing.T) {
 	t.Parallel()
-	router := NewAudioRouter(GetLogger())
+	router := NewAudioRouter(GetLogger(), nil)
 	t.Cleanup(func() { router.Close() })
 
 	consumer := newMockConsumer("consumer-1")
@@ -102,7 +102,7 @@ func TestRouter_AddAndRemoveRoute(t *testing.T) {
 // a single registered consumer.
 func TestRouter_DispatchSingleConsumer(t *testing.T) {
 	t.Parallel()
-	router := NewAudioRouter(GetLogger())
+	router := NewAudioRouter(GetLogger(), nil)
 	t.Cleanup(func() { router.Close() })
 
 	consumer := newMockConsumer("consumer-1")
@@ -125,7 +125,7 @@ func TestRouter_DispatchSingleConsumer(t *testing.T) {
 // consumers registered for the same source.
 func TestRouter_DispatchFanOut(t *testing.T) {
 	t.Parallel()
-	router := NewAudioRouter(GetLogger())
+	router := NewAudioRouter(GetLogger(), nil)
 	t.Cleanup(func() { router.Close() })
 
 	c1 := newMockConsumer("consumer-1")
@@ -151,7 +151,7 @@ func TestRouter_DispatchFanOut(t *testing.T) {
 // no registered routes does not panic.
 func TestRouter_DispatchNoConsumers(t *testing.T) {
 	t.Parallel()
-	router := NewAudioRouter(GetLogger())
+	router := NewAudioRouter(GetLogger(), nil)
 	t.Cleanup(func() { router.Close() })
 
 	// Should not panic.
@@ -164,7 +164,7 @@ func TestRouter_DispatchNoConsumers(t *testing.T) {
 // the frame is dropped and the drop counter increments.
 func TestRouter_DropOnFullInbox(t *testing.T) {
 	t.Parallel()
-	router := NewAudioRouter(GetLogger())
+	router := NewAudioRouter(GetLogger(), nil)
 	t.Cleanup(func() { router.Close() })
 
 	consumer := newBlockingConsumer("slow-consumer")
@@ -186,7 +186,7 @@ func TestRouter_DropOnFullInbox(t *testing.T) {
 // route for a given source.
 func TestRouter_RemoveAllRoutes(t *testing.T) {
 	t.Parallel()
-	router := NewAudioRouter(GetLogger())
+	router := NewAudioRouter(GetLogger(), nil)
 	t.Cleanup(func() { router.Close() })
 
 	c1 := newMockConsumer("consumer-1")
@@ -206,7 +206,7 @@ func TestRouter_RemoveAllRoutes(t *testing.T) {
 // twice for the same source returns ErrRouteExists.
 func TestRouter_DuplicateRouteError(t *testing.T) {
 	t.Parallel()
-	router := NewAudioRouter(GetLogger())
+	router := NewAudioRouter(GetLogger(), nil)
 	t.Cleanup(func() { router.Close() })
 
 	c1 := newMockConsumer("consumer-1")
@@ -225,7 +225,7 @@ func TestRouter_DuplicateRouteError(t *testing.T) {
 // resampled data (approximately 2/3 the length for a 48kHz→32kHz conversion).
 func TestRouter_DispatchWithResampling(t *testing.T) {
 	t.Parallel()
-	router := NewAudioRouter(GetLogger())
+	router := NewAudioRouter(GetLogger(), nil)
 	t.Cleanup(func() { router.Close() })
 
 	// Consumer expects 32kHz; source produces 48kHz.
@@ -282,7 +282,7 @@ func TestRouter_DispatchWithResampling(t *testing.T) {
 // multiple goroutines does not trigger data races (run with -race).
 func TestRouter_ConcurrentDispatch(t *testing.T) {
 	t.Parallel()
-	router := NewAudioRouter(GetLogger())
+	router := NewAudioRouter(GetLogger(), nil)
 	t.Cleanup(func() { router.Close() })
 
 	c1 := newMockConsumer("consumer-1")
@@ -320,7 +320,7 @@ done:
 func TestDrainRoutePanicRecovery(t *testing.T) {
 	t.Parallel()
 
-	router := NewAudioRouter(GetLogger())
+	router := NewAudioRouter(GetLogger(), nil)
 	t.Cleanup(func() { router.Close() })
 
 	panicConsumer := &panicOnWriteConsumer{
@@ -399,7 +399,7 @@ func TestRouter_DrainRouteAppliesGain(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			router := NewAudioRouter(GetLogger())
+			router := NewAudioRouter(GetLogger(), nil)
 			defer router.Close()
 
 			consumer := newMockConsumer("c1")
@@ -445,7 +445,7 @@ func TestRouter_DrainRouteAppliesGain(t *testing.T) {
 func TestRouter_GainClipping(t *testing.T) {
 	t.Parallel()
 
-	router := NewAudioRouter(GetLogger())
+	router := NewAudioRouter(GetLogger(), nil)
 	defer router.Close()
 
 	consumer := newMockConsumer("c1")
@@ -507,7 +507,7 @@ func TestRouter_AddRouteWithGain(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			router := NewAudioRouter(GetLogger())
+			router := NewAudioRouter(GetLogger(), nil)
 			t.Cleanup(func() { router.Close() })
 			consumer := newMockConsumer("c1")
 			err := router.AddRoute("src-1", consumer, 48000, tt.gainDB, nil)
@@ -523,7 +523,7 @@ func TestRouter_AddRouteWithGain(t *testing.T) {
 
 func TestRouter_UpdateFilterChain(t *testing.T) {
 	t.Parallel()
-	router := NewAudioRouter(GetLogger())
+	router := NewAudioRouter(GetLogger(), nil)
 	t.Cleanup(func() { router.Close() })
 
 	consumer := newMockConsumer("c1")
@@ -567,7 +567,7 @@ func TestRouter_UpdateFilterChain(t *testing.T) {
 // EQ chain when gain is unity (1.0) and a filter chain is set.
 func TestRouter_ApplyProcessing_EQOnly(t *testing.T) {
 	t.Parallel()
-	router := NewAudioRouter(GetLogger())
+	router := NewAudioRouter(GetLogger(), nil)
 	t.Cleanup(func() { router.Close() })
 
 	consumer := newMockConsumer("c1")
@@ -619,7 +619,7 @@ func TestRouter_ApplyProcessing_EQOnly(t *testing.T) {
 // applied in a single conversion pass.
 func TestRouter_ApplyProcessing_EQAndGain(t *testing.T) {
 	t.Parallel()
-	router := NewAudioRouter(GetLogger())
+	router := NewAudioRouter(GetLogger(), nil)
 	t.Cleanup(func() { router.Close() })
 
 	consumer := newMockConsumer("c1")

--- a/internal/audiocore/router_test.go
+++ b/internal/audiocore/router_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/audiocore/buffer"
 	"github.com/tphakala/birdnet-go/internal/audiocore/equalizer"
 )
 
@@ -663,6 +664,120 @@ func TestRouter_ApplyProcessing_EQAndGain(t *testing.T) {
 	outputRMS := rmsOfPCM16(received.Data)
 	assert.InDelta(t, inputRMS*2.0, outputRMS, inputRMS*0.5,
 		"output should be ~2x input (6 dB gain) after passing through LowPass")
+}
+
+// BenchmarkApplyProcessing_PoolWarm measures steady-state per-frame allocations
+// on the applyProcessing hot path with a fully wired buffer.Manager. The pools
+// are warmed before the timed loop so the reported allocs/op reflects recycling
+// behaviour, not first-call pool misses.
+func BenchmarkApplyProcessing_PoolWarm(b *testing.B) {
+	mgr := buffer.NewManager(GetLogger())
+	r := NewAudioRouter(GetLogger(), mgr)
+	defer r.Close()
+
+	// Construct a minimal Route that exercises the gain branch.
+	// gainLinear != 1.0 ensures applyProcessing is called; nil filterChain
+	// means EQ is skipped so only gain scaling runs.
+	route := &Route{
+		gainLinear: 2.0, // +6 dB: exercises the gain path
+		inbox:      make(chan AudioFrame, 1),
+		done:       make(chan struct{}),
+		stopped:    make(chan struct{}),
+	}
+	// filterChain zero value is a nil atomic.Pointer, which Load() returns nil for.
+
+	// 2880 bytes = 1440 samples = 30 ms of 48 kHz mono 16-bit PCM.
+	frame := AudioFrame{
+		SourceID:   "bench",
+		SourceName: "bench",
+		Data:       make([]byte, 2880),
+		SampleRate: 48000,
+		BitDepth:   16,
+		Channels:   1,
+	}
+
+	// Warm the pools so steady-state pool reuse is established before timing.
+	for range 4 {
+		res, err := r.applyProcessing(frame, route, nil)
+		if err != nil {
+			b.Fatalf("warm-up applyProcessing failed: %v", err)
+		}
+		res.release()
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for b.Loop() {
+		res, err := r.applyProcessing(frame, route, nil)
+		if err != nil {
+			b.Fatal(err)
+		}
+		res.release()
+	}
+}
+
+// TestApplyProcessing_AllocationRegression guards against allocation regressions
+// on the applyProcessing hot path. It measures steady-state allocs/op after pool
+// warm-up and asserts they stay within the cap documented in maxAllowedAllocs.
+//
+// Do NOT add t.Parallel() here: sync.Pool is stateful and parallel execution
+// could pollute pool state during the alloc-sensitive measurement window.
+func TestApplyProcessing_AllocationRegression(t *testing.T) {
+	mgr := buffer.NewManager(GetLogger())
+	r := NewAudioRouter(GetLogger(), mgr)
+	defer r.Close()
+
+	route := &Route{
+		gainLinear: 2.0,
+		inbox:      make(chan AudioFrame, 1),
+		done:       make(chan struct{}),
+		stopped:    make(chan struct{}),
+	}
+
+	frame := AudioFrame{
+		SourceID:   "bench",
+		SourceName: "bench",
+		Data:       make([]byte, 2880),
+		SampleRate: 48000,
+		BitDepth:   16,
+		Channels:   1,
+	}
+
+	// Warm the pools before measuring.
+	for range 4 {
+		res, err := r.applyProcessing(frame, route, nil)
+		require.NoError(t, err)
+		res.release()
+	}
+
+	// Measure steady-state allocation count over 100 iterations.
+	allocs := testing.AllocsPerRun(100, func() {
+		res, err := r.applyProcessing(frame, route, nil)
+		if err != nil {
+			panic(err)
+		}
+		res.release()
+	})
+
+	// Regression gate. The baseline is not zero because sync.Pool.Put boxes
+	// the slice header into an interface{} value (see SA6002 nolint comment in
+	// internal/audiocore/buffer/pool.go). Each Put call for Float64Pool and
+	// BytePool boxes one slice header, costing one small allocation. Two Put
+	// calls per applyProcessing call produce 2 allocs/op at steady state under
+	// the benchmark (warm, isolated). Under -race with parallel tests, the GC
+	// may collect pooled items causing up to 2 additional pool-miss allocs per
+	// call; the cap is set to 4 to tolerate that noise while still catching
+	// any real regressions (e.g. extra make() calls) that would push allocs
+	// well above this threshold.
+	//
+	// Measured benchmark baseline: 2 allocs/op, 48 B/op (3 runs, -count=3).
+	// Increase this constant only after investigating WHY allocations grew.
+	const maxAllowedAllocs = 4
+
+	assert.LessOrEqual(t, int(allocs), maxAllowedAllocs,
+		"applyProcessing allocations per call exceed the regression cap of %d (got %.0f)",
+		maxAllowedAllocs, allocs)
 }
 
 // rmsOfPCM16 computes the RMS of 16-bit little-endian PCM samples.

--- a/internal/audiocore/router_test.go
+++ b/internal/audiocore/router_test.go
@@ -706,7 +706,6 @@ func BenchmarkApplyProcessing_PoolWarm(b *testing.B) {
 	}
 
 	b.ReportAllocs()
-	b.ResetTimer()
 
 	for b.Loop() {
 		res, err := r.applyProcessing(frame, route, nil)


### PR DESCRIPTION
## Summary

Wires the existing `buffer.BytePool` / `buffer.Float32Pool` and a new `Float64Pool` into the audiocore router hot path, eliminating three per-frame allocations identified by production profiling.

**Production profiling baseline (2-day `alloc_space`):**
- `AudioRouter.applyProcessing` output bytes — ~243 GB churn
- `convert.BytesToFloat64PCM16` intermediate — ~195 GB churn
- Resampler-output copy at `router.go:460` — part of the same hot path

Together these were ~438 GB of the ~511 GB total 2-day allocation churn in the audiocore tracker.

## What changes

1. `Float64Pool` added to `internal/audiocore/buffer/pool.go`, mirroring `Float32Pool`.
2. Lazy per-size helpers on `buffer.Manager`:
   - `BytePoolFor(size int) *BytePool`
   - `Float64PoolFor(size int) *Float64Pool`
   - Existing `Float32Pool(size)` renamed to `Float32PoolFor(size)` for naming consistency across the three helpers (8 call sites updated).
3. `*buffer.Manager` threaded into `AudioRouter` via constructor. When `nil` (unit tests) the router falls back to plain `make()` allocations.
4. Three hot-path allocation sites now use pooled buffers:
   - Resample-output copy via `BytePoolFor(len(resampled))`.
   - `[]float64` intermediate via `Float64PoolFor(sampleCount)` + the existing `BytesToFloat64PCM16Into` destination-slice API.
   - Output bytes via `BytePoolFor(outLen)`.
5. Pool `Put` happens after `Consumer.Write` returns; all in-tree consumers (BufferConsumer, SoundLevelConsumer, AudioLevelConsumer, and hlsConsumer after #2792) read synchronously before returning.
6. `drainRoute` extracted a per-frame helper (`handleRouteFrame`) to stay under the gocognit complexity threshold after pool wiring.
7. `applyProcessing` now returns a small unexported `processingResult` struct with a `release()` method, eliminating an asymmetric caller/callee ownership split.
8. New `TestApplyProcessing_AllocationRegression` + `BenchmarkApplyProcessing_PoolWarm` guard against future regressions.

## Incidental structural changes

- Resolving an import cycle required moving `ErrBufferNotFound` from `internal/audiocore/errors.go` into `internal/audiocore/buffer/pool.go`. `audiocore.ErrBufferNotFound` is retained as a `var` alias of `buffer.ErrBufferNotFound` so `errors.Is` behaves identically via either import path.
- `hlsConsumer.Write` (merged in #2792) was the prerequisite that allowed the router to recycle its output slices without racing the FFmpeg reader.

## Allocation measurement

`TestApplyProcessing_AllocationRegression` measures steady-state allocs/op with the pools warmed. Baseline is **2 allocs/op**, attributable to `sync.Pool.Put` boxing the slice header into an `interface{}` (acknowledged in the pre-existing `SA6002` nolint in `buffer/pool.go`). The test caps the measurement at 4 to tolerate `-race` + parallel pool-pressure noise while still catching any regression that introduces a new `make()` call on the hot path (which would push allocs to 6+).

Benchmark (isolated, `-count=3` min of):
- `BenchmarkApplyProcessing_PoolWarm`: ~2.6 us/op, 48 B/op, 2 allocs/op.

## Test plan

- [x] New unit tests: `Float64Pool` (4 tests), `Manager.BytePoolFor` + `Float64PoolFor` (4 tests), `TestApplyProcessing_AllocationRegression`.
- [x] `go test -race -timeout 180s ./internal/audiocore/... ./internal/analysis/...` passes.
- [x] `golangci-lint run -v` clean.
- [x] Local `coderabbit review --plain -t committed --base origin/main` reports no findings.
- [x] All existing router / buffer / analysis tests pass unchanged.

## Follow-ups (not in this PR)

- Cache the three per-route pool pointers on `Route` at `AddRoute` time to eliminate the per-frame `Manager.*PoolFor` mutex lookup (a reviewer flagged this as Minor; addressing it has a larger blast radius than this PR's scope).
- Add a test that exercises both resampling and EQ/gain with a live `buffer.Manager` so the three resample-pool `Put` sites are covered under pooled conditions (currently exercised only via the `nil`-manager fallback path).
- A follow-up PR will pool `AnalysisBuffer.Read` and `convertS32ToS16`, the last two allocation sites identified by the profiler.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked buffer management to use per-size pooled buffers, added byte/float64 pooling, and wired a shared buffer manager into the audio router; pool accessors updated to size-specific semantics.

* **Bug Fixes**
  * Unified "buffer not found" error across audio components for consistent error handling.

* **Tests**
  * Added allocation-regression benchmarks and expanded pool behaviour tests (including byte/float64 pools).

* **Documentation**
  * Clarified buffer ownership contract for audio consumer writes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->