### PR TITLE
fix(frontend): reduce remaining Sentry noise - network errors, empty events, locale fingerprinting

### DIFF
--- a/frontend/src/lib/telemetry/sentry.test.ts
+++ b/frontend/src/lib/telemetry/sentry.test.ts
@@ -10,6 +10,7 @@ vi.mock('@sentry/browser', () => ({
       setLevel: vi.fn(),
       setTag: vi.fn(),
       setContext: vi.fn(),
+      setFingerprint: vi.fn(),
     };
     callback(mockScope);
   }),
@@ -158,6 +159,78 @@ describe('beforeSend privacy filtering', () => {
     expect(result.breadcrumbs?.[0]?.data?.response_body).toBeUndefined();
     expect(result.breadcrumbs?.[0]?.data?.body).toBeUndefined();
   });
+
+  it('drops network TypeErrors unconditionally', () => {
+    const error = new TypeError('Failed to fetch');
+    const event = { type: undefined } as Sentry.ErrorEvent;
+    const result = beforeSend?.(event, { originalException: error } as Sentry.EventHint);
+    expect(result).toBeNull();
+  });
+
+  it('drops Safari Load failed TypeErrors', () => {
+    const error = new TypeError('Load failed');
+    const event = { type: undefined } as Sentry.ErrorEvent;
+    const result = beforeSend?.(event, { originalException: error } as Sentry.EventHint);
+    expect(result).toBeNull();
+  });
+
+  it('drops events with empty error message', () => {
+    const error = new Error('');
+    const event = { type: undefined } as Sentry.ErrorEvent;
+    const result = beforeSend?.(event, { originalException: error } as Sentry.EventHint);
+    expect(result).toBeNull();
+  });
+
+  it('drops events with <anonymous> error message', () => {
+    const error = new Error('<anonymous>');
+    const event = { type: undefined } as Sentry.ErrorEvent;
+    const result = beforeSend?.(event, { originalException: error } as Sentry.EventHint);
+    expect(result).toBeNull();
+  });
+
+  it('drops events with callback error message', () => {
+    const error = new Error('callback');
+    const event = { type: undefined } as Sentry.ErrorEvent;
+    const result = beforeSend?.(event, { originalException: error } as Sentry.EventHint);
+    expect(result).toBeNull();
+  });
+
+  it('drops string exceptions with generic messages', () => {
+    const event = { type: undefined } as Sentry.ErrorEvent;
+    const result = beforeSend?.(event, { originalException: 'callback' } as Sentry.EventHint);
+    expect(result).toBeNull();
+  });
+
+  it('drops ResizeObserver loop errors', () => {
+    const error = new Error('ResizeObserver loop completed with undelivered notifications');
+    const event = { type: undefined } as Sentry.ErrorEvent;
+    const result = beforeSend?.(event, { originalException: error } as Sentry.EventHint);
+    expect(result).toBeNull();
+  });
+
+  it('sets fingerprint for API errors with status code', () => {
+    const error = Object.assign(new Error('Serverfehler'), { status: 500, isNetworkError: false });
+    const event = { type: undefined } as Sentry.ErrorEvent;
+    const result = beforeSend?.(event, { originalException: error } as Sentry.EventHint);
+    expect(result).not.toBeNull();
+    expect((result as Sentry.ErrorEvent).fingerprint).toEqual(['ApiError', '500']);
+  });
+
+  it('does not set fingerprint for non-API errors with status property', () => {
+    const error = Object.assign(new Error('Custom error'), { status: 418 });
+    const event = { type: undefined } as Sentry.ErrorEvent;
+    const result = beforeSend?.(event, { originalException: error } as Sentry.EventHint);
+    expect(result).not.toBeNull();
+    expect((result as Sentry.ErrorEvent).fingerprint).toBeUndefined();
+  });
+
+  it('does not set fingerprint for errors without status', () => {
+    const error = new Error('some error');
+    const event = { type: undefined } as Sentry.ErrorEvent;
+    const result = beforeSend?.(event, { originalException: error } as Sentry.EventHint);
+    expect(result).not.toBeNull();
+    expect((result as Sentry.ErrorEvent).fingerprint).toBeUndefined();
+  });
 });
 
 describe('captureApiError', () => {
@@ -198,12 +271,31 @@ describe('captureApiError', () => {
     expect(Sentry.withScope).toHaveBeenCalledOnce();
   });
 
-  it('captures network errors with error severity', () => {
+  it('skips network errors', () => {
     const error = new Error('Network Error') as Error & { status: number; isNetworkError: boolean };
     error.status = 0;
     error.isNetworkError = true;
     captureApiError(error);
-    expect(Sentry.withScope).toHaveBeenCalledOnce();
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+  });
+
+  it('sets fingerprint based on status code', () => {
+    const error = new Error('Server Error') as Error & { status: number; isNetworkError: boolean };
+    error.status = 500;
+    error.isNetworkError = false;
+
+    const mockScope = {
+      setLevel: vi.fn(),
+      setTag: vi.fn(),
+      setContext: vi.fn(),
+      setFingerprint: vi.fn(),
+    };
+    vi.mocked(Sentry.withScope).mockImplementation(((callback: (scope: unknown) => void) => {
+      callback(mockScope);
+    }) as typeof Sentry.withScope);
+
+    captureApiError(error);
+    expect(mockScope.setFingerprint).toHaveBeenCalledWith(['ApiError', '500']);
   });
 });
 
@@ -227,6 +319,12 @@ describe('captureError', () => {
 
   it('skips errors with status 409', () => {
     const error = Object.assign(new Error('Conflict'), { status: 409 });
+    captureError(error, { category: 'api' });
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+  });
+
+  it('skips network TypeErrors unconditionally', () => {
+    const error = new TypeError('Failed to fetch');
     captureError(error, { category: 'api' });
     expect(Sentry.captureException).not.toHaveBeenCalled();
   });

--- a/frontend/src/lib/telemetry/sentry.ts
+++ b/frontend/src/lib/telemetry/sentry.ts
@@ -25,6 +25,9 @@ const HTTP_BAD_GATEWAY = 502;
 const HTTP_SERVICE_UNAVAILABLE = 503;
 const HTTP_GATEWAY_TIMEOUT = 504;
 
+/** Minimum HTTP status considered a server-side error (5xx). */
+const HTTP_SERVER_ERROR_MIN = 500;
+
 /** API error shape matching ApiError from api.ts. */
 interface ApiErrorLike {
   message: string;
@@ -138,7 +141,7 @@ export function captureApiError(error: ApiErrorLike, context?: Record<string, st
   // Skip network errors - connectivity issues are infrastructure noise, not app bugs
   if (error.isNetworkError) return;
 
-  const severity = error.status >= 500 ? 'error' : 'warning';
+  const severity = error.status >= HTTP_SERVER_ERROR_MIN ? 'error' : 'warning';
 
   Sentry.withScope(scope => {
     scope.setLevel(severity);
@@ -157,7 +160,9 @@ export function captureApiError(error: ApiErrorLike, context?: Record<string, st
       scope.setTag('http.status_code', String(error.status));
     }
 
-    scope.setFingerprint(['ApiError', String(error.status)]);
+    if (error.status > 0) {
+      scope.setFingerprint(['ApiError', String(error.status)]);
+    }
     Sentry.captureException(error);
   });
 }

--- a/frontend/src/lib/telemetry/sentry.ts
+++ b/frontend/src/lib/telemetry/sentry.ts
@@ -7,7 +7,6 @@
  * - Privacy-first beforeSend filtering
  */
 import * as Sentry from '@sentry/browser';
-import { isBackendOnline } from '$lib/stores/connectionState.svelte';
 
 /** Configuration passed from appState after config fetch. */
 export interface SentryConfig {
@@ -63,6 +62,12 @@ const ASSET_LOADING_ERROR_PATTERNS = [
   'dynamically imported module',
 ] as const;
 
+/** Messages with zero diagnostic value (minified/anonymous callbacks, empty strings). */
+const GENERIC_MESSAGES = new Set(['', '<anonymous>', 'callback']);
+
+/** Lowercase substrings for browser-internal noise that is never an app bug. */
+const NOISE_MESSAGE_PATTERNS = ['resizeobserver loop'] as const;
+
 /** Check whether an error is a chunk/asset loading failure from lazy routes. */
 function isAssetLoadingError(err: unknown): boolean {
   if (!(err instanceof Error)) return false;
@@ -81,6 +86,20 @@ function isNetworkTypeError(err: unknown): boolean {
   return (
     msg.includes('Failed to fetch') || msg.includes('Load failed') || msg.includes('NetworkError')
   );
+}
+
+/** Check whether a normalized message matches known noise patterns. */
+function isNoiseMessage(raw: string): boolean {
+  const msg = raw.trim().toLowerCase();
+  return GENERIC_MESSAGES.has(msg) || NOISE_MESSAGE_PATTERNS.some(p => msg.includes(p));
+}
+
+/** Check whether an error has no actionable diagnostic information. */
+function hasNoDiagnosticValue(hint: Sentry.EventHint): boolean {
+  const err = hint.originalException;
+  if (typeof err === 'string') return isNoiseMessage(err);
+  if (err instanceof Error) return isNoiseMessage(err.message);
+  return false;
 }
 
 /**
@@ -116,10 +135,10 @@ export function captureApiError(error: ApiErrorLike, context?: Record<string, st
   // Skip gateway errors — 502/503/504 are proxy/infrastructure issues, not app bugs
   if (isGatewayError(error)) return;
 
-  // Skip network errors when the backend is already known to be offline
-  if (error.isNetworkError && !isBackendOnline()) return;
+  // Skip network errors - connectivity issues are infrastructure noise, not app bugs
+  if (error.isNetworkError) return;
 
-  const severity = error.isNetworkError || error.status >= 500 ? 'error' : 'warning';
+  const severity = error.status >= 500 ? 'error' : 'warning';
 
   Sentry.withScope(scope => {
     scope.setLevel(severity);
@@ -137,10 +156,8 @@ export function captureApiError(error: ApiErrorLike, context?: Record<string, st
     if (error.status) {
       scope.setTag('http.status_code', String(error.status));
     }
-    if (error.isNetworkError) {
-      scope.setTag('error.network', 'true');
-    }
 
+    scope.setFingerprint(['ApiError', String(error.status)]);
     Sentry.captureException(error);
   });
 }
@@ -156,8 +173,8 @@ export function captureError(
   // Skip expected-flow errors — 401/403/409 are not bugs
   if (isExpectedApiError(error)) return;
 
-  // Skip network TypeErrors when the backend is already known to be offline
-  if (!isBackendOnline() && isNetworkTypeError(error)) return;
+  // Skip network TypeErrors - connectivity issues are infrastructure noise, not app bugs
+  if (isNetworkTypeError(error)) return;
 
   Sentry.withScope(scope => {
     scope.setLevel('error');
@@ -229,11 +246,14 @@ function beforeSend(event: Sentry.ErrorEvent, hint: Sentry.EventHint): Sentry.Er
   // Drop gateway errors — 502/503/504 from reverse proxies during backend restarts
   if (isGatewayError(hint.originalException)) return null;
 
-  // Drop network TypeErrors when backend is known-offline (safety net for unhandled rejections)
-  if (!isBackendOnline() && isNetworkTypeError(hint.originalException)) return null;
+  // Drop network TypeErrors (connectivity issues are infrastructure noise, not app bugs)
+  if (isNetworkTypeError(hint.originalException)) return null;
 
   // Drop chunk/asset loading failures from lazy-loaded routes (stale manifests, transient network)
   if (isAssetLoadingError(hint.originalException)) return null;
+
+  // Drop events with no diagnostic value (empty/generic messages, browser noise)
+  if (hasNoDiagnosticValue(hint)) return null;
 
   // 1. Strip user data (Sentry auto-collects IP)
   delete event.user;
@@ -265,6 +285,21 @@ function beforeSend(event: Sentry.ErrorEvent, hint: Sentry.EventHint): Sentry.Er
         delete breadcrumb.data.response_body;
         delete breadcrumb.data.body;
       }
+    }
+  }
+
+  // Fingerprint API errors by type+status to merge locale variants into one Sentry issue.
+  // The 'isNetworkError' property discriminates ApiErrorLike from other error types.
+  const origErr = hint.originalException;
+  if (
+    origErr &&
+    typeof origErr === 'object' &&
+    'isNetworkError' in origErr &&
+    'status' in origErr
+  ) {
+    const status = (origErr as Record<string, unknown>).status;
+    if (typeof status === 'number' && status > 0) {
+      event.fingerprint = ['ApiError', String(status)];
     }
   }
 


### PR DESCRIPTION
## Summary

- Remove `isBackendOnline()` gate from network error filtering so `TypeError: Failed to fetch` / `Load failed` / `NetworkError` are dropped unconditionally (infrastructure noise regardless of backend state)
- Filter empty and generic error messages (`<anonymous>`, `callback`) plus `ResizeObserver loop` errors that have zero diagnostic value
- Add locale-aware fingerprinting via `scope.setFingerprint(['ApiError', status])` so the same HTTP error in different locales groups into a single Sentry issue instead of creating duplicates per language
- Clean up dead code paths (`isNetworkError` severity/tag checks unreachable after early return)

Follows up on PR #2854 (gateway/asset loading errors) and PR #2851 (network fetch suppression when backend offline).

## Test Plan

- [x] All 38 tests pass (`npx vitest run src/lib/telemetry/sentry.test.ts`)
- [x] ESLint clean
- [x] TypeScript type-check clean (svelte-check: 0 errors)
- [x] Pre-commit hooks pass (lint-staged, prettier, eslint)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Network errors are now excluded from error reporting to reduce noise.
  * Generic, empty, anonymous, and browser-internal messages (e.g., resize-observer loop) are filtered out.
  * API errors are grouped by HTTP status for clearer tracking; severity is mapped by status (>=500 treated as error, otherwise warning).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->