### PR TITLE
fix(datastore): recover from stale _v2.db sidecar on consolidated v2 database

### DIFF
--- a/internal/datastore/v2/consolidation_test.go
+++ b/internal/datastore/v2/consolidation_test.go
@@ -264,6 +264,31 @@ func TestCleanupWALFiles_NoFilesExist(t *testing.T) {
 	cleanupWALFiles(dbPath)
 }
 
+// TestCheckAndConsolidateAtStartup_RemovesEmptyStaleSidecar ensures that a
+// 0-byte sidecar sitting next to a consolidated v2 database (the real-world
+// fault seen in production when an external deploy script touched the path)
+// is removed during the consolidation preflight instead of being silently
+// left behind to trip the subsequent startup-state check.
+func TestCheckAndConsolidateAtStartup_RemovesEmptyStaleSidecar(t *testing.T) {
+	tmpDir := t.TempDir()
+	configuredPath := filepath.Join(tmpDir, "birdnet-2025.db")
+	v2SidecarPath := filepath.Join(tmpDir, "birdnet-2025_v2.db")
+
+	createConsolidatedV2DBAt(t, configuredPath)
+
+	// Simulate the production fault: empty sidecar from an external process
+	f, err := os.Create(v2SidecarPath) //nolint:gosec // Test file path is safe
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	consolidated, err := CheckAndConsolidateAtStartup(configuredPath, newTestLogger())
+	require.NoError(t, err)
+	assert.False(t, consolidated, "no consolidation needed; configured path is already v2")
+
+	_, err = os.Stat(v2SidecarPath)
+	assert.True(t, os.IsNotExist(err), "stale empty sidecar should have been cleaned up")
+}
+
 // testLogger is a simple logger for testing
 type testLogger struct{}
 

