### PR TITLE
fix(frontend): guard pre-auth API calls, fix wizard persistence, add notification button a11y

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -430,9 +430,12 @@
 
     // Load settings at app startup so they are available on any page the user navigates to
     // first (e.g. System → Terminal) without requiring a visit to the Settings page.
-    settingsActions.loadSettings().catch(err => {
-      logger.error('Failed to load settings on app init', err);
-    });
+    // Skip when authentication is required but not yet provided to avoid 401 console errors.
+    if (!securityEnabled || accessAllowed) {
+      settingsActions.loadSettings().catch(err => {
+        logger.error('Failed to load settings on app init', err);
+      });
+    }
 
     // Initial routing is handled by the reactive $effect below when appInitialized becomes true
   });
@@ -459,20 +462,21 @@
     if (!appInitialized || loadingComponent || wizardChecked) return;
     wizardChecked = true;
 
-    // Fresh install always shows onboarding, regardless of localStorage
+    // Check localStorage dismissal before any wizard flow. This covers the case
+    // where the server-side dismiss failed (e.g. 401 when not authenticated) but
+    // the client-side fallback persisted the dismissal.
+    try {
+      const dismissedVersion = localStorage.getItem(WIZARD_DISMISSED_VERSION_KEY);
+      if (dismissedVersion === appState.version) return;
+    } catch {
+      // localStorage unavailable (private browsing, etc.)
+    }
+
     if (appState.freshInstall) {
       wizardState.launch('onboarding', {
         currentVersion: appState.version,
       });
       return;
-    }
-
-    // For updates, check localStorage fallback before triggering what's-new
-    try {
-      const dismissedVersion = localStorage.getItem(WIZARD_DISMISSED_VERSION_KEY);
-      if (dismissedVersion === appState.version) return;
-    } catch {
-      // localStorage unavailable (private browsing, etc.) — proceed with wizard check
     }
 
     if (appState.newVersion) {

--- a/frontend/src/lib/desktop/features/settings/pages/NotificationsSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/NotificationsSettingsPage.svelte
@@ -2039,6 +2039,7 @@
                             onclick={() => openEditProviderForm(index)}
                             class="inline-flex items-center justify-center w-6 h-6 rounded bg-transparent hover:bg-black/5 dark:hover:bg-white/10 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                             title={t('settings.notifications.push.providers.editButton')}
+                            aria-label={t('settings.notifications.push.providers.editButton')}
                             disabled={showProviderForm}
                           >
                             <Pencil class="size-3.5" />
@@ -2047,6 +2048,7 @@
                             onclick={() => deleteProvider(index)}
                             class="inline-flex items-center justify-center w-6 h-6 rounded bg-transparent hover:bg-black/5 dark:hover:bg-white/10 text-[var(--color-error)] transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                             title={t('settings.notifications.push.providers.deleteButton')}
+                            aria-label={t('settings.notifications.push.providers.deleteButton')}
                             disabled={showProviderForm}
                           >
                             <Trash2 class="size-3.5" />

--- a/frontend/src/lib/desktop/features/settings/pages/NotificationsSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/NotificationsSettingsPage.svelte
@@ -2459,6 +2459,7 @@
             <button
               class="inline-flex items-center justify-center size-7 rounded-md text-[var(--color-base-content)]/70 hover:bg-[var(--color-base-200)] hover:text-[var(--color-base-content)] transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
               title={t('settings.alerts.actionLabels.test')}
+              aria-label={t('settings.alerts.actionLabels.test')}
               disabled={testingId === rule.id}
               onclick={() => handleTestRule(rule)}
             >
@@ -2467,6 +2468,7 @@
             <button
               class="inline-flex items-center justify-center size-7 rounded-md text-[var(--color-base-content)]/70 hover:bg-[var(--color-base-200)] hover:text-[var(--color-base-content)] transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
               title={t('settings.alerts.actionLabels.edit')}
+              aria-label={t('settings.alerts.actionLabels.edit')}
               disabled={editorOpen}
               onclick={() => openEditor(rule)}
             >

--- a/frontend/src/lib/desktop/layouts/RootLayout.svelte
+++ b/frontend/src/lib/desktop/layouts/RootLayout.svelte
@@ -52,8 +52,11 @@
     // Initialize auth state (CSRF is now handled by appState in App.svelte)
     authStore.init(securityEnabled, accessAllowed);
 
-    // Fetch restart status to show banner if restart is pending
-    fetchRestartStatus();
+    // Fetch restart status to show banner if restart is pending.
+    // Skip when authentication is required but not yet provided to avoid 401 console errors.
+    if (!securityEnabled || accessAllowed) {
+      fetchRestartStatus();
+    }
 
     // SSE notifications are auto-initialized when imported
 


### PR DESCRIPTION
## Summary

- Guard `settingsActions.loadSettings()` and `fetchRestartStatus()` behind an auth check (`!securityEnabled || accessAllowed`) so they don't fire when authentication is required but the user hasn't logged in yet; eliminates 4 console errors (2 browser-level 401s + 2 application-level error logs) per unauthenticated page load
- Move the wizard localStorage dismissal check before the `freshInstall` branch so it applies to all wizard flows; previously only the whats-new path checked localStorage, causing the onboarding wizard to reappear on every reload when the server-side dismiss failed with 401
- Add `aria-label` attributes to notification provider Edit/Delete icon-only buttons, matching the accessible pattern used on Audio Streams settings page

## Test plan

- [ ] With auth enabled, open dashboard without logging in: verify no 401 errors in browser console
- [ ] Log in and verify settings load and restart banner works normally
- [ ] On a fresh install with auth enabled, dismiss the wizard via Skip, reload the page: wizard should not reappear
- [ ] On the notifications settings page, verify Edit/Delete buttons announce their purpose to screen readers (or inspect `aria-label` in DevTools)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Startup flow now avoids loading settings or restart checks when authentication isn't granted, preventing auth-related errors.
  * Wizard dismissal/version checks run earlier and tolerate unavailable local storage to avoid initialization failures.
  * Skipped unnecessary restart-status requests when access is restricted to reduce error responses.

* **Accessibility**
  * Added descriptive screen-reader labels to icon-only buttons in notification settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->