### PR TITLE
feat(mqtt): stable source identity in MQTT payloads

### DIFF
--- a/internal/analysis/processor/actions_integrations.go
+++ b/internal/analysis/processor/actions_integrations.go
@@ -36,9 +36,10 @@ type NoteWithBirdImage struct {
 	ID     *struct{} `json:"ID,omitempty"`     // Suppressed: use detectionId instead
 	Source *struct{} `json:"Source,omitempty"` // Suppressed: use sourceId instead
 
-	DetectionID uint                    `json:"detectionId"` // Database ID for URL construction (e.g., /api/v2/audio/{id})
-	SourceID    string                  `json:"sourceId"`    // Audio source ID for HA filtering (added for HA discovery)
-	BirdImage   imageprovider.BirdImage `json:"BirdImage"`   // PascalCase for backward compatibility - DO NOT CHANGE
+	DetectionID uint                    `json:"detectionId"`          // Database ID for URL construction (e.g., /api/v2/audio/{id})
+	SourceID    string                  `json:"sourceId"`             // Audio source ID for HA filtering (added for HA discovery)
+	SourceName  string                  `json:"sourceName,omitempty"` // Display name for stable source mapping (#2799)
+	BirdImage   imageprovider.BirdImage `json:"BirdImage"`            // PascalCase for backward compatibility - DO NOT CHANGE
 }
 
 // Execute sends the note to the BirdWeather API
