### PR TITLE
fix: Windows tool path validation respects configured soxpath/ffmpegpath

### DIFF
--- a/internal/api/v2/api.go
+++ b/internal/api/v2/api.go
@@ -24,6 +24,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/api/auth"
 	"github.com/tphakala/birdnet-go/internal/audiocore"
 	"github.com/tphakala/birdnet-go/internal/audiocore/engine"
+	"github.com/tphakala/birdnet-go/internal/audiocore/ffmpeg"
 	"github.com/tphakala/birdnet-go/internal/classifier"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/datastore"
@@ -384,8 +385,14 @@ func NewWithOptions(e *echo.Echo, ds datastore.Interface, settings *conf.Setting
 		metrics:              metrics,
 		ctx:                  ctx,
 		cancel:               cancel,
-		spectrogramGenerator: spectrogram.NewGenerator(settings, sfs, getSpectrogramLogger()), // Initialize shared generator
+		spectrogramGenerator: spectrogram.NewGenerator(settings, sfs, getSpectrogramLogger()),
 		detectionRateCache:   datastore.NewDetectionRateCache(detectionRateCacheTTL),
+	}
+
+	// Propagate the derived FFprobe path from config validation to the
+	// ffmpeg package so executeFFprobe can find it without PATH lookup.
+	if settings.Realtime.Audio.FfprobePath != "" {
+		ffmpeg.SetFFprobePath(settings.Realtime.Audio.FfprobePath)
 	}
 
 	// Initialize audio processing cache and concurrency limiter

--- a/internal/api/v2/api.go
+++ b/internal/api/v2/api.go
@@ -391,9 +391,8 @@ func NewWithOptions(e *echo.Echo, ds datastore.Interface, settings *conf.Setting
 
 	// Propagate the derived FFprobe path from config validation to the
 	// ffmpeg package so executeFFprobe can find it without PATH lookup.
-	if settings.Realtime.Audio.FfprobePath != "" {
-		ffmpeg.SetFFprobePath(settings.Realtime.Audio.FfprobePath)
-	}
+	// Always set (even if empty) so repeated controller inits clear stale state.
+	ffmpeg.SetFFprobePath(settings.Realtime.Audio.FfprobePath)
 
 	// Initialize audio processing cache and concurrency limiter
 	cacheDir := filepath.Join(c.SFS.BaseDir(), ".processing-cache")

--- a/internal/audiocore/ffmpeg/validate.go
+++ b/internal/audiocore/ffmpeg/validate.go
@@ -10,10 +10,34 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/tphakala/birdnet-go/internal/errors"
 )
