### PR TITLE
fix(build): use go.mod as single source of truth for Go version

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -171,7 +171,7 @@
 	},
 	"features": {
 		"ghcr.io/devcontainers/features/go:1": {
-			"version": "1.25.3"
+			"version": "1.26"
 		},
 		"ghcr.io/devcontainers/features/node:1": {
 			"version": "24",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -170,6 +170,7 @@
 		}
 	},
 	"features": {
+		// Keep in sync with the go directive in go.mod
 		"ghcr.io/devcontainers/features/go:1": {
 			"version": "1.26"
 		},

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -22,11 +22,10 @@ if [ ! -f "$TENSORFLOW_DIR/tensorflow/lite/c/c_api.h" ]; then
     mkdir -p /home/dev-user/src
     
     # Clone with filter to minimize download size
-    git clone --branch $TFLITE_VERSION --filter=blob:none --depth 1 https://github.com/tensorflow/tensorflow.git $TENSORFLOW_DIR
+    git clone --branch $TFLITE_VERSION --filter=blob:none --no-checkout --depth 1 https://github.com/tensorflow/tensorflow.git $TENSORFLOW_DIR
     
     # Setup sparse checkout to only get header files
-    git -C $TENSORFLOW_DIR config core.sparseCheckout true
-    echo "**/*.h" >> $TENSORFLOW_DIR/.git/info/sparse-checkout
+    git -C $TENSORFLOW_DIR sparse-checkout set --no-cone '**/*.h'
     
     # Apply sparse checkout
     git -C $TENSORFLOW_DIR checkout

--- a/.github/workflows/frontend-e2e-test.yml
+++ b/.github/workflows/frontend-e2e-test.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26'
+          go-version-file: 'go.mod'
           cache: true
 
       - name: Setup TensorFlow Lite

--- a/.github/workflows/frontend-integration-test.yml
+++ b/.github/workflows/frontend-integration-test.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26'
+          go-version-file: 'go.mod'
           cache: true
 
       - name: Setup TensorFlow Lite

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26'
+          go-version-file: 'go.mod'
           cache: true
       - run: go version
 

--- a/.github/workflows/golangci-test.yml
+++ b/.github/workflows/golangci-test.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26'
+          go-version-file: 'go.mod'
           cache: true
       - run: go version
 
@@ -170,7 +170,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26'
+          go-version-file: 'go.mod'
           cache: true
 
       - name: Setup TensorFlow Lite
@@ -200,7 +200,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26'
+          go-version-file: 'go.mod'
           cache: true
 
       - name: Run quick integration tests

--- a/.github/workflows/golangci-test.yml
+++ b/.github/workflows/golangci-test.yml
@@ -40,10 +40,11 @@ jobs:
       - name: Setup TensorFlow Lite
         uses: ./.github/actions/setup-tensorflow
 
-      - name: Install FFmpeg and test dependencies
+      - name: Install FFmpeg, SoX, and test dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y ffmpeg procps
+          # sox is required -- without it, audiocore/ffmpeg and spectrogram tests silently skip
+          sudo apt-get install -y ffmpeg sox procps
 
       - name: Cache Go tools
         uses: actions/cache@v5

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26'
+          go-version-file: 'go.mod'
           check-latest: true
 
       - name: Install Linux system dependencies

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26'
+          go-version-file: 'go.mod'
           check-latest: true
 
       - name: Install Linux system dependencies

--- a/.github/workflows/reverse-proxy-test.yml
+++ b/.github/workflows/reverse-proxy-test.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26'
+          go-version-file: 'go.mod'
           cache: true
 
       - name: Setup TensorFlow Lite

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -115,7 +115,7 @@ BirdNET-Go is a self-contained application for real-time bird sound identificati
 
 ### Core Technologies
 
-**Go 1.25+**
+**Go (version specified in `go.mod`)**
 
 - Modern, statically-typed compiled language
 - Excellent concurrency primitives (goroutines, channels)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,7 +107,7 @@ Before contributing:
 
 **Requirements:**
 
-- Go 1.25+
+- Go (version specified in `go.mod`)
 - Node.js 22.x+ (LTS)
 - Build tools (gcc, git, wget)
 - TensorFlow Lite C library (auto-downloaded)
@@ -148,7 +148,7 @@ task setup-dev
 
 The `setup-dev` task installs:
 
-- Go 1.25.3, Node.js LTS, build tools
+- Go (version from `go.mod`), Node.js LTS, build tools
 - golangci-lint, air, frontend dependencies
 - Playwright browsers, git hooks (Husky)
 
@@ -157,9 +157,7 @@ The `setup-dev` task installs:
 **Step 3: Start Developing**
 
 ```bash
-task              # Build project
-task dev_server   # Hot reload development
-air realtime      # Realtime mode with hot reload
+air realtime      # Hot reload dev server (or: task dev_server)
 ```
 
 ### Option 2: Dev Container (VS Code)
@@ -210,10 +208,11 @@ task dev_server       # Full development server
 
 **What Air does:**
 
-- Watches Go, Svelte, TypeScript, CSS files
-- Rebuilds frontend (Svelte + Tailwind)
-- Recompiles Go binary with embedded frontend
+- Watches `.go` files for changes
+- Recompiles Go binary with the previously built frontend
 - Restarts server automatically
+
+**Note:** Air does not build the frontend. Run `task frontend-build` first (already done by `task setup-dev`), or use `task frontend-watch` in a separate terminal for ongoing frontend changes.
 
 ### Frontend Development
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -220,10 +220,10 @@ The frontend can be developed in two modes:
 
 **Option A: Embedded Mode (Recommended for backend changes)**
 
-Use `air` or `task dev_server` - frontend is rebuilt and embedded in Go binary:
+Use `air` or `task dev_server` - Go binary is recompiled with the previously built frontend on each change:
 
 ```bash
-air realtime          # Hot reload for Go + frontend rebuild
+air realtime          # Hot reload for Go changes
 task dev_server       # Full development server
 ```
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -202,6 +202,9 @@ tasks:
             unzip \
             ca-certificates
 
+          # Audio tools for full test coverage (spectrogram, audio duration, clip export)
+          $SUDO apt-get install -y ffmpeg sox
+
           # Install Go if not present or version is too old
           # Version comes from go.mod via Taskfile var
           GO_VERSION="{{.GO_VERSION}}"
@@ -322,8 +325,8 @@ tasks:
           # Update homebrew
           brew update
 
-          # Install base tools
-          brew install git wget curl
+          # Install base tools and audio dependencies
+          brew install git wget curl ffmpeg sox
 
           # Install Go with version checking
           # Version comes from go.mod via Taskfile var
@@ -590,6 +593,19 @@ tasks:
           echo "   Install with: cd frontend && npx playwright install --with-deps chromium"
         fi
         cd ..
+
+        # Audio tools (optional but needed for full test coverage)
+        if command -v ffmpeg >/dev/null 2>&1; then
+          echo "✅ FFmpeg: $(ffmpeg -version 2>&1 | head -n1)"
+        else
+          echo "⚠️  FFmpeg: not found (audio export and clip tests will be skipped)"
+        fi
+
+        if command -v sox >/dev/null 2>&1; then
+          echo "✅ SoX: $(sox --version 2>&1 | head -n1)"
+        else
+          echo "⚠️  SoX: not found (spectrogram and audio duration tests will be skipped)"
+        fi
 
         echo ""
         echo "✅ All required tools are installed"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -21,6 +21,9 @@ vars:
     sh: uname -s
   UNAME_M:
     sh: uname -m
+  # Go version from go.mod (single source of truth)
+  GO_VERSION:
+    sh: awk '/^go /{print $2; found=1} END{if(!found) exit 1}' go.mod
   # Common build flags
   CGO_FLAGS: CGO_ENABLED=1 CGO_CFLAGS="-I$HOME/src/tensorflow"
   BUILD_FLAGS: -ldflags "-s -w -X 'main.buildDate={{.BUILD_DATE}}' -X 'main.version={{.VERSION}}'"
@@ -138,7 +141,7 @@ tasks:
         echo "    - macOS: Homebrew must be installed first"
         echo ""
         echo "This will install:"
-        echo "  • Go 1.25.3"
+        echo "  • Go {{.GO_VERSION}}"
         echo "  • Node.js LTS"
         echo "  • Build tools (gcc, git, wget, etc.)"
         echo "  • Go dev tools (golangci-lint, air)"
@@ -153,7 +156,9 @@ tasks:
       - task: detect-and-install-deps
       - task: install-go-tools
       - task: setup-frontend-dev
+      - task: frontend-build
       - task: check-tensorflow
+      - task: check-tflite-lib
       - task: verify-dev-setup
       - |
         echo ""
@@ -161,10 +166,8 @@ tasks:
         echo ""
         echo "⚠️  If Go was just installed, run: source ~/.profile"
         echo ""
-        echo "Next steps:"
-        echo "  1. Run 'task' to build the project"
-        echo "  2. Run 'task dev_server' for development with hot reload"
-        echo "  3. Run 'air realtime' for hot reload with realtime analysis"
+        echo "Start developing:"
+        echo "  air realtime       # Hot reload dev server (or: task dev_server)"
         echo ""
 
   detect-and-install-deps:
@@ -200,8 +203,9 @@ tasks:
             ca-certificates
 
           # Install Go if not present or version is too old
-          REQUIRED_GO_VERSION="1.25"
-          GO_VERSION="1.25.3"
+          # Version comes from go.mod via Taskfile var
+          GO_VERSION="{{.GO_VERSION}}"
+          REQUIRED_GO_MINOR=$(echo "$GO_VERSION" | cut -d. -f1,2)
           INSTALL_GO=false
 
           if ! command -v go >/dev/null 2>&1; then
@@ -212,13 +216,13 @@ tasks:
             CURRENT_GO_MINOR=$(echo "$CURRENT_GO_VERSION" | cut -d. -f1,2)
 
             case "$CURRENT_GO_MINOR" in
-              ${REQUIRED_GO_VERSION}*)
+              ${REQUIRED_GO_MINOR}*)
                 echo "✅ Go ${CURRENT_GO_VERSION} is already installed (meets requirement)"
                 ;;
               *)
