### PR TITLE
fix(Perch): add location filtering for perch model

### DIFF
--- a/internal/analysis/processor/processor.go
+++ b/internal/analysis/processor/processor.go
@@ -886,12 +886,18 @@ func (p *Processor) shouldFilterDetection(settings *conf.Settings, result datast
 		return true, confidenceThreshold
 	}
 
-	// Range filter applies only to BirdNET; Bat/Perch have independent species sets.
-	if strings.HasPrefix(modelID, detection.DefaultModelName) && !settings.IsSpeciesIncluded(result.Species) {
+	// Apply range filter to all bird classifiers when location-based filtering is active.
+	// Bat is excluded: bat species are not in the bird range filter species list.
+	// For non-BirdNET models (Perch, BSG, etc.), only apply when location is configured:
+	// the species list is built from BirdNET labels, so model-exclusive species absent
+	// from BirdNET's label set would be incorrectly filtered when no location is set.
+	isBirdNETModel := strings.HasPrefix(modelID, detection.DefaultModelName)
+	if modelID != classifier.RegistryIDBat && (isBirdNETModel || settings.BirdNET.LocationConfigured) && !settings.IsSpeciesIncluded(result.Species) {
 		if settings.Debug {
 			GetLogger().Debug("species not on included list",
 				logger.String("species", result.Species),
 				logger.Float32("confidence", result.Confidence),
+				logger.String("model_id", modelID),
 				logger.String("operation", "species_inclusion_filter"))
 		}
 		return true, confidenceThreshold

--- a/internal/analysis/processor/range_filter_test.go
+++ b/internal/analysis/processor/range_filter_test.go
@@ -1,0 +1,181 @@
+package processor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tphakala/birdnet-go/internal/classifier"
+	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/datastore"
+	"github.com/tphakala/birdnet-go/internal/detection"
+)
+
+// newRangeFilterProcessor creates a minimal Processor for range filter tests.
+func newRangeFilterProcessor() *Processor {
+	return &Processor{
+		Settings: &conf.Settings{
+			BirdNET: conf.BirdNETConfig{
+				Threshold: 0.1,
+			},
+		},
+		DynamicThresholds: make(map[string]*DynamicThreshold),
+		pendingResets:     make(map[string]struct{}),
+	}
+}
+
+// rangeFilterSettings builds a conf.Settings snapshot with the given species list
+// and location configuration.
+func rangeFilterSettings(species []string, locationConfigured bool) *conf.Settings {
+	return &conf.Settings{
+		BirdNET: conf.BirdNETConfig{
+			Threshold:          0.1,
+			LocationConfigured: locationConfigured,
+			RangeFilter: conf.RangeFilterSettings{
+				Species: species,
+			},
+		},
+	}
+}
+
+// TestRangeFilterPerchRespected verifies that Perch detections are filtered by the
+// range filter when a location is configured — the bug where Perch bypassed the
+// range filter entirely.
+func TestRangeFilterPerchRespected(t *testing.T) {
+	t.Parallel()
+
+	// Simulate a range filter list built from BirdNET labels.
+	// BirdNET label format: "Scientific Name_Common Name"
+	inRangeSpecies := []string{
+		"Turdus merula_Eurasian Blackbird",
+		"Parus major_Great Tit",
+	}
+
+	// Perch uses scientific names only.
+	perchModelID := classifier.RegistryIDPerchV2
+
+	tests := []struct {
+		name               string
+		speciesLabel       string // Perch scientific name
+		locationConfigured bool
+		wantFiltered       bool
+	}{
+		{
+			name:               "out-of-range Perch species filtered when location configured",
+			speciesLabel:       "Turdus migratorius", // American Robin — not in range list
+			locationConfigured: true,
+			wantFiltered:       true,
+		},
+		{
+			name:               "in-range Perch species passes when location configured",
+			speciesLabel:       "Turdus merula", // prefix of "Turdus merula_Eurasian Blackbird"
+			locationConfigured: true,
+			wantFiltered:       false,
+		},
+		{
+			name:               "Perch-exclusive species not filtered when location not configured",
+			speciesLabel:       "Turdus migratorius", // not in BirdNET label set subset
+			locationConfigured: false,
+			wantFiltered:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			p := newRangeFilterProcessor()
+			settings := rangeFilterSettings(inRangeSpecies, tt.locationConfigured)
+			result := datastore.Results{Species: tt.speciesLabel, Confidence: 0.9}
+
+			// Use non-human species names to avoid privacy filter.
+			filtered, _ := p.shouldFilterDetection(settings, result, "Some Bird", tt.speciesLabel, "some bird", 0.1, "test", perchModelID)
+
+			assert.Equal(t, tt.wantFiltered, filtered, "species=%q locationConfigured=%v", tt.speciesLabel, tt.locationConfigured)
+		})
+	}
+}
+
+// TestRangeFilterBirdNETUnchanged verifies that BirdNET filtering behaviour is
+// unchanged after the fix.
+func TestRangeFilterBirdNETUnchanged(t *testing.T) {
+	t.Parallel()
+
+	inRangeSpecies := []string{
+		"Turdus merula_Eurasian Blackbird",
+	}
+
+	birdnetModelID := detection.DefaultModelName + "_V2.4"
+
+	tests := []struct {
+		name               string
+		speciesLabel       string
+		locationConfigured bool
+		wantFiltered       bool
+	}{
+		{
+			name:               "out-of-range BirdNET species filtered when location configured",
+			speciesLabel:       "Turdus migratorius_American Robin",
+			locationConfigured: true,
+			wantFiltered:       true,
+		},
+		{
+			name:               "in-range BirdNET species passes when location configured",
+			speciesLabel:       "Turdus merula_Eurasian Blackbird",
+			locationConfigured: true,
+			wantFiltered:       false,
+		},
+		{
+			name:               "out-of-range BirdNET species filtered even when location not configured",
+			speciesLabel:       "Turdus migratorius_American Robin",
+			locationConfigured: false,
+			wantFiltered:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			p := newRangeFilterProcessor()
+			settings := rangeFilterSettings(inRangeSpecies, tt.locationConfigured)
+			result := datastore.Results{Species: tt.speciesLabel, Confidence: 0.9}
+
+			filtered, _ := p.shouldFilterDetection(settings, result, "Some Bird", "Turdus sp.", "some bird", 0.1, "test", birdnetModelID)
+
+			assert.Equal(t, tt.wantFiltered, filtered, "species=%q locationConfigured=%v", tt.speciesLabel, tt.locationConfigured)
+		})
+	}
+}
+
+// TestRangeFilterBatExempt verifies that Bat detections are never filtered by the
+// bird range filter, since bat species are not in the bird range filter species list.
+func TestRangeFilterBatExempt(t *testing.T) {
+	t.Parallel()
+
+	// Range filter list with no bat species (as in real use).
+	inRangeSpecies := []string{
+		"Turdus merula_Eurasian Blackbird",
+	}
+
+	batModelID := classifier.RegistryIDBat
+
+	tests := []struct {
+		name               string
+		locationConfigured bool
+	}{
+		{name: "bat not filtered when location configured", locationConfigured: true},
+		{name: "bat not filtered when location not configured", locationConfigured: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			p := newRangeFilterProcessor()
+			settings := rangeFilterSettings(inRangeSpecies, tt.locationConfigured)
+			// Bat species label not in the bird range filter list.
+			result := datastore.Results{Species: "Pipistrellus pipistrellus", Confidence: 0.9}
+
+			filtered, _ := p.shouldFilterDetection(settings, result, "Common Pipistrelle", "Pipistrellus pipistrellus", "common pipistrelle", 0.1, "test", batModelID)
+
+			assert.False(t, filtered, "bat detection should never be filtered by bird range filter")
+		})
+	}
+}


