### PR TITLE
fix(classifier): hot-reload range filter after geomodel install

### DIFF
--- a/internal/classifier/birdnet.go
+++ b/internal/classifier/birdnet.go
@@ -352,6 +352,10 @@ func (bn *BirdNET) getMetaModelData() ([]byte, error) {
 // Reads range filter config from the latest published settings (not the instance's
 // potentially stale bn.Settings) so that config changes from install/uninstall
 // are reflected without restarting the instance.
+//
+// Auto-selection of the v3 geomodel is used only for local routing; settings are
+// NOT published here. The caller (ensureGeomodelConfig, applyConfigForInstall)
+// is responsible for persisting config after the backend is confirmed working.
 func (bn *BirdNET) initializeMetaModel() error {
 	log := GetLogger()
 	settings := bn.currentSettings()
@@ -365,12 +369,12 @@ func (bn *BirdNET) initializeMetaModel() error {
 		logger.String("models_dir", bn.modelsDir))
 
 	// Auto-select v3 geomodel for compatible classifiers when files exist on disk.
-	// Clone-mutate-publish to avoid racing on the shared settings object.
+	// Only applies locally for routing; does NOT publish settings to avoid
+	// inconsistency if the backend fails to initialize.
 	if bn.modelsDir != "" && shouldAutoSelectV3Geomodel(bn.ModelInfo.ID, bn.modelsDir) {
-		updated := conf.CloneSettings(settings)
-		applyAutoSelectedGeomodelPaths(updated, bn.modelsDir)
-		conf.StoreSettings(updated)
-		rf = updated.BirdNET.RangeFilter
+		localSettings := conf.CloneSettings(settings)
+		applyAutoSelectedGeomodelPaths(localSettings, bn.modelsDir)
+		rf = localSettings.BirdNET.RangeFilter
 		log.Info("Auto-selected v3.0 geomodel for compatible classifier",
 			logger.String("classifier", bn.ModelInfo.ID),
 			logger.String("models_dir", bn.modelsDir))

--- a/internal/classifier/birdnet.go
+++ b/internal/classifier/birdnet.go
@@ -347,9 +347,13 @@ func (bn *BirdNET) getMetaModelData() ([]byte, error) {
 }
 
 // initializeMetaModel loads and initializes the meta model used for range filtering.
+// Reads range filter config from the latest published settings (not the instance's
+// potentially stale bn.Settings) so that config changes from install/uninstall
+// are reflected without restarting the instance.
 func (bn *BirdNET) initializeMetaModel() error {
 	log := GetLogger()
-	rf := bn.Settings.BirdNET.RangeFilter
+	settings := bn.currentSettings()
+	rf := settings.BirdNET.RangeFilter
 
 	log.Info("Initializing range filter",
 		logger.String("model", rf.Model),
@@ -363,7 +367,8 @@ func (bn *BirdNET) initializeMetaModel() error {
 	// leaves ModelPath/LabelsPath empty (applyAutoSelectedGeomodelPaths skips
 	// when existing paths already point to valid files).
 	if bn.modelsDir != "" && shouldAutoSelectV3Geomodel(bn.ModelInfo.ID, bn.modelsDir) {
-		applyAutoSelectedGeomodelPaths(bn.Settings, bn.modelsDir)
+		applyAutoSelectedGeomodelPaths(settings, bn.modelsDir)
+		rf = settings.BirdNET.RangeFilter
 		log.Info("Auto-selected v3.0 geomodel for compatible classifier",
 			logger.String("classifier", bn.ModelInfo.ID),
 			logger.String("models_dir", bn.modelsDir))
@@ -371,15 +376,15 @@ func (bn *BirdNET) initializeMetaModel() error {
 
 	// V3 geomodel is always ONNX; route to ONNX backend even if ModelPath is empty
 	// (initializeV3GeoModel will return a clear error about missing paths).
-	if bn.Settings.BirdNET.RangeFilter.Model == "v3" {
+	if rf.Model == "v3" {
 		log.Debug("Routing to ONNX v3 geomodel backend")
 		return bn.initializeONNXMetaModel()
 	}
 
 	// If range filter model path ends with .onnx, use the ONNX backend
-	if isONNXModel(bn.Settings.BirdNET.RangeFilter.ModelPath) {
+	if isONNXModel(rf.ModelPath) {
 		log.Debug("Routing to ONNX range filter backend",
-			logger.String("model_path", bn.Settings.BirdNET.RangeFilter.ModelPath))
+			logger.String("model_path", rf.ModelPath))
 		return bn.initializeONNXMetaModel()
 	}
 

--- a/internal/classifier/birdnet.go
+++ b/internal/classifier/birdnet.go
@@ -348,13 +348,23 @@ func (bn *BirdNET) getMetaModelData() ([]byte, error) {
 
 // initializeMetaModel loads and initializes the meta model used for range filtering.
 func (bn *BirdNET) initializeMetaModel() error {
+	log := GetLogger()
+	rf := bn.Settings.BirdNET.RangeFilter
+
+	log.Info("Initializing range filter",
+		logger.String("model", rf.Model),
+		logger.String("model_path", rf.ModelPath),
+		logger.String("labels_path", rf.LabelsPath),
+		logger.String("classifier", bn.ModelInfo.ID),
+		logger.String("models_dir", bn.modelsDir))
+
 	// Auto-select v3 geomodel for compatible classifiers when files exist on disk.
 	// Also resolves empty paths when the user explicitly sets Model="v3" but
 	// leaves ModelPath/LabelsPath empty (applyAutoSelectedGeomodelPaths skips
 	// when existing paths already point to valid files).
 	if bn.modelsDir != "" && shouldAutoSelectV3Geomodel(bn.ModelInfo.ID, bn.modelsDir) {
 		applyAutoSelectedGeomodelPaths(bn.Settings, bn.modelsDir)
-		GetLogger().Info("Auto-selected v3.0 geomodel for compatible classifier",
+		log.Info("Auto-selected v3.0 geomodel for compatible classifier",
 			logger.String("classifier", bn.ModelInfo.ID),
 			logger.String("models_dir", bn.modelsDir))
 	}
@@ -362,20 +372,25 @@ func (bn *BirdNET) initializeMetaModel() error {
 	// V3 geomodel is always ONNX; route to ONNX backend even if ModelPath is empty
 	// (initializeV3GeoModel will return a clear error about missing paths).
 	if bn.Settings.BirdNET.RangeFilter.Model == "v3" {
+		log.Debug("Routing to ONNX v3 geomodel backend")
 		return bn.initializeONNXMetaModel()
 	}
 
 	// If range filter model path ends with .onnx, use the ONNX backend
 	if isONNXModel(bn.Settings.BirdNET.RangeFilter.ModelPath) {
+		log.Debug("Routing to ONNX range filter backend",
+			logger.String("model_path", bn.Settings.BirdNET.RangeFilter.ModelPath))
 		return bn.initializeONNXMetaModel()
 	}
 
+	log.Debug("Routing to TFLite range filter backend")
 	return bn.initializeTFLiteMetaModel()
 }
 
 // initializeTFLiteMetaModel loads and initializes a TFLite range filter model.
 func (bn *BirdNET) initializeTFLiteMetaModel() error {
 	start := time.Now()
+	log := GetLogger()
 
 	metaModelData, err := bn.getMetaModelData()
 	if err != nil {
@@ -383,7 +398,7 @@ func (bn *BirdNET) initializeTFLiteMetaModel() error {
 	}
 
 	rangeFilter, err := tflite.NewTFLiteRangeFilter(metaModelData, func(msg string) {
-		GetLogger().Error("TFLite meta model error", logger.String("message", msg))
+		log.Error("TFLite meta model error", logger.String("message", msg))
 	})
 	if err != nil {
 		return errors.New(err).
@@ -393,6 +408,10 @@ func (bn *BirdNET) initializeTFLiteMetaModel() error {
 			Timing("meta-model-init", time.Since(start)).
 			Build()
 	}
+
+	log.Info("TFLite range filter initialized",
+		logger.Int("species", rangeFilter.NumSpecies()),
+		logger.String("duration", time.Since(start).String()))
 
 	bn.rangeFilter = rangeFilter
 	return nil
@@ -633,6 +652,45 @@ func (bn *BirdNET) Delete() {
 	}
 	bn.mu.Unlock()
 	bn.clearSpeciesCache()
+}
+
+// ReloadRangeFilter reinitializes just the range filter backend from current
+// settings. This is lighter than ReloadModel and is used when the geomodel
+// config changes (e.g., after a model gallery install adds v3 geomodel files)
+// without requiring a full classifier reload.
+// Holds bn.mu for the entire operation to prevent races with concurrent
+// reads in GetSpeciesOccurrenceAtTime and writes in Delete/ReloadModel.
+func (bn *BirdNET) ReloadRangeFilter() error {
+	log := GetLogger()
+	log.Info("Reloading range filter from updated settings")
+
+	bn.mu.Lock()
+	defer bn.mu.Unlock()
+
+	oldRangeFilter := bn.rangeFilter
+
+	if err := bn.initializeMetaModel(); err != nil {
+		// Rollback: restore old range filter if init created a partial one
+		if bn.rangeFilter != nil && bn.rangeFilter != oldRangeFilter {
+			bn.rangeFilter.Close()
+		}
+		bn.rangeFilter = oldRangeFilter
+
+		return errors.New(err).
+			Component("birdnet").
+			Category(errors.CategoryModelInit).
+			Context("operation", "reload_range_filter").
+			Build()
+	}
+
+	// Close old range filter if it was replaced
+	if oldRangeFilter != nil && bn.rangeFilter != oldRangeFilter {
+		oldRangeFilter.Close()
+	}
+
+	bn.clearSpeciesCache()
+	log.Info("Range filter reloaded successfully")
+	return nil
 }
 
 // DefaultBirdNETModelName is the expected filesystem basename for the main BirdNET analysis model file.
@@ -1232,6 +1290,12 @@ func (bn *BirdNET) RangeFilterStatus() RangeFilterStatusInfo {
 		info.ClassifierSpecies = mrf.numClassifier
 		info.MappedSpecies = mrf.mappedCount
 		info.UnmappedSpecies = mrf.numClassifier - mrf.mappedCount
+	} else if bn.rangeFilter != nil {
+		GetLogger().Debug("Range filter is not a mappedRangeFilter",
+			logger.String("type", fmt.Sprintf("%T", bn.rangeFilter)),
+			logger.Int("num_species", bn.rangeFilter.NumSpecies()))
+	} else {
+		GetLogger().Debug("Range filter is nil, species counts will be zero")
 	}
 	bn.mu.Unlock()
 

--- a/internal/classifier/birdnet.go
+++ b/internal/classifier/birdnet.go
@@ -277,9 +277,12 @@ func (bn *BirdNET) initializeTFLiteModel() error {
 
 // getMetaModelData returns the appropriate meta model data based on the settings.
 func (bn *BirdNET) getMetaModelData() ([]byte, error) {
+	settings := bn.currentSettings()
+	rf := settings.BirdNET.RangeFilter
+
 	// Check if external model path is specified
-	if bn.Settings.BirdNET.RangeFilter.ModelPath != "" {
-		modelPath := bn.Settings.BirdNET.RangeFilter.ModelPath
+	if rf.ModelPath != "" {
+		modelPath := rf.ModelPath
 
 		// Expand environment variables and ~ prefix
 		modelPath = os.ExpandEnv(modelPath)
@@ -287,7 +290,7 @@ func (bn *BirdNET) getMetaModelData() ([]byte, error) {
 		if err != nil {
 			return nil, errors.New(err).
 				Category(errors.CategoryFileIO).
-				Context("path", bn.Settings.BirdNET.RangeFilter.ModelPath).
+				Context("path", rf.ModelPath).
 				Build()
 		}
 
@@ -297,7 +300,7 @@ func (bn *BirdNET) getMetaModelData() ([]byte, error) {
 			return nil, errors.New(err).
 				Category(errors.CategoryFileIO).
 				Context("path", modelPath).
-				Context("range_filter_model", bn.Settings.BirdNET.RangeFilter.Model).
+				Context("range_filter_model", rf.Model).
 				Build()
 		}
 
@@ -309,16 +312,15 @@ func (bn *BirdNET) getMetaModelData() ([]byte, error) {
 	if !hasEmbeddedModels {
 		// Determine which model file to look for based on the model version
 		modelFileName := DefaultRangeFilterV2ModelName
-		if bn.Settings.BirdNET.RangeFilter.Model == "legacy" {
+		if rf.Model == "legacy" {
 			modelFileName = DefaultRangeFilterV1ModelName
 			GetLogger().Warn("Looking for legacy range filter model")
 		}
 
 		data, path, err := tryLoadModelFromStandardPaths(modelFileName, "range filter")
 		if err != nil {
-			// Add extra context to the error
 			return nil, errors.Wrap(err).
-				Context("range_filter_model", bn.Settings.BirdNET.RangeFilter.Model).
+				Context("range_filter_model", rf.Model).
 				Build()
 		}
 		GetLogger().Info("Loaded range filter model from standard path", logger.String("path", path))
@@ -328,7 +330,7 @@ func (bn *BirdNET) getMetaModelData() ([]byte, error) {
 
 	// Fall back to embedded models
 	var data []byte
-	if bn.Settings.BirdNET.RangeFilter.Model == "legacy" {
+	if rf.Model == "legacy" {
 		GetLogger().Warn("Using legacy range filter model")
 		data = metaModelDataV1
 	} else {
@@ -339,7 +341,7 @@ func (bn *BirdNET) getMetaModelData() ([]byte, error) {
 		return nil, errors.Newf("range filter model not available: embedded model is nil").
 			Category(errors.CategoryModelLoad).
 			Context("embedded_models", hasEmbeddedModels).
-			Context("range_filter_model", bn.Settings.BirdNET.RangeFilter.Model).
+			Context("range_filter_model", rf.Model).
 			Build()
 	}
 
@@ -363,12 +365,12 @@ func (bn *BirdNET) initializeMetaModel() error {
 		logger.String("models_dir", bn.modelsDir))
 
 	// Auto-select v3 geomodel for compatible classifiers when files exist on disk.
-	// Also resolves empty paths when the user explicitly sets Model="v3" but
-	// leaves ModelPath/LabelsPath empty (applyAutoSelectedGeomodelPaths skips
-	// when existing paths already point to valid files).
+	// Clone-mutate-publish to avoid racing on the shared settings object.
 	if bn.modelsDir != "" && shouldAutoSelectV3Geomodel(bn.ModelInfo.ID, bn.modelsDir) {
-		applyAutoSelectedGeomodelPaths(settings, bn.modelsDir)
-		rf = settings.BirdNET.RangeFilter
+		updated := conf.CloneSettings(settings)
+		applyAutoSelectedGeomodelPaths(updated, bn.modelsDir)
+		conf.StoreSettings(updated)
+		rf = updated.BirdNET.RangeFilter
 		log.Info("Auto-selected v3.0 geomodel for compatible classifier",
 			logger.String("classifier", bn.ModelInfo.ID),
 			logger.String("models_dir", bn.modelsDir))

--- a/internal/classifier/model_manager.go
+++ b/internal/classifier/model_manager.go
@@ -239,36 +239,46 @@ func (mm *ModelManager) ensureGeomodelConfig(log logger.Logger, installedIDs []s
 			continue
 		}
 
-		// Files exist. Check if the config already has model=v3 with valid paths.
+		// Build expected paths from catalog entry.
+		expectedModelPath := ""
+		expectedLabelsPath := ""
+		for _, f := range entry.Files {
+			switch f.Role {
+			case RoleGeomodelModel:
+				expectedModelPath = filepath.Join(mm.modelsDir, "shared", f.LocalName)
+			case RoleGeomodelLabels:
+				expectedLabelsPath = filepath.Join(mm.modelsDir, "shared", f.LocalName)
+			}
+		}
+
+		// Files exist. Check if the config already matches expected paths.
 		currentSettings := conf.GetSettings()
 		rf := currentSettings.BirdNET.RangeFilter
-		if rf.Model == entry.GeomodelVersion && rf.ModelPath != "" && rf.LabelsPath != "" {
+		if rf.Model == entry.GeomodelVersion &&
+			rf.ModelPath == expectedModelPath &&
+			rf.LabelsPath == expectedLabelsPath {
 			// Config already set; initializeMetaModel handled it at startup.
 			return
 		}
 
-		// Config is stale or missing; update it.
+		// Config is stale or missing; update it under settingsMu to
+		// serialize with concurrent install/uninstall config writes.
 		log.Info("Applying geomodel config for installed model",
 			logger.String("catalog_id", catalogID),
 			logger.String("geomodel_version", entry.GeomodelVersion))
 
-		updated := conf.CloneSettings(currentSettings)
+		mm.settingsMu.Lock()
+		updated := conf.CloneSettings(conf.GetSettings())
 		updated.BirdNET.RangeFilter.Model = entry.GeomodelVersion
-		for _, f := range entry.Files {
-			switch f.Role {
-			case RoleGeomodelModel:
-				updated.BirdNET.RangeFilter.ModelPath = filepath.Join(mm.modelsDir, "shared", f.LocalName)
-			case RoleGeomodelLabels:
-				updated.BirdNET.RangeFilter.LabelsPath = filepath.Join(mm.modelsDir, "shared", f.LocalName)
-			}
-		}
-
+		updated.BirdNET.RangeFilter.ModelPath = expectedModelPath
+		updated.BirdNET.RangeFilter.LabelsPath = expectedLabelsPath
 		conf.StoreSettings(updated)
 		if err := conf.SaveSettings(); err != nil {
 			log.Warn("Failed to persist geomodel config",
 				logger.String("catalog_id", catalogID),
 				logger.Error(err))
 		}
+		mm.settingsMu.Unlock()
 
 		if err := mm.orchestrator.ReloadRangeFilter(); err != nil {
 			log.Warn("Failed to reload range filter after geomodel config update",

--- a/internal/classifier/model_manager.go
+++ b/internal/classifier/model_manager.go
@@ -200,6 +200,82 @@ func (mm *ModelManager) ScanInstalled() {
 		mm.settingsMu.Unlock()
 
 		mm.loadInstalledModels(log, installedIDs)
+
+		// After loading models, check if any installed model has geomodel
+		// companion files on disk. If so, ensure the range filter config is
+		// up to date and reload the filter. This handles the upgrade case
+		// where a new binary adds geomodel support to existing models.
+		mm.ensureGeomodelConfig(log, installedIDs)
+	}
+}
+
+// ensureGeomodelConfig checks if any installed model has geomodel companion
+// files on disk and, if the range filter config doesn't already reflect them,
+// updates the config and reloads the range filter.
+func (mm *ModelManager) ensureGeomodelConfig(log logger.Logger, installedIDs []string) {
+	if mm.orchestrator == nil {
+		return
+	}
+
+	for _, catalogID := range installedIDs {
+		entry, found := GetCatalogEntry(catalogID)
+		if !found || !HasGeomodelFiles(&entry) {
+			continue
+		}
+
+		// Check if all geomodel files exist on disk.
+		allPresent := true
+		for _, f := range entry.Files {
+			if !isGeomodelRole(f.Role) {
+				continue
+			}
+			path := filepath.Join(mm.modelsDir, "shared", f.LocalName)
+			if _, err := os.Stat(path); err != nil {
+				allPresent = false
+				break
+			}
+		}
+		if !allPresent {
+			continue
+		}
+
+		// Files exist. Check if the config already has model=v3 with valid paths.
+		currentSettings := conf.GetSettings()
+		rf := currentSettings.BirdNET.RangeFilter
+		if rf.Model == entry.GeomodelVersion && rf.ModelPath != "" && rf.LabelsPath != "" {
+			// Config already set; initializeMetaModel handled it at startup.
+			return
+		}
+
+		// Config is stale or missing; update it.
+		log.Info("Applying geomodel config for installed model",
+			logger.String("catalog_id", catalogID),
+			logger.String("geomodel_version", entry.GeomodelVersion))
+
+		updated := conf.CloneSettings(currentSettings)
+		updated.BirdNET.RangeFilter.Model = entry.GeomodelVersion
+		for _, f := range entry.Files {
+			switch f.Role {
+			case RoleGeomodelModel:
+				updated.BirdNET.RangeFilter.ModelPath = filepath.Join(mm.modelsDir, "shared", f.LocalName)
+			case RoleGeomodelLabels:
+				updated.BirdNET.RangeFilter.LabelsPath = filepath.Join(mm.modelsDir, "shared", f.LocalName)
+			}
+		}
+
+		conf.StoreSettings(updated)
+		if err := conf.SaveSettings(); err != nil {
+			log.Warn("Failed to persist geomodel config",
+				logger.String("catalog_id", catalogID),
+				logger.Error(err))
+		}
+
+		if err := mm.orchestrator.ReloadRangeFilter(); err != nil {
+			log.Warn("Failed to reload range filter after geomodel config update",
+				logger.String("catalog_id", catalogID),
+				logger.Error(err))
+		}
+		return
 	}
 }
 
@@ -346,6 +422,16 @@ func (mm *ModelManager) Uninstall(catalogID string) error {
 	delete(mm.installed, catalogID)
 
 	mm.applyConfigForUninstall(&entry)
+
+	// If geomodel was cleared during uninstall, reload the range filter
+	// so the primary model falls back to the embedded TFLite filter.
+	if mm.orchestrator != nil && HasGeomodelFiles(&entry) {
+		if err := mm.orchestrator.ReloadRangeFilter(); err != nil {
+			log.Warn("Failed to hot-reload range filter after geomodel uninstall",
+				logger.String("catalog_id", catalogID),
+				logger.Error(err))
+		}
+	}
 
 	log.Info("Model uninstalled",
 		logger.String("catalog_id", catalogID))
@@ -659,31 +745,50 @@ func (mm *ModelManager) downloadModelFiles(entry *CatalogEntry, baseURL string, 
 	}
 	mm.applyConfigForInstall(entry, modelPath, labelsPath, embeddingsPath)
 
-	// Hot-load into orchestrator.
-	if mm.orchestrator != nil && entry.RegistryID != "" {
-		if err := mm.orchestrator.LoadModel(entry.RegistryID); err != nil {
-			log.Warn("Failed to hot-load model (will be available after restart)",
-				logger.String("catalog_id", entry.ID),
-				logger.Error(err))
-		}
-	}
-
-	// Send final complete status (non-blocking in case the consumer is gone).
-	if progress != nil {
-		select {
-		case progress <- DownloadState{
-			CatalogID: entry.ID,
-			Status:    StatusComplete,
-		}:
-		default:
-		}
-	}
+	mm.hotLoadAfterInstall(log, entry)
+	sendProgress(progress, entry.ID, StatusComplete)
 
 	log.Info("Model installed",
 		logger.String("catalog_id", entry.ID),
 		logger.String("model_path", modelPath))
 
 	return nil
+}
+
+// hotLoadAfterInstall hot-loads the classifier model and, if the entry
+// includes geomodel companion files, reloads the range filter.
+func (mm *ModelManager) hotLoadAfterInstall(log logger.Logger, entry *CatalogEntry) {
+	if mm.orchestrator == nil {
+		return
+	}
+	if entry.RegistryID != "" {
+		if err := mm.orchestrator.LoadModel(entry.RegistryID); err != nil {
+			log.Warn("Failed to hot-load model (will be available after restart)",
+				logger.String("catalog_id", entry.ID),
+				logger.Error(err))
+		}
+	}
+	if HasGeomodelFiles(entry) {
+		if err := mm.orchestrator.ReloadRangeFilter(); err != nil {
+			log.Warn("Failed to hot-reload range filter after geomodel install",
+				logger.String("catalog_id", entry.ID),
+				logger.Error(err))
+		}
+	}
+}
+
+// sendProgress sends a non-blocking status update to the progress channel.
+func sendProgress(progress chan<- DownloadState, catalogID, status string) {
+	if progress == nil {
+		return
+	}
+	select {
+	case progress <- DownloadState{
+		CatalogID: catalogID,
+		Status:    status,
+	}:
+	default:
+	}
 }
 
 // markFailed sets the download state to StatusFailed so SSE pollers can

--- a/internal/classifier/model_onnx.go
+++ b/internal/classifier/model_onnx.go
@@ -91,7 +91,13 @@ func (bn *BirdNET) initializeONNXMetaModel() error {
 // names. This enables the 12K-species geomodel to work with any classifier.
 func (bn *BirdNET) initializeV3GeoModel() error {
 	start := time.Now()
+	log := GetLogger()
 	rfSettings := bn.Settings.BirdNET.RangeFilter
+
+	log.Info("V3 geomodel: starting initialization",
+		logger.String("model_path", rfSettings.ModelPath),
+		logger.String("labels_path", rfSettings.LabelsPath),
+		logger.Int("classifier_labels", len(bn.Settings.BirdNET.Labels)))
 
 	if rfSettings.ModelPath == "" {
 		return errors.Newf("v3 geomodel requires rangefilter.modelpath to be set").
@@ -126,6 +132,7 @@ func (bn *BirdNET) initializeV3GeoModel() error {
 	}
 
 	// Ensure ONNX Runtime is initialized
+	log.Debug("V3 geomodel: initializing ONNX Runtime")
 	if err := inference.InitONNXRuntime(bn.Settings.BirdNET.ONNXRuntimePath); err != nil {
 		return errors.New(err).
 			Category(errors.CategoryModelInit).
@@ -135,6 +142,7 @@ func (bn *BirdNET) initializeV3GeoModel() error {
 	}
 
 	// Load geomodel labels from file
+	log.Debug("V3 geomodel: loading labels", logger.String("path", labelsPath))
 	geoLabels, err := loadLabelsFromFile(labelsPath)
 	if err != nil {
 		return errors.New(err).
@@ -151,7 +159,12 @@ func (bn *BirdNET) initializeV3GeoModel() error {
 			Build()
 	}
 
+	log.Debug("V3 geomodel: loaded labels",
+		logger.Int("count", len(geoLabels)),
+		logger.String("first", geoLabels[0]))
+
 	// Create ONNX range filter using the geomodel's own labels
+	log.Debug("V3 geomodel: creating ONNX range filter", logger.String("model_path", modelPath))
 	innerFilter, err := inference.NewONNXRangeFilter(
 		modelPath,
 		inference.ONNXRangeFilterOptions{
@@ -174,7 +187,6 @@ func (bn *BirdNET) initializeV3GeoModel() error {
 	}
 	mapped := newMappedRangeFilter(innerFilter, classifierLabels, geoLabels, unmappedScore)
 
-	log := GetLogger()
 	if mapped.mappedCount == 0 && len(classifierLabels) > 0 {
 		log.Warn("V3 geomodel: no species matched classifier labels, range filter will filter out all detections (check labels file)",
 			logger.Int("classifier_species", len(classifierLabels)),
@@ -184,7 +196,8 @@ func (bn *BirdNET) initializeV3GeoModel() error {
 		logger.Int("geomodel_species", len(geoLabels)),
 		logger.Int("classifier_species", len(classifierLabels)),
 		logger.Int("mapped_species", mapped.mappedCount),
-		logger.Int("unmapped_species", len(classifierLabels)-mapped.mappedCount))
+		logger.Int("unmapped_species", len(classifierLabels)-mapped.mappedCount),
+		logger.String("duration", time.Since(start).String()))
 
 	bn.rangeFilter = mapped
 	return nil

--- a/internal/classifier/model_onnx.go
+++ b/internal/classifier/model_onnx.go
@@ -51,32 +51,33 @@ func (bn *BirdNET) initializeONNXModel() error {
 // For v3 geomodel, delegates to initializeV3GeoModel which loads the geomodel
 // with its own 12K labels and wraps it in a mappedRangeFilter.
 func (bn *BirdNET) initializeONNXMetaModel() error {
-	if bn.Settings.BirdNET.RangeFilter.Model == "v3" {
+	settings := bn.currentSettings()
+	if settings.BirdNET.RangeFilter.Model == "v3" {
 		return bn.initializeV3GeoModel()
 	}
 
 	start := time.Now()
 
 	// Ensure ONNX Runtime is initialized (idempotent - may already be init from classifier)
-	if err := inference.InitONNXRuntime(bn.Settings.BirdNET.ONNXRuntimePath); err != nil {
+	if err := inference.InitONNXRuntime(settings.BirdNET.ONNXRuntimePath); err != nil {
 		return errors.New(err).
 			Category(errors.CategoryModelInit).
-			Context("onnx_runtime_path", bn.Settings.BirdNET.ONNXRuntimePath).
+			Context("onnx_runtime_path", settings.BirdNET.ONNXRuntimePath).
 			Timing("onnx-init", time.Since(start)).
 			Build()
 	}
 
 	rangeFilter, err := inference.NewONNXRangeFilter(
-		bn.Settings.BirdNET.RangeFilter.ModelPath,
+		settings.BirdNET.RangeFilter.ModelPath,
 		inference.ONNXRangeFilterOptions{
-			Labels: bn.Settings.BirdNET.Labels,
+			Labels: settings.BirdNET.Labels,
 		},
 	)
 	if err != nil {
 		return errors.New(err).
 			Category(errors.CategoryModelInit).
 			Context("model_type", "range_filter").
-			Context("range_filter_model", bn.Settings.BirdNET.RangeFilter.ModelPath).
+			Context("range_filter_model", settings.BirdNET.RangeFilter.ModelPath).
 			Timing("onnx-meta-model-init", time.Since(start)).
 			Build()
 	}
@@ -92,12 +93,13 @@ func (bn *BirdNET) initializeONNXMetaModel() error {
 func (bn *BirdNET) initializeV3GeoModel() error {
 	start := time.Now()
 	log := GetLogger()
-	rfSettings := bn.Settings.BirdNET.RangeFilter
+	settings := bn.currentSettings()
+	rfSettings := settings.BirdNET.RangeFilter
 
 	log.Info("V3 geomodel: starting initialization",
 		logger.String("model_path", rfSettings.ModelPath),
 		logger.String("labels_path", rfSettings.LabelsPath),
-		logger.Int("classifier_labels", len(bn.Settings.BirdNET.Labels)))
+		logger.Int("classifier_labels", len(settings.BirdNET.Labels)))
 
 	if rfSettings.ModelPath == "" {
 		return errors.Newf("v3 geomodel requires rangefilter.modelpath to be set").
@@ -133,10 +135,10 @@ func (bn *BirdNET) initializeV3GeoModel() error {
 
 	// Ensure ONNX Runtime is initialized
 	log.Debug("V3 geomodel: initializing ONNX Runtime")
-	if err := inference.InitONNXRuntime(bn.Settings.BirdNET.ONNXRuntimePath); err != nil {
+	if err := inference.InitONNXRuntime(settings.BirdNET.ONNXRuntimePath); err != nil {
 		return errors.New(err).
 			Category(errors.CategoryModelInit).
-			Context("onnx_runtime_path", bn.Settings.BirdNET.ONNXRuntimePath).
+			Context("onnx_runtime_path", settings.BirdNET.ONNXRuntimePath).
 			Timing("onnx-init", time.Since(start)).
 			Build()
 	}
@@ -180,7 +182,7 @@ func (bn *BirdNET) initializeV3GeoModel() error {
 			Build()
 	}
 
-	classifierLabels := bn.Settings.BirdNET.Labels
+	classifierLabels := settings.BirdNET.Labels
 	var unmappedScore float32
 	if rfSettings.PassUnmappedSpecies {
 		unmappedScore = 1.0

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -288,10 +288,13 @@ func (o *Orchestrator) RangeFilterStatus() RangeFilterStatusInfo {
 // ReloadRangeFilter reinitializes the range filter on the primary model
 // from current settings without a full model reload.
 func (o *Orchestrator) ReloadRangeFilter() error {
-	if o.primary == nil {
+	o.mu.RLock()
+	primary := o.primary
+	o.mu.RUnlock()
+	if primary == nil {
 		return nil
 	}
-	return o.primary.ReloadRangeFilter()
+	return primary.ReloadRangeFilter()
 }
 
 // RunFilterProcess executes the filter process on demand and prints results.

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -285,6 +285,15 @@ func (o *Orchestrator) RangeFilterStatus() RangeFilterStatusInfo {
 	return o.primary.RangeFilterStatus()
 }
 
+// ReloadRangeFilter reinitializes the range filter on the primary model
+// from current settings without a full model reload.
+func (o *Orchestrator) ReloadRangeFilter() error {
+	if o.primary == nil {
+		return nil
+	}
+	return o.primary.ReloadRangeFilter()
+}
+
 // RunFilterProcess executes the filter process on demand and prints results.
 func (o *Orchestrator) RunFilterProcess(dateStr string, week float32) {
 	o.primary.RunFilterProcess(dateStr, week)


### PR DESCRIPTION
## Summary

- When the model gallery installs a model with v3 geomodel companion files, the range filter config is updated but the running filter is never reinitialized, leaving the old TFLite filter active while the API reports v3 with zero mapped species
- Adds `ReloadRangeFilter()` to BirdNET/Orchestrator that reinitializes just the range filter backend from current settings (holds `bn.mu` for the full operation to prevent races)
- Calls it after install, uninstall, and during startup scan for upgrade scenarios
- Adds logging throughout the geomodel initialization chain for easier debugging
- Extracts `hotLoadAfterInstall` and `sendProgress` helpers to keep cognitive complexity under lint threshold

## Test plan

- [ ] Build succeeds, `golangci-lint` clean, classifier tests pass
- [ ] Deploy to test instance with perch-v2 installed, verify `GET /api/v2/range/status` shows non-zero `mappedSpecies` and `geomodelSpecies: 12012`
- [ ] Verify `GET /api/v2/range/species/scores` returns species with varying scores (not all 1.0)
- [ ] Install a model with geomodel via UI, verify range filter hot-reloads without restart
- [ ] Uninstall the model, verify range filter falls back to TFLite

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exposed ability to reload geographic range filters independently (no full model restart).

* **Improvements**
  * Auto-detect and auto-select compatible geomodels during install/scan/uninstall, persist settings and hot-reload range filter.
  * More detailed diagnostics during model and range-filter startup, including active config, species counts and init durations.
  * Final non-blocking progress update after model install completes.

* **Bug Fixes**
  * Safer range-filter reload with rollback on failure, proper cleanup, and improved status debug logging.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3041)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->