### PR TITLE
fix(audiocore): use model spec for primary analysis buffer sizing

### DIFF
--- a/internal/analysis/audio_pipeline_service.go
+++ b/internal/analysis/audio_pipeline_service.go
@@ -131,9 +131,11 @@ func (p *AudioPipelineService) Start(_ context.Context) error {
 	dataStore := p.dbService.DataStore()
 	metrics := p.apiService.Metrics()
 
-	// Set the primary model ID on the engine so that analysis buffers are
-	// allocated with the correct model key instead of a hardcoded constant.
-	p.engine.SetPrimaryModelID(bn.ModelInfo.ID)
+	// Set the primary model ID and buffer dimensions on the engine so that
+	// analysis buffers are allocated from the model's spec, not hardcoded
+	// constants. This matches the secondary model allocation path.
+	clipBytes, overlapBytes, readSize := bn.ModelInfo.Spec.BufferDimensions()
+	p.engine.SetPrimaryModel(bn.ModelInfo.ID, clipBytes, overlapBytes, readSize)
 
 	// Register all loaded models in the ai_models database table so they
 	// appear even before any detections are saved.
@@ -701,10 +703,7 @@ func (p *AudioPipelineService) registerConsumersForSources(sourceIDs []string, s
 				allocatedModels[modelInfos[i].ID] = true
 				continue
 			}
-			spec := modelInfos[i].Spec
-			clipBytes := spec.ClipSizeBytes()
-			overlapBytes := clipBytes / 2 // 50% overlap, matching primary model ratio
-			readSize := clipBytes - overlapBytes
+			clipBytes, overlapBytes, readSize := modelInfos[i].Spec.BufferDimensions()
 			if allocErr := bufMgr.AllocateAnalysis(sid, modelInfos[i].ID, clipBytes, overlapBytes, readSize); allocErr != nil {
 				log.Warn("failed to allocate analysis buffer for secondary model",
 					logger.String("source_id", sid),
@@ -1224,17 +1223,14 @@ func cleanupHLSWithTimeout(ctx context.Context) {
 	go func() {
 		defer func() {
 			if r := recover(); r != nil {
-				panicErr := fmt.Errorf("panic during HLS cleanup: %v", r)
-				// Log panic but don't block shutdown
 				GetLogger().Error("panic during HLS cleanup",
 					logger.Any("panic", r))
-				_ = errors.New(panicErr).
+				cleanupDone <- errors.Newf("panic during HLS cleanup: %v", r).
 					Component("analysis.audio_pipeline").
 					Category(errors.CategorySystem).
 					Context("operation", "hls_cleanup_panic").
 					Priority(errors.PriorityCritical).
 					Build()
-				cleanupDone <- panicErr
 			}
 		}()
 		cleanupDone <- cleanupHLSStreamingFiles()

--- a/internal/analysis/audio_pipeline_service.go
+++ b/internal/analysis/audio_pipeline_service.go
@@ -713,7 +713,7 @@ func (p *AudioPipelineService) registerConsumersForSources(sourceIDs []string, s
 				continue
 			}
 			allocatedModels[modelInfos[i].ID] = true
-			log.Debug("allocated analysis buffer for secondary model",
+			log.Info("allocated analysis buffer for secondary model",
 				logger.String("source_id", sid),
 				logger.String("model_id", modelInfos[i].ID),
 				logger.Int("clip_bytes", clipBytes),

--- a/internal/analysis/buffer_manager.go
+++ b/internal/analysis/buffer_manager.go
@@ -203,7 +203,7 @@ func (m *BufferManager) AddMonitors(source string, models []monitorConfig) error
 		// Use the channel we just stored (actual is our monitorQuit channel)
 		monitorQuit = actual.(chan struct{})
 
-		m.logger.Debug("Allocated analysis buffer monitor",
+		m.logger.Info("allocated analysis buffer monitor",
 			logger.String("source_id", source),
 			logger.String("model_id", cfg.modelID),
 			logger.String("component", "analysis.buffer"),

--- a/internal/audiocore/buffer/analysis.go
+++ b/internal/audiocore/buffer/analysis.go
@@ -259,6 +259,12 @@ func (ab *AnalysisBuffer) OverwriteCount() int64 {
 	return ab.tracker.overwriteCount
 }
 
+// WindowSize returns the total window size (overlapSize + readSize) in bytes.
+// This is the length of the slice returned by Read().
+func (ab *AnalysisBuffer) WindowSize() int {
+	return ab.windowSize
+}
+
 // Reset clears the ring buffer and resets all overlap and tracking state.
 // Useful for testing or restarting a source.
 func (ab *AnalysisBuffer) Reset() {

--- a/internal/audiocore/engine/engine.go
+++ b/internal/audiocore/engine/engine.go
@@ -307,7 +307,7 @@ func (e *AudioEngine) AddSource(cfg *audiocore.SourceConfig) error {
 		sampleRate = defaultSampleRate
 	}
 
-	e.logger.Debug("allocated primary analysis buffer",
+	e.logger.Info("allocated primary analysis buffer",
 		logger.String("source_id", sourceID),
 		logger.String("model_id", e.primaryModelID),
 		logger.Int("clip_bytes", e.primaryClipBytes),
@@ -493,7 +493,7 @@ func (e *AudioEngine) ReconfigureSource(sourceID string, newCfg *audiocore.Sourc
 			Context("source_id", sourceID).
 			Build()
 	}
-	e.logger.Debug("reallocated primary analysis buffer",
+	e.logger.Info("reallocated primary analysis buffer",
 		logger.String("source_id", sourceID),
 		logger.String("model_id", e.primaryModelID),
 		logger.Int("clip_bytes", e.primaryClipBytes),

--- a/internal/audiocore/engine/engine.go
+++ b/internal/audiocore/engine/engine.go
@@ -238,7 +238,7 @@ func (e *AudioEngine) SetScheduler(s *schedule.QuietHoursScheduler) {
 // for the primary model. This must be called before AddSource to ensure
 // buffers are allocated with the correct model key and size.
 // clipBytes, overlapBytes, and readSize should be derived from the model's
-// ModelSpec.ClipSizeBytes(), matching the secondary model allocation path.
+// ModelSpec.BufferDimensions(), matching the secondary model allocation path.
 func (e *AudioEngine) SetPrimaryModel(id string, clipBytes, overlapBytes, readSize int) {
 	e.primaryModelID = id
 	e.primaryClipBytes = clipBytes

--- a/internal/audiocore/engine/engine.go
+++ b/internal/audiocore/engine/engine.go
@@ -34,21 +34,8 @@ func isStreamType(t audiocore.SourceType) bool {
 	}
 }
 
-// Default buffer parameters used when allocating analysis and capture buffers.
-// These match the values used by the existing BirdNET analysis pipeline.
+// Default buffer parameters used when allocating capture buffers.
 const (
-	// defaultAnalysisCapacity is the ring buffer size in bytes.
-	// 288000 bytes = 3 seconds of 16-bit 48 kHz mono audio.
-	defaultAnalysisCapacity = 288000
-
-	// defaultAnalysisOverlap is the overlap in bytes between consecutive reads.
-	// 144000 bytes = 1.5 seconds of 16-bit 48 kHz mono audio.
-	defaultAnalysisOverlap = 144000
-
-	// defaultAnalysisReadSize is the number of fresh bytes per read.
-	// 144000 bytes = 1.5 seconds of 16-bit 48 kHz mono audio.
-	defaultAnalysisReadSize = 144000
-
 	// defaultCaptureBufferSeconds is the ring buffer capacity in seconds.
 	// This determines how much audio history is retained for clip export.
 	// Must be large enough to cover the export length + detection window
@@ -135,8 +122,14 @@ type AudioEngine struct {
 	cancel    context.CancelCauseFunc
 
 	// primaryModelID is the model identifier used when allocating analysis
-	// buffers. Set via SetPrimaryModelID before adding sources.
+	// buffers. Set via SetPrimaryModel before adding sources.
 	primaryModelID string
+	// primaryClipBytes, primaryOverlapBytes, primaryReadSize are the analysis
+	// buffer dimensions derived from the primary model's spec. Set via
+	// SetPrimaryModel before adding sources.
+	primaryClipBytes    int
+	primaryOverlapBytes int
+	primaryReadSize     int
 	// ffmpegPath is the absolute path to the FFmpeg binary.
 	ffmpegPath string
 	// soxPath is the absolute path to the SoX binary.
@@ -241,12 +234,21 @@ func (e *AudioEngine) SetScheduler(s *schedule.QuietHoursScheduler) {
 	e.scheduler.Store(s)
 }
 
-// SetPrimaryModelID sets the model identifier used when allocating analysis
-// buffers. This must be called before AddSource to ensure buffers are keyed
-// to the correct model. The value should come from the Orchestrator's
-// ModelInfo.ID.
-func (e *AudioEngine) SetPrimaryModelID(id string) {
+// SetPrimaryModel sets the model identifier and analysis buffer dimensions
+// for the primary model. This must be called before AddSource to ensure
+// buffers are allocated with the correct model key and size.
+// clipBytes, overlapBytes, and readSize should be derived from the model's
+// ModelSpec.ClipSizeBytes(), matching the secondary model allocation path.
+func (e *AudioEngine) SetPrimaryModel(id string, clipBytes, overlapBytes, readSize int) {
 	e.primaryModelID = id
+	e.primaryClipBytes = clipBytes
+	e.primaryOverlapBytes = overlapBytes
+	e.primaryReadSize = readSize
+	e.logger.Info("primary model buffer dimensions set",
+		logger.String("model_id", id),
+		logger.Int("clip_bytes", clipBytes),
+		logger.Int("overlap_bytes", overlapBytes),
+		logger.Int("read_size", readSize))
 }
 
 // PrimaryModelID returns the current primary model identifier.
@@ -259,6 +261,14 @@ func (e *AudioEngine) PrimaryModelID() string {
 // is started. For audio card sources, the device manager begins capture.
 // File-type sources are registered but no long-running capture is started.
 func (e *AudioEngine) AddSource(cfg *audiocore.SourceConfig) error {
+	if e.primaryModelID == "" {
+		return errors.Newf("SetPrimaryModel must be called before AddSource").
+			Component("audiocore.engine").
+			Category(errors.CategoryState).
+			Context("source_id", cfg.ID).
+			Build()
+	}
+
 	// 1. Register the source.
 	src, err := e.registry.Register(cfg)
 	if err != nil {
@@ -272,22 +282,17 @@ func (e *AudioEngine) AddSource(cfg *audiocore.SourceConfig) error {
 
 	sourceID := src.ID
 
-	// 2. Allocate analysis buffer scaled to source sample rate.
-	sampleRate := cfg.SampleRate
-	if sampleRate <= 0 {
-		sampleRate = defaultSampleRate
-	}
-	rateScale := sampleRate / defaultSampleRate
-	if rateScale < 1 {
-		rateScale = 1
-	}
+	// 2. Allocate analysis buffer using the primary model's native dimensions.
+	// BufferConsumer resamples audio to the model's target rate before writing,
+	// so buffer size must match the model spec, not the source sample rate.
 	if err := e.bufferMgr.AllocateAnalysis(
 		sourceID,
 		e.primaryModelID,
-		defaultAnalysisCapacity*rateScale,
-		defaultAnalysisOverlap*rateScale,
-		defaultAnalysisReadSize*rateScale,
+		e.primaryClipBytes,
+		e.primaryOverlapBytes,
+		e.primaryReadSize,
 	); err != nil {
+		_ = e.registry.Unregister(sourceID)
 		return errors.New(err).
 			Component("audiocore.engine").
 			Category(errors.CategoryBuffer).
@@ -296,15 +301,29 @@ func (e *AudioEngine) AddSource(cfg *audiocore.SourceConfig) error {
 			Build()
 	}
 
-	// 3. Allocate capture buffer.
+	// 3. Default and validate sample rate for capture buffer and stream config.
+	sampleRate := cfg.SampleRate
+	if sampleRate <= 0 {
+		sampleRate = defaultSampleRate
+	}
+
+	e.logger.Debug("allocated primary analysis buffer",
+		logger.String("source_id", sourceID),
+		logger.String("model_id", e.primaryModelID),
+		logger.Int("clip_bytes", e.primaryClipBytes),
+		logger.Int("overlap_bytes", e.primaryOverlapBytes),
+		logger.Int("read_size", e.primaryReadSize),
+		logger.Int("source_sample_rate", sampleRate))
+
+	// 4. Allocate capture buffer.
 	if err := e.bufferMgr.AllocateCapture(
 		sourceID,
 		e.captureBufferSeconds,
 		sampleRate,
 		defaultBytesPerSample,
 	); err != nil {
-		// Roll back analysis buffer on failure.
 		e.bufferMgr.DeallocateSource(sourceID)
+		_ = e.registry.Unregister(sourceID)
 		return errors.New(err).
 			Component("audiocore.engine").
 			Category(errors.CategoryBuffer).
@@ -313,7 +332,7 @@ func (e *AudioEngine) AddSource(cfg *audiocore.SourceConfig) error {
 			Build()
 	}
 
-	// 4. Start capture based on source type.
+	// 5. Start capture based on source type.
 	if isStreamType(cfg.Type) {
 		streamCfg := &ffmpeg.StreamConfig{
 			SourceID:         sourceID,
@@ -370,7 +389,10 @@ func (e *AudioEngine) AddSource(cfg *audiocore.SourceConfig) error {
 
 	e.logger.Info("source added",
 		logger.String("source_id", sourceID),
-		logger.String("type", cfg.Type.String()))
+		logger.String("type", cfg.Type.String()),
+		logger.Int("sample_rate", sampleRate),
+		logger.String("primary_model", e.primaryModelID),
+		logger.Int("analysis_clip_bytes", e.primaryClipBytes))
 
 	return nil
 }
@@ -418,6 +440,14 @@ func (e *AudioEngine) RemoveSource(sourceID string) error {
 // ReconfigureSource stops the existing capture for sourceID, reallocates
 // buffers with the new configuration, and restarts capture.
 func (e *AudioEngine) ReconfigureSource(sourceID string, newCfg *audiocore.SourceConfig) error {
+	if e.primaryModelID == "" {
+		return errors.Newf("SetPrimaryModel must be called before ReconfigureSource").
+			Component("audiocore.engine").
+			Category(errors.CategoryState).
+			Context("source_id", sourceID).
+			Build()
+	}
+
 	src, ok := e.registry.Get(sourceID)
 	if !ok {
 		return fmt.Errorf("reconfigure source: %w: %s", audiocore.ErrSourceNotFound, sourceID)
@@ -443,21 +473,17 @@ func (e *AudioEngine) ReconfigureSource(sourceID string, newCfg *audiocore.Sourc
 	// 3. Deallocate old buffers.
 	e.bufferMgr.DeallocateSource(sourceID)
 
-	// 4. Allocate new buffers scaled to source sample rate.
+	// 4. Allocate new analysis buffer using the primary model's native dimensions.
 	sampleRate := newCfg.SampleRate
 	if sampleRate <= 0 {
 		sampleRate = defaultSampleRate
 	}
-	rateScale := sampleRate / defaultSampleRate
-	if rateScale < 1 {
-		rateScale = 1
-	}
 	if err := e.bufferMgr.AllocateAnalysis(
 		sourceID,
 		e.primaryModelID,
-		defaultAnalysisCapacity*rateScale,
-		defaultAnalysisOverlap*rateScale,
-		defaultAnalysisReadSize*rateScale,
+		e.primaryClipBytes,
+		e.primaryOverlapBytes,
+		e.primaryReadSize,
 	); err != nil {
 		_ = e.registry.UpdateState(sourceID, audiocore.SourceError)
 		return errors.New(err).
@@ -467,6 +493,13 @@ func (e *AudioEngine) ReconfigureSource(sourceID string, newCfg *audiocore.Sourc
 			Context("source_id", sourceID).
 			Build()
 	}
+	e.logger.Debug("reallocated primary analysis buffer",
+		logger.String("source_id", sourceID),
+		logger.String("model_id", e.primaryModelID),
+		logger.Int("clip_bytes", e.primaryClipBytes),
+		logger.Int("overlap_bytes", e.primaryOverlapBytes),
+		logger.Int("read_size", e.primaryReadSize),
+		logger.Int("source_sample_rate", sampleRate))
 	if err := e.bufferMgr.AllocateCapture(
 		sourceID,
 		e.captureBufferSeconds,

--- a/internal/audiocore/engine/engine_test.go
+++ b/internal/audiocore/engine/engine_test.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -16,11 +17,18 @@ import (
 // testModelID is used by tests to verify analysis buffer allocation.
 const testModelID = "BirdNET_V2.4"
 
+// BirdNET v2.4 analysis buffer dimensions: 3s of 16-bit 48kHz mono audio.
+const (
+	testClipBytes    = 288000 // 48000 * 3 * 1 * 2
+	testOverlapBytes = 144000
+	testReadSize     = 144000
+)
+
 func newTestEngine(t *testing.T) (eng *AudioEngine, stop func()) {
 	t.Helper()
 	cfg := &Config{Logger: audiocore.GetLogger()}
 	eng = New(t.Context(), cfg, nil)
-	eng.SetPrimaryModelID(testModelID)
+	eng.SetPrimaryModel(testModelID, testClipBytes, testOverlapBytes, testReadSize)
 	return eng, eng.Stop
 }
 
@@ -96,6 +104,90 @@ func TestEngine_AddSource_Stream(t *testing.T) {
 	// Verify FFmpeg stream was started (it appears in AllStreamHealth).
 	health := eng.FFmpegManager().AllStreamHealth()
 	assert.Contains(t, health, "test_rtsp_001", "stream should appear in FFmpeg manager")
+}
+
+// TestEngine_AddSource_HighSampleRate verifies that a source with a sample rate
+// above 48kHz gets analysis buffers sized to the primary model's native
+// dimensions, not scaled by the source/model rate ratio. This is the core
+// regression test for issue #575: BufferConsumer resamples audio to the model's
+// target rate before writing, so the analysis buffer must match the model spec.
+func TestEngine_AddSource_HighSampleRate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		sampleRate int
+	}{
+		{name: "96kHz source", sampleRate: 96000},
+		{name: "256kHz source (bat detection)", sampleRate: 256000},
+		{name: "48kHz source (baseline)", sampleRate: 48000},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			eng, stop := newTestEngine(t)
+			defer stop()
+
+			sourceID := fmt.Sprintf("test_highrate_%d", tt.sampleRate)
+			cfg := &audiocore.SourceConfig{
+				ID:               sourceID,
+				DisplayName:      "High Rate Test",
+				Type:             audiocore.SourceTypeRTSP,
+				ConnectionString: "rtsp://192.168.1.100/highrate",
+				SampleRate:       tt.sampleRate,
+				BitDepth:         16,
+				Channels:         1,
+			}
+
+			err := eng.AddSource(cfg)
+			require.NoError(t, err)
+
+			ab, err := eng.BufferManager().AnalysisBuffer(sourceID, testModelID)
+			require.NoError(t, err)
+			require.NotNil(t, ab, "analysis buffer should be allocated")
+
+			// Verify the actual buffer dimensions match the model spec, not
+			// a scaled value. On the old buggy code with rateScale, a 96kHz
+			// source would produce windowSize=576000 instead of 288000.
+			assert.Equal(t, testClipBytes, ab.WindowSize(),
+				"analysis buffer window should match model spec (overlap+readSize=%d), not be scaled by source rate", testClipBytes)
+		})
+	}
+}
+
+// TestEngine_ReconfigureSource_HighSampleRate verifies that reconfiguring a
+// source to a higher sample rate does not scale the analysis buffer.
+func TestEngine_ReconfigureSource_HighSampleRate(t *testing.T) {
+	t.Parallel()
+	eng, stop := newTestEngine(t)
+	defer stop()
+
+	cfg := &audiocore.SourceConfig{
+		ID:               "test_reconfig_highrate",
+		DisplayName:      "Reconfigure Rate Test",
+		Type:             audiocore.SourceTypeRTSP,
+		ConnectionString: "rtsp://192.168.1.50/rate",
+		SampleRate:       48000,
+		BitDepth:         16,
+		Channels:         1,
+	}
+	require.NoError(t, eng.AddSource(cfg))
+
+	// Reconfigure to 96kHz.
+	newCfg := &audiocore.SourceConfig{
+		ConnectionString: "rtsp://192.168.1.50/rate_v2",
+		SampleRate:       96000,
+		BitDepth:         16,
+		Channels:         1,
+	}
+	require.NoError(t, eng.ReconfigureSource("test_reconfig_highrate", newCfg))
+
+	ab, err := eng.BufferManager().AnalysisBuffer("test_reconfig_highrate", testModelID)
+	require.NoError(t, err)
+	require.NotNil(t, ab, "analysis buffer should be allocated after reconfigure to 96kHz")
+	assert.Equal(t, testClipBytes, ab.WindowSize(),
+		"analysis buffer window should match model spec after reconfigure to 96kHz")
 }
 
 // TestEngine_AddSource_Device adds an audio card source and verifies

--- a/internal/classifier/model.go
+++ b/internal/classifier/model.go
@@ -27,6 +27,15 @@ func (s ModelSpec) ClipSizeBytes() int {
 	return s.SampleRate * int(s.ClipLength.Seconds()) * conf.NumChannels * conf.BytesPerSample
 }
 
+// BufferDimensions returns the analysis buffer dimensions for this model
+// with 50% overlap: (clipBytes, overlapBytes, readSize).
+func (s ModelSpec) BufferDimensions() (clipBytes, overlapBytes, readSize int) {
+	clipBytes = s.ClipSizeBytes()
+	overlapBytes = clipBytes / 2
+	readSize = clipBytes - overlapBytes
+	return
+}
+
 // EffectiveSampleRate returns the sample rate the model expects to receive
 // audio at. When RawSampleRate is set, the model needs raw audio at that
 // rate (e.g. 256kHz bat audio fed without resampling). Otherwise, the


### PR DESCRIPTION
## Summary

- Fix BirdNET inference never running when source sample rate exceeds 48kHz (e.g., 96kHz, 256kHz for bat detection). The engine's `AddSource`/`ReconfigureSource` scaled the primary model's analysis buffer by `sourceSampleRate / 48000`, but `BufferConsumer` already resamples audio to the model's target rate before writing, causing a buffer/monitor size mismatch that silently prevented `ProcessData` from being called.
- Replace the `rateScale` computation with model-derived buffer dimensions passed via `SetPrimaryModel()`, matching the secondary model allocation path which was already correct.
- Add `ModelSpec.BufferDimensions()` helper to eliminate duplicate derivation across 3 call sites.
- Add precondition guard in `AddSource`/`ReconfigureSource` for missing `SetPrimaryModel` call.
- Fix pre-existing registry entry leak on buffer allocation failure in `AddSource`.
- Fix pre-existing discarded structured error in HLS cleanup panic recovery.
- Add `AnalysisBuffer.WindowSize()` accessor for test observability.
- Promote all model buffer allocation logs to Info level for troubleshooting visibility.

## Test Plan

- [x] Added regression tests for 96kHz and 256kHz source sample rates verifying buffer window matches model spec
- [x] Added test for reconfigure from 48kHz to 96kHz
- [x] All existing engine tests pass (15 tests)
- [x] Linter clean across all changed packages
- [x] Manually verified on Pi4B with BirdNET v2.4 + Bat model at 96kHz: both models producing inference results