### PR TITLE
fix(api,search): normalize verified status in /api/v2/search (#2769)

### DIFF
--- a/frontend/src/lib/desktop/views/Search.svelte
+++ b/frontend/src/lib/desktop/views/Search.svelte
@@ -136,7 +136,7 @@
     hasAudio: boolean;
   }
 
-  type VerifiedStatus = 'any' | 'verified' | 'unverified' | 'false_positive';
+  type VerifiedStatus = 'any' | 'correct' | 'unverified' | 'false_positive';
   type LockedStatus = 'any' | 'locked' | 'unlocked';
   type TimeOfDayFilter = 'any' | 'day' | 'night' | 'sunrise' | 'sunset';
   type SortBy = 'date_desc' | 'date_asc' | 'species_asc' | 'confidence_desc';
@@ -693,7 +693,7 @@
                 </label>
                 <select id="verifiedStatusFilter" bind:value={verifiedStatus} class="select w-full">
                   <option value="any">{t('search.verifiedOptions.any')}</option>
-                  <option value="verified">{t('search.verifiedOptions.verified')}</option>
+                  <option value="correct">{t('search.verifiedOptions.verified')}</option>
                   <option value="unverified">{t('search.verifiedOptions.unverified')}</option>
                   <option value="false_positive">{t('common.review.status.falsePositive')}</option>
                 </select>

--- a/internal/api/v2/search.go
+++ b/internal/api/v2/search.go
@@ -235,7 +235,7 @@ func (c *Controller) validateSearchStatusEnums(path, ip string, req *SearchReque
 		req.VerifiedStatus = QueryValueAny
 	} else if !validVerifiedStatus[req.VerifiedStatus] {
 		c.logErrorIfEnabled("Invalid verified status parameter", logger.String("verifiedStatus", req.VerifiedStatus), logger.String("path", path), logger.String("ip", ip))
-		return fmt.Errorf("invalid verified status '%s'. Use 'any', 'verified', 'unverified', or 'false_positive'", req.VerifiedStatus)
+		return fmt.Errorf("invalid verified status '%s'. Use 'any', 'correct', 'unverified', or 'false_positive'", req.VerifiedStatus)
 	}
 
 	validLockedStatus := map[string]bool{QueryValueAny: true, "locked": true, "unlocked": true}

--- a/internal/api/v2/search.go
+++ b/internal/api/v2/search.go
@@ -235,7 +235,12 @@ func (c *Controller) validateSearchStatusEnums(path, ip string, req *SearchReque
 		req.VerifiedStatus = QueryValueAny
 	} else if !validVerifiedStatus[req.VerifiedStatus] {
 		c.logErrorIfEnabled("Invalid verified status parameter", logger.String("verifiedStatus", req.VerifiedStatus), logger.String("path", path), logger.String("ip", ip))
-		return fmt.Errorf("invalid verified status '%s'. Use 'any', 'correct', 'unverified', or 'false_positive'", req.VerifiedStatus)
+		return fmt.Errorf("invalid verified status %q. Use %q, %q, %q, or %q",
+			req.VerifiedStatus,
+			QueryValueAny,
+			VerificationStatusCorrect,
+			VerificationStatusUnverified,
+			VerificationStatusFalsePositive)
 	}
 
 	validLockedStatus := map[string]bool{QueryValueAny: true, "locked": true, "unlocked": true}

--- a/internal/datastore/v2only/datastore.go
+++ b/internal/datastore/v2only/datastore.go
@@ -843,14 +843,19 @@ func (ds *Datastore) detectionToRecord(det *entities.Detection) datastore.Detect
 		hasAudio = true
 	}
 
-	// Verification status from Review
+	// Verification status from Review.
+	// Emit the same vocabulary the rest of the API speaks ("correct",
+	// "false_positive", "unverified"), matching api.VerificationStatus*
+	// constants and the /api/v2/detections response. Issue #2769 was caused by
+	// this path emitting the literal "verified", which the frontend's
+	// result.verified === 'correct' check did not recognize.
 	verified := "unverified"
 	if det.Review != nil {
 		switch det.Review.Verified {
 		case entities.VerificationCorrect:
-			verified = "verified"
+			verified = string(entities.VerificationCorrect)
 		case entities.VerificationFalsePositive:
-			verified = "false_positive"
+			verified = string(entities.VerificationFalsePositive)
 		}
 	}
 

--- a/internal/datastore/v2only/detection_to_record_test.go
+++ b/internal/datastore/v2only/detection_to_record_test.go
@@ -31,12 +31,12 @@ func TestDetectionToRecord_Verified(t *testing.T) {
 		{
 			name:   "correctly reviewed detection reports correct",
 			review: &entities.DetectionReview{Verified: entities.VerificationCorrect},
-			want:   "correct",
+			want:   string(entities.VerificationCorrect),
 		},
 		{
 			name:   "false-positive review reports false_positive",
 			review: &entities.DetectionReview{Verified: entities.VerificationFalsePositive},
-			want:   "false_positive",
+			want:   string(entities.VerificationFalsePositive),
 		},
 	}
 

