### PR TITLE
feat(bat): add nighttime scheduling for bat detection

### DIFF
--- a/frontend/src/lib/desktop/features/settings/pages/AnalysisSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/AnalysisSettingsPage.svelte
@@ -136,7 +136,9 @@
     }
   );
   let falsePositiveFilter = $derived($realtimeSettings?.falsePositiveFilter ?? { level: 0 });
-  let bat = $derived($batSettings ?? { enabled: false, threshold: 0.5, filterEnabled: false });
+  let bat = $derived(
+    $batSettings ?? { enabled: false, threshold: 0.5, filterEnabled: false, nighttimeOnly: true }
+  );
 
   // Check if a bat model is installed
   const hasBatModel = $derived(catalog.some(e => e.installed && e.category === 'bat'));
@@ -660,6 +662,10 @@
     settingsActions.updateSection('bat', { filterEnabled: value });
   }
 
+  function updateBatNighttimeOnly(value: boolean) {
+    settingsActions.updateSection('bat', { nighttimeOnly: value });
+  }
+
   function updateThreshold(value: number) {
     settingsActions.updateSection('birdnet', { threshold: value });
   }
@@ -893,12 +899,14 @@
         locale: store.originalData.birdnet?.locale,
         batThreshold: store.originalData.bat?.threshold,
         batFilterEnabled: store.originalData.bat?.filterEnabled,
+        batNighttimeOnly: store.originalData.bat?.nighttimeOnly,
       }}
       currentData={{
         threshold: birdnet?.threshold,
         locale: birdnet?.locale,
         batThreshold: bat.threshold,
         batFilterEnabled: bat.filterEnabled,
+        batNighttimeOnly: bat.nighttimeOnly,
       }}
     >
       <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
@@ -961,6 +969,13 @@
             helpText={t('analysis.detection.batFilter.helpText')}
             disabled={store.isLoading || store.isSaving}
             onchange={updateBatFilterEnabled}
+          />
+          <Checkbox
+            checked={bat.nighttimeOnly ?? true}
+            label={t('analysis.detection.batNighttimeOnly.label')}
+            helpText={t('analysis.detection.batNighttimeOnly.helpText')}
+            disabled={store.isLoading || store.isSaving}
+            onchange={updateBatNighttimeOnly}
           />
         {/if}
       </div>

--- a/frontend/src/lib/stores/settings.ts
+++ b/frontend/src/lib/stores/settings.ts
@@ -114,6 +114,7 @@ export interface BatSettings {
   threshold: number;
   locale?: string;
   filterEnabled: boolean;
+  nighttimeOnly: boolean;
 }
 
 export interface SQLiteSettings {
@@ -847,6 +848,7 @@ function createEmptySettings(): SettingsFormData {
       enabled: false,
       threshold: 0.5,
       filterEnabled: false,
+      nighttimeOnly: true,
     },
     realtime: {
       interval: 15,

--- a/frontend/static/messages/da.json
+++ b/frontend/static/messages/da.json
@@ -4507,6 +4507,10 @@
       "batFilter": {
         "label": "Flagermus-audio-højpasfilter",
         "helpText": "Filtrerer hørbare frekvenser fra før flagermusanalysen for at reducere falske positiver fra fuglesang og omgivende støj."
+      },
+      "batNighttimeOnly": {
+        "label": "Kun om natten",
+        "helpText": "Når aktiveret kører flagermusdetektering kun mellem borgerlig tusmørke og borgerlig daggry. Kræver at placering er konfigureret. Deaktiver for at køre flagermusdetektering hele dagen."
       }
     }
   },

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -4524,6 +4524,10 @@
         "label": "Fledermaus-Audio-Hochpassfilter",
         "helpText": "Filtert hörbare Frequenzen vor der Fledermausanalyse heraus, um Fehlerkennungen durch Vogelgesang und Umgebungsgeräusche zu reduzieren."
       },
