### PR TITLE
refactor: extract shared sample rate constants and fetch utility

### DIFF
--- a/frontend/src/lib/desktop/components/forms/SoundCardCard.svelte
+++ b/frontend/src/lib/desktop/components/forms/SoundCardCard.svelte
@@ -32,6 +32,7 @@
   import { t } from '$lib/i18n';
   import { cn } from '$lib/utils/cn';
   import { loggers } from '$lib/utils/logger';
+  import { fetchDeviceCapabilities as fetchCapabilities } from '$lib/utils/audio/sampleRate';
   import { DEFAULT_MODEL_ID } from '$lib/stores/models.svelte';
   import SelectDropdown from './SelectDropdown.svelte';
   import InlineSlider from './InlineSlider.svelte';
@@ -236,52 +237,12 @@
     fetchController = new AbortController();
     sampleRateLoading = true;
     try {
-      const response = await fetch(
-        `/api/v2/system/audio/devices/capabilities?deviceId=${encodeURIComponent(deviceId)}`,
-        { signal: fetchController.signal }
-      );
-      if (response.ok) {
-        const responseData: unknown = await response.json();
-        if (
-          !responseData ||
-          typeof responseData !== 'object' ||
-          !('sampleRates' in responseData) ||
-          !Array.isArray((responseData as Record<string, unknown>).sampleRates)
-        ) {
-          sampleRateOptions = [48000, 96000, 192000, 256000, 384000].map(rate => ({
-            value: String(rate),
-            label: `${rate / 1000} kHz`,
-          }));
-          sampleRateVerified = false;
-          return;
-        }
-        const data = responseData as { sampleRates: number[]; verified: boolean };
-        if (data.sampleRates.length === 0) {
-          sampleRateOptions = [48000, 96000, 192000, 256000, 384000].map(rate => ({
-            value: String(rate),
-            label: `${rate / 1000} kHz`,
-          }));
-          sampleRateVerified = false;
-          return;
-        }
-        sampleRateOptions = data.sampleRates.map(rate => ({
-          value: String(rate),
-          label: rate >= 1000 ? `${rate / 1000} kHz` : `${rate} Hz`,
-        }));
-        sampleRateVerified = data.verified;
-      } else {
-        sampleRateOptions = [48000, 96000, 192000, 256000, 384000].map(rate => ({
-          value: String(rate),
-          label: `${rate / 1000} kHz`,
-        }));
-        sampleRateVerified = false;
-      }
+      const result = await fetchCapabilities(deviceId, fetchController.signal);
+      sampleRateOptions = result.options;
+      sampleRateVerified = result.verified;
     } catch (error: unknown) {
       if (error instanceof Error && error.name === 'AbortError') return;
-      sampleRateOptions = [48000, 96000, 192000, 256000, 384000].map(rate => ({
-        value: String(rate),
-        label: `${rate / 1000} kHz`,
-      }));
+      sampleRateOptions = [{ value: '48000', label: '48 kHz' }];
       sampleRateVerified = false;
     } finally {
       sampleRateLoading = false;

--- a/frontend/src/lib/desktop/components/forms/SoundCardCard.svelte
+++ b/frontend/src/lib/desktop/components/forms/SoundCardCard.svelte
@@ -240,10 +240,8 @@
       const result = await fetchCapabilities(deviceId, fetchController.signal);
       sampleRateOptions = result.options;
       sampleRateVerified = result.verified;
-    } catch (error: unknown) {
-      if (error instanceof Error && error.name === 'AbortError') return;
-      sampleRateOptions = [{ value: '48000', label: '48 kHz' }];
-      sampleRateVerified = false;
+    } catch {
+      // Only AbortError reaches here (utility handles all other failures internally)
     } finally {
       sampleRateLoading = false;
     }

--- a/frontend/src/lib/desktop/components/forms/SoundCardManager.svelte
+++ b/frontend/src/lib/desktop/components/forms/SoundCardManager.svelte
@@ -258,10 +258,8 @@
       const result = await fetchCapabilities(deviceId, newFetchController.signal);
       newSampleRateOptions = result.options;
       newSampleRateVerified = result.verified;
