### PR TITLE
fix(wizard): harden onboarding wizard skip with 6-layer defense

### DIFF
--- a/frontend/src/lib/desktop/features/wizard/WizardDialog.svelte
+++ b/frontend/src/lib/desktop/features/wizard/WizardDialog.svelte
@@ -72,7 +72,7 @@
   isOpen={wizardState.isActive}
   size="2xl"
   className="w-full"
-  showCloseButton={false}
+  showCloseButton={true}
   closeOnBackdrop={false}
   onClose={() => wizardState.skip()}
 >

--- a/frontend/src/lib/desktop/features/wizard/wizardState.svelte.test.ts
+++ b/frontend/src/lib/desktop/features/wizard/wizardState.svelte.test.ts
@@ -219,12 +219,12 @@ describe('wizardState — state machine', () => {
   });
 
   describe('skip()', () => {
-    it('resets state to completed', async () => {
+    it('resets state to completed', () => {
       const steps = createTestSteps(3);
       vi.mocked(getStepsForFlow).mockReturnValue(steps);
       wizardState.launch('onboarding');
 
-      await wizardState.skip();
+      wizardState.skip();
 
       expect(wizardState.status).toBe('completed');
       expect(wizardState.isActive).toBe(false);
@@ -238,19 +238,19 @@ describe('wizardState — state machine', () => {
       vi.mocked(getStepsForFlow).mockReturnValue(steps);
       wizardState.launch('whats-new', { currentVersion: 'v2.0' });
 
-      await wizardState.skip();
+      wizardState.skip();
 
       expect(api.post).toHaveBeenCalledWith('/api/v2/app/wizard/dismiss');
     });
   });
 
   describe('complete()', () => {
-    it('resets state to completed', async () => {
+    it('resets state to completed', () => {
       const steps = createTestSteps(3);
       vi.mocked(getStepsForFlow).mockReturnValue(steps);
       wizardState.launch('onboarding');
 
-      await wizardState.complete();
+      wizardState.complete();
 
       expect(wizardState.status).toBe('completed');
       expect(wizardState.isActive).toBe(false);
@@ -264,17 +264,17 @@ describe('wizardState — state machine', () => {
       vi.mocked(getStepsForFlow).mockReturnValue(steps);
       wizardState.launch('onboarding', { currentVersion: 'v3.0' });
 
-      await wizardState.complete();
+      wizardState.complete();
 
       expect(api.post).toHaveBeenCalledWith('/api/v2/app/wizard/dismiss');
     });
 
-    it('sets localStorage dismissed version', async () => {
+    it('sets localStorage dismissed version', () => {
       const steps = createTestSteps(1);
       vi.mocked(getStepsForFlow).mockReturnValue(steps);
       wizardState.launch('whats-new', { currentVersion: 'v2.5' });
 
-      await wizardState.complete();
+      wizardState.complete();
 
       expect(localStorage.getItem('birdnet-wizard-dismissed-version')).toBe('v2.5');
     });

--- a/frontend/src/lib/desktop/features/wizard/wizardState.svelte.ts
+++ b/frontend/src/lib/desktop/features/wizard/wizardState.svelte.ts
@@ -64,7 +64,9 @@ async function dismissOnly(version?: string): Promise<void> {
   try {
     await api.post(WIZARD_DISMISS_ENDPOINT);
   } catch {
-    // Swallow — localStorage fallback covers this
+    setTimeout(() => {
+      api.post(WIZARD_DISMISS_ENDPOINT).catch(() => {});
+    }, 2000);
   }
 }
 

--- a/frontend/src/lib/desktop/features/wizard/wizardState.svelte.ts
+++ b/frontend/src/lib/desktop/features/wizard/wizardState.svelte.ts
@@ -34,7 +34,9 @@ async function dismiss(): Promise<void> {
   try {
     await api.post(WIZARD_DISMISS_ENDPOINT);
   } catch {
-    // Swallow error — localStorage fallback prevents re-display
+    setTimeout(() => {
+      api.post(WIZARD_DISMISS_ENDPOINT).catch(() => {});
+    }, 2000);
   }
 }
 
@@ -106,13 +108,13 @@ function setStepValid(valid: boolean): void {
   isStepValid = valid;
 }
 
-async function skip(): Promise<void> {
-  await dismiss();
+function skip(): void {
+  void dismiss();
   resetState();
 }
 
-async function complete(): Promise<void> {
-  await dismiss();
+function complete(): void {
+  void dismiss();
   resetState();
 }
 

--- a/internal/api/v2/app.go
+++ b/internal/api/v2/app.go
@@ -92,13 +92,11 @@ func (c *Controller) initAppRoutes() {
 	// that was previously injected server-side into the HTML template.
 	c.Group.GET(AppConfigEndpoint, c.GetAppConfig)
 
-	// Wizard dismiss endpoint - conditionally protected.
-	// When security is enabled, require authentication; otherwise allow public access.
-	if c.authMiddleware != nil {
-		c.Group.POST(WizardDismissEndpoint, c.DismissWizard, c.authMiddleware)
-	} else {
-		c.Group.POST(WizardDismissEndpoint, c.DismissWizard)
-	}
+	// Wizard dismiss endpoint - always public.
+	// Only writes last_seen_version to app_metadata (no data exposure, no privilege
+	// escalation). Must be accessible pre-auth so the onboarding wizard can be
+	// dismissed before login.
+	c.Group.POST(WizardDismissEndpoint, c.DismissWizard)
 }
 
 // GetAppConfig handles GET /api/v2/app/config
@@ -215,13 +213,17 @@ func (c *Controller) determineWizardState(ctx context.Context) (freshInstall, ne
 		return false, false, ""
 	}
 
-	// If last_seen_version has never been set, check for fresh install
+	// If last_seen_version has never been set, distinguish fresh from existing install
 	if lastSeenVersion == "" {
-		if c.hasZeroDetections(ctx) {
-			return true, false, ""
+		if c.isExistingInstall(ctx) {
+			// Auto-seed: existing install predates wizard tracking.
+			// Intentional write inside GET handler (idempotent upsert, fires once per install).
+			if err := c.appMetadataRepo.Set(ctx, appMetadataKeyLastSeenVersion, c.Settings.Version); err != nil {
+				c.logWarnIfEnabled("Failed to auto-seed last_seen_version", logger.Error(err))
+			}
+			return false, false, c.Settings.Version
 		}
-		// Existing install that predates wizard tracking — treat as upgrade from unknown version
-		return false, true, ""
+		return true, false, ""
 	}
 
 	// If versions differ, this is an upgrade
@@ -255,6 +257,47 @@ func (c *Controller) hasZeroDetections(ctx context.Context) bool {
 		return false
 	}
 	return exists == 0
+}
+
+// isExistingInstall returns true if multiple signals indicate this is a configured
+// installation rather than a genuinely fresh one. Checks are ordered cheapest-first.
+func (c *Controller) isExistingInstall(ctx context.Context) bool {
+	if c.Settings.BirdNET.Latitude != 0 || c.Settings.BirdNET.Longitude != 0 {
+		return true
+	}
+	if len(c.Settings.Realtime.Audio.Sources) > 0 {
+		return true
+	}
+	if c.Settings.Security.BasicAuth.Enabled || len(c.Settings.GetEnabledOAuthProviders()) > 0 {
+		return true
+	}
+	if !c.hasZeroDetections(ctx) {
+		return true
+	}
+	if c.hasNotes(ctx) {
+		return true
+	}
+	return false
+}
+
+// hasNotes returns true if the notes table contains at least one row.
+func (c *Controller) hasNotes(ctx context.Context) bool {
+	if c.V2Manager == nil {
+		return false
+	}
+
+	tableName := "notes"
+	if tp, ok := c.V2Manager.(interface{ TablePrefix() string }); ok && tp.TablePrefix() != "" {
+		tableName = tp.TablePrefix() + tableName
+	}
+
+	var exists int
+	err := c.V2Manager.DB().WithContext(ctx).Table(tableName).
+		Select("1").Limit(1).Scan(&exists).Error
+	if err != nil {
+		return false
+	}
+	return exists != 0
 }
 
 // isDevBuild returns true for development/unversioned builds where wizard should be suppressed.

--- a/internal/api/v2/app.go
+++ b/internal/api/v2/app.go
@@ -296,6 +296,7 @@ func (c *Controller) hasNotes(ctx context.Context) bool {
 	err := c.V2Manager.DB().WithContext(ctx).Table(tableName).
 		Select("1").Limit(1).Scan(&exists).Error
 	if err != nil {
+		c.logWarnIfEnabled("Failed to check notes for wizard state", logger.Error(err))
 		return false
 	}
 	return exists != 0

--- a/internal/api/v2/app.go
+++ b/internal/api/v2/app.go
@@ -194,8 +194,9 @@ func (c *Controller) GetAppConfig(ctx echo.Context) error {
 //
 // Rules:
 //   - Dev builds (empty version or "Development Build"): both flags forced to false.
-//   - If last_seen_version is missing and the database has zero detections: freshInstall = true.
-//   - If last_seen_version differs from the current version (and not fresh install): newVersion = true.
+//   - If last_seen_version is missing and isExistingInstall returns true: auto-seed and skip wizard.
+//   - If last_seen_version is missing and no install signals: freshInstall = true.
+//   - If last_seen_version differs from the current version: newVersion = true.
 func (c *Controller) determineWizardState(ctx context.Context) (freshInstall, newVersion bool, previousVersion string) {
 	// Skip wizard triggers for dev builds
 	if isDevBuild(c.Settings.Version) {

--- a/internal/api/v2/app_wizard_test.go
+++ b/internal/api/v2/app_wizard_test.go
@@ -159,14 +159,14 @@ func TestDetermineWizardState(t *testing.T) {
 			wantFresh: true,
 		},
 		{
-			name:         "upgrade from unknown — no last_seen_version, has detections",
+			name:         "existing install auto-seeds — no last_seen_version, has detections",
 			version:      "v0.9.0",
 			metadataRepo: newMockAppMetadataRepo(),
 			v2Manager: func(t *testing.T) *fakeV2Manager {
 				t.Helper()
 				return newFakeV2ManagerWithDetections(t, 5)
 			},
-			wantNew: true,
+			wantPrevVersion: "v0.9.0",
 		},
 		{
 			name:    "upgrade with known previous version",


### PR DESCRIPTION
## Summary

- Make the wizard dismiss endpoint always public so it works pre-auth (the endpoint only writes a version string, no data exposure)
- Auto-seed `last_seen_version` for existing installs that predate wizard tracking, using 5 detection signals: location configured, audio sources present, security enabled, detections exist, notes exist
- Close the wizard modal immediately before firing the dismiss API call (non-blocking UX)
- Retry the dismiss POST once on failure after 2 seconds
- Enable the close button and Escape key as an escape hatch

## Context

Users upgrading from older versions hit a failure chain where: the V2 detections table is empty (data in legacy tables), the dismiss endpoint requires auth but the wizard shows pre-auth, and `skip()`/`complete()` block on the failed API call before closing the modal. PR #2889 mitigated the localStorage side but the underlying server-side and UI-blocking failures remained.

This fix adds defense in depth so no single failure can trap the user in the wizard.

## Test plan

- [ ] Fresh Docker install: wizard shows once, skip works, never returns
- [ ] Existing install upgrade (with configured lat/lng or audio sources): wizard does NOT show
- [ ] Private browsing: dismiss persists server-side
- [ ] Clear localStorage + reload: wizard doesn't return (server has version)
- [ ] Escape key and close button both dismiss the wizard
- [ ] Security enabled: dismiss works without authentication

Fixes #2892

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Wizard dialog now shows a close button for easier dismissal.

* **Bug Fixes**
  * Wizard dismissal will automatically retry if a network request fails.

* **Improvements**
  * More robust detection of existing installs to improve when the wizard appears.
  * Wizard dismissal endpoint is now accessible without requiring authentication.
  * Skip/Complete actions reset UI immediately while dismissal runs in background.

* **Tests**
  * Updated tests to reflect synchronous skip/complete behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->