### PR TITLE
fix(datastore/v2only): prefix-aware table names in 4 raw-SQL queries

### DIFF
--- a/internal/api/v2/app_wizard_test.go
+++ b/internal/api/v2/app_wizard_test.go
@@ -65,6 +65,7 @@ func (f *fakeV2Manager) CheckpointWAL() error { return nil }
 func (f *fakeV2Manager) Delete() error        { return nil }
 func (f *fakeV2Manager) Exists() bool         { return true }
 func (f *fakeV2Manager) IsMySQL() bool        { return false }
+func (f *fakeV2Manager) TablePrefix() string  { return "" }
 
 // newFakeV2ManagerWithDetections creates a fakeV2Manager backed by an
 // in-memory SQLite database.  If count > 0, it inserts that many dummy

--- a/internal/datastore/v2/manager.go
+++ b/internal/datastore/v2/manager.go
@@ -55,6 +55,15 @@ type Manager interface {
 	Exists() bool
 	// IsMySQL returns true if this is a MySQL manager.
 	IsMySQL() bool
+	// TablePrefix returns the prefix applied to every v2 table name. It is
+	// non-empty (currently "v2_") only on MySQL deployments that are still
+	// in the v1→v2 migration window — there, v2 tables coexist alongside
+	// the legacy v1 schema and need the prefix to avoid name collisions.
+	// On SQLite, on fresh-install MySQL, and on any future cutover where
+	// the prefix is dropped, this returns "". Code that builds raw-SQL
+	// table references MUST consult this to stay correct under all three
+	// deployment modes.
+	TablePrefix() string
 }
 
 // Config holds database configuration for the v2 manager.

