### PR TITLE
feat(frontend): add unlikely badge and post detection validation settings

### DIFF
--- a/frontend/src/lib/desktop/components/data/StatusBadges.svelte
+++ b/frontend/src/lib/desktop/components/data/StatusBadges.svelte
@@ -46,6 +46,7 @@
 <script lang="ts">
   import { cn } from '$lib/utils/cn';
   import { t } from '$lib/i18n';
+  import { CircleHelp } from '@lucide/svelte';
   import type { Detection } from '$lib/types/detection.types';
   type Size = 'sm' | 'md' | 'lg';
   type VerificationStatus = Detection['verified'];
@@ -91,6 +92,14 @@
   {#if detection.locked}
     <div class={cn('status-badge locked', sizeClass)}>
       {t('common.review.status.locked')}
+    </div>
+  {/if}
+
+  <!-- Unlikely badge -->
+  {#if detection.unlikely}
+    <div class={cn('status-badge unlikely', sizeClass)}>
+      <CircleHelp class="size-3 mr-1" />
+      {t('common.review.status.unlikely')}
     </div>
   {/if}
 
@@ -149,6 +158,10 @@
   }
 
   .status-badge.locked {
+    --badge-color: var(--color-warning);
+  }
+
+  .status-badge.unlikely {
     --badge-color: var(--color-warning);
   }
 

--- a/frontend/src/lib/desktop/features/dashboard/components/SpeciesInfoBar.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/components/SpeciesInfoBar.svelte
@@ -12,7 +12,7 @@
   import type { Detection } from '$lib/types/detection.types';
   import { handleBirdImageError } from '$lib/desktop/components/ui/image-utils.js';
   import { formatRelativeTime } from '$lib/utils/formatters';
-  import { Check } from '@lucide/svelte';
+  import { Check, CircleHelp } from '@lucide/svelte';
   import { cn } from '$lib/utils/cn';
   import { t } from '$lib/i18n';
   import { buildAppUrl } from '$lib/utils/urlHelpers';
@@ -39,6 +39,7 @@
   // Check verification status (API returns verified directly on detection)
   const isVerified = $derived(detection.verified === 'correct');
   const isFalsePositive = $derived(detection.verified === 'false_positive');
+  const isUnlikely = $derived(detection.unlikely === true);
 
   // Thumbnail URL — buildAppUrl prepends the configured base path so the
   // image resolves correctly behind reverse proxies (e.g. /birdnet/...).
@@ -85,6 +86,14 @@
           role="status"
           aria-label={t('dashboard.recentDetections.status.unverified')}
           >{t('dashboard.recentDetections.status.unverified')}</span
+        >
+      {/if}
+      {#if isUnlikely}
+        <span
+          class="unlikely-badge"
+          role="status"
+          aria-label={t('dashboard.recentDetections.status.unlikely')}
+          ><CircleHelp class="size-2.5" />{t('dashboard.recentDetections.status.unlikely')}</span
         >
       {/if}
     </div>
@@ -185,6 +194,19 @@
     border-radius: 9999px;
     background-color: rgb(51 65 85 / 0.8);
     color: rgb(203 213 225);
+    font-size: 0.625rem;
+    font-weight: 500;
+  }
+
+  .unlikely-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.125rem;
+    padding: 0 0.375rem;
+    height: 1rem;
+    border-radius: 9999px;
+    background-color: rgb(245 158 11 / 0.9);
+    color: white;
     font-size: 0.625rem;
     font-weight: 500;
   }

--- a/frontend/src/lib/desktop/features/dashboard/components/SpeciesInfoBar.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/components/SpeciesInfoBar.svelte
@@ -205,7 +205,7 @@
     padding: 0 0.375rem;
     height: 1rem;
     border-radius: 9999px;
-    background-color: rgb(245 158 11 / 0.9);
+    background-color: color-mix(in srgb, var(--color-warning) 90%, transparent);
     color: white;
     font-size: 0.625rem;
     font-weight: 500;

--- a/frontend/src/lib/desktop/features/settings/pages/AnalysisSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/AnalysisSettingsPage.svelte
@@ -137,7 +137,13 @@
   );
   let falsePositiveFilter = $derived($realtimeSettings?.falsePositiveFilter ?? { level: 0 });
   let bat = $derived(
-    $batSettings ?? { enabled: false, threshold: 0.5, filterEnabled: false, nighttimeOnly: true }
+    $batSettings ?? {
+      enabled: false,
+      threshold: 0.5,
+      filterEnabled: false,
+      nighttimeOnly: true,
+      ultrasonicFilter: { enabled: true },
+    }
   );
 
   // Check if a bat model is installed
