### PR TITLE
feat(audiocore): ALSA exclusive mode for non-default sample rates

### DIFF
--- a/frontend/src/lib/desktop/components/forms/SoundCardCard.svelte
+++ b/frontend/src/lib/desktop/components/forms/SoundCardCard.svelte
@@ -24,6 +24,7 @@
     X,
     AlertCircle,
     AlertTriangle,
+    Info,
     Mic,
     Moon,
     ChevronDown,
@@ -359,6 +360,12 @@
           {#if sampleRateLoading}
             <p class="text-xs text-[var(--color-base-content)]/60 mt-1 animate-pulse">
               {t('settings.audio.soundCards.sampleRateProbing')}
+            </p>
+          {/if}
+          {#if editSampleRate > 48000}
+            <p class="flex items-center gap-1 text-xs text-[var(--color-info)] mt-1">
+              <Info class="size-3 shrink-0" />
+              {t('settings.audio.soundCards.sampleRateExclusive')}
             </p>
           {/if}
         </div>

--- a/frontend/src/lib/desktop/components/forms/SoundCardManager.svelte
+++ b/frontend/src/lib/desktop/components/forms/SoundCardManager.svelte
@@ -14,7 +14,7 @@
   @component
 -->
 <script lang="ts">
-  import { Plus, Mic, RefreshCw, ChevronDown, AlertTriangle } from '@lucide/svelte';
+  import { Plus, Mic, RefreshCw, ChevronDown, AlertTriangle, Info } from '@lucide/svelte';
   import { slide } from 'svelte/transition';
   import { t } from '$lib/i18n';
   import { loggers } from '$lib/utils/logger';
@@ -414,6 +414,12 @@
               {#if newSampleRateLoading}
                 <p class="text-xs text-[var(--color-base-content)]/60 mt-1 animate-pulse">
                   {t('settings.audio.soundCards.sampleRateProbing')}
+                </p>
+              {/if}
+              {#if newSampleRate > 48000}
+                <p class="flex items-center gap-1 text-xs text-[var(--color-info)] mt-1">
+                  <Info class="size-3 shrink-0" />
+                  {t('settings.audio.soundCards.sampleRateExclusive')}
                 </p>
               {/if}
             </div>

--- a/frontend/static/messages/da.json
+++ b/frontend/static/messages/da.json
@@ -2796,6 +2796,51 @@
           "refresh": "Opdater enheder"
         }
       },
+      "soundCards": {
+        "summary": "{count} lydkortkilde(r)",
+        "addSource": "Tilføj lydkort",
+        "nameLabel": "Kildenavn",
+        "namePlaceholder": "f.eks. Mikrofon i forhaven",
+        "nameHelp": "Et beskrivende navn til denne lydkilde",
+        "deviceLabel": "Lydenhed",
+        "devicePlaceholder": "Vælg en lydenhed",
+        "gainLabel": "Forstærkning (dB)",
+        "gainHelp": "Justering af lydindgangsforstærkning (-40 til +40 dB)",
+        "sampleRateLabel": "Samplingsfrekvens",
+        "sampleRateUnverified": "Understøttede frekvenser kunne ikke verificeres for denne enhed",
+        "sampleRateProbing": "Registrerer understøttede frekvenser...",
+        "sampleRateExclusive": "Frekvenser over 48 kHz bruger eksklusiv enhedsadgang på Linux, hvilket forhindrer andre programmer i at dele lydkortet",
+        "modelLabel": "Detektionsmodeller",
+        "modelHelp": "Vælg hvilke AI-modeller der skal køres på denne lydkilde",
+        "deleteConfirm": "Fjern denne lydkortkilde?",
+        "emptyState": {
+          "title": "Ingen lydkortkilder konfigureret",
+          "description": "Tilføj en lydkortkilde for at begynde at optage lyd til fugledetektering.",
+          "hintsTitle": "Kom i gang",
+          "hints": {
+            "device": "Vælg blandt tilgængelige lydindgangsenheder på dit system",
+            "multiple": "Du kan konfigurere flere lydkort til forskellige placeringer",
+            "model": "Hver kilde kan bruge en anden detektionsmodel (BirdNET, Perch, Bat)"
+          }
+        },
+        "models": {
+          "birdnetDefault": "BirdNET (Standard)",
+          "birdnet": "BirdNET",
+          "perchV2": "Google Perch v2",
+          "bat": "Flagermusdetektering"
+        },
+        "errors": {
+          "nameRequired": "Kildenavn er påkrævet",
+          "deviceRequired": "Lydenhed er påkrævet",
+          "duplicateName": "En kilde med dette navn findes allerede",
+          "duplicateDevice": "Denne enhed er allerede konfigureret"
+        },
+        "compatibility": {
+          "minSampleRate": "Kræver mindst {rate}kHz optagelsesfrekvens",
+          "recommendedSampleRate": "{rate}kHz anbefalet for bedste resultater",
+          "atLeastOneModel": "Mindst én model skal vælges"
+        }
+      },
       "noSources": {
         "warning": "Ingen lydkilder konfigureret",
         "description": "BirdNET-Go har brug for en lydindgang for at registrere fugle. Konfigurer venligst mindst én kilde under fanen Lydkort eller Strømme."

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -2994,6 +2994,7 @@
         "sampleRateLabel": "Abtastrate",
         "sampleRateUnverified": "Unterstützte Raten konnten für dieses Gerät nicht überprüft werden",
         "sampleRateProbing": "Unterstützte Raten werden erkannt...",
+        "sampleRateExclusive": "Raten über 48 kHz verwenden exklusiven Gerätezugriff unter Linux, wodurch andere Anwendungen die Soundkarte nicht gemeinsam nutzen können",
         "modelLabel": "Erkennungsmodelle",
         "modelHelp": "KI-Modelle für diese Audioquelle auswählen",
         "deleteConfirm": "Diese Soundkartenquelle entfernen?",

--- a/frontend/static/messages/en.json
+++ b/frontend/static/messages/en.json
@@ -2818,6 +2818,7 @@
         "sampleRateLabel": "Sample Rate",
         "sampleRateUnverified": "Supported rates could not be verified for this device",
         "sampleRateProbing": "Detecting supported rates...",
+        "sampleRateExclusive": "Rates above 48 kHz use exclusive device access on Linux, preventing other applications from sharing the sound card",
         "modelLabel": "Detection Models",
         "modelHelp": "Select which AI models to run on this audio source",
         "deleteConfirm": "Remove this sound card source?",

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -2767,6 +2767,7 @@
         "sampleRateLabel": "Frecuencia de muestreo",
         "sampleRateUnverified": "No se pudieron verificar las frecuencias compatibles para este dispositivo",
         "sampleRateProbing": "Detectando frecuencias compatibles...",
+        "sampleRateExclusive": "Las tasas superiores a 48 kHz usan acceso exclusivo al dispositivo en Linux, impidiendo que otras aplicaciones compartan la tarjeta de sonido",
         "modelLabel": "Modelos de detección",
         "modelHelp": "Seleccionar modelos de IA para esta fuente de audio",
         "deleteConfirm": "¿Eliminar esta fuente de tarjeta de sonido?",

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -2767,6 +2767,7 @@
         "sampleRateLabel": "Näytteenottotaajuus",
         "sampleRateUnverified": "Tuettuja taajuuksia ei voitu vahvistaa tälle laitteelle",
         "sampleRateProbing": "Tunnistetaan tuettuja taajuuksia...",
+        "sampleRateExclusive": "Yli 48 kHz näytteenottotaajuudet käyttävät yksinoikeudellista laitepääsyä Linuxissa, estäen muita sovelluksia jakamasta äänikorttia",
         "modelLabel": "Tunnistusmallit",
         "modelHelp": "Valitse tässä äänilähteessä käytettävät tekoälymallit",
         "deleteConfirm": "Poistetaanko tämä äänikorttilähtö?",

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -2994,6 +2994,7 @@
         "sampleRateLabel": "Fréquence d'échantillonnage",
         "sampleRateUnverified": "Les fréquences prises en charge n'ont pas pu être vérifiées pour cet appareil",
         "sampleRateProbing": "Détection des fréquences prises en charge...",
+        "sampleRateExclusive": "Les taux supérieurs à 48 kHz utilisent un accès exclusif au périphérique sous Linux, empêchant les autres applications de partager la carte son",
         "modelLabel": "Modèles de détection",
         "modelHelp": "Sélectionner les modèles d'IA pour cette source audio",
         "deleteConfirm": "Supprimer cette source de carte son ?",

--- a/frontend/static/messages/hu.json
+++ b/frontend/static/messages/hu.json
@@ -2797,6 +2797,51 @@
           "refresh": "Eszközök frissítése"
         }
       },
+      "soundCards": {
+        "summary": "{count} hangkártya forrás(ok)",
+        "addSource": "Hangkártya hozzáadása",
+        "nameLabel": "Forrás neve",
+        "namePlaceholder": "pl. Előkerti mikrofon",
+        "nameHelp": "A hangforrás leíró neve",
+        "deviceLabel": "Hangeszköz",
+        "devicePlaceholder": "Válasszon hangeszközt",
+        "gainLabel": "Erősítés (dB)",
+        "gainHelp": "Hangbemenet erősítésének beállítása (-40 - +40 dB)",
+        "sampleRateLabel": "Mintavételezési frekvencia",
+        "sampleRateUnverified": "A támogatott frekvenciák nem ellenőrizhetők ennél az eszköznél",
+        "sampleRateProbing": "Támogatott frekvenciák felderítése...",
+        "sampleRateExclusive": "A 48 kHz feletti frekvenciák kizárólagos eszközhozzáférést használnak Linuxon, megakadályozva más alkalmazásokat a hangkártya megosztásában",
+        "modelLabel": "Detekciós modellek",
+        "modelHelp": "Válassza ki, mely AI-modellek fussanak ezen a hangforráson",
+        "deleteConfirm": "Eltávolítja ezt a hangkártya forrást?",
+        "emptyState": {
+          "title": "Nincsenek hangkártya források konfigurálva",
+          "description": "Adjon hozzá egy hangkártya forrást a madárdetektáláshoz szükséges hangfelvétel elindításához.",
+          "hintsTitle": "Első lépések",
+          "hints": {
+            "device": "Válasszon a rendszerén elérhető hangbemeneti eszközök közül",
+            "multiple": "Több hangkártyát is beállíthat különböző helyszínekhez",
+            "model": "Minden forrás más detekciós modellt használhat (BirdNET, Perch, Bat)"
+          }
+        },
+        "models": {
+          "birdnetDefault": "BirdNET (Alapértelmezett)",
+          "birdnet": "BirdNET",
+          "perchV2": "Google Perch v2",
+          "bat": "Denevérdetektálás"
+        },
+        "errors": {
+          "nameRequired": "A forrás neve kötelező",
+          "deviceRequired": "A hangeszköz kötelező",
+          "duplicateName": "Már létezik ilyen nevű forrás",
+          "duplicateDevice": "Ez az eszköz már konfigurálva van"
+        },
+        "compatibility": {
+          "minSampleRate": "Legalább {rate}kHz mintavételezési frekvencia szükséges",
+          "recommendedSampleRate": "{rate}kHz ajánlott a legjobb eredményekhez",
+          "atLeastOneModel": "Legalább egy modellt ki kell választani"
+        }
+      },
       "noSources": {
         "warning": "Nincs hang forrás konfigurálva",
         "description": "A BirdNET-Go-nak hang bemenetre van szüksége a madarak érzékeléséhez. Kérjük, konfiguráljon legalább egy forrást a Hangszűrő kártya vagy Streamek lapon."

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -2766,6 +2766,51 @@
           "refresh": "Aggiorna Dispositivi"
         }
       },
