### PR TITLE
fix(api): force isGlobalOwner true in production constructor

### DIFF
--- a/internal/api/v2/api.go
+++ b/internal/api/v2/api.go
@@ -265,6 +265,12 @@ func New(e *echo.Echo, ds datastore.Interface, settings *conf.Settings,
 	birdImageCache *imageprovider.BirdImageCache, sunCalc *suncalc.SunCalc,
 	controlChan chan string,
 	metrics *observability.Metrics, opts ...Option) (*Controller, error) {
+	// Refresh from the global atomic pointer so the controller starts with
+	// the latest snapshot, not a pointer captured before out-of-band updates
+	// (range filter rebuild, ShouldUpdateRangeFilterToday, etc.).
+	if global := conf.GetSettings(); global != nil {
+		settings = global
+	}
 	c, err := NewWithOptions(e, ds, settings, birdImageCache, sunCalc, controlChan, metrics, true, opts...)
 	if err != nil {
 		return nil, err

--- a/internal/api/v2/api.go
+++ b/internal/api/v2/api.go
@@ -259,11 +259,21 @@ func (c *Controller) TunnelDetectionMiddleware() echo.MiddlewareFunc {
 }
 
 // New creates a new API controller, returning an error if initialization fails.
+// The controller owns the global settings singleton: it reads from the current
+// atomic snapshot on each request and publishes updates back via StoreSettings.
 func New(e *echo.Echo, ds datastore.Interface, settings *conf.Settings,
 	birdImageCache *imageprovider.BirdImageCache, sunCalc *suncalc.SunCalc,
 	controlChan chan string,
 	metrics *observability.Metrics, opts ...Option) (*Controller, error) {
-	return NewWithOptions(e, ds, settings, birdImageCache, sunCalc, controlChan, metrics, true, opts...)
+	c, err := NewWithOptions(e, ds, settings, birdImageCache, sunCalc, controlChan, metrics, true, opts...)
+	if err != nil {
+		return nil, err
+	}
+	// Force true: the pointer identity check in NewWithOptions can fail when
+	// an out-of-band StoreSettings call (range filter rebuild at startup)
+	// replaces the global pointer before this constructor runs.
+	c.isGlobalOwner = true
+	return c, nil
 }
 
 // resolveAndValidateMediaPath resolves a potentially relative media path and ensures it exists as a directory.


### PR DESCRIPTION
## Summary

- Fixes settings not persisting to disk after PR #2877, which replaced the per-request pointer identity check with a stable `isGlobalOwner` flag but still computed it via pointer identity at construction time
- The pointer check evaluates to `false` because `BirdNETAnalyzer.Start()` calls `BuildRangeFilter` -> `UpdateIncludedSpecies` -> `StoreSettings(newClone)` before the API controller is constructed, replacing the global pointer
- Forces `isGlobalOwner = true` in `New()` (production-only constructor); tests call `NewWithOptions` directly and correctly get `false`

## Test plan

- [x] QA verified: PATCH settings persists to disk (was silently skipped)
- [x] QA verified: PUT settings persists to disk (was silently skipped)
- [x] QA verified: values survive server restart
- [x] All api/v2 tests pass with `-race`
- [x] golangci-lint: 0 issues
- [x] Pre-commit hooks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup error propagation so initialization failures are reported reliably.
  * Ensured correct global-settings ownership during startup, preventing issues when settings are swapped or updated out-of-band.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->