### PR TITLE
feat(classifier): auto-download v3.0 geomodel as shared companion

### DIFF
--- a/internal/classifier/model_catalog.go
+++ b/internal/classifier/model_catalog.go
@@ -15,6 +15,7 @@ const (
 	RoleModel      = "model"
 	RoleLabels     = "labels"
 	RoleEmbeddings = "embeddings"
+	RoleGeomodel   = "geomodel"
 	RoleData       = "data"
 )
 
@@ -39,11 +40,12 @@ type CatalogEntry struct {
 
 // CatalogFile describes a single file within a model's HuggingFace repository.
 type CatalogFile struct {
-	RemotePath string // path within the HuggingFace repo
-	LocalName  string // filename to use on disk
-	Role       string // file role: "model", "labels", "embeddings", or "data"
-	SHA256     string // hex-encoded SHA-256 checksum
-	SizeBytes  int64  // file size in bytes
+	RemotePath      string // path within the HuggingFace repo
+	LocalName       string // filename to use on disk
+	Role            string // file role: "model", "labels", "embeddings", "geomodel", or "data"
+	SHA256          string // hex-encoded SHA-256 checksum
+	SizeBytes       int64  // file size in bytes
+	HuggingFaceRepo string // override entry-level HuggingFace repo for this file (empty = use entry repo)
 }
 
 // EmbeddedCatalog is the built-in list of models available for download.
@@ -66,10 +68,10 @@ var EmbeddedCatalog = []CatalogEntry{
 		Hidden:          true,
 		UpstreamURL:     "https://github.com/birdnet-team/BirdNET-Analyzer",
 		HuggingFaceRepo: "tphakala/BirdNET-v3.0",
-		Files: []CatalogFile{
+		Files: append([]CatalogFile{
 			{RemotePath: "birdnet_v3.0.onnx", LocalName: "birdnet_v3.0.onnx", Role: RoleModel, SHA256: "placeholder", SizeBytes: 0},
 			{RemotePath: "labels.txt", LocalName: "birdnet_v3.0_labels.txt", Role: RoleLabels, SHA256: "placeholder", SizeBytes: 0},
-		},
+		}, geomodelFiles()...),
 	},
 	{
 		ID:              "perch-v2",
@@ -85,10 +87,10 @@ var EmbeddedCatalog = []CatalogEntry{
 		RegistryID:      RegistryIDPerchV2,
 		UpstreamURL:     "https://www.kaggle.com/models/google/bird-vocalization-classifier/tensorFlow2/perch_v2",
 		HuggingFaceRepo: "tphakala/Perch-v2",
-		Files: []CatalogFile{
+		Files: append([]CatalogFile{
 			{RemotePath: "perch_v2.onnx", LocalName: "perch_v2.onnx", Role: RoleModel, SHA256: "bf0c8467a924cb074663970ca4a0ab1e143602121930209657d0dff5d5cefa1f", SizeBytes: 409148616},
 			{RemotePath: "labels.txt", LocalName: "perch_v2_labels.txt", Role: RoleLabels, SHA256: "e4d5c0397d8fb08bf90c6b13a34810af53504faad927e472fcc567793c9de057", SizeBytes: 312716},
-		},
+		}, geomodelFiles()...),
 	},
 	{
 		ID:              "bsg-finland",
@@ -144,6 +146,48 @@ const (
 	embeddingsSHA256          = "b6b8f24dc9c3d43f2deb14a6f2c7b5b233e7477b6baf1b52341291e714903fb0"
 	embeddingsSizeBytes int64 = 66932350
 )
+
+// Shared v3.0 geomodel, used as range filter companion by Perch v2 and BirdNET v3.0.
+const (
+	geomodelHuggingFaceRepo       = "tphakala/BirdNET-Geomodel"
+	geomodelONNXSHA256            = "2bc5a9b1e7c24115730015a97dbb688e9e8cd49c02c34a011439182c65ef0017"
+	geomodelONNXSizeBytes   int64 = 7483473
+	geomodelLabelsSHA256          = "92cdca7ca95beb7ed16a0a39f4010fa9a8b468b854b6e8083f732647f136ee1c"
+	geomodelLabelsSizeBytes int64 = 479350
+)
+
+// geomodelFiles returns the shared geomodel CatalogFile entries appended to
+// classifiers that use the v3.0 range filter (Perch v2, BirdNET v3.0).
+func geomodelFiles() []CatalogFile {
+	return []CatalogFile{
+		{
+			RemotePath:      "BirdNET+_Geomodel_V3.0.2_Global_12K_FP16.onnx",
+			LocalName:       "geomodel_v3.0.2_fp16.onnx",
+			Role:            RoleGeomodel,
+			SHA256:          geomodelONNXSHA256,
+			SizeBytes:       geomodelONNXSizeBytes,
+			HuggingFaceRepo: geomodelHuggingFaceRepo,
+		},
+		{
+			RemotePath:      "geomodel_v3.0.2_labels.txt",
+			LocalName:       "geomodel_v3.0.2_labels.txt",
+			Role:            RoleGeomodel,
+			SHA256:          geomodelLabelsSHA256,
+			SizeBytes:       geomodelLabelsSizeBytes,
+			HuggingFaceRepo: geomodelHuggingFaceRepo,
+		},
+	}
+}
+
+// hasGeomodelFiles reports whether a catalog entry includes shared geomodel files.
+func hasGeomodelFiles(entry *CatalogEntry) bool {
+	for _, f := range entry.Files {
+		if f.Role == RoleGeomodel {
+			return true
+		}
+	}
+	return false
+}
 
 // batFileChecksums holds SHA256 and size for a BattyBirdNET model and its labels file.
 type batFileChecksums struct {

--- a/internal/classifier/model_manager.go
+++ b/internal/classifier/model_manager.go
@@ -725,7 +725,8 @@ func (mm *ModelManager) applyConfigForInstall(entry *CatalogEntry, modelPath, la
 // applyConfigForUninstall updates settings to reflect a removed model.
 // For bat models, Enabled is only set to false when no other bat models
 // remain installed; if another bat model exists, config is re-pointed to it.
-// The caller must hold mm.mu (at least RLock).
+// The caller must hold mm.mu for writing; the uninstalled entry must already
+// be deleted from mm.installed so the geomodel and bat searches skip it.
 // Uses clone-mutate-publish so the shared settings snapshot is never mutated
 // in place. Settings are persisted to disk via conf.SaveSettings so changes
 // survive restarts and are visible to concurrent readers through conf.Setting().

--- a/internal/classifier/model_manager.go
+++ b/internal/classifier/model_manager.go
@@ -333,39 +333,9 @@ func (mm *ModelManager) Uninstall(catalogID string) error {
 		}
 	}
 
-	// Delete shared embeddings files only if no other bat models remain.
-	if entry.Category == CategoryBat {
-		otherBatInstalled := false
-		for id := range mm.installed {
-			if id == catalogID {
-				continue
-			}
-			other, found := GetCatalogEntry(id)
-			if found && other.Category == CategoryBat {
-				otherBatInstalled = true
-				break
-			}
-		}
-
-		if !otherBatInstalled {
-			for _, f := range entry.Files {
-				if f.Role == RoleEmbeddings {
-					path := filepath.Join(mm.modelsDir, "shared", f.LocalName)
-					if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
-						log.Warn("Failed to remove embeddings file",
-							logger.String("path", path),
-							logger.Error(err))
-					} else {
-						log.Info("Removed shared embeddings file",
-							logger.String("path", path))
-					}
-				}
-			}
-		} else {
-			log.Debug("Retaining shared embeddings; other bat models still installed",
-				logger.String("catalog_id", catalogID))
-		}
-	}
+	// Clean up shared embeddings and geomodel files if no other dependent models remain.
+	mm.cleanupSharedEmbeddings(log, catalogID, &entry)
+	mm.cleanupSharedGeomodel(log, catalogID, &entry)
 
 	// Labels are intentionally retained on disk.
 
@@ -377,6 +347,73 @@ func (mm *ModelManager) Uninstall(catalogID string) error {
 		logger.String("catalog_id", catalogID))
 
 	return nil
+}
+
+// cleanupSharedEmbeddings removes shared embeddings files when uninstalling a
+// bat model, but only if no other bat model remains installed. The caller must
+// hold mm.mu, and catalogID must still be in mm.installed.
+func (mm *ModelManager) cleanupSharedEmbeddings(log logger.Logger, catalogID string, entry *CatalogEntry) {
+	if entry.Category != CategoryBat {
+		return
+	}
+	for id := range mm.installed {
+		if id == catalogID {
+			continue
+		}
+		other, found := GetCatalogEntry(id)
+		if found && other.Category == CategoryBat {
+			log.Debug("Retaining shared embeddings; other bat models still installed",
+				logger.String("catalog_id", catalogID))
+			return
+		}
+	}
+	for _, f := range entry.Files {
+		if f.Role == RoleEmbeddings {
+			path := filepath.Join(mm.modelsDir, "shared", f.LocalName)
+			if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+				log.Warn("Failed to remove embeddings file",
+					logger.String("path", path),
+					logger.Error(err))
+			} else if err == nil {
+				log.Info("Removed shared embeddings file",
+					logger.String("path", path))
+			}
+		}
+	}
+}
+
+// cleanupSharedGeomodel removes shared geomodel files when uninstalling a
+// model with geomodel dependencies, but only if no other geomodel-dependent
+// model remains installed. The caller must hold mm.mu, and catalogID must
+// still be in mm.installed.
+func (mm *ModelManager) cleanupSharedGeomodel(log logger.Logger, catalogID string, entry *CatalogEntry) {
+	if !hasGeomodelFiles(entry) {
+		return
+	}
+	for id := range mm.installed {
+		if id == catalogID {
+			continue
+		}
+		other, found := GetCatalogEntry(id)
+		if found && hasGeomodelFiles(&other) {
+			log.Debug("Retaining shared geomodel files; other dependent models still installed",
+				logger.String("catalog_id", catalogID))
+			return
+		}
+	}
+	for _, f := range entry.Files {
+		if f.Role == RoleGeomodel {
+			path := filepath.Join(mm.modelsDir, "shared", f.LocalName)
+			if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+				log.Warn("Failed to remove geomodel file",
+					logger.String("path", path),
+					logger.Error(err))
+			} else if err == nil {
+				log.Info("Removed shared geomodel file",
+					logger.String("path", path))
+			}
+		}
+	}
 }
 
 // Install downloads all files for a catalog entry and records it as installed.