+      "soundCards": {
+        "summary": "{count} sorgente/i scheda audio",
+        "addSource": "Aggiungi scheda audio",
+        "nameLabel": "Nome sorgente",
+        "namePlaceholder": "es. Microfono giardino anteriore",
+        "nameHelp": "Un nome descrittivo per questa sorgente audio",
+        "deviceLabel": "Dispositivo audio",
+        "devicePlaceholder": "Seleziona un dispositivo audio",
+        "gainLabel": "Guadagno (dB)",
+        "gainHelp": "Regolazione del guadagno dell'ingresso audio (da -40 a +40 dB)",
+        "sampleRateLabel": "Frequenza di campionamento",
+        "sampleRateUnverified": "Le frequenze supportate non possono essere verificate per questo dispositivo",
+        "sampleRateProbing": "Rilevamento frequenze supportate...",
+        "sampleRateExclusive": "Le frequenze superiori a 48 kHz utilizzano l'accesso esclusivo al dispositivo su Linux, impedendo ad altre applicazioni di condividere la scheda audio",
+        "modelLabel": "Modelli di rilevamento",
+        "modelHelp": "Seleziona quali modelli AI eseguire su questa sorgente audio",
+        "deleteConfirm": "Rimuovere questa sorgente scheda audio?",
+        "emptyState": {
+          "title": "Nessuna sorgente scheda audio configurata",
+          "description": "Aggiungi una sorgente scheda audio per iniziare a catturare l'audio per il rilevamento degli uccelli.",
+          "hintsTitle": "Per iniziare",
+          "hints": {
+            "device": "Seleziona tra i dispositivi di ingresso audio disponibili sul tuo sistema",
+            "multiple": "Puoi configurare più schede audio per posizioni diverse",
+            "model": "Ogni sorgente può utilizzare un modello di rilevamento diverso (BirdNET, Perch, Bat)"
+          }
+        },
+        "models": {
+          "birdnetDefault": "BirdNET (Predefinito)",
+          "birdnet": "BirdNET",
+          "perchV2": "Google Perch v2",
+          "bat": "Rilevamento pipistrelli"
+        },
+        "errors": {
+          "nameRequired": "Il nome della sorgente è obbligatorio",
+          "deviceRequired": "Il dispositivo audio è obbligatorio",
+          "duplicateName": "Esiste già una sorgente con questo nome",
+          "duplicateDevice": "Questo dispositivo è già configurato"
+        },
+        "compatibility": {
+          "minSampleRate": "Richiede almeno {rate}kHz di frequenza di campionamento",
+          "recommendedSampleRate": "{rate}kHz consigliato per i migliori risultati",
+          "atLeastOneModel": "È necessario selezionare almeno un modello"
+        }
+      },
       "noSources": {
         "warning": "Nessuna Sorgente Audio Configurata",
         "description": "BirdNET-Go necessita di un input audio per rilevare uccelli. Per favore configura almeno una sorgente nella scheda Scheda Audio o Flussi."

--- a/frontend/static/messages/lv.json
+++ b/frontend/static/messages/lv.json
@@ -2796,6 +2796,51 @@
           "refresh": "Atsvaidzināt ierīces"
         }
       },
