### PR TITLE
fix(api): add PATCH save logging and missing section support

### DIFF
--- a/internal/api/v2/settings.go
+++ b/internal/api/v2/settings.go
@@ -664,6 +664,15 @@ func (c *Controller) UpdateSectionSettings(ctx echo.Context) error {
 			c.Settings = current
 			return c.HandleError(ctx, err, "Failed to save settings, rolled back to previous settings", http.StatusInternalServerError)
 		}
+		c.logAPIRequest(ctx, logger.LogLevelInfo, "Section settings saved successfully",
+			logger.String("section", section))
+	}
+
+	if !publishGlobal || c.DisableSaveSettings {
+		c.logAPIRequest(ctx, logger.LogLevelDebug, "Section settings updated (save to disk skipped)",
+			logger.String("section", section),
+			logger.Bool("publishGlobal", publishGlobal),
+			logger.Bool("disableSaveSettings", c.DisableSaveSettings))
 	}
 
 	telemetry.UpdateTelemetryEnabled()
@@ -929,6 +938,14 @@ func getSettingsSectionValue(settings *conf.Settings, section string) (any, erro
 		return &settings.Sentry, nil
 	case "notification":
 		return &settings.Notification, nil
+	case "logging":
+		return &settings.Logging, nil
+	case "alerting":
+		return &settings.Alerting, nil
+	case "backup":
+		return &settings.Backup, nil
+	case "output":
+		return &settings.Output, nil
 	default:
 		return nil, fmt.Errorf("unknown settings section: %s", section)
 	}
@@ -993,6 +1010,7 @@ func getSectionValidators() map[string]sectionValidator {
 		SettingsSectionSpecies:   validateSpeciesSection,
 		SettingsSectionRealtime:  validateRealtimeSection,
 		"notification":           validateNotificationSection,
+		"alerting":               validateAlertingSection,
 	}
 }
 
