### PR TITLE
fix(conf): correct season dates for southern hemisphere installations

### DIFF
--- a/internal/conf/prepare_settings_test.go
+++ b/internal/conf/prepare_settings_test.go
@@ -149,6 +149,77 @@ func TestPrepareSettingsForSave_SouthernHemisphere(t *testing.T) {
 	}
 }
 
+// TestPrepareSettingsForSave_CorrectsSouthernHemisphere verifies that pre-populated
+// Northern Hemisphere defaults are corrected for Southern Hemisphere latitude.
+// This is the exact scenario from issue #3003: Viper defaults set NH seasons,
+// but the user is in Sydney (latitude -33.9).
+func TestPrepareSettingsForSave_CorrectsSouthernHemisphere(t *testing.T) {
+	t.Parallel()
+
+	nhDefaults := map[string]Season{
+		"spring": {StartMonth: 3, StartDay: 20},
+		"summer": {StartMonth: 6, StartDay: 21},
+		"fall":   {StartMonth: 9, StartDay: 22},
+		"winter": {StartMonth: 12, StartDay: 21},
+	}
+
+	tests := []struct {
+		name     string
+		latitude float64
+	}{
+		{"Sydney", -33.9},
+		{"Melbourne", -37.8},
+		{"Auckland", -36.9},
+		{"Cape Town", -33.9},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			settings := &Settings{}
+			settings.Realtime.SpeciesTracking.SeasonalTracking.Enabled = true
+			settings.Realtime.SpeciesTracking.SeasonalTracking.Seasons = maps.Clone(nhDefaults)
+
+			result := prepareSettingsForSave(settings, tt.latitude)
+
+			spring, exists := result.Realtime.SpeciesTracking.SeasonalTracking.Seasons["spring"]
+			require.True(t, exists, "Expected spring season")
+			assert.Equal(t, 9, spring.StartMonth,
+				"Southern hemisphere spring should start in September, not March")
+
+			winter, exists := result.Realtime.SpeciesTracking.SeasonalTracking.Seasons["winter"]
+			require.True(t, exists, "Expected winter season")
+			assert.Equal(t, 6, winter.StartMonth,
+				"Southern hemisphere winter should start in June, not December")
+		})
+	}
+}
+
+// TestPrepareSettingsForSave_PreservesNorthernForNorthern verifies that Northern Hemisphere
+// defaults are preserved when latitude is Northern.
+func TestPrepareSettingsForSave_PreservesNorthernForNorthern(t *testing.T) {
+	t.Parallel()
+
+	nhDefaults := map[string]Season{
+		"spring": {StartMonth: 3, StartDay: 20},
+		"summer": {StartMonth: 6, StartDay: 21},
+		"fall":   {StartMonth: 9, StartDay: 22},
+		"winter": {StartMonth: 12, StartDay: 21},
+	}
+
+	settings := &Settings{}
+	settings.Realtime.SpeciesTracking.SeasonalTracking.Enabled = true
+	settings.Realtime.SpeciesTracking.SeasonalTracking.Seasons = maps.Clone(nhDefaults)
+
+	result := prepareSettingsForSave(settings, 45.0)
+
+	spring := result.Realtime.SpeciesTracking.SeasonalTracking.Seasons["spring"]
+	assert.Equal(t, 3, spring.StartMonth, "Northern hemisphere spring should stay in March")
+
+	winter := result.Realtime.SpeciesTracking.SeasonalTracking.Seasons["winter"]
+	assert.Equal(t, 12, winter.StartMonth, "Northern hemisphere winter should stay in December")
+}
+
 // TestPrepareSettingsForSave_EquatorialRegion verifies default seasons near equator.
 func TestPrepareSettingsForSave_EquatorialRegion(t *testing.T) {
 	t.Parallel()

--- a/internal/conf/prepare_settings_test.go
+++ b/internal/conf/prepare_settings_test.go
@@ -213,10 +213,12 @@ func TestPrepareSettingsForSave_PreservesNorthernForNorthern(t *testing.T) {
 
 	result := prepareSettingsForSave(settings, 45.0)
 
-	spring := result.Realtime.SpeciesTracking.SeasonalTracking.Seasons["spring"]
+	spring, exists := result.Realtime.SpeciesTracking.SeasonalTracking.Seasons["spring"]
+	require.True(t, exists, "Expected spring season")
 	assert.Equal(t, 3, spring.StartMonth, "Northern hemisphere spring should stay in March")
 
-	winter := result.Realtime.SpeciesTracking.SeasonalTracking.Seasons["winter"]
+	winter, exists := result.Realtime.SpeciesTracking.SeasonalTracking.Seasons["winter"]
+	require.True(t, exists, "Expected winter season")
 	assert.Equal(t, 12, winter.StartMonth, "Northern hemisphere winter should stay in December")
 }
 
@@ -270,6 +272,33 @@ func TestPrepareSettingsForSave_SkipsUnconfiguredLatitude(t *testing.T) {
 	spring := result.Realtime.SpeciesTracking.SeasonalTracking.Seasons["spring"]
 	assert.Equal(t, 3, spring.StartMonth,
 		"Seasons should be unchanged when latitude is 0 (unconfigured)")
+}
+
+// TestPrepareSettingsForSave_PreservesCustomSeasonNames verifies that non-standard
+// season names are not replaced by hemisphere defaults.
+func TestPrepareSettingsForSave_PreservesCustomSeasonNames(t *testing.T) {
+	t.Parallel()
+
+	customSeasons := map[string]Season{
+		"monsoon": {StartMonth: 6, StartDay: 1},
+		"dry":     {StartMonth: 11, StartDay: 1},
+	}
+
+	settings := &Settings{}
+	settings.Realtime.SpeciesTracking.SeasonalTracking.Enabled = true
+	settings.Realtime.SpeciesTracking.SeasonalTracking.Seasons = maps.Clone(customSeasons)
+
+	result := prepareSettingsForSave(settings, -33.9)
+
+	require.Len(t, result.Realtime.SpeciesTracking.SeasonalTracking.Seasons, 2)
+
+	monsoon, exists := result.Realtime.SpeciesTracking.SeasonalTracking.Seasons["monsoon"]
+	require.True(t, exists, "Expected monsoon season to be preserved")
+	assert.Equal(t, 6, monsoon.StartMonth, "Custom season dates should not be changed")
+
+	dry, exists := result.Realtime.SpeciesTracking.SeasonalTracking.Seasons["dry"]
+	require.True(t, exists, "Expected dry season to be preserved")
+	assert.Equal(t, 11, dry.StartMonth, "Custom season dates should not be changed")
 }
 
 // TestPrepareSettingsForSave_DoesNotMutateInput verifies original settings unchanged.

--- a/internal/conf/prepare_settings_test.go
+++ b/internal/conf/prepare_settings_test.go
@@ -227,7 +227,6 @@ func TestPrepareSettingsForSave_EquatorialRegion(t *testing.T) {
 		name     string
 		latitude float64
 	}{
-		{"equator", 0.0},
 		{"slightly north", 5.0},
 		{"slightly south", -5.0},
 		{"northern threshold boundary", NorthernHemisphereThreshold - 0.1},
@@ -248,6 +247,29 @@ func TestPrepareSettingsForSave_EquatorialRegion(t *testing.T) {
 				"Expected default seasons to be populated for equatorial region")
 		})
 	}