+      "soundCards": {
+        "summary": "{count} skaņas kartes avots(-i)",
+        "addSource": "Pievienot skaņas karti",
+        "nameLabel": "Avota nosaukums",
+        "namePlaceholder": "piem., Priekšpagalma mikrofons",
+        "nameHelp": "Aprakstošs nosaukums šim audio avotam",
+        "deviceLabel": "Audio ierīce",
+        "devicePlaceholder": "Izvēlieties audio ierīci",
+        "gainLabel": "Pastiprināšana (dB)",
+        "gainHelp": "Audio ieejas pastiprināšanas regulēšana (no -40 līdz +40 dB)",
+        "sampleRateLabel": "Diskretizācijas frekvence",
+        "sampleRateUnverified": "Atbalstītās frekvences šai ierīcei nevarēja pārbaudīt",
+        "sampleRateProbing": "Atbalstīto frekvenču noteikšana...",
+        "sampleRateExclusive": "Frekvences virs 48 kHz izmanto ekskluzīvu ierīces piekļuvi Linux sistēmā, neļaujot citām lietojumprogrammām koplietot skaņas karti",
+        "modelLabel": "Noteikšanas modeļi",
+        "modelHelp": "Izvēlieties, kurus AI modeļus palaist šajā audio avotā",
+        "deleteConfirm": "Noņemt šo skaņas kartes avotu?",
+        "emptyState": {
+          "title": "Nav konfigurētu skaņas kartes avotu",
+          "description": "Pievienojiet skaņas kartes avotu, lai sāktu audio ierakstīšanu putnu noteikšanai.",
+          "hintsTitle": "Darba sākšana",
+          "hints": {
+            "device": "Izvēlieties no pieejamajām audio ievades ierīcēm jūsu sistēmā",
+            "multiple": "Varat konfigurēt vairākas skaņas kartes dažādām atrašanās vietām",
+            "model": "Katrs avots var izmantot citu noteikšanas modeli (BirdNET, Perch, Bat)"
+          }
+        },
+        "models": {
+          "birdnetDefault": "BirdNET (Noklusējuma)",
+          "birdnet": "BirdNET",
+          "perchV2": "Google Perch v2",
+          "bat": "Sikspārņu noteikšana"
+        },
+        "errors": {
+          "nameRequired": "Avota nosaukums ir obligāts",
+          "deviceRequired": "Audio ierīce ir obligāta",
+          "duplicateName": "Avots ar šādu nosaukumu jau pastāv",
+          "duplicateDevice": "Šī ierīce jau ir konfigurēta"
+        },
+        "compatibility": {
+          "minSampleRate": "Nepieciešama vismaz {rate}kHz ierakstīšanas frekvence",
+          "recommendedSampleRate": "{rate}kHz ieteicams labākajiem rezultātiem",
+          "atLeastOneModel": "Jāizvēlas vismaz viens modelis"
+        }
+      },
       "noSources": {
         "warning": "Nav konfigurētu audio avotu",
         "description": "BirdNET-Go nepieciešama audio ievade, lai noteiktu putnus. Lūdzu, konfigurējiet vismaz vienu avotu cilnē Skaņas karte vai Straumes."

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -2994,6 +2994,7 @@
         "sampleRateLabel": "Samplefrequentie",
         "sampleRateUnverified": "Ondersteunde frequenties konden niet worden geverifieerd voor dit apparaat",
         "sampleRateProbing": "Ondersteunde frequenties worden gedetecteerd...",
+        "sampleRateExclusive": "Samplerates boven 48 kHz gebruiken exclusieve apparaattoegang op Linux, waardoor andere applicaties de geluidskaart niet kunnen delen",
         "modelLabel": "Detectiemodellen",
         "modelHelp": "Selecteer AI-modellen voor deze audiobron",
         "deleteConfirm": "Deze geluidskaartbron verwijderen?",

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -3000,6 +3000,7 @@
         "sampleRateLabel": "Częstotliwość próbkowania",
         "sampleRateUnverified": "Nie można zweryfikować obsługiwanych częstotliwości dla tego urządzenia",
         "sampleRateProbing": "Wykrywanie obsługiwanych częstotliwości...",
+        "sampleRateExclusive": "Częstotliwości powyżej 48 kHz używają wyłącznego dostępu do urządzenia w systemie Linux, uniemożliwiając innym aplikacjom współdzielenie karty dźwiękowej",
         "modelLabel": "Modele detekcji",
         "modelHelp": "Wybierz modele AI dla tego źródła audio",
         "deleteConfirm": "Usunąć to źródło karty dźwiękowej?",

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -2767,6 +2767,7 @@
         "sampleRateLabel": "Taxa de amostragem",
         "sampleRateUnverified": "As taxas suportadas não puderam ser verificadas para este dispositivo",
         "sampleRateProbing": "Detectando taxas suportadas...",
+        "sampleRateExclusive": "Taxas acima de 48 kHz usam acesso exclusivo ao dispositivo no Linux, impedindo que outras aplicações compartilhem a placa de som",
         "modelLabel": "Modelos de deteção",
         "modelHelp": "Selecionar modelos de IA para esta fonte de áudio",
         "deleteConfirm": "Remover esta fonte de placa de som?",

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -2766,6 +2766,51 @@
           "refresh": "Obnoviť zariadenia"
         }
       },
