### PR TITLE
fix(audio-export): close three validation gaps producing extension-less clip paths

### DIFF
--- a/frontend/src/lib/desktop/features/settings/pages/AudioSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/AudioSettingsPage.svelte
@@ -58,7 +58,7 @@
   import { getLocale } from '$lib/i18n';
   import { loggers } from '$lib/utils/logger';
   import { getBitrateConfig, formatBitrate, parseNumericBitrate } from '$lib/utils/audioValidation';
-  import { chooseBitrateForFormat, type ExportFormat } from './audioExportFormat';
+  import { chooseBitrateForFormat, isExportFormat, type ExportFormat } from './audioExportFormat';
   import {
     Volume2,
     Radio,
@@ -1256,7 +1256,12 @@
               helpText={t('settings.audio.fileSettings.typeHelp')}
               options={exportFormatOptions}
               disabled={!settings.audio.export.enabled || store.isLoading || store.isSaving}
-              onChange={value => updateExportFormat(value as ExportFormat)}
+              onChange={value => {
+                const candidate = Array.isArray(value) ? value[0] : value;
+                if (isExportFormat(candidate)) {
+                  updateExportFormat(candidate);
+                }
+              }}
               groupBy={false}
               menuSize="sm"
             />

--- a/frontend/src/lib/desktop/features/settings/pages/AudioSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/AudioSettingsPage.svelte
@@ -58,6 +58,7 @@
   import { getLocale } from '$lib/i18n';
   import { loggers } from '$lib/utils/logger';
   import { getBitrateConfig, formatBitrate, parseNumericBitrate } from '$lib/utils/audioValidation';
+  import { chooseBitrateForFormat, type ExportFormat } from './audioExportFormat';
   import {
     Volume2,
     Radio,
@@ -437,9 +438,13 @@
     });
   }
 
-  function updateExportFormat(type: 'wav' | 'mp3' | 'flac' | 'aac' | 'opus') {
+  function updateExportFormat(type: ExportFormat) {
+    const nextBitrate = chooseBitrateForFormat(type, settings.audio.export.bitrate ?? '');
     settingsActions.updateSection('realtime', {
-      audio: { ...$audioSettings!, export: { ...settings.audio.export, type } },
+      audio: {
+        ...$audioSettings!,
+        export: { ...settings.audio.export, type, bitrate: nextBitrate },
+      },
     });
   }
 
@@ -1251,8 +1256,7 @@
               helpText={t('settings.audio.fileSettings.typeHelp')}
               options={exportFormatOptions}
               disabled={!settings.audio.export.enabled || store.isLoading || store.isSaving}
-              onChange={value =>
-                updateExportFormat(value as 'wav' | 'mp3' | 'flac' | 'aac' | 'opus')}
+              onChange={value => updateExportFormat(value as ExportFormat)}
               groupBy={false}
               menuSize="sm"
             />

--- a/frontend/src/lib/desktop/features/settings/pages/AudioSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/AudioSettingsPage.svelte
@@ -1260,6 +1260,10 @@
                 const candidate = Array.isArray(value) ? value[0] : value;
                 if (isExportFormat(candidate)) {
                   updateExportFormat(candidate);
+                } else {
+                  logger.warn('Ignoring unknown audio export format candidate', {
+                    candidate,
+                  });
                 }
               }}
               groupBy={false}

--- a/frontend/src/lib/desktop/features/settings/pages/AudioSettingsPage.updateExportFormat.test.ts
+++ b/frontend/src/lib/desktop/features/settings/pages/AudioSettingsPage.updateExportFormat.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { chooseBitrateForFormat, type ExportFormat } from './audioExportFormat';
+
+describe('chooseBitrateForFormat', () => {
+  it('returns empty string for lossless formats', () => {
+    expect(chooseBitrateForFormat('wav', '128k')).toBe('');
+    expect(chooseBitrateForFormat('flac', '128k')).toBe('');
+  });
+
+  it('seeds format default when current bitrate is empty', () => {
+    expect(chooseBitrateForFormat('mp3', '')).toBe('128k');
+    expect(chooseBitrateForFormat('aac', '')).toBe('96k');
+    expect(chooseBitrateForFormat('opus', '')).toBe('96k');
+  });
+
+  it('preserves current bitrate when it is within the target range', () => {
+    expect(chooseBitrateForFormat('mp3', '192k')).toBe('192k');
+    expect(chooseBitrateForFormat('aac', '128k')).toBe('128k');
+    expect(chooseBitrateForFormat('opus', '128k')).toBe('128k');
+  });
+
+  it('snaps to format default when current bitrate is below the target min', () => {
+    expect(chooseBitrateForFormat('mp3', '16k')).toBe('128k');
+    expect(chooseBitrateForFormat('aac', '16k')).toBe('96k');
+  });
+
+  it('snaps to format default when current bitrate is above the target max', () => {
+    // Opus tops out at 256k, so a 320k carryover from MP3 must be clamped.
+    expect(chooseBitrateForFormat('opus', '320k')).toBe('96k');
+  });
+
+  it('snaps to format default when current bitrate is malformed', () => {
+    expect(chooseBitrateForFormat('mp3', 'garbage')).toBe('128k');
+    expect(chooseBitrateForFormat('mp3', 'not-a-bitrate')).toBe('128k');
+  });
+
+  it.each<[ExportFormat, ExportFormat]>([
+    ['wav', 'mp3'],
+    ['flac', 'mp3'],
+    ['wav', 'aac'],
+    ['flac', 'aac'],
+    ['wav', 'opus'],
+    ['flac', 'opus'],
+  ])('lossless %s -> lossy %s always yields a valid bitrate', (_from, to) => {
+    const next = chooseBitrateForFormat(to, '');
+    expect(next).toMatch(/^\d+k$/);
+  });
+});

--- a/frontend/src/lib/desktop/features/settings/pages/audioExportFormat.ts
+++ b/frontend/src/lib/desktop/features/settings/pages/audioExportFormat.ts
@@ -7,6 +7,12 @@ import { formatBitrate, getBitrateConfig } from '$lib/utils/audioValidation';
 
 export type ExportFormat = 'wav' | 'mp3' | 'flac' | 'aac' | 'opus';
 
+const EXPORT_FORMATS: readonly ExportFormat[] = ['wav', 'mp3', 'flac', 'aac', 'opus'];
+
+export function isExportFormat(value: unknown): value is ExportFormat {
+  return typeof value === 'string' && (EXPORT_FORMATS as readonly string[]).includes(value);
+}
+
 // Parse "128k" / "128K" / "128" into a positive number, or null if the
 // input cannot be interpreted as a positive numeric bitrate. Returning
 // null lets chooseBitrateForFormat distinguish "invalid" from "valid 128k"

