### PR TITLE
fix: harden model gallery SSE parsing and config dir fallback

### DIFF
--- a/frontend/src/lib/utils/modelsApi.ts
+++ b/frontend/src/lib/utils/modelsApi.ts
@@ -5,8 +5,11 @@
 
 import type { CatalogResponse, DownloadProgress, InstalledModel } from '$lib/types/models';
 import { api } from '$lib/utils/api';
+import { loggers } from '$lib/utils/logger';
 import { buildAppUrl } from '$lib/utils/urlHelpers';
 import ReconnectingEventSource from 'reconnecting-eventsource';
+
+const logger = loggers.api;
 
 const BASE = '/api/v2/models';
 
@@ -50,7 +53,13 @@ export function subscribeInstallProgress(
 
   source.addEventListener('progress', (event: Event) => {
     const messageEvent = event as MessageEvent;
-    const data = JSON.parse(messageEvent.data as string) as DownloadProgress;
+    let data: DownloadProgress;
+    try {
+      data = JSON.parse(messageEvent.data as string) as DownloadProgress;
+    } catch (error) {
+      logger.warn('Failed to parse SSE progress event', error, { component: 'modelsApi' });
+      return;
+    }
     onProgress(data);
 
     if (data.status === 'complete') {

--- a/frontend/src/lib/utils/modelsApi.ts
+++ b/frontend/src/lib/utils/modelsApi.ts
@@ -5,11 +5,11 @@
 
 import type { CatalogResponse, DownloadProgress, InstalledModel } from '$lib/types/models';
 import { api } from '$lib/utils/api';
-import { loggers } from '$lib/utils/logger';
+import { getLogger } from '$lib/utils/logger';
 import { buildAppUrl } from '$lib/utils/urlHelpers';
 import ReconnectingEventSource from 'reconnecting-eventsource';
 
-const logger = loggers.api;
+const logger = getLogger('modelsApi');
 
 const BASE = '/api/v2/models';
 
@@ -55,7 +55,11 @@ export function subscribeInstallProgress(
     const messageEvent = event as MessageEvent;
     let data: DownloadProgress;
     try {
-      data = JSON.parse(messageEvent.data as string) as DownloadProgress;
+      const parsed: unknown = JSON.parse(messageEvent.data as string);
+      if (!parsed || typeof parsed !== 'object') {
+        throw new Error('Event data is not an object');
+      }
+      data = parsed as DownloadProgress;
     } catch (error) {
       logger.warn('Failed to parse SSE progress event', error, { component: 'modelsApi' });
       return;

--- a/internal/analysis/birdnet_service.go
+++ b/internal/analysis/birdnet_service.go
@@ -106,10 +106,19 @@ func (a *BirdNETAnalyzer) initModelManager(bn *classifier.Orchestrator) {
 	if modelsDir == "" {
 		configDir, err := os.UserConfigDir()
 		if err != nil {
-			log.Warn("could not determine user config directory; model gallery disabled",
+			homeDir, homeErr := conf.GetUserHomeDir()
+			if homeErr != nil {
+				log.Warn("could not determine config or home directory; model gallery disabled",
+					logger.Error(err),
+					logger.String("home_error", homeErr.Error()),
+					logger.String("service", birdNETAnalyzerName))
+				return
+			}
+			configDir = filepath.Join(homeDir, ".config")
+			log.Warn("UserConfigDir unavailable, falling back to home directory",
 				logger.Error(err),
+				logger.String("fallback", configDir),
 				logger.String("service", birdNETAnalyzerName))
-			return
 		}
 		modelsDir = filepath.Join(configDir, "birdnet-go", "models")
 	}


### PR DESCRIPTION
## Summary
- Add try/catch around `JSON.parse` in the SSE progress handler (`modelsApi.ts`) to prevent malformed events from crashing the EventSource connection. Parse failures are logged via the api logger.
- Improve `UserConfigDir` error handling in `birdnet_service.go` by falling back to `conf.GetUserHomeDir()` (cached, multi-strategy helper) instead of immediately disabling the model gallery. This helps in Docker containers where `XDG_CONFIG_HOME` is unset but `HOME` exists.

Follow-up to #2982 (model gallery). Addresses minor fixes tracked in Forgejo.

## Test plan
- [ ] Verify SSE progress stream still works during model install
- [ ] Verify model gallery initializes in Docker container without XDG_CONFIG_HOME
- [ ] Verify malformed SSE events are logged, not silently swallowed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of model installation progress streams to avoid errors when progress events are malformed, ensuring installs continue without crashing and emit warnings instead of failures.
  * Added fallback behavior for locating the models directory when standard configuration paths aren’t available, preventing the model gallery from being disabled unnecessarily.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/2983)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->