### PR TITLE
test(datastore): add missing Lock, SaveReview, and DeleteBatch coverage

### DIFF
--- a/internal/datastore/v2/repository/detection_impl_test.go
+++ b/internal/datastore/v2/repository/detection_impl_test.go
@@ -43,25 +43,33 @@ func createTestDetection(t *testing.T, db *gorm.DB, detectedAt int64) *entities.
 	return det
 }
 
+func createBulkDetections(t *testing.T, db *gorm.DB, count int) (dets []*entities.Detection, ids []uint) {
+	t.Helper()
+	dets = make([]*entities.Detection, count)
+	for i := range dets {
+		dets[i] = &entities.Detection{LabelID: 1, ModelID: 1, Confidence: 0.9, DetectedAt: int64(1000 + i)}
+	}
+	require.NoError(t, db.Table(tableDetections).CreateInBatches(dets, 100).Error)
+	ids = make([]uint, count)
+	for i, d := range dets {
+		ids[i] = d.ID
+	}
+	return dets, ids
+}
+
 func TestDeleteBatch_SkipsLockedDetections(t *testing.T) {
 	db := setupDetectionTestDB(t)
 	ctx := t.Context()
 
 	repo := &detectionRepository{db: db}
 
-	det1 := &entities.Detection{LabelID: 1, ModelID: 1, Confidence: 0.9, DetectedAt: 1000}
-	det2 := &entities.Detection{LabelID: 1, ModelID: 1, Confidence: 0.8, DetectedAt: 2000}
-	det3 := &entities.Detection{LabelID: 1, ModelID: 1, Confidence: 0.7, DetectedAt: 3000}
+	det1 := createTestDetection(t, db, 1000)
+	det2 := createTestDetection(t, db, 2000)
+	det3 := createTestDetection(t, db, 3000)
 
-	require.NoError(t, db.Table(tableDetections).Create(det1).Error)
-	require.NoError(t, db.Table(tableDetections).Create(det2).Error)
-	require.NoError(t, db.Table(tableDetections).Create(det3).Error)
-
-	// Lock det2
 	lock := &entities.DetectionLock{DetectionID: det2.ID}
 	require.NoError(t, db.Table(tableDetectionLocks).Create(lock).Error)
 
-	// DeleteBatch all three - should skip det2
 	err := repo.DeleteBatch(ctx, []uint{det1.ID, det2.ID, det3.ID})
 	require.NoError(t, err)
 
@@ -88,11 +96,8 @@ func TestDeleteBatch_AllUnlocked(t *testing.T) {
 
 	repo := &detectionRepository{db: db}
 
-	det1 := &entities.Detection{LabelID: 1, ModelID: 1, Confidence: 0.9, DetectedAt: 1000}
-	det2 := &entities.Detection{LabelID: 1, ModelID: 1, Confidence: 0.8, DetectedAt: 2000}
-
-	require.NoError(t, db.Table(tableDetections).Create(det1).Error)
-	require.NoError(t, db.Table(tableDetections).Create(det2).Error)
+	det1 := createTestDetection(t, db, 1000)
+	det2 := createTestDetection(t, db, 2000)
 
 	err := repo.DeleteBatch(ctx, []uint{det1.ID, det2.ID})
 	require.NoError(t, err)
@@ -108,16 +113,7 @@ func TestDeleteBatch_ChunksLargeBatch(t *testing.T) {
 
 	repo := &detectionRepository{db: db}
 
-	// Create 501 detections to force chunking (batchQuerySize is 500)
-	dets := make([]*entities.Detection, 501)
-	ids := make([]uint, 501)
-	for i := range dets {
-		dets[i] = &entities.Detection{LabelID: 1, ModelID: 1, Confidence: 0.9, DetectedAt: int64(1000 + i)}
-	}
-	require.NoError(t, db.Table(tableDetections).CreateInBatches(dets, 100).Error)
-	for i, d := range dets {
-		ids[i] = d.ID
-	}
+	_, ids := createBulkDetections(t, db, batchQuerySize+1)
 
 	err := repo.DeleteBatch(ctx, ids)
 	require.NoError(t, err)
@@ -133,21 +129,10 @@ func TestDeleteBatch_ChunksRemainderCorrectly(t *testing.T) {
 
 	repo := &detectionRepository{db: db}
 
-	// Create exactly batchQuerySize + 1 detections, lock the last one.
 	// The remainder chunk (1 item) must still execute and respect the lock.
-	total := batchQuerySize + 1
-	dets := make([]*entities.Detection, total)
-	ids := make([]uint, total)
-	for i := range dets {
-		dets[i] = &entities.Detection{LabelID: 1, ModelID: 1, Confidence: 0.9, DetectedAt: int64(1000 + i)}
-	}
-	require.NoError(t, db.Table(tableDetections).CreateInBatches(dets, 100).Error)
-	for i, d := range dets {
-		ids[i] = d.ID
-	}
+	dets, ids := createBulkDetections(t, db, batchQuerySize+1)
 
-	// Lock the last detection (which falls in the remainder chunk)
-	lock := &entities.DetectionLock{DetectionID: dets[total-1].ID}
+	lock := &entities.DetectionLock{DetectionID: dets[len(dets)-1].ID}
 	require.NoError(t, db.Table(tableDetectionLocks).Create(lock).Error)
 
 	err := repo.DeleteBatch(ctx, ids)
@@ -156,7 +141,7 @@ func TestDeleteBatch_ChunksRemainderCorrectly(t *testing.T) {
 	var remaining []entities.Detection
 	require.NoError(t, db.Table(tableDetections).Find(&remaining).Error)
 	require.Len(t, remaining, 1)
-	assert.Equal(t, dets[total-1].ID, remaining[0].ID)
+	assert.Equal(t, dets[len(dets)-1].ID, remaining[0].ID)
 }
 
 // ============================================================================
@@ -313,7 +298,6 @@ func TestSaveReview_UpdatedAtChangesOnUpsert(t *testing.T) {
 	// Small delay to ensure timestamp differs
 	time.Sleep(10 * time.Millisecond)
 
-	// Upsert same status
 	review2 := &entities.DetectionReview{
 		DetectionID: det.ID,
 		Verified:    entities.VerificationFalsePositive,

--- a/internal/datastore/v2/repository/detection_impl_test.go
+++ b/internal/datastore/v2/repository/detection_impl_test.go
@@ -1,7 +1,9 @@
 package repository
 
 import (
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -27,10 +29,18 @@ func setupDetectionTestDB(t *testing.T) *gorm.DB {
 	err = db.AutoMigrate(
 		&entities.Detection{},
 		&entities.DetectionLock{},
+		&entities.DetectionReview{},
 	)
 	require.NoError(t, err, "failed to migrate detection tables")
 
 	return db
+}
+
+func createTestDetection(t *testing.T, db *gorm.DB, detectedAt int64) *entities.Detection {
+	t.Helper()
+	det := &entities.Detection{LabelID: 1, ModelID: 1, Confidence: 0.9, DetectedAt: detectedAt}
+	require.NoError(t, db.Table(tableDetections).Create(det).Error)
+	return det
 }
 
 func TestDeleteBatch_SkipsLockedDetections(t *testing.T) {
@@ -90,4 +100,264 @@ func TestDeleteBatch_AllUnlocked(t *testing.T) {
 	var remaining []entities.Detection
 	require.NoError(t, db.Table(tableDetections).Find(&remaining).Error)
 	assert.Empty(t, remaining)
+}
+
+func TestDeleteBatch_ChunksLargeBatch(t *testing.T) {
+	db := setupDetectionTestDB(t)
+	ctx := t.Context()
+
+	repo := &detectionRepository{db: db}
+
+	// Create 501 detections to force chunking (batchQuerySize is 500)
+	dets := make([]*entities.Detection, 501)
+	ids := make([]uint, 501)
+	for i := range dets {
+		dets[i] = &entities.Detection{LabelID: 1, ModelID: 1, Confidence: 0.9, DetectedAt: int64(1000 + i)}
+	}
+	require.NoError(t, db.Table(tableDetections).CreateInBatches(dets, 100).Error)
+	for i, d := range dets {
+		ids[i] = d.ID
+	}
+
+	err := repo.DeleteBatch(ctx, ids)
+	require.NoError(t, err)
+
+	var count int64
+	require.NoError(t, db.Table(tableDetections).Count(&count).Error)
+	assert.Equal(t, int64(0), count)
+}
+
+func TestDeleteBatch_ChunksRemainderCorrectly(t *testing.T) {
+	db := setupDetectionTestDB(t)
+	ctx := t.Context()
+
+	repo := &detectionRepository{db: db}
+
+	// Create exactly batchQuerySize + 1 detections, lock the last one.
+	// The remainder chunk (1 item) must still execute and respect the lock.
+	total := batchQuerySize + 1
+	dets := make([]*entities.Detection, total)
+	ids := make([]uint, total)
+	for i := range dets {
+		dets[i] = &entities.Detection{LabelID: 1, ModelID: 1, Confidence: 0.9, DetectedAt: int64(1000 + i)}
+	}
+	require.NoError(t, db.Table(tableDetections).CreateInBatches(dets, 100).Error)
+	for i, d := range dets {
+		ids[i] = d.ID
+	}
+
+	// Lock the last detection (which falls in the remainder chunk)
+	lock := &entities.DetectionLock{DetectionID: dets[total-1].ID}
+	require.NoError(t, db.Table(tableDetectionLocks).Create(lock).Error)
+
+	err := repo.DeleteBatch(ctx, ids)
+	require.NoError(t, err)
+
+	var remaining []entities.Detection
+	require.NoError(t, db.Table(tableDetections).Find(&remaining).Error)
+	require.Len(t, remaining, 1)
+	assert.Equal(t, dets[total-1].ID, remaining[0].ID)
+}
+
+// ============================================================================
+// Lock Tests
+// ============================================================================
+
+func TestLock_ExistingUnlocked(t *testing.T) {
+	db := setupDetectionTestDB(t)
+	ctx := t.Context()
+
+	repo := &detectionRepository{db: db}
+	det := createTestDetection(t, db, 1000)
+
+	err := repo.Lock(ctx, det.ID)
+	require.NoError(t, err)
+
+	locked, err := repo.IsLocked(ctx, det.ID)
+	require.NoError(t, err)
+	assert.True(t, locked)
+}
+
+func TestLock_AlreadyLockedIsIdempotent(t *testing.T) {
+	db := setupDetectionTestDB(t)
+	ctx := t.Context()
+
+	repo := &detectionRepository{db: db}
+	det := createTestDetection(t, db, 1000)
+
+	require.NoError(t, repo.Lock(ctx, det.ID))
+
+	// Second lock should succeed silently
+	err := repo.Lock(ctx, det.ID)
+	require.NoError(t, err)
+
+	// Should still be exactly one lock row
+	var count int64
+	require.NoError(t, db.Table(tableDetectionLocks).Where("detection_id = ?", det.ID).Count(&count).Error)
+	assert.Equal(t, int64(1), count)
+}
+
+func TestLock_NonexistentDetection(t *testing.T) {
+	db := setupDetectionTestDB(t)
+	ctx := t.Context()
+
+	repo := &detectionRepository{db: db}
+
+	err := repo.Lock(ctx, 99999)
+	require.ErrorIs(t, err, ErrDetectionNotFound)
+}
+
+func TestLock_ConcurrentCallsNoDuplicates(t *testing.T) {
+	db := setupDetectionTestDB(t)
+	ctx := t.Context()
+
+	repo := &detectionRepository{db: db}
+	det := createTestDetection(t, db, 1000)
+
+	const goroutines = 10
+	errs := make(chan error, goroutines)
+	var wg sync.WaitGroup
+
+	for range goroutines {
+		wg.Go(func() {
+			errs <- repo.Lock(ctx, det.ID)
+		})
+	}
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		require.NoError(t, err)
+	}
+
+	// Exactly one lock row regardless of concurrency
+	var count int64
+	require.NoError(t, db.Table(tableDetectionLocks).Where("detection_id = ?", det.ID).Count(&count).Error)
+	assert.Equal(t, int64(1), count)
+}
+
+// ============================================================================
+// SaveReview Tests
+// ============================================================================
+
+func TestSaveReview_CreateNew(t *testing.T) {
+	db := setupDetectionTestDB(t)
+	ctx := t.Context()
+
+	repo := &detectionRepository{db: db}
+	det := createTestDetection(t, db, 1000)
+
+	review := &entities.DetectionReview{
+		DetectionID: det.ID,
+		Verified:    entities.VerificationCorrect,
+	}
+
+	err := repo.SaveReview(ctx, review)
+	require.NoError(t, err)
+
+	got, err := repo.GetReview(ctx, det.ID)
+	require.NoError(t, err)
+	assert.Equal(t, entities.VerificationCorrect, got.Verified)
+	assert.Equal(t, det.ID, got.DetectionID)
+}
+
+func TestSaveReview_UpsertExisting(t *testing.T) {
+	db := setupDetectionTestDB(t)
+	ctx := t.Context()
+
+	repo := &detectionRepository{db: db}
+	det := createTestDetection(t, db, 1000)
+
+	// Create initial review
+	review := &entities.DetectionReview{
+		DetectionID: det.ID,
+		Verified:    entities.VerificationCorrect,
+	}
+	require.NoError(t, repo.SaveReview(ctx, review))
+
+	// Upsert with different status
+	review2 := &entities.DetectionReview{
+		DetectionID: det.ID,
+		Verified:    entities.VerificationFalsePositive,
+	}
+	err := repo.SaveReview(ctx, review2)
+	require.NoError(t, err)
+
+	got, err := repo.GetReview(ctx, det.ID)
+	require.NoError(t, err)
+	assert.Equal(t, entities.VerificationFalsePositive, got.Verified)
+
+	// Should still be exactly one review row
+	var count int64
+	require.NoError(t, db.Table(tableDetectionReviews).Where("detection_id = ?", det.ID).Count(&count).Error)
+	assert.Equal(t, int64(1), count)
+}
+
+func TestSaveReview_UpdatedAtChangesOnUpsert(t *testing.T) {
+	db := setupDetectionTestDB(t)
+	ctx := t.Context()
+
+	repo := &detectionRepository{db: db}
+	det := createTestDetection(t, db, 1000)
+
+	review := &entities.DetectionReview{
+		DetectionID: det.ID,
+		Verified:    entities.VerificationCorrect,
+	}
+	require.NoError(t, repo.SaveReview(ctx, review))
+
+	first, err := repo.GetReview(ctx, det.ID)
+	require.NoError(t, err)
+	firstUpdated := first.UpdatedAt
+
+	// Small delay to ensure timestamp differs
+	time.Sleep(10 * time.Millisecond)
+
+	// Upsert same status
+	review2 := &entities.DetectionReview{
+		DetectionID: det.ID,
+		Verified:    entities.VerificationFalsePositive,
+	}
+	require.NoError(t, repo.SaveReview(ctx, review2))
+
+	second, err := repo.GetReview(ctx, det.ID)
+	require.NoError(t, err)
+	assert.True(t, second.UpdatedAt.After(firstUpdated),
+		"UpdatedAt should advance on upsert: first=%v, second=%v", firstUpdated, second.UpdatedAt)
+}
+
+func TestSaveReview_ConcurrentUpsertNoDuplicates(t *testing.T) {
+	db := setupDetectionTestDB(t)
+	ctx := t.Context()
+
+	repo := &detectionRepository{db: db}
+	det := createTestDetection(t, db, 1000)
+
+	const goroutines = 10
+	errs := make(chan error, goroutines)
+	var wg sync.WaitGroup
+
+	for i := range goroutines {
+		wg.Go(func() {
+			status := entities.VerificationCorrect
+			if i%2 == 0 {
+				status = entities.VerificationFalsePositive
+			}
+			errs <- repo.SaveReview(ctx, &entities.DetectionReview{
+				DetectionID: det.ID,
+				Verified:    status,
+			})
+		})
+	}
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		require.NoError(t, err)
+	}
+
+	// Exactly one review row regardless of concurrency
+	var count int64
+	require.NoError(t, db.Table(tableDetectionReviews).Where("detection_id = ?", det.ID).Count(&count).Error)
+	assert.Equal(t, int64(1), count)
 }


### PR DESCRIPTION
## Summary

- Add 10 new tests for the v2 detection repository covering `Lock`, `SaveReview`, and `DeleteBatch` methods
- Lock tests: existing unlocked succeeds, already-locked is idempotent, nonexistent returns `ErrDetectionNotFound`, concurrent calls produce exactly one row
- SaveReview tests: create new, upsert updates status, `UpdatedAt` advances on upsert, concurrent upserts produce exactly one row
- DeleteBatch tests: batch > `batchQuerySize` (500) is chunked correctly, remainder chunk respects locks
- Migrate `DetectionReview` in `setupDetectionTestDB` and extract `createTestDetection` helper

Closes #578

## Test plan

- [x] All 178 tests in `./internal/datastore/v2/repository/` pass with `-race`
- [x] `golangci-lint` reports zero issues on the package
- [x] Concurrent tests verify no duplicate rows under contention

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for detection persistence: batch deletion with large batches and remainder chunking.
  * Added locking tests: lock acquisition, idempotency, nonexistent-item handling, and concurrency safety.
  * Added review persistence tests: create, upsert (ensuring timestamp updates), and concurrent upsert safety.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3011)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->