### PR TITLE
fix(Analysis): added a save button to the analysis settings page

### DIFF
--- a/frontend/src/lib/desktop/features/settings/pages/AnalysisSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/AnalysisSettingsPage.svelte
@@ -1487,7 +1487,7 @@
 
 <!-- ── Main Content ──────────────────────────────────────────────────── -->
 <main class="settings-page-content space-y-6" aria-label={t('analysis.title')}>
-  <SettingsTabs tabs={pageTabs} bind:activeTab={pageTab} showActions={pageTab === 'settings'} />
+  <SettingsTabs tabs={pageTabs} bind:activeTab={pageTab} />
 </main>
 
 <!-- License Acceptance Dialog -->

--- a/frontend/src/lib/desktop/features/settings/pages/AnalysisSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/AnalysisSettingsPage.svelte
@@ -1487,7 +1487,7 @@
 
 <!-- ── Main Content ──────────────────────────────────────────────────── -->
 <main class="settings-page-content space-y-6" aria-label={t('analysis.title')}>
-  <SettingsTabs tabs={pageTabs} bind:activeTab={pageTab} showActions={false} />
+  <SettingsTabs tabs={pageTabs} bind:activeTab={pageTab} showActions={pageTab === 'settings'} />
 </main>
 
 <!-- License Acceptance Dialog -->


### PR DESCRIPTION
There is no save button on the new analysis page for when you change a setting. This shows the button.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored actions on the Analysis Settings page so tab-specific actions are enabled correctly when viewing settings and models. Previously the tab bar suppressed actions; now it follows the default behavior and allows action controls to appear when appropriate, improving access to settings and model-related controls. This fixes the incorrect disabling of controls.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3023)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->