@@ -662,6 +668,12 @@
     settingsActions.updateSection('bat', { nighttimeOnly: value });
   }
 
+  function updateBatUltrasonicFilter(value: boolean) {
+    settingsActions.updateSection('bat', {
+      ultrasonicFilter: { ...bat.ultrasonicFilter, enabled: value },
+    });
+  }
+
   function updateThreshold(value: number) {
     settingsActions.updateSection('birdnet', { threshold: value });
   }
@@ -895,12 +907,14 @@
         locale: store.originalData.birdnet?.locale,
         batThreshold: store.originalData.bat?.threshold,
         batNighttimeOnly: store.originalData.bat?.nighttimeOnly,
+        batUltrasonicFilter: store.originalData.bat?.ultrasonicFilter?.enabled,
       }}
       currentData={{
         threshold: birdnet?.threshold,
         locale: birdnet?.locale,
         batThreshold: bat.threshold,
         batNighttimeOnly: bat.nighttimeOnly,
+        batUltrasonicFilter: bat.ultrasonicFilter?.enabled,
       }}
     >
       <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
@@ -963,6 +977,13 @@
             helpText={t('analysis.detection.batNighttimeOnly.helpText')}
             disabled={store.isLoading || store.isSaving}
             onchange={updateBatNighttimeOnly}
+          />
+          <Checkbox
+            checked={bat.ultrasonicFilter?.enabled ?? true}
+            label={t('analysis.detection.batUltrasonicFilter.label')}
+            helpText={t('analysis.detection.batUltrasonicFilter.helpText')}
+            disabled={store.isLoading || store.isSaving}
+            onchange={updateBatUltrasonicFilter}
           />
         {/if}
       </div>

--- a/frontend/src/lib/desktop/features/settings/pages/AnalysisSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/AnalysisSettingsPage.svelte
@@ -907,14 +907,14 @@
         locale: store.originalData.birdnet?.locale,
         batThreshold: store.originalData.bat?.threshold,
         batNighttimeOnly: store.originalData.bat?.nighttimeOnly,
-        batUltrasonicFilter: store.originalData.bat?.ultrasonicFilter?.enabled,
+        batUltrasonicFilter: store.originalData.bat?.ultrasonicFilter?.enabled ?? true,
       }}
       currentData={{
         threshold: birdnet?.threshold,
         locale: birdnet?.locale,
         batThreshold: bat.threshold,
         batNighttimeOnly: bat.nighttimeOnly,
-        batUltrasonicFilter: bat.ultrasonicFilter?.enabled,
+        batUltrasonicFilter: bat.ultrasonicFilter?.enabled ?? true,
       }}
     >
       <div class="grid grid-cols-1 md:grid-cols-2 gap-6">

