### PR TITLE
fix(analysis): skip sound level pipeline when disabled, reconcile on hot-reload

### DIFF
--- a/internal/analysis/audio_pipeline_service.go
+++ b/internal/analysis/audio_pipeline_service.go
@@ -377,6 +377,11 @@ func (p *AudioPipelineService) removeAllSources(operation string) {
 				logger.String("operation", operation))
 		}
 	}
+	// engine.RemoveSource removes router routes but has no knowledge of the
+	// soundlevel tracking map. Clear the map to keep it in sync with actual
+	// router state so the next registerSoundLevelConsumers call (e.g. after
+	// restartAudioCapture) does not skip sources due to stale entries.
+	p.untrackAllSoundLevelConsumers()
 }
 
 // setupAudioSources builds source configs from current settings, adds them to
@@ -492,7 +497,23 @@ func (p *AudioPipelineService) registerSoundLevelConsumers(sourceIDs []string, o
 				logger.String("operation", operation))
 			continue
 		}
+		// Re-check SoundLevel.Enabled while holding the mutex to close a
+		// narrow window: a concurrent ReconfigureSoundLevel disable path
+		// could have drained the map between AddRoute above and this
+		// insert. Without the re-check the route would become orphaned
+		// because removeAllSoundLevelConsumers already ran before we
+		// inserted our entry. If the flag flipped to false, we remove the
+		// route immediately and do not track it.
 		p.soundLevelMu.Lock()
+		if !conf.Setting().Realtime.Audio.SoundLevel.Enabled {
+			p.soundLevelMu.Unlock()
+			p.engine.Router().RemoveRoute(sid, consumerID)
+			log.Debug("sound level disabled mid-register, dropped route",
+				logger.String("source_id", sid),
+				logger.String("consumer_id", consumerID),
+				logger.String("operation", operation))
+			continue
+		}
 		if p.soundLevelConsumers == nil {
 			p.soundLevelConsumers = make(map[string]string)
 		}
@@ -523,10 +544,11 @@ func (p *AudioPipelineService) registerSoundLevelConsumers(sourceIDs []string, o
 }
 
 // ReconfigureSoundLevel reconciles the sound level pipeline with the current
-// value of Realtime.Audio.SoundLevel.Enabled. When enabled, it registers a
-// consumer for every active source that does not already have one; when
-// disabled, it tears down all tracked consumers by removing their router
-// routes (which closes the consumer and stops its drainer goroutine).
+// Realtime.Audio.SoundLevel settings. When enabled, it rebuilds the pipeline
+// for every active source so that changes to settings baked into the
+// processor (e.g. Interval) take effect; when disabled, it tears down all
+// tracked consumers by removing their router routes (which closes the
+// consumer and stops its drainer goroutine).
 //
 // This is the entry point for hot-reload. ControlMonitor.handleReconfigureSoundLevel
 // invokes it before restarting the downstream publisher so that the DSP
@@ -535,10 +557,12 @@ func (p *AudioPipelineService) registerSoundLevelConsumers(sourceIDs []string, o
 func (p *AudioPipelineService) ReconfigureSoundLevel() {
 	settings := conf.Setting()
 	if settings.Realtime.Audio.SoundLevel.Enabled {
-		// Enable path: register consumers for every active source that does
-		// not already have one. registerSoundLevelConsumers is idempotent so
-		// passing the full active source list is safe and handles the case
-		// where a source was added after the previous enable.
+		// Enable path: rebuild by tearing down any existing consumers first
+		// so settings such as Interval (captured at Processor construction
+		// time) propagate on hot-reload. registerSoundLevelConsumers is
+		// idempotent but does not recreate existing processors, so the
+		// teardown is required to apply interval changes.
+		p.removeAllSoundLevelConsumers("hot_reload_rebuild")
 		registry := p.engine.Registry()
 		active := registry.List()
 		sourceIDs := make([]string, 0, len(active))
@@ -554,6 +578,27 @@ func (p *AudioPipelineService) ReconfigureSoundLevel() {
 	// consumer, which closes its output channel and unblocks the bridge
 	// goroutine registered in registerSoundLevelConsumers.
 	p.removeAllSoundLevelConsumers("hot_reload_disable")
+}
+
+// untrackSoundLevelConsumer removes the tracking entry for sid without
+// calling Router.RemoveRoute. Callers use this when they have already removed
+// the router route via engine.RemoveSource or Router.RemoveAllRoutes so the
+// tracking map stays in sync with actual router state.
+func (p *AudioPipelineService) untrackSoundLevelConsumer(sid string) {
+	p.soundLevelMu.Lock()
+	delete(p.soundLevelConsumers, sid)
+	p.soundLevelMu.Unlock()
+}
+
+// untrackAllSoundLevelConsumers clears the tracking map without calling
+// Router.RemoveRoute. Callers use this when they have already removed every
+// source (and therefore every route) from the engine, so that a subsequent
+// registerSoundLevelConsumers call does not skip sources due to stale
+// entries.
+func (p *AudioPipelineService) untrackAllSoundLevelConsumers() {
+	p.soundLevelMu.Lock()
+	p.soundLevelConsumers = nil
+	p.soundLevelMu.Unlock()
 }
 
 // removeAllSoundLevelConsumers removes every tracked soundlevel route from the
@@ -793,6 +838,11 @@ func (p *AudioPipelineService) reconfigureChangedSources(audioLevelChan chan aud
 					logger.String("source_id", src.ID),
 					logger.Error(err))
 			}
+			// engine.RemoveSource also removes the soundlevel route. Drop the
+			// tracking entry so the idempotency check in
+			// registerSoundLevelConsumers does not skip this ID if the same
+			// source is re-added later.
+			p.untrackSoundLevelConsumer(src.ID)
 		}
 	}
 
