### PR TITLE
fix(conf): use clone-mutate-publish for range filter mutations

### DIFF
--- a/internal/analysis/processor/actions_integrations.go
+++ b/internal/analysis/processor/actions_integrations.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/tphakala/birdnet-go/internal/alerting"
+	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/imageprovider"
@@ -367,7 +368,7 @@ func (a *UpdateRangeFilterAction) Execute(_ context.Context, data any) error {
 	if err != nil {
 		// Reset the update flag to allow retry on next detection
 		// This prevents the issue where a failed update would block retries until tomorrow
-		a.Settings.ResetRangeFilterUpdateFlag()
+		conf.ResetRangeFilterUpdateFlag()
 
 		GetLogger().Error("Failed to get probable species for range filter",
 			logger.Error(err),
@@ -383,7 +384,7 @@ func (a *UpdateRangeFilterAction) Execute(_ context.Context, data any) error {
 	}
 
 	// Update the species list (this also updates LastUpdated timestamp atomically)
-	a.Settings.UpdateIncludedSpecies(includedSpecies)
+	conf.UpdateIncludedSpecies(includedSpecies)
 
 	if a.Settings.Debug {
 		GetLogger().Info("Range filter updated successfully",

--- a/internal/analysis/processor/processor.go
+++ b/internal/analysis/processor/processor.go
@@ -1893,7 +1893,7 @@ func (p *Processor) getDefaultActions(det *Detections) []Action {
 	// Use atomic check-and-set to prevent race conditions (see GitHub issue #1357)
 	// This ensures only ONE goroutine will trigger the daily range filter update,
 	// preventing concurrent updates that could cause species list inconsistencies
-	if settings.ShouldUpdateRangeFilterToday() {
+	if conf.ShouldUpdateRangeFilterToday() {
 		GetLogger().Info("Scheduling daily range filter update",
 			logger.Time("last_updated", settings.GetLastRangeFilterUpdate()),
 			logger.String("operation", "update_range_filter"))

--- a/internal/api/v2/range.go
+++ b/internal/api/v2/range.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/tphakala/birdnet-go/internal/classifier"
+	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/detection"
 	"github.com/tphakala/birdnet-go/internal/logger"
 )
@@ -188,16 +189,18 @@ func (c *Controller) GetRangeFilterSpeciesCount(ctx echo.Context) error {
 	c.settingsMutex.RLock()
 	defer c.settingsMutex.RUnlock()
 
-	// Get current included species
-	includedSpecies := c.Settings.GetIncludedSpecies()
+	// Use the latest published snapshot so the daily range filter update
+	// (which publishes via clone-mutate-publish) is visible immediately.
+	settings := conf.CurrentOrFallback(c.Settings)
+	includedSpecies := settings.GetIncludedSpecies()
 
 	response := RangeFilterSpeciesCount{
 		Count:       len(includedSpecies),
-		LastUpdated: c.Settings.BirdNET.RangeFilter.LastUpdated,
-		Threshold:   c.Settings.BirdNET.RangeFilter.Threshold,
+		LastUpdated: settings.BirdNET.RangeFilter.LastUpdated,
+		Threshold:   settings.BirdNET.RangeFilter.Threshold,
 		Location: Location{
-			Latitude:  c.Settings.BirdNET.Latitude,
-			Longitude: c.Settings.BirdNET.Longitude,
+			Latitude:  settings.BirdNET.Latitude,
+			Longitude: settings.BirdNET.Longitude,
 		},
 	}
 
@@ -218,8 +221,10 @@ func (c *Controller) GetRangeFilterSpeciesList(ctx echo.Context) error {
 	c.settingsMutex.RLock()
 	defer c.settingsMutex.RUnlock()
 
-	// Get current included species
-	includedSpecies := c.Settings.GetIncludedSpecies()
+	// Use the latest published snapshot so the daily range filter update
+	// (which publishes via clone-mutate-publish) is visible immediately.
+	settings := conf.CurrentOrFallback(c.Settings)
+	includedSpecies := settings.GetIncludedSpecies()
 
 	// Convert to response format with parsed names
 	// Pre-allocate slice with capacity for all included species
@@ -300,11 +305,11 @@ func (c *Controller) GetRangeFilterSpeciesList(ctx echo.Context) error {
 	response := RangeFilterSpeciesList{
 		Species:     speciesList,
 		Count:       len(speciesList),
-		LastUpdated: c.Settings.BirdNET.RangeFilter.LastUpdated,
-		Threshold:   c.Settings.BirdNET.RangeFilter.Threshold,
+		LastUpdated: settings.BirdNET.RangeFilter.LastUpdated,
+		Threshold:   settings.BirdNET.RangeFilter.Threshold,
 		Location: Location{
-			Latitude:  c.Settings.BirdNET.Latitude,
-			Longitude: c.Settings.BirdNET.Longitude,
+			Latitude:  settings.BirdNET.Latitude,
+			Longitude: settings.BirdNET.Longitude,
 		},
 		Genera:   genera,
 		Families: families,

--- a/internal/api/v2/range.go
+++ b/internal/api/v2/range.go
@@ -493,8 +493,10 @@ func (c *Controller) GetRangeFilterSpeciesCSV(ctx echo.Context) error {
 		// before expensive CSV generation and I/O.
 		c.settingsMutex.RLock()
 
-		// Use current range filter settings
-		includedSpecies := c.Settings.GetIncludedSpecies()
+		// Use the latest published snapshot for consistency with other
+		// range filter GET endpoints.
+		settings := conf.CurrentOrFallback(c.Settings)
+		includedSpecies := settings.GetIncludedSpecies()
 
 		// Convert to species list format
 		speciesList = make([]RangeFilterSpecies, 0, len(includedSpecies))
@@ -512,10 +514,10 @@ func (c *Controller) GetRangeFilterSpeciesCSV(ctx echo.Context) error {
 		}
 
 		location = Location{
-			Latitude:  c.Settings.BirdNET.Latitude,
-			Longitude: c.Settings.BirdNET.Longitude,
+			Latitude:  settings.BirdNET.Latitude,
+			Longitude: settings.BirdNET.Longitude,
 		}
-		threshold = c.Settings.BirdNET.RangeFilter.Threshold
+		threshold = settings.BirdNET.RangeFilter.Threshold
 
 		c.settingsMutex.RUnlock()
 	}
@@ -697,11 +699,11 @@ func (c *Controller) RebuildRangeFilter(ctx echo.Context) error {
 		return c.HandleError(ctx, err, "Failed to rebuild range filter", http.StatusInternalServerError)
 	}
 
-	// Get the updated count under read lock for consistency with other endpoints.
-	c.settingsMutex.RLock()
-	includedSpecies := c.Settings.GetIncludedSpecies()
-	lastUpdated := c.Settings.BirdNET.RangeFilter.LastUpdated
-	c.settingsMutex.RUnlock()
+	// Read from the latest published snapshot so the just-published rebuild
+	// result is reflected immediately.
+	settings := conf.CurrentOrFallback(c.Settings)
+	includedSpecies := settings.GetIncludedSpecies()
+	lastUpdated := settings.BirdNET.RangeFilter.LastUpdated
 
 	response := map[string]any{
 		"success":     true,

--- a/internal/api/v2/range_test.go
+++ b/internal/api/v2/range_test.go
@@ -57,12 +57,12 @@ func setupRangeTestEnvironment(t *testing.T) (*echo.Echo, *mocks.MockInterface, 
 	controller.Settings.BirdNET.RangeFilter.Threshold = 0.01
 	controller.Settings.BirdNET.RangeFilter.LastUpdated = time.Now()
 
-	// Mock the included species list using the proper API
-	controller.Settings.UpdateIncludedSpecies([]string{
+	// Set the included species list directly for test setup
+	controller.Settings.BirdNET.RangeFilter.Species = []string{
 		"Turdus merula_Eurasian Blackbird",
 		"Parus major_Great Tit",
 		"Corvus cornix_Hooded Crow",
-	})
+	}
 
 	return e, mockDS, controller
 }

--- a/internal/classifier/range_filter.go
+++ b/internal/classifier/range_filter.go
@@ -76,7 +76,7 @@ func BuildRangeFilter(o *Orchestrator) error {
 		}
 	}
 
-	conf.Setting().UpdateIncludedSpecies(includedSpecies)
+	conf.UpdateIncludedSpecies(includedSpecies)
 
 	return nil
 }

--- a/internal/conf/range_filter.go
+++ b/internal/conf/range_filter.go
@@ -1,6 +1,7 @@
 package conf
 
 import (
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -8,35 +9,40 @@ import (
 	"github.com/tphakala/birdnet-go/internal/logger"
 )
 
-var (
-	speciesListMutex sync.RWMutex
-)
+// speciesListMutex serializes clone-mutate-publish operations on range filter
+// fields (Species, LastUpdated) so that concurrent writers do not lose each
+// other's updates. Readers no longer need this mutex because published
+// snapshots are immutable.
+var speciesListMutex sync.Mutex
 
-// UpdateIncludedSpecies updates the included species list in the RangeFilter
-func (s *Settings) UpdateIncludedSpecies(species []string) {
+// UpdateIncludedSpecies clones the current settings, replaces the species
+// list and LastUpdated timestamp, and publishes a new immutable snapshot.
+func UpdateIncludedSpecies(species []string) {
 	speciesListMutex.Lock()
 	defer speciesListMutex.Unlock()
-	s.BirdNET.RangeFilter.Species = make([]string, len(species))
-	copy(s.BirdNET.RangeFilter.Species, species)
-	s.BirdNET.RangeFilter.LastUpdated = time.Now()
+
+	current := GetSettings()
+	if current == nil {
+		return
+	}
+
+	updated := CloneSettings(current)
+	updated.BirdNET.RangeFilter.Species = make([]string, len(species))
+	copy(updated.BirdNET.RangeFilter.Species, species)
+	updated.BirdNET.RangeFilter.LastUpdated = time.Now()
+	StoreSettings(updated)
 }
 
-// GetIncludedSpecies returns the current included species list from the RangeFilter
+// GetIncludedSpecies returns a copy of the included species list from this
+// snapshot. The snapshot is immutable, so no mutex is needed.
 func (s *Settings) GetIncludedSpecies() []string {
-	speciesListMutex.RLock()
-	defer speciesListMutex.RUnlock()
-	speciesCopy := make([]string, len(s.BirdNET.RangeFilter.Species))
-	copy(speciesCopy, s.BirdNET.RangeFilter.Species)
-	return speciesCopy
+	return slices.Clone(s.BirdNET.RangeFilter.Species)
 }
 
-// IsSpeciesIncluded checks if a given scientific name matches the scientific name part of any included species
+// IsSpeciesIncluded checks if a given scientific name matches the scientific
+// name part of any included species in this snapshot.
 func (s *Settings) IsSpeciesIncluded(result string) bool {
-	speciesListMutex.RLock()
-	defer speciesListMutex.RUnlock()
-
 	for _, fullSpeciesString := range s.BirdNET.RangeFilter.Species {
-		// Check if the full species string starts with our search term
 		if strings.HasPrefix(fullSpeciesString, result) {
 			return true
 		}
@@ -44,56 +50,59 @@ func (s *Settings) IsSpeciesIncluded(result string) bool {
 	return false
 }
 
-// ShouldUpdateRangeFilterToday atomically checks if the range filter should be updated today.
-// This function ensures that only ONE goroutine will trigger the update on any given day,
-// preventing race conditions where multiple concurrent detections could trigger multiple
-// range filter rebuilds simultaneously.
+// ShouldUpdateRangeFilterToday atomically checks whether the range filter
+// should be updated today and, if so, publishes a new snapshot with
+// LastUpdated set to today. Only the first caller on a given day gets true;
+// subsequent callers see the updated snapshot and return false.
 //
-// Returns true only for the FIRST caller on a given day (midnight to midnight).
-// Subsequent callers on the same day will return false.
-//
-// This solves GitHub issue #1357 where species appeared in detections that weren't in the
-// range filter due to concurrent range filter updates creating inconsistent states.
-func (s *Settings) ShouldUpdateRangeFilterToday() bool {
+// This solves GitHub issue #1357 where species appeared in detections that
+// weren't in the range filter due to concurrent range filter updates.
+func ShouldUpdateRangeFilterToday() bool {
 	speciesListMutex.Lock()
 	defer speciesListMutex.Unlock()
 
-	today := time.Now().Truncate(24 * time.Hour)
-
-	// Check if we need to update (last update was before today)
-	if s.BirdNET.RangeFilter.LastUpdated.Before(today) {
-		// Atomically mark as updated to prevent other goroutines from also updating
-		s.BirdNET.RangeFilter.LastUpdated = today
-
-		// Log the update decision for debugging
-		if s.Debug {
-			GetLogger().Debug("Scheduled range filter update",
-				logger.String("date", today.Format(time.DateOnly)),
-				logger.String("last_updated", s.BirdNET.RangeFilter.LastUpdated.Format(time.DateTime)))
-		}
-
-		return true
+	current := GetSettings()
+	if current == nil {
+		return false
 	}
 
-	return false
+	today := time.Now().Truncate(24 * time.Hour)
+	if !current.BirdNET.RangeFilter.LastUpdated.Before(today) {
+		return false
+	}
+
+	updated := CloneSettings(current)
+	updated.BirdNET.RangeFilter.LastUpdated = today
+	StoreSettings(updated)
+
+	if current.Debug {
+		GetLogger().Debug("Scheduled range filter update",
+			logger.String("date", today.Format(time.DateOnly)),
+			logger.String("last_updated", current.BirdNET.RangeFilter.LastUpdated.Format(time.DateTime)))
+	}
+
+	return true
 }
 
-// GetLastRangeFilterUpdate returns the last time the range filter was updated.
-// This is thread-safe and uses the same mutex as other range filter operations.
+// GetLastRangeFilterUpdate returns the last time the range filter was updated
+// from this snapshot. The snapshot is immutable, so no mutex is needed.
 func (s *Settings) GetLastRangeFilterUpdate() time.Time {
-	speciesListMutex.RLock()
-	defer speciesListMutex.RUnlock()
 	return s.BirdNET.RangeFilter.LastUpdated
 }
 
-// ResetRangeFilterUpdateFlag resets the LastUpdated timestamp to allow retry of failed updates.
-// This should be called when range filter update fails (e.g., network error, API failure)
-// to allow the update to be retried on the next detection instead of waiting until tomorrow.
-//
-// This is thread-safe and uses the same mutex as other range filter operations.
-func (s *Settings) ResetRangeFilterUpdateFlag() {
+// ResetRangeFilterUpdateFlag clones the current settings, zeros the
+// LastUpdated timestamp to allow retry of failed updates, and publishes
+// a new immutable snapshot.
+func ResetRangeFilterUpdateFlag() {
 	speciesListMutex.Lock()
 	defer speciesListMutex.Unlock()
-	// Set to zero time to indicate update is needed
-	s.BirdNET.RangeFilter.LastUpdated = time.Time{}
+
+	current := GetSettings()
+	if current == nil {
+		return
+	}
+
+	updated := CloneSettings(current)
+	updated.BirdNET.RangeFilter.LastUpdated = time.Time{}
+	StoreSettings(updated)
 }

--- a/internal/conf/range_filter_test.go
+++ b/internal/conf/range_filter_test.go
@@ -6,39 +6,43 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+// setupGlobalSettings publishes a test settings snapshot and returns a
+// cleanup function that restores the previous snapshot.
+func setupGlobalSettings(t *testing.T, s *Settings) {
+	t.Helper()
+	prev := GetSettings()
+	StoreSettings(s)
+	t.Cleanup(func() { StoreSettings(prev) })
+}
 
 // TestShouldUpdateRangeFilterToday_SingleThread verifies basic functionality
 func TestShouldUpdateRangeFilterToday_SingleThread(t *testing.T) {
-	t.Parallel()
-
 	settings := &Settings{}
-	settings.BirdNET.RangeFilter.LastUpdated = time.Now().Add(-25 * time.Hour) // Yesterday
+	settings.BirdNET.RangeFilter.LastUpdated = time.Now().Add(-25 * time.Hour)
+	setupGlobalSettings(t, settings)
 
-	// First call should return true
-	assert.True(t, settings.ShouldUpdateRangeFilterToday(), "First call should return true when LastUpdated is yesterday")
-
-	// Second call should return false (already updated today)
-	assert.False(t, settings.ShouldUpdateRangeFilterToday(), "Second call should return false (already updated today)")
+	assert.True(t, ShouldUpdateRangeFilterToday(), "First call should return true when LastUpdated is yesterday")
+	assert.False(t, ShouldUpdateRangeFilterToday(), "Second call should return false (already updated today)")
 }
 
-// TestShouldUpdateRangeFilterToday_ConcurrentAccess tests for race conditions
-// This is the critical test that would fail with the old implementation
+// TestShouldUpdateRangeFilterToday_ConcurrentAccess tests for race conditions.
+// Only one goroutine should get true per day (GitHub issue #1357).
 func TestShouldUpdateRangeFilterToday_ConcurrentAccess(t *testing.T) {
-	t.Parallel()
-
 	settings := &Settings{}
-	settings.BirdNET.RangeFilter.LastUpdated = time.Now().Add(-25 * time.Hour) // Yesterday
+	settings.BirdNET.RangeFilter.LastUpdated = time.Now().Add(-25 * time.Hour)
+	setupGlobalSettings(t, settings)
 
 	const numGoroutines = 100
 	var wg sync.WaitGroup
 	trueCount := 0
 	var mu sync.Mutex
 
-	// Launch multiple goroutines that all check if update is needed
 	for range numGoroutines {
 		wg.Go(func() {
-			if settings.ShouldUpdateRangeFilterToday() {
+			if ShouldUpdateRangeFilterToday() {
 				mu.Lock()
 				trueCount++
 				mu.Unlock()
@@ -47,25 +51,41 @@ func TestShouldUpdateRangeFilterToday_ConcurrentAccess(t *testing.T) {
 	}
 
 	wg.Wait()
-
-	// CRITICAL: Only ONE goroutine should have received true
-	// This prevents the bug in issue #1357 where multiple goroutines
-	// would all create UpdateRangeFilterAction, causing race conditions
 	assert.Equal(t, 1, trueCount, "Expected exactly 1 goroutine to receive true")
 }
 
 // TestShouldUpdateRangeFilterToday_AlreadyUpdated verifies that when
-// LastUpdated is already today, no updates are triggered
+// LastUpdated is already today, no updates are triggered.
 func TestShouldUpdateRangeFilterToday_AlreadyUpdated(t *testing.T) {
-	t.Parallel()
-
 	settings := &Settings{}
-	settings.BirdNET.RangeFilter.LastUpdated = time.Now() // Already updated today
+	settings.BirdNET.RangeFilter.LastUpdated = time.Now()
+	setupGlobalSettings(t, settings)
 
-	assert.False(t, settings.ShouldUpdateRangeFilterToday(), "Should return false when already updated today")
+	assert.False(t, ShouldUpdateRangeFilterToday(), "Should return false when already updated today")
 }
 
-// TestGetLastRangeFilterUpdate verifies thread-safe reading of LastUpdated
+// TestShouldUpdateRangeFilterToday_PublishesNewSnapshot verifies that the
+// function publishes a new snapshot with LastUpdated set to today.
+func TestShouldUpdateRangeFilterToday_PublishesNewSnapshot(t *testing.T) {
+	original := &Settings{}
+	original.BirdNET.RangeFilter.LastUpdated = time.Now().Add(-25 * time.Hour)
+	original.BirdNET.RangeFilter.Species = []string{"Original Species"}
+	setupGlobalSettings(t, original)
+
+	require.True(t, ShouldUpdateRangeFilterToday())
+
+	published := GetSettings()
+	require.NotSame(t, original, published, "Must publish a new snapshot, not mutate original")
+	assert.False(t, published.BirdNET.RangeFilter.LastUpdated.Before(time.Now().Truncate(24*time.Hour)),
+		"Published snapshot should have LastUpdated >= today")
+	assert.Equal(t, []string{"Original Species"}, published.BirdNET.RangeFilter.Species,
+		"Species list should be preserved in the published snapshot")
+	assert.Equal(t, time.Now().Add(-25*time.Hour).Truncate(time.Second),
+		original.BirdNET.RangeFilter.LastUpdated.Truncate(time.Second),
+		"Original snapshot must not be mutated")
+}
+
+// TestGetLastRangeFilterUpdate verifies reading of LastUpdated from a snapshot.
 func TestGetLastRangeFilterUpdate(t *testing.T) {
 	t.Parallel()
 
@@ -73,85 +93,75 @@ func TestGetLastRangeFilterUpdate(t *testing.T) {
 	expectedTime := time.Now().Add(-1 * time.Hour)
 	settings.BirdNET.RangeFilter.LastUpdated = expectedTime
 
-	// Read from multiple goroutines concurrently
-	const numReaders = 50
-	var wg sync.WaitGroup
-	var mu sync.Mutex
-	var errors []string
-
-	for range numReaders {
-		wg.Go(func() {
-			got := settings.GetLastRangeFilterUpdate()
-			if !got.Equal(expectedTime) {
-				mu.Lock()
-				errors = append(errors, "Expected time mismatch")
-				mu.Unlock()
-			}
-		})
-	}
-
-	wg.Wait()
-
-	assert.Empty(t, errors, "Concurrent reads failed: found %d errors", len(errors))
+	got := settings.GetLastRangeFilterUpdate()
+	assert.True(t, got.Equal(expectedTime), "Expected time to match")
 }
 
-// TestUpdateIncludedSpecies_ThreadSafety verifies concurrent updates are safe
+// TestUpdateIncludedSpecies_ThreadSafety verifies concurrent updates are safe.
 func TestUpdateIncludedSpecies_ThreadSafety(t *testing.T) {
-	t.Parallel()
-
 	settings := &Settings{}
+	setupGlobalSettings(t, settings)
 
 	const numGoroutines = 50
 	var wg sync.WaitGroup
 
-	// Concurrently update species lists
-	for i := range numGoroutines {
-		wg.Add(1)
-		go func(id int) {
-			defer wg.Done()
-			species := []string{"Species A", "Species B"}
-			settings.UpdateIncludedSpecies(species)
-		}(i)
+	for range numGoroutines {
+		wg.Go(func() {
+			UpdateIncludedSpecies([]string{"Species A", "Species B"})
+		})
 	}
 
 	wg.Wait()
 
-	// Verify the final state is valid
-	species := settings.GetIncludedSpecies()
+	species := GetSettings().GetIncludedSpecies()
 	assert.Len(t, species, 2, "Expected 2 species")
 }
 
-// TestIsSpeciesIncluded_ThreadSafety verifies concurrent reads during updates
-func TestIsSpeciesIncluded_ThreadSafety(t *testing.T) {
-	t.Parallel()
+// TestUpdateIncludedSpecies_PublishesNewSnapshot verifies clone-mutate-publish.
+func TestUpdateIncludedSpecies_PublishesNewSnapshot(t *testing.T) {
+	original := &Settings{}
+	original.BirdNET.RangeFilter.Species = []string{"Old Species"}
+	setupGlobalSettings(t, original)
 
+	UpdateIncludedSpecies([]string{"New Species A", "New Species B"})
+
+	published := GetSettings()
+	require.NotSame(t, original, published, "Must publish a new snapshot")
+	assert.Equal(t, []string{"New Species A", "New Species B"}, published.BirdNET.RangeFilter.Species)
+	assert.False(t, published.BirdNET.RangeFilter.LastUpdated.IsZero(), "LastUpdated should be set")
+
+	assert.Equal(t, []string{"Old Species"}, original.BirdNET.RangeFilter.Species,
+		"Original snapshot must not be mutated")
+}
+
+// TestIsSpeciesIncluded_ThreadSafety verifies concurrent reads during updates.
+func TestIsSpeciesIncluded_ThreadSafety(t *testing.T) {
 	settings := &Settings{}
-	settings.UpdateIncludedSpecies([]string{
+	settings.BirdNET.RangeFilter.Species = []string{
 		"Turdus merula_Eurasian Blackbird",
 		"Parus major_Great Tit",
-	})
+	}
+	setupGlobalSettings(t, settings)
 
 	const numReaders = 100
 	var wg sync.WaitGroup
 	var mu sync.Mutex
-	var errors []string
+	var errs []string
 
-	// Start readers
 	for range numReaders {
 		wg.Go(func() {
-			// These should consistently return true
-			if !settings.IsSpeciesIncluded("Turdus merula") {
+			snapshot := GetSettings()
+			if !snapshot.IsSpeciesIncluded("Turdus merula") {
 				mu.Lock()
-				errors = append(errors, "Expected species to be included")
+				errs = append(errs, "Expected species to be included")
 				mu.Unlock()
 			}
 		})
 	}
 
-	// While reading, also update the list (keeping the original species)
 	wg.Go(func() {
-		time.Sleep(1 * time.Millisecond) // Let some readers start
-		settings.UpdateIncludedSpecies([]string{
+		time.Sleep(1 * time.Millisecond)
+		UpdateIncludedSpecies([]string{
 			"Turdus merula_Eurasian Blackbird",
 			"Parus major_Great Tit",
 			"Corvus cornix_Hooded Crow",
@@ -159,102 +169,101 @@ func TestIsSpeciesIncluded_ThreadSafety(t *testing.T) {
 	})
 
 	wg.Wait()
-
-	assert.Empty(t, errors, "Concurrent reads failed: found %d errors", len(errors))
+	assert.Empty(t, errs, "Concurrent reads failed: found %d errors", len(errs))
 }
 
 // TestResetRangeFilterUpdateFlag verifies that ResetRangeFilterUpdateFlag
-// correctly resets the LastUpdated timestamp to allow retries
+// correctly resets the LastUpdated timestamp to allow retries.
 func TestResetRangeFilterUpdateFlag(t *testing.T) {
-	t.Parallel()
-
 	settings := &Settings{}
 	settings.BirdNET.RangeFilter.LastUpdated = time.Now()
+	setupGlobalSettings(t, settings)
 
-	// Verify it's set
 	assert.False(t, settings.BirdNET.RangeFilter.LastUpdated.IsZero(), "LastUpdated should not be zero initially")
 
-	// Reset the flag
-	settings.ResetRangeFilterUpdateFlag()
+	ResetRangeFilterUpdateFlag()
 
-	// Verify it's been reset to zero time
-	assert.True(t, settings.BirdNET.RangeFilter.LastUpdated.IsZero(), "LastUpdated should be zero after reset")
-
-	// Verify that after reset, ShouldUpdateRangeFilterToday returns true
-	assert.True(t, settings.ShouldUpdateRangeFilterToday(), "ShouldUpdateRangeFilterToday should return true after reset")
+	published := GetSettings()
+	assert.True(t, published.BirdNET.RangeFilter.LastUpdated.IsZero(), "LastUpdated should be zero after reset")
+	assert.True(t, ShouldUpdateRangeFilterToday(), "ShouldUpdateRangeFilterToday should return true after reset")
 }
 
-// TestResetRangeFilterUpdateFlag_ThreadSafety verifies concurrent resets are safe
-func TestResetRangeFilterUpdateFlag_ThreadSafety(t *testing.T) {
-	t.Parallel()
+// TestResetRangeFilterUpdateFlag_PublishesNewSnapshot verifies immutability.
+func TestResetRangeFilterUpdateFlag_PublishesNewSnapshot(t *testing.T) {
+	original := &Settings{}
+	original.BirdNET.RangeFilter.LastUpdated = time.Now()
+	original.BirdNET.RangeFilter.Species = []string{"Preserved Species"}
+	setupGlobalSettings(t, original)
 
+	ResetRangeFilterUpdateFlag()
+
+	published := GetSettings()
+	require.NotSame(t, original, published, "Must publish a new snapshot")
+	assert.True(t, published.BirdNET.RangeFilter.LastUpdated.IsZero())
+	assert.Equal(t, []string{"Preserved Species"}, published.BirdNET.RangeFilter.Species,
+		"Species list should be preserved")
+	assert.False(t, original.BirdNET.RangeFilter.LastUpdated.IsZero(),
+		"Original snapshot must not be mutated")
+}
+
+// TestResetRangeFilterUpdateFlag_ThreadSafety verifies concurrent resets.
+func TestResetRangeFilterUpdateFlag_ThreadSafety(t *testing.T) {
 	settings := &Settings{}
 	settings.BirdNET.RangeFilter.LastUpdated = time.Now()
+	setupGlobalSettings(t, settings)
 
 	const numGoroutines = 50
 	var wg sync.WaitGroup
 
-	// Concurrently reset the flag
 	for range numGoroutines {
 		wg.Go(func() {
-			settings.ResetRangeFilterUpdateFlag()
+			ResetRangeFilterUpdateFlag()
 		})
 	}
 
 	wg.Wait()
 
-	// Verify the final state is zero time
-	assert.True(t, settings.BirdNET.RangeFilter.LastUpdated.IsZero(), "LastUpdated should be zero after concurrent resets")
+	published := GetSettings()
+	assert.True(t, published.BirdNET.RangeFilter.LastUpdated.IsZero(),
+		"LastUpdated should be zero after concurrent resets")
 }
 
 // TestErrorRecoveryScenario simulates the full error recovery flow:
 // 1. Update is scheduled (ShouldUpdateRangeFilterToday returns true)
 // 2. Update fails (simulated by ResetRangeFilterUpdateFlag)
-// 3. Next detection should be able to retry (ShouldUpdateRangeFilterToday returns true again)
+// 3. Next detection retries (ShouldUpdateRangeFilterToday returns true again)
 func TestErrorRecoveryScenario(t *testing.T) {
-	t.Parallel()
-
 	settings := &Settings{}
-	settings.BirdNET.RangeFilter.LastUpdated = time.Now().Add(-25 * time.Hour) // Yesterday
+	settings.BirdNET.RangeFilter.LastUpdated = time.Now().Add(-25 * time.Hour)
+	setupGlobalSettings(t, settings)
 
-	// First detection: should trigger update
-	assert.True(t, settings.ShouldUpdateRangeFilterToday(), "First call should return true when LastUpdated is yesterday")
+	assert.True(t, ShouldUpdateRangeFilterToday(), "First call should return true when LastUpdated is yesterday")
 
-	// Simulate update failure by resetting the flag
-	// (In production, this is called in UpdateRangeFilterAction.Execute on error)
-	settings.ResetRangeFilterUpdateFlag()
+	ResetRangeFilterUpdateFlag()
 
-	// Next detection: should be able to retry
-	assert.True(t, settings.ShouldUpdateRangeFilterToday(), "Should return true after failed update (reset flag)")
+	assert.True(t, ShouldUpdateRangeFilterToday(), "Should return true after failed update (reset flag)")
 
-	// Simulate successful update by calling UpdateIncludedSpecies
-	settings.UpdateIncludedSpecies([]string{"Test Species"})
+	UpdateIncludedSpecies([]string{"Test Species"})
 
-	// Next detection: should NOT trigger update (already succeeded)
-	assert.False(t, settings.ShouldUpdateRangeFilterToday(), "Should return false after successful update")
+	assert.False(t, ShouldUpdateRangeFilterToday(), "Should return false after successful update")
 }
 
-// TestErrorRecoveryScenario_Concurrent simulates concurrent error recovery
-// This ensures that even with concurrent resets and checks, only one goroutine
-// will trigger the retry
+// TestErrorRecoveryScenario_Concurrent simulates concurrent error recovery.
 func TestErrorRecoveryScenario_Concurrent(t *testing.T) {
-	t.Parallel()
-
 	settings := &Settings{}
-	settings.BirdNET.RangeFilter.LastUpdated = time.Now() // Set to today
+	settings.BirdNET.RangeFilter.LastUpdated = time.Now()
+	setupGlobalSettings(t, settings)
 
-	// Simulate a failed update by resetting the flag
-	settings.ResetRangeFilterUpdateFlag()
+	ResetRangeFilterUpdateFlag()
 
 	const numGoroutines = 100
 	var wg sync.WaitGroup
 	trueCount := 0
 	var mu sync.Mutex
 
-	// Launch multiple goroutines that all check if retry is needed
 	for range numGoroutines {
 		wg.Go(func() {
-			if settings.ShouldUpdateRangeFilterToday() {
+			if ShouldUpdateRangeFilterToday() {
 				mu.Lock()
 				trueCount++
 				mu.Unlock()
@@ -263,47 +272,38 @@ func TestErrorRecoveryScenario_Concurrent(t *testing.T) {
 	}
 
 	wg.Wait()
-
-	// CRITICAL: Only ONE goroutine should have received true
-	// This ensures that even after a reset, we don't get duplicate retries
 	assert.Equal(t, 1, trueCount, "Expected exactly 1 goroutine to receive true after reset")
 }
 
-// TestResetAndCheckInterleaved tests interleaved reset and check operations
-// to ensure they work correctly together under concurrent access
+// TestResetAndCheckInterleaved tests interleaved reset and check operations.
 func TestResetAndCheckInterleaved(t *testing.T) {
-	t.Parallel()
-
 	settings := &Settings{}
 	settings.BirdNET.RangeFilter.LastUpdated = time.Now()
+	setupGlobalSettings(t, settings)
 
 	const numIterations = 10
 	var wg sync.WaitGroup
 
-	// Goroutine 1: Repeatedly resets
 	wg.Go(func() {
 		for range numIterations {
-			settings.ResetRangeFilterUpdateFlag()
+			ResetRangeFilterUpdateFlag()
 			time.Sleep(1 * time.Millisecond)
 		}
 	})
 
-	// Goroutine 2: Repeatedly checks
 	wg.Go(func() {
 		for range numIterations {
-			settings.ShouldUpdateRangeFilterToday()
+			ShouldUpdateRangeFilterToday()
 			time.Sleep(1 * time.Millisecond)
 		}
 	})
 
-	// Goroutine 3: Repeatedly reads
 	wg.Go(func() {
 		for range numIterations {
-			settings.GetLastRangeFilterUpdate()
+			GetSettings().GetLastRangeFilterUpdate()
 			time.Sleep(1 * time.Millisecond)
 		}
 	})
 
 	wg.Wait()
-	// If we reach here without deadlock or panic, the test passes
 }

--- a/internal/conf/range_filter_test.go
+++ b/internal/conf/range_filter_test.go
@@ -67,8 +67,9 @@ func TestShouldUpdateRangeFilterToday_AlreadyUpdated(t *testing.T) {
 // TestShouldUpdateRangeFilterToday_PublishesNewSnapshot verifies that the
 // function publishes a new snapshot with LastUpdated set to today.
 func TestShouldUpdateRangeFilterToday_PublishesNewSnapshot(t *testing.T) {
+	originalUpdatedAt := time.Now().Add(-25 * time.Hour)
 	original := &Settings{}
-	original.BirdNET.RangeFilter.LastUpdated = time.Now().Add(-25 * time.Hour)
+	original.BirdNET.RangeFilter.LastUpdated = originalUpdatedAt
 	original.BirdNET.RangeFilter.Species = []string{"Original Species"}
 	setupGlobalSettings(t, original)
 
@@ -80,7 +81,7 @@ func TestShouldUpdateRangeFilterToday_PublishesNewSnapshot(t *testing.T) {
 		"Published snapshot should have LastUpdated >= today")
 	assert.Equal(t, []string{"Original Species"}, published.BirdNET.RangeFilter.Species,
 		"Species list should be preserved in the published snapshot")
-	assert.Equal(t, time.Now().Add(-25*time.Hour).Truncate(time.Second),
+	assert.Equal(t, originalUpdatedAt.Truncate(time.Second),
 		original.BirdNET.RangeFilter.LastUpdated.Truncate(time.Second),
 		"Original snapshot must not be mutated")
 }

--- a/internal/conf/storage.go
+++ b/internal/conf/storage.go
@@ -5,7 +5,6 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
-	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -429,18 +428,10 @@ func SaveSettings() error {
 	}
 
 	// Deep-clone the published snapshot before mutating it in
-	// prepareSettingsForSave. A shallow copy would leave slice and map
-	// backing arrays shared with concurrent readers that hold current;
-	// any transformation that mutates one of those nested fields would
-	// race against them.
+	// prepareSettingsForSave. The snapshot is immutable (range filter
+	// writers use clone-mutate-publish), so CloneSettings captures a
+	// consistent point-in-time copy without additional locking.
 	settingsCopy := *CloneSettings(current)
-
-	// Refresh the species list under its dedicated lock so the runtime
-	// list (shared across Species.Include/Exclude updates) is captured
-	// atomically rather than via the clone that predates the save.
-	speciesListMutex.RLock()
-	settingsCopy.BirdNET.RangeFilter.Species = slices.Clone(current.BirdNET.RangeFilter.Species)
-	speciesListMutex.RUnlock()
 
 	// Apply data transformations (seasonal tracking, etc.) on the clone.
 	settingsCopy = prepareSettingsForSave(&settingsCopy, current.BirdNET.Latitude)


### PR DESCRIPTION
## Summary

- Convert `UpdateIncludedSpecies`, `ResetRangeFilterUpdateFlag`, and `ShouldUpdateRangeFilterToday` from methods on `*Settings` to package-level functions using the clone-mutate-publish pattern
- Remove mutex from reader methods (`GetIncludedSpecies`, `IsSpeciesIncluded`, `GetLastRangeFilterUpdate`) since published snapshots are now immutable
- Remove the special `speciesListMutex`-guarded species list refresh in `SaveSettings()` since the clone already captures consistent state

## Problem

The three mutating methods directly modified the published `*Settings` snapshot, violating the immutable-snapshot contract documented on `StoreSettings`. Concurrent readers via `GetSettings()` could observe torn writes on the species slice header because they don't acquire `speciesListMutex`.

## Test plan

- [x] All existing range filter tests pass with `-race`
- [x] New snapshot immutability tests verify original pointer is never mutated
- [x] Concurrent access tests verify only one goroutine gets `true` from `ShouldUpdateRangeFilterToday`
- [x] API v2 range tests pass
- [x] `golangci-lint run -v` reports zero issues
- [x] Full build passes

Part of Forgejo #492 (conf package refactor).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Range filter now uses an immutable snapshot workflow for updates and reads, improving consistency.

* **Bug Fixes**
  * Scheduling and reset behavior for daily range-filter updates now follow the global snapshot logic.
  * API endpoints return the latest published range-filter data (species, last-updated, threshold, location).

* **Tests**
  * Range-filter tests updated to validate snapshot publishing, immutability, and global-state behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->