### PR TITLE
fix(datastore): reconcile stale unique indexes before AutoMigrate

### DIFF
--- a/internal/datastore/index_reconcile.go
+++ b/internal/datastore/index_reconcile.go
@@ -5,12 +5,32 @@
 // from UNIQUE(species_name) to a composite UNIQUE(species_name, model_name),
 // existing MySQL/SQLite DBs retained the old single-column index. The stale
 // constraint then blocks legitimate composite-valid inserts and, on MySQL,
-// causes AutoMigrate itself to fail on restart with Error 1062. This
-// reconciler detects DB unique indexes whose column set matches no
-// entity-declared unique index and drops them before AutoMigrate runs.
+// causes AutoMigrate itself to fail on restart with Error 1062.
+//
+// Drop policy (conservative): the reconciler only drops a live unique index
+// when its column set is a strict subset of some declared unique index's
+// column set on the same entity. Exact matches are preserved (equivalent
+// constraint). Supersets, unrelated column sets, and manually added unique
+// constraints are all preserved. This targets the realistic legacy shape of
+// narrower-precursor indexes that became part of a composite, without
+// collateral damage to admin-added indexes or newer schemas the current
+// process doesn't know about (e.g., rolling downgrade).
+//
+// Tag coverage: only indexes declared via `gorm:"uniqueIndex[:name]"` tags
+// are recognised by the GORM schema parser (stmt.Schema.ParseIndexes()). The
+// bare `gorm:"unique"` column attribute emits an inline UNIQUE constraint
+// that does NOT appear as a parseable index; adding such tags to legacy
+// entities would cause the reconciler to misclassify the corresponding DB
+// index as undeclared. Today's legacy entities use `uniqueIndex` only.
 //
 // Scope: legacy entities in internal/datastore/model.go. The v2 schema has
 // its own migration path and is out of scope.
+//
+// MySQL case sensitivity: queries against information_schema use the dbName
+// and entity table name verbatim. On hosts with `lower_case_table_names=0`
+// and mixed-case table names, introspection can silently return no rows and
+// the reconciler becomes a no-op for that table. This matches the existing
+// image_caches schema-check behaviour in validateAndFixSchema.
 //
 // Symptoms addressed: MySQL Error 1062 "Duplicate entry for key
 // idx_dt_species_model" on every service start, and SQLite "UNIQUE
@@ -105,6 +125,39 @@ func indexIsDeclared(live dbUniqueIndex, declared []entityUniqueIndex) bool {
 	return false
 }
 
