### PR TITLE
feat(audiocore): format-aware downsampling at audio export time

### DIFF
--- a/internal/analysis/processor/actions_database.go
+++ b/internal/analysis/processor/actions_database.go
@@ -498,6 +498,7 @@ func (a *SaveAudioAction) resolveExportParams(outputPath string) (rate int, form
 				logger.String("operation", "audio_export_resample"))
 		} else {
 			a.pcmData = resampled
+			a.sourceSampleRate = conf.SampleRate
 			rate = conf.SampleRate
 		}
 	}

--- a/internal/analysis/processor/actions_database.go
+++ b/internal/analysis/processor/actions_database.go
@@ -12,6 +12,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/audiocore/convert"
 	"github.com/tphakala/birdnet-go/internal/audiocore/ffmpeg"
 	"github.com/tphakala/birdnet-go/internal/audiocore/resample"
+	"github.com/tphakala/birdnet-go/internal/classifier"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/datastore/v2/entities"
@@ -430,7 +431,7 @@ func (a *SaveAudioAction) Execute(ctx context.Context, _ any) error {
 	GetLogger().Info("Audio clip saved successfully",
 		logger.String("component", "analysis.processor.actions"),
 		logger.String("detection_id", a.CorrelationID),
-		logger.String("clip_path", a.ClipName),
+		logger.String("clip_path", filepath.Base(outputPath)),
 		logger.Int64("file_size_bytes", fileSize),
 		logger.String("format", exportFormat),
 		logger.Int("sample_rate", exportRate),
@@ -516,4 +517,22 @@ func replaceExtension(path, newExt string) string {
 		return path + newExt
 	}
 	return path[:len(path)-len(ext)] + newExt
+}
+
+// needsBatFormatFallback returns true when the model is a bat classifier
+// and the configured export format cannot carry its high sample rate.
+func needsBatFormatFallback(modelID, exportFormat string) bool {
+	modelInfo := classifier.DetectionModelInfoForID(modelID)
+	if detection.ResolveModelType(modelInfo.Name, modelInfo.Version) != entities.ModelTypeBat {
+		return false
+	}
+	spec, ok := classifier.GetModelSpec(modelID)
+	if !ok || spec.EffectiveSampleRate() <= conf.SampleRate {
+		return false
+	}
+	switch exportFormat {
+	case "mp3", "opus", "aac":
+		return true
+	}
+	return false
 }

--- a/internal/analysis/processor/actions_database.go
+++ b/internal/analysis/processor/actions_database.go
@@ -11,8 +11,10 @@ import (
 
 	"github.com/tphakala/birdnet-go/internal/audiocore/convert"
 	"github.com/tphakala/birdnet-go/internal/audiocore/ffmpeg"
+	"github.com/tphakala/birdnet-go/internal/audiocore/resample"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/datastore"
+	"github.com/tphakala/birdnet-go/internal/datastore/v2/entities"
 	"github.com/tphakala/birdnet-go/internal/detection"
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/events"
@@ -378,12 +380,9 @@ func (a *SaveAudioAction) Execute(ctx context.Context, _ any) error {
 		return err
 	}
 
-	exportRate := a.sourceSampleRate
-	if exportRate <= 0 {
-		exportRate = conf.SampleRate
-	}
+	exportRate, exportFormat, outputPath := a.resolveExportParams(outputPath)
 
-	if a.Settings.Realtime.Audio.Export.Type == "wav" {
+	if exportFormat == "wav" {
 		if err := convert.SavePCMDataToWAV(outputPath, a.pcmData, exportRate, conf.BitDepth); err != nil {
 			return err
 		}
@@ -392,7 +391,7 @@ func (a *SaveAudioAction) Execute(ctx context.Context, _ any) error {
 		opts := &ffmpeg.ExportOptions{
 			PCMData:    a.pcmData,
 			OutputPath: outputPath,
-			Format:     exportSettings.Type,
+			Format:     exportFormat,
 			Bitrate:    exportSettings.Bitrate,
 			SampleRate: exportRate,
 			Channels:   conf.NumChannels,
@@ -433,7 +432,7 @@ func (a *SaveAudioAction) Execute(ctx context.Context, _ any) error {
 		logger.String("detection_id", a.CorrelationID),
 		logger.String("clip_path", a.ClipName),
 		logger.Int64("file_size_bytes", fileSize),
-		logger.String("format", a.Settings.Realtime.Audio.Export.Type),
+		logger.String("format", exportFormat),
 		logger.Int("sample_rate", exportRate),
 		logger.String("operation", "audio_export_success"))
 
@@ -467,4 +466,54 @@ func (a *SaveAudioAction) Execute(ctx context.Context, _ any) error {
 	}
 
 	return nil
+}
+
+// resolveExportParams determines the export sample rate, format, and output
+// path. Bird audio at rates above 48kHz is downsampled. Bat audio keeps the
+// native rate; if the configured format cannot carry it, the format is
+// silently switched to WAV.
+func (a *SaveAudioAction) resolveExportParams(outputPath string) (rate int, format, path string) {
+	rate = a.sourceSampleRate
+	if rate <= 0 {
+		rate = conf.SampleRate
+	}
+
+	format = a.Settings.Realtime.Audio.Export.Type
+	path = outputPath
+	isBat := detection.ResolveModelType(a.modelName, "") == entities.ModelTypeBat
+
+	if rate > conf.SampleRate && !isBat {
+		resampled, err := resample.ResampleBytes(a.pcmData, rate, conf.SampleRate)
+		if err != nil {
+			GetLogger().Warn("Resampling failed, exporting at source rate",
+				logger.String("component", "analysis.processor.actions"),
+				logger.String("detection_id", a.CorrelationID),
+				logger.Int("source_rate", rate),
+				logger.Int("target_rate", conf.SampleRate),
+				logger.Error(err),
+				logger.String("operation", "audio_export_resample"))
+		} else {
+			a.pcmData = resampled
+			rate = conf.SampleRate
+		}
+	}
+
+	if isBat && rate > conf.SampleRate {
+		switch format {
+		case "mp3", "opus", "aac":
+			format = "wav"
+			path = replaceExtension(path, ".wav")
+		}
+	}
+
+	return rate, format, path
+}
+
+// replaceExtension swaps the file extension on path (e.g. ".mp3" -> ".wav").
+func replaceExtension(path, newExt string) string {
+	ext := filepath.Ext(path)
+	if ext == "" {
+		return path + newExt
+	}
+	return path[:len(path)-len(ext)] + newExt
 }

--- a/internal/analysis/processor/actions_database.go
+++ b/internal/analysis/processor/actions_database.go
@@ -12,7 +12,6 @@ import (
 	"github.com/tphakala/birdnet-go/internal/audiocore/convert"
 	"github.com/tphakala/birdnet-go/internal/audiocore/ffmpeg"
 	"github.com/tphakala/birdnet-go/internal/audiocore/resample"
-	"github.com/tphakala/birdnet-go/internal/classifier"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/datastore/v2/entities"
@@ -481,9 +480,13 @@ func (a *SaveAudioAction) resolveExportParams(outputPath string) (rate int, form
 
 	format = a.Settings.Realtime.Audio.Export.Type
 	path = outputPath
+
 	isBat := detection.ResolveModelType(a.modelName, "") == entities.ModelTypeBat
 
-	if rate > conf.SampleRate && !isBat {
+	if needsBatFormatFallback(a.modelName, "", rate, format) {
+		format = "wav"
+		path = replaceExtension(path, ".wav")
+	} else if rate > conf.SampleRate && !isBat {
 		resampled, err := resample.ResampleBytes(a.pcmData, rate, conf.SampleRate)
 		if err != nil {
 			GetLogger().Warn("Resampling failed, exporting at source rate",
@@ -496,14 +499,6 @@ func (a *SaveAudioAction) resolveExportParams(outputPath string) (rate int, form
 		} else {
 			a.pcmData = resampled
 			rate = conf.SampleRate
-		}
-	}
-
-	if isBat && rate > conf.SampleRate {
-		switch format {
-		case "mp3", "opus", "aac":
-			format = "wav"
-			path = replaceExtension(path, ".wav")
 		}
 	}
 
@@ -520,14 +515,13 @@ func replaceExtension(path, newExt string) string {
 }
 
 // needsBatFormatFallback returns true when the model is a bat classifier
-// and the configured export format cannot carry its high sample rate.
-func needsBatFormatFallback(modelID, exportFormat string) bool {
-	modelInfo := classifier.DetectionModelInfoForID(modelID)
-	if detection.ResolveModelType(modelInfo.Name, modelInfo.Version) != entities.ModelTypeBat {
+// and the actual source sample rate exceeds what the configured export
+// format can carry (MP3/Opus/AAC cap at 48kHz).
+func needsBatFormatFallback(modelName, modelVersion string, sourceRate int, exportFormat string) bool {
+	if detection.ResolveModelType(modelName, modelVersion) != entities.ModelTypeBat {
 		return false
 	}
-	spec, ok := classifier.GetModelSpec(modelID)
-	if !ok || spec.EffectiveSampleRate() <= conf.SampleRate {
+	if sourceRate <= conf.SampleRate {
 		return false
 	}
 	switch exportFormat {

--- a/internal/analysis/processor/actions_types.go
+++ b/internal/analysis/processor/actions_types.go
@@ -107,6 +107,7 @@ type SaveAudioAction struct {
 	duration         int
 	readyAt          time.Time
 	sourceSampleRate int               // Actual source capture rate for correct export headers
+	modelName        string            // Detection model name (e.g. "BattyBirdNET") for export strategy
 	NoteID           uint              // Note ID for correlation logging with pre-renderer
 	PreRenderer      PreRendererSubmit // Injected from processor
 	DetectionCtx     *DetectionContext // Shared context to signal ClipSaved to late consumers

--- a/internal/analysis/processor/processor.go
+++ b/internal/analysis/processor/processor.go
@@ -2007,6 +2007,7 @@ func (p *Processor) buildSaveAudioAction(det *Detections, detectionCtx *Detectio
 			duration:         captureLength,
 			readyAt:          captureEndTime,
 			sourceSampleRate: det.Result.AudioSource.SampleRate,
+			modelName:        det.Result.Model.Name,
 			NoteID:           det.Result.ID, // May be 0 here; updated after DB save via DetectionCtx
 			PreRenderer:      p.preRenderer,
 			DetectionCtx:     detectionCtx,
@@ -2032,6 +2033,7 @@ func (p *Processor) buildSaveAudioAction(det *Detections, detectionCtx *Detectio
 			Settings:         settings,
 			ClipName:         det.Result.ClipName,
 			sourceSampleRate: det.Result.AudioSource.SampleRate,
+			modelName:        det.Result.Model.Name,
 			NoteID:           det.Result.ID, // May be 0 here; updated after DB save via DetectionCtx
 			PreRenderer:      p.preRenderer,
 			DetectionCtx:     detectionCtx,
@@ -2044,6 +2046,7 @@ func (p *Processor) buildSaveAudioAction(det *Detections, detectionCtx *Detectio
 		ClipName:         det.Result.ClipName,
 		pcmData:          pcmData,
 		sourceSampleRate: det.Result.AudioSource.SampleRate,
+		modelName:        det.Result.Model.Name,
 		NoteID:           det.Result.ID, // May be 0 here; updated after DB save via DetectionCtx
 		PreRenderer:      p.preRenderer,
 		DetectionCtx:     detectionCtx,

--- a/internal/analysis/processor/processor.go
+++ b/internal/analysis/processor/processor.go
@@ -919,6 +919,13 @@ func (p *Processor) createDetection(settings *conf.Settings, item classifier.Res
 	// Create file name for audio clip
 	clipName := p.generateClipName(settings, scientificName, result.Confidence)
 
+	// Bat models at high sample rates need WAV when the configured format
+	// (MP3/Opus/AAC) cannot carry rates above 48kHz. Override the extension
+	// now so the database stores the same filename the export will write.
+	if needsBatFormatFallback(item.ModelID, settings.Realtime.Audio.Export.Type) {
+		clipName = replaceExtension(clipName, ".wav")
+	}
+
 	// Get capture length and pre-capture length for detection end time calculation
 	captureLength := time.Duration(settings.Realtime.Audio.Export.Length) * time.Second
 	preCaptureLength := time.Duration(settings.Realtime.Audio.Export.PreCapture) * time.Second

--- a/internal/analysis/processor/processor.go
+++ b/internal/analysis/processor/processor.go
@@ -922,7 +922,9 @@ func (p *Processor) createDetection(settings *conf.Settings, item classifier.Res
 	// Bat models at high sample rates need WAV when the configured format
 	// (MP3/Opus/AAC) cannot carry rates above 48kHz. Override the extension
 	// now so the database stores the same filename the export will write.
-	if needsBatFormatFallback(item.ModelID, settings.Realtime.Audio.Export.Type) {
+	mInfo := classifier.DetectionModelInfoForID(item.ModelID)
+	sourceRate := p.resolveAudioSource(item.Source).SampleRate
+	if needsBatFormatFallback(mInfo.Name, mInfo.Version, sourceRate, settings.Realtime.Audio.Export.Type) {
 		clipName = replaceExtension(clipName, ".wav")
 	}
 

--- a/internal/analysis/processor/save_audio_downsample_test.go
+++ b/internal/analysis/processor/save_audio_downsample_test.go
@@ -191,6 +191,35 @@ func TestSaveAudioAction_BatOpusFallsBackToWAV(t *testing.T) {
 	assert.Equal(t, sourceRate, rate, "fallback WAV should preserve native 256kHz rate")
 }
 
+// TestNeedsBatFormatFallback verifies the bat format fallback logic using
+// the classifier model registry.
+func TestNeedsBatFormatFallback(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		modelID  string
+		format   string
+		expected bool
+	}{
+		{"bat_mp3", "Bat", "mp3", true},
+		{"bat_opus", "Bat", "opus", true},
+		{"bat_aac", "Bat", "aac", true},
+		{"bat_wav", "Bat", "wav", false},
+		{"bat_flac", "Bat", "flac", false},
+		{"bird_mp3", "BirdNET_V2.4", "mp3", false},
+		{"bird_wav", "BirdNET_V2.4", "wav", false},
+		{"unknown_model", "Unknown", "mp3", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expected, needsBatFormatFallback(tt.modelID, tt.format))
+		})
+	}
+}
+
 // TestReplaceExtension verifies the file extension replacement helper.
 func TestReplaceExtension(t *testing.T) {
 	t.Parallel()

--- a/internal/analysis/processor/save_audio_downsample_test.go
+++ b/internal/analysis/processor/save_audio_downsample_test.go
@@ -192,30 +192,32 @@ func TestSaveAudioAction_BatOpusFallsBackToWAV(t *testing.T) {
 }
 
 // TestNeedsBatFormatFallback verifies the bat format fallback logic using
-// the classifier model registry.
+// model name, source rate, and export format.
 func TestNeedsBatFormatFallback(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
 		name     string
-		modelID  string
+		model    string
+		rate     int
 		format   string
 		expected bool
 	}{
-		{"bat_mp3", "Bat", "mp3", true},
-		{"bat_opus", "Bat", "opus", true},
-		{"bat_aac", "Bat", "aac", true},
-		{"bat_wav", "Bat", "wav", false},
-		{"bat_flac", "Bat", "flac", false},
-		{"bird_mp3", "BirdNET_V2.4", "mp3", false},
-		{"bird_wav", "BirdNET_V2.4", "wav", false},
-		{"unknown_model", "Unknown", "mp3", false},
+		{"bat_high_rate_mp3", "BattyBirdNET", 256000, "mp3", true},
+		{"bat_high_rate_opus", "BattyBirdNET", 256000, "opus", true},
+		{"bat_high_rate_aac", "BattyBirdNET", 256000, "aac", true},
+		{"bat_high_rate_wav", "BattyBirdNET", 256000, "wav", false},
+		{"bat_high_rate_flac", "BattyBirdNET", 256000, "flac", false},
+		{"bat_low_rate_mp3", "BattyBirdNET", 48000, "mp3", false},
+		{"bird_high_rate_mp3", "BirdNET", 192000, "mp3", false},
+		{"bird_low_rate_wav", "BirdNET", 48000, "wav", false},
+		{"unknown_model", "Unknown", 256000, "mp3", false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			assert.Equal(t, tt.expected, needsBatFormatFallback(tt.modelID, tt.format))
+			assert.Equal(t, tt.expected, needsBatFormatFallback(tt.model, "", tt.rate, tt.format))
 		})
 	}
 }

--- a/internal/analysis/processor/save_audio_downsample_test.go
+++ b/internal/analysis/processor/save_audio_downsample_test.go
@@ -1,0 +1,216 @@
+package processor
+
+import (
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tphakala/birdnet-go/internal/conf"
+)
+
+// makeSilentPCM16 creates a zero-filled 16-bit PCM byte slice with the given
+// number of samples. Silence is valid PCM and compresses well, making it
+// suitable for fast integration tests that only care about metadata.
+func makeSilentPCM16(t *testing.T, sampleCount int) []byte {
+	t.Helper()
+	return make([]byte, sampleCount*2)
+}
+
+// readWAVSampleRate parses the sample rate from a WAV file header (bytes 24-27).
+func readWAVSampleRate(t *testing.T, path string) int {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(data), 28, "WAV file too short to contain sample rate field")
+	return int(binary.LittleEndian.Uint32(data[24:28]))
+}
+
+// TestSaveAudioAction_BirdDownsampledTo48kHz verifies that bird detections
+// at high sample rates (e.g. 192kHz) are downsampled to 48kHz on export.
+func TestSaveAudioAction_BirdDownsampledTo48kHz(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	settings := conf.NewTestSettings().
+		WithAudioExport(tmpDir, "wav", "192k").
+		Build()
+
+	const sourceRate = 192000
+	const durationSamples = sourceRate * 3 // 3 seconds
+	pcm := makeSilentPCM16(t, durationSamples)
+
+	action := &SaveAudioAction{
+		Settings:         settings,
+		ClipName:         "bird-192k.wav",
+		pcmData:          pcm,
+		sourceSampleRate: sourceRate,
+		modelName:        "BirdNET",
+		CorrelationID:    "test-bird-downsample",
+	}
+
+	require.NoError(t, action.Execute(t.Context(), nil))
+
+	outputPath := filepath.Join(tmpDir, "bird-192k.wav")
+	rate := readWAVSampleRate(t, outputPath)
+	assert.Equal(t, conf.SampleRate, rate, "bird audio should be downsampled to 48kHz")
+}
+
+// TestSaveAudioAction_BatPreservesNativeRate verifies that bat detections
+// at high sample rates export at the native rate without downsampling.
+func TestSaveAudioAction_BatPreservesNativeRate(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	settings := conf.NewTestSettings().
+		WithAudioExport(tmpDir, "wav", "192k").
+		Build()
+
+	const sourceRate = 256000
+	const durationSamples = sourceRate * 3
+	pcm := makeSilentPCM16(t, durationSamples)
+
+	action := &SaveAudioAction{
+		Settings:         settings,
+		ClipName:         "bat-256k.wav",
+		pcmData:          pcm,
+		sourceSampleRate: sourceRate,
+		modelName:        "BattyBirdNET",
+		CorrelationID:    "test-bat-native",
+	}
+
+	require.NoError(t, action.Execute(t.Context(), nil))
+
+	outputPath := filepath.Join(tmpDir, "bat-256k.wav")
+	rate := readWAVSampleRate(t, outputPath)
+	assert.Equal(t, sourceRate, rate, "bat audio should stay at 256kHz")
+}
+
+// TestSaveAudioAction_BatMP3FallsBackToWAV verifies that bat detections
+// configured with MP3 (which caps at 48kHz) silently fall back to WAV.
+func TestSaveAudioAction_BatMP3FallsBackToWAV(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	settings := conf.NewTestSettings().
+		WithAudioExport(tmpDir, "mp3", "192k").
+		Build()
+
+	const sourceRate = 256000
+	const durationSamples = sourceRate * 3
+	pcm := makeSilentPCM16(t, durationSamples)
+
+	action := &SaveAudioAction{
+		Settings:         settings,
+		ClipName:         "bat-256k.mp3",
+		pcmData:          pcm,
+		sourceSampleRate: sourceRate,
+		modelName:        "BattyBirdNET",
+		CorrelationID:    "test-bat-mp3-fallback",
+	}
+
+	require.NoError(t, action.Execute(t.Context(), nil))
+
+	// MP3 file should NOT exist
+	mp3Path := filepath.Join(tmpDir, "bat-256k.mp3")
+	_, err := os.Stat(mp3Path)
+	assert.True(t, os.IsNotExist(err), "MP3 file should not be created for bat audio at high rates")
+
+	// WAV file SHOULD exist
+	wavPath := filepath.Join(tmpDir, "bat-256k.wav")
+	rate := readWAVSampleRate(t, wavPath)
+	assert.Equal(t, sourceRate, rate, "fallback WAV should preserve native 256kHz rate")
+}
+
+// TestSaveAudioAction_BirdAt48kHzNoResample verifies that bird audio already
+// at 48kHz is not resampled (no unnecessary work).
+func TestSaveAudioAction_BirdAt48kHzNoResample(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	settings := conf.NewTestSettings().
+		WithAudioExport(tmpDir, "wav", "192k").
+		Build()
+
+	const sourceRate = 48000
+	const durationSamples = sourceRate * 3
+	pcm := makeSilentPCM16(t, durationSamples)
+
+	action := &SaveAudioAction{
+		Settings:         settings,
+		ClipName:         "bird-48k.wav",
+		pcmData:          pcm,
+		sourceSampleRate: sourceRate,
+		modelName:        "BirdNET",
+		CorrelationID:    "test-bird-48k",
+	}
+
+	require.NoError(t, action.Execute(t.Context(), nil))
+
+	outputPath := filepath.Join(tmpDir, "bird-48k.wav")
+	rate := readWAVSampleRate(t, outputPath)
+	assert.Equal(t, sourceRate, rate, "bird audio at 48kHz should not be resampled")
+}
+
+// TestSaveAudioAction_BatOpusFallsBackToWAV verifies that Opus format also
+// falls back to WAV for bat audio at high sample rates.
+func TestSaveAudioAction_BatOpusFallsBackToWAV(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	settings := conf.NewTestSettings().
+		WithAudioExport(tmpDir, "opus", "128k").
+		Build()
+
+	const sourceRate = 256000
+	const durationSamples = sourceRate * 3
+	pcm := makeSilentPCM16(t, durationSamples)
+
+	action := &SaveAudioAction{
+		Settings:         settings,
+		ClipName:         "bat-256k.opus",
+		pcmData:          pcm,
+		sourceSampleRate: sourceRate,
+		modelName:        "BattyBirdNET",
+		CorrelationID:    "test-bat-opus-fallback",
+	}
+
+	require.NoError(t, action.Execute(t.Context(), nil))
+
+	// Opus file should NOT exist
+	opusPath := filepath.Join(tmpDir, "bat-256k.opus")
+	_, err := os.Stat(opusPath)
+	assert.True(t, os.IsNotExist(err), "Opus file should not be created for bat audio at high rates")
+
+	// WAV file SHOULD exist
+	wavPath := filepath.Join(tmpDir, "bat-256k.wav")
+	rate := readWAVSampleRate(t, wavPath)
+	assert.Equal(t, sourceRate, rate, "fallback WAV should preserve native 256kHz rate")
+}
+
+// TestReplaceExtension verifies the file extension replacement helper.
+func TestReplaceExtension(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		path     string
+		newExt   string
+		expected string
+	}{
+		{"mp3_to_wav", "/audio/bird.mp3", ".wav", "/audio/bird.wav"},
+		{"opus_to_wav", "/audio/bat.opus", ".wav", "/audio/bat.wav"},
+		{"no_extension", "/audio/clip", ".wav", "/audio/clip.wav"},
+		{"nested_path", "/data/2026/05/bat-256k.mp3", ".wav", "/data/2026/05/bat-256k.wav"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expected, replaceExtension(tt.path, tt.newExt))
+		})
+	}
+}

--- a/internal/audiocore/resample/resample.go
+++ b/internal/audiocore/resample/resample.go
@@ -169,7 +169,7 @@ func (r *Resampler) String() string {
 // ResampleBytes is a one-shot convenience function that resamples raw 16-bit
 // PCM bytes from one sample rate to another. It creates a temporary Resampler,
 // processes the input, and returns an independent copy of the output.
-// Returns the input unchanged when fromRate == toRate.
+// When fromRate == toRate, returns the input slice directly (no copy, no allocation).
 func ResampleBytes(pcm []byte, fromRate, toRate int) ([]byte, error) {
 	if fromRate == toRate {
 		return pcm, nil

--- a/internal/audiocore/resample/resample.go
+++ b/internal/audiocore/resample/resample.go
@@ -163,5 +163,30 @@ func (r *Resampler) Close() error {
 
 // String returns a human-readable description of the resampler for logging.
 func (r *Resampler) String() string {
-	return fmt.Sprintf("Resampler(%d→%d Hz)", r.fromRate, r.toRate)
+	return fmt.Sprintf("Resampler(%d->%d Hz)", r.fromRate, r.toRate)
+}
+
+// ResampleBytes is a one-shot convenience function that resamples raw 16-bit
+// PCM bytes from one sample rate to another. It creates a temporary Resampler,
+// processes the input, and returns an independent copy of the output.
+// Returns the input unchanged when fromRate == toRate.
+func ResampleBytes(pcm []byte, fromRate, toRate int) ([]byte, error) {
+	if fromRate == toRate {
+		return pcm, nil
+	}
+
+	r, err := NewResampler(fromRate, toRate)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = r.Close() }()
+
+	out, err := r.ResampleInto(pcm)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]byte, len(out))
+	copy(result, out)
+	return result, nil
 }

--- a/internal/audiocore/resample/resample_test.go
+++ b/internal/audiocore/resample/resample_test.go
@@ -142,6 +142,53 @@ func TestResampler_OddByteInput(t *testing.T) {
 	require.NotNil(t, r)
 	t.Cleanup(func() { require.NoError(t, r.Close()) })
 
-	_, err = r.ResampleInto([]byte{0x01, 0x02, 0x03}) // 3 bytes — not a multiple of 2
+	_, err = r.ResampleInto([]byte{0x01, 0x02, 0x03}) // 3 bytes - not a multiple of 2
 	assert.Error(t, err)
+}
+
+// TestResampleBytes_Downsamples verifies the one-shot helper correctly
+// downsamples 256kHz to 48kHz, producing approximately 48/256 of the input samples.
+func TestResampleBytes_Downsamples(t *testing.T) {
+	const fromRate = 256000
+	const toRate = 48000
+	const inputSamples = 25600 // 100 ms at 256 kHz
+
+	input := makePCM16(t, inputSamples)
+	output, err := ResampleBytes(input, fromRate, toRate)
+	require.NoError(t, err)
+
+	assert.Equal(t, 0, len(output)%bytesPerSample, "output must contain complete 16-bit samples")
+
+	outputSamples := len(output) / bytesPerSample
+	expectedSamples := inputSamples * toRate / fromRate
+	tolerance := expectedSamples / 10 // 10%
+	assert.InDelta(t, expectedSamples, outputSamples, float64(tolerance),
+		"output sample count should be approximately %d (got %d)", expectedSamples, outputSamples)
+}
+
+// TestResampleBytes_SameRate verifies that equal rates return the input unchanged.
+func TestResampleBytes_SameRate(t *testing.T) {
+	input := makePCM16(t, 100)
+	output, err := ResampleBytes(input, 48000, 48000)
+	require.NoError(t, err)
+	assert.Equal(t, input, output)
+}
+
+// TestResampleBytes_ReturnsIndependentCopy verifies the output does not alias
+// the internal resampler buffer (which would be freed on Close).
+func TestResampleBytes_ReturnsIndependentCopy(t *testing.T) {
+	input := makePCM16(t, 4800)
+	output, err := ResampleBytes(input, 48000, 32000)
+	require.NoError(t, err)
+	require.NotEmpty(t, output)
+
+	saved := make([]byte, len(output))
+	copy(saved, output)
+
+	// A second call with different data must not corrupt the first result.
+	input2 := makePCM16(t, 9600)
+	_, err = ResampleBytes(input2, 48000, 32000)
+	require.NoError(t, err)
+
+	assert.Equal(t, saved, output, "first result must remain unchanged after second call")
 }


### PR DESCRIPTION
## Summary

- Bird detections at high sample rates (192kHz+) are downsampled to 48kHz before encoding, reducing file sizes 4-8x with no information loss (bird vocalizations top out at ~12kHz)
- Bat detections export at native rate (e.g. 256kHz) to preserve ultrasonic content
- When bat audio uses a format that caps at 48kHz (MP3, Opus, AAC), the format silently falls back to WAV

## Changes

- **`internal/audiocore/resample/resample.go`**: Add `ResampleBytes` one-shot convenience function for batch PCM resampling
- **`internal/analysis/processor/actions_types.go`**: Add `modelName` field to `SaveAudioAction` for export strategy decisions
- **`internal/analysis/processor/processor.go`**: Wire `modelName` from `det.Result.Model.Name` in all three `buildSaveAudioAction` paths
- **`internal/analysis/processor/actions_database.go`**: Extract `resolveExportParams` method handling downsampling + format fallback; add `replaceExtension` helper

## Test plan

- [x] Bird audio at 192kHz downsampled to 48kHz WAV (verified via WAV header)
- [x] Bat audio at 256kHz preserved at native rate
- [x] Bat + MP3 config silently falls back to WAV
- [x] Bat + Opus config silently falls back to WAV
- [x] Bird at 48kHz passes through without resampling
- [x] `replaceExtension` helper (4 cases)
- [x] `ResampleBytes` one-shot: downsample, same-rate, independent copy
- [x] All 666 existing tests pass with race detector
- [x] Zero linter issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved audio export: bird audio is downsampled to 48 kHz when appropriate; bat audio preserves native high sample rates. High-rate bat exports configured for MP3/Opus/AAC now fall back to WAV, and export logs report the effective format, sample rate, and clip filename.
* **Tests**
  * Added tests covering resampling, format fallback behavior, export outputs, and filename/extension handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3014)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->