### PR TITLE
fix(ci): correct workflow bugs and clean up CI hygiene

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -82,7 +82,7 @@ jobs:
         run: |
           # GitHub Container Registry
           echo "GHCR_REPO=ghcr.io/${GITHUB_REPOSITORY,,}" >> ${GITHUB_ENV}
-          echo "ghcr-repo=ghcr.io/${GITHUB_REPOSITORY,,}" >> $GITHUB_OUTPUT
+          echo "ghcr-repo=${GITHUB_REPOSITORY,,}" >> $GITHUB_OUTPUT
 
           # Docker Hub (extract just the repo name)
           REPO_NAME=$(echo "${GITHUB_REPOSITORY}" | cut -d'/' -f2)
@@ -169,7 +169,6 @@ jobs:
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v7
-        continue-on-error: true
         id: build-push
         with:
           context: .
@@ -440,6 +439,7 @@ jobs:
             fi
           fi
 
+          echo "TEST_IMAGE=$TEST_IMAGE" >> $GITHUB_ENV
           echo "Testing Podman compatibility with image: $TEST_IMAGE"
 
           # Test basic Podman functionality

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -9,12 +9,6 @@ on:
   schedule:
     # Runs at 02:00 UTC every day
     - cron: "0 2 * * *"
-  pull_request:
-    branches:
-      - main
-    paths-ignore:
-      - ".github/workflows/**"
-      - "**.md"
   workflow_dispatch:
   push:
     paths-ignore:

--- a/.github/workflows/golangci-test.yml
+++ b/.github/workflows/golangci-test.yml
@@ -7,13 +7,13 @@ on:
       - '**/*.go'
       - 'go.mod'
       - 'go.sum'
-      - '.golangci.yml'
+      - '.golangci.yaml'
   pull_request:
     paths:
       - '**/*.go'
       - 'go.mod'
       - 'go.sum'
-      - '.golangci.yml'
+      - '.golangci.yaml'
 
 permissions:
   contents: read
@@ -49,7 +49,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/go/bin
-          key: ${{ runner.os }}-go-tools-gotestfmt-v2
+          key: ${{ runner.os }}-go-tools-gotestfmt-v2-${{ hashFiles('go.mod') }}
 
       - name: Set up gotestfmt
         run: |
@@ -210,8 +210,8 @@ jobs:
           go test -tags=integration -short -race -timeout 180s -v ./internal/datastore/v2/migration/... 2>&1
         timeout-minutes: 5
 
-      - name: Run full integration tests (scheduled only)
-        if: github.event_name == 'schedule' || contains(github.event.pull_request.labels.*.name, 'run-full-integration')
+      - name: Run full integration tests (label-gated)
+        if: contains(github.event.pull_request.labels.*.name, 'run-full-integration')
         run: |
           # Run full integration tests including large dataset
           go test -tags=integration -race -timeout 600s -v ./internal/datastore/v2/migration/... 2>&1

--- a/.github/workflows/i18n-validation.yml
+++ b/.github/workflows/i18n-validation.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   validate-translations:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout code

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -3,10 +3,6 @@ name: BirdNET-Go Nightly Build
 on:
   workflow_dispatch:
 
-env:
-  ACTIONS_RUNNER_DEBUG: true
-  ACTIONS_STEP_DEBUG: true
-
 permissions:
   contents: write
   packages: write

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -5,10 +5,6 @@ on:
     types: [created, edited]
   workflow_dispatch:
 
-env:
-  ACTIONS_RUNNER_DEBUG: true
-  ACTIONS_STEP_DEBUG: true
-
 permissions:
   contents: write
   packages: write
@@ -37,6 +33,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Set up Go
         uses: actions/setup-go@v6


### PR DESCRIPTION
I've (unfortunately) been on a CI kick lately and noticed a few things that seemed unintentionally different/broken.


clanker generated pr desc below

---

## Summary

Fixes a batch of correctness bugs and hygiene issues found during CI audit:

