### PR TITLE
feat(classifier): add v3.0 geomodel range filter with species mapping

### DIFF
--- a/internal/classifier/birdnet.go
+++ b/internal/classifier/birdnet.go
@@ -347,6 +347,12 @@ func (bn *BirdNET) getMetaModelData() ([]byte, error) {
 
 // initializeMetaModel loads and initializes the meta model used for range filtering.
 func (bn *BirdNET) initializeMetaModel() error {
+	// V3 geomodel is always ONNX; route to ONNX backend even if ModelPath is empty
+	// (initializeV3GeoModel will return a clear error about missing paths).
+	if bn.Settings.BirdNET.RangeFilter.Model == "v3" {
+		return bn.initializeONNXMetaModel()
+	}
+
 	// If range filter model path ends with .onnx, use the ONNX backend
 	if isONNXModel(bn.Settings.BirdNET.RangeFilter.ModelPath) {
 		return bn.initializeONNXMetaModel()

--- a/internal/classifier/mapped_range_filter.go
+++ b/internal/classifier/mapped_range_filter.go
@@ -1,0 +1,92 @@
+package classifier
+
+import (
+	"strings"
+
+	"github.com/tphakala/birdnet-go/internal/inference"
+)
+
+// mappedRangeFilter wraps an inference.RangeFilter whose output indices correspond
+// to a different label set (the geomodel's own labels) and remaps the scores to
+// align with the classifier's label order. This enables the v3.0 geomodel (12K
+// species) to work with any classifier (BirdNET v2.4, v3.0, Perch v2) without
+// changing predictFilter() or any downstream code.
+type mappedRangeFilter struct {
+	inner           inference.RangeFilter
+	classifierToGeo []int   // classifierIndex -> geomodelIndex; -1 means no match
+	numClassifier   int     // len(classifierLabels)
+	unmappedScore   float32 // score for classifier species absent from geomodel
+}
+
+// buildSpeciesMapping creates the classifier-to-geomodel index mapping by
+// matching scientific names (the part before the first underscore in
+// "ScientificName_CommonName" labels). The match is case-insensitive.
+func buildSpeciesMapping(classifierLabels, geomodelLabels []string) []int {
+	geoIndex := make(map[string]int, len(geomodelLabels))
+	for i, label := range geomodelLabels {
+		sci := extractScientificName(label)
+		geoIndex[strings.ToLower(sci)] = i
+	}
+
+	mapping := make([]int, len(classifierLabels))
+	for i, label := range classifierLabels {
+		sci := extractScientificName(label)
+		if idx, ok := geoIndex[strings.ToLower(sci)]; ok {
+			mapping[i] = idx
+		} else {
+			mapping[i] = -1
+		}
+	}
+	return mapping
+}
+
+// extractScientificName returns the scientific name portion from a
+// "ScientificName_CommonName" label string.
+func extractScientificName(label string) string {
+	if idx := strings.IndexByte(label, '_'); idx >= 0 {
+		return label[:idx]
+	}
+	return label
+}
+
+// newMappedRangeFilter wraps inner with a species mapping layer.
+// classifierLabels is the label set used by the active classifier model.
+// geomodelLabels is the label set matching the geomodel's output order.
+// unmappedScore is the score assigned to classifier species that have no
+// match in the geomodel (0.0 = filter out, 1.0 = pass through).
+func newMappedRangeFilter(inner inference.RangeFilter, classifierLabels, geomodelLabels []string, unmappedScore float32) *mappedRangeFilter {
+	return &mappedRangeFilter{
+		inner:           inner,
+		classifierToGeo: buildSpeciesMapping(classifierLabels, geomodelLabels),
+		numClassifier:   len(classifierLabels),
+		unmappedScore:   unmappedScore,
+	}
+}
+
+// Predict returns species scores aligned to the classifier's label order.
+func (m *mappedRangeFilter) Predict(latitude, longitude, week float32) ([]float32, error) {
+	geoScores, err := m.inner.Predict(latitude, longitude, week)
+	if err != nil {
+		return nil, err
+	}
+
+	scores := make([]float32, m.numClassifier)
+	for i, geoIdx := range m.classifierToGeo {
+		if geoIdx >= 0 && geoIdx < len(geoScores) {
+			scores[i] = geoScores[geoIdx]
+		} else {
+			scores[i] = m.unmappedScore
+		}
+	}
+	return scores, nil
+}
+
+// NumSpecies returns the number of classifier labels (not geomodel labels).
+func (m *mappedRangeFilter) NumSpecies() int {
+	return m.numClassifier
+}
+
+// Close releases resources held by the underlying range filter.
+func (m *mappedRangeFilter) Close() {
+	m.inner.Close()
+}

--- a/internal/classifier/mapped_range_filter_test.go
+++ b/internal/classifier/mapped_range_filter_test.go
@@ -1,0 +1,182 @@
+package classifier
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractScientificName(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		label    string
+		expected string
+	}{
+		{"Turdus merula_Common Blackbird", "Turdus merula"},
+		{"Parus major_Great Tit", "Parus major"},
+		{"NoUnderscore", "NoUnderscore"},
+		{"Sci_Common_Extra", "Sci"},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.label, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expected, extractScientificName(tt.label))
+		})
+	}
+}
+
+func TestBuildSpeciesMapping(t *testing.T) {
+	t.Parallel()
+
+	classifierLabels := []string{
+		"Turdus merula_Common Blackbird",
+		"Parus major_Great Tit",
+		"Erithacus rubecula_European Robin",
+		"Ficedula hypoleuca_European Pied Flycatcher",
+	}
+
+	geomodelLabels := []string{
+		"Parus major_Great Tit",
+		"Turdus merula_Amsel",
+		"Corvus corax_Northern Raven",
+		"Erithacus rubecula_Robin",
+	}
+
+	mapping := buildSpeciesMapping(classifierLabels, geomodelLabels)
+
+	require.Len(t, mapping, 4)
+	assert.Equal(t, 1, mapping[0], "Turdus merula should map to geomodel index 1")
+	assert.Equal(t, 0, mapping[1], "Parus major should map to geomodel index 0")
+	assert.Equal(t, 3, mapping[2], "Erithacus rubecula should map to geomodel index 3")
+	assert.Equal(t, -1, mapping[3], "Ficedula hypoleuca has no match in geomodel")
+}
+
+func TestBuildSpeciesMapping_CaseInsensitive(t *testing.T) {
+	t.Parallel()
+
+	classifierLabels := []string{
+		"turdus merula_Common Blackbird",
+	}
+	geomodelLabels := []string{
+		"Turdus Merula_Amsel",
+	}
+
+	mapping := buildSpeciesMapping(classifierLabels, geomodelLabels)
+
+	require.Len(t, mapping, 1)
+	assert.Equal(t, 0, mapping[0], "case-insensitive match should succeed")
+}
+
+func TestBuildSpeciesMapping_EmptyInputs(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty classifier labels", func(t *testing.T) {
+		t.Parallel()
+		mapping := buildSpeciesMapping(nil, []string{"A_B"})
+		assert.Empty(t, mapping)
+	})
+
+	t.Run("empty geomodel labels", func(t *testing.T) {
+		t.Parallel()
+		mapping := buildSpeciesMapping([]string{"A_B"}, nil)
+		require.Len(t, mapping, 1)
+		assert.Equal(t, -1, mapping[0])
+	})
+}
+
+// fakeRangeFilter is a test double that returns preconfigured scores.
+type fakeRangeFilter struct {
+	scores []float32
+	err    error
+	closed bool
+}
+
+func (f *fakeRangeFilter) Predict(_, _, _ float32) ([]float32, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	out := make([]float32, len(f.scores))
+	copy(out, f.scores)
+	return out, nil
+}
+
+func (f *fakeRangeFilter) NumSpecies() int { return len(f.scores) }
+func (f *fakeRangeFilter) Close()          { f.closed = true }
+
+func TestMappedRangeFilter_Predict(t *testing.T) {
+	t.Parallel()
+
+	classifierLabels := []string{
+		"Turdus merula_Common Blackbird",     // maps to geo index 1
+		"Parus major_Great Tit",              // maps to geo index 0
+		"Ficedula hypoleuca_Pied Flycatcher", // no match -> unmappedScore
+	}
+	geomodelLabels := []string{
+		"Parus major_Great Tit",
+		"Turdus merula_Amsel",
+		"Corvus corax_Northern Raven",
+	}
+
+	inner := &fakeRangeFilter{
+		scores: []float32{0.8, 0.9, 0.3},
+	}
+	mapped := newMappedRangeFilter(inner, classifierLabels, geomodelLabels, 0.0)
+
+	scores, err := mapped.Predict(60.0, 25.0, 20.0)
+	require.NoError(t, err)
+	require.Len(t, scores, 3)
+
+	assert.InDelta(t, 0.9, scores[0], 0.001, "Turdus merula -> geomodel[1]=0.9")
+	assert.InDelta(t, 0.8, scores[1], 0.001, "Parus major -> geomodel[0]=0.8")
+	assert.InDelta(t, 0.0, scores[2], 0.001, "Ficedula hypoleuca -> unmapped=0.0")
+}
+
+func TestMappedRangeFilter_UnmappedScorePassthrough(t *testing.T) {
+	t.Parallel()
+
+	classifierLabels := []string{"Unknown species_Foo"}
+	geomodelLabels := []string{"Other species_Bar"}
+
+	inner := &fakeRangeFilter{
+		scores: []float32{0.5},
+	}
+	mapped := newMappedRangeFilter(inner, classifierLabels, geomodelLabels, 1.0)
+
+	scores, err := mapped.Predict(60.0, 25.0, 20.0)
+	require.NoError(t, err)
+	require.Len(t, scores, 1)
+	assert.InDelta(t, 1.0, scores[0], 0.001, "unmapped species should get unmappedScore=1.0")
+}
+
+func TestMappedRangeFilter_PropagatesError(t *testing.T) {
+	t.Parallel()
+
+	inner := &fakeRangeFilter{
+		err: assert.AnError,
+	}
+	mapped := newMappedRangeFilter(inner, []string{"A_B"}, []string{"A_B"}, 0.0)
+
+	_, err := mapped.Predict(60.0, 25.0, 20.0)
+	assert.Error(t, err)
+}
+
+func TestMappedRangeFilter_NumSpecies(t *testing.T) {
+	t.Parallel()
+
+	inner := &fakeRangeFilter{scores: make([]float32, 5)}
+	mapped := newMappedRangeFilter(inner, make([]string, 3), make([]string, 5), 0.0)
+
+	assert.Equal(t, 3, mapped.NumSpecies(), "NumSpecies should return classifier label count")
+}
+
+func TestMappedRangeFilter_Close(t *testing.T) {
+	t.Parallel()
+
+	inner := &fakeRangeFilter{scores: make([]float32, 3)}
+	mapped := newMappedRangeFilter(inner, make([]string, 2), make([]string, 3), 0.0)
+
+	mapped.Close()
+	assert.True(t, inner.closed, "Close should delegate to inner filter")
+}

