### PR TITLE
fix(frontend): apply base paths to missing images, spectrograms etc

### DIFF
--- a/frontend/src/lib/desktop/components/modals/ReviewModal.svelte
+++ b/frontend/src/lib/desktop/components/modals/ReviewModal.svelte
@@ -7,6 +7,7 @@
   import SpeciesThumbnail from './SpeciesThumbnail.svelte';
   import type { Detection } from '$lib/types/detection.types';
   import { fetchWithCSRF } from '$lib/utils/api';
+  import { buildAppUrl } from '$lib/utils/urlHelpers';
   import { XCircle, TriangleAlert, ChevronRight } from '@lucide/svelte';
   import { t } from '$lib/i18n';
   import { safeArrayAccess } from '$lib/utils/security';
@@ -203,7 +204,7 @@
           <!-- Audio and Spectrogram -->
           <div class="relative bg-[var(--color-base-200)] rounded-lg p-4">
             <AudioPlayer
-              audioUrl="/api/v2/audio/{detection.id}"
+              audioUrl={buildAppUrl(`/api/v2/audio/${detection.id}`)}
               detectionId={detection.id.toString()}
               showSpectrogram={true}
               spectrogramSize="lg"

--- a/frontend/src/lib/desktop/components/modals/SpeciesThumbnail.svelte
+++ b/frontend/src/lib/desktop/components/modals/SpeciesThumbnail.svelte
@@ -18,6 +18,7 @@
 -->
 <script lang="ts">
   import { handleBirdImageError } from '$lib/desktop/components/ui/image-utils.js';
+  import { buildAppUrl } from '$lib/utils/urlHelpers';
 
   interface Props {
     scientificName: string;
@@ -47,7 +48,7 @@
   class={`${sizeClasses} relative overflow-hidden rounded-lg bg-[var(--color-base-100)] shadow-md shrink-0 ${className}`}
 >
   <img
-    src="/api/v2/media/species-image?name={encodeURIComponent(scientificName)}"
+    src={buildAppUrl(`/api/v2/media/species-image?name=${encodeURIComponent(scientificName)}`)}
     alt={commonName}
     class="w-full h-full object-cover"
     onerror={handleBirdImageError}

--- a/frontend/src/lib/desktop/components/ui/image-utils.test.ts
+++ b/frontend/src/lib/desktop/components/ui/image-utils.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { handleBirdImageError } from './image-utils';
+import { setBasePath, resetBasePath } from '$lib/utils/urlHelpers';
+
+describe('handleBirdImageError', () => {
+  afterEach(() => {
+    resetBasePath();
+  });
+
+  it('rewrites src to the placeholder asset', () => {
+    const img = document.createElement('img');
+    handleBirdImageError({ currentTarget: img } as unknown as Event);
+
+    expect(img.src).toContain('/ui/assets/bird-placeholder.svg');
+  });
+
+  it('includes the configured base path when one is set (regression)', () => {
+    // Simulates BirdNET-Go running behind a reverse proxy at /birdnet.
+    // Without buildAppUrl, the placeholder request 404s under such setups.
+    setBasePath('/birdnet');
+
+    const img = document.createElement('img');
+    handleBirdImageError({ currentTarget: img } as unknown as Event);
+
+    expect(img.src).toContain('/birdnet/ui/assets/bird-placeholder.svg');
+  });
+});

--- a/frontend/src/lib/desktop/components/ui/image-utils.ts
+++ b/frontend/src/lib/desktop/components/ui/image-utils.ts
@@ -2,11 +2,13 @@
  * Image utility functions for UI components
  */
 
+import { buildAppUrl } from '$lib/utils/urlHelpers';
+
 /**
  * Handles bird thumbnail image load errors by replacing failed images with a bird placeholder
  * @param e - The error event from the bird thumbnail image element
  */
 export function handleBirdImageError(e: Event): void {
   const target = e.currentTarget as globalThis.HTMLImageElement;
-  target.src = '/ui/assets/bird-placeholder.svg';
+  target.src = buildAppUrl('/ui/assets/bird-placeholder.svg');
 }

--- a/frontend/src/lib/desktop/features/analytics/pages/Analytics.svelte
+++ b/frontend/src/lib/desktop/features/analytics/pages/Analytics.svelte
@@ -12,6 +12,7 @@
   import ChartCard from '../components/ui/ChartCard.svelte';
   import StatCard from '../components/ui/StatCard.svelte';
   import { handleBirdImageError } from '$lib/desktop/components/ui/image-utils';
+  import { buildAppUrl } from '$lib/utils/urlHelpers';
 
   const logger = getLogger('app');
 
@@ -1381,9 +1382,9 @@
                       <div class="w-8 h-8 rounded-full bg-[var(--color-base-200)] overflow-hidden">
                         <!-- PERFORMANCE OPTIMIZATION: Enhanced image loading for species thumbnails -->
                         <img
-                          src="/api/v2/media/species-image?name={encodeURIComponent(
-                            detection.scientificName
-                          )}"
+                          src={buildAppUrl(
+                            `/api/v2/media/species-image?name=${encodeURIComponent(detection.scientificName)}`
+                          )}
                           alt={detection.commonName || 'Unknown species'}
                           class="w-full h-full object-cover"
                           onerror={handleBirdImageError}