+
+// configuredFFprobePath stores the validated ffprobe path set during config
+// validation. Protected by a mutex for safe concurrent access.
+var (
+	ffprobePathMu         sync.RWMutex
+	configuredFFprobePath string
+)
+
+// SetFFprobePath stores the validated ffprobe binary path for use by all
+// validation calls. Called once during config validation after deriving the
+// path from the validated FFmpeg location.
+func SetFFprobePath(path string) {
+	ffprobePathMu.Lock()
+	configuredFFprobePath = path
+	ffprobePathMu.Unlock()
+}
+
+// GetFFprobePath returns the currently configured ffprobe binary path.
+func GetFFprobePath() string {
+	ffprobePathMu.RLock()
+	defer ffprobePathMu.RUnlock()
+	return configuredFFprobePath
+}
 
 // Validation constants for audio file validation.
 const (
@@ -342,14 +366,19 @@ func getFfprobeBinaryName() string {
 
 // executeFFprobe runs ffprobe and returns its CSV output.
 func executeFFprobe(ctx context.Context, path string) (string, error) {
-	ffprobeBinary := getFfprobeBinaryName()
-
-	// Ensure ffprobe is available before attempting to run it.
-	if _, err := exec.LookPath(ffprobeBinary); err != nil {
-		return "", ErrFFprobeNotAvailable
+	// Use the configured path if set (from config validation), otherwise fall
+	// back to PATH lookup for backward compatibility.
+	ffprobeBinary := GetFFprobePath()
+	if ffprobeBinary == "" {
+		name := getFfprobeBinaryName()
+		found, err := exec.LookPath(name)
+		if err != nil {
+			return "", ErrFFprobeNotAvailable
+		}
+		ffprobeBinary = found
 	}
 
-	cmd := exec.CommandContext(ctx, ffprobeBinary, //nolint:gosec // G204: ffprobeBinary is a fixed platform constant, path validated by caller
+	cmd := exec.CommandContext(ctx, ffprobeBinary, //nolint:gosec // G204: ffprobeBinary validated by config or exec.LookPath, path validated by caller
 		"-v", "error",
 		"-show_entries", "format=duration,bit_rate:stream=sample_rate,channels,codec_name",
 		"-of", "csv=p=0",

--- a/internal/audiocore/ffmpeg/validate.go
+++ b/internal/audiocore/ffmpeg/validate.go
@@ -16,16 +16,13 @@ import (
 	"github.com/tphakala/birdnet-go/internal/errors"
 )
 
-// configuredFFprobePath stores the validated ffprobe path set during config
-// validation. Protected by a mutex for safe concurrent access.
 var (
 	ffprobePathMu         sync.RWMutex
 	configuredFFprobePath string
 )
 
-// SetFFprobePath stores the validated ffprobe binary path for use by all
-// validation calls. Called once during config validation after deriving the
-// path from the validated FFmpeg location.
+// SetFFprobePath sets the validated ffprobe path, derived from the configured
+// ffmpeg location during startup. Safe for concurrent use.
 func SetFFprobePath(path string) {
 	ffprobePathMu.Lock()
 	configuredFFprobePath = path

--- a/internal/audiocore/ffmpeg/validate_test.go
+++ b/internal/audiocore/ffmpeg/validate_test.go
@@ -193,3 +193,14 @@ func TestValidateFile_Options(t *testing.T) {
 	// With 2 attempts and 50 ms initial delay it should finish well under 1 second.
 	assert.Less(t, elapsed, 2*time.Second, "validation with short retry should finish quickly")
 }
+
+func TestSetAndGetFFprobePath(t *testing.T) {
+	original := ffmpeg.GetFFprobePath()
+	t.Cleanup(func() { ffmpeg.SetFFprobePath(original) })
+
+	ffmpeg.SetFFprobePath("")
+	assert.Empty(t, ffmpeg.GetFFprobePath())
+
+	ffmpeg.SetFFprobePath("/custom/path/to/ffprobe")
+	assert.Equal(t, "/custom/path/to/ffprobe", ffmpeg.GetFFprobePath())
+}

--- a/internal/birdweather/audio_test.go
+++ b/internal/birdweather/audio_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"math"
 	"os"
+	"os/exec"
 	"testing"
 	"time"
 
@@ -177,8 +178,7 @@ func TestContextTimeout(t *testing.T) {
 }
 
 func TestEncodeFlacUsingFFmpeg(t *testing.T) {
-	// Skip the test if FFmpeg is not available
-	if !conf.IsFfmpegAvailable() {
+	if _, err := exec.LookPath(conf.GetFfmpegBinaryName()); err != nil {
 		t.Skip("FFmpeg not available, skipping FLAC encoding test")
 	}
 

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -100,6 +100,7 @@ type AudioSettings struct {
 	FfmpegMinor     int                 `yaml:"-" json:"ffmpegMinor,omitempty"`                                 // ffmpeg minor version number, runtime value
 	SoxPath         string              `yaml:"soxpath" mapstructure:"soxpath" json:"soxPath"`                  // path to sox, runtime value
 	SoxAudioTypes   []string            `yaml:"-" json:"-"`                                                     // supported audio types of sox, runtime value
+	FfprobePath     string              `yaml:"-" json:"-"`                                                     // path to ffprobe, derived from ffmpeg path at runtime
 	StreamTransport string              `yaml:"streamtransport" json:"streamTransport"`                         // preferred transport for audio streaming: "auto", "sse", or "ws"
 	Export          ExportSettings      `yaml:"export" json:"export"`                                           // export settings
 	SoundLevel      SoundLevelSettings  `yaml:"soundlevel" json:"soundLevel"`                                   // sound level monitoring settings

--- a/internal/conf/utils.go
+++ b/internal/conf/utils.go
@@ -481,27 +481,27 @@ func IsFfprobeAvailable() bool {
 	return err == nil
 }
 
-// GetFfmpegVersion detects the installed ffmpeg version and returns the version string,
-// major version, and minor version. Returns empty string and 0,0 if detection fails.
-func GetFfmpegVersion() (version string, major, minor int) {
-	// Get the ffmpeg binary name
-	ffmpegBinary := GetFfmpegBinaryName()
-
-	// Look for ffmpeg in PATH
-	ffmpegPath, err := exec.LookPath(ffmpegBinary)
-	if err != nil {
-		return "", 0, 0
-	}
-
-	// Execute ffmpeg -version
-	cmd := exec.Command(ffmpegPath, "-version") //nolint:gosec // G204: ffmpegPath resolved via exec.LookPath()
+// GetFfmpegVersionFrom detects the ffmpeg version by executing the binary at
+// the given path. Returns empty string and 0,0 if detection fails.
+func GetFfmpegVersionFrom(ffmpegPath string) (version string, major, minor int) {
+	cmd := exec.Command(ffmpegPath, "-version") //nolint:gosec // G204: ffmpegPath validated by ValidateToolPath before reaching here
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return "", 0, 0
 	}
-
-	// Parse the version from output
 	return ParseFfmpegVersion(string(output))
+}
+
+// GetFfmpegVersion detects the installed ffmpeg version by searching the system PATH.
+// Returns empty string and 0,0 if detection fails.
+//
+// Deprecated: Use GetFfmpegVersionFrom with the validated path instead.
+func GetFfmpegVersion() (version string, major, minor int) {
+	ffmpegPath, err := exec.LookPath(GetFfmpegBinaryName())
+	if err != nil {
+		return "", 0, 0
+	}
+	return GetFfmpegVersionFrom(ffmpegPath)
 }
 
 // ParseFfmpegVersion parses ffmpeg version output and extracts version string and numbers.
@@ -623,36 +623,31 @@ func parseLibavutilVersion(output string) (major, minor int) {
 
 // IsSoxAvailable checks if SoX is available in the system PATH and returns its supported audio formats.
 // It returns a boolean indicating if SoX is available and a slice of supported audio format strings.
+//
+// Deprecated: Use ValidateToolPath + GetSoxFormats for explicit path support.
 func IsSoxAvailable() (isAvailable bool, formats []string) {
-	// Look for the SoX binary in the system PATH
 	soxPath, err := exec.LookPath(GetSoxBinaryName())
 	if err != nil {
-		return false, nil // SoX is not available
+		return false, nil
 	}
+	return true, GetSoxFormats(soxPath)
+}
 
-	// Execute SoX with the help flag to get its output
-	cmd := exec.Command(soxPath, "-h") //nolint:gosec // G204: soxPath resolved via exec.LookPath()
+// GetSoxFormats returns the audio formats supported by the SoX binary at the
+// given path. Returns nil if SoX cannot be executed or reports no formats.
+func GetSoxFormats(soxPath string) []string {
+	cmd := exec.Command(soxPath, "-h") //nolint:gosec // G204: soxPath validated by ValidateToolPath before reaching here
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return false, nil // Failed to execute SoX
+		return nil
 	}
 
-	// Convert the output to a string and split it into lines
-	outputStr := string(output)
-	lines := strings.Split(outputStr, "\n")
-
-	var audioFormats []string
-	// Iterate through the lines to find the supported audio formats
-	for _, line := range lines {
+	for line := range strings.SplitSeq(string(output), "\n") {
 		if formats, found := strings.CutPrefix(line, "AUDIO FILE FORMATS:"); found {
-			// Extract and process the list of audio formats
-			formats = strings.TrimSpace(formats)
-			audioFormats = strings.Fields(formats)
-			break
+			return strings.Fields(strings.TrimSpace(formats))
 		}
 	}
-
-	return true, audioFormats // SoX is available, return the list of supported formats
+	return nil
 }
 
 // ValidateToolPath checks if a tool is available, either at an explicit path or in the system PATH.

--- a/internal/conf/utils.go
+++ b/internal/conf/utils.go
@@ -469,18 +469,6 @@ func GetFfprobeBinaryName() string {
 	return "ffprobe"
 }
 
-// IsFfmpegAvailable checks if ffmpeg is available in the system PATH.
-func IsFfmpegAvailable() bool {
-	_, err := exec.LookPath(GetFfmpegBinaryName())
-	return err == nil
-}
-
-// IsFfprobeAvailable checks if ffprobe is available in the system PATH.
-func IsFfprobeAvailable() bool {
-	_, err := exec.LookPath(GetFfprobeBinaryName())
-	return err == nil
-}
-
 // GetFfmpegVersionFrom detects the ffmpeg version by executing the binary at
 // the given path. Returns empty string and 0,0 if detection fails.
 func GetFfmpegVersionFrom(ffmpegPath string) (version string, major, minor int) {
@@ -490,18 +478,6 @@ func GetFfmpegVersionFrom(ffmpegPath string) (version string, major, minor int) 
 		return "", 0, 0
 	}
 	return ParseFfmpegVersion(string(output))
-}
-
-// GetFfmpegVersion detects the installed ffmpeg version by searching the system PATH.
-// Returns empty string and 0,0 if detection fails.
-//
-// Deprecated: Use GetFfmpegVersionFrom with the validated path instead.
-func GetFfmpegVersion() (version string, major, minor int) {
-	ffmpegPath, err := exec.LookPath(GetFfmpegBinaryName())
-	if err != nil {
-		return "", 0, 0
-	}
-	return GetFfmpegVersionFrom(ffmpegPath)
 }
 
 // ParseFfmpegVersion parses ffmpeg version output and extracts version string and numbers.
@@ -619,18 +595,6 @@ func parseLibavutilVersion(output string) (major, minor int) {
 		}
 	}
 	return major, minor
-}
-
-// IsSoxAvailable checks if SoX is available in the system PATH and returns its supported audio formats.
-// It returns a boolean indicating if SoX is available and a slice of supported audio format strings.
-//
-// Deprecated: Use ValidateToolPath + GetSoxFormats for explicit path support.
-func IsSoxAvailable() (isAvailable bool, formats []string) {
-	soxPath, err := exec.LookPath(GetSoxBinaryName())
-	if err != nil {
-		return false, nil
-	}
-	return true, GetSoxFormats(soxPath)
 }
 
 // GetSoxFormats returns the audio formats supported by the SoX binary at the

--- a/internal/conf/utils_test.go
+++ b/internal/conf/utils_test.go
@@ -2,6 +2,7 @@ package conf
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 
@@ -277,4 +278,38 @@ func TestFindConfigFile_EmptyConfigPathFallsThrough(t *testing.T) {
 	} else {
 		assert.NotEmpty(t, result, "returned path should not be empty on success")
 	}
+}
+
+func TestGetSoxFormats_WithExplicitPath(t *testing.T) {
+	soxPath, err := exec.LookPath(GetSoxBinaryName())
+	if err != nil {
+		t.Skip("SoX not available in PATH, skipping")
+	}
+
+	formats := GetSoxFormats(soxPath)
+	require.NotEmpty(t, formats, "SoX should report supported formats")
+	assert.Contains(t, formats, "wav")
+}
+
+func TestGetSoxFormats_WithInvalidPath(t *testing.T) {
+	formats := GetSoxFormats("/nonexistent/sox")
+	assert.Empty(t, formats)
+}
+
+func TestGetFfmpegVersionFrom_WithExplicitPath(t *testing.T) {
+	ffmpegPath, err := exec.LookPath(GetFfmpegBinaryName())
+	if err != nil {
+		t.Skip("FFmpeg not available in PATH, skipping")
+	}
+
+	version, major, _ := GetFfmpegVersionFrom(ffmpegPath)
+	assert.NotEmpty(t, version)
+	assert.Positive(t, major)
+}
+
+func TestGetFfmpegVersionFrom_WithInvalidPath(t *testing.T) {
+	version, major, minor := GetFfmpegVersionFrom("/nonexistent/ffmpeg")
+	assert.Empty(t, version)
+	assert.Zero(t, major)
+	assert.Zero(t, minor)
 }

--- a/internal/conf/utils_test.go
+++ b/internal/conf/utils_test.go
@@ -200,23 +200,18 @@ func TestParsePercentage(t *testing.T) {
 }
 
 func TestGetFfmpegVersion(t *testing.T) {
-	// This test will only work if ffmpeg is installed on the system
-	version, major, minor := GetFfmpegVersion()
-
-	// If ffmpeg is not available, the function should return empty values
-	if version == "" {
+	ffmpegPath, err := exec.LookPath(GetFfmpegBinaryName())
+	if err != nil {
 		t.Skip("ffmpeg not available on system, skipping integration test")
 	}
 
-	// If we got a version, validate it has sensible values
-	// Note: For git builds, major version is derived from libavutil, so it should be valid
+	version, major, minor := GetFfmpegVersionFrom(ffmpegPath)
+	require.NotEmpty(t, version)
+
 	assert.GreaterOrEqual(t, major, 3, "major version should be at least 3")
 	assert.LessOrEqual(t, major, 10, "major version should be at most 10")
-
 	assert.GreaterOrEqual(t, minor, 0, "minor version should be non-negative")
 	assert.LessOrEqual(t, minor, 99, "minor version should be at most 99")
-
-	// Additional validation: if major is 0, something went wrong
 	assert.NotEqual(t, 0, major, "failed to detect major version, got: version=%s, major=%d, minor=%d", version, major, minor)
 
 	t.Logf("Detected FFmpeg version: %s (major: %d, minor: %d)", version, major, minor)

--- a/internal/conf/validate_audio.go
+++ b/internal/conf/validate_audio.go
@@ -406,6 +406,7 @@ func validateAudioSettings(settings *AudioSettings) error {
 				settings.FfprobePath = lookPath
 				GetLogger().Debug("FFprobe found in system PATH", logger.String("ffprobe_path", lookPath))
 			} else {
+				settings.FfprobePath = ""
 				GetLogger().Warn("FFprobe not found alongside FFmpeg or in PATH",
 					logger.String("expected_path", ffprobePath),
 					logger.String("impact", "Audio validation via FFprobe will be disabled"))

--- a/internal/conf/validate_audio.go
+++ b/internal/conf/validate_audio.go
@@ -5,6 +5,7 @@ package conf
 import (
 	"fmt"
 	"math"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
@@ -381,8 +382,8 @@ func validateAudioSettings(settings *AudioSettings) error {
 	} else {
 		settings.FfmpegPath = validatedFfmpegPath // Store the validated path (explicit or from PATH)
 
-		// Detect FFmpeg version for runtime decisions (e.g., FFmpeg 5.x bug workarounds)
-		version, major, minor := GetFfmpegVersion()
+		// Detect FFmpeg version using the validated path (not PATH lookup)
+		version, major, minor := GetFfmpegVersionFrom(validatedFfmpegPath)
 		settings.FfmpegVersion = version
 		settings.FfmpegMajor = major
 		settings.FfmpegMinor = minor
@@ -392,20 +393,36 @@ func validateAudioSettings(settings *AudioSettings) error {
 		} else {
 			GetLogger().Warn("Could not detect FFmpeg version", logger.String("version_string", version))
 		}
+
+		// Derive ffprobe path from the validated ffmpeg path. FFprobe is a
+		// sibling binary in the same directory (e.g. ffmpeg.exe -> ffprobe.exe).
+		ffprobeDir := filepath.Dir(validatedFfmpegPath)
+		ffprobePath := filepath.Join(ffprobeDir, GetFfprobeBinaryName())
+		if _, statErr := os.Stat(ffprobePath); statErr == nil {
+			settings.FfprobePath = ffprobePath
+			GetLogger().Debug("FFprobe path derived from FFmpeg", logger.String("ffprobe_path", ffprobePath))
+		} else {
+			if lookPath, lookErr := exec.LookPath(GetFfprobeBinaryName()); lookErr == nil {
+				settings.FfprobePath = lookPath
+				GetLogger().Debug("FFprobe found in system PATH", logger.String("ffprobe_path", lookPath))
+			} else {
+				GetLogger().Warn("FFprobe not found alongside FFmpeg or in PATH",
+					logger.String("expected_path", ffprobePath),
+					logger.String("impact", "Audio validation via FFprobe will be disabled"))
+			}
+		}
 	}
 
-	// Validate and determine the effective SoX path
-	// We only need to know if it's available and its formats, so LookPath is sufficient here.
-	soxPath, soxLookPathErr := exec.LookPath(GetSoxBinaryName())
-	if soxLookPathErr != nil {
+	// Validate and determine the effective SoX path, using the same
+	// ValidateToolPath pattern as FFmpeg (configured path first, then PATH).
+	validatedSoxPath, soxErr := ValidateToolPath(settings.SoxPath, GetSoxBinaryName())
+	if soxErr != nil {
 		settings.SoxPath = ""
 		settings.SoxAudioTypes = nil
-		GetLogger().Warn("SoX not found in system PATH", logger.String("impact", "Audio source processing requiring SoX might be disabled"))
+		GetLogger().Warn("SoX not available", logger.Error(soxErr), logger.String("impact", "Spectrogram generation via SoX will be disabled"))
 	} else {
-		settings.SoxPath = soxPath
-		// Get supported formats if SoX is found
-		_, formats := IsSoxAvailable() // We already know it's available from LookPath
-		settings.SoxAudioTypes = formats
+		settings.SoxPath = validatedSoxPath
+		settings.SoxAudioTypes = GetSoxFormats(validatedSoxPath)
 	}
 
 	// Validate audio sources

--- a/internal/conf/validate_audio.go
+++ b/internal/conf/validate_audio.go
@@ -358,6 +358,7 @@ func (s *AudioSettings) clearFfmpegMetadata() {
 	s.FfmpegVersion = ""
 	s.FfmpegMajor = 0
 	s.FfmpegMinor = 0
+	s.FfprobePath = ""
 }
 
 // applyFfmpegFormatFallback forces WAV export when FFmpeg is unavailable and
@@ -398,7 +399,7 @@ func validateAudioSettings(settings *AudioSettings) error {
 		// sibling binary in the same directory (e.g. ffmpeg.exe -> ffprobe.exe).
 		ffprobeDir := filepath.Dir(validatedFfmpegPath)
 		ffprobePath := filepath.Join(ffprobeDir, GetFfprobeBinaryName())
-		if _, statErr := os.Stat(ffprobePath); statErr == nil {
+		if info, statErr := os.Stat(ffprobePath); statErr == nil && !info.IsDir() {
 			settings.FfprobePath = ffprobePath
 			GetLogger().Debug("FFprobe path derived from FFmpeg", logger.String("ffprobe_path", ffprobePath))
 		} else {

--- a/internal/spectrogram/generator.go
+++ b/internal/spectrogram/generator.go
@@ -875,7 +875,7 @@ func (g *Generator) getSoxSpectrogramArgs(ctx context.Context, settings *conf.Se
 	// Priority: pre-validated (from FFprobe) > cached sox/ffprobe > configured fallback.
 	duration := preValidatedDuration
 	if duration <= 0 {
-		duration = getCachedAudioDuration(ctx, audioPath)
+		duration = getCachedAudioDuration(ctx, settings.Realtime.Audio.SoxPath, audioPath)
 	}
 	if duration <= 0 {
 		// Fallback: Use configured capture length if both sox and ffprobe fail
@@ -1038,7 +1038,7 @@ func (g *Generator) waitWithTimeoutErr(cmd *exec.Cmd, timeout time.Duration) err
 // falling back to ffprobe if sox fails (e.g., for MP3/AAC files without libsox-fmt-mp3).
 // The cache is invalidated if the file has been modified (size or modTime changed).
 // Returns 0 if duration cannot be determined (caller should use configured fallback).
-func getCachedAudioDuration(ctx context.Context, audioPath string) float64 {
+func getCachedAudioDuration(ctx context.Context, soxPath, audioPath string) float64 {
 	// Get file info for cache validation
 	fileInfo, err := os.Stat(audioPath)
 	if err != nil {
@@ -1065,7 +1065,7 @@ func getCachedAudioDuration(ctx context.Context, audioPath string) float64 {
 	}
 
 	// Cache miss or invalid - try sox --info first (~30x faster than ffprobe)
-	duration, soxErr := getAudioDurationViaSox(ctx, audioPath)
+	duration, soxErr := getAudioDurationViaSox(ctx, soxPath, audioPath)
 	if soxErr != nil {
 		// Sox failed (common for MP3/AAC without libsox-fmt-mp3) — fall back to ffprobe
 		GetLogger().Debug("Sox duration query failed, falling back to ffprobe",
@@ -1126,10 +1126,12 @@ func evictOldCacheEntriesLocked() {
 
 // getAudioDurationViaSox calls sox --info -D to get audio duration.
 // This is ~30x faster than ffprobe for duration queries.
-func getAudioDurationViaSox(ctx context.Context, audioPath string) (float64, error) {
-	soxPath := conf.GetSoxBinaryName()
+func getAudioDurationViaSox(ctx context.Context, soxPath, audioPath string) (float64, error) {
+	if soxPath == "" {
+		return 0, fmt.Errorf("sox path not configured")
+	}
 
-	cmd := exec.CommandContext(ctx, soxPath, "--info", "-D", audioPath) //nolint:gosec // G204: soxPath from conf.GetSoxBinaryName(), args are fixed
+	cmd := exec.CommandContext(ctx, soxPath, "--info", "-D", audioPath) //nolint:gosec // G204: soxPath from validated settings, args are fixed
 
 	output, err := cmd.Output()
 	if err != nil {


### PR DESCRIPTION
## Summary

- SoX validation now uses `ValidateToolPath` (matching the existing FFmpeg pattern) instead of `exec.LookPath`, respecting the user's configured `soxpath` value
- FFprobe path derived from validated FFmpeg binary (sibling in same directory) with PATH fallback, stored via `SetFFprobePath` for runtime use
- FFmpeg version detection uses the validated path instead of independent PATH lookup
- SoX duration query (`sox --info -D`) uses the configured path from settings instead of bare `"sox.exe"`
- Removed 4 dead functions (`IsSoxAvailable`, `GetFfmpegVersion`, `IsFfmpegAvailable`, `IsFfprobeAvailable`) replaced by path-aware alternatives

## Root Cause

Six code paths used `exec.LookPath()` to find SoX/FFprobe/FFmpeg, ignoring the user's explicitly configured absolute paths (`soxpath`, `ffmpegpath`). On Windows, tools installed at custom locations (e.g., `C:\birdnet-go\sox\sox.exe`) are typically not in the system PATH. The validation code overwrote the user's setting with an empty string, disabling spectrogram generation entirely.

FFmpeg validation already used `ValidateToolPath()` correctly (configured path first, PATH fallback). SoX and FFprobe did not.

## Verified on Windows 11 QA VM

Config: `soxpath: C:\birdnet-go\sox\sox.exe`, `ffmpegpath: C:\birdnet-go\ffmpeg\ffmpeg.exe`, both dirs NOT in system PATH.

**Before:** `WARN [config] SoX not found in system PATH`, `WARN [config] Could not detect FFmpeg version`
**After:** Both warnings gone. Tools detected from configured paths.

## Related Issues

Fixes #2845
Relates to #1813, #2342

## Test Plan

- [x] All 1593 existing tests pass
- [x] Linter clean
- [x] Windows binary built and tested on Windows 11 VM
- [x] Startup log confirms SoX/FFmpeg detected from configured paths (not PATH)
- [ ] CI passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configure an FFprobe executable path at runtime and store it in runtime settings.

* **Bug Fixes**
  * Ensure configured FFprobe path is consistently applied (including clearing when empty).
  * Tie spectrogram duration caching to the SoX executable used to avoid stale results.

* **Refactor**
  * Replace implicit PATH-based tool discovery with explicit-path resolution for FFmpeg/FFprobe/SoX; spectrogram and duration lookups now respect explicit tool paths.

* **Tests**
  * Added/updated tests verifying explicit executable path behavior and parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->