--- a/frontend/src/lib/stores/settings.ts
+++ b/frontend/src/lib/stores/settings.ts
@@ -115,6 +115,9 @@ export interface BatSettings {
   locale?: string;
   filterEnabled: boolean;
   nighttimeOnly: boolean;
+  ultrasonicFilter?: {
+    enabled: boolean;
+  };
 }
 
 export interface SQLiteSettings {
@@ -849,6 +852,9 @@ function createEmptySettings(): SettingsFormData {
       threshold: 0.5,
       filterEnabled: false,
       nighttimeOnly: true,
+      ultrasonicFilter: {
+        enabled: true,
+      },
     },
     realtime: {
       interval: 15,

--- a/frontend/src/lib/types/detection.types.ts
+++ b/frontend/src/lib/types/detection.types.ts
@@ -25,6 +25,7 @@ export interface Detection {
   confidence: number;
   verified: 'correct' | 'false_positive' | 'unverified';
   locked: boolean;
+  unlikely?: boolean;
   comments?: Comment[];
   clipName?: string;
   weather?: Weather;

--- a/frontend/static/messages/da.json
+++ b/frontend/static/messages/da.json
@@ -153,7 +153,8 @@
         "verifiedCorrect": "Bekræftet korrekt",
         "falsePositive": "Falsk positiv",
         "notReviewed": "Ikke gennemgået",
-        "locked": "Låst"
+        "locked": "Låst",
+        "unlikely": "Usandsynlig"
       },
       "form": {
         "correctDetection": "Korrekt detektion",
@@ -512,7 +513,8 @@
       "false": "Falsk",
       "unverified": "Ubekræftet",
       "locked": "Låst",
-      "unlocked": "Ulåst"
+      "unlocked": "Ulåst",
+      "unlikely": "Usandsynlig"
     },
     "review": {
       "review": "Gennemgå",
@@ -640,7 +642,8 @@
         "verified": "Verificeret",
         "false": "Falsk",
         "unverified": "Ikke verificeret",
-        "locked": "Låst"
+        "locked": "Låst",
+        "unlikely": "Usandsynlig"
       },
       "modals": {
         "showSpecies": "Vis art {species}",
@@ -4511,6 +4514,10 @@
       "batNighttimeOnly": {
         "label": "Kun om natten",
         "helpText": "Når aktiveret kører flagermusdetektering kun mellem borgerlig tusmørke og borgerlig daggry. Kræver at placering er konfigureret. Deaktiver for at køre flagermusdetektering hele dagen."
+      },
+      "batUltrasonicFilter": {
+        "label": "Validering efter detektion",
+        "helpText": "Når aktiveret, valideres flagermusdetektioner ved at analysere ultralydsmønstre i kildeoptagelsen. Detektioner uden typiske flagermus-ekkolokationskarakteristika markeres som usandsynlige."
       }
     }
   },

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -154,7 +154,8 @@
         "verifiedCorrect": "Als korrekt verifiziert",
         "falsePositive": "Falsch positiv",
         "notReviewed": "Nicht überprüft",
-        "locked": "Gesperrt"
+        "locked": "Gesperrt",
+        "unlikely": "Unwahrscheinlich"
       },
       "form": {
         "correctDetection": "Korrekte Erkennung",
@@ -513,7 +514,8 @@
       "false": "Falsch",
       "unverified": "Unverifiziert",
       "locked": "Gesperrt",
-      "unlocked": "Entsperrt"
+      "unlocked": "Entsperrt",
+      "unlikely": "Unwahrscheinlich"
     },
     "review": {
       "review": "Überprüfen",
@@ -641,7 +643,8 @@
         "verified": "Verifiziert",
         "false": "Falsch",
         "unverified": "Unverifiziert",
-        "locked": "Gesperrt"
+        "locked": "Gesperrt",
+        "unlikely": "Unwahrscheinlich"
       },
       "modals": {
         "showSpecies": "Art {species} anzeigen",
@@ -4527,6 +4530,10 @@
       "batNighttimeOnly": {
         "label": "Nur nachts",
         "helpText": "Wenn aktiviert, wird die Fledermauserkennung nur zwischen der bürgerlichen Abenddämmerung und der Morgendämmerung durchgeführt. Erfordert eine konfigurierte Standorteinstellung. Deaktivieren, um die Fledermauserkennung rund um die Uhr auszuführen."
+      },
+      "batUltrasonicFilter": {
+        "label": "Nachträgliche Validierung",
+        "helpText": "Wenn aktiviert, werden Fledermauserkennungen durch Analyse der Ultraschall-Energiemuster in der Quellaufnahme validiert. Erkennungen ohne typische Echoortungsmerkmale werden als unwahrscheinlich markiert."
       },
       "locale": {
         "label": "Species Language",

--- a/frontend/static/messages/en.json
+++ b/frontend/static/messages/en.json
@@ -154,7 +154,8 @@
         "verifiedCorrect": "Verified Correct",
         "falsePositive": "False Positive",
         "notReviewed": "Not Reviewed",
-        "locked": "Locked"
+        "locked": "Locked",
+        "unlikely": "Unlikely"
       },
       "form": {
         "correctDetection": "Correct Detection",
@@ -513,7 +514,8 @@
       "false": "False",
       "unverified": "Unverified",
       "locked": "Locked",
-      "unlocked": "Unlocked"
+      "unlocked": "Unlocked",
+      "unlikely": "Unlikely"
     },
     "review": {
       "review": "Review",
@@ -641,7 +643,8 @@
         "verified": "Verified",
         "false": "False",
         "unverified": "Unverified",
-        "locked": "Locked"
+        "locked": "Locked",
+        "unlikely": "Unlikely"
       },
       "modals": {
         "showSpecies": "Show Species {species}",
@@ -4527,6 +4530,10 @@
       "batNighttimeOnly": {
         "label": "Nighttime Only",
         "helpText": "When enabled, bat detection runs only between civil dusk and civil dawn. Requires location to be configured. Disable to run bat detection around the clock."
+      },
+      "batUltrasonicFilter": {
+        "label": "Post Detection Validation",
+        "helpText": "When enabled, bat detections are validated by analyzing ultrasonic energy patterns in the source audio. Detections that lack bat echolocation characteristics are tagged as unlikely."
       },
       "locale": {
         "label": "Species Language",

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -164,7 +164,8 @@
         "verifiedCorrect": "Verificado correcto",
         "falsePositive": "Falso positivo",
         "notReviewed": "No revisado",
-        "locked": "Bloqueado"
+        "locked": "Bloqueado",
+        "unlikely": "Improbable"
       },
       "form": {
         "correctDetection": "Detección correcta",
@@ -513,7 +514,8 @@
       "false": "Falso",
       "unverified": "No verificado",
       "locked": "Bloqueado",
-      "unlocked": "Desbloqueado"
+      "unlocked": "Desbloqueado",
+      "unlikely": "Improbable"
     },
     "review": {
       "review": "Revisar",
@@ -641,7 +643,8 @@
         "verified": "Verificado",
         "false": "Falso",
         "unverified": "No verificado",
-        "locked": "Bloqueado"
+        "locked": "Bloqueado",
+        "unlikely": "Improbable"
       },
       "modals": {
         "showSpecies": "Mostrar especie {species}",
@@ -4527,6 +4530,10 @@
       "batNighttimeOnly": {
         "label": "Solo nocturno",
         "helpText": "Cuando está activado, la detección de murciélagos funciona solo entre el crepúsculo civil y el amanecer civil. Requiere que la ubicación esté configurada. Desactive para ejecutar la detección de murciélagos las 24 horas."
+      },
+      "batUltrasonicFilter": {
+        "label": "Validación posterior a la detección",
+        "helpText": "Cuando está activado, las detecciones de murciélagos se validan analizando los patrones de energía ultrasónica en el audio fuente. Las detecciones sin características de ecolocalización se marcan como improbables."
       },
       "locale": {
         "label": "Species Language",

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -154,7 +154,8 @@
         "verifiedCorrect": "Todennettu oikeaksi",
         "falsePositive": "Virheellinen havainto",
         "notReviewed": "Ei tarkistettu",
-        "locked": "Lukittu"
+        "locked": "Lukittu",
+        "unlikely": "Epätodennäköinen"
       },
       "form": {
         "correctDetection": "Oikea havainto",
@@ -513,7 +514,8 @@
       "false": "Virheellinen",
       "unverified": "Todentamaton",
       "locked": "Lukittu",
-      "unlocked": "Avoin"
+      "unlocked": "Avoin",
+      "unlikely": "Epätodennäköinen"
     },
     "review": {
       "review": "Tarkista",
@@ -641,7 +643,8 @@
         "verified": "Todennettu",
         "false": "Virheellinen",
         "unverified": "Todentamaton",
-        "locked": "Lukittu"
+        "locked": "Lukittu",
+        "unlikely": "Epätodennäköinen"
       },
       "modals": {
         "showSpecies": "Näytä laji {species}",
@@ -4527,6 +4530,10 @@
       "batNighttimeOnly": {
         "label": "Vain yöaikaan",
         "helpText": "Kun käytössä, lepakkotunnistus toimii vain siviilihämärän ja siviiliaamunkoiton välillä. Vaatii, että sijainti on määritetty. Poista käytöstä, jos haluat lepakkotunnistuksen olevan käytössä ympäri vuorokauden."
+      },
+      "batUltrasonicFilter": {
+        "label": "Tunnistuksen jälkitarkistus",
+        "helpText": "Kun käytössä, lepakkotunnistukset validoidaan analysoimalla ultraäänienergiakuvioita lähdeäänitteestä. Tunnistukset, joista puuttuvat kaikuluotausominaisuudet, merkitään epätodennäköisiksi."
       },
       "locale": {
         "label": "Species Language",

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -154,7 +154,8 @@
         "verifiedCorrect": "Vérifié correct",
         "falsePositive": "Faux positif",
         "notReviewed": "Non examiné",
-        "locked": "Verrouillé"
+        "locked": "Verrouillé",
+        "unlikely": "Improbable"
       },
       "form": {
         "correctDetection": "Détection correcte",
@@ -513,7 +514,8 @@
       "false": "Faux",
       "unverified": "Non vérifié",
       "locked": "Verrouillé",
-      "unlocked": "Déverrouillé"
+      "unlocked": "Déverrouillé",
+      "unlikely": "Improbable"
     },
     "review": {
       "review": "Vérifier",
@@ -641,7 +643,8 @@
         "verified": "Vérifié",
         "false": "Faux",
         "unverified": "Non vérifié",
-        "locked": "Verrouillé"
+        "locked": "Verrouillé",
+        "unlikely": "Improbable"
       },
       "modals": {
         "showSpecies": "Afficher l'espèce {species}",
@@ -4527,6 +4530,10 @@
       "batNighttimeOnly": {
         "label": "Nocturne uniquement",
         "helpText": "Lorsqu'activé, la détection de chauves-souris fonctionne uniquement entre le crépuscule civil et l'aube civile. Nécessite la configuration de l'emplacement. Désactivez pour exécuter la détection en permanence."
+      },
+      "batUltrasonicFilter": {
+        "label": "Validation post-détection",
+        "helpText": "Lorsqu'activé, les détections de chauves-souris sont validées en analysant les motifs d'énergie ultrasonique dans l'audio source. Les détections sans caractéristiques d'écholocation sont marquées comme improbables."
       },
       "locale": {
         "label": "Species Language",

--- a/frontend/static/messages/hu.json
+++ b/frontend/static/messages/hu.json
@@ -153,7 +153,8 @@
         "verifiedCorrect": "Ellenőrizve - Helyes",
         "falsePositive": "Hamis pozitív",
         "notReviewed": "Nincs áttekintve",
-        "locked": "Zárolva"
+        "locked": "Zárolva",
+        "unlikely": "Valószínűtlen"
       },
       "form": {
         "correctDetection": "Helyes detektálás",
@@ -512,7 +513,8 @@
       "false": "Hamis",
       "unverified": "Ellenőrizetlen",
       "locked": "Zárolva",
-      "unlocked": "Zárolatlan"
+      "unlocked": "Zárolatlan",
+      "unlikely": "Valószínűtlen"
     },
     "detailsPanel": {
       "audioPlayer": "Hang lejátszó",
@@ -640,7 +642,8 @@
         "verified": "Ellenőrizve",
         "false": "Hamis",
         "unverified": "Ellenőrizetlen",
-        "locked": "Zárolva"
+        "locked": "Zárolva",
+        "unlikely": "Valószínűtlen"
       },
       "modals": {
         "showSpecies": "{species} faj megjelenítése",
@@ -4511,6 +4514,10 @@
       "batNighttimeOnly": {
         "label": "Csak éjszaka",
         "helpText": "Ha engedélyezve van, a denevérészlelés csak polgári alkony és polgári hajnal között fut. A helyszín konfigurálása szükséges. Kapcsolja ki az éjjel-nappali denevérészleléshez."
+      },
+      "batUltrasonicFilter": {
+        "label": "Utólagos érzékelés-ellenőrzés",
+        "helpText": "Bekapcsolva a denevérészleléseket az ultrahang-energiaminták elemzésével ellenőrzi a forrásanyagban. Az echolokációs jellemzőkkel nem rendelkező észleléseket valószínűtlenként jelöli meg."
       }
     }
   },

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -153,7 +153,8 @@
         "verifiedCorrect": "Verificato corretto",
         "falsePositive": "Falso positivo",
         "notReviewed": "Non revisionato",
-        "locked": "Bloccato"
+        "locked": "Bloccato",
+        "unlikely": "Improbabile"
       },
       "form": {
         "correctDetection": "Rilevamento corretto",
@@ -512,7 +513,8 @@
       "false": "Falso",
       "unverified": "Non verificato",
       "locked": "Bloccato",
-      "unlocked": "Sbloccato"
+      "unlocked": "Sbloccato",
+      "unlikely": "Improbabile"
     },
     "review": {
       "review": "Verifica",
@@ -640,7 +642,8 @@
         "verified": "Verificato",
         "false": "Falso",
         "unverified": "Non verificato",
-        "locked": "Bloccato"
+        "locked": "Bloccato",
+        "unlikely": "Improbabile"
       },
       "modals": {
         "showSpecies": "Mostra Specie {species}",
@@ -4511,6 +4514,10 @@
       "batNighttimeOnly": {
         "label": "Solo di notte",
         "helpText": "Se abilitato, il rilevamento dei pipistrelli funziona solo tra il crepuscolo civile e l'alba civile. Richiede la configurazione della posizione. Disabilita per eseguire il rilevamento continuamente."
+      },
+      "batUltrasonicFilter": {
+        "label": "Validazione post-rilevamento",
+        "helpText": "Quando abilitato, i rilevamenti di pipistrelli vengono validati analizzando i pattern di energia ultrasonica nell'audio sorgente. I rilevamenti privi di caratteristiche di ecolocalizzazione vengono contrassegnati come improbabili."
       }
     }
   },

--- a/frontend/static/messages/lv.json
+++ b/frontend/static/messages/lv.json
@@ -153,7 +153,8 @@
         "verifiedCorrect": "Verificēts kā pareizs",
         "falsePositive": "Kļūdaini pozitīvs",
         "notReviewed": "Nav pārskatīts",
-        "locked": "Bloķēts"
+        "locked": "Bloķēts",
+        "unlikely": "Maz ticams"
       },
       "form": {
         "correctDetection": "Pareiza noteikšana",
@@ -512,7 +513,8 @@
       "false": "Kļūdains",
       "unverified": "Neverificēts",
       "locked": "Bloķēts",
-      "unlocked": "Atbloķēts"
+      "unlocked": "Atbloķēts",
+      "unlikely": "Maz ticams"
     },
     "review": {
       "review": "Pārskatīt",
@@ -640,7 +642,8 @@
         "verified": "Verificēts",
         "false": "Nepatiess",
         "unverified": "Neverificēts",
-        "locked": "Bloķēts"
+        "locked": "Bloķēts",
+        "unlikely": "Maz ticams"
       },
       "modals": {
         "showSpecies": "Rādīt sugu {species}",
@@ -4511,6 +4514,10 @@
       "batNighttimeOnly": {
         "label": "Tikai naktī",
         "helpText": "Ja iespējots, sikspārņu noteikšana darbojas tikai starp pilsoniskajiem krēsliem un pilsonisko rītausmu. Nepieciešama atrašanās vietas konfigurācija. Atspējojiet, lai noteikšana darbotos visu diennakti."
+      },
+      "batUltrasonicFilter": {
+        "label": "Pēcnoteikšanas validācija",
+        "helpText": "Kad iespējots, sikspārņu noteikšana tiek pārbaudīta, analizējot ultraskaņas enerģijas modeļus avota ierakstā. Noteikšanas bez eholokācijas pazīmēm tiek atzīmētas kā maz ticamas."
       }
     }
   },

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -154,7 +154,8 @@
         "verifiedCorrect": "Goedgekeurd",
         "falsePositive": "Afgekeurd",
         "notReviewed": "Niet beoordeeld",
