### PR TITLE
fix(analysis): defer SaveAudioAction read for Extended Capture tails

### DIFF
--- a/internal/analysis/processor/actions_database.go
+++ b/internal/analysis/processor/actions_database.go
@@ -14,9 +14,16 @@ import (
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/detection"
+	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/events"
 	"github.com/tphakala/birdnet-go/internal/logger"
 )
+
+// errAudioExportDeferred signals that SaveAudioAction cannot yet read the
+// requested capture segment because the tail of the clip is still being
+// written (Extended Capture). The job queue's retry mechanism re-runs the
+// action after a backoff delay until the buffer has caught up.
+var errAudioExportDeferred = errors.NewStd("audio export deferred until capture tail is available")
 
 // Execute logs the note to the log file.
 // Note: File logging errors are logged but not returned. This is intentional because:
@@ -293,6 +300,34 @@ func (a *SaveAudioAction) Execute(ctx context.Context, _ any) error {
 			logger.String("clip_name", a.ClipName),
 			logger.String("operation", "audio_export_disabled"))
 		return nil
+	}
+
+	// Deferred-read path: Extended Capture may schedule an export whose tail
+	// still has not been written to the ring buffer. buildSaveAudioAction
+	// populates bufferMgr/sourceID/beginTime/duration/readyAt and leaves
+	// pcmData empty in that case. If readyAt is still in the future, return
+	// errAudioExportDeferred so the job queue retries with backoff; once the
+	// window has fully written, read the segment and fall through to encode.
+	if len(a.pcmData) == 0 && a.bufferMgr != nil && a.duration > 0 {
+		if time.Until(a.readyAt) > 0 {
+			return errAudioExportDeferred
+		}
+
+		cb, err := a.bufferMgr.CaptureBuffer(a.sourceID)
+		if err != nil {
+			return err
+		}
+
+		endTime := a.beginTime.Add(time.Duration(a.duration) * time.Second)
+		pcmData, err := cb.ReadSegment(a.beginTime, endTime)
+		if err != nil {
+			// ErrInsufficientData and any other read error unwind to the
+			// job-queue retry layer via the SaveAudioAction case in
+			// getJobQueueRetryConfig (workers.go). No special per-error
+			// handling is needed here.
+			return err
+		}
+		a.pcmData = pcmData
 	}
 
 	// If PCM data was not captured (e.g., buffer read failed), skip export.

--- a/internal/analysis/processor/actions_types.go
+++ b/internal/analysis/processor/actions_types.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/tphakala/birdnet-go/internal/analysis/jobqueue"
 	"github.com/tphakala/birdnet-go/internal/analysis/species"
+	"github.com/tphakala/birdnet-go/internal/audiocore/buffer"
 	"github.com/tphakala/birdnet-go/internal/birdweather"
 	"github.com/tphakala/birdnet-go/internal/classifier"
 	"github.com/tphakala/birdnet-go/internal/conf"
