### PR TITLE
fix: clone-mutate-publish for settings, shared model store, bat uninstall logic

### DIFF
--- a/frontend/src/lib/desktop/components/forms/SoundCardCard.svelte
+++ b/frontend/src/lib/desktop/components/forms/SoundCardCard.svelte
@@ -22,6 +22,7 @@
   import { t } from '$lib/i18n';
   import { cn } from '$lib/utils/cn';
   import { loggers } from '$lib/utils/logger';
+  import { DEFAULT_MODEL_ID } from '$lib/stores/models.svelte';
   import SelectDropdown from './SelectDropdown.svelte';
   import InlineSlider from './InlineSlider.svelte';
   import ModelCheckboxList from './ModelCheckboxList.svelte';
@@ -50,9 +51,6 @@
   }
 
   const logger = loggers.audio;
-
-  // Default model ID — BirdNET v2.4 is the built-in default
-  const DEFAULT_MODEL_ID = 'birdnet';
 
   function getDefaultModels(): string[] {
     const defaultModel = modelOptions.find(m => m.value === DEFAULT_MODEL_ID);

--- a/frontend/src/lib/desktop/components/forms/SoundCardManager.svelte
+++ b/frontend/src/lib/desktop/components/forms/SoundCardManager.svelte
@@ -20,7 +20,7 @@
   import { loggers } from '$lib/utils/logger';
   import { toastActions } from '$lib/stores/toast';
   import { cn } from '$lib/utils/cn';
-  import { availableModels, DEFAULT_MODEL_ID, fetchModels } from '$lib/stores/models.svelte';
+  import { getAvailableModels, DEFAULT_MODEL_ID, fetchModels } from '$lib/stores/models.svelte';
   import SoundCardCard from './SoundCardCard.svelte';
   import SelectDropdown from './SelectDropdown.svelte';
   import TextInput from './TextInput.svelte';
@@ -53,6 +53,8 @@
 
   const logger = loggers.audio;
 
+  const availableModels = $derived(getAvailableModels());
+
   function getDefaultModels(): string[] {
     if (availableModels.some(m => m.id === DEFAULT_MODEL_ID)) {
       return [DEFAULT_MODEL_ID];
@@ -64,7 +66,6 @@
     return fetchModels();
   });
 
-  // Model options — dynamically loaded from enabled models in config
   const modelOptions = $derived(availableModels.map(m => ({ value: m.id, label: m.name })));
 
   interface Props {

--- a/frontend/src/lib/desktop/components/forms/SoundCardManager.svelte
+++ b/frontend/src/lib/desktop/components/forms/SoundCardManager.svelte
@@ -15,13 +15,12 @@
 -->
 <script lang="ts">
   import { Plus, Mic, RefreshCw, ChevronDown } from '@lucide/svelte';
-  import { untrack } from 'svelte';
   import { slide } from 'svelte/transition';
   import { t } from '$lib/i18n';
   import { loggers } from '$lib/utils/logger';
   import { toastActions } from '$lib/stores/toast';
-  import { api } from '$lib/utils/api';
   import { cn } from '$lib/utils/cn';
+  import { availableModels, DEFAULT_MODEL_ID, fetchModels } from '$lib/stores/models.svelte';
   import SoundCardCard from './SoundCardCard.svelte';
   import SelectDropdown from './SelectDropdown.svelte';
   import TextInput from './TextInput.svelte';
@@ -54,9 +53,6 @@
 
   const logger = loggers.audio;
 
-  // Default model ID — BirdNET v2.4 is the built-in default
-  const DEFAULT_MODEL_ID = 'birdnet';
-
   function getDefaultModels(): string[] {
     if (availableModels.some(m => m.id === DEFAULT_MODEL_ID)) {
       return [DEFAULT_MODEL_ID];
@@ -64,48 +60,8 @@
     return availableModels.length > 0 ? [availableModels[0].id] : [DEFAULT_MODEL_ID];
   }
 
-  // Fetch available models from backend API
-  interface BackendModel {
-    id: string;
-    name: string;
-    category: string;
-    minSampleRate?: number;
-    recommendedSampleRate?: number;
-  }
-
-  const FALLBACK_MODELS: BackendModel[] = [
-    { id: DEFAULT_MODEL_ID, name: 'BirdNET v2.4 (TFLite)', category: 'bird' },
-  ];
-
-  let fetchedModels = $state<BackendModel[]>([]);
-  let availableModels = $derived(fetchedModels.length > 0 ? fetchedModels : FALLBACK_MODELS);
-
   $effect(() => {
-    const controller = new AbortController();
-
-    untrack(() => {
-      api
-        .get<BackendModel[]>('/api/v2/models', { signal: controller.signal })
-        .then(data => {
-          if (Array.isArray(data) && data.length > 0) {
-            fetchedModels = data;
-          } else {
-            logger.warn('Fetched models response is empty or not an array', {
-              component: 'SoundCardManager',
-            });
-          }
-        })
-        .catch((err: unknown) => {
-          if (err instanceof Error && err.name !== 'AbortError') {
-            logger.error('Failed to fetch models', err, {
-              component: 'SoundCardManager',
-              action: 'fetchModels',
-            });
-          }
-        });
-    });
-
-    return () => controller.abort();
+    return fetchModels();
   });
 
   // Model options — dynamically loaded from enabled models in config
@@ -216,7 +172,7 @@
             enabled: newEqualizer.enabled,
             filters: newEqualizer.filters.map(f => ({
               ...f,
-              id: f.id || (crypto?.randomUUID?.() ?? Math.random().toString(36).substr(2, 9)),
+              id: f.id || (crypto?.randomUUID?.() ?? Math.random().toString(36).slice(2, 11)),
             })),
           }
         : undefined;

--- a/frontend/src/lib/desktop/components/forms/StreamCard.svelte
+++ b/frontend/src/lib/desktop/components/forms/StreamCard.svelte
@@ -32,6 +32,7 @@
   import { slide } from 'svelte/transition';
   import { t } from '$lib/i18n';
   import { cn } from '$lib/utils/cn';
+  import { DEFAULT_MODEL_ID } from '$lib/stores/models.svelte';
   import { maskUrlCredentials } from '$lib/utils/security';
   import StatusPill, { type StatusVariant } from '$lib/desktop/components/ui/StatusPill.svelte';
   import Checkbox from './Checkbox.svelte';
@@ -310,7 +311,7 @@
     editTransport = stream.transport ?? 'tcp';
     editStreamType = stream.type;
     editEnabled = stream.enabled;
-    editModels = stream.models?.length ? [...stream.models] : ['birdnet'];
+    editModels = stream.models?.length ? [...stream.models] : [DEFAULT_MODEL_ID];
     editEqualizer = stream.equalizer
       ? { ...stream.equalizer, filters: [...stream.equalizer.filters] }
       : { enabled: false, filters: [] };

--- a/frontend/src/lib/desktop/components/forms/StreamManager.svelte
+++ b/frontend/src/lib/desktop/components/forms/StreamManager.svelte
@@ -26,7 +26,7 @@
   import { validateProtocolURL, sanitizeUrlForComparison } from '$lib/utils/security';
   import { toastActions } from '$lib/stores/toast';
   import { quietHoursStore } from '$lib/stores/quietHours.svelte';
-  import { availableModels, DEFAULT_MODEL_ID, fetchModels } from '$lib/stores/models.svelte';
+  import { getAvailableModels, DEFAULT_MODEL_ID, fetchModels } from '$lib/stores/models.svelte';
   import StreamCard, { type StreamStatus } from './StreamCard.svelte';
   import ModelCheckboxList from './ModelCheckboxList.svelte';
   import StatusPill from '$lib/desktop/components/ui/StatusPill.svelte';
@@ -38,6 +38,8 @@
   import { defaultQuietHoursConfig } from '$lib/stores/settings';
 
   const logger = loggers.audio;
+
+  const availableModels = $derived(getAvailableModels());
 
   $effect(() => {
     return fetchModels();

--- a/frontend/src/lib/desktop/components/forms/StreamManager.svelte
+++ b/frontend/src/lib/desktop/components/forms/StreamManager.svelte
@@ -16,7 +16,6 @@
 -->
 <script lang="ts">
   import { onMount, onDestroy, setContext } from 'svelte';
-  import { untrack } from 'svelte';
   import { Plus, Radio, RefreshCw } from '@lucide/svelte';
   import ReconnectingEventSource from 'reconnecting-eventsource';
   import { t } from '$lib/i18n';
@@ -27,6 +26,7 @@
   import { validateProtocolURL, sanitizeUrlForComparison } from '$lib/utils/security';
   import { toastActions } from '$lib/stores/toast';
   import { quietHoursStore } from '$lib/stores/quietHours.svelte';
+  import { availableModels, DEFAULT_MODEL_ID, fetchModels } from '$lib/stores/models.svelte';
   import StreamCard, { type StreamStatus } from './StreamCard.svelte';
   import ModelCheckboxList from './ModelCheckboxList.svelte';
   import StatusPill from '$lib/desktop/components/ui/StatusPill.svelte';
@@ -39,51 +39,8 @@
 
   const logger = loggers.audio;
 
-  // Default model ID - BirdNET v2.4 is the built-in default
-  const DEFAULT_MODEL_ID = 'birdnet';
-
-  // Fetch available models from backend API
-  interface BackendModel {
-    id: string;
-    name: string;
-    category: string;
-    minSampleRate?: number;
-    recommendedSampleRate?: number;
-  }
-
-  const FALLBACK_MODELS: BackendModel[] = [
-    { id: DEFAULT_MODEL_ID, name: 'BirdNET v2.4 (TFLite)', category: 'bird' },
-  ];
-
-  let fetchedModels = $state<BackendModel[]>([]);
-  let availableModels = $derived(fetchedModels.length > 0 ? fetchedModels : FALLBACK_MODELS);
-
   $effect(() => {
-    const controller = new AbortController();
-
-    untrack(() => {
-      api
-        .get<BackendModel[]>('/api/v2/models', { signal: controller.signal })
-        .then(data => {
-          if (Array.isArray(data) && data.length > 0) {
-            fetchedModels = data;
-          } else {
-            logger.warn('Fetched models response is empty or not an array', {
-              component: 'StreamManager',
-            });
-          }
-        })
-        .catch((err: unknown) => {
-          if (err instanceof Error && err.name !== 'AbortError') {
-            logger.error('Failed to fetch models', err, {
-              component: 'StreamManager',
-              action: 'fetchModels',
-            });
-          }
-        });
-    });
-
-    return () => controller.abort();
+    return fetchModels();
   });
 
   // Maximum allowed URL length for stream configuration

--- a/frontend/src/lib/stores/models.svelte.ts
+++ b/frontend/src/lib/stores/models.svelte.ts
@@ -20,41 +20,53 @@ const FALLBACK_MODELS: BackendModel[] = [
 
 let fetchedModels = $state<BackendModel[]>([]);
 let activeFetch: AbortController | null = null;
+let subscribers = 0;
 
-export const availableModels = $derived(fetchedModels.length > 0 ? fetchedModels : FALLBACK_MODELS);
+export function getAvailableModels(): BackendModel[] {
+  return fetchedModels.length > 0 ? fetchedModels : FALLBACK_MODELS;
+}
 
 export function fetchModels(): () => void {
-  if (fetchedModels.length > 0 || activeFetch) {
-    return () => {};
+  subscribers++;
+
+  if (fetchedModels.length === 0 && !activeFetch) {
+    const controller = new AbortController();
+    activeFetch = controller;
+
+    untrack(() => {
+      api
+        .get<BackendModel[]>('/api/v2/models', { signal: controller.signal })
+        .then(data => {
+          if (controller.signal.aborted) return;
+          if (Array.isArray(data) && data.length > 0) {
+            fetchedModels = data;
+          } else {
+            logger.warn('Fetched models response is empty or not an array', {
+              component: 'modelsStore',
+            });
+          }
+        })
+        .catch((err: unknown) => {
+          if (err instanceof Error && err.name !== 'AbortError') {
+            logger.error('Failed to fetch models', err, {
+              component: 'modelsStore',
+              action: 'fetchModels',
+            });
+          }
+        })
+        .finally(() => {
+          if (activeFetch === controller) {
+            activeFetch = null;
+          }
+        });
+    });
   }
 
-  const controller = new AbortController();
-  activeFetch = controller;
-
-  untrack(() => {
-    api
-      .get<BackendModel[]>('/api/v2/models', { signal: controller.signal })
-      .then(data => {
-        if (Array.isArray(data) && data.length > 0) {
-          fetchedModels = data;
-        } else {
-          logger.warn('Fetched models response is empty or not an array', {
-            component: 'modelsStore',
-          });
-        }
-      })
-      .catch((err: unknown) => {
-        if (err instanceof Error && err.name !== 'AbortError') {
-          logger.error('Failed to fetch models', err, {
-            component: 'modelsStore',
-            action: 'fetchModels',
-          });
-        }
-      })
-      .finally(() => {
-        activeFetch = null;
-      });
-  });
-
-  return () => controller.abort();
+  return () => {
+    subscribers--;
+    if (subscribers === 0 && activeFetch) {
+      activeFetch.abort();
+      activeFetch = null;
+    }
+  };
 }

--- a/frontend/src/lib/stores/models.svelte.ts
+++ b/frontend/src/lib/stores/models.svelte.ts
@@ -34,9 +34,11 @@ export function fetchModels(): () => void {
     activeFetch = controller;
 
     untrack(() => {
-      api
-        .get<BackendModel[]>('/api/v2/models', { signal: controller.signal })
-        .then(data => {
+      void (async () => {
+        try {
+          const data = await api.get<BackendModel[]>('/api/v2/models', {
+            signal: controller.signal,
+          });
           if (controller.signal.aborted) return;
           if (Array.isArray(data) && data.length > 0) {
             fetchedModels = data;
@@ -45,20 +47,19 @@ export function fetchModels(): () => void {
               component: 'modelsStore',
             });
           }
-        })
-        .catch((err: unknown) => {
+        } catch (err: unknown) {
           if (err instanceof Error && err.name !== 'AbortError') {
             logger.error('Failed to fetch models', err, {
               component: 'modelsStore',
               action: 'fetchModels',
             });
           }
-        })
-        .finally(() => {
+        } finally {
           if (activeFetch === controller) {
             activeFetch = null;
           }
-        });
+        }
+      })();
     });
   }
 

--- a/frontend/src/lib/stores/models.svelte.ts
+++ b/frontend/src/lib/stores/models.svelte.ts
@@ -1,0 +1,60 @@
+import { untrack } from 'svelte';
+import { api } from '$lib/utils/api';
+import { loggers } from '$lib/utils/logger';
+
+const logger = loggers.audio;
+
+export interface BackendModel {
+  id: string;
+  name: string;
+  category: string;
+  minSampleRate?: number;
+  recommendedSampleRate?: number;
+}
+
+export const DEFAULT_MODEL_ID = 'birdnet';
+
+const FALLBACK_MODELS: BackendModel[] = [
+  { id: DEFAULT_MODEL_ID, name: 'BirdNET v2.4 (TFLite)', category: 'bird' },
+];
+
+let fetchedModels = $state<BackendModel[]>([]);
+let activeFetch: AbortController | null = null;
+
+export const availableModels = $derived(fetchedModels.length > 0 ? fetchedModels : FALLBACK_MODELS);
+
+export function fetchModels(): () => void {
+  if (fetchedModels.length > 0 || activeFetch) {
+    return () => {};
+  }
+
+  const controller = new AbortController();
+  activeFetch = controller;
+
+  untrack(() => {
+    api
+      .get<BackendModel[]>('/api/v2/models', { signal: controller.signal })
+      .then(data => {
+        if (Array.isArray(data) && data.length > 0) {
+          fetchedModels = data;
+        } else {
+          logger.warn('Fetched models response is empty or not an array', {
+            component: 'modelsStore',
+          });
+        }
+      })
+      .catch((err: unknown) => {
+        if (err instanceof Error && err.name !== 'AbortError') {
+          logger.error('Failed to fetch models', err, {
+            component: 'modelsStore',
+            action: 'fetchModels',
+          });
+        }
+      })
+      .finally(() => {
+        activeFetch = null;
+      });
+  });
+
+  return () => controller.abort();
+}

--- a/internal/classifier/model_manager.go
+++ b/internal/classifier/model_manager.go
@@ -39,8 +39,9 @@ const (
 type ModelManager struct {
 	modelsDir    string
 	orchestrator *Orchestrator
-	settings     *conf.Settings
+	settings     *conf.Settings // nil sentinel: non-nil means config sync is enabled
 	mu           sync.RWMutex
+	settingsMu   sync.Mutex // serializes clone-mutate-publish cycles on settings
 	installed    map[string]InstalledModel
 	downloading  map[string]*DownloadState
 }
@@ -135,22 +136,25 @@ func (mm *ModelManager) ScanInstalled() {
 		logger.Int("installed_count", len(mm.installed)))
 
 	// Sync Models.Enabled with installed/configured models so the model picker
-	// always reflects the actual system state.
+	// always reflects the actual system state. Use clone-mutate-publish to
+	// avoid mutating the shared settings snapshot in place.
 	if mm.settings != nil {
+		mm.settingsMu.Lock()
+		updated := conf.CloneSettings(conf.GetSettings())
 		changed := false
 
 		// BirdNET is always present (permanent built-in).
-		if !slices.ContainsFunc(mm.settings.Models.Enabled, func(id string) bool {
+		if !slices.ContainsFunc(updated.Models.Enabled, func(id string) bool {
 			return strings.EqualFold(id, conf.ModelIDBirdNET)
 		}) {
-			mm.settings.Models.Enabled = append([]string{conf.ModelIDBirdNET}, mm.settings.Models.Enabled...)
+			updated.Models.Enabled = append([]string{conf.ModelIDBirdNET}, updated.Models.Enabled...)
 			changed = true
 		}
 		addIfMissing := func(alias string) {
-			if alias != "" && !slices.ContainsFunc(mm.settings.Models.Enabled, func(id string) bool {
+			if alias != "" && !slices.ContainsFunc(updated.Models.Enabled, func(id string) bool {
 				return strings.EqualFold(id, alias)
 			}) {
-				mm.settings.Models.Enabled = append(mm.settings.Models.Enabled, alias)
+				updated.Models.Enabled = append(updated.Models.Enabled, alias)
 				changed = true
 			}
 		}
@@ -165,23 +169,24 @@ func (mm *ModelManager) ScanInstalled() {
 		}
 
 		// Also add models enabled via legacy per-model config flags.
-		if mm.settings.Bat.Enabled || mm.settings.Bat.ClassifierModel != "" {
+		if updated.Bat.Enabled || updated.Bat.ClassifierModel != "" {
 			addIfMissing(conf.ModelIDBat)
 		}
-		if mm.settings.Perch.Enabled || mm.settings.Perch.ModelPath != "" {
+		if updated.Perch.Enabled || updated.Perch.ModelPath != "" {
 			addIfMissing(conf.ModelIDPerchV2)
 		}
-		if mm.settings.BSG.Enabled || mm.settings.BSG.ModelPath != "" {
+		if updated.BSG.Enabled || updated.BSG.ModelPath != "" {
 			addIfMissing(conf.ModelIDBSG)
 		}
 
 		if changed {
-			conf.StoreSettings(mm.settings)
+			conf.StoreSettings(updated)
 			if err := conf.SaveSettings(); err != nil {
 				log.Warn("Failed to persist Models.Enabled sync",
 					logger.Error(err))
 			}
 		}
+		mm.settingsMu.Unlock()
 	}
 }
 
@@ -556,57 +561,63 @@ func (mm *ModelManager) removeDownloading(catalogID string) {
 }
 
 // applyConfigForInstall updates settings to reflect a newly installed model.
-// Only fields with non-empty paths are set. The caller must hold no locks.
-// Settings are persisted to disk via conf.SaveSettings so changes survive
-// restarts and are visible to concurrent readers through conf.Setting().
+// Only fields with non-empty paths are set. The caller must hold no locks
+// other than mm.settingsMu (acquired internally).
+// Uses clone-mutate-publish so the shared settings snapshot is never mutated
+// in place. Settings are persisted to disk via conf.SaveSettings so changes
+// survive restarts and are visible to concurrent readers through conf.Setting().
 func (mm *ModelManager) applyConfigForInstall(entry *CatalogEntry, modelPath, labelsPath, embeddingsPath string) {
 	if mm.settings == nil {
 		return
 	}
+
+	mm.settingsMu.Lock()
+	defer mm.settingsMu.Unlock()
+
+	updated := conf.CloneSettings(conf.GetSettings())
 
 	switch entry.RegistryID {
 	case RegistryIDBirdNETV3:
 		GetLogger().Info("BirdNET v3.0 config wiring not yet implemented",
 			logger.String("catalog_id", entry.ID))
 	case RegistryIDPerchV2:
-		mm.settings.Perch.Enabled = true
+		updated.Perch.Enabled = true
 		if modelPath != "" {
-			mm.settings.Perch.ModelPath = modelPath
+			updated.Perch.ModelPath = modelPath
 		}
 		if labelsPath != "" {
-			mm.settings.Perch.LabelPath = labelsPath
+			updated.Perch.LabelPath = labelsPath
 		}
 	case RegistryIDBSG:
-		mm.settings.BSG.Enabled = true
+		updated.BSG.Enabled = true
 		if modelPath != "" {
-			mm.settings.BSG.ModelPath = modelPath
+			updated.BSG.ModelPath = modelPath
 		}
 		if labelsPath != "" {
-			mm.settings.BSG.LabelPath = labelsPath
+			updated.BSG.LabelPath = labelsPath
 		}
 	case RegistryIDBat:
-		mm.settings.Bat.Enabled = true
+		updated.Bat.Enabled = true
 		if modelPath != "" {
-			mm.settings.Bat.ClassifierModel = modelPath
+			updated.Bat.ClassifierModel = modelPath
 		}
 		if labelsPath != "" {
-			mm.settings.Bat.LabelPath = labelsPath
+			updated.Bat.LabelPath = labelsPath
 		}
 		if embeddingsPath != "" {
-			mm.settings.Bat.EmbeddingModel = embeddingsPath
+			updated.Bat.EmbeddingModel = embeddingsPath
 		}
 	}
 
 	// Add config alias to Models.Enabled so the model appears in source config.
 	alias := ConfigAliasForRegistry(entry.RegistryID)
-	if alias != "" && !slices.ContainsFunc(mm.settings.Models.Enabled, func(id string) bool {
+	if alias != "" && !slices.ContainsFunc(updated.Models.Enabled, func(id string) bool {
 		return strings.EqualFold(id, alias)
 	}) {
-		mm.settings.Models.Enabled = append(mm.settings.Models.Enabled, alias)
+		updated.Models.Enabled = append(updated.Models.Enabled, alias)
 	}
 
-	// Publish the mutated settings so SaveSettings picks up our changes.
-	conf.StoreSettings(mm.settings)
+	conf.StoreSettings(updated)
 	if err := conf.SaveSettings(); err != nil {
 		GetLogger().Warn("Failed to persist settings after model install",
 			logger.String("catalog_id", entry.ID),
@@ -616,54 +627,74 @@ func (mm *ModelManager) applyConfigForInstall(entry *CatalogEntry, modelPath, la
 
 // applyConfigForUninstall updates settings to reflect a removed model.
 // For bat models, Enabled is only set to false when no other bat models
-// remain installed. The caller must hold mm.mu (at least RLock).
-// Settings are persisted to disk via conf.SaveSettings so changes survive
-// restarts and are visible to concurrent readers through conf.Setting().
+// remain installed; if another bat model exists, config is re-pointed to it.
+// The caller must hold mm.mu (at least RLock).
+// Uses clone-mutate-publish so the shared settings snapshot is never mutated
+// in place. Settings are persisted to disk via conf.SaveSettings so changes
+// survive restarts and are visible to concurrent readers through conf.Setting().
 func (mm *ModelManager) applyConfigForUninstall(entry *CatalogEntry) {
 	if mm.settings == nil {
 		return
 	}
+
+	mm.settingsMu.Lock()
+	defer mm.settingsMu.Unlock()
+
+	updated := conf.CloneSettings(conf.GetSettings())
 
 	switch entry.RegistryID {
 	case RegistryIDBirdNETV3:
 		GetLogger().Info("BirdNET v3.0 config wiring not yet implemented",
 			logger.String("catalog_id", entry.ID))
 	case RegistryIDPerchV2:
-		mm.settings.Perch.Enabled = false
-		mm.settings.Perch.ModelPath = ""
-		mm.settings.Perch.LabelPath = ""
+		updated.Perch.Enabled = false
+		updated.Perch.ModelPath = ""
+		updated.Perch.LabelPath = ""
 	case RegistryIDBSG:
-		mm.settings.BSG.Enabled = false
-		mm.settings.BSG.ModelPath = ""
-		mm.settings.BSG.LabelPath = ""
+		updated.BSG.Enabled = false
+		updated.BSG.ModelPath = ""
+		updated.BSG.LabelPath = ""
 	case RegistryIDBat:
-		// Only disable if no other bat models remain installed.
-		otherBatInstalled := false
-		for id := range mm.installed {
+		// Find another installed bat model to re-point config to.
+		var replacement *InstalledModel
+		var replacementEntry CatalogEntry
+		for id, inst := range mm.installed {
 			other, found := GetCatalogEntry(id)
 			if found && other.Category == CategoryBat {
-				otherBatInstalled = true
+				replacement = &inst
+				replacementEntry = other
 				break
 			}
 		}
-		if !otherBatInstalled {
-			mm.settings.Bat.Enabled = false
+		if replacement == nil {
+			updated.Bat.Enabled = false
+			updated.Bat.ClassifierModel = ""
+			updated.Bat.LabelPath = ""
+			updated.Bat.EmbeddingModel = ""
+		} else {
+			updated.Bat.ClassifierModel = replacement.ModelPath
+			updated.Bat.LabelPath = replacement.LabelsPath
+			// Resolve embeddings path from the replacement's catalog files.
+			updated.Bat.EmbeddingModel = ""
+			for _, f := range replacementEntry.Files {
+				if f.Role == RoleEmbeddings {
+					updated.Bat.EmbeddingModel = filepath.Join(mm.modelsDir, "shared", f.LocalName)
+					break
+				}
+			}
 		}
-		mm.settings.Bat.ClassifierModel = ""
-		mm.settings.Bat.LabelPath = ""
-		mm.settings.Bat.EmbeddingModel = ""
 	}
 
 	// Remove config alias from Models.Enabled and from any source/stream that references it.
 	alias := ConfigAliasForRegistry(entry.RegistryID)
 	if alias != "" {
-		mm.settings.Models.Enabled = slices.DeleteFunc(mm.settings.Models.Enabled, func(id string) bool {
+		updated.Models.Enabled = slices.DeleteFunc(updated.Models.Enabled, func(id string) bool {
 			return strings.EqualFold(id, alias)
 		})
 
 		// Remove from sound card sources.
-		for i := range mm.settings.Realtime.Audio.Sources {
-			src := &mm.settings.Realtime.Audio.Sources[i]
+		for i := range updated.Realtime.Audio.Sources {
+			src := &updated.Realtime.Audio.Sources[i]
 			src.Models = slices.DeleteFunc(src.Models, func(id string) bool {
 				return strings.EqualFold(id, alias)
 			})
@@ -673,8 +704,8 @@ func (mm *ModelManager) applyConfigForUninstall(entry *CatalogEntry) {
 		}
 
 		// Remove from RTSP/stream sources.
-		for i := range mm.settings.Realtime.RTSP.Streams {
-			stream := &mm.settings.Realtime.RTSP.Streams[i]
+		for i := range updated.Realtime.RTSP.Streams {
+			stream := &updated.Realtime.RTSP.Streams[i]
 			stream.Models = slices.DeleteFunc(stream.Models, func(id string) bool {
 				return strings.EqualFold(id, alias)
 			})
@@ -684,8 +715,7 @@ func (mm *ModelManager) applyConfigForUninstall(entry *CatalogEntry) {
 		}
 	}
 
-	// Publish the mutated settings so SaveSettings picks up our changes.
-	conf.StoreSettings(mm.settings)
+	conf.StoreSettings(updated)
 	if err := conf.SaveSettings(); err != nil {
 		GetLogger().Warn("Failed to persist settings after model uninstall",
 			logger.String("catalog_id", entry.ID),

--- a/internal/classifier/model_manager.go
+++ b/internal/classifier/model_manager.go
@@ -641,6 +641,7 @@ func (mm *ModelManager) applyConfigForUninstall(entry *CatalogEntry) {
 	defer mm.settingsMu.Unlock()
 
 	updated := conf.CloneSettings(conf.GetSettings())
+	retainAlias := false
 
 	switch entry.RegistryID {
 	case RegistryIDBirdNETV3:
@@ -672,9 +673,9 @@ func (mm *ModelManager) applyConfigForUninstall(entry *CatalogEntry) {
 			updated.Bat.LabelPath = ""
 			updated.Bat.EmbeddingModel = ""
 		} else {
+			retainAlias = true
 			updated.Bat.ClassifierModel = replacement.ModelPath
 			updated.Bat.LabelPath = replacement.LabelsPath
-			// Resolve embeddings path from the replacement's catalog files.
 			updated.Bat.EmbeddingModel = ""
 			for _, f := range replacementEntry.Files {
 				if f.Role == RoleEmbeddings {
@@ -685,9 +686,10 @@ func (mm *ModelManager) applyConfigForUninstall(entry *CatalogEntry) {
 		}
 	}
 
-	// Remove config alias from Models.Enabled and from any source/stream that references it.
+	// Remove config alias from Models.Enabled and from any source/stream that
+	// references it, but only when no replacement model of the same category exists.
 	alias := ConfigAliasForRegistry(entry.RegistryID)
-	if alias != "" {
+	if alias != "" && !retainAlias {
 		updated.Models.Enabled = slices.DeleteFunc(updated.Models.Enabled, func(id string) bool {
 			return strings.EqualFold(id, alias)
 		})


### PR DESCRIPTION
## Summary

- Refactor `model_manager.go` settings mutations to use atomic clone-mutate-publish pattern (`CloneSettings` -> mutate -> `StoreSettings`) instead of mutating the shared pointer in place
- Add `settingsMu` mutex to serialize concurrent clone-mutate-publish cycles, eliminating TOCTOU race window
- Fix bug in `applyConfigForUninstall` where removing one Bat model while another remains installed cleared all Bat config paths (left Enabled=true with empty paths); now re-points to remaining model
- Extract duplicated model-fetch logic from `SoundCardManager` and `StreamManager` into shared `models.svelte.ts` store with fetch deduplication guard
- Consolidate `DEFAULT_MODEL_ID` constant into the shared store, removing duplicates from `SoundCardCard` and `StreamCard`
- Replace deprecated `String.prototype.substr()` with `.slice()`

## Test Plan

- [ ] `golangci-lint run -v` passes
- [ ] `go test -race ./internal/classifier/` passes (known flaky: `TestOrchestrator_ModelsMapPopulated` due to go-tflite checkptr)
- [ ] `npm run check:all` passes (0 errors, 0 warnings)
- [ ] Model install/uninstall in gallery works correctly
- [ ] Audio settings page loads models list without duplicate API calls
- [ ] Bat model uninstall with another Bat model remaining keeps config valid

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized model defaults and unified model data sourcing across the UI components.
  * Consolidated model-fetching into a shared store with single-flight loading and a safe fallback list.
  * Backend config sync tightened to use cloned settings and serialized update cycles.

* **Bug Fixes**
  * More reliable default model selection and model-loading behavior in forms and managers.
  * Reduced risk of configuration drift when models are installed or removed.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/2992)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->