### PR TITLE
test(analysis,audiocore): port flaky tests to testing/synctest

### DIFF
--- a/internal/analysis/sound_level_manager_test.go
+++ b/internal/analysis/sound_level_manager_test.go
@@ -3,6 +3,7 @@ package analysis
 import (
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -109,45 +110,27 @@ func TestSoundLevelManagerChannelCommunication(t *testing.T) {
 	close(soundLevelChan)
 }
 
-// TestHotReloadIntegrationBasic provides a basic integration test framework
+// TestHotReloadIntegrationBasic provides a basic integration test framework.
+// Uses testing/synctest so the wg.Wait completion is deterministic rather
+// than racing a 2s wall-clock timeout on loaded CI runners (Forgejo #459).
 func TestHotReloadIntegrationBasic(t *testing.T) {
-	// This test demonstrates the hot reload pattern without dependencies
+	synctest.Test(t, func(t *testing.T) {
+		soundLevelChan := make(chan soundlevel.SoundLevelData, 100)
+		manager := NewSoundLevelManager(soundLevelChan, nil, nil, nil)
 
-	// 1. Create components
-	soundLevelChan := make(chan soundlevel.SoundLevelData, 100)
-	manager := NewSoundLevelManager(soundLevelChan, nil, nil, nil)
+		var wg sync.WaitGroup
+		var restartErr error
+		wg.Go(func() {
+			time.Sleep(50 * time.Millisecond)
+			restartErr = manager.Restart()
+		})
 
-	// 2. Simulate configuration change and restart
-	var wg sync.WaitGroup
-
-	// Simulate control monitor sending restart signal
-	wg.Go(func() {
-
-		// Wait a bit then trigger restart
-		time.Sleep(50 * time.Millisecond)
-
-		// In real implementation, this would be triggered by control monitor
-		err := manager.Restart()
-		assert.NoError(t, err, "Restart should not error")
-	})
-
-	// 3. Verify restart completes
-	done := make(chan struct{})
-	go func() {
 		wg.Wait()
-		close(done)
-	}()
+		require.NoError(t, restartErr, "Restart should not error")
 
-	select {
-	case <-done:
-		// Success - restart completed
-	case <-time.After(2 * time.Second):
-		require.Fail(t, "Hot reload simulation timed out")
-	}
-
-	// 4. Cleanup
-	manager.Stop()
-	close(soundLevelChan)
+		manager.Stop()
+		close(soundLevelChan)
+	})
 }
 
 // TestSoundLevelManagerNilSafety verifies nil pointer safety

--- a/internal/analysis/sound_level_manager_test.go
+++ b/internal/analysis/sound_level_manager_test.go
@@ -116,7 +116,11 @@ func TestSoundLevelManagerChannelCommunication(t *testing.T) {
 func TestHotReloadIntegrationBasic(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		soundLevelChan := make(chan soundlevel.SoundLevelData, 100)
+		defer close(soundLevelChan)
 		manager := NewSoundLevelManager(soundLevelChan, nil, nil, nil)
+		// Defer inside the bubble so cleanup also runs if require.NoError
+		// below aborts; t.Cleanup would run after synctest.Test returns.
+		defer manager.Stop()
 
 		var wg sync.WaitGroup
 		var restartErr error
@@ -127,9 +131,6 @@ func TestHotReloadIntegrationBasic(t *testing.T) {
 
 		wg.Wait()
 		require.NoError(t, restartErr, "Restart should not error")
-
-		manager.Stop()
-		close(soundLevelChan)
 	})
 }
 

--- a/internal/audiocore/router_test.go
+++ b/internal/audiocore/router_test.go
@@ -327,7 +327,7 @@ func TestRouter_ConcurrentDispatch(t *testing.T) {
 		// progress; each outer iteration that pulls zero frames proves
 		// the drainers are parked on the select rather than on a full
 		// consumer channel, so forwarding is complete.
-		drained := 0
+		d1, d2 := 0, 0
 		for {
 			synctest.Wait()
 			got := 0
@@ -335,9 +335,10 @@ func TestRouter_ConcurrentDispatch(t *testing.T) {
 			for {
 				select {
 				case <-c1.frames:
-					drained++
+					d1++
 					got++
 				case <-c2.frames:
+					d2++
 					got++
 				default:
 					break drain
@@ -347,7 +348,8 @@ func TestRouter_ConcurrentDispatch(t *testing.T) {
 				break
 			}
 		}
-		assert.Positive(t, drained, "at least some frames should have been delivered")
+		assert.Positive(t, d1, "c1 should receive at least one frame")
+		assert.Positive(t, d2, "c2 should receive at least one frame")
 	})
 }
 

--- a/internal/audiocore/router_test.go
+++ b/internal/audiocore/router_test.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -293,41 +294,61 @@ func TestRouter_DispatchWithResampling(t *testing.T) {
 
 // TestRouter_ConcurrentDispatch verifies that concurrent dispatch from
 // multiple goroutines does not trigger data races (run with -race).
+// Uses testing/synctest so the drain assertion does not race the per-route
+// drainer goroutine on loaded CI runners (see Forgejo #453).
 func TestRouter_ConcurrentDispatch(t *testing.T) {
-	t.Parallel()
-	router := NewAudioRouter(GetLogger(), nil)
-	t.Cleanup(func() { router.Close() })
+	synctest.Test(t, func(t *testing.T) {
+		router := NewAudioRouter(GetLogger(), nil)
+		// Close inside the bubble so the drainer goroutines exit before
+		// synctest.Test waits for bubble goroutines to finish; t.Cleanup
+		// runs after synctest.Test returns and would deadlock.
+		defer router.Close()
 
-	c1 := newMockConsumer("consumer-1")
-	c2 := newMockConsumer("consumer-2")
-	require.NoError(t, router.AddRoute("src-1", c1, 48000, 0.0, nil))
-	require.NoError(t, router.AddRoute("src-1", c2, 48000, 0.0, nil))
+		c1 := newMockConsumer("consumer-1")
+		c2 := newMockConsumer("consumer-2")
+		require.NoError(t, router.AddRoute("src-1", c1, 48000, 0.0, nil))
+		require.NoError(t, router.AddRoute("src-1", c2, 48000, 0.0, nil))
 
-	const goroutines = 8
-	const framesPerGoroutine = 100
+		const goroutines = 8
+		const framesPerGoroutine = 100
 
-	var wg sync.WaitGroup
-	for range goroutines {
-		wg.Go(func() {
-			for range framesPerGoroutine {
-				router.Dispatch(testFrame("src-1"))
-			}
-		})
-	}
-	wg.Wait()
-
-	// Drain what we can — the point is no race detected.
-	drained := 0
-	for {
-		select {
-		case <-c1.frames:
-			drained++
-		default:
-			goto done
+		var wg sync.WaitGroup
+		for range goroutines {
+			wg.Go(func() {
+				for range framesPerGoroutine {
+					router.Dispatch(testFrame("src-1"))
+				}
+			})
 		}
-	}
-done:
-	assert.Positive(t, drained, "at least some frames should have been delivered")
+		wg.Wait()
+
+		// Drain both consumer channels until the drainer goroutines are
+		// blocked on empty inboxes. synctest.Wait lets the drainer make
+		// progress; each outer iteration that pulls zero frames proves
+		// the drainers are parked on the select rather than on a full
+		// consumer channel, so forwarding is complete.
+		drained := 0
+		for {
+			synctest.Wait()
+			got := 0
+		drain:
+			for {
+				select {
+				case <-c1.frames:
+					drained++
+					got++
+				case <-c2.frames:
+					got++
+				default:
+					break drain
+				}
+			}
+			if got == 0 {
+				break
+			}
+		}
+		assert.Positive(t, drained, "at least some frames should have been delivered")
+	})
 }
 
 func TestDrainRoutePanicRecovery(t *testing.T) {


### PR DESCRIPTION
## Summary

Both tests relied on wall-clock timeouts that were insufficient under `-race` instrumentation on loaded CI runners, producing intermittent failures even though the production code was correct.

- `TestRouter_ConcurrentDispatch` (`internal/audiocore/router_test.go`) used a non-blocking drain after `wg.Wait()` that raced the per-route drainer goroutine, so a slow drainer could leave `c1.frames` empty and fail the `assert.Positive(drained, ...)` check.
- `TestHotReloadIntegrationBasic` (`internal/analysis/sound_level_manager_test.go`) wrapped `wg.Wait()` in a `select` with a 2s `time.After`, and under race-instrumented CI the 2s budget was occasionally exceeded.

Both tests now run inside a `testing/synctest` bubble:

- The router test loops `synctest.Wait` + a non-blocking drain of both consumer channels until an iteration pulls zero frames, which proves every drainer is parked on the select (empty inbox) rather than on a full consumer channel, so forwarding is complete before the assertion.
- The hot-reload test drops the `select` / `time.After` altogether; the bubble's deadlock detection substitutes for the wall-clock timeout and is deterministic.

The router test closes the router via `defer` rather than `t.Cleanup` because `t.Cleanup` runs after `synctest.Test` returns, which would deadlock the bubble while drainer goroutines still reference live routes.

## Test plan

- [x] `go test -race -count=50 -run TestRouter_ConcurrentDispatch ./internal/audiocore/` (50/50 pass)
- [x] `go test -race -count=50 -run TestHotReloadIntegrationBasic ./internal/analysis/` (50/50 pass)
- [x] `go test -race ./internal/audiocore/ ./internal/analysis/` (full packages green)
- [x] `golangci-lint run -v ./internal/audiocore/... ./internal/analysis/...` (0 issues)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved reliability of sound-level manager tests by replacing fixed time-based waits with deterministic synchronization and clearer error reporting.
  * Hardened audio router tests to ensure orderly shutdown and more robust verification of concurrent dispatch and consumer draining under concurrent load.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->