### PR TITLE
feat(api): add audio source listing endpoints

### DIFF
--- a/internal/api/v2/README.md
+++ b/internal/api/v2/README.md
@@ -228,11 +228,12 @@ The `GET /settings/dashboard` endpoint is intentionally public so that unauthent
 | GET    | `/soundlevels/stream` | `StreamSoundLevels` | ❌⚡ | Real-time audio level stream |
 | GET    | `/sse/status`         | `GetSSEStatus`      | ❌   | SSE connection status        |
 
-### Audio Level SSE (`audio_level.go`)
+### Audio Level SSE (`audio_level.go`) and Stream Sources (`audio_sources.go`)
 
-| Method | Route                  | Handler            | Auth | Description               |
-| ------ | ---------------------- | ------------------ | ---- | ------------------------- |
-| GET    | `/streams/audio-level` | `StreamAudioLevel` | ❌   | Real-time audio level SSE |
+| Method | Route                  | Handler              | Auth | Description                              |
+| ------ | ---------------------- | -------------------- | ---- | ---------------------------------------- |
+| GET    | `/streams/audio-level` | `StreamAudioLevel`   | ❌   | Real-time audio level SSE                |
+| GET    | `/streams/sources`     | `ListStreamSources`  | ❌   | Active stream sources (RTSP, HTTP, etc.) |
 
 **Features:**
 
