### PR TITLE
fix(deps): update go-tflite to fix checkptr panic under race detector

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/testcontainers/testcontainers-go/modules/mysql v0.42.0
 	github.com/tphakala/flac v0.0.0-20241217200312-20d6d98f5ee3
 	github.com/tphakala/go-audio-resampler v1.3.0
-	github.com/tphakala/go-tflite v0.2.2-0.20260403122459-aedbd0bca261
+	github.com/tphakala/go-tflite v0.2.2-0.20260514101223-29408e53fff7
 	github.com/tphakala/simd v1.0.22
 	github.com/yalue/onnxruntime_go v1.30.1
 	go.uber.org/goleak v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -298,8 +298,8 @@ github.com/tphakala/flac v0.0.0-20241217200312-20d6d98f5ee3 h1:hD7Uw+Js4mZXlfLYn
 github.com/tphakala/flac v0.0.0-20241217200312-20d6d98f5ee3/go.mod h1:YEoLmuRHr0LG0zHpCWVkdGi4EqeiULta/nNCFntKMuc=
 github.com/tphakala/go-audio-resampler v1.3.0 h1:KFEmMGB4/vAFCOedzQYUR4VFhMyu/ZGINuEorYwCIkU=
 github.com/tphakala/go-audio-resampler v1.3.0/go.mod h1:2jZ7uTFDvnfMZiDkXS1lF/Z7KmsF2tqsNuL/NyceJ2o=
-github.com/tphakala/go-tflite v0.2.2-0.20260403122459-aedbd0bca261 h1:PSr03UW1NzttAVTAOcEyrFaV62/hQrpRFQp1NlC9ymA=
-github.com/tphakala/go-tflite v0.2.2-0.20260403122459-aedbd0bca261/go.mod h1:xCgggryHiQ3nD0Sy0oCZESPWmzThLKKB28Vky5m6HCo=
+github.com/tphakala/go-tflite v0.2.2-0.20260514101223-29408e53fff7 h1:fJtEs8rODoFDk8HDRwvNxIYEgsUUrEAvqPdllxF0cmg=
+github.com/tphakala/go-tflite v0.2.2-0.20260514101223-29408e53fff7/go.mod h1:xCgggryHiQ3nD0Sy0oCZESPWmzThLKKB28Vky5m6HCo=
 github.com/tphakala/goth v0.0.0-20260315123917-08c3db6a364a h1:BBvsu7Mes8McH6ikyagnU9y2N8hjoDxvDNCl162hwdA=
 github.com/tphakala/goth v0.0.0-20260315123917-08c3db6a364a/go.mod h1:fht+y3WzLavlVj4eN6u+/lmoQ4lOcsL6blDhBckFLPE=
 github.com/tphakala/malgo v0.11.25-birdnet.1 h1:QwqenAMHWxLPcWDVEfRyqbYHPvMpr0IoNLHFcTG9YO0=


### PR DESCRIPTION
## Summary

- Updates `go-tflite` to fix a `checkptr: pointer arithmetic computed bad pointer value` fatal panic that occurs when running tests with `-race`
- The upstream fix (tphakala/go-tflite@29408e5) changes `SetErrorReporter` to pass `cgo.Handle` through C as `uintptr_t` instead of `void*`, matching the official `cgo.Handle` documentation pattern
- This has been a recurring CI flake since at least May 4, flagged in every PR that runs classifier tests with the race detector

## Test Plan

- [x] `go test -race -count=1 ./internal/classifier/...` passes (533 tests, 0 failures)
- [ ] CI checks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project dependencies to latest compatible versions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3066)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->