### PR TITLE
fix(api): range filter cleanup - week validation, mutex scope, helper extraction

### DIFF
--- a/internal/api/v2/range.go
+++ b/internal/api/v2/range.go
@@ -38,6 +38,9 @@ func validateRangeFilterRequest(req *RangeFilterTestRequest) error {
 	if req.Threshold < 0 || req.Threshold > 1 {
 		return fmt.Errorf("Threshold must be between 0 and 1") //nolint:staticcheck // user-facing API message
 	}
+	if req.Week != 0 && (req.Week < 1 || req.Week > 48) {
+		return fmt.Errorf("Week must be between 1 and 48") //nolint:staticcheck // user-facing API message
+	}
 	return nil
 }
 
@@ -85,6 +88,27 @@ func (c *Controller) buildTestSettings(lat, lon float64, threshold float32) *con
 	testSnapshot.BirdNET.RangeFilter.Threshold = threshold
 	testSnapshot.BirdNET.LocationConfigured = true
 	return testSnapshot
+}
+
+// convertSpeciesScores converts classifier.SpeciesScore entries to the API
+// response format. When includeScores is true each entry carries a pointer to
+// its probability score; otherwise Score is nil.
+func convertSpeciesScores(scores []classifier.SpeciesScore, includeScores bool) []RangeFilterSpecies {
+	species := make([]RangeFilterSpecies, 0, len(scores))
+	for _, s := range scores {
+		sp := detection.ParseSpeciesString(s.Label)
+		entry := RangeFilterSpecies{
+			Label:          s.Label,
+			ScientificName: sp.ScientificName,
+			CommonName:     sp.CommonName,
+		}
+		if includeScores {
+			score := s.Score
+			entry.Score = &score
+		}
+		species = append(species, entry)
+	}
+	return species
 }
 
 // Location represents geographic coordinates
@@ -266,21 +290,7 @@ func (c *Controller) GetRangeFilterSpeciesScores(ctx echo.Context) error {
 		return c.HandleError(ctx, err, "Failed to get species scores", http.StatusInternalServerError)
 	}
 
