### PR TITLE
fix(notification): add HTTP/HTTPS protocol selector for Gotify push provider

### DIFF
--- a/frontend/src/lib/desktop/features/settings/pages/NotificationsSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/NotificationsSettingsPage.svelte
@@ -793,8 +793,11 @@
           serviceFormData.gotifyToken = token || '';
 
           const params = new URLSearchParams(queryString || '');
-          const disableTls = params.get('disabletls');
-          serviceFormData.gotifyProtocol = disableTls?.toLowerCase() === 'yes' ? 'http' : 'https';
+          const disableTlsEntry = Array.from(params.entries()).find(
+            ([key]) => key.toLowerCase() === 'disabletls'
+          );
+          const disableTls = disableTlsEntry?.[1]?.toLowerCase();
+          serviceFormData.gotifyProtocol = disableTls === 'yes' ? 'http' : 'https';
         }
         break;
       }

--- a/frontend/src/lib/desktop/features/settings/pages/NotificationsSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/NotificationsSettingsPage.svelte
@@ -248,7 +248,7 @@
     { value: 'basic', label: t('settings.notifications.push.services.webhook.auth.basic') },
   ]);
 
-  const ntfyProtocolOptions = $derived([
+  const protocolOptions = $derived([
     { value: 'https', label: 'HTTPS' },
     { value: 'http', label: 'HTTP' },
   ]);
@@ -500,7 +500,9 @@
       }
       case 'gotify': {
         if (serviceFormData.gotifyServer && serviceFormData.gotifyToken) {
-          const server = serviceFormData.gotifyServer.replace(/^https?:\/\//, '');
+          const server = serviceFormData.gotifyServer
+            .replace(/^https?:\/\//i, '')
+            .replace(/\/+$/, '');
           const disableTls = serviceFormData.gotifyProtocol === 'http' ? '?disabletls=yes' : '';
           return `gotify://${server}/${serviceFormData.gotifyToken}${disableTls}`;
         }
@@ -1607,7 +1609,7 @@
                       <div class="flex items-center gap-2 mt-1 flex-wrap">
                         <SelectDropdown
                           bind:value={serviceFormData.ntfyProtocol}
-                          options={ntfyProtocolOptions}
+                          options={protocolOptions}
                           variant="select"
                           size="sm"
                           menuSize="sm"
@@ -1699,12 +1701,13 @@
                         'settings.notifications.push.services.gotify.server.placeholder'
                       )}
                       onchange={value => {
-                        if (value.startsWith('http://')) {
+                        const lower = value.toLowerCase();
+                        if (lower.startsWith('http://')) {
                           serviceFormData.gotifyProtocol = 'http';
-                          serviceFormData.gotifyServer = value.replace(/^http:\/\//, '');
-                        } else if (value.startsWith('https://')) {
+                          serviceFormData.gotifyServer = value.replace(/^https?:\/\//i, '');
+                        } else if (lower.startsWith('https://')) {
                           serviceFormData.gotifyProtocol = 'https';
-                          serviceFormData.gotifyServer = value.replace(/^https:\/\//, '');
+                          serviceFormData.gotifyServer = value.replace(/^https?:\/\//i, '');
                         } else {
                           serviceFormData.gotifyServer = value;
                         }
@@ -1721,7 +1724,7 @@
                       </span>
                       <SelectDropdown
                         bind:value={serviceFormData.gotifyProtocol}
-                        options={ntfyProtocolOptions}
+                        options={protocolOptions}
                         variant="select"
                         size="sm"
                         menuSize="sm"

--- a/frontend/src/lib/desktop/features/settings/pages/NotificationsSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/NotificationsSettingsPage.svelte
@@ -160,6 +160,7 @@
     ntfyCheckStatus: 'idle' | 'checking' | 'https' | 'http' | 'unreachable';
     gotifyServer: string;
     gotifyToken: string;
+    gotifyProtocol: 'https' | 'http';
     pushoverApiToken: string;
     pushoverUserKey: string;
     slackWebhookUrl: string;
@@ -202,6 +203,7 @@
     ntfyCheckStatus: 'idle',
     gotifyServer: '',
     gotifyToken: '',
+    gotifyProtocol: 'https',
     pushoverApiToken: '',
     pushoverUserKey: '',
     slackWebhookUrl: '',
@@ -499,7 +501,8 @@
       case 'gotify': {
         if (serviceFormData.gotifyServer && serviceFormData.gotifyToken) {
           const server = serviceFormData.gotifyServer.replace(/^https?:\/\//, '');
-          return `gotify://${server}/${serviceFormData.gotifyToken}`;
+          const disableTls = serviceFormData.gotifyProtocol === 'http' ? '?disabletls=yes' : '';
+          return `gotify://${server}/${serviceFormData.gotifyToken}${disableTls}`;
         }
         return '';
       }
@@ -710,6 +713,7 @@
       ntfyCheckStatus: 'idle',
       gotifyServer: '',
       gotifyToken: '',
+      gotifyProtocol: 'https',
       pushoverApiToken: '',
       pushoverUserKey: '',
       slackWebhookUrl: '',
@@ -772,6 +776,23 @@
           }
           serviceFormData.ntfyCheckStatus = 'idle';
           serviceFormData.ntfyCheckHost = '';
+        }
+        break;
+      }
+      case 'gotify': {
+        /* eslint-disable security/detect-unsafe-regex -- no nested quantifiers; each segment is bounded by literal anchors */
+        const gotifyPattern = /^gotify:\/\/([^/?]+)(?:\/([^?]*))?(?:\?(.*))?$/;
+        /* eslint-enable security/detect-unsafe-regex */
+        if (safeRegexTest(gotifyPattern, url, 500)) {
+          const match = url.match(gotifyPattern)!;
+          const [, host, token, queryString] = match;
+
+          serviceFormData.gotifyServer = host || '';
+          serviceFormData.gotifyToken = token || '';
+
+          const params = new URLSearchParams(queryString || '');
+          const disableTls = params.get('disabletls');
+          serviceFormData.gotifyProtocol = disableTls?.toLowerCase() === 'yes' ? 'http' : 'https';
         }
         break;
       }
@@ -1677,11 +1698,36 @@
                       placeholder={t(
                         'settings.notifications.push.services.gotify.server.placeholder'
                       )}
-                      onchange={value => (serviceFormData.gotifyServer = value)}
+                      onchange={value => {
+                        if (value.startsWith('http://')) {
+                          serviceFormData.gotifyProtocol = 'http';
+                          serviceFormData.gotifyServer = value.replace(/^http:\/\//, '');
+                        } else if (value.startsWith('https://')) {
+                          serviceFormData.gotifyProtocol = 'https';
+                          serviceFormData.gotifyServer = value.replace(/^https:\/\//, '');
+                        } else {
+                          serviceFormData.gotifyServer = value;
+                        }
+                      }}
                     />
                     <p class="text-xs text-[var(--color-base-content)]/60 -mt-2">
                       {t('settings.notifications.push.services.gotify.server.helpText')}
                     </p>
+
+                    <!-- Protocol selector -->
+                    <div class="flex items-center gap-2 mt-1">
+                      <span class="text-sm text-[var(--color-base-content)]/70">
+                        {t('settings.notifications.push.services.gotify.protocol.label')}
+                      </span>
+                      <SelectDropdown
+                        bind:value={serviceFormData.gotifyProtocol}
+                        options={ntfyProtocolOptions}
+                        variant="select"
+                        size="sm"
+                        menuSize="sm"
+                      />
+                    </div>
+
                     <TextInput
                       id="gotify-token"
                       value={serviceFormData.gotifyToken}

--- a/frontend/src/lib/desktop/features/settings/pages/NotificationsSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/NotificationsSettingsPage.svelte
@@ -1704,13 +1704,11 @@
                         'settings.notifications.push.services.gotify.server.placeholder'
                       )}
                       onchange={value => {
-                        const lower = value.toLowerCase();
-                        if (lower.startsWith('http://')) {
-                          serviceFormData.gotifyProtocol = 'http';
-                          serviceFormData.gotifyServer = value.replace(/^https?:\/\//i, '');
-                        } else if (lower.startsWith('https://')) {
-                          serviceFormData.gotifyProtocol = 'https';
-                          serviceFormData.gotifyServer = value.replace(/^https?:\/\//i, '');
+                        const match = value.match(/^(https?):\/\/([^?#]+)/i);
+                        if (match) {
+                          serviceFormData.gotifyProtocol =
+                            match[1].toLowerCase() === 'http' ? 'http' : 'https';
+                          serviceFormData.gotifyServer = match[2];
                         } else {
                           serviceFormData.gotifyServer = value;
                         }

--- a/frontend/static/messages/da.json
+++ b/frontend/static/messages/da.json
@@ -2381,8 +2381,11 @@
             "name": "Gotify",
             "server": {
               "label": "Server-URL",
-              "placeholder": "gotify.example.com",
-              "helpText": "Dit Gotify-serverværtsnavn (uden https://)"
+              "placeholder": "gotify.example.com:8070",
+              "helpText": "Dit Gotify-servernavn og port"
+            },
+            "protocol": {
+              "label": "Protokol"
             },
             "token": {
               "label": "Applikationstoken",

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -2350,8 +2350,11 @@
             "name": "Gotify",
             "server": {
               "label": "Server-URL",
-              "placeholder": "gotify.example.com",
-              "helpText": "Ihr Gotify-Server-Hostname (ohne https://)"
+              "placeholder": "gotify.example.com:8070",
+              "helpText": "Ihr Gotify-Server-Hostname und Port"
+            },
+            "protocol": {
+              "label": "Protokoll"
             },
             "token": {
               "label": "Anwendungstoken",

--- a/frontend/static/messages/en.json
+++ b/frontend/static/messages/en.json
@@ -2386,8 +2386,11 @@
             "name": "Gotify",
             "server": {
               "label": "Server URL",
-              "placeholder": "gotify.example.com",
-              "helpText": "Your Gotify server hostname (without https://)"
+              "placeholder": "gotify.example.com:8070",
+              "helpText": "Your Gotify server hostname and port"
+            },
+            "protocol": {
+              "label": "Protocol"
             },
             "token": {
               "label": "Application Token",

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -2350,8 +2350,11 @@
             "name": "Gotify",
             "server": {
               "label": "URL del servidor",
-              "placeholder": "gotify.example.com",
-              "helpText": "Nombre de host de tu servidor Gotify (sin https://)"
+              "placeholder": "gotify.example.com:8070",
+              "helpText": "Nombre de host y puerto de su servidor Gotify"
+            },
+            "protocol": {
+              "label": "Protocolo"
             },
             "token": {
               "label": "Token de aplicación",

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -2316,8 +2316,11 @@
             "name": "Gotify",
             "server": {
               "label": "Palvelimen URL",
-              "placeholder": "gotify.example.com",
-              "helpText": "Gotify-palvelimesi isäntänimi (ilman https://)"
+              "placeholder": "gotify.example.com:8070",
+              "helpText": "Gotify-palvelimesi isäntänimi ja portti"
+            },
+            "protocol": {
+              "label": "Protokolla"
             },
             "token": {
               "label": "Sovelluksen token",

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -2315,7 +2315,7 @@
           "gotify": {
             "name": "Gotify",
             "server": {
-              "label": "Palvelimen URL",
+              "label": "Palvelin",
               "placeholder": "gotify.example.com:8070",
               "helpText": "Gotify-palvelimesi isäntänimi ja portti"
             },

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -2316,8 +2316,11 @@
             "name": "Gotify",
             "server": {
               "label": "URL du serveur",
-              "placeholder": "gotify.example.com",
-              "helpText": "Nom d'hôte de votre serveur Gotify (sans https://)"
+              "placeholder": "gotify.example.com:8070",
+              "helpText": "Nom d'hôte et port de votre serveur Gotify"
+            },
+            "protocol": {
+              "label": "Protocole"
             },
             "token": {
               "label": "Token d'application",

--- a/frontend/static/messages/hu.json
+++ b/frontend/static/messages/hu.json
@@ -2382,8 +2382,11 @@
             "name": "Gotify",
             "server": {
               "label": "Szerver URL",
-              "placeholder": "gotify.example.com",
-              "helpText": "A Gotify szerver hostname (https:// nélkül)"
+              "placeholder": "gotify.example.com:8070",
+              "helpText": "A Gotify szervered hosztneve és portja"
+            },
+            "protocol": {
+              "label": "Protokoll"
             },
             "token": {
               "label": "Alkalmazás token",

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -2351,8 +2351,11 @@
             "name": "Gotify",
             "server": {
               "label": "URL Server",
-              "placeholder": "gotify.example.com",
-              "helpText": "Il tuo hostname server Gotify (senza https://)"
+              "placeholder": "gotify.example.com:8070",
+              "helpText": "Nome host e porta del tuo server Gotify"
+            },
+            "protocol": {
+              "label": "Protocollo"
             },
             "token": {
               "label": "Token Applicazione",

--- a/frontend/static/messages/lv.json
+++ b/frontend/static/messages/lv.json
@@ -2381,8 +2381,11 @@
             "name": "Gotify",
             "server": {
               "label": "Servera URL",
-              "placeholder": "gotify.example.com",
-              "helpText": "Jūsu Gotify servera resursdatora nosaukums (bez https://)"
+              "placeholder": "gotify.example.com:8070",
+              "helpText": "Jūsu Gotify servera resursdatora nosaukums un ports"
+            },
+            "protocol": {
+              "label": "Protokols"
             },
             "token": {
               "label": "Lietojumprogrammas tokens",

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -2316,8 +2316,11 @@
             "name": "Gotify",
             "server": {
               "label": "Server-URL",
-              "placeholder": "gotify.example.com",
-              "helpText": "Je Gotify-server hostnaam (zonder https://)"
+              "placeholder": "gotify.example.com:8070",
+              "helpText": "Uw Gotify-server hostnaam en poort"
+            },
+            "protocol": {
+              "label": "Protocol"
             },
             "token": {
               "label": "Applicatietoken",

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -2326,7 +2326,7 @@
               "helpText": "Nazwa hosta i port serwera Gotify"
             },
             "protocol": {
-              "label": "Protokol"
+              "label": "Protokół"
             },
             "token": {
               "label": "Token aplikacji",

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -2322,8 +2322,11 @@
             "name": "Gotify",
             "server": {
               "label": "URL serwera",
-              "placeholder": "gotify.example.com",
-              "helpText": "Nazwa hosta twojego serwera Gotify (bez https://)"
+              "placeholder": "gotify.example.com:8070",
+              "helpText": "Nazwa hosta i port serwera Gotify"
+            },
+            "protocol": {
+              "label": "Protokol"
             },
             "token": {
               "label": "Token aplikacji",

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -2316,8 +2316,11 @@
             "name": "Gotify",
             "server": {
               "label": "URL do servidor",
-              "placeholder": "gotify.example.com",
-              "helpText": "Nome do host do seu servidor Gotify (sem https://)"
+              "placeholder": "gotify.example.com:8070",
+              "helpText": "Nome do host e porta do seu servidor Gotify"
+            },
+            "protocol": {
+              "label": "Protocolo"
             },
             "token": {
               "label": "Token da aplicação",

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -2351,8 +2351,11 @@
             "name": "Gotify",
             "server": {
               "label": "URL servera",
-              "placeholder": "gotify.example.com",
-              "helpText": "Hostname vášho Gotify servera (bez https://)"
+              "placeholder": "gotify.example.com:8070",
+              "helpText": "Názov hostiteľa a port vášho servera Gotify"
+            },
+            "protocol": {
+              "label": "Protokol"
             },
             "token": {
               "label": "Token aplikácie",

--- a/frontend/static/messages/sv.json
+++ b/frontend/static/messages/sv.json
@@ -2381,8 +2381,11 @@
             "name": "Gotify",
             "server": {
               "label": "Server-URL",
-              "placeholder": "gotify.example.com",
-              "helpText": "Ditt Gotify-servervärdnamn (utan https://)"
+              "placeholder": "gotify.example.com:8070",
+              "helpText": "Ditt Gotify-servernamn och port"
+            },
+            "protocol": {
+              "label": "Protokoll"
             },
             "token": {
               "label": "Applikationstoken",


### PR DESCRIPTION
## Summary

- Add protocol selector (HTTP/HTTPS) to the Gotify notification provider form, fixing timeout failures when Gotify runs on plain HTTP
- The Shoutrrr library defaults to HTTPS for Gotify URLs; self-hosted instances commonly use HTTP, causing TLS handshakes to hang and time out
- When HTTP is selected, the URL is constructed with `?disabletls=yes`; auto-detects protocol from pasted `http://` prefix; parses `disabletls` when editing existing providers
- Case-insensitive handling for both protocol prefix detection and query parameter parsing
- Trailing slash stripping to prevent double-slash in generated URLs
- All 14 i18n files updated with protocol label translations and revised server help text

Fixes #3050

## Test Plan

- [x] Reproduced the bug: `gotify://host:port/token` without `disabletls` fails with "server gave HTTP response to HTTPS client"
- [x] Confirmed fix: `gotify://host:port/token?disabletls=yes` delivers successfully
- [x] End-to-end: BirdNET-Go container with Gotify provider delivered notifications (system warnings and test notifications)
- [x] Frontend builds and type-checks cleanly (0 errors)
- [x] ESLint and all ast-grep checks pass
- [ ] Protocol selector displays correctly and toggles between HTTP/HTTPS
- [ ] Editing existing Gotify provider populates protocol from URL
- [ ] Pasting `http://` URL auto-sets protocol to HTTP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit HTTP/HTTPS protocol selector for Gotify notifications.
  * Gotify server field now prefers hostname:port (e.g., gotify.example.com:8070) and provides a protocol dropdown.

* **Bug Fixes / Improvements**
  * Server input auto-detects/removes typed http(s):// prefixes and normalizes generated provider URLs.
  * Provider URL parsing now recognizes Gotify protocol hints and TLS-disable flags.

* **Localization**
  * Updated UI strings across multiple languages to reflect server+port placeholder and protocol label.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3059)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->