--- a/internal/classifier/model_onnx.go
+++ b/internal/classifier/model_onnx.go
@@ -179,6 +179,11 @@ func (bn *BirdNET) initializeV3GeoModel() error {
 	}
 
 	log := GetLogger()
+	if matchCount == 0 && len(classifierLabels) > 0 {
+		log.Warn("V3 geomodel: no species matched classifier labels, range filter will filter out all detections (check labels file)",
+			logger.Int("classifier_species", len(classifierLabels)),
+			logger.String("labels_path", labelsPath))
+	}
 	log.Info("V3 geomodel initialized with species mapping",
 		logger.Int("geomodel_species", len(geoLabels)),
 		logger.Int("classifier_species", len(classifierLabels)),

--- a/internal/classifier/model_onnx.go
+++ b/internal/classifier/model_onnx.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/inference"
 	"github.com/tphakala/birdnet-go/internal/logger"
@@ -105,6 +106,25 @@ func (bn *BirdNET) initializeV3GeoModel() error {
 			Build()
 	}
 
+	// Expand environment variables and ~ prefix in paths (consistent with getMetaModelData)
+	modelPath := os.ExpandEnv(rfSettings.ModelPath)
+	modelPath, err := conf.ExpandTildePath(modelPath)
+	if err != nil {
+		return errors.New(err).
+			Category(errors.CategoryFileIO).
+			Context("path", rfSettings.ModelPath).
+			Build()
+	}
+
+	labelsPath := os.ExpandEnv(rfSettings.LabelsPath)
+	labelsPath, err = conf.ExpandTildePath(labelsPath)
+	if err != nil {
+		return errors.New(err).
+			Category(errors.CategoryFileIO).
+			Context("path", rfSettings.LabelsPath).
+			Build()
+	}
+
 	// Ensure ONNX Runtime is initialized
 	if err := inference.InitONNXRuntime(bn.Settings.BirdNET.ONNXRuntimePath); err != nil {
 		return errors.New(err).
@@ -115,18 +135,25 @@ func (bn *BirdNET) initializeV3GeoModel() error {
 	}
 
 	// Load geomodel labels from file
-	geoLabels, err := loadLabelsFromFile(rfSettings.LabelsPath)
+	geoLabels, err := loadLabelsFromFile(labelsPath)
 	if err != nil {
 		return errors.New(err).
 			Category(errors.CategoryModelInit).
 			Context("model_type", "v3_geomodel").
-			Context("labels_path", rfSettings.LabelsPath).
+			Context("labels_path", labelsPath).
+			Build()
+	}
+
+	if len(geoLabels) == 0 {
+		return errors.Newf("v3 geomodel labels file is empty: %s", labelsPath).
+			Category(errors.CategoryModelInit).
+			Context("model_type", "v3_geomodel").
 			Build()
 	}
 
 	// Create ONNX range filter using the geomodel's own labels
 	innerFilter, err := inference.NewONNXRangeFilter(
-		rfSettings.ModelPath,
+		modelPath,
 		inference.ONNXRangeFilterOptions{
 			Labels: geoLabels,
 		},
@@ -135,7 +162,7 @@ func (bn *BirdNET) initializeV3GeoModel() error {
 		return errors.New(err).
 			Category(errors.CategoryModelInit).
 			Context("model_type", "v3_geomodel").
-			Context("range_filter_model", rfSettings.ModelPath).
+			Context("range_filter_model", modelPath).
 			Timing("onnx-v3-geomodel-init", time.Since(start)).
 			Build()
 	}

--- a/internal/classifier/model_onnx.go
+++ b/internal/classifier/model_onnx.go
@@ -1,6 +1,9 @@
 package classifier
 
 import (
+	"bufio"
+	"os"
+	"strings"
 	"time"
 
 	"github.com/tphakala/birdnet-go/internal/errors"
@@ -44,10 +47,16 @@ func (bn *BirdNET) initializeONNXModel() error {
 }
 
 // initializeONNXMetaModel loads and initializes an ONNX range filter meta model.
+// For v3 geomodel, delegates to initializeV3GeoModel which loads the geomodel
+// with its own 12K labels and wraps it in a mappedRangeFilter.
 func (bn *BirdNET) initializeONNXMetaModel() error {
+	if bn.Settings.BirdNET.RangeFilter.Model == "v3" {
+		return bn.initializeV3GeoModel()
+	}
+
 	start := time.Now()
 
-	// Ensure ONNX Runtime is initialized (idempotent — may already be init from classifier)
+	// Ensure ONNX Runtime is initialized (idempotent - may already be init from classifier)
 	if err := inference.InitONNXRuntime(bn.Settings.BirdNET.ONNXRuntimePath); err != nil {
 		return errors.New(err).
 			Category(errors.CategoryModelInit).
@@ -73,4 +82,104 @@ func (bn *BirdNET) initializeONNXMetaModel() error {
 
 	bn.rangeFilter = rangeFilter
 	return nil
+}
+
+// initializeV3GeoModel loads the v3.0 geomodel ONNX with its own 12K labels,
+// then wraps the raw ONNX range filter in a mappedRangeFilter that remaps
+// geomodel output scores to the classifier's label order by matching scientific
+// names. This enables the 12K-species geomodel to work with any classifier.
+func (bn *BirdNET) initializeV3GeoModel() error {
+	start := time.Now()
+	rfSettings := bn.Settings.BirdNET.RangeFilter
+
+	if rfSettings.ModelPath == "" {
+		return errors.Newf("v3 geomodel requires rangefilter.modelpath to be set").
+			Category(errors.CategoryModelInit).
+			Context("model", "v3").
+			Build()
+	}
+	if rfSettings.LabelsPath == "" {
+		return errors.Newf("v3 geomodel requires rangefilter.labelspath to be set").
+			Category(errors.CategoryModelInit).
+			Context("model", "v3").
+			Build()
+	}
+
+	// Ensure ONNX Runtime is initialized
+	if err := inference.InitONNXRuntime(bn.Settings.BirdNET.ONNXRuntimePath); err != nil {
+		return errors.New(err).
+			Category(errors.CategoryModelInit).
+			Context("onnx_runtime_path", bn.Settings.BirdNET.ONNXRuntimePath).
+			Timing("onnx-init", time.Since(start)).
+			Build()
+	}
+
+	// Load geomodel labels from file
+	geoLabels, err := loadLabelsFromFile(rfSettings.LabelsPath)
+	if err != nil {
+		return errors.New(err).
+			Category(errors.CategoryModelInit).
+			Context("model_type", "v3_geomodel").
+			Context("labels_path", rfSettings.LabelsPath).
+			Build()
+	}
+
+	// Create ONNX range filter using the geomodel's own labels
+	innerFilter, err := inference.NewONNXRangeFilter(
+		rfSettings.ModelPath,
+		inference.ONNXRangeFilterOptions{
+			Labels: geoLabels,
+		},
+	)
+	if err != nil {
+		return errors.New(err).
+			Category(errors.CategoryModelInit).
+			Context("model_type", "v3_geomodel").
+			Context("range_filter_model", rfSettings.ModelPath).
+			Timing("onnx-v3-geomodel-init", time.Since(start)).
+			Build()
+	}
+
+	classifierLabels := bn.Settings.BirdNET.Labels
+	mapped := newMappedRangeFilter(innerFilter, classifierLabels, geoLabels, 0.0)
+
+	// Log mapping statistics
+	matchCount := 0
+	for _, idx := range mapped.classifierToGeo {
+		if idx >= 0 {
+			matchCount++
+		}
+	}
+
+	log := GetLogger()
+	log.Info("V3 geomodel initialized with species mapping",
+		logger.Int("geomodel_species", len(geoLabels)),
+		logger.Int("classifier_species", len(classifierLabels)),
+		logger.Int("mapped_species", matchCount),
+		logger.Int("unmapped_species", len(classifierLabels)-matchCount))
+
+	bn.rangeFilter = mapped
+	return nil
+}
+
+// loadLabelsFromFile reads species labels from a text file, one per line.
+func loadLabelsFromFile(path string) ([]string, error) {
+	f, err := os.Open(path) //nolint:gosec // G304: path is from application settings
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+
+	var labels []string
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line != "" {
+			labels = append(labels, line)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return labels, nil
 }

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -1162,12 +1162,13 @@ type BirdNETConfig struct {
 
 // RangeFilterSettings contains settings for the range filter
 type RangeFilterSettings struct {
-	Debug       bool      `yaml:"debug" json:"debug"`         // true to enable debug mode
-	Model       string    `yaml:"model" json:"model"`         // range filter model version: "legacy" for v1, or empty/default for v2
-	ModelPath   string    `yaml:"modelpath" json:"modelPath"` // path to external meta model file (empty for embedded)
-	Threshold   float32   `yaml:"threshold" json:"threshold"` // rangefilter species occurrence threshold
-	Species     []string  `yaml:"-" json:"species,omitempty"` // list of included species, runtime value
-	LastUpdated time.Time `yaml:"-" json:"lastUpdated"`       // last time the species list was updated, runtime value
+	Debug       bool      `yaml:"debug" json:"debug"`                               // true to enable debug mode
+	Model       string    `yaml:"model" json:"model"`                               // range filter model version: "legacy" for v1, "v3" for geomodel v3.0, or empty/default for v2
+	ModelPath   string    `yaml:"modelpath" json:"modelPath"`                       // path to external meta model file (empty for embedded)
+	LabelsPath  string    `yaml:"labelspath,omitempty" json:"labelsPath,omitempty"` // path to geomodel labels file (required when geomodel differs from classifier labels)
+	Threshold   float32   `yaml:"threshold" json:"threshold"`                       // rangefilter species occurrence threshold
+	Species     []string  `yaml:"-" json:"species,omitempty"`                       // list of included species, runtime value
+	LastUpdated time.Time `yaml:"-" json:"lastUpdated"`                             // last time the species list was updated, runtime value
 }
 
 // PerchConfig holds configuration for the Google Perch v2 model.

--- a/internal/conf/env.go
+++ b/internal/conf/env.go
@@ -371,7 +371,7 @@ func canonicalizeValue(configKey, envValue string) {
 		// Canonicalize locale to lowercase
 		viper.Set(configKey, strings.ToLower(trimmed))
 
-	case ConfigKeyModelPath, ConfigKeyLabelPath, ConfigKeyRangeFilterModel, ConfigKeyRangeFilterModelPath:
+	case ConfigKeyModelPath, ConfigKeyLabelPath, ConfigKeyRangeFilterModel, ConfigKeyRangeFilterModelPath, ConfigKeyRangeFilterLabelsPath:
 		// Regular string values - just trim whitespace
 		viper.Set(configKey, trimmed)
 

--- a/internal/conf/env.go
+++ b/internal/conf/env.go
@@ -33,10 +33,11 @@ const (
 	ConfigKeyLabelPath = "birdnet.labelpath"
 
 	// Range Filter Configuration
-	ConfigKeyRangeFilterModel     = "birdnet.rangefilter.model"
-	ConfigKeyRangeFilterThreshold = "birdnet.rangefilter.threshold"
-	ConfigKeyRangeFilterModelPath = "birdnet.rangefilter.modelpath"
-	ConfigKeyRangeFilterDebug     = "birdnet.rangefilter.debug"
+	ConfigKeyRangeFilterModel      = "birdnet.rangefilter.model"
+	ConfigKeyRangeFilterThreshold  = "birdnet.rangefilter.threshold"
+	ConfigKeyRangeFilterModelPath  = "birdnet.rangefilter.modelpath"
+	ConfigKeyRangeFilterLabelsPath = "birdnet.rangefilter.labelspath"
+	ConfigKeyRangeFilterDebug      = "birdnet.rangefilter.debug"
 
 	// Security Configuration
 	ConfigKeyBaseURL = "security.baseurl"
@@ -60,10 +61,11 @@ const (
 	EnvVarLabelPath = "BIRDNET_LABELPATH"
 
 	// Range Filter Configuration
-	EnvVarRangeFilterModel     = "BIRDNET_RANGEFILTER_MODEL"
-	EnvVarRangeFilterThreshold = "BIRDNET_RANGEFILTER_THRESHOLD"
-	EnvVarRangeFilterModelPath = "BIRDNET_RANGEFILTER_MODELPATH"
-	EnvVarRangeFilterDebug     = "BIRDNET_RANGEFILTER_DEBUG"
+	EnvVarRangeFilterModel      = "BIRDNET_RANGEFILTER_MODEL"
+	EnvVarRangeFilterThreshold  = "BIRDNET_RANGEFILTER_THRESHOLD"
+	EnvVarRangeFilterModelPath  = "BIRDNET_RANGEFILTER_MODELPATH"
+	EnvVarRangeFilterLabelsPath = "BIRDNET_RANGEFILTER_LABELSPATH"
+	EnvVarRangeFilterDebug      = "BIRDNET_RANGEFILTER_DEBUG"
 
 	// Security Configuration
 	EnvVarBaseURL = "BIRDNET_URL"
@@ -122,6 +124,7 @@ func getEnvBindings() []envBinding {
 		{ConfigKeyRangeFilterModel, EnvVarRangeFilterModel, validateEnvRangeFilterModel},
 		{ConfigKeyRangeFilterThreshold, EnvVarRangeFilterThreshold, validateEnvRangeFilterThreshold},
 		{ConfigKeyRangeFilterModelPath, EnvVarRangeFilterModelPath, validateEnvPath},
+		{ConfigKeyRangeFilterLabelsPath, EnvVarRangeFilterLabelsPath, validateEnvPath},
 		{ConfigKeyRangeFilterDebug, EnvVarRangeFilterDebug, validateEnvBool},
 
 		// Security Configuration
@@ -269,7 +272,7 @@ func validateEnvThreads(value string) error {
 
 func validateEnvRangeFilterModel(value string) error {
 	value = strings.TrimSpace(value)
-	validModels := []string{"latest", "legacy"}
+	validModels := []string{"latest", "legacy", "v3"}
 	if !slices.Contains(validModels, value) {
 		return fmt.Errorf("must be one of: %s", strings.Join(validModels, ", "))
 	}

--- a/internal/conf/env_test.go
+++ b/internal/conf/env_test.go
@@ -221,6 +221,7 @@ func TestValidateAndNormalizeRangeFilterModel(t *testing.T) {
 		{"empty string", "", true},
 		{"latest", "latest", false},
 		{"legacy", "legacy", false},
+		{"v3", "v3", false},
 		{"invalid", "invalid", true},
 	}
 
@@ -243,6 +244,7 @@ func TestValidateAndNormalizeRangeFilterModel(t *testing.T) {
 	}{
 		{"latest model", "latest", "latest"},
 		{"legacy model", "legacy", "legacy"},
+		{"v3 model", "v3", "v3"},
 	}
 
 	for _, tt := range integrationTests {

--- a/internal/conf/pure_validation_test.go
+++ b/internal/conf/pure_validation_test.go
@@ -163,7 +163,7 @@ func TestValidateBirdNETSettings_Invalid(t *testing.T) {
 					Model: "invalid",
 				},
 			},
-			expectError: "RangeFilter model must be either empty (v2 default), 'latest', or 'legacy'",
+			expectError: "RangeFilter model must be either empty (v2 default), 'latest', 'legacy', or 'v3'",
 		},
 		{
 			name: "range filter threshold too low",

--- a/internal/conf/validate_services.go
+++ b/internal/conf/validate_services.go
@@ -38,10 +38,10 @@ func ValidateBirdNETSettings(cfg *BirdNETConfig) ValidationResult {
 		result.Errors = append(result.Errors, "BirdNET threads must be at least 0")
 	}
 
-	// Empty string, "latest", or "legacy" are valid
-	if cfg.RangeFilter.Model != "" && cfg.RangeFilter.Model != "latest" && cfg.RangeFilter.Model != "legacy" {
+	// Empty string, "latest", "legacy", or "v3" are valid
+	if cfg.RangeFilter.Model != "" && cfg.RangeFilter.Model != "latest" && cfg.RangeFilter.Model != "legacy" && cfg.RangeFilter.Model != "v3" {
 		result.Valid = false
-		result.Errors = append(result.Errors, "RangeFilter model must be either empty (v2 default), 'latest', or 'legacy'")
+		result.Errors = append(result.Errors, "RangeFilter model must be either empty (v2 default), 'latest', 'legacy', or 'v3'")
 	}
 
 	checkRange(&result, cfg.RangeFilter.Threshold, 0, 1, "RangeFilter threshold must be between 0 and 1")


### PR DESCRIPTION
## Summary

Add support for the BirdNET v3.0 geomodel (12,012 species across birds, mammals, insects, amphibians, reptiles) as an improved geographic range filter. The v3.0 geomodel outputs scores for a larger species set than any single classifier, so a `mappedRangeFilter` wrapper translates geomodel scores to classifier label order by matching scientific names at init time.

This is Phase 1 of the v3.0 geomodel integration (backend only). The v2.4 embedded range filter remains the default; v3.0 activates only when explicitly configured.

### Changes

- `mapped_range_filter.go`: new `mappedRangeFilter` wrapper implementing `inference.RangeFilter` that remaps 12K geomodel scores to classifier-aligned output via scientific name matching
- `model_onnx.go`: `initializeV3GeoModel()` loads geomodel ONNX with its own labels, builds species mapping, wraps in `mappedRangeFilter`; `loadLabelsFromFile()` for reading geomodel labels
- `config.go`: added `LabelsPath` field to `RangeFilterSettings`
- `birdnet.go`: routes `rangefilter.model: "v3"` to ONNX backend
- `validate_services.go`, `env.go`: accept "v3" as valid model value; add `BIRDNET_RANGEFILTER_LABELSPATH` env var binding
- Path expansion (`~`, `$ENV`) for both model and labels paths (consistent with existing code)
- Guard against empty geomodel labels file
- 16 unit tests + updated validation/env tests

### Config example

```yaml
birdnet:
  rangefilter:
    model: v3
    modelpath: /path/to/BirdNET+_Geomodel_V3.0.2_Global_12K_FP16.onnx
    labelspath: /path/to/geomodel_v3.0.2_labels.txt
```

## Test Plan
- [x] 16 unit tests covering species mapping, score remapping, case insensitivity, error propagation, close delegation
- [x] All 1,153 conf package tests passing (validation, env binding)
- [x] golangci-lint clean
- [x] go vet clean
- [x] Pre-push gate review (4 agents + Gemini cross-validation)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for the "v3" range-filter model with automatic ONNX routing
  * New LabelsPath configuration to supply geomodel label files
  * Automatic remapping of geomodel scores into the classifier's label order

* **Bug Fixes / Validation**
  * Configuration validation updated to accept "v3" and the new labels-path key

* **Tests**
  * Added unit tests for label extraction, mapping, and range-filter behavior

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3031)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->