--- a/internal/datastore/v2only/detection_to_record_test.go
+++ b/internal/datastore/v2only/detection_to_record_test.go
@@ -1,0 +1,60 @@
+package v2only
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tphakala/birdnet-go/internal/datastore/v2/entities"
+)
+
+// TestDetectionToRecord_Verified is a regression test for GitHub issue #2769:
+// /api/v2/search must emit the same verification vocabulary that /api/v2/detections
+// and the frontend speak, namely "correct" / "false_positive" / "unverified".
+// Previously the search path returned the literal "verified", causing the Search
+// view to render every detection as "Unverified" regardless of its real status.
+func TestDetectionToRecord_Verified(t *testing.T) {
+	t.Parallel()
+
+	ds := &Datastore{timezone: time.UTC}
+
+	tests := []struct {
+		name   string
+		review *entities.DetectionReview
+		want   string
+	}{
+		{
+			name:   "unreviewed detection reports unverified",
+			review: nil,
+			want:   "unverified",
+		},
+		{
+			name:   "correctly reviewed detection reports correct",
+			review: &entities.DetectionReview{Verified: entities.VerificationCorrect},
+			want:   "correct",
+		},
+		{
+			name:   "false-positive review reports false_positive",
+			review: &entities.DetectionReview{Verified: entities.VerificationFalsePositive},
+			want:   "false_positive",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			det := &entities.Detection{
+				ID:         42,
+				Confidence: 0.9,
+				DetectedAt: time.Date(2026, 4, 14, 20, 11, 29, 0, time.UTC).Unix(),
+				Review:     tc.review,
+			}
+
+			got := ds.detectionToRecord(det)
+
+			assert.Equal(t, tc.want, got.Verified,
+				"DetectionRecord.Verified must use the shared 'correct/false_positive/unverified' vocabulary")
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #2769: the Search view at `/ui/search` showed "Unverified" for every detection, even ones already reviewed as "Verified Correct" on the Detections view.

**Root cause.** The v2-only datastore's `detectionToRecord` was emitting `"verified"` for reviewed detections, while every other path (`/api/v2/detections`, the dashboard cards, review cards, ActionMenu, SpeciesBadges) speaks `"correct"`. The Search view checks `result.verified === 'correct'`, so verified detections fell through to the "Unverified" badge.

**Secondary bug, same area.** The Search filter dropdown sent `verifiedStatus: "verified"` but `validateSearchStatusEnums` only accepted `"correct"`, so picking "Verified" in the dropdown returned HTTP 400. The error message also listed `'verified'` while the validator actually accepts `'correct'`.

## Note for `/api/v2/search` consumers (behavioural change)

The JSON response's `verified` field on `/api/v2/search` previously returned `"verified"` for reviewed detections. It now returns `"correct"`, matching the vocabulary already used everywhere else in the API (including `/api/v2/detections`). If you have an external script or integration that matched the string `"verified"` literally, update it to match `"correct"` (along with the existing `"false_positive"` and `"unverified"`).

The request-side `verifiedStatus` filter value for the same endpoint has changed in the same direction: pass `"correct"` to select reviewed detections. The previously-but-incorrectly-advertised `"verified"` was never actually accepted by the backend validator, so no working client can have been relying on it.

## Changes

- `internal/datastore/v2only/datastore.go` - `detectionToRecord` emits the canonical `"correct"` / `"false_positive"` / `"unverified"` vocabulary (uses the `entities.Verification*` constants directly).
- `internal/api/v2/search.go` - validator error message rewritten to reference the `VerificationStatus*` constants so it stays in sync.
- `frontend/src/lib/desktop/views/Search.svelte` - dropdown option value changed from `"verified"` to `"correct"` (visible label unchanged); `VerifiedStatus` type updated to match.
- `internal/datastore/v2only/detection_to_record_test.go` - table-driven regression test covering all three review states.

The display logic in Search.svelte already checks for `'correct'`, so it starts working automatically once the backend emits the right value. No translation changes needed.

## Verification

- `golangci-lint run -v`: 0 issues
- `go test -race ./internal/datastore/v2only/... ./internal/api/v2/...`: all green, including the new regression test
- `npm run check:all`: prettier, eslint, stylelint, svelte-check, ast-grep all clean
- `npm test`: 1885 tests pass

## Test plan

- [ ] Open `/ui/detections?queryType=species&species=<verified-species>`, note the "Verified Correct" badge.
- [ ] Open `/ui/search`, search the same species/date range, confirm the Status column now shows "Verified" for the same detections.
- [ ] In Advanced filters, pick "Verified" from the verification dropdown and submit, should return 200 and only verified detections (not 400).
- [ ] Try "False Positive" and "Unverified" filter options, confirm they still work.
- [ ] Check the browser network tab: `/api/v2/search` response should include `"verified": "correct"` for verified detections.

Fixes #2769