### PR TITLE
fix(conf): add LiveStream validation and normalize missing defaults

### DIFF
--- a/internal/conf/consts.go
+++ b/internal/conf/consts.go
@@ -35,9 +35,16 @@ const (
 	// LiveStream defaults for webserver configuration.
 	// Viper nested defaults can be lost when the parent key exists in the config
 	// file but the child section is absent, so validation normalizes to these.
-	DefaultLiveStreamBitRate       = 128
-	DefaultLiveStreamSegmentLength = 2
-	DefaultLiveStreamSampleRate    = 48000
+	DefaultLiveStreamBitRate        = 128
+	MinLiveStreamBitRate            = 16
+	MaxLiveStreamBitRate            = 320
+	DefaultLiveStreamSegmentLength  = 2
+	MinLiveStreamSegmentLength      = 1
+	MaxLiveStreamSegmentLength      = 30
+	DefaultLiveStreamSampleRate     = 48000
+	MinLiveStreamSampleRate         = 8000
+	MaxLiveStreamSampleRate         = 96000
+	DefaultLiveStreamFFmpegLogLevel = "warning"
 
 	// DefaultWeatherPollInterval is the default weather poll interval in minutes.
 	DefaultWeatherPollInterval = 60

--- a/internal/conf/defaults.go
+++ b/internal/conf/defaults.go
@@ -333,7 +333,7 @@ func setDefaultConfig() {
 	viper.SetDefault("webserver.livestream.bitrate", DefaultLiveStreamBitRate)
 	viper.SetDefault("webserver.livestream.sampleRate", DefaultLiveStreamSampleRate)
 	viper.SetDefault("webserver.livestream.segmentLength", DefaultLiveStreamSegmentLength)
-	viper.SetDefault("webserver.livestream.ffmpegLogLevel", "warning")
+	viper.SetDefault("webserver.livestream.ffmpegLogLevel", DefaultLiveStreamFFmpegLogLevel)
 
 	// File output configuration
 	viper.SetDefault("output.file.enabled", true)

--- a/internal/conf/pure_validation_test.go
+++ b/internal/conf/pure_validation_test.go
@@ -830,6 +830,22 @@ func TestValidateWebServerSettings_Valid(t *testing.T) {
 	}
 }
 
+// TestValidateWebServerSettings_Normalization verifies defaults are applied for zero/empty fields.
+func TestValidateWebServerSettings_Normalization(t *testing.T) {
+	t.Parallel()
+
+	settings := WebServerSettings{
+		Enabled: true,
+		Port:    "8080",
+	}
+	result := ValidateWebServerSettings(&settings)
+	assert.True(t, result.Valid, "expected valid config after normalization, got: %v", result.Errors)
+	assert.Equal(t, DefaultLiveStreamBitRate, settings.LiveStream.BitRate)
+	assert.Equal(t, DefaultLiveStreamSegmentLength, settings.LiveStream.SegmentLength)
+	assert.Equal(t, DefaultLiveStreamSampleRate, settings.LiveStream.SampleRate)
+	assert.Equal(t, DefaultLiveStreamFFmpegLogLevel, settings.LiveStream.FfmpegLogLevel)
+}
+
 // TestValidateWebServerSettings_Invalid verifies invalid web server configurations.
 func TestValidateWebServerSettings_Invalid(t *testing.T) {
 	t.Parallel()
@@ -917,6 +933,32 @@ func TestValidateWebServerSettings_Invalid(t *testing.T) {
 				},
 			},
 			expectError: "segment length must be between 1 and 30 seconds",
+		},
+		{
+			name: "livestream sample rate too low",
+			settings: WebServerSettings{
+				Enabled: true,
+				Port:    "8080",
+				LiveStream: LiveStreamSettings{
+					BitRate:       128,
+					SegmentLength: 5,
+					SampleRate:    7999,
+				},
+			},
+			expectError: "sample rate must be between",
+		},
+		{
+			name: "livestream sample rate too high",
+			settings: WebServerSettings{
+				Enabled: true,
+				Port:    "8080",
+				LiveStream: LiveStreamSettings{
+					BitRate:       128,
+					SegmentLength: 5,
+					SampleRate:    96001,
+				},
+			},
+			expectError: "sample rate must be between",
 		},
 		{
 			name: "basepath missing leading slash",

--- a/internal/conf/validate_services.go
+++ b/internal/conf/validate_services.go
@@ -269,10 +269,11 @@ func ValidateWebServerSettings(settings *WebServerSettings) ValidationResult {
 	if settings.LiveStream.SampleRate == 0 {
 		settings.LiveStream.SampleRate = DefaultLiveStreamSampleRate
 	}
-	if settings.LiveStream.FfmpegLogLevel == "" {
+	trimmed := strings.ToLower(strings.TrimSpace(settings.LiveStream.FfmpegLogLevel))
+	if trimmed == "" {
 		settings.LiveStream.FfmpegLogLevel = DefaultLiveStreamFFmpegLogLevel
 	} else {
-		settings.LiveStream.FfmpegLogLevel = strings.ToLower(strings.TrimSpace(settings.LiveStream.FfmpegLogLevel))
+		settings.LiveStream.FfmpegLogLevel = trimmed
 	}
 
 	// Validate LiveStream settings

--- a/internal/conf/validate_services.go
+++ b/internal/conf/validate_services.go
@@ -269,18 +269,32 @@ func ValidateWebServerSettings(settings *WebServerSettings) ValidationResult {
 	if settings.LiveStream.SampleRate == 0 {
 		settings.LiveStream.SampleRate = DefaultLiveStreamSampleRate
 	}
-
-	// Validate LiveStream settings
-	if settings.LiveStream.BitRate < 16 || settings.LiveStream.BitRate > 320 {
-		result.Valid = false
-		result.Errors = append(result.Errors,
-			fmt.Sprintf("LiveStream bitrate must be between 16 and 320 kbps, got %d", settings.LiveStream.BitRate))
+	if settings.LiveStream.FfmpegLogLevel == "" {
+		settings.LiveStream.FfmpegLogLevel = DefaultLiveStreamFFmpegLogLevel
+	} else {
+		settings.LiveStream.FfmpegLogLevel = strings.ToLower(strings.TrimSpace(settings.LiveStream.FfmpegLogLevel))
 	}
 
-	if settings.LiveStream.SegmentLength < 1 || settings.LiveStream.SegmentLength > 30 {
+	// Validate LiveStream settings
+	if settings.LiveStream.SampleRate < MinLiveStreamSampleRate || settings.LiveStream.SampleRate > MaxLiveStreamSampleRate {
 		result.Valid = false
 		result.Errors = append(result.Errors,
-			fmt.Sprintf("LiveStream segment length must be between 1 and 30 seconds, got %d", settings.LiveStream.SegmentLength))
+			fmt.Sprintf("LiveStream sample rate must be between %d and %d Hz, got %d",
+				MinLiveStreamSampleRate, MaxLiveStreamSampleRate, settings.LiveStream.SampleRate))
+	}
+
+	if settings.LiveStream.BitRate < MinLiveStreamBitRate || settings.LiveStream.BitRate > MaxLiveStreamBitRate {
+		result.Valid = false
+		result.Errors = append(result.Errors,
+			fmt.Sprintf("LiveStream bitrate must be between %d and %d kbps, got %d",
+				MinLiveStreamBitRate, MaxLiveStreamBitRate, settings.LiveStream.BitRate))
+	}
+
+	if settings.LiveStream.SegmentLength < MinLiveStreamSegmentLength || settings.LiveStream.SegmentLength > MaxLiveStreamSegmentLength {
+		result.Valid = false
+		result.Errors = append(result.Errors,
+			fmt.Sprintf("LiveStream segment length must be between %d and %d seconds, got %d",
+				MinLiveStreamSegmentLength, MaxLiveStreamSegmentLength, settings.LiveStream.SegmentLength))
 	}
 
 	result.Normalized = settings


### PR DESCRIPTION
## Summary

- Add range validation for LiveStream SampleRate (8000-96000 Hz, matching AAC encoder limits); invalid values previously crashed the ffmpeg process silently
- Normalize empty FfmpegLogLevel to "warning" default, and case-normalize non-empty values (ffmpeg expects lowercase)
- Extract all LiveStream validation bounds (BitRate 16-320, SegmentLength 1-30, SampleRate 8000-96000) into named constants in `consts.go`, replacing hardcoded magic numbers
- Normalize zero-valued LiveStream bitrate/segmentLength/sampleRate, weather pollInterval, and security sessionDuration to compile-time defaults instead of rejecting them as validation errors (fixes viper nested defaults issue)
- Fix tests in diskmanager, imageprovider, and security packages to use `SetTestSettings()` instead of relying on lazy disk-based config loading

Fixes the CI failure from [actions/runs/25726184287](https://github.com/tphakala/birdnet-go/actions/runs/25726184287).

## Test Plan

- [x] All 1156 conf tests pass with `-race`
- [x] All 2153 tests pass across conf, diskmanager, imageprovider, security packages
- [x] golangci-lint clean
- [x] Normalization test verifies all 4 LiveStream fields get defaults applied
- [x] Invalid SampleRate boundary tests (7999, 96001) verify range checking

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration & Validation**
  * Livestream defaults clarified and expanded to include explicit min/max bounds for bitrate, segment length, and sample rate; FFmpeg log level is standardized and normalized for consistent behavior.
* **Tests**
  * Added normalization and validation tests to ensure livestream defaults are applied and out-of-range sample rates are rejected with clear errors.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3036)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->