### PR TITLE
fix(classifier): remove legacy model enabled flags, auto-resolve gallery paths

### DIFF
--- a/internal/api/v2/settings_section_test.go
+++ b/internal/api/v2/settings_section_test.go
@@ -76,12 +76,10 @@ func TestPatchMissingSections(t *testing.T) {
 			name:    "perch section accepts valid update",
 			section: "perch",
 			body: map[string]any{
-				"enabled":   true,
 				"threshold": 0.8,
 			},
 			verify: func(t *testing.T, settings *conf.Settings) {
 				t.Helper()
-				assert.True(t, settings.Perch.Enabled)
 				assert.InDelta(t, 0.8, settings.Perch.Threshold, 1e-9)
 			},
 		},

--- a/internal/classifier/model_manager.go
+++ b/internal/classifier/model_manager.go
@@ -190,6 +190,34 @@ func (mm *ModelManager) ScanInstalled() {
 			}
 		}
 		mm.settingsMu.Unlock()
+
+		mm.loadInstalledModels(log)
+	}
+}
+
+// loadInstalledModels loads any installed models that are not yet loaded in
+// the orchestrator. Called after ScanInstalled syncs Models.Enabled, since
+// the orchestrator was created before the scan ran.
+func (mm *ModelManager) loadInstalledModels(log logger.Logger) {
+	if mm.orchestrator == nil {
+		return
+	}
+	mm.mu.RLock()
+	defer mm.mu.RUnlock()
+	for catalogID := range mm.installed {
+		entry, found := GetCatalogEntry(catalogID)
+		if !found || entry.RegistryID == "" {
+			continue
+		}
+		if mm.orchestrator.IsModelLoaded(entry.RegistryID) {
+			continue
+		}
+		if err := mm.orchestrator.LoadModel(entry.RegistryID); err != nil {
+			log.Warn("failed to load installed model at startup",
+				logger.String("catalog_id", catalogID),
+				logger.String("registry_id", entry.RegistryID),
+				logger.Error(err))
+		}
 	}
 }
 

