### PR TITLE
fix(audiocore): derive detection offset from model clip length

### DIFF
--- a/internal/analysis/buffer_manager.go
+++ b/internal/analysis/buffer_manager.go
@@ -385,7 +385,12 @@ func (m *BufferManager) UpdateMonitors(sourceModels map[string][]monitorConfig) 
 // analysisBufferMonitor reads from the audiocore analysis buffer and feeds
 // audio chunks to the BirdNET analysis pipeline.
 func (m *BufferManager) analysisBufferMonitor(quitChan chan struct{}, cfg monitorConfig) {
-	const detectionOffset = 10 * time.Second
+	// The detection offset compensates for the age of audio in the analysis
+	// window at read time. Audio is written continuously; when Read() returns
+	// a full window, the oldest sample is approximately ClipLength old. Using
+	// the model's clip length keeps the offset accurate across different models
+	// (3s for BirdNET v2.4, 5s for v3.0/Perch).
+	detectionOffset := cfg.spec.ClipLength
 	const pollInterval = 100 * time.Millisecond
 
 	// Use the model-specific read size from the config instead of the

--- a/internal/analysis/buffer_manager_test.go
+++ b/internal/analysis/buffer_manager_test.go
@@ -129,3 +129,61 @@ func TestMonitorConfig_OverlapSizeDefault(t *testing.T) {
 	}
 	assert.Equal(t, 0, cfg.overlapSize, "overlapSize should default to zero")
 }
+
+// TestDetectionOffset_DerivedFromClipLength validates that the detection offset
+// uses the model's clip length to position bird calls correctly in saved clips.
+// The offset compensates for the age of audio in the analysis window: the oldest
+// sample is approximately ClipLength seconds old when Read() returns. Using
+// ClipLength ensures the bird call appears between PreCapture and
+// (PreCapture + ClipLength) seconds into the saved clip.
+func TestDetectionOffset_DerivedFromClipLength(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		clipLength time.Duration
+		preCapture int
+		capLength  int
+	}{
+		{"BirdNET_v2.4_default", 3 * time.Second, 3, 20},
+		{"BirdNET_v2.4_no_precapture", 3 * time.Second, 0, 15},
+		{"BirdNET_v3.0", 5 * time.Second, 3, 20},
+		{"Perch_v2", 5 * time.Second, 5, 30},
+		{"BirdNET_v2.4_max_precapture", 3 * time.Second, 5, 10},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Replicate the production offset calculation from
+			// analysisBufferMonitor + processMonitorTick.
+			detectionOffset := tt.clipLength
+			preCapture := time.Duration(tt.preCapture) * time.Second
+			beginTimeOffset := preCapture + detectionOffset
+
+			now := time.Now()
+			startTime := now.Add(-beginTimeOffset)
+
+			// The bird vocalized somewhere in the analysis window, which
+			// spans approximately [now - clipLength, now]. With the offset
+			// set to clipLength, the window start maps to PreCapture seconds
+			// into the saved clip.
+			windowStart := now.Add(-tt.clipLength)
+			windowEnd := now
+
+			birdPositionEarliest := windowStart.Sub(startTime)
+			birdPositionLatest := windowEnd.Sub(startTime)
+
+			assert.Equal(t, preCapture, birdPositionEarliest,
+				"bird at window start should appear at PreCapture in clip")
+			assert.Equal(t, preCapture+tt.clipLength, birdPositionLatest,
+				"bird at window end should appear at PreCapture+ClipLength in clip")
+
+			// Verify the clip doesn't overflow the capture length.
+			captureLength := time.Duration(tt.capLength) * time.Second
+			assert.LessOrEqual(t, birdPositionLatest, captureLength,
+				"latest bird position must fit within capture length")
+		})
+	}
+}

--- a/internal/analysis/buffer_manager_test.go
+++ b/internal/analysis/buffer_manager_test.go
@@ -140,10 +140,10 @@ func TestDetectionOffset_DerivedFromClipLength(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name       string
-		clipLength time.Duration
-		preCapture int
-		capLength  int
+		name          string
+		clipLength    time.Duration
+		preCapture    int
+		captureLength int
 	}{
 		{"BirdNET_v2.4_default", 3 * time.Second, 3, 20},
 		{"BirdNET_v2.4_no_precapture", 3 * time.Second, 0, 15},
@@ -181,7 +181,7 @@ func TestDetectionOffset_DerivedFromClipLength(t *testing.T) {
 				"bird at window end should appear at PreCapture+ClipLength in clip")
 
 			// Verify the clip doesn't overflow the capture length.
-			captureLength := time.Duration(tt.capLength) * time.Second
+			captureLength := time.Duration(tt.captureLength) * time.Second
 			assert.LessOrEqual(t, birdPositionLatest, captureLength,
 				"latest bird position must fit within capture length")
 		})

--- a/internal/analysis/processor/processor_timing_test.go
+++ b/internal/analysis/processor/processor_timing_test.go
@@ -98,8 +98,11 @@ func TestDetectionWindowGivesTimeForOverlaps(t *testing.T) {
 // TestFlushDeadlineNotBackdated is a regression test that simulates the exact
 // bug scenario from BG-16. This test would have caught the original bug where
 // FlushDeadline was calculated using the backdated startTime instead of time.Now().
+// NOTE: the production detection offset was changed from a hardcoded 10s to the
+// model's clip length (e.g. 3s for v2.4). This test retains the original 10s
+// value to demonstrate the historical bug at its most visible.
 func TestFlushDeadlineNotBackdated(t *testing.T) {
-	// Simulate the bug scenario exactly with default settings
+	// Simulate the original bug scenario (10s offset made the issue obvious)
 	detectionOffset := 10 * time.Second
 	preCapture := 3 * time.Second
 	backdatedStart := time.Now().Add(-(detectionOffset + preCapture))


### PR DESCRIPTION
## Summary

- Replace hardcoded 10-second detection offset with the model's actual clip length (3s for BirdNET v2.4, 5s for v3.0/Perch)
- Bird calls now appear between PreCapture and (PreCapture + ClipLength) seconds into saved clips instead of ~12s in
- Add table-driven test validating offset calculation across all model types

## Context

The analysis buffer monitor uses a detection offset to compute where in the capture buffer the bird call occurred. The old 10s constant significantly overestimated the audio age, which became visible after the audio pipeline refactor. The oldest sample in the analysis window is approximately ClipLength old (not 10s), so using the model's clip length gives accurate positioning.

**Before (with PreCapture=3s, CaptureLength=20s):**
Bird call appears at ~12s into the clip (offset = 3s + 10s = 13s backdating, too much)

**After:**
Bird call appears at 3-6s into the clip (offset = 3s + 3s = 6s backdating, correct)

## Test plan

- [x] New `TestDetectionOffset_DerivedFromClipLength` validates timing math for v2.4, v3.0, and Perch configurations
- [x] Existing `TestFlushDeadlineNotBackdated` updated with documentation note
- [x] All 2,251 analysis + audiocore tests pass with `-race`
- [x] `golangci-lint` clean
- [ ] Deploy to regression VM with live RTSP audio to verify empirically

Fixes #2823

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a timing issue where analysis flush deadlines could be computed in the past; deadlines now align reliably with detection windows.
  * Detection offset calculation now derives from each model's clip length rather than a fixed constant, improving clip mapping accuracy.

* **Tests**
  * Added regression tests to validate detection offset behavior and to prevent timing-related regressions from recurring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->