### PR TITLE
fix(hls): fix Windows live audio/spectrogram streaming

### DIFF
--- a/internal/api/v2/audio_hls.go
+++ b/internal/api/v2/audio_hls.go
@@ -843,28 +843,29 @@ func (c *Controller) ServeHLSContent(ctx echo.Context) error {
 		return c.HandleError(ctx, nil, "Invalid segment path", http.StatusBadRequest)
 	}
 
-	// For init.mp4, use in-memory cache to survive FFmpeg's delete_segments removing
-	// the file from disk while the playlist still references it via #EXT-X-MAP.
+	// For init.mp4, serve from memory once cached to avoid TOCTOU races where
+	// FFmpeg's delete_segments removes the file between the existence check and serve.
 	isInitSegment := safeRequestPath == hlsInitSegmentName
-	segmentExists := secFS.ExistsNoErr(segmentPath)
 
 	if isInitSegment {
-		cached, _ := stream.initSegmentCache.Load().([]byte)
-
-		if !segmentExists && len(cached) > 0 {
+		if cached, _ := stream.initSegmentCache.Load().([]byte); len(cached) > 0 {
 			c.setHLSHeaders(ctx)
 			c.setHLSContentType(ctx, safeRequestPath)
-			return ctx.Blob(http.StatusOK, "video/mp4", cached)
+			return ctx.Blob(http.StatusOK, ctx.Response().Header().Get(echo.HeaderContentType), cached)
 		}
 
-		if segmentExists && len(cached) == 0 {
-			if data, err := os.ReadFile(segmentPath); err == nil {
-				stream.initSegmentCache.Store(data)
-			}
+		data, err := secFS.ReadFile(segmentPath)
+		if err != nil {
+			return c.HandleError(ctx, nil, "Segment file not found", http.StatusNotFound)
 		}
+
+		stream.initSegmentCache.Store(data)
+		c.setHLSHeaders(ctx)
+		c.setHLSContentType(ctx, safeRequestPath)
+		return ctx.Blob(http.StatusOK, ctx.Response().Header().Get(echo.HeaderContentType), data)
 	}
 
-	if !segmentExists {
+	if !secFS.ExistsNoErr(segmentPath) {
 		return c.HandleError(ctx, nil, "Segment file not found", http.StatusNotFound)
 	}
 
@@ -963,7 +964,7 @@ func (c *Controller) getEffectiveSegmentLength() int {
 func (c *Controller) setHLSContentType(ctx echo.Context, path string) {
 	switch filepath.Ext(path) {
 	case ".ts":
-		ctx.Response().Header().Set("Content-Type", "audio/mp2t")
+		ctx.Response().Header().Set("Content-Type", "video/mp2t")
 		ctx.Response().Header().Set("Cache-Control", "public, max-age=60")
 	case ".m4s":
 		ctx.Response().Header().Set("Content-Type", "video/iso.segment")

--- a/internal/api/v2/audio_hls.go
+++ b/internal/api/v2/audio_hls.go
@@ -92,9 +92,10 @@ const (
 	// Session ID validation
 
 	// FFmpeg HLS muxer settings
-	hlsListSize    = 6 // Number of HLS segments to keep in playlist (must exceed HLS.js liveSyncDurationCount)
-	hlsAllowCache  = 1 // Allow client-side caching of HLS segments
-	hlsStartNumber = 0 // Starting sequence number for HLS segments
+	hlsListSize        = 6          // Number of HLS segments to keep in playlist (must exceed HLS.js liveSyncDurationCount)
+	hlsAllowCache      = 1          // Allow client-side caching of HLS segments
+	hlsStartNumber     = 0          // Starting sequence number for HLS segments
+	hlsInitSegmentName = "init.mp4" // fMP4 initialization segment filename
 )
 
 // HLSStreamInfo contains information about an active HLS streaming session
@@ -116,6 +117,7 @@ type HLSStreamInfo struct {
 	pdtOffset         atomic.Int64 // Correction (nanoseconds) to add to FFmpeg's PDT values
 	pdtOffsetComputed atomic.Bool  // True once pdtOffset has been successfully computed
 	firstDataTime     atomic.Int64 // Wall-clock time (UnixNano) when first audio data was written to FIFO
+	initSegmentCache  atomic.Value // []byte; survives FFmpeg delete_segments removing init.mp4 from disk
 }
 
 // HLSStreamStatus represents the current status of an HLS stream (API response)
@@ -841,8 +843,28 @@ func (c *Controller) ServeHLSContent(ctx echo.Context) error {
 		return c.HandleError(ctx, nil, "Invalid segment path", http.StatusBadRequest)
 	}
 
-	// Check if segment exists
-	if !secFS.ExistsNoErr(segmentPath) {
+	// For init.mp4, use in-memory cache to survive FFmpeg's delete_segments removing
+	// the file from disk while the playlist still references it via #EXT-X-MAP.
+	isInitSegment := safeRequestPath == hlsInitSegmentName
+	segmentExists := secFS.ExistsNoErr(segmentPath)
+
+	if isInitSegment {
+		cached, _ := stream.initSegmentCache.Load().([]byte)
+
+		if !segmentExists && len(cached) > 0 {
+			c.setHLSHeaders(ctx)
+			c.setHLSContentType(ctx, safeRequestPath)
+			return ctx.Blob(http.StatusOK, "video/mp4", cached)
+		}
+
+		if segmentExists && len(cached) == 0 {
+			if data, err := os.ReadFile(segmentPath); err == nil {
+				stream.initSegmentCache.Store(data)
+			}
+		}
+	}
+
+	if !segmentExists {
 		return c.HandleError(ctx, nil, "Segment file not found", http.StatusNotFound)
 	}
 
@@ -1114,10 +1136,12 @@ func (c *Controller) createHLSStream(sourceID string) (*HLSStreamInfo, error) {
 		return nil, err
 	}
 
-	// Determine reader path based on platform
+	// Determine reader path based on platform.
+	// On Windows, setupWindowsAudioFeed writes audio data to FFmpeg's stdin,
+	// so FFmpeg must read from "pipe:0" (stdin) rather than the named pipe.
 	readerPath := fifoPath
 	if runtime.GOOS == OSWindows {
-		readerPath = pipeName
+		readerPath = "pipe:0"
 	}
 
 	// Setup and start FFmpeg
@@ -1342,18 +1366,44 @@ func (c *Controller) buildFFmpegArgs(inputSource, outputDir, playlistPath string
 		"-f", "hls",
 		"-hls_time", fmt.Sprintf("%d", segmentLength),
 		"-hls_list_size", strconv.Itoa(hlsListSize),
-		"-hls_flags", "delete_segments+temp_file+program_date_time+independent_segments",
-		"-hls_segment_type", "fmp4",
-		"-hls_fmp4_init_filename", "init.mp4",
+	}
+
+	// On Windows, FFmpeg reads from stdin (pipe:0) which is non-seekable.
+	// The fMP4 segment type requires FFmpeg to write a separate init.mp4 file,
+	// but FFmpeg fails to create it when reading from a non-seekable source.
+	// Use MPEG-TS segments on Windows which are self-contained and don't need
+	// a separate initialization segment.
+	if runtime.GOOS == OSWindows {
+		args = append(args,
+			"-hls_flags", "delete_segments+program_date_time+independent_segments",
+			"-hls_segment_type", "mpegts",
+		)
+	} else {
+		args = append(args,
+			"-hls_flags", "delete_segments+temp_file+program_date_time+independent_segments",
+			"-hls_segment_type", "fmp4",
+			"-hls_fmp4_init_filename", hlsInitSegmentName,
+			"-movflags", "empty_moov+separate_moof+default_base_moof",
+		)
+	}
+
+	args = append(args,
 		"-hls_init_time", fmt.Sprintf("%d", segmentLength),
 		"-hls_allow_cache", strconv.Itoa(hlsAllowCache),
-		"-movflags", "empty_moov+separate_moof+default_base_moof",
 		"-flush_packets", "1",
 		"-start_number", strconv.Itoa(hlsStartNumber),
 		"-loglevel", logLevel,
-		"-hls_segment_filename", filepath.ToSlash(filepath.Join(outputDir, "segment%03d.m4s")),
-		playlistPath,
+	)
+
+	// Segment filename extension matches the segment type
+	segExt := "m4s"
+	if runtime.GOOS == OSWindows {
+		segExt = "ts"
 	}
+	args = append(args,
+		"-hls_segment_filename", filepath.ToSlash(filepath.Join(outputDir, "segment%03d."+segExt)),
+		playlistPath,
+	)
 
 	return args
 }


### PR DESCRIPTION
## Summary

- Fix FFmpeg input source mismatch on Windows: `setupWindowsAudioFeed` writes audio to FFmpeg's stdin, but FFmpeg was told to read from a Windows named pipe that nothing writes to. Change FFmpeg input to `pipe:0` (stdin) on Windows.
- Switch to MPEG-TS segments on Windows: FFmpeg cannot create the fMP4 init segment (`init.mp4`) when reading from non-seekable stdin. MPEG-TS segments are self-contained and don't need a separate initialization segment.
- Add init.mp4 in-memory cache on non-Windows platforms as defense against FFmpeg's `delete_segments` removing the initialization segment during playlist rotation.

## Related Issues

Fixes #2973

## Test Plan

- [x] Verified on Windows 11 QA VM with FFmpeg 8.1.1
- [x] Zero "HLS audio data dropped: channel full" messages (user had 500+ drops every 5 seconds)
- [x] Zero "Error writing to FFmpeg stdin" errors
- [x] HLS segments produced within 2 seconds of stream start
- [x] MPEG-TS playlist serves correctly with proper PROGRAM_DATE_TIME tags
- [x] Segments serve with 200 OK status
- [x] golangci-lint clean, go vet clean on both linux/amd64 and windows/amd64

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HLS reliability by caching init segments in memory to avoid missing-segment races.
  * Adjusted platform-specific streaming output so Windows uses TS segments and other platforms use fMP4 for more stable playback.
  * Corrected content type for .ts segments to ensure proper playback and compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->