### PR TITLE
fix(securefs): bypass os.Root.Mkdir on Windows to prevent spectrogram hang

### DIFF
--- a/internal/securefs/securefs.go
+++ b/internal/securefs/securefs.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -278,15 +279,26 @@ func (sfs *SecureFS) createDirComponent(path string, perm os.FileMode) error {
 	return nil
 }
 
-// MkdirAll creates a directory and all necessary parent directories with path validation
+// MkdirAll creates a directory and all necessary parent directories with path validation.
+//
+// On Windows, os.Root.Mkdir can hang indefinitely when called on directories
+// that already exist (observed on Windows 11 25H2 with Go 1.26). This is
+// suspected to be a Go runtime issue with NtCreateFile holding the directory
+// handle when FILE_CREATE disposition encounters an existing object. As a
+// workaround, Windows uses os.MkdirAll on the resolved absolute path instead
+// of os.Root.Mkdir, after validating the path stays within the base directory.
 func (sfs *SecureFS) MkdirAll(path string, perm os.FileMode) error {
-	relPath, err := sfs.RelativePath(path)
+	relPath, err := sfs.resolveRelPath(path)
 	if err != nil {
 		return err
 	}
 
 	if relPath == "" || relPath == "." {
 		return nil
+	}
+
+	if runtime.GOOS == "windows" {
+		return sfs.mkdirAllWindows(relPath, perm)
 	}
 
 	components := strings.Split(relPath, string(filepath.Separator))
@@ -304,6 +316,38 @@ func (sfs *SecureFS) MkdirAll(path string, perm os.FileMode) error {
 	}
 
 	return nil
+}
+
+// mkdirAllWindows bypasses os.Root.Mkdir and uses os.MkdirAll directly.
+// This trades os.Root's kernel-level sandboxing for reliability; the caller
+// (resolveRelPath) validates the path stays within baseDir, but symlink-based
+// escapes are theoretically possible since EvalSymlinks is intentionally skipped.
+func (sfs *SecureFS) mkdirAllWindows(relPath string, perm os.FileMode) error {
+	absPath := filepath.Join(sfs.baseDir, relPath)
+	return os.MkdirAll(absPath, perm)
+}
+
+// resolveRelPath converts a path to a validated relative path for use with os.Root.
+// For absolute paths, it uses filepath.Rel directly (avoiding filepath.EvalSymlinks
+// which can hang on Windows when os.Root holds a handle to the base directory).
+// For relative paths, it delegates to ValidateRelativePath.
+func (sfs *SecureFS) resolveRelPath(path string) (string, error) {
+	cleanPath := filepath.Clean(path)
+	if filepath.IsAbs(cleanPath) {
+		if !filepath.IsLocal(filepath.Base(cleanPath)) {
+			return "", errors.New(ErrInvalidPath).Component(componentSecurefs).Category(errors.CategoryValidation).Context("operation", "mkdirall_invalid_path").Build()
+		}
+		relPath, err := filepath.Rel(sfs.baseDir, cleanPath)
+		if err != nil {
+			return "", errors.New(err).Component(componentSecurefs).Category(errors.CategoryValidation).Context("operation", "mkdirall_rel").Build()
+		}
+		relPath = strings.TrimPrefix(relPath, string(filepath.Separator))
+		if strings.HasPrefix(relPath, ".."+string(filepath.Separator)) || relPath == ".." {
+			return "", errors.New(ErrPathTraversal).Component(componentSecurefs).Category(errors.CategoryValidation).Context("operation", "mkdirall_traversal").Build()
+		}
+		return relPath, nil
+	}
+	return sfs.ValidateRelativePath(path)
 }
 
 // removeAllRelative removes a path using already-validated relative path