@@ -1440,9 +1441,9 @@
                   class="w-10 h-10 rounded-full bg-[var(--color-base-200)] overflow-hidden shrink-0"
                 >
                   <img
-                    src="/api/v2/media/species-image?name={encodeURIComponent(
-                      detection.scientificName
-                    )}"
+                    src={buildAppUrl(
+                      `/api/v2/media/species-image?name=${encodeURIComponent(detection.scientificName)}`
+                    )}
                     alt={detection.commonName || 'Unknown species'}
                     class="w-full h-full object-cover"
                     onerror={handleBirdImageError}

--- a/frontend/src/lib/desktop/features/analytics/pages/Species.svelte
+++ b/frontend/src/lib/desktop/features/analytics/pages/Species.svelte
@@ -144,7 +144,15 @@
         throw new Error(`Server responded with ${response.status}`);
       }
 
-      speciesData = await response.json();
+      const rawSpecies: SpeciesData[] = await response.json();
+      // Backend returns relative URLs (e.g. /api/v2/media/image/...). Run them
+      // through buildAppUrl so they include the configured base path (e.g.
+      // /birdnet, HA Ingress token) before they end up in <img src=...>.
+      speciesData = rawSpecies.map(species =>
+        species.thumbnail_url
+          ? { ...species, thumbnail_url: buildAppUrl(species.thumbnail_url) }
+          : species
+      );
       applyFilters();
 
       // Load thumbnails asynchronously after main data is displayed