@@ -255,11 +256,12 @@ func (a *MqttAction) Execute(_ context.Context, data any) error {
 	// gracefully, or use the detection ID-based audio endpoint which has
 	// built-in wait-for-encoding support.
 
-	// Wrap note with bird image and include detection ID and SourceID
+	// Wrap note with bird image and include detection ID, SourceID, and SourceName
 	noteWithBirdImage := NoteWithBirdImage{
 		Note:        note,
 		DetectionID: detectionID, // Explicit field for URL construction (e.g., /api/v2/audio/{id})
 		SourceID:    note.Source.ID,
+		SourceName:  note.Source.DisplayName,
 		BirdImage:   birdImage,
 	}
 

--- a/internal/analysis/processor/mqtt_api_contract_test.go
+++ b/internal/analysis/processor/mqtt_api_contract_test.go
@@ -59,6 +59,7 @@ var mqttAPIContractFields = struct {
 	// Detection message root-level fields (explicit JSON tags)
 	DetectionID string // camelCase - database ID for URL construction (issue #1748)
 	SourceID    string // camelCase - added for Home Assistant discovery
+	SourceName  string // camelCase - display name for stable source mapping
 	Occurrence  string // lowercase with omitempty
 	BirdImage   string // PascalCase - DO NOT CHANGE (backward compatibility)
 
@@ -87,6 +88,7 @@ var mqttAPIContractFields = struct {
 	// Root-level fields with explicit tags
 	DetectionID: "detectionId", // camelCase - database ID for URL construction (issue #1748)
 	SourceID:    "sourceId",    // camelCase - new field for HA
+	SourceName:  "sourceName",  // camelCase - display name for stable source mapping
 	Occurrence:  "occurrence",  // lowercase with omitempty
 	BirdImage:   "BirdImage",   // PascalCase - FROZEN for backward compatibility
 
@@ -128,6 +130,7 @@ func TestMQTTAPIContract_NoteWithBirdImage_FieldNames(t *testing.T) {
 		},
 		DetectionID: 12345, // Should match Note.ID for URL construction
 		SourceID:    "test-source-1",
+		SourceName:  testAudioSource().DisplayName, // "test-source"
 		BirdImage: imageprovider.BirdImage{
 			URL:            "https://example.com/bird.jpg",
 			ScientificName: "Turdus migratorius",
@@ -191,6 +194,13 @@ func TestMQTTAPIContract_NoteWithBirdImage_FieldNames(t *testing.T) {
 			"MQTT API CONTRACT: sourceId field must be present for HA filtering")
 		assert.Equal(t, "test-source-1", jsonMap[mqttAPIContractFields.SourceID],
 			"sourceId value mismatch")
+	})
+
+	t.Run("SourceName uses camelCase (display name for stable mapping)", func(t *testing.T) {
+		assert.Contains(t, jsonMap, mqttAPIContractFields.SourceName,
+			"MQTT API CONTRACT: sourceName field must be present for stable source mapping")
+		assert.Equal(t, "test-source", jsonMap[mqttAPIContractFields.SourceName],
+			"sourceName must match the audio source DisplayName")
 	})
 
 	t.Run("BirdImage field uses PascalCase for backward compatibility", func(t *testing.T) {
@@ -456,6 +466,31 @@ func TestMQTTAPIContract_NoRedundantDuplicateFields(t *testing.T) {
 		"Canonical field 'detectionId' must be present")
 	assert.Contains(t, jsonMap, "sourceId",
 		"Canonical field 'sourceId' must be present")
+}
+
+// TestMQTTAPIContract_SourceName_OmittedWhenEmpty verifies that sourceName is omitted
+// from the MQTT payload when DisplayName is empty, per the omitempty tag.
+func TestMQTTAPIContract_SourceName_OmittedWhenEmpty(t *testing.T) {
+	t.Parallel()
+
+	note := NoteWithBirdImage{
+		Note: datastore.Note{
+			CommonName:     "House Sparrow",
+			ScientificName: "Passer domesticus",
+			Confidence:     0.91,
+		},
+		SourceID: "rtsp_4d50dd0d",
+	}
+
+	jsonData, err := json.Marshal(note)
+	require.NoError(t, err)
+
+	var jsonMap map[string]any
+	err = json.Unmarshal(jsonData, &jsonMap)
+	require.NoError(t, err)
+
+	assert.NotContains(t, jsonMap, "sourceName",
+		"sourceName must be omitted when DisplayName is empty (omitempty)")
 }
 
 // TestMQTTAPIContract_NoUnexpectedCamelCaseConversions verifies that fields that

--- a/internal/analysis/processor/mqtt_api_contract_test.go
+++ b/internal/analysis/processor/mqtt_api_contract_test.go
@@ -473,11 +473,15 @@ func TestMQTTAPIContract_NoRedundantDuplicateFields(t *testing.T) {
 func TestMQTTAPIContract_SourceName_OmittedWhenEmpty(t *testing.T) {
 	t.Parallel()
 
+	src := testAudioSource()
+	src.DisplayName = ""
+
 	note := NoteWithBirdImage{
 		Note: datastore.Note{
 			CommonName:     "House Sparrow",
 			ScientificName: "Passer domesticus",
 			Confidence:     0.91,
+			Source:         src,
 		},
 		SourceID: "rtsp_4d50dd0d",
 	}

--- a/internal/audiocore/source_registry.go
+++ b/internal/audiocore/source_registry.go
@@ -54,6 +54,7 @@ type SourceEventListener func(SourceEvent)
 const (
 	registryDeviceDefault            = "default"
 	registryDeviceDefaultDisplayName = "Default Audio Device"
+	registrySourceIDHashBytes        = 4 // SHA-256 truncation width: 4 bytes = 8 hex chars
 )
 
 // SourceRegistry manages audio sources with thread-safe CRUD and event notifications.
@@ -401,7 +402,7 @@ func detectSourceType(conn string) SourceType {
 // across restarts for the same source URL or device.
 func generateSourceID(t SourceType, connStr string) string {
 	hash := sha256.Sum256([]byte(connStr))
-	return fmt.Sprintf("%s_%s", t, hex.EncodeToString(hash[:4]))
+	return fmt.Sprintf("%s_%s", t, hex.EncodeToString(hash[:registrySourceIDHashBytes]))
 }
 
 // buildDisplayName creates a human-readable display name from the connection info.

--- a/internal/audiocore/source_registry.go
+++ b/internal/audiocore/source_registry.go
@@ -2,6 +2,8 @@
 package audiocore
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"path/filepath"
 	"slices"
@@ -9,7 +11,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/logger"
 	"github.com/tphakala/birdnet-go/internal/privacy"
@@ -117,7 +118,7 @@ func (r *SourceRegistry) Register(cfg *SourceConfig) (*AudioSource, error) {
 	// Determine ID.
 	id := cfg.ID
 	if id == "" {
-		id = generateSourceID(cfg.Type)
+		id = generateSourceID(cfg.Type, connStr)
 	}
 
 	// Determine display name.
@@ -395,18 +396,12 @@ func detectSourceType(conn string) SourceType {
 	return SourceTypeUnknown
 }
 
-// generateSourceID returns a short unique ID prefixed with the source type.
-func generateSourceID(t SourceType) string {
-	u, err := uuid.NewRandom()
-	if err != nil {
-		// Extremely rare; fall back to nanosecond timestamp.
-		ts := fmt.Sprintf("%d", time.Now().UnixNano())
-		if len(ts) > 8 {
-			ts = ts[:8]
-		}
-		return fmt.Sprintf("%s_%s", t, ts)
-	}
-	return fmt.Sprintf("%s_%s", t, u.String()[:8])
+// generateSourceID returns a deterministic ID prefixed with the source type.
+// The ID is derived from SHA-256 of the connection string, making it stable
+// across restarts for the same source URL or device.
+func generateSourceID(t SourceType, connStr string) string {
+	hash := sha256.Sum256([]byte(connStr))
+	return fmt.Sprintf("%s_%s", t, hex.EncodeToString(hash[:4]))
 }
 
 // buildDisplayName creates a human-readable display name from the connection info.

--- a/internal/audiocore/source_registry_test.go
+++ b/internal/audiocore/source_registry_test.go
@@ -352,6 +352,40 @@ func TestSourceRegistry_UpdateDisplayName_NotFound(t *testing.T) {
 	assert.False(t, updated)
 }
 
+// TestGenerateSourceID_Deterministic verifies that the same inputs always produce the same ID.
+func TestGenerateSourceID_Deterministic(t *testing.T) {
+	t.Parallel()
+
+	id1 := generateSourceID(SourceTypeRTSP, "rtsp://192.168.1.10/stream")
+	id2 := generateSourceID(SourceTypeRTSP, "rtsp://192.168.1.10/stream")
+	assert.Equal(t, id1, id2, "same connection string must produce the same ID")
+}
+
+// TestGenerateSourceID_DifferentInputs verifies that different connection strings produce different IDs.
+func TestGenerateSourceID_DifferentInputs(t *testing.T) {
+	t.Parallel()
+
+	id1 := generateSourceID(SourceTypeRTSP, "rtsp://192.168.1.10/stream1")
+	id2 := generateSourceID(SourceTypeRTSP, "rtsp://192.168.1.10/stream2")
+	assert.NotEqual(t, id1, id2, "different connection strings must produce different IDs")
+}
+
+// TestGenerateSourceID_Format verifies the ID format is {type}_{8 hex chars}.
+func TestGenerateSourceID_Format(t *testing.T) {
+	t.Parallel()
+
+	id := generateSourceID(SourceTypeRTSP, "rtsp://192.168.1.10/stream")
+	assert.Regexp(t, `^rtsp_[0-9a-f]{8}$`, id, "ID must match format {type}_{8 hex chars}")
+}
+
+// TestGenerateSourceID_IncludesType verifies that the ID prefix matches the source type.
+func TestGenerateSourceID_IncludesType(t *testing.T) {
+	t.Parallel()
+
+	id := generateSourceID(SourceTypeAudioCard, "hw:1,0")
+	assert.Regexp(t, `^audio_card_[0-9a-f]{8}$`, id, "ID must include the source type prefix")
+}
+
 // TestSourceRegistry_TypeDetection verifies that source types are detected from connection strings.
 func TestSourceRegistry_TypeDetection(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Summary

- Make `sourceId` deterministic by deriving it from SHA-256 of the connection string instead of a random UUID. The ID format stays `{type}_{hex8}` (e.g., `rtsp_a3f1b2c4`) but is now stable across restarts.
- Add `sourceName` field to MQTT detection payloads, populated from the configured stream display name (e.g., "BirdCam"). Uses `omitempty` so existing deployments without a display name are unaffected.

**Breaking change:** `sourceId` values will change once after upgrading (from random UUID prefix to deterministic hash). After that, they remain stable across restarts. If your Home Assistant automations filter on a specific `sourceId`, update them to the new value. Alternatively, use the new `sourceName` field, which contains your configured stream name and is always stable.

## Related Issues

Fixes #2799

## Test Plan

- [x] `generateSourceID` determinism: same input always produces the same output
- [x] `generateSourceID` format: `{type}_{8 hex chars}` regex match
- [x] `sourceName` present in MQTT JSON when `DisplayName` is set
- [x] `sourceName` omitted from MQTT JSON when `DisplayName` is empty (omitempty)
- [x] Full source registry test suite (113 tests, race detector)
- [x] Full processor contract test suite (745 tests, race detector)
- [x] golangci-lint clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MQTT payloads now include an optional sourceName field with the audio source display name.

* **Improvements**
  * Source IDs are generated deterministically from connection details for consistent identifiers.

* **Tests**
  * Added contract tests validating presence/omission of sourceName in MQTT payloads and tests ensuring deterministic source ID format and stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->