+      "batNighttimeOnly": {
+        "label": "Nur nachts",
+        "helpText": "Wenn aktiviert, wird die Fledermauerkennung nur zwischen der bürgerlichen Abenddämmerung und der Morgendämmerung durchgeführt. Erfordert eine konfigurierte Standorteinstellung. Deaktivieren, um die Fledermauerkennung rund um die Uhr auszuführen."
+      },
       "locale": {
         "label": "Species Language",
         "helpText": "Language used for species common names in the interface."

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -4526,7 +4526,7 @@
       },
       "batNighttimeOnly": {
         "label": "Nur nachts",
-        "helpText": "Wenn aktiviert, wird die Fledermauerkennung nur zwischen der bürgerlichen Abenddämmerung und der Morgendämmerung durchgeführt. Erfordert eine konfigurierte Standorteinstellung. Deaktivieren, um die Fledermauerkennung rund um die Uhr auszuführen."
+        "helpText": "Wenn aktiviert, wird die Fledermauserkennung nur zwischen der bürgerlichen Abenddämmerung und der Morgendämmerung durchgeführt. Erfordert eine konfigurierte Standorteinstellung. Deaktivieren, um die Fledermauserkennung rund um die Uhr auszuführen."
       },
       "locale": {
         "label": "Species Language",

--- a/frontend/static/messages/en.json
+++ b/frontend/static/messages/en.json
@@ -4524,6 +4524,10 @@
         "label": "Bat Audio High-Pass Filter",
         "helpText": "Filters out human-audible frequencies before bat analysis to reduce false positives from bird songs and ambient noise."
       },
+      "batNighttimeOnly": {
+        "label": "Nighttime Only",
+        "helpText": "When enabled, bat detection runs only between civil dusk and civil dawn. Requires location to be configured. Disable to run bat detection around the clock."
+      },
       "locale": {
         "label": "Species Language",
         "helpText": "Language used for species common names in the interface."

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -4524,6 +4524,10 @@
         "label": "Filtro de paso alto para murciélagos",
         "helpText": "Filtra las frecuencias audibles antes del análisis de murciélagos para reducir falsos positivos por cantos de aves y ruido ambiental."
       },
+      "batNighttimeOnly": {
+        "label": "Solo nocturno",
+        "helpText": "Cuando está activado, la detección de murciélagos funciona solo entre el crepúsculo civil y el amanecer civil. Requiere que la ubicación esté configurada. Desactive para ejecutar la detección de murciélagos las 24 horas."
+      },
       "locale": {
         "label": "Species Language",
         "helpText": "Language used for species common names in the interface."

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -4524,6 +4524,10 @@
         "label": "Lepakkoäänen ylipäästösuodatin",
         "helpText": "Suodattaa kuultavat taajuudet ennen lepakkoanalyysiä vähentääkseen linnunlaulun ja taustamelun aiheuttamia vääriä tunnistuksia."
       },
+      "batNighttimeOnly": {
+        "label": "Vain yöaikaan",
+        "helpText": "Kun käytössä, lepakkotunnistus toimii vain siviilihämärän ja siviiliaamunkoiton välillä. Vaatii, että sijainti on määritetty. Poista käytöstä, jos haluat lepakkotunnistuksen olevan käytössä ympäri vuorokauden."
+      },
       "locale": {
         "label": "Species Language",
         "helpText": "Language used for species common names in the interface."

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -4524,6 +4524,10 @@
         "label": "Filtre passe-haut pour chauves-souris",
         "helpText": "Filtre les fréquences audibles avant l'analyse des chauves-souris pour réduire les faux positifs dus aux chants d'oiseaux et au bruit ambiant."
       },
+      "batNighttimeOnly": {
+        "label": "Nocturne uniquement",
+        "helpText": "Lorsqu'activé, la détection de chauves-souris fonctionne uniquement entre le crépuscule civil et l'aube civile. Nécessite la configuration de l'emplacement. Désactivez pour exécuter la détection en permanence."
+      },
       "locale": {
         "label": "Species Language",
         "helpText": "Language used for species common names in the interface."

--- a/frontend/static/messages/hu.json
+++ b/frontend/static/messages/hu.json
@@ -4507,6 +4507,10 @@
       "batFilter": {
         "label": "Denevér hang felüláteresztő szűrő",
         "helpText": "Kiszűri az emberi fül számára hallható frekvenciákat a denevérelemzés előtt, hogy csökkentse a madárdal és a környezeti zaj okozta téves észleléseket."
+      },
+      "batNighttimeOnly": {
+        "label": "Csak éjszaka",
+        "helpText": "Ha engedélyezve van, a denevérészlelés csak polgári alkony és polgári hajnal között fut. A helyszín konfigurálása szükséges. Kapcsolja ki az éjjel-nappali denevérészleléshez."
       }
     }
   },

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -4507,6 +4507,10 @@
       "batFilter": {
         "label": "Filtro passa-alto audio pipistrelli",
         "helpText": "Filtra le frequenze udibili dall'uomo prima dell'analisi dei pipistrelli per ridurre i falsi positivi causati dal canto degli uccelli e dal rumore ambientale."
+      },
+      "batNighttimeOnly": {
+        "label": "Solo di notte",
+        "helpText": "Se abilitato, il rilevamento dei pipistrelli funziona solo tra il crepuscolo civile e l'alba civile. Richiede la configurazione della posizione. Disabilita per eseguire il rilevamento continuamente."
       }
     }
   },

