### PR TITLE
fix(analysis): correct bat detection buffer sizing and range filter bypass

### DIFF
--- a/internal/analysis/audio_pipeline_service.go
+++ b/internal/analysis/audio_pipeline_service.go
@@ -702,7 +702,7 @@ func (p *AudioPipelineService) registerConsumersForSources(sourceIDs []string, s
 				continue
 			}
 			spec := modelInfos[i].Spec
-			clipBytes := spec.EffectiveSampleRate() * int(spec.ClipLength.Seconds()) * conf.NumChannels * (conf.BitDepth / 8)
+			clipBytes := spec.SampleRate * int(spec.ClipLength.Seconds()) * conf.NumChannels * (conf.BitDepth / 8)
 			overlapBytes := clipBytes / 2 // 50% overlap, matching primary model ratio
 			readSize := clipBytes - overlapBytes
 			if allocErr := bufMgr.AllocateAnalysis(sid, modelInfos[i].ID, clipBytes, overlapBytes, readSize); allocErr != nil {
@@ -1008,7 +1008,7 @@ func (p *AudioPipelineService) buildMonitorConfigs(sourceModelMap map[string][]s
 		for i := range infos {
 			spec := infos[i].Spec
 			clipLenSec := int(spec.ClipLength.Seconds())
-			readSize := spec.EffectiveSampleRate() * clipLenSec * conf.NumChannels * (conf.BitDepth / 8)
+			readSize := spec.SampleRate * clipLenSec * conf.NumChannels * (conf.BitDepth / 8)
 			configs[i] = monitorConfig{
 				sourceID: sid,
 				modelID:  infos[i].ID,

--- a/internal/analysis/audio_pipeline_service.go
+++ b/internal/analysis/audio_pipeline_service.go
@@ -1006,15 +1006,7 @@ func (p *AudioPipelineService) buildMonitorConfigs(sourceModelMap map[string][]s
 
 		configs := make([]monitorConfig, len(infos))
 		for i := range infos {
-			spec := infos[i].Spec
-			clipLenSec := int(spec.ClipLength.Seconds())
-			readSize := spec.SampleRate * clipLenSec * conf.NumChannels * (conf.BitDepth / 8)
-			configs[i] = monitorConfig{
-				sourceID: sid,
-				modelID:  infos[i].ID,
-				spec:     spec,
-				readSize: readSize,
-			}
+			configs[i] = buildMonitorConfig(sid, &infos[i])
 		}
 		result[sid] = configs
 	}

--- a/internal/analysis/buffer_manager.go
+++ b/internal/analysis/buffer_manager.go
@@ -498,7 +498,7 @@ func (m *BufferManager) processMonitorTick(
 func buildMonitorConfig(sourceID string, info *classifier.ModelInfo) monitorConfig {
 	spec := info.Spec
 	clipLenSec := int(spec.ClipLength.Seconds())
-	readSize := spec.EffectiveSampleRate() * clipLenSec * conf.NumChannels * (conf.BitDepth / 8)
+	readSize := spec.SampleRate * clipLenSec * conf.NumChannels * (conf.BitDepth / 8)
 
 	return monitorConfig{
 		sourceID: sourceID,

--- a/internal/analysis/processor/processor.go
+++ b/internal/analysis/processor/processor.go
@@ -861,8 +861,8 @@ func (p *Processor) shouldFilterDetection(settings *conf.Settings, result datast
 		return true, confidenceThreshold
 	}
 
-	// Check species inclusion filter
-	if !settings.IsSpeciesIncluded(result.Species) {
+	// Range filter applies only to BirdNET; Bat/Perch have independent species sets.
+	if strings.HasPrefix(modelID, detection.DefaultModelName) && !settings.IsSpeciesIncluded(result.Species) {
 		if settings.Debug {
 			GetLogger().Debug("species not on included list",
 				logger.String("species", result.Species),


### PR DESCRIPTION
## Summary
- Revert analysis buffer sizing from `EffectiveSampleRate()` back to `SampleRate` in three locations. The bat model's BirdNET embedding layer expects exactly 144,000 float32 samples (48kHz * 3s) per inference window. PR #2976 switched to `EffectiveSampleRate()` (256kHz for bat), producing 768,000-sample buffers that the model rejected with "expected 144000 audio samples, got 768000".
- Guard the BirdNET range filter species inclusion check (`IsSpeciesIncluded`) with a model ID prefix match so non-BirdNET models (Bat, Perch) bypass it. The range filter only contains bird species from the location-based filter, so every bat detection was silently dropped by this check.

## Test Plan
- [x] Built with `EXTRA_BUILD_TAGS="onnx" task noembed`
- [x] Played 256kHz bat recording (XC838798, Vespertilio murinus) through ALSA loopback
- [x] Verified buffer allocation: `clip_bytes=288000` (144k samples * 2 bytes)
- [x] Verified model receives correct sample count: `chunk_len=144000`
- [x] Verified embedding extraction succeeds: `embedding_dim=1024, duration=46ms`
- [x] Verified 6 bat detections saved to database (Pipistrellus nathusii 100%, Barbastella barbastellus 92%, Nyctalus noctula 60%)
- [x] Linter clean: `golangci-lint run -v`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Apply species inclusion filtering only to BirdNET model outputs; other models (e.g., Bat, Perch) now use their independent species sets.
  * Fix audio analysis and monitor buffer sizing to compute read/clip byte sizes from the configured sample rate, correcting buffer window calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->