-                echo "⚠️  Go ${CURRENT_GO_VERSION} found, but Go ${REQUIRED_GO_VERSION}.x required"
+                echo "⚠️  Go ${CURRENT_GO_VERSION} found, but Go ${REQUIRED_GO_MINOR}.x required"
                 echo "   Current: ${CURRENT_GO_VERSION}"
-                echo "   Required: ${REQUIRED_GO_VERSION}.x"
+                echo "   Required: ${REQUIRED_GO_MINOR}.x"
                 echo ""
                 printf "   Upgrade to Go ${GO_VERSION}? (y/N) "
                 read REPLY
@@ -322,7 +326,9 @@ tasks:
           brew install git wget curl
 
           # Install Go with version checking
-          REQUIRED_GO_VERSION="1.25"
+          # Version comes from go.mod via Taskfile var
+          GO_VERSION="{{.GO_VERSION}}"
+          REQUIRED_GO_MINOR=$(echo "$GO_VERSION" | cut -d. -f1,2)
           INSTALL_GO=false
 
           if ! command -v go >/dev/null 2>&1; then
@@ -333,15 +339,15 @@ tasks:
             CURRENT_GO_MINOR=$(echo "$CURRENT_GO_VERSION" | cut -d. -f1,2)
 
             case "$CURRENT_GO_MINOR" in
