### PR TITLE
fix(ui): distinguish network errors from HTTP errors in restart store

### DIFF
--- a/frontend/src/lib/stores/restart.svelte.ts
+++ b/frontend/src/lib/stores/restart.svelte.ts
@@ -114,14 +114,15 @@ async function requestRestart(endpoint: string, logMessage: string): Promise<boo
     startRecoveryPolling();
     return true;
   } catch (error) {
-    // Network errors (server shut down before responding) mean restart may have succeeded.
-    // HTTP errors (403, 500) mean the request was rejected.
-    if (error instanceof ApiError) {
+    if (error instanceof ApiError && !error.isNetworkError) {
+      // HTTP error (403, 500): request was rejected, abort restart
       restartInProgress.value = false;
+      logger.error(logMessage, error);
     } else {
+      // Network error: server shut down before responding, restart likely succeeded
       startRecoveryPolling();
+      logger.info('Server connection lost after restart request, starting recovery polling');
     }
-    logger.error(logMessage, error);
     return false;
   }
 }

--- a/frontend/src/lib/stores/restart.svelte.ts
+++ b/frontend/src/lib/stores/restart.svelte.ts
@@ -114,14 +114,20 @@ async function requestRestart(endpoint: string, logMessage: string): Promise<boo
     startRecoveryPolling();
     return true;
   } catch (error) {
-    if (error instanceof ApiError && !error.isNetworkError) {
-      // HTTP error (403, 500): request was rejected, abort restart
+    if (error instanceof ApiError) {
+      if (!error.isNetworkError) {
+        // HTTP error (403, 500): request was rejected, abort restart
+        restartInProgress.value = false;
+        logger.error(logMessage, error);
+      } else {
+        // Network error: server shut down before responding, restart likely succeeded
+        startRecoveryPolling();
+        logger.info('Server connection lost after restart request, starting recovery polling');
+      }
+    } else {
+      // Unexpected client/runtime error: abort restart
       restartInProgress.value = false;
       logger.error(logMessage, error);
-    } else {
-      // Network error: server shut down before responding, restart likely succeeded
-      startRecoveryPolling();
-      logger.info('Server connection lost after restart request, starting recovery polling');
     }
     return false;
   }


### PR DESCRIPTION
## Summary

- Fix restart store treating all `ApiError` instances as HTTP rejections, which made recovery polling unreachable
- Network errors (`isNetworkError: true`) during restart now correctly start recovery polling instead of resetting the UI
- Log network errors at `info` level (expected behavior) and HTTP errors at `error` level

The `else` branch calling `startRecoveryPolling()` was dead code because `api.post()` always throws `ApiError` for both network and HTTP errors. Adding `&& !error.isNetworkError` to the condition makes the branch reachable.

47 Sentry events (BIRDNET-GO-1RA) showed users getting "unexpected error" instead of restart progress.

## Test Plan

- [x] TypeScript type check passes
- [x] ESLint passes
- [x] All 1918 frontend tests pass
- [x] Pre-commit hooks pass (prettier, eslint, svelte-check)
- [x] Local CodeRabbit review clean
- [x] Gemini peer review clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved restart failure handling: the app now distinguishes network interruptions from HTTP errors during restarts. When the server connection is lost the client will begin automatic recovery polling; when an HTTP rejection occurs the restart flow stops cleanly. Logging has been adjusted so informational messages are used for recoverable network cases and errors for non-recoverable failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->