### PR TITLE
fix(frontend): use server timezone for daily activity grid and date navigation

### DIFF
--- a/frontend/src/lib/desktop/features/dashboard/components/DailySummaryCard.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/components/DailySummaryCard.svelte
@@ -51,7 +51,7 @@ Responsive Breakpoints:
   import SkeletonDailySummary from '$lib/desktop/components/ui/SkeletonDailySummary.svelte';
   import { t } from '$lib/i18n';
   import type { DailySpeciesSummary } from '$lib/types/detection.types';
-  import { getLocalDateString, getLocalTimeString, parseLocalDateString } from '$lib/utils/date';
+  import { getLocalDateString, getDateInTimezone } from '$lib/utils/date';
   import {
     buildHourlyDetectionUrl,
     buildSpeciesDetectionUrl,
@@ -126,6 +126,7 @@ Responsive Breakpoints:
   interface SunTimes {
     sunrise: string; // ISO date string
     sunset: string; // ISO date string
+    timezone: string; // IANA timezone name from server
   }
 
   // Hourly weather data from API
@@ -188,6 +189,7 @@ Responsive Breakpoints:
     onNextDay: () => void;
     onGoToToday: () => void;
     onDateChange: (_date: string) => void;
+    onServerTimezone?: (_timezone: string) => void;
   }
 
   let {
@@ -201,6 +203,7 @@ Responsive Breakpoints:
     onNextDay,
     onGoToToday,
     onDateChange,
+    onServerTimezone,
   }: Props = $props();
 
   // Progressive loading state management
@@ -209,6 +212,9 @@ Responsive Breakpoints:
 
   // Sun times state
   let sunTimes = $state<SunTimes | null>(null);
+
+  // Server timezone from sun times API (used for date constraints)
+  let serverTimezone = $state('');
 
   // Hourly weather state
   let hourlyWeather = $state<HourlyWeatherResponse[]>([]);
@@ -272,6 +278,7 @@ Responsive Breakpoints:
       const sunTimesData: SunTimes = {
         sunrise: responseData.sunrise,
         sunset: responseData.sunset,
+        timezone: responseData.timezone ?? '',
       };
 
       // Cache the result
@@ -295,6 +302,11 @@ Responsive Breakpoints:
         // Only update if this is still the current date (prevents race condition)
         if (selectedDate === currentDate) {
           sunTimes = times;
+          // Propagate server timezone to parent for date navigation constraints
+          if (times?.timezone && times.timezone !== serverTimezone) {
+            serverTimezone = times.timezone;
+            onServerTimezone?.(times.timezone);
+          }
         }
       });
     }
@@ -352,12 +364,17 @@ Responsive Breakpoints:
     }
   });
 
