### PR TITLE
fix(diskmanager): default log level to info to prevent log flooding

### DIFF
--- a/internal/conf/defaults.go
+++ b/internal/conf/defaults.go
@@ -45,16 +45,17 @@ func setDefaultConfig() {
 	setModuleLogDefaults("ebird", false)       // eBird integration (disabled by default)
 
 	// System and support modules
-	setModuleLogDefaults("backup", true)        // Backup operations
-	setModuleLogDefaults("config", true)        // Configuration management
-	setModuleLogDefaults("diskmanager", true)   // Disk management
-	setModuleLogDefaults("events", true)        // Event bus
-	setModuleLogDefaults("imageprovider", true) // Bird image provider
-	setModuleLogDefaults("monitor", true)       // System monitoring
-	setModuleLogDefaults("notifications", true) // Push notifications
-	setModuleLogDefaults("securefs", true)      // Secure filesystem operations
-	setModuleLogDefaults("support", true)       // Support/diagnostics
-	setModuleLogDefaults("telemetry", true)     // Telemetry/metrics
+	setModuleLogDefaults("backup", true)                          // Backup operations
+	setModuleLogDefaults("config", true)                          // Configuration management
+	setModuleLogDefaults("diskmanager", true)                     // Disk management
+	viper.SetDefault("logging.modules.diskmanager.level", "info") // Override: runs per-clip, debug floods log
+	setModuleLogDefaults("events", true)                          // Event bus
+	setModuleLogDefaults("imageprovider", true)                   // Bird image provider
+	setModuleLogDefaults("monitor", true)                         // System monitoring
+	setModuleLogDefaults("notifications", true)                   // Push notifications
+	setModuleLogDefaults("securefs", true)                        // Secure filesystem operations
+	setModuleLogDefaults("support", true)                         // Support/diagnostics
+	setModuleLogDefaults("telemetry", true)                       // Telemetry/metrics
 
 	// Main configuration
 	viper.SetDefault("main.name", "BirdNET-Go")

--- a/internal/conf/logging_config_test.go
+++ b/internal/conf/logging_config_test.go
@@ -239,3 +239,16 @@ func TestLoggingModuleLevelInfoFiltersDebug(t *testing.T) {
 	assert.NotContains(t, string(content), "should not appear", "Debug messages should be filtered at info level")
 	assert.Contains(t, string(content), "should appear")
 }
+
+// TestDiskmanagerModuleDefaultLogLevelIsInfo verifies that the diskmanager module
+// defaults to "info" log level, not "debug". The diskmanager runs frequently and
+// logs one DEBUG line per candidate clip per cycle, so a "debug" default causes
+// log files to balloon to 100+ MB/day with no user-visible control.
+func TestDiskmanagerModuleDefaultLogLevelIsInfo(t *testing.T) {
+	// Not parallel: reads global viper defaults set by setDefaultConfig.
+	setDefaultConfig()
+
+	level := viper.GetString("logging.modules.diskmanager.level")
+	assert.Equal(t, "info", level,
+		"diskmanager module must default to info level; debug default floods the log file with per-clip entries")
+}

--- a/internal/conf/logging_config_test.go
+++ b/internal/conf/logging_config_test.go
@@ -245,7 +245,9 @@ func TestLoggingModuleLevelInfoFiltersDebug(t *testing.T) {
 // logs one DEBUG line per candidate clip per cycle, so a "debug" default causes
 // log files to balloon to 100+ MB/day with no user-visible control.
 func TestDiskmanagerModuleDefaultLogLevelIsInfo(t *testing.T) {
-	// Not parallel: reads global viper defaults set by setDefaultConfig.
+	// Not parallel: reads/writes global viper defaults set by setDefaultConfig.
+	viper.Reset()
+	t.Cleanup(viper.Reset)
 	setDefaultConfig()
 
 	level := viper.GetString("logging.modules.diskmanager.level")

--- a/internal/diskmanager/file_utils.go
+++ b/internal/diskmanager/file_utils.go
@@ -114,12 +114,11 @@ type walkState struct {
 	parseErrorCount int
 	firstParseError error
 	maxParseErrors  int
-	debug           bool
 }
 
 // GetAudioFiles returns a list of audio files in the directory and its subdirectories
-func GetAudioFiles(baseDir string, allowedExts []string, db Interface, debug bool) ([]FileInfo, error) {
-	return GetAudioFilesContext(context.Background(), baseDir, allowedExts, db, debug)
+func GetAudioFiles(baseDir string, allowedExts []string, db Interface) ([]FileInfo, error) {
+	return GetAudioFilesContext(context.Background(), baseDir, allowedExts, db)
 }
 
 // createWalkFunc creates the filepath.Walk function with all necessary context
@@ -133,7 +132,7 @@ func createWalkFunc(state *walkState) filepath.WalkFunc {
 		}
 
 		if err != nil {
-			return handleWalkError(err, path, state.debug)
+			return handleWalkError(err, path)
 		}
 
 		// Skip hidden directories (dot-prefixed) like .processing-cache
@@ -152,7 +151,7 @@ func createWalkFunc(state *walkState) filepath.WalkFunc {
 }
 
 // handleWalkError handles errors during filepath.Walk, specifically temp file race conditions
-func handleWalkError(err error, path string, _ bool) error {
+func handleWalkError(err error, path string) error {
 	// Handle race condition where temp files are renamed between directory
 	// listing and lstat call. If the error is "no such file or directory"
 	// and the path appears to be a temp file, continue walking.
@@ -213,7 +212,7 @@ func processFile(path string, info os.FileInfo, state *walkState) {
 }
 
 // GetAudioFilesContext returns a list of audio files in the directory and its subdirectories with context support for cancellation
-func GetAudioFilesContext(ctx context.Context, baseDir string, allowedExts []string, db Interface, debug bool) ([]FileInfo, error) {
+func GetAudioFilesContext(ctx context.Context, baseDir string, allowedExts []string, db Interface) ([]FileInfo, error) {
 	// Fast path: empty allowed extensions
 	if len(allowedExts) == 0 {
 		return nil, nil
@@ -278,7 +277,6 @@ func GetAudioFilesContext(ctx context.Context, baseDir string, allowedExts []str
 		parseErrorCount: parseErrorCount,
 		firstParseError: firstParseError,
 		maxParseErrors:  maxParseErrors,
-		debug:           debug,
 	}
 
 	err = filepath.Walk(baseDir, createWalkFunc(state))

--- a/internal/diskmanager/file_utils_bench_test.go
+++ b/internal/diskmanager/file_utils_bench_test.go
@@ -36,7 +36,7 @@ func BenchmarkGetAudioFiles(b *testing.B) {
 	b.ReportAllocs()
 
 	for b.Loop() {
-		_, err := GetAudioFiles(tempDir, allowedFileTypes, mockDB, false)
+		_, err := GetAudioFiles(tempDir, allowedFileTypes, mockDB)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -129,7 +129,7 @@ func BenchmarkMemoryProfile(b *testing.B) {
 			b.ReportAllocs()
 
 			for b.Loop() {
-				_, err := GetAudioFiles(tempDir, allowedFileTypes, mockDB, false)
+				_, err := GetAudioFiles(tempDir, allowedFileTypes, mockDB)
 				if err != nil {
 					b.Fatal(err)
 				}
@@ -170,7 +170,7 @@ func BenchmarkPoolEffectiveness(b *testing.B) {
 		b.ReportAllocs()
 
 		for b.Loop() {
-			_, err := GetAudioFiles(tempDir, allowedFileTypes, mockDB, false)
+			_, err := GetAudioFiles(tempDir, allowedFileTypes, mockDB)
 			if err != nil {
 				b.Fatal(err)
 			}
@@ -213,7 +213,7 @@ func BenchmarkErrorHandling(b *testing.B) {
 	b.ReportAllocs()
 
 	for b.Loop() {
-		files, err := GetAudioFiles(tempDir, allowedFileTypes, mockDB, false)
+		files, err := GetAudioFiles(tempDir, allowedFileTypes, mockDB)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/internal/diskmanager/file_utils_test.go
+++ b/internal/diskmanager/file_utils_test.go
@@ -203,7 +203,7 @@ func TestGetAudioFilesSkipsNonBirdNETFiles(t *testing.T) {
 	}
 
 	mockDB := &MockDB{}
-	files, err := GetAudioFiles(tempDir, allowedFileTypes, mockDB, false)
+	files, err := GetAudioFiles(tempDir, allowedFileTypes, mockDB)
 
 	require.NoError(t, err, "non-BirdNET files should not cause errors")
 	require.Len(t, files, 1)
@@ -221,7 +221,7 @@ func TestGetAudioFilesOnlyNonBirdNETFiles(t *testing.T) {
 	}
 
 	mockDB := &MockDB{}
-	files, err := GetAudioFiles(tempDir, allowedFileTypes, mockDB, false)
+	files, err := GetAudioFiles(tempDir, allowedFileTypes, mockDB)
 
 	require.NoError(t, err, "directory with only non-BirdNET files should not error")
 	assert.Empty(t, files)
@@ -246,8 +246,7 @@ func TestGetAudioFilesContinuesOnError(t *testing.T) {
 	// Create a mock DB
 	mockDB := &MockDB{}
 
-	// Call GetAudioFiles with debug enabled to see the error messages
-	files, err := GetAudioFiles(tempDir, allowedFileTypes, mockDB, true)
+	files, err := GetAudioFiles(tempDir, allowedFileTypes, mockDB)
 
 	// Should not return an error as long as at least one file is valid
 	require.NoError(t, err, "Should not return an error when at least one file is valid")
@@ -284,8 +283,7 @@ func TestGetAudioFilesWithMixedFiles(t *testing.T) {
 	// Create a mock DB
 	mockDB := &MockDB{}
 
-	// Call GetAudioFiles with debug enabled to see the error messages
-	files, err := GetAudioFiles(tempDir, allowedFileTypes, mockDB, true)
+	files, err := GetAudioFiles(tempDir, allowedFileTypes, mockDB)
 
 	// Should not return an error as long as at least one file is valid
 	require.NoError(t, err, "Should not return an error when at least one file is valid")
@@ -311,7 +309,7 @@ func TestGetAudioFilesWithMixedFiles(t *testing.T) {
 	}
 
 	// Call GetAudioFiles with all invalid files
-	files, err = GetAudioFiles(invalidOnlyDir, allowedFileTypes, mockDB, true)
+	files, err = GetAudioFiles(invalidOnlyDir, allowedFileTypes, mockDB)
 
 	// Should return an error when all files are invalid
 	require.Error(t, err, "Should return an error when all files are invalid")
@@ -414,7 +412,7 @@ func TestGetAudioFilesIgnoresTempFiles(t *testing.T) {
 	mockDB := &MockDB{}
 
 	// Call GetAudioFiles
-	files, err := GetAudioFiles(tempDir, allowedFileTypes, mockDB, false)
+	files, err := GetAudioFiles(tempDir, allowedFileTypes, mockDB)
 
 	// Should not return an error
 	require.NoError(t, err, "Should not return an error")
@@ -458,7 +456,7 @@ func TestGetAudioFilesHandlesTempFileRaceCondition(t *testing.T) {
 
 	// We'll test this by using a custom walk function that simulates the error
 	// First, let's verify normal operation works
-	files, err := GetAudioFiles(tempDir, allowedFileTypes, mockDB, false)
+	files, err := GetAudioFiles(tempDir, allowedFileTypes, mockDB)
 	require.NoError(t, err, "Should not return an error for normal operation")
 	assert.Len(t, files, 1, "Should return the valid file")
 	assert.Equal(t, "bubo_bubo", files[0].Species, "Should process the valid file correctly")
@@ -480,21 +478,21 @@ func TestHandleWalkError(t *testing.T) {
 	tempDir := t.TempDir()
 
 	// Test case 1: os.IsNotExist error for a .temp file should be ignored
-	err := handleWalkError(os.ErrNotExist, filepath.Join(tempDir, "foo.wav.temp"), true)
+	err := handleWalkError(os.ErrNotExist, filepath.Join(tempDir, "foo.wav.temp"))
 	require.NoError(t, err, "missing .temp file should be ignored")
 
 	// Test case 2: os.IsNotExist error for a .TEMP file (uppercase) should be ignored
-	err = handleWalkError(os.ErrNotExist, filepath.Join(tempDir, "bar.wav.TEMP"), true)
+	err = handleWalkError(os.ErrNotExist, filepath.Join(tempDir, "bar.wav.TEMP"))
 	require.NoError(t, err, "missing .TEMP file (uppercase) should be ignored")
 
 	// Test case 3: os.IsNotExist error for a non-temp file should propagate
-	err = handleWalkError(os.ErrNotExist, filepath.Join(tempDir, "baz.wav"), false)
+	err = handleWalkError(os.ErrNotExist, filepath.Join(tempDir, "baz.wav"))
 	require.Error(t, err, "missing non-temp file should not be ignored")
 	require.ErrorIs(t, err, os.ErrNotExist, "should return the original error")
 
 	// Test case 4: Other errors should always propagate, even for temp files
 	permErr := os.ErrPermission
-	err = handleWalkError(permErr, filepath.Join(tempDir, "denied.wav.temp"), false)
+	err = handleWalkError(permErr, filepath.Join(tempDir, "denied.wav.temp"))
 	require.Error(t, err, "permission error should propagate even for temp files")
 	require.ErrorIs(t, err, permErr, "should return the original error")
 }

--- a/internal/diskmanager/metrics_collector.go
+++ b/internal/diskmanager/metrics_collector.go
@@ -66,8 +66,7 @@ func CollectProductionMetrics(baseDir string, allowedExts []string, db Interface
 	// Time the operation
 	startTime := time.Now()
 
-	// Run GetAudioFiles with debug enabled
-	files, err := GetAudioFiles(baseDir, allowedExts, db, true)
+	files, err := GetAudioFiles(baseDir, allowedExts, db)
 
 	processingTime := time.Since(startTime)
 	metrics.ProcessingTime = processingTime

--- a/internal/diskmanager/mocks/mock_functions.go
+++ b/internal/diskmanager/mocks/mock_functions.go
@@ -10,7 +10,7 @@ import (
 type MockFunctions struct {
 	// Mock function implementations
 	GetDiskUsage         func(path string) (float64, error)
-	GetAudioFiles        func(baseDir string, allowedExts []string, db any, debug bool) ([]any, error)
+	GetAudioFiles        func(baseDir string, allowedExts []string, db any) ([]any, error)
 	Setting              func() *conf.Settings
 	ParseRetentionPeriod func(period string) (int, error)
 	ParsePercentage      func(percentage, configKey string) (float64, error)
@@ -23,7 +23,7 @@ func NewMockFunctions() *MockFunctions {
 		GetDiskUsage: func(path string) (float64, error) {
 			return 0.0, nil
 		},
-		GetAudioFiles: func(baseDir string, allowedExts []string, db any, debug bool) ([]any, error) {
+		GetAudioFiles: func(baseDir string, allowedExts []string, db any) ([]any, error) {
 			return []any{}, nil
 		},
 		Setting: func() *conf.Settings {
@@ -48,7 +48,7 @@ func NewMockFunctions() *MockFunctions {
 var MockGetDiskUsage func(path string) (float64, error)
 
 // MockGetAudioFiles is a mock for the GetAudioFiles function
-var MockGetAudioFiles func(baseDir string, allowedExts []string, db any, debug bool) ([]any, error)
+var MockGetAudioFiles func(baseDir string, allowedExts []string, db any) ([]any, error)
 
 // MockSetting is a mock for the conf.Setting function
 var MockSetting func() *conf.Settings

--- a/internal/diskmanager/policy_age_test.go
+++ b/internal/diskmanager/policy_age_test.go
@@ -110,7 +110,7 @@ func TestAgeBasedFilesAfterFilter(t *testing.T) {
 	}
 
 	// Get audio files using the function that would be used by the policy
-	audioFiles, err := GetAudioFiles(testDir, allowedTypes, db, false)
+	audioFiles, err := GetAudioFiles(testDir, allowedTypes, db)
 	require.NoError(t, err, "Failed to get audio files")
 
 	// Verify only allowed audio files are returned

--- a/internal/diskmanager/policy_common.go
+++ b/internal/diskmanager/policy_common.go
@@ -496,14 +496,12 @@ func ShouldSkipUsageBasedCleanup(retention *conf.RetentionSettings, baseDir stri
 // If proceed is false, it also returns a completed CleanupResult.
 func prepareInitialCleanup(db Interface) (files []FileInfo, baseDir string, retention conf.RetentionSettings, proceed bool, result CleanupResult) {
 	settings := conf.Setting()
-	debug := settings.Realtime.Audio.Export.Retention.Debug
 	baseDir = settings.Realtime.Audio.Export.Path
 	retention = settings.Realtime.Audio.Export.Retention // Return the whole retention struct
 
 	GetLogger().Info("Preparing initial cleanup",
 		logger.String("base_dir", baseDir),
-		logger.String("policy", retention.Policy),
-		logger.Bool("debug", debug))
+		logger.String("policy", retention.Policy))
 
 	// OPTIMIZATION: For usage-based policy, check disk usage BEFORE scanning all files
 	// This avoids wasting CPU/IO scanning thousands of files when cleanup isn't needed
@@ -520,7 +518,7 @@ func prepareInitialCleanup(db Interface) (files []FileInfo, baseDir string, rete
 		}
 	}
 
-	files, err := GetAudioFiles(baseDir, allowedFileTypes, db, debug)
+	files, err := GetAudioFiles(baseDir, allowedFileTypes, db)
 	if err != nil {
 		// Try to get current disk usage for the result even if file listing failed
 		currentUsage, diskErr := GetDiskUsage(baseDir)


### PR DESCRIPTION
## Summary

- Changes the diskmanager module logger default level from `debug` to `info`. All module loggers inherit `"debug"` from `setModuleLogDefaults`, but diskmanager emits one DEBUG entry per candidate clip per cleanup cycle. With potentially thousands of clips and multiple cycles per hour, this produced 100+ MB log files per day with no user-visible off switch.
- Removes the dead `debug bool` parameter from `GetAudioFiles` / `GetAudioFilesContext`. The parameter was stored in `walkState.debug`, passed to `handleWalkError` (which discarded it with `_`), and had no effect on any code path. Its presence gave the false impression that `retention.debug` controlled log verbosity.
- Removes the read of `retention.Debug` in `prepareInitialCleanup` since the only use of that variable was passing it to `GetAudioFiles`, which no longer accepts it.

Users who need DEBUG output from diskmanager can set `logging.modules.diskmanager.level: debug` explicitly in their config.

## Test Plan

- [x] Added `TestDiskmanagerModuleDefaultLogLevelIsInfo` in `internal/conf/logging_config_test.go` - confirms the new default is `"info"` (was failing before the fix)
- [x] All diskmanager tests pass: `go test -race ./internal/diskmanager/...`
- [x] All conf tests pass: `go test -race ./internal/conf/...`
- [x] Full project builds clean: `go build ./...`
- [x] Zero linter issues: `golangci-lint run`

Fixes #2824

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Diskmanager default log level lowered to info, reducing its verbose output.
  * File discovery APIs simplified by removing debug/verbosity flag, reducing debug-driven output.

* **Tests**
  * New test added to verify diskmanager log-level default.
  * Existing tests and benchmarks updated to match the simplified file-discovery API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->