### PR TITLE
fix(conf): centralize home directory resolution for systemd compatibility

### DIFF
--- a/internal/backup/targets/common.go
+++ b/internal/backup/targets/common.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/tphakala/birdnet-go/internal/backup"
+	"github.com/tphakala/birdnet-go/internal/conf"
 )
 
 // Common constants for file operations and limits
@@ -349,7 +350,7 @@ func (p *SettingsParser) HasErrors() bool {
 
 // DefaultKnownHostsFile returns the default SSH known_hosts file path
 func DefaultKnownHostsFile() string {
-	homeDir, err := os.UserHomeDir()
+	homeDir, err := conf.GetUserHomeDir()
 	if err != nil {
 		return ""
 	}

--- a/internal/classifier/birdnet.go
+++ b/internal/classifier/birdnet.go
@@ -280,19 +280,14 @@ func (bn *BirdNET) getMetaModelData() ([]byte, error) {
 	if bn.Settings.BirdNET.RangeFilter.ModelPath != "" {
 		modelPath := bn.Settings.BirdNET.RangeFilter.ModelPath
 
-		// Expand environment variables first
+		// Expand environment variables and ~ prefix
 		modelPath = os.ExpandEnv(modelPath)
-
-		// Then expand ~ to home directory if needed
-		if strings.HasPrefix(modelPath, "~/") {
-			homeDir, err := os.UserHomeDir()
-			if err != nil {
-				return nil, errors.New(err).
-					Category(errors.CategoryFileIO).
-					Context("path", modelPath).
-					Build()
-			}
-			modelPath = filepath.Join(homeDir, modelPath[2:])
+		modelPath, err := conf.ExpandTildePath(modelPath)
+		if err != nil {
+			return nil, errors.New(err).
+				Category(errors.CategoryFileIO).
+				Context("path", bn.Settings.BirdNET.RangeFilter.ModelPath).
+				Build()
 		}
 
 		// Load model from external file
@@ -686,7 +681,7 @@ func getOSSpecificSystemPaths(modelName string) []string {
 		)
 
 		// macOS user-specific path
-		if home := os.Getenv("HOME"); home != "" {
+		if home, err := conf.GetUserHomeDir(); err == nil {
 			paths = append(paths,
 				filepath.Join(home, "Library", "Application Support", "BirdNET-Go", DefaultModelDirectory, modelName),
 			)
@@ -702,7 +697,7 @@ func getOSSpecificSystemPaths(modelName string) []string {
 		// XDG Base Directory specification for user data
 		if xdgDataHome := os.Getenv("XDG_DATA_HOME"); xdgDataHome != "" {
 			paths = append(paths, filepath.Join(xdgDataHome, "birdnet-go", DefaultModelDirectory, modelName))
-		} else if home := os.Getenv("HOME"); home != "" {
+		} else if home, err := conf.GetUserHomeDir(); err == nil {
 			paths = append(paths, filepath.Join(home, ".local", "share", "birdnet-go", DefaultModelDirectory, modelName))
 		}
 	}
@@ -763,19 +758,14 @@ func (bn *BirdNET) loadModel() ([]byte, error) {
 	// If a specific model path is configured, use it
 	if bn.Settings.BirdNET.ModelPath != "" {
 		modelPath := bn.Settings.BirdNET.ModelPath
-		// Expand environment variables first
+		// Expand environment variables and ~ prefix
 		modelPath = os.ExpandEnv(modelPath)
-
-		// Then expand ~ to home directory if needed
-		if strings.HasPrefix(modelPath, "~/") {
-			homeDir, err := os.UserHomeDir()
-			if err != nil {
-				return nil, errors.New(err).
-					Category(errors.CategoryFileIO).
-					Context("path", modelPath).
-					Build()
-			}
-			modelPath = filepath.Join(homeDir, modelPath[2:])
+		modelPath, err := conf.ExpandTildePath(modelPath)
+		if err != nil {
+			return nil, errors.New(err).
+				Category(errors.CategoryFileIO).
+				Context("path", bn.Settings.BirdNET.ModelPath).
+				Build()
 		}
 
 		data, err := os.ReadFile(modelPath) //nolint:gosec // G304: modelPath is from application settings

--- a/internal/conf/tls.go
+++ b/internal/conf/tls.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"sync"
 
@@ -39,16 +38,9 @@ var (
 // GetTLSManager returns the global TLS manager instance
 func GetTLSManager() *TLSManager {
 	tlsManagerOnce.Do(func() {
-		homeDir, err := GetUserHomeDir()
-		if err == nil {
-			var configDir string
-			switch runtime.GOOS {
-			case osWindows:
-				configDir = filepath.Join(homeDir, "AppData", "Roaming", "birdnet-go")
-			default:
-				configDir = filepath.Join(homeDir, ".config", "birdnet-go")
-			}
-			globalTLSManager = NewTLSManager(configDir)
+		configPaths, err := GetDefaultConfigPaths()
+		if err == nil && len(configPaths) > 0 {
+			globalTLSManager = NewTLSManager(configPaths[0])
 		} else {
 			globalTLSManager = NewTLSManager(filepath.Join(".", "config"))
 		}

--- a/internal/conf/tls.go
+++ b/internal/conf/tls.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 
@@ -38,12 +39,18 @@ var (
 // GetTLSManager returns the global TLS manager instance
 func GetTLSManager() *TLSManager {
 	tlsManagerOnce.Do(func() {
-		configPaths, _ := GetDefaultConfigPaths()
-		if len(configPaths) > 0 {
-			globalTLSManager = NewTLSManager(configPaths[0])
+		homeDir, err := GetUserHomeDir()
+		if err == nil {
+			var configDir string
+			switch runtime.GOOS {
+			case osWindows:
+				configDir = filepath.Join(homeDir, "AppData", "Roaming", "birdnet-go")
+			default:
+				configDir = filepath.Join(homeDir, ".config", "birdnet-go")
+			}
+			globalTLSManager = NewTLSManager(configDir)
 		} else {
-			// Use a default path or panic to fail fast
-			globalTLSManager = NewTLSManager("./config")
+			globalTLSManager = NewTLSManager(filepath.Join(".", "config"))
 		}
 	})
 	return globalTLSManager

--- a/internal/conf/utils.go
+++ b/internal/conf/utils.go
@@ -14,6 +14,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/spf13/viper"
@@ -26,6 +27,54 @@ const (
 	osLinux   = "linux"
 	osWindows = "windows"
 )
+
+var (
+	cachedHomeDir string
+	errCachedHome error
+	homeDirOnce   sync.Once
+)
+
+// GetUserHomeDir returns the user's home directory. It tries os/user.Current()
+// first (works without $HOME, reads /etc/passwd), then os.UserHomeDir(), then
+// the HOME environment variable. The result is cached for the process lifetime.
+func GetUserHomeDir() (string, error) {
+	homeDirOnce.Do(func() {
+		cachedHomeDir, errCachedHome = resolveHomeDir()
+	})
+	return cachedHomeDir, errCachedHome
+}
+
+func resolveHomeDir() (string, error) {
+	if u, err := user.Current(); err == nil && u.HomeDir != "" {
+		return u.HomeDir, nil
+	}
+	if homeDir, err := os.UserHomeDir(); err == nil {
+		return homeDir, nil
+	}
+	if home := os.Getenv("HOME"); home != "" {
+		return home, nil
+	}
+	return "", errors.Newf("home directory could not be determined: $HOME not set and os/user lookup failed").
+		Category(errors.CategorySystem).
+		Context("operation", "get-home-directory").
+		Build()
+}
+
+// ExpandTildePath expands a leading "~/" or bare "~" to the user's home
+// directory. Non-tilde paths are returned unchanged.
+func ExpandTildePath(path string) (string, error) {
+	if path == "~" {
+		return GetUserHomeDir()
+	}
+	if !strings.HasPrefix(path, "~/") {
+		return path, nil
+	}
+	homeDir, err := GetUserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(homeDir, path[2:]), nil
+}
 
 // getDefaultConfigPaths returns a list of default configuration paths for the current operating system.
 // It determines paths based on standard conventions for storing application configuration files.
@@ -44,7 +93,7 @@ func GetDefaultConfigPaths() ([]string, error) {
 	exeDir := filepath.Dir(exePath)
 
 	// Fetch the user's home directory.
-	homeDir, err := os.UserHomeDir()
+	homeDir, err := GetUserHomeDir()
 	if err != nil {
 		return nil, errors.New(err).
 			Category(errors.CategorySystem).

--- a/internal/conf/utils_test.go
+++ b/internal/conf/utils_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -307,4 +308,69 @@ func TestGetFfmpegVersionFrom_WithInvalidPath(t *testing.T) {
 	assert.Empty(t, version)
 	assert.Zero(t, major)
 	assert.Zero(t, minor)
+}
+
+func TestGetUserHomeDir(t *testing.T) {
+	t.Run("returns a non-empty directory", func(t *testing.T) {
+		homeDir, err := GetUserHomeDir()
+		require.NoError(t, err)
+		assert.NotEmpty(t, homeDir)
+		assert.DirExists(t, homeDir)
+	})
+
+	t.Run("result is cached", func(t *testing.T) {
+		first, err1 := GetUserHomeDir()
+		require.NoError(t, err1)
+		second, err2 := GetUserHomeDir()
+		require.NoError(t, err2)
+		assert.Equal(t, first, second)
+	})
+}
+
+func TestResolveHomeDir(t *testing.T) {
+	t.Run("resolves without HOME set", func(t *testing.T) {
+		origHome := os.Getenv("HOME")
+		t.Cleanup(func() { _ = os.Setenv("HOME", origHome) })
+		require.NoError(t, os.Unsetenv("HOME"))
+
+		homeDir, err := resolveHomeDir()
+		require.NoError(t, err, "resolveHomeDir must succeed without $HOME via os/user.Current()")
+		assert.NotEmpty(t, homeDir)
+		assert.DirExists(t, homeDir)
+	})
+}
+
+func TestExpandTildePath(t *testing.T) {
+	t.Run("expands tilde prefix", func(t *testing.T) {
+		result, err := ExpandTildePath("~/models/bird.tflite")
+		require.NoError(t, err)
+		assert.NotContains(t, result, "~")
+		assert.True(t, filepath.IsAbs(result))
+		assert.True(t, strings.HasSuffix(result, filepath.Join("models", "bird.tflite")))
+	})
+
+	t.Run("returns non-tilde path unchanged", func(t *testing.T) {
+		result, err := ExpandTildePath("/usr/share/models/bird.tflite")
+		require.NoError(t, err)
+		assert.Equal(t, "/usr/share/models/bird.tflite", result)
+	})
+
+	t.Run("returns relative path unchanged", func(t *testing.T) {
+		result, err := ExpandTildePath("models/bird.tflite")
+		require.NoError(t, err)
+		assert.Equal(t, "models/bird.tflite", result)
+	})
+
+	t.Run("handles bare tilde", func(t *testing.T) {
+		result, err := ExpandTildePath("~")
+		require.NoError(t, err)
+		assert.NotEqual(t, "~", result)
+		assert.DirExists(t, result)
+	})
+
+	t.Run("returns empty path unchanged", func(t *testing.T) {
+		result, err := ExpandTildePath("")
+		require.NoError(t, err)
+		assert.Empty(t, result)
+	})
 }

--- a/internal/conf/utils_test.go
+++ b/internal/conf/utils_test.go
@@ -3,6 +3,7 @@ package conf
 import (
 	"os"
 	"os/exec"
+	"os/user"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -329,6 +330,10 @@ func TestGetUserHomeDir(t *testing.T) {
 
 func TestResolveHomeDir(t *testing.T) {
 	t.Run("resolves without HOME set", func(t *testing.T) {
+		if _, err := user.Current(); err != nil {
+			t.Skip("skipping: os/user.Current() unavailable (minimal container without /etc/passwd)")
+		}
+
 		origHome := os.Getenv("HOME")
 		t.Cleanup(func() { _ = os.Setenv("HOME", origHome) })
 		require.NoError(t, os.Unsetenv("HOME"))

--- a/tools/dbexport/config.go
+++ b/tools/dbexport/config.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/spf13/viper"
+	"github.com/tphakala/birdnet-go/internal/conf"
 )
 
 // Config holds the configuration for the export tool.
@@ -70,7 +71,7 @@ func (c *Config) loadFromConfigFile() error {
 	configPath := c.ConfigPath
 	if configPath == "" {
 		// Try default locations, preferring home directory
-		if homeDir, err := os.UserHomeDir(); err == nil {
+		if homeDir, err := conf.GetUserHomeDir(); err == nil {
 			p := filepath.Join(homeDir, ".config", "birdnet-go", "config.yaml")
 			if _, statErr := os.Stat(p); statErr == nil {
 				configPath = p


### PR DESCRIPTION
## Summary

- Add `GetUserHomeDir()` helper to `internal/conf/utils.go` that tries `os/user.Current()` first (reads `/etc/passwd` via `getpwuid_r`, works without `$HOME`), then `os.UserHomeDir()`, then raw `$HOME` env var. Result is cached via `sync.Once` for process lifetime.
- Add `ExpandTildePath()` helper for `~/path` expansion used by classifier model loading.
- Replace all 6+ independent `os.UserHomeDir()`/`os.Getenv("HOME")` call sites across `conf`, `backup`, `classifier`, and `dbexport` packages with the centralized helpers.
- Update TLS manager to use `GetUserHomeDir()` directly instead of going through `GetDefaultConfigPaths()`.

When `$HOME` is unset (common in systemd services without a full user environment), every subsystem that resolves the home directory fails independently, generating 8 separate Sentry issues from a single startup event. This fix ensures all home directory resolution goes through a single helper with proper fallback.

**Files changed:** `internal/conf/utils.go`, `internal/conf/tls.go`, `internal/classifier/birdnet.go`, `internal/backup/targets/common.go`, `tools/dbexport/config.go`, `internal/conf/utils_test.go`

## Test Plan

- [x] `TestGetUserHomeDir` - verifies resolution and caching
- [x] `TestResolveHomeDir` - verifies fallback works without `$HOME`
- [x] `TestExpandTildePath` - verifies tilde expansion, passthrough, bare tilde, empty path
- [x] All existing `conf`, `backup`, and `classifier` tests pass
- [x] `golangci-lint` clean (zero new issues)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved home-directory detection with caching and clearer fallbacks for more reliable config and model file location.
  * Enhanced tilde (~) path expansion and cross-platform candidate paths for model/config discovery.

* **Tests**
  * Added unit tests covering home-directory resolution, caching behavior, and tilde path expansion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->