--- a/internal/datastore/v2only/datastore.go
+++ b/internal/datastore/v2only/datastore.go
@@ -1041,16 +1041,17 @@ func (ds *Datastore) GetTopBirdsData(selectedDate string, minConfidenceNormalize
 	// detection_predictions table (which only stores secondary predictions).
 	// Secondary sort by scientific_name ensures deterministic results when counts are equal.
 	// Excludes detections marked as false_positive.
+	prefix := ds.manager.TablePrefix()
 	db := ds.manager.DB()
-	err = db.Table("detections d").
+	err = db.Table(prefix+"detections d").
 		Select(`
 			l.scientific_name,
 			COUNT(d.id) as count,
 			MAX(d.confidence) as max_confidence,
 			MAX(d.detected_at) as latest_time
 		`).
-		Joins("JOIN labels l ON d.label_id = l.id").
-		Joins("LEFT JOIN detection_reviews dr ON d.id = dr.detection_id").
+		Joins(fmt.Sprintf("JOIN %slabels l ON d.label_id = l.id", prefix)).
+		Joins(fmt.Sprintf("LEFT JOIN %sdetection_reviews dr ON d.id = dr.detection_id", prefix)).
 		Where("d.detected_at >= ? AND d.detected_at < ?", startTime, endTime).
 		Where("d.confidence >= ?", minConfidenceNormalized).
 		Where("(dr.verified IS NULL OR dr.verified != ?)", string(entities.VerificationFalsePositive)).
@@ -1206,9 +1207,10 @@ func (ds *Datastore) GetBatchHourlyOccurrences(date string, species []string, mi
 
 	var results []result
 	// Exclude detections marked as false_positive
+	prefix := ds.manager.TablePrefix()
 	err = ds.manager.DB().WithContext(ctx).
-		Table("detections d").
-		Joins("LEFT JOIN detection_reviews dr ON d.id = dr.detection_id").
+		Table(prefix+"detections d").
+		Joins(fmt.Sprintf("LEFT JOIN %sdetection_reviews dr ON d.id = dr.detection_id", prefix)).
 		Select(fmt.Sprintf("d.label_id as label_id, %s as hour, COUNT(*) as count", hourExpr)).
 		Where("d.label_id IN ?", flatLabelIDs).
 		Where("d.detected_at >= ? AND d.detected_at < ?", startOfDay, endOfDay).
@@ -2111,13 +2113,14 @@ func (ds *Datastore) ClearNoteClipPathsByNames(clipNames []string) (int64, error
 	const batchSize = 500
 	var totalAffected int64
 	ctx := context.Background()
+	detectionsTable := ds.manager.TablePrefix() + "detections"
 
 	for i := 0; i < len(clipNames); i += batchSize {
 		end := min(i+batchSize, len(clipNames))
 		batch := clipNames[i:end]
 
 		result := ds.manager.DB().WithContext(ctx).
-			Table("detections").
+			Table(detectionsTable).
 			Where("clip_name IN ?", batch).
 			Update("clip_name", nil)
 		if result.Error != nil {
@@ -2561,11 +2564,12 @@ func (ds *Datastore) GetSpeciesDiversityData(ctx context.Context, startDate, end
 	}
 
 	// Build query to count distinct species per day, excluding false positives
+	prefix := ds.manager.TablePrefix()
 	query := ds.manager.DB().WithContext(ctx).
-		Table("detections d").
+		Table(prefix+"detections d").
 		Select(fmt.Sprintf("%s as date, COUNT(DISTINCT l.scientific_name) as count", dateExpr)).
-		Joins("JOIN labels l ON d.label_id = l.id").
-		Joins("LEFT JOIN detection_reviews dr ON d.id = dr.detection_id").
+		Joins(fmt.Sprintf("JOIN %slabels l ON d.label_id = l.id", prefix)).
+		Joins(fmt.Sprintf("LEFT JOIN %sdetection_reviews dr ON d.id = dr.detection_id", prefix)).
 		Where("(dr.verified IS NULL OR dr.verified != ?)", string(entities.VerificationFalsePositive)).
 		Group(dateExpr).
 		Order("date")


### PR DESCRIPTION
## Summary

Four queries in `internal/datastore/v2only/datastore.go` build raw SQL with hardcoded `"detections"` / `"labels"` / `"detection_reviews"` table names. On MySQL deployments that are still in the v1→v2 migration window the v2 schema lives behind a `v2_` prefix (see `TablePrefix()` on `MySQLManager`), so every one of these queries hits *table not found* — silently breaking:

- `GetTopBirdsData` — top-of-period species aggregator (~L1045)
- `GetBatchHourlyOccurrences` — batched hourly-occurrence fetch (~L1211)
- `DeleteClipPathsBatch` — clip-path cleanup batch (~L2121)
- `GetSpeciesDiversityData` — species diversity chart (~L2566)

The last one is what Sentry [flagged on #3020](https://github.com/tphakala/birdnet-go/pull/3020#discussion_r2549500000). The hardcoded name there predates #3020 and the same bug exists in the three siblings, so this PR fixes all four uniformly rather than patching just the one the bot caught.

## Fix shape

- Read `ds.manager.TablePrefix()` once at the top of each query.
- Concatenate the prefix onto every raw table reference: the `Table(...)` anchor and the `Joins(...)` clauses. Returns `""` on SQLite and on fresh-install MySQL where the v2 tables already use unprefixed names, so the existing happy path keeps working.

To avoid type-asserting the `Manager` interface at every call site, also expose `TablePrefix()` on `v2.Manager` itself. Both `SQLiteManager` and `MySQLManager` already implement it on their concrete types; this just lifts it onto the interface.

## Test plan

- [ ] CI: `go test ./...` (no behavior change on SQLite / fresh-install MySQL — prefix is `""`)
- [ ] Manual: on a v1→v2 migrated MySQL DB, hit `/api/v2/analytics/species/diversity`, `/api/v2/analytics/top-birds`, and the batched hourly-occurrences endpoint — confirm they return data instead of failing with *Table 'detections' doesn't exist*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated internal datastore handling to consistently apply table prefixes so database queries behave correctly across different database setups and migration modes.
* **Tests**
  * Aligned test doubles with the updated datastore interface to preserve test accuracy.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3054)

<!-- review_stack_entry_end -->

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3054)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->