### PR TITLE
refactor(range-filter): eliminate global state swap in test endpoint

### DIFF
--- a/internal/api/v2/range.go
+++ b/internal/api/v2/range.go
@@ -77,10 +77,9 @@ func (c *Controller) getBirdNETInstance() (*classifier.Orchestrator, error) {
 // directly to GetProbableSpeciesWithSettings without modifying global state.
 func (c *Controller) buildTestSettings(lat, lon float64, threshold float32) *conf.Settings {
 	c.settingsMutex.RLock()
-	current := conf.CurrentOrFallback(c.Settings)
+	testSnapshot := conf.CloneSettings(conf.CurrentOrFallback(c.Settings))
 	c.settingsMutex.RUnlock()
 
-	testSnapshot := conf.CloneSettings(current)
 	testSnapshot.BirdNET.Latitude = lat
 	testSnapshot.BirdNET.Longitude = lon
 	testSnapshot.BirdNET.RangeFilter.Threshold = threshold

--- a/internal/api/v2/range.go
+++ b/internal/api/v2/range.go
@@ -11,7 +11,6 @@ import (
 	"slices"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/labstack/echo/v4"
@@ -26,9 +25,6 @@ const (
 	weeksPerMonth = 4 // Simplified ML model uses 4 weeks per month (48 weeks/year)
 	daysPerWeek   = 7 // Days in a week for week calculation
 )
-
-// rangeFilterMutex protects against concurrent modifications to global settings during testing
-var rangeFilterMutex sync.Mutex
 
 // validateRangeFilterRequest validates the range filter test request parameters.
 // Returns user-facing error messages with capitalized first letter for API responses.
@@ -75,36 +71,21 @@ func (c *Controller) getBirdNETInstance() (*classifier.Orchestrator, error) {
 	return instance, nil
 }
 
-// swapRangeFilterSettings temporarily publishes a settings snapshot with the
-// given test coordinates and threshold, then returns a restore function that
-// republishes the original snapshot. Because GetProbableSpecies reads from the
-// latest published snapshot (via conf.CurrentOrFallback), modifying a single
-// controller-cached pointer is not sufficient; the global snapshot must be
-// swapped so the BirdNET instance sees the test values.
-//
-// It acquires settingsMutex (write lock) to prevent concurrent API settings
-// reads from seeing the temporary test values (see #1940).
-// The caller MUST call the returned restore function to release the lock.
-func (c *Controller) swapRangeFilterSettings(lat, lon float64, threshold float32) func() {
-	c.settingsMutex.Lock()
+// buildTestSettings creates a settings snapshot with the given test coordinates
+// and threshold for range filter testing. The snapshot is a clone of the
+// current settings with only the test values overridden, so it can be passed
+// directly to GetProbableSpeciesWithSettings without modifying global state.
+func (c *Controller) buildTestSettings(lat, lon float64, threshold float32) *conf.Settings {
+	c.settingsMutex.RLock()
+	current := conf.CurrentOrFallback(c.Settings)
+	c.settingsMutex.RUnlock()
 
-	original := conf.CurrentOrFallback(c.Settings)
-	savedController := c.Settings
-
-	testSnapshot := conf.CloneSettings(original)
+	testSnapshot := conf.CloneSettings(current)
 	testSnapshot.BirdNET.Latitude = lat
 	testSnapshot.BirdNET.Longitude = lon
 	testSnapshot.BirdNET.RangeFilter.Threshold = threshold
 	testSnapshot.BirdNET.LocationConfigured = true
-
-	conf.StoreSettings(testSnapshot)
-	c.Settings = testSnapshot
-
-	return func() {
-		conf.StoreSettings(original)
-		c.Settings = savedController
-		c.settingsMutex.Unlock()
-	}
+	return testSnapshot
 }
 
 // Location represents geographic coordinates
@@ -361,13 +342,9 @@ func (c *Controller) TestRangeFilter(ctx echo.Context) error {
 		return c.HandleError(ctx, err, "BirdNET service not available", http.StatusInternalServerError)
 	}
 
-	// Use mutex to protect against concurrent modifications to global settings
-	rangeFilterMutex.Lock()
-	defer rangeFilterMutex.Unlock()
-
-	// Temporarily swap settings for testing
-	restore := c.swapRangeFilterSettings(req.Latitude, req.Longitude, req.Threshold)
-	defer restore()
+	// Build a local settings snapshot with test values; no global state is
+	// modified, so concurrent BuildRangeFilter calls are unaffected.
+	testSettings := c.buildTestSettings(req.Latitude, req.Longitude, req.Threshold)
 
 	// Calculate week if not provided
 	week := req.Week
@@ -376,7 +353,7 @@ func (c *Controller) TestRangeFilter(ctx echo.Context) error {
 	}
 
 	// Get probable species for the test parameters
-	speciesScores, err := birdnetInstance.GetProbableSpecies(testDate, week)
+	speciesScores, err := birdnetInstance.GetProbableSpeciesWithSettings(testDate, week, testSettings)
 	if err != nil {
 		return c.HandleError(ctx, err, "Failed to get probable species", http.StatusInternalServerError)
 	}
@@ -559,20 +536,14 @@ func (c *Controller) getTestSpeciesList(req RangeFilterTestRequest) ([]RangeFilt
 		return nil, Location{}, 0, err
 	}
 
-	// Use mutex to protect against concurrent modifications to global settings
-	rangeFilterMutex.Lock()
-	defer rangeFilterMutex.Unlock()
-
-	// Temporarily set test values and restore after testing
-	restore := c.swapRangeFilterSettings(req.Latitude, req.Longitude, req.Threshold)
-	defer restore()
+	testSettings := c.buildTestSettings(req.Latitude, req.Longitude, req.Threshold)
 
 	// Use current date and calculate week
 	testDate := time.Now()
 	week := calculateWeek(testDate)
 
 	// Get probable species for the test parameters
-	speciesScores, err := birdnetInstance.GetProbableSpecies(testDate, week)
+	speciesScores, err := birdnetInstance.GetProbableSpeciesWithSettings(testDate, week, testSettings)
 	if err != nil {
 		return nil, Location{}, 0, err
 	}

--- a/internal/api/v2/range_test.go
+++ b/internal/api/v2/range_test.go
@@ -307,98 +307,35 @@ func TestRebuildRangeFilterWithoutProcessor(t *testing.T) {
 	assert.Contains(t, response.Message, "BirdNET service not available")
 }
 
-// TestSwapRangeFilterSettingsBlocksSettingsReads verifies that swapRangeFilterSettings
-// holds settingsMutex so concurrent settings reads cannot see temporarily swapped values.
-// This is a regression test for #1940 where the frontend could receive wrong coordinates.
-func TestSwapRangeFilterSettingsBlocksSettingsReads(t *testing.T) {
-	_, _, controller := setupRangeTestEnvironment(t)
-
-	// Original coordinates (Helsinki)
-	originalLat := 60.1699
-	originalLon := 24.9384
-
-	// Test coordinates (New York) - deliberately different
-	testLat := 40.7128
-	testLon := -74.0060
-
-	controller.Settings.BirdNET.Latitude = originalLat
-	controller.Settings.BirdNET.Longitude = originalLon
-
-	const iterations = 100
-	var wg sync.WaitGroup
-
-	// Channel to collect any incorrect readings
-	badReadings := make(chan Location, iterations)
-
-	for range iterations {
-		wg.Add(2)
-
-		// Goroutine 1: swap settings temporarily (simulates range filter test)
-		go func() {
-			defer wg.Done()
-			rangeFilterMutex.Lock()
-			restore := controller.swapRangeFilterSettings(testLat, testLon, 0.05)
-			// Simulate model inference time
-			time.Sleep(time.Microsecond)
-			restore()
-			rangeFilterMutex.Unlock()
-		}()
-
-		// Goroutine 2: read settings (simulates GetAllSettings)
-		go func() {
-			defer wg.Done()
-			controller.settingsMutex.RLock()
-			lat := controller.Settings.BirdNET.Latitude
-			lon := controller.Settings.BirdNET.Longitude
-			controller.settingsMutex.RUnlock()
-
-			// The read should see either the original or the test values atomically,
-			// but never a partial/mixed state. Both consistent states are acceptable.
-			isOriginal := lat == originalLat && lon == originalLon
-			isTest := lat == testLat && lon == testLon
-			if !isOriginal && !isTest {
-				badReadings <- Location{Latitude: lat, Longitude: lon}
-			}
-		}()
-	}
-
-	wg.Wait()
-	close(badReadings)
-
-	for bad := range badReadings {
-		t.Errorf("Read inconsistent coordinates: lat=%f, lon=%f", bad.Latitude, bad.Longitude)
-	}
-}
-
-// TestSwapRangeFilterSettingsRestoresValues verifies that the restore function
-// correctly restores original settings values after a swap.
-func TestSwapRangeFilterSettingsRestoresValues(t *testing.T) {
+// TestBuildTestSettingsDoesNotMutateGlobal verifies that buildTestSettings
+// creates an isolated snapshot: the controller's cached settings and the
+// global published snapshot remain unchanged.
+func TestBuildTestSettingsDoesNotMutateGlobal(t *testing.T) {
 	_, _, controller := setupRangeTestEnvironment(t)
 
 	originalLat := controller.Settings.BirdNET.Latitude
 	originalLon := controller.Settings.BirdNET.Longitude
 	originalThreshold := controller.Settings.BirdNET.RangeFilter.Threshold
 
-	// Swap to different values
-	restore := controller.swapRangeFilterSettings(40.7128, -74.0060, 0.05)
+	testSettings := controller.buildTestSettings(40.7128, -74.0060, 0.05)
 
-	// Verify swapped values
-	assert.InDelta(t, 40.7128, controller.Settings.BirdNET.Latitude, 0.0001)
-	assert.InDelta(t, -74.0060, controller.Settings.BirdNET.Longitude, 0.0001)
-	assert.InDelta(t, float32(0.05), controller.Settings.BirdNET.RangeFilter.Threshold, 0.001)
+	// Test snapshot has the overridden values
+	assert.InDelta(t, 40.7128, testSettings.BirdNET.Latitude, 0.0001)
+	assert.InDelta(t, -74.0060, testSettings.BirdNET.Longitude, 0.0001)
+	assert.InDelta(t, float32(0.05), testSettings.BirdNET.RangeFilter.Threshold, 0.001)
+	assert.True(t, testSettings.BirdNET.LocationConfigured)
 
-	// Restore
-	restore()
-
-	// Verify original values restored
+	// Controller's settings are unchanged
 	assert.InDelta(t, originalLat, controller.Settings.BirdNET.Latitude, 0.0001)
 	assert.InDelta(t, originalLon, controller.Settings.BirdNET.Longitude, 0.0001)
 	assert.InDelta(t, originalThreshold, controller.Settings.BirdNET.RangeFilter.Threshold, 0.001)
 }
 
-// TestGetRangeFilterSpeciesCountDuringSwap verifies that the species count endpoint
-// returns correct coordinates even when a range filter test is swapping settings.
-func TestGetRangeFilterSpeciesCountDuringSwap(t *testing.T) {
+// TestBuildTestSettingsConcurrentWithCountEndpoint verifies that the count
+// endpoint always returns the real coordinates even while buildTestSettings
+// is called concurrently. Because buildTestSettings never modifies global
+// state, this is trivially safe (regression test for #1940).
+func TestBuildTestSettingsConcurrentWithCountEndpoint(t *testing.T) {
 	e, _, controller := setupRangeTestEnvironment(t)
 
 	originalLat := controller.Settings.BirdNET.Latitude
@@ -410,17 +347,11 @@ func TestGetRangeFilterSpeciesCountDuringSwap(t *testing.T) {
 	for range iterations {
 		wg.Add(2)
 
-		// Goroutine 1: swap settings
 		go func() {
 			defer wg.Done()
-			rangeFilterMutex.Lock()
-			restore := controller.swapRangeFilterSettings(-33.8688, 151.2093, 0.05)
-			time.Sleep(time.Microsecond)
-			restore()
-			rangeFilterMutex.Unlock()
+			_ = controller.buildTestSettings(-33.8688, 151.2093, 0.05)
 		}()
 
-		// Goroutine 2: call the count endpoint
 		go func() {
 			defer wg.Done()
 			req := httptest.NewRequest(http.MethodGet, "/api/v2/range/species/count", http.NoBody)
@@ -440,13 +371,8 @@ func TestGetRangeFilterSpeciesCountDuringSwap(t *testing.T) {
 				return
 			}
 
-			// With the fix, reads are blocked during swap, so the endpoint
-			// should return either original or test values, never a mix.
-			isOriginal := response.Location.Latitude == originalLat && response.Location.Longitude == originalLon
-			isTest := response.Location.Latitude == -33.8688 && response.Location.Longitude == 151.2093
-			assert.True(t, isOriginal || isTest,
-				"Got unexpected coordinates: lat=%f, lon=%f",
-				response.Location.Latitude, response.Location.Longitude)
+			assert.InDelta(t, originalLat, response.Location.Latitude, 0.0001)
+			assert.InDelta(t, originalLon, response.Location.Longitude, 0.0001)
 		}()
 	}
 

--- a/internal/api/v2/range_test.go
+++ b/internal/api/v2/range_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/classifier"
+	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/datastore/mocks"
 )
 
@@ -329,6 +330,12 @@ func TestBuildTestSettingsDoesNotMutateGlobal(t *testing.T) {
 	assert.InDelta(t, originalLat, controller.Settings.BirdNET.Latitude, 0.0001)
 	assert.InDelta(t, originalLon, controller.Settings.BirdNET.Longitude, 0.0001)
 	assert.InDelta(t, originalThreshold, controller.Settings.BirdNET.RangeFilter.Threshold, 0.001)
+
+	// Published snapshot (what handlers read via CurrentOrFallback) is also unchanged
+	published := conf.CurrentOrFallback(controller.Settings)
+	assert.InDelta(t, originalLat, published.BirdNET.Latitude, 0.0001)
+	assert.InDelta(t, originalLon, published.BirdNET.Longitude, 0.0001)
+	assert.InDelta(t, originalThreshold, published.BirdNET.RangeFilter.Threshold, 0.001)
 }
 
 // TestBuildTestSettingsConcurrentWithCountEndpoint verifies that the count

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -146,6 +146,13 @@ func (o *Orchestrator) GetProbableSpecies(date time.Time, week float32) ([]Speci
 	return o.primary.GetProbableSpecies(date, week)
 }
 
+// GetProbableSpeciesWithSettings filters species using the supplied settings
+// snapshot, allowing callers to test arbitrary coordinates and thresholds
+// without modifying global state.
+func (o *Orchestrator) GetProbableSpeciesWithSettings(date time.Time, week float32, settings *conf.Settings) ([]SpeciesScore, error) {
+	return o.primary.GetProbableSpeciesWithSettings(date, week, settings)
+}
+
 // GetSpeciesOccurrence returns the occurrence probability for a species at the current time.
 func (o *Orchestrator) GetSpeciesOccurrence(species string) float64 {
 	return o.primary.GetSpeciesOccurrence(species)

--- a/internal/classifier/range_filter.go
+++ b/internal/classifier/range_filter.go
@@ -82,15 +82,26 @@ func BuildRangeFilter(o *Orchestrator) error {
 }
 
 // GetProbableSpecies filters and sorts bird species based on their scores.
-// It also updates the scores for species that have custom actions defined in the speciesConfigCSV.
-//
 // Settings are read from the latest published snapshot (via conf.CurrentOrFallback)
 // so that UI changes to coordinates, threshold, or LocationConfigured take
 // effect immediately without restarting the service.
 func (bn *BirdNET) GetProbableSpecies(date time.Time, week float32) ([]SpeciesScore, error) {
-	bn.Debug("Applying range filter")
+	return bn.getProbableSpecies(date, week, conf.CurrentOrFallback(bn.Settings))
+}
 
-	settings := conf.CurrentOrFallback(bn.Settings)
+// GetProbableSpeciesWithSettings filters species using the supplied settings
+// snapshot instead of reading from the global atomic pointer. This allows the
+// test endpoint to evaluate arbitrary coordinates and thresholds without
+// publishing temporary values into the global settings, eliminating the race
+// where a concurrent BuildRangeFilter could pick up test data.
+func (bn *BirdNET) GetProbableSpeciesWithSettings(date time.Time, week float32, settings *conf.Settings) ([]SpeciesScore, error) {
+	return bn.getProbableSpecies(date, week, settings)
+}
+
+// getProbableSpecies is the shared implementation for both the global-settings
+// and explicit-settings entry points.
+func (bn *BirdNET) getProbableSpecies(date time.Time, week float32, settings *conf.Settings) ([]SpeciesScore, error) {
+	bn.Debug("Applying range filter")
 
 	// Skip filtering if range filter backend is not initialized.
 	// Read under lock to avoid data race with Delete().


### PR DESCRIPTION
## Summary

- Replace `swapRangeFilterSettings` (which temporarily published test values into the global settings) with `buildTestSettings` that creates an isolated snapshot
- Add `GetProbableSpeciesWithSettings` to BirdNET and Orchestrator for callers that need to test with explicit settings
- The test endpoint now passes the local snapshot directly, so no global state is modified during testing
- Remove `rangeFilterMutex` (no longer needed)
- Replace three swap-based concurrency tests with two tests that verify isolation

This eliminates the race condition flagged by Sentry Seer on #2897 where a concurrent `BuildRangeFilter` could read temporary test coordinates.

## Test plan

- [x] `go test -race ./internal/api/v2/ -run "Range|BuildTest"` - all 14 tests pass
- [x] `golangci-lint run -v` - zero issues
- [x] New test `TestBuildTestSettingsDoesNotMutateGlobal` verifies snapshot isolation
- [x] New test `TestBuildTestSettingsConcurrentWithCountEndpoint` verifies no race with count endpoint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved concurrency and stability of species filtering by moving from shared mutable state to localized, immutable settings snapshots—reduces interference between simultaneous requests.

* **Tests**
  * Updated and expanded tests to verify isolation, immutability, and correct concurrent behavior of the new settings-driven approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->