-  // Calculate which hour column corresponds to sunrise/sunset
+  // Calculate which hour column corresponds to sunrise/sunset.
+  // Parses the hour directly from the RFC3339 string to preserve the server's timezone.
+  // Using new Date().getHours() would convert to browser local time, causing wrong
+  // column placement when browser and server are in different timezones (#3005).
   const getSunHourFromTime = (timeStr: string): number | null => {
     if (!timeStr) return null;
     try {
-      const date = new Date(timeStr);
-      return date.getHours();
+      const tIndex = timeStr.indexOf('T');
+      if (tIndex === -1) return null;
+      const hour = parseInt(timeStr.substring(tIndex + 1, tIndex + 3), 10);
+      return isNaN(hour) || hour < 0 || hour > 23 ? null : hour;
     } catch (parseError) {
       logger.error('Error parsing time', parseError, { timeStr });
       return null;
@@ -664,7 +681,11 @@ Responsive Breakpoints:
 
   // LRU cache automatically manages memory, no need for periodic cleanup
 
-  const isToday = $derived(selectedDate === getLocalDateString());
+  // Use server timezone for "today" check when available, falling back to browser local
+  const serverTodayDate = $derived(
+    serverTimezone ? getDateInTimezone(serverTimezone) : getLocalDateString()
+  );
+  const isToday = $derived(selectedDate === serverTodayDate);
 
   // Check for reduced motion preference for performance and accessibility
   const prefersReducedMotion = $derived(
@@ -740,6 +761,7 @@ Responsive Breakpoints:
       value={selectedDate}
       onChange={onDateChange}
       onTodayClick={onGoToToday}
+      maxDate={serverTodayDate}
       className="mx-auto md:mx-2 w-auto"
     />
 
@@ -757,9 +779,9 @@ Responsive Breakpoints:
 
 {#snippet sunIcon(sunType: 'sunrise' | 'sunset', sunTime: string | undefined, shouldShow: boolean)}
   {#if shouldShow && sunTime}
-    {@const parsedDate = parseLocalDateString(sunTime)}
-    {#if parsedDate}
-      {@const formattedTime = getLocalTimeString(parsedDate, false)}
+    {@const tIdx = sunTime.indexOf('T')}
+    {@const formattedTime = tIdx !== -1 ? sunTime.substring(tIdx + 1, tIdx + 6) : ''}
+    {#if formattedTime}
       <div
         class="sun-icon-wrapper"
         title={t(`dashboard.dailySummary.daylight.${sunType}`, { time: formattedTime })}

--- a/frontend/src/lib/desktop/features/dashboard/components/DailySummaryCard.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/components/DailySummaryCard.svelte
@@ -681,10 +681,20 @@ Responsive Breakpoints:
 
   // LRU cache automatically manages memory, no need for periodic cleanup
 
+  // Minute-level tick so serverTodayDate recomputes across midnight
+  let nowTick = $state(Date.now());
+  $effect(() => {
+    const id = setInterval(() => {
+      nowTick = Date.now();
+    }, 60_000);
+    return () => clearInterval(id);
+  });
+
   // Use server timezone for "today" check when available, falling back to browser local
-  const serverTodayDate = $derived(
-    serverTimezone ? getDateInTimezone(serverTimezone) : getLocalDateString()
-  );
+  const serverTodayDate = $derived.by(() => {
+    void nowTick;
+    return serverTimezone ? getDateInTimezone(serverTimezone) : getLocalDateString();
+  });
   const isToday = $derived(selectedDate === serverTodayDate);
 
   // Check for reduced motion preference for performance and accessibility

--- a/frontend/src/lib/desktop/features/dashboard/pages/DashboardPage.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/pages/DashboardPage.svelte
@@ -943,11 +943,21 @@ Performance Optimizations:
     }
   }
 
+  // Minute-level tick so serverTodayDate recomputes across midnight
+  let nowTick = $state(Date.now());
+  $effect(() => {
+    const id = setInterval(() => {
+      nowTick = Date.now();
+    }, 60_000);
+    return () => clearInterval(id);
+  });
+
   // Server-aware "today" date: uses server timezone when known, falls back to browser local.
   // All date comparisons that gate navigation or SSE updates should use this, not getLocalDateString().
-  const serverTodayDate = $derived(
-    serverTimezone ? getDateInTimezone(serverTimezone) : getLocalDateString()
-  );
+  const serverTodayDate = $derived.by(() => {
+    void nowTick;
+    return serverTimezone ? getDateInTimezone(serverTimezone) : getLocalDateString();
+  });
 
   // Derived state to check if we're viewing today's data
   const isViewingToday = $derived(selectedDate === serverTodayDate);

--- a/frontend/src/lib/desktop/features/dashboard/pages/DashboardPage.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/pages/DashboardPage.svelte
@@ -48,7 +48,7 @@ Performance Optimizations:
   import type { PendingDetection } from '$lib/types/pending.types';
   import {
     getLocalDateString,
-    isFutureDate,
+    getDateInTimezone,
     parseHour,
     parseLocalDateString,
   } from '$lib/utils/date';
@@ -163,6 +163,12 @@ Performance Optimizations:
   let summaryLimit = $state(30); // Default from backend (conf/defaults.go) - species count limit for daily summary
   let configLoaded = $state(false); // Gates reactive preloading until config is loaded
   let pendingDetections = $state<PendingDetection[]>([]);
+
+  // Server timezone from sun times API, used for date navigation constraints.
+  // When the server is ahead of the browser (e.g., server in Sydney, browser in California),
+  // the server's "today" may be the browser's "tomorrow". Without this, the date picker
+  // blocks navigation to the server's current date (#3005).
+  let serverTimezone = $state('');
 
   // Subscribe to edit mode store
   let isEditing = $derived($dashboardEditMode);
@@ -801,8 +807,8 @@ Performance Optimizations:
         handleDateChangeWithCleanup();
         fetchDailySummary();
       } else if (!urlDate) {
-        // If no date in URL, use current date
-        const currentDate = getLocalDateString();
+        // If no date in URL, use current date (server timezone when available)
+        const currentDate = serverTodayDate;
         if (currentDate !== selectedDate) {
           selectedDate = currentDate;
           handleDateChangeWithCleanup();
@@ -891,7 +897,7 @@ Performance Optimizations:
     if (!date) return;
     date.setDate(date.getDate() + 1);
     const newDateString = getLocalDateString(date);
-    if (!isFutureDate(newDateString)) {
+    if (newDateString <= serverTodayDate) {
       selectedDate = newDateString;
       persistDate(newDateString);
       handleDateChangeWithCleanup();
@@ -916,9 +922,9 @@ Performance Optimizations:
    * Clears both URL parameter and localStorage to show current date
    */
   function goToToday() {
-    // Reset date persistence and navigate to today
+    // Reset date persistence and navigate to today (using server timezone when available)
     resetDateToToday();
-    const currentDate = getLocalDateString();
+    const currentDate = serverTodayDate;
     selectedDate = currentDate;
     handleDateChangeWithCleanup();
     fetchDailySummary();
@@ -937,8 +943,14 @@ Performance Optimizations:
     }
   }
 
+  // Server-aware "today" date: uses server timezone when known, falls back to browser local.
+  // All date comparisons that gate navigation or SSE updates should use this, not getLocalDateString().
+  const serverTodayDate = $derived(
+    serverTimezone ? getDateInTimezone(serverTimezone) : getLocalDateString()
+  );
+
   // Derived state to check if we're viewing today's data
-  const isViewingToday = $derived(selectedDate === getLocalDateString());
+  const isViewingToday = $derived(selectedDate === serverTodayDate);
 
   // Location availability for banner map toggle
   let birdnet = $derived($birdnetSettings);
@@ -1002,14 +1014,14 @@ Performance Optimizations:
     }
 
     // Additional safety check: ensure detection is for today and matches selected date
-    if (detection.date !== selectedDate && detection.date !== getLocalDateString()) {
+    if (detection.date !== selectedDate && detection.date !== serverTodayDate) {
       logger.debug(
         'Skipping daily summary update - detection date mismatch:',
         detection.date,
         'vs',
         selectedDate,
         'today:',
-        getLocalDateString()
+        serverTodayDate
       );
       return;
     }
@@ -1174,11 +1186,11 @@ Performance Optimizations:
     prevDate.setDate(prevDate.getDate() - 1);
     dates.push(getLocalDateString(prevDate));
 
-    // Next date (only if not future)
+    // Next date (only if not past the server's today)
     const nextDate = new Date(base);
     nextDate.setDate(nextDate.getDate() + 1);
     const nextDateString = getLocalDateString(nextDate);
-    if (!isFutureDate(nextDateString)) {
+    if (nextDateString <= serverTodayDate) {
       dates.push(nextDateString);
     }
 
@@ -1571,6 +1583,9 @@ Performance Optimizations:
           onNextDay={nextDay}
           onGoToToday={goToToday}
           onDateChange={handleDateChange}
+          onServerTimezone={tz => {
+            serverTimezone = tz;
+          }}
         />
       {:else if element.type === 'currently-hearing'}
         <CurrentlyHearingCard detections={isViewingToday ? pendingDetections : []} />

--- a/frontend/src/lib/utils/date.test.ts
+++ b/frontend/src/lib/utils/date.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import {
   getLocalDateString,
+  getDateInTimezone,
   parseLocalDateString,
   isToday,
   isFutureDate,
@@ -354,6 +355,36 @@ describe('Date Utilities', () => {
 
       expect(getLocalDateString(endOfYear)).toBe('2023-12-31');
       expect(getLocalDateString(startOfNewYear)).toBe('2024-01-01');
+    });
+  });
+
+  describe('getDateInTimezone', () => {
+    it('should return a valid YYYY-MM-DD string', () => {
+      const result = getDateInTimezone('America/New_York');
+      expect(result).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    });
+
+    it('should return different dates for timezones across the date line', () => {
+      // Fix time to just after midnight UTC so Pacific/Auckland (UTC+12) is already
+      // on the next day while America/Los_Angeles (UTC-7) is still on the previous day
+      vi.setSystemTime(new Date('2024-06-15T00:30:00Z'));
+
+      const auckland = getDateInTimezone('Pacific/Auckland');
+      const losAngeles = getDateInTimezone('America/Los_Angeles');
+
+      // Auckland at UTC 00:30 is Jun 15 12:30 NZST, LA is Jun 14 17:30 PDT
+      expect(auckland).toBe('2024-06-15');
+      expect(losAngeles).toBe('2024-06-14');
+    });
+
+    it('should fall back to local date for invalid timezone', () => {
+      const result = getDateInTimezone('Invalid/Timezone');
+      expect(result).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    });
+
+    it('should handle UTC timezone', () => {
+      vi.setSystemTime(new Date('2024-03-10T12:00:00Z'));
+      expect(getDateInTimezone('UTC')).toBe('2024-03-10');
     });
   });
 });

--- a/frontend/src/lib/utils/date.ts
+++ b/frontend/src/lib/utils/date.ts
@@ -80,6 +80,27 @@ export function isFutureDate(dateString: string): boolean {
 }
 
 /**
+ * Get the current date as YYYY-MM-DD in a specific IANA timezone.
+ * Uses Intl.DateTimeFormat for correct DST handling.
+ *
+ * @param timezone - IANA timezone name (e.g., "Australia/Sydney", "America/Los_Angeles")
+ * @returns Date string in YYYY-MM-DD format, or browser local date if timezone is invalid
+ */
+export function getDateInTimezone(timezone: string): string {
+  try {
+    const formatter = new Intl.DateTimeFormat('en-CA', {
+      timeZone: timezone,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    });
+    return formatter.format(new Date());
+  } catch {
+    return getLocalDateString();
+  }
+}
+
+/**
  * Parse a time string (HH:MM:SS) and extract the hour component
  *
  * @param timeString - Time string in HH:MM:SS format

--- a/internal/api/v2/weather.go
+++ b/internal/api/v2/weather.go
@@ -586,6 +586,7 @@ type SunTimesResponse struct {
 	Sunset    time.Time `json:"sunset"`
 	CivilDawn time.Time `json:"civil_dawn"`
 	CivilDusk time.Time `json:"civil_dusk"`
+	Timezone  string    `json:"timezone"` // IANA timezone name derived from observer coordinates
 }
 
 // GetSunTimes handles GET /api/v2/weather/sun/:date
@@ -649,6 +650,7 @@ func (c *Controller) GetSunTimes(ctx echo.Context) error {
 		Sunset:    sunTimes.Sunset,
 		CivilDawn: sunTimes.CivilDawn,
 		CivilDusk: sunTimes.CivilDusk,
+		Timezone:  c.SunCalc.LocationName(),
 	}
 
 	c.logInfoIfEnabled("Calculated sun times",

--- a/internal/suncalc/suncalc.go
+++ b/internal/suncalc/suncalc.go
@@ -176,6 +176,12 @@ func (sc *SunCalc) calculateSunEventTimes(date time.Time) (SunEventTimes, error)
 	}, nil
 }
 
+// LocationName returns the IANA timezone name for the observer's location
+// (e.g., "Australia/Sydney", "America/Los_Angeles").
+func (sc *SunCalc) LocationName() string {
+	return sc.location.String()
+}
+
 // GetSunriseTime returns the sunrise time for a given date
 func (sc *SunCalc) GetSunriseTime(date time.Time) (time.Time, error) {
 	sunEventTimes, err := sc.GetSunEventTimes(date)

--- a/internal/suncalc/suncalc_test.go
+++ b/internal/suncalc/suncalc_test.go
@@ -59,6 +59,17 @@ func TestGetSunsetTime(t *testing.T) {
 	assert.False(t, sunset.IsZero(), "sunset time is zero")
 }
 
+func TestLocationName(t *testing.T) {
+	sc := newTestSunCalc()
+
+	name := sc.LocationName()
+	assert.Equal(t, "Europe/Helsinki", name, "expected IANA timezone for Helsinki coordinates")
+
+	// Sydney coordinates
+	scSydney := NewSunCalc(-33.8688, 151.2093)
+	assert.Equal(t, "Australia/Sydney", scSydney.LocationName(), "expected IANA timezone for Sydney coordinates")
+}
+
 func TestCacheConsistency(t *testing.T) {
 	sc := newTestSunCalc()
 	date := midsummerDate()


### PR DESCRIPTION
## Summary

Fixes the Daily Activity grid being confused about timezones when the browser and server are in different timezones (e.g., server in Sydney AEST+10, browser in California PDT-7).

Two bugs fixed:

- **Sunrise/sunset icons in wrong column**: `getSunHourFromTime()` used `new Date(rfcString).getHours()` which converts to browser local time. Now parses the hour directly from the RFC3339 string to preserve the server's timezone.
- **Date picker blocks navigation to server's "today"**: The date picker `maxDate` and `nextDay()` guard used the browser's local date. When the server is ahead, the server's current date appears as "tomorrow" to the browser, blocking navigation. Now uses the server's IANA timezone from the sun times API response to compute the correct date constraints.

### Changes

**Backend:**
- `internal/suncalc/suncalc.go`: Add `LocationName()` method returning IANA timezone name
- `internal/api/v2/weather.go`: Add `timezone` field to `SunTimesResponse`

**Frontend:**
- `frontend/src/lib/utils/date.ts`: Add `getDateInTimezone()` utility using `Intl.DateTimeFormat` for DST-correct timezone date computation
- `DailySummaryCard.svelte`: Fix sunrise/sunset hour parsing from RFC3339 string; fix tooltip to show server-local time; propagate server timezone to parent via callback; use server date for `isToday` and DatePicker `maxDate`
- `DashboardPage.svelte`: Use server timezone for `nextDay()`, `goToToday()`, `isViewingToday`, `handlePopState`, `updateDailySummary` SSE check, and adjacent date preloading

**Tests:**
- `internal/suncalc/suncalc_test.go`: Test `LocationName()` for Helsinki and Sydney
- `frontend/src/lib/utils/date.test.ts`: Test `getDateInTimezone()` including cross-date-line, invalid timezone fallback, UTC

Fixes #3005

## Test Plan

- [x] Go tests pass (`go test -race ./internal/suncalc/`)
- [x] Go linter clean (`golangci-lint run -v`)
- [x] Frontend type check clean (`svelte-check` - 0 errors)
- [x] Frontend date tests pass (47/47)
- [x] QA container deployed and verified: API returns `timezone: "Europe/Helsinki"`, sunrise icon at correct column 04 (not column 01 as with old browser-local parsing)
- [x] Verified via Playwright: `parsedSunriseHour: 4` (correct) vs `browserLocalSunriseHour: 1` (old bug) in UTC browser

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboard now uses server-provided timezone to determine "today", constrain navigation, and display sunrise/sunset times consistently.
  * Date picker and "Today" action respect server-local date boundaries.

* **Bug Fixes**
  * Sunrise/sunset placement and tooltip times no longer shift due to browser-local conversions.

* **Tests**
  * Added tests for timezone-aware date utility to ensure correct date calculations across time zones.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3061)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->