### PR TITLE
fix(logger): add hierarchical module level inheritance and detection event debug logging

### DIFF
--- a/internal/alerting/detection_bridge.go
+++ b/internal/alerting/detection_bridge.go
@@ -40,6 +40,15 @@ func (b *DetectionAlertBridge) ProcessDetectionEvent(event events.DetectionEvent
 		eventName = EventDetectionNewSpecies
 	}
 
+	b.log.Debug("Detection event received at alert bridge",
+		logger.String("component", "alerting.detection_bridge"),
+		logger.String("event_name", eventName),
+		logger.String("species", event.GetSpeciesName()),
+		logger.String("scientific_name", event.GetScientificName()),
+		logger.Float64("confidence", event.GetConfidence()),
+		logger.Bool("is_new_species", event.IsNewSpecies()),
+		logger.String("operation", "bridge_detection_event"))
+
 	properties := map[string]any{
 		PropertySpeciesName:    event.GetSpeciesName(),
 		PropertyScientificName: event.GetScientificName(),

--- a/internal/alerting/engine.go
+++ b/internal/alerting/engine.go
@@ -232,7 +232,8 @@ func (e *Engine) HandleEvent(event *AlertEvent) {
 	copy(rules, e.rules)
 	e.rulesMu.RUnlock()
 
-	if isDetectionEvent(event.EventName) {
+	isDetection := isDetectionEvent(event.EventName)
+	if isDetection {
 		e.log.Debug("Alert engine received detection event",
 			logger.String("component", "alerting.engine"),
 			logger.String("event_name", event.EventName),
@@ -278,7 +279,7 @@ func (e *Engine) HandleEvent(event *AlertEvent) {
 		}
 
 		if e.tryAcquireCooldown(cdKey, rule.CooldownSec) {
-			if isDetectionEvent(event.EventName) {
+			if isDetection {
 				e.log.Debug("Detection rule fired",
 					logger.String("component", "alerting.engine"),
 					logger.String("event_name", event.EventName),
@@ -287,7 +288,7 @@ func (e *Engine) HandleEvent(event *AlertEvent) {
 					logger.String("operation", "fire_detection_rule"))
 			}
 			e.fireRule(rule, event)
-		} else if isDetectionEvent(event.EventName) {
+		} else if isDetection {
 			e.log.Debug("Detection rule suppressed by cooldown",
 				logger.String("component", "alerting.engine"),
 				logger.String("event_name", event.EventName),

--- a/internal/alerting/engine.go
+++ b/internal/alerting/engine.go
@@ -232,6 +232,15 @@ func (e *Engine) HandleEvent(event *AlertEvent) {
 	copy(rules, e.rules)
 	e.rulesMu.RUnlock()
 
+	if isDetectionEvent(event.EventName) {
+		e.log.Debug("Alert engine received detection event",
+			logger.String("component", "alerting.engine"),
+			logger.String("event_name", event.EventName),
+			logger.String("object_type", event.ObjectType),
+			logger.Int("rules_count", len(rules)),
+			logger.String("operation", "handle_detection_event"))
+	}
+
 	// Phase 1: Clear escalation state for metrics that have recovered.
 	e.clearEscalationIfRecovered(rules, event)
 
@@ -269,7 +278,23 @@ func (e *Engine) HandleEvent(event *AlertEvent) {
 		}
 
 		if e.tryAcquireCooldown(cdKey, rule.CooldownSec) {
+			if isDetectionEvent(event.EventName) {
+				e.log.Debug("Detection rule fired",
+					logger.String("component", "alerting.engine"),
+					logger.String("event_name", event.EventName),
+					logger.Uint64("rule_id", uint64(rule.ID)),
+					logger.String("rule_name", rule.Name),
+					logger.String("operation", "fire_detection_rule"))
+			}
 			e.fireRule(rule, event)
+		} else if isDetectionEvent(event.EventName) {
+			e.log.Debug("Detection rule suppressed by cooldown",
+				logger.String("component", "alerting.engine"),
+				logger.String("event_name", event.EventName),
+				logger.Uint64("rule_id", uint64(rule.ID)),
+				logger.String("rule_name", rule.Name),
+				logger.Int("cooldown_sec", rule.CooldownSec),
+				logger.String("operation", "cooldown_suppressed"))
 		}
 	}
 }

--- a/internal/analysis/processor/actions_database.go
+++ b/internal/analysis/processor/actions_database.go
@@ -264,6 +264,15 @@ func (a *DatabaseAction) recordNotificationSent(notificationTime time.Time) {
 // This helper method orchestrates notification suppression, event creation, and publishing.
 func (a *DatabaseAction) publishNewSpeciesDetectionEvent(isNewSpecies bool, daysSinceFirstSeen int) {
 	if !isNewSpecies || !events.IsInitialized() {
+		if events.IsInitialized() && !isNewSpecies {
+			GetLogger().Debug("Skipping detection event publish: not a new species",
+				logger.String("component", "analysis.processor.actions"),
+				logger.String("detection_id", a.CorrelationID),
+				logger.String("species", a.Result.Species.CommonName),
+				logger.String("scientific_name", a.Result.Species.ScientificName),
+				logger.Float64("confidence", a.Result.Confidence),
+				logger.String("operation", "skip_detection_event"))
+		}
 		return
 	}
 

--- a/internal/logger/central_logger.go
+++ b/internal/logger/central_logger.go
@@ -321,25 +321,15 @@ func (cl *CentralLogger) Module(name string) Logger {
 }
 
 // getModuleLevelLocked returns the log level for a module, walking up the
-// hierarchy. For "analysis.processor", it checks "analysis.processor" first,
-// then "analysis", then falls back to DefaultLevel. This also checks
-// ModuleOutputs so that YAML config like modules.analysis.level=debug
-// applies to sub-modules like analysis.processor.
+// hierarchy from most-specific to least-specific. For "analysis.processor",
+// it checks "analysis.processor" first, then "analysis", then falls back to
+// DefaultLevel. At each level, both moduleLevels and ModuleOutputs are checked
+// so that an exact child match in either source wins over a parent match.
 func (cl *CentralLogger) getModuleLevelLocked(module string) slog.Level {
-	// Check module_levels map (exact match, then parent prefixes)
 	for name := module; name != ""; {
 		if level, ok := cl.moduleLevels[name]; ok {
 			return level
 		}
-		if idx := strings.LastIndex(name, "."); idx >= 0 {
-			name = name[:idx]
-		} else {
-			break
-		}
-	}
-
-	// Check ModuleOutputs level (exact match, then parent prefixes)
-	for name := module; name != ""; {
 		if modOut, ok := cl.config.ModuleOutputs[name]; ok && modOut.Level != "" {
 			return parseLogLevel(modOut.Level)
 		}
@@ -349,7 +339,6 @@ func (cl *CentralLogger) getModuleLevelLocked(module string) slog.Level {
 			break
 		}
 	}
-
 	return parseLogLevel(cl.config.DefaultLevel)
 }
 

--- a/internal/logger/central_logger.go
+++ b/internal/logger/central_logger.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"sync"
 	"time"
 
@@ -319,11 +320,36 @@ func (cl *CentralLogger) Module(name string) Logger {
 	}
 }
 
-// getModuleLevelLocked returns the log level for a module (must hold read lock)
+// getModuleLevelLocked returns the log level for a module, walking up the
+// hierarchy. For "analysis.processor", it checks "analysis.processor" first,
+// then "analysis", then falls back to DefaultLevel. This also checks
+// ModuleOutputs so that YAML config like modules.analysis.level=debug
+// applies to sub-modules like analysis.processor.
 func (cl *CentralLogger) getModuleLevelLocked(module string) slog.Level {
-	if level, ok := cl.moduleLevels[module]; ok {
-		return level
+	// Check module_levels map (exact match, then parent prefixes)
+	for name := module; name != ""; {
+		if level, ok := cl.moduleLevels[name]; ok {
+			return level
+		}
+		if idx := strings.LastIndex(name, "."); idx >= 0 {
+			name = name[:idx]
+		} else {
+			break
+		}
 	}
+
+	// Check ModuleOutputs level (exact match, then parent prefixes)
+	for name := module; name != ""; {
+		if modOut, ok := cl.config.ModuleOutputs[name]; ok && modOut.Level != "" {
+			return parseLogLevel(modOut.Level)
+		}
+		if idx := strings.LastIndex(name, "."); idx >= 0 {
+			name = name[:idx]
+		} else {
+			break
+		}
+	}
+
 	return parseLogLevel(cl.config.DefaultLevel)
 }
 


### PR DESCRIPTION
## Summary

- Fix module log level resolution to walk up dot-separated hierarchy (e.g., `analysis.level=debug` now applies to `analysis.processor` sub-module)
- Add debug logging at three points in the detection event pipeline to diagnose GitHub #2699

## Changes

**Logger hierarchy fix (`internal/logger/central_logger.go`):**
`getModuleLevelLocked()` now walks up the module name hierarchy. Previously, setting `modules.analysis.level: debug` had no effect on `analysis.processor` because there was no inheritance. Now the level lookup checks `analysis.processor` first, then `analysis`, then `DefaultLevel`.

**Detection event debug logging:**
- `actions_database.go`: Logs when non-new-species detections skip event publishing (`skip_detection_event`)
- `detection_bridge.go`: Logs events arriving at the alert bridge (`bridge_detection_event`)
- `engine.go`: Logs rule matching, firing, and cooldown suppression for detection events

## Context

Investigated GitHub #2699 where `detection.occurred` events are defined in the alert schema/UI but never emitted for ordinary detections. This PR adds the observability needed to confirm and diagnose the issue. Verified on RPi5 with 357k real detections: 27+ species correctly trigger `skip_detection_event`, confirming only new species events reach the alerting pipeline.

## Test plan

- [x] `golangci-lint run -v` passes (0 issues)
- [x] `go test -race ./internal/logger/... ./internal/alerting/...` passes
- [x] Verified on QA container (fresh DB, RTSP stream source)
- [x] Verified on RPi5 production (192.168.4.159, 357k detections, sound card source)
- [x] Module hierarchy confirmed: `analysis.level=debug` now applies to `analysis.processor`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced debug logging around detection events and alert processing (receipt, rule evaluation, cooldown decisions).
  * Emit debug logs when publishing is skipped for previously-seen species while the events system is active.
  * Improved module-level logging resolution with hierarchical namespace fallback for finer-grained log level control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->