### PR TITLE
fix(frontend): suppress network fetch errors in Sentry when backend is offline

### DIFF
--- a/frontend/src/lib/desktop/features/dashboard/pages/DashboardPage.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/pages/DashboardPage.svelte
@@ -1276,7 +1276,7 @@ Performance Optimizations:
   });
 
   // Refetch data when backend connectivity is restored
-  let wasOnline = $state(connectionState.isOnline);
+  let wasOnline = connectionState.isOnline;
   $effect(() => {
     const online = connectionState.isOnline;
     if (online && !wasOnline) {

--- a/frontend/src/lib/desktop/features/dashboard/pages/DashboardPage.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/pages/DashboardPage.svelte
@@ -64,6 +64,7 @@ Performance Optimizations:
   import { api } from '$lib/utils/api';
   import { buildAppUrl } from '$lib/utils/urlHelpers';
   import { navigation } from '$lib/stores/navigation.svelte';
+  import { connectionState } from '$lib/stores/connectionState.svelte';
   import { appState } from '$lib/stores/appState.svelte';
   import { birdnetSettings, dashboardLayout, settingsStore } from '$lib/stores/settings';
   import type { Dashboard, DashboardElement, DashboardLayout } from '$lib/stores/settings';
@@ -318,6 +319,8 @@ Performance Optimizations:
 
   // Fetch functions
   async function fetchDailySummary() {
+    if (!connectionState.isOnline) return;
+
     isLoadingSummary = true;
     summaryError = null;
 
@@ -403,6 +406,8 @@ Performance Optimizations:
   }
 
   async function fetchRecentDetections(applyAnimations = false) {
+    if (!connectionState.isOnline) return;
+
     isLoadingDetections = true;
     detectionsError = null;
 

--- a/frontend/src/lib/desktop/features/dashboard/pages/DashboardPage.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/pages/DashboardPage.svelte
@@ -319,7 +319,10 @@ Performance Optimizations:
 
   // Fetch functions
   async function fetchDailySummary() {
-    if (!connectionState.isOnline) return;
+    if (!connectionState.isOnline) {
+      isLoadingSummary = false;
+      return;
+    }
 
     isLoadingSummary = true;
     summaryError = null;
@@ -406,7 +409,10 @@ Performance Optimizations:
   }
 
   async function fetchRecentDetections(applyAnimations = false) {
-    if (!connectionState.isOnline) return;
+    if (!connectionState.isOnline) {
+      isLoadingDetections = false;
+      return;
+    }
 
     isLoadingDetections = true;
     detectionsError = null;
@@ -1267,6 +1273,17 @@ Performance Optimizations:
     if (selectedDate && configLoaded) {
       triggerAdjacentPreload(selectedDate);
     }
+  });
+
+  // Refetch data when backend connectivity is restored
+  let wasOnline = $state(connectionState.isOnline);
+  $effect(() => {
+    const online = connectionState.isOnline;
+    if (online && !wasOnline) {
+      fetchDailySummary();
+      fetchRecentDetections();
+    }
+    wasOnline = online;
   });
 
   // Update freeze state management

--- a/frontend/src/lib/telemetry/sentry.ts
+++ b/frontend/src/lib/telemetry/sentry.ts
@@ -7,6 +7,7 @@
  * - Privacy-first beforeSend filtering
  */
 import * as Sentry from '@sentry/browser';
+import { isBackendOnline } from '$lib/stores/connectionState.svelte';
 
 /** Configuration passed from appState after config fetch. */
 export interface SentryConfig {
@@ -32,6 +33,19 @@ function isExpectedApiError(err: unknown): boolean {
   if (typeof err !== 'object' || err === null) return false;
   const status = (err as Record<string, unknown>).status;
   return status === HTTP_UNAUTHORIZED || status === HTTP_FORBIDDEN || status === HTTP_CONFLICT;
+}
+
+/**
+ * Check whether an error is a browser-level network TypeError.
+ * Chrome/Firefox: "Failed to fetch", Safari: "Load failed",
+ * older Firefox: "NetworkError when attempting to fetch resource".
+ */
+function isNetworkTypeError(err: unknown): boolean {
+  if (!(err instanceof TypeError)) return false;
+  const msg = err.message;
+  return (
+    msg.includes('Failed to fetch') || msg.includes('Load failed') || msg.includes('NetworkError')
+  );
 }
 
 /**
@@ -63,6 +77,9 @@ export function initSentry(config: SentryConfig): void {
 export function captureApiError(error: ApiErrorLike, context?: Record<string, string>): void {
   // Skip expected-flow errors — auth (401/403) and conflict (409, e.g. v2 database not available)
   if (isExpectedApiError(error)) return;
+
+  // Skip network errors when the backend is already known to be offline
+  if (error.isNetworkError && !isBackendOnline()) return;
 
   const severity = error.isNetworkError || error.status >= 500 ? 'error' : 'warning';
 
@@ -100,6 +117,9 @@ export function captureError(
 ): void {
   // Skip expected-flow errors — 401/403/409 are not bugs
   if (isExpectedApiError(error)) return;
+
+  // Skip network TypeErrors when the backend is already known to be offline
+  if (!isBackendOnline() && isNetworkTypeError(error)) return;
 
   Sentry.withScope(scope => {
     scope.setLevel('error');
@@ -167,6 +187,9 @@ function scrubUrl(raw: string): string {
 function beforeSend(event: Sentry.ErrorEvent, hint: Sentry.EventHint): Sentry.ErrorEvent | null {
   // Drop expected-flow errors — 401/403/409 can arrive via unhandled rejections or logger.error().
   if (isExpectedApiError(hint.originalException)) return null;
+
+  // Drop network TypeErrors when backend is known-offline (safety net for unhandled rejections)
+  if (!isBackendOnline() && isNetworkTypeError(hint.originalException)) return null;
 
   // 1. Strip user data (Sentry auto-collects IP)
   delete event.user;


### PR DESCRIPTION
## Summary

- Add offline guards to DashboardPage `fetchDailySummary()` and `fetchRecentDetections()`, matching the pattern used by DatabaseDashboard and System views
- Filter network errors (TypeError: Failed to fetch / Load failed / NetworkError) in all three Sentry capture paths when backend is known-offline
- SSE connection intentionally not guarded since it drives the watchdog heartbeat for recovery detection

## Context

DashboardPage fires raw `fetch()` calls without checking `connectionState.isOnline`. When the backend is unreachable, these produce browser-level TypeErrors that flood Sentry with 530+ noise events per release cycle across 8 Sentry issues (BIRDNET-GO-1D4, 1ND, 1PG, 1PH, 1JV, 1JW, 1JY, 1M8). The offline banner eventually appears via the SSE watchdog, but by then the errors have already been sent to Sentry.

**Two-layer fix:**
1. **Fetch guards** - prevent REST fetches when offline state is already known
2. **Sentry filtering** - drop network errors via `captureApiError`, `captureError`, and `beforeSend` when `isBackendOnline()` is false. Network errors while online still reach Sentry as legitimate signals.

## Test Plan

- [ ] Verify `npm run check:all` passes with zero errors
- [ ] Existing sentry.test.ts tests pass (26/26)
- [ ] Manual: stop backend, confirm offline banner shows and no Sentry events fire for dashboard fetches
- [ ] Manual: restart backend, confirm dashboard recovers via SSE reconnection

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents unnecessary network requests and ensures loading indicators are cleared when the app is offline; dashboard data is automatically refetched when connectivity is restored.
  * Suppresses redundant browser network-type error reports in telemetry when the app already detects offline status, reducing noisy/duplicate error alerts while preserving privacy scrubbing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->