@@ -92,9 +93,19 @@ type DatabaseAction struct {
 }
 
 type SaveAudioAction struct {
-	Settings      *conf.Settings
-	ClipName      string
-	pcmData       []byte            // Pre-read PCM data (set by buildSaveAudioAction)
+	Settings *conf.Settings
+	ClipName string
+	pcmData  []byte // Pre-read PCM data (set by buildSaveAudioAction)
+	// Deferred-read fields. These are populated instead of pcmData when the
+	// requested capture range ends in the future (e.g. Extended Capture is
+	// still writing the tail of the clip). Execute() reads from the capture
+	// buffer once readyAt has passed, and the job queue retries the action
+	// in the meantime.
+	bufferMgr     *buffer.Manager
+	sourceID      string
+	beginTime     time.Time
+	duration      int
+	readyAt       time.Time
 	NoteID        uint              // Note ID for correlation logging with pre-renderer
 	PreRenderer   PreRendererSubmit // Injected from processor
 	DetectionCtx  *DetectionContext // Shared context to signal ClipSaved to late consumers

--- a/internal/analysis/processor/processor.go
+++ b/internal/analysis/processor/processor.go
@@ -1896,6 +1896,31 @@ func (p *Processor) buildSaveAudioAction(det *Detections, detectionCtx *Detectio
 		captureLength = bufferCap
 	}
 
+	// Extended Capture may request a segment whose tail has not yet been
+	// written to the ring buffer (e.g. BeginTime was a few seconds ago but
+	// the configured capture length runs well into the future). Reading
+	// immediately would fail with ErrInsufficientData and silently drop the
+	// clip. Defer the read to SaveAudioAction so the job-queue retry
+	// mechanism picks it up once the buffer has caught up to captureEndTime.
+	// Only take this path when BufferMgr is available; if it is nil the
+	// eager read below will produce a proper error log and no-op action.
+	captureEndTime := det.Result.BeginTime.Add(time.Duration(captureLength) * time.Second)
+	if p.BufferMgr != nil && captureEndTime.After(time.Now()) {
+		return &SaveAudioAction{
+			Settings:      p.Settings,
+			ClipName:      det.Result.ClipName,
+			bufferMgr:     p.BufferMgr,
+			sourceID:      det.Result.AudioSource.ID,
+			beginTime:     det.Result.BeginTime,
+			duration:      captureLength,
+			readyAt:       captureEndTime,
+			NoteID:        det.Result.ID, // May be 0 here; updated after DB save via DetectionCtx
+			PreRenderer:   p.preRenderer,
+			DetectionCtx:  detectionCtx,
+			CorrelationID: det.CorrelationID,
+		}
+	}
+
 	// Read PCM data from the capture buffer NOW, while the data is still in the
 	// ring buffer. By the time the job queue picks up the SaveAudioAction, the
 	// buffer may have been overwritten with newer audio data.

--- a/internal/analysis/processor/save_audio_action_test.go
+++ b/internal/analysis/processor/save_audio_action_test.go
@@ -1,0 +1,200 @@
+// Tests for SaveAudioAction deferred-read behavior used by Extended Capture.
+// These tests cover the path introduced when buildSaveAudioAction can't read
+// the capture segment immediately because the tail of the clip has not been
+// written to the ring buffer yet.
+
+package processor
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	audioBuffer "github.com/tphakala/birdnet-go/internal/audiocore/buffer"
+	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/errors"
+)
+
+func TestSaveAudioActionExecute_DefersUntilCaptureReady(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	settings := conf.NewTestSettings().
+		WithAudioExport(tmpDir, "wav", "192k").
+		Build()
+
+	mgr := audioBuffer.NewManager(GetLogger())
+
+	action := &SaveAudioAction{
+		Settings:  settings,
+		ClipName:  "deferred.wav",
+		bufferMgr: mgr,
+		sourceID:  "test-source",
+		beginTime: time.Now(),
+		duration:  2,
+		// Use a generous margin so a CI runner that delays test dispatch
+		// still sees readyAt as "in the future" when Execute runs. A
+		// shorter value (e.g. 100 ms) was observed to be flaky under load.
+		readyAt: time.Now().Add(5 * time.Second),
+	}
+
+	err := action.Execute(t.Context(), nil)
+	require.Error(t, err)
+	require.ErrorIs(t, err, errAudioExportDeferred)
+}
+
+func TestSaveAudioActionExecute_ReadsDeferredCaptureWhenReady(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	settings := conf.NewTestSettings().
+		WithAudioExport(tmpDir, "wav", "192k").
+		Build()
+
+	mgr := audioBuffer.NewManager(GetLogger())
+	sourceID := "test-source"
+	require.NoError(t, mgr.AllocateCapture(sourceID, 10, conf.SampleRate, conf.BitDepth/8))
+
+	cb, err := mgr.CaptureBuffer(sourceID)
+	require.NoError(t, err)
+
+	// Write three seconds of deterministic PCM so ReadSegment has data to
+	// return for the two-second window requested below.
+	const writeSeconds = 3
+	chunk := make([]byte, writeSeconds*conf.SampleRate*(conf.BitDepth/8))
+	for i := range chunk {
+		chunk[i] = byte(i % 251)
+	}
+	require.NoError(t, cb.Write(chunk))
+
+	action := &SaveAudioAction{
+		Settings:  settings,
+		ClipName:  "deferred.wav",
+		bufferMgr: mgr,
+		sourceID:  sourceID,
+		beginTime: cb.StartTime(),
+		duration:  2,
+		readyAt:   time.Now().Add(-time.Second),
+	}
+
+	require.NoError(t, action.Execute(t.Context(), nil))
+
+	outputPath := filepath.Join(tmpDir, "deferred.wav")
+	info, err := os.Stat(outputPath)
+	require.NoError(t, err)
+	assert.Positive(t, info.Size())
+}
+
+func TestSaveAudioActionExecute_PropagatesBufferReadError(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	settings := conf.NewTestSettings().
+		WithAudioExport(tmpDir, "wav", "192k").
+		Build()
+
+	mgr := audioBuffer.NewManager(GetLogger())
+	// Deliberately do not allocate a capture buffer for this sourceID so
+	// CaptureBuffer() returns an error. Execute should surface that error
+	// instead of silently dropping the clip.
+	action := &SaveAudioAction{
+		Settings:  settings,
+		ClipName:  "deferred.wav",
+		bufferMgr: mgr,
+		sourceID:  "missing-source",
+		beginTime: time.Now().Add(-10 * time.Second),
+		duration:  2,
+		readyAt:   time.Now().Add(-time.Second),
+	}
+
+	err := action.Execute(t.Context(), nil)
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, errAudioExportDeferred)
+}
+
+func TestGetJobQueueRetryConfig_SaveAudioDeferred(t *testing.T) {
+	t.Parallel()
+
+	mgr := audioBuffer.NewManager(GetLogger())
+
+	cfg := getJobQueueRetryConfig(&SaveAudioAction{
+		bufferMgr: mgr,
+		sourceID:  "test-source",
+		duration:  10,
+		readyAt:   time.Now().Add(time.Second),
+	})
+
+	// Pin the backoff parameters so an accidental change to workers.go
+	// fails this test instead of silently altering production behavior.
+	assert.True(t, cfg.Enabled)
+	assert.Equal(t, saveAudioDeferredInitialDelay, cfg.InitialDelay)
+	assert.Equal(t, saveAudioDeferredMaxDelay, cfg.MaxDelay)
+	assert.InEpsilon(t, saveAudioDeferredMultiplier, cfg.Multiplier, 0.001)
+	// Short clips (10s + 30s margin = 40s) fit within the exponential
+	// phase (~61s), so MaxRetries equals the exponential-phase count.
+	assert.Equal(t, saveAudioDeferredExpPhaseRetries, cfg.MaxRetries)
+}
+
+func TestSaveAudioDeferredMaxRetries_ScalesWithDuration(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		duration int
+		minTotal time.Duration
+	}{
+		// duration + saveAudioDeferredMarginSeconds must be covered by the
+		// summed backoff schedule; a few representative points across the
+		// supported range (1s..MaxExtendedCaptureDuration=1200s).
+		{"short", 10, 40 * time.Second},
+		{"medium", 60, 90 * time.Second},
+		{"long", 300, 330 * time.Second},
+		{"maximum", 1200, 1230 * time.Second},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			retries := saveAudioDeferredMaxRetries(tt.duration)
+			// Simulate the backoff sum to verify the schedule covers the budget.
+			total := time.Duration(0)
+			delay := saveAudioDeferredInitialDelay
+			for range retries {
+				total += delay
+				delay = time.Duration(float64(delay) * saveAudioDeferredMultiplier)
+				if delay > saveAudioDeferredMaxDelay {
+					delay = saveAudioDeferredMaxDelay
+				}
+			}
+			assert.GreaterOrEqual(t, total, tt.minTotal,
+				"retry schedule must cover capture duration + margin for %s", tt.name)
+		})
+	}
+}
+
+func TestGetJobQueueRetryConfig_SaveAudioEagerHasNoRetry(t *testing.T) {
+	t.Parallel()
+
+	// Eager (non-deferred) SaveAudioAction has pcmData already populated and
+	// must not participate in the retry loop; retrying an encode failure
+	// does not help because the PCM window has already been copied out.
+	cfg := getJobQueueRetryConfig(&SaveAudioAction{
+		pcmData: []byte{0},
+	})
+
+	assert.False(t, cfg.Enabled)
+}
+
+// Guard against drift: errAudioExportDeferred is a plain sentinel today but
+// if someone wraps it through the internal/errors builder chain the
+// ErrorIs() check in the deferred-path test must still hold.
+func TestErrAudioExportDeferred_IsSentinel(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, errors.Is(errAudioExportDeferred, errAudioExportDeferred))
+}