@@ -292,10 +300,13 @@
         if (response.ok) {
           const thumbnails = await response.json();
 
-          // Update species data with fetched thumbnails
+          // Update species data with fetched thumbnails. Backend URLs are
+          // relative; buildAppUrl prepends the configured base path so the
+          // image request resolves correctly behind a reverse proxy.
           speciesData = speciesData.map(species => {
-            if (thumbnails[species.scientific_name]) {
-              return { ...species, thumbnail_url: thumbnails[species.scientific_name] };
+            const url = thumbnails[species.scientific_name];
+            if (url) {
+              return { ...species, thumbnail_url: buildAppUrl(url) };
             }
             return species;
           });

--- a/frontend/src/lib/desktop/features/analytics/pages/Species.test.ts
+++ b/frontend/src/lib/desktop/features/analytics/pages/Species.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { cleanup, waitFor } from '@testing-library/svelte';
+import { createComponentTestFactory } from '../../../../../test/render-helpers';
+import { setBasePath, resetBasePath } from '$lib/utils/urlHelpers';
+import Species from './Species.svelte';
+
+interface SpeciesSummary {
+  common_name: string;
+  scientific_name: string;
+  count: number;
+  avg_confidence: number;
+  max_confidence: number;
+  first_heard: string;
+  last_heard: string;
+  thumbnail_url?: string;
+}
+
+function mockFetchSequence(handlers: Record<string, () => unknown>) {
+  return vi.fn().mockImplementation((input: RequestInfo | URL) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    for (const [pattern, body] of Object.entries(handlers)) {
+      if (url.includes(pattern)) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          statusText: 'OK',
+          headers: new Headers({ 'content-type': 'application/json' }),
+          json: () => Promise.resolve(body()),
+          text: () => Promise.resolve(JSON.stringify(body())),
+        });
+      }
+    }
+    return Promise.reject(new Error(`Unexpected fetch in test: ${url}`));
+  });
+}
+
+const speciesTest = createComponentTestFactory(Species);
+
+describe('Species (analytics page)', () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    cleanup();
+    resetBasePath();
+    globalThis.fetch = originalFetch;
+  });
+
+  it('prefixes thumbnail URLs with the configured base path (regression)', async () => {
+    // Reproduces the bug reported on /ui/analytics/species: the backend
+    // returns a relative thumbnail_url like /api/v2/media/image/<name>, and
+    // when configured behind a reverse proxy (e.g. /birdnet), the frontend
+    // must prepend the base path before using it as <img src>.
+    setBasePath('/birdnet');
+
+    const summary: SpeciesSummary[] = [
+      {
+        common_name: "Wilson's Warbler",
+        scientific_name: 'Cardellina pusilla',
+        count: 42,
+        avg_confidence: 0.85,
+        max_confidence: 0.95,
+        first_heard: '2026-04-01',
+        last_heard: '2026-04-27',
+        thumbnail_url: '/api/v2/media/image/Cardellina%20pusilla',
+      },
+    ];
+
+    globalThis.fetch = mockFetchSequence({
+      '/api/v2/analytics/species/summary': () => summary,
+      '/api/v2/analytics/species/thumbnails': () => ({}),
+    });
+
+    const { container } = speciesTest.render({});
+
+    // Wait for the async fetch + render to complete and an <img> to appear
+    // in either the grid card or the table list view.
+    const img = await waitFor(
+      () => {
+        const found = container.querySelector('img');
+        if (!found) throw new Error('image not yet rendered');
+        return found;
+      },
+      { timeout: 2000 }
+    );
+
+    expect(img.getAttribute('src')).toBe('/birdnet/api/v2/media/image/Cardellina%20pusilla');
+  });
+
+  it('also prefixes URLs returned by the batched thumbnails endpoint', async () => {
+    setBasePath('/birdnet');
+
+    const summary: SpeciesSummary[] = [
+      {
+        common_name: 'Northern Cardinal',
+        scientific_name: 'Cardinalis cardinalis',
+        count: 7,
+        avg_confidence: 0.91,
+        max_confidence: 0.99,
+        first_heard: '2026-04-10',
+        last_heard: '2026-04-26',
+        // No thumbnail_url here — the page's loadThumbnailsAsync() should
+        // populate it from the batch endpoint.
+      },
+    ];
+
+    globalThis.fetch = mockFetchSequence({
+      '/api/v2/analytics/species/summary': () => summary,
+      '/api/v2/analytics/species/thumbnails': () => ({
+        'Cardinalis cardinalis': '/api/v2/media/image/Cardinalis%20cardinalis',
+      }),
+    });
+
+    const { container } = speciesTest.render({});
+
+    const img = await waitFor(
+      () => {
+        const found = container.querySelector('img');
+        if (!found?.getAttribute('src')?.includes('Cardinalis')) {
+          throw new Error('thumbnail not yet rendered');
+        }
+        return found;
+      },
+      { timeout: 2000 }
+    );
+
+    expect(img.getAttribute('src')).toBe('/birdnet/api/v2/media/image/Cardinalis%20cardinalis');
+  });
+});

--- a/frontend/src/lib/desktop/features/dashboard/components/CurrentlyHearingCard.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/components/CurrentlyHearingCard.svelte
@@ -17,6 +17,7 @@ Props:
   import { untrack } from 'svelte';
   import { t } from '$lib/i18n';
   import type { PendingDetection } from '$lib/types/pending.types';
