### PR TITLE
docs: add BirdEcho mobile companion app to related projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,10 @@ Join our [Discord server](https://discord.gg/gcSCFGUtsd) for support, discussion
 - [M5Stack Atom Echo RTSP Mic](https://github.com/stedrow/birdnetgo-m5stack-atom-echo-rtsp-mic) - RTSP audio streaming server for M5Stack Atom Echo, no soldering required
 - [M5Stack AtomS3 Lite PDM Mic](https://github.com/matthew73210/birdnetgo-m5stack-AtomS3-Lite-PDM-rtsp-mic) - RTSP audio streaming server for M5Stack AtomS3 Lite with MEMS PDM microphone
 
+### Mobile Apps
+
+- [Perch](https://github.com/arunrajiah/perch) - Open-source Android/iOS companion app. Connects to your BirdNET-Go station via the BirdWeather API. Live detection feed, audio playback, species browser, 14-day chart, and local notifications for favourite species. MIT licensed.
+
 ## Contributing
 
 **Want to contribute?** We welcome contributions from the community! 🎉


### PR DESCRIPTION
## What this changes

Adds a new **Mobile Apps** subsection to the Related Projects section, with a one-line entry for [BirdEcho](https://github.com/arunrajiah/birdecho) — an open-source mobile companion app for BirdNET-Go stations.

## Proposed addition

```markdown
### Mobile Apps

- [BirdEcho](https://github.com/arunrajiah/birdecho) - Open-source Android/iOS companion app. Connects to your BirdNET-Go station via the BirdWeather API. Live detection feed, audio playback, species browser, 14-day chart, and local notifications for favourite species. MIT licensed.
```

## Notes

- BirdEcho uses the BirdWeather API, so it requires BirdWeather integration to be enabled on the BirdNET-Go instance.
- It is not affiliated with or endorsed by the BirdNET-Go project.
- Happy to adjust wording or placement to match the project's conventions.