+}
+
+// TestPrepareSettingsForSave_SkipsUnconfiguredLatitude verifies that latitude 0
+// (location not yet configured) preserves existing seasons without adjustment.
+func TestPrepareSettingsForSave_SkipsUnconfiguredLatitude(t *testing.T) {
+	t.Parallel()
+
+	nhDefaults := map[string]Season{
+		"spring": {StartMonth: 3, StartDay: 20},
+		"summer": {StartMonth: 6, StartDay: 21},
+		"fall":   {StartMonth: 9, StartDay: 22},
+		"winter": {StartMonth: 12, StartDay: 21},
+	}
+
+	settings := &Settings{}
+	settings.Realtime.SpeciesTracking.SeasonalTracking.Enabled = true
+	settings.Realtime.SpeciesTracking.SeasonalTracking.Seasons = maps.Clone(nhDefaults)
+
+	result := prepareSettingsForSave(settings, 0.0)
+
+	spring := result.Realtime.SpeciesTracking.SeasonalTracking.Seasons["spring"]
+	assert.Equal(t, 3, spring.StartMonth,
+		"Seasons should be unchanged when latitude is 0 (unconfigured)")
 }
 
 // TestPrepareSettingsForSave_DoesNotMutateInput verifies original settings unchanged.
@@ -275,7 +297,6 @@ func TestPrepareSettingsForSave_DifferentLatitudes(t *testing.T) {
 		{45.0, "northern"},
 		{NorthernHemisphereThreshold + 1, "northern"},
 		{5.0, "equatorial"},
-		{0.0, "equatorial"},
 		{-5.0, "equatorial"},
 		{SouthernHemisphereThreshold - 1, "southern"},
 		{-45.0, "southern"},

--- a/internal/conf/storage.go
+++ b/internal/conf/storage.go
@@ -151,6 +151,18 @@ func Load() (*Settings, error) {
 		}
 	}
 
