### PR TITLE
fix: resolve correct model type for multi-taxa and bat classifiers

### DIFF
--- a/internal/datastore/v2/repository/conversion.go
+++ b/internal/datastore/v2/repository/conversion.go
@@ -42,7 +42,7 @@ func ConvertToV2Detection(ctx context.Context, result *detection.Result, deps *C
 		modelVariant = detection.DefaultModelVariant
 	}
 
-	model, err := deps.ModelRepo.GetOrCreate(ctx, modelName, modelVersion, modelVariant, entities.ModelTypeBird, result.Model.ClassifierPath)
+	model, err := deps.ModelRepo.GetOrCreate(ctx, modelName, modelVersion, modelVariant, detection.ResolveModelType(modelName, modelVersion), result.Model.ClassifierPath)
 	if err != nil {
 		return nil, fmt.Errorf("model resolution failed: %w", err)
 	}

--- a/internal/datastore/v2/repository/model_impl.go
+++ b/internal/datastore/v2/repository/model_impl.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/datastore/v2/entities"
@@ -55,9 +56,12 @@ func (r *modelRepository) GetOrCreate(ctx context.Context, name, version, varian
 		First(&model).Error
 	if err == nil {
 		if model.ModelType != modelType {
-			r.db.WithContext(ctx).Table(r.tableName()).
+			updateErr := r.db.WithContext(ctx).Table(r.tableName()).
 				Where("id = ?", model.ID).
-				Update("model_type", modelType)
+				Update("model_type", modelType).Error
+			if updateErr != nil {
+				return nil, fmt.Errorf("failed to update model type: %w", updateErr)
+			}
 			model.ModelType = modelType
 		}
 		return &model, nil

--- a/internal/datastore/v2/repository/model_impl.go
+++ b/internal/datastore/v2/repository/model_impl.go
@@ -46,6 +46,7 @@ func (r *modelRepository) labelsTable() string {
 
 // GetOrCreate retrieves an existing model or creates a new one.
 // Matches on name + version + variant combination.
+// If the model already exists but has a different ModelType, it is updated.
 func (r *modelRepository) GetOrCreate(ctx context.Context, name, version, variant string, modelType entities.ModelType, classifierPath *string) (*entities.AIModel, error) {
 	var model entities.AIModel
 
@@ -53,6 +54,12 @@ func (r *modelRepository) GetOrCreate(ctx context.Context, name, version, varian
 		Where("name = ? AND version = ? AND variant = ?", name, version, variant).
 		First(&model).Error
 	if err == nil {
+		if model.ModelType != modelType {
+			r.db.WithContext(ctx).Table(r.tableName()).
+				Where("id = ?", model.ID).
+				Update("model_type", modelType)
+			model.ModelType = modelType
+		}
 		return &model, nil
 	}
 	if !errors.Is(err, gorm.ErrRecordNotFound) {

--- a/internal/datastore/v2only/datastore.go
+++ b/internal/datastore/v2only/datastore.go
@@ -451,6 +451,9 @@ func (ds *Datastore) GetDatabaseStats() (*datastore.DatabaseStats, error) {
 
 // EnsureModelRegistered creates the model entry in ai_models if it doesn't exist.
 func (ds *Datastore) EnsureModelRegistered(info detection.ModelInfo) error {
+	if info.Name == "" {
+		info = detection.DefaultModelInfo()
+	}
 	ctx := context.Background()
 	_, err := ds.model.GetOrCreate(ctx, info.Name, info.Version, info.Variant, detection.ResolveModelType(info.Name, info.Version), info.ClassifierPath)
 	return err

--- a/internal/datastore/v2only/datastore.go
+++ b/internal/datastore/v2only/datastore.go
@@ -452,7 +452,7 @@ func (ds *Datastore) GetDatabaseStats() (*datastore.DatabaseStats, error) {
 // EnsureModelRegistered creates the model entry in ai_models if it doesn't exist.
 func (ds *Datastore) EnsureModelRegistered(info detection.ModelInfo) error {
 	ctx := context.Background()
-	_, err := ds.model.GetOrCreate(ctx, info.Name, info.Version, info.Variant, entities.ModelTypeBird, info.ClassifierPath)
+	_, err := ds.model.GetOrCreate(ctx, info.Name, info.Version, info.Variant, detection.ResolveModelType(info.Name, info.Version), info.ClassifierPath)
 	return err
 }
 
@@ -468,7 +468,7 @@ func (ds *Datastore) Save(note *datastore.Note, results []datastore.Results) err
 	if modelInfo.Name == "" {
 		modelInfo = detection.DefaultModelInfo()
 	}
-	model, err := ds.model.GetOrCreate(ctx, modelInfo.Name, modelInfo.Version, modelInfo.Variant, entities.ModelTypeBird, modelInfo.ClassifierPath)
+	model, err := ds.model.GetOrCreate(ctx, modelInfo.Name, modelInfo.Version, modelInfo.Variant, detection.ResolveModelType(modelInfo.Name, modelInfo.Version), modelInfo.ClassifierPath)
 	if err != nil {
 		return fmt.Errorf("failed to get/create model: %w", err)
 	}

--- a/internal/detection/model_info.go
+++ b/internal/detection/model_info.go
@@ -1,5 +1,7 @@
 package detection
 
+import "github.com/tphakala/birdnet-go/internal/datastore/v2/entities"
+
 // Default model constants.
 const (
 	DefaultModelName    = "BirdNET"
@@ -22,5 +24,21 @@ func DefaultModelInfo() ModelInfo {
 		Version:        DefaultModelVersion,
 		Variant:        DefaultModelVariant,
 		ClassifierPath: nil,
+	}
+}
+
+// ResolveModelType determines the entity ModelType from a model's name and version.
+// BattyBirdNET models are bat, BirdNET v3.0+ and Perch are multi-taxa wildlife,
+// and everything else (BirdNET v2.4, BSG) is bird.
+func ResolveModelType(name, version string) entities.ModelType {
+	switch {
+	case name == "BattyBirdNET":
+		return entities.ModelTypeBat
+	case name == "Perch":
+		return entities.ModelTypeMulti
+	case name == "BirdNET" && version != "2.4":
+		return entities.ModelTypeMulti
+	default:
+		return entities.ModelTypeBird
 	}
 }

--- a/internal/detection/model_info.go
+++ b/internal/detection/model_info.go
@@ -29,14 +29,14 @@ func DefaultModelInfo() ModelInfo {
 
 // ResolveModelType determines the entity ModelType from a model's name and version.
 // BattyBirdNET models are bat, BirdNET v3.0+ and Perch are multi-taxa wildlife,
-// and everything else (BirdNET v2.4, BSG) is bird.
+// and everything else (BirdNET v2.4, BSG, unknown) is bird.
 func ResolveModelType(name, version string) entities.ModelType {
 	switch {
 	case name == "BattyBirdNET":
 		return entities.ModelTypeBat
 	case name == "Perch":
 		return entities.ModelTypeMulti
-	case name == "BirdNET" && version != "2.4":
+	case name == "BirdNET" && version != "" && version != "2.4":
 		return entities.ModelTypeMulti
 	default:
 		return entities.ModelTypeBird


### PR DESCRIPTION
## Summary

- Add `detection.ResolveModelType()` that maps model name+version to the correct `entities.ModelType`
- BattyBirdNET -> `ModelTypeBat`, Perch/BirdNET v3.0+ -> `ModelTypeMulti`, everything else -> `ModelTypeBird`
- Replace hardcoded `entities.ModelTypeBird` in `EnsureModelRegistered`, `Save`, and `convertResult` with the resolver
- Ensures bat and wildlife model detections are stored with correct type for label resolution and taxonomic class assignment

## Context

The `ModelTypeMulti` and `ModelTypeBat` constants existed in entities but were never assigned during model registration in the v2only datastore. All models were unconditionally stored as `ModelTypeBird`. This meant the downstream label parsing and taxonomic class assignment logic (which correctly handles all three types) never received bat or multi types.

## Test Plan

- [ ] Existing tests pass (68 v2only tests, 14 detection tests)
- [ ] Lint clean
- [ ] Verify bat model detections get `ModelTypeBat` in database
- [ ] Verify BirdNET v2.4 continues to get `ModelTypeBird`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Model type is now resolved from model name and version (including BattyBird, Perch, and BirdNET variants such as 2.4), ensuring correct taxonomic-class selection and improved detection accuracy. Model registration/save flows now default missing model info and update stored model type when needed to keep records consistent.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/2995)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->