### PR TITLE
feat: add v2.4 embedding extraction and bat detection support

### DIFF
--- a/internal/classifier/bat_onnx.go
+++ b/internal/classifier/bat_onnx.go
@@ -161,10 +161,24 @@ func (b *Bat) ModelName() string { return b.info.Name }
 func (b *Bat) ModelVersion() string { return "1.0" }
 
 // NumSpecies returns the number of bat species.
-func (b *Bat) NumSpecies() int { return b.batClassifier.NumClasses() }
+func (b *Bat) NumSpecies() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.batClassifier == nil {
+		return b.info.NumSpecies
+	}
+	return b.batClassifier.NumClasses()
+}
 
 // Labels returns the bat species labels.
-func (b *Bat) Labels() []string { return b.batClassifier.Labels() }
+func (b *Bat) Labels() []string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.batClassifier == nil {
+		return nil
+	}
+	return b.batClassifier.Labels()
+}
 
 // Close releases resources held by the bat model.
 func (b *Bat) Close() error {

--- a/internal/classifier/bat_onnx.go
+++ b/internal/classifier/bat_onnx.go
@@ -1,0 +1,182 @@
+//go:build onnx
+
+package classifier
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/tphakala/birdnet-go/internal/datastore"
+	"github.com/tphakala/birdnet-go/internal/errors"
+	"github.com/tphakala/birdnet-go/internal/inference"
+	"github.com/tphakala/birdnet-go/internal/logger"
+)
+
+// Bat represents a loaded bat detection model that chains BirdNET v2.4
+// embedding extraction with a custom bat species classifier.
+// Implements ModelInstance. Goroutine-safe via internal mutex.
+type Bat struct {
+	embeddingExtractor inference.EmbeddingExtractor
+	batClassifier      inference.CustomClassifier
+	info               ModelInfo
+	mu                 sync.Mutex
+}
+
+// BatModelConfig holds configuration for creating a Bat model instance.
+type BatModelConfig struct {
+	EmbeddingModelPath  string
+	EmbeddingLabels     []string
+	ClassifierModelPath string
+	ClassifierLabelPath string
+	ONNXRuntimePath     string
+	Threads             int
+}
+
+// NewBat creates a new bat detection model instance.
+func NewBat(cfg *BatModelConfig) (*Bat, error) {
+	log := GetLogger()
+
+	if err := inference.InitONNXRuntime(cfg.ONNXRuntimePath); err != nil {
+		return nil, errors.New(err).
+			Category(errors.CategoryModelInit).
+			Context("onnx_runtime_path", cfg.ONNXRuntimePath).
+			Build()
+	}
+
+	embClassifier, err := inference.NewONNXClassifier(cfg.EmbeddingModelPath, inference.ONNXClassifierOptions{
+		Labels:  cfg.EmbeddingLabels,
+		Threads: cfg.Threads,
+	})
+	if err != nil {
+		return nil, errors.New(err).
+			Category(errors.CategoryModelInit).
+			Context("embedding_model", cfg.EmbeddingModelPath).
+			Build()
+	}
+
+	embExtractor, ok := embClassifier.(inference.EmbeddingExtractor)
+	if !ok {
+		embClassifier.Close()
+		return nil, errors.Newf("embedding model does not support embedding extraction; ensure it has 2 outputs").
+			Category(errors.CategoryModelInit).
+			Context("embedding_model", cfg.EmbeddingModelPath).
+			Build()
+	}
+
+	batCC, err := inference.NewONNXCustomClassifier(cfg.ClassifierModelPath, inference.ONNXCustomClassifierOptions{
+		LabelsPath: cfg.ClassifierLabelPath,
+		Threads:    cfg.Threads,
+	})
+	if err != nil {
+		embClassifier.Close()
+		return nil, errors.New(err).
+			Category(errors.CategoryModelInit).
+			Context("classifier_model", cfg.ClassifierModelPath).
+			Build()
+	}
+
+	batLabels := batCC.Labels()
+	info := ModelInfo{
+		ID:          "Bat",
+		Name:        "Bat Classifier",
+		Description: fmt.Sprintf("Bat species detection with %d species", len(batLabels)),
+		Spec:        ModelSpec{SampleRate: 48000, ClipLength: 3 * time.Second},
+		NumSpecies:  len(batLabels),
+	}
+
+	log.Info("Bat detection model initialized",
+		logger.String("embedding_model", cfg.EmbeddingModelPath),
+		logger.String("classifier_model", cfg.ClassifierModelPath),
+		logger.Int("bat_species", len(batLabels)))
+
+	return &Bat{
+		embeddingExtractor: embExtractor,
+		batClassifier:      batCC,
+		info:               info,
+	}, nil
+}
+
+// Predict runs the two-stage bat detection pipeline: embedding extraction then bat classification.
+func (b *Bat) Predict(ctx context.Context, samples [][]float32) ([]datastore.Results, error) {
+	if len(samples) == 0 || len(samples[0]) == 0 {
+		return nil, errors.Newf("empty audio sample").
+			Category(errors.CategoryValidation).
+			Build()
+	}
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if b.embeddingExtractor == nil || b.batClassifier == nil {
+		return nil, errors.Newf("bat classifier is not initialized").
+			Category(errors.CategoryModelInit).
+			Build()
+	}
+
+	_, embeddings, err := b.embeddingExtractor.PredictWithEmbeddings(samples[0])
+	if err != nil {
+		return nil, errors.New(err).
+			Category(errors.CategoryAudio).
+			Context("model", "Bat").
+			Context("stage", "embedding_extraction").
+			Build()
+	}
+
+	if embeddings == nil {
+		return nil, errors.Newf("embedding model did not produce embeddings").
+			Category(errors.CategoryModelInit).
+			Context("model", "Bat").
+			Build()
+	}
+
+	scores, err := b.batClassifier.PredictEmbedding(embeddings)
+	if err != nil {
+		return nil, errors.New(err).
+			Category(errors.CategoryAudio).
+			Context("model", "Bat").
+			Context("stage", "bat_classification").
+			Build()
+	}
+
+	results, err := pairLabelsAndConfidence(b.batClassifier.Labels(), scores)
+	if err != nil {
+		return nil, err
+	}
+
+	return getTopKResults(results, 10), nil
+}
+
+// Spec returns the audio requirements for the bat model.
+func (b *Bat) Spec() ModelSpec { return b.info.Spec }
+
+// ModelID returns the unique model identifier.
+func (b *Bat) ModelID() string { return b.info.ID }
+
+// ModelName returns the human-readable model name.
+func (b *Bat) ModelName() string { return b.info.Name }
+
+// ModelVersion returns the model version string.
+func (b *Bat) ModelVersion() string { return "1.0" }
+
+// NumSpecies returns the number of bat species.
+func (b *Bat) NumSpecies() int { return b.batClassifier.NumClasses() }
+
+// Labels returns the bat species labels.
+func (b *Bat) Labels() []string { return b.batClassifier.Labels() }
+
+// Close releases resources held by the bat model.
+func (b *Bat) Close() error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.batClassifier != nil {
+		b.batClassifier.Close()
+		b.batClassifier = nil
+	}
+	if b.embeddingExtractor != nil {
+		b.embeddingExtractor.Close()
+		b.embeddingExtractor = nil
+	}
+	return nil
+}

