### PR TITLE
refactor(audiocore): pool AnalysisBuffer.Read window via buffer.Manager

### DIFF
--- a/internal/analysis/buffer_consumer_test.go
+++ b/internal/analysis/buffer_consumer_test.go
@@ -129,7 +129,8 @@ func TestBufferConsumer_WritesToBothBuffers(t *testing.T) {
 	}
 	require.NoError(t, consumer.Write(bigFrame))
 
-	data, readErr := ab.Read()
+	data, release, readErr := ab.Read()
+	defer release()
 	require.NoError(t, readErr)
 	assert.NotNil(t, data, "analysis buffer should return data after sufficient writes")
 
@@ -348,14 +349,16 @@ func TestBufferConsumer_FanOut_MultiModel(t *testing.T) {
 	// Verify birdnet buffer received data (no resampling).
 	ab48, err := mgr.AnalysisBuffer(sourceID, birdnetModel)
 	require.NoError(t, err)
-	data48, readErr := ab48.Read()
+	data48, release48, readErr := ab48.Read()
+	defer release48()
 	require.NoError(t, readErr)
 	require.NotNil(t, data48, "48 kHz buffer should have data after write")
 
 	// Verify perch buffer received resampled data.
 	ab32, err := mgr.AnalysisBuffer(sourceID, perchModel)
 	require.NoError(t, err)
-	data32, readErr := ab32.Read()
+	data32, release32, readErr := ab32.Read()
+	defer release32()
 	require.NoError(t, readErr)
 	require.NotNil(t, data32, "32 kHz buffer should have resampled data after write")
 
@@ -434,10 +437,11 @@ func TestBufferConsumer_SingleModel_FullPipeline(t *testing.T) {
 		require.NoError(t, consumer.Write(frame))
 	}
 
-	// Read from the analysis buffer — should return data.
+	// Read from the analysis buffer, should return data.
 	ab, err := mgr.AnalysisBuffer("mic1", "birdnet-v2.4")
 	require.NoError(t, err)
-	data, err := ab.Read()
+	data, release, err := ab.Read()
+	defer release()
 	require.NoError(t, err)
 	assert.NotNil(t, data, "should have enough data for a full read")
 }

