### PR TITLE
fix(datastore): populate ModelName in v2only threshold queries (#2902)

### DIFF
--- a/internal/datastore/v2/repository/dynamic_threshold_impl.go
+++ b/internal/datastore/v2/repository/dynamic_threshold_impl.go
@@ -94,6 +94,7 @@ func (r *dynamicThresholdRepository) GetDynamicThreshold(ctx context.Context, sp
 
 	var threshold entities.DynamicThreshold
 	err = r.db.WithContext(ctx).Table(r.thresholdTable()).
+		Preload("Label.Model").
 		Preload("Label").
 		Where("label_id IN ?", labelIDs).
 		First(&threshold).Error
@@ -111,6 +112,7 @@ func (r *dynamicThresholdRepository) GetDynamicThreshold(ctx context.Context, sp
 func (r *dynamicThresholdRepository) GetAllDynamicThresholds(ctx context.Context, limit ...int) ([]entities.DynamicThreshold, error) {
 	var thresholds []entities.DynamicThreshold
 	query := r.db.WithContext(ctx).Table(r.thresholdTable()).
+		Preload("Label.Model").
 		Preload("Label").
 		Order("label_id ASC")
 	if len(limit) > 0 && limit[0] > 0 {

--- a/internal/datastore/v2only/datastore.go
+++ b/internal/datastore/v2only/datastore.go
@@ -2572,6 +2572,14 @@ func thresholdScientificName(t *entities.DynamicThreshold) string {
 	return ""
 }
 
+// thresholdModelName constructs the classifier-style model ID from a threshold's label.
+func thresholdModelName(t *entities.DynamicThreshold) string {
+	if t.Label != nil && t.Label.Model != nil && t.Label.Model.Name != "" {
+		return t.Label.Model.Name + "_V" + t.Label.Model.Version
+	}
+	return detection.DefaultModelName + "_V" + detection.DefaultModelVersion
+}
+
 // resolveCommonName maps a scientific name to its common name using the
 // pre-built name maps. Falls back to the scientific name if no mapping exists.
 // Handles legacy concatenated "ScientificName_CommonName" format by extracting
@@ -2653,8 +2661,9 @@ func (ds *Datastore) GetDynamicThreshold(speciesName, _ string) (*datastore.Dyna
 	scientificName := thresholdScientificName(t)
 	return &datastore.DynamicThreshold{
 		ID:             t.ID,
-		SpeciesName:    ds.resolveCommonName(scientificName),
+		SpeciesName:    strings.ToLower(ds.resolveCommonName(scientificName)),
 		ScientificName: scientificName,
+		ModelName:      thresholdModelName(t),
 		Level:          t.Level,
 		CurrentValue:   t.CurrentValue,
 		BaseThreshold:  t.BaseThreshold,
@@ -2684,8 +2693,9 @@ func (ds *Datastore) GetAllDynamicThresholds(limit ...int) ([]datastore.DynamicT
 		scientificName := thresholdScientificName(t)
 		result = append(result, datastore.DynamicThreshold{
 			ID:             t.ID,
-			SpeciesName:    ds.resolveCommonName(scientificName),
+			SpeciesName:    strings.ToLower(ds.resolveCommonName(scientificName)),
 			ScientificName: scientificName,
+			ModelName:      thresholdModelName(t),
 			Level:          t.Level,
 			CurrentValue:   t.CurrentValue,
 			BaseThreshold:  t.BaseThreshold,

--- a/internal/datastore/v2only/datastore_test.go
+++ b/internal/datastore/v2only/datastore_test.go
@@ -223,7 +223,7 @@ func TestV2OnlyDatastore_DynamicThreshold(t *testing.T) {
 	// Get threshold by scientific name
 	retrieved, err := ds.GetDynamicThreshold("Passer domesticus", "")
 	require.NoError(t, err)
-	assert.Equal(t, "Passer domesticus", retrieved.SpeciesName)
+	assert.Equal(t, "passer domesticus", retrieved.SpeciesName)
 	assert.Equal(t, "Passer domesticus", retrieved.ScientificName)
 	assert.Equal(t, 1, retrieved.Level)
 	assert.InDelta(t, 0.7, retrieved.CurrentValue, 0.001)
@@ -275,15 +275,62 @@ func TestV2OnlyDatastore_DynamicThreshold_CommonNameDisplay(t *testing.T) {
 	// GetDynamicThreshold should return common name in SpeciesName
 	retrieved, err := ds.GetDynamicThreshold("Parus major", "")
 	require.NoError(t, err)
-	assert.Equal(t, "Great Tit", retrieved.SpeciesName, "SpeciesName should be common name")
+	assert.Equal(t, "great tit", retrieved.SpeciesName, "SpeciesName should be common name")
 	assert.Equal(t, "Parus major", retrieved.ScientificName, "ScientificName should stay scientific")
 
 	// GetAllDynamicThresholds should also return common name
 	all, err := ds.GetAllDynamicThresholds()
 	require.NoError(t, err)
 	require.Len(t, all, 1)
-	assert.Equal(t, "Great Tit", all[0].SpeciesName, "SpeciesName should be common name in list")
+	assert.Equal(t, "great tit", all[0].SpeciesName, "SpeciesName should be common name in list")
 	assert.Equal(t, "Parus major", all[0].ScientificName, "ScientificName should stay scientific in list")
+}
+
+// TestV2OnlyDatastore_DynamicThreshold_ModelName verifies that
+// GetAllDynamicThresholds and GetDynamicThreshold return ModelName
+// constructed from the Label's AIModel (e.g., "BirdNET_V2.4").
+// Regression test for GitHub issue #2902.
+func TestV2OnlyDatastore_DynamicThreshold_ModelName(t *testing.T) {
+	labels := []string{
+		"Parus major_Great Tit",
+	}
+	ds, cleanup := setupTestDatastoreWithLabels(t, labels)
+	defer cleanup()
+
+	threshold := &datastore.DynamicThreshold{
+		SpeciesName:    "Parus major",
+		ScientificName: "Parus major",
+		ModelName:      "BirdNET_V2.4",
+		Level:          2,
+		CurrentValue:   0.5,
+		BaseThreshold:  0.8,
+		HighConfCount:  3,
+		ValidHours:     12,
+		ExpiresAt:      time.Now().Add(12 * time.Hour),
+		LastTriggered:  time.Now(),
+		FirstCreated:   time.Now(),
+		UpdatedAt:      time.Now(),
+		TriggerCount:   5,
+	}
+	err := ds.SaveDynamicThreshold(threshold)
+	require.NoError(t, err)
+
+	// GetAllDynamicThresholds must return non-empty ModelName
+	all, err := ds.GetAllDynamicThresholds()
+	require.NoError(t, err)
+	require.Len(t, all, 1)
+	assert.Equal(t, "BirdNET_V2.4", all[0].ModelName,
+		"ModelName must be constructed from Label's Model (Name_VVersion)")
+	assert.Equal(t, "great tit", all[0].SpeciesName,
+		"SpeciesName must be lowercase to match processor convention")
+
+	// GetDynamicThreshold (single lookup) must also return ModelName
+	single, err := ds.GetDynamicThreshold("Parus major", "")
+	require.NoError(t, err)
+	assert.Equal(t, "BirdNET_V2.4", single.ModelName,
+		"Single lookup must also return ModelName")
+	assert.Equal(t, "great tit", single.SpeciesName,
+		"Single lookup SpeciesName must be lowercase")
 }
 
 // TestV2OnlyDatastore_DynamicThreshold_DeleteByCommonName verifies that
@@ -356,7 +403,7 @@ func TestV2OnlyDatastore_DynamicThreshold_GetByCommonName(t *testing.T) {
 	// Retrieve using lowercase common name
 	retrieved, err := ds.GetDynamicThreshold("great tit", "")
 	require.NoError(t, err)
-	assert.Equal(t, "Great Tit", retrieved.SpeciesName)
+	assert.Equal(t, "great tit", retrieved.SpeciesName)
 	assert.Equal(t, "Parus major", retrieved.ScientificName)
 }
 
@@ -386,7 +433,7 @@ func TestV2OnlyDatastore_DynamicThreshold_FallbackWithoutMapping(t *testing.T) {
 	// Without label mapping, should fall back to scientific name
 	retrieved, err := ds.GetDynamicThreshold("Passer domesticus", "")
 	require.NoError(t, err)
-	assert.Equal(t, "Passer domesticus", retrieved.SpeciesName, "should fallback to scientific name")
+	assert.Equal(t, "passer domesticus", retrieved.SpeciesName, "should fallback to scientific name")
 	assert.Equal(t, "Passer domesticus", retrieved.ScientificName)
 }
 


### PR DESCRIPTION
## Summary

- v2only `GetAllDynamicThresholds()` and `GetDynamicThreshold()` returned empty `ModelName` because the v2 schema stores thresholds by `LabelID` with no model name column
- The API merge in `getMergedThresholdData()` uses `ToLower(ModelName) + ":" + ToLower(SpeciesName)` as composite keys; empty ModelName from DB vs `"BirdNET_V2.4"` from processor memory created different keys for the same species, producing exact 2x duplicate entries
- Secondary: `SpeciesName` from `resolveCommonName()` returned Title Case while processor uses lowercase, causing display inconsistency between the two duplicates

### Changes

1. **Repository** (`dynamic_threshold_impl.go`): Add `Preload("Label.Model")` to both threshold queries so the AIModel relationship is available
2. **v2only adapter** (`datastore.go`): Add `thresholdModelName()` helper that constructs `"BirdNET_V2.4"` from `Label.Model.Name + "_V" + Label.Model.Version`; set `ModelName` and lowercase `SpeciesName` in both `GetAllDynamicThresholds` and `GetDynamicThreshold`
3. **Tests** (`datastore_test.go`): Add regression test `TestV2OnlyDatastore_DynamicThreshold_ModelName`; update 5 existing assertions for lowercase SpeciesName

### Evidence

Reproduced on `bng-regression-std` (fresh v2only install, SQLite, live RTSP audio):
- 10 unique species, 20 API entries (exact 2x)
- Each species appeared twice: once with `model=BirdNET_V2.4` (memory), once with `model=""` (v2only DB)

This bug only affects v2only mode (fresh installs and migrated systems). Legacy datastore stores and returns ModelName correctly.

Fixes #2902

## Test Plan

- [x] `go test -race ./internal/datastore/v2only/` - 8 threshold tests pass
- [x] `go test -race ./internal/datastore/...` - 693 tests pass
- [x] `go test -race ./internal/analysis/processor/...` - 630 tests pass
- [x] `golangci-lint run -v` - zero issues
- [x] Build succeeds
- [ ] Deploy to regression VM and verify 0 duplicates after threshold reset

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Normalized species name formatting to lowercase for consistency across threshold lookups.

* **Improvements**
  * Dynamic thresholds now include model version information for better traceability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->