--- a/frontend/static/messages/lv.json
+++ b/frontend/static/messages/lv.json
@@ -4507,6 +4507,10 @@
       "batFilter": {
         "label": "Sikspārņu audio augstfrekvences filtrs",
         "helpText": "Filtrē cilvēka dzirdei pieejamās frekvences pirms sikspārņu analīzes, lai samazinātu viltus pozitīvos rezultātus no putnu dziesmām un apkārtējā trokšņa."
+      },
+      "batNighttimeOnly": {
+        "label": "Tikai naktī",
+        "helpText": "Ja iespējots, sikspārņu noteikšana darbojas tikai starp pilsoniskajiem krēsliem un pilsonisko rītausmu. Nepieciešama atrašanās vietas konfigurācija. Atspējojiet, lai noteikšana darbotos visu diennakti."
       }
     }
   },

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -4524,6 +4524,10 @@
         "label": "Vleermuis audio hoogdoorlaatfilter",
         "helpText": "Filtert hoorbare frequenties vóór de vleermuisanalyse om valse detecties door vogelzang en omgevingsgeluid te verminderen."
       },
+      "batNighttimeOnly": {
+        "label": "Alleen 's nachts",
+        "helpText": "Wanneer ingeschakeld, werkt de vleermuisdetectie alleen tussen de burgerlijke schemering en de burgerlijke dageraad. Vereist dat de locatie is geconfigureerd. Schakel uit om vleermuisdetectie de klok rond uit te voeren."
+      },
       "locale": {
         "label": "Species Language",
         "helpText": "Language used for species common names in the interface."

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -4524,6 +4524,10 @@
         "label": "Filtr górnoprzepustowy dla nietoperzy",
         "helpText": "Filtruje słyszalne częstotliwości przed analizą nietoperzy, aby zmniejszyć fałszywe wykrycia spowodowane śpiewem ptaków i hałasem otoczenia."
       },
+      "batNighttimeOnly": {
+        "label": "Tylko w nocy",
+        "helpText": "Po włączeniu wykrywanie nietoperzy działa tylko między zmierzchem cywilnym a świtem cywilnym. Wymaga skonfigurowanej lokalizacji. Wyłącz, aby wykrywanie nietoperzy działało całą dobę."
+      },
       "locale": {
         "label": "Species Language",
         "helpText": "Language used for species common names in the interface."

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -4524,6 +4524,10 @@
         "label": "Filtro passa-altas para morcegos",
         "helpText": "Filtra frequências audíveis antes da análise de morcegos para reduzir falsos positivos causados por cantos de aves e ruído ambiente."
       },
+      "batNighttimeOnly": {
+        "label": "Apenas noturno",
+        "helpText": "Quando ativado, a deteção de morcegos funciona apenas entre o crepúsculo civil e a aurora civil. Requer que a localização esteja configurada. Desative para executar a deteção de morcegos 24 horas por dia."
+      },
       "locale": {
         "label": "Species Language",
         "helpText": "Language used for species common names in the interface."

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -4507,6 +4507,10 @@
       "batFilter": {
         "label": "Horný priepustný filter pre netopiere",
         "helpText": "Filtruje počuteľné frekvencie pred analýzou netopierov na zníženie falošných detekcií spôsobených spevom vtákov a okolitým hlukom."
+      },
+      "batNighttimeOnly": {
+        "label": "Iba v noci",
+        "helpText": "Keď je povolené, detekcia netopierov beží iba medzi občianskym súmrakom a občianskym svitaním. Vyžaduje nakonfigurovanú polohu. Vypnite pre nepretržitú detekciu."
       }
     }
   },

--- a/frontend/static/messages/sv.json
+++ b/frontend/static/messages/sv.json
@@ -4507,6 +4507,10 @@
       "batFilter": {
         "label": "Högpassfilter för fladdermöss-ljud",
         "helpText": "Filtrerar bort hörbara frekvenser före fladdermöss-analysen för att minska falska positiva resultat från fågelsång och omgivningsljud."
+      },
+      "batNighttimeOnly": {
+        "label": "Endast nattetid",
+        "helpText": "När aktiverat körs fladdermöss-detektering endast mellan borgerlig skymning och borgerlig gryning. Kräver konfigurerad plats. Inaktivera för att köra detektering dygnet runt."
       }
     }
   },

