### PR TITLE
fix(conf): normalize zero-valued settings instead of rejecting them

### DIFF
--- a/internal/conf/config.yaml
+++ b/internal/conf/config.yaml
@@ -355,6 +355,12 @@ webserver:
   enabled: true           # true to enable web server
   port: 8080              # port for web server
   allowembedding: false   # true to allow embedding in iframes (e.g., Home Assistant)
+  livestream:
+    debug: false
+    bitrate: 128          # bitrate for live stream in kbps (16-320)
+    samplerate: 48000     # sample rate for live stream in Hz
+    segmentlength: 2      # length of each HLS segment in seconds (1-30)
+    ffmpegloglevel: warning
   log:
     enabled: false        # true to enable log file
     path: webui.log       # path to log file
@@ -398,6 +404,7 @@ security:
   # redirecttohttps forces HTTP connections to redirect to HTTPS
   # Only works when autotls is enabled or manual TLS certificates are configured
   redirecttohttps: false
+  sessionduration: 168h      # browser session cookie lifetime (default: 7 days)
   allowsubnetbypass:
     enabled: false           # true to disable OAuth in subnet
     subnet: ""               # comma-separated list of CIDR ranges (e.g., "192.168.1.0/24,10.0.0.0/8")

--- a/internal/conf/consts.go
+++ b/internal/conf/consts.go
@@ -44,6 +44,4 @@ const (
 )
 
 // DefaultSessionDuration is the default session duration (7 days).
-// Declared as a var because time.Duration constants cannot use time.Hour
-// (which is not a compile-time constant in the language spec).
-var DefaultSessionDuration = 168 * time.Hour
+const DefaultSessionDuration = 168 * time.Hour

--- a/internal/conf/consts.go
+++ b/internal/conf/consts.go
@@ -1,6 +1,8 @@
 // conf/consts.go hard coded constants
 package conf
 