+// columnSubset reports whether every column in sub is also in super. Order
+// is ignored. An empty sub is considered a subset of any super.
+func columnSubset(sub, super []string) bool {
+	if len(sub) > len(super) {
+		return false
+	}
+	seen := make(map[string]struct{}, len(super))
+	for _, c := range super {
+		seen[c] = struct{}{}
+	}
+	for _, c := range sub {
+		if _, ok := seen[c]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// indexIsLegacyPrecursor reports whether the live DB unique index is a
+// strict subset of any entity-declared unique index. This is the drop
+// criterion for the reconciler: a legacy single-column or narrower
+// composite unique index that was superseded by a broader declared
+// composite (e.g. UNIQUE(species_name) -> UNIQUE(species_name, model_name)).
+// Equal column sets are handled by indexIsDeclared and must be preserved.
+func indexIsLegacyPrecursor(live dbUniqueIndex, declared []entityUniqueIndex) bool {
+	for _, d := range declared {
+		if columnSubset(live.Columns, d.Columns) && !columnSetsEqual(live.Columns, d.Columns) {
+			return true
+		}
+	}
+	return false
+}
+
 // reconcileLegacyUniqueIndexes drops DB-side unique indexes that the given
 // GORM entities no longer declare. It is intended to run before AutoMigrate
 // so that stale constraints don't block legitimate schema evolution.
@@ -165,19 +218,29 @@ func reconcileLegacyUniqueIndexes(db *gorm.DB, dbType, dbName string, entities [
 			if indexIsDeclared(idx, declared) {
 				continue
 			}
-			GetLogger().Info("Dropping stale unique index not declared by entity",
+			if !indexIsLegacyPrecursor(idx, declared) {
+				// Preserve indexes that aren't a strict subset of a declared
+				// unique index. Covers admin-added stricter constraints,
+				// unrelated unique indexes, and any newer declarations a
+				// rolling-downgrade process would otherwise delete.
+				continue
+			}
+			GetLogger().Info("Dropping legacy precursor unique index superseded by declared composite",
 				logger.String("db_type", dialect),
 				logger.String("table", idx.Table),
 				logger.String("index", idx.Name),
 				logger.Any("columns", idx.Columns))
 			if err := dropUniqueIndex(db, dialect, idx); err != nil {
-				return errors.New(err).
-					Component("datastore").
-					Category(errors.CategoryDatabase).
-					Context("operation", "reconcile_drop_index").
-					Context("table", idx.Table).
-					Context("index", idx.Name).
-					Build()
+				// Non-fatal: log and continue so one problematic index doesn't
+				// block reconciliation of the rest. The caller already treats
+				// reconciler failures as warnings, but per-index resilience is
+				// cheaper than restarting the loop.
+				GetLogger().Warn("Failed to drop legacy precursor index, continuing",
+					logger.String("db_type", dialect),
+					logger.String("table", idx.Table),
+					logger.String("index", idx.Name),
+					logger.Error(err))
+				continue
 			}
 		}
 	}
@@ -283,11 +346,18 @@ func dropUniqueIndex(db *gorm.DB, dialect string, idx dbUniqueIndex) error {
 		if !isSafeIdentifier(idx.Name) || !isSafeIdentifier(idx.Table) {
 			return fmt.Errorf("unsafe identifier refusing drop: table=%q index=%q", idx.Table, idx.Name)
 		}
-		return db.Exec(fmt.Sprintf("ALTER TABLE `%s` DROP INDEX `%s`", idx.Table, idx.Name)).Error
+		err := db.Exec(fmt.Sprintf("ALTER TABLE `%s` DROP INDEX `%s`", idx.Table, idx.Name)).Error
+		if err != nil && isMySQLError(err, mysqlErrCantDropFieldOrKey) {
+			// Another instance (or an operator) dropped the index between our
+			// read and this statement. The intent is met; treat as success.
+			return nil
+		}
+		return err
 	case DialectSQLite:
 		if !isSafeIdentifier(idx.Name) {
 			return fmt.Errorf("unsafe identifier refusing drop: index=%q", idx.Name)
 		}
+		// SQLite's IF EXISTS already handles the concurrent-drop race.
 		return db.Exec(fmt.Sprintf("DROP INDEX IF EXISTS %q", idx.Name)).Error
 	default:
 		return fmt.Errorf("unsupported dialect: %s", dialect)

--- a/internal/datastore/index_reconcile.go
+++ b/internal/datastore/index_reconcile.go
@@ -1,0 +1,317 @@
+// Package datastore: stale unique-index reconciler.
+//
+// GORM's AutoMigrate only adds new indexes; it never drops indexes that are
+// no longer declared on the entity. When the DynamicThreshold schema evolved
+// from UNIQUE(species_name) to a composite UNIQUE(species_name, model_name),
+// existing MySQL/SQLite DBs retained the old single-column index. The stale
+// constraint then blocks legitimate composite-valid inserts and, on MySQL,
+// causes AutoMigrate itself to fail on restart with Error 1062. This
+// reconciler detects DB unique indexes whose column set matches no
+// entity-declared unique index and drops them before AutoMigrate runs.
+//
+// Scope: legacy entities in internal/datastore/model.go. The v2 schema has
+// its own migration path and is out of scope.
+//
+// Symptoms addressed: MySQL Error 1062 "Duplicate entry for key
+// idx_dt_species_model" on every service start, and SQLite "UNIQUE
+// constraint failed: dynamic_thresholds.species_name" on legitimate inserts
+// once the schema grew the composite (species_name, model_name) index.
+package datastore
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/tphakala/birdnet-go/internal/errors"
+	"github.com/tphakala/birdnet-go/internal/logger"
+	"gorm.io/gorm"
+)
+
+// dbUniqueIndex describes a unique index discovered on the live database.
+// Columns are ordered by the index's column sequence (SEQ_IN_INDEX in MySQL,
+// seqno in SQLite PRAGMA index_info).
+type dbUniqueIndex struct {
+	Name    string
+	Table   string
+	Columns []string
+}
+
+// entityUniqueIndex describes a unique index declared on a GORM entity.
+// Columns are the physical (DB) column names in declaration order.
+type entityUniqueIndex struct {
+	Name    string
+	Columns []string
+}
+
+// declaredUniqueIndexes parses a GORM entity and returns its declared unique
+// indexes along with its physical table name. Declared indexes come from
+// `gorm:"uniqueIndex:..."` tags and single-column `gorm:"uniqueIndex"` tags.
+// The GORM schema parser (stmt.Parse + Schema.ParseIndexes) is the source of
+// truth here; it matches the index names GORM would emit via AutoMigrate.
+func declaredUniqueIndexes(db *gorm.DB, entity any) (tableName string, indexes []entityUniqueIndex, err error) {
+	stmt := &gorm.Statement{DB: db}
+	if err := stmt.Parse(entity); err != nil {
+		return "", nil, fmt.Errorf("parse entity %T: %w", entity, err)
+	}
+
+	parsedIndexes := stmt.Schema.ParseIndexes()
+	indexes = make([]entityUniqueIndex, 0, len(parsedIndexes))
+	for _, idx := range parsedIndexes {
+		if !strings.EqualFold(idx.Class, "UNIQUE") {
+			continue
+		}
+		cols := make([]string, 0, len(idx.Fields))
+		for _, f := range idx.Fields {
+			if f.Field != nil { //nolint:staticcheck // QF1008: Field is embedded *schema.Field; nil check is required before accessing promoted fields
+				cols = append(cols, f.DBName)
+			}
+		}
+		if len(cols) == 0 {
+			continue
+		}
+		indexes = append(indexes, entityUniqueIndex{
+			Name:    idx.Name,
+			Columns: cols,
+		})
+	}
+
+	return stmt.Schema.Table, indexes, nil
+}
+
+// columnSetsEqual reports whether two column lists describe the same set of
+// columns, ignoring order. Index identity for uniqueness purposes is the
+// unordered column set; GORM emits indexes in declaration order but legacy
+// DDL could have stored them in any order.
+func columnSetsEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	aSorted := slices.Clone(a)
+	bSorted := slices.Clone(b)
+	slices.Sort(aSorted)
+	slices.Sort(bSorted)
+	return slices.Equal(aSorted, bSorted)
+}
+
+// indexIsDeclared reports whether the given live DB unique index matches any
+// entity-declared unique index by column set.
+func indexIsDeclared(live dbUniqueIndex, declared []entityUniqueIndex) bool {
+	for _, d := range declared {
+		if columnSetsEqual(live.Columns, d.Columns) {
+			return true
+		}
+	}
+	return false
+}
+
+// reconcileLegacyUniqueIndexes drops DB-side unique indexes that the given
+// GORM entities no longer declare. It is intended to run before AutoMigrate
+// so that stale constraints don't block legitimate schema evolution.
+//
+// Failures drop through as errors for the caller to log + swallow (same
+// non-fatal pattern as cleanupLegacySchemaContamination).
+//
+// dbType is case-insensitive ("MySQL", "SQLite", ...). dbName is required
+// for MySQL (used as TABLE_SCHEMA); pass "" for SQLite.
+func reconcileLegacyUniqueIndexes(db *gorm.DB, dbType, dbName string, entities []any) error {
+	dialect := strings.ToLower(dbType)
+	switch dialect {
+	case DialectSQLite:
+		// ok, no dbName needed
+	case DialectMySQL:
+		if dbName == "" {
+			// Same defensive posture as validateAndFixSchema: without dbName
+			// we can't query information_schema safely. Skip quietly.
+			GetLogger().Warn("reconcileLegacyUniqueIndexes: empty dbName for MySQL, skipping")
+			return nil
+		}
+	default:
+		// Unknown dialect: skip. Unit tests exercise the known dialects.
+		return nil
+	}
+
+	for _, entity := range entities {
+		tableName, declared, err := declaredUniqueIndexes(db, entity)
+		if err != nil {
+			return errors.New(err).
+				Component("datastore").
+				Category(errors.CategoryDatabase).
+				Context("operation", "reconcile_parse_entity").
+				Build()
+		}
+
+		if !db.Migrator().HasTable(entity) {
+			continue
+		}
+
+		var live []dbUniqueIndex
+		switch dialect {
+		case DialectSQLite:
+			live, err = liveUniqueIndexesSQLite(db, tableName)
+		case DialectMySQL:
+			live, err = liveUniqueIndexesMySQL(db, dbName, tableName)
+		}
+		if err != nil {
+			return errors.New(err).
+				Component("datastore").
+				Category(errors.CategoryDatabase).
+				Context("operation", "reconcile_read_live_indexes").
+				Context("table", tableName).
+				Build()
+		}
+
+		for _, idx := range live {
+			if indexIsDeclared(idx, declared) {
+				continue
+			}
+			GetLogger().Info("Dropping stale unique index not declared by entity",
+				logger.String("db_type", dialect),
+				logger.String("table", idx.Table),
+				logger.String("index", idx.Name),
+				logger.Any("columns", idx.Columns))
+			if err := dropUniqueIndex(db, dialect, idx); err != nil {
+				return errors.New(err).
+					Component("datastore").
+					Category(errors.CategoryDatabase).
+					Context("operation", "reconcile_drop_index").
+					Context("table", idx.Table).
+					Context("index", idx.Name).
+					Build()
+			}
+		}
+	}
+	return nil
+}
+
+// liveUniqueIndexesSQLite returns the unique indexes currently present on the
+// given table in SQLite, excluding the implicit PRIMARY KEY index (sqlite
+// auto-generated indexes whose names start with "sqlite_autoindex_" are
+// skipped; they cannot be dropped and track PK/UNIQUE constraints that
+// belong to the CREATE TABLE statement).
+func liveUniqueIndexesSQLite(db *gorm.DB, tableName string) ([]dbUniqueIndex, error) {
+	type listRow struct {
+		Name   string `gorm:"column:name"`
+		Unique int    `gorm:"column:unique"`
+	}
+	var list []listRow
+	escaped := strings.ReplaceAll(tableName, "'", "''")
+	if err := db.Raw("PRAGMA index_list('" + escaped + "')").Scan(&list).Error; err != nil {
+		return nil, fmt.Errorf("pragma index_list %s: %w", tableName, err)
+	}
+
+	result := make([]dbUniqueIndex, 0, len(list))
+	for _, r := range list {
+		if r.Unique != 1 {
+			continue
+		}
+		if strings.HasPrefix(r.Name, "sqlite_autoindex_") {
+			continue
+		}
+		cols, err := getSQLiteIndexColumns(db, r.Name, false)
+		if err != nil {
+			// getSQLiteIndexColumns already logs; skip this index.
+			continue
+		}
+		if len(cols) == 0 {
+			continue
+		}
+		result = append(result, dbUniqueIndex{
+			Name:    r.Name,
+			Table:   tableName,
+			Columns: cols,
+		})
+	}
+	return result, nil
+}
+
+// liveUniqueIndexesMySQL returns the unique indexes currently present on the
+// given table in MySQL, excluding the PRIMARY key.
+func liveUniqueIndexesMySQL(db *gorm.DB, dbName, tableName string) ([]dbUniqueIndex, error) {
+	type row struct {
+		IndexName  string `gorm:"column:INDEX_NAME"`
+		ColumnName string `gorm:"column:COLUMN_NAME"`
+		SeqInIndex int    `gorm:"column:SEQ_IN_INDEX"`
+		NonUnique  int    `gorm:"column:NON_UNIQUE"`
+	}
+	var rows []row
+	query := `SELECT INDEX_NAME, COLUMN_NAME, SEQ_IN_INDEX, NON_UNIQUE
+	          FROM information_schema.STATISTICS
+	          WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ?
+	          ORDER BY INDEX_NAME, SEQ_IN_INDEX`
+	if err := db.Raw(query, dbName, tableName).Scan(&rows).Error; err != nil {
+		if isMySQLError(err, mysqlErrNoSuchTable) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("information_schema.STATISTICS for %s.%s: %w", dbName, tableName, err)
+	}
+
+	grouped := make(map[string]*dbUniqueIndex)
+	for _, r := range rows {
+		if r.NonUnique != 0 {
+			continue
+		}
+		if strings.EqualFold(r.IndexName, "PRIMARY") {
+			continue
+		}
+		idx, ok := grouped[r.IndexName]
+		if !ok {
+			idx = &dbUniqueIndex{Name: r.IndexName, Table: tableName}
+			grouped[r.IndexName] = idx
+		}
+		idx.Columns = append(idx.Columns, r.ColumnName)
+	}
+
+	result := make([]dbUniqueIndex, 0, len(grouped))
+	for _, idx := range grouped {
+		if len(idx.Columns) == 0 {
+			continue
+		}
+		result = append(result, *idx)
+	}
+	return result, nil
+}
+
+// dropUniqueIndex issues a dialect-appropriate DROP INDEX for the given live
+// index. Identifier quoting uses backticks (MySQL) and double quotes
+// (SQLite); GORM's quoted identifier helpers are not used here because we
+// already hold resolved identifier strings from the introspection queries.
+func dropUniqueIndex(db *gorm.DB, dialect string, idx dbUniqueIndex) error {
+	switch dialect {
+	case DialectMySQL:
+		// Validate identifier to prevent SQL injection via crafted index names.
+		if !isSafeIdentifier(idx.Name) || !isSafeIdentifier(idx.Table) {
+			return fmt.Errorf("unsafe identifier refusing drop: table=%q index=%q", idx.Table, idx.Name)
+		}
+		return db.Exec(fmt.Sprintf("ALTER TABLE `%s` DROP INDEX `%s`", idx.Table, idx.Name)).Error
+	case DialectSQLite:
+		if !isSafeIdentifier(idx.Name) {
+			return fmt.Errorf("unsafe identifier refusing drop: index=%q", idx.Name)
+		}
+		return db.Exec(fmt.Sprintf("DROP INDEX IF EXISTS %q", idx.Name)).Error
+	default:
+		return fmt.Errorf("unsupported dialect: %s", dialect)
+	}
+}
+
+// isSafeIdentifier rejects identifiers that contain characters outside the
+// conservative [a-zA-Z0-9_] set. Index/table names discovered via
+// information_schema or PRAGMA should never contain exotic characters in
+// this codebase; this is defence-in-depth against a compromised system
+// catalog.
+func isSafeIdentifier(s string) bool {
+	if s == "" || len(s) > 64 {
+		return false
+	}
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z':
+		case r >= 'A' && r <= 'Z':
+		case r >= '0' && r <= '9':
+		case r == '_':
+		default:
+			return false
+		}
+	}
+	return true
+}

