### PR TITLE
fix(search): restore partial common name matching in v2only datastore

### DIFF
--- a/internal/datastore/v2/repository/filter_conversion.go
+++ b/internal/datastore/v2/repository/filter_conversion.go
@@ -416,7 +416,9 @@ func ResolveSpeciesToLabelIDsWithCommonName(ctx context.Context, deps *FilterLoo
 		return nil, nil
 	}
 
-	labels, err := deps.LabelRepo.Search(ctx, species, 100)
+	normalized := norm.NFC.String(species)
+
+	labels, err := deps.LabelRepo.Search(ctx, normalized, 100)
 	if err != nil {
 		return nil, err
 	}
@@ -428,10 +430,10 @@ func ResolveSpeciesToLabelIDsWithCommonName(ctx context.Context, deps *FilterLoo
 
 	// Also search common names for partial matches.
 	if len(deps.SciToCommon) > 0 {
-		needle := strings.ToLower(norm.NFC.String(species))
+		needle := strings.ToLower(normalized)
 		matchedScientific := make([]string, 0, 16)
 		for sci, common := range deps.SciToCommon {
-			if strings.Contains(strings.ToLower(common), needle) {
+			if strings.Contains(strings.ToLower(norm.NFC.String(common)), needle) {
 				matchedScientific = append(matchedScientific, sci)
 			}
 		}

--- a/internal/datastore/v2/repository/filter_conversion.go
+++ b/internal/datastore/v2/repository/filter_conversion.go
@@ -12,6 +12,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/datastore/v2/entities"
 	"github.com/tphakala/birdnet-go/internal/errors"
+	"golang.org/x/text/unicode/norm"
 )
 
 // =============================================================================
@@ -261,8 +262,9 @@ var sentinelNoMatchIDs = []uint{0}
 
 // FilterLookupDeps contains dependencies for filter entity lookups.
 type FilterLookupDeps struct {
-	LabelRepo  LabelRepository
-	SourceRepo AudioSourceRepository
+	LabelRepo   LabelRepository
+	SourceRepo  AudioSourceRepository
+	SciToCommon map[string]string
 }
 
 // ResolveSpeciesToLabelIDs converts species names to label IDs.
@@ -402,7 +404,8 @@ func singleTimeOfDayToHours(timeOfDay string) []int {
 }
 
 // ResolveSpeciesToLabelIDsWithCommonName converts a species search string to label IDs.
-// This does a LIKE search on scientific names. The species parameter can be a partial match.
+// Searches both scientific names (via LabelRepo.Search LIKE) and common names
+// (via deps.SciToCommon) for partial matches.
 // Returns nil if species is empty (no filtering).
 // Returns sentinel []uint{0} if species is non-empty but no labels are found.
 func ResolveSpeciesToLabelIDsWithCommonName(ctx context.Context, deps *FilterLookupDeps, species string) ([]uint, error) {
@@ -413,28 +416,43 @@ func ResolveSpeciesToLabelIDsWithCommonName(ctx context.Context, deps *FilterLoo
 		return nil, nil
 	}
 
-	// LabelRepo.Search does a LIKE match on scientific_name only. Common-name
-	// search is handled at the API handler layer by pre-resolving common names
-	// to scientific names before this helper is called; see
-	// (*Controller).resolveSpeciesToScientific in internal/api/v2/search.go.
-	// The limit of 100 is intentional for Simple Search: a broader term returning
-	// 100+ species indicates the user should refine the query.
-	// TODO: support partial common-name search once a persistent common_name column exists.
 	labels, err := deps.LabelRepo.Search(ctx, species, 100)
 	if err != nil {
 		return nil, err
 	}
 
-	if len(labels) == 0 {
-		// Species specified but not found - use sentinel to ensure zero results
+	labelIDSet := make(map[uint]struct{}, len(labels))
+	for _, label := range labels {
+		labelIDSet[label.ID] = struct{}{}
+	}
+
+	// Also search common names for partial matches.
+	if len(deps.SciToCommon) > 0 {
+		needle := strings.ToLower(norm.NFC.String(species))
+		matchedScientific := make([]string, 0, 16)
+		for sci, common := range deps.SciToCommon {
+			if strings.Contains(strings.ToLower(common), needle) {
+				matchedScientific = append(matchedScientific, sci)
+			}
+		}
+		if len(matchedScientific) > 0 {
+			commonLabels, err := deps.LabelRepo.GetByScientificNames(ctx, matchedScientific)
+			if err != nil {
+				return nil, err
+			}
+			for _, labelsForSci := range commonLabels {
+				for _, label := range labelsForSci {
+					labelIDSet[label.ID] = struct{}{}
+				}
+			}
+		}
+	}
+
+	if len(labelIDSet) == 0 {
 		return sentinelNoMatchIDs, nil
 	}
 
-	labelIDs := make([]uint, len(labels))
-	for i, label := range labels {
-		labelIDs[i] = label.ID
-	}
-	return labelIDs, nil
+	return slices.Collect(maps.Keys(labelIDSet)), nil
 }
 
 // ResolveDeviceToSourceIDs converts a device name to audio source IDs.
@@ -583,7 +601,7 @@ func ConvertSearchFilters(
 
 	// Entity lookups (require deps)
 	if deps != nil {
-		// Convert species string to label IDs (LIKE search)
+		// Convert species string to label IDs (LIKE search on scientific + common names)
 		sf.LabelIDs, err = ResolveSpeciesToLabelIDsWithCommonName(ctx, deps, filters.Species)
 		if err != nil {
 			return nil, err

--- a/internal/datastore/v2/repository/filter_conversion_test.go
+++ b/internal/datastore/v2/repository/filter_conversion_test.go
@@ -1100,21 +1100,43 @@ func TestResolveSpeciesToLabelIDsWithCommonName(t *testing.T) {
 			LabelRepo: &mockLabelRepositoryWithSearch{
 				mockLabelRepository: mockLabelRepository{
 					labels: map[string]*entities.Label{
-						"Parus major": {ID: 30, ScientificName: "Parus major"},
+						"Turdus migratorius": {ID: 30, ScientificName: "Turdus migratorius"},
 					},
 				},
 				searchResults: []*entities.Label{
-					{ID: 5, ScientificName: "Parus ater"},
+					{ID: 5, ScientificName: "Erithacus rubecula"},
 				},
 			},
 			SciToCommon: map[string]string{
-				"Parus major": "talitiainen",
+				"Turdus migratorius": "american robin",
 			},
 		}
 
-		result, err := ResolveSpeciesToLabelIDsWithCommonName(ctx, deps, "Parus")
+		result, err := ResolveSpeciesToLabelIDsWithCommonName(ctx, deps, "robin")
 		require.NoError(t, err)
-		assert.Contains(t, result, uint(5))
+		assert.ElementsMatch(t, []uint{5, 30}, result)
+	})
+
+	t.Run("NFC normalization matches decomposed input", func(t *testing.T) {
+		// "ö" as combining sequence (NFD): o + U+0308
+		nfdQuery := "lehtopöllö"
+		deps := &FilterLookupDeps{
+			LabelRepo: &mockLabelRepositoryWithSearch{
+				mockLabelRepository: mockLabelRepository{
+					labels: map[string]*entities.Label{
+						"Strix aluco": {ID: 40, ScientificName: "Strix aluco"},
+					},
+				},
+				searchResults: []*entities.Label{},
+			},
+			SciToCommon: map[string]string{
+				"Strix aluco": "Lehtopöllö",
+			},
+		}
+
+		result, err := ResolveSpeciesToLabelIDsWithCommonName(ctx, deps, nfdQuery)
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []uint{40}, result)
 	})
 }
 

--- a/internal/datastore/v2/repository/filter_conversion_test.go
+++ b/internal/datastore/v2/repository/filter_conversion_test.go
@@ -1051,6 +1051,71 @@ func TestResolveSpeciesToLabelIDsWithCommonName(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, []uint{0}, result)
 	})
