### PR TITLE
fix(audiocore): update registry DisplayName on source/stream rename

### DIFF
--- a/internal/analysis/audio_pipeline_service.go
+++ b/internal/analysis/audio_pipeline_service.go
@@ -809,6 +809,11 @@ func (p *AudioPipelineService) reconfigureChangedSources(audioLevelChan chan aud
 				registry.UpdateGain(src.ID, scm.config.Gain)
 				gainChangedIDs = append(gainChangedIDs, src.ID)
 			}
+
+			// Sync display name if the config name changed (e.g., stream renamed in UI).
+			if src.DisplayName != scm.config.DisplayName {
+				registry.UpdateDisplayName(src.ID, scm.config.DisplayName)
+			}
 		} else {
 			// New source — add it.
 			log.Info("adding new stream from config",

--- a/internal/api/v2/settings_audio.go
+++ b/internal/api/v2/settings_audio.go
@@ -225,18 +225,37 @@ func (c *Controller) handleAudioSettingsChanges(oldSettings, currentSettings *co
 	srcNameChanged := audioSourceNameChanged(oldSettings, currentSettings)
 	strmNameChanged := streamNameChanged(oldSettings, currentSettings)
 
-	if srcNameChanged && c.engine != nil {
+	if c.engine != nil {
 		registry := c.engine.Registry()
-		oldSources := oldSettings.Realtime.Audio.Sources
-		newSources := currentSettings.Realtime.Audio.Sources
-		for i := range oldSources {
-			if i >= len(newSources) {
-				break
+
+		if srcNameChanged {
+			oldSources := oldSettings.Realtime.Audio.Sources
+			newSources := currentSettings.Realtime.Audio.Sources
+			for i := range oldSources {
+				if i >= len(newSources) {
+					break
+				}
+				if oldSources[i].Device == newSources[i].Device &&
+					oldSources[i].Name != newSources[i].Name {
+					if src, ok := registry.GetByConnection(newSources[i].Device); ok {
+						registry.UpdateDisplayName(src.ID, newSources[i].Name)
+					}
+				}
 			}
-			if oldSources[i].Device == newSources[i].Device &&
-				oldSources[i].Name != newSources[i].Name {
-				if src, ok := registry.GetByConnection(newSources[i].Device); ok {
-					registry.UpdateDisplayName(src.ID, newSources[i].Name)
+		}
+
+		if strmNameChanged {
+			oldStreams := oldSettings.Realtime.RTSP.Streams
+			newStreams := currentSettings.Realtime.RTSP.Streams
+			for i := range oldStreams {
+				if i >= len(newStreams) {
+					break
+				}
+				if oldStreams[i].URL == newStreams[i].URL &&
+					oldStreams[i].Name != newStreams[i].Name {
+					if src, ok := registry.GetByConnection(newStreams[i].URL); ok {
+						registry.UpdateDisplayName(src.ID, newStreams[i].Name)
+					}
 				}
 			}
 		}

--- a/internal/api/v2/settings_audio.go
+++ b/internal/api/v2/settings_audio.go
@@ -29,6 +29,43 @@ func audioDeviceSettingChanged(oldSettings, currentSettings *conf.Settings) bool
 	return false
 }
 
+// audioSourceNameChanged checks if any audio source was renamed while keeping
+// the same device. Returns false on length mismatch (handled by device change
+// detection) or when the device also changed (handled by full reconfiguration).
+func audioSourceNameChanged(oldSettings, currentSettings *conf.Settings) bool {
+	oldSources := oldSettings.Realtime.Audio.Sources
+	newSources := currentSettings.Realtime.Audio.Sources
+
+	if len(oldSources) != len(newSources) {
+		return false
+	}
+	for i := range oldSources {
+		if oldSources[i].Device == newSources[i].Device &&
+			oldSources[i].Name != newSources[i].Name {
+			return true
+		}
+	}
+	return false
+}
+
+// streamNameChanged checks if any stream was renamed while keeping the same URL.
+// Returns false on length mismatch or when the URL also changed.
+func streamNameChanged(oldSettings, currentSettings *conf.Settings) bool {
+	oldStreams := oldSettings.Realtime.RTSP.Streams
+	newStreams := currentSettings.Realtime.RTSP.Streams
+
+	if len(oldStreams) != len(newStreams) {
+		return false
+	}
+	for i := range oldStreams {
+		if oldStreams[i].URL == newStreams[i].URL &&
+			oldStreams[i].Name != newStreams[i].Name {
+			return true
+		}
+	}
+	return false
+}
+
 // soundLevelSettingsChanged checks if sound level monitoring settings have changed
 func soundLevelSettingsChanged(oldSettings, currentSettings *conf.Settings) bool {
 	// Check for changes in enabled state

--- a/internal/api/v2/settings_audio.go
+++ b/internal/api/v2/settings_audio.go
@@ -4,10 +4,18 @@ package api
 import (
 	"reflect"
 
+	"github.com/tphakala/birdnet-go/internal/audiocore"
 	"github.com/tphakala/birdnet-go/internal/audiocore/equalizer"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/notification"
 )
+
+// sourceNameUpdater is the subset of SourceRegistry used by the name-sync
+// helpers. Accepting an interface keeps them testable without a full registry.
+type sourceNameUpdater interface {
+	GetByConnection(connStr string) (*audiocore.AudioSource, bool)
+	UpdateDisplayName(sourceID, newName string) bool
+}
 
 // audioDeviceSettingChanged checks if audio device pipeline settings have changed.
 // Only compares device-affecting fields (Device, Gain, Model), not display-only
@@ -29,41 +37,56 @@ func audioDeviceSettingChanged(oldSettings, currentSettings *conf.Settings) bool
 	return false
 }
 
-// audioSourceNameChanged checks if any audio source was renamed while keeping
-// the same device. Returns false on length mismatch (handled by device change
-// detection) or when the device also changed (handled by full reconfiguration).
-func audioSourceNameChanged(oldSettings, currentSettings *conf.Settings) bool {
+// syncAudioSourceNames detects audio sources that were renamed while keeping
+// the same device, and updates their DisplayName in the registry. Returns true
+// if any name was changed. Skips length mismatches (handled by device change
+// detection) and entries where the device also changed (handled by full
+// reconfiguration).
+func syncAudioSourceNames(oldSettings, currentSettings *conf.Settings, registry sourceNameUpdater) bool {
 	oldSources := oldSettings.Realtime.Audio.Sources
 	newSources := currentSettings.Realtime.Audio.Sources
 
 	if len(oldSources) != len(newSources) {
 		return false
 	}
+	changed := false
 	for i := range oldSources {
 		if oldSources[i].Device == newSources[i].Device &&
 			oldSources[i].Name != newSources[i].Name {
-			return true
+			changed = true
+			if registry != nil {
+				if src, ok := registry.GetByConnection(newSources[i].Device); ok {
+					registry.UpdateDisplayName(src.ID, newSources[i].Name)
+				}
+			}
 		}
 	}
-	return false
+	return changed
 }
 
-// streamNameChanged checks if any stream was renamed while keeping the same URL.
-// Returns false on length mismatch or when the URL also changed.
-func streamNameChanged(oldSettings, currentSettings *conf.Settings) bool {
+// syncStreamNames detects streams that were renamed while keeping the same URL,
+// and updates their DisplayName in the registry. Returns true if any name was
+// changed. Skips length mismatches and entries where the URL also changed.
+func syncStreamNames(oldSettings, currentSettings *conf.Settings, registry sourceNameUpdater) bool {
 	oldStreams := oldSettings.Realtime.RTSP.Streams
 	newStreams := currentSettings.Realtime.RTSP.Streams
 
 	if len(oldStreams) != len(newStreams) {
 		return false
 	}
+	changed := false
 	for i := range oldStreams {
 		if oldStreams[i].URL == newStreams[i].URL &&
 			oldStreams[i].Name != newStreams[i].Name {
-			return true
+			changed = true
+			if registry != nil {
+				if src, ok := registry.GetByConnection(newStreams[i].URL); ok {
+					registry.UpdateDisplayName(src.ID, newStreams[i].Name)
+				}
+			}
 		}
 	}
-	return false
+	return changed
 }
 
 // soundLevelSettingsChanged checks if sound level monitoring settings have changed
@@ -222,44 +245,13 @@ func (c *Controller) handleAudioSettingsChanges(oldSettings, currentSettings *co
 	}
 
 	// Detect source/stream name changes and sync DisplayName in the registry.
-	srcNameChanged := audioSourceNameChanged(oldSettings, currentSettings)
-	strmNameChanged := streamNameChanged(oldSettings, currentSettings)
-
+	// Each function detects renames and updates the registry in a single pass.
+	var registry sourceNameUpdater
 	if c.engine != nil {
-		registry := c.engine.Registry()
-
-		if srcNameChanged {
-			oldSources := oldSettings.Realtime.Audio.Sources
-			newSources := currentSettings.Realtime.Audio.Sources
-			for i := range oldSources {
-				if i >= len(newSources) {
-					break
-				}
-				if oldSources[i].Device == newSources[i].Device &&
-					oldSources[i].Name != newSources[i].Name {
-					if src, ok := registry.GetByConnection(newSources[i].Device); ok {
-						registry.UpdateDisplayName(src.ID, newSources[i].Name)
-					}
-				}
-			}
-		}
-
-		if strmNameChanged {
-			oldStreams := oldSettings.Realtime.RTSP.Streams
-			newStreams := currentSettings.Realtime.RTSP.Streams
-			for i := range oldStreams {
-				if i >= len(newStreams) {
-					break
-				}
-				if oldStreams[i].URL == newStreams[i].URL &&
-					oldStreams[i].Name != newStreams[i].Name {
-					if src, ok := registry.GetByConnection(newStreams[i].URL); ok {
-						registry.UpdateDisplayName(src.ID, newStreams[i].Name)
-					}
-				}
-			}
-		}
+		registry = c.engine.Registry()
 	}
+	srcNameChanged := syncAudioSourceNames(oldSettings, currentSettings, registry)
+	strmNameChanged := syncStreamNames(oldSettings, currentSettings, registry)
 
 	// Check audio equalizer settings (global, per-source, or per-stream) - hot-swap filter chains.
 	// Also rebuild when names change, since ResolveEQOverride matches by name.

--- a/internal/api/v2/settings_audio.go
+++ b/internal/api/v2/settings_audio.go
@@ -39,20 +39,24 @@ func audioDeviceSettingChanged(oldSettings, currentSettings *conf.Settings) bool
 
 // syncAudioSourceNames detects audio sources that were renamed while keeping
 // the same device, and updates their DisplayName in the registry. Returns true
-// if any name was changed. Skips length mismatches (handled by device change
-// detection) and entries where the device also changed (handled by full
-// reconfiguration).
+// if any name was changed. Uses a map keyed by Device so renames are detected
+// even if the source list was reordered.
 func syncAudioSourceNames(oldSettings, currentSettings *conf.Settings, registry sourceNameUpdater) bool {
-	oldSources := oldSettings.Realtime.Audio.Sources
-	newSources := currentSettings.Realtime.Audio.Sources
-
-	if len(oldSources) != len(newSources) {
-		return false
+	sources := oldSettings.Realtime.Audio.Sources
+	oldNames := make(map[string]string, len(sources))
+	for i := range sources {
+		if sources[i].Device != "" {
+			oldNames[sources[i].Device] = sources[i].Name
+		}
 	}
+
 	changed := false
-	for i := range oldSources {
-		if oldSources[i].Device == newSources[i].Device &&
-			oldSources[i].Name != newSources[i].Name {
+	newSources := currentSettings.Realtime.Audio.Sources
+	for i := range newSources {
+		if newSources[i].Device == "" {
+			continue
+		}
+		if oldName, ok := oldNames[newSources[i].Device]; ok && oldName != newSources[i].Name {
 			changed = true
 			if registry != nil {
 				if src, ok := registry.GetByConnection(newSources[i].Device); ok {
@@ -66,18 +70,24 @@ func syncAudioSourceNames(oldSettings, currentSettings *conf.Settings, registry 
 
 // syncStreamNames detects streams that were renamed while keeping the same URL,
 // and updates their DisplayName in the registry. Returns true if any name was
-// changed. Skips length mismatches and entries where the URL also changed.
+// changed. Uses a map keyed by URL so renames are detected even if the stream
+// list was reordered.
 func syncStreamNames(oldSettings, currentSettings *conf.Settings, registry sourceNameUpdater) bool {
-	oldStreams := oldSettings.Realtime.RTSP.Streams
-	newStreams := currentSettings.Realtime.RTSP.Streams
-
-	if len(oldStreams) != len(newStreams) {
-		return false
+	streams := oldSettings.Realtime.RTSP.Streams
+	oldNames := make(map[string]string, len(streams))
+	for i := range streams {
+		if streams[i].URL != "" {
+			oldNames[streams[i].URL] = streams[i].Name
+		}
 	}
+
 	changed := false
-	for i := range oldStreams {
-		if oldStreams[i].URL == newStreams[i].URL &&
-			oldStreams[i].Name != newStreams[i].Name {
+	newStreams := currentSettings.Realtime.RTSP.Streams
+	for i := range newStreams {
+		if newStreams[i].URL == "" {
+			continue
+		}
+		if oldName, ok := oldNames[newStreams[i].URL]; ok && oldName != newStreams[i].Name {
 			changed = true
 			if registry != nil {
 				if src, ok := registry.GetByConnection(newStreams[i].URL); ok {

--- a/internal/api/v2/settings_audio.go
+++ b/internal/api/v2/settings_audio.go
@@ -221,16 +221,41 @@ func (c *Controller) handleAudioSettingsChanges(oldSettings, currentSettings *co
 			notification.MsgSettingsExtendedCaptureRestart, nil)
 	}
 
+	// Detect source/stream name changes and sync DisplayName in the registry.
+	srcNameChanged := audioSourceNameChanged(oldSettings, currentSettings)
+	strmNameChanged := streamNameChanged(oldSettings, currentSettings)
+
+	if srcNameChanged && c.engine != nil {
+		registry := c.engine.Registry()
+		oldSources := oldSettings.Realtime.Audio.Sources
+		newSources := currentSettings.Realtime.Audio.Sources
+		for i := range oldSources {
+			if i >= len(newSources) {
+				break
+			}
+			if oldSources[i].Device == newSources[i].Device &&
+				oldSources[i].Name != newSources[i].Name {
+				if src, ok := registry.GetByConnection(newSources[i].Device); ok {
+					registry.UpdateDisplayName(src.ID, newSources[i].Name)
+				}
+			}
+		}
+	}
+
 	// Check audio equalizer settings (global, per-source, or per-stream) - hot-swap filter chains.
+	// Also rebuild when names change, since ResolveEQOverride matches by name.
 	globalEQChanged := equalizerSettingsChanged(oldSettings.Realtime.Audio.Equalizer, currentSettings.Realtime.Audio.Equalizer)
 	perSourceEQChanged := perSourceEqualizerChanged(oldSettings, currentSettings)
 	perStreamEQChanged := perStreamEqualizerChanged(oldSettings, currentSettings)
-	if globalEQChanged || perSourceEQChanged || perStreamEQChanged {
+	nameChanged := srcNameChanged || strmNameChanged
+	if globalEQChanged || perSourceEQChanged || perStreamEQChanged || nameChanged {
 		c.Debug("Audio equalizer settings changed, updating filter chains")
 		if err := c.handleEqualizerChange(currentSettings); err != nil {
 			c.Debug("Failed to update EQ filter chains: %v", err)
 		}
-		_ = c.SendToast("Audio equalizer settings updated.", "success", toastDurationShort)
+		if !nameChanged {
+			_ = c.SendToast("Audio equalizer settings updated.", "success", toastDurationShort)
+		}
 	}
 
 	return reconfigActions, nil

--- a/internal/api/v2/settings_audio.go
+++ b/internal/api/v2/settings_audio.go
@@ -264,7 +264,7 @@ func (c *Controller) handleAudioSettingsChanges(oldSettings, currentSettings *co
 		if err := c.handleEqualizerChange(currentSettings); err != nil {
 			c.Debug("Failed to update EQ filter chains: %v", err)
 		}
-		if !nameChanged {
+		if globalEQChanged || perSourceEQChanged || perStreamEQChanged {
 			_ = c.SendToast("Audio equalizer settings updated.", "success", toastDurationShort)
 		}
 	}

--- a/internal/api/v2/settings_audio_test.go
+++ b/internal/api/v2/settings_audio_test.go
@@ -92,7 +92,7 @@ func TestPerStreamEqualizerChanged(t *testing.T) {
 }
 
 //nolint:dupl // parallel test for audio sources mirrors stream test by design
-func TestAudioSourceNameChanged(t *testing.T) {
+func TestSyncAudioSourceNames(t *testing.T) {
 	t.Parallel()
 
 	t.Run("same names", func(t *testing.T) {
@@ -105,7 +105,7 @@ func TestAudioSourceNameChanged(t *testing.T) {
 		cur.Realtime.Audio.Sources = []conf.AudioSourceConfig{
 			{Name: "Front Yard", Device: "hw:0,0"},
 		}
-		assert.False(t, audioSourceNameChanged(old, cur))
+		assert.False(t, syncAudioSourceNames(old, cur, nil))
 	})
 
 	t.Run("name changed same device", func(t *testing.T) {
@@ -118,7 +118,7 @@ func TestAudioSourceNameChanged(t *testing.T) {
 		cur.Realtime.Audio.Sources = []conf.AudioSourceConfig{
 			{Name: "Garden Mic", Device: "hw:0,0"},
 		}
-		assert.True(t, audioSourceNameChanged(old, cur))
+		assert.True(t, syncAudioSourceNames(old, cur, nil))
 	})
 
 	t.Run("name and device both changed", func(t *testing.T) {
@@ -131,7 +131,7 @@ func TestAudioSourceNameChanged(t *testing.T) {
 		cur.Realtime.Audio.Sources = []conf.AudioSourceConfig{
 			{Name: "Garden Mic", Device: "hw:1,0"},
 		}
-		assert.False(t, audioSourceNameChanged(old, cur),
+		assert.False(t, syncAudioSourceNames(old, cur, nil),
 			"should be false when device also changed (handled by reconfiguration)")
 	})
 
@@ -146,7 +146,7 @@ func TestAudioSourceNameChanged(t *testing.T) {
 			{Name: "A", Device: "hw:0,0"},
 			{Name: "B", Device: "hw:1,0"},
 		}
-		assert.False(t, audioSourceNameChanged(old, cur),
+		assert.False(t, syncAudioSourceNames(old, cur, nil),
 			"should be false on length mismatch (handled by device change detection)")
 	})
 
@@ -154,12 +154,12 @@ func TestAudioSourceNameChanged(t *testing.T) {
 		t.Parallel()
 		old := &conf.Settings{}
 		cur := &conf.Settings{}
-		assert.False(t, audioSourceNameChanged(old, cur))
+		assert.False(t, syncAudioSourceNames(old, cur, nil))
 	})
 }
 
 //nolint:dupl // parallel test for streams mirrors audio source test by design
-func TestStreamNameChanged(t *testing.T) {
+func TestSyncStreamNames(t *testing.T) {
 	t.Parallel()
 
 	t.Run("same names", func(t *testing.T) {
@@ -172,7 +172,7 @@ func TestStreamNameChanged(t *testing.T) {
 		cur.Realtime.RTSP.Streams = []conf.StreamConfig{
 			{Name: "Backyard Cam", URL: "rtsp://192.168.1.10/stream"},
 		}
-		assert.False(t, streamNameChanged(old, cur))
+		assert.False(t, syncStreamNames(old, cur, nil))
 	})
 
 	t.Run("name changed same URL", func(t *testing.T) {
@@ -185,7 +185,7 @@ func TestStreamNameChanged(t *testing.T) {
 		cur.Realtime.RTSP.Streams = []conf.StreamConfig{
 			{Name: "Garden Cam", URL: "rtsp://192.168.1.10/stream"},
 		}
-		assert.True(t, streamNameChanged(old, cur))
+		assert.True(t, syncStreamNames(old, cur, nil))
 	})
 
 	t.Run("name and URL both changed", func(t *testing.T) {
@@ -198,7 +198,7 @@ func TestStreamNameChanged(t *testing.T) {
 		cur.Realtime.RTSP.Streams = []conf.StreamConfig{
 			{Name: "Garden Cam", URL: "rtsp://192.168.1.20/stream"},
 		}
-		assert.False(t, streamNameChanged(old, cur),
+		assert.False(t, syncStreamNames(old, cur, nil),
 			"should be false when URL also changed (handled by reconfiguration)")
 	})
 
@@ -213,7 +213,7 @@ func TestStreamNameChanged(t *testing.T) {
 			{Name: "A", URL: "rtsp://a/stream"},
 			{Name: "B", URL: "rtsp://b/stream"},
 		}
-		assert.False(t, streamNameChanged(old, cur),
+		assert.False(t, syncStreamNames(old, cur, nil),
 			"should be false on length mismatch (handled by stream reconfiguration)")
 	})
 
@@ -221,7 +221,7 @@ func TestStreamNameChanged(t *testing.T) {
 		t.Parallel()
 		old := &conf.Settings{}
 		cur := &conf.Settings{}
-		assert.False(t, streamNameChanged(old, cur))
+		assert.False(t, syncStreamNames(old, cur, nil))
 	})
 }
 

--- a/internal/api/v2/settings_audio_test.go
+++ b/internal/api/v2/settings_audio_test.go
@@ -90,3 +90,137 @@ func TestPerStreamEqualizerChanged(t *testing.T) {
 		assert.False(t, perStreamEqualizerChanged(old, cur))
 	})
 }
+
+//nolint:dupl // parallel test for audio sources mirrors stream test by design
+func TestAudioSourceNameChanged(t *testing.T) {
+	t.Parallel()
+
+	t.Run("same names", func(t *testing.T) {
+		t.Parallel()
+		old := &conf.Settings{}
+		old.Realtime.Audio.Sources = []conf.AudioSourceConfig{
+			{Name: "Front Yard", Device: "hw:0,0"},
+		}
+		cur := &conf.Settings{}
+		cur.Realtime.Audio.Sources = []conf.AudioSourceConfig{
+			{Name: "Front Yard", Device: "hw:0,0"},
+		}
+		assert.False(t, audioSourceNameChanged(old, cur))
+	})
+
+	t.Run("name changed same device", func(t *testing.T) {
+		t.Parallel()
+		old := &conf.Settings{}
+		old.Realtime.Audio.Sources = []conf.AudioSourceConfig{
+			{Name: "Front Yard", Device: "hw:0,0"},
+		}
+		cur := &conf.Settings{}
+		cur.Realtime.Audio.Sources = []conf.AudioSourceConfig{
+			{Name: "Garden Mic", Device: "hw:0,0"},
+		}
+		assert.True(t, audioSourceNameChanged(old, cur))
+	})
+
+	t.Run("name and device both changed", func(t *testing.T) {
+		t.Parallel()
+		old := &conf.Settings{}
+		old.Realtime.Audio.Sources = []conf.AudioSourceConfig{
+			{Name: "Front Yard", Device: "hw:0,0"},
+		}
+		cur := &conf.Settings{}
+		cur.Realtime.Audio.Sources = []conf.AudioSourceConfig{
+			{Name: "Garden Mic", Device: "hw:1,0"},
+		}
+		assert.False(t, audioSourceNameChanged(old, cur),
+			"should be false when device also changed (handled by reconfiguration)")
+	})
+
+	t.Run("length mismatch", func(t *testing.T) {
+		t.Parallel()
+		old := &conf.Settings{}
+		old.Realtime.Audio.Sources = []conf.AudioSourceConfig{
+			{Name: "A", Device: "hw:0,0"},
+		}
+		cur := &conf.Settings{}
+		cur.Realtime.Audio.Sources = []conf.AudioSourceConfig{
+			{Name: "A", Device: "hw:0,0"},
+			{Name: "B", Device: "hw:1,0"},
+		}
+		assert.False(t, audioSourceNameChanged(old, cur),
+			"should be false on length mismatch (handled by device change detection)")
+	})
+
+	t.Run("both empty", func(t *testing.T) {
+		t.Parallel()
+		old := &conf.Settings{}
+		cur := &conf.Settings{}
+		assert.False(t, audioSourceNameChanged(old, cur))
+	})
+}
+
+//nolint:dupl // parallel test for streams mirrors audio source test by design
+func TestStreamNameChanged(t *testing.T) {
+	t.Parallel()
+
+	t.Run("same names", func(t *testing.T) {
+		t.Parallel()
+		old := &conf.Settings{}
+		old.Realtime.RTSP.Streams = []conf.StreamConfig{
+			{Name: "Backyard Cam", URL: "rtsp://192.168.1.10/stream"},
+		}
+		cur := &conf.Settings{}
+		cur.Realtime.RTSP.Streams = []conf.StreamConfig{
+			{Name: "Backyard Cam", URL: "rtsp://192.168.1.10/stream"},
+		}
+		assert.False(t, streamNameChanged(old, cur))
+	})
+
+	t.Run("name changed same URL", func(t *testing.T) {
+		t.Parallel()
+		old := &conf.Settings{}
+		old.Realtime.RTSP.Streams = []conf.StreamConfig{
+			{Name: "Backyard Cam", URL: "rtsp://192.168.1.10/stream"},
+		}
+		cur := &conf.Settings{}
+		cur.Realtime.RTSP.Streams = []conf.StreamConfig{
+			{Name: "Garden Cam", URL: "rtsp://192.168.1.10/stream"},
+		}
+		assert.True(t, streamNameChanged(old, cur))
+	})
+
+	t.Run("name and URL both changed", func(t *testing.T) {
+		t.Parallel()
+		old := &conf.Settings{}
+		old.Realtime.RTSP.Streams = []conf.StreamConfig{
+			{Name: "Backyard Cam", URL: "rtsp://192.168.1.10/stream"},
+		}
+		cur := &conf.Settings{}
+		cur.Realtime.RTSP.Streams = []conf.StreamConfig{
+			{Name: "Garden Cam", URL: "rtsp://192.168.1.20/stream"},
+		}
+		assert.False(t, streamNameChanged(old, cur),
+			"should be false when URL also changed (handled by reconfiguration)")
+	})
+
+	t.Run("length mismatch", func(t *testing.T) {
+		t.Parallel()
+		old := &conf.Settings{}
+		old.Realtime.RTSP.Streams = []conf.StreamConfig{
+			{Name: "A", URL: "rtsp://a/stream"},
+		}
+		cur := &conf.Settings{}
+		cur.Realtime.RTSP.Streams = []conf.StreamConfig{
+			{Name: "A", URL: "rtsp://a/stream"},
+			{Name: "B", URL: "rtsp://b/stream"},
+		}
+		assert.False(t, streamNameChanged(old, cur),
+			"should be false on length mismatch (handled by stream reconfiguration)")
+	})
+
+	t.Run("both empty", func(t *testing.T) {
+		t.Parallel()
+		old := &conf.Settings{}
+		cur := &conf.Settings{}
+		assert.False(t, streamNameChanged(old, cur))
+	})
+}

--- a/internal/api/v2/settings_audio_test.go
+++ b/internal/api/v2/settings_audio_test.go
@@ -5,8 +5,27 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/tphakala/birdnet-go/internal/audiocore"
 	"github.com/tphakala/birdnet-go/internal/conf"
 )
+
+type fakeRegistry struct {
+	byConn  map[string]*audiocore.AudioSource
+	updates map[string]string
+}
+
+func (f *fakeRegistry) GetByConnection(c string) (*audiocore.AudioSource, bool) {
+	s, ok := f.byConn[c]
+	return s, ok
+}
+
+func (f *fakeRegistry) UpdateDisplayName(id, name string) bool {
+	if f.updates == nil {
+		f.updates = map[string]string{}
+	}
+	f.updates[id] = name
+	return true
+}
 
 func TestGetAudioBlockedFields(t *testing.T) {
 	t.Parallel()
@@ -282,4 +301,50 @@ func TestResolveEQOverrideMatchesByName(t *testing.T) {
 		"EQ override should resolve for the new stream name")
 	assert.Nil(t, settings.ResolveEQOverride("Old Stream Name"),
 		"EQ override should not resolve for the old stream name")
+}
+
+func TestSyncAudioSourceNames_UpdatesRegistry(t *testing.T) {
+	t.Parallel()
+
+	reg := &fakeRegistry{byConn: map[string]*audiocore.AudioSource{
+		"hw:0,0": {ID: "src-1"},
+	}}
+
+	old := &conf.Settings{}
+	old.Realtime.Audio.Sources = []conf.AudioSourceConfig{
+		{Name: "Front Yard", Device: "hw:0,0"},
+		{Name: "Side Mic", Device: "hw:1,0"},
+	}
+	cur := &conf.Settings{}
+	cur.Realtime.Audio.Sources = []conf.AudioSourceConfig{
+		{Name: "Garden Mic", Device: "hw:0,0"},
+		{Name: "Side Renamed", Device: "hw:1,0"},
+	}
+
+	assert.True(t, syncAudioSourceNames(old, cur, reg))
+	assert.Equal(t, map[string]string{"src-1": "Garden Mic"}, reg.updates,
+		"should update only sources found in the registry")
+}
+
+func TestSyncStreamNames_UpdatesRegistry(t *testing.T) {
+	t.Parallel()
+
+	reg := &fakeRegistry{byConn: map[string]*audiocore.AudioSource{
+		"rtsp://a/stream": {ID: "strm-1"},
+	}}
+
+	old := &conf.Settings{}
+	old.Realtime.RTSP.Streams = []conf.StreamConfig{
+		{Name: "Cam A", URL: "rtsp://a/stream"},
+		{Name: "Cam B", URL: "rtsp://b/stream"},
+	}
+	cur := &conf.Settings{}
+	cur.Realtime.RTSP.Streams = []conf.StreamConfig{
+		{Name: "Garden Cam", URL: "rtsp://a/stream"},
+		{Name: "Cam B Renamed", URL: "rtsp://b/stream"},
+	}
+
+	assert.True(t, syncStreamNames(old, cur, reg))
+	assert.Equal(t, map[string]string{"strm-1": "Garden Cam"}, reg.updates,
+		"should update only streams found in the registry")
 }

--- a/internal/api/v2/settings_audio_test.go
+++ b/internal/api/v2/settings_audio_test.go
@@ -225,7 +225,7 @@ func TestSyncStreamNames(t *testing.T) {
 	})
 }
 
-func TestEQResolutionAfterSourceRename(t *testing.T) {
+func TestResolveEQOverrideMatchesByName(t *testing.T) {
 	t.Parallel()
 
 	eq := &conf.EqualizerSettings{

--- a/internal/api/v2/settings_audio_test.go
+++ b/internal/api/v2/settings_audio_test.go
@@ -135,7 +135,7 @@ func TestSyncAudioSourceNames(t *testing.T) {
 			"should be false when device also changed (handled by reconfiguration)")
 	})
 
-	t.Run("length mismatch", func(t *testing.T) {
+	t.Run("rename with new source added", func(t *testing.T) {
 		t.Parallel()
 		old := &conf.Settings{}
 		old.Realtime.Audio.Sources = []conf.AudioSourceConfig{
@@ -143,11 +143,27 @@ func TestSyncAudioSourceNames(t *testing.T) {
 		}
 		cur := &conf.Settings{}
 		cur.Realtime.Audio.Sources = []conf.AudioSourceConfig{
-			{Name: "A", Device: "hw:0,0"},
+			{Name: "A-renamed", Device: "hw:0,0"},
 			{Name: "B", Device: "hw:1,0"},
 		}
-		assert.False(t, syncAudioSourceNames(old, cur, nil),
-			"should be false on length mismatch (handled by device change detection)")
+		assert.True(t, syncAudioSourceNames(old, cur, nil),
+			"should detect rename even when a new source was added")
+	})
+
+	t.Run("reordered sources with rename", func(t *testing.T) {
+		t.Parallel()
+		old := &conf.Settings{}
+		old.Realtime.Audio.Sources = []conf.AudioSourceConfig{
+			{Name: "Mic A", Device: "hw:0,0"},
+			{Name: "Mic B", Device: "hw:1,0"},
+		}
+		cur := &conf.Settings{}
+		cur.Realtime.Audio.Sources = []conf.AudioSourceConfig{
+			{Name: "Mic B", Device: "hw:1,0"},
+			{Name: "Garden Mic", Device: "hw:0,0"},
+		}
+		assert.True(t, syncAudioSourceNames(old, cur, nil),
+			"should detect rename even when sources are reordered")
 	})
 
 	t.Run("both empty", func(t *testing.T) {
@@ -202,7 +218,7 @@ func TestSyncStreamNames(t *testing.T) {
 			"should be false when URL also changed (handled by reconfiguration)")
 	})
 
-	t.Run("length mismatch", func(t *testing.T) {
+	t.Run("rename with new stream added", func(t *testing.T) {
 		t.Parallel()
 		old := &conf.Settings{}
 		old.Realtime.RTSP.Streams = []conf.StreamConfig{
@@ -210,11 +226,27 @@ func TestSyncStreamNames(t *testing.T) {
 		}
 		cur := &conf.Settings{}
 		cur.Realtime.RTSP.Streams = []conf.StreamConfig{
-			{Name: "A", URL: "rtsp://a/stream"},
+			{Name: "A-renamed", URL: "rtsp://a/stream"},
 			{Name: "B", URL: "rtsp://b/stream"},
 		}
-		assert.False(t, syncStreamNames(old, cur, nil),
-			"should be false on length mismatch (handled by stream reconfiguration)")
+		assert.True(t, syncStreamNames(old, cur, nil),
+			"should detect rename even when a new stream was added")
+	})
+
+	t.Run("reordered streams with rename", func(t *testing.T) {
+		t.Parallel()
+		old := &conf.Settings{}
+		old.Realtime.RTSP.Streams = []conf.StreamConfig{
+			{Name: "Stream A", URL: "rtsp://a/stream"},
+			{Name: "Stream B", URL: "rtsp://b/stream"},
+		}
+		cur := &conf.Settings{}
+		cur.Realtime.RTSP.Streams = []conf.StreamConfig{
+			{Name: "Stream B", URL: "rtsp://b/stream"},
+			{Name: "Garden Cam", URL: "rtsp://a/stream"},
+		}
+		assert.True(t, syncStreamNames(old, cur, nil),
+			"should detect rename even when streams are reordered")
 	})
 
 	t.Run("both empty", func(t *testing.T) {

--- a/internal/api/v2/settings_audio_test.go
+++ b/internal/api/v2/settings_audio_test.go
@@ -224,3 +224,30 @@ func TestStreamNameChanged(t *testing.T) {
 		assert.False(t, streamNameChanged(old, cur))
 	})
 }
+
+func TestEQResolutionAfterSourceRename(t *testing.T) {
+	t.Parallel()
+
+	eq := &conf.EqualizerSettings{
+		Enabled: true,
+		Filters: []conf.EqualizerFilter{{Type: "HighPass", Frequency: 300, Q: 0.7}},
+	}
+
+	settings := &conf.Settings{}
+	settings.Realtime.Audio.Sources = []conf.AudioSourceConfig{
+		{Name: "New Name", Device: "hw:0,0", Equalizer: eq},
+	}
+	settings.Realtime.RTSP.Streams = []conf.StreamConfig{
+		{Name: "Renamed Stream", URL: "rtsp://cam/stream", Equalizer: eq},
+	}
+
+	assert.Equal(t, eq, settings.ResolveEQOverride("New Name"),
+		"EQ override should resolve for the new source name")
+	assert.Nil(t, settings.ResolveEQOverride("Old Name"),
+		"EQ override should not resolve for the old source name")
+
+	assert.Equal(t, eq, settings.ResolveEQOverride("Renamed Stream"),
+		"EQ override should resolve for the new stream name")
+	assert.Nil(t, settings.ResolveEQOverride("Old Stream Name"),
+		"EQ override should not resolve for the old stream name")
+}

--- a/internal/audiocore/source_registry.go
+++ b/internal/audiocore/source_registry.go
@@ -239,6 +239,33 @@ func (r *SourceRegistry) UpdateState(sourceID string, state SourceState) error {
 	return nil
 }
 
+// UpdateDisplayName changes the display name of a source and fires
+// SourceReconfigured. Returns false if the source does not exist or
+// the name is unchanged.
+func (r *SourceRegistry) UpdateDisplayName(sourceID, newName string) bool {
+	r.mu.Lock()
+
+	src, ok := r.sources[sourceID]
+	if !ok || src.DisplayName == newName {
+		r.mu.Unlock()
+		return false
+	}
+
+	oldName := src.DisplayName
+	src.DisplayName = newName
+	snapshot := r.copySource(src)
+
+	r.mu.Unlock()
+
+	r.log.Info("display name updated",
+		logger.String("id", sourceID),
+		logger.String("old_name", oldName),
+		logger.String("new_name", newName))
+
+	r.notify(SourceEvent{Type: SourceReconfigured, SourceID: sourceID, Source: snapshot})
+	return true
+}
+
 // UpdateGain updates the Gain field of the source with the given ID.
 // Returns false if the source does not exist.
 func (r *SourceRegistry) UpdateGain(sourceID string, gain float64) bool {

--- a/internal/audiocore/source_registry_test.go
+++ b/internal/audiocore/source_registry_test.go
@@ -270,6 +270,88 @@ func TestSourceRegistry_RegisterDefaultGain(t *testing.T) {
 	assert.InDelta(t, 0.0, src.Gain, 1e-9, "Gain should default to 0 when not specified")
 }
 
+// TestSourceRegistry_UpdateDisplayName verifies that UpdateDisplayName changes
+// the display name, fires SourceReconfigured, and returns true.
+func TestSourceRegistry_UpdateDisplayName(t *testing.T) {
+	t.Parallel()
+	r := newTestRegistry(t)
+
+	var mu sync.Mutex
+	var received []SourceEvent
+
+	r.AddListener(func(e SourceEvent) {
+		mu.Lock()
+		defer mu.Unlock()
+		received = append(received, e)
+	})
+
+	src, err := r.Register(&SourceConfig{
+		DisplayName:      "Old Name",
+		ConnectionString: "hw:0,0",
+		Type:             SourceTypeAudioCard,
+	})
+	require.NoError(t, err)
+
+	updated := r.UpdateDisplayName(src.ID, "New Name")
+	assert.True(t, updated, "should return true when name changes")
+
+	got, ok := r.Get(src.ID)
+	require.True(t, ok)
+	assert.Equal(t, "New Name", got.DisplayName)
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	// Events: SourceAdded + SourceReconfigured
+	require.Len(t, received, 2)
+	assert.Equal(t, SourceReconfigured, received[1].Type)
+	assert.Equal(t, src.ID, received[1].SourceID)
+	assert.Equal(t, "New Name", received[1].Source.DisplayName)
+}
+
+// TestSourceRegistry_UpdateDisplayName_NoOp verifies that UpdateDisplayName
+// returns false and fires no event when the name is unchanged.
+func TestSourceRegistry_UpdateDisplayName_NoOp(t *testing.T) {
+	t.Parallel()
+	r := newTestRegistry(t)
+
+	var mu sync.Mutex
+	var received []SourceEvent
+
+	r.AddListener(func(e SourceEvent) {
+		mu.Lock()
+		defer mu.Unlock()
+		received = append(received, e)
+	})
+
+	src, err := r.Register(&SourceConfig{
+		DisplayName:      "Same Name",
+		ConnectionString: "hw:1,0",
+		Type:             SourceTypeAudioCard,
+	})
+	require.NoError(t, err)
+
+	updated := r.UpdateDisplayName(src.ID, "Same Name")
+	assert.False(t, updated, "should return false when name is unchanged")
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	// Only SourceAdded, no SourceReconfigured
+	assert.Len(t, received, 1)
+	assert.Equal(t, SourceAdded, received[0].Type)
+}
+
+// TestSourceRegistry_UpdateDisplayName_NotFound verifies that UpdateDisplayName
+// returns false for an unknown source ID.
+func TestSourceRegistry_UpdateDisplayName_NotFound(t *testing.T) {
+	t.Parallel()
+	r := newTestRegistry(t)
+
+	updated := r.UpdateDisplayName("nonexistent-id", "Any Name")
+	assert.False(t, updated)
+}
+
 // TestSourceRegistry_TypeDetection verifies that source types are detected from connection strings.
 func TestSourceRegistry_TypeDetection(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Summary

- Add `UpdateDisplayName` method to `SourceRegistry` that updates the name in-place and fires a `SourceReconfigured` event for downstream listeners
- Add single-pass `syncAudioSourceNames` / `syncStreamNames` helpers that detect renames (same Device/URL, different Name) and update the registry in one pass
- In `handleAudioSettingsChanges`, sync DisplayNames before rebuilding EQ filter chains so `ResolveEQOverride` uses the updated name
- In `reconfigureChangedSources`, sync DisplayName for kept sources as a safety net for the async reconfiguration path

## Problem

When a user renames an audio source or RTSP stream in the settings UI, the `SourceRegistry` retained the old `DisplayName`. Any config lookup using `DisplayName` (EQ resolution via `ResolveEQOverride`, MQTT discovery entity IDs, detection source attribution) silently fell back to defaults until the next restart.

Root cause: `audioDeviceSettingChanged` only compared Device/Gain/Model (not Name), so a name-only change triggered no action for audio sources. For streams, `streamsSettingsChanged` detected name changes but `reconfigureChangedSources` never synced DisplayName for kept sources.

## Test Plan

- [x] Unit tests for `UpdateDisplayName`: name change fires `SourceReconfigured`, no-op returns false, not-found returns false
- [x] Unit tests for `syncAudioSourceNames`: same names, changed names, device-changed skip, length mismatch
- [x] Unit tests for `syncStreamNames`: same names, changed names, URL-changed skip, length mismatch
- [x] Integration test: `ResolveEQOverride` matches after rename
- [x] All tests pass with `-race`, zero linter issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Display-name synchronization now updates the central registry when audio source or RTSP stream names change (e.g., UI renames).

* **Bug Fixes**
  * Renamed sources/streams now properly propagate so equalizer selection and related behavior use updated names.
  * Success toasts for equalizer updates only appear when EQ settings actually change.

* **Tests**
  * Added unit tests covering name synchronization, rename detection, and EQ override matching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->