### PR TITLE
feat(classifier): v3 geomodel auto-selection, pipeline extension, range filter API

### DIFF
--- a/internal/analysis/processor/processor.go
+++ b/internal/analysis/processor/processor.go
@@ -840,9 +840,10 @@ func (p *Processor) parseAndValidateSpecies(settings *conf.Settings, result data
 
 // shouldApplyRangeFilter returns true if the given model should have its
 // detections filtered by the geographic range filter.
-// BirdNET (any version): always filtered.
+// BirdNET (any version) and unknown models: always filtered (DetectionModelInfoForID
+// returns DefaultModelInfo with Name="BirdNET" for unrecognized IDs).
 // Perch: filtered only when the v3.0 geomodel is active (it covers Perch species).
-// Bat/BSG/other: never filtered (independent species sets, no geomodel coverage).
+// Bat/BSG: never filtered (independent species sets, no geomodel coverage).
 func shouldApplyRangeFilter(modelID string, settings *conf.Settings) bool {
 	mInfo := classifier.DetectionModelInfoForID(modelID)
 	if mInfo.Name == detection.DefaultModelName {

--- a/internal/analysis/processor/processor.go
+++ b/internal/analysis/processor/processor.go
@@ -845,14 +845,13 @@ func (p *Processor) parseAndValidateSpecies(settings *conf.Settings, result data
 // Bat/BSG/other: never filtered (independent species sets, no geomodel coverage).
 func shouldApplyRangeFilter(modelID string, settings *conf.Settings) bool {
 	mInfo := classifier.DetectionModelInfoForID(modelID)
-	switch mInfo.Name {
-	case "BirdNET":
+	if mInfo.Name == detection.DefaultModelName {
 		return true
-	case "Perch":
-		return settings.BirdNET.RangeFilter.Model == "v3"
-	default:
-		return false
 	}
+	if mInfo.Name == classifier.DetectionNamePerch {
+		return settings.BirdNET.RangeFilter.Model == "v3"
+	}
+	return false
 }
 
 // shouldFilterDetection checks if a detection should be filtered out

--- a/internal/analysis/processor/processor.go
+++ b/internal/analysis/processor/processor.go
@@ -838,6 +838,23 @@ func (p *Processor) parseAndValidateSpecies(settings *conf.Settings, result data
 	return
 }
 
+// shouldApplyRangeFilter returns true if the given model should have its
+// detections filtered by the geographic range filter.
+// BirdNET (any version): always filtered.
+// Perch: filtered only when the v3.0 geomodel is active (it covers Perch species).
+// Bat/BSG/other: never filtered (independent species sets, no geomodel coverage).
+func shouldApplyRangeFilter(modelID string, settings *conf.Settings) bool {
+	mInfo := classifier.DetectionModelInfoForID(modelID)
+	switch mInfo.Name {
+	case "BirdNET":
+		return true
+	case "Perch":
+		return settings.BirdNET.RangeFilter.Model == "v3"
+	default:
+		return false
+	}
+}
+
 // shouldFilterDetection checks if a detection should be filtered out
 func (p *Processor) shouldFilterDetection(settings *conf.Settings, result datastore.Results, commonName, scientificName, speciesLowercase string, baseThreshold float32, source, modelID string) (shouldFilter bool, confidenceThreshold float32) {
 	// Check human detection privacy filter
@@ -886,8 +903,7 @@ func (p *Processor) shouldFilterDetection(settings *conf.Settings, result datast
 		return true, confidenceThreshold
 	}
 
-	// Range filter applies only to BirdNET; Bat/Perch have independent species sets.
-	if strings.HasPrefix(modelID, detection.DefaultModelName) && !settings.IsSpeciesIncluded(result.Species) {
+	if shouldApplyRangeFilter(modelID, settings) && !settings.IsSpeciesIncluded(result.Species) {
 		if settings.Debug {
 			GetLogger().Debug("species not on included list",
 				logger.String("species", result.Species),

--- a/internal/analysis/processor/processor_filter_test.go
+++ b/internal/analysis/processor/processor_filter_test.go
@@ -76,6 +76,12 @@ func TestShouldApplyRangeFilter(t *testing.T) {
 			rangeFilterModel: "v3",
 			expected:         false,
 		},
+		{
+			name:             "unknown model ID defaults to BirdNET via DetectionModelInfoForID",
+			modelID:          "SomeUnknownModel",
+			rangeFilterModel: "",
+			expected:         true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/analysis/processor/processor_filter_test.go
+++ b/internal/analysis/processor/processor_filter_test.go
@@ -1,0 +1,92 @@
+package processor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tphakala/birdnet-go/internal/conf"
+)
+
+func TestShouldApplyRangeFilter(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		modelID          string
+		rangeFilterModel string
+		expected         bool
+	}{
+		{
+			name:             "BirdNET V2.4 always filtered",
+			modelID:          "BirdNET_V2.4",
+			rangeFilterModel: "",
+			expected:         true,
+		},
+		{
+			name:             "BirdNET V2.4 filtered with legacy range model",
+			modelID:          "BirdNET_V2.4",
+			rangeFilterModel: "legacy",
+			expected:         true,
+		},
+		{
+			name:             "BirdNET V2.4 filtered with v3 range model",
+			modelID:          "BirdNET_V2.4",
+			rangeFilterModel: "v3",
+			expected:         true,
+		},
+		{
+			name:             "BirdNET V3.0 always filtered",
+			modelID:          "BirdNET_V3.0",
+			rangeFilterModel: "",
+			expected:         true,
+		},
+		{
+			name:             "BirdNET V3.0 filtered with v3 range model",
+			modelID:          "BirdNET_V3.0",
+			rangeFilterModel: "v3",
+			expected:         true,
+		},
+		{
+			name:             "Perch V2 filtered when v3 geomodel active",
+			modelID:          "Perch_V2",
+			rangeFilterModel: "v3",
+			expected:         true,
+		},
+		{
+			name:             "Perch V2 not filtered when range model empty",
+			modelID:          "Perch_V2",
+			rangeFilterModel: "",
+			expected:         false,
+		},
+		{
+			name:             "Perch V2 not filtered when legacy range model",
+			modelID:          "Perch_V2",
+			rangeFilterModel: "legacy",
+			expected:         false,
+		},
+		{
+			name:             "Bat never filtered",
+			modelID:          "Bat",
+			rangeFilterModel: "v3",
+			expected:         false,
+		},
+		{
+			name:             "BSG never filtered",
+			modelID:          "BSG",
+			rangeFilterModel: "v3",
+			expected:         false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			settings := &conf.Settings{}
+			settings.BirdNET.RangeFilter.Model = tt.rangeFilterModel
+
+			result := shouldApplyRangeFilter(tt.modelID, settings)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/internal/api/v2/README.md
+++ b/internal/api/v2/README.md
@@ -168,13 +168,15 @@ Lightweight connectivity check. Returns a minimal response with no database quer
 
 ### Range Filter (`range.go`)
 
-| Method | Route                  | Handler                      | Auth | Description                         |
-| ------ | ---------------------- | ---------------------------- | ---- | ----------------------------------- |
-| GET    | `/range/species/count` | `GetRangeFilterSpeciesCount` | ❌   | Species count with range filter     |
-| GET    | `/range/species/list`  | `GetRangeFilterSpeciesList`  | ❌   | Species list with taxonomy groups   |
-| GET    | `/range/species/csv`   | `GetRangeFilterSpeciesCSV`   | ❌   | Export species list as CSV download |
-| POST   | `/range/species/test`  | `TestRangeFilter`            | ❌   | Test range filter configuration     |
-| POST   | `/range/rebuild`       | `RebuildRangeFilter`         | ❌   | Rebuild range filter data           |
+| Method | Route                   | Handler                        | Auth | Description                                                      |
+| ------ | ----------------------- | ------------------------------ | ---- | ---------------------------------------------------------------- |
+| GET    | `/range/status`         | `GetRangeFilterStatus`         | ❌   | Range filter model, mapping stats, auto-selection status         |
+| GET    | `/range/species/scores` | `GetRangeFilterSpeciesScores`  | ❌   | All species with raw geomodel scores (no threshold cutoff)       |
+| GET    | `/range/species/count`  | `GetRangeFilterSpeciesCount`   | ❌   | Species count with range filter                                  |
+| GET    | `/range/species/list`   | `GetRangeFilterSpeciesList`    | ❌   | Species list with taxonomy groups                                |
+| GET    | `/range/species/csv`    | `GetRangeFilterSpeciesCSV`     | ❌   | Export species list as CSV download                              |
+| POST   | `/range/species/test`   | `TestRangeFilter`              | ❌   | Test range filter configuration                                  |
+| POST   | `/range/rebuild`        | `RebuildRangeFilter`           | ❌   | Rebuild range filter data                                        |
 
 ### Search (`search.go`)
 

--- a/internal/api/v2/range.go
+++ b/internal/api/v2/range.go
@@ -127,23 +127,6 @@ type RangeFilterSpeciesList struct {
 	Orders      []string             `json:"orders"`
 }
 
-// RangeFilterStatusResponse represents the status of the active range filter model
-type RangeFilterStatusResponse struct {
-	Model               string    `json:"model"`
-	ModelPath           string    `json:"modelPath"`
-	LabelsPath          string    `json:"labelsPath"`
-	AutoSelected        bool      `json:"autoSelected"`
-	ClassifierModel     string    `json:"classifierModel"`
-	GeomodelSpecies     int       `json:"geomodelSpecies"`
-	ClassifierSpecies   int       `json:"classifierSpecies"`
-	MappedSpecies       int       `json:"mappedSpecies"`
-	UnmappedSpecies     int       `json:"unmappedSpecies"`
-	PassUnmappedSpecies bool      `json:"passUnmappedSpecies"`
-	Threshold           float32   `json:"threshold"`
-	LocationConfigured  bool      `json:"locationConfigured"`
-	LastUpdated         time.Time `json:"lastUpdated"`
-}
-
 // RangeFilterScoresResponse represents all species with their raw geomodel scores
 type RangeFilterScoresResponse struct {
 	Species   []RangeFilterSpecies `json:"species"`
@@ -198,7 +181,7 @@ func (c *Controller) initRangeRoutes() {
 // @Description Returns the active geomodel, mapping statistics, auto-selection status, and threshold
 // @Tags range
 // @Produce json
-// @Success 200 {object} RangeFilterStatusResponse
+// @Success 200 {object} classifier.RangeFilterStatusInfo
 // @Failure 500 {object} ErrorResponse
 // @Router /api/v2/range/status [get]
 func (c *Controller) GetRangeFilterStatus(ctx echo.Context) error {
@@ -207,25 +190,7 @@ func (c *Controller) GetRangeFilterStatus(ctx echo.Context) error {
 		return c.HandleError(ctx, err, "BirdNET service not available", http.StatusInternalServerError)
 	}
 
-	status := birdnetInstance.RangeFilterStatus()
-
-	response := RangeFilterStatusResponse{
-		Model:               status.Model,
-		ModelPath:           status.ModelPath,
-		LabelsPath:          status.LabelsPath,
-		AutoSelected:        status.AutoSelected,
-		ClassifierModel:     status.ClassifierModel,
-		GeomodelSpecies:     status.GeomodelSpecies,
-		ClassifierSpecies:   status.ClassifierSpecies,
-		MappedSpecies:       status.MappedSpecies,
-		UnmappedSpecies:     status.UnmappedSpecies,
-		PassUnmappedSpecies: status.PassUnmappedSpecies,
-		Threshold:           status.Threshold,
-		LocationConfigured:  status.LocationConfigured,
-		LastUpdated:         status.LastUpdated,
-	}
-
-	return ctx.JSON(http.StatusOK, response)
+	return ctx.JSON(http.StatusOK, birdnetInstance.RangeFilterStatus())
 }
 
 // GetRangeFilterSpeciesScores returns all species with their raw geomodel probability scores

--- a/internal/api/v2/range.go
+++ b/internal/api/v2/range.go
@@ -127,6 +127,23 @@ type RangeFilterSpeciesList struct {
 	Orders      []string             `json:"orders"`
 }
 
+// RangeFilterStatusResponse represents the status of the active range filter model
+type RangeFilterStatusResponse struct {
+	Model               string    `json:"model"`
+	ModelPath           string    `json:"modelPath"`
+	LabelsPath          string    `json:"labelsPath"`
+	AutoSelected        bool      `json:"autoSelected"`
+	ClassifierModel     string    `json:"classifierModel"`
+	GeomodelSpecies     int       `json:"geomodelSpecies"`
+	ClassifierSpecies   int       `json:"classifierSpecies"`
+	MappedSpecies       int       `json:"mappedSpecies"`
+	UnmappedSpecies     int       `json:"unmappedSpecies"`
+	PassUnmappedSpecies bool      `json:"passUnmappedSpecies"`
+	Threshold           float32   `json:"threshold"`
+	LocationConfigured  bool      `json:"locationConfigured"`
+	LastUpdated         time.Time `json:"lastUpdated"`
+}
+
 // RangeFilterTestRequest represents the request for testing range filter
 type RangeFilterTestRequest struct {
 	Latitude  float64 `json:"latitude"`
@@ -155,12 +172,50 @@ type RangeFilterTestResponse struct {
 
 // initRangeRoutes sets up the range filter related routes
 func (c *Controller) initRangeRoutes() {
-	// Range filter routes
+	// Range filter status
+	c.Group.GET("/range/status", c.GetRangeFilterStatus)
+
+	// Range filter species routes
 	c.Group.GET("/range/species/count", c.GetRangeFilterSpeciesCount)
 	c.Group.GET("/range/species/list", c.GetRangeFilterSpeciesList)
 	c.Group.GET("/range/species/csv", c.GetRangeFilterSpeciesCSV)
 	c.Group.POST("/range/species/test", c.TestRangeFilter)
 	c.Group.POST("/range/rebuild", c.RebuildRangeFilter)
+}
+
+// GetRangeFilterStatus returns introspection data about the active range filter
+// @Summary Get range filter status
+// @Description Returns the active geomodel, mapping statistics, auto-selection status, and threshold
+// @Tags range
+// @Produce json
+// @Success 200 {object} RangeFilterStatusResponse
+// @Failure 500 {object} ErrorResponse
+// @Router /api/v2/range/status [get]
+func (c *Controller) GetRangeFilterStatus(ctx echo.Context) error {
+	birdnetInstance, err := c.getBirdNETInstance()
+	if err != nil {
+		return c.HandleError(ctx, err, "BirdNET service not available", http.StatusInternalServerError)
+	}
+
+	status := birdnetInstance.RangeFilterStatus()
+
+	response := RangeFilterStatusResponse{
+		Model:               status.Model,
+		ModelPath:           status.ModelPath,
+		LabelsPath:          status.LabelsPath,
+		AutoSelected:        status.AutoSelected,
+		ClassifierModel:     status.ClassifierModel,
+		GeomodelSpecies:     status.GeomodelSpecies,
+		ClassifierSpecies:   status.ClassifierSpecies,
+		MappedSpecies:       status.MappedSpecies,
+		UnmappedSpecies:     status.UnmappedSpecies,
+		PassUnmappedSpecies: status.PassUnmappedSpecies,
+		Threshold:           status.Threshold,
+		LocationConfigured:  status.LocationConfigured,
+		LastUpdated:         status.LastUpdated,
+	}
+
+	return ctx.JSON(http.StatusOK, response)
 }
 
 // GetRangeFilterSpeciesCount returns the count of species in the current range filter

--- a/internal/api/v2/range.go
+++ b/internal/api/v2/range.go
@@ -144,6 +144,15 @@ type RangeFilterStatusResponse struct {
 	LastUpdated         time.Time `json:"lastUpdated"`
 }
 
+// RangeFilterScoresResponse represents all species with their raw geomodel scores
+type RangeFilterScoresResponse struct {
+	Species   []RangeFilterSpecies `json:"species"`
+	Count     int                  `json:"count"`
+	Location  Location             `json:"location"`
+	Week      int                  `json:"week"`
+	Threshold float32              `json:"threshold"`
+}
+
 // RangeFilterTestRequest represents the request for testing range filter
 type RangeFilterTestRequest struct {
 	Latitude  float64 `json:"latitude"`
@@ -172,8 +181,9 @@ type RangeFilterTestResponse struct {
 
 // initRangeRoutes sets up the range filter related routes
 func (c *Controller) initRangeRoutes() {
-	// Range filter status
+	// Range filter status and scores
 	c.Group.GET("/range/status", c.GetRangeFilterStatus)
+	c.Group.GET("/range/species/scores", c.GetRangeFilterSpeciesScores)
 
 	// Range filter species routes
 	c.Group.GET("/range/species/count", c.GetRangeFilterSpeciesCount)
@@ -215,6 +225,109 @@ func (c *Controller) GetRangeFilterStatus(ctx echo.Context) error {
 		LastUpdated:         status.LastUpdated,
 	}
 
+	return ctx.JSON(http.StatusOK, response)
+}
+
+// GetRangeFilterSpeciesScores returns all species with their raw geomodel probability scores
+// @Summary Get range filter species scores
+// @Description Returns all species with raw geomodel scores, using current or custom location and week
+// @Tags range
+// @Produce json
+// @Param lat query number false "Custom latitude (uses current settings if not provided)"
+// @Param lon query number false "Custom longitude (uses current settings if not provided)"
+// @Param week query integer false "Custom week 1-48 (uses current date if not provided)"
+// @Success 200 {object} RangeFilterScoresResponse
+// @Failure 400 {object} ErrorResponse
+// @Failure 500 {object} ErrorResponse
+// @Router /api/v2/range/species/scores [get]
+func (c *Controller) GetRangeFilterSpeciesScores(ctx echo.Context) error {
+	birdnetInstance, err := c.getBirdNETInstance()
+	if err != nil {
+		return c.HandleError(ctx, err, "BirdNET service not available", http.StatusInternalServerError)
+	}
+
+	// Read current settings for defaults
+	c.settingsMutex.RLock()
+	lat := c.Settings.BirdNET.Latitude
+	lon := c.Settings.BirdNET.Longitude
+	threshold := c.Settings.BirdNET.RangeFilter.Threshold
+	c.settingsMutex.RUnlock()
+
+	// Override with query params if provided
+	if latStr := ctx.QueryParam("lat"); latStr != "" {
+		parsed, err := parseFloat64(latStr)
+		if err != nil {
+			return c.HandleError(ctx, err, "Invalid latitude format", http.StatusBadRequest)
+		}
+		if parsed < -90 || parsed > 90 {
+			return c.HandleError(ctx, nil, "Latitude must be between -90 and 90", http.StatusBadRequest)
+		}
+		lat = parsed
+	}
+
+	if lonStr := ctx.QueryParam("lon"); lonStr != "" {
+		parsed, err := parseFloat64(lonStr)
+		if err != nil {
+			return c.HandleError(ctx, err, "Invalid longitude format", http.StatusBadRequest)
+		}
+		if parsed < -180 || parsed > 180 {
+			return c.HandleError(ctx, nil, "Longitude must be between -180 and 180", http.StatusBadRequest)
+		}
+		lon = parsed
+	}
+
+	// Calculate week from current date or use provided value
+	now := time.Now()
+	week := calculateWeek(now)
+
+	if weekStr := ctx.QueryParam("week"); weekStr != "" {
+		parsed, err := strconv.Atoi(weekStr)
+		if err != nil {
+			return c.HandleError(ctx, err, "Invalid week format", http.StatusBadRequest)
+		}
+		if parsed < 1 || parsed > 48 {
+			return c.HandleError(ctx, nil, "Week must be between 1 and 48", http.StatusBadRequest)
+		}
+		week = float32(parsed)
+	}
+
+	// Build test settings with zero threshold to get ALL species with scores
+	testSettings := c.buildTestSettings(lat, lon, 0)
+
+	// Get all species with their raw scores
+	speciesScores, err := birdnetInstance.GetProbableSpeciesWithSettings(now, week, testSettings)
+	if err != nil {
+		return c.HandleError(ctx, err, "Failed to get species scores", http.StatusInternalServerError)
+	}
+
+	// Convert to response format
+	speciesList := make([]RangeFilterSpecies, 0, len(speciesScores))
+	for _, speciesScore := range speciesScores {
+		sp := detection.ParseSpeciesString(speciesScore.Label)
+
+		score := speciesScore.Score
+		species := RangeFilterSpecies{
+			Label:          speciesScore.Label,
+			ScientificName: sp.ScientificName,
+			CommonName:     sp.CommonName,
+			Score:          &score,
+		}
+
+		speciesList = append(speciesList, species)
+	}
+
+	response := RangeFilterScoresResponse{
+		Species:   speciesList,
+		Count:     len(speciesList),
+		Week:      int(week),
+		Threshold: threshold,
+		Location: Location{
+			Latitude:  lat,
+			Longitude: lon,
+		},
+	}
+
+	c.logAPIRequest(ctx, logger.LogLevelInfo, "Range filter species scores retrieved", logger.Int("species_count", len(speciesList)))
 	return ctx.JSON(http.StatusOK, response)
 }
 

--- a/internal/api/v2/range.go
+++ b/internal/api/v2/range.go
@@ -211,11 +211,12 @@ func (c *Controller) GetRangeFilterSpeciesScores(ctx echo.Context) error {
 		return c.HandleError(ctx, err, "BirdNET service not available", http.StatusInternalServerError)
 	}
 
-	// Read current settings for defaults
+	// Read defaults from latest published settings snapshot so UI changes
+	// to coordinates take effect without restart.
 	c.settingsMutex.RLock()
-	lat := c.Settings.BirdNET.Latitude
-	lon := c.Settings.BirdNET.Longitude
-	threshold := c.Settings.BirdNET.RangeFilter.Threshold
+	settings := conf.CurrentOrFallback(c.Settings)
+	lat := settings.BirdNET.Latitude
+	lon := settings.BirdNET.Longitude
 	c.settingsMutex.RUnlock()
 
 	// Override with query params if provided
@@ -285,14 +286,14 @@ func (c *Controller) GetRangeFilterSpeciesScores(ctx echo.Context) error {
 		Species:   speciesList,
 		Count:     len(speciesList),
 		Week:      int(week),
-		Threshold: threshold,
+		Threshold: 0,
 		Location: Location{
 			Latitude:  lat,
 			Longitude: lon,
 		},
 	}
 
-	c.logAPIRequest(ctx, logger.LogLevelInfo, "Range filter species scores retrieved", logger.Int("species_count", len(speciesList)))
+	c.logAPIRequest(ctx, logger.LogLevelDebug, "Range filter species scores retrieved", logger.Int("species_count", len(speciesList)))
 	return ctx.JSON(http.StatusOK, response)
 }
 

--- a/internal/classifier/birdnet.go
+++ b/internal/classifier/birdnet.go
@@ -50,6 +50,7 @@ type BirdNET struct {
 	ScientificIndex  ScientificNameIndex // Index for fast scientific name lookups
 	TaxonomyPath     string              // Path to custom taxonomy file, if used
 	modelVersion     string              // Human-readable model version string (per-instance to avoid shared global state)
+	modelsDir        string              // base directory for gallery-installed models (set by Orchestrator)
 	mu               sync.Mutex
 	resultsBuffer    []datastore.Results // Pre-allocated buffer for results to reduce allocations
 	confidenceBuffer []float32           // Pre-allocated buffer for confidence values to reduce allocations
@@ -347,6 +348,16 @@ func (bn *BirdNET) getMetaModelData() ([]byte, error) {
 
 // initializeMetaModel loads and initializes the meta model used for range filtering.
 func (bn *BirdNET) initializeMetaModel() error {
+	// Auto-select v3 geomodel for compatible classifiers when files exist on disk.
+	if bn.Settings.BirdNET.RangeFilter.Model != "v3" && bn.modelsDir != "" {
+		if shouldAutoSelectV3Geomodel(bn.ModelInfo.ID, bn.modelsDir) {
+			applyAutoSelectedGeomodelPaths(bn.Settings, bn.modelsDir)
+			GetLogger().Info("Auto-selected v3.0 geomodel for compatible classifier",
+				logger.String("classifier", bn.ModelInfo.ID),
+				logger.String("models_dir", bn.modelsDir))
+		}
+	}
+
 	// V3 geomodel is always ONNX; route to ONNX backend even if ModelPath is empty
 	// (initializeV3GeoModel will return a clear error about missing paths).
 	if bn.Settings.BirdNET.RangeFilter.Model == "v3" {
@@ -634,6 +645,13 @@ const DefaultRangeFilterV1ModelName = "BirdNET_GLOBAL_6K_V2.4_MData_Model_FP16.t
 // DefaultRangeFilterV2ModelName is the expected filesystem basename for the default (v2) range filter model file.
 // This filename is used when RangeFilter.Model is set to "latest" or unspecified in noembed builds.
 const DefaultRangeFilterV2ModelName = "BirdNET_GLOBAL_6K_V2.4_MData_Model_V2_FP16.tflite"
+
+// Geomodel v3 local file names used for auto-selection when the geomodel
+// has been downloaded as a shared companion file by the model gallery.
+const (
+	geomodelONNXLocalName   = "geomodel_v3.0.2_fp16.onnx"
+	geomodelLabelsLocalName = "geomodel_v3.0.2_labels.txt"
+)
 
 // DefaultModelDirectory is the default directory name where model files are expected to be found.
 // This is a relative path that will be resolved against various base paths during model discovery.
@@ -1158,4 +1176,69 @@ func (bn *BirdNET) EnrichResultWithTaxonomy(speciesLabel string) (scientific, co
 	}
 
 	return scientific, common, code
+}
+
+// SetModelsDir sets the base directory for gallery-installed models.
+// Called by the Orchestrator after creation so auto-selection can
+// resolve geomodel paths from the installed models directory.
+func (bn *BirdNET) SetModelsDir(dir string) {
+	bn.modelsDir = dir
+}
+
+// shouldAutoSelectV3Geomodel reports whether the v3 geomodel should be
+// auto-selected for the given classifier. Returns true when the classifier
+// is PerchV2 or BirdNET V3.0 and both geomodel files exist under
+// {modelsDir}/shared/.
+func shouldAutoSelectV3Geomodel(modelID, modelsDir string) bool {
+	if modelsDir == "" {
+		return false
+	}
+	switch modelID {
+	case RegistryIDPerchV2, RegistryIDBirdNETV3:
+		// eligible classifier; check files below
+	default:
+		return false
+	}
+	sharedDir := filepath.Join(modelsDir, "shared")
+	onnxPath := filepath.Join(sharedDir, geomodelONNXLocalName)
+	labelsPath := filepath.Join(sharedDir, geomodelLabelsLocalName)
+	if _, err := os.Stat(onnxPath); err != nil {
+		return false
+	}
+	if _, err := os.Stat(labelsPath); err != nil {
+		return false
+	}
+	return true
+}
+
+// applyAutoSelectedGeomodelPaths configures the range filter settings to
+// use the v3 geomodel from the shared directory. It does not override
+// an existing v3 configuration where both files already point to valid
+// paths on disk.
+func applyAutoSelectedGeomodelPaths(settings *conf.Settings, modelsDir string) {
+	rf := &settings.BirdNET.RangeFilter
+
+	// Do not override if already configured with v3 and paths are valid.
+	if rf.Model == "v3" {
+		onnxOK := false
+		labelsOK := false
+		if rf.ModelPath != "" {
+			if _, err := os.Stat(rf.ModelPath); err == nil {
+				onnxOK = true
+			}
+		}
+		if rf.LabelsPath != "" {
+			if _, err := os.Stat(rf.LabelsPath); err == nil {
+				labelsOK = true
+			}
+		}
+		if onnxOK && labelsOK {
+			return
+		}
+	}
+
+	sharedDir := filepath.Join(modelsDir, "shared")
+	rf.Model = "v3"
+	rf.ModelPath = filepath.Join(sharedDir, geomodelONNXLocalName)
+	rf.LabelsPath = filepath.Join(sharedDir, geomodelLabelsLocalName)
 }

--- a/internal/classifier/birdnet.go
+++ b/internal/classifier/birdnet.go
@@ -1229,14 +1229,8 @@ func (bn *BirdNET) RangeFilterStatus() RangeFilterStatusInfo {
 	if mrf, ok := bn.rangeFilter.(*mappedRangeFilter); ok {
 		info.GeomodelSpecies = mrf.inner.NumSpecies()
 		info.ClassifierSpecies = mrf.numClassifier
-		mapped := 0
-		for _, idx := range mrf.classifierToGeo {
-			if idx >= 0 {
-				mapped++
-			}
-		}
-		info.MappedSpecies = mapped
-		info.UnmappedSpecies = mrf.numClassifier - mapped
+		info.MappedSpecies = mrf.mappedCount
+		info.UnmappedSpecies = mrf.numClassifier - mrf.mappedCount
 	}
 	bn.mu.Unlock()
 

--- a/internal/classifier/birdnet.go
+++ b/internal/classifier/birdnet.go
@@ -349,13 +349,14 @@ func (bn *BirdNET) getMetaModelData() ([]byte, error) {
 // initializeMetaModel loads and initializes the meta model used for range filtering.
 func (bn *BirdNET) initializeMetaModel() error {
 	// Auto-select v3 geomodel for compatible classifiers when files exist on disk.
-	if bn.Settings.BirdNET.RangeFilter.Model != "v3" && bn.modelsDir != "" {
-		if shouldAutoSelectV3Geomodel(bn.ModelInfo.ID, bn.modelsDir) {
-			applyAutoSelectedGeomodelPaths(bn.Settings, bn.modelsDir)
-			GetLogger().Info("Auto-selected v3.0 geomodel for compatible classifier",
-				logger.String("classifier", bn.ModelInfo.ID),
-				logger.String("models_dir", bn.modelsDir))
-		}
+	// Also resolves empty paths when the user explicitly sets Model="v3" but
+	// leaves ModelPath/LabelsPath empty (applyAutoSelectedGeomodelPaths skips
+	// when existing paths already point to valid files).
+	if bn.modelsDir != "" && shouldAutoSelectV3Geomodel(bn.ModelInfo.ID, bn.modelsDir) {
+		applyAutoSelectedGeomodelPaths(bn.Settings, bn.modelsDir)
+		GetLogger().Info("Auto-selected v3.0 geomodel for compatible classifier",
+			logger.String("classifier", bn.ModelInfo.ID),
+			logger.String("models_dir", bn.modelsDir))
 	}
 
 	// V3 geomodel is always ONNX; route to ONNX backend even if ModelPath is empty

--- a/internal/classifier/birdnet.go
+++ b/internal/classifier/birdnet.go
@@ -1178,6 +1178,71 @@ func (bn *BirdNET) EnrichResultWithTaxonomy(speciesLabel string) (scientific, co
 	return scientific, common, code
 }
 
+// RangeFilterStatusInfo holds introspection data about the active range filter
+// configuration. Used by the API to expose geomodel state without coupling
+// callers to internal types.
+type RangeFilterStatusInfo struct {
+	Model               string    `json:"model"`
+	ModelPath           string    `json:"modelPath"`
+	LabelsPath          string    `json:"labelsPath"`
+	AutoSelected        bool      `json:"autoSelected"`
+	ClassifierModel     string    `json:"classifierModel"`
+	GeomodelSpecies     int       `json:"geomodelSpecies"`
+	ClassifierSpecies   int       `json:"classifierSpecies"`
+	MappedSpecies       int       `json:"mappedSpecies"`
+	UnmappedSpecies     int       `json:"unmappedSpecies"`
+	PassUnmappedSpecies bool      `json:"passUnmappedSpecies"`
+	Threshold           float32   `json:"threshold"`
+	LocationConfigured  bool      `json:"locationConfigured"`
+	LastUpdated         time.Time `json:"lastUpdated"`
+}
+
+// RangeFilterStatus returns introspection data about the active range filter.
+// Safe for concurrent use; acquires bn.mu to read the rangeFilter field.
+func (bn *BirdNET) RangeFilterStatus() RangeFilterStatusInfo {
+	settings := bn.currentSettings()
+	rf := settings.BirdNET.RangeFilter
+
+	info := RangeFilterStatusInfo{
+		Model:               rf.Model,
+		ModelPath:           rf.ModelPath,
+		LabelsPath:          rf.LabelsPath,
+		ClassifierModel:     bn.ModelInfo.ID,
+		PassUnmappedSpecies: rf.PassUnmappedSpecies,
+		Threshold:           rf.Threshold,
+		LocationConfigured:  settings.BirdNET.LocationConfigured,
+		LastUpdated:         rf.LastUpdated,
+	}
+
+	// Determine if the geomodel was auto-selected: model must be "v3" and
+	// paths must match the shared directory pattern produced by
+	// applyAutoSelectedGeomodelPaths.
+	if rf.Model == "v3" && bn.modelsDir != "" {
+		sharedDir := filepath.Join(bn.modelsDir, "shared")
+		expectedONNX := filepath.Join(sharedDir, geomodelONNXLocalName)
+		expectedLabels := filepath.Join(sharedDir, geomodelLabelsLocalName)
+		info.AutoSelected = rf.ModelPath == expectedONNX && rf.LabelsPath == expectedLabels
+	}
+
+	// Extract mapping stats from mappedRangeFilter if present.
+	bn.mu.Lock()
+	if mrf, ok := bn.rangeFilter.(*mappedRangeFilter); ok {
+		info.GeomodelSpecies = mrf.inner.NumSpecies()
+		info.ClassifierSpecies = mrf.numClassifier
+		mapped := 0
+		for _, idx := range mrf.classifierToGeo {
+			if idx >= 0 {
+				mapped++
+			}
+		}
+		info.MappedSpecies = mapped
+		info.UnmappedSpecies = mrf.numClassifier - mapped
+	}
+	bn.mu.Unlock()
+
+	return info
+}
+
 // SetModelsDir sets the base directory for gallery-installed models.
 // Called by the Orchestrator after creation so auto-selection can
 // resolve geomodel paths from the installed models directory.

--- a/internal/classifier/birdnet_test.go
+++ b/internal/classifier/birdnet_test.go
@@ -1,0 +1,160 @@
+package classifier
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/conf"
+)
+
+func TestShouldAutoSelectV3Geomodel(t *testing.T) {
+	t.Parallel()
+
+	// Create a temp directory with the expected shared geomodel files.
+	modelsDir := t.TempDir()
+	sharedDir := filepath.Join(modelsDir, "shared")
+	require.NoError(t, os.MkdirAll(sharedDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(sharedDir, geomodelONNXLocalName), []byte("fake-onnx"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(sharedDir, geomodelLabelsLocalName), []byte("fake-labels"), 0o644))
+
+	// A separate temp dir that has no geomodel files.
+	emptyModelsDir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(emptyModelsDir, "shared"), 0o755))
+
+	tests := []struct {
+		name      string
+		modelID   string
+		modelsDir string
+		want      bool
+	}{
+		{
+			name:      "PerchV2 with files present",
+			modelID:   RegistryIDPerchV2,
+			modelsDir: modelsDir,
+			want:      true,
+		},
+		{
+			name:      "BirdNET V3.0 with files present",
+			modelID:   RegistryIDBirdNETV3,
+			modelsDir: modelsDir,
+			want:      true,
+		},
+		{
+			name:      "BirdNET V2.4 is not eligible",
+			modelID:   "BirdNET_V2.4",
+			modelsDir: modelsDir,
+			want:      false,
+		},
+		{
+			name:      "Bat is not eligible",
+			modelID:   RegistryIDBat,
+			modelsDir: modelsDir,
+			want:      false,
+		},
+		{
+			name:      "BSG is not eligible",
+			modelID:   RegistryIDBSG,
+			modelsDir: modelsDir,
+			want:      false,
+		},
+		{
+			name:      "empty modelsDir returns false",
+			modelID:   RegistryIDPerchV2,
+			modelsDir: "",
+			want:      false,
+		},
+		{
+			name:      "missing geomodel files returns false",
+			modelID:   RegistryIDPerchV2,
+			modelsDir: emptyModelsDir,
+			want:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := shouldAutoSelectV3Geomodel(tt.modelID, tt.modelsDir)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestApplyAutoSelectedGeomodelPaths(t *testing.T) {
+	t.Parallel()
+
+	t.Run("sets paths when not configured", func(t *testing.T) {
+		t.Parallel()
+
+		modelsDir := t.TempDir()
+		sharedDir := filepath.Join(modelsDir, "shared")
+		require.NoError(t, os.MkdirAll(sharedDir, 0o755))
+
+		settings := &conf.Settings{}
+		// RangeFilter.Model is empty (default), so auto-selection should apply.
+		applyAutoSelectedGeomodelPaths(settings, modelsDir)
+
+		assert.Equal(t, "v3", settings.BirdNET.RangeFilter.Model)
+		assert.Equal(t, filepath.Join(sharedDir, geomodelONNXLocalName), settings.BirdNET.RangeFilter.ModelPath)
+		assert.Equal(t, filepath.Join(sharedDir, geomodelLabelsLocalName), settings.BirdNET.RangeFilter.LabelsPath)
+	})
+
+	t.Run("does not override existing valid v3 config", func(t *testing.T) {
+		t.Parallel()
+
+		modelsDir := t.TempDir()
+		sharedDir := filepath.Join(modelsDir, "shared")
+		require.NoError(t, os.MkdirAll(sharedDir, 0o755))
+
+		// Create real files at custom paths to simulate an existing valid config.
+		customONNX := filepath.Join(t.TempDir(), "custom_geomodel.onnx")
+		customLabels := filepath.Join(t.TempDir(), "custom_labels.txt")
+		require.NoError(t, os.WriteFile(customONNX, []byte("custom"), 0o644))
+		require.NoError(t, os.WriteFile(customLabels, []byte("custom"), 0o644))
+
+		settings := &conf.Settings{}
+		settings.BirdNET.RangeFilter.Model = "v3"
+		settings.BirdNET.RangeFilter.ModelPath = customONNX
+		settings.BirdNET.RangeFilter.LabelsPath = customLabels
+
+		applyAutoSelectedGeomodelPaths(settings, modelsDir)
+
+		// Paths should remain unchanged because both files exist.
+		assert.Equal(t, "v3", settings.BirdNET.RangeFilter.Model)
+		assert.Equal(t, customONNX, settings.BirdNET.RangeFilter.ModelPath)
+		assert.Equal(t, customLabels, settings.BirdNET.RangeFilter.LabelsPath)
+	})
+
+	t.Run("overrides v3 config when files are missing", func(t *testing.T) {
+		t.Parallel()
+
+		modelsDir := t.TempDir()
+		sharedDir := filepath.Join(modelsDir, "shared")
+		require.NoError(t, os.MkdirAll(sharedDir, 0o755))
+
+		settings := &conf.Settings{}
+		settings.BirdNET.RangeFilter.Model = "v3"
+		settings.BirdNET.RangeFilter.ModelPath = "/nonexistent/geomodel.onnx"
+		settings.BirdNET.RangeFilter.LabelsPath = "/nonexistent/labels.txt"
+
+		applyAutoSelectedGeomodelPaths(settings, modelsDir)
+
+		// Paths should be overridden because the configured files don't exist.
+		assert.Equal(t, "v3", settings.BirdNET.RangeFilter.Model)
+		assert.Equal(t, filepath.Join(sharedDir, geomodelONNXLocalName), settings.BirdNET.RangeFilter.ModelPath)
+		assert.Equal(t, filepath.Join(sharedDir, geomodelLabelsLocalName), settings.BirdNET.RangeFilter.LabelsPath)
+	})
+}
+
+func TestBirdNET_SetModelsDir(t *testing.T) {
+	t.Parallel()
+
+	bn := &BirdNET{}
+	assert.Empty(t, bn.modelsDir)
+
+	bn.SetModelsDir("/some/path")
+	assert.Equal(t, "/some/path", bn.modelsDir)
+}

--- a/internal/classifier/birdnet_test.go
+++ b/internal/classifier/birdnet_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -157,4 +158,93 @@ func TestBirdNET_SetModelsDir(t *testing.T) {
 
 	bn.SetModelsDir("/some/path")
 	assert.Equal(t, "/some/path", bn.modelsDir)
+}
+
+func TestRangeFilterStatus_NoFilter(t *testing.T) {
+	t.Parallel()
+
+	settings := &conf.Settings{}
+	settings.BirdNET.RangeFilter.Model = ""
+	settings.BirdNET.RangeFilter.Threshold = 0.05
+
+	bn := &BirdNET{
+		Settings:     settings,
+		speciesCache: make(map[string]*speciesCacheEntry),
+		ModelInfo:    ModelInfo{ID: "BirdNET_V2.4"},
+	}
+
+	info := bn.RangeFilterStatus()
+
+	assert.Empty(t, info.Model, "model should be empty when no range filter is configured")
+	assert.False(t, info.AutoSelected, "AutoSelected should be false without v3 geomodel")
+	assert.Equal(t, "BirdNET_V2.4", info.ClassifierModel)
+	assert.InDelta(t, 0.05, info.Threshold, 0.001)
+	assert.Zero(t, info.GeomodelSpecies, "GeomodelSpecies should be 0 without a mapped filter")
+	assert.Zero(t, info.MappedSpecies, "MappedSpecies should be 0 without a mapped filter")
+	assert.Zero(t, info.UnmappedSpecies, "UnmappedSpecies should be 0 without a mapped filter")
+}
+
+func TestRangeFilterStatus_WithMappedFilter(t *testing.T) {
+	t.Parallel()
+
+	modelsDir := t.TempDir()
+	sharedDir := filepath.Join(modelsDir, "shared")
+	require.NoError(t, os.MkdirAll(sharedDir, 0o755))
+
+	expectedONNX := filepath.Join(sharedDir, geomodelONNXLocalName)
+	expectedLabels := filepath.Join(sharedDir, geomodelLabelsLocalName)
+
+	lastUpdated := time.Date(2026, 5, 12, 10, 0, 0, 0, time.UTC)
+
+	settings := &conf.Settings{}
+	settings.BirdNET.RangeFilter.Model = "v3"
+	settings.BirdNET.RangeFilter.ModelPath = expectedONNX
+	settings.BirdNET.RangeFilter.LabelsPath = expectedLabels
+	settings.BirdNET.RangeFilter.Threshold = 0.03
+	settings.BirdNET.RangeFilter.PassUnmappedSpecies = true
+	settings.BirdNET.RangeFilter.LastUpdated = lastUpdated
+	settings.BirdNET.LocationConfigured = true
+
+	// Build a mappedRangeFilter with known mapping stats.
+	// 3 geomodel species, 4 classifier species, 3 mapped, 1 unmapped.
+	classifierLabels := []string{
+		"Turdus merula_Common Blackbird",
+		"Parus major_Great Tit",
+		"Erithacus rubecula_European Robin",
+		"Ficedula hypoleuca_Pied Flycatcher",
+	}
+	geomodelLabels := []string{
+		"Parus major_Great Tit",
+		"Turdus merula_Amsel",
+		"Erithacus rubecula_Robin",
+	}
+
+	inner := &fakeRangeFilter{
+		scores: make([]float32, len(geomodelLabels)),
+	}
+	mapped := newMappedRangeFilter(inner, classifierLabels, geomodelLabels, 1.0)
+
+	bn := &BirdNET{
+		Settings:     settings,
+		speciesCache: make(map[string]*speciesCacheEntry),
+		ModelInfo:    ModelInfo{ID: RegistryIDBirdNETV3},
+		modelsDir:    modelsDir,
+		rangeFilter:  mapped,
+	}
+
+	info := bn.RangeFilterStatus()
+
+	assert.Equal(t, "v3", info.Model)
+	assert.Equal(t, expectedONNX, info.ModelPath)
+	assert.Equal(t, expectedLabels, info.LabelsPath)
+	assert.True(t, info.AutoSelected, "paths match auto-selected pattern")
+	assert.Equal(t, RegistryIDBirdNETV3, info.ClassifierModel)
+	assert.Equal(t, len(geomodelLabels), info.GeomodelSpecies)
+	assert.Equal(t, len(classifierLabels), info.ClassifierSpecies)
+	assert.Equal(t, 3, info.MappedSpecies)
+	assert.Equal(t, 1, info.UnmappedSpecies)
+	assert.True(t, info.PassUnmappedSpecies)
+	assert.InDelta(t, 0.03, info.Threshold, 0.001)
+	assert.True(t, info.LocationConfigured)
+	assert.Equal(t, lastUpdated, info.LastUpdated)
 }

--- a/internal/classifier/mapped_range_filter.go
+++ b/internal/classifier/mapped_range_filter.go
@@ -15,6 +15,7 @@ type mappedRangeFilter struct {
 	inner           inference.RangeFilter
 	classifierToGeo []int   // classifierIndex -> geomodelIndex; -1 means no match
 	numClassifier   int     // len(classifierLabels)
+	mappedCount     int     // number of classifier species with a geomodel match
 	unmappedScore   float32 // score for classifier species absent from geomodel
 }
 
@@ -55,10 +56,18 @@ func extractScientificName(label string) string {
 // unmappedScore is the score assigned to classifier species that have no
 // match in the geomodel (0.0 = filter out, 1.0 = pass through).
 func newMappedRangeFilter(inner inference.RangeFilter, classifierLabels, geomodelLabels []string, unmappedScore float32) *mappedRangeFilter {
+	mapping := buildSpeciesMapping(classifierLabels, geomodelLabels)
+	mapped := 0
+	for _, idx := range mapping {
+		if idx >= 0 {
+			mapped++
+		}
+	}
 	return &mappedRangeFilter{
 		inner:           inner,
-		classifierToGeo: buildSpeciesMapping(classifierLabels, geomodelLabels),
+		classifierToGeo: mapping,
 		numClassifier:   len(classifierLabels),
+		mappedCount:     mapped,
 		unmappedScore:   unmappedScore,
 	}
 }

--- a/internal/classifier/model_onnx.go
+++ b/internal/classifier/model_onnx.go
@@ -174,16 +174,8 @@ func (bn *BirdNET) initializeV3GeoModel() error {
 	}
 	mapped := newMappedRangeFilter(innerFilter, classifierLabels, geoLabels, unmappedScore)
 
-	// Log mapping statistics
-	matchCount := 0
-	for _, idx := range mapped.classifierToGeo {
-		if idx >= 0 {
-			matchCount++
-		}
-	}
-
 	log := GetLogger()
-	if matchCount == 0 && len(classifierLabels) > 0 {
+	if mapped.mappedCount == 0 && len(classifierLabels) > 0 {
 		log.Warn("V3 geomodel: no species matched classifier labels, range filter will filter out all detections (check labels file)",
 			logger.Int("classifier_species", len(classifierLabels)),
 			logger.String("labels_path", labelsPath))
@@ -191,8 +183,8 @@ func (bn *BirdNET) initializeV3GeoModel() error {
 	log.Info("V3 geomodel initialized with species mapping",
 		logger.Int("geomodel_species", len(geoLabels)),
 		logger.Int("classifier_species", len(classifierLabels)),
-		logger.Int("mapped_species", matchCount),
-		logger.Int("unmapped_species", len(classifierLabels)-matchCount))
+		logger.Int("mapped_species", mapped.mappedCount),
+		logger.Int("unmapped_species", len(classifierLabels)-mapped.mappedCount))
 
 	bn.rangeFilter = mapped
 	return nil

--- a/internal/classifier/model_registry.go
+++ b/internal/classifier/model_registry.go
@@ -36,6 +36,10 @@ const (
 	RegistryIDPerchV2   = "Perch_V2"
 )
 
+// DetectionNamePerch is the detection model name for Perch classifiers,
+// matching the DetectionName field in the ModelRegistry.
+const DetectionNamePerch = "Perch"
+
 // ModelInfo represents metadata about a classifier model.
 type ModelInfo struct {
 	ID               string    // Unique registry identifier (e.g., "BirdNET_V2.4")

--- a/internal/classifier/model_registry.go
+++ b/internal/classifier/model_registry.go
@@ -100,7 +100,7 @@ var ModelRegistry = map[string]ModelInfo{
 		ID:               RegistryIDPerchV2,
 		Name:             ModelNamePerchV2,
 		Backend:          BackendONNX,
-		DetectionName:    "Perch",
+		DetectionName:    DetectionNamePerch,
 		DetectionVersion: "V2",
 		Description:      "Perch v2 model with ~14,795 species (scientific names only)",
 		Spec:             ModelSpec{SampleRate: 32000, ClipLength: 5 * time.Second},

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -98,8 +98,13 @@ func NewOrchestrator(settings *conf.Settings) (*Orchestrator, error) {
 // SetModelsDir sets the base directory for gallery-installed models.
 // Called by ModelManager after creation so model loaders can resolve
 // paths from the installed models directory when config paths are empty.
+// Also propagates the directory to the primary BirdNET instance for
+// geomodel auto-selection.
 func (o *Orchestrator) SetModelsDir(dir string) {
 	o.modelsDir = dir
+	if o.primary != nil {
+		o.primary.SetModelsDir(dir)
+	}
 }
 
 // resolveInstalledPaths looks up catalog entries for the given registry ID

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -279,6 +279,12 @@ func (o *Orchestrator) EnrichResultWithTaxonomy(speciesLabel string) (scientific
 	return scientific, common, code
 }
 
+// RangeFilterStatus returns introspection data about the primary model's
+// active range filter configuration.
+func (o *Orchestrator) RangeFilterStatus() RangeFilterStatusInfo {
+	return o.primary.RangeFilterStatus()
+}
+
 // RunFilterProcess executes the filter process on demand and prints results.
 func (o *Orchestrator) RunFilterProcess(dateStr string, week float32) {
 	o.primary.RunFilterProcess(dateStr, week)


### PR DESCRIPTION
## Summary

- Auto-select the v3.0 geomodel range filter when a compatible classifier (Perch V2 or BirdNET V3.0) is active and geomodel files exist on disk
- Extend the detection pipeline to apply range filtering to Perch V2 detections when the v3 geomodel is active (Bat/BSG remain unaffected)
- Add `GET /api/v2/range/status` endpoint for range filter introspection (model, paths, mapping stats, auto-selection status)
- Add `GET /api/v2/range/species/scores` endpoint returning all species with raw geomodel scores (no threshold cutoff)
- Add `RangeFilterStatus()` method on BirdNET/Orchestrator exposing mapping stats from the mappedRangeFilter
- Precompute mapped species count in `mappedRangeFilter` for lock-free reads
- Replace `strings.HasPrefix` model guard with type-safe `shouldApplyRangeFilter()` using `DetectionModelInfoForID()`

## Changes

- `internal/classifier/birdnet.go` - auto-selection logic, `RangeFilterStatusInfo`, `SetModelsDir()`
- `internal/classifier/orchestrator.go` - propagate modelsDir, forward `RangeFilterStatus()`
- `internal/classifier/mapped_range_filter.go` - precomputed `mappedCount` field
- `internal/classifier/model_registry.go` - `DetectionNamePerch` constant
- `internal/classifier/model_onnx.go` - use precomputed `mappedCount` in logging
- `internal/analysis/processor/processor.go` - `shouldApplyRangeFilter()` helper
- `internal/api/v2/range.go` - two new GET endpoints
- Tests: 27 new tests across `birdnet_test.go` and `processor_filter_test.go`

## Constraints

- BirdNET v2.4 default behavior is completely unchanged
- Bat and BSG models are not affected by range filter changes
- Follows existing API patterns in range.go

## Test plan

- [x] `shouldAutoSelectV3Geomodel`: Perch V2 + files = true, BirdNET V3.0 + files = true, BirdNET V2.4 = false, Bat = false, BSG = false, empty dir = false, missing files = false
- [x] `applyAutoSelectedGeomodelPaths`: sets paths when unconfigured, preserves valid v3 config, overrides when files missing
- [x] `RangeFilterStatus`: no filter returns empty, mapped filter returns correct stats
- [x] `shouldApplyRangeFilter`: BirdNET (any) = true, Perch + v3 = true, Perch without v3 = false, Bat = false, BSG = false, unknown = true (documents default)
- [x] All 27 new tests pass with `-race`
- [x] golangci-lint: zero issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added /range/status and /range/species/scores endpoints; returns range-filter status and per-species scores with optional location/week overrides
  * Automatic gallery-model discovery for v3 range filtering and a models-directory configuration

* **Bug Fixes**
  * More accurate application of geographic range filtering across detection models

* **Documentation**
  * Updated API docs to include new range endpoints

* **Tests**
  * New unit tests covering range-filter selection and auto-selection behavior

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3035)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->