-              ${REQUIRED_GO_VERSION}*)
+              ${REQUIRED_GO_MINOR}*)
                 echo "✅ Go ${CURRENT_GO_VERSION} is already installed (meets requirement)"
                 ;;
               *)
-                echo "⚠️  Go ${CURRENT_GO_VERSION} found, but Go ${REQUIRED_GO_VERSION}.x required"
+                echo "⚠️  Go ${CURRENT_GO_VERSION} found, but Go ${REQUIRED_GO_MINOR}.x required"
                 echo "   Current: ${CURRENT_GO_VERSION}"
-                echo "   Required: ${REQUIRED_GO_VERSION}.x"
+                echo "   Required: ${REQUIRED_GO_MINOR}.x"
                 echo ""
-                printf "   Upgrade to Go ${REQUIRED_GO_VERSION}? (y/N) "
+                printf "   Upgrade to Go ${REQUIRED_GO_MINOR}? (y/N) "
                 read REPLY
                 case "$REPLY" in
                   [Yy]|[Yy][Ee][Ss]) INSTALL_GO=true ;;
@@ -352,19 +358,18 @@ tasks:
           fi
 
           if [ "$INSTALL_GO" = true ]; then
-            echo "📥 Installing Go ${REQUIRED_GO_VERSION}..."
+            echo "📥 Installing Go ${REQUIRED_GO_MINOR}..."
             # Try versioned formula first, fallback to latest
