### PR TITLE
fix(range-filter): use fresh settings snapshot instead of stale startup pointer

### DIFF
--- a/frontend/src/lib/desktop/features/settings/pages/MainSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/MainSettingsPage.svelte
@@ -1024,12 +1024,13 @@
   }
 
   $effect(() => {
-    // Track coordinate changes as dependencies
+    // Track coordinate and threshold changes as dependencies
     const _lat = settings.birdnet.latitude;
     const _lng = settings.birdnet.longitude;
+    const _threshold = settings.birdnet.rangeFilter.threshold;
     const configured = settings.birdnet.locationConfigured;
 
-    if (configured && _lat != null && _lng != null) {
+    if (configured && _lat != null && _lng != null && _threshold != null) {
       debouncedTestRangeFilter();
     }
   });

--- a/internal/api/v2/range.go
+++ b/internal/api/v2/range.go
@@ -75,26 +75,34 @@ func (c *Controller) getBirdNETInstance() (*classifier.Orchestrator, error) {
 	return instance, nil
 }
 
-// swapRangeFilterSettings temporarily sets range filter settings and returns a restore function.
-// It acquires settingsMutex (write lock) to prevent concurrent settings reads from seeing
-// the temporary test values. This fixes a race condition where GetAllSettings could return
-// temporarily swapped coordinates during a range filter test (see #1940).
+// swapRangeFilterSettings temporarily publishes a settings snapshot with the
+// given test coordinates and threshold, then returns a restore function that
+// republishes the original snapshot. Because GetProbableSpecies reads from the
+// latest published snapshot (via conf.CurrentOrFallback), modifying a single
+// controller-cached pointer is not sufficient; the global snapshot must be
+// swapped so the BirdNET instance sees the test values.
+//
+// It acquires settingsMutex (write lock) to prevent concurrent API settings
+// reads from seeing the temporary test values (see #1940).
 // The caller MUST call the returned restore function to release the lock.
 func (c *Controller) swapRangeFilterSettings(lat, lon float64, threshold float32) func() {
 	c.settingsMutex.Lock()
 
-	originalLat := c.Settings.BirdNET.Latitude
-	originalLon := c.Settings.BirdNET.Longitude
-	originalThreshold := c.Settings.BirdNET.RangeFilter.Threshold
+	original := conf.CurrentOrFallback(c.Settings)
+	savedController := c.Settings
 
-	c.Settings.BirdNET.Latitude = lat
-	c.Settings.BirdNET.Longitude = lon
-	c.Settings.BirdNET.RangeFilter.Threshold = threshold
+	testSnapshot := conf.CloneSettings(original)
+	testSnapshot.BirdNET.Latitude = lat
+	testSnapshot.BirdNET.Longitude = lon
+	testSnapshot.BirdNET.RangeFilter.Threshold = threshold
+	testSnapshot.BirdNET.LocationConfigured = true
+
+	conf.StoreSettings(testSnapshot)
+	c.Settings = testSnapshot
 
 	return func() {
-		c.Settings.BirdNET.Latitude = originalLat
-		c.Settings.BirdNET.Longitude = originalLon
-		c.Settings.BirdNET.RangeFilter.Threshold = originalThreshold
+		conf.StoreSettings(original)
+		c.Settings = savedController
 		c.settingsMutex.Unlock()
 	}
 }

--- a/internal/classifier/range_filter.go
+++ b/internal/classifier/range_filter.go
@@ -83,8 +83,14 @@ func BuildRangeFilter(o *Orchestrator) error {
 
 // GetProbableSpecies filters and sorts bird species based on their scores.
 // It also updates the scores for species that have custom actions defined in the speciesConfigCSV.
+//
+// Settings are read from the latest published snapshot (via conf.CurrentOrFallback)
+// so that UI changes to coordinates, threshold, or LocationConfigured take
+// effect immediately without restarting the service.
 func (bn *BirdNET) GetProbableSpecies(date time.Time, week float32) ([]SpeciesScore, error) {
 	bn.Debug("Applying range filter")
+
+	settings := conf.CurrentOrFallback(bn.Settings)
 
 	// Skip filtering if range filter backend is not initialized.
 	// Read under lock to avoid data race with Delete().
@@ -93,41 +99,40 @@ func (bn *BirdNET) GetProbableSpecies(date time.Time, week float32) ([]SpeciesSc
 	bn.mu.Unlock()
 	if !hasRangeFilter {
 		bn.Debug("Range filter model not loaded, returning zero scores for all labels")
-		return zeroScoresForAllLabels(bn.Settings.BirdNET.Labels, bn.Settings.Realtime.Species.Exclude), nil
+		return zeroScoresForAllLabels(settings.BirdNET.Labels, settings.Realtime.Species.Exclude), nil
 	}
 
 	// Skip filtering if location is not configured
-	if !bn.Settings.BirdNET.LocationConfigured {
+	if !settings.BirdNET.LocationConfigured {
 		bn.Debug("Location not configured, not using location based prediction filter")
-		return zeroScoresForAllLabels(bn.Settings.BirdNET.Labels, bn.Settings.Realtime.Species.Exclude), nil
+		return zeroScoresForAllLabels(settings.BirdNET.Labels, settings.Realtime.Species.Exclude), nil
 	}
 
 	// Apply prediction filter based on the context
-	filters, err := bn.predictFilter(date, week)
+	filters, err := bn.predictFilter(date, week, settings)
 	if err != nil {
 		return nil, errors.New(err).
 			Category(errors.CategoryValidation).
 			Context("date", date.Format(time.DateOnly)).
 			Context("week", week).
-			Context("model", bn.Settings.BirdNET.RangeFilter.Model).
+			Context("model", settings.BirdNET.RangeFilter.Model).
 			Build()
 	}
 
-	// check bn.Settings.BirdNET.LocationFilterThreshold for valid value
-	if bn.Settings.BirdNET.RangeFilter.Threshold < 0 ||
-		bn.Settings.BirdNET.RangeFilter.Threshold > 1 {
+	threshold := settings.BirdNET.RangeFilter.Threshold
+	if threshold < 0 || threshold > 1 {
 		GetLogger().Warn("Invalid LocationFilterThreshold value, using default",
-			logger.Float64("invalid_value", float64(bn.Settings.BirdNET.RangeFilter.Threshold)),
+			logger.Float64("invalid_value", float64(threshold)),
 			logger.Float64("default_value", 0.01))
-		bn.Settings.BirdNET.RangeFilter.Threshold = 0.01
+		threshold = 0.01
 	}
 
 	// Collect species scores above a certain threshold
 	var speciesScores []SpeciesScore
 	for _, filter := range filters {
-		if filter.Score >= bn.Settings.BirdNET.RangeFilter.Threshold {
+		if filter.Score >= threshold {
 			// Check if species is in exclude list before adding
-			if !isSpeciesExcluded(filter.Label, bn.Settings.Realtime.Species.Exclude) {
+			if !isSpeciesExcluded(filter.Label, settings.Realtime.Species.Exclude) {
 				speciesScores = append(speciesScores, SpeciesScore{Score: float64(filter.Score), Label: filter.Label})
 			} else {
 				bn.Debug("Excluding species from range filter: %s", filter.Label)
@@ -139,15 +144,16 @@ func (bn *BirdNET) GetProbableSpecies(date time.Time, week float32) ([]SpeciesSc
 	processedSpecies := make(map[string]bool)
 
 	// Process explicitly included species
-	for _, includedSpecies := range bn.Settings.Realtime.Species.Include {
+	labels := settings.BirdNET.Labels
+	for _, includedSpecies := range settings.Realtime.Species.Include {
 		bn.Debug("Processing included species: %s", includedSpecies)
-		addSpeciesWithMaxScore(bn, &speciesScores, includedSpecies, processedSpecies)
+		addSpeciesWithMaxScore(bn, &speciesScores, includedSpecies, processedSpecies, labels)
 	}
 
 	// Process species with configured actions
-	for species := range bn.Settings.Realtime.Species.Config {
+	for species := range settings.Realtime.Species.Config {
 		bn.Debug("Processing species with actions: %s", species)
-		addSpeciesWithMaxScore(bn, &speciesScores, species, processedSpecies)
+		addSpeciesWithMaxScore(bn, &speciesScores, species, processedSpecies, labels)
 	}
 
 	// Sort species scores in descending order
@@ -170,14 +176,14 @@ func zeroScoresForAllLabels(labels, excludeList []string) []SpeciesScore {
 }
 
 // addSpeciesWithMaxScore adds all matching species to the scores list with maximum score
-func addSpeciesWithMaxScore(bn *BirdNET, speciesScores *[]SpeciesScore, speciesName string, processedSpecies map[string]bool) {
+func addSpeciesWithMaxScore(bn *BirdNET, speciesScores *[]SpeciesScore, speciesName string, processedSpecies map[string]bool, labels []string) {
 	// Skip if already processed
 	if processedSpecies[speciesName] {
 		return
 	}
 
 	matchFound := false
-	for _, label := range bn.Settings.BirdNET.Labels {
+	for _, label := range labels {
 		if matchesSpecies(label, speciesName) {
 			bn.Debug("Adding species with max score: %s (matched with: %s)", label, speciesName)
 			*speciesScores = append(*speciesScores, SpeciesScore{Score: 1.0, Label: label})
@@ -207,7 +213,9 @@ func matchesSpecies(label, speciesName string) bool {
 }
 
 // predictFilter applies the range filter model to predict species based on location and date.
-func (bn *BirdNET) predictFilter(date time.Time, week float32) ([]Filter, error) {
+// The caller supplies the settings snapshot so that the same snapshot is used
+// consistently across the entire GetProbableSpecies call.
+func (bn *BirdNET) predictFilter(date time.Time, week float32, settings *conf.Settings) ([]Filter, error) {
 	start := time.Now()
 
 	// If week is not set, use current date to get week
@@ -225,8 +233,8 @@ func (bn *BirdNET) predictFilter(date time.Time, week float32) ([]Filter, error)
 		return nil, fmt.Errorf("range filter was closed during prediction")
 	}
 	scores, err := bn.rangeFilter.Predict(
-		float32(bn.Settings.BirdNET.Latitude),
-		float32(bn.Settings.BirdNET.Longitude),
+		float32(settings.BirdNET.Latitude),
+		float32(settings.BirdNET.Longitude),
 		week,
 	)
 	bn.mu.Unlock()
@@ -235,18 +243,18 @@ func (bn *BirdNET) predictFilter(date time.Time, week float32) ([]Filter, error)
 		return nil, errors.New(err).
 			Category(errors.CategoryModelInit).
 			Context("model_type", "range_filter").
-			Context("latitude", bn.Settings.BirdNET.Latitude).
-			Context("longitude", bn.Settings.BirdNET.Longitude).
+			Context("latitude", settings.BirdNET.Latitude).
+			Context("longitude", settings.BirdNET.Longitude).
 			Context("week", week).
 			Timing("range-filter-invoke", time.Since(start)).
 			Build()
 	}
 
-	// Filter and label the results, but only for indices that exist in bn.Labels
+	// Filter and label the results, but only for indices that exist in labels
 	var results []Filter
 	for i, score := range scores {
-		if score >= bn.Settings.BirdNET.RangeFilter.Threshold && i < len(bn.Settings.BirdNET.Labels) {
-			results = append(results, Filter{Score: score, Label: bn.Settings.BirdNET.Labels[i]})
+		if score >= settings.BirdNET.RangeFilter.Threshold && i < len(settings.BirdNET.Labels) {
+			results = append(results, Filter{Score: score, Label: settings.BirdNET.Labels[i]})
 		}
 	}
 

--- a/internal/classifier/range_filter.go
+++ b/internal/classifier/range_filter.go
@@ -108,8 +108,16 @@ func (bn *BirdNET) GetProbableSpecies(date time.Time, week float32) ([]SpeciesSc
 		return zeroScoresForAllLabels(settings.BirdNET.Labels, settings.Realtime.Species.Exclude), nil
 	}
 
+	threshold := settings.BirdNET.RangeFilter.Threshold
+	if threshold < 0 || threshold > 1 {
+		GetLogger().Warn("Invalid LocationFilterThreshold value, using default",
+			logger.Float64("invalid_value", float64(threshold)),
+			logger.Float64("default_value", 0.01))
+		threshold = 0.01
+	}
+
 	// Apply prediction filter based on the context
-	filters, err := bn.predictFilter(date, week, settings)
+	filters, err := bn.predictFilter(date, week, settings, threshold)
 	if err != nil {
 		return nil, errors.New(err).
 			Category(errors.CategoryValidation).
@@ -119,24 +127,13 @@ func (bn *BirdNET) GetProbableSpecies(date time.Time, week float32) ([]SpeciesSc
 			Build()
 	}
 
-	threshold := settings.BirdNET.RangeFilter.Threshold
-	if threshold < 0 || threshold > 1 {
-		GetLogger().Warn("Invalid LocationFilterThreshold value, using default",
-			logger.Float64("invalid_value", float64(threshold)),
-			logger.Float64("default_value", 0.01))
-		threshold = 0.01
-	}
-
-	// Collect species scores above a certain threshold
+	// Collect species scores, applying exclude list
 	var speciesScores []SpeciesScore
 	for _, filter := range filters {
-		if filter.Score >= threshold {
-			// Check if species is in exclude list before adding
-			if !isSpeciesExcluded(filter.Label, settings.Realtime.Species.Exclude) {
-				speciesScores = append(speciesScores, SpeciesScore{Score: float64(filter.Score), Label: filter.Label})
-			} else {
-				bn.Debug("Excluding species from range filter: %s", filter.Label)
-			}
+		if !isSpeciesExcluded(filter.Label, settings.Realtime.Species.Exclude) {
+			speciesScores = append(speciesScores, SpeciesScore{Score: float64(filter.Score), Label: filter.Label})
+		} else {
+			bn.Debug("Excluding species from range filter: %s", filter.Label)
 		}
 	}
 
@@ -213,9 +210,10 @@ func matchesSpecies(label, speciesName string) bool {
 }
 
 // predictFilter applies the range filter model to predict species based on location and date.
-// The caller supplies the settings snapshot so that the same snapshot is used
-// consistently across the entire GetProbableSpecies call.
-func (bn *BirdNET) predictFilter(date time.Time, week float32, settings *conf.Settings) ([]Filter, error) {
+// The caller supplies the settings snapshot and a pre-validated threshold so
+// that the same values are used consistently across the entire
+// GetProbableSpecies call.
+func (bn *BirdNET) predictFilter(date time.Time, week float32, settings *conf.Settings, threshold float32) ([]Filter, error) {
 	start := time.Now()
 
 	// If week is not set, use current date to get week
@@ -253,7 +251,7 @@ func (bn *BirdNET) predictFilter(date time.Time, week float32, settings *conf.Se
 	// Filter and label the results, but only for indices that exist in labels
 	var results []Filter
 	for i, score := range scores {
-		if score >= settings.BirdNET.RangeFilter.Threshold && i < len(settings.BirdNET.Labels) {
+		if score >= threshold && i < len(settings.BirdNET.Labels) {
 			results = append(results, Filter{Score: score, Label: settings.BirdNET.Labels[i]})
 		}
 	}


### PR DESCRIPTION
## Summary

- **Backend**: `GetProbableSpecies` and `predictFilter` now read from `conf.CurrentOrFallback(bn.Settings)` instead of the stale startup pointer, so UI changes to coordinates, threshold, and `LocationConfigured` take effect immediately
- `swapRangeFilterSettings` publishes a temporary global snapshot (and restores it) so the test endpoint works with the fresh-settings read path
- Threshold validation moved before `predictFilter` to prevent invalid values (e.g., > 1.0) from silently producing empty results
- **Frontend**: `$effect` in `MainSettingsPage` now tracks threshold changes, so the species count updates when the user edits the threshold

Fixes #2896

## Test plan

- [x] `go test -race ./internal/api/v2/` - all range filter tests pass
- [x] `go test -race ./internal/conf/` - all conf tests pass
- [x] `golangci-lint run -v` - zero issues
- [x] `npm run check:all` - frontend checks pass
- [x] QA container deployed and API tested: threshold 0.01 -> 252 species, 0.1 -> 112, 0.5 -> 24
- [x] Stored species count unaffected after test endpoint calls (proper restore)
- [x] E2E settings roundtrip (15 tests) and config integrity (13 tests) pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Range filter threshold validation is now consistent across the application
  * Range filter settings are properly applied when testing and configuring filters
  * Improved location configuration handling for range filtering to ensure settings take effect reliably

<!-- end of auto-generated comment: release notes by coderabbit.ai -->