@@ -257,6 +258,23 @@ The `GET /settings/dashboard` endpoint is intentionally public so that unauthent
   }
 }
 ```
+
+**Stream Sources Response (`/streams/sources` and `/system/audio/sources`):**
+
+```json
+{
+  "sources": [
+    {
+      "id": "rtsp_ce4e5692",
+      "name": "RPI",
+      "type": "rtsp",
+      "state": "running"
+    }
+  ]
+}
+```
+
+Returns an empty `sources` array when no sources are configured. The `type` field is one of: `rtsp`, `http`, `hls`, `rtmp`, `udp`, `audio_card`, `file`. The `state` field is one of: `inactive`, `starting`, `running`, `error`, `stopped`. The `/streams/sources` endpoint returns only stream types (excludes `audio_card` and `file`).
 
 ### HLS Streaming (`audio_hls.go`)
 
@@ -387,6 +405,7 @@ HLS playlist and segment routes use token-based authentication instead of standa
 | GET    | `/system/audio/devices`          | `GetAudioDevices`         | ✅   | Available audio devices              |
 | GET    | `/system/audio/active`           | `GetActiveAudioDevice`    | ✅   | Active audio device                  |
 | GET    | `/system/audio/equalizer/config` | `GetEqualizerConfig`      | ✅   | Audio equalizer filter configuration |
+| GET    | `/system/audio/sources`          | `ListAudioSources`        | ✅   | Active audio sources (all types)     |
 | GET    | `/system/network-interfaces`     | `GetNetworkInterfaces`    | ✅   | IPv4 network interfaces for binding  |
 
 ### Events (`events.go`, `events_aggregation.go`)

--- a/internal/api/v2/audio_level.go
+++ b/internal/api/v2/audio_level.go
@@ -185,6 +185,9 @@ func (c *Controller) initAudioLevelRoutes() {
 	// The per-IP connection limit (audioLevelMaxConnectionsPerIP) still applies
 	// Authentication is checked within the handler to control data anonymization
 	c.Group.GET("/streams/audio-level", c.StreamAudioLevel)
+
+	// Stream sources listing - public, returns active stream sources
+	c.Group.GET("/streams/sources", c.ListStreamSources)
 }
 
 // StreamAudioLevel handles SSE connections for real-time audio level streaming

--- a/internal/api/v2/audio_sources.go
+++ b/internal/api/v2/audio_sources.go
@@ -1,0 +1,114 @@
+// audio_sources.go - Handlers for audio source listing endpoints.
+package api
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	"github.com/tphakala/birdnet-go/internal/audiocore"
+	"github.com/tphakala/birdnet-go/internal/logger"
+)
+
+// AudioSourceInfo represents a single audio source in API responses.
+type AudioSourceInfo struct {
+	ID    string `json:"id"`
+	Name  string `json:"name"`
+	Type  string `json:"type"`
+	State string `json:"state"`
+}
+
+// AudioSourceListResponse is the response for the audio sources listing endpoints.
+type AudioSourceListResponse struct {
+	Sources []AudioSourceInfo `json:"sources"`
+}
+
+// ListAudioSources handles GET /api/v2/system/audio/sources.
+// Returns all active audio sources from the engine registry (sound cards + streams).
+func (c *Controller) ListAudioSources(ctx echo.Context) error {
+	c.logInfoIfEnabled("Listing audio sources",
+		logger.String("path", ctx.Request().URL.Path),
+		logger.String("ip", ctx.RealIP()),
+	)
+
+	resp := AudioSourceListResponse{Sources: []AudioSourceInfo{}}
+
+	if c.engine == nil {
+		return ctx.JSON(http.StatusOK, resp)
+	}
+
+	registry := c.engine.Registry()
+	if registry == nil {
+		return ctx.JSON(http.StatusOK, resp)
+	}
+
+	for _, src := range registry.List() {
+		resp.Sources = append(resp.Sources, AudioSourceInfo{
+			ID:    src.ID,
+			Name:  src.DisplayName,
+			Type:  string(src.Type),
+			State: src.State.String(),
+		})
+	}
+
+	c.logInfoIfEnabled("Audio sources listed",
+		logger.Int("count", len(resp.Sources)),
+		logger.String("path", ctx.Request().URL.Path),
+		logger.String("ip", ctx.RealIP()),
+	)
+
+	return ctx.JSON(http.StatusOK, resp)
+}
+
+// isStreamSourceType returns true for source types that represent network streams.
+func isStreamSourceType(t string) bool {
+	switch audiocore.SourceType(t) {
+	case audiocore.SourceTypeRTSP,
+		audiocore.SourceTypeHTTP,
+		audiocore.SourceTypeHLS,
+		audiocore.SourceTypeRTMP,
+		audiocore.SourceTypeUDP:
+		return true
+	default:
+		return false
+	}
+}
+
+// ListStreamSources handles GET /api/v2/streams/sources.
+// Returns only stream-type audio sources (RTSP, HTTP, HLS, RTMP, UDP).
+func (c *Controller) ListStreamSources(ctx echo.Context) error {
+	c.logInfoIfEnabled("Listing stream sources",
+		logger.String("path", ctx.Request().URL.Path),
+		logger.String("ip", ctx.RealIP()),
+	)
+
+	resp := AudioSourceListResponse{Sources: []AudioSourceInfo{}}
+
+	if c.engine == nil {
+		return ctx.JSON(http.StatusOK, resp)
+	}
+
+	registry := c.engine.Registry()
+	if registry == nil {
+		return ctx.JSON(http.StatusOK, resp)
+	}
+
+	for _, src := range registry.List() {
+		if !isStreamSourceType(string(src.Type)) {
+			continue
+		}
+		resp.Sources = append(resp.Sources, AudioSourceInfo{
+			ID:    src.ID,
+			Name:  src.DisplayName,
+			Type:  string(src.Type),
+			State: src.State.String(),
+		})
+	}
+
+	c.logInfoIfEnabled("Stream sources listed",
+		logger.Int("count", len(resp.Sources)),
+		logger.String("path", ctx.Request().URL.Path),
+		logger.String("ip", ctx.RealIP()),
+	)
+
+	return ctx.JSON(http.StatusOK, resp)
+}

--- a/internal/api/v2/audio_sources.go
+++ b/internal/api/v2/audio_sources.go
@@ -47,8 +47,10 @@ func isStreamSourceType(t audiocore.SourceType) bool {
 }
 
 // listSources is the shared implementation for source listing endpoints.
-// When filter is nil, all sources are included.
-func (c *Controller) listSources(ctx echo.Context, label string, filter func(audiocore.SourceType) bool) error {
+// When filter is nil, all sources are included. When anonymize is true,
+// source names are replaced with anonymized values for unauthenticated
+// clients, matching the behavior of the audio-level SSE stream.
+func (c *Controller) listSources(ctx echo.Context, label string, filter func(audiocore.SourceType) bool, anonymize bool) error {
 	c.logInfoIfEnabled("Listing "+label,
 		logger.String("path", ctx.Request().URL.Path),
 		logger.String("ip", ctx.RealIP()),
@@ -66,12 +68,17 @@ func (c *Controller) listSources(ctx echo.Context, label string, filter func(aud
 	}
 
 	sources := registry.List()
+	isAuthenticated := !anonymize || c.isClientAuthenticated(ctx)
 	resp.Sources = make([]AudioSourceInfo, 0, len(sources))
 	for _, src := range sources {
 		if filter != nil && !filter(src.Type) {
 			continue
 		}
-		resp.Sources = append(resp.Sources, toAudioSourceInfo(src))
+		info := toAudioSourceInfo(src)
+		if !isAuthenticated {
+			info.Name = c.getAnonymizedSourceName(src)
+		}
+		resp.Sources = append(resp.Sources, info)
 	}
 
 	c.logInfoIfEnabled(label+" listed",
@@ -86,11 +93,12 @@ func (c *Controller) listSources(ctx echo.Context, label string, filter func(aud
 // ListAudioSources handles GET /api/v2/system/audio/sources.
 // Returns all active audio sources from the engine registry (sound cards + streams).
 func (c *Controller) ListAudioSources(ctx echo.Context) error {
-	return c.listSources(ctx, "audio sources", nil)
+	return c.listSources(ctx, "audio sources", nil, false)
 }
 
 // ListStreamSources handles GET /api/v2/streams/sources.
 // Returns only stream-type audio sources (RTSP, HTTP, HLS, RTMP, UDP).
+// Source names are anonymized for unauthenticated clients.
 func (c *Controller) ListStreamSources(ctx echo.Context) error {
-	return c.listSources(ctx, "stream sources", isStreamSourceType)
+	return c.listSources(ctx, "stream sources", isStreamSourceType, true)
 }

--- a/internal/api/v2/audio_sources.go
+++ b/internal/api/v2/audio_sources.go
@@ -22,46 +22,19 @@ type AudioSourceListResponse struct {
 	Sources []AudioSourceInfo `json:"sources"`
 }
 
-// ListAudioSources handles GET /api/v2/system/audio/sources.
-// Returns all active audio sources from the engine registry (sound cards + streams).
-func (c *Controller) ListAudioSources(ctx echo.Context) error {
-	c.logInfoIfEnabled("Listing audio sources",
-		logger.String("path", ctx.Request().URL.Path),
-		logger.String("ip", ctx.RealIP()),
-	)
-
-	resp := AudioSourceListResponse{Sources: []AudioSourceInfo{}}
-
-	if c.engine == nil {
-		return ctx.JSON(http.StatusOK, resp)
+// toAudioSourceInfo converts an audiocore.AudioSource to the API response type.
+func toAudioSourceInfo(src *audiocore.AudioSource) AudioSourceInfo {
+	return AudioSourceInfo{
+		ID:    src.ID,
+		Name:  src.DisplayName,
+		Type:  string(src.Type),
+		State: src.State.String(),
 	}
-
-	registry := c.engine.Registry()
-	if registry == nil {
-		return ctx.JSON(http.StatusOK, resp)
-	}
-
-	for _, src := range registry.List() {
-		resp.Sources = append(resp.Sources, AudioSourceInfo{
-			ID:    src.ID,
-			Name:  src.DisplayName,
-			Type:  string(src.Type),
-			State: src.State.String(),
-		})
-	}
-
-	c.logInfoIfEnabled("Audio sources listed",
-		logger.Int("count", len(resp.Sources)),
-		logger.String("path", ctx.Request().URL.Path),
-		logger.String("ip", ctx.RealIP()),
-	)
-
-	return ctx.JSON(http.StatusOK, resp)
 }
 
 // isStreamSourceType returns true for source types that represent network streams.
-func isStreamSourceType(t string) bool {
-	switch audiocore.SourceType(t) {
+func isStreamSourceType(t audiocore.SourceType) bool {
+	switch t {
 	case audiocore.SourceTypeRTSP,
 		audiocore.SourceTypeHTTP,
 		audiocore.SourceTypeHLS,
@@ -73,10 +46,10 @@ func isStreamSourceType(t string) bool {
 	}
 }
 
-// ListStreamSources handles GET /api/v2/streams/sources.
-// Returns only stream-type audio sources (RTSP, HTTP, HLS, RTMP, UDP).
-func (c *Controller) ListStreamSources(ctx echo.Context) error {
-	c.logInfoIfEnabled("Listing stream sources",
+// listSources is the shared implementation for source listing endpoints.
+// When filter is nil, all sources are included.
+func (c *Controller) listSources(ctx echo.Context, label string, filter func(audiocore.SourceType) bool) error {
+	c.logInfoIfEnabled("Listing "+label,
 		logger.String("path", ctx.Request().URL.Path),
 		logger.String("ip", ctx.RealIP()),
 	)
@@ -92,23 +65,32 @@ func (c *Controller) ListStreamSources(ctx echo.Context) error {
 		return ctx.JSON(http.StatusOK, resp)
 	}
 
-	for _, src := range registry.List() {
-		if !isStreamSourceType(string(src.Type)) {
+	sources := registry.List()
+	resp.Sources = make([]AudioSourceInfo, 0, len(sources))
+	for _, src := range sources {
+		if filter != nil && !filter(src.Type) {
 			continue
 		}
-		resp.Sources = append(resp.Sources, AudioSourceInfo{
-			ID:    src.ID,
-			Name:  src.DisplayName,
-			Type:  string(src.Type),
-			State: src.State.String(),
-		})
+		resp.Sources = append(resp.Sources, toAudioSourceInfo(src))
 	}
 
-	c.logInfoIfEnabled("Stream sources listed",
+	c.logInfoIfEnabled(label+" listed",
 		logger.Int("count", len(resp.Sources)),
 		logger.String("path", ctx.Request().URL.Path),
 		logger.String("ip", ctx.RealIP()),
 	)
 
 	return ctx.JSON(http.StatusOK, resp)
+}
+
+// ListAudioSources handles GET /api/v2/system/audio/sources.
+// Returns all active audio sources from the engine registry (sound cards + streams).
+func (c *Controller) ListAudioSources(ctx echo.Context) error {
+	return c.listSources(ctx, "audio sources", nil)
+}
+
+// ListStreamSources handles GET /api/v2/streams/sources.
+// Returns only stream-type audio sources (RTSP, HTTP, HLS, RTMP, UDP).
+func (c *Controller) ListStreamSources(ctx echo.Context) error {
+	return c.listSources(ctx, "stream sources", isStreamSourceType)
 }

--- a/internal/api/v2/audio_sources_test.go
+++ b/internal/api/v2/audio_sources_test.go
@@ -1,0 +1,195 @@
+// audio_sources_test.go - Tests for audio source listing endpoints.
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/audiocore"
+	"github.com/tphakala/birdnet-go/internal/audiocore/engine"
+	"github.com/tphakala/birdnet-go/internal/conf"
+)
+
+// setupAudioSourcesTestEnv creates a Controller with an AudioEngine whose
+// registry contains the given sources. Sources are registered directly in the
+// registry to avoid requiring real audio hardware or network streams.
+// The engine is stopped automatically when the test completes.
+func setupAudioSourcesTestEnv(t *testing.T, sources []*audiocore.SourceConfig) (*echo.Echo, *Controller) {
+	t.Helper()
+
+	ctx := t.Context()
+	log := audiocore.GetLogger()
+	eng := engine.New(ctx, &engine.Config{Logger: log}, nil)
+	t.Cleanup(eng.Stop)
+
+	// Register sources directly in the registry instead of using
+	// engine.AddSource, which tries to start real hardware capture
+	// for audio cards and FFmpeg for streams.
+	registry := eng.Registry()
+	for _, cfg := range sources {
+		_, err := registry.Register(cfg)
+		require.NoError(t, err)
+	}
+
+	e := echo.New()
+	controller := &Controller{
+		Echo:     e,
+		Group:    e.Group("/api/v2"),
+		Settings: &conf.Settings{},
+		engine:   eng,
+	}
+	return e, controller
+}
+
+func TestListAudioSources(t *testing.T) {
+	t.Parallel()
+	t.Attr("component", "system")
+	t.Attr("type", "integration")
+	t.Attr("feature", "audio-sources")
+
+	t.Run("No engine returns empty list", func(t *testing.T) {
+		e := echo.New()
+		controller := &Controller{
+			Echo:     e,
+			Group:    e.Group("/api/v2"),
+			Settings: &conf.Settings{},
+		}
+
+		req := httptest.NewRequest(http.MethodGet, "/api/v2/system/audio/sources", http.NoBody)
+		rec := httptest.NewRecorder()
+		ctx := e.NewContext(req, rec)
+		ctx.SetPath("/api/v2/system/audio/sources")
+
+		err := controller.ListAudioSources(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, rec.Code)
+
+		var resp AudioSourceListResponse
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+		assert.Empty(t, resp.Sources)
+	})
+
+	t.Run("Returns RTSP and audio card sources", func(t *testing.T) {
+		sources := []*audiocore.SourceConfig{
+			{
+				DisplayName:      "Backyard Mic",
+				Type:             audiocore.SourceTypeAudioCard,
+				ConnectionString: "hw:0,0",
+				SampleRate:       48000,
+				BitDepth:         16,
+				Channels:         1,
+			},
+			{
+				DisplayName:      "Front Camera",
+				Type:             audiocore.SourceTypeRTSP,
+				ConnectionString: "rtsp://192.168.1.10:554/audio",
+				SampleRate:       48000,
+				BitDepth:         16,
+				Channels:         1,
+			},
+		}
+		e, controller := setupAudioSourcesTestEnv(t, sources)
+
+		req := httptest.NewRequest(http.MethodGet, "/api/v2/system/audio/sources", http.NoBody)
+		rec := httptest.NewRecorder()
+		ctx := e.NewContext(req, rec)
+		ctx.SetPath("/api/v2/system/audio/sources")
+
+		err := controller.ListAudioSources(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, rec.Code)
+
+		var resp AudioSourceListResponse
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+		assert.Len(t, resp.Sources, 2)
+
+		// Sorted by DisplayName
+		assert.Equal(t, "Backyard Mic", resp.Sources[0].Name)
+		assert.Equal(t, "audio_card", resp.Sources[0].Type)
+		assert.Equal(t, "Front Camera", resp.Sources[1].Name)
+		assert.Equal(t, "rtsp", resp.Sources[1].Type)
+	})
+}
+
+func TestListStreamSources(t *testing.T) {
+	t.Parallel()
+	t.Attr("component", "streams")
+	t.Attr("type", "integration")
+	t.Attr("feature", "stream-sources")
+
+	t.Run("No engine returns empty list", func(t *testing.T) {
+		e := echo.New()
+		controller := &Controller{
+			Echo:     e,
+			Group:    e.Group("/api/v2"),
+			Settings: &conf.Settings{},
+		}
+
+		req := httptest.NewRequest(http.MethodGet, "/api/v2/streams/sources", http.NoBody)
+		rec := httptest.NewRecorder()
+		ctx := e.NewContext(req, rec)
+		ctx.SetPath("/api/v2/streams/sources")
+
+		err := controller.ListStreamSources(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, rec.Code)
+
+		var resp AudioSourceListResponse
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+		assert.Empty(t, resp.Sources)
+	})
+
+	t.Run("Filters to stream types only", func(t *testing.T) {
+		sources := []*audiocore.SourceConfig{
+			{
+				DisplayName:      "Backyard Mic",
+				Type:             audiocore.SourceTypeAudioCard,
+				ConnectionString: "hw:0,0",
+				SampleRate:       48000,
+				BitDepth:         16,
+				Channels:         1,
+			},
+			{
+				DisplayName:      "Front Camera",
+				Type:             audiocore.SourceTypeRTSP,
+				ConnectionString: "rtsp://192.168.1.10:554/audio",
+				SampleRate:       48000,
+				BitDepth:         16,
+				Channels:         1,
+			},
+			{
+				DisplayName:      "HTTP Stream",
+				Type:             audiocore.SourceTypeHTTP,
+				ConnectionString: "http://192.168.1.20:8000/stream",
+				SampleRate:       48000,
+				BitDepth:         16,
+				Channels:         1,
+			},
+		}
+		e, controller := setupAudioSourcesTestEnv(t, sources)
+
+		req := httptest.NewRequest(http.MethodGet, "/api/v2/streams/sources", http.NoBody)
+		rec := httptest.NewRecorder()
+		ctx := e.NewContext(req, rec)
+		ctx.SetPath("/api/v2/streams/sources")
+
+		err := controller.ListStreamSources(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, rec.Code)
+
+		var resp AudioSourceListResponse
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+		assert.Len(t, resp.Sources, 2, "Should only include stream sources, not audio cards")
+
+		types := make([]string, len(resp.Sources))
+		for i, s := range resp.Sources {
+			types[i] = s.Type
+		}
+		assert.NotContains(t, types, "audio_card")
+	})
+}

--- a/internal/api/v2/system.go
+++ b/internal/api/v2/system.go
@@ -407,6 +407,7 @@ func (c *Controller) initSystemRoutes() {
 	audioGroup.GET("/devices", c.GetAudioDevices)
 	audioGroup.GET("/active", c.GetActiveAudioDevice)
 	audioGroup.GET("/equalizer/config", c.GetEqualizerConfig)
+	audioGroup.GET("/sources", c.ListAudioSources)
 
 	// Events routes (detection lifecycle + operational logs)
 	c.registerEventsRoutes(protectedGroup)


### PR DESCRIPTION
## Summary

- Add `GET /api/v2/system/audio/sources` (protected) to list all active audio sources from the engine registry (sound cards + streams)
- Add `GET /api/v2/streams/sources` (public) to list stream-type sources only (RTSP, HTTP, HLS, RTMP, UDP)
- Both endpoints return `{"sources": [{"id", "name", "type", "state"}]}` with an empty array when no sources exist

These endpoints provide a REST alternative for source enumeration. Previously the only way to discover sources was via the SSE stream at `/api/v2/streams/audio-level`. The route collision where `GET /api/v2/audio/sources` returns 400 (caught by the `/api/v2/audio/:id` clip handler) remains unchanged; the new endpoints use the correct API namespaces (`/system/audio/` and `/streams/`).

## Related Issues

Fixes #2911

## Test Plan

- [x] Unit tests: 6 tests covering nil engine, populated registry, and stream-type filtering
- [x] Linter: zero issues
- [x] QA: verified with RTSP-only container (no sound card), both endpoints return correct data
- [x] Live Audio page: source dropdown populates correctly via SSE (existing behavior preserved)
- [x] Old routes: `/api/v2/audio/sources` still returns 400, `/api/v2/audio/1` still returns 404

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public endpoint to list available stream sources with type and state info.
  * Authenticated endpoint to retrieve registered audio sources (type, state, and anonymized names for unauthenticated clients).

* **Documentation**
  * Expanded API docs describing stream-source and audio-source listing endpoints, response contracts, filtering behavior, and empty-state behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->