-            if brew install go@1.25 2>/dev/null; then
-              echo "✅ Go 1.25.x installed via go@1.25"
-              # Link the versioned formula
-              brew link go@1.25 || true
+            if brew install "go@${REQUIRED_GO_MINOR}" 2>/dev/null; then
+              echo "✅ Go ${REQUIRED_GO_MINOR}.x installed via go@${REQUIRED_GO_MINOR}"
+              brew link "go@${REQUIRED_GO_MINOR}" || true
             else
-              echo "⚠️  go@1.25 formula not available, installing latest Go"
+              echo "⚠️  go@${REQUIRED_GO_MINOR} formula not available, installing latest Go"
               brew install go
               INSTALLED_VERSION=$(go version | awk '{print $3}' | sed 's/go//')
               echo "✅ Go ${INSTALLED_VERSION} installed"
               case "$INSTALLED_VERSION" in
-                ${REQUIRED_GO_VERSION}*) ;;
+                ${REQUIRED_GO_MINOR}*) ;;
                 *) echo "⚠️  Installed version may not match project requirements" ;;
               esac
             fi
@@ -488,18 +493,18 @@ tasks:
         echo "🔍 Verifying development environment..."
         echo ""
 
-        # Check Go with version validation
-        REQUIRED_GO_VERSION="1.25"
+        # Check Go with version validation (from go.mod)
+        REQUIRED_GO_MINOR=$(echo "{{.GO_VERSION}}" | cut -d. -f1,2)
         if command -v go >/dev/null 2>&1; then
           CURRENT_GO_VERSION=$(go version | awk '{print $3}' | sed 's/go//')
           CURRENT_GO_MINOR=$(echo "$CURRENT_GO_VERSION" | cut -d. -f1,2)
 
           case "$CURRENT_GO_MINOR" in
-            ${REQUIRED_GO_VERSION}*)
-              echo "✅ Go: ${CURRENT_GO_VERSION} (meets ${REQUIRED_GO_VERSION}.x requirement)"
+            ${REQUIRED_GO_MINOR}*)
+              echo "✅ Go: ${CURRENT_GO_VERSION} (meets ${REQUIRED_GO_MINOR}.x requirement)"
               ;;
             *)
-              echo "❌ Go: ${CURRENT_GO_VERSION} found, but ${REQUIRED_GO_VERSION}.x required"
+              echo "❌ Go: ${CURRENT_GO_VERSION} found, but ${REQUIRED_GO_MINOR}.x required"
               echo "   Current version does not match project requirements"
               echo "   Run 'task setup-dev' to install the correct version"
               exit 1
@@ -606,15 +611,48 @@ tasks:
           echo "TensorFlow Lite C API header not found. Cloning TensorFlow source..."
           mkdir -vp $HOME/src
           echo "Cloning TensorFlow source..."