+      "soundCards": {
+        "summary": "{count} zdroj(e/ov) zvukovej karty",
+        "addSource": "Pridať zvukovú kartu",
+        "nameLabel": "Názov zdroja",
+        "namePlaceholder": "napr. Mikrofón v prednej záhrade",
+        "nameHelp": "Popisný názov pre tento zvukový zdroj",
+        "deviceLabel": "Zvukové zariadenie",
+        "devicePlaceholder": "Vyberte zvukové zariadenie",
+        "gainLabel": "Zosilnenie (dB)",
+        "gainHelp": "Úprava zosilnenia zvukového vstupu (-40 až +40 dB)",
+        "sampleRateLabel": "Vzorkovacia frekvencia",
+        "sampleRateUnverified": "Podporované frekvencie nebolo možné overiť pre toto zariadenie",
+        "sampleRateProbing": "Zisťovanie podporovaných frekvencií...",
+        "sampleRateExclusive": "Frekvencie nad 48 kHz používajú výhradný prístup k zariadeniu v Linuxe, čím bránia iným aplikáciám zdieľať zvukovú kartu",
+        "modelLabel": "Detekčné modely",
+        "modelHelp": "Vyberte, ktoré AI modely sa majú spustiť na tomto zvukovom zdroji",
+        "deleteConfirm": "Odstrániť tento zdroj zvukovej karty?",
+        "emptyState": {
+          "title": "Nie sú nakonfigurované žiadne zdroje zvukovej karty",
+          "description": "Pridajte zdroj zvukovej karty pre začatie nahrávania zvuku na detekciu vtákov.",
+          "hintsTitle": "Začíname",
+          "hints": {
+            "device": "Vyberte z dostupných zvukových vstupných zariadení vo vašom systéme",
+            "multiple": "Môžete nakonfigurovať viacero zvukových kariet pre rôzne umiestnenia",
+            "model": "Každý zdroj môže používať iný detekčný model (BirdNET, Perch, Bat)"
+          }
+        },
+        "models": {
+          "birdnetDefault": "BirdNET (Predvolený)",
+          "birdnet": "BirdNET",
+          "perchV2": "Google Perch v2",
+          "bat": "Detekcia netopierov"
+        },
+        "errors": {
+          "nameRequired": "Názov zdroja je povinný",
+          "deviceRequired": "Zvukové zariadenie je povinné",
+          "duplicateName": "Zdroj s týmto názvom už existuje",
+          "duplicateDevice": "Toto zariadenie je už nakonfigurované"
+        },
+        "compatibility": {
+          "minSampleRate": "Vyžaduje minimálne {rate}kHz vzorkovaciu frekvenciu",
+          "recommendedSampleRate": "{rate}kHz odporúčané pre najlepšie výsledky",
+          "atLeastOneModel": "Musí byť vybraný aspoň jeden model"
+        }
+      },
       "noSources": {
         "warning": "Žiadne nakonfigurované zdroje zvuku",
         "description": "BirdNET-Go potrebuje zvukový vstup na detekciu vtákov. Nakonfigurujte aspoň jeden zdroj na karte Zvuková karta alebo Streamy."

--- a/frontend/static/messages/sv.json
+++ b/frontend/static/messages/sv.json
@@ -2796,6 +2796,51 @@
           "refresh": "Uppdatera enheter"
         }
       },