--- a/internal/analysis/audio_pipeline_service.go
+++ b/internal/analysis/audio_pipeline_service.go
@@ -224,6 +224,9 @@ func (p *AudioPipelineService) Start(_ context.Context) error {
 	p.engine.SetScheduler(p.quietHoursScheduler)
 	p.quietHoursScheduler.Start()
 
+	// Inject suncalc into the orchestrator for bat nighttime scheduling.
+	bn.SetSunCalc(p.apiService.SunCalc())
+
 	// Publish application started alert event.
 	alerting.TryPublish(&alerting.AlertEvent{
 		ObjectType: alerting.ObjectTypeApplication,

--- a/internal/analysis/buffer_manager.go
+++ b/internal/analysis/buffer_manager.go
@@ -473,6 +473,13 @@ func (m *BufferManager) processMonitorTick(
 		return true, hasReadBuffer
 	}
 
+	// Skip inference for models that are currently inactive (e.g., bat model
+	// during daytime when nighttime-only scheduling is enabled). The buffered
+	// audio data is released by the existing defer release().
+	if !m.bn.IsModelActive(cfg.modelID) {
+		return true, hasReadBuffer
+	}
+
 	m.logger.Debug("buffer monitor dispatching to ProcessData",
 		logger.String("source_id", cfg.sourceID),
 		logger.String("model_id", cfg.modelID),

--- a/internal/classifier/nighttime_scheduler.go
+++ b/internal/classifier/nighttime_scheduler.go
@@ -1,6 +1,7 @@
 package classifier
 
 import (
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -15,10 +16,13 @@ const schedulerRefreshInterval = 60 * time.Second
 // based on civil dusk/dawn times. A background goroutine refreshes the
 // state every 60 seconds so the hot path is a single atomic load.
 type nighttimeScheduler struct {
-	sunCalc  *suncalc.SunCalc
-	active   atomic.Bool
-	stopChan chan struct{}
-	warnOnce atomic.Bool
+	sunCalc      *suncalc.SunCalc
+	active       atomic.Bool
+	stopChan     chan struct{}
+	stopOnce     sync.Once
+	warnOnce     atomic.Bool
+	locationWarn atomic.Bool
+	prevNight    atomic.Int32 // -1=unset, 0=day, 1=night; for transition logging
 }
 
 // newNighttimeScheduler creates a scheduler. If sunCalc is nil, the
@@ -28,7 +32,8 @@ func newNighttimeScheduler(sc *suncalc.SunCalc) *nighttimeScheduler {
 		sunCalc:  sc,
 		stopChan: make(chan struct{}),
 	}
-	s.active.Store(true) // fail open: active until first refresh
+	s.active.Store(true)  // fail open: active until first refresh
+	s.prevNight.Store(-1) // unset; first refresh will log the initial state
 	return s
 }
 
@@ -53,14 +58,11 @@ func (s *nighttimeScheduler) start(nighttimeOnlyFn func() bool) {
 	}()
 }
 
-// stop terminates the background goroutine.
+// stop terminates the background goroutine. Safe for concurrent callers.
 func (s *nighttimeScheduler) stop() {
-	select {
-	case <-s.stopChan:
-		// already closed
-	default:
+	s.stopOnce.Do(func() {
 		close(s.stopChan)
-	}
+	})
 }
 
 // isActive returns the precomputed bat-active state. Single atomic load.
@@ -86,11 +88,31 @@ func (s *nighttimeScheduler) refresh(nighttimeOnly bool) {
 	}
 
 	if !conf.Setting().BirdNET.LocationConfigured {
+		if s.locationWarn.CompareAndSwap(false, true) {
+			GetLogger().Warn("bat nighttime scheduler: location not configured, bat model will run 24/7",
+				logger.String("operation", "nighttime_scheduler_refresh"))
+		}
 		s.active.Store(true)
 		return
 	}
 
-	s.active.Store(isNighttime(s.sunCalc, time.Now()))
+	night := isNighttime(s.sunCalc, time.Now())
+	s.active.Store(night)
+
+	var nightInt int32
+	if night {
+		nightInt = 1
+	}
+	prev := s.prevNight.Swap(nightInt)
+	if prev != nightInt {
+		if night {
+			GetLogger().Info("bat detection activated (nighttime)",
+				logger.String("operation", "nighttime_scheduler_transition"))
+		} else {
+			GetLogger().Info("bat detection paused (daytime)",
+				logger.String("operation", "nighttime_scheduler_transition"))
+		}
+	}
 }
 
 // isNighttime checks if the given time falls within the nighttime window

--- a/internal/classifier/nighttime_scheduler.go
+++ b/internal/classifier/nighttime_scheduler.go
@@ -4,6 +4,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/logger"
 	"github.com/tphakala/birdnet-go/internal/suncalc"
 )
@@ -80,6 +81,11 @@ func (s *nighttimeScheduler) refresh(nighttimeOnly bool) {
 			GetLogger().Warn("bat nighttime scheduler has no suncalc instance, bat model will run 24/7",
 				logger.String("operation", "nighttime_scheduler_refresh"))
 		}
+		s.active.Store(true)
+		return
+	}
+
+	if !conf.Setting().BirdNET.LocationConfigured {
 		s.active.Store(true)
 		return
 	}

