### PR TITLE
fix: clarify taxonomy synonyms UI copy (image lookups only)

### DIFF
--- a/frontend/src/lib/desktop/features/settings/pages/SpeciesSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/SpeciesSettingsPage.svelte
@@ -1302,6 +1302,9 @@
   <div class="space-y-4">
     <SettingsNote>
       <p>{t('settings.species.synonyms.description')}</p>
+      <p class="mt-2 text-xs text-muted">
+        {t('settings.species.synonyms.helpText')}
+      </p>
     </SettingsNote>
 
     <!-- Add Synonym Form -->

--- a/frontend/static/messages/da.json
+++ b/frontend/static/messages/da.json
@@ -3442,9 +3442,10 @@
       },
       "synonyms": {
         "tabLabel": "Synonymer",
-        "description": "Knyt BirdNET-artsnavne til dine foretrukne navne. Når en detektion matcher et synonym, bruges det opdaterede navn i stedet.",
+        "description": "Knyt BirdNETs videnskabelige artsnavne til deres opdaterede modstykker i nyere taksonomi. Bruges kun som reserve ved opslag af fuglebilleder fra Wikipedia og AviCommons; omdøber ikke arter i detektioner eller på dashboardet.",
+        "helpText": "For at ændre hvordan en art vises i brugerfladen skal du redigere din BirdNET-etiketfil (indstillingen \"Labelsti\" under Hovedindstillinger).",
         "birdnetName": "BirdNET-navn",
-        "updatedName": "Opdateret navn",
+        "updatedName": "Opdateret videnskabeligt navn",
         "addButton": "Tilføj synonym",
         "emptyState": "Ingen taksonomi-synonymer konfigureret",
         "errors": {

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -3215,9 +3215,10 @@
       },
       "synonyms": {
         "tabLabel": "Synonyme",
-        "description": "Ordnen Sie BirdNET-Artennamen Ihren bevorzugten Namen zu. Bei einer Erkennung wird der aktualisierte Name verwendet.",
+        "description": "Ordnen Sie wissenschaftliche BirdNET-Namen ihren aktualisierten Entsprechungen in einer neueren Taxonomie zu. Wird nur als Fallback beim Abrufen von Vogelbildern von Wikipedia und AviCommons verwendet; benennt Arten weder in Erkennungen noch im Dashboard um.",
+        "helpText": "Um den in der Oberfläche angezeigten Namen einer Art zu ändern, bearbeiten Sie Ihre BirdNET-Labeldatei (Einstellung \"Label-Pfad\" unter Haupteinstellungen).",
         "birdnetName": "BirdNET-Name",
-        "updatedName": "Neuer Name",
+        "updatedName": "Aktualisierter wissenschaftlicher Name",
         "addButton": "Synonym hinzufügen",
         "emptyState": "Keine Taxonomie-Synonyme konfiguriert",
         "errors": {

--- a/frontend/static/messages/en.json
+++ b/frontend/static/messages/en.json
@@ -3480,9 +3480,10 @@
       },
       "synonyms": {
         "tabLabel": "Synonyms",
-        "description": "Map BirdNET species names to your preferred names. When a detection matches a synonym, the updated name is used instead.",
+        "description": "Map BirdNET scientific names to their updated equivalents in newer taxonomy. Used only as a fallback when looking up bird photos from Wikipedia and AviCommons; does not rename species in detections or on the dashboard.",
+        "helpText": "To change how a species is named in the UI, edit your BirdNET labels file (the \"Label Path\" setting under Main settings).",
         "birdnetName": "BirdNET Name",
-        "updatedName": "Updated Name",
+        "updatedName": "Updated scientific name",
         "addButton": "Add Synonym",
         "emptyState": "No taxonomy synonyms configured",
         "errors": {

--- a/frontend/static/messages/en.json
+++ b/frontend/static/messages/en.json
@@ -3483,7 +3483,7 @@
         "description": "Map BirdNET scientific names to their updated equivalents in newer taxonomy. Used only as a fallback when looking up bird photos from Wikipedia and AviCommons; does not rename species in detections or on the dashboard.",
         "helpText": "To change how a species is named in the UI, edit your BirdNET labels file (the \"Label Path\" setting under Main settings).",
         "birdnetName": "BirdNET Name",
-        "updatedName": "Updated scientific name",
+        "updatedName": "Updated Scientific Name",
         "addButton": "Add Synonym",
         "emptyState": "No taxonomy synonyms configured",
         "errors": {

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -3215,9 +3215,10 @@
       },
       "synonyms": {
         "tabLabel": "Sinónimos",
-        "description": "Asigne nombres de especies de BirdNET a sus nombres preferidos. Cuando una detección coincida con un sinónimo, se usará el nombre actualizado.",
+        "description": "Asigne nombres científicos de BirdNET a sus equivalentes actualizados en una taxonomía más reciente. Se usa solo como alternativa al buscar fotos de aves en Wikipedia y AviCommons; no renombra especies en las detecciones ni en el panel.",
+        "helpText": "Para cambiar cómo se muestra una especie en la interfaz, edite su archivo de etiquetas de BirdNET (ajuste \"Ruta de etiquetas\" en Configuración principal).",
         "birdnetName": "Nombre BirdNET",
-        "updatedName": "Nombre actualizado",
+        "updatedName": "Nombre científico actualizado",
         "addButton": "Agregar sinónimo",
         "emptyState": "No hay sinónimos de taxonomía configurados",
         "errors": {

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -3215,9 +3215,10 @@
       },
       "synonyms": {
         "tabLabel": "Synonyymit",
-        "description": "Yhdistä BirdNET-lajinimet haluamiisi nimiin. Kun havainto vastaa synonyymia, käytetään päivitettyä nimeä.",
+        "description": "Yhdistä BirdNETin tieteelliset lajinimet niiden päivitettyihin vastineisiin uudemmassa taksonomiassa. Käytetään vain varasijana haettaessa lintukuvia Wikipediasta ja AviCommonsista; ei nimeä lajeja uudelleen havainnoissa tai koontinäytöllä.",
+        "helpText": "Muuttaaksesi lajin käyttöliittymässä näkyvää nimeä, muokkaa BirdNETin tunnistetiedostoa (asetus \"Nimikkeiden polku\" pääasetuksissa).",
         "birdnetName": "BirdNET-nimi",
-        "updatedName": "Päivitetty nimi",
+        "updatedName": "Päivitetty tieteellinen nimi",
         "addButton": "Lisää synonyymi",
         "emptyState": "Ei määritettyjä taksonomiasynonyymejä",
         "errors": {

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -3444,9 +3444,10 @@
       },
       "synonyms": {
         "tabLabel": "Synonymes",
-        "description": "Associez les noms d'espèces BirdNET à vos noms préférés. Lors d'une détection correspondant à un synonyme, le nom mis à jour sera utilisé.",
+        "description": "Associez les noms scientifiques BirdNET à leurs équivalents mis à jour dans une taxonomie récente. Utilisé uniquement comme solution de secours lors de la recherche de photos d'oiseaux sur Wikipedia et AviCommons ; ne renomme pas les espèces dans les détections ni sur le tableau de bord.",
+        "helpText": "Pour modifier le nom affiché d'une espèce dans l'interface, modifiez votre fichier d'étiquettes BirdNET (paramètre « Chemin des étiquettes » dans les paramètres principaux).",
         "birdnetName": "Nom BirdNET",
-        "updatedName": "Nom mis à jour",
+        "updatedName": "Nom scientifique mis à jour",
         "addButton": "Ajouter un synonyme",
         "emptyState": "Aucun synonyme de taxonomie configuré",
         "errors": {

--- a/frontend/static/messages/hu.json
+++ b/frontend/static/messages/hu.json
@@ -3443,9 +3443,10 @@
       },
       "synonyms": {
         "tabLabel": "Szinonimák",
-        "description": "BirdNET faj nevek leképezése az Ön preferált neveire. Amikor egy detektálás egyezik egy szinonimával, a frissített név kerül használatra.",
+        "description": "Rendelje hozzá a BirdNET tudományos fajneveit újabb taxonómia szerinti megfelelőikhez. Csak tartalékként használatos a madárképek Wikipédiáról és AviCommonsról való lekérésekor; nem nevezi át a fajokat a detektálásokban vagy az irányítópulton.",
+        "helpText": "Ha módosítani szeretné egy faj felületen megjelenő nevét, szerkessze a BirdNET címkefájlját (a „Címke útvonal” beállítás a fő beállítások között).",
         "birdnetName": "BirdNET név",
-        "updatedName": "Frissített név",
+        "updatedName": "Frissített tudományos név",
         "addButton": "Szinonima hozzáadása",
         "emptyState": "Nincs taxonómia szinonima konfigurálva",
         "errors": {

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -3412,9 +3412,10 @@
       },
       "synonyms": {
         "tabLabel": "Sinonimi",
-        "description": "Associa i nomi delle specie BirdNET ai tuoi nomi preferiti. Quando un rilevamento corrisponde a un sinonimo, verrà utilizzato il nome aggiornato.",
+        "description": "Associa i nomi scientifici BirdNET ai corrispettivi aggiornati in una tassonomia più recente. Utilizzato solo come alternativa nel recupero delle foto degli uccelli da Wikipedia e AviCommons; non rinomina le specie nei rilevamenti né nella dashboard.",
+        "helpText": "Per modificare il nome con cui una specie appare nell'interfaccia, modifica il tuo file di etichette BirdNET (impostazione \"Percorso Etichette\" nelle impostazioni principali).",
         "birdnetName": "Nome BirdNET",
-        "updatedName": "Nome aggiornato",
+        "updatedName": "Nome scientifico aggiornato",
         "addButton": "Aggiungi sinonimo",
         "emptyState": "Nessun sinonimo tassonomico configurato",
         "errors": {

--- a/frontend/static/messages/lv.json
+++ b/frontend/static/messages/lv.json
@@ -3442,9 +3442,10 @@
       },
       "synonyms": {
         "tabLabel": "Sinonīmi",
-        "description": "Saistiet BirdNET sugu nosaukumus ar vēlamajiem nosaukumiem. Kad noteikšana atbilst sinonīmam, tiks izmantots atjauninātais nosaukums.",
+        "description": "Saistiet BirdNET zinātniskos sugu nosaukumus ar to atjauninātajiem ekvivalentiem jaunākajā taksonomijā. Tiek izmantots tikai kā rezerves variants, meklējot putnu fotoattēlus Wikipedia un AviCommons; nepārsauc sugas atklājumos vai informācijas panelī.",
+        "helpText": "Lai mainītu, kā suga tiek attēlota saskarnē, rediģējiet savu BirdNET etiķešu failu (iestatījums \"Etiķešu ceļš\" galvenajos iestatījumos).",
         "birdnetName": "BirdNET nosaukums",
-        "updatedName": "Atjaunināts nosaukums",
+        "updatedName": "Atjaunināts zinātniskais nosaukums",
         "addButton": "Pievienot sinonīmu",
         "emptyState": "Nav konfigurēti taksonomijas sinonīmi",
         "errors": {

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -3445,7 +3445,7 @@
       "synonyms": {
         "tabLabel": "Synoniemen",
         "description": "Koppel wetenschappelijke BirdNET-namen aan hun bijgewerkte equivalenten in een nieuwere taxonomie. Wordt alleen als fallback gebruikt bij het ophalen van vogelfoto's van Wikipedia en AviCommons; hernoemt geen soorten in detecties of op het dashboard.",
-        "helpText": "Om te wijzigen hoe een soort in de interface wordt weergegeven, bewerk uw BirdNET-labelbestand (instelling \"Label Pad\" onder Hoofd Instellingen).",
+        "helpText": "Om te wijzigen hoe een soort in de interface wordt weergegeven, bewerk uw BirdNET-labelbestand (instelling \"Labelpad\" onder Hoofdinstellingen).",
         "birdnetName": "BirdNET-naam",
         "updatedName": "Bijgewerkte wetenschappelijke naam",
         "addButton": "Synoniem toevoegen",

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -3444,9 +3444,10 @@
       },
       "synonyms": {
         "tabLabel": "Synoniemen",
-        "description": "Koppel BirdNET-soortennamen aan uw voorkeursnamen. Wanneer een detectie overeenkomt met een synoniem, wordt de bijgewerkte naam gebruikt.",
+        "description": "Koppel wetenschappelijke BirdNET-namen aan hun bijgewerkte equivalenten in een nieuwere taxonomie. Wordt alleen als fallback gebruikt bij het ophalen van vogelfoto's van Wikipedia en AviCommons; hernoemt geen soorten in detecties of op het dashboard.",
+        "helpText": "Om te wijzigen hoe een soort in de interface wordt weergegeven, bewerk uw BirdNET-labelbestand (instelling \"Label Pad\" onder Hoofd Instellingen).",
         "birdnetName": "BirdNET-naam",
-        "updatedName": "Bijgewerkte naam",
+        "updatedName": "Bijgewerkte wetenschappelijke naam",
         "addButton": "Synoniem toevoegen",
         "emptyState": "Geen taxonomie-synoniemen geconfigureerd",
         "errors": {

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -3450,9 +3450,10 @@
       },
       "synonyms": {
         "tabLabel": "Synonimy",
-        "description": "Przypisz nazwy gatunków BirdNET do preferowanych nazw. Gdy wykrycie pasuje do synonimu, zostanie użyta zaktualizowana nazwa.",
+        "description": "Przypisz naukowe nazwy BirdNET do ich zaktualizowanych odpowiedników w nowszej taksonomii. Używane wyłącznie jako rozwiązanie awaryjne przy pobieraniu zdjęć ptaków z Wikipedii i AviCommons; nie zmienia nazw gatunków w wykryciach ani na panelu.",
+        "helpText": "Aby zmienić nazwę, pod którą gatunek pojawia się w interfejsie, edytuj swój plik etykiet BirdNET (ustawienie \"Ścieżka Etykiet\" w ustawieniach głównych).",
         "birdnetName": "Nazwa BirdNET",
-        "updatedName": "Zaktualizowana nazwa",
+        "updatedName": "Zaktualizowana nazwa naukowa",
         "addButton": "Dodaj synonim",
         "emptyState": "Nie skonfigurowano synonimów taksonomicznych",
         "errors": {

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -3215,9 +3215,10 @@
       },
       "synonyms": {
         "tabLabel": "Sinônimos",
-        "description": "Associe nomes de espécies do BirdNET aos seus nomes preferidos. Quando uma detecção corresponder a um sinônimo, o nome atualizado será usado.",
+        "description": "Associe nomes científicos do BirdNET aos seus equivalentes atualizados em taxonomia mais recente. Usado apenas como alternativa ao buscar fotos de aves na Wikipedia e no AviCommons; não renomeia espécies nas detecções nem no painel.",
+        "helpText": "Para alterar como uma espécie aparece na interface, edite seu arquivo de rótulos do BirdNET (configuração \"Caminho dos rótulos\" nas configurações principais).",
         "birdnetName": "Nome BirdNET",
-        "updatedName": "Nome atualizado",
+        "updatedName": "Nome científico atualizado",
         "addButton": "Adicionar sinônimo",
         "emptyState": "Nenhum sinônimo de taxonomia configurado",
         "errors": {

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -3412,9 +3412,10 @@
       },
       "synonyms": {
         "tabLabel": "Synonymá",
-        "description": "Priraďte názvy druhov BirdNET k vašim preferovaným názvom. Keď detekcia zodpovedá synonymu, použije sa aktualizovaný názov.",
+        "description": "Priraďte vedecké názvy BirdNET k ich aktualizovaným ekvivalentom v novšej taxonómii. Používa sa len ako záložná možnosť pri vyhľadávaní fotografií vtákov na Wikipédii a AviCommons; nepremenuje druhy v detekciách ani na ovládacom paneli.",
+        "helpText": "Ak chcete zmeniť, pod akým názvom sa druh zobrazuje v rozhraní, upravte súbor menoviek BirdNET (nastavenie \"Cesta k štítkom\" v hlavných nastaveniach).",
         "birdnetName": "Názov BirdNET",
-        "updatedName": "Aktualizovaný názov",
+        "updatedName": "Aktualizovaný vedecký názov",
         "addButton": "Pridať synonymum",
         "emptyState": "Žiadne taxonomické synonymá nie sú nakonfigurované",
         "errors": {

--- a/frontend/static/messages/sv.json
+++ b/frontend/static/messages/sv.json
@@ -3442,9 +3442,10 @@
       },
       "synonyms": {
         "tabLabel": "Synonymer",
-        "description": "Koppla BirdNET-artnamn till dina föredragna namn. När en detektion matchar en synonym används det uppdaterade namnet istället.",
+        "description": "Koppla BirdNETs vetenskapliga artnamn till deras uppdaterade motsvarigheter i nyare taxonomi. Används endast som reserv vid hämtning av fågelbilder från Wikipedia och AviCommons; byter inte namn på arter i detektioner eller på instrumentpanelen.",
+        "helpText": "För att ändra hur en art visas i gränssnittet, redigera din BirdNET-etikettfil (inställningen \"Etikettsökväg\" under Huvudinställningar).",
         "birdnetName": "BirdNET-namn",
-        "updatedName": "Uppdaterat namn",
+        "updatedName": "Uppdaterat vetenskapligt namn",
         "addButton": "Lägg till synonym",
         "emptyState": "Inga taxonomisynonymer konfigurerade",
         "errors": {


### PR DESCRIPTION
## Summary

The Synonyms tab in Species Settings previously described itself as a general display-name override (" _when a detection matches a synonym, the updated name is used instead_ "), leading users to expect their mapping to rename species on the dashboard. The underlying `TaxonomySynonyms` config is only the scientific-name fallback used by the image providers ([Wikipedia](https://github.com/tphakala/birdnet-go/blob/main/internal/imageprovider/wikipedia.go), [AviCommons](https://github.com/tphakala/birdnet-go/blob/main/internal/imageprovider/avicommons.go)) when the BirdNET 2021E name is not present in newer taxonomy (see `internal/imageprovider/taxonomy_synonyms.go`). Nothing in the detection pipeline, SSE feed, or dashboard API consults it.

This PR fixes the misleading copy:

- Rewrites `settings.species.synonyms.description` across all 14 locales to describe the actual scope (image-provider fallback) and explicitly notes it does not rename detections or dashboard entries.
- Tightens the "Updated Name" field label to "Updated scientific name" so users understand the expected input shape.
- Adds a `settings.species.synonyms.helpText` key pointing users to the BirdNET label file (the "Label Path" setting under Main settings) for actual display-name changes, which is the workflow that already works.

Rendered as a second paragraph inside the existing `SettingsNote` on the Synonyms tab.

## Test plan

- [ ] `npm run check:all` (format, lint, stylelint, typecheck, ast-grep)
- [ ] `npm test` (1885 tests)
- [ ] i18n key parity verified across all 14 locale files
- [ ] Spot-check rendered strings in `en` and one non-English locale in the dev server
- [ ] CI i18n validation (warnings are pre-existing on `main`; this change strictly adds 1 key across all locales)

Fixes #2783

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an inline help paragraph in the Taxonomy Synonyms settings tab explaining label-file based name changes.

* **Documentation**
  * Clarified that synonyms are used only as a fallback for image lookups (Wikipedia/AviCommons), not to rename detections or dashboard entries.
  * Updated wording across languages: "Updated Name" → "Updated Scientific Name".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->