### PR TITLE
fix(classifier): skip label validation for bat embedding model

### DIFF
--- a/internal/classifier/bat_onnx.go
+++ b/internal/classifier/bat_onnx.go
@@ -45,8 +45,9 @@ func NewBat(cfg *BatModelConfig) (*Bat, error) {
 	}
 
 	embClassifier, err := inference.NewONNXClassifier(cfg.EmbeddingModelPath, inference.ONNXClassifierOptions{
-		Labels:  cfg.EmbeddingLabels,
-		Threads: cfg.Threads,
+		Labels:              cfg.EmbeddingLabels,
+		Threads:             cfg.Threads,
+		SkipLabelValidation: true,
 	})
 	if err != nil {
 		return nil, errors.New(err).

--- a/internal/inference/onnx.go
+++ b/internal/inference/onnx.go
@@ -21,6 +21,10 @@ type ONNXClassifierOptions struct {
 	Labels []string
 	// Threads is the number of CPU threads for ONNX inference. 0 = use ONNX defaults.
 	Threads int
+	// SkipLabelValidation disables the label-count-vs-model-output check.
+	// Use when the model is loaded only for embedding extraction and the
+	// caller's label list may not match the model's logits dimension.
+	SkipLabelValidation bool
 }
 
 // onnxClassifier implements Classifier using an ONNX Runtime session.
@@ -40,6 +44,9 @@ func NewONNXClassifier(modelPath string, opts ONNXClassifierOptions) (Classifier
 		ort.WithLabels(opts.Labels),
 		ort.WithTopK(0),          // We handle topK in BirdNET-Go's post-processing
 		ort.WithMinConfidence(0), // No filtering, return all raw scores
+	}
+	if opts.SkipLabelValidation {
+		classifierOpts = append(classifierOpts, ort.WithSkipLabelValidation())
 	}
 	var configErr error
 	if opts.Threads > 0 {

--- a/internal/inference/onnx/classifier.go
+++ b/internal/inference/onnx/classifier.go
@@ -22,12 +22,13 @@ type Classifier struct {
 type ClassifierOption func(*classifierConfig)
 
 type classifierConfig struct {
-	modelType     *ModelType
-	labels        []string
-	labelsPath    string
-	topK          int
-	minConf       float32
-	sessionOptsFn func(*ort.SessionOptions)
+	modelType           *ModelType
+	labels              []string
+	labelsPath          string
+	topK                int
+	minConf             float32
+	sessionOptsFn       func(*ort.SessionOptions)
+	skipLabelValidation bool
 }
 
 func defaultClassifierConfig() *classifierConfig {
@@ -60,6 +61,13 @@ func WithTopK(k int) ClassifierOption {
 // WithMinConfidence sets the minimum confidence threshold. Default: 0.0.
 func WithMinConfidence(threshold float32) ClassifierOption {
 	return func(c *classifierConfig) { c.minConf = threshold }
+}
+
+// WithSkipLabelValidation disables the label-count-vs-model-output check.
+// Use when the model is loaded only for embedding extraction and the caller's
+// label list may not match the model's logits output dimension.
+func WithSkipLabelValidation() ClassifierOption {
+	return func(c *classifierConfig) { c.skipLabelValidation = true }
 }
 
 // WithSessionOptions provides a callback to configure the ONNX Runtime session options.
@@ -106,8 +114,10 @@ func NewClassifier(modelPath string, opts ...ClassifierOption) (*Classifier, err
 		return nil, err
 	}
 
-	if err := validateLabelCount(&modelCfg, outputInfos, len(labels)); err != nil {
-		return nil, err
+	if !cfg.skipLabelValidation {
+		if err := validateLabelCount(&modelCfg, outputInfos, len(labels)); err != nil {
+			return nil, err
+		}
 	}
 
 	// Create ONNX session
@@ -275,12 +285,12 @@ func (c *Classifier) PredictRawWithEmbeddings(audio []float32) (logits, embeddin
 		return nil, nil, fmt.Errorf("birdnet: logits tensor has unexpected type")
 	}
 	allLogits := logitsTensor.GetData()
-	numClasses := len(c.labels)
-	if numClasses > len(allLogits) {
-		return nil, nil, fmt.Errorf("birdnet: logits tensor too small: need %d, have %d", numClasses, len(allLogits))
+	logitsSize := c.config.LogitsSize
+	if logitsSize > len(allLogits) {
+		return nil, nil, fmt.Errorf("birdnet: logits tensor too small: need %d, have %d", logitsSize, len(allLogits))
 	}
-	logits = make([]float32, numClasses)
-	copy(logits, allLogits[:numClasses])
+	logits = make([]float32, logitsSize)
+	copy(logits, allLogits[:logitsSize])
 
 	if c.config.EmbeddingIndex >= 0 {
 		embTensor, ok := outputs[c.config.EmbeddingIndex].(*ort.Tensor[float32])
@@ -439,7 +449,7 @@ func (c *Classifier) outputShape(outputIdx, batchSize int) ([]int64, error) {
 	case BirdNETv24:
 		switch outputIdx {
 		case 0:
-			return []int64{batch, int64(len(c.labels))}, nil
+			return []int64{batch, int64(c.config.LogitsSize)}, nil
 		case 1:
 			if c.config.EmbeddingSize > 0 {
 				return []int64{batch, int64(c.config.EmbeddingSize)}, nil
@@ -450,7 +460,7 @@ func (c *Classifier) outputShape(outputIdx, batchSize int) ([]int64, error) {
 		case 0:
 			return []int64{batch, int64(c.config.EmbeddingSize)}, nil
 		case 1:
-			return []int64{batch, int64(len(c.labels))}, nil
+			return []int64{batch, int64(c.config.LogitsSize)}, nil
 		}
 	case PerchV2:
 		switch outputIdx {
@@ -461,7 +471,7 @@ func (c *Classifier) outputShape(outputIdx, batchSize int) ([]int64, error) {
 		case 2:
 			return []int64{batch, 500, 128}, nil
 		case 3:
-			return []int64{batch, int64(len(c.labels))}, nil
+			return []int64{batch, int64(c.config.LogitsSize)}, nil
 		}
 	}
 	return nil, fmt.Errorf("birdnet: unexpected output index %d for model %s", outputIdx, c.config.Type)
@@ -474,9 +484,9 @@ func (c *Classifier) processOutput(outputs []ort.Value, batchIdx int) (*Result, 
 		return nil, fmt.Errorf("birdnet: logits tensor has unexpected type")
 	}
 	allLogits := logitsTensor.GetData()
-	numClasses := len(c.labels)
-	start := batchIdx * numClasses
-	end := start + numClasses
+	stride := c.config.LogitsSize
+	start := batchIdx * stride
+	end := start + stride
 	if end > len(allLogits) {
 		return nil, fmt.Errorf("birdnet: logits tensor too small for batch index %d", batchIdx)
 	}

--- a/internal/inference/onnx/classifier.go
+++ b/internal/inference/onnx/classifier.go
@@ -286,6 +286,9 @@ func (c *Classifier) PredictRawWithEmbeddings(audio []float32) (logits, embeddin
 	}
 	allLogits := logitsTensor.GetData()
 	logitsSize := c.config.LogitsSize
+	if logitsSize <= 0 {
+		return nil, nil, fmt.Errorf("birdnet: invalid logits size %d", logitsSize)
+	}
 	if logitsSize > len(allLogits) {
 		return nil, nil, fmt.Errorf("birdnet: logits tensor too small: need %d, have %d", logitsSize, len(allLogits))
 	}
@@ -485,6 +488,9 @@ func (c *Classifier) processOutput(outputs []ort.Value, batchIdx int) (*Result, 
 	}
 	allLogits := logitsTensor.GetData()
 	stride := c.config.LogitsSize
+	if stride <= 0 {
+		return nil, fmt.Errorf("birdnet: invalid logits size %d", stride)
+	}
 	start := batchIdx * stride
 	end := start + stride
 	if end > len(allLogits) {

--- a/internal/inference/onnx/detection.go
+++ b/internal/inference/onnx/detection.go
@@ -60,6 +60,7 @@ func buildModelConfig(mt ModelType, inputShape []int64, outputShapes [][]int64) 
 	switch mt {
 	case BirdNETv24:
 		cfg.LogitsIndex = 0
+		cfg.LogitsSize = lastDim(outputShapes[0])
 		if numOutputs >= 2 {
 			if embSize := lastDim(outputShapes[1]); embSize > 0 {
 				cfg.EmbeddingIndex = 1
@@ -68,10 +69,12 @@ func buildModelConfig(mt ModelType, inputShape []int64, outputShapes [][]int64) 
 		}
 	case BirdNETv30:
 		cfg.LogitsIndex = 1
+		cfg.LogitsSize = lastDim(outputShapes[1])
 		cfg.EmbeddingIndex = 0
 		cfg.EmbeddingSize = embeddingSizeV30
 	case PerchV2:
 		cfg.LogitsIndex = 3
+		cfg.LogitsSize = lastDim(outputShapes[3])
 		cfg.EmbeddingIndex = 0
 		cfg.EmbeddingSize = embeddingSizePerch
 	}

--- a/internal/inference/onnx/types.go
+++ b/internal/inference/onnx/types.go
@@ -66,6 +66,7 @@ type ModelConfig struct {
 	EmbeddingSize  int     // 0 if model doesn't produce embeddings
 	EmbeddingIndex int     // which output tensor contains embeddings, -1 if none
 	LogitsIndex    int     // which output tensor contains logits
+	LogitsSize     int     // actual logits output dimension from model metadata
 	InputShape     []int64 // actual shape from ONNX model
 }
 


### PR DESCRIPTION
## Summary

- Fix bat classifier failing to load when the user has a custom BirdNET model with a different species count than the standard v2.4 (6522 classes)
- The bat pipeline uses BirdNET v2.4 embeddings extraction followed by a custom bat classifier head; the embedding model's labels are unused (only embeddings are extracted), but label count validation blocked initialization
- Add `WithSkipLabelValidation` option to skip the label-vs-model-output check for embedding-only use
- Decouple output tensor allocation from label count by adding `LogitsSize` to `ModelConfig`, populated from actual ONNX model metadata, preventing tensor shape mismatches at inference time

## Test Plan

- [ ] Deploy to production instance with custom BirdNET model (6559 labels) and verify bat classifier loads
- [ ] Verify bat classifier appears in inference timing stats
- [ ] Verify standard BirdNET and Perch v2 models are unaffected (label validation still enforced)
- [ ] `go build` and `golangci-lint run -v` pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to skip label-count validation when loading models, allowing embedding extraction even if provided labels don’t match the model’s logits dimension.

* **Improvements**
  * Model metadata now records the actual logits output dimension, improving compatibility and correctness when interpreting model outputs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3051)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->