### PR TITLE
fix(dashboard): restore banner visibility for guest users

### DIFF
--- a/frontend/src/lib/desktop/features/dashboard/pages/DashboardPage.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/pages/DashboardPage.svelte
@@ -66,7 +66,12 @@ Performance Optimizations:
   import { navigation } from '$lib/stores/navigation.svelte';
   import { connectionState } from '$lib/stores/connectionState.svelte';
   import { appState } from '$lib/stores/appState.svelte';
-  import { birdnetSettings, dashboardLayout, settingsStore } from '$lib/stores/settings';
+  import {
+    birdnetSettings,
+    dashboardLayout,
+    settingsDataLoaded,
+    settingsStore,
+  } from '$lib/stores/settings';
   import type { Dashboard, DashboardElement, DashboardLayout } from '$lib/stores/settings';
   import { dashboardEditMode } from '$lib/stores/dashboardEditMode';
   import { guestDashboardLayout, saveGuestLayout } from '$lib/stores/guestDashboardLayout';
@@ -169,22 +174,43 @@ Performance Optimizations:
     { id: 'live-spectrogram-0', type: 'live-spectrogram', enabled: true },
     { id: 'detections-grid-0', type: 'detections-grid', enabled: true },
   ];
-  // Check whether authenticated settings were actually loaded successfully.
-  // When settings failed to load (e.g. guest/unauthenticated), skip the
-  // settings-derived layout so we fall through to the public app config.
-  let settingsLoaded = $derived(!$settingsStore.isLoading && !$settingsStore.error);
+  // Only use the settings store layout when data was actually fetched from the
+  // server. The store initializes with default elements, so checking isLoading
+  // alone would incorrectly treat the defaults as "loaded" for guests (where
+  // loadSettings() is intentionally skipped to avoid 401 errors).
+  let settingsLoaded = $derived($settingsDataLoaded);
   // Guest detection: security is on but user has no access (not authenticated)
   let isGuest = $derived(appState.security.enabled && !appState.security.accessAllowed);
   // Priority: authenticated settings > guest localStorage > public app config > hardcoded defaults
