### PR TITLE
fix: prefix spectrogram urls with basepath

### DIFF
--- a/frontend/src/lib/utils/spectrogramLoader.svelte.ts
+++ b/frontend/src/lib/utils/spectrogramLoader.svelte.ts
@@ -16,6 +16,7 @@
 import { acquireSlot, releaseSlot, type SlotHandle } from '$lib/utils/imageLoadQueue';
 import { getCsrfToken } from '$lib/utils/api';
 import { loggers } from '$lib/utils/logger';
+import { buildAppUrl } from '$lib/utils/urlHelpers';
 
 const logger = loggers.ui;
 
@@ -137,15 +138,21 @@ export function createSpectrogramLoader(userConfig: SpectrogramLoaderConfig = {}
   }
 
   function buildStatusUrl(detectionId: number): string {
-    return `/api/v2/spectrogram/${detectionId}/status?size=${config.size}&raw=${String(config.raw)}`;
+    return buildAppUrl(
+      `/api/v2/spectrogram/${detectionId}/status?size=${config.size}&raw=${String(config.raw)}`
+    );
   }
 
   function buildGenerateUrl(detectionId: number): string {
-    return `/api/v2/spectrogram/${detectionId}/generate?size=${config.size}&raw=${String(config.raw)}`;
+    return buildAppUrl(
+      `/api/v2/spectrogram/${detectionId}/generate?size=${config.size}&raw=${String(config.raw)}`
+    );
   }
 
   function buildImageUrl(detectionId: number): string {
-    let url = `/api/v2/spectrogram/${detectionId}?size=${config.size}&raw=${String(config.raw)}`;
+    let url = buildAppUrl(
+      `/api/v2/spectrogram/${detectionId}?size=${config.size}&raw=${String(config.raw)}`
+    );
     if (imageRetryCount > 0) {
       url += `&t=${String(Date.now())}`;
     }

--- a/frontend/src/lib/utils/spectrogramLoader.test.ts
+++ b/frontend/src/lib/utils/spectrogramLoader.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { resetBasePath, setBasePath } from './urlHelpers';
 
 // Default: acquireSlot resolves immediately with true
 const mockAcquireSlot = vi.fn(() => ({
@@ -58,10 +59,12 @@ describe('spectrogramLoader', () => {
     vi.clearAllMocks();
     vi.useFakeTimers();
     mockFetch.mockReset();
+    resetBasePath();
   });
 
   afterEach(() => {
     vi.useRealTimers();
+    resetBasePath();
   });
 
   describe('initial state', () => {
@@ -106,6 +109,22 @@ describe('spectrogramLoader', () => {
       expect(loader.state).toBe('loaded');
       expect(loader.showSpinner).toBe(false);
       expect(mockReleaseSlot).toHaveBeenCalled();
+      loader.destroy();
+    });
+
+    it('uses the configured app base path for status and image URLs', async () => {
+      setBasePath('/proxy');
+      mockFetch.mockResolvedValueOnce(mockJsonResponse({ data: { status: 'exists' } }));
+
+      const loader = createSpectrogramLoader({ size: 'md', raw: true });
+      loader.start(42);
+      await flushAll();
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        '/proxy/api/v2/spectrogram/42/status?size=md&raw=true',
+        expect.objectContaining({ signal: expect.any(AbortSignal) })
+      );
+      expect(loader.spectrogramUrl).toBe('/proxy/api/v2/spectrogram/42?size=md&raw=true');
       loader.destroy();
     });
   });


### PR DESCRIPTION
My previous attempt at fixing basepaths was not exhaustive, it seems. The spectrograms do not request with the basepath, and fails.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage to verify base path configuration is correctly applied to spectrogram request URLs across all operations.

* **Refactor**
  * Improved consistency in spectrogram API endpoint URL construction using a unified approach for all request types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->