### PR TITLE
fix(build): set CGO env vars in test and test-coverage tasks

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -38,12 +38,9 @@ tasks:
   # Task for running tests
   test:
     desc: Run tests for the application
-    env:
-      CGO_ENABLED: "1"
-      CGO_CFLAGS: "-I{{.HOME}}/src/tensorflow"
     cmds:
       # Use noembed,skipfrontend tags to skip model and frontend embedding for faster tests
-      - go test -tags noembed,skipfrontend ./... {{.TEST_FLAGS}}
+      - {{.CGO_FLAGS}} go test -tags noembed,skipfrontend ./... {{.TEST_FLAGS}}
     vars:
       TEST_FLAGS: '{{default "" .CLI_ARGS}}'
 
@@ -57,13 +54,10 @@ tasks:
   # Task for running tests with coverage report
   test-coverage:
     desc: Run tests with coverage report
-    env:
-      CGO_ENABLED: "1"
-      CGO_CFLAGS: "-I{{.HOME}}/src/tensorflow"
     cmds:
       - mkdir -p coverage
       # Use noembed,skipfrontend tags to skip model and frontend embedding for faster tests
-      - go test -tags noembed,skipfrontend ./... -coverprofile=coverage/coverage.out {{.TEST_FLAGS}}
+      - {{.CGO_FLAGS}} go test -tags noembed,skipfrontend ./... -coverprofile=coverage/coverage.out {{.TEST_FLAGS}}
       - go tool cover -html=coverage/coverage.out -o coverage/coverage.html
     vars:
       TEST_FLAGS: '{{default "" .CLI_ARGS}}'

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -40,7 +40,7 @@ tasks:
     desc: Run tests for the application
     cmds:
       # Use noembed,skipfrontend tags to skip model and frontend embedding for faster tests
-      - {{.CGO_FLAGS}} go test -tags noembed,skipfrontend ./... {{.TEST_FLAGS}}
+      - '{{.CGO_FLAGS}} go test -tags noembed,skipfrontend ./... {{.TEST_FLAGS}}'
     vars:
       TEST_FLAGS: '{{default "" .CLI_ARGS}}'
 
@@ -57,7 +57,7 @@ tasks:
     cmds:
       - mkdir -p coverage
       # Use noembed,skipfrontend tags to skip model and frontend embedding for faster tests
-      - {{.CGO_FLAGS}} go test -tags noembed,skipfrontend ./... -coverprofile=coverage/coverage.out {{.TEST_FLAGS}}
+      - '{{.CGO_FLAGS}} go test -tags noembed,skipfrontend ./... -coverprofile=coverage/coverage.out {{.TEST_FLAGS}}'
       - go tool cover -html=coverage/coverage.out -o coverage/coverage.html
     vars:
       TEST_FLAGS: '{{default "" .CLI_ARGS}}'

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -35,6 +35,9 @@ tasks:
   # Task for running tests
   test:
     desc: Run tests for the application
+    env:
+      CGO_ENABLED: "1"
+      CGO_CFLAGS: "-I{{.HOME}}/src/tensorflow"
     cmds:
       # Use noembed,skipfrontend tags to skip model and frontend embedding for faster tests
       - go test -tags noembed,skipfrontend ./... {{.TEST_FLAGS}}
@@ -51,6 +54,9 @@ tasks:
   # Task for running tests with coverage report
   test-coverage:
     desc: Run tests with coverage report
+    env:
+      CGO_ENABLED: "1"
+      CGO_CFLAGS: "-I{{.HOME}}/src/tensorflow"
     cmds:
       - mkdir -p coverage
       # Use noembed,skipfrontend tags to skip model and frontend embedding for faster tests


### PR DESCRIPTION
related to [tphakala/birdnet-go#2930](https://github.com/tphakala/birdnet-go/pull/2930)

once i had task setup-dev finishing successfully, I still could not run `task test` without errors. This copies the test config from other steps into the task commands that were missing so they work now.

clanker generated pr desc below

---

## Summary

`task test` and `task test-coverage` fail out of the box after `task setup-dev` because the `go-tflite` dependency needs `CGO_ENABLED=1` and `CGO_CFLAGS` pointing at the TensorFlow headers. The `lint` task already sets these via the `CGO_FLAGS` variable, but the test tasks were missing them.

Prefixes the `go test` commands with `{{.CGO_FLAGS}}`, reusing the existing variable and matching the pattern used by `lint` and all build tasks.

#2933 builds on this to enable the race detector.

## Test plan

- Ran `task test` locally with `CGO_ENABLED` and `CGO_CFLAGS` unset -- all tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated test tasks so regular tests and coverage runs use consistent build flags, ensuring tests and coverage are executed with the same compilation configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->