--- a/internal/datastore/index_reconcile.go
+++ b/internal/datastore/index_reconcile.go
@@ -43,7 +43,6 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/logger"
 	"gorm.io/gorm"
 )
@@ -187,11 +186,13 @@ func reconcileLegacyUniqueIndexes(db *gorm.DB, dbType, dbName string, entities [
 	for _, entity := range entities {
 		tableName, declared, err := declaredUniqueIndexes(db, entity)
 		if err != nil {
-			return errors.New(err).
-				Component("datastore").
-				Category(errors.CategoryDatabase).
-				Context("operation", "reconcile_parse_entity").
-				Build()
+			// Per-entity failure must not block reconciliation of the rest.
+			// A parse failure here indicates a programming error on this
+			// entity only; log and move on.
+			GetLogger().Warn("Failed to parse entity for index reconciliation, skipping",
+				logger.String("entity", fmt.Sprintf("%T", entity)),
+				logger.Error(err))
+			continue
 		}
 
 		if !db.Migrator().HasTable(entity) {
@@ -206,12 +207,15 @@ func reconcileLegacyUniqueIndexes(db *gorm.DB, dbType, dbName string, entities [
 			live, err = liveUniqueIndexesMySQL(db, dbName, tableName)
 		}
 		if err != nil {
-			return errors.New(err).
-				Component("datastore").
-				Category(errors.CategoryDatabase).
-				Context("operation", "reconcile_read_live_indexes").
-				Context("table", tableName).
-				Build()
+			// Live-index introspection failure for one table should not
+			// abort the whole reconciliation loop. A transient error or
+			// permission problem on table X shouldn't leave tables Y and Z
+			// with stale indexes.
+			GetLogger().Warn("Failed to read live indexes for table, skipping",
+				logger.String("db_type", dialect),
+				logger.String("table", tableName),
+				logger.Error(err))
+			continue
 		}
 
 		for _, idx := range live {

--- a/internal/datastore/index_reconcile_mysql_test.go
+++ b/internal/datastore/index_reconcile_mysql_test.go
@@ -1,0 +1,217 @@
+//go:build integration
+
+// Package datastore: MySQL integration tests for reconcileLegacyUniqueIndexes.
+//
+// These run inside a disposable MySQL 8.0 container provisioned by
+// internal/testutil/containers. Guard: build tag "integration". The tests
+// share one container and MUST NOT use t.Parallel() since they mutate
+// schema.
+package datastore
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/testutil/containers"
+	gormmysql "gorm.io/driver/mysql"
+	"gorm.io/gorm"
+	gormlogger "gorm.io/gorm/logger"
+)
+
+var (
+	reconTestContainer *containers.MySQLContainer
+	reconTestDB        *gorm.DB
+	reconTestDBName    string
+)
+
+func TestMain(m *testing.M) {
+	os.Exit(reconTestMain(m))
+}
+
+func reconTestMain(m *testing.M) int {
+	ctx := context.Background() //nolint:gocritic // TestMain has no *testing.T
+
+	cfg := &containers.MySQLConfig{
+		Database:     "recon_test",
+		RootPassword: "test",
+		Username:     "testuser",
+		Password:     "testpass",
+		ImageTag:     "8.0",
+	}
+
+	var err error
+	reconTestContainer, err = containers.NewMySQLContainer(ctx, cfg)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "mysql container: %v\n", err)
+		return 1
+	}
+	defer func() {
+		if err := reconTestContainer.Terminate(context.Background()); err != nil { //nolint:gocritic // cleanup outlives test
+			fmt.Fprintf(os.Stderr, "terminate container: %v\n", err)
+		}
+	}()
+
+	host, err := reconTestContainer.GetHost(ctx)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "container host: %v\n", err)
+		return 1
+	}
+	port, err := reconTestContainer.GetPort(ctx)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "container port: %v\n", err)
+		return 1
+	}
+
+	reconTestDBName = cfg.Database
+	dsn := fmt.Sprintf("%s:%s@tcp(%s:%s)/%s?charset=utf8mb4&parseTime=True&loc=Local",
+		cfg.Username, cfg.Password, host, strconv.Itoa(port), cfg.Database)
+	reconTestDB, err = gorm.Open(gormmysql.Open(dsn), &gorm.Config{
+		Logger: gormlogger.Default.LogMode(gormlogger.Silent),
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "gorm open: %v\n", err)
+		return 1
+	}
+
+	return m.Run()
+}
+
+// resetMySQLDynamicThresholds drops the table if present, so each test starts
+// from a clean slate.
+func resetMySQLDynamicThresholds(t *testing.T) {
+	t.Helper()
+	require.NoError(t, reconTestDB.Exec("DROP TABLE IF EXISTS dynamic_thresholds").Error)
+}
+
+// mysqlUniqueIndexNames returns unique-index names (excluding PRIMARY) for
+// the given table in reconTestDB.
+func mysqlUniqueIndexNames(t *testing.T, table string) []string {
+	t.Helper()
+	type row struct {
+		IndexName string `gorm:"column:INDEX_NAME"`
+	}
+	var rows []row
+	q := `SELECT DISTINCT INDEX_NAME FROM information_schema.STATISTICS
+	      WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ? AND NON_UNIQUE = 0 AND INDEX_NAME <> 'PRIMARY'`
+	require.NoError(t, reconTestDB.Raw(q, reconTestDBName, table).Scan(&rows).Error)
+	names := make([]string, 0, len(rows))
+	for _, r := range rows {
+		names = append(names, r.IndexName)
+	}
+	return names
+}
+
+// TestReconcile_MySQL_DropsStaleSpeciesName is the MySQL equivalent of the
+// SQLite test in index_reconcile_test.go: seed a pre-multi-model legacy
+// shape, run the reconciler, assert the stale index is gone and the
+// composite survives.
+func TestReconcile_MySQL_DropsStaleSpeciesName(t *testing.T) {
+	resetMySQLDynamicThresholds(t)
+
+	require.NoError(t, reconTestDB.Exec(`
+		CREATE TABLE dynamic_thresholds (
+			id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+			species_name VARCHAR(200) NOT NULL,
+			model_name VARCHAR(100) NOT NULL DEFAULT 'BirdNET',
+			scientific_name VARCHAR(200),
+			level INT NOT NULL DEFAULT 0,
+			current_value DOUBLE NOT NULL,
+			base_threshold DOUBLE NOT NULL,
+			high_conf_count INT NOT NULL DEFAULT 0,
+			valid_hours INT NOT NULL,
+			expires_at DATETIME NOT NULL,
+			last_triggered DATETIME NOT NULL,
+			first_created DATETIME NOT NULL,
+			updated_at DATETIME NOT NULL,
+			trigger_count INT NOT NULL DEFAULT 0,
+			UNIQUE KEY idx_dt_species_legacy (species_name),
+			KEY idx_expires (expires_at),
+			KEY idx_last_trig (last_triggered)
+		) ENGINE=InnoDB
+	`).Error)
+
+	require.NoError(t, reconcileLegacyUniqueIndexes(reconTestDB, "mysql", reconTestDBName, []any{&DynamicThreshold{}}))
+
+	names := mysqlUniqueIndexNames(t, "dynamic_thresholds")
+	assert.NotContains(t, names, "idx_dt_species_legacy",
+		"reconciler should drop stale UNIQUE(species_name) index")
+}
+
+// TestReconcile_MySQL_AutoMigrateSucceedsAfterReconcile is the end-to-end
+// regression for the MySQL Error 1062 restart loop: stale index present,
+// reconciler runs, AutoMigrate(&DynamicThreshold{}) must then complete
+// without error.
+func TestReconcile_MySQL_AutoMigrateSucceedsAfterReconcile(t *testing.T) {
+	resetMySQLDynamicThresholds(t)
+
+	require.NoError(t, reconTestDB.Exec(`
+		CREATE TABLE dynamic_thresholds (
+			id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+			species_name VARCHAR(200) NOT NULL,
+			model_name VARCHAR(100) NOT NULL DEFAULT 'BirdNET',
+			scientific_name VARCHAR(200),
+			level INT NOT NULL DEFAULT 0,
+			current_value DOUBLE NOT NULL,
+			base_threshold DOUBLE NOT NULL,
+			high_conf_count INT NOT NULL DEFAULT 0,
+			valid_hours INT NOT NULL,
+			expires_at DATETIME NOT NULL,
+			last_triggered DATETIME NOT NULL,
+			first_created DATETIME NOT NULL,
+			updated_at DATETIME NOT NULL,
+			trigger_count INT NOT NULL DEFAULT 0,
+			UNIQUE KEY idx_dt_species_legacy (species_name),
+			KEY idx_expires (expires_at),
+			KEY idx_last_trig (last_triggered)
+		) ENGINE=InnoDB
+	`).Error)
+	require.NoError(t, reconTestDB.Exec(`
+		INSERT INTO dynamic_thresholds
+		(species_name, model_name, current_value, base_threshold, valid_hours, expires_at, last_triggered, first_created, updated_at)
+		VALUES ('robin', 'BirdNET', 0.8, 0.5, 24, NOW(), NOW(), NOW(), NOW())
+	`).Error)
+
+	require.NoError(t, reconcileLegacyUniqueIndexes(reconTestDB, "mysql", reconTestDBName, []any{&DynamicThreshold{}}))
+	require.NoError(t, reconTestDB.AutoMigrate(&DynamicThreshold{}),
+		"AutoMigrate must succeed after reconciler drops the stale index (MySQL Error 1062 regression)")
+
+	names := mysqlUniqueIndexNames(t, "dynamic_thresholds")
+	assert.Contains(t, names, "idx_dt_species_model",
+		"composite unique index must be created by AutoMigrate post-reconcile")
+
+	var count int64
+	require.NoError(t, reconTestDB.Raw(`SELECT COUNT(*) FROM dynamic_thresholds`).Scan(&count).Error)
+	assert.Equal(t, int64(1), count, "row must survive reconcile + AutoMigrate")
+}
+
+// TestReconcile_MySQL_Idempotent verifies two consecutive reconciler runs
+// leave the index set unchanged once the DB is healthy.
+func TestReconcile_MySQL_Idempotent(t *testing.T) {
+	resetMySQLDynamicThresholds(t)
+	require.NoError(t, reconTestDB.AutoMigrate(&DynamicThreshold{}))
+	before := mysqlUniqueIndexNames(t, "dynamic_thresholds")
+
+	require.NoError(t, reconcileLegacyUniqueIndexes(reconTestDB, "mysql", reconTestDBName, []any{&DynamicThreshold{}}))
+	require.NoError(t, reconcileLegacyUniqueIndexes(reconTestDB, "mysql", reconTestDBName, []any{&DynamicThreshold{}}))
+
+	after := mysqlUniqueIndexNames(t, "dynamic_thresholds")
+	assert.ElementsMatch(t, before, after)
+}
+
+// TestReconcile_MySQL_EmptyDBName is defensive: passing an empty dbName
+// must not error and must not drop anything.
+func TestReconcile_MySQL_EmptyDBName(t *testing.T) {
+	resetMySQLDynamicThresholds(t)
+	require.NoError(t, reconTestDB.AutoMigrate(&DynamicThreshold{}))
+	before := mysqlUniqueIndexNames(t, "dynamic_thresholds")
+
+	require.NoError(t, reconcileLegacyUniqueIndexes(reconTestDB, "mysql", "", []any{&DynamicThreshold{}}))
+
+	after := mysqlUniqueIndexNames(t, "dynamic_thresholds")
+	assert.ElementsMatch(t, before, after, "empty dbName path must be a no-op")
+}