--- a/internal/classifier/nighttime_scheduler.go
+++ b/internal/classifier/nighttime_scheduler.go
@@ -1,0 +1,114 @@
+package classifier
+
+import (
+	"sync/atomic"
+	"time"
+
+	"github.com/tphakala/birdnet-go/internal/logger"
+	"github.com/tphakala/birdnet-go/internal/suncalc"
+)
+
+const schedulerRefreshInterval = 60 * time.Second
+
+// nighttimeScheduler precomputes whether the bat model should be active
+// based on civil dusk/dawn times. A background goroutine refreshes the
+// state every 60 seconds so the hot path is a single atomic load.
+type nighttimeScheduler struct {
+	sunCalc  *suncalc.SunCalc
+	active   atomic.Bool
+	stopChan chan struct{}
+	warnOnce atomic.Bool
+}
+
+// newNighttimeScheduler creates a scheduler. If sunCalc is nil, the
+// scheduler fails open (bat model always active).
+func newNighttimeScheduler(sc *suncalc.SunCalc) *nighttimeScheduler {
+	s := &nighttimeScheduler{
+		sunCalc:  sc,
+		stopChan: make(chan struct{}),
+	}
+	s.active.Store(true) // fail open: active until first refresh
+	return s
+}
+
+// start begins the background refresh goroutine. The goroutine reads
+// nighttimeOnly from the callback on each tick so settings changes are
+// picked up without restart.
+func (s *nighttimeScheduler) start(nighttimeOnlyFn func() bool) {
+	// Run initial refresh immediately
+	s.refresh(nighttimeOnlyFn())
+
+	go func() {
+		ticker := time.NewTicker(schedulerRefreshInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-s.stopChan:
+				return
+			case <-ticker.C:
+				s.refresh(nighttimeOnlyFn())
+			}
+		}
+	}()
+}
+
+// stop terminates the background goroutine.
+func (s *nighttimeScheduler) stop() {
+	select {
+	case <-s.stopChan:
+		// already closed
+	default:
+		close(s.stopChan)
+	}
+}
+
+// isActive returns the precomputed bat-active state. Single atomic load.
+func (s *nighttimeScheduler) isActive() bool {
+	return s.active.Load()
+}
+
+// refresh recalculates the bat-active state based on current time and
+// sun position. Called by the background ticker.
+func (s *nighttimeScheduler) refresh(nighttimeOnly bool) {
+	if !nighttimeOnly {
+		s.active.Store(true)
+		return
+	}
+
+	if s.sunCalc == nil {
+		if s.warnOnce.CompareAndSwap(false, true) {
+			GetLogger().Warn("bat nighttime scheduler has no suncalc instance, bat model will run 24/7",
+				logger.String("operation", "nighttime_scheduler_refresh"))
+		}
+		s.active.Store(true)
+		return
+	}
+
+	s.active.Store(isNighttime(s.sunCalc, time.Now()))
+}
+
+// isNighttime checks if the given time falls within the nighttime window
+// [CivilDusk, next CivilDawn). Handles the midnight crossing case by
+// checking both today's dusk and today's dawn independently.
+func isNighttime(sc *suncalc.SunCalc, now time.Time) bool {
+	todaySun, err := sc.GetSunEventTimes(now)
+	if err != nil {
+		GetLogger().Warn("suncalc error in nighttime check, allowing bat detection",
+			logger.Error(err),
+			logger.String("operation", "nighttime_check"))
+		return true // fail open
+	}
+
+	// Before today's civil dawn: we are in the tail of last night
+	if now.Before(todaySun.CivilDawn) {
+		return true
+	}
+
+	// After today's civil dusk: night has started
+	if !now.Before(todaySun.CivilDusk) {
+		return true
+	}
+
+	// Between dawn and dusk: daytime
+	return false
+}

