### PR TITLE
fix: pick up config changes from UI

### DIFF
--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -1883,6 +1883,21 @@ func GetSettings() *Settings {
 	return settingsInstance.Load()
 }
 
+// CurrentOrFallback returns the latest published settings snapshot, or the
+// supplied fallback when none has been published. It exists so long-lived
+// services can pick up UI edits without a restart: capture the initial
+// *Settings in a field, then call conf.CurrentOrFallback(s.settings) whenever
+// the value is actually read. In production the fallback is effectively
+// unreachable (settings are always loaded before services start); it's there
+// so unit tests that inject a custom *Settings into a struct literal — without
+// touching the package-global atomic pointer — keep working.
+func CurrentOrFallback(fallback *Settings) *Settings {
+	if latest := settingsInstance.Load(); latest != nil {
+		return latest
+	}
+	return fallback
+}
+
 // StoreSettings publishes a new *Settings snapshot atomically. Callers must
 // not mutate the pointee after calling StoreSettings; readers may observe the
 // snapshot concurrently through GetSettings. The canonical writer pattern is:

--- a/internal/spectrogram/generator.go
+++ b/internal/spectrogram/generator.go
@@ -227,8 +227,10 @@ func (g *Generator) currentSettings() *conf.Settings {
 
 // getDynamicRange returns the configured dynamic range value for Sox -z parameter.
 // Returns the default value ("100") if not configured or if an invalid value is set.
-func (g *Generator) getDynamicRange() string {
-	dr := g.currentSettings().Realtime.Dashboard.Spectrogram.DynamicRange
+// The settings snapshot is threaded in from the public entry point so the
+// whole generation sees a consistent view.
+func (g *Generator) getDynamicRange(settings *conf.Settings) string {
+	dr := settings.Realtime.Dashboard.Spectrogram.DynamicRange
 	if dr == "" {
 		return defaultDynamicRange
 	}
@@ -303,12 +305,17 @@ func (g *Generator) GenerateFromFile(ctx context.Context, audioPath, outputPath 
 		return err
 	}
 
+	// Capture one settings snapshot for the whole generation so SoxPath,
+	// Style, DynamicRange, etc. all read from the same view. A UI edit that
+	// lands mid-generation cannot split the output across two snapshots.
+	settings := g.currentSettings()
+
 	// Create context with timeout for Sox (see function documentation for timeout layering behavior)
 	soxCtx, soxCancel := context.WithTimeout(ctx, defaultGenerationTimeout)
 	defer soxCancel()
 
 	// Try Sox first (faster, direct processing)
-	if err := g.generateWithSoxFile(soxCtx, audioPath, outputPath, width, raw, options.preValidatedDuration); err != nil {
+	if err := g.generateWithSoxFile(soxCtx, settings, audioPath, outputPath, width, raw, options.preValidatedDuration); err != nil {
 		g.log().Warn("Sox spectrogram generation failed, falling back to FFmpeg",
 			logger.String("audio_path", audioPath),
 			logger.Error(err),
@@ -322,7 +329,7 @@ func (g *Generator) GenerateFromFile(ctx context.Context, audioPath, outputPath 
 		defer ffmpegCancel()
 
 		// Fallback to FFmpeg pipeline with fresh context
-		if ffmpegErr := g.generateWithFFmpeg(ffmpegCtx, audioPath, outputPath, width, raw); ffmpegErr != nil {
+		if ffmpegErr := g.generateWithFFmpeg(ffmpegCtx, settings, audioPath, outputPath, width, raw); ffmpegErr != nil {
 			g.log().Error("Both Sox and FFmpeg generation failed",
 				logger.String("audio_path", audioPath),
 				logger.String("sox_error", err.Error()),
@@ -393,12 +400,17 @@ func (g *Generator) GenerateFromPCM(ctx context.Context, pcmData []byte, outputP
 		return err
 	}
 
+	// Capture one settings snapshot for the whole generation so all reads
+	// (SoxPath, Style, DynamicRange, Export.Length) are consistent even if
+	// the user saves settings mid-render.
+	settings := g.currentSettings()
+
 	// Create context with timeout (see function documentation for timeout layering behavior)
 	ctx, cancel := context.WithTimeout(ctx, defaultGenerationTimeout)
 	defer cancel()
 
 	// Generate directly from PCM stdin (no FFmpeg needed)
-	if err := g.generateWithSoxPCM(ctx, pcmData, outputPath, width, raw); err != nil {
+	if err := g.generateWithSoxPCM(ctx, settings, pcmData, outputPath, width, raw); err != nil {
 		return err
 	}
 
@@ -414,8 +426,8 @@ func (g *Generator) GenerateFromPCM(ctx context.Context, pcmData []byte, outputP
 // generateWithSoxFile generates a spectrogram using Sox from an audio file.
 // If the file format is supported by Sox, it uses Sox directly.
 // Otherwise, it uses FFmpeg to convert to Sox format and pipes to Sox.
-func (g *Generator) generateWithSoxFile(ctx context.Context, audioPath, outputPath string, width int, raw bool, preValidatedDuration float64) error {
-	soxBinary := g.currentSettings().Realtime.Audio.SoxPath
+func (g *Generator) generateWithSoxFile(ctx context.Context, settings *conf.Settings, audioPath, outputPath string, width int, raw bool, preValidatedDuration float64) error {
+	soxBinary := settings.Realtime.Audio.SoxPath
 	if soxBinary == "" {
 		return errors.Newf("sox binary not configured").
 			Component("spectrogram").
@@ -428,7 +440,7 @@ func (g *Generator) generateWithSoxFile(ctx context.Context, audioPath, outputPa
 	ext := strings.ToLower(filepath.Ext(audioPath))
 	ext = strings.TrimPrefix(ext, ".")
 	useFFmpeg := true
-	for _, soxType := range g.currentSettings().Realtime.Audio.SoxAudioTypes {
+	for _, soxType := range settings.Realtime.Audio.SoxAudioTypes {
 		soxType = strings.TrimPrefix(strings.ToLower(soxType), ".")
 		if ext == soxType {
 			useFFmpeg = false
@@ -438,17 +450,17 @@ func (g *Generator) generateWithSoxFile(ctx context.Context, audioPath, outputPa
 
 	// If file is supported by Sox, use Sox directly
 	if !useFFmpeg {
-		return g.generateWithSoxDirect(ctx, audioPath, outputPath, width, raw, preValidatedDuration)
+		return g.generateWithSoxDirect(ctx, settings, audioPath, outputPath, width, raw, preValidatedDuration)
 	}
 
 	// Otherwise, use FFmpeg to convert to Sox format
-	return g.generateWithFFmpegSoxPipeline(ctx, audioPath, outputPath, width, raw, preValidatedDuration)
+	return g.generateWithFFmpegSoxPipeline(ctx, settings, audioPath, outputPath, width, raw, preValidatedDuration)
 }
 
 // generateWithSoxDirect generates a spectrogram using only Sox (no FFmpeg).
 // Used when the audio file format is natively supported by Sox.
-func (g *Generator) generateWithSoxDirect(ctx context.Context, audioPath, outputPath string, width int, raw bool, preValidatedDuration float64) error {
-	soxBinary := g.currentSettings().Realtime.Audio.SoxPath
+func (g *Generator) generateWithSoxDirect(ctx context.Context, settings *conf.Settings, audioPath, outputPath string, width int, raw bool, preValidatedDuration float64) error {
+	soxBinary := settings.Realtime.Audio.SoxPath
 	if soxBinary == "" {
 		return errors.Newf("sox binary not configured").
 			Component("spectrogram").
@@ -458,7 +470,7 @@ func (g *Generator) generateWithSoxDirect(ctx context.Context, audioPath, output
 	}
 
 	// Build Sox arguments for file input
-	soxArgs := g.getSoxArgs(ctx, audioPath, outputPath, width, raw, SoxInputFile, preValidatedDuration)
+	soxArgs := g.getSoxArgs(ctx, settings, audioPath, outputPath, width, raw, SoxInputFile, preValidatedDuration)
 
 	g.log().Debug("Executing SoX command directly",
 		logger.String("sox_binary", soxBinary),
@@ -527,9 +539,9 @@ func (g *Generator) killSoxProcess(soxCmd *exec.Cmd, soxPid int) {
 
 // generateWithFFmpegSoxPipeline generates a spectrogram using FFmpeg piped to Sox.
 // Used when the audio file format is not natively supported by Sox.
-func (g *Generator) generateWithFFmpegSoxPipeline(ctx context.Context, audioPath, outputPath string, width int, raw bool, preValidatedDuration float64) error {
-	ffmpegBinary := g.currentSettings().Realtime.Audio.FfmpegPath
-	soxBinary := g.currentSettings().Realtime.Audio.SoxPath
+func (g *Generator) generateWithFFmpegSoxPipeline(ctx context.Context, settings *conf.Settings, audioPath, outputPath string, width int, raw bool, preValidatedDuration float64) error {
+	ffmpegBinary := settings.Realtime.Audio.FfmpegPath
+	soxBinary := settings.Realtime.Audio.SoxPath
 
 	// Validate FFmpeg path (defense-in-depth against ingress path contamination, see #2195)
 	if err := ffmpeg.ValidateFFmpegPath(ffmpegBinary); err != nil {
@@ -550,7 +562,7 @@ func (g *Generator) generateWithFFmpegSoxPipeline(ctx context.Context, audioPath
 
 	// FFmpeg converts audio to Sox format and pipes to Sox
 	ffmpegArgs := []string{"-hide_banner", "-i", audioPath, "-f", "sox", "-"}
-	soxArgs := append([]string{"-t", "sox", "-"}, g.getSoxSpectrogramArgs(ctx, audioPath, outputPath, width, raw, preValidatedDuration)...)
+	soxArgs := append([]string{"-t", "sox", "-"}, g.getSoxSpectrogramArgs(ctx, settings, audioPath, outputPath, width, raw, preValidatedDuration)...)
 
 	ffmpegCmd := createCommandWithNice(ctx, ffmpegBinary, ffmpegArgs)
 	soxCmd := createCommandWithNice(ctx, soxBinary, soxArgs)
@@ -675,8 +687,8 @@ func (g *Generator) generateWithFFmpegSoxPipeline(ctx context.Context, audioPath
 // generateWithSoxPCM generates a spectrogram by feeding PCM data directly to Sox stdin.
 // This bypasses FFmpeg entirely, reducing CPU overhead and memory usage.
 // PCM format: s16le, 48kHz, mono
-func (g *Generator) generateWithSoxPCM(ctx context.Context, pcmData []byte, outputPath string, width int, raw bool) error {
-	soxBinary := g.currentSettings().Realtime.Audio.SoxPath
+func (g *Generator) generateWithSoxPCM(ctx context.Context, settings *conf.Settings, pcmData []byte, outputPath string, width int, raw bool) error {
+	soxBinary := settings.Realtime.Audio.SoxPath
 	if soxBinary == "" {
 		return errors.Newf("sox binary not configured").
 			Component("spectrogram").
@@ -699,7 +711,7 @@ func (g *Generator) generateWithSoxPCM(ctx context.Context, pcmData []byte, outp
 		"spectrogram",             // Effect: spectrogram
 		"-x", strconv.Itoa(width), // Width in pixels
 		"-y", strconv.Itoa(fftFriendlyHeight(width)), // Height in pixels (FFT-friendly 2^n + 1)
-		"-z", g.getDynamicRange(), // Dynamic range in dB
+		"-z", g.getDynamicRange(settings), // Dynamic range in dB
 		"-o", outputPath, // Output PNG file
 	}
 
@@ -709,7 +721,7 @@ func (g *Generator) generateWithSoxPCM(ctx context.Context, pcmData []byte, outp
 	}
 
 	// Add style-specific arguments
-	style := g.currentSettings().Realtime.Dashboard.Spectrogram.Style
+	style := settings.Realtime.Dashboard.Spectrogram.Style
 	if styleArgs := getStyleArgs(style); styleArgs != nil {
 		args = append(args, styleArgs...)
 	}
@@ -758,8 +770,8 @@ func (g *Generator) generateWithSoxPCM(ctx context.Context, pcmData []byte, outp
 
 // generateWithFFmpeg generates a spectrogram using only FFmpeg (no Sox).
 // This is a fallback when Sox is not available or fails.
-func (g *Generator) generateWithFFmpeg(ctx context.Context, audioPath, outputPath string, width int, raw bool) error {
-	ffmpegBinary := g.currentSettings().Realtime.Audio.FfmpegPath
+func (g *Generator) generateWithFFmpeg(ctx context.Context, settings *conf.Settings, audioPath, outputPath string, width int, raw bool) error {
+	ffmpegBinary := settings.Realtime.Audio.FfmpegPath
 	// Validate FFmpeg path (defense-in-depth against ingress path contamination, see #2195)
 	if err := ffmpeg.ValidateFFmpegPath(ffmpegBinary); err != nil {
 		return errors.Newf("invalid FFmpeg path: %s", err).
@@ -775,7 +787,7 @@ func (g *Generator) generateWithFFmpeg(ctx context.Context, audioPath, outputPat
 	// Apply style-aware color mode so FFmpeg fallback matches the Sox primary style.
 	// Without this, the FFmpeg fallback always produces the default colorful style,
 	// causing intermittent style mismatches when Sox fails under resource pressure.
-	style := g.currentSettings().Realtime.Dashboard.Spectrogram.Style
+	style := settings.Realtime.Dashboard.Spectrogram.Style
 	colorMode := getFFmpegColorMode(style)
 
 	var filterStr string
@@ -833,13 +845,13 @@ func (g *Generator) generateWithFFmpeg(ctx context.Context, audioPath, outputPat
 
 // getSoxArgs builds Sox arguments for file input.
 // Used when Sox can directly read the audio file.
-func (g *Generator) getSoxArgs(ctx context.Context, audioPath, outputPath string, width int, raw bool, inputType SoxInputType, preValidatedDuration float64) []string {
+func (g *Generator) getSoxArgs(ctx context.Context, settings *conf.Settings, audioPath, outputPath string, width int, raw bool, inputType SoxInputType, preValidatedDuration float64) []string {
 	args := make([]string, 0, 16) // Preallocate capacity for input path + spectrogram args
 	if inputType == SoxInputFile {
 		args = append(args, audioPath)
 	}
 
-	args = append(args, g.getSoxSpectrogramArgs(ctx, audioPath, outputPath, width, raw, preValidatedDuration)...)
+	args = append(args, g.getSoxSpectrogramArgs(ctx, settings, audioPath, outputPath, width, raw, preValidatedDuration)...)
 	return args
 }
 
@@ -851,7 +863,7 @@ func (g *Generator) getSoxArgs(ctx context.Context, audioPath, outputPath string
 //
 // preValidatedDuration, when > 0, is used directly (e.g., from FFprobe validation),
 // skipping the sox --info duration query entirely.
-func (g *Generator) getSoxSpectrogramArgs(ctx context.Context, audioPath, outputPath string, width int, raw bool, preValidatedDuration float64) []string {
+func (g *Generator) getSoxSpectrogramArgs(ctx context.Context, settings *conf.Settings, audioPath, outputPath string, width int, raw bool, preValidatedDuration float64) []string {
 	heightStr := strconv.Itoa(fftFriendlyHeight(width))
 	widthStr := strconv.Itoa(width)
 
@@ -867,7 +879,7 @@ func (g *Generator) getSoxSpectrogramArgs(ctx context.Context, audioPath, output
 	}
 	if duration <= 0 {
 		// Fallback: Use configured capture length if both sox and ffprobe fail
-		captureLength := g.currentSettings().Realtime.Audio.Export.Length
+		captureLength := settings.Realtime.Audio.Export.Length
 		duration = float64(captureLength)
 		g.log().Warn("Duration query failed, using configured fallback duration",
 			logger.Float64("fallback_duration_seconds", duration),
@@ -878,7 +890,7 @@ func (g *Generator) getSoxSpectrogramArgs(ctx context.Context, audioPath, output
 	captureLengthStr := strconv.Itoa(int(duration + durationRoundingOffset))
 
 	// Add duration and remaining common parameters
-	args = append(args, "-d", captureLengthStr, "-z", g.getDynamicRange(), "-o", outputPath)
+	args = append(args, "-d", captureLengthStr, "-z", g.getDynamicRange(settings), "-o", outputPath)
 
 	// Add raw flag if requested (no axes/legends)
 	if raw {
@@ -886,7 +898,7 @@ func (g *Generator) getSoxSpectrogramArgs(ctx context.Context, audioPath, output
 	}
 
 	// Add style-specific arguments
-	style := g.currentSettings().Realtime.Dashboard.Spectrogram.Style
+	style := settings.Realtime.Dashboard.Spectrogram.Style
 	if styleArgs := getStyleArgs(style); styleArgs != nil {
 		args = append(args, styleArgs...)
 	}
@@ -1136,7 +1148,7 @@ func getAudioDurationViaSox(ctx context.Context, audioPath string) (float64, err
 // This method is exported to allow tests in other packages to verify the
 // FFmpeg version optimization logic.
 func (g *Generator) GetSoxSpectrogramArgsForTest(ctx context.Context, audioPath, outputPath string, width int, raw bool) []string {
-	return g.getSoxSpectrogramArgs(ctx, audioPath, outputPath, width, raw, 0)
+	return g.getSoxSpectrogramArgs(ctx, g.currentSettings(), audioPath, outputPath, width, raw, 0)
 }
 
 // CreateFreshFFmpegContext creates a new context for FFmpeg fallback with full timeout.

--- a/internal/spectrogram/generator.go
+++ b/internal/spectrogram/generator.go
@@ -218,10 +218,17 @@ func (g *Generator) log() logger.Logger {
 	return GetLogger()
 }
 
+// currentSettings returns the latest settings snapshot so UI changes to
+// spectrogram style, dynamic range, Sox/FFmpeg paths, etc. take effect on
+// the next render without restarting the service.
+func (g *Generator) currentSettings() *conf.Settings {
+	return conf.CurrentOrFallback(g.settings)
+}
+
 // getDynamicRange returns the configured dynamic range value for Sox -z parameter.
 // Returns the default value ("100") if not configured or if an invalid value is set.
 func (g *Generator) getDynamicRange() string {
-	dr := g.settings.Realtime.Dashboard.Spectrogram.DynamicRange
+	dr := g.currentSettings().Realtime.Dashboard.Spectrogram.DynamicRange
 	if dr == "" {
 		return defaultDynamicRange
 	}
@@ -408,7 +415,7 @@ func (g *Generator) GenerateFromPCM(ctx context.Context, pcmData []byte, outputP
 // If the file format is supported by Sox, it uses Sox directly.
 // Otherwise, it uses FFmpeg to convert to Sox format and pipes to Sox.
 func (g *Generator) generateWithSoxFile(ctx context.Context, audioPath, outputPath string, width int, raw bool, preValidatedDuration float64) error {
-	soxBinary := g.settings.Realtime.Audio.SoxPath
+	soxBinary := g.currentSettings().Realtime.Audio.SoxPath
 	if soxBinary == "" {
 		return errors.Newf("sox binary not configured").
 			Component("spectrogram").
@@ -421,7 +428,7 @@ func (g *Generator) generateWithSoxFile(ctx context.Context, audioPath, outputPa
 	ext := strings.ToLower(filepath.Ext(audioPath))
 	ext = strings.TrimPrefix(ext, ".")
 	useFFmpeg := true
-	for _, soxType := range g.settings.Realtime.Audio.SoxAudioTypes {
+	for _, soxType := range g.currentSettings().Realtime.Audio.SoxAudioTypes {
 		soxType = strings.TrimPrefix(strings.ToLower(soxType), ".")
 		if ext == soxType {
 			useFFmpeg = false
@@ -441,7 +448,7 @@ func (g *Generator) generateWithSoxFile(ctx context.Context, audioPath, outputPa
 // generateWithSoxDirect generates a spectrogram using only Sox (no FFmpeg).
 // Used when the audio file format is natively supported by Sox.
 func (g *Generator) generateWithSoxDirect(ctx context.Context, audioPath, outputPath string, width int, raw bool, preValidatedDuration float64) error {
-	soxBinary := g.settings.Realtime.Audio.SoxPath
+	soxBinary := g.currentSettings().Realtime.Audio.SoxPath
 	if soxBinary == "" {
 		return errors.Newf("sox binary not configured").
 			Component("spectrogram").
@@ -521,8 +528,8 @@ func (g *Generator) killSoxProcess(soxCmd *exec.Cmd, soxPid int) {
 // generateWithFFmpegSoxPipeline generates a spectrogram using FFmpeg piped to Sox.
 // Used when the audio file format is not natively supported by Sox.
 func (g *Generator) generateWithFFmpegSoxPipeline(ctx context.Context, audioPath, outputPath string, width int, raw bool, preValidatedDuration float64) error {
-	ffmpegBinary := g.settings.Realtime.Audio.FfmpegPath
-	soxBinary := g.settings.Realtime.Audio.SoxPath
+	ffmpegBinary := g.currentSettings().Realtime.Audio.FfmpegPath
+	soxBinary := g.currentSettings().Realtime.Audio.SoxPath
 
 	// Validate FFmpeg path (defense-in-depth against ingress path contamination, see #2195)
 	if err := ffmpeg.ValidateFFmpegPath(ffmpegBinary); err != nil {
@@ -669,7 +676,7 @@ func (g *Generator) generateWithFFmpegSoxPipeline(ctx context.Context, audioPath
 // This bypasses FFmpeg entirely, reducing CPU overhead and memory usage.
 // PCM format: s16le, 48kHz, mono
 func (g *Generator) generateWithSoxPCM(ctx context.Context, pcmData []byte, outputPath string, width int, raw bool) error {
-	soxBinary := g.settings.Realtime.Audio.SoxPath
+	soxBinary := g.currentSettings().Realtime.Audio.SoxPath
 	if soxBinary == "" {
 		return errors.Newf("sox binary not configured").
 			Component("spectrogram").
@@ -702,7 +709,7 @@ func (g *Generator) generateWithSoxPCM(ctx context.Context, pcmData []byte, outp
 	}
 
 	// Add style-specific arguments
-	style := g.settings.Realtime.Dashboard.Spectrogram.Style
+	style := g.currentSettings().Realtime.Dashboard.Spectrogram.Style
 	if styleArgs := getStyleArgs(style); styleArgs != nil {
 		args = append(args, styleArgs...)
 	}
@@ -752,7 +759,7 @@ func (g *Generator) generateWithSoxPCM(ctx context.Context, pcmData []byte, outp
 // generateWithFFmpeg generates a spectrogram using only FFmpeg (no Sox).
 // This is a fallback when Sox is not available or fails.
 func (g *Generator) generateWithFFmpeg(ctx context.Context, audioPath, outputPath string, width int, raw bool) error {
-	ffmpegBinary := g.settings.Realtime.Audio.FfmpegPath
+	ffmpegBinary := g.currentSettings().Realtime.Audio.FfmpegPath
 	// Validate FFmpeg path (defense-in-depth against ingress path contamination, see #2195)
 	if err := ffmpeg.ValidateFFmpegPath(ffmpegBinary); err != nil {
 		return errors.Newf("invalid FFmpeg path: %s", err).
@@ -768,7 +775,7 @@ func (g *Generator) generateWithFFmpeg(ctx context.Context, audioPath, outputPat
 	// Apply style-aware color mode so FFmpeg fallback matches the Sox primary style.
 	// Without this, the FFmpeg fallback always produces the default colorful style,
 	// causing intermittent style mismatches when Sox fails under resource pressure.
-	style := g.settings.Realtime.Dashboard.Spectrogram.Style
+	style := g.currentSettings().Realtime.Dashboard.Spectrogram.Style
 	colorMode := getFFmpegColorMode(style)
 
 	var filterStr string
@@ -860,7 +867,7 @@ func (g *Generator) getSoxSpectrogramArgs(ctx context.Context, audioPath, output
 	}
 	if duration <= 0 {
 		// Fallback: Use configured capture length if both sox and ffprobe fail
-		captureLength := g.settings.Realtime.Audio.Export.Length
+		captureLength := g.currentSettings().Realtime.Audio.Export.Length
 		duration = float64(captureLength)
 		g.log().Warn("Duration query failed, using configured fallback duration",
 			logger.Float64("fallback_duration_seconds", duration),
@@ -879,7 +886,7 @@ func (g *Generator) getSoxSpectrogramArgs(ctx context.Context, audioPath, output
 	}
 
 	// Add style-specific arguments
-	style := g.settings.Realtime.Dashboard.Spectrogram.Style
+	style := g.currentSettings().Realtime.Dashboard.Spectrogram.Style
 	if styleArgs := getStyleArgs(style); styleArgs != nil {
 		args = append(args, styleArgs...)
 	}

--- a/internal/spectrogram/generator_test.go
+++ b/internal/spectrogram/generator_test.go
@@ -107,7 +107,7 @@ func TestGenerator_GetSoxSpectrogramArgs(t *testing.T) {
 			audioPath := filepath.Join(tempDir, "test.wav")
 			outputPath := filepath.Join(tempDir, "test.png")
 
-			args := gen.getSoxSpectrogramArgs(t.Context(), audioPath, outputPath, tt.width, tt.raw, 0)
+			args := gen.getSoxSpectrogramArgs(t.Context(), gen.currentSettings(), audioPath, outputPath, tt.width, tt.raw, 0)
 			result := parseSoxSpectrogramArgs(args)
 
 			assert.Equal(t, tt.wantDuration, result.hasDuration, "duration parameter mismatch")
@@ -142,7 +142,7 @@ func TestGenerator_GetSoxArgs(t *testing.T) {
 	audioPath := filepath.Join(env.TempDir, "test.wav")
 	outputPath := filepath.Join(env.TempDir, "test.png")
 
-	args := gen.getSoxArgs(t.Context(), audioPath, outputPath, 800, false, SoxInputFile, 0)
+	args := gen.getSoxArgs(t.Context(), gen.currentSettings(), audioPath, outputPath, 800, false, SoxInputFile, 0)
 
 	// First argument should be the audio file path
 	require.NotEmpty(t, args, "getSoxArgs() should return args")
@@ -587,7 +587,7 @@ func TestGenerateWithSoxDirect_MissingBinary(t *testing.T) {
 	err := os.WriteFile(audioPath, []byte("fake audio"), 0o600)
 	require.NoError(t, err, "Failed to create test file")
 
-	err = gen.generateWithSoxDirect(t.Context(), audioPath, outputPath, 400, false, 0)
+	err = gen.generateWithSoxDirect(t.Context(), gen.currentSettings(), audioPath, outputPath, 400, false, 0)
 	require.Error(t, err, "should error when Sox binary not configured")
 	assert.Contains(t, err.Error(), "sox binary not configured", "error should mention sox binary")
 }
@@ -626,7 +626,7 @@ func TestGenerateWithFFmpegSoxPipeline_MissingBinaries(t *testing.T) {
 			audioPath := filepath.Join(env.TempDir, "test.wav")
 			outputPath := filepath.Join(env.TempDir, "test.png")
 
-			err := gen.generateWithFFmpegSoxPipeline(t.Context(), audioPath, outputPath, 400, false, 0)
+			err := gen.generateWithFFmpegSoxPipeline(t.Context(), gen.currentSettings(), audioPath, outputPath, 400, false, 0)
 			require.Error(t, err, "should error when binary not configured")
 			assert.Contains(t, err.Error(), tt.errContain, "error should mention missing binary")
 		})
@@ -643,7 +643,7 @@ func TestGenerateWithFFmpeg_MissingBinary(t *testing.T) {
 	audioPath := filepath.Join(env.TempDir, "test.wav")
 	outputPath := filepath.Join(env.TempDir, "test.png")
 
-	err := gen.generateWithFFmpeg(t.Context(), audioPath, outputPath, 400, false)
+	err := gen.generateWithFFmpeg(t.Context(), gen.currentSettings(), audioPath, outputPath, 400, false)
 	require.Error(t, err, "should error when FFmpeg binary not configured")
 	assert.Contains(t, err.Error(), "invalid FFmpeg path", "error should mention ffmpeg binary")
 }
@@ -658,7 +658,7 @@ func TestGenerateWithSoxPCM_MissingBinary(t *testing.T) {
 	outputPath := filepath.Join(env.TempDir, "test.png")
 	pcmData := []byte{0, 1, 2, 3, 4, 5, 6, 7}
 
-	err := gen.generateWithSoxPCM(t.Context(), pcmData, outputPath, 400, false)
+	err := gen.generateWithSoxPCM(t.Context(), gen.currentSettings(), pcmData, outputPath, 400, false)
 	require.Error(t, err, "should error when Sox binary not configured")
 	assert.Contains(t, err.Error(), "sox binary not configured", "error should mention sox binary")
 }
@@ -673,7 +673,7 @@ func TestGetSoxArgs_FileInput(t *testing.T) {
 	audioPath := filepath.Join(env.TempDir, "test.wav")
 	outputPath := filepath.Join(env.TempDir, "test.png")
 
-	args := gen.getSoxArgs(t.Context(), audioPath, outputPath, 800, false, SoxInputFile, 0)
+	args := gen.getSoxArgs(t.Context(), gen.currentSettings(), audioPath, outputPath, 800, false, SoxInputFile, 0)
 
 	// First argument should be the audio file for SoxInputFile
 	require.NotEmpty(t, args, "args should not be empty")
@@ -702,12 +702,12 @@ func TestGetSoxSpectrogramArgs_RawFlag(t *testing.T) {
 	outputPath := filepath.Join(env.TempDir, "test.png")
 
 	// Test with raw=false
-	argsNoRaw := gen.getSoxSpectrogramArgs(t.Context(), audioPath, outputPath, 400, false, 0)
+	argsNoRaw := gen.getSoxSpectrogramArgs(t.Context(), gen.currentSettings(), audioPath, outputPath, 400, false, 0)
 	hasRaw := slices.Contains(argsNoRaw, "-r")
 	assert.False(t, hasRaw, "should not contain -r flag when raw=false")
 
 	// Test with raw=true
-	argsWithRaw := gen.getSoxSpectrogramArgs(t.Context(), audioPath, outputPath, 400, true, 0)
+	argsWithRaw := gen.getSoxSpectrogramArgs(t.Context(), gen.currentSettings(), audioPath, outputPath, 400, true, 0)
 	hasRaw = slices.Contains(argsWithRaw, "-r")
 	assert.True(t, hasRaw, "should contain -r flag when raw=true")
 }
@@ -720,7 +720,7 @@ func TestGetSoxSpectrogramArgs_UsesProvidedDuration(t *testing.T) {
 	audioPath := filepath.Join(tempDir, "input.mp3")
 	outputPath := filepath.Join(tempDir, "out.png")
 
-	args := gen.getSoxSpectrogramArgs(t.Context(), audioPath, outputPath, 400, false, 12.6)
+	args := gen.getSoxSpectrogramArgs(t.Context(), gen.currentSettings(), audioPath, outputPath, 400, false, 12.6)
 
 	idx := slices.Index(args, "-d")
 	require.NotEqual(t, -1, idx, "should contain -d parameter")
@@ -751,7 +751,7 @@ func TestGetSoxSpectrogramArgs_DimensionCalculation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run("width_"+strconv.Itoa(tt.width), func(t *testing.T) {
-			args := gen.getSoxSpectrogramArgs(t.Context(), audioPath, outputPath, tt.width, false, 0)
+			args := gen.getSoxSpectrogramArgs(t.Context(), gen.currentSettings(), audioPath, outputPath, tt.width, false, 0)
 
 			widthStr := strconv.Itoa(tt.width)
 			heightStr := strconv.Itoa(tt.expectedHeight)
@@ -898,7 +898,7 @@ func TestNewGenerator_WithNilLogger(t *testing.T) {
 	outputPath := filepath.Join(env.TempDir, "test.png")
 
 	// getSoxSpectrogramArgs uses g.log().Warn internally
-	args := gen.getSoxSpectrogramArgs(t.Context(), audioPath, outputPath, 400, false, 0)
+	args := gen.getSoxSpectrogramArgs(t.Context(), gen.currentSettings(), audioPath, outputPath, 400, false, 0)
 	assert.NotEmpty(t, args, "should return valid args without panic")
 }
 
@@ -1104,7 +1104,7 @@ func TestGetSoxSpectrogramArgs_StyleArgs(t *testing.T) {
 			audioPath := filepath.Join(env.TempDir, "test.wav")
 			outputPath := filepath.Join(env.TempDir, "test.png")
 
-			args := gen.getSoxSpectrogramArgs(t.Context(), audioPath, outputPath, 400, false, 0)
+			args := gen.getSoxSpectrogramArgs(t.Context(), gen.currentSettings(), audioPath, outputPath, 400, false, 0)
 
 			for _, want := range tt.wantContains {
 				assert.True(t, slices.Contains(args, want),

--- a/internal/spectrogram/prerenderer.go
+++ b/internal/spectrogram/prerenderer.go
@@ -95,11 +95,13 @@ func (pr *PreRenderer) currentSettings() *conf.Settings {
 // using SecureFS base directory, avoiding path doubling when the path
 // already includes the export prefix (e.g., "clips/2026/03/file.png").
 // filepath.Rel with two relative paths is safe (no os.Getwd dependency).
-func (pr *PreRenderer) normalizeSpectrogramPath(spectrogramPath string) string {
+// settings is the snapshot captured by the caller for this unit of work so
+// any hot-reloaded values stay consistent with the caller's other reads.
+func (pr *PreRenderer) normalizeSpectrogramPath(settings *conf.Settings, spectrogramPath string) string {
 	if filepath.IsAbs(spectrogramPath) {
 		return spectrogramPath
 	}
-	exportPath := pr.currentSettings().Realtime.Audio.Export.Path
+	exportPath := settings.Realtime.Audio.Export.Path
 	if relToExport, err := filepath.Rel(exportPath, spectrogramPath); err == nil && !strings.HasPrefix(relToExport, "..") {
 		return filepath.Join(pr.sfs.BaseDir(), relToExport)
 	}
@@ -129,11 +131,12 @@ func NewPreRenderer(parentCtx context.Context, settings *conf.Settings, sfs *sec
 
 // Start initializes the worker pool and begins processing jobs.
 func (pr *PreRenderer) Start() {
+	specSettings := pr.currentSettings().Realtime.Dashboard.Spectrogram
 	pr.logger.Info("Starting spectrogram pre-renderer",
 		logger.Int("workers", pr.workers),
 		logger.Int("queue_size", defaultQueueSize),
-		logger.String("size", pr.currentSettings().Realtime.Dashboard.Spectrogram.Size),
-		logger.Bool("raw", pr.currentSettings().Realtime.Dashboard.Spectrogram.Raw))
+		logger.String("size", specSettings.Size),
+		logger.Bool("raw", specSettings.Raw))
 
 	for i := range pr.workers {
 		pr.wg.Add(1)
@@ -235,7 +238,7 @@ func (pr *PreRenderer) Submit(jobDTO interface {
 
 	// Make spectrogram path absolute using SecureFS base dir, stripping export
 	// prefix to avoid path doubling (e.g., "clips/clips/..."). See #2342.
-	absOut := pr.normalizeSpectrogramPath(spectrogramPath)
+	absOut := pr.normalizeSpectrogramPath(pr.currentSettings(), spectrogramPath)
 
 	relPath, err := filepath.Rel(absRoot, absOut)
 	if err != nil || relPath == ".." || strings.HasPrefix(relPath, ".."+string(os.PathSeparator)) {
@@ -373,6 +376,15 @@ func (pr *PreRenderer) worker(id int) {
 func (pr *PreRenderer) processJob(job *Job, workerID int) {
 	start := time.Now()
 
+	// Capture a single settings snapshot for this job so size, raw, and
+	// export path are read from the same view — a UI edit that lands
+	// mid-job can't produce a mix of old/new values. The Generator below
+	// captures its own snapshot when its public entry point runs; that is
+	// a deliberate per-component boundary (Size/Raw are per-call inputs
+	// passed across, render-engine config stays on Generator's side).
+	settings := pr.currentSettings()
+	specSettings := settings.Realtime.Dashboard.Spectrogram
+
 	pr.logger.Debug("Processing pre-render job",
 		logger.Int("worker_id", workerID),
 		logger.Any("note_id", job.NoteID),
@@ -395,7 +407,7 @@ func (pr *PreRenderer) processJob(job *Job, workerID int) {
 
 	// Make spectrogram path absolute using SecureFS base dir, stripping export
 	// prefix to avoid path doubling (e.g., "clips/clips/..."). See #2342.
-	spectrogramPath = pr.normalizeSpectrogramPath(spectrogramPath)
+	spectrogramPath = pr.normalizeSpectrogramPath(settings, spectrogramPath)
 
 	// Check if spectrogram already exists
 	// Race conditions are acceptable here (idempotent operation):
@@ -415,12 +427,12 @@ func (pr *PreRenderer) processJob(job *Job, workerID int) {
 	}
 
 	// Convert size string to pixels
-	width, err := SizeToPixels(pr.currentSettings().Realtime.Dashboard.Spectrogram.Size)
+	width, err := SizeToPixels(specSettings.Size)
 	if err != nil {
 		pr.logger.Error("Invalid spectrogram size",
 			logger.Int("worker_id", workerID),
 			logger.Any("note_id", job.NoteID),
-			logger.String("size", pr.currentSettings().Realtime.Dashboard.Spectrogram.Size),
+			logger.String("size", specSettings.Size),
 			logger.Error(err))
 		pr.mu.Lock()
 		pr.stats.Failed++
@@ -437,11 +449,11 @@ func (pr *PreRenderer) processJob(job *Job, workerID int) {
 	pr.logger.Info("Spectrogram generation started",
 		logger.Any("note_id", job.NoteID),
 		logger.String("audio_path", job.ClipPath),
-		logger.String("size", pr.currentSettings().Realtime.Dashboard.Spectrogram.Size),
+		logger.String("size", specSettings.Size),
 		logger.String("operation", "spectrogram_generation_start"))
 
 	// Generate spectrogram using shared generator
-	if err := pr.generator.GenerateFromPCM(ctx, job.PCMData, spectrogramPath, width, pr.currentSettings().Realtime.Dashboard.Spectrogram.Raw); err != nil {
+	if err := pr.generator.GenerateFromPCM(ctx, job.PCMData, spectrogramPath, width, specSettings.Raw); err != nil {
 		// Check if this is an expected operational error (context canceled, process killed)
 		// These are normal events during shutdown, timeout, or resource management
 		if IsOperationalError(err) {

--- a/internal/spectrogram/prerenderer.go
+++ b/internal/spectrogram/prerenderer.go
@@ -84,6 +84,13 @@ type Stats struct {
 	Skipped   int64 // Number skipped (already exist)
 }
 
+// currentSettings returns the latest settings snapshot so UI changes to
+// spectrogram size/raw/export path take effect on the next rendered job
+// without restarting the pre-renderer.
+func (pr *PreRenderer) currentSettings() *conf.Settings {
+	return conf.CurrentOrFallback(pr.settings)
+}
+
 // normalizeSpectrogramPath converts a relative spectrogram path to absolute
 // using SecureFS base directory, avoiding path doubling when the path
 // already includes the export prefix (e.g., "clips/2026/03/file.png").
@@ -92,7 +99,7 @@ func (pr *PreRenderer) normalizeSpectrogramPath(spectrogramPath string) string {
 	if filepath.IsAbs(spectrogramPath) {
 		return spectrogramPath
 	}
-	exportPath := pr.settings.Realtime.Audio.Export.Path
+	exportPath := pr.currentSettings().Realtime.Audio.Export.Path
 	if relToExport, err := filepath.Rel(exportPath, spectrogramPath); err == nil && !strings.HasPrefix(relToExport, "..") {
 		return filepath.Join(pr.sfs.BaseDir(), relToExport)
 	}
@@ -125,8 +132,8 @@ func (pr *PreRenderer) Start() {
 	pr.logger.Info("Starting spectrogram pre-renderer",
 		logger.Int("workers", pr.workers),
 		logger.Int("queue_size", defaultQueueSize),
-		logger.String("size", pr.settings.Realtime.Dashboard.Spectrogram.Size),
-		logger.Bool("raw", pr.settings.Realtime.Dashboard.Spectrogram.Raw))
+		logger.String("size", pr.currentSettings().Realtime.Dashboard.Spectrogram.Size),
+		logger.Bool("raw", pr.currentSettings().Realtime.Dashboard.Spectrogram.Raw))
 
 	for i := range pr.workers {
 		pr.wg.Add(1)
@@ -408,12 +415,12 @@ func (pr *PreRenderer) processJob(job *Job, workerID int) {
 	}
 
 	// Convert size string to pixels
-	width, err := SizeToPixels(pr.settings.Realtime.Dashboard.Spectrogram.Size)
+	width, err := SizeToPixels(pr.currentSettings().Realtime.Dashboard.Spectrogram.Size)
 	if err != nil {
 		pr.logger.Error("Invalid spectrogram size",
 			logger.Int("worker_id", workerID),
 			logger.Any("note_id", job.NoteID),
-			logger.String("size", pr.settings.Realtime.Dashboard.Spectrogram.Size),
+			logger.String("size", pr.currentSettings().Realtime.Dashboard.Spectrogram.Size),
 			logger.Error(err))
 		pr.mu.Lock()
 		pr.stats.Failed++
@@ -430,11 +437,11 @@ func (pr *PreRenderer) processJob(job *Job, workerID int) {
 	pr.logger.Info("Spectrogram generation started",
 		logger.Any("note_id", job.NoteID),
 		logger.String("audio_path", job.ClipPath),
-		logger.String("size", pr.settings.Realtime.Dashboard.Spectrogram.Size),
+		logger.String("size", pr.currentSettings().Realtime.Dashboard.Spectrogram.Size),
 		logger.String("operation", "spectrogram_generation_start"))
 
 	// Generate spectrogram using shared generator
-	if err := pr.generator.GenerateFromPCM(ctx, job.PCMData, spectrogramPath, width, pr.settings.Realtime.Dashboard.Spectrogram.Raw); err != nil {
+	if err := pr.generator.GenerateFromPCM(ctx, job.PCMData, spectrogramPath, width, pr.currentSettings().Realtime.Dashboard.Spectrogram.Raw); err != nil {
 		// Check if this is an expected operational error (context canceled, process killed)
 		// These are normal events during shutdown, timeout, or resource management
 		if IsOperationalError(err) {

--- a/internal/weather/weather.go
+++ b/internal/weather/weather.go
@@ -175,17 +175,17 @@ func NewService(settings *conf.Settings, db datastore.Interface, weatherMetrics 
 	switch settings.Realtime.Weather.Provider {
 	case "yrno":
 		provider = NewYrNoProvider()
-		providerName = "yrno"
+		providerName = yrNoProviderName
 	case "openweather":
 		provider = NewOpenWeatherProvider()
-		providerName = "openweather"
+		providerName = openWeatherProviderName
 	case "wunderground":
 		provider = NewWundergroundProvider(nil)
-		providerName = "wunderground"
+		providerName = wundergroundProviderName
 	case "":
-		// Not configured — default to yr.no
+		// Not configured - default to yr.no
 		provider = NewYrNoProvider()
-		providerName = "yrno"
+		providerName = yrNoProviderName
 	case "none":
 		// Explicitly disabled
 		getLogger().Info("Weather provider set to none, weather service disabled")

--- a/internal/weather/weather.go
+++ b/internal/weather/weather.go
@@ -99,7 +99,14 @@ func (b *backoffState) isAuthDisabled() bool {
 
 // Service handles weather data operations
 type Service struct {
-	provider     Provider
+	provider Provider
+	// providerName is pinned at construction so logs and metrics always
+	// identify the actual provider implementation in use. Switching providers
+	// through the UI requires a service restart anyway (the provider interface
+	// implementation is selected once in NewService), so reading the provider
+	// string from the latest settings snapshot could misreport what the HTTP
+	// calls are actually hitting.
+	providerName string
 	db           datastore.Interface
 	settings     *conf.Settings
 	metrics      *metrics.WeatherMetrics
@@ -159,19 +166,26 @@ type Precipitation struct {
 // Returns ErrWeatherDisabled when the provider is empty or unrecognized,
 // which the caller should treat as "weather disabled" (no service to start).
 func NewService(settings *conf.Settings, db datastore.Interface, weatherMetrics *metrics.WeatherMetrics) (*Service, error) {
-	var provider Provider
+	var (
+		provider     Provider
+		providerName string
+	)
 
 	// Select weather provider based on configuration
 	switch settings.Realtime.Weather.Provider {
 	case "yrno":
 		provider = NewYrNoProvider()
+		providerName = "yrno"
 	case "openweather":
 		provider = NewOpenWeatherProvider()
+		providerName = "openweather"
 	case "wunderground":
 		provider = NewWundergroundProvider(nil)
+		providerName = "wunderground"
 	case "":
 		// Not configured — default to yr.no
 		provider = NewYrNoProvider()
+		providerName = "yrno"
 	case "none":
 		// Explicitly disabled
 		getLogger().Info("Weather provider set to none, weather service disabled")
@@ -186,6 +200,7 @@ func NewService(settings *conf.Settings, db datastore.Interface, weatherMetrics 
 
 	return &Service{
 		provider:     provider,
+		providerName: providerName,
 		db:           db,
 		settings:     settings,
 		metrics:      weatherMetrics,
@@ -373,11 +388,13 @@ func validateWeatherData(data *datastore.HourlyWeather) error {
 
 // StartPolling starts the weather polling service
 func (s *Service) StartPolling(stopChan <-chan struct{}) {
+	// Poll interval is read once at startup; the ticker cadence is not
+	// hot-reloadable without a service restart.
 	interval := time.Duration(s.settings.Realtime.Weather.PollInterval) * time.Minute
 
 	// Use the dedicated weather logger
 	getLogger().Info("Starting weather polling service",
-		logger.String("provider", s.settings.Realtime.Weather.Provider),
+		logger.String("provider", s.providerName),
 		logger.Int("interval_minutes", s.settings.Realtime.Weather.PollInterval))
 
 	// Delay initial fetch to reduce startup DB contention with other services
@@ -429,21 +446,23 @@ func (s *Service) Poll() error {
 // entirely after maxConsecutiveAuthFailures.
 func (s *Service) fetchAndSave() error {
 	// Read a fresh settings snapshot so coordinate changes made via the
-	// settings UI take effect without restarting the weather service.
-	// Provider stays pinned to what NewService selected — changing provider
-	// still requires a service restart.
+	// settings UI take effect without restarting the weather service. The
+	// snapshot is captured once per cycle and passed to the provider so that
+	// coordinate/API-key reads inside the provider see a consistent view.
+	// Provider implementation stays pinned to what NewService selected —
+	// switching providers still requires a service restart, and s.providerName
+	// records the actually-used one for logs and metrics.
 	currentSettings := s.currentSettings()
-	providerName := currentSettings.Realtime.Weather.Provider
 
 	// Check if we should skip this cycle due to backoff
 	if s.backoff.shouldSkip() {
 		if s.backoff.isAuthDisabled() {
 			// Already logged when auth was disabled; emit periodic reminder at Debug level
 			getLogger().Debug("Skipping weather fetch — API authentication disabled due to repeated 401 errors",
-				logger.String("provider", providerName))
+				logger.String("provider", s.providerName))
 		} else {
 			getLogger().Debug("Skipping weather fetch — backing off after previous failures",
-				logger.String("provider", providerName))
+				logger.String("provider", s.providerName))
 		}
 		return nil
 	}
@@ -460,11 +479,11 @@ func (s *Service) fetchAndSave() error {
 		// not counted as errors.
 		if errors.Is(err, ErrWeatherDataNotModified) {
 			if s.metrics != nil {
-				s.metrics.RecordWeatherFetchDuration(providerName, time.Since(fetchStart).Seconds())
-				s.metrics.RecordWeatherFetch(providerName, "not_modified")
+				s.metrics.RecordWeatherFetchDuration(s.providerName, time.Since(fetchStart).Seconds())
+				s.metrics.RecordWeatherFetch(s.providerName, "not_modified")
 			}
 			getLogger().Debug("Weather data not modified since last fetch",
-				logger.String("provider", providerName))
+				logger.String("provider", s.providerName))
 			s.backoff.reset()
 			return nil
 		}
@@ -473,11 +492,11 @@ func (s *Service) fetchAndSave() error {
 		// This is a valid API response, not an error condition.
 		if errors.Is(err, ErrWeatherNoData) {
 			if s.metrics != nil {
-				s.metrics.RecordWeatherFetchDuration(providerName, time.Since(fetchStart).Seconds())
-				s.metrics.RecordWeatherFetch(providerName, "no_data")
+				s.metrics.RecordWeatherFetchDuration(s.providerName, time.Since(fetchStart).Seconds())
+				s.metrics.RecordWeatherFetch(s.providerName, "no_data")
 			}
 			getLogger().Debug("Weather station has no data available, will retry next cycle",
-				logger.String("provider", providerName))
+				logger.String("provider", s.providerName))
 			// Don't backoff — this is a normal condition for inactive stations
 			return nil
 		}
@@ -485,12 +504,12 @@ func (s *Service) fetchAndSave() error {
 
 	// Record fetch metrics for real errors and successes
 	if s.metrics != nil {
-		s.metrics.RecordWeatherFetchDuration(providerName, time.Since(fetchStart).Seconds())
+		s.metrics.RecordWeatherFetchDuration(s.providerName, time.Since(fetchStart).Seconds())
 		if err != nil {
-			s.metrics.RecordWeatherFetch(providerName, "error")
-			s.metrics.RecordWeatherFetchError(providerName, "fetch_error")
+			s.metrics.RecordWeatherFetch(s.providerName, "error")
+			s.metrics.RecordWeatherFetchError(s.providerName, "fetch_error")
 		} else {
-			s.metrics.RecordWeatherFetch(providerName, "success")
+			s.metrics.RecordWeatherFetch(s.providerName, "success")
 		}
 	}
 
@@ -501,11 +520,11 @@ func (s *Service) fetchAndSave() error {
 			if stopped {
 				getLogger().Error("Weather API authentication failed repeatedly — stopping retries. "+
 					"Please check your API key in the settings and restart the service.",
-					logger.String("provider", providerName),
+					logger.String("provider", s.providerName),
 					logger.Int("consecutive_failures", maxConsecutiveAuthFailures))
 			} else {
 				getLogger().Warn("Weather API authentication failed — will retry",
-					logger.String("provider", providerName),
+					logger.String("provider", s.providerName),
 					logger.Error(err))
 			}
 			return ErrWeatherAuthFailed
@@ -514,7 +533,7 @@ func (s *Service) fetchAndSave() error {
 		// General failure: apply exponential backoff
 		backoff, failures := s.backoff.recordFailure()
 		getLogger().Error("Failed to fetch weather data from provider, backing off",
-			logger.String("provider", providerName),
+			logger.String("provider", s.providerName),
 			logger.String("backoff", backoff.String()),
 			logger.Int("consecutive_failures", failures),
 			logger.Error(err))
@@ -523,7 +542,7 @@ func (s *Service) fetchAndSave() error {
 			Component("weather").
 			Category(errors.CategoryNetwork).
 			Context("operation", "fetch_weather_data").
-			Context("provider", providerName).
+			Context("provider", s.providerName).
 			Build()
 	}
 
@@ -535,7 +554,7 @@ func (s *Service) fetchAndSave() error {
 	localTimeForLog := data.Time.In(time.Local)
 
 	getLogger().Info("Successfully fetched weather data",
-		logger.String("provider", providerName),
+		logger.String("provider", s.providerName),
 		logger.String("time", localTimeForLog.Format("2006-01-02 15:04:05-07:00")),
 		logger.Float64("temp_c", data.Temperature.Current),
 		logger.Float64("wind_mps", data.Wind.Speed),

--- a/internal/weather/weather.go
+++ b/internal/weather/weather.go
@@ -108,6 +108,13 @@ type Service struct {
 	backoff      backoffState
 }
 
+// currentSettings returns the latest settings snapshot so the service picks
+// up changes made through the UI (e.g. a new BirdNET latitude/longitude)
+// without requiring a restart.
+func (s *Service) currentSettings() *conf.Settings {
+	return conf.CurrentOrFallback(s.settings)
+}
+
 // WeatherData represents the common structure for weather data across providers
 type WeatherData struct {
 	Time          time.Time
@@ -421,15 +428,22 @@ func (s *Service) Poll() error {
 // errors. For persistent authentication failures (HTTP 401), it stops retrying
 // entirely after maxConsecutiveAuthFailures.
 func (s *Service) fetchAndSave() error {
+	// Read a fresh settings snapshot so coordinate changes made via the
+	// settings UI take effect without restarting the weather service.
+	// Provider stays pinned to what NewService selected — changing provider
+	// still requires a service restart.
+	currentSettings := s.currentSettings()
+	providerName := currentSettings.Realtime.Weather.Provider
+
 	// Check if we should skip this cycle due to backoff
 	if s.backoff.shouldSkip() {
 		if s.backoff.isAuthDisabled() {
 			// Already logged when auth was disabled; emit periodic reminder at Debug level
 			getLogger().Debug("Skipping weather fetch — API authentication disabled due to repeated 401 errors",
-				logger.String("provider", s.settings.Realtime.Weather.Provider))
+				logger.String("provider", providerName))
 		} else {
 			getLogger().Debug("Skipping weather fetch — backing off after previous failures",
-				logger.String("provider", s.settings.Realtime.Weather.Provider))
+				logger.String("provider", providerName))
 		}
 		return nil
 	}
@@ -438,7 +452,7 @@ func (s *Service) fetchAndSave() error {
 	fetchStart := time.Now()
 
 	// FetchWeather should now internally log its start/end/errors
-	data, err := s.provider.FetchWeather(s.settings)
+	data, err := s.provider.FetchWeather(currentSettings)
 
 	if err != nil {
 		// Handle "not modified" as a success case — no new data to save.
@@ -446,11 +460,11 @@ func (s *Service) fetchAndSave() error {
 		// not counted as errors.
 		if errors.Is(err, ErrWeatherDataNotModified) {
 			if s.metrics != nil {
-				s.metrics.RecordWeatherFetchDuration(s.settings.Realtime.Weather.Provider, time.Since(fetchStart).Seconds())
-				s.metrics.RecordWeatherFetch(s.settings.Realtime.Weather.Provider, "not_modified")
+				s.metrics.RecordWeatherFetchDuration(providerName, time.Since(fetchStart).Seconds())
+				s.metrics.RecordWeatherFetch(providerName, "not_modified")
 			}
 			getLogger().Debug("Weather data not modified since last fetch",
-				logger.String("provider", s.settings.Realtime.Weather.Provider))
+				logger.String("provider", providerName))
 			s.backoff.reset()
 			return nil
 		}
@@ -459,11 +473,11 @@ func (s *Service) fetchAndSave() error {
 		// This is a valid API response, not an error condition.
 		if errors.Is(err, ErrWeatherNoData) {
 			if s.metrics != nil {
-				s.metrics.RecordWeatherFetchDuration(s.settings.Realtime.Weather.Provider, time.Since(fetchStart).Seconds())
-				s.metrics.RecordWeatherFetch(s.settings.Realtime.Weather.Provider, "no_data")
+				s.metrics.RecordWeatherFetchDuration(providerName, time.Since(fetchStart).Seconds())
+				s.metrics.RecordWeatherFetch(providerName, "no_data")
 			}
 			getLogger().Debug("Weather station has no data available, will retry next cycle",
-				logger.String("provider", s.settings.Realtime.Weather.Provider))
+				logger.String("provider", providerName))
 			// Don't backoff — this is a normal condition for inactive stations
 			return nil
 		}
@@ -471,12 +485,12 @@ func (s *Service) fetchAndSave() error {
 
 	// Record fetch metrics for real errors and successes
 	if s.metrics != nil {
-		s.metrics.RecordWeatherFetchDuration(s.settings.Realtime.Weather.Provider, time.Since(fetchStart).Seconds())
+		s.metrics.RecordWeatherFetchDuration(providerName, time.Since(fetchStart).Seconds())
 		if err != nil {
-			s.metrics.RecordWeatherFetch(s.settings.Realtime.Weather.Provider, "error")
-			s.metrics.RecordWeatherFetchError(s.settings.Realtime.Weather.Provider, "fetch_error")
+			s.metrics.RecordWeatherFetch(providerName, "error")
+			s.metrics.RecordWeatherFetchError(providerName, "fetch_error")
 		} else {
-			s.metrics.RecordWeatherFetch(s.settings.Realtime.Weather.Provider, "success")
+			s.metrics.RecordWeatherFetch(providerName, "success")
 		}
 	}
 
@@ -487,11 +501,11 @@ func (s *Service) fetchAndSave() error {
 			if stopped {
 				getLogger().Error("Weather API authentication failed repeatedly — stopping retries. "+
 					"Please check your API key in the settings and restart the service.",
-					logger.String("provider", s.settings.Realtime.Weather.Provider),
+					logger.String("provider", providerName),
 					logger.Int("consecutive_failures", maxConsecutiveAuthFailures))
 			} else {
 				getLogger().Warn("Weather API authentication failed — will retry",
-					logger.String("provider", s.settings.Realtime.Weather.Provider),
+					logger.String("provider", providerName),
 					logger.Error(err))
 			}
 			return ErrWeatherAuthFailed
@@ -500,7 +514,7 @@ func (s *Service) fetchAndSave() error {
 		// General failure: apply exponential backoff
 		backoff, failures := s.backoff.recordFailure()
 		getLogger().Error("Failed to fetch weather data from provider, backing off",
-			logger.String("provider", s.settings.Realtime.Weather.Provider),
+			logger.String("provider", providerName),
 			logger.String("backoff", backoff.String()),
 			logger.Int("consecutive_failures", failures),
 			logger.Error(err))
@@ -509,7 +523,7 @@ func (s *Service) fetchAndSave() error {
 			Component("weather").
 			Category(errors.CategoryNetwork).
 			Context("operation", "fetch_weather_data").
-			Context("provider", s.settings.Realtime.Weather.Provider).
+			Context("provider", providerName).
 			Build()
 	}
 
@@ -521,7 +535,7 @@ func (s *Service) fetchAndSave() error {
 	localTimeForLog := data.Time.In(time.Local)
 
 	getLogger().Info("Successfully fetched weather data",
-		logger.String("provider", s.settings.Realtime.Weather.Provider),
+		logger.String("provider", providerName),
 		logger.String("time", localTimeForLog.Format("2006-01-02 15:04:05-07:00")),
 		logger.Float64("temp_c", data.Temperature.Current),
 		logger.Float64("wind_mps", data.Wind.Speed),

--- a/internal/weather/weather_test.go
+++ b/internal/weather/weather_test.go
@@ -1236,6 +1236,64 @@ func TestFetchAndSave_SuccessResetsBackoff(t *testing.T) {
 	mockDB.AssertExpectations(t)
 }
 
+// TestFetchAndSave_HotReloadCoordinates verifies that coordinates updated via
+// conf.StoreSettings (as done by the settings UI) are picked up on the next
+// fetch without restarting the weather service. Regression test for a bug
+// where the Service cached a *conf.Settings pointer at construction and kept
+// sending lat=0, lon=0 to yr.no after the user set their location.
+func TestFetchAndSave_HotReloadCoordinates(t *testing.T) {
+	// Swap the global settings pointer for the duration of the test and
+	// restore it on cleanup so this test is isolated.
+	t.Cleanup(func() { conf.StoreSettings(nil) })
+
+	initial := createTestSettings(t, "yrno", func(s *conf.Settings) {
+		s.BirdNET.Latitude = 0
+		s.BirdNET.Longitude = 0
+	})
+	conf.StoreSettings(initial)
+
+	var observedLat, observedLon float64
+	provider := &mockProvider{
+		fetchFunc: func(settings *conf.Settings) (*WeatherData, error) {
+			observedLat = settings.BirdNET.Latitude
+			observedLon = settings.BirdNET.Longitude
+			return nil, errors.New("short-circuit after observing coords")
+		},
+	}
+
+	// Service is constructed with the initial (zero-coord) snapshot — this
+	// mirrors how NewService is called at startup before the user has
+	// configured their location.
+	service := &Service{
+		provider: provider,
+		db:       nil,
+		settings: initial,
+		metrics:  nil,
+	}
+
+	_ = service.fetchAndSave()
+	assert.InDelta(t, 0.0, observedLat, 1e-9, "initial fetch should use the captured coords")
+	assert.InDelta(t, 0.0, observedLon, 1e-9, "initial fetch should use the captured coords")
+
+	// Clear backoff so the second fetch runs, then publish a new snapshot
+	// with real coords — exactly what the settings UI does.
+	service.backoff.mu.Lock()
+	service.backoff.nextAllowedFetchTime = time.Time{}
+	service.backoff.mu.Unlock()
+
+	updated := createTestSettings(t, "yrno", func(s *conf.Settings) {
+		s.BirdNET.Latitude = 60.1699
+		s.BirdNET.Longitude = 24.9384
+	})
+	conf.StoreSettings(updated)
+
+	_ = service.fetchAndSave()
+	assert.InDelta(t, 60.1699, observedLat, 1e-9,
+		"fetch should pick up updated latitude from global settings")
+	assert.InDelta(t, 24.9384, observedLon, 1e-9,
+		"fetch should pick up updated longitude from global settings")
+}
+
 // TestWundergroundProvider_HTTP204_NoContent tests that Wunderground returns
 // ErrWeatherNoData for HTTP 204.
 func TestWundergroundProvider_HTTP204_NoContent(t *testing.T) {

--- a/internal/weather/weather_test.go
+++ b/internal/weather/weather_test.go
@@ -1313,10 +1313,10 @@ func TestNewService_PinsProviderName(t *testing.T) {
 		configured string
 		want       string
 	}{
-		{"yrno", "yrno"},
-		{"openweather", "openweather"},
-		{"wunderground", "wunderground"},
-		{"", "yrno"}, // empty defaults to yrno
+		{yrNoProviderName, yrNoProviderName},
+		{openWeatherProviderName, openWeatherProviderName},
+		{wundergroundProviderName, wundergroundProviderName},
+		{"", yrNoProviderName}, // empty defaults to yrno
 	}
 	for _, tt := range tests {
 		t.Run(tt.configured+"_pins_to_"+tt.want, func(t *testing.T) {

--- a/internal/weather/weather_test.go
+++ b/internal/weather/weather_test.go
@@ -1273,7 +1273,7 @@ func TestFetchAndSave_HotReloadCoordinates(t *testing.T) {
 	// configured their location.
 	service := &Service{
 		provider:     provider,
-		providerName: "yrno",
+		providerName: yrNoProviderName,
 		db:           nil,
 		settings:     initial,
 		metrics:      nil,

--- a/internal/weather/weather_test.go
+++ b/internal/weather/weather_test.go
@@ -1241,10 +1241,17 @@ func TestFetchAndSave_SuccessResetsBackoff(t *testing.T) {
 // fetch without restarting the weather service. Regression test for a bug
 // where the Service cached a *conf.Settings pointer at construction and kept
 // sending lat=0, lon=0 to yr.no after the user set their location.
+//
+// Intentionally NOT t.Parallel(): this test mutates the package-global
+// settings snapshot via conf.StoreSettings, so running in parallel with any
+// sibling test that touches the global would race. Same pattern as
+// TestSettings_GetStore_NoRace in the conf package.
 func TestFetchAndSave_HotReloadCoordinates(t *testing.T) {
-	// Swap the global settings pointer for the duration of the test and
-	// restore it on cleanup so this test is isolated.
-	t.Cleanup(func() { conf.StoreSettings(nil) })
+	// Capture the previous snapshot so any earlier test's state is restored
+	// on cleanup — blindly clearing with StoreSettings(nil) could perturb
+	// siblings that depend on a previously-loaded global.
+	prevSettings := conf.GetSettings()
+	t.Cleanup(func() { conf.StoreSettings(prevSettings) })
 
 	initial := createTestSettings(t, "yrno", func(s *conf.Settings) {
 		s.BirdNET.Latitude = 0
@@ -1265,10 +1272,11 @@ func TestFetchAndSave_HotReloadCoordinates(t *testing.T) {
 	// mirrors how NewService is called at startup before the user has
 	// configured their location.
 	service := &Service{
-		provider: provider,
-		db:       nil,
-		settings: initial,
-		metrics:  nil,
+		provider:     provider,
+		providerName: "yrno",
+		db:           nil,
+		settings:     initial,
+		metrics:      nil,
 	}
 
 	_ = service.fetchAndSave()
@@ -1292,6 +1300,34 @@ func TestFetchAndSave_HotReloadCoordinates(t *testing.T) {
 		"fetch should pick up updated latitude from global settings")
 	assert.InDelta(t, 24.9384, observedLon, 1e-9,
 		"fetch should pick up updated longitude from global settings")
+}
+
+// TestNewService_PinsProviderName verifies that the Service pins the
+// provider name at construction based on the actual provider implementation
+// it selected. This matters because fetchAndSave uses s.providerName in logs
+// and metrics, and reading the name from the (hot-reloadable) settings
+// snapshot instead could misreport a later UI change while s.provider still
+// points at the original implementation.
+func TestNewService_PinsProviderName(t *testing.T) {
+	tests := []struct {
+		configured string
+		want       string
+	}{
+		{"yrno", "yrno"},
+		{"openweather", "openweather"},
+		{"wunderground", "wunderground"},
+		{"", "yrno"}, // empty defaults to yrno
+	}
+	for _, tt := range tests {
+		t.Run(tt.configured+"_pins_to_"+tt.want, func(t *testing.T) {
+			settings := createTestSettings(t, tt.configured)
+			svc, err := NewService(settings, nil, nil)
+			require.NoError(t, err)
+			require.NotNil(t, svc)
+			assert.Equal(t, tt.want, svc.providerName,
+				"providerName should reflect the actual provider implementation, not be re-read from settings")
+		})
+	}
 }
 
 // TestWundergroundProvider_HTTP204_NoContent tests that Wunderground returns


### PR DESCRIPTION
I noticed that weather api requests on my instance were still using old coordinates from before I changed the setting. I saw that there's a few other places with potentially similar behaviour, so figured I'd fix it a bit more broadly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Spectrogram generation now samples runtime configuration once per job so export path, size/raw, style, dynamic range, and audio-tool paths take immediate effect.

* **Bug Fixes / Behavior**
  * Weather service pins the chosen provider at startup; provider selection won’t change on hot-reload.

* **Tests**
  * Added tests covering hot-reload of coordinates/API key and provider-pinning behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->