### PR TITLE
fix(api/search): match by common name on the backend, revert #2782 client-side shim

### DIFF
--- a/frontend/src/lib/desktop/views/Search.svelte
+++ b/frontend/src/lib/desktop/views/Search.svelte
@@ -1,75 +1,3 @@
-<script module lang="ts">
-  import { api } from '$lib/utils/api';
-  import { loggers } from '$lib/utils/logger';
-  import {
-    buildSpeciesNameMaps,
-    type SpeciesApiEntry,
-    type SpeciesNameMaps,
-  } from '$lib/utils/speciesNames';
-
-  // Module-level cache for species name maps. Survives component
-  // mount/unmount across route changes, so navigating away from Search and
-  // back does not refetch /api/v2/species/all. Invalidated explicitly when
-  // the BirdNET label locale changes (see the component-level $effect).
-  let cachedSpeciesNameMaps: SpeciesNameMaps | null = null;
-  let cachedSpeciesMapsLocale: string | null = null;
-  let cachedSpeciesMapsInFlight: Promise<SpeciesNameMaps | null> | null = null;
-
-  /**
-   * Load the full species list from /api/v2/species/all once per locale,
-   * build bidirectional name maps, and cache the result at module scope.
-   * Subsequent calls return the cached maps. Failures are logged without
-   * surfacing to the user, since the search falls back to the raw query.
-   */
-  export function ensureSpeciesNameMapsCache(locale: string): Promise<SpeciesNameMaps | null> {
-    if (cachedSpeciesNameMaps && cachedSpeciesMapsLocale === locale) {
-      return Promise.resolve(cachedSpeciesNameMaps);
-    }
-    if (cachedSpeciesMapsInFlight && cachedSpeciesMapsLocale === locale) {
-      return cachedSpeciesMapsInFlight;
-    }
-
-    cachedSpeciesMapsLocale = locale;
-    cachedSpeciesMapsInFlight = (async () => {
-      try {
-        interface SpeciesListResponse {
-          species?: SpeciesApiEntry[];
-        }
-        const data = await api.get<SpeciesListResponse>('/api/v2/species/all');
-        const maps = buildSpeciesNameMaps(data.species ?? []);
-        // Only commit to cache if the locale is still the one we fetched
-        // for; otherwise, a newer fetch has superseded us.
-        if (cachedSpeciesMapsLocale === locale) {
-          cachedSpeciesNameMaps = maps;
-        }
-        return maps;
-      } catch (error: unknown) {
-        loggers.ui.error('Failed to load species name map for search', error);
-        return null;
-      } finally {
-        // Only clear the in-flight marker if a newer fetch (different locale)
-        // has not already replaced it; otherwise we would orphan its promise
-        // and trigger a redundant refetch on the next caller.
-        if (cachedSpeciesMapsLocale === locale) {
-          cachedSpeciesMapsInFlight = null;
-        }
-      }
-    })();
-
-    return cachedSpeciesMapsInFlight;
-  }
-
-  /**
-   * Invalidate the module-level species-name cache. Call when the BirdNET
-   * label locale changes so the next search refetches the label mapping.
-   */
-  export function invalidateSpeciesNameMapsCache(): void {
-    cachedSpeciesNameMaps = null;
-    cachedSpeciesMapsLocale = null;
-    cachedSpeciesMapsInFlight = null;
-  }
-</script>
-
 <script lang="ts">
   import WeatherInfo from '$lib/desktop/components/data/WeatherInfo.svelte';
   import AudioPlayer from '$lib/desktop/components/media/AudioPlayer.svelte';
@@ -78,9 +6,9 @@
   import { handleBirdImageError } from '$lib/desktop/components/ui/image-utils';
   import TimeOfDayIcon from '$lib/desktop/components/ui/TimeOfDayIcon.svelte';
   import { getLocale, t } from '$lib/i18n';
-  import { birdnetSettings, dashboardSettings } from '$lib/stores/settings';
+  import { dashboardSettings } from '$lib/stores/settings';
   import { toastActions } from '$lib/stores/toast';