@@ -808,6 +858,11 @@ func (p *AudioPipelineService) reconfigureChangedSources(audioLevelChan chan aud
 	if len(gainChangedIDs) > 0 {
 		for _, sid := range gainChangedIDs {
 			p.engine.Router().RemoveAllRoutes(sid)
+			// RemoveAllRoutes also removes the soundlevel route, so drop the
+			// tracking entry. Without this, the registerSoundLevelConsumers
+			// call below would skip the source (idempotency check) and leave
+			// it permanently without sound level monitoring.
+			p.untrackSoundLevelConsumer(sid)
 		}
 		p.registerConsumersForSources(gainChangedIDs, sourceModelMap, audioLevelChan, "gain_change")
 		p.registerSoundLevelConsumers(gainChangedIDs, "gain_change")

--- a/internal/analysis/audio_pipeline_service.go
+++ b/internal/analysis/audio_pipeline_service.go
@@ -56,6 +56,17 @@ type AudioPipelineService struct {
 	done                chan struct{}
 	doneOnce            sync.Once
 	wg                  sync.WaitGroup
+
+	// soundLevelMu guards soundLevelConsumers. It is held only while mutating
+	// the map; router and engine calls happen outside the critical section so
+	// that Router.RemoveRoute (which itself takes a write lock and waits for
+	// the drainer to stop) cannot deadlock against a concurrent reconfigure.
+	soundLevelMu sync.Mutex
+	// soundLevelConsumers maps sourceID to the soundlevel consumer ID currently
+	// registered on the router. A missing entry means no soundlevel route is
+	// active for that source. Populated by registerSoundLevelConsumers, drained
+	// by removeAllSoundLevelConsumers.
+	soundLevelConsumers map[string]string
 }
 
 // NewAudioPipelineService creates a new AudioPipelineService with the given dependencies.
@@ -245,8 +256,9 @@ func (p *AudioPipelineService) Start(_ context.Context) error {
 	reconfigureFn := func() {
 		p.reconfigureChangedSources(apiAudioLevelChan)
 	}
+	reconfigureSoundLevelFn := p.ReconfigureSoundLevel
 	apiController := p.apiService.APIController()
-	p.ctrlMonitor = NewControlMonitor(&p.wg, p.apiService.ControlChan(), p.done, p.restartChan, p.bufferMgr, proc, apiAudioLevelChan, p.soundLevelChan, apiController, metrics, p.quietHoursScheduler, p.engine, reconfigureFn)
+	p.ctrlMonitor = NewControlMonitor(&p.wg, p.apiService.ControlChan(), p.done, p.restartChan, p.bufferMgr, proc, apiAudioLevelChan, p.soundLevelChan, apiController, metrics, p.quietHoursScheduler, p.engine, reconfigureFn, reconfigureSoundLevelFn)
 	p.ctrlMonitor.Start()
 
 	// Start restart loop goroutine.
@@ -421,15 +433,34 @@ func (p *AudioPipelineService) setupAudioSources(audioLevelChan chan audiocore.A
 
 // registerSoundLevelConsumers creates and registers a SoundLevelConsumer on the
 // AudioRouter for each source ID, bridging output to the pipeline's soundLevelChan.
+//
+// The function is a no-op when Realtime.Audio.SoundLevel.Enabled is false so that
+// the DSP pipeline (27 biquad filters per source, per-second float64 accumulator
+// windows) is not allocated or exercised when sound level monitoring is off. It
+// is also idempotent: sources that already have a tracked consumer are skipped,
+// so the caller may include previously registered source IDs.
 func (p *AudioPipelineService) registerSoundLevelConsumers(sourceIDs []string, operation string) {
 	log := GetLogger()
 	settings := conf.Setting()
+	if !settings.Realtime.Audio.SoundLevel.Enabled {
+		return
+	}
 	slInterval := settings.Realtime.Audio.SoundLevel.Interval
 	if slInterval <= 0 {
 		slInterval = 10 // default 10-second aggregation window
 	}
 	audioSettings := &settings.Realtime.Audio
 	for _, sid := range sourceIDs {
+		// Skip sources that already have a registered soundlevel consumer so
+		// the function is safe to call with overlapping source ID sets across
+		// startup, reconfigure_diff and hot-reload enable paths.
+		p.soundLevelMu.Lock()
+		_, already := p.soundLevelConsumers[sid]
+		p.soundLevelMu.Unlock()
+		if already {
+			continue
+		}
+
 		// Look up per-source gain from the registry.
 		gainDB, _ := p.engine.Registry().GetGain(sid)
 
@@ -445,7 +476,8 @@ func (p *AudioPipelineService) registerSoundLevelConsumers(sourceIDs []string, o
 				logger.String("operation", operation))
 			continue
 		}
-		slc, slOutCh, slcErr := NewSoundLevelConsumer("soundlevel_"+sid, slProc, conf.SampleRate, conf.BitDepth, 1)
+		consumerID := "soundlevel_" + sid
+		slc, slOutCh, slcErr := NewSoundLevelConsumer(consumerID, slProc, conf.SampleRate, conf.BitDepth, 1)
 		if slcErr != nil {
 			log.Warn("failed to create sound level consumer",
 				logger.String("source_id", sid),
@@ -460,6 +492,12 @@ func (p *AudioPipelineService) registerSoundLevelConsumers(sourceIDs []string, o
 				logger.String("operation", operation))
 			continue
 		}
+		p.soundLevelMu.Lock()
+		if p.soundLevelConsumers == nil {
+			p.soundLevelConsumers = make(map[string]string)
+		}
+		p.soundLevelConsumers[sid] = consumerID
+		p.soundLevelMu.Unlock()
 		// Bridge sound level data to the pipeline's sound level channel.
 		p.wg.Go(func() {
 			for {
@@ -480,6 +518,67 @@ func (p *AudioPipelineService) registerSoundLevelConsumers(sourceIDs []string, o
 		log.Debug("registered sound level consumer",
 			logger.String("source_id", sid),
 			logger.Int("interval_seconds", slInterval),
+			logger.String("operation", operation))
+	}
+}
+
+// ReconfigureSoundLevel reconciles the sound level pipeline with the current
+// value of Realtime.Audio.SoundLevel.Enabled. When enabled, it registers a
+// consumer for every active source that does not already have one; when
+// disabled, it tears down all tracked consumers by removing their router
+// routes (which closes the consumer and stops its drainer goroutine).
+//
+// This is the entry point for hot-reload. ControlMonitor.handleReconfigureSoundLevel
+// invokes it before restarting the downstream publisher so that the DSP
+// pipeline is either fully constructed (enable) or fully torn down (disable)
+// by the time the publisher side (SoundLevelManager) reconfigures.
+func (p *AudioPipelineService) ReconfigureSoundLevel() {
+	settings := conf.Setting()
+	if settings.Realtime.Audio.SoundLevel.Enabled {
+		// Enable path: register consumers for every active source that does
+		// not already have one. registerSoundLevelConsumers is idempotent so
+		// passing the full active source list is safe and handles the case
+		// where a source was added after the previous enable.
+		registry := p.engine.Registry()
+		active := registry.List()
+		sourceIDs := make([]string, 0, len(active))
+		for i := range active {
+			sourceIDs = append(sourceIDs, active[i].ID)
+		}
+		if len(sourceIDs) > 0 {
+			p.registerSoundLevelConsumers(sourceIDs, "hot_reload_enable")
+		}
+		return
+	}
+	// Disable path: remove every tracked consumer. The router closes the
+	// consumer, which closes its output channel and unblocks the bridge
+	// goroutine registered in registerSoundLevelConsumers.
+	p.removeAllSoundLevelConsumers("hot_reload_disable")
+}
+
+// removeAllSoundLevelConsumers removes every tracked soundlevel route from the
+// router. Safe to call when no routes are tracked. The operation label is
+// included in the route-removed log entry via the router's own logging.
+func (p *AudioPipelineService) removeAllSoundLevelConsumers(operation string) {
+	p.soundLevelMu.Lock()
+	if len(p.soundLevelConsumers) == 0 {
+		p.soundLevelMu.Unlock()
+		return
+	}
+	// Drain the map into a local copy so RemoveRoute calls happen outside the
+	// critical section. Clearing the map first ensures a concurrent call
+	// observes no tracked consumers.
+	toRemove := p.soundLevelConsumers
+	p.soundLevelConsumers = make(map[string]string)
+	p.soundLevelMu.Unlock()
+
+	log := GetLogger()
+	router := p.engine.Router()
+	for sid, cid := range toRemove {
+		router.RemoveRoute(sid, cid)
+		log.Debug("removed sound level consumer",
+			logger.String("source_id", sid),
+			logger.String("consumer_id", cid),
 			logger.String("operation", operation))
 	}
 }

--- a/internal/analysis/audio_pipeline_soundlevel_gate_test.go
+++ b/internal/analysis/audio_pipeline_soundlevel_gate_test.go
@@ -106,3 +106,58 @@ func TestRemoveAllSoundLevelConsumers_DrainsMapBeforeRouterCalls(t *testing.T) {
 	require.Empty(t, p.soundLevelConsumers,
 		"tracking map must be cleared atomically before router.RemoveRoute is called")
 }
+
+// TestUntrackSoundLevelConsumer_RemovesOnlyTargetEntry verifies that the
+// helper called by reconfigureChangedSources (gain change path) and the
+// removed-source path in reconfigure_diff drops just the requested source
+// from the tracking map. Without this helper those paths would leave the map
+// out of sync with the router after RemoveAllRoutes / engine.RemoveSource
+// and re-registration would be silently skipped.
+func TestUntrackSoundLevelConsumer_RemovesOnlyTargetEntry(t *testing.T) {
+	p := &AudioPipelineService{
+		soundLevelConsumers: map[string]string{
+			"src-1": "soundlevel_src-1",
+			"src-2": "soundlevel_src-2",
+		},
+	}
+
+	p.untrackSoundLevelConsumer("src-1")
+
+	assert.NotContains(t, p.soundLevelConsumers, "src-1",
+		"targeted source must be removed from tracking map")
+	assert.Contains(t, p.soundLevelConsumers, "src-2",
+		"unrelated sources must remain tracked")
+}
+
+// TestUntrackSoundLevelConsumer_MissingSourceIsNoOp confirms the helper is
+// safe to call for a source that was never tracked (e.g. sound level
+// disabled at the time the route was added). A panic here would block
+// reconfigureChangedSources any time gain changes on a non-soundlevel run.
+func TestUntrackSoundLevelConsumer_MissingSourceIsNoOp(t *testing.T) {
+	p := &AudioPipelineService{
+		soundLevelConsumers: map[string]string{"src-1": "soundlevel_src-1"},
+	}
+
+	assert.NotPanics(t, func() { p.untrackSoundLevelConsumer("nonexistent") })
+	assert.Len(t, p.soundLevelConsumers, 1,
+		"map must be unchanged when untracking an unknown source")
+}
+
+// TestUntrackAllSoundLevelConsumers_ClearsMap confirms the full-clear helper
+// used by removeAllSources resets the map. Without this, restartAudioCapture
+// (which calls removeAllSources followed by setupAudioSources) would leave
+// stale entries that cause the subsequent registerSoundLevelConsumers call
+// to skip every source.
+func TestUntrackAllSoundLevelConsumers_ClearsMap(t *testing.T) {
+	p := &AudioPipelineService{
+		soundLevelConsumers: map[string]string{
+			"src-1": "soundlevel_src-1",
+			"src-2": "soundlevel_src-2",
+		},
+	}
+
+	p.untrackAllSoundLevelConsumers()
+
+	assert.Empty(t, p.soundLevelConsumers,
+		"all tracking entries must be cleared after untrackAllSoundLevelConsumers")
+}

--- a/internal/analysis/audio_pipeline_soundlevel_gate_test.go
+++ b/internal/analysis/audio_pipeline_soundlevel_gate_test.go
@@ -1,0 +1,108 @@
+// audio_pipeline_soundlevel_gate_test.go verifies that the sound level
+// pipeline (router route + Processor + bridge goroutine) is only created when
+// Realtime.Audio.SoundLevel.Enabled is true. Before the gate existed, every
+// audio source got a full biquad filter bank and accumulator even when sound
+// level monitoring was off, costing ~16 MB of live heap and ~13 MB/h of
+// allocation churn per source on a Pi.
+package analysis
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/conf"
+)
+
+// TestRegisterSoundLevelConsumers_DisabledIsNoOp confirms the guard added to
+// registerSoundLevelConsumers short-circuits before touching p.engine when
+// sound level monitoring is disabled. Passing a nil engine proves the early
+// return is taken: if the body executed it would panic on the first
+// p.engine.Registry() call.
+func TestRegisterSoundLevelConsumers_DisabledIsNoOp(t *testing.T) {
+	// Not parallel: conf.SetTestSettings mutates package-global state.
+	prev := conf.GetSettings()
+	t.Cleanup(func() { conf.SetTestSettings(prev) })
+
+	settings := &conf.Settings{}
+	settings.Realtime.Audio.SoundLevel.Enabled = false
+	settings.Realtime.Audio.SoundLevel.Interval = 10
+	conf.SetTestSettings(settings)
+
+	// engine is intentionally nil: the guard must return before dereferencing
+	// it. If this panics, the gate was not taken.
+	p := &AudioPipelineService{}
+	assert.NotPanics(t, func() {
+		p.registerSoundLevelConsumers([]string{"src-1", "src-2"}, "unit_test_disabled")
+	}, "registerSoundLevelConsumers must early-return when SoundLevel.Enabled is false")
+	assert.Empty(t, p.soundLevelConsumers,
+		"no consumers should be tracked when sound level is disabled")
+}
+
+// TestRegisterSoundLevelConsumers_DisabledRepeatedCallsStayQuiet re-runs the
+// disabled-path check to catch any state that might accumulate across calls
+// (idempotency regression).
+func TestRegisterSoundLevelConsumers_DisabledRepeatedCallsStayQuiet(t *testing.T) {
+	prev := conf.GetSettings()
+	t.Cleanup(func() { conf.SetTestSettings(prev) })
+
+	settings := &conf.Settings{}
+	settings.Realtime.Audio.SoundLevel.Enabled = false
+	conf.SetTestSettings(settings)
+
+	p := &AudioPipelineService{}
+	for range 10 {
+		p.registerSoundLevelConsumers([]string{"src-1"}, "unit_test_repeat")
+	}
+	assert.Empty(t, p.soundLevelConsumers)
+}
+
+// TestReconfigureSoundLevel_DisableWithNoRoutes verifies the hot-reload
+// disable path is safe when no routes were ever created. The teardown helper
+// must not touch the engine in that case since p.engine would be nil in a
+// unit-test context.
+func TestReconfigureSoundLevel_DisableWithNoRoutes(t *testing.T) {
+	prev := conf.GetSettings()
+	t.Cleanup(func() { conf.SetTestSettings(prev) })
+
+	settings := &conf.Settings{}
+	settings.Realtime.Audio.SoundLevel.Enabled = false
+	conf.SetTestSettings(settings)
+
+	p := &AudioPipelineService{}
+	// Nil engine is acceptable because the disable path with an empty
+	// consumer map short-circuits before calling router.
+	assert.NotPanics(t, func() { p.ReconfigureSoundLevel() })
+}
+
+// TestRemoveAllSoundLevelConsumers_EmptyMapIsNoOp confirms the teardown helper
+// does not access p.engine when there is nothing tracked. Guards against a
+// regression where the helper would unconditionally dereference p.engine.
+func TestRemoveAllSoundLevelConsumers_EmptyMapIsNoOp(t *testing.T) {
+	p := &AudioPipelineService{}
+	assert.NotPanics(t, func() { p.removeAllSoundLevelConsumers("unit_test_empty") })
+	assert.Empty(t, p.soundLevelConsumers)
+}
+
+// TestRemoveAllSoundLevelConsumers_ClearsMapBeforeCalls confirms the helper
+// drains the tracking map atomically so a concurrent call sees no tracked
+// consumers while the first call is still issuing RemoveRoute.
+//
+// We simulate this by injecting a map entry and then verifying the map is
+// emptied even though the RemoveRoute call will panic on a nil engine (the
+// recover below swallows it). The post-panic state check confirms the drain
+// happened before the router call.
+func TestRemoveAllSoundLevelConsumers_DrainsMapBeforeRouterCalls(t *testing.T) {
+	p := &AudioPipelineService{
+		soundLevelConsumers: map[string]string{"src-1": "soundlevel_src-1"},
+	}
+
+	// Engine is nil, so RemoveRoute will panic. The drain must happen first.
+	func() {
+		defer func() { _ = recover() }()
+		p.removeAllSoundLevelConsumers("unit_test_drain")
+	}()
+
+	require.Empty(t, p.soundLevelConsumers,
+		"tracking map must be cleared atomically before router.RemoveRoute is called")
+}

--- a/internal/analysis/audio_pipeline_soundlevel_gate_test.go
+++ b/internal/analysis/audio_pipeline_soundlevel_gate_test.go
@@ -79,6 +79,8 @@ func TestReconfigureSoundLevel_DisableWithNoRoutes(t *testing.T) {
 // does not access p.engine when there is nothing tracked. Guards against a
 // regression where the helper would unconditionally dereference p.engine.
 func TestRemoveAllSoundLevelConsumers_EmptyMapIsNoOp(t *testing.T) {
+	t.Parallel()
+
 	p := &AudioPipelineService{}
 	assert.NotPanics(t, func() { p.removeAllSoundLevelConsumers("unit_test_empty") })
 	assert.Empty(t, p.soundLevelConsumers)
@@ -89,17 +91,26 @@ func TestRemoveAllSoundLevelConsumers_EmptyMapIsNoOp(t *testing.T) {
 // consumers while the first call is still issuing RemoveRoute.
 //
 // We simulate this by injecting a map entry and then verifying the map is
-// emptied even though the RemoveRoute call will panic on a nil engine (the
-// recover below swallows it). The post-panic state check confirms the drain
-// happened before the router call.
+// emptied even though the RemoveRoute call panics on a nil engine. The
+// deferred recover asserts the panic actually occurred so the test fails if
+// a future change allows removeAllSoundLevelConsumers to return without
+// panicking (which would silently bypass the drain guarantee we are
+// testing).
 func TestRemoveAllSoundLevelConsumers_DrainsMapBeforeRouterCalls(t *testing.T) {
+	t.Parallel()
+
 	p := &AudioPipelineService{
 		soundLevelConsumers: map[string]string{"src-1": "soundlevel_src-1"},
 	}
 
 	// Engine is nil, so RemoveRoute will panic. The drain must happen first.
 	func() {
-		defer func() { _ = recover() }()
+		defer func() {
+			r := recover()
+			require.NotNil(t, r,
+				"expected nil-engine panic from removeAllSoundLevelConsumers; "+
+					"if it returned without panicking the drain assertion below is meaningless")
+		}()
 		p.removeAllSoundLevelConsumers("unit_test_drain")
 	}()
 
@@ -114,6 +125,8 @@ func TestRemoveAllSoundLevelConsumers_DrainsMapBeforeRouterCalls(t *testing.T) {
 // out of sync with the router after RemoveAllRoutes / engine.RemoveSource
 // and re-registration would be silently skipped.
 func TestUntrackSoundLevelConsumer_RemovesOnlyTargetEntry(t *testing.T) {
+	t.Parallel()
+
 	p := &AudioPipelineService{
 		soundLevelConsumers: map[string]string{
 			"src-1": "soundlevel_src-1",
@@ -134,6 +147,8 @@ func TestUntrackSoundLevelConsumer_RemovesOnlyTargetEntry(t *testing.T) {
 // disabled at the time the route was added). A panic here would block
 // reconfigureChangedSources any time gain changes on a non-soundlevel run.
 func TestUntrackSoundLevelConsumer_MissingSourceIsNoOp(t *testing.T) {
+	t.Parallel()
+
 	p := &AudioPipelineService{
 		soundLevelConsumers: map[string]string{"src-1": "soundlevel_src-1"},
 	}
@@ -149,6 +164,8 @@ func TestUntrackSoundLevelConsumer_MissingSourceIsNoOp(t *testing.T) {
 // stale entries that cause the subsequent registerSoundLevelConsumers call
 // to skip every source.
 func TestUntrackAllSoundLevelConsumers_ClearsMap(t *testing.T) {
+	t.Parallel()
+
 	p := &AudioPipelineService{
 		soundLevelConsumers: map[string]string{
 			"src-1": "soundlevel_src-1",

--- a/internal/analysis/control_monitor.go
+++ b/internal/analysis/control_monitor.go
@@ -45,6 +45,13 @@ type ControlMonitor struct {
 	// duplicating source setup logic.
 	reconfigureSourcesFn func()
 
+	// reconfigureSoundLevelFn reconciles the sound level DSP pipeline (router
+	// routes, per-source Processor, bridge goroutines) with the current
+	// Realtime.Audio.SoundLevel.Enabled value. Provided by AudioPipelineService
+	// because the pipeline owns those resources; ControlMonitor only toggles
+	// the downstream publisher via soundLevelManager.
+	reconfigureSoundLevelFn func()
+
 	// Sound level manager for lifecycle management
 	soundLevelManager *SoundLevelManager
 
@@ -60,25 +67,33 @@ type ControlMonitor struct {
 }
 
 // NewControlMonitor creates a new ControlMonitor instance.
-// The reconfigureSourcesFn callback removes all existing audio sources and
-// sets up new ones from current settings; it is called during stream
-// reconfiguration to avoid duplicating source setup logic.
-func NewControlMonitor(wg *sync.WaitGroup, controlChan chan string, quitChan, restartChan chan struct{}, bufferManager *BufferManager, proc *processor.Processor, audioLevelChan chan audiocore.AudioLevelData, soundLevelChan chan soundlevel.SoundLevelData, apiController *apiv2.Controller, metrics *observability.Metrics, quietHoursScheduler *schedule.QuietHoursScheduler, audioEngine *engine.AudioEngine, reconfigureSourcesFn func()) *ControlMonitor {
+//
+// reconfigureSourcesFn removes all existing audio sources and sets up new ones
+// from current settings; it is called during stream reconfiguration to avoid
+// duplicating source setup logic.
+//
+// reconfigureSoundLevelFn reconciles the sound level DSP pipeline with the
+// current Realtime.Audio.SoundLevel.Enabled value; it is called before the
+// sound level manager is restarted so that router routes exist when the
+// publisher starts (enable) or are gone before the publisher stops (disable).
+// May be nil in contexts where no sound level pipeline is owned.
+func NewControlMonitor(wg *sync.WaitGroup, controlChan chan string, quitChan, restartChan chan struct{}, bufferManager *BufferManager, proc *processor.Processor, audioLevelChan chan audiocore.AudioLevelData, soundLevelChan chan soundlevel.SoundLevelData, apiController *apiv2.Controller, metrics *observability.Metrics, quietHoursScheduler *schedule.QuietHoursScheduler, audioEngine *engine.AudioEngine, reconfigureSourcesFn, reconfigureSoundLevelFn func()) *ControlMonitor {
 	cm := &ControlMonitor{
-		wg:                   wg,
-		controlChan:          controlChan,
-		quitChan:             quitChan,
-		restartChan:          restartChan,
-		bufferManager:        bufferManager,
-		audioLevelChan:       audioLevelChan,
-		soundLevelChan:       soundLevelChan,
-		proc:                 proc,
-		bn:                   proc.Bn,
-		apiController:        apiController,
-		metrics:              metrics,
-		quietHoursScheduler:  quietHoursScheduler,
-		engine:               audioEngine,
-		reconfigureSourcesFn: reconfigureSourcesFn,
+		wg:                      wg,
+		controlChan:             controlChan,
+		quitChan:                quitChan,
+		restartChan:             restartChan,
+		bufferManager:           bufferManager,
+		audioLevelChan:          audioLevelChan,
+		soundLevelChan:          soundLevelChan,
+		proc:                    proc,
+		bn:                      proc.Bn,
+		apiController:           apiController,
+		metrics:                 metrics,
+		quietHoursScheduler:     quietHoursScheduler,
+		engine:                  audioEngine,
+		reconfigureSourcesFn:    reconfigureSourcesFn,
+		reconfigureSoundLevelFn: reconfigureSoundLevelFn,
 	}
 
 	// Initialize the sound level manager but don't start it yet
@@ -133,7 +148,10 @@ func (cm *ControlMonitor) Stop() {
 	cm.telemetryEndpointMutex.Unlock()
 }
 
-// initializeSoundLevelIfEnabled starts sound level monitoring if it's enabled in settings
+// initializeSoundLevelIfEnabled starts sound level monitoring if it is enabled
+// in settings. The DSP-side pipeline (router routes, per-source Processor,
+// bridge goroutines) is owned by AudioPipelineService and is already set up at
+// startup via registerSoundLevelConsumers when SoundLevel.Enabled is true.
 func (cm *ControlMonitor) initializeSoundLevelIfEnabled() {
 	settings := conf.Setting()
 	if settings.Realtime.Audio.SoundLevel.Enabled {
@@ -459,9 +477,21 @@ func (cm *ControlMonitor) notifyError(message string, err error) {
 	GetLogger().Error(message, logger.Error(err))
 }
 
-// handleReconfigureSoundLevel reconfigures sound level monitoring
+// handleReconfigureSoundLevel reconfigures sound level monitoring to match the
+// current Realtime.Audio.SoundLevel settings. The DSP pipeline (router routes,
+// per-source Processor, bridge goroutines) is reconciled first via the
+// callback supplied by AudioPipelineService; the downstream publisher is then
+// restarted via SoundLevelManager. Ordering matters so that on enable the
+// routes exist before the publisher starts, and on disable the routes are
+// removed before the publisher stops.
 func (cm *ControlMonitor) handleReconfigureSoundLevel() {
 	GetLogger().Info("Reconfiguring sound level monitoring")
+
+	// Reconcile the DSP pipeline first so the state observed by the
+	// publisher matches the new settings.
+	if cm.reconfigureSoundLevelFn != nil {
+		cm.reconfigureSoundLevelFn()
+	}
 
 	// Initialize the sound level manager if not already created
 	if cm.soundLevelManager == nil {


### PR DESCRIPTION
## Summary

`AudioPipelineService.registerSoundLevelConsumers` built the full sound level DSP pipeline for every source regardless of `Realtime.Audio.SoundLevel.Enabled`. Only the downstream publisher was gated, so with sound level disabled every incoming audio frame still ran through a 27-band biquad filter bank before the resulting measurement was discarded on a default-skip channel send.

Observed on a production Pi instance with sound level disabled, 1 source, 2h51m uptime:

| Metric | Value |
|---|---:|
| `soundlevel.Processor.ProcessSamples` live heap | 16 MB |
| `soundlevel.NewProcessor` alloc (startup) | 13.4 MB |
| `soundlevel.Processor.ProcessSamples` alloc churn | 19.1 MB / 2h51m |
| `formatBandKey` + `fmt.Sprintf` churn | 3 MB |

That is about 13 MB/h of alloc churn per source, on top of the wasted DSP CPU from running 27 biquad filters at 48 kHz for output nobody reads.

## Changes

- Gate `registerSoundLevelConsumers` on `SoundLevel.Enabled`. Returns before any processor, consumer or route is created.
- Track registered consumers in a new `soundLevelConsumers` map (`sourceID -> consumerID`) so the function is idempotent across startup, `reconfigure_diff`, `gain_change` and hot-reload calls.
- Add `AudioPipelineService.ReconfigureSoundLevel` as the hot-reload entry point: on enable, register consumers for every active source that does not already have one; on disable, drain the tracking map and call `Router.RemoveRoute` for each entry, which closes the consumer and unblocks its bridge goroutine.
- Thread a `reconfigureSoundLevelFn` callback through `NewControlMonitor`. `handleReconfigureSoundLevel` invokes it before restarting `SoundLevelManager` so the publisher only ever observes consistent DSP-side state (enable: routes exist before publisher starts; disable: routes are gone before publisher stops).
- Unit tests cover the disabled no-op path, idempotent repeated calls, and verify that the teardown helper drains the tracking map atomically before issuing `RemoveRoute`.

## Hot-reload path

Toggling `SoundLevel.Enabled` via the UI now correctly builds or tears down the DSP pipeline at runtime without a service restart. The ordering in `handleReconfigureSoundLevel`:

1. `reconfigureSoundLevelFn()` reconciles the DSP pipeline with the new flag value.
2. `soundLevelManager.Restart()` reconfigures the publisher.

## Test plan

- [x] `go test -race ./internal/analysis/...` — existing suite plus new gate tests pass
- [x] `golangci-lint run ./internal/analysis/...` — 0 issues
- [ ] Validate on Pi: restart the binary with this build, confirm `soundlevel.Processor.ProcessSamples` no longer appears in the heap profile when `SoundLevel.Enabled=false`
- [ ] Toggle `SoundLevel.Enabled` true -> false -> true via Settings UI, confirm the route appears in the router logs on enable and disappears on disable, and that publisher output resumes on re-enable

## Notes

CodeRabbit local CLI is rate-limited right now, so review is deferred to the PR side (CodeRabbit auto-reviews main-targeted PRs).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dynamic sound‑level monitoring that immediately reconciles routing and publisher state when enabled or disabled.
  * Idempotent registration of sound‑level consumers to avoid duplicate routes.

* **Bug Fixes**
  * Safer teardown and reconfiguration to prevent state leakage and races when toggling sound‑level.
  * Avoids panics when sound‑level is disabled concurrently with route operations.

* **Tests**
  * Added tests for enable/disable behavior, idempotency, teardown semantics, and tracking helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->