### PR TITLE
fix(notification): apply user templates to detection notifications via alert path

### DIFF
--- a/internal/alerting/init.go
+++ b/internal/alerting/init.go
@@ -23,6 +23,7 @@ func (a *notificationAdapter) CreateAndBroadcast(notifType notification.Type, ti
 	if svc == nil {
 		return nil // notification service not yet initialized
 	}
+	title, message = applyDetectionTemplates(notifType, title, message, eventProps)
 	notif := notification.NewNotification(notifType, notification.PriorityHigh, title, message)
 	notif = enrichFromEventProps(notif, notifType, eventProps)
 	return svc.CreateWithMetadata(notif)
@@ -36,6 +37,7 @@ func (a *notificationAdapter) CreateAndBroadcastWithKeys(
 	if svc == nil {
 		return nil // notification service not yet initialized
 	}
+	title, message = applyDetectionTemplates(notifType, title, message, eventProps)
 	notif := notification.NewNotification(notifType, notification.PriorityHigh, title, message).
 		WithTitleKey(titleKey, titleParams)
 	if messageKey != "" {
@@ -233,6 +235,54 @@ func buildTemplateDataFromProps(props map[string]any) *notification.TemplateData
 		ImageURL:           imageURL,
 		DaysSinceFirstSeen: daysSinceFirstSeen,
 	}
+}
+
+// applyDetectionTemplates overrides title and message with user-configured
+// notification templates for detection events. Non-detection types pass through unchanged.
+func applyDetectionTemplates(notifType notification.Type, title, message string, eventProps map[string]any) (renderedTitle, renderedMessage string) {
+	if notifType != notification.TypeDetection {
+		return title, message
+	}
+	rt, rm := renderDetectionTemplates(eventProps)
+	if rt != "" {
+		title = rt
+	}
+	if rm != "" {
+		message = rm
+	}
+	return title, message
+}
+
+func renderDetectionTemplates(props map[string]any) (title, message string) {
+	settings := conf.GetSettings()
+	if settings == nil {
+		return "", ""
+	}
+
+	titleTmpl := settings.Notification.Templates.NewSpecies.Title
+	msgTmpl := settings.Notification.Templates.NewSpecies.Message
+	if titleTmpl == "" && msgTmpl == "" {
+		return "", ""
+	}
+
+	templateData := buildTemplateDataFromProps(props)
+	if templateData == nil {
+		return "", ""
+	}
+
+	if titleTmpl != "" {
+		if rendered, err := notification.RenderTemplate("title", titleTmpl, templateData); err == nil {
+			title = rendered
+		}
+	}
+
+	if msgTmpl != "" {
+		if rendered, err := notification.RenderTemplate("message", msgTmpl, templateData); err == nil {
+			message = rendered
+		}
+	}
+
+	return title, message
 }
 
 // Initialize creates and starts the alerting engine.

--- a/internal/alerting/init.go
+++ b/internal/alerting/init.go
@@ -238,9 +238,14 @@ func buildTemplateDataFromProps(props map[string]any) *notification.TemplateData
 }
 
 // applyDetectionTemplates overrides title and message with user-configured
