### PR TITLE
fix(classifier): use universal geomodel species list for range filter inclusion

### DIFF
--- a/frontend/src/lib/desktop/features/settings/pages/AnalysisSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/AnalysisSettingsPage.svelte
@@ -1131,7 +1131,7 @@
                 >{t('analysis.rangeFilter.status.classifierSpecies')}</span
               >
               <span class="ml-2 font-medium tabular-nums"
-                >{rangeFilterStatus.classifierSpecies.toLocaleString()}</span
+                >{(rangeFilterStatus.classifierSpecies ?? 0).toLocaleString()}</span
               >
             </div>
             <div>

--- a/frontend/src/lib/desktop/features/settings/pages/AnalysisSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/AnalysisSettingsPage.svelte
@@ -1128,6 +1128,14 @@
             </div>
             <div>
               <span class="text-[var(--color-base-content)]/60"
+                >{t('analysis.rangeFilter.status.classifierSpecies')}</span
+              >
+              <span class="ml-2 font-medium tabular-nums"
+                >{rangeFilterStatus.classifierSpecies.toLocaleString()}</span
+              >
+            </div>
+            <div>
+              <span class="text-[var(--color-base-content)]/60"
                 >{t('analysis.rangeFilter.status.mappedSpecies')}</span
               >
               <span class="ml-2 font-medium tabular-nums"

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -4537,6 +4537,7 @@
         "autoSelected": "Automatisch ausgewählt",
         "manual": "Manuell",
         "classifierModel": "Klassifikator",
+        "classifierSpecies": "Klassifikator-Arten",
         "mappedSpecies": "Zugeordnete Arten",
         "unmappedSpecies": "Nicht zugeordnete Arten",
         "totalSpecies": "Arten insgesamt",

--- a/frontend/static/messages/en.json
+++ b/frontend/static/messages/en.json
@@ -4537,6 +4537,7 @@
         "autoSelected": "Auto-selected",
         "manual": "Manual",
         "classifierModel": "Classifier",
+        "classifierSpecies": "Classifier Species",
         "mappedSpecies": "Mapped Species",
         "unmappedSpecies": "Unmapped Species",
         "totalSpecies": "Total Species",

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -4537,6 +4537,7 @@
         "autoSelected": "Seleccionado automáticamente",
         "manual": "Manual",
         "classifierModel": "Clasificador",
+        "classifierSpecies": "Especies del clasificador",
         "mappedSpecies": "Especies mapeadas",
         "unmappedSpecies": "Especies no mapeadas",
         "totalSpecies": "Total de especies",

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -4537,6 +4537,7 @@
         "autoSelected": "Automaattisesti valittu",
         "manual": "Manuaalinen",
         "classifierModel": "Luokittelija",
+        "classifierSpecies": "Luokittelijan lajit",
         "mappedSpecies": "Kartoitetut lajit",
         "unmappedSpecies": "Kartoittamattomat lajit",
         "totalSpecies": "Lajeja yhteensä",

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -4537,6 +4537,7 @@
         "autoSelected": "Sélectionné automatiquement",
         "manual": "Manuel",
         "classifierModel": "Classificateur",
+        "classifierSpecies": "Espèces du classificateur",
         "mappedSpecies": "Espèces cartographiées",
         "unmappedSpecies": "Espèces non cartographiées",
         "totalSpecies": "Total des espèces",

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -4537,6 +4537,7 @@
         "autoSelected": "Automatisch geselecteerd",
         "manual": "Handmatig",
         "classifierModel": "Classificator",
+        "classifierSpecies": "Classificator soorten",
         "mappedSpecies": "Gekoppelde soorten",
         "unmappedSpecies": "Niet-gekoppelde soorten",
         "totalSpecies": "Totaal aantal soorten",

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -4537,6 +4537,7 @@
         "autoSelected": "Wybrano automatycznie",
         "manual": "Ręczny",
         "classifierModel": "Klasyfikator",
+        "classifierSpecies": "Gatunki klasyfikatora",
         "mappedSpecies": "Zmapowane gatunki",
         "unmappedSpecies": "Niezmapowane gatunki",
         "totalSpecies": "Łącznie gatunków",

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -4537,6 +4537,7 @@
         "autoSelected": "Selecionado automaticamente",
         "manual": "Manual",
         "classifierModel": "Classificador",
+        "classifierSpecies": "Espécies do classificador",
         "mappedSpecies": "Espécies mapeadas",
         "unmappedSpecies": "Espécies não mapeadas",
         "totalSpecies": "Total de espécies",

