### PR TITLE
feat: add wildlife category and uniform license modal

### DIFF
--- a/frontend/src/lib/desktop/components/forms/SoundCardCard.test.ts
+++ b/frontend/src/lib/desktop/components/forms/SoundCardCard.test.ts
@@ -26,7 +26,7 @@ describe('SoundCardCard defensive model guards', () => {
   ];
   const availableModels = [
     { id: 'birdnet', name: 'BirdNET v2.4', category: 'bird' },
-    { id: 'perch_v2', name: 'Perch v2', category: 'bird' },
+    { id: 'perch_v2', name: 'Perch v2', category: 'wildlife' },
   ];
 
   const baseSource: Omit<AudioSourceConfig, 'models'> = {

--- a/frontend/src/lib/desktop/features/settings/pages/AnalysisSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/AnalysisSettingsPage.svelte
@@ -141,6 +141,9 @@
 
   // ── Derived catalog views ─────────────────────────────────────────────
   const installedEntries = $derived(catalog.filter(e => e.installed));
+  const availableWildlife = $derived(
+    catalog.filter(e => !e.installed && e.compatible && e.category === 'wildlife')
+  );
   const availableBirds = $derived(
     catalog.filter(e => !e.installed && e.compatible && e.category === 'bird')
   );
@@ -1425,6 +1428,22 @@
         </button>
       </div>
     {:else}
+      <!-- Wildlife Classifiers -->
+      {#if availableWildlife.length > 0}
+        <div>
+          <h3
+            class="mb-3 text-sm font-semibold uppercase tracking-wider text-[var(--color-base-content)]/80"
+          >
+            {t('analysis.gallery.categories.wildlife')}
+          </h3>
+          <div class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+            {#each availableWildlife as entry (entry.id)}
+              {@render modelCard(entry)}
+            {/each}
+          </div>
+        </div>
+      {/if}
+
       <!-- Bird Classifiers -->
       {#if availableBirds.length > 0}
         <div>
@@ -1457,7 +1476,7 @@
         </div>
       {/if}
 
-      {#if availableBirds.length === 0 && availableBats.length === 0}
+      {#if availableWildlife.length === 0 && availableBirds.length === 0 && availableBats.length === 0}
         <p class="py-8 text-center text-sm text-[var(--color-base-content)]/80">
           {t('analysis.gallery.noAvailableModels')}
         </p>
@@ -1474,61 +1493,79 @@
 <!-- License Acceptance Dialog -->
 <dialog
   bind:this={licenseDialogRef}
-  class="m-auto rounded-xl border border-[var(--color-base-300)] bg-[var(--color-base-100)] p-0 shadow-xl backdrop:bg-black/50"
+  class="m-auto w-full max-w-md rounded-xl border border-[var(--color-base-300)] bg-[var(--color-base-100)] p-0 shadow-xl backdrop:bg-black/50"
   aria-labelledby="license-dialog-title"
 >
   {#if licenseModel}
-    <div class="w-full max-w-lg p-6">
+    <div class="p-6">
       <h3 id="license-dialog-title" class="text-lg font-semibold text-[var(--color-base-content)]">
         {t('analysis.gallery.license.title')}
       </h3>
       <div class="mt-4 space-y-3">
-        <div class="rounded-lg bg-[var(--color-base-200)] p-4 text-sm">
-          <div class="space-y-2">
-            <div class="flex items-center justify-between">
-              <span class="text-[var(--color-base-content)]/80"
-                >{t('analysis.gallery.license.model')}</span
+        <table class="w-full rounded-lg bg-[var(--color-base-200)] text-sm">
+          <tbody>
+            <tr>
+              <th
+                scope="row"
+                class="px-4 pt-4 pb-1 text-left font-normal align-top text-[var(--color-base-content)]/80"
+                >{t('analysis.gallery.license.model')}</th
               >
-              <span class="font-medium text-[var(--color-base-content)]">{licenseModel.name}</span>
-            </div>
-            <div class="flex items-center justify-between">
-              <span class="text-[var(--color-base-content)]/80"
-                >{t('analysis.gallery.license.author')}</span
+              <td class="px-4 pt-4 pb-1 text-right font-medium text-[var(--color-base-content)]"
+                >{licenseModel.name}</td
               >
-              <span class="text-[var(--color-base-content)]">{licenseModel.author}</span>
-            </div>
-            <div class="flex items-center justify-between">
-              <span class="text-[var(--color-base-content)]/80"
-                >{t('analysis.gallery.license.license')}</span
+            </tr>
+            <tr>
+              <th
+                scope="row"
+                class="px-4 py-1 text-left font-normal align-top text-[var(--color-base-content)]/80"
+                >{t('analysis.gallery.license.author')}</th
               >
-              <span class="text-[var(--color-base-content)]">{licenseModel.license}</span>
-            </div>
-            <div class="flex items-center justify-between">
-              <span class="text-[var(--color-base-content)]/80"
-                >{t('analysis.gallery.license.commercialUse')}</span
+              <td class="px-4 py-1 text-right text-[var(--color-base-content)]"
+                >{licenseModel.author}</td
               >
-              {#if licenseModel.commercialUse}
-                <span class="inline-flex items-center gap-1 text-[var(--color-success)]">
-                  <Shield class="size-3.5" />
-                  {t('analysis.gallery.license.allowed')}
-                </span>
-              {:else}
-                <span class="inline-flex items-center gap-1 text-[var(--color-warning)]">
-                  <ShieldAlert class="size-3.5" />
-                  {t('analysis.gallery.license.notAllowed')}
-                </span>
-              {/if}
-            </div>
-            <div class="flex items-center justify-between">
-              <span class="text-[var(--color-base-content)]/80"
-                >{t('analysis.gallery.license.downloadSize')}</span
+            </tr>
+            <tr>
+              <th
+                scope="row"
+                class="px-4 py-1 text-left font-normal align-top text-[var(--color-base-content)]/80"
+                >{t('analysis.gallery.license.license')}</th
               >
-              <span class="text-[var(--color-base-content)]"
-                >{formatBytes(licenseModel.totalSizeBytes)}</span
+              <td class="px-4 py-1 text-right text-[var(--color-base-content)]"
+                >{licenseModel.license}</td
               >
-            </div>
-          </div>
-        </div>
+            </tr>
+            <tr>
+              <th
+                scope="row"
+                class="px-4 py-1 text-left font-normal align-top text-[var(--color-base-content)]/80"
+                >{t('analysis.gallery.license.commercialUse')}</th
+              >
+              <td class="px-4 py-1 text-right">
+                {#if licenseModel.commercialUse}
+                  <span class="inline-flex items-center gap-1 text-[var(--color-success)]">
+                    <Shield class="size-3.5" />
+                    {t('analysis.gallery.license.allowed')}
+                  </span>
+                {:else}
+                  <span class="inline-flex items-center gap-1 text-[var(--color-warning)]">
+                    <ShieldAlert class="size-3.5" />
+                    {t('analysis.gallery.license.notAllowed')}
+                  </span>
+                {/if}
+              </td>
+            </tr>
+            <tr>
+              <th
+                scope="row"
+                class="px-4 pt-1 pb-4 text-left font-normal align-top text-[var(--color-base-content)]/80"
+                >{t('analysis.gallery.license.downloadSize')}</th
+              >
+              <td class="px-4 pt-1 pb-4 text-right text-[var(--color-base-content)]"
+                >{formatBytes(licenseModel.totalSizeBytes)}</td
+              >
+            </tr>
+          </tbody>
+        </table>
 
         {#if !licenseModel.commercialUse}
           <div

--- a/frontend/src/lib/desktop/features/settings/pages/AnalysisSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/AnalysisSettingsPage.svelte
@@ -1512,7 +1512,8 @@
                 class="px-4 pt-4 pb-1 text-left font-normal align-top text-[var(--color-base-content)]/80"
                 >{t('analysis.gallery.license.model')}</th
               >
-              <td class="px-4 pt-4 pb-1 text-right font-medium text-[var(--color-base-content)]"
+              <td
+                class="px-4 pt-4 pb-1 text-right align-top font-medium text-[var(--color-base-content)]"
                 >{licenseModel.name}</td
               >
             </tr>
@@ -1522,7 +1523,7 @@
                 class="px-4 py-1 text-left font-normal align-top text-[var(--color-base-content)]/80"
                 >{t('analysis.gallery.license.author')}</th
               >
-              <td class="px-4 py-1 text-right text-[var(--color-base-content)]"
+              <td class="px-4 py-1 text-right align-top text-[var(--color-base-content)]"
                 >{licenseModel.author}</td
               >
             </tr>
@@ -1532,7 +1533,7 @@
                 class="px-4 py-1 text-left font-normal align-top text-[var(--color-base-content)]/80"
                 >{t('analysis.gallery.license.license')}</th
               >
-              <td class="px-4 py-1 text-right text-[var(--color-base-content)]"
+              <td class="px-4 py-1 text-right align-top text-[var(--color-base-content)]"
                 >{licenseModel.license}</td
               >
             </tr>
@@ -1542,7 +1543,7 @@
                 class="px-4 py-1 text-left font-normal align-top text-[var(--color-base-content)]/80"
                 >{t('analysis.gallery.license.commercialUse')}</th
               >
-              <td class="px-4 py-1 text-right">
+              <td class="px-4 py-1 text-right align-top">
                 {#if licenseModel.commercialUse}
                   <span class="inline-flex items-center gap-1 text-[var(--color-success)]">
                     <Shield class="size-3.5" />
@@ -1562,7 +1563,7 @@
                 class="px-4 pt-1 pb-4 text-left font-normal align-top text-[var(--color-base-content)]/80"
                 >{t('analysis.gallery.license.downloadSize')}</th
               >
-              <td class="px-4 pt-1 pb-4 text-right text-[var(--color-base-content)]"
+              <td class="px-4 pt-1 pb-4 text-right align-top text-[var(--color-base-content)]"
                 >{formatBytes(licenseModel.totalSizeBytes)}</td
               >
             </tr>

--- a/frontend/src/lib/desktop/features/settings/pages/AnalysisSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/AnalysisSettingsPage.svelte
@@ -1502,7 +1502,9 @@
         {t('analysis.gallery.license.title')}
       </h3>
       <div class="mt-4 space-y-3">
-        <table class="w-full rounded-lg bg-[var(--color-base-200)] text-sm">
+        <table
+          class="w-full overflow-hidden rounded-lg border-separate border-spacing-0 bg-[var(--color-base-200)] text-sm"
+        >
           <tbody>
             <tr>
               <th

--- a/frontend/src/lib/types/models.ts
+++ b/frontend/src/lib/types/models.ts
@@ -11,7 +11,7 @@ export interface CatalogEntry {
   author: string;
   license: string;
   commercialUse: boolean;
-  category: 'bird' | 'bat';
+  category: 'wildlife' | 'bird' | 'bat';
   region: string;
   speciesCount: number;
   version: string;

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -4516,6 +4516,7 @@
       "noInstalledModels": "Keine zusätzlichen Modelle installiert. Durchsuchen Sie den Tab Verfügbar, um weitere Klassifikatoren hinzuzufügen.",
       "noAvailableModels": "Keine zusätzlichen Modelle für Ihre Plattform verfügbar.",
       "categories": {
+        "wildlife": "Wildtierklassifikatoren",
         "bird": "Vogelklassifikatoren",
         "bat": "Fledermausklassifikatoren"
       },

--- a/frontend/static/messages/en.json
+++ b/frontend/static/messages/en.json
@@ -4516,6 +4516,7 @@
       "noInstalledModels": "No additional models installed. Browse the Available tab to add more classifiers.",
       "noAvailableModels": "No additional models available for your platform.",
       "categories": {
+        "wildlife": "Wildlife Classifiers",
         "bird": "Bird Classifiers",
         "bat": "Bat Classifiers"
       },

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -4516,6 +4516,7 @@
       "noInstalledModels": "No hay modelos adicionales instalados. Explore la pestaña Disponibles para agregar más clasificadores.",
       "noAvailableModels": "No hay modelos adicionales disponibles para su plataforma.",
       "categories": {
+        "wildlife": "Clasificadores de fauna",
         "bird": "Clasificadores de aves",
         "bat": "Clasificadores de murciélagos"
       },

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -4516,6 +4516,7 @@
       "noInstalledModels": "Ei asennettuja lisämalleja. Selaa Saatavilla-välilehteä lisätäksesi luokittelijoita.",
       "noAvailableModels": "Ei lisämalleja saatavilla alustallesi.",
       "categories": {
+        "wildlife": "Eläinluokittelijat",
         "bird": "Lintuluokittelijat",
         "bat": "Lepakkoluokittelijat"
       },

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -4516,6 +4516,7 @@
       "noInstalledModels": "Aucun modèle supplémentaire installé. Parcourez l'onglet Disponibles pour ajouter des classificateurs.",
       "noAvailableModels": "Aucun modèle supplémentaire disponible pour votre plateforme.",
       "categories": {
+        "wildlife": "Classificateurs de faune",
         "bird": "Classificateurs d'oiseaux",
         "bat": "Classificateurs de chauves-souris"
       },

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -4516,6 +4516,7 @@
       "noInstalledModels": "Geen extra modellen geïnstalleerd. Blader door het tabblad Beschikbaar om meer classificatoren toe te voegen.",
       "noAvailableModels": "Geen extra modellen beschikbaar voor uw platform.",
       "categories": {
+        "wildlife": "Wildlifeclassificatoren",
         "bird": "Vogelclassificatoren",
         "bat": "Vleermuisclassificatoren"
       },

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -4516,6 +4516,7 @@
       "noInstalledModels": "Brak zainstalowanych dodatkowych modeli. Przejdź do karty Dostępne, aby dodać więcej klasyfikatorów.",
       "noAvailableModels": "Brak dodatkowych modeli dostępnych dla Twojej platformy.",
       "categories": {
+        "wildlife": "Klasyfikatory dzikiej przyrody",
         "bird": "Klasyfikatory ptaków",
         "bat": "Klasyfikatory nietoperzy"
       },

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -4516,6 +4516,7 @@
       "noInstalledModels": "Nenhum modelo adicional instalado. Navegue na aba Disponíveis para adicionar mais classificadores.",
       "noAvailableModels": "Nenhum modelo adicional disponível para sua plataforma.",
       "categories": {
+        "wildlife": "Classificadores de fauna",
         "bird": "Classificadores de aves",
         "bat": "Classificadores de morcegos"
       },

--- a/internal/classifier/model_catalog.go
+++ b/internal/classifier/model_catalog.go
@@ -5,8 +5,9 @@ package classifier
 
 // Catalog category constants.
 const (
-	CategoryBird = "bird"
-	CategoryBat  = "bat"
+	CategoryWildlife = "wildlife"
+	CategoryBird     = "bird"
+	CategoryBat      = "bat"
 )
 
 // CatalogFile role constants.
@@ -25,7 +26,7 @@ type CatalogEntry struct {
 	Author            string        // model author or organization
 	License           string        // license identifier (e.g., "Apache-2.0")
 	CommercialUse     bool          // whether commercial use is permitted
-	Category          string        // "bird" or "bat"
+	Category          string        // "wildlife", "bird", or "bat"
 	Region            string        // geographic region, or empty for global models
 	SpeciesCount      int           // number of species the model can identify
 	Version           string        // model version string
@@ -49,15 +50,15 @@ type CatalogFile struct {
 // Each entry provides enough metadata for the gallery UI and enough file
 // information to drive the download process.
 var EmbeddedCatalog = []CatalogEntry{
-	// Bird models
+	// Wildlife models (multi-taxa classifiers)
 	{
 		ID:                "birdnet-v3.0",
 		Name:              "BirdNET v3.0",
-		Description:       "Global bird species classifier using BirdNET v3.0 architecture",
+		Description:       "Global wildlife classifier using BirdNET v3.0 architecture",
 		Author:            "Cornell Lab of Ornithology & Chemnitz University of Technology",
 		License:           "TBD",
 		CommercialUse:     false,
-		Category:          CategoryBird,
+		Category:          CategoryWildlife,
 		Region:            "",
 		SpeciesCount:      0, // determined at runtime from label file
 		Version:           "3.0",
@@ -77,7 +78,7 @@ var EmbeddedCatalog = []CatalogEntry{
 		Author:            "Google Research",
 		License:           "Apache-2.0",
 		CommercialUse:     true,
-		Category:          CategoryBird,
+		Category:          CategoryWildlife,
 		Region:            "",
 		SpeciesCount:      14795,
 		Version:           "2",

--- a/internal/classifier/model_catalog_test.go
+++ b/internal/classifier/model_catalog_test.go
@@ -47,10 +47,10 @@ func TestEmbeddedCatalog_HasFilesWithModelRole(t *testing.T) {
 func TestEmbeddedCatalog_ValidCategories(t *testing.T) {
 	t.Parallel()
 
-	validCategories := map[string]bool{CategoryBird: true, CategoryBat: true}
+	validCategories := map[string]bool{CategoryWildlife: true, CategoryBird: true, CategoryBat: true}
 	for _, entry := range EmbeddedCatalog {
 		assert.True(t, validCategories[entry.Category],
-			"catalog entry %q has invalid category %q (must be \"bird\" or \"bat\")", entry.ID, entry.Category)
+			"catalog entry %q has invalid category %q (must be \"wildlife\", \"bird\", or \"bat\")", entry.ID, entry.Category)
 	}
 }
 
@@ -77,9 +77,15 @@ func TestCatalogByCategory(t *testing.T) {
 
 	grouped := CatalogByCategory()
 
-	// Should have both bird and bat categories
+	// Should have wildlife, bird, and bat categories
+	require.Contains(t, grouped, CategoryWildlife)
 	require.Contains(t, grouped, CategoryBird)
 	require.Contains(t, grouped, CategoryBat)
+
+	// All wildlife entries should have the wildlife category
+	for _, entry := range grouped[CategoryWildlife] {
+		assert.Equal(t, CategoryWildlife, entry.Category)
+	}
 
 	// All bird entries should have the bird category
 	for _, entry := range grouped[CategoryBird] {
@@ -91,8 +97,9 @@ func TestCatalogByCategory(t *testing.T) {
 		assert.Equal(t, CategoryBat, entry.Category)
 	}
 
-	// Verify expected counts (3 bird entries, 11 bat entries)
-	assert.Len(t, grouped[CategoryBird], 3, "expected 3 bird catalog entries")
+	// Verify expected counts (2 wildlife, 1 bird, 11 bat entries)
+	assert.Len(t, grouped[CategoryWildlife], 2, "expected 2 wildlife catalog entries")
+	assert.Len(t, grouped[CategoryBird], 1, "expected 1 bird catalog entry")
 	assert.Len(t, grouped[CategoryBat], 11, "expected 11 bat catalog entries")
 }
 
@@ -120,7 +127,7 @@ func TestEmbeddedCatalog_BatEntriesHaveEmbeddingsFile(t *testing.T) {
 func TestEmbeddedCatalog_EntryCount(t *testing.T) {
 	t.Parallel()
 
-	// 3 bird entries (birdnet-v3.0, perch-v2, bsg-finland) + 11 bat entries = 14 total
+	// 2 wildlife entries (birdnet-v3.0, perch-v2) + 1 bird entry (bsg-finland) + 11 bat entries = 14 total
 	assert.Len(t, EmbeddedCatalog, 14, "expected 14 total catalog entries")
 }
 
@@ -158,6 +165,6 @@ func TestGetCatalogEntry_BirdNETv30(t *testing.T) {
 	assert.Equal(t, "birdnet-v3.0", entry.ID)
 	assert.Equal(t, "BirdNET v3.0", entry.Name)
 	assert.Equal(t, RegistryIDBirdNETV3, entry.RegistryID)
-	assert.Equal(t, CategoryBird, entry.Category)
+	assert.Equal(t, CategoryWildlife, entry.Category)
 	assert.Contains(t, entry.RequiredBuildTags, "onnx")
 }


### PR DESCRIPTION
## Summary

- Add "Wildlife Classifiers" category for multi-taxa models (BirdNET v3.0, Perch v2) that identify species beyond just birds
- BSG Finland stays in "Bird Classifiers" since it only classifies Finnish bird species
- Refactor license acceptance modal from flex-based to fixed-width table layout for uniform size across all models (fixes long author names like "Cornell Lab of Ornithology & Chemnitz University of Technology" causing inconsistent sizing)
- Use semantic `<th scope="row">` for accessible table row headers
- Add i18n keys for the new category in all 8 locales

## Test Plan

- [ ] Verify "Wildlife Classifiers" section appears in Available tab with BirdNET v3.0 and Perch v2
- [ ] Verify "Bird Classifiers" section shows only BSG Finland
- [ ] Verify license modal has consistent size for all models (short and long author names)
- [ ] Verify screen reader correctly announces table row headers in license modal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new "Wildlife Classifiers" category to the model gallery and surfaced it in Models → Available.

* **Refactor**
  * Redesigned the license acceptance dialog to a table layout (model, author, license, commercial use, download size).
  * Adjusted Available tab empty-state to consider Birds, Bats, and Wildlife together.

* **Chores**
  * Added multilingual translations for the Wildlife category.
  * Updated tests and model categorizations to include Wildlife.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/2994)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->