### PR TITLE
fix(frontend): add required field indicators to audio source forms

### DIFF
--- a/frontend/src/lib/desktop/components/forms/SoundCardCard.svelte
+++ b/frontend/src/lib/desktop/components/forms/SoundCardCard.svelte
@@ -258,6 +258,7 @@
           <label class="block py-1" for="soundcard-name-{index}">
             <span class="text-xs font-medium text-[var(--color-base-content)]">
               {t('settings.audio.soundCards.nameLabel')}
+              <span class="text-[var(--color-error)] ml-1">*</span>
             </span>
           </label>
           <input
@@ -275,6 +276,7 @@
           value={editDevice}
           label={t('settings.audio.soundCards.deviceLabel')}
           options={deviceOptions}
+          required
           onChange={value => (editDevice = value as string)}
           groupBy={false}
           menuSize="sm"

--- a/frontend/src/lib/desktop/components/forms/SoundCardCard.svelte
+++ b/frontend/src/lib/desktop/components/forms/SoundCardCard.svelte
@@ -258,7 +258,7 @@
           <label class="block py-1" for="soundcard-name-{index}">
             <span class="text-xs font-medium text-[var(--color-base-content)]">
               {t('settings.audio.soundCards.nameLabel')}
-              <span class="text-[var(--color-error)] ml-1">*</span>
+              <span class="text-[var(--color-error)] ml-1" aria-hidden="true">*</span>
             </span>
           </label>
           <input
@@ -266,6 +266,7 @@
             type="text"
             bind:value={editName}
             onkeydown={handleKeydown}
+            required
             class="w-full h-9 px-3 text-sm rounded-lg border border-[var(--border-200)] bg-[var(--color-base-200)] text-[var(--color-base-content)] placeholder:text-[var(--color-base-content)]/40 focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)] focus:border-transparent transition-colors"
             placeholder={t('settings.audio.soundCards.namePlaceholder')}
           />

--- a/frontend/src/lib/desktop/components/forms/SoundCardManager.svelte
+++ b/frontend/src/lib/desktop/components/forms/SoundCardManager.svelte
@@ -349,6 +349,7 @@
                 label={t('settings.audio.soundCards.nameLabel')}
                 placeholder={t('settings.audio.soundCards.namePlaceholder')}
                 helpText={nameError ? undefined : t('settings.audio.soundCards.nameHelp')}
+                required
                 {disabled}
               />
               {#if nameError}
@@ -369,6 +370,7 @@
                 label={t('settings.audio.soundCards.deviceLabel')}
                 placeholder={t('settings.audio.soundCards.devicePlaceholder')}
                 options={deviceOptions}
+                required
                 {disabled}
                 onChange={value => (newDevice = value as string)}
                 groupBy={false}

--- a/frontend/src/lib/desktop/components/forms/StreamCard.svelte
+++ b/frontend/src/lib/desktop/components/forms/StreamCard.svelte
@@ -415,7 +415,7 @@
           <label class="block py-1" for="stream-name-{index}">
             <span class="text-xs font-medium text-[var(--color-base-content)]">
               {t('settings.audio.streams.nameLabel')}
-              <span class="text-[var(--color-error)] ml-1">*</span>
+              <span class="text-[var(--color-error)] ml-1" aria-hidden="true">*</span>
             </span>
           </label>
           <input
@@ -423,6 +423,7 @@
             type="text"
             bind:value={editName}
             onkeydown={handleKeydown}
+            required
             class="w-full h-9 px-3 text-sm rounded-lg border border-[var(--border-200)] bg-[var(--color-base-200)] text-[var(--color-base-content)] placeholder:text-[var(--color-base-content)]/40 focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)] focus:border-transparent transition-colors"
             placeholder={t('settings.audio.streams.namePlaceholder')}
           />
@@ -433,7 +434,7 @@
           <label class="block py-1" for="stream-url-{index}">
             <span class="text-xs font-medium text-[var(--color-base-content)]">
               {t('settings.audio.streams.urlLabel')}
-              <span class="text-[var(--color-error)] ml-1">*</span>
+              <span class="text-[var(--color-error)] ml-1" aria-hidden="true">*</span>
             </span>
           </label>
           <input
@@ -441,6 +442,7 @@
             type="text"
             bind:value={editUrl}
             onkeydown={handleKeydown}
+            required
             class="w-full h-9 px-3 font-mono text-sm rounded-lg border border-[var(--border-200)] bg-[var(--color-base-200)] text-[var(--color-base-content)] placeholder:text-[var(--color-base-content)]/40 focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)] focus:border-transparent transition-colors"
             placeholder="rtsp://user:password@host:port/path"
           />

--- a/frontend/src/lib/desktop/components/forms/StreamCard.svelte
+++ b/frontend/src/lib/desktop/components/forms/StreamCard.svelte
@@ -415,6 +415,7 @@
           <label class="block py-1" for="stream-name-{index}">
             <span class="text-xs font-medium text-[var(--color-base-content)]">
               {t('settings.audio.streams.nameLabel')}
+              <span class="text-[var(--color-error)] ml-1">*</span>
             </span>
           </label>
           <input
@@ -432,6 +433,7 @@
           <label class="block py-1" for="stream-url-{index}">
             <span class="text-xs font-medium text-[var(--color-base-content)]">
               {t('settings.audio.streams.urlLabel')}
+              <span class="text-[var(--color-error)] ml-1">*</span>
             </span>
           </label>
           <input

--- a/frontend/src/lib/desktop/components/forms/StreamManager.svelte
+++ b/frontend/src/lib/desktop/components/forms/StreamManager.svelte
@@ -600,6 +600,7 @@
                 label={t('settings.audio.streams.nameLabel')}
                 placeholder={t('settings.audio.streams.namePlaceholder')}
                 helpText={nameError ? undefined : t('settings.audio.streams.nameHelp')}
+                required
                 {disabled}
               />
               {#if nameError}
@@ -621,6 +622,7 @@
                 label={t('settings.audio.streams.urlLabel')}
                 placeholder="rtsp://user:password@192.168.1.100:554/stream"
                 helpText={urlError ? undefined : t('settings.audio.streams.urlHelp')}
+                required
                 oninput={handleUrlInput}
                 {disabled}
               />


### PR DESCRIPTION
## Summary
- Add red asterisk (`*`) required-field indicators to mandatory fields in soundcard and RTSP stream forms
- Covers both "add" and "edit" forms across four components: SoundCardManager, SoundCardCard, StreamManager, StreamCard
- Fields marked: source name, audio device (soundcard), stream name, stream URL (streams)

Closes #2935

## Test Plan
- [x] Frontend builds cleanly (`task frontend-build`)
- [x] Frontend lints pass (`task frontend-lint`)
- [x] Visually verified in browser via QA test container: soundcard edit form shows "Source Name *" and "Audio Device *"
- [x] Visually verified: stream add form shows "Stream Name *" and "Stream URL *"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Sound card name and device fields are now required and show visible required indicators in add and edit forms.
  * Stream name and URL fields are now required and show visible required indicators in both add and edit forms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->