### PR TITLE
fix(classifier): abort model uninstall when UnloadModel fails

### DIFF
--- a/internal/classifier/model_manager.go
+++ b/internal/classifier/model_manager.go
@@ -296,11 +296,18 @@ func (mm *ModelManager) Uninstall(catalogID string) error {
 	}
 
 	// Unload from orchestrator BEFORE deleting files to avoid crashes.
+	// If unload fails, abort the uninstall: the model may still be
+	// memory-mapped by a running inference engine, so deleting the
+	// file on disk could cause a segfault.
 	if mm.orchestrator != nil && entry.RegistryID != "" {
 		if err := mm.orchestrator.UnloadModel(entry.RegistryID); err != nil {
-			log.Warn("Failed to unload model from orchestrator",
-				logger.String("catalog_id", catalogID),
-				logger.Error(err))
+			return errors.Newf("cannot uninstall %s: model still in use", catalogID).
+				Component("classifier.model_manager").
+				Category(errors.CategorySystem).
+				Context("catalog_id", catalogID).
+				Context("registry_id", entry.RegistryID).
+				Context("unload_error", err.Error()).
+				Build()
 		}
 	}
 

--- a/internal/classifier/model_manager.go
+++ b/internal/classifier/model_manager.go
@@ -296,10 +296,11 @@ func (mm *ModelManager) Uninstall(catalogID string) error {
 	}
 
 	// Unload from orchestrator BEFORE deleting files to avoid crashes.
