### PR TITLE
fix(frontend): prevent 401 redirect for guest users behind Cloudflare Tunnel

### DIFF
--- a/frontend/src/lib/stores/appState.svelte.ts
+++ b/frontend/src/lib/stores/appState.svelte.ts
@@ -400,6 +400,15 @@ export function isAccessAllowed(): boolean {
 }
 
 /**
+ * Checks if the current viewer is an unauthenticated guest (security is
+ * enabled but access has not been granted). Used to suppress login redirects
+ * and hide auth-gated UI elements.
+ */
+export function isGuestMode(): boolean {
+  return appState.security.enabled && !appState.security.accessAllowed;
+}
+
+/**
  * Gets the authentication configuration.
  *
  * @returns The auth config

--- a/frontend/src/lib/utils/api.test.ts
+++ b/frontend/src/lib/utils/api.test.ts
@@ -289,7 +289,10 @@ describe('API utilities', () => {
         headers: new Headers(),
       });
 
-      await expect(fetchWithCSRF('/api/test')).rejects.toThrow('Authentication required');
+      await expect(fetchWithCSRF('/api/test')).rejects.toMatchObject({
+        message: 'errors.api.unauthorized',
+        status: 401,
+      });
       // Should NOT redirect
       expect(window.location.href).not.toBe('/ui/');
     });

--- a/frontend/src/lib/utils/api.test.ts
+++ b/frontend/src/lib/utils/api.test.ts
@@ -3,10 +3,12 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 // Unmock the logger module for API tests since API depends on logger
 vi.unmock('$lib/utils/logger');
 
-// Mock appState module to control CSRF token in tests
+// Mock appState module to control CSRF token and security state in tests
 let mockCsrfToken = '';
+let mockGuestMode = false;
 vi.mock('$lib/stores/appState.svelte', () => ({
   getCsrfToken: () => mockCsrfToken,
+  isGuestMode: () => mockGuestMode,
   isSentryEnabled: () => false,
   refreshCsrfToken: vi.fn().mockResolvedValue(false),
 }));
@@ -22,6 +24,7 @@ describe('API utilities', () => {
 
     // Set up a default CSRF token for all tests to prevent warning logs
     mockCsrfToken = 'test-csrf-token-default';
+    mockGuestMode = false;
   });
 
   afterEach(() => {
@@ -274,6 +277,21 @@ describe('API utilities', () => {
       // window.location.href should have been set exactly once
       // (the guard prevents subsequent assignments)
       expect(window.location.href).toBe('/ui/');
+    });
+
+    it('throws ApiError instead of redirecting in guest mode', async () => {
+      mockGuestMode = true;
+
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        statusText: 'Unauthorized',
+        headers: new Headers(),
+      });
+
+      await expect(fetchWithCSRF('/api/test')).rejects.toThrow('Authentication required');
+      // Should NOT redirect
+      expect(window.location.href).not.toBe('/ui/');
     });
   });
 

--- a/frontend/src/lib/utils/api.ts
+++ b/frontend/src/lib/utils/api.ts
@@ -450,7 +450,7 @@ export async function fetchWithCSRF<T = unknown>(
     // gracefully; session-expired users redirect to login.
     if (response.status === 401) {
       if (isGuestMode()) {
-        throw new ApiError('Authentication required', 401, response);
+        throw new ApiError(getSecureErrorMessage(401), 401, response);
       }
       return redirectToLogin();
     }

--- a/frontend/src/lib/utils/api.ts
+++ b/frontend/src/lib/utils/api.ts
@@ -12,6 +12,7 @@
 import { loggers } from '$lib/utils/logger';
 import {
   getCsrfToken as getAppStateCsrfToken,
+  isGuestMode,
   isSentryEnabled,
   refreshCsrfToken,
 } from '$lib/stores/appState.svelte';
@@ -445,10 +446,12 @@ export async function fetchWithCSRF<T = unknown>(
     // Any HTTP response (even 4xx/5xx) proves the backend is reachable
     markOnline();
 
-    // 401 Unauthorized means the session has expired.  Redirect to login
-    // instead of throwing an ApiError (which would flood Sentry with
-    // expected expired-session errors across every locale).
+    // Guests get an ApiError so callers handle auth-gated endpoints
+    // gracefully; session-expired users redirect to login.
     if (response.status === 401) {
+      if (isGuestMode()) {
+        throw new ApiError('Authentication required', 401, response);
+      }
       return redirectToLogin();
     }
 


### PR DESCRIPTION
## Summary

- When security is enabled (Basic Auth/OAuth), guest users accessing via Cloudflare Tunnel were intermittently redirected back to the dashboard when navigating to detection pages
- Root cause: `fetchWithCSRF()` treated all 401 responses as "session expired" and called `redirectToLogin()`, but guests never had a session
- Fix: add `isGuestMode()` check before redirecting; guests get a thrown `ApiError` (which components handle gracefully) instead of a disruptive redirect
- The redirect now only fires for users who previously had access (genuine session expiry)

Fixes #2779

## Test Plan

- [x] All 1896 frontend tests pass (including new guest-mode test)
- [x] `npm run check:all` passes with 0 errors, 0 warnings
- [x] Verified via Cloudflare Tunnel (test-bng.pobox.fi) with Basic Auth enabled: public endpoints return 200, protected endpoints return 401 without triggering redirect
- [x] Local CodeRabbit review: no findings
- [x] Gemini peer review: no critical issues (Sentry correctly filters 401 errors)
- [ ] Manual browser test via Cloudflare Tunnel: navigate dashboard -> detection list as guest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Guest-mode authentication now returns a clear unauthorized error when session-less access fails, avoiding an automatic redirect to the login page.

* **Tests**
  * Added tests to cover guest-mode authentication error handling and to ensure guest state is reset between tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->