### PR TITLE
fix(api): validate LiveStream fields in settings PATCH endpoint

### DIFF
--- a/internal/api/v2/settings.go
+++ b/internal/api/v2/settings.go
@@ -1417,14 +1417,45 @@ func validateBirdNETSection(data json.RawMessage) error {
 	return validateFloatInRange(updateMap, "longitude", minLongitude, maxLongitude, "longitude")
 }
 
-// validateWebServerSection validates WebServer settings
+// validateWebServerSection validates WebServer settings including LiveStream fields.
 func validateWebServerSection(data json.RawMessage) error {
 	var updateMap map[string]any
 	if err := json.Unmarshal(data, &updateMap); err != nil {
 		return err
 	}
 
-	return validatePortField(updateMap, "port")
+	if err := validatePortField(updateMap, "port"); err != nil {
+		return err
+	}
+
+	return validateLiveStreamFields(updateMap)
+}
+
+// validateLiveStreamFields validates LiveStream sub-fields if the livestream
+// key is present in the PATCH payload.
+func validateLiveStreamFields(updateMap map[string]any) error {
+	lsRaw, ok := updateMap["livestream"]
+	if !ok {
+		return nil
+	}
+	ls, ok := lsRaw.(map[string]any)
+	if !ok {
+		return fmt.Errorf("livestream must be an object")
+	}
+
+	if err := validateFloatInRange(ls, "bitRate",
+		float64(conf.MinLiveStreamBitRate), float64(conf.MaxLiveStreamBitRate),
+		"LiveStream bitrate (kbps)"); err != nil {
+		return err
+	}
+	if err := validateFloatInRange(ls, "segmentLength",
+		float64(conf.MinLiveStreamSegmentLength), float64(conf.MaxLiveStreamSegmentLength),
+		"LiveStream segment length (seconds)"); err != nil {
+		return err
+	}
+	return validateFloatInRange(ls, "sampleRate",
+		float64(conf.MinLiveStreamSampleRate), float64(conf.MaxLiveStreamSampleRate),
+		"LiveStream sample rate (Hz)")
 }
 
 // validateSpeciesSection validates species settings

--- a/internal/api/v2/settings.go
+++ b/internal/api/v2/settings.go
@@ -1431,16 +1431,16 @@ func validateWebServerSection(data json.RawMessage) error {
 	return validateLiveStreamFields(updateMap)
 }
 
