### PR TITLE
fix: use unique temp files for model downloads

### DIFF
--- a/internal/classifier/model_manager.go
+++ b/internal/classifier/model_manager.go
@@ -625,7 +625,17 @@ func (mm *ModelManager) downloadFile(catalogID, url, destPath, expectedSHA256 st
 			Build()
 	}
 
-	tmpPath := destPath + ".tmp"
+	// Use a unique temp file in the same directory to avoid collisions when
+	// multiple goroutines download the same shared file (e.g., embeddings).
+	tmpFile, err := os.CreateTemp(filepath.Dir(destPath), filepath.Base(destPath)+".*.tmp")
+	if err != nil {
+		return errors.Newf("failed to create temp file for %s: %v", destPath, err).
+			Component("classifier.model_manager").
+			Category(errors.CategoryFileIO).
+			Context("dest_path", destPath).
+			Build()
+	}
+	tmpPath := tmpFile.Name()
 
 	// Always attempt best-effort cleanup of the temp file on error.
 	success := false
@@ -654,14 +664,7 @@ func (mm *ModelManager) downloadFile(catalogID, url, destPath, expectedSHA256 st
 			Build()
 	}
 
-	outFile, err := os.Create(tmpPath)
-	if err != nil {
-		return errors.Newf("failed to create temp file %s: %v", tmpPath, err).
-			Component("classifier.model_manager").
-			Category(errors.CategoryFileIO).
-			Context("tmp_path", tmpPath).
-			Build()
-	}
+	outFile := tmpFile
 	defer func() { _ = outFile.Close() }()
 
 	hasher := sha256.New()

--- a/internal/classifier/model_manager.go
+++ b/internal/classifier/model_manager.go
@@ -637,9 +637,10 @@ func (mm *ModelManager) downloadFile(catalogID, url, destPath, expectedSHA256 st
 	}
 	tmpPath := tmpFile.Name()
 
-	// Always attempt best-effort cleanup of the temp file on error.
+	// Always close the temp file and clean it up on error.
 	success := false
 	defer func() {
+		_ = tmpFile.Close()
 		if !success {
 			_ = os.Remove(tmpPath)
 		}
@@ -664,9 +665,6 @@ func (mm *ModelManager) downloadFile(catalogID, url, destPath, expectedSHA256 st
 			Build()
 	}
 
-	outFile := tmpFile
-	defer func() { _ = outFile.Close() }()
-
 	hasher := sha256.New()
 	reader := io.TeeReader(resp.Body, hasher)
 
@@ -677,7 +675,7 @@ func (mm *ModelManager) downloadFile(catalogID, url, destPath, expectedSHA256 st
 	for {
 		n, readErr := reader.Read(buf)
 		if n > 0 {
-			if _, writeErr := outFile.Write(buf[:n]); writeErr != nil {
+			if _, writeErr := tmpFile.Write(buf[:n]); writeErr != nil {
 				return errors.Newf("failed to write to %s: %v", tmpPath, writeErr).
 					Component("classifier.model_manager").
 					Category(errors.CategoryFileIO).
@@ -724,7 +722,7 @@ func (mm *ModelManager) downloadFile(catalogID, url, destPath, expectedSHA256 st
 	}
 
 	// Close before rename so the file is flushed.
-	if err := outFile.Close(); err != nil {
+	if err := tmpFile.Close(); err != nil {
 		return errors.Newf("failed to close temp file %s: %v", tmpPath, err).
 			Component("classifier.model_manager").
 			Category(errors.CategoryFileIO).

--- a/internal/classifier/model_manager_test.go
+++ b/internal/classifier/model_manager_test.go
@@ -186,9 +186,9 @@ func TestModelManager_DownloadFile(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, content, got)
 
-	// Verify no temp file remains.
-	_, err = os.Stat(destPath + ".tmp")
-	assert.True(t, os.IsNotExist(err), "temp file should be removed after successful download")
+	// Verify no temp files remain.
+	matches, _ := filepath.Glob(destPath + ".*.tmp")
+	assert.Empty(t, matches, "temp files should be removed after successful download")
 
 	// Verify progress was updated in shared state.
 	state := mm.GetDownloadState("test-download")
@@ -216,13 +216,13 @@ func TestModelManager_DownloadFile_BadChecksum(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "checksum")
 
-	// Verify temp file was cleaned up.
-	_, statErr := os.Stat(destPath + ".tmp")
-	assert.True(t, os.IsNotExist(statErr), "temp file should be cleaned up after checksum mismatch")
+	// Verify temp files were cleaned up.
+	matches, _ := filepath.Glob(destPath + ".*.tmp")
+	assert.Empty(t, matches, "temp files should be cleaned up after checksum mismatch")
 
 	// Verify destination file was not created.
-	_, statErr = os.Stat(destPath)
-	assert.True(t, os.IsNotExist(statErr), "destination file should not exist after checksum failure")
+	_, err = os.Stat(destPath)
+	assert.True(t, os.IsNotExist(err), "destination file should not exist after checksum failure")
 }
 
 func TestModelManager_Install(t *testing.T) {


### PR DESCRIPTION
## Summary
- Use `os.CreateTemp` instead of a fixed `destPath + ".tmp"` suffix for download temp files
- Prevents concurrent downloads of the same shared file (e.g., embeddings) from colliding on the temp path
- Each download gets its own unique temp file; `os.Rename` provides atomic promotion to the final path

## Context
Follow-up from CodeRabbit review on PR #2989. Two browser tabs could trigger simultaneous bat model installs that both need `shared/birdnet-v24-embeddings.onnx`, causing both goroutines to write to the same `.tmp` file.

## Test plan
- [ ] Verify `go test ./internal/classifier/` passes (temp file glob patterns updated)
- [ ] Verify no `.tmp` files remain after successful or failed downloads

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved download reliability by using unique temporary files and ensuring proper cleanup on success or failure.
  * Added post-download integrity verification to detect corrupted downloads.
* **Tests**
  * Updated tests to validate temporary-file cleanup and behavior on checksum failures.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/2990)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->