### PR TITLE
fix(audio): add EQ debug logging and settings round-trip tests

### DIFF
--- a/internal/api/v2/settings_eq_roundtrip_test.go
+++ b/internal/api/v2/settings_eq_roundtrip_test.go
@@ -1,0 +1,311 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/conf"
+)
+
+// putTestSettingsJSON marshals a full Settings struct to JSON, then patches
+// the equalizer section with the provided config. This mimics what the
+// frontend does: send the complete settings object with modifications.
+func putTestSettingsJSON(t *testing.T, settings *conf.Settings, eqOverride map[string]any) []byte {
+	t.Helper()
+
+	// Marshal the full settings to JSON (same as what GetAllSettings returns)
+	fullJSON, err := json.Marshal(settings)
+	require.NoError(t, err)
+
+	// Unmarshal into a generic map so we can patch the equalizer
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(fullJSON, &payload))
+
+	// Patch the audio equalizer
+	realtime, ok := payload["realtime"].(map[string]any)
+	require.True(t, ok, "payload must contain realtime section")
+	audio, ok := realtime["audio"].(map[string]any)
+	require.True(t, ok, "realtime must contain audio section")
+	audio["equalizer"] = eqOverride
+
+	body, err := json.Marshal(payload)
+	require.NoError(t, err)
+	return body
+}
+
+// TestEQFilterRoundTrip_PUT verifies that equalizer filters survive the full
+// PUT /api/v2/settings path that the frontend save button uses. This tests
+// the ctx.Bind -> updateAllowedFieldsRecursivelyWithTracking flow, not the
+// PATCH mergeJSONIntoStruct flow.
+func TestEQFilterRoundTrip_PUT(t *testing.T) {
+	t.Parallel()
+
+	initial := getTestSettings(t)
+	// Start with no EQ filters
+	initial.Realtime.Audio.Equalizer = conf.EqualizerSettings{
+		Enabled: false,
+		Filters: nil,
+	}
+
+	e := echo.New()
+	controller := &Controller{
+		Echo:                e,
+		Settings:            initial,
+		controlChan:         make(chan string, testControlChanBuffer),
+		DisableSaveSettings: true,
+	}
+
+	eqConfig := map[string]any{
+		"enabled": true,
+		"filters": []map[string]any{
+			{
+				"type":      "HighPass",
+				"frequency": 200,
+				"q":         0.707,
+				"gain":      0,
+				"width":     0,
+				"passes":    1,
+			},
+			{
+				"type":      "LowPass",
+				"frequency": 14000,
+				"q":         0.707,
+				"gain":      0,
+				"width":     0,
+				"passes":    2,
+			},
+		},
+	}
+
+	body := putTestSettingsJSON(t, initial, eqConfig)
+
+	req := httptest.NewRequest(http.MethodPut, "/api/v2/settings", bytes.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+
+	err := controller.UpdateSettings(ctx)
+	require.NoError(t, err)
+	t.Logf("PUT response (status %d): %s", rec.Code, rec.Body.String())
+	assert.Equal(t, http.StatusOK, rec.Code, "PUT should succeed")
+
+	// Verify global EQ filters persisted
+	eq := controller.Settings.Realtime.Audio.Equalizer
+	assert.True(t, eq.Enabled, "Equalizer should be enabled")
+	require.Len(t, eq.Filters, 2, "Should have 2 filters")
+	assert.Equal(t, "HighPass", eq.Filters[0].Type)
+	assert.InDelta(t, float64(200), eq.Filters[0].Frequency, 0.01)
+	assert.InDelta(t, 0.707, eq.Filters[0].Q, 0.001)
+	assert.Equal(t, 1, eq.Filters[0].Passes)
+	assert.Equal(t, "LowPass", eq.Filters[1].Type)
+	assert.InDelta(t, float64(14000), eq.Filters[1].Frequency, 0.01)
+	assert.Equal(t, 2, eq.Filters[1].Passes)
+}
+
+// putTestSettingsWithSourceEQ marshals a full Settings struct to JSON, then
+// patches the sources array to include per-source equalizer config.
+func putTestSettingsWithSourceEQ(t *testing.T, settings *conf.Settings, sourceEQ map[string]any) []byte {
+	t.Helper()
+
+	fullJSON, err := json.Marshal(settings)
+	require.NoError(t, err)
+
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(fullJSON, &payload))
+
+	if realtime, ok := payload["realtime"].(map[string]any); ok {
+		if audio, ok := realtime["audio"].(map[string]any); ok {
+			if sources, ok := audio["sources"].([]any); ok && len(sources) > 0 {
+				if src, ok := sources[0].(map[string]any); ok {
+					src["equalizer"] = sourceEQ
+				}
+			}
+		}
+	}
+
+	body, err := json.Marshal(payload)
+	require.NoError(t, err)
+	return body
+}
+
+// TestEQFilterRoundTrip_PUT_PerSource verifies that per-source equalizer
+// filters survive the PUT path when attached to an AudioSourceConfig.
+func TestEQFilterRoundTrip_PUT_PerSource(t *testing.T) {
+	t.Parallel()
+
+	initial := getTestSettings(t)
+	initial.Realtime.Audio.Sources = []conf.AudioSourceConfig{{
+		Name:   "Test Sound Card",
+		Device: "default",
+		Models: []string{"birdnet"},
+	}}
+
+	e := echo.New()
+	controller := &Controller{
+		Echo:                e,
+		Settings:            initial,
+		controlChan:         make(chan string, testControlChanBuffer),
+		DisableSaveSettings: true,
+	}
+
+	sourceEQ := map[string]any{
+		"enabled": true,
+		"filters": []map[string]any{
+			{
+				"type":      "HighPass",
+				"frequency": 500,
+				"q":         0.707,
+				"gain":      0,
+				"width":     0,
+				"passes":    2,
+			},
+		},
+	}
+
+	body := putTestSettingsWithSourceEQ(t, initial, sourceEQ)
+
+	req := httptest.NewRequest(http.MethodPut, "/api/v2/settings", bytes.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+
+	err := controller.UpdateSettings(ctx)
+	require.NoError(t, err)
+	t.Logf("PUT response (status %d): %s", rec.Code, rec.Body.String())
+	assert.Equal(t, http.StatusOK, rec.Code, "PUT should succeed")
+
+	// Verify per-source EQ
+	require.Len(t, controller.Settings.Realtime.Audio.Sources, 1)
+	srcEQ := controller.Settings.Realtime.Audio.Sources[0].Equalizer
+	require.NotNil(t, srcEQ, "Per-source equalizer should not be nil")
+	assert.True(t, srcEQ.Enabled, "Per-source equalizer should be enabled")
+	require.Len(t, srcEQ.Filters, 1, "Per-source should have 1 filter")
+	assert.Equal(t, "HighPass", srcEQ.Filters[0].Type)
+	assert.InDelta(t, float64(500), srcEQ.Filters[0].Frequency, 0.01)
+	assert.Equal(t, 2, srcEQ.Filters[0].Passes)
+
+	// Global EQ should remain unchanged
+	assert.False(t, controller.Settings.Realtime.Audio.Equalizer.Enabled)
+}
+
+// TestEQFilterRoundTrip_PATCH verifies the PATCH path (section update) for
+// comparison with the PUT path.
+func TestEQFilterRoundTrip_PATCH(t *testing.T) {
+	t.Parallel()
+
+	initial := getTestSettings(t)
+	initial.Realtime.Audio.Equalizer = conf.EqualizerSettings{
+		Enabled: false,
+		Filters: nil,
+	}
+
+	e := echo.New()
+	controller := &Controller{
+		Echo:                e,
+		Settings:            initial,
+		controlChan:         make(chan string, testControlChanBuffer),
+		DisableSaveSettings: true,
+	}
+
+	payload := map[string]any{
+		"audio": map[string]any{
+			"equalizer": map[string]any{
+				"enabled": true,
+				"filters": []map[string]any{
+					{
+						"type":      "HighPass",
+						"frequency": 200,
+						"q":         0.707,
+						"gain":      0,
+						"width":     0,
+						"passes":    1,
+					},
+					{
+						"type":      "LowPass",
+						"frequency": 14000,
+						"q":         0.707,
+						"gain":      0,
+						"width":     0,
+						"passes":    2,
+					},
+				},
+			},
+		},
+	}
+
+	body, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPatch, "/api/v2/settings/realtime", bytes.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+	ctx.SetParamNames("section")
+	ctx.SetParamValues("realtime")
+
+	err = controller.UpdateSectionSettings(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code, "PATCH should succeed")
+
+	eq := controller.Settings.Realtime.Audio.Equalizer
+	assert.True(t, eq.Enabled, "Equalizer should be enabled")
+	require.Len(t, eq.Filters, 2, "Should have 2 filters")
+	assert.Equal(t, "HighPass", eq.Filters[0].Type)
+	assert.InDelta(t, float64(200), eq.Filters[0].Frequency, 0.01)
+	assert.Equal(t, "LowPass", eq.Filters[1].Type)
+	assert.InDelta(t, float64(14000), eq.Filters[1].Frequency, 0.01)
+}
+
+// TestEQFilterRoundTrip_PUT_WithFrontendIDField verifies that the extra
+// "id" field the frontend sends (not present in the Go struct) does not
+// break deserialization of equalizer filters.
+func TestEQFilterRoundTrip_PUT_WithFrontendIDField(t *testing.T) {
+	t.Parallel()
+
+	initial := getTestSettings(t)
+	e := echo.New()
+	controller := &Controller{
+		Echo:                e,
+		Settings:            initial,
+		controlChan:         make(chan string, testControlChanBuffer),
+		DisableSaveSettings: true,
+	}
+
+	eqConfig := map[string]any{
+		"enabled": true,
+		"filters": []map[string]any{
+			{
+				"id":        "filter-1714567890-0",
+				"type":      "HighPass",
+				"frequency": 300,
+				"q":         0.707,
+				"gain":      0,
+				"width":     0,
+				"passes":    1,
+			},
+		},
+	}
+
+	body := putTestSettingsJSON(t, initial, eqConfig)
+
+	req := httptest.NewRequest(http.MethodPut, "/api/v2/settings", bytes.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+
+	err := controller.UpdateSettings(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	eq := controller.Settings.Realtime.Audio.Equalizer
+	assert.True(t, eq.Enabled)
+	require.Len(t, eq.Filters, 1)
+	assert.Equal(t, "HighPass", eq.Filters[0].Type)
+	assert.InDelta(t, float64(300), eq.Filters[0].Frequency, 0.01)
+}

--- a/internal/api/v2/settings_eq_roundtrip_test.go
+++ b/internal/api/v2/settings_eq_roundtrip_test.go
@@ -105,6 +105,7 @@ func TestEQFilterRoundTrip_PUT(t *testing.T) {
 	assert.Equal(t, 1, eq.Filters[0].Passes)
 	assert.Equal(t, "LowPass", eq.Filters[1].Type)
 	assert.InDelta(t, float64(14000), eq.Filters[1].Frequency, 0.01)
+	assert.InDelta(t, 0.707, eq.Filters[1].Q, 0.001)
 	assert.Equal(t, 2, eq.Filters[1].Passes)
 }
 
@@ -119,15 +120,16 @@ func putTestSettingsWithSourceEQ(t *testing.T, settings *conf.Settings, sourceEQ
 	var payload map[string]any
 	require.NoError(t, json.Unmarshal(fullJSON, &payload))
 
-	if realtime, ok := payload["realtime"].(map[string]any); ok {
-		if audio, ok := realtime["audio"].(map[string]any); ok {
-			if sources, ok := audio["sources"].([]any); ok && len(sources) > 0 {
-				if src, ok := sources[0].(map[string]any); ok {
-					src["equalizer"] = sourceEQ
-				}
-			}
-		}
-	}
+	realtime, ok := payload["realtime"].(map[string]any)
+	require.True(t, ok, "payload must contain realtime section")
+	audio, ok := realtime["audio"].(map[string]any)
+	require.True(t, ok, "realtime must contain audio section")
+	sources, ok := audio["sources"].([]any)
+	require.True(t, ok, "audio must contain sources section")
+	require.NotEmpty(t, sources, "sources must be non-empty")
+	src, ok := sources[0].(map[string]any)
+	require.True(t, ok, "sources[0] must be an object")
+	src["equalizer"] = sourceEQ
 
 	body, err := json.Marshal(payload)
 	require.NoError(t, err)

--- a/internal/api/v2/settings_eq_roundtrip_test.go
+++ b/internal/api/v2/settings_eq_roundtrip_test.go
@@ -260,8 +260,12 @@ func TestEQFilterRoundTrip_PATCH(t *testing.T) {
 	require.Len(t, eq.Filters, 2, "Should have 2 filters")
 	assert.Equal(t, "HighPass", eq.Filters[0].Type)
 	assert.InDelta(t, float64(200), eq.Filters[0].Frequency, 0.01)
+	assert.InDelta(t, 0.707, eq.Filters[0].Q, 0.001)
+	assert.Equal(t, 1, eq.Filters[0].Passes)
 	assert.Equal(t, "LowPass", eq.Filters[1].Type)
 	assert.InDelta(t, float64(14000), eq.Filters[1].Frequency, 0.01)
+	assert.InDelta(t, 0.707, eq.Filters[1].Q, 0.001)
+	assert.Equal(t, 2, eq.Filters[1].Passes)
 }
 
 // TestEQFilterRoundTrip_PUT_WithFrontendIDField verifies that the extra

--- a/internal/audiocore/equalizer/builder.go
+++ b/internal/audiocore/equalizer/builder.go
@@ -10,11 +10,19 @@ import (
 // Returns nil when the equalizer is disabled or has no filters configured.
 // Unknown filter types are logged and skipped without aborting the chain.
 func BuildFilterChain(settings conf.EqualizerSettings, sampleRate int) *FilterChain {
+	log := logger.Global().Module("audio").Module("equalizer")
+
 	if !settings.Enabled || len(settings.Filters) == 0 {
+		log.Debug("EQ disabled or no filters configured",
+			logger.Bool("enabled", settings.Enabled),
+			logger.Int("filter_count", len(settings.Filters)))
 		return nil
 	}
 
-	log := logger.Global().Module("audio").Module("equalizer")
+	log.Debug("building EQ filter chain",
+		logger.Int("filter_count", len(settings.Filters)),
+		logger.Int("sample_rate", sampleRate))
+
 	chain := NewFilterChain()
 	sr := float64(sampleRate)
 
@@ -44,11 +52,18 @@ func BuildFilterChain(settings conf.EqualizerSettings, sampleRate int) *FilterCh
 				logger.Error(addErr))
 			continue
 		}
+		log.Debug("added EQ filter",
+			logger.String("type", f.Type),
+			logger.Float64("frequency", f.Frequency),
+			logger.Int("passes", passes))
 	}
 
 	if chain.Length() == 0 {
+		log.Debug("EQ filter chain empty after building, all filters failed")
 		return nil
 	}
+	log.Debug("EQ filter chain built",
+		logger.Int("active_filters", chain.Length()))
 	return chain
 }
 
@@ -57,9 +72,23 @@ func BuildFilterChain(settings conf.EqualizerSettings, sampleRate int) *FilterCh
 // Returns nil when EQ is disabled or has no filters. Falls back to global
 // settings if sourceCfg is nil or has no per-source override.
 func BuildFilterChainForSource(sourceCfg *conf.AudioSourceConfig, globalEQ conf.EqualizerSettings, sampleRate int) *FilterChain {
+	log := logger.Global().Module("audio").Module("equalizer")
 	eqSettings := globalEQ
 	if sourceCfg != nil && sourceCfg.Equalizer != nil {
 		eqSettings = *sourceCfg.Equalizer
+		log.Debug("using per-source EQ override",
+			logger.String("source", sourceCfg.Name),
+			logger.Bool("enabled", eqSettings.Enabled),
+			logger.Int("filter_count", len(eqSettings.Filters)))
+	} else {
+		sourceName := "unknown"
+		if sourceCfg != nil {
+			sourceName = sourceCfg.Name
+		}
+		log.Debug("using global EQ for source",
+			logger.String("source", sourceName),
+			logger.Bool("enabled", globalEQ.Enabled),
+			logger.Int("filter_count", len(globalEQ.Filters)))
 	}
 	return BuildFilterChain(eqSettings, sampleRate)
 }

--- a/internal/audiocore/equalizer/builder.go
+++ b/internal/audiocore/equalizer/builder.go
@@ -6,20 +6,20 @@ import (
 	"github.com/tphakala/birdnet-go/internal/logger"
 )
 
+var eqLog = logger.Global().Module("audio").Module("equalizer")
+
 // BuildFilterChain creates a FilterChain from the given equalizer settings.
 // Returns nil when the equalizer is disabled or has no filters configured.
 // Unknown filter types are logged and skipped without aborting the chain.
 func BuildFilterChain(settings conf.EqualizerSettings, sampleRate int) *FilterChain {
-	log := logger.Global().Module("audio").Module("equalizer")
-
 	if !settings.Enabled || len(settings.Filters) == 0 {
-		log.Debug("EQ disabled or no filters configured",
+		eqLog.Debug("EQ disabled or no filters configured",
 			logger.Bool("enabled", settings.Enabled),
 			logger.Int("filter_count", len(settings.Filters)))
 		return nil
 	}
 
-	log.Debug("building EQ filter chain",
+	eqLog.Debug("building EQ filter chain",
 		logger.Int("filter_count", len(settings.Filters)),
 		logger.Int("sample_rate", sampleRate))
 
@@ -35,34 +35,34 @@ func BuildFilterChain(settings conf.EqualizerSettings, sampleRate int) *FilterCh
 
 		filter, err := buildFilter(f, sr, passes)
 		if err != nil {
-			log.Warn("skipping EQ filter",
+			eqLog.Warn("skipping EQ filter",
 				logger.String("type", f.Type),
 				logger.Float64("frequency", f.Frequency),
 				logger.Error(err))
 			continue
 		}
 		if filter == nil {
-			log.Warn("unknown EQ filter type, skipping",
+			eqLog.Warn("unknown EQ filter type, skipping",
 				logger.String("type", f.Type))
 			continue
 		}
 		if addErr := chain.AddFilter(filter); addErr != nil {
-			log.Warn("failed to add EQ filter to chain",
+			eqLog.Warn("failed to add EQ filter to chain",
 				logger.String("type", f.Type),
 				logger.Error(addErr))
 			continue
 		}
-		log.Debug("added EQ filter",
+		eqLog.Debug("added EQ filter",
 			logger.String("type", f.Type),
 			logger.Float64("frequency", f.Frequency),
 			logger.Int("passes", passes))
 	}
 
 	if chain.Length() == 0 {
-		log.Debug("EQ filter chain empty after building, all filters failed")
+		eqLog.Debug("EQ filter chain empty after building, all filters failed")
 		return nil
 	}
-	log.Debug("EQ filter chain built",
+	eqLog.Debug("EQ filter chain built",
 		logger.Int("active_filters", chain.Length()))
 	return chain
 }
@@ -72,11 +72,10 @@ func BuildFilterChain(settings conf.EqualizerSettings, sampleRate int) *FilterCh
 // Returns nil when EQ is disabled or has no filters. Falls back to global
 // settings if sourceCfg is nil or has no per-source override.
 func BuildFilterChainForSource(sourceCfg *conf.AudioSourceConfig, globalEQ conf.EqualizerSettings, sampleRate int) *FilterChain {
-	log := logger.Global().Module("audio").Module("equalizer")
 	eqSettings := globalEQ
 	if sourceCfg != nil && sourceCfg.Equalizer != nil {
 		eqSettings = *sourceCfg.Equalizer
-		log.Debug("using per-source EQ override",
+		eqLog.Debug("using per-source EQ override",
 			logger.String("source", sourceCfg.Name),
 			logger.Bool("enabled", eqSettings.Enabled),
 			logger.Int("filter_count", len(eqSettings.Filters)))
@@ -85,7 +84,7 @@ func BuildFilterChainForSource(sourceCfg *conf.AudioSourceConfig, globalEQ conf.
 		if sourceCfg != nil {
 			sourceName = sourceCfg.Name
 		}
-		log.Debug("using global EQ for source",
+		eqLog.Debug("using global EQ for source",
 			logger.String("source", sourceName),
 			logger.Bool("enabled", globalEQ.Enabled),
 			logger.Int("filter_count", len(globalEQ.Filters)))

--- a/internal/audiocore/router.go
+++ b/internal/audiocore/router.go
@@ -273,8 +273,22 @@ func (r *AudioRouter) UpdateFilterChain(sourceID string, build FilterChainBuilde
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
-	for _, rt := range r.routes[sourceID] {
-		rt.filterChain.Store(build(rt.Consumer.SampleRate()))
+	routes := r.routes[sourceID]
+	for _, rt := range routes {
+		chain := build(rt.Consumer.SampleRate())
+		rt.filterChain.Store(chain)
+		filterCount := 0
+		if chain != nil {
+			filterCount = chain.Length()
+		}
+		r.log.Debug("EQ filter chain updated",
+			logger.String("source_id", sourceID),
+			logger.String("consumer_id", rt.Consumer.ID()),
+			logger.Int("active_filters", filterCount))
+	}
+	if len(routes) == 0 {
+		r.log.Debug("EQ filter chain update: no routes found for source",
+			logger.String("source_id", sourceID))
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add debug-level logging to the equalizer pipeline (filter chain build, per-source vs global resolution, hot-swap updates) to help diagnose issues like #2849 where users report audio filters not saving
- Add 4 Go unit tests proving both PUT and PATCH settings endpoints correctly persist equalizer filters (global EQ, per-source EQ, frontend extra `id` field)
- Investigation confirmed the backend save paths work correctly; the new logging will help diagnose the user's specific environment

## Related Issues

Relates to #2849

## Test Plan

- [x] `go test -race -v -run TestEQFilterRoundTrip ./internal/api/v2/` passes (4 tests)
- [x] `golangci-lint run -v` passes with 0 issues
- [x] E2E Playwright tests in birdnet-go-qa pass (8 tests covering API and UI flows)
- [ ] Verify debug logs appear when EQ is configured (manual check with debug logging enabled)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added API tests validating global and per-source equalizer updates, including persistence checks for enablement, filter count, filter types and numeric fields, plus tolerance and frontend-only field handling.

* **Chores**
  * Improved debug logging and observability for equalizer chain construction and per-route updates, including detailed logs for applied settings, filter counts, and no-route conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->