### PR TITLE
fix(processor): use fresh settings for hot-reload support

### DIFF
--- a/internal/analysis/processor/build_clip_path_test.go
+++ b/internal/analysis/processor/build_clip_path_test.go
@@ -37,7 +37,7 @@ func TestBuildClipPath_EmptyTypeFallsBackToWav(t *testing.T) {
 	p := newProcessorWithExportType(t, "")
 	ts := time.Date(2026, 3, 14, 9, 37, 1, 0, time.UTC)
 
-	got := p.buildClipPath("Strix aluco", 0.94, 15, ts)
+	got := p.buildClipPath(p.Settings, "Strix aluco", 0.94, 15, ts)
 
 	assert.True(t, strings.HasSuffix(got, ".wav"),
 		"empty Type should fall back to .wav, got %q", got)
@@ -57,7 +57,7 @@ func TestBuildClipPath_NeverEndsInDot(t *testing.T) {
 	for _, in := range inputs {
 		t.Run("type="+in, func(t *testing.T) {
 			p := newProcessorWithExportType(t, in)
-			got := p.buildClipPath("Strix aluco", 0.94, 15, ts)
+			got := p.buildClipPath(p.Settings, "Strix aluco", 0.94, 15, ts)
 			assert.False(t, strings.HasSuffix(got, "."),
 				"path must never end in bare dot (type=%q, got %q)", in, got)
 			ext := strings.TrimPrefix(strings.TrimSpace(path.Ext(got)), ".")
@@ -77,7 +77,7 @@ func TestBuildClipPath_FallbackWarnsOnlyOnce(t *testing.T) {
 	var wg sync.WaitGroup
 	for range 10 {
 		wg.Go(func() {
-			_ = p.buildClipPath("Strix aluco", 0.94, 15, ts)
+			_ = p.buildClipPath(p.Settings, "Strix aluco", 0.94, 15, ts)
 		})
 	}
 	wg.Wait()

--- a/internal/analysis/processor/clip_name_test.go
+++ b/internal/analysis/processor/clip_name_test.go
@@ -47,7 +47,7 @@ func TestGenerateClipNameWithDuration(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			clipName := p.generateClipNameWithDuration(tt.scientificName, tt.confidence, tt.durationSecs, time.Now())
+			clipName := p.generateClipNameWithDuration(p.Settings, tt.scientificName, tt.confidence, tt.durationSecs, time.Now())
 			for _, want := range tt.wantContains {
 				assert.Contains(t, clipName, want)
 			}

--- a/internal/analysis/processor/daylight_filter.go
+++ b/internal/analysis/processor/daylight_filter.go
@@ -20,7 +20,9 @@ func (p *Processor) SetSunCalc(sc *suncalc.SunCalc) {
 // initDaylightFilter resolves the daylight filter species list at startup.
 // Follows the same pattern as initExtendedCapture(). Safe to re-call on settings refresh.
 func (p *Processor) initDaylightFilter() {
-	if !p.Settings.Realtime.DaylightFilter.Enabled {
+	settings := p.currentSettings()
+
+	if !settings.Realtime.DaylightFilter.Enabled {
 		p.daylightFilterMu.Lock()
 		p.daylightFilterAll = false
 		p.daylightFilterSpecies = nil
@@ -29,7 +31,7 @@ func (p *Processor) initDaylightFilter() {
 	}
 
 	// Skip if location has not been explicitly configured by the user
-	if !p.Settings.BirdNET.LocationConfigured {
+	if !settings.BirdNET.LocationConfigured {
 		GetLogger().Warn("Daylight filter enabled but location not configured, filter will not be active",
 			logger.String("operation", "daylight_filter_init"))
 		p.daylightFilterMu.Lock()
@@ -49,7 +51,7 @@ func (p *Processor) initDaylightFilter() {
 	taxonomyDB := p.getTaxonomyDB()
 
 	isAll, resolved := resolveSpeciesFilter(
-		p.Settings.Realtime.DaylightFilter.Species, labels, taxonomyDB, "daylight_filter",
+		settings.Realtime.DaylightFilter.Species, labels, taxonomyDB, "daylight_filter",
 	)
 
 	// For an exclusionary filter, empty species list means "filter nothing",
@@ -71,13 +73,15 @@ func (p *Processor) initDaylightFilter() {
 
 	GetLogger().Info("Daylight filter enabled for filtered species",
 		logger.Int("species_count", len(resolved)),
-		logger.Int("offset_hours", p.Settings.Realtime.DaylightFilter.Offset),
+		logger.Int("offset_hours", settings.Realtime.DaylightFilter.Offset),
 		logger.String("operation", "daylight_filter_init"))
 }
 
 // isDaylightFilterSpecies checks if a species is in the daylight filter set.
 func (p *Processor) isDaylightFilterSpecies(scientificName string) bool {
-	if !p.Settings.Realtime.DaylightFilter.Enabled {
+	settings := p.currentSettings()
+
+	if !settings.Realtime.DaylightFilter.Enabled {
 		return false
 	}
 
@@ -108,7 +112,8 @@ func (p *Processor) isDaylight(t time.Time) (bool, error) {
 		return false, err
 	}
 
-	offset := time.Duration(p.Settings.Realtime.DaylightFilter.Offset) * time.Hour
+	settings := p.currentSettings()
+	offset := time.Duration(settings.Realtime.DaylightFilter.Offset) * time.Hour
 	daylightStart := sunTimes.CivilDawn.Add(offset)
 	daylightEnd := sunTimes.CivilDusk.Add(-offset)
 
@@ -125,7 +130,9 @@ func (p *Processor) isDaylight(t time.Time) (bool, error) {
 // A detection is discarded when the species is in the filter set AND the
 // detection time falls within the daylight window. Fails open on suncalc errors.
 func (p *Processor) checkDaylightFilter(scientificName string, detectionTime time.Time) bool {
-	if !p.Settings.Realtime.DaylightFilter.Enabled {
+	settings := p.currentSettings()
+
+	if !settings.Realtime.DaylightFilter.Enabled {
 		return false
 	}
 

--- a/internal/analysis/processor/dogbarkfilter.go
+++ b/internal/analysis/processor/dogbarkfilter.go
@@ -18,8 +18,9 @@ func dogBarkFilterTimeLimit() time.Duration {
 
 // CheckDogBarkFilter checks if the species should be filtered based on the last dog bark timestamp.
 func (p *Processor) CheckDogBarkFilter(species string, lastDogBark time.Time) bool {
+	settings := p.currentSettings()
 	species = strings.ToLower(species)
-	if slices.Contains(p.Settings.Realtime.DogBarkFilter.Species, species) {
+	if slices.Contains(settings.Realtime.DogBarkFilter.Species, species) {
 		return time.Since(lastDogBark) <= dogBarkFilterTimeLimit()
 	}
 	return false

--- a/internal/analysis/processor/dynamic_threshold.go
+++ b/internal/analysis/processor/dynamic_threshold.go
@@ -58,6 +58,8 @@ type DynamicThreshold struct {
 
 // addSpeciesToDynamicThresholds adds a species to the dynamic thresholds map if it doesn't already exist.
 func (p *Processor) addSpeciesToDynamicThresholds(modelID, speciesLowercase, scientificName string, baseThreshold float32) {
+	settings := p.currentSettings()
+
 	// Lock the mutex to ensure thread-safe access to the DynamicThresholds map
 	p.thresholdsMutex.Lock()
 	defer p.thresholdsMutex.Unlock()
@@ -69,7 +71,7 @@ func (p *Processor) addSpeciesToDynamicThresholds(modelID, speciesLowercase, sci
 
 	// If it doesn't exist, initialize it
 	if !exists {
-		if p.Settings.Realtime.DynamicThreshold.Debug {
+		if settings.Realtime.DynamicThreshold.Debug {
 			log := GetLogger()
 			log.Debug("Initializing dynamic threshold", logger.String("species", speciesLowercase), logger.String("model_id", modelID))
 		}
@@ -78,7 +80,7 @@ func (p *Processor) addSpeciesToDynamicThresholds(modelID, speciesLowercase, sci
 			CurrentValue:   float64(baseThreshold),
 			Timer:          time.Now(),
 			HighConfCount:  0,
-			ValidHours:     p.Settings.Realtime.DynamicThreshold.ValidHours,
+			ValidHours:     settings.Realtime.DynamicThreshold.ValidHours,
 			ScientificName: scientificName,
 		}
 	} else if existing.ScientificName == "" && scientificName != "" {
@@ -97,6 +99,8 @@ func (p *Processor) getAdjustedConfidenceThreshold(modelID, speciesLowercase str
 	if isCustomThreshold {
 		return baseThreshold
 	}
+
+	settings := p.currentSettings()
 
 	// Lock the mutex to ensure thread-safe access to the DynamicThresholds map
 	p.thresholdsMutex.Lock()
@@ -132,8 +136,8 @@ func (p *Processor) getAdjustedConfidenceThreshold(modelID, speciesLowercase str
 	}
 
 	// Apply minimum threshold enforcement
-	if dt.CurrentValue < p.Settings.Realtime.DynamicThreshold.Min {
-		dt.CurrentValue = p.Settings.Realtime.DynamicThreshold.Min
+	if dt.CurrentValue < settings.Realtime.DynamicThreshold.Min {
+		dt.CurrentValue = settings.Realtime.DynamicThreshold.Min
 	}
 
 	return float32(dt.CurrentValue)
@@ -182,28 +186,29 @@ func (p *Processor) recordThresholdEvent(speciesName, scientificName, modelName 
 // been confirmed (approved), not when first detected. This ensures that false positives
 // (discarded detections) do not trigger threshold learning.
 func (p *Processor) LearnFromApprovedDetection(modelID, speciesLowercase, scientificName string, confidence float32) {
-	if !p.Settings.Realtime.DynamicThreshold.Enabled {
+	settings := p.currentSettings()
+	if !settings.Realtime.DynamicThreshold.Enabled {
 		return
 	}
 
 	// Only learn from detections that exceed the trigger threshold
-	if confidence <= float32(p.Settings.Realtime.DynamicThreshold.Trigger) {
+	if confidence <= float32(settings.Realtime.DynamicThreshold.Trigger) {
 		return
 	}
 
 	// Check if this species has a custom threshold - don't learn for custom thresholds
-	config, exists := lookupSpeciesConfig(p.Settings.Realtime.Species.Config, speciesLowercase, scientificName)
+	config, exists := lookupSpeciesConfig(settings.Realtime.Species.Config, speciesLowercase, scientificName)
 	if exists && config.Threshold > 0 {
 		return
 	}
 
 	// Use global threshold as base (species has no custom threshold)
-	baseThreshold := float32(p.Settings.BirdNET.Threshold)
+	baseThreshold := float32(settings.BirdNET.Threshold)
 
 	// Calculate learning cooldown based on detection window duration
 	// This prevents multiple threshold learnings within a single detection event
-	captureLength := time.Duration(p.Settings.Realtime.Audio.Export.Length) * time.Second
-	preCaptureLength := time.Duration(p.Settings.Realtime.Audio.Export.PreCapture) * time.Second
+	captureLength := time.Duration(settings.Realtime.Audio.Export.Length) * time.Second
+	preCaptureLength := time.Duration(settings.Realtime.Audio.Export.PreCapture) * time.Second
 	learningCooldown := captureLength - preCaptureLength
 	const minCooldown = 5 * time.Second
 	if learningCooldown < minCooldown {
@@ -253,8 +258,8 @@ func (p *Processor) LearnFromApprovedDetection(modelID, speciesLowercase, scient
 	dt.CurrentValue = float64(baseThreshold) * levelMultiplier(dt.Level)
 
 	// Apply minimum threshold clamp
-	if dt.CurrentValue < p.Settings.Realtime.DynamicThreshold.Min {
-		dt.CurrentValue = p.Settings.Realtime.DynamicThreshold.Min
+	if dt.CurrentValue < settings.Realtime.DynamicThreshold.Min {
+		dt.CurrentValue = settings.Realtime.DynamicThreshold.Min
 	}
 
 	// Record event if level changed
@@ -263,7 +268,7 @@ func (p *Processor) LearnFromApprovedDetection(modelID, speciesLowercase, scient
 			previousValue, dt.CurrentValue, changeReasonHighConfidence, float64(confidence))
 	}
 
-	if p.Settings.Realtime.DynamicThreshold.Debug {
+	if settings.Realtime.DynamicThreshold.Debug {
 		log := GetLogger()
 		log.Debug("Learned from approved detection",
 			logger.String("species", speciesLowercase),
@@ -275,7 +280,8 @@ func (p *Processor) LearnFromApprovedDetection(modelID, speciesLowercase, scient
 
 // updateDynamicThreshold updates the dynamic threshold for a given species if enabled.
 func (p *Processor) updateDynamicThreshold(modelID, commonName string, confidence float64) {
-	if p.Settings.Realtime.DynamicThreshold.Enabled {
+	settings := p.currentSettings()
+	if settings.Realtime.DynamicThreshold.Enabled {
 		// Lock the mutex to ensure thread-safe access to the DynamicThresholds map
 		p.thresholdsMutex.Lock()
 		defer p.thresholdsMutex.Unlock()
@@ -284,7 +290,7 @@ func (p *Processor) updateDynamicThreshold(modelID, commonName string, confidenc
 
 		// Check if the species already has a dynamic threshold
 		// Note: scientific name not available in this context, but common name lookup is sufficient
-		if dt, exists := p.DynamicThresholds[key]; exists && confidence > float64(p.getBaseConfidenceThreshold(commonName, "")) {
+		if dt, exists := p.DynamicThresholds[key]; exists && confidence > float64(p.getBaseConfidenceThreshold(settings, commonName, "")) {
 			// Update the timer to extend the threshold's validity
 			// Note: dt is a pointer, so this directly mutates the struct in the map
 			dt.Timer = time.Now().Add(time.Duration(dt.ValidHours) * time.Hour)
@@ -295,9 +301,10 @@ func (p *Processor) updateDynamicThreshold(modelID, commonName string, confidenc
 // cleanUpDynamicThresholds removes stale dynamic thresholds for species that haven't been detected for a long time.
 // This cleans up both the in-memory map and the database.
 func (p *Processor) cleanUpDynamicThresholds() {
+	settings := p.currentSettings()
 	log := GetLogger()
 	// Calculate the duration after which a dynamic threshold is considered stale
-	staleDuration := time.Duration(p.Settings.Realtime.DynamicThreshold.ValidHours) * time.Hour
+	staleDuration := time.Duration(settings.Realtime.DynamicThreshold.ValidHours) * time.Hour
 
 	// Get the current time
 	now := time.Now()
@@ -313,7 +320,7 @@ func (p *Processor) cleanUpDynamicThresholds() {
 		// Check if the threshold for this species is stale
 		if now.Sub(dt.Timer) > staleDuration {
 			// If debug mode is enabled, log the removal of the stale threshold
-			if p.Settings.Realtime.DynamicThreshold.Debug {
+			if settings.Realtime.DynamicThreshold.Debug {
 				log.Debug("removing stale dynamic threshold from memory", logger.String("species", species))
 			}
 			// Remove the stale threshold from the map
@@ -502,8 +509,9 @@ func levelMultiplier(level int) float64 {
 // map (they are filtered out in LearnFromApprovedDetection), so no special handling is needed.
 func (p *Processor) RecalculateDynamicThresholds() {
 	log := GetLogger()
-	newBase := float64(p.Settings.BirdNET.Threshold)
-	minThreshold := p.Settings.Realtime.DynamicThreshold.Min
+	settings := p.currentSettings()
+	newBase := float64(settings.BirdNET.Threshold)
+	minThreshold := settings.Realtime.DynamicThreshold.Min
 
 	p.thresholdsMutex.Lock()
 	defer p.thresholdsMutex.Unlock()
@@ -522,7 +530,7 @@ func (p *Processor) RecalculateDynamicThresholds() {
 			dt.CurrentValue = newValue
 			recalculated++
 
-			if p.Settings.Realtime.DynamicThreshold.Debug {
+			if settings.Realtime.DynamicThreshold.Debug {
 				log.Debug("Recalculated dynamic threshold for new base",
 					logger.String("species", species),
 					logger.Int("level", dt.Level),

--- a/internal/analysis/processor/extended_capture.go
+++ b/internal/analysis/processor/extended_capture.go
@@ -43,7 +43,9 @@ func (p *Processor) RebuildExtendedCaptureFilter() {
 // initExtendedCapture resolves the extended capture species filter at startup.
 // Called from Processor.New(). Safe to re-call on settings refresh.
 func (p *Processor) initExtendedCapture() {
-	if !p.Settings.Realtime.ExtendedCapture.Enabled {
+	settings := p.currentSettings()
+
+	if !settings.Realtime.ExtendedCapture.Enabled {
 		p.extendedCaptureMu.Lock()
 		p.extendedCaptureAll = false
 		p.extendedCaptureSpecies = nil
@@ -61,7 +63,7 @@ func (p *Processor) initExtendedCapture() {
 	taxonomyDB := p.getTaxonomyDB()
 
 	isAll, resolved := resolveSpeciesFilter(
-		p.Settings.Realtime.ExtendedCapture.Species, labels, taxonomyDB, "extended_capture",
+		settings.Realtime.ExtendedCapture.Species, labels, taxonomyDB, "extended_capture",
 	)
 
 	p.extendedCaptureMu.Lock()
@@ -71,19 +73,21 @@ func (p *Processor) initExtendedCapture() {
 
 	if isAll {
 		GetLogger().Info("Extended capture enabled for all species",
-			logger.Int("max_duration_seconds", p.Settings.Realtime.ExtendedCapture.MaxDuration),
+			logger.Int("max_duration_seconds", settings.Realtime.ExtendedCapture.MaxDuration),
 			logger.String("operation", "extended_capture_init"))
 	} else {
 		GetLogger().Info("Extended capture enabled for filtered species",
 			logger.Int("species_count", len(resolved)),
-			logger.Int("max_duration_seconds", p.Settings.Realtime.ExtendedCapture.MaxDuration),
+			logger.Int("max_duration_seconds", settings.Realtime.ExtendedCapture.MaxDuration),
 			logger.String("operation", "extended_capture_init"))
 	}
 }
 
 // isExtendedCaptureSpecies checks if a species qualifies for extended capture.
 func (p *Processor) isExtendedCaptureSpecies(scientificName string) bool {
-	if !p.Settings.Realtime.ExtendedCapture.Enabled {
+	settings := p.currentSettings()
+
+	if !settings.Realtime.ExtendedCapture.Enabled {
 		return false
 	}
 
@@ -180,10 +184,11 @@ func resolveSpeciesFilter(configSpecies, labels []string, taxonomyDB *classifier
 //
 // For extended captures the clip name is regenerated to reflect the actual duration.
 func (p *Processor) normalizeDetectionTimes(item *PendingDetection) {
+	settings := p.currentSettings()
 	item.Detection.Result.BeginTime = item.FirstDetected
 
-	captureLength := time.Duration(p.Settings.Realtime.Audio.Export.Length) * time.Second
-	preCaptureLength := time.Duration(p.Settings.Realtime.Audio.Export.PreCapture) * time.Second
+	captureLength := time.Duration(settings.Realtime.Audio.Export.Length) * time.Second
+	preCaptureLength := time.Duration(settings.Realtime.Audio.Export.PreCapture) * time.Second
 	normalDetectionWindow := max(time.Duration(0), captureLength-preCaptureLength)
 
 	if item.ExtendedCapture {
@@ -192,9 +197,10 @@ func (p *Processor) normalizeDetectionTimes(item *PendingDetection) {
 		item.Detection.Result.EndTime = item.LastUpdated.Add(normalDetectionWindow)
 
 		// Regenerate clip name with actual duration (unknown at createDetection time)
-		preCapture := p.Settings.Realtime.Audio.Export.PreCapture
+		preCapture := settings.Realtime.Audio.Export.PreCapture
 		durationSeconds := int(item.Detection.Result.EndTime.Sub(item.Detection.Result.BeginTime).Seconds()) + preCapture
 		item.Detection.Result.ClipName = p.generateClipNameWithDuration(
+			settings,
 			item.Detection.Result.Species.ScientificName,
 			float32(item.Confidence),
 			durationSeconds,
@@ -215,8 +221,9 @@ func (p *Processor) normalizeDetectionTimes(item *PendingDetection) {
 // This is called from processDetections after the pending detection is created/updated.
 // Must be called while pendingMutex is held.
 func (p *Processor) applyExtendedCapture(mapKey string, now time.Time, normalDetectionWindow time.Duration) {
+	settings := p.currentSettings()
 	item := p.pendingDetections[mapKey]
-	maxDuration := time.Duration(p.Settings.Realtime.ExtendedCapture.MaxDuration) * time.Second
+	maxDuration := time.Duration(settings.Realtime.ExtendedCapture.MaxDuration) * time.Second
 
 	if !item.ExtendedCapture {
 		// First time: set extended capture flag and absolute deadline

--- a/internal/analysis/processor/mqtt.go
+++ b/internal/analysis/processor/mqtt.go
@@ -207,9 +207,10 @@ func (p *Processor) publishHomeAssistantDiscovery(ctx context.Context, client mq
 // This can be called from the API to force republishing of discovery messages.
 func (p *Processor) TriggerHomeAssistantDiscovery(ctx context.Context) error {
 	log := GetLogger()
+	settings := p.currentSettings()
 
 	// Guard against nil settings during startup/teardown
-	if p.Settings == nil {
+	if settings == nil {
 		return errors.Newf("settings not initialized").
 			Component("analysis.processor").
 			Category(errors.CategoryConfiguration).
@@ -218,14 +219,14 @@ func (p *Processor) TriggerHomeAssistantDiscovery(ctx context.Context) error {
 	}
 
 	// Check if MQTT is enabled and Home Assistant discovery is enabled
-	if !p.Settings.Realtime.MQTT.Enabled {
+	if !settings.Realtime.MQTT.Enabled {
 		return errors.Newf("MQTT is not enabled").
 			Component("analysis.processor").
 			Category(errors.CategoryConfiguration).
 			Context("operation", "trigger_ha_discovery").
 			Build()
 	}
-	if !p.Settings.Realtime.MQTT.HomeAssistant.Enabled {
+	if !settings.Realtime.MQTT.HomeAssistant.Enabled {
 		return errors.Newf("home assistant discovery is not enabled").
 			Component("analysis.processor").
 			Category(errors.CategoryConfiguration).
@@ -249,7 +250,7 @@ func (p *Processor) TriggerHomeAssistantDiscovery(ctx context.Context) error {
 	publishCtx, cancel := context.WithTimeout(ctx, discoveryPublishTimeout)
 	defer cancel()
 
-	if err := p.publishHomeAssistantDiscovery(publishCtx, client, p.Settings); err != nil {
+	if err := p.publishHomeAssistantDiscovery(publishCtx, client, settings); err != nil {
 		log.Error("Failed to publish Home Assistant discovery", logger.Error(err))
 		return errors.New(err).
 			Component("analysis.processor").

--- a/internal/analysis/processor/processor.go
+++ b/internal/analysis/processor/processor.go
@@ -168,6 +168,13 @@ type Processor struct {
 	invalidCommandPaths sync.Map
 }
 
+// currentSettings returns the latest settings snapshot so UI changes to
+// detection thresholds, filters, and export config take effect on the next
+// processing cycle without restarting the service.
+func (p *Processor) currentSettings() *conf.Settings {
+	return conf.CurrentOrFallback(p.Settings)
+}
+
 type Detections struct {
 	CorrelationID string                       // Unique detection identifier for log correlation
 	pcmData3s     []byte                       // 3s PCM data containing the detection
@@ -605,18 +612,22 @@ func (p *Processor) processDetections(item classifier.Results) {
 		logger.Int64("elapsed_time_ms", item.ElapsedTime.Milliseconds()),
 		logger.String("operation", "process_detections_entry"))
 
+	// Capture a settings snapshot once so every decision in this cycle
+	// uses a consistent, hot-reloadable view of the configuration.
+	settings := p.currentSettings()
+
 	// Detection window sets wait time before a detection is considered final and is flushed.
 	// This represents the duration to wait from NOW (detection creation time) before flushing,
 	// allowing overlapping analyses to accumulate confirmations for false positive filtering.
-	captureLength := time.Duration(p.Settings.Realtime.Audio.Export.Length) * time.Second
-	preCaptureLength := time.Duration(p.Settings.Realtime.Audio.Export.PreCapture) * time.Second
+	captureLength := time.Duration(settings.Realtime.Audio.Export.Length) * time.Second
+	preCaptureLength := time.Duration(settings.Realtime.Audio.Export.PreCapture) * time.Second
 	// Ensure detectionWindow is non-negative to prevent early flushes
 	detectionWindow := max(time.Duration(0), captureLength-preCaptureLength)
 
 	// processResults() returns a slice of detections, we iterate through each and process them
 	// detections are put into pendingDetections map where they are held until flush deadline is reached
 	// once deadline is reached detections are delivered to workers for actions (save to db etc) processing
-	detectionResults := p.processResults(item)
+	detectionResults := p.processResults(settings, item)
 
 	// Log processing results with deduplication to prevent spam
 	p.logDetectionResults(item.Source.ID, len(item.Results), len(detectionResults))
@@ -691,7 +702,7 @@ func (p *Processor) processDetections(item classifier.Results) {
 
 	// Broadcast updated pending detections snapshot for "currently hearing" UI.
 	// This runs after all new detections are incorporated into pendingDetections.
-	minDet := p.calculateMinDetections()
+	minDet := calculateMinDetectionsFromSettings(settings)
 	snapshot := p.SnapshotVisiblePending(minDet)
 	p.broadcastPendingSnapshot(snapshot)
 }
@@ -699,12 +710,12 @@ func (p *Processor) processDetections(item classifier.Results) {
 // processResults processes the results from the BirdNET prediction and returns a list of detections.
 //
 //nolint:gocritic // hugeParam: Pass by value is intentional - avoids pointer dereferencing in hot path
-func (p *Processor) processResults(item classifier.Results) []Detections {
+func (p *Processor) processResults(settings *conf.Settings, item classifier.Results) []Detections {
 	// Pre-allocate slice with capacity for all results
 	detections := make([]Detections, 0, len(item.Results))
 
 	// Collect processing time metric
-	if p.Settings.Realtime.Telemetry.Enabled && p.Metrics != nil && p.Metrics.BirdNET != nil {
+	if settings.Realtime.Telemetry.Enabled && p.Metrics != nil && p.Metrics.BirdNET != nil {
 		p.Metrics.BirdNET.SetProcessTime(float64(item.ElapsedTime.Milliseconds()))
 	}
 
@@ -714,10 +725,10 @@ func (p *Processor) processResults(item classifier.Results) []Detections {
 	// Process each result in item.Results
 	for _, result := range item.Results {
 		// Parse and validate species information
-		scientificName, commonName, speciesCode, speciesLowercase := p.parseAndValidateSpecies(result, item)
+		scientificName, commonName, speciesCode, speciesLowercase := p.parseAndValidateSpecies(settings, result, item)
 		// Skip if either scientific or common name is missing (partial/invalid parsing)
 		if scientificName == "" || commonName == "" {
-			if p.Settings.Debug {
+			if settings.Debug {
 				GetLogger().Debug("Skipping partially parsed species",
 					logger.String("scientific_name", scientificName),
 					logger.String("common_name", commonName),
@@ -732,20 +743,20 @@ func (p *Processor) processResults(item classifier.Results) []Detections {
 
 		// Handle dog and human detection, this sets LastDogDetection and LastHumanDetection which is
 		// later used to discard detection if privacy filter or dog bark filters are enabled in settings.
-		p.handleDogDetection(item, speciesLowercase, result)
-		p.handleHumanDetection(item, speciesLowercase, result)
+		p.handleDogDetection(settings, item, speciesLowercase, result)
+		p.handleHumanDetection(settings, item, speciesLowercase, result)
 
 		// Determine confidence threshold and check filters
-		baseThreshold := p.getBaseConfidenceThreshold(commonName, scientificName)
+		baseThreshold := p.getBaseConfidenceThreshold(settings, commonName, scientificName)
 
 		// Check if detection should be filtered
-		shouldSkip, _ := p.shouldFilterDetection(result, commonName, scientificName, speciesLowercase, baseThreshold, item.Source.ID, item.ModelID)
+		shouldSkip, _ := p.shouldFilterDetection(settings, result, commonName, scientificName, speciesLowercase, baseThreshold, item.Source.ID, item.ModelID)
 		if shouldSkip {
 			continue
 		}
 
 		// Create the detection
-		det := p.createDetection(item, result, scientificName, commonName, speciesCode)
+		det := p.createDetection(settings, item, result, scientificName, commonName, speciesCode)
 		detections = append(detections, det)
 	}
 
@@ -755,14 +766,14 @@ func (p *Processor) processResults(item classifier.Results) []Detections {
 // parseAndValidateSpecies parses species information and validates it
 //
 //nolint:gocritic // hugeParam: Pass by value is intentional - avoids pointer dereferencing in hot path
-func (p *Processor) parseAndValidateSpecies(result datastore.Results, item classifier.Results) (scientificName, commonName, speciesCode, speciesLowercase string) {
+func (p *Processor) parseAndValidateSpecies(settings *conf.Settings, result datastore.Results, item classifier.Results) (scientificName, commonName, speciesCode, speciesLowercase string) {
 	// Use BirdNET's EnrichResultWithTaxonomy to get species information
 	scientificName, commonName, speciesCode = p.Bn.EnrichResultWithTaxonomy(result.Species)
 
 	// Skip processing if scientific name is missing. Common name may be empty
 	// for models like Perch v2 that return scientific-name-only labels.
 	if scientificName == "" {
-		if p.Settings.Debug {
+		if settings.Debug {
 			GetLogger().Debug("Skipping species with invalid format",
 				logger.String("species", result.Species),
 				logger.Float32("confidence", result.Confidence),
@@ -777,7 +788,7 @@ func (p *Processor) parseAndValidateSpecies(result datastore.Results, item class
 	}
 
 	// Log placeholder taxonomy codes if using custom model
-	if p.Settings.BirdNET.ModelPath != "" && p.Settings.Debug && speciesCode != "" {
+	if settings.BirdNET.ModelPath != "" && settings.Debug && speciesCode != "" {
 		if len(speciesCode) == 8 && (speciesCode[:2] == "XX" || (speciesCode[0] >= 'A' && speciesCode[0] <= 'Z' && speciesCode[1] >= 'A' && speciesCode[1] <= 'Z')) {
 			GetLogger().Debug("using placeholder taxonomy code",
 				logger.String("taxonomy_code", speciesCode),
@@ -797,7 +808,7 @@ func (p *Processor) parseAndValidateSpecies(result datastore.Results, item class
 }
 
 // shouldFilterDetection checks if a detection should be filtered out
-func (p *Processor) shouldFilterDetection(result datastore.Results, commonName, scientificName, speciesLowercase string, baseThreshold float32, source, modelID string) (shouldFilter bool, confidenceThreshold float32) {
+func (p *Processor) shouldFilterDetection(settings *conf.Settings, result datastore.Results, commonName, scientificName, speciesLowercase string, baseThreshold float32, source, modelID string) (shouldFilter bool, confidenceThreshold float32) {
 	// Check human detection privacy filter
 	if strings.Contains(strings.ToLower(commonName), speciesHuman) && result.Confidence > baseThreshold {
 		return true, 0 // Filter out human detections for privacy
@@ -808,8 +819,8 @@ func (p *Processor) shouldFilterDetection(result datastore.Results, commonName, 
 	// species when building the included list, but that only works when the range filter
 	// model is active and location is configured. This check ensures excluded species are
 	// always filtered regardless of range filter state.
-	if isSpeciesExcluded(commonName, scientificName, p.Settings.Realtime.Species.Exclude) {
-		if p.Settings.Debug {
+	if isSpeciesExcluded(commonName, scientificName, settings.Realtime.Species.Exclude) {
+		if settings.Debug {
 			GetLogger().Debug("Detection filtered: species is on exclude list",
 				logger.String("species", result.Species),
 				logger.Float32("confidence", result.Confidence),
@@ -819,11 +830,11 @@ func (p *Processor) shouldFilterDetection(result datastore.Results, commonName, 
 	}
 
 	// Determine confidence threshold
-	if p.Settings.Realtime.DynamicThreshold.Enabled {
+	if settings.Realtime.DynamicThreshold.Enabled {
 		// Check if this species has a custom user-configured threshold (> 0)
 		// Species may be in Config only for custom actions/interval without threshold set
 		// Use lookupSpeciesConfig to support both common name and scientific name lookups
-		config, exists := lookupSpeciesConfig(p.Settings.Realtime.Species.Config, commonName, scientificName)
+		config, exists := lookupSpeciesConfig(settings.Realtime.Species.Config, commonName, scientificName)
 		isCustomThreshold := exists && config.Threshold > 0
 		confidenceThreshold = p.getAdjustedConfidenceThreshold(modelID, speciesLowercase, baseThreshold, isCustomThreshold)
 	} else {
@@ -832,7 +843,7 @@ func (p *Processor) shouldFilterDetection(result datastore.Results, commonName, 
 
 	// Check confidence threshold
 	if result.Confidence <= confidenceThreshold {
-		if p.Settings.Debug {
+		if settings.Debug {
 			GetLogger().Debug("Detection filtered out due to low confidence",
 				logger.String("species", result.Species),
 				logger.Float32("confidence", result.Confidence),
@@ -845,8 +856,8 @@ func (p *Processor) shouldFilterDetection(result datastore.Results, commonName, 
 	}
 
 	// Check species inclusion filter
-	if !p.Settings.IsSpeciesIncluded(result.Species) {
-		if p.Settings.Debug {
+	if !settings.IsSpeciesIncluded(result.Species) {
+		if settings.Debug {
 			GetLogger().Debug("species not on included list",
 				logger.String("species", result.Species),
 				logger.Float32("confidence", result.Confidence),
@@ -873,13 +884,13 @@ func isSpeciesExcluded(commonName, scientificName string, excludeList []string) 
 // createDetection creates a detection object with all necessary information
 //
 //nolint:gocritic // hugeParam: Pass by value is intentional - avoids pointer dereferencing in hot path
-func (p *Processor) createDetection(item classifier.Results, result datastore.Results, scientificName, commonName, speciesCode string) Detections {
+func (p *Processor) createDetection(settings *conf.Settings, item classifier.Results, result datastore.Results, scientificName, commonName, speciesCode string) Detections {
 	// Create file name for audio clip
-	clipName := p.generateClipName(scientificName, result.Confidence)
+	clipName := p.generateClipName(settings, scientificName, result.Confidence)
 
 	// Get capture length and pre-capture length for detection end time calculation
-	captureLength := time.Duration(p.Settings.Realtime.Audio.Export.Length) * time.Second
-	preCaptureLength := time.Duration(p.Settings.Realtime.Audio.Export.PreCapture) * time.Second
+	captureLength := time.Duration(settings.Realtime.Audio.Export.Length) * time.Second
+	preCaptureLength := time.Duration(settings.Realtime.Audio.Export.PreCapture) * time.Second
 
 	// Set begin and end time for note
 	beginTime := item.StartTime
@@ -893,7 +904,7 @@ func (p *Processor) createDetection(item classifier.Results, result datastore.Re
 	detectionTime := time.Now().Add(-detection.DetectionTimeOffset)
 
 	// Create the detection.Result
-	detectionResult := p.createDetectionResult(
+	detectionResult := p.createDetectionResult(settings,
 		detectionTime,
 		beginTime, endTime,
 		scientificName, commonName, speciesCode,
@@ -927,7 +938,7 @@ func (p *Processor) createDetection(item classifier.Results, result datastore.Re
 // createDetectionResult creates a detection.Result from the given parameters.
 // detectionTime should be pre-computed by the caller to ensure timestamp consistency
 // with other detection artifacts (e.g., Note) created from the same analysis.
-func (p *Processor) createDetectionResult(
+func (p *Processor) createDetectionResult(settings *conf.Settings,
 	detectionTime time.Time,
 	beginTime, endTime time.Time,
 	scientificName, commonName, speciesCode string,
@@ -941,7 +952,7 @@ func (p *Processor) createDetectionResult(
 
 	return detection.Result{
 		Timestamp:   detectionTime,
-		SourceNode:  p.Settings.Main.Name,
+		SourceNode:  settings.Main.Name,
 		AudioSource: audioSource,
 		BeginTime:   beginTime,
 		EndTime:     endTime,
@@ -951,10 +962,10 @@ func (p *Processor) createDetectionResult(
 			Code:           speciesCode,
 		},
 		Confidence:     math.Round(confidence*100) / 100,
-		Latitude:       p.Settings.BirdNET.Latitude,
-		Longitude:      p.Settings.BirdNET.Longitude,
-		Threshold:      p.Settings.BirdNET.Threshold,
-		Sensitivity:    p.Settings.BirdNET.Sensitivity,
+		Latitude:       settings.BirdNET.Latitude,
+		Longitude:      settings.BirdNET.Longitude,
+		Threshold:      settings.BirdNET.Threshold,
+		Sensitivity:    settings.BirdNET.Sensitivity,
 		ClipName:       clipName,
 		ProcessingTime: elapsedTime,
 		Occurrence:     math.Max(0.0, math.Min(1.0, occurrence)),
@@ -1056,12 +1067,12 @@ func (p *Processor) syncSpeciesTrackerIfNeeded() {
 // handleDogDetection handles the detection of dog barks and updates the last detection timestamp.
 //
 //nolint:gocritic // hugeParam: Pass by value is intentional - avoids pointer dereferencing in hot path
-func (p *Processor) handleDogDetection(item classifier.Results, speciesLowercase string, result datastore.Results) {
-	if p.Settings.Realtime.DogBarkFilter.Enabled && strings.Contains(speciesLowercase, speciesDog) &&
-		result.Confidence > p.Settings.Realtime.DogBarkFilter.Confidence {
+func (p *Processor) handleDogDetection(settings *conf.Settings, item classifier.Results, speciesLowercase string, result datastore.Results) {
+	if settings.Realtime.DogBarkFilter.Enabled && strings.Contains(speciesLowercase, speciesDog) &&
+		result.Confidence > settings.Realtime.DogBarkFilter.Confidence {
 		GetLogger().Info("dog detection filtered",
 			logger.Float32("confidence", result.Confidence),
-			logger.Float32("threshold", float32(p.Settings.Realtime.DogBarkFilter.Confidence)),
+			logger.Float32("threshold", float32(settings.Realtime.DogBarkFilter.Confidence)),
 			logger.String("source", item.Source.DisplayName),
 			logger.String("operation", "dog_bark_filter"))
 		p.detectionMutex.Lock()
@@ -1073,13 +1084,13 @@ func (p *Processor) handleDogDetection(item classifier.Results, speciesLowercase
 // handleHumanDetection handles the detection of human vocalizations and updates the last detection timestamp.
 //
 //nolint:gocritic // hugeParam: Pass by value is intentional - avoids pointer dereferencing in hot path
-func (p *Processor) handleHumanDetection(item classifier.Results, speciesLowercase string, result datastore.Results) {
+func (p *Processor) handleHumanDetection(settings *conf.Settings, item classifier.Results, speciesLowercase string, result datastore.Results) {
 	// only check this if privacy filter is enabled
-	if p.Settings.Realtime.PrivacyFilter.Enabled && strings.Contains(speciesLowercase, "human ") &&
-		result.Confidence > p.Settings.Realtime.PrivacyFilter.Confidence {
+	if settings.Realtime.PrivacyFilter.Enabled && strings.Contains(speciesLowercase, "human ") &&
+		result.Confidence > settings.Realtime.PrivacyFilter.Confidence {
 		GetLogger().Info("human detection filtered",
 			logger.Float32("confidence", result.Confidence),
-			logger.Float32("threshold", float32(p.Settings.Realtime.PrivacyFilter.Confidence)),
+			logger.Float32("threshold", float32(settings.Realtime.PrivacyFilter.Confidence)),
 			logger.String("source", item.Source.DisplayName),
 			logger.String("operation", "privacy_filter"))
 		// put human detection timestamp into LastHumanDetection map. This is used to discard
@@ -1092,10 +1103,10 @@ func (p *Processor) handleHumanDetection(item classifier.Results, speciesLowerca
 
 // getBaseConfidenceThreshold retrieves the confidence threshold for a species, using custom or global thresholds.
 // It supports lookup by both common name and scientific name for consistency with include/exclude matching.
-func (p *Processor) getBaseConfidenceThreshold(commonName, scientificName string) float32 {
+func (p *Processor) getBaseConfidenceThreshold(settings *conf.Settings, commonName, scientificName string) float32 {
 	// Check if species has a custom threshold using both common and scientific name lookup
-	if config, exists := lookupSpeciesConfig(p.Settings.Realtime.Species.Config, commonName, scientificName); exists {
-		if p.Settings.Debug {
+	if config, exists := lookupSpeciesConfig(settings.Realtime.Species.Config, commonName, scientificName); exists {
+		if settings.Debug {
 			GetLogger().Debug("using custom confidence threshold",
 				logger.String("commonName", commonName),
 				logger.String("scientificName", scientificName),
@@ -1106,19 +1117,19 @@ func (p *Processor) getBaseConfidenceThreshold(commonName, scientificName string
 	}
 
 	// Fall back to global threshold
-	return float32(p.Settings.BirdNET.Threshold)
+	return float32(settings.BirdNET.Threshold)
 }
 
 // generateClipName generates a clip name for the given scientific name and confidence.
-func (p *Processor) generateClipName(scientificName string, confidence float32) string {
-	return p.buildClipPath(scientificName, confidence, 0, time.Now())
+func (p *Processor) generateClipName(settings *conf.Settings, scientificName string, confidence float32) string {
+	return p.buildClipPath(settings, scientificName, confidence, 0, time.Now())
 }
 
 // generateClipNameWithDuration creates a clip filename with duration suffix.
 // Format: year/month/scientific_name_CONFp_TIMESTAMP_DURs.ext
 // detectionTime should be the original detection timestamp (not flush time).
-func (p *Processor) generateClipNameWithDuration(scientificName string, confidence float32, durationSeconds int, detectionTime time.Time) string {
-	return p.buildClipPath(scientificName, confidence, durationSeconds, detectionTime)
+func (p *Processor) generateClipNameWithDuration(settings *conf.Settings, scientificName string, confidence float32, durationSeconds int, detectionTime time.Time) string {
+	return p.buildClipPath(settings, scientificName, confidence, durationSeconds, detectionTime)
 }
 
 // buildClipPathFallbackOnce guards the one-shot WARN log emitted when
@@ -1136,14 +1147,14 @@ var (
 
 // buildClipPath constructs a clip file path with optional duration suffix.
 // When durationSeconds is 0, the duration suffix is omitted.
-func (p *Processor) buildClipPath(scientificName string, confidence float32, durationSeconds int, t time.Time) string {
+func (p *Processor) buildClipPath(settings *conf.Settings, scientificName string, confidence float32, durationSeconds int, t time.Time) string {
 	formattedName := strings.ToLower(strings.ReplaceAll(scientificName, " ", "_"))
 	formattedConfidence := fmt.Sprintf("%.0fp", confidence*100)
 	timestamp := t.Format("20060102T150405Z")
 	year := t.Format("2006")
 	month := t.Format("01")
 
-	rawExportType := p.Settings.Realtime.Audio.Export.Type
+	rawExportType := settings.Realtime.Audio.Export.Type
 	// GetFileExtension is a passthrough for unknown formats, so a whitespace-
 	// only Type would otherwise leak into the filename as a ". " suffix.
 	fileType := convert.GetFileExtension(strings.TrimSpace(rawExportType))
@@ -1169,6 +1180,8 @@ func (p *Processor) buildClipPath(scientificName string, confidence float32, dur
 
 // shouldDiscardDetection checks if a detection should be discarded based on various criteria
 func (p *Processor) shouldDiscardDetection(item *PendingDetection, minDetections int) (shouldDiscard bool, reason string) {
+	settings := p.currentSettings()
+
 	// Check minimum detection count
 	if item.Count < minDetections {
 		// Add structured logging for minimum count filtering
@@ -1182,7 +1195,7 @@ func (p *Processor) shouldDiscardDetection(item *PendingDetection, minDetections
 	}
 
 	// Check privacy filter
-	if p.Settings.Realtime.PrivacyFilter.Enabled {
+	if settings.Realtime.PrivacyFilter.Enabled {
 		p.detectionMutex.RLock()
 		lastHumanDetection, exists := p.LastHumanDetection[item.Source]
 		p.detectionMutex.RUnlock()
@@ -1199,8 +1212,8 @@ func (p *Processor) shouldDiscardDetection(item *PendingDetection, minDetections
 	}
 
 	// Check dog bark filter
-	if p.Settings.Realtime.DogBarkFilter.Enabled {
-		if p.Settings.Realtime.DogBarkFilter.Debug {
+	if settings.Realtime.DogBarkFilter.Enabled {
+		if settings.Realtime.DogBarkFilter.Debug {
 			p.detectionMutex.RLock()
 			GetLogger().Debug("last dog detection status",
 				logger.Any("last_detections", p.LastDogDetection),
@@ -1224,8 +1237,8 @@ func (p *Processor) shouldDiscardDetection(item *PendingDetection, minDetections
 	}
 
 	// Check daylight filter
-	if p.Settings.Realtime.DaylightFilter.Enabled {
-		if p.Settings.Realtime.DaylightFilter.Debug {
+	if settings.Realtime.DaylightFilter.Enabled {
+		if settings.Realtime.DaylightFilter.Debug {
 			GetLogger().Debug("Daylight filter check",
 				logger.String("species", item.Detection.Result.Species.CommonName),
 				logger.String("scientific_name", item.Detection.Result.Species.ScientificName),
@@ -1251,6 +1264,8 @@ func (p *Processor) shouldDiscardDetection(item *PendingDetection, minDetections
 
 // processApprovedDetection handles an approved detection by sending it to the worker queue
 func (p *Processor) processApprovedDetection(item *PendingDetection, speciesName string) {
+	settings := p.currentSettings()
+
 	// Use item.Confidence directly - it's the correct confidence for THIS species,
 	// not Results[0].Confidence which could be a different (higher confidence) species
 	confidence := float32(item.Confidence)
@@ -1293,7 +1308,7 @@ func (p *Processor) processApprovedDetection(item *PendingDetection, speciesName
 	}
 
 	// Update BirdNET metrics detection counter if enabled
-	if p.Settings.Realtime.Telemetry.Enabled && p.Metrics != nil && p.Metrics.BirdNET != nil {
+	if settings.Realtime.Telemetry.Enabled && p.Metrics != nil && p.Metrics.BirdNET != nil {
 		p.Metrics.BirdNET.IncrementDetectionCounter(item.Detection.Result.Species.CommonName)
 	}
 }
@@ -1398,7 +1413,7 @@ func calculateMinDetectionsFromSettings(settings *conf.Settings) int {
 // calculateMinDetections is a convenience method that calls calculateMinDetectionsFromSettings
 // with the processor's settings.
 func (p *Processor) calculateMinDetections() int {
-	return calculateMinDetectionsFromSettings(p.Settings)
+	return calculateMinDetectionsFromSettings(p.currentSettings())
 }
 
 // flushPendingDetections processes one flush cycle, flushing eligible detections.
@@ -1549,9 +1564,11 @@ func (p *Processor) pendingDetectionsFlusher() {
 
 // getActionsForItem determines the actions to be taken for a given detection.
 func (p *Processor) getActionsForItem(det *Detections) []Action {
+	settings := p.currentSettings()
+
 	// Check if species has custom configuration using both common and scientific name lookup
-	if speciesConfig, exists := lookupSpeciesConfig(p.Settings.Realtime.Species.Config, det.Result.Species.CommonName, det.Result.Species.ScientificName); exists {
-		if p.Settings.Debug {
+	if speciesConfig, exists := lookupSpeciesConfig(settings.Realtime.Species.Config, det.Result.Species.CommonName, det.Result.Species.ScientificName); exists {
+		if settings.Debug {
 			GetLogger().Debug("species config exists for custom actions",
 				logger.String("commonName", det.Result.Species.CommonName),
 				logger.String("scientificName", det.Result.Species.ScientificName),
@@ -1695,6 +1712,8 @@ func parseCommandParams(params []string, det *Detections) map[string]any {
 
 // getDefaultActions returns the default actions to be taken for a given detection.
 func (p *Processor) getDefaultActions(det *Detections) []Action {
+	settings := p.currentSettings()
+
 	var actions []Action
 	var databaseAction *DatabaseAction
 	var sseAction *SSEAction
@@ -1706,9 +1725,9 @@ func (p *Processor) getDefaultActions(det *Detections) []Action {
 	detectionCtx := &DetectionContext{}
 
 	// Append various default actions based on the application settings
-	if p.Settings.Realtime.Log.Enabled {
+	if settings.Realtime.Log.Enabled {
 		actions = append(actions, &LogAction{
-			Settings:      p.Settings,
+			Settings:      settings,
 			EventTracker:  p.GetEventTracker(),
 			Result:        det.Result,
 			CorrelationID: det.CorrelationID,
@@ -1716,13 +1735,13 @@ func (p *Processor) getDefaultActions(det *Detections) []Action {
 	}
 
 	// Create DatabaseAction if database is enabled
-	if p.Settings.Output.SQLite.Enabled || p.Settings.Output.MySQL.Enabled {
+	if settings.Output.SQLite.Enabled || settings.Output.MySQL.Enabled {
 		p.speciesTrackerMu.RLock()
 		tracker := p.NewSpeciesTracker
 		p.speciesTrackerMu.RUnlock()
 
 		databaseAction = &DatabaseAction{
-			Settings:          p.Settings,
+			Settings:          settings,
 			EventTracker:      p.GetEventTracker(),
 			NewSpeciesTracker: tracker,
 			processor:         p,            // Add processor reference for source name resolution
@@ -1747,7 +1766,7 @@ func (p *Processor) getDefaultActions(det *Detections) []Action {
 		}
 
 		sseAction = &SSEAction{
-			Settings:       p.Settings,
+			Settings:       settings,
 			Result:         det.Result, // Domain model (single source of truth)
 			BirdImageCache: p.BirdImageCache,
 			EventTracker:   p.GetEventTracker(),
@@ -1762,20 +1781,20 @@ func (p *Processor) getDefaultActions(det *Detections) []Action {
 	// NOTE: We intentionally do NOT check IsConnected() here. The connection state
 	// at action-creation time is stale by the time the action executes from the job queue
 	// (TOCTOU Layer 1, GitHub #2397). The publish path handles disconnected state gracefully.
-	if p.Settings.Realtime.MQTT.Enabled {
+	if settings.Realtime.MQTT.Enabled {
 		mqttClient := p.GetMQTTClient()
 		if mqttClient != nil {
 			// Create MQTT retry config from settings
 			mqttRetryConfig := jobqueue.RetryConfig{
-				Enabled:      p.Settings.Realtime.MQTT.RetrySettings.Enabled,
-				MaxRetries:   p.Settings.Realtime.MQTT.RetrySettings.MaxRetries,
-				InitialDelay: time.Duration(p.Settings.Realtime.MQTT.RetrySettings.InitialDelay) * time.Second,
-				MaxDelay:     time.Duration(p.Settings.Realtime.MQTT.RetrySettings.MaxDelay) * time.Second,
-				Multiplier:   p.Settings.Realtime.MQTT.RetrySettings.BackoffMultiplier,
+				Enabled:      settings.Realtime.MQTT.RetrySettings.Enabled,
+				MaxRetries:   settings.Realtime.MQTT.RetrySettings.MaxRetries,
+				InitialDelay: time.Duration(settings.Realtime.MQTT.RetrySettings.InitialDelay) * time.Second,
+				MaxDelay:     time.Duration(settings.Realtime.MQTT.RetrySettings.MaxDelay) * time.Second,
+				Multiplier:   settings.Realtime.MQTT.RetrySettings.BackoffMultiplier,
 			}
 
 			mqttAction = &MqttAction{
-				Settings:       p.Settings,
+				Settings:       settings,
 				MqttClient:     mqttClient,
 				EventTracker:   p.GetEventTracker(),
 				DetectionCtx:   detectionCtx, // Share context from DatabaseAction
@@ -1840,26 +1859,26 @@ func (p *Processor) getDefaultActions(det *Detections) []Action {
 	// On resource-constrained hardware (RPi with SD cards), FFmpeg encoding can
 	// take 10-30+ seconds, which previously caused CompositeAction 30s timeouts
 	// (Sentry BIRDNET-GO-WD), preventing SSE/MQTT from ever firing.
-	if p.Settings.Realtime.Audio.Export.Enabled && databaseAction != nil {
+	if settings.Realtime.Audio.Export.Enabled && databaseAction != nil {
 		actions = append(actions, p.buildSaveAudioAction(det, detectionCtx))
 	}
 
 	// Add BirdWeatherAction if enabled and client is initialized
 	// NOTE: BirdWeather runs independently (doesn't need detection ID from database)
-	if p.Settings.Realtime.Birdweather.Enabled {
+	if settings.Realtime.Birdweather.Enabled {
 		bwClient := p.GetBwClient() // Use getter for thread safety
 		if bwClient != nil {
 			// Create BirdWeather retry config from settings
 			bwRetryConfig := jobqueue.RetryConfig{
-				Enabled:      p.Settings.Realtime.Birdweather.RetrySettings.Enabled,
-				MaxRetries:   p.Settings.Realtime.Birdweather.RetrySettings.MaxRetries,
-				InitialDelay: time.Duration(p.Settings.Realtime.Birdweather.RetrySettings.InitialDelay) * time.Second,
-				MaxDelay:     time.Duration(p.Settings.Realtime.Birdweather.RetrySettings.MaxDelay) * time.Second,
-				Multiplier:   p.Settings.Realtime.Birdweather.RetrySettings.BackoffMultiplier,
+				Enabled:      settings.Realtime.Birdweather.RetrySettings.Enabled,
+				MaxRetries:   settings.Realtime.Birdweather.RetrySettings.MaxRetries,
+				InitialDelay: time.Duration(settings.Realtime.Birdweather.RetrySettings.InitialDelay) * time.Second,
+				MaxDelay:     time.Duration(settings.Realtime.Birdweather.RetrySettings.MaxDelay) * time.Second,
+				Multiplier:   settings.Realtime.Birdweather.RetrySettings.BackoffMultiplier,
 			}
 
 			actions = append(actions, &BirdWeatherAction{
-				Settings:      p.Settings,
+				Settings:      settings,
 				EventTracker:  p.GetEventTracker(),
 				BwClient:      bwClient,
 				Result:        det.Result, // Domain model (single source of truth)
@@ -1874,14 +1893,14 @@ func (p *Processor) getDefaultActions(det *Detections) []Action {
 	// Use atomic check-and-set to prevent race conditions (see GitHub issue #1357)
 	// This ensures only ONE goroutine will trigger the daily range filter update,
 	// preventing concurrent updates that could cause species list inconsistencies
-	if p.Settings.ShouldUpdateRangeFilterToday() {
+	if settings.ShouldUpdateRangeFilterToday() {
 		GetLogger().Info("Scheduling daily range filter update",
-			logger.Time("last_updated", p.Settings.GetLastRangeFilterUpdate()),
+			logger.Time("last_updated", settings.GetLastRangeFilterUpdate()),
 			logger.String("operation", "update_range_filter"))
 		// Add UpdateRangeFilterAction if it hasn't been executed today
 		actions = append(actions, &UpdateRangeFilterAction{
 			Bn:       p.Bn,
-			Settings: p.Settings,
+			Settings: settings,
 		})
 	}
 
@@ -1894,9 +1913,11 @@ func (p *Processor) getDefaultActions(det *Detections) []Action {
 // when executed by the job queue. This decouples the slow FFmpeg encoding
 // from the fast Database -> SSE -> MQTT pipeline.
 func (p *Processor) buildSaveAudioAction(det *Detections, detectionCtx *DetectionContext) *SaveAudioAction {
-	captureLength := p.Settings.Realtime.Audio.Export.Length
+	settings := p.currentSettings()
+
+	captureLength := settings.Realtime.Audio.Export.Length
 	if !det.Result.EndTime.IsZero() && !det.Result.BeginTime.IsZero() {
-		preCapture := p.Settings.Realtime.Audio.Export.PreCapture
+		preCapture := settings.Realtime.Audio.Export.PreCapture
 		derivedLength := int(det.Result.EndTime.Sub(det.Result.BeginTime).Seconds()) + preCapture
 		if derivedLength > captureLength {
 			captureLength = derivedLength
@@ -1904,15 +1925,15 @@ func (p *Processor) buildSaveAudioAction(det *Detections, detectionCtx *Detectio
 				logger.String("detection_id", det.CorrelationID),
 				logger.String("species", det.Result.Species.CommonName),
 				logger.Int("duration_seconds", captureLength),
-				logger.Int("configured_length", p.Settings.Realtime.Audio.Export.Length),
+				logger.Int("configured_length", settings.Realtime.Audio.Export.Length),
 				logger.String("operation", "extended_capture_audio_export"))
 		}
 	}
 
 	// Cap at capture buffer size to prevent reading beyond buffer bounds.
 	bufferCap := conf.DefaultCaptureBufferSeconds
-	if p.Settings.Realtime.ExtendedCapture.Enabled && p.Settings.Realtime.ExtendedCapture.CaptureBufferSeconds > 0 {
-		bufferCap = p.Settings.Realtime.ExtendedCapture.CaptureBufferSeconds
+	if settings.Realtime.ExtendedCapture.Enabled && settings.Realtime.ExtendedCapture.CaptureBufferSeconds > 0 {
+		bufferCap = settings.Realtime.ExtendedCapture.CaptureBufferSeconds
 	}
 	if captureLength > bufferCap {
 		GetLogger().Warn("Capping capture length at buffer size",
@@ -1934,7 +1955,7 @@ func (p *Processor) buildSaveAudioAction(det *Detections, detectionCtx *Detectio
 	captureEndTime := det.Result.BeginTime.Add(time.Duration(captureLength) * time.Second)
 	if p.BufferMgr != nil && captureEndTime.After(time.Now()) {
 		return &SaveAudioAction{
-			Settings:      p.Settings,
+			Settings:      settings,
 			ClipName:      det.Result.ClipName,
 			bufferMgr:     p.BufferMgr,
 			sourceID:      det.Result.AudioSource.ID,
@@ -1963,7 +1984,7 @@ func (p *Processor) buildSaveAudioAction(det *Detections, detectionCtx *Detectio
 			logger.String("operation", "capture_buffer_read_for_export"))
 		// Return an action with nil pcmData; Execute() will be a no-op
 		return &SaveAudioAction{
-			Settings:      p.Settings,
+			Settings:      settings,
 			ClipName:      det.Result.ClipName,
 			NoteID:        det.Result.ID, // May be 0 here; updated after DB save via DetectionCtx
 			PreRenderer:   p.preRenderer,
@@ -1973,7 +1994,7 @@ func (p *Processor) buildSaveAudioAction(det *Detections, detectionCtx *Detectio
 	}
 
 	return &SaveAudioAction{
-		Settings:      p.Settings,
+		Settings:      settings,
 		ClipName:      det.Result.ClipName,
 		pcmData:       pcmData,
 		NoteID:        det.Result.ID, // May be 0 here; updated after DB save via DetectionCtx
@@ -2196,7 +2217,7 @@ func (p *Processor) ShutdownWithContext(ctx context.Context) error {
 	}
 
 	// Flush dynamic thresholds using the provided context deadline
-	if p.Settings.Realtime.DynamicThreshold.Enabled {
+	if p.currentSettings().Realtime.DynamicThreshold.Enabled {
 		done := make(chan error, 1)
 		go func() {
 			done <- p.FlushDynamicThresholds()

--- a/internal/analysis/processor/processor_hot_reload_test.go
+++ b/internal/analysis/processor/processor_hot_reload_test.go
@@ -1,0 +1,109 @@
+package processor
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tphakala/birdnet-go/internal/conf"
+)
+
+func TestCurrentSettings_FallsBackToInjected(t *testing.T) {
+	injected := &conf.Settings{
+		BirdNET: conf.BirdNETConfig{Threshold: 0.42},
+	}
+	p := &Processor{Settings: injected}
+
+	got := p.currentSettings()
+	assert.Same(t, injected, got, "should fall back to injected settings when no global settings published")
+	assert.InDelta(t, 0.42, got.BirdNET.Threshold, 0.001)
+}
+
+func TestCurrentSettings_ReturnsGlobalWhenPublished(t *testing.T) {
+	injected := &conf.Settings{
+		BirdNET: conf.BirdNETConfig{Threshold: 0.42},
+	}
+	global := &conf.Settings{
+		BirdNET: conf.BirdNETConfig{Threshold: 0.99},
+	}
+
+	conf.StoreSettings(global)
+	t.Cleanup(func() { conf.StoreSettings(nil) })
+
+	p := &Processor{Settings: injected}
+
+	got := p.currentSettings()
+	assert.Same(t, global, got, "should return global settings when published")
+	assert.InDelta(t, 0.99, got.BirdNET.Threshold, 0.001)
+}
+
+func TestRecalculateDynamicThresholds_ReadsGlobalSettings(t *testing.T) {
+	// Start with base threshold 0.80
+	initial := &conf.Settings{
+		BirdNET: conf.BirdNETConfig{Threshold: 0.80},
+		Realtime: conf.RealtimeSettings{
+			Audio: conf.AudioSettings{
+				Export: conf.ExportSettings{Length: 15, PreCapture: 3},
+			},
+			DynamicThreshold: conf.DynamicThresholdSettings{
+				Enabled: true, Trigger: 0.90, Min: 0.10, ValidHours: 24,
+			},
+		},
+	}
+	p := &Processor{
+		Settings:          initial,
+		DynamicThresholds: make(map[string]*DynamicThreshold),
+		pendingResets:     make(map[string]struct{}),
+	}
+
+	// Add a species at level 1 (75% of base)
+	key := dynamicThresholdKey("model1", "species_a")
+	p.DynamicThresholds[key] = &DynamicThreshold{
+		Level:          1,
+		CurrentValue:   0.60, // 75% of 0.80
+		Timer:          time.Now().Add(1 * time.Hour),
+		ScientificName: "Speciesus testus",
+	}
+
+	// Simulate UI changing threshold to 0.40 via global settings
+	updated := &conf.Settings{
+		BirdNET:  conf.BirdNETConfig{Threshold: 0.40},
+		Realtime: initial.Realtime,
+	}
+	conf.StoreSettings(updated)
+	t.Cleanup(func() { conf.StoreSettings(nil) })
+
+	// Recalculate should use the NEW base (0.40), not old (0.80)
+	p.RecalculateDynamicThresholds()
+
+	assert.InDelta(t, 0.30, p.DynamicThresholds[key].CurrentValue, 0.01,
+		"expected 75%% of new base 0.40 = 0.30")
+}
+
+func TestCalculateMinDetections_ReadsGlobalSettings(t *testing.T) {
+	// Start with FP filter level 3 (strict)
+	initial := &conf.Settings{
+		Realtime: conf.RealtimeSettings{
+			FalsePositiveFilter: conf.FalsePositiveFilterSettings{Level: 3},
+		},
+		BirdNET: conf.BirdNETConfig{Overlap: 2.0},
+	}
+	p := &Processor{Settings: initial}
+
+	minDetStrict := p.calculateMinDetections()
+
+	// Change to level 0 (disabled) via global settings
+	updated := &conf.Settings{
+		Realtime: conf.RealtimeSettings{
+			FalsePositiveFilter: conf.FalsePositiveFilterSettings{Level: 0},
+		},
+		BirdNET: conf.BirdNETConfig{Overlap: 2.0},
+	}
+	conf.StoreSettings(updated)
+	t.Cleanup(func() { conf.StoreSettings(nil) })
+
+	minDetDisabled := p.calculateMinDetections()
+
+	assert.Greater(t, minDetStrict, 1, "strict filter should require multiple detections")
+	assert.Equal(t, 1, minDetDisabled, "disabled filter should require exactly 1 detection")
+}

--- a/internal/analysis/processor/processor_hot_reload_test.go
+++ b/internal/analysis/processor/processor_hot_reload_test.go
@@ -80,7 +80,7 @@ func TestRecalculateDynamicThresholds_ReadsGlobalSettings(t *testing.T) {
 	p.RecalculateDynamicThresholds()
 
 	assert.InDelta(t, 0.30, p.DynamicThresholds[key].CurrentValue, 0.01,
-		"expected 75%% of new base 0.40 = 0.30")
+		"expected 75% of new base 0.40 = 0.30")
 }
 
 func TestCalculateMinDetections_ReadsGlobalSettings(t *testing.T) {

--- a/internal/analysis/processor/processor_hot_reload_test.go
+++ b/internal/analysis/processor/processor_hot_reload_test.go
@@ -9,6 +9,9 @@ import (
 )
 
 func TestCurrentSettings_FallsBackToInjected(t *testing.T) {
+	conf.StoreSettings(nil)
+	t.Cleanup(func() { conf.StoreSettings(nil) })
+
 	injected := &conf.Settings{
 		BirdNET: conf.BirdNETConfig{Threshold: 0.42},
 	}
@@ -81,6 +84,9 @@ func TestRecalculateDynamicThresholds_ReadsGlobalSettings(t *testing.T) {
 }
 
 func TestCalculateMinDetections_ReadsGlobalSettings(t *testing.T) {
+	conf.StoreSettings(nil)
+	t.Cleanup(func() { conf.StoreSettings(nil) })
+
 	// Start with FP filter level 3 (strict)
 	initial := &conf.Settings{
 		Realtime: conf.RealtimeSettings{

--- a/internal/analysis/processor/processor_model_test.go
+++ b/internal/analysis/processor/processor_model_test.go
@@ -47,7 +47,7 @@ func TestCreateDetectionResult_ModelInfo(t *testing.T) {
 			t.Parallel()
 			p := &Processor{Settings: &conf.Settings{}}
 
-			result := p.createDetectionResult(
+			result := p.createDetectionResult(p.Settings,
 				time.Now(),
 				time.Now(), time.Now().Add(3*time.Second),
 				"Parus major", "Great Tit", "gretit1",

--- a/internal/analysis/processor/threshold_persistence.go
+++ b/internal/analysis/processor/threshold_persistence.go
@@ -27,6 +27,7 @@ const (
 // loadDynamicThresholdsFromDB loads persisted dynamic thresholds from the database
 // This is called during processor initialization to restore learned thresholds across restarts
 func (p *Processor) loadDynamicThresholdsFromDB() error {
+	settings := p.currentSettings()
 	GetLogger().Info("Loading dynamic thresholds from database",
 		logger.String("operation", "load_dynamic_thresholds"))
 
@@ -63,7 +64,7 @@ func (p *Processor) loadDynamicThresholdsFromDB() error {
 		// Skip expired thresholds
 		if now.After(dbThreshold.ExpiresAt) {
 			expiredCount++
-			if p.Settings.Realtime.DynamicThreshold.Debug {
+			if settings.Realtime.DynamicThreshold.Debug {
 				GetLogger().Debug("Skipping expired threshold",
 					logger.String("species", dbThreshold.SpeciesName),
 					logger.String("model", dbThreshold.ModelName),
@@ -87,7 +88,7 @@ func (p *Processor) loadDynamicThresholdsFromDB() error {
 		}
 		loadedCount++
 
-		if p.Settings.Realtime.DynamicThreshold.Debug {
+		if settings.Realtime.DynamicThreshold.Debug {
 			GetLogger().Debug("Loaded dynamic threshold",
 				logger.String("species", dbThreshold.SpeciesName),
 				logger.String("model", dbThreshold.ModelName),
@@ -110,6 +111,8 @@ func (p *Processor) loadDynamicThresholdsFromDB() error {
 // convertThresholdsForPersistence converts in-memory thresholds to database format.
 // Returns the database thresholds and a list of expired species to clean up.
 func (p *Processor) convertThresholdsForPersistence() (dbThresholds []datastore.DynamicThreshold, expiredSpecies []string) {
+	settings := p.currentSettings()
+
 	p.thresholdsMutex.RLock()
 	defer p.thresholdsMutex.RUnlock()
 
@@ -124,7 +127,7 @@ func (p *Processor) convertThresholdsForPersistence() (dbThresholds []datastore.
 	for compositeKey, threshold := range p.DynamicThresholds {
 		if now.After(threshold.Timer) {
 			expiredSpecies = append(expiredSpecies, compositeKey)
-			if p.Settings.Realtime.DynamicThreshold.Debug {
+			if settings.Realtime.DynamicThreshold.Debug {
 				GetLogger().Debug("Found expired threshold during persistence",
 					logger.String("key", compositeKey),
 					logger.Time("expires_at", threshold.Timer),
@@ -136,7 +139,7 @@ func (p *Processor) convertThresholdsForPersistence() (dbThresholds []datastore.
 		// Extract model name and species name from composite key
 		modelName, speciesName := splitDynamicThresholdKey(compositeKey)
 
-		baseThreshold := p.getBaseConfidenceThreshold(speciesName, "")
+		baseThreshold := p.getBaseConfidenceThreshold(settings, speciesName, "")
 		dbThresholds = append(dbThresholds, datastore.DynamicThreshold{
 			SpeciesName:    speciesName,
 			ModelName:      modelName,
@@ -217,6 +220,7 @@ func (p *Processor) saveThresholdsWithRetry(dbThresholds []datastore.DynamicThre
 // persistDynamicThresholds saves all current dynamic thresholds to the database
 // This is called periodically by the persistence goroutine
 func (p *Processor) persistDynamicThresholds() error {
+	settings := p.currentSettings()
 	dbThresholds, expiredSpecies := p.convertThresholdsForPersistence()
 
 	p.cleanupExpiredThresholds(expiredSpecies)
@@ -238,7 +242,7 @@ func (p *Processor) persistDynamicThresholds() error {
 	// Draining pending resets re-deletes those species from the database.
 	p.drainPendingResets()
 
-	if p.Settings.Realtime.DynamicThreshold.Debug {
+	if settings.Realtime.DynamicThreshold.Debug {
 		GetLogger().Debug("Persisted dynamic thresholds to database",
 			logger.Int("count", len(dbThresholds)),
 			logger.String("operation", "persist_dynamic_thresholds"))

--- a/internal/analysis/processor/threshold_persistence.go
+++ b/internal/analysis/processor/threshold_persistence.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/logger"
 )
@@ -110,9 +111,7 @@ func (p *Processor) loadDynamicThresholdsFromDB() error {
 
 // convertThresholdsForPersistence converts in-memory thresholds to database format.
 // Returns the database thresholds and a list of expired species to clean up.
-func (p *Processor) convertThresholdsForPersistence() (dbThresholds []datastore.DynamicThreshold, expiredSpecies []string) {
-	settings := p.currentSettings()
-
+func (p *Processor) convertThresholdsForPersistence(settings *conf.Settings) (dbThresholds []datastore.DynamicThreshold, expiredSpecies []string) {
 	p.thresholdsMutex.RLock()
 	defer p.thresholdsMutex.RUnlock()
 
@@ -221,7 +220,7 @@ func (p *Processor) saveThresholdsWithRetry(dbThresholds []datastore.DynamicThre
 // This is called periodically by the persistence goroutine
 func (p *Processor) persistDynamicThresholds() error {
 	settings := p.currentSettings()
-	dbThresholds, expiredSpecies := p.convertThresholdsForPersistence()
+	dbThresholds, expiredSpecies := p.convertThresholdsForPersistence(settings)
 
 	p.cleanupExpiredThresholds(expiredSpecies)
 

--- a/internal/analysis/processor/workers.go
+++ b/internal/analysis/processor/workers.go
@@ -244,8 +244,11 @@ func (p *Processor) EnqueueTaskCtx(ctx context.Context, task *Task) error {
 	// Get retry configuration for the action
 	jqRetryConfig := getJobQueueRetryConfig(task.Action)
 
+	// Read fresh settings for hot-reload support
+	settings := p.currentSettings()
+
 	// State transition logging - task received
-	if p.Settings.Debug {
+	if settings.Debug {
 		log.Debug("Task received for enqueueing",
 			logger.String("task_description", sanitizedDesc),
 			logger.String("species", speciesName),
@@ -325,7 +328,7 @@ func (p *Processor) EnqueueTaskCtx(ctx context.Context, task *Task) error {
 	}
 
 	// State transition logging - task successfully enqueued
-	if p.Settings.Debug {
+	if settings.Debug {
 		log.Debug("Task enqueued successfully",
 			logger.String("task_description", sanitizedDesc),
 			logger.String("job_id", job.ID),


### PR DESCRIPTION
## Summary

The March service orchestration rewrite cached `*conf.Settings` at processor construction time, causing all runtime reads to use stale values after UI settings changes. This affected every processor-level setting: detection threshold, false positive filter, dog bark filter, privacy filter, daylight filter, extended capture, export config, dynamic thresholds, and detection metadata (lat/lon/sensitivity). All required a restart to take effect.

- Add `currentSettings()` helper (matching PreRenderer/Generator/Weather pattern) that returns the latest published settings snapshot via `conf.CurrentOrFallback()`
- Thread settings snapshot through the detection pipeline as a parameter for per-batch consistency
- Capture fresh settings at standalone entry points (flush loop, action creation, threshold persistence)
- All runtime `p.Settings` reads in the processor package now use fresh settings
- Startup-only methods correctly retain direct `p.Settings` access

12 files changed across `internal/analysis/processor/`: processor.go, dynamic_threshold.go, threshold_persistence.go, daylight_filter.go, extended_capture.go, dogbarkfilter.go, mqtt.go, workers.go, and 4 test files.

## Test Plan

- [x] 4 new hot-reload tests verify `currentSettings()` fallback, global override, threshold recalculation, and FP filter propagation
- [x] All existing processor tests pass unchanged (CurrentOrFallback falls back to injected settings in tests)
- [x] `go test -race -count=1 ./internal/analysis/processor/...` passes
- [x] `golangci-lint run -v` reports zero issues
- [x] CodeRabbit local review: zero findings
- [x] /code-review skill: zero issues (race conditions, panics, smells)
- [x] /simplify review (reuse + quality + efficiency): one fix applied

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Live configuration (hot-reload) now consistently applied across detection processing, filtering, audio export, thresholds, MQTT/Home Assistant, and clip naming.

* **Bug Fixes**
  * Runtime decisions and filters now consistently read the current settings snapshot to avoid timing/inconsistency issues (capture timing, thresholds, species filters, dog-bark handling).

* **Tests**
  * Added and updated tests to validate hot-reload behavior, dynamic-threshold recalculation, and clip-name/clip-path handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->