### PR TITLE
fix(security): eliminate stale settings reads in OAuth2Server

### DIFF
--- a/internal/api/v2/app_test.go
+++ b/internal/api/v2/app_test.go
@@ -123,7 +123,7 @@ func setupAppConfigTestWithAuth(t *testing.T, securityConfig *conf.Security) (*e
 	mockMetrics, _ := observability.NewMetrics()
 
 	// Create OAuth2Server for auth
-	oauth2Server := security.NewOAuth2ServerForTesting(settings)
+	oauth2Server := security.NewOAuth2ServerForTesting(t, settings)
 	authService := auth.NewSecurityAdapter(oauth2Server)
 	authMw := auth.NewMiddleware(authService)
 

--- a/internal/api/v2/auth_integration_test.go
+++ b/internal/api/v2/auth_integration_test.go
@@ -77,7 +77,7 @@ func setupAuthIntegrationTest(t *testing.T) (*echo.Echo, *Controller, *conf.Sett
 	mockMetrics, _ := observability.NewMetrics()
 
 	// Create OAuth2Server with test settings
-	oauth2Server := createTestOAuth2Server(settings)
+	oauth2Server := createTestOAuth2Server(t, settings)
 
 	// Create auth service and middleware for testing
 	authService := auth.NewSecurityAdapter(oauth2Server)
@@ -101,10 +101,9 @@ func setupAuthIntegrationTest(t *testing.T) (*echo.Echo, *Controller, *conf.Sett
 }
 
 // createTestOAuth2Server creates an OAuth2Server with the provided settings for testing.
-func createTestOAuth2Server(settings *conf.Settings) *security.OAuth2Server {
-	// Create OAuth2Server manually for testing (bypasses conf.GetSettings())
-	// Must call NewOAuth2ServerForTesting to properly initialize internal maps
-	return security.NewOAuth2ServerForTesting(settings)
+func createTestOAuth2Server(tb testing.TB, settings *conf.Settings) *security.OAuth2Server {
+	tb.Helper()
+	return security.NewOAuth2ServerForTesting(tb, settings)
 }
 
 // TestV2AuthFlow_CompleteLogin tests the complete V2 login flow end-to-end.
@@ -233,7 +232,7 @@ func TestV2AuthFlow_EmptyClientID_V1Compatible(t *testing.T) {
 	sunCalc := suncalc.NewSunCalc(60.1699, 24.9384)
 	controlChan := make(chan string, 10)
 	mockMetrics, _ := observability.NewMetrics()
-	oauth2Server := createTestOAuth2Server(settings)
+	oauth2Server := createTestOAuth2Server(t, settings)
 
 	// Create auth service and middleware for testing
 	authService := auth.NewSecurityAdapter(oauth2Server)
@@ -486,7 +485,7 @@ func TestV2AuthService_Interface(t *testing.T) {
 			},
 		}
 
-		oauth2Server := createTestOAuth2Server(settings)
+		oauth2Server := createTestOAuth2Server(t, settings)
 		adapter := auth.NewSecurityAdapter(oauth2Server)
 
 		// Verify adapter implements Service interface

--- a/internal/api/v2/settings_public_dashboard_test.go
+++ b/internal/api/v2/settings_public_dashboard_test.go
@@ -105,7 +105,7 @@ func newSettingsAuthTestEnv(t *testing.T) *echo.Echo {
 	mockMetrics, err := observability.NewMetrics()
 	require.NoError(t, err, "Failed to create test metrics")
 
-	oauth2Server := security.NewOAuth2ServerForTesting(settings)
+	oauth2Server := security.NewOAuth2ServerForTesting(t, settings)
 	authService := auth.NewSecurityAdapter(oauth2Server)
 	authMw := auth.NewMiddleware(authService)
 

--- a/internal/security/fuzz_test.go
+++ b/internal/security/fuzz_test.go
@@ -444,16 +444,18 @@ func FuzzIsRequestFromAllowedSubnet(f *testing.F) {
 	}
 
 	f.Fuzz(func(t *testing.T, ipStr, subnets string, enabled bool) {
-		server := &OAuth2Server{
-			Settings: &conf.Settings{
-				Security: conf.Security{
-					AllowSubnetBypass: conf.AllowSubnetBypass{
-						Enabled: enabled,
-						Subnet:  subnets,
-					},
+		settings := &conf.Settings{
+			Security: conf.Security{
+				AllowSubnetBypass: conf.AllowSubnetBypass{
+					Enabled: enabled,
+					Subnet:  subnets,
 				},
 			},
 		}
+		conf.SetTestSettings(settings)
+		t.Cleanup(func() { conf.SetTestSettings(nil) })
+
+		server := &OAuth2Server{Settings: settings}
 
 		// Should never panic
 		result := server.IsRequestFromAllowedSubnet(ipStr)

--- a/internal/security/oauth.go
+++ b/internal/security/oauth.go
@@ -16,6 +16,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"testing"
 	"time"
 
 	"github.com/gorilla/sessions"
@@ -161,11 +162,12 @@ var testConfigPath string
 
 // NewOAuth2ServerForTesting creates an OAuth2Server with the provided settings
 // for testing. It publishes the settings as the global test snapshot so that
-// currentSettings() returns the expected values even when other tests have set
-// a different global pointer. Callers should defer conf.SetTestSettings(nil)
-// or use t.Cleanup to restore the global after the test.
-func NewOAuth2ServerForTesting(settings *conf.Settings) *OAuth2Server {
+// currentSettings() returns the expected values, and registers cleanup to
+// restore the global after the test finishes.
+func NewOAuth2ServerForTesting(tb testing.TB, settings *conf.Settings) *OAuth2Server {
+	tb.Helper()
 	conf.SetTestSettings(settings)
+	tb.Cleanup(func() { conf.SetTestSettings(nil) })
 	return &OAuth2Server{
 		Settings:          settings,
 		authCodes:         make(map[string]AuthCode),

--- a/internal/security/oauth.go
+++ b/internal/security/oauth.go
@@ -16,7 +16,6 @@ import (
 	"slices"
 	"strings"
 	"sync"
-	"testing"
 	"time"
 
 	"github.com/gorilla/sessions"
@@ -159,22 +158,6 @@ func (s *OAuth2Server) currentSettings() *conf.Settings {
 
 // For testing purposes
 var testConfigPath string
-
-// NewOAuth2ServerForTesting creates an OAuth2Server with the provided settings
-// for testing. It publishes the settings as the global test snapshot so that
-// currentSettings() returns the expected values, and registers cleanup to
-// restore the global after the test finishes.
-func NewOAuth2ServerForTesting(tb testing.TB, settings *conf.Settings) *OAuth2Server {
-	tb.Helper()
-	conf.SetTestSettings(settings)
-	tb.Cleanup(func() { conf.SetTestSettings(nil) })
-	return &OAuth2Server{
-		Settings:          settings,
-		authCodes:         make(map[string]AuthCode),
-		accessTokens:      make(map[string]AccessToken),
-		throttledMessages: make(map[string]time.Time),
-	}
-}
 
 // Pre-defined errors for token validation
 var (

--- a/internal/security/oauth.go
+++ b/internal/security/oauth.go
@@ -150,12 +150,22 @@ type OAuth2Server struct {
 	throttledMessages map[string]time.Time
 }
 
+// currentSettings returns the latest settings snapshot so security
+// configuration changes take effect without recreating the OAuth2Server.
+func (s *OAuth2Server) currentSettings() *conf.Settings {
+	return conf.CurrentOrFallback(s.Settings)
+}
+
 // For testing purposes
 var testConfigPath string
 
-// NewOAuth2ServerForTesting creates an OAuth2Server with the provided settings for testing.
-// This bypasses conf.GetSettings() and allows custom settings to be injected.
+// NewOAuth2ServerForTesting creates an OAuth2Server with the provided settings
+// for testing. It publishes the settings as the global test snapshot so that
+// currentSettings() returns the expected values even when other tests have set
+// a different global pointer. Callers should defer conf.SetTestSettings(nil)
+// or use t.Cleanup to restore the global after the test.
 func NewOAuth2ServerForTesting(settings *conf.Settings) *OAuth2Server {
+	conf.SetTestSettings(settings)
 	return &OAuth2Server{
 		Settings:          settings,
 		authCodes:         make(map[string]AuthCode),
@@ -565,16 +575,17 @@ func SetTestConfigPath(path string) {
 func (s *OAuth2Server) UpdateProviders() {
 	GetLogger().Info("Updating Goth providers based on potentially changed settings")
 	cancelOIDCRetry()
-	InitializeGoth(s.Settings)
+	InitializeGoth(s.currentSettings())
 }
 
 // IsUserAuthenticated checks if the user is authenticated
 func (s *OAuth2Server) IsUserAuthenticated(c echo.Context) bool {
+	settings := s.currentSettings()
 	clientIP := parseIPWithZone(c.RealIP())
 	secLog := GetLogger().With(logger.String("client_ip", c.RealIP()))
 	secLog.Debug("Checking user authentication status")
 
-	if s.Settings.Security.AllowSubnetBypass.Enabled && IsInLocalSubnet(clientIP) {
+	if settings.Security.AllowSubnetBypass.Enabled && IsInLocalSubnet(clientIP) {
 		secLog.Info("User authenticated: request from local subnet (subnet bypass enabled)")
 		return true
 	}
@@ -641,7 +652,7 @@ func (s *OAuth2Server) checkSocialAuthDirect(r *http.Request, userId string, log
 
 	// Look up the config provider for this goth provider name
 	configProvider := gothToConfigProvider(activeProvider)
-	provider := s.Settings.GetOAuthProvider(configProvider)
+	provider := s.currentSettings().GetOAuthProvider(configProvider)
 	if provider == nil || !provider.Enabled {
 		log.Debug("Active auth provider not enabled or not found in config", logger.String("provider", activeProvider))
 		return false
@@ -657,8 +668,9 @@ func (s *OAuth2Server) checkSocialAuthDirect(r *http.Request, userId string, log
 // checkSocialAuthFallback iterates over all configured providers to find a valid session.
 // This handles sessions created before the auth_provider key was introduced.
 func (s *OAuth2Server) checkSocialAuthFallback(r *http.Request, userId string, log SecurityLogger) bool {
+	settings := s.currentSettings()
 	for configProvider, gothProvider := range ConfigToGothProvider {
-		provider := s.Settings.GetOAuthProvider(configProvider)
+		provider := settings.GetOAuthProvider(configProvider)
 		if provider == nil || !provider.Enabled {
 			continue
 		}
@@ -746,7 +758,7 @@ func (s *OAuth2Server) GenerateAuthCode() (string, error) {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
-	expiresAt := time.Now().Add(s.Settings.Security.BasicAuth.AuthCodeExp)
+	expiresAt := time.Now().Add(s.currentSettings().Security.BasicAuth.AuthCodeExp)
 	s.authCodes[authCode] = AuthCode{
 		Code:      authCode,
 		ExpiresAt: expiresAt,
@@ -800,7 +812,7 @@ func (s *OAuth2Server) ExchangeAuthCode(ctx context.Context, code string) (strin
 		return "", err
 	}
 	accessToken := base64.URLEncoding.EncodeToString(tokenBytes)
-	expiresAt := time.Now().Add(s.Settings.Security.BasicAuth.AccessTokenExp)
+	expiresAt := time.Now().Add(s.currentSettings().Security.BasicAuth.AccessTokenExp)
 
 	s.accessTokens[accessToken] = AccessToken{
 		Token:     accessToken,
@@ -843,6 +855,7 @@ func (s *OAuth2Server) ValidateAccessToken(token string) error {
 
 // IsAuthenticationEnabled checks if any authentication method is enabled
 func (s *OAuth2Server) IsAuthenticationEnabled(ip string) bool {
+	settings := s.currentSettings()
 	authLog := GetLogger().With(logger.String("ip", ip))
 	authLog.Debug("Checking if authentication is enabled for IP")
 	if s.IsRequestFromAllowedSubnet(ip) {
@@ -851,10 +864,10 @@ func (s *OAuth2Server) IsAuthenticationEnabled(ip string) bool {
 	}
 
 	// Check if basic auth is enabled
-	basicEnabled := s.Settings.Security.BasicAuth.Enabled
+	basicEnabled := settings.Security.BasicAuth.Enabled
 
 	// Check if any OAuth provider is enabled using the new array
-	enabledOAuthProviders := s.Settings.GetEnabledOAuthProviders()
+	enabledOAuthProviders := settings.GetEnabledOAuthProviders()
 	oauthEnabled := len(enabledOAuthProviders) > 0
 
 	if basicEnabled || oauthEnabled {
@@ -874,7 +887,8 @@ func (s *OAuth2Server) IsRequestFromAllowedSubnet(ipStr string) bool {
 	authLog.Debug("Checking if IP is in allowed subnet")
 
 	// Check if subnet bypass is enabled first
-	if !s.Settings.Security.AllowSubnetBypass.Enabled {
+	settings := s.currentSettings()
+	if !settings.Security.AllowSubnetBypass.Enabled {
 		authLog.Debug("Allowed subnet check: subnet bypass is disabled in settings")
 		return false
 	}
@@ -897,7 +911,7 @@ func (s *OAuth2Server) IsRequestFromAllowedSubnet(ipStr string) bool {
 	}
 
 	// The allowedSubnets string is expected to be a comma-separated list of CIDR ranges.
-	allowedSubnetsStr := s.Settings.Security.AllowSubnetBypass.Subnet
+	allowedSubnetsStr := settings.Security.AllowSubnetBypass.Subnet
 	if allowedSubnetsStr == "" {
 		authLog.Debug("Allowed subnet check: no allowed subnets configured (subnet string is empty)")
 		return false

--- a/internal/security/oauth_test.go
+++ b/internal/security/oauth_test.go
@@ -113,8 +113,9 @@ func TestIsUserAuthenticatedTableDriven(t *testing.T) {
 }
 
 func TestOAuth2Server(t *testing.T) {
-	// Set the settings instance
+	// Ensure global settings are initialized for NewOAuth2Server()
 	conf.Setting()
+	t.Cleanup(func() { conf.SetTestSettings(nil) })
 
 	tests := []struct {
 		name string
@@ -124,7 +125,7 @@ func TestOAuth2Server(t *testing.T) {
 			name: "generate and validate auth code",
 			test: func(t *testing.T, s *OAuth2Server) {
 				t.Helper()
-				// Initialize settings
+				// Override settings and publish as global so currentSettings() returns them
 				s.Settings = &conf.Settings{
 					Security: conf.Security{
 						BasicAuth: conf.BasicAuth{
@@ -136,6 +137,7 @@ func TestOAuth2Server(t *testing.T) {
 						},
 					},
 				}
+				conf.SetTestSettings(s.Settings)
 
 				// Generate and immediately use the auth code
 				code, err := s.GenerateAuthCode()
@@ -159,6 +161,7 @@ func TestOAuth2Server(t *testing.T) {
 					Enabled: true,
 					Subnet:  "192.168.1.0/24",
 				}
+				conf.SetTestSettings(s.Settings)
 
 				assert.True(t, s.IsRequestFromAllowedSubnet("192.168.1.100"), "expected IP to be allowed")
 				assert.False(t, s.IsRequestFromAllowedSubnet("10.0.0.1"), "expected IP to be denied")
@@ -520,14 +523,18 @@ func TestValidateAccessToken(t *testing.T) {
 
 // TestGenerateAuthCode tests the GenerateAuthCode method
 func TestGenerateAuthCode(t *testing.T) {
-	server := &OAuth2Server{
-		Settings: &conf.Settings{
-			Security: conf.Security{
-				BasicAuth: conf.BasicAuth{
-					AuthCodeExp: 10 * time.Minute,
-				},
+	settings := &conf.Settings{
+		Security: conf.Security{
+			BasicAuth: conf.BasicAuth{
+				AuthCodeExp: 10 * time.Minute,
 			},
 		},
+	}
+	conf.SetTestSettings(settings)
+	t.Cleanup(func() { conf.SetTestSettings(nil) })
+
+	server := &OAuth2Server{
+		Settings:     settings,
 		authCodes:    make(map[string]AuthCode),
 		accessTokens: make(map[string]AccessToken),
 	}
@@ -1235,13 +1242,15 @@ func TestCheckSocialAuthDirect(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			gothic.Store = sessions.NewCookieStore([]byte("test-secret-32-bytes-minimum-len"))
 
-			server := &OAuth2Server{
-				Settings: &conf.Settings{
-					Security: conf.Security{
-						OAuthProviders: tt.providers,
-					},
+			settings := &conf.Settings{
+				Security: conf.Security{
+					OAuthProviders: tt.providers,
 				},
 			}
+			conf.SetTestSettings(settings)
+			t.Cleanup(func() { conf.SetTestSettings(nil) })
+
+			server := &OAuth2Server{Settings: settings}
 
 			req := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
 			req = tt.setupSession(t, req)
@@ -1288,13 +1297,15 @@ func TestCheckSocialAuthFallback(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			gothic.Store = sessions.NewCookieStore([]byte("test-secret-32-bytes-minimum-len"))
 
-			server := &OAuth2Server{
-				Settings: &conf.Settings{
-					Security: conf.Security{
-						OAuthProviders: tt.providers,
-					},
+			settings := &conf.Settings{
+				Security: conf.Security{
+					OAuthProviders: tt.providers,
 				},
 			}
+			conf.SetTestSettings(settings)
+			t.Cleanup(func() { conf.SetTestSettings(nil) })
+
+			server := &OAuth2Server{Settings: settings}
 
 			req := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
 			req = tt.setupSession(t, req)
@@ -1311,15 +1322,17 @@ func TestCheckSocialAuthFallback(t *testing.T) {
 func TestCheckSocialAuthSessionsWithAuthProviderKey(t *testing.T) {
 	gothic.Store = sessions.NewCookieStore([]byte("test-secret-32-bytes-minimum-len"))
 
-	server := &OAuth2Server{
-		Settings: &conf.Settings{
-			Security: conf.Security{
-				OAuthProviders: []conf.OAuthProviderConfig{
-					{Provider: ConfigGoogle, Enabled: true, UserID: "user@example.com"},
-				},
+	settings := &conf.Settings{
+		Security: conf.Security{
+			OAuthProviders: []conf.OAuthProviderConfig{
+				{Provider: ConfigGoogle, Enabled: true, UserID: "user@example.com"},
 			},
 		},
 	}
+	conf.SetTestSettings(settings)
+	t.Cleanup(func() { conf.SetTestSettings(nil) })
+
+	server := &OAuth2Server{Settings: settings}
 
 	req := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
 	req = storeMultipleInSession(t, req,

--- a/internal/security/oauth_test.go
+++ b/internal/security/oauth_test.go
@@ -192,7 +192,7 @@ func TestNewOAuth2ServerForTesting(t *testing.T) {
 		},
 	}
 
-	server := NewOAuth2ServerForTesting(settings)
+	server := NewOAuth2ServerForTesting(t, settings)
 
 	require.NotNil(t, server)
 	assert.Equal(t, settings, server.Settings)
@@ -211,7 +211,7 @@ func TestIsUserAuthenticatedExpiredToken(t *testing.T) {
 		},
 	}
 
-	server := NewOAuth2ServerForTesting(settings)
+	server := NewOAuth2ServerForTesting(t, settings)
 	gothic.Store = sessions.NewCookieStore([]byte(settings.Security.SessionSecret))
 
 	e := echo.New()
@@ -243,7 +243,7 @@ func TestIsUserAuthenticatedNoToken(t *testing.T) {
 		},
 	}
 
-	server := NewOAuth2ServerForTesting(settings)
+	server := NewOAuth2ServerForTesting(t, settings)
 	gothic.Store = sessions.NewCookieStore([]byte(settings.Security.SessionSecret))
 
 	e := echo.New()
@@ -318,7 +318,7 @@ func TestIsUserAuthenticatedSubnetBypassDisabled(t *testing.T) {
 		},
 	}
 
-	server := NewOAuth2ServerForTesting(settings)
+	server := NewOAuth2ServerForTesting(t, settings)
 	gothic.Store = sessions.NewCookieStore([]byte(settings.Security.SessionSecret))
 
 	e := echo.New()
@@ -353,7 +353,7 @@ func TestIsUserAuthenticatedSubnetBypassEnabled(t *testing.T) {
 		},
 	}
 
-	server := NewOAuth2ServerForTesting(settings)
+	server := NewOAuth2ServerForTesting(t, settings)
 	gothic.Store = sessions.NewCookieStore([]byte(settings.Security.SessionSecret))
 
 	e := echo.New()
@@ -380,7 +380,7 @@ func TestIsUserAuthenticatedTokenAuthWorksWhenSubnetBypassDisabled(t *testing.T)
 		},
 	}
 
-	server := NewOAuth2ServerForTesting(settings)
+	server := NewOAuth2ServerForTesting(t, settings)
 	gothic.Store = sessions.NewCookieStore([]byte(settings.Security.SessionSecret))
 
 	e := echo.New()
@@ -725,7 +725,7 @@ func TestIsAuthenticationEnabled(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			server := NewOAuth2ServerForTesting(tt.settings)
+			server := NewOAuth2ServerForTesting(t, tt.settings)
 			result := server.IsAuthenticationEnabled(tt.ip)
 			assert.Equal(t, tt.expected, result)
 		})
@@ -848,7 +848,7 @@ func TestIsRequestFromAllowedSubnet(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			server := NewOAuth2ServerForTesting(tt.settings)
+			server := NewOAuth2ServerForTesting(t, tt.settings)
 			result := server.IsRequestFromAllowedSubnet(tt.ip)
 			assert.Equal(t, tt.expected, result)
 		})

--- a/internal/security/oauth_testing.go
+++ b/internal/security/oauth_testing.go
@@ -1,0 +1,24 @@
+package security
+
+import (
+	"testing"
+	"time"
+
+	"github.com/tphakala/birdnet-go/internal/conf"
+)
+
+// NewOAuth2ServerForTesting creates an OAuth2Server with the provided settings
+// for testing. It publishes the settings as the global test snapshot so that
+// currentSettings() returns the expected values, and registers cleanup to
+// restore the global after the test finishes.
+func NewOAuth2ServerForTesting(tb testing.TB, settings *conf.Settings) *OAuth2Server {
+	tb.Helper()
+	conf.SetTestSettings(settings)
+	tb.Cleanup(func() { conf.SetTestSettings(nil) })
+	return &OAuth2Server{
+		Settings:          settings,
+		authCodes:         make(map[string]AuthCode),
+		accessTokens:      make(map[string]AccessToken),
+		throttledMessages: make(map[string]time.Time),
+	}
+}


### PR DESCRIPTION
## Summary

- Add `currentSettings()` helper to OAuth2Server (matching BirdNET, Controller, Processor pattern)
- Fix all 8 stale `s.Settings.*` read sites in `internal/security/oauth.go`
- Update `NewOAuth2ServerForTesting` to publish settings as global test snapshot
- Fix affected tests to use `conf.SetTestSettings` for proper test isolation

### Fixed sites
- `IsUserAuthenticated`: subnet bypass check
- `checkSocialAuthDirect`: OAuth provider lookup
- `checkSocialAuthFallback`: OAuth provider iteration
- `generateAuthCode`: auth code expiry
- `exchangeAuthCode`: access token expiry
- `IsAuthenticationEnabled`: basic auth + OAuth provider checks
- `IsRequestFromAllowedSubnet`: subnet bypass enabled + subnet list
- `UpdateProviders`: Goth provider initialization

### Follow-up from
PR #2899 (Forgejo #519) deferred OAuth2Server to Forgejo #520 due to test infrastructure requirements.

## Test plan
- [x] `go build ./...` passes
- [x] `golangci-lint run` reports zero issues
- [x] `go test -race ./internal/security/...` all 50+ tests pass
- [x] `go test -race ./internal/api/v2/...` passes (NewOAuth2ServerForTesting callers)
- [x] Pre-commit hooks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Authentication now reads the latest runtime configuration so changes to auth settings take effect immediately across login, token, and provider flows.

* **Tests**
  * Test harness and helpers updated for safer configuration injection and cleanup, improving isolation across unit, integration, and fuzz tests to ensure consistent behavior during runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->