-          git clone --branch {{.TFLITE_VERSION}} --filter=blob:none --depth 1 https://github.com/tensorflow/tensorflow.git $HOME/src/tensorflow
+          git clone --branch {{.TFLITE_VERSION}} --filter=blob:none --no-checkout --depth 1 https://github.com/tensorflow/tensorflow.git $HOME/src/tensorflow
           echo "Setting up sparse checkout..."
-          git -C $HOME/src/tensorflow config core.sparseCheckout true
-          echo "**/*.h" >> $HOME/src/tensorflow/.git/info/sparse-checkout
+          git -C $HOME/src/tensorflow sparse-checkout set --no-cone '**/*.h'
           echo "Checking out TensorFlow source..."
           git -C $HOME/src/tensorflow checkout
         else
           echo "TensorFlow headers already exist at version {{.TFLITE_VERSION}}"
         fi
+
+  check-tflite-lib:
+    desc: Download TensorFlow Lite C library for the current platform
+    internal: true
+    cmds:
+      - task: download-tflite
+        vars:
+          TFLITE_LIB_DIR:
+            sh: |
+              if [ "{{.UNAME_S}}" = "Darwin" ]; then
+                if [ "{{.UNAME_M}}" = "arm64" ]; then
+                  echo "/opt/homebrew/lib"
+                else
+                  echo "/usr/local/lib"
+                fi
+              else
+                echo "{{.SYSTEM_LIB_DIR_AMD64}}"
+              fi
+          TFLITE_LIB_ARCH:
+            sh: |
+              case "{{.UNAME_S}}_{{.UNAME_M}}" in
+                Linux_x86_64) echo "linux_amd64.tar.gz";;
+                Linux_aarch64) echo "linux_arm64.tar.gz";;
+                Darwin_x86_64) echo "darwin_amd64.tar.gz";;
+                Darwin_arm64) echo "darwin_arm64.tar.gz";;
+              esac
+          TARGET:
+            sh: |
+              case "{{.UNAME_S}}_{{.UNAME_M}}" in
+                Linux_x86_64) echo "linux_amd64";;
+                Linux_aarch64) echo "linux_arm64";;
+                Darwin_x86_64) echo "darwin_amd64";;
+                Darwin_arm64) echo "darwin_arm64";;
+              esac
 
   dev_server:
     cmds:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -644,30 +644,30 @@ tasks:
         vars:
           TFLITE_LIB_DIR:
             sh: |
-              if [ "{{.UNAME_S}}" = "Darwin" ]; then
-                if [ "{{.UNAME_M}}" = "arm64" ]; then
-                  echo "/opt/homebrew/lib"
-                else
-                  echo "/usr/local/lib"
-                fi
-              else
-                echo "{{.SYSTEM_LIB_DIR_AMD64}}"
-              fi
+              case "{{.UNAME_S}}_{{.UNAME_M}}" in
+                Darwin_arm64) echo "/opt/homebrew/lib";;
+                Darwin_*) echo "/usr/local/lib";;
+                Linux_aarch64|Linux_arm64) echo "{{.SYSTEM_LIB_DIR_ARM64}}";;
+                Linux_*) echo "{{.SYSTEM_LIB_DIR_AMD64}}";;
+                *) echo "unsupported platform: {{.UNAME_S}}_{{.UNAME_M}}" >&2; exit 1;;
+              esac
           TFLITE_LIB_ARCH:
             sh: |
               case "{{.UNAME_S}}_{{.UNAME_M}}" in
                 Linux_x86_64) echo "linux_amd64.tar.gz";;
-                Linux_aarch64) echo "linux_arm64.tar.gz";;
+                Linux_aarch64|Linux_arm64) echo "linux_arm64.tar.gz";;
                 Darwin_x86_64) echo "darwin_amd64.tar.gz";;
                 Darwin_arm64) echo "darwin_arm64.tar.gz";;
+                *) echo "unsupported platform: {{.UNAME_S}}_{{.UNAME_M}}" >&2; exit 1;;
               esac
           TARGET:
             sh: |
               case "{{.UNAME_S}}_{{.UNAME_M}}" in
                 Linux_x86_64) echo "linux_amd64";;
