### PR TITLE
fix(audiocore): route audio reconfigure events to audio.log and detect parameter changes

### DIFF
--- a/internal/analysis/audio_pipeline_service.go
+++ b/internal/analysis/audio_pipeline_service.go
@@ -908,7 +908,7 @@ func (p *AudioPipelineService) reconfigureChangedSources(audioLevelChan chan aud
 	}
 
 	// Rebuild routes for sources whose gain changed. The capture device
-	// stays running — only the routes are torn down and re-created so
+	// stays running; only the routes are torn down and re-created so
 	// drainRoute picks up the new gainLinear value.
 	if len(gainChangedIDs) > 0 {
 		for _, sid := range gainChangedIDs {
@@ -936,7 +936,7 @@ func (p *AudioPipelineService) reconfigureChangedSources(audioLevelChan chan aud
 		}
 	}
 
-	log.Info("stream reconfiguration complete",
+	log.Info("audio source reconfiguration complete",
 		logger.Int("kept", keptCount),
 		logger.Int("added", len(newSourceIDs)),
 		logger.Int("removed", removedCount),

--- a/internal/analysis/audio_pipeline_service.go
+++ b/internal/analysis/audio_pipeline_service.go
@@ -793,7 +793,7 @@ func sourceNeedsReconfigure(running *audiocore.AudioSource, desired *audiocore.S
 // changed are touched - unchanged streams keep their capture buffers and
 // source IDs intact.
 func (p *AudioPipelineService) reconfigureChangedSources(audioLevelChan chan audiocore.AudioLevelData) {
-	log := GetAudiocoreLogger()
+	log := audiocore.GetLogger()
 
 	// Build desired config keyed by connection string, including model IDs.
 	desiredConfigs := p.buildSourceConfigsWithModels()
@@ -820,19 +820,10 @@ func (p *AudioPipelineService) reconfigureChangedSources(audioLevelChan chan aud
 			sourceModelMap[src.ID] = scm.modelIDs
 			keptCount++
 
-			// Detect gain-only changes on kept sources.
-			if src.Gain != scm.config.Gain {
-				log.Info("gain changed for kept source, rebuilding routes",
-					logger.String("source_id", src.ID),
-					logger.Float64("old_gain_db", src.Gain),
-					logger.Float64("new_gain_db", scm.config.Gain),
-					logger.String("operation", "reconfigure_diff"))
-				registry.UpdateGain(src.ID, scm.config.Gain)
-				gainChangedIDs = append(gainChangedIDs, src.ID)
-			}
-
 			// Detect audio parameter changes (sample rate, bit depth, channels)
-			// that require a full source reconfigure (stop + buffer realloc + restart).
+			// that require a full source reconfigure (stop + route removal +
+			// buffer realloc + restart). ReconfigureSource handles everything,
+			// so skip the gain-only route rebuild for this source.
 			if sourceNeedsReconfigure(src, scm.config) {
 				log.Info("audio parameters changed, reconfiguring source",
 					logger.String("source_id", src.ID),
@@ -841,12 +832,24 @@ func (p *AudioPipelineService) reconfigureChangedSources(audioLevelChan chan aud
 					logger.Int("old_bit_depth", src.BitDepth),
 					logger.Int("new_bit_depth", scm.config.BitDepth),
 					logger.String("operation", "reconfigure_diff"))
+				if src.Gain != scm.config.Gain {
+					registry.UpdateGain(src.ID, scm.config.Gain)
+				}
 				if err := p.engine.ReconfigureSource(src.ID, scm.config); err != nil {
 					log.Error("failed to reconfigure source",
 						logger.String("source_id", src.ID),
 						logger.Error(err),
 						logger.String("operation", "reconfigure_diff"))
 				}
+			} else if src.Gain != scm.config.Gain {
+				// Gain-only change: update registry and rebuild routes (no restart needed).
+				log.Info("gain changed for kept source, rebuilding routes",
+					logger.String("source_id", src.ID),
+					logger.Float64("old_gain_db", src.Gain),
+					logger.Float64("new_gain_db", scm.config.Gain),
+					logger.String("operation", "reconfigure_diff"))
+				registry.UpdateGain(src.ID, scm.config.Gain)
+				gainChangedIDs = append(gainChangedIDs, src.ID)
 			}
 
 			// Sync display name if the config name changed (e.g., stream renamed in UI).

--- a/internal/analysis/audio_pipeline_service.go
+++ b/internal/analysis/audio_pipeline_service.go
@@ -785,7 +785,7 @@ func (p *AudioPipelineService) registerConsumersForSources(sourceIDs []string, s
 // changed are touched — unchanged streams keep their capture buffers and
 // source IDs intact.
 func (p *AudioPipelineService) reconfigureChangedSources(audioLevelChan chan audiocore.AudioLevelData) {
-	log := GetLogger()
+	log := GetAudiocoreLogger()
 
 	// Build desired config keyed by connection string, including model IDs.
 	desiredConfigs := p.buildSourceConfigsWithModels()

--- a/internal/analysis/audio_pipeline_service.go
+++ b/internal/analysis/audio_pipeline_service.go
@@ -780,9 +780,17 @@ func (p *AudioPipelineService) registerConsumersForSources(sourceIDs []string, s
 	}
 }
 
+// sourceNeedsReconfigure reports whether the running source's audio parameters
+// differ from the desired config, requiring a full reconfigure (stop + restart).
+func sourceNeedsReconfigure(running *audiocore.AudioSource, desired *audiocore.SourceConfig) bool {
+	return running.SampleRate != desired.SampleRate ||
+		running.BitDepth != desired.BitDepth ||
+		running.Channels != desired.Channels
+}
+
 // reconfigureChangedSources diffs the currently running sources against the
 // desired config from settings. Only sources that were added, removed, or
-// changed are touched — unchanged streams keep their capture buffers and
+// changed are touched - unchanged streams keep their capture buffers and
 // source IDs intact.
 func (p *AudioPipelineService) reconfigureChangedSources(audioLevelChan chan audiocore.AudioLevelData) {
 	log := GetAudiocoreLogger()
@@ -799,7 +807,7 @@ func (p *AudioPipelineService) reconfigureChangedSources(audioLevelChan chan aud
 	// security, so we look up sources via GetByConnection on the desired
 	// connection strings instead.
 	registry := p.engine.Registry()
-	alreadyRunning := make(map[string]string) // connStr → sourceID (for sources that stay)
+	alreadyRunning := make(map[string]string) // connStr -> sourceID (for sources that stay)
 	sourceModelMap := make(map[string][]string)
 	var newSourceIDs []string
 	var gainChangedIDs []string
@@ -807,7 +815,7 @@ func (p *AudioPipelineService) reconfigureChangedSources(audioLevelChan chan aud
 
 	for connStr, scm := range desired {
 		if src, found := registry.GetByConnection(connStr); found {
-			// Source already running — keep it.
+			// Source already running - keep it.
 			alreadyRunning[connStr] = src.ID
 			sourceModelMap[src.ID] = scm.modelIDs
 			keptCount++
@@ -823,12 +831,30 @@ func (p *AudioPipelineService) reconfigureChangedSources(audioLevelChan chan aud
 				gainChangedIDs = append(gainChangedIDs, src.ID)
 			}
 
+			// Detect audio parameter changes (sample rate, bit depth, channels)
+			// that require a full source reconfigure (stop + buffer realloc + restart).
+			if sourceNeedsReconfigure(src, scm.config) {
+				log.Info("audio parameters changed, reconfiguring source",
+					logger.String("source_id", src.ID),
+					logger.Int("old_sample_rate", src.SampleRate),
+					logger.Int("new_sample_rate", scm.config.SampleRate),
+					logger.Int("old_bit_depth", src.BitDepth),
+					logger.Int("new_bit_depth", scm.config.BitDepth),
+					logger.String("operation", "reconfigure_diff"))
+				if err := p.engine.ReconfigureSource(src.ID, scm.config); err != nil {
+					log.Error("failed to reconfigure source",
+						logger.String("source_id", src.ID),
+						logger.Error(err),
+						logger.String("operation", "reconfigure_diff"))
+				}
+			}
+
 			// Sync display name if the config name changed (e.g., stream renamed in UI).
 			if src.DisplayName != scm.config.DisplayName {
 				registry.UpdateDisplayName(src.ID, scm.config.DisplayName)
 			}
 		} else {
-			// New source — add it.
+			// New source - add it.
 			log.Info("adding new stream from config",
 				logger.String("connection", privacy.SanitizeStreamUrl(connStr)),
 				logger.String("operation", "reconfigure_diff"))

--- a/internal/analysis/audio_pipeline_service.go
+++ b/internal/analysis/audio_pipeline_service.go
@@ -173,7 +173,7 @@ func (p *AudioPipelineService) Start(_ context.Context) error {
 	// ranges over birdnet.ResultsQueue, and ResizeQueue closes the old channel
 	// and creates a new one. The processor's range loop exits on the closed
 	// channel, killing the detection pipeline. The default queue size of 100 is
-	// fine — shrinking to 5 added unnecessary backpressure with no benefit.
+	// fine; shrinking to 5 added unnecessary backpressure with no benefit.
 
 	// Initialize the buffer manager using the engine's buffer manager.
 	quitChan := p.done // buffer manager uses this to know when to stop
@@ -214,7 +214,7 @@ func (p *AudioPipelineService) Start(_ context.Context) error {
 	})
 
 	// Initialize quiet hours scheduler for stream and sound card management.
-	// Uses audiocore/schedule — scheduler is independent of the audio capture pipeline.
+	// Uses audiocore/schedule: scheduler is independent of the audio capture pipeline.
 	p.quietHoursScheduler = schedule.NewQuietHoursScheduler(schedule.QuietHoursConfig{
 		SunCalc:     p.apiService.SunCalc(),
 		ControlChan: p.apiService.ControlChan(),
@@ -237,7 +237,7 @@ func (p *AudioPipelineService) Start(_ context.Context) error {
 	}
 
 	// Start clip cleanup monitor.
-	// Uses conf.Setting() instead of local settings for hot-reload support —
+	// Uses conf.Setting() instead of local settings for hot-reload support:
 	// retention policy can be changed at runtime via the web UI.
 	if conf.Setting().Realtime.Audio.Export.Retention.Policy != policyNone {
 		p.wg.Go(func() {
@@ -392,7 +392,7 @@ func (p *AudioPipelineService) removeAllSources(operation string) {
 func (p *AudioPipelineService) setupAudioSources(audioLevelChan chan audiocore.AudioLevelData, operation string) []string {
 	log := GetLogger()
 
-	// Add audio sources via engine — this registers sources, allocates buffers,
+	// Add audio sources via engine: this registers sources, allocates buffers,
 	// and starts capture (FFmpeg streams or device capture).
 	sourceConfigs := p.buildSourceConfigsWithModels()
 	sourceModelMap := make(map[string][]string, len(sourceConfigs))
@@ -927,7 +927,7 @@ func (p *AudioPipelineService) reconfigureChangedSources(audioLevelChan chan aud
 	// receives the full desired state and removes stale monitors correctly.
 	allActiveIDs := slices.Collect(maps.Values(alreadyRunning))
 	allActiveIDs = append(allActiveIDs, newSourceIDs...)
-	// Always call UpdateMonitors — even with an empty slice — so stale
+	// Always call UpdateMonitors (even with an empty slice) so stale
 	// monitors are torn down when the last active stream is disabled.
 	if p.bufferMgr != nil {
 		monitorMap := p.buildMonitorConfigs(sourceModelMap, allActiveIDs)

--- a/internal/analysis/audio_pipeline_service.go
+++ b/internal/analysis/audio_pipeline_service.go
@@ -192,7 +192,7 @@ func (p *AudioPipelineService) Start(_ context.Context) error {
 	sourceIDs := p.setupAudioSources(apiAudioLevelChan, "start")
 
 	if len(sourceIDs) == 0 {
-		GetLogger().Warn("starting without active audio sources",
+		audiocore.GetLogger().Warn("starting without active audio sources",
 			logger.Int("rtsp_streams", len(settings.Realtime.RTSP.Streams)),
 			logger.Int("audio_sources", len(settings.Realtime.Audio.Sources)),
 			logger.String("operation", "startup_audio_check"))
@@ -202,12 +202,12 @@ func (p *AudioPipelineService) Start(_ context.Context) error {
 	// when the watchdog force-resets a stuck stream.
 	p.engine.FFmpegManager().SetOnStreamReset(func(newSourceID string) {
 		if err := p.bufferMgr.AddMonitor(newSourceID); err != nil {
-			GetLogger().Warn("failed to add monitor after watchdog stream reset",
+			audiocore.GetLogger().Warn("failed to add monitor after watchdog stream reset",
 				logger.String("source_id", newSourceID),
 				logger.Error(err),
 				logger.String("operation", "watchdog_add_monitor"))
 		} else {
-			GetLogger().Info("started analysis monitor after watchdog stream reset",
+			audiocore.GetLogger().Info("started analysis monitor after watchdog stream reset",
 				logger.String("source_id", newSourceID),
 				logger.String("operation", "watchdog_add_monitor"))
 		}
@@ -231,7 +231,7 @@ func (p *AudioPipelineService) Start(_ context.Context) error {
 
 	// RTSP health monitoring is built into the FFmpeg manager.
 	if len(settings.Realtime.RTSP.Streams) > 0 {
-		GetLogger().Info("RTSP streams will be monitored by FFmpeg manager",
+		audiocore.GetLogger().Info("RTSP streams will be monitored by FFmpeg manager",
 			logger.Int("stream_count", len(settings.Realtime.RTSP.Streams)),
 			logger.String("operation", "rtsp_monitoring_setup"))
 	}
@@ -355,7 +355,7 @@ func (p *AudioPipelineService) Stop(ctx context.Context) error {
 // restartAudioCapture restarts the audio capture by removing and re-adding
 // all sources via the AudioEngine.
 func (p *AudioPipelineService) restartAudioCapture() {
-	GetLogger().Info("restarting audio capture",
+	audiocore.GetLogger().Info("restarting audio capture",
 		logger.String("operation", "restart_audio_capture"))
 
 	// Remove all existing sources.
@@ -371,7 +371,7 @@ func (p *AudioPipelineService) restartAudioCapture() {
 func (p *AudioPipelineService) removeAllSources(operation string) {
 	for _, src := range p.engine.Registry().List() {
 		if err := p.engine.RemoveSource(src.ID); err != nil {
-			GetLogger().Warn("failed to remove source",
+			audiocore.GetLogger().Warn("failed to remove source",
 				logger.String("source_id", src.ID),
 				logger.Error(err),
 				logger.String("operation", operation))
@@ -390,7 +390,7 @@ func (p *AudioPipelineService) removeAllSources(operation string) {
 // The audioLevelChan receives bridged audio level data for the API SSE endpoint.
 // The operation parameter is used in log messages to distinguish callers.
 func (p *AudioPipelineService) setupAudioSources(audioLevelChan chan audiocore.AudioLevelData, operation string) []string {
-	log := GetLogger()
+	log := audiocore.GetLogger()
 
 	// Add audio sources via engine: this registers sources, allocates buffers,
 	// and starts capture (FFmpeg streams or device capture).
@@ -445,7 +445,7 @@ func (p *AudioPipelineService) setupAudioSources(audioLevelChan chan audiocore.A
 // is also idempotent: sources that already have a tracked consumer are skipped,
 // so the caller may include previously registered source IDs.
 func (p *AudioPipelineService) registerSoundLevelConsumers(sourceIDs []string, operation string) {
-	log := GetLogger()
+	log := audiocore.GetLogger()
 	settings := conf.Setting()
 	if !settings.Realtime.Audio.SoundLevel.Enabled {
 		return
@@ -630,7 +630,7 @@ func (p *AudioPipelineService) removeAllSoundLevelConsumers(operation string) {
 	p.soundLevelConsumers = make(map[string]string)
 	p.soundLevelMu.Unlock()
 
-	log := GetLogger()
+	log := audiocore.GetLogger()
 	router := p.engine.Router()
 	for sid, cid := range toRemove {
 		router.RemoveRoute(sid, cid)
@@ -647,7 +647,7 @@ func (p *AudioPipelineService) removeAllSoundLevelConsumers(operation string) {
 // only the models assigned to that source. When a source has no configured
 // models (empty slice), the primary model is used as a fallback.
 func (p *AudioPipelineService) registerConsumersForSources(sourceIDs []string, sourceModelMap map[string][]string, audioLevelChan chan audiocore.AudioLevelData, operation string) {
-	log := GetLogger()
+	log := audiocore.GetLogger()
 
 	// Build a lookup of all loaded model infos keyed by registry ID.
 	modelInfoSlice := p.bnAnalyzer.BirdNET().ModelInfos()

--- a/internal/analysis/audio_pipeline_service.go
+++ b/internal/analysis/audio_pipeline_service.go
@@ -811,6 +811,7 @@ func (p *AudioPipelineService) reconfigureChangedSources(audioLevelChan chan aud
 	sourceModelMap := make(map[string][]string)
 	var newSourceIDs []string
 	var gainChangedIDs []string
+	var reconfiguredIDs []string
 	var keptCount int
 
 	for connStr, scm := range desired {
@@ -835,11 +836,17 @@ func (p *AudioPipelineService) reconfigureChangedSources(audioLevelChan chan aud
 				if src.Gain != scm.config.Gain {
 					registry.UpdateGain(src.ID, scm.config.Gain)
 				}
+				// ReconfigureSource removes all routes; clear the sound level
+				// tracking entry so re-registration is not blocked by the
+				// idempotency check.
+				p.untrackSoundLevelConsumer(src.ID)
 				if err := p.engine.ReconfigureSource(src.ID, scm.config); err != nil {
 					log.Error("failed to reconfigure source",
 						logger.String("source_id", src.ID),
 						logger.Error(err),
 						logger.String("operation", "reconfigure_diff"))
+				} else {
+					reconfiguredIDs = append(reconfiguredIDs, src.ID)
 				}
 			} else if src.Gain != scm.config.Gain {
 				// Gain-only change: update registry and rebuild routes (no restart needed).
@@ -908,6 +915,13 @@ func (p *AudioPipelineService) reconfigureChangedSources(audioLevelChan chan aud
 	if len(newSourceIDs) > 0 {
 		p.registerConsumersForSources(newSourceIDs, sourceModelMap, audioLevelChan, "reconfigure_diff")
 		p.registerSoundLevelConsumers(newSourceIDs, "reconfigure_diff")
+	}
+
+	// Rebuild routes for sources whose audio params changed. ReconfigureSource
+	// removed all routes and reallocated buffers; consumers must be re-created.
+	if len(reconfiguredIDs) > 0 {
+		p.registerConsumersForSources(reconfiguredIDs, sourceModelMap, audioLevelChan, "reconfigure_params")
+		p.registerSoundLevelConsumers(reconfiguredIDs, "reconfigure_params")
 	}
 
 	// Rebuild routes for sources whose gain changed. The capture device

--- a/internal/analysis/control_monitor.go
+++ b/internal/analysis/control_monitor.go
@@ -371,7 +371,7 @@ func (cm *ControlMonitor) handleReconfigureMQTT() {
 // It delegates to the reconfigureSourcesFn callback provided by AudioPipelineService
 // to avoid duplicating source setup logic.
 func (cm *ControlMonitor) handleReconfigureStreams() {
-	GetLogger().Info("Reconfiguring audio streams")
+	GetAudiocoreLogger().Info("Reconfiguring audio streams")
 
 	cm.reconfigureSourcesFn()
 
@@ -381,7 +381,7 @@ func (cm *ControlMonitor) handleReconfigureStreams() {
 		cm.quietHoursScheduler.Evaluate()
 	}
 
-	GetLogger().Info("Audio streams reconfigured successfully")
+	GetAudiocoreLogger().Info("Audio streams reconfigured successfully")
 	cm.notifySuccess("Audio capture reconfigured successfully")
 }
 
@@ -745,7 +745,7 @@ func (cm *ControlMonitor) handleRebuildExtendedCapture() {
 // when their settings (device, gain, model) change. It delegates to the same
 // diff-based reconfiguration used for RTSP stream changes.
 func (cm *ControlMonitor) handleReconfigureAudioSources() {
-	GetLogger().Info("Reconfiguring audio sources")
+	GetAudiocoreLogger().Info("Reconfiguring audio sources")
 
 	defer func() {
 		if r := recover(); r != nil {
@@ -755,7 +755,7 @@ func (cm *ControlMonitor) handleReconfigureAudioSources() {
 			} else {
 				err = fmt.Errorf("panic during audio source reconfiguration: %v", r)
 			}
-			GetLogger().Error(err.Error(),
+			GetAudiocoreLogger().Error(err.Error(),
 				logger.String("stack", string(debug.Stack())))
 		}
 	}()
@@ -768,7 +768,7 @@ func (cm *ControlMonitor) handleReconfigureAudioSources() {
 		cm.quietHoursScheduler.Evaluate()
 	}
 
-	GetLogger().Info("Audio sources reconfigured successfully")
+	GetAudiocoreLogger().Info("Audio sources reconfigured successfully")
 	cm.notifySuccess("Audio sources reconfigured successfully")
 }
 

--- a/internal/analysis/control_monitor.go
+++ b/internal/analysis/control_monitor.go
@@ -371,7 +371,7 @@ func (cm *ControlMonitor) handleReconfigureMQTT() {
 // It delegates to the reconfigureSourcesFn callback provided by AudioPipelineService
 // to avoid duplicating source setup logic.
 func (cm *ControlMonitor) handleReconfigureStreams() {
-	GetAudiocoreLogger().Info("Reconfiguring audio streams")
+	audiocore.GetLogger().Info("Reconfiguring audio streams")
 
 	cm.reconfigureSourcesFn()
 
@@ -381,7 +381,7 @@ func (cm *ControlMonitor) handleReconfigureStreams() {
 		cm.quietHoursScheduler.Evaluate()
 	}
 
-	GetAudiocoreLogger().Info("Audio streams reconfigured successfully")
+	audiocore.GetLogger().Info("Audio streams reconfigured successfully")
 	cm.notifySuccess("Audio capture reconfigured successfully")
 }
 
@@ -745,7 +745,7 @@ func (cm *ControlMonitor) handleRebuildExtendedCapture() {
 // when their settings (device, gain, model) change. It delegates to the same
 // diff-based reconfiguration used for RTSP stream changes.
 func (cm *ControlMonitor) handleReconfigureAudioSources() {
-	GetAudiocoreLogger().Info("Reconfiguring audio sources")
+	audiocore.GetLogger().Info("Reconfiguring audio sources")
 
 	defer func() {
 		if r := recover(); r != nil {
@@ -755,7 +755,7 @@ func (cm *ControlMonitor) handleReconfigureAudioSources() {
 			} else {
 				err = fmt.Errorf("panic during audio source reconfiguration: %v", r)
 			}
-			GetAudiocoreLogger().Error(err.Error(),
+			audiocore.GetLogger().Error(err.Error(),
 				logger.String("stack", string(debug.Stack())))
 		}
 	}()
@@ -768,7 +768,7 @@ func (cm *ControlMonitor) handleReconfigureAudioSources() {
 		cm.quietHoursScheduler.Evaluate()
 	}
 
-	GetAudiocoreLogger().Info("Audio sources reconfigured successfully")
+	audiocore.GetLogger().Info("Audio sources reconfigured successfully")
 	cm.notifySuccess("Audio sources reconfigured successfully")
 }
 

--- a/internal/analysis/control_monitor.go
+++ b/internal/analysis/control_monitor.go
@@ -382,7 +382,6 @@ func (cm *ControlMonitor) handleReconfigureStreams() {
 	}
 
 	audiocore.GetLogger().Info("Audio streams reconfigured successfully")
-	cm.notifySuccess("Audio capture reconfigured successfully")
 }
 
 // handleReconfigureBirdWeather reconfigures the BirdWeather integration
@@ -769,7 +768,6 @@ func (cm *ControlMonitor) handleReconfigureAudioSources() {
 	}
 
 	audiocore.GetLogger().Info("Audio sources reconfigured successfully")
-	cm.notifySuccess("Audio sources reconfigured successfully")
 }
 
 // handleRecalculateDynamicThresholds recalculates all dynamic threshold CurrentValue entries

--- a/internal/analysis/logger.go
+++ b/internal/analysis/logger.go
@@ -15,6 +15,12 @@ func GetLogger() logger.Logger {
 	return logger.Global().Module("analysis")
 }
 
+// GetAudiocoreLogger returns the audiocore module logger for audio pipeline
+// events that should route to logs/audio.log instead of the analysis log.
+func GetAudiocoreLogger() logger.Logger {
+	return logger.Global().Module("audiocore")
+}
+
 // Sound level structured logging functions
 
 // LogSoundLevelMQTTPublished logs successful MQTT publication of sound level data

--- a/internal/analysis/logger.go
+++ b/internal/analysis/logger.go
@@ -15,12 +15,6 @@ func GetLogger() logger.Logger {
 	return logger.Global().Module("analysis")
 }
 
-// GetAudiocoreLogger returns the audiocore module logger for audio pipeline
-// events that should route to logs/audio.log instead of the analysis log.
-func GetAudiocoreLogger() logger.Logger {
-	return logger.Global().Module("audiocore")
-}
-
 // Sound level structured logging functions
 
 // LogSoundLevelMQTTPublished logs successful MQTT publication of sound level data

--- a/internal/analysis/source_config_diff_test.go
+++ b/internal/analysis/source_config_diff_test.go
@@ -1,0 +1,84 @@
+package analysis
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tphakala/birdnet-go/internal/audiocore"
+)
+
+func TestSourceNeedsReconfigure(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		running  *audiocore.AudioSource
+		desired  *audiocore.SourceConfig
+		expected bool
+	}{
+		{
+			name: "same config, no reconfigure needed",
+			running: &audiocore.AudioSource{
+				SampleRate: 48000,
+				BitDepth:   16,
+				Channels:   1,
+			},
+			desired: &audiocore.SourceConfig{
+				SampleRate: 48000,
+				BitDepth:   16,
+				Channels:   1,
+			},
+			expected: false,
+		},
+		{
+			name: "sample rate changed",
+			running: &audiocore.AudioSource{
+				SampleRate: 48000,
+				BitDepth:   16,
+				Channels:   1,
+			},
+			desired: &audiocore.SourceConfig{
+				SampleRate: 96000,
+				BitDepth:   16,
+				Channels:   1,
+			},
+			expected: true,
+		},
+		{
+			name: "bit depth changed",
+			running: &audiocore.AudioSource{
+				SampleRate: 48000,
+				BitDepth:   16,
+				Channels:   1,
+			},
+			desired: &audiocore.SourceConfig{
+				SampleRate: 48000,
+				BitDepth:   32,
+				Channels:   1,
+			},
+			expected: true,
+		},
+		{
+			name: "channels changed",
+			running: &audiocore.AudioSource{
+				SampleRate: 48000,
+				BitDepth:   16,
+				Channels:   1,
+			},
+			desired: &audiocore.SourceConfig{
+				SampleRate: 48000,
+				BitDepth:   16,
+				Channels:   2,
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := sourceNeedsReconfigure(tt.running, tt.desired)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/internal/api/v2/settings_audio.go
+++ b/internal/api/v2/settings_audio.go
@@ -7,6 +7,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/audiocore"
 	"github.com/tphakala/birdnet-go/internal/audiocore/equalizer"
 	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/logger"
 	"github.com/tphakala/birdnet-go/internal/notification"
 )
 
@@ -235,6 +236,7 @@ func (c *Controller) handleAudioSettingsChanges(oldSettings, currentSettings *co
 	// Check audio device settings
 	if audioDeviceSettingChanged(oldSettings, currentSettings) {
 		c.logInfoIfEnabled("Audio device settings changed, triggering reconfiguration")
+		logger.Global().Module("audiocore").Info("audio device settings changed, triggering reconfiguration")
 		reconfigActions = append(reconfigActions, "reconfigure_audio_sources")
 		_ = c.SendToastWithKey("Reconfiguring audio sources...", "info", toastDurationMedium,
 			notification.MsgSettingsReconfiguringAudioSources, nil)

--- a/internal/api/v2/settings_audio.go
+++ b/internal/api/v2/settings_audio.go
@@ -234,7 +234,6 @@ func (c *Controller) handleAudioSettingsChanges(oldSettings, currentSettings *co
 
 	// Check audio device settings
 	if audioDeviceSettingChanged(oldSettings, currentSettings) {
-		c.logInfoIfEnabled("Audio device settings changed, triggering reconfiguration")
 		audiocore.GetLogger().Info("audio device settings changed, triggering reconfiguration")
 		reconfigActions = append(reconfigActions, "reconfigure_audio_sources")
 		_ = c.SendToastWithKey("Reconfiguring audio sources...", "info", toastDurationMedium,

--- a/internal/api/v2/settings_audio.go
+++ b/internal/api/v2/settings_audio.go
@@ -7,7 +7,6 @@ import (
 	"github.com/tphakala/birdnet-go/internal/audiocore"
 	"github.com/tphakala/birdnet-go/internal/audiocore/equalizer"
 	"github.com/tphakala/birdnet-go/internal/conf"
-	"github.com/tphakala/birdnet-go/internal/logger"
 	"github.com/tphakala/birdnet-go/internal/notification"
 )
 
@@ -236,7 +235,7 @@ func (c *Controller) handleAudioSettingsChanges(oldSettings, currentSettings *co
 	// Check audio device settings
 	if audioDeviceSettingChanged(oldSettings, currentSettings) {
 		c.logInfoIfEnabled("Audio device settings changed, triggering reconfiguration")
-		logger.Global().Module("audiocore").Info("audio device settings changed, triggering reconfiguration")
+		audiocore.GetLogger().Info("audio device settings changed, triggering reconfiguration")
 		reconfigActions = append(reconfigActions, "reconfigure_audio_sources")
 		_ = c.SendToastWithKey("Reconfiguring audio sources...", "info", toastDurationMedium,
 			notification.MsgSettingsReconfiguringAudioSources, nil)

--- a/internal/audiocore/engine/engine.go
+++ b/internal/audiocore/engine/engine.go
@@ -437,10 +437,13 @@ func (e *AudioEngine) ReconfigureSource(sourceID string, newCfg *audiocore.Sourc
 		_ = e.deviceMgr.StopCapture(sourceID)
 	}
 
-	// 2. Deallocate old buffers.
+	// 2. Remove all routes so consumers don't reference deallocated buffers.
+	e.router.RemoveAllRoutes(sourceID)
+
+	// 3. Deallocate old buffers.
 	e.bufferMgr.DeallocateSource(sourceID)
 
-	// 3. Allocate new buffers scaled to source sample rate.
+	// 4. Allocate new buffers scaled to source sample rate.
 	sampleRate := newCfg.SampleRate
 	if sampleRate <= 0 {
 		sampleRate = defaultSampleRate
@@ -478,7 +481,7 @@ func (e *AudioEngine) ReconfigureSource(sourceID string, newCfg *audiocore.Sourc
 			Build()
 	}
 
-	// 4. Restart capture with new config.
+	// 5. Restart capture with new config.
 	newType := newCfg.Type
 	if newType == "" || newType == audiocore.SourceTypeUnknown {
 		newType = src.Type
@@ -500,7 +503,7 @@ func (e *AudioEngine) ReconfigureSource(sourceID string, newCfg *audiocore.Sourc
 			Debug:            e.debug,
 		}
 		if err := e.ffmpegMgr.StartStream(streamCfg); err != nil {
-			// Source stays registered — mark it as errored so callers can see the failure.
+			// Source stays registered; mark it as errored so callers can see the failure.
 			_ = e.registry.UpdateState(sourceID, audiocore.SourceError)
 			return errors.New(err).
 				Component("audiocore.engine").
@@ -516,7 +519,7 @@ func (e *AudioEngine) ReconfigureSource(sourceID string, newCfg *audiocore.Sourc
 			Channels:   newCfg.Channels,
 		}
 		if err := e.deviceMgr.StartCapture(sourceID, newCfg.ConnectionString, devCfg); err != nil {
-			// Source stays registered — mark it as errored so callers can see the failure.
+			// Source stays registered; mark it as errored so callers can see the failure.
 			_ = e.registry.UpdateState(sourceID, audiocore.SourceError)
 			return errors.New(err).
 				Component("audiocore.engine").
@@ -526,6 +529,9 @@ func (e *AudioEngine) ReconfigureSource(sourceID string, newCfg *audiocore.Sourc
 				Build()
 		}
 	}
+
+	// 6. Update registry so downstream consumers see the new audio params.
+	e.registry.UpdateAudioParams(sourceID, sampleRate, newCfg.BitDepth, newCfg.Channels)
 
 	e.logger.Info("source reconfigured",
 		logger.String("source_id", sourceID),

--- a/internal/audiocore/engine/engine.go
+++ b/internal/audiocore/engine/engine.go
@@ -459,6 +459,7 @@ func (e *AudioEngine) ReconfigureSource(sourceID string, newCfg *audiocore.Sourc
 		defaultAnalysisOverlap*rateScale,
 		defaultAnalysisReadSize*rateScale,
 	); err != nil {
+		_ = e.registry.UpdateState(sourceID, audiocore.SourceError)
 		return errors.New(err).
 			Component("audiocore.engine").
 			Category(errors.CategoryBuffer).
@@ -473,6 +474,7 @@ func (e *AudioEngine) ReconfigureSource(sourceID string, newCfg *audiocore.Sourc
 		defaultBytesPerSample,
 	); err != nil {
 		e.bufferMgr.DeallocateSource(sourceID)
+		_ = e.registry.UpdateState(sourceID, audiocore.SourceError)
 		return errors.New(err).
 			Component("audiocore.engine").
 			Category(errors.CategoryBuffer).

--- a/internal/audiocore/source_registry.go
+++ b/internal/audiocore/source_registry.go
@@ -269,17 +269,23 @@ func (r *SourceRegistry) UpdateDisplayName(sourceID, newName string) bool {
 }
 
 // UpdateAudioParams updates the SampleRate, BitDepth, and Channels fields of
-// the source after a successful reconfigure. Returns false if not found.
+// the source after a successful reconfigure. Fires SourceReconfigured so
+// listeners (SSE, MQTT HA discovery) see the new parameters. Returns false
+// if the source does not exist.
 func (r *SourceRegistry) UpdateAudioParams(sourceID string, sampleRate, bitDepth, channels int) bool {
 	r.mu.Lock()
-	defer r.mu.Unlock()
 	src, ok := r.sources[sourceID]
 	if !ok {
+		r.mu.Unlock()
 		return false
 	}
 	src.SampleRate = sampleRate
 	src.BitDepth = bitDepth
 	src.Channels = channels
+	snapshot := r.copySource(src)
+	r.mu.Unlock()
+
+	r.notify(SourceEvent{Type: SourceReconfigured, SourceID: sourceID, Source: snapshot})
 	return true
 }
 

--- a/internal/audiocore/source_registry.go
+++ b/internal/audiocore/source_registry.go
@@ -109,9 +109,9 @@ func (r *SourceRegistry) Register(cfg *SourceConfig) (*AudioSource, error) {
 
 	r.mu.Lock()
 
-	// Deduplication: return existing source for the same connection string.
+	// Deduplication: return a safe copy of the existing source.
 	if existingID, ok := r.connectionMap[connStr]; ok {
-		existing := r.sources[existingID]
+		existing := r.copySource(r.sources[existingID])
 		r.mu.Unlock()
 		return existing, nil
 	}
@@ -156,7 +156,7 @@ func (r *SourceRegistry) Register(cfg *SourceConfig) (*AudioSource, error) {
 		logger.String("type", cfg.Type.String()))
 
 	r.notify(SourceEvent{Type: SourceAdded, SourceID: id, Source: snapshot})
-	return src, nil
+	return snapshot, nil
 }
 
 // Unregister removes the source with the given ID from the registry.

--- a/internal/audiocore/source_registry.go
+++ b/internal/audiocore/source_registry.go
@@ -186,16 +186,21 @@ func (r *SourceRegistry) Unregister(sourceID string) error {
 	return nil
 }
 
-// Get returns the source with the given ID, or (nil, false) if not found.
+// Get returns a safe copy of the source with the given ID, or (nil, false) if
+// not found. The copy omits the private connection string to prevent credential
+// leaks. Callers can read fields without holding the registry lock.
 func (r *SourceRegistry) Get(sourceID string) (*AudioSource, bool) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	src, ok := r.sources[sourceID]
-	return src, ok
+	if !ok {
+		return nil, false
+	}
+	return r.copySource(src), true
 }
 
-// GetByConnection returns the source registered for the given connection string,
-// or (nil, false) if not found.
+// GetByConnection returns a safe copy of the source registered for the given
+// connection string, or (nil, false) if not found.
 func (r *SourceRegistry) GetByConnection(connStr string) (*AudioSource, bool) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
@@ -204,7 +209,10 @@ func (r *SourceRegistry) GetByConnection(connStr string) (*AudioSource, bool) {
 		return nil, false
 	}
 	src, ok := r.sources[id]
-	return src, ok
+	if !ok {
+		return nil, false
+	}
+	return r.copySource(src), true
 }
 
 // List returns safe copies of all registered sources, sorted by DisplayName.

--- a/internal/audiocore/source_registry.go
+++ b/internal/audiocore/source_registry.go
@@ -42,7 +42,7 @@ type SourceEvent struct {
 	SourceID string
 
 	// Source is a copy of the affected AudioSource at the time of the event.
-	// It is always a copy — listeners must not modify it.
+	// It is always a copy; listeners must not modify it.
 	Source *AudioSource
 }
 
@@ -93,7 +93,7 @@ func NewSourceRegistry(log logger.Logger) *SourceRegistry {
 // Register adds a source to the registry from the given SourceConfig.
 //
 // If a source with the same ConnectionString already exists, it is returned
-// unchanged — no duplicate is created.
+// unchanged, so no duplicate is created.
 //
 // The source type is detected automatically from the ConnectionString unless
 // cfg.Type is already set to a non-Unknown value.
@@ -265,6 +265,21 @@ func (r *SourceRegistry) UpdateDisplayName(sourceID, newName string) bool {
 		logger.String("new_name", newName))
 
 	r.notify(SourceEvent{Type: SourceReconfigured, SourceID: sourceID, Source: snapshot})
+	return true
+}
+
+// UpdateAudioParams updates the SampleRate, BitDepth, and Channels fields of
+// the source after a successful reconfigure. Returns false if not found.
+func (r *SourceRegistry) UpdateAudioParams(sourceID string, sampleRate, bitDepth, channels int) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	src, ok := r.sources[sourceID]
+	if !ok {
+		return false
+	}
+	src.SampleRate = sampleRate
+	src.BitDepth = bitDepth
+	src.Channels = channels
 	return true
 }
 


### PR DESCRIPTION
## Summary

- Route all audio source lifecycle logs (reconfigure, add, remove, restart, consumer registration) to the `audiocore` module logger so they appear in `logs/audio.log` instead of `logs/application.log`
- Detect sample rate, bit depth, and channel changes on existing sources during hot-reload and call `ReconfigureSource()` (previously only gain and display name changes were detected)
- Fix `ReconfigureSource()` to remove routes before buffer deallocation, preventing stale consumers from referencing freed buffers
- Update registry `AudioSource` fields after successful reconfigure via new `UpdateAudioParams()` method, preventing repeated unnecessary reconfigures
- Make gain-only and full-reconfigure paths mutually exclusive per source
- Rebuild consumer routes (buffer, audio level, sound level) after `ReconfigureSource` completes

## Test Plan

- [x] `TestSourceNeedsReconfigure` covers all parameter change combinations
- [x] QA-verified on local host: changed sample rate 48000->96000 via API, confirmed all 7 reconfigure events appear in `audio.log`
- [x] `golangci-lint run` clean
- [x] `go test -race` clean
- [x] Two rounds of parallel gate review (4 agents + Gemini cross-validation)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hot-reload now distinguishes gain-only updates from audio-parameter (sample rate/bit depth/channels) changes, reducing unnecessary restarts and improving stability.
  * Reconfiguration failures now mark affected sources as errored to avoid lingering invalid state.

* **New Features**
  * Registry now updates and exposes revised audio parameters so downstream components observe new configurations.
  * Added an explicit info log when audio device pipeline settings change.

* **Tests**
  * Added unit tests for detecting audio-parameter changes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3002)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->