-        "locked": "Vergrendeld"
+        "locked": "Vergrendeld",
+        "unlikely": "Onwaarschijnlijk"
       },
       "form": {
         "correctDetection": "Herkenning goedgekeurd",
@@ -513,7 +514,8 @@
       "false": "Afgekeurd",
       "unverified": "Niet beoordeeld",
       "locked": "Vergrendeld",
-      "unlocked": "Ontgrendeld"
+      "unlocked": "Ontgrendeld",
+      "unlikely": "Onwaarschijnlijk"
     },
     "review": {
       "review": "Beoordelen",
@@ -641,7 +643,8 @@
         "verified": "Goedgekeurd",
         "false": "Afgekeurd",
         "unverified": "Niet beoordeeld",
-        "locked": "Vergrendeld"
+        "locked": "Vergrendeld",
+        "unlikely": "Onwaarschijnlijk"
       },
       "modals": {
         "showSpecies": "Toon soort {species}",
@@ -4527,6 +4530,10 @@
       "batNighttimeOnly": {
         "label": "Alleen 's nachts",
         "helpText": "Wanneer ingeschakeld, werkt de vleermuisdetectie alleen tussen de burgerlijke schemering en de burgerlijke dageraad. Vereist dat de locatie is geconfigureerd. Schakel uit om vleermuisdetectie de klok rond uit te voeren."
+      },
+      "batUltrasonicFilter": {
+        "label": "Validatie na detectie",
+        "helpText": "Indien ingeschakeld worden vleermuisdetecties gevalideerd door analyse van ultrasone energiepatronen in de bronaudio. Detecties zonder echolocatiekenmerken worden gemarkeerd als onwaarschijnlijk."
       },
       "locale": {
         "label": "Species Language",

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -154,7 +154,8 @@
         "verifiedCorrect": "Zweryfikowane Poprawnie",
         "falsePositive": "Fałszywie Pozytywne",
         "notReviewed": "Nieprzejrzane",
-        "locked": "Zablokowane"
+        "locked": "Zablokowane",
+        "unlikely": "Mało prawdopodobne"
       },
       "form": {
         "correctDetection": "Poprawna Detekcja",
@@ -513,7 +514,8 @@
       "false": "Fałszywe",
       "unverified": "Niezweryfikowane",
       "locked": "Zablokowane",
-      "unlocked": "Odblokowane"
+      "unlocked": "Odblokowane",
+      "unlikely": "Mało prawdopodobne"
     },
     "review": {
       "review": "Oceń",
@@ -641,7 +643,8 @@
         "verified": "Zweryfikowane",
         "false": "Fałszywe",
         "unverified": "Niezweryfikowane",
-        "locked": "Zablokowane"
+        "locked": "Zablokowane",
+        "unlikely": "Mało prawdopodobne"
       },
       "modals": {
         "showSpecies": "Pokaż Gatunek {species}",
@@ -4527,6 +4530,10 @@
       "batNighttimeOnly": {
         "label": "Tylko w nocy",
         "helpText": "Po włączeniu wykrywanie nietoperzy działa tylko między zmierzchem cywilnym a świtem cywilnym. Wymaga skonfigurowanej lokalizacji. Wyłącz, aby wykrywanie nietoperzy działało całą dobę."
+      },
+      "batUltrasonicFilter": {
+        "label": "Walidacja po wykryciu",
+        "helpText": "Po włączeniu wykrycia nietoperzy są weryfikowane przez analizę wzorców energii ultradźwiękowej w nagraniu źródłowym. Wykrycia bez cech echolokacji są oznaczane jako mało prawdopodobne."
       },
       "locale": {
         "label": "Species Language",

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -164,7 +164,8 @@
         "verifiedCorrect": "Verificado correto",
         "falsePositive": "Falso positivo",
         "notReviewed": "Não revisado",
-        "locked": "Bloqueado"
+        "locked": "Bloqueado",
+        "unlikely": "Improvável"
       },
       "form": {
         "correctDetection": "Detecção correta",
@@ -513,7 +514,8 @@
       "false": "Falso",
       "unverified": "Não verificado",
       "locked": "Bloqueado",
-      "unlocked": "Desbloqueado"
+      "unlocked": "Desbloqueado",
+      "unlikely": "Improvável"
     },
     "review": {
       "review": "Revisar",
@@ -641,7 +643,8 @@
         "verified": "Verificado",
         "false": "Falso",
         "unverified": "Não verificado",
-        "locked": "Bloqueado"
+        "locked": "Bloqueado",
+        "unlikely": "Improvável"
       },
       "modals": {
         "showSpecies": "Mostrar espécie {species}",
@@ -4527,6 +4530,10 @@
       "batNighttimeOnly": {
         "label": "Apenas noturno",
         "helpText": "Quando ativado, a deteção de morcegos funciona apenas entre o crepúsculo civil e a aurora civil. Requer que a localização esteja configurada. Desative para executar a deteção de morcegos 24 horas por dia."
+      },
+      "batUltrasonicFilter": {
+        "label": "Validação pós-deteção",
+        "helpText": "Quando ativado, as deteções de morcegos são validadas pela análise dos padrões de energia ultrassónica no áudio de origem. Deteções sem características de ecolocalização são marcadas como improváveis."
       },
       "locale": {
         "label": "Species Language",

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -153,7 +153,8 @@
         "verifiedCorrect": "Overené ako správne",
         "falsePositive": "Falošne pozitívne",
         "notReviewed": "Neskontrolované",
-        "locked": "Uzamknuté"
+        "locked": "Uzamknuté",
+        "unlikely": "Nepravdepodobné"
       },
       "form": {
         "correctDetection": "Správna detekcia",
@@ -512,7 +513,8 @@
       "false": "Falošné",
       "unverified": "Neoverené",
       "locked": "Uzamknuté",
-      "unlocked": "Odomknuté"
+      "unlocked": "Odomknuté",
+      "unlikely": "Nepravdepodobné"
     },
     "review": {
       "review": "Overiť",
@@ -640,7 +642,8 @@
         "verified": "Overené",
         "false": "Falošné",
         "unverified": "Neoverené",
-        "locked": "Uzamknuté"
+        "locked": "Uzamknuté",
+        "unlikely": "Nepravdepodobné"
       },
       "modals": {
         "showSpecies": "Zobraziť druh {species}",
@@ -4511,6 +4514,10 @@
       "batNighttimeOnly": {
         "label": "Iba v noci",
         "helpText": "Keď je povolené, detekcia netopierov beží iba medzi občianskym súmrakom a občianskym svitaním. Vyžaduje nakonfigurovanú polohu. Vypnite pre nepretržitú detekciu."
+      },
+      "batUltrasonicFilter": {
+        "label": "Overenie po detekcii",
+        "helpText": "Keď je zapnuté, detekcie netopierov sa overujú analýzou ultrazvukových energetických vzorcov v zdrojovom zvuku. Detekcie bez charakteristík echolokácie sú označené ako nepravdepodobné."
       }
     }
   },

--- a/frontend/static/messages/sv.json
+++ b/frontend/static/messages/sv.json
@@ -153,7 +153,8 @@
         "verifiedCorrect": "Verifierad korrekt",
         "falsePositive": "Falskt positiv",
         "notReviewed": "Ej granskad",
-        "locked": "Låst"
+        "locked": "Låst",
+        "unlikely": "Osannolik"
       },
       "form": {
         "correctDetection": "Korrekt detektion",
@@ -512,7 +513,8 @@
       "false": "Falsk",
       "unverified": "Overifierad",
       "locked": "Låst",
-      "unlocked": "Olåst"
+      "unlocked": "Olåst",
+      "unlikely": "Osannolik"
     },
     "review": {
       "review": "Granska",
@@ -640,7 +642,8 @@
         "verified": "Verifierad",
         "false": "Falsk",
         "unverified": "Overifierad",
-        "locked": "Låst"
+        "locked": "Låst",
+        "unlikely": "Osannolik"
       },
       "modals": {
         "showSpecies": "Visa art {species}",
@@ -4511,6 +4514,10 @@
       "batNighttimeOnly": {
         "label": "Endast nattetid",
         "helpText": "När aktiverat körs fladdermöss-detektering endast mellan borgerlig skymning och borgerlig gryning. Kräver konfigurerad plats. Inaktivera för att köra detektering dygnet runt."
+      },
+      "batUltrasonicFilter": {
+        "label": "Validering efter detektion",
+        "helpText": "När aktiverat valideras fladdermusdetektioner genom att analysera ultraljudsenergi i källljudet. Detektioner utan ekolokationsegenskaper markeras som osannolika."
       }
     }
   },


