### PR TITLE
feat(api): add PATCH support for perch, models, taxonomySynonyms

### DIFF
--- a/internal/api/v2/settings.go
+++ b/internal/api/v2/settings.go
@@ -964,6 +964,12 @@ func getSettingsSectionValue(settings *conf.Settings, section string) (any, erro
 		return &settings.Backup, nil
 	case "output":
 		return &settings.Output, nil
+	case "perch":
+		return &settings.Perch, nil
+	case "models":
+		return &settings.Models, nil
+	case "taxonomysynonyms":
+		return &settings.TaxonomySynonyms, nil
 	default:
 		return nil, fmt.Errorf("unknown settings section: %s", section)
 	}

--- a/internal/api/v2/settings_section_test.go
+++ b/internal/api/v2/settings_section_test.go
@@ -72,6 +72,42 @@ func TestPatchMissingSections(t *testing.T) {
 				assert.Equal(t, "/tmp/test.db", settings.Output.SQLite.Path)
 			},
 		},
+		{
+			name:    "perch section accepts valid update",
+			section: "perch",
+			body: map[string]any{
+				"enabled":   true,
+				"threshold": 0.8,
+			},
+			verify: func(t *testing.T, settings *conf.Settings) {
+				t.Helper()
+				assert.True(t, settings.Perch.Enabled)
+				assert.InDelta(t, 0.8, settings.Perch.Threshold, 1e-9)
+			},
+		},
+		{
+			name:    "models section accepts valid update",
+			section: "models",
+			body: map[string]any{
+				"enabled": []string{"birdnet", "perch_v2"},
+			},
+			verify: func(t *testing.T, settings *conf.Settings) {
+				t.Helper()
+				assert.Equal(t, []string{"birdnet", "perch_v2"}, settings.Models.Enabled)
+			},
+		},
+		{
+			name:    "taxonomysynonyms section accepts valid update",
+			section: "taxonomysynonyms",
+			body: map[string]any{
+				"Parus major": "Great Tit",
+			},
+			verify: func(t *testing.T, settings *conf.Settings) {
+				t.Helper()
+				require.Contains(t, settings.TaxonomySynonyms, "Parus major")
+				assert.Equal(t, "Great Tit", settings.TaxonomySynonyms["Parus major"])
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -96,6 +132,38 @@ func TestPatchMissingSections(t *testing.T) {
 			tt.verify(t, controller.Settings)
 		})
 	}
+}
+
+// TestPatchTaxonomySynonymsMerge verifies that PATCH merges new synonym
+// entries with existing ones instead of replacing the entire map.
+func TestPatchTaxonomySynonymsMerge(t *testing.T) {
+	e := echo.New()
+	controller := getTestController(t, e)
+
+	controller.Settings.TaxonomySynonyms = map[string]string{
+		"Corvus corax": "Common Raven",
+	}
+
+	body, err := json.Marshal(map[string]any{
+		"Parus major": "Great Tit",
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPatch, "/api/v2/settings/taxonomysynonyms", bytes.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+	ctx.SetParamNames("section")
+	ctx.SetParamValues("taxonomysynonyms")
+
+	err = controller.UpdateSectionSettings(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	assert.Equal(t, "Common Raven", controller.Settings.TaxonomySynonyms["Corvus corax"],
+		"existing entry must be preserved after PATCH")
+	assert.Equal(t, "Great Tit", controller.Settings.TaxonomySynonyms["Parus major"],
+		"new entry must be added by PATCH")
 }
 
 // TestPatchAlertingValidation verifies that the alerting section validator


### PR DESCRIPTION
## Summary

- Add missing `perch`, `models`, and `taxonomysynonyms` cases to `getSettingsSectionValue()` in the Settings API
- Previously these sections returned 400 "unknown settings section" on PATCH requests
- The `taxonomySynonyms` section (`map[string]string`) correctly merges entries via `deepMergeMaps` (sequential PATCHes preserve existing entries)

## Test Plan

- [x] Unit tests: 3 new table entries in `TestPatchMissingSections` (perch, models, taxonomysynonyms)
- [x] `TestPatchTaxonomySynonymsMerge` verifies map merge semantics (new entries added, existing preserved)
- [x] All api/v2 tests pass with `-race`
- [x] `golangci-lint` zero issues
- [x] QA verified end-to-end in test container: PATCH + API readback + config.yaml persistence

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Settings API now properly recognizes and handles `perch`, `models`, and `taxonomysynonyms` configuration sections.

* **Bug Fixes**
  * Fixed settings merge behavior to preserve existing entries when updating configuration sections instead of overwriting them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->