### PR TITLE
fix(datastore): update audio source display name on device swap

### DIFF
--- a/internal/datastore/v2/repository/audio_source.go
+++ b/internal/datastore/v2/repository/audio_source.go
@@ -12,11 +12,10 @@ type AudioSourceRepository interface {
 	// Matches on sourceURI + nodeName combination.
 	// sourceURI is the source identifier (e.g., "rtsp://...", "hw:0,0").
 	// nodeName identifies the processing node.
-	// displayName is an optional human-readable name (ignored if source already exists).
-	// sourceType is auto-detected from the URI if not provided.
-	//
-	// Note: If the source already exists, displayName and sourceType are NOT updated.
-	// Use Update() to modify existing sources.
+	// displayName is an optional human-readable name; if the source already exists
+	// and displayName differs from the stored value, the DB row is updated.
+	// sourceType is auto-detected from the URI if not provided and is NOT updated
+	// on existing sources; use Update() for that.
 	GetOrCreate(ctx context.Context, sourceURI, nodeName string, displayName *string, sourceType entities.SourceType) (*entities.AudioSource, error)
 
 	// GetByID retrieves an audio source by its ID.

--- a/internal/datastore/v2/repository/audio_source_impl.go
+++ b/internal/datastore/v2/repository/audio_source_impl.go
@@ -50,6 +50,14 @@ func (r *audioSourceRepository) GetOrCreate(ctx context.Context, sourceURI, node
 		Where("source_uri = ? AND node_name = ?", sourceURI, nodeName).
 		First(&source).Error
 	if err == nil {
+		// Update display name if it changed (e.g., USB device swap on same ALSA path).
+		if displayName != nil && *displayName != "" &&
+			(source.DisplayName == nil || *source.DisplayName != *displayName) {
+			copied := *displayName
+			if err := r.Update(ctx, source.ID, map[string]any{"display_name": copied}); err == nil {
+				source.DisplayName = &copied
+			}
+		}
 		return &source, nil
 	}
 	if !errors.Is(err, gorm.ErrRecordNotFound) {

--- a/internal/datastore/v2/repository/audio_source_impl.go
+++ b/internal/datastore/v2/repository/audio_source_impl.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 
 	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/datastore/v2/entities"
@@ -54,7 +55,10 @@ func (r *audioSourceRepository) GetOrCreate(ctx context.Context, sourceURI, node
 		if displayName != nil && *displayName != "" &&
 			(source.DisplayName == nil || *source.DisplayName != *displayName) {
 			copied := *displayName
-			if err := r.Update(ctx, source.ID, map[string]any{"display_name": copied}); err == nil {
+			if updateErr := r.Update(ctx, source.ID, map[string]any{"display_name": copied}); updateErr != nil {
+				slog.Warn("audio source display name update failed",
+					"source_id", source.ID, "name", copied, "error", updateErr)
+			} else {
 				source.DisplayName = &copied
 			}
 		}

--- a/internal/datastore/v2/repository/audio_source_impl_test.go
+++ b/internal/datastore/v2/repository/audio_source_impl_test.go
@@ -1,0 +1,162 @@
+package repository
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/datastore/v2/entities"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	gorm_logger "gorm.io/gorm/logger"
+)
+
+const testDisplayNameSnowball = "Blue Snowball"
+
+func setupAudioSourceTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	db, err := gorm.Open(sqlite.Open(dbPath), &gorm.Config{
+		Logger: gorm_logger.Default.LogMode(gorm_logger.Silent),
+	})
+	require.NoError(t, err, "failed to open test database")
+
+	sqlDB, err := db.DB()
+	require.NoError(t, err, "failed to get sql.DB")
+	t.Cleanup(func() { _ = sqlDB.Close() })
+
+	err = db.AutoMigrate(&entities.AudioSource{})
+	require.NoError(t, err, "failed to migrate audio_sources table")
+	return db
+}
+
+func TestGetOrCreate_CreatesNewSource(t *testing.T) {
+	t.Parallel()
+	db := setupAudioSourceTestDB(t)
+	repo := NewAudioSourceRepository(db, nil, false, false)
+	ctx := t.Context()
+
+	name := testDisplayNameSnowball
+	source, err := repo.GetOrCreate(ctx, "hw:0,0", "node1", &name, entities.SourceTypeALSA)
+	require.NoError(t, err)
+	assert.Equal(t, "hw:0,0", source.SourceURI)
+	assert.Equal(t, "node1", source.NodeName)
+	require.NotNil(t, source.DisplayName)
+	assert.Equal(t, testDisplayNameSnowball, *source.DisplayName)
+	assert.Equal(t, entities.SourceTypeALSA, source.SourceType)
+}
+
+func TestGetOrCreate_ReturnsSameSourceForSameURI(t *testing.T) {
+	t.Parallel()
+	db := setupAudioSourceTestDB(t)
+	repo := NewAudioSourceRepository(db, nil, false, false)
+	ctx := t.Context()
+
+	name := "Mic One"
+	first, err := repo.GetOrCreate(ctx, "hw:1,0", "node1", &name, entities.SourceTypeALSA)
+	require.NoError(t, err)
+
+	second, err := repo.GetOrCreate(ctx, "hw:1,0", "node1", &name, entities.SourceTypeALSA)
+	require.NoError(t, err)
+	assert.Equal(t, first.ID, second.ID)
+}
+
+func TestGetOrCreate_UpdatesDisplayNameOnDeviceSwap(t *testing.T) {
+	t.Parallel()
+	db := setupAudioSourceTestDB(t)
+	repo := NewAudioSourceRepository(db, nil, false, false)
+	ctx := t.Context()
+
+	oldName := testDisplayNameSnowball
+	source, err := repo.GetOrCreate(ctx, "hw:0,0", "node1", &oldName, entities.SourceTypeALSA)
+	require.NoError(t, err)
+	originalID := source.ID
+	require.NotNil(t, source.DisplayName)
+	assert.Equal(t, testDisplayNameSnowball, *source.DisplayName)
+
+	// Same ALSA path, different mic plugged in
+	newName := "RODE AI-Micro"
+	source, err = repo.GetOrCreate(ctx, "hw:0,0", "node1", &newName, entities.SourceTypeALSA)
+	require.NoError(t, err)
+	assert.Equal(t, originalID, source.ID, "should return the same row, not create a new one")
+	require.NotNil(t, source.DisplayName)
+	assert.Equal(t, "RODE AI-Micro", *source.DisplayName, "display name should be updated")
+
+	// Verify the update was persisted to the database
+	fetched, err := repo.GetByID(ctx, originalID)
+	require.NoError(t, err)
+	require.NotNil(t, fetched.DisplayName)
+	assert.Equal(t, "RODE AI-Micro", *fetched.DisplayName, "updated name should be persisted in DB")
+}
+
+func TestGetOrCreate_DoesNotUpdateWhenNameUnchanged(t *testing.T) {
+	t.Parallel()
+	db := setupAudioSourceTestDB(t)
+	repo := NewAudioSourceRepository(db, nil, false, false)
+	ctx := t.Context()
+
+	name := "My Mic"
+	source, err := repo.GetOrCreate(ctx, "hw:2,0", "node1", &name, entities.SourceTypeALSA)
+	require.NoError(t, err)
+	require.NotNil(t, source.DisplayName)
+	assert.Equal(t, "My Mic", *source.DisplayName)
+
+	// Call again with the same name; should be a no-op
+	sameName := "My Mic"
+	source, err = repo.GetOrCreate(ctx, "hw:2,0", "node1", &sameName, entities.SourceTypeALSA)
+	require.NoError(t, err)
+	require.NotNil(t, source.DisplayName)
+	assert.Equal(t, "My Mic", *source.DisplayName)
+}
+
+func TestGetOrCreate_SkipsUpdateForEmptyDisplayName(t *testing.T) {
+	t.Parallel()
+	db := setupAudioSourceTestDB(t)
+	repo := NewAudioSourceRepository(db, nil, false, false)
+	ctx := t.Context()
+
+	original := testDisplayNameSnowball
+	source, err := repo.GetOrCreate(ctx, "hw:3,0", "node1", &original, entities.SourceTypeALSA)
+	require.NoError(t, err)
+	require.NotNil(t, source.DisplayName)
+	assert.Equal(t, testDisplayNameSnowball, *source.DisplayName)
+
+	// Empty display name should not overwrite the existing one
+	empty := ""
+	source, err = repo.GetOrCreate(ctx, "hw:3,0", "node1", &empty, entities.SourceTypeALSA)
+	require.NoError(t, err)
+	require.NotNil(t, source.DisplayName)
+	assert.Equal(t, testDisplayNameSnowball, *source.DisplayName, "empty name should not overwrite existing")
+}
+
+func TestGetOrCreate_SkipsUpdateForNilDisplayName(t *testing.T) {
+	t.Parallel()
+	db := setupAudioSourceTestDB(t)
+	repo := NewAudioSourceRepository(db, nil, false, false)
+	ctx := t.Context()
+
+	original := testDisplayNameSnowball
+	source, err := repo.GetOrCreate(ctx, "hw:4,0", "node1", &original, entities.SourceTypeALSA)
+	require.NoError(t, err)
+	require.NotNil(t, source.DisplayName)
+	assert.Equal(t, testDisplayNameSnowball, *source.DisplayName)
+
+	// Nil display name should not overwrite the existing one
+	source, err = repo.GetOrCreate(ctx, "hw:4,0", "node1", nil, entities.SourceTypeALSA)
+	require.NoError(t, err)
+	require.NotNil(t, source.DisplayName)
+	assert.Equal(t, testDisplayNameSnowball, *source.DisplayName, "nil name should not overwrite existing")
+}
+
+func TestGetOrCreate_AutoDetectsSourceType(t *testing.T) {
+	t.Parallel()
+	db := setupAudioSourceTestDB(t)
+	repo := NewAudioSourceRepository(db, nil, false, false)
+	ctx := t.Context()
+
+	name := "Camera"
+	source, err := repo.GetOrCreate(ctx, "rtsp://192.168.1.10/stream", "node1", &name, "")
+	require.NoError(t, err)
+	assert.Equal(t, entities.SourceTypeRTSP, source.SourceType)
+}

--- a/internal/datastore/v2/repository/audio_source_impl_test.go
+++ b/internal/datastore/v2/repository/audio_source_impl_test.go
@@ -149,6 +149,28 @@ func TestGetOrCreate_SkipsUpdateForNilDisplayName(t *testing.T) {
 	assert.Equal(t, testDisplayNameSnowball, *source.DisplayName, "nil name should not overwrite existing")
 }
 
+func TestGetOrCreate_SetsDisplayNameWhenInitiallyNil(t *testing.T) {
+	t.Parallel()
+	db := setupAudioSourceTestDB(t)
+	repo := NewAudioSourceRepository(db, nil, false, false)
+	ctx := t.Context()
+
+	source, err := repo.GetOrCreate(ctx, "hw:5,0", "node1", nil, entities.SourceTypeALSA)
+	require.NoError(t, err)
+	assert.Nil(t, source.DisplayName)
+
+	name := "New Mic"
+	source, err = repo.GetOrCreate(ctx, "hw:5,0", "node1", &name, entities.SourceTypeALSA)
+	require.NoError(t, err)
+	require.NotNil(t, source.DisplayName)
+	assert.Equal(t, "New Mic", *source.DisplayName)
+
+	fetched, err := repo.GetByID(ctx, source.ID)
+	require.NoError(t, err)
+	require.NotNil(t, fetched.DisplayName)
+	assert.Equal(t, "New Mic", *fetched.DisplayName)
+}
+
 func TestGetOrCreate_AutoDetectsSourceType(t *testing.T) {
 	t.Parallel()
 	db := setupAudioSourceTestDB(t)


### PR DESCRIPTION
## Summary

- `GetOrCreate()` returned stale `DisplayName` when a different USB mic landed on the same ALSA device path (e.g., `hw:0,0`). Now compares the caller-provided name against the stored value and updates the DB row when they differ.
- Uses the existing `Update()` method with defensive string copying. In-memory object only updated on successful DB write.
- Added 7 tests covering creation, deduplication, device swap update, no-op cases (unchanged/empty/nil name), and source type auto-detection.

## Related Issues
Fixes #2921

## Test Plan
- [x] `go test -race -v ./internal/datastore/v2/repository/ -run TestGetOrCreate` (7 tests pass)
- [x] `golangci-lint run -v ./internal/datastore/v2/repository/` (zero issues)
- [ ] CI checks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Audio source display names can now be updated automatically when the same source is re-encountered with a different device association, enabling seamless device swaps. If a display-name update fails, the existing source is still returned.

* **Tests**
  * Added comprehensive tests for audio source creation, idempotency, display-name updates, auto-detection of source type for RTSP, and related edge cases.

* **Documentation**
  * Clarified behavior for display-name updates and source-type detection in GetOrCreate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->