+	// Adjust seasonal tracking for the user's hemisphere so the settings
+	// API returns correct season dates from the start. Without this,
+	// Viper defaults (Northern Hemisphere) would be served regardless
+	// of the configured latitude.
+	if settings.Realtime.SpeciesTracking.SeasonalTracking.Enabled &&
+		settings.BirdNET.Latitude != 0 {
+		settings.Realtime.SpeciesTracking.SeasonalTracking = GetSeasonalTrackingWithHemisphere(
+			settings.Realtime.SpeciesTracking.SeasonalTracking,
+			settings.BirdNET.Latitude,
+		)
+	}
+
 	// Publish the loaded settings atomically. Readers calling GetSettings
 	// immediately after this point see this snapshot.
 	settingsInstance.Store(settings)
@@ -398,7 +410,7 @@ func Setting() *Settings {
 // This function is separated from SaveSettings to enable unit testing without filesystem I/O.
 //
 // Current transformations:
-//   - Auto-populates seasonal tracking seasons based on latitude if not already set
+//   - Adjusts seasonal tracking seasons for the user's hemisphere based on latitude
 //
 // Note: This is a pure function that only transforms data. It does not handle:
 //   - Mutex locking (handled by SaveSettings caller)
@@ -407,13 +419,11 @@ func Setting() *Settings {
 func prepareSettingsForSave(s *Settings, latitude float64) Settings {
 	settingsCopy := *s
 
-	// Auto-update seasonal tracking dates based on latitude if seasonal tracking is enabled
-	// and no custom seasons are already defined
-	if settingsCopy.Realtime.SpeciesTracking.SeasonalTracking.Enabled &&
-		len(settingsCopy.Realtime.SpeciesTracking.SeasonalTracking.Seasons) == 0 {
-		// Get hemisphere-appropriate default seasons
-		defaultSeasons := GetDefaultSeasons(latitude)
-		settingsCopy.Realtime.SpeciesTracking.SeasonalTracking.Seasons = defaultSeasons
+	if settingsCopy.Realtime.SpeciesTracking.SeasonalTracking.Enabled {
+		settingsCopy.Realtime.SpeciesTracking.SeasonalTracking = GetSeasonalTrackingWithHemisphere(
+			settingsCopy.Realtime.SpeciesTracking.SeasonalTracking,
+			latitude,
+		)
 	}
 
 	return settingsCopy

--- a/internal/conf/storage.go
+++ b/internal/conf/storage.go
@@ -155,8 +155,8 @@ func Load() (*Settings, error) {
 	// API returns correct season dates from the start. Without this,
 	// Viper defaults (Northern Hemisphere) would be served regardless
 	// of the configured latitude.
-	if settings.Realtime.SpeciesTracking.SeasonalTracking.Enabled &&
-		settings.BirdNET.Latitude != 0 {
+	locationConfigured := settings.BirdNET.Latitude != 0 || settings.BirdNET.Longitude != 0
+	if settings.Realtime.SpeciesTracking.SeasonalTracking.Enabled && locationConfigured {
 		settings.Realtime.SpeciesTracking.SeasonalTracking = GetSeasonalTrackingWithHemisphere(
 			settings.Realtime.SpeciesTracking.SeasonalTracking,
 			settings.BirdNET.Latitude,
@@ -419,7 +419,8 @@ func Setting() *Settings {
 func prepareSettingsForSave(s *Settings, latitude float64) Settings {
 	settingsCopy := *s
 
-	if settingsCopy.Realtime.SpeciesTracking.SeasonalTracking.Enabled && latitude != 0 {
+	locationConfigured := latitude != 0 || s.BirdNET.Longitude != 0
+	if settingsCopy.Realtime.SpeciesTracking.SeasonalTracking.Enabled && locationConfigured {
 		settingsCopy.Realtime.SpeciesTracking.SeasonalTracking = GetSeasonalTrackingWithHemisphere(
 			settingsCopy.Realtime.SpeciesTracking.SeasonalTracking,
 			latitude,

--- a/internal/conf/storage.go
+++ b/internal/conf/storage.go
@@ -419,7 +419,7 @@ func Setting() *Settings {
 func prepareSettingsForSave(s *Settings, latitude float64) Settings {
 	settingsCopy := *s
 
-	if settingsCopy.Realtime.SpeciesTracking.SeasonalTracking.Enabled {
+	if settingsCopy.Realtime.SpeciesTracking.SeasonalTracking.Enabled && latitude != 0 {
 		settingsCopy.Realtime.SpeciesTracking.SeasonalTracking = GetSeasonalTrackingWithHemisphere(
 			settingsCopy.Realtime.SpeciesTracking.SeasonalTracking,
 			latitude,


### PR DESCRIPTION
## Summary

- Fixes season detection for southern hemisphere users where season dates in the settings UI showed northern hemisphere defaults (e.g., winter starting in December instead of June for Sydney, Australia)
- Root cause: Viper defaults always pre-populate Northern Hemisphere season dates, making the existing `len(Seasons) == 0` hemisphere check in `prepareSettingsForSave` dead code
- Applies `GetSeasonalTrackingWithHemisphere` in both the config load path and the save path so the settings API returns hemisphere-correct dates from startup

Fixes #3003

## Test plan

- [x] Existing `prepareSettingsForSave` tests pass (41 tests)
- [x] New test `TestPrepareSettingsForSave_CorrectsSouthernHemisphere` covers the exact bug scenario (NH defaults + SH latitude)
- [x] New test `TestPrepareSettingsForSave_PreservesNorthernForNorthern` verifies no regression for NH users
- [x] Full `internal/conf` test suite passes (1163 tests)
- [x] Full `internal/analysis/species` test suite passes (724 tests)
- [x] golangci-lint clean
- [x] QA: deployed test container with Sydney coordinates (-33.87, 151.21) and verified settings API returns correct SH seasons (spring=Sep, summer=Dec, fall=Mar, winter=Jun)
- [x] QA: verified frontend Species > Tracking page displays correct season dates via Playwright

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Seasonal tracking now adjusts spring/winter dates for Southern Hemisphere during load and save, preserves Northern dates when applicable, leaves pre-populated seasons unchanged when location is unconfigured (equator/lat zero), and retains custom/non-standard season names.

* **Tests**
  * Added coverage for Southern-hemisphere corrections, preserving Northern settings, skipping adjustment for unconfigured latitude, and preserving custom season names.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3063)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->