+      "soundCards": {
+        "summary": "{count} ljudkortskälla/-or",
+        "addSource": "Lägg till ljudkort",
+        "nameLabel": "Källnamn",
+        "namePlaceholder": "t.ex. Mikrofon i trädgården",
+        "nameHelp": "Ett beskrivande namn för denna ljudkälla",
+        "deviceLabel": "Ljudenhet",
+        "devicePlaceholder": "Välj en ljudenhet",
+        "gainLabel": "Förstärkning (dB)",
+        "gainHelp": "Justering av ljudingångsförstärkning (-40 till +40 dB)",
+        "sampleRateLabel": "Samplingsfrekvens",
+        "sampleRateUnverified": "Stödda frekvenser kunde inte verifieras för denna enhet",
+        "sampleRateProbing": "Identifierar stödda frekvenser...",
+        "sampleRateExclusive": "Frekvenser över 48 kHz använder exklusiv enhetsåtkomst på Linux, vilket förhindrar andra program från att dela ljudkortet",
+        "modelLabel": "Detektionsmodeller",
+        "modelHelp": "Välj vilka AI-modeller som ska köras på denna ljudkälla",
+        "deleteConfirm": "Ta bort denna ljudkortskälla?",
+        "emptyState": {
+          "title": "Inga ljudkortskällor konfigurerade",
+          "description": "Lägg till en ljudkortskälla för att börja spela in ljud för fågeldetektering.",
+          "hintsTitle": "Kom igång",
+          "hints": {
+            "device": "Välj bland tillgängliga ljudingångsenheter på ditt system",
+            "multiple": "Du kan konfigurera flera ljudkort för olika platser",
+            "model": "Varje källa kan använda en annan detektionsmodell (BirdNET, Perch, Bat)"
+          }
+        },
+        "models": {
+          "birdnetDefault": "BirdNET (Standard)",
+          "birdnet": "BirdNET",
+          "perchV2": "Google Perch v2",
+          "bat": "Fladdermöss-detektering"
+        },
+        "errors": {
+          "nameRequired": "Källnamn krävs",
+          "deviceRequired": "Ljudenhet krävs",
+          "duplicateName": "En källa med detta namn finns redan",
+          "duplicateDevice": "Denna enhet är redan konfigurerad"
+        },
+        "compatibility": {
+          "minSampleRate": "Kräver minst {rate}kHz inspelningsfrekvens",
+          "recommendedSampleRate": "{rate}kHz rekommenderat för bästa resultat",
+          "atLeastOneModel": "Minst en modell måste väljas"
+        }
+      },
       "noSources": {
         "warning": "Inga ljudkällor konfigurerade",
         "description": "BirdNET-Go behöver en ljudingång för att detektera fåglar. Konfigurera minst en källa i fliken Ljudkort eller Strömmar."

--- a/go.mod
+++ b/go.mod
@@ -161,3 +161,5 @@ require (
 )
 
 replace github.com/markbates/goth => github.com/tphakala/goth v0.0.0-20260315123917-08c3db6a364a
+
+replace github.com/gen2brain/malgo => github.com/tphakala/malgo v0.11.25-birdnet.1

--- a/go.sum
+++ b/go.sum
@@ -63,8 +63,6 @@ github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7z
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx59Ho=
 github.com/fsnotify/fsnotify v1.10.1/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=
-github.com/gen2brain/malgo v0.11.24 h1:hHcIJVfzWcEDHFdPl5Dl/CUSOjzOleY0zzAV8Kx+imE=
-github.com/gen2brain/malgo v0.11.24/go.mod h1:f9TtuN7DVrXMiV/yIceMeWpvanyVzJQMlBecJFVMxww=
 github.com/getsentry/sentry-go v0.46.2 h1:1jhYwrKGa3sIpo/y5iDNXS5wDoT7I1KNzMHrnK6ojns=
 github.com/getsentry/sentry-go v0.46.2/go.mod h1:evVbw2qotNUdYG8KxXbAdjOQWWvWIwKxpjdZZIvcIPw=
 github.com/go-audio/audio v1.0.0 h1:zS9vebldgbQqktK4H0lUqWrG8P0NxCJVqcj7ZpNnwd4=
@@ -304,6 +302,8 @@ github.com/tphakala/go-tflite v0.2.2-0.20260403122459-aedbd0bca261 h1:PSr03UW1Nz
 github.com/tphakala/go-tflite v0.2.2-0.20260403122459-aedbd0bca261/go.mod h1:xCgggryHiQ3nD0Sy0oCZESPWmzThLKKB28Vky5m6HCo=
 github.com/tphakala/goth v0.0.0-20260315123917-08c3db6a364a h1:BBvsu7Mes8McH6ikyagnU9y2N8hjoDxvDNCl162hwdA=
 github.com/tphakala/goth v0.0.0-20260315123917-08c3db6a364a/go.mod h1:fht+y3WzLavlVj4eN6u+/lmoQ4lOcsL6blDhBckFLPE=
+github.com/tphakala/malgo v0.11.25-birdnet.1 h1:QwqenAMHWxLPcWDVEfRyqbYHPvMpr0IoNLHFcTG9YO0=
+github.com/tphakala/malgo v0.11.25-birdnet.1/go.mod h1:f9TtuN7DVrXMiV/yIceMeWpvanyVzJQMlBecJFVMxww=
 github.com/tphakala/simd v1.0.22 h1:3wHL91t4yvhCB0ycyTznvucTHax+QGpYkvOhqfraTYw=
 github.com/tphakala/simd v1.0.22/go.mod h1:8xsPUbOTnNI4WUdPlXVlWXt85Y8RCm3xqGAo8PLxYyA=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=

--- a/internal/api/v2/settings_audio.go
+++ b/internal/api/v2/settings_audio.go
@@ -234,7 +234,7 @@ func (c *Controller) handleAudioSettingsChanges(oldSettings, currentSettings *co
 
 	// Check audio device settings
 	if audioDeviceSettingChanged(oldSettings, currentSettings) {
-		c.Debug("Audio device settings changed, triggering reconfiguration")
+		c.logInfoIfEnabled("Audio device settings changed, triggering reconfiguration")
 		reconfigActions = append(reconfigActions, "reconfigure_audio_sources")
 		_ = c.SendToastWithKey("Reconfiguring audio sources...", "info", toastDurationMedium,
 			notification.MsgSettingsReconfiguringAudioSources, nil)

--- a/internal/audiocore/capabilities.go
+++ b/internal/audiocore/capabilities.go
@@ -173,6 +173,12 @@ func probeByInit(malgoCtx *malgo.AllocatedContext, deviceInfo *malgo.DeviceInfo,
 		// Use S32 format for rates above the standard BirdNET rate.
 		if rate > conf.SampleRate {
 			deviceCfg.Capture.Format = malgo.FormatS32
+			if runtime.GOOS == captureOSLinux {
+				deviceCfg.Capture.ShareMode = malgo.Exclusive
+				if nativeCh := nativeCaptureChannels(deviceInfo); nativeCh > 0 {
+					deviceCfg.Capture.Channels = nativeCh
+				}
+			}
 		}
 
 		callbacks := malgo.DeviceCallbacks{}

--- a/internal/audiocore/capabilities.go
+++ b/internal/audiocore/capabilities.go
@@ -183,6 +183,15 @@ func probeByInit(malgoCtx *malgo.AllocatedContext, deviceInfo *malgo.DeviceInfo,
 
 		callbacks := malgo.DeviceCallbacks{}
 		device, err := malgo.InitDevice(malgoCtx.Context, deviceCfg, callbacks)
+		// If exclusive mode init fails, retry with stereo. Many USB audio
+		// devices only support 2-channel capture on the hw: interface;
+		// miniaudio handles the downmix to mono internally.
+		if err != nil && deviceCfg.Capture.ShareMode == malgo.Exclusive && deviceCfg.Capture.Channels != 2 {
+			log.Debug("probe: exclusive mono failed, retrying with stereo",
+				logger.Int("sample_rate", rate))
+			deviceCfg.Capture.Channels = 2
+			device, err = malgo.InitDevice(malgoCtx.Context, deviceCfg, callbacks)
+		}
 		if err != nil {
 			log.Debug("probe: rate not supported",
 				logger.Int("sample_rate", rate),

--- a/internal/audiocore/capabilities.go
+++ b/internal/audiocore/capabilities.go
@@ -46,6 +46,15 @@ type DeviceCapabilities struct {
 	Verified    bool   `json:"verified"`
 }
 
+func cloneCapabilities(c *DeviceCapabilities) *DeviceCapabilities {
+	if c == nil {
+		return nil
+	}
+	cp := *c
+	cp.SampleRates = slices.Clone(c.SampleRates)
+	return &cp
+}
+
 // ProbeAllDeviceCapabilities probes all available capture devices and populates
 // the capabilities cache. Call this at startup before capture begins so that
 // exclusive mode probing can access devices without contention.
@@ -66,7 +75,7 @@ func ProbeAllDeviceCapabilities(log logger.Logger) {
 			continue
 		}
 		capabilitiesCacheMu.Lock()
-		capabilitiesCache[dev.Name] = caps
+		capabilitiesCache[dev.ID] = caps
 		capabilitiesCacheMu.Unlock()
 		log.Info("cached device capabilities",
 			logger.String("device", dev.Name),
@@ -80,7 +89,12 @@ func ProbeAllDeviceCapabilities(log logger.Logger) {
 func GetCachedCapabilities(deviceName string) *DeviceCapabilities {
 	capabilitiesCacheMu.RLock()
 	defer capabilitiesCacheMu.RUnlock()
-	return capabilitiesCache[deviceName]
+	for _, caps := range capabilitiesCache {
+		if caps.DeviceName == deviceName {
+			return cloneCapabilities(caps)
+		}
+	}
+	return nil
 }
 
 // ProbeDeviceCapabilities returns cached capabilities if available, otherwise
@@ -88,13 +102,18 @@ func GetCachedCapabilities(deviceName string) *DeviceCapabilities {
 // the fallback for devices plugged in after startup.
 func ProbeDeviceCapabilities(deviceID string, log logger.Logger) (*DeviceCapabilities, error) {
 	// Check cache first (covers devices probed at startup).
-	// Match by exact ID, exact name, or substring of name (same as matchesDevice).
+	// Direct lookup by ID, then iterate for name/substring match
+	// (same matching logic as matchesDevice in capture.go).
 	capabilitiesCacheMu.RLock()
+	if caps, ok := capabilitiesCache[deviceID]; ok {
+		capabilitiesCacheMu.RUnlock()
+		return cloneCapabilities(caps), nil
+	}
 	for _, caps := range capabilitiesCache {
-		if caps.DeviceID == deviceID || caps.DeviceName == deviceID ||
+		if caps.DeviceName == deviceID ||
 			strings.Contains(caps.DeviceName, deviceID) {
 			capabilitiesCacheMu.RUnlock()
-			return caps, nil
+			return cloneCapabilities(caps), nil
 		}
 	}
 	capabilitiesCacheMu.RUnlock()

--- a/internal/audiocore/capabilities.go
+++ b/internal/audiocore/capabilities.go
@@ -7,11 +7,20 @@ import (
 	"maps"
 	"runtime"
 	"slices"
+	"strings"
+	"sync"
 
 	"github.com/gen2brain/malgo"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/logger"
+)
+
+// capabilitiesCache stores probed device capabilities keyed by device name.
+// Populated at startup before capture begins, read by the API at runtime.
+var (
+	capabilitiesCache   = make(map[string]*DeviceCapabilities)
+	capabilitiesCacheMu sync.RWMutex
 )
 
 // CandidateSampleRates are the rates tested during device probing.
@@ -37,11 +46,67 @@ type DeviceCapabilities struct {
 	Verified    bool   `json:"verified"`
 }
 
-// ProbeDeviceCapabilities queries supported sample rates for a device.
-// Fast path: reads from the device's Formats array (nativeDataFormats).
-// Slow path (ALSA only): probes by attempting InitDevice at each candidate rate.
-// On non-ALSA backends (macOS/Windows), returns unverified candidates if Formats are unavailable.
+// ProbeAllDeviceCapabilities probes all available capture devices and populates
+// the capabilities cache. Call this at startup before capture begins so that
+// exclusive mode probing can access devices without contention.
+func ProbeAllDeviceCapabilities(log logger.Logger) {
+	devices, err := ListCaptureDevices()
+	if err != nil {
+		log.Warn("failed to list devices for capability probing", logger.Error(err))
+		return
+	}
+
+	for _, dev := range devices {
+		caps, err := probeDeviceCapabilitiesLive(dev.ID, log)
+		if err != nil {
+			log.Warn("failed to probe device capabilities",
+				logger.String("device", dev.Name),
+				logger.String("device_id", dev.ID),
+				logger.Error(err))
+			continue
+		}
+		capabilitiesCacheMu.Lock()
+		capabilitiesCache[dev.Name] = caps
+		capabilitiesCacheMu.Unlock()
+		log.Info("cached device capabilities",
+			logger.String("device", dev.Name),
+			logger.Any("sample_rates", caps.SampleRates),
+			logger.Bool("verified", caps.Verified))
+	}
+}
+
+// GetCachedCapabilities returns cached capabilities for a device, or nil if
+// the device was not probed at startup.
+func GetCachedCapabilities(deviceName string) *DeviceCapabilities {
+	capabilitiesCacheMu.RLock()
+	defer capabilitiesCacheMu.RUnlock()
+	return capabilitiesCache[deviceName]
+}
+
+// ProbeDeviceCapabilities returns cached capabilities if available, otherwise
+// probes the device live. The cache is populated at startup; live probing is
+// the fallback for devices plugged in after startup.
 func ProbeDeviceCapabilities(deviceID string, log logger.Logger) (*DeviceCapabilities, error) {
+	// Check cache first (covers devices probed at startup).
+	// Match by exact ID, exact name, or substring of name (same as matchesDevice).
+	capabilitiesCacheMu.RLock()
+	for _, caps := range capabilitiesCache {
+		if caps.DeviceID == deviceID || caps.DeviceName == deviceID ||
+			strings.Contains(caps.DeviceName, deviceID) {
+			capabilitiesCacheMu.RUnlock()
+			return caps, nil
+		}
+	}
+	capabilitiesCacheMu.RUnlock()
+
+	// Cache miss: probe live (device may have been plugged in after startup).
+	return probeDeviceCapabilitiesLive(deviceID, log)
+}
+
+// probeDeviceCapabilitiesLive queries supported sample rates for a device.
+// On Linux, always uses init-probing in exclusive mode to get accurate hardware rates.
+// On other platforms, reads from the device's native Formats array.
+func probeDeviceCapabilitiesLive(deviceID string, log logger.Logger) (*DeviceCapabilities, error) {
 	backend := platformBackend()
 
 	malgoCtx, err := malgo.InitContext([]malgo.Backend{backend}, malgo.ContextConfig{}, nil)
@@ -89,9 +154,12 @@ func ProbeDeviceCapabilities(deviceID string, log logger.Logger) (*DeviceCapabil
 	}
 
 	// Fast path: extract rates from the device's native format list.
+	// On Linux, skip the fast path entirely because ALSA's device info
+	// is queried through dsnoop (shared mode), which constrains the
+	// reported formats to 48kHz regardless of what the hardware supports.
 	rates := extractSampleRates(selectedInfo.Formats)
 
-	if len(rates) > 0 {
+	if len(rates) > 0 && runtime.GOOS != captureOSLinux {
 		log.Debug("device capabilities from native formats",
 			logger.String("device_id", deviceID),
 			logger.String("device_name", deviceName),
@@ -104,7 +172,8 @@ func ProbeDeviceCapabilities(deviceID string, log logger.Logger) (*DeviceCapabil
 		}, nil
 	}
 
-	// Slow path: formats are all zero or empty.
+	// On Linux, always probe by init because the fast path is unreliable.
+	// On other platforms, this is the fallback when formats are all zero.
 	if runtime.GOOS == captureOSLinux {
 		log.Info("probing device by init (ALSA zero-rate formats)",
 			logger.String("device_id", deviceID),

--- a/internal/audiocore/capabilities.go
+++ b/internal/audiocore/capabilities.go
@@ -119,7 +119,13 @@ func ProbeDeviceCapabilities(deviceID string, log logger.Logger) (*DeviceCapabil
 	capabilitiesCacheMu.RUnlock()
 
 	// Cache miss: probe live (device may have been plugged in after startup).
-	return probeDeviceCapabilitiesLive(deviceID, log)
+	caps, err := probeDeviceCapabilitiesLive(deviceID, log)
+	if err == nil && caps != nil {
+		capabilitiesCacheMu.Lock()
+		capabilitiesCache[caps.DeviceID] = caps
+		capabilitiesCacheMu.Unlock()
+	}
+	return caps, err
 }
 
 // probeDeviceCapabilitiesLive queries supported sample rates for a device.

--- a/internal/audiocore/capture.go
+++ b/internal/audiocore/capture.go
@@ -349,16 +349,30 @@ func startCapture(
 		Data: onReceiveFrames,
 	}
 
+	if deviceCfg.Capture.ShareMode == malgo.Exclusive {
+		log.Info("attempting exclusive mode capture",
+			logger.String("source_id", sourceID),
+			logger.String("device", selectedDevInfo.Name),
+			logger.Int("rate", int(deviceCfg.SampleRate)),
+			logger.Int("channels", int(deviceCfg.Capture.Channels)),
+			logger.Int("format", int(deviceCfg.Capture.Format)))
+	}
 	captureDevice, err = malgo.InitDevice(malgoCtx.Context, deviceCfg, callbacks)
 	// If exclusive mode init fails, retry with stereo before falling back
 	// to default rate. Many USB devices only support 2-channel capture on
 	// the hw: interface; miniaudio handles the downmix to mono internally.
-	if err != nil && deviceCfg.Capture.ShareMode == malgo.Exclusive && deviceCfg.Capture.Channels != 2 {
-		log.Debug("exclusive mono init failed, retrying with stereo",
+	if err != nil && deviceCfg.Capture.ShareMode == malgo.Exclusive {
+		log.Warn("exclusive mode init failed",
 			logger.String("source_id", sourceID),
-			logger.String("device", selectedDevInfo.Name))
-		deviceCfg.Capture.Channels = 2
-		captureDevice, err = malgo.InitDevice(malgoCtx.Context, deviceCfg, callbacks)
+			logger.String("device", selectedDevInfo.Name),
+			logger.Int("channels", int(deviceCfg.Capture.Channels)),
+			logger.Error(err))
+		if deviceCfg.Capture.Channels != 2 {
+			log.Debug("retrying exclusive mode with stereo",
+				logger.String("source_id", sourceID))
+			deviceCfg.Capture.Channels = 2
+			captureDevice, err = malgo.InitDevice(malgoCtx.Context, deviceCfg, callbacks)
+		}
 	}
 	if err != nil && cfg.SampleRate > conf.SampleRate {
 		log.Warn("capture init failed at configured rate, falling back to default",

--- a/internal/audiocore/capture.go
+++ b/internal/audiocore/capture.go
@@ -401,8 +401,13 @@ func startCapture(
 			Build()
 	}
 
-	// Capture the actual format reported by the device after init.
+	// Capture the actual format and channel count reported by the device
+	// after init. The channel count may differ from cfg.Channels if the
+	// stereo retry path was taken for exclusive mode.
 	formatType = captureDevice.CaptureFormat()
+	if actualCh := int(captureDevice.CaptureChannels()); actualCh != cfg.Channels {
+		cfg.Channels = actualCh
+	}
 
 	if err = captureDevice.Start(); err != nil {
 		captureDevice.Uninit()

--- a/internal/audiocore/capture.go
+++ b/internal/audiocore/capture.go
@@ -110,8 +110,11 @@ func listDevices(log logger.Logger) ([]DeviceInfo, error) {
 
 	for i := range infos {
 		name := infos[i].Name()
-		if name == "" || strings.Contains(name, "Discard all samples") {
+		if strings.Contains(name, "Discard all samples") {
 			continue
+		}
+		if name == "" {
+			name = "Default Audio Device"
 		}
 
 		decodedID, err := hexToASCII(infos[i].ID.String())

--- a/internal/audiocore/capture.go
+++ b/internal/audiocore/capture.go
@@ -368,7 +368,7 @@ func startCapture(
 			logger.Int("channels", int(deviceCfg.Capture.Channels)),
 			logger.Error(err))
 		if deviceCfg.Capture.Channels != 2 {
-			log.Debug("retrying exclusive mode with stereo",
+			log.Info("retrying exclusive mode with stereo",
 				logger.String("source_id", sourceID))
 			deviceCfg.Capture.Channels = 2
 			captureDevice, err = malgo.InitDevice(malgoCtx.Context, deviceCfg, callbacks)

--- a/internal/audiocore/capture.go
+++ b/internal/audiocore/capture.go
@@ -110,7 +110,7 @@ func listDevices(log logger.Logger) ([]DeviceInfo, error) {
 
 	for i := range infos {
 		name := infos[i].Name()
-		if strings.Contains(name, "Discard all samples") {
+		if name == "" || strings.Contains(name, "Discard all samples") {
 			continue
 		}
 
@@ -347,6 +347,16 @@ func startCapture(
 	}
 
 	captureDevice, err = malgo.InitDevice(malgoCtx.Context, deviceCfg, callbacks)
+	// If exclusive mode init fails, retry with stereo before falling back
+	// to default rate. Many USB devices only support 2-channel capture on
+	// the hw: interface; miniaudio handles the downmix to mono internally.
+	if err != nil && deviceCfg.Capture.ShareMode == malgo.Exclusive && deviceCfg.Capture.Channels != 2 {
+		log.Debug("exclusive mono init failed, retrying with stereo",
+			logger.String("source_id", sourceID),
+			logger.String("device", selectedDevInfo.Name))
+		deviceCfg.Capture.Channels = 2
+		captureDevice, err = malgo.InitDevice(malgoCtx.Context, deviceCfg, callbacks)
+	}
 	if err != nil && cfg.SampleRate > conf.SampleRate {
 		log.Warn("capture init failed at configured rate, falling back to default",
 			logger.String("source_id", sourceID),

--- a/internal/audiocore/capture.go
+++ b/internal/audiocore/capture.go
@@ -56,6 +56,17 @@ func platformBackend() malgo.Backend {
 	}
 }
 
+// nativeCaptureChannels returns the channel count from the device's first
+// reported native capture format, or 0 if none are available.
+func nativeCaptureChannels(info *malgo.DeviceInfo) uint32 {
+	for _, f := range info.Formats {
+		if f.Channels > 0 {
+			return f.Channels
+		}
+	}
+	return 0
+}
+
 // hexToASCII converts a hexadecimal string (as returned by malgo's
 // DeviceID.String()) to its ASCII representation.
 func hexToASCII(hexStr string) (string, error) {
@@ -250,6 +261,16 @@ func startCapture(
 	deviceCfg.Capture.DeviceID = devIDPtr
 	if cfg.SampleRate > conf.SampleRate {
 		deviceCfg.Capture.Format = malgo.FormatS32
+		if runtime.GOOS == captureOSLinux {
+			deviceCfg.Capture.ShareMode = malgo.Exclusive
+			// In exclusive mode (hw: direct access), the device may reject
+			// channel counts it doesn't natively support. Use the device's
+			// native channel count so InitDevice succeeds; miniaudio's
+			// internal data converter handles any needed downmix.
+			if nativeCh := nativeCaptureChannels(selectedInfo); nativeCh > 0 {
+				deviceCfg.Capture.Channels = nativeCh
+			}
+		}
 	}
 
 	var captureDevice *malgo.Device
@@ -334,6 +355,8 @@ func startCapture(
 			logger.Int("fallback_rate", conf.SampleRate))
 		deviceCfg.SampleRate = uint32(conf.SampleRate)
 		deviceCfg.Capture.Format = malgo.FormatS16
+		deviceCfg.Capture.ShareMode = malgo.Shared
+		deviceCfg.Capture.Channels = uint32(cfg.Channels)
 		captureDevice, err = malgo.InitDevice(malgoCtx.Context, deviceCfg, callbacks)
 		if err == nil {
 			cfg.SampleRate = conf.SampleRate
@@ -367,13 +390,21 @@ func startCapture(
 			Build()
 	}
 
+	internalRate := captureDevice.CaptureInternalSampleRate()
 	log.Info("malgo capture device started",
 		logger.String("source_id", sourceID),
 		logger.String("device", selectedDevInfo.Name),
 		logger.Int("requested_rate", cfg.SampleRate),
-		logger.Int("actual_rate", int(captureDevice.SampleRate())),
+		logger.Int("hw_rate", int(internalRate)),
 		logger.Int("channels", int(captureDevice.CaptureChannels())),
 		logger.Int("format", int(formatType)))
+	if internalRate > 0 && internalRate != uint32(cfg.SampleRate) {
+		log.Warn("ALSA hardware rate differs from requested rate, audio may be software-resampled",
+			logger.String("source_id", sourceID),
+			logger.String("device", selectedDevInfo.Name),
+			logger.Int("requested_rate", cfg.SampleRate),
+			logger.Int("hw_rate", int(internalRate)))
+	}
 
 	// done is closed when the capture goroutine exits, allowing callers to
 	// wait for graceful device teardown.

--- a/internal/audiocore/engine/engine.go
+++ b/internal/audiocore/engine/engine.go
@@ -176,6 +176,11 @@ func New(ctx context.Context, cfg *Config, scheduler *schedule.QuietHoursSchedul
 	}, nil, log, bufMgr)
 	deviceMgr := audiocore.NewDeviceManager(router, bufMgr, log)
 
+	// Probe all device capabilities at startup, before any capture begins.
+	// Exclusive mode probing requires sole device access, so it must happen
+	// before sources are added and capture starts.
+	audiocore.ProbeAllDeviceCapabilities(log)
+
 	e := &AudioEngine{
 		registry:             audiocore.NewSourceRegistry(log),
 		router:               router,

--- a/internal/audiocore/engine/engine.go
+++ b/internal/audiocore/engine/engine.go
@@ -423,6 +423,11 @@ func (e *AudioEngine) ReconfigureSource(sourceID string, newCfg *audiocore.Sourc
 		return fmt.Errorf("reconfigure source: %w: %s", audiocore.ErrSourceNotFound, sourceID)
 	}
 
+	e.logger.Info("reconfiguring audio source",
+		logger.String("source_id", sourceID),
+		logger.String("device", newCfg.ConnectionString),
+		logger.Int("sample_rate", newCfg.SampleRate))
+
 	// 1. Stop existing capture.
 	if isStreamType(src.Type) {
 		_ = e.ffmpegMgr.StopStream(sourceID)

--- a/internal/audiocore/engine/engine.go
+++ b/internal/audiocore/engine/engine.go
@@ -426,7 +426,9 @@ func (e *AudioEngine) ReconfigureSource(sourceID string, newCfg *audiocore.Sourc
 	e.logger.Info("reconfiguring audio source",
 		logger.String("source_id", sourceID),
 		logger.String("device", newCfg.ConnectionString),
-		logger.Int("sample_rate", newCfg.SampleRate))
+		logger.Int("sample_rate", newCfg.SampleRate),
+		logger.Int("bit_depth", newCfg.BitDepth),
+		logger.Int("channels", newCfg.Channels))
 
 	// 1. Stop existing capture.
 	if isStreamType(src.Type) {


### PR DESCRIPTION
## Summary

- Switch to ALSA exclusive mode (hw: direct access) on Linux when sample rate exceeds 48 kHz, bypassing dsnoop's silent software resampling
- Use tphakala/malgo fork (v0.11.25-birdnet.1) exposing CaptureInternalSampleRate() for hardware rate mismatch detection
- Probe all device capabilities at engine startup before capture begins, caching results so the API can serve them while devices are in active use
- Show an informational warning in the sound card settings UI when rate > 48 kHz, with proper translations in all 14 languages
- Add stereo retry fallback: if exclusive mode init fails with mono, retry with 2 channels since many USB devices only support stereo on hw: interface

## Verified

- Zoom AMS-24 on ubuntu.koti: 48 kHz shared mode (hw_rate=48000), 96 kHz exclusive mode (hw_rate=96000, Momentary freq=96000 Hz)
- Zoom AMS-24 on Pi4b: startup probing caches [48000, 96000, 192000, 256000, 384000], exclusive mode capture at 96 kHz succeeds
- Fallback to 48 kHz shared mode works when exclusive mode init fails
- All 713 audiocore tests pass with race detector
- golangci-lint clean, frontend check:all passes

## Known limitations

- Rates above device's hardware max (e.g., 192/256/384 kHz on AMS-24 which maxes at 96 kHz) show as supported in probing because exclusive mode init succeeds but ALSA may still software-resample (tracked in Forgejo #566)
- Audio device reconfigure via UI hot-reload not triggering properly (filed as Forgejo #573, not a regression from this PR)

## Test plan

- [ ] Verify 48 kHz capture uses shared mode (no exclusive mode log)
- [ ] Verify >48 kHz capture uses exclusive mode with matching hw_rate
- [ ] Verify fallback to 48 kHz shared when exclusive mode fails
- [ ] Verify capabilities API returns cached rates while device is capturing
- [ ] Verify UI shows exclusive mode warning when rate > 48 kHz
- [ ] Verify i18n translations render correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Informational warning when selecting sample rates above 48 kHz (Linux exclusive-device access)
  * Info icons and inline messages added to sound card configuration forms

* **Improvements**
  * Startup caching for faster, more reliable audio device capability detection
  * More robust exclusive-mode initialization and recovery on Linux (including channel-fallback)
  * Fallback for empty device names and clearer requested vs. hardware sample-rate logging
  * Updated translations for sound card settings across many languages

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3001)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->