### PR TITLE
test(datastore): make TestNightFilterExcludesSunriseSunsetWindows truly timezone-agnostic

### DIFF
--- a/internal/datastore/time_of_day_test.go
+++ b/internal/datastore/time_of_day_test.go
@@ -18,12 +18,35 @@ import (
 // The test is timezone-agnostic and works in any timezone (UTC, local, etc.) by
 // dynamically calculating test times based on actual sunrise/sunset for the test date.
 func TestNightFilterExcludesSunriseSunsetWindows(t *testing.T) {
-	// Setup test date and location
-	// Use time.Local to match whatever timezone the test is running in
-	// Use coordinates near the prime meridian to avoid sunset crossing midnight in UTC
-	testDate := time.Date(2025, 7, 15, 0, 0, 0, 0, time.Local)
-	latitude := 51.5074  // London, UK - near UTC meridian
-	longitude := -0.1278 // Avoids sunset crossing midnight in UTC timezone
+	// Setup test date and location.
+	//
+	// Two constraints to make the test truly timezone-agnostic:
+	//
+	// 1. **testDate must be UTC midnight, not Local.** The production filter
+	//    parses filters.DateStart with time.Parse(time.DateOnly, ...) which
+	//    returns UTC midnight. SunCalc caches by date.Equal() and
+	//    astral.julianday() does date.UTC() and uses the UTC calendar day
+	//    components. If the test passes a Local-midnight date, astral computes
+	//    sunrise/sunset for a different UTC calendar day than the filter does
+	//    (e.g. in NZST, Local-midnight is at noon UTC of the previous UTC day),
+	//    yielding sub-minute drift on sunrise/sunset and off-by-1-second
+	//    boundary failures.
+	//
+	// 2. **Longitude derived from local zone offset** so that solar noon at
+	//    the test location ≈ local-clock noon. This keeps the location's
+	//    sunrise and sunset both within the same local calendar day after
+	//    SunCalc's ConvertUTCToLocal, regardless of where the test runs. With
+	//    a fixed location far from the local timezone (e.g. London in CDT),
+	//    sunrise's local-time string can lex-compare against sunset's in a
+	//    way that breaks the filter's `time < sunriseStart OR time > sunsetEnd`
+	//    logic.
+	//
+	// Mid-latitude (45° N) keeps day length moderate and avoids polar edge
+	// cases (no sunrise/sunset in extreme latitudes around the solstices).
+	testDate := time.Date(2025, 7, 15, 0, 0, 0, 0, time.UTC)
+	_, offsetSec := time.Now().In(time.Local).Zone()
+	latitude := 45.0
+	longitude := float64(offsetSec) / 3600.0 * 15.0
 
 	// Create test database with location settings
 	settings := &conf.Settings{}


### PR DESCRIPTION
## Summary
`TestNightFilterExcludesSunriseSunsetWindows` (added in #1641 to verify the issue #961 fix) claims in its docstring to be timezone-agnostic, but actually only passes in timezones where the fixed London coordinates' sunrise/sunset stay within the same local calendar day after `SunCalc.ConvertUTCToLocal`. In CDT (UTC-5), it fails: London's UTC sunrise (~04:00 UTC) becomes 23:00 on the **previous** local calendar day, the test then inserts notes with date='2025-07-15' at local-clock-time strings semantically belonging to 2025-07-14, and the filter's `time < sunriseStart OR time > sunsetEnd` lex-compare matches everything (because sunsetEnd lex-compared smaller than sunriseStart) — "all 17 inserted detections returned" rather than the expected 4.

This is a **test fix, not a filter fix**. Production filter behavior is unchanged.

## Two coupled fixes

1. **`testDate` is now UTC midnight, not Local.**
   The production filter parses `filters.DateStart` with `time.Parse(time.DateOnly, ...)` which returns UTC midnight. `SunCalc` caches by `date.Equal()` and `astral.julianday()` does `date.UTC()` and uses the UTC calendar-day components. A Local-midnight `testDate` computes sunrise/sunset for a *different UTC calendar day* than the filter does (e.g. in NZST, Local-midnight = noon UTC of the previous UTC day), causing sub-minute drift and off-by-1-second boundary failures.

2. **Longitude derived from the local timezone offset** so solar noon at the test location ≈ local-clock noon. This keeps sunrise and sunset both within the same local calendar day after `SunCalc`'s local conversion, no matter where the test runs.

## Why a fixed location doesn't work

The original setup picked London (lat 51.5074, lon -0.1278) "to avoid sunset crossing midnight in UTC". That's true in UTC, but not in any other timezone after `ConvertUTCToLocal`. The author was likely in a timezone close to UTC where the test happened to pass; CI presumably also runs in UTC. In CDT, NZST, JST, etc., the test fails for the reasons above.

## Test plan
- [x] `go test ./internal/datastore/ -run TestNightFilterExcludesSunriseSunsetWindows` passes locally (CDT)
- [x] Same passes with `TZ=UTC`, `TZ=Pacific/Auckland` (UTC+12), `TZ=Asia/Tokyo` (UTC+9), `TZ=Pacific/Honolulu` (UTC-10), `TZ=Europe/London`, `TZ=America/Argentina/Buenos_Aires`
- [x] Full `go test ./internal/datastore/ -race -count=1` green (25s)
- [x] `go vet ./internal/datastore/...` clean
- [ ] CI green

## Out of scope (real but separate prod bug)
The filter at `internal/datastore/interfaces.go::buildTimeOfDayConditions` has a real cross-meridian bug for users whose configured `BirdNET.Latitude`/`Longitude` are far from their system timezone — sunrise's local-clock-time can lex-compare against sunset's in a way that breaks both Day (`AND` becomes impossible-to-match) and Night (`OR` matches almost everything). Rare in practice (users typically colocate server with birds). Tracking separately; happy to file an issue if useful.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced timezone handling in the night filter test to improve robustness across different geographic locations and timezone configurations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/2999)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->