### PR TITLE
feat(observability): per-model inference time tracking

### DIFF
--- a/frontend/src/lib/desktop/features/system/components/MetricStrip.svelte
+++ b/frontend/src/lib/desktop/features/system/components/MetricStrip.svelte
@@ -4,6 +4,15 @@
   import { formatBytesCompact } from '$lib/utils/formatters';
   import Sparkline from './Sparkline.svelte';
 
+  interface ModelMetrics {
+    id: string;
+    name: string;
+    metricKey: string;
+    chunkSeconds: number;
+    history: number[];
+    color: string;
+  }
+
   interface Props {
     cpuPercent: number;
     cpuCores: number;
@@ -17,10 +26,8 @@
     temperatureValue: number;
     temperatureHistory: number[];
     tempSymbol: string;
-    inferenceAvgMs: number;
-    inferenceHistory: number[];
-    hasInferenceData: boolean;
-    inferenceThresholdMs?: number;
+    models: ModelMetrics[];
+    birdnetOverlap: number;
   }
 
   let {
@@ -36,28 +43,58 @@
     temperatureValue,
     temperatureHistory,
     tempSymbol,
-    inferenceAvgMs,
-    inferenceHistory,
-    hasInferenceData,
-    inferenceThresholdMs,
+    models,
+    birdnetOverlap,
   }: Props = $props();
 
   const sparklineColorCpu = '#3b82f6';
   const sparklineColorMemory = '#8b5cf6';
   const sparklineColorTemperature = '#f97316';
-  const sparklineColorInference = '#14b8a6';
 
   let hasTempHistory = $derived(temperatureHistory.length > 0);
   let tempMin = $derived(hasTempHistory ? Math.min(...temperatureHistory) : temperatureValue);
   let tempMax = $derived(hasTempHistory ? Math.max(...temperatureHistory) : temperatureValue);
 
