### PR TITLE
fix(frontend): prevent unhandled promise rejections from async event handlers

### DIFF
--- a/frontend/src/lib/desktop/components/ui/Modal.svelte
+++ b/frontend/src/lib/desktop/components/ui/Modal.svelte
@@ -127,7 +127,6 @@
       await onConfirm();
     } catch (error) {
       logger.error('Modal onConfirm callback threw an error:', error);
-      throw error;
     } finally {
       isConfirming = false;
     }

--- a/frontend/src/lib/desktop/layouts/DesktopSidebar.svelte
+++ b/frontend/src/lib/desktop/layouts/DesktopSidebar.svelte
@@ -74,6 +74,7 @@ Performance Optimizations:
   } from '@lucide/svelte';
   import { flyout } from '$lib/utils/transitions';
   import { t } from '$lib/i18n';
+  import { loggers } from '$lib/utils/logger';
   import { hasLiveAudioAccess } from '$lib/stores/appState.svelte';
   import { resetDateToToday } from '$lib/utils/datePersistence';
   import LoginModal from '../components/modals/LoginModal.svelte';
@@ -81,6 +82,8 @@ Performance Optimizations:
   import { scheme } from '$lib/stores/scheme';
   import { logoStyle } from '$lib/stores/logoStyle';
   import { SCHEME_GRADIENT_MAP, type LogoVariant } from '$lib/stores/logoVariant';
+
+  const logger = loggers.ui;
 
   interface Props {
     securityEnabled?: boolean;
@@ -296,7 +299,11 @@ Performance Optimizations:
   }
 
   async function handleLogout() {
-    await authStore.logout();
+    try {
+      await authStore.logout();
+    } catch (error) {
+      logger.error('Logout failed:', error);
+    }
   }
 
   function handleLogin() {

--- a/frontend/src/lib/desktop/layouts/DesktopSidebar.svelte
+++ b/frontend/src/lib/desktop/layouts/DesktopSidebar.svelte
@@ -74,7 +74,6 @@ Performance Optimizations:
   } from '@lucide/svelte';
   import { flyout } from '$lib/utils/transitions';
   import { t } from '$lib/i18n';
-  import { loggers } from '$lib/utils/logger';
   import { hasLiveAudioAccess } from '$lib/stores/appState.svelte';
   import { resetDateToToday } from '$lib/utils/datePersistence';
   import LoginModal from '../components/modals/LoginModal.svelte';
@@ -82,8 +81,6 @@ Performance Optimizations:
   import { scheme } from '$lib/stores/scheme';
   import { logoStyle } from '$lib/stores/logoStyle';
   import { SCHEME_GRADIENT_MAP, type LogoVariant } from '$lib/stores/logoVariant';
-
-  const logger = loggers.ui;
 
   interface Props {
     securityEnabled?: boolean;
@@ -301,8 +298,9 @@ Performance Optimizations:
   async function handleLogout() {
     try {
       await authStore.logout();
-    } catch (error) {
-      logger.error('Logout failed:', error);
+    } catch {
+      // authStore.logout() already logs before rethrowing; swallow here
+      // to prevent an unhandled rejection from the non-awaited onclick.
     }
   }
 


### PR DESCRIPTION
## Summary

- Remove `throw error` from `Modal.handleConfirm()` catch block. The error is already logged via `logger.error()` which sends it to Sentry through the structured `captureLoggerError` path. Since `onclick` does not await the returned Promise, re-throwing creates an unhandled promise rejection that Sentry captures as a duplicate event (BIRDNET-GO-1PF, 108 events in 3 days).
- Wrap `DesktopSidebar.handleLogout()` in try/catch for the same reason: `authStore.logout()` re-throws after logging, and the `onclick` handler does not await the Promise.

## Test Plan

- [ ] Open a modal with an `onConfirm` callback, trigger a network error during confirm - verify error is logged but no unhandled rejection appears in the console
- [ ] Click logout when the server is unreachable - verify error is logged but no unhandled rejection appears in the console
- [ ] Verify modal confirm flow works normally (detection delete, lock, ignore species)
- [ ] Verify logout works normally when server is reachable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Confirmation dialogs now catch and log errors from confirmation handlers and prevent those exceptions from propagating to callers.
  * Logout action now catches and logs failures during sign-out to avoid unhandled errors from the logout flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->