+
+	t.Run("partial common name match returns label IDs", func(t *testing.T) {
+		deps := &FilterLookupDeps{
+			LabelRepo: &mockLabelRepositoryWithSearch{
+				mockLabelRepository: mockLabelRepository{
+					labels: map[string]*entities.Label{
+						"Turdus pilaris": {ID: 10, ScientificName: "Turdus pilaris"},
+						"Turdus merula":  {ID: 11, ScientificName: "Turdus merula"},
+					},
+				},
+				searchResults: []*entities.Label{},
+			},
+			SciToCommon: map[string]string{
+				"Turdus pilaris": "räkättirastas",
+				"Turdus merula":  "mustarastas",
+				"Parus major":    "talitiainen",
+			},
+		}
+
+		result, err := ResolveSpeciesToLabelIDsWithCommonName(ctx, deps, "rastas")
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []uint{10, 11}, result)
+	})
+
+	t.Run("partial common name match is case-insensitive", func(t *testing.T) {
+		deps := &FilterLookupDeps{
+			LabelRepo: &mockLabelRepositoryWithSearch{
+				mockLabelRepository: mockLabelRepository{
+					labels: map[string]*entities.Label{
+						"Parus major": {ID: 20, ScientificName: "Parus major"},
+					},
+				},
+				searchResults: []*entities.Label{},
+			},
+			SciToCommon: map[string]string{
+				"Parus major": "Talitiainen",
+			},
+		}
+
+		result, err := ResolveSpeciesToLabelIDsWithCommonName(ctx, deps, "tiainen")
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []uint{20}, result)
+	})
+
+	t.Run("combines scientific and common name matches", func(t *testing.T) {
+		deps := &FilterLookupDeps{
+			LabelRepo: &mockLabelRepositoryWithSearch{
+				mockLabelRepository: mockLabelRepository{
+					labels: map[string]*entities.Label{
+						"Parus major": {ID: 30, ScientificName: "Parus major"},
+					},
+				},
+				searchResults: []*entities.Label{
+					{ID: 5, ScientificName: "Parus ater"},
+				},
+			},
+			SciToCommon: map[string]string{
+				"Parus major": "talitiainen",
+			},
+		}
+
+		result, err := ResolveSpeciesToLabelIDsWithCommonName(ctx, deps, "Parus")
+		require.NoError(t, err)
+		assert.Contains(t, result, uint(5))
+	})
 }
 
 // =============================================================================

