### PR TITLE
fix(conf): validation code quality improvements

### DIFF
--- a/internal/conf/validate.go
+++ b/internal/conf/validate.go
@@ -91,12 +91,58 @@ type ValidationResult struct {
 	Normalized any      // Normalized/transformed config (type matches input)
 }
 
+// numeric covers all Go numeric types for range validation.
+type numeric interface {
+	~int | ~int8 | ~int16 | ~int32 | ~int64 |
+		~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 |
+		~float32 | ~float64
+}
+
+// checkRange appends an error to result if value is outside [lo, hi].
+func checkRange[T numeric](result *ValidationResult, value, lo, hi T, msg string) {
+	if value < lo || value > hi {
+		result.Valid = false
+		result.Errors = append(result.Errors, msg)
+	}
+}
+
+// extractNormalized extracts and type-asserts the Normalized field from a
+// ValidationResult. Returns an error if the field is nil or the wrong type.
+func extractNormalized[T any](result ValidationResult, funcName string) (*T, error) {
+	if result.Normalized == nil {
+		return nil, errors.Newf("internal error: %s returned nil Normalized", funcName).
+			Category(errors.CategoryValidation).
+			Context("validation_type", "type-assertion").
+			Build()
+	}
+	normalized, ok := result.Normalized.(*T)
+	if !ok {
+		return nil, errors.Newf("internal error: %s returned unexpected type %T", funcName, result.Normalized).
+			Category(errors.CategoryValidation).
+			Context("validation_type", "type-assertion").
+			Build()
+	}
+	return normalized, nil
+}
+
+// firstValidationError wraps the first error from a ValidationResult into an
+// EnhancedError with the given validation type. Returns nil when valid.
+func firstValidationError(result ValidationResult, validationType string) error {
+	if result.Valid {
+		return nil
+	}
+	return errors.Newf("%s", result.Errors[0]).
+		Category(errors.CategoryValidation).
+		Context("validation_type", validationType).
+		Build()
+}
+
 // ValidateSettings validates the entire Settings struct
 func ValidateSettings(settings *Settings) error {
 	ve := ValidationError{}
 
 	// Validate BirdNET settings
-	if err := validateBirdNETSettings(&settings.BirdNET, settings); err != nil {
+	if err := validateBirdNETSettings(&settings.BirdNET); err != nil {
 		ve.Errors = append(ve.Errors, err.Error())
 	}
 

--- a/internal/conf/validate.go
+++ b/internal/conf/validate.go
@@ -131,6 +131,12 @@ func firstValidationError(result ValidationResult, validationType string) error 
 	if result.Valid {
 		return nil
 	}
+	if len(result.Errors) == 0 {
+		return errors.Newf("validation failed with no error details").
+			Category(errors.CategoryValidation).
+			Context("validation_type", validationType).
+			Build()
+	}
 	return errors.Newf("%s", result.Errors[0]).
 		Category(errors.CategoryValidation).
 		Context("validation_type", validationType).

--- a/internal/conf/validate.go
+++ b/internal/conf/validate.go
@@ -122,6 +122,12 @@ func extractNormalized[T any](result ValidationResult, funcName string) (*T, err
 			Context("validation_type", "type-assertion").
 			Build()
 	}
+	if normalized == nil {
+		return nil, errors.Newf("internal error: %s returned typed nil Normalized", funcName).
+			Category(errors.CategoryValidation).
+			Context("validation_type", "type-assertion").
+			Build()
+	}
 	return normalized, nil
 }
 

--- a/internal/conf/validate_audio.go
+++ b/internal/conf/validate_audio.go
@@ -92,19 +92,22 @@ var ValidStreamTypes = map[string]bool{
 
 // Validate validates a single stream configuration
 func (s *StreamConfig) Validate() error {
+	// Normalize fields in-place so downstream code sees trimmed values.
+	s.Name = strings.TrimSpace(s.Name)
+	s.URL = strings.TrimSpace(s.URL)
+
 	// Name is required
-	name := strings.TrimSpace(s.Name)
-	if name == "" {
+	if s.Name == "" {
 		return fmt.Errorf("stream name is required")
 	}
 
-	// Name length limit (check trimmed name for consistency)
-	if len(name) > MaxStreamNameLength {
-		return fmt.Errorf("stream name '%s' exceeds maximum length of %d characters", name, MaxStreamNameLength)
+	// Name length limit
+	if len(s.Name) > MaxStreamNameLength {
+		return fmt.Errorf("stream name '%s' exceeds maximum length of %d characters", s.Name, MaxStreamNameLength)
 	}
 
 	// URL is required
-	if strings.TrimSpace(s.URL) == "" {
+	if s.URL == "" {
 		return fmt.Errorf("stream URL is required for '%s'", s.Name)
 	}
 
@@ -232,18 +235,17 @@ func (r *RTSPSettings) ValidateStreams() error {
 		}
 
 		// Check for duplicate names (case-insensitive)
-		nameLower := strings.ToLower(strings.TrimSpace(stream.Name))
+		nameLower := strings.ToLower(stream.Name)
 		if names[nameLower] {
 			return fmt.Errorf("duplicate stream name: '%s'", stream.Name)
 		}
 		names[nameLower] = true
 
-		// Check for duplicate URLs (trimmed for consistency)
-		urlTrimmed := strings.TrimSpace(stream.URL)
-		if urls[urlTrimmed] {
+		// Check for duplicate URLs
+		if urls[stream.URL] {
 			return fmt.Errorf("stream '%s' has a duplicate URL: '%s'", stream.Name, stream.URL)
 		}
-		urls[urlTrimmed] = true
+		urls[stream.URL] = true
 	}
 
 	return nil
@@ -320,21 +322,38 @@ func (a *AudioSettings) ValidateSources() error {
 		}
 
 		// Check for duplicate names (case-insensitive)
-		nameLower := strings.ToLower(strings.TrimSpace(src.Name))
+		nameLower := strings.ToLower(src.Name)
 		if names[nameLower] {
 			return fmt.Errorf("duplicate audio source name: '%s'", src.Name)
 		}
 		names[nameLower] = true
 
-		// Check for duplicate devices (trimmed for consistency)
-		deviceTrimmed := strings.TrimSpace(src.Device)
-		if devices[deviceTrimmed] {
+		// Check for duplicate devices
+		if devices[src.Device] {
 			return fmt.Errorf("audio source '%s' has a duplicate device: '%s'", src.Name, src.Device)
 		}
-		devices[deviceTrimmed] = true
+		devices[src.Device] = true
 	}
 
 	return nil
+}
+
+// clearFfmpegMetadata resets all FFmpeg-related fields when path validation fails.
+func (s *AudioSettings) clearFfmpegMetadata() {
+	s.FfmpegPath = ""
+	s.FfmpegVersion = ""
+	s.FfmpegMajor = 0
+	s.FfmpegMinor = 0
+}
+
+// applyFfmpegFormatFallback forces WAV export when FFmpeg is unavailable and
+// export is enabled. Does nothing when export is disabled.
+func (s *AudioSettings) applyFfmpegFormatFallback() {
+	if s.Export.Enabled && s.FfmpegPath == "" && s.Export.Type != AudioExportTypeWAV {
+		GetLogger().Warn("FFmpeg not available, forcing WAV format for audio export",
+			logger.String("previous_type", s.Export.Type))
+		s.Export.Type = AudioExportTypeWAV
+	}
 }
 
 // validateAudioSettings validates the audio settings and sets ffmpeg and sox paths
@@ -345,7 +364,7 @@ func validateAudioSettings(settings *AudioSettings) error {
 		GetLogger().Warn("FFmpeg validation failed", logger.Error(ffmpegErr), logger.String("impact", "Audio export/conversion requiring FFmpeg might be disabled or use defaults"))
 		// Log validation warning for telemetry
 		logValidationWarning(ffmpegErr, "audio-tool-ffmpeg", "ffmpeg-not-available")
-		settings.FfmpegPath = "" // Ensure path is empty if validation failed
+		settings.clearFfmpegMetadata()
 	} else {
 		settings.FfmpegPath = validatedFfmpegPath // Store the validated path (explicit or from PATH)
 
@@ -422,11 +441,7 @@ func validateAudioSettings(settings *AudioSettings) error {
 			Build()
 	}
 
-	if settings.FfmpegPath == "" && settings.Export.Type != AudioExportTypeWAV {
-		GetLogger().Warn("FFmpeg not available, forcing WAV format for audio export",
-			logger.String("previous_type", settings.Export.Type))
-		settings.Export.Type = AudioExportTypeWAV
-	}
+	settings.applyFfmpegFormatFallback()
 
 	// Bitrate only matters for lossy formats and only when export is enabled.
 	switch settings.Export.Type {

--- a/internal/conf/validate_cleanup_test.go
+++ b/internal/conf/validate_cleanup_test.go
@@ -124,6 +124,7 @@ func TestClearFfmpegMetadata(t *testing.T) {
 
 // Integration check: validateAudioSettings clears metadata when FFmpeg is absent.
 func TestValidateAudioSettings_ClearsFFmpegMetadataOnFailure(t *testing.T) {
+	t.Parallel()
 	if _, err := exec.LookPath(GetFfmpegBinaryName()); err == nil {
 		t.Skip("ffmpeg found on PATH; integration test requires ffmpeg to be absent")
 	}

--- a/internal/conf/validate_cleanup_test.go
+++ b/internal/conf/validate_cleanup_test.go
@@ -1,0 +1,198 @@
+package conf
+
+import (
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Tests for issue #493: validation code quality improvements.
+
+// Item 1: validateBirdNETSettings no longer takes unused *Settings param.
+// Covered implicitly by compilation: the call site in ValidateSettings
+// passes only one argument. No runtime test needed beyond the existing
+// TestValidateSoundLevelSettings suite exercising the full path.
+
+// Item 2 + A: StreamConfig.Validate now trims Name and URL in-place.
+func TestStreamConfigValidate_TrimsFieldsInPlace(t *testing.T) {
+	t.Parallel()
+
+	s := &StreamConfig{
+		Name:      "  my-stream  ",
+		URL:       "  rtsp://example.com/stream  ",
+		Type:      StreamTypeRTSP,
+		Transport: "tcp",
+	}
+	err := s.Validate()
+	require.NoError(t, err)
+	assert.Equal(t, "my-stream", s.Name, "Name should be trimmed in-place")
+	assert.Equal(t, "rtsp://example.com/stream", s.URL, "URL should be trimmed in-place")
+}
+
+// Item 3: Nil guards on exported pure validators.
+func TestNilGuards(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		validate func() ValidationResult
+	}{
+		{"ValidateBirdNETSettings", func() ValidationResult { return ValidateBirdNETSettings(nil) }},
+		{"ValidateBirdweatherSettings", func() ValidationResult { return ValidateBirdweatherSettings(nil) }},
+		{"ValidateMQTTSettings", func() ValidationResult { return ValidateMQTTSettings(nil) }},
+		{"ValidateWebServerSettings", func() ValidationResult { return ValidateWebServerSettings(nil) }},
+		{"ValidateTelemetrySettings", func() ValidationResult { return ValidateTelemetrySettings(nil) }},
+		{"ValidateWebhookProvider", func() ValidationResult { return ValidateWebhookProvider(nil) }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := tt.validate()
+			assert.False(t, result.Valid, "nil input should fail validation")
+			require.NotEmpty(t, result.Errors, "nil input should produce an error")
+			assert.Contains(t, result.Errors[0], "nil")
+		})
+	}
+}
+
+// Item 4: Whitespace-only MQTT broker/topic must be rejected.
+func TestValidateMQTTSettings_WhitespaceOnlyBrokerAndTopic(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		broker      string
+		topic       string
+		errContains string
+	}{
+		{
+			name:        "whitespace-only broker",
+			broker:      "   ",
+			topic:       "birds/detections",
+			errContains: "broker URL is required",
+		},
+		{
+			name:        "whitespace-only topic",
+			broker:      "tcp://localhost:1883",
+			topic:       "   ",
+			errContains: "topic is required",
+		},
+		{
+			name:        "both whitespace-only",
+			broker:      "  ",
+			topic:       "\t",
+			errContains: "broker URL is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			settings := &MQTTSettings{
+				Enabled: true,
+				Broker:  tt.broker,
+				Topic:   tt.topic,
+			}
+			result := ValidateMQTTSettings(settings)
+			assert.False(t, result.Valid, "whitespace-only values should fail")
+			require.NotEmpty(t, result.Errors)
+			assert.Contains(t, result.Errors[0], tt.errContains)
+		})
+	}
+}
+
+// Item 5: clearFfmpegMetadata resets all FFmpeg-related fields.
+func TestClearFfmpegMetadata(t *testing.T) {
+	t.Parallel()
+
+	settings := &AudioSettings{
+		FfmpegPath:    "/usr/bin/ffmpeg",
+		FfmpegVersion: "6.1.2",
+		FfmpegMajor:   6,
+		FfmpegMinor:   1,
+	}
+	settings.clearFfmpegMetadata()
+
+	assert.Empty(t, settings.FfmpegPath)
+	assert.Empty(t, settings.FfmpegVersion)
+	assert.Zero(t, settings.FfmpegMajor)
+	assert.Zero(t, settings.FfmpegMinor)
+}
+
+// Integration check: validateAudioSettings clears metadata when FFmpeg is absent.
+func TestValidateAudioSettings_ClearsFFmpegMetadataOnFailure(t *testing.T) {
+	if _, err := exec.LookPath(GetFfmpegBinaryName()); err == nil {
+		t.Skip("ffmpeg found on PATH; integration test requires ffmpeg to be absent")
+	}
+
+	settings := &AudioSettings{
+		FfmpegPath:    "/nonexistent/ffmpeg",
+		FfmpegVersion: "6.1.2",
+		FfmpegMajor:   6,
+		FfmpegMinor:   1,
+		Export: ExportSettings{
+			Enabled: false,
+			Type:    AudioExportTypeWAV,
+		},
+	}
+	_ = validateAudioSettings(settings)
+
+	assert.Empty(t, settings.FfmpegPath)
+	assert.Empty(t, settings.FfmpegVersion)
+	assert.Zero(t, settings.FfmpegMajor)
+	assert.Zero(t, settings.FfmpegMinor)
+}
+
+// Item 6: Export format is not rewritten when export is disabled and FFmpeg is missing.
+func TestApplyFfmpegFormatFallback_NoRewriteWhenDisabled(t *testing.T) {
+	t.Parallel()
+
+	settings := &AudioSettings{
+		FfmpegPath: "",
+		Export: ExportSettings{
+			Enabled: false,
+			Type:    AudioExportTypeFLAC,
+		},
+	}
+	settings.applyFfmpegFormatFallback()
+
+	assert.Equal(t, AudioExportTypeFLAC, settings.Export.Type,
+		"Export.Type should not be rewritten to WAV when export is disabled")
+}
+
+// Ensure the format IS rewritten when export is enabled and FFmpeg is missing.
+func TestApplyFfmpegFormatFallback_RewritesWhenEnabled(t *testing.T) {
+	t.Parallel()
+
+	settings := &AudioSettings{
+		FfmpegPath: "",
+		Export: ExportSettings{
+			Enabled: true,
+			Type:    AudioExportTypeFLAC,
+		},
+	}
+	settings.applyFfmpegFormatFallback()
+
+	assert.Equal(t, AudioExportTypeWAV, settings.Export.Type,
+		"Export.Type should be forced to WAV when export is enabled and FFmpeg is missing")
+}
+
+// Verify WAV format is not touched even when enabled and FFmpeg is missing.
+func TestApplyFfmpegFormatFallback_LeavesWAVAlone(t *testing.T) {
+	t.Parallel()
+
+	settings := &AudioSettings{
+		FfmpegPath: "",
+		Export: ExportSettings{
+			Enabled: true,
+			Type:    AudioExportTypeWAV,
+		},
+	}
+	settings.applyFfmpegFormatFallback()
+
+	assert.Equal(t, AudioExportTypeWAV, settings.Export.Type,
+		"WAV format should not be touched")
+}

--- a/internal/conf/validate_services.go
+++ b/internal/conf/validate_services.go
@@ -21,56 +21,30 @@ import (
 //
 // The private validateBirdNETSettings() calls this and handles side effects.
 func ValidateBirdNETSettings(cfg *BirdNETConfig) ValidationResult {
+	if cfg == nil {
+		return ValidationResult{Valid: false, Errors: []string{"BirdNET config is nil"}}
+	}
 	result := ValidationResult{Valid: true, Warnings: []string{}}
 	normalized := *cfg
 
-	// Sensitivity range check
-	if cfg.Sensitivity < 0 || cfg.Sensitivity > 1.5 {
-		result.Valid = false
-		result.Errors = append(result.Errors, "BirdNET sensitivity must be between 0 and 1.5")
-	}
+	checkRange(&result, cfg.Sensitivity, 0, 1.5, "BirdNET sensitivity must be between 0 and 1.5")
+	checkRange(&result, cfg.Threshold, 0, 1, "BirdNET threshold must be between 0 and 1")
+	checkRange(&result, cfg.Overlap, 0, 2.99, "BirdNET overlap value must be between 0 and 2.99 seconds")
+	checkRange(&result, cfg.Longitude, -180, 180, "BirdNET longitude must be between -180 and 180")
+	checkRange(&result, cfg.Latitude, -90, 90, "BirdNET latitude must be between -90 and 90")
 
-	// Threshold range check
-	if cfg.Threshold < 0 || cfg.Threshold > 1 {
-		result.Valid = false
-		result.Errors = append(result.Errors, "BirdNET threshold must be between 0 and 1")
-	}
-
-	// Overlap range check
-	if cfg.Overlap < 0 || cfg.Overlap > 2.99 {
-		result.Valid = false
-		result.Errors = append(result.Errors, "BirdNET overlap value must be between 0 and 2.99 seconds")
-	}
-
-	// Longitude range check
-	if cfg.Longitude < -180 || cfg.Longitude > 180 {
-		result.Valid = false
-		result.Errors = append(result.Errors, "BirdNET longitude must be between -180 and 180")
-	}
-
-	// Latitude range check
-	if cfg.Latitude < -90 || cfg.Latitude > 90 {
-		result.Valid = false
-		result.Errors = append(result.Errors, "BirdNET latitude must be between -90 and 90")
-	}
-
-	// Threads check
 	if cfg.Threads < 0 {
 		result.Valid = false
 		result.Errors = append(result.Errors, "BirdNET threads must be at least 0")
 	}
 
-	// RangeFilter model check - empty string, "latest", or "legacy" are valid
+	// Empty string, "latest", or "legacy" are valid
 	if cfg.RangeFilter.Model != "" && cfg.RangeFilter.Model != "latest" && cfg.RangeFilter.Model != "legacy" {
 		result.Valid = false
 		result.Errors = append(result.Errors, "RangeFilter model must be either empty (v2 default), 'latest', or 'legacy'")
 	}
 
-	// RangeFilter threshold check
-	if cfg.RangeFilter.Threshold < 0 || cfg.RangeFilter.Threshold > 1 {
-		result.Valid = false
-		result.Errors = append(result.Errors, "RangeFilter threshold must be between 0 and 1")
-	}
+	checkRange(&result, cfg.RangeFilter.Threshold, 0, 1, "RangeFilter threshold must be between 0 and 1")
 
 	// Locale validation and normalization (pure transformation)
 	if cfg.Locale != "" {
@@ -91,6 +65,9 @@ func ValidateBirdNETSettings(cfg *BirdNETConfig) ValidationResult {
 // ValidateBirdweatherSettings performs Birdweather validation without side effects.
 // Returns validation result with normalized settings.
 func ValidateBirdweatherSettings(settings *BirdweatherSettings) ValidationResult {
+	if settings == nil {
+		return ValidationResult{Valid: false, Errors: []string{"Birdweather settings is nil"}}
+	}
 	result := ValidationResult{Valid: true, Warnings: []string{}}
 	normalized := *settings
 
@@ -110,13 +87,8 @@ func ValidateBirdweatherSettings(settings *BirdweatherSettings) ValidationResult
 			result.Warnings = append(result.Warnings, "Birdweather will be disabled due to invalid ID format")
 		}
 
-		// Check threshold range
-		if settings.Threshold < 0 || settings.Threshold > 1 {
-			result.Valid = false
-			result.Errors = append(result.Errors, "birdweather threshold must be between 0 and 1")
-		}
+		checkRange(&result, settings.Threshold, 0, 1, "birdweather threshold must be between 0 and 1")
 
-		// Check location accuracy
 		if settings.LocationAccuracy < 0 {
 			result.Valid = false
 			result.Errors = append(result.Errors, "birdweather location accuracy must be non-negative")
@@ -130,6 +102,9 @@ func ValidateBirdweatherSettings(settings *BirdweatherSettings) ValidationResult
 // ValidateWebhookProvider performs webhook provider validation without side effects.
 // Returns validation result with errors.
 func ValidateWebhookProvider(p *PushProviderConfig) ValidationResult {
+	if p == nil {
+		return ValidationResult{Valid: false, Errors: []string{"webhook provider config is nil"}}
+	}
 	result := ValidationResult{Valid: true}
 
 	if !p.Enabled {
@@ -198,15 +173,23 @@ func ValidateWebhookProvider(p *PushProviderConfig) ValidationResult {
 	return result
 }
 
-// ValidateMQTTSettings performs MQTT validation without side effects.
+// ValidateMQTTSettings performs MQTT validation.
+// Trims Broker and Topic in-place before checking.
 // Returns validation result with errors.
 func ValidateMQTTSettings(settings *MQTTSettings) ValidationResult {
+	if settings == nil {
+		return ValidationResult{Valid: false, Errors: []string{"MQTT settings is nil"}}
+	}
 	result := ValidationResult{Valid: true}
 
 	if !settings.Enabled {
 		result.Normalized = settings
 		return result
 	}
+
+	// Normalize fields in-place so downstream code sees trimmed values.
+	settings.Broker = strings.TrimSpace(settings.Broker)
+	settings.Topic = strings.TrimSpace(settings.Topic)
 
 	// Check if broker is provided when enabled
 	if settings.Broker == "" {
@@ -247,6 +230,9 @@ func ValidateMQTTSettings(settings *MQTTSettings) ValidationResult {
 // ValidateWebServerSettings performs WebServer validation without side effects.
 // Returns validation result with errors.
 func ValidateWebServerSettings(settings *WebServerSettings) ValidationResult {
+	if settings == nil {
+		return ValidationResult{Valid: false, Errors: []string{"WebServer settings is nil"}}
+	}
 	result := ValidationResult{Valid: true}
 
 	if settings.Enabled {
@@ -335,6 +321,9 @@ func validateBasePath(basePath string) error {
 // ValidateTelemetrySettings validates the telemetry endpoint configuration.
 // Returns validation result with errors if enabled and listen address is malformed.
 func ValidateTelemetrySettings(settings *TelemetrySettings) ValidationResult {
+	if settings == nil {
+		return ValidationResult{Valid: false, Errors: []string{"telemetry settings is nil"}}
+	}
 	result := ValidationResult{Valid: true}
 
 	if !settings.Enabled {
@@ -372,20 +361,14 @@ func ValidateTelemetrySettings(settings *TelemetrySettings) ValidationResult {
 // validateBirdNETSettings validates the BirdNET-specific settings.
 // This function uses ValidateBirdNETSettings internally and handles side effects
 // (logging, mutation) to maintain backward compatibility.
-func validateBirdNETSettings(birdnetSettings *BirdNETConfig, settings *Settings) error {
-	// Call the pure validation function
+func validateBirdNETSettings(birdnetSettings *BirdNETConfig) error {
 	result := ValidateBirdNETSettings(birdnetSettings)
 
-	// Apply normalized configuration (side effect: mutation)
-	if normalized, ok := result.Normalized.(*BirdNETConfig); ok && normalized != nil {
-		*birdnetSettings = *normalized
-	} else if !ok {
-		// Type assertion failed - this indicates a bug in ValidateBirdNETSettings
-		return errors.Newf("internal error: ValidateBirdNETSettings returned unexpected type %T", result.Normalized).
-			Category(errors.CategoryValidation).
-			Context("validation_type", "birdnet-type-assertion").
-			Build()
+	normalized, err := extractNormalized[BirdNETConfig](result, "ValidateBirdNETSettings")
+	if err != nil {
+		return err
 	}
+	*birdnetSettings = *normalized
 
 	// Handle warnings (side effects: logging)
 	// Locale fallback warnings are debug-level since the fallback works correctly
@@ -409,72 +392,33 @@ func validateBirdNETSettings(birdnetSettings *BirdNETConfig, settings *Settings)
 // This function uses ValidateWebServerSettings internally and handles error formatting
 // to maintain backward compatibility.
 func validateWebServerSettings(settings *WebServerSettings) error {
-	// Call the pure validation function
-	result := ValidateWebServerSettings(settings)
-
-	// Return errors if validation failed
-	if !result.Valid {
-		// Format first error with enhanced error for backward compatibility
-		firstError := result.Errors[0]
-		return errors.Newf("%s", firstError).
-			Category(errors.CategoryValidation).
-			Context("validation_type", "webserver-settings").
-			Build()
-	}
-
-	return nil
+	return firstValidationError(ValidateWebServerSettings(settings), "webserver-settings")
 }
 
 // validateMQTTSettings validates the MQTT-specific settings.
 // This function uses ValidateMQTTSettings internally and handles error formatting
 // to maintain backward compatibility.
 func validateMQTTSettings(settings *MQTTSettings) error {
-	// Call the pure validation function
-	result := ValidateMQTTSettings(settings)
-
-	// Return errors if validation failed
-	if !result.Valid {
-		// Format first error with enhanced error for backward compatibility
-		firstError := result.Errors[0]
-		return errors.Newf("%s", firstError).
-			Category(errors.CategoryValidation).
-			Context("validation_type", "mqtt-settings").
-			Build()
-	}
-
-	return nil
+	return firstValidationError(ValidateMQTTSettings(settings), "mqtt-settings")
 }
 
 // validateTelemetrySettings validates the telemetry-specific settings.
 // This function uses ValidateTelemetrySettings internally and handles error formatting.
 func validateTelemetrySettings(settings *TelemetrySettings) error {
-	result := ValidateTelemetrySettings(settings)
-	if !result.Valid {
-		return errors.Newf("%s", result.Errors[0]).
-			Category(errors.CategoryValidation).
-			Context("validation_type", "telemetry-listen-address").
-			Build()
-	}
-	return nil
+	return firstValidationError(ValidateTelemetrySettings(settings), "telemetry-listen-address")
 }
 
 // validateBirdweatherSettings validates the Birdweather-specific settings.
 // This function uses ValidateBirdweatherSettings internally and handles side effects
 // (logging, mutation) to maintain backward compatibility.
 func validateBirdweatherSettings(settings *BirdweatherSettings) error {
-	// Call the pure validation function
 	result := ValidateBirdweatherSettings(settings)
 
-	// Apply normalized configuration (side effect: mutation)
-	if normalized, ok := result.Normalized.(*BirdweatherSettings); ok && normalized != nil {
-		*settings = *normalized
-	} else if !ok {
-		// Type assertion failed - this indicates a bug in ValidateBirdweatherSettings
-		return errors.Newf("internal error: ValidateBirdweatherSettings returned unexpected type %T", result.Normalized).
-			Category(errors.CategoryValidation).
-			Context("validation_type", "birdweather-type-assertion").
-			Build()
+	normalized, err := extractNormalized[BirdweatherSettings](result, "ValidateBirdweatherSettings")
+	if err != nil {
+		return err
 	}
+	*settings = *normalized
 
 	// Handle warnings (side effect: logging)
 	for _, warning := range result.Warnings {
@@ -555,9 +499,7 @@ func validateWebhookProvider(p *PushProviderConfig) error {
 
 	// Return early if basic validation failed
 	if !result.Valid {
-		// Format first error with enhanced error for backward compatibility
-		firstError := result.Errors[0]
-		return errors.Newf("%s", firstError).
+		return errors.Newf("%s", result.Errors[0]).
 			Category(errors.CategoryValidation).
 			Context("validation_type", "notification-push-webhook").
 			Context("provider_name", p.Name).


### PR DESCRIPTION
## Summary

- Address pre-existing validation code quality issues identified during the validate.go split (PR #2871) review
- Fix correctness issues (nil guards, whitespace handling, type assertion gaps, FFmpeg metadata leaks)
- Extract reusable helpers to reduce boilerplate and improve consistency

## Changes

**Fixes:**
- Remove unused `settings` parameter from `validateBirdNETSettings`
- Trim `StreamConfig` Name and URL in-place (consistent with `AudioSourceConfig`)
- Add nil guards to all six exported pure validators
- Reject whitespace-only MQTT broker/topic; normalize in-place
- Clear FFmpeg version metadata on path validation failure
- Guard FFmpeg-missing format fallback behind `Export.Enabled`
- Fix type assertion nil gap where typed nil silently fell through

**Refactors:**
- Extract generic `checkRange[T]` helper for float/int range validation
- Extract `extractNormalized[T]` for type assertion on `ValidationResult`
- Extract `firstValidationError` for error-wrapping boilerplate
- Extract `clearFfmpegMetadata` and `applyFfmpegFormatFallback` methods
- Remove redundant `TrimSpace` calls in `ValidateStreams`/`ValidateSources`
- Remove comments that restate what the code does
- Fix `ValidateMQTTSettings` docstring (documents in-place trimming)

## Test plan

- [x] All existing conf package tests pass with `-race`
- [x] New test file `validate_cleanup_test.go` covers nil guards, whitespace rejection, stream field trimming, FFmpeg metadata clearing, and format fallback logic
- [x] `golangci-lint` reports zero issues
- [x] Full project builds cleanly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * FFmpeg fallback now forces WAV export when FFmpeg is unavailable and clears FFmpeg-related metadata, with clearer warnings.
  * Validators now handle nil inputs gracefully and return explicit validation errors instead of panicking.

* **Refactor**
  * Validation logic standardized with unified range checks and consistent first-error reporting.
  * Stream, audio source and MQTT fields are normalized during validation; duplicate-detection comparisons use the normalized/raw fields consistently.

* **Tests**
  * New tests cover normalization, FFmpeg fallback, duplicate-detection and nil-input behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->