--- a/internal/analysis/processor/processor.go
+++ b/internal/analysis/processor/processor.go
@@ -908,6 +908,7 @@ func (p *Processor) shouldFilterDetection(settings *conf.Settings, result datast
 			GetLogger().Debug("species not on included list",
 				logger.String("species", result.Species),
 				logger.Float32("confidence", result.Confidence),
+				logger.String("model_id", modelID),
 				logger.String("operation", "species_inclusion_filter"))
 		}
 		return true, confidenceThreshold

--- a/internal/classifier/mapped_range_filter.go
+++ b/internal/classifier/mapped_range_filter.go
@@ -110,6 +110,13 @@ func (m *mappedRangeFilter) PredictIncludedSpecies(lat, lon, week, threshold flo
 	return included, nil
 }
 
+// GeomodelLabels returns the full geomodel label set for use in species
+// override matching, where the caller needs to search all known species
+// (not just those passing the range filter threshold).
+func (m *mappedRangeFilter) GeomodelLabels() []string {
+	return m.geomodelLabels
+}
+
 // NumSpecies returns the number of classifier labels (not geomodel labels).
 func (m *mappedRangeFilter) NumSpecies() int {
 	return m.numClassifier

--- a/internal/classifier/mapped_range_filter.go
+++ b/internal/classifier/mapped_range_filter.go
@@ -13,10 +13,11 @@ import (
 // changing predictFilter() or any downstream code.
 type mappedRangeFilter struct {
 	inner           inference.RangeFilter
-	classifierToGeo []int   // classifierIndex -> geomodelIndex; -1 means no match
-	numClassifier   int     // len(classifierLabels)
-	mappedCount     int     // number of classifier species with a geomodel match
-	unmappedScore   float32 // score for classifier species absent from geomodel
+	classifierToGeo []int    // classifierIndex -> geomodelIndex; -1 means no match
+	numClassifier   int      // len(classifierLabels)
+	mappedCount     int      // number of classifier species with a geomodel match
+	unmappedScore   float32  // score for classifier species absent from geomodel
+	geomodelLabels  []string // geomodel label set in geomodel output order
 }
 
 // buildSpeciesMapping creates the classifier-to-geomodel index mapping by
@@ -69,6 +70,7 @@ func newMappedRangeFilter(inner inference.RangeFilter, classifierLabels, geomode
 		numClassifier:   len(classifierLabels),
 		mappedCount:     mapped,
 		unmappedScore:   unmappedScore,
+		geomodelLabels:  geomodelLabels,
 	}
 }
 
@@ -88,6 +90,24 @@ func (m *mappedRangeFilter) Predict(latitude, longitude, week float32) ([]float3
 		}
 	}
 	return scores, nil
+}
+
+// PredictIncludedSpecies returns the geomodel labels whose predicted score meets
+// or exceeds threshold. The returned labels come from the geomodel's own label
+// set (not the classifier's labels), so the result covers all species the
+// geomodel knows about regardless of which classifier is active.
+func (m *mappedRangeFilter) PredictIncludedSpecies(lat, lon, week, threshold float32) ([]string, error) {
+	geoScores, err := m.inner.Predict(lat, lon, week)
+	if err != nil {
+		return nil, err
+	}
+	included := make([]string, 0, len(m.geomodelLabels)/4)
+	for i, score := range geoScores {
+		if score >= threshold && i < len(m.geomodelLabels) {
+			included = append(included, m.geomodelLabels[i])
+		}
+	}
+	return included, nil
 }
 
 // NumSpecies returns the number of classifier labels (not geomodel labels).

--- a/internal/classifier/mapped_range_filter_test.go
+++ b/internal/classifier/mapped_range_filter_test.go
@@ -180,3 +180,80 @@ func TestMappedRangeFilter_Close(t *testing.T) {
 	mapped.Close()
 	assert.True(t, inner.closed, "Close should delegate to inner filter")
 }