--- a/internal/classifier/nighttime_scheduler_test.go
+++ b/internal/classifier/nighttime_scheduler_test.go
@@ -1,0 +1,90 @@
+package classifier
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/suncalc"
+)
+
+func TestIsNighttime(t *testing.T) {
+	t.Parallel()
+
+	// Helsinki: ~60.17N, 24.94E
+	sc := suncalc.NewSunCalc(60.17, 24.94)
+
+	// Use a date with well-defined civil dusk/dawn (equinox-ish)
+	// March 20: civil dawn ~05:30, civil dusk ~19:00 (approximate)
+	date := time.Date(2026, 3, 20, 0, 0, 0, 0, time.UTC)
+	sunTimes, err := sc.GetSunEventTimes(date)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name    string
+		timeStr string
+		want    bool
+	}{
+		{
+			name:    "midnight is nighttime",
+			timeStr: "2026-03-20T00:00:00",
+			want:    true,
+		},
+		{
+			name:    "noon is daytime",
+			timeStr: "2026-03-20T12:00:00",
+			want:    false,
+		},
+		{
+			name:    "just before civil dawn is nighttime",
+			timeStr: sunTimes.CivilDawn.Add(-1 * time.Minute).Format("2006-01-02T15:04:05"),
+			want:    true,
+		},
+		{
+			name:    "just after civil dawn is daytime",
+			timeStr: sunTimes.CivilDawn.Add(1 * time.Minute).Format("2006-01-02T15:04:05"),
+			want:    false,
+		},
+		{
+			name:    "just before civil dusk is daytime",
+			timeStr: sunTimes.CivilDusk.Add(-1 * time.Minute).Format("2006-01-02T15:04:05"),
+			want:    false,
+		},
+		{
+			name:    "just after civil dusk is nighttime",
+			timeStr: sunTimes.CivilDusk.Add(1 * time.Minute).Format("2006-01-02T15:04:05"),
+			want:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ts, err := time.ParseInLocation("2006-01-02T15:04:05", tt.timeStr, sunTimes.CivilDawn.Location())
+			require.NoError(t, err)
+			got := isNighttime(sc, ts)
+			assert.Equal(t, tt.want, got, "at %s (civilDawn=%s, civilDusk=%s)",
+				tt.timeStr, sunTimes.CivilDawn.Format(time.TimeOnly), sunTimes.CivilDusk.Format(time.TimeOnly))
+		})
+	}
+}
+
+func TestNighttimeScheduler_NilSunCalc(t *testing.T) {
+	t.Parallel()
+
+	s := newNighttimeScheduler(nil)
+	// Nil suncalc: fail open, bat should be active
+	assert.True(t, s.isActive())
+}
+
+func TestNighttimeScheduler_DisabledSetting(t *testing.T) {
+	t.Parallel()
+
+	sc := suncalc.NewSunCalc(60.17, 24.94)
+	s := newNighttimeScheduler(sc)
+
+	// When nighttimeOnly is false, model should always be active
+	s.refresh(false)
+	assert.True(t, s.isActive())
+}

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/tphakala/birdnet-go/internal/conf"
@@ -45,8 +46,9 @@ type Orchestrator struct {
 	primary   *BirdNET // direct access to the primary model
 	modelsDir string   // base directory for gallery-installed models
 
-	// Nighttime scheduling for bat model.
-	scheduler *nighttimeScheduler
+	// Nighttime scheduling for bat model. Stored as atomic.Pointer so
+	// IsModelActive (called on every monitor tick) reads lock-free.
+	scheduler atomic.Pointer[nighttimeScheduler]
 }
 
 // NewOrchestrator creates a new Orchestrator with BirdNET as the primary model
@@ -159,19 +161,16 @@ func (o *Orchestrator) SetSunCalc(sc *suncalc.SunCalc) {
 	o.mu.Lock()
 	defer o.mu.Unlock()
 
-	if o.scheduler != nil {
+	if o.scheduler.Load() != nil {
 		return // already started
 	}
 
-	o.scheduler = newNighttimeScheduler(sc)
+	s := newNighttimeScheduler(sc)
+	o.scheduler.Store(s)
 
 	// Only start the scheduler if the bat model is actually loaded.
 	if _, hasBat := o.models[RegistryIDBat]; hasBat {
-		o.scheduler.start(func() bool {
-			return conf.Setting().Bat.NighttimeOnly
-		})
-		GetLogger().Info("bat nighttime scheduler started",
-			logger.String("operation", "set_suncalc"))
+		o.startBatScheduler(s)
 	}
 }
 
@@ -182,11 +181,23 @@ func (o *Orchestrator) IsModelActive(modelID string) bool {
 	if modelID != RegistryIDBat {
 		return true
 	}
-	s := o.scheduler
+	s := o.scheduler.Load()
 	if s == nil {
 		return true // no scheduler = no restriction
 	}
 	return s.isActive()
+}
+
+// startBatScheduler creates a fresh scheduler (preserving the suncalc
+// reference from an existing one if present) and starts it. Handles the
+// unload/reload case where the previous scheduler's stopChan is closed.
+func (o *Orchestrator) startBatScheduler(s *nighttimeScheduler) {
+	nighttimeOnlyFn := func() bool {
+		return conf.Setting().Bat.NighttimeOnly
+	}
+	s.start(nighttimeOnlyFn)
+	GetLogger().Info("bat nighttime scheduler started",
+		logger.String("operation", "bat_scheduler_start"))
 }
 
 // resolveInstalledPaths looks up catalog entries for the given registry ID
@@ -480,8 +491,8 @@ func (o *Orchestrator) Delete() {
 		}
 		entry.mu.Unlock()
 	}
