### PR TITLE
fix(logging): check per-handler level in multiwriter to prevent debug log flooding

### DIFF
--- a/internal/logger/multiwriter.go
+++ b/internal/logger/multiwriter.go
@@ -30,7 +30,10 @@ func (h *multiWriterHandler) Enabled(ctx context.Context, level slog.Level) bool
 	return false
 }
 
-// Handle sends the record to all handlers
+// Handle sends the record to all handlers whose level accepts it.
+// Each sub-handler's Enabled() is checked individually so that, for example,
+// a debug-level file handler does not cause debug messages to leak into an
+// info-level console handler.
 //
 //nolint:gocritic // slog.Handler interface requires record by value, not pointer
 func (h *multiWriterHandler) Handle(ctx context.Context, record slog.Record) error {
@@ -40,6 +43,9 @@ func (h *multiWriterHandler) Handle(ctx context.Context, record slog.Record) err
 	var errs []error
 	for _, handler := range h.handlers {
 		if handler == nil {
+			continue
+		}
+		if !handler.Enabled(ctx, record.Level) {
 			continue
 		}
 		if err := handler.Handle(ctx, record); err != nil {

--- a/internal/logger/multiwriter_test.go
+++ b/internal/logger/multiwriter_test.go
@@ -1,0 +1,100 @@
+package logger
+
+import (
+	"bytes"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMultiWriterHandler_RespectsPerHandlerLevel(t *testing.T) {
+	t.Parallel()
+
+	t.Run("debug message goes to debug handler but not info handler", func(t *testing.T) {
+		t.Parallel()
+
+		var debugBuf, infoBuf bytes.Buffer
+		debugHandler := slog.NewTextHandler(&debugBuf, &slog.HandlerOptions{Level: slog.LevelDebug})
+		infoHandler := slog.NewTextHandler(&infoBuf, &slog.HandlerOptions{Level: slog.LevelInfo})
+
+		multi := newMultiWriterHandler(debugHandler, infoHandler)
+		log := slog.New(multi)
+
+		log.Debug("should only appear in debug output")
+		log.Info("should appear in both outputs")
+
+		assert.Contains(t, debugBuf.String(), "should only appear in debug output")
+		assert.Contains(t, debugBuf.String(), "should appear in both outputs")
+
+		assert.NotContains(t, infoBuf.String(), "should only appear in debug output")
+		assert.Contains(t, infoBuf.String(), "should appear in both outputs")
+	})
+
+	t.Run("replicates issue 2938: console_also with mixed levels", func(t *testing.T) {
+		t.Parallel()
+
+		var fileBuf, consoleBuf bytes.Buffer
+		fileHandler := slog.NewJSONHandler(&fileBuf, &slog.HandlerOptions{Level: slog.LevelDebug})
+		consoleHandler := newTextHandler(&consoleBuf, slog.LevelInfo, nil)
+
+		multi := newMultiWriterHandler(fileHandler, consoleHandler)
+		log := slog.New(multi)
+
+		log.Debug("Processing detections from queue", slog.String("source", "rtsp_test"))
+
+		assert.Contains(t, fileBuf.String(), "Processing detections from queue",
+			"debug message should be written to file handler")
+		assert.Empty(t, consoleBuf.String(),
+			"debug message must not leak to info-level console handler")
+	})
+
+	t.Run("enabled returns true when any handler accepts the level", func(t *testing.T) {
+		t.Parallel()
+
+		var buf bytes.Buffer
+		debugHandler := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+		errorHandler := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelError})
+
+		multi := newMultiWriterHandler(debugHandler, errorHandler)
+
+		require.True(t, multi.Enabled(t.Context(), slog.LevelDebug))
+		require.True(t, multi.Enabled(t.Context(), slog.LevelInfo))
+		require.True(t, multi.Enabled(t.Context(), slog.LevelError))
+	})
+
+	t.Run("enabled returns false when no handler accepts the level", func(t *testing.T) {
+		t.Parallel()
+
+		var buf bytes.Buffer
+		errorHandler := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelError})
+
+		multi := newMultiWriterHandler(errorHandler)
+
+		require.False(t, multi.Enabled(t.Context(), slog.LevelDebug))
+		require.False(t, multi.Enabled(t.Context(), slog.LevelInfo))
+		require.True(t, multi.Enabled(t.Context(), slog.LevelError))
+	})
+
+	t.Run("nil handler is safely skipped", func(t *testing.T) {
+		t.Parallel()
+
+		var buf bytes.Buffer
+		handler := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})
+
+		multi := newMultiWriterHandler(nil, handler, nil)
+		log := slog.New(multi)
+
+		log.Info("test message")
+		assert.Contains(t, buf.String(), "test message")
+	})
+
+	t.Run("nil multiwriter handler is safe", func(t *testing.T) {
+		t.Parallel()
+
+		var h *multiWriterHandler
+		require.False(t, h.Enabled(t.Context(), slog.LevelInfo))
+		require.NoError(t, h.Handle(t.Context(), slog.Record{}))
+	})
+}


### PR DESCRIPTION
## Summary

- Fix `multiWriterHandler.Handle()` to check each sub-handler's `Enabled()` before dispatching, preventing debug-level messages from leaking to info-level console handlers
- The `analysis.processor` module has `ConsoleAlso: true` with a debug-level file handler, causing every detection processing log to flood stdout
- Add comprehensive tests for mixed-level handler filtering, including the exact issue #2938 scenario

## Root Cause

`multiWriterHandler.Enabled()` returns true if ANY sub-handler accepts the level (correct for slog.Logger's gate check). But `Handle()` then dispatched to ALL sub-handlers without per-handler filtering. For `analysis.processor` (file=debug + console=info), debug messages passed the top-level gate via the file handler, then leaked to the console handler.

## Related Issues

Fixes #2938

## Test Plan

- [x] `go test -race -v ./internal/logger/...` (142 tests pass)
- [x] `golangci-lint run ./internal/logger/...` (0 issues)
- [x] New `TestMultiWriterHandler_RespectsPerHandlerLevel` covers: mixed debug/info levels, exact #2938 scenario (JSON file + text console), Enabled() semantics, nil safety

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Log handlers now properly respect their individual level configurations during filtering, ensuring logs are correctly routed based on each handler's settings.

* **Tests**
  * Added comprehensive test coverage for per-handler level filtering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->