### PR TITLE
fix(classifier): replace metrics RWMutex with atomic.Pointer and document span safety

### DIFF
--- a/internal/classifier/analyze.go
+++ b/internal/classifier/analyze.go
@@ -74,8 +74,8 @@ func (bn *BirdNET) Predict(ctx context.Context, sample [][]float32) ([]datastore
 		span.SetTag("error", "true")
 		span.SetData("error_type", "invoke_failed")
 
-		if globalMetrics != nil {
-			globalMetrics.RecordPrediction(bn.ModelInfo.ID, time.Since(start).Seconds(), err)
+		if m := getMetrics(); m != nil {
+			m.RecordPrediction(bn.ModelInfo.ID, time.Since(start).Seconds(), err)
 		}
 
 		return nil, err
@@ -85,8 +85,8 @@ func (bn *BirdNET) Predict(ctx context.Context, sample [][]float32) ([]datastore
 	span.SetData("invoke_duration_ms", invokeDuration.Milliseconds())
 
 	// Record model invoke timing separately
-	if globalMetrics != nil {
-		globalMetrics.RecordModelInvoke(bn.ModelInfo.ID, invokeDuration.Seconds())
+	if m := getMetrics(); m != nil {
+		m.RecordModelInvoke(bn.ModelInfo.ID, invokeDuration.Seconds())
 	}
 
 	// Use optimized sigmoid function with buffer reuse
@@ -106,8 +106,8 @@ func (bn *BirdNET) Predict(ctx context.Context, sample [][]float32) ([]datastore
 		span.SetData("error_type", "label_mismatch")
 
 		// Record error in metrics
-		if globalMetrics != nil {
-			globalMetrics.RecordPrediction(bn.ModelInfo.ID, time.Since(start).Seconds(), err)
+		if m := getMetrics(); m != nil {
+			m.RecordPrediction(bn.ModelInfo.ID, time.Since(start).Seconds(), err)
 		}
 
 		return nil, err

--- a/internal/classifier/tracing.go
+++ b/internal/classifier/tracing.go
@@ -18,7 +18,8 @@ import (
 // tagKeyModel is the tracing tag key used to identify the model in spans.
 const tagKeyModel = "model"
 
-// TracingSpan represents a traced operation with minimal overhead
+// TracingSpan represents a traced operation with minimal overhead.
+// A TracingSpan must not be used from multiple goroutines concurrently.
 type TracingSpan struct {
 	operation      string
 	description    string
@@ -32,8 +33,7 @@ type TracingSpan struct {
 
 // Global metrics instance (set by observability package)
 var (
-	globalMetrics    *metrics.BirdNETMetrics
-	metricsMutex     sync.RWMutex
+	globalMetrics    atomic.Pointer[metrics.BirdNETMetrics]
 	metricsOnce      sync.Once
 	activeOperations int64
 )
@@ -53,17 +53,13 @@ func GetInferenceCounters() *inferencestats.CounterMap {
 // metrics configuration remains consistent throughout the application lifecycle.
 func SetMetrics(m *metrics.BirdNETMetrics) {
 	metricsOnce.Do(func() {
-		metricsMutex.Lock()
-		defer metricsMutex.Unlock()
-		globalMetrics = m
+		globalMetrics.Store(m)
 	})
 }
 
-// getMetrics returns the current metrics instance in a thread-safe manner
+// getMetrics returns the current metrics instance in a thread-safe manner.
 func getMetrics() *metrics.BirdNETMetrics {
-	metricsMutex.RLock()
-	defer metricsMutex.RUnlock()
-	return globalMetrics
+	return globalMetrics.Load()
 }
 
 // StartSpan starts a new tracing span with minimal overhead

--- a/internal/classifier/tracing_test.go
+++ b/internal/classifier/tracing_test.go
@@ -1,0 +1,83 @@
+package classifier
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/observability/metrics"
+)
+
+// resetGlobalMetrics resets the package-level metrics state so each test
+// starts with a clean slate. Only safe in tests (same package).
+func resetGlobalMetrics(t *testing.T) {
+	t.Helper()
+	globalMetrics.Store(nil)
+	metricsOnce = sync.Once{}
+}
+
+// newTestMetrics creates a BirdNETMetrics instance backed by a throw-away
+// Prometheus registry, suitable for unit tests.
+func newTestMetrics(t *testing.T) *metrics.BirdNETMetrics {
+	t.Helper()
+	reg := prometheus.NewRegistry()
+	m, err := metrics.NewBirdNETMetrics(reg)
+	require.NoError(t, err, "creating test metrics must succeed")
+	return m
+}
+
+func TestSetMetrics_StoresAndReturnsInstance(t *testing.T) {
+	resetGlobalMetrics(t)
+	t.Cleanup(func() { resetGlobalMetrics(t) })
+
+	// Before SetMetrics, getMetrics should return nil.
+	assert.Nil(t, getMetrics(), "getMetrics must return nil before SetMetrics is called")
+
+	m := newTestMetrics(t)
+	SetMetrics(m)
+
+	got := getMetrics()
+	require.NotNil(t, got, "getMetrics must return the stored instance after SetMetrics")
+	assert.Same(t, m, got, "getMetrics must return the exact same pointer passed to SetMetrics")
+}
+
+func TestSetMetrics_IsIdempotent(t *testing.T) {
+	resetGlobalMetrics(t)
+	t.Cleanup(func() { resetGlobalMetrics(t) })
+
+	first := newTestMetrics(t)
+	second := newTestMetrics(t)
+
+	SetMetrics(first)
+	SetMetrics(second) // should be ignored
+
+	got := getMetrics()
+	assert.Same(t, first, got, "second call to SetMetrics must be ignored; first instance should persist")
+}
+
+func TestGetMetrics_IsSafeForConcurrentAccess(t *testing.T) {
+	resetGlobalMetrics(t)
+	t.Cleanup(func() { resetGlobalMetrics(t) })
+
+	m := newTestMetrics(t)
+	SetMetrics(m)
+
+	// Spin up several goroutines that all read concurrently.
+	const goroutines = 64
+	results := make(chan *metrics.BirdNETMetrics, goroutines)
+
+	var wg sync.WaitGroup
+	for range goroutines {
+		wg.Go(func() {
+			results <- getMetrics()
+		})
+	}
+	wg.Wait()
+	close(results)
+
+	for got := range results {
+		assert.Same(t, m, got, "concurrent getMetrics must always return the stored instance")
+	}
+}


### PR DESCRIPTION
## Summary

- Replace `sync.RWMutex` + plain pointer for `globalMetrics` with `atomic.Pointer[metrics.BirdNETMetrics]` for lock-free access on the inference hot path (`getMetrics()` is called on every `StartSpan`, `Finish`, and `Predict`)
- Update three direct `globalMetrics` accesses in `analyze.go` to use the `getMetrics()` accessor (required since `atomic.Pointer` cannot be compared with `!= nil`)
- Document `TracingSpan` as not safe for concurrent goroutine use (maps are lazily allocated without synchronization; spans are always single-goroutine scoped)
- Add test coverage for `SetMetrics`/`getMetrics`: store-and-retrieve, write-once idempotency, and concurrent read safety (64 goroutines)

## Related Issues

Fixes #583 - TracingSpan maps not thread-safe
Fixes #585 - Replace getMetrics() RWMutex with atomic.Pointer

## Test Plan

- [x] `go test -race -v ./internal/classifier/...` passes
- [x] `golangci-lint run -v ./internal/classifier/...` passes with zero issues
- [x] New tests verify atomic pointer store/retrieve, idempotency, and concurrent safety

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests covering metrics initialization procedures, idempotency verification, and safe concurrent access patterns to ensure system reliability.

* **Refactor**
  * Enhanced internal metrics infrastructure to optimize storage and access patterns, reducing synchronization overhead and improving performance during concurrent operations while maintaining thread safety.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3015)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->