- **Path filter typo**: `golangci-test.yml` filtered on `.golangci.yml` but the config file is `.golangci.yaml` — the typo was introduced in ec0f78e3 ("chore: update golangci-lint and golangci-test workflows to trigger on Go file changes", Oct 2025). The file `.golangci.yml` has never existed in this repo, so changes to the linter config never triggered the lint/test workflow. Three golangci-only pushes to main after the typo produced zero `golangci-test` workflow runs:
  - [`7c5ec119`](https://github.com/tphakala/birdnet-go/commit/7c5ec119) — "fix: disable gosec linter in golangci configuration" (Feb 25, 2026)
  - [`efebb058`](https://github.com/tphakala/birdnet-go/commit/efebb058) — "chore(golangci): update linter settings and increase min-complexity threshold" (Dec 20, 2025)
  - [`065db114`](https://github.com/tphakala/birdnet-go/commit/065db114) — "chore(golangci): remove nolintlint from linter configuration" (Dec 16, 2025)

- **Double `ghcr.io/` prefix**: `docker-build-push.yml` (introduced in 99f346c7) sets the output `ghcr-repo=ghcr.io/${GITHUB_REPOSITORY,,}`, but the `cache-from`/`cache-to` lines prepend `ghcr.io/` again, producing `ghcr.io/ghcr.io/tphakala/birdnet-go:buildcache`. This means registry-layer caching is a no-op on every Docker build — the import resolves in 0.3s (no layers), while each export wastes ~30s pushing to the wrong path. Visible in the [2026-05-02 nightly build](https://github.com/tphakala/birdnet-go/actions/runs/25250063164) (`docker / build (linux/amd64)` job, step 8) logs:
  ```
  #13 importing cache manifest from ghcr.io/ghcr.io/tphakala/birdnet-go:buildcache
  #13 inferred cache manifest type: application/vnd.oci.image.manifest.v1+json done
  #13 DONE 0.3s
  ```
  The GHA cache (`#12`) is doing all the real caching work; registry cache has been broken since the workflow was introduced.

- **Dead `schedule` condition**: integration test step checked `github.event_name == 'schedule'` but the workflow has no schedule trigger, making the condition dead code.

- **Swallowed build failures**: `continue-on-error: true` on the Docker build-push step would mask a broken image build. No actual failures have been swallowed in recent history (all Docker builds succeeded), but `continue-on-error` on the core build step means a real failure would be silently ignored and downstream steps (manifest creation, Podman validation) would run against stale or missing images.

- **Unset `$TEST_IMAGE`**: Podman validation's summary step references `$TEST_IMAGE`, but the variable is set in a prior step's shell and never exported via `GITHUB_ENV`. The summary always writes `- Image tested: ` with an empty value. Visible in the [2026-05-02 nightly](https://github.com/tphakala/birdnet-go/actions/runs/25250063164) validate-podman logs — the summary step's env block only contains `GHCR_REPO` and `DOCKERHUB_REPO`, not `TEST_IMAGE`.

- **Debug noise**: `ACTIONS_RUNNER_DEBUG`/`ACTIONS_STEP_DEBUG` were globally hardcoded in nightly ([`dc8541ef`](https://github.com/tphakala/birdnet-go/commit/dc8541ef), Dec 2024 — added while debugging the nightly workflow) and release ([`2b37f1ec`](https://github.com/tphakala/birdnet-go/commit/2b37f1ec), Jan 2025 — added while debugging the release pipeline) builds, generating verbose step-level debug output on every run since. These can be re-enabled on-demand without a code change via the GitHub UI: Settings → Secrets and variables → Actions → Variables → set `ACTIONS_STEP_DEBUG` to `true`. This is the [recommended approach](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/troubleshooting-workflows/enabling-debug-logging) — it lets any maintainer toggle debug logging for a single re-run.

- **Runner pin**: `i18n-validation.yml` used `ubuntu-latest` while all other workflows pin `ubuntu-24.04`.

- **Stale gotestfmt cache**: static cache key `go-tools-gotestfmt-v2` never busted when Go version changed; added `go.mod` hash.

- **PR trigger noise**: `docker-build.yml` triggered on PRs but immediately skipped its only job (the `if:` condition excluded PRs).

- **Shallow clone in release build**: the `build` matrix job in `release-build.yml` checks out with the default `fetch-depth: 1`, but the `workflow_dispatch` path (line 129) runs `git describe --tags --abbrev=0` to find the latest release tag for the GitHub Release upload. In a shallow clone, this would fail or return an incorrect tag. The build version itself is fine (set explicitly via `BUILD_VERSION: ${{ github.ref_name }}`), but the tag lookup for the release artifact upload needs history. Added `fetch-depth: 0` to match the `get-version` job which already does this.

## Test plan

- Workflow YAML only — no application code changes
- Each fix is independently verifiable by reading the diff against the documented bug

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD workflows with improved concurrency handling and reduced debug logging.
  * Enhanced build caching to automatically invalidate when project dependencies change.
  * Updated workflow configurations for consistency and reliability across build environments.
  * Refined build triggers and runner specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->