### PR TITLE
fix(classifier): SHA256 guard, unified cleanup, context downloads, loader map

### DIFF
--- a/internal/api/v2/models.go
+++ b/internal/api/v2/models.go
@@ -181,7 +181,7 @@ func (c *Controller) InstallModel(ctx echo.Context) error {
 				)
 			}
 		}()
-		if err := c.ModelManager.Install(&entry, "", progressChan); err != nil {
+		if err := c.ModelManager.Install(c.ctx, &entry, "", progressChan); err != nil {
 			c.logErrorIfEnabled("Model install failed",
 				logger.String("catalog_id", catalogID),
 				logger.Error(err),
@@ -232,7 +232,7 @@ func (c *Controller) ReinstallModel(ctx echo.Context) error {
 				)
 			}
 		}()
-		if err := c.ModelManager.Reinstall(&entry, "", progressChan); err != nil {
+		if err := c.ModelManager.Reinstall(c.ctx, &entry, "", progressChan); err != nil {
 			c.logErrorIfEnabled("Model reinstall failed",
 				logger.String("catalog_id", catalogID),
 				logger.Error(err),

--- a/internal/classifier/model_catalog.go
+++ b/internal/classifier/model_catalog.go
@@ -210,10 +210,16 @@ func geomodelFiles() []CatalogFile {
 	}
 }
 
+// isEmbeddingsRole reports whether the given file role is an embeddings role.
+func isEmbeddingsRole(role string) bool { return role == RoleEmbeddings }
+
 // isGeomodelRole reports whether the given file role is a geomodel role.
 func isGeomodelRole(role string) bool {
 	return role == RoleGeomodelModel || role == RoleGeomodelLabels
 }
+
+// isTaxonomyRole reports whether the given file role is a taxonomy role.
+func isTaxonomyRole(role string) bool { return role == RoleTaxonomy }
 
 // isSharedRole reports whether the given file role stores into models/shared/.
 func isSharedRole(role string) bool {
@@ -234,6 +240,16 @@ func HasTaxonomyFiles(entry *CatalogEntry) bool {
 func HasGeomodelFiles(entry *CatalogEntry) bool {
 	for _, f := range entry.Files {
 		if isGeomodelRole(f.Role) {
+			return true
+		}
+	}
+	return false
+}
+
+// HasEmbeddingsFiles reports whether a catalog entry includes shared embeddings files.
+func HasEmbeddingsFiles(entry *CatalogEntry) bool {
+	for _, f := range entry.Files {
+		if f.Role == RoleEmbeddings {
 			return true
 		}
 	}

--- a/internal/classifier/model_manager.go
+++ b/internal/classifier/model_manager.go
@@ -7,6 +7,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"hash"
 	"io"
 	"maps"
 	"net/http"
@@ -1055,7 +1056,7 @@ func (mm *ModelManager) downloadFile(ctx context.Context, catalogID, url, destPa
 	if err != nil {
 		return errors.Newf("failed to create request for %s: %v", url, err).
 			Component("classifier.model_manager").
-			Category(errors.CategoryNetwork).
+			Category(errors.CategoryValidation).
 			Context("url", url).
 			Build()
 	}
@@ -1078,8 +1079,14 @@ func (mm *ModelManager) downloadFile(ctx context.Context, catalogID, url, destPa
 			Build()
 	}
 
-	hasher := sha256.New()
-	reader := io.TeeReader(resp.Body, hasher)
+	var hasher hash.Hash
+	var reader io.Reader
+	if expectedSHA256 != "" {
+		hasher = sha256.New()
+		reader = io.TeeReader(resp.Body, hasher)
+	} else {
+		reader = resp.Body
+	}
 
 	var downloaded int64
 	var lastReport int64

--- a/internal/classifier/model_manager.go
+++ b/internal/classifier/model_manager.go
@@ -3,6 +3,7 @@
 package classifier
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
@@ -424,9 +425,9 @@ func (mm *ModelManager) Uninstall(catalogID string) error {
 	}
 
 	// Clean up shared embeddings, geomodel, and taxonomy files if no other dependent models remain.
-	mm.cleanupSharedEmbeddings(log, catalogID, &entry)
-	mm.cleanupSharedGeomodel(log, catalogID, &entry)
-	mm.cleanupSharedTaxonomy(log, catalogID, &entry)
+	mm.cleanupSharedFiles(log, catalogID, &entry, HasEmbeddingsFiles, isEmbeddingsRole, "embeddings")
+	mm.cleanupSharedFiles(log, catalogID, &entry, HasGeomodelFiles, isGeomodelRole, "geomodel")
+	mm.cleanupSharedFiles(log, catalogID, &entry, HasTaxonomyFiles, isTaxonomyRole, "taxonomy")
 
 	// Labels are intentionally retained on disk.
 
@@ -450,11 +451,14 @@ func (mm *ModelManager) Uninstall(catalogID string) error {
 	return nil
 }
 
-// cleanupSharedEmbeddings removes shared embeddings files when uninstalling a
-// bat model, but only if no other bat model remains installed. The caller must
-// hold mm.mu, and catalogID must still be in mm.installed.
-func (mm *ModelManager) cleanupSharedEmbeddings(log logger.Logger, catalogID string, entry *CatalogEntry) {
-	if entry.Category != CategoryBat {
+// cleanupSharedFiles removes shared files of a given kind when uninstalling
+// a model, but only if no other installed or currently-downloading model
+// depends on the same files.
+// hasFiles checks whether a catalog entry depends on this kind of shared file.
+// matchRole checks whether a CatalogFile belongs to this kind.
+// The caller must hold mm.mu, and catalogID must still be in mm.installed.
+func (mm *ModelManager) cleanupSharedFiles(log logger.Logger, catalogID string, entry *CatalogEntry, hasFiles func(*CatalogEntry) bool, matchRole func(string) bool, label string) {
+	if !hasFiles(entry) {
 		return
 	}
 	for id := range mm.installed {
@@ -462,89 +466,33 @@ func (mm *ModelManager) cleanupSharedEmbeddings(log logger.Logger, catalogID str
 			continue
 		}
 		other, found := GetCatalogEntry(id)
-		if found && other.Category == CategoryBat {
-			log.Debug("Retaining shared embeddings; other bat models still installed",
+		if found && hasFiles(&other) {
+			log.Debug("Retaining shared "+label+" files; other dependent models still installed",
 				logger.String("catalog_id", catalogID))
 			return
 		}
 	}
-	for _, f := range entry.Files {
-		if f.Role == RoleEmbeddings {
-			path := filepath.Join(mm.modelsDir, "shared", f.LocalName)
-			if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
-				log.Warn("Failed to remove embeddings file",
-					logger.String("path", path),
-					logger.Error(err))
-			} else if err == nil {
-				log.Info("Removed shared embeddings file",
-					logger.String("path", path))
-			}
-		}
-	}
-}
-
-// cleanupSharedGeomodel removes shared geomodel files when uninstalling a
-// model with geomodel dependencies, but only if no other geomodel-dependent
-// model remains installed. The caller must hold mm.mu, and catalogID must
-// still be in mm.installed.
-func (mm *ModelManager) cleanupSharedGeomodel(log logger.Logger, catalogID string, entry *CatalogEntry) {
-	if !HasGeomodelFiles(entry) {
-		return
-	}
-	for id := range mm.installed {
+	for id := range mm.downloading {
 		if id == catalogID {
 			continue
 		}
 		other, found := GetCatalogEntry(id)
-		if found && HasGeomodelFiles(&other) {
-			log.Debug("Retaining shared geomodel files; other dependent models still installed",
-				logger.String("catalog_id", catalogID))
+		if found && hasFiles(&other) {
+			log.Debug("Retaining shared "+label+" files; another model is downloading",
+				logger.String("catalog_id", catalogID),
+				logger.String("downloading_id", id))
 			return
 		}
 	}
 	for _, f := range entry.Files {
-		if isGeomodelRole(f.Role) {
+		if matchRole(f.Role) {
 			path := filepath.Join(mm.modelsDir, "shared", f.LocalName)
 			if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
-				log.Warn("Failed to remove geomodel file",
+				log.Warn("Failed to remove "+label+" file",
 					logger.String("path", path),
 					logger.Error(err))
 			} else if err == nil {
-				log.Info("Removed shared geomodel file",
-					logger.String("path", path))
-			}
-		}
-	}
-}
-
-// cleanupSharedTaxonomy removes shared taxonomy files when uninstalling a
-// model with taxonomy dependencies, but only if no other taxonomy-dependent
-// model remains installed. The caller must hold mm.mu, and catalogID must
-// still be in mm.installed.
-func (mm *ModelManager) cleanupSharedTaxonomy(log logger.Logger, catalogID string, entry *CatalogEntry) {
-	if !HasTaxonomyFiles(entry) {
-		return
-	}
-	for id := range mm.installed {
-		if id == catalogID {
-			continue
-		}
-		other, found := GetCatalogEntry(id)
-		if found && HasTaxonomyFiles(&other) {
-			log.Debug("Retaining shared taxonomy files; other dependent models still installed",
-				logger.String("catalog_id", catalogID))
-			return
-		}
-	}
-	for _, f := range entry.Files {
-		if f.Role == RoleTaxonomy {
-			path := filepath.Join(mm.modelsDir, "shared", f.LocalName)
-			if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
-				log.Warn("Failed to remove taxonomy file",
-					logger.String("path", path),
-					logger.Error(err))
-			} else if err == nil {
-				log.Info("Removed shared taxonomy file",
+				log.Info("Removed shared "+label+" file",
 					logger.String("path", path))
 			}
 		}
@@ -555,7 +503,7 @@ func (mm *ModelManager) cleanupSharedTaxonomy(log logger.Logger, catalogID strin
 // The baseURL parameter overrides the HuggingFace URL for testing; pass an
 // empty string to use the default HuggingFace URL constructed from the entry's
 // repo. Progress is reported via the channel if non-nil.
-func (mm *ModelManager) Install(entry *CatalogEntry, baseURL string, progress chan<- DownloadState) error {
+func (mm *ModelManager) Install(ctx context.Context, entry *CatalogEntry, baseURL string, progress chan<- DownloadState) error {
 	// Check if already installed or already downloading.
 	mm.mu.Lock()
 	if _, ok := mm.installed[entry.ID]; ok {
@@ -582,7 +530,7 @@ func (mm *ModelManager) Install(entry *CatalogEntry, baseURL string, progress ch
 	}
 	mm.mu.Unlock()
 
-	if err := mm.downloadModelFiles(entry, baseURL, progress, true); err != nil {
+	if err := mm.downloadModelFiles(ctx, entry, baseURL, progress, true); err != nil {
 		// Keep failed state briefly for SSE pollers, then clean up.
 		time.AfterFunc(failedStateRetention, func() {
 			mm.removeDownloading(entry.ID)
@@ -597,7 +545,7 @@ func (mm *ModelManager) Install(entry *CatalogEntry, baseURL string, progress ch
 // Files that pass SHA256 validation are skipped. The baseURL parameter overrides
 // the HuggingFace URL for testing; pass an empty string to use the default.
 // Progress is reported via the channel if non-nil.
-func (mm *ModelManager) Reinstall(entry *CatalogEntry, baseURL string, progress chan<- DownloadState) error {
+func (mm *ModelManager) Reinstall(ctx context.Context, entry *CatalogEntry, baseURL string, progress chan<- DownloadState) error {
 	// Check that the model IS installed (opposite of Install's guard).
 	mm.mu.Lock()
 	if _, ok := mm.installed[entry.ID]; !ok {
@@ -624,7 +572,7 @@ func (mm *ModelManager) Reinstall(entry *CatalogEntry, baseURL string, progress 
 	}
 	mm.mu.Unlock()
 
-	if err := mm.downloadModelFiles(entry, baseURL, progress, false); err != nil {
+	if err := mm.downloadModelFiles(ctx, entry, baseURL, progress, false); err != nil {
 		// Keep failed state briefly for SSE pollers, then clean up.
 		time.AfterFunc(failedStateRetention, func() {
 			mm.removeDownloading(entry.ID)
@@ -643,7 +591,7 @@ func (mm *ModelManager) Reinstall(entry *CatalogEntry, baseURL string, progress 
 // When cleanupOnFailure is true (Install), newly downloaded files are removed
 // on failure. When false (Reinstall), repaired files are kept so partial
 // progress is not lost.
-func (mm *ModelManager) downloadModelFiles(entry *CatalogEntry, baseURL string, progress chan<- DownloadState, cleanupOnFailure bool) error {
+func (mm *ModelManager) downloadModelFiles(ctx context.Context, entry *CatalogEntry, baseURL string, progress chan<- DownloadState, cleanupOnFailure bool) error {
 	log := GetLogger()
 
 	// Create model subdirectory.
@@ -745,7 +693,7 @@ func (mm *ModelManager) downloadModelFiles(entry *CatalogEntry, baseURL string, 
 		}
 		mm.mu.Unlock()
 
-		if err := mm.downloadFile(entry.ID, url, destPath, f.SHA256, f.SizeBytes, completedBytes); err != nil {
+		if err := mm.downloadFile(ctx, entry.ID, url, destPath, f.SHA256, f.SizeBytes, completedBytes); err != nil {
 			log.Error("Failed to download file",
 				logger.String("catalog_id", entry.ID),
 				logger.String("url", url),
@@ -1072,7 +1020,7 @@ var downloadHTTPClient = &http.Client{
 // polling. completedBytes is the cumulative size of previously downloaded
 // files, used so progress reflects total download, not just the current file.
 // On failure, any temporary file is cleaned up.
-func (mm *ModelManager) downloadFile(catalogID, url, destPath, expectedSHA256 string, totalBytes, completedBytes int64) error {
+func (mm *ModelManager) downloadFile(ctx context.Context, catalogID, url, destPath, expectedSHA256 string, totalBytes, completedBytes int64) error {
 	// Ensure parent directory exists.
 	if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {
 		return errors.Newf("failed to create directory for %s: %v", destPath, err).
@@ -1103,7 +1051,15 @@ func (mm *ModelManager) downloadFile(catalogID, url, destPath, expectedSHA256 st
 		}
 	}()
 
-	resp, err := downloadHTTPClient.Get(url) //nolint:noctx // URL is constructed from catalog metadata, not user input
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
+	if err != nil {
+		return errors.Newf("failed to create request for %s: %v", url, err).
+			Component("classifier.model_manager").
+			Category(errors.CategoryNetwork).
+			Context("url", url).
+			Build()
+	}
+	resp, err := downloadHTTPClient.Do(req)
 	if err != nil {
 		return errors.Newf("HTTP request failed for %s: %v", url, err).
 			Component("classifier.model_manager").
@@ -1166,16 +1122,18 @@ func (mm *ModelManager) downloadFile(catalogID, url, destPath, expectedSHA256 st
 		}
 	}
 
-	// Verify checksum.
-	actualSHA256 := hex.EncodeToString(hasher.Sum(nil))
-	if actualSHA256 != expectedSHA256 {
-		return errors.Newf("checksum mismatch for %s: expected %s, got %s", destPath, expectedSHA256, actualSHA256).
-			Component("classifier.model_manager").
-			Category(errors.CategoryValidation).
-			Context("dest_path", destPath).
-			Context("expected_sha256", expectedSHA256).
-			Context("actual_sha256", actualSHA256).
-			Build()
+	// Verify checksum (skip when the catalog entry has no expected hash).
+	if expectedSHA256 != "" {
+		actualSHA256 := hex.EncodeToString(hasher.Sum(nil))
+		if actualSHA256 != expectedSHA256 {
+			return errors.Newf("checksum mismatch for %s: expected %s, got %s", destPath, expectedSHA256, actualSHA256).
+				Component("classifier.model_manager").
+				Category(errors.CategoryValidation).
+				Context("dest_path", destPath).
+				Context("expected_sha256", expectedSHA256).
+				Context("actual_sha256", actualSHA256).
+				Build()
+		}
 	}
 
 	// Close before rename so the file is flushed.

--- a/internal/classifier/model_manager_test.go
+++ b/internal/classifier/model_manager_test.go
@@ -1,6 +1,7 @@
 package classifier
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"net/http"
@@ -134,7 +135,7 @@ func TestModelManager_UninstallRemovesModelRetainsLabels(t *testing.T) {
 	// Create all catalog files on disk in their expected locations.
 	for _, f := range entry.Files {
 		var dir string
-		if f.Role == RoleEmbeddings || isGeomodelRole(f.Role) {
+		if isSharedRole(f.Role) {
 			dir = filepath.Join(modelsDir, "shared")
 		} else {
 			dir = subdir
@@ -154,7 +155,7 @@ func TestModelManager_UninstallRemovesModelRetainsLabels(t *testing.T) {
 	// shared geomodel files should be gone (no other dependent model installed).
 	for _, f := range entry.Files {
 		var path string
-		if f.Role == RoleEmbeddings || isGeomodelRole(f.Role) {
+		if isSharedRole(f.Role) {
 			path = filepath.Join(modelsDir, "shared", f.LocalName)
 		} else {
 			path = filepath.Join(subdir, f.LocalName)
@@ -167,6 +168,10 @@ func TestModelManager_UninstallRemovesModelRetainsLabels(t *testing.T) {
 			require.NoError(t, err, "labels file %s should be retained", f.LocalName)
 		case isGeomodelRole(f.Role):
 			assert.True(t, os.IsNotExist(err), "geomodel file %s should be deleted when no dependents remain", f.LocalName)
+		case f.Role == RoleEmbeddings:
+			assert.True(t, os.IsNotExist(err), "embeddings file %s should be deleted when no dependents remain", f.LocalName)
+		case f.Role == RoleTaxonomy:
+			assert.True(t, os.IsNotExist(err), "taxonomy file %s should be deleted when no dependents remain", f.LocalName)
 		}
 	}
 }
@@ -204,7 +209,7 @@ func TestModelManager_DownloadFile(t *testing.T) {
 	destPath := filepath.Join(mm.modelsDir, "test-model", "model.onnx")
 
 	mm.downloading["test-download"] = &DownloadState{CatalogID: "test-download", Status: StatusDownloading}
-	err := mm.downloadFile("test-download", srv.URL+"/model.onnx", destPath, checksum, int64(len(content)), 0)
+	err := mm.downloadFile(t.Context(), "test-download", srv.URL+"/model.onnx", destPath, checksum, int64(len(content)), 0)
 	require.NoError(t, err)
 
 	// Verify file was written with correct content.
@@ -238,7 +243,7 @@ func TestModelManager_DownloadFile_BadChecksum(t *testing.T) {
 	destPath := filepath.Join(mm.modelsDir, "bad-checksum", "model.onnx")
 
 	mm.downloading["test-bad-checksum"] = &DownloadState{CatalogID: "test-bad-checksum", Status: StatusDownloading}
-	err := mm.downloadFile("test-bad-checksum", srv.URL+"/model.onnx", destPath, wrongChecksum, int64(len(content)), 0)
+	err := mm.downloadFile(t.Context(), "test-bad-checksum", srv.URL+"/model.onnx", destPath, wrongChecksum, int64(len(content)), 0)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "checksum")
 
@@ -249,6 +254,52 @@ func TestModelManager_DownloadFile_BadChecksum(t *testing.T) {
 	// Verify destination file was not created.
 	_, err = os.Stat(destPath)
 	assert.True(t, os.IsNotExist(err), "destination file should not exist after checksum failure")
+}
+
+func TestModelManager_DownloadFile_EmptySHA256(t *testing.T) {
+	t.Parallel()
+
+	content := []byte("model data without checksum")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(content)
+	}))
+	defer srv.Close()
+
+	mm := NewModelManager(t.TempDir(), nil, nil)
+	destPath := filepath.Join(mm.modelsDir, "no-checksum", "model.onnx")
+
+	mm.downloading["test-no-checksum"] = &DownloadState{CatalogID: "test-no-checksum", Status: StatusDownloading}
+	err := mm.downloadFile(t.Context(), "test-no-checksum", srv.URL+"/model.onnx", destPath, "", int64(len(content)), 0)
+	require.NoError(t, err, "empty expectedSHA256 should skip verification")
+
+	got, err := os.ReadFile(destPath)
+	require.NoError(t, err)
+	assert.Equal(t, content, got)
+}
+
+func TestModelManager_DownloadFile_ContextCancelled(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("data"))
+	}))
+	defer srv.Close()
+
+	mm := NewModelManager(t.TempDir(), nil, nil)
+	destPath := filepath.Join(mm.modelsDir, "cancelled", "model.onnx")
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	mm.downloading["test-cancelled"] = &DownloadState{CatalogID: "test-cancelled", Status: StatusDownloading}
+	err := mm.downloadFile(ctx, "test-cancelled", srv.URL+"/model.onnx", destPath, "", 4, 0)
+	require.Error(t, err, "cancelled context should produce an error")
+
+	_, statErr := os.Stat(destPath)
+	assert.True(t, os.IsNotExist(statErr), "file should not exist after cancelled download")
 }
 
 func TestModelManager_Install(t *testing.T) {
@@ -288,7 +339,7 @@ func TestModelManager_Install(t *testing.T) {
 	mm := NewModelManager(modelsDir, nil, nil)
 
 	progress := make(chan DownloadState, 100)
-	err := mm.Install(&entry, srv.URL, progress)
+	err := mm.Install(t.Context(), &entry, srv.URL, progress)
 	require.NoError(t, err)
 
 	// Verify installed.
@@ -332,7 +383,7 @@ func TestModelManager_Install_AlreadyInstalled(t *testing.T) {
 		Name: "Already Installed",
 	}
 
-	err := mm.Install(&entry, "", nil)
+	err := mm.Install(t.Context(), &entry, "", nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "already installed")
 }
@@ -374,7 +425,7 @@ func TestModelManager_Install_SharedEmbeddings(t *testing.T) {
 	modelsDir := t.TempDir()
 	mm := NewModelManager(modelsDir, nil, nil)
 
-	err := mm.Install(&entry, srv.URL, nil)
+	err := mm.Install(t.Context(), &entry, srv.URL, nil)
 	require.NoError(t, err)
 
 	// Embeddings should be in shared/, not in the model subdirectory.
@@ -411,7 +462,7 @@ func TestModelManager_Install_ConcurrentDownloadRejected(t *testing.T) {
 		Name: "Concurrent Test",
 	}
 
-	err := mm.Install(&entry, "", nil)
+	err := mm.Install(t.Context(), &entry, "", nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "already being downloaded")
 }
@@ -430,7 +481,7 @@ func TestModelManager_UninstallSucceedsWhenModelNotLoaded(t *testing.T) {
 	// Create all catalog files on disk in their expected locations.
 	for _, f := range entry.Files {
 		var dir string
-		if f.Role == RoleEmbeddings || isGeomodelRole(f.Role) {
+		if isSharedRole(f.Role) {
 			dir = filepath.Join(modelsDir, "shared")
 		} else {
 			dir = subdir
@@ -456,7 +507,7 @@ func TestModelManager_UninstallSucceedsWhenModelNotLoaded(t *testing.T) {
 	// Verify per-role file expectations after uninstall.
 	for _, f := range entry.Files {
 		var path string
-		if f.Role == RoleEmbeddings || isGeomodelRole(f.Role) {
+		if isSharedRole(f.Role) {
 			path = filepath.Join(modelsDir, "shared", f.LocalName)
 		} else {
 			path = filepath.Join(subdir, f.LocalName)
@@ -469,6 +520,10 @@ func TestModelManager_UninstallSucceedsWhenModelNotLoaded(t *testing.T) {
 			require.NoError(t, statErr, "labels file %s must be retained after uninstall", f.LocalName)
 		case isGeomodelRole(f.Role):
 			assert.True(t, os.IsNotExist(statErr), "geomodel file %s must be deleted when no dependents remain", f.LocalName)
+		case f.Role == RoleEmbeddings:
+			assert.True(t, os.IsNotExist(statErr), "embeddings file %s must be deleted when no dependents remain", f.LocalName)
+		case f.Role == RoleTaxonomy:
+			assert.True(t, os.IsNotExist(statErr), "taxonomy file %s must be deleted when no dependents remain", f.LocalName)
 		}
 	}
 }
@@ -486,7 +541,7 @@ func TestModelManager_UninstallAbortsOnUnloadFailure(t *testing.T) {
 
 	for _, f := range entry.Files {
 		var dir string
-		if f.Role == RoleEmbeddings || isGeomodelRole(f.Role) {
+		if isSharedRole(f.Role) {
 			dir = filepath.Join(modelsDir, "shared")
 		} else {
 			dir = subdir
@@ -519,7 +574,7 @@ func TestModelManager_UninstallAbortsOnUnloadFailure(t *testing.T) {
 	// All files must still exist on disk.
 	for _, f := range entry.Files {
 		var path string
-		if f.Role == RoleEmbeddings || isGeomodelRole(f.Role) {
+		if isSharedRole(f.Role) {
 			path = filepath.Join(modelsDir, "shared", f.LocalName)
 		} else {
 			path = filepath.Join(subdir, f.LocalName)
@@ -573,7 +628,7 @@ func TestModelManager_Install_SharedGeomodel(t *testing.T) {
 	modelsDir := t.TempDir()
 	mm := NewModelManager(modelsDir, nil, nil)
 
-	err := mm.Install(&entry, srv.URL, nil)
+	err := mm.Install(t.Context(), &entry, srv.URL, nil)
 	require.NoError(t, err)
 
 	// Geomodel files should be in shared/, not in the model subdirectory.
@@ -633,7 +688,7 @@ func TestModelManager_Install_GeomodelSkipsExisting(t *testing.T) {
 	}
 
 	mm := NewModelManager(modelsDir, nil, nil)
-	err := mm.Install(&entry, srv.URL, nil)
+	err := mm.Install(t.Context(), &entry, srv.URL, nil)
 	require.NoError(t, err)
 
 	// The server returns 404 for geomodel.onnx, so if Install tried to
@@ -665,7 +720,7 @@ func TestModelManager_Uninstall_GeomodelRetainedWhenDependentExists(t *testing.T
 		require.NoError(t, os.MkdirAll(subdir, 0o755))
 		for _, f := range entry.Files {
 			var dir string
-			if f.Role == RoleEmbeddings || isGeomodelRole(f.Role) {
+			if isSharedRole(f.Role) {
 				dir = sharedDir
 			} else {
 				dir = subdir
@@ -700,6 +755,49 @@ func TestModelManager_Uninstall_GeomodelRetainedWhenDependentExists(t *testing.T
 			path := filepath.Join(sharedDir, f.LocalName)
 			_, err := os.Stat(path)
 			assert.True(t, os.IsNotExist(err), "geomodel file %s must be deleted when no dependents remain", f.LocalName)
+		}
+	}
+}
+
+func TestModelManager_Uninstall_SharedFilesRetainedWhileDownloading(t *testing.T) {
+	t.Parallel()
+
+	entryPerch, ok := GetCatalogEntry("perch-v2")
+	require.True(t, ok)
+
+	modelsDir := t.TempDir()
+	sharedDir := filepath.Join(modelsDir, "shared")
+	require.NoError(t, os.MkdirAll(sharedDir, 0o755))
+
+	subdir := filepath.Join(modelsDir, entryPerch.ID)
+	require.NoError(t, os.MkdirAll(subdir, 0o755))
+	for _, f := range entryPerch.Files {
+		var dir string
+		if isSharedRole(f.Role) {
+			dir = sharedDir
+		} else {
+			dir = subdir
+		}
+		require.NoError(t, os.WriteFile(filepath.Join(dir, f.LocalName), []byte("data"), 0o644))
+	}
+
+	mm := NewModelManager(modelsDir, nil, nil)
+	mm.ScanInstalled()
+	require.True(t, mm.IsInstalled("perch-v2"))
+
+	// Simulate another geomodel-dependent model downloading concurrently.
+	mm.mu.Lock()
+	mm.downloading["birdnet-v3.0"] = &DownloadState{CatalogID: "birdnet-v3.0", Status: StatusDownloading}
+	mm.mu.Unlock()
+
+	require.NoError(t, mm.Uninstall("perch-v2"))
+
+	// Shared geomodel files must be retained because birdnet-v3.0 is downloading.
+	for _, f := range entryPerch.Files {
+		if isGeomodelRole(f.Role) {
+			path := filepath.Join(sharedDir, f.LocalName)
+			_, err := os.Stat(path)
+			require.NoError(t, err, "geomodel file %s must be retained while another dependent model is downloading", f.LocalName)
 		}
 	}
 }
@@ -784,7 +882,7 @@ func TestModelManager_Install_GeomodelConfigWiring(t *testing.T) {
 	conf.StoreSettings(settings)
 	mm := NewModelManager(modelsDir, nil, settings)
 
-	err := mm.Install(&entry, srv.URL, nil)
+	err := mm.Install(t.Context(), &entry, srv.URL, nil)
 	require.NoError(t, err)
 
 	// Verify range filter config was set.
@@ -842,7 +940,7 @@ func TestModelManager_Uninstall_GeomodelConfigClearing(t *testing.T) {
 	mm := NewModelManager(modelsDir, nil, settings)
 
 	// Install to set config.
-	err := mm.Install(&entry, srv.URL, nil)
+	err := mm.Install(t.Context(), &entry, srv.URL, nil)
 	require.NoError(t, err)
 
 	current := conf.GetSettings()
@@ -1007,7 +1105,7 @@ func TestModelManager_Install_RedownloadsCorruptSharedFile(t *testing.T) {
 	}
 
 	mm := NewModelManager(modelsDir, nil, nil)
-	err := mm.Install(&entry, srv.URL, nil)
+	err := mm.Install(t.Context(), &entry, srv.URL, nil)
 	require.NoError(t, err)
 
 	// Verify the corrupt file was replaced with correct content.
@@ -1063,7 +1161,7 @@ func TestModelManager_Install_GeomodelVersionWiring(t *testing.T) {
 	conf.StoreSettings(settings)
 	mm := NewModelManager(modelsDir, nil, settings)
 
-	err := mm.Install(&entry, srv.URL, nil)
+	err := mm.Install(t.Context(), &entry, srv.URL, nil)
 	require.NoError(t, err)
 
 	current := conf.GetSettings()
@@ -1151,7 +1249,7 @@ func TestModelManager_Reinstall(t *testing.T) {
 	mm := NewModelManager(modelsDir, nil, nil)
 
 	// Install first.
-	err := mm.Install(&entry, srv.URL, nil)
+	err := mm.Install(t.Context(), &entry, srv.URL, nil)
 	require.NoError(t, err)
 	require.True(t, mm.IsInstalled("test-reinstall-model"))
 
@@ -1163,7 +1261,7 @@ func TestModelManager_Reinstall(t *testing.T) {
 
 	// Reinstall should re-download the missing file.
 	progress := make(chan DownloadState, 100)
-	err = mm.Reinstall(&entry, srv.URL, progress)
+	err = mm.Reinstall(t.Context(), &entry, srv.URL, progress)
 	require.NoError(t, err)
 
 	// Verify the model file was re-downloaded with correct content.
@@ -1192,7 +1290,7 @@ func TestModelManager_Reinstall_NotInstalled(t *testing.T) {
 		Name: "Not Installed Model",
 	}
 
-	err := mm.Reinstall(&entry, "", nil)
+	err := mm.Reinstall(t.Context(), &entry, "", nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not installed")
 }
@@ -1234,7 +1332,7 @@ func TestModelManager_Reinstall_SkipsValidFiles(t *testing.T) {
 	mm := NewModelManager(modelsDir, nil, nil)
 
 	// Install first.
-	err := mm.Install(&entry, srv.URL, nil)
+	err := mm.Install(t.Context(), &entry, srv.URL, nil)
 	require.NoError(t, err)
 	require.True(t, mm.IsInstalled("test-reinstall-skip"))
 
@@ -1242,7 +1340,7 @@ func TestModelManager_Reinstall_SkipsValidFiles(t *testing.T) {
 	downloadCount.Store(0)
 
 	// Reinstall without deleting anything; all files should pass SHA256 validation.
-	err = mm.Reinstall(&entry, srv.URL, nil)
+	err = mm.Reinstall(t.Context(), &entry, srv.URL, nil)
 	require.NoError(t, err)
 
 	// No HTTP requests should have been made since all files are valid.

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -439,10 +439,18 @@ func (o *Orchestrator) IsModelLoaded(registryID string) bool {
 	return exists
 }
 
+// modelLoaders maps registry IDs to their loader functions. Models not in
+// this map are recognized but not yet implemented; callers log a warning
+// and skip. Adding a new loader only requires one entry here.
+var modelLoaders = map[string]func(o *Orchestrator, threads int) error{
+	RegistryIDPerchV2: (*Orchestrator).loadPerch,
+	RegistryIDBat:     (*Orchestrator).loadBat,
+}
+
 // LoadModel dynamically loads a model into the Orchestrator at runtime.
 // Called by ModelManager after a successful install. The method delegates
-// to the appropriate model loader (loadPerch, loadBat, etc.) based on
-// the registry ID. Thread-safe.
+// to the appropriate model loader via modelLoaders based on the registry
+// ID. Thread-safe.
 //
 // The write lock is held for the entire load (including I/O-heavy ONNX
 // initialization, typically 1-3 seconds). This briefly blocks inference
@@ -480,6 +488,17 @@ func (o *Orchestrator) LoadModel(registryID string) error {
 			Build()
 	}
 
+	loader, implemented := modelLoaders[registryID]
+	if !implemented {
+		log.Warn("Loader not yet implemented",
+			logger.String("registry_id", registryID))
+		return errors.Newf("loader not yet implemented for model %s", registryID).
+			Component("classifier.orchestrator").
+			Category(errors.CategoryModelInit).
+			Context("registry_id", registryID).
+			Build()
+	}
+
 	// Allocate a single thread for the new model. The thread count defaults
 	// to 1 because the primary model's thread allocation was computed at
 	// startup and should not be reduced by a dynamic load.
@@ -489,37 +508,7 @@ func (o *Orchestrator) LoadModel(registryID string) error {
 		logger.String("registry_id", registryID),
 		logger.Int("threads", dynamicThreads))
 
-	var err error
-	switch registryID {
-	case RegistryIDBirdNETV3:
-		log.Warn("BirdNET v3.0 loader not yet implemented",
-			logger.String("registry_id", registryID))
-		return errors.Newf("BirdNET v3.0 loader not yet implemented").
-			Component("classifier.orchestrator").
-			Category(errors.CategoryModelInit).
-			Context("registry_id", registryID).
-			Build()
-	case RegistryIDPerchV2:
-		err = o.loadPerch(dynamicThreads)
-	case RegistryIDBSG:
-		log.Warn("BSG loader not yet implemented",
-			logger.String("registry_id", registryID))
-		return errors.Newf("BSG loader not yet implemented").
-			Component("classifier.orchestrator").
-			Category(errors.CategoryModelInit).
-			Context("registry_id", registryID).
-			Build()
-	case RegistryIDBat:
-		err = o.loadBat(dynamicThreads)
-	default:
-		return errors.Newf("no loader implemented for model %s", registryID).
-			Component("classifier.orchestrator").
-			Category(errors.CategoryModelInit).
-			Context("registry_id", registryID).
-			Build()
-	}
-
-	if err != nil {
+	if err := loader(o, dynamicThreads); err != nil {
 		return err
 	}
 
@@ -683,22 +672,13 @@ func (o *Orchestrator) loadAdditionalModels(threadAlloc map[string]int) error {
 
 		threads := threadAlloc[registryID]
 
-		var loadErr error
-		switch registryID {
-		case RegistryIDBirdNETV3:
-			log.Warn("BirdNET v3.0 loader not yet implemented, skipping",
+		loader, implemented := modelLoaders[registryID]
+		if !implemented {
+			log.Warn("Loader not yet implemented, skipping",
 				logger.String("registry_id", registryID))
-		case RegistryIDPerchV2:
-			loadErr = o.loadPerch(threads)
-		case RegistryIDBSG:
-			log.Warn("BSG loader not yet implemented, skipping",
-				logger.String("registry_id", registryID))
-		case RegistryIDBat:
-			loadErr = o.loadBat(threads)
-		default:
-			log.Warn("model registered but no loader implemented",
-				logger.String("registry_id", registryID))
+			continue
 		}
+		loadErr := loader(o, threads)
 		if loadErr != nil {
 			log.Warn("optional model failed to load, will retry after gallery scan",
 				logger.String("registry_id", registryID),


### PR DESCRIPTION
## Summary

- Skip SHA256 verification in `downloadFile` when the expected hash is empty, matching `verifySHA256` behavior
- Unify three `cleanupShared{Embeddings,Geomodel,Taxonomy}` methods into a single generic `cleanupSharedFiles` helper with predicate functions, also fixing a pre-existing race where cleanup ignored `mm.downloading`
- Thread `context.Context` through `Install`/`Reinstall`/`downloadModelFiles`/`downloadFile` for cancellation support during shutdown; API handlers pass the controller's lifecycle context
- Replace duplicate `switch registryID` dispatch in `LoadModel`/`loadAdditionalModels` with a `modelLoaders` map
- Add `HasEmbeddingsFiles` and promote `isEmbeddingsRole`/`isTaxonomyRole` to package-level functions for consistency
- Fix test helpers to use `isSharedRole` instead of incomplete predicates, add taxonomy/embeddings assertion branches

## Test Plan

- [x] 29 model manager tests pass with `-race` (28 existing + 1 new downloading-race test)
- [x] New `TestModelManager_DownloadFile_EmptySHA256` verifies empty hash skips verification
- [x] New `TestModelManager_DownloadFile_ContextCancelled` verifies cancelled context produces error
- [x] New `TestModelManager_Uninstall_SharedFilesRetainedWhileDownloading` verifies shared files retained during concurrent download
- [x] Zero lint issues (`golangci-lint run`)
- [x] Two gate passes clean (4 agents + Gemini each pass)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Model downloads are now cancellable via context-aware requests.
  * Improved shared-file cleanup so embeddings/geomodel/taxonomy artifacts are retained while still needed.
  * SHA256 verification is skipped when no expected checksum is provided.
  * Model-role classification refined to better detect embedding and taxonomy files.

* **Refactor**
  * Model loader registry reworked for clearer, pluggable loading.

* **Tests**
  * Added/updated tests for cancellation, checksum skipping, and shared-file retention.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3043)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->