-	// Convert to response format
-	speciesList := make([]RangeFilterSpecies, 0, len(speciesScores))
-	for _, speciesScore := range speciesScores {
-		sp := detection.ParseSpeciesString(speciesScore.Label)
-
-		score := speciesScore.Score
-		species := RangeFilterSpecies{
-			Label:          speciesScore.Label,
-			ScientificName: sp.ScientificName,
-			CommonName:     sp.CommonName,
-			Score:          &score,
-		}
-
-		speciesList = append(speciesList, species)
-	}
+	speciesList := convertSpeciesScores(speciesScores, true)
 
 	response := RangeFilterScoresResponse{
 		Species:   speciesList,
@@ -306,11 +316,6 @@ func (c *Controller) GetRangeFilterSpeciesScores(ctx echo.Context) error {
 // @Failure 500 {object} ErrorResponse
 // @Router /api/v2/range/species/count [get]
 func (c *Controller) GetRangeFilterSpeciesCount(ctx echo.Context) error {
-	// Acquire read lock to prevent reading temporarily swapped values
-	// during a concurrent range filter test (see #1940).
-	c.settingsMutex.RLock()
-	defer c.settingsMutex.RUnlock()
-
 	// Use the latest published snapshot so the daily range filter update
 	// (which publishes via clone-mutate-publish) is visible immediately.
 	settings := conf.CurrentOrFallback(c.Settings)
@@ -338,11 +343,6 @@ func (c *Controller) GetRangeFilterSpeciesCount(ctx echo.Context) error {
 // @Failure 500 {object} ErrorResponse
 // @Router /api/v2/range/species/list [get]
 func (c *Controller) GetRangeFilterSpeciesList(ctx echo.Context) error {
-	// Acquire read lock to prevent reading temporarily swapped values
-	// during a concurrent range filter test (see #1940).
-	c.settingsMutex.RLock()
-	defer c.settingsMutex.RUnlock()
-
 	// Use the latest published snapshot so the daily range filter update
 	// (which publishes via clone-mutate-publish) is visible immediately.
 	settings := conf.CurrentOrFallback(c.Settings)
@@ -491,23 +491,7 @@ func (c *Controller) TestRangeFilter(ctx echo.Context) error {
 		return c.HandleError(ctx, err, "Failed to get probable species", http.StatusInternalServerError)
 	}
 
-	// Convert to response format
-	// Pre-allocate slice with capacity for all species scores
-	speciesList := make([]RangeFilterSpecies, 0, len(speciesScores))
-	for _, speciesScore := range speciesScores {
-		sp := detection.ParseSpeciesString(speciesScore.Label)
-
-		// Create score pointer for non-nil value
-		score := speciesScore.Score
-		species := RangeFilterSpecies{
-			Label:          speciesScore.Label,
-			ScientificName: sp.ScientificName,
-			CommonName:     sp.CommonName,
-			Score:          &score, // Individual scores are available from GetProbableSpecies
-		}
-
-		speciesList = append(speciesList, species)
-	}
+	speciesList := convertSpeciesScores(speciesScores, true)
 
 	response := RangeFilterTestResponse{
 		Species:   speciesList,
@@ -681,22 +665,7 @@ func (c *Controller) getTestSpeciesList(req RangeFilterTestRequest) ([]RangeFilt
 		return nil, Location{}, 0, err
 	}
 
-	// Convert to response format
-	speciesList := make([]RangeFilterSpecies, 0, len(speciesScores))
-	for _, speciesScore := range speciesScores {
-		sp := detection.ParseSpeciesString(speciesScore.Label)
-
-		// Create score pointer for non-nil value
-		score := speciesScore.Score
-		species := RangeFilterSpecies{
-			Label:          speciesScore.Label,
-			ScientificName: sp.ScientificName,
-			CommonName:     sp.CommonName,
-			Score:          &score,
-		}
-
-		speciesList = append(speciesList, species)
-	}
+	speciesList := convertSpeciesScores(speciesScores, true)
 
 	location := Location{
 		Latitude:  req.Latitude,

--- a/internal/api/v2/range.go
+++ b/internal/api/v2/range.go
@@ -40,7 +40,7 @@ func validateRangeFilterRequest(req *RangeFilterTestRequest) error {
 		return fmt.Errorf("Threshold must be between 0 and 1") //nolint:staticcheck // user-facing API message
 	}
 	if req.Week != 0 && (req.Week < 1 || req.Week > weeksPerYear) {
-		return fmt.Errorf("Week must be between 1 and 48") //nolint:staticcheck // user-facing API message
+		return fmt.Errorf("Week must be between 1 and %d", weeksPerYear) //nolint:staticcheck // user-facing API message
 	}
 	return nil
 }
@@ -287,7 +287,7 @@ func (c *Controller) GetRangeFilterSpeciesScores(ctx echo.Context) error {
 			return c.HandleError(ctx, err, "Invalid week format", http.StatusBadRequest)
 		}
 		if parsed < 1 || parsed > weeksPerYear {
-			return c.HandleError(ctx, nil, "Week must be between 1 and 48", http.StatusBadRequest)
+			return c.HandleError(ctx, nil, fmt.Sprintf("Week must be between 1 and %d", weeksPerYear), http.StatusBadRequest)
 		}
 		week = float32(parsed)
 	}

--- a/internal/api/v2/range.go
+++ b/internal/api/v2/range.go
@@ -22,8 +22,9 @@ import (
 
 // Range filter constants (file-local)
 const (
-	weeksPerMonth = 4 // Simplified ML model uses 4 weeks per month (48 weeks/year)
-	daysPerWeek   = 7 // Days in a week for week calculation
+	weeksPerMonth = 4                  // Simplified ML model uses 4 weeks per month
+	weeksPerYear  = weeksPerMonth * 12 // 48 weeks per year in BirdNET's model
+	daysPerWeek   = 7                  // Days in a week for week calculation
 )
 
 // validateRangeFilterRequest validates the range filter test request parameters.
@@ -38,7 +39,7 @@ func validateRangeFilterRequest(req *RangeFilterTestRequest) error {
 	if req.Threshold < 0 || req.Threshold > 1 {
 		return fmt.Errorf("Threshold must be between 0 and 1") //nolint:staticcheck // user-facing API message
 	}
-	if req.Week != 0 && (req.Week < 1 || req.Week > 48) {
+	if req.Week != 0 && (req.Week < 1 || req.Week > weeksPerYear) {
 		return fmt.Errorf("Week must be between 1 and 48") //nolint:staticcheck // user-facing API message
 	}
 	return nil
@@ -91,22 +92,32 @@ func (c *Controller) buildTestSettings(lat, lon float64, threshold float32) *con
 }
 
 // convertSpeciesScores converts classifier.SpeciesScore entries to the API
-// response format. When includeScores is true each entry carries a pointer to
-// its probability score; otherwise Score is nil.
-func convertSpeciesScores(scores []classifier.SpeciesScore, includeScores bool) []RangeFilterSpecies {
+// response format with probability score pointers.
+func convertSpeciesScores(scores []classifier.SpeciesScore) []RangeFilterSpecies {
 	species := make([]RangeFilterSpecies, 0, len(scores))
 	for _, s := range scores {
 		sp := detection.ParseSpeciesString(s.Label)
-		entry := RangeFilterSpecies{
+		score := s.Score
+		species = append(species, RangeFilterSpecies{
 			Label:          s.Label,
 			ScientificName: sp.ScientificName,
 			CommonName:     sp.CommonName,
-		}
-		if includeScores {
-			score := s.Score
-			entry.Score = &score
-		}
-		species = append(species, entry)
+			Score:          &score,
+		})
+	}
+	return species
+}
+
+// convertLabels converts string labels to the API response format without scores.
+func convertLabels(labels []string) []RangeFilterSpecies {
+	species := make([]RangeFilterSpecies, 0, len(labels))
+	for _, label := range labels {
+		sp := detection.ParseSpeciesString(label)
+		species = append(species, RangeFilterSpecies{
+			Label:          label,
+			ScientificName: sp.ScientificName,
+			CommonName:     sp.CommonName,
+		})
 	}
 	return species
 }
@@ -275,7 +286,7 @@ func (c *Controller) GetRangeFilterSpeciesScores(ctx echo.Context) error {
 		if err != nil {
 			return c.HandleError(ctx, err, "Invalid week format", http.StatusBadRequest)
 		}
-		if parsed < 1 || parsed > 48 {
+		if parsed < 1 || parsed > weeksPerYear {
 			return c.HandleError(ctx, nil, "Week must be between 1 and 48", http.StatusBadRequest)
 		}
 		week = float32(parsed)
@@ -290,7 +301,7 @@ func (c *Controller) GetRangeFilterSpeciesScores(ctx echo.Context) error {
 		return c.HandleError(ctx, err, "Failed to get species scores", http.StatusInternalServerError)
 	}
 
-	speciesList := convertSpeciesScores(speciesScores, true)
+	speciesList := convertSpeciesScores(speciesScores)
 
 	response := RangeFilterScoresResponse{
 		Species:   speciesList,
@@ -316,9 +327,9 @@ func (c *Controller) GetRangeFilterSpeciesScores(ctx echo.Context) error {
 // @Failure 500 {object} ErrorResponse
 // @Router /api/v2/range/species/count [get]
 func (c *Controller) GetRangeFilterSpeciesCount(ctx echo.Context) error {
-	// Use the latest published snapshot so the daily range filter update
-	// (which publishes via clone-mutate-publish) is visible immediately.
+	c.settingsMutex.RLock()
 	settings := conf.CurrentOrFallback(c.Settings)
+	c.settingsMutex.RUnlock()
 	includedSpecies := settings.GetIncludedSpecies()
 
 	response := RangeFilterSpeciesCount{
@@ -343,26 +354,11 @@ func (c *Controller) GetRangeFilterSpeciesCount(ctx echo.Context) error {
 // @Failure 500 {object} ErrorResponse
 // @Router /api/v2/range/species/list [get]
 func (c *Controller) GetRangeFilterSpeciesList(ctx echo.Context) error {
-	// Use the latest published snapshot so the daily range filter update
-	// (which publishes via clone-mutate-publish) is visible immediately.
+	c.settingsMutex.RLock()
 	settings := conf.CurrentOrFallback(c.Settings)
+	c.settingsMutex.RUnlock()
 	includedSpecies := settings.GetIncludedSpecies()
-
-	// Convert to response format with parsed names
-	// Pre-allocate slice with capacity for all included species
-	speciesList := make([]RangeFilterSpecies, 0, len(includedSpecies))
-	for _, label := range includedSpecies {
-		sp := detection.ParseSpeciesString(label)
-
-		species := RangeFilterSpecies{
-			Label:          label,
-			ScientificName: sp.ScientificName,
-			CommonName:     sp.CommonName,
-			Score:          nil, // No individual scores available for current range filter species
-		}
-
-		speciesList = append(speciesList, species)
-	}
+	speciesList := convertLabels(includedSpecies)
 
 	// Extract taxonomy groups from species list via taxonomy DB
 	var genera []string
@@ -491,7 +487,7 @@ func (c *Controller) TestRangeFilter(ctx echo.Context) error {
 		return c.HandleError(ctx, err, "Failed to get probable species", http.StatusInternalServerError)
 	}
 
-	speciesList := convertSpeciesScores(speciesScores, true)
+	speciesList := convertSpeciesScores(speciesScores)
 
 	response := RangeFilterTestResponse{
 		Species:   speciesList,
@@ -545,10 +541,11 @@ func (c *Controller) GetRangeFilterSpeciesCSV(ctx echo.Context) error {
 
 		// Read current settings under lock for defaults
 		c.settingsMutex.RLock()
-		testReq.Latitude = c.Settings.BirdNET.Latitude
-		testReq.Longitude = c.Settings.BirdNET.Longitude
-		testReq.Threshold = c.Settings.BirdNET.RangeFilter.Threshold
+		defaults := conf.CurrentOrFallback(c.Settings)
 		c.settingsMutex.RUnlock()
+		testReq.Latitude = defaults.BirdNET.Latitude
+		testReq.Longitude = defaults.BirdNET.Longitude
+		testReq.Threshold = defaults.BirdNET.RangeFilter.Threshold
 
 		// Override with custom values if provided
 		if customLat != "" {
@@ -591,37 +588,16 @@ func (c *Controller) GetRangeFilterSpeciesCSV(ctx echo.Context) error {
 			return c.HandleError(ctx, err, "Failed to get species list", http.StatusInternalServerError)
 		}
 	} else {
-		// Acquire read lock to snapshot current settings, then release
-		// before expensive CSV generation and I/O.
 		c.settingsMutex.RLock()
-
-		// Use the latest published snapshot for consistency with other
-		// range filter GET endpoints.
 		settings := conf.CurrentOrFallback(c.Settings)
-		includedSpecies := settings.GetIncludedSpecies()
+		c.settingsMutex.RUnlock()
 
-		// Convert to species list format
-		speciesList = make([]RangeFilterSpecies, 0, len(includedSpecies))
-		for _, label := range includedSpecies {
-			sp := detection.ParseSpeciesString(label)
-
-			species := RangeFilterSpecies{
-				Label:          label,
-				ScientificName: sp.ScientificName,
-				CommonName:     sp.CommonName,
-				Score:          nil,
-			}
-
-			speciesList = append(speciesList, species)
-		}
-
+		speciesList = convertLabels(settings.GetIncludedSpecies())
 		location = Location{
 			Latitude:  settings.BirdNET.Latitude,
 			Longitude: settings.BirdNET.Longitude,
 		}
 		threshold = settings.BirdNET.RangeFilter.Threshold
-
-		c.settingsMutex.RUnlock()
 	}
 
 	// Generate CSV content
@@ -665,7 +641,7 @@ func (c *Controller) getTestSpeciesList(req RangeFilterTestRequest) ([]RangeFilt
 		return nil, Location{}, 0, err
 	}
 
-	speciesList := convertSpeciesScores(speciesScores, true)
+	speciesList := convertSpeciesScores(speciesScores)
 
 	location := Location{
 		Latitude:  req.Latitude,

--- a/internal/api/v2/range_test.go
+++ b/internal/api/v2/range_test.go
@@ -5,6 +5,7 @@ package api
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -298,6 +299,42 @@ func TestTestRangeFilterValidation(t *testing.T) {
 			err = json.Unmarshal(rec.Body.Bytes(), &response)
 			require.NoError(t, err)
 			assert.Contains(t, response.Message, tt.expectedError)
+		})
+	}
+}
+
+// TestValidWeekBoundaries verifies that valid week boundary values pass
+// validation and reach the processor (which returns 500 since it's nil).
+func TestValidWeekBoundaries(t *testing.T) {
+	e, _, controller := setupRangeTestEnvironment(t)
+	controller.Processor = nil
+
+	for _, week := range []float32{1, 48} {
+		t.Run(fmt.Sprintf("week=%v", week), func(t *testing.T) {
+			testRequest := RangeFilterTestRequest{
+				Latitude:  60.1699,
+				Longitude: 24.9384,
+				Threshold: 0.01,
+				Week:      week,
+			}
+
+			requestBody, _ := json.Marshal(testRequest)
+			req := httptest.NewRequest(http.MethodPost, "/api/v2/range/species/test", bytes.NewReader(requestBody))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+			c.SetPath("/api/v2/range/species/test")
+
+			err := controller.TestRangeFilter(c)
+			require.NoError(t, err)
+
+			// Valid week passes validation and reaches processor (500, not 400)
+			assert.Equal(t, http.StatusInternalServerError, rec.Code)
+
+			var response ErrorResponse
+			err = json.Unmarshal(rec.Body.Bytes(), &response)
+			require.NoError(t, err)
+			assert.Contains(t, response.Message, "BirdNET service not available")
 		})
 	}
 }

--- a/internal/api/v2/range_test.go
+++ b/internal/api/v2/range_test.go
@@ -243,6 +243,28 @@ func TestTestRangeFilterValidation(t *testing.T) {
 			expectedError:  "Invalid range filter parameters",
 		},
 		{
+			name: "Invalid week too low",
+			request: RangeFilterTestRequest{
+				Latitude:  60.1699,
+				Longitude: 24.9384,
+				Threshold: 0.01,
+				Week:      -1,
+			},
+			expectedStatus: http.StatusBadRequest,
+			expectedError:  "Invalid range filter parameters",
+		},
+		{
+			name: "Invalid week too high",
+			request: RangeFilterTestRequest{
+				Latitude:  60.1699,
+				Longitude: 24.9384,
+				Threshold: 0.01,
+				Week:      49,
+			},
+			expectedStatus: http.StatusBadRequest,
+			expectedError:  "Invalid range filter parameters",
+		},
+		{
 			name: "Invalid date format",
 			request: RangeFilterTestRequest{
 				Latitude:  60.1699,


### PR DESCRIPTION
## Summary

- Add week bounds (1-48) validation to `POST /range/species/test` endpoint, matching the existing validation on `GET /range/species/scores`
- Narrow `settingsMutex` scope in GET count/list/csv endpoints: minimal RLock around `c.Settings` read instead of locking the entire handler, fixing a data race on the pointer read while eliminating contention
- Extract `convertSpeciesScores` and `convertLabels` helpers to deduplicate 5 conversion sites across `range.go`
- Add `weeksPerYear` constant derived from `weeksPerMonth` to replace magic number `48`
- Use `conf.CurrentOrFallback` consistently in CSV custom-params branch (was reading `c.Settings` fields directly)
- Add positive boundary tests for valid week values (1, 48)

Net result: -105 lines removed, +109 added (mostly tests), 5 duplicated conversion loops consolidated into 2 helpers.

## Related Issues

Fixes #601, Fixes #602, Fixes #600

## Test Plan

- [x] `go test -race -v ./internal/api/v2/` passes (19 range filter tests)
- [x] `golangci-lint run ./internal/api/v2/` clean
- [x] Week validation rejects -1 and 49, accepts 1 and 48
- [x] Concurrent settings access test passes with race detector

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforces week-range validation to BirdNET's 1–48 boundaries.
  * Tightened settings lock scope to avoid unintended side effects.

* **New Features**
  * Centralized species label and score formatting for consistent outputs.
  * Default parameter selection and more consistent species list generation for CSV export.

* **Tests**
  * Expanded validation tests for invalid and boundary week values.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3039)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->