-  // Inference status based on avg vs threshold: OK < 70%, WARNING 70-100%, CRITICAL >= 100%
-  let inferenceStatus = $derived.by(() => {
-    if (!hasInferenceData || inferenceThresholdMs == null) return null;
-    const ratio = inferenceAvgMs / inferenceThresholdMs;
-    if (ratio >= 1.0) return 'critical' as const;
-    if (ratio >= 0.7) return 'warning' as const;
-    return 'ok' as const;
+  let hasInferenceData = $derived(models.some(m => m.history.length > 0));
+
+  function getThresholdMs(model: ModelMetrics): number {
+    if (model.id.startsWith('BirdNET')) {
+      return (model.chunkSeconds - birdnetOverlap) * 1000;
+    }
+    return model.chunkSeconds * 1000;
+  }
+
+  type StatusLevel = 'ok' | 'warning' | 'critical';
+
+  function getModelStatus(model: ModelMetrics): StatusLevel | null {
+    if (model.history.length === 0) return null;
+    const avgMs = model.history[model.history.length - 1];
+    const threshold = getThresholdMs(model);
+    const ratio = avgMs / threshold;
+    if (ratio >= 1.0) return 'critical';
+    if (ratio >= 0.7) return 'warning';
+    return 'ok';
+  }
+
+  let worstStatus = $derived.by((): StatusLevel | null => {
+    const priority: Record<StatusLevel, number> = { ok: 0, warning: 1, critical: 2 };
+    let worst: StatusLevel | null = null;
+    for (const m of models) {
+      const s = getModelStatus(m);
+      if (s == null) continue;
+      if (worst == null || priority[s] > priority[worst]) worst = s;
+    }
+    return worst;
+  });
+
+  let inferenceDatasets = $derived(
+    models.filter(m => m.history.length > 0).map(m => ({ data: m.history, color: m.color }))
+  );
+
+  let primaryAvgMs = $derived.by(() => {
+    const withData = models.filter(m => m.history.length > 0);
+    if (withData.length === 0) return 0;
+    return withData[0].history[withData[0].history.length - 1];
   });
 </script>
 
@@ -121,7 +158,7 @@
         {#if temperatureAvailable}
           {temperatureValue.toFixed(1)}{tempSymbol}
         {:else}
-          —
+          -
         {/if}
       </span>
     </div>
@@ -152,37 +189,44 @@
         <span class="text-xs font-medium text-muted">{t('system.metrics.inference')}</span>
       </div>
       <div class="flex items-center gap-2">
-        {#if inferenceStatus === 'ok'}
+        {#if worstStatus === 'ok'}
           <span
             class="text-[10px] font-semibold uppercase px-1.5 py-0.5 rounded badge-status-success"
             >{t('system.metrics.statusOk')}</span
           >
-        {:else if inferenceStatus === 'warning'}
+        {:else if worstStatus === 'warning'}
           <span
             class="text-[10px] font-semibold uppercase px-1.5 py-0.5 rounded badge-status-warning"
             >{t('system.metrics.statusWarning')}</span
           >
-        {:else if inferenceStatus === 'critical'}
+        {:else if worstStatus === 'critical'}
           <span class="text-[10px] font-semibold uppercase px-1.5 py-0.5 rounded badge-status-error"
             >{t('system.metrics.statusCritical')}</span
           >
         {/if}
         <span class="font-mono tabular-nums text-lg font-semibold">
           {#if hasInferenceData}
-            {inferenceAvgMs.toFixed(0)}ms
+            {primaryAvgMs.toFixed(0)}ms
           {:else}
-            —
+            -
           {/if}
         </span>
       </div>
     </div>
     {#if hasInferenceData}
       <div class="flex-1 min-h-[28px]">
-        <Sparkline data={inferenceHistory} color={sparklineColorInference} />
+        <Sparkline datasets={inferenceDatasets} />
       </div>
-      <div class="flex justify-between mt-2 text-[10px] text-muted">
-        <span>{t('system.metrics.avgTime')} {inferenceAvgMs.toFixed(1)}ms</span>
-        <span>{inferenceHistory.length} {t('system.metrics.samples')}</span>
+      <div class="flex flex-wrap gap-x-3 gap-y-0.5 mt-2 text-[10px] text-muted">
+        {#each models.filter(m => m.history.length > 0) as m}
+          <span class="flex items-center gap-1">
+            <span class="inline-block w-1.5 h-1.5 rounded-full" style:background="{m.color}"></span>
+            {m.name}
+            <span class="font-mono tabular-nums"
+              >{m.history[m.history.length - 1].toFixed(0)}ms</span
+            >
+          </span>
+        {/each}
       </div>
     {:else}
       <div class="flex-1 min-h-[28px] flex items-center">

--- a/frontend/src/lib/desktop/features/system/components/MetricStrip.svelte
+++ b/frontend/src/lib/desktop/features/system/components/MetricStrip.svelte
@@ -212,7 +212,7 @@
         <Sparkline datasets={inferenceDatasets} />
       </div>
       <div class="flex flex-wrap gap-x-3 gap-y-0.5 mt-2 text-[10px] text-muted">
-        {#each modelsWithData as m}
+        {#each modelsWithData as m (m.id)}
           <span class="flex items-center gap-1">
             <span class="inline-block w-1.5 h-1.5 rounded-full" style:background={m.color}></span>
             {m.name}

--- a/frontend/src/lib/desktop/features/system/components/MetricStrip.svelte
+++ b/frontend/src/lib/desktop/features/system/components/MetricStrip.svelte
@@ -3,15 +3,7 @@
   import { Cpu, MemoryStick, Thermometer, Brain } from '@lucide/svelte';
   import { formatBytesCompact } from '$lib/utils/formatters';
   import Sparkline from './Sparkline.svelte';
-
-  interface ModelMetrics {
-    id: string;
-    name: string;
-    metricKey: string;
-    chunkSeconds: number;
-    history: number[];
-    color: string;
-  }
+  import type { ModelMetrics } from '$lib/desktop/features/system/types';
 
   interface Props {
     cpuPercent: number;
@@ -55,13 +47,15 @@
   let tempMin = $derived(hasTempHistory ? Math.min(...temperatureHistory) : temperatureValue);
   let tempMax = $derived(hasTempHistory ? Math.max(...temperatureHistory) : temperatureValue);
 
-  let hasInferenceData = $derived(models.some(m => m.history.length > 0));
+  let modelsWithData = $derived(models.filter(m => m.history.length > 0));
+  let hasInferenceData = $derived(modelsWithData.length > 0);
 
   function getThresholdMs(model: ModelMetrics): number {
+    let seconds = model.chunkSeconds;
     if (model.id.startsWith('BirdNET')) {
-      return (model.chunkSeconds - birdnetOverlap) * 1000;
+      seconds = model.chunkSeconds - birdnetOverlap;
     }
-    return model.chunkSeconds * 1000;
+    return Math.max(seconds, 0.001) * 1000;
   }
 
   type StatusLevel = 'ok' | 'warning' | 'critical';
@@ -87,14 +81,14 @@
     return worst;
   });
 
-  let inferenceDatasets = $derived(
-    models.filter(m => m.history.length > 0).map(m => ({ data: m.history, color: m.color }))
-  );
+  let inferenceDatasets = $derived(modelsWithData.map(m => ({ data: m.history, color: m.color })));
 
+  // Prefer BirdNET for the header display; fall back to first model with data
   let primaryAvgMs = $derived.by(() => {
-    const withData = models.filter(m => m.history.length > 0);
-    if (withData.length === 0) return 0;
-    return withData[0].history[withData[0].history.length - 1];
+    if (modelsWithData.length === 0) return 0;
+    const birdnet = modelsWithData.find(m => m.id.startsWith('BirdNET'));
+    const primary = birdnet ?? modelsWithData[0];
+    return primary.history[primary.history.length - 1];
   });
 </script>
 
@@ -218,9 +212,9 @@
         <Sparkline datasets={inferenceDatasets} />
       </div>
       <div class="flex flex-wrap gap-x-3 gap-y-0.5 mt-2 text-[10px] text-muted">
-        {#each models.filter(m => m.history.length > 0) as m}
+        {#each modelsWithData as m}
           <span class="flex items-center gap-1">
-            <span class="inline-block w-1.5 h-1.5 rounded-full" style:background="{m.color}"></span>
+            <span class="inline-block w-1.5 h-1.5 rounded-full" style:background={m.color}></span>
             {m.name}
             <span class="font-mono tabular-nums"
               >{m.history[m.history.length - 1].toFixed(0)}ms</span

--- a/frontend/src/lib/desktop/features/system/components/Sparkline.svelte
+++ b/frontend/src/lib/desktop/features/system/components/Sparkline.svelte
@@ -47,6 +47,9 @@
 
     const padding = 2;
 
+    // Shared X domain: align all datasets to the right edge (most recent point)
+    const maxLen = Math.max(0, ...effectiveDatasets.map(ds => ds.data.length));
+
     let globalMin = Infinity;
     let globalMax = -Infinity;
     for (const ds of effectiveDatasets) {
@@ -66,21 +69,23 @@
       .domain([globalMin, globalMax])
       .range([viewHeight - padding, padding]);
 
+    const xScale = scaleLinear()
+      .domain([0, maxLen - 1])
+      .range([0, viewWidth]);
+
     const paths: PathResult[] = [];
     for (const ds of effectiveDatasets) {
       if (ds.data.length < 2) continue;
 
-      const xScale = scaleLinear()
-        .domain([0, ds.data.length - 1])
-        .range([0, viewWidth]);
+      const offset = maxLen - ds.data.length;
 
       const lineGenerator = line<number>()
-        .x((_, i) => xScale(i))
+        .x((_, i) => xScale(offset + i))
         .y(d => yScale(d))
         .curve(curveMonotoneX);
 
       const areaGenerator = area<number>()
-        .x((_, i) => xScale(i))
+        .x((_, i) => xScale(offset + i))
         .y0(viewHeight)
         .y1(d => yScale(d))
         .curve(curveMonotoneX);

--- a/frontend/src/lib/desktop/features/system/components/Sparkline.svelte
+++ b/frontend/src/lib/desktop/features/system/components/Sparkline.svelte
@@ -3,62 +3,97 @@
   import { line, area, curveMonotoneX } from 'd3-shape';
   import { extent } from 'd3-array';
 
+  interface Dataset {
+    data: number[];
+    color: string;
+  }
+
   interface Props {
     data?: number[];
     color?: string;
-    /** Optional threshold value — renders a dashed horizontal line */
+    datasets?: Dataset[];
     threshold?: number;
-    /** Color for the threshold line */
     thresholdColor?: string;
-    /** Internal viewBox width for path calculations */
     viewWidth?: number;
-    /** Internal viewBox height for path calculations */
     viewHeight?: number;
   }
 
   let {
     data = [],
     color = 'var(--color-primary)',
+    datasets,
     threshold,
     thresholdColor = '#ef4444',
     viewWidth = 200,
     viewHeight = 40,
   }: Props = $props();
 
-  let paths = $derived.by(() => {
-    if (data.length < 2) return { line: '', area: '', thresholdY: undefined as number | undefined };
+  let effectiveDatasets = $derived.by((): Dataset[] => {
+    if (datasets && datasets.length > 0) return datasets;
+    if (data.length > 0) return [{ data, color }];
+    return [];
+  });
 
-    const padding = 2;
-    let [minVal, maxVal] = extent(data) as [number, number];
+  interface PathResult {
+    line: string;
+    area: string;
+    color: string;
+  }
 
-    // Extend domain to include threshold so the line is always visible
-    if (threshold != null) {
-      if (threshold > maxVal) maxVal = threshold;
-      if (threshold < minVal) minVal = threshold;
+  let rendered = $derived.by((): { paths: PathResult[]; thresholdY: number | undefined } => {
+    if (effectiveDatasets.length === 0) {
+      return { paths: [], thresholdY: undefined };
     }
 
-    const xScale = scaleLinear()
-      .domain([0, data.length - 1])
-      .range([0, viewWidth]);
+    const padding = 2;
+
+    let globalMin = Infinity;
+    let globalMax = -Infinity;
+    for (const ds of effectiveDatasets) {
+      if (ds.data.length < 2) continue;
+      const [mn, mx] = extent(ds.data) as [number, number];
+      if (mn < globalMin) globalMin = mn;
+      if (mx > globalMax) globalMax = mx;
+    }
+    if (threshold != null) {
+      if (threshold > globalMax) globalMax = threshold;
+      if (threshold < globalMin) globalMin = threshold;
+    }
+    if (!isFinite(globalMin)) globalMin = 0;
+    if (!isFinite(globalMax) || globalMax === globalMin) globalMax = globalMin + 1;
 
     const yScale = scaleLinear()
-      .domain([minVal, maxVal === minVal ? minVal + 1 : maxVal])
+      .domain([globalMin, globalMax])
       .range([viewHeight - padding, padding]);
 
-    const lineGenerator = line<number>()
-      .x((_, i) => xScale(i))
-      .y(d => yScale(d))
-      .curve(curveMonotoneX);
+    const paths: PathResult[] = [];
+    for (const ds of effectiveDatasets) {
+      if (ds.data.length < 2) continue;
 
-    const areaGenerator = area<number>()
-      .x((_, i) => xScale(i))
-      .y0(viewHeight)
-      .y1(d => yScale(d))
-      .curve(curveMonotoneX);
+      const xScale = scaleLinear()
+        .domain([0, ds.data.length - 1])
+        .range([0, viewWidth]);
+
+      const lineGenerator = line<number>()
+        .x((_, i) => xScale(i))
+        .y(d => yScale(d))
+        .curve(curveMonotoneX);
+
+      const areaGenerator = area<number>()
+        .x((_, i) => xScale(i))
+        .y0(viewHeight)
+        .y1(d => yScale(d))
+        .curve(curveMonotoneX);
+
+      paths.push({
+        line: lineGenerator(ds.data) ?? '',
+        area: areaGenerator(ds.data) ?? '',
+        color: ds.color,
+      });
+    }
 
     return {
-      line: lineGenerator(data) ?? '',
-      area: areaGenerator(data) ?? '',
+      paths,
       thresholdY: threshold != null ? yScale(threshold) : undefined,
     };
   });
@@ -71,29 +106,29 @@
   preserveAspectRatio="none"
   class="overflow-visible"
 >
-  {#if paths.line}
-    <path d={paths.area} fill={color} opacity="0.08" />
+  {#each rendered.paths as p}
+    <path d={p.area} fill={p.color} opacity="0.08" />
     <path
-      d={paths.line}
+      d={p.line}
       fill="none"
-      stroke={color}
+      stroke={p.color}
       stroke-width="1.5"
       stroke-linecap="round"
       stroke-linejoin="round"
       vector-effect="non-scaling-stroke"
     />
-    {#if paths.thresholdY != null}
-      <line
-        x1="0"
-        y1={paths.thresholdY}
-        x2={viewWidth}
-        y2={paths.thresholdY}
-        stroke={thresholdColor}
-        stroke-width="1"
-        stroke-dasharray="4 3"
-        opacity="0.6"
-        vector-effect="non-scaling-stroke"
-      />
-    {/if}
+  {/each}
+  {#if rendered.thresholdY != null}
+    <line
+      x1="0"
+      y1={rendered.thresholdY}
+      x2={viewWidth}
+      y2={rendered.thresholdY}
+      stroke={thresholdColor}
+      stroke-width="1"
+      stroke-dasharray="4 3"
+      opacity="0.6"
+      vector-effect="non-scaling-stroke"
+    />
   {/if}
 </svg>

--- a/frontend/src/lib/desktop/features/system/components/Sparkline.svelte
+++ b/frontend/src/lib/desktop/features/system/components/Sparkline.svelte
@@ -106,7 +106,7 @@
   preserveAspectRatio="none"
   class="overflow-visible"
 >
-  {#each rendered.paths as p}
+  {#each rendered.paths as p (p.color)}
     <path d={p.area} fill={p.color} opacity="0.08" />
     <path
       d={p.line}

--- a/frontend/src/lib/desktop/features/system/components/Sparkline.svelte
+++ b/frontend/src/lib/desktop/features/system/components/Sparkline.svelte
@@ -111,7 +111,7 @@
   preserveAspectRatio="none"
   class="overflow-visible"
 >
-  {#each rendered.paths as p (p.color)}
+  {#each rendered.paths as p, i (i)}
     <path d={p.area} fill={p.color} opacity="0.08" />
     <path
       d={p.line}

--- a/frontend/src/lib/desktop/features/system/types.ts
+++ b/frontend/src/lib/desktop/features/system/types.ts
@@ -1,0 +1,8 @@
+export interface ModelMetrics {
+  id: string;
+  name: string;
+  metricKey: string;
+  chunkSeconds: number;
+  history: number[];
+  color: string;
+}

--- a/frontend/src/lib/desktop/views/System.svelte
+++ b/frontend/src/lib/desktop/views/System.svelte
@@ -189,14 +189,18 @@
   async function fetchActiveModels(): Promise<void> {
     try {
       const models = await api.get<ActiveModelResponse[]>('/api/v2/system/models');
-      modelMetrics = models.map((m, i) => ({
-        id: m.id,
-        name: m.name,
-        metricKey: m.metric_key,
-        chunkSeconds: m.chunk_seconds,
-        history: [],
-        color: assignModelColor(m.id, i),
-      }));
+      const existing = new Map(modelMetrics.map(m => [m.id, m]));
+      modelMetrics = models.map((m, i) => {
+        const prev = existing.get(m.id);
+        return {
+          id: m.id,
+          name: m.name,
+          metricKey: m.metric_key,
+          chunkSeconds: m.chunk_seconds,
+          history: prev ? prev.history : [],
+          color: prev ? prev.color : assignModelColor(m.id, i),
+        };
+      });
     } catch {
       logger.debug('Models endpoint not available');
     }

--- a/frontend/src/lib/desktop/views/System.svelte
+++ b/frontend/src/lib/desktop/views/System.svelte
@@ -18,6 +18,7 @@
   } from '$lib/utils/formatters';
   import ReconnectingEventSource from 'reconnecting-eventsource';
   import { connectionState } from '$lib/stores/connectionState.svelte';
+  import type { ModelMetrics } from '$lib/desktop/features/system/types';
 
   const logger = loggers.ui;
 
@@ -101,15 +102,6 @@
     metric_key: string;
     chunk_seconds: number;
     sample_rate: number;
-  }
-
-  interface ModelMetrics {
-    id: string;
-    name: string;
-    metricKey: string;
-    chunkSeconds: number;
-    history: number[];
-    color: string;
   }
 
   const MODEL_COLORS: Record<string, string> = {
@@ -210,13 +202,14 @@
     }
   }
 
-  // Load initial metrics history for sparklines, then connect SSE if available.
-  // Falls back to polling existing endpoints when metrics history isn't available.
-  // The `active` flag prevents orphaned resources if the component unmounts mid-flight.
+  function buildMetricsParam(): string {
+    const inferenceKeys = modelMetrics.map(m => m.metricKey).join(',');
+    return `cpu.total,memory.used_percent,cpu.temperature${inferenceKeys ? ',' + inferenceKeys : ''}`;
+  }
+
   async function loadMetricsHistory(active: { current: boolean }): Promise<void> {
     try {
-      const inferenceKeys = modelMetrics.map(m => m.metricKey).join(',');
-      const metricsParam = `cpu.total,memory.used_percent,cpu.temperature${inferenceKeys ? ',' + inferenceKeys : ''}`;
+      const metricsParam = buildMetricsParam();
       const data = await api.get<MetricsHistoryResponse>(
         `/api/v2/system/metrics/history?points=${MAX_HISTORY_POINTS}&metrics=${metricsParam}`
       );
@@ -317,10 +310,8 @@
 
   // Connect to metrics SSE stream for live updates
   function connectMetricsStream(): void {
-    const inferenceKeys = modelMetrics.map(m => m.metricKey).join(',');
-    const metricsParam = `cpu.total,memory.used_percent,cpu.temperature${inferenceKeys ? ',' + inferenceKeys : ''}`;
     metricsSSE = new ReconnectingEventSource(
-      `/api/v2/system/metrics/stream?metrics=${metricsParam}`,
+      `/api/v2/system/metrics/stream?metrics=${buildMetricsParam()}`,
       { max_retry_time: 30000 }
     );
 

--- a/frontend/src/lib/desktop/views/System.svelte
+++ b/frontend/src/lib/desktop/views/System.svelte
@@ -95,6 +95,37 @@
     metrics: Record<string, MetricPoint[]>;
   }
 
+  interface ActiveModelResponse {
+    id: string;
+    name: string;
+    metric_key: string;
+    chunk_seconds: number;
+    sample_rate: number;
+  }
+
+  interface ModelMetrics {
+    id: string;
+    name: string;
+    metricKey: string;
+    chunkSeconds: number;
+    history: number[];
+    color: string;
+  }
+
+  const MODEL_COLORS: Record<string, string> = {
+    BirdNET: '#14b8a6',
+    Perch: '#f59e0b',
+    Bat: '#f43f5e',
+  };
+  const FALLBACK_COLORS = ['#6366f1', '#ec4899', '#84cc16', '#06b6d4'];
+
+  function assignModelColor(id: string, index: number): string {
+    for (const [prefix, color] of Object.entries(MODEL_COLORS)) {
+      if (id.startsWith(prefix)) return color;
+    }
+    return FALLBACK_COLORS[index % FALLBACK_COLORS.length];
+  }
+
   interface ResourcesResponse {
     cpu_usage_percent: number;
     memory_total: number;
@@ -116,7 +147,7 @@
   let cpuHistory = $state<number[]>([]);
   let memoryHistory = $state<number[]>([]);
   let temperatureHistory = $state<number[]>([]);
-  let inferenceHistory = $state<number[]>([]);
+  let modelMetrics = $state<ModelMetrics[]>([]);
 
   // Toggle for showing all processes
   let showAllProcesses = $state(false);
@@ -155,19 +186,7 @@
     temperatureHistory.map(c => convertTemperature(c, temperatureUnit))
   );
 
-  // Inference sparkline derived values
-  let inferenceAvgMs = $derived(
-    inferenceHistory.length > 0 ? inferenceHistory[inferenceHistory.length - 1] : 0
-  );
-  let hasInferenceData = $derived(inferenceHistory.length > 0);
-
-  // BirdNET overlap setting — used to compute the inference threshold
-  // Threshold = (3.0 - overlap) * 1000 ms: inference must stay below this to keep up with real-time
-  const BIRDNET_CHUNK_SECONDS = 3.0;
-  let birdnetOverlap = $state<number | null>(null);
-  let inferenceThresholdMs = $derived(
-    birdnetOverlap != null ? (BIRDNET_CHUNK_SECONDS - birdnetOverlap) * 1000 : undefined
-  );
+  let birdnetOverlap = $state<number>(0);
 
   // Append a value to a history array, keeping it capped at MAX_HISTORY_POINTS
   function appendHistory(arr: number[], value: number): number[] {
@@ -175,13 +194,31 @@
     return next.length > MAX_HISTORY_POINTS ? next.slice(next.length - MAX_HISTORY_POINTS) : next;
   }
 
+  async function fetchActiveModels(): Promise<void> {
+    try {
+      const models = await api.get<ActiveModelResponse[]>('/api/v2/system/models');
+      modelMetrics = models.map((m, i) => ({
+        id: m.id,
+        name: m.name,
+        metricKey: m.metric_key,
+        chunkSeconds: m.chunk_seconds,
+        history: [],
+        color: assignModelColor(m.id, i),
+      }));
+    } catch {
+      logger.debug('Models endpoint not available');
+    }
+  }
+
   // Load initial metrics history for sparklines, then connect SSE if available.
   // Falls back to polling existing endpoints when metrics history isn't available.
   // The `active` flag prevents orphaned resources if the component unmounts mid-flight.
   async function loadMetricsHistory(active: { current: boolean }): Promise<void> {
     try {
+      const inferenceKeys = modelMetrics.map(m => m.metricKey).join(',');
+      const metricsParam = `cpu.total,memory.used_percent,cpu.temperature${inferenceKeys ? ',' + inferenceKeys : ''}`;
       const data = await api.get<MetricsHistoryResponse>(
-        `/api/v2/system/metrics/history?points=${MAX_HISTORY_POINTS}&metrics=cpu.total,memory.used_percent,cpu.temperature,birdnet.invoke_avg_ms`
+        `/api/v2/system/metrics/history?points=${MAX_HISTORY_POINTS}&metrics=${metricsParam}`
       );
 
       if (!active.current) return;
@@ -195,11 +232,12 @@
       if (data.metrics['cpu.temperature']) {
         temperatureHistory = data.metrics['cpu.temperature'].map((p: MetricPoint) => p.value);
       }
-      if (data.metrics['birdnet.invoke_avg_ms']) {
-        inferenceHistory = data.metrics['birdnet.invoke_avg_ms'].map((p: MetricPoint) => p.value);
+      for (const m of modelMetrics) {
+        if (data.metrics[m.metricKey]) {
+          m.history = data.metrics[m.metricKey].map((p: MetricPoint) => p.value);
+        }
       }
 
-      // Only connect SSE if the history endpoint succeeded and component is still mounted
       connectMetricsStream();
     } catch {
       if (!active.current) return;
@@ -279,8 +317,10 @@
 
   // Connect to metrics SSE stream for live updates
   function connectMetricsStream(): void {
+    const inferenceKeys = modelMetrics.map(m => m.metricKey).join(',');
+    const metricsParam = `cpu.total,memory.used_percent,cpu.temperature${inferenceKeys ? ',' + inferenceKeys : ''}`;
     metricsSSE = new ReconnectingEventSource(
-      '/api/v2/system/metrics/stream?metrics=cpu.total,memory.used_percent,cpu.temperature,birdnet.invoke_avg_ms',
+      `/api/v2/system/metrics/stream?metrics=${metricsParam}`,
       { max_retry_time: 30000 }
     );
 
@@ -299,14 +339,13 @@
         if (metrics['cpu.temperature']) {
           temperatureHistory = appendHistory(temperatureHistory, metrics['cpu.temperature'].value);
         }
-        if (metrics['birdnet.invoke_avg_ms']) {
-          inferenceHistory = appendHistory(
-            inferenceHistory,
-            metrics['birdnet.invoke_avg_ms'].value
-          );
+        for (const m of modelMetrics) {
+          if (metrics[m.metricKey]) {
+            m.history = appendHistory(m.history, metrics[m.metricKey].value);
+          }
         }
       } catch {
-        logger.debug('Failed to parse metrics SSE event');
+        // Ignore malformed events
       }
     });
   }
@@ -395,15 +434,12 @@
     }
   }
 
-  // Load BirdNET overlap setting for inference threshold calculation
   async function loadBirdnetOverlap(): Promise<void> {
     try {
       const data = await api.get<{ overlap?: number }>('/api/v2/settings/birdnet');
-      if (data.overlap != null) {
-        birdnetOverlap = data.overlap;
-      }
+      if (typeof data.overlap === 'number') birdnetOverlap = data.overlap;
     } catch {
-      // Settings may require auth or not be available — threshold just won't render
+      // Default overlap 0 is fine
     }
   }
 
@@ -456,8 +492,10 @@
   $effect(() => {
     componentActive.current = true;
 
-    // Load initial data, then load metrics history (which needs data for fallback seeding)
-    loadAllData().then(() => {
+    // Load initial data, fetch active models, then load metrics history
+    loadAllData().then(async () => {
+      if (!componentActive.current) return;
+      await fetchActiveModels();
       if (componentActive.current) {
         loadMetricsHistory(componentActive);
       }
@@ -519,10 +557,8 @@
       temperatureValue={temperatureDisplay}
       temperatureHistory={temperatureHistoryConverted}
       {tempSymbol}
-      {inferenceAvgMs}
-      {inferenceHistory}
-      {hasInferenceData}
-      {inferenceThresholdMs}
+      models={modelMetrics}
+      {birdnetOverlap}
     />
 
     <!-- System Details + Storage -->

--- a/internal/api/v2/README.md
+++ b/internal/api/v2/README.md
@@ -407,6 +407,7 @@ HLS playlist and segment routes use token-based authentication instead of standa
 | GET    | `/system/audio/equalizer/config` | `GetEqualizerConfig`      | ✅   | Audio equalizer filter configuration |
 | GET    | `/system/audio/sources`          | `ListAudioSources`        | ✅   | Active audio sources (all types)     |
 | GET    | `/system/network-interfaces`     | `GetNetworkInterfaces`    | ✅   | IPv4 network interfaces for binding  |
+| GET    | `/system/models`                 | `GetActiveModels`         | ✅   | Active model metadata                |
 
 ### Events (`events.go`, `events_aggregation.go`)
 

--- a/internal/api/v2/system.go
+++ b/internal/api/v2/system.go
@@ -404,6 +404,7 @@ func (c *Controller) initSystemRoutes() {
 	protectedGroup.POST("/database/backup", c.DownloadDatabaseBackup)
 	protectedGroup.GET("/network-interfaces", c.GetNetworkInterfaces)
 	protectedGroup.GET("/restart-status", c.GetRestartStatus)
+	protectedGroup.GET("/models", c.GetActiveModels)
 
 	// Audio device routes (all protected)
 	audioGroup := protectedGroup.Group("/audio")

--- a/internal/api/v2/system_models.go
+++ b/internal/api/v2/system_models.go
@@ -2,9 +2,9 @@ package api
 
 import (
 	"net/http"
-	"strings"
 
 	"github.com/labstack/echo/v4"
+	"github.com/tphakala/birdnet-go/internal/classifier/inferencestats"
 )
 
 // ActiveModelResponse describes a single loaded model for the /system/models endpoint.
@@ -14,18 +14,6 @@ type ActiveModelResponse struct {
 	MetricKey    string  `json:"metric_key"`
 	ChunkSeconds float64 `json:"chunk_seconds"`
 	SampleRate   int     `json:"sample_rate"`
-}
-
-// sanitizeModelIDForMetric replaces any character that is not alphanumeric or
-// underscore with an underscore so that the resulting string is safe to use as
-// part of a Prometheus-style metric key.
-func sanitizeModelIDForMetric(modelID string) string {
-	return strings.Map(func(r rune) rune {
-		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_' {
-			return r
-		}
-		return '_'
-	}, modelID)
 }
 
 // GetActiveModels returns metadata for all currently loaded models.
@@ -45,7 +33,7 @@ func (c *Controller) GetActiveModels(ctx echo.Context) error {
 		models = append(models, ActiveModelResponse{
 			ID:           infos[i].ID,
 			Name:         infos[i].Name,
-			MetricKey:    "inference." + sanitizeModelIDForMetric(infos[i].ID) + ".avg_ms",
+			MetricKey:    inferencestats.MetricKey(infos[i].ID),
 			ChunkSeconds: infos[i].Spec.ClipLength.Seconds(),
 			SampleRate:   infos[i].Spec.SampleRate,
 		})

--- a/internal/api/v2/system_models.go
+++ b/internal/api/v2/system_models.go
@@ -1,0 +1,55 @@
+package api
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/labstack/echo/v4"
+)
+
+// ActiveModelResponse describes a single loaded model for the /system/models endpoint.
+type ActiveModelResponse struct {
+	ID           string  `json:"id"`
+	Name         string  `json:"name"`
+	MetricKey    string  `json:"metric_key"`
+	ChunkSeconds float64 `json:"chunk_seconds"`
+	SampleRate   int     `json:"sample_rate"`
+}
+
+// sanitizeModelIDForMetric replaces any character that is not alphanumeric or
+// underscore with an underscore so that the resulting string is safe to use as
+// part of a Prometheus-style metric key.
+func sanitizeModelIDForMetric(modelID string) string {
+	return strings.Map(func(r rune) rune {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_' {
+			return r
+		}
+		return '_'
+	}, modelID)
+}
+
+// GetActiveModels returns metadata for all currently loaded models.
+// GET /api/v2/system/models
+func (c *Controller) GetActiveModels(ctx echo.Context) error {
+	if c.ModelManager == nil {
+		return ctx.JSON(http.StatusOK, []ActiveModelResponse{})
+	}
+
+	infos := c.ModelManager.ModelInfos()
+	if infos == nil {
+		return ctx.JSON(http.StatusOK, []ActiveModelResponse{})
+	}
+
+	models := make([]ActiveModelResponse, 0, len(infos))
+	for i := range infos {
+		models = append(models, ActiveModelResponse{
+			ID:           infos[i].ID,
+			Name:         infos[i].Name,
+			MetricKey:    "inference." + sanitizeModelIDForMetric(infos[i].ID) + ".avg_ms",
+			ChunkSeconds: infos[i].Spec.ClipLength.Seconds(),
+			SampleRate:   infos[i].Spec.SampleRate,
+		})
+	}
+
+	return ctx.JSON(http.StatusOK, models)
+}

--- a/internal/classifier/analyze.go
+++ b/internal/classifier/analyze.go
@@ -89,9 +89,6 @@ func (bn *BirdNET) Predict(ctx context.Context, sample [][]float32) ([]datastore
 		globalMetrics.RecordModelInvoke(bn.ModelInfo.ID, invokeDuration.Seconds())
 	}
 
-	// Record to atomic counters for ring buffer metrics
-	globalInferenceCounters.RecordInvoke(invokeDuration.Microseconds())
-
 	// Use optimized sigmoid function with buffer reuse
 	confidence := applySigmoidToPredictionsReuse(predictions, settings.BirdNET.Sensitivity, bn.confidenceBuffer)
 

--- a/internal/classifier/inferencestats/counters.go
+++ b/internal/classifier/inferencestats/counters.go
@@ -97,3 +97,8 @@ func (m *CounterMap) SnapshotAll() map[string]Snapshot {
 	})
 	return result
 }
+
+// Delete removes the counters for the given model ID.
+func (m *CounterMap) Delete(modelID string) {
+	m.models.Delete(modelID)
+}

--- a/internal/classifier/inferencestats/counters.go
+++ b/internal/classifier/inferencestats/counters.go
@@ -4,6 +4,7 @@
 package inferencestats
 
 import (
+	"sync"
 	"sync/atomic"
 	"time"
 )
@@ -53,4 +54,30 @@ func updateAtomicMax(addr *atomic.Int64, val int64) {
 			return
 		}
 	}
+}
+
+// CounterMap tracks per-model inference counters. Safe for concurrent use.
+type CounterMap struct {
+	models sync.Map // model ID (string) -> *Counters
+}
+
+// RecordInvoke records a single invocation duration for the given model ID.
+func (m *CounterMap) RecordInvoke(modelID string, durationUs int64) {
+	if v, ok := m.models.Load(modelID); ok {
+		v.(*Counters).RecordInvoke(durationUs)
+		return
+	}
+	c, _ := m.models.LoadOrStore(modelID, &Counters{})
+	c.(*Counters).RecordInvoke(durationUs)
+}
+
+// SnapshotAll returns a snapshot of all per-model counters. Each model's max
+// is reset on read, consistent with Counters.Snapshot behaviour.
+func (m *CounterMap) SnapshotAll() map[string]Snapshot {
+	result := make(map[string]Snapshot)
+	m.models.Range(func(key, value any) bool {
+		result[key.(string)] = value.(*Counters).Snapshot()
+		return true
+	})
+	return result
 }

--- a/internal/classifier/inferencestats/counters.go
+++ b/internal/classifier/inferencestats/counters.go
@@ -4,6 +4,7 @@
 package inferencestats
 
 import (
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -54,6 +55,21 @@ func updateAtomicMax(addr *atomic.Int64, val int64) {
 			return
 		}
 	}
+}
+
+// SanitizeModelID replaces non-alphanumeric/non-underscore characters with underscores.
+func SanitizeModelID(modelID string) string {
+	return strings.Map(func(r rune) rune {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_' {
+			return r
+		}
+		return '_'
+	}, modelID)
+}
+
+// MetricKey returns the metrics store key for a model's average inference time.
+func MetricKey(modelID string) string {
+	return "inference." + SanitizeModelID(modelID) + ".avg_ms"
 }
 
 // CounterMap tracks per-model inference counters. Safe for concurrent use.

--- a/internal/classifier/inferencestats/counters_test.go
+++ b/internal/classifier/inferencestats/counters_test.go
@@ -72,3 +72,72 @@ func TestCounters_ConcurrentAccess(t *testing.T) {
 	snap := c.Snapshot()
 	assert.Equal(t, int64(goroutines*iterations), snap.InvokeCount)
 }
+
+func TestCounterMap_RecordInvoke(t *testing.T) {
+	t.Parallel()
+	m := &CounterMap{}
+
+	m.RecordInvoke("model_a", 500)
+	m.RecordInvoke("model_a", 1200)
+	m.RecordInvoke("model_b", 300)
+
+	snaps := m.SnapshotAll()
+	require.Len(t, snaps, 2)
+
+	a := snaps["model_a"]
+	assert.Equal(t, int64(2), a.InvokeCount)
+	assert.Equal(t, int64(1700), a.InvokeTotalUs)
+	assert.Equal(t, int64(1200), a.InvokeMaxUs)
+
+	b := snaps["model_b"]
+	assert.Equal(t, int64(1), b.InvokeCount)
+	assert.Equal(t, int64(300), b.InvokeTotalUs)
+}
+
+func TestCounterMap_SnapshotAll_ResetsMax(t *testing.T) {
+	t.Parallel()
+	m := &CounterMap{}
+
+	m.RecordInvoke("model_a", 5000)
+	snap1 := m.SnapshotAll()
+	assert.Equal(t, int64(5000), snap1["model_a"].InvokeMaxUs)
+
+	snap2 := m.SnapshotAll()
+	assert.Equal(t, int64(0), snap2["model_a"].InvokeMaxUs)
+	assert.Equal(t, int64(1), snap2["model_a"].InvokeCount)
+	assert.Equal(t, int64(5000), snap2["model_a"].InvokeTotalUs)
+}
+
+func TestCounterMap_ConcurrentAccess(t *testing.T) {
+	t.Parallel()
+	m := &CounterMap{}
+
+	const goroutines = 10
+	const iterations = 1000
+	models := []string{"model_a", "model_b", "model_c"}
+
+	var wg sync.WaitGroup
+	for _, modelID := range models {
+		for range goroutines {
+			wg.Go(func() {
+				for range iterations {
+					m.RecordInvoke(modelID, 100)
+				}
+			})
+		}
+	}
+	wg.Wait()
+
+	snaps := m.SnapshotAll()
+	require.Len(t, snaps, 3)
+	for _, modelID := range models {
+		assert.Equal(t, int64(goroutines*iterations), snaps[modelID].InvokeCount)
+	}
+}
+
+func TestCounterMap_EmptySnapshot(t *testing.T) {
+	t.Parallel()
+	m := &CounterMap{}
+	snaps := m.SnapshotAll()
+	assert.Empty(t, snaps)
+}

--- a/internal/classifier/model_manager.go
+++ b/internal/classifier/model_manager.go
@@ -84,6 +84,14 @@ func NewModelManager(modelsDir string, orchestrator *Orchestrator, settings *con
 	}
 }
 
+// ModelInfos returns ModelInfo for all currently loaded models.
+func (mm *ModelManager) ModelInfos() []ModelInfo {
+	if mm.orchestrator == nil {
+		return nil
+	}
+	return mm.orchestrator.ModelInfos()
+}
+
 // ScanInstalled scans modelsDir for subdirectories matching catalog IDs. For
 // each matching subdirectory, it checks whether the ONNX model file (the
 // CatalogFile with Role "model") exists on disk. If found, the model is

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -507,6 +507,8 @@ func (o *Orchestrator) UnloadModel(registryID string) error {
 	delete(o.models, registryID)
 	o.mu.Unlock()
 
+	globalInferenceCounters.Delete(registryID)
+
 	// Close the model instance outside the map lock. Acquire the per-model
 	// lock to wait for any in-flight inference to complete.
 	entry.mu.Lock()

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -145,9 +145,9 @@ func (o *Orchestrator) resolveInstalledPaths(registryID string) (modelPath, labe
 }
 
 // Predict runs inference using the primary model.
-// Relies on BirdNET's internal locking.
+// Delegates to PredictModel for uniform locking and telemetry.
 func (o *Orchestrator) Predict(ctx context.Context, sample [][]float32) ([]datastore.Results, error) {
-	return o.primary.Predict(ctx, sample)
+	return o.PredictModel(ctx, o.ModelInfo.ID, sample)
 }
 
 // PredictModel runs inference on a specific model identified by modelID.

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -147,7 +147,10 @@ func (o *Orchestrator) resolveInstalledPaths(registryID string) (modelPath, labe
 // Predict runs inference using the primary model.
 // Delegates to PredictModel for uniform locking and telemetry.
 func (o *Orchestrator) Predict(ctx context.Context, sample [][]float32) ([]datastore.Results, error) {
-	return o.PredictModel(ctx, o.ModelInfo.ID, sample)
+	o.mu.RLock()
+	id := o.ModelInfo.ID
+	o.mu.RUnlock()
+	return o.PredictModel(ctx, id, sample)
 }
 
 // PredictModel runs inference on a specific model identified by modelID.

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -200,6 +200,7 @@ func (o *Orchestrator) PredictModel(ctx context.Context, modelID string, sample 
 			logger.Error(err),
 			logger.Duration("duration", duration))
 	} else {
+		globalInferenceCounters.RecordInvoke(modelID, duration.Microseconds())
 		log.Debug("PredictModel complete",
 			logger.String("model_id", modelID),
 			logger.Int("result_count", len(results)),

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -507,12 +507,13 @@ func (o *Orchestrator) UnloadModel(registryID string) error {
 	delete(o.models, registryID)
 	o.mu.Unlock()
 
-	globalInferenceCounters.Delete(registryID)
-
 	// Close the model instance outside the map lock. Acquire the per-model
-	// lock to wait for any in-flight inference to complete.
+	// lock to wait for any in-flight inference to complete before deleting
+	// the counter (prevents re-creation by in-flight RecordInvoke).
 	entry.mu.Lock()
 	defer entry.mu.Unlock()
+
+	globalInferenceCounters.Delete(registryID)
 
 	if entry.instance != nil {
 		modelID := entry.instance.ModelID()

--- a/internal/classifier/tracing.go
+++ b/internal/classifier/tracing.go
@@ -38,12 +38,11 @@ var (
 	activeOperations int64
 )
 
-// globalInferenceCounters is always initialized and safe to use.
-// Tracks inference timing via lock-free atomics for the ring buffer metrics pipeline.
-var globalInferenceCounters = &inferencestats.Counters{}
+// globalInferenceCounters tracks per-model inference timing via lock-free atomics.
+var globalInferenceCounters = &inferencestats.CounterMap{}
 
-// GetInferenceCounters returns the shared inference counters for collector wiring.
-func GetInferenceCounters() *inferencestats.Counters {
+// GetInferenceCounters returns the shared per-model inference counters for collector wiring.
+func GetInferenceCounters() *inferencestats.CounterMap {
 	return globalInferenceCounters
 }
 

--- a/internal/observability/collector.go
+++ b/internal/observability/collector.go
@@ -303,6 +303,15 @@ func (c *Collector) collectInference(points map[string]float64) {
 		s := snap
 		c.prevInferenceSnaps[modelID] = &s
 	}
+
+	// Remove stale snapshots for unloaded models
+	if len(c.prevInferenceSnaps) > len(snaps) {
+		for modelID := range c.prevInferenceSnaps {
+			if _, ok := snaps[modelID]; !ok {
+				delete(c.prevInferenceSnaps, modelID)
+			}
+		}
+	}
 }
 
 // logOnce logs a message for a metric category only on the first occurrence.

--- a/internal/observability/collector.go
+++ b/internal/observability/collector.go
@@ -304,12 +304,9 @@ func (c *Collector) collectInference(points map[string]float64) {
 		c.prevInferenceSnaps[modelID] = &s
 	}
 
-	// Remove stale snapshots for unloaded models
-	if len(c.prevInferenceSnaps) > len(snaps) {
-		for modelID := range c.prevInferenceSnaps {
-			if _, ok := snaps[modelID]; !ok {
-				delete(c.prevInferenceSnaps, modelID)
-			}
+	for modelID := range c.prevInferenceSnaps {
+		if _, ok := snaps[modelID]; !ok {
+			delete(c.prevInferenceSnaps, modelID)
 		}
 	}
 }

--- a/internal/observability/collector.go
+++ b/internal/observability/collector.go
@@ -98,13 +98,21 @@ const (
 	metricDBReadLatencyMax  = "db.read_latency_max_ms"
 	metricDBWriteLatencyMax = "db.write_latency_max_ms"
 	metricDBQueriesPerSec   = "db.queries_per_sec"
-	metricBirdNETInvokeAvg  = "birdnet.invoke_avg_ms"
-	metricBirdNETInvokeMax  = "birdnet.invoke_max_ms"
 
 	// maxValidCelsius is the upper bound for valid CPU temperature readings.
 	// 120°C captures overheating events before thermal shutdown while filtering bogus values.
 	maxValidCelsius = 120.0
 )
+
+func inferenceMetricKey(modelID string) string {
+	sanitized := strings.Map(func(r rune) rune {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_' {
+			return r
+		}
+		return '_'
+	}, modelID)
+	return "inference." + sanitized + ".avg_ms"
+}
 
 // collect gathers all system metrics and records them as a single batch.
 func (c *Collector) collect() {
@@ -264,43 +272,42 @@ func (c *Collector) SetInferenceCounters(counters *inferencestats.CounterMap) {
 	c.inferenceCounters = counters
 }
 
-// collectInference computes inference latency metrics from per-model atomic counter snapshots.
-// Aggregates across all models for the combined sparkline metrics.
-// When idle (no new invocations since last tick), avg is recorded as 0 to maintain
-// consistent sparkline time axis spacing.
 func (c *Collector) collectInference(points map[string]float64) {
 	if c.inferenceCounters == nil {
 		return
 	}
 
 	snaps := c.inferenceCounters.SnapshotAll()
+
 	if c.prevInferenceSnaps == nil {
 		c.prevInferenceSnaps = make(map[string]*inferencestats.Snapshot, len(snaps))
+		for modelID := range snaps {
+			snap := snaps[modelID]
+			c.prevInferenceSnaps[modelID] = &snap
+		}
+		return
 	}
 
-	var totalInvokes, totalUs, maxUs int64
-	hasPrev := false
 	for modelID, snap := range snaps {
-		prev := c.prevInferenceSnaps[modelID]
-		if prev != nil {
-			hasPrev = true
-			delta := snap.InvokeCount - prev.InvokeCount
-			totalInvokes += delta
-			totalUs += snap.InvokeTotalUs - prev.InvokeTotalUs
-		}
-		if snap.InvokeMaxUs > maxUs {
-			maxUs = snap.InvokeMaxUs
-		}
-		c.prevInferenceSnaps[modelID] = &snap
-	}
+		key := inferenceMetricKey(modelID)
+		prev, hasPrev := c.prevInferenceSnaps[modelID]
 
-	points[metricBirdNETInvokeMax] = float64(maxUs) / usToMs
-	if hasPrev {
-		if totalInvokes > 0 {
-			points[metricBirdNETInvokeAvg] = float64(totalUs) / float64(totalInvokes) / usToMs
-		} else {
-			points[metricBirdNETInvokeAvg] = 0
+		if !hasPrev {
+			s := snap
+			c.prevInferenceSnaps[modelID] = &s
+			continue
 		}
+
+		deltaInvokes := snap.InvokeCount - prev.InvokeCount
+		if deltaInvokes > 0 {
+			deltaUs := snap.InvokeTotalUs - prev.InvokeTotalUs
+			points[key] = float64(deltaUs) / float64(deltaInvokes) / usToMs
+		} else {
+			points[key] = 0
+		}
+
+		s := snap
+		c.prevInferenceSnaps[modelID] = &s
 	}
 }
 

--- a/internal/observability/collector.go
+++ b/internal/observability/collector.go
@@ -85,7 +85,7 @@ func (c *Collector) Start(ctx context.Context) {
 // Metric key constants for collected system metrics.
 const (
 	// expectedMetricCount is the pre-allocation hint for the number of metrics collected per tick.
-	expectedMetricCount = 8
+	expectedMetricCount = 12
 
 	metricCPUTotal          = "cpu.total"
 	metricMemoryUsedPercent = "memory.used_percent"
@@ -105,13 +105,7 @@ const (
 )
 
 func inferenceMetricKey(modelID string) string {
-	sanitized := strings.Map(func(r rune) rune {
-		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_' {
-			return r
-		}
-		return '_'
-	}, modelID)
-	return "inference." + sanitized + ".avg_ms"
+	return inferencestats.MetricKey(modelID)
 }
 
 // collect gathers all system metrics and records them as a single batch.

--- a/internal/observability/collector.go
+++ b/internal/observability/collector.go
@@ -36,8 +36,8 @@ type Collector struct {
 	prevDBSnap *dbstats.Snapshot
 
 	// Inference latency tracking (optional, set via SetInferenceCounters)
-	inferenceCounters *inferencestats.Counters
-	prevInferenceSnap *inferencestats.Snapshot
+	inferenceCounters  *inferencestats.CounterMap
+	prevInferenceSnaps map[string]*inferencestats.Snapshot
 
 	// Track which metrics have had logged errors to avoid log spam
 	loggedErrors map[string]bool
@@ -258,13 +258,14 @@ func (c *Collector) collectDatabase(points map[string]float64) {
 	c.prevDBSnap = &snap
 }
 
-// SetInferenceCounters sets the BirdNET inference counters for latency tracking.
+// SetInferenceCounters sets the per-model inference counters for latency tracking.
 // Must be called before Start. If not called, inference metrics are skipped.
-func (c *Collector) SetInferenceCounters(counters *inferencestats.Counters) {
+func (c *Collector) SetInferenceCounters(counters *inferencestats.CounterMap) {
 	c.inferenceCounters = counters
 }
 
-// collectInference computes inference latency metrics from atomic counter snapshots.
+// collectInference computes inference latency metrics from per-model atomic counter snapshots.
+// Aggregates across all models for the combined sparkline metrics.
 // When idle (no new invocations since last tick), avg is recorded as 0 to maintain
 // consistent sparkline time axis spacing.
 func (c *Collector) collectInference(points map[string]float64) {
@@ -272,22 +273,35 @@ func (c *Collector) collectInference(points map[string]float64) {
 		return
 	}
 
-	snap := c.inferenceCounters.Snapshot()
+	snaps := c.inferenceCounters.SnapshotAll()
+	if c.prevInferenceSnaps == nil {
+		c.prevInferenceSnaps = make(map[string]*inferencestats.Snapshot, len(snaps))
+	}
 
-	points[metricBirdNETInvokeMax] = float64(snap.InvokeMaxUs) / usToMs
+	var totalInvokes, totalUs, maxUs int64
+	hasPrev := false
+	for modelID, snap := range snaps {
+		prev := c.prevInferenceSnaps[modelID]
+		if prev != nil {
+			hasPrev = true
+			delta := snap.InvokeCount - prev.InvokeCount
+			totalInvokes += delta
+			totalUs += snap.InvokeTotalUs - prev.InvokeTotalUs
+		}
+		if snap.InvokeMaxUs > maxUs {
+			maxUs = snap.InvokeMaxUs
+		}
+		c.prevInferenceSnaps[modelID] = &snap
+	}
 
-	if c.prevInferenceSnap != nil {
-		deltaInvokes := snap.InvokeCount - c.prevInferenceSnap.InvokeCount
-		if deltaInvokes > 0 {
-			deltaUs := snap.InvokeTotalUs - c.prevInferenceSnap.InvokeTotalUs
-			points[metricBirdNETInvokeAvg] = float64(deltaUs) / float64(deltaInvokes) / usToMs
+	points[metricBirdNETInvokeMax] = float64(maxUs) / usToMs
+	if hasPrev {
+		if totalInvokes > 0 {
+			points[metricBirdNETInvokeAvg] = float64(totalUs) / float64(totalInvokes) / usToMs
 		} else {
-			// Record 0 during idle periods to keep sparkline time axis consistent
 			points[metricBirdNETInvokeAvg] = 0
 		}
 	}
-
-	c.prevInferenceSnap = &snap
 }
 
 // logOnce logs a message for a metric category only on the first occurrence.

--- a/internal/observability/collector_test.go
+++ b/internal/observability/collector_test.go
@@ -183,48 +183,52 @@ func TestCollector_CollectsInferenceMetrics(t *testing.T) {
 	collector := NewCollector(store, 1*time.Second, func() float64 { return 0 })
 
 	counters := &inferencestats.CounterMap{}
-	counters.RecordInvoke("test-model", 5000)  // 5ms
-	counters.RecordInvoke("test-model", 15000) // 15ms
+	counters.RecordInvoke("BirdNET_V2.4", 5000)  // 5ms
+	counters.RecordInvoke("BirdNET_V2.4", 15000) // 15ms
+	counters.RecordInvoke("Perch_V2", 8000)      // 8ms
 	collector.SetInferenceCounters(counters)
 
-	// First tick: only max (no previous snapshot for avg)
+	// First tick: no avg yet (no previous snapshot)
 	collector.collect()
-	maxPts := store.Get("birdnet.invoke_max_ms", 1)
-	require.Len(t, maxPts, 1)
-	assert.InDelta(t, 15.0, maxPts[0].Value, 0.01)
-
-	// Avg should NOT be recorded on first tick (no prev snapshot)
-	avgPts := store.Get("birdnet.invoke_avg_ms", 10)
+	avgPts := store.Get("inference.BirdNET_V2_4.avg_ms", 10)
 	assert.Nil(t, avgPts, "avg should not be recorded on first tick")
 
 	// Record more data for second tick
-	counters.RecordInvoke("test-model", 8000) // 8ms
+	counters.RecordInvoke("BirdNET_V2.4", 10000) // 10ms
+	counters.RecordInvoke("Perch_V2", 6000)      // 6ms
 
-	// Second tick: should have avg
+	// Second tick: should have per-model avg
 	collector.collect()
-	avgPts = store.Get("birdnet.invoke_avg_ms", 10)
-	require.Len(t, avgPts, 1)
-	// 8ms total / 1 invoke = 8ms avg
-	assert.InDelta(t, 8.0, avgPts[0].Value, 0.01)
+
+	birdnetAvg := store.Get("inference.BirdNET_V2_4.avg_ms", 10)
+	require.Len(t, birdnetAvg, 1)
+	assert.InDelta(t, 10.0, birdnetAvg[0].Value, 0.01) // 10ms / 1 invoke
+
+	perchAvg := store.Get("inference.Perch_V2.avg_ms", 10)
+	require.Len(t, perchAvg, 1)
+	assert.InDelta(t, 6.0, perchAvg[0].Value, 0.01) // 6ms / 1 invoke
+
+	// Old metric keys should not exist
+	assert.Nil(t, store.Get("birdnet.invoke_avg_ms", 10))
+	assert.Nil(t, store.Get("birdnet.invoke_max_ms", 10))
 }
 
-func TestCollector_InferenceIdleRecordsZero(t *testing.T) {
+func TestCollector_InferenceIdlePeriod(t *testing.T) {
 	t.Parallel()
 	store := NewMemoryStore(10)
 	collector := NewCollector(store, 1*time.Second, func() float64 { return 0 })
 
 	counters := &inferencestats.CounterMap{}
-	counters.RecordInvoke("test-model", 5000)
+	counters.RecordInvoke("BirdNET_V2.4", 5000)
 	collector.SetInferenceCounters(counters)
 
-	// First tick: establishes baseline
+	// Two ticks with no new data between them
+	collector.collect()
 	collector.collect()
 
-	// Second tick: no new invocations — should record 0
-	collector.collect()
-	avgPts := store.Get("birdnet.invoke_avg_ms", 10)
+	avgPts := store.Get("inference.BirdNET_V2_4.avg_ms", 10)
 	require.Len(t, avgPts, 1)
-	assert.InDelta(t, 0.0, avgPts[0].Value, 0.01)
+	assert.InDelta(t, 0.0, avgPts[0].Value, 0.001, "idle period should record 0")
 }
 
 func TestReadThermalZone_OutOfRangeTemperature(t *testing.T) {

--- a/internal/observability/collector_test.go
+++ b/internal/observability/collector_test.go
@@ -182,9 +182,9 @@ func TestCollector_CollectsInferenceMetrics(t *testing.T) {
 	store := NewMemoryStore(10)
 	collector := NewCollector(store, 1*time.Second, func() float64 { return 0 })
 
-	counters := &inferencestats.Counters{}
-	counters.RecordInvoke(5000)  // 5ms
-	counters.RecordInvoke(15000) // 15ms
+	counters := &inferencestats.CounterMap{}
+	counters.RecordInvoke("test-model", 5000)  // 5ms
+	counters.RecordInvoke("test-model", 15000) // 15ms
 	collector.SetInferenceCounters(counters)
 
 	// First tick: only max (no previous snapshot for avg)
@@ -198,7 +198,7 @@ func TestCollector_CollectsInferenceMetrics(t *testing.T) {
 	assert.Nil(t, avgPts, "avg should not be recorded on first tick")
 
 	// Record more data for second tick
-	counters.RecordInvoke(8000) // 8ms
+	counters.RecordInvoke("test-model", 8000) // 8ms
 
 	// Second tick: should have avg
 	collector.collect()
@@ -213,8 +213,8 @@ func TestCollector_InferenceIdleRecordsZero(t *testing.T) {
 	store := NewMemoryStore(10)
 	collector := NewCollector(store, 1*time.Second, func() float64 { return 0 })
 
-	counters := &inferencestats.Counters{}
-	counters.RecordInvoke(5000)
+	counters := &inferencestats.CounterMap{}
+	counters.RecordInvoke("test-model", 5000)
 	collector.SetInferenceCounters(counters)
 
 	// First tick: establishes baseline

--- a/internal/observability/collector_test.go
+++ b/internal/observability/collector_test.go
@@ -188,9 +188,12 @@ func TestCollector_CollectsInferenceMetrics(t *testing.T) {
 	counters.RecordInvoke("Perch_V2", 8000)      // 8ms
 	collector.SetInferenceCounters(counters)
 
+	birdnetKey := inferencestats.MetricKey("BirdNET_V2.4")
+	perchKey := inferencestats.MetricKey("Perch_V2")
+
 	// First tick: no avg yet (no previous snapshot)
 	collector.collect()
-	avgPts := store.Get("inference.BirdNET_V2_4.avg_ms", 10)
+	avgPts := store.Get(birdnetKey, 10)
 	assert.Nil(t, avgPts, "avg should not be recorded on first tick")
 
 	// Record more data for second tick
@@ -200,11 +203,11 @@ func TestCollector_CollectsInferenceMetrics(t *testing.T) {
 	// Second tick: should have per-model avg
 	collector.collect()
 
-	birdnetAvg := store.Get("inference.BirdNET_V2_4.avg_ms", 10)
+	birdnetAvg := store.Get(birdnetKey, 10)
 	require.Len(t, birdnetAvg, 1)
 	assert.InDelta(t, 10.0, birdnetAvg[0].Value, 0.01) // 10ms / 1 invoke
 
-	perchAvg := store.Get("inference.Perch_V2.avg_ms", 10)
+	perchAvg := store.Get(perchKey, 10)
 	require.Len(t, perchAvg, 1)
 	assert.InDelta(t, 6.0, perchAvg[0].Value, 0.01) // 6ms / 1 invoke
 
@@ -226,7 +229,7 @@ func TestCollector_InferenceIdlePeriod(t *testing.T) {
 	collector.collect()
 	collector.collect()
 
-	avgPts := store.Get("inference.BirdNET_V2_4.avg_ms", 10)
+	avgPts := store.Get(inferencestats.MetricKey("BirdNET_V2.4"), 10)
 	require.Len(t, avgPts, 1)
 	assert.InDelta(t, 0.0, avgPts[0].Value, 0.001, "idle period should record 0")
 }


### PR DESCRIPTION
## Summary

- Add per-model inference time tracking for all models (BirdNET, Perch V2, Bat)
- Previously only BirdNET recorded inference timing; Perch V2 and Bat had no visibility
- Display stacked colored sparklines in the system overview inference card
- Each model shows its own inference time, color-coded line, and per-model threshold status

## Changes

**Backend:**
- `CounterMap` in `inferencestats` package: per-model lock-free atomic counters using `sync.Map`
- Recording moved from `BirdNET.Predict` to `Orchestrator.PredictModel` for uniform tracking
- `Orchestrator.Predict` now delegates to `PredictModel` for consistent telemetry
- Collector emits per-model metrics (`inference.<model>.avg_ms`) instead of single aggregate
- Shared `inferencestats.MetricKey()` function ensures collector and API produce matching keys
- New `GET /api/v2/system/models` endpoint returns active model metadata (ID, name, metric key, chunk duration)

**Frontend:**
- `Sparkline.svelte` extended to support multiple datasets with shared Y-axis scaling
- `MetricStrip.svelte` inference card shows stacked sparklines with per-model legend
- Per-model threshold calculation (BirdNET uses overlap, others use full chunk duration)
- Worst-case status badge across all models
- `ModelMetrics` interface extracted to shared types file

## Test Plan
- [x] `CounterMap` unit tests (concurrent access, snapshot, reset-on-read)
- [x] Collector tests verify per-model metric keys emitted correctly
- [x] `go test -race ./...` passes
- [x] `golangci-lint run` clean
- [x] `svelte-check` 0 errors
- [ ] Manual: run with BirdNET + Perch V2, verify both sparklines appear

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-model inference tracking with multi-series sparkline visualization
  * New API endpoint to list active models and their specs

* **Improvements**
  * Overview shows aggregated worst-status badge and selects a primary model for the main inference value
  * Per-model thresholds respect model chunking and BirdNET overlap
  * Metrics loading and live updates driven by per-model histories (SSE)
  * Temperature unavailable formatting tweaked

* **Tests / Docs**
  * Added tests for per-model inference counters and API documentation for the new endpoint

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3012)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->