### PR TITLE
fix: use light foreground color on live stream page for spectrogram

### DIFF
--- a/frontend/src/lib/desktop/features/live-stream/pages/LiveStreamPage.svelte
+++ b/frontend/src/lib/desktop/features/live-stream/pages/LiveStreamPage.svelte
@@ -856,7 +856,7 @@
         <button
           onclick={handleStartClick}
           disabled={!selectedSourceId || sources.length === 0}
-          class="flex h-full w-full flex-col items-center justify-center gap-3 bg-black text-[var(--color-base-content)]/60 transition-colors hover:text-[var(--color-base-content)]/80 disabled:cursor-not-allowed disabled:opacity-50"
+          class="flex h-full w-full flex-col items-center justify-center gap-3 bg-black text-white/75 transition-colors hover:text-white disabled:cursor-not-allowed disabled:opacity-50"
         >
           {#if sources.length === 0 && !sourceDiscoveryDone}
             <Loader2 class="size-8 animate-spin" />


### PR DESCRIPTION
On the live stream page, if you're using light mode, it is very hard to see the play button/"Audio Source" text. See below for comparison.

| light mode | dark mode |
| ---- | ----- |
| <img width="141" height="132" alt="image" src="https://github.com/user-attachments/assets/6b2ef684-fb26-4152-80ed-2ec15d0bb41c" /> | <img width="161" height="147" alt="image" src="https://github.com/user-attachments/assets/9b9c9b7c-7c7e-414c-94e5-f2ae3f1937ee" /> |

This PR standardizes on light foreground color for this spectrogram, since it's overlayed on a black background

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced the start button appearance on the live stream page with improved text color contrast and clearer hover state visibility for better user interaction feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->