### PR TITLE
refactor(securefs): remove unnecessary Windows workarounds

### DIFF
--- a/internal/securefs/securefs.go
+++ b/internal/securefs/securefs.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"time"
 
@@ -93,13 +92,7 @@ func resolveAbsPath(cache *PathCache, path string) (string, error) {
 }
 
 // resolveSymlinks resolves symlinks for a path, using cache if available.
-// On Windows, skipped: filepath.EvalSymlinks hangs when os.Root holds the base
-// directory handle (Go 1.26, Windows 11). os.Root provides kernel-level protection.
 func resolveSymlinks(cache *PathCache, path string) string {
-	if runtime.GOOS == "windows" {
-		return path
-	}
-
 	var resolved string
 	var err error
 
@@ -227,7 +220,7 @@ func (sfs *SecureFS) RelativePath(path string) (string, error) {
 	}
 
 	// Using the cached version of IsPathWithinBase for better performance
-	cacheKey := fmt.Sprintf("%s|%s", sfs.baseDir, absPath)
+	cacheKey := sfs.baseDir + "|" + absPath
 	isWithin, err := sfs.cache.GetWithinBase(cacheKey, func() (bool, error) {
 		return IsPathWithinBaseWithCache(sfs.cache, sfs.baseDir, absPath)
 	})
@@ -288,25 +281,14 @@ func (sfs *SecureFS) createDirComponent(path string, perm os.FileMode) error {
 }
 
 // MkdirAll creates a directory and all necessary parent directories with path validation.
-//
-// On Windows, os.Root.Mkdir can hang indefinitely when called on directories
-// that already exist (observed on Windows 11 25H2 with Go 1.26). This is
-// suspected to be a Go runtime issue with NtCreateFile holding the directory
-// handle when FILE_CREATE disposition encounters an existing object. As a
-// workaround, Windows uses os.MkdirAll on the resolved absolute path instead
-// of os.Root.Mkdir, after validating the path stays within the base directory.
 func (sfs *SecureFS) MkdirAll(path string, perm os.FileMode) error {
-	relPath, err := sfs.resolveRelPath(path)
+	relPath, err := sfs.RelativePath(path)
 	if err != nil {
 		return err
 	}
 
 	if relPath == "" || relPath == "." {
 		return nil
-	}
-
-	if runtime.GOOS == "windows" {
-		return sfs.mkdirAllWindows(relPath, perm)
 	}
 
 	components := strings.Split(relPath, string(filepath.Separator))
@@ -324,58 +306,6 @@ func (sfs *SecureFS) MkdirAll(path string, perm os.FileMode) error {
 	}
 
 	return nil
-}
-
-// mkdirAllWindows bypasses os.Root.Mkdir and uses os.MkdirAll directly.
-// This trades os.Root's kernel-level sandboxing for reliability; the caller
-// (resolveRelPath) validates the path stays within baseDir, but symlink-based
-// escapes are theoretically possible since EvalSymlinks is intentionally skipped.
-func (sfs *SecureFS) mkdirAllWindows(relPath string, perm os.FileMode) error {
-	absPath := filepath.Join(sfs.baseDir, relPath)
-	current := sfs.baseDir
-	for component := range strings.SplitSeq(relPath, string(filepath.Separator)) {
-		if component == "" {
-			continue
-		}
-		current = filepath.Join(current, component)
-		info, err := os.Lstat(current)
-		if err != nil {
-			if os.IsNotExist(err) {
-				break
-			}
-			return errors.New(err).Component(componentSecurefs).Category(errors.CategoryFileIO).Context("operation", "mkdirall_windows_stat").Build()
-		}
-		if info.Mode()&os.ModeSymlink != 0 {
-			return errors.New(ErrPathTraversal).Component(componentSecurefs).Category(errors.CategoryValidation).Context("operation", "mkdirall_windows_junction").Build()
-		}
-	}
-	if err := os.MkdirAll(absPath, perm); err != nil {
-		return errors.New(err).Component(componentSecurefs).Category(errors.CategoryFileIO).Context("operation", "mkdirall_windows").Build()
-	}
-	return nil
-}
-
-// resolveRelPath converts a path to a validated relative path for use with os.Root.
-// For absolute paths, it uses filepath.Rel directly (avoiding filepath.EvalSymlinks
-// which can hang on Windows when os.Root holds a handle to the base directory).
-// For relative paths, it delegates to ValidateRelativePath.
-func (sfs *SecureFS) resolveRelPath(path string) (string, error) {
-	cleanPath := filepath.Clean(path)
-	if filepath.IsAbs(cleanPath) {
-		relPath, err := filepath.Rel(sfs.baseDir, cleanPath)
-		if err != nil {
-			return "", errors.New(err).Component(componentSecurefs).Category(errors.CategoryValidation).Context("operation", "mkdirall_rel").Build()
-		}
-		relPath = strings.TrimPrefix(relPath, string(filepath.Separator))
-		if strings.HasPrefix(relPath, ".."+string(filepath.Separator)) || relPath == ".." {
-			return "", errors.New(ErrPathTraversal).Component(componentSecurefs).Category(errors.CategoryValidation).Context("operation", "mkdirall_traversal").Build()
-		}
-		if !filepath.IsLocal(relPath) {
-			return "", errors.New(ErrInvalidPath).Component(componentSecurefs).Category(errors.CategoryValidation).Context("operation", "mkdirall_invalid_path").Build()
-		}
-		return relPath, nil
-	}
-	return sfs.ValidateRelativePath(path)
 }
 
 // removeAllRelative removes a path using already-validated relative path


### PR DESCRIPTION
## Summary

- Remove Windows-specific workarounds from SecureFS that were based on a wrong root cause diagnosis
- The Windows spectrogram hang was caused by an infinite loop in `resolveParentSymlinks` (`filepath.Dir("C:\")` returns `"C:\"` which never matches Unix-centric loop termination), not by `filepath.EvalSymlinks` or `os.Root.Mkdir`
- The actual fix (parent == dir loop guard) was already merged in #2959
- `MkdirAll` now uses `RelativePath` like every other SecureFS method, restoring consistent symlink-aware validation on all platforms

**Removed:**
- `resolveSymlinks` Windows no-op (EvalSymlinks works fine on Windows)
- `mkdirAllWindows` function (os.Root.Mkdir works correctly on Windows)
- `resolveRelPath` helper (was only needed to avoid EvalSymlinks)
- `runtime` import (no longer needed)
- Incorrect doc comments attributing the hang to os.Root.Mkdir

**Kept:**
- The `parent == dir` loop guard in `resolveParentSymlinks` (the real fix from #2959)

## Test Plan

- [x] All 44 securefs tests pass with `-race`
- [x] Zero lint issues
- [x] Verified on Windows 11 25H2 QA VM that `filepath.EvalSymlinks` and `os.Root.Mkdir` work correctly (standalone tests pass)
- [x] Root cause confirmed via instrumented binary: infinite `resolveSymlinks("C:\")` loop in logs (700MB/5s of cached cache hits)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved cross-platform file system consistency and performance in internal path handling and directory operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->