### PR TITLE
fix(ui): add crypto.randomUUID fallback for non-HTTPS contexts

### DIFF
--- a/frontend/src/lib/desktop/components/forms/SoundCardCard.svelte
+++ b/frontend/src/lib/desktop/components/forms/SoundCardCard.svelte
@@ -142,7 +142,7 @@
             enabled: editEqualizer.enabled,
             filters: editEqualizer.filters.map(f => ({
               ...f,
-              id: f.id || crypto.randomUUID(),
+              id: f.id || (crypto?.randomUUID?.() ?? Math.random().toString(36).substr(2, 9)),
             })),
           }
         : undefined;

--- a/frontend/src/lib/desktop/components/forms/SoundCardManager.svelte
+++ b/frontend/src/lib/desktop/components/forms/SoundCardManager.svelte
@@ -207,7 +207,7 @@
             enabled: newEqualizer.enabled,
             filters: newEqualizer.filters.map(f => ({
               ...f,
-              id: f.id || crypto.randomUUID(),
+              id: f.id || (crypto?.randomUUID?.() ?? Math.random().toString(36).substr(2, 9)),
             })),
           }
         : undefined;
@@ -271,7 +271,7 @@
       enabled: updated.enabled,
       filters: updated.filters.map(filter => ({
         ...filter,
-        id: filter.id || crypto.randomUUID(),
+        id: filter.id || (crypto?.randomUUID?.() ?? Math.random().toString(36).substr(2, 9)),
       })),
     };
   }

--- a/frontend/src/lib/desktop/components/forms/StreamCard.svelte
+++ b/frontend/src/lib/desktop/components/forms/StreamCard.svelte
@@ -314,7 +314,7 @@
               enabled: editEqualizer.enabled,
               filters: editEqualizer.filters.map(f => ({
                 ...f,
-                id: f.id || crypto.randomUUID(),
+                id: f.id || (crypto?.randomUUID?.() ?? Math.random().toString(36).substr(2, 9)),
               })),
             }
           : undefined;


### PR DESCRIPTION
## Summary

- Add fallback for `crypto.randomUUID()` in equalizer filter ID generation for users accessing BirdNET-Go over plain HTTP
- Replaces 4 bare `crypto.randomUUID()` calls in `StreamCard`, `SoundCardCard`, and `SoundCardManager` with the established pattern: `crypto?.randomUUID?.() ?? Math.random().toString(36).substr(2, 9)`
- PR #2616 introduced these calls without the fallback established in PR #2024, causing `TypeError: crypto.randomUUID is not a function` on non-HTTPS setups

## Test Plan

- [x] Frontend type check passes (0 errors)
- [x] Frontend linter passes (0 warnings)
- [x] All 1918 frontend tests pass
- [x] Verified no remaining bare `crypto.randomUUID()` calls in the affected files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved equalizer filter reliability and audio feature stability across sound card and streaming components through enhanced ID generation fallback mechanisms, ensuring consistent and uninterrupted functionality in diverse runtime environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->