### PR TITLE
fix(alerting): handle push action target in dispatcher

### DIFF
--- a/internal/alerting/constants.go
+++ b/internal/alerting/constants.go
@@ -85,6 +85,7 @@ const (
 // Action targets identify where notifications are sent.
 const (
 	TargetBell = "bell"
+	TargetPush = "push"
 )
 
 // Built-in rule i18n key constants.

--- a/internal/alerting/dispatcher.go
+++ b/internal/alerting/dispatcher.go
@@ -60,6 +60,7 @@ func (d *ActionDispatcher) dispatchInternal(rule *entities.AlertRule, event *Ale
 	if event == nil {
 		event = &AlertEvent{}
 	}
+	dispatched := false
 	for i := range rule.Actions {
 		action := &rule.Actions[i]
 		title := renderTitle(action.TemplateTitle, rule, event)
@@ -67,8 +68,16 @@ func (d *ActionDispatcher) dispatchInternal(rule *entities.AlertRule, event *Ale
 
 		switch action.Target {
 		case TargetBell, TargetPush:
+			// Both targets create and broadcast a notification through the
+			// same path. When a rule has both bell and push actions with
+			// identical (or empty) templates, skip the second dispatch to
+			// avoid duplicate notifications.
+			if dispatched && action.TemplateTitle == "" && action.TemplateMessage == "" {
+				continue
+			}
 			hasCustomTemplate := action.TemplateTitle != "" || action.TemplateMessage != ""
-			d.dispatchBell(title, message, rule, event, hasCustomTemplate, isTest)
+			d.dispatchNotification(action.Target, title, message, rule, event, hasCustomTemplate, isTest)
+			dispatched = true
 		default:
 			d.log.Warn("unknown alert action target",
 				logger.String("target", action.Target),
@@ -77,7 +86,7 @@ func (d *ActionDispatcher) dispatchInternal(rule *entities.AlertRule, event *Ale
 	}
 }
 
-func (d *ActionDispatcher) dispatchBell(title, message string, rule *entities.AlertRule, event *AlertEvent, hasCustomTemplate, isTest bool) {
+func (d *ActionDispatcher) dispatchNotification(target, title, message string, rule *entities.AlertRule, event *AlertEvent, hasCustomTemplate, isTest bool) {
 	if d.notifCreator == nil {
 		return
 	}
@@ -100,10 +109,11 @@ func (d *ActionDispatcher) dispatchBell(title, message string, rule *entities.Al
 			)
 		}
 		if err != nil {
-			d.log.Error("failed to create bell notification",
+			d.log.Error("failed to dispatch notification",
+				logger.String("target", target),
 				logger.Uint64("rule_id", uint64(rule.ID)),
 				logger.Error(err))
-			d.telemetry.ReportDispatchFailed(TargetBell, err.Error())
+			d.telemetry.ReportDispatchFailed(target, err.Error())
 		}
 		return
 	}
@@ -115,10 +125,11 @@ func (d *ActionDispatcher) dispatchBell(title, message string, rule *entities.Al
 		err = d.notifCreator.CreateAndBroadcast(notifType, title, message, event.Properties)
 	}
 	if err != nil {
-		d.log.Error("failed to create bell notification",
+		d.log.Error("failed to dispatch notification",
+			logger.String("target", target),
 			logger.Uint64("rule_id", uint64(rule.ID)),
 			logger.Error(err))
-		d.telemetry.ReportDispatchFailed(TargetBell, err.Error())
+		d.telemetry.ReportDispatchFailed(target, err.Error())
 	}
 }
 

--- a/internal/alerting/dispatcher.go
+++ b/internal/alerting/dispatcher.go
@@ -60,7 +60,7 @@ func (d *ActionDispatcher) dispatchInternal(rule *entities.AlertRule, event *Ale
 	if event == nil {
 		event = &AlertEvent{}
 	}
-	dispatched := false
+	defaultDispatched := false
 	for i := range rule.Actions {
 		action := &rule.Actions[i]
 		title := renderTitle(action.TemplateTitle, rule, event)
@@ -68,16 +68,17 @@ func (d *ActionDispatcher) dispatchInternal(rule *entities.AlertRule, event *Ale
 
 		switch action.Target {
 		case TargetBell, TargetPush:
-			// Both targets create and broadcast a notification through the
-			// same path. When a rule has both bell and push actions with
-			// identical (or empty) templates, skip the second dispatch to
-			// avoid duplicate notifications.
-			if dispatched && action.TemplateTitle == "" && action.TemplateMessage == "" {
+			hasCustomTemplate := action.TemplateTitle != "" || action.TemplateMessage != ""
+			// Both targets broadcast through the same path. Deduplicate
+			// only when multiple actions use default templates, since
+			// they produce identical notifications.
+			if !hasCustomTemplate && defaultDispatched {
 				continue
 			}
-			hasCustomTemplate := action.TemplateTitle != "" || action.TemplateMessage != ""
 			d.dispatchNotification(action.Target, title, message, rule, event, hasCustomTemplate, isTest)
-			dispatched = true
+			if !hasCustomTemplate {
+				defaultDispatched = true
+			}
 		default:
 			d.log.Warn("unknown alert action target",
 				logger.String("target", action.Target),

--- a/internal/alerting/dispatcher.go
+++ b/internal/alerting/dispatcher.go
@@ -66,7 +66,7 @@ func (d *ActionDispatcher) dispatchInternal(rule *entities.AlertRule, event *Ale
 		message := renderMessage(action.TemplateMessage, rule, event)
 
 		switch action.Target {
-		case TargetBell:
+		case TargetBell, TargetPush:
 			hasCustomTemplate := action.TemplateTitle != "" || action.TemplateMessage != ""
 			d.dispatchBell(title, message, rule, event, hasCustomTemplate, isTest)
 		default:

--- a/internal/alerting/dispatcher_test.go
+++ b/internal/alerting/dispatcher_test.go
@@ -283,7 +283,7 @@ func TestDispatcher_PushAction_DefaultTemplate(t *testing.T) {
 	assert.Equal(t, MsgAlertDetectionOccurred, mock.keyCalls[0].messageKey)
 }
 
-func TestDispatcher_BellAndPush(t *testing.T) {
+func TestDispatcher_BellAndPush_DefaultTemplates_Deduplicated(t *testing.T) {
 	mock := &mockNotifCreator{}
 	dispatcher := NewActionDispatcher(mock, dispatchTestLogger(), nil)
 
@@ -307,7 +307,34 @@ func TestDispatcher_BellAndPush(t *testing.T) {
 
 	dispatcher.Dispatch(rule, event)
 
-	assert.Len(t, mock.keyCalls, 2, "both bell and push should create notifications")
+	assert.Len(t, mock.keyCalls, 1, "bell+push with identical default templates should deduplicate to one notification")
+}
+
+func TestDispatcher_BellAndPush_DifferentTemplates(t *testing.T) {
+	mock := &mockNotifCreator{}
+	dispatcher := NewActionDispatcher(mock, dispatchTestLogger(), nil)
+
+	rule := &entities.AlertRule{
+		ID:   1,
+		Name: "Full Alert",
+		Actions: []entities.AlertAction{
+			{Target: TargetBell, TemplateTitle: "Bell: new bird"},
+			{Target: TargetPush, TemplateTitle: "Push: {{species_name}}"},
+		},
+	}
+	event := &AlertEvent{
+		ObjectType: ObjectTypeDetection,
+		EventName:  EventDetectionOccurred,
+		Properties: map[string]any{
+			PropertySpeciesName: "Rock Pigeon",
+			PropertyConfidence:  0.85,
+		},
+		Timestamp: time.Now(),
+	}
+
+	dispatcher.Dispatch(rule, event)
+
+	assert.Len(t, mock.calls, 2, "bell+push with different custom templates should create two notifications")
 }
 
 func TestDispatcher_UnknownTargetSkipped(t *testing.T) {

--- a/internal/alerting/dispatcher_test.go
+++ b/internal/alerting/dispatcher_test.go
@@ -310,6 +310,62 @@ func TestDispatcher_BellAndPush_DefaultTemplates_Deduplicated(t *testing.T) {
 	assert.Len(t, mock.keyCalls, 1, "bell+push with identical default templates should deduplicate to one notification")
 }
 
+func TestDispatcher_BellCustom_PushDefault(t *testing.T) {
+	mock := &mockNotifCreator{}
+	dispatcher := NewActionDispatcher(mock, dispatchTestLogger(), nil)
+
+	rule := &entities.AlertRule{
+		ID:   1,
+		Name: "Mixed Templates",
+		Actions: []entities.AlertAction{
+			{Target: TargetBell, TemplateTitle: "Custom bell title"},
+			{Target: TargetPush},
+		},
+	}
+	event := &AlertEvent{
+		ObjectType: ObjectTypeDetection,
+		EventName:  EventDetectionOccurred,
+		Properties: map[string]any{
+			PropertySpeciesName: "Rock Pigeon",
+			PropertyConfidence:  0.85,
+		},
+		Timestamp: time.Now(),
+	}
+
+	dispatcher.Dispatch(rule, event)
+
+	require.Len(t, mock.calls, 1, "bell with custom template should dispatch")
+	require.Len(t, mock.keyCalls, 1, "push with default template should also dispatch")
+}
+
+func TestDispatcher_BellDefault_PushCustom(t *testing.T) {
+	mock := &mockNotifCreator{}
+	dispatcher := NewActionDispatcher(mock, dispatchTestLogger(), nil)
+
+	rule := &entities.AlertRule{
+		ID:   1,
+		Name: "Mixed Templates",
+		Actions: []entities.AlertAction{
+			{Target: TargetBell},
+			{Target: TargetPush, TemplateTitle: "Push: {{species_name}}"},
+		},
+	}
+	event := &AlertEvent{
+		ObjectType: ObjectTypeDetection,
+		EventName:  EventDetectionOccurred,
+		Properties: map[string]any{
+			PropertySpeciesName: "Rock Pigeon",
+			PropertyConfidence:  0.85,
+		},
+		Timestamp: time.Now(),
+	}
+
+	dispatcher.Dispatch(rule, event)
+
+	require.Len(t, mock.keyCalls, 1, "bell with default template should dispatch")
+	require.Len(t, mock.calls, 1, "push with custom template should also dispatch")
+}
+
 func TestDispatcher_BellAndPush_DifferentTemplates(t *testing.T) {
 	mock := &mockNotifCreator{}
 	dispatcher := NewActionDispatcher(mock, dispatchTestLogger(), nil)

--- a/internal/alerting/dispatcher_test.go
+++ b/internal/alerting/dispatcher_test.go
@@ -307,6 +307,7 @@ func TestDispatcher_BellAndPush_DefaultTemplates_Deduplicated(t *testing.T) {
 
 	dispatcher.Dispatch(rule, event)
 
+	assert.Empty(t, mock.calls, "deduplicated actions should not produce non-keyed calls")
 	assert.Len(t, mock.keyCalls, 1, "bell+push with identical default templates should deduplicate to one notification")
 }
 

--- a/internal/alerting/dispatcher_test.go
+++ b/internal/alerting/dispatcher_test.go
@@ -225,6 +225,91 @@ func TestDispatcher_MultipleActions(t *testing.T) {
 	assert.Len(t, mock.calls, 2)
 }
 
+func TestDispatcher_PushAction(t *testing.T) {
+	mock := &mockNotifCreator{}
+	dispatcher := NewActionDispatcher(mock, dispatchTestLogger(), nil)
+
+	rule := &entities.AlertRule{
+		ID:   1,
+		Name: "Pigeon Alert",
+		Actions: []entities.AlertAction{
+			{Target: TargetPush, TemplateTitle: "Pigeon detected", TemplateMessage: "A pigeon was seen"},
+		},
+	}
+	event := &AlertEvent{
+		ObjectType: ObjectTypeDetection,
+		EventName:  EventDetectionOccurred,
+		Properties: map[string]any{
+			PropertySpeciesName: "Rock Pigeon",
+			PropertyConfidence:  0.85,
+		},
+		Timestamp: time.Now(),
+	}
+
+	dispatcher.Dispatch(rule, event)
+
+	require.Len(t, mock.calls, 1, "push target should create a notification")
+	assert.Equal(t, notification.TypeDetection, mock.calls[0].notifType)
+	assert.Equal(t, "Pigeon detected", mock.calls[0].title)
+	assert.Equal(t, "A pigeon was seen", mock.calls[0].message)
+}
+
+func TestDispatcher_PushAction_DefaultTemplate(t *testing.T) {
+	mock := &mockNotifCreator{}
+	dispatcher := NewActionDispatcher(mock, dispatchTestLogger(), nil)
+
+	rule := &entities.AlertRule{
+		ID:   1,
+		Name: "Pigeon Alert",
+		Actions: []entities.AlertAction{
+			{Target: TargetPush},
+		},
+	}
+	event := &AlertEvent{
+		ObjectType: ObjectTypeDetection,
+		EventName:  EventDetectionOccurred,
+		Properties: map[string]any{
+			PropertySpeciesName: "Rock Pigeon",
+			PropertyConfidence:  0.85,
+		},
+		Timestamp: time.Now(),
+	}
+
+	dispatcher.Dispatch(rule, event)
+
+	assert.Empty(t, mock.calls, "push with default template should use keyed variant")
+	require.Len(t, mock.keyCalls, 1)
+	assert.Equal(t, notification.TypeDetection, mock.keyCalls[0].notifType)
+	assert.Equal(t, MsgAlertDetectionOccurred, mock.keyCalls[0].messageKey)
+}
+
+func TestDispatcher_BellAndPush(t *testing.T) {
+	mock := &mockNotifCreator{}
+	dispatcher := NewActionDispatcher(mock, dispatchTestLogger(), nil)
+
+	rule := &entities.AlertRule{
+		ID:   1,
+		Name: "Full Alert",
+		Actions: []entities.AlertAction{
+			{Target: TargetBell},
+			{Target: TargetPush},
+		},
+	}
+	event := &AlertEvent{
+		ObjectType: ObjectTypeDetection,
+		EventName:  EventDetectionOccurred,
+		Properties: map[string]any{
+			PropertySpeciesName: "Rock Pigeon",
+			PropertyConfidence:  0.85,
+		},
+		Timestamp: time.Now(),
+	}
+
+	dispatcher.Dispatch(rule, event)
+
+	assert.Len(t, mock.keyCalls, 2, "both bell and push should create notifications")
+}
+
 func TestDispatcher_UnknownTargetSkipped(t *testing.T) {
 	mock := &mockNotifCreator{}
 	dispatcher := NewActionDispatcher(mock, dispatchTestLogger(), nil)

--- a/internal/alerting/integration_test.go
+++ b/internal/alerting/integration_test.go
@@ -225,7 +225,7 @@ func TestIntegration_CustomRuleWithConditions(t *testing.T) {
 		},
 		Actions: []entities.AlertAction{
 			{Target: TargetBell},
-			{Target: "push"},
+			{Target: TargetPush},
 		},
 	}
 	err := repo.CreateRule(t.Context(), customRule)
@@ -254,7 +254,7 @@ func TestIntegration_CustomRuleWithConditions(t *testing.T) {
 	}
 	engine.HandleEvent(highEvent)
 	assert.Equal(t, 1, recorder.count(), "high-confidence event should trigger rule")
-	assert.Equal(t, []string{TargetBell, "push"}, recorder.lastCall().targets)
+	assert.Equal(t, []string{TargetBell, TargetPush}, recorder.lastCall().targets)
 }
 
 func TestIntegration_MetricSustainedThresholdFires(t *testing.T) {


### PR DESCRIPTION
## Summary

- The `ActionDispatcher.dispatchInternal()` only handled the `"bell"` action target. The `"push"` target, which the frontend UI explicitly offers alongside "bell" in the alert rule editor, was silently ignored (fell through to a warning log in the default case).
- Rules configured with "push" actions appeared to work because alert history was saved *before* the action dispatch, so the notification history UI showed the rule fired. But no notification was actually created or broadcast, so webhook providers never received anything.
- This is the root cause of #3021: the user's pigeon detection rule had action target "push", which was ignored. The webhook they observed at 18:55 was actually from a separate "new species" rule with target "bell".

## Changes

- Added `TargetPush = "push"` constant in `constants.go`
- Added `TargetPush` to the dispatcher's switch case alongside `TargetBell` so both targets create and broadcast notifications
- Added three new tests: push with custom template, push with default template, and combined bell+push

## Test plan

- [x] All 178 alerting package tests pass (including 3 new push target tests)
- [x] All 709 notification package tests pass
- [x] golangci-lint clean
- [ ] Manual: create a rule with "push" action, verify webhook fires on detection

Fixes #3021

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added push notifications as an alert delivery option alongside existing notifications.

* **Bug Fixes / Improvements**
  * Unified notification dispatch for consistent behavior across targets, improved deduplication when multiple targets are active, and clearer error reporting.

* **Tests**
  * Added tests for push delivery, default vs custom templates, and combined multi-target scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3062)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->