--- a/frontend/src/lib/desktop/features/settings/pages/audioExportFormat.ts
+++ b/frontend/src/lib/desktop/features/settings/pages/audioExportFormat.ts
@@ -1,0 +1,50 @@
+/**
+ * Audio export format helpers. Kept separate from AudioSettingsPage so the
+ * lossless-to-lossy transition logic can be unit-tested without mounting
+ * the Svelte component.
+ */
+import { formatBitrate, getBitrateConfig } from '$lib/utils/audioValidation';
+
+export type ExportFormat = 'wav' | 'mp3' | 'flac' | 'aac' | 'opus';
+
+// Parse "128k" / "128K" / "128" into a positive number, or null if the
+// input cannot be interpreted as a positive numeric bitrate. Returning
+// null lets chooseBitrateForFormat distinguish "invalid" from "valid 128k"
+// so it can snap to the target format default rather than accept stray
+// values. The shared parseNumericBitrate in audioValidation.ts returns a
+// hardcoded default on failure and cannot make that distinction.
+function parseBitrateNullable(raw: string): number | null {
+  const trimmed = raw.trim();
+  if (trimmed === '') {
+    return null;
+  }
+  const stripped = trimmed.endsWith('k') || trimmed.endsWith('K') ? trimmed.slice(0, -1) : trimmed;
+  const parsed = Number(stripped);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+}
+
+/**
+ * Pick a bitrate string appropriate for the given target format.
+ *
+ * - For lossless formats (wav, flac): returns '' (bitrate is ignored by the
+ *   backend).
+ * - For lossy formats (mp3, aac, opus): returns the current bitrate if it
+ *   is a valid in-range numeric value for the target format, otherwise
+ *   seeds that format's default.
+ */
+export function chooseBitrateForFormat(target: ExportFormat, current: string): string {
+  // getBitrateConfig returns null for lossless formats. That is the single
+  // source of truth; calling getExportTypeConfig separately would re-derive
+  // the same lossless/lossy split.
+  const config = getBitrateConfig(target);
+  if (!config) {
+    return '';
+  }
+
+  const currentValue = parseBitrateNullable(current);
+  if (currentValue !== null && currentValue >= config.min && currentValue <= config.max) {
+    return formatBitrate(currentValue);
+  }
+
+  return formatBitrate(config.default);
+}

