### PR TITLE
fix(api): resolve data race in Controller.Debug and enable race detector

### DIFF
--- a/.github/workflows/golangci-test.yml
+++ b/.github/workflows/golangci-test.yml
@@ -83,7 +83,7 @@ jobs:
           # Note: We must capture PIPESTATUS immediately after the pipeline
           # gotestfmt may return non-zero even when tests pass, so we only check go test's exit code
           # Use noembed,skipfrontend tags to skip model and frontend embedding requirement
-          go test -tags noembed,skipfrontend -json -v -short -timeout 120s ./... 2>&1 | tee /tmp/gotest.log | gotestfmt -ci github; TEST_EXIT_CODE=${PIPESTATUS[0]}
+          go test -tags noembed,skipfrontend -race -json -v -short -timeout 300s ./... 2>&1 | tee /tmp/gotest.log | gotestfmt -ci github; TEST_EXIT_CODE=${PIPESTATUS[0]}
 
           if [ $TEST_EXIT_CODE -ne 0 ]; then
             echo "::error title=Test Failure::Unit tests failed - see job summary for details"
@@ -106,7 +106,7 @@ jobs:
           fi
 
           echo "## :white_check_mark: All Tests Passed" >> $GITHUB_STEP_SUMMARY
-        timeout-minutes: 5
+        timeout-minutes: 10
 
       - name: Cleanup any remaining processes
         if: always()

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -38,6 +38,9 @@ tasks:
   # Task for running tests
   test:
     desc: Run tests for the application
+    env:
+      CGO_ENABLED: "1"
+      CGO_CFLAGS: "-I{{.HOME}}/src/tensorflow"
     cmds:
       # Use noembed,skipfrontend tags to skip model and frontend embedding for faster tests
       - '{{.CGO_FLAGS}} go test -tags noembed,skipfrontend ./... {{.TEST_FLAGS}}'
@@ -54,6 +57,9 @@ tasks:
   # Task for running tests with coverage report
   test-coverage:
     desc: Run tests with coverage report
+    env:
+      CGO_ENABLED: "1"
+      CGO_CFLAGS: "-I{{.HOME}}/src/tensorflow"
     cmds:
       - mkdir -p coverage
       # Use noembed,skipfrontend tags to skip model and frontend embedding for faster tests

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -43,7 +43,7 @@ tasks:
       CGO_CFLAGS: "-I{{.HOME}}/src/tensorflow"
     cmds:
       # Use noembed,skipfrontend tags to skip model and frontend embedding for faster tests
-      - '{{.CGO_FLAGS}} go test -tags noembed,skipfrontend ./... {{.TEST_FLAGS}}'
+      - '{{.CGO_FLAGS}} go test -tags noembed,skipfrontend -race ./... {{.TEST_FLAGS}}'
     vars:
       TEST_FLAGS: '{{default "" .CLI_ARGS}}'
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -38,11 +38,10 @@ tasks:
   # Task for running tests
   test:
     desc: Run tests for the application
-    env:
-      CGO_ENABLED: "1"
-      CGO_CFLAGS: "-I{{.HOME}}/src/tensorflow"
     cmds:
       # Use noembed,skipfrontend tags to skip model and frontend embedding for faster tests
+      # CGO_FLAGS supplies CGO_ENABLED=1 and the TensorFlow header include path;
+      # -race needs CGO so it must stay enabled here.
       - '{{.CGO_FLAGS}} go test -tags noembed,skipfrontend -race ./... {{.TEST_FLAGS}}'
     vars:
       TEST_FLAGS: '{{default "" .CLI_ARGS}}'
@@ -57,13 +56,11 @@ tasks:
   # Task for running tests with coverage report
   test-coverage:
     desc: Run tests with coverage report
-    env:
-      CGO_ENABLED: "1"
-      CGO_CFLAGS: "-I{{.HOME}}/src/tensorflow"
     cmds:
       - mkdir -p coverage
       # Use noembed,skipfrontend tags to skip model and frontend embedding for faster tests