-  let layoutElements = $derived(
-    (settingsLoaded ? $dashboardLayout?.elements : null) ??
-      (isGuest ? $guestDashboardLayout?.elements : null) ??
-      (appState.layout?.elements as DashboardElement[] | undefined) ??
-      defaultElements
+  // Source is computed alongside elements so the priority logic exists in one place.
+  let layoutResolution = $derived(
+    settingsLoaded && $dashboardLayout?.elements
+      ? { elements: $dashboardLayout.elements, source: 'settings-store' as const }
+      : isGuest && $guestDashboardLayout?.elements
+        ? { elements: $guestDashboardLayout.elements, source: 'guest-localstorage' as const }
+        : appState.layout?.elements
+          ? {
+              elements: appState.layout.elements as DashboardElement[],
+              source: 'app-config' as const,
+            }
+          : { elements: defaultElements, source: 'hardcoded-defaults' as const }
   );
+  let layoutElements = $derived(layoutResolution.elements);
 
   // Current layout as a DashboardLayout object for DashboardEditMode
   let currentLayout = $derived<DashboardLayout>({ elements: layoutElements });
+
+  let previousLayoutSource = '';
+  $effect(() => {
+    if (layoutResolution.source !== previousLayoutSource) {
+      logger.debug('Dashboard layout resolved', {
+        source: layoutResolution.source,
+        elementCount: layoutResolution.elements.length,
+        types: layoutResolution.elements.map(e => e.type),
+      });
+      previousLayoutSource = layoutResolution.source;
+    }
+  });
 
   function handleEditModeChange(editing: boolean) {
     dashboardEditMode.set(editing);

--- a/frontend/src/lib/desktop/features/settings/pages/AudioSettingsPage.test.ts
+++ b/frontend/src/lib/desktop/features/settings/pages/AudioSettingsPage.test.ts
@@ -209,6 +209,7 @@ describe('AudioSettingsPage - Stream Configuration', () => {
       isSaving: false,
       error: null,
       restartRequired: false,
+      dataLoaded: false,
       activeSection: 'audio',
       originalData: {
         main: {

--- a/frontend/src/lib/desktop/features/settings/pages/MainSettingsPage.range.test.ts
+++ b/frontend/src/lib/desktop/features/settings/pages/MainSettingsPage.range.test.ts
@@ -72,6 +72,7 @@ describe('Settings Store - Range Filter Dynamic Updates', () => {
       activeSection: 'main',
       error: null,
       restartRequired: false,
+      dataLoaded: false,
     });
   });
 
@@ -326,6 +327,7 @@ describe('Range Filter - View Species uses filtered threshold (#2393)', () => {
       activeSection: 'main',
       error: null,
       restartRequired: false,
+      dataLoaded: false,
     });
   });
 

--- a/frontend/src/lib/desktop/features/wizard/steps/LocationLanguageStep.test.ts
+++ b/frontend/src/lib/desktop/features/wizard/steps/LocationLanguageStep.test.ts
@@ -68,6 +68,7 @@ vi.mock('$lib/stores/settings', async () => {
     isSaving: false,
     error: null,
     restartRequired: false,
+    dataLoaded: false,
     activeSection: 'main',
     originalData: JSON.parse(JSON.stringify(initialFormData)) as SettingsFormData,
     formData: JSON.parse(JSON.stringify(initialFormData)) as SettingsFormData,
@@ -119,6 +120,7 @@ describe('LocationLanguageStep - UI locale persistence on unmount', () => {
       isSaving: false,
       error: null,
       restartRequired: false,
+      dataLoaded: false,
       activeSection: 'main',
       originalData: {
         birdnet: {

--- a/frontend/src/lib/stores/settings.species.test.ts
+++ b/frontend/src/lib/stores/settings.species.test.ts
@@ -56,6 +56,7 @@ describe('Species Settings Store', () => {
       activeSection: 'main',
       error: null,
       restartRequired: false,
+      dataLoaded: false,
     });
   });
 

--- a/frontend/src/lib/stores/settings.test.ts
+++ b/frontend/src/lib/stores/settings.test.ts
@@ -67,6 +67,7 @@ describe('Settings Store - Dynamic Threshold and Range Filter', () => {
       activeSection: 'main',
       error: null,
       restartRequired: false,
+      dataLoaded: false,
     });
   });
 
@@ -284,6 +285,7 @@ describe('Settings Store - Model/Label Path Null Conversion', () => {
       activeSection: 'main',
       error: null,
       restartRequired: false,
+      dataLoaded: false,
     });
   });
 
@@ -506,6 +508,7 @@ describe('Settings Store - UI Locale Preservation (#2756/#2760)', () => {
       activeSection: 'main',
       error: null,
       restartRequired: false,
+      dataLoaded: false,
     });
   };
 

--- a/frontend/src/lib/stores/settings.ts
+++ b/frontend/src/lib/stores/settings.ts
@@ -793,6 +793,7 @@ export interface GlobalSettingsState {
   activeSection: string;
   error: string | null;
   restartRequired: boolean;
+  dataLoaded: boolean;
 }
 
 // API response types
@@ -1036,6 +1037,7 @@ const initialState: GlobalSettingsState = {
   activeSection: 'main',
   error: null,
   restartRequired: false,
+  dataLoaded: false,
 };
 
 export const settingsStore = writable<GlobalSettingsState>(initialState);
@@ -1054,6 +1056,8 @@ export const currentSection = derived(settingsStore, $store => $store.activeSect
 export const isLoading = derived(settingsStore, $store => $store.isLoading);
 
 export const isSaving = derived(settingsStore, $store => $store.isSaving);
+
+export const settingsDataLoaded = derived(settingsStore, $store => $store.dataLoaded);
 
 // Section-specific derived stores matching backend structure
 export const mainSettings = derived(settingsStore, $store => $store.formData.main);
@@ -1179,6 +1183,7 @@ export const settingsActions = {
         formData: coercedData,
         originalData: JSON.parse(JSON.stringify(coercedData)),
         isLoading: false,
+        dataLoaded: true,
       }));
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : t('settings.errors.loadFailed');


### PR DESCRIPTION
## Summary

- Guest/unauthenticated users could not see the admin-configured dashboard banner (map, weather, station info)
- Root cause: the settings store initialized with `isLoading: false` and `error: null`, so the layout derivation treated default elements as "loaded from server" even when `loadSettings()` was never called (intentionally skipped for guests to avoid 401 errors)
- Added a `dataLoaded` flag to the settings store that tracks whether `loadSettings()` actually completed successfully
- Unified the layout resolution into a single `$derived` that computes both elements and source, eliminating duplicated priority logic and adding debug logging

## Related Issues

Fixes #2526

## Test Plan

- [x] svelte-check: 0 errors, 0 warnings
- [x] Frontend tests: 1918/1918 passing
- [x] QA: deployed with auth enabled + banner configured, verified banner visible for guest in incognito
- [x] QA: verified admin dashboard still shows banner after login (no regression)
- [x] QA: verified zero console errors for both guest and admin views
- [x] CodeRabbit local review: no findings on changed files
- [x] Simplify review (3 parallel agents): no issues, unified ternary duplication

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactoring**
  * Refactored dashboard layout resolution logic to use unified state management with source tracking
  * Introduced settings data loading state flag for improved state consistency across the application

* **Tests**
  * Updated test suites to include new settings store state field in mock initializations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->