### PR TITLE
feat(audio): add per-stream EQ support and fix EQ resolution

### DIFF
--- a/frontend/src/lib/desktop/components/forms/StreamCard.svelte
+++ b/frontend/src/lib/desktop/components/forms/StreamCard.svelte
@@ -37,10 +37,29 @@
   import Checkbox from './Checkbox.svelte';
   import SelectDropdown from './SelectDropdown.svelte';
   import QuietHoursEditor from './QuietHoursEditor.svelte';
-  import type { StreamConfig, StreamType, QuietHoursConfig } from '$lib/stores/settings';
+  import AudioEqualizerSettings from '$lib/desktop/features/settings/components/AudioEqualizerSettings.svelte';
+  import type {
+    StreamConfig,
+    StreamType,
+    EqualizerFilterType,
+    QuietHoursConfig,
+  } from '$lib/stores/settings';
   import { defaultQuietHoursConfig } from '$lib/stores/settings';
   import type { StreamHealthResponse } from './StreamManager.svelte';
   import StreamTimeline from './StreamTimeline.svelte';
+
+  interface LocalEqualizerSettings {
+    enabled: boolean;
+    filters: Array<{
+      id?: string;
+      type: EqualizerFilterType;
+      frequency: number;
+      q?: number;
+      width?: number;
+      gain?: number;
+      passes?: number;
+    }>;
+  }
 
   // Stream health status type
   export type StreamStatus =
@@ -137,8 +156,10 @@
   let editTransport = $state<'tcp' | 'udp'>('tcp');
   let editStreamType = $state<StreamType>('rtsp');
   let editEnabled = $state(true);
+  let editEqualizer = $state<LocalEqualizerSettings>({ enabled: false, filters: [] });
   let editQuietHours = $state<QuietHoursConfig>({ ...defaultQuietHoursConfig });
   let showDeleteConfirm = $state(false);
+  let showEqualizer = $state(false);
 
   // Stream type options (all supported types)
   const streamTypeOptions = [
@@ -272,7 +293,11 @@
     editTransport = stream.transport ?? 'tcp';
     editStreamType = stream.type;
     editEnabled = stream.enabled;
+    editEqualizer = stream.equalizer
+      ? { ...stream.equalizer, filters: [...stream.equalizer.filters] }
+      : { enabled: false, filters: [] };
     editQuietHours = { ...defaultQuietHoursConfig, ...stream.quietHours };
+    showEqualizer = false;
     isEditing = true;
   }
 