+
+func TestMappedRangeFilter_GeomodelLabelsStored(t *testing.T) {
+	t.Parallel()
+
+	geomodelLabels := []string{
+		"Parus major_Great Tit",
+		"Turdus merula_Amsel",
+		"Corvus corax_Northern Raven",
+		"Erithacus rubecula_Robin",
+	}
+
+	inner := &fakeRangeFilter{scores: make([]float32, len(geomodelLabels))}
+	mapped := newMappedRangeFilter(inner, []string{"Parus major_Great Tit"}, geomodelLabels, 0.0)
+
+	require.Len(t, mapped.geomodelLabels, len(geomodelLabels), "geomodelLabels field should be populated with all geomodel labels")
+	assert.Equal(t, geomodelLabels, mapped.geomodelLabels)
+}
+
+func TestMappedRangeFilter_PredictIncludedSpecies(t *testing.T) {
+	t.Parallel()
+
+	// geomodel scores: species A=0.8, B=0.9, C=0.3, D=0.05
+	// threshold=0.1, so A, B, C pass; D does not
+	geomodelLabels := []string{
+		"Parus major_Great Tit",
+		"Turdus merula_Amsel",
+		"Erithacus rubecula_Robin",
+		"Ficedula hypoleuca_Pied Flycatcher",
+	}
+	inner := &fakeRangeFilter{
+		scores: []float32{0.8, 0.9, 0.3, 0.05},
+	}
+
+	// classifier labels can differ from geomodel labels
+	classifierLabels := []string{"Parus major_Titmouse"}
+	mapped := newMappedRangeFilter(inner, classifierLabels, geomodelLabels, 0.0)
+
+	included, err := mapped.PredictIncludedSpecies(60.0, 25.0, 20.0, 0.1)
+	require.NoError(t, err)
+
+	// species D (score 0.05) is below threshold; A, B, C should be included
+	require.Len(t, included, 3)
+	assert.Equal(t, "Parus major_Great Tit", included[0])
+	assert.Equal(t, "Turdus merula_Amsel", included[1])
+	assert.Equal(t, "Erithacus rubecula_Robin", included[2])
+}
+
+func TestMappedRangeFilter_PredictIncludedSpecies_EmptyResult(t *testing.T) {
+	t.Parallel()
+
+	geomodelLabels := []string{
+		"Parus major_Great Tit",
+		"Turdus merula_Amsel",
+	}
+	inner := &fakeRangeFilter{
+		scores: []float32{0.05, 0.08},
+	}
+
+	mapped := newMappedRangeFilter(inner, []string{"Parus major_Titmouse"}, geomodelLabels, 0.0)
+
+	// threshold of 0.5 means no species pass
+	included, err := mapped.PredictIncludedSpecies(60.0, 25.0, 20.0, 0.5)
+	require.NoError(t, err)
+	assert.Empty(t, included, "no species should pass a high threshold")
+}
+
+func TestMappedRangeFilter_PredictIncludedSpecies_PropagatesError(t *testing.T) {
+	t.Parallel()
+
+	inner := &fakeRangeFilter{
+		err: assert.AnError,
+	}
+	mapped := newMappedRangeFilter(inner, []string{"A_B"}, []string{"A_B"}, 0.0)
+
+	_, err := mapped.PredictIncludedSpecies(60.0, 25.0, 20.0, 0.1)
+	assert.Error(t, err)
+}

--- a/internal/classifier/range_filter.go
+++ b/internal/classifier/range_filter.go
@@ -87,6 +87,12 @@ func BuildRangeFilter(o *Orchestrator) error {
 		}
 
 		addUserOverrideSpecies(&includedSpecies, settings, labels)