-      - '{{.CGO_FLAGS}} go test -tags noembed,skipfrontend ./... -coverprofile=coverage/coverage.out {{.TEST_FLAGS}}'
+      # Keep -race in sync with the test task so coverage runs catch data races too.
+      - '{{.CGO_FLAGS}} go test -tags noembed,skipfrontend -race ./... -coverprofile=coverage/coverage.out {{.TEST_FLAGS}}'
       - go tool cover -html=coverage/coverage.out -o coverage/coverage.html
     vars:
       TEST_FLAGS: '{{default "" .CLI_ARGS}}'

--- a/internal/api/v2/api.go
+++ b/internal/api/v2/api.go
@@ -941,16 +941,20 @@ func (c *Controller) HandleErrorForTest(ctx echo.Context, err error, message str
 //
 // Reads the debug flag via conf.GetSettings() rather than c.Settings so the
 // check is race-free against concurrent c.Settings writes in the settings
-// handlers: c.Settings is plain a *conf.Settings field with no locking on
+// handlers: c.Settings is a plain *conf.Settings field with no locking on
 // the Debug read path, while conf.GetSettings() is a lock-free atomic.Load.
-// Falls back to c.Settings when the global snapshot has not been set (tests
-// that inject a standalone Controller without touching the global).
+// Returns silently when the global snapshot has not been set (e.g. in unit
+// tests with a standalone Controller).
 func (c *Controller) Debug(format string, v ...any) {
 	settings := conf.GetSettings()
 	if settings == nil {
-		settings = c.Settings
+		// Skip debug logging when the global snapshot hasn't been set
+		// (e.g. in unit tests with a standalone Controller). Reading
+		// c.Settings here would race with concurrent writes in the
+		// settings update handlers.
+		return
 	}
-	if settings != nil && settings.WebServer.Debug {
+	if settings.WebServer.Debug {
 		msg := fmt.Sprintf(format, v...)
 		c.logDebugIfEnabled(msg)
 	}

--- a/internal/api/v2/api_debug_race_test.go
+++ b/internal/api/v2/api_debug_race_test.go
@@ -1,0 +1,72 @@
+package api
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/conf"
+)
+
+// TestDebugSkipsControllerFallbackWhenGlobalUnset verifies Debug() remains a
+// no-op when conf.GetSettings() is nil, even while c.Settings is being updated
+// concurrently. Run with -race: if Debug() starts reading c.Settings fallback
+// again, the race detector should report a data race.
+func TestDebugSkipsControllerFallbackWhenGlobalUnset(t *testing.T) {
+	previous := conf.GetSettings()
+	conf.SetTestSettings(nil)
+	t.Cleanup(func() {
+		conf.SetTestSettings(previous)
+	})
+
+	controller := &Controller{
+		Settings: newValidTestSettings(),
+	}
+
+	stopWriters := make(chan struct{})
+	var writers sync.WaitGroup
+	for range 4 {
+		writers.Go(func() {
+			for {
+				select {
+				case <-stopWriters:
+					return
+				default:
+					updated := newValidTestSettings()
+					updated.WebServer.Debug = true
+					controller.Settings = updated
+				}
+			}
+		})
+	}
+
+	debugDone := make(chan struct{})
+	go func() {
+		defer close(debugDone)
+		for i := range 5000 {
+			controller.Debug("concurrent debug call %d", i)
+		}
+	}()
+
+	select {
+	case <-debugDone:
+	case <-time.After(2 * time.Second):
+		require.FailNow(t, "Debug did not complete", fmt.Sprintf("timed out waiting for debug loop after %s", 2*time.Second))
+	}
+
+	close(stopWriters)
+
+	writersDone := make(chan struct{})
+	go func() {
+		defer close(writersDone)
+		writers.Wait()
+	}()
+
+	select {
+	case <-writersDone:
+	case <-time.After(2 * time.Second):
+		require.FailNow(t, "Writer goroutines did not stop", fmt.Sprintf("timed out waiting for writers after %s", 2*time.Second))
+	}
+}

--- a/internal/api/v2/api_debug_race_test.go
+++ b/internal/api/v2/api_debug_race_test.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"fmt"
-	"sync"
 	"testing"
 	"time"
 
@@ -25,48 +24,31 @@ func TestDebugSkipsControllerFallbackWhenGlobalUnset(t *testing.T) {
 		Settings: newValidTestSettings(),
 	}
 
-	stopWriters := make(chan struct{})
-	var writers sync.WaitGroup
-	for range 4 {
-		writers.Go(func() {
-			for {
-				select {
-				case <-stopWriters:
-					return
-				default:
-					updated := newValidTestSettings()
-					updated.WebServer.Debug = true
-					controller.Settings = updated
-				}
-			}
-		})
-	}
-
-	debugDone := make(chan struct{})
+	stopWriter := make(chan struct{})
+	writerDone := make(chan struct{})
 	go func() {
-		defer close(debugDone)
-		for i := range 5000 {
-			controller.Debug("concurrent debug call %d", i)
+		defer close(writerDone)
+		for {
+			select {
+			case <-stopWriter:
+				return
+			default:
+				updated := newValidTestSettings()
+				updated.WebServer.Debug = true
+				controller.Settings = updated
+			}
 		}
 	}()
 
-	select {
-	case <-debugDone:
-	case <-time.After(2 * time.Second):
-		require.FailNow(t, "Debug did not complete", fmt.Sprintf("timed out waiting for debug loop after %s", 2*time.Second))
+	for i := range 5000 {
+		controller.Debug("concurrent debug call %d", i)
 	}
 
-	close(stopWriters)
-
-	writersDone := make(chan struct{})
-	go func() {
-		defer close(writersDone)
-		writers.Wait()
-	}()
+	close(stopWriter)
 
 	select {
-	case <-writersDone:
+	case <-writerDone:
 	case <-time.After(2 * time.Second):
-		require.FailNow(t, "Writer goroutines did not stop", fmt.Sprintf("timed out waiting for writers after %s", 2*time.Second))
+		require.FailNow(t, "Writer goroutine did not stop", fmt.Sprintf("timed out waiting for writer after %s", 2*time.Second))
 	}
 }

--- a/internal/api/v2/api_debug_race_test.go
+++ b/internal/api/v2/api_debug_race_test.go
@@ -1,13 +1,16 @@
 package api
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/conf"
 )
+
+// writerStopTimeout bounds how long the test waits for the background writer
+// goroutine to stop before failing.
+const writerStopTimeout = 2 * time.Second
 
 // TestDebugSkipsControllerFallbackWhenGlobalUnset verifies Debug() remains a
 // no-op when conf.GetSettings() is nil, even while c.Settings is being updated
@@ -48,7 +51,7 @@ func TestDebugSkipsControllerFallbackWhenGlobalUnset(t *testing.T) {
 
 	select {
 	case <-writerDone:
-	case <-time.After(2 * time.Second):
-		require.FailNow(t, "Writer goroutine did not stop", fmt.Sprintf("timed out waiting for writer after %s", 2*time.Second))
+	case <-time.After(writerStopTimeout):
+		require.FailNow(t, "Writer goroutine did not stop", "timed out waiting for writer after %s", writerStopTimeout)
 	}
 }


### PR DESCRIPTION
## Summary

Based on #2931 (CGO env vars for test tasks).

- Fixes a data race between `Controller.UpdateSectionSettings` (writes `c.Settings`) and a goroutine spawned by `handleSettingsChanges` that calls `Controller.Debug` (reads `c.Settings` as fallback). The `Debug` method's fallback to `c.Settings` when `conf.GetSettings()` returns nil is removed; it now returns silently, which is safe since it's purely for logging.
- Enables the Go race detector (`-race`) in CI unit tests and in `task test` so future races are caught automatically.

## CI Runtime Impact

Measured from GitHub Actions `golangci-test` runs (12 successful pre-change `main` runs vs this PR run):

- `unit-tests`: 244s baseline median -> 321s with `-race` (**+77s**, **+31.6%**)
- Whole `golangci-test` workflow: 248s baseline median -> 324s (**+76s**, **+30.6%**)
- CI budgeting estimate: about **+1.3 minutes per run**

## Test plan

- `go test -race -short ./...` passes locally with zero race warnings
- `TestDashboardLayoutWidthPersistence` specifically verified with `-race` (was the only failing test)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enabled race condition detection in test suite to identify potential concurrency issues and improve code reliability.

* **Chores**
  * Updated test execution and CI workflows to include race detector.
  * Increased test timeout to accommodate extended test execution time.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/2933?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->