-	if o.scheduler != nil {
-		o.scheduler.stop()
+	if s := o.scheduler.Load(); s != nil {
+		s.stop()
 	}
 	// Nil out references to fail fast on use-after-delete.
 	o.primary = nil
@@ -575,12 +586,14 @@ func (o *Orchestrator) LoadModel(registryID string) error {
 		logger.String("registry_id", registryID))
 
 	// Start nighttime scheduler if bat model was just loaded and suncalc is available.
-	if registryID == RegistryIDBat && o.scheduler != nil {
-		o.scheduler.start(func() bool {
-			return conf.Setting().Bat.NighttimeOnly
-		})
-		log.Info("bat nighttime scheduler started after dynamic load",
-			logger.String("operation", "load_model"))
+	// Create a fresh scheduler to handle the unload/reload case where the
+	// previous scheduler's stopChan was closed.
+	if registryID == RegistryIDBat {
+		if old := o.scheduler.Load(); old != nil && old.sunCalc != nil {
+			s := newNighttimeScheduler(old.sunCalc)
+			o.scheduler.Store(s)
+			o.startBatScheduler(s)
+		}
 	}
 
 	return nil
@@ -625,8 +638,10 @@ func (o *Orchestrator) UnloadModel(registryID string) error {
 	// Remove from map while holding the write lock so no new PredictModel
 	// calls can obtain this entry.
 	delete(o.models, registryID)
-	if registryID == RegistryIDBat && o.scheduler != nil {
-		o.scheduler.stop()
+	if registryID == RegistryIDBat {
+		if s := o.scheduler.Load(); s != nil {
+			s.stop()
+		}
 	}
 	o.mu.Unlock()
 

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -13,6 +13,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/logger"
+	"github.com/tphakala/birdnet-go/internal/suncalc"
 )
 
 // modelEntry holds a model instance with its own lock for concurrent access.
@@ -43,6 +44,9 @@ type Orchestrator struct {
 	models    map[string]*modelEntry
 	primary   *BirdNET // direct access to the primary model
 	modelsDir string   // base directory for gallery-installed models
+
+	// Nighttime scheduling for bat model.
+	scheduler *nighttimeScheduler
 }
 
 // NewOrchestrator creates a new Orchestrator with BirdNET as the primary model
@@ -146,6 +150,43 @@ func (o *Orchestrator) registerTaxonomyResolver(modelsDir string) {
 		logger.String("path", taxonomyPath),
 		logger.String("locale", locale),
 		logger.Int("species", len(resolver.index)))
+}
+
+// SetSunCalc injects the sun calculator into the orchestrator and starts
+// the bat nighttime scheduler if the bat model is loaded. Called during
+// pipeline startup after the suncalc instance is available.
+func (o *Orchestrator) SetSunCalc(sc *suncalc.SunCalc) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	if o.scheduler != nil {
+		return // already started
+	}
+
+	o.scheduler = newNighttimeScheduler(sc)
+
+	// Only start the scheduler if the bat model is actually loaded.
+	if _, hasBat := o.models[RegistryIDBat]; hasBat {
+		o.scheduler.start(func() bool {
+			return conf.Setting().Bat.NighttimeOnly
+		})
+		GetLogger().Info("bat nighttime scheduler started",
+			logger.String("operation", "set_suncalc"))
+	}
+}
+
+// IsModelActive returns whether a model should currently run inference.
+// For the bat model, this checks the nighttime scheduler. For all other
+// models, it always returns true.
+func (o *Orchestrator) IsModelActive(modelID string) bool {
+	if modelID != RegistryIDBat {
+		return true
+	}
+	s := o.scheduler
+	if s == nil {
+		return true // no scheduler = no restriction
+	}
+	return s.isActive()
 }
 
 // resolveInstalledPaths looks up catalog entries for the given registry ID
@@ -439,6 +480,9 @@ func (o *Orchestrator) Delete() {
 		}
 		entry.mu.Unlock()
 	}
+	if o.scheduler != nil {
+		o.scheduler.stop()
+	}
 	// Nil out references to fail fast on use-after-delete.
 	o.primary = nil
 	o.models = nil
