### PR TITLE
fix(frontend): add null guards for species settings before config loads

### DIFF
--- a/frontend/src/lib/desktop/features/settings/pages/SpeciesSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/SpeciesSettingsPage.svelte
@@ -620,8 +620,8 @@
       ): boolean =>
         nameSet.has(commonName.toLowerCase()) || nameSet.has(scientificName.toLowerCase());
 
-      const includeSet = new Set(currentInclude.map(s => s.toLowerCase()));
-      const configKeys = new Set(Object.keys(currentConfig).map(s => s.toLowerCase()));
+      const includeSet = new Set((currentInclude ?? []).map(s => s.toLowerCase()));
+      const configKeys = new Set(Object.keys(currentConfig ?? {}).map(s => s.toLowerCase()));
 
       // Filter species that pass the threshold OR are manually included
       const mappedSpecies: ActiveSpecies[] = response.species


### PR DESCRIPTION
## Summary

- Add nullish coalescing fallbacks (`?? []` / `?? {}`) to `currentInclude` and `currentConfig` in `loadActiveSpecies()` to prevent `TypeError` when the species settings page renders before the config API response arrives

## Related Issues

Fixes BIRDNET-GO-1RN (Sentry)

## Test Plan

- [ ] Navigate to species analytics page on a fresh page load; verify no TypeError in console
- [ ] Verify species list renders correctly once settings load
- [ ] Confirm existing species filtering behavior is unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed runtime errors in the species settings page that occurred when certain configuration values were missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->