+  import { buildAppUrl } from '$lib/utils/urlHelpers';
 
   interface Props {
     detections: PendingDetection[];
@@ -167,7 +168,7 @@ Props:
           <!-- Thumbnail -->
           {#if detection.thumbnail}
             <img
-              src={detection.thumbnail}
+              src={buildAppUrl(detection.thumbnail)}
               alt={detection.species}
               class="h-8 aspect-[4/3] rounded-md object-cover"
             />

--- a/frontend/src/lib/desktop/features/dashboard/components/DailySummaryCard.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/components/DailySummaryCard.svelte
@@ -1023,10 +1023,11 @@ Responsive Breakpoints:
                 <div class="species-label-col shrink-0 flex items-center gap-2 pr-4">
                   {#if showThumbnails}
                     <BirdThumbnailPopup
-                      thumbnailUrl={item.thumbnail_url ||
-                        buildAppUrl(
-                          `/api/v2/media/species-image?name=${encodeURIComponent(item.scientific_name)}`
-                        )}
+                      thumbnailUrl={item.thumbnail_url
+                        ? buildAppUrl(item.thumbnail_url)
+                        : buildAppUrl(
+                            `/api/v2/media/species-image?name=${encodeURIComponent(item.scientific_name)}`
+                          )}
                       commonName={item.common_name}
                       scientificName={item.scientific_name}
                       detectionUrl={urlBuilders.species(item)}

--- a/frontend/src/lib/desktop/features/dashboard/components/DetectionCard.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/components/DetectionCard.svelte
@@ -25,6 +25,7 @@
   import ActionMenu from '$lib/desktop/components/ui/ActionMenu.svelte';
   import AudioSettingsButton from './AudioSettingsButton.svelte';
   import { cn } from '$lib/utils/cn';
+  import { buildAppUrl } from '$lib/utils/urlHelpers';
   import { createSpectrogramLoader } from '$lib/utils/spectrogramLoader.svelte';
   import { DEFAULT_PLAYBACK_SPEED } from '$lib/utils/audio';
   import { get } from 'svelte/store';
@@ -128,7 +129,7 @@
   function handleDownload() {
     // Create a temporary anchor element to trigger download
     const link = document.createElement('a');
-    link.href = `/api/v2/audio/${detection.id}`;
+    link.href = buildAppUrl(`/api/v2/audio/${detection.id}`);
     // Use species name and date/time for filename
     // Sanitize commonName to prevent path traversal (remove characters that aren't alphanumeric, space, dot, underscore, or hyphen)
     const safeCommonName = (detection.commonName || DEFAULT_DOWNLOAD_NAME).replace(

--- a/frontend/src/lib/desktop/features/dashboard/components/PlayOverlay.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/components/PlayOverlay.svelte
@@ -19,6 +19,7 @@
   import { Play, Pause, Loader2 } from '@lucide/svelte';
   import { cn } from '$lib/utils/cn';
   import { loggers } from '$lib/utils/logger';
+  import { buildAppUrl } from '$lib/utils/urlHelpers';
   import { t } from '$lib/i18n';
   import {
     applyPlaybackRate,
@@ -88,7 +89,7 @@
   let audioNodes = $state<AudioNodeChain | null>(null);
   // PLAY_END_DELAY_MS imported from $lib/utils/audio
 
-  const audioUrl = $derived(`/api/v2/audio/${encodeURIComponent(detectionId)}`);
+  const audioUrl = $derived(buildAppUrl(`/api/v2/audio/${encodeURIComponent(detectionId)}`));
 
   // Update audio nodes when gain/filter props change
   // Read values unconditionally to ensure they're tracked as dependencies

--- a/frontend/src/lib/desktop/features/dashboard/components/SpeciesInfoBar.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/components/SpeciesInfoBar.svelte
@@ -15,6 +15,7 @@
   import { Check } from '@lucide/svelte';
   import { cn } from '$lib/utils/cn';
   import { t } from '$lib/i18n';
+  import { buildAppUrl } from '$lib/utils/urlHelpers';
 
   interface Props {
     detection: Detection;
@@ -39,9 +40,10 @@
   const isVerified = $derived(detection.verified === 'correct');
   const isFalsePositive = $derived(detection.verified === 'false_positive');
 
-  // Thumbnail URL
+  // Thumbnail URL — buildAppUrl prepends the configured base path so the
+  // image resolves correctly behind reverse proxies (e.g. /birdnet/...).
   const thumbnailUrl = $derived(
-    `/api/v2/media/species-image?name=${encodeURIComponent(detection.scientificName)}`
+    buildAppUrl(`/api/v2/media/species-image?name=${encodeURIComponent(detection.scientificName)}`)
   );
 </script>
 

--- a/frontend/src/lib/desktop/features/dashboard/components/SpeciesInfoBar.test.ts
+++ b/frontend/src/lib/desktop/features/dashboard/components/SpeciesInfoBar.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { cleanup } from '@testing-library/svelte';
+import { createComponentTestFactory } from '../../../../../test/render-helpers';
+import { setBasePath, resetBasePath } from '$lib/utils/urlHelpers';
+import type { Detection } from '$lib/types/detection.types';
+import SpeciesInfoBar from './SpeciesInfoBar.svelte';
+
+const baseDetection: Detection = {
+  id: 1,
+  date: '2026-04-27',
+  time: '10:00',
+  beginTime: '2026-04-27T10:00:00',
+  endTime: '2026-04-27T10:00:03',
+  speciesCode: 'cardpu',
+  scientificName: 'Cardellina pusilla',
+  commonName: "Wilson's Warbler",
+  confidence: 0.92,
+  verified: 'unverified',
+  locked: false,
+};
+
+const speciesInfoBar = createComponentTestFactory(SpeciesInfoBar);
+
+describe('SpeciesInfoBar', () => {
+  afterEach(() => {
+    cleanup();
+    resetBasePath();
+  });
+
+  it('builds the species image URL without a base path by default', () => {
+    const { container } = speciesInfoBar.render({ props: { detection: baseDetection } });
+
+    const img = container.querySelector('img');
+    if (!img) throw new Error('expected an <img> to be rendered');
+    expect(img.getAttribute('src')).toBe('/api/v2/media/species-image?name=Cardellina%20pusilla');
+  });
+
+  it('prefixes the species image URL with the configured base path (regression)', () => {
+    // Without buildAppUrl, this image 404s under reverse-proxy setups like
+    // /birdnet or Home Assistant Ingress. See fix in fix/image-base-paths.
+    setBasePath('/birdnet');
+
+    const { container } = speciesInfoBar.render({ props: { detection: baseDetection } });
+
+    const img = container.querySelector('img');
+    if (!img) throw new Error('expected an <img> to be rendered');
+    expect(img.getAttribute('src')).toBe(
+      '/birdnet/api/v2/media/species-image?name=Cardellina%20pusilla'
+    );
+  });
+});

--- a/frontend/src/lib/desktop/features/detections/components/DetectionCardMobile.svelte
+++ b/frontend/src/lib/desktop/features/detections/components/DetectionCardMobile.svelte
@@ -8,6 +8,7 @@
   import { navigation } from '$lib/stores/navigation.svelte';
   import { settingsStore } from '$lib/stores/settings';
   import { getFriendlyAudioSourceName } from '$lib/utils/audioSourceLabel';
+  import { buildAppUrl } from '$lib/utils/urlHelpers';
 
   interface Props {
     detection: Detection;
@@ -38,7 +39,7 @@
   );
 
   function handlePlay() {
-    const audioUrl = `/api/v2/audio/${detection.id}`;
+    const audioUrl = buildAppUrl(`/api/v2/audio/${detection.id}`);
     if (onPlayMobileAudio) {
       onPlayMobileAudio({ audioUrl, speciesName: detection.commonName, detectionId: detection.id });
     }

--- a/frontend/src/lib/desktop/features/detections/components/DetectionRow.svelte
+++ b/frontend/src/lib/desktop/features/detections/components/DetectionRow.svelte
@@ -44,6 +44,7 @@
   import { useImageDelayedLoading } from '$lib/utils/delayedLoading.svelte.js';
   import { loggers } from '$lib/utils/logger';
   import { navigation } from '$lib/stores/navigation.svelte';
+  import { buildAppUrl } from '$lib/utils/urlHelpers';
 
   const logger = loggers.ui;
 
@@ -225,10 +226,11 @@
     showConfirmModal = true;
   }
 
-  // Placeholder function for thumbnail URL
+  // Placeholder function for thumbnail URL. buildAppUrl prepends the
+  // configured base path so the image resolves through reverse proxies.
   function getThumbnailUrl(scientificName: string): string {
     // TODO: Replace with actual thumbnail API endpoint
-    return `/api/v2/media/species-image?name=${encodeURIComponent(scientificName)}`;
+    return buildAppUrl(`/api/v2/media/species-image?name=${encodeURIComponent(scientificName)}`);
   }
 
   // Thumbnail loading handlers
@@ -264,7 +266,7 @@
 
   // Cleanup is handled automatically by useImageDelayedLoading
   function playMobileAudio() {
-    const audioUrl = `/api/v2/audio/${detection.id}`;
+    const audioUrl = buildAppUrl(`/api/v2/audio/${detection.id}`);
     onPlayMobileAudio?.({ audioUrl, speciesName: detection.commonName, detectionId: detection.id });
   }
 </script>
@@ -408,7 +410,7 @@
 <!-- Recording/Spectrogram -->
 <td class="hidden md:table-cell">
   <SpectrogramPlayer
-    audioUrl={`/api/v2/audio/${detection.id}`}
+    audioUrl={buildAppUrl(`/api/v2/audio/${detection.id}`)}
     detectionId={detection.id.toString()}
     spectrogramSize="md"
   />

--- a/frontend/src/lib/desktop/features/settings/components/DynamicThresholdTab.svelte
+++ b/frontend/src/lib/desktop/features/settings/components/DynamicThresholdTab.svelte
@@ -33,6 +33,7 @@
   import { loggers } from '$lib/utils/logger';
   import { toastActions } from '$lib/stores/toast';
   import { handleBirdImageError } from '$lib/desktop/components/ui/image-utils.js';
+  import { buildAppUrl } from '$lib/utils/urlHelpers';
   import SettingsNote from './SettingsNote.svelte';
   import ResizableContainer from '$lib/desktop/components/ui/ResizableContainer.svelte';
 
@@ -537,9 +538,9 @@
                   >
                     {#if threshold.scientificName}
                       <img
-                        src="/api/v2/media/species-image?name={encodeURIComponent(
-                          threshold.scientificName
-                        )}"
+                        src={buildAppUrl(
+                          `/api/v2/media/species-image?name=${encodeURIComponent(threshold.scientificName)}`
+                        )}
                         alt=""
                         class="w-full h-full object-cover"
                         onerror={handleBirdImageError}

--- a/frontend/src/lib/desktop/features/settings/pages/UserInterfaceSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/UserInterfaceSettingsPage.svelte
@@ -23,6 +23,7 @@
     type SpectrogramDynamicRange,
   } from '$lib/stores/settings';
   import { hasSettingsChanged } from '$lib/utils/settingsChanges';
+  import { buildAppUrl } from '$lib/utils/urlHelpers';
   import SettingsTabs from '$lib/desktop/features/settings/components/SettingsTabs.svelte';
   import type { TabDefinition } from '$lib/desktop/features/settings/components/SettingsTabs.svelte';
   import SettingsSection from '$lib/desktop/features/settings/components/SettingsSection.svelte';
@@ -590,7 +591,7 @@
                   onclick={() => updateSpectrogramSetting('style', style.value)}
                 >
                   <img
-                    src={`/ui/assets/images/spectrogram-preview-${style.value}.png`}
+                    src={buildAppUrl(`/ui/assets/images/spectrogram-preview-${style.value}.png`)}
                     alt={style.label}
                     class="w-full aspect-[4/3] object-cover rounded"
                   />

--- a/frontend/src/lib/desktop/views/DetectionDetail.svelte
+++ b/frontend/src/lib/desktop/views/DetectionDetail.svelte
@@ -439,7 +439,9 @@
         <!-- Species thumbnail with credit overlay -->
         <div class="hero-thumbnail">
           <img
-            src="/api/v2/media/species-image?name={encodeURIComponent(det.scientificName)}"
+            src={buildAppUrl(
+              `/api/v2/media/species-image?name=${encodeURIComponent(det.scientificName)}`
+            )}
             alt={det.commonName}
             class="w-full h-full object-contain"
             onerror={handleBirdImageError}

--- a/frontend/src/lib/desktop/views/Search.svelte
+++ b/frontend/src/lib/desktop/views/Search.svelte
@@ -28,6 +28,7 @@
   import { dropdown } from '$lib/utils/transitions';
   import { hasReviewPermission, isAuthenticated } from '$lib/utils/auth';
   import { loggers } from '$lib/utils/logger';
+  import { buildAppUrl } from '$lib/utils/urlHelpers';
 
   // SPINNER CONTROL: Set to false to disable loading spinners (reduces flickering)
   // Change back to true to re-enable spinners for testing
@@ -187,7 +188,7 @@
 
   function openMobilePlayer(result: SearchResult) {
     if (!result?.id) return;
-    selectedAudioUrl = `/api/v2/audio/${result.id}`;
+    selectedAudioUrl = buildAppUrl(`/api/v2/audio/${result.id}`);
     selectedSpeciesName = result.commonName || '';
     selectedDetectionId = result.id;
     showMobilePlayer = true;
@@ -811,14 +812,14 @@
                         <!-- decoding="async": Decode image off-main-thread to prevent UI blocking -->
                         <!-- fetchpriority="low": Lower network priority for species thumbnails -->
                         <img
-                          src="/api/v2/media/species-image?name={encodeURIComponent(
-                            result.scientificName
-                          )}"
+                          src={buildAppUrl(
+                            `/api/v2/media/species-image?name=${encodeURIComponent(result.scientificName)}`
+                          )}
                           alt={result.commonName || t('search.detailsPanel.unknownSpecies')}
                           class="w-full h-full object-cover"
                           onerror={e => {
                             const target = e.currentTarget as HTMLImageElement;
-                            target.src = '/ui/assets/bird-placeholder.svg';
+                            target.src = buildAppUrl('/ui/assets/bird-placeholder.svg');
                             target.classList.add('p-2');
                           }}
                           loading="lazy"
@@ -1023,14 +1024,14 @@
                               title={t('search.detailsPanel.clickToCollapse')}
                             >
                               <img
-                                src="/api/v2/media/species-image?name={encodeURIComponent(
-                                  result.scientificName
-                                )}"
+                                src={buildAppUrl(
+                                  `/api/v2/media/species-image?name=${encodeURIComponent(result.scientificName)}`
+                                )}
                                 alt={result.commonName || t('search.detailsPanel.unknownSpecies')}
                                 class="w-full h-full object-cover"
                                 onerror={e => {
                                   const target = e.currentTarget as HTMLImageElement;
-                                  target.src = '/ui/assets/bird-placeholder.svg';
+                                  target.src = buildAppUrl('/ui/assets/bird-placeholder.svg');
                                   target.classList.add('p-2');
                                 }}
                                 loading="lazy"
@@ -1046,7 +1047,7 @@
                               {t('search.detailsPanel.audioPlayer')}
                             </h3>
                             <AudioPlayer
-                              audioUrl="/api/v2/audio/{result.id}"
+                              audioUrl={buildAppUrl(`/api/v2/audio/${result.id}`)}
                               detectionId={result.id}
                               width={400}
                               height={200}
@@ -1089,9 +1090,9 @@
                       class="w-12 h-9 rounded-md overflow-hidden bg-[var(--color-base-200)] shrink-0"
                     >
                       <img
-                        src="/api/v2/media/species-image?name={encodeURIComponent(
-                          result.scientificName
-                        )}"
+                        src={buildAppUrl(
+                          `/api/v2/media/species-image?name=${encodeURIComponent(result.scientificName)}`
+                        )}
                         alt={result.commonName || t('search.detailsPanel.unknownSpecies')}
                         class="w-full h-full object-cover"
                         onerror={handleBirdImageError}