-    } catch (error: unknown) {
-      if (error instanceof Error && error.name === 'AbortError') return;
-      newSampleRateOptions = [{ value: '48000', label: '48 kHz' }];
-      newSampleRateVerified = false;
+    } catch {
+      // Only AbortError reaches here (utility handles all other failures internally)
     } finally {
       newSampleRateLoading = false;
     }

--- a/frontend/src/lib/desktop/components/forms/SoundCardManager.svelte
+++ b/frontend/src/lib/desktop/components/forms/SoundCardManager.svelte
@@ -18,6 +18,7 @@
   import { slide } from 'svelte/transition';
   import { t } from '$lib/i18n';
   import { loggers } from '$lib/utils/logger';
+  import { fetchDeviceCapabilities as fetchCapabilities } from '$lib/utils/audio/sampleRate';
   import { toastActions } from '$lib/stores/toast';
   import { cn } from '$lib/utils/cn';
   import { getAvailableModels, DEFAULT_MODEL_ID, fetchModels } from '$lib/stores/models.svelte';
@@ -254,52 +255,12 @@
     newFetchController = new AbortController();
     newSampleRateLoading = true;
     try {
-      const response = await fetch(
-        `/api/v2/system/audio/devices/capabilities?deviceId=${encodeURIComponent(deviceId)}`,
-        { signal: newFetchController.signal }
-      );
-      if (response.ok) {
-        const responseData: unknown = await response.json();
-        if (
-          !responseData ||
-          typeof responseData !== 'object' ||
-          !('sampleRates' in responseData) ||
-          !Array.isArray((responseData as Record<string, unknown>).sampleRates)
-        ) {
-          newSampleRateOptions = [48000, 96000, 192000, 256000, 384000].map(rate => ({
-            value: String(rate),
-            label: `${rate / 1000} kHz`,
-          }));
-          newSampleRateVerified = false;
-          return;
-        }
-        const data = responseData as { sampleRates: number[]; verified: boolean };
-        if (data.sampleRates.length === 0) {
-          newSampleRateOptions = [48000, 96000, 192000, 256000, 384000].map(rate => ({
-            value: String(rate),
-            label: `${rate / 1000} kHz`,
-          }));
-          newSampleRateVerified = false;
-          return;
-        }
-        newSampleRateOptions = data.sampleRates.map(rate => ({
-          value: String(rate),
-          label: rate >= 1000 ? `${rate / 1000} kHz` : `${rate} Hz`,
-        }));
-        newSampleRateVerified = data.verified;
-      } else {
-        newSampleRateOptions = [48000, 96000, 192000, 256000, 384000].map(rate => ({
-          value: String(rate),
-          label: `${rate / 1000} kHz`,
-        }));
-        newSampleRateVerified = false;
-      }
+      const result = await fetchCapabilities(deviceId, newFetchController.signal);
+      newSampleRateOptions = result.options;
+      newSampleRateVerified = result.verified;
     } catch (error: unknown) {
       if (error instanceof Error && error.name === 'AbortError') return;
-      newSampleRateOptions = [48000, 96000, 192000, 256000, 384000].map(rate => ({
-        value: String(rate),
-        label: `${rate / 1000} kHz`,
-      }));
+      newSampleRateOptions = [{ value: '48000', label: '48 kHz' }];
       newSampleRateVerified = false;
     } finally {
       newSampleRateLoading = false;

--- a/frontend/src/lib/utils/audio/sampleRate.ts
+++ b/frontend/src/lib/utils/audio/sampleRate.ts
@@ -1,0 +1,65 @@
+/**
+ * Shared sample rate constants and utilities for device capabilities.
+ */
+
+export const CANDIDATE_SAMPLE_RATES = [48000, 96000, 192000, 256000, 384000] as const;
+
+export type SampleRateOption = { value: string; label: string };
+
+export interface DeviceCapabilitiesResult {
+  options: SampleRateOption[];
+  verified: boolean;
+}
+
+export function formatSampleRateLabel(rate: number): string {
+  return rate >= 1000 ? `${rate / 1000} kHz` : `${rate} Hz`;
+}
+
+function fallbackOptions(): SampleRateOption[] {
+  return CANDIDATE_SAMPLE_RATES.map(rate => ({
+    value: String(rate),
+    label: `${rate / 1000} kHz`,
+  }));
+}
+
+/**
+ * Fetch device sample rate capabilities from the backend API.
+ * Returns supported rates with verified status.
+ * On any failure, returns all candidate rates as unverified.
+ */
+export async function fetchDeviceCapabilities(
+  deviceId: string,
+  signal?: AbortSignal
+): Promise<DeviceCapabilitiesResult> {
+  const response = await fetch(
+    `/api/v2/system/audio/devices/capabilities?deviceId=${encodeURIComponent(deviceId)}`,
+    signal ? { signal } : undefined
+  );
+
+  if (!response.ok) {
+    return { options: fallbackOptions(), verified: false };
+  }
+
+  const responseData: unknown = await response.json();
+  if (
+    !responseData ||
+    typeof responseData !== 'object' ||
+    !('sampleRates' in responseData) ||
+    !Array.isArray((responseData as Record<string, unknown>).sampleRates)
+  ) {
+    return { options: fallbackOptions(), verified: false };
+  }
+
+  const data = responseData as { sampleRates: number[]; verified: boolean };
+  if (data.sampleRates.length === 0) {
+    return { options: fallbackOptions(), verified: false };
+  }
+
+  return {
+    options: data.sampleRates.map(rate => ({
+      value: String(rate),
+      label: formatSampleRateLabel(rate),
+    })),
+    verified: data.verified,
+  };
+}

--- a/frontend/src/lib/utils/audio/sampleRate.ts
+++ b/frontend/src/lib/utils/audio/sampleRate.ts
@@ -25,41 +25,58 @@ function fallbackOptions(): SampleRateOption[] {
 /**
  * Fetch device sample rate capabilities from the backend API.
  * Returns supported rates with verified status.
- * On any failure, returns all candidate rates as unverified.
+ * On any failure (network, malformed JSON, invalid data), returns all
+ * candidate rates as unverified. Only AbortError is re-thrown so callers
+ * can detect request cancellation.
  */
 export async function fetchDeviceCapabilities(
   deviceId: string,
   signal?: AbortSignal
 ): Promise<DeviceCapabilitiesResult> {
-  const response = await fetch(
-    `/api/v2/system/audio/devices/capabilities?deviceId=${encodeURIComponent(deviceId)}`,
-    signal ? { signal } : undefined
-  );
+  try {
+    const response = await fetch(
+      `/api/v2/system/audio/devices/capabilities?deviceId=${encodeURIComponent(deviceId)}`,
+      signal ? { signal } : undefined
+    );
 
-  if (!response.ok) {
+    if (!response.ok) {
+      return { options: fallbackOptions(), verified: false };
+    }
+
+    let responseData: unknown;
+    try {
+      responseData = await response.json();
+    } catch {
+      return { options: fallbackOptions(), verified: false };
+    }
+
+    if (
+      !responseData ||
+      typeof responseData !== 'object' ||
+      !('sampleRates' in responseData) ||
+      !Array.isArray((responseData as Record<string, unknown>).sampleRates)
+    ) {
+      return { options: fallbackOptions(), verified: false };
+    }
+
+    const raw = responseData as { sampleRates: unknown[]; verified?: unknown };
+    const rates = raw.sampleRates.filter(
+      (r): r is number => typeof r === 'number' && Number.isFinite(r)
+    );
+
+    if (rates.length === 0) {
+      return { options: fallbackOptions(), verified: false };
+    }
+
+    return {
+      options: rates.map(rate => ({
+        value: String(rate),
+        label: formatSampleRateLabel(rate),
+      })),
+      verified: typeof raw.verified === 'boolean' ? raw.verified : false,
+    };
+  } catch (error: unknown) {
+    if (error instanceof Error && error.name === 'AbortError') throw error;
     return { options: fallbackOptions(), verified: false };
   }
-
-  const responseData: unknown = await response.json();
-  if (
-    !responseData ||
-    typeof responseData !== 'object' ||
-    !('sampleRates' in responseData) ||
-    !Array.isArray((responseData as Record<string, unknown>).sampleRates)
-  ) {
-    return { options: fallbackOptions(), verified: false };
-  }
-
-  const data = responseData as { sampleRates: number[]; verified: boolean };
-  if (data.sampleRates.length === 0) {
-    return { options: fallbackOptions(), verified: false };
-  }
-
-  return {
-    options: data.sampleRates.map(rate => ({
-      value: String(rate),
-      label: formatSampleRateLabel(rate),
-    })),
-    verified: data.verified,
-  };
 }

--- a/frontend/src/lib/utils/settingsCoercion.ts
+++ b/frontend/src/lib/utils/settingsCoercion.ts
@@ -5,6 +5,7 @@
  * Ensures settings values are always within valid ranges and of correct types.
  */
 
+import { CANDIDATE_SAMPLE_RATES } from '$lib/utils/audio/sampleRate';
 import type {
   BirdNetSettings,
   AudioSettings,
@@ -271,12 +272,11 @@ export function coerceAudioSettings(settings: PartialAudioSettings): PartialAudi
 
   // Sample rate: accept candidate rates from 48kHz to 384kHz (0 means default)
   if ('sampleRate' in settings) {
-    const validRates = [48000, 96000, 192000, 256000, 384000];
     const rate = coerceNumber(settings.sampleRate, 0, 384000, 0);
     if (rate === 0) {
       delete coerced.sampleRate;
     } else {
-      coerced.sampleRate = validRates.reduce((prev, curr) =>
+      coerced.sampleRate = CANDIDATE_SAMPLE_RATES.reduce((prev, curr) =>
         Math.abs(curr - rate) < Math.abs(prev - rate) ? curr : prev
       );
     }

--- a/internal/conf/validate_audio.go
+++ b/internal/conf/validate_audio.go
@@ -304,6 +304,7 @@ func (a *AudioSourceConfig) Validate() error {
 	}
 
 	// Validate sample rate if specified (0 means use default 48000)
+	// NOTE: These rates must stay in sync with audiocore.CandidateSampleRates.
 	if a.SampleRate != 0 {
 		validRates := map[int]struct{}{
 			48000: {}, 96000: {}, 192000: {}, 256000: {}, 384000: {},


### PR DESCRIPTION
## Summary

- Extract `CANDIDATE_SAMPLE_RATES` constant and `fetchDeviceCapabilities` utility into shared `frontend/src/lib/utils/audio/sampleRate.ts`
- Both `SoundCardCard.svelte` and `SoundCardManager.svelte` now call the shared utility instead of duplicating ~50 lines of identical fetch/validate/fallback logic
- `settingsCoercion.ts` imports the shared constant instead of defining its own inline array
- Add sync comment to `validate_audio.go` noting dependency on `audiocore.CandidateSampleRates`

Follow-up to #2997. Addresses CodeRabbit and Gemini review feedback about DRY violations.

## Test Plan

- [ ] `npx svelte-check` passes (0 errors)
- [ ] Behavior unchanged: sample rate dropdown still fetches capabilities, falls back correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized audio sample-rate handling so device probes and UI use a shared capability lookup for consistent options and verified state.
* **Bug Fixes**
  * More robust fallback for invalid or missing device sample-rate data; improved nearest-rate coercion for saved settings.
* **Style**
  * Standardized sample-rate labels (Hz/kHz) shown in UI.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/2998)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->