-                Linux_aarch64) echo "linux_arm64";;
+                Linux_aarch64|Linux_arm64) echo "linux_arm64";;
                 Darwin_x86_64) echo "darwin_amd64";;
                 Darwin_arm64) echo "darwin_arm64";;
+                *) echo "unsupported platform: {{.UNAME_S}}_{{.UNAME_M}}" >&2; exit 1;;
               esac
 
   dev_server:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -67,16 +67,14 @@ tasks:
     desc: Run golangci-lint with TensorFlow CGO flags
     cmds:
       - |
-        # Determine library path based on OS
-        if [ "{{.UNAME_S}}" = "Darwin" ]; then
-          if [ "{{.UNAME_M}}" = "arm64" ]; then
-            LIB_DIR="/opt/homebrew/lib"
-          else
-            LIB_DIR="/usr/local/lib"
-          fi
-        else
-          LIB_DIR="/usr/lib"
-        fi
+        # Determine library path based on OS and architecture
+        case "{{.UNAME_S}}_{{.UNAME_M}}" in
+          Darwin_arm64) LIB_DIR="/opt/homebrew/lib";;
+          Darwin_*) LIB_DIR="/usr/local/lib";;
+          Linux_aarch64|Linux_arm64) LIB_DIR="{{.SYSTEM_LIB_DIR_ARM64}}";;
+          Linux_*) LIB_DIR="{{.SYSTEM_LIB_DIR_AMD64}}";;
+          *) echo "unsupported platform: {{.UNAME_S}}_{{.UNAME_M}}" >&2; exit 1;;
+        esac
         # Use noembed,skipfrontend tags to skip model and frontend embedding for faster linting
         {{.CGO_FLAGS}} CGO_LDFLAGS="-L${LIB_DIR} -ltensorflowlite_c" \
         golangci-lint run --build-tags=noembed,skipfrontend {{.CLI_ARGS}}


