### PR TITLE
fix(audiocore): propagate source sample rate through audio export pipeline

### DIFF
--- a/internal/analysis/processor/actions_database.go
+++ b/internal/analysis/processor/actions_database.go
@@ -378,8 +378,13 @@ func (a *SaveAudioAction) Execute(ctx context.Context, _ any) error {
 		return err
 	}
 
+	exportRate := a.sourceSampleRate
+	if exportRate <= 0 {
+		exportRate = conf.SampleRate
+	}
+
 	if a.Settings.Realtime.Audio.Export.Type == "wav" {
-		if err := convert.SavePCMDataToWAV(outputPath, a.pcmData, conf.SampleRate, conf.BitDepth); err != nil {
+		if err := convert.SavePCMDataToWAV(outputPath, a.pcmData, exportRate, conf.BitDepth); err != nil {
 			return err
 		}
 	} else {
@@ -389,7 +394,7 @@ func (a *SaveAudioAction) Execute(ctx context.Context, _ any) error {
 			OutputPath: outputPath,
 			Format:     exportSettings.Type,
 			Bitrate:    exportSettings.Bitrate,
-			SampleRate: conf.SampleRate,
+			SampleRate: exportRate,
 			Channels:   conf.NumChannels,
 			BitDepth:   conf.BitDepth,
 			FFmpegPath: a.Settings.Realtime.Audio.FfmpegPath,
@@ -429,6 +434,7 @@ func (a *SaveAudioAction) Execute(ctx context.Context, _ any) error {
 		logger.String("clip_path", a.ClipName),
 		logger.Int64("file_size_bytes", fileSize),
 		logger.String("format", a.Settings.Realtime.Audio.Export.Type),
+		logger.Int("sample_rate", exportRate),
 		logger.String("operation", "audio_export_success"))
 
 	// Signal that the clip file exists on disk. This is used by any late
@@ -441,14 +447,15 @@ func (a *SaveAudioAction) Execute(ctx context.Context, _ any) error {
 	if a.Settings.Realtime.Dashboard.Spectrogram.Enabled && a.PreRenderer != nil {
 		// Create pre-render job using local DTO (avoids direct spectrogram dependency)
 		job := PreRenderJob{
-			PCMData:   a.pcmData,
-			ClipPath:  outputPath, // Use full path to audio file
-			NoteID:    a.NoteID,
-			Timestamp: time.Now(),
+			PCMData:    a.pcmData,
+			SampleRate: exportRate,
+			ClipPath:   outputPath, // Use full path to audio file
+			NoteID:     a.NoteID,
+			Timestamp:  time.Now(),
 		}
 
 		// Non-blocking submission - errors logged but don't fail action
-		if err := a.PreRenderer.Submit(job); err != nil {
+		if err := a.PreRenderer.Submit(&job); err != nil {
 			GetLogger().Warn("Failed to submit spectrogram pre-render job",
 				logger.String("component", "analysis.processor.actions"),
 				logger.String("detection_id", a.CorrelationID),

--- a/internal/analysis/processor/actions_types.go
+++ b/internal/analysis/processor/actions_types.go
@@ -101,33 +101,36 @@ type SaveAudioAction struct {
 	// still writing the tail of the clip). Execute() reads from the capture
 	// buffer once readyAt has passed, and the job queue retries the action
 	// in the meantime.
-	bufferMgr     *buffer.Manager
-	sourceID      string
-	beginTime     time.Time
-	duration      int
-	readyAt       time.Time
-	NoteID        uint              // Note ID for correlation logging with pre-renderer
-	PreRenderer   PreRendererSubmit // Injected from processor
-	DetectionCtx  *DetectionContext // Shared context to signal ClipSaved to late consumers
-	EventTracker  *EventTracker
-	Description   string
-	CorrelationID string // Detection correlation ID for log tracking
+	bufferMgr        *buffer.Manager
+	sourceID         string
+	beginTime        time.Time
+	duration         int
+	readyAt          time.Time
+	sourceSampleRate int               // Actual source capture rate for correct export headers
+	NoteID           uint              // Note ID for correlation logging with pre-renderer
+	PreRenderer      PreRendererSubmit // Injected from processor
+	DetectionCtx     *DetectionContext // Shared context to signal ClipSaved to late consumers
+	EventTracker     *EventTracker
+	Description      string
+	CorrelationID    string // Detection correlation ID for log tracking
 }
 
 // PreRenderJob represents a spectrogram pre-rendering task.
 // This is a local DTO to avoid direct coupling to spectrogram package types.
 type PreRenderJob struct {
-	PCMData   []byte    // Raw PCM data from memory (s16le, 48kHz, mono)
-	ClipPath  string    // Full absolute path to audio clip file
-	NoteID    uint      // For logging correlation
-	Timestamp time.Time // Job submission time
+	PCMData    []byte    // Raw PCM data from memory (s16le, mono)
+	SampleRate int       // PCM sample rate in Hz
+	ClipPath   string    // Full absolute path to audio clip file
+	NoteID     uint      // For logging correlation
+	Timestamp  time.Time // Job submission time
 }
 
 // Methods to expose fields (allows prerenderer to access without importing processor)
-func (j PreRenderJob) GetPCMData() []byte      { return j.PCMData }
-func (j PreRenderJob) GetClipPath() string     { return j.ClipPath }
-func (j PreRenderJob) GetNoteID() uint         { return j.NoteID }
-func (j PreRenderJob) GetTimestamp() time.Time { return j.Timestamp }
+func (j *PreRenderJob) GetPCMData() []byte      { return j.PCMData }
+func (j *PreRenderJob) GetSampleRate() int      { return j.SampleRate }
+func (j *PreRenderJob) GetClipPath() string     { return j.ClipPath }
+func (j *PreRenderJob) GetNoteID() uint         { return j.NoteID }
+func (j *PreRenderJob) GetTimestamp() time.Time { return j.Timestamp }
 
 // PreRendererSubmit is an interface for submitting pre-render jobs.
 // Callers create PreRenderJob instances, and the implementation adapts them
@@ -135,6 +138,7 @@ func (j PreRenderJob) GetTimestamp() time.Time { return j.Timestamp }
 type PreRendererSubmit interface {
 	Submit(job interface {
 		GetPCMData() []byte
+		GetSampleRate() int
 		GetClipPath() string
 		GetNoteID() uint
 		GetTimestamp() time.Time

--- a/internal/analysis/processor/processor.go
+++ b/internal/analysis/processor/processor.go
@@ -1993,17 +1993,18 @@ func (p *Processor) buildSaveAudioAction(det *Detections, detectionCtx *Detectio
 	captureEndTime := det.Result.BeginTime.Add(time.Duration(captureLength) * time.Second)
 	if p.BufferMgr != nil && captureEndTime.After(time.Now()) {
 		return &SaveAudioAction{
-			Settings:      settings,
-			ClipName:      det.Result.ClipName,
-			bufferMgr:     p.BufferMgr,
-			sourceID:      det.Result.AudioSource.ID,
-			beginTime:     det.Result.BeginTime,
-			duration:      captureLength,
-			readyAt:       captureEndTime,
-			NoteID:        det.Result.ID, // May be 0 here; updated after DB save via DetectionCtx
-			PreRenderer:   p.preRenderer,
-			DetectionCtx:  detectionCtx,
-			CorrelationID: det.CorrelationID,
+			Settings:         settings,
+			ClipName:         det.Result.ClipName,
+			bufferMgr:        p.BufferMgr,
+			sourceID:         det.Result.AudioSource.ID,
+			beginTime:        det.Result.BeginTime,
+			duration:         captureLength,
+			readyAt:          captureEndTime,
+			sourceSampleRate: det.Result.AudioSource.SampleRate,
+			NoteID:           det.Result.ID, // May be 0 here; updated after DB save via DetectionCtx
+			PreRenderer:      p.preRenderer,
+			DetectionCtx:     detectionCtx,
+			CorrelationID:    det.CorrelationID,
 		}
 	}
 
@@ -2022,23 +2023,25 @@ func (p *Processor) buildSaveAudioAction(det *Detections, detectionCtx *Detectio
 			logger.String("operation", "capture_buffer_read_for_export"))
 		// Return an action with nil pcmData; Execute() will be a no-op
 		return &SaveAudioAction{
-			Settings:      settings,
-			ClipName:      det.Result.ClipName,
-			NoteID:        det.Result.ID, // May be 0 here; updated after DB save via DetectionCtx
-			PreRenderer:   p.preRenderer,
-			DetectionCtx:  detectionCtx,
-			CorrelationID: det.CorrelationID,
+			Settings:         settings,
+			ClipName:         det.Result.ClipName,
+			sourceSampleRate: det.Result.AudioSource.SampleRate,
+			NoteID:           det.Result.ID, // May be 0 here; updated after DB save via DetectionCtx
+			PreRenderer:      p.preRenderer,
+			DetectionCtx:     detectionCtx,
+			CorrelationID:    det.CorrelationID,
 		}
 	}
 
 	return &SaveAudioAction{
-		Settings:      settings,
-		ClipName:      det.Result.ClipName,
-		pcmData:       pcmData,
-		NoteID:        det.Result.ID, // May be 0 here; updated after DB save via DetectionCtx
-		PreRenderer:   p.preRenderer,
-		DetectionCtx:  detectionCtx,
-		CorrelationID: det.CorrelationID,
+		Settings:         settings,
+		ClipName:         det.Result.ClipName,
+		pcmData:          pcmData,
+		sourceSampleRate: det.Result.AudioSource.SampleRate,
+		NoteID:           det.Result.ID, // May be 0 here; updated after DB save via DetectionCtx
+		PreRenderer:      p.preRenderer,
+		DetectionCtx:     detectionCtx,
+		CorrelationID:    det.CorrelationID,
 	}
 }
 

--- a/internal/analysis/processor/processor.go
+++ b/internal/analysis/processor/processor.go
@@ -1024,11 +1024,13 @@ func (p *Processor) resolveAudioSource(source datastore.AudioSource) detection.A
 			audioSource.SafeString = existingSource.SafeString
 			audioSource.DisplayName = existingSource.DisplayName
 			audioSource.Type = detection.DetermineSourceType(existingSource.SafeString)
+			audioSource.SampleRate = existingSource.SampleRate
 		} else if existingSource, exists := registry.Get(source.ID); exists {
 			audioSource.ID = existingSource.ID
 			audioSource.SafeString = existingSource.SafeString
 			audioSource.DisplayName = existingSource.DisplayName
 			audioSource.Type = detection.DetermineSourceType(existingSource.SafeString)
+			audioSource.SampleRate = existingSource.SampleRate
 		}
 	}
 

--- a/internal/analysis/processor/processor.go
+++ b/internal/analysis/processor/processor.go
@@ -1034,6 +1034,12 @@ func (p *Processor) resolveAudioSource(source datastore.AudioSource) detection.A
 		}
 	}
 
+	if audioSource.SampleRate <= 0 && p.BufferMgr != nil {
+		if cb, err := p.BufferMgr.CaptureBuffer(source.ID); err == nil {
+			audioSource.SampleRate = cb.SampleRate()
+		}
+	}
+
 	return audioSource
 }
 

--- a/internal/analysis/processor/processor.go
+++ b/internal/analysis/processor/processor.go
@@ -1035,7 +1035,7 @@ func (p *Processor) resolveAudioSource(source datastore.AudioSource) detection.A
 	}
 
 	if audioSource.SampleRate <= 0 && p.BufferMgr != nil {
-		if cb, err := p.BufferMgr.CaptureBuffer(source.ID); err == nil {
+		if cb, err := p.BufferMgr.CaptureBuffer(audioSource.ID); err == nil {
 			audioSource.SampleRate = cb.SampleRate()
 		}
 	}

--- a/internal/audiocore/buffer/capture.go
+++ b/internal/audiocore/buffer/capture.go
@@ -316,6 +316,12 @@ func (cb *CaptureBuffer) extractSegment(startIdx, endIdx int) []byte {
 	return seg
 }
 
+// SampleRate returns the capture sample rate in Hz.
+// This value is immutable after construction.
+func (cb *CaptureBuffer) SampleRate() int {
+	return cb.sampleRate
+}
+
 // StartTime returns the wall-clock time corresponding to the first byte of the
 // buffer. Returns the zero time if no data has been written yet.
 //

--- a/internal/audiocore/buffer/capture_test.go
+++ b/internal/audiocore/buffer/capture_test.go
@@ -488,6 +488,31 @@ func TestCaptureBuffer_MonotonicBaseOffset(t *testing.T) {
 	}
 }
 
+// TestCaptureBuffer_SampleRate verifies that SampleRate returns the value
+// passed to NewCaptureBuffer unchanged, across all expected sample rates.
+func TestCaptureBuffer_SampleRate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		sampleRate int
+	}{
+		{name: "standard 48kHz", sampleRate: 48000},
+		{name: "high 192kHz", sampleRate: 192000},
+		{name: "bat 256kHz", sampleRate: 256000},
+		{name: "max 384kHz", sampleRate: 384000},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cb, err := buffer.NewCaptureBuffer(10, tt.sampleRate, 2, "test-source")
+			require.NoError(t, err)
+			assert.Equal(t, tt.sampleRate, cb.SampleRate())
+		})
+	}
+}
+
 // TestCaptureBuffer_AlignmentPaddedBaseOffset verifies that the base offset
 // calculation is correct when the backing buffer includes alignment padding.
 // With a sample rate that does NOT produce a buffer size evenly divisible by