--- a/internal/analysis/buffer_manager.go
+++ b/internal/analysis/buffer_manager.go
@@ -404,7 +404,7 @@ func (m *BufferManager) analysisBufferMonitor(quitChan chan struct{}, cfg monito
 		case <-quitChan:
 			return
 		case <-ticker.C:
-			keepRunning, newHasReadBuffer := m.processMonitorTick(cfg, analysisWindowBytes, detectionOffset, hasReadBuffer)
+			keepRunning, newHasReadBuffer := m.processMonitorTick(quitChan, cfg, analysisWindowBytes, detectionOffset, hasReadBuffer)
 			hasReadBuffer = newHasReadBuffer
 			if !keepRunning {
 				return
@@ -417,15 +417,16 @@ func (m *BufferManager) analysisBufferMonitor(quitChan chan struct{}, cfg monito
 // up the current AnalysisBuffer for (sourceID, modelID), reads one window,
 // and dispatches it to ProcessData when a full readSize window is present.
 //
-// Returns keepRunning=false when the buffer was not found and the goroutine
-// should terminate. The updated hasReadBuffer flag is propagated back so the
-// caller can toggle its "once seen, log on later loss" log-level preference
-// across ticks.
+// Returns keepRunning=false when the buffer was not found OR the goroutine was
+// asked to shut down during a backoff. The updated hasReadBuffer flag is
+// propagated back so the caller can toggle its "once seen, log on later loss"
+// log-level preference across ticks.
 //
 // The window's backing slice is always returned to its pool via a
 // "defer release()" immediately after Read, so every exit path including the
 // try-again-later (nil data), error, and partial-read branches releases.
 func (m *BufferManager) processMonitorTick(
+	quitChan <-chan struct{},
 	cfg monitorConfig,
 	analysisWindowBytes int,
 	detectionOffset time.Duration,
@@ -453,8 +454,14 @@ func (m *BufferManager) processMonitorTick(
 			logger.String("source_id", cfg.sourceID),
 			logger.String("model_id", cfg.modelID),
 			logger.Error(readErr))
-		time.Sleep(1 * time.Second)
-		return true, hasReadBuffer
+		// Backoff one second, but exit immediately if the goroutine is
+		// told to shut down during the sleep.
+		select {
+		case <-time.After(1 * time.Second):
+			return true, hasReadBuffer
+		case <-quitChan:
+			return false, hasReadBuffer
+		}
 	}
 
 	// Exact equality is required: AnalysisBuffer.Read returns overlapSize +

--- a/internal/analysis/buffer_manager.go
+++ b/internal/analysis/buffer_manager.go
@@ -404,34 +404,40 @@ func (m *BufferManager) analysisBufferMonitor(quitChan chan struct{}, cfg monito
 		case <-quitChan:
 			return
 		case <-ticker.C:
-			ab, err := m.bufferMgr.AnalysisBuffer(cfg.sourceID, cfg.modelID)
-			if err != nil {
-				if hasReadBuffer {
-					m.logger.Info("analysis buffer removed, stopping monitor",
-						logger.String("source_id", cfg.sourceID),
-						logger.String("model_id", cfg.modelID))
-				} else {
-					m.logger.Warn("analysis buffer not found for monitor, may not be allocated",
-						logger.String("source_id", cfg.sourceID),
-						logger.String("model_id", cfg.modelID))
+			shouldReturn := false
+			func() {
+				ab, err := m.bufferMgr.AnalysisBuffer(cfg.sourceID, cfg.modelID)
+				if err != nil {
+					if hasReadBuffer {
+						m.logger.Info("analysis buffer removed, stopping monitor",
+							logger.String("source_id", cfg.sourceID),
+							logger.String("model_id", cfg.modelID))
+					} else {
+						m.logger.Warn("analysis buffer not found for monitor, may not be allocated",
+							logger.String("source_id", cfg.sourceID),
+							logger.String("model_id", cfg.modelID))
+					}
+					shouldReturn = true
+					return
 				}
-				return
-			}
-			hasReadBuffer = true
-			data, readErr := ab.Read()
-			if readErr != nil {
-				m.logger.Error("buffer read error",
-					logger.String("source_id", cfg.sourceID),
-					logger.String("model_id", cfg.modelID),
-					logger.Error(readErr))
-				time.Sleep(1 * time.Second)
-				continue
-			}
+				hasReadBuffer = true
+				data, release, readErr := ab.Read()
+				defer release()
+				if readErr != nil {
+					m.logger.Error("buffer read error",
+						logger.String("source_id", cfg.sourceID),
+						logger.String("model_id", cfg.modelID),
+						logger.Error(readErr))
+					time.Sleep(1 * time.Second)
+					return
+				}
 
-			// Exact equality is required: AnalysisBuffer.Read() returns
-			// overlapSize + readSize bytes or nil. A partial read means
-			// the buffer hasn't accumulated enough data yet.
-			if len(data) == analysisWindowBytes {
+				// Exact equality is required: AnalysisBuffer.Read() returns
+				// overlapSize + readSize bytes or nil. A partial read means
+				// the buffer hasn't accumulated enough data yet.
+				if len(data) != analysisWindowBytes {
+					return
+				}
 				audioCapturedAt := time.Now()
 
 				// Calculate the offset dynamically to pick up runtime configuration changes
@@ -444,6 +450,9 @@ func (m *BufferManager) analysisBufferMonitor(quitChan chan struct{}, cfg monito
 						logger.String("model_id", cfg.modelID),
 						logger.Error(processErr))
 				}
+			}()
+			if shouldReturn {
+				return
 			}
 		}
 	}

--- a/internal/analysis/buffer_manager.go
+++ b/internal/analysis/buffer_manager.go
@@ -404,58 +404,78 @@ func (m *BufferManager) analysisBufferMonitor(quitChan chan struct{}, cfg monito
 		case <-quitChan:
 			return
 		case <-ticker.C:
-			shouldReturn := false
-			func() {
-				ab, err := m.bufferMgr.AnalysisBuffer(cfg.sourceID, cfg.modelID)
-				if err != nil {
-					if hasReadBuffer {
-						m.logger.Info("analysis buffer removed, stopping monitor",
-							logger.String("source_id", cfg.sourceID),
-							logger.String("model_id", cfg.modelID))
-					} else {
-						m.logger.Warn("analysis buffer not found for monitor, may not be allocated",
-							logger.String("source_id", cfg.sourceID),
-							logger.String("model_id", cfg.modelID))
-					}
-					shouldReturn = true
-					return
-				}
-				hasReadBuffer = true
-				data, release, readErr := ab.Read()
-				defer release()
-				if readErr != nil {
-					m.logger.Error("buffer read error",
-						logger.String("source_id", cfg.sourceID),
-						logger.String("model_id", cfg.modelID),
-						logger.Error(readErr))
-					time.Sleep(1 * time.Second)
-					return
-				}
-
-				// Exact equality is required: AnalysisBuffer.Read() returns
-				// overlapSize + readSize bytes or nil. A partial read means
-				// the buffer hasn't accumulated enough data yet.
-				if len(data) != analysisWindowBytes {
-					return
-				}
-				audioCapturedAt := time.Now()
-
-				// Calculate the offset dynamically to pick up runtime configuration changes
-				beginTimeOffset := time.Duration(conf.Setting().Realtime.Audio.Export.PreCapture)*time.Second + detectionOffset
-				startTime := time.Now().Add(-beginTimeOffset)
-
-				if processErr := ProcessData(context.Background(), m.bn, m.bufferMgr, data, startTime, audioCapturedAt, cfg.sourceID, cfg.modelID); processErr != nil {
-					m.logger.Error("error processing data",
-						logger.String("source_id", cfg.sourceID),
-						logger.String("model_id", cfg.modelID),
-						logger.Error(processErr))
-				}
-			}()
-			if shouldReturn {
+			keepRunning, newHasReadBuffer := m.processMonitorTick(cfg, analysisWindowBytes, detectionOffset, hasReadBuffer)
+			hasReadBuffer = newHasReadBuffer
+			if !keepRunning {
 				return
 			}
 		}
 	}
+}
+
+// processMonitorTick runs one iteration of the analysis buffer monitor: looks
+// up the current AnalysisBuffer for (sourceID, modelID), reads one window,
+// and dispatches it to ProcessData when a full readSize window is present.
+//
+// Returns keepRunning=false when the buffer was not found and the goroutine
+// should terminate. The updated hasReadBuffer flag is propagated back so the
+// caller can toggle its "once seen, log on later loss" log-level preference
+// across ticks.
+//
+// The window's backing slice is always returned to its pool via a
+// "defer release()" immediately after Read, so every exit path including the
+// try-again-later (nil data), error, and partial-read branches releases.
+func (m *BufferManager) processMonitorTick(
+	cfg monitorConfig,
+	analysisWindowBytes int,
+	detectionOffset time.Duration,
+	hasReadBuffer bool,
+) (keepRunning, updatedHasReadBuffer bool) {
+	ab, err := m.bufferMgr.AnalysisBuffer(cfg.sourceID, cfg.modelID)
+	if err != nil {
+		if hasReadBuffer {
+			m.logger.Info("analysis buffer removed, stopping monitor",
+				logger.String("source_id", cfg.sourceID),
+				logger.String("model_id", cfg.modelID))
+		} else {
+			m.logger.Warn("analysis buffer not found for monitor, may not be allocated",
+				logger.String("source_id", cfg.sourceID),
+				logger.String("model_id", cfg.modelID))
+		}
+		return false, hasReadBuffer
+	}
+	hasReadBuffer = true
+
+	data, release, readErr := ab.Read()
+	defer release()
+	if readErr != nil {
+		m.logger.Error("buffer read error",
+			logger.String("source_id", cfg.sourceID),
+			logger.String("model_id", cfg.modelID),
+			logger.Error(readErr))
+		time.Sleep(1 * time.Second)
+		return true, hasReadBuffer
+	}
+
+	// Exact equality is required: AnalysisBuffer.Read returns overlapSize +
+	// readSize bytes or nil. A partial read means the buffer has not yet
+	// accumulated enough data.
+	if len(data) != analysisWindowBytes {
+		return true, hasReadBuffer
+	}
+
+	audioCapturedAt := time.Now()
+	// Calculate the offset dynamically to pick up runtime configuration changes.
+	beginTimeOffset := time.Duration(conf.Setting().Realtime.Audio.Export.PreCapture)*time.Second + detectionOffset
+	startTime := time.Now().Add(-beginTimeOffset)
+
+	if processErr := ProcessData(context.Background(), m.bn, m.bufferMgr, data, startTime, audioCapturedAt, cfg.sourceID, cfg.modelID); processErr != nil {
+		m.logger.Error("error processing data",
+			logger.String("source_id", cfg.sourceID),
+			logger.String("model_id", cfg.modelID),
+			logger.Error(processErr))
+	}
+	return true, hasReadBuffer
 }
 
 // buildMonitorConfig builds a monitorConfig from a ModelInfo.

--- a/internal/analysis/process.go
+++ b/internal/analysis/process.go
@@ -283,19 +283,29 @@ func ProcessData(ctx context.Context, bn *classifier.Orchestrator, bufMgr *buffe
 		DisplayName: source,
 	}
 
+	// The data slice is owned by the pooled AnalysisBuffer.Read path and is
+	// returned to its BytePool as soon as ProcessData returns (via the
+	// monitor's defer release()). The queue consumer retains PCMdata through
+	// filter evaluation and clip export, which outlive ProcessData. Without
+	// this copy a subsequent Read could hand the same backing array to a new
+	// caller while the consumer goroutine is still reading from it.
+	pcmCopy := make([]byte, len(data))
+	copy(pcmCopy, data)
+
 	// Create a Results message to be sent through queue to processor
 	resultsMessage := classifier.Results{
 		StartTime:       startTime,
 		AudioCapturedAt: audioCapturedAt,
 		ElapsedTime:     elapsedTime,
-		PCMdata:         data,
+		PCMdata:         pcmCopy,
 		Results:         results,
 		Source:          audioSource,
 		ModelID:         modelID,
 	}
 
-	// Send the results to the queue
-	// Note: No copy needed - ownership transfers to the queue consumer
+	// Send the results to the queue. PCMdata is the independently owned copy
+	// made above; per classifier.ResultsQueue's ownership contract the sender
+	// must not mutate it after the send.
 	select {
 	case classifier.ResultsQueue <- resultsMessage:
 		if pm != nil {

--- a/internal/audiocore/buffer/analysis.go
+++ b/internal/audiocore/buffer/analysis.go
@@ -184,9 +184,7 @@ func (ab *AnalysisBuffer) Write(data []byte) error {
 // Read is safe for concurrent use. The returned release func is bound to a
 // single call chain and must not be invoked from multiple goroutines; in
 // practice callers "defer release()" in the same goroutine as the Read call.
-//
-//nolint:gocritic // unnamedResult: naming the three results would shadow the internal `window`, `release`, and `err` locals used below; result positions are documented above.
-func (ab *AnalysisBuffer) Read() ([]byte, func(), error) {
+func (ab *AnalysisBuffer) Read() (window []byte, release func(), err error) {
 	ab.mu.Lock()
 	defer ab.mu.Unlock()
 
@@ -194,7 +192,6 @@ func (ab *AnalysisBuffer) Read() ([]byte, func(), error) {
 		return nil, noopRelease, nil
 	}
 
-	var window []byte
 	if ab.windowPool != nil {
 		window = ab.windowPool.Get()
 	} else {
@@ -209,12 +206,12 @@ func (ab *AnalysisBuffer) Read() ([]byte, func(), error) {
 		}
 	}
 
-	n, err := ab.ring.Read(window[ab.overlapSize : ab.overlapSize+ab.readSize])
-	if err != nil {
+	n, readErr := ab.ring.Read(window[ab.overlapSize : ab.overlapSize+ab.readSize])
+	if readErr != nil {
 		if ab.windowPool != nil {
 			ab.windowPool.Put(window)
 		}
-		return nil, noopRelease, errors.New(err).
+		return nil, noopRelease, errors.New(readErr).
 			Component("audiocore").
 			Category(errors.CategorySystem).
 			Context("operation", "analysis_buffer_read").
@@ -243,7 +240,7 @@ func (ab *AnalysisBuffer) Read() ([]byte, func(), error) {
 
 	pool := ab.windowPool
 	released := false
-	release := func() {
+	release = func() {
 		if released || pool == nil {
 			return
 		}

--- a/internal/audiocore/buffer/analysis.go
+++ b/internal/audiocore/buffer/analysis.go
@@ -28,10 +28,12 @@ type AnalysisBuffer struct {
 	prevData    []byte // tail of the previous read, used as overlap prefix
 	overlapSize int    // number of bytes to retain as overlap
 	readSize    int    // number of bytes to read from the ring per call
+	windowSize  int    // overlapSize + readSize, cached for pool lookups
 	sourceID    string // identifier used in log messages
 	tracker     *OverwriteTracker
 	mu          sync.Mutex
 	log         logger.Logger
+	windowPool  *BytePool // nil when unpooled; sized to windowSize when set
 }
 
 // NewAnalysisBuffer creates an AnalysisBuffer with a ring buffer of the given
@@ -40,8 +42,14 @@ type AnalysisBuffer struct {
 // fresh bytes consumed from the ring per Read call; the total returned slice
 // length is overlapSize+readSize.
 //
+// bufMgr is optional: when non-nil, the window slices are sourced from
+// bufMgr.BytePoolFor(overlapSize+readSize) and must be returned via the
+// release func that Read returns (added in a later commit). When bufMgr is
+// nil (test paths), window slices are allocated per Read and the release
+// func is a no-op.
+//
 // Returns an error if any dimension is not positive or if sourceID is empty.
-func NewAnalysisBuffer(capacity, overlapSize, readSize int, sourceID string, log logger.Logger) (*AnalysisBuffer, error) {
+func NewAnalysisBuffer(capacity, overlapSize, readSize int, sourceID string, log logger.Logger, bufMgr *Manager) (*AnalysisBuffer, error) {
 	if capacity <= 0 {
 		return nil, errors.Newf("invalid analysis buffer capacity: %d, must be greater than 0", capacity).
 			Component("audiocore").
@@ -115,13 +123,21 @@ func NewAnalysisBuffer(capacity, overlapSize, readSize int, sourceID string, log
 		Logger:         log,
 	}
 
+	windowSize := overlapSize + readSize
+	var windowPool *BytePool
+	if bufMgr != nil {
+		windowPool = bufMgr.BytePoolFor(windowSize)
+	}
+
 	return &AnalysisBuffer{
 		ring:        ring,
 		overlapSize: overlapSize,
 		readSize:    readSize,
+		windowSize:  windowSize,
 		sourceID:    sourceID,
 		tracker:     NewOverwriteTracker(trackerOpts),
 		log:         log,
+		windowPool:  windowPool,
 	}, nil
 }
 
@@ -201,7 +217,7 @@ func (ab *AnalysisBuffer) Read() ([]byte, error) {
 		if n >= ab.overlapSize {
 			copy(ab.prevData, fresh[n-ab.overlapSize:n])
 		} else {
-			// Fewer fresh bytes than overlap — zero-pad the beginning,
+			// Fewer fresh bytes than overlap, zero-pad the beginning,
 			// place available data at the end so the overlap slice
 			// always has exactly overlapSize length.
 			clear(ab.prevData)

--- a/internal/audiocore/buffer/analysis.go
+++ b/internal/audiocore/buffer/analysis.go
@@ -46,11 +46,10 @@ type AnalysisBuffer struct {
 // fresh bytes consumed from the ring per Read call; the total returned slice
 // length is overlapSize+readSize.
 //
-// bufMgr is optional: when non-nil, the window slices are sourced from
-// bufMgr.BytePoolFor(overlapSize+readSize) and must be returned via the
-// release func that Read returns (added in a later commit). When bufMgr is
-// nil (test paths), window slices are allocated per Read and the release
-// func is a no-op.
+// bufMgr is optional: when non-nil, the window slices that Read returns are
+// sourced from bufMgr.BytePoolFor(overlapSize+readSize) and must be returned
+// via the release func that Read returns. When bufMgr is nil (test paths),
+// window slices are allocated per Read and the release func is a no-op.
 //
 // Returns an error if any dimension is not positive or if sourceID is empty.
 func NewAnalysisBuffer(capacity, overlapSize, readSize int, sourceID string, log logger.Logger, bufMgr *Manager) (*AnalysisBuffer, error) {
@@ -186,9 +185,7 @@ func (ab *AnalysisBuffer) Write(data []byte) error {
 // single call chain and must not be invoked from multiple goroutines; in
 // practice callers "defer release()" in the same goroutine as the Read call.
 //
-// would shadow the internal `window`, `release`, and `err` locals used below.
-//
-//nolint:gocritic // unnamedResult: result positions are documented; naming them
+//nolint:gocritic // unnamedResult: naming the three results would shadow the internal `window`, `release`, and `err` locals used below; result positions are documented above.
 func (ab *AnalysisBuffer) Read() ([]byte, func(), error) {
 	ab.mu.Lock()
 	defer ab.mu.Unlock()

--- a/internal/audiocore/buffer/analysis.go
+++ b/internal/audiocore/buffer/analysis.go
@@ -189,8 +189,19 @@ func (ab *AnalysisBuffer) Read() ([]byte, error) {
 		return nil, nil
 	}
 
-	fresh := make([]byte, ab.readSize)
-	n, err := ab.ring.Read(fresh)
+	window := make([]byte, ab.windowSize)
+
+	// Overlap prefix: copy prevData when we have a valid tail, zero otherwise.
+	if ab.overlapSize > 0 {
+		if len(ab.prevData) == ab.overlapSize {
+			copy(window[:ab.overlapSize], ab.prevData)
+		} else {
+			clear(window[:ab.overlapSize])
+		}
+	}
+
+	// Read fresh bytes directly into the window's fresh region.
+	n, err := ab.ring.Read(window[ab.overlapSize : ab.overlapSize+ab.readSize])
 	if err != nil {
 		return nil, errors.New(err).
 			Component("audiocore").
@@ -202,26 +213,24 @@ func (ab *AnalysisBuffer) Read() ([]byte, error) {
 			Build()
 	}
 
-	// Build the full window: overlap prefix + fresh bytes.
-	window := make([]byte, ab.overlapSize+ab.readSize)
-	if ab.overlapSize > 0 && len(ab.prevData) == ab.overlapSize {
-		copy(window[:ab.overlapSize], ab.prevData)
+	// Defensive: zero any tail bytes the ring could not supply. In steady
+	// state n == readSize because of the Length precheck above; short reads
+	// are a defensive edge case.
+	if n < ab.readSize {
+		clear(window[ab.overlapSize+n:])
 	}
-	copy(window[ab.overlapSize:], fresh[:n])
 
-	// Advance the overlap cursor: save the last overlapSize bytes of fresh data.
+	// Advance the overlap cursor from the freshly-read region.
 	if ab.overlapSize > 0 {
 		if ab.prevData == nil {
 			ab.prevData = make([]byte, ab.overlapSize)
 		}
+		freshEnd := ab.overlapSize + n
 		if n >= ab.overlapSize {
-			copy(ab.prevData, fresh[n-ab.overlapSize:n])
+			copy(ab.prevData, window[freshEnd-ab.overlapSize:freshEnd])
 		} else {
-			// Fewer fresh bytes than overlap, zero-pad the beginning,
-			// place available data at the end so the overlap slice
-			// always has exactly overlapSize length.
 			clear(ab.prevData)
-			copy(ab.prevData[ab.overlapSize-n:], fresh[:n])
+			copy(ab.prevData[ab.overlapSize-n:], window[ab.overlapSize:freshEnd])
 		}
 	}
 

--- a/internal/audiocore/buffer/analysis.go
+++ b/internal/audiocore/buffer/analysis.go
@@ -17,6 +17,10 @@ const (
 	analysisOverwriteNotifyCooldown = 1 * time.Hour   // minimum time between warnings per source
 )
 
+// noopRelease is returned from Read when no pool is in use or when there was
+// no window to release. Safe to call any number of times.
+func noopRelease() {}
+
 // AnalysisBuffer is a lock-protected ring buffer designed for audio analysis.
 // It maintains per-instance overlap tracking so that consecutive reads share
 // a configurable number of bytes from the previous read, enabling BirdNET's
@@ -170,28 +174,36 @@ func (ab *AnalysisBuffer) Write(data []byte) error {
 	return nil
 }
 
-// Read returns the next analysis window as a byte slice of length
-// overlapSize+readSize. The first overlapSize bytes are the tail of the
-// previous successful read (the overlap region); the remaining readSize bytes
-// are freshly consumed from the ring buffer.
+// Read returns the next analysis window plus a release func that returns the
+// window's backing slice to the pool. release is never nil and is idempotent:
+// callers should "defer release()" to guarantee the slice is returned even on
+// error paths.
 //
-// Returns (nil, nil) when there is not yet enough data in the ring buffer for
-// a full readSize-byte read. Callers should treat nil data as "try again
-// later" rather than an error.
+// (nil, noopRelease, nil) is still the "try again later" signal when the ring
+// has not yet accumulated readSize bytes.
 //
-// Read is safe for concurrent use.
-func (ab *AnalysisBuffer) Read() ([]byte, error) {
+// Read is safe for concurrent use. The returned release func is bound to a
+// single call chain and must not be invoked from multiple goroutines; in
+// practice callers "defer release()" in the same goroutine as the Read call.
+//
+// would shadow the internal `window`, `release`, and `err` locals used below.
+//
+//nolint:gocritic // unnamedResult: result positions are documented; naming them
+func (ab *AnalysisBuffer) Read() ([]byte, func(), error) {
 	ab.mu.Lock()
 	defer ab.mu.Unlock()
 
-	// Wait until the ring holds at least readSize bytes.
 	if ab.ring.Length() < ab.readSize {
-		return nil, nil
+		return nil, noopRelease, nil
 	}
 
-	window := make([]byte, ab.windowSize)
+	var window []byte
+	if ab.windowPool != nil {
+		window = ab.windowPool.Get()
+	} else {
+		window = make([]byte, ab.windowSize)
+	}
 
-	// Overlap prefix: copy prevData when we have a valid tail, zero otherwise.
 	if ab.overlapSize > 0 {
 		if len(ab.prevData) == ab.overlapSize {
 			copy(window[:ab.overlapSize], ab.prevData)
@@ -200,10 +212,12 @@ func (ab *AnalysisBuffer) Read() ([]byte, error) {
 		}
 	}
 
-	// Read fresh bytes directly into the window's fresh region.
 	n, err := ab.ring.Read(window[ab.overlapSize : ab.overlapSize+ab.readSize])
 	if err != nil {
-		return nil, errors.New(err).
+		if ab.windowPool != nil {
+			ab.windowPool.Put(window)
+		}
+		return nil, noopRelease, errors.New(err).
 			Component("audiocore").
 			Category(errors.CategorySystem).
 			Context("operation", "analysis_buffer_read").
@@ -213,14 +227,10 @@ func (ab *AnalysisBuffer) Read() ([]byte, error) {
 			Build()
 	}
 
-	// Defensive: zero any tail bytes the ring could not supply. In steady
-	// state n == readSize because of the Length precheck above; short reads
-	// are a defensive edge case.
 	if n < ab.readSize {
 		clear(window[ab.overlapSize+n:])
 	}
 
-	// Advance the overlap cursor from the freshly-read region.
 	if ab.overlapSize > 0 {
 		if ab.prevData == nil {
 			ab.prevData = make([]byte, ab.overlapSize)
@@ -234,7 +244,16 @@ func (ab *AnalysisBuffer) Read() ([]byte, error) {
 		}
 	}
 
-	return window, nil
+	pool := ab.windowPool
+	released := false
+	release := func() {
+		if released || pool == nil {
+			return
+		}
+		released = true
+		pool.Put(window)
+	}
+	return window, release, nil
 }
 
 // OverwriteCount returns the number of overwrite events recorded in the

--- a/internal/audiocore/buffer/analysis_test.go
+++ b/internal/audiocore/buffer/analysis_test.go
@@ -43,17 +43,20 @@ func TestAnalysisBuffer_WriteRead(t *testing.T) {
 	// overlapSize+readSize yet (no previous overlap data yet).
 	// Keep writing and reading until we get data back.
 	var got []byte
+	var release func()
 	for range 10 {
-		got, err = ab.Read()
+		got, release, err = ab.Read()
 		require.NoError(t, err)
 		if got != nil {
 			break
 		}
+		release()
 		require.NoError(t, ab.Write(payload))
 	}
 
 	require.NotNil(t, got, "expected to read data back after enough writes")
 	assert.Len(t, got, overlapSize+readSize, "read should return overlapSize+readSize bytes")
+	release()
 }
 
 // TestAnalysisBuffer_Overwrite verifies that filling the buffer past capacity
@@ -127,13 +130,15 @@ func TestAnalysisBuffer_OverlapRead(t *testing.T) {
 	// Pump writes until we get a first successful read.
 	var first []byte
 	var readErr error
+	var firstRelease func()
 	for range 20 {
 		writeChunk(0xAA)
-		first, readErr = ab.Read()
+		first, firstRelease, readErr = ab.Read()
 		require.NoError(t, readErr)
 		if first != nil {
 			break
 		}
+		firstRelease()
 	}
 	require.NotNil(t, first, "first read should eventually return data")
 	assert.Len(t, first, totalSize)
@@ -142,16 +147,20 @@ func TestAnalysisBuffer_OverlapRead(t *testing.T) {
 	// Write another chunk so a second read succeeds.
 	for range 5 {
 		writeChunk(0xBB)
-		second, secErr := ab.Read()
+		second, secondRelease, secErr := ab.Read()
 		require.NoError(t, secErr)
 		if second != nil {
 			// The first overlapSize bytes of second must equal the last overlapSize
 			// bytes of first (the overlap region).
 			assert.Equal(t, first[readSize:], second[:overlapSize],
 				"overlap region of second read must match tail of first read")
+			secondRelease()
+			firstRelease()
 			return
 		}
+		secondRelease()
 	}
+	firstRelease()
 	t.Fatal("second read did not return data in time")
 }
 
@@ -210,21 +219,127 @@ func TestAnalysisBuffer_Read_ContentParity(t *testing.T) {
 
 	// First Read: no prior overlap; prefix is zero-filled, fresh region is
 	// stream[0:readSize].
-	win1, err := ab.Read()
+	win1, release1, err := ab.Read()
 	require.NoError(t, err)
 	require.Len(t, win1, overlapSize+readSize)
 
 	wantPrefix1 := make([]byte, overlapSize) // zeros
 	assert.Equal(t, wantPrefix1, win1[:overlapSize], "first Read prefix must be zero")
 	assert.Equal(t, stream[0:readSize], win1[overlapSize:], "first Read fresh region")
+	release1()
 
 	// Second Read: prefix is the tail overlapSize bytes of the previous
 	// fresh region (stream[readSize-overlapSize:readSize]); fresh is
 	// stream[readSize:2*readSize].
-	win2, err := ab.Read()
+	win2, release2, err := ab.Read()
 	require.NoError(t, err)
 	require.Len(t, win2, overlapSize+readSize)
 
 	assert.Equal(t, stream[readSize-overlapSize:readSize], win2[:overlapSize], "second Read prefix")
 	assert.Equal(t, stream[readSize:2*readSize], win2[overlapSize:], "second Read fresh region")
+	release2()
+}
+
+// TestAnalysisBuffer_Read_ReleaseIdempotent verifies that calling the release
+// func multiple times is safe and does not double-Put to the pool.
+func TestAnalysisBuffer_Read_ReleaseIdempotent(t *testing.T) {
+	t.Parallel()
+	const (
+		capacity    = 4096
+		overlapSize = 32
+		readSize    = 128
+	)
+	mgr := buffer.NewManager(newTestLogger())
+	ab, err := buffer.NewAnalysisBuffer(capacity, overlapSize, readSize, "idemp-source", newTestLogger(), mgr)
+	require.NoError(t, err)
+
+	require.NoError(t, ab.Write(make([]byte, readSize*2)))
+
+	_, release, err := ab.Read()
+	require.NoError(t, err)
+	require.NotNil(t, release)
+
+	pool := mgr.BytePoolFor(overlapSize + readSize)
+	require.NotNil(t, pool)
+
+	beforeStats := pool.GetStats()
+	release()
+	release()
+	release()
+	afterStats := pool.GetStats()
+
+	assert.Equal(t, beforeStats.Discarded, afterStats.Discarded,
+		"release must not double-Put (which would increment Discarded on a mismatched second call)")
+}
+
+// TestAnalysisBuffer_Read_TryAgainLaterReleaseIsNoop asserts the sentinel
+// release on the try-again-later path is safe.
+func TestAnalysisBuffer_Read_TryAgainLaterReleaseIsNoop(t *testing.T) {
+	t.Parallel()
+	mgr := buffer.NewManager(newTestLogger())
+	ab, err := buffer.NewAnalysisBuffer(4096, 32, 128, "try-again-source", newTestLogger(), mgr)
+	require.NoError(t, err)
+
+	data, release, err := ab.Read()
+	require.NoError(t, err)
+	assert.Nil(t, data)
+	require.NotNil(t, release)
+
+	pool := mgr.BytePoolFor(32 + 128)
+	require.NotNil(t, pool)
+	before := pool.GetStats()
+	release()
+	release()
+	after := pool.GetStats()
+	assert.Equal(t, before, after, "try-again-later release must be a no-op")
+}
+
+// TestAnalysisBuffer_Read_BoundedAllocsWhenWarm asserts the pooled Read path
+// stays within a small, fixed allocation budget per iteration once the pool
+// is warm. See the per-allocation accounting in the assertion comment.
+func TestAnalysisBuffer_Read_BoundedAllocsWhenWarm(t *testing.T) {
+	const (
+		capacity    = 32768
+		overlapSize = 128
+		readSize    = 512
+	)
+	mgr := buffer.NewManager(newTestLogger())
+	ab, err := buffer.NewAnalysisBuffer(capacity, overlapSize, readSize, "bounded-alloc-source", newTestLogger(), mgr)
+	require.NoError(t, err)
+
+	payload := make([]byte, readSize*2)
+	for i := range payload {
+		payload[i] = byte(i)
+	}
+
+	require.NoError(t, ab.Write(payload))
+	_, release, err := ab.Read()
+	require.NoError(t, err)
+	release()
+
+	allocs := testing.AllocsPerRun(100, func() {
+		if err := ab.Write(payload); err != nil {
+			t.Fatal(err)
+		}
+		_, release, err := ab.Read()
+		if err != nil {
+			t.Fatal(err)
+		}
+		release()
+	})
+
+	// The pooled Read path retains three small unavoidable allocations per
+	// call on top of whatever sync.Pool happens to cache:
+	//   1. the release closure escapes because it is returned to the caller,
+	//   2. the closure captures a local `released` bool by reference,
+	//   3. buffer.BytePool.Put boxes the []byte into an interface{} to store
+	//      it in sync.Pool (accepted project-wide via SA6002 nolint).
+	// Under -race the counter can tick up to 4; budget 5 to keep the test
+	// stable while still catching a regression to the per-Read
+	// make([]byte, windowSize) that Task 2 eliminated (a ~640-byte alloc
+	// per tick which would blow this budget immediately).
+	const maxAllocsPerWarmRead = 5
+	assert.LessOrEqualf(t, allocs, float64(maxAllocsPerWarmRead),
+		"AnalysisBuffer.Read + Write loop must stay within %d allocs/op once warm; got %v. A large jump usually means the window slice returned to make() rather than the pool.",
+		maxAllocsPerWarmRead, allocs)
 }

--- a/internal/audiocore/buffer/analysis_test.go
+++ b/internal/audiocore/buffer/analysis_test.go
@@ -29,7 +29,7 @@ func TestAnalysisBuffer_WriteRead(t *testing.T) {
 		readSize    = 1024
 	)
 
-	ab, err := buffer.NewAnalysisBuffer(capacity, overlapSize, readSize, "test-source", newTestLogger())
+	ab, err := buffer.NewAnalysisBuffer(capacity, overlapSize, readSize, "test-source", newTestLogger(), nil)
 	require.NoError(t, err)
 
 	// Write enough data so that one full read is possible (readSize bytes).
@@ -67,7 +67,7 @@ func TestAnalysisBuffer_Overwrite(t *testing.T) {
 		readSize    = 256
 	)
 
-	ab, err := buffer.NewAnalysisBuffer(capacity, overlapSize, readSize, "overwrite-source", newTestLogger())
+	ab, err := buffer.NewAnalysisBuffer(capacity, overlapSize, readSize, "overwrite-source", newTestLogger(), nil)
 	require.NoError(t, err)
 
 	// Write data that exceeds the buffer capacity to force overwrites.
@@ -94,7 +94,7 @@ func TestAnalysisBuffer_Overwrite(t *testing.T) {
 func TestAnalysisBuffer_ReadSizeLessThanOverlapSize(t *testing.T) {
 	t.Parallel()
 
-	_, err := buffer.NewAnalysisBuffer(4096, 1024, 512, "test-source", newTestLogger())
+	_, err := buffer.NewAnalysisBuffer(4096, 1024, 512, "test-source", newTestLogger(), nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "read size 512 must be >= overlap size 1024")
 }
@@ -111,7 +111,7 @@ func TestAnalysisBuffer_OverlapRead(t *testing.T) {
 		totalSize   = overlapSize + readSize
 	)
 
-	ab, err := buffer.NewAnalysisBuffer(capacity, overlapSize, readSize, "overlap-source", newTestLogger())
+	ab, err := buffer.NewAnalysisBuffer(capacity, overlapSize, readSize, "overlap-source", newTestLogger(), nil)
 	require.NoError(t, err)
 
 	// Helper: write enough bytes for one full chunk to be readable.

--- a/internal/audiocore/buffer/analysis_test.go
+++ b/internal/audiocore/buffer/analysis_test.go
@@ -185,3 +185,46 @@ func TestOverwriteTracker_RateCalculation(t *testing.T) {
 	tracker.Reset()
 	assert.InDelta(t, 0.0, tracker.OverwriteRate(), 0.01, "rate should be zero after Reset")
 }
+
+// TestAnalysisBuffer_Read_ContentParity asserts that consecutive Read calls
+// return byte-identical windows to what the pre-refactor implementation would
+// produce: an overlapSize prefix of prior fresh tail bytes, followed by
+// readSize fresh bytes from the ring. Guards the in-place ring.Read refactor
+// against off-by-one errors and prevData advancement regressions.
+func TestAnalysisBuffer_Read_ContentParity(t *testing.T) {
+	t.Parallel()
+	const (
+		capacity    = 4096
+		overlapSize = 32
+		readSize    = 128
+	)
+	ab, err := buffer.NewAnalysisBuffer(capacity, overlapSize, readSize, "parity-source", newTestLogger(), nil)
+	require.NoError(t, err)
+
+	// Write a monotonically increasing byte stream so we can predict contents.
+	stream := make([]byte, readSize*4)
+	for i := range stream {
+		stream[i] = byte(i & 0xFF)
+	}
+	require.NoError(t, ab.Write(stream))
+
+	// First Read: no prior overlap; prefix is zero-filled, fresh region is
+	// stream[0:readSize].
+	win1, err := ab.Read()
+	require.NoError(t, err)
+	require.Len(t, win1, overlapSize+readSize)
+
+	wantPrefix1 := make([]byte, overlapSize) // zeros
+	assert.Equal(t, wantPrefix1, win1[:overlapSize], "first Read prefix must be zero")
+	assert.Equal(t, stream[0:readSize], win1[overlapSize:], "first Read fresh region")
+
+	// Second Read: prefix is the tail overlapSize bytes of the previous
+	// fresh region (stream[readSize-overlapSize:readSize]); fresh is
+	// stream[readSize:2*readSize].
+	win2, err := ab.Read()
+	require.NoError(t, err)
+	require.Len(t, win2, overlapSize+readSize)
+
+	assert.Equal(t, stream[readSize-overlapSize:readSize], win2[:overlapSize], "second Read prefix")
+	assert.Equal(t, stream[readSize:2*readSize], win2[overlapSize:], "second Read fresh region")
+}

--- a/internal/audiocore/buffer/analysis_test.go
+++ b/internal/audiocore/buffer/analysis_test.go
@@ -343,3 +343,41 @@ func TestAnalysisBuffer_Read_BoundedAllocsWhenWarm(t *testing.T) {
 		"AnalysisBuffer.Read + Write loop must stay within %d allocs/op once warm; got %v. A large jump usually means the window slice returned to make() rather than the pool.",
 		maxAllocsPerWarmRead, allocs)
 }
+
+// BenchmarkAnalysisBuffer_Read reports the per-Read allocation rate on the
+// pooled path. Advisory only; the regression gate is
+// TestAnalysisBuffer_Read_BoundedAllocsWhenWarm.
+func BenchmarkAnalysisBuffer_Read(b *testing.B) {
+	const (
+		capacity    = 32768
+		overlapSize = 128
+		readSize    = 512
+	)
+	mgr := buffer.NewManager(newTestLogger())
+	ab, err := buffer.NewAnalysisBuffer(capacity, overlapSize, readSize, "bench-source", newTestLogger(), mgr)
+	require.NoError(b, err)
+
+	payload := make([]byte, readSize*2)
+	for i := range payload {
+		payload[i] = byte(i)
+	}
+
+	// Warm.
+	require.NoError(b, ab.Write(payload))
+	_, release, err := ab.Read()
+	require.NoError(b, err)
+	release()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		if err := ab.Write(payload); err != nil {
+			b.Fatal(err)
+		}
+		_, release, err := ab.Read()
+		if err != nil {
+			b.Fatal(err)
+		}
+		release()
+	}
+}

--- a/internal/audiocore/buffer/manager.go
+++ b/internal/audiocore/buffer/manager.go
@@ -72,7 +72,7 @@ func (m *Manager) AllocateAnalysis(sourceID, modelID string, capacity, overlapSi
 		return fmt.Errorf("analysis buffer already allocated for source %q model %q", sourceID, modelID)
 	}
 
-	ab, err := NewAnalysisBuffer(capacity, overlapSize, readSize, sourceID, m.logger)
+	ab, err := NewAnalysisBuffer(capacity, overlapSize, readSize, sourceID, m.logger, m)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

Cuts the remaining per-Read allocation churn in `AnalysisBuffer.Read` by pooling the returned byte window through the shared `buffer.Manager`. On top of that, the redundant `fresh` intermediate slice is gone: `ring.Read` now writes directly into `window[overlapSize:overlapSize+readSize]`.

`Read` signature is now `([]byte, func(), error)`. The returned release func is non-nil on every path (including the try-again-later `nil` window), idempotent, and safe for the monitor's `defer release()` pattern. Monitor iteration is extracted into a named `processMonitorTick` method so the defer is scoped to one tick rather than the goroutine lifetime.

The pooled path is not strictly zero-alloc (the release closure escapes, its captured `released` bool escapes, and `sync.Pool.Put([]byte)` incurs the SA6002 interface box this package already accepts). A bounded-allocs test gates at 5 allocs/op, which catches the real regression: a return to per-Read `make([]byte, windowSize)` would blow the budget immediately.

## Commits

- `refactor(audiocore/buffer): thread buffer.Manager into NewAnalysisBuffer` - optional `bufMgr` parameter, `windowSize` field, `windowPool` field. No behavioural change.
- `refactor(audiocore/buffer): eliminate fresh intermediate in AnalysisBuffer.Read` - in-place `ring.Read` into the window; content-parity test as baseline gate.
- `refactor(audiocore/buffer): pool AnalysisBuffer.Read window via buffer.Manager` - the central signature change; all callers updated atomically; idempotency + try-again + bounded-allocs tests.
- `refactor(analysis): extract processMonitorTick for per-tick release scoping` - replaces the intermediate IIFE with a named method so `defer release()` scopes correctly.
- `test(audiocore/buffer): add advisory benchmark for AnalysisBuffer.Read` - 0 alloc target is not reached per the SA6002 tradeoff; benchmark reports current state (~3 allocs/op, ~73 B/op).
- `docs(audiocore/buffer): clean up NewAnalysisBuffer and Read doc comments` - merges a nolint directive split by gofmt; rewrites a now-stale paragraph.

## Test plan

- [x] `go test -race ./internal/audiocore/buffer/... ./internal/analysis/...` passes.
- [x] `golangci-lint run -v` clean (28 linters, 0 issues).
- [x] `TestAnalysisBuffer_Read_ContentParity` passes against both the pre-refactor and post-refactor paths (used as a baseline gate during the refactor).
- [x] `TestAnalysisBuffer_Read_ReleaseIdempotent` guards against double-Put.
- [x] `TestAnalysisBuffer_Read_TryAgainLaterReleaseIsNoop` guards the nil-data sentinel.
- [x] `TestAnalysisBuffer_Read_BoundedAllocsWhenWarm` caps allocs/op at 5 (measured 3 under `-race`).
- [x] `BenchmarkAnalysisBuffer_Read` reports ~3 allocs/op and ~73 B/op on the warm pool path.
- [x] Local CodeRabbit review: no findings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved buffer resource handling with pooled windows and guaranteed release to lower allocations and improve runtime stability.

* **Bug Fixes**
  * Prevented accidental mutation of audio payloads by ensuring processors receive independent copies.

* **Tests**
  * Added/updated tests for release idempotency, allocation budgets, content consistency, and pooled-path performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->