### PR DESCRIPTION
Hello thank you for maintaining this. I am a new user and tried to follow the contributing doc (in my case, on ubuntu 22.04 but I don't think that is a large factor) but ran into a few issues. Hopefully this helps future folx getting started. The goal for this was to "get task setup-dev to setup dev". There were multiple pieces that seemed broken though, so it could be broken up accordingly if that is preferred.

* first ran into issues because the task dev setup wanted an older version of golang than i had (and it turned out was older than the project expected).
* i saw that some workflows already used the go.mod version parsing and some didn't, so unified that where possible to minimize manual work in the future. unfortunately the devcontainer doesn't have a clean way of doing it and needs to be manually specified, but i think everything else now reads from the go.mod successfully.
* checking out the tensorflow headers broke on the first run, so updated how they are checked out
* starting the air server failed for me because the frontend wasn't build yet, which seems intentional so updated the steps to make sure they are called
* then the tf shared lib also wasn't downloaded so it failed (only downloaded by full build) -- added a step to  make sure this is downloaded as well. it looks a little gnarly to support the different archs
* then trying to run tests, my dev env didnt have ffmpeg or SoX installed, so tests were skipped and there were a lot of warnings in the logs. this doesn't seem intentional, since they are actual dev dependencies, so this adds them as well
* the output of task setup-dev and the docs at least to this newcomer made it seem like there were multiple similar options -- task dev_server vs air realtime when one is just an alias of the other. so simplified those


I tested this by removing the tf headers, doing a fresh clone of this branch, and running `task setup-dev` then `air realtime` and verified it loaded cleanly



clanker generated pr desc below

---


## Summary

- Make `go.mod` the single source of truth for the Go version, eliminating version drift across Taskfile, CI, devcontainer, and docs
- Fix TensorFlow sparse checkout that fails on fresh `task setup-dev`
- Fix `setup-dev` so `air realtime` works immediately after setup (missing frontend build step)
- Install FFmpeg and SoX as part of `setup-dev` and CI so audio-related tests actually run
- Fix `check-tflite-lib` and `lint` tasks to handle Linux ARM64 correctly
- Consistency fixes for CONTRIBUTING.md and devcontainer.json

## What changed

**Go version management:** The Go version was hardcoded as `1.25` / `1.25.3` in the Taskfile, while `go.mod` and the Dockerfile already use `1.26.1`. Instead of bumping the number everywhere, the Taskfile now reads the version dynamically from `go.mod` via `awk '/^go /{print $2}' go.mod`. All 7 GitHub Actions workflows (9 occurrences) now use `go-version-file: 'go.mod'` instead of `go-version: '1.26'`. Next time `go.mod` is bumped, everything follows automatically.

**TensorFlow sparse checkout:** `git clone --filter=blob:none --depth 1` does not create `.git/info/`, so `echo >> .git/info/sparse-checkout` fails. Replaced the manual `core.sparseCheckout` + file write with `git sparse-checkout set --no-cone '**/*.h'`, which handles directory creation internally. Same fix applied in both `Taskfile.yml` and `.devcontainer/postCreateCommand.sh`.

**setup-dev + air:** `task setup-dev` installed frontend npm dependencies but never ran `task frontend-build`, so `air realtime` immediately failed with `pattern all:dist: no matching files found`. Added `frontend-build` as a step in `setup-dev`. Also corrected the CONTRIBUTING.md "What Air does" section -- air only watches `.go` files and does not build the frontend. Fixed "Option A: Embedded Mode" to be consistent with this (it previously implied air rebuilds the frontend).

**Audio tools (FFmpeg + SoX):** Without SoX on PATH, every test that loads config emits `WARN [config] SoX not found in system PATH`, and 4 tests silently skip (3 in `audiocore/ffmpeg/common_test.go`, 1 in `spectrogram/helpers_test.go`). The CI unit-tests job installed FFmpeg but not SoX, and the testcontainer-tests job (which does install SoX) doesn't run `audiocore/ffmpeg` -- so those 3 tests never executed anywhere. Added both tools to `detect-and-install-deps` (Linux apt + macOS brew), soft version checks to `verify-dev-setup`, and SoX to the CI unit-tests apt install line.

**ARM64 TFLite library path:** Both `check-tflite-lib` and the `lint` task unconditionally used `SYSTEM_LIB_DIR_AMD64` (`/usr/lib`) for all Linux hosts. On ARM64, this placed/looked for the TFLite library in the wrong directory instead of `SYSTEM_LIB_DIR_ARM64` (`/usr/aarch64-linux-gnu/lib`). Switched both to case statements matching `aarch64` and `arm64` uname variants, with unsupported-platform error fallbacks.

**devcontainer.json:** Added a comment noting the Go version must be manually synced with `go.mod` (devcontainer features can't read it dynamically).

## Test plan (manual)

- Clone fresh, run `task setup-dev`, verify it completes (includes frontend build + TensorFlow headers + ffmpeg/sox)
- Run `air realtime` immediately after -- verify the Go binary compiles and starts
- Confirm CI workflows that run on this PR (if any trigger) resolve Go correctly from `go.mod`
- Verify `verify-dev-setup` reports FFmpeg and SoX versions
- Confirm CI unit-tests no longer skip the SoX-dependent tests in `audiocore/ffmpeg/common_test.go`
- On ARM64 Linux: verify `task lint` resolves TFLite from the correct lib dir

**Follow-up:** Consider adding a CI workflow that exercises the contributing guide setup steps (`task setup-dev` + build) to catch drift automatically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded Go toolchain version management to use repository configuration instead of hardcoded versions.
  * Optimized TensorFlow setup process with improved sparse-checkout workflow.

* **Documentation**
  * Updated development environment requirements and setup instructions.
  * Clarified hot reload behavior for local development.
  * Added system dependencies (ffmpeg, sox) to setup guidance.

* **Refactor**
  * Streamlined development setup task execution order.
  * Enhanced platform-specific build configuration detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->