--- a/frontend/src/lib/utils/spectrogramLoader.svelte.ts
+++ b/frontend/src/lib/utils/spectrogramLoader.svelte.ts
@@ -16,6 +16,7 @@
 import { acquireSlot, releaseSlot, type SlotHandle } from '$lib/utils/imageLoadQueue';
 import { getCsrfToken } from '$lib/utils/api';
 import { loggers } from '$lib/utils/logger';
+import { buildAppUrl } from '$lib/utils/urlHelpers';
 
 const logger = loggers.ui;
 
@@ -137,15 +138,21 @@ export function createSpectrogramLoader(userConfig: SpectrogramLoaderConfig = {}
   }
 
   function buildStatusUrl(detectionId: number): string {
-    return `/api/v2/spectrogram/${detectionId}/status?size=${config.size}&raw=${String(config.raw)}`;
+    return buildAppUrl(
+      `/api/v2/spectrogram/${detectionId}/status?size=${config.size}&raw=${String(config.raw)}`
+    );
   }
 
   function buildGenerateUrl(detectionId: number): string {
-    return `/api/v2/spectrogram/${detectionId}/generate?size=${config.size}&raw=${String(config.raw)}`;
+    return buildAppUrl(
+      `/api/v2/spectrogram/${detectionId}/generate?size=${config.size}&raw=${String(config.raw)}`
+    );
   }
 
   function buildImageUrl(detectionId: number): string {
-    let url = `/api/v2/spectrogram/${detectionId}?size=${config.size}&raw=${String(config.raw)}`;
+    let url = buildAppUrl(
+      `/api/v2/spectrogram/${detectionId}?size=${config.size}&raw=${String(config.raw)}`
+    );
     if (imageRetryCount > 0) {
       url += `&t=${String(Date.now())}`;
     }

--- a/frontend/src/lib/utils/spectrogramLoader.test.ts
+++ b/frontend/src/lib/utils/spectrogramLoader.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { resetBasePath, setBasePath } from './urlHelpers';
 
 // Default: acquireSlot resolves immediately with true
 const mockAcquireSlot = vi.fn(() => ({
@@ -58,10 +59,12 @@ describe('spectrogramLoader', () => {
     vi.clearAllMocks();
     vi.useFakeTimers();
     mockFetch.mockReset();
+    resetBasePath();
   });
 
   afterEach(() => {
     vi.useRealTimers();
+    resetBasePath();
   });
 
   describe('initial state', () => {
@@ -106,6 +109,22 @@ describe('spectrogramLoader', () => {
       expect(loader.state).toBe('loaded');
       expect(loader.showSpinner).toBe(false);
       expect(mockReleaseSlot).toHaveBeenCalled();
+      loader.destroy();
+    });
+
+    it('uses the configured app base path for status and image URLs', async () => {
+      setBasePath('/proxy');
+      mockFetch.mockResolvedValueOnce(mockJsonResponse({ data: { status: 'exists' } }));
+
+      const loader = createSpectrogramLoader({ size: 'md', raw: true });
+      loader.start(42);
+      await flushAll();
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        '/proxy/api/v2/spectrogram/42/status?size=md&raw=true',
+        expect.objectContaining({ signal: expect.any(AbortSignal) })
+      );
+      expect(loader.spectrogramUrl).toBe('/proxy/api/v2/spectrogram/42?size=md&raw=true');
       loader.destroy();
     });
   });


### PR DESCRIPTION
(Supersedes #2862)

My previous attempt at fixing basepaths was not exhaustive, it seems. Now that I've got an actual instance up and running behind a basepath, I found more URLs not working:
- Spectrograms
- Audio URLs
- Species images + placeholders


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved image and audio loading issues when the app operates with a custom base path, ensuring proper functionality in reverse proxy and non-root deployment scenarios.

* **Tests**
  * Added test coverage for species page rendering, detection components, and spectrogram URL resolution across various base path configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->