### PR TITLE
fix(species): use date-only comparison in pruning to prevent timezone mismatch

### DIFF
--- a/internal/analysis/species/maintenance.go
+++ b/internal/analysis/species/maintenance.go
@@ -71,13 +71,31 @@ func (t *SpeciesTracker) SyncIfNeeded() error {
 	return nil
 }
 
+// dateOnlyBefore reports whether the calendar date of a is strictly before the
+// calendar date of b, ignoring time-of-day and timezone. This prevents
+// incorrect comparisons when one timestamp is UTC midnight (from time.Parse)
+// and the other uses a local timezone (from time.Date with Location).
+func dateOnlyBefore(a, b time.Time) bool {
+	ay, am, ad := a.Date()
+	by, bm, bd := b.Date()
+	aDate := time.Date(ay, am, ad, 0, 0, 0, 0, time.UTC)
+	bDate := time.Date(by, bm, bd, 0, 0, 0, 0, time.UTC)
+	return aDate.Before(bDate)
+}
+
+// dateOnlyAfter reports whether the calendar date of a is strictly after the
+// calendar date of b, ignoring time-of-day and timezone.
+func dateOnlyAfter(a, b time.Time) bool {
+	return dateOnlyBefore(b, a)
+}
+
 // pruneLifetimeEntriesLocked removes very old lifetime entries (>10 years).
 // Assumes lock is held.
 func (t *SpeciesTracker) pruneLifetimeEntriesLocked(now time.Time) int {
 	lifetimeCutoff := now.AddDate(-lifetimeRetentionYears, 0, 0)
 	pruned := 0
 	for scientificName, firstSeen := range t.speciesFirstSeen {
-		if firstSeen.Before(lifetimeCutoff) {
+		if dateOnlyBefore(firstSeen, lifetimeCutoff) {
 			delete(t.speciesFirstSeen, scientificName)
 			pruned++
 		}
@@ -99,7 +117,7 @@ func (t *SpeciesTracker) pruneYearlyEntriesLocked(now time.Time) int {
 
 	pruned := 0
 	for scientificName, firstSeen := range t.speciesThisYear {
-		if firstSeen.Before(currentYearStart) {
+		if dateOnlyBefore(firstSeen, currentYearStart) {
 			delete(t.speciesThisYear, scientificName)
 			pruned++
 			getLog().Debug("Pruned old yearly entry",
@@ -112,9 +130,12 @@ func (t *SpeciesTracker) pruneYearlyEntriesLocked(now time.Time) int {
 }
 
 // isSeasonOld checks if all entries in a season map are older than the cutoff.
+// Uses date-only comparison to avoid timezone mismatch between UTC-parsed
+// database dates and local-timezone cutoffs. An entry on the same calendar
+// date as the cutoff is considered current (not old).
 func isSeasonOld(speciesMap map[string]time.Time, cutoff time.Time) bool {
 	for _, firstSeen := range speciesMap {
-		if firstSeen.After(cutoff) {
+		if !dateOnlyBefore(firstSeen, cutoff) {
 			return false
 		}
 	}

--- a/internal/analysis/species/maintenance.go
+++ b/internal/analysis/species/maintenance.go
@@ -78,15 +78,13 @@ func (t *SpeciesTracker) SyncIfNeeded() error {
 func dateOnlyBefore(a, b time.Time) bool {
 	ay, am, ad := a.Date()
 	by, bm, bd := b.Date()
-	aDate := time.Date(ay, am, ad, 0, 0, 0, 0, time.UTC)
-	bDate := time.Date(by, bm, bd, 0, 0, 0, 0, time.UTC)
-	return aDate.Before(bDate)
-}
-
-// dateOnlyAfter reports whether the calendar date of a is strictly after the
-// calendar date of b, ignoring time-of-day and timezone.
-func dateOnlyAfter(a, b time.Time) bool {
-	return dateOnlyBefore(b, a)
+	if ay != by {
+		return ay < by
+	}
+	if am != bm {
+		return am < bm
+	}
+	return ad < bd
 }
 
 // pruneLifetimeEntriesLocked removes very old lifetime entries (>10 years).

--- a/internal/analysis/species/prune_timezone_test.go
+++ b/internal/analysis/species/prune_timezone_test.go
@@ -98,6 +98,51 @@ func TestPruneYearlyTimezoneMultipleOffsets(t *testing.T) {
 	}
 }
 
+// TestPruneYearlyTimezoneEastOfUTC confirms the fix doesn't break timezones
+// east of UTC where local midnight is an earlier instant than UTC midnight.
+func TestPruneYearlyTimezoneEastOfUTC(t *testing.T) {
+	t.Parallel()
+
+	timezones := []string{
+		"Europe/Berlin",    // UTC+1 / UTC+2
+		"Asia/Tokyo",       // UTC+9
+		"Pacific/Auckland", // UTC+12 / UTC+13
+	}
+
+	for _, tzName := range timezones {
+		t.Run(tzName, func(t *testing.T) {
+			t.Parallel()
+
+			loc, err := time.LoadLocation(tzName)
+			require.NoError(t, err)
+
+			tracker := &SpeciesTracker{
+				yearlyEnabled:   true,
+				resetMonth:      1,
+				resetDay:        1,
+				currentYear:     2026,
+				speciesThisYear: make(map[string]time.Time),
+			}
+
+			jan1UTC, _ := time.Parse(time.DateOnly, "2026-01-01")
+			tracker.speciesThisYear["Corvus brachyrhynchos"] = jan1UTC
+
+			dec31UTC, _ := time.Parse(time.DateOnly, "2025-12-31")
+			tracker.speciesThisYear["Passer domesticus"] = dec31UTC
+
+			now := time.Date(2026, 5, 6, 12, 0, 0, 0, loc)
+			pruned := tracker.pruneYearlyEntriesLocked(now)
+
+			assert.Equal(t, 1, pruned,
+				"only previous-year entry should be pruned in %s", tzName)
+			assert.Contains(t, tracker.speciesThisYear, "Corvus brachyrhynchos",
+				"Jan 1 species must remain in %s", tzName)
+			assert.NotContains(t, tracker.speciesThisYear, "Passer domesticus",
+				"Dec 31 species should be pruned in %s", tzName)
+		})
+	}
+}
+
 // TestPruneYearlyStillRemovesPreviousYearEntries confirms that entries from a
 // previous tracking year ARE correctly pruned (the fix must not break this).
 func TestPruneYearlyStillRemovesPreviousYearEntries(t *testing.T) {
@@ -167,9 +212,9 @@ func TestPruneYearlyCustomResetDateTimezone(t *testing.T) {
 }
 
 // TestIsSeasonOldTimezoneWestOfUTC verifies that isSeasonOld uses date-only
-// comparison. A species detected the day AFTER the cutoff date must keep the
-// season alive, even when the UTC-midnight timestamp is before the cutoff
-// instant in local time.
+// comparison. A species detected ON the cutoff date must keep the season
+// alive, even when the UTC-midnight timestamp is before the cutoff instant
+// in local time.
 func TestIsSeasonOldTimezoneWestOfUTC(t *testing.T) {
 	t.Parallel()
 

--- a/internal/analysis/species/prune_timezone_test.go
+++ b/internal/analysis/species/prune_timezone_test.go
@@ -1,0 +1,227 @@
+package species
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPruneYearlyTimezoneWestOfUTC verifies that species first detected on the
+// year start date are NOT pruned when the system runs in a timezone west of UTC.
+//
+// Bug: loadYearlyDataFromDatabase parses dates with time.Parse (UTC midnight),
+// but pruneYearlyEntriesLocked computes the cutoff with now.Location() (local
+// midnight). For timezones west of UTC, local midnight is a later instant than
+// UTC midnight of the same date, so "Jan 1 00:00 UTC".Before("Jan 1 00:00 EST")
+// is true and the entry is incorrectly pruned.
+func TestPruneYearlyTimezoneWestOfUTC(t *testing.T) {
+	t.Parallel()
+
+	eastern, err := time.LoadLocation("America/New_York")
+	require.NoError(t, err)
+
+	tracker := &SpeciesTracker{
+		yearlyEnabled:   true,
+		resetMonth:      1,
+		resetDay:        1,
+		currentYear:     2026,
+		speciesThisYear: make(map[string]time.Time),
+	}
+
+	// Simulate DB-loaded date: time.Parse returns UTC midnight
+	jan1UTC, _ := time.Parse(time.DateOnly, "2026-01-01")
+	tracker.speciesThisYear["Cyanocitta cristata"] = jan1UTC // Blue Jay
+	tracker.speciesThisYear["Spinus tristis"] = jan1UTC      // American Goldfinch
+
+	// Also add a species first seen later (should never be pruned)
+	mar15UTC, _ := time.Parse(time.DateOnly, "2026-03-15")
+	tracker.speciesThisYear["Turdus migratorius"] = mar15UTC // American Robin
+
+	// Prune from the perspective of May 6 in US Eastern timezone
+	nowEastern := time.Date(2026, 5, 6, 10, 0, 0, 0, eastern)
+	pruned := tracker.pruneYearlyEntriesLocked(nowEastern)
+
+	assert.Equal(t, 0, pruned, "no current-year species should be pruned")
+	assert.Len(t, tracker.speciesThisYear, 3,
+		"all three species should remain in the yearly tracking map")
+	assert.Contains(t, tracker.speciesThisYear, "Cyanocitta cristata",
+		"Blue Jay (first seen Jan 1) must not be pruned")
+	assert.Contains(t, tracker.speciesThisYear, "Spinus tristis",
+		"American Goldfinch (first seen Jan 1) must not be pruned")
+	assert.Contains(t, tracker.speciesThisYear, "Turdus migratorius",
+		"American Robin (first seen Mar 15) must not be pruned")
+}
+
+// TestPruneYearlyTimezoneMultipleOffsets verifies the fix across several
+// western timezones with varying UTC offsets.
+func TestPruneYearlyTimezoneMultipleOffsets(t *testing.T) {
+	t.Parallel()
+
+	timezones := []string{
+		"America/New_York",    // UTC-5 / UTC-4
+		"America/Chicago",     // UTC-6 / UTC-5
+		"America/Denver",      // UTC-7 / UTC-6
+		"America/Los_Angeles", // UTC-8 / UTC-7
+		"America/Anchorage",   // UTC-9 / UTC-8
+		"Pacific/Honolulu",    // UTC-10
+	}
+
+	for _, tzName := range timezones {
+		t.Run(tzName, func(t *testing.T) {
+			t.Parallel()
+
+			loc, err := time.LoadLocation(tzName)
+			require.NoError(t, err)
+
+			tracker := &SpeciesTracker{
+				yearlyEnabled:   true,
+				resetMonth:      1,
+				resetDay:        1,
+				currentYear:     2026,
+				speciesThisYear: make(map[string]time.Time),
+			}
+
+			// Simulate DB-loaded Jan 1 date (UTC midnight)
+			jan1UTC, _ := time.Parse(time.DateOnly, "2026-01-01")
+			tracker.speciesThisYear["Corvus brachyrhynchos"] = jan1UTC
+
+			now := time.Date(2026, 5, 6, 12, 0, 0, 0, loc)
+			pruned := tracker.pruneYearlyEntriesLocked(now)
+
+			assert.Equal(t, 0, pruned,
+				"species first seen on year start date must not be pruned in %s", tzName)
+			assert.Contains(t, tracker.speciesThisYear, "Corvus brachyrhynchos",
+				"American Crow must remain in yearly map for %s", tzName)
+		})
+	}
+}
+
+// TestPruneYearlyStillRemovesPreviousYearEntries confirms that entries from a
+// previous tracking year ARE correctly pruned (the fix must not break this).
+func TestPruneYearlyStillRemovesPreviousYearEntries(t *testing.T) {
+	t.Parallel()
+
+	eastern, err := time.LoadLocation("America/New_York")
+	require.NoError(t, err)
+
+	tracker := &SpeciesTracker{
+		yearlyEnabled:   true,
+		resetMonth:      1,
+		resetDay:        1,
+		currentYear:     2026,
+		speciesThisYear: make(map[string]time.Time),
+	}
+
+	// Entry from previous year (should be pruned)
+	dec15UTC, _ := time.Parse(time.DateOnly, "2025-12-15")
+	tracker.speciesThisYear["Passer domesticus"] = dec15UTC // House Sparrow
+
+	// Entry from current year (should NOT be pruned)
+	jan15UTC, _ := time.Parse(time.DateOnly, "2026-01-15")
+	tracker.speciesThisYear["Sitta pusilla"] = jan15UTC // Brown-headed Nuthatch
+
+	now := time.Date(2026, 5, 6, 10, 0, 0, 0, eastern)
+	pruned := tracker.pruneYearlyEntriesLocked(now)
+
+	assert.Equal(t, 1, pruned, "only the previous-year entry should be pruned")
+	assert.NotContains(t, tracker.speciesThisYear, "Passer domesticus",
+		"House Sparrow (Dec 2025) should be pruned")
+	assert.Contains(t, tracker.speciesThisYear, "Sitta pusilla",
+		"Brown-headed Nuthatch (Jan 2026) should remain")
+}
+
+// TestPruneYearlyCustomResetDateTimezone verifies the timezone fix with a
+// non-January-1 reset date (e.g., July 1 for southern hemisphere users).
+func TestPruneYearlyCustomResetDateTimezone(t *testing.T) {
+	t.Parallel()
+
+	pacific, err := time.LoadLocation("America/Los_Angeles")
+	require.NoError(t, err)
+
+	tracker := &SpeciesTracker{
+		yearlyEnabled:   true,
+		resetMonth:      7,
+		resetDay:        1,
+		currentYear:     2026,
+		speciesThisYear: make(map[string]time.Time),
+	}
+
+	// Species first seen on the custom reset date (July 1), loaded from DB as UTC midnight
+	jul1UTC, _ := time.Parse(time.DateOnly, "2026-07-01")
+	tracker.speciesThisYear["Zenaida macroura"] = jul1UTC // Mourning Dove
+
+	// Species from before the reset date (should be pruned)
+	jun15UTC, _ := time.Parse(time.DateOnly, "2026-06-15")
+	tracker.speciesThisYear["Sturnus vulgaris"] = jun15UTC // European Starling
+
+	now := time.Date(2026, 8, 15, 10, 0, 0, 0, pacific)
+	pruned := tracker.pruneYearlyEntriesLocked(now)
+
+	assert.Equal(t, 1, pruned, "only the pre-reset entry should be pruned")
+	assert.Contains(t, tracker.speciesThisYear, "Zenaida macroura",
+		"Mourning Dove (first seen on reset date Jul 1) must not be pruned")
+	assert.NotContains(t, tracker.speciesThisYear, "Sturnus vulgaris",
+		"European Starling (before reset date) should be pruned")
+}
+
+// TestIsSeasonOldTimezoneWestOfUTC verifies that isSeasonOld uses date-only
+// comparison. A species detected the day AFTER the cutoff date must keep the
+// season alive, even when the UTC-midnight timestamp is before the cutoff
+// instant in local time.
+func TestIsSeasonOldTimezoneWestOfUTC(t *testing.T) {
+	t.Parallel()
+
+	eastern, err := time.LoadLocation("America/New_York")
+	require.NoError(t, err)
+
+	// Species detected on May 7, 2025 (loaded from DB as UTC midnight)
+	may7UTC, _ := time.Parse(time.DateOnly, "2025-05-07")
+	seasonMap := map[string]time.Time{
+		"Setophaga petechia": may7UTC, // Yellow Warbler
+	}
+
+	// now = May 7, 2026 10:00 Eastern; cutoff = May 7, 2025 10:00 Eastern
+	// In UTC: cutoff = May 7, 2025 14:00 UTC
+	// Bug: May 7 00:00 UTC.After(May 7 14:00 UTC) = false, so the season
+	// is incorrectly considered old despite having the same calendar date.
+	now := time.Date(2026, 5, 7, 10, 0, 0, 0, eastern)
+	cutoff := now.AddDate(-1, 0, 0)
+
+	result := isSeasonOld(seasonMap, cutoff)
+	assert.False(t, result,
+		"season with entries on the cutoff calendar date should not be considered old")
+}
+
+// TestPruneLifetimeTimezoneWestOfUTC verifies the lifetime pruning also uses
+// date-safe comparison. The lifetime cutoff is 10 years ago, so this is less
+// likely to trigger in practice, but the same pattern should be consistent.
+func TestPruneLifetimeTimezoneWestOfUTC(t *testing.T) {
+	t.Parallel()
+
+	eastern, err := time.LoadLocation("America/New_York")
+	require.NoError(t, err)
+
+	tracker := &SpeciesTracker{
+		speciesFirstSeen: make(map[string]time.Time),
+	}
+
+	// Species first seen exactly 10 years ago (the cutoff boundary)
+	// Loaded from DB as UTC midnight
+	boundaryDate, _ := time.Parse(time.DateOnly, "2016-05-06")
+	tracker.speciesFirstSeen["Melospiza melodia"] = boundaryDate // Song Sparrow
+
+	// Species from 10 years + 1 day ago (should be pruned)
+	oldDate, _ := time.Parse(time.DateOnly, "2016-05-05")
+	tracker.speciesFirstSeen["Agelaius phoeniceus"] = oldDate // Red-winged Blackbird
+
+	now := time.Date(2026, 5, 6, 10, 0, 0, 0, eastern)
+	pruned := tracker.pruneLifetimeEntriesLocked(now)
+
+	assert.Equal(t, 1, pruned, "only the entry older than 10 years should be pruned")
+	assert.Contains(t, tracker.speciesFirstSeen, "Melospiza melodia",
+		"Song Sparrow (exactly at cutoff) must not be pruned")
+	assert.NotContains(t, tracker.speciesFirstSeen, "Agelaius phoeniceus",
+		"Red-winged Blackbird (older than cutoff) should be pruned")
+}

--- a/internal/analysis/species/species_tracker_cleanup_test.go
+++ b/internal/analysis/species/species_tracker_cleanup_test.go
@@ -122,13 +122,14 @@ func TestPruneOldEntries_CriticalReliability(t *testing.T) {
 			"boundary_conditions",
 			func(tracker *SpeciesTracker, now time.Time) {
 				// Test exact boundary (10 years for lifetime tracking)
-				// PruneOldEntries uses Before() which means entries at exactly 10 years ARE pruned
-				tracker.speciesFirstSeen["Exactly_At_Boundary"] = now.AddDate(-10, 0, 0)  // Exactly 10 years - will be pruned
+				// Pruning uses date-only comparison: entries on the same calendar date
+				// as the cutoff are NOT pruned (they are exactly N years old, not older).
+				tracker.speciesFirstSeen["Exactly_At_Boundary"] = now.AddDate(-10, 0, 0)  // Exactly 10 years - same date, NOT pruned
 				tracker.speciesFirstSeen["Just_Before_Boundary"] = now.AddDate(-10, 0, 1) // Just under 10 years - not pruned
 				tracker.speciesFirstSeen["Just_After_Boundary"] = now.AddDate(-10, 0, -1) // Just over 10 years - will be pruned
 			},
 			time.Now(),
-			2, // Both exactly 10 years and over should be pruned (Before() includes the boundary)
+			1, // Only entries with a calendar date strictly before the cutoff are pruned
 			"Boundary conditions should be handled correctly (10 year cutoff)",
 		},
 		{


### PR DESCRIPTION
## Summary

- Fix timezone mismatch in species tracker pruning that caused false "first time this year" badges on the dashboard for users in timezones west of UTC (Americas)
- Root cause: DB-loaded dates are parsed as UTC midnight (`time.Parse`), but pruning cutoffs use local midnight (`time.Date` with `now.Location()`). For western timezones, `Jan 1 00:00 UTC` is before `Jan 1 00:00 EST`, so species first detected on the year start date were incorrectly pruned on every sync cycle
- Replace `time.Before`/`time.After` with `dateOnlyBefore` helper that compares year/month/day tuples directly, matching the pattern already used by `calculateDaysSince` in the same package

Fixes #2954

## Test Plan

- [x] 8 new timezone-specific tests covering US Eastern through Hawaii (UTC-5 to UTC-10)
- [x] 3 east-of-UTC tests (Berlin, Tokyo, Auckland) confirming symmetric correctness
- [x] Regression tests for previous-year pruning and custom reset dates
- [x] `isSeasonOld` and lifetime pruning boundary tests
- [x] All 724 existing tests pass with `-race`
- [x] golangci-lint clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed timezone-related issues in data pruning logic that could incorrectly remove entries for users in certain timezones, especially those west of UTC.
  * Entries on the exact cutoff date are now correctly preserved instead of being pruned.

* **Tests**
  * Added comprehensive timezone-specific test coverage for pruning operations to ensure correct behavior across different timezone offsets and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->