### PR TITLE
refactor(api): per-classifier range filter status response

### DIFF
--- a/internal/api/v2/README.md
+++ b/internal/api/v2/README.md
@@ -171,7 +171,7 @@ Lightweight connectivity check. Returns a minimal response with no database quer
 
 | Method | Route                   | Handler                        | Auth | Description                                                      |
 | ------ | ----------------------- | ------------------------------ | ---- | ---------------------------------------------------------------- |
-| GET    | `/range/status`         | `GetRangeFilterStatus`         | ❌   | Range filter model, mapping stats, auto-selection status         |
+| GET    | `/range/status`         | `GetRangeFilterStatus`         | ❌   | Per-classifier geomodel coverage, auto-selection, threshold      |
 | GET    | `/range/species/scores` | `GetRangeFilterSpeciesScores`  | ❌   | All species with raw geomodel scores (no threshold cutoff)       |
 | GET    | `/range/species/count`  | `GetRangeFilterSpeciesCount`   | ❌   | Species count with range filter                                  |
 | GET    | `/range/species/list`   | `GetRangeFilterSpeciesList`    | ❌   | Species list with taxonomy groups                                |

--- a/internal/api/v2/range.go
+++ b/internal/api/v2/range.go
@@ -213,10 +213,10 @@ func (c *Controller) initRangeRoutes() {
 
 // GetRangeFilterStatus returns introspection data about the active range filter
 // @Summary Get range filter status
-// @Description Returns the active geomodel, mapping statistics, auto-selection status, and threshold
+// @Description Returns per-classifier geomodel coverage, auto-selection status, and threshold
 // @Tags range
 // @Produce json
-// @Success 200 {object} classifier.RangeFilterStatusInfo
+// @Success 200 {object} classifier.RangeFilterStatusResponse
 // @Failure 500 {object} ErrorResponse
 // @Router /api/v2/range/status [get]
 func (c *Controller) GetRangeFilterStatus(ctx echo.Context) error {

--- a/internal/classifier/birdnet.go
+++ b/internal/classifier/birdnet.go
@@ -1246,69 +1246,73 @@ func (bn *BirdNET) EnrichResultWithTaxonomy(speciesLabel string) (scientific, co
 	return scientific, common, code
 }
 
-// RangeFilterStatusInfo holds introspection data about the active range filter
-// configuration. Used by the API to expose geomodel state without coupling
-// callers to internal types.
-type RangeFilterStatusInfo struct {
-	Model               string    `json:"model"`
-	ModelPath           string    `json:"modelPath"`
-	LabelsPath          string    `json:"labelsPath"`
-	AutoSelected        bool      `json:"autoSelected"`
-	ClassifierModel     string    `json:"classifierModel"`
-	GeomodelSpecies     int       `json:"geomodelSpecies"`
-	ClassifierSpecies   int       `json:"classifierSpecies"`
-	MappedSpecies       int       `json:"mappedSpecies"`
-	UnmappedSpecies     int       `json:"unmappedSpecies"`
-	PassUnmappedSpecies bool      `json:"passUnmappedSpecies"`
-	Threshold           float32   `json:"threshold"`
-	LocationConfigured  bool      `json:"locationConfigured"`
-	LastUpdated         time.Time `json:"lastUpdated"`
+// GeomodelStatus holds metadata about the active geomodel.
+type GeomodelStatus struct {
+	Version      string `json:"version"`
+	TotalSpecies int    `json:"totalSpecies"`
+	AutoSelected bool   `json:"autoSelected"`
 }
 
-// RangeFilterStatus returns introspection data about the active range filter.
-// Safe for concurrent use; acquires bn.mu to read the rangeFilter field.
-func (bn *BirdNET) RangeFilterStatus() RangeFilterStatusInfo {
+// ClassifierCoverage holds the geomodel coverage stats for one classifier.
+type ClassifierCoverage struct {
+	ID               string `json:"id"`
+	Name             string `json:"name"`
+	TotalSpecies     int    `json:"totalSpecies"`
+	WithRangeData    int    `json:"withRangeData"`
+	WithoutRangeData int    `json:"withoutRangeData"`
+}
+
+// RangeFilterStatusResponse holds the complete range filter status including
+// per-classifier geomodel coverage. Used by the API to expose geomodel state
+// without coupling callers to internal types.
+type RangeFilterStatusResponse struct {
+	Geomodel            *GeomodelStatus      `json:"geomodel"`
+	Classifiers         []ClassifierCoverage `json:"classifiers"`
+	PassUnmappedSpecies bool                 `json:"passUnmappedSpecies"`
+	Threshold           float32              `json:"threshold"`
+	LocationConfigured  bool                 `json:"locationConfigured"`
+	LastUpdated         time.Time            `json:"lastUpdated"`
+}
+
+// PrimaryRangeFilterCoverage returns the geomodel info and coverage stats for
+// the primary classifier. The orchestrator calls this and then adds coverage
+// for additional models.
+func (bn *BirdNET) PrimaryRangeFilterCoverage() (geomodel *GeomodelStatus, primary ClassifierCoverage, geoLabels []string, autoSelected bool) {
 	settings := bn.currentSettings()
 	rf := settings.BirdNET.RangeFilter
 
-	info := RangeFilterStatusInfo{
-		Model:               rf.Model,
-		ModelPath:           rf.ModelPath,
-		LabelsPath:          rf.LabelsPath,
-		ClassifierModel:     bn.ModelInfo.ID,
-		PassUnmappedSpecies: rf.PassUnmappedSpecies,
-		Threshold:           rf.Threshold,
-		LocationConfigured:  settings.BirdNET.LocationConfigured,
-		LastUpdated:         rf.LastUpdated,
+	primary = ClassifierCoverage{
+		ID:           bn.ModelInfo.ID,
+		Name:         bn.ModelInfo.Name,
+		TotalSpecies: bn.NumSpecies(),
 	}
 
-	// Determine if the geomodel was auto-selected: model must be "v3" and
-	// paths must match the shared directory pattern produced by
-	// applyAutoSelectedGeomodelPaths.
+	bn.mu.Lock()
+	mrf, isMapped := bn.rangeFilter.(*mappedRangeFilter)
+	if isMapped {
+		primary.WithRangeData = mrf.mappedCount
+		primary.WithoutRangeData = mrf.numClassifier - mrf.mappedCount
+		geoLabels = mrf.geomodelLabels
+
+		geomodel = &GeomodelStatus{
+			Version:      rf.Model,
+			TotalSpecies: mrf.inner.NumSpecies(),
+		}
+	}
+	bn.mu.Unlock()
+
 	if rf.Model == "v3" && bn.modelsDir != "" {
 		sharedDir := filepath.Join(bn.modelsDir, "shared")
 		expectedONNX := filepath.Join(sharedDir, geomodelONNXLocalName)
 		expectedLabels := filepath.Join(sharedDir, geomodelLabelsLocalName)
-		info.AutoSelected = rf.ModelPath == expectedONNX && rf.LabelsPath == expectedLabels
+		autoSelected = rf.ModelPath == expectedONNX && rf.LabelsPath == expectedLabels
 	}
 
-	// Extract mapping stats from mappedRangeFilter if present.
-	bn.mu.Lock()
-	if mrf, ok := bn.rangeFilter.(*mappedRangeFilter); ok {
-		info.GeomodelSpecies = mrf.inner.NumSpecies()
-		info.ClassifierSpecies = mrf.numClassifier
-		info.MappedSpecies = mrf.mappedCount
-		info.UnmappedSpecies = mrf.numClassifier - mrf.mappedCount
-	} else if bn.rangeFilter != nil {
-		GetLogger().Debug("Range filter is not a mappedRangeFilter",
-			logger.String("type", fmt.Sprintf("%T", bn.rangeFilter)),
-			logger.Int("num_species", bn.rangeFilter.NumSpecies()))
-	} else {
-		GetLogger().Debug("Range filter is nil, species counts will be zero")
+	if geomodel != nil {
+		geomodel.AutoSelected = autoSelected
 	}
-	bn.mu.Unlock()
 
-	return info
+	return geomodel, primary, geoLabels, autoSelected
 }
 
 // SetModelsDir sets the base directory for gallery-installed models.

--- a/internal/classifier/birdnet.go
+++ b/internal/classifier/birdnet.go
@@ -1298,6 +1298,8 @@ func (bn *BirdNET) PrimaryRangeFilterCoverage() (geomodel *GeomodelStatus, prima
 			Version:      rf.Model,
 			TotalSpecies: mrf.inner.NumSpecies(),
 		}
+	} else {
+		primary.WithoutRangeData = primary.TotalSpecies
 	}
 	bn.mu.Unlock()
 

--- a/internal/classifier/birdnet_test.go
+++ b/internal/classifier/birdnet_test.go
@@ -1,14 +1,36 @@
 package classifier
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/datastore"
 )
+
+// fakeModelInstance is a minimal ModelInstance for testing orchestrator logic
+// without loading real models.
+type fakeModelInstance struct {
+	id     string
+	name   string
+	labels []string
+}
+
+func (f *fakeModelInstance) Predict(_ context.Context, _ [][]float32) ([]datastore.Results, error) {
+	return nil, nil
+}
+func (f *fakeModelInstance) Spec() ModelSpec      { return ModelSpec{} }
+func (f *fakeModelInstance) ModelID() string      { return f.id }
+func (f *fakeModelInstance) ModelName() string    { return f.name }
+func (f *fakeModelInstance) ModelVersion() string { return "" }
+func (f *fakeModelInstance) NumSpecies() int      { return len(f.labels) }
+func (f *fakeModelInstance) Labels() []string     { return f.labels }
+func (f *fakeModelInstance) Close() error         { return nil }
 
 func TestShouldAutoSelectV3Geomodel(t *testing.T) {
 	t.Parallel()
@@ -243,4 +265,178 @@ func TestPrimaryRangeFilterCoverage_WithMappedFilter(t *testing.T) {
 	assert.Equal(t, 1, primary.WithoutRangeData)
 
 	assert.Equal(t, geomodelLabels, geoLabels)
+}
+
+func TestRangeFilterStatus_PerClassifierCoverage(t *testing.T) {
+	t.Parallel()
+
+	modelsDir := t.TempDir()
+	sharedDir := filepath.Join(modelsDir, "shared")
+	require.NoError(t, os.MkdirAll(sharedDir, 0o755))
+
+	expectedONNX := filepath.Join(sharedDir, geomodelONNXLocalName)
+	expectedLabels := filepath.Join(sharedDir, geomodelLabelsLocalName)
+
+	settings := &conf.Settings{}
+	settings.BirdNET.RangeFilter.Model = "v3"
+	settings.BirdNET.RangeFilter.ModelPath = expectedONNX
+	settings.BirdNET.RangeFilter.LabelsPath = expectedLabels
+	settings.BirdNET.RangeFilter.Threshold = 0.01
+	settings.BirdNET.RangeFilter.PassUnmappedSpecies = false
+	settings.BirdNET.LocationConfigured = true
+	settings.BirdNET.RangeFilter.LastUpdated = time.Date(2026, 5, 14, 12, 0, 0, 0, time.UTC)
+
+	primaryLabels := []string{
+		"Turdus merula_Common Blackbird",
+		"Parus major_Great Tit",
+		"Erithacus rubecula_European Robin",
+		"Ficedula hypoleuca_Pied Flycatcher",
+	}
+	// NumSpecies() reads from settings.BirdNET.Labels, so populate it.
+	settings.BirdNET.Labels = primaryLabels
+
+	geomodelLabels := []string{
+		"Parus major_Great Tit",
+		"Turdus merula_Amsel",
+		"Erithacus rubecula_Robin",
+		"Corvus corax_Northern Raven",
+		"Sturnus vulgaris_European Starling",
+	}
+
+	inner := &fakeRangeFilter{scores: make([]float32, len(geomodelLabels))}
+	mapped := newMappedRangeFilter(inner, primaryLabels, geomodelLabels, 0.0)
+
+	primary := &BirdNET{
+		Settings:     settings,
+		speciesCache: make(map[string]*speciesCacheEntry),
+		ModelInfo:    ModelInfo{ID: "BirdNET_V2.4", Name: "BirdNET v2.4"},
+		modelsDir:    modelsDir,
+		rangeFilter:  mapped,
+	}
+
+	perchLabels := []string{
+		"Turdus merula",
+		"Corvus corax",
+		"Bubo bubo",
+	}
+	perchInstance := &fakeModelInstance{
+		id:     RegistryIDPerchV2,
+		name:   ModelNamePerchV2,
+		labels: perchLabels,
+	}
+
+	orch := &Orchestrator{
+		Settings:  settings,
+		ModelInfo: primary.ModelInfo,
+		primary:   primary,
+		models: map[string]*modelEntry{
+			"BirdNET_V2.4":    {instance: primary},
+			RegistryIDPerchV2: {instance: perchInstance},
+		},
+		modelsDir: modelsDir,
+	}
+
+	resp := orch.RangeFilterStatus()
+
+	require.NotNil(t, resp.Geomodel)
+	assert.Equal(t, "v3", resp.Geomodel.Version)
+	assert.Equal(t, len(geomodelLabels), resp.Geomodel.TotalSpecies)
+	assert.True(t, resp.Geomodel.AutoSelected)
+
+	assert.False(t, resp.PassUnmappedSpecies)
+	assert.InDelta(t, 0.01, resp.Threshold, 0.001)
+	assert.True(t, resp.LocationConfigured)
+
+	require.Len(t, resp.Classifiers, 2)
+
+	classifierByID := make(map[string]ClassifierCoverage)
+	for _, c := range resp.Classifiers {
+		classifierByID[c.ID] = c
+	}
+
+	birdnet := classifierByID["BirdNET_V2.4"]
+	assert.Equal(t, "BirdNET v2.4", birdnet.Name)
+	assert.Equal(t, 4, birdnet.TotalSpecies)
+	assert.Equal(t, 3, birdnet.WithRangeData)
+	assert.Equal(t, 1, birdnet.WithoutRangeData)
+
+	perch := classifierByID[RegistryIDPerchV2]
+	assert.Equal(t, ModelNamePerchV2, perch.Name)
+	assert.Equal(t, 3, perch.TotalSpecies)
+	assert.Equal(t, 2, perch.WithRangeData)
+	assert.Equal(t, 1, perch.WithoutRangeData)
+}
+
+func TestRangeFilterStatus_BatExcluded(t *testing.T) {
+	t.Parallel()
+
+	settings := &conf.Settings{}
+	settings.BirdNET.RangeFilter.Model = "v3"
+
+	geomodelLabels := []string{"Parus major_Great Tit"}
+	primaryLabels := []string{"Parus major_Great Tit"}
+	settings.BirdNET.Labels = primaryLabels
+
+	inner := &fakeRangeFilter{scores: make([]float32, len(geomodelLabels))}
+	mapped := newMappedRangeFilter(inner, primaryLabels, geomodelLabels, 0.0)
+
+	primary := &BirdNET{
+		Settings:     settings,
+		speciesCache: make(map[string]*speciesCacheEntry),
+		ModelInfo:    ModelInfo{ID: "BirdNET_V2.4", Name: "BirdNET v2.4"},
+		rangeFilter:  mapped,
+	}
+
+	batInstance := &fakeModelInstance{
+		id:     RegistryIDBat,
+		name:   "Bat Classifier",
+		labels: []string{"Myotis daubentonii", "Pipistrellus pipistrellus"},
+	}
+
+	orch := &Orchestrator{
+		Settings:  settings,
+		ModelInfo: primary.ModelInfo,
+		primary:   primary,
+		models: map[string]*modelEntry{
+			"BirdNET_V2.4": {instance: primary},
+			RegistryIDBat:  {instance: batInstance},
+		},
+	}
+
+	resp := orch.RangeFilterStatus()
+
+	require.Len(t, resp.Classifiers, 1, "bat model should be excluded")
+	assert.Equal(t, "BirdNET_V2.4", resp.Classifiers[0].ID)
+}
+
+func TestRangeFilterStatus_NoGeomodel(t *testing.T) {
+	t.Parallel()
+
+	settings := &conf.Settings{}
+	settings.BirdNET.RangeFilter.Model = ""
+	settings.BirdNET.RangeFilter.Threshold = 0.05
+
+	primary := &BirdNET{
+		Settings:     settings,
+		speciesCache: make(map[string]*speciesCacheEntry),
+		ModelInfo:    ModelInfo{ID: "BirdNET_V2.4", Name: "BirdNET v2.4"},
+	}
+
+	orch := &Orchestrator{
+		Settings:  settings,
+		ModelInfo: primary.ModelInfo,
+		primary:   primary,
+		models: map[string]*modelEntry{
+			"BirdNET_V2.4": {instance: primary},
+		},
+	}
+
+	resp := orch.RangeFilterStatus()
+
+	assert.Nil(t, resp.Geomodel)
+	require.Len(t, resp.Classifiers, 1)
+	assert.Equal(t, "BirdNET_V2.4", resp.Classifiers[0].ID)
+	assert.Zero(t, resp.Classifiers[0].WithRangeData)
+	assert.Zero(t, resp.Classifiers[0].WithoutRangeData)
+	assert.InDelta(t, 0.05, resp.Threshold, 0.001)
 }

--- a/internal/classifier/birdnet_test.go
+++ b/internal/classifier/birdnet_test.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -160,7 +159,7 @@ func TestBirdNET_SetModelsDir(t *testing.T) {
 	assert.Equal(t, "/some/path", bn.modelsDir)
 }
 
-func TestRangeFilterStatus_NoFilter(t *testing.T) {
+func TestPrimaryRangeFilterCoverage_NoFilter(t *testing.T) {
 	t.Parallel()
 
 	settings := &conf.Settings{}
@@ -170,21 +169,21 @@ func TestRangeFilterStatus_NoFilter(t *testing.T) {
 	bn := &BirdNET{
 		Settings:     settings,
 		speciesCache: make(map[string]*speciesCacheEntry),
-		ModelInfo:    ModelInfo{ID: "BirdNET_V2.4"},
+		ModelInfo:    ModelInfo{ID: "BirdNET_V2.4", Name: "BirdNET v2.4"},
 	}
 
-	info := bn.RangeFilterStatus()
+	geomodel, primary, geoLabels, autoSelected := bn.PrimaryRangeFilterCoverage()
 
-	assert.Empty(t, info.Model, "model should be empty when no range filter is configured")
-	assert.False(t, info.AutoSelected, "AutoSelected should be false without v3 geomodel")
-	assert.Equal(t, "BirdNET_V2.4", info.ClassifierModel)
-	assert.InDelta(t, 0.05, info.Threshold, 0.001)
-	assert.Zero(t, info.GeomodelSpecies, "GeomodelSpecies should be 0 without a mapped filter")
-	assert.Zero(t, info.MappedSpecies, "MappedSpecies should be 0 without a mapped filter")
-	assert.Zero(t, info.UnmappedSpecies, "UnmappedSpecies should be 0 without a mapped filter")
+	assert.Nil(t, geomodel, "geomodel should be nil when no mapped filter is active")
+	assert.Equal(t, "BirdNET_V2.4", primary.ID)
+	assert.Equal(t, "BirdNET v2.4", primary.Name)
+	assert.Zero(t, primary.WithRangeData)
+	assert.Zero(t, primary.WithoutRangeData)
+	assert.Empty(t, geoLabels)
+	assert.False(t, autoSelected)
 }
 
-func TestRangeFilterStatus_WithMappedFilter(t *testing.T) {
+func TestPrimaryRangeFilterCoverage_WithMappedFilter(t *testing.T) {
 	t.Parallel()
 
 	modelsDir := t.TempDir()
@@ -194,19 +193,14 @@ func TestRangeFilterStatus_WithMappedFilter(t *testing.T) {
 	expectedONNX := filepath.Join(sharedDir, geomodelONNXLocalName)
 	expectedLabels := filepath.Join(sharedDir, geomodelLabelsLocalName)
 
-	lastUpdated := time.Date(2026, 5, 12, 10, 0, 0, 0, time.UTC)
-
 	settings := &conf.Settings{}
 	settings.BirdNET.RangeFilter.Model = "v3"
 	settings.BirdNET.RangeFilter.ModelPath = expectedONNX
 	settings.BirdNET.RangeFilter.LabelsPath = expectedLabels
 	settings.BirdNET.RangeFilter.Threshold = 0.03
 	settings.BirdNET.RangeFilter.PassUnmappedSpecies = true
-	settings.BirdNET.RangeFilter.LastUpdated = lastUpdated
 	settings.BirdNET.LocationConfigured = true
 
-	// Build a mappedRangeFilter with known mapping stats.
-	// 3 geomodel species, 4 classifier species, 3 mapped, 1 unmapped.
 	classifierLabels := []string{
 		"Turdus merula_Common Blackbird",
 		"Parus major_Great Tit",
@@ -219,6 +213,9 @@ func TestRangeFilterStatus_WithMappedFilter(t *testing.T) {
 		"Erithacus rubecula_Robin",
 	}
 
+	// NumSpecies() reads from settings.BirdNET.Labels, so populate it.
+	settings.BirdNET.Labels = classifierLabels
+
 	inner := &fakeRangeFilter{
 		scores: make([]float32, len(geomodelLabels)),
 	}
@@ -227,24 +224,23 @@ func TestRangeFilterStatus_WithMappedFilter(t *testing.T) {
 	bn := &BirdNET{
 		Settings:     settings,
 		speciesCache: make(map[string]*speciesCacheEntry),
-		ModelInfo:    ModelInfo{ID: RegistryIDBirdNETV3},
+		ModelInfo:    ModelInfo{ID: RegistryIDBirdNETV3, Name: ModelNameBirdNETv30},
 		modelsDir:    modelsDir,
 		rangeFilter:  mapped,
 	}
 
-	info := bn.RangeFilterStatus()
+	geomodel, primary, geoLabels, autoSelected := bn.PrimaryRangeFilterCoverage()
 
-	assert.Equal(t, "v3", info.Model)
-	assert.Equal(t, expectedONNX, info.ModelPath)
-	assert.Equal(t, expectedLabels, info.LabelsPath)
-	assert.True(t, info.AutoSelected, "paths match auto-selected pattern")
-	assert.Equal(t, RegistryIDBirdNETV3, info.ClassifierModel)
-	assert.Equal(t, len(geomodelLabels), info.GeomodelSpecies)
-	assert.Equal(t, len(classifierLabels), info.ClassifierSpecies)
-	assert.Equal(t, 3, info.MappedSpecies)
-	assert.Equal(t, 1, info.UnmappedSpecies)
-	assert.True(t, info.PassUnmappedSpecies)
-	assert.InDelta(t, 0.03, info.Threshold, 0.001)
-	assert.True(t, info.LocationConfigured)
-	assert.Equal(t, lastUpdated, info.LastUpdated)
+	require.NotNil(t, geomodel)
+	assert.Equal(t, "v3", geomodel.Version)
+	assert.Equal(t, len(geomodelLabels), geomodel.TotalSpecies)
+	assert.True(t, geomodel.AutoSelected)
+	assert.True(t, autoSelected)
+
+	assert.Equal(t, RegistryIDBirdNETV3, primary.ID)
+	assert.Equal(t, len(classifierLabels), primary.TotalSpecies)
+	assert.Equal(t, 3, primary.WithRangeData)
+	assert.Equal(t, 1, primary.WithoutRangeData)
+
+	assert.Equal(t, geomodelLabels, geoLabels)
 }

--- a/internal/classifier/mapped_range_filter.go
+++ b/internal/classifier/mapped_range_filter.go
@@ -42,6 +42,20 @@ func buildSpeciesMapping(classifierLabels, geomodelLabels []string) []int {
 	return mapping
 }
 
+// ComputeGeomodelCoverage counts how many classifier species have a matching
+// scientific name in the geomodel label set. Returns (withRangeData, withoutRangeData).
+func ComputeGeomodelCoverage(classifierLabels, geomodelLabels []string) (withRangeData, withoutRangeData int) {
+	mapping := buildSpeciesMapping(classifierLabels, geomodelLabels)
+	for _, idx := range mapping {
+		if idx >= 0 {
+			withRangeData++
+		} else {
+			withoutRangeData++
+		}
+	}
+	return withRangeData, withoutRangeData
+}
+
 // extractScientificName returns the scientific name portion from a
 // "ScientificName_CommonName" label string.
 func extractScientificName(label string) string {

--- a/internal/classifier/mapped_range_filter_test.go
+++ b/internal/classifier/mapped_range_filter_test.go
@@ -257,3 +257,39 @@ func TestMappedRangeFilter_PredictIncludedSpecies_PropagatesError(t *testing.T) 
 	_, err := mapped.PredictIncludedSpecies(60.0, 25.0, 20.0, 0.1)
 	assert.Error(t, err)
 }
+
+func TestComputeGeomodelCoverage(t *testing.T) {
+	t.Parallel()
+
+	classifierLabels := []string{
+		"Turdus merula_Common Blackbird",
+		"Parus major_Great Tit",
+		"Erithacus rubecula_European Robin",
+		"Ficedula hypoleuca_Pied Flycatcher",
+	}
+	geomodelLabels := []string{
+		"Parus major_Great Tit",
+		"Turdus merula_Amsel",
+		"Corvus corax_Northern Raven",
+		"Erithacus rubecula_Robin",
+	}
+
+	withRange, withoutRange := ComputeGeomodelCoverage(classifierLabels, geomodelLabels)
+	assert.Equal(t, 3, withRange, "3 classifier species match geomodel by scientific name")
+	assert.Equal(t, 1, withoutRange, "1 classifier species has no geomodel match")
+}
+
+func TestComputeGeomodelCoverage_EmptyInputs(t *testing.T) {
+	t.Parallel()
+
+	withRange, withoutRange := ComputeGeomodelCoverage(nil, nil)
+	assert.Zero(t, withRange)
+	assert.Zero(t, withoutRange)
+
+	withRange, withoutRange = ComputeGeomodelCoverage(
+		[]string{"Turdus merula_Blackbird"},
+		nil,
+	)
+	assert.Zero(t, withRange)
+	assert.Equal(t, 1, withoutRange)
+}

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"sort"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -420,6 +421,11 @@ func (o *Orchestrator) RangeFilterStatus() RangeFilterStatusResponse {
 		resp.Classifiers = append(resp.Classifiers, cov)
 	}
 	o.mu.RUnlock()
+
+	// Sort classifiers by ID for stable API output (map iteration is random).
+	sort.Slice(resp.Classifiers, func(i, j int) bool {
+		return resp.Classifiers[i].ID < resp.Classifiers[j].ID
+	})
 
 	return resp
 }

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -376,10 +376,18 @@ func (o *Orchestrator) EnrichResultWithTaxonomy(speciesLabel string) (scientific
 // RangeFilterStatus returns introspection data about the range filter,
 // including per-classifier geomodel coverage for all active non-bat models.
 func (o *Orchestrator) RangeFilterStatus() RangeFilterStatusResponse {
-	settings := o.primary.currentSettings()
+	// Snapshot primary under read lock to avoid racing with Delete().
+	o.mu.RLock()
+	primary := o.primary
+	o.mu.RUnlock()
+	if primary == nil {
+		return RangeFilterStatusResponse{}
+	}
+
+	settings := primary.currentSettings()
 	rf := settings.BirdNET.RangeFilter
 
-	geomodel, primaryCoverage, geoLabels, _ := o.primary.PrimaryRangeFilterCoverage()
+	geomodel, primaryCoverage, geoLabels, _ := primary.PrimaryRangeFilterCoverage()
 
 	resp := RangeFilterStatusResponse{
 		Geomodel:            geomodel,
@@ -392,10 +400,18 @@ func (o *Orchestrator) RangeFilterStatus() RangeFilterStatusResponse {
 	// Always include the primary classifier.
 	resp.Classifiers = append(resp.Classifiers, primaryCoverage)
 
-	// Add coverage for additional (non-bat) models.
+	// Collect additional model info under a brief lock, then compute
+	// coverage outside the lock to avoid blocking writers.
+	type modelTask struct {
+		id     string
+		name   string
+		labels []string
+	}
+
+	var tasks []modelTask
 	o.mu.RLock()
 	for id, entry := range o.models {
-		if entry.instance == nil || id == o.primary.ModelInfo.ID {
+		if entry.instance == nil || id == primary.ModelInfo.ID {
 			continue
 		}
 		if id == RegistryIDBat {
@@ -406,21 +422,29 @@ func (o *Orchestrator) RangeFilterStatus() RangeFilterStatusResponse {
 		if exists {
 			name = info.Name
 		}
+		tasks = append(tasks, modelTask{
+			id:     id,
+			name:   name,
+			labels: entry.instance.Labels(),
+		})
+	}
+	o.mu.RUnlock()
+
+	for _, task := range tasks {
 		cov := ClassifierCoverage{
-			ID:           id,
-			Name:         name,
-			TotalSpecies: entry.instance.NumSpecies(),
+			ID:           task.id,
+			Name:         task.name,
+			TotalSpecies: len(task.labels),
 		}
 		if len(geoLabels) > 0 {
 			cov.WithRangeData, cov.WithoutRangeData = ComputeGeomodelCoverage(
-				entry.instance.Labels(), geoLabels,
+				task.labels, geoLabels,
 			)
 		} else {
 			cov.WithoutRangeData = cov.TotalSpecies
 		}
 		resp.Classifiers = append(resp.Classifiers, cov)
 	}
-	o.mu.RUnlock()
 
 	// Sort classifiers by ID for stable API output (map iteration is random).
 	sort.Slice(resp.Classifiers, func(i, j int) bool {

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -372,10 +372,56 @@ func (o *Orchestrator) EnrichResultWithTaxonomy(speciesLabel string) (scientific
 	return scientific, common, code
 }
 
-// RangeFilterStatus returns introspection data about the primary model's
-// active range filter configuration.
-func (o *Orchestrator) RangeFilterStatus() RangeFilterStatusInfo {
-	return o.primary.RangeFilterStatus()
+// RangeFilterStatus returns introspection data about the range filter,
+// including per-classifier geomodel coverage for all active non-bat models.
+func (o *Orchestrator) RangeFilterStatus() RangeFilterStatusResponse {
+	settings := o.primary.currentSettings()
+	rf := settings.BirdNET.RangeFilter
+
+	geomodel, primaryCoverage, geoLabels, _ := o.primary.PrimaryRangeFilterCoverage()
+
+	resp := RangeFilterStatusResponse{
+		Geomodel:            geomodel,
+		PassUnmappedSpecies: rf.PassUnmappedSpecies,
+		Threshold:           rf.Threshold,
+		LocationConfigured:  settings.BirdNET.LocationConfigured,
+		LastUpdated:         rf.LastUpdated,
+	}
+
+	// Always include the primary classifier.
+	resp.Classifiers = append(resp.Classifiers, primaryCoverage)
+
+	// Add coverage for additional (non-bat) models.
+	o.mu.RLock()
+	for id, entry := range o.models {
+		if entry.instance == nil || id == o.primary.ModelInfo.ID {
+			continue
+		}
+		if id == RegistryIDBat {
+			continue
+		}
+		info, exists := ModelRegistry[id]
+		name := id
+		if exists {
+			name = info.Name
+		}
+		cov := ClassifierCoverage{
+			ID:           id,
+			Name:         name,
+			TotalSpecies: entry.instance.NumSpecies(),
+		}
+		if len(geoLabels) > 0 {
+			cov.WithRangeData, cov.WithoutRangeData = ComputeGeomodelCoverage(
+				entry.instance.Labels(), geoLabels,
+			)
+		} else {
+			cov.WithoutRangeData = cov.TotalSpecies
+		}
+		resp.Classifiers = append(resp.Classifiers, cov)
+	}
+	o.mu.RUnlock()
+
+	return resp
 }
 
 // ReloadRangeFilter reinitializes the range filter on the primary model


### PR DESCRIPTION
## Summary

- Replace single-classifier `RangeFilterStatusInfo` with per-classifier `RangeFilterStatusResponse` that treats all classifiers equally
- New `GET /api/v2/range/status` response includes a `geomodel` object, a `classifiers` array with per-model species coverage, and the existing `passUnmappedSpecies` toggle
- Bat classifiers excluded from the response (range filter doesn't apply to them)
- Classifiers sorted by ID for stable API output

## Motivation

The old API response only showed BirdNET V2.4 mapping stats even when Perch v2 was installed. Terms like "Mapped Species" and "Unmapped Species" were confusing. After PR #3070 made range filter inclusion universal, the old mapping stats no longer reflected how the filter actually works.

This PR is the backend half of the range filter UX redesign. Frontend changes will follow in a separate PR.

## API response shape

```json
{
  "geomodel": {
    "version": "v3",
    "totalSpecies": 12012,
    "autoSelected": true
  },
  "classifiers": [
    {
      "id": "BirdNET_V2.4",
      "name": "BirdNET v2.4",
      "totalSpecies": 6559,
      "withRangeData": 6245,
      "withoutRangeData": 314
    },
    {
      "id": "Perch_V2",
      "name": "Google Perch v2",
      "totalSpecies": 14795,
      "withRangeData": 10842,
      "withoutRangeData": 3953
    }
  ],
  "passUnmappedSpecies": false,
  "threshold": 0.01,
  "locationConfigured": true,
  "lastUpdated": "2026-05-14T15:32:36Z"
}
```

## Test plan

- [x] `TestComputeGeomodelCoverage` - helper counts species with/without geomodel data
- [x] `TestComputeGeomodelCoverage_EmptyInputs` - nil/empty input handling
- [x] `TestPrimaryRangeFilterCoverage_NoFilter` - no geomodel active
- [x] `TestPrimaryRangeFilterCoverage_WithMappedFilter` - v3 geomodel with auto-selection
- [x] `TestRangeFilterStatus_PerClassifierCoverage` - multi-classifier coverage breakdown
- [x] `TestRangeFilterStatus_BatExcluded` - bat model excluded from response
- [x] `TestRangeFilterStatus_NoGeomodel` - legacy path with nil geomodel
- [x] All 543 classifier tests pass with `-race`
- [x] Zero lint issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **API Updates**
  * The `/api/v2/range/status` endpoint response now includes per-classifier geomodel coverage, auto-selection flags, and threshold info.

* **Documentation**
  * Endpoint docs updated to match the new response structure.

* **New Features**
  * Added per-classifier coverage reporting and geomodel-coverage computation to the status response.

* **Tests**
  * Added and reorganized unit tests to validate per-classifier coverage, geomodel selection, thresholds, and various filter scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3073)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->