### PR TITLE
chore(deps): update Go and npm dependencies

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -984,9 +984,9 @@
       }
     },
     "node_modules/@jscpd/badge-reporter": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@jscpd/badge-reporter/-/badge-reporter-4.1.0.tgz",
-      "integrity": "sha512-18dLePKrcUGP25MnwAWW2pCv9k6jYQI/AmtEroF7h/gvxJ7IakFKYIzDO8MO/HcFwfFDzkKe3AP2ZSrgUvN84w==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@jscpd/badge-reporter/-/badge-reporter-4.1.1.tgz",
+      "integrity": "sha512-vRTrzYpmc8SlNLcE0YTO3wE8uZ2BeEPX5Jo17zITuuhOwQ/T9qamXBk504/6Y/gkt21lon/jb7dnEFE59TrCEw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -996,9 +996,9 @@
       }
     },
     "node_modules/@jscpd/core": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@jscpd/core/-/core-4.1.0.tgz",
-      "integrity": "sha512-6hnibDeLfIWS5Dfy1V/CUf2CijszSe1Z2dNymfqwGK1BDqGaaXqXU3WMZzL0Us131rGLIqqExjfQrBGDQ940TA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@jscpd/core/-/core-4.1.1.tgz",
+      "integrity": "sha512-oRGAA+jwm9PNOm4gpIbeWAi1ryPq4usKBtPPzMLJUn/egmh4W1T0RvwLwAuFJTbhy+o0hgqlS8X3OMkCOFKaHg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1006,14 +1006,14 @@
       }
     },
     "node_modules/@jscpd/finder": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@jscpd/finder/-/finder-4.1.0.tgz",
-      "integrity": "sha512-7bb6Ap+/BGmmZjopq6LZ7knXl2BW3uYvfRMg5eZ44KMzQBUZTAF154SdQMkFBA4tPZKOtMf1SjOJI55ja+2CFQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@jscpd/finder/-/finder-4.1.1.tgz",
+      "integrity": "sha512-6QTmZ8ruvYBUnAs3FXxF8zqT/x6MNfjDAw6PiYPdIG58G4GeIRLMNdjw7kFDjQo07FTnHKidToKNek3dN2jKAQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jscpd/core": "4.1.0",
-        "@jscpd/tokenizer": "4.1.0",
+        "@jscpd/core": "4.1.1",
+        "@jscpd/tokenizer": "4.1.1",
         "blamer": "^1.0.6",
         "bytes": "^3.1.2",
         "cli-table3": "^0.6.5",
@@ -1025,9 +1025,9 @@
       }
     },
     "node_modules/@jscpd/html-reporter": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@jscpd/html-reporter/-/html-reporter-4.1.0.tgz",
-      "integrity": "sha512-mINEEgtgITHGpF9U9vL/caf48msNarBeDJCBRA6S7xnHkIoDjjYNxeEyJSI7sAlcGeibl21sHOtfjpJz8i2tRQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@jscpd/html-reporter/-/html-reporter-4.1.1.tgz",
+      "integrity": "sha512-mlwmHjAlDbyXVy4Wdjsb0V4cj8xnKeW3nNLPV4VSkRhZcYBFdBlMznyMuFqzkhKLQeWv6Ux9JdB3AW+IoStQ9w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1037,14 +1037,15 @@
       }
     },
     "node_modules/@jscpd/tokenizer": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@jscpd/tokenizer/-/tokenizer-4.1.0.tgz",
