### PR TITLE
fix(logging): fix two Windows-specific test failures

### DIFF
--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"os"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -542,6 +543,10 @@ func TestSlogLogger_FileLogging(t *testing.T) {
 
 	t.Run("reopen log file", func(t *testing.T) {
 		t.Helper()
+
+		if runtime.GOOS == "windows" {
+			t.Skip("SIGHUP-based log rotation is a Unix-only pattern; Windows does not allow renaming open files")
+		}
 
 		tmpFile := t.TempDir() + "/test.log"
 

--- a/internal/logger/rotation.go
+++ b/internal/logger/rotation.go
@@ -93,7 +93,8 @@ func (c RotationConfig) IsEnabled() bool {
 // RotationManager handles log file rotation for a BufferedFileWriter.
 type RotationManager struct {
 	config   RotationConfig
-	filePath string // Base path (e.g., "logs/application.log")
+	basePath string // Immutable original path (for deriving rotated/temp names)
+	filePath string // Current write path (may differ from basePath after failed rotation)
 	mu       sync.Mutex
 
 	// Reference to the writer for file swapping
@@ -117,6 +118,7 @@ func NewRotationManager(filePath string, config RotationConfig, writer *Buffered
 	}
 	return &RotationManager{
 		config:   config,
+		basePath: filePath,
 		filePath: filePath,
 		writer:   writer,
 	}
@@ -191,26 +193,22 @@ func (rm *RotationManager) rotateLocked() {
 	}
 
 	// Step 4: Rename old log file to timestamped name
-	newFilePath := rm.filePath + ".new"
+	newFilePath := newFile.Name()
 	renameOldOK := true
 	if err := os.Rename(rm.filePath, rotatedPath); err != nil {
 		fmt.Fprintf(os.Stderr, "rotation: failed to rename old file: %v\n", err)
 		renameOldOK = false
 	}
 
-	// Step 5: Rename the new file to the original path and sync paths.
-	// The final path depends on whether renames succeed.
-	finalLogPath := newFilePath // Default: logging to .new path
-	if renameOldOK {
-		if err := os.Rename(newFilePath, rm.filePath); err == nil {
-			// Success: new log is at the original path
-			finalLogPath = rm.filePath
-		} else {
-			// Failure: new log remains at the .new path
-			fmt.Fprintf(os.Stderr, "rotation: failed to rename new file: %v\n", err)
-		}
+	// Step 5: Try to move the new file to the base path.
+	// Always attempt the rename regardless of step 4 outcome; on Windows
+	// the old file lock may have been released between steps.
+	finalLogPath := newFilePath
+	if err := os.Rename(newFilePath, rm.basePath); err == nil {
+		finalLogPath = rm.basePath
+	} else if renameOldOK {
+		fmt.Fprintf(os.Stderr, "rotation: failed to rename new file: %v\n", err)
 	}
-	// Update both rotation manager and writer to the final canonical path
 	rm.filePath = finalLogPath
 	rm.writer.SetFilePath(finalLogPath)
 
@@ -226,25 +224,32 @@ func (rm *RotationManager) rotateLocked() {
 	rm.disableConsoleFallback()
 }
 
-// createNewFile creates a new log file with .new suffix for atomic swap.
+// createNewFile creates a new log file with a temp suffix for atomic swap.
+// Always derives the path from basePath to prevent .new suffix accumulation.
+// Uses an alternate suffix when the .new path is the active write target.
 func (rm *RotationManager) createNewFile() (*os.File, error) {
-	newPath := rm.filePath + ".new"
+	newPath := rm.basePath + ".new"
+	if rm.filePath == newPath {
+		newPath = rm.basePath + ".rotating"
+	}
 	return os.OpenFile(newPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, LogFilePermissions) //nolint:gosec // path derived from config
 }
 
 // rotatedFilePath generates the path for a rotated file with timestamp.
+// Uses basePath to ensure correct extension even after failed rotations.
 // Example: "logs/application.log" -> "logs/application-2025-01-15T14-30-05Z.log"
 func (rm *RotationManager) rotatedFilePath(timestamp string) string {
-	ext := filepath.Ext(rm.filePath)
-	base := strings.TrimSuffix(rm.filePath, ext)
+	ext := filepath.Ext(rm.basePath)
+	base := strings.TrimSuffix(rm.basePath, ext)
 	return fmt.Sprintf("%s-%s%s", base, timestamp, ext)
 }
 
 // rotatedFilePattern returns a glob pattern matching rotated files.
+// Uses basePath to ensure correct extension even after failed rotations.
 // Example: "logs/application-*Z.log" and "logs/application-*Z.log.gz"
 func (rm *RotationManager) rotatedFilePattern() string {
-	ext := filepath.Ext(rm.filePath)
-	base := strings.TrimSuffix(rm.filePath, ext)
+	ext := filepath.Ext(rm.basePath)
+	base := strings.TrimSuffix(rm.basePath, ext)
 	return fmt.Sprintf("%s-*Z%s", base, ext)
 }
 
@@ -414,7 +419,7 @@ func (rm *RotationManager) recoverDiskSpace() bool {
 
 // testDiskSpace checks if we can create a file (disk has space).
 func (rm *RotationManager) testDiskSpace() bool {
-	testPath := rm.filePath + ".test"
+	testPath := rm.basePath + ".test"
 	f, err := os.Create(testPath) //nolint:gosec // path derived from config
 	if err != nil {
 		return false

--- a/internal/logger/rotation.go
+++ b/internal/logger/rotation.go
@@ -200,14 +200,17 @@ func (rm *RotationManager) rotateLocked() {
 		renameOldOK = false
 	}
 
-	// Step 5: Try to move the new file to the base path.
-	// Always attempt the rename regardless of step 4 outcome; on Windows
-	// the old file lock may have been released between steps.
+	// Step 5: Move the new file to the base path (only if the old file was
+	// moved out of the way). On POSIX, rename overwrites the destination,
+	// so attempting this when the old file is still at basePath would cause
+	// data loss.
 	finalLogPath := newFilePath
-	if err := os.Rename(newFilePath, rm.basePath); err == nil {
-		finalLogPath = rm.basePath
-	} else if renameOldOK {
-		fmt.Fprintf(os.Stderr, "rotation: failed to rename new file: %v\n", err)
+	if renameOldOK {
+		if err := os.Rename(newFilePath, rm.basePath); err == nil {
+			finalLogPath = rm.basePath
+		} else {
+			fmt.Fprintf(os.Stderr, "rotation: failed to rename new file: %v\n", err)
+		}
 	}
 	rm.filePath = finalLogPath
 	rm.writer.SetFilePath(finalLogPath)

--- a/internal/logger/rotation_test.go
+++ b/internal/logger/rotation_test.go
@@ -653,20 +653,20 @@ func TestRotationManager_RepeatedFailedRotations(t *testing.T) {
 	require.NotNil(t, rm)
 
 	for i := range 10 {
-		data := strings.Repeat("x", testDataSmall)
-		_, err = writer.Write([]byte(data))
-		require.NoError(t, err)
-		require.NoError(t, writer.Flush())
+		// Inject rename failure BEFORE rotation: set filePath to .new and
+		// write enough data to the .new file to exceed MaxSize, so the
+		// next CheckAndRotate exercises the suffix-accumulation path.
+		rm.mu.Lock()
+		rm.filePath = logPath + ".new"
+		rm.mu.Unlock()
+		require.NoError(t, os.WriteFile(logPath+".new",
+			[]byte(strings.Repeat("x", testDataSmall)), 0o600))
 
 		rm.CheckAndRotate()
 		time.Sleep(50 * time.Millisecond)
 
-		// Inject rename failure: force filePath to .new (simulating Windows
-		// behavior where os.Rename fails due to file locking).
+		// Read filePath AFTER CheckAndRotate to verify it didn't accumulate
 		rm.mu.Lock()
-		rm.filePath = logPath + ".new"
-		// Ensure the .new file exists for the next rotation cycle
-		_ = os.WriteFile(rm.filePath, []byte("data"), 0o600)
 		currentPath := rm.filePath
 		rm.mu.Unlock()
 

--- a/internal/logger/rotation_test.go
+++ b/internal/logger/rotation_test.go
@@ -194,6 +194,7 @@ func TestRotationConfigFromModuleOutput(t *testing.T) {
 
 func TestRotationManager_rotatedFilePath(t *testing.T) {
 	rm := &RotationManager{
+		basePath: "/logs/application.log",
 		filePath: "/logs/application.log",
 	}
 
@@ -205,6 +206,7 @@ func TestRotationManager_rotatedFilePath(t *testing.T) {
 
 func TestRotationManager_rotatedFilePattern(t *testing.T) {
 	rm := &RotationManager{
+		basePath: "/logs/application.log",
 		filePath: "/logs/application.log",
 	}
 
@@ -561,4 +563,116 @@ func TestWithRotation_DisabledWhenMaxSizeZero(t *testing.T) {
 
 	// Rotation should not be set when disabled
 	assert.Nil(t, writer.rotation)
+}
+
+func TestRotationManager_NoNewSuffixAccumulation(t *testing.T) {
+	// Regression test for GitHub issue #2942: on Windows, when os.Rename fails
+	// during rotation (e.g., file locked by antivirus), subsequent rotations
+	// must not accumulate .new suffixes (app.log.new.new.new...).
+	tempDir := t.TempDir()
+	logPath := filepath.Join(tempDir, "test.log")
+
+	config := RotationConfig{
+		MaxSize:         testMaxSizeSmall,
+		MaxRotatedFiles: testMaxFiles,
+	}
+
+	writer, err := NewBufferedFileWriter(logPath, WithRotation(config))
+	require.NoError(t, err)
+	defer func() { _ = writer.Close() }()
+
+	rm := writer.rotation
+	require.NotNil(t, rm)
+
+	// Simulate a failed rotation by manually setting filePath to .new
+	// (as happens when os.Rename fails on Windows).
+	// Hold mutex to avoid racing with the auto-flush goroutine.
+	rm.mu.Lock()
+	rm.filePath = logPath + ".new"
+	rm.mu.Unlock()
+
+	// Create the .new file so createNewFile can work
+	require.NoError(t, os.WriteFile(logPath+".new", []byte("data"), 0o600))
+
+	// The next createNewFile must NOT create logPath + ".new.new"
+	rm.mu.Lock()
+	f, err := rm.createNewFile()
+	rm.mu.Unlock()
+	require.NoError(t, err)
+	defer func() { _ = f.Close() }()
+
+	createdPath := f.Name()
+	assert.NotContains(t, createdPath, ".new.new",
+		"createNewFile must not accumulate .new suffixes")
+}
+
+func TestRotationManager_RotatedFilePathUsesBasePath(t *testing.T) {
+	// Verify rotated file paths always use the original base path,
+	// even if filePath has diverged after a failed rotation.
+	rm := &RotationManager{
+		basePath: "/logs/application.log",
+		filePath: "/logs/application.log.new",
+	}
+
+	timestamp := "2025-01-15T14-30-05Z"
+	result := rm.rotatedFilePath(timestamp)
+
+	// Must use basePath extension (.log), not filePath extension (.new)
+	assert.Equal(t, "/logs/application-2025-01-15T14-30-05Z.log", result)
+}
+
+func TestRotationManager_RotatedFilePatternUsesBasePath(t *testing.T) {
+	rm := &RotationManager{
+		basePath: "/logs/application.log",
+		filePath: "/logs/application.log.new",
+	}
+
+	result := rm.rotatedFilePattern()
+
+	assert.Equal(t, "/logs/application-*Z.log", result)
+}
+
+func TestRotationManager_RepeatedFailedRotations(t *testing.T) {
+	// Regression test: simulate repeated rename failures (as on Windows with
+	// file locking) by forcing filePath to .new after each rotation cycle.
+	// Verifies that filePath oscillates between .new and .rotating instead
+	// of growing an unbounded .new.new.new... chain.
+	tempDir := t.TempDir()
+	logPath := filepath.Join(tempDir, "test.log")
+
+	config := RotationConfig{
+		MaxSize:         testMaxSizeSmall,
+		MaxRotatedFiles: testMaxFiles,
+	}
+
+	writer, err := NewBufferedFileWriter(logPath, WithRotation(config))
+	require.NoError(t, err)
+	defer func() { _ = writer.Close() }()
+
+	rm := writer.rotation
+	require.NotNil(t, rm)
+
+	for i := range 10 {
+		data := strings.Repeat("x", testDataSmall)
+		_, err = writer.Write([]byte(data))
+		require.NoError(t, err)
+		require.NoError(t, writer.Flush())
+
+		rm.CheckAndRotate()
+		time.Sleep(50 * time.Millisecond)
+
+		// Inject rename failure: force filePath to .new (simulating Windows
+		// behavior where os.Rename fails due to file locking).
+		rm.mu.Lock()
+		rm.filePath = logPath + ".new"
+		// Ensure the .new file exists for the next rotation cycle
+		_ = os.WriteFile(rm.filePath, []byte("data"), 0o600)
+		currentPath := rm.filePath
+		rm.mu.Unlock()
+
+		assert.NotContains(t, currentPath, ".new.new",
+			"iteration %d: filePath must not accumulate .new suffixes, got %s", i, currentPath)
+		assert.NotContains(t, currentPath, ".rotating.rotating",
+			"iteration %d: filePath must not accumulate .rotating suffixes, got %s", i, currentPath)
+	}
 }

--- a/internal/logger/rotation_test.go
+++ b/internal/logger/rotation_test.go
@@ -251,8 +251,11 @@ func TestRotationManager_CheckAndRotate_SizeBasedRotation(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, files, 1, "should have one rotated file")
 
-	// Original file should be empty or small (new file after rotation)
-	info, err := os.Stat(logPath)
+	// Active log file should be empty or small (new file after rotation).
+	// On Windows, the active file may be at .new (rename back to base path
+	// can fail when the file is open), so check the writer's actual path.
+	activePath := writer.FilePath()
+	info, err := os.Stat(activePath)
 	require.NoError(t, err)
 	assert.Less(t, info.Size(), int64(100), "new log file should be small")
 }


### PR DESCRIPTION
## Summary

Follow-up to #2964. Fixes two pre-existing Windows test failures in the logger package:

- **Skip `TestSlogLogger_FileLogging/reopen_log_file` on Windows**: SIGHUP-based log rotation is a Unix-only pattern; `os.Rename` cannot rename files with open handles on Windows
- **Fix `TestRotationManager_CheckAndRotate_SizeBasedRotation`**: check the writer's actual path via `writer.FilePath()` instead of the hardcoded base path, since on Windows the active file may be at `.new` when the rename back fails

## Test Plan

- [x] All 113 logger tests pass on Linux (with race detector)
- [x] Zero test failures on Windows 11 QA VM (was 2 before)
- [x] golangci-lint clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved log file rotation stability and file naming consistency across platforms. Fixed issues where rotated files could accumulate temporary suffixes and lose correct file extensions. Enhanced rotation handling to preserve proper file naming patterns even after rotation failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->