--- a/internal/analysis/processor/save_audio_action_test.go
+++ b/internal/analysis/processor/save_audio_action_test.go
@@ -6,6 +6,7 @@
 package processor
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -16,7 +17,6 @@ import (
 
 	audioBuffer "github.com/tphakala/birdnet-go/internal/audiocore/buffer"
 	"github.com/tphakala/birdnet-go/internal/conf"
-	"github.com/tphakala/birdnet-go/internal/errors"
 )
 
 func TestSaveAudioActionExecute_DefersUntilCaptureReady(t *testing.T) {
@@ -191,10 +191,13 @@ func TestGetJobQueueRetryConfig_SaveAudioEagerHasNoRetry(t *testing.T) {
 }
 
 // Guard against drift: errAudioExportDeferred is a plain sentinel today but
-// if someone wraps it through the internal/errors builder chain the
-// ErrorIs() check in the deferred-path test must still hold.
+// callers may wrap it (e.g. with fmt.Errorf %w) as the deferred-read path
+// evolves. Assert the wrapped form still satisfies errors.Is so
+// DefersUntilCaptureReady's ErrorIs check cannot be defeated by a future
+// wrap/unwrap change.
 func TestErrAudioExportDeferred_IsSentinel(t *testing.T) {
 	t.Parallel()
 
-	assert.True(t, errors.Is(errAudioExportDeferred, errAudioExportDeferred))
+	wrapped := fmt.Errorf("deferred execute: %w", errAudioExportDeferred)
+	assert.ErrorIs(t, wrapped, errAudioExportDeferred)
 }

--- a/internal/analysis/processor/workers.go
+++ b/internal/analysis/processor/workers.go
@@ -24,6 +24,43 @@ const (
 	DefaultEnqueueTimeout = 5 * time.Second
 )
 
+// Retry backoff parameters for deferred SaveAudioAction executions (Extended
+// Capture). The delay schedule grows exponentially (1s, 2s, 4s, 8s, 16s)
+// before saturating at MaxDelay=30s. The first 6 retries cover ~61 seconds;
+// each additional retry adds another 30 seconds. MaxRetries is computed per
+// action from the capture duration so a 30-second tail gets a tight budget
+// while a 20-minute tail (MaxExtendedCaptureDuration) still has time to
+// complete.
+const (
+	saveAudioDeferredInitialDelay = 1 * time.Second
+	saveAudioDeferredMaxDelay     = 30 * time.Second
+	saveAudioDeferredMultiplier   = 2.0
+
+	// saveAudioDeferredExpPhaseRetries is the number of retries whose
+	// cumulative delay equals saveAudioDeferredExpPhaseSpan. Kept in sync
+	// with the backoff parameters above: 1s + 2s + 4s + 8s + 16s + 30s.
+	saveAudioDeferredExpPhaseRetries = 6
+	saveAudioDeferredExpPhaseSpan    = 61 * time.Second
+
+	// saveAudioDeferredMarginSeconds is an additional cushion over the
+	// capture duration, covering queue wait time and buffer writer jitter.
+	saveAudioDeferredMarginSeconds = 30
+)
+
+// saveAudioDeferredMaxRetries returns the number of retry attempts needed to
+// cover a capture window of durationSeconds, so a short clip fails fast while
+// a long Extended Capture tail has time to finish writing to the ring buffer.
+func saveAudioDeferredMaxRetries(durationSeconds int) int {
+	budget := time.Duration(durationSeconds+saveAudioDeferredMarginSeconds) * time.Second
+	if budget <= saveAudioDeferredExpPhaseSpan {
+		return saveAudioDeferredExpPhaseRetries
+	}
+	extra := budget - saveAudioDeferredExpPhaseSpan
+	// Round up so the schedule always reaches at least `budget` seconds.
+	extraRetries := int((extra + saveAudioDeferredMaxDelay - 1) / saveAudioDeferredMaxDelay)
+	return saveAudioDeferredExpPhaseRetries + extraRetries
+}
+
 // Sentinel errors for processor operations
 var (
 	ErrNilTask = errors.Newf("cannot enqueue nil task").
@@ -96,6 +133,20 @@ func getJobQueueRetryConfig(action Action) jobqueue.RetryConfig {
 		return a.RetryConfig // Now directly returns jobqueue.RetryConfig
 	case *MqttAction:
 		return a.RetryConfig // Now directly returns jobqueue.RetryConfig
+	case *SaveAudioAction:
+		// Only deferred SaveAudioActions (those waiting for an Extended
+		// Capture tail) need retry. Regular eager-read actions return
+		// with pcmData already populated and never need to retry.
+		if a.bufferMgr != nil && a.duration > 0 {
+			return jobqueue.RetryConfig{
+				Enabled:      true,
+				MaxRetries:   saveAudioDeferredMaxRetries(a.duration),
+				InitialDelay: saveAudioDeferredInitialDelay,
+				MaxDelay:     saveAudioDeferredMaxDelay,
+				Multiplier:   saveAudioDeferredMultiplier,
+			}
+		}
+		return jobqueue.RetryConfig{Enabled: false}
 	default:
 		// Default no retry for actions that don't support it
 		return jobqueue.RetryConfig{Enabled: false}


### PR DESCRIPTION
## Summary

Fixes #2789. When Extended Capture is enabled, the audio export path silently drops every clip with `error="requested segment exceeds written data"`.

`buildSaveAudioAction` computes `captureLength` from `EndTime - BeginTime + PreCapture` and then eagerly calls `readCaptureSegment`. With an extended clip whose tail has not yet been written to the ring buffer, `ReadSegment` correctly returns `ErrInsufficientData` because `endByteOffset > writtenBytes`. The resulting `SaveAudioAction` has nil `pcmData`, its `Execute()` becomes a no-op, and the user loses both audio and spectrogram for the affected detections.

## Fix

Defer the read when `captureEndTime` is in the future:

- `buildSaveAudioAction` returns a `SaveAudioAction` populated with `bufferMgr`, `sourceID`, `beginTime`, `duration`, and `readyAt` instead of `pcmData`.
- `SaveAudioAction.Execute()` checks these fields: if `readyAt` is still future it returns a sentinel `errAudioExportDeferred`; once `readyAt` has passed it reads from the capture buffer and falls through to the existing encode path.
- `getJobQueueRetryConfig` enables retry for deferred `SaveAudioAction` only. `MaxRetries` is computed from `duration` so short clips fail fast (6 retries, ~61s) while a `MaxExtendedCaptureDuration` (1200s / 20 min) tail still has enough schedule to complete. Backoff parameters (1s initial, 30s cap, 2.0x) are constant.
- If encoding fails after the buffer read, the populated `pcmData` lets the next retry skip straight to encode without re-reading a buffer that may have rolled over.

## Memory impact

Strictly better for Extended Capture. The pre-fix path eagerly copied up to ~5.8 MB of PCM per queued action. Deferred actions hold only a `buffer.Manager` pointer and a few timestamps until `readyAt`, then allocate `pcmData` at execute time.

## Test plan

- [x] Unit tests in `internal/analysis/processor/save_audio_action_test.go`:
  - defers with `errAudioExportDeferred` when `readyAt` is in the future
  - reads the capture buffer and writes a WAV when `readyAt` has passed
  - propagates errors from a missing capture source (final retry failure)
  - retry config is enabled with the backoff constants
  - eager `SaveAudioAction` (non-deferred) has retry disabled
  - `MaxRetries` schedule covers capture duration + margin across the supported range (10s / 60s / 300s / 1200s)
- [x] `golangci-lint run -v` clean
- [x] `go test -race` passes across `internal/analysis/processor/`
- [x] `coderabbit review --plain -t uncommitted` reports no findings
- [ ] Manual: enable Extended Capture, trigger several detections, confirm audio + spectrogram files appear on disk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio export reliability: exports now defer and automatically retry when capture data isn’t yet available, reducing failed/empty exports. Retry timing adapts to capture length so longer recordings get longer retry windows.
* **Tests**
  * Added tests covering deferred export behavior, retry scheduling, and success/failure cases to ensure robust behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->