--- a/internal/classifier/bat_stub.go
+++ b/internal/classifier/bat_stub.go
@@ -1,0 +1,23 @@
+//go:build !onnx
+
+package classifier
+
+import "fmt"
+
+// Bat is unavailable without ONNX support.
+type Bat struct{}
+
+// BatModelConfig holds configuration for creating a Bat model instance.
+type BatModelConfig struct {
+	EmbeddingModelPath  string
+	EmbeddingLabels     []string
+	ClassifierModelPath string
+	ClassifierLabelPath string
+	ONNXRuntimePath     string
+	Threads             int
+}
+
+// NewBat returns an error when built without ONNX support.
+func NewBat(_ *BatModelConfig) (*Bat, error) {
+	return nil, fmt.Errorf("Bat model requires ONNX support (build with -tags onnx)")
+}

--- a/internal/classifier/model_registry.go
+++ b/internal/classifier/model_registry.go
@@ -95,6 +95,16 @@ var ModelRegistry = map[string]ModelInfo{
 		ConfigAliases:    []string{conf.ModelIDPerchV2},
 		NumSpecies:       14795,
 	},
+	"Bat": {
+		ID:               "Bat",
+		Name:             "Bat Classifier",
+		Backend:          BackendONNX,
+		DetectionName:    "BattyBirdNET",
+		DetectionVersion: "1.0",
+		Description:      "Bat species detection using BirdNET v2.4 embeddings",
+		Spec:             ModelSpec{SampleRate: 48000, ClipLength: 3 * time.Second},
+		ConfigAliases:    []string{conf.ModelIDBat},
+	},
 }
 
 // birdnetVersionToRegistryID maps user-facing BirdNET version strings to registry IDs.

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -374,6 +374,11 @@ func (o *Orchestrator) loadAdditionalModels(threadAlloc map[string]int) error {
 			if err := o.loadPerch(threads); err != nil {
 				return err
 			}
+		case "Bat":
+			//nolint:staticcheck // SA4023: loadBat always errors in non-onnx build, but returns nil in onnx build
+			if err := o.loadBat(threads); err != nil {
+				return err
+			}
 		default:
 			log.Warn("model registered but no loader implemented",
 				logger.String("registry_id", registryID))

--- a/internal/classifier/orchestrator_bat.go
+++ b/internal/classifier/orchestrator_bat.go
@@ -1,0 +1,13 @@
+//go:build !onnx
+
+package classifier
+
+import "github.com/tphakala/birdnet-go/internal/errors"
+
+// loadBat is the fallback when the onnx build tag is not set.
+func (o *Orchestrator) loadBat(_ int) error {
+	return errors.Newf("Bat model requires ONNX build (compile with -tags onnx)").
+		Component("classifier.orchestrator").
+		Category(errors.CategoryModelInit).
+		Build()
+}

--- a/internal/classifier/orchestrator_bat_onnx.go
+++ b/internal/classifier/orchestrator_bat_onnx.go
@@ -1,0 +1,38 @@
+//go:build onnx
+
+package classifier
+
+import (
+	"github.com/tphakala/birdnet-go/internal/errors"
+	"github.com/tphakala/birdnet-go/internal/logger"
+)
+
+// loadBat creates and registers a bat detection model instance from settings.
+func (o *Orchestrator) loadBat(threads int) error {
+	log := GetLogger()
+	cfg := BatModelConfig{
+		EmbeddingModelPath:  o.Settings.Bat.EmbeddingModel,
+		EmbeddingLabels:     o.Settings.BirdNET.Labels,
+		ClassifierModelPath: o.Settings.Bat.ClassifierModel,
+		ClassifierLabelPath: o.Settings.Bat.LabelPath,
+		ONNXRuntimePath:     o.Settings.BirdNET.ONNXRuntimePath,
+		Threads:             threads,
+	}
+
+	bat, err := NewBat(&cfg)
+	if err != nil {
+		return errors.New(err).
+			Component("classifier.orchestrator").
+			Category(errors.CategoryModelInit).
+			Context("model", "Bat").
+			Build()
+	}
+
+	o.models[bat.ModelID()] = &modelEntry{instance: bat}
+
+	log.Info("Bat model loaded into Orchestrator",
+		logger.String("model_id", bat.ModelID()),
+		logger.Int("species", bat.NumSpecies()))
+
+	return nil
+}

--- a/internal/classifier/orchestrator_bat_onnx.go
+++ b/internal/classifier/orchestrator_bat_onnx.go
@@ -10,6 +10,11 @@ import (
 // loadBat creates and registers a bat detection model instance from settings.
 func (o *Orchestrator) loadBat(threads int) error {
 	log := GetLogger()
+	if !o.Settings.Bat.Enabled {
+		log.Debug("Bat model disabled by configuration")
+		return nil
+	}
+
 	cfg := BatModelConfig{
 		EmbeddingModelPath:  o.Settings.Bat.EmbeddingModel,
 		EmbeddingLabels:     o.Settings.BirdNET.Labels,

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -1177,6 +1177,15 @@ type PerchConfig struct {
 	Threshold float64 `yaml:"threshold" json:"threshold"`                     // confidence threshold for detections
 }
 
+// BatConfig holds configuration for bat detection using BirdNET v2.4 embeddings.
+type BatConfig struct {
+	Enabled         bool    `yaml:"enabled" json:"enabled"`                                     // true to load bat detection at startup
+	EmbeddingModel  string  `yaml:"embeddingmodel,omitempty" json:"embeddingModel,omitempty"`   // path to BirdNET v2.4 embeddings ONNX model
+	ClassifierModel string  `yaml:"classifiermodel,omitempty" json:"classifierModel,omitempty"` // path to bat species classifier ONNX model
+	LabelPath       string  `yaml:"labelpath,omitempty" json:"labelPath,omitempty"`             // path to bat species labels file
+	Threshold       float64 `yaml:"threshold" json:"threshold"`                                 // confidence threshold for bat detections
+}
+
 // ModelsConfig holds global model enablement settings.
 type ModelsConfig struct {
 	Enabled []string `yaml:"enabled" json:"enabled"` // list of model IDs to load (e.g., "birdnet", "perch_v2")
@@ -1498,6 +1507,7 @@ type Settings struct {
 
 	BirdNET BirdNETConfig `yaml:"birdnet" json:"birdnet"` // BirdNET configuration
 	Perch   PerchConfig   `yaml:"perch" json:"perch"`     // Perch v2 model configuration
+	Bat     BatConfig     `yaml:"bat" json:"bat"`         // Bat detection configuration
 	Models  ModelsConfig  `yaml:"models" json:"models"`   // Global model enablement
 
 	TaxonomySynonyms map[string]string `yaml:"taxonomySynonyms" json:"taxonomySynonyms" mapstructure:"taxonomySynonyms"` // Optional scientific-name synonym overrides merged with built-ins

--- a/internal/conf/defaults.go
+++ b/internal/conf/defaults.go
@@ -86,6 +86,13 @@ func setDefaultConfig() {
 	viper.SetDefault("perch.labelpath", "")
 	viper.SetDefault("perch.threshold", 0.5)
 
+	// Bat detection configuration (disabled by default)
+	viper.SetDefault("bat.enabled", false)
+	viper.SetDefault("bat.embeddingmodel", "")
+	viper.SetDefault("bat.classifiermodel", "")
+	viper.SetDefault("bat.labelpath", "")
+	viper.SetDefault("bat.threshold", 0.5)
+
 	// Global model enablement (BirdNET only by default)
 	viper.SetDefault("models.enabled", []string{"birdnet"})
 

--- a/internal/inference/backend.go
+++ b/internal/inference/backend.go
@@ -18,6 +18,33 @@ type Classifier interface {
 	Close()
 }
 
+// EmbeddingExtractor extends Classifier with the ability to also return
+// embedding vectors from models that produce them (e.g., patched BirdNET v2.4).
+type EmbeddingExtractor interface {
+	Classifier
+	// PredictWithEmbeddings runs classification and returns both raw logits
+	// and the embedding vector. Returns nil embeddings if the model does not
+	// produce embeddings.
+	PredictWithEmbeddings(samples []float32) (logits []float32, embeddings []float32, err error)
+}
+
+// CustomClassifier runs secondary classification on embedding vectors.
+// Used for custom classification heads (e.g., bat species from BirdNET embeddings).
+type CustomClassifier interface {
+	// PredictEmbedding runs inference on an embedding vector and returns
+	// sigmoid-applied scores for each class.
+	PredictEmbedding(embeddings []float32) ([]float32, error)
+
+	// NumClasses returns the number of output classes.
+	NumClasses() int
+
+	// Labels returns the classification labels.
+	Labels() []string
+
+	// Close releases all runtime resources.
+	Close()
+}
+
 // RangeFilter abstracts the ML runtime for geographic range filtering.
 // Implementations are NOT goroutine-safe; callers must synchronize access.
 type RangeFilter interface {

--- a/internal/inference/onnx.go
+++ b/internal/inference/onnx.go
@@ -118,17 +118,26 @@ func NewONNXCustomClassifier(modelPath string, opts ONNXCustomClassifierOptions)
 		return nil, fmt.Errorf("ONNX custom classifier requires labels or labels path")
 	}
 
+	var configErr error
 	if opts.Threads > 0 {
 		threads := opts.Threads
 		builder = builder.SessionOptions(func(so *ortlib.SessionOptions) {
-			_ = so.SetIntraOpNumThreads(threads)
-			_ = so.SetInterOpNumThreads(threads)
+			if err := so.SetIntraOpNumThreads(threads); err != nil && configErr == nil {
+				configErr = fmt.Errorf("failed to set IntraOpNumThreads to %d: %w", threads, err)
+			}
+			if err := so.SetInterOpNumThreads(threads); err != nil && configErr == nil {
+				configErr = fmt.Errorf("failed to set InterOpNumThreads to %d: %w", threads, err)
+			}
 		})
 	}
 
 	cc, err := builder.Build()
 	if err != nil {
 		return nil, fmt.Errorf("failed to create ONNX custom classifier: %w", err)
+	}
+	if configErr != nil {
+		_ = cc.Close()
+		return nil, fmt.Errorf("failed to configure ONNX custom classifier session: %w", configErr)
 	}
 
 	return &onnxCustomClassifier{

--- a/internal/inference/onnx.go
+++ b/internal/inference/onnx.go
@@ -73,6 +73,11 @@ func (c *onnxClassifier) Predict(samples []float32) ([]float32, error) {
 	return c.classifier.PredictRaw(samples)
 }
 
+// PredictWithEmbeddings runs ONNX inference, returning both raw logits and embedding vector.
+func (c *onnxClassifier) PredictWithEmbeddings(samples []float32) (logits, embeddings []float32, err error) {
+	return c.classifier.PredictRawWithEmbeddings(samples)
+}
+
 // NumSpecies returns the number of species in the model output.
 func (c *onnxClassifier) NumSpecies() int {
 	return c.numSpecies
@@ -80,6 +85,74 @@ func (c *onnxClassifier) NumSpecies() int {
 
 // Close releases the ONNX session resources.
 func (c *onnxClassifier) Close() {
+	if c.classifier != nil {
+		_ = c.classifier.Close()
+		c.classifier = nil
+	}
+}
+
+// ONNXCustomClassifierOptions configures the ONNX custom classifier.
+type ONNXCustomClassifierOptions struct {
+	Labels     []string // Provide labels directly (takes priority over LabelsPath)
+	LabelsPath string   // Load labels from file (text, CSV, or JSON)
+	Threads    int
+}
+
+type onnxCustomClassifier struct {
+	classifier *ort.CustomClassifier
+}
+
+// NewONNXCustomClassifier creates a CustomClassifier backed by an ONNX Runtime model.
+func NewONNXCustomClassifier(modelPath string, opts ONNXCustomClassifierOptions) (CustomClassifier, error) {
+	builder := ort.NewCustomClassifierBuilder().
+		ModelPath(modelPath).
+		TopK(0).
+		MinConfidence(0)
+
+	switch {
+	case len(opts.Labels) > 0:
+		builder = builder.Labels(opts.Labels)
+	case opts.LabelsPath != "":
+		builder = builder.LabelsPath(opts.LabelsPath)
+	default:
+		return nil, fmt.Errorf("ONNX custom classifier requires labels or labels path")
+	}
+
+	if opts.Threads > 0 {
+		threads := opts.Threads
+		builder = builder.SessionOptions(func(so *ortlib.SessionOptions) {
+			_ = so.SetIntraOpNumThreads(threads)
+			_ = so.SetInterOpNumThreads(threads)
+		})
+	}
+
+	cc, err := builder.Build()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create ONNX custom classifier: %w", err)
+	}
+
+	return &onnxCustomClassifier{
+		classifier: cc,
+	}, nil
+}
+
+// PredictEmbedding runs inference on an embedding vector.
+func (c *onnxCustomClassifier) PredictEmbedding(embeddings []float32) ([]float32, error) {
+	return c.classifier.PredictRaw(embeddings)
+}
+
+// NumClasses returns the number of output classes.
+func (c *onnxCustomClassifier) NumClasses() int {
+	return c.classifier.NumClasses()
+}
+
+// Labels returns the classification labels.
+func (c *onnxCustomClassifier) Labels() []string {
+	return c.classifier.Labels()
+}
+
+// Close releases the ONNX custom classifier session.
+func (c *onnxCustomClassifier) Close() {
 	if c.classifier != nil {
 		_ = c.classifier.Close()
 		c.classifier = nil

--- a/internal/inference/onnx/classifier.go
+++ b/internal/inference/onnx/classifier.go
@@ -97,7 +97,11 @@ func NewClassifier(modelPath string, opts ...ClassifierOption) (*Classifier, err
 	}
 
 	// Build model config and load labels
-	modelCfg := buildModelConfig(mt, inputShapes[0], len(outputNames))
+	outputShapes := make([][]int64, len(outputInfos))
+	for i := range outputInfos {
+		outputShapes[i] = outputInfos[i].Dimensions
+	}
+	modelCfg := buildModelConfig(mt, inputShapes[0], outputShapes)
 
 	labels, err := resolveLabels(cfg)
 	if err != nil {
@@ -239,42 +243,61 @@ func (c *Classifier) Labels() []string {
 // PredictRaw runs inference and returns raw logits (pre-activation) for a single segment.
 // This is used by adapters that handle their own post-processing (e.g., sensitivity-adjusted sigmoid).
 func (c *Classifier) PredictRaw(audio []float32) ([]float32, error) {
+	logits, _, err := c.PredictRawWithEmbeddings(audio)
+	return logits, err
+}
+
+// PredictRawWithEmbeddings runs inference and returns both raw logits and embedding vector.
+// Returns nil embeddings if the model does not produce embeddings.
+func (c *Classifier) PredictRawWithEmbeddings(audio []float32) (logits, embeddings []float32, err error) {
 	if len(audio) != c.config.SampleCount {
-		return nil, &InputSizeError{Expected: c.config.SampleCount, Got: len(audio)}
+		return nil, nil, &InputSizeError{Expected: c.config.SampleCount, Got: len(audio)}
 	}
 
 	inputShape := makeBatchInputShape(c.config.InputShape, 1)
 	inputTensor, err := ort.NewTensor(ort.NewShape(inputShape...), audio)
 	if err != nil {
-		return nil, fmt.Errorf("birdnet: failed to create input tensor: %w", err)
+		return nil, nil, fmt.Errorf("birdnet: failed to create input tensor: %w", err)
 	}
 	defer func() { _ = inputTensor.Destroy() }()
 
 	outputs, err := c.createOutputTensors(1)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	defer destroyTensors(outputs)
 
 	err = c.session.Run([]ort.Value{inputTensor}, outputs)
 	if err != nil {
-		return nil, fmt.Errorf("birdnet: inference failed: %w", err)
+		return nil, nil, fmt.Errorf("birdnet: inference failed: %w", err)
 	}
 
-	// Extract raw logits without applying activation function
 	logitsTensor, ok := outputs[c.config.LogitsIndex].(*ort.Tensor[float32])
 	if !ok {
-		return nil, fmt.Errorf("birdnet: logits tensor has unexpected type")
+		return nil, nil, fmt.Errorf("birdnet: logits tensor has unexpected type")
 	}
 	allLogits := logitsTensor.GetData()
 	numClasses := len(c.labels)
 	if numClasses > len(allLogits) {
-		return nil, fmt.Errorf("birdnet: logits tensor too small: need %d, have %d", numClasses, len(allLogits))
+		return nil, nil, fmt.Errorf("birdnet: logits tensor too small: need %d, have %d", numClasses, len(allLogits))
+	}
+	logits = make([]float32, numClasses)
+	copy(logits, allLogits[:numClasses])
+
+	if c.config.EmbeddingIndex >= 0 {
+		embTensor, ok := outputs[c.config.EmbeddingIndex].(*ort.Tensor[float32])
+		if !ok {
+			return nil, nil, fmt.Errorf("birdnet: embedding tensor has unexpected type")
+		}
+		allEmb := embTensor.GetData()
+		if c.config.EmbeddingSize > len(allEmb) {
+			return nil, nil, fmt.Errorf("birdnet: embedding tensor too small: need %d, have %d", c.config.EmbeddingSize, len(allEmb))
+		}
+		embeddings = make([]float32, c.config.EmbeddingSize)
+		copy(embeddings, allEmb[:c.config.EmbeddingSize])
 	}
 
-	logits := make([]float32, numClasses)
-	copy(logits, allLogits[:numClasses])
-	return logits, nil
+	return logits, embeddings, nil
 }
 
 // Predict runs inference on a single audio segment.
@@ -416,7 +439,14 @@ func (c *Classifier) outputShape(outputIdx, batchSize int) ([]int64, error) {
 	batch := int64(batchSize)
 	switch c.config.Type {
 	case BirdNETv24:
-		return []int64{batch, int64(len(c.labels))}, nil
+		switch outputIdx {
+		case 0:
+			return []int64{batch, int64(len(c.labels))}, nil
+		case 1:
+			if c.config.EmbeddingSize > 0 {
+				return []int64{batch, int64(c.config.EmbeddingSize)}, nil
+			}
+		}
 	case BirdNETv30:
 		switch outputIdx {
 		case 0:

--- a/internal/inference/onnx/custom_classifier.go
+++ b/internal/inference/onnx/custom_classifier.go
@@ -211,6 +211,9 @@ func (c *CustomClassifier) PredictBatch(embeddings [][]float32) ([][]Prediction,
 	for i := range batchSize {
 		start := i * c.numClasses
 		end := start + c.numClasses
+		if end > len(allLogits) {
+			return nil, fmt.Errorf("birdnet: custom classifier output too small for batch index %d: need %d, have %d", i, end, len(allLogits))
+		}
 		scores := sigmoidSlice(allLogits[start:end])
 		results[i] = topK(scores, c.labels, c.topK, c.minConf)
 	}

--- a/internal/inference/onnx/custom_classifier.go
+++ b/internal/inference/onnx/custom_classifier.go
@@ -1,0 +1,245 @@
+//go:build onnx
+
+package onnx
+
+import (
+	"fmt"
+
+	ort "github.com/yalue/onnxruntime_go"
+)
+
+// CustomClassifier runs secondary classification on embedding vectors from a primary model.
+// Used for custom classification heads (e.g., bat species detection from BirdNET embeddings).
+// It is safe for concurrent use from multiple goroutines.
+type CustomClassifier struct {
+	session    *ort.DynamicAdvancedSession
+	labels     []string
+	inputDim   int
+	numClasses int
+	topK       int
+	minConf    float32
+}
+
+// CustomClassifierBuilder constructs a CustomClassifier with validated configuration.
+type CustomClassifierBuilder struct {
+	modelPath     string
+	labelsPath    string
+	labels        []string
+	topK          int
+	minConf       float32
+	sessionOptsFn func(*ort.SessionOptions)
+}
+
+// NewCustomClassifierBuilder creates a new builder.
+func NewCustomClassifierBuilder() *CustomClassifierBuilder {
+	return &CustomClassifierBuilder{}
+}
+
+// ModelPath sets the ONNX model path.
+func (b *CustomClassifierBuilder) ModelPath(path string) *CustomClassifierBuilder {
+	b.modelPath = path
+	return b
+}
+
+// LabelsPath sets the labels file path (text, CSV, or JSON).
+func (b *CustomClassifierBuilder) LabelsPath(path string) *CustomClassifierBuilder {
+	b.labelsPath = path
+	return b
+}
+
+// Labels provides species labels directly.
+func (b *CustomClassifierBuilder) Labels(labels []string) *CustomClassifierBuilder {
+	b.labels = labels
+	return b
+}
+
+// TopK sets how many top predictions to return. Default: all classes.
+func (b *CustomClassifierBuilder) TopK(k int) *CustomClassifierBuilder {
+	b.topK = k
+	return b
+}
+
+// MinConfidence sets the minimum confidence threshold.
+func (b *CustomClassifierBuilder) MinConfidence(threshold float32) *CustomClassifierBuilder {
+	b.minConf = threshold
+	return b
+}
+
+// SessionOptions provides a callback to configure the ONNX Runtime session options.
+func (b *CustomClassifierBuilder) SessionOptions(fn func(*ort.SessionOptions)) *CustomClassifierBuilder {
+	b.sessionOptsFn = fn
+	return b
+}
+
+// Build creates the CustomClassifier. Returns an error if model path or labels are not set,
+// the model cannot be loaded, or the label count does not match the model output.
+func (b *CustomClassifierBuilder) Build() (*CustomClassifier, error) {
+	if b.modelPath == "" {
+		return nil, ErrModelPathRequired
+	}
+
+	inputInfos, outputInfos, err := ort.GetInputOutputInfo(b.modelPath)
+	if err != nil {
+		return nil, fmt.Errorf("birdnet: failed to load custom model metadata: %w", err)
+	}
+
+	if len(inputInfos) == 0 || len(outputInfos) == 0 {
+		return nil, &ModelDetectionError{Reason: "custom model must have at least one input and one output"}
+	}
+
+	inputDim := lastDim(inputInfos[0].Dimensions)
+	if inputDim <= 0 {
+		return nil, &ModelDetectionError{Reason: "custom model input has dynamic or missing dimensions"}
+	}
+
+	numClasses := lastDim(outputInfos[0].Dimensions)
+	if numClasses <= 0 {
+		return nil, &ModelDetectionError{Reason: "custom model output has dynamic or missing dimensions"}
+	}
+
+	var labels []string
+	switch {
+	case len(b.labels) > 0:
+		labels = b.labels
+	case b.labelsPath != "":
+		labels, err = loadLabels(b.labelsPath)
+		if err != nil {
+			return nil, err
+		}
+	default:
+		return nil, ErrLabelsRequired
+	}
+
+	if len(labels) != numClasses {
+		return nil, &LabelCountError{Expected: numClasses, Got: len(labels)}
+	}
+
+	inputNames := []string{inputInfos[0].Name}
+	outputNames := []string{outputInfos[0].Name}
+	session, err := createSession(b.modelPath, inputNames, outputNames, b.sessionOptsFn)
+	if err != nil {
+		return nil, err
+	}
+
+	topK := b.topK
+	if topK == 0 {
+		topK = numClasses
+	}
+
+	return &CustomClassifier{
+		session:    session,
+		labels:     labels,
+		inputDim:   inputDim,
+		numClasses: numClasses,
+		topK:       topK,
+		minConf:    b.minConf,
+	}, nil
+}
+
+// Predict runs inference on a single embedding vector.
+func (c *CustomClassifier) Predict(embeddings []float32) ([]Prediction, error) {
+	scores, err := c.PredictRaw(embeddings)
+	if err != nil {
+		return nil, err
+	}
+	return topK(scores, c.labels, c.topK, c.minConf), nil
+}
+
+// PredictRaw runs inference on a single embedding vector and returns all
+// sigmoid-applied scores as a flat array (no topK filtering).
+func (c *CustomClassifier) PredictRaw(embeddings []float32) ([]float32, error) {
+	if len(embeddings) != c.inputDim {
+		return nil, &EmbeddingDimMismatchError{Expected: c.inputDim, Got: len(embeddings)}
+	}
+
+	inputTensor, err := ort.NewTensor(ort.NewShape(1, int64(c.inputDim)), embeddings)
+	if err != nil {
+		return nil, fmt.Errorf("birdnet: failed to create embedding tensor: %w", err)
+	}
+	defer func() { _ = inputTensor.Destroy() }()
+
+	outputTensor, err := ort.NewEmptyTensor[float32](ort.NewShape(1, int64(c.numClasses)))
+	if err != nil {
+		return nil, fmt.Errorf("birdnet: failed to create output tensor: %w", err)
+	}
+	defer func() { _ = outputTensor.Destroy() }()
+
+	err = c.session.Run([]ort.Value{inputTensor}, []ort.Value{outputTensor})
+	if err != nil {
+		return nil, fmt.Errorf("birdnet: custom classifier inference failed: %w", err)
+	}
+
+	return sigmoidSlice(outputTensor.GetData()), nil
+}
+
+// PredictBatch runs inference on multiple embedding vectors in a single batch.
+func (c *CustomClassifier) PredictBatch(embeddings [][]float32) ([][]Prediction, error) {
+	if len(embeddings) == 0 {
+		return nil, ErrEmptyBatch
+	}
+
+	batchSize := len(embeddings)
+	flat := make([]float32, 0, batchSize*c.inputDim)
+	for i, emb := range embeddings {
+		if len(emb) != c.inputDim {
+			return nil, fmt.Errorf("birdnet: embedding %d: %w", i, &EmbeddingDimMismatchError{
+				Expected: c.inputDim, Got: len(emb),
+			})
+		}
+		flat = append(flat, emb...)
+	}
+
+	inputTensor, err := ort.NewTensor(ort.NewShape(int64(batchSize), int64(c.inputDim)), flat)
+	if err != nil {
+		return nil, fmt.Errorf("birdnet: failed to create batch embedding tensor: %w", err)
+	}
+	defer func() { _ = inputTensor.Destroy() }()
+
+	outputTensor, err := ort.NewEmptyTensor[float32](ort.NewShape(int64(batchSize), int64(c.numClasses)))
+	if err != nil {
+		return nil, fmt.Errorf("birdnet: failed to create batch output tensor: %w", err)
+	}
+	defer func() { _ = outputTensor.Destroy() }()
+
+	err = c.session.Run([]ort.Value{inputTensor}, []ort.Value{outputTensor})
+	if err != nil {
+		return nil, fmt.Errorf("birdnet: custom classifier batch inference failed: %w", err)
+	}
+
+	allLogits := outputTensor.GetData()
+	results := make([][]Prediction, batchSize)
+	for i := range batchSize {
+		start := i * c.numClasses
+		end := start + c.numClasses
+		scores := sigmoidSlice(allLogits[start:end])
+		results[i] = topK(scores, c.labels, c.topK, c.minConf)
+	}
+	return results, nil
+}
+
+// InputDim returns the expected embedding dimension.
+func (c *CustomClassifier) InputDim() int {
+	return c.inputDim
+}
+
+// NumClasses returns the number of output classes.
+func (c *CustomClassifier) NumClasses() int {
+	return c.numClasses
+}
+
+// Labels returns a copy of the classification labels.
+func (c *CustomClassifier) Labels() []string {
+	cp := make([]string, len(c.labels))
+	copy(cp, c.labels)
+	return cp
+}
+
+// Close releases the ONNX session and associated resources.
+func (c *CustomClassifier) Close() error {
+	if c.session != nil {
+		err := c.session.Destroy()
+		c.session = nil
+		return err
+	}
+	return nil
+}

--- a/internal/inference/onnx/detection.go
+++ b/internal/inference/onnx/detection.go
@@ -6,11 +6,12 @@ import "fmt"
 
 // Known model sample counts and output counts for auto-detection.
 const (
-	sampleCountV24  = 144000 // BirdNET v2.4: 48kHz * 3s
-	sampleCountV30  = 160000 // BirdNET v3.0 / Perch v2: 32kHz * 5s
-	numOutputsV24   = 1      // BirdNET v2.4: logits only
-	numOutputsV30   = 2      // BirdNET v3.0: embeddings + logits
-	numOutputsPerch = 4      // Perch v2: embeddings + features + attention + logits
+	sampleCountV24   = 144000 // BirdNET v2.4: 48kHz * 3s
+	sampleCountV30   = 160000 // BirdNET v3.0 / Perch v2: 32kHz * 5s
+	numOutputsV24    = 1      // BirdNET v2.4: logits only
+	numOutputsV24Emb = 2      // BirdNET v2.4 with embeddings: logits + embeddings
+	numOutputsV30    = 2      // BirdNET v3.0: embeddings + logits
+	numOutputsPerch  = 4      // Perch v2: embeddings + features + attention + logits
 
 	embeddingSizeV30   = 1280 // BirdNET v3.0 embedding dimension
 	embeddingSizePerch = 1536 // Perch v2 embedding dimension
@@ -32,6 +33,8 @@ func detectModelTypeFromShapes(inputShapes [][]int64, numOutputs int) (ModelType
 	switch {
 	case sampleCount == sampleCountV24 && numOutputs == numOutputsV24:
 		return BirdNETv24, nil
+	case sampleCount == sampleCountV24 && numOutputs == numOutputsV24Emb:
+		return BirdNETv24, nil
 	case sampleCount == sampleCountV30 && numOutputs == numOutputsV30:
 		return BirdNETv30, nil
 	case sampleCount == sampleCountV30 && numOutputs == numOutputsPerch:
@@ -43,7 +46,8 @@ func detectModelTypeFromShapes(inputShapes [][]int64, numOutputs int) (ModelType
 	}
 }
 
-func buildModelConfig(mt ModelType, inputShape []int64, numOutputs int) ModelConfig {
+func buildModelConfig(mt ModelType, inputShape []int64, outputShapes [][]int64) ModelConfig {
+	numOutputs := len(outputShapes)
 	cfg := ModelConfig{
 		Type:           mt,
 		SampleRate:     mt.SampleRate(),
@@ -58,7 +62,10 @@ func buildModelConfig(mt ModelType, inputShape []int64, numOutputs int) ModelCon
 	switch mt {
 	case BirdNETv24:
 		cfg.LogitsIndex = 0
-		cfg.EmbeddingSize = 0
+		if numOutputs >= 2 {
+			cfg.EmbeddingIndex = 1
+			cfg.EmbeddingSize = lastDim(outputShapes[1])
+		}
 	case BirdNETv30:
 		cfg.LogitsIndex = 1
 		cfg.EmbeddingIndex = 0
@@ -70,4 +77,11 @@ func buildModelConfig(mt ModelType, inputShape []int64, numOutputs int) ModelCon
 	}
 
 	return cfg
+}
+
+func lastDim(shape []int64) int {
+	if len(shape) == 0 {
+		return 0
+	}
+	return int(shape[len(shape)-1])
 }

--- a/internal/inference/onnx/detection.go
+++ b/internal/inference/onnx/detection.go
@@ -63,8 +63,10 @@ func buildModelConfig(mt ModelType, inputShape []int64, outputShapes [][]int64) 
 	case BirdNETv24:
 		cfg.LogitsIndex = 0
 		if numOutputs >= 2 {
-			cfg.EmbeddingIndex = 1
-			cfg.EmbeddingSize = lastDim(outputShapes[1])
+			if embSize := lastDim(outputShapes[1]); embSize > 0 {
+				cfg.EmbeddingIndex = 1
+				cfg.EmbeddingSize = embSize
+			}
 		}
 	case BirdNETv30:
 		cfg.LogitsIndex = 1

--- a/internal/inference/onnx/errors.go
+++ b/internal/inference/onnx/errors.go
@@ -32,6 +32,15 @@ func (e *BatchInputSizeError) Error() string {
 	return fmt.Sprintf("birdnet: segment %d has %d audio samples, expected %d", e.Index, e.Got, e.Expected)
 }
 
+type EmbeddingDimMismatchError struct {
+	Expected int
+	Got      int
+}
+
+func (e *EmbeddingDimMismatchError) Error() string {
+	return fmt.Sprintf("birdnet: embedding dimension mismatch: classifier expects %d, got %d", e.Expected, e.Got)
+}
+
 type LabelCountError struct {
 	Expected int
 	Got      int

--- a/internal/inference/onnx/types.go
+++ b/internal/inference/onnx/types.go
@@ -6,6 +6,7 @@ package onnx
 type ModelType int
 
 const (
+	// BirdNETv24 - 48kHz, 3s segments, optional embeddings (when model has 2 outputs).
 	BirdNETv24 ModelType = iota
 	BirdNETv30
 	PerchV2


### PR DESCRIPTION
## Summary

- Detect BirdNET v2.4 ONNX models with 2 outputs (predictions + embeddings) alongside the existing 1-output variant
- Add `CustomClassifier` type for running secondary ONNX models on embedding vectors
- Add `Bat` model instance that chains BirdNET v2.4 embedding extraction with a regional bat species classifier
- Add `EmbeddingExtractor` and `CustomClassifier` interfaces to the inference abstraction layer
- Add `BatConfig` with embedding model, classifier model, label path, and threshold settings
- Add "Bat" entry to the model registry with orchestrator wiring

Ports embedding extraction and CustomClassifier from [go-birdnet-onnx PR #3](https://github.com/tphakala/go-birdnet-onnx/pull/3) and [rust-birdnet-onnx PR #80](https://github.com/tphakala/rust-birdnet-onnx/pull/80).

Bat classifier models and labels are available at [BattyBirdNET-onnx on HuggingFace](https://huggingface.co/tphakala/BattyBirdNET-onnx).

### Architecture

The bat detection pipeline uses the "slow-down trick": 256kHz bat audio is fed directly to BirdNET v2.4 without resampling. BirdNET treats the samples as 48kHz, shifting ultrasonic bat calls into audible range. The patched v2.4 model produces 1024-dim embeddings from the GLOBAL_AVG_POOL layer. These embeddings feed into lightweight regional bat classifiers.

The `Bat` model instance manages both ONNX sessions (embedding extractor + bat classifier) and implements `ModelInstance`, fitting cleanly into the existing multi-model orchestrator architecture.

### Layers changed

1. **ONNX layer** (`internal/inference/onnx/`): v2.4 embedding detection, `buildModelConfig` accepts output shapes, `PredictRawWithEmbeddings`, `CustomClassifier` with builder pattern
2. **Inference abstraction** (`internal/inference/`): `EmbeddingExtractor` and `CustomClassifier` interfaces, ONNX wrappers
3. **Model integration** (`internal/classifier/`): `Bat` model instance, registry entry, orchestrator wiring, build-tag-gated stubs
4. **Configuration** (`internal/conf/`): `BatConfig` struct and defaults

Audio pipeline changes for 256kHz bat sources are a follow-up task.

## Test Plan
- [x] `go build -tags onnx ./...` compiles
- [x] `go build ./...` (non-ONNX) compiles
- [x] 1544 existing tests pass
- [x] 0 golangci-lint warnings
- [x] End-to-end bat detection verified in go-birdnet-onnx test program (256kHz audio -> embeddings -> bat species)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an ONNX-backed bat species classification model for bat detections.
  * Integrated two-stage embedding-based inference (embedding extraction + secondary classifier) for improved accuracy.
  * Orchestrator now recognizes and loads the Bat model automatically when enabled.
  * New configuration options for bat detection (model paths, labels, threshold, and runtime threading).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->