-// validateLiveStreamFields validates LiveStream sub-fields if the livestream
+// validateLiveStreamFields validates LiveStream sub-fields if the liveStream
 // key is present in the PATCH payload.
 func validateLiveStreamFields(updateMap map[string]any) error {
-	lsRaw, ok := updateMap["livestream"]
+	lsRaw, ok := updateMap["liveStream"]
 	if !ok {
 		return nil
 	}
 	ls, ok := lsRaw.(map[string]any)
 	if !ok {
-		return fmt.Errorf("livestream must be an object")
+		return fmt.Errorf("liveStream must be an object")
 	}
 
 	if err := validateFloatInRange(ls, "bitRate",

--- a/internal/api/v2/settings.go
+++ b/internal/api/v2/settings.go
@@ -1435,7 +1435,7 @@ func validateWebServerSection(data json.RawMessage) error {
 // key is present in the PATCH payload.
 func validateLiveStreamFields(updateMap map[string]any) error {
 	lsRaw, ok := updateMap["liveStream"]
-	if !ok {
+	if !ok || lsRaw == nil {
 		return nil
 	}
 	ls, ok := lsRaw.(map[string]any)

--- a/internal/api/v2/settings_section_test.go
+++ b/internal/api/v2/settings_section_test.go
@@ -219,3 +219,87 @@ func TestPatchAlertingZeroRetention(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.Equal(t, 0, controller.Settings.Alerting.HistoryRetentionDays)
 }
+
+func TestPatchWebServerLiveStreamValidation(t *testing.T) {
+	tests := []struct {
+		name        string
+		payload     map[string]any
+		wantStatus  int
+		wantContain string
+	}{
+		{
+			name:        "bitRate too low",
+			payload:     map[string]any{"livestream": map[string]any{"bitRate": float64(conf.MinLiveStreamBitRate - 1)}},
+			wantStatus:  http.StatusBadRequest,
+			wantContain: "LiveStream bitrate",
+		},
+		{
+			name:        "bitRate too high",
+			payload:     map[string]any{"livestream": map[string]any{"bitRate": float64(conf.MaxLiveStreamBitRate + 1)}},
+			wantStatus:  http.StatusBadRequest,
+			wantContain: "LiveStream bitrate",
+		},
+		{
+			name:        "sampleRate too low",
+			payload:     map[string]any{"livestream": map[string]any{"sampleRate": float64(conf.MinLiveStreamSampleRate - 1)}},
+			wantStatus:  http.StatusBadRequest,
+			wantContain: "LiveStream sample rate",
+		},
+		{
+			name:        "sampleRate too high",
+			payload:     map[string]any{"livestream": map[string]any{"sampleRate": float64(conf.MaxLiveStreamSampleRate + 1)}},
+			wantStatus:  http.StatusBadRequest,
+			wantContain: "LiveStream sample rate",
+		},
+		{
+			name:        "segmentLength too low",
+			payload:     map[string]any{"livestream": map[string]any{"segmentLength": float64(0)}},
+			wantStatus:  http.StatusBadRequest,
+			wantContain: "LiveStream segment length",
+		},
+		{
+			name:        "segmentLength too high",
+			payload:     map[string]any{"livestream": map[string]any{"segmentLength": float64(conf.MaxLiveStreamSegmentLength + 1)}},
+			wantStatus:  http.StatusBadRequest,
+			wantContain: "LiveStream segment length",
+		},
+		{
+			name:       "valid LiveStream values accepted",
+			payload:    map[string]any{"livestream": map[string]any{"bitRate": float64(128), "sampleRate": float64(48000), "segmentLength": float64(2)}},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "port-only patch skips LiveStream validation",
+			payload:    map[string]any{"port": "8080"},
+			wantStatus: http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := echo.New()
+			controller := getTestController(t, e)
+			controller.Settings.WebServer.Debug = true
+
+			body, err := json.Marshal(tt.payload)
+			require.NoError(t, err)
+
+			req := httptest.NewRequest(http.MethodPatch, "/api/v2/settings/webserver", bytes.NewReader(body))
+			req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+			rec := httptest.NewRecorder()
+			ctx := e.NewContext(req, rec)
+			ctx.SetParamNames("section")
+			ctx.SetParamValues("webserver")
+
+			err = controller.UpdateSectionSettings(ctx)
+			require.NoError(t, err, "handler should return nil and send HTTP response")
+			assert.Equal(t, tt.wantStatus, rec.Code)
+
+			if tt.wantContain != "" {
+				var response map[string]any
+				require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &response))
+				assert.Contains(t, response["error"], tt.wantContain)
+			}
+		})
+	}
+}

--- a/internal/api/v2/settings_section_test.go
+++ b/internal/api/v2/settings_section_test.go
@@ -269,6 +269,11 @@ func TestPatchWebServerLiveStreamValidation(t *testing.T) {
 			wantStatus: http.StatusOK,
 		},
 		{
+			name:       "partial liveStream update succeeds",
+			payload:    map[string]any{"liveStream": map[string]any{"bitRate": float64(192)}},
+			wantStatus: http.StatusOK,
+		},
+		{
 			name:       "port-only patch skips LiveStream validation",
 			payload:    map[string]any{"port": "8080"},
 			wantStatus: http.StatusOK,

--- a/internal/api/v2/settings_section_test.go
+++ b/internal/api/v2/settings_section_test.go
@@ -229,43 +229,43 @@ func TestPatchWebServerLiveStreamValidation(t *testing.T) {
 	}{
 		{
 			name:        "bitRate too low",
-			payload:     map[string]any{"livestream": map[string]any{"bitRate": float64(conf.MinLiveStreamBitRate - 1)}},
+			payload:     map[string]any{"liveStream": map[string]any{"bitRate": float64(conf.MinLiveStreamBitRate - 1)}},
 			wantStatus:  http.StatusBadRequest,
 			wantContain: "LiveStream bitrate",
 		},
 		{
 			name:        "bitRate too high",
-			payload:     map[string]any{"livestream": map[string]any{"bitRate": float64(conf.MaxLiveStreamBitRate + 1)}},
+			payload:     map[string]any{"liveStream": map[string]any{"bitRate": float64(conf.MaxLiveStreamBitRate + 1)}},
 			wantStatus:  http.StatusBadRequest,
 			wantContain: "LiveStream bitrate",
 		},
 		{
 			name:        "sampleRate too low",
-			payload:     map[string]any{"livestream": map[string]any{"sampleRate": float64(conf.MinLiveStreamSampleRate - 1)}},
+			payload:     map[string]any{"liveStream": map[string]any{"sampleRate": float64(conf.MinLiveStreamSampleRate - 1)}},
 			wantStatus:  http.StatusBadRequest,
 			wantContain: "LiveStream sample rate",
 		},
 		{
 			name:        "sampleRate too high",
-			payload:     map[string]any{"livestream": map[string]any{"sampleRate": float64(conf.MaxLiveStreamSampleRate + 1)}},
+			payload:     map[string]any{"liveStream": map[string]any{"sampleRate": float64(conf.MaxLiveStreamSampleRate + 1)}},
 			wantStatus:  http.StatusBadRequest,
 			wantContain: "LiveStream sample rate",
 		},
 		{
 			name:        "segmentLength too low",
-			payload:     map[string]any{"livestream": map[string]any{"segmentLength": float64(0)}},
+			payload:     map[string]any{"liveStream": map[string]any{"segmentLength": float64(0)}},
 			wantStatus:  http.StatusBadRequest,
 			wantContain: "LiveStream segment length",
 		},
 		{
 			name:        "segmentLength too high",
-			payload:     map[string]any{"livestream": map[string]any{"segmentLength": float64(conf.MaxLiveStreamSegmentLength + 1)}},
+			payload:     map[string]any{"liveStream": map[string]any{"segmentLength": float64(conf.MaxLiveStreamSegmentLength + 1)}},
 			wantStatus:  http.StatusBadRequest,
 			wantContain: "LiveStream segment length",
 		},
 		{
 			name:       "valid LiveStream values accepted",
-			payload:    map[string]any{"livestream": map[string]any{"bitRate": float64(128), "sampleRate": float64(48000), "segmentLength": float64(2)}},
+			payload:    map[string]any{"liveStream": map[string]any{"bitRate": float64(128), "sampleRate": float64(48000), "segmentLength": float64(2)}},
 			wantStatus: http.StatusOK,
 		},
 		{


### PR DESCRIPTION
## Summary

- Add LiveStream field validation (bitRate, segmentLength, sampleRate) to the webserver section PATCH validator
- Previously only port was validated, allowing invalid LiveStream values to be persisted via API and crash the ffmpeg HLS process
- Uses existing `validateFloatInRange` helper with exported bounds from `conf.consts.go`
- Only validates fields present in the PATCH payload (correct PATCH semantics)

## Related Issues

Fixes #599

## Test Plan

- [x] `go test -race ./internal/api/v2/ -run TestPatchWebServer` (8 test cases)
- [x] Invalid bitRate/sampleRate/segmentLength rejected with 400
- [x] Valid values accepted with 200
- [x] Port-only PATCH skips LiveStream validation
- [x] `golangci-lint run ./internal/api/v2/` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced validation for WebServer live stream settings so bit rate, segment length, and sample rate are checked against configured acceptable ranges and invalid PATCH payloads return appropriate errors.
* **Tests**
  * Added regression tests covering valid and out-of-range live stream updates and partial/port-only patches.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3040)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->