--- a/internal/detection/audio_source.go
+++ b/internal/detection/audio_source.go
@@ -10,6 +10,7 @@ type AudioSource struct {
 	Type        string // "rtsp", "alsa", "pulseaudio", "file"
 	DisplayName string // User-friendly name (e.g., "Front Yard Camera")
 	SafeString  string // Connection string with credentials removed (for logging)
+	SampleRate  int    // Source capture sample rate in Hz (0 = default 48kHz)
 }
 
 // NewAudioSource creates an AudioSource with the given ID.
@@ -23,12 +24,13 @@ func NewAudioSource(id string) AudioSource {
 }
 
 // NewAudioSourceWithDetails creates an AudioSource with full details.
-func NewAudioSourceWithDetails(id, sourceType, displayName, safeString string) AudioSource {
+func NewAudioSourceWithDetails(id, sourceType, displayName, safeString string, sampleRate int) AudioSource {
 	return AudioSource{
 		ID:          id,
 		Type:        sourceType,
 		DisplayName: displayName,
 		SafeString:  safeString,
+		SampleRate:  sampleRate,
 	}
 }
 

--- a/internal/spectrogram/generator.go
+++ b/internal/spectrogram/generator.go
@@ -348,14 +348,15 @@ func (g *Generator) GenerateFromFile(ctx context.Context, audioPath, outputPath 
 
 // GenerateFromPCM creates a spectrogram from in-memory PCM data.
 // Used by pre-renderer (background mode).
-// PCM format: s16le, 48kHz, mono
+// PCM format: s16le, mono. sampleRate is the source capture rate in Hz;
+// pass 0 to fall back to conf.SampleRate (48000 Hz).
 //
 // Context Timeout Behavior:
 // This function enforces a 60-second timeout for spectrogram generation.
 // The pre-renderer also sets its own timeout (see prerenderer.go:416), so the
 // effective timeout will be whichever is shorter. This layered approach ensures
 // both the pre-renderer and generator have safety limits.
-func (g *Generator) GenerateFromPCM(ctx context.Context, pcmData []byte, outputPath string, width int, raw bool) error {
+func (g *Generator) GenerateFromPCM(ctx context.Context, pcmData []byte, outputPath string, width int, raw bool, sampleRate int) error {
 	start := time.Now()
 	g.log().Debug("Starting spectrogram generation from PCM",
 		logger.String("output_path", outputPath),
@@ -410,7 +411,7 @@ func (g *Generator) GenerateFromPCM(ctx context.Context, pcmData []byte, outputP
 	defer cancel()
 
 	// Generate directly from PCM stdin (no FFmpeg needed)
-	if err := g.generateWithSoxPCM(ctx, settings, pcmData, outputPath, width, raw); err != nil {
+	if err := g.generateWithSoxPCM(ctx, settings, pcmData, outputPath, width, raw, sampleRate); err != nil {
 		return err
 	}
 
@@ -686,8 +687,9 @@ func (g *Generator) generateWithFFmpegSoxPipeline(ctx context.Context, settings 
 
 // generateWithSoxPCM generates a spectrogram by feeding PCM data directly to Sox stdin.
 // This bypasses FFmpeg entirely, reducing CPU overhead and memory usage.
-// PCM format: s16le, 48kHz, mono
-func (g *Generator) generateWithSoxPCM(ctx context.Context, settings *conf.Settings, pcmData []byte, outputPath string, width int, raw bool) error {
+// PCM format: s16le, mono. sampleRate is the source capture rate in Hz;
+// pass 0 to fall back to conf.SampleRate (48000 Hz).
+func (g *Generator) generateWithSoxPCM(ctx context.Context, settings *conf.Settings, pcmData []byte, outputPath string, width int, raw bool, sampleRate int) error {
 	soxBinary := settings.Realtime.Audio.SoxPath
 	if soxBinary == "" {
 		return errors.Newf("sox binary not configured").
@@ -697,11 +699,17 @@ func (g *Generator) generateWithSoxPCM(ctx context.Context, settings *conf.Setti
 			Build()
 	}
 
+	// Use provided sample rate; fall back to default when caller passes 0
+	effectiveRate := sampleRate
+	if effectiveRate <= 0 {
+		effectiveRate = conf.SampleRate
+	}
+
 	// Build Sox arguments for PCM stdin
 	// PCM format parameters use constants from conf package for consistency
 	args := []string{
 		"-t", "raw", // Input type: raw/headerless PCM
-		"-r", strconv.Itoa(conf.SampleRate), // Sample rate: 48kHz
+		"-r", strconv.Itoa(effectiveRate), // Sample rate from source
 		"-e", "signed", // Encoding: signed integer
 		"-b", strconv.Itoa(conf.BitDepth), // Bit depth: 16-bit
 		"-c", strconv.Itoa(conf.NumChannels), // Channels: mono

--- a/internal/spectrogram/generator_test.go
+++ b/internal/spectrogram/generator_test.go
@@ -162,7 +162,7 @@ func TestGenerator_GenerateFromPCM_MissingBinary(t *testing.T) {
 	outputPath := filepath.Join(env.TempDir, "test.png")
 	pcmData := []byte{0, 1, 2, 3}
 
-	err := gen.GenerateFromPCM(t.Context(), pcmData, outputPath, 400, false)
+	err := gen.GenerateFromPCM(t.Context(), pcmData, outputPath, 400, false, 0)
 	assert.Error(t, err, "GenerateFromPCM() should error when Sox binary not configured")
 }
 
@@ -488,7 +488,7 @@ func TestGenerateFromPCM_Validation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := gen.GenerateFromPCM(t.Context(), tt.pcmData, tt.outputPath, tt.width, false)
+			err := gen.GenerateFromPCM(t.Context(), tt.pcmData, tt.outputPath, tt.width, false, 0)
 
 			if tt.wantErr {
 				require.Error(t, err, "expected error for invalid input")
@@ -658,7 +658,7 @@ func TestGenerateWithSoxPCM_MissingBinary(t *testing.T) {
 	outputPath := filepath.Join(env.TempDir, "test.png")
 	pcmData := []byte{0, 1, 2, 3, 4, 5, 6, 7}
 
-	err := gen.generateWithSoxPCM(t.Context(), gen.currentSettings(), pcmData, outputPath, 400, false)
+	err := gen.generateWithSoxPCM(t.Context(), gen.currentSettings(), pcmData, outputPath, 400, false, 0)
 	require.Error(t, err, "should error when Sox binary not configured")
 	assert.Contains(t, err.Error(), "sox binary not configured", "error should mention sox binary")
 }
@@ -833,7 +833,7 @@ func TestOperationalErrors_SetLowPriority(t *testing.T) {
 			outputPath := filepath.Join(env.TempDir, "test_"+tt.name+".png")
 			pcmData := []byte{0, 1, 2, 3}
 
-			err := gen.GenerateFromPCM(ctx, pcmData, outputPath, 400, false)
+			err := gen.GenerateFromPCM(ctx, pcmData, outputPath, 400, false, 0)
 			require.Error(t, err, "expected error from cancelled/expired context")
 
 			var enhancedErr *errors.EnhancedError
@@ -857,7 +857,7 @@ func TestNonOperationalErrors_NoExplicitPriority(t *testing.T) {
 
 	// Use a valid (non-cancelled) context — the error will be "exec: /nonexistent/sox: not found"
 	// which is NOT an operational error
-	err := gen.GenerateFromPCM(t.Context(), pcmData, outputPath, 400, false)
+	err := gen.GenerateFromPCM(t.Context(), pcmData, outputPath, 400, false, 0)
 	require.Error(t, err, "expected error from missing binary execution")
 
 	var enhancedErr *errors.EnhancedError

--- a/internal/spectrogram/prerenderer.go
+++ b/internal/spectrogram/prerenderer.go
@@ -64,14 +64,16 @@ type PreRenderer struct {
 
 // Job represents a single spectrogram generation task.
 type Job struct {
-	PCMData   []byte    // Raw PCM data from memory (s16le, 48kHz, mono)
-	ClipPath  string    // Full absolute path to audio clip; PNG path is derived by swapping extension
-	NoteID    uint      // For logging correlation
-	Timestamp time.Time // Job submission time
+	PCMData    []byte    // Raw PCM data from memory (s16le, mono)
+	SampleRate int       // PCM sample rate in Hz (0 = use conf.SampleRate default)
+	ClipPath   string    // Full absolute path to audio clip; PNG path is derived by swapping extension
+	NoteID     uint      // For logging correlation
+	Timestamp  time.Time // Job submission time
 }
 
 // Methods to match the interface (allows Job to be submitted directly in tests)
 func (j *Job) GetPCMData() []byte      { return j.PCMData }
+func (j *Job) GetSampleRate() int      { return j.SampleRate }
 func (j *Job) GetClipPath() string     { return j.ClipPath }
 func (j *Job) GetNoteID() uint         { return j.NoteID }
 func (j *Job) GetTimestamp() time.Time { return j.Timestamp }
@@ -193,16 +195,18 @@ func (pr *PreRenderer) Stop() {
 // Accepts PreRenderJob from processor package to avoid circular dependency.
 func (pr *PreRenderer) Submit(jobDTO interface {
 	GetPCMData() []byte
+	GetSampleRate() int
 	GetClipPath() string
 	GetNoteID() uint
 	GetTimestamp() time.Time
 }) (err error) {
 	// Convert DTO to internal Job type
 	job := &Job{
-		PCMData:   jobDTO.GetPCMData(),
-		ClipPath:  jobDTO.GetClipPath(),
-		NoteID:    jobDTO.GetNoteID(),
-		Timestamp: jobDTO.GetTimestamp(),
+		PCMData:    jobDTO.GetPCMData(),
+		SampleRate: jobDTO.GetSampleRate(),
+		ClipPath:   jobDTO.GetClipPath(),
+		NoteID:     jobDTO.GetNoteID(),
+		Timestamp:  jobDTO.GetTimestamp(),
 	}
 
 	// Early check: skip if spectrogram already exists (avoid queueing duplicate jobs)
@@ -453,7 +457,7 @@ func (pr *PreRenderer) processJob(job *Job, workerID int) {
 		logger.String("operation", "spectrogram_generation_start"))
 
 	// Generate spectrogram using shared generator
-	if err := pr.generator.GenerateFromPCM(ctx, job.PCMData, spectrogramPath, width, specSettings.Raw); err != nil {
+	if err := pr.generator.GenerateFromPCM(ctx, job.PCMData, spectrogramPath, width, specSettings.Raw, job.SampleRate); err != nil {
 		// Check if this is an expected operational error (context canceled, process killed)
 		// These are normal events during shutdown, timeout, or resource management
 		if IsOperationalError(err) {


### PR DESCRIPTION
## Summary

- Fixes audio export using hardcoded 48kHz headers regardless of actual source capture rate, causing slowed-down playback at high rates (192kHz, 256kHz, 384kHz)
- Adds `SampleRate()` getter to `CaptureBuffer` and `SampleRate` field to `detection.AudioSource`
- Threads the actual source sample rate from the registry through `resolveAudioSource` into `SaveAudioAction`, replacing `conf.SampleRate` in both WAV and FFmpeg export paths
- Updates the spectrogram pre-renderer and sox pipeline to use the source rate instead of hardcoded 48kHz
- Falls back to `conf.SampleRate` (48kHz) when source rate is unavailable (file-based analysis)

## Test Plan

- [x] `TestCaptureBuffer_SampleRate` covers 48kHz, 192kHz, 256kHz, 384kHz
- [x] 869 tests pass across affected packages (buffer, detection, processor, spectrogram)
- [x] `golangci-lint run` clean on all affected packages
- [x] No stale `conf.SampleRate` references remain in the export path
- [ ] Manual: configure a high-rate source, verify exported clips play at correct speed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Audio export now preserves the actual source sample rate, improving audio fidelity and compatibility.
  * Spectrograms are generated using the source capture rate so visualizations accurately match the audio.
  * When a source rate is missing, the system now infers and uses the correct rate to keep exports and visuals consistent.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3013)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->