### PR TITLE
feat(classifier): taxonomy-based species name resolver for Perch v2

### DIFF
--- a/internal/classifier/model_catalog.go
+++ b/internal/classifier/model_catalog.go
@@ -3,6 +3,8 @@
 // key via RegistryID and provides download metadata for HuggingFace repos.
 package classifier
 
+import "slices"
+
 // Catalog category constants.
 const (
 	CategoryWildlife = "wildlife"
@@ -72,10 +74,10 @@ var EmbeddedCatalog = []CatalogEntry{
 		Hidden:          true,
 		UpstreamURL:     "https://github.com/birdnet-team/BirdNET-Analyzer",
 		HuggingFaceRepo: "tphakala/BirdNET-v3.0",
-		Files: append(append([]CatalogFile{
+		Files: slices.Concat([]CatalogFile{
 			{RemotePath: "birdnet_v3.0.onnx", LocalName: "birdnet_v3.0.onnx", Role: RoleModel, SHA256: "", SizeBytes: 0},
 			{RemotePath: "labels.txt", LocalName: "birdnet_v3.0_labels.txt", Role: RoleLabels, SHA256: "", SizeBytes: 0},
-		}, geomodelFiles()...), taxonomyFiles()...),
+		}, geomodelFiles(), taxonomyFiles()),
 	},
 	{
 		ID:              "perch-v2",
@@ -92,10 +94,10 @@ var EmbeddedCatalog = []CatalogEntry{
 		RegistryID:      RegistryIDPerchV2,
 		UpstreamURL:     "https://www.kaggle.com/models/google/bird-vocalization-classifier/tensorFlow2/perch_v2",
 		HuggingFaceRepo: "tphakala/Perch-v2",
-		Files: append(append([]CatalogFile{
+		Files: slices.Concat([]CatalogFile{
 			{RemotePath: "perch_v2.onnx", LocalName: "perch_v2.onnx", Role: RoleModel, SHA256: "bf0c8467a924cb074663970ca4a0ab1e143602121930209657d0dff5d5cefa1f", SizeBytes: 409148616},
 			{RemotePath: "labels.txt", LocalName: "perch_v2_labels.txt", Role: RoleLabels, SHA256: "e4d5c0397d8fb08bf90c6b13a34810af53504faad927e472fcc567793c9de057", SizeBytes: 312716},
-		}, geomodelFiles()...), taxonomyFiles()...),
+		}, geomodelFiles(), taxonomyFiles()),
 	},
 	{
 		ID:              "bsg-finland",

--- a/internal/classifier/model_catalog.go
+++ b/internal/classifier/model_catalog.go
@@ -18,6 +18,7 @@ const (
 	RoleGeomodelModel  = "geomodel_model"
 	RoleGeomodelLabels = "geomodel_labels"
 	RoleData           = "data"
+	RoleTaxonomy       = "taxonomy"
 )
 
 // CatalogEntry describes a downloadable model available in the model gallery.
@@ -71,10 +72,10 @@ var EmbeddedCatalog = []CatalogEntry{
 		Hidden:          true,
 		UpstreamURL:     "https://github.com/birdnet-team/BirdNET-Analyzer",
 		HuggingFaceRepo: "tphakala/BirdNET-v3.0",
-		Files: append([]CatalogFile{
+		Files: append(append([]CatalogFile{
 			{RemotePath: "birdnet_v3.0.onnx", LocalName: "birdnet_v3.0.onnx", Role: RoleModel, SHA256: "", SizeBytes: 0},
 			{RemotePath: "labels.txt", LocalName: "birdnet_v3.0_labels.txt", Role: RoleLabels, SHA256: "", SizeBytes: 0},
-		}, geomodelFiles()...),
+		}, geomodelFiles()...), taxonomyFiles()...),
 	},
 	{
 		ID:              "perch-v2",
@@ -91,10 +92,10 @@ var EmbeddedCatalog = []CatalogEntry{
 		RegistryID:      RegistryIDPerchV2,
 		UpstreamURL:     "https://www.kaggle.com/models/google/bird-vocalization-classifier/tensorFlow2/perch_v2",
 		HuggingFaceRepo: "tphakala/Perch-v2",
-		Files: append([]CatalogFile{
+		Files: append(append([]CatalogFile{
 			{RemotePath: "perch_v2.onnx", LocalName: "perch_v2.onnx", Role: RoleModel, SHA256: "bf0c8467a924cb074663970ca4a0ab1e143602121930209657d0dff5d5cefa1f", SizeBytes: 409148616},
 			{RemotePath: "labels.txt", LocalName: "perch_v2_labels.txt", Role: RoleLabels, SHA256: "e4d5c0397d8fb08bf90c6b13a34810af53504faad927e472fcc567793c9de057", SizeBytes: 312716},
-		}, geomodelFiles()...),
+		}, geomodelFiles()...), taxonomyFiles()...),
 	},
 	{
 		ID:              "bsg-finland",
@@ -160,6 +161,30 @@ const (
 	geomodelLabelsSizeBytes int64 = 479350
 )
 
+// Shared taxonomy.csv from BirdNET v3.0, provides common names in 29 languages
+// for ~13,361 species. Used as fallback name resolver for Perch v2 and other
+// models whose labels contain only scientific names.
+const (
+	taxonomyHuggingFaceRepo       = "tphakala/BirdNET-Geomodel"
+	taxonomySHA256                = "74e4b31d2f9c56fbd1a45d980591654f508c73fc4a153cab52f11367a078ddfd"
+	taxonomySizeBytes       int64 = 9162669
+)
+
+// taxonomyFiles returns the shared taxonomy CatalogFile entry appended to
+// classifiers that benefit from multilingual common name resolution.
+func taxonomyFiles() []CatalogFile {
+	return []CatalogFile{
+		{
+			RemotePath:      "taxonomy.csv",
+			LocalName:       "taxonomy.csv",
+			Role:            RoleTaxonomy,
+			SHA256:          taxonomySHA256,
+			SizeBytes:       taxonomySizeBytes,
+			HuggingFaceRepo: taxonomyHuggingFaceRepo,
+		},
+	}
+}
+
 // geomodelFiles returns the shared geomodel CatalogFile entries appended to
 // classifiers that use the v3.0 range filter (Perch v2, BirdNET v3.0).
 func geomodelFiles() []CatalogFile {
@@ -186,6 +211,21 @@ func geomodelFiles() []CatalogFile {
 // isGeomodelRole reports whether the given file role is a geomodel role.
 func isGeomodelRole(role string) bool {
 	return role == RoleGeomodelModel || role == RoleGeomodelLabels
+}
+
+// isSharedRole reports whether the given file role stores into models/shared/.
+func isSharedRole(role string) bool {
+	return role == RoleEmbeddings || role == RoleTaxonomy || isGeomodelRole(role)
+}
+
+// HasTaxonomyFiles reports whether a catalog entry includes shared taxonomy files.
+func HasTaxonomyFiles(entry *CatalogEntry) bool {
+	for _, f := range entry.Files {
+		if f.Role == RoleTaxonomy {
+			return true
+		}
+	}
+	return false
 }
 
 // HasGeomodelFiles reports whether a catalog entry includes shared geomodel files.

--- a/internal/classifier/model_manager.go
+++ b/internal/classifier/model_manager.go
@@ -423,9 +423,10 @@ func (mm *ModelManager) Uninstall(catalogID string) error {
 		}
 	}
 
-	// Clean up shared embeddings and geomodel files if no other dependent models remain.
+	// Clean up shared embeddings, geomodel, and taxonomy files if no other dependent models remain.
 	mm.cleanupSharedEmbeddings(log, catalogID, &entry)
 	mm.cleanupSharedGeomodel(log, catalogID, &entry)
+	mm.cleanupSharedTaxonomy(log, catalogID, &entry)
 
 	// Labels are intentionally retained on disk.
 
@@ -510,6 +511,40 @@ func (mm *ModelManager) cleanupSharedGeomodel(log logger.Logger, catalogID strin
 					logger.Error(err))
 			} else if err == nil {
 				log.Info("Removed shared geomodel file",
+					logger.String("path", path))
+			}
+		}
+	}
+}
+
+// cleanupSharedTaxonomy removes shared taxonomy files when uninstalling a
+// model with taxonomy dependencies, but only if no other taxonomy-dependent
+// model remains installed. The caller must hold mm.mu, and catalogID must
+// still be in mm.installed.
+func (mm *ModelManager) cleanupSharedTaxonomy(log logger.Logger, catalogID string, entry *CatalogEntry) {
+	if !HasTaxonomyFiles(entry) {
+		return
+	}
+	for id := range mm.installed {
+		if id == catalogID {
+			continue
+		}
+		other, found := GetCatalogEntry(id)
+		if found && HasTaxonomyFiles(&other) {
+			log.Debug("Retaining shared taxonomy files; other dependent models still installed",
+				logger.String("catalog_id", catalogID))
+			return
+		}
+	}
+	for _, f := range entry.Files {
+		if f.Role == RoleTaxonomy {
+			path := filepath.Join(mm.modelsDir, "shared", f.LocalName)
+			if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+				log.Warn("Failed to remove taxonomy file",
+					logger.String("path", path),
+					logger.Error(err))
+			} else if err == nil {
+				log.Info("Removed shared taxonomy file",
 					logger.String("path", path))
 			}
 		}
@@ -634,9 +669,9 @@ func (mm *ModelManager) downloadModelFiles(entry *CatalogEntry, baseURL string, 
 	}
 
 	// fileDestPath returns the local destination for a catalog file.
-	// Shared files (embeddings, geomodel) are stored in a common directory.
+	// Shared files (embeddings, geomodel, taxonomy) are stored in a common directory.
 	fileDestPath := func(f CatalogFile) string {
-		if f.Role == RoleEmbeddings || isGeomodelRole(f.Role) {
+		if isSharedRole(f.Role) {
 			return filepath.Join(mm.modelsDir, "shared", f.LocalName)
 		}
 		return filepath.Join(subdir, f.LocalName)

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -113,20 +113,24 @@ func (o *Orchestrator) SetModelsDir(dir string) {
 // directory and, if present, appends a TaxonomyResolver to the name
 // resolver chain. This provides multilingual common name resolution for
 // species not covered by BirdNET's label files.
+//
+// Called during initialization before inference goroutines start, so the
+// unsynchronized append to nameResolvers is safe.
 func (o *Orchestrator) registerTaxonomyResolver(modelsDir string) {
-	log := GetLogger()
-	taxonomyPath := filepath.Join(modelsDir, "shared", "taxonomy.csv")
-
-	if _, err := os.Stat(taxonomyPath); err != nil {
+	if o.Settings == nil {
 		return
 	}
+	log := GetLogger()
+	taxonomyPath := filepath.Join(modelsDir, "shared", "taxonomy.csv")
 
 	locale := o.Settings.BirdNET.Locale
 	resolver, err := NewTaxonomyResolver(taxonomyPath, locale)
 	if err != nil {
-		log.Warn("Failed to load taxonomy resolver",
-			logger.String("path", taxonomyPath),
-			logger.Error(err))
+		if !os.IsNotExist(err) {
+			log.Warn("Failed to load taxonomy resolver",
+				logger.String("path", taxonomyPath),
+				logger.Error(err))
+		}
 		return
 	}
 

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -120,6 +120,13 @@ func (o *Orchestrator) registerTaxonomyResolver(modelsDir string) {
 	if o.Settings == nil {
 		return
 	}
+
+	for _, r := range o.nameResolvers {
+		if _, ok := r.(*TaxonomyResolver); ok {
+			return
+		}
+	}
+
 	log := GetLogger()
 	taxonomyPath := filepath.Join(modelsDir, "shared", "taxonomy.csv")
 

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -99,12 +99,42 @@ func NewOrchestrator(settings *conf.Settings) (*Orchestrator, error) {
 // Called by ModelManager after creation so model loaders can resolve
 // paths from the installed models directory when config paths are empty.
 // Also propagates the directory to the primary BirdNET instance for
-// geomodel auto-selection.
+// geomodel auto-selection, and registers the taxonomy resolver if
+// taxonomy.csv is available on disk.
 func (o *Orchestrator) SetModelsDir(dir string) {
 	o.modelsDir = dir
 	if o.primary != nil {
 		o.primary.SetModelsDir(dir)
 	}
+	o.registerTaxonomyResolver(dir)
+}
+
+// registerTaxonomyResolver checks for taxonomy.csv in the shared models
+// directory and, if present, appends a TaxonomyResolver to the name
+// resolver chain. This provides multilingual common name resolution for
+// species not covered by BirdNET's label files.
+func (o *Orchestrator) registerTaxonomyResolver(modelsDir string) {
+	log := GetLogger()
+	taxonomyPath := filepath.Join(modelsDir, "shared", "taxonomy.csv")
+
+	if _, err := os.Stat(taxonomyPath); err != nil {
+		return
+	}
+
+	locale := o.Settings.BirdNET.Locale
+	resolver, err := NewTaxonomyResolver(taxonomyPath, locale)
+	if err != nil {
+		log.Warn("Failed to load taxonomy resolver",
+			logger.String("path", taxonomyPath),
+			logger.Error(err))
+		return
+	}
+
+	o.nameResolvers = append(o.nameResolvers, resolver)
+	log.Info("Taxonomy resolver registered",
+		logger.String("path", taxonomyPath),
+		logger.String("locale", locale),
+		logger.Int("species", len(resolver.index)))
 }
 
 // resolveInstalledPaths looks up catalog entries for the given registry ID

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -298,12 +298,12 @@ func (o *Orchestrator) GetSpeciesWithScientificAndCommonName(label string) (scie
 // EnrichResultWithTaxonomy adds taxonomy information to a detection result.
 // If the primary model cannot resolve a common name (e.g., Perch labels
 // contain only scientific names), the name resolver chain is consulted
-// to map the scientific name to BirdNET's common name.
+// to find a common name (BirdNET labels, then taxonomy.csv).
 func (o *Orchestrator) EnrichResultWithTaxonomy(speciesLabel string) (scientific, common, code string) {
 	scientific, common, code = o.primary.EnrichResultWithTaxonomy(speciesLabel)
 
 	// Perch v2 labels are scientific-name-only. Try the resolver chain
-	// to look up a common name from BirdNET's label database.
+	// to look up a common name.
 	if common == "" && scientific != "" {
 		if resolved := o.ResolveName(scientific, ""); resolved != "" {
 			common = resolved

--- a/internal/classifier/taxonomy_resolver.go
+++ b/internal/classifier/taxonomy_resolver.go
@@ -113,7 +113,7 @@ func (r *TaxonomyResolver) Resolve(scientificName, _ string) string {
 	if r.index == nil {
 		return ""
 	}
-	return r.index[strings.ToLower(scientificName)]
+	return r.index[strings.ToLower(strings.TrimSpace(scientificName))]
 }
 
 // resolveLocaleColumn finds the best column index for the given locale.

--- a/internal/classifier/taxonomy_resolver.go
+++ b/internal/classifier/taxonomy_resolver.go
@@ -1,0 +1,134 @@
+// taxonomy_resolver.go provides multilingual common name resolution using
+// the BirdNET v3.0 geomodel taxonomy.csv, covering ~13,361 species in 29
+// languages plus English.
+package classifier
+
+import (
+	"encoding/csv"
+	"os"
+	"strings"
+)
+
+// taxonomyLocaleColumns maps BirdNET-Go locale codes to taxonomy.csv column
+// names. Locales not listed here fall back to the English "com_name" column.
+var taxonomyLocaleColumns = map[string]string{
+	"bg":    "common_name_bg",
+	"ca":    "common_name_ca",
+	"cs":    "common_name_cs",
+	"da":    "common_name_da",
+	"de":    "common_name_de",
+	"es":    "common_name_es",
+	"et":    "common_name_et",
+	"fi":    "common_name_fi",
+	"fr":    "common_name_fr",
+	"hr":    "common_name_hr",
+	"ja":    "common_name_ja",
+	"lt":    "common_name_lt",
+	"nl":    "common_name_nl",
+	"no":    "common_name_no",
+	"pl":    "common_name_pl",
+	"pt":    "common_name_pt",
+	"pt-br": "common_name_pt",
+	"pt-pt": "common_name_pt_PT",
+	"ru":    "common_name_ru",
+	"sk":    "common_name_sk",
+	"sr":    "common_name_sr",
+	"sv":    "common_name_sv",
+	"tr":    "common_name_tr",
+	"uk":    "common_name_uk",
+	"zh":    "common_name_zh-CN",
+}
+
+// TaxonomyResolver resolves scientific names to common names using the
+// BirdNET v3.0 geomodel taxonomy.csv. The index is built at construction
+// time for the configured locale, with fallback to English common names.
+//
+// Implements NameResolver.
+type TaxonomyResolver struct {
+	index map[string]string
+}
+
+// NewTaxonomyResolver creates a resolver by parsing taxonomyPath for the
+// given locale. If the locale has no dedicated column in taxonomy.csv,
+// English common names (com_name column) are used.
+func NewTaxonomyResolver(taxonomyPath, locale string) (*TaxonomyResolver, error) {
+	f, err := os.Open(taxonomyPath) //nolint:gosec // G304: path from catalog metadata
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+
+	reader := csv.NewReader(f)
+	reader.LazyQuotes = true
+
+	records, err := reader.ReadAll()
+	if err != nil {
+		return nil, err
+	}
+
+	if len(records) < 2 {
+		return &TaxonomyResolver{index: make(map[string]string)}, nil
+	}
+
+	header := records[0]
+
+	sciCol := findColumn(header, "sci_name")
+	if sciCol < 0 {
+		return &TaxonomyResolver{index: make(map[string]string)}, nil
+	}
+
+	nameCol := resolveLocaleColumn(header, locale)
+
+	index := make(map[string]string, len(records)-1)
+	for _, row := range records[1:] {
+		if sciCol >= len(row) || nameCol >= len(row) {
+			continue
+		}
+		sci := strings.ToLower(strings.TrimSpace(row[sciCol]))
+		name := strings.TrimSpace(row[nameCol])
+		if sci != "" && name != "" {
+			index[sci] = name
+		}
+	}
+
+	return &TaxonomyResolver{index: index}, nil
+}
+
+// Resolve returns the common name for a scientific name.
+// The locale parameter is accepted for interface compliance but unused;
+// the locale is selected at construction time.
+func (r *TaxonomyResolver) Resolve(scientificName, _ string) string {
+	if r.index == nil {
+		return ""
+	}
+	return r.index[strings.ToLower(scientificName)]
+}
+
+// resolveLocaleColumn finds the best column index for the given locale.
+// Falls back to the English "com_name" column if no locale-specific column
+// exists.
+func resolveLocaleColumn(header []string, locale string) int {
+	locale = strings.ToLower(locale)
+
+	if colName, ok := taxonomyLocaleColumns[locale]; ok {
+		if idx := findColumn(header, colName); idx >= 0 {
+			return idx
+		}
+	}
+
+	if idx := findColumn(header, "com_name"); idx >= 0 {
+		return idx
+	}
+
+	return 0
+}
+
+// findColumn returns the index of the named column in header, or -1.
+func findColumn(header []string, name string) int {
+	for i, h := range header {
+		if strings.EqualFold(strings.TrimSpace(h), name) {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/classifier/taxonomy_resolver.go
+++ b/internal/classifier/taxonomy_resolver.go
@@ -76,12 +76,12 @@ func NewTaxonomyResolver(taxonomyPath, locale string) (*TaxonomyResolver, error)
 
 	sciCol := findColumn(header, "sci_name")
 	if sciCol < 0 {
-		return &TaxonomyResolver{index: make(map[string]string)}, nil
+		return nil, fmt.Errorf("taxonomy file missing required column 'sci_name'")
 	}
 
 	nameCol := resolveLocaleColumn(header, locale)
 	if nameCol < 0 {
-		return &TaxonomyResolver{index: make(map[string]string)}, nil
+		return nil, fmt.Errorf("taxonomy file missing 'com_name' and locale-specific column for %q", locale)
 	}
 
 	index := make(map[string]string, 14000)

--- a/internal/classifier/taxonomy_resolver.go
+++ b/internal/classifier/taxonomy_resolver.go
@@ -5,8 +5,12 @@ package classifier
 
 import (
 	"encoding/csv"
+	"fmt"
+	"io"
 	"os"
 	"strings"
+
+	"github.com/tphakala/birdnet-go/internal/errors"
 )
 
 // taxonomyLocaleColumns maps BirdNET-Go locale codes to taxonomy.csv column
@@ -50,7 +54,8 @@ type TaxonomyResolver struct {
 
 // NewTaxonomyResolver creates a resolver by parsing taxonomyPath for the
 // given locale. If the locale has no dedicated column in taxonomy.csv,
-// English common names (com_name column) are used.
+// English common names (com_name column) are used. The CSV is streamed
+// row-by-row to avoid loading the entire ~9 MB file into memory.
 func NewTaxonomyResolver(taxonomyPath, locale string) (*TaxonomyResolver, error) {
 	f, err := os.Open(taxonomyPath) //nolint:gosec // G304: path from catalog metadata
 	if err != nil {
@@ -61,16 +66,13 @@ func NewTaxonomyResolver(taxonomyPath, locale string) (*TaxonomyResolver, error)
 	reader := csv.NewReader(f)
 	reader.LazyQuotes = true
 
-	records, err := reader.ReadAll()
-	if err != nil {
-		return nil, err
-	}
-
-	if len(records) < 2 {
+	header, err := reader.Read()
+	if errors.Is(err, io.EOF) {
 		return &TaxonomyResolver{index: make(map[string]string)}, nil
 	}
-
-	header := records[0]
+	if err != nil {
+		return nil, fmt.Errorf("reading taxonomy header: %w", err)
+	}
 
 	sciCol := findColumn(header, "sci_name")
 	if sciCol < 0 {
@@ -78,9 +80,19 @@ func NewTaxonomyResolver(taxonomyPath, locale string) (*TaxonomyResolver, error)
 	}
 
 	nameCol := resolveLocaleColumn(header, locale)
+	if nameCol < 0 {
+		return &TaxonomyResolver{index: make(map[string]string)}, nil
+	}
 
-	index := make(map[string]string, len(records)-1)
-	for _, row := range records[1:] {
+	index := make(map[string]string, 14000)
+	for {
+		row, readErr := reader.Read()
+		if errors.Is(readErr, io.EOF) {
+			break
+		}
+		if readErr != nil {
+			return nil, fmt.Errorf("reading taxonomy row: %w", readErr)
+		}
 		if sciCol >= len(row) || nameCol >= len(row) {
 			continue
 		}
@@ -106,7 +118,7 @@ func (r *TaxonomyResolver) Resolve(scientificName, _ string) string {
 
 // resolveLocaleColumn finds the best column index for the given locale.
 // Falls back to the English "com_name" column if no locale-specific column
-// exists.
+// exists. Returns -1 if neither is found.
 func resolveLocaleColumn(header []string, locale string) int {
 	locale = strings.ToLower(locale)
 
@@ -116,11 +128,7 @@ func resolveLocaleColumn(header []string, locale string) int {
 		}
 	}
 
-	if idx := findColumn(header, "com_name"); idx >= 0 {
-		return idx
-	}
-
-	return 0
+	return findColumn(header, "com_name")
 }
 
 // findColumn returns the index of the named column in header, or -1.

--- a/internal/classifier/taxonomy_resolver_test.go
+++ b/internal/classifier/taxonomy_resolver_test.go
@@ -1,0 +1,140 @@
+package classifier
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Compile-time check that TaxonomyResolver implements NameResolver.
+var _ NameResolver = (*TaxonomyResolver)(nil)
+
+const testTaxonomyCSV = `idx,sci_name,com_name,species_code,class_name,common_name_de,common_name_fi,common_name_fr,common_name_zh-CN,common_name_pt_PT
+0,Struthio camelus,Common Ostrich,ostric2,Aves,Afrikanischer Strauß,Afrikkanstrutssi,Autruche d'Afrique,鸵鸟,Avestruz-comum
+1,Dromaius novaehollandiae,Emu,emu1,Aves,Emu,Emu,Émeu d'Australie,鸸鹋,Emu
+2,Apteryx mantelli,North Island Brown Kiwi,nibkiw1,Aves,Nördlicher Streifenkiwi,Pohjanruskokiivi,Kiwi austral,北岛褐几维,Quivi-castanho
+3,Tinamus major,Great Tinamou,gretia1,Aves,Großtinamu,Isotinami,Grand Tinamou,大共鸟,Macuco
+`
+
+func writeTaxonomyFixture(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "taxonomy.csv")
+	require.NoError(t, os.WriteFile(path, []byte(testTaxonomyCSV), 0o644))
+	return path
+}
+
+func TestTaxonomyResolver_EnglishDefault(t *testing.T) {
+	t.Parallel()
+	path := writeTaxonomyFixture(t)
+
+	resolver, err := NewTaxonomyResolver(path, "en-uk")
+	require.NoError(t, err)
+
+	assert.Equal(t, "Common Ostrich", resolver.Resolve("Struthio camelus", ""))
+	assert.Equal(t, "Emu", resolver.Resolve("Dromaius novaehollandiae", ""))
+	assert.Equal(t, "North Island Brown Kiwi", resolver.Resolve("Apteryx mantelli", ""))
+}
+
+func TestTaxonomyResolver_GermanLocale(t *testing.T) {
+	t.Parallel()
+	path := writeTaxonomyFixture(t)
+
+	resolver, err := NewTaxonomyResolver(path, "de")
+	require.NoError(t, err)
+
+	assert.Equal(t, "Afrikanischer Strauß", resolver.Resolve("Struthio camelus", ""))
+	assert.Equal(t, "Emu", resolver.Resolve("Dromaius novaehollandiae", ""))
+	assert.Equal(t, "Großtinamu", resolver.Resolve("Tinamus major", ""))
+}
+
+func TestTaxonomyResolver_FinnishLocale(t *testing.T) {
+	t.Parallel()
+	path := writeTaxonomyFixture(t)
+
+	resolver, err := NewTaxonomyResolver(path, "fi")
+	require.NoError(t, err)
+
+	assert.Equal(t, "Afrikkanstrutssi", resolver.Resolve("Struthio camelus", ""))
+	assert.Equal(t, "Isotinami", resolver.Resolve("Tinamus major", ""))
+}
+
+func TestTaxonomyResolver_ChineseLocale(t *testing.T) {
+	t.Parallel()
+	path := writeTaxonomyFixture(t)
+
+	resolver, err := NewTaxonomyResolver(path, "zh")
+	require.NoError(t, err)
+
+	assert.Equal(t, "鸵鸟", resolver.Resolve("Struthio camelus", ""))
+	assert.Equal(t, "鸸鹋", resolver.Resolve("Dromaius novaehollandiae", ""))
+}
+
+func TestTaxonomyResolver_PortuguesePortugal(t *testing.T) {
+	t.Parallel()
+	path := writeTaxonomyFixture(t)
+
+	resolver, err := NewTaxonomyResolver(path, "pt-pt")
+	require.NoError(t, err)
+
+	assert.Equal(t, "Avestruz-comum", resolver.Resolve("Struthio camelus", ""))
+	assert.Equal(t, "Quivi-castanho", resolver.Resolve("Apteryx mantelli", ""))
+}
+
+func TestTaxonomyResolver_FallbackToEnglish(t *testing.T) {
+	t.Parallel()
+	path := writeTaxonomyFixture(t)
+
+	resolver, err := NewTaxonomyResolver(path, "ar")
+	require.NoError(t, err)
+
+	assert.Equal(t, "Common Ostrich", resolver.Resolve("Struthio camelus", ""),
+		"unsupported locale should fall back to English com_name")
+}
+
+func TestTaxonomyResolver_CaseInsensitive(t *testing.T) {
+	t.Parallel()
+	path := writeTaxonomyFixture(t)
+
+	resolver, err := NewTaxonomyResolver(path, "en-uk")
+	require.NoError(t, err)
+
+	assert.Equal(t, "Emu", resolver.Resolve("dromaius novaehollandiae", ""))
+	assert.Equal(t, "Emu", resolver.Resolve("DROMAIUS NOVAEHOLLANDIAE", ""))
+}
+
+func TestTaxonomyResolver_MissingSpecies(t *testing.T) {
+	t.Parallel()
+	path := writeTaxonomyFixture(t)
+
+	resolver, err := NewTaxonomyResolver(path, "en-uk")
+	require.NoError(t, err)
+
+	assert.Empty(t, resolver.Resolve("Nonexistent species", ""))
+}
+
+func TestTaxonomyResolver_EmptyCSV(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "empty.csv")
+	require.NoError(t, os.WriteFile(path, []byte(""), 0o644))
+
+	resolver, err := NewTaxonomyResolver(path, "en-uk")
+	require.NoError(t, err)
+	assert.Empty(t, resolver.Resolve("Anything", ""))
+}
+
+func TestTaxonomyResolver_NilIndex(t *testing.T) {
+	t.Parallel()
+	resolver := &TaxonomyResolver{}
+	assert.Empty(t, resolver.Resolve("Struthio camelus", ""))
+}
+
+func TestTaxonomyResolver_MissingFile(t *testing.T) {
+	t.Parallel()
+	_, err := NewTaxonomyResolver("/nonexistent/path/taxonomy.csv", "en-uk")
+	assert.Error(t, err)
+}


### PR DESCRIPTION
## Summary

- Add `TaxonomyResolver` that uses BirdNET v3.0 geomodel `taxonomy.csv` (~13,361 species, 29 languages + English) as a fallback name resolver after `BirdNETLabelResolver`
- Increases Perch v2 common name coverage from 42% to ~85%
- taxonomy.csv is downloaded as a shared companion file alongside geomodel ONNX and labels from `tphakala/BirdNET-Geomodel` HuggingFace repo
- CSV is streamed row-by-row (not ReadAll) to avoid ~30MB allocation spike
- Supports 24 locale mappings with automatic fallback to English `com_name` column
- Resolver chain: BirdNET labels (priority) -> taxonomy.csv (fallback)
- Graceful degradation: resolver only registers if taxonomy.csv exists on disk

## Changes

- `model_catalog.go`: `RoleTaxonomy` constant, `taxonomyFiles()` helper, `isSharedRole()`, `HasTaxonomyFiles()`, `slices.Concat` for catalog file assembly
- `model_manager.go`: `isSharedRole` routing in `fileDestPath`, `cleanupSharedTaxonomy()` for uninstall cleanup
- `orchestrator.go`: `registerTaxonomyResolver()` called from `SetModelsDir()`, updated `EnrichResultWithTaxonomy` comment
- `taxonomy_resolver.go`: New file - streaming CSV parser, locale column mapping, `NameResolver` interface implementation
- `taxonomy_resolver_test.go`: 11 tests covering locale selection, fallback, case-insensitivity, edge cases

## Test Plan

- [x] 11 unit tests pass with `-race` (locale selection, English fallback, case-insensitive matching, missing species, empty CSV, nil index, missing file)
- [x] All 45 related classifier tests pass (taxonomy + BirdNET labels + catalog + model manager)
- [x] `golangci-lint run -v` reports zero issues
- [x] Compile-time `NameResolver` interface check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Taxonomy support added for BirdNET v3.0 and Perch v2 models.
  * Multi-locale common-name resolution (EN, DE, FI, ZH, PT-PT) with fallback to English.
  * Runtime registration of a taxonomy resolver when taxonomy data is present.

* **Bug Fixes / Improvements**
  * Taxonomy files treated as shared model assets and cleaned up when no installed model needs them.
  * Download/install logic stores taxonomy alongside other shared files.

* **Tests**
  * Added comprehensive tests for taxonomy resolution and edge cases.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3042)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->