### PR TITLE
fix(api/detections): resolve common name before search in detections endpoint

### DIFF
--- a/internal/api/v2/detections.go
+++ b/internal/api/v2/detections.go
@@ -602,6 +602,11 @@ func (c *Controller) getDetectionsByQueryType(params *detectionQueryParams) ([]d
 	case queryTypeSpecies:
 		return c.getSpeciesDetections(params.Species, params.Date, params.Hour, params.Duration, params.NumResults, params.Offset)
 	case queryTypeSearch:
+		// Resolve a locale common name (e.g. Finnish "lehtopöllö") to its
+		// scientific name so the downstream LIKE query matches the DB column.
+		if resolved, hit := c.resolveSpeciesToScientific(params.Search); hit {
+			params.Search = resolved
+		}
 		// Use advanced search if filters are present
 		if hasAdvancedFilters {
 			return c.getSearchDetectionsAdvanced(params)

--- a/internal/api/v2/detections.go
+++ b/internal/api/v2/detections.go
@@ -596,17 +596,21 @@ func (c *Controller) getDetectionsByQueryType(params *detectionQueryParams) ([]d
 		params.Date != "" || params.StartDate != "" || params.EndDate != "" ||
 		(params.SortBy != "" && params.SortBy != "date_desc")
 
+	// Resolve locale common names to scientific names before routing so every
+	// query type benefits without per-case duplication.
+	if resolved, hit := c.resolveSpeciesToScientific(params.Species); hit {
+		params.Species = resolved
+	}
+	if resolved, hit := c.resolveSpeciesToScientific(params.Search); hit {
+		params.Search = resolved
+	}
+
 	switch params.QueryType {
 	case "hourly":
 		return c.getHourlyDetections(params.Date, params.Hour, params.Duration, params.NumResults, params.Offset)
 	case queryTypeSpecies:
 		return c.getSpeciesDetections(params.Species, params.Date, params.Hour, params.Duration, params.NumResults, params.Offset)
 	case queryTypeSearch:
-		// Resolve a locale common name (e.g. Finnish "lehtopöllö") to its
-		// scientific name so the downstream LIKE query matches the DB column.
-		if resolved, hit := c.resolveSpeciesToScientific(params.Search); hit {
-			params.Search = resolved
-		}
 		// Use advanced search if filters are present
 		if hasAdvancedFilters {
 			return c.getSearchDetectionsAdvanced(params)


### PR DESCRIPTION
## Summary

- The `/api/v2/detections?queryType=search` path passed the user query directly to `SearchNotes` without calling `resolveSpeciesToScientific`, so locale-language searches (Finnish "lehtopöllö", "varis") returned zero results
- The common-name resolver added in #2805 was only wired into `HandleSearch` (POST `/api/v2/search`); the detections endpoint used by the search UI never benefited from it
- Fix: call `resolveSpeciesToScientific` once before the advanced-filter branch so both `getSearchDetections` and `getSearchDetectionsAdvanced` receive the resolved scientific name

## Test plan

- [x] `go test -race ./internal/api/v2/...` passes
- [x] Local CodeRabbit review: no findings
- [x] Deployed to Pi 5 (Finnish locale): "lehtopöllö" returns Tawny Owl detections, "varis" returns 4,358 Hooded Crow detections
- [x] English scientific name passthrough unchanged (resolver returns hit=false for unknown inputs)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Search now automatically resolves common/local species names to their scientific names, improving match accuracy for species queries.
  * This resolution ensures consistent results across simple, advanced, and filtered searches, reducing missed matches and improving overall search reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->