@@ -530,6 +574,15 @@ func (o *Orchestrator) LoadModel(registryID string) error {
 	log.Info("Model loaded dynamically",
 		logger.String("registry_id", registryID))
 
+	// Start nighttime scheduler if bat model was just loaded and suncalc is available.
+	if registryID == RegistryIDBat && o.scheduler != nil {
+		o.scheduler.start(func() bool {
+			return conf.Setting().Bat.NighttimeOnly
+		})
+		log.Info("bat nighttime scheduler started after dynamic load",
+			logger.String("operation", "load_model"))
+	}
+
 	return nil
 }
 
@@ -572,6 +625,9 @@ func (o *Orchestrator) UnloadModel(registryID string) error {
 	// Remove from map while holding the write lock so no new PredictModel
 	// calls can obtain this entry.
 	delete(o.models, registryID)
+	if registryID == RegistryIDBat && o.scheduler != nil {
+		o.scheduler.stop()
+	}
 	o.mu.Unlock()
 
 	// Close the model instance outside the map lock. Acquire the per-model

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -590,6 +590,7 @@ func (o *Orchestrator) LoadModel(registryID string) error {
 	// previous scheduler's stopChan was closed.
 	if registryID == RegistryIDBat {
 		if old := o.scheduler.Load(); old != nil && old.sunCalc != nil {
+			old.stop()
 			s := newNighttimeScheduler(old.sunCalc)
 			o.scheduler.Store(s)
 			o.startBatScheduler(s)

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -1190,6 +1190,7 @@ type BatConfig struct {
 	FilterEnabled   bool    `yaml:"filterenabled" json:"filterEnabled"`                         // enable high-pass filter for bat audio
 	FilterCutoffHz  float64 `yaml:"filtercutoffhz,omitempty" json:"filterCutoffHz,omitempty"`   // high-pass filter cutoff frequency in Hz
 	FilterPassCount int     `yaml:"filterpasscount,omitempty" json:"filterPassCount,omitempty"` // number of filter passes for steeper rolloff
+	NighttimeOnly   bool    `yaml:"nighttimeonly" json:"nighttimeOnly"`                         // restrict bat detection to nighttime (civil dusk to civil dawn)
 }
 
 // BSGConfig holds configuration for BSG regional bird models.

--- a/internal/conf/defaults.go
+++ b/internal/conf/defaults.go
@@ -88,6 +88,7 @@ func setDefaultConfig() {
 	viper.SetDefault("bat.filterenabled", false)
 	viper.SetDefault("bat.filtercutoffhz", 4000.0)
 	viper.SetDefault("bat.filterpasscount", 1)
+	viper.SetDefault("bat.nighttimeonly", true)
 
 	// Global model enablement (BirdNET only by default)
 	viper.SetDefault("models.enabled", []string{"birdnet"})


### PR DESCRIPTION
## Summary

- Add `NighttimeOnly` config toggle to `BatConfig` (default: `true`)
- Implement `NighttimeScheduler` that precomputes bat-active state every 60 seconds using civil dusk/dawn from suncalc
- Wire scheduler into `Orchestrator` with `SetSunCalc()` and `IsModelActive()` methods
- Gate inference in `BufferManager.processMonitorTick` before `ProcessData` dispatch
- Add "Nighttime Only" checkbox in Settings > Analysis > Detection Settings (bat section)
- Translations for all 14 locales

The hot path is a single `atomic.Bool` load per monitor tick. Non-bat models pay zero cost (single string comparison). The scheduler uses `atomic.Pointer` for the scheduler field to avoid data races, creates fresh scheduler instances on bat model reinstall, and fails open on errors (bat model stays active if suncalc or location is unavailable).

Transition events ("bat detection activated/paused") are logged at Info level on dawn/dusk boundaries.

## Test Plan

- [x] `TestIsNighttime` - 6 boundary cases (midnight, noon, dawn +/- 1min, dusk +/- 1min)
- [x] `TestNighttimeScheduler_NilSunCalc` - fail-open when suncalc unavailable
- [x] `TestNighttimeScheduler_DisabledSetting` - always active when nighttimeOnly=false
- [x] `golangci-lint run` - zero issues
- [x] `go test -race ./internal/classifier/ ./internal/conf/` - 1697 tests pass
- [x] `npm run check:all` - zero errors, zero warnings from svelte-check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Nighttime Only" option for bat detection with a UI checkbox to restrict detection to civil dusk–dawn. Enabled by default; requires configured location.

* **Localization**
  * Added translations for the new bat detection setting in DA, DE, EN, ES, FI, FR, HU, IT, LV, NL, PL, PT, SK, and SV.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3069)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->