-  import { fetchWithCSRF } from '$lib/utils/api';
+  import { api, fetchWithCSRF } from '$lib/utils/api';
   import { getLocalDateString, parseLocalDateString } from '$lib/utils/date';
   import type { TemperatureUnit } from '$lib/utils/formatters';
   import {
@@ -99,7 +27,7 @@
   import { navigation } from '$lib/stores/navigation.svelte';
   import { dropdown } from '$lib/utils/transitions';
   import { hasReviewPermission, isAuthenticated } from '$lib/utils/auth';
-  import { resolveSpeciesQuery } from '$lib/utils/speciesNames';
+  import { loggers } from '$lib/utils/logger';
 
   // SPINNER CONTROL: Set to false to disable loading spinners (reduces flickering)
   // Change back to true to re-enable spinners for testing
@@ -244,27 +172,6 @@
   let hasConfidenceError = $state(false);
   let showTooltip = $state<string | null>(null);
 
-  // Monotonic search ID used to drop stale results from out-of-order
-  // responses when the user fires multiple searches in quick succession.
-  // Each new search increments this; the resolver compares against the
-  // captured ID before touching reactive state.
-  let currentSearchId = 0;
-
-  // Invalidate the module-level species-name cache whenever the BirdNET
-  // label locale changes, so the next search refetches /api/v2/species/all
-  // with labels in the new locale. This is the LABEL locale (used by the
-  // BirdNET model), not the UI display locale. Track the previous locale so
-  // we only invalidate on a real transition; otherwise mounts and unrelated
-  // birdnetSettings updates would clear the module-level cache for nothing.
-  let previousLocale: string | undefined;
-  $effect(() => {
-    const currentLocale = $birdnetSettings?.locale;
-    if (previousLocale !== undefined && previousLocale !== currentLocale) {
-      invalidateSpeciesNameMapsCache();
-    }
-    previousLocale = currentLocale;
-  });
-
   // Localized pluralized results count using i18n keys
   function formatResultsCount(count: number) {
     if (!count || count === 0) return t('search.resultsCountZero');
@@ -307,39 +214,15 @@
   async function submitSearch(page = 1) {
     if (!validateForm()) return;
 
-    // Capture a unique ID for this search. If another search starts before
-    // this one resolves, that later search bumps `currentSearchId` and our
-    // response will be dropped below to prevent stale-result flicker.
-    const searchId = ++currentSearchId;
-
     isLoading = true;
     errorMessage = '';
     currentPage = page;
     expandedItems.clear(); // Reset expanded state when loading new results
 
     try {
-      // Resolve common-name input to a scientific name before querying.
-      // The backend /api/v2/search endpoint only searches scientific names,
-      // so a user typing e.g. "Tawny Owl" (or "Lehtopöllö" when the BirdNET
-      // label locale is Finnish) needs to be mapped to "Strix aluco" first.
-      // Falls back to the raw input if the map cannot be loaded or no match
-      // is found, preserving partial scientific-name search behaviour. Skip
-      // the species map fetch entirely for date-only searches so we do not
-      // add an unrelated round trip to /api/v2/species/all.
-      let resolvedSpecies = '';
-      if (speciesSearchTerm.trim() !== '') {
-        const locale = $birdnetSettings?.locale ?? 'en';
-        const maps = await ensureSpeciesNameMapsCache(locale);
-        // Drop stale results: a newer search may have started while we were
-        // waiting on the species map; firing the backend request anyway
-        // would race the newer call.
-        if (searchId !== currentSearchId) return;
-        resolvedSpecies = resolveSpeciesQuery(speciesSearchTerm, maps);
-      }
-
       // Build request body
       const requestBody = {
-        species: resolvedSpecies,
+        species: speciesSearchTerm,
         dateStart: dateRange.start,
         dateEnd: dateRange.end,
         confidenceMin: confidenceRange.min / 100,
@@ -357,32 +240,20 @@
         pages: number;
       }
 
-      // `api` is imported in the <script module> block and is in scope here.
       const data = await api.post<SearchResponse>('/api/v2/search', requestBody);
-      // Ignore stale responses: a newer search has already started.
-      if (searchId !== currentSearchId) return;
 
       results = data.results ?? [];
       totalResults = data.total ?? 0;
       totalPages = data.pages ?? 1;
       formSubmitted = true;
     } catch (error: unknown) {
-      // Ignore errors from stale searches as well, so a failed older
-      // request cannot clobber results from a newer successful one.
-      if (searchId !== currentSearchId) return;
-
       // Handle search error silently
       errorMessage = t('search.errors.searchFailed', {
         error: error instanceof Error ? error.message : 'Unknown error',
       });
       results = [];
     } finally {
-      // Only clear the loading spinner for the newest search; an older
-      // search finishing late must not unset isLoading while a newer one
-      // is still in flight.
-      if (searchId === currentSearchId) {
-        isLoading = false;
-      }
+      isLoading = false;
     }
   }
 

--- a/frontend/src/lib/utils/speciesNames.test.ts
+++ b/frontend/src/lib/utils/speciesNames.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, beforeAll } from 'vitest';
 import {
   buildSpeciesNameMaps,
   resolveSpeciesDisplayNames,
-  resolveSpeciesQuery,
   isSpeciesInList,
   type SpeciesNameMaps,
   type SpeciesApiEntry,
@@ -18,44 +17,6 @@ describe('buildSpeciesNameMaps', () => {
       label: 'Passer domesticus_House Sparrow',
     },
   ];
-
-  it('accepts snake_case keys as a fallback shape', () => {
-    // Guards against regressions if an API response ever lands with
-    // snake_case keys (e.g. a different species endpoint is reused here).
-    const snakeCaseEntries: SpeciesApiEntry[] = [
-      {
-        common_name: 'Tawny Owl',
-        scientific_name: 'Strix aluco',
-        label: 'Strix aluco_Tawny Owl',
-      },
-      {
-        common_name: 'Great Tit',
-        scientific_name: 'Parus major',
-        label: 'Parus major_Great Tit',
-      },
-    ];
-    const maps = buildSpeciesNameMaps(snakeCaseEntries);
-    expect(maps.commonToScientific.get('tawny owl')).toBe('Strix aluco');
-    expect(maps.scientificToCommon.get('strix aluco')).toBe('Tawny Owl');
-    expect(maps.allNames).toContain('Tawny Owl');
-    expect(maps.allNames).toContain('Parus major');
-  });
-
-  it('prefers camelCase over snake_case when both are present', () => {
-    const entries: SpeciesApiEntry[] = [
-      {
-        commonName: 'Tawny Owl',
-        scientificName: 'Strix aluco',
-        common_name: 'WRONG',
-        scientific_name: 'WRONG',
-        label: 'Strix aluco_Tawny Owl',
-      },
-    ];
-    const maps = buildSpeciesNameMaps(entries);
-    expect(maps.commonToScientific.get('tawny owl')).toBe('Strix aluco');
-    expect(maps.scientificToCommon.get('strix aluco')).toBe('Tawny Owl');
-    expect(maps.commonToScientific.has('wrong')).toBe(false);
-  });
 
   it('builds commonToScientific map keyed by lowercase common name', () => {
     const maps = buildSpeciesNameMaps(sampleSpecies);
@@ -173,77 +134,5 @@ describe('isSpeciesInList', () => {
   it('returns false when species is not in list at all', () => {
     const list = ['Tawny Owl'];
     expect(isSpeciesInList('Great Tit', list, maps)).toBe(false);
-  });
-});
-
-describe('resolveSpeciesQuery', () => {
-  let maps: SpeciesNameMaps;
-
-  beforeAll(() => {
-    const sampleSpecies: SpeciesApiEntry[] = [
-      { commonName: 'Tawny Owl', scientificName: 'Strix aluco', label: 'Strix aluco_Tawny Owl' },
-      { commonName: 'Great Tit', scientificName: 'Parus major', label: 'Parus major_Great Tit' },
-      {
-        commonName: 'Lehtopöllö',
-        scientificName: 'Strix aluco',
-        label: 'Strix aluco_Lehtopöllö',
-      },
-      {
-        commonName: 'Eurasian Blue Tit',
-        scientificName: 'Cyanistes caeruleus',
-        label: 'Cyanistes caeruleus_Eurasian Blue Tit',
-      },
-    ];
-    maps = buildSpeciesNameMaps(sampleSpecies);
-  });
-
-  it('returns empty string for empty input', () => {
-    expect(resolveSpeciesQuery('', maps)).toBe('');
-    expect(resolveSpeciesQuery('   ', maps)).toBe('');
-  });
-
-  it('falls back to raw input when maps are null', () => {
-    expect(resolveSpeciesQuery('Tawny Owl', null)).toBe('Tawny Owl');
-  });
-
-  it('resolves an exact common-name hit to its scientific name', () => {
-    expect(resolveSpeciesQuery('Tawny Owl', maps)).toBe('Strix aluco');
-  });
-
-  it('resolves case-insensitively', () => {
-    expect(resolveSpeciesQuery('tawny owl', maps)).toBe('Strix aluco');
-    expect(resolveSpeciesQuery('GREAT TIT', maps)).toBe('Parus major');
-  });
-
-  it('resolves non-ASCII common names (e.g. Finnish)', () => {
-    expect(resolveSpeciesQuery('Lehtopöllö', maps)).toBe('Strix aluco');
-    expect(resolveSpeciesQuery('lehtopöllö', maps)).toBe('Strix aluco');
-  });
-
-  it('passes scientific-looking input through unchanged', () => {
-    expect(resolveSpeciesQuery('Strix aluco', maps)).toBe('Strix aluco');
-  });
-
-  it('passes through single-word capitalised input as raw, letting the backend partial-match', () => {
-    // "Turdus" is a genus name but no common name in the map contains the
-    // substring "turdus", so the resolver should return the raw input so
-    // the backend LIKE clause can still match scientific names.
-    expect(resolveSpeciesQuery('Turdus', maps)).toBe('Turdus');
-  });
-
-  it('passes ambiguous partial common-name fragments through verbatim', () => {
-    // "owl" is a substring of "Tawny Owl" but it is also a substring of
-    // every other owl in the BirdNET label set. The resolver must NOT
-    // collapse it to whichever entry happens to be inserted first in the
-    // map; the backend LIKE clause is responsible for partial matching.
-    expect(resolveSpeciesQuery('owl', maps)).toBe('owl');
-  });
-
-  it('returns the raw input when there is no match at all', () => {
-    expect(resolveSpeciesQuery('nonexistent', maps)).toBe('nonexistent');
-  });
-
-  it('trims leading and trailing whitespace', () => {
-    expect(resolveSpeciesQuery('  Tawny Owl  ', maps)).toBe('Strix aluco');
   });
 });

--- a/frontend/src/lib/utils/speciesNames.ts
+++ b/frontend/src/lib/utils/speciesNames.ts
@@ -6,22 +6,10 @@
  * (nameMaps struct with common and species maps).
  */
 
-/**
- * Shape of a species entry from /api/v2/species/all.
- *
- * The canonical endpoint (`RangeFilterSpecies` in internal/api/v2/range.go)
- * serialises as camelCase. A few other species-related Go structs
- * (e.g. `SpeciesInfo`) use snake_case tags, so this interface accepts both
- * key shapes defensively. Callers should not rely on snake_case from
- * `/api/v2/species/all` specifically, but the fallback keeps us safe if
- * a different species endpoint is ever plumbed through this helper.
- */
+/** Shape of a species entry from /api/v2/species/all */
 export interface SpeciesApiEntry {
   commonName?: string;
   scientificName?: string;
-  // Fallback snake_case keys for endpoints that serialise in that style.
-  common_name?: string;
-  scientific_name?: string;
   label: string;
 }
 
@@ -51,10 +39,8 @@ export function buildSpeciesNameMaps(species: SpeciesApiEntry[]): SpeciesNameMap
   const namesSet = new Set<string>();
 
   for (const s of species) {
-    // Prefer camelCase (the canonical shape for /api/v2/species/all); fall
-    // back to snake_case, then to the combined `label` for common name only.
-    const commonName = s.commonName ?? s.common_name ?? s.label;
-    const scientificName = s.scientificName ?? s.scientific_name ?? '';
+    const commonName = s.commonName ?? s.label;
+    const scientificName = s.scientificName ?? '';
 
     // Always add common name to allNames for autocomplete, even without scientific name
     if (commonName) {
@@ -118,40 +104,6 @@ export function resolveSpeciesDisplayNames(
     displayCommonName: storedValue,
     displayScientificName: '',
   };
-}
-
-/**
- * Resolve a free-text species query (common name or scientific name) to a
- * scientific name suitable for the backend search filter, using a prebuilt
- * species name map (derived from /api/v2/species/all, which follows the
- * BirdNET label locale).
- *
- * Behavior:
- *   - Empty input returns empty string.
- *   - If a common name exactly matches (case-insensitive), returns the matching
- *     scientific name.
- *   - Otherwise the input passes through unchanged so the backend can run its
- *     own partial scientific-name match (e.g. "Turdus" matching multiple
- *     species). We deliberately do not collapse ambiguous partial common-name
- *     fragments like "owl" to a single arbitrary scientific name; that would
- *     hide other matches behind whichever entry happened to be inserted first
- *     in the underlying Map.
- */
-export function resolveSpeciesQuery(input: string, maps: SpeciesNameMaps | null): string {
-  const trimmed = input.trim();
-  if (!trimmed) return '';
-  if (!maps) return trimmed;
-
-  const lower = trimmed.toLowerCase();
-
-  // Exact common-name hit wins.
-  const exactCommon = maps.commonToScientific.get(lower);
-  if (exactCommon !== undefined) return exactCommon;
-
-  // Anything else (looks-like-scientific input, exact scientific match,
-  // ambiguous partial fragment, unknown text) passes through verbatim so
-  // the backend's LIKE match on scientific_name keeps working.
-  return trimmed;
 }
 
 /**

--- a/internal/api/v2/api.go
+++ b/internal/api/v2/api.go
@@ -109,9 +109,8 @@ type Controller struct {
 	alertEngine   *alerting.Engine
 
 	// Insights fields (initialized lazily in initInsightsRoutes)
-	insightsRepo          repository.InsightsRepository
-	commonNameMap         atomic.Value // stores map[string]string; scientific name -> common name
-	commonToScientificMap atomic.Value // stores map[string]string; lowercase common name -> scientific name
+	insightsRepo repository.InsightsRepository
+	nameMaps     atomic.Value // stores *nameMaps; see internal/api/v2/insights.go
 
 	// Audio processing fields
 	processingCache     *processingCache

--- a/internal/api/v2/api.go
+++ b/internal/api/v2/api.go
@@ -109,8 +109,9 @@ type Controller struct {
 	alertEngine   *alerting.Engine
 
 	// Insights fields (initialized lazily in initInsightsRoutes)
-	insightsRepo  repository.InsightsRepository
-	commonNameMap atomic.Value // stores map[string]string; scientific name → common name
+	insightsRepo          repository.InsightsRepository
+	commonNameMap         atomic.Value // stores map[string]string; scientific name -> common name
+	commonToScientificMap atomic.Value // stores map[string]string; lowercase common name -> scientific name
 
 	// Audio processing fields
 	processingCache     *processingCache

--- a/internal/api/v2/insights.go
+++ b/internal/api/v2/insights.go
@@ -169,15 +169,19 @@ func normalizeForLookup(s string) string {
 }
 
 // buildNameMaps parses a BirdNET label list ("ScientificName_CommonName")
-// and builds both lookup maps in a single pass. If several labels share the
-// same common name (a cross-species collision or a locale quirk), the last
-// one wins in commonToSci; scientific names are unique so sciToCommon is not
-// affected.
+// and builds both lookup maps in a single pass. If two or more labels share
+// the same normalised common name but map to different scientific names,
+// the common-name key is removed from commonToSci so that search queries
+// matching an ambiguous common name pass through untranslated; resolving
+// them to an arbitrary species based on label order would silently hide
+// valid matches. sciToCommon is not affected because scientific names are
+// unique per label.
 func buildNameMaps(labels []string) *nameMaps {
 	nm := &nameMaps{
 		sciToCommon: make(map[string]string, len(labels)),
 		commonToSci: make(map[string]string, len(labels)),
 	}
+	ambiguous := make(map[string]struct{})
 	for _, label := range labels {
 		scientificName, commonName, found := strings.Cut(label, "_")
 		if !found {
@@ -189,7 +193,17 @@ func buildNameMaps(labels []string) *nameMaps {
 			continue
 		}
 		nm.sciToCommon[scientificName] = commonName
-		nm.commonToSci[normalizeForLookup(commonName)] = scientificName
+
+		key := normalizeForLookup(commonName)
+		if _, seen := ambiguous[key]; seen {
+			continue
+		}
+		if existing, exists := nm.commonToSci[key]; exists && existing != scientificName {
+			ambiguous[key] = struct{}{}
+			delete(nm.commonToSci, key)
+			continue
+		}
+		nm.commonToSci[key] = scientificName
 	}
 	return nm
 }

--- a/internal/api/v2/insights.go
+++ b/internal/api/v2/insights.go
@@ -165,10 +165,40 @@ func buildCommonNameMap(labels []string) map[string]string {
 	return m
 }
 
-// UpdateCommonNameMap rebuilds the cached common name map from updated BirdNET labels.
-// Called after locale or model changes to keep insights endpoints current.
+// buildCommonToScientificMap creates a map from lowercase common name to scientific name
+// using the BirdNET labels in Settings (format: "ScientificName_CommonName"). Used by
+// the search handler to pre-resolve common-name queries.
+func buildCommonToScientificMap(labels []string) map[string]string {
+	m := make(map[string]string, len(labels))
+	for _, label := range labels {
+		scientificName, commonName, found := strings.Cut(label, "_")
+		if !found {
+			continue
+		}
+		scientificName = strings.TrimSpace(scientificName)
+		commonName = strings.TrimSpace(commonName)
+		if scientificName == "" || commonName == "" {
+			continue
+		}
+		m[strings.ToLower(commonName)] = scientificName
+	}
+	return m
+}
+
+// loadCommonToScientificMap returns the current common-to-scientific lookup map.
+// Always returns a non-nil map.
+func (c *Controller) loadCommonToScientificMap() map[string]string {
+	if m, ok := c.commonToScientificMap.Load().(map[string]string); ok && m != nil {
+		return m
+	}
+	return make(map[string]string)
+}
+
+// UpdateCommonNameMap rebuilds both cached name maps from updated BirdNET labels.
+// Called after locale or model changes to keep insights and search endpoints current.
 func (c *Controller) UpdateCommonNameMap(labels []string) {
 	c.commonNameMap.Store(buildCommonNameMap(labels))
+	c.commonToScientificMap.Store(buildCommonToScientificMap(labels))
 }
 
 // loadCommonNameMap returns the current common name map. Always returns a non-nil map.
@@ -308,9 +338,10 @@ func (c *Controller) initInsightsRoutes() {
 	}
 	c.insightsRepo = repository.NewInsightsRepository(db, useV2Prefix, isMySQL)
 
-	// Build common name map once and cache on Controller
+	// Build both name maps once and cache on Controller
 	if c.Settings != nil {
 		c.commonNameMap.Store(buildCommonNameMap(c.Settings.BirdNET.Labels))
+		c.commonToScientificMap.Store(buildCommonToScientificMap(c.Settings.BirdNET.Labels))
 	}
 
 	insightsGroup := c.Group.Group("/insights")

--- a/internal/api/v2/insights.go
+++ b/internal/api/v2/insights.go
@@ -208,13 +208,21 @@ func buildNameMaps(labels []string) *nameMaps {
 	return nm
 }
 
+// emptyNameMaps is returned by loadNameMaps when the atomic.Value has not been
+// populated yet (a narrow startup window before initInsightsRoutes runs). It
+// avoids allocating a fresh struct and two empty maps on every cold-path call.
+var emptyNameMaps = &nameMaps{
+	sciToCommon: map[string]string{},
+	commonToSci: map[string]string{},
+}
+
 // loadNameMaps returns the current name-maps struct. Always returns a non-nil
 // struct with non-nil inner maps so callers can index without guards.
 func (c *Controller) loadNameMaps() *nameMaps {
 	if nm, ok := c.nameMaps.Load().(*nameMaps); ok && nm != nil {
 		return nm
 	}
-	return &nameMaps{sciToCommon: map[string]string{}, commonToSci: map[string]string{}}
+	return emptyNameMaps
 }
 
 // loadCommonToScientificMap returns the current common-to-scientific lookup map.

--- a/internal/api/v2/insights.go
+++ b/internal/api/v2/insights.go
@@ -13,6 +13,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/datastore/v2/repository"
 	"github.com/tphakala/birdnet-go/internal/imageprovider"
 	"github.com/tphakala/birdnet-go/internal/logger"
+	"golang.org/x/text/unicode/norm"
 )
 
 // Insights constants
@@ -148,28 +149,35 @@ type StreakInfo struct {
 
 // --- Helper functions ---
 
-// buildCommonNameMap creates a map from scientific name to common name
-// using the BirdNET labels in Settings (format: "ScientificName_CommonName").
-func buildCommonNameMap(labels []string) map[string]string {
-	m := make(map[string]string, len(labels))
-	for _, label := range labels {
-		scientificName, commonName, found := strings.Cut(label, "_")
-		if found {
-			scientificName = strings.TrimSpace(scientificName)
-			commonName = strings.TrimSpace(commonName)
-			if scientificName != "" && commonName != "" {
-				m[scientificName] = commonName
-			}
-		}
-	}
-	return m
+// nameMaps holds the bidirectional BirdNET label lookup maps. Grouping them
+// into one struct lets a single atomic.Value Store swap both maps together,
+// avoiding any window where readers could see a partially updated pair.
+type nameMaps struct {
+	// sciToCommon maps scientific name -> common name.
+	sciToCommon map[string]string
+	// commonToSci maps NFC-normalised, lowercased common name -> scientific name.
+	commonToSci map[string]string
 }
 
-// buildCommonToScientificMap creates a map from lowercase common name to scientific name
-// using the BirdNET labels in Settings (format: "ScientificName_CommonName"). Used by
-// the search handler to pre-resolve common-name queries.
-func buildCommonToScientificMap(labels []string) map[string]string {
-	m := make(map[string]string, len(labels))
+// normalizeForLookup prepares a string for case- and Unicode-form-insensitive
+// map lookup. BirdNET labels ship in composed (NFC) form, but users typing
+// on macOS or with composing keyboards may submit decomposed (NFD) bytes
+// for diacritics, so normalising both sides to NFC prevents silent misses
+// on species like "Lehtopöllö".
+func normalizeForLookup(s string) string {
+	return strings.ToLower(norm.NFC.String(s))
+}
+
+// buildNameMaps parses a BirdNET label list ("ScientificName_CommonName")
+// and builds both lookup maps in a single pass. If several labels share the
+// same common name (a cross-species collision or a locale quirk), the last
+// one wins in commonToSci; scientific names are unique so sciToCommon is not
+// affected.
+func buildNameMaps(labels []string) *nameMaps {
+	nm := &nameMaps{
+		sciToCommon: make(map[string]string, len(labels)),
+		commonToSci: make(map[string]string, len(labels)),
+	}
 	for _, label := range labels {
 		scientificName, commonName, found := strings.Cut(label, "_")
 		if !found {
@@ -180,33 +188,50 @@ func buildCommonToScientificMap(labels []string) map[string]string {
 		if scientificName == "" || commonName == "" {
 			continue
 		}
-		m[strings.ToLower(commonName)] = scientificName
+		nm.sciToCommon[scientificName] = commonName
+		nm.commonToSci[normalizeForLookup(commonName)] = scientificName
 	}
-	return m
+	return nm
+}
+
+// buildCommonNameMap returns only the scientific-to-common half of the name
+// maps. Kept as a thin wrapper for tests that pre-populate a single direction.
+func buildCommonNameMap(labels []string) map[string]string {
+	return buildNameMaps(labels).sciToCommon
+}
+
+// buildCommonToScientificMap returns only the common-to-scientific half of
+// the name maps. Kept as a thin wrapper for tests that pre-populate a single
+// direction.
+func buildCommonToScientificMap(labels []string) map[string]string {
+	return buildNameMaps(labels).commonToSci
+}
+
+// loadNameMaps returns the current name-maps struct. Always returns a non-nil
+// struct with non-nil inner maps so callers can index without guards.
+func (c *Controller) loadNameMaps() *nameMaps {
+	if nm, ok := c.nameMaps.Load().(*nameMaps); ok && nm != nil {
+		return nm
+	}
+	return &nameMaps{sciToCommon: map[string]string{}, commonToSci: map[string]string{}}
 }
 
 // loadCommonToScientificMap returns the current common-to-scientific lookup map.
 // Always returns a non-nil map.
 func (c *Controller) loadCommonToScientificMap() map[string]string {
-	if m, ok := c.commonToScientificMap.Load().(map[string]string); ok && m != nil {
-		return m
-	}
-	return make(map[string]string)
+	return c.loadNameMaps().commonToSci
 }
 
 // UpdateCommonNameMap rebuilds both cached name maps from updated BirdNET labels.
 // Called after locale or model changes to keep insights and search endpoints current.
 func (c *Controller) UpdateCommonNameMap(labels []string) {
-	c.commonNameMap.Store(buildCommonNameMap(labels))
-	c.commonToScientificMap.Store(buildCommonToScientificMap(labels))
+	c.nameMaps.Store(buildNameMaps(labels))
 }
 
-// loadCommonNameMap returns the current common name map. Always returns a non-nil map.
+// loadCommonNameMap returns the current scientific-to-common lookup map.
+// Always returns a non-nil map.
 func (c *Controller) loadCommonNameMap() map[string]string {
-	if m, ok := c.commonNameMap.Load().(map[string]string); ok && m != nil {
-		return m
-	}
-	return make(map[string]string)
+	return c.loadNameMaps().sciToCommon
 }
 
 // resolveCommonName looks up the common name for a scientific name.
@@ -340,8 +365,7 @@ func (c *Controller) initInsightsRoutes() {
 
 	// Build both name maps once and cache on Controller
 	if c.Settings != nil {
-		c.commonNameMap.Store(buildCommonNameMap(c.Settings.BirdNET.Labels))
-		c.commonToScientificMap.Store(buildCommonToScientificMap(c.Settings.BirdNET.Labels))
+		c.UpdateCommonNameMap(c.Settings.BirdNET.Labels)
 	}
 
 	insightsGroup := c.Group.Group("/insights")

--- a/internal/api/v2/insights.go
+++ b/internal/api/v2/insights.go
@@ -208,19 +208,6 @@ func buildNameMaps(labels []string) *nameMaps {
 	return nm
 }
 
-// buildCommonNameMap returns only the scientific-to-common half of the name
-// maps. Kept as a thin wrapper for tests that pre-populate a single direction.
-func buildCommonNameMap(labels []string) map[string]string {
-	return buildNameMaps(labels).sciToCommon
-}
-
-// buildCommonToScientificMap returns only the common-to-scientific half of
-// the name maps. Kept as a thin wrapper for tests that pre-populate a single
-// direction.
-func buildCommonToScientificMap(labels []string) map[string]string {
-	return buildNameMaps(labels).commonToSci
-}
-
 // loadNameMaps returns the current name-maps struct. Always returns a non-nil
 // struct with non-nil inner maps so callers can index without guards.
 func (c *Controller) loadNameMaps() *nameMaps {

--- a/internal/api/v2/insights_test.go
+++ b/internal/api/v2/insights_test.go
@@ -65,7 +65,7 @@ func setupInsightsTestController(t *testing.T, mock *mockInsightsRepo) (*echo.Ec
 		},
 		insightsRepo: mock,
 	}
-	controller.commonNameMap.Store(buildCommonNameMap([]string{
+	controller.nameMaps.Store(buildNameMaps([]string{
 		"Turdus merula_Eurasian Blackbird",
 		"Parus major_Great Tit",
 	}))

--- a/internal/api/v2/insights_test.go
+++ b/internal/api/v2/insights_test.go
@@ -65,10 +65,7 @@ func setupInsightsTestController(t *testing.T, mock *mockInsightsRepo) (*echo.Ec
 		},
 		insightsRepo: mock,
 	}
-	controller.nameMaps.Store(buildNameMaps([]string{
-		"Turdus merula_Eurasian Blackbird",
-		"Parus major_Great Tit",
-	}))
+	controller.UpdateCommonNameMap(controller.Settings.BirdNET.Labels)
 	return e, controller
 }
 

--- a/internal/api/v2/insights_test.go
+++ b/internal/api/v2/insights_test.go
@@ -291,7 +291,7 @@ func TestBuildCommonNameMap(t *testing.T) {
 		"_EmptyScientificName",
 	}
 
-	m := buildCommonNameMap(labels)
+	m := buildNameMaps(labels).sciToCommon
 	assert.Equal(t, "Eurasian Blackbird", m["Turdus merula"])
 	assert.Equal(t, "Great Tit", m["Parus major"])
 	assert.Len(t, m, 2) // invalid entries excluded

--- a/internal/api/v2/search.go
+++ b/internal/api/v2/search.go
@@ -6,6 +6,7 @@ import (
 	"maps"
 	"net/http"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/labstack/echo/v4"
@@ -66,6 +67,13 @@ func (c *Controller) HandleSearch(ctx echo.Context) error {
 	if err := c.validateAndNormalizeSearchRequest(ctx, &req); err != nil {
 		return c.HandleError(ctx, err, "Invalid search parameters", http.StatusBadRequest)
 	}
+
+	// Resolve common-name input to a scientific name before filtering. The backend
+	// datastore search does LIKE on scientific_name only; this pre-translation lets
+	// clients submit common names in any BirdNET label locale. Partial scientific
+	// names, ambiguous common-name substrings, and unknown text pass through
+	// unchanged.
+	req.Species = c.resolveSpeciesToScientific(req.Species)
 
 	// Log validated request parameters
 	c.logValidatedRequest(path, ip, &req)
@@ -329,4 +337,27 @@ func (c *Controller) validateSearchSortBy(path, ip string, req *SearchRequest) e
 		}
 	}
 	return nil
+}
+
+// resolveSpeciesToScientific maps a free-form species search term to a scientific
+// name when the input is an exact case-insensitive match for a common name in the
+// currently loaded BirdNET label list. Non-matching input (partial common-name
+// fragments, Latin substrings, unknown text) is returned unchanged so the existing
+// LIKE search on scientific_name keeps working.
+//
+// The BirdNET label list is already cached in memory via UpdateCommonNameMap; there
+// is no I/O here. The lookup is O(1) for the common-name exact-match case.
+//
+// This is an interim fix; the proper long-term fix is a persistent species_common_names
+// table that decouples common-name storage from the active model's label file.
+func (c *Controller) resolveSpeciesToScientific(input string) string {
+	trimmed := strings.TrimSpace(input)
+	if trimmed == "" {
+		return ""
+	}
+	lookup := c.loadCommonToScientificMap()
+	if scientific, ok := lookup[strings.ToLower(trimmed)]; ok {
+		return scientific
+	}
+	return trimmed
 }

--- a/internal/api/v2/search.go
+++ b/internal/api/v2/search.go
@@ -68,12 +68,16 @@ func (c *Controller) HandleSearch(ctx echo.Context) error {
 		return c.HandleError(ctx, err, "Invalid search parameters", http.StatusBadRequest)
 	}
 
-	// Resolve common-name input to a scientific name before filtering. The backend
-	// datastore search does LIKE on scientific_name only; this pre-translation lets
-	// clients submit common names in any BirdNET label locale. Partial scientific
-	// names, ambiguous common-name substrings, and unknown text pass through
-	// unchanged.
+	originalSpecies := req.Species
 	req.Species = c.resolveSpeciesToScientific(req.Species)
+	if req.Species != originalSpecies {
+		c.logDebugIfEnabled("Resolved common-name query to scientific name",
+			logger.String("input", originalSpecies),
+			logger.String("resolved", req.Species),
+			logger.String("path", path),
+			logger.String("ip", ip),
+		)
+	}
 
 	// Log validated request parameters
 	c.logValidatedRequest(path, ip, &req)
@@ -356,7 +360,7 @@ func (c *Controller) resolveSpeciesToScientific(input string) string {
 		return ""
 	}
 	lookup := c.loadCommonToScientificMap()
-	if scientific, ok := lookup[strings.ToLower(trimmed)]; ok {
+	if scientific, ok := lookup[normalizeForLookup(trimmed)]; ok {
 		return scientific
 	}
 	return trimmed

--- a/internal/api/v2/search.go
+++ b/internal/api/v2/search.go
@@ -69,8 +69,9 @@ func (c *Controller) HandleSearch(ctx echo.Context) error {
 	}
 
 	originalSpecies := req.Species
-	req.Species = c.resolveSpeciesToScientific(req.Species)
-	if req.Species != originalSpecies {
+	resolved, hit := c.resolveSpeciesToScientific(req.Species)
+	req.Species = resolved
+	if hit {
 		c.logDebugIfEnabled("Resolved common-name query to scientific name",
 			logger.String("input", originalSpecies),
 			logger.String("resolved", req.Species),
@@ -346,22 +347,27 @@ func (c *Controller) validateSearchSortBy(path, ip string, req *SearchRequest) e
 // resolveSpeciesToScientific maps a free-form species search term to a scientific
 // name when the input is an exact case-insensitive match for a common name in the
 // currently loaded BirdNET label list. Non-matching input (partial common-name
-// fragments, Latin substrings, unknown text) is returned unchanged so the existing
+// fragments, Latin substrings, unknown text, ambiguous common names shared by
+// multiple species) is returned trimmed but otherwise unchanged so the existing
 // LIKE search on scientific_name keeps working.
 //
 // The BirdNET label list is already cached in memory via UpdateCommonNameMap; there
 // is no I/O here. The lookup is O(1) for the common-name exact-match case.
 //
+// Returns the resolved (or trimmed passthrough) value and a hit flag. hit is true
+// only when a common-name lookup succeeded, so callers can log resolution events
+// without false positives from whitespace-only or unmatched input.
+//
 // This is an interim fix; the proper long-term fix is a persistent species_common_names
 // table that decouples common-name storage from the active model's label file.
-func (c *Controller) resolveSpeciesToScientific(input string) string {
+func (c *Controller) resolveSpeciesToScientific(input string) (resolved string, hit bool) {
 	trimmed := strings.TrimSpace(input)
 	if trimmed == "" {
-		return ""
+		return "", false
 	}
 	lookup := c.loadCommonToScientificMap()
 	if scientific, ok := lookup[normalizeForLookup(trimmed)]; ok {
-		return scientific
+		return scientific, true
 	}
-	return trimmed
+	return trimmed, false
 }

--- a/internal/api/v2/search_common_name_test.go
+++ b/internal/api/v2/search_common_name_test.go
@@ -1,0 +1,144 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/conf"
+)
+
+// testLabels contains representative BirdNET label strings used across
+// common-name resolution tests (format: "ScientificName_CommonName").
+var testLabels = []string{
+	"Strix aluco_Tawny Owl",
+	"Strix aluco_Lehtopöllö",
+	"Turdus merula_Eurasian Blackbird",
+	"Parus major_Great Tit",
+}
+
+// setupSearchTestController builds a minimal Controller with the given BirdNET
+// labels pre-loaded into both name maps. It mirrors the pattern in
+// setupInsightsTestController so tests share the same construction style.
+func setupSearchTestController(t *testing.T, labels []string) *Controller {
+	t.Helper()
+	e := echo.New()
+	c := &Controller{
+		Group: e.Group("/api/v2"),
+		Settings: &conf.Settings{
+			BirdNET: conf.BirdNETConfig{
+				Labels: labels,
+			},
+		},
+	}
+	c.commonNameMap.Store(buildCommonNameMap(labels))
+	c.commonToScientificMap.Store(buildCommonToScientificMap(labels))
+	return c
+}
+
+func TestResolveSpeciesToScientific(t *testing.T) {
+	t.Parallel()
+
+	c := setupSearchTestController(t, testLabels)
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "empty string returns empty string",
+			input: "",
+			want:  "",
+		},
+		{
+			name:  "whitespace-only returns empty string",
+			input: "   ",
+			want:  "",
+		},
+		{
+			name:  "exact common-name match",
+			input: "Tawny Owl",
+			want:  "Strix aluco",
+		},
+		{
+			name:  "case-insensitive match lowercase",
+			input: "tawny owl",
+			want:  "Strix aluco",
+		},
+		{
+			name:  "case-insensitive match uppercase",
+			input: "TAWNY OWL",
+			want:  "Strix aluco",
+		},
+		{
+			name:  "non-ASCII common name (Finnish)",
+			input: "Lehtopöllö",
+			want:  "Strix aluco",
+		},
+		{
+			name:  "non-ASCII common name lowercase (Finnish)",
+			input: "lehtopöllö",
+			want:  "Strix aluco",
+		},
+		{
+			name:  "scientific name passes through unchanged",
+			input: "Strix aluco",
+			want:  "Strix aluco",
+		},
+		{
+			name:  "partial scientific name passes through unchanged",
+			input: "Turdus",
+			want:  "Turdus",
+		},
+		{
+			name:  "unknown text passes through unchanged",
+			input: "xyzzy",
+			want:  "xyzzy",
+		},
+		{
+			name:  "common name with surrounding whitespace resolves correctly",
+			input: "  Tawny Owl  ",
+			want:  "Strix aluco",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := c.resolveSpeciesToScientific(tt.input)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestUpdateCommonNameMap_PopulatesBothMaps verifies that UpdateCommonNameMap
+// populates both the scientific-to-common map and the common-to-scientific map
+// from the same label input, keeping them consistent.
+func TestUpdateCommonNameMap_PopulatesBothMaps(t *testing.T) {
+	t.Parallel()
+
+	e := echo.New()
+	c := &Controller{
+		Group: e.Group("/api/v2"),
+	}
+
+	labels := []string{
+		"Strix aluco_Tawny Owl",
+		"Parus major_Great Tit",
+	}
+	c.UpdateCommonNameMap(labels)
+
+	// Verify the scientific-to-common map (used by insights endpoints).
+	sciToCommon := c.loadCommonNameMap()
+	require.NotNil(t, sciToCommon)
+	assert.Equal(t, "Tawny Owl", sciToCommon["Strix aluco"])
+	assert.Equal(t, "Great Tit", sciToCommon["Parus major"])
+
+	// Verify the common-to-scientific map (used by the search resolver).
+	commonToSci := c.loadCommonToScientificMap()
+	require.NotNil(t, commonToSci)
+	assert.Equal(t, "Strix aluco", commonToSci["tawny owl"])
+	assert.Equal(t, "Parus major", commonToSci["great tit"])
+}

--- a/internal/api/v2/search_common_name_test.go
+++ b/internal/api/v2/search_common_name_test.go
@@ -41,82 +41,120 @@ func TestResolveSpeciesToScientific(t *testing.T) {
 	c := setupSearchTestController(t, testLabels)
 
 	tests := []struct {
-		name  string
-		input string
-		want  string
+		name    string
+		input   string
+		want    string
+		wantHit bool
 	}{
 		{
-			name:  "empty string returns empty string",
-			input: "",
-			want:  "",
+			name:    "empty string returns empty string",
+			input:   "",
+			want:    "",
+			wantHit: false,
 		},
 		{
-			name:  "whitespace-only returns empty string",
-			input: "   ",
-			want:  "",
+			name:    "whitespace-only returns empty string without hit",
+			input:   "   ",
+			want:    "",
+			wantHit: false,
 		},
 		{
-			name:  "exact common-name match",
-			input: "Tawny Owl",
-			want:  "Strix aluco",
+			name:    "exact common-name match",
+			input:   "Tawny Owl",
+			want:    "Strix aluco",
+			wantHit: true,
 		},
 		{
-			name:  "case-insensitive match lowercase",
-			input: "tawny owl",
-			want:  "Strix aluco",
+			name:    "case-insensitive match lowercase",
+			input:   "tawny owl",
+			want:    "Strix aluco",
+			wantHit: true,
 		},
 		{
-			name:  "case-insensitive match uppercase",
-			input: "TAWNY OWL",
-			want:  "Strix aluco",
+			name:    "case-insensitive match uppercase",
+			input:   "TAWNY OWL",
+			want:    "Strix aluco",
+			wantHit: true,
 		},
 		{
-			name:  "non-ASCII common name (Finnish)",
-			input: "Lehtopöllö",
-			want:  "Strix aluco",
+			name:    "non-ASCII common name (Finnish)",
+			input:   "Lehtopöllö",
+			want:    "Strix aluco",
+			wantHit: true,
 		},
 		{
-			name:  "non-ASCII common name lowercase (Finnish)",
-			input: "lehtopöllö",
-			want:  "Strix aluco",
+			name:    "non-ASCII common name lowercase (Finnish)",
+			input:   "lehtopöllö",
+			want:    "Strix aluco",
+			wantHit: true,
 		},
 		{
-			name:  "scientific name passes through unchanged",
-			input: "Strix aluco",
-			want:  "Strix aluco",
+			name:    "scientific name passes through unchanged",
+			input:   "Strix aluco",
+			want:    "Strix aluco",
+			wantHit: false,
 		},
 		{
-			name:  "partial scientific name passes through unchanged",
-			input: "Turdus",
-			want:  "Turdus",
+			name:    "partial scientific name passes through unchanged",
+			input:   "Turdus",
+			want:    "Turdus",
+			wantHit: false,
 		},
 		{
-			name:  "unknown text passes through unchanged",
-			input: "xyzzy",
-			want:  "xyzzy",
+			name:    "unknown text passes through unchanged",
+			input:   "xyzzy",
+			want:    "xyzzy",
+			wantHit: false,
 		},
 		{
-			name:  "common name with surrounding whitespace resolves correctly",
-			input: "  Tawny Owl  ",
-			want:  "Strix aluco",
+			name:    "common name with surrounding whitespace resolves correctly",
+			input:   "  Tawny Owl  ",
+			want:    "Strix aluco",
+			wantHit: true,
 		},
 		{
 			// macOS and some composing keyboards submit NFD bytes for
 			// diacritics. The resolver must normalise to NFC so labels
 			// (which ship as NFC) still match.
-			name:  "NFD-form diacritic matches NFC-stored label",
-			input: "Lehtopo\u0308llo\u0308",
-			want:  "Strix aluco",
+			name:    "NFD-form diacritic matches NFC-stored label",
+			input:   "Lehtopo\u0308llo\u0308",
+			want:    "Strix aluco",
+			wantHit: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got := c.resolveSpeciesToScientific(tt.input)
+			got, hit := c.resolveSpeciesToScientific(tt.input)
 			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.wantHit, hit)
 		})
 	}
+}
+
+// TestResolveSpeciesToScientific_AmbiguousCommonName verifies that when two
+// species share the same common name, the resolver passes the query through
+// untranslated (hit=false) rather than resolving it to an arbitrary species
+// based on label order.
+func TestResolveSpeciesToScientific_AmbiguousCommonName(t *testing.T) {
+	t.Parallel()
+
+	ambiguousLabels := []string{
+		"Strix aluco_Owl",
+		"Bubo bubo_Owl",
+		"Turdus merula_Eurasian Blackbird",
+	}
+	c := setupSearchTestController(t, ambiguousLabels)
+
+	resolved, hit := c.resolveSpeciesToScientific("Owl")
+	assert.Equal(t, "Owl", resolved, "ambiguous common name should pass through untranslated")
+	assert.False(t, hit, "ambiguous common name should not register as a hit")
+
+	// Non-ambiguous names must still resolve correctly.
+	resolved, hit = c.resolveSpeciesToScientific("Eurasian Blackbird")
+	assert.Equal(t, "Turdus merula", resolved)
+	assert.True(t, hit)
 }
 
 // TestUpdateCommonNameMap_PopulatesBothMaps verifies that UpdateCommonNameMap
@@ -147,6 +185,46 @@ func TestUpdateCommonNameMap_PopulatesBothMaps(t *testing.T) {
 	require.NotNil(t, commonToSci)
 	assert.Equal(t, "Strix aluco", commonToSci["tawny owl"])
 	assert.Equal(t, "Parus major", commonToSci["great tit"])
+}
+
+// TestBuildNameMaps_AmbiguousCommonName verifies that a common name mapped
+// by two different scientific names is removed from commonToSci so the
+// search resolver passes ambiguous queries through untranslated.
+func TestBuildNameMaps_AmbiguousCommonName(t *testing.T) {
+	t.Parallel()
+
+	nm := buildNameMaps([]string{
+		"Strix aluco_Owl",
+		"Bubo bubo_Owl",
+		"Parus major_Great Tit",
+	})
+	require.NotNil(t, nm)
+
+	// sciToCommon keeps both species; scientific names are always unique.
+	assert.Equal(t, "Owl", nm.sciToCommon["Strix aluco"])
+	assert.Equal(t, "Owl", nm.sciToCommon["Bubo bubo"])
+
+	// commonToSci must NOT contain the ambiguous key.
+	_, ok := nm.commonToSci["owl"]
+	assert.False(t, ok, "ambiguous common-name key should be removed")
+
+	// A third label that repeats an already-ambiguous key should not
+	// accidentally restore the key.
+	nm = buildNameMaps([]string{
+		"Strix aluco_Owl",
+		"Bubo bubo_Owl",
+		"Tyto alba_Owl",
+	})
+	_, ok = nm.commonToSci["owl"]
+	assert.False(t, ok)
+
+	// Non-ambiguous names remain.
+	nm = buildNameMaps([]string{
+		"Strix aluco_Owl",
+		"Bubo bubo_Owl",
+		"Parus major_Great Tit",
+	})
+	assert.Equal(t, "Parus major", nm.commonToSci["great tit"])
 }
 
 // TestBuildNameMaps_MalformedLabels verifies that labels missing a scientific

--- a/internal/api/v2/search_common_name_test.go
+++ b/internal/api/v2/search_common_name_test.go
@@ -19,8 +19,7 @@ var testLabels = []string{
 }
 
 // setupSearchTestController builds a minimal Controller with the given BirdNET
-// labels pre-loaded into both name maps. It mirrors the pattern in
-// setupInsightsTestController so tests share the same construction style.
+// labels pre-loaded into both name maps.
 func setupSearchTestController(t *testing.T, labels []string) *Controller {
 	t.Helper()
 	e := echo.New()
@@ -32,8 +31,7 @@ func setupSearchTestController(t *testing.T, labels []string) *Controller {
 			},
 		},
 	}
-	c.commonNameMap.Store(buildCommonNameMap(labels))
-	c.commonToScientificMap.Store(buildCommonToScientificMap(labels))
+	c.nameMaps.Store(buildNameMaps(labels))
 	return c
 }
 
@@ -102,6 +100,14 @@ func TestResolveSpeciesToScientific(t *testing.T) {
 			input: "  Tawny Owl  ",
 			want:  "Strix aluco",
 		},
+		{
+			// macOS and some composing keyboards submit NFD bytes for
+			// diacritics. The resolver must normalise to NFC so labels
+			// (which ship as NFC) still match.
+			name:  "NFD-form diacritic matches NFC-stored label",
+			input: "Lehtopo\u0308llo\u0308",
+			want:  "Strix aluco",
+		},
 	}
 
 	for _, tt := range tests {
@@ -141,4 +147,38 @@ func TestUpdateCommonNameMap_PopulatesBothMaps(t *testing.T) {
 	require.NotNil(t, commonToSci)
 	assert.Equal(t, "Strix aluco", commonToSci["tawny owl"])
 	assert.Equal(t, "Parus major", commonToSci["great tit"])
+}
+
+// TestBuildNameMaps_MalformedLabels verifies that labels missing a scientific
+// name, a common name, or the separator are silently skipped rather than
+// producing empty keys.
+func TestBuildNameMaps_MalformedLabels(t *testing.T) {
+	t.Parallel()
+
+	nm := buildNameMaps([]string{
+		"Strix aluco_Tawny Owl",
+		"_MissingScientific",
+		"MissingCommon_",
+		"NoSeparatorAtAll",
+		"",
+		"   _   ",
+	})
+	require.NotNil(t, nm)
+	assert.Len(t, nm.sciToCommon, 1)
+	assert.Len(t, nm.commonToSci, 1)
+	assert.Equal(t, "Tawny Owl", nm.sciToCommon["Strix aluco"])
+	assert.Equal(t, "Strix aluco", nm.commonToSci["tawny owl"])
+}
+
+// TestLoadNameMaps_CalledBeforeInit verifies that the load helpers return
+// non-nil empty maps when the Controller has not yet seeded nameMaps, so
+// callers can index without nil checks during the startup window.
+func TestLoadNameMaps_CalledBeforeInit(t *testing.T) {
+	t.Parallel()
+
+	c := &Controller{}
+	assert.NotNil(t, c.loadCommonNameMap())
+	assert.NotNil(t, c.loadCommonToScientificMap())
+	assert.Empty(t, c.loadCommonNameMap())
+	assert.Empty(t, c.loadCommonToScientificMap())
 }

--- a/internal/datastore/v2/repository/filter_conversion.go
+++ b/internal/datastore/v2/repository/filter_conversion.go
@@ -413,9 +413,13 @@ func ResolveSpeciesToLabelIDsWithCommonName(ctx context.Context, deps *FilterLoo
 		return nil, nil
 	}
 
-	// Use the Search method which does LIKE matching on scientific_name and common_name.
-	// Limit of 100 is intentional for Simple Search API - a broader search term returning
-	// 100+ species indicates the user should refine their search.
+	// LabelRepo.Search does a LIKE match on scientific_name only. Common-name
+	// search is handled at the API handler layer by pre-resolving common names
+	// to scientific names before this helper is called; see
+	// (*Controller).resolveSpeciesToScientific in internal/api/v2/search.go.
+	// The limit of 100 is intentional for Simple Search: a broader term returning
+	// 100+ species indicates the user should refine the query.
+	// TODO: restore partial-common-name search via a persistent common_name column.
 	labels, err := deps.LabelRepo.Search(ctx, species, 100)
 	if err != nil {
 		return nil, err

--- a/internal/datastore/v2/repository/filter_conversion.go
+++ b/internal/datastore/v2/repository/filter_conversion.go
@@ -419,7 +419,7 @@ func ResolveSpeciesToLabelIDsWithCommonName(ctx context.Context, deps *FilterLoo
 	// (*Controller).resolveSpeciesToScientific in internal/api/v2/search.go.
 	// The limit of 100 is intentional for Simple Search: a broader term returning
 	// 100+ species indicates the user should refine the query.
-	// TODO: restore partial-common-name search via a persistent common_name column.
+	// TODO: support partial common-name search once a persistent common_name column exists.
 	labels, err := deps.LabelRepo.Search(ctx, species, 100)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

`/api/v2/search` filters by scientific name only because the v2 `labels` table has no `common_name` column. Users searching by common name (English "Tawny Owl", Finnish "Lehtopöllö", etc.) saw zero results unless they happened to type Latin.

PR #2782 landed a frontend-only workaround: the Svelte Search view fetched `/api/v2/species/all`, built bidirectional name maps in the browser, and translated the query client-side behind a module-scoped cache with locale-invalidation effects and race guards. That plaster does not help any non-browser API client (mobile, Home Assistant, MQTT bridges, automation scripts), duplicates data the server already has in memory, and had a real cache-invalidation bug across component mount boundaries.

This PR reverts the frontend changes and does the fix where it belongs.

### Backend

- New `resolveSpeciesToScientific` method on `*Controller` maps a case-insensitive common-name input to its scientific name before the datastore filter is built. Scientific-looking input, unknown text, and ambiguous substrings pass through unchanged so the existing `scientific_name LIKE ?` behaviour is preserved.
- Reuses the name-map plumbing from `insights.go`: a single `nameMaps` struct holds both the scientific-to-common and common-to-scientific lookups, built in one pass by `buildNameMaps`, swapped atomically on hot-reload via `UpdateCommonNameMap`.
- Unicode NFC normalisation on both the map keys and the lookup, so users typing on macOS or any composing keyboard that emits decomposed diacritics still match NFC-stored labels like "Lehtopöllö".
- Audit log: when resolution rewrites the query, a Debug line records both the submitted term and the resolved scientific name so the original user intent is preserved.
- The stale docstring at `filter_conversion.go` that claimed LIKE matching on both scientific and common names now reflects the actual SQL (scientific only) and points at the handler-level resolver, with a TODO for the persistent-column fix.

### Frontend

Clean revert of the #2782 changes in `Search.svelte`, `speciesNames.ts`, and `speciesNames.test.ts`. No downstream callers relied on the removed exports.

### Limitations accepted

Partial common-name substrings ("owl" matching every owl in the label set) still do not match. The proper fix is a persistent `common_name` column or dedicated table, tracked separately; this PR intentionally keeps scope to the interim resolver.

## Related Issues

Fixes #2766.

## Test Plan

- [x] `golangci-lint run -v` clean on `./internal/...`
- [x] `go test -race -count=1 ./internal/api/v2/...` passes (108s)
- [x] `cd frontend && npm run check:all` clean
- [x] `cd frontend && npm test -- Search speciesNames --run` green (37 tests)
- [ ] Manual: with BirdNET label locale Finnish, search for "Lehtopöllö" returns Strix aluco detections.
- [ ] Manual: with English label locale, search "Tawny Owl" returns Strix aluco detections.
- [ ] Manual: search "Turdus" still returns partial scientific-name matches.
- [ ] Manual: NFD-form diacritic input resolves correctly (paste decomposed "o" + combining umlaut).
- [ ] Manual: change BirdNET label locale, search again, confirm the server-side map has been rebuilt for the new locale (no UI state carried over).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server-side common-name resolution added: case-insensitive, Unicode-normalized matching with ambiguity preserved.

* **Bug Fixes**
  * Search loading state simplified: loading indicator reliably clears when a search finishes.

* **Refactor**
  * Species-name resolution moved out of the UI; search now sends species terms directly.

* **Tests**
  * Expanded tests for common-name resolution and ambiguity handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->