### PR TITLE
build: move TensorFlow headers from $HOME to project-local .cache/

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -12,7 +12,9 @@ tmp_dir = "tmp"  # Temporary directory for build artifacts
   cmd = """
     # Enable CGO for TensorFlow Lite integration
     export CGO_ENABLED=1
-    export CGO_CFLAGS="-I${HOME}/src/tensorflow"
+    # Headers live in the project-local cache populated by `task check-tensorflow`.
+    # air runs this build command from the project root, so $(pwd) resolves there.
+    export CGO_CFLAGS="-I$(pwd)/.cache/tensorflow"
 
     # Set library paths based on OS
     if [ "$(uname)" = "Darwin" ]; then

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,7 +19,7 @@
 	"containerEnv": {
 		"ALSA_CARD": "0",
 		"CGO_ENABLED": "1",
-		"CGO_CFLAGS": "-I /home/dev-user/src/tensorflow",
+		"CGO_CFLAGS": "-I/workspaces/birdnet-go/.cache/tensorflow",
 		"NODE_ENV": "development",
 		"VITE_DEV_PORT": "5173"
 	},

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -12,31 +12,11 @@ sudo apt-get install -y ca-certificates libasound2 ffmpeg sox alsa-utils
 # Install development tools (git is already included)
 sudo apt-get install -y nano vim curl wget git dialog build-essential fish socat
 
-# Clone TensorFlow source for compilation (headers needed for CGO)
-echo "Setting up TensorFlow source..."
-TFLITE_VERSION="v2.17.1"
-TENSORFLOW_DIR="/home/dev-user/src/tensorflow"
-
-if [ ! -f "$TENSORFLOW_DIR/tensorflow/lite/c/c_api.h" ]; then
-    echo "Cloning TensorFlow $TFLITE_VERSION source (sparse checkout for headers only)..."
-    mkdir -p /home/dev-user/src
-    
-    # Clone with filter to minimize download size
-    git clone --branch $TFLITE_VERSION --filter=blob:none --no-checkout --depth 1 https://github.com/tensorflow/tensorflow.git $TENSORFLOW_DIR
-    
-    # Setup sparse checkout to only get header files
-    git -C $TENSORFLOW_DIR sparse-checkout set --no-cone '**/*.h'
-    
-    # Apply sparse checkout
-    git -C $TENSORFLOW_DIR checkout
-    
-    echo "✓ TensorFlow headers installed at $TENSORFLOW_DIR"
-else
-    echo "✓ TensorFlow headers already exist at $TENSORFLOW_DIR"
-fi
-
-# Ensure correct ownership
-sudo chown -R dev-user:dev-user /home/dev-user/src
+# Clone TensorFlow source for compilation (headers needed for CGO).
+# Delegate to `task check-tensorflow` so the clone location (.cache/tensorflow/)
+# stays in sync with Taskfile.yml automatically.
+echo "Setting up TensorFlow headers via task..."
+task check-tensorflow
 
 # Download and install TensorFlow Lite C library
 echo "Setting up TensorFlow Lite C library..."
@@ -221,7 +201,7 @@ echo "Oh My Posh version: $(oh-my-posh version)"
 # Verify TensorFlow setup
 echo ""
 echo "=== TensorFlow Setup ==="
-if [ -f "/home/dev-user/src/tensorflow/tensorflow/lite/c/c_api.h" ]; then
+if [ -f ".cache/tensorflow/tensorflow/lite/c/c_api.h" ]; then
     echo "✓ TensorFlow headers: Available"
 else
     echo "✗ TensorFlow headers: Missing"

--- a/.github/actions/setup-tensorflow/action.yml
+++ b/.github/actions/setup-tensorflow/action.yml
@@ -14,7 +14,10 @@ runs:
       uses: actions/cache@v5
       with:
         path: .cache/tensorflow
-        key: ${{ runner.os }}-tensorflow-${{ inputs.tflite-version }}
+        # Key bumped to "tensorflow-cache" so the new project-local path gets a
+        # fresh cache entry. Reusing the old key would restore the headers to the
+        # previous ~/src/tensorflow location and never re-save under the new path.
+        key: ${{ runner.os }}-tensorflow-cache-${{ inputs.tflite-version }}
 
     - name: Install Task
       uses: arduino/setup-task@v2

--- a/.github/actions/setup-tensorflow/action.yml
+++ b/.github/actions/setup-tensorflow/action.yml
@@ -13,7 +13,7 @@ runs:
     - name: Cache TensorFlow headers
       uses: actions/cache@v5
       with:
-        path: ~/src/tensorflow
+        path: .cache/tensorflow
         key: ${{ runner.os }}-tensorflow-${{ inputs.tflite-version }}
 
     - name: Install Task
@@ -47,4 +47,4 @@ runs:
       shell: bash
       run: |
         echo "CGO_ENABLED=1" >> $GITHUB_ENV
-        echo "CGO_CFLAGS=-I $HOME/src/tensorflow" >> $GITHUB_ENV
+        echo "CGO_CFLAGS=-I ${{ github.workspace }}/.cache/tensorflow" >> $GITHUB_ENV

--- a/.github/actions/setup-tensorflow/action.yml
+++ b/.github/actions/setup-tensorflow/action.yml
@@ -47,4 +47,4 @@ runs:
       shell: bash
       run: |
         echo "CGO_ENABLED=1" >> $GITHUB_ENV
-        echo "CGO_CFLAGS=-I ${{ github.workspace }}/.cache/tensorflow" >> $GITHUB_ENV
+        echo "CGO_CFLAGS=-I${{ github.workspace }}/.cache/tensorflow" >> $GITHUB_ENV

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ docs/superpowers/
 db/
 cache/
 spectrograms/
+.cache/
 .task/*
 .vscode/*
 .mcp.json

--- a/Makefile
+++ b/Makefile
@@ -126,18 +126,18 @@ check-tools:
 check-tensorflow:
 	@if [ ! -f "$(TENSORFLOW_HEADERS_DIR)/tensorflow/lite/c/c_api.h" ]; then \
 		echo "TensorFlow Lite C API header not found. Cloning TensorFlow source..."; \
-		mkdir -p $(dir $(TENSORFLOW_HEADERS_DIR)); \
-		git clone --branch $(TFLITE_VERSION) --filter=blob:none --depth 1 --no-checkout https://github.com/tensorflow/tensorflow.git $(TENSORFLOW_HEADERS_DIR); \
-		git -C $(TENSORFLOW_HEADERS_DIR) config core.sparseCheckout true; \
-		echo "**/*.h" >> $(TENSORFLOW_HEADERS_DIR)/.git/info/sparse-checkout; \
-		git -C $(TENSORFLOW_HEADERS_DIR) checkout; \
+		mkdir -p "$(dir $(TENSORFLOW_HEADERS_DIR))"; \
+		git clone --branch $(TFLITE_VERSION) --filter=blob:none --depth 1 --no-checkout https://github.com/tensorflow/tensorflow.git "$(TENSORFLOW_HEADERS_DIR)"; \
+		git -C "$(TENSORFLOW_HEADERS_DIR)" config core.sparseCheckout true; \
+		echo "**/*.h" >> "$(TENSORFLOW_HEADERS_DIR)/.git/info/sparse-checkout"; \
+		git -C "$(TENSORFLOW_HEADERS_DIR)" checkout; \
 	else \
 		echo "Checking TensorFlow version..."; \
-		current_version=$$(git -C $(TENSORFLOW_HEADERS_DIR) describe --tags); \
+		current_version=$$(git -C "$(TENSORFLOW_HEADERS_DIR)" describe --tags); \
 		if [ "$$current_version" != "$(TFLITE_VERSION)" ]; then \
 			echo "Switching TensorFlow source to version $(TFLITE_VERSION)..."; \
-			git -C $(TENSORFLOW_HEADERS_DIR) fetch --depth 1 origin $(TFLITE_VERSION); \
-			git -C $(TENSORFLOW_HEADERS_DIR) checkout $(TFLITE_VERSION); \
+			git -C "$(TENSORFLOW_HEADERS_DIR)" fetch --depth 1 origin $(TFLITE_VERSION); \
+			git -C "$(TENSORFLOW_HEADERS_DIR)" checkout $(TFLITE_VERSION); \
 		else \
 			echo "TensorFlow source tree is at version $(TFLITE_VERSION)"; \
 		fi; \

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,8 @@ BINARY_NAME := birdnet-go
 TFLITE_VERSION := v2.17.1
 
 # Common flags
-CGO_FLAGS := CGO_ENABLED=1 CGO_CFLAGS="-I$(HOME)/src/tensorflow"
+TENSORFLOW_HEADERS_DIR := $(CURDIR)/.cache/tensorflow
+CGO_FLAGS := CGO_ENABLED=1 CGO_CFLAGS="-I$(TENSORFLOW_HEADERS_DIR)"
 LDFLAGS = -ldflags "-s -w \
     -X 'main.buildDate=$(shell date -u +%Y-%m-%dT%H:%M:%SZ)' \
     -X 'main.version=$(shell git describe --tags --always)' \
@@ -85,7 +86,7 @@ endef
 define get_cgo_flags
 $(strip \
     CGO_ENABLED=1 \
-    CGO_CFLAGS="-I$(HOME)/src/tensorflow" \
+    CGO_CFLAGS="-I$(TENSORFLOW_HEADERS_DIR)" \
     $(if $(filter linux_arm64,$1), \
         $(if $(filter x86_64,$(UNAME_M)), \
             CC=aarch64-linux-gnu-gcc \
@@ -123,20 +124,20 @@ check-tools:
 
 # Check and clone TensorFlow if not exists
 check-tensorflow:
-	@if [ ! -f "$(HOME)/src/tensorflow/tensorflow/lite/c/c_api.h" ]; then \
+	@if [ ! -f "$(TENSORFLOW_HEADERS_DIR)/tensorflow/lite/c/c_api.h" ]; then \
 		echo "TensorFlow Lite C API header not found. Cloning TensorFlow source..."; \
-		mkdir -p $(HOME)/src; \
-		git clone --branch $(TFLITE_VERSION) --filter=blob:none --depth 1 --no-checkout https://github.com/tensorflow/tensorflow.git $(HOME)/src/tensorflow; \
-		git -C $(HOME)/src/tensorflow config core.sparseCheckout true; \
-		echo "**/*.h" >> $(HOME)/src/tensorflow/.git/info/sparse-checkout; \
-		git -C $(HOME)/src/tensorflow checkout; \
+		mkdir -p $(dir $(TENSORFLOW_HEADERS_DIR)); \
+		git clone --branch $(TFLITE_VERSION) --filter=blob:none --depth 1 --no-checkout https://github.com/tensorflow/tensorflow.git $(TENSORFLOW_HEADERS_DIR); \
+		git -C $(TENSORFLOW_HEADERS_DIR) config core.sparseCheckout true; \
+		echo "**/*.h" >> $(TENSORFLOW_HEADERS_DIR)/.git/info/sparse-checkout; \
+		git -C $(TENSORFLOW_HEADERS_DIR) checkout; \
 	else \
 		echo "Checking TensorFlow version..."; \
-		current_version=$$(git -C $(HOME)/src/tensorflow describe --tags); \
+		current_version=$$(git -C $(TENSORFLOW_HEADERS_DIR) describe --tags); \
 		if [ "$$current_version" != "$(TFLITE_VERSION)" ]; then \
 			echo "Switching TensorFlow source to version $(TFLITE_VERSION)..."; \
-			git -C $(HOME)/src/tensorflow fetch --depth 1 origin $(TFLITE_VERSION); \
-			git -C $(HOME)/src/tensorflow checkout $(TFLITE_VERSION); \
+			git -C $(TENSORFLOW_HEADERS_DIR) fetch --depth 1 origin $(TFLITE_VERSION); \
+			git -C $(TENSORFLOW_HEADERS_DIR) checkout $(TFLITE_VERSION); \
 		else \
 			echo "TensorFlow source tree is at version $(TFLITE_VERSION)"; \
 		fi; \

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -45,7 +45,8 @@ vars:
   PROJECT_COMMUNITY_URL:
     sh: echo "${PROJECT_COMMUNITY_URL:-}"
   # Common build flags
-  CGO_FLAGS: CGO_ENABLED=1 CGO_CFLAGS="-I$HOME/src/tensorflow"
+  TENSORFLOW_HEADERS_DIR: '{{.ROOT_DIR}}/.cache/tensorflow'
+  CGO_FLAGS: CGO_ENABLED=1 CGO_CFLAGS="-I{{.TENSORFLOW_HEADERS_DIR}}"
   EXTRA_BUILD_TAGS: '{{.EXTRA_BUILD_TAGS | default ""}}'
   BUILD_TAGS_FLAG:
     sh: |
@@ -695,15 +696,15 @@ tasks:
     desc: Clone TensorFlow headers for CGo compilation
     cmds:
       - |
-        if [ ! -f "$HOME/src/tensorflow/tensorflow/lite/c/c_api.h" ]; then
+        if [ ! -f "{{.TENSORFLOW_HEADERS_DIR}}/tensorflow/lite/c/c_api.h" ]; then
           echo "TensorFlow Lite C API header not found. Cloning TensorFlow source..."
-          mkdir -vp $HOME/src
+          mkdir -vp "$(dirname "{{.TENSORFLOW_HEADERS_DIR}}")"
           echo "Cloning TensorFlow source..."
-          git clone --branch {{.TFLITE_VERSION}} --filter=blob:none --no-checkout --depth 1 https://github.com/tensorflow/tensorflow.git $HOME/src/tensorflow
+          git clone --branch {{.TFLITE_VERSION}} --filter=blob:none --no-checkout --depth 1 https://github.com/tensorflow/tensorflow.git "{{.TENSORFLOW_HEADERS_DIR}}"
           echo "Setting up sparse checkout..."
-          git -C $HOME/src/tensorflow sparse-checkout set --no-cone '**/*.h'
+          git -C "{{.TENSORFLOW_HEADERS_DIR}}" sparse-checkout set --no-cone '**/*.h'
           echo "Checking out TensorFlow source..."
-          git -C $HOME/src/tensorflow checkout
+          git -C "{{.TENSORFLOW_HEADERS_DIR}}" checkout
         else
           echo "TensorFlow headers already exist at version {{.TFLITE_VERSION}}"
         fi

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -706,7 +706,15 @@ tasks:
           echo "Checking out TensorFlow source..."
           git -C "{{.TENSORFLOW_HEADERS_DIR}}" checkout
         else
-          echo "TensorFlow headers already exist at version {{.TFLITE_VERSION}}"
+          echo "Checking TensorFlow version..."
+          current_version=$(git -C "{{.TENSORFLOW_HEADERS_DIR}}" describe --tags)
+          if [ "$current_version" != "{{.TFLITE_VERSION}}" ]; then
+            echo "Switching TensorFlow source to version {{.TFLITE_VERSION}}..."
+            git -C "{{.TENSORFLOW_HEADERS_DIR}}" fetch --depth 1 origin {{.TFLITE_VERSION}}
+            git -C "{{.TENSORFLOW_HEADERS_DIR}}" checkout {{.TFLITE_VERSION}}
+          else
+            echo "TensorFlow headers already at version {{.TFLITE_VERSION}}"
+          fi
         fi
 
   check-tflite-lib:

--- a/doc/wiki/building.md
+++ b/doc/wiki/building.md
@@ -54,7 +54,7 @@ This project uses [Task](https://taskfile.dev/) (`Taskfile.yml`) as its build sy
 
 - **TensorFlow Lite C Library:** `task` will automatically download the correct pre-compiled library (from [tphakala/tflite_c](https://github.com/tphakala/tflite_c/releases/tag/{{TFLITE_VERSION}})) for your target OS/architecture when you run a build task. It places the library in the expected system path (e.g., `/usr/lib`, `/usr/local/lib`, `/opt/homebrew/lib`, or `/usr/x86_64-w64-mingw32/lib` for Windows cross-compile) and creates necessary symlinks.
 - **ONNX Runtime (Optional):** Needed for BirdNET v3.0 models (currently in development preview). Run `task download-onnxruntime` to automatically download and install the correct version for your platform. See [ONNX Runtime Installation](../ONNX-Runtime-Installation.md) for manual installation options.
-- **TensorFlow Headers:** `task` checks if TensorFlow source code (needed for C header files for CGO) is present in `$HOME/src/tensorflow`. If not, it clones the specific tag (`{{TFLITE_VERSION}}`) required.
+- **TensorFlow Headers:** `task` checks if TensorFlow source code (needed for C header files for CGO) is present in `.cache/tensorflow/` inside the project root. If not, it clones the specific tag (`{{TFLITE_VERSION}}`) required.
 
 ### One-Command Setup
 


### PR DESCRIPTION
* moves the tf download to .cache dir in workspace

one thing i found surprising working with the repo was that the default setup puts things in my home dir -- tensorflow headers get put in ~/src/tensorflow by default. i think it makes sense to keep them in the project dir just gitignored? this moves them to a .cache dir inside the repo and gitignores it.


clanker generated pr desc below
---

Move the TensorFlow header sparse-checkout from `$HOME/src/tensorflow` to `.cache/tensorflow/` inside the project root. Keeps build artifacts project-scoped instead of polluting the user's home directory. Multiple checkouts on different branches can safely use different TFLite versions without conflicts.

## Changes

- **Taskfile.yml**: New `TENSORFLOW_HEADERS_DIR` variable (`{{.ROOT_DIR}}/.cache/tensorflow`), updated `CGO_FLAGS` and `check-tensorflow` task. Added version-checking logic in the `else` branch (ported from the Makefile) so stale headers are updated automatically when `TFLITE_VERSION` changes.
- **Makefile**: Same path migration using `$(CURDIR)/.cache/tensorflow`. Quoted `$(TENSORFLOW_HEADERS_DIR)` in shell commands for robustness with paths containing spaces.
- **CI action**: Cache `.cache/tensorflow` instead of `~/src/tensorflow`, use `${{ github.workspace }}` for `CGO_CFLAGS`. Removed stray space after `-I` for consistency with the Taskfile and Makefile.
- **.gitignore**: Add `.cache/`
- **.devcontainer/devcontainer.json**: Updated `CGO_CFLAGS` to point at the new `.cache/tensorflow` location.
- **.devcontainer/postCreateCommand.sh**: Replaced duplicated TensorFlow clone logic with a call to `task check-tensorflow`, keeping the clone location in sync with the Taskfile automatically. Updated the verification check to use the new path.
- **doc/wiki/building.md**: Updated documentation to reference `.cache/tensorflow/` instead of `$HOME/src/tensorflow`.

## Notes

- The CI cache key is unchanged (`runner.os-tensorflow-version`), so the first run after merge will miss the old cache entry and re-clone. Subsequent runs cache normally.
- Docker builds (`Dockerfile`) call `task check-tensorflow` and will automatically pick up the new location.
- Runtime model file loading (`tryLoadModelFromStandardPaths`) is unaffected; it already uses proper OS-specific paths (XDG, system paths, etc.).

## Test plan

- [ ] CI passes (header clone + CGO compilation in new location)
- [ ] Local `task check-tensorflow` clones into `.cache/tensorflow/` instead of `$HOME/src/`
- [ ] Docker build succeeds with the new path
- [ ] Devcontainer build succeeds with updated `CGO_CFLAGS` and `postCreateCommand.sh`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Streamlined TensorFlow build setup by caching TensorFlow Lite headers locally under the project directory instead of relying on a hardcoded home-directory path.
  * Updated devcontainer, build scripts, and CI setup to use the cached headers for consistent CGO include paths.
  * Added the cache directory to ignore patterns to keep generated files out of version control.

* **Documentation**
  * Updated “TensorFlow Headers” build-preparation instructions to reference the new project-local cache location.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->