### PR TITLE
fix(suncalc): release tzf finder after resolve to drop ~32 MB polygon data

### DIFF
--- a/internal/suncalc/timezone.go
+++ b/internal/suncalc/timezone.go
@@ -13,8 +13,13 @@ import (
 // Rounding to four decimal places (~11 m) is coarser than any real
 // timezone boundary, so stable home coordinates always land on the same
 // key across restarts and minor config edits.
+//
+// Access is guarded by tzMu. Readers may hold the read lock for cache
+// hits; writers acquire the write lock across the (expensive) cache
+// miss path, which also serialises concurrent startup callers so the
+// 32 MB tzf polygon dataset is loaded at most once per unique key.
 var (
-	tzMu    sync.Mutex
+	tzMu    sync.RWMutex
 	tzCache = make(map[string]*time.Location)
 )
 
@@ -33,47 +38,72 @@ func tzCacheKey(latitude, longitude float64) string {
 // cached by rounded coordinate so repeat callers never trigger another
 // load.
 //
-// Falls back to time.Local with a warning log if the finder cannot be
-// created, the coordinate is not covered by the polygon database, or
-// the IANA name cannot be loaded by the Go runtime.
+// Cache reads use an RLock for concurrent hits; only cache misses
+// acquire the write lock. A double-check after promoting to the write
+// lock ensures a concurrent caller that already resolved the same key
+// wins the race.
+//
+// Falls back to time.Local with a warning log (and does NOT cache the
+// fallback) if the finder cannot be created, the coordinate is not
+// covered by the polygon database, or the IANA name cannot be loaded
+// by the Go runtime. Skipping the cache on failure lets a subsequent
+// call retry once the underlying cause is resolved.
 func resolveTimezone(latitude, longitude float64) *time.Location {
 	key := tzCacheKey(latitude, longitude)
+
+	tzMu.RLock()
+	if loc, ok := tzCache[key]; ok {
+		tzMu.RUnlock()
+		return loc
+	}
+	tzMu.RUnlock()
 
 	tzMu.Lock()
 	defer tzMu.Unlock()
 
+	// Double-check: another goroutine may have populated the cache
+	// while we were waiting for the write lock.
 	if loc, ok := tzCache[key]; ok {
 		return loc
 	}
-	loc := lookupLocationLocked(latitude, longitude)
-	tzCache[key] = loc
+	loc, ok := lookupLocationLocked(latitude, longitude)
+	if ok {
+		tzCache[key] = loc
+	}
 	return loc
 }
 
 // lookupLocationLocked resolves a single coordinate pair using a
-// short-lived tzf finder. The caller must hold tzMu, which serialises
-// the expensive first load across concurrent startup callers.
+// short-lived tzf finder. The caller must hold the write lock of
+// tzMu, which serialises the expensive first load across concurrent
+// startup callers.
+//
+// Returns (loc, true) on a real resolution and (time.Local, false)
+// on any failure. The caller uses the bool to decide whether to
+// cache the result so transient failures (missing tzdata, OS errors
+// inside time.LoadLocation) do not stick for the lifetime of the
+// process.
 //
 // The finder escapes this function only as unreferenced memory: once
 // the call returns, no goroutine holds a pointer to it, so its
 // polygon backing store becomes eligible for collection.
-func lookupLocationLocked(latitude, longitude float64) *time.Location {
+func lookupLocationLocked(latitude, longitude float64) (*time.Location, bool) {
 	finder, err := tzf.NewDefaultFinder()
 	if err != nil {
 		log.Printf("suncalc: timezone finder init failed, falling back to system timezone: %v", err)
-		return time.Local
+		return time.Local, false
 	}
 	// tzf API takes (longitude, latitude) -- longitude first.
 	tzName := finder.GetTimezoneName(longitude, latitude)
 	if tzName == "" {
 		log.Printf("suncalc: no timezone found for coordinates (%.4f, %.4f), falling back to system timezone", latitude, longitude)
-		return time.Local
+		return time.Local, false
 	}
 	loc, err := time.LoadLocation(tzName)
 	if err != nil {
 		log.Printf("suncalc: failed to load timezone %q for coordinates (%.4f, %.4f), falling back to system timezone: %v",
 			tzName, latitude, longitude, err)
-		return time.Local
+		return time.Local, false
 	}
-	return loc
+	return loc, true
 }

--- a/internal/suncalc/timezone.go
+++ b/internal/suncalc/timezone.go
@@ -1,6 +1,7 @@
 package suncalc
 
 import (
+	"fmt"
 	"log"
 	"sync"
 	"time"
@@ -8,30 +9,62 @@ import (
 	tzf "github.com/ringsaturn/tzf"
 )
 
+// tzCache maps a rounded "lat,lon" key to the resolved *time.Location.
+// Rounding to four decimal places (~11 m) is coarser than any real
+// timezone boundary, so stable home coordinates always land on the same
+// key across restarts and minor config edits.
 var (
-	tzFinder  tzf.F
-	tzOnce    sync.Once
-	errTZInit error
+	tzMu    sync.Mutex
+	tzCache = make(map[string]*time.Location)
 )
 
-// initTZFinder initializes the singleton timezone finder.
-// Uses sync.Once to ensure the expensive polygon data is loaded only once.
-func initTZFinder() {
-	tzOnce.Do(func() {
-		tzFinder, errTZInit = tzf.NewDefaultFinder()
-	})
+// tzCacheKey builds the cache key for a coordinate pair.
+func tzCacheKey(latitude, longitude float64) string {
+	return fmt.Sprintf("%.4f,%.4f", latitude, longitude)
 }
 
 // resolveTimezone returns the IANA timezone for the given coordinates.
-// Falls back to time.Local if lookup fails, with a warning log.
+//
+// The tzf finder carries ~32 MB of worldwide polygon data and only
+// needs to answer one question per unique coordinate pair. To avoid
+// pinning that dataset for the lifetime of the process, the finder is
+// created inside a local scope, consulted once, and dropped so the
+// next GC cycle can reclaim its memory. The resolved *time.Location is
+// cached by rounded coordinate so repeat callers never trigger another
+// load.
+//
+// Falls back to time.Local with a warning log if the finder cannot be
+// created, the coordinate is not covered by the polygon database, or
+// the IANA name cannot be loaded by the Go runtime.
 func resolveTimezone(latitude, longitude float64) *time.Location {
-	initTZFinder()
-	if errTZInit != nil {
-		log.Printf("suncalc: timezone finder init failed, falling back to system timezone: %v", errTZInit)
+	key := tzCacheKey(latitude, longitude)
+
+	tzMu.Lock()
+	defer tzMu.Unlock()
+
+	if loc, ok := tzCache[key]; ok {
+		return loc
+	}
+	loc := lookupLocationLocked(latitude, longitude)
+	tzCache[key] = loc
+	return loc
+}
+
+// lookupLocationLocked resolves a single coordinate pair using a
+// short-lived tzf finder. The caller must hold tzMu, which serialises
+// the expensive first load across concurrent startup callers.
+//
+// The finder escapes this function only as unreferenced memory: once
+// the call returns, no goroutine holds a pointer to it, so its
+// polygon backing store becomes eligible for collection.
+func lookupLocationLocked(latitude, longitude float64) *time.Location {
+	finder, err := tzf.NewDefaultFinder()
+	if err != nil {
+		log.Printf("suncalc: timezone finder init failed, falling back to system timezone: %v", err)
 		return time.Local
 	}
-	// tzf API takes (longitude, latitude) -- longitude first
-	tzName := tzFinder.GetTimezoneName(longitude, latitude)
+	// tzf API takes (longitude, latitude) -- longitude first.
+	tzName := finder.GetTimezoneName(longitude, latitude)
 	if tzName == "" {
 		log.Printf("suncalc: no timezone found for coordinates (%.4f, %.4f), falling back to system timezone", latitude, longitude)
 		return time.Local

--- a/internal/suncalc/timezone_test.go
+++ b/internal/suncalc/timezone_test.go
@@ -31,6 +31,32 @@ func TestResolveTimezone_FallbackOnZeroCoordinates(t *testing.T) {
 	require.NotNil(t, loc, "resolveTimezone returned nil for (0,0)")
 }
 
+func TestResolveTimezone_CacheReturnsSameLocation(t *testing.T) {
+	first := resolveTimezone(testLatitude, testLongitude)
+	second := resolveTimezone(testLatitude, testLongitude)
+	require.NotNil(t, first)
+	require.NotNil(t, second)
+	// Cache hit returns the exact same *time.Location pointer, so the
+	// per-coord load path runs at most once.
+	assert.Same(t, first, second, "repeat resolveTimezone should return the cached pointer")
+
+	tzMu.Lock()
+	_, ok := tzCache[tzCacheKey(testLatitude, testLongitude)]
+	tzMu.Unlock()
+	assert.True(t, ok, "cache should be populated after first resolve")
+}
+
+func TestResolveTimezone_NearbyCoordsShareCacheEntry(t *testing.T) {
+	// Coordinates within ~11 m (the 4-decimal cache precision) must
+	// share a cache entry, so tiny config drift does not re-load the
+	// 32 MB tzf dataset.
+	first := resolveTimezone(testLatitude, testLongitude)
+	second := resolveTimezone(testLatitude+0.00001, testLongitude+0.00001)
+	require.NotNil(t, first)
+	require.NotNil(t, second)
+	assert.Same(t, first, second, "nearby coordinates should resolve to the cached *time.Location")
+}
+
 func TestNewSunCalc_StoresLocation(t *testing.T) {
 	sc := NewSunCalc(testLatitude, testLongitude)
 	require.NotNil(t, sc.location, "SunCalc.location is nil after construction")

--- a/internal/suncalc/timezone_test.go
+++ b/internal/suncalc/timezone_test.go
@@ -40,9 +40,9 @@ func TestResolveTimezone_CacheReturnsSameLocation(t *testing.T) {
 	// per-coord load path runs at most once.
 	assert.Same(t, first, second, "repeat resolveTimezone should return the cached pointer")
 
-	tzMu.Lock()
+	tzMu.RLock()
 	_, ok := tzCache[tzCacheKey(testLatitude, testLongitude)]
-	tzMu.Unlock()
+	tzMu.RUnlock()
 	assert.True(t, ok, "cache should be populated after first resolve")
 }
 
@@ -50,6 +50,16 @@ func TestResolveTimezone_NearbyCoordsShareCacheEntry(t *testing.T) {
 	// Coordinates within ~11 m (the 4-decimal cache precision) must
 	// share a cache entry, so tiny config drift does not re-load the
 	// 32 MB tzf dataset.
+	//
+	// Precondition: the two coord pairs must round to the same key.
+	// Assert it explicitly so the test fails deterministically (not
+	// flakily) if testLatitude/testLongitude is ever tweaked to sit on
+	// a 4-decimal rounding boundary like X.XXX95.
+	require.Equal(t,
+		tzCacheKey(testLatitude, testLongitude),
+		tzCacheKey(testLatitude+0.00001, testLongitude+0.00001),
+		"test precondition: both coord pairs must round to the same cache key")
+
 	first := resolveTimezone(testLatitude, testLongitude)
 	second := resolveTimezone(testLatitude+0.00001, testLongitude+0.00001)
 	require.NotNil(t, first)


### PR DESCRIPTION
## Summary

- Release the `tzf` timezone finder after each coordinate resolve instead of pinning it for the process lifetime, reclaiming ~32 MB of live heap (43% of the ~73 MB live heap on a reference deployment).
- Cache the resolved `*time.Location` by rounded `(lat, lon)` so repeat callers never re-create the finder, while a coordinate change at runtime still reloads correctly.

## Motivation

Profiling on a Raspberry Pi deployment showed that `tidwall/geojson/geometry.makeSeries` (15.6 MB) + `geometry.(*baseSeries).setCompressed` (8.4 MB) + `ringsaturn/tzf.NewFuzzyFinderFromPB` (7.3 MB) accounted for ~32 MB of live heap, 43% of the 73 MB total. Those allocations come from `tzf.NewDefaultFinder()` which the old `initTZFinder` stored in a package-level `tzFinder` variable guarded by `sync.Once`. After the first `resolveTimezone` call the polygon data was never consulted again but sat resident for the lifetime of the process.

`resolveTimezone` is only called three times at startup (from `NewSunCalc` in `internal/analysis`, `internal/weather`, and the datastore) with the same home coordinate, so pinning the worldwide polygon database is pure waste.

## Approach

1. Drop the `tzFinder` / `tzOnce` / `errTZInit` package vars.
2. Introduce `tzCache map[string]*time.Location` guarded by `tzMu sync.Mutex`, keyed by `fmt.Sprintf("%.4f,%.4f", lat, lon)` (~11 m precision, well under any real timezone boundary).
3. On cache miss, create a local `tzf.Finder` inside `lookupLocationLocked`, read the zone name, return. Because the finder is a local variable, it becomes unreachable when the function returns and GC reclaims the polygon data on the next cycle.
4. Fallback behavior unchanged: `time.Local` with a descriptive log on init failure, unknown coordinate, or `LoadLocation` failure.

## Verification

- `go test -race -count=1 ./internal/suncalc/...` - all existing tests pass, plus two new ones:
  - `TestResolveTimezone_CacheReturnsSameLocation` - repeat call returns the same cached `*time.Location` pointer.
  - `TestResolveTimezone_NearbyCoordsShareCacheEntry` - coords within the 4-decimal precision collapse to the same cache key.
- `golangci-lint run ./internal/suncalc/...` - 0 issues.
- `go build ./...` - clean.

## Expected impact

- Live heap drops from ~73 MB to ~41 MB on the reference deployment.
- One-time startup alloc decreases by the ~580 MB of `NewFinderFromPB` / `DecompressedPolylineBytesToPoints` / `makeSeries` traffic, since that memory is released immediately after use instead of being retained.
- RSS on Raspberry Pi deployments expected to drop roughly 30 MB from a baseline of ~427 MB.

## Test plan

- [ ] Local unit tests: `go test -race -count=1 ./internal/suncalc/...`
- [ ] Build for Raspberry Pi (aarch64) and deploy to reference host, warm up, capture post-deploy heap profile, compare with pre-deploy baseline.
- [ ] Verify RSS drop via `ps rss` sweep post-deploy.
- [ ] Sanity-check timezone resolution on two distinct coordinates to ensure the cache miss path still works after the first resolve.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes / Performance Improvements**
  * Improved timezone resolution caching to reduce redundant lookups and ensure identical coordinates reuse the same timezone object.
* **Tests**
  * Added tests validating cache behavior: repeated lookups return the same timezone instance and nearby coordinates normalize to a shared cache entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->