--- a/internal/analysis/processor/build_clip_path_test.go
+++ b/internal/analysis/processor/build_clip_path_test.go
@@ -1,0 +1,87 @@
+package processor
+
+import (
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tphakala/birdnet-go/internal/conf"
+)
+
+// newProcessorWithExportType returns a minimal Processor suitable for
+// exercising buildClipPath in isolation. Only the fields buildClipPath
+// reads are populated.
+func newProcessorWithExportType(t *testing.T, exportType string) *Processor {
+	t.Helper()
+	return &Processor{
+		Settings: &conf.Settings{
+			Realtime: conf.RealtimeSettings{
+				Audio: conf.AudioSettings{
+					Export: conf.ExportSettings{
+						Type: exportType,
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestBuildClipPath_EmptyTypeFallsBackToWav(t *testing.T) {
+	// Resets the package-level sync.Once so this test is order-independent.
+	resetBuildClipPathFallbackOnce()
+	t.Cleanup(resetBuildClipPathFallbackOnce)
+
+	p := newProcessorWithExportType(t, "")
+	ts := time.Date(2026, 3, 14, 9, 37, 1, 0, time.UTC)
+
+	got := p.buildClipPath("Strix aluco", 0.94, 15, ts)
+
+	assert.True(t, strings.HasSuffix(got, ".wav"),
+		"empty Type should fall back to .wav, got %q", got)
+	assert.False(t, strings.HasSuffix(got, "."),
+		"path must never end in a bare dot, got %q", got)
+}
+
+func TestBuildClipPath_NeverEndsInDot(t *testing.T) {
+	// Class-of-bug invariant: regardless of Type value, the returned path
+	// must not end in a bare dot.
+	resetBuildClipPathFallbackOnce()
+	t.Cleanup(resetBuildClipPathFallbackOnce)
+
+	inputs := []string{"", " ", "wav", "mp3", "aac", "opus", "flac", "garbage"}
+	ts := time.Date(2026, 3, 14, 9, 37, 1, 0, time.UTC)
+
+	for _, in := range inputs {
+		t.Run("type="+in, func(t *testing.T) {
+			p := newProcessorWithExportType(t, in)
+			got := p.buildClipPath("Strix aluco", 0.94, 15, ts)
+			assert.False(t, strings.HasSuffix(got, "."),
+				"path must never end in bare dot (type=%q, got %q)", in, got)
+			assert.NotEmpty(t, strings.TrimSuffix(got, "."),
+				"path must have a non-empty extension (type=%q, got %q)", in, got)
+		})
+	}
+}
+
+func TestBuildClipPath_FallbackWarnsOnlyOnce(t *testing.T) {
+	resetBuildClipPathFallbackOnce()
+	t.Cleanup(resetBuildClipPathFallbackOnce)
+
+	// Drive the fallback path 10 times in quick succession.
+	p := newProcessorWithExportType(t, "")
+	ts := time.Date(2026, 3, 14, 9, 37, 1, 0, time.UTC)
+	var wg sync.WaitGroup
+	for range 10 {
+		wg.Go(func() {
+			_ = p.buildClipPath("Strix aluco", 0.94, 15, ts)
+		})
+	}
+	wg.Wait()
+
+	// sync.Once guarantees at-most-one; the bool confirms it fired at least
+	// once under concurrent load. Exact-once is a stdlib invariant.
+	assert.True(t, buildClipPathFallbackWarned(),
+		"expected sync.Once to have fired after empty-Type calls")
+}

--- a/internal/analysis/processor/build_clip_path_test.go
+++ b/internal/analysis/processor/build_clip_path_test.go
@@ -1,6 +1,7 @@
 package processor
 
 import (
+	"path"
 	"strings"
 	"sync"
 	"testing"
@@ -59,8 +60,9 @@ func TestBuildClipPath_NeverEndsInDot(t *testing.T) {
 			got := p.buildClipPath("Strix aluco", 0.94, 15, ts)
 			assert.False(t, strings.HasSuffix(got, "."),
 				"path must never end in bare dot (type=%q, got %q)", in, got)
-			assert.NotEmpty(t, strings.TrimSuffix(got, "."),
-				"path must have a non-empty extension (type=%q, got %q)", in, got)
+			ext := strings.TrimPrefix(strings.TrimSpace(path.Ext(got)), ".")
+			assert.NotEmpty(t, ext,
+				"path must have a non-empty, non-whitespace extension (type=%q, got %q)", in, got)
 		})
 	}
 }

--- a/internal/analysis/processor/export_test.go
+++ b/internal/analysis/processor/export_test.go
@@ -1,0 +1,16 @@
+package processor
+
+import "sync"
+
+// resetBuildClipPathFallbackOnce resets the one-shot WARN guard so tests
+// can exercise the fallback path multiple times. Test-only.
+func resetBuildClipPathFallbackOnce() {
+	buildClipPathFallbackOnce = sync.Once{}
+	buildClipPathFallbackFired.Store(false)
+}
+
+// buildClipPathFallbackWarned returns true if the one-shot WARN has fired
+// at least once since the last reset. Test-only.
+func buildClipPathFallbackWarned() bool {
+	return buildClipPathFallbackFired.Load()
+}

--- a/internal/analysis/processor/processor.go
+++ b/internal/analysis/processor/processor.go
@@ -1155,7 +1155,7 @@ func (p *Processor) buildClipPath(scientificName string, confidence float32, dur
 				logger.String("component", "processor"),
 				logger.String("action", "buildClipPath_fallback"))
 		})
-		fileType = "wav"
+		fileType = conf.AudioExportTypeWAV
 	}
 
 	var filename string

--- a/internal/analysis/processor/processor.go
+++ b/internal/analysis/processor/processor.go
@@ -1143,13 +1143,15 @@ func (p *Processor) buildClipPath(scientificName string, confidence float32, dur
 	year := t.Format("2006")
 	month := t.Format("01")
 
-	exportType := p.Settings.Realtime.Audio.Export.Type
-	fileType := convert.GetFileExtension(exportType)
+	rawExportType := p.Settings.Realtime.Audio.Export.Type
+	// GetFileExtension is a passthrough for unknown formats, so "   " (all
+	// whitespace) would leak into the filename as a ". " suffix. Trim first.
+	fileType := strings.TrimSpace(convert.GetFileExtension(strings.TrimSpace(rawExportType)))
 	if fileType == "" {
 		buildClipPathFallbackOnce.Do(func() {
 			buildClipPathFallbackFired.Store(true)
 			GetLogger().Warn("audio export type produced empty file extension, falling back to wav",
-				logger.String("export_type", exportType),
+				logger.String("export_type", rawExportType),
 				logger.String("component", "processor"),
 				logger.String("action", "buildClipPath_fallback"))
 		})

--- a/internal/analysis/processor/processor.go
+++ b/internal/analysis/processor/processor.go
@@ -1121,6 +1121,19 @@ func (p *Processor) generateClipNameWithDuration(scientificName string, confiden
 	return p.buildClipPath(scientificName, confidence, durationSeconds, detectionTime)
 }
 
+// buildClipPathFallbackOnce guards the one-shot WARN log emitted when
+// buildClipPath falls back to a wav extension because Export.Type produced
+// an empty GetFileExtension result. Post fix this branch should be
+// unreachable - the WARN exists purely as a defense-in-depth signal that a
+// previously unknown code path is writing extension-less clip paths to the
+// DB (see GitHub #2810, #2814).
+//
+//nolint:gochecknoglobals // one-shot WARN guard for defense-in-depth fallback
+var (
+	buildClipPathFallbackOnce  sync.Once
+	buildClipPathFallbackFired atomic.Bool
+)
+
 // buildClipPath constructs a clip file path with optional duration suffix.
 // When durationSeconds is 0, the duration suffix is omitted.
 func (p *Processor) buildClipPath(scientificName string, confidence float32, durationSeconds int, t time.Time) string {
@@ -1129,7 +1142,19 @@ func (p *Processor) buildClipPath(scientificName string, confidence float32, dur
 	timestamp := t.Format("20060102T150405Z")
 	year := t.Format("2006")
 	month := t.Format("01")
-	fileType := convert.GetFileExtension(p.Settings.Realtime.Audio.Export.Type)
+
+	exportType := p.Settings.Realtime.Audio.Export.Type
+	fileType := convert.GetFileExtension(exportType)
+	if fileType == "" {
+		buildClipPathFallbackOnce.Do(func() {
+			buildClipPathFallbackFired.Store(true)
+			GetLogger().Warn("audio export type produced empty file extension, falling back to wav",
+				logger.String("export_type", exportType),
+				logger.String("component", "processor"),
+				logger.String("action", "buildClipPath_fallback"))
+		})
+		fileType = "wav"
+	}
 
 	var filename string
 	if durationSeconds > 0 {

--- a/internal/analysis/processor/processor.go
+++ b/internal/analysis/processor/processor.go
@@ -1144,9 +1144,9 @@ func (p *Processor) buildClipPath(scientificName string, confidence float32, dur
 	month := t.Format("01")
 
 	rawExportType := p.Settings.Realtime.Audio.Export.Type
-	// GetFileExtension is a passthrough for unknown formats, so "   " (all
-	// whitespace) would leak into the filename as a ". " suffix. Trim first.
-	fileType := strings.TrimSpace(convert.GetFileExtension(strings.TrimSpace(rawExportType)))
+	// GetFileExtension is a passthrough for unknown formats, so a whitespace-
+	// only Type would otherwise leak into the filename as a ". " suffix.
+	fileType := convert.GetFileExtension(strings.TrimSpace(rawExportType))
 	if fileType == "" {
 		buildClipPathFallbackOnce.Do(func() {
 			buildClipPathFallbackFired.Store(true)

--- a/internal/conf/audio_source_migration_test.go
+++ b/internal/conf/audio_source_migration_test.go
@@ -11,7 +11,7 @@ func TestMigrateAudioSourceConfig_BasicMigration(t *testing.T) {
 	t.Parallel()
 
 	settings := &Settings{}
-	settings.Realtime.Audio.Source = "sysdefault"
+	settings.Realtime.Audio.Source = testAudioDeviceSysdefault
 	settings.Realtime.Audio.QuietHours = QuietHoursConfig{
 		Enabled:   true,
 		Mode:      "fixed",
@@ -26,7 +26,7 @@ func TestMigrateAudioSourceConfig_BasicMigration(t *testing.T) {
 
 	src := settings.Realtime.Audio.Sources[0]
 	assert.Equal(t, "Sound Card 1", src.Name)
-	assert.Equal(t, "sysdefault", src.Device)
+	assert.Equal(t, testAudioDeviceSysdefault, src.Device)
 	assert.InDelta(t, 0.0, src.Gain, 0.001)
 	assert.Empty(t, src.Model)
 	assert.Nil(t, src.Equalizer)
@@ -45,7 +45,7 @@ func TestMigrateAudioSourceConfig_SkipIfAlreadyMigrated(t *testing.T) {
 		Name:   "My Mic",
 		Device: "hw:0,0",
 	}}
-	settings.Realtime.Audio.Source = "sysdefault" // Leftover legacy, should be ignored
+	settings.Realtime.Audio.Source = testAudioDeviceSysdefault // Leftover legacy, should be ignored
 
 	migrated := settings.MigrateAudioSourceConfig()
 

--- a/internal/conf/test_helpers_test.go
+++ b/internal/conf/test_helpers_test.go
@@ -11,6 +11,9 @@ import (
 // testHelper provides common assertion helpers for configuration tests.
 // These helpers reduce code duplication and improve test readability.
 
+// testAudioDeviceSysdefault is the ALSA system-default device name used in tests.
+const testAudioDeviceSysdefault = "sysdefault"
+
 // requireEnhancedError asserts that the error is an EnhancedError and returns it.
 func requireEnhancedError(t *testing.T, err error) *errors.EnhancedError {
 	t.Helper()

--- a/internal/conf/validate.go
+++ b/internal/conf/validate.go
@@ -75,6 +75,15 @@ const (
 	DefaultPlaybackGain = 0.0  // Safe default if invalid value provided
 )
 
+// Audio export type constants
+const (
+	AudioExportTypeWAV  = "wav"  // Lossless PCM audio
+	AudioExportTypeFLAC = "flac" // Lossless compressed audio
+	AudioExportTypeMP3  = "mp3"  // Lossy compressed audio
+	AudioExportTypeAAC  = "aac"  // Lossy compressed audio
+	AudioExportTypeOPUS = "opus" // Lossy compressed audio
+)
+
 // Stream validation constants
 const (
 	MaxStreamNameLength      = 64
@@ -1291,7 +1300,49 @@ func validateAudioSettings(settings *AudioSettings) error {
 			Build()
 	}
 
-	// Validate audio export settings
+	// Validate audio export settings.
+	//
+	// Normalize first, validate second. Type must be normalized even when
+	// Export.Enabled is false, because the Enabled flag can be flipped back on
+	// without triggering validation of the already-persisted Type value.
+	// An empty Type previously produced extension-less clip_name rows in the
+	// DB, causing audio download and spectrogram generation to 404
+	// (GitHub #2810, #2814).
+	if strings.TrimSpace(settings.Export.Type) == "" {
+		GetLogger().Warn("audio export type is empty, normalizing to wav",
+			logger.String("previous_type", settings.Export.Type),
+			logger.String("action", "normalize_to_wav"))
+		settings.Export.Type = AudioExportTypeWAV
+	}
+
+	if settings.FfmpegPath == "" && settings.Export.Type != AudioExportTypeWAV {
+		GetLogger().Warn("FFmpeg not available, forcing WAV format for audio export",
+			logger.String("previous_type", settings.Export.Type))
+		settings.Export.Type = AudioExportTypeWAV
+	}
+
+	// Type must be one of the known formats regardless of Enabled, so a
+	// persisted garbage value can never silently roll forward.
+	switch settings.Export.Type {
+	case AudioExportTypeWAV, AudioExportTypeFLAC:
+		// lossless, no bitrate needed
+	case AudioExportTypeAAC, AudioExportTypeOPUS, AudioExportTypeMP3:
+		// lossy, bitrate required - but only enforce when export is actually enabled
+		if settings.Export.Enabled {
+			if err := validateExportBitrate(settings.Export.Type, settings.Export.Bitrate); err != nil {
+				return err
+			}
+		}
+	default:
+		return errors.Newf("unsupported audio export type: %s", settings.Export.Type).
+			Category(errors.CategoryValidation).
+			Context("validation_type", "audio-export-type").
+			Context("export_type", settings.Export.Type).
+			Build()
+	}
+
+	// Remaining checks (length, pre-capture, gain, normalization) only make
+	// sense when export is actually enabled.
 	if settings.Export.Enabled {
 		// Validate capture length (10-60 seconds)
 		if settings.Export.Length < 10 || settings.Export.Length > 60 {
@@ -1327,88 +1378,79 @@ func validateAudioSettings(settings *AudioSettings) error {
 
 		// Validate normalization settings if enabled
 		if settings.Export.Normalization.Enabled {
-			// Validate target LUFS (reasonable range for EBU R128)
-			if settings.Export.Normalization.TargetLUFS < MinTargetLUFS || settings.Export.Normalization.TargetLUFS > MaxTargetLUFS {
-				return errors.Newf("normalization target LUFS must be between %.0f and %.0f, got %.1f", MinTargetLUFS, MaxTargetLUFS, settings.Export.Normalization.TargetLUFS).
-					Category(errors.CategoryValidation).
-					Context("validation_type", "audio-normalization-target").
-					Context("target_lufs", settings.Export.Normalization.TargetLUFS).
-					Context("min_target_lufs", MinTargetLUFS).
-					Context("max_target_lufs", MaxTargetLUFS).
-					Build()
-			}
-
-			// Validate loudness range (dynamic range)
-			if settings.Export.Normalization.LoudnessRange < MinLoudnessRange || settings.Export.Normalization.LoudnessRange > MaxLoudnessRange {
-				return errors.Newf("normalization loudness range must be between %.0f and %.0f LU, got %.1f", MinLoudnessRange, MaxLoudnessRange, settings.Export.Normalization.LoudnessRange).
-					Category(errors.CategoryValidation).
-					Context("validation_type", "audio-normalization-range").
-					Context("loudness_range", settings.Export.Normalization.LoudnessRange).
-					Context("min_loudness_range", MinLoudnessRange).
-					Context("max_loudness_range", MaxLoudnessRange).
-					Build()
-			}
-
-			// Validate true peak (headroom to prevent clipping)
-			if settings.Export.Normalization.TruePeak < MinTruePeak || settings.Export.Normalization.TruePeak > MaxTruePeak {
-				return errors.Newf("normalization true peak must be between %.0f and %.0f dBTP, got %.1f", MinTruePeak, MaxTruePeak, settings.Export.Normalization.TruePeak).
-					Category(errors.CategoryValidation).
-					Context("validation_type", "audio-normalization-peak").
-					Context("true_peak", settings.Export.Normalization.TruePeak).
-					Context("min_true_peak", MinTruePeak).
-					Context("max_true_peak", MaxTruePeak).
-					Build()
-			}
-
-			// Warn if gain is also set (normalization takes precedence)
-			if settings.Export.Gain != 0 {
-				GetLogger().Warn("Both gain and normalization are configured", logger.String("action", "Normalization will take precedence, gain setting will be ignored"))
-			}
-		}
-
-		if settings.FfmpegPath == "" {
-			settings.Export.Type = "wav"
-			GetLogger().Warn("FFmpeg not available, using WAV format for audio export")
-		} else {
-			// Validate audio type and bitrate
-			switch settings.Export.Type {
-			case "aac", "opus", "mp3":
-				if !strings.HasSuffix(settings.Export.Bitrate, "k") {
-					return errors.Newf("invalid bitrate format for %s: %s. Must end with 'k' (e.g., '64k')", settings.Export.Type, settings.Export.Bitrate).
-						Category(errors.CategoryValidation).
-						Context("validation_type", "audio-export-bitrate-format").
-						Context("export_type", settings.Export.Type).
-						Context("bitrate", settings.Export.Bitrate).
-						Build()
-				}
-				bitrateValue, err := strconv.Atoi(strings.TrimSuffix(settings.Export.Bitrate, "k"))
-				if err != nil {
-					return errors.Newf("invalid bitrate value for %s: %s", settings.Export.Type, settings.Export.Bitrate).
-						Category(errors.CategoryValidation).
-						Context("validation_type", "audio-export-bitrate-value").
-						Context("export_type", settings.Export.Type).
-						Context("bitrate", settings.Export.Bitrate).
-						Build()
-				}
-				if bitrateValue < 32 || bitrateValue > 320 {
-					return errors.Newf("bitrate for %s must be between 32k and 320k", settings.Export.Type).
-						Category(errors.CategoryValidation).
-						Context("validation_type", "audio-export-bitrate-range").
-						Context("export_type", settings.Export.Type).
-						Build()
-				}
-			case "wav", "flac":
-				// These formats don't use bitrate, so we'll ignore the bitrate setting
-			default:
-				return errors.Newf("unsupported audio export type: %s", settings.Export.Type).
-					Category(errors.CategoryValidation).
-					Context("validation_type", "audio-export-type").
-					Context("export_type", settings.Export.Type).
-					Build()
+			if err := validateNormalizationSettings(&settings.Export.Normalization, settings.Export.Gain); err != nil {
+				return err
 			}
 		}
 	}
 
+	return nil
+}
+
+// validateExportBitrate validates the bitrate setting for lossy audio export formats
+// (mp3, aac, opus). It must end with "k" and be between 32 and 320 kbps.
+func validateExportBitrate(exportType, bitrate string) error {
+	if !strings.HasSuffix(bitrate, "k") {
+		return errors.Newf("invalid bitrate format for %s: %s. Must end with 'k' (e.g., '64k')", exportType, bitrate).
+			Category(errors.CategoryValidation).
+			Context("validation_type", "audio-export-bitrate-format").
+			Context("export_type", exportType).
+			Context("bitrate", bitrate).
+			Build()
+	}
+	bitrateValue, err := strconv.Atoi(strings.TrimSuffix(bitrate, "k"))
+	if err != nil {
+		return errors.Newf("invalid bitrate value for %s: %s", exportType, bitrate).
+			Category(errors.CategoryValidation).
+			Context("validation_type", "audio-export-bitrate-value").
+			Context("export_type", exportType).
+			Context("bitrate", bitrate).
+			Build()
+	}
+	if bitrateValue < 32 || bitrateValue > 320 {
+		return errors.Newf("bitrate for %s must be between 32k and 320k, got %dk", exportType, bitrateValue).
+			Category(errors.CategoryValidation).
+			Context("validation_type", "audio-export-bitrate-range").
+			Context("export_type", exportType).
+			Context("bitrate_value", bitrateValue).
+			Build()
+	}
+	return nil
+}
+
+// validateNormalizationSettings validates the EBU R128 normalization parameters
+// (target LUFS, loudness range, and true peak) and warns if gain is also configured.
+func validateNormalizationSettings(norm *NormalizationSettings, gain float64) error {
+	if norm.TargetLUFS < MinTargetLUFS || norm.TargetLUFS > MaxTargetLUFS {
+		return errors.Newf("normalization target LUFS must be between %.0f and %.0f, got %.1f", MinTargetLUFS, MaxTargetLUFS, norm.TargetLUFS).
+			Category(errors.CategoryValidation).
+			Context("validation_type", "audio-normalization-target").
+			Context("target_lufs", norm.TargetLUFS).
+			Context("min_target_lufs", MinTargetLUFS).
+			Context("max_target_lufs", MaxTargetLUFS).
+			Build()
+	}
+	if norm.LoudnessRange < MinLoudnessRange || norm.LoudnessRange > MaxLoudnessRange {
+		return errors.Newf("normalization loudness range must be between %.0f and %.0f LU, got %.1f", MinLoudnessRange, MaxLoudnessRange, norm.LoudnessRange).
+			Category(errors.CategoryValidation).
+			Context("validation_type", "audio-normalization-range").
+			Context("loudness_range", norm.LoudnessRange).
+			Context("min_loudness_range", MinLoudnessRange).
+			Context("max_loudness_range", MaxLoudnessRange).
+			Build()
+	}
+	if norm.TruePeak < MinTruePeak || norm.TruePeak > MaxTruePeak {
+		return errors.Newf("normalization true peak must be between %.0f and %.0f dBTP, got %.1f", MinTruePeak, MaxTruePeak, norm.TruePeak).
+			Category(errors.CategoryValidation).
+			Context("validation_type", "audio-normalization-peak").
+			Context("true_peak", norm.TruePeak).
+			Context("min_true_peak", MinTruePeak).
+			Context("max_true_peak", MaxTruePeak).
+			Build()
+	}
+	if gain != 0 {
+		GetLogger().Warn("Both gain and normalization are configured", logger.String("action", "Normalization will take precedence, gain setting will be ignored"))
+	}
 	return nil
 }
 

--- a/internal/conf/validate.go
+++ b/internal/conf/validate.go
@@ -1315,30 +1315,35 @@ func validateAudioSettings(settings *AudioSettings) error {
 		settings.Export.Type = AudioExportTypeWAV
 	}
 
-	if settings.FfmpegPath == "" && settings.Export.Type != AudioExportTypeWAV {
-		GetLogger().Warn("FFmpeg not available, forcing WAV format for audio export",
-			logger.String("previous_type", settings.Export.Type))
-		settings.Export.Type = AudioExportTypeWAV
-	}
-
-	// Type must be one of the known formats regardless of Enabled, so a
-	// persisted garbage value can never silently roll forward.
+	// Reject unknown Type before any fallback runs. Doing this first means a
+	// garbage value cannot be silently rewritten to WAV by the ffmpeg-missing
+	// fallback below, which would hide the misconfiguration.
 	switch settings.Export.Type {
-	case AudioExportTypeWAV, AudioExportTypeFLAC:
-		// lossless, no bitrate needed
-	case AudioExportTypeAAC, AudioExportTypeOPUS, AudioExportTypeMP3:
-		// lossy, bitrate required - but only enforce when export is actually enabled
-		if settings.Export.Enabled {
-			if err := validateExportBitrate(settings.Export.Type, settings.Export.Bitrate); err != nil {
-				return err
-			}
-		}
+	case AudioExportTypeWAV, AudioExportTypeFLAC,
+		AudioExportTypeAAC, AudioExportTypeOPUS, AudioExportTypeMP3:
+		// known format
 	default:
 		return errors.Newf("unsupported audio export type: %s", settings.Export.Type).
 			Category(errors.CategoryValidation).
 			Context("validation_type", "audio-export-type").
 			Context("export_type", settings.Export.Type).
 			Build()
+	}
+
+	if settings.FfmpegPath == "" && settings.Export.Type != AudioExportTypeWAV {
+		GetLogger().Warn("FFmpeg not available, forcing WAV format for audio export",
+			logger.String("previous_type", settings.Export.Type))
+		settings.Export.Type = AudioExportTypeWAV
+	}
+
+	// Bitrate only matters for lossy formats and only when export is enabled.
+	switch settings.Export.Type {
+	case AudioExportTypeAAC, AudioExportTypeOPUS, AudioExportTypeMP3:
+		if settings.Export.Enabled {
+			if err := validateExportBitrate(settings.Export.Type, settings.Export.Bitrate); err != nil {
+				return err
+			}
+		}
 	}
 
 	// Remaining checks (length, pre-capture, gain, normalization) only make

--- a/internal/conf/validate.go
+++ b/internal/conf/validate.go
@@ -1392,18 +1392,28 @@ func validateAudioSettings(settings *AudioSettings) error {
 	return nil
 }
 
-// validateExportBitrate validates the bitrate setting for lossy audio export formats
-// (mp3, aac, opus). It must end with "k" and be between 32 and 320 kbps.
+// Bitrate constraints for lossy audio export formats (mp3, aac, opus).
+// The suffix and kbps bounds are consumed by validateExportBitrate and
+// documented in the frontend's getBitrateConfig (audioValidation.ts).
+const (
+	audioExportBitrateSuffix  = "k"
+	minAudioExportBitrateKbps = 32
+	maxAudioExportBitrateKbps = 320
+)
+
+// validateExportBitrate validates the bitrate setting for lossy audio export
+// formats. The value must use the "k" suffix and fall within the supported
+// kbps range.
 func validateExportBitrate(exportType, bitrate string) error {
-	if !strings.HasSuffix(bitrate, "k") {
-		return errors.Newf("invalid bitrate format for %s: %s. Must end with 'k' (e.g., '64k')", exportType, bitrate).
+	if !strings.HasSuffix(bitrate, audioExportBitrateSuffix) {
+		return errors.Newf("invalid bitrate format for %s: %s. Must end with %q (e.g., '64k')", exportType, bitrate, audioExportBitrateSuffix).
 			Category(errors.CategoryValidation).
 			Context("validation_type", "audio-export-bitrate-format").
 			Context("export_type", exportType).
 			Context("bitrate", bitrate).
 			Build()
 	}
-	bitrateValue, err := strconv.Atoi(strings.TrimSuffix(bitrate, "k"))
+	bitrateValue, err := strconv.Atoi(strings.TrimSuffix(bitrate, audioExportBitrateSuffix))
 	if err != nil {
 		return errors.Newf("invalid bitrate value for %s: %s", exportType, bitrate).
 			Category(errors.CategoryValidation).
@@ -1412,8 +1422,9 @@ func validateExportBitrate(exportType, bitrate string) error {
 			Context("bitrate", bitrate).
 			Build()
 	}
-	if bitrateValue < 32 || bitrateValue > 320 {
-		return errors.Newf("bitrate for %s must be between 32k and 320k, got %dk", exportType, bitrateValue).
+	if bitrateValue < minAudioExportBitrateKbps || bitrateValue > maxAudioExportBitrateKbps {
+		return errors.Newf("bitrate for %s must be between %dk and %dk, got %dk",
+			exportType, minAudioExportBitrateKbps, maxAudioExportBitrateKbps, bitrateValue).
 			Category(errors.CategoryValidation).
 			Context("validation_type", "audio-export-bitrate-range").
 			Context("export_type", exportType).

--- a/internal/conf/validate_audio_export_test.go
+++ b/internal/conf/validate_audio_export_test.go
@@ -1,0 +1,155 @@
+// Package conf tests the audio export validation and normalization logic
+// that prevents extension-less clip_name rows (GitHub #2810, #2814).
+package conf
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The "missing ffmpeg forces wav" branch is not covered here because
+// validateAudioSettings calls ValidateToolPath, which falls back to
+// exec.LookPath("ffmpeg") when the configured FfmpegPath is empty.
+// In any CI environment with ffmpeg on PATH the branch is unreachable
+// without mocking exec.LookPath. Behaviour is exercised by the
+// existing integration test suite in internal/analysis.
+func TestValidateAudioSettings_NormalizesEmptyExportType(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		enabled    bool
+		typeIn     string
+		bitrateIn  string
+		ffmpegPath string
+		wantErr    bool
+		wantType   string
+	}{
+		{
+			name:       "disabled with empty type normalizes to wav",
+			enabled:    false,
+			typeIn:     "",
+			bitrateIn:  "",
+			ffmpegPath: "/usr/bin/ffmpeg",
+			wantErr:    false,
+			wantType:   "wav",
+		},
+		{
+			name:       "enabled with empty type normalizes to wav",
+			enabled:    true,
+			typeIn:     "",
+			bitrateIn:  "",
+			ffmpegPath: "/usr/bin/ffmpeg",
+			wantErr:    false,
+			wantType:   "wav",
+		},
+		{
+			name:       "disabled with garbage type now rejected",
+			enabled:    false,
+			typeIn:     "gibberish",
+			bitrateIn:  "",
+			ffmpegPath: "/usr/bin/ffmpeg",
+			wantErr:    true,
+			wantType:   "gibberish",
+		},
+		{
+			name:       "enabled wav with empty bitrate is fine",
+			enabled:    true,
+			typeIn:     "wav",
+			bitrateIn:  "",
+			ffmpegPath: "/usr/bin/ffmpeg",
+			wantErr:    false,
+			wantType:   "wav",
+		},
+		{
+			name:       "enabled mp3 with empty bitrate rejected",
+			enabled:    true,
+			typeIn:     "mp3",
+			bitrateIn:  "",
+			ffmpegPath: "/usr/bin/ffmpeg",
+			wantErr:    true,
+			wantType:   "mp3",
+		},
+		{
+			name:       "enabled mp3 with valid bitrate accepted",
+			enabled:    true,
+			typeIn:     "mp3",
+			bitrateIn:  "128k",
+			ffmpegPath: "/usr/bin/ffmpeg",
+			wantErr:    false,
+			wantType:   "mp3",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			settings := newMinimalAudioSettings()
+			settings.Export.Enabled = tc.enabled
+			settings.Export.Type = tc.typeIn
+			settings.Export.Bitrate = tc.bitrateIn
+			settings.FfmpegPath = tc.ffmpegPath
+
+			err := validateAudioSettings(settings)
+
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tc.wantType, settings.Export.Type,
+				"Export.Type should be normalized in-memory after validateAudioSettings")
+		})
+	}
+}
+
+// TestValidateAudioSettings_NeverReturnsEmptyType is the class-of-bug invariant:
+// regardless of input, a successful validation must leave Export.Type non-empty.
+func TestValidateAudioSettings_NeverReturnsEmptyType(t *testing.T) {
+	t.Parallel()
+
+	inputs := []string{"", " ", "wav", "WAV", "mp3", "aac", "opus", "flac"}
+	for _, in := range inputs {
+		t.Run("input="+in, func(t *testing.T) {
+			t.Parallel()
+
+			settings := newMinimalAudioSettings()
+			settings.Export.Enabled = false // gates that used to skip normalization
+			settings.Export.Type = in
+			settings.Export.Bitrate = "128k"
+			settings.FfmpegPath = "/usr/bin/ffmpeg"
+
+			_ = validateAudioSettings(settings) // may or may not error
+			if settings.Export.Type == "" {
+				t.Fatalf("Export.Type is empty after validation (input=%q)", in)
+			}
+			if strings.TrimSpace(settings.Export.Type) == "" {
+				t.Fatalf("Export.Type is whitespace after validation (input=%q)", in)
+			}
+		})
+	}
+}
+
+// newMinimalAudioSettings returns an AudioSettings instance populated with the
+// minimum fields needed to pass validateAudioSettings apart from the fields
+// the individual test cases override. Values mirror the Viper defaults from
+// internal/conf/defaults.go.
+func newMinimalAudioSettings() *AudioSettings {
+	s := &AudioSettings{}
+	s.Source = testAudioDeviceSysdefault
+	s.Sources = []AudioSourceConfig{{Name: "Default", Device: testAudioDeviceSysdefault}}
+	s.Export.Enabled = true
+	s.Export.Length = 15
+	s.Export.PreCapture = 3
+	s.Export.Gain = 0
+	s.Export.Type = "wav"
+	s.Export.Bitrate = "96k"
+	s.Export.Path = "clips/"
+	s.Export.Retention.Policy = RetentionPolicyNone
+	s.FfmpegPath = "/usr/bin/ffmpeg"
+	return s
+}

--- a/internal/conf/validate_audio_export_test.go
+++ b/internal/conf/validate_audio_export_test.go
@@ -3,12 +3,26 @@
 package conf
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// fakeFFmpegPath writes an executable stub inside t.TempDir() and returns its
+// path. Tests need a resolvable, host-agnostic FfmpegPath because
+// validateAudioSettings invokes ValidateToolPath, which clears FfmpegPath when
+// the configured path cannot be executed. A hardcoded /usr/bin/ffmpeg breaks
+// on hosts where ffmpeg lives elsewhere (e.g. /opt/homebrew/bin).
+func fakeFFmpegPath(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), GetFfmpegBinaryName())
+	require.NoError(t, os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o755))
+	return path
+}
 
 // The "missing ffmpeg forces wav" branch is not covered here because
 // validateAudioSettings calls ValidateToolPath, which falls back to
@@ -18,6 +32,7 @@ import (
 // existing integration test suite in internal/analysis.
 func TestValidateAudioSettings_NormalizesEmptyExportType(t *testing.T) {
 	t.Parallel()
+	ffmpegPath := fakeFFmpegPath(t)
 
 	cases := []struct {
 		name       string
@@ -33,7 +48,7 @@ func TestValidateAudioSettings_NormalizesEmptyExportType(t *testing.T) {
 			enabled:    false,
 			typeIn:     "",
 			bitrateIn:  "",
-			ffmpegPath: "/usr/bin/ffmpeg",
+			ffmpegPath: ffmpegPath,
 			wantErr:    false,
 			wantType:   "wav",
 		},
@@ -42,7 +57,7 @@ func TestValidateAudioSettings_NormalizesEmptyExportType(t *testing.T) {
 			enabled:    true,
 			typeIn:     "",
 			bitrateIn:  "",
-			ffmpegPath: "/usr/bin/ffmpeg",
+			ffmpegPath: ffmpegPath,
 			wantErr:    false,
 			wantType:   "wav",
 		},
@@ -51,7 +66,7 @@ func TestValidateAudioSettings_NormalizesEmptyExportType(t *testing.T) {
 			enabled:    false,
 			typeIn:     "gibberish",
 			bitrateIn:  "",
-			ffmpegPath: "/usr/bin/ffmpeg",
+			ffmpegPath: ffmpegPath,
 			wantErr:    true,
 			wantType:   "gibberish",
 		},
@@ -60,7 +75,7 @@ func TestValidateAudioSettings_NormalizesEmptyExportType(t *testing.T) {
 			enabled:    true,
 			typeIn:     "wav",
 			bitrateIn:  "",
-			ffmpegPath: "/usr/bin/ffmpeg",
+			ffmpegPath: ffmpegPath,
 			wantErr:    false,
 			wantType:   "wav",
 		},
@@ -69,7 +84,7 @@ func TestValidateAudioSettings_NormalizesEmptyExportType(t *testing.T) {
 			enabled:    true,
 			typeIn:     "mp3",
 			bitrateIn:  "",
-			ffmpegPath: "/usr/bin/ffmpeg",
+			ffmpegPath: ffmpegPath,
 			wantErr:    true,
 			wantType:   "mp3",
 		},
@@ -78,7 +93,7 @@ func TestValidateAudioSettings_NormalizesEmptyExportType(t *testing.T) {
 			enabled:    true,
 			typeIn:     "mp3",
 			bitrateIn:  "128k",
-			ffmpegPath: "/usr/bin/ffmpeg",
+			ffmpegPath: ffmpegPath,
 			wantErr:    false,
 			wantType:   "mp3",
 		},
@@ -111,6 +126,7 @@ func TestValidateAudioSettings_NormalizesEmptyExportType(t *testing.T) {
 // regardless of input, a successful validation must leave Export.Type non-empty.
 func TestValidateAudioSettings_NeverReturnsEmptyType(t *testing.T) {
 	t.Parallel()
+	ffmpegPath := fakeFFmpegPath(t)
 
 	inputs := []string{"", " ", "wav", "WAV", "mp3", "aac", "opus", "flac"}
 	for _, in := range inputs {
@@ -121,7 +137,7 @@ func TestValidateAudioSettings_NeverReturnsEmptyType(t *testing.T) {
 			settings.Export.Enabled = false // gates that used to skip normalization
 			settings.Export.Type = in
 			settings.Export.Bitrate = "128k"
-			settings.FfmpegPath = "/usr/bin/ffmpeg"
+			settings.FfmpegPath = ffmpegPath
 
 			_ = validateAudioSettings(settings) // may or may not error
 			if settings.Export.Type == "" {
@@ -150,6 +166,5 @@ func newMinimalAudioSettings() *AudioSettings {
 	s.Export.Bitrate = "96k"
 	s.Export.Path = "clips/"
 	s.Export.Retention.Policy = RetentionPolicyNone
-	s.FfmpegPath = "/usr/bin/ffmpeg"
 	return s
 }

--- a/internal/conf/validate_audio_export_test.go
+++ b/internal/conf/validate_audio_export_test.go
@@ -140,12 +140,10 @@ func TestValidateAudioSettings_NeverReturnsEmptyType(t *testing.T) {
 			settings.FfmpegPath = ffmpegPath
 
 			_ = validateAudioSettings(settings) // may or may not error
-			if settings.Export.Type == "" {
-				t.Fatalf("Export.Type is empty after validation (input=%q)", in)
-			}
-			if strings.TrimSpace(settings.Export.Type) == "" {
-				t.Fatalf("Export.Type is whitespace after validation (input=%q)", in)
-			}
+			require.NotEmpty(t, settings.Export.Type,
+				"Export.Type is empty after validation (input=%q)", in)
+			require.NotEmpty(t, strings.TrimSpace(settings.Export.Type),
+				"Export.Type is whitespace after validation (input=%q)", in)
 		})
 	}
 }


### PR DESCRIPTION
## Summary

Three bugs in the audio export settings flow combined to produce DB \`clip_name\` rows with no file extension (path ending in \`.\`). When that happened the audio download endpoint and spectrogram generation both 404'd on those detections.

1. **Frontend: \`updateExportFormat\` left bitrate untouched on format change.** Switching from a lossless format (WAV/FLAC) where the bitrate slider is hidden to a lossy format (MP3/AAC/Opus) sent a PATCH with an empty bitrate, which the backend rejected with HTTP 400. User-visible symptom: \"cannot save config\" error after picking MP3/AAC/Opus.
2. **Backend: \`ValidateSettings\` gated the Type/Bitrate switch on \`Export.Enabled\`.** A PATCH with \`{enabled:false, type:\"\"}\` returned 200 and persisted an empty Type string. When Enabled was later flipped back to true the stale empty Type stayed in memory until the next full save, and every detection went through \`buildClipPath\` with \`convert.GetFileExtension(\"\") == \"\"\`.
3. **Backend: \`buildClipPath\` had no fallback when the extension came back empty**, so the persisted filename ended in a bare \`.\` and the corrupted path was written to the DB silently.

## Fix shape (defense in depth)

**Frontend** (\`AudioSettingsPage.svelte\`): extract \`chooseBitrateForFormat\` as a pure helper. For lossless targets it clears bitrate; for lossy targets it preserves an in-range numeric value and otherwise seeds the format default from \`getBitrateConfig\` (mp3=128k, aac=96k, opus=96k). 12 Vitest cases cover the transition matrix including the out-of-range case (opus carrying 320k snaps to 96k since opus tops at 256k).

**Backend \`ValidateSettings\`**: normalize empty or whitespace Type to \`\"wav\"\` at the top of the export block, regardless of Enabled. Run the Type switch unconditionally so a garbage value can never be silently persisted, even when export is disabled. Bitrate validation stays gated on Enabled for lossy formats only (WAV/FLAC legitimately have no bitrate). The existing \`FfmpegPath == \"\"\` fallback that forces wav is preserved. Same \`ValidateSettings\` call runs at startup (\`conf.Load\`) and on every PATCH (\`/api/v2/settings\`), so a previously-persisted empty Type self-heals on the next load.

**Backend \`buildClipPath\`**: defense-in-depth fallback. If \`GetFileExtension\` ever returns empty, fall back to \`\"wav\"\` and emit one WARN per process via \`sync.Once\`. Post Task 1 this branch should be unreachable; the WARN exists to notice if some other code path regresses.

## Related Issues

Fixes #2810
Fixes #2814

## Test Plan

- [x] New Go tests: \`TestValidateAudioSettings_NormalizesEmptyExportType\` (6 cases covering the regression matrix), \`TestValidateAudioSettings_NeverReturnsEmptyType\` (class-of-bug invariant over 8 inputs), \`TestBuildClipPath_EmptyTypeFallsBackToWav\`, \`TestBuildClipPath_NeverEndsInDot\` (invariant sweep), \`TestBuildClipPath_FallbackWarnsOnlyOnce\` (concurrent one-shot WARN guarantee).
- [x] New Vitest: \`AudioSettingsPage.updateExportFormat.test.ts\` (12 cases).
- [x] \`golangci-lint run -v ./...\` — 0 issues.
- [x] \`go test -race\` on touched packages — pass.
- [x] \`npm run check:all\` — 0 errors.
- [x] \`task\` build — success.
- [x] \`coderabbit review --plain -t committed\` — no findings.
- [ ] Manual: switch export format between WAV/FLAC and MP3/AAC/Opus in the settings UI; verify save succeeds and the bitrate field shows the seeded default when the slider becomes visible.
- [ ] Manual: save settings with \`{enabled:false, type:\"\"}\` via the API; verify the persisted Type normalizes to \`\"wav\"\` rather than staying empty.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Export bitrate now auto-adjusts (seeds/clamps) when changing audio format; lossless formats ignore bitrate.
  * Format selector normalizes ambiguous inputs and ignores invalid selections.

* **Bug Fixes**
  * Empty or unsupported export types are normalized to WAV with a single fallback warning.
  * Clip path generation always yields a valid file extension and avoids trailing dots.

* **Tests**
  * Added coverage for bitrate selection, format validation/normalization, and clip-path fallback concurrency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->