@@ -283,6 +308,17 @@
 
   function saveEdit() {
     if (editName.trim() && editUrl.trim()) {
+      const transformedEqualizer =
+        editEqualizer.enabled || editEqualizer.filters.length > 0
+          ? {
+              enabled: editEqualizer.enabled,
+              filters: editEqualizer.filters.map(f => ({
+                ...f,
+                id: f.id || crypto.randomUUID(),
+              })),
+            }
+          : undefined;
+
       const success = onUpdate({
         name: editName.trim(),
         url: editUrl.trim(),
@@ -290,12 +326,17 @@
         type: editStreamType,
         // Use selected transport for RTSP/RTMP, omit for others
         ...(showTransportInEdit ? { transport: editTransport } : {}),
+        equalizer: transformedEqualizer,
         quietHours: editQuietHours,
       } as StreamConfig);
       if (success) {
         isEditing = false;
       }
     }
+  }
+
+  function handleEqualizerUpdate(updated: LocalEqualizerSettings) {
+    editEqualizer = updated;
   }
 
   function confirmDelete() {
@@ -438,6 +479,38 @@
           size="sm"
         />
 
+        <!-- Equalizer (expandable) -->
+        <div>
+          <button
+            type="button"
+            class="flex items-center gap-2 text-sm font-medium text-[var(--color-base-content)] hover:text-[var(--color-primary)] transition-colors"
+            onclick={() => (showEqualizer = !showEqualizer)}
+            aria-expanded={showEqualizer}
+            aria-controls="stream-eq-{index}"
+          >
+            <ChevronDown
+              class={cn('size-4 transition-transform duration-200', showEqualizer && 'rotate-180')}
+            />
+            {t('settings.audio.audioFilters.title')}
+            {#if editEqualizer.enabled}
+              <span
+                class="px-1.5 py-0.5 rounded text-[10px] font-medium bg-[var(--color-primary)]/15 text-[var(--color-primary)]"
+              >
+                {t('common.enabled')}
+              </span>
+            {/if}
+          </button>
+          {#if showEqualizer}
+            <div id="stream-eq-{index}" class="mt-3" transition:slide={{ duration: 200 }}>
+              <AudioEqualizerSettings
+                equalizerSettings={editEqualizer}
+                {disabled}
+                onUpdate={handleEqualizerUpdate}
+              />
+            </div>
+          {/if}
+        </div>
+
         <!-- Quiet Hours -->
         <QuietHoursEditor
           config={editQuietHours}
@@ -495,6 +568,13 @@
               size="sm"
               pulse={status === 'connecting'}
             />
+            {#if stream.equalizer?.enabled}
+              <span
+                class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium bg-[var(--color-primary)]/15 text-[var(--color-primary)]"
+              >
+                {t('settings.audio.audioFilters.title')}
+              </span>
+            {/if}
             {#if stream.quietHours?.enabled}
               <span
                 class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium bg-[var(--color-base-300)] text-[var(--color-base-content)] opacity-70"

--- a/frontend/src/lib/stores/settings.ts
+++ b/frontend/src/lib/stores/settings.ts
@@ -198,6 +198,7 @@ export interface StreamConfig {
   enabled: boolean; // Materialized during settings coercion for backward compatibility
   type: StreamType; // Stream type: rtsp, http, hls, rtmp, udp
   transport?: 'tcp' | 'udp'; // Transport protocol (for RTSP/RTMP only)
+  equalizer?: EqualizerSettings; // Per-stream EQ (undefined = use global)
   quietHours?: QuietHoursConfig; // Quiet hours configuration
 }
 

--- a/internal/analysis/audio_pipeline_service.go
+++ b/internal/analysis/audio_pipeline_service.go
@@ -469,9 +469,15 @@ func (p *AudioPipelineService) registerSoundLevelConsumers(sourceIDs []string, o
 		// Look up per-source gain from the registry.
 		gainDB, _ := p.engine.Registry().GetGain(sid)
 
-		// Resolve per-source EQ filter chain.
-		srcCfg := audioSettings.FindSourceByID(sid)
-		eqChain := equalizer.BuildFilterChainForSource(srcCfg, audioSettings.Equalizer, conf.SampleRate)
+		// Resolve per-source/per-stream EQ filter chain using the registry's
+		// DisplayName, which matches the config Name for both audio sources and streams.
+		src, _ := p.engine.Registry().Get(sid)
+		sourceName := sid
+		if src != nil {
+			sourceName = src.DisplayName
+		}
+		override := settings.ResolveEQOverride(sourceName)
+		eqChain := equalizer.BuildFilterChainWithOverride(override, audioSettings.Equalizer, sourceName, conf.SampleRate)
 
 		slProc, slErr := soundlevel.NewProcessor(sid, sid, conf.SampleRate, slInterval)
 		if slErr != nil {
@@ -655,10 +661,15 @@ func (p *AudioPipelineService) registerConsumersForSources(sourceIDs []string, s
 		// Look up per-source gain from the registry.
 		gainDB, _ := p.engine.Registry().GetGain(sid)
 
-		// Resolve per-source EQ config for building per-route filter chains.
-		// Each route needs its own FilterChain because biquad filters have
-		// mutable state (in1/in2/out1/out2) — sharing would cause a data race.
-		srcCfg := audioSettings.FindSourceByID(sid)
+		// Resolve per-source/per-stream EQ config for building per-route filter
+		// chains. Each route needs its own FilterChain because biquad filters
+		// have mutable state (in1/in2/out1/out2); sharing would cause a data race.
+		src, _ := p.engine.Registry().Get(sid)
+		sourceName := sid
+		if src != nil {
+			sourceName = src.DisplayName
+		}
+		eqOverride := currentSettings.ResolveEQOverride(sourceName)
 
 		// Resolve per-source model targets. Fall back to primary if the
 		// source has no configured models or none could be resolved.
@@ -724,14 +735,14 @@ func (p *AudioPipelineService) registerConsumersForSources(sourceIDs []string, s
 				logger.String("source_id", sid), logger.Error(bcErr), logger.String("operation", operation))
 			continue
 		}
-		bcChain := equalizer.BuildFilterChainForSource(srcCfg, audioSettings.Equalizer, conf.SampleRate)
+		bcChain := equalizer.BuildFilterChainWithOverride(eqOverride, audioSettings.Equalizer, sourceName, conf.SampleRate)
 		if routeErr := p.engine.Router().AddRoute(sid, bc, conf.SampleRate, gainDB, bcChain); routeErr != nil {
 			log.Warn("failed to add buffer route",
 				logger.String("source_id", sid), logger.Error(routeErr), logger.String("operation", operation))
 		}
 
 		alc, alcOutCh := NewAudioLevelConsumer("audio_level_"+sid, conf.SampleRate, conf.BitDepth, 1)
-		alcChain := equalizer.BuildFilterChainForSource(srcCfg, audioSettings.Equalizer, conf.SampleRate)
+		alcChain := equalizer.BuildFilterChainWithOverride(eqOverride, audioSettings.Equalizer, sourceName, conf.SampleRate)
 		if routeErr := p.engine.Router().AddRoute(sid, alc, conf.SampleRate, gainDB, alcChain); routeErr != nil {
 			log.Warn("failed to add audio level route",
 				logger.String("source_id", sid), logger.Error(routeErr), logger.String("operation", operation))

--- a/internal/api/v2/audio_hls.go
+++ b/internal/api/v2/audio_hls.go
@@ -1548,9 +1548,13 @@ func (c *Controller) setupAudioCallback(sourceID string) (audioChan chan []byte,
 	// Resolve EQ filter chain for this source so HLS listeners
 	// hear the same filtered audio as the analysis pipeline.
 	settings := conf.Setting()
-	audioSettings := &settings.Realtime.Audio
-	srcCfg := audioSettings.FindSourceByID(sourceID)
-	eqChain := equalizer.BuildFilterChainForSource(srcCfg, audioSettings.Equalizer, sampleRate)
+	src, _ := c.engine.Registry().Get(sourceID)
+	sourceName := sourceID
+	if src != nil {
+		sourceName = src.DisplayName
+	}
+	override := settings.ResolveEQOverride(sourceName)
+	eqChain := equalizer.BuildFilterChainWithOverride(override, settings.Realtime.Audio.Equalizer, sourceName, sampleRate)
 
 	// Add route on the AudioRouter
 	if routeErr := c.engine.Router().AddRoute(sourceID, consumer, sampleRate, gainDB, eqChain); routeErr != nil {

--- a/internal/api/v2/settings_audio.go
+++ b/internal/api/v2/settings_audio.go
@@ -51,21 +51,21 @@ func equalizerSettingsChanged(oldSettings, newSettings conf.EqualizerSettings) b
 }
 
 // handleEqualizerChange rebuilds EQ filter chains and hot-swaps them on all
-// affected routes. Sources with per-source EQ are updated only when their own
-// settings changed; sources using the global default are updated when the
-// global EQ changed.
+// registered sources (both sound cards and streams). Each source's effective EQ
+// is resolved via Settings.ResolveEQOverride using the registry DisplayName.
 func (c *Controller) handleEqualizerChange(currentSettings *conf.Settings) error {
 	if c.engine == nil {
 		return nil
 	}
 
 	router := c.engine.Router()
-	audioSettings := &currentSettings.Realtime.Audio
+	globalEQ := currentSettings.Realtime.Audio.Equalizer
 
 	for _, src := range c.engine.Registry().List() {
-		srcCfg := audioSettings.FindSourceByID(src.ID)
+		displayName := src.DisplayName
+		override := currentSettings.ResolveEQOverride(displayName)
 		router.UpdateFilterChain(src.ID, func(sampleRate int) *equalizer.FilterChain {
-			return equalizer.BuildFilterChainForSource(srcCfg, audioSettings.Equalizer, sampleRate)
+			return equalizer.BuildFilterChainWithOverride(override, globalEQ, displayName, sampleRate)
 		})
 	}
 
@@ -82,6 +82,21 @@ func perSourceEqualizerChanged(oldSettings, currentSettings *conf.Settings) bool
 	}
 	for i := range oldSources {
 		if !reflect.DeepEqual(oldSources[i].Equalizer, newSources[i].Equalizer) {
+			return true
+		}
+	}
+	return false
+}
+
+// perStreamEqualizerChanged checks if any per-stream equalizer settings have changed.
+func perStreamEqualizerChanged(oldSettings, currentSettings *conf.Settings) bool {
+	oldStreams := oldSettings.Realtime.RTSP.Streams
+	newStreams := currentSettings.Realtime.RTSP.Streams
+	if len(oldStreams) != len(newStreams) {
+		return true
+	}
+	for i := range oldStreams {
+		if !reflect.DeepEqual(oldStreams[i].Equalizer, newStreams[i].Equalizer) {
 			return true
 		}
 	}
@@ -169,10 +184,11 @@ func (c *Controller) handleAudioSettingsChanges(oldSettings, currentSettings *co
 			notification.MsgSettingsExtendedCaptureRestart, nil)
 	}
 
-	// Check audio equalizer settings (global or per-source) — hot-swap filter chains.
+	// Check audio equalizer settings (global, per-source, or per-stream) - hot-swap filter chains.
 	globalEQChanged := equalizerSettingsChanged(oldSettings.Realtime.Audio.Equalizer, currentSettings.Realtime.Audio.Equalizer)
 	perSourceEQChanged := perSourceEqualizerChanged(oldSettings, currentSettings)
-	if globalEQChanged || perSourceEQChanged {
+	perStreamEQChanged := perStreamEqualizerChanged(oldSettings, currentSettings)
+	if globalEQChanged || perSourceEQChanged || perStreamEQChanged {
 		c.Debug("Audio equalizer settings changed, updating filter chains")
 		if err := c.handleEqualizerChange(currentSettings); err != nil {
 			c.Debug("Failed to update EQ filter chains: %v", err)

--- a/internal/api/v2/settings_audio_test.go
+++ b/internal/api/v2/settings_audio_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/tphakala/birdnet-go/internal/conf"
 )
 
 func TestGetAudioBlockedFields(t *testing.T) {
@@ -19,4 +21,72 @@ func TestGetAudioBlockedFields(t *testing.T) {
 
 	// SoxAudioTypes was already blocked
 	assert.Equal(t, true, blocked["SoxAudioTypes"], "SoxAudioTypes must be blocked from API updates")
+}
+
+func TestPerStreamEqualizerChanged(t *testing.T) {
+	t.Parallel()
+
+	eq := &conf.EqualizerSettings{
+		Enabled: true,
+		Filters: []conf.EqualizerFilter{{Type: "HighPass", Frequency: 200}},
+	}
+
+	t.Run("no change", func(t *testing.T) {
+		t.Parallel()
+		old := &conf.Settings{}
+		old.Realtime.RTSP.Streams = []conf.StreamConfig{
+			{Name: "a", Equalizer: nil},
+		}
+		cur := &conf.Settings{}
+		cur.Realtime.RTSP.Streams = []conf.StreamConfig{
+			{Name: "a", Equalizer: nil},
+		}
+		assert.False(t, perStreamEqualizerChanged(old, cur))
+	})
+
+	t.Run("eq added", func(t *testing.T) {
+		t.Parallel()
+		old := &conf.Settings{}
+		old.Realtime.RTSP.Streams = []conf.StreamConfig{
+			{Name: "a", Equalizer: nil},
+		}
+		cur := &conf.Settings{}
+		cur.Realtime.RTSP.Streams = []conf.StreamConfig{
+			{Name: "a", Equalizer: eq},
+		}
+		assert.True(t, perStreamEqualizerChanged(old, cur))
+	})
+
+	t.Run("eq removed", func(t *testing.T) {
+		t.Parallel()
+		old := &conf.Settings{}
+		old.Realtime.RTSP.Streams = []conf.StreamConfig{
+			{Name: "a", Equalizer: eq},
+		}
+		cur := &conf.Settings{}
+		cur.Realtime.RTSP.Streams = []conf.StreamConfig{
+			{Name: "a", Equalizer: nil},
+		}
+		assert.True(t, perStreamEqualizerChanged(old, cur))
+	})
+
+	t.Run("stream count changed", func(t *testing.T) {
+		t.Parallel()
+		old := &conf.Settings{}
+		old.Realtime.RTSP.Streams = []conf.StreamConfig{
+			{Name: "a"},
+		}
+		cur := &conf.Settings{}
+		cur.Realtime.RTSP.Streams = []conf.StreamConfig{
+			{Name: "a"}, {Name: "b"},
+		}
+		assert.True(t, perStreamEqualizerChanged(old, cur))
+	})
+
+	t.Run("both empty", func(t *testing.T) {
+		t.Parallel()
+		old := &conf.Settings{}
+		cur := &conf.Settings{}
+		assert.False(t, perStreamEqualizerChanged(old, cur))
+	})
 }

--- a/internal/api/v2/settings_eq_roundtrip_test.go
+++ b/internal/api/v2/settings_eq_roundtrip_test.go
@@ -111,7 +111,10 @@ func TestEQFilterRoundTrip_PUT(t *testing.T) {
 
 // putTestSettingsWithSourceEQ marshals a full Settings struct to JSON, then
 // patches the sources array to include per-source equalizer config.
-func putTestSettingsWithSourceEQ(t *testing.T, settings *conf.Settings, sourceEQ map[string]any) []byte {
+// patchSettingsEQ patches the equalizer field at the given JSON path within a
+// full settings payload. The path is a sequence of keys (and "[0]" for the first
+// array element) leading to the target object whose "equalizer" field is set.
+func patchSettingsEQ(t *testing.T, settings *conf.Settings, eqOverride map[string]any, path ...string) []byte {
 	t.Helper()
 
 	fullJSON, err := json.Marshal(settings)
@@ -120,20 +123,32 @@ func putTestSettingsWithSourceEQ(t *testing.T, settings *conf.Settings, sourceEQ
 	var payload map[string]any
 	require.NoError(t, json.Unmarshal(fullJSON, &payload))
 
-	realtime, ok := payload["realtime"].(map[string]any)
-	require.True(t, ok, "payload must contain realtime section")
-	audio, ok := realtime["audio"].(map[string]any)
-	require.True(t, ok, "realtime must contain audio section")
-	sources, ok := audio["sources"].([]any)
-	require.True(t, ok, "audio must contain sources section")
-	require.NotEmpty(t, sources, "sources must be non-empty")
-	src, ok := sources[0].(map[string]any)
-	require.True(t, ok, "sources[0] must be an object")
-	src["equalizer"] = sourceEQ
+	var current any = payload
+	for _, key := range path {
+		switch key {
+		case "[0]":
+			arr, ok := current.([]any)
+			require.True(t, ok, "expected array at path segment [0]")
+			require.NotEmpty(t, arr, "array must be non-empty")
+			current = arr[0]
+		default:
+			m, ok := current.(map[string]any)
+			require.True(t, ok, "expected object at path segment %q", key)
+			current = m[key]
+		}
+	}
+	target, ok := current.(map[string]any)
+	require.True(t, ok, "final path target must be an object")
+	target["equalizer"] = eqOverride
 
 	body, err := json.Marshal(payload)
 	require.NoError(t, err)
 	return body
+}
+
+func putTestSettingsWithSourceEQ(t *testing.T, settings *conf.Settings, sourceEQ map[string]any) []byte {
+	t.Helper()
+	return patchSettingsEQ(t, settings, sourceEQ, "realtime", "audio", "sources", "[0]")
 }
 
 // TestEQFilterRoundTrip_PUT_PerSource verifies that per-source equalizer
@@ -271,6 +286,72 @@ func TestEQFilterRoundTrip_PATCH(t *testing.T) {
 // TestEQFilterRoundTrip_PUT_WithFrontendIDField verifies that the extra
 // "id" field the frontend sends (not present in the Go struct) does not
 // break deserialization of equalizer filters.
+func putTestSettingsWithStreamEQ(t *testing.T, settings *conf.Settings, streamEQ map[string]any) []byte {
+	t.Helper()
+	return patchSettingsEQ(t, settings, streamEQ, "realtime", "rtsp", "streams", "[0]")
+}
+
+// TestEQFilterRoundTrip_PUT_PerStream verifies that per-stream equalizer
+// filters survive the PUT path when attached to a StreamConfig.
+func TestEQFilterRoundTrip_PUT_PerStream(t *testing.T) {
+	t.Parallel()
+
+	initial := getTestSettings(t)
+	initial.Realtime.RTSP.Streams = []conf.StreamConfig{{
+		Name:    "Test Stream",
+		URL:     "rtsp://192.168.1.100/stream",
+		Enabled: true,
+		Type:    "rtsp",
+	}}
+
+	e := echo.New()
+	controller := &Controller{
+		Echo:                e,
+		Settings:            initial,
+		controlChan:         make(chan string, testControlChanBuffer),
+		DisableSaveSettings: true,
+	}
+
+	streamEQ := map[string]any{
+		"enabled": true,
+		"filters": []map[string]any{
+			{
+				"type":      "HighPass",
+				"frequency": 400,
+				"q":         0.707,
+				"gain":      0,
+				"width":     0,
+				"passes":    2,
+			},
+		},
+	}
+
+	body := putTestSettingsWithStreamEQ(t, initial, streamEQ)
+
+	req := httptest.NewRequest(http.MethodPut, "/api/v2/settings", bytes.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+
+	err := controller.UpdateSettings(ctx)
+	require.NoError(t, err)
+	t.Logf("PUT response (status %d): %s", rec.Code, rec.Body.String())
+	assert.Equal(t, http.StatusOK, rec.Code, "PUT should succeed")
+
+	// Verify per-stream EQ survived the round-trip
+	require.Len(t, controller.Settings.Realtime.RTSP.Streams, 1)
+	stEQ := controller.Settings.Realtime.RTSP.Streams[0].Equalizer
+	require.NotNil(t, stEQ, "Per-stream equalizer should not be nil")
+	assert.True(t, stEQ.Enabled, "Per-stream equalizer should be enabled")
+	require.Len(t, stEQ.Filters, 1, "Per-stream should have 1 filter")
+	assert.Equal(t, "HighPass", stEQ.Filters[0].Type)
+	assert.InDelta(t, float64(400), stEQ.Filters[0].Frequency, 0.01)
+	assert.Equal(t, 2, stEQ.Filters[0].Passes)
+
+	// Global EQ should remain unchanged
+	assert.False(t, controller.Settings.Realtime.Audio.Equalizer.Enabled)
+}
+
 func TestEQFilterRoundTrip_PUT_WithFrontendIDField(t *testing.T) {
 	t.Parallel()
 

--- a/internal/audiocore/equalizer/builder.go
+++ b/internal/audiocore/equalizer/builder.go
@@ -92,6 +92,27 @@ func BuildFilterChainForSource(sourceCfg *conf.AudioSourceConfig, globalEQ conf.
 	return BuildFilterChain(eqSettings, sampleRate)
 }
 
+// BuildFilterChainWithOverride builds a FilterChain from the given EQ override
+// settings, or from globalEQ if override is nil. This is the preferred entry
+// point for callers that have already resolved the per-source/per-stream override
+// via Settings.ResolveEQOverride.
+func BuildFilterChainWithOverride(override *conf.EqualizerSettings, globalEQ conf.EqualizerSettings, sourceName string, sampleRate int) *FilterChain {
+	eqSettings := globalEQ
+	if override != nil {
+		eqSettings = *override
+		eqLog.Debug("using per-source EQ override",
+			logger.String("source", sourceName),
+			logger.Bool("enabled", eqSettings.Enabled),
+			logger.Int("filter_count", len(eqSettings.Filters)))
+	} else {
+		eqLog.Debug("using global EQ for source",
+			logger.String("source", sourceName),
+			logger.Bool("enabled", globalEQ.Enabled),
+			logger.Int("filter_count", len(globalEQ.Filters)))
+	}
+	return BuildFilterChain(eqSettings, sampleRate)
+}
+
 // buildFilter creates a single Filter from a config entry.
 // Returns (nil, nil) for unknown filter types.
 func buildFilter(f *conf.EqualizerFilter, sampleRate float64, passes int) (*Filter, error) {

--- a/internal/audiocore/equalizer/builder_test.go
+++ b/internal/audiocore/equalizer/builder_test.go
@@ -163,3 +163,55 @@ func TestBuildFilterChain_Peaking(t *testing.T) {
 	require.NotNil(t, chain)
 	assert.Equal(t, 1, chain.Length())
 }
+
+func TestBuildFilterChainWithOverride_UsesOverride(t *testing.T) {
+	t.Parallel()
+	override := &conf.EqualizerSettings{
+		Enabled: true,
+		Filters: []conf.EqualizerFilter{
+			{Type: "HighPass", Frequency: 300, Q: 0.707, Passes: 1},
+		},
+	}
+	globalEQ := conf.EqualizerSettings{
+		Enabled: true,
+		Filters: []conf.EqualizerFilter{
+			{Type: "LowPass", Frequency: 15000, Q: 0.707, Passes: 1},
+			{Type: "HighPass", Frequency: 100, Q: 0.707, Passes: 1},
+		},
+	}
+	chain := equalizer.BuildFilterChainWithOverride(override, globalEQ, "test-source", 48000)
+	require.NotNil(t, chain)
+	assert.Equal(t, 1, chain.Length(), "should use 1-filter override, not 2-filter global")
+}
+
+func TestBuildFilterChainWithOverride_FallsBackToGlobal(t *testing.T) {
+	t.Parallel()
+	globalEQ := conf.EqualizerSettings{
+		Enabled: true,
+		Filters: []conf.EqualizerFilter{
+			{Type: "LowPass", Frequency: 15000, Q: 0.707, Passes: 1},
+			{Type: "HighPass", Frequency: 100, Q: 0.707, Passes: 1},
+		},
+	}
+	chain := equalizer.BuildFilterChainWithOverride(nil, globalEQ, "test-source", 48000)
+	require.NotNil(t, chain)
+	assert.Equal(t, 2, chain.Length(), "should use 2-filter global when override is nil")
+}
+
+func TestBuildFilterChainWithOverride_DisabledOverride(t *testing.T) {
+	t.Parallel()
+	override := &conf.EqualizerSettings{
+		Enabled: false,
+		Filters: []conf.EqualizerFilter{
+			{Type: "HighPass", Frequency: 300, Q: 0.707, Passes: 1},
+		},
+	}
+	globalEQ := conf.EqualizerSettings{
+		Enabled: true,
+		Filters: []conf.EqualizerFilter{
+			{Type: "LowPass", Frequency: 15000, Q: 0.707, Passes: 1},
+		},
+	}
+	chain := equalizer.BuildFilterChainWithOverride(override, globalEQ, "test-source", 48000)
+	assert.Nil(t, chain, "disabled override should return nil chain regardless of global")
+}

--- a/internal/conf/clone.go
+++ b/internal/conf/clone.go
@@ -136,6 +136,11 @@ func cloneStreamConfigs(in []StreamConfig) []StreamConfig {
 	for i := range in {
 		s := in[i]
 		s.Models = slices.Clone(s.Models)
+		if s.Equalizer != nil {
+			eq := *s.Equalizer
+			eq.Filters = slices.Clone(eq.Filters)
+			s.Equalizer = &eq
+		}
 		out[i] = s
 	}
 	return out

--- a/internal/conf/clone_test.go
+++ b/internal/conf/clone_test.go
@@ -100,7 +100,13 @@ func newPopulatedSettings() *Settings {
 	s.Realtime.DaylightFilter.Species = []string{"Strix aluco"}
 
 	s.Realtime.RTSP.Streams = []StreamConfig{
-		{Name: "front", URL: "rtsp://x", Enabled: true, Models: []string{"birdnet"}},
+		{
+			Name: "front", URL: "rtsp://x", Enabled: true, Models: []string{"birdnet"},
+			Equalizer: &EqualizerSettings{
+				Enabled: true,
+				Filters: []EqualizerFilter{{Type: "HighPass", Frequency: 500}},
+			},
+		},
 	}
 	s.Realtime.RTSP.URLs = []string{"rtsp://legacy"}
 	s.Realtime.RTSP.FFmpegParameters = []string{"-rtsp_transport", "tcp"}
@@ -220,6 +226,8 @@ func mutateCloneEverywhere(dst *Settings) {
 
 	dst.Realtime.RTSP.Streams[0].Models[0] = mutated
 	dst.Realtime.RTSP.Streams[0].Enabled = false
+	dst.Realtime.RTSP.Streams[0].Equalizer.Enabled = false
+	dst.Realtime.RTSP.Streams[0].Equalizer.Filters[0].Type = mutated
 	dst.Realtime.RTSP.URLs[0] = mutated
 	dst.Realtime.RTSP.FFmpegParameters[0] = mutated
 
@@ -326,6 +334,10 @@ func assertSourceUnchanged(t *testing.T, src *Settings) {
 	require.Len(t, src.Realtime.RTSP.Streams, 1)
 	assert.True(t, src.Realtime.RTSP.Streams[0].Enabled)
 	assert.Equal(t, []string{"birdnet"}, src.Realtime.RTSP.Streams[0].Models)
+	require.NotNil(t, src.Realtime.RTSP.Streams[0].Equalizer)
+	assert.True(t, src.Realtime.RTSP.Streams[0].Equalizer.Enabled)
+	require.Len(t, src.Realtime.RTSP.Streams[0].Equalizer.Filters, 1)
+	assert.Equal(t, "HighPass", src.Realtime.RTSP.Streams[0].Equalizer.Filters[0].Type)
 	assert.Equal(t, []string{"rtsp://legacy"}, src.Realtime.RTSP.URLs)
 	assert.Equal(t, []string{"-rtsp_transport", "tcp"}, src.Realtime.RTSP.FFmpegParameters)
 

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -546,13 +546,14 @@ const DefaultTransport = "tcp"
 
 // StreamConfig represents a single audio stream source
 type StreamConfig struct {
-	Name       string           `yaml:"name" json:"name" mapstructure:"name"`                           // Required: descriptive name like "Front Yard"
-	URL        string           `yaml:"url" json:"url" mapstructure:"url"`                              // Required: stream URL
-	Enabled    bool             `yaml:"enabled" json:"enabled" mapstructure:"enabled"`                  // true when the configured stream should be active
-	Type       string           `yaml:"type" json:"type" mapstructure:"type"`                           // Stream type: rtsp, http, hls, rtmp, udp
-	Transport  string           `yaml:"transport" json:"transport" mapstructure:"transport"`            // Transport: tcp or udp (for RTSP/RTMP)
-	QuietHours QuietHoursConfig `yaml:"quietHours" json:"quietHours" mapstructure:"quietHours"`         // Quiet hours configuration
-	Models     []string         `yaml:"models,omitempty" json:"models,omitempty" mapstructure:"models"` // Model IDs for this stream (e.g., ["birdnet", "perch_v2"])
+	Name       string             `yaml:"name" json:"name" mapstructure:"name"`                                    // Required: descriptive name like "Front Yard"
+	URL        string             `yaml:"url" json:"url" mapstructure:"url"`                                       // Required: stream URL
+	Enabled    bool               `yaml:"enabled" json:"enabled" mapstructure:"enabled"`                           // true when the configured stream should be active
+	Type       string             `yaml:"type" json:"type" mapstructure:"type"`                                    // Stream type: rtsp, http, hls, rtmp, udp
+	Transport  string             `yaml:"transport" json:"transport" mapstructure:"transport"`                     // Transport: tcp or udp (for RTSP/RTMP)
+	Equalizer  *EqualizerSettings `yaml:"equalizer,omitempty" json:"equalizer,omitempty" mapstructure:"equalizer"` // Per-stream EQ (nil = use global)
+	QuietHours QuietHoursConfig   `yaml:"quietHours" json:"quietHours" mapstructure:"quietHours"`                  // Quiet hours configuration
+	Models     []string           `yaml:"models,omitempty" json:"models,omitempty" mapstructure:"models"`          // Model IDs for this stream (e.g., ["birdnet", "perch_v2"])
 }
 
 // IsEnabled returns the effective enabled state for a stream.
@@ -600,6 +601,17 @@ func (r *RTSPSettings) EnabledStreams() iter.Seq2[int, *StreamConfig] {
 			}
 		}
 	}
+}
+
+// FindStreamByName returns a pointer to the StreamConfig matching the given
+// name. Returns nil if no match is found.
+func (r *RTSPSettings) FindStreamByName(name string) *StreamConfig {
+	for i := range r.Streams {
+		if r.Streams[i].Name == name {
+			return &r.Streams[i]
+		}
+	}
+	return nil
 }
 
 // CRITICAL: Legacy fields (URLs, Transport) MUST include json tags to accept
@@ -1532,6 +1544,23 @@ type Settings struct {
 	Notification NotificationConfig `yaml:"notification" json:"notification"` // Configuration for push notifications
 
 	Alerting AlertSettings `yaml:"alerting" json:"alerting"` // Alerting rules engine settings
+}
+
+// ResolveEQOverride returns the per-source or per-stream EQ override for the
+// given source display name. Returns nil when no override exists (use global).
+// Audio sources are checked first, then RTSP streams.
+func (s *Settings) ResolveEQOverride(displayName string) *EqualizerSettings {
+	for i := range s.Realtime.Audio.Sources {
+		if s.Realtime.Audio.Sources[i].Name == displayName {
+			return s.Realtime.Audio.Sources[i].Equalizer
+		}
+	}
+	for i := range s.Realtime.RTSP.Streams {
+		if s.Realtime.RTSP.Streams[i].Name == displayName {
+			return s.Realtime.RTSP.Streams[i].Equalizer
+		}
+	}
+	return nil
 }
 
 // AlertSettings configures the alerting rules engine.

--- a/internal/conf/eq_resolve_test.go
+++ b/internal/conf/eq_resolve_test.go
@@ -1,0 +1,106 @@
+package conf
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFindStreamByName(t *testing.T) {
+	t.Parallel()
+
+	r := &RTSPSettings{
+		Streams: []StreamConfig{
+			{Name: "Front Yard", URL: "rtsp://front"},
+			{Name: "Back Garden", URL: "rtsp://back"},
+		},
+	}
+
+	t.Run("match found", func(t *testing.T) {
+		t.Parallel()
+		s := r.FindStreamByName("Back Garden")
+		require.NotNil(t, s)
+		assert.Equal(t, "rtsp://back", s.URL)
+	})
+
+	t.Run("no match", func(t *testing.T) {
+		t.Parallel()
+		s := r.FindStreamByName("nonexistent")
+		assert.Nil(t, s)
+	})
+
+	t.Run("empty streams", func(t *testing.T) {
+		t.Parallel()
+		empty := &RTSPSettings{}
+		assert.Nil(t, empty.FindStreamByName("anything"))
+	})
+}
+
+func TestResolveEQOverride(t *testing.T) {
+	t.Parallel()
+
+	audioEQ := &EqualizerSettings{
+		Enabled: true,
+		Filters: []EqualizerFilter{{Type: "LowPass", Frequency: 8000}},
+	}
+	streamEQ := &EqualizerSettings{
+		Enabled: true,
+		Filters: []EqualizerFilter{{Type: "HighPass", Frequency: 200}},
+	}
+
+	s := &Settings{}
+	s.Realtime.Audio.Sources = []AudioSourceConfig{
+		{Name: "Front Mic", Equalizer: audioEQ},
+		{Name: "Back Mic", Equalizer: nil},
+	}
+	s.Realtime.RTSP.Streams = []StreamConfig{
+		{Name: "Front Cam", Equalizer: streamEQ},
+		{Name: "Back Cam", Equalizer: nil},
+	}
+
+	t.Run("audio source with override", func(t *testing.T) {
+		t.Parallel()
+		got := s.ResolveEQOverride("Front Mic")
+		require.NotNil(t, got)
+		assert.Equal(t, audioEQ, got)
+	})
+
+	t.Run("audio source without override", func(t *testing.T) {
+		t.Parallel()
+		got := s.ResolveEQOverride("Back Mic")
+		assert.Nil(t, got)
+	})
+
+	t.Run("stream with override", func(t *testing.T) {
+		t.Parallel()
+		got := s.ResolveEQOverride("Front Cam")
+		require.NotNil(t, got)
+		assert.Equal(t, streamEQ, got)
+	})
+
+	t.Run("stream without override", func(t *testing.T) {
+		t.Parallel()
+		got := s.ResolveEQOverride("Back Cam")
+		assert.Nil(t, got)
+	})
+
+	t.Run("no match returns nil", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, s.ResolveEQOverride("unknown-source"))
+	})
+
+	t.Run("audio source takes precedence over stream with same name", func(t *testing.T) {
+		t.Parallel()
+		conflict := &Settings{}
+		conflict.Realtime.Audio.Sources = []AudioSourceConfig{
+			{Name: "Shared Name", Equalizer: audioEQ},
+		}
+		conflict.Realtime.RTSP.Streams = []StreamConfig{
+			{Name: "Shared Name", Equalizer: streamEQ},
+		}
+		got := conflict.ResolveEQOverride("Shared Name")
+		require.NotNil(t, got)
+		assert.Equal(t, audioEQ, got, "audio source EQ should take precedence")
+	})
+}


### PR DESCRIPTION
## Summary

- Add per-stream equalizer overrides for RTSP/FFmpeg streams, mirroring existing per-source EQ for sound cards
- Fix bug where EQ resolution used auto-generated registry IDs instead of DisplayName, causing per-source EQ to silently fall back to global for all source types
- Add unified `ResolveEQOverride` resolver that searches both audio sources and streams by name
- Add `BuildFilterChainWithOverride` as the preferred entry point for callers with pre-resolved overrides
- Add per-stream EQ controls in StreamCard UI (expandable, reuses AudioEqualizerSettings component)
- Add EQ hot-reload change detection for streams

## Test Plan

- [x] `go test -race ./internal/conf/...` - ResolveEQOverride, FindStreamByName, clone deep-copy
- [x] `go test -race ./internal/audiocore/equalizer/...` - BuildFilterChainWithOverride (override, fallback, disabled)
- [x] `go test -race ./internal/api/v2/...` - Per-stream EQ round-trip, perStreamEqualizerChanged
- [x] `golangci-lint run -v` - zero issues
- [x] `npm run check:all` - zero errors/warnings
- [ ] Manual: configure per-stream EQ in UI, verify it saves and hot-reloads
- [ ] Manual: verify per-source EQ for sound cards works (fixed bug)
- [ ] Manual: verify global EQ applies when no override is set

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-stream audio equalizer configuration capability
  * Stream equalizer status now displays an "audio filters" badge in the interface
  * Users can independently configure and customize audio filter settings for each stream

<!-- end of auto-generated comment: release notes by coderabbit.ai -->