+import "time"
+
 const (
 	// Model IDs identify the inference backends available for detection.
 	ModelIDBirdNET = "birdnet"
@@ -29,4 +31,19 @@ const (
 	MaxExtendedCaptureDuration        = 1200 // Absolute max (20 minutes)
 	ExtendedCaptureBufferMargin       = 60   // Margin added to MaxDuration for buffer sizing
 	ExtendedCaptureMinBufferMargin    = 30   // Minimum margin above MaxDuration + PreCapture
+
+	// LiveStream defaults for webserver configuration.
+	// Viper nested defaults can be lost when the parent key exists in the config
+	// file but the child section is absent, so validation normalizes to these.
+	DefaultLiveStreamBitRate       = 128
+	DefaultLiveStreamSegmentLength = 2
+	DefaultLiveStreamSampleRate    = 48000
+
+	// DefaultWeatherPollInterval is the default weather poll interval in minutes.
+	DefaultWeatherPollInterval = 60
 )
+
+// DefaultSessionDuration is the default session duration (7 days).
+// Declared as a var because time.Duration constants cannot use time.Hour
+// (which is not a compile-time constant in the language spec).
+var DefaultSessionDuration = 168 * time.Hour

--- a/internal/conf/defaults.go
+++ b/internal/conf/defaults.go
@@ -229,7 +229,7 @@ func setDefaultConfig() {
 
 	// New weather configuration
 	viper.SetDefault("realtime.weather.debug", false)
-	viper.SetDefault("realtime.weather.pollinterval", 60)
+	viper.SetDefault("realtime.weather.pollinterval", DefaultWeatherPollInterval)
 	viper.SetDefault("realtime.weather.provider", "yrno")
 
 	// OpenWeather specific configuration
@@ -330,9 +330,9 @@ func setDefaultConfig() {
 
 	// Live stream configuration
 	viper.SetDefault("webserver.livestream.debug", false)
-	viper.SetDefault("webserver.livestream.bitrate", 128)
-	viper.SetDefault("webserver.livestream.sampleRate", 48000)
-	viper.SetDefault("webserver.livestream.segmentLength", 2)
+	viper.SetDefault("webserver.livestream.bitrate", DefaultLiveStreamBitRate)
+	viper.SetDefault("webserver.livestream.sampleRate", DefaultLiveStreamSampleRate)
+	viper.SetDefault("webserver.livestream.segmentLength", DefaultLiveStreamSegmentLength)
 	viper.SetDefault("webserver.livestream.ffmpegLogLevel", "warning")
 
 	// File output configuration

--- a/internal/conf/pure_validation_test.go
+++ b/internal/conf/pure_validation_test.go
@@ -901,7 +901,7 @@ func TestValidateWebServerSettings_Invalid(t *testing.T) {
 				Port:    "8080",
 				LiveStream: LiveStreamSettings{
 					BitRate:       128,
-					SegmentLength: 0,
+					SegmentLength: -1,
 				},
 			},
 			expectError: "segment length must be between 1 and 30 seconds",

--- a/internal/conf/test_helpers.go
+++ b/internal/conf/test_helpers.go
@@ -1,5 +1,7 @@
 package conf
 
+import "time"
+
 // SetTestSettings allows tests to inject their own settings instance.
 // Subsequent GetSettings()/Setting() calls observe the new snapshot
 // atomically. Passing nil clears the snapshot, causing the next
@@ -38,6 +40,16 @@ func GetTestSettings() *Settings {
 	// Web server settings
 	settings.WebServer.Enabled = false
 	settings.WebServer.Port = "8080"
+	settings.WebServer.LiveStream.BitRate = 128
+	settings.WebServer.LiveStream.SegmentLength = 2
+	settings.WebServer.LiveStream.SampleRate = 48000
+
+	// Security settings
+	settings.Security.SessionSecret = "test-secret-for-unit-tests"
+	settings.Security.SessionDuration = 168 * time.Hour // 7 days
+
+	// Weather settings
+	settings.Realtime.Weather.PollInterval = 60
 
 	// Output settings
 	settings.Output.SQLite.Enabled = false

--- a/internal/conf/test_helpers.go
+++ b/internal/conf/test_helpers.go
@@ -1,7 +1,5 @@
 package conf
 
-import "time"
-
 // SetTestSettings allows tests to inject their own settings instance.
 // Subsequent GetSettings()/Setting() calls observe the new snapshot
 // atomically. Passing nil clears the snapshot, causing the next
@@ -40,16 +38,16 @@ func GetTestSettings() *Settings {
 	// Web server settings
 	settings.WebServer.Enabled = false
 	settings.WebServer.Port = "8080"
-	settings.WebServer.LiveStream.BitRate = 128
-	settings.WebServer.LiveStream.SegmentLength = 2
-	settings.WebServer.LiveStream.SampleRate = 48000
+	settings.WebServer.LiveStream.BitRate = DefaultLiveStreamBitRate
+	settings.WebServer.LiveStream.SegmentLength = DefaultLiveStreamSegmentLength
+	settings.WebServer.LiveStream.SampleRate = DefaultLiveStreamSampleRate
 
 	// Security settings
 	settings.Security.SessionSecret = "test-secret-for-unit-tests"
-	settings.Security.SessionDuration = 168 * time.Hour // 7 days
+	settings.Security.SessionDuration = DefaultSessionDuration
 
 	// Weather settings
-	settings.Realtime.Weather.PollInterval = 60
+	settings.Realtime.Weather.PollInterval = DefaultWeatherPollInterval
 
 	// Output settings
 	settings.Output.SQLite.Enabled = false

--- a/internal/conf/validate_realtime.go
+++ b/internal/conf/validate_realtime.go
@@ -301,6 +301,12 @@ func validateWeatherSettings(settings *WeatherSettings) error {
 		}
 	}
 
+	// Normalize poll interval: viper nested defaults can be lost when the
+	// parent key exists in the config file but pollinterval is absent.
+	if settings.PollInterval == 0 {
+		settings.PollInterval = 60 // matches viper default
+	}
+
 	// Validate poll interval (minimum 15 minutes)
 	if settings.PollInterval < 15 {
 		return errors.Newf("weather poll interval must be at least 15 minutes, got %d", settings.PollInterval).

--- a/internal/conf/validate_realtime.go
+++ b/internal/conf/validate_realtime.go
@@ -304,7 +304,7 @@ func validateWeatherSettings(settings *WeatherSettings) error {
 	// Normalize poll interval: viper nested defaults can be lost when the
 	// parent key exists in the config file but pollinterval is absent.
 	if settings.PollInterval == 0 {
-		settings.PollInterval = 60 // matches viper default
+		settings.PollInterval = DefaultWeatherPollInterval // matches viper default
 	}
 
 	// Validate poll interval (minimum 15 minutes)

--- a/internal/conf/validate_security.go
+++ b/internal/conf/validate_security.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/logger"
@@ -52,12 +53,10 @@ func validateSecuritySettings(settings *Security) error {
 		}
 	}
 
-	// Validate session duration
+	// Normalize session duration: viper nested defaults can be lost when the
+	// parent key exists in the config file but sessionduration is absent.
 	if settings.SessionDuration <= 0 {
-		return errors.Newf("security.sessionduration must be a positive duration").
-			Category(errors.CategoryValidation).
-			Context("validation_type", "security-session-duration").
-			Build()
+		settings.SessionDuration = 168 * time.Hour // 7 days, matches viper default
 	}
 
 	// Validate OIDC provider configuration

--- a/internal/conf/validate_security.go
+++ b/internal/conf/validate_security.go
@@ -6,7 +6,6 @@ import (
 	"net"
 	"net/url"
 	"strings"
-	"time"
 
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/logger"
@@ -56,7 +55,7 @@ func validateSecuritySettings(settings *Security) error {
 	// Normalize session duration: viper nested defaults can be lost when the
 	// parent key exists in the config file but sessionduration is absent.
 	if settings.SessionDuration <= 0 {
-		settings.SessionDuration = 168 * time.Hour // 7 days, matches viper default
+		settings.SessionDuration = DefaultSessionDuration // 7 days, matches viper default
 	}
 
 	// Validate OIDC provider configuration

--- a/internal/conf/validate_security_test.go
+++ b/internal/conf/validate_security_test.go
@@ -448,20 +448,18 @@ func TestValidateSecuritySettings_SessionDuration(t *testing.T) {
 		errType  string
 	}{
 		{
-			name: "Zero session duration - should fail",
+			name: "Zero session duration - normalized to default",
 			security: Security{
 				SessionDuration: 0,
 			},
-			wantErr: true,
-			errType: "security-session-duration",
+			wantErr: false,
 		},
 		{
-			name: "Negative session duration - should fail",
+			name: "Negative session duration - normalized to default",
 			security: Security{
 				SessionDuration: -1,
 			},
-			wantErr: true,
-			errType: "security-session-duration",
+			wantErr: false,
 		},
 		{
 			name: "Valid positive session duration - should pass",

--- a/internal/conf/validate_security_test.go
+++ b/internal/conf/validate_security_test.go
@@ -442,24 +442,30 @@ func TestValidateSecuritySettings_SessionDuration(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name     string
-		security Security
-		wantErr  bool
-		errType  string
+		name          string
+		security      Security
+		wantErr       bool
+		errType       string
+		wantDuration  time.Duration // expected duration after normalization
+		checkDuration bool          // whether to assert the normalized value
 	}{
 		{
 			name: "Zero session duration - normalized to default",
 			security: Security{
 				SessionDuration: 0,
 			},
-			wantErr: false,
+			wantErr:       false,
+			checkDuration: true,
+			wantDuration:  DefaultSessionDuration,
 		},
 		{
 			name: "Negative session duration - normalized to default",
 			security: Security{
 				SessionDuration: -1,
 			},
-			wantErr: false,
+			wantErr:       false,
+			checkDuration: true,
+			wantDuration:  DefaultSessionDuration,
 		},
 		{
 			name: "Valid positive session duration - should pass",
@@ -481,6 +487,10 @@ func TestValidateSecuritySettings_SessionDuration(t *testing.T) {
 				assertValidationError(t, err, tt.errType)
 			} else {
 				assert.NoError(t, err)
+				if tt.checkDuration {
+					assert.Equal(t, tt.wantDuration, tt.security.SessionDuration,
+						"session duration should be normalized to default")
+				}
 			}
 		})
 	}

--- a/internal/conf/validate_services.go
+++ b/internal/conf/validate_services.go
@@ -257,6 +257,16 @@ func ValidateWebServerSettings(settings *WebServerSettings) ValidationResult {
 		result.Errors = append(result.Errors, err.Error())
 	}
 
+	// Normalize LiveStream defaults: viper nested defaults can be lost when the
+	// parent key (webserver:) exists in the config file but the child section
+	// (livestream:) is absent. Apply compile-time defaults before range-checking.
+	if settings.LiveStream.BitRate == 0 {
+		settings.LiveStream.BitRate = 128
+	}
+	if settings.LiveStream.SegmentLength == 0 {
+		settings.LiveStream.SegmentLength = 2
+	}
+
 	// Validate LiveStream settings
 	if settings.LiveStream.BitRate < 16 || settings.LiveStream.BitRate > 320 {
 		result.Valid = false

--- a/internal/conf/validate_services.go
+++ b/internal/conf/validate_services.go
@@ -261,10 +261,13 @@ func ValidateWebServerSettings(settings *WebServerSettings) ValidationResult {
 	// parent key (webserver:) exists in the config file but the child section
 	// (livestream:) is absent. Apply compile-time defaults before range-checking.
 	if settings.LiveStream.BitRate == 0 {
-		settings.LiveStream.BitRate = 128
+		settings.LiveStream.BitRate = DefaultLiveStreamBitRate
 	}
 	if settings.LiveStream.SegmentLength == 0 {
-		settings.LiveStream.SegmentLength = 2
+		settings.LiveStream.SegmentLength = DefaultLiveStreamSegmentLength
+	}
+	if settings.LiveStream.SampleRate == 0 {
+		settings.LiveStream.SampleRate = DefaultLiveStreamSampleRate
 	}
 
 	// Validate LiveStream settings

--- a/internal/diskmanager/file_utils_test.go
+++ b/internal/diskmanager/file_utils_test.go
@@ -341,7 +341,7 @@ func TestCleanupReturnValues(t *testing.T) {
 	settings.Realtime.Audio.Export.Retention.MaxAge = "30d"
 	settings.Realtime.Audio.Export.Retention.MaxUsage = "80%"
 	settings.Realtime.Audio.Export.Retention.MinClips = 10
-	t.Cleanup(func() { conf.SetTestSettings(nil) })
+	t.Cleanup(func() { conf.NewTestSettings().Apply() })
 
 	// Create a mock DB
 	mockDB := &MockDB{}

--- a/internal/diskmanager/file_utils_test.go
+++ b/internal/diskmanager/file_utils_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/errors"
 )
 
@@ -333,6 +334,15 @@ func TestGetDiskUsage(t *testing.T) {
 
 // TestCleanupReturnValues tests that cleanup functions return the expected values
 func TestCleanupReturnValues(t *testing.T) {
+	settings := conf.NewTestSettings().
+		WithAudioExport(t.TempDir(), "wav", "96k").
+		Apply()
+	settings.Realtime.Audio.Export.Retention.Policy = "age"
+	settings.Realtime.Audio.Export.Retention.MaxAge = "30d"
+	settings.Realtime.Audio.Export.Retention.MaxUsage = "80%"
+	settings.Realtime.Audio.Export.Retention.MinClips = 10
+	t.Cleanup(func() { conf.SetTestSettings(nil) })
+
 	// Create a mock DB
 	mockDB := &MockDB{}
 

--- a/internal/imageprovider/imageprovider_test.go
+++ b/internal/imageprovider/imageprovider_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/detection"
 	"github.com/tphakala/birdnet-go/internal/errors"
@@ -1017,6 +1018,8 @@ func (m *mockProviderWithContext) FetchWithContext(ctx context.Context, scientif
 
 // TestMain provides goleak verification to detect goroutine leaks
 func TestMain(m *testing.M) {
+	conf.NewTestSettings().Apply()
+
 	goleak.VerifyTestMain(m,
 		goleak.IgnoreTopFunction("testing.(*T).Run"),
 		goleak.IgnoreTopFunction("runtime.gopark"),

--- a/internal/security/main_test.go
+++ b/internal/security/main_test.go
@@ -1,0 +1,13 @@
+package security
+
+import (
+	"os"
+	"testing"
+
+	"github.com/tphakala/birdnet-go/internal/conf"
+)
+
+func TestMain(m *testing.M) {
+	conf.NewTestSettings().Apply()
+	os.Exit(m.Run())
+}

--- a/internal/security/oauth_test.go
+++ b/internal/security/oauth_test.go
@@ -22,14 +22,8 @@ import (
 
 // TestIsUserAuthenticatedValidAccessToken tests the IsUserAuthenticated function with a valid access token
 func TestIsUserAuthenticatedValidAccessToken(t *testing.T) {
-	// Set the settings instance
-	conf.Setting()
-
-	settings := &conf.Settings{
-		Security: conf.Security{
-			SessionSecret: "test-secret",
-		},
-	}
+	settings := conf.NewTestSettings().Apply()
+	t.Cleanup(func() { conf.SetTestSettings(nil) })
 
 	s := NewOAuth2Server()
 

--- a/internal/security/oauth_test.go
+++ b/internal/security/oauth_test.go
@@ -23,7 +23,7 @@ import (
 // TestIsUserAuthenticatedValidAccessToken tests the IsUserAuthenticated function with a valid access token
 func TestIsUserAuthenticatedValidAccessToken(t *testing.T) {
 	settings := conf.NewTestSettings().Apply()
-	t.Cleanup(func() { conf.SetTestSettings(nil) })
+	t.Cleanup(func() { conf.NewTestSettings().Apply() })
 
 	s := NewOAuth2Server()
 
@@ -53,9 +53,6 @@ func TestIsUserAuthenticatedValidAccessToken(t *testing.T) {
 
 // TestIsUserAuthenticatedTableDriven tests the IsUserAuthenticated function with a table-driven approach
 func TestIsUserAuthenticatedTableDriven(t *testing.T) {
-	// Set the settings instance
-	conf.Setting()
-
 	tests := []struct {
 		name    string
 		token   string
@@ -107,9 +104,7 @@ func TestIsUserAuthenticatedTableDriven(t *testing.T) {
 }
 
 func TestOAuth2Server(t *testing.T) {
-	// Ensure global settings are initialized for NewOAuth2Server()
-	conf.Setting()
-	t.Cleanup(func() { conf.SetTestSettings(nil) })
+	t.Cleanup(func() { conf.NewTestSettings().Apply() })
 
 	tests := []struct {
 		name string
@@ -197,8 +192,6 @@ func TestNewOAuth2ServerForTesting(t *testing.T) {
 
 // TestIsUserAuthenticatedExpiredToken tests with an expired access token
 func TestIsUserAuthenticatedExpiredToken(t *testing.T) {
-	conf.Setting()
-
 	settings := &conf.Settings{
 		Security: conf.Security{
 			SessionSecret: "test-secret-32-bytes-minimum-len",
@@ -229,8 +222,6 @@ func TestIsUserAuthenticatedExpiredToken(t *testing.T) {
 
 // TestIsUserAuthenticatedNoToken tests with no access token
 func TestIsUserAuthenticatedNoToken(t *testing.T) {
-	conf.Setting()
-
 	settings := &conf.Settings{
 		Security: conf.Security{
 			SessionSecret: "test-secret-32-bytes-minimum-len",
@@ -300,8 +291,6 @@ func TestIsUserAuthenticatedSubnetBypassDisabled(t *testing.T) {
 		t.Skip("Skipping: no non-loopback IPv4 interface found for subnet bypass test")
 	}
 
-	conf.Setting()
-
 	settings := &conf.Settings{
 		Security: conf.Security{
 			SessionSecret: "test-secret-32-bytes-minimum-len",
@@ -335,8 +324,6 @@ func TestIsUserAuthenticatedSubnetBypassEnabled(t *testing.T) {
 		t.Skip("Skipping: no non-loopback IPv4 interface found for subnet bypass test")
 	}
 
-	conf.Setting()
-
 	settings := &conf.Settings{
 		Security: conf.Security{
 			SessionSecret: "test-secret-32-bytes-minimum-len",
@@ -363,8 +350,6 @@ func TestIsUserAuthenticatedSubnetBypassEnabled(t *testing.T) {
 // TestIsUserAuthenticatedTokenAuthWorksWhenSubnetBypassDisabled verifies that
 // disabling subnet bypass does NOT break token-based authentication.
 func TestIsUserAuthenticatedTokenAuthWorksWhenSubnetBypassDisabled(t *testing.T) {
-	conf.Setting()
-
 	settings := &conf.Settings{
 		Security: conf.Security{
 			SessionSecret: "test-secret-32-bytes-minimum-len",
@@ -525,7 +510,7 @@ func TestGenerateAuthCode(t *testing.T) {
 		},
 	}
 	conf.SetTestSettings(settings)
-	t.Cleanup(func() { conf.SetTestSettings(nil) })
+	t.Cleanup(func() { conf.NewTestSettings().Apply() })
 
 	server := &OAuth2Server{
 		Settings:     settings,
@@ -1242,7 +1227,7 @@ func TestCheckSocialAuthDirect(t *testing.T) {
 				},
 			}
 			conf.SetTestSettings(settings)
-			t.Cleanup(func() { conf.SetTestSettings(nil) })
+			t.Cleanup(func() { conf.NewTestSettings().Apply() })
 
 			server := &OAuth2Server{Settings: settings}
 
@@ -1297,7 +1282,7 @@ func TestCheckSocialAuthFallback(t *testing.T) {
 				},
 			}
 			conf.SetTestSettings(settings)
-			t.Cleanup(func() { conf.SetTestSettings(nil) })
+			t.Cleanup(func() { conf.NewTestSettings().Apply() })
 
 			server := &OAuth2Server{Settings: settings}
 
@@ -1324,7 +1309,7 @@ func TestCheckSocialAuthSessionsWithAuthProviderKey(t *testing.T) {
 		},
 	}
 	conf.SetTestSettings(settings)
-	t.Cleanup(func() { conf.SetTestSettings(nil) })
+	t.Cleanup(func() { conf.NewTestSettings().Apply() })
 
 	server := &OAuth2Server{Settings: settings}
 


### PR DESCRIPTION
## Summary

- Normalize zero-valued LiveStream bitrate/segmentLength/sampleRate, weather pollInterval, and security sessionDuration to their compile-time defaults before range-checking, instead of rejecting them as validation errors
- Root cause: viper nested defaults are silently lost when a parent YAML key (e.g. `webserver:`) exists in the config file but child sections (e.g. `livestream:`) are absent
- Add missing `livestream` and `sessionduration` sections to the embedded config.yaml template
- Define named constants (`DefaultLiveStreamBitRate`, `DefaultLiveStreamSegmentLength`, etc.) in `consts.go` and use them consistently across defaults, validators, and test helpers
- Fix tests in diskmanager, imageprovider, and security packages to use `SetTestSettings()` instead of relying on lazy disk-based config loading via `conf.Setting()`
- Add `TestMain` to security package for consistent test settings baseline

## Test Plan

- [x] All 2153 tests pass across conf, diskmanager, imageprovider, and security packages with `-race`
- [x] golangci-lint clean on all affected packages
- [x] Reproduces and fixes the CI failure from [actions/runs/25726184287](https://github.com/tphakala/birdnet-go/actions/runs/25726184287)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added live streaming configuration options: bitrate, sample rate, and HLS segment length.
  * Added configurable session duration for browser session cookies (default: 7 days).

* **Bug Fixes**
  * Default handling improved: livestream, session duration, and weather poll interval now normalize missing/zero values to safe defaults so validations behave correctly.

* **Tests**
  * Updated tests to exercise and assert the new default/normalization behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3034)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->