### PR TITLE
fix(settings): eliminate stale *conf.Settings pointer reads across codebase

### DIFF
--- a/internal/analysis/control_monitor.go
+++ b/internal/analysis/control_monitor.go
@@ -303,8 +303,8 @@ func (cm *ControlMonitor) handleReloadBirdnet() {
 		cm.notifySuccess("Range filter rebuilt successfully")
 	}
 
-	// Rebuild name maps with new locale labels
-	labels := cm.bn.Settings.BirdNET.Labels
+	// Rebuild name maps with new locale labels (use fresh settings, not stale pointer)
+	labels := conf.CurrentOrFallback(cm.bn.Settings).BirdNET.Labels
 	if cm.proc != nil && cm.proc.Ds != nil {
 		cm.proc.Ds.UpdateNameMaps(labels)
 		GetLogger().Info("Datastore name maps updated with new labels")

--- a/internal/analysis/processor/daylight_filter.go
+++ b/internal/analysis/processor/daylight_filter.go
@@ -41,10 +41,10 @@ func (p *Processor) initDaylightFilter() {
 		return
 	}
 
-	// Get BirdNET labels for common name resolution
+	// Get BirdNET labels from fresh settings for common name resolution
 	var labels []string
-	if p.Bn != nil && p.Bn.Settings != nil {
-		labels = p.Bn.Settings.BirdNET.Labels
+	if settings != nil {
+		labels = settings.BirdNET.Labels
 	}
 
 	// Get cached taxonomy database for genus/family/order resolution

--- a/internal/analysis/processor/extended_capture.go
+++ b/internal/analysis/processor/extended_capture.go
@@ -53,10 +53,10 @@ func (p *Processor) initExtendedCapture() {
 		return
 	}
 
-	// Get BirdNET labels for common name resolution
+	// Get BirdNET labels from fresh settings for common name resolution
 	var labels []string
-	if p.Bn != nil && p.Bn.Settings != nil {
-		labels = p.Bn.Settings.BirdNET.Labels
+	if settings != nil {
+		labels = settings.BirdNET.Labels
 	}
 
 	// Get cached taxonomy database for genus/family/order resolution

--- a/internal/api/v2/api.go
+++ b/internal/api/v2/api.go
@@ -132,6 +132,12 @@ type ShutdownRequester interface {
 	RequestShutdown()
 }
 
+// currentSettings returns the latest settings snapshot so UI changes
+// take effect in API responses without restarting the service.
+func (c *Controller) currentSettings() *conf.Settings {
+	return conf.CurrentOrFallback(c.Settings)
+}
+
 // Option is a functional option for configuring the Controller.
 type Option func(*Controller)
 

--- a/internal/api/v2/dynamic_thresholds.go
+++ b/internal/api/v2/dynamic_thresholds.go
@@ -223,7 +223,7 @@ func (c *Controller) addMemoryThresholds(thresholdMap map[string]*DynamicThresho
 		return
 	}
 	memoryData := c.Processor.GetDynamicThresholdData()
-	baseThreshold := c.Settings.BirdNET.Threshold
+	baseThreshold := c.currentSettings().BirdNET.Threshold
 
 	for _, dt := range memoryData {
 		key := strings.ToLower(dt.ModelName) + ":" + strings.ToLower(dt.SpeciesName)
@@ -274,13 +274,14 @@ func (c *Controller) GetDynamicThresholdStats(ctx echo.Context) error {
 		})
 	}
 
+	settings := c.currentSettings()
 	return ctx.JSON(http.StatusOK, ThresholdStatsResponse{
 		TotalCount:        totalCount,
 		ActiveCount:       activeCount,
 		AtMinimumCount:    atMinimumCount,
 		LevelDistribution: distribution,
-		ValidHours:        c.Settings.Realtime.DynamicThreshold.ValidHours,
-		MinThreshold:      c.Settings.Realtime.DynamicThreshold.Min,
+		ValidHours:        settings.Realtime.DynamicThreshold.ValidHours,
+		MinThreshold:      settings.Realtime.DynamicThreshold.Min,
 	})
 }
 

--- a/internal/api/v2/integrations.go
+++ b/internal/api/v2/integrations.go
@@ -278,7 +278,7 @@ func (c *Controller) GetMQTTStatus(ctx echo.Context) error {
 	c.logDebugIfEnabled("Checking MQTT connection status",
 		logger.String("path", path),
 		logger.String("ip", ip))
-	connected, checkErr := c.checkMQTTConnectionStatus(ctx.Request().Context())
+	connected, checkErr := c.checkMQTTConnectionStatus(ctx.Request().Context(), settings)
 	status.Connected = connected
 	if checkErr != "" {
 		status.LastError = checkErr
@@ -297,8 +297,7 @@ func (c *Controller) GetMQTTStatus(ctx echo.Context) error {
 // checkMQTTConnectionStatus attempts to connect to the MQTT broker using a temporary client
 // to determine the current connection status.
 // Returns true if connected, false otherwise, along with any error message encountered.
-func (c *Controller) checkMQTTConnectionStatus(parentCtx context.Context) (connected bool, lastError string) {
-	settings := c.currentSettings()
+func (c *Controller) checkMQTTConnectionStatus(parentCtx context.Context, settings *conf.Settings) (connected bool, lastError string) {
 	// Use the injected metrics instance
 	if c.metrics == nil {
 		c.logErrorIfEnabled("Metrics instance not available for MQTT status check")
@@ -472,7 +471,7 @@ func (c *Controller) TestBirdWeatherConnection(ctx echo.Context) error {
 	if err != nil {
 		return ctx.JSON(http.StatusInternalServerError, map[string]any{
 			"success": false,
-			"message": formatClientError("Failed to create BirdWeather client", err, c.Settings),
+			"message": formatClientError("Failed to create BirdWeather client", err, currentCfg),
 			"state":   "failed",
 		})
 	}

--- a/internal/api/v2/integrations.go
+++ b/internal/api/v2/integrations.go
@@ -254,15 +254,16 @@ func (c *Controller) GetMQTTStatus(ctx echo.Context) error {
 		logger.String("path", path),
 		logger.String("ip", ip))
 
-	// Get MQTT configuration from settings
-	mqttConfig := c.Settings.Realtime.MQTT
+	// Get MQTT configuration from fresh settings
+	settings := c.currentSettings()
+	mqttConfig := settings.Realtime.MQTT
 
 	// Prepare status response
 	status := MQTTStatus{
 		Connected: false, // Default to not connected
 		Broker:    mqttConfig.Broker,
 		Topic:     mqttConfig.Topic,
-		ClientID:  c.Settings.Main.Name, // Use the application name as client ID
+		ClientID:  settings.Main.Name, // Use the application name as client ID
 	}
 
 	// If MQTT is not enabled, return status as-is
@@ -297,13 +298,14 @@ func (c *Controller) GetMQTTStatus(ctx echo.Context) error {
 // to determine the current connection status.
 // Returns true if connected, false otherwise, along with any error message encountered.
 func (c *Controller) checkMQTTConnectionStatus(parentCtx context.Context) (connected bool, lastError string) {
+	settings := c.currentSettings()
 	// Use the injected metrics instance
 	if c.metrics == nil {
 		c.logErrorIfEnabled("Metrics instance not available for MQTT status check")
 		return false, "error:metrics:not_initialized"
 	}
 
-	tempClient, err := mqtt.NewClient(c.Settings, c.metrics)
+	tempClient, err := mqtt.NewClient(settings, c.metrics)
 	if err != nil {
 		c.logErrorIfEnabled("Failed to create temporary MQTT client for status check",
 			logger.Error(err))
@@ -320,20 +322,20 @@ func (c *Controller) checkMQTTConnectionStatus(parentCtx context.Context) (conne
 	if err != nil {
 		c.logWarnIfEnabled("Temporary MQTT client connection failed during status check",
 			logger.Error(err),
-			logger.String("broker", c.Settings.Realtime.MQTT.Broker))
+			logger.String("broker", settings.Realtime.MQTT.Broker))
 		return false, fmt.Sprintf("error:connection:mqtt_broker:%s", err.Error())
 	}
 
 	// Check if genuinely connected
 	if !tempClient.IsConnected() {
 		c.logWarnIfEnabled("Temporary MQTT client connected but IsConnected() returned false",
-			logger.String("broker", c.Settings.Realtime.MQTT.Broker))
+			logger.String("broker", settings.Realtime.MQTT.Broker))
 		// Consider this a failure for status purposes, though connection might be flapping
 		return false, "error:connection:mqtt_connection_unstable"
 	}
 
 	c.logDebugIfEnabled("Temporary MQTT client connected successfully for status check",
-		logger.String("broker", c.Settings.Realtime.MQTT.Broker))
+		logger.String("broker", settings.Realtime.MQTT.Broker))
 	return true, "" // Connected successfully
 }
 
@@ -345,8 +347,8 @@ func (c *Controller) GetBirdWeatherStatus(ctx echo.Context) error {
 		logger.String("path", path),
 		logger.String("ip", ip))
 
-	// Get BirdWeather configuration from settings
-	bwConfig := c.Settings.Realtime.Birdweather
+	// Get BirdWeather configuration from fresh settings
+	bwConfig := c.currentSettings().Realtime.Birdweather
 
 	// Prepare status response
 	status := BirdWeatherStatus{
@@ -371,8 +373,9 @@ func (c *Controller) GetBirdWeatherStatus(ctx echo.Context) error {
 
 // TestMQTTConnection handles POST /api/v2/integrations/mqtt/test
 func (c *Controller) TestMQTTConnection(ctx echo.Context) error {
-	// Get MQTT configuration from settings
-	mqttConfig := c.Settings.Realtime.MQTT
+	// Get MQTT configuration from fresh settings
+	settings := c.currentSettings()
+	mqttConfig := settings.Realtime.MQTT
 
 	if !mqttConfig.Enabled {
 		return ctx.JSON(http.StatusOK, MQTTTestResult{
@@ -398,11 +401,11 @@ func (c *Controller) TestMQTTConnection(ctx echo.Context) error {
 	}
 
 	// Create test MQTT client with the current configuration
-	client, err := mqtt.NewClient(c.Settings, c.metrics)
+	client, err := mqtt.NewClient(settings, c.metrics)
 	if err != nil {
 		return ctx.JSON(http.StatusInternalServerError, MQTTTestResult{
 			Success: false,
-			Message: formatClientError("Failed to create MQTT client", err, c.Settings),
+			Message: formatClientError("Failed to create MQTT client", err, settings),
 		})
 	}
 
@@ -443,14 +446,15 @@ func (c *Controller) TestBirdWeatherConnection(ctx echo.Context) error {
 		})
 	}
 
-	// Create temporary settings for the test
+	// Create temporary settings for the test using fresh settings
+	currentCfg := c.currentSettings()
 	testSettings := &conf.Settings{
 		BirdNET: conf.BirdNETConfig{
-			Latitude:  c.Settings.BirdNET.Latitude,
-			Longitude: c.Settings.BirdNET.Longitude,
+			Latitude:  currentCfg.BirdNET.Latitude,
+			Longitude: currentCfg.BirdNET.Longitude,
 		},
 		Realtime: conf.RealtimeSettings{
-			Audio: c.Settings.Realtime.Audio, // Required for FFmpeg path (FLAC encoding)
+			Audio: currentCfg.Realtime.Audio, // Required for FFmpeg path (FLAC encoding)
 			Birdweather: conf.BirdweatherSettings{
 				Enabled:          request.Enabled,
 				ID:               request.ID,
@@ -461,7 +465,7 @@ func (c *Controller) TestBirdWeatherConnection(ctx echo.Context) error {
 		},
 	}
 	// Copy main settings
-	testSettings.Main = c.Settings.Main
+	testSettings.Main = currentCfg.Main
 
 	// Create test BirdWeather client with the test configuration
 	client, err := birdweather.New(testSettings)
@@ -542,11 +546,12 @@ func (c *Controller) TestWeatherConnection(ctx echo.Context) error {
 	ctx.Response().Header().Set("Connection", "keep-alive")
 	ctx.Response().WriteHeader(http.StatusOK)
 
-	// Create test settings from request
+	// Create test settings from request using fresh settings
+	weatherCfg := c.currentSettings()
 	testSettings := &conf.Settings{
 		BirdNET: conf.BirdNETConfig{
-			Latitude:  c.Settings.BirdNET.Latitude,
-			Longitude: c.Settings.BirdNET.Longitude,
+			Latitude:  weatherCfg.BirdNET.Latitude,
+			Longitude: weatherCfg.BirdNET.Longitude,
 		},
 		Realtime: conf.RealtimeSettings{
 			Weather: conf.WeatherSettings{

--- a/internal/classifier/analyze.go
+++ b/internal/classifier/analyze.go
@@ -26,6 +26,7 @@ func (bn *BirdNET) Predict(ctx context.Context, sample [][]float32) ([]datastore
 	span, _ := StartSpan(ctx, "birdnet.predict", "Species prediction")
 	defer span.Finish()
 
+	settings := bn.currentSettings()
 	start := time.Now()
 	span.SetTag("model", bn.ModelInfo.ID)
 	span.SetData("sample_count", len(sample))
@@ -37,7 +38,7 @@ func (bn *BirdNET) Predict(ctx context.Context, sample [][]float32) ([]datastore
 	if len(sample) == 0 || len(sample[0]) == 0 {
 		err := errors.Newf("empty audio sample").
 			Category(errors.CategoryValidation).
-			ModelContext(bn.Settings.BirdNET.ModelPath, bn.ModelInfo.ID).
+			ModelContext(settings.BirdNET.ModelPath, bn.ModelInfo.ID).
 			Build()
 		span.SetTag("error", "true")
 		span.SetData("error_type", "empty_sample")
@@ -52,7 +53,7 @@ func (bn *BirdNET) Predict(ctx context.Context, sample [][]float32) ([]datastore
 	if bn.classifier == nil {
 		err := errors.Newf("classifier backend is not initialized").
 			Category(errors.CategoryModelInit).
-			ModelContext(bn.Settings.BirdNET.ModelPath, bn.ModelInfo.ID).
+			ModelContext(settings.BirdNET.ModelPath, bn.ModelInfo.ID).
 			Build()
 		span.SetTag("error", "true")
 		span.SetData("error_type", "classifier_nil")
@@ -65,7 +66,7 @@ func (bn *BirdNET) Predict(ctx context.Context, sample [][]float32) ([]datastore
 	if err != nil {
 		err = errors.New(err).
 			Category(errors.CategoryAudio).
-			ModelContext(bn.Settings.BirdNET.ModelPath, bn.ModelInfo.ID).
+			ModelContext(settings.BirdNET.ModelPath, bn.ModelInfo.ID).
 			Context("sample_length", len(sample[0])).
 			Timing("prediction-invoke", time.Since(start)).
 			Build()
@@ -92,14 +93,14 @@ func (bn *BirdNET) Predict(ctx context.Context, sample [][]float32) ([]datastore
 	globalInferenceCounters.RecordInvoke(invokeDuration.Microseconds())
 
 	// Use optimized sigmoid function with buffer reuse
-	confidence := applySigmoidToPredictionsReuse(predictions, bn.Settings.BirdNET.Sensitivity, bn.confidenceBuffer)
+	confidence := applySigmoidToPredictionsReuse(predictions, settings.BirdNET.Sensitivity, bn.confidenceBuffer)
 
 	// Use the pre-allocated buffer to reduce memory allocations
-	results, err := pairLabelsAndConfidenceReuse(bn.Settings.BirdNET.Labels, confidence, bn.resultsBuffer)
+	results, err := pairLabelsAndConfidenceReuse(settings.BirdNET.Labels, confidence, bn.resultsBuffer)
 	if err != nil {
 		err = errors.New(err).
 			Category(errors.CategoryValidation).
-			Context("label_count", len(bn.Settings.BirdNET.Labels)).
+			Context("label_count", len(settings.BirdNET.Labels)).
 			Context("confidence_count", len(confidence)).
 			Timing("prediction-total", time.Since(start)).
 			Build()

--- a/internal/classifier/birdnet.go
+++ b/internal/classifier/birdnet.go
@@ -59,6 +59,12 @@ type BirdNET struct {
 	speciesCache   map[string]*speciesCacheEntry
 }
 
+// currentSettings returns the latest settings snapshot so UI changes to
+// sensitivity, location, and labels take effect without restarting the service.
+func (bn *BirdNET) currentSettings() *conf.Settings {
+	return conf.CurrentOrFallback(bn.Settings)
+}
+
 // NewBirdNET initializes a new BirdNET instance with given settings.
 // If modelInfo is non-nil it is used directly (orchestrator path); otherwise
 // the function walks a 4-tier resolution chain: config version > filename > default.
@@ -544,13 +550,14 @@ func (bn *BirdNET) clearSpeciesCache() {
 
 // getCachedSpeciesScores returns species occurrence scores with caching to avoid repeated calls within same day
 func (bn *BirdNET) getCachedSpeciesScores(targetDate time.Time) (map[string]float64, error) {
+	settings := bn.currentSettings()
 	// Build composite cache key: date + rounded lat/lon + model
 	day := targetDate.Format(time.DateOnly)
 	cacheKey := fmt.Sprintf("%s|%.4f,%.4f|%s",
 		day,
-		bn.Settings.BirdNET.Latitude,
-		bn.Settings.BirdNET.Longitude,
-		bn.Settings.BirdNET.RangeFilter.Model,
+		settings.BirdNET.Latitude,
+		settings.BirdNET.Longitude,
+		settings.BirdNET.RangeFilter.Model,
 	)
 
 	// FAST PATH: read under RLock and return a defensive copy
@@ -1052,7 +1059,7 @@ func (bn *BirdNET) GetSpeciesOccurrenceAtTime(species string, detectionTime time
 	}
 
 	// If location not configured, range filter is not active, return 0
-	if !bn.Settings.BirdNET.LocationConfigured {
+	if !bn.currentSettings().BirdNET.LocationConfigured {
 		return 0.0
 	}
 
@@ -1124,13 +1131,13 @@ func (bn *BirdNET) ModelVersion() string {
 // NumSpecies returns the number of species this model can classify.
 // Implements ModelInstance.
 func (bn *BirdNET) NumSpecies() int {
-	return len(bn.Settings.BirdNET.Labels)
+	return len(bn.currentSettings().BirdNET.Labels)
 }
 
 // Labels returns the full list of species labels for this model.
 // Implements ModelInstance.
 func (bn *BirdNET) Labels() []string {
-	return bn.Settings.BirdNET.Labels
+	return bn.currentSettings().BirdNET.Labels
 }
 
 // Close releases resources held by the BirdNET model.


### PR DESCRIPTION
## Summary

- Add `currentSettings()` helpers to BirdNET and Controller structs (matching existing Processor pattern)
- Fix all runtime settings reads to use fresh atomic snapshots instead of stale startup pointers
- Covers 8 files across classifier, API v2, processor, and analysis packages

### HIGH severity fixes (user-visible settings not taking effect)
- **Predict method**: sensitivity and labels now read from fresh settings on every inference call
- **Species cache key**: lat/lon/model used for cache key now reflect UI changes
- **LocationConfigured**: range filter activation responds to location changes without restart

### MEDIUM severity fixes
- Dynamic threshold API stats return current ValidHours/MinThreshold
- MQTT/BirdWeather/Weather integration endpoints use current broker/coordinates
- Extended capture and daylight filter read labels from fresh settings
- Control monitor reads labels from fresh settings after model reload
- NumSpecies/Labels accessors return current label set

### Deferred
- OAuth2Server (8 stale read sites) requires test infrastructure updates; tracked separately

## Test plan
- [x] `go build ./...` passes
- [x] `golangci-lint run -v` reports zero issues
- [x] Pre-commit hooks pass
- [x] `go test -race ./internal/analysis/...` passes
- [x] `go test -race ./internal/api/v2/...` passes
- [x] `go test -race ./internal/security/...` passes
- [x] Classifier test failure confirmed pre-existing (TFLite checkptr issue on main)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Runtime configuration now applies immediately across the system without restarts.
  * BirdNET labels, detection thresholds, species filters, and location-based behavior use the latest settings snapshot.
  * MQTT, BirdWeather/Weather integrations, dynamic thresholds, and inference logic read current configuration so monitoring and connections reflect up-to-date settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->