--- a/internal/datastore/v2/startup.go
+++ b/internal/datastore/v2/startup.go
@@ -114,18 +114,9 @@ func checkSQLiteMigrationState(settings *conf.Settings) StartupState {
 
 	// If v2 migration database doesn't exist, check if configured path is a v2 DB
 	if !v2MigrationExists {
-		if configuredExists {
-			// Check if the configured database is a fresh v2 database
-			if isV2Database := CheckSQLiteHasV2Schema(configuredPath); isV2Database {
-				// This is a fresh v2 install (restart after initial fresh install)
-				return StartupState{
-					MigrationStatus: entities.MigrationStatusCompleted,
-					V2Available:     true,
-					LegacyRequired:  false,
-					FreshInstall:    false,
-					Error:           nil,
-				}
-			}
+		if configuredExists && CheckSQLiteHasV2Schema(configuredPath) {
+			// Fresh v2 install (restart after initial fresh install)
+			return completedV2StartupState()
 		}
 		// Configured path exists but is not v2 = legacy mode
 		return StartupState{
@@ -144,6 +135,9 @@ func checkSQLiteMigrationState(settings *conf.Settings) StartupState {
 	})
 	if err != nil {
 		reportStartupError("sqlite", "openV2Database", err, v2MigrationPath)
+		if fallback, ok := fallbackConsolidatedV2State(configuredPath, v2MigrationPath); ok {
+			return fallback
+		}
 		return StartupState{
 			MigrationStatus: entities.MigrationStatusIdle,
 			V2Available:     false,
@@ -156,6 +150,9 @@ func checkSQLiteMigrationState(settings *conf.Settings) StartupState {
 	sqlDB, err := db.DB()
 	if err != nil {
 		reportStartupError("sqlite", "getUnderlyingDB", err, v2MigrationPath)
+		if fallback, ok := fallbackConsolidatedV2State(configuredPath, v2MigrationPath); ok {
+			return fallback
+		}
 		return StartupState{
 			MigrationStatus: entities.MigrationStatusIdle,
 			V2Available:     false,
@@ -168,6 +165,12 @@ func checkSQLiteMigrationState(settings *conf.Settings) StartupState {
 	// Read migration state — try both table names (plural is current, singular is pre-PR #2165)
 	migrationTable := resolveSQLiteTableName(db, "migration_states", "migration_state")
 	if migrationTable == "" {
+		// Close the sidecar handle before the fallback may delete the file.
+		// sql.DB.Close is idempotent, so the deferred close remains safe.
+		_ = sqlDB.Close()
+		if fallback, ok := fallbackConsolidatedV2State(configuredPath, v2MigrationPath); ok {
+			return fallback
+		}
 		reportStartupError("sqlite", "readMigrationState", fmt.Errorf("migration state table not found"), v2MigrationPath)
 		return StartupState{
 			MigrationStatus: entities.MigrationStatusIdle,
@@ -178,6 +181,10 @@ func checkSQLiteMigrationState(settings *conf.Settings) StartupState {
 	}
 	var state entities.MigrationState
 	if err := db.Table(migrationTable).First(&state).Error; err != nil {
+		_ = sqlDB.Close()
+		if fallback, ok := fallbackConsolidatedV2State(configuredPath, v2MigrationPath); ok {
+			return fallback
+		}
 		reportStartupError("sqlite", "readMigrationState", err, v2MigrationPath)
 		return StartupState{
 			MigrationStatus: entities.MigrationStatusIdle,
@@ -196,6 +203,49 @@ func checkSQLiteMigrationState(settings *conf.Settings) StartupState {
 		LegacyRequired:  legacyRequired,
 		Error:           nil,
 	}
+}
+
+// completedV2StartupState returns the canonical StartupState for a v2-only
+// install with a fully consolidated (completed) migration. Used by both the
+// fresh-v2-restart branch and the stale-sidecar fallback so the two paths
+// cannot drift apart.
+func completedV2StartupState() StartupState {
+	return StartupState{
+		MigrationStatus: entities.MigrationStatusCompleted,
+		V2Available:     true,
+		LegacyRequired:  false,
+	}
+}
+
+// removeStaleV2Sidecar deletes a v2 migration sidecar (plus WAL/SHM) that is
+// known to be stale because the configured path already holds a consolidated
+// v2 database. Best-effort: ignores os errors so startup can proceed.
+func removeStaleV2Sidecar(v2MigrationPath, configuredPath, operation string) {
+	logger.Global().Module("datastore").Info(
+		"removing stale v2 migration sidecar next to consolidated v2 database",
+		logger.String("migration_path", v2MigrationPath),
+		logger.String("configured_path", configuredPath),
+		logger.String("operation", operation),
+	)
+	_ = os.Remove(v2MigrationPath)
+	cleanupWALFiles(v2MigrationPath)
+}
+
+// fallbackConsolidatedV2State recovers from a stale or corrupt _v2.db sidecar
+// sitting next to a configured path that is already a fully consolidated v2
+// database (created by a deploy script, failed migration, or accidental
+// touch). It removes the sidecar and returns the v2-only StartupState so the
+// caller does not misroute into legacy-migration mode.
+//
+// Returns (state, true) when the configured path is a valid completed v2
+// database; otherwise (zero, false) signalling the caller should fall
+// through to its original legacy-mode result.
+func fallbackConsolidatedV2State(configuredPath, v2MigrationPath string) (StartupState, bool) {
+	if !CheckSQLiteHasV2Schema(configuredPath) {
+		return StartupState{}, false
+	}
+	removeStaleV2Sidecar(v2MigrationPath, configuredPath, "fallback_consolidated_v2_state")
+	return completedV2StartupState(), true
 }
 
 // checkMySQLMigrationState checks migration state for MySQL deployments.
@@ -817,7 +867,15 @@ func CheckAndConsolidateAtStartup(configuredPath string, log logger.Logger) (con
 
 	// Check if v2 migration database has COMPLETED status
 	if !CheckSQLiteHasV2Schema(v2MigrationPath) {
-		// V2 exists but migration not complete, no consolidation
+		// Sidecar exists but is empty, corrupt, or has an incomplete migration.
+		// When the configured path is already a consolidated v2 database the
+		// sidecar is stale (deploy script, crashed init, accidental touch) and
+		// must be removed so the subsequent startup-state check does not
+		// misroute into legacy-migration mode.
+		if CheckSQLiteHasV2Schema(configuredPath) {
+			removeStaleV2Sidecar(v2MigrationPath, configuredPath, "consolidate_at_startup")
+		}
+		// V2 sidecar is not a completed migration DB; nothing to consolidate
 		return false, nil
 	}
 

--- a/internal/datastore/v2/startup_test.go
+++ b/internal/datastore/v2/startup_test.go
@@ -111,6 +111,72 @@ func TestCheckMigrationState_BothDBsExist_SQLite(t *testing.T) {
 	assert.False(t, state.FreshInstall, "should NOT be fresh install when both exist")
 }
 
+// TestCheckMigrationState_StaleEmptySidecar_V2Consolidated is a regression
+// test for the production failure where an empty birdnet-2025_v2.db sidecar
+// (created by an external deploy script, not by BirdNET-Go) caused startup
+// to misroute into legacy mode on a consolidated v2 database, triggering
+// "Cannot add a NOT NULL column with default value NULL" from AutoMigrate.
+//
+// With the fix, an empty/corrupt sidecar next to a healthy v2 database must
+// fall through to the configured-path check, return v2-only mode, and remove
+// the stale sidecar so subsequent startups take the clean path.
+func TestCheckMigrationState_StaleEmptySidecar_V2Consolidated(t *testing.T) {
+	tmpDir := t.TempDir()
+	configuredPath := filepath.Join(tmpDir, "birdnet-2025.db")
+	v2SidecarPath := filepath.Join(tmpDir, "birdnet-2025_v2.db")
+
+	createConsolidatedV2DBAt(t, configuredPath)
+
+	// Simulate the production fault: a 0-byte sidecar created externally
+	f, err := os.Create(v2SidecarPath) //nolint:gosec // Test file path is safe
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	settings := &conf.Settings{}
+	settings.Output.SQLite.Enabled = true
+	settings.Output.SQLite.Path = configuredPath
+
+	startupState := CheckMigrationStateBeforeStartup(settings)
+
+	assert.False(t, startupState.FreshInstall, "should NOT be fresh install")
+	assert.True(t, startupState.V2Available, "v2 should be available")
+	assert.False(t, startupState.LegacyRequired, "legacy must not be required")
+	assert.Equal(t, entities.MigrationStatusCompleted, startupState.MigrationStatus)
+	require.NoError(t, startupState.Error)
+
+	// Stale sidecar must be cleaned up so next startup does not re-enter
+	// this branch; regression guard for the deploy-script failure mode.
+	_, err = os.Stat(v2SidecarPath)
+	assert.True(t, os.IsNotExist(err), "stale sidecar should have been removed")
+}
+
+// TestCheckMigrationState_EmptySidecar_NoConfigured covers the edge case
+// where a stray empty sidecar exists but the configured path is missing.
+// The fallback must not trigger (there is no v2 schema to fall back to)
+// and startup must surface the corruption error.
+func TestCheckMigrationState_EmptySidecar_NoConfigured(t *testing.T) {
+	tmpDir := t.TempDir()
+	v2SidecarPath := filepath.Join(tmpDir, "birdnet_v2.db")
+
+	f, err := os.Create(v2SidecarPath) //nolint:gosec // Test file path is safe
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	settings := &conf.Settings{}
+	settings.Output.SQLite.Enabled = true
+	settings.Output.SQLite.Path = filepath.Join(tmpDir, "birdnet.db")
+
+	startupState := CheckMigrationStateBeforeStartup(settings)
+
+	assert.False(t, startupState.FreshInstall)
+	require.Error(t, startupState.Error, "should surface error when no fallback is available")
+
+	// Sidecar must remain: the function only removes it when a valid
+	// consolidated v2 database exists at the configured path.
+	_, err = os.Stat(v2SidecarPath)
+	require.NoError(t, err, "sidecar should be preserved when no v2 fallback exists")
+}
+
 func TestCheckMigrationState_DeepNestedPath(t *testing.T) {
 	tmpDir := t.TempDir()
 	// Custom path with multiple nested directories that don't exist
@@ -230,6 +296,21 @@ func createLegacySQLite(t *testing.T, path string, recordCount int) {
 	for i := range recordCount {
 		require.NoError(t, db.Exec("INSERT INTO notes (id, source_node) VALUES (?, 'test')", i+1).Error)
 	}
+}
+
+// createConsolidatedV2DBAt creates a fully initialized v2 database at the
+// exact path given (not the derived migration sidecar path), with migration
+// state set to COMPLETED. Used by regression tests that need a "consolidated
+// v2 DB at the configured path" fixture.
+func createConsolidatedV2DBAt(t *testing.T, path string) {
+	t.Helper()
+	mgr, err := NewSQLiteManager(Config{DirectPath: path})
+	require.NoError(t, err)
+	require.NoError(t, mgr.Initialize())
+	require.NoError(t, mgr.DB().Model(&entities.MigrationState{}).
+		Where("id = 1").
+		Update("state", entities.MigrationStatusCompleted).Error)
+	require.NoError(t, mgr.Close())
 }
 
 // createCompletedV2MigrationDB creates a v2 migration database with COMPLETED state


### PR DESCRIPTION
## Summary

A 0-byte or corrupt `birdnet_v2.db` sidecar next to a fully consolidated v2 database caused startup to misroute into legacy AutoMigrate mode and crash with:

```
ERROR [main] Command execution failed error="Cannot add a NOT NULL column with default value NULL"
sql: ALTER TABLE `dynamic_thresholds` ADD `species_name` text NOT NULL
```

The sidecar file can be created by external factors (deploy script, failed migration, accidental touch). Once present, every subsequent startup hit the same fault because `checkSQLiteMigrationState` treated the file's existence as proof a legacy migration was in flight, even when the configured path was already a fully completed v2 database.

## Root cause

`internal/datastore/v2/startup.go#checkSQLiteMigrationState` short-circuited to `{Idle, V2Available:true, LegacyRequired:true}` as soon as it saw the sidecar file and could not read a migration state from it. It never fell through to the existing `CheckSQLiteHasV2Schema(configuredPath)` check that correctly identifies a consolidated v2 database.

## Fix

- `checkSQLiteMigrationState` now falls through to a new `fallbackConsolidatedV2State` helper at every sidecar-read error path (GORM open failure, underlying DB failure, missing migration state table, unreadable state row). When the configured path is a completed v2 database, the helper returns v2-only mode and removes the stale sidecar + WAL/SHM files.
- `CheckAndConsolidateAtStartup` removes the stale sidecar during the consolidation preflight so the subsequent state check cannot re-trigger the same fault.
- Two small shared helpers (`completedV2StartupState`, `removeStaleV2Sidecar`) collapse duplicated state-construction and cleanup code.

The fallback is strictly gated on `CheckSQLiteHasV2Schema(configuredPath)` returning true (requires `migration_states` table with `COMPLETED` status), so there is no data-loss path: an in-progress migration in the sidecar is preserved because the configured path would not yet be in `COMPLETED` state.

## Test plan

- [x] `go test ./internal/datastore/v2/ -race` passes
- [x] `golangci-lint run ./internal/datastore/v2/...` clean
- [x] New regression tests:
  - `TestCheckMigrationState_StaleEmptySidecar_V2Consolidated` - the main regression case
  - `TestCheckMigrationState_EmptySidecar_NoConfigured` - fallback must NOT trigger when there is no v2 schema to fall back to; sidecar is preserved
  - `TestCheckAndConsolidateAtStartup_RemovesEmptyStaleSidecar` - consolidation preflight cleans up the stale sidecar
- [x] Shared test fixture `createConsolidatedV2DBAt` keeps the two regression tests in lockstep
- [ ] Manual verify on the affected machine after merge (reproduced locally first)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup reliability when handling stale or incomplete database migration files.
  * Added automatic cleanup of problematic sidecar files during startup when a valid consolidated database exists.
  * Enhanced error recovery for database migration state detection to prevent startup failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->