### PR TITLE
refactor(analysis): extract ClipSizeBytes() to eliminate buffer formula duplication

### DIFF
--- a/internal/analysis/audio_pipeline_service.go
+++ b/internal/analysis/audio_pipeline_service.go
@@ -702,7 +702,7 @@ func (p *AudioPipelineService) registerConsumersForSources(sourceIDs []string, s
 				continue
 			}
 			spec := modelInfos[i].Spec
-			clipBytes := spec.SampleRate * int(spec.ClipLength.Seconds()) * conf.NumChannels * (conf.BitDepth / 8)
+			clipBytes := spec.ClipSizeBytes()
 			overlapBytes := clipBytes / 2 // 50% overlap, matching primary model ratio
 			readSize := clipBytes - overlapBytes
 			if allocErr := bufMgr.AllocateAnalysis(sid, modelInfos[i].ID, clipBytes, overlapBytes, readSize); allocErr != nil {

--- a/internal/analysis/buffer_manager.go
+++ b/internal/analysis/buffer_manager.go
@@ -497,8 +497,7 @@ func (m *BufferManager) processMonitorTick(
 // allocation time (in audio_pipeline_service.go), not by the monitor goroutine.
 func buildMonitorConfig(sourceID string, info *classifier.ModelInfo) monitorConfig {
 	spec := info.Spec
-	clipLenSec := int(spec.ClipLength.Seconds())
-	readSize := spec.SampleRate * clipLenSec * conf.NumChannels * (conf.BitDepth / 8)
+	readSize := spec.ClipSizeBytes()
 
 	return monitorConfig{
 		sourceID: sourceID,

--- a/internal/classifier/model.go
+++ b/internal/classifier/model.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/datastore"
 )
 
@@ -15,6 +16,13 @@ type ModelSpec struct {
 	SampleRate    int           // Hz: 48000 (BirdNET v2.4), 32000 (v3.0, Perch)
 	ClipLength    time.Duration // 3s (BirdNET v2.4), 5s (v3.0, Perch)
 	RawSampleRate int           // Hz: when non-zero, the model expects raw audio at this rate (e.g. 256000 for bat detection)
+}
+
+// ClipSizeBytes returns the analysis window size in bytes for this model.
+// Uses SampleRate (not EffectiveSampleRate) because the model's inference
+// layer determines the window size regardless of the source capture rate.
+func (s ModelSpec) ClipSizeBytes() int {
+	return s.SampleRate * int(s.ClipLength.Seconds()) * conf.NumChannels * conf.BytesPerSample
 }
 
 // EffectiveSampleRate returns the sample rate the model expects to receive

--- a/internal/conf/consts.go
+++ b/internal/conf/consts.go
@@ -17,7 +17,7 @@ const (
 	SpeciesActionsCSV = "species_actions.csv"
 
 	// BufferSize is the size of the audio buffer in bytes, rounded up to the nearest 2048
-	BufferSize = ((SampleRate*NumChannels*CaptureLength*BitDepth/8 + 2047) / 2048) * 2048
+	BufferSize = ((SampleRate*NumChannels*CaptureLength*BytesPerSample + 2047) / 2048) * 2048
 
 	// DefaultCaptureBufferSeconds is the default ring buffer duration when extended capture is disabled.
 	// Audio.Export.Length must not exceed this value or audio export will be truncated.

--- a/internal/conf/consts.go
+++ b/internal/conf/consts.go
@@ -7,10 +7,11 @@ const (
 	ModelIDPerchV2 = "perch_v2"
 	ModelIDBat     = "bat"
 
-	SampleRate    = 48000 // Sample rate of the audio fed to BirdNET Analyzer
-	BitDepth      = 16    // Bit depth of the audio fed to BirdNET Analyzer
-	NumChannels   = 1     // Number of channels of the audio fed to BirdNET Analyzer
-	CaptureLength = 3     // Length of audio data fed to BirdNET Analyzer in seconds
+	SampleRate     = 48000 // Sample rate of the audio fed to BirdNET Analyzer
+	BitDepth       = 16    // Bit depth of the audio fed to BirdNET Analyzer
+	NumChannels    = 1     // Number of channels of the audio fed to BirdNET Analyzer
+	BytesPerSample = BitDepth / 8
+	CaptureLength  = 3 // Length of audio data fed to BirdNET Analyzer in seconds
 
 	SpeciesConfigCSV  = "species_config.csv"
 	SpeciesActionsCSV = "species_actions.csv"


### PR DESCRIPTION
## Summary
- Add `ModelSpec.ClipSizeBytes()` method as the single source of truth for analysis window sizing, replacing the formula that was duplicated in `audio_pipeline_service.go` and `buffer_manager.go`
- Add `conf.BytesPerSample` constant to replace inline `BitDepth/8` expressions

This prevents the class of divergence bug that caused PR #2977 (buffer sizing used `EffectiveSampleRate()` in some sites but `SampleRate` in others).

## Test Plan
- [x] `go build ./...` passes
- [x] `golangci-lint run -v` clean
- [x] `go test -race ./internal/classifier/ -run TestModelSpec` passes (4 tests)
- [x] Verified `ClipSizeBytes()` returns correct values: 288000 (BirdNET v2.4: 48000*3*1*2), 320000 (v3.0/Perch: 32000*5*1*2)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized audio buffer size and clip-size calculations across processing and classification components, unifying how analysis/read sizes are derived to improve consistency and reduce duplication. This streamlines buffer allocation and monitoring behavior without changing external interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->