-      "integrity": "sha512-eYQun9bMOcSj14C7uH3QDkkQqIogRem+UqFYLuyt6UqJ+PrXJJkoa+gRTICqyY/xH73HsXy0BPNhGMsi3wTMGg==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@jscpd/tokenizer/-/tokenizer-4.1.1.tgz",
+      "integrity": "sha512-1Qg8kcUzWyn+JJTv18P7MsNgpMDaKvnQrrV4onpiVVy1tcgolK8TN2fho247JedK5MjfGzeX+RU+s5SSp011dA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jscpd/core": "4.1.0",
-        "prismjs": "^1.30.0"
+        "@jscpd/core": "4.1.1",
+        "prismjs": "^1.30.0",
+        "spark-md5": "^3.0.2"
       }
     },
     "node_modules/@keyv/bigmap": {
@@ -1258,13 +1259,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
-      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.59.1"
+        "playwright": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -2491,13 +2492,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.6.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.2.tgz",
-      "integrity": "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw==",
+      "version": "25.7.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.7.0.tgz",
+      "integrity": "sha512-z+pdZyxE+RTQE9AcboAZCb4otwcrvgHD+GlBpPgn0emDVt0ohrTMhAwlr2Wd9nZ+nihhYFxO2pThz3C5qSu2Eg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.19.0"
+        "undici-types": "~7.21.0"
       }
     },
     "node_modules/@types/sarif": {
@@ -6201,30 +6202,30 @@
       }
     },
     "node_modules/jscpd": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/jscpd/-/jscpd-4.1.0.tgz",
-      "integrity": "sha512-LOXYBLp08+CoCVmb161k4rdR7Za/IGilmKnhXb9uLSgGSq135JMEXRku71xWpCDRyNzZHltxYbYgd8gkrdqJ2Q==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/jscpd/-/jscpd-4.1.1.tgz",
+      "integrity": "sha512-Z+BkeNF1lEO1RQlon59rDx0uzmE3VRqi+4hjTnGj7GDkwYjwdVqFW8tiVvQ3dJ2myUQSrT3mAsFWDMlFEArJXA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jscpd/badge-reporter": "4.1.0",
-        "@jscpd/core": "4.1.0",
-        "@jscpd/finder": "4.1.0",
-        "@jscpd/html-reporter": "4.1.0",
-        "@jscpd/tokenizer": "4.1.0",
+        "@jscpd/badge-reporter": "4.1.1",
+        "@jscpd/core": "4.1.1",
+        "@jscpd/finder": "4.1.1",
+        "@jscpd/html-reporter": "4.1.1",
+        "@jscpd/tokenizer": "4.1.1",
         "colors": "^1.4.0",
         "commander": "^5.0.0",
         "fs-extra": "^11.2.0",
-        "jscpd-sarif-reporter": "4.1.0"
+        "jscpd-sarif-reporter": "4.1.1"
       },
       "bin": {
         "jscpd": "bin/jscpd"
       }
     },
     "node_modules/jscpd-sarif-reporter": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/jscpd-sarif-reporter/-/jscpd-sarif-reporter-4.1.0.tgz",
-      "integrity": "sha512-D2JEDLrbt/aUahjhBLzgNtVrrRJ7UuWBBNkiwXXBh3wQ7+FRRL5T6TilBCFEu+2Plvmo/UygXyZXO8dOJM3mww==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/jscpd-sarif-reporter/-/jscpd-sarif-reporter-4.1.1.tgz",
+      "integrity": "sha512-ipT2Qr9WTEb/r51FMdHy/U1Z1HTChzpxj8/9csqq2eIizEBeY8vRk8xw9m9blBa/WajsmQmnwuCdZiHYe0YNLg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7540,13 +7541,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
-      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.59.1"
+        "playwright-core": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -7559,9 +7560,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
-      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -8708,6 +8709,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/spark-md5": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/spark-md5/-/spark-md5-3.0.2.tgz",
+      "integrity": "sha512-wcFzz9cDfbuqe0FZzfi2or1sgyIrsDwmPwfZC4hiNidPdPINjeUwNfv5kldczoEAcjl9Y1L3SM7Uz2PUEQzxQw==",
+      "dev": true,
+      "license": "(WTFPL OR MIT)"
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -9630,9 +9638,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.19.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
-      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.21.0.tgz",
+      "integrity": "sha512-w9IMgQrz4O0YN1LtB7K5P63vhlIOvC7opSmouCJ+ZywlPAlO9gIkJ+otk6LvGpAs2wg4econaCz3TvQ9xPoyuQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/tphakala/go-audio-resampler v1.3.0
 	github.com/tphakala/go-tflite v0.2.2-0.20260403122459-aedbd0bca261
 	github.com/tphakala/simd v1.0.22
