### PR TITLE
fix(frontend/search): prevent sort-dropdown race on rapid resubmits

### DIFF
--- a/frontend/src/lib/desktop/views/Search.svelte
+++ b/frontend/src/lib/desktop/views/Search.svelte
@@ -287,8 +287,11 @@
     submitSearch(page);
   }
 
-  // Handle sorting
+  // Handle sorting. Guarded against concurrent in-flight searches so a
+  // rapidly-clicked sort option cannot race an already-running submitSearch
+  // and clobber newer state with a stale response.
   function changeSort(sortOption: SortBy) {
+    if (isLoading) return;
     sortBy = sortOption;
     submitSearch(1);
   }
@@ -643,11 +646,14 @@
             >
             <div class="dropdown dropdown-end">
               <div
-                tabindex="0"
+                tabindex={isLoading ? -1 : 0}
                 role="button"
                 class="btn btn-sm btn-outline"
+                class:opacity-50={isLoading}
+                class:pointer-events-none={isLoading}
                 aria-haspopup="true"
                 aria-expanded="false"
+                aria-disabled={isLoading}
                 aria-label={t('common.sort')}
               >
                 <ArrowDownUp class="size-5" />
@@ -662,6 +668,7 @@
                   <button
                     type="button"
                     class="btn btn-ghost btn-sm justify-start w-full"
+                    disabled={isLoading}
                     onclick={() => changeSort('date_desc')}
                     >{t('search.sortOptions.dateDesc')}</button
                   >
@@ -670,6 +677,7 @@
                   <button
                     type="button"
                     class="btn btn-ghost btn-sm justify-start w-full"
+                    disabled={isLoading}
                     onclick={() => changeSort('date_asc')}>{t('search.sortOptions.dateAsc')}</button
                   >
                 </li>
@@ -677,6 +685,7 @@
                   <button
                     type="button"
                     class="btn btn-ghost btn-sm justify-start w-full"
+                    disabled={isLoading}
                     onclick={() => changeSort('species_asc')}
                     >{t('search.sortOptions.speciesAsc')}</button
                   >
@@ -685,6 +694,7 @@
                   <button
                     type="button"
                     class="btn btn-ghost btn-sm justify-start w-full"
+                    disabled={isLoading}
                     onclick={() => changeSort('confidence_desc')}
                     >{t('search.sortOptions.confidenceDesc')}</button
                   >

--- a/frontend/src/lib/desktop/views/Search.svelte
+++ b/frontend/src/lib/desktop/views/Search.svelte
@@ -210,8 +210,12 @@
     return true;
   }
 
-  // Form submission
+  // Form submission. Guarded against overlapping calls so any caller
+  // (form submit, pagination, sort dropdown, future programmatic trigger)
+  // cannot start a new request while one is still in flight; an older
+  // response would otherwise clobber newer state on completion.
   async function submitSearch(page = 1) {
+    if (isLoading) return;
     if (!validateForm()) return;
 
     isLoading = true;


### PR DESCRIPTION
## Summary

The Search view had a narrow race: the sort dropdown was not gated on the in-flight search state, so rapid-clicking two sort options while a search was loading could start overlapping requests. An out-of-order response would then clobber newer results, totals, error state, and the loading flag.

The submit button is already `disabled={isLoading}` (line 615). The pagination block is already wrapped in `{#if formSubmitted && !isLoading && totalPages > 1}` (line 1234). The sort dropdown was the only path left that could trigger an overlapping `submitSearch`.

## What this changes

- Each sort option button now carries `disabled={isLoading}`.
- The dropdown trigger (a `<div role="button">`, which cannot take a native `disabled` attribute) is gated with `tabindex={isLoading ? -1 : 0}`, `aria-disabled={isLoading}`, plus `opacity-50` and `pointer-events-none` Tailwind utilities so the menu cannot open at all during a load.
- `changeSort()` returns early when `isLoading` is true as a defence-in-depth guard for any programmatic or keyboard-driven caller.

Pre-existing bug, not caused by any recent PR. Found during review of #2805.

## Test Plan

- [x] `npm run check:all` clean.
- [x] `npm test -- Search --run` green (22 tests pass).
- [ ] Manual: open `/ui/search`, submit a search, throttle DevTools network to slow 3G, click two sort options in quick succession; confirm the second click does not fire while the first is loading and the results reflect only the completed request.
- [ ] Manual: keyboard navigation to the sort dropdown during a load should skip the disabled trigger (tabindex -1).
- [ ] Manual: screen reader announces the sort control as disabled during a load (aria-disabled=true).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents overlapping search requests by ignoring new search or sort actions while a search is in progress.
  * Sort dropdown is disabled during active searches with visual dimming and proper accessibility state, avoiding inconsistent results and accidental interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->