### PR TITLE
fix(analytics): incorrect placeholder image url

### DIFF
--- a/internal/api/v2/analytics.go
+++ b/internal/api/v2/analytics.go
@@ -21,7 +21,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/logger"
 )
 
-const placeholderImageURL = "/assets/images/bird-placeholder.svg"
+const placeholderImageURL = "/ui/assets/bird-placeholder.svg"
 const maxSpeciesBatch = 10
 
 // Analytics constants (file-local)


### PR DESCRIPTION
Minor, but the backend sometimes returns a placeholder URL for species that is not actually valid

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated fallback image path for thumbnail display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->