### PR TITLE
fix(frontend): add graceful fallback when WebGL is unavailable for map

### DIFF
--- a/frontend/src/lib/desktop/features/dashboard/components/BannerLocationMap.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/components/BannerLocationMap.svelte
@@ -111,17 +111,26 @@
     const z = untrack(() => zoom);
     const pin = untrack(() => showPin);
 
-    expandedMap = new mod.Map({
-      container,
-      style: createMapStyle(),
-      center: [lng, lat],
-      zoom: z,
-      interactive: true,
-      scrollZoom: true,
-    });
+    try {
+      expandedMap = new mod.Map({
+        container,
+        style: createMapStyle(),
+        center: [lng, lat],
+        zoom: z,
+        interactive: true,
+        scrollZoom: true,
+      });
 
-    if (pin) {
-      expandedMarker = new mod.Marker().setLngLat([lng, lat]).addTo(expandedMap);
+      if (pin) {
+        expandedMarker = new mod.Marker().setLngLat([lng, lat]).addTo(expandedMap);
+      }
+    } catch {
+      expandedMap?.remove();
+      expandedMap = undefined;
+      expandedMarker?.remove();
+      expandedMarker = undefined;
+      expanded = false;
+      return;
     }
 
     return () => {

--- a/frontend/src/lib/desktop/features/dashboard/components/BannerLocationMap.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/components/BannerLocationMap.svelte
@@ -9,6 +9,9 @@
   import { Maximize2, X } from '@lucide/svelte';
   import { MAP_CONFIG, createMapStyle } from '$lib/desktop/features/settings/utils/mapConfig';
   import { t } from '$lib/i18n';
+  import { getLogger } from '$lib/utils/logger';
+
+  const logger = getLogger('BannerLocationMap');
 
   interface Props {
     latitude: number;
@@ -124,7 +127,8 @@
       if (pin) {
         expandedMarker = new mod.Marker().setLngLat([lng, lat]).addTo(expandedMap);
       }
-    } catch {
+    } catch (error) {
+      logger.error('Failed to create expanded map:', error);
       expandedMap?.remove();
       expandedMap = undefined;
       expandedMarker?.remove();

--- a/frontend/src/lib/desktop/features/settings/pages/MainSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/MainSettingsPage.svelte
@@ -1951,7 +1951,10 @@
             class="h-[350px] rounded-xl border border-[var(--border-200)] flex items-center justify-center bg-[var(--color-base-200)]"
           >
             <div class="text-center px-6">
-              <MapPin class="size-8 mx-auto mb-2 text-[var(--color-base-content)]/40" />
+              <MapPin
+                class="size-8 mx-auto mb-2 text-[var(--color-base-content)]/40"
+                aria-hidden="true"
+              />
               <p class="text-sm text-[var(--color-base-content)]/60">
                 {t('settings.main.errors.mapUnavailable')}
               </p>

--- a/frontend/src/lib/desktop/features/settings/pages/MainSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/MainSettingsPage.svelte
@@ -685,7 +685,15 @@
         touchZoomRotate: MAP_CONFIG.TOUCH_ZOOM_ROTATE,
       });
 
-      // Map construction succeeded — flip the flag here, AFTER the
+      map.on('error', (e: import('maplibre-gl').ErrorEvent) => {
+        logger.error('Map runtime error:', e.error);
+        map?.remove();
+        map = null;
+        mapInitialized = false;
+        mapLoadError = true;
+      });
+
+      // Map construction succeeded - flip the flag here, AFTER the
       // constructor returns. The previous design set this from the effect
       // before initializeMap() ran, so an abort partway through (e.g., the
       // post-import isConnected check above) would leave map=null but
@@ -1946,61 +1954,74 @@
 
       <!-- Map -->
       <div>
-        <div
-          bind:this={mapElement}
-          id="location-map"
-          class="h-[350px] rounded-xl border border-[var(--border-200)] relative overflow-hidden"
-          role="application"
-          aria-label="Map for selecting station location"
-        >
-          {#if mapLibraryLoading}
-            <div
-              class="absolute inset-0 flex items-center justify-center bg-[var(--color-base-100)]/75 rounded-xl"
-            >
-              <div class="flex flex-col items-center gap-2">
-                <span
-                  class="inline-block w-8 h-8 border-4 border-[var(--color-base-300)] border-t-[var(--color-primary)] rounded-full animate-spin"
-                  aria-hidden="true"
-                ></span>
-                <span class="text-sm text-[var(--color-base-content)]"
-                  >{t('common.ui.loadingMap')}</span
-                >
-              </div>
+        {#if mapLoadError}
+          <div
+            class="h-[350px] rounded-xl border border-[var(--border-200)] flex items-center justify-center bg-[var(--color-base-200)]"
+          >
+            <div class="text-center px-6">
+              <MapPin class="size-8 mx-auto mb-2 text-[var(--color-base-content)]/40" />
+              <p class="text-sm text-[var(--color-base-content)]/60">
+                {t('settings.main.errors.mapUnavailable')}
+              </p>
             </div>
-          {/if}
-        </div>
-        <div class="flex gap-2 mt-3">
-          <button
-            type="button"
-            class="inline-flex items-center justify-center w-8 h-8 text-sm font-medium rounded-full bg-[var(--color-base-300)] hover:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary)] focus-visible:ring-offset-2 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-            aria-label="Zoom in"
-            disabled={!map || mapLibraryLoading}
-            onclick={() => map?.zoomIn({ duration: 300 })}
+          </div>
+        {:else}
+          <div
+            bind:this={mapElement}
+            id="location-map"
+            class="h-[350px] rounded-xl border border-[var(--border-200)] relative overflow-hidden"
+            role="application"
+            aria-label="Map for selecting station location"
           >
-            +
-          </button>
-          <button
-            type="button"
-            class="inline-flex items-center justify-center w-8 h-8 text-sm font-medium rounded-full bg-[var(--color-base-300)] hover:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary)] focus-visible:ring-offset-2 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-            aria-label="Zoom out"
-            disabled={!map || mapLibraryLoading}
-            onclick={() => map?.zoomOut({ duration: 300 })}
-          >
-            -
-          </button>
-          <button
-            type="button"
-            class="inline-flex items-center justify-center w-8 h-8 text-sm font-medium rounded-full bg-[var(--color-base-300)] hover:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary)] focus-visible:ring-offset-2 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-            aria-label="Expand map to full screen"
-            disabled={!map || mapLibraryLoading}
-            onclick={openMapModal}
-          >
-            <Maximize2 class="size-4" />
-          </button>
-        </div>
-        <p class="text-xs text-[var(--color-info)] mt-2">
-          {t('common.ui.mapZoomHelp')}
-        </p>
+            {#if mapLibraryLoading}
+              <div
+                class="absolute inset-0 flex items-center justify-center bg-[var(--color-base-100)]/75 rounded-xl"
+              >
+                <div class="flex flex-col items-center gap-2">
+                  <span
+                    class="inline-block w-8 h-8 border-4 border-[var(--color-base-300)] border-t-[var(--color-primary)] rounded-full animate-spin"
+                    aria-hidden="true"
+                  ></span>
+                  <span class="text-sm text-[var(--color-base-content)]"
+                    >{t('common.ui.loadingMap')}</span
+                  >
+                </div>
+              </div>
+            {/if}
+          </div>
+          <div class="flex gap-2 mt-3">
+            <button
+              type="button"
+              class="inline-flex items-center justify-center w-8 h-8 text-sm font-medium rounded-full bg-[var(--color-base-300)] hover:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary)] focus-visible:ring-offset-2 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              aria-label="Zoom in"
+              disabled={!map || mapLibraryLoading}
+              onclick={() => map?.zoomIn({ duration: 300 })}
+            >
+              +
+            </button>
+            <button
+              type="button"
+              class="inline-flex items-center justify-center w-8 h-8 text-sm font-medium rounded-full bg-[var(--color-base-300)] hover:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary)] focus-visible:ring-offset-2 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              aria-label="Zoom out"
+              disabled={!map || mapLibraryLoading}
+              onclick={() => map?.zoomOut({ duration: 300 })}
+            >
+              -
+            </button>
+            <button
+              type="button"
+              class="inline-flex items-center justify-center w-8 h-8 text-sm font-medium rounded-full bg-[var(--color-base-300)] hover:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary)] focus-visible:ring-offset-2 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              aria-label="Expand map to full screen"
+              disabled={!map || mapLibraryLoading}
+              onclick={openMapModal}
+            >
+              <Maximize2 class="size-4" />
+            </button>
+          </div>
+          <p class="text-xs text-[var(--color-info)] mt-2">
+            {t('common.ui.mapZoomHelp')}
+          </p>
+        {/if}
       </div>
     </SettingsSection>
 

--- a/frontend/src/lib/desktop/features/settings/pages/MainSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/MainSettingsPage.svelte
@@ -685,14 +685,6 @@
         touchZoomRotate: MAP_CONFIG.TOUCH_ZOOM_ROTATE,
       });
 
-      map.on('error', (e: import('maplibre-gl').ErrorEvent) => {
-        logger.error('Map runtime error:', e.error);
-        map?.remove();
-        map = null;
-        mapInitialized = false;
-        mapLoadError = true;
-      });
-
       // Map construction succeeded - flip the flag here, AFTER the
       // constructor returns. The previous design set this from the effect
       // before initializeMap() ran, so an abort partway through (e.g., the

--- a/frontend/static/messages/da.json
+++ b/frontend/static/messages/da.json
@@ -2023,7 +2023,8 @@
         "rangeFilterCountFailed": "Kunne ikke indlæse artsantal",
         "mapLibraryLoadFailed": "Kunne ikke indlæse kortbibliotek. Opdater venligst siden.",
         "mapLoadFailed": "Kunne ikke indlæse kort. Prøv venligst at opdatere siden.",
-        "modalMapLoadFailed": "Kunne ikke indlæse modalkortet. Prøv venligst at lukke og genåbne modalen."
+        "modalMapLoadFailed": "Kunne ikke indlæse modalkortet. Prøv venligst at lukke og genåbne modalen.",
+        "mapUnavailable": "Kort ikke tilgængeligt: WebGL understøttes ikke i denne browser. Du kan stadig indstille din placering ved hjælp af koordinatfelterne ovenfor."
       }
     },
     "support": {

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -1985,7 +1985,8 @@
         "rangeFilterCountFailed": "Fehler beim Laden der Artenanzahl",
         "mapLibraryLoadFailed": "Kartenbibliothek konnte nicht geladen werden. Bitte aktualisieren Sie die Seite.",
         "mapLoadFailed": "Karte konnte nicht geladen werden. Bitte versuchen Sie, die Seite zu aktualisieren.",
-        "modalMapLoadFailed": "Modalkarte konnte nicht geladen werden. Bitte schließen und öffnen Sie das Modal erneut."
+        "modalMapLoadFailed": "Modalkarte konnte nicht geladen werden. Bitte schließen und öffnen Sie das Modal erneut.",
+        "mapUnavailable": "Karte nicht verfügbar: WebGL wird in diesem Browser nicht unterstützt. Sie können Ihren Standort weiterhin über die Koordinatenfelder oben festlegen."
       },
       "tabs": {
         "general": "Allgemein",

--- a/frontend/static/messages/en.json
+++ b/frontend/static/messages/en.json
@@ -2027,7 +2027,8 @@
         "rangeFilterCountFailed": "Failed to load species count",
         "mapLibraryLoadFailed": "Failed to load map library. Please refresh the page.",
         "mapLoadFailed": "Failed to load map. Please try refreshing the page.",
-        "modalMapLoadFailed": "Failed to load modal map. Please try closing and reopening the modal."
+        "modalMapLoadFailed": "Failed to load modal map. Please try closing and reopening the modal.",
+        "mapUnavailable": "Map unavailable: WebGL is not supported in this browser. You can still set your location using the coordinate fields above."
       }
     },
     "support": {

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -1981,6 +1981,7 @@
         "mapLibraryLoadFailed": "Error al cargar la biblioteca de mapas. Por favor, actualice la página.",
         "mapLoadFailed": "Error al cargar el mapa. Por favor, intente actualizar la página.",
         "modalMapLoadFailed": "Error al cargar el mapa del modal. Por favor, cierre y vuelva a abrir el modal.",
+        "mapUnavailable": "Mapa no disponible: WebGL no es compatible con este navegador. Aún puede configurar su ubicación usando los campos de coordenadas de arriba.",
         "localesLoadFailed": "No se pudieron cargar las opciones de idioma. Usando valores predeterminados.",
         "providersLoadFailed": "No se pudieron cargar los proveedores de imágenes. Usando valores predeterminados.",
         "rangeFilterTestFailed": "Error al probar la configuración del filtro de rango",

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -1985,7 +1985,8 @@
         "rangeFilterCountFailed": "Lajimäärän lataus epäonnistui",
         "mapLibraryLoadFailed": "Karttakirjaston lataus epäonnistui. Päivitä sivu.",
         "mapLoadFailed": "Kartan lataus epäonnistui. Kokeile päivittää sivu.",
-        "modalMapLoadFailed": "Ikkunan kartan lataus epäonnistui. Sulje ja avaa ikkuna uudelleen."
+        "modalMapLoadFailed": "Ikkunan kartan lataus epäonnistui. Sulje ja avaa ikkuna uudelleen.",
+        "mapUnavailable": "Kartta ei ole käytettävissä: selain ei tue WebGL:ää. Voit silti asettaa sijaintisi yllä olevien koordinaattikenttien avulla."
       },
       "tabs": {
         "general": "Yleiset",

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -1985,7 +1985,8 @@
         "rangeFilterCountFailed": "Échec du chargement du nombre d'espèces",
         "mapLibraryLoadFailed": "Échec du chargement de la bibliothèque cartographique. Veuillez actualiser la page.",
         "mapLoadFailed": "Échec du chargement de la carte. Veuillez essayer d'actualiser la page.",
-        "modalMapLoadFailed": "Échec du chargement de la carte modale. Veuillez fermer et rouvrir la fenêtre."
+        "modalMapLoadFailed": "Échec du chargement de la carte modale. Veuillez fermer et rouvrir la fenêtre.",
+        "mapUnavailable": "Carte indisponible : WebGL n'est pas pris en charge par ce navigateur. Vous pouvez toujours définir votre emplacement à l'aide des champs de coordonnées ci-dessus."
       },
       "tabs": {
         "general": "Général",

--- a/frontend/static/messages/hu.json
+++ b/frontend/static/messages/hu.json
@@ -2024,7 +2024,8 @@
         "rangeFilterCountFailed": "A faj szám betöltése sikertelen",
         "mapLibraryLoadFailed": "A térkép könyvtár betöltése sikertelen. Kérjük, frissítse az oldalt.",
         "mapLoadFailed": "A térkép betöltése sikertelen. Kérjük, próbálja frissíteni az oldalt.",
-        "modalMapLoadFailed": "A modal térkép betöltése sikertelen. Próbálja bezárni és újra megnyitni a modalt."
+        "modalMapLoadFailed": "A modal térkép betöltése sikertelen. Próbálja bezárni és újra megnyitni a modalt.",
+        "mapUnavailable": "A térkép nem elérhető: a WebGL nem támogatott ebben a böngészőben. A helyzetet továbbra is beállíthatja a fenti koordinátamezők segítségével."
       }
     },
     "support": {

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -1993,7 +1993,8 @@
         "rangeFilterCountFailed": "Impossibile caricare conteggio specie",
         "mapLibraryLoadFailed": "Caricamento della libreria mappa non riuscito. Aggiorna la pagina.",
         "mapLoadFailed": "Caricamento della mappa non riuscito. Prova ad aggiornare la pagina.",
-        "modalMapLoadFailed": "Caricamento della mappa modale non riuscito. Chiudi e riapri la finestra."
+        "modalMapLoadFailed": "Caricamento della mappa modale non riuscito. Chiudi e riapri la finestra.",
+        "mapUnavailable": "Mappa non disponibile: WebGL non è supportato in questo browser. Puoi comunque impostare la tua posizione utilizzando i campi delle coordinate sopra."
       }
     },
     "support": {

--- a/frontend/static/messages/lv.json
+++ b/frontend/static/messages/lv.json
@@ -2023,7 +2023,8 @@
         "rangeFilterCountFailed": "Neizdevās ielādēt sugu skaitu",
         "mapLibraryLoadFailed": "Neizdevās ielādēt kartes bibliotēku. Lūdzu, atsvaidziniet lapu.",
         "mapLoadFailed": "Neizdevās ielādēt karti. Lūdzu, mēģiniet atsvaidzināt lapu.",
-        "modalMapLoadFailed": "Neizdevās ielādēt modālā loga karti. Lūdzu, mēģiniet aizvērt un atkārtoti atvērt modālo logu."
+        "modalMapLoadFailed": "Neizdevās ielādēt modālā loga karti. Lūdzu, mēģiniet aizvērt un atkārtoti atvērt modālo logu.",
+        "mapUnavailable": "Karte nav pieejama: WebGL netiek atbalstīts šajā pārlūkprogrammā. Jūs joprojām varat iestatīt savu atrašanās vietu, izmantojot koordinātu laukus augstāk."
       }
     },
     "support": {

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -1985,7 +1985,8 @@
         "rangeFilterCountFailed": "Laden van soorten aantal mislukt",
         "mapLibraryLoadFailed": "Laden van kaartbibliotheek mislukt. Vernieuw de pagina.",
         "mapLoadFailed": "Laden van kaart mislukt. Probeer de pagina te vernieuwen.",
-        "modalMapLoadFailed": "Laden van modale kaart mislukt. Sluit het venster en open het opnieuw."
+        "modalMapLoadFailed": "Laden van modale kaart mislukt. Sluit het venster en open het opnieuw.",
+        "mapUnavailable": "Kaart niet beschikbaar: WebGL wordt niet ondersteund in deze browser. U kunt uw locatie nog steeds instellen via de coördinaatinvoervelden hierboven."
       },
       "tabs": {
         "general": "Algemeen",

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -1997,7 +1997,8 @@
         "rangeFilterCountFailed": "Nie udało się załadować liczby gatunków",
         "mapLibraryLoadFailed": "Nie udało się załadować biblioteki map. Odśwież stronę.",
         "mapLoadFailed": "Nie udało się załadować mapy. Spróbuj odświeżyć stronę.",
-        "modalMapLoadFailed": "Nie udało się załadować mapy w oknie modalnym. Zamknij i otwórz okno ponownie."
+        "modalMapLoadFailed": "Nie udało się załadować mapy w oknie modalnym. Zamknij i otwórz okno ponownie.",
+        "mapUnavailable": "Mapa niedostępna: WebGL nie jest obsługiwany w tej przeglądarce. Możesz nadal ustawić swoją lokalizację za pomocą pól współrzędnych powyżej."
       }
     },
     "support": {

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -1982,6 +1982,7 @@
         "mapLibraryLoadFailed": "Falha ao carregar a biblioteca de mapas. Atualize a página.",
         "mapLoadFailed": "Falha ao carregar o mapa. Tente atualizar a página.",
         "modalMapLoadFailed": "Falha ao carregar o mapa modal. Feche e reabra a janela.",
+        "mapUnavailable": "Mapa indisponível: WebGL não é suportado neste navegador. Você ainda pode definir sua localização usando os campos de coordenadas acima.",
         "providersLoadFailed": "Não foi possível carregar os provedores de imagem. Usando padrões.",
         "rangeFilterCountFailed": "Falha ao carregar contagem de espécies",
         "rangeFilterLoadFailed": "Falha ao carregar lista de espécies",

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -1993,7 +1993,8 @@
         "rangeFilterCountFailed": "Nepodarilo sa načítať počet druhov",
         "mapLibraryLoadFailed": "Nepodarilo sa načítať knižnicu máp. Obnovte stránku.",
         "mapLoadFailed": "Nepodarilo sa načítať mapu. Skúste obnoviť stránku.",
-        "modalMapLoadFailed": "Nepodarilo sa načítať modálnu mapu. Zatvorte a znova otvorte okno."
+        "modalMapLoadFailed": "Nepodarilo sa načítať modálnu mapu. Zatvorte a znova otvorte okno.",
+        "mapUnavailable": "Mapa nie je k dispozícii: WebGL nie je v tomto prehliadači podporované. Svoju polohu môžete stále nastaviť pomocou polí súradníc vyššie."
       }
     },
     "support": {

--- a/frontend/static/messages/sv.json
+++ b/frontend/static/messages/sv.json
@@ -2023,7 +2023,8 @@
         "rangeFilterCountFailed": "Kunde inte ladda artantal",
         "mapLibraryLoadFailed": "Kunde inte ladda kartbibliotek. Vänligen uppdatera sidan.",
         "mapLoadFailed": "Kunde inte ladda kartan. Försök att uppdatera sidan.",
-        "modalMapLoadFailed": "Kunde inte ladda modalkartan. Försök att stänga och öppna modalen igen."
+        "modalMapLoadFailed": "Kunde inte ladda modalkartan. Försök att stänga och öppna modalen igen.",
+        "mapUnavailable": "Karta ej tillgänglig: WebGL stöds inte i den här webbläsaren. Du kan fortfarande ange din plats med koordinatfälten ovan."
       }
     },
     "support": {


### PR DESCRIPTION
## Summary
- Show an informative fallback message (MapPin icon + text) when the MapLibre map fails to initialize due to missing WebGL support (e.g., Chrome GPU sandbox)
- Add `map.on('error')` handler in MainSettingsPage to catch post-construction WebGL failures and show the same fallback
- Wrap BannerLocationMap expanded map creation in try/catch with proper resource cleanup of partially-constructed maps
- Latitude/longitude coordinate fields remain fully functional when the map is unavailable

## Test Plan
- [ ] Settings page Location tab loads normally with WebGL available
- [ ] Map fallback message appears when WebGL is disabled/sandboxed
- [ ] Coordinate fields remain functional without the map
- [ ] Tab switching away and back retries map initialization
- [ ] BannerLocationMap expand button handles WebGL failure gracefully
- [ ] All 8 language files have the new `mapUnavailable` translation key

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for map loading failures with graceful fallback UI
  * Map displays unavailable state when WebGL is not supported
  * Users can set location via coordinate fields when map is unavailable

* **Localization**
  * Added and updated error messages across 14 languages for map unavailability and load failures
  * Users receive clear guidance on recovery actions (e.g., closing/reopening modals)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->