### PR TITLE
fix(labels): update Estonian BirdNET translations

### DIFF
--- a/internal/classifier/data/labels/V2.4/BirdNET_GLOBAL_6K_V2.4_Labels_et_ee.txt
+++ b/internal/classifier/data/labels/V2.4/BirdNET_GLOBAL_6K_V2.4_Labels_et_ee.txt
@@ -1,157 +1,157 @@
-Abroscopus albogularis_Rufous-faced Warbler
-Abroscopus schisticeps_Black-faced Warbler
-Abroscopus superciliaris_Yellow-bellied Warbler
-Aburria aburri_Wattled Guan
+Abroscopus albogularis_Pisi-rädilind
+Abroscopus schisticeps_Mustpõsk-rädilind
+Abroscopus superciliaris_Bambuse-rädilind
+Aburria aburri_Sireenhoko
 Acanthagenys rufogularis_Spiny-cheeked Honeyeater
 Acanthidops bairdi_Peg-billed Finch
-Acanthis cabaret_Lesser Redpoll
-Acanthis flammea_Common Redpoll
-Acanthis hornemanni_Hoary Redpoll
-Acanthisitta chloris_Rifleman
-Acanthiza apicalis_Inland Thornbill
-Acanthiza chrysorrhoa_Yellow-rumped Thornbill
-Acanthiza ewingii_Tasmanian Thornbill
-Acanthiza inornata_Western Thornbill
-Acanthiza lineata_Striated Thornbill
-Acanthiza nana_Yellow Thornbill
-Acanthiza pusilla_Brown Thornbill
-Acanthiza reguloides_Buff-rumped Thornbill
-Acanthiza uropygialis_Chestnut-rumped Thornbill
-Acanthorhynchus superciliosus_Western Spinebill
-Acanthorhynchus tenuirostris_Eastern Spinebill
-Accipiter badius_Shikra
-Accipiter bicolor_Bicolored Hawk
-Accipiter cirrocephalus_Collared Sparrowhawk
-Accipiter cooperii_Cooper's Hawk
-Accipiter fasciatus_Brown Goshawk
+Acanthis cabaret_Lõuna-urvalind
+Acanthis flammea_Urvalind
+Acanthis hornemanni_Hele-urvalind
+Acanthisitta chloris_Õõne-nürisaba
+Acanthiza apicalis_Mallee-sirilind
+Acanthiza chrysorrhoa_Täpiklaup-sirilind
+Acanthiza ewingii_Kiripugu-sirilind
+Acanthiza inornata_Lääne-sirilind
+Acanthiza lineata_Triip-sirilind
+Acanthiza nana_Kold-sirilind
+Acanthiza pusilla_Ruskelaup-sirilind
+Acanthiza reguloides_Eukalüpti-sirilind
+Acanthiza uropygialis_Õõne-sirilind
+Acanthorhynchus superciliosus_Vöö-meelind
+Acanthorhynchus tenuirostris_Manisk-meelind
+Accipiter badius_Šikra-raudkull
+Accipiter bicolor_Väike-tanukull
+Accipiter cirrocephalus_Kaelus-raudkull
+Accipiter cooperii_Põhja-tanukull
+Accipiter fasciatus_Vööt-tuvikull
 Accipiter gentilis_Kanakull
-Accipiter gularis_Japanese Sparrowhawk
-Accipiter hiogaster_Variable Goshawk
-Accipiter melanoleucus_Black Goshawk
-Accipiter minullus_Little Sparrowhawk
+Accipiter gularis_Ida-raudkull
+Accipiter hiogaster_Saare-tuvikull
+Accipiter melanoleucus_Pugal-kanakull
+Accipiter minullus_Jõgi-värbkull
 Accipiter nisus_Raudkull
-Accipiter novaehollandiae_Gray Goshawk
-Accipiter poliogaster_Gray-bellied Hawk
-Accipiter soloensis_Chinese Sparrowhawk
-Accipiter striatus_Sharp-shinned Hawk
-Accipiter superciliosus_Tiny Hawk
-Accipiter tachiro_African Goshawk
-Accipiter trinotatus_Spot-tailed Goshawk
-Accipiter trivirgatus_Crested Goshawk
-Accipiter virgatus_Besra
-Aceros nipalensis_Rufous-necked Hornbill
+Accipiter novaehollandiae_Lõuna-tuvikull
+Accipiter poliogaster_Selvakull
+Accipiter soloensis_Konna-raudkull
+Accipiter striatus_Ameerika raudkull
+Accipiter superciliosus_Koolibrikull
+Accipiter tachiro_Ao-raudkull
+Accipiter trinotatus_Täppsaba-raudkull
+Accipiter trivirgatus_Tutt-raudkull
+Accipiter virgatus_Habe-raudkull
+Aceros nipalensis_Nudi-sarvlind
 Achaetops pycnopygius_Rockrunner
-Acridotheres burmannicus_Vinous-breasted Starling
-Acridotheres cristatellus_Crested Myna
-Acridotheres fuscus_Jungle Myna
-Acridotheres ginginianus_Bank Myna
-Acridotheres grandis_Great Myna
-Acridotheres javanicus_Javan Myna
-Acridotheres tristis_Common Myna
+Acridotheres burmannicus_Hõbe-mainakuldnokk
+Acridotheres cristatellus_Hiina mainakuldnokk
+Acridotheres fuscus_Džungli-mainakuldnokk
+Acridotheres ginginianus_Kalda-mainakuldnokk
+Acridotheres grandis_Pühvli-mainakuldnokk
+Acridotheres javanicus_Jaava mainakuldnokk
+Acridotheres tristis_Mainakuldnokk
 Acris crepitans_Northern Cricket Frog
 Acris gryllus_Southern Cricket Frog
 Acrobatornis fonsecai_Pink-legged Graveteiro
-Acrocephalus agricola_Paddyfield Warbler
-Acrocephalus arundinaceus_Roolind
-Acrocephalus australis_Australian Reed Warbler
-Acrocephalus baeticatus_African Reed Warbler
-Acrocephalus bistrigiceps_Black-browed Reed Warbler
-Acrocephalus concinens_Blunt-winged Warbler
+Acrocephalus agricola_Padu-roolind
+Acrocephalus arundinaceus_Rästas-roolind
+Acrocephalus australis_Austraalia roolind
+Acrocephalus baeticatus_Aafrika roolind
+Acrocephalus bistrigiceps_Mustkulm-roolind
+Acrocephalus concinens_Lammi-roolind
 Acrocephalus dumetorum_Aed-roolind
-Acrocephalus gracilirostris_Lesser Swamp Warbler
-Acrocephalus griseldis_Basra Reed Warbler
-Acrocephalus melanopogon_Moustached Warbler
-Acrocephalus newtoni_Madagascar Swamp Warbler
-Acrocephalus orientalis_Oriental Reed Warbler
-Acrocephalus paludicola_Aquatic Warbler
+Acrocephalus gracilirostris_Bantu roolind
+Acrocephalus griseldis_Mesopotaamia roolind
+Acrocephalus melanopogon_Mustpea-roolind
+Acrocephalus newtoni_Madagaskari roolind
+Acrocephalus orientalis_Ida-roolind
+Acrocephalus paludicola_Tarna-roolind
 Acrocephalus palustris_Soo-roolind
-Acrocephalus rufescens_Greater Swamp Warbler
+Acrocephalus rufescens_Papüüruse-roolind
 Acrocephalus schoenobaenus_Kõrkja-roolind
 Acrocephalus scirpaceus_Tiigi-roolind
-Acrocephalus stentoreus_Clamorous Reed Warbler
-Acrocephalus tangorum_Manchurian Reed Warbler
+Acrocephalus stentoreus_Lõuna-roolind
+Acrocephalus tangorum_Mandžuuria roolind
 Acropternis orthonyx_Ocellated Tapaculo
-Actenoides concretus_Rufous-collared Kingfisher
-Actenoides lindsayi_Spotted Kingfisher
-Actenoides monachus_Green-backed Kingfisher
-Actinodura cyanouroptera_Blue-winged Minla
-Actinodura egertoni_Rusty-fronted Barwing
-Actinodura nipalensis_Hoary-throated Barwing
-Actinodura ramsayi_Spectacled Barwing
-Actinodura strigula_Chestnut-tailed Minla
-Actinodura waldeni_Streak-throated Barwing
-Actitis hypoleucos_Common Sandpiper
-Actitis macularius_Spotted Sandpiper
-Actophilornis africanus_African Jacana
-Adelomyia melanogenys_Speckled Hummingbird
-Aechmophorus clarkii_Clark's Grebe
-Aechmophorus occidentalis_Western Grebe
-Aegithalos caudatus_Pikksaba-tihane
-Aegithalos concinnus_Black-throated Tit
-Aegithalos glaucogularis_Silver-throated Tit
-Aegithalos iouschistos_Black-browed Tit
-Aegithalos niveogularis_White-throated Tit
-Aegithina nigrolutea_White-tailed Iora
-Aegithina tiphia_Common Iora
-Aegithina viridissima_Green Iora
-Aegolius acadicus_Northern Saw-whet Owl
+Actenoides concretus_Malai safiirlind
+Actenoides lindsayi_Helmes-safiirlind
+Actenoides monachus_Roheselg-safiirlind
+Actinodura cyanouroptera_Sinitiib-vädrak
+Actinodura egertoni_Džungli-viirvädrak
+Actinodura nipalensis_Nepaali viirvädrak
+Actinodura ramsayi_Prill-viirvädrak
+Actinodura strigula_Viirkurk-vädrak
+Actinodura waldeni_Mets-viirvädrak
+Actitis hypoleucos_Vihitaja
+Actitis macularius_Ameerika vihitaja
+Actophilornis africanus_Suur-lootoselind
+Adelomyia melanogenys_Tähnikkoolibri
+Aechmophorus clarkii_Hele-suurpütt
+Aechmophorus occidentalis_Suurpütt
+Aegithalos caudatus_Sabatihane
+Aegithalos concinnus_Mustkurk-sabatihane
+Aegithalos glaucogularis_Hiina sabatihane
+Aegithalos iouschistos_Mägi-sabatihane
+Aegithalos niveogularis_Himaalaja sabatihane
+Aegithina nigrolutea_Džungli-mangolind
+Aegithina tiphia_Mangolind
+Aegithina viridissima_Mets-mangolind
+Aegolius acadicus_Töbikakk
 Aegolius funereus_Karvasjalg-kakk
-Aegolius harrisii_Buff-fronted Owl
-Aegolius ridgwayi_Unspotted Saw-whet Owl
-Aegotheles cristatus_Australian Owlet-nightjar
-Aegypius monachus_Cinereous Vulture
-Aerodramus bartschi_Mariana Swiftlet
-Aerodramus fuciphagus_White-nest Swiftlet
-Aerodramus maximus_Black-nest Swiftlet
-Aeronautes andecolus_Andean Swift
-Aeronautes montivagus_White-tipped Swift
+Aegolius harrisii_Laukkakk
+Aegolius ridgwayi_Lõuna-töbikakk
+Aegotheles cristatus_Austraalia õõnesorr
+Aegypius monachus_Raisakotkas
+Aerodramus bartschi_Mariaani salangaan
+Aerodramus fuciphagus_Hõrkpesa-salangaan
+Aerodramus maximus_Sulispesa-salangaan
+Aeronautes andecolus_Andi piiritaja
+Aeronautes montivagus_Mägipiiritaja
 Aeronautes saxatalis_White-throated Swift
-Aethia pusilla_Least Auklet
-Aethia pygmaea_Whiskered Auklet
-Aethopyga christinae_Fork-tailed Sunbird
-Aethopyga gouldiae_Mrs. Gould's Sunbird
-Aethopyga ignicauda_Fire-tailed Sunbird
-Aethopyga nipalensis_Green-tailed Sunbird
-Aethopyga saturata_Black-throated Sunbird
-Aethopyga siparaja_Crimson Sunbird
-Aethopyga temminckii_Temminck's Sunbird
-Aethopyga vigorsii_Vigors's Sunbird
-Agapornis canus_Gray-headed Lovebird
-Agapornis fischeri_Fischer's Lovebird
-Agapornis personatus_Yellow-collared Lovebird
-Agapornis roseicollis_Rosy-faced Lovebird
-Agapornis taranta_Black-winged Lovebird
-Agelaioides badius_Grayish Baywing
-Agelaius phoeniceus_Red-winged Blackbird
-Agelaius tricolor_Tricolored Blackbird
-Agelasticus cyanopus_Unicolored Blackbird
-Agelasticus thilius_Yellow-winged Blackbird
-Agelasticus xanthophthalmus_Pale-eyed Blackbird
-Aglaiocercus coelestis_Violet-tailed Sylph
-Aglaiocercus kingii_Long-tailed Sylph
+Aethia pusilla_Kääbusörd
+Aethia pygmaea_Kiharörd
+Aethopyga christinae_Harksaba-nektarilind
+Aethopyga gouldiae_Sarlak-nektarilind
+Aethopyga ignicauda_Tulisaba-nektarilind
+Aethopyga nipalensis_Sadul-nektarilind
+Aethopyga saturata_Ruskeselg-nektarilind
+Aethopyga siparaja_Karmiin-nektarilind
+Aethopyga temminckii_Puna-nektarilind
+Aethopyga vigorsii_Sahyadri nektarilind
+Agapornis canus_Hallpea-lembelind
+Agapornis fischeri_Serengeti lembelind
+Agapornis personatus_Akaatsia-lembelind
+Agapornis roseicollis_Roosapõsk-lembelind
+Agapornis taranta_Kadaka-lembelind
+Agelaioides badius_Tuhkturpial
+Agelaius phoeniceus_Leekõlg-turpial
+Agelaius tricolor_Kalifornia turpial
+Agelasticus cyanopus_Vesiturpial
+Agelasticus thilius_Paduturpial
+Agelasticus xanthophthalmus_Sooditurpial
+Aglaiocercus coelestis_Pilve-vedikkoolibri
+Aglaiocercus kingii_Vedikkoolibri
 Agriornis montanus_Black-billed Shrike-Tyrant
-Agropsar philippensis_Chestnut-cheeked Starling
-Agropsar sturninus_Daurian Starling
-Ailuroedus crassirostris_Green Catbird
+Agropsar philippensis_Jaapani kuldnokk
+Agropsar sturninus_Väike-kuldnokk
+Ailuroedus crassirostris_Austraalia kõutslind
 Ailuroedus maculosus_Spotted Catbird
-Aimophila notosticta_Oaxaca Sparrow
-Aimophila rufescens_Rusty Sparrow
-Aimophila ruficeps_Rufous-crowned Sparrow
-Aix galericulata_Mandarin Duck
-Aix sponsa_Wood Duck
+Aimophila notosticta_Oaxaca maasidrik
+Aimophila rufescens_Ruske-maasidrik
+Aimophila ruficeps_Pruun-maasidrik
+Aix galericulata_Mandariinpart
+Aix sponsa_Mõrsjapart
 Akletos goeldii_Goeldi's Antbird
 Akletos melanoceps_White-shouldered Antbird
-Alaemon alaudipes_Greater Hoopoe-Lark
+Alaemon alaudipes_Jooksurlõoke
 Alauda arvensis_Põldlõoke
-Alauda gulgula_Oriental Skylark
-Alaudala cheleensis_Asian Short-toed Lark
-Alaudala heinei_Turkestan Short-toed Lark
-Alaudala raytal_Sand Lark
-Alaudala rufescens_Mediterranean Short-toed Lark
-Alaudala somalica_Somali Short-toed Lark
-Alca torda_Razorbill
+Alauda gulgula_Kagu-põldlõoke
+Alaudala cheleensis_Soolaku-väikelõoke
+Alaudala heinei_Turgi väikelõoke
+Alaudala raytal_Kalda-väikelõoke
+Alaudala rufescens_Kõnnu-väikelõoke
+Alaudala somalica_Triip-väikelõoke
+Alca torda_Alk
 Alcedo atthis_Jäälind
-Alcedo meninting_Blue-eared Kingfisher
+Alcedo meninting_Türkiis-jäälind
 Alcippe brunneicauda_Brown Fulvetta
 Alcippe fratercula_Yunnan Fulvetta
 Alcippe hueti_Huet's Fulvetta
@@ -161,89 +161,89 @@ Alcippe peracensis_Mountain Fulvetta
 Alcippe poioicephala_Brown-cheeked Fulvetta
 Alcippe pyrrhoptera_Javan Fulvetta
 Aleadryas rufinucha_Rufous-naped Bellbird
-Alectoris barbara_Barbary Partridge
-Alectoris chukar_Chukar
-Alectoris graeca_Rock Partridge
-Alectoris rufa_Red-legged Partridge
-Alectura lathami_Australian Brushturkey
-Alethe castanea_Fire-crested Alethe
-Alethe diademata_White-tailed Alethe
-Alipiopsitta xanthops_Yellow-faced Parrot
-Alisterus scapularis_Australian King-Parrot
-Allenia fusca_Scaly-breasted Thrasher
+Alectoris barbara_Berberi kivikana
+Alectoris chukar_Aasia kivikana
+Alectoris graeca_Kalju-kivikana
+Alectoris rufa_Lääne-kivikana
+Alectura lathami_Kalkun-rihukana
+Alethe castanea_Ruske-sipelgaööbik
+Alethe diademata_Ginea sipelgaööbik
+Alipiopsitta xanthops_Serrado-amatsoonpapagoi
+Alisterus scapularis_Austraalia kuningpapagoi
+Allenia fusca_Soomus-pilalind
 Allonemobius allardi_Allard's Ground Cricket
 Allonemobius tinnulus_Tinkling Ground Cricket
 Allonemobius walkeri_Walker's Ground Cricket
-Alophoixus finschii_Finsch's Bulbul
-Alophoixus flaveolus_White-throated Bulbul
-Alophoixus ochraceus_Ochraceous Bulbul
-Alophoixus pallidus_Puff-throated Bulbul
-Alophoixus phaeocephalus_Yellow-bellied Bulbul
-Alophoixus tephrogenys_Gray-cheeked Bulbul
-Alopochelidon fucata_Tawny-headed Swallow
-Alopochen aegyptiaca_Egyptian Goose
+Alophoixus finschii_Väike-habebülbül
+Alophoixus flaveolus_Lääne-habebülbül
+Alophoixus ochraceus_Roostekõht-habebülbül
+Alophoixus pallidus_Suur-habebülbül
+Alophoixus phaeocephalus_Hallpea-habebülbül
+Alophoixus tephrogenys_Häälis-habebülbül
+Alopochelidon fucata_Ruugepea-pääsuke
+Alopochen aegyptiaca_Vaaraohani
 Alouatta pigra_Mexican Black Howler Monkey
 Amalocichla incerta_Lesser Ground-Robin
-Amandava amandava_Red Avadavat
-Amaurolimnas concolor_Uniform Crake
-Amaurornis isabellina_Isabelline Bush-hen
-Amaurornis moluccana_Pale-vented Bush-hen
-Amaurornis phoenicurus_White-breasted Waterhen
+Amandava amandava_Maasik-amadiin
+Amaurolimnas concolor_Loduruik
+Amaurornis isabellina_Ruugehuik
+Amaurornis moluccana_Lõuna-tõmmuhuik
+Amaurornis phoenicurus_Valgerind-huik
 Amaurospiza concolor_Blue Seedeater
 Amaurospiza moesta_Blackish-blue Seedeater
-Amazilia luciae_Honduran Emerald
-Amazilia rutila_Cinnamon Hummingbird
-Amazilia tzacatl_Rufous-tailed Hummingbird
-Amazilia yucatanensis_Buff-bellied Hummingbird
-Amazilis amazilia_Amazilia Hummingbird
-Amazona aestiva_Turquoise-fronted Parrot
-Amazona agilis_Black-billed Parrot
-Amazona albifrons_White-fronted Parrot
-Amazona amazonica_Orange-winged Parrot
-Amazona auropalliata_Yellow-naped Parrot
-Amazona autumnalis_Red-lored Parrot
-Amazona brasiliensis_Red-tailed Parrot
-Amazona dufresniana_Blue-cheeked Parrot
-Amazona farinosa_Mealy Parrot
-Amazona festiva_Festive Parrot
-Amazona finschi_Lilac-crowned Parrot
-Amazona kawalli_Kawall's Parrot
-Amazona leucocephala_Cuban Parrot
-Amazona mercenarius_Scaly-naped Parrot
-Amazona ochrocephala_Yellow-crowned Parrot
-Amazona oratrix_Yellow-headed Parrot
-Amazona rhodocorytha_Red-browed Parrot
-Amazona tucumana_Tucuman Parrot
-Amazona ventralis_Hispaniolan Parrot
-Amazona vinacea_Vinaceous-breasted Parrot
-Amazona viridigenalis_Red-crowned Parrot
-Amazona xantholora_Yellow-lored Parrot
-Amazonetta brasiliensis_Brazilian Teal
+Amazilia luciae_Hondurase safiirkoolibri
+Amazilia rutila_Kaneel-safiirkoolibri
+Amazilia tzacatl_Salu-safiirkoolibri
+Amazilia yucatanensis_Mehhiko safiirkoolibri
+Amazilis amazilia_Kõnnu-safiirkoolibri
+Amazona aestiva_Sinilaup-amatsoonpapagoi
+Amazona agilis_Mustnokk-amatsoonpapagoi
+Amazona albifrons_Lauk-amatsoonpapagoi
+Amazona amazonica_Tava-amatsoonpapagoi
+Amazona auropalliata_Kuldkukal-amatsoonpapagoi
+Amazona autumnalis_Palmi-amatsoonpapagoi
+Amazona brasiliensis_Rand-amatsoonpapagoi
+Amazona dufresniana_Guajaana amatsoonpapagoi
+Amazona farinosa_Selva-amatsoonpapagoi
+Amazona festiva_Jõgi-amatsoonpapagoi
+Amazona finschi_Mehhiko amatsoonpapagoi
+Amazona kawalli_Pagu-amatsoonpapagoi
+Amazona leucocephala_Kuuba amatsoonpapagoi
+Amazona mercenarius_Andi amatsoonpapagoi
+Amazona ochrocephala_Kuldkiird-amatsoonpapagoi
+Amazona oratrix_Kuldpea-amatsoonpapagoi
+Amazona rhodocorytha_Vikerpea-amatsoonpapagoi
+Amazona tucumana_Lepa-amatsoonpapagoi
+Amazona ventralis_Haiti amatsoonpapagoi
+Amazona vinacea_Purpur-amatsoonpapagoi
+Amazona viridigenalis_Tamaulipase amatsoonpapagoi
+Amazona xantholora_Yucatani amatsoonpapagoi
+Amazonetta brasiliensis_Brasiilia part
 Amblycercus holosericeus_Yellow-billed Cacique
 Amblycorypha alexanderi_Clicker Round-winged Katydid
 Amblycorypha longinicta_Common Virtuoso Katydid
 Amblycorypha oblongifolia_Oblong-winged Katydid
 Amblycorypha rotundifolia_Rattler Round-winged Katydid
-Amblyornis newtoniana_Golden Bowerbird
-Amblyospiza albifrons_Grosbeak Weaver
-Amblyramphus holosericeus_Scarlet-headed Blackbird
-Ammodramus aurifrons_Yellow-browed Sparrow
-Ammodramus humeralis_Grassland Sparrow
-Ammodramus savannarum_Grasshopper Sparrow
-Ammomanes cinctura_Bar-tailed Lark
-Ammomanes deserti_Desert Lark
-Ammomanes phoenicura_Rufous-tailed Lark
+Amblyornis newtoniana_Kuld-lehtlalind
+Amblyospiza albifrons_Suurnokk-kangurlind
+Amblyramphus holosericeus_Punapea-turpial
+Ammodramus aurifrons_Kuldkulm-sidrik
+Ammodramus humeralis_Kamposidrik
+Ammodramus savannarum_Heinasidrik
+Ammomanes cinctura_Kõrbelõoke
+Ammomanes deserti_Kivi-kõnnulõoke
+Ammomanes phoenicura_India kõnnulõoke
 Ammonastes pelzelni_Gray-bellied Antbird
-Ammospiza caudacuta_Saltmarsh Sparrow
-Ammospiza leconteii_LeConte's Sparrow
-Ammospiza maritima_Seaside Sparrow
-Ammospiza nelsoni_Nelson's Sparrow
-Ampelioides tschudii_Scaled Fruiteater
-Ampelion rubrocristatus_Red-crested Cotinga
-Ampelion rufaxilla_Chestnut-crested Cotinga
+Ammospiza caudacuta_Rohusidrik
+Ammospiza leconteii_Tarnasidrik
+Ammospiza maritima_Randsidrik
+Ammospiza nelsoni_Kanada rohusidrik
+Ampelioides tschudii_Soomuskotinga
+Ampelion rubrocristatus_Hall-tuttkotinga
+Ampelion rufaxilla_Kaelus-tuttkotinga
 Ampelornis griseiceps_Gray-headed Antbird
-Amphispiza bilineata_Black-throated Sparrow
-Amphispizopsis quinquestriata_Five-striped Sparrow
+Amphispiza bilineata_Manisksidrik
+Amphispizopsis quinquestriata_Kõnnusidrik
 Anabacerthia amaurotis_White-browed Foliage-gleaner
 Anabacerthia lichtensteini_Ochre-breasted Foliage-gleaner
 Anabacerthia ruficaudata_Rufous-tailed Foliage-gleaner
@@ -257,22 +257,22 @@ Anairetes nigrocristatus_Black-crested Tit-Tyrant
 Anairetes parulus_Tufted Tit-Tyrant
 Anairetes reguloides_Pied-crested Tit-Tyrant
 Anas acuta_Soopart
-Anas andium_Andean Teal
-Anas castanea_Chestnut Teal
+Anas andium_Kolumbia piilpart
+Anas castanea_Kastan-piilpart
 Anas crecca_Piilpart
-Anas diazi_Mexican Duck
-Anas flavirostris_Yellow-billed Teal
-Anas fulvigula_Mottled Duck
-Anas georgica_Yellow-billed Pintail
-Anas gracilis_Gray Teal
+Anas diazi_Mehhiko sinikael-part
+Anas flavirostris_Koldnokk-piilpart
+Anas fulvigula_Rand-sinikaelpart
+Anas georgica_Koldnokk-soopart
+Anas gracilis_Austraalia piilpart
 Anas platyrhynchos_Sinikael-part
-Anas poecilorhyncha_Indian Spot-billed Duck
-Anas rubripes_American Black Duck
-Anas superciliosa_Pacific Black Duck
-Anas undulata_Yellow-billed Duck
-Anas wyvilliana_Hawaiian Duck
-Anas zonorhyncha_Eastern Spot-billed Duck
-Anastomus oscitans_Asian Openbill
+Anas poecilorhyncha_Laiknokk-part
+Anas rubripes_Nõgipart
+Anas superciliosa_Tõmmupart
+Anas undulata_Väävelnokk-part
+Anas wyvilliana_Havai sinikael-part
+Anas zonorhyncha_Hiina laiknokk-part
+Anastomus oscitans_Valge-irvnokk
 Anaxipha exigua_Say's Trig
 Anaxyrus americanus_American Toad
 Anaxyrus canorus_Yosemite Toad
@@ -285,106 +285,106 @@ Anaxyrus speciosus_Texas Toad
 Anaxyrus terrestris_Southern Toad
 Anaxyrus woodhousii_Woodhouse's Toad
 Ancistrops strigilatus_Chestnut-winged Hookbill
-Andigena hypoglauca_Gray-breasted Mountain-Toucan
-Andigena laminirostris_Plate-billed Mountain-Toucan
-Andigena nigrirostris_Black-billed Mountain-Toucan
-Androdon aequatorialis_Tooth-billed Hummingbird
-Andropadus importunus_Sombre Greenbul
-Anhima cornuta_Horned Screamer
-Anhinga anhinga_Anhinga
-Anhinga melanogaster_Oriental Darter
-Anhinga novaehollandiae_Australasian Darter
+Andigena hypoglauca_Tume-mägituukan
+Andigena laminirostris_Kilbis-mägituukan
+Andigena nigrirostris_Hele-mägituukan
+Androdon aequatorialis_Kidanokk-koolibri
+Andropadus importunus_Valgesilm-viherbülbül
+Anhima cornuta_Sarvik-ogatiib
+Anhinga anhinga_Ameerika madukael
+Anhinga melanogaster_Aasia madukael
+Anhinga novaehollandiae_Austraalia madukael
 Anisognathus igniventris_Scarlet-bellied Mountain Tanager
 Anisognathus lacrymosus_Lacrimose Mountain Tanager
 Anisognathus somptuosus_Blue-winged Mountain Tanager
-Anodorhynchus hyacinthinus_Hyacinth Macaw
-Anodorhynchus leari_Indigo Macaw
-Anorrhinus galeritus_Bushy-crested Hornbill
+Anodorhynchus hyacinthinus_Hüatsint-siniaara
+Anodorhynchus leari_Indigo-siniaara
+Anorrhinus galeritus_Tume-sarvlind
 Anous ceruleus_Blue-gray Noddy
-Anous minutus_Black Noddy
-Anous stolidus_Brown Noddy
-Anous tenuirostris_Lesser Noddy
+Anous minutus_Tume-tõmmutiir
+Anous stolidus_Suur-tõmmutiir
+Anous tenuirostris_Väike-tõmmutiir
 Anser albifrons_Suur-laukhani
 Anser anser_Hallhani
-Anser brachyrhynchus_Pink-footed Goose
-Anser caerulescens_Snow Goose
-Anser canagicus_Emperor Goose
-Anser cygnoides_Swan Goose
-Anser erythropus_Lesser White-fronted Goose
+Anser brachyrhynchus_Lühinokk-hani
+Anser caerulescens_Lumehani
+Anser canagicus_Randhani
+Anser cygnoides_Stepihani
+Anser erythropus_Väike-laukhani
 Anser fabalis_Rabahani
-Anser indicus_Bar-headed Goose
-Anser rossii_Ross's Goose
-Anser serrirostris_Tundra Bean-Goose
-Anseranas semipalmata_Magpie Goose
-Anthipes monileger_White-gorgeted Flycatcher
-Anthipes solitaris_Rufous-browed Flycatcher
-Anthobaphes violacea_Orange-breasted Sunbird
+Anser indicus_Vööthani
+Anser rossii_Väike-lumehani
+Anser serrirostris_Tundrahani
+Anseranas semipalmata_Harakhani
+Anthipes monileger_Manisk-sininäpp
+Anthipes solitaris_Ruugekulm-sininäpp
+Anthobaphes violacea_Kapimaa nektarilind
 Anthochaera carunculata_Red Wattlebird
 Anthochaera chrysoptera_Little Wattlebird
 Anthochaera lunulata_Western Wattlebird
 Anthochaera paradoxa_Yellow Wattlebird
 Anthochaera phrygia_Regent Honeyeater
 Anthornis melanura_New Zealand Bellbird
-Anthoscopus minutus_Southern Penduline-Tit
-Anthoscopus musculus_Mouse-colored Penduline-Tit
-Anthracoceros albirostris_Oriental Pied-Hornbill
-Anthracoceros coronatus_Malabar Pied-Hornbill
-Anthracoceros malayanus_Black Hornbill
-Anthracothorax nigricollis_Black-throated Mango
-Anthreptes malacensis_Brown-throated Sunbird
+Anthoscopus minutus_Lõuna-kukkurtihane
+Anthoscopus musculus_Galla kukkurtihane
+Anthracoceros albirostris_Ida-sarvlind
+Anthracoceros coronatus_India sarvlind
+Anthracoceros malayanus_Valgekulm-sarvlind
+Anthracothorax nigricollis_Aed-sametkoolibri
+Anthreptes malacensis_Hurm-nektarilind
 Anthreptes orientalis_Eastern Violet-backed Sunbird
-Anthropoides paradiseus_Blue Crane
-Anthropoides virgo_Demoiselle Crane
-Anthus berthelotii_Berthelot's Pipit
-Anthus bogotensis_Paramo Pipit
-Anthus campestris_Tawny Pipit
-Anthus cervinus_Red-throated Pipit
-Anthus chacoensis_Pampas Pipit
-Anthus cinnamomeus_African Pipit
-Anthus correndera_Correndera Pipit
-Anthus crenatus_Yellow-tufted Pipit
-Anthus furcatus_Short-billed Pipit
-Anthus godlewskii_Blyth's Pipit
-Anthus gustavi_Pechora Pipit
-Anthus hellmayri_Hellmayr's Pipit
-Anthus hodgsoni_Olive-backed Pipit
-Anthus leucophrys_Plain-backed Pipit
-Anthus lineiventris_Striped Pipit
-Anthus lutescens_Yellowish Pipit
-Anthus nattereri_Ochre-breasted Pipit
-Anthus novaeseelandiae_Australasian Pipit
+Anthropoides paradiseus_Paradiisikurg
+Anthropoides virgo_Neitsikurg
+Anthus berthelotii_Kanaari kiur
+Anthus bogotensis_Paramokiur
+Anthus campestris_Nõmmekiur
+Anthus cervinus_Tundrakiur
+Anthus chacoensis_Paraná kiur
+Anthus cinnamomeus_Aafrika niidukiur
+Anthus correndera_Pampakiur
+Anthus crenatus_Kõnnukiur
+Anthus furcatus_Väljakiur
+Anthus godlewskii_Mongoolia kiur
+Anthus gustavi_Põhjakiur
+Anthus hellmayri_Rohukiur
+Anthus hodgsoni_Taigakiur
+Anthus leucophrys_Kõrrekiur
+Anthus lineiventris_Rünkakiur
+Anthus lutescens_Väikekiur
+Anthus nattereri_Kampokiur
+Anthus novaeseelandiae_Lõuna-niidukiur
 Anthus peruvianus_Peruvian Pipit
-Anthus petrosus_Rock Pipit
+Anthus petrosus_Randkiur
 Anthus pratensis_Sookiur
-Anthus richardi_Richard's Pipit
-Anthus roseatus_Rosy Pipit
-Anthus rubescens_American Pipit
-Anthus rufulus_Paddyfield Pipit
-Anthus similis_Long-billed Pipit
-Anthus spinoletta_Water Pipit
-Anthus spragueii_Sprague's Pipit
-Anthus sylvanus_Upland Pipit
+Anthus richardi_Niidukiur
+Anthus roseatus_Roosarind-kiur
+Anthus rubescens_Leetkiur
+Anthus rufulus_Kagu-niidukiur
+Anthus similis_Nõlvakiur
+Anthus spinoletta_Mägikiur
+Anthus spragueii_Preeriakiur
+Anthus sylvanus_Rahnukiur
 Anthus trivialis_Metskiur
-Antigone antigone_Sarus Crane
-Antigone canadensis_Sandhill Crane
-Antigone rubicunda_Brolga
-Antigone vipio_White-naped Crane
-Antilophia bokermanni_Araripe Manakin
-Antilophia galeata_Helmeted Manakin
+Antigone antigone_Saaruskurg
+Antigone canadensis_Kanada kurg
+Antigone rubicunda_Brolgakurg
+Antigone vipio_Idakurg
+Antilophia bokermanni_Araripe tantsulind
+Antilophia galeata_Kiiver-tantsulind
 Antrostomus arizonae_Mexican Whip-poor-will
-Antrostomus badius_Yucatan Nightjar
-Antrostomus carolinensis_Chuck-will's-widow
-Antrostomus noctitherus_Puerto Rican Nightjar
-Antrostomus ridgwayi_Buff-collared Nightjar
-Antrostomus rufus_Rufous Nightjar
-Antrostomus salvini_Tawny-collared Nightjar
-Antrostomus saturatus_Dusky Nightjar
+Antrostomus badius_Maia öösorr
+Antrostomus carolinensis_Suur-öösorr
+Antrostomus noctitherus_Puertoriiko öösorr
+Antrostomus ridgwayi_Kärka-öösorr
+Antrostomus rufus_Ruske-öösorr
+Antrostomus salvini_Mehhiko öösorr
+Antrostomus saturatus_Kostariika öösorr
 Antrostomus sericocaudatus_Silky-tailed Nightjar
-Antrostomus vociferus_Eastern Whip-poor-will
+Antrostomus vociferus_Tamme-öösorr
 Anumbius annumbi_Firewood-gatherer
-Anurolimnas castaneiceps_Chestnut-headed Crake
-Anurolimnas fasciatus_Black-banded Crake
-Anurolimnas viridis_Russet-crowned Crake
+Anurolimnas castaneiceps_Mets-rägaruik
+Anurolimnas fasciatus_Soo-rägaruik
+Anurolimnas viridis_Väike-rägaruik
 Apalis alticola_Brown-headed Apalis
 Apalis chapini_Chapin's Apalis
 Apalis cinerea_Gray Apalis
@@ -397,146 +397,146 @@ Apalis ruddi_Rudd's Apalis
 Apalis rufogularis_Buff-throated Apalis
 Apalis sharpii_Sharpe's Apalis
 Apalis thoracica_Bar-throated Apalis
-Apaloderma narina_Narina Trogon
-Apaloderma vittatum_Bar-tailed Trogon
+Apaloderma narina_Aafrika järanokk
+Apaloderma vittatum_Viir-järanokk
 Aphanotriccus audax_Black-billed Flycatcher
 Aphanotriccus capitalis_Tawny-chested Flycatcher
-Aphelocephala leucopsis_Southern Whiteface
-Aphelocoma californica_California Scrub-Jay
-Aphelocoma coerulescens_Florida Scrub-Jay
-Aphelocoma ultramarina_Transvolcanic Jay
-Aphelocoma unicolor_Unicolored Jay
-Aphelocoma wollweberi_Mexican Jay
-Aphelocoma woodhouseii_Woodhouse's Scrub-Jay
+Aphelocephala leucopsis_Lauk-sirilind
+Aphelocoma californica_Võsa-sininäär
+Aphelocoma coerulescens_Florida sininäär
+Aphelocoma ultramarina_Asteegi sininäär
+Aphelocoma unicolor_Maia sininäär
+Aphelocoma wollweberi_Lääne-sininäär
+Aphelocoma woodhouseii_Hallrind-sininäär
 Aphrastura spinicauda_Thorn-tailed Rayadito
 Apis mellifera_Honey Bee
-Aplonis atrifusca_Samoan Starling
-Aplonis grandis_Brown-winged Starling
-Aplonis metallica_Metallic Starling
-Aplonis mysolensis_Moluccan Starling
-Aplonis opaca_Micronesian Starling
-Aplonis panayensis_Asian Glossy Starling
-Aplonis tabuensis_Polynesian Starling
-Aprosmictus erythropterus_Red-winged Parrot
-Aptenodytes patagonicus_King Penguin
-Apteryx mantelli_North Island Brown Kiwi
-Apus affinis_Little Swift
+Aplonis atrifusca_Samoa viiralind
+Aplonis grandis_Suur-viiralind
+Aplonis metallica_Küüt-viiralind
+Aplonis mysolensis_Maluku viiralind
+Aplonis opaca_Mikroneesia viiralind
+Aplonis panayensis_Aasia viiralind
+Aplonis tabuensis_Okeaania viiralind
+Aprosmictus erythropterus_Punatiib-papagoi
+Aptenodytes patagonicus_Kuningpingviin
+Apteryx mantelli_Triipkiivi
+Apus affinis_Väikepiiritaja
 Apus apus_Piiritaja
-Apus caffer_White-rumped Swift
-Apus melba_Alpine Swift
-Apus nipalensis_House Swift
-Apus pacificus_Pacific Swift
-Apus pallidus_Pallid Swift
-Apus unicolor_Plain Swift
-Aquila adalberti_Spanish Eagle
+Apus caffer_Sirppiiritaja
+Apus melba_Suurpiiritaja
+Apus nipalensis_Kodupiiritaja
+Apus pacificus_Idapiiritaja
+Apus pallidus_Randpiiritaja
+Apus unicolor_Saarepiiritaja
+Aquila adalberti_Ibeeria kääpakotkas
 Aquila chrysaetos_Kaljukotkas
-Aquila heliaca_Imperial Eagle
-Aquila nipalensis_Steppe Eagle
-Ara ambiguus_Great Green Macaw
-Ara ararauna_Blue-and-yellow Macaw
-Ara chloropterus_Red-and-green Macaw
-Ara glaucogularis_Blue-throated Macaw
-Ara macao_Scarlet Macaw
-Ara militaris_Military Macaw
-Ara severus_Chestnut-fronted Macaw
+Aquila heliaca_Kääpakotkas
+Aquila nipalensis_Stepikotkas
+Ara ambiguus_Suur-soldataara
+Ara ararauna_Ararauna
+Ara chloropterus_Rohetiib-aara
+Ara glaucogularis_Boliivia ararauna
+Ara macao_Puna-aara
+Ara militaris_Soldat-aara
+Ara severus_Jõgiaara
 Arachnothera chrysogenys_Yellow-eared Spiderhunter
 Arachnothera crassirostris_Thick-billed Spiderhunter
 Arachnothera flavigaster_Spectacled Spiderhunter
 Arachnothera longirostra_Little Spiderhunter
 Arachnothera magna_Streaked Spiderhunter
 Aramides albiventris_Russet-naped Wood-Rail
-Aramides axillaris_Rufous-necked Wood-Rail
-Aramides cajaneus_Gray-cowled Wood-Rail
-Aramides saracura_Slaty-breasted Wood-Rail
-Aramides wolfi_Brown Wood-Rail
-Aramides ypecaha_Giant Wood-Rail
-Aramus guarauna_Limpkin
-Aratinga auricapillus_Golden-capped Parakeet
-Aratinga jandaya_Jandaya Parakeet
-Aratinga nenday_Nanday Parakeet
-Aratinga weddellii_Dusky-headed Parakeet
-Arborophila atrogularis_White-cheeked Partridge
-Arborophila brunneopectus_Bar-backed Partridge
-Arborophila crudigularis_Taiwan Partridge
-Arborophila hyperythra_Red-breasted Partridge
-Arborophila javanica_Chestnut-bellied Partridge
-Arborophila mandellii_Chestnut-breasted Partridge
-Arborophila rufogularis_Rufous-throated Partridge
-Arborophila torqueola_Hill Partridge
-Archilochus alexandri_Black-chinned Hummingbird
-Archilochus colubris_Ruby-throated Hummingbird
-Ardea alba_Suur-valgehaigur
+Aramides axillaris_Rand-võsaruik
+Aramides cajaneus_Hallkael-võsaruik
+Aramides saracura_Rohenokk-võsaruik
+Aramides wolfi_Pruun-võsaruik
+Aramides ypecaha_Suur-võsaruik
+Aramus guarauna_Ruikkurg
+Aratinga auricapillus_Tulipea-aratinga
+Aratinga jandaya_Leek-aratinga
+Aratinga nenday_Mustpea-aratinga
+Aratinga weddellii_Lodu-aratinga
+Arborophila atrogularis_Mustkurk-künkakana
+Arborophila brunneopectus_Helmes-künkakana
+Arborophila crudigularis_Taivani künkakana
+Arborophila hyperythra_Kalimantani künkakana
+Arborophila javanica_Jaava künkakana
+Arborophila mandellii_Punarind-künkakana
+Arborophila rufogularis_Punakael-künkakana
+Arborophila torqueola_Himaalaja künkakana
+Archilochus alexandri_Tumekurk-koolibri
+Archilochus colubris_Rubiinkurk-koolibri
+Ardea alba_Hõbehaigur
 Ardea cinerea_Hallhaigur
-Ardea cocoi_Cocoi Heron
-Ardea herodias_Great Blue Heron
-Ardea intermedia_Intermediate Egret
-Ardea melanocephala_Black-headed Heron
-Ardea purpurea_Purple Heron
-Ardea sumatrana_Great-billed Heron
-Ardenna bulleri_Buller's Shearwater
-Ardenna carneipes_Flesh-footed Shearwater
-Ardenna creatopus_Pink-footed Shearwater
-Ardenna grisea_Sooty Shearwater
-Ardenna pacifica_Wedge-tailed Shearwater
-Ardenna tenuirostris_Short-tailed Shearwater
-Ardeola bacchus_Chinese Pond-Heron
-Ardeola grayii_Indian Pond-Heron
-Ardeola ralloides_Squacco Heron
-Ardeola speciosa_Javan Pond-Heron
-Arenaria interpres_Ruddy Turnstone
-Arenaria melanocephala_Black Turnstone
-Argusianus argus_Great Argus
-Argya affinis_Yellow-billed Babbler
-Argya caudata_Common Babbler
-Argya earlei_Striated Babbler
-Argya malcolmi_Large Gray Babbler
-Argya striata_Jungle Babbler
-Argya subrufa_Rufous Babbler
-Arizelocichla masukuensis_Shelley's Greenbul
-Arizelocichla milanjensis_Stripe-cheeked Greenbul
-Arizelocichla nigriceps_Eastern Mountain Greenbul
-Arremon abeillei_Black-capped Sparrow
-Arremon assimilis_Gray-browed Brushfinch
-Arremon atricapillus_Black-headed Brushfinch
-Arremon aurantiirostris_Orange-billed Sparrow
-Arremon basilicus_Sierra Nevada Brushfinch
-Arremon brunneinucha_Chestnut-capped Brushfinch
-Arremon castaneiceps_Olive Finch
-Arremon costaricensis_Costa Rican Brushfinch
-Arremon crassirostris_Sooty-faced Finch
-Arremon flavirostris_Saffron-billed Sparrow
-Arremon franciscanus_Sao Francisco Sparrow
-Arremon perijanus_Perija Brushfinch
-Arremon schlegeli_Golden-winged Sparrow
-Arremon semitorquatus_Half-collared Sparrow
-Arremon taciturnus_Pectoral Sparrow
-Arremon torquatus_White-browed Brushfinch
-Arremon virenticeps_Green-striped Brushfinch
-Arremonops chloronotus_Green-backed Sparrow
-Arremonops conirostris_Black-striped Sparrow
-Arremonops rufivirgatus_Olive Sparrow
-Arremonops tocuyensis_Tocuyo Sparrow
+Ardea cocoi_Koko-hallhaigur
+Ardea herodias_Ameerika hallhaigur
+Ardea intermedia_Väike-hõbehaigur
+Ardea melanocephala_Savannihaigur
+Ardea purpurea_Purpurhaigur
+Ardea sumatrana_Mangroovihaigur
+Ardenna bulleri_Tuhkur-tormilind
+Ardenna carneipes_Kahkjalg-tormilind
+Ardenna creatopus_Tšiili tormilind
+Ardenna grisea_Peegel-tormilind
+Ardenna pacifica_Kiilsaba-tormilind
+Ardenna tenuirostris_Austraalia tormilind
+Ardeola bacchus_Hiina tiigihaigur
+Ardeola grayii_India tiigihaigur
+Ardeola ralloides_Koldhaigur
+Ardeola speciosa_Sunda tiigihaigur
+Arenaria interpres_Kivirullija
+Arenaria melanocephala_Must-kivirullija
+Argusianus argus_Argusfaasan
+Argya affinis_Draviidi vadavädrak
+Argya caudata_Triip-vadavädrak
+Argya earlei_Soo-vadavädrak
+Argya malcolmi_Dekkani vadavädrak
+Argya striata_Džungli-vadavädrak
+Argya subrufa_Ghati vadavädrak
+Arizelocichla masukuensis_Tüve-viherbülbül
+Arizelocichla milanjensis_Viirpõsk-viherbülbül
+Arizelocichla nigriceps_Nõgikiird-viherbülbül
+Arremon abeillei_Hall-metssidrik
+Arremon assimilis_Andi metssidrik
+Arremon atricapillus_Karbus-metssidrik
+Arremon aurantiirostris_Punanokk-metssidrik
+Arremon basilicus_Santamarta metssidrik
+Arremon brunneinucha_Tanu-metssidrik
+Arremon castaneiceps_Roostekiird-metssidrik
+Arremon costaricensis_Kostariika metssidrik
+Arremon crassirostris_Habe-metssidrik
+Arremon flavirostris_Ruugenokk-metssidrik
+Arremon franciscanus_Kaatinga-metssidrik
+Arremon perijanus_Perijá metssidrik
+Arremon schlegeli_Koldnokk-metssidrik
+Arremon semitorquatus_Brasiilia metssidrik
+Arremon taciturnus_Kuldõlg-metssidrik
+Arremon torquatus_Valgekulm-metssidrik
+Arremon virenticeps_Rohekulm-metssidrik
+Arremonops chloronotus_Maia padrikusidrik
+Arremonops conirostris_Suur-padrikusidrik
+Arremonops rufivirgatus_Mehhiko padrikusidrik
+Arremonops tocuyensis_Venetsueela padrikusidrik
 Arses telescopthalmus_Frilled Monarch
-Artamus cinereus_Black-faced Woodswallow
-Artamus cyanopterus_Dusky Woodswallow
-Artamus fuscus_Ashy Woodswallow
-Artamus leucorynchus_White-breasted Woodswallow
-Artamus personatus_Masked Woodswallow
-Artamus superciliosus_White-browed Woodswallow
-Artemisiospiza belli_Bell's Sparrow
-Artemisiospiza nevadensis_Sagebrush Sparrow
+Artamus cinereus_Halltuulas
+Artamus cyanopterus_Valgetiib-tuulas
+Artamus fuscus_Aasia tuulas
+Artamus leucorynchus_Valgekõht-tuulas
+Artamus personatus_Masktuulas
+Artamus superciliosus_Ruskekõht-tuulas
+Artemisiospiza belli_Habesidrik
+Artemisiospiza nevadensis_Nevada sidrik
 Artisornis metopias_African Tailorbird
 Artisornis moreaui_Long-billed Tailorbird
-Arundinax aedon_Thick-billed Warbler
-Arundinicola leucocephala_White-headed Marsh Tyrant
+Arundinax aedon_Võsa-käosulane
+Arundinicola leucocephala_Valgepea-padutikat
 Asemospiza fuliginosa_Sooty Grassquit
 Asemospiza obscura_Dull-colored Grassquit
-Asio clamator_Striped Owl
+Asio clamator_Triipräts
 Asio flammeus_Sooräts
-Asio grammicus_Jamaican Owl
+Asio grammicus_Jamaika räts
 Asio otus_Kõrvukräts
-Asio stygius_Stygian Owl
-Aspatha gularis_Blue-throated Motmot
+Asio stygius_Tooneräts
+Aspatha gularis_Mägimotmot
 Asthenes anthoides_Austral Canastero
 Asthenes baeri_Short-billed Canastero
 Asthenes coryi_Ochre-browed Thistletail
@@ -562,58 +562,58 @@ Asthenes urubambensis_Line-fronted Canastero
 Asthenes virgata_Junin Canastero
 Asthenes wyatti_Streak-backed Canastero
 Atalotriccus pilaris_Pale-eyed Pygmy-Tyrant
-Atelornis crossleyi_Rufous-headed Ground-Roller
-Atelornis pittoides_Pitta-like Ground-Roller
-Athene blewitti_Forest Owlet
-Athene brama_Spotted Owlet
-Athene cunicularia_Burrowing Owl
-Athene noctua_Little Owl
-Athene superciliaris_White-browed Owl
-Atimastillas flavicollis_Yellow-throated Greenbul
+Atelornis crossleyi_Ruske-maaraag
+Atelornis pittoides_Sinipea-maaraag
+Athene blewitti_Mets-kivikakk
+Athene brama_Küla-kivikakk
+Athene cunicularia_Koopakakk
+Athene noctua_Kivikakk
+Athene superciliaris_Valgekulm-haugaskakk
+Atimastillas flavicollis_Salu-viherbülbül
 Atlanticus testaceus_Protean Shieldback
-Atlapetes albinucha_White-naped Brushfinch
-Atlapetes albofrenatus_Moustached Brushfinch
-Atlapetes citrinellus_Yellow-striped Brushfinch
-Atlapetes flaviceps_Yellow-headed Brushfinch
-Atlapetes fulviceps_Fulvous-headed Brushfinch
-Atlapetes fuscoolivaceus_Dusky-headed Brushfinch
-Atlapetes latinuchus_Yellow-breasted Brushfinch
-Atlapetes leucopis_White-rimmed Brushfinch
-Atlapetes leucopterus_White-winged Brushfinch
-Atlapetes melanocephalus_Santa Marta Brushfinch
-Atlapetes melanolaemus_Black-faced Brushfinch
-Atlapetes pallidiceps_Pale-headed Brushfinch
-Atlapetes pallidinucha_Pale-naped Brushfinch
-Atlapetes personatus_Tepui Brushfinch
-Atlapetes pileatus_Rufous-capped Brushfinch
-Atlapetes rufigenis_Rufous-eared Brushfinch
-Atlapetes rufinucha_Bolivian Brushfinch
-Atlapetes schistaceus_Slaty Brushfinch
-Atlapetes semirufus_Ochre-breasted Brushfinch
-Atlapetes tibialis_Yellow-thighed Brushfinch
-Atlapetes tricolor_Tricolored Brushfinch
-Atrichornis clamosus_Noisy Scrub-bird
-Atrichornis rufescens_Rufous Scrub-bird
-Attagis gayi_Rufous-bellied Seedsnipe
-Atticora fasciata_White-banded Swallow
-Atticora pileata_Black-capped Swallow
-Atticora tibialis_White-thighed Swallow
-Attila bolivianus_Dull-capped Attila
-Attila cinnamomeus_Cinnamon Attila
-Attila citriniventris_Citron-bellied Attila
-Attila phoenicurus_Rufous-tailed Attila
-Attila rufus_Gray-hooded Attila
-Attila spadiceus_Bright-rumped Attila
-Attila torridus_Ochraceous Attila
-Augastes lumachella_Hooded Visorbearer
-Augastes scutatus_Hyacinth Visorbearer
-Aulacorhynchus albivitta_Southern Emerald-Toucanet
-Aulacorhynchus coeruleicinctis_Blue-banded Toucanet
-Aulacorhynchus derbianus_Chestnut-tipped Toucanet
-Aulacorhynchus haematopygus_Crimson-rumped Toucanet
-Aulacorhynchus prasinus_Northern Emerald-Toucanet
-Aulacorhynchus sulcatus_Groove-billed Toucanet
-Auriparus flaviceps_Verdin
+Atlapetes albinucha_Mustpea-võsasidrik
+Atlapetes albofrenatus_Valgekurk-võsasidrik
+Atlapetes citrinellus_Lepa-võsasidrik
+Atlapetes flaviceps_Kold-võsasidrik
+Atlapetes fulviceps_Punapea-võsasidrik
+Atlapetes fuscoolivaceus_Oliiv-võsasidrik
+Atlapetes latinuchus_Veere-võsasidrik
+Atlapetes leucopis_Prill-võsasidrik
+Atlapetes leucopterus_Väike-võsasidrik
+Atlapetes melanocephalus_Santamarta võsasidrik
+Atlapetes melanolaemus_Mustkurk-võsasidrik
+Atlapetes pallidiceps_Kahkpea-võsasidrik
+Atlapetes pallidinucha_Ruugelaup-võsasidrik
+Atlapetes personatus_Tepui-võsasidrik
+Atlapetes pileatus_Mehhiko võsasidrik
+Atlapetes rufigenis_Marañóni võsasidrik
+Atlapetes rufinucha_Boliivia võsasidrik
+Atlapetes schistaceus_Hall-võsasidrik
+Atlapetes semirufus_Rooste-võsasidrik
+Atlapetes tibialis_Tume-võsasidrik
+Atlapetes tricolor_Kuldkiird-võsasidrik
+Atrichornis clamosus_Häälis-tihnikulind
+Atrichornis rufescens_Väike-tihnikulind
+Attagis gayi_Lumekurp
+Atticora fasciata_Vööpääsuke
+Atticora pileata_Maia mägipääsuke
+Atticora tibialis_Tõmmupääsuke
+Attila bolivianus_Valgesilm-rebastikat
+Attila cinnamomeus_Lammi-rebastikat
+Attila citriniventris_Selva-rebastikat
+Attila phoenicurus_Araukaaria-rebastikat
+Attila rufus_Karbus-rebastikat
+Attila spadiceus_Rebastikat
+Attila torridus_Ekuadori rebastikat
+Augastes lumachella_Kaktuse-ametüstkoolibri
+Augastes scutatus_Väike-ametüstkoolibri
+Aulacorhynchus albivitta_Ida-smaragdtuukan
+Aulacorhynchus coeruleicinctis_Valgesilm-rohetuukan
+Aulacorhynchus derbianus_Nõlva-rohetuukan
+Aulacorhynchus haematopygus_Punanokk-rohetuukan
+Aulacorhynchus prasinus_Smaragdtuukan
+Aulacorhynchus sulcatus_Vagunokk-rohetuukan
+Auriparus flaviceps_Ameerika kukkurtihane
 Automolus exsertus_Chiriqui Foliage-gleaner
 Automolus infuscatus_Olive-backed Foliage-gleaner
 Automolus leucophthalmus_White-eyed Foliage-gleaner
@@ -622,46 +622,46 @@ Automolus ochrolaemus_Buff-throated Foliage-gleaner
 Automolus paraensis_Para Foliage-gleaner
 Automolus rufipileatus_Chestnut-crowned Foliage-gleaner
 Automolus subulatus_Striped Woodhaunter
-Aviceda jerdoni_Jerdon's Baza
-Aviceda leuphotes_Black Baza
-Aviceda subcristata_Pacific Baza
-Aythya affinis_Lesser Scaup
-Aythya americana_Redhead
-Aythya collaris_Ring-necked Duck
-Aythya ferina_Common Pochard
-Aythya fuligula_Tufted Duck
-Aythya marila_Greater Scaup
-Aythya nyroca_Ferruginous Duck
-Aythya valisineria_Canvasback
-Baeolophus atricristatus_Black-crested Titmouse
-Baeolophus bicolor_Tufted Titmouse
-Baeolophus inornatus_Oak Titmouse
-Baeolophus ridgwayi_Juniper Titmouse
-Baeolophus wollweberi_Bridled Titmouse
-Baeopogon indicator_Honeyguide Greenbul
-Balearica regulorum_Gray Crowned-Crane
-Bambusicola fytchii_Mountain Bamboo-Partridge
-Bambusicola sonorivox_Taiwan Bamboo-Partridge
-Bambusicola thoracicus_Chinese Bamboo-Partridge
+Aviceda jerdoni_Pruun-tutthaugas
+Aviceda leuphotes_Must-tutthaugas
+Aviceda subcristata_Lõuna-tutthaugas
+Aythya affinis_Väike-merivart
+Aythya americana_Preeriavart
+Aythya collaris_Lannuvart
+Aythya ferina_Punapea-vart
+Aythya fuligula_Tuttvart
+Aythya marila_Merivart
+Aythya nyroca_Valgesilm-vart
+Aythya valisineria_Suurvart
+Baeolophus atricristatus_Texase tanutihane
+Baeolophus bicolor_Tanutihane
+Baeolophus inornatus_Tuhktihane
+Baeolophus ridgwayi_Kadakatihane
+Baeolophus wollweberi_Valjastihane
+Baeopogon indicator_Vile-viherbülbül
+Balearica regulorum_Lõuna-kroonkurg
+Bambusicola fytchii_Mägi-bambuskana
+Bambusicola sonorivox_Taivani bambuskana
+Bambusicola thoracicus_Bambuskana
 Bangsia aureocincta_Gold-ringed Tanager
 Bangsia edwardsi_Moss-backed Tanager
 Bangsia melanochlamys_Black-and-gold Tanager
-Barnardius zonarius_Australian Ringneck
-Bartramia longicauda_Upland Sandpiper
-Baryphthengus martii_Rufous Motmot
-Baryphthengus ruficapillus_Rufous-capped Motmot
-Basileuterus belli_Golden-browed Warbler
-Basileuterus culicivorus_Golden-crowned Warbler
-Basileuterus delattrii_Chestnut-capped Warbler
-Basileuterus lachrymosus_Fan-tailed Warbler
-Basileuterus melanogenys_Black-cheeked Warbler
+Barnardius zonarius_Eukalüptipapagoi
+Bartramia longicauda_Koovtilder
+Baryphthengus martii_Suurmotmot
+Baryphthengus ruficapillus_Brasiilia motmot
+Basileuterus belli_Kuldkulm-selvasäälik
+Basileuterus culicivorus_Väike-selvasäälik
+Basileuterus delattrii_Punapõsk-selvasäälik
+Basileuterus lachrymosus_Lehviksaba-säälik
+Basileuterus melanogenys_Mustpõsk-selvasäälik
 Basileuterus melanotis_Costa Rican Warbler
-Basileuterus rufifrons_Rufous-capped Warbler
-Basileuterus trifasciatus_Three-banded Warbler
-Basileuterus tristriatus_Three-striped Warbler
-Basilinna leucotis_White-eared Hummingbird
+Basileuterus rufifrons_Valgekulm-selvasäälik
+Basileuterus trifasciatus_Triip-selvasäälik
+Basileuterus tristriatus_Leet-selvasäälik
+Basilinna leucotis_Tammekoolibri
 Batara cinerea_Giant Antshrike
-Bathmocercus rufus_Black-faced Rufous-Warbler
+Bathmocercus rufus_Sõba-rohulind
 Batis capensis_Cape Batis
 Batis erlangeri_Western Black-headed Batis
 Batis mixta_Short-tailed Batis
@@ -670,424 +670,424 @@ Batis orientalis_Gray-headed Batis
 Batis perkeo_Pygmy Batis
 Batis pririt_Pririt Batis
 Batis soror_Pale Batis
-Batrachostomus affinis_Blyth's Frogmouth
-Batrachostomus auritus_Large Frogmouth
-Batrachostomus cornutus_Sunda Frogmouth
-Batrachostomus hodgsoni_Hodgson's Frogmouth
-Batrachostomus moniliger_Sri Lanka Frogmouth
-Batrachostomus septimus_Philippine Frogmouth
-Batrachostomus stellatus_Gould's Frogmouth
-Berenicornis comatus_White-crowned Hornbill
+Batrachostomus affinis_Ida-konnsuu
+Batrachostomus auritus_Suur-konnsuu
+Batrachostomus cornutus_Džungli-konnsuu
+Batrachostomus hodgsoni_Nõlva-konnsuu
+Batrachostomus moniliger_Tseiloni konnsuu
+Batrachostomus septimus_Filipiini konnsuu
+Batrachostomus stellatus_Malai konnsuu
+Berenicornis comatus_Kähar-sarvlind
 Berlepschia rikeri_Point-tailed Palmcreeper
-Bernieria madagascariensis_Long-billed Bernieria
+Bernieria madagascariensis_Pikknokk-farifutša
 Bias musicus_Black-and-white Shrike-flycatcher
 Biatas nigropectus_White-bearded Antshrike
-Biziura lobata_Musk Duck
-Bleda canicapillus_Gray-headed Bristlebill
-Bleda notatus_Lesser Bristlebill
-Bleda syndactylus_Red-tailed Bristlebill
-Blythipicus pyrrhotis_Bay Woodpecker
-Blythipicus rubiginosus_Maroon Woodpecker
-Boissonneaua flavescens_Buff-tailed Coronet
-Boissonneaua jardini_Velvet-purple Coronet
-Boissonneaua matthewsii_Chestnut-breasted Coronet
-Bolbopsittacus lunulatus_Guaiabero
-Bolborhynchus lineola_Barred Parakeet
-Bolborhynchus orbygnesius_Andean Parakeet
+Biziura lobata_Lottpart
+Bleda canicapillus_Ginea viherbülbül
+Bleda notatus_Valjas-viherbülbül
+Bleda syndactylus_Punasaba-viherbülbül
+Blythipicus pyrrhotis_Roosterähn
+Blythipicus rubiginosus_Enderähn
+Boissonneaua flavescens_Leetsaba-läikkoolibri
+Boissonneaua jardini_Valgesaba-läikkoolibri
+Boissonneaua matthewsii_Ruske-läikkoolibri
+Bolbopsittacus lunulatus_Nudisaba-papagoi
+Bolborhynchus lineola_Vööt-mägipapagoi
+Bolborhynchus orbygnesius_Rohe-mägipapagoi
 Bolemoreus frenatus_Bridled Honeyeater
-Bombycilla cedrorum_Cedar Waxwing
-Bombycilla garrulus_Bohemian Waxwing
-Bombycilla japonica_Japanese Waxwing
-Bonasa umbellus_Ruffed Grouse
-Bostrychia carunculata_Wattled Ibis
-Bostrychia hagedash_Hadada Ibis
-Botaurus lentiginosus_American Bittern
-Botaurus stellaris_Great Bittern
-Brachygalba albogularis_White-throated Jacamar
-Brachygalba lugubris_Brown Jacamar
+Bombycilla cedrorum_Ameerika siidisaba
+Bombycilla garrulus_Siidisaba
+Bombycilla japonica_Amuuri siidisaba
+Bonasa umbellus_Kraepüü
+Bostrychia carunculata_Lottiibis
+Bostrychia hagedash_Naeruiibis
+Botaurus lentiginosus_Habehüüp
+Botaurus stellaris_Hüüp
+Brachygalba albogularis_Väike-läiklind
+Brachygalba lugubris_Pruun-läiklind
 Brachypodius eutilotus_Puff-backed Bulbul
 Brachypodius melanocephalos_Black-headed Bulbul
 Brachypodius melanoleucos_Black-and-white Bulbul
-Brachypodius priocephalus_Gray-headed Bulbul
+Brachypodius priocephalus_Tuhkpea-bülbül
 Brachypodius urostictus_Yellow-wattled Bulbul
-Brachypteryx cruralis_Himalayan Shortwing
-Brachypteryx goodfellowi_Taiwan Shortwing
-Brachypteryx hyperythra_Rusty-bellied Shortwing
-Brachypteryx leucophris_Lesser Shortwing
-Brachypteryx montana_White-browed Shortwing
-Brachyramphus marmoratus_Marbled Murrelet
-Bradornis microrhynchus_African Gray Flycatcher
-Bradypterus baboecala_Little Rush Warbler
-Bradypterus barratti_Barratt's Warbler
-Bradypterus brunneus_Brown Emutail
-Bradypterus carpalis_White-winged Swamp Warbler
-Bradypterus cinnamomeus_Cinnamon Bracken-Warbler
-Bradypterus lopezi_Evergreen-forest Warbler
-Bradypterus sylvaticus_Knysna Warbler
-Branta bernicla_Brant
-Branta canadensis_Canada Goose
-Branta hutchinsii_Cackling Goose
-Branta leucopsis_Barnacle Goose
-Branta sandvicensis_Hawaiian Goose
-Brotogeris chiriri_Yellow-chevroned Parakeet
-Brotogeris chrysoptera_Golden-winged Parakeet
-Brotogeris cyanoptera_Cobalt-winged Parakeet
-Brotogeris jugularis_Orange-chinned Parakeet
-Brotogeris pyrrhoptera_Gray-cheeked Parakeet
-Brotogeris sanctithomae_Tui Parakeet
-Brotogeris tirica_Plain Parakeet
-Brotogeris versicolurus_White-winged Parakeet
-Bubalornis albirostris_White-billed Buffalo-Weaver
-Bubalornis niger_Red-billed Buffalo-Weaver
-Bubo africanus_Spotted Eagle-Owl
-Bubo bengalensis_Rock Eagle-Owl
-Bubo bubo_Eurasian Eagle-Owl
-Bubo coromandus_Dusky Eagle-Owl
-Bubo lacteus_Verreaux's Eagle-Owl
-Bubo nipalensis_Spot-bellied Eagle-Owl
-Bubo scandiacus_Snowy Owl
-Bubo sumatranus_Barred Eagle-Owl
-Bubo virginianus_Great Horned Owl
-Bubulcus ibis_Cattle Egret
-Bucanetes githagineus_Trumpeter Finch
-Buccanodon duchaillui_Yellow-spotted Barbet
-Bucco capensis_Collared Puffbird
-Bucco macrodactylus_Chestnut-capped Puffbird
-Bucco tamatia_Spotted Puffbird
-Bucephala albeola_Bufflehead
-Bucephala clangula_Common Goldeneye
-Bucephala islandica_Barrow's Goldeneye
-Buceros bicornis_Great Hornbill
-Buceros hydrocorax_Rufous Hornbill
-Buceros rhinoceros_Rhinoceros Hornbill
-Buceros vigil_Helmeted Hornbill
-Bucorvus leadbeateri_Southern Ground-Hornbill
-Bulweria bulwerii_Bulwer's Petrel
-Buphagus africanus_Yellow-billed Oxpecker
-Buphagus erythrorynchus_Red-billed Oxpecker
-Burhinus bistriatus_Double-striped Thick-knee
-Burhinus capensis_Spotted Thick-knee
-Burhinus grallarius_Bush Thick-knee
+Brachypteryx cruralis_Kaguaasia paguööbik
+Brachypteryx goodfellowi_Taivani paguööbik
+Brachypteryx hyperythra_Bambuse-paguööbik
+Brachypteryx leucophris_Leet-paguööbik
+Brachypteryx montana_Mägi-paguööbik
+Brachyramphus marmoratus_Mets-kirjuörd
+Bradornis microrhynchus_Võseriku-kärbsenäpp
+Bradypterus baboecala_Lõikheina-padulind
+Bradypterus barratti_Tihniku-padulind
+Bradypterus brunneus_Mets-padulind
+Bradypterus carpalis_Papüüruse-padulind
+Bradypterus cinnamomeus_Kaneel-padulind
+Bradypterus lopezi_Kõrgmaa-padulind
+Bradypterus sylvaticus_Kapimaa padulind
+Branta bernicla_Mustlagle
+Branta canadensis_Kanada lagle
+Branta hutchinsii_Eskimo lagle
+Branta leucopsis_Valgepõsk-lagle
+Branta sandvicensis_Nenelagle
+Brotogeris chiriri_Küüdus-viherpapagoi
+Brotogeris chrysoptera_Nektari-viherpapagoi
+Brotogeris cyanoptera_Koobalttiib-viherpapagoi
+Brotogeris jugularis_Salu-viherpapagoi
+Brotogeris pyrrhoptera_Hõbepõsk-viherpapagoi
+Brotogeris sanctithomae_Kuldlauk-viherpapagoi
+Brotogeris tirica_Vaskõlg-viherpapagoi
+Brotogeris versicolurus_Kuldtiib-viherpapagoi
+Bubalornis albirostris_Karja-kangurlind
+Bubalornis niger_Punanokk-kangurlind
+Bubo africanus_Savanni-kassikakk
+Bubo bengalensis_India kassikakk
+Bubo bubo_Kassikakk
+Bubo coromandus_Tuhk-kassikakk
+Bubo lacteus_Hall-kassikakk
+Bubo nipalensis_Džungli-kassikakk
+Bubo scandiacus_Lumekakk
+Bubo sumatranus_Malai kassikakk
+Bubo virginianus_Ameerika kassikakk
+Bubulcus ibis_Veisehaigur
+Bucanetes githagineus_Kõrbeleevike
+Buccanodon duchaillui_Herilas-udelind
+Bucco capensis_Võru-puhvlind
+Bucco macrodactylus_Viir-puhvlind
+Bucco tamatia_Tähnik-puhvlind
+Bucephala albeola_Sõnnpea-sõtkas
+Bucephala clangula_Sõtkas
+Bucephala islandica_Läänesõtkas
+Buceros bicornis_Suur-sarvlind
+Buceros hydrocorax_Tuli-sarvlind
+Buceros rhinoceros_Ninasarviklind
+Buceros vigil_Kilp-sarvlind
+Bucorvus leadbeateri_Lõuna-maasarvik
+Bulweria bulwerii_Nõgi-tormilind
+Buphagus africanus_Koldnokk-pühvlilind
+Buphagus erythrorynchus_Punanokk-pühvlilind
+Burhinus bistriatus_Rohtla-jämejalg
+Burhinus capensis_Täpik-jämejalg
+Burhinus grallarius_Rand-jämejalg
 Burhinus indicus_Indian Thick-knee
-Burhinus oedicnemus_Eurasian Thick-knee
-Burhinus senegalensis_Senegal Thick-knee
-Burhinus superciliaris_Peruvian Thick-knee
-Burhinus vermiculatus_Water Thick-knee
-Busarellus nigricollis_Black-collared Hawk
-Butastur indicus_Gray-faced Buzzard
-Butastur teesa_White-eyed Buzzard
-Buteo albigula_White-throated Hawk
-Buteo albonotatus_Zone-tailed Hawk
-Buteo augur_Augur Buzzard
-Buteo brachypterus_Madagascar Buzzard
-Buteo brachyurus_Short-tailed Hawk
+Burhinus oedicnemus_Jämejalg
+Burhinus senegalensis_Jõgi-jämejalg
+Burhinus superciliaris_Peruu jämejalg
+Burhinus vermiculatus_Kalda-jämejalg
+Busarellus nigricollis_Kalaviu
+Butastur indicus_Hallpea-haugasviu
+Butastur teesa_India haugasviu
+Buteo albigula_Andi viu
+Buteo albonotatus_Mustviu
+Buteo augur_Kiltmaa-viu
+Buteo brachypterus_Madagaskari viu
+Buteo brachyurus_Linnuviu
 Buteo buteo_Hiireviu
-Buteo jamaicensis_Red-tailed Hawk
-Buteo japonicus_Eastern Buzzard
+Buteo jamaicensis_Punasaba-viu
+Buteo japonicus_Ida-hiireviu
 Buteo lagopus_Karvasjalg-viu
-Buteo lineatus_Red-shouldered Hawk
-Buteo nitidus_Gray-lined Hawk
-Buteo oreophilus_Mountain Buzzard
-Buteo plagiatus_Gray Hawk
-Buteo platypterus_Broad-winged Hawk
-Buteo regalis_Ferruginous Hawk
-Buteo ridgwayi_Ridgway's Hawk
-Buteo solitarius_Hawaiian Hawk
-Buteo swainsoni_Swainson's Hawk
-Buteogallus anthracinus_Common Black Hawk
-Buteogallus coronatus_Chaco Eagle
-Buteogallus meridionalis_Savanna Hawk
-Buteogallus schistaceus_Slate-colored Hawk
-Buteogallus solitarius_Solitary Eagle
-Buteogallus urubitinga_Great Black Hawk
+Buteo lineatus_Kirjuviu
+Buteo nitidus_Hallviu
+Buteo oreophilus_Tähnikviu
+Buteo plagiatus_Mehhiko hallviu
+Buteo platypterus_Laitiib-viu
+Buteo regalis_Kuningviu
+Buteo ridgwayi_Haiti viu
+Buteo solitarius_Havai viu
+Buteo swainsoni_Preeriaviu
+Buteogallus anthracinus_Kaldaviu
+Buteogallus coronatus_Hall-hiidviu
+Buteogallus meridionalis_Ruugeviu
+Buteogallus schistaceus_Hall-selvaviu
+Buteogallus solitarius_Tõmmu-hiidviu
+Buteogallus urubitinga_Sooviu
 Buthraupis montana_Hooded Mountain Tanager
-Butorides striata_Striated Heron
-Butorides virescens_Green Heron
-Bycanistes albotibialis_White-thighed Hornbill
-Bycanistes brevis_Silvery-cheeked Hornbill
-Bycanistes bucinator_Trumpeter Hornbill
-Bycanistes fistulator_Piping Hornbill
-Bycanistes subcylindricus_Black-and-white-casqued Hornbill
-Cacatua alba_White Cockatoo
-Cacatua ducorpsii_Ducorps's Cockatoo
-Cacatua galerita_Sulphur-crested Cockatoo
-Cacatua goffiniana_Tanimbar Corella
-Cacatua sanguinea_Little Corella
-Cacatua tenuirostris_Long-billed Corella
-Cacicus cela_Yellow-rumped Cacique
-Cacicus chrysonotus_Mountain Cacique
-Cacicus chrysopterus_Golden-winged Cacique
-Cacicus haemorrhous_Red-rumped Cacique
-Cacicus latirostris_Band-tailed Cacique
-Cacicus oseryi_Casqued Cacique
-Cacicus solitarius_Solitary Black Cacique
-Cacicus uropygialis_Scarlet-rumped Cacique
-Cacomantis castaneiventris_Chestnut-breasted Cuckoo
-Cacomantis flabelliformis_Fan-tailed Cuckoo
+Butorides striata_Väikehaigur
+Butorides virescens_Punakael-väikehaigur
+Bycanistes albotibialis_Tääk-kiiverlind
+Bycanistes brevis_Hõbepõsk-kiiverlind
+Bycanistes bucinator_Trompet-kiiverlind
+Bycanistes fistulator_Väike-kiiverlind
+Bycanistes subcylindricus_Salu-kiiverlind
+Cacatua alba_Maluku kakaduu
+Cacatua ducorpsii_Melaneesia kakaduu
+Cacatua galerita_Kollatutt-kakaduu
+Cacatua goffiniana_Tanimbari kakaduu
+Cacatua sanguinea_Lättekakaduu
+Cacatua tenuirostris_Kaevurkakaduu
+Cacicus cela_Pila-kuningturpial
+Cacicus chrysonotus_Mägi-kuningturpial
+Cacicus chrysopterus_Väike-kuningturpial
+Cacicus haemorrhous_Punaselg-kuningturpial
+Cacicus latirostris_Selva-kuningturpial
+Cacicus oseryi_Vada-kuningturpial
+Cacicus solitarius_Lammiturpial
+Cacicus uropygialis_Nõlva-kuningturpial
+Cacomantis castaneiventris_Paapua tüüdukägu
+Cacomantis flabelliformis_Kiilsaba-tüüdukägu
 Cacomantis leucolophus_White-crowned Koel
-Cacomantis merulinus_Plaintive Cuckoo
+Cacomantis merulinus_Väike-tüüdukägu
 Cacomantis pallidus_Pallid Cuckoo
-Cacomantis passerinus_Gray-bellied Cuckoo
-Cacomantis sonneratii_Banded Bay Cuckoo
-Cacomantis variolosus_Brush Cuckoo
-Cairina moschata_Muscovy Duck
+Cacomantis passerinus_Hall-tüüdukägu
+Cacomantis sonneratii_Viir-tüüdukägu
+Cacomantis variolosus_Võsa-tüüdukägu
+Cairina moschata_Muskuspart
 Calamanthus fuliginosus_Striated Fieldwren
 Calamonastes fasciolatus_Barred Wren-Warbler
 Calamonastes simplex_Gray Wren-Warbler
 Calamonastes stierlingi_Stierling's Wren-Warbler
-Calamospiza melanocorys_Lark Bunting
-Calandrella acutirostris_Hume's Lark
-Calandrella brachydactyla_Greater Short-toed Lark
-Calandrella cinerea_Red-capped Lark
-Calandrella dukhunensis_Mongolian Short-toed Lark
-Calcarius lapponicus_Lapland Longspur
-Calcarius ornatus_Chestnut-collared Longspur
-Calcarius pictus_Smith's Longspur
-Calendulauda africanoides_Fawn-colored Lark
-Calendulauda albescens_Karoo Lark
-Calendulauda alopex_Foxy Lark
-Calendulauda poecilosterna_Pink-breasted Lark
-Calendulauda sabota_Sabota Lark
-Calicalicus madagascariensis_Red-tailed Vanga
-Calidris acuminata_Sharp-tailed Sandpiper
-Calidris alba_Sanderling
-Calidris alpina_Dunlin
-Calidris bairdii_Baird's Sandpiper
-Calidris canutus_Red Knot
-Calidris falcinellus_Broad-billed Sandpiper
-Calidris ferruginea_Curlew Sandpiper
-Calidris fuscicollis_White-rumped Sandpiper
-Calidris himantopus_Stilt Sandpiper
-Calidris maritima_Purple Sandpiper
-Calidris mauri_Western Sandpiper
-Calidris melanotos_Pectoral Sandpiper
-Calidris minuta_Little Stint
-Calidris minutilla_Least Sandpiper
-Calidris ptilocnemis_Rock Sandpiper
-Calidris pugnax_Ruff
-Calidris pusilla_Semipalmated Sandpiper
-Calidris pygmaea_Spoon-billed Sandpiper
-Calidris ruficollis_Red-necked Stint
-Calidris subminuta_Long-toed Stint
-Calidris subruficollis_Buff-breasted Sandpiper
-Calidris temminckii_Temminck's Stint
-Calidris tenuirostris_Great Knot
-Calidris virgata_Surfbird
+Calamospiza melanocorys_Preeriasidrik
+Calandrella acutirostris_Mägi-väikelõoke
+Calandrella brachydactyla_Välja-väikelõoke
+Calandrella cinerea_Punapea-väikelõoke
+Calandrella dukhunensis_Ida-väikelõoke
+Calcarius lapponicus_Lapi tsiitsitaja
+Calcarius ornatus_Mustkõht-tsiitsitaja
+Calcarius pictus_Tarnatsiitsitaja
+Calendulauda africanoides_Kahkrind-lõoke
+Calendulauda albescens_Kapimaa lõoke
+Calendulauda alopex_Rebaslõoke
+Calendulauda poecilosterna_Roosapugu-lõoke
+Calendulauda sabota_Puhmalõoke
+Calicalicus madagascariensis_Tihasvanga
+Calidris acuminata_Älverüdi
+Calidris alba_Leeterüdi
+Calidris alpina_Soorüdi
+Calidris bairdii_Eskimo rüdi
+Calidris canutus_Suurrüdi
+Calidris falcinellus_Plütt
+Calidris ferruginea_Kõvernokk-rüdi
+Calidris fuscicollis_Valgepära-rüdi
+Calidris himantopus_Pikkjalg-rüdi
+Calidris maritima_Merirüdi
+Calidris mauri_Alaska rüdi
+Calidris melanotos_Kiripugu-rüdi
+Calidris minuta_Väikerüdi
+Calidris minutilla_Pisirüdi
+Calidris ptilocnemis_Tuhkrüdi
+Calidris pugnax_Tutkas
+Calidris pusilla_Hallrüdi
+Calidris pygmaea_Luitsnokk-rüdi
+Calidris ruficollis_Punakael-rüdi
+Calidris subminuta_Siberi rüdi
+Calidris subruficollis_Ruugerüdi
+Calidris temminckii_Värbrüdi
+Calidris tenuirostris_Hiidrüdi
+Calidris virgata_Kaljurüdi
 Caligavis chrysops_Yellow-faced Honeyeater
 Caligavis subfrenata_Black-throated Honeyeater
-Callacanthis burtoni_Spectacled Finch
-Callaeas wilsoni_North Island Kokako
-Calliope calliope_Siberian Rubythroat
-Calliope pectardens_Firethroat
-Calliope pectoralis_Himalayan Rubythroat
-Calliope tschebaiewi_Chinese Rubythroat
-Callipepla californica_California Quail
-Callipepla douglasii_Elegant Quail
-Callipepla gambelii_Gambel's Quail
-Callipepla squamata_Scaled Quail
-Callocephalon fimbriatum_Gang-gang Cockatoo
-Calocitta colliei_Black-throated Magpie-Jay
-Calocitta formosa_White-throated Magpie-Jay
-Calonectris diomedea_Cory's Shearwater
+Callacanthis burtoni_Seedrileevike
+Callaeas wilsoni_Sinisagar-kookako
+Calliope calliope_Rubiinööbik
+Calliope pectardens_Tulikurk-ööbik
+Calliope pectoralis_Artšaööbik
+Calliope tschebaiewi_Tiibeti ööbik
+Callipepla californica_Kalifornia tuttvutt
+Callipepla douglasii_Võsa-tuttvutt
+Callipepla gambelii_Kõrbe-tuttvutt
+Callipepla squamata_Soomus-tuttvutt
+Callocephalon fimbriatum_Kiiverkakaduu
+Calocitta colliei_Mustkurk-haraknäär
+Calocitta formosa_Haraknäär
+Calonectris diomedea_Atlantise tormilind
 Caloramphus fuliginosus_Brown Barbet
-Calothorax lucifer_Lucifer Hummingbird
-Calypte anna_Anna's Hummingbird
-Calypte costae_Costa's Hummingbird
-Calyptomena viridis_Green Broadbill
-Calyptomena whiteheadi_Whitehead's Broadbill
+Calothorax lucifer_Põhja-kõnnukoolibri
+Calypte anna_Roosapea-koolibri
+Calypte costae_Kõrbekoolibri
+Calyptomena viridis_Viigi-lainokk
+Calyptomena whiteheadi_Suur-lainokk
 Calyptophilus frugivorus_Eastern Chat-Tanager
 Calyptophilus tertius_Western Chat-Tanager
-Calyptorhynchus banksii_Red-tailed Black-Cockatoo
-Calyptorhynchus funereus_Yellow-tailed Black-Cockatoo
-Calyptorhynchus lathami_Glossy Black-Cockatoo
-Calyptorhynchus latirostris_Carnaby's Black-Cockatoo
+Calyptorhynchus banksii_Käharkakaduu
+Calyptorhynchus funereus_Mustkakaduu
+Calyptorhynchus lathami_Kasuariinikakaduu
+Calyptorhynchus latirostris_Nõmme-mustkakaduu
 Camaroptera brachyura_Green-backed Camaroptera
 Camaroptera chloronota_Olive-green Camaroptera
 Camaroptera superciliaris_Yellow-browed Camaroptera
 Campephaga flava_Black Cuckooshrike
 Campephaga quiscalina_Purple-throated Cuckooshrike
-Campephilus gayaquilensis_Guayaquil Woodpecker
-Campephilus guatemalensis_Pale-billed Woodpecker
-Campephilus haematogaster_Crimson-bellied Woodpecker
-Campephilus leucopogon_Cream-backed Woodpecker
-Campephilus magellanicus_Magellanic Woodpecker
-Campephilus melanoleucos_Crimson-crested Woodpecker
-Campephilus pollens_Powerful Woodpecker
-Campephilus robustus_Robust Woodpecker
-Campephilus rubricollis_Red-necked Woodpecker
-Campethera abingoni_Golden-tailed Woodpecker
-Campethera cailliautii_Green-backed Woodpecker
-Campethera mombassica_Mombasa Woodpecker
-Campethera nubica_Nubian Woodpecker
+Campephilus gayaquilensis_Ekuadori kuningrähn
+Campephilus guatemalensis_Helenokk-kuningrähn
+Campephilus haematogaster_Punaselg-kuningrähn
+Campephilus leucopogon_Chaco kuningrähn
+Campephilus magellanicus_Pöögi-kuningrähn
+Campephilus melanoleucos_Vöötkõht-kuningrähn
+Campephilus pollens_Mägi-kuningrähn
+Campephilus robustus_Araukaaria-kuningrähn
+Campephilus rubricollis_Selva-kuningrähn
+Campethera abingoni_Salu-helmesrähn
+Campethera cailliautii_Väike-helmesrähn
+Campethera mombassica_Ranniku-helmesrähn
+Campethera nubica_Akaatsia-helmesrähn
 Camptostoma imberbe_Northern Beardless-Tyrannulet
 Camptostoma obsoletum_Southern Beardless-Tyrannulet
-Campylopterus falcatus_Lazuline Sabrewing
-Campylopterus hemileucurus_Violet Sabrewing
-Campylopterus largipennis_Gray-breasted Sabrewing
+Campylopterus falcatus_Ruskesaba-saabelkoolibri
+Campylopterus hemileucurus_Sini-saabelkoolibri
+Campylopterus largipennis_Amasoonia saabelkoolibri
 Campylorhamphus falcularius_Black-billed Scythebill
 Campylorhamphus procurvoides_Curve-billed Scythebill
 Campylorhamphus pusillus_Brown-billed Scythebill
 Campylorhamphus trochilirostris_Red-billed Scythebill
-Campylorhynchus albobrunneus_White-headed Wren
-Campylorhynchus brunneicapillus_Cactus Wren
-Campylorhynchus chiapensis_Giant Wren
-Campylorhynchus fasciatus_Fasciated Wren
-Campylorhynchus griseus_Bicolored Wren
-Campylorhynchus gularis_Spotted Wren
-Campylorhynchus jocosus_Boucard's Wren
-Campylorhynchus megalopterus_Gray-barred Wren
-Campylorhynchus nuchalis_Stripe-backed Wren
-Campylorhynchus rufinucha_Rufous-naped Wren
-Campylorhynchus turdinus_Thrush-like Wren
-Campylorhynchus yucatanicus_Yucatan Wren
-Campylorhynchus zonatus_Band-backed Wren
-Canachites canadensis_Spruce Grouse
+Campylorhynchus albobrunneus_Valgepea-käblik
+Campylorhynchus brunneicapillus_Kaktusekäblik
+Campylorhynchus chiapensis_Chiapase suurkäblik
+Campylorhynchus fasciatus_Peruu vöötkäblik
+Campylorhynchus griseus_Suurkäblik
+Campylorhynchus gularis_Pruunkiird-käblik
+Campylorhynchus jocosus_Misteegi käblik
+Campylorhynchus megalopterus_Männi-vöötkäblik
+Campylorhynchus nuchalis_Hallsilm-vöötkäblik
+Campylorhynchus rufinucha_Kirjukäblik
+Campylorhynchus turdinus_Rästaskäblik
+Campylorhynchus yucatanicus_Rannikukäblik
+Campylorhynchus zonatus_Vöötkäblik
+Canachites canadensis_Kuusepüü
 Canis latrans_Coyote
 Canis lupus_Gray Wolf
 Cantorchilus elutus_Isthmian Wren
-Cantorchilus guarayanus_Fawn-breasted Wren
-Cantorchilus leucopogon_Stripe-throated Wren
-Cantorchilus leucotis_Buff-breasted Wren
-Cantorchilus longirostris_Long-billed Wren
-Cantorchilus modestus_Cabanis's Wren
-Cantorchilus nigricapillus_Bay Wren
-Cantorchilus semibadius_Riverside Wren
-Cantorchilus superciliaris_Superciliated Wren
-Cantorchilus thoracicus_Stripe-breasted Wren
-Cantorchilus zeledoni_Canebrake Wren
-Capito auratus_Gilded Barbet
-Capito aurovirens_Scarlet-crowned Barbet
-Capito dayi_Black-girdled Barbet
-Capito hypoleucus_White-mantled Barbet
-Capito niger_Black-spotted Barbet
-Capito quinticolor_Five-colored Barbet
-Capito squamatus_Orange-fronted Barbet
-Capito wallacei_Scarlet-banded Barbet
-Caprimulgus affinis_Savanna Nightjar
-Caprimulgus asiaticus_Indian Nightjar
-Caprimulgus atripennis_Jerdon's Nightjar
-Caprimulgus clarus_Slender-tailed Nightjar
-Caprimulgus climacurus_Long-tailed Nightjar
+Cantorchilus guarayanus_Varzeakäblik
+Cantorchilus leucopogon_Triipkurk-käblik
+Cantorchilus leucotis_Kaldakäblik
+Cantorchilus longirostris_Kaatingakäblik
+Cantorchilus modestus_Keskameerika käblik
+Cantorchilus nigricapillus_Ojakäblik
+Cantorchilus semibadius_Jõgikäblik
+Cantorchilus superciliaris_Valgepõsk-käblik
+Cantorchilus thoracicus_Tumekäblik
+Cantorchilus zeledoni_Rookäblik
+Capito auratus_Tulikurk-parbelind
+Capito aurovirens_Oliiv-parbelind
+Capito dayi_Brasiilia parbelind
+Capito hypoleucus_Vandelnokk-parbelind
+Capito niger_Guajaana parbelind
+Capito quinticolor_Koldkõht-parbelind
+Capito squamatus_Valgeselg-parbelind
+Capito wallacei_Loreto parbelind
+Caprimulgus affinis_Rohtla-öösorr
+Caprimulgus asiaticus_Džungli-öösorr
+Caprimulgus atripennis_Draviidi öösorr
+Caprimulgus clarus_Pügalsaba-öösorr
+Caprimulgus climacurus_Händ-öösorr
 Caprimulgus europaeus_Öösorr
-Caprimulgus fossii_Square-tailed Nightjar
-Caprimulgus indicus_Jungle Nightjar
+Caprimulgus fossii_Kiilsaba-öösorr
+Caprimulgus indicus_Ida-öösorr
 Caprimulgus jotaka_Gray Nightjar
-Caprimulgus macrurus_Large-tailed Nightjar
-Caprimulgus madagascariensis_Madagascar Nightjar
-Caprimulgus manillensis_Philippine Nightjar
-Caprimulgus natalensis_Swamp Nightjar
-Caprimulgus nigriscapularis_Black-shouldered Nightjar
-Caprimulgus pectoralis_Fiery-necked Nightjar
-Caprimulgus poliocephalus_Abyssinian Nightjar
-Caprimulgus ruficollis_Red-necked Nightjar
-Caprimulgus rufigena_Rufous-cheeked Nightjar
-Caprimulgus tristigma_Freckled Nightjar
+Caprimulgus macrurus_Kagu-öösorr
+Caprimulgus madagascariensis_Madagaskari öösorr
+Caprimulgus manillensis_Filipiini öösorr
+Caprimulgus natalensis_Soo-öösorr
+Caprimulgus nigriscapularis_Ruuge-öösorr
+Caprimulgus pectoralis_Vile-öösorr
+Caprimulgus poliocephalus_Mägi-öösorr
+Caprimulgus ruficollis_Punakael-öösorr
+Caprimulgus rufigena_Lõuna-öösorr
+Caprimulgus tristigma_Kalju-öösorr
 Capsiempis flaveola_Yellow Tyrannulet
-Caracara plancus_Crested Caracara
-Cardellina canadensis_Canada Warbler
-Cardellina pusilla_Wilson's Warbler
-Cardellina rubra_Red Warbler
+Caracara plancus_Tutt-karakaara
+Cardellina canadensis_Viirpugu-säälik
+Cardellina pusilla_Pajusäälik
+Cardellina rubra_Punasäälik
 Cardellina rubrifrons_Red-faced Warbler
-Cardellina versicolor_Pink-headed Warbler
-Cardinalis cardinalis_Northern Cardinal
+Cardellina versicolor_Roosasäälik
+Cardinalis cardinalis_Kardinal
 Cardinalis phoeniceus_Vermilion Cardinal
 Cardinalis sinuatus_Pyrrhuloxia
 Carduelis carduelis_Ohakalind
-Carduelis citrinella_Citril Finch
-Carduelis corsicana_Corsican Finch
-Cariama cristata_Red-legged Seriema
-Carpococcyx radiceus_Bornean Ground-Cuckoo
-Carpococcyx renauldi_Coral-billed Ground-Cuckoo
-Carpodacus dubius_Chinese White-browed Rosefinch
-Carpodacus erythrinus_Common Rosefinch
-Carpodacus puniceus_Red-fronted Rosefinch
-Carpodacus rodochroa_Pink-browed Rosefinch
-Carpodacus rubicilla_Great Rosefinch
-Carpodacus rubicilloides_Streaked Rosefinch
-Carpodacus sibiricus_Long-tailed Rosefinch
-Carpodacus synoicus_Sinai Rosefinch
-Carpodacus thura_Himalayan White-browed Rosefinch
-Carpornis cucullata_Hooded Berryeater
-Carpornis melanocephala_Black-headed Berryeater
-Carpospiza brachydactyla_Pale Rockfinch
-Carterornis chrysomela_Golden Monarch
-Carterornis leucotis_White-eared Monarch
-Carterornis pileatus_White-naped Monarch
+Carduelis citrinella_Kuusevint
+Carduelis corsicana_Türreeni vint
+Cariama cristata_Tuttserieema
+Carpococcyx radiceus_Vööt-redukägu
+Carpococcyx renauldi_Suur-redukägu
+Carpodacus dubius_Gansu karmiinleevike
+Carpodacus erythrinus_Karmiinleevike
+Carpodacus puniceus_Liustiku-karmiinleevike
+Carpodacus rodochroa_Himaalaja karmiinleevike
+Carpodacus rubicilla_Suur-karmiinleevike
+Carpodacus rubicilloides_Tähnik-karmiinleevike
+Carpodacus sibiricus_Sabaleevike
+Carpodacus synoicus_Hele-karmiinleevike
+Carpodacus thura_Valgekulm-karmiinleevike
+Carpornis cucullata_Pruunselg-karbuskotinga
+Carpornis melanocephala_Roheselg-karbuskotinga
+Carpospiza brachydactyla_Kõnnuvarblane
+Carterornis chrysomela_Kuldpiibik
+Carterornis leucotis_Võrapiibik
+Carterornis pileatus_Laikpea-piibik
 Caryothraustes canadensis_Yellow-green Grosbeak
 Caryothraustes poliogaster_Black-faced Grosbeak
-Casiornis rufus_Rufous Casiornis
-Cassiculus melanicterus_Yellow-winged Cacique
-Casuarius casuarius_Southern Cassowary
+Casiornis rufus_Lõuna-kaneeltikat
+Cassiculus melanicterus_Tutt-turpial
+Casuarius casuarius_Kiiverkaasuar
 Catamblyrhynchus diadema_Plushcap
 Catamenia analis_Band-tailed Seedeater
 Catamenia homochroa_Paramo Seedeater
 Catamenia inornata_Plain-colored Seedeater
-Cathartes aura_Turkey Vulture
-Catharus aurantiirostris_Orange-billed Nightingale-Thrush
-Catharus bicknelli_Bicknell's Thrush
-Catharus dryas_Yellow-throated Nightingale-Thrush
-Catharus frantzii_Ruddy-capped Nightingale-Thrush
-Catharus fuscater_Slaty-backed Nightingale-Thrush
-Catharus fuscescens_Veery
-Catharus gracilirostris_Black-billed Nightingale-Thrush
-Catharus guttatus_Hermit Thrush
+Cathartes aura_Kalkunkondor
+Catharus aurantiirostris_Ruugenokk-värbrästas
+Catharus bicknelli_Laanerästas
+Catharus dryas_Mustpea-värbrästas
+Catharus frantzii_Kuru-värbrästas
+Catharus fuscater_Hall-värbrästas
+Catharus fuscescens_Väikerästas
+Catharus gracilirostris_Mustnokk-värbrästas
+Catharus guttatus_Erakrästas
 Catharus maculatus_Speckled Nightingale-Thrush
-Catharus mexicanus_Black-headed Nightingale-Thrush
-Catharus minimus_Gray-cheeked Thrush
-Catharus occidentalis_Russet Nightingale-Thrush
-Catharus ustulatus_Swainson's Thrush
-Catherpes mexicanus_Canyon Wren
-Catreus wallichii_Cheer Pheasant
-Cecropis abyssinica_Lesser Striped Swallow
-Cecropis cucullata_Greater Striped Swallow
-Cecropis daurica_Red-rumped Swallow
-Cecropis semirufa_Rufous-chested Swallow
-Cecropis striolata_Striated Swallow
-Celeus castaneus_Chestnut-colored Woodpecker
-Celeus elegans_Chestnut Woodpecker
-Celeus flavescens_Blond-crested Woodpecker
-Celeus flavus_Cream-colored Woodpecker
-Celeus galeatus_Helmeted Woodpecker
-Celeus grammicus_Scale-breasted Woodpecker
-Celeus loricatus_Cinnamon Woodpecker
-Celeus lugubris_Pale-crested Woodpecker
+Catharus mexicanus_Tanu-värbrästas
+Catharus minimus_Tundrarästas
+Catharus occidentalis_Tamme-värbrästas
+Catharus ustulatus_Tsuugarästas
+Catherpes mexicanus_Kanjonikäblik
+Catreus wallichii_Viirfaasan
+Cecropis abyssinica_Väike-roostepääsuke
+Cecropis cucullata_Lõuna-roostepääsuke
+Cecropis daurica_Roostepääsuke
+Cecropis semirufa_Välja-roostepääsuke
+Cecropis striolata_Triip-roostepääsuke
+Celeus castaneus_Tähnik-tutträhn
+Celeus elegans_Ruske-tutträhn
+Celeus flavescens_Tõmmu-tutträhn
+Celeus flavus_Võik-tutträhn
+Celeus galeatus_Väike-musträhn
+Celeus grammicus_Viir-tutträhn
+Celeus loricatus_Punakurk-tutträhn
+Celeus lugubris_Termiidi-tutträhn
 Celeus obrieni_Kaempfer's Woodpecker
-Celeus ochraceus_Ochre-backed Woodpecker
-Celeus spectabilis_Rufous-headed Woodpecker
-Celeus torquatus_Ringed Woodpecker
-Celeus undatus_Waved Woodpecker
-Centrocercus urophasianus_Greater Sage-Grouse
-Centronyx bairdii_Baird's Sparrow
-Centronyx henslowii_Henslow's Sparrow
-Centropus andamanensis_Andaman Coucal
-Centropus bengalensis_Lesser Coucal
-Centropus celebensis_Bay Coucal
-Centropus chlororhynchos_Green-billed Coucal
-Centropus leucogaster_Black-throated Coucal
-Centropus melanops_Black-faced Coucal
-Centropus menbeki_Greater Black Coucal
-Centropus milo_Buff-headed Coucal
-Centropus monachus_Blue-headed Coucal
-Centropus phasianinus_Pheasant Coucal
-Centropus rectunguis_Short-toed Coucal
-Centropus senegalensis_Senegal Coucal
-Centropus sinensis_Greater Coucal
-Centropus superciliosus_White-browed Coucal
-Centropus toulou_Malagasy Coucal
-Centropus viridis_Philippine Coucal
-Cephalopterus penduliger_Long-wattled Umbrellabird
-Cepphus columba_Pigeon Guillemot
-Cepphus grylle_Black Guillemot
-Ceratogymna atrata_Black-casqued Hornbill
-Ceratopipra chloromeros_Round-tailed Manakin
-Ceratopipra cornuta_Scarlet-horned Manakin
-Ceratopipra erythrocephala_Golden-headed Manakin
-Ceratopipra mentalis_Red-capped Manakin
-Ceratopipra rubrocapilla_Red-headed Manakin
-Cercibis oxycerca_Sharp-tailed Ibis
-Cercococcyx mechowi_Dusky Long-tailed Cuckoo
-Cercococcyx montanus_Barred Long-tailed Cuckoo
-Cercococcyx olivinus_Olive Long-tailed Cuckoo
+Celeus ochraceus_Pernambuco tutträhn
+Celeus spectabilis_Bambuse-tutträhn
+Celeus torquatus_Mustpugu-tutträhn
+Celeus undatus_Kirju-tutträhn
+Centrocercus urophasianus_Pujupüü
+Centronyx bairdii_Rohtlasidrik
+Centronyx henslowii_Söödisidrik
+Centropus andamanensis_Andamani kannuskägu
+Centropus bengalensis_Väike-kannuskägu
+Centropus celebensis_Sulawesi kannuskägu
+Centropus chlororhynchos_Vandelnokk-kannuskägu
+Centropus leucogaster_Mustpugu-kannuskägu
+Centropus melanops_Mask-kannuskägu
+Centropus menbeki_Menebiki-kannuskägu
+Centropus milo_Saalomonisaarte kannuskägu
+Centropus monachus_Sinipea-kannuskägu
+Centropus phasianinus_Faasan-kannuskägu
+Centropus rectunguis_Lodu-kannuskägu
+Centropus senegalensis_Rohu-kannuskägu
+Centropus sinensis_Punaselg-kannuskägu
+Centropus superciliosus_Valgekulm-kannuskägu
+Centropus toulou_Madagaskari kannuskägu
+Centropus viridis_Filipiini kannuskägu
+Cephalopterus penduliger_Lokut-sirmilind
+Cepphus columba_Kirdekrüüsel
+Cepphus grylle_Krüüsel
+Ceratogymna atrata_Must-kiiverlind
+Ceratopipra chloromeros_Ümarsaba-tantsulind
+Ceratopipra cornuta_Lakk-tantsulind
+Ceratopipra erythrocephala_Kuldpea-tantsulind
+Ceratopipra mentalis_Koldpüks-tantsulind
+Ceratopipra rubrocapilla_Punapea-tantsulind
+Cercibis oxycerca_Händiibis
+Cercococcyx mechowi_Jõgi-händkägu
+Cercococcyx montanus_Mägi-händkägu
+Cercococcyx olivinus_Oliiv-händkägu
 Cercomacra brasiliana_Rio de Janeiro Antbird
 Cercomacra carbonaria_Rio Branco Antbird
 Cercomacra cinerascens_Gray Antbird
@@ -1101,222 +1101,222 @@ Cercomacroides nigrescens_Blackish Antbird
 Cercomacroides parkeri_Parker's Antbird
 Cercomacroides serva_Black Antbird
 Cercomacroides tyrannina_Dusky Antbird
-Cercotrichas barbata_Miombo Scrub-Robin
-Cercotrichas coryphoeus_Karoo Scrub-Robin
-Cercotrichas galactotes_Rufous-tailed Scrub-Robin
-Cercotrichas hartlaubi_Brown-backed Scrub-Robin
-Cercotrichas leucophrys_Red-backed Scrub-Robin
-Cercotrichas paena_Kalahari Scrub-Robin
-Cercotrichas podobe_Black Scrub-Robin
-Cercotrichas quadrivirgata_Bearded Scrub-Robin
-Cercotrichas signata_Brown Scrub-Robin
-Certhia americana_Brown Creeper
-Certhia brachydactyla_Short-toed Treecreeper
-Certhia discolor_Sikkim Treecreeper
+Cercotrichas barbata_Miombo-võsaööbik
+Cercotrichas coryphoeus_Karoo võsaööbik
+Cercotrichas galactotes_Võsaööbik
+Cercotrichas hartlaubi_Hirsi-võsaööbik
+Cercotrichas leucophrys_Akaatsia-võsaööbik
+Cercotrichas paena_Kalahari võsaööbik
+Cercotrichas podobe_Must-võsaööbik
+Cercotrichas quadrivirgata_Ruuge-võsaööbik
+Cercotrichas signata_Suur-võsaööbik
+Certhia americana_Ameerika porr
+Certhia brachydactyla_Aedporr
+Certhia discolor_Tõmmuporr
 Certhia familiaris_Porr
-Certhia himalayana_Bar-tailed Treecreeper
-Certhia hodgsoni_Hodgson's Treecreeper
-Certhia manipurensis_Hume's Treecreeper
+Certhia himalayana_Vöötsaba-porr
+Certhia hodgsoni_Mägiporr
+Certhia manipurensis_Kaguporr
 Certhiasomus stictolaemus_Spot-throated Woodcreeper
 Certhiaxis cinnamomeus_Yellow-chinned Spinetail
 Certhiaxis mustelinus_Red-and-white Spinetail
-Certhilauda chuana_Short-clawed Lark
-Certhilauda semitorquata_Eastern Long-billed Lark
-Certhilauda subcoronata_Karoo Long-billed Lark
+Certhilauda chuana_Tsvaana lõoke
+Certhilauda semitorquata_Sotho lõoke
+Certhilauda subcoronata_Karoo lõoke
 Certhionyx variegatus_Pied Honeyeater
-Ceryle rudis_Pied Kingfisher
-Cettia brunnifrons_Gray-sided Bush Warbler
-Cettia castaneocoronata_Chestnut-headed Tesia
-Cettia cetti_Cetti's Warbler
-Cettia major_Chestnut-crowned Bush Warbler
-Ceuthmochares aereus_Blue Malkoha
+Ceryle rudis_Kirju-kuningkalur
+Cettia brunnifrons_Hallkülg-rädilind
+Cettia castaneocoronata_Punapea-rädilind
+Cettia cetti_Kalda-rädilind
+Cettia major_Rododendroni-rädilind
+Ceuthmochares aereus_Aafrika malkohakägu
 Ceuthmochares australis_Green Malkoha
-Ceyx azureus_Azure Kingfisher
-Ceyx erithaca_Black-backed Dwarf-Kingfisher
-Chaetocercus mulsant_White-bellied Woodstar
+Ceyx azureus_Lõuna-jäälind
+Ceyx erithaca_Ritsika-jäälind
+Chaetocercus mulsant_Suur-töbikoolibri
 Chaetops frenatus_Cape Rockjumper
-Chaetura brachyura_Short-tailed Swift
-Chaetura chapmani_Chapman's Swift
-Chaetura cinereiventris_Gray-rumped Swift
-Chaetura meridionalis_Sick's Swift
-Chaetura pelagica_Chimney Swift
-Chaetura spinicaudus_Band-rumped Swift
-Chaetura vauxi_Vaux's Swift
-Chalcomitra amethystina_Amethyst Sunbird
+Chaetura brachyura_Nudi-kammsaba
+Chaetura chapmani_Siid-kammsaba
+Chaetura cinereiventris_Läik-kammsaba
+Chaetura meridionalis_Lõuna-kammsaba
+Chaetura pelagica_Korstna-kammsaba
+Chaetura spinicaudus_Laikselg-kammsaba
+Chaetura vauxi_Lääne-kammsaba
+Chalcomitra amethystina_Õlak-nektarilind
 Chalcomitra senegalensis_Scarlet-chested Sunbird
-Chalcoparia singalensis_Ruby-cheeked Sunbird
-Chalcophaps indica_Asian Emerald Dove
+Chalcoparia singalensis_Lühinokk-nektarilind
+Chalcophaps indica_Smaragdtuvi
 Chalcophaps longirostris_Pacific Emerald Dove
-Chalcophaps stephani_Stephan's Dove
-Chalybura buffonii_White-vented Plumeleteer
-Chalybura urochrysia_Bronze-tailed Plumeleteer
+Chalcophaps stephani_Mets-smaragdtuvi
+Chalybura buffonii_Salu-kapralkoolibri
+Chalybura urochrysia_Punajalg-kapralkoolibri
 Chamaea fasciata_Wrentit
-Chamaepetes goudotii_Sickle-winged Guan
-Chamaepetes unicolor_Black Guan
-Chamaetylas fuelleborni_White-chested Alethe
-Chamaetylas poliocephala_Brown-chested Alethe
+Chamaepetes goudotii_Punakõht-nõlvahoko
+Chamaepetes unicolor_Must-nõlvahoko
+Chamaetylas fuelleborni_Valgepugu-sipelgaööbik
+Chamaetylas poliocephala_Helekulm-sipelgaööbik
 Chamaeza campanisona_Short-tailed Antthrush
 Chamaeza meruloides_Such's Antthrush
 Chamaeza mollissima_Barred Antthrush
 Chamaeza nobilis_Striated Antthrush
 Chamaeza ruficauda_Rufous-tailed Antthrush
 Chamaeza turdina_Schwartz's Antthrush
-Charadrius alexandrinus_Kentish Plover
-Charadrius bicinctus_Double-banded Plover
-Charadrius collaris_Collared Plover
-Charadrius dubius_Little Ringed Plover
-Charadrius falklandicus_Two-banded Plover
-Charadrius hiaticula_Common Ringed Plover
-Charadrius javanicus_Javan Plover
-Charadrius leschenaultii_Greater Sand-Plover
-Charadrius melodus_Piping Plover
-Charadrius modestus_Rufous-chested Dotterel
-Charadrius mongolus_Lesser Sand-Plover
-Charadrius montanus_Mountain Plover
-Charadrius morinellus_Eurasian Dotterel
-Charadrius nivosus_Snowy Plover
-Charadrius peronii_Malaysian Plover
-Charadrius placidus_Long-billed Plover
-Charadrius semipalmatus_Semipalmated Plover
-Charadrius tricollaris_Three-banded Plover
-Charadrius veredus_Oriental Plover
-Charadrius vociferus_Killdeer
-Charadrius wilsonia_Wilson's Plover
+Charadrius alexandrinus_Mustjalg-tüll
+Charadrius bicinctus_Erisvöö-tüll
+Charadrius collaris_Värbtüll
+Charadrius dubius_Väiketüll
+Charadrius falklandicus_Lõunatüll
+Charadrius hiaticula_Liivatüll
+Charadrius javanicus_Jaava tüll
+Charadrius leschenaultii_Kõrbetüll
+Charadrius melodus_Hõbetüll
+Charadrius modestus_Ruskepugu-tüll
+Charadrius mongolus_Mägitüll
+Charadrius montanus_Preeriatüll
+Charadrius morinellus_Roosterind-tüll
+Charadrius nivosus_Ameerika mustjalg-tüll
+Charadrius peronii_Malai tüll
+Charadrius placidus_Idatüll
+Charadrius semipalmatus_Ameerika tundratüll
+Charadrius tricollaris_Vöötpugu-tüll
+Charadrius veredus_Kõnnutüll
+Charadrius vociferus_Kilatüll
+Charadrius wilsonia_Krabitüll
 Charitospiza eucosma_Coal-crested Finch
-Charmosyna papou_Papuan Lorikeet
+Charmosyna papou_Niitsaba-nestepapagoi
 Chasiempis ibidis_Oahu Elepaio
 Chasiempis sandwichensis_Hawaii Elepaio
 Chasiempis sclateri_Kauai Elepaio
-Chauna chavaria_Northern Screamer
-Chauna torquata_Southern Screamer
-Chelidoptera tenebrosa_Swallow-winged Puffbird
+Chauna chavaria_Tutt-ogatiib
+Chauna torquata_Kaelus-ogatiib
+Chelidoptera tenebrosa_Pääsu-puhvlind
 Chelidorhynx hypoxanthus_Yellow-bellied Fairy-Fantail
-Chenonetta jubata_Maned Duck
-Chersomanes albofasciata_Spike-heeled Lark
-Chersophilus duponti_Dupont's Lark
-Chionomesa fimbriata_Glittering-throated Emerald
-Chionomesa lactea_Sapphire-spangled Emerald
-Chiroxiphia boliviana_Yungas Manakin
-Chiroxiphia caudata_Swallow-tailed Manakin
-Chiroxiphia lanceolata_Lance-tailed Manakin
-Chiroxiphia linearis_Long-tailed Manakin
-Chiroxiphia pareola_Blue-backed Manakin
-Chlamydera maculata_Spotted Bowerbird
-Chlamydera nuchalis_Great Bowerbird
-Chlidonias albostriatus_Black-fronted Tern
-Chlidonias hybrida_Whiskered Tern
-Chlidonias leucopterus_White-winged Tern
-Chlidonias niger_Black Tern
-Chloephaga picta_Upland Goose
-Chlorestes candida_White-bellied Emerald
-Chlorestes cyanus_White-chinned Sapphire
-Chlorestes eliciae_Blue-throated Goldentail
-Chlorestes julie_Violet-bellied Hummingbird
-Chlorestes notata_Blue-chinned Sapphire
+Chenonetta jubata_Rohupart
+Chersomanes albofasciata_Kannuslõoke
+Chersophilus duponti_Pujulõoke
+Chionomesa fimbriata_Hõrendiku-safiirkoolibri
+Chionomesa lactea_Violettkurk-safiirkoolibri
+Chiroxiphia boliviana_Mägi-tantsulind
+Chiroxiphia caudata_Sini-tantsulind
+Chiroxiphia lanceolata_Piiksaba-tantsulind
+Chiroxiphia linearis_Paelsaba-tantsulind
+Chiroxiphia pareola_Siniselg-tantsulind
+Chlamydera maculata_Akaatsia-lehtlalind
+Chlamydera nuchalis_Suur-lehtlalind
+Chlidonias albostriatus_Virdviires
+Chlidonias hybrida_Habeviires
+Chlidonias leucopterus_Valgetiib-viires
+Chlidonias niger_Mustviires
+Chloephaga picta_Niidu-nösuhani
+Chlorestes candida_Selva-safiirkoolibri
+Chlorestes cyanus_Vaskselg-safiirkoolibri
+Chlorestes eliciae_Kuldsaba-safiirkoolibri
+Chlorestes julie_Sinikõht-safiirkoolibri
+Chlorestes notata_Indigo-safiirkoolibri
 Chloris chloris_Rohevint
-Chloris monguilloti_Vietnamese Greenfinch
-Chloris sinica_Oriental Greenfinch
-Chloris spinoides_Yellow-breasted Greenfinch
-Chloroceryle aenea_American Pygmy Kingfisher
-Chloroceryle amazona_Amazon Kingfisher
-Chloroceryle americana_Green Kingfisher
-Chloroceryle inda_Green-and-rufous Kingfisher
+Chloris monguilloti_Annami rohevint
+Chloris sinica_Ida-rohevint
+Chloris spinoides_Mägi-rohevint
+Chloroceryle aenea_Kääbus-kuningkalur
+Chloroceryle amazona_Laulu-kuningkalur
+Chloroceryle americana_Väike-kuningkalur
+Chloroceryle inda_Punakõht-kuningkalur
 Chlorochrysa phoenicotis_Glistening-green Tanager
-Chlorocichla flaviventris_Yellow-bellied Greenbul
-Chlorocichla laetissima_Joyful Greenbul
-Chlorocichla simplex_Simple Greenbul
-Chlorodrepanis flava_Oahu Amakihi
-Chlorodrepanis stejnegeri_Kauai Amakihi
-Chlorodrepanis virens_Hawaii Amakihi
+Chlorocichla flaviventris_Bantu viherbülbül
+Chlorocichla laetissima_Kuld-viherbülbül
+Chlorocichla simplex_Maavitsa-viherbülbül
+Chlorodrepanis flava_Oahu amakihi-nestevint
+Chlorodrepanis stejnegeri_Kauai amakihi-nestevint
+Chlorodrepanis virens_Amakihi-nestevint
 Chlorophanes spiza_Green Honeycreeper
-Chlorophonia callophrys_Golden-browed Chlorophonia
-Chlorophonia cyanea_Blue-naped Chlorophonia
-Chlorophonia cyanocephala_Golden-rumped Euphonia
-Chlorophonia elegantissima_Elegant Euphonia
-Chlorophonia flavirostris_Yellow-collared Chlorophonia
-Chlorophonia musica_Antillean Euphonia
-Chlorophonia occipitalis_Blue-crowned Chlorophonia
-Chlorophonia pyrrhophrys_Chestnut-breasted Chlorophonia
+Chlorophonia callophrys_Kuldkulm-marjavint
+Chlorophonia cyanea_Sinikukal-marjavint
+Chlorophonia cyanocephala_Kuldselg-marjavint
+Chlorophonia elegantissima_Ruugekõht-marjavint
+Chlorophonia flavirostris_Punanokk-marjavint
+Chlorophonia musica_Sinipea-marjavint
+Chlorophonia occipitalis_Smaragd-marjavint
+Chlorophonia pyrrhophrys_Mägi-marjavint
 Chloropicus fuscescens_Cardinal Woodpecker
 Chloropicus goertae_African Gray Woodpecker
 Chloropicus griseocephalus_Olive Woodpecker
-Chloropicus namaquus_Bearded Woodpecker
+Chloropicus namaquus_Savanni-pruunrähn
 Chloropicus spodocephalus_Mountain Gray Woodpecker
-Chloropsis aurifrons_Golden-fronted Leafbird
-Chloropsis cochinchinensis_Blue-winged Leafbird
-Chloropsis cyanopogon_Lesser Green Leafbird
-Chloropsis hardwickii_Orange-bellied Leafbird
-Chloropsis jerdoni_Jerdon's Leafbird
-Chloropsis sonnerati_Greater Green Leafbird
-Chlorornis riefferii_Grass-green Tanager
-Chlorospingus canigularis_Ashy-throated Chlorospingus
-Chlorospingus flavigularis_Yellow-throated Chlorospingus
-Chlorospingus flavopectus_Common Chlorospingus
-Chlorospingus pileatus_Sooty-capped Chlorospingus
-Chlorospingus semifuscus_Dusky Chlorospingus
-Chlorostilbon gibsoni_Red-billed Emerald
-Chlorostilbon lucidus_Glittering-bellied Emerald
-Chlorostilbon mellisugus_Blue-tailed Emerald
+Chloropsis aurifrons_Tanu-viherlüüdik
+Chloropsis cochinchinensis_Sinitiib-viherlüüdik
+Chloropsis cyanopogon_Väike-viherlüüdik
+Chloropsis hardwickii_Ruugekõht-viherlüüdik
+Chloropsis jerdoni_India viherlüüdik
+Chloropsis sonnerati_Suur-viherlüüdik
+Chlorornis riefferii_Malahhiit-tangara
+Chlorospingus canigularis_Väädi-samblasidrik
+Chlorospingus flavigularis_Koldkurk-samblasidrik
+Chlorospingus flavopectus_Samblasidrik
+Chlorospingus pileatus_Tihas-samblasidrik
+Chlorospingus semifuscus_Tuhk-samblasidrik
+Chlorostilbon gibsoni_Punanokk-smaragdkoolibri
+Chlorostilbon lucidus_Lõuna-smaragdkoolibri
+Chlorostilbon mellisugus_Sinisaba-smaragdkoolibri
 Chlorothraupis carmioli_Carmiol's Tanager
 Chlorothraupis olivacea_Lemon-spectacled Tanager
 Chlorothraupis stolzmanni_Ochre-breasted Tanager
-Cholornis unicolor_Brown Parrotbill
-Chondestes grammacus_Lark Sparrow
-Chondrohierax uncinatus_Hook-billed Kite
-Chordeiles acutipennis_Lesser Nighthawk
-Chordeiles gundlachii_Antillean Nighthawk
-Chordeiles minor_Common Nighthawk
-Chordeiles nacunda_Nacunda Nighthawk
-Chordeiles pusillus_Least Nighthawk
-Chroicocephalus brunnicephalus_Brown-headed Gull
-Chroicocephalus cirrocephalus_Gray-hooded Gull
-Chroicocephalus genei_Slender-billed Gull
-Chroicocephalus maculipennis_Brown-hooded Gull
-Chroicocephalus novaehollandiae_Silver Gull
-Chroicocephalus philadelphia_Bonaparte's Gull
+Cholornis unicolor_Pruun-koonusnokk
+Chondestes grammacus_Lõosidrik
+Chondrohierax uncinatus_Konksnokk-haugas
+Chordeiles acutipennis_Välja-videvikusorr
+Chordeiles gundlachii_Antilli videvikusorr
+Chordeiles minor_Videvikusorr
+Chordeiles nacunda_Suur-videvikusorr
+Chordeiles pusillus_Väike-videvikusorr
+Chroicocephalus brunnicephalus_Mägikajakas
+Chroicocephalus cirrocephalus_Hallpea-kajakas
+Chroicocephalus genei_Salenokk-kajakas
+Chroicocephalus maculipennis_Pampakajakas
+Chroicocephalus novaehollandiae_Punanokk-kajakas
+Chroicocephalus philadelphia_Kuusekajakas
 Chroicocephalus ridibundus_Naerukajakas
-Chroicocephalus serranus_Andean Gull
-Chrysococcyx basalis_Horsfield's Bronze-Cuckoo
-Chrysococcyx caprius_Dideric Cuckoo
-Chrysococcyx cupreus_African Emerald Cuckoo
-Chrysococcyx klaas_Klaas's Cuckoo
-Chrysococcyx lucidus_Shining Bronze-Cuckoo
-Chrysococcyx maculatus_Asian Emerald Cuckoo
-Chrysococcyx minutillus_Little Bronze-Cuckoo
-Chrysococcyx osculans_Black-eared Cuckoo
-Chrysococcyx xanthorhynchus_Violet Cuckoo
-Chrysocolaptes festivus_White-naped Woodpecker
-Chrysocolaptes guttacristatus_Greater Flameback
-Chrysolampis mosquitus_Ruby-topaz Hummingbird
-Chrysolophus amherstiae_Lady Amherst's Pheasant
-Chrysolophus pictus_Golden Pheasant
+Chroicocephalus serranus_Andi kajakas
+Chrysococcyx basalis_Välja-pronkskägu
+Chrysococcyx caprius_Valgerind-rohekägu
+Chrysococcyx cupreus_Kuldkõht-rohekägu
+Chrysococcyx klaas_Väike-rohekägu
+Chrysococcyx lucidus_Ränd-pronkskägu
+Chrysococcyx maculatus_Smaragdkägu
+Chrysococcyx minutillus_Väike-pronkskägu
+Chrysococcyx osculans_Mustkõrv-kägu
+Chrysococcyx xanthorhynchus_Ametüstkägu
+Chrysocolaptes festivus_Valgeturi-sultanrähn
+Chrysocolaptes guttacristatus_Suur-sultanrähn
+Chrysolampis mosquitus_Fööniks-koolibri
+Chrysolophus amherstiae_Teemantfaasan
+Chrysolophus pictus_Kuldfaasan
 Chrysomma altirostre_Jerdon's Babbler
 Chrysomma sinense_Yellow-eyed Babbler
-Chrysomus icterocephalus_Yellow-hooded Blackbird
-Chrysomus ruficapillus_Chestnut-capped Blackbird
-Chrysophlegma flavinucha_Greater Yellownape
+Chrysomus icterocephalus_Kuldpea-turpial
+Chrysomus ruficapillus_Ruskkiird-turpial
+Chrysophlegma flavinucha_Hallkõht-roherähn
 Chrysophlegma mentale_Checker-throated Woodpecker
-Chrysophlegma miniaceum_Banded Woodpecker
+Chrysophlegma miniaceum_Punarähn
 Chrysothlypis chrysomelas_Black-and-yellow Tanager
 Chrysothlypis salmoni_Scarlet-and-white Tanager
-Chrysuronia oenone_Golden-tailed Sapphire
-Chrysuronia versicolor_Versicolored Emerald
-Chunga burmeisteri_Black-legged Seriema
-Ciccaba albitarsis_Rufous-banded Owl
-Ciccaba huhula_Black-banded Owl
-Ciccaba nigrolineata_Black-and-white Owl
-Ciccaba virgata_Mottled Owl
-Cichladusa arquata_Collared Palm-Thrush
-Cichladusa guttata_Spotted Morning-Thrush
+Chrysuronia oenone_Sinipea-safiirkoolibri
+Chrysuronia versicolor_Kampo-safiirkoolibri
+Chunga burmeisteri_Väikeserieema
+Ciccaba albitarsis_Andi metskakk
+Ciccaba huhula_Selvakakk
+Ciccaba nigrolineata_Karbuskakk
+Ciccaba virgata_Välukakk
+Cichladusa arquata_Kee-palmiööbik
+Cichladusa guttata_Täpik-palmiööbik
 Cichlocolaptes leucophrus_Pale-browed Treehunter
-Cichlopsis leucogenys_Rufous-brown Solitaire
-Cicinnurus magnificus_Magnificent Bird-of-Paradise
-Cicinnurus regius_King Bird-of-Paradise
-Cicinnurus respublica_Wilson's Bird-of-Paradise
+Cichlopsis leucogenys_Selvarästas
+Cicinnurus magnificus_Kuld-paradiisilind
+Cicinnurus regius_Karmiin-paradiisilind
+Cicinnurus respublica_Viker-paradiisilind
 Ciconia ciconia_Valge-toonekurg
 Ciconia nigra_Must-toonekurg
-Cinclidium frontale_Blue-fronted Robin
-Cinclocerthia gutturalis_Gray Trembler
+Cinclidium frontale_Redusiirak
+Cinclocerthia gutturalis_Tuhk-pilalind
 Cinclodes albidiventris_Chestnut-winged Cinclodes
 Cinclodes albiventris_Cream-winged Cinclodes
 Cinclodes excelsior_Stout-billed Cinclodes
@@ -1325,184 +1325,184 @@ Cinclodes nigrofumosus_Seaside Cinclodes
 Cinclodes oustaleti_Gray-flanked Cinclodes
 Cinclodes pabsti_Long-tailed Cinclodes
 Cinclodes patagonicus_Dark-bellied Cinclodes
-Cincloramphus cruralis_Brown Songlark
-Cincloramphus macrurus_Papuan Grassbird
-Cincloramphus mathewsi_Rufous Songlark
-Cincloramphus timoriensis_Tawny Grassbird
+Cincloramphus cruralis_Välja-padulind
+Cincloramphus macrurus_Mägi-padulind
+Cincloramphus mathewsi_Lõo-padulind
+Cincloramphus timoriensis_Lammi-padulind
 Cinclosoma ajax_Painted Quail-thrush
 Cinclosoma castaneothorax_Chestnut-breasted Quail-thrush
 Cinclosoma punctatum_Spotted Quail-thrush
 Cinclus cinclus_Vesipapp
-Cinclus mexicanus_American Dipper
-Cinclus pallasii_Brown Dipper
-Cinnycerthia fulva_Fulvous Wren
-Cinnycerthia olivascens_Sharpe's Wren
-Cinnycerthia peruana_Peruvian Wren
-Cinnycerthia unirufa_Rufous Wren
-Cinnyricinclus leucogaster_Violet-backed Starling
-Cinnyris afer_Greater Double-collared Sunbird
-Cinnyris asiaticus_Purple Sunbird
+Cinclus mexicanus_Hall-vesipapp
+Cinclus pallasii_Tõmmu-vesipapp
+Cinnycerthia fulva_Leetkulm-ruugekäblik
+Cinnycerthia olivascens_Tõmmu-ruugekäblik
+Cinnycerthia peruana_Peruu ruugekäblik
+Cinnycerthia unirufa_Valjas-ruugekäblik
+Cinnyricinclus leucogaster_Ametüst-kuldnokk
+Cinnyris afer_Välja-nektarilind
+Cinnyris asiaticus_Sini-nektarilind
 Cinnyris bifasciatus_Purple-banded Sunbird
-Cinnyris chalybeus_Southern Double-collared Sunbird
-Cinnyris chloropygius_Olive-bellied Sunbird
+Cinnyris chalybeus_Lõuna-nektarilind
+Cinnyris chloropygius_Välu-nektarilind
 Cinnyris coccinigastrus_Splendid Sunbird
-Cinnyris cupreus_Copper Sunbird
-Cinnyris erythrocercus_Red-chested Sunbird
-Cinnyris fuscus_Dusky Sunbird
-Cinnyris gertrudis_Western Miombo Sunbird
-Cinnyris habessinicus_Shining Sunbird
-Cinnyris jugularis_Olive-backed Sunbird
-Cinnyris lotenius_Loten's Sunbird
+Cinnyris cupreus_Vask-nektarilind
+Cinnyris erythrocercus_Lammi-nektarilind
+Cinnyris fuscus_Kõnnu-nektarilind
+Cinnyris gertrudis_Miombo-nektarilind
+Cinnyris habessinicus_Kuši nektarilind
+Cinnyris jugularis_Läikpugu-nektarilind
+Cinnyris lotenius_Draviidi nektarilind
 Cinnyris mariquensis_Mariqua Sunbird
-Cinnyris mediocris_Eastern Double-collared Sunbird
+Cinnyris mediocris_Keenia nektarilind
 Cinnyris nectarinioides_Black-bellied Sunbird
-Cinnyris osea_Palestine Sunbird
+Cinnyris osea_Araabia nektarilind
 Cinnyris pulchellus_Beautiful Sunbird
-Cinnyris regius_Regal Sunbird
-Cinnyris reichenowi_Northern Double-collared Sunbird
-Cinnyris solaris_Flame-breasted Sunbird
-Cinnyris sovimanga_Souimanga Sunbird
+Cinnyris regius_Viker-nektarilind
+Cinnyris reichenowi_Kõrgmaa-nektarilind
+Cinnyris solaris_Tulikõht-nektarilind
+Cinnyris sovimanga_Ruskevöö-nektarilind
 Cinnyris talatala_White-breasted Sunbird
-Cinnyris venustus_Variable Sunbird
-Circaetus gallicus_Short-toed Snake-Eagle
+Cinnyris venustus_Eris-nektarilind
+Circaetus gallicus_Madukotkas
 Circus aeruginosus_Roo-loorkull
-Circus approximans_Swamp Harrier
-Circus buffoni_Long-winged Harrier
+Circus approximans_Lõuna-loorkull
+Circus buffoni_Pale-loorkull
 Circus cyaneus_Välja-loorkull
-Circus hudsonius_Northern Harrier
-Circus macrourus_Pallid Harrier
-Circus melanoleucos_Pied Harrier
-Circus pygargus_Montagu's Harrier
-Circus spilonotus_Eastern Marsh-Harrier
-Cissa chinensis_Common Green-Magpie
-Cissa hypoleuca_Indochinese Green-Magpie
+Circus hudsonius_Ameerika loorkull
+Circus macrourus_Stepi-loorkull
+Circus melanoleucos_Pugal-loorkull
+Circus pygargus_Soo-loorkull
+Circus spilonotus_Ida-loorkull
+Cissa chinensis_Roheharakas
+Cissa hypoleuca_Vietnami roheharakas
 Cissa jefferyi_Bornean Green-Magpie
-Cissopis leverianus_Magpie Tanager
-Cisticola aberrans_Rock-loving Cisticola
+Cissopis leverianus_Haraktangara
+Cisticola aberrans_Nõlva-rohulind
 Cisticola anonymus_Chattering Cisticola
-Cisticola aridulus_Desert Cisticola
-Cisticola ayresii_Wing-snapping Cisticola
-Cisticola brachypterus_Siffling Cisticola
+Cisticola aridulus_Kõnnu-rohulind
+Cisticola ayresii_Häälistiib-rohulind
+Cisticola brachypterus_Välu-rohulind
 Cisticola cantans_Singing Cisticola
-Cisticola cherina_Madagascar Cisticola
+Cisticola cherina_Madagaskari rohulind
 Cisticola chiniana_Rattling Cisticola
 Cisticola chubbi_Chubb's Cisticola
-Cisticola cinereolus_Ashy Cisticola
+Cisticola cinereolus_Tuhk-rohulind
 Cisticola erythrops_Red-faced Cisticola
-Cisticola exilis_Golden-headed Cisticola
+Cisticola exilis_Ida-rohulind
 Cisticola fulvicapilla_Piping Cisticola
-Cisticola haematocephalus_Coastal Cisticola
+Cisticola haematocephalus_Kikuju rohulind
 Cisticola hunteri_Hunter's Cisticola
-Cisticola juncidis_Zitting Cisticola
-Cisticola lais_Wailing Cisticola
+Cisticola juncidis_Rohulind
+Cisticola lais_Kingu-rohulind
 Cisticola lateralis_Whistling Cisticola
-Cisticola marginatus_Winding Cisticola
+Cisticola marginatus_Tarna-rohulind
 Cisticola natalensis_Croaking Cisticola
 Cisticola nigriloris_Black-lored Cisticola
 Cisticola njombe_Churring Cisticola
-Cisticola pipiens_Chirping Cisticola
+Cisticola pipiens_Roo-rohulind
 Cisticola robustus_Stout Cisticola
 Cisticola subruficapilla_Red-headed Cisticola
-Cisticola textrix_Cloud Cisticola
+Cisticola textrix_Tiks-rohulind
 Cisticola tinniens_Levaillant's Cisticola
 Cisticola woosnami_Trilling Cisticola
-Cistothorus apolinari_Apolinar's Wren
-Cistothorus palustris_Marsh Wren
-Cistothorus platensis_Grass Wren
+Cistothorus apolinari_Kolumbia käblik
+Cistothorus palustris_Sookäblik
+Cistothorus platensis_Tarnakäblik
 Cistothorus stellaris_Sedge Wren
-Clamator coromandus_Chestnut-winged Cuckoo
-Clamator glandarius_Great Spotted Cuckoo
-Clamator jacobinus_Pied Cuckoo
-Clamator levaillantii_Levaillant's Cuckoo
-Clanga clanga_Greater Spotted Eagle
-Clanga pomarina_Lesser Spotted Eagle
-Clangula hyemalis_Long-tailed Duck
-Claravis pretiosa_Blue Ground Dove
+Clamator coromandus_Aasia harakkägu
+Clamator glandarius_Harakkägu
+Clamator jacobinus_Jakobiinkägu
+Clamator levaillantii_Suur-jakobiinkägu
+Clanga clanga_Suur-konnakotkas
+Clanga pomarina_Väike-konnakotkas
+Clangula hyemalis_Aul
+Claravis pretiosa_Täpiktiib-tuvi
 Clibanornis dendrocolaptoides_Canebrake Groundcreeper
 Clibanornis erythrocephalus_Henna-hooded Foliage-gleaner
 Clibanornis rectirostris_Chestnut-capped Foliage-gleaner
 Clibanornis rubiginosus_Ruddy Foliage-gleaner
 Clibanornis rufipectus_Santa Marta Foliage-gleaner
-Climacteris picumnus_Brown Treecreeper
+Climacteris picumnus_Leetkulm-tüvelind
 Clytoctantes alixii_Recurve-billed Bushbird
-Clytolaema rubricauda_Brazilian Ruby
+Clytolaema rubricauda_Ida-briljantkoolibri
 Clytorhynchus vitiensis_Fiji Shrikebill
 Cnemoscopus rubrirostris_Gray-hooded Bush Tanager
 Cnemotriccus fuscatus_Fuscous Flycatcher
 Cnipodectes subbrunneus_Brownish Twistwing
-Coccopygia melanotis_Swee Waxbill
-Coccopygia quartinia_Yellow-bellied Waxbill
-Coccothraustes abeillei_Hooded Grosbeak
+Coccopygia melanotis_Oliivselg-amadiin
+Coccopygia quartinia_Koldkõht-amadiin
+Coccothraustes abeillei_Mehhiko suurnokk-vint
 Coccothraustes coccothraustes_Suurnokk-vint
 Coccothraustes vespertinus_Evening Grosbeak
-Coccycua cinerea_Ash-colored Cuckoo
-Coccycua minuta_Little Cuckoo
-Coccyzus americanus_Yellow-billed Cuckoo
-Coccyzus erythropthalmus_Black-billed Cuckoo
-Coccyzus euleri_Pearly-breasted Cuckoo
-Coccyzus longirostris_Hispaniolan Lizard-Cuckoo
-Coccyzus melacoryphus_Dark-billed Cuckoo
-Coccyzus merlini_Great Lizard-Cuckoo
-Coccyzus minor_Mangrove Cuckoo
-Coccyzus vieilloti_Puerto Rican Lizard-Cuckoo
-Cochlearius cochlearius_Boat-billed Heron
-Cochoa viridis_Green Cochoa
-Coeligena coeligena_Bronzy Inca
-Coeligena iris_Rainbow Starfrontlet
-Coeligena lutetiae_Buff-winged Starfrontlet
-Coeligena wilsoni_Brown Inca
+Coccycua cinerea_Väike-vihmakägu
+Coccycua minuta_Väike-oravkägu
+Coccyzus americanus_Koldnokk-vihmakägu
+Coccyzus erythropthalmus_Põhja-vihmakägu
+Coccyzus euleri_Hõberind-vihmakägu
+Coccyzus longirostris_Haiti sisalikukägu
+Coccyzus melacoryphus_Lõuna-vihmakägu
+Coccyzus merlini_Suur-sisalikukägu
+Coccyzus minor_Mangroovikägu
+Coccyzus vieilloti_Puertoriiko sisalikukägu
+Cochlearius cochlearius_Lodinokk-haigur
+Cochoa viridis_Roherästas
+Coeligena coeligena_Kirikurk-koidukoolibri
+Coeligena iris_Viker-koidukoolibri
+Coeligena lutetiae_Laiktiib-koidukoolibri
+Coeligena wilsoni_Väike-koidukoolibri
 Coereba flaveola_Bananaquit
-Colaptes atricollis_Black-necked Woodpecker
-Colaptes auratus_Northern Flicker
-Colaptes auricularis_Gray-crowned Woodpecker
-Colaptes campestris_Campo Flicker
-Colaptes chrysoides_Gilded Flicker
-Colaptes fernandinae_Fernandina's Flicker
-Colaptes melanochloros_Green-barred Woodpecker
-Colaptes pitius_Chilean Flicker
-Colaptes punctigula_Spot-breasted Woodpecker
-Colaptes rivolii_Crimson-mantled Woodpecker
-Colaptes rubiginosus_Golden-olive Woodpecker
-Colaptes rupicola_Andean Flicker
-Colibri coruscans_Sparkling Violetear
-Colibri cyanotus_Lesser Violetear
-Colibri delphinae_Brown Violetear
-Colibri serrirostris_White-vented Violetear
-Colibri thalassinus_Mexican Violetear
-Colinus cristatus_Crested Bobwhite
-Colinus nigrogularis_Black-throated Bobwhite
-Colinus virginianus_Northern Bobwhite
-Colius colius_White-backed Mousebird
-Colius striatus_Speckled Mousebird
+Colaptes atricollis_Mustkurk-täpikrähn
+Colaptes auratus_Täpikrähn
+Colaptes auricularis_Väike-pronksrähn
+Colaptes campestris_Kamporähn
+Colaptes chrysoides_Saguaaro-täpikrähn
+Colaptes fernandinae_Saabalpalmi-rähn
+Colaptes melanochloros_Viher-täpikrähn
+Colaptes pitius_Tšiili rähn
+Colaptes punctigula_Koldkõht-täpikrähn
+Colaptes rivolii_Punaselg-pronksrähn
+Colaptes rubiginosus_Helepõsk-pronksrähn
+Colaptes rupicola_Inkarähn
+Colibri coruscans_Aed-ametüstkoolibri
+Colibri cyanotus_Nõlva-ametüstkoolibri
+Colibri delphinae_Pruun-ametüstkoolibri
+Colibri serrirostris_Hele-ametüstkoolibri
+Colibri thalassinus_Rohe-ametüstkoolibri
+Colinus cristatus_Lõuna-nurmvutt
+Colinus nigrogularis_Mustkurk-nurmvutt
+Colinus virginianus_Nurmvutt
+Colius colius_Triipselg-hiirlind
+Colius striatus_Pruun-hiirlind
 Collocalia affinis_Plume-toed Swiftlet
 Colluricincla boweri_Bower's Shrikethrush
 Colluricincla harmonica_Gray Shrikethrush
 Colluricincla megarhyncha_Arafura Shrikethrush
 Colluricincla rufogaster_Rufous Shrikethrush
-Colonia colonus_Long-tailed Tyrant
+Colonia colonus_Händtikat
 Colorhamphus parvirostris_Patagonian Tyrant
-Columba arquatrix_Rameron Pigeon
-Columba delegorguei_Delegorgue's Pigeon
-Columba guinea_Speckled Pigeon
-Columba iriditorques_Bronze-naped Pigeon
-Columba janthina_Japanese Wood-Pigeon
-Columba larvata_Lemon Dove
-Columba livia_Rock Pigeon
+Columba arquatrix_Helmestuvi
+Columba delegorguei_Bantu tuvi
+Columba guinea_Prilltuvi
+Columba iriditorques_Pronkskael-tuvi
+Columba janthina_Kameeliatuvi
+Columba larvata_Paletuvi
+Columba livia_Kodutuvi
 Columba oenas_Õõnetuvi
 Columba palumbus_Kaelustuvi
-Columba unicincta_Afep Pigeon
-Columba vitiensis_Metallic Pigeon
-Columbina buckleyi_Ecuadorian Ground Dove
-Columbina cruziana_Croaking Ground Dove
-Columbina cyanopis_Blue-eyed Ground Dove
-Columbina inca_Inca Dove
-Columbina minuta_Plain-breasted Ground Dove
-Columbina passerina_Common Ground Dove
-Columbina picui_Picui Ground Dove
-Columbina squammata_Scaled Dove
-Columbina talpacoti_Ruddy Ground Dove
+Columba unicincta_Kongo tuvi
+Columba vitiensis_Manisktuvi
+Columbina buckleyi_Tumbese värbtuvi
+Columbina cruziana_Konn-värbtuvi
+Columbina cyanopis_Kampo-värbtuvi
+Columbina inca_Asteegi tuvi
+Columbina minuta_Tuhk-värbtuvi
+Columbina passerina_Pärl-värbtuvi
+Columbina picui_Leet-värbtuvi
+Columbina squammata_Soomustuvi
+Columbina talpacoti_Ruuge-värbtuvi
 Compsothraupis loricata_Scarlet-throated Tanager
-Conioptilon mcilhennyi_Black-faced Cotinga
+Conioptilon mcilhennyi_Lammikotinga
 Conirostrum albifrons_Capped Conebill
 Conirostrum bicolor_Bicolored Conebill
 Conirostrum binghami_Giant Conebill
@@ -1515,10 +1515,10 @@ Conirostrum speciosum_Chestnut-vented Conebill
 Conirostrum tamarugense_Tamarugo Conebill
 Conocephalus brevipennis_Short-winged Meadow Katydid
 Conocephalus fasciatus_Slender Meadow Katydid
-Conopias albovittatus_White-ringed Flycatcher
-Conopias cinchoneti_Lemon-browed Flycatcher
-Conopias parvus_Yellow-throated Flycatcher
-Conopias trivirgatus_Three-striped Flycatcher
+Conopias albovittatus_Pugalpea-masktikat
+Conopias cinchoneti_Koldkulm-masktikat
+Conopias parvus_Amasoonia masktikat
+Conopias trivirgatus_Väike-masktikat
 Conopophaga ardesiaca_Slaty Gnateater
 Conopophaga aurita_Chestnut-belted Gnateater
 Conopophaga castaneiceps_Chestnut-crowned Gnateater
@@ -1528,31 +1528,31 @@ Conopophaga melanogaster_Black-bellied Gnateater
 Conopophaga melanops_Black-cheeked Gnateater
 Conopophaga peruviana_Ash-throated Gnateater
 Conopophila albogularis_Rufous-banded Honeyeater
-Conostoma aemodium_Great Parrotbill
-Conothraupis speculigera_Black-and-white Tanager
-Contopus caribaeus_Cuban Pewee
-Contopus cinereus_Tropical Pewee
-Contopus cooperi_Olive-sided Flycatcher
-Contopus fumigatus_Smoke-colored Pewee
-Contopus lugubris_Dark Pewee
-Contopus nigrescens_Blackish Pewee
-Contopus pertinax_Greater Pewee
-Contopus sordidulus_Western Wood-Pewee
-Contopus virens_Eastern Wood-Pewee
-Copsychus albiventris_Andaman Shama
-Copsychus albospecularis_Madagascar Magpie-Robin
-Copsychus cebuensis_Black Shama
-Copsychus fulicatus_Indian Robin
-Copsychus luzoniensis_White-browed Shama
-Copsychus malabaricus_White-rumped Shama
-Copsychus mindanensis_Philippine Magpie-Robin
-Copsychus niger_White-vented Shama
-Copsychus pyrropygus_Rufous-tailed Shama
-Copsychus saularis_Oriental Magpie-Robin
-Coracias abyssinicus_Abyssinian Roller
-Coracias benghalensis_Indian Roller
-Coracias caudatus_Lilac-breasted Roller
-Coracias garrulus_European Roller
+Conostoma aemodium_Hiid-koonusnokk
+Conothraupis speculigera_Ränd-pugalsirk
+Contopus caribaeus_Kuuba piivitikat
+Contopus cinereus_Lõuna-piivitikat
+Contopus cooperi_Laane-piivitikat
+Contopus fumigatus_Hall-piivitikat
+Contopus lugubris_Tuhm-piivitikat
+Contopus nigrescens_Nõgi-piivitikat
+Contopus pertinax_Tutt-piivitikat
+Contopus sordidulus_Lääne-piivitikat
+Contopus virens_Ida-piivitikat
+Copsychus albiventris_Andamani harakööbik
+Copsychus albospecularis_Madagaskari harakööbik
+Copsychus cebuensis_Cebu harakööbik
+Copsychus fulicatus_Väike-harakööbik
+Copsychus luzoniensis_Valgekulm-harakööbik
+Copsychus malabaricus_Šaama-harakööbik
+Copsychus mindanensis_Filipiini harakööbik
+Copsychus niger_Palawani harakööbik
+Copsychus pyrropygus_Tulisaba-harakööbik
+Copsychus saularis_Pugal-harakööbik
+Coracias abyssinicus_Saheli siniraag
+Coracias benghalensis_India siniraag
+Coracias caudatus_Rohtla-siniraag
+Coracias garrulus_Siniraag
 Coracina caesia_Gray Cuckooshrike
 Coracina cinerea_Madagascar Cuckooshrike
 Coracina lineata_Barred Cuckooshrike
@@ -1562,88 +1562,88 @@ Coracina novaehollandiae_Black-faced Cuckooshrike
 Coracina papuensis_White-bellied Cuckooshrike
 Coracina pectoralis_White-breasted Cuckooshrike
 Coracina striata_Bar-bellied Cuckooshrike
-Coracopsis nigra_Lesser Vasa Parrot
-Coracopsis vasa_Greater Vasa Parrot
-Coragyps atratus_Black Vulture
-Corapipo altera_White-ruffed Manakin
-Corapipo gutturalis_White-throated Manakin
+Coracopsis nigra_Mustpapagoi
+Coracopsis vasa_Ronkpapagoi
+Coragyps atratus_Ronkkondor
+Corapipo altera_Kostariika tantsulind
+Corapipo gutturalis_Manisk-tantsulind
 Corcorax melanorhamphos_White-winged Chough
-Cormobates leucophaea_White-throated Treecreeper
-Cormobates placens_Papuan Treecreeper
-Corthylio calendula_Ruby-crowned Kinglet
-Corvus albicollis_White-necked Raven
-Corvus albus_Pied Crow
-Corvus brachyrhynchos_American Crow
-Corvus capensis_Cape Crow
+Cormobates leucophaea_Valgepugu-tüvelind
+Cormobates placens_Paapua tüvelind
+Corthylio calendula_Rubiin-pöialpoiss
+Corvus albicollis_Kaelusronk
+Corvus albus_Pugalronk
+Corvus brachyrhynchos_Ameerika vares
+Corvus capensis_Aafrika künnivares
 Corvus corax_Ronk
 Corvus cornix_Hallvares
-Corvus corone_Carrion Crow
-Corvus coronoides_Australian Raven
-Corvus cryptoleucus_Chihuahuan Raven
-Corvus dauuricus_Daurian Jackdaw
-Corvus enca_Slender-billed Crow
-Corvus florensis_Flores Crow
+Corvus corone_Mustvares
+Corvus coronoides_Halavares
+Corvus cryptoleucus_Asteegi ronk
+Corvus dauuricus_Idahakk
+Corvus enca_Salenokk-vares
+Corvus florensis_Florese vares
 Corvus frugilegus_Künnivares
-Corvus hawaiiensis_Hawaiian Crow
-Corvus imparatus_Tamaulipas Crow
-Corvus jamaicensis_Jamaican Crow
-Corvus leucognaphalus_White-necked Crow
-Corvus macrorhynchos_Large-billed Crow
-Corvus mellori_Little Raven
+Corvus hawaiiensis_Havai vares
+Corvus imparatus_Mehhiko vares
+Corvus jamaicensis_Jamaika vares
+Corvus leucognaphalus_Haiti vares
+Corvus macrorhynchos_Suurnokk-vares
+Corvus mellori_Eukalüptivares
 Corvus monedula_Hakk
-Corvus nasicus_Cuban Crow
-Corvus orru_Torresian Crow
-Corvus ossifragus_Fish Crow
-Corvus palmarum_Palm Crow
-Corvus rhipidurus_Fan-tailed Raven
-Corvus ruficollis_Brown-necked Raven
-Corvus sinaloae_Sinaloa Crow
-Corvus splendens_House Crow
-Corvus tasmanicus_Forest Raven
-Corvus tristis_Gray Crow
-Corvus typicus_Piping Crow
-Corvus validus_Long-billed Crow
-Corydon sumatranus_Dusky Broadbill
+Corvus nasicus_Kuuba vares
+Corvus orru_Viljavares
+Corvus ossifragus_Kalavares
+Corvus palmarum_Palmivares
+Corvus rhipidurus_Lühisaba-ronk
+Corvus ruficollis_Kõrberonk
+Corvus sinaloae_Sinaloa vares
+Corvus splendens_Õuevares
+Corvus tasmanicus_Tasmaania vares
+Corvus tristis_Paapua vares
+Corvus typicus_Sulawesi vares
+Corvus validus_Pikknokk-vares
+Corydon sumatranus_Tõmmu-lainokk
 Coryphaspiza melanotis_Black-masked Finch
 Coryphistera alaudina_Lark-like Brushrunner
 Coryphospingus cucullatus_Red-crested Finch
 Coryphospingus pileatus_Pileated Finch
-Corythaeola cristata_Great Blue Turaco
-Corythaixoides concolor_Gray Go-away-bird
-Corythaixoides leucogaster_White-bellied Go-away-bird
+Corythaeola cristata_Hiidturako
+Corythaixoides concolor_Hallturako
+Corythaixoides leucogaster_Akaatsiaturako
 Corythopis delalandi_Southern Antpipit
 Corythopis torquatus_Ringed Antpipit
-Corythornis cristatus_Malachite Kingfisher
-Coscoroba coscoroba_Coscoroba Swan
-Cossypha albicapillus_White-crowned Robin-Chat
-Cossypha anomala_Olive-flanked Robin-Chat
-Cossypha archeri_Archer's Robin-Chat
-Cossypha caffra_Cape Robin-Chat
-Cossypha cyanocampter_Blue-shouldered Robin-Chat
-Cossypha dichroa_Chorister Robin-Chat
-Cossypha heuglini_White-browed Robin-Chat
-Cossypha humeralis_White-throated Robin-Chat
-Cossypha natalensis_Red-capped Robin-Chat
-Cossypha niveicapilla_Snowy-crowned Robin-Chat
-Cossypha polioptera_Gray-winged Robin-Chat
-Cossypha semirufa_Rüppell's Robin-Chat
-Coturnicops noveboracensis_Yellow Rail
-Coturnix coromandelica_Rain Quail
-Coturnix coturnix_Common Quail
-Coturnix delegorguei_Harlequin Quail
-Coturnix japonica_Japanese Quail
-Coturnix pectoralis_Stubble Quail
-Coua caerulea_Blue Coua
-Coua coquereli_Coquerel's Coua
-Coua cristata_Crested Coua
-Coua gigas_Giant Coua
-Coua reynaudii_Red-fronted Coua
-Coua ruficeps_Red-capped Coua
-Coua serriana_Red-breasted Coua
-Cracticus cassicus_Hooded Butcherbird
-Cracticus nigrogularis_Pied Butcherbird
-Cracticus quoyi_Black Butcherbird
-Cracticus torquatus_Gray Butcherbird
+Corythornis cristatus_Tutt-jäälind
+Coscoroba coscoroba_Koskoroba
+Cossypha albicapillus_Händ-ruugeööbik
+Cossypha anomala_Tuhk-ruugeööbik
+Cossypha archeri_Sõnajala-ruugeööbik
+Cossypha caffra_Mägi-ruugeööbik
+Cossypha cyanocampter_Siniõlg-ruugeööbik
+Cossypha dichroa_Võra-ruugeööbik
+Cossypha heuglini_Salu-ruugeööbik
+Cossypha humeralis_Valgetiib-ruugeööbik
+Cossypha natalensis_Rebu-ruugeööbik
+Cossypha niveicapilla_Tihniku-ruugeööbik
+Cossypha polioptera_Valgekulm-ruugerind
+Cossypha semirufa_Kadaka-ruugeööbik
+Coturnicops noveboracensis_Kold-vuttruik
+Coturnix coromandelica_India vihmavutt
+Coturnix coturnix_Põldvutt
+Coturnix delegorguei_Aafrika vihmavutt
+Coturnix japonica_Ida-põldvutt
+Coturnix pectoralis_Punakurk-vutt
+Coua caerulea_Sini-siidkägu
+Coua coquereli_Lääne-siidkägu
+Coua cristata_Tutt-siidkägu
+Coua gigas_Suur-siidkägu
+Coua reynaudii_Tanu-siidkägu
+Coua ruficeps_Punakiird-siidkägu
+Coua serriana_Tõmmu-siidkägu
+Cracticus cassicus_Paapua leigar
+Cracticus nigrogularis_Taideleigar
+Cracticus quoyi_Mustleigar
+Cracticus torquatus_Hall-leigar
 Cranioleuca albicapilla_Creamy-crested Spinetail
 Cranioleuca albiceps_Light-crowned Spinetail
 Cranioleuca antisiensis_Line-cheeked Spinetail
@@ -1662,108 +1662,108 @@ Cranioleuca vulpecula_Parker's Spinetail
 Cranioleuca vulpina_Rusty-backed Spinetail
 Crateroscelis murina_Rusty Mouse-Warbler
 Crateroscelis robusta_Mountain Mouse-Warbler
-Crax alberti_Blue-billed Curassow
-Crax alector_Black Curassow
-Crax fasciolata_Bare-faced Curassow
-Crax rubra_Great Curassow
-Creagrus furcatus_Swallow-tailed Gull
-Creatophora cinerea_Wattled Starling
+Crax alberti_Sinisagar-hoko
+Crax alector_Guajaana hoko
+Crax fasciolata_Palehoko
+Crax rubra_Suurhoko
+Creagrus furcatus_Öökajakas
+Creatophora cinerea_Lokut-kuldnokk
 Crex crex_Rukkirääk
-Crinifer piscator_Western Plantain-eater
-Criniger barbatus_Western Bearded-Greenbul
-Criniger calurus_Red-tailed Greenbul
-Criniger chloronotus_Eastern Bearded-Greenbul
-Crithagra albogularis_White-throated Canary
-Crithagra atrogularis_Black-throated Canary
-Crithagra buchanani_Southern Grosbeak-Canary
-Crithagra dorsostriata_White-bellied Canary
-Crithagra flaviventris_Yellow Canary
-Crithagra gularis_Streaky-headed Seedeater
-Crithagra hyposticta_Southern Citril
-Crithagra menachensis_Yemen Serin
-Crithagra mozambica_Yellow-fronted Canary
-Crithagra reichenowi_Reichenow's Seedeater
-Crithagra scotops_Forest Canary
-Crithagra striolata_Streaky Seedeater
-Crithagra sulphurata_Brimstone Canary
-Crossleyia xanthophrys_Yellow-browed Oxylabes
-Crotophaga ani_Smooth-billed Ani
-Crotophaga major_Greater Ani
-Crotophaga sulcirostris_Groove-billed Ani
-Crypsirina temia_Racket-tailed Treepie
+Crinifer piscator_Rohtlaturako
+Criniger barbatus_Triiprind-vurrukbülbül
+Criniger calurus_Prill-vurrukbülbül
+Criniger chloronotus_Hallpugu-vurrukbülbül
+Crithagra albogularis_Hele-rohtlavint
+Crithagra atrogularis_Tuhk-rohtlavint
+Crithagra buchanani_Tsavo rohtlavint
+Crithagra dorsostriata_Valgekõht-rohtlavint
+Crithagra flaviventris_Kuld-rohtlavint
+Crithagra gularis_Valgekulm-rohtlavint
+Crithagra hyposticta_Tanganjika koldvint
+Crithagra menachensis_Jeemeni rohtlavint
+Crithagra mozambica_Habe-rohtlavint
+Crithagra reichenowi_Keenia rohtlavint
+Crithagra scotops_Mets-koldvint
+Crithagra striolata_Triip-rohtlavint
+Crithagra sulphurata_Koldkurk-rohtlavint
+Crossleyia xanthophrys_Koldkulm-farifutša
+Crotophaga ani_Kiilnokk-ühiskägu
+Crotophaga major_Suur-ühiskägu
+Crotophaga sulcirostris_Vagunokk-ühiskägu
+Crypsirina temia_Must-pisiharakas
 Cryptillas victorini_Victorin's Warbler
-Cryptoleucopteryx plumbea_Plumbeous Hawk
+Cryptoleucopteryx plumbea_Peegeltiib-selvaviu
 Cryptopezus nattereri_Speckle-breasted Antpitta
-Cryptopipo holochlora_Green Manakin
-Cryptospiza reichenovii_Red-faced Crimsonwing
-Cryptosylvicola randrianasoloi_Cryptic Warbler
-Crypturellus atrocapillus_Black-capped Tinamou
-Crypturellus bartletti_Bartlett's Tinamou
-Crypturellus boucardi_Slaty-breasted Tinamou
-Crypturellus cinereus_Cinereous Tinamou
-Crypturellus cinnamomeus_Thicket Tinamou
-Crypturellus duidae_Gray-legged Tinamou
-Crypturellus erythropus_Red-legged Tinamou
-Crypturellus noctivagus_Yellow-legged Tinamou
-Crypturellus obsoletus_Brown Tinamou
-Crypturellus parvirostris_Small-billed Tinamou
-Crypturellus soui_Little Tinamou
-Crypturellus strigulosus_Brazilian Tinamou
-Crypturellus tataupa_Tataupa Tinamou
-Crypturellus transfasciatus_Pale-browed Tinamou
-Crypturellus undulatus_Undulated Tinamou
-Crypturellus variegatus_Variegated Tinamou
+Cryptopipo holochlora_Viher-tantsulind
+Cryptospiza reichenovii_Väike-mägiamadiin
+Cryptosylvicola randrianasoloi_Redu-farifutša
+Crypturellus atrocapillus_Tumekiird-metstinamu
+Crypturellus bartletti_Ruske-metstinamu
+Crypturellus boucardi_Kariibi metstinamu
+Crypturellus cinereus_Tõmmu-metstinamu
+Crypturellus cinnamomeus_Põhja-metstinamu
+Crypturellus duidae_Halljalg-metstinamu
+Crypturellus erythropus_Punajalg-metstinamu
+Crypturellus noctivagus_Tanu-metstinamu
+Crypturellus obsoletus_Pruun-metstinamu
+Crypturellus parvirostris_Lühinokk-metstinamu
+Crypturellus soui_Väike-metstinamu
+Crypturellus strigulosus_Punakael-metstinamu
+Crypturellus tataupa_Tataupa-metstinamu
+Crypturellus transfasciatus_Valgekulm-metstinamu
+Crypturellus undulatus_Vile-metstinamu
+Crypturellus variegatus_Mustpea-metstinamu
 Cuculus canorus_Kägu
-Cuculus clamosus_Black Cuckoo
-Cuculus gularis_African Cuckoo
+Cuculus clamosus_Mustkägu
+Cuculus gularis_Savannikägu
 Cuculus lepidus_Sunda Cuckoo
-Cuculus micropterus_Indian Cuckoo
-Cuculus optatus_Oriental Cuckoo
-Cuculus poliocephalus_Lesser Cuckoo
-Cuculus rochii_Madagascar Cuckoo
-Cuculus saturatus_Himalayan Cuckoo
-Cuculus solitarius_Red-chested Cuckoo
+Cuculus micropterus_Vilekägu
+Cuculus optatus_Taigakägu
+Cuculus poliocephalus_Väikekägu
+Cuculus rochii_Madagaskari väikekägu
+Cuculus saturatus_Lõuna-taigakägu
+Cuculus solitarius_Punarind-kägu
 Culicicapa ceylonensis_Gray-headed Canary-Flycatcher
 Culicicapa helianthea_Citrine Canary-Flycatcher
 Culicivora caudacuta_Sharp-tailed Tyrant
-Curaeus curaeus_Austral Blackbird
-Curruca boehmi_Banded Parisoma
-Curruca communis_Greater Whitethroat
-Curruca conspicillata_Spectacled Warbler
-Curruca crassirostris_Eastern Orphean Warbler
-Curruca curruca_Lesser Whitethroat
-Curruca hortensis_Western Orphean Warbler
-Curruca iberiae_Western Subalpine Warbler
-Curruca melanocephala_Sardinian Warbler
-Curruca nisoria_Barred Warbler
-Curruca subcoerulea_Chestnut-vented Warbler
-Curruca undata_Dartford Warbler
-Cutia legalleni_Vietnamese Cutia
-Cutia nipalensis_Himalayan Cutia
-Cyanerpes caeruleus_Purple Honeycreeper
-Cyanerpes cyaneus_Red-legged Honeycreeper
+Curaeus curaeus_Pöögiturpial
+Curruca boehmi_Laidpugu-põõsalind
+Curruca communis_Pruunselg-põõsalind
+Curruca conspicillata_Kõnnu-põõsalind
+Curruca crassirostris_Laulu-põõsalind
+Curruca curruca_Väike-põõsalind
+Curruca hortensis_Salu-põõsalind
+Curruca iberiae_Berberi põõsalind
+Curruca melanocephala_Sametpea-põõsalind
+Curruca nisoria_Vööt-põõsalind
+Curruca subcoerulea_Lõuna-põõsalind
+Curruca undata_Nõmme-põõsalind
+Cutia legalleni_Vietnami tüvevädrak
+Cutia nipalensis_Valgerind-tüvevädrak
+Cyanerpes caeruleus_Selva-türkiissirk
+Cyanerpes cyaneus_Punajalg-türkiissirk
 Cyanicterus cyanicterus_Blue-backed Tanager
 Cyanistes caeruleus_Sinitihane
-Cyanistes cyanus_Azure Tit
-Cyanistes teneriffae_African Blue Tit
-Cyanocitta cristata_Blue Jay
-Cyanocitta stelleri_Steller's Jay
+Cyanistes cyanus_Lasuurtihane
+Cyanistes teneriffae_Kanaari sinitihane
+Cyanocitta cristata_Sininäär
+Cyanocitta stelleri_Tutt-sininäär
 Cyanocompsa parellina_Blue Bunting
-Cyanocorax affinis_Black-chested Jay
-Cyanocorax beecheii_Purplish-backed Jay
-Cyanocorax caeruleus_Azure Jay
-Cyanocorax cayanus_Cayenne Jay
-Cyanocorax chrysops_Plush-crested Jay
-Cyanocorax cristatellus_Curl-crested Jay
-Cyanocorax cyanomelas_Purplish Jay
-Cyanocorax cyanopogon_White-naped Jay
-Cyanocorax dickeyi_Tufted Jay
-Cyanocorax melanocyaneus_Bushy-crested Jay
-Cyanocorax mystacalis_White-tailed Jay
-Cyanocorax sanblasianus_San Blas Jay
-Cyanocorax violaceus_Violaceous Jay
-Cyanocorax yncas_Green Jay
-Cyanocorax yucatanicus_Yucatan Jay
+Cyanocorax affinis_Kolumbia sininäär
+Cyanocorax beecheii_Tõmmu-sininäär
+Cyanocorax caeruleus_Araukaaria-sininäär
+Cyanocorax cayanus_Guajaana sininäär
+Cyanocorax chrysops_Kübar-sininäär
+Cyanocorax cristatellus_Kihar-sininäär
+Cyanocorax cyanomelas_Purpur-sininäär
+Cyanocorax cyanopogon_Pugal-sininäär
+Cyanocorax dickeyi_Hari-sininäär
+Cyanocorax melanocyaneus_Hondurase sininäär
+Cyanocorax mystacalis_Meskite-sininäär
+Cyanocorax sanblasianus_Kookose-sininäär
+Cyanocorax violaceus_Jõgi-sininäär
+Cyanocorax yncas_Rohenäär
+Cyanocorax yucatanicus_Yucatani sininäär
 Cyanoderma ambiguum_Buff-chested Babbler
 Cyanoderma chrysaeum_Golden Babbler
 Cyanoderma erythropterum_Chestnut-winged Babbler
@@ -1771,89 +1771,89 @@ Cyanoderma melanothorax_Crescent-chested Babbler
 Cyanoderma pyrrhops_Black-chinned Babbler
 Cyanoderma ruficeps_Rufous-capped Babbler
 Cyanoderma rufifrons_Rufous-fronted Babbler
-Cyanolanius madagascarinus_Blue Vanga
-Cyanoliseus patagonus_Burrowing Parakeet
+Cyanolanius madagascarinus_Sinivanga
+Cyanoliseus patagonus_Kaldapapagoi
 Cyanoloxia brissonii_Ultramarine Grosbeak
 Cyanoloxia cyanoides_Blue-black Grosbeak
 Cyanoloxia glaucocaerulea_Glaucous-blue Grosbeak
 Cyanoloxia rothschildii_Amazonian Grosbeak
-Cyanolyca armillata_Black-collared Jay
-Cyanolyca cucullata_Azure-hooded Jay
-Cyanolyca mirabilis_White-throated Jay
-Cyanolyca nanus_Dwarf Jay
-Cyanolyca pulchra_Beautiful Jay
-Cyanolyca pumilo_Black-throated Jay
-Cyanolyca turcosa_Turquoise Jay
-Cyanolyca viridicyanus_White-collared Jay
+Cyanolyca armillata_Kaelus-sininäär
+Cyanolyca cucullata_Lasuurkiird-sininäär
+Cyanolyca mirabilis_Valgekurk-sininäär
+Cyanolyca nanus_Väike-sininäär
+Cyanolyca pulchra_Pagu-sininäär
+Cyanolyca pumilo_Guatemaala sininäär
+Cyanolyca turcosa_Ekuadori sininäär
+Cyanolyca viridicyanus_Andi sininäär
 Cyanomitra cyanolaema_Blue-throated Brown Sunbird
 Cyanomitra olivacea_Olive Sunbird
-Cyanomitra veroxii_Mouse-colored Sunbird
-Cyanomitra verticalis_Green-headed Sunbird
-Cyanopica cooki_Iberian Magpie
-Cyanopica cyanus_Azure-winged Magpie
-Cyanoptila cumatilis_Zappey's Flycatcher
-Cyanoptila cyanomelana_Blue-and-white Flycatcher
-Cyanoramphus novaezelandiae_Red-crowned Parakeet
+Cyanomitra veroxii_Tuhk-nektarilind
+Cyanomitra verticalis_Moorapipra-nektarilind
+Cyanopica cooki_Ibeeria siniharakas
+Cyanopica cyanus_Siniharakas
+Cyanoptila cumatilis_Taiga-sininäpp
+Cyanoptila cyanomelana_Põhja-sininäpp
+Cyanoramphus novaezelandiae_Suur-maooripapagoi
 Cyclarhis gujanensis_Rufous-browed Peppershrike
 Cyclarhis nigrirostris_Black-billed Peppershrike
-Cygnus atratus_Black Swan
-Cygnus buccinator_Trumpeter Swan
-Cygnus columbianus_Tundra Swan
+Cygnus atratus_Mustluik
+Cygnus buccinator_Ameerika laululuik
+Cygnus columbianus_Väikeluik
 Cygnus cygnus_Laululuik
-Cygnus melancoryphus_Black-necked Swan
+Cygnus melancoryphus_Mustkael-luik
 Cygnus olor_Kühmnokk-luik
 Cymbilaimus lineatus_Fasciated Antshrike
 Cymbilaimus sanctaemariae_Bamboo Antshrike
-Cymbirhynchus macrorhynchos_Black-and-red Broadbill
-Cynanthus latirostris_Broad-billed Hummingbird
-Cyornis caerulatus_Sunda Blue Flycatcher
-Cyornis concretus_White-tailed Flycatcher
-Cyornis glaucicomans_Chinese Blue Flycatcher
-Cyornis hainanus_Hainan Blue Flycatcher
-Cyornis hoevelli_Blue-fronted Flycatcher
-Cyornis olivaceus_Fulvous-chested Jungle-Flycatcher
-Cyornis omissus_Sulawesi Blue Flycatcher
-Cyornis pallidipes_White-bellied Blue Flycatcher
-Cyornis poliogenys_Pale-chinned Blue Flycatcher
-Cyornis rubeculoides_Blue-throated Flycatcher
-Cyornis rufigastra_Mangrove Blue Flycatcher
-Cyornis sumatrensis_Indochinese Blue Flycatcher
-Cyornis superbus_Bornean Blue Flycatcher
-Cyornis tickelliae_Tickell's Blue Flycatcher
-Cyornis turcosus_Malaysian Blue Flycatcher
-Cyornis umbratilis_Gray-chested Jungle-Flycatcher
-Cyornis unicolor_Pale Blue Flycatcher
+Cymbirhynchus macrorhynchos_Jõgi-lainokk
+Cynanthus latirostris_Põhja-smaragdkoolibri
+Cyornis caerulatus_Lainokk-sininäpp
+Cyornis concretus_Pugalsaba-sininäpp
+Cyornis glaucicomans_Sichuani sininäpp
+Cyornis hainanus_Safiir-sininäpp
+Cyornis hoevelli_Pruunselg-sininäpp
+Cyornis olivaceus_Oliiv-sininäpp
+Cyornis omissus_Ruugepugu-sininäpp
+Cyornis pallidipes_Ghati sininäpp
+Cyornis poliogenys_Pruun-sininäpp
+Cyornis rubeculoides_Diadeem-sininäpp
+Cyornis rufigastra_Mangroovi-sininäpp
+Cyornis sumatrensis_Indohiina sininäpp
+Cyornis superbus_Türkiis-sininäpp
+Cyornis tickelliae_Salu-sininäpp
+Cyornis turcosus_Jõgi-sininäpp
+Cyornis umbratilis_Hallpugu-sininäpp
+Cyornis unicolor_Koobalt-sininäpp
 Cyornis whitei_Hill Blue Flycatcher
-Cyphorhinus arada_Musician Wren
-Cyphorhinus phaeocephalus_Song Wren
-Cyphorhinus thoracicus_Chestnut-breasted Wren
-Cypseloides niger_Black Swift
-Cypsiurus balasiensis_Asian Palm-Swift
-Cypsiurus parvus_African Palm-Swift
+Cyphorhinus arada_Taidurkäblik
+Cyphorhinus phaeocephalus_Laulukäblik
+Cyphorhinus thoracicus_Punarind-käblik
+Cypseloides niger_Põhja-kosepiiritaja
+Cypsiurus balasiensis_Aasia palmipiiritaja
+Cypsiurus parvus_Aafrika palmipiiritaja
 Cypsnagra hirundinacea_White-rumped Tanager
-Cyrtonyx montezumae_Montezuma Quail
-Cyrtonyx ocellatus_Ocellated Quail
+Cyrtonyx montezumae_Mehhiko maskvutt
+Cyrtonyx ocellatus_Maia maskvutt
 Cyrtoxipha columbiana_Columbian Trig
-Dacelo gaudichaud_Rufous-bellied Kookaburra
-Dacelo leachii_Blue-winged Kookaburra
-Dacelo novaeguineae_Laughing Kookaburra
-Dacnis cayana_Blue Dacnis
-Dacnis flaviventer_Yellow-bellied Dacnis
-Dacnis lineata_Black-faced Dacnis
-Dacnis venusta_Scarlet-thighed Dacnis
-Dactylortyx thoracicus_Singing Quail
+Dacelo gaudichaud_Valgenokk-kuukabarra
+Dacelo leachii_Siniõlg-kuukabarra
+Dacelo novaeguineae_Kuukabarra
+Dacnis cayana_Roosajalg-türkiissirk
+Dacnis flaviventer_Kold-türkiissirk
+Dacnis lineata_Mask-türkiissirk
+Dacnis venusta_Punapüks-türkiissirk
+Dactylortyx thoracicus_Lauluvutt
 Daphoenositta chrysoptera_Varied Sittella
-Daption capense_Cape Petrel
-Daptrius ater_Black Caracara
-Dasylophus cumingi_Scale-feathered Malkoha
-Dasyornis brachypterus_Eastern Bristlebird
-Dasyornis broadbenti_Rufous Bristlebird
-Dasyornis longirostris_Western Bristlebird
+Daption capense_Kirju-tormilind
+Daptrius ater_Metskarakaara
+Dasylophus cumingi_Soomus-malkohakägu
+Dasyornis brachypterus_Ida-rägalind
+Dasyornis broadbenti_Suur-rägalind
+Dasyornis longirostris_Lääne-rägalind
 Deconychura longicauda_Long-tailed Woodcreeper
-Delichon dasypus_Asian House-Martin
+Delichon dasypus_Ida-räästapääsuke
 Delichon urbicum_Räästapääsuke
 Dendragapus fuliginosus_Sooty Grouse
-Dendragapus obscurus_Dusky Grouse
+Dendragapus obscurus_Nulupüü
 Dendrexetastes rufigula_Cinnamon-throated Woodcreeper
 Dendrocincla anabatina_Tawny-winged Woodcreeper
 Dendrocincla fuliginosa_Plain-brown Woodcreeper
@@ -1861,70 +1861,70 @@ Dendrocincla homochroa_Ruddy Woodcreeper
 Dendrocincla merula_White-chinned Woodcreeper
 Dendrocincla turdina_Plain-winged Woodcreeper
 Dendrocincla tyrannina_Tyrannine Woodcreeper
-Dendrocitta cinerascens_Bornean Treepie
-Dendrocitta formosae_Gray Treepie
-Dendrocitta leucogastra_White-bellied Treepie
-Dendrocitta vagabunda_Rufous Treepie
+Dendrocitta cinerascens_Kalimantani ruskharakas
+Dendrocitta formosae_Hiina ruskharakas
+Dendrocitta leucogastra_Draviidi ruskharakas
+Dendrocitta vagabunda_Aed-ruskharakas
 Dendrocolaptes certhia_Amazonian Barred-Woodcreeper
 Dendrocolaptes picumnus_Black-banded Woodcreeper
 Dendrocolaptes platyrostris_Planalto Woodcreeper
 Dendrocolaptes sanctithomae_Northern Barred-Woodcreeper
-Dendrocopos analis_Freckle-breasted Woodpecker
-Dendrocopos darjellensis_Darjeeling Woodpecker
-Dendrocopos himalayensis_Himalayan Woodpecker
-Dendrocopos hyperythrus_Rufous-bellied Woodpecker
-Dendrocopos leucopterus_White-winged Woodpecker
+Dendrocopos analis_Kagu-kirjurähn
+Dendrocopos darjellensis_Mägi-kirjurähn
+Dendrocopos himalayensis_Himaalaja kirjurähn
+Dendrocopos hyperythrus_Mandariinrähn
+Dendrocopos leucopterus_Valgetiib-kirjurähn
 Dendrocopos leucotos_Valgeselg-kirjurähn
-Dendrocopos macei_Fulvous-breasted Woodpecker
+Dendrocopos macei_Leekkõht-kirjurähn
 Dendrocopos major_Suur-kirjurähn
-Dendrocopos syriacus_Syrian Woodpecker
-Dendrocoptes auriceps_Brown-fronted Woodpecker
-Dendrocoptes medius_Middle Spotted Woodpecker
-Dendrocygna arcuata_Wandering Whistling-Duck
-Dendrocygna autumnalis_Black-bellied Whistling-Duck
-Dendrocygna bicolor_Fulvous Whistling-Duck
-Dendrocygna eytoni_Plumed Whistling-Duck
-Dendrocygna javanica_Lesser Whistling-Duck
-Dendrocygna viduata_White-faced Whistling-Duck
+Dendrocopos syriacus_Salu-kirjurähn
+Dendrocoptes auriceps_Leekpea-kirjurähn
+Dendrocoptes medius_Tamme-kirjurähn
+Dendrocygna arcuata_Roostekõht-vilepart
+Dendrocygna autumnalis_Punanokk-vilepart
+Dendrocygna bicolor_Ruuge-vilepart
+Dendrocygna eytoni_Rohtla-vilepart
+Dendrocygna javanica_Väike-vilepart
+Dendrocygna viduata_Valgepõsk-vilepart
 Dendroma erythroptera_Chestnut-winged Foliage-gleaner
 Dendroma rufa_Buff-fronted Foliage-gleaner
-Dendronanthus indicus_Forest Wagtail
+Dendronanthus indicus_Võravästrik
 Dendroplex picus_Straight-billed Woodcreeper
-Dendrortyx barbatus_Bearded Wood-Partridge
-Dendrortyx leucophrys_Buffy-crowned Wood-Partridge
-Dendrortyx macroura_Long-tailed Wood-Partridge
-Deroptyus accipitrinus_Red-fan Parrot
-Dicaeum aeneum_Midget Flowerpecker
-Dicaeum agile_Thick-billed Flowerpecker
-Dicaeum australe_Red-keeled Flowerpecker
-Dicaeum chrysorrheum_Yellow-vented Flowerpecker
-Dicaeum concolor_Nilgiri Flowerpecker
-Dicaeum cruentatum_Scarlet-backed Flowerpecker
-Dicaeum erythrorhynchos_Pale-billed Flowerpecker
-Dicaeum hirundinaceum_Mistletoebird
-Dicaeum ignipectus_Fire-breasted Flowerpecker
-Dicaeum minullum_Plain Flowerpecker
-Dicaeum pygmaeum_Pygmy Flowerpecker
-Dicaeum trigonostigma_Orange-bellied Flowerpecker
-Dicaeum tristrami_Mottled Flowerpecker
+Dendrortyx barbatus_Hallkurk-händvutt
+Dendrortyx leucophrys_Valgekurk-händvutt
+Dendrortyx macroura_Mustkurk-händvutt
+Deroptyus accipitrinus_Kraepapagoi
+Dicaeum aeneum_Saalomonisaarte võõrikulind
+Dicaeum agile_Kathaki-võõrikulind
+Dicaeum australe_Punakõht-võõrikulind
+Dicaeum chrysorrheum_Triip-võõrikulind
+Dicaeum concolor_Ghati võõrikulind
+Dicaeum cruentatum_Tuliselg-võõrikulind
+Dicaeum erythrorhynchos_Helenokk-võõrikulind
+Dicaeum hirundinaceum_Austraalia võõrikulind
+Dicaeum ignipectus_Mägi-võõrikulind
+Dicaeum minullum_Hiir-võõrikulind
+Dicaeum pygmaeum_Pisi-võõrikulind
+Dicaeum trigonostigma_Kuld-võõrikulind
+Dicaeum tristrami_Makira võõrikulind
 Dichrozona cincta_Banded Antbird
-Dicrurus adsimilis_Fork-tailed Drongo
-Dicrurus aeneus_Bronzed Drongo
-Dicrurus andamanensis_Andaman Drongo
-Dicrurus annectens_Crow-billed Drongo
-Dicrurus atripennis_Shining Drongo
-Dicrurus balicassius_Balicassiao
-Dicrurus bracteatus_Spangled Drongo
-Dicrurus caerulescens_White-bellied Drongo
+Dicrurus adsimilis_Savannidrongo
+Dicrurus aeneus_Läikdrongo
+Dicrurus andamanensis_Andamani drongo
+Dicrurus annectens_Varesnokk-drongo
+Dicrurus atripennis_Metsdrongo
+Dicrurus balicassius_Filipiini drongo
+Dicrurus bracteatus_Kagudrongo
+Dicrurus caerulescens_Valgekõht-drongo
 Dicrurus divaricatus_Glossy-backed Drongo
-Dicrurus forficatus_Crested Drongo
-Dicrurus hottentottus_Hair-crested Drongo
-Dicrurus leucophaeus_Ashy Drongo
-Dicrurus ludwigii_Common Square-tailed Drongo
-Dicrurus macrocercus_Black Drongo
-Dicrurus montanus_Sulawesi Drongo
-Dicrurus paradiseus_Greater Racket-tailed Drongo
-Dicrurus remifer_Lesser Racket-tailed Drongo
+Dicrurus forficatus_Tuttdrongo
+Dicrurus hottentottus_Džunglidrongo
+Dicrurus leucophaeus_Tuhkdrongo
+Dicrurus ludwigii_Kantsaba-drongo
+Dicrurus macrocercus_Nurmdrongo
+Dicrurus montanus_Sulawesi drongo
+Dicrurus paradiseus_Paradiisidrongo
+Dicrurus remifer_Lippsaba-drongo
 Diglossa albilatera_White-sided Flowerpiercer
 Diglossa baritula_Cinnamon-bellied Flowerpiercer
 Diglossa brunneiventris_Black-throated Flowerpiercer
@@ -1938,26 +1938,26 @@ Diglossa lafresnayii_Glossy Flowerpiercer
 Diglossa mystacalis_Moustached Flowerpiercer
 Diglossa plumbea_Slaty Flowerpiercer
 Diglossa sittoides_Rusty Flowerpiercer
-Dinemellia dinemelli_White-headed Buffalo-Weaver
-Dinopium benghalense_Black-rumped Flameback
-Dinopium javanense_Common Flameback
-Dinopium rafflesii_Olive-backed Woodpecker
-Diomedea exulans_Wandering Albatross
-Diopsittaca nobilis_Red-shouldered Macaw
-Diuca diuca_Diuca Finch
-Dives dives_Melodious Blackbird
-Dives warczewiczi_Scrub Blackbird
+Dinemellia dinemelli_Valgepea-kangurlind
+Dinopium benghalense_Mustkurk-sultanrähn
+Dinopium javanense_Tuliselg-sultanrähn
+Dinopium rafflesii_Sooviku-sultanrähn
+Diomedea exulans_Rändalbatross
+Diopsittaca nobilis_Väikeaara
+Diuca diuca_Tuhktangara
+Dives dives_Männiturpial
+Dives warczewiczi_Kõnnuturpial
 Dog_Dog
-Dolichonyx oryzivorus_Bobolink
+Dolichonyx oryzivorus_Heinaturpial
 Donacobius atricapilla_Black-capped Donacobius
 Donacospiza albifrons_Long-tailed Reed Finch
-Doryfera ludovicae_Green-fronted Lancebill
-Drepanis coccinea_Iiwi
+Doryfera ludovicae_Nõlva-piikkoolibri
+Drepanis coccinea_Iiwi-nestevint
 Drepanornis albertisi_Black-billed Sicklebill
-Dromas ardeola_Crab-Plover
-Dromococcyx pavoninus_Pavonine Cuckoo
-Dromococcyx phasianellus_Pheasant Cuckoo
-Drymodes brunneopygia_Southern Scrub-Robin
+Dromas ardeola_Krabijooksur
+Dromococcyx pavoninus_Väike-selvakägu
+Dromococcyx phasianellus_Suur-selvakägu
+Drymodes brunneopygia_Võsa-rästasmiro
 Drymophila caudata_East Andean Antbird
 Drymophila devillei_Striated Antbird
 Drymophila ferruginea_Ferruginous Antbird
@@ -1971,34 +1971,34 @@ Drymophila squamata_Scaled Antbird
 Drymophila striaticeps_Streak-headed Antbird
 Drymornis bridgesii_Scimitar-billed Woodcreeper
 Dryobates affinis_Red-stained Woodpecker
-Dryobates albolarvatus_White-headed Woodpecker
+Dryobates albolarvatus_Valgepea-rähn
 Dryobates arizonae_Arizona Woodpecker
-Dryobates borealis_Red-cockaded Woodpecker
+Dryobates borealis_Palu-kirjurähn
 Dryobates callonotus_Scarlet-backed Woodpecker
 Dryobates cassini_Golden-collared Woodpecker
-Dryobates cathpharius_Crimson-breasted Woodpecker
+Dryobates cathpharius_Punarind-kirjurähn
 Dryobates dignus_Yellow-vented Woodpecker
 Dryobates frontalis_Dot-fronted Woodpecker
 Dryobates fumigatus_Smoky-brown Woodpecker
 Dryobates kirkii_Red-rumped Woodpecker
 Dryobates lignarius_Striped Woodpecker
 Dryobates maculifrons_Yellow-eared Woodpecker
-Dryobates minor_Lesser Spotted Woodpecker
+Dryobates minor_Väike-kirjurähn
 Dryobates mixtus_Checkered Woodpecker
 Dryobates nigriceps_Bar-bellied Woodpecker
-Dryobates nuttallii_Nuttall's Woodpecker
+Dryobates nuttallii_Kalifornia kirjurähn
 Dryobates passerinus_Little Woodpecker
-Dryobates pubescens_Downy Woodpecker
-Dryobates scalaris_Ladder-backed Woodpecker
+Dryobates pubescens_Haava-kirjurähn
+Dryobates scalaris_Kõnnu-kirjurähn
 Dryobates spilogaster_White-spotted Woodpecker
-Dryobates stricklandi_Strickland's Woodpecker
-Dryobates villosus_Hairy Woodpecker
-Dryocopus javensis_White-bellied Woodpecker
-Dryocopus lineatus_Lineated Woodpecker
+Dryobates stricklandi_Mehhiko kirjurähn
+Dryobates villosus_Männi-kirjurähn
+Dryocopus javensis_Valgekõht-musträhn
+Dryocopus lineatus_Vööt-musträhn
 Dryocopus martius_Musträhn
-Dryocopus pileatus_Pileated Woodpecker
+Dryocopus pileatus_Ameerika musträhn
 Dryocopus schulzii_Black-bodied Woodpecker
-Dryolimnas cuvieri_White-throated Rail
+Dryolimnas cuvieri_Valgekurk-ruik
 Dryophytes andersonii_Pine Barrens Treefrog
 Dryophytes arenicolor_Canyon Treefrog
 Dryophytes avivoca_Bird-voiced Treefrog
@@ -2008,28 +2008,28 @@ Dryophytes femoralis_Pine Woods Treefrog
 Dryophytes gratiosus_Barking Treefrog
 Dryophytes squirellus_Squirrel Treefrog
 Dryophytes versicolor_Gray Treefrog
-Dryoscopus cubla_Black-backed Puffback
-Dryoscopus gambensis_Northern Puffback
-Dryotriorchis spectabilis_Congo Serpent-Eagle
+Dryoscopus cubla_Puhvselg-pagulind
+Dryoscopus gambensis_Sudaani pagulind
+Dryotriorchis spectabilis_Aafrika maduhaugas
 Dubusia castaneoventris_Chestnut-bellied Mountain Tanager
 Dubusia taeniata_Buff-breasted Mountain Tanager
-Ducula aenea_Green Imperial-Pigeon
-Ducula badia_Mountain Imperial-Pigeon
-Ducula basilica_Cinnamon-bellied Imperial-Pigeon
-Ducula bicolor_Pied Imperial-Pigeon
-Ducula concinna_Elegant Imperial-Pigeon
-Ducula lacernulata_Dark-backed Imperial-Pigeon
-Ducula latrans_Peale's Imperial-Pigeon
-Ducula pacifica_Pacific Imperial-Pigeon
-Ducula perspicillata_Spectacled Imperial-Pigeon
-Ducula pinon_Pinon's Imperial-Pigeon
-Ducula pistrinaria_Island Imperial-Pigeon
-Ducula poliocephala_Pink-bellied Imperial-Pigeon
-Ducula rubricera_Red-knobbed Imperial-Pigeon
-Ducula spilorrhoa_Torresian Imperial-Pigeon
-Ducula zoeae_Zoe's Imperial-Pigeon
-Dulus dominicus_Palmchat
-Dumetella carolinensis_Gray Catbird
+Ducula aenea_Rohe-keisertuvi
+Ducula badia_Pruun-keisertuvi
+Ducula basilica_Halmahera keisertuvi
+Ducula bicolor_Valge-keisertuvi
+Ducula concinna_Sinisaba-keisertuvi
+Ducula lacernulata_Jaava keisertuvi
+Ducula latrans_Fidži keisertuvi
+Ducula pacifica_Okeaania keisertuvi
+Ducula perspicillata_Prill-keisertuvi
+Ducula pinon_Kiil-keisertuvi
+Ducula pistrinaria_Hõbe-keisertuvi
+Ducula poliocephala_Roosakõht-keisertuvi
+Ducula rubricera_Punasagar-keisertuvi
+Ducula spilorrhoa_Pugal-keisertuvi
+Ducula zoeae_Ehis-keisertuvi
+Dulus dominicus_Palmilind
+Dumetella carolinensis_Kass-pilalind
 Dumetia atriceps_Dark-fronted Babbler
 Dumetia hyperythra_Tawny-bellied Babbler
 Dysithamnus leucostictus_White-streaked Antvireo
@@ -2040,18 +2040,18 @@ Dysithamnus puncticeps_Spot-crowned Antvireo
 Dysithamnus stictothorax_Spot-breasted Antvireo
 Dysithamnus striaticeps_Streak-crowned Antvireo
 Dysithamnus xanthopterus_Rufous-backed Antvireo
-Eclectus roratus_Eclectus Parrot
+Eclectus roratus_Erispapagoi
 Edolisoma montanum_Black-bellied Cicadabird
 Edolisoma tenuirostre_Common Cicadabird
-Egretta caerulea_Little Blue Heron
-Egretta eulophotes_Chinese Egret
-Egretta garzetta_Little Egret
+Egretta caerulea_Sinihaigur
+Egretta eulophotes_Hiina siidhaigur
+Egretta garzetta_Siidhaigur
 Egretta gularis_Western Reef-Heron
-Egretta novaehollandiae_White-faced Heron
-Egretta rufescens_Reddish Egret
-Egretta sacra_Pacific Reef-Heron
-Egretta thula_Snowy Egret
-Egretta tricolor_Tricolored Heron
+Egretta novaehollandiae_Valgepõsk-haigur
+Egretta rufescens_Tantsuhaigur
+Egretta sacra_Rifi-siidhaigur
+Egretta thula_Ameerika siidhaigur
+Egretta tricolor_Mudahaigur
 Elachura formosa_Spotted Elachura
 Elaenia albiceps_White-crested Elaenia
 Elaenia brachyptera_Coopmans's Elaenia
@@ -2071,92 +2071,92 @@ Elaenia ruficeps_Rufous-crowned Elaenia
 Elaenia sordida_Small-headed Elaenia
 Elaenia spectabilis_Large Elaenia
 Elaenia strepera_Slaty Elaenia
-Elanoides forficatus_Swallow-tailed Kite
-Elanus caeruleus_Black-winged Kite
-Elanus leucurus_White-tailed Kite
-Electron carinatum_Keel-billed Motmot
-Electron platyrhynchum_Broad-billed Motmot
+Elanoides forficatus_Pääsuhaugas
+Elanus caeruleus_Hõbehaugas
+Elanus leucurus_Ameerika hõbehaugas
+Electron carinatum_Kariibi motmot
+Electron platyrhynchum_Selvamotmot
 Eleoscytalopus indigoticus_White-breasted Tapaculo
-Eleothreptus anomalus_Sickle-winged Nightjar
+Eleothreptus anomalus_Kooldtiib-öösorr
 Eleutherodactylus planirostris_Greenhouse Frog
-Elliotomyia chionogaster_White-bellied Hummingbird
+Elliotomyia chionogaster_Valgekõht-safiirkoolibri
 Elminia albonotata_White-tailed Crested-Flycatcher
 Elminia longicauda_African Blue Flycatcher
-Elseyornis melanops_Black-fronted Dotterel
-Emarginata sinuata_Sickle-winged Chat
-Emberiza aureola_Yellow-breasted Bunting
-Emberiza bruniceps_Red-headed Bunting
-Emberiza buchanani_Gray-necked Bunting
-Emberiza cabanisi_Cabanis's Bunting
-Emberiza caesia_Cretzschmar's Bunting
-Emberiza calandra_Corn Bunting
-Emberiza capensis_Cape Bunting
-Emberiza chrysophrys_Yellow-browed Bunting
-Emberiza cia_Rock Bunting
-Emberiza cineracea_Cinereous Bunting
-Emberiza cioides_Meadow Bunting
-Emberiza cirlus_Cirl Bunting
+Elseyornis melanops_Mudatüll
+Emarginata sinuata_Karoo kaljutäks
+Emberiza aureola_Kuldtsiitsitaja
+Emberiza bruniceps_Punapea-tsiitsitaja
+Emberiza buchanani_Kivitsiitsitaja
+Emberiza cabanisi_Mustpõsk-tsiitsitaja
+Emberiza caesia_Nõlvatsiitsitaja
+Emberiza calandra_Halltsiitsitaja
+Emberiza capensis_Rünkatsiitsitaja
+Emberiza chrysophrys_Evengi tsiitsitaja
+Emberiza cia_Mägitsiitsitaja
+Emberiza cineracea_Türgi tsiitsitaja
+Emberiza cioides_Kingutsiitsitaja
+Emberiza cirlus_Viinamäe-tsiitsitaja
 Emberiza citrinella_Talvike
-Emberiza elegans_Yellow-throated Bunting
-Emberiza flaviventris_Golden-breasted Bunting
-Emberiza fucata_Chestnut-eared Bunting
-Emberiza godlewskii_Godlewski's Bunting
-Emberiza hortulana_Ortolan Bunting
-Emberiza impetuani_Lark-like Bunting
-Emberiza lathami_Crested Bunting
-Emberiza leucocephalos_Pine Bunting
-Emberiza melanocephala_Black-headed Bunting
-Emberiza pallasi_Pallas's Bunting
-Emberiza pusilla_Little Bunting
-Emberiza rustica_Rustic Bunting
-Emberiza sahari_House Bunting
+Emberiza elegans_Tanutsiitsitaja
+Emberiza flaviventris_Savannitsiitsitaja
+Emberiza fucata_Kee-tsiitsitaja
+Emberiza godlewskii_Idatsiitsitaja
+Emberiza hortulana_Põldtsiitsitaja
+Emberiza impetuani_Leet-tsiitsitaja
+Emberiza lathami_Tutt-tsiitsitaja
+Emberiza leucocephalos_Männitalvike
+Emberiza melanocephala_Mustpea-tsiitsitaja
+Emberiza pallasi_Pajutsiitsitaja
+Emberiza pusilla_Väiketsiitsitaja
+Emberiza rustica_Põhjatsiitsitaja
+Emberiza sahari_Külatsiitsitaja
 Emberiza schoeniclus_Rootsiitsitaja
-Emberiza spodocephala_Black-faced Bunting
-Emberiza stewarti_White-capped Bunting
-Emberiza striolata_Striolated Bunting
-Emberiza sulphurata_Yellow Bunting
-Emberiza tahapisi_Cinnamon-breasted Bunting
-Emberiza tristrami_Tristram's Bunting
-Emberiza variabilis_Gray Bunting
-Emberiza yessoensis_Ochre-rumped Bunting
+Emberiza spodocephala_Hallpea-tsiitsitaja
+Emberiza stewarti_Tadžiki tsiitsitaja
+Emberiza striolata_Kaljutsiitsitaja
+Emberiza sulphurata_Honshu tsiitsitaja
+Emberiza tahapisi_Vöötpea-tsiitsitaja
+Emberiza tristrami_Taigatsiitsitaja
+Emberiza variabilis_Ohhoota tsiitsitaja
+Emberiza yessoensis_Karbus-tsiitsitaja
 Emberizoides herbicola_Wedge-tailed Grass-Finch
 Emberizoides ypiranganus_Lesser Grass-Finch
 Embernagra longicauda_Pale-throated Pampa-Finch
 Embernagra platensis_Great Pampa-Finch
 Eminia lepida_Gray-capped Warbler
-Empidonax affinis_Pine Flycatcher
-Empidonax albigularis_White-throated Flycatcher
-Empidonax alnorum_Alder Flycatcher
-Empidonax atriceps_Black-capped Flycatcher
-Empidonax difficilis_Pacific-slope Flycatcher
-Empidonax flavescens_Yellowish Flycatcher
-Empidonax flaviventris_Yellow-bellied Flycatcher
-Empidonax fulvifrons_Buff-breasted Flycatcher
-Empidonax hammondii_Hammond's Flycatcher
-Empidonax minimus_Least Flycatcher
-Empidonax oberholseri_Dusky Flycatcher
-Empidonax occidentalis_Cordilleran Flycatcher
-Empidonax traillii_Willow Flycatcher
-Empidonax virescens_Acadian Flycatcher
-Empidonax wrightii_Gray Flycatcher
-Empidonomus aurantioatrocristatus_Crowned Slaty Flycatcher
-Empidonomus varius_Variegated Flycatcher
+Empidonax affinis_Männi-salutikat
+Empidonax albigularis_Pruun-salutikat
+Empidonax alnorum_Lepa-salutikat
+Empidonax atriceps_Mustpea-salutikat
+Empidonax difficilis_Sekvoia-salutikat
+Empidonax flavescens_Keskameerika salutikat
+Empidonax flaviventris_Kuuse-salutikat
+Empidonax fulvifrons_Ruuge-salutikat
+Empidonax hammondii_Laane-salutikat
+Empidonax minimus_Vahtra-salutikat
+Empidonax oberholseri_Nõlva-salutikat
+Empidonax occidentalis_Mägi-salutikat
+Empidonax traillii_Paju-salutikat
+Empidonax virescens_Lodu-salutikat
+Empidonax wrightii_Hall-salutikat
+Empidonomus aurantioatrocristatus_Tanutikat
+Empidonomus varius_Tähniktikat
 Engine_Engine
-Enicognathus ferrugineus_Austral Parakeet
-Enicognathus leptorhynchus_Slender-billed Parakeet
-Enicurus leschenaulti_White-crowned Forktail
-Enicurus maculatus_Spotted Forktail
-Enicurus schistaceus_Slaty-backed Forktail
-Entomodestes coracinus_Black Solitaire
-Entomodestes leucotis_White-eared Solitaire
+Enicognathus ferrugineus_Väike-pöögipapagoi
+Enicognathus leptorhynchus_Tšiili pöögipapagoi
+Enicurus leschenaulti_Sukel-käärsaba
+Enicurus maculatus_Tähnik-käärsaba
+Enicurus schistaceus_Hall-käärsaba
+Entomodestes coracinus_Valgepõsk-rästas
+Entomodestes leucotis_Tõmmurästas
 Entomyzon cyanotis_Blue-faced Honeyeater
 Environmental_Environmental
-Eolophus roseicapilla_Galah
-Eophona migratoria_Yellow-billed Grosbeak
-Eophona personata_Japanese Grosbeak
-Eopsaltria australis_Eastern Yellow Robin
-Epimachus fastosus_Black Sicklebill
-Epimachus meyeri_Brown Sicklebill
+Eolophus roseicapilla_Roosakakaduu
+Eophona migratoria_Hiina suurnokkvint
+Eophona personata_Laane-suurnokkvint
+Eopsaltria australis_Koldmiro
+Epimachus fastosus_Händ-paradiisilind
+Epimachus meyeri_Mõõksaba-paradiisilind
 Epinecrophylla amazonica_Rio Madeira Stipplethroat
 Epinecrophylla erythrura_Rufous-tailed Stipplethroat
 Epinecrophylla fulviventris_Checker-throated Stipplethroat
@@ -2165,170 +2165,170 @@ Epinecrophylla haematonota_Rufous-backed Stipplethroat
 Epinecrophylla leucophthalma_White-eyed Stipplethroat
 Epinecrophylla ornata_Ornate Stipplethroat
 Epinecrophylla spodionota_Foothill Stipplethroat
-Epthianura tricolor_Crimson Chat
+Epthianura tricolor_Puna-maltsalind
 Eremomela gregalis_Yellow-rumped Eremomela
 Eremomela icteropygialis_Yellow-bellied Eremomela
 Eremomela pusilla_Senegal Eremomela
 Eremomela scotops_Greencap Eremomela
-Eremophila alpestris_Horned Lark
-Eremopterix griseus_Ashy-crowned Sparrow-Lark
-Eremopterix hova_Madagascar Lark
-Eremopterix nigriceps_Black-crowned Sparrow-Lark
+Eremophila alpestris_Sarviklõoke
+Eremopterix griseus_India värblõoke
+Eremopterix hova_Madagaskari lõoke
+Eremopterix nigriceps_Lauk-värblõoke
 Erithacus rubecula_Punarind
 Erpornis zantholeuca_White-bellied Erpornis
-Erythrocercus holochlorus_Yellow Flycatcher
+Erythrocercus holochlorus_Kold-rädilind
 Erythrogenys erythrocnemis_Black-necklaced Scimitar-Babbler
 Erythrogenys erythrogenys_Rusty-cheeked Scimitar-Babbler
 Erythrogenys gravivox_Black-streaked Scimitar-Babbler
 Erythrogenys hypoleucos_Large Scimitar-Babbler
 Erythrogenys mcclellandi_Spot-breasted Scimitar-Babbler
 Erythrogenys swinhoei_Gray-sided Scimitar-Babbler
-Erythropitta arquata_Blue-banded Pitta
-Erythropitta erythrogaster_Blue-breasted Pitta
-Erythropitta granatina_Garnet Pitta
+Erythropitta arquata_Punapita
+Erythropitta erythrogaster_Sinipugu-pita
+Erythropitta granatina_Väikepita
 Erythropitta macklotii_Papuan Pitta
 Erythropitta rufiventris_North Moluccan Pitta
-Erythropitta ussheri_Black-crowned Pitta
-Erythrura trichroa_Blue-faced Parrotfinch
-Esacus magnirostris_Beach Thick-knee
-Esacus recurvirostris_Great Thick-knee
-Estrilda astrild_Common Waxbill
-Estrilda melpoda_Orange-cheeked Waxbill
-Estrilda nonnula_Black-crowned Waxbill
-Estrilda paludicola_Fawn-breasted Waxbill
-Estrilda troglodytes_Black-rumped Waxbill
-Eubucco bourcierii_Red-headed Barbet
-Eubucco richardsoni_Lemon-throated Barbet
+Erythropitta ussheri_Pisipita
+Erythrura trichroa_Sinipõsk-roheamadiin
+Esacus magnirostris_Austraalia jämejalg
+Esacus recurvirostris_India jämejalg
+Estrilda astrild_Vahanokk-amadiin
+Estrilda melpoda_Tulipõsk-amadiin
+Estrilda nonnula_Hallselg-amadiin
+Estrilda paludicola_Pruunselg-amadiin
+Estrilda troglodytes_Savanniamadiin
+Eubucco bourcierii_Andi parbelind
+Eubucco richardsoni_Eris-parbelind
 Euchrepomis callinota_Rufous-rumped Antwren
 Euchrepomis humeralis_Chestnut-shouldered Antwren
 Euchrepomis spodioptila_Ash-winged Antwren
 Eucometis penicillata_Gray-headed Tanager
-Eudocimus albus_White Ibis
-Eudromia elegans_Elegant Crested-Tinamou
-Eudynamys melanorhynchus_Black-billed Koel
-Eudynamys orientalis_Pacific Koel
-Eudynamys scolopaceus_Asian Koel
-Eudyptes chrysocome_Southern Rockhopper Penguin
-Eudyptula minor_Little Penguin
-Eugenes fulgens_Rivoli's Hummingbird
-Eugenes spectabilis_Talamanca Hummingbird
+Eudocimus albus_Valgeiibis
+Eudromia elegans_Tutt-tinamu
+Eudynamys melanorhynchus_Mustnokk-koelkägu
+Eudynamys orientalis_Austraalia koelkägu
+Eudynamys scolopaceus_Koelkägu
+Eudyptes chrysocome_Kaljupingviin
+Eudyptula minor_Kääbuspingviin
+Eugenes fulgens_Kroonkoolibri
+Eugenes spectabilis_Talamanca kroonkoolibri
 Eugralla paradoxa_Ochre-flanked Tapaculo
-Eumomota superciliosa_Turquoise-browed Motmot
-Eumyias albicaudatus_Nilgiri Flycatcher
-Eumyias indigo_Indigo Flycatcher
-Eumyias panayensis_Turquoise Flycatcher
-Eumyias thalassinus_Verditer Flycatcher
+Eumomota superciliosa_Türkiismotmot
+Eumyias albicaudatus_Kerala sininäpp
+Eumyias indigo_Indigo-sininäpp
+Eumyias panayensis_Kagu-sininäpp
+Eumyias thalassinus_Lasuur-sininäpp
 Eunemobius carolinus_Carolina Ground Cricket
 Eunemobius confusus_Confused Ground Cricket
-Euodice cantans_African Silverbill
-Euodice malabarica_Indian Silverbill
+Euodice cantans_Aafrika leetamadiin
+Euodice malabarica_India leetamadiin
 Eupetes macrocerus_Malaysian Rail-babbler
-Eupetomena cirrochloris_Sombre Hummingbird
-Eupetomena macroura_Swallow-tailed Hummingbird
-Euphagus carolinus_Rusty Blackbird
-Euphagus cyanocephalus_Brewer's Blackbird
-Eupherusa eximia_Stripe-tailed Hummingbird
-Euphonia affinis_Scrub Euphonia
-Euphonia anneae_Tawny-capped Euphonia
-Euphonia cayennensis_Golden-sided Euphonia
-Euphonia chalybea_Green-throated Euphonia
-Euphonia chlorotica_Purple-throated Euphonia
-Euphonia chrysopasta_Golden-bellied Euphonia
-Euphonia concinna_Velvet-fronted Euphonia
-Euphonia finschi_Finsch's Euphonia
-Euphonia fulvicrissa_Fulvous-vented Euphonia
-Euphonia gouldi_Olive-backed Euphonia
-Euphonia hirundinacea_Yellow-throated Euphonia
-Euphonia imitans_Spot-crowned Euphonia
-Euphonia laniirostris_Thick-billed Euphonia
-Euphonia luteicapilla_Yellow-crowned Euphonia
-Euphonia mesochrysa_Bronze-green Euphonia
-Euphonia minuta_White-vented Euphonia
-Euphonia pectoralis_Chestnut-bellied Euphonia
-Euphonia plumbea_Plumbeous Euphonia
-Euphonia rufiventris_Rufous-bellied Euphonia
-Euphonia trinitatis_Trinidad Euphonia
-Euphonia violacea_Violaceous Euphonia
-Euphonia xanthogaster_Orange-bellied Euphonia
-Euplectes afer_Yellow-crowned Bishop
-Euplectes ardens_Red-collared Widowbird
-Euplectes capensis_Yellow Bishop
-Euplectes franciscanus_Northern Red Bishop
-Euplectes hordeaceus_Black-winged Bishop
-Euplectes orix_Southern Red Bishop
-Euplectes progne_Long-tailed Widowbird
-Eupodotis afra_Black Bustard
-Eupodotis afraoides_White-quilled Bustard
-Eupodotis caerulescens_Blue Bustard
-Eupodotis ruficrista_Red-crested Bustard
-Eupodotis senegalensis_White-bellied Bustard
-Eupodotis vigorsii_Karoo Bustard
-Eupsittula aurea_Peach-fronted Parakeet
-Eupsittula cactorum_Cactus Parakeet
-Eupsittula canicularis_Orange-fronted Parakeet
-Eupsittula nana_Olive-throated Parakeet
-Eupsittula pertinax_Brown-throated Parakeet
-Euptilotis neoxenus_Eared Quetzal
-Eurillas ansorgei_Ansorge's Greenbul
-Eurillas curvirostris_Plain Greenbul
-Eurillas latirostris_Yellow-whiskered Greenbul
-Eurillas virens_Little Greenbul
-Eurocephalus ruppelli_White-rumped Shrike
-Eurostopodus argus_Spotted Nightjar
-Eurostopodus mystacalis_White-throated Nightjar
-Eurylaimus javanicus_Banded Broadbill
-Eurylaimus ochromalus_Black-and-yellow Broadbill
-Eurypyga helias_Sunbittern
-Eurystomus glaucurus_Broad-billed Roller
-Eurystomus orientalis_Dollarbird
+Eupetomena cirrochloris_Ihmkoolibri
+Eupetomena macroura_Pääsukoolibri
+Euphagus carolinus_Taigaturpial
+Euphagus cyanocephalus_Väluturpial
+Eupherusa eximia_Triipsaba-pagunkoolibri
+Euphonia affinis_Mehhiko marjavint
+Euphonia anneae_Ruskkiird-marjavint
+Euphonia cayennensis_Tume-marjavint
+Euphonia chalybea_Suurnokk-marjavint
+Euphonia chlorotica_Võsa-marjavint
+Euphonia chrysopasta_Viher-marjavint
+Euphonia concinna_Samet-marjavint
+Euphonia finschi_Guajaana marjavint
+Euphonia fulvicrissa_Kolumbia marjavint
+Euphonia gouldi_Oliiv-marjavint
+Euphonia hirundinacea_Kuldkurk-marjavint
+Euphonia imitans_Kirilaup-marjavint
+Euphonia laniirostris_Tanu-marjavint
+Euphonia luteicapilla_Niidu-marjavint
+Euphonia mesochrysa_Nõlva-marjavint
+Euphonia minuta_Valgekõht-marjavint
+Euphonia pectoralis_Ruskekõht-marjavint
+Euphonia plumbea_Hall-marjavint
+Euphonia rufiventris_Amasoonia marjavint
+Euphonia trinitatis_Salu-marjavint
+Euphonia violacea_Pila-marjavint
+Euphonia xanthogaster_Tulipea-marjavint
+Euplectes afer_Väike-kangurlind
+Euplectes ardens_Händ-kangurlind
+Euplectes capensis_Kimalas-kangurlind
+Euplectes franciscanus_Põhja-kangurlind
+Euplectes hordeaceus_Krae-kangurlind
+Euplectes orix_Lõuna-kangurlind
+Euplectes progne_Vedik-kangurlind
+Eupodotis afra_Musttrapp
+Eupodotis afraoides_Peegeltrapp
+Eupodotis caerulescens_Sinitrapp
+Eupodotis ruficrista_Viletrapp
+Eupodotis senegalensis_Ruugetrapp
+Eupodotis vigorsii_Karoo trapp
+Eupsittula aurea_Kampo-aratinga
+Eupsittula cactorum_Kaktuse-aratinga
+Eupsittula canicularis_Ranniku-aratinga
+Eupsittula nana_Väikearatinga
+Eupsittula pertinax_Ljaano-aratinga
+Euptilotis neoxenus_Kõrvukketsal
+Eurillas ansorgei_Hallpea-pruunbülbül
+Eurillas curvirostris_Ruskesaba-pruunbülbül
+Eurillas latirostris_Habe-pruunbülbül
+Eurillas virens_Tõmmu-pruunbülbül
+Eurocephalus ruppelli_Liblikõgija
+Eurostopodus argus_Kõnnu-tanusorr
+Eurostopodus mystacalis_Mets-tanusorr
+Eurylaimus javanicus_Purpur-lainokk
+Eurylaimus ochromalus_Kaelus-lainokk
+Eurypyga helias_Päikesekurg
+Eurystomus glaucurus_Savanni-tõmmuraag
+Eurystomus orientalis_Ida-tõmmuraag
 Euscarthmus fulviceps_Fulvous-headed Pygmy-Tyrant
 Euscarthmus meloryphus_Rufous-crowned Pygmy-Tyrant
 Euscarthmus rufomarginatus_Rufous-sided Pygmy-Tyrant
-Eutoxeres aquila_White-tipped Sicklebill
-Falco amurensis_Amur Falcon
-Falco berigora_Brown Falcon
+Eutoxeres aquila_Rohe-sirpkoolibri
+Falco amurensis_Ida-punajalgpistrik
+Falco berigora_Viupistrik
 Falco columbarius_Väikepistrik
-Falco deiroleucus_Orange-breasted Falcon
-Falco femoralis_Aplomado Falcon
-Falco mexicanus_Prairie Falcon
-Falco naumanni_Lesser Kestrel
+Falco deiroleucus_Ruugepugu-pistrik
+Falco femoralis_Tandempistrik
+Falco mexicanus_Preeriapistrik
+Falco naumanni_Stepi-tuuletallaja
 Falco peregrinus_Rabapistrik
-Falco rufigularis_Bat Falcon
-Falco rusticolus_Gyrfalcon
-Falco sparverius_American Kestrel
+Falco rufigularis_Nahkhiirepistrik
+Falco rusticolus_Jahipistrik
+Falco sparverius_Ameerika tuuletallaja
 Falco subbuteo_Lõopistrik
 Falco tinnunculus_Tuuletallaja
-Falco vespertinus_Red-footed Falcon
+Falco vespertinus_Punajalg-pistrik
 Falculea palliata_Sickle-billed Vanga
 Falcunculus frontatus_Crested Shrike-tit
-Ferminia cerverai_Zapata Wren
-Ficedula albicilla_Taiga Flycatcher
-Ficedula albicollis_Collared Flycatcher
-Ficedula basilanica_Little Slaty Flycatcher
-Ficedula dumetoria_Rufous-chested Flycatcher
-Ficedula elisae_Green-backed Flycatcher
-Ficedula erithacus_Slaty-backed Flycatcher
-Ficedula hodgsoni_Pygmy Flycatcher
-Ficedula hyperythra_Snowy-browed Flycatcher
+Ferminia cerverai_Mõõkrohukäblik
+Ficedula albicilla_Siberi kärbsenäpp
+Ficedula albicollis_Kaelus-kärbsenäpp
+Ficedula basilanica_Pagu-kärbsenäpp
+Ficedula dumetoria_Joonik-kärbsenäpp
+Ficedula elisae_Rohepea-kärbsenäpp
+Ficedula erithacus_Punarind-kärbsenäpp
+Ficedula hodgsoni_Kääbus-kärbsenäpp
+Ficedula hyperythra_Kiltselg-kärbsenäpp
 Ficedula hypoleuca_Must-kärbsenäpp
-Ficedula mugimaki_Mugimaki Flycatcher
-Ficedula narcissina_Narcissus Flycatcher
-Ficedula nigrorufa_Black-and-orange Flycatcher
+Ficedula mugimaki_Taiga-kärbsenäpp
+Ficedula narcissina_Jaapani kärbsenäpp
+Ficedula nigrorufa_Ruuge-kärbsenäpp
 Ficedula parva_Väike-kärbsenäpp
-Ficedula ruficauda_Rusty-tailed Flycatcher
-Ficedula semitorquata_Semicollared Flycatcher
-Ficedula strophiata_Rufous-gorgeted Flycatcher
-Ficedula subrubra_Kashmir Flycatcher
-Ficedula superciliaris_Ultramarine Flycatcher
-Ficedula tricolor_Slaty-blue Flycatcher
-Ficedula westermanni_Little Pied Flycatcher
-Ficedula zanthopygia_Yellow-rumped Flycatcher
+Ficedula ruficauda_Ruskesaba-kärbsenäpp
+Ficedula semitorquata_Tamme-kärbsenäpp
+Ficedula strophiata_Mägi-kärbsenäpp
+Ficedula subrubra_Kašmiiri kärbsenäpp
+Ficedula superciliaris_Sini-kärbsenäpp
+Ficedula tricolor_Põõsa-kärbsenäpp
+Ficedula westermanni_Pugal-kärbsenäpp
+Ficedula zanthopygia_Kuld-kärbsenäpp
 Fireworks_Fireworks
-Florisuga fusca_Black Jacobin
-Florisuga mellivora_White-necked Jacobin
-Fluvicola albiventer_Black-backed Water-Tyrant
-Fluvicola nengeta_Masked Water-Tyrant
-Fluvicola pica_Pied Water-Tyrant
+Florisuga fusca_Mustkoolibri
+Florisuga mellivora_Pugalkoolibri
+Fluvicola albiventer_Vööt-padutikat
+Fluvicola nengeta_Mask-padutikat
+Fluvicola pica_Pugal-padutikat
 Formicarius analis_Black-faced Antthrush
 Formicarius colma_Rufous-capped Antthrush
 Formicarius moniliger_Mayan Antthrush
@@ -2343,42 +2343,42 @@ Formicivora iheringi_Narrow-billed Antwren
 Formicivora melanogaster_Black-bellied Antwren
 Formicivora rufa_Rusty-backed Antwren
 Formicivora serrana_Serra Antwren
-Forpus coelestis_Pacific Parrotlet
-Forpus conspicillatus_Spectacled Parrotlet
-Forpus cyanopygius_Mexican Parrotlet
-Forpus modestus_Dusky-billed Parrotlet
-Forpus passerinus_Green-rumped Parrotlet
-Forpus xanthopterygius_Cobalt-rumped Parrotlet
-Foudia madagascariensis_Red Fody
-Foudia rubra_Mauritius Fody
+Forpus coelestis_Võsa-värbpapagoi
+Forpus conspicillatus_Kolumbia värbpapagoi
+Forpus cyanopygius_Mehhiko värbpapagoi
+Forpus modestus_Amasoonia värbpapagoi
+Forpus passerinus_Roheselg-värbpapagoi
+Forpus xanthopterygius_Brasiilia värbpapagoi
+Foudia madagascariensis_Kinaver-kangurlind
+Foudia rubra_Mauritiuse kangurlind
 Foulehaio carunculatus_Eastern Wattled-Honeyeater
 Foulehaio procerior_Western Wattled-Honeyeater
-Francolinus francolinus_Black Francolin
-Francolinus pictus_Painted Francolin
-Francolinus pintadeanus_Chinese Francolin
-Fraseria caerulescens_Ashy Flycatcher
-Fraseria griseigularis_Gray-throated Tit-Flycatcher
-Fraseria ocreata_African Forest-Flycatcher
-Fraseria plumbea_Gray Tit-Flycatcher
-Fratercula arctica_Atlantic Puffin
+Francolinus francolinus_Mustfrankoliin
+Francolinus pictus_Vihma-frankoliin
+Francolinus pintadeanus_Ida-frankoliin
+Fraseria caerulescens_Kilt-kärbsenäpp
+Fraseria griseigularis_Tina-kärbsenäpp
+Fraseria ocreata_Ühis-kärbsenäpp
+Fraseria plumbea_Tihas-kärbsenäpp
+Fratercula arctica_Lunn
 Frederickena fulva_Fulvous Antshrike
 Frederickena unduliger_Undulated Antshrike
 Frederickena viridis_Black-throated Antshrike
-Fregata andrewsi_Christmas Island Frigatebird
-Fregata ariel_Lesser Frigatebird
-Fregata magnificens_Magnificent Frigatebird
-Fregata minor_Great Frigatebird
+Fregata andrewsi_Jõulusaare fregattlind
+Fregata ariel_Väike-fregattlind
+Fregata magnificens_Keiser-fregattlind
+Fregata minor_Kuning-fregattlind
 Fringilla coelebs_Metsvint
 Fringilla montifringilla_Põhjavint
-Fulica alai_Hawaiian Coot
-Fulica americana_American Coot
-Fulica ardesiaca_Slate-colored Coot
-Fulica armillata_Red-gartered Coot
+Fulica alai_Havai lauk
+Fulica americana_Ameerika lauk
+Fulica ardesiaca_Andi lauk
+Fulica armillata_Tähtlauk
 Fulica atra_Lauk
-Fulica cristata_Red-knobbed Coot
-Fulica gigantea_Giant Coot
-Fulica rufifrons_Red-fronted Coot
-Fulmarus glacialis_Northern Fulmar
+Fulica cristata_Sagarlauk
+Fulica gigantea_Suurlauk
+Fulica rufifrons_Rägalauk
+Fulmarus glacialis_Jää-tormilind
 Fulvetta formosana_Taiwan Fulvetta
 Fulvetta ruficapilla_Spectacled Fulvetta
 Fulvetta vinipectus_White-browed Fulvetta
@@ -2387,89 +2387,89 @@ Furnarius figulus_Wing-banded Hornero
 Furnarius leucopus_Pale-legged Hornero
 Furnarius minor_Lesser Hornero
 Furnarius rufus_Rufous Hornero
-Galbalcyrhynchus leucotis_White-eared Jacamar
-Galbalcyrhynchus purusianus_Purus Jacamar
-Galbula albirostris_Yellow-billed Jacamar
-Galbula chalcothorax_Purplish Jacamar
-Galbula cyanescens_Bluish-fronted Jacamar
-Galbula cyanicollis_Blue-cheeked Jacamar
-Galbula dea_Paradise Jacamar
-Galbula galbula_Green-tailed Jacamar
-Galbula leucogastra_Bronzy Jacamar
-Galbula pastazae_Coppery-chested Jacamar
-Galbula ruficauda_Rufous-tailed Jacamar
-Galbula tombacea_White-chinned Jacamar
-Galerida cristata_Crested Lark
-Galerida deva_Tawny Lark
-Galerida magnirostris_Large-billed Lark
-Galerida malabarica_Malabar Lark
-Galerida theklae_Thekla's Lark
-Gallicrex cinerea_Watercock
-Gallinago andina_Puna Snipe
-Gallinago delicata_Wilson's Snipe
+Galbalcyrhynchus leucotis_Valgekõrv-läiklind
+Galbalcyrhynchus purusianus_Ruske-läiklind
+Galbula albirostris_Selva-läiklind
+Galbula chalcothorax_Purpur-läiklind
+Galbula cyanescens_Türkiis-läiklind
+Galbula cyanicollis_Lodu-läiklind
+Galbula dea_Tõmmu-läiklind
+Galbula galbula_Guajaana läiklind
+Galbula leucogastra_Pronks-läiklind
+Galbula pastazae_Nõlva-läiklind
+Galbula ruficauda_Punasaba-läiklind
+Galbula tombacea_Tanu-läiklind
+Galerida cristata_Tuttlõoke
+Galerida deva_Väike-tuttlõoke
+Galerida magnirostris_Lõunalõoke
+Galerida malabarica_Malabari tuttlõoke
+Galerida theklae_Kivi-tuttlõoke
+Gallicrex cinerea_Sarviktait
+Gallinago andina_Puunatikutaja
+Gallinago delicata_Ameerika tikutaja
 Gallinago gallinago_Tikutaja
-Gallinago hardwickii_Latham's Snipe
-Gallinago imperialis_Imperial Snipe
-Gallinago jamesoni_Jameson's Snipe
+Gallinago hardwickii_Jaapani nepp
+Gallinago imperialis_Inkanepp
+Gallinago jamesoni_Andi nepp
 Gallinago magellanica_Magellanic Snipe
-Gallinago media_Great Snipe
-Gallinago megala_Swinhoe's Snipe
-Gallinago nobilis_Noble Snipe
-Gallinago paraguaiae_Paraguayan Snipe
-Gallinago stenura_Pin-tailed Snipe
-Gallinago undulata_Giant Snipe
+Gallinago media_Rohunepp
+Gallinago megala_Taiganepp
+Gallinago nobilis_Ülangunepp
+Gallinago paraguaiae_Heletikutaja
+Gallinago stenura_Siberi nepp
+Gallinago undulata_Hiidnepp
 Gallinula chloropus_Tait
-Gallinula galeata_Common Gallinule
-Gallinula tenebrosa_Dusky Moorhen
-Gallirallus australis_Weka
-Gallirallus philippensis_Buff-banded Rail
-Gallirallus torquatus_Barred Rail
-Galloperdix bicalcarata_Sri Lanka Spurfowl
-Galloperdix spadicea_Red Spurfowl
-Gallus gallus_Red Junglefowl
-Gallus lafayettii_Sri Lanka Junglefowl
-Gallus sonneratii_Gray Junglefowl
-Gallus varius_Green Junglefowl
-Gampsonyx swainsonii_Pearl Kite
+Gallinula galeata_Ameerika tait
+Gallinula tenebrosa_Tumetait
+Gallirallus australis_Veeka
+Gallirallus philippensis_Vööruik
+Gallirallus torquatus_Kriimruik
+Galloperdix bicalcarata_Tseiloni kannuskana
+Galloperdix spadicea_Ruuge-kannuskana
+Gallus gallus_Puna-džunglikana
+Gallus lafayettii_Tseiloni džunglikana
+Gallus sonneratii_Täpik-džunglikana
+Gallus varius_Rohe-džunglikana
+Gampsonyx swainsonii_Pisihaugas
 Gampsorhynchus rufulus_White-hooded Babbler
 Gampsorhynchus torquatus_Collared Babbler
-Garrulax canorus_Chinese Hwamei
-Garrulax leucolophus_White-crested Laughingthrush
-Garrulax milleti_Black-hooded Laughingthrush
-Garrulax monileger_Lesser Necklaced Laughingthrush
-Garrulax palliatus_Sunda Laughingthrush
-Garrulax strepitans_White-necked Laughingthrush
-Garrulax taewanus_Taiwan Hwamei
+Garrulax canorus_Hiina lauluvädrak
+Garrulax leucolophus_Mask-naeruvädrak
+Garrulax milleti_Kaelus-naeruvädrak
+Garrulax monileger_Kee-naeruvädrak
+Garrulax palliatus_Sunda naeruvädrak
+Garrulax strepitans_Pruunkiird-naeruvädrak
+Garrulax taewanus_Taivani lauluvädrak
 Garrulus glandarius_Pasknäär
-Garrulus lanceolatus_Black-headed Jay
-Garrulus lidthi_Lidth's Jay
+Garrulus lanceolatus_Tutt-pasknäär
+Garrulus lidthi_Ryukyu pasknäär
 Gastrophryne carolinensis_Eastern Narrow-mouthed Toad
 Gastrophryne olivacea_Great Plains Narrow-mouthed Toad
-Gavia adamsii_Yellow-billed Loon
+Gavia adamsii_Tundrakaur
 Gavia arctica_Järvekaur
-Gavia immer_Common Loon
-Gavia pacifica_Pacific Loon
+Gavia immer_Jääkaur
+Gavia pacifica_Kirdekaur
 Gavia stellata_Punakurk-kaur
 Gavicalis fasciogularis_Mangrove Honeyeater
 Gavicalis virescens_Singing Honeyeater
-Gecinulus grantia_Pale-headed Woodpecker
-Gecinulus viridis_Bamboo Woodpecker
-Gelochelidon nilotica_Gull-billed Tern
+Gecinulus grantia_Leetkiird-bambuserähn
+Gecinulus viridis_Punapea-bambuserähn
+Gelochelidon nilotica_Naerutiir
 Geocerthia serrana_Striated Earthcreeper
-Geococcyx californianus_Greater Roadrunner
-Geococcyx velox_Lesser Roadrunner
-Geoffroyus geoffroyi_Red-cheeked Parrot
-Geoffroyus heteroclitus_Singing Parrot
-Geokichla citrina_Orange-headed Thrush
-Geokichla gurneyi_Orange Ground-Thrush
-Geokichla guttata_Spotted Ground-Thrush
-Geokichla peronii_Orange-banded Thrush
-Geokichla piaggiae_Abyssinian Ground-Thrush
-Geokichla sibirica_Siberian Thrush
-Geokichla spiloptera_Spot-winged Thrush
-Geopelia humeralis_Bar-shouldered Dove
-Geopelia placida_Peaceful Dove
-Geopelia striata_Zebra Dove
+Geococcyx californianus_Suur-jooksurkägu
+Geococcyx velox_Väike-jooksurkägu
+Geoffroyus geoffroyi_Punapõsk-papagoi
+Geoffroyus heteroclitus_Kuldpea-papagoi
+Geokichla citrina_Ruuge-maarästas
+Geokichla gurneyi_Mägi-maarästas
+Geokichla guttata_Täpik-maarästas
+Geokichla peronii_Timori maarästas
+Geokichla piaggiae_Sõõrsilm-maarästas
+Geokichla sibirica_Siberi rästas
+Geokichla spiloptera_Tseiloni maarästas
+Geopelia humeralis_Pandanituvi
+Geopelia placida_Austraalia viirtuvi
+Geopelia striata_Viirtuvi
 Geositta antarctica_Short-billed Miner
 Geositta cunicularia_Common Miner
 Geositta punensis_Puna Miner
@@ -2477,74 +2477,74 @@ Geositta rufipennis_Rufous-banded Miner
 Geositta tenuirostris_Slender-billed Miner
 Geospizopsis plebejus_Ash-breasted Sierra Finch
 Geospizopsis unicolor_Plumbeous Sierra Finch
-Geothlypis aequinoctialis_Masked Yellowthroat
-Geothlypis beldingi_Belding's Yellowthroat
-Geothlypis formosa_Kentucky Warbler
-Geothlypis nelsoni_Hooded Yellowthroat
-Geothlypis philadelphia_Mourning Warbler
-Geothlypis poliocephala_Gray-crowned Yellowthroat
-Geothlypis rostrata_Bahama Yellowthroat
-Geothlypis semiflava_Olive-crowned Yellowthroat
-Geothlypis speciosa_Black-polled Yellowthroat
-Geothlypis tolmiei_MacGillivray's Warbler
-Geothlypis trichas_Common Yellowthroat
-Geotrygon chrysia_Key West Quail-Dove
-Geotrygon montana_Ruddy Quail-Dove
-Geotrygon violacea_Violaceous Quail-Dove
+Geothlypis aequinoctialis_Lõuna-masksäälik
+Geothlypis beldingi_Kalifornia masksäälik
+Geothlypis formosa_Habesäälik
+Geothlypis nelsoni_Kaktuse-masksäälik
+Geothlypis philadelphia_Mustpugu-säälik
+Geothlypis poliocephala_Valjassäälik
+Geothlypis rostrata_Bahama masksäälik
+Geothlypis semiflava_Heina-masksäälik
+Geothlypis speciosa_Luha-masksäälik
+Geothlypis tolmiei_Kiltpugu-säälik
+Geothlypis trichas_Põhja-masksäälik
+Geotrygon chrysia_Pronks-töbituvi
+Geotrygon montana_Pruun-töbituvi
+Geotrygon violacea_Ametüst-töbituvi
 Geranoaetus albicaudatus_White-tailed Hawk
-Geranoaetus melanoleucus_Black-chested Buzzard-Eagle
-Geranoaetus polyosoma_Variable Hawk
-Geranospiza caerulescens_Crane Hawk
-Geronticus eremita_Northern Bald Ibis
-Gerygone chloronota_Green-backed Gerygone
-Gerygone flavolateralis_Fan-tailed Gerygone
-Gerygone fusca_Western Gerygone
-Gerygone igata_Gray Gerygone
-Gerygone levigaster_Mangrove Gerygone
-Gerygone magnirostris_Large-billed Gerygone
-Gerygone mouki_Brown Gerygone
-Gerygone olivacea_White-throated Gerygone
-Gerygone palpebrosa_Fairy Gerygone
-Gerygone sulphurea_Golden-bellied Gerygone
-Glareola lactea_Small Pratincole
-Glareola maldivarum_Oriental Pratincole
-Glareola pratincola_Collared Pratincole
-Glaucestrilda caerulescens_Lavender Waxbill
-Glaucidium bolivianum_Yungas Pygmy-Owl
-Glaucidium brasilianum_Ferruginous Pygmy-Owl
-Glaucidium capense_African Barred Owlet
-Glaucidium castanopterum_Javan Owlet
-Glaucidium castanotum_Chestnut-backed Owlet
-Glaucidium costaricanum_Costa Rican Pygmy-Owl
-Glaucidium cuculoides_Asian Barred Owlet
-Glaucidium gnoma_Northern Pygmy-Owl
-Glaucidium griseiceps_Central American Pygmy-Owl
-Glaucidium hardyi_Amazonian Pygmy-Owl
-Glaucidium jardinii_Andean Pygmy-Owl
-Glaucidium minutissimum_Least Pygmy-Owl
-Glaucidium nana_Austral Pygmy-Owl
-Glaucidium nubicola_Cloud-forest Pygmy-Owl
-Glaucidium palmarum_Colima Pygmy-Owl
-Glaucidium parkeri_Subtropical Pygmy-Owl
-Glaucidium passerinum_Eurasian Pygmy-Owl
-Glaucidium perlatum_Pearl-spotted Owlet
-Glaucidium peruanum_Peruvian Pygmy-Owl
-Glaucidium radiatum_Jungle Owlet
-Glaucidium sanchezi_Tamaulipas Pygmy-Owl
-Glaucidium siju_Cuban Pygmy-Owl
-Glaucidium tephronotum_Red-chested Owlet
-Glaucis dohrnii_Hook-billed Hermit
-Glaucis hirsutus_Rufous-breasted Hermit
+Geranoaetus melanoleucus_Kotkasviu
+Geranoaetus polyosoma_Mägiviu
+Geranospiza caerulescens_Väänjalg-viu
+Geronticus eremita_Kaljuiibis
+Gerygone chloronota_Roheselg-sirilind
+Gerygone flavolateralis_Melaneesia sirilind
+Gerygone fusca_Leet-sirilind
+Gerygone igata_Maoori sirilind
+Gerygone levigaster_Mangroovi-sirilind
+Gerygone magnirostris_Padu-sirilind
+Gerygone mouki_Mets-sirilind
+Gerygone olivacea_Valgekurk-sirilind
+Gerygone palpebrosa_Habe-sirilind
+Gerygone sulphurea_Kuldkurk-sirilind
+Glareola lactea_Väike-pääsujooksur
+Glareola maldivarum_Ida-pääsujooksur
+Glareola pratincola_Kõnnu-pääsujooksur
+Glaucestrilda caerulescens_Põhja-hõbeamadiin
+Glaucidium bolivianum_Lepa-värbkakk
+Glaucidium brasilianum_Õnne-värbkakk
+Glaucidium capense_Täpik-värbkakk
+Glaucidium castanopterum_Jaava värbkakk
+Glaucidium castanotum_Tseiloni värbkakk
+Glaucidium costaricanum_Kostariika värbkakk
+Glaucidium cuculoides_Vööt-värbkakk
+Glaucidium gnoma_Mehhiko värbkakk
+Glaucidium griseiceps_Keskameerika värbkakk
+Glaucidium hardyi_Amasoonia värbkakk
+Glaucidium jardinii_Mägi-värbkakk
+Glaucidium minutissimum_Pisi-värbkakk
+Glaucidium nana_Lõuna-värbkakk
+Glaucidium nubicola_Udumetsa-värbkakk
+Glaucidium palmarum_Jalami-värbkakk
+Glaucidium parkeri_Ketšua värbkakk
+Glaucidium passerinum_Värbkakk
+Glaucidium perlatum_Savanni-värbkakk
+Glaucidium peruanum_Peruu värbkakk
+Glaucidium radiatum_Džungli-värbkakk
+Glaucidium sanchezi_Tamaulipase värbkakk
+Glaucidium siju_Kuuba värbkakk
+Glaucidium tephronotum_Tõmmuselg-värbkakk
+Glaucis dohrnii_Bahia selvakoolibri
+Glaucis hirsutus_Ruskepugu-selvakoolibri
 Gliciphila melanops_Tawny-crowned Honeyeater
-Glossopsitta concinna_Musk Lorikeet
+Glossopsitta concinna_Muskus-nestepapagoi
 Glyphorynchus spirurus_Wedge-billed Woodcreeper
-Gnorimopsar chopi_Chopi Blackbird
-Gorsachius melanolophus_Malayan Night-Heron
-Gracula indica_Southern Hill Myna
-Gracula ptilogenys_Sri Lanka Myna
-Gracula religiosa_Common Hill Myna
-Gracupica contra_Asian Pied Starling
-Gracupica nigricollis_Black-collared Starling
+Gnorimopsar chopi_Nõgiturpial
+Gorsachius melanolophus_Ida-ööhaigur
+Gracula indica_Draviidi maina
+Gracula ptilogenys_Singali maina
+Gracula religiosa_Suurmaina
+Gracupica contra_Pugal-kuldnokk
+Gracupica nigricollis_Kaelus-kuldnokk
 Grallaria albigula_White-throated Antpitta
 Grallaria alleni_Moustached Antpitta
 Grallaria andicolus_Stripe-headed Antpitta
@@ -2586,48 +2586,48 @@ Grallaricula lineifrons_Crescent-faced Antpitta
 Grallaricula nana_Slate-crowned Antpitta
 Grallaricula ochraceifrons_Ochre-fronted Antpitta
 Grallaricula peruviana_Peruvian Antpitta
-Grallina cyanoleuca_Magpie-lark
-Grammatoptila striata_Striated Laughingthrush
-Granatellus pelzelni_Rose-breasted Chat
-Granatellus sallaei_Gray-throated Chat
-Granatellus venustus_Red-breasted Chat
-Granatina ianthinogaster_Purple Grenadier
+Grallina cyanoleuca_Suurpiibik
+Grammatoptila striata_Harivädrak
+Granatellus pelzelni_Lõuna-rubiinsäälik
+Granatellus sallaei_Yucatani rubiinsäälik
+Granatellus venustus_Põhja-rubiinsäälik
+Granatina ianthinogaster_Aaloeamadiin
 Grantiella picta_Painted Honeyeater
-Graydidascalus brachyurus_Short-tailed Parrot
-Grus americana_Whooping Crane
+Graydidascalus brachyurus_Liblikpapagoi
+Grus americana_Trompetkurg
 Grus grus_Sookurg
-Grus japonensis_Red-crowned Crane
-Grus monacha_Hooded Crane
-Grus nigricollis_Black-necked Crane
+Grus japonensis_Õnnekurg
+Grus monacha_Munkkurg
+Grus nigricollis_Mägikurg
 Gryllus assimilis_Gryllus assimilis
 Gryllus fultoni_Southern Wood Cricket
 Gryllus pennsylvanicus_Fall Field Cricket
 Gryllus rubens_Southeastern Field Cricket
-Guaruba guarouba_Golden Parakeet
+Guaruba guarouba_Kuldaratinga
 Gubernatrix cristata_Yellow Cardinal
 Gubernetes yetapa_Streamer-tailed Tyrant
-Guira guira_Guira Cuckoo
+Guira guira_Guirakägu
 Gun_Gun
-Guttera pucherani_Crested Guineafowl
-Gygis alba_White Tern
-Gymnasio nudipes_Puerto Rican Owl
-Gymnobucco bonapartei_Gray-throated Barbet
-Gymnobucco calvus_Naked-faced Barbet
+Guttera pucherani_Kähar-pärlkana
+Gygis alba_Haldjastiir
+Gymnasio nudipes_Puertoriiko päll
+Gymnobucco bonapartei_Hallkurk-udelind
+Gymnobucco calvus_Kiilas-udelind
 Gymnocichla nudiceps_Bare-crowned Antbird
-Gymnomystax mexicanus_Oriole Blackbird
+Gymnomystax mexicanus_Pihoturpial
 Gymnomyza brunneirostris_Duetting Giant-Honeyeater
 Gymnomyza samoensis_Mao
 Gymnopithys bicolor_Bicolored Antbird
 Gymnopithys leucaspis_White-cheeked Antbird
 Gymnopithys rufigula_Rufous-throated Antbird
-Gymnorhina tibicen_Australian Magpie
-Gymnorhinus cyanocephalus_Pinyon Jay
-Gymnoris dentata_Sahel Bush Sparrow
-Gymnoris pyrgita_Yellow-spotted Bush Sparrow
-Gymnoris superciliaris_Yellow-throated Bush Sparrow
-Gymnoris xanthocollis_Yellow-throated Sparrow
-Gyps fulvus_Eurasian Griffon
-Gyps himalayensis_Himalayan Griffon
+Gymnorhina tibicen_Suurleigar
+Gymnorhinus cyanocephalus_Männi-sininäär
+Gymnoris dentata_Punakulm-varblane
+Gymnoris pyrgita_Aafrika tuhkvarblane
+Gymnoris superciliaris_Valgekulm-varblane
+Gymnoris xanthocollis_Tuhkvarblane
+Gyps fulvus_Kaeluskotkas
+Gyps himalayensis_Kumai-kaeluskotkas
 Gypsophila brevicaudata_Streaked Wren-Babbler
 Gypsophila rufipectus_Rusty-breasted Wren-Babbler
 Habia atrimaxillaris_Black-cheeked Ant-Tanager
@@ -2635,87 +2635,87 @@ Habia cristata_Crested Ant-Tanager
 Habia fuscicauda_Red-throated Ant-Tanager
 Habia gutturalis_Sooty Ant-Tanager
 Habia rubica_Red-crowned Ant-Tanager
-Haematopus ater_Blackish Oystercatcher
-Haematopus bachmani_Black Oystercatcher
-Haematopus finschi_South Island Oystercatcher
-Haematopus fuliginosus_Sooty Oystercatcher
-Haematopus leucopodus_Magellanic Oystercatcher
-Haematopus longirostris_Pied Oystercatcher
+Haematopus ater_Lõuna-mustmerisk
+Haematopus bachmani_Põhja-mustmerisk
+Haematopus finschi_Põldmerisk
+Haematopus fuliginosus_Austraalia mustmerisk
+Haematopus leucopodus_Patagoonia merisk
+Haematopus longirostris_Austraalia merisk
 Haematopus ostralegus_Merisk
-Haematopus palliatus_American Oystercatcher
-Haematopus unicolor_Variable Oystercatcher
-Haematortyx sanguiniceps_Crimson-headed Partridge
-Haemorhous cassinii_Cassin's Finch
-Haemorhous mexicanus_House Finch
-Haemorhous purpureus_Purple Finch
+Haematopus palliatus_Ameerika merisk
+Haematopus unicolor_Maoori mustmerisk
+Haematortyx sanguiniceps_Süsikana
+Haemorhous cassinii_Männi-karmiinleevike
+Haemorhous mexicanus_Aed-karmiinleevike
+Haemorhous purpureus_Ameerika karmiinleevike
 Hafferia fortis_Sooty Antbird
 Hafferia immaculata_Blue-lored Antbird
 Hafferia zeledoni_Zeledon's Antbird
-Halcyon albiventris_Brown-hooded Kingfisher
-Halcyon badia_Chocolate-backed Kingfisher
-Halcyon chelicuti_Striped Kingfisher
-Halcyon coromanda_Ruddy Kingfisher
+Halcyon albiventris_Välja-safiirlind
+Halcyon badia_Mahagon-safiirlind
+Halcyon chelicuti_Triip-safiirlind
+Halcyon coromanda_Puna-safiirlind
 Halcyon gularis_Brown-breasted Kingfisher
-Halcyon leucocephala_Gray-headed Kingfisher
-Halcyon malimbica_Blue-breasted Kingfisher
-Halcyon pileata_Black-capped Kingfisher
-Halcyon senegalensis_Woodland Kingfisher
-Halcyon smyrnensis_White-throated Kingfisher
+Halcyon leucocephala_Hallpea-safiirlind
+Halcyon malimbica_Sinipugu-safiirlind
+Halcyon pileata_Mustpea-safiirlind
+Halcyon senegalensis_Salu-safiirlind
+Halcyon smyrnensis_Ruske-safiirlind
 Haliaeetus albicilla_Merikotkas
 Haliaeetus humilis_Lesser Fish-Eagle
 Haliaeetus ichthyaetus_Gray-headed Fish-Eagle
-Haliaeetus leucocephalus_Bald Eagle
-Haliaeetus leucogaster_White-bellied Sea-Eagle
-Haliaeetus pelagicus_Steller's Sea-Eagle
-Haliaeetus vocifer_African Fish-Eagle
-Haliastur indus_Brahminy Kite
-Haliastur sphenurus_Whistling Kite
-Hapalocrex flaviventer_Yellow-breasted Crake
-Hapalopsittaca amazonina_Rusty-faced Parrot
-Hapalopsittaca fuertesi_Indigo-winged Parrot
-Hapaloptila castanea_White-faced Nunbird
-Haplophaedia aureliae_Greenish Puffleg
+Haliaeetus leucocephalus_Valgepea-merikotkas
+Haliaeetus leucogaster_Hele-merikotkas
+Haliaeetus pelagicus_Hiid-merikotkas
+Haliaeetus vocifer_Kilg-merikotkas
+Haliastur indus_Valgepea-purihaugas
+Haliastur sphenurus_Vile-purihaugas
+Hapalocrex flaviventer_Koldrind-huik
+Hapalopsittaca amazonina_Põhja-pilvepapagoi
+Hapalopsittaca fuertesi_Koldpugu-pilvepapagoi
+Hapaloptila castanea_Diadeem-puhvlind
+Haplophaedia aureliae_Ruugepea-muhvkoolibri
 Haplospiza unicolor_Uniform Finch
-Harpactes ardens_Philippine Trogon
-Harpactes diardii_Diard's Trogon
-Harpactes duvaucelii_Scarlet-rumped Trogon
-Harpactes erythrocephalus_Red-headed Trogon
-Harpactes fasciatus_Malabar Trogon
-Harpactes kasumba_Red-naped Trogon
-Harpactes oreskios_Orange-breasted Trogon
-Harpactes orrhophaeus_Cinnamon-rumped Trogon
-Harpactes wardi_Ward's Trogon
-Harpagus bidentatus_Double-toothed Kite
-Harpagus diodon_Rufous-thighed Kite
-Harpia harpyja_Harpy Eagle
-Harpyopsis novaeguineae_New Guinea Eagle
+Harpactes ardens_Filipiini järanokk
+Harpactes diardii_Võlu-järanokk
+Harpactes duvaucelii_Õnne-järanokk
+Harpactes erythrocephalus_Puna-järanokk
+Harpactes fasciatus_India järanokk
+Harpactes kasumba_Valjas-järanokk
+Harpactes oreskios_Kuld-järanokk
+Harpactes orrhophaeus_Kaneel-järanokk
+Harpactes wardi_Põhja-järanokk
+Harpagus bidentatus_Ruske-hammashaugas
+Harpagus diodon_Hall-hammashaugas
+Harpia harpyja_Harpüia
+Harpyopsis novaeguineae_Käharkotkas
 Hedydipna collaris_Collared Sunbird
-Hedydipna metallica_Nile Valley Sunbird
+Hedydipna metallica_Niiluse nektarilind
 Hedydipna platura_Pygmy Sunbird
-Heliangelus amethysticollis_Amethyst-throated Sunangel
-Heliangelus exortis_Tourmaline Sunangel
-Heliangelus viola_Purple-throated Sunangel
-Helicolestes hamatus_Slender-billed Kite
+Heliangelus amethysticollis_Lõuna-päikesekoolibri
+Heliangelus exortis_Turmaliin-päikesekoolibri
+Heliangelus viola_Sinilaup-päikesekoolibri
+Helicolestes hamatus_Jõgi-teohaugas
 Heliobletus contaminatus_Sharp-billed Treehunter
-Heliodoxa jacula_Green-crowned Brilliant
-Heliodoxa leadbeateri_Violet-fronted Brilliant
-Heliodoxa rubinoides_Fawn-breasted Brilliant
-Heliomaster constantii_Plain-capped Starthroat
-Heliomaster longirostris_Long-billed Starthroat
-Heliornis fulica_Sungrebe
-Heliothryx auritus_Black-eared Fairy
+Heliodoxa jacula_Loode-briljantkoolibri
+Heliodoxa leadbeateri_Sinilaup-briljantkoolibri
+Heliodoxa rubinoides_Pruunkõht-briljantkoolibri
+Heliomaster constantii_Sädekoolibri
+Heliomaster longirostris_Korallpuu-koolibri
+Heliornis fulica_Ameerika redulind
+Heliothryx auritus_Selva-viherkoolibri
 Hellmayrea gularis_White-browed Spinetail
-Helmitheros vermivorum_Worm-eating Warbler
-Helopsaltes certhiola_Pallas's Grasshopper Warbler
-Helopsaltes ochotensis_Middendorff's Grasshopper Warbler
-Helopsaltes pryeri_Marsh Grassbird
-Hemicircus canente_Heart-spotted Woodpecker
-Hemicircus concretus_Gray-and-buff Woodpecker
-Hemignathus wilsoni_Akiapolaau
-Hemiprocne comata_Whiskered Treeswift
-Hemiprocne coronata_Crested Treeswift
-Hemiprocne longipennis_Gray-rumped Treeswift
-Hemiprocne mystacea_Moustached Treeswift
+Helmitheros vermivorum_Triippea-säälik
+Helopsaltes certhiola_Niidu-ritsiklind
+Helopsaltes ochotensis_Ohhoota ritsiklind
+Helopsaltes pryeri_Soo-ritsiklind
+Hemicircus canente_Manisk-ladvarähn
+Hemicircus concretus_Hall-ladvarähn
+Hemignathus wilsoni_Akiapola'au-nestevint
+Hemiprocne comata_Väike-puispiiritaja
+Hemiprocne coronata_Kroon-puispiiritaja
+Hemiprocne longipennis_Tutt-puispiiritaja
+Hemiprocne mystacea_Suur-puispiiritaja
 Hemipus hirundinaceus_Black-winged Flycatcher-shrike
 Hemipus picatus_Bar-winged Flycatcher-shrike
 Hemithraupis flavicollis_Yellow-backed Tanager
@@ -2740,15 +2740,15 @@ Hemitriccus rufigularis_Buff-throated Tody-Tyrant
 Hemitriccus spodiops_Yungas Tody-Tyrant
 Hemitriccus striaticollis_Stripe-necked Tody-Tyrant
 Hemitriccus zosterops_White-eyed Tody-Tyrant
-Hemixos castanonotus_Chestnut Bulbul
-Hemixos cinereus_Cinereous Bulbul
-Hemixos flavala_Ashy Bulbul
-Henicorhina anachoreta_Hermit Wood-Wren
-Henicorhina leucophrys_Gray-breasted Wood-Wren
-Henicorhina leucoptera_Bar-winged Wood-Wren
-Henicorhina leucosticta_White-breasted Wood-Wren
-Henicorhina negreti_Munchique Wood-Wren
-Herpetotheres cachinnans_Laughing Falcon
+Hemixos castanonotus_Hiina tuhkbülbül
+Hemixos cinereus_Malai tuhkbülbül
+Hemixos flavala_Tuhkbülbül
+Henicorhina anachoreta_Santamarta pardkäblik
+Henicorhina leucophrys_Mägi-pardkäblik
+Henicorhina leucoptera_Vööttiib-pardkäblik
+Henicorhina leucosticta_Valgerind-pardkäblik
+Henicorhina negreti_Pilvemetsa-pardkäblik
+Herpetotheres cachinnans_Naerupistrik
 Herpsilochmus atricapillus_Black-capped Antwren
 Herpsilochmus axillaris_Yellow-breasted Antwren
 Herpsilochmus dorsimaculatus_Spot-backed Antwren
@@ -2765,91 +2765,91 @@ Herpsilochmus rufimarginatus_Rufous-margined Antwren
 Herpsilochmus sellowi_Caatinga Antwren
 Herpsilochmus stictocephalus_Todd's Antwren
 Herpsilochmus sticturus_Spot-tailed Antwren
-Heterocercus aurantiivertex_Orange-crowned Manakin
-Heterocercus flavivertex_Yellow-crowned Manakin
-Heterocercus linteatus_Flame-crowned Manakin
-Heteromyias albispecularis_Ashy Robin
-Heteromyias cinereifrons_Gray-headed Robin
-Heterophasia auricularis_White-eared Sibia
-Heterophasia capistrata_Rufous Sibia
-Heterophasia desgodinsi_Black-headed Sibia
-Heterophasia gracilis_Gray Sibia
-Heterophasia melanoleuca_Black-backed Sibia
-Heterophasia picaoides_Long-tailed Sibia
-Heterophasia pulchella_Beautiful Sibia
+Heterocercus aurantiivertex_Ruugekiird-tantsulind
+Heterocercus flavivertex_Kuldkiird-tantsulind
+Heterocercus linteatus_Punakiird-tantsulind
+Heteromyias albispecularis_Tuhkmiro
+Heteromyias cinereifrons_Queenslandi tuhkmiro
+Heterophasia auricularis_Kõrvuk-nestevädrak
+Heterophasia capistrata_Ruuge-nestevädrak
+Heterophasia desgodinsi_Karbus-nestevädrak
+Heterophasia gracilis_Hall-nestevädrak
+Heterophasia melanoleuca_Valgekõht-nestevädrak
+Heterophasia picaoides_Händvädrak
+Heterophasia pulchella_Sini-nestevädrak
 Heterospingus xanthopygius_Scarlet-browed Tanager
-Hieraaetus pennatus_Booted Eagle
-Hierococcyx bocki_Dark Hawk-Cuckoo
-Hierococcyx fugax_Malaysian Hawk-Cuckoo
-Hierococcyx hyperythrus_Northern Hawk-Cuckoo
+Hieraaetus pennatus_Kääbuskotkas
+Hierococcyx bocki_Malai haugaskägu
+Hierococcyx fugax_Pagu-haugaskägu
+Hierococcyx hyperythrus_Hiina haugaskägu
 Hierococcyx nisicolor_Hodgson's Hawk-Cuckoo
-Hierococcyx pectoralis_Philippine Hawk-Cuckoo
-Hierococcyx sparverioides_Large Hawk-Cuckoo
-Hierococcyx vagans_Moustached Hawk-Cuckoo
-Hierococcyx varius_Common Hawk-Cuckoo
-Himantopus himantopus_Black-winged Stilt
-Himantopus leucocephalus_Pied Stilt
-Himantopus mexicanus_Black-necked Stilt
-Himatione sanguinea_Apapane
-Hippolais icterina_Icterine Warbler
-Hippolais languida_Upcher's Warbler
-Hippolais olivetorum_Olive-tree Warbler
-Hippolais polyglotta_Melodious Warbler
-Hirundapus caudacutus_White-throated Needletail
-Hirundapus giganteus_Brown-backed Needletail
+Hierococcyx pectoralis_Filipiini haugaskägu
+Hierococcyx sparverioides_Tamme-haugaskägu
+Hierococcyx vagans_Habe-haugaskägu
+Hierococcyx varius_India haugaskägu
+Himantopus himantopus_Karkjalg
+Himantopus leucocephalus_Kaelus-karkjalg
+Himantopus mexicanus_Mustpea-karkjalg
+Himatione sanguinea_Apapane-nestevint
+Hippolais icterina_Käosulane
+Hippolais languida_Kõnnu-käosulane
+Hippolais olivetorum_Õlipuu-käosulane
+Hippolais polyglotta_Lääne-käosulane
+Hirundapus caudacutus_Kammsaba
+Hirundapus giganteus_Suur-kammsaba
 Hirundinea ferruginea_Cliff Flycatcher
-Hirundo angolensis_Angola Swallow
-Hirundo neoxena_Welcome Swallow
+Hirundo angolensis_Bantu suitsupääsuke
+Hirundo neoxena_Austraalia suitsupääsuke
 Hirundo rustica_Suitsupääsuke
-Hirundo smithii_Wire-tailed Swallow
+Hirundo smithii_Niitsaba-pääsuke
 Hirundo tahitica_Pacific Swallow
-Histrionicus histrionicus_Harlequin Duck
-Histurgops ruficauda_Rufous-tailed Weaver
-Horizocerus albocristatus_White-crested Hornbill
-Horornis acanthizoides_Yellowish-bellied Bush Warbler
-Horornis annae_Palau Bush Warbler
-Horornis brunnescens_Hume's Bush Warbler
-Horornis canturians_Manchurian Bush Warbler
-Horornis diphone_Japanese Bush Warbler
-Horornis flavolivaceus_Aberrant Bush Warbler
-Horornis fortipes_Brownish-flanked Bush Warbler
-Horornis ruficapilla_Fiji Bush Warbler
-Horornis seebohmi_Philippine Bush Warbler
+Histrionicus histrionicus_Kärestikuaul
+Histurgops ruficauda_Rästas-kangurlind
+Horizocerus albocristatus_Kroon-sarvnokk
+Horornis acanthizoides_Hiina rädilind
+Horornis annae_Palau rädilind
+Horornis brunnescens_Hele-rädilind
+Horornis canturians_Võsa-rädilind
+Horornis diphone_Suur-rädilind
+Horornis flavolivaceus_Mägi-rädilind
+Horornis fortipes_Pruunkülg-rädilind
+Horornis ruficapilla_Fidži rädilind
+Horornis seebohmi_Luzoni rädilind
 Horornis vulcanius_Sunda Bush Warbler
 Human non-vocal_Human non-vocal
 Human vocal_Human vocal
 Human whistle_Human whistle
-Hydrobates castro_Band-rumped Storm-Petrel
-Hydrobates leucorhous_Leach's Storm-Petrel
-Hydrobates monorhis_Swinhoe's Storm-Petrel
-Hydrobates pelagicus_European Storm-Petrel
-Hydrobates tristrami_Tristram's Storm-Petrel
+Hydrobates castro_Tõmmu-tormipääsu
+Hydrobates leucorhous_Põhja-tormipääsu
+Hydrobates monorhis_Jaapani tormipääsu
+Hydrobates pelagicus_Atlandi tormipääsu
+Hydrobates tristrami_Havai tormipääsu
 Hydrocoloeus minutus_Väikekajakas
-Hydrophasianus chirurgus_Pheasant-tailed Jacana
-Hydroprogne caspia_Caspian Tern
-Hydropsalis cayennensis_White-tailed Nightjar
-Hydropsalis climacocerca_Ladder-tailed Nightjar
-Hydropsalis maculicaudus_Spot-tailed Nightjar
-Hydropsalis torquata_Scissor-tailed Nightjar
-Hydrornis baudii_Blue-headed Pitta
-Hydrornis caeruleus_Giant Pitta
-Hydrornis cyaneus_Blue Pitta
+Hydrophasianus chirurgus_Pahlsaba-lootoselind
+Hydroprogne caspia_Räusktiir
+Hydropsalis cayennensis_Valgesaba-öösorr
+Hydropsalis climacocerca_Lõhissaba-öösorr
+Hydropsalis maculicaudus_Helmes-öösorr
+Hydropsalis torquata_Käärsaba-öösorr
+Hydrornis baudii_Türkiispita
+Hydrornis caeruleus_Suurpita
+Hydrornis cyaneus_Sinipita
 Hydrornis elliotii_Bar-bellied Pitta
 Hydrornis irena_Malayan Banded-Pitta
-Hydrornis nipalensis_Blue-naped Pitta
-Hydrornis oatesi_Rusty-naped Pitta
+Hydrornis nipalensis_Sinikukal-pita
+Hydrornis oatesi_Ruugepita
 Hydrornis schwaneri_Bornean Banded-Pitta
-Hydrornis soror_Blue-rumped Pitta
+Hydrornis soror_Sinipära-pita
 Hylacola cauta_Shy Heathwren
 Hylexetastes perrotii_Red-billed Woodcreeper
 Hylexetastes stresemanni_Bar-bellied Woodcreeper
 Hylexetastes uniformis_Uniform Woodcreeper
 Hylia prasina_Green Hylia
 Hyliola regilla_Pacific Chorus Frog
-Hylocharis chrysura_Gilded Hummingbird
-Hylocharis sapphirina_Rufous-throated Sapphire
-Hylocichla mustelina_Wood Thrush
-Hylomanes momotula_Tody Motmot
+Hylocharis chrysura_Kold-safiirkoolibri
+Hylocharis sapphirina_Punakurk-safiirkoolibri
+Hylocichla mustelina_Täpikrästas
+Hylomanes momotula_Värbmotmot
 Hylopezus macularius_Spotted Antpitta
 Hylopezus ochroleucus_White-browed Antpitta
 Hylopezus paraensis_Snethlage's Antpitta
@@ -2866,12 +2866,12 @@ Hylophilus thoracicus_Lemon-chested Greenlet
 Hylophylax naevioides_Spotted Antbird
 Hylophylax naevius_Spot-backed Antbird
 Hylophylax punctulatus_Dot-backed Antbird
-Hylorchilus navai_Nava's Wren
-Hylorchilus sumichrasti_Sumichrast's Wren
+Hylorchilus navai_Mets-karstikäblik
+Hylorchilus sumichrasti_Ruuge-karstikäblik
 Hymenops perspicillatus_Spectacled Tyrant
-Hypargos niveoguttatus_Peters's Twinspot
-Hypergerus atriceps_Oriole Warbler
-Hypnelus ruficollis_Russet-throated Puffbird
+Hypargos niveoguttatus_Punarind-täpikamadiin
+Hypergerus atriceps_Piho-rohulind
+Hypnelus ruficollis_Valjas-puhvlind
 Hypocnemis cantator_Guianan Warbling-Antbird
 Hypocnemis flavescens_Imeri Warbling-Antbird
 Hypocnemis hypoxantha_Yellow-browed Antbird
@@ -2881,62 +2881,62 @@ Hypocnemis striata_Spix's Warbling-Antbird
 Hypocnemis subflava_Yellow-breasted Warbling-Antbird
 Hypocnemoides maculicauda_Band-tailed Antbird
 Hypocnemoides melanopogon_Black-chinned Antbird
-Hypocolius ampelinus_Hypocolius
+Hypocolius ampelinus_Paindpuulind
 Hypoedaleus guttatus_Spot-backed Antshrike
-Hypopyrrhus pyrohypogaster_Red-bellied Grackle
-Hypothymis azurea_Black-naped Monarch
-Hypothymis puella_Pale-blue Monarch
-Hypsipetes amaurotis_Brown-eared Bulbul
-Hypsipetes everetti_Yellowish Bulbul
-Hypsipetes ganeesa_Square-tailed Bulbul
-Hypsipetes leucocephalus_Black Bulbul
-Hypsipetes madagascariensis_Malagasy Bulbul
-Hypsipetes olivaceus_Mauritius Bulbul
-Hypsipetes philippinus_Philippine Bulbul
-Ianthocincla maxima_Giant Laughingthrush
-Ianthocincla ocellata_Spotted Laughingthrush
-Ianthocincla rufogularis_Rufous-chinned Laughingthrush
-Ibidorhyncha struthersii_Ibisbill
-Ibycter americanus_Red-throated Caracara
-Ichthyaetus audouinii_Audouin's Gull
-Ichthyaetus melanocephalus_Mediterranean Gull
-Icteria virens_Yellow-breasted Chat
-Icterus abeillei_Black-backed Oriole
-Icterus auratus_Orange Oriole
-Icterus auricapillus_Orange-crowned Oriole
-Icterus bullockii_Bullock's Oriole
-Icterus cayanensis_Epaulet Oriole
-Icterus chrysater_Yellow-backed Oriole
-Icterus croconotus_Orange-backed Troupial
-Icterus cucullatus_Hooded Oriole
-Icterus galbula_Baltimore Oriole
-Icterus graceannae_White-edged Oriole
-Icterus graduacauda_Audubon's Oriole
-Icterus gularis_Altamira Oriole
-Icterus icterus_Venezuelan Troupial
-Icterus jamacaii_Campo Troupial
-Icterus leucopteryx_Jamaican Oriole
-Icterus mesomelas_Yellow-tailed Oriole
-Icterus nigrogularis_Yellow Oriole
-Icterus parisorum_Scott's Oriole
-Icterus pectoralis_Spot-breasted Oriole
-Icterus portoricensis_Puerto Rican Oriole
-Icterus prosthemelas_Black-cowled Oriole
-Icterus pustulatus_Streak-backed Oriole
-Icterus pyrrhopterus_Variable Oriole
-Icterus spurius_Orchard Oriole
-Icterus wagleri_Black-vented Oriole
-Ictinaetus malaiensis_Black Eagle
-Ictinia mississippiensis_Mississippi Kite
-Ictinia plumbea_Plumbeous Kite
-Iduna caligata_Booted Warbler
-Iduna natalensis_African Yellow-Warbler
-Iduna opaca_Western Olivaceous Warbler
-Iduna pallida_Eastern Olivaceous Warbler
-Iduna rama_Sykes's Warbler
-Iduna similis_Mountain Yellow-Warbler
+Hypopyrrhus pyrohypogaster_Punakõht-turpial
+Hypothymis azurea_Kipa-sinipiibik
+Hypothymis puella_Sulawesi sinipiibik
+Hypsipetes amaurotis_Keiserbülbül
+Hypsipetes everetti_Koldkõht-bülbül
+Hypsipetes ganeesa_Lõuna-nõgibülbül
+Hypsipetes leucocephalus_Nõgibülbül
+Hypsipetes madagascariensis_Madagaskari bülbül
+Hypsipetes olivaceus_Mauritiuse bülbül
+Hypsipetes philippinus_Punakurk-bülbül
+Ianthocincla maxima_Pärl-võsavädrak
+Ianthocincla ocellata_Helmes-võsavädrak
+Ianthocincla rufogularis_Himaalaja võsavädrak
+Ibidorhyncha struthersii_Sirpnokk
+Ibycter americanus_Herilasekarakaara
+Ichthyaetus audouinii_Vahemere kajakas
+Ichthyaetus melanocephalus_Karbuskajakas
+Icteria virens_Tihnikuturpial
+Icterus abeillei_Asteegi turpial
+Icterus auratus_Yucatani turpial
+Icterus auricapillus_Tulipea-turpial
+Icterus bullockii_Valgetiib-turpial
+Icterus cayanensis_Pagunturpial
+Icterus chrysater_Koldselg-turpial
+Icterus croconotus_Porgandturpial
+Icterus cucullatus_Saluturpial
+Icterus galbula_Jalakaturpial
+Icterus graceannae_Kõrbeturpial
+Icterus graduacauda_Viherselg-turpial
+Icterus gularis_Mimoositurpial
+Icterus icterus_Venetsueela turpial
+Icterus jamacaii_Kaatingaturpial
+Icterus leucopteryx_Kariibi turpial
+Icterus mesomelas_Koldsaba-turpial
+Icterus nigrogularis_Kuldturpial
+Icterus parisorum_Jukaturpial
+Icterus pectoralis_Tähnikrind-turpial
+Icterus portoricensis_Puertoriiko turpial
+Icterus prosthemelas_Banaaniturpial
+Icterus pustulatus_Leekturpial
+Icterus pyrrhopterus_Õlakturpial
+Icterus spurius_Väiketurpial
+Icterus wagleri_Mustpära-turpial
+Ictinaetus malaiensis_Krattkotkas
+Ictinia mississippiensis_Põhja-noolhaugas
+Ictinia plumbea_Lõuna-noolhaugas
+Iduna caligata_Väike-käosulane
+Iduna natalensis_Bantu käosulane
+Iduna opaca_Mauri käosulane
+Iduna pallida_Leet-käosulane
+Iduna rama_Lõuna-käosulane
+Iduna similis_Mägi-käosulane
 Ifrita kowaldi_Blue-capped Ifrita
-Ilicura militaris_Pin-tailed Manakin
+Ilicura militaris_Punaselg-tantsulind
 Illadopsis albipectus_Scaly-breasted Illadopsis
 Illadopsis cleaveri_Blackcap Illadopsis
 Illadopsis fulvescens_Brown Illadopsis
@@ -2947,75 +2947,75 @@ Incaspiza laeta_Buff-bridled Inca-Finch
 Incaspiza ortizi_Gray-winged Inca-Finch
 Incaspiza personata_Rufous-backed Inca-Finch
 Incilius valliceps_Gulf Coast Toad
-Indicator indicator_Greater Honeyguide
-Indicator minor_Lesser Honeyguide
-Indicator variegatus_Scaly-throated Honeyguide
+Indicator indicator_Suur-meenäitur
+Indicator minor_Hall-meenäitur
+Indicator variegatus_Kiripugu-meenäitur
 Inezia caudata_Pale-tipped Tyrannulet
 Inezia inornata_Plain Tyrannulet
 Inezia subflava_Amazonian Tyrannulet
 Inezia tenuirostris_Slender-billed Tyrannulet
 Iodopleura isabellae_White-browed Purpletuft
 Iodopleura pipra_Buff-throated Purpletuft
-Iole crypta_Buff-vented Bulbul
-Iole indica_Yellow-browed Bulbul
-Iole propinqua_Gray-eyed Bulbul
-Iole viridescens_Olive Bulbul
-Irania gutturalis_White-throated Robin
-Irena cyanogastra_Philippine Fairy-bluebird
-Irena puella_Asian Fairy-bluebird
+Iole crypta_Malai oliivbülbül
+Iole indica_Draviidi bülbül
+Iole propinqua_Indohiina oliivbülbül
+Iole viridescens_Birma oliivbülbül
+Irania gutturalis_Valgekurk-ööbik
+Irena cyanogastra_Filipiini sinilüüdik
+Irena puella_Sinilüüdik
 Iridosornis analis_Yellow-throated Tanager
 Iridosornis porphyrocephalus_Purplish-mantled Tanager
 Iridosornis rufivertex_Golden-crowned Tanager
 Isleria guttata_Rufous-bellied Antwren
 Isleria hauxwelli_Plain-throated Antwren
-Ithaginis cruentus_Blood Pheasant
-Ixobrychus cinnamomeus_Cinnamon Bittern
-Ixobrychus dubius_Black-backed Bittern
-Ixobrychus eurhythmus_Schrenck's Bittern
-Ixobrychus exilis_Least Bittern
-Ixobrychus flavicollis_Black Bittern
-Ixobrychus involucris_Stripe-backed Bittern
-Ixobrychus minutus_Little Bittern
-Ixobrychus sinensis_Yellow Bittern
-Ixonotus guttatus_Spotted Greenbul
-Ixoreus naevius_Varied Thrush
-Ixos malaccensis_Streaked Bulbul
-Ixos mcclellandii_Mountain Bulbul
+Ithaginis cruentus_Püüfaasan
+Ixobrychus cinnamomeus_Puna-väikehüüp
+Ixobrychus dubius_Austraalia väikehüüp
+Ixobrychus eurhythmus_Ida-väikehüüp
+Ixobrychus exilis_Ameerika väikehüüp
+Ixobrychus flavicollis_Musthüüp
+Ixobrychus involucris_Tarna-väikehüüp
+Ixobrychus minutus_Väikehüüp
+Ixobrychus sinensis_Kold-väikehüüp
+Ixonotus guttatus_Täpikbülbül
+Ixoreus naevius_Ameerika maarästas
+Ixos malaccensis_Triippugu-bülbül
+Ixos mcclellandii_Mägibülbül
 Ixothraupis guttata_Speckled Tanager
 Ixothraupis punctata_Spotted Tanager
 Ixothraupis rufigula_Rufous-throated Tanager
 Ixothraupis varia_Dotted Tanager
-Jabiru mycteria_Jabiru
-Jacamaralcyon tridactyla_Three-toed Jacamar
-Jacamerops aureus_Great Jacamar
-Jacana jacana_Wattled Jacana
-Jacana spinosa_Northern Jacana
-Junco hyemalis_Dark-eyed Junco
-Junco phaeonotus_Yellow-eyed Junco
-Jynx ruficollis_Rufous-necked Wryneck
+Jabiru mycteria_Jabiru-toonekurg
+Jacamaralcyon tridactyla_Kolmvarvas-läiklind
+Jacamerops aureus_Suur-läiklind
+Jacana jacana_Lokut-lootoselind
+Jacana spinosa_Kuldlauk-lootoselind
+Junco hyemalis_Välusidrik
+Junco phaeonotus_Punaselg-sidrik
+Jynx ruficollis_Punapugu-väänkael
 Jynx torquilla_Väänkael
 Kakamega poliothorax_Gray-chested Babbler
-Kaupifalco monogrammicus_Lizard Buzzard
+Kaupifalco monogrammicus_Sisalikukull
 Kenopia striata_Striped Wren-Babbler
-Ketupa blakistoni_Blakiston's Fish-Owl
-Ketupa ketupu_Buffy Fish-Owl
-Ketupa zeylonensis_Brown Fish-Owl
-Klais guimeti_Violet-headed Hummingbird
+Ketupa blakistoni_Amuuri kakk
+Ketupa ketupu_Väike-kalakakk
+Ketupa zeylonensis_Kalakakk
+Klais guimeti_Kapellkoolibri
 Kleinothraupis atropileus_Black-capped Hemispingus
 Kleinothraupis parodii_Parodi's Hemispingus
 Knipolegus aterrimus_White-winged Black-Tyrant
-Knipolegus hudsoni_Hudson's Black-Tyrant
-Knipolegus orenocensis_Riverside Tyrant
-Knipolegus poecilurus_Rufous-tailed Tyrant
+Knipolegus hudsoni_Pampa-tõmmutikat
+Knipolegus orenocensis_Jõgi-tõmmutikat
+Knipolegus poecilurus_Hall-tõmmutikat
 Kurochkinegramma hypogrammicum_Purple-naped Spiderhunter
-Lacedo pulchella_Banded Kingfisher
-Lafresnaya lafresnayi_Mountain Velvetbreast
-Lagonosticta rhodopareia_Jameson's Firefinch
-Lagonosticta rubricata_African Firefinch
-Lagonosticta senegala_Red-billed Firefinch
-Lagopus lagopus_Willow Ptarmigan
-Lagopus leucura_White-tailed Ptarmigan
-Lagopus muta_Rock Ptarmigan
+Lacedo pulchella_Vööt-safiirlind
+Lafresnaya lafresnayi_Mustkõht-koolibri
+Lagonosticta rhodopareia_Kõnnu-leekamadiin
+Lagonosticta rubricata_Võsa-leekamadiin
+Lagonosticta senegala_Akaatsia-leekamadiin
+Lagopus lagopus_Rabapüü
+Lagopus leucura_Valgesaba-püü
+Lagopus muta_Lumepüü
 Lalage aurea_Rufous-bellied Triller
 Lalage fimbriata_Lesser Cuckooshrike
 Lalage leucomela_Varied Triller
@@ -3025,38 +3025,38 @@ Lalage melanoptera_Black-headed Cuckooshrike
 Lalage melaschistos_Black-winged Cuckooshrike
 Lalage nigra_Pied Triller
 Lalage tricolor_White-winged Triller
-Lampornis amethystinus_Amethyst-throated Mountain-gem
-Lampornis clemenciae_Blue-throated Mountain-gem
-Lampornis sybillae_Green-breasted Mountain-gem
-Lampornis viridipallens_Green-throated Mountain-gem
-Lampropsar tanagrinus_Velvet-fronted Grackle
+Lampornis amethystinus_Roosakurk-kulmkoolibri
+Lampornis clemenciae_Sinikurk-kulmkoolibri
+Lampornis sybillae_Hondurase kulmkoolibri
+Lampornis viridipallens_Maia kulmkoolibri
+Lampropsar tanagrinus_Sametturpial
 Lamprospiza melanoleuca_Red-billed Pied Tanager
-Lamprotornis australis_Burchell's Starling
-Lamprotornis bicolor_African Pied Starling
-Lamprotornis caudatus_Long-tailed Glossy Starling
-Lamprotornis chalybaeus_Greater Blue-eared Starling
-Lamprotornis chloropterus_Lesser Blue-eared Starling
-Lamprotornis hildebrandti_Hildebrandt's Starling
-Lamprotornis mevesii_Meves's Starling
-Lamprotornis nitens_Cape Starling
-Lamprotornis purpuroptera_Rüppell's Starling
-Lamprotornis splendidus_Splendid Starling
-Lamprotornis superbus_Superb Starling
-Lamprotornis unicolor_Ashy Starling
-Laniarius aethiopicus_Ethiopian Boubou
-Laniarius atrococcineus_Crimson-breasted Gonolek
-Laniarius atroflavus_Yellow-breasted Boubou
-Laniarius barbarus_Yellow-crowned Gonolek
-Laniarius bicolor_Gabon Boubou
-Laniarius erythrogaster_Black-headed Gonolek
-Laniarius ferrugineus_Southern Boubou
-Laniarius fuelleborni_Fülleborn's Boubou
-Laniarius funebris_Slate-colored Boubou
-Laniarius luehderi_Lühder's Bushshrike
-Laniarius major_Tropical Boubou
-Laniarius mufumbiri_Papyrus Gonolek
-Laniarius poensis_Western Boubou
-Laniarius sublacteus_Zanzibar Boubou
+Lamprotornis australis_Akaatsia-kuldnokk
+Lamprotornis bicolor_Valgepära-kuldnokk
+Lamprotornis caudatus_Händ-kuldnokk
+Lamprotornis chalybaeus_Safiir-kuldnokk
+Lamprotornis chloropterus_Tsüaan-kuldnokk
+Lamprotornis hildebrandti_Roostekõht-kuldnokk
+Lamprotornis mevesii_Baobabi-kuldnokk
+Lamprotornis nitens_Koobalt-kuldnokk
+Lamprotornis purpuroptera_Niiluse kuldnokk
+Lamprotornis splendidus_Suur-kuldnokk
+Lamprotornis superbus_Hund-kuldnokk
+Lamprotornis unicolor_Tuhk-kuldnokk
+Laniarius aethiopicus_Tiva-pagulind
+Laniarius atrococcineus_Leek-pagulind
+Laniarius atroflavus_Kuldpugu-pagulind
+Laniarius barbarus_Koldkiird-pagulind
+Laniarius bicolor_Roo-pagulind
+Laniarius erythrogaster_Kinaver-pagulind
+Laniarius ferrugineus_Roostekõht-pagulind
+Laniarius fuelleborni_Tanganjika pagulind
+Laniarius funebris_Tume-pagulind
+Laniarius luehderi_Kaneel-pagulind
+Laniarius major_Bubu-pagulind
+Laniarius mufumbiri_Papüüruse-pagulind
+Laniarius poensis_Mägi-pagulind
+Laniarius sublacteus_Kikuju pagulind
 Laniisoma elegans_Shrike-like Cotinga
 Lanio aurantius_Black-throated Shrike-Tanager
 Lanio fulvus_Fulvous Shrike-Tanager
@@ -3064,80 +3064,80 @@ Lanio leucothorax_White-throated Shrike-Tanager
 Lanio versicolor_White-winged Shrike-Tanager
 Laniocera hypopyrra_Cinereous Mourner
 Laniocera rufescens_Speckled Mourner
-Lanius borealis_Northern Shrike
-Lanius bucephalus_Bull-headed Shrike
-Lanius cabanisi_Long-tailed Fiscal
-Lanius collaris_Southern Fiscal
+Lanius borealis_Viir-hallõgija
+Lanius bucephalus_Väluõgija
+Lanius cabanisi_Händõgija
+Lanius collaris_Pugalõgija
 Lanius collurio_Punaselg-õgija
-Lanius collurioides_Burmese Shrike
-Lanius corvinus_Yellow-billed Shrike
-Lanius cristatus_Brown Shrike
+Lanius collurioides_Indohiina õgija
+Lanius corvinus_Pruun-harakõgija
+Lanius cristatus_Pruunõgija
 Lanius excubitor_Hallõgija
-Lanius humeralis_Northern Fiscal
-Lanius isabellinus_Isabelline Shrike
-Lanius ludovicianus_Loggerhead Shrike
-Lanius meridionalis_Iberian Gray Shrike
-Lanius minor_Lesser Gray Shrike
-Lanius nubicus_Masked Shrike
-Lanius phoenicuroides_Red-tailed Shrike
-Lanius schach_Long-tailed Shrike
-Lanius senator_Woodchat Shrike
-Lanius sphenocercus_Chinese Gray Shrike
-Lanius tephronotus_Gray-backed Shrike
-Lanius tigrinus_Tiger Shrike
-Lanius vittatus_Bay-backed Shrike
-Larosterna inca_Inca Tern
+Lanius humeralis_Savanniõgija
+Lanius isabellinus_Mongoolia kõnnuõgija
+Lanius ludovicianus_Ameerika õgija
+Lanius meridionalis_Lõuna-hallõgija
+Lanius minor_Mustlauk-õgija
+Lanius nubicus_Valgelauk-õgija
+Lanius phoenicuroides_Punasaba-kõnnuõgija
+Lanius schach_Ruskselg-õgija
+Lanius senator_Punapea-õgija
+Lanius sphenocercus_Hiina hallõgija
+Lanius tephronotus_Mägiõgija
+Lanius tigrinus_Tiigerõgija
+Lanius vittatus_Kõrbselg-õgija
+Larosterna inca_Inkatiir
 Larus argentatus_Hõbekajakas
-Larus belcheri_Belcher's Gull
-Larus brachyrhynchus_Short-billed Gull
-Larus cachinnans_Caspian Gull
-Larus californicus_California Gull
+Larus belcheri_Peruu kajakas
+Larus brachyrhynchus_Ameerika kalakajakas
+Larus cachinnans_Koldjalg-hõbekajakas
+Larus californicus_Järvekajakas
 Larus canus_Kalakajakas
-Larus crassirostris_Black-tailed Gull
-Larus delawarensis_Ring-billed Gull
-Larus dominicanus_Kelp Gull
-Larus fuscus_Lesser Black-backed Gull
-Larus glaucescens_Glaucous-winged Gull
-Larus glaucoides_Iceland Gull
-Larus heermanni_Heermann's Gull
-Larus hyperboreus_Glaucous Gull
-Larus livens_Yellow-footed Gull
-Larus marinus_Great Black-backed Gull
-Larus michahellis_Yellow-legged Gull
-Larus occidentalis_Western Gull
-Larus schistisagus_Slaty-backed Gull
-Larvivora akahige_Japanese Robin
-Larvivora brunnea_Indian Blue Robin
-Larvivora cyane_Siberian Blue Robin
-Larvivora komadori_Ryukyu Robin
-Larvivora sibilans_Rufous-tailed Robin
-Laterallus albigularis_White-throated Crake
-Laterallus exilis_Gray-breasted Crake
-Laterallus jamaicensis_Black Rail
-Laterallus leucopyrrhus_Red-and-white Crake
-Laterallus levraudi_Rusty-flanked Crake
-Laterallus melanophaius_Rufous-sided Crake
-Laterallus ruber_Ruddy Crake
-Laterallus xenopterus_Rufous-faced Crake
-Lathamus discolor_Swift Parrot
+Larus crassirostris_Jaapani kajakas
+Larus delawarensis_Vöötnokk-kajakas
+Larus dominicanus_Lõunakajakas
+Larus fuscus_Tõmmukajakas
+Larus glaucescens_Hele-kiltkajakas
+Larus glaucoides_Polaarkajakas
+Larus heermanni_Tuhkkajakas
+Larus hyperboreus_Jääkajakas
+Larus livens_Kalifornia kiltkajakas
+Larus marinus_Merikajakas
+Larus michahellis_Lõuna-hõbekajakas
+Larus occidentalis_Kiltkajakas
+Larus schistisagus_Ohhoota hõbekajakas
+Larvivora akahige_Jaapani ööbik
+Larvivora brunnea_Punapugu-ööbik
+Larvivora cyane_Siniööbik
+Larvivora komadori_Mustrind-ööbik
+Larvivora sibilans_Taigaööbik
+Laterallus albigularis_Kolumbia pisiruik
+Laterallus exilis_Hallrind-pisiruik
+Laterallus jamaicensis_Tõmmu-pisiruik
+Laterallus leucopyrrhus_Paraná pisiruik
+Laterallus levraudi_Venetsueela pisiruik
+Laterallus melanophaius_Lõuna-pisiruik
+Laterallus ruber_Puna-pisiruik
+Laterallus xenopterus_Kampo-pisiruik
+Lathamus discolor_Õiepapagoi
 Lathrotriccus euleri_Euler's Flycatcher
 Lathrotriccus griseipectus_Gray-breasted Flycatcher
 Laticilla cinerascens_Swamp Grass Babbler
-Legatus leucophaius_Piratic Flycatcher
-Leiopicus mahrattensis_Yellow-crowned Woodpecker
-Leioptila annectens_Rufous-backed Sibia
-Leiothlypis celata_Orange-crowned Warbler
-Leiothlypis crissalis_Colima Warbler
-Leiothlypis luciae_Lucy's Warbler
-Leiothlypis peregrina_Tennessee Warbler
-Leiothlypis ruficapilla_Nashville Warbler
-Leiothlypis virginiae_Virginia's Warbler
-Leiothrix argentauris_Silver-eared Mesia
-Leiothrix lutea_Red-billed Leiothrix
-Leistes bellicosus_Peruvian Meadowlark
-Leistes loyca_Long-tailed Meadowlark
-Leistes militaris_Red-breasted Meadowlark
-Leistes superciliaris_White-browed Meadowlark
+Legatus leucophaius_Kaapertikat
+Leiopicus mahrattensis_Hele-kirjurähn
+Leioptila annectens_Valgepugu-hundvädrak
+Leiothlypis celata_Rohesäälik
+Leiothlypis crissalis_Tammesäälik
+Leiothlypis luciae_Kõrbesäälik
+Leiothlypis peregrina_Kanada säälik
+Leiothlypis ruficapilla_Salusäälik
+Leiothlypis virginiae_Orusäälik
+Leiothrix argentauris_Viker-hundvädrak
+Leiothrix lutea_Harksaba-hundvädrak
+Leistes bellicosus_Peruu niiduturpial
+Leistes loyca_Patagoonia turpial
+Leistes militaris_Ljaanoturpial
+Leistes superciliaris_Brasiilia niiduturpial
 Lepidocolaptes affinis_Spot-crowned Woodcreeper
 Lepidocolaptes albolineatus_Guianan Woodcreeper
 Lepidocolaptes angustirostris_Narrow-billed Woodcreeper
@@ -3149,12 +3149,12 @@ Lepidocolaptes lacrymiger_Montane Woodcreeper
 Lepidocolaptes leucogaster_White-striped Woodcreeper
 Lepidocolaptes souleyetii_Streak-headed Woodcreeper
 Lepidocolaptes squamatus_Scaled Woodcreeper
-Lepidothrix coronata_Blue-crowned Manakin
-Lepidothrix iris_Opal-crowned Manakin
-Lepidothrix isidorei_Blue-rumped Manakin
-Lepidothrix nattereri_Snow-capped Manakin
-Lepidothrix serena_White-fronted Manakin
-Lepidothrix suavissima_Orange-bellied Manakin
+Lepidothrix coronata_Sinikiird-tantsulind
+Lepidothrix iris_Opaal-tantsulind
+Lepidothrix isidorei_Pugal-tantsulind
+Lepidothrix nattereri_Valgeselg-tantsulind
+Lepidothrix serena_Kuldrind-tantsulind
+Lepidothrix suavissima_Lauk-tantsulind
 Leptasthenura aegithaloides_Plain-mantled Tit-Spinetail
 Leptasthenura andicola_Andean Tit-Spinetail
 Leptasthenura fuliginiceps_Brown-capped Tit-Spinetail
@@ -3164,49 +3164,49 @@ Leptasthenura setaria_Araucaria Tit-Spinetail
 Leptasthenura striata_Streaked Tit-Spinetail
 Leptasthenura striolata_Striolated Tit-Spinetail
 Leptasthenura xenothorax_White-browed Tit-Spinetail
-Leptocoma aspasia_Black Sunbird
-Leptocoma brasiliana_Van Hasselt's Sunbird
-Leptocoma calcostetha_Copper-throated Sunbird
-Leptocoma minima_Crimson-backed Sunbird
-Leptocoma sperata_Purple-throated Sunbird
-Leptocoma zeylonica_Purple-rumped Sunbird
-Leptodon cayanensis_Gray-headed Kite
-Leptopoecile sophiae_White-browed Tit-Warbler
+Leptocoma aspasia_Samet-nektarilind
+Leptocoma brasiliana_Kübar-nektarilind
+Leptocoma calcostetha_Ranniku-nektarilind
+Leptocoma minima_Ghati nektarilind
+Leptocoma sperata_Purpurkurk-nektarilind
+Leptocoma zeylonica_India nektarilind
+Leptodon cayanensis_Valjashaugas
+Leptopoecile sophiae_Purpur-sabatihane
 Leptopogon amaurocephalus_Sepia-capped Flycatcher
 Leptopogon rufipectus_Rufous-breasted Flycatcher
 Leptopogon superciliaris_Slaty-capped Flycatcher
 Leptopogon taczanowskii_Inca Flycatcher
-Leptoptilos crumenifer_Marabou Stork
-Leptosittaca branickii_Golden-plumed Parakeet
-Leptosomus discolor_Cuckoo-roller
+Leptoptilos crumenifer_Marabu
+Leptosittaca branickii_Kivijugapuu-papagoi
+Leptosomus discolor_Kurol
 Leptotila cassinii_Gray-chested Dove
-Leptotila conoveri_Tolima Dove
-Leptotila jamaicensis_Caribbean Dove
-Leptotila megalura_Large-tailed Dove
-Leptotila ochraceiventris_Ochre-bellied Dove
-Leptotila pallida_Pallid Dove
-Leptotila plumbeiceps_Gray-headed Dove
-Leptotila rufaxilla_Gray-fronted Dove
-Leptotila verreauxi_White-tipped Dove
-Lesbia nuna_Green-tailed Trainbearer
-Lesbia victoriae_Black-tailed Trainbearer
-Leucippus fallax_Buffy Hummingbird
-Leucochloris albicollis_White-throated Hummingbird
-Leucogeranus leucogeranus_Siberian Crane
-Leucolia violiceps_Violet-crowned Hummingbird
-Leucophaeus atricilla_Laughing Gull
-Leucophaeus modestus_Gray Gull
-Leucophaeus pipixcan_Franklin's Gull
-Leucophaeus scoresbii_Dolphin Gull
-Leucopternis kuhli_White-browed Hawk
-Leucopternis melanops_Black-faced Hawk
-Leucopternis semiplumbeus_Semiplumbeous Hawk
-Leucosarcia melanoleuca_Wonga Pigeon
-Leucosticte atrata_Black Rosy-Finch
-Leucosticte australis_Brown-capped Rosy-Finch
-Leucosticte tephrocotis_Gray-crowned Rosy-Finch
-Lewinia pectoralis_Lewin's Rail
-Lewinia striata_Slaty-breasted Rail
+Leptotila conoveri_Tolima manteltuvi
+Leptotila jamaicensis_Kariibi manteltuvi
+Leptotila megalura_Lepa-manteltuvi
+Leptotila ochraceiventris_Rädi-manteltuvi
+Leptotila pallida_Hele-manteltuvi
+Leptotila plumbeiceps_Laane-manteltuvi
+Leptotila rufaxilla_Selva-manteltuvi
+Leptotila verreauxi_Võsa-manteltuvi
+Lesbia nuna_Väike-händkoolibri
+Lesbia victoriae_Suur-händkoolibri
+Leucippus fallax_Seemiskoolibri
+Leucochloris albicollis_Vöö-safiirkoolibri
+Leucogeranus leucogeranus_Valgekurg
+Leucolia violiceps_Asteegi arukoolibri
+Leucophaeus atricilla_Randkajakas
+Leucophaeus modestus_Kõrbekajakas
+Leucophaeus pipixcan_Preeriakajakas
+Leucophaeus scoresbii_Röövkajakas
+Leucopternis kuhli_Valgekulm-selvaviu
+Leucopternis melanops_Mask-selvaviu
+Leucopternis semiplumbeus_Väike-selvaviu
+Leucosarcia melanoleuca_Vongatuvi
+Leucosticte atrata_Must-mägivint
+Leucosticte australis_Colorado mägivint
+Leucosticte tephrocotis_Hallpea-mägivint
+Lewinia pectoralis_Väikeruik
+Lewinia striata_Punapea-ruik
 Lichenostomus cratitius_Purple-gaped Honeyeater
 Lichenostomus melanops_Yellow-tufted Honeyeater
 Lichmera incana_Dark-brown Honeyeater
@@ -3215,286 +3215,286 @@ Lichmera limbata_Indonesian Honeyeater
 Lichmera squamata_White-tufted Honeyeater
 Limnoctites rectirostris_Straight-billed Reedhaunter
 Limnoctites sulphuriferus_Sulphur-bearded Reedhaunter
-Limnodromus griseus_Short-billed Dowitcher
-Limnodromus scolopaceus_Long-billed Dowitcher
-Limnodromus semipalmatus_Asian Dowitcher
+Limnodromus griseus_Raba-neppvigle
+Limnodromus scolopaceus_Tundra-neppvigle
+Limnodromus semipalmatus_Stepi-neppvigle
 Limnornis curvirostris_Curve-billed Reedhaunter
-Limnothlypis swainsonii_Swainson's Warbler
-Limosa fedoa_Marbled Godwit
-Limosa haemastica_Hudsonian Godwit
-Limosa lapponica_Bar-tailed Godwit
+Limnothlypis swainsonii_Redusäälik
+Limosa fedoa_Preeriavigle
+Limosa haemastica_Tumevigle
+Limosa lapponica_Vöötsaba-vigle
 Limosa limosa_Mustsaba-vigle
 Linaria cannabina_Kanepilind
-Linaria flavirostris_Twite
-Linaria yemenensis_Yemen Linnet
-Liocichla phoenicea_Red-faced Liocichla
-Liocichla ripponi_Scarlet-faced Liocichla
-Liocichla steerii_Steere's Liocichla
+Linaria flavirostris_Mägi-kanepilind
+Linaria yemenensis_Jeemeni kanepilind
+Liocichla phoenicea_Prill-hundvädrak
+Liocichla ripponi_Punapale-hundvädrak
+Liocichla steerii_Taivani hundvädrak
 Lioparus chrysotis_Golden-breasted Fulvetta
 Liosceles thoracicus_Rusty-belted Tapaculo
-Lipaugus ater_Black-and-gold Cotinga
-Lipaugus fuscocinereus_Dusky Piha
-Lipaugus lanioides_Cinnamon-vented Piha
-Lipaugus unirufus_Rufous Piha
-Lipaugus vociferans_Screaming Piha
-Lipaugus weberi_Chestnut-capped Piha
+Lipaugus ater_Kuldtiib-kotinga
+Lipaugus fuscocinereus_Hallkotinga
+Lipaugus lanioides_Palmikotinga
+Lipaugus unirufus_Roostekotinga
+Lipaugus vociferans_Hääliskotinga
+Lipaugus weberi_Tanukotinga
 Lithobates catesbeianus_American Bullfrog
 Lithobates clamitans_Green Frog
 Lithobates palustris_Pickerel Frog
 Lithobates sylvaticus_Wood Frog
 Lochmias nematura_Sharp-tailed Streamcreeper
-Locustella alishanensis_Taiwan Bush Warbler
-Locustella caudata_Long-tailed Bush Warbler
-Locustella davidi_Baikal Bush Warbler
+Locustella alishanensis_Taivani ritsiklind
+Locustella caudata_Filipiini ritsiklind
+Locustella davidi_Burjaadi ritsiklind
 Locustella fluviatilis_Jõgi-ritsiklind
-Locustella lanceolata_Lanceolated Warbler
-Locustella luscinioides_Savi's Warbler
-Locustella luteoventris_Brown Bush Warbler
-Locustella mandelli_Russet Bush Warbler
-Locustella montis_Javan Bush Warbler
+Locustella lanceolata_Triip-ritsiklind
+Locustella luscinioides_Roo-ritsiklind
+Locustella luteoventris_Leet-ritsiklind
+Locustella mandelli_Nõlva-ritsiklind
+Locustella montis_Sunda ritsiklind
 Locustella naevia_Võsa-ritsiklind
-Locustella tacsanowskia_Chinese Bush Warbler
-Locustella thoracica_Spotted Bush Warbler
-Lonchura atricapilla_Chestnut Munia
-Lonchura castaneothorax_Chestnut-breasted Munia
-Lonchura kelaarti_Black-throated Munia
-Lonchura leucogastroides_Javan Munia
-Lonchura maja_White-headed Munia
-Lonchura malacca_Tricolored Munia
-Lonchura punctulata_Scaly-breasted Munia
-Lonchura striata_White-rumped Munia
-Lophaetus occipitalis_Long-crested Eagle
-Lophoceros alboterminatus_Crowned Hornbill
-Lophoceros camurus_Red-billed Dwarf Hornbill
-Lophoceros fasciatus_African Pied Hornbill
-Lophoceros hemprichii_Hemprich's Hornbill
-Lophoceros nasutus_African Gray Hornbill
+Locustella tacsanowskia_Rohu-ritsiklind
+Locustella thoracica_Mägi-ritsiklind
+Lonchura atricapilla_Põhja-ruskeamadiin
+Lonchura castaneothorax_Roostepugu-amadiin
+Lonchura kelaarti_Kirikõht-amadiin
+Lonchura leucogastroides_Jaava pugal-amadiin
+Lonchura maja_Valgepea-amadiin
+Lonchura malacca_Ruskeamadiin
+Lonchura punctulata_Võrkamadiin
+Lonchura striata_Pugal-amadiin
+Lophaetus occipitalis_Harikotkas
+Lophoceros alboterminatus_Tõmmu-sarvnokk
+Lophoceros camurus_Ruske-sarvnokk
+Lophoceros fasciatus_Harak-sarvnokk
+Lophoceros hemprichii_Etioopia sarvnokk
+Lophoceros nasutus_Hall-sarvnokk
 Lophochroa leadbeateri_Pink Cockatoo
-Lophodytes cucullatus_Hooded Merganser
-Lophonetta specularioides_Crested Duck
+Lophodytes cucullatus_Kübarkoskel
+Lophonetta specularioides_Lakkpart
 Lophophanes cristatus_Tutt-tihane
-Lophophanes dichrous_Gray-crested Tit
-Lophophorus impejanus_Himalayan Monal
-Lophorina superba_Greater Lophorina
-Lophostrix cristata_Crested Owl
+Lophophanes dichrous_Hall-tutttihane
+Lophophorus impejanus_Kroon-läikfaasan
+Lophorina superba_Hõlmik-paradiisilind
+Lophostrix cristata_Tuttkakk
 Lophotriccus eulophotes_Long-crested Pygmy-Tyrant
 Lophotriccus galeatus_Helmeted Pygmy-Tyrant
 Lophotriccus pileatus_Scale-crested Pygmy-Tyrant
 Lophotriccus vitiosus_Double-banded Pygmy-Tyrant
-Lophotriorchis kienerii_Rufous-bellied Eagle
-Lophura leucomelanos_Kalij Pheasant
-Loriculus beryllinus_Sri Lanka Hanging-Parrot
-Loriculus galgulus_Blue-crowned Hanging-Parrot
-Loriculus philippensis_Philippine Hanging-Parrot
-Loriculus vernalis_Vernal Hanging-Parrot
+Lophotriorchis kienerii_Nool-kääbuskotkas
+Lophura leucomelanos_Terasfaasan
+Loriculus beryllinus_Tseiloni ripplind
+Loriculus galgulus_Malai ripplind
+Loriculus philippensis_Filipiini ripplind
+Loriculus vernalis_India ripplind
 Loriotus cristatus_Flame-crested Tanager
 Loriotus luctuosus_White-shouldered Tanager
-Lorius chlorocercus_Yellow-bibbed Lory
-Lorius lory_Black-capped Lory
+Lorius chlorocercus_Kaelus-nestepapagoi
+Lorius lory_Mustkõht-nestepapagoi
 Loxia curvirostra_Kuuse-käbilind
-Loxia leucoptera_White-winged Crossbill
-Loxia pytyopsittacus_Parrot Crossbill
-Loxia scotica_Scottish Crossbill
+Loxia leucoptera_Vööt-käbilind
+Loxia pytyopsittacus_Männi-käbilind
+Loxia scotica_Šoti käbilind
 Loxia sinesciuris_Cassia Crossbill
 Loxigilla noctis_Lesser Antillean Bullfinch
-Loxioides bailleui_Palila
-Loxops caeruleirostris_Akekee
-Loxops coccineus_Hawaii Akepa
-Loxops mana_Hawaii Creeper
+Loxioides bailleui_Palila-nestevint
+Loxops caeruleirostris_Akeke'e-nestevint
+Loxops coccineus_Akepa-nestevint
+Loxops mana_Ohia-nestevint
 Lullula arborea_Nõmmelõoke
-Lurocalis rufiventris_Rufous-bellied Nighthawk
-Lurocalis semitorquatus_Short-tailed Nighthawk
+Lurocalis rufiventris_Andi videvikusorr
+Lurocalis semitorquatus_Mets-videvikusorr
 Luscinia luscinia_Ööbik
-Luscinia megarhynchos_Common Nightingale
-Luscinia phaenicuroides_White-bellied Redstart
+Luscinia megarhynchos_Lõunaööbik
+Luscinia phaenicuroides_Händööbik
 Luscinia svecica_Sinirind
-Lybius bidentatus_Double-toothed Barbet
-Lybius guifsobalito_Black-billed Barbet
-Lybius torquatus_Black-collared Barbet
-Lybius vieilloti_Vieillot's Barbet
-Lycocorax pyrrhopterus_Paradise-crow
-Lymnocryptes minimus_Jack Snipe
-Lyncornis macrotis_Great Eared-Nightjar
-Lyncornis temminckii_Malaysian Eared-Nightjar
+Lybius bidentatus_Puna-udelind
+Lybius guifsobalito_Tõmmu-udelind
+Lybius torquatus_Krae-udelind
+Lybius vieilloti_Veri-udelind
+Lycocorax pyrrhopterus_Paradiisivares
+Lymnocryptes minimus_Mudanepp
+Lyncornis macrotis_Suur-kõrvuksorr
+Lyncornis temminckii_Malai kõrvuksorr
 Lyrurus tetrix_Teder
 Machaerirhynchus flaviventer_Yellow-breasted Boatbill
 Machaerirhynchus nigripectus_Black-breasted Boatbill
-Machaeropterus deliciosus_Club-winged Manakin
-Machaeropterus pyrocephalus_Fiery-capped Manakin
-Machaeropterus regulus_Kinglet Manakin
-Machaeropterus striolatus_Striolated Manakin
-Macheiramphus alcinus_Bat Hawk
-Machetornis rixosa_Cattle Tyrant
-Machlolophus aplonotus_Indian Yellow Tit
-Machlolophus holsti_Taiwan Yellow Tit
-Machlolophus nuchalis_White-naped Tit
-Machlolophus spilonotus_Yellow-cheeked Tit
-Machlolophus xanthogenys_Himalayan Black-lored Tit
+Machaeropterus deliciosus_Häälistiib-tantsulind
+Machaeropterus pyrocephalus_Tulipea-tantsulind
+Machaeropterus regulus_Triip-tantsulind
+Machaeropterus striolatus_Punatriip-tantsulind
+Macheiramphus alcinus_Videvikuhaugas
+Machetornis rixosa_Veisetikat
+Machlolophus aplonotus_Leet-džunglitihane
+Machlolophus holsti_Kiivertihane
+Machlolophus nuchalis_Pugaltihane
+Machlolophus spilonotus_Kuldpõsk-tihane
+Machlolophus xanthogenys_Džunglitihane
 Mackenziaena leachii_Large-tailed Antshrike
 Mackenziaena severa_Tufted Antshrike
-Macroagelaius imthurni_Golden-tufted Grackle
-Macroagelaius subalaris_Mountain Grackle
+Macroagelaius imthurni_Tepuiturpial
+Macroagelaius subalaris_Tammeturpial
 Macronus ptilosus_Fluffy-backed Tit-Babbler
 Macronus striaticeps_Brown Tit-Babbler
-Macronyx capensis_Orange-throated Longclaw
-Macronyx croceus_Yellow-throated Longclaw
-Macronyx fuelleborni_Fülleborn's Longclaw
-Macropygia amboinensis_Amboyna Cuckoo-Dove
+Macronyx capensis_Tulikurk-kaeluskiur
+Macronyx croceus_Safran-kaeluskiur
+Macronyx fuelleborni_Kold-kaeluskiur
+Macropygia amboinensis_Ruuge-kägutuvi
 Macropygia doreya_Sultan's Cuckoo-Dove
-Macropygia mackinlayi_Mackinlay's Cuckoo-Dove
-Macropygia phasianella_Brown Cuckoo-Dove
-Macropygia ruficeps_Little Cuckoo-Dove
-Macropygia tenuirostris_Philippine Cuckoo-Dove
-Macropygia unchall_Barred Cuckoo-Dove
+Macropygia mackinlayi_Melaneesia kägutuvi
+Macropygia phasianella_Austraalia kägutuvi
+Macropygia ruficeps_Väike-kägutuvi
+Macropygia tenuirostris_Filipiini kägutuvi
+Macropygia unchall_Vöötsaba-kägutuvi
 Macrosphenus concolor_Gray Longbill
 Macrosphenus flavicans_Yellow Longbill
 Macrosphenus kempi_Kemp's Longbill
-Magumma parva_Anianiau
+Magumma parva_Anianiau-nestevint
 Malacocincla abbotti_Abbott's Babbler
 Malacocincla sepiaria_Horsfield's Babbler
-Malaconotus blanchoti_Gray-headed Bushshrike
+Malaconotus blanchoti_Hallpea-pagulind
 Malacopteron affine_Sooty-capped Babbler
 Malacopteron cinereum_Scaly-crowned Babbler
 Malacopteron magnirostre_Moustached Babbler
 Malacopteron magnum_Rufous-crowned Babbler
-Malacoptila fulvogularis_Black-streaked Puffbird
-Malacoptila fusca_White-chested Puffbird
-Malacoptila mystacalis_Moustached Puffbird
-Malacoptila panamensis_White-whiskered Puffbird
-Malacoptila rufa_Rufous-necked Puffbird
-Malacoptila semicincta_Semicollared Puffbird
-Malacoptila striata_Crescent-chested Puffbird
-Malacorhynchus membranaceus_Pink-eared Duck
-Malcorus pectoralis_Rufous-eared Warbler
-Malia grata_Malia
-Malimbus nitens_Blue-billed Malimbe
+Malacoptila fulvogularis_Nõlva-puhvlind
+Malacoptila fusca_Tõmmu-puhvlind
+Malacoptila mystacalis_Habe-puhvlind
+Malacoptila panamensis_Ude-puhvlind
+Malacoptila rufa_Karbus-puhvlind
+Malacoptila semicincta_Ruskkukal-puhvlind
+Malacoptila striata_Laidpugu-puhvlind
+Malacorhynchus membranaceus_Koostnokk-part
+Malcorus pectoralis_Kaelus-rohulind
+Malia grata_Kold-padulind
+Malimbus nitens_Hõbenokk-kangurlind
 Malindangia mcgregori_McGregor's Cuckooshrike
-Malurus alboscapulatus_White-shouldered Fairywren
-Malurus amabilis_Lovely Fairywren
+Malurus alboscapulatus_Õlak-tikksaba
+Malurus amabilis_Mets-tikksaba
 Malurus assimilis_Purple-backed Fairywren
-Malurus cyaneus_Superb Fairywren
-Malurus cyanocephalus_Emperor Fairywren
-Malurus elegans_Red-winged Fairywren
-Malurus lamberti_Variegated Fairywren
-Malurus leucopterus_White-winged Fairywren
-Malurus melanocephalus_Red-backed Fairywren
-Malurus splendens_Splendid Fairywren
-Manacus aurantiacus_Orange-collared Manakin
-Manacus candei_White-collared Manakin
-Manacus manacus_White-bearded Manakin
-Manacus vitellinus_Golden-collared Manakin
+Malurus cyaneus_Salu-tikksaba
+Malurus cyanocephalus_Kuning-tikksaba
+Malurus elegans_Lasuurpea-tikksaba
+Malurus lamberti_Hund-tikksaba
+Malurus leucopterus_Valgetiib-tikksaba
+Malurus melanocephalus_Punaselg-tikksaba
+Malurus splendens_Türkiis-tikksaba
+Manacus aurantiacus_Leekkael-tantsulind
+Manacus candei_Valgekael-tantsulind
+Manacus manacus_Habe-tantsulind
+Manacus vitellinus_Kuldkael-tantsulind
 Manorina flavigula_Yellow-throated Miner
 Manorina melanocephala_Noisy Miner
 Manorina melanophrys_Bell Miner
-Mareca americana_American Wigeon
-Mareca falcata_Falcated Duck
-Mareca penelope_Eurasian Wigeon
-Mareca sibilatrix_Chiloe Wigeon
-Mareca strepera_Gadwall
-Margarops fuscatus_Pearly-eyed Thrasher
+Mareca americana_Ameerika viupart
+Mareca falcata_Sirppart
+Mareca penelope_Viupart
+Mareca sibilatrix_Patagoonia viupart
+Mareca strepera_Rääkspart
+Margarops fuscatus_Suur-pilalind
 Margarornis rubiginosus_Ruddy Treerunner
 Margarornis squamiger_Pearled Treerunner
-Masius chrysopterus_Golden-winged Manakin
+Masius chrysopterus_Kuldtiib-tantsulind
 Mazaria propinqua_White-bellied Spinetail
 Mecocerculus hellmayri_Buff-banded Tyrannulet
 Mecocerculus leucophrys_White-throated Tyrannulet
 Mecocerculus minor_Sulphur-bellied Tyrannulet
 Mecocerculus poecilocercus_White-tailed Tyrannulet
 Mecocerculus stictopterus_White-banded Tyrannulet
-Megaceryle alcyon_Belted Kingfisher
-Megaceryle lugubris_Crested Kingfisher
-Megaceryle maxima_Giant Kingfisher
-Megaceryle torquata_Ringed Kingfisher
-Megalurus palustris_Striated Grassbird
-Megapodius cumingii_Tabon Scrubfowl
-Megapodius eremita_Melanesian Scrubfowl
-Megapodius freycinet_Dusky Scrubfowl
-Megapodius reinwardt_Orange-footed Scrubfowl
-Megarynchus pitangua_Boat-billed Flycatcher
-Megascops albogularis_White-throated Screech-Owl
-Megascops asio_Eastern Screech-Owl
-Megascops atricapilla_Black-capped Screech-Owl
+Megaceryle alcyon_Põhja-kuningkalur
+Megaceryle lugubris_Kroon-kuningkalur
+Megaceryle maxima_Hiid-kuningkalur
+Megaceryle torquata_Kaelus-kuningkalur
+Megalurus palustris_Suur-padulind
+Megapodius cumingii_Filipiini rihukana
+Megapodius eremita_Melaneesia rihukana
+Megapodius freycinet_Tõmmu-rihukana
+Megapodius reinwardt_Punajalg-rihukana
+Megarynchus pitangua_Suurnokk-masktikat
+Megascops albogularis_Valgekurk-päll
+Megascops asio_Aedpäll
+Megascops atricapilla_Liaanipäll
 Megascops centralis_Choco Screech-Owl
-Megascops choliba_Tropical Screech-Owl
-Megascops clarkii_Bare-shanked Screech-Owl
-Megascops cooperi_Pacific Screech-Owl
+Megascops choliba_Lõunapäll
+Megascops clarkii_Panama päll
+Megascops cooperi_Rannikupäll
 Megascops gilesi_Santa Marta Screech-Owl
-Megascops guatemalae_Middle American Screech-Owl
-Megascops hoyi_Montane Forest Screech-Owl
-Megascops ingens_Rufescent Screech-Owl
-Megascops kennicottii_Western Screech-Owl
-Megascops koepckeae_Koepcke's Screech-Owl
-Megascops petersoni_Cinnamon Screech-Owl
-Megascops roboratus_Peruvian Screech-Owl
+Megascops guatemalae_Värepäll
+Megascops hoyi_Vihmapäll
+Megascops ingens_Suur-pilvepäll
+Megascops kennicottii_Läänepäll
+Megascops koepckeae_Andi päll
+Megascops petersoni_Ruuge-pilvepäll
+Megascops roboratus_Võsapäll
 Megascops roraimae_Foothill Screech-Owl
-Megascops sanctaecatarinae_Long-tufted Screech-Owl
-Megascops seductus_Balsas Screech-Owl
-Megascops trichopsis_Whiskered Screech-Owl
-Megascops watsonii_Tawny-bellied Screech-Owl
+Megascops sanctaecatarinae_Araukaariapäll
+Megascops seductus_Kõnnupäll
+Megascops trichopsis_Tammepäll
+Megascops watsonii_Selvapäll
 Megastictus margaritatus_Pearly Antshrike
 Megaxenops parnaguae_Great Xenops
-Meiglyptes tristis_Buff-rumped Woodpecker
-Meiglyptes tukki_Buff-necked Woodpecker
-Melaenornis edolioides_Northern Black-Flycatcher
-Melaenornis fischeri_White-eyed Slaty-Flycatcher
-Melaenornis pammelaina_Southern Black-Flycatcher
-Melaenornis silens_Fiscal Flycatcher
+Meiglyptes tristis_Kirju-võrarähn
+Meiglyptes tukki_Pruun-võrarähn
+Melaenornis edolioides_Nõgi-kärbsenäpp
+Melaenornis fischeri_Prill-kärbsenäpp
+Melaenornis pammelaina_Süsi-kärbsenäpp
+Melaenornis silens_Salu-kärbsenäpp
 Melampitta lugubris_Lesser Melampitta
-Melanerpes aurifrons_Golden-fronted Woodpecker
-Melanerpes cactorum_White-fronted Woodpecker
-Melanerpes candidus_White Woodpecker
-Melanerpes carolinus_Red-bellied Woodpecker
-Melanerpes chrysauchen_Golden-naped Woodpecker
-Melanerpes chrysogenys_Golden-cheeked Woodpecker
-Melanerpes cruentatus_Yellow-tufted Woodpecker
-Melanerpes erythrocephalus_Red-headed Woodpecker
-Melanerpes flavifrons_Yellow-fronted Woodpecker
-Melanerpes formicivorus_Acorn Woodpecker
-Melanerpes hoffmannii_Hoffmann's Woodpecker
-Melanerpes hypopolius_Gray-breasted Woodpecker
-Melanerpes lewis_Lewis's Woodpecker
-Melanerpes portoricensis_Puerto Rican Woodpecker
-Melanerpes pucherani_Black-cheeked Woodpecker
-Melanerpes pygmaeus_Yucatan Woodpecker
-Melanerpes radiolatus_Jamaican Woodpecker
-Melanerpes rubricapillus_Red-crowned Woodpecker
-Melanerpes striatus_Hispaniolan Woodpecker
-Melanerpes superciliaris_West Indian Woodpecker
-Melanerpes uropygialis_Gila Woodpecker
-Melaniparus afer_Gray Tit
-Melaniparus albiventris_White-bellied Tit
-Melaniparus cinerascens_Ashy Tit
-Melaniparus funereus_Dusky Tit
-Melaniparus leucomelas_White-winged Black-Tit
-Melaniparus niger_Southern Black-Tit
-Melaniparus rufiventris_Rufous-bellied Tit
-Melaniparus thruppi_Somali Tit
-Melanitta americana_Black Scoter
-Melanitta fusca_Velvet Scoter
-Melanitta nigra_Common Scoter
-Melanitta perspicillata_Surf Scoter
-Melanochlora sultanea_Sultan Tit
-Melanocorypha calandra_Calandra Lark
-Melanocorypha maxima_Tibetan Lark
+Melanerpes aurifrons_Tulipea-leeträhn
+Melanerpes cactorum_Valgekukal-maskrähn
+Melanerpes candidus_Valgerähn
+Melanerpes carolinus_Pähkli-leeträhn
+Melanerpes chrysauchen_Kuldkukal-maskrähn
+Melanerpes chrysogenys_Laiksilm-leeträhn
+Melanerpes cruentatus_Must-maskrähn
+Melanerpes erythrocephalus_Punapea-rähn
+Melanerpes flavifrons_Kuldkurk-maskrähn
+Melanerpes formicivorus_Tõrurähn
+Melanerpes hoffmannii_Nikaraagua leeträhn
+Melanerpes hypopolius_Oaxaca leeträhn
+Melanerpes lewis_Tikaträhn
+Melanerpes portoricensis_Puertoriiko rähn
+Melanerpes pucherani_Viirselg-maskrähn
+Melanerpes pygmaeus_Yucatani leeträhn
+Melanerpes radiolatus_Jamaika leeträhn
+Melanerpes rubricapillus_Väike-leeträhn
+Melanerpes striatus_Haiti leeträhn
+Melanerpes superciliaris_Suur-leeträhn
+Melanerpes uropygialis_Kaktuse-leeträhn
+Melaniparus afer_Halltihane
+Melaniparus albiventris_Valgekõht-nõgitihane
+Melaniparus cinerascens_Akaatsia-halltihane
+Melaniparus funereus_Mets-nõgitihane
+Melaniparus leucomelas_Valgetiib-nõgitihane
+Melaniparus niger_Lõuna-nõgitihane
+Melaniparus rufiventris_Savannitihane
+Melaniparus thruppi_Väike-halltihane
+Melanitta americana_Ida-mustvaeras
+Melanitta fusca_Tõmmuvaeras
+Melanitta nigra_Mustvaeras
+Melanitta perspicillata_Prillvaeras
+Melanochlora sultanea_Sultantihane
+Melanocorypha calandra_Stepilõoke
+Melanocorypha maxima_Tiibeti lõoke
 Melanodera melanodera_White-bridled Finch
 Melanodera xanthogramma_Yellow-bridled Finch
-Melanodryas cucullata_Hooded Robin
-Melanodryas vittata_Dusky Robin
+Melanodryas cucullata_Pugalmiro
+Melanodryas vittata_Tasmaania miro
 Melanopareia elegans_Elegant Crescentchest
 Melanopareia maranonica_Marañon Crescentchest
 Melanopareia maximiliani_Olive-crowned Crescentchest
 Melanopareia torquata_Collared Crescentchest
-Melanoptila glabrirostris_Black Catbird
+Melanoptila glabrirostris_Must-pilalind
 Melanorectes nigrescens_Black Pitohui
 Melanospiza bicolor_Black-faced Grassquit
-Melanotis caerulescens_Blue Mockingbird
-Melanotis hypoleucus_Blue-and-white Mockingbird
-Meleagris gallopavo_Wild Turkey
-Meleagris ocellata_Ocellated Turkey
+Melanotis caerulescens_Sini-pilalind
+Melanotis hypoleucus_Lasuur-pilalind
+Meleagris gallopavo_Metskalkun
+Meleagris ocellata_Silmikkalkun
 Meliarchus sclateri_Makira Honeyeater
 Melidectes belfordi_Belford's Melidectes
 Melidectes rufocrissalis_Yellow-browed Melidectes
-Melidora macrorrhina_Hook-billed Kingfisher
+Melidora macrorrhina_Öö-safiirlind
 Meliphaga lewinii_Lewin's Honeyeater
 Meliphaga notata_Yellow-spotted Honeyeater
 Melithreptus affinis_Black-headed Honeyeater
@@ -3504,75 +3504,75 @@ Melithreptus chloropsis_Gilbert's Honeyeater
 Melithreptus gularis_Black-chinned Honeyeater
 Melithreptus lunatus_White-naped Honeyeater
 Melithreptus validirostris_Strong-billed Honeyeater
-Mellisuga helenae_Bee Hummingbird
-Mellisuga minima_Vervain Hummingbird
+Mellisuga helenae_Kimalaskoolibri
+Mellisuga minima_Pisikoolibri
 Melocichla mentalis_Moustached Grass-Warbler
-Melopsittacus undulatus_Budgerigar
+Melopsittacus undulatus_Viirpapagoi
 Melopyrrha portoricensis_Puerto Rican Bullfinch
 Melopyrrha violacea_Greater Antillean Bullfinch
-Melospiza georgiana_Swamp Sparrow
-Melospiza lincolnii_Lincoln's Sparrow
-Melospiza melodia_Song Sparrow
-Melozone aberti_Abert's Towhee
-Melozone albicollis_White-throated Towhee
-Melozone biarcuata_White-faced Ground-Sparrow
-Melozone cabanisi_Cabanis's Ground-Sparrow
-Melozone crissalis_California Towhee
-Melozone fusca_Canyon Towhee
-Melozone kieneri_Rusty-crowned Ground-Sparrow
-Melozone leucotis_White-eared Ground-Sparrow
-Menura alberti_Albert's Lyrebird
-Menura novaehollandiae_Superb Lyrebird
-Mergellus albellus_Smew
+Melospiza georgiana_Soosidrik
+Melospiza lincolnii_Rabasidrik
+Melospiza melodia_Laulusidrik
+Melozone aberti_Jõgi-maasidrik
+Melozone albicollis_Vööt-maasidrik
+Melozone biarcuata_Prill-maasidrik
+Melozone cabanisi_Karbus-maasidrik
+Melozone crissalis_Kalifornia maasidrik
+Melozone fusca_Asteegi maasidrik
+Melozone kieneri_Punakael-maasidrik
+Melozone leucotis_Kuldlaik-maasidrik
+Menura alberti_Väike-lüürasaba
+Menura novaehollandiae_Hund-lüürasaba
+Mergellus albellus_Väikekoskel
 Mergus merganser_Jääkoskel
 Mergus serrator_Rohukoskel
-Merops albicollis_White-throated Bee-eater
-Merops apiaster_European Bee-eater
-Merops bullockoides_White-fronted Bee-eater
-Merops bulocki_Red-throated Bee-eater
-Merops hirundineus_Swallow-tailed Bee-eater
-Merops leschenaulti_Chestnut-headed Bee-eater
-Merops oreobates_Cinnamon-chested Bee-eater
-Merops orientalis_Green Bee-eater
-Merops ornatus_Rainbow Bee-eater
-Merops persicus_Blue-cheeked Bee-eater
-Merops philippinus_Blue-tailed Bee-eater
-Merops pusillus_Little Bee-eater
-Merops superciliosus_Madagascar Bee-eater
-Merops variegatus_Blue-breasted Bee-eater
-Merops viridis_Blue-throated Bee-eater
+Merops albicollis_Kõrbe-mesilasenäpp
+Merops apiaster_Mesilasenäpp
+Merops bullockoides_Valgelaup-mesilasenäpp
+Merops bulocki_Savanni-mesilasenäpp
+Merops hirundineus_Harksaba-mesilasenäpp
+Merops leschenaulti_Ida-mesilasenäpp
+Merops oreobates_Mägi-mesilasenäpp
+Merops orientalis_Väike-mesilasenäpp
+Merops ornatus_Austraalia mesilasenäpp
+Merops persicus_Rohe-mesilasenäpp
+Merops philippinus_Sinisaba-mesilasenäpp
+Merops pusillus_Pisi-mesilasenäpp
+Merops superciliosus_Ruskekurk-mesilasenäpp
+Merops variegatus_Soo-mesilasenäpp
+Merops viridis_Lasuurkurk-mesilasenäpp
 Merulaxis ater_Slaty Bristlefront
-Mesembrinibis cayennensis_Green Ibis
-Mesitornis unicolor_Brown Mesite
-Mesitornis variegatus_White-breasted Mesite
-Metallura tyrianthina_Tyrian Metaltail
-Metallura williami_Viridian Metaltail
-Metopidius indicus_Bronze-winged Jacana
+Mesembrinibis cayennensis_Selvaiibis
+Mesitornis unicolor_Pruun-roatelo
+Mesitornis variegatus_Valgerind-roatelo
+Metallura tyrianthina_Väike-helksabakoolibri
+Metallura williami_Paramo-helksabakoolibri
+Metopidius indicus_Läik-lootoselind
 Metopothrix aurantiaca_Orange-fronted Plushcrown
-Metriopelia melanoptera_Black-winged Ground Dove
-Micrastur buckleyi_Buckley's Forest-Falcon
-Micrastur gilvicollis_Lined Forest-Falcon
-Micrastur mintoni_Cryptic Forest-Falcon
-Micrastur mirandollei_Slaty-backed Forest-Falcon
-Micrastur ruficollis_Barred Forest-Falcon
-Micrastur semitorquatus_Collared Forest-Falcon
-Micrathene whitneyi_Elf Owl
-Microbates cinereiventris_Tawny-faced Gnatwren
-Microbates collaris_Collared Gnatwren
-Microcarbo niger_Little Cormorant
+Metriopelia melanoptera_Suur-puunatuvi
+Micrastur buckleyi_Peruu metspistrik
+Micrastur gilvicollis_Amasoonia metspistrik
+Micrastur mintoni_Brasiilia metspistrik
+Micrastur mirandollei_Mustpea-metspistrik
+Micrastur ruficollis_Vööt-metspistrik
+Micrastur semitorquatus_Suur-metspistrik
+Micrathene whitneyi_Kaktusekakk
+Microbates cinereiventris_Töbi-händkäblik
+Microbates collaris_Mustpugu-händkäblik
+Microcarbo niger_Ida-kääbuskormoran
 Microcentrum rhombifolium_Greater Angle-wing
-Microcerculus bambla_Wing-banded Wren
-Microcerculus marginatus_Scaly-breasted Wren
-Microcerculus philomela_Nightingale Wren
-Microcerculus ustulatus_Flutist Wren
-Microeca fascinans_Jacky-winter
-Microeca flavigaster_Lemon-bellied Flycatcher
-Microhierax fringillarius_Black-thighed Falconet
-Micromonacha lanceolata_Lanceolated Monklet
-Micronisus gabar_Gabar Goshawk
-Micropsitta finschii_Finsch's Pygmy-Parrot
-Micropternus brachyurus_Rufous Woodpecker
-Micropygia schomburgkii_Ocellated Crake
+Microcerculus bambla_Vööt-vilekäblik
+Microcerculus marginatus_Valgepugu-vilekäblik
+Microcerculus philomela_Töbi-vilekäblik
+Microcerculus ustulatus_Pruun-vilekäblik
+Microeca fascinans_Pruun-sööstmiro
+Microeca flavigaster_Savanni-sööstmiro
+Microhierax fringillarius_Malai värbpistrik
+Micromonacha lanceolata_Väike-puhvlind
+Micronisus gabar_Väike-laulukull
+Micropsitta finschii_Rohe-kääbuspapagoi
+Micropternus brachyurus_Sipelgarähn
+Micropygia schomburgkii_Helmes-vuttruik
 Microrhopias quixensis_Dot-winged Antwren
 Microspingus cabanisi_Gray-throated Warbling Finch
 Microspingus erythrophrys_Rusty-browed Warbling Finch
@@ -3580,133 +3580,133 @@ Microspingus lateralis_Buff-throated Warbling Finch
 Microspingus melanoleucus_Black-capped Warbling Finch
 Microspingus torquatus_Ringed Warbling Finch
 Microxenops milleri_Rufous-tailed Xenops
-Milvago chimachima_Yellow-headed Caracara
-Milvago chimango_Chimango Caracara
+Milvago chimachima_Helekarakaara
+Milvago chimango_Väikekarakaara
 Milvus migrans_Must-harksaba
-Milvus milvus_Red Kite
-Mimus dorsalis_Brown-backed Mockingbird
-Mimus gilvus_Tropical Mockingbird
-Mimus gundlachii_Bahama Mockingbird
-Mimus longicaudatus_Long-tailed Mockingbird
-Mimus patagonicus_Patagonian Mockingbird
-Mimus polyglottos_Northern Mockingbird
-Mimus saturninus_Chalk-browed Mockingbird
-Mimus thenca_Chilean Mockingbird
-Mimus triurus_White-banded Mockingbird
-Minla ignotincta_Red-tailed Minla
-Mino dumontii_Yellow-faced Myna
-Mino kreffti_Long-tailed Myna
+Milvus milvus_Puna-harksaba
+Mimus dorsalis_Mägi-pilalind
+Mimus gilvus_Troopika-pilalind
+Mimus gundlachii_Pruun-pilalind
+Mimus longicaudatus_Händ-pilalind
+Mimus patagonicus_Patagoonia pilalind
+Mimus polyglottos_Taidur-pilalind
+Mimus saturninus_Valgekulm-pilalind
+Mimus thenca_Tšiili pilalind
+Mimus triurus_Valgetiib-pilalind
+Minla ignotincta_Väike-hundvädrak
+Mino dumontii_Paapua maina
+Mino kreffti_Melaneesia maina
 Miogryllus saussurei_Miogryllus saussurei
 Mionectes macconnelli_McConnell's Flycatcher
 Mionectes oleagineus_Ochre-bellied Flycatcher
 Mionectes olivaceus_Olive-striped Flycatcher
 Mionectes rufiventris_Gray-hooded Flycatcher
 Mionectes striaticollis_Streak-necked Flycatcher
-Mirafra affinis_Jerdon's Bushlark
-Mirafra africana_Rufous-naped Lark
-Mirafra apiata_Cape Clapper Lark
-Mirafra assamica_Bengal Bushlark
-Mirafra cantillans_Singing Bushlark
-Mirafra cheniana_Latakoo Lark
-Mirafra erythrocephala_Indochinese Bushlark
-Mirafra erythroptera_Indian Bushlark
-Mirafra fasciolata_Eastern Clapper Lark
-Mirafra javanica_Australasian Bushlark
-Mirafra passerina_Monotonous Lark
-Mirafra rufocinnamomea_Flappet Lark
-Mitrephanes phaeocercus_Tufted Flycatcher
+Mirafra affinis_Draviidi rohtlalõoke
+Mirafra africana_Ruuge-rohtlalõoke
+Mirafra apiata_Lõgislõoke
+Mirafra assamica_Bengali rohtlalõoke
+Mirafra cantillans_Lääne-rohtlalõoke
+Mirafra cheniana_Taidur-rohtlalõoke
+Mirafra erythrocephala_Indohiina rohtlalõoke
+Mirafra erythroptera_Dekkani rohtlalõoke
+Mirafra fasciolata_Ida-lõgislõoke
+Mirafra javanica_Ida-rohtlalõoke
+Mirafra passerina_Mopaani-rohtlalõoke
+Mirafra rufocinnamomea_Käristilõoke
+Mitrephanes phaeocercus_Andi tutt-tikat
 Mitrospingus cassinii_Dusky-faced Tanager
 Mitrospingus oleagineus_Olive-backed Tanager
-Mitu salvini_Salvin's Curassow
-Mitu tomentosum_Crestless Curassow
-Mitu tuberosum_Razor-billed Curassow
+Mitu salvini_Loreto hoko
+Mitu tomentosum_Jõgihoko
+Mitu tuberosum_Kühmnokk-hoko
 Mixornis bornensis_Bold-striped Tit-Babbler
 Mixornis flavicollis_Gray-cheeked Tit-Babbler
 Mixornis gularis_Pin-striped Tit-Babbler
 Mixornis kelleyi_Gray-faced Tit-Babbler
-Mniotilta varia_Black-and-white Warbler
+Mniotilta varia_Tüvesäälik
 Modulatrix stictigula_Spot-throat
-Mohoua albicilla_Whitehead
-Mohoua novaeseelandiae_Pipipi
-Mohoua ochrocephala_Yellowhead
-Molothrus aeneus_Bronzed Cowbird
-Molothrus ater_Brown-headed Cowbird
-Molothrus bonariensis_Shiny Cowbird
-Molothrus oryzivorus_Giant Cowbird
-Molothrus rufoaxillaris_Screaming Cowbird
-Momotus aequatorialis_Andean Motmot
+Mohoua albicilla_Poopokatea-pöögilind
+Mohoua novaeseelandiae_Piipipi-pöögilind
+Mohoua ochrocephala_Moohua-pöögilind
+Molothrus aeneus_Sinitiib-nugiturpial
+Molothrus ater_Piisoniturpial
+Molothrus bonariensis_Läik-nugiturpial
+Molothrus oryzivorus_Näärturpial
+Molothrus rufoaxillaris_Aed-nugiturpial
+Momotus aequatorialis_Andi motmot
 Momotus coeruliceps_Blue-capped Motmot
 Momotus lessonii_Lesson's Motmot
-Momotus mexicanus_Russet-crowned Motmot
-Momotus momota_Amazonian Motmot
+Momotus mexicanus_Punapea-motmot
+Momotus momota_Diadeem-motmot
 Momotus subrufescens_Whooping Motmot
 Monarcha castaneiventris_Chestnut-bellied Monarch
 Monarcha frater_Black-winged Monarch
 Monarcha melanopsis_Black-faced Monarch
 Monarcha richardsii_White-capped Monarch
-Monasa atra_Black Nunbird
-Monasa flavirostris_Yellow-billed Nunbird
-Monasa morphoeus_White-fronted Nunbird
-Monasa nigrifrons_Black-fronted Nunbird
-Montecincla fairbanki_Palani Laughingthrush
-Monticola cinclorhyncha_Blue-capped Rock-Thrush
-Monticola gularis_White-throated Rock-Thrush
-Monticola rufiventris_Chestnut-bellied Rock-Thrush
-Monticola rupestris_Cape Rock-Thrush
-Monticola saxatilis_Rufous-tailed Rock-Thrush
-Monticola sharpei_Forest Rock-Thrush
-Monticola solitarius_Blue Rock-Thrush
-Montifringilla blanfordi_Blanford's Snowfinch
-Montifringilla nivalis_White-winged Snowfinch
-Montifringilla taczanowskii_White-rumped Snowfinch
-Morococcyx erythropygus_Lesser Ground-Cuckoo
-Morphnarchus princeps_Barred Hawk
-Morphnus guianensis_Crested Eagle
-Morus bassanus_Northern Gannet
-Motacilla aguimp_African Pied Wagtail
+Monasa atra_Guajaana puhvlind
+Monasa flavirostris_Koldnokk-puhvlind
+Monasa morphoeus_Lauk-puhvlind
+Monasa nigrifrons_Nõgi-puhvlind
+Montecincla fairbanki_Vaarika-kulmvädrak
+Monticola cinclorhyncha_Himaalaja kivisiirak
+Monticola gularis_Taiga-kivisiirak
+Monticola rufiventris_Mustkurk-kivisiirak
+Monticola rupestris_Pruunselg-kivisiirak
+Monticola saxatilis_Kivisiirak
+Monticola sharpei_Madagaskari kivisiirak
+Monticola solitarius_Sini-kivisiirak
+Montifringilla blanfordi_Liiv-lumevarblane
+Montifringilla nivalis_Lumevarblane
+Montifringilla taczanowskii_Hele-lumevarblane
+Morococcyx erythropygus_Rästaskägu
+Morphnarchus princeps_Suur-selvaviu
+Morphnus guianensis_Sarvikkotkas
+Morus bassanus_Suula
+Motacilla aguimp_Aafrika linavästrik
 Motacilla alba_Linavästrik
-Motacilla capensis_Cape Wagtail
-Motacilla cinerea_Mägivästrik
-Motacilla citreola_Citrine Wagtail
-Motacilla clara_Mountain Wagtail
+Motacilla capensis_Lõunavästrik
+Motacilla cinerea_Jõgivästrik
+Motacilla citreola_Kuldhänilane
+Motacilla clara_Kosevästrik
 Motacilla flava_Hänilane
-Motacilla flaviventris_Madagascar Wagtail
-Motacilla grandis_Japanese Wagtail
-Motacilla maderaspatensis_White-browed Wagtail
-Motacilla tschutschensis_Eastern Yellow Wagtail
-Mulleripicus fulvus_Ashy Woodpecker
-Mulleripicus pulverulentus_Great Slaty Woodpecker
-Muscicapa adusta_African Dusky Flycatcher
-Muscicapa aquatica_Swamp Flycatcher
-Muscicapa dauurica_Asian Brown Flycatcher
-Muscicapa ferruginea_Ferruginous Flycatcher
-Muscicapa griseisticta_Gray-streaked Flycatcher
-Muscicapa muttui_Brown-breasted Flycatcher
-Muscicapa sibirica_Dark-sided Flycatcher
+Motacilla flaviventris_Madagaskari västrik
+Motacilla grandis_Jaapani linavästrik
+Motacilla maderaspatensis_India linavästrik
+Motacilla tschutschensis_Idahänilane
+Mulleripicus fulvus_Sulawesi suurrähn
+Mulleripicus pulverulentus_Hall-suurrähn
+Muscicapa adusta_Välu-kärbsenäpp
+Muscicapa aquatica_Soo-kärbsenäpp
+Muscicapa dauurica_Ida-kärbsenäpp
+Muscicapa ferruginea_Rooste-kärbsenäpp
+Muscicapa griseisticta_Lehise-kärbsenäpp
+Muscicapa muttui_Pruun-kärbsenäpp
+Muscicapa sibirica_Tuhk-kärbsenäpp
 Muscicapa striata_Hall-kärbsenäpp
-Muscicapa williamsoni_Brown-streaked Flycatcher
-Muscigralla brevicauda_Short-tailed Field Tyrant
-Muscipipra vetula_Shear-tailed Gray Tyrant
+Muscicapa williamsoni_Kra kärbsenäpp
+Muscigralla brevicauda_Lühisaba-tikat
+Muscipipra vetula_Frakktikat
 Muscisaxicola albilora_White-browed Ground-Tyrant
 Muscisaxicola maculirostris_Spot-billed Ground-Tyrant
-Musophaga rossae_Ross's Turaco
-Mustelirallus albicollis_Ash-throated Crake
-Mustelirallus erythrops_Paint-billed Crake
-Myadestes coloratus_Varied Solitaire
-Myadestes elisabeth_Cuban Solitaire
-Myadestes genibarbis_Rufous-throated Solitaire
-Myadestes melanops_Black-faced Solitaire
-Myadestes obscurus_Omao
-Myadestes occidentalis_Brown-backed Solitaire
+Musophaga rossae_Prillturako
+Mustelirallus albicollis_Tärinhuik
+Mustelirallus erythrops_Ehisnokk-huik
+Myadestes coloratus_Panama näpprästas
+Myadestes elisabeth_Kuuba näpprästas
+Myadestes genibarbis_Punakurk-näpprästas
+Myadestes melanops_Kostariika näpprästas
+Myadestes obscurus_Roostetiib-näpprästas
+Myadestes occidentalis_Roostetiib-näpprästas
 Myadestes palmeri_Puaiohi
-Myadestes ralloides_Andean Solitaire
-Myadestes townsendi_Townsend's Solitaire
-Myadestes unicolor_Slate-colored Solitaire
-Mycerobas affinis_Collared Grosbeak
-Mycerobas carnipes_White-winged Grosbeak
-Mycerobas icterioides_Black-and-yellow Grosbeak
-Mycteria americana_Wood Stork
-Mycteria leucocephala_Painted Stork
+Myadestes ralloides_Andi näpprästas
+Myadestes townsendi_Näpprästas
+Myadestes unicolor_Tuhk-näpprästas
+Mycerobas affinis_Tuli-suurnokkvint
+Mycerobas carnipes_Artša-suurnokkvint
+Mycerobas icterioides_Kašmiiri suurnokk-vint
+Mycteria americana_Muda-toonekurg
+Mycteria leucocephala_Ehis-toonekurg
 Myiagra alecto_Shining Flycatcher
 Myiagra caledonica_Melanesian Flycatcher
 Myiagra cyanoleuca_Satin Flycatcher
@@ -3717,41 +3717,41 @@ Myiagra nana_Paperbark Flycatcher
 Myiagra rubecula_Leaden Flycatcher
 Myiagra ruficollis_Broad-billed Flycatcher
 Myiagra vanikorensis_Vanikoro Flycatcher
-Myiarchus antillarum_Puerto Rican Flycatcher
-Myiarchus apicalis_Apical Flycatcher
-Myiarchus barbirostris_Sad Flycatcher
-Myiarchus cephalotes_Pale-edged Flycatcher
-Myiarchus cinerascens_Ash-throated Flycatcher
-Myiarchus crinitus_Great Crested Flycatcher
-Myiarchus ferox_Short-crested Flycatcher
-Myiarchus nuttingi_Nutting's Flycatcher
-Myiarchus panamensis_Panama Flycatcher
-Myiarchus phaeocephalus_Sooty-crowned Flycatcher
-Myiarchus sagrae_La Sagra's Flycatcher
-Myiarchus stolidus_Stolid Flycatcher
-Myiarchus swainsoni_Swainson's Flycatcher
-Myiarchus tuberculifer_Dusky-capped Flycatcher
-Myiarchus tyrannulus_Brown-crested Flycatcher
-Myiarchus venezuelensis_Venezuelan Flycatcher
-Myiarchus yucatanensis_Yucatan Flycatcher
+Myiarchus antillarum_Puertoriiko kahutikat
+Myiarchus apicalis_Kolumbia kahutikat
+Myiarchus barbirostris_Väike-kahutikat
+Myiarchus cephalotes_Mägi-kahutikat
+Myiarchus cinerascens_Kõnnu-kahutikat
+Myiarchus crinitus_Aed-kahutikat
+Myiarchus ferox_Salu-kahutikat
+Myiarchus nuttingi_Võsa-kahutikat
+Myiarchus panamensis_Selva-kahutikat
+Myiarchus phaeocephalus_Tuhkpea-kahutikat
+Myiarchus sagrae_Kuuba kahutikat
+Myiarchus stolidus_Leetrind-kahutikat
+Myiarchus swainsoni_Välu-kahutikat
+Myiarchus tuberculifer_Mets-kahutikat
+Myiarchus tyrannulus_Vööt-kahutikat
+Myiarchus venezuelensis_Venetsueela kahutikat
+Myiarchus yucatanensis_Yucatani kahutikat
 Myiobius atricaudus_Black-tailed Flycatcher
 Myiobius barbatus_Whiskered Flycatcher
 Myiobius sulphureipygius_Sulphur-rumped Flycatcher
-Myioborus albifrons_White-fronted Redstart
-Myioborus brunniceps_Brown-capped Redstart
-Myioborus castaneocapilla_Tepui Redstart
-Myioborus flavivertex_Yellow-crowned Redstart
-Myioborus melanocephalus_Spectacled Redstart
-Myioborus miniatus_Slate-throated Redstart
-Myioborus ornatus_Golden-fronted Redstart
-Myioborus pictus_Painted Redstart
-Myioborus torquatus_Collared Redstart
-Myiodynastes bairdii_Baird's Flycatcher
-Myiodynastes chrysocephalus_Golden-crowned Flycatcher
-Myiodynastes hemichrysus_Golden-bellied Flycatcher
-Myiodynastes luteiventris_Sulphur-bellied Flycatcher
-Myiodynastes maculatus_Streaked Flycatcher
-Myiomela leucura_White-tailed Robin
+Myioborus albifrons_Prill-mägisäälik
+Myioborus brunniceps_Lõuna-mägisäälik
+Myioborus castaneocapilla_Tepui-mägisäälik
+Myioborus flavivertex_Kuldkiird-mägisäälik
+Myioborus melanocephalus_Andi mägisäälik
+Myioborus miniatus_Tanu-mägisäälik
+Myioborus ornatus_Kuld-mägisäälik
+Myioborus pictus_Sametsäälik
+Myioborus torquatus_Kaelus-mägisäälik
+Myiodynastes bairdii_Ruuge-masktikat
+Myiodynastes chrysocephalus_Andi masktikat
+Myiodynastes hemichrysus_Kostariika masktikat
+Myiodynastes luteiventris_Joonik-masktikat
+Myiodynastes maculatus_Triip-masktikat
+Myiomela leucura_Pugalsaba-koobaltööbik
 Myiopagis caniceps_Gray Elaenia
 Myiopagis flavivertex_Yellow-crowned Elaenia
 Myiopagis gaimardii_Forest Elaenia
@@ -3762,7 +3762,7 @@ Myiophobus cryptoxanthus_Olive-chested Flycatcher
 Myiophobus fasciatus_Bran-colored Flycatcher
 Myiophobus flavicans_Flavescent Flycatcher
 Myiophobus phoenicomitra_Orange-crested Flycatcher
-Myiopsitta monachus_Monk Parakeet
+Myiopsitta monachus_Munkpapagoi
 Myiornis albiventris_White-bellied Pygmy-Tyrant
 Myiornis atricapillus_Black-capped Pygmy-Tyrant
 Myiornis auricularis_Eared Pygmy-Tyrant
@@ -3771,37 +3771,37 @@ Myiotheretes fumigatus_Smoky Bush-Tyrant
 Myiotheretes fuscorufus_Rufous-bellied Bush-Tyrant
 Myiotheretes pernix_Santa Marta Bush-Tyrant
 Myiotheretes striaticollis_Streak-throated Bush-Tyrant
-Myiothlypis basilica_Santa Marta Warbler
-Myiothlypis bivittata_Two-banded Warbler
-Myiothlypis chrysogaster_Golden-bellied Warbler
-Myiothlypis cinereicollis_Gray-throated Warbler
-Myiothlypis conspicillata_White-lored Warbler
-Myiothlypis coronata_Russet-crowned Warbler
-Myiothlypis flaveola_Flavescent Warbler
-Myiothlypis fraseri_Gray-and-gold Warbler
-Myiothlypis fulvicauda_Buff-rumped Warbler
-Myiothlypis leucoblephara_White-browed Warbler
-Myiothlypis leucophrys_White-striped Warbler
-Myiothlypis luteoviridis_Citrine Warbler
-Myiothlypis nigrocristata_Black-crested Warbler
-Myiothlypis rivularis_Riverbank Warbler
-Myiothlypis signata_Pale-legged Warbler
+Myiothlypis basilica_Pugalpea-selvasäälik
+Myiothlypis bivittata_Laulu-selvasäälik
+Myiothlypis chrysogaster_Rohe-selvasäälik
+Myiothlypis cinereicollis_Hõbekurk-selvasäälik
+Myiothlypis conspicillata_Valjas-selvasäälik
+Myiothlypis coronata_Tulikiird-selvasäälik
+Myiothlypis flaveola_Viher-selvasäälik
+Myiothlypis fraseri_Ekuadori selvasäälik
+Myiothlypis fulvicauda_Oja-selvasäälik
+Myiothlypis leucoblephara_Uruguai selvasäälik
+Myiothlypis leucophrys_Lammi-selvasäälik
+Myiothlypis luteoviridis_Mägi-selvasäälik
+Myiothlypis nigrocristata_Mustkiird-selvasäälik
+Myiothlypis rivularis_Kalda-selvasäälik
+Myiothlypis signata_Händ-selvasäälik
 Myiotriccus ornatus_Ornate Flycatcher
-Myiozetetes cayanensis_Rusty-margined Flycatcher
-Myiozetetes granadensis_Gray-capped Flycatcher
-Myiozetetes luteiventris_Dusky-chested Flycatcher
-Myiozetetes similis_Social Flycatcher
-Myophonus caeruleus_Blue Whistling-Thrush
-Myophonus horsfieldii_Malabar Whistling-Thrush
-Myophonus insularis_Taiwan Whistling-Thrush
-Myophonus melanurus_Shiny Whistling-Thrush
+Myiozetetes cayanensis_Roostetiib-masktikat
+Myiozetetes granadensis_Hallpea-masktikat
+Myiozetetes luteiventris_Värb-masktikat
+Myiozetetes similis_Kime-masktikat
+Myophonus caeruleus_Suur-jõgisiirak
+Myophonus horsfieldii_India jõgisiirak
+Myophonus insularis_Taivani jõgisiirak
+Myophonus melanurus_Sinikulm-jõgisiirak
 Myornis senilis_Ash-colored Tapaculo
 Myrmeciza longipes_White-bellied Antbird
-Myrmecocichla aethiops_Northern Anteater-Chat
-Myrmecocichla arnotti_Arnot's Chat
-Myrmecocichla formicivora_Southern Anteater-Chat
-Myrmecocichla monticola_Mountain Wheatear
-Myrmecocichla nigra_Sooty Chat
+Myrmecocichla aethiops_Põhja-termiiditäks
+Myrmecocichla arnotti_Miombotäks
+Myrmecocichla formicivora_Lõuna-termiiditäks
+Myrmecocichla monticola_Rünkatäks
+Myrmecocichla nigra_Must-termiiditäks
 Myrmelastes humaythae_Humaita Antbird
 Myrmelastes hyperythrus_Plumbeous Antbird
 Myrmelastes leucostigma_Spot-winged Antbird
@@ -3845,144 +3845,144 @@ Myrmotherula sclateri_Sclater's Antwren
 Myrmotherula surinamensis_Guianan Streaked-Antwren
 Myrmotherula unicolor_Unicolored Antwren
 Myrmotherula urosticta_Band-tailed Antwren
-Myrtis fanny_Purple-collared Woodstar
+Myrtis fanny_Sinipõsk-tähtkoolibri
 Mystacornis crossleyi_Crossley's Vanga
 Myza sarasinorum_White-eared Myza
-Myzomela cardinalis_Cardinal Myzomela
+Myzomela cardinalis_Kardinal-meelind
 Myzomela erythrocephala_Red-headed Myzomela
 Myzomela obscura_Dusky Myzomela
 Myzomela rosenbergii_Red-collared Myzomela
 Myzomela rubratra_Micronesian Myzomela
 Myzomela sanguinolenta_Scarlet Myzomela
-Nannopsittaca panychlora_Tepui Parrotlet
-Nannopterum auritum_Double-crested Cormorant
-Nannopterum brasilianum_Neotropic Cormorant
+Nannopsittaca panychlora_Tepui-pisipapagoi
+Nannopterum auritum_Ameerika kormoran
+Nannopterum brasilianum_Süsikormoran
 Napothera danjoui_Short-tailed Scimitar-Babbler
 Napothera epilepidota_Eyebrowed Wren-Babbler
 Napothera malacoptila_Long-billed Wren-Babbler
-Nasica longirostris_Long-billed Woodcreeper
-Nectarinia famosa_Malachite Sunbird
-Nectarinia kilimensis_Bronze Sunbird
+Nasica longirostris_Mõõknokk-ronilind
+Nectarinia famosa_Malahhiit-nektarilind
+Nectarinia kilimensis_Pronks-nektarilind
 Nemosia pileata_Hooded Tanager
 Nengetus cinereus_Gray Monjita
-Neochmia phaeton_Crimson Finch
-Neochmia temporalis_Red-browed Firetail
+Neochmia phaeton_Karmiinamadiin
+Neochmia temporalis_Punakulm-amadiin
 Neoconocephalus bivocatus_False Robust Conehead
 Neoconocephalus ensiger_Sword-bearing Conehead
 Neoconocephalus retusus_Round-tipped Conehead
 Neoconocephalus robustus_Robust Conehead
 Neocossyphus finschi_Finsch's Flycatcher-Thrush
-Neocossyphus fraseri_Rufous Flycatcher-Thrush
-Neocossyphus poensis_White-tailed Ant-Thrush
-Neocossyphus rufus_Red-tailed Ant-Thrush
+Neocossyphus fraseri_Kongo sipelgarästas
+Neocossyphus poensis_Tõmmu-sipelgarästas
+Neocossyphus rufus_Punasaba-sipelgarästas
 Neoctantes niger_Black Bushbird
-Neomixis striatigula_Stripe-throated Jery
-Neomixis tenella_Common Jery
-Neomorphus geoffroyi_Rufous-vented Ground-Cuckoo
-Neomorphus rufipennis_Rufous-winged Ground-Cuckoo
+Neomixis striatigula_Viirkurk-kimitsi
+Neomixis tenella_Kimitsi
+Neomorphus geoffroyi_Punakõht-maakägu
+Neomorphus rufipennis_Purpur-maakägu
 Neonemobius cubensis_Cuban Ground Cricket
-Neopelma aurifrons_Wied's Tyrant-Manakin
-Neopelma chrysocephalum_Saffron-crested Tyrant-Manakin
-Neopelma chrysolophum_Serra do Mar Tyrant-Manakin
-Neopelma pallescens_Pale-bellied Tyrant-Manakin
-Neopelma sulphureiventer_Sulphur-bellied Tyrant-Manakin
-Neophema pulchella_Turquoise Parrot
+Neopelma aurifrons_Rohe-tantsulind
+Neopelma chrysocephalum_Safrankiird-tantsulind
+Neopelma chrysolophum_Võsa-tantsulind
+Neopelma pallescens_Valgekõht-tantsulind
+Neopelma sulphureiventer_Lammi-tantsulind
+Neophema pulchella_Türkiis-rohupapagoi
 Neopipo cinnamomea_Cinnamon Manakin-Tyrant
 Neothraupis fasciata_White-banded Tanager
 Nephelomyias lintoni_Orange-banded Flycatcher
 Nephelomyias pulcher_Handsome Flycatcher
-Nesillas lantzii_Subdesert Brush-Warbler
-Nesillas typica_Malagasy Brush-Warbler
-Nesoenas mayeri_Pink Pigeon
+Nesillas lantzii_Kõnnu-aretika
+Nesillas typica_Aretika
+Nesoenas mayeri_Roosatuvi
 Nesoptilotis flavicollis_Yellow-throated Honeyeater
 Nesoptilotis leucotis_White-eared Honeyeater
 Nesospingus speculiferus_Puerto Rican Tanager
-Nestor meridionalis_New Zealand Kaka
-Netta rufina_Red-crested Pochard
-Nettapus coromandelianus_Cotton Pygmy-Goose
-Newtonia amphichroa_Dark Newtonia
-Newtonia archboldi_Archbold's Newtonia
-Newtonia brunneicauda_Common Newtonia
+Nestor meridionalis_Kaaka
+Netta rufina_Punanokk-vart
+Nettapus coromandelianus_Kaelus-pisipart
+Newtonia amphichroa_Pruun-pisivanga
+Newtonia archboldi_Kõnnu-pisivanga
+Newtonia brunneicauda_Hall-pisivanga
 Nicator chloris_Western Nicator
 Nicator gularis_Eastern Nicator
 Nicator vireo_Yellow-throated Nicator
-Nigrita canicapillus_Gray-headed Nigrita
-Nilaus afer_Brubru
-Niltava grandis_Large Niltava
-Niltava macgrigoriae_Small Niltava
-Niltava sundara_Rufous-bellied Niltava
-Niltava vivida_Vivid Niltava
-Ninox boobook_Southern Boobook
-Ninox connivens_Barking Owl
-Ninox ios_Cinnabar Boobook
+Nigrita canicapillus_Suur-munkamadiin
+Nilaus afer_Väike-pagulind
+Niltava grandis_Suur-sininäpp
+Niltava macgrigoriae_Väike-sininäpp
+Niltava sundara_Helekiird-sininäpp
+Niltava vivida_Taivani sininäpp
+Ninox boobook_Väike-haugaskakk
+Ninox connivens_Koer-haugaskakk
+Ninox ios_Minahassa haugaskakk
 Ninox japonica_Northern Boobook
-Ninox novaeseelandiae_Morepork
-Ninox obscura_Hume's Boobook
-Ninox philippensis_Luzon Boobook
-Ninox scutulata_Brown Boobook
-Ninox strenua_Powerful Owl
-Ninox theomacha_Papuan Boobook
-Nisaetus cirrhatus_Changeable Hawk-Eagle
-Nisaetus nanus_Wallace's Hawk-Eagle
-Nisaetus nipalensis_Mountain Hawk-Eagle
+Ninox novaeseelandiae_Lõuna-haugaskakk
+Ninox obscura_Tõmmu-haugaskakk
+Ninox philippensis_Pisi-haugaskakk
+Ninox scutulata_Põhja-haugaskakk
+Ninox strenua_Suur-haugaskakk
+Ninox theomacha_Paapua haugaskakk
+Nisaetus cirrhatus_Välu-tuttkotkas
+Nisaetus nanus_Väike-tuttkotkas
+Nisaetus nipalensis_Mägi-tuttkotkas
 Noise_Noise
-Nonnula brunnea_Brown Nunlet
-Nonnula frontalis_Gray-cheeked Nunlet
-Nonnula rubecula_Rusty-breasted Nunlet
-Nonnula ruficapilla_Rufous-capped Nunlet
-Northiella haematogaster_Greater Bluebonnet
-Notharchus hyperrhynchus_White-necked Puffbird
-Notharchus macrorhynchos_Guianan Puffbird
-Notharchus ordii_Brown-banded Puffbird
-Notharchus pectoralis_Black-breasted Puffbird
-Notharchus swainsoni_Buff-bellied Puffbird
-Notharchus tectus_Pied Puffbird
-Nothocercus bonapartei_Highland Tinamou
-Nothocercus julius_Tawny-breasted Tinamou
-Nothocercus nigrocapillus_Hooded Tinamou
-Nothocrax urumutum_Nocturnal Curassow
-Nothoprocta cinerascens_Brushland Tinamou
-Nothoprocta ornata_Ornate Tinamou
-Nothoprocta pentlandii_Andean Tinamou
-Nothoprocta perdicaria_Chilean Tinamou
-Nothura boraquira_White-bellied Nothura
-Nothura darwinii_Darwin's Nothura
-Nothura maculosa_Spotted Nothura
-Notiomystis cincta_Stitchbird
-Notopholia corusca_Black-bellied Starling
-Nucifraga caryocatactes_Eurasian Nutcracker
-Nucifraga columbiana_Clark's Nutcracker
-Numenius americanus_Long-billed Curlew
+Nonnula brunnea_Pruun-puhvlind
+Nonnula frontalis_Hallpõsk-puhvlind
+Nonnula rubecula_Macurú-puhvlind
+Nonnula ruficapilla_Ruskepea-puhvlind
+Northiella haematogaster_Raudpapagoi
+Notharchus hyperrhynchus_Lumipea-puhvlind
+Notharchus macrorhynchos_Pugal-puhvlind
+Notharchus ordii_Põll-puhvlind
+Notharchus pectoralis_Võra-puhvlind
+Notharchus swainsoni_Leetkõht-puhvlind
+Notharchus tectus_Manisk-puhvlind
+Nothocercus bonapartei_Bambusetinamu
+Nothocercus julius_Välutinamu
+Nothocercus nigrocapillus_Karbustinamu
+Nothocrax urumutum_Ööhoko
+Nothoprocta cinerascens_Viir-mägitinamu
+Nothoprocta ornata_Põld-mägitinamu
+Nothoprocta pentlandii_Redu-mägitinamu
+Nothoprocta perdicaria_Tšiili mägitinamu
+Nothura boraquira_Kaatinga-triiptinamu
+Nothura darwinii_Nõlva-triiptinamu
+Nothura maculosa_Nurm-triiptinamu
+Notiomystis cincta_Hihi
+Notopholia corusca_Leeksilm-kuldnokk
+Nucifraga caryocatactes_Mänsak
+Nucifraga columbiana_Hallmänsak
+Numenius americanus_Preeriakoovitaja
 Numenius arquata_Suurkoovitaja
-Numenius madagascariensis_Far Eastern Curlew
-Numenius minutus_Little Curlew
+Numenius madagascariensis_Idakoovitaja
+Numenius minutus_Kääbuskoovitaja
 Numenius phaeopus_Väikekoovitaja
-Numenius tahitiensis_Bristle-thighed Curlew
-Numida meleagris_Helmeted Guineafowl
-Nyctanassa violacea_Yellow-crowned Night-Heron
-Nyctibius aethereus_Long-tailed Potoo
-Nyctibius bracteatus_Rufous Potoo
-Nyctibius grandis_Great Potoo
-Nyctibius griseus_Common Potoo
-Nyctibius jamaicensis_Northern Potoo
-Nyctibius leucopterus_White-winged Potoo
-Nycticorax nycticorax_Black-crowned Night-Heron
-Nyctidromus albicollis_Common Pauraque
-Nyctidromus anthonyi_Scrub Nightjar
-Nyctiphrynus mcleodii_Eared Poorwill
-Nyctiphrynus ocellatus_Ocellated Poorwill
-Nyctiphrynus rosenbergi_Choco Poorwill
-Nyctiphrynus yucatanicus_Yucatan Poorwill
-Nyctipolus nigrescens_Blackish Nightjar
-Nyctiprogne leucopyga_Band-tailed Nighthawk
-Nyctyornis amictus_Red-bearded Bee-eater
-Nyctyornis athertoni_Blue-bearded Bee-eater
-Nymphicus hollandicus_Cockatiel
-Nystalus chacuru_White-eared Puffbird
-Nystalus maculatus_Spot-backed Puffbird
+Numenius tahitiensis_Alaska koovitaja
+Numida meleagris_Pärlkana
+Nyctanassa violacea_Krabi-ööhaigur
+Nyctibius aethereus_Pikksaba-tüükasorr
+Nyctibius bracteatus_Ruske-tüükasorr
+Nyctibius grandis_Suur-tüükasorr
+Nyctibius griseus_Hall-tüükasorr
+Nyctibius jamaicensis_Põhja-tüükasorr
+Nyctibius leucopterus_Valgetiib-tüükasorr
+Nycticorax nycticorax_Ööhaigur
+Nyctidromus albicollis_Paurake-öösorr
+Nyctidromus anthonyi_Ekuadori öösorr
+Nyctiphrynus mcleodii_Võru-öösorr
+Nyctiphrynus ocellatus_Tõmmu-öösorr
+Nyctiphrynus rosenbergi_Kolumbia öösorr
+Nyctiphrynus yucatanicus_Yucatani öösorr
+Nyctipolus nigrescens_Kivi-öösorr
+Nyctiprogne leucopyga_Laiksaba-videvikusorr
+Nyctyornis amictus_Punahabe-mesilasenäpp
+Nyctyornis athertoni_Sinihabe-mesilasenäpp
+Nymphicus hollandicus_Nümfkakaduu
+Nystalus chacuru_Mustpõsk-puhvlind
+Nystalus maculatus_Kampo-puhvlind
 Nystalus obamai_Western Striolated-Puffbird
-Nystalus radiatus_Barred Puffbird
-Nystalus striolatus_Eastern Striolated-Puffbird
+Nystalus radiatus_Vööt-puhvlind
+Nystalus striolatus_Triip-puhvlind
 Ochetorhynchus andaecola_Rock Earthcreeper
 Ochetorhynchus melanurus_Crag Chilia
 Ochetorhynchus phoenicurus_Band-tailed Earthcreeper
@@ -3996,29 +3996,29 @@ Ochthoeca leucophrys_White-browed Chat-Tyrant
 Ochthoeca oenanthoides_d'Orbigny's Chat-Tyrant
 Ochthoeca pulchella_Golden-browed Chat-Tyrant
 Ochthoeca rufipectoralis_Rufous-breasted Chat-Tyrant
-Ochthornis littoralis_Drab Water Tyrant
-Ocreatus underwoodii_Booted Racket-tail
-Ocyceros birostris_Indian Gray Hornbill
-Ocyceros gingalensis_Sri Lanka Gray Hornbill
-Ocyceros griseus_Malabar Gray Hornbill
-Ocyphaps lophotes_Crested Pigeon
+Ochthornis littoralis_Jõgitikat
+Ocreatus underwoodii_Põhja-lippsabakoolibri
+Ocyceros birostris_Hõbe-sarvnokk
+Ocyceros gingalensis_Tseiloni sarvnokk
+Ocyceros griseus_Malabari sarvnokk
+Ocyphaps lophotes_Tutt-tuvi
 Odocoileus virginianus_White-tailed Deer
-Odontophorus atrifrons_Black-fronted Wood-Quail
-Odontophorus balliviani_Stripe-faced Wood-Quail
-Odontophorus capueira_Spot-winged Wood-Quail
-Odontophorus columbianus_Venezuelan Wood-Quail
-Odontophorus erythrops_Rufous-fronted Wood-Quail
-Odontophorus gujanensis_Marbled Wood-Quail
-Odontophorus guttatus_Spotted Wood-Quail
-Odontophorus hyperythrus_Chestnut Wood-Quail
-Odontophorus leucolaemus_Black-breasted Wood-Quail
-Odontophorus melanonotus_Dark-backed Wood-Quail
-Odontophorus melanotis_Black-eared Wood-Quail
-Odontophorus speciosus_Rufous-breasted Wood-Quail
-Odontophorus stellatus_Starred Wood-Quail
-Odontophorus strophium_Gorgeted Wood-Quail
-Odontorchilus branickii_Gray-mantled Wren
-Odontorchilus cinereus_Tooth-billed Wren
+Odontophorus atrifrons_Mustpõsk-selvavutt
+Odontophorus balliviani_Aimaraa selvavutt
+Odontophorus capueira_Hall-selvavutt
+Odontophorus columbianus_Venetsueela selvavutt
+Odontophorus erythrops_Manisk-selvavutt
+Odontophorus gujanensis_Pruun-selvavutt
+Odontophorus guttatus_Põhja-selvavutt
+Odontophorus hyperythrus_Prill-selvavutt
+Odontophorus leucolaemus_Mustrind-selvavutt
+Odontophorus melanonotus_Tume-selvavutt
+Odontophorus melanotis_Tanu-selvavutt
+Odontophorus speciosus_Peruu selvavutt
+Odontophorus stellatus_Paruk-selvavutt
+Odontophorus strophium_Tamme-selvavutt
+Odontorchilus branickii_Andi võrakäblik
+Odontorchilus cinereus_Selva-võrakäblik
 Oecanthus celerinictus_Fast-calling Tree Cricket
 Oecanthus exclamationis_Davis's Tree Cricket
 Oecanthus fultoni_Snowy Tree Cricket
@@ -4026,37 +4026,37 @@ Oecanthus nigricornis_Blackhorned Tree Cricket
 Oecanthus niveus_Narrow-winged Tree Cricket
 Oecanthus pini_Pine Tree Cricket
 Oecanthus quadripunctatus_Four-spotted Tree Cricket
-Oena capensis_Namaqua Dove
-Oenanthe deserti_Desert Wheatear
-Oenanthe familiaris_Familiar Chat
-Oenanthe fusca_Brown Rock Chat
-Oenanthe hispanica_Western Black-eared Wheatear
-Oenanthe isabellina_Isabelline Wheatear
-Oenanthe leucopyga_White-crowned Wheatear
-Oenanthe leucura_Black Wheatear
+Oena capensis_Sabatuvi
+Oenanthe deserti_Kõrbe-kivitäks
+Oenanthe familiaris_Punasaba-kaljutäks
+Oenanthe fusca_India kaljutäks
+Oenanthe hispanica_Vahemere kivitäks
+Oenanthe isabellina_Liiv-kivitäks
+Oenanthe leucopyga_Tanu-kivitäks
+Oenanthe leucura_Must-kivitäks
 Oenanthe melanoleuca_Eastern Black-eared Wheatear
-Oenanthe melanura_Blackstart
+Oenanthe melanura_Mustsaba-kaljutäks
 Oenanthe oenanthe_Kivitäks
-Oenanthe pileata_Capped Wheatear
-Oenanthe pleschanka_Pied Wheatear
-Oenanthe scotocerca_Brown-tailed Chat
-Ognorhynchus icterotis_Yellow-eared Parrot
+Oenanthe pileata_Vöö-kivitäks
+Oenanthe pleschanka_Nunn-kivitäks
+Oenanthe scotocerca_Vadi-kaljutäks
+Ognorhynchus icterotis_Vahapalmi-papagoi
 Oncostoma cinereigulare_Northern Bentbill
 Oncostoma olivaceum_Southern Bentbill
 Oneillornis lunulatus_Lunulated Antbird
 Oneillornis salvini_White-throated Antbird
-Onychognathus morio_Red-winged Starling
-Onychognathus nabouroup_Pale-winged Starling
-Onychognathus tenuirostris_Slender-billed Starling
-Onychognathus tristramii_Tristram's Starling
-Onychognathus walleri_Waller's Starling
-Onychoprion aleuticus_Aleutian Tern
-Onychoprion anaethetus_Bridled Tern
-Onychoprion fuscatus_Sooty Tern
-Onychoprion lunatus_Gray-backed Tern
+Onychognathus morio_Kalju-kuldnokk
+Onychognathus nabouroup_Kõrbe-kuldnokk
+Onychognathus tenuirostris_Mägi-kuldnokk
+Onychognathus tristramii_Jordani kuldnokk
+Onychognathus walleri_Nõlva-kuldnokk
+Onychoprion aleuticus_Viletiir
+Onychoprion anaethetus_Troopikatiir
+Onychoprion fuscatus_Nõgitiir
+Onychoprion lunatus_Valjastiir
 Onychorhynchus coronatus_Royal Flycatcher
-Opisthocomus hoazin_Hoatzin
-Oporornis agilis_Connecticut Warbler
+Opisthocomus hoazin_Hoatsiin
+Oporornis agilis_Ämblikusäälik
 Orchelimum agile_Agile Meadow Katydid
 Orchelimum concinnum_Stripe-faced Meadow Katydid
 Orchelimum pulchellum_Handsome Meadow Katydid
@@ -4065,102 +4065,102 @@ Oreocharis arfaki_Tit Berrypecker
 Oreoica gutturalis_Crested Bellbird
 Oreolais pulcher_Black-collared Apalis
 Oreolais ruwenzorii_Rwenzori Apalis
-Oreomystis bairdi_Akikiki
-Oreophasis derbianus_Horned Guan
-Oreopholus ruficollis_Tawny-throated Dotterel
-Oreopsar bolivianus_Bolivian Blackbird
-Oreortyx pictus_Mountain Quail
-Oreoscoptes montanus_Sage Thrasher
+Oreomystis bairdi_Akikiki-nestevint
+Oreophasis derbianus_Sarvhoko
+Oreopholus ruficollis_Andi tüll
+Oreopsar bolivianus_Kaljuturpial
+Oreortyx pictus_Mägi-tuttvutt
+Oreoscoptes montanus_Puju-pilalind
 Oreoscopus gutturalis_Fernwren
 Oreothlypis gutturalis_Flame-throated Warbler
-Oreothlypis superciliosa_Crescent-chested Warbler
-Oreothraupis arremonops_Tanager Finch
-Oreotrochilus estella_Andean Hillstar
+Oreothlypis superciliosa_Sirpsäälik
+Oreothraupis arremonops_Ruske-samblasidrik
+Oreotrochilus estella_Kaljukoolibri
 Oressochen jubatus_Orinoco Goose
 Oressochen melanopterus_Andean Goose
-Oriolus auratus_African Golden Oriole
-Oriolus brachyrynchus_Western Black-headed Oriole
-Oriolus chinensis_Black-naped Oriole
-Oriolus chlorocephalus_Green-headed Oriole
-Oriolus cruentus_Black-and-crimson Oriole
-Oriolus flavocinctus_Green Oriole
-Oriolus kundoo_Indian Golden Oriole
-Oriolus larvatus_African Black-headed Oriole
-Oriolus monacha_Ethiopian Black-headed Oriole
-Oriolus nigripennis_Black-winged Oriole
+Oriolus auratus_Kuldpeoleo
+Oriolus brachyrynchus_Metspeoleo
+Oriolus chinensis_Maskpeoleo
+Oriolus chlorocephalus_Rohepea-peoleo
+Oriolus cruentus_Punalaik-peoleo
+Oriolus flavocinctus_Ojapeoleo
+Oriolus kundoo_Mangopeoleo
+Oriolus larvatus_Akaatsiapeoleo
+Oriolus monacha_Etioopia peoleo
+Oriolus nigripennis_Musttiib-peoleo
 Oriolus oriolus_Peoleo
-Oriolus percivali_Black-tailed Oriole
-Oriolus phaeochromus_Halmahera Oriole
-Oriolus sagittatus_Olive-backed Oriole
-Oriolus steerii_Philippine Oriole
-Oriolus szalayi_Brown Oriole
-Oriolus tenuirostris_Slender-billed Oriole
-Oriolus traillii_Maroon Oriole
-Oriolus xanthonotus_Dark-throated Oriole
-Oriolus xanthornus_Black-hooded Oriole
-Oriturus superciliosus_Striped Sparrow
+Oriolus percivali_Mägipeoleo
+Oriolus phaeochromus_Halmahera peoleo
+Oriolus sagittatus_Tähnikpeoleo
+Oriolus steerii_Filipiini peoleo
+Oriolus szalayi_Paapua peoleo
+Oriolus tenuirostris_Salenokk-peoleo
+Oriolus traillii_Punapeoleo
+Oriolus xanthonotus_Väikepeoleo
+Oriolus xanthornus_Karbuspeoleo
+Oriturus superciliosus_Helekulm-sidrik
 Ornithion brunneicapillus_Brown-capped Tyrannulet
 Ornithion inerme_White-lored Tyrannulet
 Ornithion semiflavum_Yellow-bellied Tyrannulet
 Orocharis saltator_Jumping Bush Cricket
-Orochelidon flavipes_Pale-footed Swallow
-Orochelidon murina_Brown-bellied Swallow
-Ortalis araucuan_East Brazilian Chachalaca
-Ortalis canicollis_Chaco Chachalaca
-Ortalis cinereiceps_Gray-headed Chachalaca
-Ortalis columbiana_Colombian Chachalaca
-Ortalis erythroptera_Rufous-headed Chachalaca
-Ortalis garrula_Chestnut-winged Chachalaca
-Ortalis guttata_Speckled Chachalaca
-Ortalis leucogastra_White-bellied Chachalaca
-Ortalis motmot_Variable Chachalaca
-Ortalis poliocephala_West Mexican Chachalaca
-Ortalis ruficauda_Rufous-vented Chachalaca
+Orochelidon flavipes_Punakurk-mägipääsuke
+Orochelidon murina_Pruunkõht-mägipääsuke
+Ortalis araucuan_Bahia tšatšalaka
+Ortalis canicollis_Lõuna-tšatšalaka
+Ortalis cinereiceps_Panama tšatšalaka
+Ortalis columbiana_Kolumbia tšatšalaka
+Ortalis erythroptera_Ekuadori tšatšalaka
+Ortalis garrula_Punatiib-tšatšalaka
+Ortalis guttata_Kiripugu-tšatšalaka
+Ortalis leucogastra_Valgekõht-tšatšalaka
+Ortalis motmot_Väike-tšatšalaka
+Ortalis poliocephala_Suur-tšatšalaka
+Ortalis ruficauda_Venetsueela tšatšalaka
 Ortalis squamata_Scaled Chachalaca
-Ortalis vetula_Plain Chachalaca
-Ortalis wagleri_Rufous-bellied Chachalaca
+Ortalis vetula_Võsa-tšatšalaka
+Ortalis wagleri_Punakõht-tšatšalaka
 Orthogonys chloricterus_Olive-green Tanager
-Orthonyx novaeguineae_Papuan Logrunner
-Orthonyx spaldingii_Chowchilla
-Orthonyx temminckii_Australian Logrunner
-Orthopsittaca manilatus_Red-bellied Macaw
-Orthotomus atrogularis_Dark-necked Tailorbird
-Orthotomus chaktomuk_Cambodian Tailorbird
-Orthotomus chloronotus_Green-backed Tailorbird
-Orthotomus derbianus_Gray-backed Tailorbird
-Orthotomus frontalis_Rufous-fronted Tailorbird
-Orthotomus nigriceps_White-browed Tailorbird
-Orthotomus ruficeps_Ashy Tailorbird
-Orthotomus sepium_Olive-backed Tailorbird
-Orthotomus sericeus_Rufous-tailed Tailorbird
-Orthotomus sutorius_Common Tailorbird
-Ortygornis pondicerianus_Gray Francolin
-Ortygornis sephaena_Crested Francolin
-Ortygospiza atricollis_Quailfinch
-Otidiphaps nobilis_Pheasant Pigeon
-Otocichla mupinensis_Chinese Thrush
-Otus bakkamoena_Indian Scops-Owl
+Orthonyx novaeguineae_Uusginea kõdulind
+Orthonyx spaldingii_Suur-kõdulind
+Orthonyx temminckii_Kirju-kõdulind
+Orthopsittaca manilatus_Palmi-aara
+Orthotomus atrogularis_Mustkurk-rätseplind
+Orthotomus chaktomuk_Khmeeri rätseplind
+Orthotomus chloronotus_Viherselg-rätseplind
+Orthotomus derbianus_Tuhkkõht-rätseplind
+Orthotomus frontalis_Hallkiird-rätseplind
+Orthotomus nigriceps_Valgekulm-rätseplind
+Orthotomus ruficeps_Hall-rätseplind
+Orthotomus sepium_Jaava rätseplind
+Orthotomus sericeus_Roostesaba-rätseplind
+Orthotomus sutorius_Aed-rätseplind
+Ortygornis pondicerianus_Hallfrankoliin
+Ortygornis sephaena_Tanufrankoliin
+Ortygospiza atricollis_Niidu-vuttamadiin
+Otidiphaps nobilis_Faasantuvi
+Otocichla mupinensis_Hiina laulurästas
+Otus bakkamoena_Kaeluspäll
 Otus cyprius_Cyprus Scops-Owl
-Otus elegans_Ryukyu Scops-Owl
-Otus lempiji_Sunda Scops-Owl
-Otus lettia_Collared Scops-Owl
-Otus madagascariensis_Torotoroka Scops-Owl
-Otus magicus_Moluccan Scops-Owl
-Otus manadensis_Sulawesi Scops-Owl
-Otus mantananensis_Mantanani Scops-Owl
-Otus pamelae_Arabian Scops-Owl
-Otus rufescens_Reddish Scops-Owl
-Otus rutilus_Madagascar Scops-Owl
-Otus sagittatus_White-fronted Scops-Owl
-Otus scops_Eurasian Scops-Owl
-Otus semitorques_Japanese Scops-Owl
-Otus senegalensis_African Scops-Owl
-Otus spilocephalus_Mountain Scops-Owl
-Otus sunia_Oriental Scops-Owl
-Oxylabes madagascariensis_White-throated Oxylabes
+Otus elegans_Ryukyu päll
+Otus lempiji_Kagu-kaeluspäll
+Otus lettia_Ida-kaeluspäll
+Otus madagascariensis_Läänemadagaskari päll
+Otus magicus_Maluku päll
+Otus manadensis_Sulawesi päll
+Otus mantananensis_Kookosepäll
+Otus pamelae_Jeemeni salupäll
+Otus rufescens_Malai päll
+Otus rutilus_Madagaskari päll
+Otus sagittatus_Laukpäll
+Otus scops_Salupäll
+Otus semitorques_Jaapani päll
+Otus senegalensis_Aafrika salupäll
+Otus spilocephalus_Nõlvapäll
+Otus sunia_Ida-salupäll
+Oxylabes madagascariensis_Duett-farifutša
 Oxyruncus cristatus_Sharpbill
-Oxyura ferruginea_Andean Duck
-Oxyura jamaicensis_Ruddy Duck
+Oxyura ferruginea_Andi händpart
+Oxyura jamaicensis_Valgepõsk-händpart
 Pachycare flavogriseum_Goldenface
 Pachycephala chlorura_Vanuatu Whistler
 Pachycephala cinerea_Mangrove Whistler
@@ -4185,7 +4185,7 @@ Pachycephala simplex_Gray Whistler
 Pachycephala soror_Sclater's Whistler
 Pachycephala sulfuriventer_Sulphur-bellied Whistler
 Pachycephala vitiensis_Fiji Whistler
-Pachyphantes superciliosus_Compact Weaver
+Pachyphantes superciliosus_Rohtla-kangurlind
 Pachyramphus aglaiae_Rose-throated Becard
 Pachyramphus albogriseus_Black-and-white Becard
 Pachyramphus castaneus_Chestnut-crowned Becard
@@ -4206,87 +4206,87 @@ Pachysylvia decurtata_Lesser Greenlet
 Pachysylvia hypoxantha_Dusky-capped Greenlet
 Pachysylvia muscicapina_Buff-cheeked Greenlet
 Pachysylvia semibrunnea_Rufous-naped Greenlet
-Padda oryzivora_Java Sparrow
-Palmeria dolei_Akohekohe
-Pampa curvipennis_Wedge-tailed Sabrewing
+Padda oryzivora_Riisiamadiin
+Palmeria dolei_Tutt-nestevint
+Pampa curvipennis_Mehhiko laulukoolibri
 Pandion haliaetus_Kalakotkas
-Panterpe insignis_Fiery-throated Hummingbird
-Panurus biarmicus_Vainurästas
-Panyptila sanctihieronymi_Great Swallow-tailed Swift
-Parabuteo leucorrhous_White-rumped Hawk
-Parabuteo unicinctus_Harris's Hawk
-Paraclaravis mondetoura_Maroon-chested Ground Dove
-Paradisaea minor_Lesser Bird-of-Paradise
-Paradisaea rubra_Red Bird-of-Paradise
-Paradoxornis flavirostris_Black-breasted Parrotbill
-Paradoxornis guttaticollis_Spot-breasted Parrotbill
-Pardalotus punctatus_Spotted Pardalote
-Pardalotus rubricatus_Red-browed Pardalote
-Pardalotus striatus_Striated Pardalote
-Pardirallus maculatus_Spotted Rail
-Pardirallus nigricans_Blackish Rail
-Pardirallus sanguinolentus_Plumbeous Rail
+Panterpe insignis_Leekkurk-koolibri
+Panurus biarmicus_Roohabekas
+Panyptila sanctihieronymi_Suur-pääsupiiritaja
+Parabuteo leucorrhous_Valgepära-viu
+Parabuteo unicinctus_Rüütelviu
+Paraclaravis mondetoura_Mägi-bambusetuvi
+Paradisaea minor_Printsess-paradiisilind
+Paradisaea rubra_Punasaba-paradiisilind
+Paradoxornis flavirostris_Brahmaputra koonusnokk
+Paradoxornis guttaticollis_Mustpõsk-koonusnokk
+Pardalotus punctatus_Täpik-teemantlind
+Pardalotus rubricatus_Kõnnu-teemantlind
+Pardalotus striatus_Triip-teemantlind
+Pardirallus maculatus_Kirjuhuik
+Pardirallus nigricans_Soo-kilthuik
+Pardirallus sanguinolentus_Roo-kilthuik
 Parkerthraustes humeralis_Yellow-shouldered Grosbeak
-Parkesia motacilla_Louisiana Waterthrush
-Parkesia noveboracensis_Northern Waterthrush
+Parkesia motacilla_Jõgisäälik
+Parkesia noveboracensis_Lodusäälik
 Paroaria capitata_Yellow-billed Cardinal
 Paroaria coronata_Red-crested Cardinal
 Paroaria dominicana_Red-cowled Cardinal
 Paroaria gularis_Red-capped Cardinal
-Paroreomyza montana_Maui Alauahio
-Parus cinereus_Cinereous Tit
+Paroreomyza montana_Maui alauahio-nestevint
+Parus cinereus_Lõuna-rasvatihane
 Parus major_Rasvatihane
-Parus minor_Japanese Tit
-Parus monticolus_Green-backed Tit
-Parvipsitta porphyrocephala_Purple-crowned Lorikeet
-Parvipsitta pusilla_Little Lorikeet
-Passer ammodendri_Saxaul Sparrow
-Passer cinnamomeus_Russet Sparrow
-Passer diffusus_Southern Gray-headed Sparrow
+Parus minor_Ida-rasvatihane
+Parus monticolus_Mägi-rasvatihane
+Parvipsitta porphyrocephala_Lasuur-nestepapagoi
+Parvipsitta pusilla_Mask-nestepapagoi
+Passer ammodendri_Saksauulivarblane
+Passer cinnamomeus_Punavarblane
+Passer diffusus_Hallpea-varblane
 Passer domesticus_Koduvarblane
-Passer flaveolus_Plain-backed Sparrow
-Passer griseus_Northern Gray-headed Sparrow
-Passer hispaniolensis_Spanish Sparrow
-Passer italiae_Italian Sparrow
-Passer melanurus_Cape Sparrow
-Passer moabiticus_Dead Sea Sparrow
+Passer flaveolus_Punaselg-varblane
+Passer griseus_Hallvarblane
+Passer hispaniolensis_Pajuvarblane
+Passer italiae_Itaalia varblane
+Passer melanurus_Mustpea-varblane
+Passer moabiticus_Tamariskivarblane
 Passer montanus_Põldvarblane
-Passer pyrrhonotus_Sind Sparrow
-Passer rufocinctus_Kenya Rufous Sparrow
-Passer simplex_Desert Sparrow
-Passer swainsonii_Swainson's Sparrow
-Passerculus sandwichensis_Savannah Sparrow
-Passerella iliaca_Fox Sparrow
-Passerina amoena_Lazuli Bunting
-Passerina caerulea_Blue Grosbeak
-Passerina ciris_Painted Bunting
-Passerina cyanea_Indigo Bunting
+Passer pyrrhonotus_Induse varblane
+Passer rufocinctus_Põhja-savannivarblane
+Passer simplex_Kõrbevarblane
+Passer swainsonii_Etioopia varblane
+Passerculus sandwichensis_Väljasidrik
+Passerella iliaca_Rebassidrik
+Passerina amoena_Vööt-indigolind
+Passerina caerulea_Suur-indigolind
+Passerina ciris_Viker-indigolind
+Passerina cyanea_Indigolind
 Passerina leclancherii_Orange-breasted Bunting
 Passerina rositae_Rose-bellied Bunting
 Passerina versicolor_Varied Bunting
-Pastor roseus_Rosy Starling
-Patagioenas araucana_Chilean Pigeon
-Patagioenas cayennensis_Pale-vented Pigeon
-Patagioenas corensis_Bare-eyed Pigeon
-Patagioenas fasciata_Band-tailed Pigeon
-Patagioenas flavirostris_Red-billed Pigeon
-Patagioenas goodsoni_Dusky Pigeon
-Patagioenas leucocephala_White-crowned Pigeon
-Patagioenas maculosa_Spot-winged Pigeon
-Patagioenas nigrirostris_Short-billed Pigeon
-Patagioenas picazuro_Picazuro Pigeon
-Patagioenas plumbea_Plumbeous Pigeon
-Patagioenas speciosa_Scaled Pigeon
-Patagioenas squamosa_Scaly-naped Pigeon
-Patagioenas subvinacea_Ruddy Pigeon
-Patagona gigas_Giant Hummingbird
-Pauxi pauxi_Helmeted Curassow
-Pavo cristatus_Indian Peafowl
-Pelargopsis amauroptera_Brown-winged Kingfisher
-Pelargopsis capensis_Stork-billed Kingfisher
-Pelecanus conspicillatus_Australian Pelican
-Pelecanus erythrorhynchos_American White Pelican
-Pelecanus occidentalis_Brown Pelican
+Pastor roseus_Roosa-kuldnokk
+Patagioenas araucana_Araukaariatuvi
+Patagioenas cayennensis_Purpurtuvi
+Patagioenas corensis_Vihmatuvi
+Patagioenas fasciata_Tõrutuvi
+Patagioenas flavirostris_Mehhiko tuvi
+Patagioenas goodsoni_Kolumbia tuvi
+Patagioenas leucocephala_Tanutuvi
+Patagioenas maculosa_Päevalilletuvi
+Patagioenas nigrirostris_Lühinokk-tuvi
+Patagioenas picazuro_Brasiilia tuvi
+Patagioenas plumbea_Suur-selvatuvi
+Patagioenas speciosa_Tähniktuvi
+Patagioenas squamosa_Kariibi tuvi
+Patagioenas subvinacea_Väike-selvatuvi
+Patagona gigas_Suurkoolibri
+Pauxi pauxi_Kiiverhoko
+Pavo cristatus_Sini-paabulind
+Pelargopsis amauroptera_Rand-safiirlind
+Pelargopsis capensis_Jõgi-safiirlind
+Pelecanus conspicillatus_Austraalia pelikan
+Pelecanus erythrorhynchos_Sarvnokk-pelikan
+Pelecanus occidentalis_Pruunpelikan
 Pellorneum albiventre_Spot-throated Babbler
 Pellorneum bicolor_Ferruginous Babbler
 Pellorneum capistratum_Black-capped Babbler
@@ -4298,75 +4298,75 @@ Pellorneum pyrrogenys_Temminck's Babbler
 Pellorneum rostratum_White-chested Babbler
 Pellorneum ruficeps_Puff-throated Babbler
 Pellorneum tickelli_Buff-breasted Babbler
-Peltops montanus_Mountain Peltops
-Penelope albipennis_White-winged Guan
-Penelope argyrotis_Band-tailed Guan
-Penelope barbata_Bearded Guan
-Penelope dabbenei_Red-faced Guan
-Penelope jacquacu_Spix's Guan
-Penelope marail_Marail Guan
-Penelope montagnii_Andean Guan
-Penelope obscura_Dusky-legged Guan
-Penelope perspicax_Cauca Guan
-Penelope purpurascens_Crested Guan
-Penelope superciliaris_Rusty-margined Guan
-Penelopides affinis_Mindanao Hornbill
-Penelopina nigra_Highland Guan
-Peneothello cyanus_Blue-gray Robin
-Peneothello sigillata_White-winged Robin
+Peltops montanus_Mägi-puduleigar
+Penelope albipennis_Valgetiib-lotthoko
+Penelope argyrotis_Laidsaba-lotthoko
+Penelope barbata_Väike-lotthoko
+Penelope dabbenei_Punapale-lotthoko
+Penelope jacquacu_Häälis-lotthoko
+Penelope marail_Läik-lotthoko
+Penelope montagnii_Andi lotthoko
+Penelope obscura_Tõmmu-lotthoko
+Penelope perspicax_Cauca lotthoko
+Penelope purpurascens_Suur-lotthoko
+Penelope superciliaris_Brasiilia lotthoko
+Penelopides affinis_Mindanao sarvlind
+Penelopina nigra_Lokut-nõlvahoko
+Peneothello cyanus_Virpmiro
+Peneothello sigillata_Valgetiib-miro
 Percnostola arenarum_Allpahuayo Antbird
 Percnostola rufifrons_Black-headed Antbird
-Perdicula argoondah_Rock Bush-Quail
-Perdicula asiatica_Jungle Bush-Quail
-Perdicula erythrorhyncha_Painted Bush-Quail
-Perdix perdix_Põldpüü
-Pericrocotus cantonensis_Brown-rumped Minivet
-Pericrocotus cinnamomeus_Small Minivet
-Pericrocotus divaricatus_Ashy Minivet
-Pericrocotus erythropygius_White-bellied Minivet
-Pericrocotus ethologus_Long-tailed Minivet
-Pericrocotus flammeus_Orange Minivet
-Pericrocotus solaris_Gray-chinned Minivet
-Pericrocotus speciosus_Scarlet Minivet
-Pericrocotus tegimae_Ryukyu Minivet
+Perdicula argoondah_Kõnnuvutt
+Perdicula asiatica_Džunglivutt
+Perdicula erythrorhyncha_Valgekurk-vutt
+Perdix perdix_Nurmkana
+Pericrocotus cantonensis_Valgepea-hundnaagas
+Pericrocotus cinnamomeus_Väike-hundnaagas
+Pericrocotus divaricatus_Põhja-hundnaagas
+Pericrocotus erythropygius_Valgetiib-hundnaagas
+Pericrocotus ethologus_Mägi-hundnaagas
+Pericrocotus flammeus_Loit-hundnaagas
+Pericrocotus solaris_Hallpõsk-hundnaagas
+Pericrocotus speciosus_Leek-hundnaagas
+Pericrocotus tegimae_Ryukyu hundnaagas
 Periparus ater_Musttihane
-Periparus elegans_Elegant Tit
-Periparus rubidiventris_Rufous-vented Tit
-Periparus rufonuchalis_Rufous-naped Tit
-Periparus venustulus_Yellow-bellied Tit
+Periparus elegans_Filipiini koldtihane
+Periparus rubidiventris_Rododendronitihane
+Periparus rufonuchalis_Artšatihane
+Periparus venustulus_Hiina koldtihane
 Periporphyrus erythromelas_Red-and-black Grosbeak
-Perisoreus canadensis_Canada Jay
-Perisoreus infaustus_Siberian Jay
-Perissocephalus tricolor_Capuchinbird
+Perisoreus canadensis_Ameerika laanenäär
+Perisoreus infaustus_Laanenäär
+Perissocephalus tricolor_Kapuutskotinga
 Pernis apivorus_Herilaseviu
-Pernis ptilorhynchus_Oriental Honey-buzzard
-Petrochelidon ariel_Fairy Martin
-Petrochelidon fluvicola_Streak-throated Swallow
-Petrochelidon fulva_Cave Swallow
-Petrochelidon nigricans_Tree Martin
-Petrochelidon pyrrhonota_Cliff Swallow
-Petrochelidon spilodera_South African Swallow
-Petroica australis_South Island Robin
-Petroica boodang_Scarlet Robin
-Petroica goodenovii_Red-capped Robin
+Pernis ptilorhynchus_Tutt-herilaseviu
+Petrochelidon ariel_Punapea-kaljupääsuke
+Petrochelidon fluvicola_India kaljupääsuke
+Petrochelidon fulva_Koopapääsuke
+Petrochelidon nigricans_Eukalüptipääsuke
+Petrochelidon pyrrhonota_Ameerika kaljupääsuke
+Petrochelidon spilodera_Rohtla-kaljupääsuke
+Petroica australis_Suurmiro
+Petroica boodang_Eukalüptimiro
+Petroica goodenovii_Punalaup-miro
 Petroica longipes_North Island Robin
-Petroica macrocephala_Tomtit
-Petroica phoenicea_Flame Robin
+Petroica macrocephala_Mustmiro
+Petroica phoenicea_Leekmiro
 Petroica pusilla_Pacific Robin
-Petroica rodinogaster_Pink Robin
-Petroica rosea_Rose Robin
-Petronia petronia_Rock Sparrow
-Peucaea aestivalis_Bachman's Sparrow
-Peucaea botterii_Botteri's Sparrow
-Peucaea carpalis_Rufous-winged Sparrow
-Peucaea cassinii_Cassin's Sparrow
-Peucaea humeralis_Black-chested Sparrow
-Peucaea mystacalis_Bridled Sparrow
-Peucaea ruficauda_Stripe-headed Sparrow
-Peucaea sumichrasti_Cinnamon-tailed Sparrow
-Peucedramus taeniatus_Olive Warbler
-Pezopetes capitalis_Large-footed Finch
-Pezoporus wallicus_Ground Parrot
+Petroica rodinogaster_Roosamiro
+Petroica rosea_Rubiinmiro
+Petronia petronia_Kaljuvarblane
+Peucaea aestivalis_Põlendikusidrik
+Peucaea botterii_Kingusidrik
+Peucaea carpalis_Sonora sidrik
+Peucaea cassinii_Hallsidrik
+Peucaea humeralis_Mustpugu-sidrik
+Peucaea mystacalis_Mustkurk-sidrik
+Peucaea ruficauda_Ruskesaba-sidrik
+Peucaea sumichrasti_Tehuantepeci sidrik
+Peucedramus taeniatus_Pedakalind
+Pezopetes capitalis_Bambuse-maasidrik
+Pezoporus wallicus_Maapapagoi
 Phacellodomus dorsalis_Chestnut-backed Thornbird
 Phacellodomus erythrophthalmus_Orange-eyed Thornbird
 Phacellodomus ferrugineigula_Orange-breasted Thornbird
@@ -4376,114 +4376,114 @@ Phacellodomus rufifrons_Rufous-fronted Thornbird
 Phacellodomus sibilatrix_Little Thornbird
 Phacellodomus striaticeps_Streak-fronted Thornbird
 Phacellodomus striaticollis_Freckle-breasted Thornbird
-Phaenicophaeus sumatranus_Chestnut-bellied Malkoha
-Phaenicophaeus tristis_Green-billed Malkoha
-Phaenicophaeus viridirostris_Blue-faced Malkoha
+Phaenicophaeus sumatranus_Pruunkõht-malkohakägu
+Phaenicophaeus tristis_Händ-malkohakägu
+Phaenicophaeus viridirostris_Prill-malkohakägu
 Phaenicophilus palmarum_Black-crowned Palm-Tanager
 Phaenostictus mcleannani_Ocellated Antbird
-Phaeochroa cuvierii_Scaly-breasted Hummingbird
+Phaeochroa cuvierii_Soomuskoolibri
 Phaeomyias murina_Mouse-colored Tyrannulet
-Phaethon aethereus_Red-billed Tropicbird
-Phaethon lepturus_White-tailed Tropicbird
-Phaethon rubricauda_Red-tailed Tropicbird
-Phaethornis atrimentalis_Black-throated Hermit
-Phaethornis bourcieri_Straight-billed Hermit
-Phaethornis eurynome_Scale-throated Hermit
-Phaethornis griseogularis_Gray-chinned Hermit
-Phaethornis guy_Green Hermit
-Phaethornis hispidus_White-bearded Hermit
-Phaethornis longirostris_Long-billed Hermit
-Phaethornis longuemareus_Little Hermit
-Phaethornis malaris_Great-billed Hermit
-Phaethornis nattereri_Cinnamon-throated Hermit
-Phaethornis pretrei_Planalto Hermit
-Phaethornis ruber_Reddish Hermit
-Phaethornis rupurumii_Streak-throated Hermit
-Phaethornis squalidus_Dusky-throated Hermit
-Phaethornis striigularis_Stripe-throated Hermit
-Phaethornis superciliosus_Long-tailed Hermit
-Phaethornis syrmatophorus_Tawny-bellied Hermit
-Phaethornis yaruqui_White-whiskered Hermit
-Phaetusa simplex_Large-billed Tern
-Phainopepla nitens_Phainopepla
+Phaethon aethereus_Viir-troopikalind
+Phaethon lepturus_Väike-troopikalind
+Phaethon rubricauda_Punasaba-troopikalind
+Phaethornis atrimentalis_Tumekurk-selvakoolibri
+Phaethornis bourcieri_Amasoonia selvakoolibri
+Phaethornis eurynome_Tähnikkurk-selvakoolibri
+Phaethornis griseogularis_Hallsaba-selvakoolibri
+Phaethornis guy_Rohe-selvakoolibri
+Phaethornis hispidus_Tuhkrind-selvakoolibri
+Phaethornis longirostris_Keskameerika selvakoolibri
+Phaethornis longuemareus_Guajaana selvakoolibri
+Phaethornis malaris_Suur-selvakoolibri
+Phaethornis nattereri_Kaneel-selvakoolibri
+Phaethornis pretrei_Kampo-selvakoolibri
+Phaethornis ruber_Ruuge-selvakoolibri
+Phaethornis rupurumii_Valgerind-selvakoolibri
+Phaethornis squalidus_Tine-selvakoolibri
+Phaethornis striigularis_Tuhkkurk-selvakoolibri
+Phaethornis superciliosus_Pruun-selvakoolibri
+Phaethornis syrmatophorus_Andi selvakoolibri
+Phaethornis yaruqui_Läik-selvakoolibri
+Phaetusa simplex_Suurnokk-tiir
+Phainopepla nitens_Must-siidinäpp
 Phalacrocorax carbo_Kormoran
-Phalaenoptilus nuttallii_Common Poorwill
-Phalaropus fulicarius_Red Phalarope
-Phalaropus lobatus_Red-necked Phalarope
-Phalaropus tricolor_Wilson's Phalarope
-Phapitreron amethystinus_Amethyst Brown-Dove
-Phapitreron leucotis_White-eared Brown-Dove
-Phaps chalcoptera_Common Bronzewing
-Phaps elegans_Brush Bronzewing
-Pharomachrus antisianus_Crested Quetzal
-Pharomachrus auriceps_Golden-headed Quetzal
-Pharomachrus fulgidus_White-tipped Quetzal
-Pharomachrus mocinno_Resplendent Quetzal
-Pharomachrus pavoninus_Pavonine Quetzal
-Phasianus colchicus_Ring-necked Pheasant
-Phedina borbonica_Mascarene Martin
-Phegornis mitchellii_Diademed Sandpiper-Plover
-Phelpsia inornata_White-bearded Flycatcher
+Phalaenoptilus nuttallii_Uni-öösorr
+Phalaropus fulicarius_Puna-veetallaja
+Phalaropus lobatus_Veetallaja
+Phalaropus tricolor_Suur-veetallaja
+Phapitreron amethystinus_Suur-pruuntuvi
+Phapitreron leucotis_Väike-pruuntuvi
+Phaps chalcoptera_Suur-valjastuvi
+Phaps elegans_Võsa-valjastuvi
+Pharomachrus antisianus_Säbarketsal
+Pharomachrus auriceps_Andi ketsal
+Pharomachrus fulgidus_Kariibi ketsal
+Pharomachrus mocinno_Ketsal
+Pharomachrus pavoninus_Selvaketsal
+Phasianus colchicus_Faasan
+Phedina borbonica_Suur-triippääsuke
+Phegornis mitchellii_Diadeemtüll
+Phelpsia inornata_Ljaano-masktikat
 Pheucticus aureoventris_Black-backed Grosbeak
 Pheucticus chrysogaster_Golden Grosbeak
 Pheucticus chrysopeplus_Yellow Grosbeak
-Pheucticus ludovicianus_Rose-breasted Grosbeak
+Pheucticus ludovicianus_Hund-kuhiknokk
 Pheucticus melanocephalus_Black-headed Grosbeak
 Pheucticus tibialis_Black-thighed Grosbeak
-Pheugopedius atrogularis_Black-throated Wren
-Pheugopedius coraya_Coraya Wren
-Pheugopedius eisenmanni_Inca Wren
-Pheugopedius euophrys_Plain-tailed Wren
-Pheugopedius fasciatoventris_Black-bellied Wren
-Pheugopedius felix_Happy Wren
-Pheugopedius genibarbis_Moustached Wren
-Pheugopedius maculipectus_Spot-breasted Wren
-Pheugopedius mystacalis_Whiskered Wren
-Pheugopedius rutilus_Rufous-breasted Wren
-Pheugopedius sclateri_Speckle-breasted Wren
-Pheugopedius spadix_Sooty-headed Wren
+Pheugopedius atrogularis_Mustpugu-käblik
+Pheugopedius coraya_Mustpõsk-käblik
+Pheugopedius eisenmanni_Inkakäblik
+Pheugopedius euophrys_Ekuadori käblik
+Pheugopedius fasciatoventris_Maniskkäblik
+Pheugopedius felix_Kiripõsk-käblik
+Pheugopedius genibarbis_Bambusekäblik
+Pheugopedius maculipectus_Põhja-tähnikkäblik
+Pheugopedius mystacalis_Valjaskäblik
+Pheugopedius rutilus_Täpikkurk-käblik
+Pheugopedius sclateri_Lõuna-tähnikkäblik
+Pheugopedius spadix_Karbuskäblik
 Philemon buceroides_Helmeted Friarbird
 Philemon citreogularis_Little Friarbird
 Philemon corniculatus_Noisy Friarbird
 Philentoma pyrhoptera_Rufous-winged Philentoma
 Philentoma velata_Maroon-breasted Philentoma
-Philepitta schlegeli_Schlegel's Asity
-Philesturnus rufusater_North Island Saddleback
-Philetairus socius_Sociable Weaver
-Philortyx fasciatus_Banded Quail
+Philepitta schlegeli_Kold-asiiti
+Philesturnus rufusater_Põhjatieke
+Philetairus socius_Ühis-kangurlind
+Philortyx fasciatus_Vööt-tuttvutt
 Philydor atricapillus_Black-capped Foliage-gleaner
 Philydor erythrocercum_Rufous-rumped Foliage-gleaner
 Philydor fuscipenne_Slaty-winged Foliage-gleaner
 Philydor pyrrhodes_Cinnamon-rumped Foliage-gleaner
-Phimosus infuscatus_Bare-faced Ibis
+Phimosus infuscatus_Võsaiibis
 Phlegopsis erythroptera_Reddish-winged Bare-eye
 Phlegopsis nigromaculata_Black-spotted Bare-eye
 Phleocryptes melanops_Wren-like Rushbird
-Phlogophilus hemileucurus_Ecuadorian Piedtail
-Phodilus assimilis_Sri Lanka Bay-Owl
-Phodilus badius_Oriental Bay-Owl
-Phoebastria immutabilis_Laysan Albatross
-Phoebastria nigripes_Black-footed Albatross
-Phoenicircus carnifex_Guianan Red-Cotinga
-Phoenicircus nigricollis_Black-necked Red-Cotinga
-Phoeniconaias minor_Lesser Flamingo
-Phoenicoparrus andinus_Andean Flamingo
-Phoenicoparrus jamesi_James's Flamingo
-Phoenicopterus chilensis_Chilean Flamingo
-Phoenicopterus roseus_Greater Flamingo
-Phoenicopterus ruber_American Flamingo
-Phoeniculus bollei_White-headed Woodhoopoe
-Phoeniculus purpureus_Green Woodhoopoe
-Phoenicurus auroreus_Daurian Redstart
-Phoenicurus frontalis_Blue-fronted Redstart
-Phoenicurus fuliginosus_Plumbeous Redstart
-Phoenicurus hodgsoni_Hodgson's Redstart
-Phoenicurus leucocephalus_White-capped Redstart
-Phoenicurus moussieri_Moussier's Redstart
+Phlogophilus hemileucurus_Ekuadori pugalhänd-koolibri
+Phodilus assimilis_Tseiloni maskkakk
+Phodilus badius_Aasia maskkakk
+Phoebastria immutabilis_Mask-albatross
+Phoebastria nigripes_Tõmmualbatross
+Phoenicircus carnifex_Guajaana punakotinga
+Phoenicircus nigricollis_Amasoonia punakotinga
+Phoeniconaias minor_Väikeflamingo
+Phoenicoparrus andinus_Koldjalg-flamingo
+Phoenicoparrus jamesi_Lühinokk-flamingo
+Phoenicopterus chilensis_Lõunaflamingo
+Phoenicopterus roseus_Heleflamingo
+Phoenicopterus ruber_Punaflamingo
+Phoeniculus bollei_Mask-tääknokk
+Phoeniculus purpureus_Rohe-tääknokk
+Phoenicurus auroreus_Mustselg-lepalind
+Phoenicurus frontalis_Sini-lepalind
+Phoenicurus fuliginosus_Jõgi-lepalind
+Phoenicurus hodgsoni_Tiibeti lepalind
+Phoenicurus leucocephalus_Kärestiku-lepalind
+Phoenicurus moussieri_Diadeem-lepalind
 Phoenicurus ochruros_Must-lepalind
-Phoenicurus phoenicurus_Aed-lepalind
-Pholia sharpii_Sharpe's Starling
-Phonygammus keraudrenii_Trumpet Manucode
+Phoenicurus phoenicurus_Lepalind
+Pholia sharpii_Ruugekõht-kuldnokk
+Phonygammus keraudrenii_Krae-paradiisihakk
 Phragmacia substriata_Namaqua Warbler
 Phrygilus atriceps_Black-hooded Sierra Finch
 Phrygilus gayi_Gray-hooded Sierra Finch
@@ -4491,14 +4491,14 @@ Phrygilus patagonicus_Patagonian Sierra Finch
 Phylidonyris niger_White-cheeked Honeyeater
 Phylidonyris novaehollandiae_New Holland Honeyeater
 Phylidonyris pyrrhopterus_Crescent Honeyeater
-Phyllastrephus cabanisi_Cabanis's Greenbul
-Phyllastrephus cerviniventris_Gray-olive Greenbul
-Phyllastrephus fischeri_Fischer's Greenbul
-Phyllastrephus flavostriatus_Yellow-streaked Greenbul
-Phyllastrephus strepitans_Northern Brownbul
-Phyllastrephus terrestris_Terrestrial Brownbul
-Phyllergates cucullatus_Mountain Tailorbird
-Phyllergates heterolaemus_Rufous-headed Tailorbird
+Phyllastrephus cabanisi_Koldkurk-pruunbülbül
+Phyllastrephus cerviniventris_Tulisilm-pruunbülbül
+Phyllastrephus fischeri_Madaliku-pruunbülbül
+Phyllastrephus flavostriatus_Roni-pruunbülbül
+Phyllastrephus strepitans_Põhja-pruunbülbül
+Phyllastrephus terrestris_Maa-pruunbülbül
+Phyllergates cucullatus_Pikknokk-rädilind
+Phyllergates heterolaemus_Mindanao rädilind
 Phyllolais pulchella_Buff-bellied Warbler
 Phyllomyias burmeisteri_Rough-legged Tyrannulet
 Phyllomyias cinereiceps_Ashy-headed Tyrannulet
@@ -4527,185 +4527,185 @@ Phylloscartes superciliaris_Rufous-browed Tyrannulet
 Phylloscartes sylviolus_Bay-ringed Tyrannulet
 Phylloscartes ventralis_Mottle-cheeked Tyrannulet
 Phylloscartes virescens_Olive-green Tyrannulet
-Phylloscopus affinis_Tickell's Leaf Warbler
-Phylloscopus armandii_Yellow-streaked Warbler
-Phylloscopus bonelli_Western Bonelli's Warbler
-Phylloscopus borealis_Arctic Warbler
-Phylloscopus borealoides_Sakhalin Leaf Warbler
-Phylloscopus budongoensis_Uganda Woodland-Warbler
-Phylloscopus burkii_Green-crowned Warbler
-Phylloscopus calciatilis_Limestone Leaf Warbler
-Phylloscopus cantator_Yellow-vented Warbler
-Phylloscopus castaniceps_Chestnut-crowned Warbler
-Phylloscopus chloronotus_Lemon-rumped Warbler
-Phylloscopus claudiae_Claudia's Leaf Warbler
+Phylloscopus affinis_Mägi-lehelind
+Phylloscopus armandii_Papli-lehelind
+Phylloscopus bonelli_Lääne-lehelind
+Phylloscopus borealis_Põhja-lehelind
+Phylloscopus borealoides_Jaapani lehelind
+Phylloscopus budongoensis_Kahkpugu-lehelind
+Phylloscopus burkii_Rohepea-lehelind
+Phylloscopus calciatilis_Karsti-lehelind
+Phylloscopus cantator_Koldkurk-lehelind
+Phylloscopus castaniceps_Ruskkiird-lehelind
+Phylloscopus chloronotus_Himaalaja lehelind
+Phylloscopus claudiae_Keskhiina lehelind
 Phylloscopus collybita_Väike-lehelind
-Phylloscopus coronatus_Eastern Crowned Warbler
-Phylloscopus emeiensis_Emei Leaf Warbler
-Phylloscopus examinandus_Kamchatka Leaf Warbler
-Phylloscopus forresti_Sichuan Leaf Warbler
-Phylloscopus fuligiventer_Smoky Warbler
-Phylloscopus fuscatus_Dusky Warbler
-Phylloscopus goodsoni_Hartert's Leaf Warbler
-Phylloscopus grammiceps_Sunda Warbler
-Phylloscopus griseolus_Sulphur-bellied Warbler
-Phylloscopus humei_Hume's Warbler
-Phylloscopus ibericus_Iberian Chiffchaff
-Phylloscopus ijimae_Ijima's Leaf Warbler
-Phylloscopus inornatus_Yellow-browed Warbler
-Phylloscopus intensior_Davison's Leaf Warbler
-Phylloscopus intermedius_White-spectacled Warbler
-Phylloscopus kansuensis_Gansu Leaf Warbler
-Phylloscopus maculipennis_Ashy-throated Warbler
-Phylloscopus magnirostris_Large-billed Leaf Warbler
-Phylloscopus montis_Yellow-breasted Warbler
-Phylloscopus neglectus_Plain Leaf Warbler
-Phylloscopus nitidus_Green Warbler
-Phylloscopus occipitalis_Western Crowned Warbler
-Phylloscopus occisinensis_Alpine Leaf Warbler
-Phylloscopus ogilviegranti_Kloss's Leaf Warbler
-Phylloscopus olivaceus_Philippine Leaf Warbler
-Phylloscopus omeiensis_Martens's Warbler
-Phylloscopus orientalis_Eastern Bonelli's Warbler
-Phylloscopus plumbeitarsus_Two-barred Warbler
-Phylloscopus poliocephalus_Island Leaf Warbler
-Phylloscopus poliogenys_Gray-cheeked Warbler
-Phylloscopus proregulus_Pallas's Leaf Warbler
-Phylloscopus pulcher_Buff-barred Warbler
-Phylloscopus reguloides_Blyth's Leaf Warbler
-Phylloscopus ruficapilla_Yellow-throated Woodland-Warbler
-Phylloscopus sarasinorum_Sulawesi Leaf Warbler
-Phylloscopus schwarzi_Radde's Warbler
+Phylloscopus coronatus_Häilu-lehelind
+Phylloscopus emeiensis_Triller-lehelind
+Phylloscopus examinandus_Ainu lehelind
+Phylloscopus forresti_Sichuani lehelind
+Phylloscopus fuligiventer_Nõgi-lehelind
+Phylloscopus fuscatus_Tõmmu-lehelind
+Phylloscopus goodsoni_Lõunahiina lehelind
+Phylloscopus grammiceps_Sunda lehelind
+Phylloscopus griseolus_Rahnu-lehelind
+Phylloscopus humei_Tuhk-lehelind
+Phylloscopus ibericus_Ibeeria väike-lehelind
+Phylloscopus ijimae_Izu lehelind
+Phylloscopus inornatus_Vööt-lehelind
+Phylloscopus intensior_Pugalsaba-lehelind
+Phylloscopus intermedius_Prill-lehelind
+Phylloscopus kansuensis_Gansu lehelind
+Phylloscopus maculipennis_Hallkurk-lehelind
+Phylloscopus magnirostris_Oja-lehelind
+Phylloscopus montis_Punapea-lehelind
+Phylloscopus neglectus_Kadaka-lehelind
+Phylloscopus nitidus_Kaspia lehelind
+Phylloscopus occipitalis_Tadžiki lehelind
+Phylloscopus occisinensis_Hiina mägi-lehelind
+Phylloscopus ogilviegranti_Kagu-lehelind
+Phylloscopus olivaceus_Mindanao lehelind
+Phylloscopus omeiensis_Viher-lehelind
+Phylloscopus orientalis_Bütsantsi lehelind
+Phylloscopus plumbeitarsus_Laane-lehelind
+Phylloscopus poliocephalus_Melaneesia lehelind
+Phylloscopus poliogenys_Karbus-lehelind
+Phylloscopus proregulus_Kuld-lehelind
+Phylloscopus pulcher_Rododendroni-lehelind
+Phylloscopus reguloides_Võra-lehelind
+Phylloscopus ruficapilla_Kõrbkiird-lehelind
+Phylloscopus sarasinorum_Sulawesi lehelind
+Phylloscopus schwarzi_Siberi lehelind
 Phylloscopus sibilatrix_Mets-lehelind
-Phylloscopus sindianus_Mountain Chiffchaff
-Phylloscopus soror_Alström's Warbler
-Phylloscopus subaffinis_Buff-throated Warbler
-Phylloscopus subviridis_Brooks's Leaf Warbler
-Phylloscopus tenellipes_Pale-legged Leaf Warbler
-Phylloscopus tephrocephalus_Gray-crowned Warbler
-Phylloscopus trivirgatus_Mountain Leaf Warbler
-Phylloscopus trochiloides_Greenish Warbler
+Phylloscopus sindianus_Mägi-väikelehelind
+Phylloscopus soror_Töbi-lehelind
+Phylloscopus subaffinis_Kingu-lehelind
+Phylloscopus subviridis_Kuuse-lehelind
+Phylloscopus tenellipes_Ussuuri lehelind
+Phylloscopus tephrocephalus_Joonik-lehelind
+Phylloscopus trivirgatus_Lõuna-lehelind
+Phylloscopus trochiloides_Nõlva-lehelind
 Phylloscopus trochilus_Salu-lehelind
-Phylloscopus tytleri_Tytler's Leaf Warbler
-Phylloscopus umbrovirens_Brown Woodland-Warbler
-Phylloscopus valentini_Bianchi's Warbler
-Phylloscopus whistleri_Whistler's Warbler
-Phylloscopus xanthodryas_Japanese Leaf Warbler
-Phylloscopus xanthoschistos_Gray-hooded Warbler
-Phylloscopus yunnanensis_Chinese Leaf Warbler
-Phytotoma raimondii_Peruvian Plantcutter
-Phytotoma rara_Rufous-tailed Plantcutter
-Phytotoma rutila_White-tipped Plantcutter
-Piaya cayana_Squirrel Cuckoo
-Piaya melanogaster_Black-bellied Cuckoo
+Phylloscopus tytleri_Männi-lehelind
+Phylloscopus umbrovirens_Pruun-lehelind
+Phylloscopus valentini_Pehe-lehelind
+Phylloscopus whistleri_Hägu-lehelind
+Phylloscopus xanthodryas_Ida-lehelind
+Phylloscopus xanthoschistos_Hallpea-lehelind
+Phylloscopus yunnanensis_Huanghe lehelind
+Phytotoma raimondii_Kõnnukotinga
+Phytotoma rara_Tšiili kotinga
+Phytotoma rutila_Pampakotinga
+Piaya cayana_Oravkägu
+Piaya melanogaster_Ruske-oravkägu
 Pica bottanensis_Black-rumped Magpie
-Pica hudsonia_Black-billed Magpie
-Pica nuttalli_Yellow-billed Magpie
+Pica hudsonia_Ameerika harakas
+Pica nuttalli_Kalifornia harakas
 Pica pica_Harakas
 Pica serica_Oriental Magpie
-Picoides arcticus_Black-backed Woodpecker
-Picoides dorsalis_American Three-toed Woodpecker
+Picoides arcticus_Mustselg-laanerähn
+Picoides dorsalis_Väike-laanerähn
 Picoides tridactylus_Laanerähn
-Piculus aurulentus_White-browed Woodpecker
-Piculus callopterus_Stripe-cheeked Woodpecker
-Piculus chrysochloros_Golden-green Woodpecker
-Piculus flavigula_Yellow-throated Woodpecker
-Piculus leucolaemus_White-throated Woodpecker
-Picumnus albosquamatus_White-wedged Piculet
-Picumnus aurifrons_Bar-breasted Piculet
-Picumnus cinnamomeus_Chestnut Piculet
-Picumnus cirratus_White-barred Piculet
-Picumnus dorbignyanus_Ocellated Piculet
-Picumnus exilis_Golden-spangled Piculet
-Picumnus granadensis_Grayish Piculet
-Picumnus innominatus_Speckled Piculet
-Picumnus lafresnayi_Lafresnaye's Piculet
-Picumnus limae_Ochraceous Piculet
-Picumnus nebulosus_Mottled Piculet
-Picumnus olivaceus_Olivaceous Piculet
-Picumnus pygmaeus_Spotted Piculet
-Picumnus rufiventris_Rufous-breasted Piculet
-Picumnus sclateri_Ecuadorian Piculet
-Picumnus spilogaster_White-bellied Piculet
-Picumnus squamulatus_Scaled Piculet
-Picumnus temminckii_Ochre-collared Piculet
-Picus awokera_Japanese Woodpecker
+Piculus aurulentus_Helekulm-pronksrähn
+Piculus callopterus_Panama pronksrähn
+Piculus chrysochloros_Joonik-pronksrähn
+Piculus flavigula_Kuldpõsk-pronksrähn
+Piculus leucolaemus_Valgekurk-pronksrähn
+Picumnus albosquamatus_Serradorähnak
+Picumnus aurifrons_Amasoonia rähnak
+Picumnus cinnamomeus_Kaneelrähnak
+Picumnus cirratus_Kamporähnak
+Picumnus dorbignyanus_Silmikrähnak
+Picumnus exilis_Koldrähnak
+Picumnus granadensis_Helerähnak
+Picumnus innominatus_Valjasrähnak
+Picumnus lafresnayi_Selvarähnak
+Picumnus limae_Kahkrähnak
+Picumnus nebulosus_Uruguai rähnak
+Picumnus olivaceus_Oliivrähnak
+Picumnus pygmaeus_Kaatingarähnak
+Picumnus rufiventris_Ruskerähnak
+Picumnus sclateri_Ekuadori rähnak
+Picumnus spilogaster_Madalikurähnak
+Picumnus squamulatus_Venetsueela rähnak
+Picumnus temminckii_Kaelusrähnak
+Picus awokera_Jaapani roherähn
 Picus canus_Hallpea-rähn
-Picus chlorolophus_Lesser Yellownape
-Picus erythropygius_Black-headed Woodpecker
-Picus puniceus_Crimson-winged Woodpecker
-Picus sharpei_Iberian Green Woodpecker
-Picus squamatus_Scaly-bellied Woodpecker
-Picus vaillantii_Levaillant's Woodpecker
+Picus chlorolophus_Punakulm-roherähn
+Picus erythropygius_Kuldpugu-roherähn
+Picus puniceus_Võra-roherähn
+Picus sharpei_Ibeeria roherähn
+Picus squamatus_Mägi-roherähn
+Picus vaillantii_Aafrika roherähn
 Picus viridis_Roherähn
-Picus vittatus_Laced Woodpecker
-Picus xanthopygaeus_Streak-throated Woodpecker
-Pinicola enucleator_Pine Grosbeak
-Pionites leucogaster_White-bellied Parrot
-Pionites melanocephalus_Black-headed Parrot
-Pionopsitta pileata_Pileated Parrot
-Pionus chalcopterus_Bronze-winged Parrot
-Pionus fuscus_Dusky Parrot
-Pionus maximiliani_Scaly-headed Parrot
-Pionus menstruus_Blue-headed Parrot
-Pionus senilis_White-crowned Parrot
-Pionus sordidus_Red-billed Parrot
-Pionus tumultuosus_Speckle-faced Parrot
-Pipile cujubi_Red-throated Piping-Guan
-Pipile cumanensis_Blue-throated Piping-Guan
-Pipilo chlorurus_Green-tailed Towhee
-Pipilo erythrophthalmus_Eastern Towhee
-Pipilo maculatus_Spotted Towhee
-Pipilo ocai_Collared Towhee
-Pipra aureola_Crimson-hooded Manakin
-Pipra fasciicauda_Band-tailed Manakin
-Pipra filicauda_Wire-tailed Manakin
+Picus vittatus_Palmi-roherähn
+Picus xanthopygaeus_Kirikõht-roherähn
+Pinicola enucleator_Männileevike
+Pionites leucogaster_Valgekõht-papagoi
+Pionites melanocephalus_Mustpea-papagoi
+Pionopsitta pileata_Punalaup-selvapapagoi
+Pionus chalcopterus_Pronkstiib-papagoi
+Pionus fuscus_Tõmmupapagoi
+Pionus maximiliani_Soomuspapagoi
+Pionus menstruus_Sinipea-papagoi
+Pionus senilis_Laukpapagoi
+Pionus sordidus_Punanokk-papagoi
+Pionus tumultuosus_Täpikpea-papagoi
+Pipile cujubi_Amasoonia pugalhoko
+Pipile cumanensis_Läik-pugalhoko
+Pipilo chlorurus_Tanu-maasidrik
+Pipilo erythrophthalmus_Punakülg-maasidrik
+Pipilo maculatus_Täpik-maasidrik
+Pipilo ocai_Kaelus-maasidrik
+Pipra aureola_Punarind-tantsulind
+Pipra fasciicauda_Vöötsaba-tantsulind
+Pipra filicauda_Niitsaba-tantsulind
 Pipraeidea melanonota_Fawn-breasted Tanager
-Pipreola arcuata_Barred Fruiteater
-Pipreola aureopectus_Golden-breasted Fruiteater
-Pipreola formosa_Handsome Fruiteater
-Pipreola frontalis_Scarlet-breasted Fruiteater
-Pipreola intermedia_Band-tailed Fruiteater
-Pipreola jucunda_Orange-breasted Fruiteater
-Pipreola lubomirskii_Black-chested Fruiteater
-Pipreola riefferii_Green-and-black Fruiteater
-Pipreola whitelyi_Red-banded Fruiteater
+Pipreola arcuata_Vööt-rohekotinga
+Pipreola aureopectus_Kuldpugu-rohekotinga
+Pipreola formosa_Venetsueela rohekotinga
+Pipreola frontalis_Roostepugu-rohekotinga
+Pipreola intermedia_Kippel-rohekotinga
+Pipreola jucunda_Manisk-rohekotinga
+Pipreola lubomirskii_Süsipea-rohekotinga
+Pipreola riefferii_Võru-rohekotinga
+Pipreola whitelyi_Tepuikotinga
 Piprites chloris_Wing-barred Piprites
 Piprites griseiceps_Gray-headed Piprites
 Piprites pileata_Black-capped Piprites
-Piranga bidentata_Flame-colored Tanager
-Piranga erythrocephala_Red-headed Tanager
-Piranga flava_Hepatic Tanager
-Piranga leucoptera_White-winged Tanager
-Piranga ludoviciana_Western Tanager
-Piranga olivacea_Scarlet Tanager
-Piranga roseogularis_Rose-throated Tanager
-Piranga rubra_Summer Tanager
-Piranga rubriceps_Red-hooded Tanager
-Pitangus lictor_Lesser Kiskadee
-Pitangus sulphuratus_Great Kiskadee
-Pithecophaga jefferyi_Philippine Eagle
+Piranga bidentata_Kiriselg-leeklind
+Piranga erythrocephala_Mehhiko leeklind
+Piranga flava_Maksa-leeklind
+Piranga leucoptera_Väike-leeklind
+Piranga ludoviciana_Loode-leeklind
+Piranga olivacea_Kirde-leeklind
+Piranga roseogularis_Hall-leeklind
+Piranga rubra_Laulu-leeklind
+Piranga rubriceps_Andi leeklind
+Pitangus lictor_Lammi-masktikat
+Pitangus sulphuratus_Suur-masktikat
+Pithecophaga jefferyi_Ahvikotkas
 Pithys albifrons_White-plumed Antbird
-Pitohui kirhocephalus_Northern Variable Pitohui
-Pitta brachyura_Indian Pitta
-Pitta elegans_Elegant Pitta
-Pitta maxima_Ivory-breasted Pitta
-Pitta megarhyncha_Mangrove Pitta
-Pitta moluccensis_Blue-winged Pitta
-Pitta nympha_Fairy Pitta
-Pitta sordida_Hooded Pitta
-Pitta steerii_Azure-breasted Pitta
-Pitta versicolor_Noisy Pitta
+Pitohui kirhocephalus_Eris-mürkpeoleo
+Pitta brachyura_Koidupita
+Pitta elegans_Hundpita
+Pitta maxima_Halmahera pita
+Pitta megarhyncha_Mangroovipita
+Pitta moluccensis_Peegelpita
+Pitta nympha_Võlupita
+Pitta sordida_Karbuspita
+Pitta steerii_Lasuurpita
+Pitta versicolor_Austraalia pita
 Pittasoma michleri_Black-crowned Antpitta
 Pittasoma rufopileatum_Rufous-crowned Antpitta
 Pityriasis gymnocephala_Bornean Bristlehead
-Platalea ajaja_Roseate Spoonbill
-Platalea leucorodia_Eurasian Spoonbill
-Platycercus adscitus_Pale-headed Rosella
-Platycercus caledonicus_Green Rosella
-Platycercus elegans_Crimson Rosella
-Platycercus eximius_Eastern Rosella
-Platylophus galericulatus_Crested Shrikejay
+Platalea ajaja_Roosa-luitsnokkiibis
+Platalea leucorodia_Luitsnokk-iibis
+Platycercus adscitus_Sini-rosellapapagoi
+Platycercus caledonicus_Tasmaania rosellapapagoi
+Platycercus elegans_Puna-rosellapapagoi
+Platycercus eximius_Hund-rosellapapagoi
+Platylophus galericulatus_Tuttõgija
 Platyrinchus cancrominus_Stub-tailed Spadebill
 Platyrinchus coronatus_Golden-crowned Spadebill
 Platyrinchus flavigularis_Yellow-throated Spadebill
@@ -4713,76 +4713,76 @@ Platyrinchus leucoryphus_Russet-winged Spadebill
 Platyrinchus mystaceus_White-throated Spadebill
 Platyrinchus platyrhynchos_White-crested Spadebill
 Platyrinchus saturatus_Cinnamon-crested Spadebill
-Platysmurus leucopterus_Black Magpie
+Platysmurus leucopterus_Mustnäär
 Platysteira blissetti_Red-cheeked Wattle-eye
 Platysteira castanea_Chestnut Wattle-eye
 Platysteira concreta_Yellow-bellied Wattle-eye
 Platysteira cyanea_Brown-throated Wattle-eye
 Platysteira peltata_Black-throated Wattle-eye
 Plectorhyncha lanceolata_Striped Honeyeater
-Plectrophenax hyperboreus_McKay's Bunting
-Plectrophenax nivalis_Snow Bunting
-Plegadis chihi_White-faced Ibis
-Plegadis falcinellus_Glossy Ibis
-Plegadis ridgwayi_Puna Ibis
-Plocepasser mahali_White-browed Sparrow-Weaver
-Plocepasser superciliosus_Chestnut-crowned Sparrow-Weaver
-Ploceus baglafecht_Baglafecht Weaver
-Ploceus bicolor_Forest Weaver
-Ploceus capensis_Cape Weaver
-Ploceus cucullatus_Village Weaver
-Ploceus galbula_Rüppell's Weaver
-Ploceus hypoxanthus_Asian Golden Weaver
-Ploceus intermedius_Lesser Masked-Weaver
-Ploceus jacksoni_Golden-backed Weaver
-Ploceus luteolus_Little Weaver
-Ploceus manyar_Streaked Weaver
-Ploceus melanocephalus_Black-headed Weaver
-Ploceus nelicourvi_Nelicourvi Weaver
-Ploceus nigerrimus_Vieillot's Weaver
-Ploceus nigricollis_Black-necked Weaver
-Ploceus ocularis_Spectacled Weaver
-Ploceus philippinus_Baya Weaver
-Ploceus sakalava_Sakalava Weaver
-Ploceus spekei_Speke's Weaver
-Ploceus subaureus_African Golden-Weaver
-Ploceus velatus_Southern Masked-Weaver
-Ploceus vitellinus_Vitelline Masked-Weaver
-Ploceus xanthops_Holub's Golden-Weaver
-Ploceus xanthopterus_Southern Brown-throated Weaver
-Pluvialis apricaria_European Golden-Plover
-Pluvialis dominica_American Golden-Plover
-Pluvialis fulva_Pacific Golden-Plover
-Pluvialis squatarola_Black-bellied Plover
+Plectrophenax hyperboreus_Lumelind
+Plectrophenax nivalis_Hangelind
+Plegadis chihi_Prill-iibis
+Plegadis falcinellus_Tõmmuiibis
+Plegadis ridgwayi_Mägi-iibis
+Plocepasser mahali_Valgekulm-kangurlind
+Plocepasser superciliosus_Ruugekiird-kangurlind
+Ploceus baglafecht_Salu-kangurlind
+Ploceus bicolor_Duett-kangurlind
+Ploceus capensis_Aaloe-kangurlind
+Ploceus cucullatus_Küla-kangurlind
+Ploceus galbula_Aksumi kangurlind
+Ploceus hypoxanthus_Kuld-kangurlind
+Ploceus intermedius_Kahksilm-kangurlind
+Ploceus jacksoni_Kuldselg-kangurlind
+Ploceus luteolus_Sudaani kangurlind
+Ploceus manyar_Triip-kangurlind
+Ploceus melanocephalus_Mustpea-kangurlind
+Ploceus nelicourvi_Roheselg-kangurlind
+Ploceus nigerrimus_Nõgi-kangurlind
+Ploceus nigricollis_Valjas-kangurlind
+Ploceus ocularis_Bantu kangurlind
+Ploceus philippinus_Riisi-kangurlind
+Ploceus sakalava_Õnne-kangurlind
+Ploceus spekei_Kiriselg-kangurlind
+Ploceus subaureus_Safran-kangurlind
+Ploceus velatus_Mask-kangurlind
+Ploceus vitellinus_Savanni-kangurlind
+Ploceus xanthops_Viher-kangurlind
+Ploceus xanthopterus_Roo-kangurlind
+Pluvialis apricaria_Rüüt
+Pluvialis dominica_Ameerika rüüt
+Pluvialis fulva_Tundrarüüt
+Pluvialis squatarola_Plüü
 Pnoepyga albiventer_Scaly-breasted Cupwing
 Pnoepyga formosana_Taiwan Cupwing
 Pnoepyga immaculata_Immaculate Cupwing
 Pnoepyga pusilla_Pygmy Cupwing
-Podargus ocellatus_Marbled Frogmouth
-Podargus strigoides_Tawny Frogmouth
-Podiceps auritus_Horned Grebe
-Podiceps cristatus_Hallpõsk-pütt
-Podiceps gallardoi_Hooded Grebe
-Podiceps grisegena_Red-necked Grebe
-Podiceps major_Great Grebe
-Podiceps nigricollis_Eared Grebe
-Podiceps occipitalis_Silvery Grebe
-Podilymbus podiceps_Pied-billed Grebe
-Podoces hendersoni_Mongolian Ground-Jay
-Poecile atricapillus_Black-capped Chickadee
-Poecile carolinensis_Carolina Chickadee
-Poecile cinctus_Gray-headed Chickadee
-Poecile gambeli_Mountain Chickadee
-Poecile hudsonicus_Boreal Chickadee
-Poecile lugubris_Sombre Tit
+Podargus ocellatus_Mets-konnkurk
+Podargus strigoides_Austraalia konnkurk
+Podiceps auritus_Sarvikpütt
+Podiceps cristatus_Tuttpütt
+Podiceps gallardoi_Lumipütt
+Podiceps grisegena_Hallpõsk-pütt
+Podiceps major_Hiidpütt
+Podiceps nigricollis_Mustkael-pütt
+Podiceps occipitalis_Hõbepütt
+Podilymbus podiceps_Vöötnokk-pütt
+Podoces hendersoni_Mongoolia maanäär
+Poecile atricapillus_Ameerika põhjatihane
+Poecile carolinensis_Ojatihane
+Poecile cinctus_Taigatihane
+Poecile gambeli_Mägitihane
+Poecile hudsonicus_Kanada tihane
+Poecile lugubris_Tammetihane
 Poecile montanus_Põhjatihane
 Poecile palustris_Salutihane
-Poecile rufescens_Chestnut-backed Chickadee
-Poecile sclateri_Mexican Chickadee
-Poecile weigoldicus_Sichuan Tit
-Poecilodryas hypoleuca_Black-sided Robin
+Poecile rufescens_Ruskselg-tihane
+Poecile sclateri_Asteegi tihane
+Poecile weigoldicus_Hiina põhjatihane
+Poecilodryas hypoleuca_Saagomiro
 Poecilostreptus cabanisi_Azure-rumped Tanager
-Poecilostreptus palmeri_Gray-and-gold Tanager
+Poecilostreptus palmeri_Hõbetangara
 Poecilotriccus albifacies_White-cheeked Tody-Flycatcher
 Poecilotriccus calopterus_Golden-winged Tody-Flycatcher
 Poecilotriccus capitalis_Black-and-white Tody-Flycatcher
@@ -4793,47 +4793,47 @@ Poecilotriccus plumbeiceps_Ochre-faced Tody-Flycatcher
 Poecilotriccus ruficeps_Rufous-crowned Tody-Flycatcher
 Poecilotriccus russatus_Ruddy Tody-Flycatcher
 Poecilotriccus sylvia_Slate-headed Tody-Flycatcher
-Pogoniulus atroflavus_Red-rumped Tinkerbird
-Pogoniulus bilineatus_Yellow-rumped Tinkerbird
-Pogoniulus chrysoconus_Yellow-fronted Tinkerbird
-Pogoniulus leucomystax_Moustached Tinkerbird
-Pogoniulus pusillus_Red-fronted Tinkerbird
-Pogoniulus scolopaceus_Speckled Tinkerbird
-Pogoniulus simplex_Green Tinkerbird
-Pogoniulus subsulphureus_Yellow-throated Tinkerbird
-Pogonocichla stellata_White-starred Robin
-Poicephalus cryptoxanthus_Brown-headed Parrot
+Pogoniulus atroflavus_Punapära-udelind
+Pogoniulus bilineatus_Välu-udelind
+Pogoniulus chrysoconus_Kuldlaup-udelind
+Pogoniulus leucomystax_Valjas-udelind
+Pogoniulus pusillus_Punalaup-udelind
+Pogoniulus scolopaceus_Värb-udelind
+Pogoniulus simplex_Pisi-udelind
+Pogoniulus subsulphureus_Mets-udelind
+Pogonocichla stellata_Kuld-ruugeööbik
+Poicephalus cryptoxanthus_Võsa-moorapapagoi
 Poicephalus fuscicollis_Brown-necked Parrot
-Poicephalus meyeri_Meyer's Parrot
-Poicephalus robustus_Cape Parrot
-Poicephalus rufiventris_Red-bellied Parrot
-Poicephalus senegalus_Senegal Parrot
+Poicephalus meyeri_Väike-moorapapagoi
+Poicephalus robustus_Suur-moorapapagoi
+Poicephalus rufiventris_Somaali moorapapagoi
+Poicephalus senegalus_Baobabi-moorapapagoi
 Poliocrania exsul_Chestnut-backed Antbird
-Poliolimnas cinereus_White-browed Crake
-Polioptila albiloris_White-lored Gnatcatcher
+Poliolimnas cinereus_Valjashuik
+Polioptila albiloris_Võsa-händkäblik
 Polioptila bilineata_White-browed Gnatcatcher
-Polioptila caerulea_Blue-gray Gnatcatcher
-Polioptila californica_California Gnatcatcher
-Polioptila dumicola_Masked Gnatcatcher
-Polioptila lactea_Creamy-bellied Gnatcatcher
-Polioptila lembeyei_Cuban Gnatcatcher
-Polioptila melanura_Black-tailed Gnatcatcher
-Polioptila nigriceps_Black-capped Gnatcatcher
-Polioptila plumbea_Tropical Gnatcatcher
-Polioptila schistaceigula_Slate-throated Gnatcatcher
-Polyboroides typus_African Harrier-Hawk
-Polyerata amabilis_Blue-chested Hummingbird
-Polyerata decora_Charming Hummingbird
-Polyplectron bicalcaratum_Gray Peacock-Pheasant
-Polyplectron chalcurum_Bronze-tailed Peacock-Pheasant
-Polyplectron germaini_Germain's Peacock-Pheasant
-Polyplectron malacense_Malayan Peacock-Pheasant
+Polioptila caerulea_Mustkulm-händkäblik
+Polioptila californica_Kalifornia händkäblik
+Polioptila dumicola_Mask-händkäblik
+Polioptila lactea_Vandelkõht-händkäblik
+Polioptila lembeyei_Kuuba händkäblik
+Polioptila melanura_Kõrbe-händkäblik
+Polioptila nigriceps_Mustpõsk-händkäblik
+Polioptila plumbea_Karbus-händkäblik
+Polioptila schistaceigula_Kolumbia händkäblik
+Polyboroides typus_Aafrika maskkull
+Polyerata amabilis_Tuhkkõht-safiirkoolibri
+Polyerata decora_Kostariika safiirkoolibri
+Polyplectron bicalcaratum_Hall-paabufaasan
+Polyplectron chalcurum_Sumatra paabufaasan
+Polyplectron germaini_Vietnami paabufaasan
+Polyplectron malacense_Kübar-paabufaasan
 Polystictus pectoralis_Bearded Tachuri
 Polystictus superciliaris_Gray-backed Tachuri
-Polytelis anthopeplus_Regent Parrot
-Polytelis swainsonii_Superb Parrot
-Polytmus guainumbi_White-tailed Goldenthroat
-Polytmus theresiae_Green-tailed Goldenthroat
+Polytelis anthopeplus_Koldpapagoi
+Polytelis swainsonii_Jõgipapagoi
+Polytmus guainumbi_Rohtla-viherkoolibri
+Polytmus theresiae_Rohesaba-viherkoolibri
 Pomatorhinus ferruginosus_Coral-billed Scimitar-Babbler
 Pomatorhinus horsfieldii_Indian Scimitar-Babbler
 Pomatorhinus melanurus_Sri Lanka Scimitar-Babbler
@@ -4843,92 +4843,92 @@ Pomatorhinus ochraceiceps_Red-billed Scimitar-Babbler
 Pomatorhinus ruficollis_Streak-breasted Scimitar-Babbler
 Pomatorhinus schisticeps_White-browed Scimitar-Babbler
 Pomatorhinus superciliaris_Slender-billed Scimitar-Babbler
-Pomatostomus ruficeps_Chestnut-crowned Babbler
-Pomatostomus superciliosus_White-browed Babbler
-Pomatostomus temporalis_Gray-crowned Babbler
-Poodytes gramineus_Little Grassbird
-Poodytes punctatus_New Zealand Fernbird
-Pooecetes gramineus_Vesper Sparrow
+Pomatostomus ruficeps_Vööttiib-määrlind
+Pomatostomus superciliosus_Väike-määrlind
+Pomatostomus temporalis_Suur-määrlind
+Poodytes gramineus_Väike-padulind
+Poodytes punctatus_Maoori padulind
+Pooecetes gramineus_Põldsidrik
 Poospiza nigrorufa_Black-and-rufous Warbling Finch
-Porphyrio flavirostris_Azure Gallinule
-Porphyrio madagascariensis_African Swamphen
-Porphyrio martinica_Purple Gallinule
-Porphyrio melanotus_Australasian Swamphen
-Porphyrio poliocephalus_Gray-headed Swamphen
-Porphyrio porphyrio_Western Swamphen
-Porphyriops melanops_Spot-flanked Gallinule
-Porzana carolina_Sora
-Porzana porzana_Spotted Crake
-Porzana spiloptera_Dot-winged Crake
+Porphyrio flavirostris_Hele-sultantait
+Porphyrio madagascariensis_Smaragd-sultantait
+Porphyrio martinica_Koldjalg-sultantait
+Porphyrio melanotus_Tõmmu-sultantait
+Porphyrio poliocephalus_Lasuur-sultantait
+Porphyrio porphyrio_Sultantait
+Porphyriops melanops_Naerutait
+Porzana carolina_Ameerika huik
+Porzana porzana_Täpikhuik
+Porzana spiloptera_Pampahuik
 Power tools_Power tools
 Premnoplex brunnescens_Spotted Barbtail
 Premnornis guttuliger_Rusty-winged Barbtail
-Primolius auricollis_Yellow-collared Macaw
-Primolius couloni_Blue-headed Macaw
-Primolius maracana_Blue-winged Macaw
-Prinia atrogularis_Black-throated Prinia
-Prinia bairdii_Banded Prinia
-Prinia buchanani_Rufous-fronted Prinia
-Prinia crinigera_Himalayan Prinia
-Prinia erythroptera_Red-winged Prinia
-Prinia familiaris_Bar-winged Prinia
-Prinia flavicans_Black-chested Prinia
-Prinia flaviventris_Yellow-bellied Prinia
-Prinia gracilis_Graceful Prinia
-Prinia hodgsonii_Gray-breasted Prinia
-Prinia hypoxantha_Drakensberg Prinia
-Prinia inornata_Plain Prinia
+Primolius auricollis_Kaelus-aara
+Primolius couloni_Smaragd-aara
+Primolius maracana_Roheaara
+Prinia atrogularis_Himaalaja puhmalind
+Prinia bairdii_Vööt-puhmalind
+Prinia buchanani_Kõnnu-puhmalind
+Prinia crinigera_Mägi-puhmalind
+Prinia erythroptera_Punatiib-puhmalind
+Prinia familiaris_Sunda puhmalind
+Prinia flavicans_Mustpugu-puhmalind
+Prinia flaviventris_Koldkõht-puhmalind
+Prinia gracilis_Leet-puhmalind
+Prinia hodgsonii_Hallpugu-puhmalind
+Prinia hypoxantha_Draakonimägede puhmalind
+Prinia inornata_Tuhk-puhmalind
 Prinia lepida_Delicate Prinia
-Prinia maculosa_Karoo Prinia
-Prinia polychroa_Brown Prinia
-Prinia rufescens_Rufescent Prinia
-Prinia rufifrons_Red-fronted Prinia
-Prinia socialis_Ashy Prinia
+Prinia maculosa_Tähnik-puhmalind
+Prinia polychroa_Suur-puhmalind
+Prinia rufescens_Pruunselg-puhmalind
+Prinia rufifrons_Ruskelaup-puhmalind
+Prinia socialis_Aed-puhmalind
 Prinia striata_Striped Prinia
-Prinia subflava_Tawny-flanked Prinia
-Prinia superciliaris_Hill Prinia
-Prinia sylvatica_Jungle Prinia
-Prionochilus maculatus_Yellow-breasted Flowerpecker
-Prionochilus thoracicus_Scarlet-breasted Flowerpecker
-Prionochilus xanthopygius_Yellow-rumped Flowerpecker
+Prinia subflava_Aafrika puhmalind
+Prinia superciliaris_Nõlva-puhmalind
+Prinia sylvatica_Džungli-puhmalind
+Prionochilus maculatus_Tanu-võõrikulind
+Prionochilus thoracicus_Viker-võõrikulind
+Prionochilus xanthopygius_Virsikrind-võõrikulind
 Prionops plumatus_White Helmetshrike
 Prionops retzii_Retz's Helmetshrike
-Priotelus roseigaster_Hispaniolan Trogon
-Priotelus temnurus_Cuban Trogon
-Probosciger aterrimus_Palm Cockatoo
-Procarduelis nipalensis_Dark-breasted Rosefinch
-Procnias albus_White Bellbird
-Procnias averano_Bearded Bellbird
-Procnias nudicollis_Bare-throated Bellbird
-Procnias tricarunculatus_Three-wattled Bellbird
-Progne chalybea_Gray-breasted Martin
-Progne elegans_Southern Martin
-Progne subis_Purple Martin
-Progne tapera_Brown-chested Martin
-Promerops cafer_Cape Sugarbird
-Prosopeia personata_Masked Shining-Parrot
-Prosopeia tabuensis_Red Shining-Parrot
+Priotelus roseigaster_Haiti järanokk
+Priotelus temnurus_Kuuba järanokk
+Probosciger aterrimus_Ronkkakaduu
+Procarduelis nipalensis_Tõmmu-karmiinleevike
+Procnias albus_Valge-kellalind
+Procnias averano_Habe-kellalind
+Procnias nudicollis_Paljaskurk-kellalind
+Procnias tricarunculatus_Lokut-kellalind
+Progne chalybea_Tuhk-türkiispääsuke
+Progne elegans_Lõuna-türkiispääsuke
+Progne subis_Türkiispääsuke
+Progne tapera_Kiilipääsuke
+Promerops cafer_Händ-prootealind
+Prosopeia personata_Maskpapagoi
+Prosopeia tabuensis_Muskaadipapagoi
 Prosthemadera novaeseelandiae_Tui
-Protonotaria citrea_Prothonotary Warbler
-Prunella collaris_Alpine Accentor
-Prunella fulvescens_Brown Accentor
+Protonotaria citrea_Õõnesäälik
+Prunella collaris_Mägiraat
+Prunella fulvescens_Kiviraat
 Prunella modularis_Võsaraat
-Prunella montanella_Siberian Accentor
-Prunella ocularis_Radde's Accentor
-Prunella rubeculoides_Robin Accentor
-Prunella strophiata_Rufous-breasted Accentor
-Psalidoprocne pristoptera_Black Sawwing
-Psaltriparus minimus_Bushtit
-Psarisomus dalhousiae_Long-tailed Broadbill
-Psarocolius angustifrons_Russet-backed Oropendola
-Psarocolius atrovirens_Dusky-green Oropendola
-Psarocolius bifasciatus_Olive Oropendola
-Psarocolius decumanus_Crested Oropendola
-Psarocolius montezuma_Montezuma Oropendola
-Psarocolius viridis_Green Oropendola
-Psarocolius wagleri_Chestnut-headed Oropendola
-Psephotus haematonotus_Red-rumped Parrot
-Psephotus varius_Mulga Parrot
+Prunella montanella_Siberi raat
+Prunella ocularis_Kadaka-kiviraat
+Prunella rubeculoides_Punarind-raat
+Prunella strophiata_Triipraat
+Psalidoprocne pristoptera_Pugaltiib-nõgipääsuke
+Psaltriparus minimus_Ameerika sabatihane
+Psarisomus dalhousiae_Händ-lainokk
+Psarocolius angustifrons_Eris-suurturpial
+Psarocolius atrovirens_Oliiv-suurturpial
+Psarocolius bifasciatus_Pará suurturpial
+Psarocolius decumanus_Must-suurturpial
+Psarocolius montezuma_Ruske-suurturpial
+Psarocolius viridis_Rohe-suurturpial
+Psarocolius wagleri_Talbnokk-suurturpial
+Psephotus haematonotus_Kuldkõht-paradiisipapagoi
+Psephotus varius_Mulga-paradiisipapagoi
 Pseudacris brimleyi_Brimley's Chorus Frog
 Pseudacris clarkii_Spotted Chorus Frog
 Pseudacris crucifer_Spring Peeper
@@ -4939,23 +4939,23 @@ Pseudacris ornata_Ornate Chorus Frog
 Pseudacris streckeri_Strecker's Chorus Frog
 Pseudacris triseriata_Striped Chorus Frog
 Pseudasthenes humicola_Dusky-tailed Canastero
-Pseudastur albicollis_White Hawk
-Pseudastur occidentalis_Gray-backed Hawk
+Pseudastur albicollis_Valge-selvaviu
+Pseudastur occidentalis_Ekuadori selvaviu
 Pseudelaenia leucospodia_Gray-and-white Tyrannulet
-Pseudeos cardinalis_Cardinal Lory
-Pseudibis papillosa_Red-naped Ibis
+Pseudeos cardinalis_Kinaver-nestepapagoi
+Pseudibis papillosa_Nõgi-iibis
 Pseudocolaptes boissonneautii_Streaked Tuftedcheek
 Pseudocolaptes lawrencii_Buffy Tuftedcheek
 Pseudocolopteryx citreola_Ticking Doradito
 Pseudocolopteryx dinelliana_Dinelli's Doradito
 Pseudocolopteryx flaviventris_Warbling Doradito
 Pseudocolopteryx sclateri_Crested Doradito
-Pseudoleistes guirahuro_Yellow-rumped Marshbird
-Pseudoleistes virescens_Brown-and-yellow Marshbird
-Pseudonestor xanthophrys_Maui Parrotbill
-Pseudonigrita arnaudi_Gray-headed Social-Weaver
-Pseudopipra pipra_White-crowned Manakin
-Pseudopodoces humilis_Ground Tit
+Pseudoleistes guirahuro_Kuldselg-sooturpial
+Pseudoleistes virescens_Pruunselg-sooturpial
+Pseudonestor xanthophrys_Konksnokk-nestevint
+Pseudonigrita arnaudi_Leet-kangurlind
+Pseudopipra pipra_Tanu-tantsulind
+Pseudopodoces humilis_Maatihane
 Pseudorectes ferrugineus_Rusty Pitohui
 Pseudoseisura cristata_Caatinga Cacholote
 Pseudoseisura gutturalis_White-throated Cacholote
@@ -4964,339 +4964,339 @@ Pseudoseisura unirufa_Rufous Cacholote
 Pseudospingus verticalis_Black-headed Hemispingus
 Pseudotriccus pelzelni_Bronze-olive Pygmy-Tyrant
 Pseudotriccus ruficeps_Rufous-headed Pygmy-Tyrant
-Psilopogon annamensis_Indochinese Barbet
-Psilopogon armillaris_Flame-fronted Barbet
-Psilopogon asiaticus_Blue-throated Barbet
+Psilopogon annamensis_Annami habelind
+Psilopogon armillaris_Kuldpugu-habelind
+Psilopogon asiaticus_Sinipõsk-habelind
 Psilopogon auricularis_Necklaced Barbet
-Psilopogon australis_Little Barbet
-Psilopogon chrysopogon_Gold-whiskered Barbet
-Psilopogon corvinus_Brown-throated Barbet
+Psilopogon australis_Väike-habelind
+Psilopogon chrysopogon_Laikpea-habelind
+Psilopogon corvinus_Pruunpea-habelind
 Psilopogon duvaucelii_Blue-eared Barbet
-Psilopogon eximius_Bornean Barbet
-Psilopogon faber_Chinese Barbet
-Psilopogon faiostrictus_Green-eared Barbet
-Psilopogon flavifrons_Yellow-fronted Barbet
-Psilopogon franklinii_Golden-throated Barbet
-Psilopogon haemacephalus_Coppersmith Barbet
-Psilopogon henricii_Yellow-crowned Barbet
-Psilopogon incognitus_Moustached Barbet
-Psilopogon lagrandieri_Red-vented Barbet
-Psilopogon lineatus_Lineated Barbet
-Psilopogon malabaricus_Malabar Barbet
-Psilopogon monticola_Mountain Barbet
-Psilopogon mystacophanos_Red-throated Barbet
-Psilopogon nuchalis_Taiwan Barbet
-Psilopogon oorti_Black-browed Barbet
-Psilopogon pulcherrimus_Golden-naped Barbet
-Psilopogon pyrolophus_Fire-tufted Barbet
-Psilopogon rafflesii_Red-crowned Barbet
-Psilopogon rubricapillus_Crimson-fronted Barbet
-Psilopogon virens_Great Barbet
-Psilopogon viridis_White-cheeked Barbet
-Psilopogon zeylanicus_Brown-headed Barbet
-Psilopsiagon aurifrons_Mountain Parakeet
-Psilopsiagon aymara_Gray-hooded Parakeet
+Psilopogon eximius_Mustkurk-habelind
+Psilopogon faber_Hainani habelind
+Psilopogon faiostrictus_Rohepõsk-habelind
+Psilopogon flavifrons_Tseiloni habelind
+Psilopogon franklinii_Mägi-habelind
+Psilopogon haemacephalus_Sepp-habelind
+Psilopogon henricii_Kuldkulm-habelind
+Psilopogon incognitus_Vöötpõsk-habelind
+Psilopogon lagrandieri_Vietnami habelind
+Psilopogon lineatus_Marmor-habelind
+Psilopogon malabaricus_Malabari habelind
+Psilopogon monticola_Viirkurk-habelind
+Psilopogon mystacophanos_Punakurk-habelind
+Psilopogon nuchalis_Taivani habelind
+Psilopogon oorti_Mustkulm-habelind
+Psilopogon pulcherrimus_Sinikiird-habelind
+Psilopogon pyrolophus_Tsikaad-habelind
+Psilopogon rafflesii_Punakiird-habelind
+Psilopogon rubricapillus_Tamili habelind
+Psilopogon virens_Suur-habelind
+Psilopogon viridis_Valgepõsk-habelind
+Psilopogon zeylanicus_Prill-habelind
+Psilopsiagon aurifrons_Kold-mägipapagoi
+Psilopsiagon aymara_Karbus-mägipapagoi
 Psilorhamphus guttatus_Spotted Bamboowren
-Psilorhinus morio_Brown Jay
-Psiloscops flammeolus_Flammulated Owl
-Psittacara erythrogenys_Red-masked Parakeet
-Psittacara finschi_Crimson-fronted Parakeet
-Psittacara holochlorus_Green Parakeet
-Psittacara leucophthalmus_White-eyed Parakeet
-Psittacara mitratus_Mitred Parakeet
-Psittacara strenuus_Pacific Parakeet
-Psittacara wagleri_Scarlet-fronted Parakeet
-Psittacula alexandri_Red-breasted Parakeet
-Psittacula calthrapae_Layard's Parakeet
-Psittacula columboides_Malabar Parakeet
-Psittacula cyanocephala_Plum-headed Parakeet
-Psittacula eques_Echo Parakeet
-Psittacula eupatria_Alexandrine Parakeet
-Psittacula finschii_Gray-headed Parakeet
-Psittacula himalayana_Slaty-headed Parakeet
-Psittacula krameri_Rose-ringed Parakeet
-Psittacula longicauda_Long-tailed Parakeet
-Psittacus erithacus_Gray Parrot
-Psittinus cyanurus_Blue-rumped Parrot
-Psittiparus gularis_Gray-headed Parrotbill
-Psophia crepitans_Gray-winged Trumpeter
-Psophia leucoptera_Pale-winged Trumpeter
-Psophia viridis_Dark-winged Trumpeter
-Psophocichla litsitsirupa_Groundscraper Thrush
+Psilorhinus morio_Pruunnäär
+Psiloscops flammeolus_Männipäll
+Psittacara erythrogenys_Punapea-aratinga
+Psittacara finschi_Kostariika aratinga
+Psittacara holochlorus_Rohearatinga
+Psittacara leucophthalmus_Salu-aratinga
+Psittacara mitratus_Mägiaratinga
+Psittacara strenuus_Lõuna-rohearatinga
+Psittacara wagleri_Kaljuaratinga
+Psittacula alexandri_Väike-habepapagoi
+Psittacula calthrapae_Tseiloni kaeluspapagoi
+Psittacula columboides_Malabari kaeluspapagoi
+Psittacula cyanocephala_Karmiinpea-kaeluspapagoi
+Psittacula eques_Maskareeni kaeluspapagoi
+Psittacula eupatria_Suur-kaeluspapagoi
+Psittacula finschii_Hallpea-kaeluspapagoi
+Psittacula himalayana_Himaalaja kaeluspapagoi
+Psittacula krameri_Kaeluspapagoi
+Psittacula longicauda_Malai habepapagoi
+Psittacus erithacus_Hallpapagoi
+Psittinus cyanurus_Õlipalmi-papagoi
+Psittiparus gularis_Võra-koonusnokk
+Psophia crepitans_Halltiib-trompetlind
+Psophia leucoptera_Valgetiib-trompetlind
+Psophia viridis_Tõmmu-trompetlind
+Psophocichla litsitsirupa_Lühisaba-rästas
 Psophodes cristatus_Chirruping Wedgebill
 Psophodes nigrogularis_Western Whipbird
 Psophodes occidentalis_Chiming Wedgebill
 Psophodes olivaceus_Eastern Whipbird
-Pteridophora alberti_King-of-Saxony Bird-of-Paradise
-Pternistis adspersus_Red-billed Francolin
-Pternistis afer_Red-necked Francolin
-Pternistis ahantensis_Ahanta Francolin
-Pternistis bicalcaratus_Double-spurred Francolin
-Pternistis capensis_Cape Francolin
-Pternistis erckelii_Erckel's Francolin
-Pternistis hildebrandti_Hildebrandt's Francolin
-Pternistis leucoscepus_Yellow-necked Francolin
-Pternistis natalensis_Natal Francolin
-Pternistis squamatus_Scaly Francolin
-Pternistis swainsonii_Swainson's Francolin
-Pterocles alchata_Pin-tailed Sandgrouse
-Pterocles exustus_Chestnut-bellied Sandgrouse
-Pterocles namaqua_Namaqua Sandgrouse
-Pterocles orientalis_Black-bellied Sandgrouse
-Pterocles senegallus_Spotted Sandgrouse
-Pterodroma cervicalis_White-necked Petrel
-Pterodroma cookii_Cook's Petrel
-Pterodroma externa_Juan Fernandez Petrel
-Pterodroma hypoleuca_Bonin Petrel
-Pterodroma inexpectata_Mottled Petrel
-Pterodroma madeira_Zino's Petrel
-Pterodroma neglecta_Kermadec Petrel
-Pterodroma nigripennis_Black-winged Petrel
-Pterodroma phaeopygia_Galapagos Petrel
-Pterodroma sandwichensis_Hawaiian Petrel
-Pteroglossus aracari_Black-necked Aracari
-Pteroglossus azara_Ivory-billed Aracari
-Pteroglossus bailloni_Saffron Toucanet
+Pteridophora alberti_Lint-paradiisilind
+Pternistis adspersus_Viirfrankoliin
+Pternistis afer_Punakurk-frankoliin
+Pternistis ahantensis_Ginea frankoliin
+Pternistis bicalcaratus_Savannifrankoliin
+Pternistis capensis_Kapi frankoliin
+Pternistis erckelii_Suurfrankoliin
+Pternistis hildebrandti_Tähnikfrankoliin
+Pternistis leucoscepus_Kuldkurk-frankoliin
+Pternistis natalensis_Kiripugu-frankoliin
+Pternistis squamatus_Tuhkfrankoliin
+Pternistis swainsonii_Lammifrankoliin
+Pterocles alchata_Valgekõht-vuril
+Pterocles exustus_Pruunkõht-vuril
+Pterocles namaqua_Namiibia vuril
+Pterocles orientalis_Mustkõht-vuril
+Pterocles senegallus_Kõrbevuril
+Pterodroma cervicalis_Valgekael-tormilind
+Pterodroma cookii_Hele-tormilind
+Pterodroma externa_Másafuera tormilind
+Pterodroma hypoleuca_Mustlaik-tormilind
+Pterodroma inexpectata_Hallkõht-tormilind
+Pterodroma madeira_Madeira tormilind
+Pterodroma neglecta_Okeaania tormilind
+Pterodroma nigripennis_Hallkael-tormilind
+Pterodroma phaeopygia_Lauk-tormilind
+Pterodroma sandwichensis_Maui tormilind
+Pteroglossus aracari_Mustkael-tuukan
+Pteroglossus azara_Vandelnokk-tuukan
+Pteroglossus bailloni_Safrantuukan
 Pteroglossus beauharnaisii_Curl-crested Aracari
-Pteroglossus bitorquatus_Red-necked Aracari
-Pteroglossus castanotis_Chestnut-eared Aracari
-Pteroglossus frantzii_Fiery-billed Aracari
-Pteroglossus inscriptus_Lettered Aracari
-Pteroglossus pluricinctus_Many-banded Aracari
-Pteroglossus torquatus_Collared Aracari
+Pteroglossus bitorquatus_Punatuukan
+Pteroglossus castanotis_Jõgituukan
+Pteroglossus frantzii_Tulinokk-tuukan
+Pteroglossus inscriptus_Kirinokk-tuukan
+Pteroglossus pluricinctus_Kaksvööt-tuukan
+Pteroglossus torquatus_Kaelustuukan
 Pterophylla camellifolia_Common True Katydid
 Pteroptochos castaneus_Chestnut-throated Huet-huet
 Pteroptochos megapodius_Moustached Turca
 Pteroptochos tarnii_Black-throated Huet-huet
-Pterorhinus albogularis_White-throated Laughingthrush
-Pterorhinus berthemyi_Buffy Laughingthrush
-Pterorhinus chinensis_Black-throated Laughingthrush
-Pterorhinus davidi_Pere David's Laughingthrush
-Pterorhinus delesserti_Wayanad Laughingthrush
-Pterorhinus mitratus_Chestnut-capped Laughingthrush
-Pterorhinus pectoralis_Greater Necklaced Laughingthrush
-Pterorhinus perspicillatus_Masked Laughingthrush
-Pterorhinus poecilorhynchus_Rusty Laughingthrush
-Pterorhinus ruficollis_Rufous-necked Laughingthrush
-Pterorhinus sannio_White-browed Laughingthrush
-Pterorhinus treacheri_Chestnut-hooded Laughingthrush
+Pterorhinus albogularis_Valgekurk-võsavädrak
+Pterorhinus berthemyi_Ruuge-võsavädrak
+Pterorhinus chinensis_Valgepõsk-võsarvädrak
+Pterorhinus davidi_Tuhk-võsavädrak
+Pterorhinus delesserti_Ghati võsavädrak
+Pterorhinus mitratus_Malai võsavädrak
+Pterorhinus pectoralis_Kaelus-võsavädrak
+Pterorhinus perspicillatus_Mask-võsavädrak
+Pterorhinus poecilorhynchus_Rooste-võsavädrak
+Pterorhinus ruficollis_Punakael-võsavädrak
+Pterorhinus sannio_Sõrgsilm-võsavädrak
+Pterorhinus treacheri_Kalimantani võsavädrak
 Pteruthius aeralatus_Blyth's Shrike-Babbler
 Pteruthius intermedius_Clicking Shrike-Babbler
 Pteruthius melanotis_Black-eared Shrike-Babbler
 Pteruthius ripleyi_Himalayan Shrike-Babbler
 Pteruthius rufiventer_Black-headed Shrike-Babbler
 Pteruthius xanthochlorus_Green Shrike-Babbler
-Ptilinopus iozonus_Orange-bellied Fruit-Dove
-Ptilinopus magnificus_Wompoo Fruit-Dove
-Ptilinopus melanospilus_Black-naped Fruit-Dove
-Ptilinopus occipitalis_Yellow-breasted Fruit-Dove
-Ptilinopus pelewensis_Palau Fruit-Dove
-Ptilinopus porphyraceus_Crimson-crowned Fruit-Dove
-Ptilinopus regina_Rose-crowned Fruit-Dove
-Ptilinopus rivoli_White-breasted Fruit-Dove
-Ptilinopus solomonensis_Yellow-bibbed Fruit-Dove
-Ptilinopus superbus_Superb Fruit-Dove
-Ptilinopus viridis_Claret-breasted Fruit-Dove
-Ptiliogonys caudatus_Long-tailed Silky-flycatcher
-Ptiliogonys cinereus_Gray Silky-flycatcher
+Ptilinopus iozonus_Ruugekõht-rohetuvi
+Ptilinopus magnificus_Suur-rohetuvi
+Ptilinopus melanospilus_Mustkukal-rohetuvi
+Ptilinopus occipitalis_Koldrind-rohetuvi
+Ptilinopus pelewensis_Palau rohetuvi
+Ptilinopus porphyraceus_Okeaania rohetuvi
+Ptilinopus regina_Lõuna-rohetuvi
+Ptilinopus rivoli_Vöö-rohetuvi
+Ptilinopus solomonensis_Roosakõht-rohetuvi
+Ptilinopus superbus_Hund-rohetuvi
+Ptilinopus viridis_Punapugu-rohetuvi
+Ptiliogonys caudatus_Händ-siidinäpp
+Ptiliogonys cinereus_Hall-siidinäpp
 Ptilocichla falcata_Falcated Wren-Babbler
 Ptilocichla leucogrammica_Bornean Wren-Babbler
 Ptilocichla mindanensis_Striated Wren-Babbler
-Ptilonorhynchus violaceus_Satin Bowerbird
-Ptilopachus petrosus_Stone Partridge
+Ptilonorhynchus violaceus_Läik-lehtlalind
+Ptilopachus petrosus_Rahnukana
 Ptiloprora guisei_Rufous-backed Honeyeater
 Ptiloprora perstriata_Gray-streaked Honeyeater
-Ptilopsis leucotis_Northern White-faced Owl
-Ptiloris magnificus_Magnificent Riflebird
-Ptiloris paradiseus_Paradise Riflebird
-Ptiloris victoriae_Victoria's Riflebird
+Ptilopsis leucotis_Savannipäll
+Ptiloris magnificus_Safiir-paradiisilind
+Ptiloris paradiseus_Lõuna-paradiisilind
+Ptiloris victoriae_Queenslandi paradiisilind
 Ptilorrhoa caerulescens_Blue Jewel-babbler
 Ptilorrhoa castanonota_Chestnut-backed Jewel-babbler
 Ptilorrhoa leucosticta_Spotted Jewel-babbler
-Ptilostomus afer_Piapiac
+Ptilostomus afer_Savanniharakas
 Ptilotula fusca_Fuscous Honeyeater
 Ptilotula ornata_Yellow-plumed Honeyeater
 Ptilotula penicillata_White-plumed Honeyeater
-Ptiloxena atroviolacea_Cuban Blackbird
-Ptyonoprogne concolor_Dusky Crag-Martin
-Ptyonoprogne fuligula_Rock Martin
-Ptyonoprogne rupestris_Eurasian Crag-Martin
-Pucrasia macrolopha_Koklass Pheasant
-Puffinus bailloni_Tropical Shearwater
-Puffinus nativitatis_Christmas Shearwater
-Puffinus newelli_Newell's Shearwater
-Puffinus puffinus_Manx Shearwater
-Pulsatrix koeniswaldiana_Tawny-browed Owl
-Pulsatrix melanota_Band-bellied Owl
-Pulsatrix perspicillata_Spectacled Owl
+Ptiloxena atroviolacea_Läikturpial
+Ptyonoprogne concolor_Tume-kivipääsuke
+Ptyonoprogne fuligula_Aafrika kivipääsuke
+Ptyonoprogne rupestris_Kivipääsuke
+Pucrasia macrolopha_Tuttfaasan
+Puffinus bailloni_Mustselg-tormilind
+Puffinus nativitatis_Polüneesia tormilind
+Puffinus newelli_Kauai tormilind
+Puffinus puffinus_Põhja-tormilind
+Pulsatrix koeniswaldiana_Väike-prillkakk
+Pulsatrix melanota_Vööt-prillkakk
+Pulsatrix perspicillata_Suur-prillkakk
 Purnella albifrons_White-fronted Honeyeater
-Purpureicephalus spurius_Red-capped Parrot
-Pycnonotus aurigaster_Sooty-headed Bulbul
-Pycnonotus barbatus_Common Bulbul
-Pycnonotus brunneus_Red-eyed Bulbul
-Pycnonotus cafer_Red-vented Bulbul
-Pycnonotus capensis_Cape Bulbul
+Purpureicephalus spurius_Marripapagoi
+Pycnonotus aurigaster_Ida-salubülbül
+Pycnonotus barbatus_Aedbülbül
+Pycnonotus brunneus_Punasilm-bülbül
+Pycnonotus cafer_Salubülbül
+Pycnonotus capensis_Sõõrsilm-bülbül
 Pycnonotus conradi_Streak-eared Bulbul
-Pycnonotus finlaysoni_Stripe-throated Bulbul
-Pycnonotus flavescens_Flavescent Bulbul
-Pycnonotus goiavier_Yellow-vented Bulbul
-Pycnonotus jocosus_Red-whiskered Bulbul
-Pycnonotus leucogenys_Himalayan Bulbul
-Pycnonotus leucotis_White-eared Bulbul
-Pycnonotus luteolus_White-browed Bulbul
-Pycnonotus nigricans_Black-fronted Bulbul
-Pycnonotus plumosus_Olive-winged Bulbul
-Pycnonotus simplex_Cream-vented Bulbul
-Pycnonotus sinensis_Light-vented Bulbul
-Pycnonotus striatus_Striated Bulbul
-Pycnonotus taivanus_Styan's Bulbul
-Pycnonotus xantholaemus_Yellow-throated Bulbul
-Pycnonotus xanthopygos_White-spectacled Bulbul
-Pycnonotus xanthorrhous_Brown-breasted Bulbul
-Pycnonotus zeylanicus_Straw-headed Bulbul
+Pycnonotus finlaysoni_Kriimpea-bülbül
+Pycnonotus flavescens_Nõlvabülbül
+Pycnonotus goiavier_Valgekulm-bülbül
+Pycnonotus jocosus_Punapõsk-bülbül
+Pycnonotus leucogenys_Himaalaja bülbül
+Pycnonotus leucotis_Valgepõsk-bülbül
+Pycnonotus luteolus_Leetkulm-bülbül
+Pycnonotus nigricans_Prill-bülbül
+Pycnonotus plumosus_Khakibülbül
+Pycnonotus simplex_Valgesilm-bülbül
+Pycnonotus sinensis_Hiina bülbül
+Pycnonotus striatus_Triipbülbül
+Pycnonotus taivanus_Taivani bülbül
+Pycnonotus xantholaemus_Rahnubülbül
+Pycnonotus xanthopygos_Araabia bülbül
+Pycnonotus xanthorrhous_Pruunpõsk-bülbül
+Pycnonotus zeylanicus_Suurbülbül
 Pycnoptilus floccosus_Pilotbird
 Pygarrhichas albogularis_White-throated Treerunner
 Pygiptila stellaris_Spot-winged Antshrike
-Pygochelidon cyanoleuca_Blue-and-white Swallow
-Pygoscelis adeliae_Adelie Penguin
-Pygoscelis antarcticus_Chinstrap Penguin
-Pygoscelis papua_Gentoo Penguin
+Pygochelidon cyanoleuca_Lõuna-mägipääsuke
+Pygoscelis adeliae_Adeelia pingviin
+Pygoscelis antarcticus_Valjaspingviin
+Pygoscelis papua_Eeselpingviin
 Pyriglena atra_Fringe-backed Fire-eye
 Pyriglena leuconota_East Amazonian Fire-eye
 Pyriglena leucoptera_White-shouldered Fire-eye
 Pyriglena maura_Western Fire-eye
-Pyrilia barrabandi_Orange-cheeked Parrot
-Pyrilia caica_Caica Parrot
-Pyrilia haematotis_Brown-hooded Parrot
-Pyrilia pulchra_Rose-faced Parrot
-Pyrilia pyrilia_Saffron-headed Parrot
-Pyrocephalus rubinus_Vermilion Flycatcher
-Pyroderus scutatus_Red-ruffed Fruitcrow
+Pyrilia barrabandi_Kuldpõsk-selvapapagoi
+Pyrilia caica_Karbus-selvapapagoi
+Pyrilia haematotis_Valjas-selvapapagoi
+Pyrilia pulchra_Roosapõsk-selvapapagoi
+Pyrilia pyrilia_Prill-selvapapagoi
+Pyrocephalus rubinus_Rubiintikat
+Pyroderus scutatus_Leekpugu-kotinga
 Pyrope pyrope_Fire-eyed Diucon
-Pyrrhocorax graculus_Yellow-billed Chough
-Pyrrhocorax pyrrhocorax_Red-billed Chough
+Pyrrhocorax graculus_Mägihakk
+Pyrrhocorax pyrrhocorax_Kaljuhakk
 Pyrrholaemus brunneus_Redthroat
 Pyrrholaemus sagittatus_Speckled Warbler
 Pyrrhomyias cinnamomeus_Cinnamon Flycatcher
-Pyrrhula erythaca_Gray-headed Bullfinch
-Pyrrhula nipalensis_Brown Bullfinch
+Pyrrhula erythaca_Hiina leevike
+Pyrrhula nipalensis_Hall-leevike
 Pyrrhula pyrrhula_Leevike
-Pyrrhura albipectus_White-necked Parakeet
+Pyrrhura albipectus_Valgekael-võrkpapagoi
 Pyrrhura amazonum_Santarem Parakeet
-Pyrrhura calliptera_Brown-breasted Parakeet
-Pyrrhura cruentata_Ochre-marked Parakeet
-Pyrrhura frontalis_Maroon-bellied Parakeet
-Pyrrhura hoematotis_Red-eared Parakeet
-Pyrrhura hoffmanni_Sulphur-winged Parakeet
-Pyrrhura leucotis_Maroon-faced Parakeet
-Pyrrhura melanura_Maroon-tailed Parakeet
-Pyrrhura molinae_Green-cheeked Parakeet
-Pyrrhura orcesi_El Oro Parakeet
-Pyrrhura perlata_Crimson-bellied Parakeet
-Pyrrhura picta_Painted Parakeet
-Pyrrhura rhodocephala_Rose-headed Parakeet
+Pyrrhura calliptera_Mägi-võrkpapagoi
+Pyrrhura cruentata_Sinipugu-võrkpapagoi
+Pyrrhura frontalis_Araukaaria-võrkpapagoi
+Pyrrhura hoematotis_Venetsueela võrkpapagoi
+Pyrrhura hoffmanni_Kostariika võrkpapagoi
+Pyrrhura leucotis_Ruskepõsk-võrkpapagoi
+Pyrrhura melanura_Pruunhänd-võrkpapagoi
+Pyrrhura molinae_Rohepõsk-võrkpapagoi
+Pyrrhura orcesi_Punalaup-võrkpapagoi
+Pyrrhura perlata_Punakõht-võrkpapagoi
+Pyrrhura picta_Selva-võrkpapagoi
+Pyrrhura rhodocephala_Punapea-võrkpapagoi
 Pyrrhura roseifrons_Rose-fronted Parakeet
-Pyrrhura rupicola_Black-capped Parakeet
-Pyrrhura viridicata_Santa Marta Parakeet
-Pytilia melba_Green-winged Pytilia
-Quelea quelea_Red-billed Quelea
-Querula purpurata_Purple-throated Fruitcrow
-Quiscalus lugubris_Carib Grackle
-Quiscalus major_Boat-tailed Grackle
-Quiscalus mexicanus_Great-tailed Grackle
-Quiscalus nicaraguensis_Nicaraguan Grackle
-Quiscalus niger_Greater Antillean Grackle
-Quiscalus quiscula_Common Grackle
-Radjah radjah_Radjah Shelduck
-Rallina eurizonoides_Slaty-legged Crake
-Rallina fasciata_Red-legged Crake
-Rallina tricolor_Red-necked Crake
-Rallus antarcticus_Austral Rail
+Pyrrhura rupicola_Tumekiird-võrkpapagoi
+Pyrrhura viridicata_Santamarta võrkpapagoi
+Pytilia melba_Rohetiib-amadiin
+Quelea quelea_Vilja-kangurlind
+Querula purpurata_Ühiskotinga
+Quiscalus lugubris_Väike-händturpial
+Quiscalus major_Padura-händturpial
+Quiscalus mexicanus_Suur-händturpial
+Quiscalus nicaraguensis_Nikaraagua händturpial
+Quiscalus niger_Antilli händturpial
+Quiscalus quiscula_Händturpial
+Radjah radjah_Valge-ristpart
+Rallina eurizonoides_Vööt-metsruik
+Rallina fasciata_Punajalg-metsruik
+Rallina tricolor_Tõmmu-metsruik
+Rallus antarcticus_Patagoonia ruik
 Rallus aquaticus_Rooruik
-Rallus caerulescens_African Rail
-Rallus crepitans_Clapper Rail
-Rallus elegans_King Rail
+Rallus caerulescens_Aafrika rooruik
+Rallus crepitans_Klaperruik
+Rallus elegans_Suur-klaperruik
 Rallus indicus_Brown-cheeked Rail
-Rallus limicola_Virginia Rail
-Rallus longirostris_Mangrove Rail
-Rallus obsoletus_Ridgway's Rail
-Rallus semiplumbeus_Bogota Rail
-Rallus tenuirostris_Aztec Rail
-Ramphastos ambiguus_Yellow-throated Toucan
-Ramphastos brevis_Choco Toucan
-Ramphastos dicolorus_Red-breasted Toucan
-Ramphastos sulfuratus_Keel-billed Toucan
-Ramphastos toco_Toco Toucan
-Ramphastos tucanus_White-throated Toucan
-Ramphastos vitellinus_Channel-billed Toucan
-Ramphocaenus melanurus_Long-billed Gnatwren
+Rallus limicola_Paduruik
+Rallus longirostris_Klaperruik
+Rallus obsoletus_Kalifornia ruik
+Rallus semiplumbeus_Mägiruik
+Rallus tenuirostris_Asteegi ruik
+Ramphastos ambiguus_Kilatuukan
+Ramphastos brevis_Rannikutuukan
+Ramphastos dicolorus_Brasiilia tuukan
+Ramphastos sulfuratus_Vääveltuukan
+Ramphastos toco_Tokotuukan
+Ramphastos tucanus_Manisktuukan
+Ramphastos vitellinus_Mustnokk-tuukan
+Ramphocaenus melanurus_Pikknokk-händkäblik
 Ramphocaenus sticturus_Chattering Gnatwren
-Ramphocelus bresilius_Brazilian Tanager
-Ramphocelus carbo_Silver-beaked Tanager
-Ramphocelus dimidiatus_Crimson-backed Tanager
-Ramphocelus flammigerus_Flame-rumped Tanager
-Ramphocelus melanogaster_Black-bellied Tanager
-Ramphocelus nigrogularis_Masked Crimson Tanager
-Ramphocelus passerinii_Scarlet-rumped Tanager
-Ramphocelus sanguinolentus_Crimson-collared Tanager
-Ramphodon naevius_Saw-billed Hermit
-Ramphomicron microrhynchum_Purple-backed Thornbill
-Ramphotrigon flammulatum_Flammulated Flycatcher
-Ramphotrigon fuscicauda_Dusky-tailed Flatbill
-Ramphotrigon megacephalum_Large-headed Flatbill
-Ramphotrigon ruficauda_Rufous-tailed Flatbill
+Ramphocelus bresilius_Soo-karmiinsirk
+Ramphocelus carbo_Tõmmu-karmiinsirk
+Ramphocelus dimidiatus_Aed-karmiinsirk
+Ramphocelus flammigerus_Tuliselg-sirk
+Ramphocelus melanogaster_Ketšua karmiinsirk
+Ramphocelus nigrogularis_Jõgi-karmiinsirk
+Ramphocelus passerinii_Punaselg-sirk
+Ramphocelus sanguinolentus_Kaelus-karmiinsirk
+Ramphodon naevius_Saagnokk-selvakoolibri
+Ramphomicron microrhynchum_Lühinokk-koolibri
+Ramphotrigon flammulatum_Mehhiko oliivtikat
+Ramphotrigon fuscicauda_Välu-oliivtikat
+Ramphotrigon megacephalum_Bambuse-oliivtikat
+Ramphotrigon ruficauda_Punasaba-oliivtikat
 Ramsayornis modestus_Brown-backed Honeyeater
 Rauenia bonariensis_Blue-and-yellow Tanager
-Recurvirostra americana_American Avocet
-Recurvirostra andina_Andean Avocet
-Recurvirostra avosetta_Pied Avocet
-Regulus goodfellowi_Flamecrest
-Regulus ignicapilla_Common Firecrest
-Regulus madeirensis_Madeira Firecrest
+Recurvirostra americana_Preeria-naaskelnokk
+Recurvirostra andina_Andi naaskelnokk
+Recurvirostra avosetta_Naaskelnokk
+Regulus goodfellowi_Taivani pöialpoiss
+Regulus ignicapilla_Lääne-pöialpoiss
+Regulus madeirensis_Madeira pöialpoiss
 Regulus regulus_Pöialpoiss
-Regulus satrapa_Golden-crowned Kinglet
-Reinwardtipicus validus_Orange-backed Woodpecker
-Reinwardtoena reinwardti_Great Cuckoo-Dove
-Remiz consobrinus_Chinese Penduline-Tit
-Remiz coronatus_White-crowned Penduline-Tit
-Remiz pendulinus_Eurasian Penduline-Tit
-Rhabdotorrhinus corrugatus_Wrinkled Hornbill
-Rhabdotorrhinus exarhatus_Sulawesi Hornbill
-Rhaphidura leucopygialis_Silver-rumped Needletail
-Rhea americana_Greater Rhea
+Regulus satrapa_Tsuuga-pöialpoiss
+Reinwardtipicus validus_Ruugerähn
+Reinwardtoena reinwardti_Händ-haraktuvi
+Remiz consobrinus_Hiina kukkurtihane
+Remiz coronatus_Papli-kukkurtihane
+Remiz pendulinus_Kukkurtihane
+Rhabdotorrhinus corrugatus_Kiber-sarvlind
+Rhabdotorrhinus exarhatus_Koldpõsk-sarvlind
+Rhaphidura leucopygialis_Väike-kammsaba
+Rhea americana_Nandu
 Rhegmatorhina cristata_Chestnut-crested Antbird
 Rhegmatorhina gymnops_Bare-eyed Antbird
 Rhegmatorhina hoffmannsi_White-breasted Antbird
 Rhegmatorhina melanosticta_Hairy-crested Antbird
 Rhinocrypta lanceolata_Crested Gallito
-Rhinopomastus cyanomelas_Common Scimitarbill
-Rhinortha chlorophaea_Raffles's Malkoha
-Rhipidura albicollis_White-throated Fantail
-Rhipidura albiscapa_Gray Fantail
-Rhipidura albogularis_Spot-breasted Fantail
-Rhipidura albolimbata_Friendly Fantail
-Rhipidura atra_Black Fantail
-Rhipidura aureola_White-browed Fantail
-Rhipidura brachyrhyncha_Dimorphic Fantail
-Rhipidura cyaniceps_Blue-headed Fantail
-Rhipidura dryas_Arafura Fantail
-Rhipidura fuliginosa_New Zealand Fantail
-Rhipidura javanica_Malaysian Pied-Fantail
-Rhipidura leucophrys_Willie-wagtail
-Rhipidura leucothorax_White-bellied Thicket-Fantail
-Rhipidura maculipectus_Black Thicket-Fantail
-Rhipidura nigritorquis_Philippine Pied-Fantail
-Rhipidura perlata_Spotted Fantail
-Rhipidura rufifrons_Rufous Fantail
-Rhipidura rufiventris_Northern Fantail
-Rhipidura teysmanni_Sulawesi Fantail
-Rhipidura threnothorax_Sooty Thicket-Fantail
-Rhipidura verreauxi_Streaked Fantail
+Rhinopomastus cyanomelas_Suur-saabelnokk
+Rhinortha chlorophaea_Ruske-malkohakägu
+Rhipidura albicollis_Nõgi-lehviksaba
+Rhipidura albiscapa_Hall-lehviksaba
+Rhipidura albogularis_Dekkani lehviksaba
+Rhipidura albolimbata_Mägi-lehviksaba
+Rhipidura atra_Must-lehviksaba
+Rhipidura aureola_Valgekulm-lehviksaba
+Rhipidura brachyrhyncha_Eris-lehviksaba
+Rhipidura cyaniceps_Sinipea-lehviksaba
+Rhipidura dryas_Arafura lehviksaba
+Rhipidura fuliginosa_Maoori lehviksaba
+Rhipidura javanica_Pugal-lehviksaba
+Rhipidura leucophrys_Västrik-lehviksaba
+Rhipidura leucothorax_Võsa-lehviksaba
+Rhipidura maculipectus_Valjas-lehviksaba
+Rhipidura nigritorquis_Tuhkselg-lehviksaba
+Rhipidura perlata_Tähnik-lehviksaba
+Rhipidura rufifrons_Punalaup-lehviksaba
+Rhipidura rufiventris_Välu-lehviksaba
+Rhipidura teysmanni_Sulawesi lehviksaba
+Rhipidura threnothorax_Helmes-lehviksaba
+Rhipidura verreauxi_Melaneesia lehviksaba
 Rhodinocichla rosea_Rosy Thrush-Tanager
-Rhodophoneus cruentus_Rosy-patched Bushshrike
+Rhodophoneus cruentus_Karmiinlaik-pagulind
 Rhodospingus cruentus_Crimson-breasted Finch
-Rhodospiza obsoleta_Desert Finch
-Rhodostethia rosea_Ross's Gull
+Rhodospiza obsoleta_Oaasileevike
+Rhodostethia rosea_Roosakajakas
 Rhodothraupis celaeno_Crimson-collared Grosbeak
 Rhopias gularis_Star-throated Antwren
 Rhopophilus pekinensis_Beijing Babbler
@@ -5306,41 +5306,41 @@ Rhopospina caerulescens_Blue Finch
 Rhopospina fruticeti_Mourning Sierra Finch
 Rhynchocyclus brevirostris_Eye-ringed Flatbill
 Rhynchocyclus olivaceus_Olivaceous Flatbill
-Rhynchophanes mccownii_Thick-billed Longspur
-Rhynchopsitta pachyrhyncha_Thick-billed Parrot
-Rhynchopsitta terrisi_Maroon-fronted Parrot
-Rhynchortyx cinctus_Tawny-faced Quail
-Rhynchospiza stolzmanni_Tumbes Sparrow
-Rhynchospiza strigiceps_Chaco Sparrow
-Rhynchotus rufescens_Red-winged Tinamou
+Rhynchophanes mccownii_Preeriatsiitsitaja
+Rhynchopsitta pachyrhyncha_Männipapagoi
+Rhynchopsitta terrisi_Ida-männipapagoi
+Rhynchortyx cinctus_Roostepõsk-vutt
+Rhynchospiza stolzmanni_Tumbese sidrik
+Rhynchospiza strigiceps_Argentiina sidrik
+Rhynchotus rufescens_Pampatinamu
 Rhynochetos jubatus_Kagu
-Rhyticeros cassidix_Knobbed Hornbill
-Rhyticeros plicatus_Blyth's Hornbill
-Rhyticeros undulatus_Wreathed Hornbill
-Rhytipterna holerythra_Rufous Mourner
-Rhytipterna immunda_Pale-bellied Mourner
-Rhytipterna simplex_Grayish Mourner
-Riparia chinensis_Gray-throated Martin
-Riparia diluta_Pale Sand Martin
-Riparia paludicola_Plain Martin
+Rhyticeros cassidix_Sinilott-sarvlind
+Rhyticeros plicatus_Paapua sarvlind
+Rhyticeros undulatus_Vagunokk-sarvlind
+Rhytipterna holerythra_Põhja-kaneeltikat
+Rhytipterna immunda_Kahk-kaneeltikat
+Rhytipterna simplex_Hall-kaneeltikat
+Riparia chinensis_Kagu-kaldapääsuke
+Riparia diluta_Leet-kaldapääsuke
+Riparia paludicola_Väike-kaldapääsuke
 Riparia riparia_Kaldapääsuke
-Rissa tridactyla_Black-legged Kittiwake
-Rollulus rouloul_Crested Partridge
+Rissa tridactyla_Kaljukajakas
+Rollulus rouloul_Tanukana
 Roraimia adusta_Roraiman Barbtail
-Rostratula benghalensis_Greater Painted-Snipe
-Rostrhamus sociabilis_Snail Kite
+Rostratula benghalensis_Prillnerp
+Rostrhamus sociabilis_Teohaugas
 Rubigula erythropthalmos_Spectacled Bulbul
-Rubigula flaviventris_Black-crested Bulbul
-Rubigula gularis_Flame-throated Bulbul
-Rupicola peruvianus_Andean Cock-of-the-rock
-Rupicola rupicola_Guianan Cock-of-the-rock
-Rupornis magnirostris_Roadside Hawk
-Rynchops niger_Black Skimmer
+Rubigula flaviventris_Tutt-pihobülbül
+Rubigula gularis_Ghati pihobülbül
+Rupicola peruvianus_Andi kaljukukes
+Rupicola rupicola_Guajaana kaljukukes
+Rupornis magnirostris_Väikeviu
+Rynchops niger_Ameerika käärnokk
 Sakesphorus canadensis_Black-crested Antshrike
 Sakesphorus cristatus_Silvery-cheeked Antshrike
 Sakesphorus luctuosus_Glossy Antshrike
-Salpinctes obsoletus_Rock Wren
-Salpornis salvadori_African Spotted Creeper
+Salpinctes obsoletus_Kaljukäblik
+Salpornis salvadori_Aafrika tähnikporr
 Saltator albicollis_Lesser Antillean Saltator
 Saltator atriceps_Black-headed Saltator
 Saltator atripennis_Black-winged Saltator
@@ -5360,33 +5360,33 @@ Saltator striatipectus_Streaked Saltator
 Saltatricula atricollis_Black-throated Saltator
 Saltatricula multicolor_Many-colored Chaco Finch
 Sapayoa aenigma_Sapayoa
-Sappho sparganurus_Red-tailed Comet
-Sarcops calvus_Coleto
-Sarothrura elegans_Buff-spotted Flufftail
-Sarothrura insularis_Madagascar Flufftail
-Sarothrura pulchra_White-spotted Flufftail
-Sarothrura rufa_Red-chested Flufftail
-Sasia abnormis_Rufous Piculet
-Sasia ochracea_White-browed Piculet
-Saucerottia beryllina_Berylline Hummingbird
-Saucerottia cyanocephala_Azure-crowned Hummingbird
-Saucerottia tobaci_Copper-rumped Hummingbird
-Saundersilarus saundersi_Saunders's Gull
-Saxicola caprata_Pied Bushchat
-Saxicola ferreus_Gray Bushchat
-Saxicola maurus_Siberian Stonechat
+Sappho sparganurus_Tiigerkoolibri
+Sarcops calvus_Kiilasmaina
+Sarothrura elegans_Võsapirk
+Sarothrura insularis_Madagaskari pirk
+Sarothrura pulchra_Täpikpirk
+Sarothrura rufa_Padupirk
+Sasia abnormis_Püharähnak
+Sasia ochracea_Rebasrähnak
+Saucerottia beryllina_Tamme-arukoolibri
+Saucerottia cyanocephala_Männi-arukoolibri
+Saucerottia tobaci_Venetsueela arukoolibri
+Saundersilarus saundersi_Hiina kajakas
+Saxicola caprata_Nõgitäks
+Saxicola ferreus_Valgekulm-täks
+Saxicola maurus_Niidu-kaelustäks
 Saxicola rubetra_Kadakatäks
-Saxicola rubicola_European Stonechat
-Saxicola stejnegeri_Amur Stonechat
-Saxicola torquatus_African Stonechat
-Sayornis nigricans_Black Phoebe
-Sayornis phoebe_Eastern Phoebe
-Sayornis saya_Say's Phoebe
+Saxicola rubicola_Euroopa kaelustäks
+Saxicola stejnegeri_Ida-kaelustäks
+Saxicola torquatus_Kaelustäks
+Sayornis nigricans_Must-ojatikat
+Sayornis phoebe_Salu-ojatikat
+Sayornis saya_Kõnnu-ojatikat
 Scaphiopus couchii_Couch's Spadefoot
 Scelorchilus albicollis_White-throated Tapaculo
 Scelorchilus rubecula_Chucao Tapaculo
-Scenopoeetes dentirostris_Tooth-billed Bowerbird
-Schetba rufa_Rufous Vanga
+Scenopoeetes dentirostris_Kidanokk-lehtlalind
+Schetba rufa_Ruskevanga
 Schiffornis aenea_Foothill Schiffornis
 Schiffornis major_Varzea Schiffornis
 Schiffornis olivacea_Olivaceous Schiffornis
@@ -5394,11 +5394,11 @@ Schiffornis stenorhyncha_Russet-winged Schiffornis
 Schiffornis turdina_Brown-winged Schiffornis
 Schiffornis veraepacis_Northern Schiffornis
 Schiffornis virescens_Greenish Schiffornis
-Schistes geoffroyi_Geoffroy's Daggerbill
+Schistes geoffroyi_Kiilnokk-ametüstkoolibri
 Schistochlamys melanopis_Black-faced Tanager
 Schistochlamys ruficapillus_Cinnamon Tanager
-Schoenicola platyurus_Broad-tailed Grassbird
-Schoenicola striatus_Bristled Grassbird
+Schoenicola platyurus_Ghati padulind
+Schoenicola striatus_India padulind
 Schoeniophylax phryganophilus_Chotoy Spinetail
 Schoeniparus brunneus_Dusky Fulvetta
 Schoeniparus castaneceps_Rufous-winged Fulvetta
@@ -5409,10 +5409,10 @@ Sciaphylax castanea_Zimmer's Antbird
 Sciaphylax hemimelaena_Chestnut-tailed Antbird
 Sciurus carolinensis_Eastern Gray Squirrel
 Sclateria naevia_Silvered Antbird
-Scleroptila afra_Gray-winged Francolin
-Scleroptila gutturalis_Orange River Francolin
-Scleroptila levaillantii_Red-winged Francolin
-Scleroptila shelleyi_Shelley's Francolin
+Scleroptila afra_Lõunafrankoliin
+Scleroptila gutturalis_Valgekurk-frankoliin
+Scleroptila levaillantii_Orufrankoliin
+Scleroptila shelleyi_Välufrankoliin
 Sclerurus albigularis_Gray-throated Leaftosser
 Sclerurus caudacutus_Black-tailed Leaftosser
 Sclerurus guatemalensis_Scaly-throated Leaftosser
@@ -5420,11 +5420,11 @@ Sclerurus mexicanus_Middle American Leaftosser
 Sclerurus obscurior_South American Leaftosser
 Sclerurus rufigularis_Short-billed Leaftosser
 Sclerurus scansor_Rufous-breasted Leaftosser
-Scolopax bukidnonensis_Bukidnon Woodcock
-Scolopax minor_American Woodcock
+Scolopax bukidnonensis_Filipiini kurvits
+Scolopax minor_Ameerika kurvits
 Scolopax rusticola_Metskurvits
-Scopus umbretta_Hamerkop
-Scotocerca inquieta_Scrub Warbler
+Scopus umbretta_Vasarpea
+Scotocerca inquieta_Kõrbe-rädilind
 Scudderia curvicauda_Curve-tailed Bush Katydid
 Scudderia furcata_Fork-tailed Bush Katydid
 Scudderia texensis_Texas Bush Katydid
@@ -5472,78 +5472,78 @@ Scytalopus unicolor_Unicolored Tapaculo
 Scytalopus urubambae_Vilcabamba Tapaculo
 Scytalopus vicinior_Nariño Tapaculo
 Scytalopus zimmeri_Zimmer's Tapaculo
-Scythrops novaehollandiae_Channel-billed Cuckoo
-Seiurus aurocapilla_Ovenbird
-Selasphorus calliope_Calliope Hummingbird
-Selasphorus ellioti_Wine-throated Hummingbird
-Selasphorus heloisa_Bumblebee Hummingbird
-Selasphorus platycercus_Broad-tailed Hummingbird
-Selasphorus rufus_Rufous Hummingbird
-Selasphorus sasin_Allen's Hummingbird
-Selenidera gouldii_Gould's Toucanet
-Selenidera maculirostris_Spot-billed Toucanet
-Selenidera piperivora_Guianan Toucanet
-Selenidera reinwardtii_Golden-collared Toucanet
-Selenidera spectabilis_Yellow-eared Toucanet
-Seleucidis melanoleucus_Twelve-wired Bird-of-Paradise
-Semioptera wallacii_Standardwing Bird-of-Paradise
-Semnornis frantzii_Prong-billed Barbet
-Semnornis ramphastinus_Toucan Barbet
-Sephanoides sephaniodes_Green-backed Firecrown
+Scythrops novaehollandiae_Hiidnokk-kägu
+Seiurus aurocapilla_Maasäälik
+Selasphorus calliope_Habekoolibri
+Selasphorus ellioti_Maia väikekoolibri
+Selasphorus heloisa_Asteegi väikekoolibri
+Selasphorus platycercus_Palukoolibri
+Selasphorus rufus_Rebaskoolibri
+Selasphorus sasin_Kalifornia koolibri
+Selenidera gouldii_Laiknokk-tuukan
+Selenidera maculirostris_Vöötnokk-tuukan
+Selenidera piperivora_Pipratuukan
+Selenidera reinwardtii_Selvatuukan
+Selenidera spectabilis_Koldkõrv-tuukan
+Seleucidis melanoleucus_Puhv-paradiisilind
+Semioptera wallacii_Paeltiib-paradiisilind
+Semnornis frantzii_Ruuge-lõhisnokk
+Semnornis ramphastinus_Viker-lõhisnokk
+Sephanoides sephaniodes_Tšiili koolibri
 Sericornis citreogularis_Yellow-throated Scrubwren
 Sericornis frontalis_White-browed Scrubwren
 Sericornis humilis_Tasmanian Scrubwren
 Sericornis magnirostra_Large-billed Scrubwren
 Sericornis papuensis_Papuan Scrubwren
 Sericossypha albocristata_White-capped Tanager
-Serilophus lunatus_Silver-breasted Broadbill
-Serinus alario_Black-headed Canary
-Serinus canaria_Island Canary
-Serinus canicollis_Cape Canary
-Serinus flavivertex_Yellow-crowned Canary
-Serinus pusillus_Fire-fronted Serin
-Serinus serinus_European Serin
-Serpophaga cinerea_Torrent Tyrannulet
+Serilophus lunatus_Hõbe-lainokk
+Serinus alario_Ruskevint
+Serinus canaria_Kanaari koldvint
+Serinus canicollis_Aed-koldvint
+Serinus flavivertex_Päikese-koldvint
+Serinus pusillus_Tulipea-koldvint
+Serinus serinus_Koldvint
+Serpophaga cinerea_Kärestikutikat
 Serpophaga griseicapilla_Straneck's Tyrannulet
-Serpophaga hypoleuca_River Tyrannulet
+Serpophaga hypoleuca_Lammitikat
 Serpophaga munda_White-bellied Tyrannulet
-Serpophaga nigricans_Sooty Tyrannulet
-Serpophaga subcristata_White-crested Tyrannulet
-Setopagis parvula_Little Nightjar
-Setophaga adelaidae_Adelaide's Warbler
-Setophaga americana_Northern Parula
-Setophaga caerulescens_Black-throated Blue Warbler
-Setophaga castanea_Bay-breasted Warbler
-Setophaga cerulea_Cerulean Warbler
-Setophaga chrysoparia_Golden-cheeked Warbler
-Setophaga citrina_Hooded Warbler
-Setophaga coronata_Yellow-rumped Warbler
-Setophaga discolor_Prairie Warbler
-Setophaga dominica_Yellow-throated Warbler
-Setophaga fusca_Blackburnian Warbler
-Setophaga graciae_Grace's Warbler
-Setophaga kirtlandii_Kirtland's Warbler
-Setophaga magnolia_Magnolia Warbler
-Setophaga nigrescens_Black-throated Gray Warbler
-Setophaga occidentalis_Hermit Warbler
-Setophaga palmarum_Palm Warbler
-Setophaga pensylvanica_Chestnut-sided Warbler
-Setophaga petechia_Yellow Warbler
-Setophaga pinus_Pine Warbler
-Setophaga pitiayumi_Tropical Parula
-Setophaga pityophila_Olive-capped Warbler
-Setophaga ruticilla_American Redstart
-Setophaga striata_Blackpoll Warbler
-Setophaga tigrina_Cape May Warbler
-Setophaga townsendi_Townsend's Warbler
-Setophaga virens_Black-throated Green Warbler
-Sheppardia gunningi_East Coast Akalat
-Sheppardia sharpei_Sharpe's Akalat
-Sholicola albiventris_White-bellied Sholakili
-Sholicola major_Nilgiri Sholakili
-Sialia currucoides_Mountain Bluebird
-Sialia mexicana_Western Bluebird
-Sialia sialis_Eastern Bluebird
+Serpophaga nigricans_Kaldatikat
+Serpophaga subcristata_Virvakiird-tikat
+Setopagis parvula_Väike-öösorr
+Setophaga adelaidae_Antilli säälik
+Setophaga americana_Samblikusäälik
+Setophaga caerulescens_Sinisäälik
+Setophaga castanea_Ruskesäälik
+Setophaga cerulea_Lasuursäälik
+Setophaga chrysoparia_Kadakasäälik
+Setophaga citrina_Karbussäälik
+Setophaga coronata_Metssäälik
+Setophaga discolor_Põõsasäälik
+Setophaga dominica_Kuldkurk-säälik
+Setophaga fusca_Tulikurk-säälik
+Setophaga graciae_Asteegi säälik
+Setophaga kirtlandii_Michigani säälik
+Setophaga magnolia_Tsuugasäälik
+Setophaga nigrescens_Võsasäälik
+Setophaga occidentalis_Laanesäälik
+Setophaga palmarum_Rabasäälik
+Setophaga pensylvanica_Ruskkülg-säälik
+Setophaga petechia_Koldsäälik
+Setophaga pinus_Männisäälik
+Setophaga pitiayumi_Bromeeliasäälik
+Setophaga pityophila_Manisksäälik
+Setophaga ruticilla_Punasaba-säälik
+Setophaga striata_Põhjasäälik
+Setophaga tigrina_Kuusesäälik
+Setophaga townsendi_Nulusäälik
+Setophaga virens_Mustkurk-säälik
+Sheppardia gunningi_Häilu-ruugerind
+Sheppardia sharpei_Sooviku-ruugerind
+Sholicola albiventris_Cardamomi koobaltööbik
+Sholicola major_Nilgiri koobaltööbik
+Sialia currucoides_Mägi-sinilind
+Sialia mexicana_Lääne-sinilind
+Sialia sialis_Ida-sinilind
 Sicalis auriventris_Greater Yellow-Finch
 Sicalis citrina_Stripe-tailed Yellow-Finch
 Sicalis flaveola_Saffron Finch
@@ -5552,100 +5552,100 @@ Sicalis luteocephala_Citron-headed Yellow-Finch
 Sicalis luteola_Grassland Yellow-Finch
 Sicalis olivascens_Greenish Yellow-Finch
 Sicalis uropygialis_Bright-rumped Yellow-Finch
-Sinosuthora webbiana_Vinous-throated Parrotbill
-Siphonorhis brewsteri_Least Pauraque
+Sinosuthora webbiana_Salu-koonusnokk
+Siphonorhis brewsteri_Võseriku-öösorr
 Sipia berlepschi_Stub-tailed Antbird
 Sipia laemosticta_Dull-mantled Antbird
 Sipia nigricauda_Esmeraldas Antbird
 Sipia palliata_Magdalena Antbird
 Siren_Siren
-Sirystes albocinereus_White-rumped Sirystes
-Sirystes albogriseus_Choco Sirystes
-Sirystes sibilator_Sibilant Sirystes
-Sitta canadensis_Red-breasted Nuthatch
-Sitta carolinensis_White-breasted Nuthatch
-Sitta cinnamoventris_Chestnut-bellied Nuthatch
+Sirystes albocinereus_Valgekõht-viletikat
+Sirystes albogriseus_Hele-viletikat
+Sirystes sibilator_Brasiilia viletikat
+Sitta canadensis_Valgekulm-puukoristaja
+Sitta carolinensis_Valgepõsk-puukoristaja
+Sitta cinnamoventris_Ruske-puukoristaja
 Sitta europaea_Puukoristaja
-Sitta frontalis_Velvet-fronted Nuthatch
-Sitta himalayensis_White-tailed Nuthatch
-Sitta krueperi_Krüper's Nuthatch
-Sitta magna_Giant Nuthatch
-Sitta nagaensis_Chestnut-vented Nuthatch
-Sitta neumayer_Western Rock Nuthatch
-Sitta pusilla_Brown-headed Nuthatch
-Sitta pygmaea_Pygmy Nuthatch
-Sitta tephronota_Eastern Rock Nuthatch
-Sitta villosa_Snowy-browed Nuthatch
-Sitta whiteheadi_Corsican Nuthatch
-Sitta yunnanensis_Yunnan Nuthatch
+Sitta frontalis_Punanokk-puukoristaja
+Sitta himalayensis_Himaalaja puukoristaja
+Sitta krueperi_Punapugu-puukoristaja
+Sitta magna_Suur-puukoristaja
+Sitta nagaensis_Kagu-puukoristaja
+Sitta neumayer_Kalju-puukoristaja
+Sitta pusilla_Pisi-puukoristaja
+Sitta pygmaea_Kääbus-puukoristaja
+Sitta tephronota_Mägi-puukoristaja
+Sitta villosa_Hiina puukoristaja
+Sitta whiteheadi_Korsika puukoristaja
+Sitta yunnanensis_Yunnani puukoristaja
 Sittasomus griseicapillus_Olivaceous Woodcreeper
-Sittiparus castaneoventris_Chestnut-bellied Tit
-Sittiparus owstoni_Owston's Tit
-Sittiparus varius_Varied Tit
+Sittiparus castaneoventris_Taivani tihane
+Sittiparus owstoni_Izu tihane
+Sittiparus varius_Õnnetihane
 Smicrornis brevirostris_Weebill
-Smithornis capensis_African Broadbill
-Smithornis rufolateralis_Rufous-sided Broadbill
-Snowornis subalaris_Gray-tailed Piha
-Somateria mollissima_Common Eider
-Somateria spectabilis_King Eider
+Smithornis capensis_Võsa-lainokk
+Smithornis rufolateralis_Väike-lainokk
+Snowornis subalaris_Hallsaba-kotinga
+Somateria mollissima_Hahk
+Somateria spectabilis_Kuninghahk
 Spartonoica maluroides_Bay-capped Wren-Spinetail
-Spatula clypeata_Northern Shoveler
-Spatula cyanoptera_Cinnamon Teal
-Spatula discors_Blue-winged Teal
-Spatula platalea_Red Shoveler
-Spatula puna_Puna Teal
-Spatula querquedula_Garganey
+Spatula clypeata_Luitsnokk-part
+Spatula cyanoptera_Puna-rägapart
+Spatula discors_Sini-rägapart
+Spatula platalea_Täpik-luitsnokkpart
+Spatula puna_Mägi-üllpart
+Spatula querquedula_Rägapart
 Spea bombifrons_Plains Spadefoot
 Spelaeornis caudatus_Rufous-throated Wren-Babbler
 Spelaeornis oatesi_Chin Hills Wren-Babbler
 Spelaeornis troglodytoides_Bar-winged Wren-Babbler
-Spermestes cucullata_Bronze Mannikin
-Spermophaga haematina_Western Bluebill
-Sphecotheres vieilloti_Australasian Figbird
-Spheniscus demersus_African Penguin
-Spheniscus magellanicus_Magellanic Penguin
+Spermestes cucullata_Pronksamadiin
+Spermophaga haematina_Sininokk-veriamadiin
+Sphecotheres vieilloti_Austraalia viigipeoleo
+Spheniscus demersus_Aafrika pingviin
+Spheniscus magellanicus_Patagoonia pingviin
 Sphenoeacus afer_Cape Grassbird
 Sphenopsis frontalis_Oleaginous Hemispingus
 Sphenopsis melanotis_Black-eared Hemispingus
-Sphyrapicus nuchalis_Red-naped Sapsucker
-Sphyrapicus ruber_Red-breasted Sapsucker
-Sphyrapicus thyroideus_Williamson's Sapsucker
-Sphyrapicus varius_Yellow-bellied Sapsucker
+Sphyrapicus nuchalis_Lääne-mahlarähn
+Sphyrapicus ruber_Puna-mahlarähn
+Sphyrapicus thyroideus_Must-mahlarähn
+Sphyrapicus varius_Ida-mahlarähn
 Spiloptila clamans_Cricket Longtail
-Spilornis cheela_Crested Serpent-Eagle
-Spilornis holospilus_Philippine Serpent-Eagle
+Spilornis cheela_Aasia maduhaugas
+Spilornis holospilus_Filipiini maduhaugas
 Spindalis zena_Western Spindalis
-Spinus atratus_Black Siskin
-Spinus barbatus_Black-chinned Siskin
-Spinus crassirostris_Thick-billed Siskin
-Spinus cucullatus_Red Siskin
-Spinus lawrencei_Lawrence's Goldfinch
-Spinus magellanicus_Hooded Siskin
-Spinus notatus_Black-headed Siskin
-Spinus olivaceus_Olivaceous Siskin
-Spinus pinus_Pine Siskin
-Spinus psaltria_Lesser Goldfinch
-Spinus spinescens_Andean Siskin
-Spinus spinus_Sisask
-Spinus tristis_American Goldfinch
-Spinus xanthogastrus_Yellow-bellied Siskin
-Spiza americana_Dickcissel
-Spizaetus isidori_Black-and-chestnut Eagle
-Spizaetus melanoleucus_Black-and-white Hawk-Eagle
-Spizaetus ornatus_Ornate Hawk-Eagle
-Spizaetus tyrannus_Black Hawk-Eagle
-Spizella atrogularis_Black-chinned Sparrow
-Spizella breweri_Brewer's Sparrow
-Spizella pallida_Clay-colored Sparrow
-Spizella passerina_Chipping Sparrow
-Spizella pusilla_Field Sparrow
-Spizella wortheni_Worthen's Sparrow
-Spizelloides arborea_American Tree Sparrow
-Spiziapteryx circumcincta_Spot-winged Falconet
-Spizixos canifrons_Crested Finchbill
-Spizixos semitorques_Collared Finchbill
-Spodiopsar cineraceus_White-cheeked Starling
-Spodiopsar sericeus_Red-billed Starling
+Spinus atratus_Mustsiisike
+Spinus barbatus_Patagoonia siisike
+Spinus crassirostris_Suurnokk-siisike
+Spinus cucullatus_Punasiisike
+Spinus lawrencei_Hõbesiisike
+Spinus magellanicus_Salusiisike
+Spinus notatus_Mehhiko siisike
+Spinus olivaceus_Inkasiisike
+Spinus pinus_Männisiisike
+Spinus psaltria_Väikesiisike
+Spinus spinescens_Paramosiisike
+Spinus spinus_Siisike
+Spinus tristis_Kuldsiisike
+Spinus xanthogastrus_Tõmmusiisike
+Spiza americana_Põld-kuhiknokk
+Spizaetus isidori_Koidukotkas
+Spizaetus melanoleucus_Tanukotkas
+Spizaetus ornatus_Hund-tuttkotkas
+Spizaetus tyrannus_Must-tuttkotkas
+Spizella atrogularis_Nõgikurk-sidrik
+Spizella breweri_Pujusidrik
+Spizella pallida_Põõsasidrik
+Spizella passerina_Häilusidrik
+Spizella pusilla_Jäätmaa-sidrik
+Spizella wortheni_Kadakasidrik
+Spizelloides arborea_Tundrasidrik
+Spiziapteryx circumcincta_Täpiktiib-pistrik
+Spizixos canifrons_Tutt-vintbülbül
+Spizixos semitorques_Kaelus-vintbülbül
+Spodiopsar cineraceus_Hall-kuldnokk
+Spodiopsar sericeus_Siid-kuldnokk
 Spodiornis rusticus_Slaty Finch
 Sporathraupis cyanocephala_Blue-capped Tanager
 Sporophila albogularis_White-throated Seedeater
@@ -5683,126 +5683,126 @@ Sporophila schistacea_Slate-colored Seedeater
 Sporophila simplex_Drab Seedeater
 Sporophila telasco_Chestnut-throated Seedeater
 Sporophila torqueola_Cinnamon-rumped Seedeater
-Sporopipes frontalis_Speckle-fronted Weaver
-Sporopipes squamifrons_Scaly Weaver
+Sporopipes frontalis_Pärllaup-kangurlind
+Sporopipes squamifrons_Roosanokk-kangurlind
 Stachyris maculata_Chestnut-rumped Babbler
 Stachyris nigriceps_Gray-throated Babbler
 Stachyris nigricollis_Black-throated Babbler
 Stachyris poliocephala_Gray-headed Babbler
 Stachyris strialata_Spot-necked Babbler
 Stachyris thoracica_White-bibbed Babbler
-Stactolaema leucotis_White-eared Barbet
-Stactolaema olivacea_Green Barbet
-Stagonopleura bella_Beautiful Firetail
+Stactolaema leucotis_Valgekõrv-udelind
+Stactolaema olivacea_Oliiv-udelind
+Stagonopleura bella_Viiramadiin
 Staphida torqueola_Indochinese Yuhina
-Steatornis caripensis_Oilbird
-Stelgidillas gracilirostris_Slender-billed Greenbul
-Stelgidopteryx ruficollis_Southern Rough-winged Swallow
-Stelgidopteryx serripennis_Northern Rough-winged Swallow
+Steatornis caripensis_Õlilind
+Stelgidillas gracilirostris_Ladva-viherbülbül
+Stelgidopteryx ruficollis_Lõuna-kammpääsuke
+Stelgidopteryx serripennis_Põhja-kammpääsuke
 Stenostira scita_Fairy Flycatcher
-Stephanoaetus coronatus_Crowned Eagle
-Stephanophorus diadematus_Diademed Tanager
-Stephanoxis lalandi_Green-crowned Plovercrest
-Stephanoxis loddigesii_Purple-crowned Plovercrest
-Stercorarius antarcticus_Brown Skua
-Stercorarius longicaudus_Long-tailed Jaeger
-Stercorarius maccormicki_South Polar Skua
-Stercorarius parasiticus_Parasitic Jaeger
-Stercorarius pomarinus_Pomarine Jaeger
-Stercorarius skua_Great Skua
-Sterna aurantia_River Tern
-Sterna dougallii_Roseate Tern
-Sterna forsteri_Forster's Tern
-Sterna hirundinacea_South American Tern
+Stephanoaetus coronatus_Kroonkotkas
+Stephanophorus diadematus_Diadeemtangara
+Stephanoxis lalandi_Rohetutt-koolibri
+Stephanoxis loddigesii_Sinitutt-koolibri
+Stercorarius antarcticus_Lõunaänn
+Stercorarius longicaudus_Pikksaba-änn
+Stercorarius maccormicki_Antarktika änn
+Stercorarius parasiticus_Söödikänn
+Stercorarius pomarinus_Laisaba-änn
+Stercorarius skua_Suuränn
+Sterna aurantia_Tulvatiir
+Sterna dougallii_Roosatiir
+Sterna forsteri_Sootiir
+Sterna hirundinacea_Pärltiir
 Sterna hirundo_Jõgitiir
-Sterna paradisaea_Arctic Tern
-Sterna repressa_White-cheeked Tern
-Sterna striata_White-fronted Tern
-Sterna sumatrana_Black-naped Tern
-Sterna trudeaui_Snowy-crowned Tern
-Sterna vittata_Antarctic Tern
+Sterna paradisaea_Randtiir
+Sterna repressa_Korallitiir
+Sterna striata_Uusmeremaa tiir
+Sterna sumatrana_Mustkukal-tiir
+Sterna trudeaui_Pampatiir
+Sterna vittata_Lõunatiir
 Sternula albifrons_Väiketiir
-Sternula antillarum_Least Tern
-Sternula saundersi_Saunders's Tern
-Sternula superciliaris_Yellow-billed Tern
+Sternula antillarum_Ameerika väiketiir
+Sternula saundersi_Araabia väiketiir
+Sternula superciliaris_Amazonase väiketiir
 Stigmatura budytoides_Greater Wagtail-Tyrant
 Stigmatura napensis_Lesser Wagtail-Tyrant
 Stilpnia cayana_Burnished-buff Tanager
 Stilpnia cyanicollis_Blue-necked Tanager
-Stilpnia cyanoptera_Black-headed Tanager
+Stilpnia cyanoptera_Karbustangara
 Stilpnia heinei_Black-capped Tanager
-Stilpnia larvata_Golden-hooded Tanager
+Stilpnia larvata_Koldpea-tangara
 Stilpnia nigrocincta_Masked Tanager
 Stilpnia peruviana_Black-backed Tanager
 Stilpnia preciosa_Chestnut-backed Tanager
 Stilpnia vitriolina_Scrub Tanager
-Stiphrornis erythrothorax_Forest Robin
-Stipiturus malachurus_Southern Emuwren
-Stizoptera bichenovii_Double-barred Finch
+Stiphrornis erythrothorax_Ginea ruugeööbik
+Stipiturus malachurus_Ranniku-ohesaba
+Stizoptera bichenovii_Kiritiib-amadiin
 Stomiopera unicolor_White-gaped Honeyeater
-Strepera fuliginosa_Black Currawong
-Strepera graculina_Pied Currawong
-Strepera versicolor_Gray Currawong
-Streptopelia capicola_Ring-necked Dove
-Streptopelia chinensis_Spotted Dove
+Strepera fuliginosa_Must-karravong
+Strepera graculina_Pugal-karravong
+Strepera versicolor_Hall-karravong
+Streptopelia capicola_Savanni-turteltuvi
+Streptopelia chinensis_Džungli-turteltuvi
 Streptopelia decaocto_Kaelus-turteltuvi
-Streptopelia decipiens_Mourning Collared-Dove
-Streptopelia lugens_Dusky Turtle-Dove
-Streptopelia orientalis_Oriental Turtle-Dove
-Streptopelia roseogrisea_African Collared-Dove
-Streptopelia semitorquata_Red-eyed Dove
-Streptopelia senegalensis_Laughing Dove
-Streptopelia tranquebarica_Red Collared-Dove
-Streptopelia turtur_European Turtle-Dove
-Streptopelia vinacea_Vinaceous Dove
-Streptoprocne biscutata_Biscutate Swift
-Streptoprocne rutila_Chestnut-collared Swift
-Streptoprocne zonaris_White-collared Swift
+Streptopelia decipiens_Akaatsia-turteltuvi
+Streptopelia lugens_Mägi-turteltuvi
+Streptopelia orientalis_Suur-turteltuvi
+Streptopelia roseogrisea_Naeru-turteltuvi
+Streptopelia semitorquata_Prill-turteltuvi
+Streptopelia senegalensis_Küla-turteltuvi
+Streptopelia tranquebarica_Puna-turteltuvi
+Streptopelia turtur_Turteltuvi
+Streptopelia vinacea_Sudaani turteltuvi
+Streptoprocne biscutata_Brasiilia kosepiiritaja
+Streptoprocne rutila_Punakael-kosepiiritaja
+Streptoprocne zonaris_Kaelus-kosepiiritaja
 Strix aluco_Kodukakk
-Strix chacoensis_Chaco Owl
-Strix fulvescens_Fulvous Owl
+Strix chacoensis_Chaco kakk
+Strix fulvescens_Mägi-metskakk
 Strix hadorami_Desert Owl
-Strix hylophila_Rusty-barred Owl
-Strix leptogrammica_Brown Wood-Owl
-Strix nebulosa_Great Gray Owl
-Strix nivicolum_Himalayan Owl
-Strix occidentalis_Spotted Owl
-Strix ocellata_Mottled Wood-Owl
-Strix rufipes_Rufous-legged Owl
-Strix seloputo_Spotted Wood-Owl
+Strix hylophila_Brasiilia metskakk
+Strix leptogrammica_Pagukakk
+Strix nebulosa_Habekakk
+Strix nivicolum_Hiina kodukakk
+Strix occidentalis_Tähnikkakk
+Strix ocellata_Salukakk
+Strix rufipes_Tšiili metskakk
+Strix seloputo_Pargikakk
 Strix uralensis_Händkakk
-Strix varia_Barred Owl
-Strix woodfordii_African Wood-Owl
+Strix varia_Ameerika metskakk
+Strix woodfordii_Aafrika metskakk
 Struthidea cinerea_Apostlebird
-Sturnella magna_Eastern Meadowlark
-Sturnella neglecta_Western Meadowlark
-Sturnia blythii_Malabar Starling
-Sturnia malabarica_Chestnut-tailed Starling
-Sturnia pagodarum_Brahminy Starling
-Sturnia sinensis_White-shouldered Starling
-Sturnus unicolor_Spotless Starling
+Sturnella magna_Ida-niiduturpial
+Sturnella neglecta_Lääne-niiduturpial
+Sturnia blythii_Valgepea-kuldnokk
+Sturnia malabarica_Halltiib-kuldnokk
+Sturnia pagodarum_India kuldnokk
+Sturnia sinensis_Valgeõlg-kuldnokk
+Sturnus unicolor_Ibeeria kuldnokk
 Sturnus vulgaris_Kuldnokk
 Sublegatus arenarum_Northern Scrub-Flycatcher
 Sublegatus modestus_Southern Scrub-Flycatcher
 Sublegatus obscurior_Amazonian Scrub-Flycatcher
 Sugomel nigrum_Black Honeyeater
 Suiriri suiriri_Suiriri Flycatcher
-Sula dactylatra_Masked Booby
-Sula leucogaster_Brown Booby
-Sula nebouxii_Blue-footed Booby
-Sula sula_Red-footed Booby
-Surnia ulula_Northern Hawk Owl
+Sula dactylatra_Masksuula
+Sula leucogaster_Pruunsuula
+Sula nebouxii_Sinijalg-suula
+Sula sula_Punajalg-suula
+Surnia ulula_Vöötkakk
 Surniculus dicruroides_Fork-tailed Drongo-Cuckoo
-Surniculus lugubris_Square-tailed Drongo-Cuckoo
-Surniculus velutinus_Philippine Drongo-Cuckoo
-Suthora nipalensis_Black-throated Parrotbill
-Suthora verreauxi_Golden Parrotbill
-Swynnertonia swynnertoni_Swynnerton's Robin
-Sylvia abyssinica_African Hill Babbler
+Surniculus lugubris_Malai drongokägu
+Surniculus velutinus_Filipiini drongokägu
+Suthora nipalensis_Habe-koonusnokk
+Suthora verreauxi_Väike-koonusnokk
+Swynnertonia swynnertoni_Valgetähn-ruugeööbik
+Sylvia abyssinica_Hallpea-põõsalind
 Sylvia atricapilla_Mustpea-põõsalind
-Sylvia atriceps_Rwenzori Hill Babbler
+Sylvia atriceps_Karbus-põõsalind
 Sylvia borin_Aed-põõsalind
-Sylvia nigricapillus_Bush Blackcap
+Sylvia nigricapillus_Suur-põõsalind
 Sylvietta brachyura_Northern Crombec
 Sylvietta rufescens_Cape Crombec
 Sylvietta ruficapilla_Red-capped Crombec
@@ -5810,8 +5810,8 @@ Sylvietta virens_Green Crombec
 Sylvietta whytii_Red-faced Crombec
 Sylviorthorhynchus desmursii_Des Murs's Wiretail
 Sylviorthorhynchus yanacensis_Tawny Tit-Spinetail
-Sylviparus modestus_Yellow-browed Tit
-Syma torotoro_Yellow-billed Kingfisher
+Sylviparus modestus_Lehetihane
+Syma torotoro_Koldnokk-safiirlind
 Symposiachrus trivirgatus_Spectacled Monarch
 Synallaxis albescens_Pale-breasted Spinetail
 Synallaxis albigularis_Dark-breasted Spinetail
@@ -5853,137 +5853,137 @@ Syndactyla rufosuperciliata_Buff-browed Foliage-gleaner
 Syndactyla striata_Bolivian Recurvebill
 Syndactyla subalaris_Lineated Foliage-gleaner
 Syndactyla ucayalae_Peruvian Recurvebill
-Synoicus chinensis_Blue-breasted Quail
-Synoicus ypsilophorus_Brown Quail
-Syrigma sibilatrix_Whistling Heron
-Syrrhaptes paradoxus_Pallas's Sandgrouse
+Synoicus chinensis_Ida-sinivutt
+Synoicus ypsilophorus_Soovutt
+Syrigma sibilatrix_Vilehaigur
+Syrrhaptes paradoxus_Stepivuril
 Systellura decussata_Tschudi's Nightjar
-Systellura longirostris_Band-winged Nightjar
-Taccocua leschenaultii_Sirkeer Malkoha
-Tachornis phoenicobia_Antillean Palm-Swift
-Tachornis squamata_Fork-tailed Palm-Swift
+Systellura longirostris_Välu-öösorr
+Taccocua leschenaultii_Leet-malkohakägu
+Tachornis phoenicobia_Antilli palmipiiritaja
+Tachornis squamata_Ameerika palmipiiritaja
 Tachuris rubrigastra_Many-colored Rush Tyrant
-Tachybaptus dominicus_Least Grebe
-Tachybaptus novaehollandiae_Australasian Grebe
+Tachybaptus dominicus_Ameerika väikepütt
+Tachybaptus novaehollandiae_Austraalia väikepütt
 Tachybaptus ruficollis_Väikepütt
-Tachycineta albilinea_Mangrove Swallow
-Tachycineta albiventer_White-winged Swallow
-Tachycineta bicolor_Tree Swallow
-Tachycineta euchrysea_Golden Swallow
-Tachycineta leucopyga_Chilean Swallow
-Tachycineta leucorrhoa_White-rumped Swallow
-Tachycineta thalassina_Violet-green Swallow
-Tachyeres patachonicus_Flying Steamer-Duck
+Tachycineta albilinea_Mangroovipääsuke
+Tachycineta albiventer_Kiritiib-pääsuke
+Tachycineta bicolor_Õõnepääsuke
+Tachycineta euchrysea_Kuldpääsuke
+Tachycineta leucopyga_Patagoonia pääsuke
+Tachycineta leucorrhoa_Safiirpääsuke
+Tachycineta thalassina_Rohepääsuke
+Tachyeres patachonicus_Järve-aurikpart
 Tachyphonus coronatus_Ruby-crowned Tanager
 Tachyphonus delatrii_Tawny-crested Tanager
 Tachyphonus phoenicius_Red-shouldered Tanager
 Tachyphonus rufus_White-lined Tanager
 Tachyphonus surinamus_Fulvous-crested Tanager
-Tadorna cana_South African Shelduck
-Tadorna ferruginea_Ruddy Shelduck
-Tadorna tadorna_Common Shelduck
-Tadorna tadornoides_Australian Shelduck
-Tadorna variegata_Paradise Shelduck
-Taenioptynx brodiei_Collared Owlet
-Taeniopygia guttata_Zebra Finch
+Tadorna cana_Kapi tulipart
+Tadorna ferruginea_Tulipart
+Tadorna tadorna_Ristpart
+Tadorna tadornoides_Billabongipart
+Tadorna variegata_Paradiisipart
+Taenioptynx brodiei_Kagu-värbkakk
+Taeniopygia guttata_Sebra-amadiin
 Taeniotriccus andrei_Black-chested Tyrant
-Talaphorus chlorocercus_Olive-spotted Hummingbird
-Talegalla fuscirostris_Yellow-legged Brushturkey
-Talegalla jobiensis_Red-legged Brushturkey
+Talaphorus chlorocercus_Jõgikoolibri
+Talegalla fuscirostris_Nõgi-rihukana
+Talegalla jobiensis_Pruunkael-rihukana
 Tamias striatus_Eastern Chipmunk
 Tamiasciurus hudsonicus_Red Squirrel
 Tangara arthus_Golden Tanager
-Tangara chilensis_Paradise Tanager
-Tangara cyanocephala_Red-necked Tanager
+Tangara chilensis_Vikertangara
+Tangara cyanocephala_Punakael-tangara
 Tangara cyanoventris_Gilt-edged Tanager
-Tangara desmaresti_Brassy-breasted Tanager
+Tangara desmaresti_Ruugepugu-tangara
 Tangara dowii_Spangle-cheeked Tanager
 Tangara florida_Emerald Tanager
 Tangara gyrola_Bay-headed Tanager
-Tangara icterocephala_Silver-throated Tanager
+Tangara icterocephala_Hõbekurk-tangara
 Tangara inornata_Plain-colored Tanager
 Tangara labradorides_Metallic-green Tanager
-Tangara lavinia_Rufous-winged Tanager
-Tangara mexicana_Turquoise Tanager
+Tangara lavinia_Rusktiib-tangara
+Tangara mexicana_Samettangara
 Tangara nigroviridis_Beryl-spangled Tanager
-Tangara parzudakii_Flame-faced Tanager
-Tangara schrankii_Green-and-gold Tanager
+Tangara parzudakii_Leekpea-tangara
+Tangara schrankii_Valjastangara
 Tangara seledon_Green-headed Tanager
 Tangara vassorii_Blue-and-black Tanager
 Tangara velia_Opal-rumped Tanager
-Tangara xanthocephala_Saffron-crowned Tanager
-Tanygnathus sumatranus_Azure-rumped Parrot
-Tanysiptera galatea_Common Paradise-Kingfisher
-Tanysiptera sylvia_Buff-breasted Paradise-Kingfisher
-Tapera naevia_Striped Cuckoo
+Tangara xanthocephala_Kuldkiird-tangara
+Tanygnathus sumatranus_Rohe-konkpapagoi
+Tanysiptera galatea_Paradiisi-safiirlind
+Tanysiptera sylvia_Niitsaba-safiirlind
+Tapera naevia_Triipkägu
 Taraba major_Great Antshrike
 Tarphonomus certhioides_Chaco Earthcreeper
 Tarphonomus harterti_Bolivian Earthcreeper
-Tarsiger chrysaeus_Golden Bush-Robin
-Tarsiger cyanurus_Red-flanked Bluetail
-Tarsiger indicus_White-browed Bush-Robin
-Tarsiger johnstoniae_Collared Bush-Robin
-Tarsiger rufilatus_Himalayan Bluetail
-Tauraco corythaix_Knysna Turaco
-Tauraco fischeri_Fischer's Turaco
-Tauraco hartlaubi_Hartlaub's Turaco
-Tauraco leucotis_White-cheeked Turaco
-Tauraco livingstonii_Livingstone's Turaco
-Tauraco macrorhynchus_Yellow-billed Turaco
-Tauraco persa_Guinea Turaco
-Tauraco porphyreolophus_Purple-crested Turaco
-Tauraco schalowi_Schalow's Turaco
-Tchagra australis_Brown-crowned Tchagra
-Tchagra senegalus_Black-crowned Tchagra
-Tchagra tchagra_Southern Tchagra
+Tarsiger chrysaeus_Kuld-sinisaba
+Tarsiger cyanurus_Sinisaba
+Tarsiger indicus_Valjas-sinisaba
+Tarsiger johnstoniae_Taivani sinisaba
+Tarsiger rufilatus_Tiibeti sinisaba
+Tauraco corythaix_Lõunaturako
+Tauraco fischeri_Rannikuturako
+Tauraco hartlaubi_Keenia turako
+Tauraco leucotis_Etioopia turako
+Tauraco livingstonii_Roheturako
+Tauraco macrorhynchus_Paguturako
+Tauraco persa_Metsturako
+Tauraco porphyreolophus_Aedturako
+Tauraco schalowi_Smaragdturako
+Tchagra australis_Pruunkiird-pagulind
+Tchagra senegalus_Mustkiird-pagulind
+Tchagra tchagra_Lõuna-pagulind
 Teledromas fuscus_Sandy Gallito
-Telespiza ultima_Nihoa Finch
-Telophorus bocagei_Gray-green Bushshrike
-Telophorus dohertyi_Doherty's Bushshrike
-Telophorus nigrifrons_Black-fronted Bushshrike
-Telophorus olivaceus_Olive Bushshrike
+Telespiza ultima_Niihau nestevint
+Telophorus bocagei_Diadeem-pagulind
+Telophorus dohertyi_Ülangu-pagulind
+Telophorus nigrifrons_Ida-pagulind
+Telophorus olivaceus_Mustpõsk-pagulind
 Telophorus sulfureopectus_Sulphur-breasted Bushshrike
-Telophorus viridis_Four-colored Bushshrike
-Telophorus zeylonus_Bokmakierie
-Temnurus temnurus_Ratchet-tailed Treepie
+Telophorus viridis_Punakurk-pagulind
+Telophorus zeylonus_Võru-pagulind
+Temnurus temnurus_Kidasaba-harakas
 Tephrodornis pondicerianus_Common Woodshrike
 Tephrodornis sylvicola_Malabar Woodshrike
 Tephrodornis virgatus_Large Woodshrike
 Terenotriccus erythrurus_Ruddy-tailed Flycatcher
 Terenura maculata_Streak-capped Antwren
 Terenura sicki_Orange-bellied Antwren
-Teretistris fernandinae_Yellow-headed Warbler
-Teretistris fornsi_Oriente Warbler
-Terpsiphone affinis_Blyth's Paradise-Flycatcher
-Terpsiphone atrocaudata_Japanese Paradise-Flycatcher
-Terpsiphone bourbonnensis_Mascarene Paradise-Flycatcher
-Terpsiphone cinnamomea_Rufous Paradise-Flycatcher
-Terpsiphone incei_Amur Paradise-Flycatcher
-Terpsiphone mutata_Malagasy Paradise-Flycatcher
-Terpsiphone paradisi_Indian Paradise-Flycatcher
-Terpsiphone rufiventer_Black-headed Paradise-Flycatcher
-Terpsiphone viridis_African Paradise-Flycatcher
-Tersina viridis_Swallow Tanager
-Tesia cyaniventer_Gray-bellied Tesia
-Tesia everetti_Russet-capped Tesia
-Tesia olivea_Slaty-bellied Tesia
-Tesia superciliaris_Javan Tesia
+Teretistris fernandinae_Läänekuuba säälik
+Teretistris fornsi_Idakuuba säälik
+Terpsiphone affinis_Hallpugu-paradiisipiibik
+Terpsiphone atrocaudata_Tume-paradiisipiibik
+Terpsiphone bourbonnensis_Maskareeni paradiisipiibik
+Terpsiphone cinnamomea_Ruuge-paradiisipiibik
+Terpsiphone incei_Hiina paradiisipiibik
+Terpsiphone mutata_Madagaskari paradiisipiibik
+Terpsiphone paradisi_Tutt-paradiisipiibik
+Terpsiphone rufiventer_Ruugekõht-paradiisipiibik
+Terpsiphone viridis_Salu-paradiisipiibik
+Tersina viridis_Õõne-türkiissirk
+Tesia cyaniventer_Hallpugu-rädilind
+Tesia everetti_Roostekiird-rädilind
+Tesia olivea_Tume-rädilind
+Tesia superciliaris_Jaava rädilind
 Tetrao urogallus_Metsis
-Tetraogallus caucasicus_Caucasian Snowcock
-Tetraogallus tibetanus_Tibetan Snowcock
-Tetrastes bonasia_Hazel Grouse
-Tetrax tetrax_Little Bustard
-Thalassarche melanophris_Black-browed Albatross
-Thalasseus bengalensis_Lesser Crested Tern
-Thalasseus bergii_Great Crested Tern
-Thalasseus elegans_Elegant Tern
-Thalasseus maximus_Royal Tern
-Thalasseus sandvicensis_Sandwich Tern
-Thalurania colombica_Crowned Woodnymph
-Thalurania furcata_Fork-tailed Woodnymph
-Thalurania glaucopis_Violet-capped Woodnymph
+Tetraogallus caucasicus_Kaukaasia mägikana
+Tetraogallus tibetanus_Tiibeti mägikana
+Tetrastes bonasia_Laanepüü
+Tetrax tetrax_Väiketrapp
+Thalassarche melanophris_Mustkulm-albatross
+Thalasseus bengalensis_Liivatiir
+Thalasseus bergii_Tanutiir
+Thalasseus elegans_Kalifornia tiir
+Thalasseus maximus_Kuningtiir
+Thalasseus sandvicensis_Tutt-tiir
+Thalurania colombica_Mets-nümfkoolibri
+Thalurania furcata_Pronkskiird-nümfkoolibri
+Thalurania glaucopis_Rohe-nümfkoolibri
 Thamnistes anabatinus_Russet Antshrike
-Thamnolaea cinnamomeiventris_Mocking Cliff-Chat
+Thamnolaea cinnamomeiventris_Viigitäks
 Thamnomanes ardesiacus_Dusky-throated Antshrike
 Thamnomanes caesius_Cinereous Antshrike
 Thamnomanes saturninus_Saturnine Antshrike
@@ -6015,13 +6015,13 @@ Thamnophilus tenuepunctatus_Lined Antshrike
 Thamnophilus torquatus_Rufous-winged Antshrike
 Thamnophilus unicolor_Uniform Antshrike
 Thamnophilus zarumae_Chapman's Antshrike
-Thectocercus acuticaudatus_Blue-crowned Parakeet
-Theristicus caerulescens_Plumbeous Ibis
-Theristicus caudatus_Buff-necked Ibis
-Theristicus melanopis_Black-faced Ibis
-Thescelocichla leucopleura_Swamp Greenbul
-Thinocorus orbignyianus_Gray-breasted Seedsnipe
-Thinocorus rumicivorus_Least Seedsnipe
+Thectocercus acuticaudatus_Sinipea-aratinga
+Theristicus caerulescens_Halliibis
+Theristicus caudatus_Väljaiibis
+Theristicus melanopis_Habeiibis
+Thescelocichla leucopleura_Raffiapalmi-bülbül
+Thinocorus orbignyianus_Väikekurp
+Thinocorus rumicivorus_Kääbuskurp
 Thlypopsis ornata_Rufous-chested Tanager
 Thlypopsis pyrrhocoma_Chestnut-headed Tanager
 Thlypopsis sordida_Orange-headed Tanager
@@ -6030,12 +6030,12 @@ Thraupis abbas_Yellow-winged Tanager
 Thraupis cyanoptera_Azure-shouldered Tanager
 Thraupis episcopus_Blue-gray Tanager
 Thraupis ornata_Golden-chevroned Tanager
-Thraupis palmarum_Palm Tanager
+Thraupis palmarum_Palmitangara
 Thraupis sayaca_Sayaca Tanager
-Threnetes leucurus_Pale-tailed Barbthroat
-Threnetes ruckeri_Band-tailed Barbthroat
-Threskiornis melanocephalus_Black-headed Ibis
-Threskiornis molucca_Australian Ibis
+Threnetes leucurus_Kaelus-selvakoolibri
+Threnetes ruckeri_Laidsaba-selvakoolibri
+Threskiornis melanocephalus_Idaiibis
+Threskiornis molucca_Lõunaiibis
 Thripadectes flammulatus_Flammulated Treehunter
 Thripadectes holostictus_Striped Treehunter
 Thripadectes ignobilis_Uniform Treehunter
@@ -6046,360 +6046,360 @@ Thripadectes virgaticeps_Streak-capped Treehunter
 Thripophaga cherriei_Orinoco Softtail
 Thripophaga fusciceps_Plain Softtail
 Thripophaga macroura_Striated Softtail
-Thryomanes bewickii_Bewick's Wren
-Thryophilus nicefori_Niceforo's Wren
-Thryophilus pleurostictus_Banded Wren
-Thryophilus rufalbus_Rufous-and-white Wren
-Thryophilus sernai_Antioquia Wren
-Thryophilus sinaloa_Sinaloa Wren
-Thryothorus ludovicianus_Carolina Wren
+Thryomanes bewickii_Võsakäblik
+Thryophilus nicefori_Santanderi käblik
+Thryophilus pleurostictus_Täpikkülg-käblik
+Thryophilus rufalbus_Rebaskäblik
+Thryophilus sernai_Cauca käblik
+Thryophilus sinaloa_Ööbikkäblik
+Thryothorus ludovicianus_Salukäblik
 Tiaris olivaceus_Yellow-faced Grassquit
-Tichodroma muraria_Wallcreeper
-Tickellia hodgsoni_Broad-billed Warbler
-Tigrisoma lineatum_Rufescent Tiger-Heron
-Tigrisoma mexicanum_Bare-throated Tiger-Heron
+Tichodroma muraria_Kaljuklutt
+Tickellia hodgsoni_Habe-rädilind
+Tigrisoma lineatum_Soo-tiigerhüüp
+Tigrisoma mexicanum_Suur-tiigerhüüp
 Timalia pileata_Chestnut-capped Babbler
-Tinamotis pentlandii_Puna Tinamou
-Tinamus guttatus_White-throated Tinamou
-Tinamus major_Great Tinamou
-Tinamus solitarius_Solitary Tinamou
-Tinamus tao_Gray Tinamou
+Tinamotis pentlandii_Puunatinamu
+Tinamus guttatus_Helmestinamu
+Tinamus major_Suurtinamu
+Tinamus solitarius_Eraktinamu
+Tinamus tao_Halltinamu
 Tityra cayana_Black-tailed Tityra
 Tityra inquisitor_Black-crowned Tityra
 Tityra semifasciata_Masked Tityra
-Tockus deckeni_Von der Decken's Hornbill
-Tockus erythrorhynchus_Northern Red-billed Hornbill
+Tockus deckeni_Mangusti-sarvnokk
+Tockus erythrorhynchus_Savanni-sarvnokk
 Tockus kempi_Western Red-billed Hornbill
-Tockus leucomelas_Southern Yellow-billed Hornbill
+Tockus leucomelas_Lõuna-sarvnokk
 Tockus rufirostris_Southern Red-billed Hornbill
-Todiramphus australasia_Cinnamon-banded Kingfisher
-Todiramphus chloris_Collared Kingfisher
-Todiramphus funebris_Sombre Kingfisher
-Todiramphus macleayii_Forest Kingfisher
+Todiramphus australasia_Timori safiirlind
+Todiramphus chloris_Mangroovi-safiirlind
+Todiramphus funebris_Tõmmu-safiirlind
+Todiramphus macleayii_Mets-safiirlind
 Todiramphus sacer_Pacific Kingfisher
-Todiramphus sanctus_Sacred Kingfisher
+Todiramphus sanctus_Lõuna-safiirlind
 Todiramphus sordidus_Torresian Kingfisher
 Todiramphus tristrami_Melanesian Kingfisher
-Todiramphus winchelli_Rufous-lored Kingfisher
+Todiramphus winchelli_Punakael-safiirlind
 Todirostrum chrysocrotaphum_Yellow-browed Tody-Flycatcher
 Todirostrum cinereum_Common Tody-Flycatcher
 Todirostrum maculatum_Spotted Tody-Flycatcher
 Todirostrum nigriceps_Black-headed Tody-Flycatcher
 Todirostrum pictum_Painted Tody-Flycatcher
 Todirostrum poliocephalum_Gray-headed Tody-Flycatcher
-Todus angustirostris_Narrow-billed Tody
-Todus mexicanus_Puerto Rican Tody
-Todus multicolor_Cuban Tody
-Todus subulatus_Broad-billed Tody
-Todus todus_Jamaican Tody
+Todus angustirostris_Ahasnokk-todi
+Todus mexicanus_Puertoriiko todi
+Todus multicolor_Kuuba todi
+Todus subulatus_Lainokk-todi
+Todus todus_Jamaika todi
 Tolmomyias assimilis_Yellow-margined Flycatcher
 Tolmomyias flaviventris_Yellow-breasted Flycatcher
 Tolmomyias poliocephalus_Gray-crowned Flycatcher
 Tolmomyias sulphurescens_Yellow-olive Flycatcher
 Tolmomyias traylori_Orange-eyed Flycatcher
-Topaza pella_Crimson Topaz
-Topaza pyra_Fiery Topaz
-Torreornis inexpectata_Zapata Sparrow
-Touit batavicus_Lilac-tailed Parrotlet
-Touit dilectissimus_Blue-fronted Parrotlet
-Touit huetii_Scarlet-shouldered Parrotlet
-Touit melanonotus_Brown-backed Parrotlet
-Touit purpuratus_Sapphire-rumped Parrotlet
-Touit stictopterus_Spot-winged Parrotlet
-Touit surdus_Golden-tailed Parrotlet
+Topaza pella_Puna-topaaskoolibri
+Topaza pyra_Tuli-topaaskoolibri
+Torreornis inexpectata_Kuuba maasidrik
+Touit batavicus_Mustselg-väikepapagoi
+Touit dilectissimus_Leektiib-väikepapagoi
+Touit huetii_Mustlaup-väikepapagoi
+Touit melanonotus_Pruunselg-väikepapagoi
+Touit purpuratus_Selva-väikepapagoi
+Touit stictopterus_Tähnik-väikepapagoi
+Touit surdus_Koldsaba-väikepapagoi
 Toxorhamphus novaeguineae_Yellow-bellied Longbill
-Toxostoma bendirei_Bendire's Thrasher
-Toxostoma cinereum_Gray Thrasher
-Toxostoma crissale_Crissal Thrasher
-Toxostoma curvirostre_Curve-billed Thrasher
-Toxostoma lecontei_LeConte's Thrasher
-Toxostoma longirostre_Long-billed Thrasher
-Toxostoma ocellatum_Ocellated Thrasher
-Toxostoma redivivum_California Thrasher
-Toxostoma rufum_Brown Thrasher
-Trachyphonus darnaudii_D'Arnaud's Barbet
-Trachyphonus erythrocephalus_Red-and-yellow Barbet
-Trachyphonus purpuratus_Yellow-billed Barbet
-Trachyphonus vaillantii_Crested Barbet
-Tregellasia capito_Pale-yellow Robin
-Treron affinis_Gray-fronted Green-Pigeon
-Treron bicinctus_Orange-breasted Green-Pigeon
-Treron calvus_African Green-Pigeon
-Treron curvirostra_Thick-billed Green-Pigeon
-Treron formosae_Whistling Green-Pigeon
-Treron fulvicollis_Cinnamon-headed Green-Pigeon
-Treron olax_Little Green-Pigeon
-Treron phayrei_Ashy-headed Green-Pigeon
-Treron phoenicopterus_Yellow-footed Green-Pigeon
-Treron sieboldii_White-bellied Green-Pigeon
-Treron sphenurus_Wedge-tailed Green-Pigeon
-Treron vernans_Pink-necked Green-Pigeon
-Tribonyx mortierii_Tasmanian Nativehen
-Tribonyx ventralis_Black-tailed Nativehen
-Trichoglossus chlorolepidotus_Scaly-breasted Lorikeet
-Trichoglossus haematodus_Coconut Lorikeet
+Toxostoma bendirei_Kõnnu-pilalind
+Toxostoma cinereum_Rästas-pilalind
+Toxostoma crissale_Punapära-pilalind
+Toxostoma curvirostre_Kaktuse-pilalind
+Toxostoma lecontei_Kõrbe-pilalind
+Toxostoma longirostre_Tamaulipase pilalind
+Toxostoma ocellatum_Täpik-pilalind
+Toxostoma redivivum_Kalifornia pilalind
+Toxostoma rufum_Ruske-pilalind
+Trachyphonus darnaudii_Maa-udelind
+Trachyphonus erythrocephalus_Tähnik-udelind
+Trachyphonus purpuratus_Sultan-udelind
+Trachyphonus vaillantii_Tutt-udelind
+Tregellasia capito_Rotangi-miro
+Treron affinis_Ghati viigituvi
+Treron bicinctus_Ruugerind-viigituvi
+Treron calvus_Aafrika viigituvi
+Treron curvirostra_Prill-viigituvi
+Treron formosae_Taivani viigituvi
+Treron fulvicollis_Kaneel-viigituvi
+Treron olax_Väike-viigituvi
+Treron phayrei_Indohiina viigituvi
+Treron phoenicopterus_Koldkael-viigituvi
+Treron sieboldii_Ida-viigituvi
+Treron sphenurus_Kiilsaba-viigituvi
+Treron vernans_Koidu-viigituvi
+Tribonyx mortierii_Tasmaania kanatait
+Tribonyx ventralis_Austraalia kanatait
+Trichoglossus chlorolepidotus_Vööt-nestepapagoi
+Trichoglossus haematodus_Viker-nestepapagoi
 Trichoglossus moluccanus_Rainbow Lorikeet
-Trichoglossus rubritorquis_Red-collared Lorikeet
-Tricholaema diademata_Red-fronted Barbet
-Tricholaema hirsuta_Hairy-breasted Barbet
-Tricholaema lacrymosa_Spot-flanked Barbet
-Tricholaema leucomelas_Pied Barbet
-Tricholaema melanocephala_Black-throated Barbet
-Tricholestes criniger_Hairy-backed Bulbul
+Trichoglossus rubritorquis_Arnhemi nestepapagoi
+Tricholaema diademata_Diadeem-udelind
+Tricholaema hirsuta_Punasilm-udelind
+Tricholaema lacrymosa_Täpikkülg-udelind
+Tricholaema leucomelas_Lõuna-udelind
+Tricholaema melanocephala_Kõnnu-udelind
+Tricholestes criniger_Jõhvselg-bülbül
 Trichothraupis melanops_Black-goggled Tanager
-Triclaria malachitacea_Blue-bellied Parrot
-Tringa brevipes_Gray-tailed Tattler
-Tringa erythropus_Spotted Redshank
-Tringa flavipes_Lesser Yellowlegs
+Triclaria malachitacea_Laulupapagoi
+Tringa brevipes_Siberi mägitilder
+Tringa erythropus_Tumetilder
+Tringa flavipes_Kollajalg-tilder
 Tringa glareola_Mudatilder
-Tringa guttifer_Nordmann's Greenshank
-Tringa incana_Wandering Tattler
-Tringa melanoleuca_Greater Yellowlegs
+Tringa guttifer_Sahhalini tilder
+Tringa incana_Alaska mägitilder
+Tringa melanoleuca_Ameerika heletilder
 Tringa nebularia_Heletilder
 Tringa ochropus_Metstilder
-Tringa semipalmata_Willet
-Tringa solitaria_Solitary Sandpiper
-Tringa stagnatilis_Marsh Sandpiper
+Tringa semipalmata_Suurtilder
+Tringa solitaria_Ameerika metstilder
+Tringa stagnatilis_Lammitilder
 Tringa totanus_Punajalg-tilder
-Trochalopteron affine_Black-faced Laughingthrush
-Trochalopteron chrysopterum_Assam Laughingthrush
-Trochalopteron elliotii_Elliot's Laughingthrush
-Trochalopteron erythrocephalum_Chestnut-crowned Laughingthrush
-Trochalopteron henrici_Prince Henry's Laughingthrush
-Trochalopteron imbricatum_Bhutan Laughingthrush
-Trochalopteron lineatum_Streaked Laughingthrush
-Trochalopteron melanostigma_Silver-eared Laughingthrush
-Trochalopteron milnei_Red-tailed Laughingthrush
-Trochalopteron morrisonianum_White-whiskered Laughingthrush
-Trochalopteron peninsulae_Malayan Laughingthrush
-Trochalopteron squamatum_Blue-winged Laughingthrush
-Trochalopteron subunicolor_Scaly Laughingthrush
-Trochalopteron variegatum_Variegated Laughingthrush
-Trochalopteron virgatum_Striped Laughingthrush
-Trochocercus cyanomelas_African Crested-Flycatcher
-Trochocercus nitens_Blue-headed Crested-Flycatcher
-Troglodytes aedon_House Wren
-Troglodytes hiemalis_Winter Wren
-Troglodytes ochraceus_Ochraceous Wren
-Troglodytes pacificus_Pacific Wren
-Troglodytes rufociliatus_Rufous-browed Wren
-Troglodytes solstitialis_Mountain Wren
-Troglodytes troglodytes_Kaelusrähn
-Trogon bairdii_Baird's Trogon
+Trochalopteron affine_Mägi-vilevädrak
+Trochalopteron chrysopterum_Hallpõsk-vilevädrak
+Trochalopteron elliotii_Hiina vilevädrak
+Trochalopteron erythrocephalum_Himaalaja vilevädrak
+Trochalopteron henrici_Tiibeti vilevädrak
+Trochalopteron imbricatum_Bhutani vilevädrak
+Trochalopteron lineatum_Aed-vilevädrak
+Trochalopteron melanostigma_Hõbepõsk-vilevädrak
+Trochalopteron milnei_Valgepõsk-vilevädrak
+Trochalopteron morrisonianum_Taivani vilevädrak
+Trochalopteron peninsulae_Malai vilevädrak
+Trochalopteron squamatum_Mustkulm-vilevädrak
+Trochalopteron subunicolor_Võrk-vilevädrak
+Trochalopteron variegatum_Rododendroni-vilevädrak
+Trochalopteron virgatum_Triip-vilevädrak
+Trochocercus cyanomelas_Vööttiib-piibik
+Trochocercus nitens_Liaanipiibik
+Troglodytes aedon_Aedkäblik
+Troglodytes hiemalis_Ida-metskäblik
+Troglodytes ochraceus_Kostariika käblik
+Troglodytes pacificus_Lääne-metskäblik
+Troglodytes rufociliatus_Maia käblik
+Troglodytes solstitialis_Mägikäblik
+Troglodytes troglodytes_Käblik
+Trogon bairdii_Kostariika järanokk
 Trogon caligatus_Gartered Trogon
 Trogon chionurus_White-tailed Trogon
-Trogon citreolus_Citreoline Trogon
-Trogon clathratus_Lattice-tailed Trogon
-Trogon collaris_Collared Trogon
-Trogon comptus_Blue-tailed Trogon
-Trogon curucui_Blue-crowned Trogon
-Trogon elegans_Elegant Trogon
-Trogon massena_Slaty-tailed Trogon
-Trogon melanocephalus_Black-headed Trogon
-Trogon melanurus_Black-tailed Trogon
-Trogon mesurus_Ecuadorian Trogon
-Trogon mexicanus_Mountain Trogon
-Trogon personatus_Masked Trogon
+Trogon citreolus_Võsa-järanokk
+Trogon clathratus_Nõlva-järanokk
+Trogon collaris_Välu-järanokk
+Trogon comptus_Kolumbia järanokk
+Trogon curucui_Amasoonia järanokk
+Trogon elegans_Männi-järanokk
+Trogon massena_Suur-järanokk
+Trogon melanocephalus_Salu-järanokk
+Trogon melanurus_Selva-järanokk
+Trogon mesurus_Ekuadori järanokk
+Trogon mexicanus_Ülangu-järanokk
+Trogon personatus_Mägi-järanokk
 Trogon ramonianus_Amazonian Trogon
-Trogon rufus_Black-throated Trogon
-Trogon surrucura_Surucua Trogon
-Trogon violaceus_Guianan Trogon
-Trogon viridis_Green-backed Trogon
-Tropicoperdix chloropus_Scaly-breasted Partridge
+Trogon rufus_Vile-järanokk
+Trogon surrucura_Brasiilia järanokk
+Trogon violaceus_Herilase-järanokk
+Trogon viridis_Võra-järanokk
+Tropicoperdix chloropus_Rohejalg-künkakana
 Tumbezia salvini_Tumbes Tyrant
 Tunchiornis ochraceiceps_Tawny-crowned Greenlet
 Turdinus atrigularis_Black-throated Wren-Babbler
 Turdinus macrodactylus_Large Wren-Babbler
 Turdinus marmoratus_Marbled Wren-Babbler
-Turdoides hartlaubii_Hartlaub's Babbler
-Turdoides jardineii_Arrow-marked Babbler
-Turdoides leucopygia_White-rumped Babbler
-Turdoides plebejus_Brown Babbler
-Turdoides reinwardtii_Blackcap Babbler
-Turdoides sharpei_Black-lored Babbler
-Turdus abyssinicus_Abyssinian Thrush
-Turdus albicollis_White-necked Thrush
-Turdus albocinctus_White-collared Blackbird
-Turdus amaurochalinus_Creamy-bellied Thrush
-Turdus assimilis_White-throated Thrush
-Turdus atrogularis_Black-throated Thrush
-Turdus aurantius_White-chinned Thrush
-Turdus boulboul_Gray-winged Blackbird
-Turdus cardis_Japanese Thrush
-Turdus celaenops_Izu Thrush
-Turdus chiguanco_Chiguanco Thrush
-Turdus chrysolaus_Brown-headed Thrush
-Turdus dissimilis_Black-breasted Thrush
-Turdus eunomus_Dusky Thrush
-Turdus falcklandii_Austral Thrush
-Turdus feae_Gray-sided Thrush
-Turdus flavipes_Yellow-legged Thrush
-Turdus fulviventris_Chestnut-bellied Thrush
-Turdus fumigatus_Cocoa Thrush
-Turdus fuscater_Great Thrush
-Turdus grayi_Clay-colored Thrush
-Turdus hauxwelli_Hauxwell's Thrush
-Turdus hortulorum_Gray-backed Thrush
-Turdus ignobilis_Black-billed Thrush
+Turdoides hartlaubii_Valgepära-vadavädrak
+Turdoides jardineii_Tähnik-vadavädrak
+Turdoides leucopygia_Soomus-vadavädrak
+Turdoides plebejus_Sudaani vadavädrak
+Turdoides reinwardtii_Mustpea-vadavädrak
+Turdoides sharpei_Valjas-vadavädrak
+Turdus abyssinicus_Ülangurästas
+Turdus albicollis_Valgepugu-rästas
+Turdus albocinctus_Valgekael-rästas
+Turdus amaurochalinus_Serradorästas
+Turdus assimilis_Keskameerika rästas
+Turdus atrogularis_Mustpugu-rästas
+Turdus aurantius_Sisalikurästas
+Turdus boulboul_Kahktiib-rästas
+Turdus cardis_Valgekõht-rästas
+Turdus celaenops_Aukuubarästas
+Turdus chiguanco_Põõsa-nõgirästas
+Turdus chrysolaus_Jaapani rästas
+Turdus dissimilis_Mustpea-rästas
+Turdus eunomus_Rusktiib-rästas
+Turdus falcklandii_Patagoonia rästas
+Turdus feae_Pekingi rästas
+Turdus flavipes_Süsirästas
+Turdus fulviventris_Punakõht-rästas
+Turdus fumigatus_Pruunrästas
+Turdus fuscater_Suur-nõgirästas
+Turdus grayi_Aedrästas
+Turdus hauxwelli_Tulvametsa-rästas
+Turdus hortulorum_Amuuri rästas
+Turdus ignobilis_Ljaanorästas
 Turdus iliacus_Vainurästas
-Turdus infuscatus_Black Thrush
-Turdus lawrencii_Lawrence's Thrush
-Turdus leucomelas_Pale-breasted Thrush
-Turdus leucops_Pale-eyed Thrush
-Turdus libonyana_Kurrichane Thrush
-Turdus maculirostris_Ecuadorian Thrush
-Turdus mandarinus_Chinese Blackbird
-Turdus maranonicus_Marañon Thrush
-Turdus menachensis_Yemen Thrush
+Turdus infuscatus_Pigirästas
+Turdus lawrencii_Taidurrästas
+Turdus leucomelas_Leeträstas
+Turdus leucops_Andi süsirästas
+Turdus libonyana_Miomborästas
+Turdus maculirostris_Ekuadori rästas
+Turdus mandarinus_Ida-musträstas
+Turdus maranonicus_Marañoni rästas
+Turdus menachensis_Jeemeni rästas
 Turdus merula_Musträstas
-Turdus migratorius_American Robin
-Turdus naumanni_Naumann's Thrush
-Turdus nigrescens_Sooty Thrush
-Turdus nigriceps_Andean Slaty Thrush
-Turdus nudigenis_Spectacled Thrush
-Turdus obscurus_Eyebrowed Thrush
-Turdus obsoletus_Pale-vented Thrush
-Turdus olivaceus_Olive Thrush
-Turdus olivater_Black-hooded Thrush
-Turdus pallidus_Pale Thrush
-Turdus pelios_African Thrush
+Turdus migratorius_Punarind-rästas
+Turdus naumanni_Ruskerästas
+Turdus nigrescens_Laavarästas
+Turdus nigriceps_Kilträstas
+Turdus nudigenis_Sõõrsilm-rästas
+Turdus obscurus_Taigarästas
+Turdus obsoletus_Nõlvarästas
+Turdus olivaceus_Oliivrästas
+Turdus olivater_Karbusrästas
+Turdus pallidus_Mandžuuria rästas
+Turdus pelios_Kaldarästas
 Turdus philomelos_Laulurästas
 Turdus pilaris_Hallrästas
-Turdus plebejus_Mountain Thrush
-Turdus plumbeus_Red-legged Thrush
-Turdus poliocephalus_Island Thrush
-Turdus reevei_Plumbeous-backed Thrush
-Turdus rubrocanus_Chestnut Thrush
-Turdus ruficollis_Red-throated Thrush
-Turdus rufitorques_Rufous-collared Robin
-Turdus rufiventris_Rufous-bellied Thrush
-Turdus rufopalliatus_Rufous-backed Robin
-Turdus sanchezorum_Varzea Thrush
-Turdus serranus_Glossy-black Thrush
-Turdus simillimus_Indian Blackbird
-Turdus smithi_Karoo Thrush
-Turdus subalaris_Blacksmith Thrush
-Turdus swalesi_La Selle Thrush
-Turdus tephronotus_African Bare-eyed Thrush
-Turdus torquatus_Ring Ouzel
-Turdus unicolor_Tickell's Thrush
+Turdus plebejus_Udumetsa-rästas
+Turdus plumbeus_Punajalg-rästas
+Turdus poliocephalus_Lõunarästas
+Turdus reevei_Tinarästas
+Turdus rubrocanus_Kastanrästas
+Turdus ruficollis_Punapugu-rästas
+Turdus rufitorques_Punakael-rästas
+Turdus rufiventris_Brasiilia rästas
+Turdus rufopalliatus_Roosterästas
+Turdus sanchezorum_Varzearästas
+Turdus serranus_Salu-nõgirästas
+Turdus simillimus_India musträstas
+Turdus smithi_Karoo rästas
+Turdus subalaris_Araukaariarästas
+Turdus swalesi_Haiti rästas
+Turdus tephronotus_Prillrästas
+Turdus torquatus_Kaelusrästas
+Turdus unicolor_Himaalaja rästas
 Turdus viscivorus_Hoburästas
-Turnix maculosus_Red-backed Buttonquail
-Turnix suscitator_Barred Buttonquail
-Turnix sylvaticus_Small Buttonquail
-Turnix varius_Painted Buttonquail
-Turtur abyssinicus_Black-billed Wood-Dove
-Turtur afer_Blue-spotted Wood-Dove
-Turtur brehmeri_Blue-headed Wood-Dove
-Turtur chalcospilos_Emerald-spotted Wood-Dove
-Turtur tympanistria_Tambourine Dove
-Tylas eduardi_Tylas Vanga
-Tympanuchus cupido_Greater Prairie-Chicken
-Tympanuchus pallidicinctus_Lesser Prairie-Chicken
-Tympanuchus phasianellus_Sharp-tailed Grouse
-Tyranneutes stolzmanni_Dwarf Tyrant-Manakin
-Tyranneutes virescens_Tiny Tyrant-Manakin
-Tyrannopsis sulphurea_Sulphury Flycatcher
+Turnix maculosus_Rohuledik
+Turnix suscitator_Vöötledik
+Turnix sylvaticus_Vuttledik
+Turnix varius_Suurledik
+Turtur abyssinicus_Sudaani halatuvi
+Turtur afer_Sinitähn-halatuvi
+Turtur brehmeri_Sinipea-tuvi
+Turtur chalcospilos_Savanni-halatuvi
+Turtur tympanistria_Tamburiintuvi
+Tylas eduardi_Kinkimavu
+Tympanuchus cupido_Preeriapüü
+Tympanuchus pallidicinctus_Väike-preeriapüü
+Tympanuchus phasianellus_Välupüü
+Tyranneutes stolzmanni_Väike-tantsulind
+Tyranneutes virescens_Pisi-tantsulind
+Tyrannopsis sulphurea_Palmi-masktikat
 Tyrannulus elatus_Yellow-crowned Tyrannulet
-Tyrannus albogularis_White-throated Kingbird
-Tyrannus caudifasciatus_Loggerhead Kingbird
-Tyrannus couchii_Couch's Kingbird
-Tyrannus crassirostris_Thick-billed Kingbird
-Tyrannus dominicensis_Gray Kingbird
-Tyrannus forficatus_Scissor-tailed Flycatcher
-Tyrannus melancholicus_Tropical Kingbird
-Tyrannus niveigularis_Snowy-throated Kingbird
-Tyrannus savana_Fork-tailed Flycatcher
-Tyrannus tyrannus_Eastern Kingbird
-Tyrannus verticalis_Western Kingbird
-Tyrannus vociferans_Cassin's Kingbird
-Tyto alba_Barn Owl
-Tyto novaehollandiae_Australian Masked-Owl
-Tyto tenebricosa_Sooty Owl
+Tyrannus albogularis_Kahkpea- türanntikat
+Tyrannus caudifasciatus_Antilli türanntikat
+Tyrannus couchii_Ahasnokk-türanntikat
+Tyrannus crassirostris_Jämenokk-türanntikat
+Tyrannus dominicensis_Hall-türanntikat
+Tyrannus forficatus_Käärsaba-tikat
+Tyrannus melancholicus_Lõuna-türanntikat
+Tyrannus niveigularis_Valgepugu-türanntikat
+Tyrannus savana_Lõhissaba-tikat
+Tyrannus tyrannus_Karbus-türanntikat
+Tyrannus verticalis_Lääne-türanntikat
+Tyrannus vociferans_Salu-türanntikat
+Tyto alba_Loorkakk
+Tyto novaehollandiae_Lõuna-loorkakk
+Tyto tenebricosa_Nõgi-loorkakk
 Upucerthia dumetaria_Scale-throated Earthcreeper
 Upucerthia saturatior_Patagonian Forest Earthcreeper
 Upucerthia validirostris_Buff-breasted Earthcreeper
 Upupa epops_Vaenukägu
-Upupa marginata_Madagascar Hoopoe
-Uraeginthus angolensis_Southern Cordonbleu
-Uraeginthus bengalus_Red-cheeked Cordonbleu
-Uranomitra franciae_Andean Emerald
-Uria aalge_Common Murre
-Uria lomvia_Thick-billed Murre
-Urocissa caerulea_Taiwan Blue-Magpie
-Urocissa erythroryncha_Red-billed Blue-Magpie
-Urocissa flavirostris_Yellow-billed Blue-Magpie
-Urocissa ornata_Sri Lanka Blue-Magpie
-Urocolius indicus_Red-faced Mousebird
-Urocolius macrourus_Blue-naped Mousebird
+Upupa marginata_Madagaskari vaenukägu
+Uraeginthus angolensis_Savanni-lasuuramadiin
+Uraeginthus bengalus_Aed-lasuuramadiin
+Uranomitra franciae_Andi safiirkoolibri
+Uria aalge_Lõunatirk
+Uria lomvia_Põhjatirk
+Urocissa caerulea_Taivani lasuurharakas
+Urocissa erythroryncha_Hiina lasuurharakas
+Urocissa flavirostris_Himaalaja lasuurharakas
+Urocissa ornata_Tseiloni lasuurharakas
+Urocolius indicus_Mask-hiirlind
+Urocolius macrourus_Hall-hiirlind
 Urocynchramus pylzowi_Przevalski's Pinktail
-Urodynamis taitensis_Long-tailed Koel
+Urodynamis taitensis_Maoori koelkägu
 Uromyias agilis_Agile Tit-Tyrant
 Uromyias agraphia_Unstreaked Tit-Tyrant
-Uropsalis lyra_Lyre-tailed Nightjar
-Uropsalis segmentata_Swallow-tailed Nightjar
-Uropsila leucogastra_White-bellied Wren
-Urosphena pallidipes_Pale-footed Bush Warbler
-Urosphena squameiceps_Asian Stubtail
-Urosphena subulata_Timor Stubtail
-Urosphena whiteheadi_Bornean Stubtail
+Uropsalis lyra_Lüüra-öösorr
+Uropsalis segmentata_Pääsu-öösorr
+Uropsila leucogastra_Bromeeliakäblik
+Urosphena pallidipes_Kahkjalg-rädilind
+Urosphena squameiceps_Taiga-rädilind
+Urosphena subulata_Timori rädilind
+Urosphena whiteheadi_Kalimantani rädilind
 Urothraupis stolzmanni_Black-backed Bush Tanager
-Urotriorchis macrourus_Long-tailed Hawk
-Vanellus armatus_Blacksmith Lapwing
-Vanellus cayanus_Pied Lapwing
-Vanellus chilensis_Southern Lapwing
-Vanellus cinereus_Gray-headed Lapwing
-Vanellus coronatus_Crowned Lapwing
-Vanellus duvaucelii_River Lapwing
-Vanellus indicus_Red-wattled Lapwing
-Vanellus leucurus_White-tailed Lapwing
-Vanellus malabaricus_Yellow-wattled Lapwing
-Vanellus melanocephalus_Spot-breasted Lapwing
-Vanellus melanopterus_Black-winged Lapwing
-Vanellus miles_Masked Lapwing
-Vanellus resplendens_Andean Lapwing
-Vanellus senegallus_Wattled Lapwing
-Vanellus spinosus_Spur-winged Lapwing
-Vanellus tectus_Black-headed Lapwing
-Vanellus tricolor_Banded Lapwing
+Urotriorchis macrourus_Pikksaba-kull
+Vanellus armatus_Seppkiivitaja
+Vanellus cayanus_Maskkiivitaja
+Vanellus chilensis_Lõunakiivitaja
+Vanellus cinereus_Hallpea-kiivitaja
+Vanellus coronatus_Kroonkiivitaja
+Vanellus duvaucelii_Jõgikiivitaja
+Vanellus indicus_Sagarkiivitaja
+Vanellus leucurus_Valgesaba-kiivitaja
+Vanellus malabaricus_India kiivitaja
+Vanellus melanocephalus_Etioopia kiivitaja
+Vanellus melanopterus_Karjakiivitaja
+Vanellus miles_Lokutkiivitaja
+Vanellus resplendens_Andi kiivitaja
+Vanellus senegallus_Kriimkiivitaja
+Vanellus spinosus_Valgekael-kiivitaja
+Vanellus tectus_Kõnnukiivitaja
+Vanellus tricolor_Pardkiivitaja
 Vanellus vanellus_Kiivitaja
-Vanga curvirostris_Hook-billed Vanga
-Vermivora chrysoptera_Golden-winged Warbler
-Vermivora cyanoptera_Blue-winged Warbler
+Vanga curvirostris_Pugalvanga
+Vermivora chrysoptera_Kuldtiib-säälik
+Vermivora cyanoptera_Välusäälik
 Vidua chalybeata_Village Indigobird
-Vidua fischeri_Straw-tailed Whydah
+Vidua fischeri_Õlgsaba-viidas
 Vidua funerea_Variable Indigobird
-Vidua macroura_Pin-tailed Whydah
-Vireo altiloquus_Black-whiskered Vireo
-Vireo atricapilla_Black-capped Vireo
-Vireo bairdi_Cozumel Vireo
-Vireo bellii_Bell's Vireo
+Vidua macroura_Pugalviidas
+Vireo altiloquus_Antilli virelind
+Vireo atricapilla_Mustpea-virelind
+Vireo bairdi_Cozumeli virelind
+Vireo bellii_Kalda-virelind
 Vireo brevipennis_Slaty Vireo
-Vireo carmioli_Yellow-winged Vireo
-Vireo cassinii_Cassin's Vireo
+Vireo carmioli_Kostariika virelind
+Vireo cassinii_Lääne-virelind
 Vireo chivi_Chivi Vireo
-Vireo crassirostris_Thick-billed Vireo
-Vireo flavifrons_Yellow-throated Vireo
+Vireo crassirostris_Bahama virelind
+Vireo flavifrons_Kuldkurk-virelind
 Vireo flavoviridis_Yellow-green Vireo
-Vireo gilvus_Warbling Vireo
-Vireo gracilirostris_Noronha Vireo
-Vireo griseus_White-eyed Vireo
-Vireo gundlachii_Cuban Vireo
+Vireo gilvus_Laulu-virelind
+Vireo gracilirostris_Noronha virelind
+Vireo griseus_Võsa-virelind
+Vireo gundlachii_Kuuba virelind
 Vireo huttoni_Hutton's Vireo
 Vireo hypochryseus_Golden Vireo
-Vireo latimeri_Puerto Rican Vireo
-Vireo leucophrys_Brown-capped Vireo
-Vireo magister_Yucatan Vireo
+Vireo latimeri_Puertoriiko virelind
+Vireo leucophrys_Pruunselg-virelind
+Vireo magister_Yucatani virelind
 Vireo masteri_Choco Vireo
-Vireo modestus_Jamaican Vireo
+Vireo modestus_Vööt-virelind
 Vireo nelsoni_Dwarf Vireo
-Vireo olivaceus_Red-eyed Vireo
-Vireo pallens_Mangrove Vireo
-Vireo philadelphicus_Philadelphia Vireo
-Vireo plumbeus_Plumbeous Vireo
+Vireo olivaceus_Hallkiird-virelind
+Vireo pallens_Mangroovi-virelind
+Vireo philadelphicus_Kanada virelind
+Vireo plumbeus_Männi-virelind
 Vireo sclateri_Tepui Vireo
-Vireo solitarius_Blue-headed Vireo
-Vireo vicinior_Gray Vireo
+Vireo solitarius_Prill-virelind
+Vireo vicinior_Hall-virelind
 Vireolanius eximius_Yellow-browed Shrike-Vireo
 Vireolanius leucotis_Slaty-capped Shrike-Vireo
 Vireolanius melitophrys_Chestnut-sided Shrike-Vireo
@@ -6408,30 +6408,30 @@ Volatinia jacarina_Blue-black Grassquit
 Wetmorethraupis sterrhopteron_Orange-throated Tanager
 Willisornis poecilinotus_Common Scale-backed Antbird
 Willisornis vidua_Xingu Scale-backed Antbird
-Xanthocephalus xanthocephalus_Yellow-headed Blackbird
-Xanthomixis zosterops_Spectacled Tetraka
-Xanthopsar flavus_Saffron-cowled Blackbird
+Xanthocephalus xanthocephalus_Hundinuia-turpial
+Xanthomixis zosterops_Prill-farifutša
+Xanthopsar flavus_Safranturpial
 Xanthotis macleayanus_Macleay's Honeyeater
-Xema sabini_Sabine's Gull
+Xema sabini_Harksaba-kajakas
 Xenerpestes singularis_Equatorial Graytail
 Xenodacnis parina_Tit-like Dacnis
-Xenoglaux loweryi_Long-whiskered Owlet
-Xenopipo atronitens_Black Manakin
-Xenopirostris damii_Van Dam's Vanga
-Xenopirostris polleni_Pollen's Vanga
+Xenoglaux loweryi_Udekakk
+Xenopipo atronitens_Must-tantsulind
+Xenopirostris damii_Tumeselg-karbusvanga
+Xenopirostris polleni_Mustpugu-karbusvanga
 Xenops minutus_Plain Xenops
 Xenops rutilans_Streaked Xenops
 Xenops tenuirostris_Slender-billed Xenops
 Xenopsaris albinucha_White-naped Xenopsaris
-Xenospiza baileyi_Sierra Madre Sparrow
+Xenospiza baileyi_Muulaheina-sidrik
 Xenotriccus callizonus_Belted Flycatcher
 Xenotriccus mexicanus_Pileated Flycatcher
-Xenus cinereus_Terek Sandpiper
-Xiphidiopicus percussus_Cuban Green Woodpecker
+Xenus cinereus_Hallkibu
+Xiphidiopicus percussus_Viherrähn
 Xiphocolaptes albicollis_White-throated Woodcreeper
 Xiphocolaptes major_Great Rufous Woodcreeper
 Xiphocolaptes promeropirhynchus_Strong-billed Woodcreeper
-Xipholena punicea_Pompadour Cotinga
+Xipholena punicea_Purpurkotinga
 Xiphorhynchus elegans_Elegant Woodcreeper
 Xiphorhynchus erythropygius_Spotted Woodcreeper
 Xiphorhynchus flavigaster_Ivory-billed Woodcreeper
@@ -6450,31 +6450,31 @@ Yuhina flavicollis_Whiskered Yuhina
 Yuhina gularis_Stripe-throated Yuhina
 Yuhina nigrimenta_Black-chinned Yuhina
 Yuhina occipitalis_Rufous-vented Yuhina
-Yungipicus canicapillus_Gray-capped Pygmy Woodpecker
-Yungipicus kizuki_Japanese Pygmy Woodpecker
-Yungipicus moluccensis_Sunda Pygmy Woodpecker
-Yungipicus nanus_Brown-capped Pygmy Woodpecker
-Zapornia bicolor_Black-tailed Crake
-Zapornia flavirostra_Black Crake
-Zapornia fusca_Ruddy-breasted Crake
-Zapornia parva_Little Crake
-Zapornia paykullii_Band-bellied Crake
-Zapornia pusilla_Baillon's Crake
-Zapornia tabuensis_Spotless Crake
-Zavattariornis stresemanni_Stresemann's Bush-Crow
-Zebrilus undulatus_Zigzag Heron
-Zeledonia coronata_Wrenthrush
-Zenaida asiatica_White-winged Dove
-Zenaida auriculata_Eared Dove
-Zenaida aurita_Zenaida Dove
-Zenaida macroura_Mourning Dove
-Zenaida meloda_West Peruvian Dove
-Zentrygon albifacies_White-faced Quail-Dove
-Zentrygon carrikeri_Tuxtla Quail-Dove
-Zentrygon frenata_White-throated Quail-Dove
-Zentrygon goldmani_Russet-crowned Quail-Dove
-Zentrygon lawrencii_Purplish-backed Quail-Dove
-Zentrygon linearis_Lined Quail-Dove
+Yungipicus canicapillus_Hallkiird-kirjurähn
+Yungipicus kizuki_Jaapani kirjurähn
+Yungipicus moluccensis_Džungli-kirjurähn
+Yungipicus nanus_Pisi-kirjurähn
+Zapornia bicolor_Mustsaba-huik
+Zapornia flavirostra_Musthuik
+Zapornia fusca_Kaneelhuik
+Zapornia parva_Väikehuik
+Zapornia paykullii_Mandariinhuik
+Zapornia pusilla_Värbhuik
+Zapornia tabuensis_Putoto-huik
+Zavattariornis stresemanni_Akaatsianäär
+Zebrilus undulatus_Viirhüüp
+Zeledonia coronata_Nõgisäälik
+Zenaida asiatica_Valgetiib-tuvi
+Zenaida auriculata_Lõuna-ruugetuvi
+Zenaida aurita_Antilli ruugetuvi
+Zenaida macroura_Händ-ruugetuvi
+Zenaida meloda_Peruu valgetiib-tuvi
+Zentrygon albifacies_Maia töbituvi
+Zentrygon carrikeri_Veracruzi töbituvi
+Zentrygon frenata_Mägi-töbituvi
+Zentrygon goldmani_Panama töbituvi
+Zentrygon lawrencii_Valjas-töbituvi
+Zentrygon linearis_Tuhk-töbituvi
 Zimmerius acer_Guianan Tyrannulet
 Zimmerius albigularis_Choco Tyrannulet
 Zimmerius bolivianus_Bolivian Tyrannulet
@@ -6485,38 +6485,38 @@ Zimmerius parvus_Mistletoe Tyrannulet
 Zimmerius vilissimus_Guatemalan Tyrannulet
 Zimmerius villarejoi_Mishana Tyrannulet
 Zimmerius viridiflavus_Peruvian Tyrannulet
-Zonotrichia albicollis_White-throated Sparrow
-Zonotrichia atricapilla_Golden-crowned Sparrow
-Zonotrichia capensis_Rufous-collared Sparrow
-Zonotrichia leucophrys_White-crowned Sparrow
-Zonotrichia querula_Harris's Sparrow
-Zoothera aurea_White's Thrush
-Zoothera heinei_Russet-tailed Thrush
-Zoothera lunulata_Bassian Thrush
-Zoothera major_Amami Thrush
-Zosterops abyssinicus_Abyssinian White-eye
-Zosterops anderssoni_Southern Yellow White-eye
+Zonotrichia albicollis_Valgekurk-sidrik
+Zonotrichia atricapilla_Kuldkiird-sidrik
+Zonotrichia capensis_Aedsidrik
+Zonotrichia leucophrys_Valgekiird-sidrik
+Zonotrichia querula_Kuusesidrik
+Zoothera aurea_Põhja-kirjurästas
+Zoothera heinei_Korallimere kirjurästas
+Zoothera lunulata_Austraalia kirjurästas
+Zoothera major_Amami kirjurästas
+Zosterops abyssinicus_Aksumi prilliklind
+Zosterops anderssoni_Bantu prilliklind
 Zosterops atricapilla_Black-capped White-eye
 Zosterops atriceps_Cream-throated White-eye
 Zosterops atrifrons_Black-crowned White-eye
 Zosterops auriventer_Hume's White-eye
-Zosterops ceylonensis_Sri Lanka White-eye
-Zosterops chloronothos_Mauritius White-eye
+Zosterops ceylonensis_Tseiloni prilliklind
+Zosterops chloronothos_Kõvernokk-prilliklind
 Zosterops citrinella_Ashy-bellied White-eye
-Zosterops erythropleurus_Chestnut-flanked White-eye
-Zosterops eurycricotus_Kilimanjaro White-eye
+Zosterops erythropleurus_Ussuuri prilliklind
+Zosterops eurycricotus_Kilimandžaro prilliklind
 Zosterops everetti_Everett's White-eye
-Zosterops flavifrons_Yellow-fronted White-eye
-Zosterops flavilateralis_Pale White-eye
+Zosterops flavifrons_Vanuatu prilliklind
+Zosterops flavilateralis_Akaatsia-prilliklind
 Zosterops japonicus_Warbling White-eye
-Zosterops lateralis_Silvereye
-Zosterops luteus_Australian Yellow White-eye
-Zosterops maderaspatanus_Malagasy White-eye
-Zosterops mauritianus_Mauritius Gray White-eye
+Zosterops lateralis_Lõuna-prilliklind
+Zosterops luteus_Mangroovi-prilliklind
+Zosterops maderaspatanus_Madagaskari prilliklind
+Zosterops mauritianus_Hõbe-prilliklind
 Zosterops metcalfii_Yellow-throated White-eye
-Zosterops meyeni_Lowland White-eye
-Zosterops pallidus_Orange River White-eye
+Zosterops meyeni_Madaliku-prilliklind
+Zosterops pallidus_Oranje prilliklind
 Zosterops palpebrosus_Indian White-eye
-Zosterops senegalensis_Northern Yellow White-eye
+Zosterops senegalensis_Salu-prilliklind
 Zosterops simplex_Swinhoe's White-eye
 Zosterops virens_Cape White-eye


### PR DESCRIPTION
## Summary

Update `internal/classifier/data/labels/V2.4/BirdNET_GLOBAL_6K_V2.4_Labels_et_ee.txt` by replacing English common names with Estonian names where an exact Latin-name match was available from official EOÜ naming sources.

## Changes

- Replace English label values after `_` with EOÜ-backed Estonian bird names matched by Latin taxon
- Prefer wording from the EOÜ Estonia bird list when both EOÜ sources covered the same species
- Keep the original Latin taxon keys unchanged
- Document the EOÜ sources used for the translation review

## Testing

- [ ] Go tests pass (`task test`)
- [ ] Frontend tests pass (`task frontend-test`)
- [ ] Linting passes
- [x] Manual testing completed

Manual verification:
- Reviewed the updated labels against EOÜ sources using Latin-name matching
- Spot-checked representative replacements in the updated file

Sources used:
- https://www.eoy.ee/ET/list-of-estonian-birds/
- https://www.eoy.ee/ET/16/31/birdnames/

## Related Issues

No related issue was referenced for this data correction.
