### PR TITLE
fix(datastore): complete convertFilters and atomicize SaveReview

### DIFF
--- a/internal/datastore/v2/repository/detection_impl.go
+++ b/internal/datastore/v2/repository/detection_impl.go
@@ -1097,31 +1097,15 @@ func (r *detectionRepository) DeletePredictions(ctx context.Context, detectionID
 // ============================================================================
 
 // SaveReview creates or updates a review for a detection.
+// Uses INSERT...ON CONFLICT to avoid TOCTOU between existence check and insert.
+// Idempotent: re-saving updates the verified status and timestamp.
 func (r *detectionRepository) SaveReview(ctx context.Context, review *entities.DetectionReview) error {
-	// Check if review exists
-	var existing entities.DetectionReview
-	err := r.db.WithContext(ctx).Table(r.reviewsTable()).
-		Where("detection_id = ?", review.DetectionID).
-		First(&existing).Error
-
-	if errors.Is(err, gorm.ErrRecordNotFound) {
-		// Create new review
-		return datastore.RetryOnLock(ctx, "v2_save_review", func() error {
-			return r.db.WithContext(ctx).Table(r.reviewsTable()).Create(review).Error
-		}, r.metrics)
-	}
-	if err != nil {
-		return err
-	}
-
-	// Update existing review
-	return datastore.RetryOnLock(ctx, "v2_save_review_update", func() error {
-		return r.db.WithContext(ctx).Table(r.reviewsTable()).
-			Where("detection_id = ?", review.DetectionID).
-			Updates(map[string]any{
-				"verified":   review.Verified,
-				"updated_at": time.Now(),
-			}).Error
+	return datastore.RetryOnLock(ctx, "v2_save_review", func() error {
+		now := time.Now()
+		return r.db.WithContext(ctx).Exec(
+			fmt.Sprintf("INSERT INTO %s (detection_id, verified, created_at, updated_at) VALUES (?, ?, ?, ?) ON CONFLICT(detection_id) DO UPDATE SET verified = excluded.verified, updated_at = excluded.updated_at",
+				r.reviewsTable()),
+			review.DetectionID, string(review.Verified), now, now).Error
 	}, r.metrics)
 }
 

--- a/internal/datastore/v2/repository/detection_impl.go
+++ b/internal/datastore/v2/repository/detection_impl.go
@@ -1097,15 +1097,21 @@ func (r *detectionRepository) DeletePredictions(ctx context.Context, detectionID
 // ============================================================================
 
 // SaveReview creates or updates a review for a detection.
-// Uses INSERT...ON CONFLICT to avoid TOCTOU between existence check and insert.
+// Uses GORM's clause.OnConflict for dialect-aware upsert (SQLite + MySQL).
 // Idempotent: re-saving updates the verified status and timestamp.
 func (r *detectionRepository) SaveReview(ctx context.Context, review *entities.DetectionReview) error {
 	return datastore.RetryOnLock(ctx, "v2_save_review", func() error {
 		now := time.Now()
-		return r.db.WithContext(ctx).Exec(
-			fmt.Sprintf("INSERT INTO %s (detection_id, verified, created_at, updated_at) VALUES (?, ?, ?, ?) ON CONFLICT(detection_id) DO UPDATE SET verified = excluded.verified, updated_at = excluded.updated_at",
-				r.reviewsTable()),
-			review.DetectionID, string(review.Verified), now, now).Error
+		review.UpdatedAt = now
+		return r.db.WithContext(ctx).Table(r.reviewsTable()).
+			Clauses(clause.OnConflict{
+				Columns: []clause.Column{{Name: "detection_id"}},
+				DoUpdates: clause.Assignments(map[string]any{
+					"verified":   string(review.Verified),
+					"updated_at": now,
+				}),
+			}).
+			Create(review).Error
 	}, r.metrics)
 }
 

--- a/internal/datastore/v2/repository/dual_write.go
+++ b/internal/datastore/v2/repository/dual_write.go
@@ -907,14 +907,14 @@ func (dw *DualWriteRepository) convertFilters(filters *datastore.DetectionFilter
 		}
 		if filters.EndDate != "" {
 			if t, err := time.ParseInLocation(time.DateOnly, filters.EndDate, time.Local); err == nil {
-				end := t.Add(24*time.Hour - time.Nanosecond).Unix()
+				end := t.Add(24 * time.Hour).Unix()
 				sf.EndTime = &end
 			}
 		}
 	} else if filters.Date != "" {
 		if t, err := time.ParseInLocation(time.DateOnly, filters.Date, time.Local); err == nil {
 			start := t.Unix()
-			end := t.Add(24*time.Hour - time.Nanosecond).Unix()
+			end := t.Add(24 * time.Hour).Unix()
 			sf.StartTime = &start
 			sf.EndTime = &end
 		}

--- a/internal/datastore/v2/repository/dual_write.go
+++ b/internal/datastore/v2/repository/dual_write.go
@@ -891,11 +891,32 @@ func (dw *DualWriteRepository) convertFilters(filters *datastore.DetectionFilter
 		sf.IsLocked = filters.Locked
 	}
 
-	// Convert verified filter
+	// Convert verified filter: legacy Verified=true means "has a review",
+	// Verified=false means "no review or empty verdict"
 	if filters.Verified != nil {
-		if *filters.Verified {
-			v := VerificationFilter(entities.VerificationCorrect)
-			sf.Verified = &v
+		sf.IsReviewed = filters.Verified
+	}
+
+	// Convert date filters to Unix timestamps
+	if filters.StartDate != "" || filters.EndDate != "" {
+		if filters.StartDate != "" {
+			if t, err := time.ParseInLocation(time.DateOnly, filters.StartDate, time.Local); err == nil {
+				start := t.Unix()
+				sf.StartTime = &start
+			}
+		}
+		if filters.EndDate != "" {
+			if t, err := time.ParseInLocation(time.DateOnly, filters.EndDate, time.Local); err == nil {
+				end := t.Add(24*time.Hour - time.Nanosecond).Unix()
+				sf.EndTime = &end
+			}
+		}
+	} else if filters.Date != "" {
+		if t, err := time.ParseInLocation(time.DateOnly, filters.Date, time.Local); err == nil {
+			start := t.Unix()
+			end := t.Add(24*time.Hour - time.Nanosecond).Unix()
+			sf.StartTime = &start
+			sf.EndTime = &end
 		}
 	}
 

--- a/internal/datastore/v2/repository/dual_write.go
+++ b/internal/datastore/v2/repository/dual_write.go
@@ -907,14 +907,14 @@ func (dw *DualWriteRepository) convertFilters(filters *datastore.DetectionFilter
 		}
 		if filters.EndDate != "" {
 			if t, err := time.ParseInLocation(time.DateOnly, filters.EndDate, time.Local); err == nil {
-				end := t.Add(24 * time.Hour).Unix()
+				end := t.AddDate(0, 0, 1).Unix()
 				sf.EndTime = &end
 			}
 		}
 	} else if filters.Date != "" {
 		if t, err := time.ParseInLocation(time.DateOnly, filters.Date, time.Local); err == nil {
 			start := t.Unix()
-			end := t.Add(24 * time.Hour).Unix()
+			end := t.AddDate(0, 0, 1).Unix()
 			sf.StartTime = &start
 			sf.EndTime = &end
 		}

--- a/internal/datastore/v2/repository/dual_write_test.go
+++ b/internal/datastore/v2/repository/dual_write_test.go
@@ -4,11 +4,11 @@ import (
 	"io"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/datastore"
-	"github.com/tphakala/birdnet-go/internal/datastore/v2/entities"
 	"github.com/tphakala/birdnet-go/internal/logger"
 )
 
@@ -39,11 +39,77 @@ func TestConvertFilters_PreservesAllFields(t *testing.T) {
 	assert.InDelta(t, minConf, *sf.MinConfidence, 0.001)
 	require.NotNil(t, sf.IsLocked)
 	assert.True(t, *sf.IsLocked)
-	require.NotNil(t, sf.Verified)
-	assert.Equal(t, VerificationFilter(entities.VerificationCorrect), *sf.Verified)
+	require.NotNil(t, sf.IsReviewed)
+	assert.True(t, *sf.IsReviewed)
 	assert.Equal(t, 25, sf.Limit)
 	assert.Equal(t, 10, sf.Offset)
 	assert.True(t, sf.SortDesc)
+}
+
+func TestConvertFilters_VerifiedFalse(t *testing.T) {
+	t.Parallel()
+
+	verified := false
+	filters := &datastore.DetectionFilters{
+		Verified: &verified,
+	}
+
+	dw := &DualWriteRepository{}
+	sf := dw.convertFilters(filters)
+
+	require.NotNil(t, sf.IsReviewed)
+	assert.False(t, *sf.IsReviewed)
+}
+
+func TestConvertFilters_DateRange(t *testing.T) {
+	t.Parallel()
+
+	filters := &datastore.DetectionFilters{
+		StartDate: "2024-06-15",
+		EndDate:   "2024-06-17",
+	}
+
+	dw := &DualWriteRepository{}
+	sf := dw.convertFilters(filters)
+
+	require.NotNil(t, sf.StartTime)
+	require.NotNil(t, sf.EndTime)
+
+	startExpected := time.Date(2024, 6, 15, 0, 0, 0, 0, time.Local).Unix()
+	endExpected := time.Date(2024, 6, 17, 23, 59, 59, 999999999, time.Local).Unix()
+
+	assert.Equal(t, startExpected, *sf.StartTime)
+	assert.Equal(t, endExpected, *sf.EndTime)
+}
+
+func TestConvertFilters_SingleDate(t *testing.T) {
+	t.Parallel()
+
+	filters := &datastore.DetectionFilters{
+		Date: "2024-06-15",
+	}
+
+	dw := &DualWriteRepository{}
+	sf := dw.convertFilters(filters)
+
+	require.NotNil(t, sf.StartTime)
+	require.NotNil(t, sf.EndTime)
+
+	startExpected := time.Date(2024, 6, 15, 0, 0, 0, 0, time.Local).Unix()
+	assert.Equal(t, startExpected, *sf.StartTime)
+	assert.Greater(t, *sf.EndTime, *sf.StartTime)
+}
+
+func TestConvertFilters_NoDates(t *testing.T) {
+	t.Parallel()
+
+	filters := &datastore.DetectionFilters{}
+
+	dw := &DualWriteRepository{}
+	sf := dw.convertFilters(filters)
+
+	assert.Nil(t, sf.StartTime)
+	assert.Nil(t, sf.EndTime)
 }
 
 func TestConvertFilters_ConfidenceOperators(t *testing.T) {

--- a/internal/datastore/v2/repository/dual_write_test.go
+++ b/internal/datastore/v2/repository/dual_write_test.go
@@ -76,7 +76,7 @@ func TestConvertFilters_DateRange(t *testing.T) {
 	require.NotNil(t, sf.EndTime)
 
 	startExpected := time.Date(2024, 6, 15, 0, 0, 0, 0, time.Local).Unix()
-	endExpected := time.Date(2024, 6, 17, 23, 59, 59, 999999999, time.Local).Unix()
+	endExpected := time.Date(2024, 6, 18, 0, 0, 0, 0, time.Local).Unix()
 
 	assert.Equal(t, startExpected, *sf.StartTime)
 	assert.Equal(t, endExpected, *sf.EndTime)


### PR DESCRIPTION
## Summary

Follow-up to PR #3009 addressing remaining quality items in the v2 dual-write layer.

- **convertFilters**: add date range conversion (StartDate/EndDate/Date to StartTime/EndTime Unix timestamps) and fix Verified mapping (legacy Verified=true/false maps to IsReviewed, not VerificationCorrect)
- **SaveReview**: replace TOCTOU select-then-insert with atomic INSERT...ON CONFLICT upsert

### Validated and skipped

- **GetModelStats N+1 queries**: zero callers in production, dead code on the interface. Not worth optimizing.

## Test Plan

- [x] 5 new tests: Verified=false, date range, single date, no dates, existing filter preservation updated
- [x] Full package suite: 168 tests pass with `-race`
- [x] Zero lint issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Detection review saving is now atomic to improve reliability and consistency.

* **New Features**
  * "Verified" filter now maps directly to the reviewed flag.
  * Date-based filtering: support for start/end date ranges and single-date queries using local day boundaries.

* **Tests**
  * Added/expanded tests covering filter conversion, verification mapping, pagination, ordering, and date handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3010)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->