--- a/internal/datastore/index_reconcile_mysql_test.go
+++ b/internal/datastore/index_reconcile_mysql_test.go
@@ -215,3 +215,44 @@ func TestReconcile_MySQL_EmptyDBName(t *testing.T) {
 	after := mysqlUniqueIndexNames(t, "dynamic_thresholds")
 	assert.ElementsMatch(t, before, after, "empty dbName path must be a no-op")
 }
+
+// TestReconcile_MySQL_ToleratesAlreadyDropped simulates the concurrent-drop
+// race: the reconciler reads the stale index into memory, the operator (or
+// another starting instance) drops it, and then the reconciler's DROP INDEX
+// should not bubble MySQL error 1091 back as a failure.
+func TestReconcile_MySQL_ToleratesAlreadyDropped(t *testing.T) {
+	resetMySQLDynamicThresholds(t)
+	require.NoError(t, reconTestDB.Exec(`
+		CREATE TABLE dynamic_thresholds (
+			id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+			species_name VARCHAR(200) NOT NULL,
+			model_name VARCHAR(100) NOT NULL DEFAULT 'BirdNET',
+			scientific_name VARCHAR(200),
+			level INT NOT NULL DEFAULT 0,
+			current_value DOUBLE NOT NULL,
+			base_threshold DOUBLE NOT NULL,
+			high_conf_count INT NOT NULL DEFAULT 0,
+			valid_hours INT NOT NULL,
+			expires_at DATETIME NOT NULL,
+			last_triggered DATETIME NOT NULL,
+			first_created DATETIME NOT NULL,
+			updated_at DATETIME NOT NULL,
+			trigger_count INT NOT NULL DEFAULT 0,
+			UNIQUE KEY idx_dt_species_legacy (species_name)
+		) ENGINE=InnoDB
+	`).Error)
+
+	// Directly drop the stale index first to simulate a concurrent dropper.
+	// The reconciler will still think the index exists from its earlier read,
+	// but the low-level dropUniqueIndex call must swallow MySQL error 1091.
+	idx := dbUniqueIndex{
+		Name:    "idx_dt_species_legacy",
+		Table:   "dynamic_thresholds",
+		Columns: []string{"species_name"},
+	}
+	require.NoError(t, reconTestDB.Exec(
+		"ALTER TABLE `dynamic_thresholds` DROP INDEX `idx_dt_species_legacy`").Error,
+		"precondition: first drop should succeed")
+	assert.NoError(t, dropUniqueIndex(reconTestDB, "mysql", idx),
+		"second drop via reconciler helper must swallow MySQL error 1091")
+}