--- a/internal/datastore/v2only/datastore.go
+++ b/internal/datastore/v2only/datastore.go
@@ -1869,8 +1869,9 @@ func (ds *Datastore) SearchDetections(filters *datastore.SearchFilters) ([]datas
 
 	// Set up dependencies for entity lookups
 	deps := &repository.FilterLookupDeps{
-		LabelRepo:  ds.label,
-		SourceRepo: ds.source,
+		LabelRepo:   ds.label,
+		SourceRepo:  ds.source,
+		SciToCommon: ds.loadNameMaps().common,
 	}
 
 	// Convert API-level filters to repository filters


### PR DESCRIPTION
## Summary
- The v2only datastore's `LabelRepo.Search` only matched scientific names via SQL LIKE, breaking partial common name search (e.g. "rastas" matching "räkättirastas", "tiainen" matching "talitiainen")
- Adds in-memory common name scanning to `ResolveSpeciesToLabelIDsWithCommonName`: iterates `deps.SciToCommon` map, finds species whose common names contain the search term, then batch-resolves their label IDs via `GetByScientificNames`
- Uses NFC normalization for correct diacritical matching on macOS keyboards
- `SciToCommon` placed on `FilterLookupDeps` (lookup dependency), not on `SearchFilters` (user filter DTO)

Fixes #2917

## Test plan
- [x] Unit tests: partial common name match, case-insensitive match, combined scientific + common name match (3 new tests)
- [x] Existing tests updated and passing (143 repository tests, 2032 api/v2 tests)
- [x] Reproduced on regression VM (bng-std.koti) via Playwright: "rastas" and "tiainen" return no results, "Turdus pilaris" and exact "räkättirastas" work
- [x] Lint clean (`golangci-lint run` on all affected packages)
- [ ] E2E verification after deploy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Species filtering now supports queries using both common and scientific names for broader match coverage
  * Implemented case-insensitive substring matching for species filters, enabling more flexible search queries
  * Added Unicode normalization so queries with composed or decomposed characters match correctly
  * Results are automatically deduplicated when matches occur across multiple name sources for cleaner results
<!-- end of auto-generated comment: release notes by coderabbit.ai -->