+
+		GetLogger().Info("Range filter updated via universal geomodel path",
+			logger.Int("geomodel_species", len(labels)),
+			logger.Int("included_species", len(includedSpecies)),
+			logger.Float64("threshold", float64(threshold)),
+			logger.String("duration", time.Since(start).String()))
 	} else {
 		speciesScores, err := o.GetProbableSpecies(today, 0.0)
 		if err != nil {
@@ -102,6 +108,10 @@ func BuildRangeFilter(o *Orchestrator) error {
 		for _, speciesScore := range speciesScores {
 			includedSpecies = append(includedSpecies, speciesScore.Label)
 		}
+
+		GetLogger().Info("Range filter updated via legacy classifier path",
+			logger.Int("included_species", len(includedSpecies)),
+			logger.String("duration", time.Since(start).String()))
 	}
 
 	if conf.Setting().BirdNET.RangeFilter.Debug {

--- a/internal/classifier/range_filter.go
+++ b/internal/classifier/range_filter.go
@@ -31,34 +31,80 @@ func (a ByScore) Len() int           { return len(a) }
 func (a ByScore) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
 func (a ByScore) Less(i, j int) bool { return a[i].Score > a[j].Score } // For descending order
 
-// BuildRangeFilter updates the range filter with current probable species
+// UniversalSpeciesPredictor is implemented by range filters that can
+// produce a species inclusion list from their own labels, independent
+// of any specific classifier's label set.
+type UniversalSpeciesPredictor interface {
+	PredictIncludedSpecies(lat, lon, week, threshold float32) ([]string, error)
+}
+
+// BuildRangeFilter updates the range filter with current probable species.
+// If the active range filter implements UniversalSpeciesPredictor, the
+// species list is derived directly from the geomodel's own labels
+// (typically ~12K species). Otherwise it falls back to GetProbableSpecies,
+// which is limited to the BirdNET classifier's label set.
 func BuildRangeFilter(o *Orchestrator) error {
 	start := time.Now()
-
-	// Get date for Range Filter week calculation
 	today := time.Now().Truncate(24 * time.Hour)
+	settings := conf.CurrentOrFallback(o.Settings)
 
-	// Update location based species list
-	speciesScores, err := o.GetProbableSpecies(today, 0.0)
-	if err != nil {
-		return errors.New(err).
-			Category(errors.CategoryValidation).
-			Context("date", today.Format(time.DateOnly)).
-			Context("latitude", o.Settings.BirdNET.Latitude).
-			Context("longitude", o.Settings.BirdNET.Longitude).
-			Timing("range-filter-build", time.Since(start)).
-			Build()
-	}
+	var includedSpecies []string
 
-	// Convert the speciesScores slice to a slice of species labels
-	// Pre-allocate slice with capacity for all species scores
-	includedSpecies := make([]string, 0, len(speciesScores))
-	for _, speciesScore := range speciesScores {
-		includedSpecies = append(includedSpecies, speciesScore.Label)
+	o.primary.mu.Lock()
+	rf := o.primary.rangeFilter
+	o.primary.mu.Unlock()
+
+	if up, ok := rf.(UniversalSpeciesPredictor); ok && settings.BirdNET.LocationConfigured {
+		threshold := settings.BirdNET.RangeFilter.Threshold
+		if threshold < 0 || threshold > 1 {
+			GetLogger().Warn("Invalid LocationFilterThreshold value, using default",
+				logger.Float64("invalid_value", float64(threshold)),
+				logger.Float64("default_value", 0.01))
+			threshold = 0.01
+		}
+
+		labels, err := up.PredictIncludedSpecies(
+			float32(settings.BirdNET.Latitude),
+			float32(settings.BirdNET.Longitude),
+			getWeekForFilter(today),
+			threshold,
+		)
+		if err != nil {
+			return errors.New(err).
+				Category(errors.CategoryValidation).
+				Context("date", today.Format(time.DateOnly)).
+				Context("latitude", settings.BirdNET.Latitude).
+				Context("longitude", settings.BirdNET.Longitude).
+				Timing("range-filter-build", time.Since(start)).
+				Build()
+		}
+
+		includedSpecies = make([]string, 0, len(labels))
+		for _, label := range labels {
+			if !isSpeciesExcluded(label, settings.Realtime.Species.Exclude) {
+				includedSpecies = append(includedSpecies, label)
+			}
+		}
+
+		addUserOverrideSpecies(&includedSpecies, settings, labels)
+	} else {
+		speciesScores, err := o.GetProbableSpecies(today, 0.0)
+		if err != nil {
+			return errors.New(err).
+				Category(errors.CategoryValidation).
+				Context("date", today.Format(time.DateOnly)).
+				Context("latitude", settings.BirdNET.Latitude).
+				Context("longitude", settings.BirdNET.Longitude).
+				Timing("range-filter-build", time.Since(start)).
+				Build()
+		}
+		includedSpecies = make([]string, 0, len(speciesScores))
+		for _, speciesScore := range speciesScores {
+			includedSpecies = append(includedSpecies, speciesScore.Label)
+		}
 	}
 
 	if conf.Setting().BirdNET.RangeFilter.Debug {
-		// Debug: Write included species to file
 		debugFile := "debug_included_species.txt"
 		var content strings.Builder
 		fmt.Fprintf(&content, "Updated at: %s\nSpecies count: %d\n\nSpecies list:\n",
@@ -68,7 +114,6 @@ func BuildRangeFilter(o *Orchestrator) error {
 			content.WriteString(species + "\n")
 		}
 		if err := os.WriteFile(debugFile, []byte(content.String()), 0o600); err != nil {
-			// Don't fail the operation, just log the error
 			GetLogger().Warn("Failed to write included species debug file",
 				logger.Error(err),
 				logger.String("debug_file", debugFile),
@@ -77,8 +122,40 @@ func BuildRangeFilter(o *Orchestrator) error {
 	}
 
 	conf.UpdateIncludedSpecies(includedSpecies)
-
 	return nil
+}
+
+// addUserOverrideSpecies appends species from the explicit include list
+// and species with configured actions to the inclusion set. Each entry is
+// matched against availableLabels by common or scientific name; if no match
+// is found the raw entry is appended so the scientific name map picks it up.
+func addUserOverrideSpecies(includedSpecies *[]string, settings *conf.Settings, availableLabels []string) {
+	seen := make(map[string]bool, len(*includedSpecies))
+	for _, s := range *includedSpecies {
+		seen[s] = true
+	}
+
+	addOverride := func(speciesName string) {
+		matched := false
+		for _, label := range availableLabels {
+			if matchesSpecies(label, speciesName) && !seen[label] {
+				*includedSpecies = append(*includedSpecies, label)
+				seen[label] = true
+				matched = true
+			}
+		}
+		if !matched && !seen[speciesName] {
+			*includedSpecies = append(*includedSpecies, speciesName)
+			seen[speciesName] = true
+		}
+	}
+
+	for _, species := range settings.Realtime.Species.Include {
+		addOverride(species)
+	}
+	for species := range settings.Realtime.Species.Config {
+		addOverride(species)
+	}
 }
 
 // GetProbableSpecies filters and sorts bird species based on their scores.

--- a/internal/classifier/range_filter.go
+++ b/internal/classifier/range_filter.go
@@ -45,21 +45,18 @@ type UniversalSpeciesPredictor interface {
 // which is limited to the BirdNET classifier's label set.
 func BuildRangeFilter(o *Orchestrator) error {
 	start := time.Now()
-	today := time.Now().Truncate(24 * time.Hour)
+	today := start.Truncate(24 * time.Hour)
 	settings := conf.CurrentOrFallback(o.Settings)
 
 	var includedSpecies []string
 
 	o.primary.mu.Lock()
 	rf := o.primary.rangeFilter
-	o.primary.mu.Unlock()
+	up, isUniversal := rf.(UniversalSpeciesPredictor)
 
-	if up, ok := rf.(UniversalSpeciesPredictor); ok && settings.BirdNET.LocationConfigured {
+	if isUniversal && settings.BirdNET.LocationConfigured {
 		threshold := settings.BirdNET.RangeFilter.Threshold
 		if threshold < 0 || threshold > 1 {
-			GetLogger().Warn("Invalid LocationFilterThreshold value, using default",
-				logger.Float64("invalid_value", float64(threshold)),
-				logger.Float64("default_value", 0.01))
 			threshold = 0.01
 		}
 
@@ -69,6 +66,8 @@ func BuildRangeFilter(o *Orchestrator) error {
 			getWeekForFilter(today),
 			threshold,
 		)
+		o.primary.mu.Unlock()
+
 		if err != nil {
 			return errors.New(err).
 				Category(errors.CategoryValidation).
@@ -94,6 +93,7 @@ func BuildRangeFilter(o *Orchestrator) error {
 			logger.Float64("threshold", float64(threshold)),
 			logger.String("duration", time.Since(start).String()))
 	} else {
+		o.primary.mu.Unlock()
 		speciesScores, err := o.GetProbableSpecies(today, 0.0)
 		if err != nil {
 			return errors.New(err).
@@ -114,7 +114,7 @@ func BuildRangeFilter(o *Orchestrator) error {
 			logger.String("duration", time.Since(start).String()))
 	}
 
-	if conf.Setting().BirdNET.RangeFilter.Debug {
+	if settings.BirdNET.RangeFilter.Debug {
 		debugFile := "debug_included_species.txt"
 		var content strings.Builder
 		fmt.Fprintf(&content, "Updated at: %s\nSpecies count: %d\n\nSpecies list:\n",

--- a/internal/classifier/range_filter.go
+++ b/internal/classifier/range_filter.go
@@ -150,10 +150,12 @@ func addUserOverrideSpecies(includedSpecies *[]string, settings *conf.Settings, 
 	addOverride := func(speciesName string) {
 		matched := false
 		for _, label := range availableLabels {
-			if matchesSpecies(label, speciesName) && !seen[label] {
-				*includedSpecies = append(*includedSpecies, label)
-				seen[label] = true
+			if matchesSpecies(label, speciesName) {
 				matched = true
+				if !seen[label] {
+					*includedSpecies = append(*includedSpecies, label)
+					seen[label] = true
+				}
 			}
 		}
 		if !matched && !seen[speciesName] {

--- a/internal/classifier/range_filter.go
+++ b/internal/classifier/range_filter.go
@@ -36,6 +36,7 @@ func (a ByScore) Less(i, j int) bool { return a[i].Score > a[j].Score } // For d
 // of any specific classifier's label set.
 type UniversalSpeciesPredictor interface {
 	PredictIncludedSpecies(lat, lon, week, threshold float32) ([]string, error)
+	GeomodelLabels() []string
 }
 
 // BuildRangeFilter updates the range filter with current probable species.
@@ -60,6 +61,7 @@ func BuildRangeFilter(o *Orchestrator) error {
 			threshold = 0.01
 		}
 
+		allGeoLabels := up.GeomodelLabels()
 		labels, err := up.PredictIncludedSpecies(
 			float32(settings.BirdNET.Latitude),
 			float32(settings.BirdNET.Longitude),
@@ -85,7 +87,7 @@ func BuildRangeFilter(o *Orchestrator) error {
 			}
 		}
 
-		addUserOverrideSpecies(&includedSpecies, settings, labels)
+		addUserOverrideSpecies(&includedSpecies, settings, allGeoLabels)
 
 		GetLogger().Info("Range filter updated via universal geomodel path",
 			logger.Int("geomodel_species", len(labels)),

--- a/internal/conf/clone.go
+++ b/internal/conf/clone.go
@@ -50,6 +50,7 @@ func CloneSettings(src *Settings) *Settings {
 	// BirdNET.
 	dst.BirdNET.Labels = slices.Clone(src.BirdNET.Labels)
 	dst.BirdNET.RangeFilter.Species = slices.Clone(src.BirdNET.RangeFilter.Species)
+	dst.BirdNET.RangeFilter.IncludedScientificNames = maps.Clone(src.BirdNET.RangeFilter.IncludedScientificNames)
 
 	// Models.
 	dst.Models.Enabled = slices.Clone(src.Models.Enabled)

--- a/internal/conf/clone_test.go
+++ b/internal/conf/clone_test.go
@@ -280,6 +280,27 @@ func mutateCloneEverywhere(dst *Settings) {
 	dst.Notification.Push.Providers[0] = pp
 }
 
+// TestCloneSettings_IncludedScientificNamesIndependence verifies that
+// IncludedScientificNames is deep-cloned so mutations on the copy do not
+// affect the original.
+func TestCloneSettings_IncludedScientificNamesIndependence(t *testing.T) {
+	t.Parallel()
+
+	src := &Settings{}
+	src.BirdNET.RangeFilter.IncludedScientificNames = map[string]struct{}{
+		"turdus merula": {},
+		"parus major":   {},
+	}
+
+	dst := CloneSettings(src)
+
+	dst.BirdNET.RangeFilter.IncludedScientificNames["corvus corax"] = struct{}{}
+
+	assert.Len(t, src.BirdNET.RangeFilter.IncludedScientificNames, 2,
+		"source map must not be modified by mutation of clone")
+	assert.Len(t, dst.BirdNET.RangeFilter.IncludedScientificNames, 3)
+}
+
 // assertSourceUnchanged verifies that every field touched by
 // mutateCloneEverywhere still holds its original value on src.
 func assertSourceUnchanged(t *testing.T, src *Settings) {

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -1162,14 +1162,15 @@ type BirdNETConfig struct {
 
 // RangeFilterSettings contains settings for the range filter
 type RangeFilterSettings struct {
-	Debug               bool      `yaml:"debug" json:"debug"`                               // true to enable debug mode
-	Model               string    `yaml:"model" json:"model"`                               // range filter model version: "legacy" for v1, "v3" for geomodel v3.0, or empty/default for v2
-	ModelPath           string    `yaml:"modelpath" json:"modelPath"`                       // path to external meta model file (empty for embedded)
-	LabelsPath          string    `yaml:"labelspath,omitempty" json:"labelsPath,omitempty"` // path to geomodel labels file (required when geomodel differs from classifier labels)
-	Threshold           float32   `yaml:"threshold" json:"threshold"`                       // rangefilter species occurrence threshold
-	PassUnmappedSpecies bool      `yaml:"passunmappedspecies" json:"passUnmappedSpecies"`   // true to pass through species absent from geomodel (score 1.0); false to filter them out (score 0.0)
-	Species             []string  `yaml:"-" json:"species,omitempty"`                       // list of included species, runtime value
-	LastUpdated         time.Time `yaml:"-" json:"lastUpdated"`                             // last time the species list was updated, runtime value
+	Debug                   bool                `yaml:"debug" json:"debug"`                               // true to enable debug mode
+	Model                   string              `yaml:"model" json:"model"`                               // range filter model version: "legacy" for v1, "v3" for geomodel v3.0, or empty/default for v2
+	ModelPath               string              `yaml:"modelpath" json:"modelPath"`                       // path to external meta model file (empty for embedded)
+	LabelsPath              string              `yaml:"labelspath,omitempty" json:"labelsPath,omitempty"` // path to geomodel labels file (required when geomodel differs from classifier labels)
+	Threshold               float32             `yaml:"threshold" json:"threshold"`                       // rangefilter species occurrence threshold
+	PassUnmappedSpecies     bool                `yaml:"passunmappedspecies" json:"passUnmappedSpecies"`   // true to pass through species absent from geomodel (score 1.0); false to filter them out (score 0.0)
+	Species                 []string            `yaml:"-" json:"species,omitempty"`                       // list of included species, runtime value
+	IncludedScientificNames map[string]struct{} `yaml:"-" json:"-"`                                       // O(1) lookup set of included scientific names (lowercase), runtime value
+	LastUpdated             time.Time           `yaml:"-" json:"lastUpdated"`                             // last time the species list was updated, runtime value
 }
 
 // PerchConfig holds configuration for the Google Perch v2 model.

--- a/internal/conf/range_filter.go
+++ b/internal/conf/range_filter.go
@@ -16,7 +16,8 @@ import (
 var speciesListMutex sync.Mutex
 
 // UpdateIncludedSpecies clones the current settings, replaces the species
-// list and LastUpdated timestamp, and publishes a new immutable snapshot.
+// list, builds the O(1) scientific name lookup map, and publishes a new
+// immutable snapshot.
 func UpdateIncludedSpecies(species []string) {
 	speciesListMutex.Lock()
 	defer speciesListMutex.Unlock()
@@ -29,6 +30,17 @@ func UpdateIncludedSpecies(species []string) {
 	updated := CloneSettings(current)
 	updated.BirdNET.RangeFilter.Species = make([]string, len(species))
 	copy(updated.BirdNET.RangeFilter.Species, species)
+
+	sciNames := make(map[string]struct{}, len(species))
+	for _, label := range species {
+		sci := label
+		if idx := strings.IndexByte(label, '_'); idx >= 0 {
+			sci = label[:idx]
+		}
+		sciNames[strings.ToLower(sci)] = struct{}{}
+	}
+	updated.BirdNET.RangeFilter.IncludedScientificNames = sciNames
+
 	updated.BirdNET.RangeFilter.LastUpdated = time.Now()
 	StoreSettings(updated)
 }
@@ -39,9 +51,21 @@ func (s *Settings) GetIncludedSpecies() []string {
 	return slices.Clone(s.BirdNET.RangeFilter.Species)
 }
 
-// IsSpeciesIncluded checks if a given scientific name matches the scientific
-// name part of any included species in this snapshot.
+// IsSpeciesIncluded reports whether the given label is in the included species
+// set. When the IncludedScientificNames map is populated (the fast path), it
+// performs an O(1) lookup on the lowercased scientific name portion of the
+// label. Labels may be in BirdNET format ("Parus major_Great Tit") or contain
+// the scientific name only ("Parus major"). The legacy O(n) fallback is used
+// when the map is empty (e.g. for snapshots loaded before this feature).
 func (s *Settings) IsSpeciesIncluded(result string) bool {
+	if len(s.BirdNET.RangeFilter.IncludedScientificNames) > 0 {
+		sci := result
+		if idx := strings.IndexByte(result, '_'); idx >= 0 {
+			sci = result[:idx]
+		}
+		_, found := s.BirdNET.RangeFilter.IncludedScientificNames[strings.ToLower(sci)]
+		return found
+	}
 	for _, fullSpeciesString := range s.BirdNET.RangeFilter.Species {
 		if strings.HasPrefix(fullSpeciesString, result) {
 			return true

--- a/internal/conf/range_filter_test.go
+++ b/internal/conf/range_filter_test.go
@@ -276,6 +276,85 @@ func TestErrorRecoveryScenario_Concurrent(t *testing.T) {
 	assert.Equal(t, 1, trueCount, "Expected exactly 1 goroutine to receive true after reset")
 }
 
+// TestIsSpeciesIncluded_ScientificNameMap verifies that IsSpeciesIncluded uses
+// the O(1) map path when IncludedScientificNames is populated.
+func TestIsSpeciesIncluded_ScientificNameMap(t *testing.T) {
+	t.Parallel()
+
+	settings := &Settings{}
+	settings.BirdNET.RangeFilter.Species = []string{
+		"Turdus merula_Common Blackbird",
+		"Parus major_Great Tit",
+		"Corvus corax_Northern Raven",
+	}
+	settings.BirdNET.RangeFilter.IncludedScientificNames = map[string]struct{}{
+		"turdus merula": {},
+		"parus major":   {},
+		"corvus corax":  {},
+	}
+
+	tests := []struct {
+		name     string
+		input    string
+		expected bool
+	}{
+		{"full label match", "Turdus merula_Common Blackbird", true},
+		{"scientific name only", "Turdus merula", true},
+		{"case insensitive", "TURDUS MERULA", true},
+		{"case insensitive full label", "PARUS MAJOR_Great Tit", true},
+		{"not included", "Ficedula hypoleuca_Pied Flycatcher", false},
+		{"not included sci only", "Ficedula hypoleuca", false},
+		{"empty string", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expected, settings.IsSpeciesIncluded(tt.input))
+		})
+	}
+}
+
+// TestUpdateIncludedSpecies_BuildsScientificNameMap verifies that
+// UpdateIncludedSpecies populates IncludedScientificNames with lowercased
+// scientific names extracted from BirdNET-style labels.
+func TestUpdateIncludedSpecies_BuildsScientificNameMap(t *testing.T) {
+	settings := &Settings{}
+	setupGlobalSettings(t, settings)
+
+	UpdateIncludedSpecies([]string{
+		"Turdus merula_Common Blackbird",
+		"Parus major_Great Tit",
+		"Canis lupus_Gray Wolf",
+	})
+
+	published := GetSettings()
+	require.NotNil(t, published.BirdNET.RangeFilter.IncludedScientificNames)
+	assert.Len(t, published.BirdNET.RangeFilter.IncludedScientificNames, 3)
+
+	_, hasTurdus := published.BirdNET.RangeFilter.IncludedScientificNames["turdus merula"]
+	assert.True(t, hasTurdus, "should contain lowercased scientific name")
+
+	_, hasParus := published.BirdNET.RangeFilter.IncludedScientificNames["parus major"]
+	assert.True(t, hasParus)
+
+	_, hasCanis := published.BirdNET.RangeFilter.IncludedScientificNames["canis lupus"]
+	assert.True(t, hasCanis)
+}
+
+// TestUpdateIncludedSpecies_ScientificNameOnly verifies that labels without an
+// underscore (i.e. scientific name only) are stored using the full string.
+func TestUpdateIncludedSpecies_ScientificNameOnly(t *testing.T) {
+	settings := &Settings{}
+	setupGlobalSettings(t, settings)
+
+	UpdateIncludedSpecies([]string{"Parus major", "Corvus corax"})
+
+	published := GetSettings()
+	_, hasParus := published.BirdNET.RangeFilter.IncludedScientificNames["parus major"]
+	assert.True(t, hasParus, "labels without underscore should use full string as scientific name")
+}
+
 // TestResetAndCheckInterleaved tests interleaved reset and check operations.
 func TestResetAndCheckInterleaved(t *testing.T) {
 	settings := &Settings{}


### PR DESCRIPTION
## Summary

- Build the range filter species inclusion list from the geomodel's full 12K species set instead of filtering through BirdNET V2.4's ~6,500 classifier labels, fixing incorrect range filtering of Perch v2 detections
- Switch `IsSpeciesIncluded()` from O(n) `HasPrefix` scan to O(1) scientific name map lookup
- Add `UniversalSpeciesPredictor` interface so `BuildRangeFilter()` automatically uses the geomodel's own labels when available, falling back to the legacy classifier-only path for v2.4 geomodel
- Display classifier species count in the settings analysis page so users can see the actual mapping coverage (95% of classifier species, not 52% of geomodel species)
- Hold mutex during `PredictIncludedSpecies` to prevent race with concurrent `Delete`/`ReloadModel`

## Test Plan

- [x] Unit tests for `PredictIncludedSpecies`: threshold filtering, empty result, error propagation
- [x] Unit tests for `IsSpeciesIncluded`: scientific name matching, case insensitivity, both label formats
- [x] Unit tests for `UpdateIncludedSpecies`: map correctly built from labels
- [x] Unit tests for clone independence of `IncludedScientificNames` map
- [x] 1703 tests pass with `-race` in affected packages
- [x] `golangci-lint` clean
- [x] Frontend `npm run check:all` clean
- [x] i18n: `classifierSpecies` key added to all 8 language files with proper translations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Classifier Species" metric to the Range Filter status panel
  * Added translations for this label in DE, EN, ES, FI, FR, NL, PL, PT

* **Performance / Reliability**
  * Faster and more reliable species-inclusion checks via a scientific-name lookup
  * Safer settings cloning to prevent snapshot mutation issues

* **Tests**
  * Added unit tests for species inclusion, cloning, and range-filter prediction behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3070)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->