### PR TITLE
fix(datastore): classify "database is closed" as transient and nil DB on close

### DIFF
--- a/internal/datastore/db_close_test.go
+++ b/internal/datastore/db_close_test.go
@@ -1,0 +1,91 @@
+package datastore
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/conf"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	gormlogger "gorm.io/gorm/logger"
+)
+
+func TestSQLiteStore_Close_NilsOutDB(t *testing.T) {
+	t.Parallel()
+
+	store := newTestSQLiteStore(t)
+	require.NotNil(t, store.DB, "DB should be non-nil before Close")
+
+	err := store.Close()
+	require.NoError(t, err)
+
+	assert.Nil(t, store.DB, "DB should be nil after Close to prevent stale reference queries")
+}
+
+func TestSQLiteStore_ClosedDB_QueryReturnsClosedError(t *testing.T) {
+	t.Parallel()
+
+	db := openUnmanagedTestDB(t)
+
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	require.NoError(t, sqlDB.Close())
+
+	var count int64
+	queryErr := db.Model(&DailyEvents{}).Count(&count).Error
+	require.Error(t, queryErr)
+	assert.Contains(t, queryErr.Error(), "database is closed")
+
+	assert.True(t, IsTransientDBError(queryErr),
+		"'database is closed' from a real closed pool should be classified as transient")
+}
+
+func TestRetryOnLock_RetriesAfterDatabaseClosed(t *testing.T) {
+	t.Parallel()
+
+	calls := 0
+	err := RetryOnLock(t.Context(), "test_closed_retry", func() error {
+		calls++
+		if calls < 3 {
+			return fmt.Errorf("sql: database is closed")
+		}
+		return nil
+	}, nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, 3, calls, "should have retried until success")
+}
+
+// openUnmanagedTestDB creates a file-backed SQLite database without
+// registering a cleanup closer. Use this when the test needs to
+// manually control the DB lifecycle (e.g., closing the pool explicitly).
+func openUnmanagedTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+
+	dbPath := fmt.Sprintf("%s/lifecycle_test.db", t.TempDir())
+	dsn := buildSQLiteDSN(dbPath, "_journal_mode=WAL&_busy_timeout=5000")
+
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{
+		Logger: gormlogger.Discard,
+	})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&DailyEvents{}))
+
+	return db
+}
+
+func newTestSQLiteStore(t *testing.T) *SQLiteStore {
+	t.Helper()
+
+	db := openUnmanagedTestDB(t)
+
+	settings := &conf.Settings{}
+	settings.Output.SQLite.Path = "test.db"
+
+	return &SQLiteStore{
+		Settings:  settings,
+		DataStore: DataStore{DB: db},
+	}
+}

--- a/internal/datastore/errors_helper.go
+++ b/internal/datastore/errors_helper.go
@@ -33,7 +33,7 @@ func initRegexPatterns() {
 		diskFullPattern = regexp.MustCompile(`(?i)(disk full|no space|out of space)`)
 		deadlockPattern = regexp.MustCompile(`(?i)(deadlock detected|lock wait timeout|deadlock found)`)
 		corruptionPattern = regexp.MustCompile(`(?i)(corrupt|malformed|database disk image is malformed|file is not a database)`)
-		lockPattern = regexp.MustCompile(`(?i)(locked|database is locked|resource busy|SQLITE_BUSY)`)
+		lockPattern = regexp.MustCompile(`(?i)(locked|database is locked|database is closed|resource busy|SQLITE_BUSY)`)
 		constraintPattern = regexp.MustCompile(`(?i)(constraint|duplicate|unique constraint|foreign key)`)
 	})
 }

--- a/internal/datastore/mysql.go
+++ b/internal/datastore/mysql.go
@@ -166,11 +166,11 @@ func (store *MySQLStore) Close() error {
 		return err
 	}
 
-	// Log successful closure
 	GetLogger().Info("MySQL database closed successfully",
 		logger.String("host", store.Settings.Output.MySQL.Host),
 		logger.String("database", store.Settings.Output.MySQL.Database))
 
+	store.DB = nil
 	return nil
 }
 

