### PR TITLE
fix(conf): check --config flag path in FindConfigFile before defaults

### DIFF
--- a/internal/conf/utils.go
+++ b/internal/conf/utils.go
@@ -87,7 +87,7 @@ func GetDefaultConfigPaths() ([]string, error) {
 func FindConfigFile() (string, error) {
 	// Check explicit config path first (set by --config CLI flag).
 	if ConfigPath != "" {
-		if _, err := os.Stat(ConfigPath); err == nil {
+		if info, err := os.Stat(ConfigPath); err == nil && !info.IsDir() {
 			return ConfigPath, nil
 		}
 		return "", errors.Newf("config file not found at explicit path: %s", ConfigPath).
@@ -99,7 +99,7 @@ func FindConfigFile() (string, error) {
 
 	// Check the path viper resolved during Load() as a secondary source.
 	if viperPath := viper.ConfigFileUsed(); viperPath != "" {
-		if _, err := os.Stat(viperPath); err == nil {
+		if info, err := os.Stat(viperPath); err == nil && !info.IsDir() {
 			return viperPath, nil
 		}
 	}

--- a/internal/conf/utils.go
+++ b/internal/conf/utils.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/spf13/viper"
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/logger"
 )
@@ -80,8 +81,30 @@ func GetDefaultConfigPaths() ([]string, error) {
 	return configPaths, nil
 }
 
-// findConfigFile locates the configuration file.
+// FindConfigFile locates the configuration file.
+// It checks the explicit --config CLI flag path first, then falls back
+// to viper.ConfigFileUsed(), and finally searches the default paths.
 func FindConfigFile() (string, error) {
+	// Check explicit config path first (set by --config CLI flag).
+	if ConfigPath != "" {
+		if _, err := os.Stat(ConfigPath); err == nil {
+			return ConfigPath, nil
+		}
+		return "", errors.Newf("config file not found at explicit path: %s", ConfigPath).
+			Category(errors.CategoryFileIO).
+			Context("operation", "find-config-file").
+			Context("config_path", ConfigPath).
+			Build()
+	}
+
+	// Check the path viper resolved during Load() as a secondary source.
+	if viperPath := viper.ConfigFileUsed(); viperPath != "" {
+		if _, err := os.Stat(viperPath); err == nil {
+			return viperPath, nil
+		}
+	}
+
+	// Fall through to default path search.
 	configPaths, err := GetDefaultConfigPaths()
 	if err != nil {
 		return "", errors.New(err).

--- a/internal/conf/utils_test.go
+++ b/internal/conf/utils_test.go
@@ -1,6 +1,8 @@
 package conf
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -217,4 +219,62 @@ func TestGetFfmpegVersion(t *testing.T) {
 	assert.NotEqual(t, 0, major, "failed to detect major version, got: version=%s, major=%d, minor=%d", version, major, minor)
 
 	t.Logf("Detected FFmpeg version: %s (major: %d, minor: %d)", version, major, minor)
+}
+
+func TestFindConfigFile_ExplicitConfigPath(t *testing.T) {
+	// Save and restore the global ConfigPath after the test.
+	origConfigPath := ConfigPath
+	t.Cleanup(func() {
+		ConfigPath = origConfigPath
+	})
+
+	// Create a temporary config file.
+	tmpDir := t.TempDir()
+	customPath := filepath.Join(tmpDir, "custom-config.yaml")
+	require.NoError(t, os.WriteFile(customPath, []byte("# test config"), 0o600))
+
+	// Set ConfigPath to the custom path.
+	ConfigPath = customPath
+
+	got, err := FindConfigFile()
+	require.NoError(t, err)
+	assert.Equal(t, customPath, got, "FindConfigFile should return the explicit --config path")
+}
+
+func TestFindConfigFile_ExplicitConfigPathMissing(t *testing.T) {
+	// Save and restore the global ConfigPath after the test.
+	origConfigPath := ConfigPath
+	t.Cleanup(func() {
+		ConfigPath = origConfigPath
+	})
+
+	// Point ConfigPath at a file that does not exist.
+	ConfigPath = "/nonexistent/path/config.yaml"
+
+	_, err := FindConfigFile()
+	require.Error(t, err)
+	require.ErrorContains(t, err, "config file not found at explicit path")
+	require.ErrorContains(t, err, ConfigPath)
+}
+
+func TestFindConfigFile_EmptyConfigPathFallsThrough(t *testing.T) {
+	// Save and restore the global ConfigPath after the test.
+	origConfigPath := ConfigPath
+	t.Cleanup(func() {
+		ConfigPath = origConfigPath
+	})
+
+	// Ensure ConfigPath is empty so FindConfigFile falls through to defaults.
+	ConfigPath = ""
+
+	// We cannot predict whether a default config file exists on the test
+	// machine, so just verify the function does not error with
+	// "explicit path" and either succeeds or returns a generic not-found.
+	result, err := FindConfigFile()
+	if err != nil {
+		assert.NotContains(t, err.Error(), "explicit path",
+			"with empty ConfigPath, error should not mention explicit path")
+	} else {
+		assert.NotEmpty(t, result, "returned path should not be empty on success")
+	}
 }


### PR DESCRIPTION
## Summary

- `FindConfigFile()` now checks the explicit `--config` CLI flag path before searching OS-specific default directories
- Adds `viper.ConfigFileUsed()` as a secondary fallback for paths resolved during viper initialization
- Returns a clear error when the explicit config path is set but the file is missing, instead of silently falling through to defaults

This fixes a silent data loss bug where all settings changes via the UI were lost on restart when BirdNET-Go was started with a custom config path (the standard Docker deployment pattern). The API returned 200 and updated in-memory state, but `SaveSettings()` wrote to the wrong file (or failed to find any file).

## Test plan

- [x] Unit test: explicit `ConfigPath` returns that path
- [x] Unit test: explicit `ConfigPath` pointing to missing file returns clear error
- [x] Unit test: empty `ConfigPath` falls through to default search
- [x] `golangci-lint run -v` passes with zero issues
- [x] `go test -race ./internal/conf/...` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Configuration file resolution follows a clearer three-stage precedence (explicit path, secondary candidate, then default locations), making behavior more predictable. Error messages have been clarified when an explicitly provided config path is missing.

* **Tests**
  * Added tests covering explicit-path handling, missing-path error messaging, and fallback/default resolution scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->