@@ -1448,6 +1466,20 @@ func validateNotificationSection(data json.RawMessage) error {
 		if _, err := template.New("message").Funcs(notification.TemplateFuncs).Parse(notificationConfig.Templates.NewSpecies.Message); err != nil {
 			return fmt.Errorf("invalid template syntax in new species message: %w", err)
 		}
+	}
+
+	return nil
+}
+
+// validateAlertingSection validates alerting settings
+func validateAlertingSection(data json.RawMessage) error {
+	var alertSettings conf.AlertSettings
+	if err := json.Unmarshal(data, &alertSettings); err != nil {
+		return err
+	}
+
+	if alertSettings.HistoryRetentionDays < 0 {
+		return fmt.Errorf("historyRetentionDays must be non-negative, got %d", alertSettings.HistoryRetentionDays)
 	}
 
 	return nil

--- a/internal/api/v2/settings_section_test.go
+++ b/internal/api/v2/settings_section_test.go
@@ -1,0 +1,155 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/conf"
+)
+
+// TestPatchMissingSections verifies that PATCH requests to the logging,
+// alerting, backup, and output sections return 200 instead of 400 (unknown
+// section). This is a regression test for adding these four section cases to
+// getSettingsSectionValue.
+func TestPatchMissingSections(t *testing.T) {
+	tests := []struct {
+		name    string
+		section string
+		body    map[string]any
+		verify  func(t *testing.T, settings *conf.Settings)
+	}{
+		{
+			name:    "logging section accepts valid update",
+			section: "logging",
+			body: map[string]any{
+				"level": "debug",
+			},
+			verify: func(t *testing.T, settings *conf.Settings) {
+				t.Helper()
+				assert.Equal(t, "debug", settings.Logging.Level)
+			},
+		},
+		{
+			name:    "alerting section accepts valid update",
+			section: "alerting",
+			body: map[string]any{
+				"historyRetentionDays": 30,
+			},
+			verify: func(t *testing.T, settings *conf.Settings) {
+				t.Helper()
+				assert.Equal(t, 30, settings.Alerting.HistoryRetentionDays)
+			},
+		},
+		{
+			name:    "backup section accepts valid update",
+			section: "backup",
+			body: map[string]any{
+				"enabled": true,
+			},
+			verify: func(t *testing.T, settings *conf.Settings) {
+				t.Helper()
+				assert.True(t, settings.Backup.Enabled)
+			},
+		},
+		{
+			name:    "output section accepts valid update",
+			section: "output",
+			body: map[string]any{
+				"sqlite": map[string]any{
+					"enabled": true,
+					"path":    "/tmp/test.db",
+				},
+			},
+			verify: func(t *testing.T, settings *conf.Settings) {
+				t.Helper()
+				assert.True(t, settings.Output.SQLite.Enabled)
+				assert.Equal(t, "/tmp/test.db", settings.Output.SQLite.Path)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := echo.New()
+			controller := getTestController(t, e)
+
+			body, err := json.Marshal(tt.body)
+			require.NoError(t, err)
+
+			req := httptest.NewRequest(http.MethodPatch, "/api/v2/settings/"+tt.section, bytes.NewReader(body))
+			req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+			rec := httptest.NewRecorder()
+			ctx := e.NewContext(req, rec)
+			ctx.SetParamNames("section")
+			ctx.SetParamValues(tt.section)
+
+			err = controller.UpdateSectionSettings(ctx)
+			require.NoError(t, err)
+			assert.Equal(t, http.StatusOK, rec.Code)
+
+			tt.verify(t, controller.Settings)
+		})
+	}
+}
+
+// TestPatchAlertingValidation verifies that the alerting section validator
+// rejects negative historyRetentionDays.
+func TestPatchAlertingValidation(t *testing.T) {
+	e := echo.New()
+	controller := getTestController(t, e)
+	// Enable debug so the raw validation error is exposed in the "error" field
+	controller.Settings.WebServer.Debug = true
+
+	body, err := json.Marshal(map[string]any{
+		"historyRetentionDays": -1,
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPatch, "/api/v2/settings/alerting", bytes.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+	ctx.SetParamNames("section")
+	ctx.SetParamValues("alerting")
+
+	err = controller.UpdateSectionSettings(ctx)
+	// The handler wraps the validation error, so check the status code and
+	// the raw error field (exposed in debug mode) for the validation message.
+	require.NoError(t, err, "handler should return nil and send HTTP response")
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+
+	var response map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &response))
+	assert.Contains(t, response["error"], "historyRetentionDays must be non-negative")
+}
+
+// TestPatchAlertingZeroRetention verifies that zero is accepted as a valid
+// value for historyRetentionDays (meaning unlimited retention).
+func TestPatchAlertingZeroRetention(t *testing.T) {
+	e := echo.New()
+	controller := getTestController(t, e)
+	controller.Settings.Alerting.HistoryRetentionDays = 30
+
+	body, err := json.Marshal(map[string]any{
+		"historyRetentionDays": 0,
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPatch, "/api/v2/settings/alerting", bytes.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+	ctx.SetParamNames("section")
+	ctx.SetParamValues("alerting")
+
+	err = controller.UpdateSectionSettings(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, 0, controller.Settings.Alerting.HistoryRetentionDays)
+}


### PR DESCRIPTION
## Summary

- Add info-level logging to the PATCH settings handler on successful save, matching the existing PUT handler behavior
- Add debug-level logging when save is skipped (test mode or non-global publish) to aid diagnostics
- Add PATCH support for the `logging`, `alerting`, `backup`, and `output` sections which were previously returning 400 "unknown settings section"
- Add validator for the alerting section to reject negative `historyRetentionDays` values

## Test plan

- [x] Table-driven test: PATCH to logging/alerting/backup/output returns 200 and updates the correct fields
- [x] Alerting validation test: negative `historyRetentionDays` returns 400
- [x] Alerting validation test: zero `historyRetentionDays` (unlimited) returns 200
- [x] `golangci-lint run -v` passes with zero issues
- [x] `go test -race ./internal/api/v2/...` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Extended settings API to support additional configuration sections: logging, alerting, backup, and output.
  * Added validation for alerting settings to enforce non-negative retention period values.

* **Tests**
  * Added test coverage for settings section updates, including validation enforcement and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->