### PR TITLE
fix(i18n): derive SUPPORTED_LOCALES dynamically to fix Hungarian revert

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -63,23 +63,11 @@
         }
       })();
 
-      // Detect and set initial locale before content loads
+      // Detect and set initial locale before content loads.
+      // SUPPORTED_LOCALES is injected at build time by the inject-supported-locales
+      // Vite plugin from static/messages/*.json. Do NOT hardcode locale codes here.
       (function () {
-        const SUPPORTED_LOCALES = [
-          'da',
-          'en',
-          'de',
-          'es',
-          'fi',
-          'fr',
-          'it',
-          'lv',
-          'nl',
-          'pl',
-          'pt',
-          'sk',
-          'sv',
-        ];
+        const SUPPORTED_LOCALES = [__SUPPORTED_LOCALES_PLACEHOLDER__];
         const DEFAULT_LOCALE = 'en';
 
         function detectBrowserLocale() {

--- a/frontend/tests/e2e/settings/locale-persistence.spec.ts
+++ b/frontend/tests/e2e/settings/locale-persistence.spec.ts
@@ -9,9 +9,8 @@ import { test, expect, type Page } from '@playwright/test';
  * - Restores the correct locale after page reload
  * - Displays translated text for every supported locale
  *
- * This test suite covers all 10 supported locales and specifically
- * catches the bug where certain locales (e.g., Slovak) revert to
- * English after reload due to backend validation resetting the value.
+ * This test suite covers all 14 supported locales and catches the bug
+ * where certain locales revert to English after reload.
  */
 
 // All supported locales with their display names and a known translated string.
@@ -22,17 +21,20 @@ const LOCALE_DATA: {
   name: string;
   settingsTranslation: string;
 }[] = [
+  { code: 'da', name: 'Dansk', settingsTranslation: 'Indstillinger' },
   { code: 'en', name: 'English', settingsTranslation: 'Settings' },
   { code: 'de', name: 'Deutsch', settingsTranslation: 'Einstellungen' },
   { code: 'es', name: 'Espanol', settingsTranslation: 'Configuración' },
   { code: 'fi', name: 'Suomi', settingsTranslation: 'Asetukset' },
   { code: 'fr', name: 'Francais', settingsTranslation: 'Paramètres' },
-  { code: 'it', name: 'Italiano', settingsTranslation: 'Impostazioni' },
   { code: 'hu', name: 'Magyar', settingsTranslation: 'Beállítások' },
+  { code: 'it', name: 'Italiano', settingsTranslation: 'Impostazioni' },
+  { code: 'lv', name: 'Latviešu', settingsTranslation: 'Iestatījumi' },
   { code: 'nl', name: 'Nederlands', settingsTranslation: 'Instellingen' },
   { code: 'pl', name: 'Polski', settingsTranslation: 'Ustawienia' },
   { code: 'pt', name: 'Portugues', settingsTranslation: 'Configurações' },
   { code: 'sk', name: 'Slovenčina', settingsTranslation: 'Nastavenia' },
+  { code: 'sv', name: 'Svenska', settingsTranslation: 'Inställningar' },
 ];
 
 /** Clear the locale from localStorage to start with a clean state. */

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -18,8 +18,9 @@ const LOCALES_PLACEHOLDER = '__SUPPORTED_LOCALES_PLACEHOLDER__'
  */
 function getMessageFiles() {
   if (!existsSync(MESSAGES_SOURCE_DIR)) return []
-  return readdirSync(MESSAGES_SOURCE_DIR)
-    .filter(f => f.endsWith('.json'))
+  return readdirSync(MESSAGES_SOURCE_DIR, { withFileTypes: true })
+    .filter(dirent => dirent.isFile() && dirent.name.endsWith('.json'))
+    .map(dirent => dirent.name)
     .sort()
 }
 
@@ -81,6 +82,9 @@ export default defineConfig({
     {
       name: 'inject-supported-locales',
       transformIndexHtml(html) {
+        if (!html.includes(LOCALES_PLACEHOLDER)) {
+          throw new Error('[inject-supported-locales] Missing ' + LOCALES_PLACEHOLDER + ' in index.html')
+        }
         const locales = discoverSupportedLocales()
         const formatted = locales.map(l => JSON.stringify(l)).join(', ')
         return html.replace(LOCALES_PLACEHOLDER, formatted)

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -6,48 +6,57 @@ import { copyFileSync, mkdirSync, readdirSync, readFileSync, existsSync } from '
 import { join } from 'node:path'
 import { createHash } from 'node:crypto'
 
-// Single source of truth for the translation files directory. Both the i18n
-// cache version helper and the copy-messages plugin reference this path so
-// they cannot drift apart.
+// Single source of truth for the translation files directory.
 const MESSAGES_SOURCE_DIR = './static/messages'
 
+// Placeholder token replaced by the inject-supported-locales plugin.
+const LOCALES_PLACEHOLDER = '__SUPPORTED_LOCALES_PLACEHOLDER__'
+
 /**
- * Compute a stable i18n cache version from the content of
- * `static/messages/*.json`. This replaces `Date.now()` so two builds from
- * identical sources produce identical bundle content hashes (reproducible
- * builds) and the i18n localStorage cache only evicts when translations
- * actually change.
- *
- * Returns 'dev' if the messages directory is missing or empty so dev/test
- * runs still get a well-defined value.
+ * Return sorted *.json filenames from static/messages/, or [] if missing.
+ * Shared by the cache-version, locale-discovery, and copy-messages helpers.
  */
-function computeI18nCacheVersion() {
-  const sourceDir = MESSAGES_SOURCE_DIR
-  if (!existsSync(sourceDir)) return 'dev'
-  const files = readdirSync(sourceDir)
+function getMessageFiles() {
+  if (!existsSync(MESSAGES_SOURCE_DIR)) return []
+  return readdirSync(MESSAGES_SOURCE_DIR)
     .filter(f => f.endsWith('.json'))
     .sort()
+}
+
+/**
+ * Compute a stable i18n cache version from the content of the message files.
+ * Two builds from identical sources produce identical hashes (reproducible
+ * builds) and the i18n localStorage cache only evicts when translations
+ * actually change. Returns 'dev' when no message files exist.
+ */
+function computeI18nCacheVersion() {
+  const files = getMessageFiles()
   if (files.length === 0) return 'dev'
   const hash = createHash('sha256')
-  // NUL-byte delimiter prevents collisions between (filename, content) pairs:
-  // without it, `a.json` containing `bc` and `ab.json` containing `c` both
-  // hash the byte stream `abc` and produce the same digest.
+  // NUL-byte delimiter prevents collisions between (filename, content) pairs.
   const delimiter = Buffer.from([0])
   for (const file of files) {
     hash.update(file)
     hash.update(delimiter)
     try {
-      hash.update(readFileSync(join(sourceDir, file)))
+      hash.update(readFileSync(join(MESSAGES_SOURCE_DIR, file)))
     } catch (/** @type {any} */ err) {
-      // Surface the failing file name then re-throw so the build fails loudly
-      // rather than silently producing a 'dev' cache version that masks the
-      // problem.
       console.error(`[i18n-cache-version] Failed to read ${file}:`, err.message)
       throw err
     }
     hash.update(delimiter)
   }
   return hash.digest('hex').slice(0, 8)
+}
+
+/**
+ * Derive supported UI locale codes from the message files.
+ * Used by the inject-supported-locales plugin so index.html stays in sync
+ * with the actual message files automatically.
+ */
+function discoverSupportedLocales() {
+  const locales = getMessageFiles().map(f => f.replace('.json', ''))
+  return locales.length > 0 ? locales : ['en']
 }
 
 // https://vite.dev/config/
@@ -66,42 +75,44 @@ export default defineConfig({
       },
     }),
     svelteTesting(),
+    // Derive SUPPORTED_LOCALES in index.html from the actual message files.
+    // Adding a new locale only requires the .json file + config.ts entry;
+    // index.html stays in sync automatically via this plugin.
+    {
+      name: 'inject-supported-locales',
+      transformIndexHtml(html) {
+        const locales = discoverSupportedLocales()
+        const formatted = locales.map(l => `'${l}'`).join(', ')
+        return html.replace(LOCALES_PLACEHOLDER, formatted)
+      },
+    },
     // Copy message files to dist during build
     {
       name: 'copy-messages',
       closeBundle() {
         try {
-          // Create messages directory in dist
           const messagesDir = './dist/messages';
           mkdirSync(messagesDir, { recursive: true });
 
-          // Copy all message files
-          const sourceDir = MESSAGES_SOURCE_DIR;
-          
-          // Check if source directory exists
-          if (!existsSync(sourceDir)) {
-            console.warn('[copy-messages] Source directory not found:', sourceDir);
+          const files = getMessageFiles();
+          if (files.length === 0) {
+            console.warn('[copy-messages] No message files found in', MESSAGES_SOURCE_DIR);
             return;
           }
-          
-          const files = readdirSync(sourceDir);
+
           let copiedCount = 0;
-          
-          files.forEach(file => {
-            if (file.endsWith('.json')) {
-              try {
-                copyFileSync(join(sourceDir, file), join(messagesDir, file));
-                copiedCount++;
-              } catch (/** @type {any} */ err) {
-                console.error(`[copy-messages] Failed to copy ${file}:`, err.message);
-              }
+          for (const file of files) {
+            try {
+              copyFileSync(join(MESSAGES_SOURCE_DIR, file), join(messagesDir, file));
+              copiedCount++;
+            } catch (/** @type {any} */ err) {
+              console.error(`[copy-messages] Failed to copy ${file}:`, err.message);
             }
-          });
-          
+          }
+
           console.log(`[copy-messages] Copied ${copiedCount} message files to dist/messages`);
         } catch (/** @type {any} */ err) {
           console.error('[copy-messages] Error during message file copying:', err.message);
-          // Don't fail the build, just log the error
         }
       }
     }

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -82,7 +82,7 @@ export default defineConfig({
       name: 'inject-supported-locales',
       transformIndexHtml(html) {
         const locales = discoverSupportedLocales()
-        const formatted = locales.map(l => `'${l}'`).join(', ')
+        const formatted = locales.map(l => JSON.stringify(l)).join(', ')
         return html.replace(LOCALES_PLACEHOLDER, formatted)
       },
     },

--- a/internal/conf/locale.go
+++ b/internal/conf/locale.go
@@ -129,15 +129,22 @@ var LocaleCodes = map[string]string{
 	"vi-vn": "Vietnamese", // Vietnamese (Vietnam)
 }
 
-// defaultUILocales is the fallback list of valid UI locales, matching the frontend message files.
-// This is used when DiscoverUILocales has not been called or fails.
-var defaultUILocales = []string{"de", "en", "es", "fi", "fr", "it", "nl", "pl", "pt", "sk"}
+// defaultUILocales is the fallback list of valid UI locales.
+// Keep in sync with frontend/static/messages/*.json and frontend/src/lib/i18n/config.ts.
+// This is ONLY used when DiscoverUILocales fails to read the embedded frontend FS.
+var defaultUILocales = []string{"da", "de", "en", "es", "fi", "fr", "hu", "it", "lv", "nl", "pl", "pt", "sk", "sv"}
 
 // validUILocales holds the currently active set of valid UI locale codes.
 // It is initialized to defaultUILocales and can be overridden by SetValidUILocales.
 var validUILocales = defaultUILocales
 
-// validUILocalesMu protects concurrent access to validUILocales.
+// uiLocalesDiscovered tracks whether SetValidUILocales has been called with
+// dynamically discovered locales. Before discovery, locale validation is
+// skipped to avoid resetting valid-but-unlisted locales to "en" during
+// config load (which runs before the embedded frontend FS is available).
+var uiLocalesDiscovered bool
+
+// validUILocalesMu protects concurrent access to validUILocales and uiLocalesDiscovered.
 var validUILocalesMu sync.RWMutex
 
 // ValidUILocales returns the current list of valid UI locale codes.
@@ -147,12 +154,22 @@ func ValidUILocales() []string {
 	return slices.Clone(validUILocales)
 }
 
-// SetValidUILocales overrides the valid UI locale list.
-// This should be called during server initialization after the embedded frontend FS is available.
+// UILocalesDiscovered reports whether SetValidUILocales has been called.
+// Validation code uses this to decide whether to enforce locale checks.
+func UILocalesDiscovered() bool {
+	validUILocalesMu.RLock()
+	defer validUILocalesMu.RUnlock()
+	return uiLocalesDiscovered
+}
+
+// SetValidUILocales overrides the valid UI locale list and marks discovery
+// as complete. This should be called during server initialization after
+// the embedded frontend FS is available.
 func SetValidUILocales(locales []string) {
 	validUILocalesMu.Lock()
 	defer validUILocalesMu.Unlock()
 	validUILocales = slices.Clone(locales)
+	uiLocalesDiscovered = true
 }
 
 // DiscoverUILocales reads the messages/ directory from the given filesystem

--- a/internal/conf/locale_test.go
+++ b/internal/conf/locale_test.go
@@ -100,33 +100,28 @@ func TestSetValidUILocales(t *testing.T) {
 }
 
 func TestValidUILocalesDefault(t *testing.T) {
-	// Verify the default includes all current frontend locales.
+	// Verify the default exactly matches all current frontend locales.
 	// Keep in sync with frontend/static/messages/*.json.
 	locales := ValidUILocales()
 	expected := []string{"da", "de", "en", "es", "fi", "fr", "hu", "it", "lv", "nl", "pl", "pt", "sk", "sv"}
-	for _, code := range expected {
-		assert.Contains(t, locales, code, "defaultUILocales is missing %q; update locale.go to match frontend/static/messages/", code)
-	}
+	assert.ElementsMatch(t, expected, locales, "defaultUILocales must exactly match frontend/static/messages")
 }
 
 func TestUILocalesDiscovered(t *testing.T) {
-	// Save original state and restore after test
 	original := ValidUILocales()
+	originalDiscovered := UILocalesDiscovered()
 	t.Cleanup(func() {
 		SetValidUILocales(original)
-		// Reset discovered flag by re-setting originals
 		validUILocalesMu.Lock()
-		uiLocalesDiscovered = false
+		uiLocalesDiscovered = originalDiscovered
 		validUILocalesMu.Unlock()
 	})
 
-	// Before SetValidUILocales is called, discovered should be false
 	validUILocalesMu.Lock()
 	uiLocalesDiscovered = false
 	validUILocalesMu.Unlock()
 	assert.False(t, UILocalesDiscovered(), "should be false before SetValidUILocales")
 
-	// After SetValidUILocales, discovered should be true
 	SetValidUILocales([]string{"en", "hu"})
 	assert.True(t, UILocalesDiscovered(), "should be true after SetValidUILocales")
 }

--- a/internal/conf/locale_test.go
+++ b/internal/conf/locale_test.go
@@ -56,7 +56,7 @@ func TestDiscoverUILocales(t *testing.T) {
 			name: "falls back to defaults when messages dir missing",
 			fs:   fstest.MapFS{},
 			expected: []string{
-				"de", "en", "es", "fi", "fr", "it", "nl", "pl", "pt", "sk",
+				"da", "de", "en", "es", "fi", "fr", "hu", "it", "lv", "nl", "pl", "pt", "sk", "sv",
 			},
 		},
 		{
@@ -100,11 +100,33 @@ func TestSetValidUILocales(t *testing.T) {
 }
 
 func TestValidUILocalesDefault(t *testing.T) {
-	// Verify the default includes all current frontend locales
+	// Verify the default includes all current frontend locales.
+	// Keep in sync with frontend/static/messages/*.json.
 	locales := ValidUILocales()
-	assert.Contains(t, locales, "en")
-	assert.Contains(t, locales, "sk")
-	assert.Contains(t, locales, "it")
-	assert.Contains(t, locales, "nl")
-	assert.Contains(t, locales, "pl")
+	expected := []string{"da", "de", "en", "es", "fi", "fr", "hu", "it", "lv", "nl", "pl", "pt", "sk", "sv"}
+	for _, code := range expected {
+		assert.Contains(t, locales, code, "defaultUILocales is missing %q; update locale.go to match frontend/static/messages/", code)
+	}
+}
+
+func TestUILocalesDiscovered(t *testing.T) {
+	// Save original state and restore after test
+	original := ValidUILocales()
+	t.Cleanup(func() {
+		SetValidUILocales(original)
+		// Reset discovered flag by re-setting originals
+		validUILocalesMu.Lock()
+		uiLocalesDiscovered = false
+		validUILocalesMu.Unlock()
+	})
+
+	// Before SetValidUILocales is called, discovered should be false
+	validUILocalesMu.Lock()
+	uiLocalesDiscovered = false
+	validUILocalesMu.Unlock()
+	assert.False(t, UILocalesDiscovered(), "should be false before SetValidUILocales")
+
+	// After SetValidUILocales, discovered should be true
+	SetValidUILocales([]string{"en", "hu"})
+	assert.True(t, UILocalesDiscovered(), "should be true after SetValidUILocales")
 }

--- a/internal/conf/validate_realtime.go
+++ b/internal/conf/validate_realtime.go
@@ -205,11 +205,14 @@ func validateDashboardSettings(settings *Dashboard) error {
 		}
 	}
 
-	// Validate UI locale if provided
-	if settings.Locale != "" {
+	// Validate UI locale if provided. Only enforce when DiscoverUILocales has
+	// populated the valid list (i.e., after server startup). During the initial
+	// config load the embedded FS is not yet available, so resetting here would
+	// destroy preferences for newly added locales that are not in the hardcoded
+	// defaultUILocales fallback.
+	if settings.Locale != "" && UILocalesDiscovered() {
 		isValid := slices.Contains(ValidUILocales(), settings.Locale)
 		if !isValid {
-			// Log warning but don't fail - fallback to default
 			GetLogger().Warn("Invalid UI locale, will use default", logger.String("invalid_locale", settings.Locale), logger.String("fallback", "en"))
 			settings.Locale = "en"
 		}


### PR DESCRIPTION
## Summary

- Fix Hungarian locale reverting to English on F5 by deriving `SUPPORTED_LOCALES` at build time from `static/messages/*.json` via a Vite `transformIndexHtml` plugin, eliminating the hardcoded array in `index.html`
- Update backend `defaultUILocales` fallback to include all 14 locales (was missing `da`, `hu`, `lv`, `sv`) and make locale validation discovery-aware to prevent false resets during config load
- Add missing `da`, `lv`, `sv` locales to the E2E locale-persistence test for complete coverage

## Root Cause

The inline `<script>` in `frontend/index.html` runs before any Svelte JS loads. It had a hardcoded `SUPPORTED_LOCALES` array missing `'hu'`. When the script found `'hu'` in localStorage but not in the array, it fell through to browser locale detection (English) and overwrote localStorage, destroying the Hungarian preference on every page load.

## Test plan

- [x] Reproduced on regression VM (bng-std.koti) using Playwright: set locale to `hu`, reload, confirmed it reverted to `en`
- [x] Verified fix on regression VM: with fix applied, Hungarian persists through reload, UI shows "Iranyitopult" heading
- [x] All 1138 Go `conf` package tests pass with race detector
- [x] Frontend build produces `dist/index.html` with all 14 locales including `hu`
- [x] `npm run check:all` passes (format, lint, typecheck, ast-grep)
- [x] `golangci-lint run` passes with zero issues

Fixes #2914

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Prevents your language choice from unexpectedly reverting by delaying validation until available locales are discovered.
  * Startup now reliably detects which UI languages are available and uses that list for locale handling.

* **New**
  * Injects the discovered supported locales at build time so the app uses the exact set of translation files.
  * Adds additional supported languages (Danish, Latvian, Swedish).

* **Tests**
  * Expanded end-to-end and unit coverage to include the new locales and discovery behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->