--- a/internal/datastore/index_reconcile_test.go
+++ b/internal/datastore/index_reconcile_test.go
@@ -151,6 +151,18 @@ func TestReconcileLegacyUniqueIndexes_SQLite_Idempotent(t *testing.T) {
 	assert.ElementsMatch(t, before, after, "idempotent runs must not change index set")
 }
 
+// noisyEntity is a test-only GORM entity pinned to the "noisy" table name.
+// The explicit TableName() prevents GORM's default pluralization from
+// resolving the struct to "noisies", which would make the autoindex test
+// vacuous (the reconciler would skip a non-existent table).
+type noisyEntity struct {
+	K string `gorm:"primaryKey;column:k"`
+	V string `gorm:"column:v"`
+}
+
+// TableName overrides GORM's naming strategy for this test entity.
+func (noisyEntity) TableName() string { return "noisy" }
+
 // TestReconcileLegacyUniqueIndexes_SQLite_IgnoresAutoIndex verifies the
 // reconciler does not attempt to drop sqlite_autoindex_* internal indexes
 // that SQLite creates for PRIMARY KEY / inline UNIQUE constraints.
@@ -164,15 +176,10 @@ func TestReconcileLegacyUniqueIndexes_SQLite_IgnoresAutoIndex(t *testing.T) {
 
 	// Give the reconciler an entity that maps to the same table name but
 	// declares no unique indexes at all, so the implicit PK autoindex would
-	// be "stale" by naive column-set comparison.
-	type noisy struct {
-		K string `gorm:"primaryKey;column:k"`
-		V string `gorm:"column:v"`
-	}
-	// This must not error and must not drop anything (DROP INDEX on an
-	// autoindex name would fail with "index associated with UNIQUE or
-	// PRIMARY KEY constraint cannot be dropped").
-	require.NoError(t, reconcileLegacyUniqueIndexes(db, "sqlite", "", []any{&noisy{}}))
+	// be "stale" by naive column-set comparison. The explicit TableName()
+	// method overrides GORM's default pluralization (which would resolve the
+	// struct "noisy" to "noisies" and skip the seeded table entirely).
+	require.NoError(t, reconcileLegacyUniqueIndexes(db, "sqlite", "", []any{&noisyEntity{}}))
 
 	// Verify the table is still usable.
 	require.NoError(t, db.Exec(`INSERT INTO noisy(k, v) VALUES ('a', '1')`).Error)

--- a/internal/datastore/index_reconcile_test.go
+++ b/internal/datastore/index_reconcile_test.go
@@ -178,6 +178,50 @@ func TestReconcileLegacyUniqueIndexes_SQLite_IgnoresAutoIndex(t *testing.T) {
 	require.NoError(t, db.Exec(`INSERT INTO noisy(k, v) VALUES ('a', '1')`).Error)
 }
 
+// TestReconcileLegacyUniqueIndexes_SQLite_PreservesSuperset verifies the
+// reconciler does NOT drop a stricter admin-added unique index whose
+// column set is a superset of a declared composite. Preserving such
+// constraints is required so the reconciler cannot relax uniqueness rules
+// the operator explicitly imposed.
+func TestReconcileLegacyUniqueIndexes_SQLite_PreservesSuperset(t *testing.T) {
+	t.Parallel()
+
+	db := openSQLiteTestDB(t)
+	require.NoError(t, db.AutoMigrate(&DynamicThreshold{}))
+	// Simulated admin-added stricter constraint: composite over declared
+	// (species_name, model_name) plus an extra column.
+	require.NoError(t, db.Exec(`
+		CREATE UNIQUE INDEX idx_dt_admin_superset
+		ON dynamic_thresholds(species_name, model_name, scientific_name)
+	`).Error)
+
+	require.NoError(t, reconcileLegacyUniqueIndexes(db, "sqlite", "", []any{&DynamicThreshold{}}))
+
+	indexes := sqliteIndexNames(t, db, "dynamic_thresholds")
+	assert.Contains(t, indexes, "idx_dt_admin_superset",
+		"superset unique index must be preserved (not a legacy precursor)")
+	assert.Contains(t, indexes, "idx_dt_species_model",
+		"declared composite must still be present")
+}
+
+// TestReconcileLegacyUniqueIndexes_SQLite_PreservesUnrelated verifies the
+// reconciler does NOT drop unique indexes whose column set does not overlap
+// with any declared unique index. Prevents collateral damage when an
+// operator added domain-specific uniqueness rules.
+func TestReconcileLegacyUniqueIndexes_SQLite_PreservesUnrelated(t *testing.T) {
+	t.Parallel()
+
+	db := openSQLiteTestDB(t)
+	require.NoError(t, db.AutoMigrate(&DynamicThreshold{}))
+	require.NoError(t, db.Exec(`CREATE UNIQUE INDEX idx_dt_unrelated ON dynamic_thresholds(scientific_name)`).Error)
+
+	require.NoError(t, reconcileLegacyUniqueIndexes(db, "sqlite", "", []any{&DynamicThreshold{}}))
+
+	indexes := sqliteIndexNames(t, db, "dynamic_thresholds")
+	assert.Contains(t, indexes, "idx_dt_unrelated",
+		"unrelated unique index (columns not a subset of any declared) must be preserved")
+}
+
 // TestReconcileLegacyUniqueIndexes_SQLite_PreservesData verifies the drop
 // does not destroy existing rows.
 func TestReconcileLegacyUniqueIndexes_SQLite_PreservesData(t *testing.T) {

--- a/internal/datastore/index_reconcile_test.go
+++ b/internal/datastore/index_reconcile_test.go
@@ -2,9 +2,9 @@
 //
 // These tests exercise real SQLite (in-memory, no cgo) to verify that the
 // reconciler correctly drops DB-side unique indexes that the GORM entity no
-// longer declares. They guard Forgejo #436 / #469: stale UNIQUE(species_name)
-// index on dynamic_thresholds after the composite idx_dt_species_model was
-// introduced.
+// longer declares. They guard against the stale UNIQUE(species_name) index on
+// dynamic_thresholds that lingers after the composite idx_dt_species_model
+// was introduced.
 package datastore
 
 import (
@@ -51,7 +51,8 @@ func sqliteIndexNames(t *testing.T, db *gorm.DB, table string) []string {
 
 // TestReconcileLegacyUniqueIndexes_SQLite_DropsStaleSpeciesName verifies the
 // reconciler drops a pre-multi-model UNIQUE(species_name) index on
-// dynamic_thresholds (the exact legacy shape from Forgejo #436).
+// dynamic_thresholds (the exact legacy shape behind the SQLite
+// UNIQUE-constraint insert failures).
 func TestReconcileLegacyUniqueIndexes_SQLite_DropsStaleSpeciesName(t *testing.T) {
 	t.Parallel()
 
@@ -86,4 +87,131 @@ func TestReconcileLegacyUniqueIndexes_SQLite_DropsStaleSpeciesName(t *testing.T)
 	indexes := sqliteIndexNames(t, db, "dynamic_thresholds")
 	assert.NotContains(t, indexes, "idx_dt_species_legacy",
 		"reconciler should have dropped legacy UNIQUE(species_name) index")
+}
+
+// TestReconcileLegacyUniqueIndexes_SQLite_PreservesComposite verifies the
+// reconciler leaves the declared composite idx_dt_species_model alone.
+func TestReconcileLegacyUniqueIndexes_SQLite_PreservesComposite(t *testing.T) {
+	t.Parallel()
+
+	db := openSQLiteTestDB(t)
+	require.NoError(t, db.AutoMigrate(&DynamicThreshold{}))
+
+	require.NoError(t, reconcileLegacyUniqueIndexes(db, "sqlite", "", []any{&DynamicThreshold{}}))
+
+	indexes := sqliteIndexNames(t, db, "dynamic_thresholds")
+	assert.Contains(t, indexes, "idx_dt_species_model",
+		"declared composite unique index must survive reconciliation")
+}
+
+// TestReconcileLegacyUniqueIndexes_SQLite_DropsStaleModelName covers the
+// alternative legacy shape where the stale unique index was on model_name
+// alone (paranoia: the MySQL 1062 error displays 'BirdNET' as the duplicate
+// value, hinting this layout is possible in the wild).
+func TestReconcileLegacyUniqueIndexes_SQLite_DropsStaleModelName(t *testing.T) {
+	t.Parallel()
+
+	db := openSQLiteTestDB(t)
+	require.NoError(t, db.AutoMigrate(&DynamicThreshold{}))
+	require.NoError(t, db.Exec(`CREATE UNIQUE INDEX idx_dt_model_legacy ON dynamic_thresholds(model_name)`).Error)
+
+	require.NoError(t, reconcileLegacyUniqueIndexes(db, "sqlite", "", []any{&DynamicThreshold{}}))
+
+	indexes := sqliteIndexNames(t, db, "dynamic_thresholds")
+	assert.NotContains(t, indexes, "idx_dt_model_legacy")
+	assert.Contains(t, indexes, "idx_dt_species_model")
+}
+
+// TestReconcileLegacyUniqueIndexes_SQLite_FreshInstall verifies the
+// reconciler is a no-op when AutoMigrate has never run (table absent).
+func TestReconcileLegacyUniqueIndexes_SQLite_FreshInstall(t *testing.T) {
+	t.Parallel()
+
+	db := openSQLiteTestDB(t)
+
+	require.NoError(t, reconcileLegacyUniqueIndexes(db, "sqlite", "", []any{&DynamicThreshold{}}))
+
+	assert.False(t, db.Migrator().HasTable(&DynamicThreshold{}),
+		"reconciler must not create tables")
+}
+
+// TestReconcileLegacyUniqueIndexes_SQLite_Idempotent verifies running the
+// reconciler twice on an already-correct DB is a no-op.
+func TestReconcileLegacyUniqueIndexes_SQLite_Idempotent(t *testing.T) {
+	t.Parallel()
+
+	db := openSQLiteTestDB(t)
+	require.NoError(t, db.AutoMigrate(&DynamicThreshold{}))
+	before := sqliteIndexNames(t, db, "dynamic_thresholds")
+
+	require.NoError(t, reconcileLegacyUniqueIndexes(db, "sqlite", "", []any{&DynamicThreshold{}}))
+	require.NoError(t, reconcileLegacyUniqueIndexes(db, "sqlite", "", []any{&DynamicThreshold{}}))
+
+	after := sqliteIndexNames(t, db, "dynamic_thresholds")
+	assert.ElementsMatch(t, before, after, "idempotent runs must not change index set")
+}
+
+// TestReconcileLegacyUniqueIndexes_SQLite_IgnoresAutoIndex verifies the
+// reconciler does not attempt to drop sqlite_autoindex_* internal indexes
+// that SQLite creates for PRIMARY KEY / inline UNIQUE constraints.
+func TestReconcileLegacyUniqueIndexes_SQLite_IgnoresAutoIndex(t *testing.T) {
+	t.Parallel()
+
+	db := openSQLiteTestDB(t)
+	// A table whose PRIMARY KEY is a TEXT column generates a
+	// sqlite_autoindex_ entry visible in PRAGMA index_list.
+	require.NoError(t, db.Exec(`CREATE TABLE noisy (k TEXT PRIMARY KEY, v TEXT)`).Error)
+
+	// Give the reconciler an entity that maps to the same table name but
+	// declares no unique indexes at all, so the implicit PK autoindex would
+	// be "stale" by naive column-set comparison.
+	type noisy struct {
+		K string `gorm:"primaryKey;column:k"`
+		V string `gorm:"column:v"`
+	}
+	// This must not error and must not drop anything (DROP INDEX on an
+	// autoindex name would fail with "index associated with UNIQUE or
+	// PRIMARY KEY constraint cannot be dropped").
+	require.NoError(t, reconcileLegacyUniqueIndexes(db, "sqlite", "", []any{&noisy{}}))
+
+	// Verify the table is still usable.
+	require.NoError(t, db.Exec(`INSERT INTO noisy(k, v) VALUES ('a', '1')`).Error)
+}
+
+// TestReconcileLegacyUniqueIndexes_SQLite_PreservesData verifies the drop
+// does not destroy existing rows.
+func TestReconcileLegacyUniqueIndexes_SQLite_PreservesData(t *testing.T) {
+	t.Parallel()
+
+	db := openSQLiteTestDB(t)
+	require.NoError(t, db.Exec(`
+		CREATE TABLE dynamic_thresholds (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			species_name TEXT NOT NULL,
+			model_name TEXT NOT NULL DEFAULT 'BirdNET',
+			scientific_name TEXT,
+			level INTEGER NOT NULL DEFAULT 0,
+			current_value REAL NOT NULL,
+			base_threshold REAL NOT NULL,
+			high_conf_count INTEGER NOT NULL DEFAULT 0,
+			valid_hours INTEGER NOT NULL,
+			expires_at DATETIME NOT NULL,
+			last_triggered DATETIME NOT NULL,
+			first_created DATETIME NOT NULL,
+			updated_at DATETIME NOT NULL,
+			trigger_count INTEGER NOT NULL DEFAULT 0
+		)
+	`).Error)
+	require.NoError(t, db.Exec(`CREATE UNIQUE INDEX idx_dt_species_legacy ON dynamic_thresholds(species_name)`).Error)
+	require.NoError(t, db.Exec(`
+		INSERT INTO dynamic_thresholds
+		(species_name, model_name, current_value, base_threshold, valid_hours, expires_at, last_triggered, first_created, updated_at)
+		VALUES ('robin', 'BirdNET', 0.8, 0.5, 24, '2026-04-18', '2026-04-18', '2026-04-18', '2026-04-18')
+	`).Error)
+
+	require.NoError(t, reconcileLegacyUniqueIndexes(db, "sqlite", "", []any{&DynamicThreshold{}}))
+
+	var count int64
+	require.NoError(t, db.Raw(`SELECT COUNT(*) FROM dynamic_thresholds`).Scan(&count).Error)
+	assert.Equal(t, int64(1), count, "data must survive index drop")
 }

--- a/internal/datastore/index_reconcile_test.go
+++ b/internal/datastore/index_reconcile_test.go
@@ -19,17 +19,23 @@ import (
 
 // openSQLiteTestDB returns a fresh in-memory SQLite GORM DB with silent logging.
 // Callers get a clean schema each time; the DB is closed when t ends.
+//
+// SetMaxOpenConns(1) pins the pool to a single connection so the ":memory:"
+// database stays consistent across all queries in the test. Without this,
+// database/sql's default connection pool can create multiple connections,
+// each with its own independent in-memory database, leading to flaky "no
+// such table" errors under concurrent query paths.
 func openSQLiteTestDB(t *testing.T) *gorm.DB {
 	t.Helper()
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
 		Logger: gormlogger.Default.LogMode(gormlogger.Silent),
 	})
 	require.NoError(t, err, "open in-memory sqlite")
+	sqlDB, err := db.DB()
+	require.NoError(t, err, "retrieve *sql.DB from gorm")
+	sqlDB.SetMaxOpenConns(1)
 	t.Cleanup(func() {
-		sqlDB, err := db.DB()
-		if err == nil {
-			_ = sqlDB.Close()
-		}
+		_ = sqlDB.Close()
 	})
 	return db
 }

--- a/internal/datastore/index_reconcile_test.go
+++ b/internal/datastore/index_reconcile_test.go
@@ -1,0 +1,89 @@
+// Package datastore: SQLite-level tests for reconcileLegacyUniqueIndexes.
+//
+// These tests exercise real SQLite (in-memory, no cgo) to verify that the
+// reconciler correctly drops DB-side unique indexes that the GORM entity no
+// longer declares. They guard Forgejo #436 / #469: stale UNIQUE(species_name)
+// index on dynamic_thresholds after the composite idx_dt_species_model was
+// introduced.
+package datastore
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	gormlogger "gorm.io/gorm/logger"
+)
+
+// openSQLiteTestDB returns a fresh in-memory SQLite GORM DB with silent logging.
+// Callers get a clean schema each time; the DB is closed when t ends.
+func openSQLiteTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: gormlogger.Default.LogMode(gormlogger.Silent),
+	})
+	require.NoError(t, err, "open in-memory sqlite")
+	t.Cleanup(func() {
+		sqlDB, err := db.DB()
+		if err == nil {
+			_ = sqlDB.Close()
+		}
+	})
+	return db
+}
+
+// sqliteIndexNames returns all index names on the given table in load order.
+func sqliteIndexNames(t *testing.T, db *gorm.DB, table string) []string {
+	t.Helper()
+	type row struct {
+		Name string `gorm:"column:name"`
+	}
+	var rows []row
+	require.NoError(t, db.Raw("PRAGMA index_list('"+table+"')").Scan(&rows).Error)
+	names := make([]string, 0, len(rows))
+	for _, r := range rows {
+		names = append(names, r.Name)
+	}
+	return names
+}
+
+// TestReconcileLegacyUniqueIndexes_SQLite_DropsStaleSpeciesName verifies the
+// reconciler drops a pre-multi-model UNIQUE(species_name) index on
+// dynamic_thresholds (the exact legacy shape from Forgejo #436).
+func TestReconcileLegacyUniqueIndexes_SQLite_DropsStaleSpeciesName(t *testing.T) {
+	t.Parallel()
+
+	db := openSQLiteTestDB(t)
+
+	// Seed the legacy-shaped table: DynamicThreshold columns + a stale single-column
+	// unique index on species_name (no composite idx_dt_species_model yet).
+	require.NoError(t, db.Exec(`
+		CREATE TABLE dynamic_thresholds (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			species_name TEXT NOT NULL,
+			model_name TEXT NOT NULL DEFAULT 'BirdNET',
+			scientific_name TEXT,
+			level INTEGER NOT NULL DEFAULT 0,
+			current_value REAL NOT NULL,
+			base_threshold REAL NOT NULL,
+			high_conf_count INTEGER NOT NULL DEFAULT 0,
+			valid_hours INTEGER NOT NULL,
+			expires_at DATETIME NOT NULL,
+			last_triggered DATETIME NOT NULL,
+			first_created DATETIME NOT NULL,
+			updated_at DATETIME NOT NULL,
+			trigger_count INTEGER NOT NULL DEFAULT 0
+		)
+	`).Error)
+	require.NoError(t, db.Exec(`CREATE UNIQUE INDEX idx_dt_species_legacy ON dynamic_thresholds(species_name)`).Error)
+
+	// Run the reconciler against the current DynamicThreshold entity definition.
+	require.NoError(t, reconcileLegacyUniqueIndexes(db, "sqlite", "", []any{&DynamicThreshold{}}))
+
+	// Stale single-column unique index must be gone.
+	indexes := sqliteIndexNames(t, db, "dynamic_thresholds")
+	assert.NotContains(t, indexes, "idx_dt_species_legacy",
+		"reconciler should have dropped legacy UNIQUE(species_name) index")
+}