-	github.com/yalue/onnxruntime_go v1.30.0
+	github.com/yalue/onnxruntime_go v1.30.1
 	go.uber.org/goleak v1.3.0
 	golang.org/x/crypto v0.51.0
 	golang.org/x/net v0.54.0
@@ -113,7 +113,7 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/term v0.43.0 // indirect
 	gonum.org/v1/gonum v0.17.0 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20260504160031-60b97b32f348 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20260511170946-3700d4141b60 // indirect
 	google.golang.org/grpc v1.81.0 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -310,8 +310,8 @@ github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6Kllzaw
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasttemplate v1.2.2 h1:lxLXG0uE3Qnshl9QyaK6XJxMXlQZELvChBOCmQD0Loo=
 github.com/valyala/fasttemplate v1.2.2/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
-github.com/yalue/onnxruntime_go v1.30.0 h1:VAZyXhTu0mUkq+hXwVp/flc7sndhSxz9787lZvBUVm0=
-github.com/yalue/onnxruntime_go v1.30.0/go.mod h1:b4X26A8pekNb1ACJ58wAXgNKeUCGEAQ9dmACut9Sm/4=
+github.com/yalue/onnxruntime_go v1.30.1 h1:NaEng5lWbsHZ/8X1dtaw1mIj7eV1ozyjbFo//g0ktl4=
+github.com/yalue/onnxruntime_go v1.30.1/go.mod h1:b4X26A8pekNb1ACJ58wAXgNKeUCGEAQ9dmACut9Sm/4=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
@@ -375,8 +375,8 @@ google.golang.org/genproto v0.0.0-20260319201613-d00831a3d3e7 h1:XzmzkmB14QhVhgn
 google.golang.org/genproto v0.0.0-20260319201613-d00831a3d3e7/go.mod h1:L43LFes82YgSonw6iTXTxXUX1OlULt4AQtkik4ULL/I=
 google.golang.org/genproto/googleapis/api v0.0.0-20260319201613-d00831a3d3e7 h1:41r6JMbpzBMen0R/4TZeeAmGXSJC7DftGINUodzTkPI=
 google.golang.org/genproto/googleapis/api v0.0.0-20260319201613-d00831a3d3e7/go.mod h1:EIQZ5bFCfRQDV4MhRle7+OgjNtZ6P1PiZBgAKuxXu/Y=
-google.golang.org/genproto/googleapis/rpc v0.0.0-20260504160031-60b97b32f348 h1:pfIbyB44sWzHiCpRqIen67ZQnVXSfIxWrqUMk1qwODE=
-google.golang.org/genproto/googleapis/rpc v0.0.0-20260504160031-60b97b32f348/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20260511170946-3700d4141b60 h1:seT2EwLWM78plQ7wcDfuWBc/4FAEAXDDiaSol4ku4qo=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20260511170946-3700d4141b60/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
 google.golang.org/grpc v1.81.0 h1:W3G9N3KQf3BU+YuCtGKJk0CmxQNbAISICD/9AORxLIw=
 google.golang.org/grpc v1.81.0/go.mod h1:xGH9GfzOyMTGIOXBJmXt+BX/V0kcdQbdcuwQ/zNw42I=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=


### PR DESCRIPTION
## Summary
- Update Go dependencies: onnxruntime_go v1.30.0 -> v1.30.1, genproto/googleapis/rpc
- Update npm dependencies: playwright 1.60.0, @types/node 25.7.0, jscpd 4.1.1

## Test Plan
- [x] `go mod tidy` clean
- [x] `go build ./...` passes
- [x] `golangci-lint run` no issues
- [x] Go tests pass (6346 passed, 1 pre-existing TFLite race failure)
- [x] `npm run check:all` passes
- [x] Frontend tests pass (1918/1918)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ONNX Runtime Go library to v1.30.1
  * Updated Google RPC protobuf dependency

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3030)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->