### PR DESCRIPTION
## Summary

- Display an "unlikely" badge on detection cards (StatusBadges) and dashboard rows (SpeciesInfoBar) for detections tagged by the bat ultrasonic validation filter (PR #3072)
- Add a "Post Detection Validation" settings toggle in the bat analysis section to enable/disable the ultrasonic filter
- Add `unlikely?: boolean` field to the Detection TypeScript interface
- Add i18n translations for all 14 supported locales

## Related Issues

Closes #3072 follow-up (frontend portion)

## Design Notes

- The unlikely badge uses amber/warning color with a CircleHelp icon to convey uncertainty, distinct from the verified (green), false positive (red), and locked (text-only warning) badges
- The badge appears alongside other status badges (a detection can be both "unlikely" and "verified correct")
- Only the enabled/disabled toggle is exposed in the UI; advanced parameters (CV threshold, FFT size, etc.) remain config-file-only
- The settings toggle renders only when a bat model is installed (`hasBatModel` guard)

## Test Plan

- [ ] Verify unlikely badge renders on detection cards when `unlikely: true`
- [ ] Verify badge does not render when `unlikely` is false or absent
- [ ] Verify Post Detection Validation checkbox appears in Analysis > Detection Settings when bat model is installed
- [ ] Verify checkbox toggle persists through save/reload cycle
- [ ] Verify change detection indicator shows when toggling the checkbox
- [ ] Verify translations render correctly for non-English locales

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "unlikely" detection status indicator displayed across species review, search results, and recent detections views to flag low-confidence detections.
  * Introduced configurable bat ultrasonic filter setting in analysis configuration to control detection validation behavior.
  * Full internationalization support with translations in all 12 supported languages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3074)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->