### PR TITLE
fix(alerting): emit detection.occurred event for all detections

### DIFF
--- a/frontend/src/lib/api/alerts.ts
+++ b/frontend/src/lib/api/alerts.ts
@@ -62,6 +62,7 @@ export interface PropertySchema {
 export interface EventSchema {
   name: string;
   label: string;
+  description?: string;
   properties: PropertySchema[];
 }
 

--- a/frontend/src/lib/desktop/features/settings/components/AlertRuleEditor.svelte
+++ b/frontend/src/lib/desktop/features/settings/components/AlertRuleEditor.svelte
@@ -142,6 +142,7 @@
     selectedObjectType?.events?.map(e => ({
       value: e.name,
       label: schemaEventLabel(e.name, e.label),
+      description: e.description ?? '',
     })) ?? []
   );
 
@@ -616,6 +617,9 @@
             >
               <div class="flex-1 min-w-0">
                 <div class="text-sm font-medium text-[var(--color-base-content)]">{item.label}</div>
+                {#if 'description' in item && item.description}
+                  <div class="text-xs text-[var(--color-base-content)]/50">{item.description}</div>
+                {/if}
                 <div class="text-[11px] font-mono text-[var(--color-base-content)]/40">
                   {item.value}
                 </div>

--- a/internal/alerting/detection_bridge.go
+++ b/internal/alerting/detection_bridge.go
@@ -1,6 +1,8 @@
 package alerting
 
 import (
+	"maps"
+
 	"github.com/tphakala/birdnet-go/internal/events"
 	"github.com/tphakala/birdnet-go/internal/logger"
 )
@@ -59,17 +61,18 @@ func (b *DetectionAlertBridge) ProcessDetectionEvent(event events.DetectionEvent
 		properties[PropertyEventMetadata] = meta
 	}
 
+	var newSpeciesProps map[string]any
+	if event.IsNewSpecies() {
+		newSpeciesProps = maps.Clone(properties)
+	}
+
 	TryPublish(&AlertEvent{
 		ObjectType: ObjectTypeDetection,
 		EventName:  EventDetectionOccurred,
 		Properties: properties,
 	})
 
-	if event.IsNewSpecies() {
-		newSpeciesProps := make(map[string]any, len(properties))
-		for k, v := range properties {
-			newSpeciesProps[k] = v
-		}
+	if newSpeciesProps != nil {
 		TryPublish(&AlertEvent{
 			ObjectType: ObjectTypeDetection,
 			EventName:  EventDetectionNewSpecies,

--- a/internal/alerting/detection_bridge.go
+++ b/internal/alerting/detection_bridge.go
@@ -58,7 +58,7 @@ func (b *DetectionAlertBridge) ProcessDetectionEvent(event events.DetectionEvent
 	}
 
 	if meta := event.GetMetadata(); len(meta) > 0 {
-		properties[PropertyEventMetadata] = meta
+		properties[PropertyEventMetadata] = maps.Clone(meta)
 	}
 
 	var newSpeciesProps map[string]any

--- a/internal/alerting/detection_bridge.go
+++ b/internal/alerting/detection_bridge.go
@@ -34,15 +34,11 @@ func (b *DetectionAlertBridge) SupportsBatching() bool {
 }
 
 // ProcessDetectionEvent publishes detection events to the alert event bus.
+// Every detection emits detection.occurred; new species additionally emit
+// detection.new_species so rules on either event work as users expect.
 func (b *DetectionAlertBridge) ProcessDetectionEvent(event events.DetectionEvent) error {
-	eventName := EventDetectionOccurred
-	if event.IsNewSpecies() {
-		eventName = EventDetectionNewSpecies
-	}
-
 	b.log.Debug("Detection event received at alert bridge",
 		logger.String("component", "alerting.detection_bridge"),
-		logger.String("event_name", eventName),
 		logger.String("species", event.GetSpeciesName()),
 		logger.String("scientific_name", event.GetScientificName()),
 		logger.Float64("confidence", event.GetConfidence()),
@@ -50,29 +46,36 @@ func (b *DetectionAlertBridge) ProcessDetectionEvent(event events.DetectionEvent
 		logger.String("operation", "bridge_detection_event"))
 
 	properties := map[string]any{
-		PropertySpeciesName:    event.GetSpeciesName(),
-		PropertyScientificName: event.GetScientificName(),
-		PropertyConfidence:     event.GetConfidence(),
-		PropertyLocation:       event.GetLocation(),
-		// Additional fields for notification metadata enrichment.
-		// These are not used for condition evaluation but are passed through
-		// to the notification adapter so webhook templates can reference them.
+		PropertySpeciesName:        event.GetSpeciesName(),
+		PropertyScientificName:     event.GetScientificName(),
+		PropertyConfidence:         event.GetConfidence(),
+		PropertyLocation:           event.GetLocation(),
 		PropertyEventTimestamp:     event.GetTimestamp(),
 		PropertyDaysSinceFirstSeen: event.GetDaysSinceFirstSeen(),
 		PropertyIsNewSpecies:       event.IsNewSpecies(),
 	}
 
-	// Pass through raw event metadata (note_id, latitude, longitude, image_url, begin_time)
-	// so the notification adapter can build full template data.
 	if meta := event.GetMetadata(); len(meta) > 0 {
 		properties[PropertyEventMetadata] = meta
 	}
 
 	TryPublish(&AlertEvent{
 		ObjectType: ObjectTypeDetection,
-		EventName:  eventName,
+		EventName:  EventDetectionOccurred,
 		Properties: properties,
 	})
+
+	if event.IsNewSpecies() {
+		newSpeciesProps := make(map[string]any, len(properties))
+		for k, v := range properties {
+			newSpeciesProps[k] = v
+		}
+		TryPublish(&AlertEvent{
+			ObjectType: ObjectTypeDetection,
+			EventName:  EventDetectionNewSpecies,
+			Properties: newSpeciesProps,
+		})
+	}
 
 	return nil
 }

--- a/internal/alerting/detection_bridge_test.go
+++ b/internal/alerting/detection_bridge_test.go
@@ -1,0 +1,118 @@
+package alerting
+
+import (
+	"io"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/events"
+	"github.com/tphakala/birdnet-go/internal/logger"
+)
+
+type capturedAlertEvent struct {
+	ObjectType string
+	EventName  string
+	Properties map[string]any
+}
+
+func waitForEvents(t *testing.T, mu *sync.Mutex, captured *[]capturedAlertEvent, count int) []capturedAlertEvent {
+	t.Helper()
+	var result []capturedAlertEvent
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		mu.Lock()
+		result = make([]capturedAlertEvent, len(*captured))
+		copy(result, *captured)
+		mu.Unlock()
+		assert.GreaterOrEqual(collect, len(result), count)
+	}, 2*time.Second, 20*time.Millisecond)
+	return result
+}
+
+func setupBridgeWithCapture(t *testing.T) (*DetectionAlertBridge, *sync.Mutex, *[]capturedAlertEvent) {
+	t.Helper()
+
+	var mu sync.Mutex
+	var captured []capturedAlertEvent
+
+	bus := NewAlertEventBus(nil)
+	bus.Subscribe(func(event *AlertEvent) {
+		mu.Lock()
+		defer mu.Unlock()
+		captured = append(captured, capturedAlertEvent{
+			ObjectType: event.ObjectType,
+			EventName:  event.EventName,
+			Properties: event.Properties,
+		})
+	})
+	SetGlobalBus(bus)
+	t.Cleanup(func() {
+		bus.Stop()
+		SetGlobalBus(nil)
+	})
+
+	bridge := NewDetectionAlertBridge(
+		logger.NewSlogLogger(io.Discard, logger.LogLevelError, nil),
+	)
+
+	return bridge, &mu, &captured
+}
+
+func TestBridge_OrdinaryDetection_EmitsOccurredOnly(t *testing.T) {
+	bridge, mu, captured := setupBridgeWithCapture(t)
+
+	event, err := events.NewDetectionEvent("Test Bird", "Testus birdus", 0.9, "mic", false, 30)
+	require.NoError(t, err)
+
+	require.NoError(t, bridge.ProcessDetectionEvent(event))
+
+	result := waitForEvents(t, mu, captured, 1)
+	assert.Len(t, result, 1)
+	assert.Equal(t, EventDetectionOccurred, result[0].EventName)
+	assert.Equal(t, "Test Bird", result[0].Properties[PropertySpeciesName])
+	assert.InDelta(t, 0.9, result[0].Properties[PropertyConfidence], 0.001)
+	assert.Equal(t, false, result[0].Properties[PropertyIsNewSpecies])
+}
+
+func TestBridge_NewSpecies_EmitsBothEvents(t *testing.T) {
+	bridge, mu, captured := setupBridgeWithCapture(t)
+
+	event, err := events.NewDetectionEvent("Test Bird", "Testus birdus", 0.9, "mic", true, 0)
+	require.NoError(t, err)
+
+	require.NoError(t, bridge.ProcessDetectionEvent(event))
+
+	result := waitForEvents(t, mu, captured, 2)
+	assert.Len(t, result, 2)
+
+	eventNames := []string{result[0].EventName, result[1].EventName}
+	assert.Contains(t, eventNames, EventDetectionOccurred)
+	assert.Contains(t, eventNames, EventDetectionNewSpecies)
+
+	// Verify both events carry correct properties
+	for _, r := range result {
+		assert.Equal(t, "Test Bird", r.Properties[PropertySpeciesName])
+		assert.Equal(t, "Testus birdus", r.Properties[PropertyScientificName])
+		assert.InDelta(t, 0.9, r.Properties[PropertyConfidence], 0.001)
+		assert.Equal(t, true, r.Properties[PropertyIsNewSpecies])
+	}
+}
+
+func TestBridge_NewSpecies_IndependentPropertyMaps(t *testing.T) {
+	bridge, mu, captured := setupBridgeWithCapture(t)
+
+	event, err := events.NewDetectionEvent("Test Bird", "Testus birdus", 0.9, "mic", true, 0)
+	require.NoError(t, err)
+
+	require.NoError(t, bridge.ProcessDetectionEvent(event))
+
+	result := waitForEvents(t, mu, captured, 2)
+	require.Len(t, result, 2)
+
+	// Mutating one event's properties must not affect the other
+	result[0].Properties["test_marker"] = "mutated"
+	_, hasMarker := result[1].Properties["test_marker"]
+	assert.False(t, hasMarker, "property maps should be independent copies")
+}

--- a/internal/alerting/detection_bridge_test.go
+++ b/internal/alerting/detection_bridge_test.go
@@ -73,7 +73,7 @@ func TestBridge_OrdinaryDetection_EmitsOccurredOnly(t *testing.T) {
 	assert.Equal(t, EventDetectionOccurred, result[0].EventName)
 	assert.Equal(t, "Test Bird", result[0].Properties[PropertySpeciesName])
 	assert.InDelta(t, 0.9, result[0].Properties[PropertyConfidence], 0.001)
-	assert.Equal(t, false, result[0].Properties[PropertyIsNewSpecies])
+	assert.False(t, result[0].Properties[PropertyIsNewSpecies].(bool))
 }
 
 func TestBridge_NewSpecies_EmitsBothEvents(t *testing.T) {
@@ -96,7 +96,7 @@ func TestBridge_NewSpecies_EmitsBothEvents(t *testing.T) {
 		assert.Equal(t, "Test Bird", r.Properties[PropertySpeciesName])
 		assert.Equal(t, "Testus birdus", r.Properties[PropertyScientificName])
 		assert.InDelta(t, 0.9, r.Properties[PropertyConfidence], 0.001)
-		assert.Equal(t, true, r.Properties[PropertyIsNewSpecies])
+		assert.True(t, r.Properties[PropertyIsNewSpecies].(bool))
 	}
 }
 

--- a/internal/alerting/schema.go
+++ b/internal/alerting/schema.go
@@ -16,9 +16,10 @@ type ObjectTypeSchema struct {
 
 // EventSchema describes an event trigger and its available properties.
 type EventSchema struct {
-	Name       string           `json:"name"`
-	Label      string           `json:"label"`
-	Properties []PropertySchema `json:"properties"`
+	Name        string           `json:"name"`
+	Label       string           `json:"label"`
+	Description string           `json:"description,omitempty"`
+	Properties  []PropertySchema `json:"properties"`
 }
 
 // MetricSchema describes a metric trigger and its available properties.
@@ -67,8 +68,8 @@ func GetSchema() Schema {
 				Name:  ObjectTypeDetection,
 				Label: "Detection",
 				Events: []EventSchema{
-					{Name: EventDetectionNewSpecies, Label: "New Species Detected", Properties: detectionProperties()},
-					{Name: EventDetectionOccurred, Label: "Detection Occurred", Properties: detectionProperties()},
+					{Name: EventDetectionNewSpecies, Label: "New Species Detected", Description: "Fires when a species is seen for the first time within the tracking window", Properties: detectionProperties()},
+					{Name: EventDetectionOccurred, Label: "Detection Occurred", Description: "Fires for every detection, including new species", Properties: detectionProperties()},
 				},
 			},
 			{

--- a/internal/analysis/processor/actions_database.go
+++ b/internal/analysis/processor/actions_database.go
@@ -149,8 +149,8 @@ func (a *DatabaseAction) ExecuteContext(ctx context.Context, _ any) error {
 		a.DetectionCtx.NoteID.Store(uint64(a.Result.ID))
 	}
 
-	// After successful save, publish detection event for new species
-	a.publishNewSpeciesDetectionEvent(isNewSpecies, daysSinceFirstSeen)
+	// After successful save, publish detection event to the event bus.
+	a.publishDetectionEvent(isNewSpecies, daysSinceFirstSeen)
 
 	// NOTE: Audio export is intentionally NOT performed here.
 	// It runs as a separate action (SaveAudioAction) outside the CompositeAction
@@ -260,24 +260,11 @@ func (a *DatabaseAction) recordNotificationSent(notificationTime time.Time) {
 	}
 }
 
-// publishNewSpeciesDetectionEvent publishes a detection event for new species.
-// This helper method orchestrates notification suppression, event creation, and publishing.
-func (a *DatabaseAction) publishNewSpeciesDetectionEvent(isNewSpecies bool, daysSinceFirstSeen int) {
-	if !isNewSpecies || !events.IsInitialized() {
-		if events.IsInitialized() && !isNewSpecies {
-			GetLogger().Debug("Skipping detection event publish: not a new species",
-				logger.String("component", "analysis.processor.actions"),
-				logger.String("detection_id", a.CorrelationID),
-				logger.String("species", a.Result.Species.CommonName),
-				logger.String("scientific_name", a.Result.Species.ScientificName),
-				logger.Float64("confidence", a.Result.Confidence),
-				logger.String("operation", "skip_detection_event"))
-		}
-		return
-	}
-
-	suppress, notificationTime := a.shouldSuppressNewSpeciesNotification()
-	if suppress {
+// publishDetectionEvent publishes a detection event to the event bus.
+// All detections are published so that alert rules on detection.occurred can fire.
+// New species detections additionally go through suppression and notification recording.
+func (a *DatabaseAction) publishDetectionEvent(isNewSpecies bool, daysSinceFirstSeen int) {
+	if !events.IsInitialized() {
 		return
 	}
 
@@ -286,16 +273,29 @@ func (a *DatabaseAction) publishNewSpeciesDetectionEvent(isNewSpecies bool, days
 		return
 	}
 
-	detectionEvent := a.createDetectionEvent(isNewSpecies, daysSinceFirstSeen)
+	if isNewSpecies {
+		suppress, notificationTime := a.shouldSuppressNewSpeciesNotification()
+		if !suppress {
+			detectionEvent := a.createDetectionEvent(true, daysSinceFirstSeen)
+			if detectionEvent != nil {
+				a.populateEventMetadata(detectionEvent)
+				if published := eventBus.TryPublishDetection(detectionEvent); published {
+					a.recordNotificationSent(notificationTime)
+				}
+			}
+			return
+		}
+		// Suppressed new species still gets published as an ordinary detection
+		// so that detection.occurred alert rules fire for every detection.
+	}
+
+	detectionEvent := a.createDetectionEvent(false, daysSinceFirstSeen)
 	if detectionEvent == nil {
 		return
 	}
 
 	a.populateEventMetadata(detectionEvent)
-
-	if published := eventBus.TryPublishDetection(detectionEvent); published {
-		a.recordNotificationSent(notificationTime)
-	}
+	eventBus.TryPublishDetection(detectionEvent)
 }
 
 // Execute saves the audio clip to a file

--- a/internal/analysis/processor/detection_event_test.go
+++ b/internal/analysis/processor/detection_event_test.go
@@ -29,6 +29,7 @@ const (
 	testDaysWithinWindow      = 5
 	testDaysOutsideWindow     = 15
 	testConsumerName          = "test-detection-consumer"
+	testSuppressionHours      = 168
 )
 
 // TestDetectionEventCreation tests the creation of detection events
@@ -227,9 +228,9 @@ func TestPublishDetectionEvent_SuppressedNewSpecies(t *testing.T) {
 
 	tracker := species.NewTrackerFromSettings(mockDS, &conf.SpeciesTrackingSettings{
 		Enabled:                      true,
-		NewSpeciesWindowDays:         14,
-		SyncIntervalMinutes:          60,
-		NotificationSuppressionHours: 168,
+		NewSpeciesWindowDays:         testWindowDays,
+		SyncIntervalMinutes:          testSyncIntervalMins,
+		NotificationSuppressionHours: testSuppressionHours,
 	})
 
 	det := testDetection()

--- a/internal/analysis/processor/detection_event_test.go
+++ b/internal/analysis/processor/detection_event_test.go
@@ -149,21 +149,21 @@ func (c *testDetectionConsumer) GetReceivedEvents() []events.DetectionEvent {
 	return eventsCopy
 }
 
+func setupEventBusWithConsumer(t *testing.T) *testDetectionConsumer {
+	t.Helper()
+	events.ResetForTesting()
+	t.Cleanup(events.ResetForTesting)
+	eb, err := events.Initialize(&events.Config{BufferSize: 100, Workers: 1, Enabled: true})
+	require.NoError(t, err)
+	c := &testDetectionConsumer{}
+	require.NoError(t, eb.RegisterConsumer(c))
+	return c
+}
+
 // TestPublishDetectionEvent_OrdinaryDetection verifies that non-new-species
 // detections reach the event bus with isNewSpecies=false.
 func TestPublishDetectionEvent_OrdinaryDetection(t *testing.T) {
-	events.ResetForTesting()
-	t.Cleanup(events.ResetForTesting)
-
-	eb, err := events.Initialize(&events.Config{
-		BufferSize: 100,
-		Workers:    1,
-		Enabled:    true,
-	})
-	require.NoError(t, err)
-
-	consumer := &testDetectionConsumer{}
-	require.NoError(t, eb.RegisterConsumer(consumer))
+	consumer := setupEventBusWithConsumer(t)
 
 	det := testDetection()
 	action := &DatabaseAction{
@@ -174,7 +174,6 @@ func TestPublishDetectionEvent_OrdinaryDetection(t *testing.T) {
 
 	action.publishDetectionEvent(false, 30)
 
-	// Give the event bus worker time to deliver
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
 		received := consumer.GetReceivedEvents()
 		assert.Len(collect, received, 1)
@@ -189,18 +188,7 @@ func TestPublishDetectionEvent_OrdinaryDetection(t *testing.T) {
 // TestPublishDetectionEvent_NewSpecies verifies that new-species detections
 // still go through suppression and reach the event bus with isNewSpecies=true.
 func TestPublishDetectionEvent_NewSpecies(t *testing.T) {
-	events.ResetForTesting()
-	t.Cleanup(events.ResetForTesting)
-
-	eb, err := events.Initialize(&events.Config{
-		BufferSize: 100,
-		Workers:    1,
-		Enabled:    true,
-	})
-	require.NoError(t, err)
-
-	consumer := &testDetectionConsumer{}
-	require.NoError(t, eb.RegisterConsumer(consumer))
+	consumer := setupEventBusWithConsumer(t)
 
 	det := testDetection()
 	action := &DatabaseAction{
@@ -225,18 +213,7 @@ func TestPublishDetectionEvent_NewSpecies(t *testing.T) {
 // new species detection still reaches the event bus as an ordinary detection
 // (isNewSpecies=false) so detection.occurred alert rules still fire.
 func TestPublishDetectionEvent_SuppressedNewSpecies(t *testing.T) {
-	events.ResetForTesting()
-	t.Cleanup(events.ResetForTesting)
-
-	eb, err := events.Initialize(&events.Config{
-		BufferSize: 100,
-		Workers:    1,
-		Enabled:    true,
-	})
-	require.NoError(t, err)
-
-	consumer := &testDetectionConsumer{}
-	require.NoError(t, eb.RegisterConsumer(consumer))
+	consumer := setupEventBusWithConsumer(t)
 
 	mockDS := mocks.NewMockInterface(t)
 	mockDS.EXPECT().

--- a/internal/analysis/processor/detection_event_test.go
+++ b/internal/analysis/processor/detection_event_test.go
@@ -6,9 +6,11 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/analysis/species"
 	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/datastore/mocks"
 	"github.com/tphakala/birdnet-go/internal/events"
 )
@@ -145,4 +147,153 @@ func (c *testDetectionConsumer) GetReceivedEvents() []events.DetectionEvent {
 	eventsCopy := make([]events.DetectionEvent, len(c.receivedEvents))
 	copy(eventsCopy, c.receivedEvents)
 	return eventsCopy
+}
+
+// TestPublishDetectionEvent_OrdinaryDetection verifies that non-new-species
+// detections reach the event bus with isNewSpecies=false.
+func TestPublishDetectionEvent_OrdinaryDetection(t *testing.T) {
+	events.ResetForTesting()
+	t.Cleanup(events.ResetForTesting)
+
+	eb, err := events.Initialize(&events.Config{
+		BufferSize: 100,
+		Workers:    1,
+		Enabled:    true,
+	})
+	require.NoError(t, err)
+
+	consumer := &testDetectionConsumer{}
+	require.NoError(t, eb.RegisterConsumer(consumer))
+
+	det := testDetection()
+	action := &DatabaseAction{
+		Settings:      &conf.Settings{Debug: true},
+		Result:        det.Result,
+		CorrelationID: "test-ordinary-det",
+	}
+
+	action.publishDetectionEvent(false, 30)
+
+	// Give the event bus worker time to deliver
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		received := consumer.GetReceivedEvents()
+		assert.Len(collect, received, 1)
+	}, 2*time.Second, 50*time.Millisecond)
+
+	received := consumer.GetReceivedEvents()
+	assert.Equal(t, det.Result.Species.CommonName, received[0].GetSpeciesName())
+	assert.Equal(t, det.Result.Species.ScientificName, received[0].GetScientificName())
+	assert.False(t, received[0].IsNewSpecies())
+}
+
+// TestPublishDetectionEvent_NewSpecies verifies that new-species detections
+// still go through suppression and reach the event bus with isNewSpecies=true.
+func TestPublishDetectionEvent_NewSpecies(t *testing.T) {
+	events.ResetForTesting()
+	t.Cleanup(events.ResetForTesting)
+
+	eb, err := events.Initialize(&events.Config{
+		BufferSize: 100,
+		Workers:    1,
+		Enabled:    true,
+	})
+	require.NoError(t, err)
+
+	consumer := &testDetectionConsumer{}
+	require.NoError(t, eb.RegisterConsumer(consumer))
+
+	det := testDetection()
+	action := &DatabaseAction{
+		Settings:      &conf.Settings{Debug: true},
+		Result:        det.Result,
+		CorrelationID: "test-new-species-det",
+	}
+
+	action.publishDetectionEvent(true, 0)
+
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		received := consumer.GetReceivedEvents()
+		assert.Len(collect, received, 1)
+	}, 2*time.Second, 50*time.Millisecond)
+
+	received := consumer.GetReceivedEvents()
+	assert.Equal(t, det.Result.Species.CommonName, received[0].GetSpeciesName())
+	assert.True(t, received[0].IsNewSpecies())
+}
+
+// TestPublishDetectionEvent_SuppressedNewSpecies verifies that a suppressed
+// new species detection still reaches the event bus as an ordinary detection
+// (isNewSpecies=false) so detection.occurred alert rules still fire.
+func TestPublishDetectionEvent_SuppressedNewSpecies(t *testing.T) {
+	events.ResetForTesting()
+	t.Cleanup(events.ResetForTesting)
+
+	eb, err := events.Initialize(&events.Config{
+		BufferSize: 100,
+		Workers:    1,
+		Enabled:    true,
+	})
+	require.NoError(t, err)
+
+	consumer := &testDetectionConsumer{}
+	require.NoError(t, eb.RegisterConsumer(consumer))
+
+	mockDS := mocks.NewMockInterface(t)
+	mockDS.EXPECT().
+		GetActiveNotificationHistory(mock.AnythingOfType("time.Time")).
+		Return([]datastore.NotificationHistory{}, nil).
+		Maybe()
+	mockDS.EXPECT().
+		SaveNotificationHistory(mock.AnythingOfType("*datastore.NotificationHistory")).
+		Return(nil).
+		Maybe()
+
+	tracker := species.NewTrackerFromSettings(mockDS, &conf.SpeciesTrackingSettings{
+		Enabled:                      true,
+		NewSpeciesWindowDays:         14,
+		SyncIntervalMinutes:          60,
+		NotificationSuppressionHours: 168,
+	})
+
+	det := testDetection()
+	// Record a notification first so next call is suppressed
+	tracker.RecordNotificationSent(det.Result.Species.ScientificName, det.Result.BeginTime)
+
+	action := &DatabaseAction{
+		Settings:          &conf.Settings{Debug: true},
+		Result:            det.Result,
+		CorrelationID:     "test-suppressed",
+		NewSpeciesTracker: tracker,
+	}
+
+	action.publishDetectionEvent(true, 0)
+
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		received := consumer.GetReceivedEvents()
+		assert.Len(collect, received, 1)
+	}, 2*time.Second, 50*time.Millisecond)
+
+	received := consumer.GetReceivedEvents()
+	assert.Equal(t, det.Result.Species.CommonName, received[0].GetSpeciesName())
+	assert.False(t, received[0].IsNewSpecies(), "suppressed new species should publish as ordinary detection")
+}
+
+// TestPublishDetectionEvent_NoEventBus verifies graceful handling when the
+// event bus is not initialized.
+func TestPublishDetectionEvent_NoEventBus(t *testing.T) {
+	events.ResetForTesting()
+	t.Cleanup(events.ResetForTesting)
+
+	det := testDetection()
+	action := &DatabaseAction{
+		Settings:      &conf.Settings{Debug: true},
+		Result:        det.Result,
+		CorrelationID: "test-no-bus",
+	}
+
+	// Should not panic when event bus is not initialized
+	assert.NotPanics(t, func() {
+		action.publishDetectionEvent(false, 10)
+		action.publishDetectionEvent(true, 0)
+	})
 }


### PR DESCRIPTION
## Summary

- All detections now reach the event bus, not just new species. Previously `publishNewSpeciesDetectionEvent` returned early for ordinary detections, making `detection.occurred` alert rules unusable.
- The detection alert bridge emits `detection.occurred` for every detection and additionally emits `detection.new_species` for new species (previously these were mutually exclusive).
- Suppressed new species (duplicate notification window) now fall through to emit `detection.occurred` so alert rules on that event still fire.
- Added `Description` field to the alert schema `EventSchema` with UI rendering in the alert rule editor dropdown.

Fixes #2699

## Changes

**Backend:**
- `actions_database.go`: Renamed `publishNewSpeciesDetectionEvent` to `publishDetectionEvent`. All detections are published. New species go through suppression + notification recording; ordinary detections publish directly. Suppressed new species fall through as ordinary detections.
- `detection_bridge.go`: Bridge emits both `detection.occurred` and `detection.new_species` for new species, with independent property map copies.
- `schema.go`: Added `Description` field to `EventSchema`; detection events include scope descriptions.

**Frontend:**
- `alerts.ts`: Added optional `description` field to `EventSchema` interface.
- `AlertRuleEditor.svelte`: Event dropdown renders description text below the label.

**Tests:**
- `detection_event_test.go`: 4 new tests (ordinary detection, new species, suppressed new species, no event bus).
- `detection_bridge_test.go`: 3 new tests (ordinary emits occurred only, new species emits both, property map independence).

## Test plan

- [x] All existing processor and alerting tests pass with `-race`
- [x] `golangci-lint` zero issues
- [x] Frontend `svelte-check` and `check:all` pass
- [x] Deployed to RPi5 (192.168.4.159), verified detections approved without errors
- [ ] Verify `detection.occurred` alert rule fires for ordinary detections
- [ ] Verify `detection.new_species` alert rule still works
- [ ] Verify no duplicate notifications with both rules configured

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Event descriptions are now included in the event schema and shown in the alert rule editor dropdown.
  * All detections emit a general detection alert; new-species detections also emit a separate new-species alert.

* **Tests**
  * Added tests validating emitted detection alerts, their properties, independence, and suppression behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->