--- a/internal/datastore/manage.go
+++ b/internal/datastore/manage.go
@@ -418,12 +418,18 @@ func validateAndFixSchema(db *gorm.DB, dbType, dbName string, debug bool, log lo
 	return nil
 }
 
-// migrateTables performs the actual table migrations
-func migrateTables(db *gorm.DB, dbType string, log logger.Logger) (int, error) {
-	tableMappings := []struct {
-		model any
-		name  string
-	}{
+// legacyEntityMapping holds a GORM model pointer paired with its physical table name.
+// Centralising this list lets both migrateTables and the stale-index reconciler
+// iterate the same entities in the same order.
+type legacyEntityMapping struct {
+	model any
+	name  string
+}
+
+// legacyEntities returns the ordered list of legacy-schema entities that
+// performAutoMigration manages. Callers must not mutate the returned slice.
+func legacyEntities() []legacyEntityMapping {
+	return []legacyEntityMapping{
 		{&Note{}, "notes"},
 		{&Results{}, "results"},
 		{&NoteReview{}, "note_reviews"},
@@ -436,6 +442,11 @@ func migrateTables(db *gorm.DB, dbType string, log logger.Logger) (int, error) {
 		{&ThresholdEvent{}, "threshold_events"},            // BG-59: Threshold change history
 		{&NotificationHistory{}, "notification_histories"}, // BG-17: Notification suppression persistence
 	}
+}
+
+// migrateTables performs the actual table migrations
+func migrateTables(db *gorm.DB, dbType string, log logger.Logger) (int, error) {
+	tableMappings := legacyEntities()
 
 	GetLogger().Debug("Starting table migrations",
 		logger.Int("table_count", len(tableMappings)))

--- a/internal/datastore/manage.go
+++ b/internal/datastore/manage.go
@@ -312,6 +312,21 @@ func performAutoMigration(db *gorm.DB, debug bool, dbType, dbName string) error 
 
 	migrationLogger.Debug("Starting database migration")
 
+	// Drop stale unique indexes the GORM entities no longer declare. Must
+	// run before AutoMigrate/validateAndFixSchema because MySQL will otherwise
+	// fail AutoMigrate with Error 1062 on restart when a pre-multi-model
+	// UNIQUE(species_name) index lingers alongside the composite
+	// idx_dt_species_model. Non-fatal on failure: log and continue so a
+	// reconciler bug can't brick startup.
+	entityModels := make([]any, 0, len(legacyEntities()))
+	for _, m := range legacyEntities() {
+		entityModels = append(entityModels, m.model)
+	}
+	if err := reconcileLegacyUniqueIndexes(db, dbType, dbName, entityModels); err != nil {
+		migrationLogger.Warn("Failed to reconcile legacy unique indexes, continuing",
+			logger.Error(err))
+	}
+
 	// Validate and fix schema if needed
 	if err := validateAndFixSchema(db, dbType, dbName, debug, migrationLogger); err != nil {
 		return err

--- a/internal/datastore/manage.go
+++ b/internal/datastore/manage.go
@@ -654,6 +654,12 @@ const (
 	// "Duplicate key name '%s'"
 	mysqlErrDupKeyName uint16 = 1061
 
+	// mysqlErrCantDropFieldOrKey is MySQL error 1091 (ER_CANT_DROP_FIELD_OR_KEY):
+	// "Can't DROP '%s'; check that column/key exists". Returned when a DROP
+	// INDEX targets an index that no longer exists (e.g., a concurrent process
+	// already dropped it).
+	mysqlErrCantDropFieldOrKey uint16 = 1091
+
 	// mysqlErrIllegalHA is MySQL error 1031 (ER_ILLEGAL_HA):
 	// "Table storage engine for '%s' doesn't have this option"
 	// Returned when running OPTIMIZE TABLE on InnoDB tables.

--- a/internal/datastore/manage.go
+++ b/internal/datastore/manage.go
@@ -318,8 +318,9 @@ func performAutoMigration(db *gorm.DB, debug bool, dbType, dbName string) error 
 	// UNIQUE(species_name) index lingers alongside the composite
 	// idx_dt_species_model. Non-fatal on failure: log and continue so a
 	// reconciler bug can't brick startup.
-	entityModels := make([]any, 0, len(legacyEntities()))
-	for _, m := range legacyEntities() {
+	mappings := legacyEntities()
+	entityModels := make([]any, 0, len(mappings))
+	for _, m := range mappings {
 		entityModels = append(entityModels, m.model)
 	}
 	if err := reconcileLegacyUniqueIndexes(db, dbType, dbName, entityModels); err != nil {


### PR DESCRIPTION
## Summary

Adds a small generic reconciler that drops DB-side unique indexes which the GORM entity no longer declares, before `AutoMigrate` runs. This stops the MySQL Error 1062 restart loop on legacy `dynamic_thresholds` tables and the corresponding SQLite `UNIQUE constraint failed: dynamic_thresholds.species_name` insert failures. Both symptoms trace to the same root cause: the schema evolved from `UNIQUE(species_name)` to the composite `UNIQUE(species_name, model_name)`, and GORM AutoMigrate never drops the old single-column index.

## Scope

- Legacy datastore only (`internal/datastore/`). The v2 and v2only datastores are not touched.
- `image_caches` keeps its existing bespoke `validateAndFixSchema` path. The new reconciler is a strict superset of that logic but replacing it is a follow-up, not part of this PR.
- Non-fatal at the callsite: a reconciler error is logged and startup continues, so a bug in the reconciler cannot brick service start.

## Implementation

- New `reconcileLegacyUniqueIndexes(db, dbType, dbName, entities...)` in `internal/datastore/index_reconcile.go`.
- Entity-declared unique indexes come from `gorm.Statement.Parse(entity)` + `schema.ParseIndexes()`, matching the source-of-truth approach established in a prior migration-validation PR (struct tags, not DB column types).
- Live DB indexes come from `information_schema.STATISTICS` (MySQL) or `PRAGMA index_list` + `PRAGMA index_info` (SQLite).
- Drop policy is conservative: only drops unique indexes whose column set is a **strict subset** of some declared unique index on the same entity. Exact matches are preserved as equivalent constraints. Supersets, unrelated column sets, and manually added unique indexes are all preserved, so the reconciler cannot accidentally relax constraints an operator intentionally imposed.
- MySQL error 1091 (`ER_CANT_DROP_FIELD_OR_KEY`) is swallowed so concurrent-drop races don't produce Sentry noise.
- Per-index drop failures log and continue instead of aborting the whole reconciliation loop.

## Tests

- `index_reconcile_test.go` (SQLite, 9 cases): drops stale `species_name`, drops stale `model_name`, preserves declared composite, preserves admin-added superset, preserves unrelated unique index, fresh install no-op, idempotency, data preservation, ignores SQLite internal autoindex.
- `index_reconcile_mysql_test.go` (MySQL 8.0 testcontainer, build tag `integration`, 5 cases): drops stale index, end-to-end regression (stale index plus rows then reconcile then AutoMigrate succeeds), idempotency, empty dbName no-op, tolerates-already-dropped race path.

## Test plan

- [x] `go test -race -count=1 ./internal/datastore/...` green
- [x] `go test -race -count=1 -tags=integration ./internal/datastore/ -run TestReconcile_MySQL` green
- [x] `golangci-lint run -v ./internal/datastore/...` zero issues
- [x] Local CodeRabbit review clean
- [ ] CI green on push
- [ ] Gemini auto-review clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Startup migration now automatically removes obsolete single-column unique indexes superseded by declared composite uniques, preserving rows; operation is idempotent and non-fatal on error.
* **Bug Fixes**
  * Avoids touching internal DB auto-indexes and unrelated stronger admin-created unique indexes.
* **Tests**
  * New integration and in-memory tests validate removal behavior, idempotency, concurrent-drop handling, and no-op paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->