--- a/internal/datastore/mysql.go
+++ b/internal/datastore/mysql.go
@@ -132,13 +132,8 @@ func (store *MySQLStore) Open() error {
 
 // Close MySQL database connections
 func (store *MySQLStore) Close() error {
-	// Ensure that the store's DB field is not nil to avoid a panic
 	if store.DB == nil {
-		return errors.Newf("database connection is not initialized").
-			Component("datastore").
-			Category(errors.CategoryValidation).
-			Context("operation", "close").
-			Build()
+		return nil
 	}
 
 	// Stop monitoring before closing database

--- a/internal/datastore/mysql.go
+++ b/internal/datastore/mysql.go
@@ -152,8 +152,10 @@ func (store *MySQLStore) Close() error {
 		return err
 	}
 
-	// Close the generic database object, which closes the underlying SQL database connection
-	if err := sqlDB.Close(); err != nil {
+	err = sqlDB.Close()
+	store.DB = nil
+
+	if err != nil {
 		GetLogger().Error("Failed to close MySQL database",
 			logger.String("host", store.Settings.Output.MySQL.Host),
 			logger.String("database", store.Settings.Output.MySQL.Database),
@@ -164,8 +166,6 @@ func (store *MySQLStore) Close() error {
 	GetLogger().Info("MySQL database closed successfully",
 		logger.String("host", store.Settings.Output.MySQL.Host),
 		logger.String("database", store.Settings.Output.MySQL.Database))
-
-	store.DB = nil
 	return nil
 }
 

--- a/internal/datastore/retry_test.go
+++ b/internal/datastore/retry_test.go
@@ -96,6 +96,17 @@ func TestRetryOnLock(t *testing.T) {
 			expectError:   false,
 		},
 		{
+			name: "retries on database is closed",
+			fn: func(calls *int) error {
+				if *calls < 3 {
+					return fmt.Errorf("sql: database is closed")
+				}
+				return nil
+			},
+			expectedCalls: 3,
+			expectError:   false,
+		},
+		{
 			name: "retries on SQLITE_BUSY",
 			fn: func(calls *int) error {
 				if *calls < 2 {
@@ -201,6 +212,8 @@ func TestIsTransientDBError(t *testing.T) {
 		{name: "resource busy", err: fmt.Errorf("resource busy"), expected: true},
 		{name: "deadlock detected", err: fmt.Errorf("deadlock detected"), expected: true},
 		{name: "lock wait timeout", err: fmt.Errorf("lock wait timeout exceeded"), expected: true},
+		{name: "database is closed", err: fmt.Errorf("sql: database is closed"), expected: true},
+		{name: "wrapped database is closed", err: fmt.Errorf("query failed: %w", fmt.Errorf("sql: database is closed")), expected: true},
 		{name: "unrelated error", err: fmt.Errorf("connection refused"), expected: false},
 		{name: "wrapped database locked", err: fmt.Errorf("tx failed: %w", fmt.Errorf("database is locked")), expected: true},
 		{name: "double wrapped SQLITE_BUSY", err: fmt.Errorf("outer: %w", fmt.Errorf("inner: %w", fmt.Errorf("SQLITE_BUSY"))), expected: true},

--- a/internal/datastore/sqlite.go
+++ b/internal/datastore/sqlite.go
@@ -431,9 +431,10 @@ func (s *SQLiteStore) Close() error {
 			return err
 		}
 
-		// Log successful closure
 		GetLogger().Info("SQLite database closed successfully",
 			logger.String("path", s.Settings.Output.SQLite.Path))
+
+		s.DB = nil
 		return nil
 	}
 	return nil

--- a/internal/datastore/sqlite.go
+++ b/internal/datastore/sqlite.go
@@ -424,7 +424,10 @@ func (s *SQLiteStore) Close() error {
 				Build()
 		}
 
-		if err := sqlDB.Close(); err != nil {
+		err = sqlDB.Close()
+		s.DB = nil
+
+		if err != nil {
 			GetLogger().Error("Failed to close SQLite database",
 				logger.String("path", s.Settings.Output.SQLite.Path),
 				logger.Error(err))
@@ -433,8 +436,6 @@ func (s *SQLiteStore) Close() error {
 
 		GetLogger().Info("SQLite database closed successfully",
 			logger.String("path", s.Settings.Output.SQLite.Path))
-
-		s.DB = nil
 		return nil
 	}
 	return nil

--- a/internal/datastore/v2/manager.go
+++ b/internal/datastore/v2/manager.go
@@ -549,11 +549,9 @@ func (m *SQLiteManager) Close() error {
 	if err != nil {
 		return fmt.Errorf("failed to get underlying database: %w", err)
 	}
-	if err := sqlDB.Close(); err != nil {
-		return err
-	}
+	err = sqlDB.Close()
 	m.db = nil
-	return nil
+	return err
 }
 
 // CheckpointWAL forces a checkpoint of the Write-Ahead Log to ensure all changes

--- a/internal/datastore/v2/manager.go
+++ b/internal/datastore/v2/manager.go
@@ -541,6 +541,10 @@ func (m *SQLiteManager) Path() string {
 func (m *SQLiteManager) Close() error {
 	m.StopPeriodicCheckpoint()
 
+	if m.db == nil {
+		return nil
+	}
+
 	sqlDB, err := m.db.DB()
 	if err != nil {
 		return fmt.Errorf("failed to get underlying database: %w", err)

--- a/internal/datastore/v2/manager.go
+++ b/internal/datastore/v2/manager.go
@@ -545,7 +545,11 @@ func (m *SQLiteManager) Close() error {
 	if err != nil {
 		return fmt.Errorf("failed to get underlying database: %w", err)
 	}
-	return sqlDB.Close()
+	if err := sqlDB.Close(); err != nil {
+		return err
+	}
+	m.db = nil
+	return nil
 }
 
 // CheckpointWAL forces a checkpoint of the Write-Ahead Log to ensure all changes

--- a/internal/datastore/v2/manager_test.go
+++ b/internal/datastore/v2/manager_test.go
@@ -706,7 +706,21 @@ func TestValidateV2SchemaIntegrity_PassesCleanSchema(t *testing.T) {
 	err = mgr.Initialize()
 	require.NoError(t, err)
 
-	// Run validation on a clean schema — should pass with no error
+	// Run validation on a clean schema - should pass with no error
 	err = mgr.validateV2SchemaIntegrity()
 	require.NoError(t, err)
+}
+
+func TestSQLiteManager_Close_NilsOutDB(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	mgr, err := NewSQLiteManager(Config{DataDir: tmpDir})
+	require.NoError(t, err)
+
+	require.NotNil(t, mgr.DB(), "DB should be non-nil before Close")
+
+	err = mgr.Close()
+	require.NoError(t, err)
+
+	assert.Nil(t, mgr.DB(), "DB should be nil after Close to prevent stale reference queries")
 }


### PR DESCRIPTION
## Summary

- Add `database is closed` to the `lockPattern` regex in `errors_helper.go` so `IsTransientDBError()` returns true and retry logic kicks in during connection pool recycling (e.g., settings reload)
- Nil out the DB handle in `Close()` for `SQLiteStore`, `MySQLStore`, and v2 `SQLiteManager` to prevent stale references from querying a closed connection pool
- Add tests for transient error classification, retry behavior, and Close() nil-out for both legacy and v2 datastores

Fixes the `sql: database is closed` errors observed in Sentry (BIRDNET-GO-1SF) during normal operation after ~3.4 hours of uptime. The root cause: the error was not classified as transient, so no retry was attempted, and the DB handle was not cleared after close, leaving goroutines with stale references.

## Test plan

- [x] `TestIsTransientDBError` - verifies "database is closed" (plain and wrapped) is classified as transient
- [x] `TestRetryOnLock` - verifies retry succeeds after "database is closed" errors
- [x] `TestSQLiteStore_Close_NilsOutDB` - verifies legacy SQLite Close() nils DB handle
- [x] `TestSQLiteManager_Close_NilsOutDB` - verifies v2 manager Close() nils DB handle
- [x] `TestSQLiteStore_ClosedDB_QueryReturnsClosedError` - verifies real closed-pool error is classified as transient
- [x] `TestRetryOnLock_RetriesAfterDatabaseClosed` - verifies full retry path succeeds
- [x] All 343 datastore + v2 tests pass with `-race`
- [x] E2E tests pass (settings-roundtrip, config-integrity, alert-rules)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of “database is closed” so retry logic treats it as transient
  * Enhanced connection shutdown to clear stale DB references and unify logging (SQLite & MySQL)
  * Manager shutdown now stops WAL checkpointing and guards against nil DBs

* **Tests**
  * Expanded coverage for close/retry scenarios (including retry-after-closed cases)
  * Added tests ensuring stores/managers nil out DB handles after close and schema-validation check
<!-- end of auto-generated comment: release notes by coderabbit.ai -->