### PR DESCRIPTION
## Problem

When running both BirdNET and Google Perch classifiers simultaneously, Perch
detections completely bypassed the geographic range filter. Birds outside the
configured location appeared in the detection list.

The range filter check in shouldFilterDetection only applied to models whose ID
starts with "BirdNET". Since Perch's model ID is "Perch_V2", the condition was
always false for Perch — the range filter was silently skipped for every Perch
detection.

## Fix

The range filter now applies to all bird classifiers when location-based
filtering is active, with two guards:

- Bat is exempt: bat species are not in the bird range filter list — applying
  it would block all bat detections.

- Non-BirdNET models only filter when location is configured: when no location
  is set, the range filter species list is built from BirdNET's ~6,400 labels
  only. Perch has ~14,795 species; Perch-exclusive species absent from BirdNET's
  label set would be incorrectly blocked. When a location is configured, the
  list is geographically filtered and the check is correct for Perch too.

BirdNET behaviour is unchanged.

## Tests

Added range_filter_test.go with 8 sub-tests covering:

- Perch out-of-range species filtered when location configured (the bug)
- Perch in-range species passes when location configured
- Perch species not filtered when no location configured (Perch-exclusive regression)
- BirdNET behaviour unchanged across all location states
- Bat always exempt from the bird range filter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined species range filtering logic to correctly apply across different bird detection classifiers while properly exempting certain classifier types from range-based filtering.

* **Tests**
  * Added unit tests to verify range filter behavior across multiple detector types and location configurations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3024)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->