### PR TITLE
fix(streams): resolve empty URL in stream health API causing Unknown status

### DIFF
--- a/internal/api/v2/streams_health.go
+++ b/internal/api/v2/streams_health.go
@@ -150,17 +150,18 @@ func (c *Controller) initStreamHealthRoutes() {
 		middleware.RateLimiterWithConfig(rateLimiterConfig))
 }
 
-// resolveSourceURL retrieves the raw connection URL for a sourceID from the registry.
-// Returns an empty string if the source is not found.
+// resolveSourceURL retrieves the raw connection URL for a sourceID from the
+// registry. Returns an empty string if the source is not found. The raw URL
+// is needed for matching against config entries; callers that expose the URL
+// to API clients MUST sanitize it first (privacy.SanitizeStreamUrl).
 func (c *Controller) resolveSourceURL(registry *audiocore.SourceRegistry, sourceID string) string {
 	if registry == nil {
 		return ""
 	}
-	src, ok := registry.Get(sourceID)
+	connStr, ok := registry.ConnectionStringByID(sourceID)
 	if !ok {
 		return ""
 	}
-	connStr, _ := src.GetConnectionString()
 	return connStr
 }
 

--- a/internal/audiocore/source_registry.go
+++ b/internal/audiocore/source_registry.go
@@ -199,6 +199,21 @@ func (r *SourceRegistry) Get(sourceID string) (*AudioSource, bool) {
 	return r.copySource(src), true
 }
 
+// ConnectionStringByID returns the raw connection string for the given source
+// ID, or ("", false) if not found. This bypasses the safe-copy path used by
+// Get(); the returned string may contain credentials. Callers MUST sanitize
+// before exposing to API clients (use privacy.SanitizeStreamUrl).
+func (r *SourceRegistry) ConnectionStringByID(sourceID string) (string, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	src, ok := r.sources[sourceID]
+	if !ok {
+		return "", false
+	}
+	connStr, _ := src.GetConnectionString()
+	return connStr, true
+}
+
 // GetByConnection returns a safe copy of the source registered for the given
 // connection string, or (nil, false) if not found.
 func (r *SourceRegistry) GetByConnection(connStr string) (*AudioSource, bool) {

--- a/internal/audiocore/source_registry.go
+++ b/internal/audiocore/source_registry.go
@@ -210,8 +210,7 @@ func (r *SourceRegistry) ConnectionStringByID(sourceID string) (string, bool) {
 	if !ok {
 		return "", false
 	}
-	connStr, _ := src.GetConnectionString()
-	return connStr, true
+	return src.connectionString, true
 }
 
 // GetByConnection returns a safe copy of the source registered for the given

--- a/internal/audiocore/source_registry_test.go
+++ b/internal/audiocore/source_registry_test.go
@@ -352,6 +352,41 @@ func TestSourceRegistry_UpdateDisplayName_NotFound(t *testing.T) {
 	assert.False(t, updated)
 }
 
+// TestSourceRegistry_ConnectionStringByID verifies that ConnectionStringByID
+// returns the raw connection string while Get still strips it.
+func TestSourceRegistry_ConnectionStringByID(t *testing.T) {
+	t.Parallel()
+	r := newTestRegistry(t)
+
+	const rawURL = "rtsp://admin:secret@192.168.1.10/stream"
+
+	src, err := r.Register(&SourceConfig{ConnectionString: rawURL})
+	require.NoError(t, err)
+
+	// ConnectionStringByID returns the raw URL (credentials included)
+	connStr, ok := r.ConnectionStringByID(src.ID)
+	require.True(t, ok)
+	assert.Equal(t, rawURL, connStr)
+
+	// Get returns a safe copy with the connection string stripped
+	safeCopy, ok := r.Get(src.ID)
+	require.True(t, ok)
+	safeConn, err := safeCopy.GetConnectionString()
+	require.Error(t, err, "safe copy should return an error for empty connection string")
+	assert.Empty(t, safeConn)
+}
+
+// TestSourceRegistry_ConnectionStringByID_NotFound verifies that
+// ConnectionStringByID returns false for an unknown source ID.
+func TestSourceRegistry_ConnectionStringByID_NotFound(t *testing.T) {
+	t.Parallel()
+	r := newTestRegistry(t)
+
+	connStr, ok := r.ConnectionStringByID("nonexistent-id")
+	assert.False(t, ok)
+	assert.Empty(t, connStr)
+}
+
 // TestGenerateSourceID_Deterministic verifies that the same inputs always produce the same ID.
 func TestGenerateSourceID_Deterministic(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Summary

- RTSP streams showed "Unknown" status in Settings > Audio > Streams because `resolveSourceURL` used `SourceRegistry.Get()`, which returns a credential-stripped copy with an empty connection string
- Added `ConnectionStringByID()` to `SourceRegistry` that returns the raw connection string under read lock, bypassing the safe-copy path
- Wired `resolveSourceURL()` to use it; the raw URL is still sanitized at the API response boundary via `privacy.SanitizeStreamUrl`

Fixes #3038

## Test plan

- [x] New unit tests for `ConnectionStringByID` (happy path with credentials, not-found)
- [x] Cross-check test verifying `Get()` still strips connection strings
- [x] All 121 audiocore tests pass with `-race`
- [x] All 30 stream health tests pass with `-race`
- [x] Linter clean (`golangci-lint run -v`)
- [x] Gate review: all 6 callsites of `resolveSourceURL` verified to sanitize before API exposure

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal connection-string retrieval to allow returning raw (credential-containing) values when needed while preserving external-facing safety behavior.

* **Tests**
  * Added tests covering raw connection-string access and not-found edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3049)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->