-	// If unload fails, abort the uninstall: the model may still be
-	// memory-mapped by a running inference engine, so deleting the
-	// file on disk could cause a segfault.
-	if mm.orchestrator != nil && entry.RegistryID != "" {
+	// Only attempt unload if the model is currently loaded; if it is not
+	// loaded, file deletion is safe (nothing is memory-mapping the ONNX file).
+	// If unload fails, abort: the model may still be memory-mapped by a
+	// running inference engine, so deleting the file could cause a segfault.
+	if mm.orchestrator != nil && entry.RegistryID != "" && mm.orchestrator.IsModelLoaded(entry.RegistryID) {
 		if err := mm.orchestrator.UnloadModel(entry.RegistryID); err != nil {
 			return errors.Newf("cannot uninstall %s: model still in use", catalogID).
 				Component("classifier.model_manager").

--- a/internal/classifier/model_manager_test.go
+++ b/internal/classifier/model_manager_test.go
@@ -401,8 +401,7 @@ func TestModelManager_UninstallSucceedsWhenModelNotLoaded(t *testing.T) {
 	subdir := filepath.Join(modelsDir, entry.ID)
 	require.NoError(t, os.MkdirAll(subdir, 0o755))
 
-	// Create model files on disk.
-	var modelPath string
+	// Create all catalog files on disk.
 	for _, f := range entry.Files {
 		var dir string
 		if f.Role == RoleEmbeddings {
@@ -411,11 +410,7 @@ func TestModelManager_UninstallSucceedsWhenModelNotLoaded(t *testing.T) {
 			dir = subdir
 		}
 		require.NoError(t, os.MkdirAll(dir, 0o755))
-		path := filepath.Join(dir, f.LocalName)
-		require.NoError(t, os.WriteFile(path, []byte("data"), 0o644))
-		if f.Role == RoleModel {
-			modelPath = path
-		}
+		require.NoError(t, os.WriteFile(filepath.Join(dir, f.LocalName), []byte("data"), 0o644))
 	}
 
 	// Orchestrator with empty models map: IsModelLoaded returns false,
@@ -432,9 +427,22 @@ func TestModelManager_UninstallSucceedsWhenModelNotLoaded(t *testing.T) {
 	require.NoError(t, err, "Uninstall must succeed when model is not loaded")
 	assert.False(t, mm.IsInstalled(entry.ID), "model must be removed from installed map")
 
-	// Model file must be deleted; labels are retained by design.
-	_, statErr := os.Stat(modelPath)
-	assert.True(t, os.IsNotExist(statErr), "model ONNX file must be deleted after uninstall")
+	// Verify per-role file expectations after uninstall.
+	for _, f := range entry.Files {
+		var path string
+		if f.Role == RoleEmbeddings {
+			path = filepath.Join(modelsDir, "shared", f.LocalName)
+		} else {
+			path = filepath.Join(subdir, f.LocalName)
+		}
+		_, statErr := os.Stat(path)
+		switch f.Role {
+		case RoleModel, RoleData:
+			assert.True(t, os.IsNotExist(statErr), "%s file %s must be deleted after uninstall", f.Role, f.LocalName)
+		case RoleLabels:
+			assert.NoError(t, statErr, "labels file %s must be retained after uninstall", f.LocalName)
+		}
+	}
 }
 
 func TestModelManager_UninstallAbortsOnUnloadFailure(t *testing.T) {

--- a/internal/classifier/model_manager_test.go
+++ b/internal/classifier/model_manager_test.go
@@ -390,11 +390,9 @@ func TestModelManager_Install_ConcurrentDownloadRejected(t *testing.T) {
 	assert.Contains(t, err.Error(), "already being downloaded")
 }
 
-func TestModelManager_UninstallAbortsOnUnloadFailure(t *testing.T) {
+func TestModelManager_UninstallSucceedsWhenModelNotLoaded(t *testing.T) {
 	t.Parallel()
 
-	// Use perch-v2 as the test subject: it has a RegistryID and is not the
-	// permanent model, so Uninstall will attempt to unload it.
 	entry, ok := GetCatalogEntry("perch-v2")
 	require.True(t, ok, "expected perch-v2 catalog entry to exist")
 	require.NotEmpty(t, entry.RegistryID, "perch-v2 must have a RegistryID for this test")
@@ -403,7 +401,53 @@ func TestModelManager_UninstallAbortsOnUnloadFailure(t *testing.T) {
 	subdir := filepath.Join(modelsDir, entry.ID)
 	require.NoError(t, os.MkdirAll(subdir, 0o755))
 
-	// Create all catalog files on disk so we can verify they survive.
+	// Create model files on disk.
+	var modelPath string
+	for _, f := range entry.Files {
+		var dir string
+		if f.Role == RoleEmbeddings {
+			dir = filepath.Join(modelsDir, "shared")
+		} else {
+			dir = subdir
+		}
+		require.NoError(t, os.MkdirAll(dir, 0o755))
+		path := filepath.Join(dir, f.LocalName)
+		require.NoError(t, os.WriteFile(path, []byte("data"), 0o644))
+		if f.Role == RoleModel {
+			modelPath = path
+		}
+	}
+
+	// Orchestrator with empty models map: IsModelLoaded returns false,
+	// so Uninstall skips the unload step and proceeds to delete files.
+	orch := &Orchestrator{
+		models: make(map[string]*modelEntry),
+	}
+
+	mm := NewModelManager(modelsDir, orch, nil)
+	mm.ScanInstalled()
+	require.True(t, mm.IsInstalled(entry.ID), "model must be installed before uninstall")
+
+	err := mm.Uninstall(entry.ID)
+	require.NoError(t, err, "Uninstall must succeed when model is not loaded")
+	assert.False(t, mm.IsInstalled(entry.ID), "model must be removed from installed map")
+
+	// Model file must be deleted; labels are retained by design.
+	_, statErr := os.Stat(modelPath)
+	assert.True(t, os.IsNotExist(statErr), "model ONNX file must be deleted after uninstall")
+}
+
+func TestModelManager_UninstallAbortsOnUnloadFailure(t *testing.T) {
+	t.Parallel()
+
+	entry, ok := GetCatalogEntry("perch-v2")
+	require.True(t, ok, "expected perch-v2 catalog entry to exist")
+	require.NotEmpty(t, entry.RegistryID, "perch-v2 must have a RegistryID for this test")
+
+	modelsDir := t.TempDir()
+	subdir := filepath.Join(modelsDir, entry.ID)
+	require.NoError(t, os.MkdirAll(subdir, 0o755))
+
 	for _, f := range entry.Files {
 		var dir string
 		if f.Role == RoleEmbeddings {
@@ -415,25 +459,28 @@ func TestModelManager_UninstallAbortsOnUnloadFailure(t *testing.T) {
 		require.NoError(t, os.WriteFile(filepath.Join(dir, f.LocalName), []byte("data"), 0o644))
 	}
 
-	// Create a minimal Orchestrator whose models map is empty so
-	// UnloadModel will fail with "model ... is not loaded".
+	// Orchestrator with the model present in the models map AND set as
+	// primary. IsModelLoaded returns true, but UnloadModel refuses to
+	// unload the primary model, simulating a "model still in use" failure.
+	primaryBN := &BirdNET{ModelInfo: ModelInfo{ID: entry.RegistryID}}
 	orch := &Orchestrator{
-		models: make(map[string]*modelEntry),
+		models: map[string]*modelEntry{
+			entry.RegistryID: {instance: primaryBN},
+		},
+		primary: primaryBN,
 	}
 
 	mm := NewModelManager(modelsDir, orch, nil)
 	mm.ScanInstalled()
 	require.True(t, mm.IsInstalled(entry.ID), "model must be installed before uninstall attempt")
 
-	// Uninstall should fail because UnloadModel cannot find the model.
 	err := mm.Uninstall(entry.ID)
 	require.Error(t, err, "Uninstall must return an error when UnloadModel fails")
 	assert.Contains(t, err.Error(), "model still in use")
 
-	// The model must still be marked as installed.
 	assert.True(t, mm.IsInstalled(entry.ID), "model must remain installed after failed uninstall")
 
-	// All files must still exist on disk (no deletion happened).
+	// All files must still exist on disk.
 	for _, f := range entry.Files {
 		var path string
 		if f.Role == RoleEmbeddings {

--- a/internal/classifier/model_manager_test.go
+++ b/internal/classifier/model_manager_test.go
@@ -390,6 +390,62 @@ func TestModelManager_Install_ConcurrentDownloadRejected(t *testing.T) {
 	assert.Contains(t, err.Error(), "already being downloaded")
 }
 
+func TestModelManager_UninstallAbortsOnUnloadFailure(t *testing.T) {
+	t.Parallel()
+
+	// Use perch-v2 as the test subject: it has a RegistryID and is not the
+	// permanent model, so Uninstall will attempt to unload it.
+	entry, ok := GetCatalogEntry("perch-v2")
+	require.True(t, ok, "expected perch-v2 catalog entry to exist")
+	require.NotEmpty(t, entry.RegistryID, "perch-v2 must have a RegistryID for this test")
+
+	modelsDir := t.TempDir()
+	subdir := filepath.Join(modelsDir, entry.ID)
+	require.NoError(t, os.MkdirAll(subdir, 0o755))
+
+	// Create all catalog files on disk so we can verify they survive.
+	for _, f := range entry.Files {
+		var dir string
+		if f.Role == RoleEmbeddings {
+			dir = filepath.Join(modelsDir, "shared")
+		} else {
+			dir = subdir
+		}
+		require.NoError(t, os.MkdirAll(dir, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, f.LocalName), []byte("data"), 0o644))
+	}
+
+	// Create a minimal Orchestrator whose models map is empty so
+	// UnloadModel will fail with "model ... is not loaded".
+	orch := &Orchestrator{
+		models: make(map[string]*modelEntry),
+	}
+
+	mm := NewModelManager(modelsDir, orch, nil)
+	mm.ScanInstalled()
+	require.True(t, mm.IsInstalled(entry.ID), "model must be installed before uninstall attempt")
+
+	// Uninstall should fail because UnloadModel cannot find the model.
+	err := mm.Uninstall(entry.ID)
+	require.Error(t, err, "Uninstall must return an error when UnloadModel fails")
+	assert.Contains(t, err.Error(), "model still in use")
+
+	// The model must still be marked as installed.
+	assert.True(t, mm.IsInstalled(entry.ID), "model must remain installed after failed uninstall")
+
+	// All files must still exist on disk (no deletion happened).
+	for _, f := range entry.Files {
+		var path string
+		if f.Role == RoleEmbeddings {
+			path = filepath.Join(modelsDir, "shared", f.LocalName)
+		} else {
+			path = filepath.Join(subdir, f.LocalName)
+		}
+		_, statErr := os.Stat(path)
+		assert.NoError(t, statErr, "file %s must still exist after aborted uninstall", f.LocalName)
+	}
+}
+
 func TestBuildHuggingFaceURL(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Change `ModelManager.Uninstall` to return an error when `UnloadModel` fails, instead of logging a warning and proceeding to delete model files from disk
- If the ONNX model is memory-mapped by a running inference engine, deleting the file could cause a segfault; the uninstall now aborts safely
- Add test that verifies: error is returned, model remains installed, and all files survive on disk

## Related Issues

Fixes #584 - ModelManager.Uninstall proceeds after UnloadModel failure

## Test Plan

- [x] `go test -race -v ./internal/classifier/...` passes
- [x] `golangci-lint run -v ./internal/classifier/...` passes with zero issues
- [x] New test `TestModelManager_UninstallAbortsOnUnloadFailure` exercises the fixed path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Model uninstallation now aborts with a clear error if unloading fails, preventing accidental deletion and preserving files for models still in use.

* **Tests**
  * Added tests validating successful uninstallation when a model is not loaded and abort-on-unload-failure behavior to ensure proper error reporting and file preservation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3016)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->