### PR TITLE
fix(telemetry): restore support dump attachment uploads broken by sentry-go v0.46.0

### DIFF
--- a/internal/telemetry/sentry.go
+++ b/internal/telemetry/sentry.go
@@ -272,6 +272,10 @@ func initializeSentrySDK(settings *conf.Settings) error {
 
 		// BeforeSend allows us to filter sensitive data
 		BeforeSend: createBeforeSendHook(settings),
+
+		// sentry-go v0.46.0 telemetry processor drops event attachments (support dumps).
+		// Scheduler.sendItem() only adds the event envelope item, skipping Attachments.
+		DisableTelemetryBuffer: true,
 	})
 
 	if err != nil {
@@ -1064,6 +1068,10 @@ func InitMinimalSentryForSupport(systemID, version string) error {
 		Environment:      "production",
 		ServerName:       "", // No server identification
 		Release:          fmt.Sprintf("birdnet-go@%s", version),
+
+		// sentry-go v0.46.0 telemetry processor drops event attachments (support dumps).
+		DisableTelemetryBuffer: true,
+
 		// Only allow support dump events
 		BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
 			// Only allow events tagged as support dumps


### PR DESCRIPTION
## Summary

- sentry-go v0.46.0 introduced a telemetry processor (enabled by default) that silently drops event attachments. The new `Scheduler.sendItem()` path only adds the event JSON as a single envelope item, skipping `event.Attachments` which must be separate envelope items per the Sentry protocol.
- This broke all support dump uploads since PR #2856 (April 26) bumped sentry-go from v0.45.1 to v0.46.0. Events arrived in Sentry with correct metadata but the zip file attachment was missing.
- Fix: set `DisableTelemetryBuffer: true` in both `initializeSentrySDK()` and `InitMinimalSentryForSupport()` to force the legacy transport path that correctly handles attachments.

## Root Cause

Two code paths exist for sending events in sentry-go v0.46.0:

1. **Old path** (`internalAsyncTransportAdapter.SendEvent`) iterates `event.Attachments` and adds each as a separate envelope item. Works correctly.
2. **New path** (`Scheduler.sendItem`) calls `event.ToEnvelopeItem()` and adds only that single item. Never processes `event.Attachments`. Attachments are silently dropped.

When `DisableTelemetryBuffer` is false (the default) and no custom `Transport` is set, all events flow through the new path.

Upstream bug filed: https://github.com/getsentry/sentry-go/issues/1291

## Verification

Deployed a build with this fix to the QA test container, submitted a support dump via the UI, and confirmed the attachment appeared in Sentry (event `0fb29d29`, attachment ID `539580096`, 37 KB zip file).

## Test Plan

- [x] `go test -race ./internal/telemetry/` - all 197 tests pass
- [x] QA deployment test - support dump attachment confirmed in Sentry
- [x] `go build ./internal/telemetry/` compiles cleanly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved telemetry event attachment handling to prevent loss of error report data during transmission and enhance error tracking reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->