@@ -442,8 +479,9 @@ func (mm *ModelManager) Install(entry *CatalogEntry, baseURL string, progress ch
 	}
 
 	// fileDestPath returns the local destination for a catalog file.
+	// Shared files (embeddings, geomodel) are stored in a common directory.
 	fileDestPath := func(f CatalogFile) string {
-		if f.Role == RoleEmbeddings {
+		if f.Role == RoleEmbeddings || f.Role == RoleGeomodel {
 			return filepath.Join(mm.modelsDir, "shared", f.LocalName)
 		}
 		return filepath.Join(subdir, f.LocalName)
@@ -481,12 +519,17 @@ func (mm *ModelManager) Install(entry *CatalogEntry, baseURL string, progress ch
 			continue
 		}
 
-		// Build download URL.
+		// Build download URL. Per-file HuggingFaceRepo overrides the entry-level repo,
+		// allowing companion files (e.g., geomodel) to live in a separate repository.
 		var url string
 		if baseURL != "" {
 			url = baseURL + "/" + f.RemotePath
 		} else {
-			url = buildHuggingFaceURL(entry.HuggingFaceRepo, f.RemotePath)
+			repo := entry.HuggingFaceRepo
+			if f.HuggingFaceRepo != "" {
+				repo = f.HuggingFaceRepo
+			}
+			url = buildHuggingFaceURL(repo, f.RemotePath)
 		}
 
 		fileIndex++
@@ -619,8 +662,8 @@ func (mm *ModelManager) applyConfigForInstall(entry *CatalogEntry, modelPath, la
 
 	switch entry.RegistryID {
 	case RegistryIDBirdNETV3:
-		GetLogger().Info("BirdNET v3.0 config wiring not yet implemented",
-			logger.String("catalog_id", entry.ID))
+		// BirdNET v3.0 acoustic model config will be added when the model is released.
+		// Geomodel range filter config is applied generically below.
 	case RegistryIDPerchV2:
 		if modelPath != "" {
 			updated.Perch.ModelPath = modelPath
@@ -644,6 +687,22 @@ func (mm *ModelManager) applyConfigForInstall(entry *CatalogEntry, modelPath, la
 		}
 		if embeddingsPath != "" {
 			updated.Bat.EmbeddingModel = embeddingsPath
+		}
+	}
+
+	// Apply v3 geomodel range filter config if this entry includes geomodel files.
+	if hasGeomodelFiles(entry) {
+		updated.BirdNET.RangeFilter.Model = "v3"
+		for _, f := range entry.Files {
+			if f.Role != RoleGeomodel {
+				continue
+			}
+			path := filepath.Join(mm.modelsDir, "shared", f.LocalName)
+			if strings.HasSuffix(f.LocalName, ".onnx") {
+				updated.BirdNET.RangeFilter.ModelPath = path
+			} else {
+				updated.BirdNET.RangeFilter.LabelsPath = path
+			}
 		}
 	}
 
@@ -683,8 +742,8 @@ func (mm *ModelManager) applyConfigForUninstall(entry *CatalogEntry) {
 
 	switch entry.RegistryID {
 	case RegistryIDBirdNETV3:
-		GetLogger().Info("BirdNET v3.0 config wiring not yet implemented",
-			logger.String("catalog_id", entry.ID))
+		// BirdNET v3.0 acoustic model config will be cleared when the model is released.
+		// Geomodel range filter config is handled generically below.
 	case RegistryIDPerchV2:
 		updated.Perch.ModelPath = ""
 		updated.Perch.LabelPath = ""
@@ -718,6 +777,24 @@ func (mm *ModelManager) applyConfigForUninstall(entry *CatalogEntry) {
 					break
 				}
 			}
+		}
+	}
+
+	// Reset v3 geomodel range filter config if no other geomodel-dependent model remains.
+	// mm.installed no longer contains the uninstalled entry (deleted by caller).
+	if hasGeomodelFiles(entry) {
+		otherGeomodel := false
+		for id := range mm.installed {
+			other, found := GetCatalogEntry(id)
+			if found && hasGeomodelFiles(&other) {
+				otherGeomodel = true
+				break
+			}
+		}
+		if !otherGeomodel {
+			updated.BirdNET.RangeFilter.Model = ""
+			updated.BirdNET.RangeFilter.ModelPath = ""
+			updated.BirdNET.RangeFilter.LabelsPath = ""
 		}
 	}
 

--- a/internal/classifier/model_manager_test.go
+++ b/internal/classifier/model_manager_test.go
@@ -11,6 +11,15 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/conf"
+)
+
+// Test URL paths used in httptest handlers.
+const (
+	testPathModelONNX = "/model.onnx"
+	testPathLabels    = "/labels.txt"
+	testPathGeomodel  = "/geomodel.onnx"
+	testPathGeoLabels = "/geomodel_labels.txt"
 )
 
 // sha256Hex returns the hex-encoded SHA-256 hash of data.
@@ -119,10 +128,16 @@ func TestModelManager_UninstallRemovesModelRetainsLabels(t *testing.T) {
 	subdir := filepath.Join(modelsDir, entry.ID)
 	require.NoError(t, os.MkdirAll(subdir, 0o755))
 
-	// Create all catalog files on disk.
+	// Create all catalog files on disk in their expected locations.
 	for _, f := range entry.Files {
-		path := filepath.Join(subdir, f.LocalName)
-		require.NoError(t, os.WriteFile(path, []byte("data"), 0o644))
+		var dir string
+		if f.Role == RoleEmbeddings || f.Role == RoleGeomodel {
+			dir = filepath.Join(modelsDir, "shared")
+		} else {
+			dir = subdir
+		}
+		require.NoError(t, os.MkdirAll(dir, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, f.LocalName), []byte("data"), 0o644))
 	}
 
 	mm := NewModelManager(modelsDir, nil, nil)
@@ -132,15 +147,23 @@ func TestModelManager_UninstallRemovesModelRetainsLabels(t *testing.T) {
 	require.NoError(t, mm.Uninstall(entry.ID))
 	assert.False(t, mm.IsInstalled(entry.ID))
 
-	// Model file should be gone, labels should remain.
+	// Model file should be gone, labels should remain,
+	// shared geomodel files should be gone (no other dependent model installed).
 	for _, f := range entry.Files {
-		path := filepath.Join(subdir, f.LocalName)
-		_, err := os.Stat(path)
-		if f.Role == "model" {
-			assert.True(t, os.IsNotExist(err), "model file %s should be deleted", f.LocalName)
+		var path string
+		if f.Role == RoleEmbeddings || f.Role == RoleGeomodel {
+			path = filepath.Join(modelsDir, "shared", f.LocalName)
+		} else {
+			path = filepath.Join(subdir, f.LocalName)
 		}
-		if f.Role == "labels" {
-			assert.NoError(t, err, "labels file %s should be retained", f.LocalName)
+		_, err := os.Stat(path)
+		switch f.Role {
+		case RoleModel:
+			assert.True(t, os.IsNotExist(err), "model file %s should be deleted", f.LocalName)
+		case RoleLabels:
+			require.NoError(t, err, "labels file %s should be retained", f.LocalName)
+		case RoleGeomodel:
+			assert.True(t, os.IsNotExist(err), "geomodel file %s should be deleted when no dependents remain", f.LocalName)
 		}
 	}
 }
@@ -401,10 +424,10 @@ func TestModelManager_UninstallSucceedsWhenModelNotLoaded(t *testing.T) {
 	subdir := filepath.Join(modelsDir, entry.ID)
 	require.NoError(t, os.MkdirAll(subdir, 0o755))
 
-	// Create all catalog files on disk.
+	// Create all catalog files on disk in their expected locations.
 	for _, f := range entry.Files {
 		var dir string
-		if f.Role == RoleEmbeddings {
+		if f.Role == RoleEmbeddings || f.Role == RoleGeomodel {
 			dir = filepath.Join(modelsDir, "shared")
 		} else {
 			dir = subdir
@@ -430,7 +453,7 @@ func TestModelManager_UninstallSucceedsWhenModelNotLoaded(t *testing.T) {
 	// Verify per-role file expectations after uninstall.
 	for _, f := range entry.Files {
 		var path string
-		if f.Role == RoleEmbeddings {
+		if f.Role == RoleEmbeddings || f.Role == RoleGeomodel {
 			path = filepath.Join(modelsDir, "shared", f.LocalName)
 		} else {
 			path = filepath.Join(subdir, f.LocalName)
@@ -440,7 +463,9 @@ func TestModelManager_UninstallSucceedsWhenModelNotLoaded(t *testing.T) {
 		case RoleModel, RoleData:
 			assert.True(t, os.IsNotExist(statErr), "%s file %s must be deleted after uninstall", f.Role, f.LocalName)
 		case RoleLabels:
-			assert.NoError(t, statErr, "labels file %s must be retained after uninstall", f.LocalName)
+			require.NoError(t, statErr, "labels file %s must be retained after uninstall", f.LocalName)
+		case RoleGeomodel:
+			assert.True(t, os.IsNotExist(statErr), "geomodel file %s must be deleted when no dependents remain", f.LocalName)
 		}
 	}
 }
@@ -458,7 +483,7 @@ func TestModelManager_UninstallAbortsOnUnloadFailure(t *testing.T) {
 
 	for _, f := range entry.Files {
 		var dir string
-		if f.Role == RoleEmbeddings {
+		if f.Role == RoleEmbeddings || f.Role == RoleGeomodel {
 			dir = filepath.Join(modelsDir, "shared")
 		} else {
 			dir = subdir
@@ -491,13 +516,341 @@ func TestModelManager_UninstallAbortsOnUnloadFailure(t *testing.T) {
 	// All files must still exist on disk.
 	for _, f := range entry.Files {
 		var path string
-		if f.Role == RoleEmbeddings {
+		if f.Role == RoleEmbeddings || f.Role == RoleGeomodel {
 			path = filepath.Join(modelsDir, "shared", f.LocalName)
 		} else {
 			path = filepath.Join(subdir, f.LocalName)
 		}
 		_, statErr := os.Stat(path)
 		assert.NoError(t, statErr, "file %s must still exist after aborted uninstall", f.LocalName)
+	}
+}
+
+func TestModelManager_Install_SharedGeomodel(t *testing.T) {
+	t.Parallel()
+
+	modelContent := []byte("perch-model-data")
+	labelsContent := []byte("species_a\nspecies_b\n")
+	geomodelContent := []byte("geomodel-onnx-data")
+	geomodelLabelsContent := []byte("Acrocephalus_arundinaceus\n")
+	modelChecksum := sha256Hex(modelContent)
+	labelsChecksum := sha256Hex(labelsContent)
+	geomodelChecksum := sha256Hex(geomodelContent)
+	geomodelLabelsChecksum := sha256Hex(geomodelLabelsContent)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case testPathModelONNX:
+			_, _ = w.Write(modelContent)
+		case testPathLabels:
+			_, _ = w.Write(labelsContent)
+		case testPathGeomodel:
+			_, _ = w.Write(geomodelContent)
+		case testPathGeoLabels:
+			_, _ = w.Write(geomodelLabelsContent)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	entry := CatalogEntry{
+		ID:              "test-geomodel-shared",
+		Name:            "Test with Geomodel",
+		Version:         "1.0",
+		HuggingFaceRepo: "test/repo",
+		Files: []CatalogFile{
+			{RemotePath: "model.onnx", LocalName: "model.onnx", Role: RoleModel, SHA256: modelChecksum, SizeBytes: int64(len(modelContent))},
+			{RemotePath: "labels.txt", LocalName: "labels.txt", Role: RoleLabels, SHA256: labelsChecksum, SizeBytes: int64(len(labelsContent))},
+			{RemotePath: "geomodel.onnx", LocalName: "geomodel_v3.onnx", Role: RoleGeomodel, SHA256: geomodelChecksum, SizeBytes: int64(len(geomodelContent))},
+			{RemotePath: "geomodel_labels.txt", LocalName: "geomodel_v3_labels.txt", Role: RoleGeomodel, SHA256: geomodelLabelsChecksum, SizeBytes: int64(len(geomodelLabelsContent))},
+		},
+	}
+
+	modelsDir := t.TempDir()
+	mm := NewModelManager(modelsDir, nil, nil)
+
+	err := mm.Install(&entry, srv.URL, nil)
+	require.NoError(t, err)
+
+	// Geomodel files should be in shared/, not in the model subdirectory.
+	sharedONNX := filepath.Join(modelsDir, "shared", "geomodel_v3.onnx")
+	_, err = os.Stat(sharedONNX)
+	require.NoError(t, err, "geomodel ONNX should exist in shared/")
+
+	sharedLabels := filepath.Join(modelsDir, "shared", "geomodel_v3_labels.txt")
+	_, err = os.Stat(sharedLabels)
+	require.NoError(t, err, "geomodel labels should exist in shared/")
+
+	// Model file should be in the model subdirectory.
+	modelPath := filepath.Join(modelsDir, "test-geomodel-shared", "model.onnx")
+	_, err = os.Stat(modelPath)
+	require.NoError(t, err, "model file should exist in model subdirectory")
+
+	// Geomodel files should NOT be in the model subdirectory.
+	_, err = os.Stat(filepath.Join(modelsDir, "test-geomodel-shared", "geomodel_v3.onnx"))
+	assert.True(t, os.IsNotExist(err), "geomodel should NOT exist in model subdirectory")
+}
+
+func TestModelManager_Install_GeomodelSkipsExisting(t *testing.T) {
+	t.Parallel()
+
+	modelContent := []byte("model-data-second")
+	geomodelContent := []byte("shared-geomodel-data")
+	modelChecksum := sha256Hex(modelContent)
+	geomodelChecksum := sha256Hex(geomodelContent)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case testPathModelONNX:
+			_, _ = w.Write(modelContent)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	modelsDir := t.TempDir()
+
+	// Pre-create the shared geomodel file (simulating a previous install).
+	sharedDir := filepath.Join(modelsDir, "shared")
+	require.NoError(t, os.MkdirAll(sharedDir, 0o755))
+	sharedPath := filepath.Join(sharedDir, "geomodel.onnx")
+	require.NoError(t, os.WriteFile(sharedPath, geomodelContent, 0o644))
+
+	entry := CatalogEntry{
+		ID:              "test-skip-geomodel",
+		Name:            "Second Model with Shared Geomodel",
+		Version:         "1.0",
+		HuggingFaceRepo: "test/repo",
+		Files: []CatalogFile{
+			{RemotePath: "model.onnx", LocalName: "model.onnx", Role: RoleModel, SHA256: modelChecksum, SizeBytes: int64(len(modelContent))},
+			{RemotePath: "geomodel.onnx", LocalName: "geomodel.onnx", Role: RoleGeomodel, SHA256: geomodelChecksum, SizeBytes: int64(len(geomodelContent))},
+		},
+	}
+
+	mm := NewModelManager(modelsDir, nil, nil)
+	err := mm.Install(&entry, srv.URL, nil)
+	require.NoError(t, err)
+
+	// The server returns 404 for geomodel.onnx, so if Install tried to
+	// download it, it would fail. Success proves it was skipped.
+	assert.True(t, mm.IsInstalled("test-skip-geomodel"))
+
+	// Verify shared file is still there with original content.
+	got, err := os.ReadFile(sharedPath)
+	require.NoError(t, err)
+	assert.Equal(t, geomodelContent, got)
+}
+
+func TestModelManager_Uninstall_GeomodelRetainedWhenDependentExists(t *testing.T) {
+	t.Parallel()
+
+	// Use real catalog entries: both perch-v2 and birdnet-v3.0 have geomodel files.
+	entryPerch, ok := GetCatalogEntry("perch-v2")
+	require.True(t, ok)
+	entryV3, ok := GetCatalogEntry("birdnet-v3.0")
+	require.True(t, ok)
+
+	modelsDir := t.TempDir()
+	sharedDir := filepath.Join(modelsDir, "shared")
+	require.NoError(t, os.MkdirAll(sharedDir, 0o755))
+
+	// Set up files on disk for both entries.
+	for _, entry := range []CatalogEntry{entryPerch, entryV3} {
+		subdir := filepath.Join(modelsDir, entry.ID)
+		require.NoError(t, os.MkdirAll(subdir, 0o755))
+		for _, f := range entry.Files {
+			var dir string
+			if f.Role == RoleEmbeddings || f.Role == RoleGeomodel {
+				dir = sharedDir
+			} else {
+				dir = subdir
+			}
+			require.NoError(t, os.WriteFile(filepath.Join(dir, f.LocalName), []byte("data"), 0o644))
+		}
+	}
+
+	mm := NewModelManager(modelsDir, nil, nil)
+	mm.ScanInstalled()
+	require.True(t, mm.IsInstalled("perch-v2"))
+	require.True(t, mm.IsInstalled("birdnet-v3.0"))
+
+	// Uninstall perch-v2; birdnet-v3.0 still depends on the geomodel.
+	require.NoError(t, mm.Uninstall("perch-v2"))
+
+	// Shared geomodel files should be retained.
+	for _, f := range entryPerch.Files {
+		if f.Role == RoleGeomodel {
+			path := filepath.Join(sharedDir, f.LocalName)
+			_, err := os.Stat(path)
+			require.NoError(t, err, "geomodel file %s must be retained while birdnet-v3.0 is installed", f.LocalName)
+		}
+	}
+
+	// Now uninstall birdnet-v3.0; no dependents remain.
+	require.NoError(t, mm.Uninstall("birdnet-v3.0"))
+
+	// Shared geomodel files should now be deleted.
+	for _, f := range entryV3.Files {
+		if f.Role == RoleGeomodel {
+			path := filepath.Join(sharedDir, f.LocalName)
+			_, err := os.Stat(path)
+			assert.True(t, os.IsNotExist(err), "geomodel file %s must be deleted when no dependents remain", f.LocalName)
+		}
+	}
+}
+
+func TestModelManager_Install_PerFileHuggingFaceRepo(t *testing.T) {
+	t.Parallel()
+
+	entry := CatalogEntry{
+		ID:              "test-per-file-repo",
+		Name:            "Per-file repo test",
+		Version:         "1.0",
+		HuggingFaceRepo: "main-repo",
+		Files: []CatalogFile{
+			{RemotePath: "model.onnx", LocalName: "model.onnx", Role: RoleModel},
+			{RemotePath: "companion.bin", LocalName: "companion.bin", Role: RoleGeomodel, HuggingFaceRepo: "companion-repo"},
+		},
+	}
+
+	// Verify the URL construction logic: when HuggingFaceRepo is set on a
+	// CatalogFile, Install should use it instead of the entry-level repo.
+	for _, f := range entry.Files {
+		repo := entry.HuggingFaceRepo
+		if f.HuggingFaceRepo != "" {
+			repo = f.HuggingFaceRepo
+		}
+		got := buildHuggingFaceURL(repo, f.RemotePath)
+		if f.HuggingFaceRepo != "" {
+			assert.Contains(t, got, "companion-repo", "file with per-file repo should use companion-repo")
+			assert.Equal(t, "https://huggingface.co/companion-repo/resolve/main/companion.bin", got)
+		} else {
+			assert.Contains(t, got, "main-repo", "file without per-file repo should use entry repo")
+			assert.Equal(t, "https://huggingface.co/main-repo/resolve/main/model.onnx", got)
+		}
+	}
+}
+
+func TestModelManager_Install_GeomodelConfigWiring(t *testing.T) {
+	// Not parallel: mutates global settings via conf.StoreSettings.
+
+	modelContent := []byte("perch-model")
+	labelsContent := []byte("labels")
+	geomodelContent := []byte("geo-onnx")
+	geomodelLabelsContent := []byte("geo-labels")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case testPathModelONNX:
+			_, _ = w.Write(modelContent)
+		case testPathLabels:
+			_, _ = w.Write(labelsContent)
+		case testPathGeomodel:
+			_, _ = w.Write(geomodelContent)
+		case testPathGeoLabels:
+			_, _ = w.Write(geomodelLabelsContent)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	entry := CatalogEntry{
+		ID:              "test-geo-config",
+		Name:            "Config Wiring Test",
+		Version:         "1.0",
+		RegistryID:      RegistryIDPerchV2,
+		HuggingFaceRepo: "test/repo",
+		Files: []CatalogFile{
+			{RemotePath: "model.onnx", LocalName: "model.onnx", Role: RoleModel, SHA256: sha256Hex(modelContent), SizeBytes: int64(len(modelContent))},
+			{RemotePath: "labels.txt", LocalName: "labels.txt", Role: RoleLabels, SHA256: sha256Hex(labelsContent), SizeBytes: int64(len(labelsContent))},
+			{RemotePath: "geomodel.onnx", LocalName: "geomodel_v3.onnx", Role: RoleGeomodel, SHA256: sha256Hex(geomodelContent), SizeBytes: int64(len(geomodelContent))},
+			{RemotePath: "geomodel_labels.txt", LocalName: "geomodel_v3_labels.txt", Role: RoleGeomodel, SHA256: sha256Hex(geomodelLabelsContent), SizeBytes: int64(len(geomodelLabelsContent))},
+		},
+	}
+
+	// Save original settings to restore after test.
+	origSettings := conf.GetSettings()
+	t.Cleanup(func() { conf.StoreSettings(origSettings) })
+
+	modelsDir := t.TempDir()
+	settings := conf.GetTestSettings()
+	conf.StoreSettings(settings)
+	mm := NewModelManager(modelsDir, nil, settings)
+
+	err := mm.Install(&entry, srv.URL, nil)
+	require.NoError(t, err)
+
+	// Verify range filter config was set.
+	current := conf.GetSettings()
+	assert.Equal(t, "v3", current.BirdNET.RangeFilter.Model)
+	assert.Equal(t, filepath.Join(modelsDir, "shared", "geomodel_v3.onnx"), current.BirdNET.RangeFilter.ModelPath)
+	assert.Equal(t, filepath.Join(modelsDir, "shared", "geomodel_v3_labels.txt"), current.BirdNET.RangeFilter.LabelsPath)
+}
+
+func TestHasGeomodelFiles(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		entry CatalogEntry
+		want  bool
+	}{
+		{
+			name:  "no files",
+			entry: CatalogEntry{Files: nil},
+			want:  false,
+		},
+		{
+			name: "model and labels only",
+			entry: CatalogEntry{Files: []CatalogFile{
+				{Role: RoleModel},
+				{Role: RoleLabels},
+			}},
+			want: false,
+		},
+		{
+			name: "has geomodel files",
+			entry: CatalogEntry{Files: []CatalogFile{
+				{Role: RoleModel},
+				{Role: RoleGeomodel},
+			}},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, hasGeomodelFiles(&tt.entry))
+		})
+	}
+}
+
+func TestCatalog_GeomodelFilesOnPerchAndBirdNET(t *testing.T) {
+	t.Parallel()
+
+	for _, id := range []string{"perch-v2", "birdnet-v3.0"} {
+		t.Run(id, func(t *testing.T) {
+			t.Parallel()
+			entry, ok := GetCatalogEntry(id)
+			require.True(t, ok, "expected %s catalog entry to exist", id)
+
+			assert.True(t, hasGeomodelFiles(&entry), "%s should have geomodel files", id)
+
+			var geoFileCount int
+			for _, f := range entry.Files {
+				if f.Role == RoleGeomodel {
+					geoFileCount++
+					assert.NotEmpty(t, f.SHA256, "geomodel file %s must have a SHA256 checksum", f.LocalName)
+					assert.Positive(t, f.SizeBytes, "geomodel file %s must have a non-zero size", f.LocalName)
+					assert.Equal(t, geomodelHuggingFaceRepo, f.HuggingFaceRepo, "geomodel file %s must use the geomodel HuggingFace repo", f.LocalName)
+				}
+			}
+			assert.Equal(t, 2, geoFileCount, "expected exactly 2 geomodel files (ONNX + labels)")
+		})
 	}
 }
 

--- a/internal/classifier/model_manager_test.go
+++ b/internal/classifier/model_manager_test.go
@@ -790,6 +790,73 @@ func TestModelManager_Install_GeomodelConfigWiring(t *testing.T) {
 	assert.Equal(t, filepath.Join(modelsDir, "shared", "geomodel_v3_labels.txt"), current.BirdNET.RangeFilter.LabelsPath)
 }
 
+func TestModelManager_Uninstall_GeomodelConfigClearing(t *testing.T) {
+	// Not parallel: mutates global settings via conf.StoreSettings.
+
+	modelContent := []byte("perch-model")
+	labelsContent := []byte("labels")
+	geomodelContent := []byte("geo-onnx")
+	geomodelLabelsContent := []byte("geo-labels")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case testPathModelONNX:
+			_, _ = w.Write(modelContent)
+		case testPathLabels:
+			_, _ = w.Write(labelsContent)
+		case testPathGeomodel:
+			_, _ = w.Write(geomodelContent)
+		case testPathGeoLabels:
+			_, _ = w.Write(geomodelLabelsContent)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	entry := CatalogEntry{
+		ID:              "test-geo-uninstall-config",
+		Name:            "Uninstall Config Test",
+		Version:         "1.0",
+		RegistryID:      RegistryIDPerchV2,
+		HuggingFaceRepo: "test/repo",
+		Files: []CatalogFile{
+			{RemotePath: "model.onnx", LocalName: "model.onnx", Role: RoleModel, SHA256: sha256Hex(modelContent), SizeBytes: int64(len(modelContent))},
+			{RemotePath: "labels.txt", LocalName: "labels.txt", Role: RoleLabels, SHA256: sha256Hex(labelsContent), SizeBytes: int64(len(labelsContent))},
+			{RemotePath: "geomodel.onnx", LocalName: "geomodel_v3.onnx", Role: RoleGeomodel, SHA256: sha256Hex(geomodelContent), SizeBytes: int64(len(geomodelContent))},
+			{RemotePath: "geomodel_labels.txt", LocalName: "geomodel_v3_labels.txt", Role: RoleGeomodel, SHA256: sha256Hex(geomodelLabelsContent), SizeBytes: int64(len(geomodelLabelsContent))},
+		},
+	}
+
+	origSettings := conf.GetSettings()
+	t.Cleanup(func() { conf.StoreSettings(origSettings) })
+
+	modelsDir := t.TempDir()
+	settings := conf.GetTestSettings()
+	conf.StoreSettings(settings)
+	mm := NewModelManager(modelsDir, nil, settings)
+
+	// Install to set config.
+	err := mm.Install(&entry, srv.URL, nil)
+	require.NoError(t, err)
+
+	current := conf.GetSettings()
+	require.Equal(t, "v3", current.BirdNET.RangeFilter.Model, "precondition: install must set model to v3")
+
+	// Add entry to EmbeddedCatalog temporarily so Uninstall can find it.
+	origLen := len(EmbeddedCatalog)
+	EmbeddedCatalog = append(EmbeddedCatalog, entry)
+	t.Cleanup(func() { EmbeddedCatalog = EmbeddedCatalog[:origLen] })
+
+	// Uninstall should clear the range filter config.
+	require.NoError(t, mm.Uninstall("test-geo-uninstall-config"))
+
+	current = conf.GetSettings()
+	assert.Empty(t, current.BirdNET.RangeFilter.Model, "uninstall must clear range filter model")
+	assert.Empty(t, current.BirdNET.RangeFilter.ModelPath, "uninstall must clear range filter model path")
+	assert.Empty(t, current.BirdNET.RangeFilter.LabelsPath, "uninstall must clear range filter labels path")
+}
+
 func TestHasGeomodelFiles(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Add auto-download of the v3.0 geomodel ONNX range filter as a shared companion when installing Perch v2 or BirdNET v3.0 from the model gallery
- Geomodel files (7.5 MB ONNX + 479 KB labels) hosted at `tphakala/BirdNET-Geomodel` on HuggingFace, stored in `models/shared/`
- Downloaded once and retained while any dependent classifier is installed; cleaned up only when the last dependent model is removed
- RangeFilter config (`model=v3`, `modelpath`, `labelspath`) automatically wired on install and cleared on uninstall
- Add `RoleGeomodel` catalog file role and `HuggingFaceRepo` per-file override on `CatalogFile` for cross-repo companion downloads
- Extract shared file cleanup into `cleanupSharedEmbeddings` and `cleanupSharedGeomodel` helpers to reduce `Uninstall` cognitive complexity

## Changes

- `internal/classifier/model_catalog.go`: New role constant, per-file repo override field, geomodel file entries on Perch v2 and BirdNET v3.0, `hasGeomodelFiles` helper
- `internal/classifier/model_manager.go`: Shared file routing in `Install`, cleanup helpers, config wiring in `applyConfigForInstall`/`applyConfigForUninstall`
- `internal/classifier/model_manager_test.go`: 9 new tests covering shared download, skip-existing, retention with dependents, per-file repo URLs, config wiring on install and uninstall, `hasGeomodelFiles` predicate, catalog validation

## Test Plan

- [x] 31 model manager tests pass with race detector
- [x] Zero golangci-lint issues
- [x] Gate review (4 agents + Gemini) completed with no critical/high findings
- [x] Install Perch v2: geomodel downloaded to `shared/`
- [x] Install BirdNET v3.0 after Perch v2: geomodel download skipped (already present)
- [x] Uninstall Perch v2 while BirdNET v3.0 installed: geomodel retained
- [x] Uninstall last dependent: geomodel cleaned up, RangeFilter config cleared

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added geomodel file support to the model catalog system.
  * BirdNET v3.0 and Perch v2 now include shared geomodel files.
  * Improved handling and configuration of shared assets across models during installation and uninstallation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3032)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->