--- a/internal/classifier/model_manager.go
+++ b/internal/classifier/model_manager.go
@@ -72,6 +72,9 @@ type DownloadState struct {
 // parameter is used to update configuration after install/uninstall; it may
 // be nil for testing.
 func NewModelManager(modelsDir string, orchestrator *Orchestrator, settings *conf.Settings) *ModelManager {
+	if orchestrator != nil {
+		orchestrator.SetModelsDir(modelsDir)
+	}
 	return &ModelManager{
 		modelsDir:    modelsDir,
 		orchestrator: orchestrator,
@@ -168,14 +171,14 @@ func (mm *ModelManager) ScanInstalled() {
 			addIfMissing(ConfigAliasForRegistry(entry.RegistryID))
 		}
 
-		// Also add models enabled via legacy per-model config flags.
-		if updated.Bat.Enabled || updated.Bat.ClassifierModel != "" {
+		// Also add models with explicit config paths to the enabled list.
+		if updated.Bat.ClassifierModel != "" {
 			addIfMissing(conf.ModelIDBat)
 		}
-		if updated.Perch.Enabled || updated.Perch.ModelPath != "" {
+		if updated.Perch.ModelPath != "" {
 			addIfMissing(conf.ModelIDPerchV2)
 		}
-		if updated.BSG.Enabled || updated.BSG.ModelPath != "" {
+		if updated.BSG.ModelPath != "" {
 			addIfMissing(conf.ModelIDBSG)
 		}
 
@@ -581,7 +584,6 @@ func (mm *ModelManager) applyConfigForInstall(entry *CatalogEntry, modelPath, la
 		GetLogger().Info("BirdNET v3.0 config wiring not yet implemented",
 			logger.String("catalog_id", entry.ID))
 	case RegistryIDPerchV2:
-		updated.Perch.Enabled = true
 		if modelPath != "" {
 			updated.Perch.ModelPath = modelPath
 		}
@@ -589,7 +591,6 @@ func (mm *ModelManager) applyConfigForInstall(entry *CatalogEntry, modelPath, la
 			updated.Perch.LabelPath = labelsPath
 		}
 	case RegistryIDBSG:
-		updated.BSG.Enabled = true
 		if modelPath != "" {
 			updated.BSG.ModelPath = modelPath
 		}
@@ -597,7 +598,6 @@ func (mm *ModelManager) applyConfigForInstall(entry *CatalogEntry, modelPath, la
 			updated.BSG.LabelPath = labelsPath
 		}
 	case RegistryIDBat:
-		updated.Bat.Enabled = true
 		if modelPath != "" {
 			updated.Bat.ClassifierModel = modelPath
 		}
@@ -648,11 +648,9 @@ func (mm *ModelManager) applyConfigForUninstall(entry *CatalogEntry) {
 		GetLogger().Info("BirdNET v3.0 config wiring not yet implemented",
 			logger.String("catalog_id", entry.ID))
 	case RegistryIDPerchV2:
-		updated.Perch.Enabled = false
 		updated.Perch.ModelPath = ""
 		updated.Perch.LabelPath = ""
 	case RegistryIDBSG:
-		updated.BSG.Enabled = false
 		updated.BSG.ModelPath = ""
 		updated.BSG.LabelPath = ""
 	case RegistryIDBat:
@@ -668,7 +666,6 @@ func (mm *ModelManager) applyConfigForUninstall(entry *CatalogEntry) {
 			}
 		}
 		if replacement == nil {
-			updated.Bat.Enabled = false
 			updated.Bat.ClassifierModel = ""
 			updated.Bat.LabelPath = ""
 			updated.Bat.EmbeddingModel = ""

--- a/internal/classifier/model_manager.go
+++ b/internal/classifier/model_manager.go
@@ -90,14 +90,13 @@ func NewModelManager(modelsDir string, orchestrator *Orchestrator, settings *con
 // recorded as installed.
 func (mm *ModelManager) ScanInstalled() {
 	log := GetLogger()
-	mm.mu.Lock()
-	defer mm.mu.Unlock()
 
+	// Phase 1: scan the filesystem under mm.mu.
+	mm.mu.Lock()
 	for i := range EmbeddedCatalog {
 		entry := &EmbeddedCatalog[i]
 		subdir := filepath.Join(mm.modelsDir, entry.ID)
 
-		// Find the model file (Role "model") in the catalog entry.
 		modelFile := ""
 		labelsFile := ""
 		for _, f := range entry.Files {
@@ -135,18 +134,17 @@ func (mm *ModelManager) ScanInstalled() {
 			logger.String("path", modelPath))
 	}
 
+	installedIDs := slices.Collect(maps.Keys(mm.installed))
 	log.Info("Model scan complete",
 		logger.Int("installed_count", len(mm.installed)))
+	mm.mu.Unlock()
 
-	// Sync Models.Enabled with installed/configured models so the model picker
-	// always reflects the actual system state. Use clone-mutate-publish to
-	// avoid mutating the shared settings snapshot in place.
+	// Phase 2: sync Models.Enabled and load models (lock-free).
 	if mm.settings != nil {
 		mm.settingsMu.Lock()
 		updated := conf.CloneSettings(conf.GetSettings())
 		changed := false
 
-		// BirdNET is always present (permanent built-in).
 		if !slices.ContainsFunc(updated.Models.Enabled, func(id string) bool {
 			return strings.EqualFold(id, conf.ModelIDBirdNET)
 		}) {
@@ -162,8 +160,7 @@ func (mm *ModelManager) ScanInstalled() {
 			}
 		}
 
-		// Add models found in the gallery models directory.
-		for catalogID := range mm.installed {
+		for _, catalogID := range installedIDs {
 			entry, found := GetCatalogEntry(catalogID)
 			if !found {
 				continue
@@ -171,7 +168,6 @@ func (mm *ModelManager) ScanInstalled() {
 			addIfMissing(ConfigAliasForRegistry(entry.RegistryID))
 		}
 
-		// Also add models with explicit config paths to the enabled list.
 		if updated.Bat.ClassifierModel != "" {
 			addIfMissing(conf.ModelIDBat)
 		}
@@ -191,20 +187,18 @@ func (mm *ModelManager) ScanInstalled() {
 		}
 		mm.settingsMu.Unlock()
 
-		mm.loadInstalledModels(log)
+		mm.loadInstalledModels(log, installedIDs)
 	}
 }
 
 // loadInstalledModels loads any installed models that are not yet loaded in
-// the orchestrator. Called after ScanInstalled syncs Models.Enabled, since
-// the orchestrator was created before the scan ran.
-func (mm *ModelManager) loadInstalledModels(log logger.Logger) {
+// the orchestrator. The caller must provide the list of installed catalog IDs
+// (collected while holding mm.mu) so this method runs lock-free.
+func (mm *ModelManager) loadInstalledModels(log logger.Logger, installedIDs []string) {
 	if mm.orchestrator == nil {
 		return
 	}
-	mm.mu.RLock()
-	defer mm.mu.RUnlock()
-	for catalogID := range mm.installed {
+	for _, catalogID := range installedIDs {
 		entry, found := GetCatalogEntry(catalogID)
 		if !found || entry.RegistryID == "" {
 			continue

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -359,6 +359,18 @@ func (o *Orchestrator) Delete() {
 	o.models = nil
 }
 
+// IsModelLoaded returns true if a model with the given registry ID is
+// currently loaded in the orchestrator.
+func (o *Orchestrator) IsModelLoaded(registryID string) bool {
+	o.mu.RLock()
+	defer o.mu.RUnlock()
+	if o.models == nil {
+		return false
+	}
+	_, exists := o.models[registryID]
+	return exists
+}
+
 // LoadModel dynamically loads a model into the Orchestrator at runtime.
 // Called by ModelManager after a successful install. The method delegates
 // to the appropriate model loader (loadPerch, loadBat, etc.) based on

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -613,26 +613,28 @@ func (o *Orchestrator) loadAdditionalModels(threadAlloc map[string]int) error {
 
 		threads := threadAlloc[registryID]
 
+		var loadErr error
 		switch registryID {
 		case RegistryIDBirdNETV3:
 			log.Warn("BirdNET v3.0 loader not yet implemented, skipping",
 				logger.String("registry_id", registryID))
 		case RegistryIDPerchV2:
 			//nolint:staticcheck // SA4023: loadPerch always errors in non-onnx build, but returns nil in onnx build
-			if err := o.loadPerch(threads); err != nil {
-				return err
-			}
+			loadErr = o.loadPerch(threads)
 		case RegistryIDBSG:
 			log.Warn("BSG loader not yet implemented, skipping",
 				logger.String("registry_id", registryID))
 		case RegistryIDBat:
 			//nolint:staticcheck // SA4023: loadBat always errors in non-onnx build, but returns nil in onnx build
-			if err := o.loadBat(threads); err != nil {
-				return err
-			}
+			loadErr = o.loadBat(threads)
 		default:
 			log.Warn("model registered but no loader implemented",
 				logger.String("registry_id", registryID))
+		}
+		if loadErr != nil {
+			log.Warn("optional model failed to load, will retry after gallery scan",
+				logger.String("registry_id", registryID),
+				logger.Error(loadErr))
 		}
 	}
 

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -4,6 +4,8 @@ package classifier
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"sync"
 	"time"
 
@@ -37,9 +39,10 @@ type Orchestrator struct {
 	// NOTE: models map is keyed by ModelInfo.ID at construction time. If ReloadModel
 	// changes the model ID, the key goes stale. Delete() iterates values so cleanup
 	// is unaffected. ReloadModel re-keys the map after reload.
-	mu      sync.RWMutex // protects the models map
-	models  map[string]*modelEntry
-	primary *BirdNET // direct access to the primary model
+	mu        sync.RWMutex // protects the models map
+	models    map[string]*modelEntry
+	primary   *BirdNET // direct access to the primary model
+	modelsDir string   // base directory for gallery-installed models
 }
 
 // NewOrchestrator creates a new Orchestrator with BirdNET as the primary model
@@ -90,6 +93,55 @@ func NewOrchestrator(settings *conf.Settings) (*Orchestrator, error) {
 	}
 
 	return o, nil
+}
+
+// SetModelsDir sets the base directory for gallery-installed models.
+// Called by ModelManager after creation so model loaders can resolve
+// paths from the installed models directory when config paths are empty.
+func (o *Orchestrator) SetModelsDir(dir string) {
+	o.modelsDir = dir
+}
+
+// resolveInstalledPaths looks up catalog entries for the given registry ID
+// and returns the absolute paths for the first installed model found on disk.
+// Returns empty strings if no installed model is found.
+func (o *Orchestrator) resolveInstalledPaths(registryID string) (modelPath, labelsPath, embeddingsPath string) {
+	log := GetLogger()
+	if o.modelsDir == "" {
+		log.Debug("cannot resolve model paths: models directory not set",
+			logger.String("registry_id", registryID))
+		return "", "", ""
+	}
+	for i := range EmbeddedCatalog {
+		entry := &EmbeddedCatalog[i]
+		if entry.RegistryID != registryID {
+			continue
+		}
+		subdir := filepath.Join(o.modelsDir, entry.ID)
+		var mp, lp, ep string
+		for _, f := range entry.Files {
+			switch f.Role {
+			case RoleModel:
+				mp = filepath.Join(subdir, f.LocalName)
+			case RoleLabels:
+				lp = filepath.Join(subdir, f.LocalName)
+			case RoleEmbeddings:
+				ep = filepath.Join(o.modelsDir, "shared", f.LocalName)
+			}
+		}
+		if mp != "" {
+			if _, err := os.Stat(mp); err == nil {
+				log.Debug("resolved model paths from gallery",
+					logger.String("registry_id", registryID),
+					logger.String("model_path", mp))
+				return mp, lp, ep
+			}
+		}
+	}
+	log.Warn("model in models.enabled but not installed on disk",
+		logger.String("registry_id", registryID),
+		logger.String("models_dir", o.modelsDir))
+	return "", "", ""
 }
 
 // Predict runs inference using the primary model.

--- a/internal/classifier/orchestrator_bat_onnx.go
+++ b/internal/classifier/orchestrator_bat_onnx.go
@@ -10,16 +10,29 @@ import (
 // loadBat creates and registers a bat detection model instance from settings.
 func (o *Orchestrator) loadBat(threads int) error {
 	log := GetLogger()
-	if !o.Settings.Bat.Enabled {
-		log.Debug("Bat model disabled by configuration")
-		return nil
+
+	classifierModel := o.Settings.Bat.ClassifierModel
+	labelPath := o.Settings.Bat.LabelPath
+	embeddingModel := o.Settings.Bat.EmbeddingModel
+
+	if classifierModel == "" || labelPath == "" || embeddingModel == "" {
+		m, l, e := o.resolveInstalledPaths(RegistryIDBat)
+		if classifierModel == "" {
+			classifierModel = m
+		}
+		if labelPath == "" {
+			labelPath = l
+		}
+		if embeddingModel == "" {
+			embeddingModel = e
+		}
 	}
 
 	cfg := BatModelConfig{
-		EmbeddingModelPath:  o.Settings.Bat.EmbeddingModel,
+		EmbeddingModelPath:  embeddingModel,
 		EmbeddingLabels:     o.Settings.BirdNET.Labels,
-		ClassifierModelPath: o.Settings.Bat.ClassifierModel,
-		ClassifierLabelPath: o.Settings.Bat.LabelPath,
+		ClassifierModelPath: classifierModel,
+		ClassifierLabelPath: labelPath,
 		ONNXRuntimePath:     o.Settings.BirdNET.ONNXRuntimePath,
 		Threads:             threads,
 	}

--- a/internal/classifier/orchestrator_perch_onnx.go
+++ b/internal/classifier/orchestrator_perch_onnx.go
@@ -10,9 +10,23 @@ import (
 // loadPerch creates and registers a Perch v2 model instance from settings.
 func (o *Orchestrator) loadPerch(threads int) error {
 	log := GetLogger()
+
+	modelPath := o.Settings.Perch.ModelPath
+	labelPath := o.Settings.Perch.LabelPath
+
+	if modelPath == "" || labelPath == "" {
+		m, l, _ := o.resolveInstalledPaths(RegistryIDPerchV2)
+		if modelPath == "" {
+			modelPath = m
+		}
+		if labelPath == "" {
+			labelPath = l
+		}
+	}
+
 	cfg := PerchConfig{
-		ModelPath:       o.Settings.Perch.ModelPath,
-		LabelPath:       o.Settings.Perch.LabelPath,
+		ModelPath:       modelPath,
+		LabelPath:       labelPath,
 		ONNXRuntimePath: o.Settings.BirdNET.ONNXRuntimePath,
 		Threads:         threads,
 	}

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -1172,7 +1172,6 @@ type RangeFilterSettings struct {
 
 // PerchConfig holds configuration for the Google Perch v2 model.
 type PerchConfig struct {
-	Enabled   bool    `yaml:"enabled" json:"enabled"`                         // true to load Perch at startup
 	ModelPath string  `yaml:"modelpath,omitempty" json:"modelPath,omitempty"` // path to Perch v2 ONNX model file
 	LabelPath string  `yaml:"labelpath,omitempty" json:"labelPath,omitempty"` // path to Perch v2 label CSV file
 	Threshold float64 `yaml:"threshold" json:"threshold"`                     // confidence threshold for detections
@@ -1181,7 +1180,6 @@ type PerchConfig struct {
 
 // BatConfig holds configuration for bat detection using BirdNET v2.4 embeddings.
 type BatConfig struct {
-	Enabled         bool    `yaml:"enabled" json:"enabled"`                                     // true to load bat detection at startup
 	EmbeddingModel  string  `yaml:"embeddingmodel,omitempty" json:"embeddingModel,omitempty"`   // path to BirdNET v2.4 embeddings ONNX model
 	ClassifierModel string  `yaml:"classifiermodel,omitempty" json:"classifierModel,omitempty"` // path to bat species classifier ONNX model
 	LabelPath       string  `yaml:"labelpath,omitempty" json:"labelPath,omitempty"`             // path to bat species labels file
@@ -1191,7 +1189,6 @@ type BatConfig struct {
 
 // BSGConfig holds configuration for BSG regional bird models.
 type BSGConfig struct {
-	Enabled   bool   `yaml:"enabled" json:"enabled"`                         // true to load BSG model at startup
 	ModelPath string `yaml:"modelpath,omitempty" json:"modelPath,omitempty"` // path to BSG ONNX model file
 	LabelPath string `yaml:"labelpath,omitempty" json:"labelPath,omitempty"` // path to BSG label file
 	Locale    string `yaml:"locale,omitempty" json:"locale,omitempty"`       // locale for species label translation

--- a/internal/conf/defaults.go
+++ b/internal/conf/defaults.go
@@ -80,17 +80,10 @@ func setDefaultConfig() {
 	viper.SetDefault("birdnet.rangefilter.model", "latest")
 	viper.SetDefault("birdnet.rangefilter.threshold", 0.01)
 
-	// Perch model configuration (disabled by default)
-	viper.SetDefault("perch.enabled", false)
-	viper.SetDefault("perch.modelpath", "")
-	viper.SetDefault("perch.labelpath", "")
+	// Perch model configuration
 	viper.SetDefault("perch.threshold", 0.5)
 
-	// Bat detection configuration (disabled by default)
-	viper.SetDefault("bat.enabled", false)
-	viper.SetDefault("bat.embeddingmodel", "")
-	viper.SetDefault("bat.classifiermodel", "")
-	viper.SetDefault("bat.labelpath", "")
+	// Bat detection configuration
 	viper.SetDefault("bat.threshold", 0.5)
 
 	// Global model enablement (BirdNET only by default)

--- a/internal/conf/migrations.go
+++ b/internal/conf/migrations.go
@@ -380,23 +380,6 @@ func (s *Settings) ValidateModelConfig(knownIDs map[string]bool) []string {
 		}
 	}
 
-	if enabledSet[ModelIDPerchV2] && !s.Perch.Enabled {
-		issues = append(issues, "error: "+ModelIDPerchV2+" in models.enabled but perch.enabled is false")
-	}
-
-	if s.Perch.Enabled && !enabledSet[ModelIDPerchV2] {
-		issues = append(issues, "warning: perch.enabled is true but '"+ModelIDPerchV2+"' is not in models.enabled")
-	}
-
-	if s.Perch.Enabled {
-		if s.Perch.ModelPath == "" {
-			issues = append(issues, "error: perch.enabled is true but perch.modelpath is empty")
-		}
-		if s.Perch.LabelPath == "" {
-			issues = append(issues, "error: perch.enabled is true but perch.labelpath is empty")
-		}
-	}
-
 	for i := range s.Realtime.Audio.Sources {
 		src := &s.Realtime.Audio.Sources[i]
 		for _, modelID := range src.Models {

--- a/internal/conf/multi_model_config_test.go
+++ b/internal/conf/multi_model_config_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 // testKnownIDs mirrors classifier.KnownConfigIDs() for testing without circular imports.
-var testKnownIDs = map[string]bool{"birdnet": true, "perch_v2": true}
+var testKnownIDs = map[string]bool{"birdnet": true, "perch_v2": true, "bat": true, "bsg": true}
 
 func TestPerchConfig_Defaults(t *testing.T) {
 	t.Parallel()

--- a/internal/conf/multi_model_config_test.go
+++ b/internal/conf/multi_model_config_test.go
@@ -13,7 +13,6 @@ var testKnownIDs = map[string]bool{"birdnet": true, "perch_v2": true}
 func TestPerchConfig_Defaults(t *testing.T) {
 	t.Parallel()
 	settings := &Settings{}
-	assert.False(t, settings.Perch.Enabled)
 	assert.Empty(t, settings.Perch.ModelPath)
 	assert.Empty(t, settings.Perch.LabelPath)
 	assert.InDelta(t, 0.0, settings.Perch.Threshold, 0.001)
@@ -90,30 +89,12 @@ func TestMigrateSourceModels_StreamConfigMigration(t *testing.T) {
 	assert.Equal(t, []string{"birdnet"}, settings.Realtime.RTSP.Streams[0].Models)
 }
 
-func TestValidateModelConfig_PerchEnabledRequiresPaths(t *testing.T) {
-	t.Parallel()
-	settings := &Settings{}
-	settings.Perch.Enabled = true
-	settings.Models.Enabled = []string{"birdnet", "perch_v2"}
-	errs := settings.ValidateModelConfig(testKnownIDs)
-	assert.NotEmpty(t, errs, "should return errors when Perch enabled without paths")
-}
-
-func TestValidateModelConfig_PerchDisabledNoErrors(t *testing.T) {
+func TestValidateModelConfig_NoErrorsWithJustBirdNET(t *testing.T) {
 	t.Parallel()
 	settings := &Settings{}
 	settings.Models.Enabled = []string{"birdnet"}
 	errs := settings.ValidateModelConfig(testKnownIDs)
 	assert.Empty(t, errs, "should have no errors with just BirdNET")
-}
-
-func TestValidateModelConfig_PerchInModelsRequiresEnabled(t *testing.T) {
-	t.Parallel()
-	settings := &Settings{}
-	settings.Models.Enabled = []string{"birdnet", "perch_v2"}
-	settings.Perch.Enabled = false
-	errs := settings.ValidateModelConfig(testKnownIDs)
-	assert.NotEmpty(t, errs, "perch_v2 in models.enabled requires perch.enabled=true")
 }
 
 func TestValidateModelConfig_UnknownModelWarning(t *testing.T) {

--- a/internal/inference/onnx.go
+++ b/internal/inference/onnx.go
@@ -4,6 +4,8 @@ package inference
 
 import (
 	"fmt"
+	"os"
+	"runtime"
 	"sync"
 
 	ort "github.com/tphakala/birdnet-go/internal/inference/onnx"
@@ -218,7 +220,9 @@ func (r *onnxRangeFilter) Close() {
 }
 
 // InitONNXRuntime initializes the ONNX Runtime with the given shared library path.
-// Safe to call multiple times — skips if already initialized successfully.
+// When libraryPath is empty, searches standard system library paths for
+// libonnxruntime.so (Linux) or onnxruntime.dll (Windows).
+// Safe to call multiple times; skips if already initialized successfully.
 // On failure, allows retry with a corrected path (supports hot-reload recovery).
 func InitONNXRuntime(libraryPath string) (err error) {
 	ortInitMu.Lock()
@@ -226,6 +230,10 @@ func InitONNXRuntime(libraryPath string) (err error) {
 
 	if ortInitialized {
 		return nil
+	}
+
+	if libraryPath == "" {
+		libraryPath = findONNXRuntimeLibrary()
 	}
 
 	defer func() {
@@ -237,6 +245,30 @@ func InitONNXRuntime(libraryPath string) (err error) {
 	ort.MustInitORT(libraryPath)
 	ortInitialized = true
 	return nil
+}
+
+// findONNXRuntimeLibrary searches standard system paths for the ONNX Runtime
+// shared library. Returns the first path found, or "onnxruntime" as a
+// fallback for dlopen's default search.
+func findONNXRuntimeLibrary() string {
+	var candidates []string
+	if runtime.GOOS == "windows" {
+		candidates = []string{"onnxruntime.dll"}
+	} else {
+		candidates = []string{
+			"/usr/lib/libonnxruntime.so",
+			"/usr/local/lib/libonnxruntime.so",
+			"/usr/lib/aarch64-linux-gnu/libonnxruntime.so",
+			"/usr/lib/x86_64-linux-gnu/libonnxruntime.so",
+			"libonnxruntime.so",
+		}
+	}
+	for _, path := range candidates {
+		if _, err := os.Stat(path); err == nil {
+			return path
+		}
+	}
+	return "onnxruntime"
 }
 
 // DestroyONNXRuntime tears down the ONNX Runtime environment.


### PR DESCRIPTION
## Summary

- Remove redundant `Enabled` bool from `PerchConfig`, `BatConfig`, and `BSGConfig`. Model loading is now driven solely by the `models.enabled` list and per-source model assignments
- When config paths are empty, model loaders (`loadPerch`, `loadBat`) resolve files from the gallery's installed models directory via `resolveInstalledPaths`, eliminating the race where `applyConfigForInstall`'s config save could be overwritten by a concurrent settings API save
- Make optional model (Perch, Bat, BSG) load failures non-fatal at startup so the primary BirdNET model always starts
- Load gallery-installed models after `ScanInstalled` discovers them (fixes timing issue where orchestrator was created before gallery scan)
- Fix deadlock in `ScanInstalled` caused by re-entrant mutex acquisition when loading installed models
- Auto-detect ONNX Runtime library from standard system paths (`/usr/lib/libonnxruntime.so`, etc.) when `ONNXRuntimePath` is not configured

## Test Plan

- [x] Build passes, lint clean, all tests pass
- [x] Verified on live aarch64 system (192.168.4.159): Perch v2 loads from gallery, runs inference at ~680ms/cycle alongside BirdNET v2.4
- [x] Verified ONNX Runtime auto-detection finds `/usr/lib/libonnxruntime.so`
- [x] Verified startup with missing/uninstalled model produces warning, not crash
- [x] Verified no deadlock on startup (previously hung at `ScanInstalled`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic discovery and loading of gallery-installed models without requiring explicit configuration flags.
  * Added automatic detection of ONNX Runtime shared libraries for simpler runtime setup.
  * Added model load status checking capability.

* **Bug Fixes**
  * Improved model initialization to gracefully handle secondary model loading failures and allow retries.

* **Refactor**
  * Simplified model configuration by removing per-model enablement flags; model availability is now determined by installation and configuration paths.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3006)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->