### PR TITLE
fix: stream health SSE safety, orchestrator locking, model validation ordering

### DIFF
--- a/internal/api/v2/streams_health.go
+++ b/internal/api/v2/streams_health.go
@@ -176,7 +176,10 @@ type streamInfo struct {
 // Uses c.Settings (injected via Controller constructor) which points to the
 // shared settings instance — mutations are visible immediately.
 func (c *Controller) getStreamInfo(rawURL string) streamInfo {
+	c.settingsMutex.RLock()
 	settings := c.Settings
+	c.settingsMutex.RUnlock()
+
 	if settings == nil {
 		return streamInfo{}
 	}
@@ -518,8 +521,13 @@ func (c *Controller) handleStreamStatsUpdate(ctx echo.Context, clientID string) 
 // @Success 200 {object} SSEStreamHealthData "Stream health update events"
 // @Failure 401 {object} ErrorResponse "Unauthorized"
 // @Failure 429 {object} ErrorResponse "Too many requests"
+// @Failure 503 {object} ErrorResponse "Audio engine not initialized"
 // @Router /api/v2/streams/health/stream [get]
 func (c *Controller) StreamHealthUpdates(ctx echo.Context) error {
+	if c.engine == nil {
+		return c.HandleError(ctx, nil, "Audio engine not initialized", http.StatusServiceUnavailable)
+	}
+
 	// Create a context with timeout for maximum connection duration
 	timeoutCtx, cancel := context.WithTimeout(ctx.Request().Context(), maxSSEStreamDuration)
 	defer cancel()
@@ -574,8 +582,10 @@ func (c *Controller) StreamHealthUpdates(ctx echo.Context) error {
 	}
 }
 
-// streamHealthSnapshot captures key health metrics for change detection
+// streamHealthSnapshot captures key health metrics for change detection.
+// RawURL is cached at creation time so it survives source unregistration.
 type streamHealthSnapshot struct {
+	RawURL             string
 	IsHealthy          bool
 	ProcessState       string
 	LastErrorType      string
@@ -585,8 +595,9 @@ type streamHealthSnapshot struct {
 }
 
 // createHealthSnapshot creates a snapshot of stream health for comparison.
-func createHealthSnapshot(health *ffmpeg.StreamHealth) streamHealthSnapshot {
+func createHealthSnapshot(rawURL string, health *ffmpeg.StreamHealth) streamHealthSnapshot {
 	snapshot := streamHealthSnapshot{
+		RawURL:             rawURL,
 		IsHealthy:          health.IsHealthy,
 		ProcessState:       health.ProcessState.String(),
 		RestartCount:       health.RestartCount,
@@ -602,7 +613,7 @@ func createHealthSnapshot(health *ffmpeg.StreamHealth) streamHealthSnapshot {
 }
 
 // hasHealthChanged checks if stream health has changed significantly
-func hasHealthChanged(prev, current streamHealthSnapshot) bool {
+func hasHealthChanged(prev, current *streamHealthSnapshot) bool {
 	return prev.IsHealthy != current.IsHealthy ||
 		prev.ProcessState != current.ProcessState ||
 		prev.LastErrorType != current.LastErrorType ||
@@ -611,7 +622,7 @@ func hasHealthChanged(prev, current streamHealthSnapshot) bool {
 }
 
 // determineEventType determines the appropriate event type based on what changed
-func determineEventType(prev, current streamHealthSnapshot) string {
+func determineEventType(prev, current *streamHealthSnapshot) string {
 	// Prioritize event types by importance
 	if prev.ProcessState != current.ProcessState {
 		return "state_change"
@@ -642,10 +653,9 @@ func (c *Controller) processStreamHealthUpdates(ctx echo.Context, clientID strin
 	registry := c.engine.Registry()
 
 	for sourceID, health := range healthData {
-		currentSnapshot := createHealthSnapshot(health)
-
 		// Resolve the connection URL for SSE events (sourceID is an internal key, not a URL)
 		rawURL := c.resolveSourceURL(registry, sourceID)
+		currentSnapshot := createHealthSnapshot(rawURL, health)
 
 		// Check if this is a new stream or if something changed
 		previousSnapshot, exists := previousState[sourceID]
@@ -658,9 +668,9 @@ func (c *Controller) processStreamHealthUpdates(ctx echo.Context, clientID strin
 					logger.Error(err))
 				return err
 			}
-		} else if hasHealthChanged(previousSnapshot, currentSnapshot) {
+		} else if hasHealthChanged(&previousSnapshot, &currentSnapshot) {
 			// Stream health changed
-			eventType := determineEventType(previousSnapshot, currentSnapshot)
+			eventType := determineEventType(&previousSnapshot, &currentSnapshot)
 			if err := c.sendStreamHealthUpdate(ctx, rawURL, health, eventType); err != nil {
 				c.logDebugIfEnabled("Failed to send health update, client disconnected",
 					logger.String("url", privacy.SanitizeStreamUrl(rawURL)),
@@ -682,15 +692,14 @@ func (c *Controller) processStreamHealthUpdates(ctx echo.Context, clientID strin
 
 // processRemovedStreams checks for and processes streams that have been removed
 func (c *Controller) processRemovedStreams(ctx echo.Context, clientID string, healthData map[string]*ffmpeg.StreamHealth, previousState map[string]streamHealthSnapshot) error {
-	registry := c.engine.Registry()
-
-	for prevSourceID := range previousState {
+	for prevSourceID, prevSnapshot := range previousState {
 		if _, exists := healthData[prevSourceID]; exists {
 			continue
 		}
 
-		// Stream was removed — resolve the connection URL for the SSE event
-		rawURL := c.resolveSourceURL(registry, prevSourceID)
+		// Stream was removed; use the cached URL from the snapshot since the
+		// source has already been unregistered from the registry.
+		rawURL := prevSnapshot.RawURL
 		sanitizedURL := privacy.SanitizeStreamUrl(rawURL)
 		emptyHealth := ffmpeg.StreamHealth{}
 		response := convertStreamHealthToResponse(rawURL, &emptyHealth)

--- a/internal/api/v2/streams_health_test.go
+++ b/internal/api/v2/streams_health_test.go
@@ -25,7 +25,7 @@ func TestCreateHealthSnapshot(t *testing.T) {
 			LastErrorContext:   nil,
 		}
 
-		snapshot := createHealthSnapshot(health)
+		snapshot := createHealthSnapshot("rtsp://test/stream", health)
 
 		assert.True(t, snapshot.IsHealthy)
 		assert.Equal(t, "running", snapshot.ProcessState)
@@ -48,7 +48,7 @@ func TestCreateHealthSnapshot(t *testing.T) {
 			},
 		}
 
-		snapshot := createHealthSnapshot(health)
+		snapshot := createHealthSnapshot("rtsp://test/stream", health)
 
 		assert.False(t, snapshot.IsHealthy)
 		assert.Equal(t, "circuit_open", snapshot.ProcessState)
@@ -68,7 +68,7 @@ func TestCreateHealthSnapshot(t *testing.T) {
 			LastErrorContext:   nil,
 		}
 
-		snapshot := createHealthSnapshot(health)
+		snapshot := createHealthSnapshot("rtsp://test/stream", health)
 
 		assert.Empty(t, snapshot.LastErrorType)
 		assert.True(t, snapshot.IsHealthy)
@@ -86,7 +86,7 @@ func TestCreateHealthSnapshot(t *testing.T) {
 			},
 		}
 
-		snapshot := createHealthSnapshot(health)
+		snapshot := createHealthSnapshot("rtsp://test/stream", health)
 
 		assert.Equal(t, "backoff", snapshot.ProcessState)
 		assert.Equal(t, 3, snapshot.RestartCount)
@@ -107,7 +107,7 @@ func TestHasHealthChanged(t *testing.T) {
 		}
 		current := prev
 
-		assert.False(t, hasHealthChanged(prev, current))
+		assert.False(t, hasHealthChanged(&prev, &current))
 	})
 
 	t.Run("health status changed", func(t *testing.T) {
@@ -122,7 +122,7 @@ func TestHasHealthChanged(t *testing.T) {
 		current := prev
 		current.IsHealthy = false
 
-		assert.True(t, hasHealthChanged(prev, current))
+		assert.True(t, hasHealthChanged(&prev, &current))
 	})
 
 	t.Run("process state changed", func(t *testing.T) {
@@ -137,7 +137,7 @@ func TestHasHealthChanged(t *testing.T) {
 		current := prev
 		current.ProcessState = "circuit_open"
 
-		assert.True(t, hasHealthChanged(prev, current))
+		assert.True(t, hasHealthChanged(&prev, &current))
 	})
 
 	t.Run("error type changed", func(t *testing.T) {
@@ -152,7 +152,7 @@ func TestHasHealthChanged(t *testing.T) {
 		current := prev
 		current.LastErrorType = testErrorTypeTimeout
 
-		assert.True(t, hasHealthChanged(prev, current))
+		assert.True(t, hasHealthChanged(&prev, &current))
 	})
 
 	t.Run("restart count increased", func(t *testing.T) {
@@ -167,7 +167,7 @@ func TestHasHealthChanged(t *testing.T) {
 		current := prev
 		current.RestartCount = 4
 
-		assert.True(t, hasHealthChanged(prev, current))
+		assert.True(t, hasHealthChanged(&prev, &current))
 	})
 
 	t.Run("data flow status changed", func(t *testing.T) {
@@ -182,7 +182,7 @@ func TestHasHealthChanged(t *testing.T) {
 		current := prev
 		current.IsReceivingData = false
 
-		assert.True(t, hasHealthChanged(prev, current))
+		assert.True(t, hasHealthChanged(&prev, &current))
 	})
 
 	t.Run("total bytes changed but not tracked as change", func(t *testing.T) {
@@ -198,7 +198,7 @@ func TestHasHealthChanged(t *testing.T) {
 		current.TotalBytesReceived = 2048
 
 		// Byte count changes should NOT trigger hasHealthChanged
-		assert.False(t, hasHealthChanged(prev, current))
+		assert.False(t, hasHealthChanged(&prev, &current))
 	})
 
 	t.Run("multiple changes simultaneously", func(t *testing.T) {
@@ -219,7 +219,7 @@ func TestHasHealthChanged(t *testing.T) {
 			TotalBytesReceived: 1024,
 		}
 
-		assert.True(t, hasHealthChanged(prev, current))
+		assert.True(t, hasHealthChanged(&prev, &current))
 	})
 }
 
@@ -241,7 +241,7 @@ func TestDetermineEventType(t *testing.T) {
 			IsReceivingData: false,
 		}
 
-		eventType := determineEventType(prev, current)
+		eventType := determineEventType(&prev, &current)
 		assert.Equal(t, "state_change", eventType)
 	})
 
@@ -258,7 +258,7 @@ func TestDetermineEventType(t *testing.T) {
 		current.LastErrorType = ""
 		current.IsReceivingData = true
 
-		eventType := determineEventType(prev, current)
+		eventType := determineEventType(&prev, &current)
 		assert.Equal(t, "health_recovered", eventType)
 	})
 
@@ -274,7 +274,7 @@ func TestDetermineEventType(t *testing.T) {
 		current.IsHealthy = false
 		current.LastErrorType = testErrorTypeTimeout
 
-		eventType := determineEventType(prev, current)
+		eventType := determineEventType(&prev, &current)
 		assert.Equal(t, "health_degraded", eventType)
 	})
 
@@ -289,7 +289,7 @@ func TestDetermineEventType(t *testing.T) {
 		current := prev
 		current.LastErrorType = testErrorTypeTimeout
 
-		eventType := determineEventType(prev, current)
+		eventType := determineEventType(&prev, &current)
 		assert.Equal(t, "error_detected", eventType)
 	})
 
@@ -304,7 +304,7 @@ func TestDetermineEventType(t *testing.T) {
 		current := prev
 		current.LastErrorType = "rtsp_404"
 
-		eventType := determineEventType(prev, current)
+		eventType := determineEventType(&prev, &current)
 		assert.Equal(t, "error_detected", eventType)
 	})
 
@@ -319,7 +319,7 @@ func TestDetermineEventType(t *testing.T) {
 		current := prev
 		current.RestartCount = 3
 
-		eventType := determineEventType(prev, current)
+		eventType := determineEventType(&prev, &current)
 		assert.Equal(t, "stream_restarted", eventType)
 	})
 
@@ -334,7 +334,7 @@ func TestDetermineEventType(t *testing.T) {
 		current := prev
 		current.IsReceivingData = true
 
-		eventType := determineEventType(prev, current)
+		eventType := determineEventType(&prev, &current)
 		assert.Equal(t, "data_flow_resumed", eventType)
 	})
 
@@ -349,7 +349,7 @@ func TestDetermineEventType(t *testing.T) {
 		current := prev
 		current.IsReceivingData = false
 
-		eventType := determineEventType(prev, current)
+		eventType := determineEventType(&prev, &current)
 		assert.Equal(t, "data_flow_stopped", eventType)
 	})
 
@@ -365,7 +365,7 @@ func TestDetermineEventType(t *testing.T) {
 		}
 		current := prev
 
-		eventType := determineEventType(prev, current)
+		eventType := determineEventType(&prev, &current)
 		assert.Equal(t, "status_update", eventType)
 	})
 }

--- a/internal/api/v2/streams_health_test.go
+++ b/internal/api/v2/streams_health_test.go
@@ -27,6 +27,7 @@ func TestCreateHealthSnapshot(t *testing.T) {
 
 		snapshot := createHealthSnapshot("rtsp://test/stream", health)
 
+		assert.Equal(t, "rtsp://test/stream", snapshot.RawURL)
 		assert.True(t, snapshot.IsHealthy)
 		assert.Equal(t, "running", snapshot.ProcessState)
 		assert.Equal(t, 0, snapshot.RestartCount)
@@ -48,8 +49,9 @@ func TestCreateHealthSnapshot(t *testing.T) {
 			},
 		}
 
-		snapshot := createHealthSnapshot("rtsp://test/stream", health)
+		snapshot := createHealthSnapshot("rtsp://test/unhealthy", health)
 
+		assert.Equal(t, "rtsp://test/unhealthy", snapshot.RawURL)
 		assert.False(t, snapshot.IsHealthy)
 		assert.Equal(t, "circuit_open", snapshot.ProcessState)
 		assert.Equal(t, 5, snapshot.RestartCount)

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -663,26 +663,27 @@ func (o *Orchestrator) loadAdditionalModels(threadAlloc map[string]int) error {
 			continue
 		}
 
-		o.mu.Lock()
-		_, exists := o.models[registryID]
-		if exists {
-			o.mu.Unlock()
-			continue
-		}
+		// Closure with defer ensures the mutex is released even if a
+		// loader panics during model initialization.
+		loadErr := func() error {
+			o.mu.Lock()
+			defer o.mu.Unlock()
 
-		threads := threadAlloc[registryID]
-		loader, implemented := modelLoaders[registryID]
-		if !implemented {
-			o.mu.Unlock()
-			log.Warn("Loader not yet implemented, skipping",
-				logger.String("registry_id", registryID))
-			continue
-		}
+			if _, exists := o.models[registryID]; exists {
+				return nil
+			}
 
-		// Hold the lock through the loader call because loaders write
-		// directly to o.models (e.g., loadPerch, loadBat).
-		loadErr := loader(o, threads)
-		o.mu.Unlock()
+			loader, implemented := modelLoaders[registryID]
+			if !implemented {
+				log.Warn("Loader not yet implemented, skipping",
+					logger.String("registry_id", registryID))
+				return nil
+			}
+
+			// Hold the lock through the loader call because loaders write
+			// directly to o.models (e.g., loadPerch, loadBat).
+			return loader(o, threadAlloc[registryID])
+		}()
 		if loadErr != nil {
 			log.Warn("optional model failed to load, will retry after gallery scan",
 				logger.String("registry_id", registryID),

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -481,11 +481,9 @@ func (o *Orchestrator) LoadModel(registryID string) error {
 	}
 
 	if _, exists := o.models[registryID]; exists {
-		return errors.Newf("model %s is already loaded", registryID).
-			Component("classifier.orchestrator").
-			Category(errors.CategoryValidation).
-			Context("registry_id", registryID).
-			Build()
+		log.Debug("model already loaded, skipping",
+			logger.String("registry_id", registryID))
+		return nil
 	}
 
 	loader, implemented := modelLoaders[registryID]
@@ -665,19 +663,25 @@ func (o *Orchestrator) loadAdditionalModels(threadAlloc map[string]int) error {
 			continue
 		}
 
-		// Skip the primary model (already loaded)
-		if _, exists := o.models[registryID]; exists {
+		o.mu.Lock()
+		_, exists := o.models[registryID]
+		if exists {
+			o.mu.Unlock()
 			continue
 		}
 
 		threads := threadAlloc[registryID]
-
 		loader, implemented := modelLoaders[registryID]
 		if !implemented {
+			o.mu.Unlock()
 			log.Warn("Loader not yet implemented, skipping",
 				logger.String("registry_id", registryID))
 			continue
 		}
+
+		// Release lock during expensive model loading to avoid blocking
+		// inference on concurrent goroutines.
+		o.mu.Unlock()
 		loadErr := loader(o, threads)
 		if loadErr != nil {
 			log.Warn("optional model failed to load, will retry after gallery scan",

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -679,10 +679,10 @@ func (o *Orchestrator) loadAdditionalModels(threadAlloc map[string]int) error {
 			continue
 		}
 
-		// Release lock during expensive model loading to avoid blocking
-		// inference on concurrent goroutines.
-		o.mu.Unlock()
+		// Hold the lock through the loader call because loaders write
+		// directly to o.models (e.g., loadPerch, loadBat).
 		loadErr := loader(o, threads)
+		o.mu.Unlock()
 		if loadErr != nil {
 			log.Warn("optional model failed to load, will retry after gallery scan",
 				logger.String("registry_id", registryID),

--- a/internal/conf/migrations.go
+++ b/internal/conf/migrations.go
@@ -365,8 +365,10 @@ func normalizeRTSPStreamEnabledDefaults(rawStreams any) ([]any, bool) {
 // prefixed with "error:"; non-fatal issues with "warning:".
 // knownIDs is the set of recognized config-level model identifiers; callers
 // should pass classifier.KnownConfigIDs() when available, or a hardcoded
-// fallback during early config loading.
-func (s *Settings) ValidateModelConfig(knownIDs map[string]bool) []string {
+// fallback during early config loading. When checkSourceRefs is true,
+// sources and streams are validated against models.enabled; set to false
+// during early loading before ScanInstalled has synced the enabled list.
+func (s *Settings) ValidateModelConfig(knownIDs map[string]bool, checkSourceRefs bool) []string {
 	var issues []string
 
 	enabledSet := make(map[string]bool, len(s.Models.Enabled))
@@ -380,18 +382,25 @@ func (s *Settings) ValidateModelConfig(knownIDs map[string]bool) []string {
 		}
 	}
 
-	for i := range s.Realtime.Audio.Sources {
-		src := &s.Realtime.Audio.Sources[i]
-		for _, modelID := range src.Models {
-			if !enabledSet[strings.ToLower(modelID)] {
-				issues = append(issues, "warning: source \""+src.Name+"\" references model \""+modelID+"\" not in models.enabled")
+	// Source/stream reference checks are skipped here. During early config
+	// loading, models.enabled is not yet synchronized with gallery-installed
+	// models (ScanInstalled runs later), so these checks produce false
+	// positives. The orchestrator re-validates with the authoritative model
+	// list after startup sync is complete.
+	if checkSourceRefs {
+		for i := range s.Realtime.Audio.Sources {
+			src := &s.Realtime.Audio.Sources[i]
+			for _, modelID := range src.Models {
+				if !enabledSet[strings.ToLower(modelID)] {
+					issues = append(issues, "warning: source \""+src.Name+"\" references model \""+modelID+"\" not in models.enabled")
+				}
 			}
 		}
-	}
-	for _, stream := range s.Realtime.RTSP.AllStreams() {
-		for _, modelID := range stream.Models {
-			if !enabledSet[strings.ToLower(modelID)] {
-				issues = append(issues, "warning: stream \""+stream.Name+"\" references model \""+modelID+"\" not in models.enabled")
+		for _, stream := range s.Realtime.RTSP.AllStreams() {
+			for _, modelID := range stream.Models {
+				if !enabledSet[strings.ToLower(modelID)] {
+					issues = append(issues, "warning: stream \""+stream.Name+"\" references model \""+modelID+"\" not in models.enabled")
+				}
 			}
 		}
 	}
@@ -408,7 +417,7 @@ func (s *Settings) applyModelValidation() error {
 	// This fallback is used during config loading before the classifier package
 	// is available. The orchestrator re-validates with the authoritative list.
 	knownIDs := map[string]bool{ModelIDBirdNET: true, ModelIDPerchV2: true, ModelIDBat: true, ModelIDBSG: true}
-	modelIssues := s.ValidateModelConfig(knownIDs)
+	modelIssues := s.ValidateModelConfig(knownIDs, false)
 	var fatalErrors []string
 	for _, issue := range modelIssues {
 		if strings.HasPrefix(issue, "error:") {

--- a/internal/conf/migrations.go
+++ b/internal/conf/migrations.go
@@ -371,23 +371,21 @@ func normalizeRTSPStreamEnabledDefaults(rawStreams any) ([]any, bool) {
 func (s *Settings) ValidateModelConfig(knownIDs map[string]bool, checkSourceRefs bool) []string {
 	var issues []string
 
-	enabledSet := make(map[string]bool, len(s.Models.Enabled))
-	for _, id := range s.Models.Enabled {
-		enabledSet[strings.ToLower(id)] = true
-	}
-
 	for _, id := range s.Models.Enabled {
 		if !knownIDs[strings.ToLower(id)] {
 			issues = append(issues, "warning: unknown model ID in models.enabled: "+id)
 		}
 	}
 
-	// Source/stream reference checks are skipped here. During early config
-	// loading, models.enabled is not yet synchronized with gallery-installed
-	// models (ScanInstalled runs later), so these checks produce false
-	// positives. The orchestrator re-validates with the authoritative model
-	// list after startup sync is complete.
+	// During early config loading, models.enabled is not yet synchronized
+	// with gallery-installed models (ScanInstalled runs later), so these
+	// checks produce false positives. The orchestrator re-validates with
+	// the authoritative model list after startup sync is complete.
 	if checkSourceRefs {
+		enabledSet := make(map[string]bool, len(s.Models.Enabled))
+		for _, id := range s.Models.Enabled {
+			enabledSet[strings.ToLower(id)] = true
+		}
 		for i := range s.Realtime.Audio.Sources {
 			src := &s.Realtime.Audio.Sources[i]
 			for _, modelID := range src.Models {

--- a/internal/conf/multi_model_config_test.go
+++ b/internal/conf/multi_model_config_test.go
@@ -116,6 +116,17 @@ func TestValidateModelConfig_SourceReferencesUnavailableModel(t *testing.T) {
 	assert.NotEmpty(t, warnings, "source referencing model not in models.enabled should warn")
 }
 
+func TestValidateModelConfig_SkipSourceRefsAtEarlyLoading(t *testing.T) {
+	t.Parallel()
+	settings := &Settings{}
+	settings.Models.Enabled = []string{"birdnet"}
+	settings.Realtime.Audio.Sources = []AudioSourceConfig{
+		{Name: "Mic1", Device: "hw:0,0", Models: []string{"birdnet", "perch_v2"}},
+	}
+	warnings := settings.ValidateModelConfig(testKnownIDs, false)
+	assert.Empty(t, warnings, "source reference checks should be skipped when checkSourceRefs is false")
+}
+
 func TestBirdNETConfig_VersionField(t *testing.T) {
 	t.Parallel()
 	settings := &Settings{}

--- a/internal/conf/multi_model_config_test.go
+++ b/internal/conf/multi_model_config_test.go
@@ -93,7 +93,7 @@ func TestValidateModelConfig_NoErrorsWithJustBirdNET(t *testing.T) {
 	t.Parallel()
 	settings := &Settings{}
 	settings.Models.Enabled = []string{"birdnet"}
-	errs := settings.ValidateModelConfig(testKnownIDs)
+	errs := settings.ValidateModelConfig(testKnownIDs, true)
 	assert.Empty(t, errs, "should have no errors with just BirdNET")
 }
 
@@ -101,7 +101,7 @@ func TestValidateModelConfig_UnknownModelWarning(t *testing.T) {
 	t.Parallel()
 	settings := &Settings{}
 	settings.Models.Enabled = []string{"birdnet", "unknown_model"}
-	warnings := settings.ValidateModelConfig(testKnownIDs)
+	warnings := settings.ValidateModelConfig(testKnownIDs, true)
 	assert.NotEmpty(t, warnings, "unknown model ID should produce a warning")
 }
 
@@ -112,7 +112,7 @@ func TestValidateModelConfig_SourceReferencesUnavailableModel(t *testing.T) {
 	settings.Realtime.Audio.Sources = []AudioSourceConfig{
 		{Name: "Mic1", Device: "hw:0,0", Models: []string{"birdnet", "perch_v2"}},
 	}
-	warnings := settings.ValidateModelConfig(testKnownIDs)
+	warnings := settings.ValidateModelConfig(testKnownIDs, true)
 	assert.NotEmpty(t, warnings, "source referencing model not in models.enabled should warn")
 }
 


### PR DESCRIPTION
## Summary

- **Stream health SSE fixes** (`streams_health.go`):
  - Add engine nil guard to `StreamHealthUpdates` SSE endpoint, matching the pattern used by `GetAllStreamsHealth`, `GetStreamHealth`, and `GetStreamsStatusSummary` (returns 503 if engine not initialized)
  - Cache raw URL in `streamHealthSnapshot` so `stream_removed` events carry the URL even after the source is unregistered from the registry
  - Add `settingsMutex.RLock` to `getStreamInfo` to prevent race with hot-reload settings updates
  - Pass `hasHealthChanged`/`determineEventType` by pointer to satisfy gocritic hugeParam after adding `RawURL` field

- **Orchestrator locking** (`orchestrator.go`):
  - Make `LoadModel` treat "already loaded" as a benign no-op (debug log + return nil) instead of returning a validation error that fires Sentry events
  - Add `o.mu` lock to `loadAdditionalModels` for the models map check, holding it through the loader call since loaders write directly to `o.models`

- **Model validation ordering** (`migrations.go`):
  - Add `checkSourceRefs` parameter to `ValidateModelConfig` to skip source/stream reference checks during early config loading (before `ScanInstalled` has synced `models.enabled` with gallery-installed models)
  - Early loading passes `false` to avoid false-positive warnings; the orchestrator re-validates with the authoritative list after startup sync

## Test Plan

- [x] `TestCreateHealthSnapshot` - verifies `RawURL` is cached in snapshot
- [x] `TestHasHealthChanged` - pointer params, all change/no-change scenarios
- [x] `TestDetermineEventType` - pointer params, all event type priorities
- [x] `TestValidateModelConfig_SkipSourceRefsAtEarlyLoading` - new test for `checkSourceRefs=false`
- [x] `TestValidateModelConfig_SourceReferencesUnavailableModel` - existing test with `checkSourceRefs=true`
- [x] `golangci-lint` clean, `go test -race` passing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stream health monitoring now checks audio engine initialization and returns 503 when unready before opening connections
  * Model loading no longer errors when a model is already present
  * Configuration validation avoids false-positive warnings during startup by deferring source-reference checks

* **Tests**
  * Updated tests for stream-health change detection and for the parameterized model-validation behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3060)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->