### PR TITLE
fix(frontend): add isConnected guards to modal map initialization

### DIFF
--- a/frontend/src/lib/desktop/features/settings/pages/MainSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/MainSettingsPage.svelte
@@ -547,14 +547,25 @@
   // Modal map lifecycle
   $effect(() => {
     let cleanup: (() => void) | undefined;
+    let cancelled = false;
 
     if (mapModalOpen && modalMapElement && initialLoadComplete) {
-      initializeModalMap().then(cleanupFn => {
-        cleanup = cleanupFn;
+      const el = modalMapElement;
+
+      void tick().then(() => {
+        if (cancelled || !el.isConnected) return;
+        initializeModalMap().then(cleanupFn => {
+          if (cancelled) {
+            cleanupFn?.();
+            return;
+          }
+          cleanup = cleanupFn;
+        });
       });
     }
 
     return () => {
+      cancelled = true;
       if (cleanup) {
         cleanup();
       }
@@ -824,7 +835,7 @@
   }
 
   async function initializeModalMap() {
-    if (!modalMapElement || modalMap || !maplibregl) return;
+    if (!modalMapElement || !modalMapElement.isConnected || modalMap || !maplibregl) return;
 
     const handleModalWheel = (e: globalThis.WheelEvent) => {
       if (modalMap) {


### PR DESCRIPTION
## Summary

- Add `tick()` + `isConnected` guards to the modal map initialization in `MainSettingsPage.svelte`, mirroring the pattern already used for the main map (added in PR #2726)
- Add a cancellation flag to prevent MapLibre instance and wheel event listener leaks if the effect tears down before async initialization completes
- The modal map could crash with "container must be a String or HTMLElement" when MapLibre received a detached DOM node (Sentry: BIRDNET-GO-1AB)

## Test Plan

- [ ] Open Settings > Location tab, verify main map renders
- [ ] Click the map expand button, verify modal map renders correctly
- [ ] Rapidly open/close the modal map to exercise the cancellation path
- [ ] Frontend lint and type checks pass (`npm run check:all`)