--- a/internal/securefs/securefs.go
+++ b/internal/securefs/securefs.go
@@ -324,7 +324,10 @@ func (sfs *SecureFS) MkdirAll(path string, perm os.FileMode) error {
 // escapes are theoretically possible since EvalSymlinks is intentionally skipped.
 func (sfs *SecureFS) mkdirAllWindows(relPath string, perm os.FileMode) error {
 	absPath := filepath.Join(sfs.baseDir, relPath)
-	return os.MkdirAll(absPath, perm)
+	if err := os.MkdirAll(absPath, perm); err != nil {
+		return errors.New(err).Component(componentSecurefs).Category(errors.CategoryFileIO).Context("operation", "mkdirall_windows").Build()
+	}
+	return nil
 }
 
 // resolveRelPath converts a path to a validated relative path for use with os.Root.
@@ -334,9 +337,6 @@ func (sfs *SecureFS) mkdirAllWindows(relPath string, perm os.FileMode) error {
 func (sfs *SecureFS) resolveRelPath(path string) (string, error) {
 	cleanPath := filepath.Clean(path)
 	if filepath.IsAbs(cleanPath) {
-		if !filepath.IsLocal(filepath.Base(cleanPath)) {
-			return "", errors.New(ErrInvalidPath).Component(componentSecurefs).Category(errors.CategoryValidation).Context("operation", "mkdirall_invalid_path").Build()
-		}
 		relPath, err := filepath.Rel(sfs.baseDir, cleanPath)
 		if err != nil {
 			return "", errors.New(err).Component(componentSecurefs).Category(errors.CategoryValidation).Context("operation", "mkdirall_rel").Build()
@@ -344,6 +344,9 @@ func (sfs *SecureFS) resolveRelPath(path string) (string, error) {
 		relPath = strings.TrimPrefix(relPath, string(filepath.Separator))
 		if strings.HasPrefix(relPath, ".."+string(filepath.Separator)) || relPath == ".." {
 			return "", errors.New(ErrPathTraversal).Component(componentSecurefs).Category(errors.CategoryValidation).Context("operation", "mkdirall_traversal").Build()
+		}
+		if !filepath.IsLocal(relPath) {
+			return "", errors.New(ErrInvalidPath).Component(componentSecurefs).Category(errors.CategoryValidation).Context("operation", "mkdirall_invalid_path").Build()
 		}
 		return relPath, nil
 	}

--- a/internal/securefs/securefs.go
+++ b/internal/securefs/securefs.go
@@ -324,6 +324,23 @@ func (sfs *SecureFS) MkdirAll(path string, perm os.FileMode) error {
 // escapes are theoretically possible since EvalSymlinks is intentionally skipped.
 func (sfs *SecureFS) mkdirAllWindows(relPath string, perm os.FileMode) error {
 	absPath := filepath.Join(sfs.baseDir, relPath)
+	current := sfs.baseDir
+	for component := range strings.SplitSeq(relPath, string(filepath.Separator)) {
+		if component == "" {
+			continue
+		}
+		current = filepath.Join(current, component)
+		info, err := os.Lstat(current)
+		if err != nil {
+			if os.IsNotExist(err) {
+				break
+			}
+			return errors.New(err).Component(componentSecurefs).Category(errors.CategoryFileIO).Context("operation", "mkdirall_windows_stat").Build()
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return errors.New(ErrPathTraversal).Component(componentSecurefs).Category(errors.CategoryValidation).Context("operation", "mkdirall_windows_junction").Build()
+		}
+	}
 	if err := os.MkdirAll(absPath, perm); err != nil {
 		return errors.New(err).Component(componentSecurefs).Category(errors.CategoryFileIO).Context("operation", "mkdirall_windows").Build()
 	}


### PR DESCRIPTION
## Summary

- `os.Root.Mkdir` hangs indefinitely on Windows 11 25H2 with Go 1.26 when called on directories that already exist
- The hang occurs in the spectrogram generation flow: `GenerateFromFile` -> `ensureOutputDirectory` -> `SecureFS.MkdirAll` -> `RelativePath` -> `filepath.EvalSymlinks` (hangs forever when `os.Root` holds a handle to the base directory)
- Added a Windows-specific code path in `MkdirAll` that uses `os.MkdirAll` directly after validating the path stays within the base directory
- Added `resolveRelPath` helper that avoids `filepath.EvalSymlinks` for absolute paths

## Root Cause

`SecureFS.MkdirAll` called `RelativePath()` which internally invokes `filepath.EvalSymlinks` via `IsPathWithinBaseWithCache`. On Windows, `filepath.EvalSymlinks` uses `NtCreateFile` or `GetFinalPathNameByHandle`, and this hangs when `os.Root` already holds a handle to the base directory. The result is that the spectrogram endpoint (`/api/v2/spectrogram/:id`) hangs with 0 bytes returned until client timeout.

## Verification

Tested on Windows 11 QA VM (Build 26200, 25H2):
- Before fix: spectrogram endpoint hangs indefinitely (0 bytes, curl timeout)
- After fix: returns 200 OK with valid 1026x513 PNG in ~25ms (first request), ~1.6ms (cached)
- Audio endpoint unaffected (always worked)
- All 44 securefs tests pass, zero lint issues

## Related Issues

Fixes #2845

## Test Plan

- [x] Verified on Windows 11 QA VM (spectrogram endpoint returns 200 with valid PNG)
- [x] Audio endpoint still works (200, correct FLAC file)
- [x] Spectrogram status endpoint still works
- [x] Cached spectrogram fast path works (1.6ms)
- [x] `go test -race ./internal/securefs/` passes (44 tests)
- [x] `golangci-lint run -v` passes
- [x] Local CodeRabbit review: no findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed directory creation issues on Windows by using a Windows-safe creation path.

* **Security / Hardening**
  * Improved path validation for directory creation to reject traversal/invalid inputs and avoid evaluating symlinks, increasing robustness and safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->