### PR TITLE
feat: add verified SHA256 checksums for Perch v2 model

### DIFF
--- a/frontend/src/lib/desktop/features/settings/pages/AnalysisSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/AnalysisSettingsPage.svelte
@@ -34,6 +34,7 @@
     uninstallModel,
     subscribeInstallProgress,
   } from '$lib/utils/modelsApi';
+  import { invalidateModels } from '$lib/stores/models.svelte';
   import SettingsTabs from '$lib/desktop/features/settings/components/SettingsTabs.svelte';
   import type { TabDefinition } from '$lib/desktop/features/settings/components/SettingsTabs.svelte';
   import SettingsSection from '$lib/desktop/features/settings/components/SettingsSection.svelte';
@@ -728,6 +729,7 @@
               installingId = null;
               downloadProgress = null;
             }
+            invalidateModels();
             loadCatalog();
           }, 2000);
         },
@@ -762,6 +764,7 @@
 
     try {
       await uninstallModel(modelId);
+      invalidateModels();
       await loadCatalog();
     } catch (e) {
       error = e instanceof Error ? e.message : t('analysis.gallery.errors.removeFailed');

--- a/frontend/src/lib/stores/models.svelte.ts
+++ b/frontend/src/lib/stores/models.svelte.ts
@@ -26,6 +26,14 @@ export function getAvailableModels(): BackendModel[] {
   return fetchedModels.length > 0 ? fetchedModels : FALLBACK_MODELS;
 }
 
+export function invalidateModels(): void {
+  if (activeFetch) {
+    activeFetch.abort();
+    activeFetch = null;
+  }
+  fetchedModels = [];
+}
+
 export function fetchModels(): () => void {
   subscribers++;
 

--- a/internal/classifier/model_catalog.go
+++ b/internal/classifier/model_catalog.go
@@ -86,8 +86,8 @@ var EmbeddedCatalog = []CatalogEntry{
 		UpstreamURL:       "https://www.kaggle.com/models/google/bird-vocalization-classifier/tensorFlow2/perch_v2",
 		HuggingFaceRepo:   "tphakala/Perch-v2",
 		Files: []CatalogFile{
-			{RemotePath: "perch_v2.onnx", LocalName: "perch_v2.onnx", Role: RoleModel, SHA256: "placeholder", SizeBytes: 0},
-			{RemotePath: "labels.txt", LocalName: "perch_v2_labels.txt", Role: RoleLabels, SHA256: "placeholder", SizeBytes: 0},
+			{RemotePath: "perch_v2.onnx", LocalName: "perch_v2.onnx", Role: RoleModel, SHA256: "bf0c8467a924cb074663970ca4a0ab1e143602121930209657d0dff5d5cefa1f", SizeBytes: 409148616},
+			{RemotePath: "labels.txt", LocalName: "perch_v2_labels.txt", Role: RoleLabels, SHA256: "e4d5c0397d8fb08bf90c6b13a34810af53504faad927e472fcc567793c9de057", SizeBytes: 312716},
 		},
 	},
 	{


### PR DESCRIPTION
## Summary

- Replace placeholder SHA256 and SizeBytes values with verified checksums for the Perch v2 model catalog entry
- Enables download integrity verification for `perch_v2.onnx` (409 MB) and `labels.txt` (313 KB) from the new `tphakala/Perch-v2` HuggingFace repository

## Context

The Perch v2 model files have been uploaded to `tphakala/Perch-v2` on HuggingFace with proper attribution to Google Research (original model), justinchuby (ONNX conversion), and cgeorgiaw (labels). This change populates the catalog with real checksums so the model gallery can download and verify Perch v2 files.

## Test Plan

- [ ] Verify catalog entry compiles correctly
- [ ] Confirm SHA256 checksums match files on HuggingFace

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Models list now properly refreshes after installing or uninstalling models.

* **Chores**
  * Updated perch-v2 model metadata with correct values.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/2993)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->