-// notification templates for detection events. Non-detection types pass through unchanged.
+// notification templates for new-species detection events. Non-detection types
+// and non-new-species detections pass through unchanged.
 func applyDetectionTemplates(notifType notification.Type, title, message string, eventProps map[string]any) (renderedTitle, renderedMessage string) {
 	if notifType != notification.TypeDetection {
+		return title, message
+	}
+	isNew, _ := eventProps[PropertyIsNewSpecies].(bool)
+	if !isNew {
 		return title, message
 	}
 	rt, rm := renderDetectionTemplates(eventProps)
@@ -266,18 +271,25 @@ func renderDetectionTemplates(props map[string]any) (title, message string) {
 	}
 
 	templateData := buildTemplateDataFromProps(props)
-	if templateData == nil {
-		return "", ""
-	}
+
+	log := notification.GetLogger()
 
 	if titleTmpl != "" {
-		if rendered, err := notification.RenderTemplate("title", titleTmpl, templateData); err == nil {
+		rendered, err := notification.RenderTemplate("title", titleTmpl, templateData)
+		if err != nil {
+			log.Warn("failed to render detection title template",
+				logger.String("template", titleTmpl), logger.Error(err))
+		} else {
 			title = rendered
 		}
 	}
 
 	if msgTmpl != "" {
-		if rendered, err := notification.RenderTemplate("message", msgTmpl, templateData); err == nil {
+		rendered, err := notification.RenderTemplate("message", msgTmpl, templateData)
+		if err != nil {
+			log.Warn("failed to render detection message template",
+				logger.String("template", msgTmpl), logger.Error(err))
+		} else {
 			message = rendered
 		}
 	}

--- a/internal/alerting/init_test.go
+++ b/internal/alerting/init_test.go
@@ -269,6 +269,7 @@ func validDetectionProps() map[string]any {
 		PropertyConfidence:     0.95,
 		PropertyEventTimestamp: time.Now(),
 		PropertyLocation:       "backyard",
+		PropertyIsNewSpecies:   true,
 	}
 }
 
@@ -324,6 +325,22 @@ func TestApplyDetectionTemplates_NonDetectionUnchanged(t *testing.T) {
 
 	title, message := applyDetectionTemplates(
 		notification.TypeWarning, "Original Title", "Original Message", validDetectionProps(),
+	)
+	assert.Equal(t, "Original Title", title)
+	assert.Equal(t, "Original Message", message)
+}
+
+func TestApplyDetectionTemplates_NonNewSpeciesUnchanged(t *testing.T) {
+	settings := conf.GetTestSettings()
+	settings.Notification.Templates.NewSpecies.Title = "New: {{.CommonName}}"
+	conf.SetTestSettings(settings)
+	t.Cleanup(func() { conf.SetTestSettings(nil) })
+
+	props := validDetectionProps()
+	props[PropertyIsNewSpecies] = false
+
+	title, message := applyDetectionTemplates(
+		notification.TypeDetection, "Original Title", "Original Message", props,
 	)
 	assert.Equal(t, "Original Title", title)
 	assert.Equal(t, "Original Message", message)

--- a/internal/alerting/init_test.go
+++ b/internal/alerting/init_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/datastore/v2/entities"
 	"github.com/tphakala/birdnet-go/internal/datastore/v2/repository"
 	"github.com/tphakala/birdnet-go/internal/logger"
@@ -249,7 +250,7 @@ func TestEnrichFromEventProps_FallbackImageURL(t *testing.T) {
 		PropertySpeciesName:    "Eurasian Blue Tit",
 		PropertyScientificName: "Cyanistes caeruleus",
 		PropertyConfidence:     0.9,
-		// No event_metadata with image_url — should fall back to proxy URL
+		// No event_metadata with image_url; should fall back to proxy URL
 	}
 
 	notif := notification.NewNotification(notification.TypeDetection, notification.PriorityHigh, "Title", "Message")
@@ -258,4 +259,72 @@ func TestEnrichFromEventProps_FallbackImageURL(t *testing.T) {
 	// Should use the proxy URL with encoded scientific name
 	assert.Contains(t, enriched.Metadata["bg_image_url"], "/api/v2/media/species-image")
 	assert.Contains(t, enriched.Metadata["bg_image_url"], "Cyanistes+caeruleus")
+}
+
+// validDetectionProps returns a props map suitable for renderDetectionTemplates tests.
+func validDetectionProps() map[string]any {
+	return map[string]any{
+		PropertySpeciesName:    "Eurasian Blue Tit",
+		PropertyScientificName: "Cyanistes caeruleus",
+		PropertyConfidence:     0.95,
+		PropertyEventTimestamp: time.Now(),
+		PropertyLocation:       "backyard",
+	}
+}
+
+func TestRenderDetectionTemplates_WithConfiguredTemplates(t *testing.T) {
+	settings := conf.GetTestSettings()
+	settings.Notification.Templates.NewSpecies.Title = "New: {{.CommonName}}"
+	settings.Notification.Templates.NewSpecies.Message = "{{.CommonName}} ({{.ScientificName}}) at {{.ConfidencePercent}}%"
+	conf.SetTestSettings(settings)
+	t.Cleanup(func() { conf.SetTestSettings(nil) })
+
+	title, message := renderDetectionTemplates(validDetectionProps())
+	assert.Equal(t, "New: Eurasian Blue Tit", title)
+	assert.Contains(t, message, "Eurasian Blue Tit")
+	assert.Contains(t, message, "Cyanistes caeruleus")
+	assert.Contains(t, message, "95%")
+}
+
+func TestRenderDetectionTemplates_EmptyTemplates(t *testing.T) {
+	settings := conf.GetTestSettings()
+	conf.SetTestSettings(settings)
+	t.Cleanup(func() { conf.SetTestSettings(nil) })
+
+	title, message := renderDetectionTemplates(validDetectionProps())
+	assert.Empty(t, title)
+	assert.Empty(t, message)
+}
+
+func TestRenderDetectionTemplates_NilSettings(t *testing.T) {
+	conf.SetTestSettings(nil)
+	t.Cleanup(func() { conf.SetTestSettings(nil) })
+
+	title, message := renderDetectionTemplates(validDetectionProps())
+	assert.Empty(t, title)
+	assert.Empty(t, message)
+}
+
+func TestRenderDetectionTemplates_TitleOnlyTemplate(t *testing.T) {
+	settings := conf.GetTestSettings()
+	settings.Notification.Templates.NewSpecies.Title = "Spotted: {{.CommonName}}"
+	conf.SetTestSettings(settings)
+	t.Cleanup(func() { conf.SetTestSettings(nil) })
+
+	title, message := renderDetectionTemplates(validDetectionProps())
+	assert.Equal(t, "Spotted: Eurasian Blue Tit", title)
+	assert.Empty(t, message)
+}
+
+func TestApplyDetectionTemplates_NonDetectionUnchanged(t *testing.T) {
+	settings := conf.GetTestSettings()
+	settings.Notification.Templates.NewSpecies.Title = "Override: {{.CommonName}}"
+	conf.SetTestSettings(settings)
+	t.Cleanup(func() { conf.SetTestSettings(nil) })
+
+	title, message := applyDetectionTemplates(
+		notification.TypeWarning, "Original Title", "Original Message", validDetectionProps(),
+	)
+	assert.Equal(t, "Original Title", title)
+	assert.Equal(t, "Original Message", message)
 }


### PR DESCRIPTION
## Summary

- The alerting dispatcher created notifications with hardcoded fallback messages instead of rendering user-configured notification templates
- Shoutrrr providers (Telegram, Pushover, ntfy) use `n.Title`/`n.Message` directly, so they received the hardcoded text (e.g., "Species detected with X% confidence") while webhook providers (Discord) were unaffected because they render from `bg_*` metadata
- Added `renderDetectionTemplates()` and `applyDetectionTemplates()` to `internal/alerting/init.go` that render user templates from settings for detection-type notifications, with graceful fallback to original title/message when templates are empty or rendering fails

## Related Issues

Fixes #2840

## Test Plan

- [x] `TestRenderDetectionTemplates_WithConfiguredTemplates` - verifies templates render correctly with detection props
- [x] `TestRenderDetectionTemplates_EmptyTemplates` - verifies fallback when no templates configured
- [x] `TestRenderDetectionTemplates_NilSettings` - verifies fallback when settings unavailable
- [x] `TestRenderDetectionTemplates_TitleOnlyTemplate` - verifies partial template configuration
- [x] `TestApplyDetectionTemplates_NonDetectionUnchanged` - verifies non-detection types pass through unchanged
- [x] `golangci-lint run -v ./internal/alerting/...` - zero issues
- [x] `go test -race ./internal/alerting/...` - all tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detection notifications can be customized with user-configured title and message templates.
  * Templates may include species name, scientific name, and confidence percentage.
  * Template overrides apply only for "new species" detection notifications and use defaults if templates are empty or fail to render.

* **Tests**
  * Added unit tests covering template rendering and conditional application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->