### PR TITLE
fix(i18n): add missing translation keys to da, hu, it, lv, sk, sv locales

### DIFF
--- a/frontend/static/messages/da.json
+++ b/frontend/static/messages/da.json
@@ -12,6 +12,7 @@
     "refresh": "Opdater",
     "delete": "Slet",
     "edit": "Rediger",
+    "enabled": "Aktiveret",
     "search": "Søg",
     "filter": "Filtrer",
     "sort": "Sortér",
@@ -659,6 +660,8 @@
       },
       "actions": {
         "menuLabel": "Handlinger for {species}",
+        "markCorrect": "Korrekt",
+        "markFalsePositive": "Ukorrekt",
         "review": "Gennemgå registrering",
         "showSpecies": "Vis art",
         "ignoreSpecies": "Ignorér art",
@@ -764,6 +767,7 @@
     "headers": {
       "dateTime": "Dato og tid",
       "weather": "Vejr",
+      "source": "Kilde",
       "species": "Art",
       "confidence": "Sikkerhed",
       "thumbnail": "Miniaturebillede",
@@ -1667,6 +1671,7 @@
     "title": "Indstillinger - BirdNET-Go",
     "loading": "Indlæser indstillinger...",
     "sections": {
+      "analysis": "Analyse",
       "node": "Generelt",
       "userinterface": "Grænseflade",
       "audio": "Lyd",
@@ -2830,6 +2835,10 @@
           "refresh": "Opdater enheder"
         }
       },
+      "noSources": {
+        "warning": "Ingen lydkilder konfigureret",
+        "description": "BirdNET-Go har brug for en lydindgang for at registrere fugle. Konfigurer venligst mindst én kilde under fanen Lydkort eller Strømme."
+      },
       "soundCards": {
         "summary": "{count} lydkortkilde(r)",
         "addSource": "Tilføj lydkort",
@@ -2874,10 +2883,6 @@
           "recommendedSampleRate": "{rate}kHz anbefalet for bedste resultater",
           "atLeastOneModel": "Mindst én model skal vælges"
         }
-      },
-      "noSources": {
-        "warning": "Ingen lydkilder konfigureret",
-        "description": "BirdNET-Go har brug for en lydindgang for at registrere fugle. Konfigurer venligst mindst én kilde under fanen Lydkort eller Strømme."
       },
       "audioCapture": {
         "title": "Lydkortkonfiguration",
@@ -4052,13 +4057,13 @@
     "labels": {
       "showPassword": "Vis adgangskode",
       "hidePassword": "Skjul adgangskode",
-      "copyToClipboard": "Kopiér til udklipsholder",
-      "clearSelection": "Ryd valg",
-      "selectOption": "Vælg en mulighed",
       "secretSet": "Indstillet",
       "changeSecret": "Skift",
       "cancelChange": "Annuller",
-      "enterNewSecret": "Indtast ny værdi"
+      "enterNewSecret": "Indtast ny værdi",
+      "copyToClipboard": "Kopiér til udklipsholder",
+      "clearSelection": "Ryd valg",
+      "selectOption": "Vælg en mulighed"
     },
     "help": {
       "passwordStrength": "Adgangskodestyrke: {strength}",
@@ -4159,11 +4164,11 @@
       "spectrogramLoading": "Indlæser spektrogram...",
       "spectrogramLoaded": "Spektrogram indlæst",
       "spectrogramLoadingAria": "Indlæser spektrogram",
+      "spectrogramAlt": "Lydspektrogram",
       "spectrogramGeneratingAria": "Genererer spektrogram",
       "generating": "Genererer...",
       "queuePosition": "Kø: {position}",
-      "loadError": "Kunne ikke indlæse lyd",
-      "spectrogramAlt": "Lydspektrogram"
+      "loadError": "Kunne ikke indlæse lyd"
     },
     "forms": {
       "numberField": {
@@ -4502,7 +4507,18 @@
     }
   },
   "analysis": {
+    "title": "Analyse",
+    "tabs": {
+      "settings": "Settings",
+      "models": "Models"
+    },
     "detection": {
+      "title": "Detection Settings",
+      "description": "Configure confidence thresholds and language for species classification.",
+      "confidenceThreshold": {
+        "label": "Confidence Threshold",
+        "helpText": "Minimum confidence score (0.0 - 1.0) required for a detection to be recorded."
+      },
       "batThreshold": {
         "label": "Flagermus-detekteringsgrænse",
         "helpText": "Minimum konfidensscore for flagermusartsdetektioner. Gælder kun for flagermusklassificeringsmodeller."
@@ -4518,7 +4534,95 @@
       "batUltrasonicFilter": {
         "label": "Validering efter detektion",
         "helpText": "Når aktiveret, valideres flagermusdetektioner ved at analysere ultralydsmønstre i kildeoptagelsen. Detektioner uden typiske flagermus-ekkolokationskarakteristika markeres som usandsynlige."
+      },
+      "locale": {
+        "label": "Species Language",
+        "helpText": "Language used for species common names in the interface."
       }
+    },
+    "rangeFilter": {
+      "birdOnlyNote": "Range filter applies to bird classifiers only. Bat models use their own species lists.",
+      "status": {
+        "title": "Range Filter Overview",
+        "geomodelInfo": "Geomodel {version} - {species} known species",
+        "autoSelected": "Auto-selected",
+        "manual": "Manual",
+        "classifier": "Classifier",
+        "totalSpecies": "Total Species",
+        "withRangeData": "With Range Data",
+        "withoutRangeData": "Without Range Data",
+        "withRangeDataTooltip": "Species that the geomodel can evaluate for geographic probability at your location",
+        "withoutRangeDataTooltip": "Species without geographic data in the geomodel, handled by the unmapped species setting below",
+        "noFilter": "No range filter active",
+        "passUnmapped": {
+          "label": "Allow species without range data",
+          "helpText": "Allow detections of species the geomodel has no geographic data for. When disabled, these species are always filtered out."
+        }
+      }
+    },
+    "advanced": {
+      "title": "Advanced",
+      "description": "Processing and custom model configuration."
+    },
+    "gallery": {
+      "title": "Model Gallery",
+      "description": "Manage classifier models for bird and bat detection.",
+      "tabs": {
+        "installed": "Installed",
+        "available": "Available"
+      },
+      "loading": "Loading models...",
+      "retry": "Retry",
+      "builtIn": "Built-in",
+      "builtInDescription": "Built-in bird species classifier by the BirdNET team.",
+      "species": "{count} species",
+      "install": "Install",
+      "installing": "Installing...",
+      "remove": "Remove",
+      "removing": "Removing...",
+      "noInstalledModels": "No additional models installed. Browse the Available tab to add more classifiers.",
+      "noAvailableModels": "No additional models available for your platform.",
+      "categories": {
+        "wildlife": "Wildlife Classifiers",
+        "bird": "Bird Classifiers",
+        "bat": "Bat Classifiers"
+      },
+      "progress": {
+        "downloading": "Downloading...",
+        "verifying": "Verifying...",
+        "loading": "Loading...",
+        "complete": "Installed successfully",
+        "failed": "Failed"
+      },
+      "license": {
+        "title": "License Agreement",
+        "model": "Model",
+        "author": "Author",
+        "license": "License",
+        "commercialUse": "Commercial Use",
+        "downloadSize": "Download Size",
+        "allowed": "Allowed",
+        "notAllowed": "Not allowed",
+        "commercialUseAllowed": "Commercial use allowed",
+        "nonCommercialOnly": "Non-commercial use only",
+        "nonCommercialWarning": "This model is licensed for non-commercial use only. By installing, you agree to comply with the license terms.",
+        "acceptAndInstall": "Accept & Install"
+      },
+      "removeDialog": {
+        "title": "Remove {name}?",
+        "confirmation": "This will remove the model files from disk. Label data is retained for existing detections."
+      },
+      "errors": {
+        "catalogLoadFailed": "Failed to load model catalog",
+        "installFailed": "Failed to start model installation",
+        "removeFailed": "Failed to remove model"
+      },
+      "regionLabel": "Region",
+      "speciesLabel": "Species",
+      "reinstall": "Reinstall",
+      "reinstalling": "Reinstalling...",
+      "reinstallComplete": "Files verified successfully",
+      "geomodelBadge": "Includes BirdNET v3.0 geomodel"
     }
   },
   "restart": {

--- a/frontend/static/messages/hu.json
+++ b/frontend/static/messages/hu.json
@@ -12,6 +12,7 @@
     "refresh": "Frissítés",
     "delete": "Törlés",
     "edit": "Szerkesztés",
+    "enabled": "Engedélyezve",
     "search": "Keresés",
     "filter": "Szűrés",
     "sort": "Rendezés",
@@ -391,17 +392,17 @@
         "reconfiguringTelemetry": "Telemetria beállítások frissítése...",
         "reconfiguringPushNotifications": "Push értesítési szolgáltatók újrakonfigurálása...",
         "reconfiguringSpeciesTracking": "Faj követés frissítése...",
+        "recalculatingThresholds": "Dinamikus küszöbértékek újraszámítása az új alapértékhez",
+        "reconfiguringDynamicThresholds": "Dinamikus küszöbértékek újrakonfigurálása...",
         "webserverRestartRequired": "Webszerver beállítások megváltoztak. Újraindítás szükséges.",
         "reconfiguringSoundLevel": "Hangszint monitorozás frissítése...",
         "reconfiguringAudioSources": "Hangforrások újrakonfigurálása...",
+        "rebuildingExtendedCapture": "Kiterjesztett rögzítési szűrő újraépítése...",
         "extendedCaptureRestartRequired": "Kiterjesztett rögzítés beállítások megváltoztak. Újraindítás szükséges.",
         "equalizerUpdateFailed": "A hang EQ beállítások frissítése sikertelen",
         "equalizerUpdated": "Hang EQ beállítások frissítve",
         "savedSuccessfully": "Beállítások sikeresen mentve",
-        "saveFailed": "A beállítások mentése sikertelen",
-        "recalculatingThresholds": "Dinamikus küszöbértékek újraszámítása az új alapértékhez",
-        "reconfiguringDynamicThresholds": "Dinamikus küszöbértékek újrakonfigurálása...",
-        "rebuildingExtendedCapture": "Kiterjesztett rögzítési szűrő újraépítése..."
+        "saveFailed": "A beállítások mentése sikertelen"
       },
       "migration": {
         "startedTitle": "Adatbázis migráció elkezdődött",
@@ -516,6 +517,15 @@
       "unlocked": "Zárolatlan",
       "unlikely": "Valószínűtlen"
     },
+    "review": {
+      "review": "Ellenőrzés",
+      "reviewDetection": "Detektálás ellenőrzése: {species}",
+      "markCorrect": "Megjelölés helyesként",
+      "markFalsePositive": "Megjelölés téves pozitívként",
+      "markedCorrect": "Detektálás helyesként megjelölve",
+      "markedFalsePositive": "Detektálás téves pozitívként megjelölve",
+      "failed": "Az ellenőrzési állapot frissítése sikertelen"
+    },
     "detailsPanel": {
       "audioPlayer": "Hang lejátszó",
       "expandDetails": "Részletek kibontása: {species}",
@@ -533,15 +543,6 @@
       "page": "{current}. oldal / {total}",
       "goToPrevious": "Előző oldal",
       "goToNext": "Következő oldal"
-    },
-    "review": {
-      "review": "Ellenőrzés",
-      "reviewDetection": "Detektálás ellenőrzése: {species}",
-      "markCorrect": "Megjelölés helyesként",
-      "markFalsePositive": "Megjelölés téves pozitívként",
-      "markedCorrect": "Detektálás helyesként megjelölve",
-      "markedFalsePositive": "Detektálás téves pozitívként megjelölve",
-      "failed": "Az ellenőrzési állapot frissítése sikertelen"
     }
   },
   "error": {
@@ -659,6 +660,8 @@
       },
       "actions": {
         "menuLabel": "Műveletek: {species}",
+        "markCorrect": "Megjelölés helyesként",
+        "markFalsePositive": "Megjelölés téves pozitívként",
         "review": "Detektálás áttekintése",
         "showSpecies": "Faj megjelenítése",
         "ignoreSpecies": "Faj figyelmen kívül hagyása",
@@ -764,6 +767,7 @@
     "headers": {
       "dateTime": "Dátum és idő",
       "weather": "Időjárás",
+      "source": "Forrás",
       "species": "Faj",
       "confidence": "Megbízhatóság",
       "thumbnail": "Miniatűr",
@@ -964,11 +968,11 @@
       "frequencyRange": "Frekvencia tartomány",
       "colorMap": "Színtérkép",
       "gain": "Erősítés",
+      "gainTooltip": "Spektrogram megjelenítési erősítés",
       "mute": "Némítás",
       "unmute": "Némítás feloldása",
       "frequencyRangeMin": "Minimum frekvencia",
       "frequencyRangeMax": "Maximum frekvencia",
-      "gainTooltip": "Spektrogram megjelenítési erősítés",
       "audioMonitor": "Hangmonitor"
     },
     "error": {
@@ -1667,6 +1671,7 @@
     "title": "Beállítások - BirdNET-Go",
     "loading": "Beállítások betöltése...",
     "sections": {
+      "analysis": "Elemzés",
       "node": "Általános",
       "userinterface": "Felület",
       "audio": "Hang",
@@ -1707,7 +1712,6 @@
       "setAsDefault": "Beállítás alapértelmezettként",
       "defaultIndicator": "Alapértelmezett bemeneti forrás"
     },
-    "restartRequired": "Néhány változtatáshoz szerver újraindítás szükséges. Kérjük, indítsa újra a BirdNET-Go-t.",
     "main": {
       "tabs": {
         "general": "Általános",
@@ -2831,6 +2835,10 @@
           "refresh": "Eszközök frissítése"
         }
       },
+      "noSources": {
+        "warning": "Nincs hang forrás konfigurálva",
+        "description": "A BirdNET-Go-nak hang bemenetre van szüksége a madarak érzékeléséhez. Kérjük, konfiguráljon legalább egy forrást a Hangszűrő kártya vagy Streamek lapon."
+      },
       "soundCards": {
         "summary": "{count} hangkártya forrás(ok)",
         "addSource": "Hangkártya hozzáadása",
@@ -2875,10 +2883,6 @@
           "recommendedSampleRate": "{rate}kHz ajánlott a legjobb eredményekhez",
           "atLeastOneModel": "Legalább egy modellt ki kell választani"
         }
-      },
-      "noSources": {
-        "warning": "Nincs hang forrás konfigurálva",
-        "description": "A BirdNET-Go-nak hang bemenetre van szüksége a madarak érzékeléséhez. Kérjük, konfiguráljon legalább egy forrást a Hangszűrő kártya vagy Streamek lapon."
       },
       "audioCapture": {
         "title": "Hangszűrő kártya konfiguráció",
@@ -3888,6 +3892,7 @@
         }
       },
       "v2Required": "A riasztási szabályokhoz a bővített adatbázis séma szükséges. Az adatbázist a Rendszer alatti Adatbázis oldalról migrálhatja.",
+      "v2RequiredLink": "Rendszer adatbázis oldal.",
       "builtInRules": {
         "newSpecies": {
           "name": "Új faj detektálva",
@@ -3929,8 +3934,7 @@
           "name": "BirdWeather feltöltés sikertelen",
           "description": "Értesít, amikor egy BirdWeather feltöltés sikertelen"
         }
-      },
-      "v2RequiredLink": "Rendszer adatbázis oldal."
+      }
     },
     "appearance": {
       "colorScheme": "Szín séma",
@@ -3972,7 +3976,8 @@
         "defaultGainHelpText": "Kezdeti erősítés a felvételek lejátszásakor. A madár hangok gyakran halkak, ezért 6-12 dB erősítés ajánlott.",
         "defaultGainUnit": "dB"
       }
-    }
+    },
+    "restartRequired": "Néhány változtatáshoz szerver újraindítás szükséges. Kérjük, indítsa újra a BirdNET-Go-t."
   },
   "auth": {
     "login": "Bejelentkezés",
@@ -4052,13 +4057,13 @@
     "labels": {
       "showPassword": "Jelszó megjelenítése",
       "hidePassword": "Jelszó elrejtése",
-      "copyToClipboard": "Másolás vágólapra",
-      "clearSelection": "Kijelölés törlése",
-      "selectOption": "Opció kiválasztása",
       "secretSet": "Beállítva",
       "changeSecret": "Módosítás",
       "cancelChange": "Mégse",
-      "enterNewSecret": "Új érték megadása"
+      "enterNewSecret": "Új érték megadása",
+      "copyToClipboard": "Másolás vágólapra",
+      "clearSelection": "Kijelölés törlése",
+      "selectOption": "Opció kiválasztása"
     },
     "help": {
       "passwordStrength": "Jelszó erőssége: {strength}",
@@ -4502,7 +4507,18 @@
     }
   },
   "analysis": {
+    "title": "Elemzés",
+    "tabs": {
+      "settings": "Settings",
+      "models": "Models"
+    },
     "detection": {
+      "title": "Detection Settings",
+      "description": "Configure confidence thresholds and language for species classification.",
+      "confidenceThreshold": {
+        "label": "Confidence Threshold",
+        "helpText": "Minimum confidence score (0.0 - 1.0) required for a detection to be recorded."
+      },
       "batThreshold": {
         "label": "Denevér-észlelési küszöb",
         "helpText": "Minimális megbízhatósági pontszám a denevérfajok észleléséhez. Csak a denevérosztályozó modellekre vonatkozik."
@@ -4518,7 +4534,95 @@
       "batUltrasonicFilter": {
         "label": "Utólagos érzékelés-ellenőrzés",
         "helpText": "Bekapcsolva a denevérészleléseket az ultrahang-energiaminták elemzésével ellenőrzi a forrásanyagban. Az echolokációs jellemzőkkel nem rendelkező észleléseket valószínűtlenként jelöli meg."
+      },
+      "locale": {
+        "label": "Species Language",
+        "helpText": "Language used for species common names in the interface."
       }
+    },
+    "rangeFilter": {
+      "birdOnlyNote": "Range filter applies to bird classifiers only. Bat models use their own species lists.",
+      "status": {
+        "title": "Range Filter Overview",
+        "geomodelInfo": "Geomodel {version} - {species} known species",
+        "autoSelected": "Auto-selected",
+        "manual": "Manual",
+        "classifier": "Classifier",
+        "totalSpecies": "Total Species",
+        "withRangeData": "With Range Data",
+        "withoutRangeData": "Without Range Data",
+        "withRangeDataTooltip": "Species that the geomodel can evaluate for geographic probability at your location",
+        "withoutRangeDataTooltip": "Species without geographic data in the geomodel, handled by the unmapped species setting below",
+        "noFilter": "No range filter active",
+        "passUnmapped": {
+          "label": "Allow species without range data",
+          "helpText": "Allow detections of species the geomodel has no geographic data for. When disabled, these species are always filtered out."
+        }
+      }
+    },
+    "advanced": {
+      "title": "Advanced",
+      "description": "Processing and custom model configuration."
+    },
+    "gallery": {
+      "title": "Model Gallery",
+      "description": "Manage classifier models for bird and bat detection.",
+      "tabs": {
+        "installed": "Installed",
+        "available": "Available"
+      },
+      "loading": "Loading models...",
+      "retry": "Retry",
+      "builtIn": "Built-in",
+      "builtInDescription": "Built-in bird species classifier by the BirdNET team.",
+      "species": "{count} species",
+      "install": "Install",
+      "installing": "Installing...",
+      "remove": "Remove",
+      "removing": "Removing...",
+      "noInstalledModels": "No additional models installed. Browse the Available tab to add more classifiers.",
+      "noAvailableModels": "No additional models available for your platform.",
+      "categories": {
+        "wildlife": "Wildlife Classifiers",
+        "bird": "Bird Classifiers",
+        "bat": "Bat Classifiers"
+      },
+      "progress": {
+        "downloading": "Downloading...",
+        "verifying": "Verifying...",
+        "loading": "Loading...",
+        "complete": "Installed successfully",
+        "failed": "Failed"
+      },
+      "license": {
+        "title": "License Agreement",
+        "model": "Model",
+        "author": "Author",
+        "license": "License",
+        "commercialUse": "Commercial Use",
+        "downloadSize": "Download Size",
+        "allowed": "Allowed",
+        "notAllowed": "Not allowed",
+        "commercialUseAllowed": "Commercial use allowed",
+        "nonCommercialOnly": "Non-commercial use only",
+        "nonCommercialWarning": "This model is licensed for non-commercial use only. By installing, you agree to comply with the license terms.",
+        "acceptAndInstall": "Accept & Install"
+      },
+      "removeDialog": {
+        "title": "Remove {name}?",
+        "confirmation": "This will remove the model files from disk. Label data is retained for existing detections."
+      },
+      "errors": {
+        "catalogLoadFailed": "Failed to load model catalog",
+        "installFailed": "Failed to start model installation",
+        "removeFailed": "Failed to remove model"
+      },
+      "regionLabel": "Region",
+      "speciesLabel": "Species",
+      "reinstall": "Reinstall",
+      "reinstalling": "Reinstalling...",
+      "reinstallComplete": "Files verified successfully",
+      "geomodelBadge": "Includes BirdNET v3.0 geomodel"
     }
   },
   "restart": {

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -12,6 +12,7 @@
     "refresh": "Aggiorna",
     "delete": "Elimina",
     "edit": "Modifica",
+    "enabled": "Abilitato",
     "search": "Cerca",
     "filter": "Filtra",
     "sort": "Ordina",
@@ -659,6 +660,8 @@
       },
       "actions": {
         "menuLabel": "Azioni per {species}",
+        "markCorrect": "Corretto",
+        "markFalsePositive": "Non corretto",
         "review": "Revisiona rilevamento",
         "showSpecies": "Mostra specie",
         "ignoreSpecies": "Ignora specie",
@@ -764,12 +767,18 @@
     "headers": {
       "dateTime": "Data e Ora",
       "weather": "Meteo",
+      "source": "Sorgente",
       "species": "Specie",
       "confidence": "Confidenza",
       "thumbnail": "Miniatura",
       "status": "Stato",
       "recording": "Registrazione",
       "actions": "Azioni"
+    },
+    "viewToggle": {
+      "label": "Modalità visualizzazione",
+      "table": "Vista tabella",
+      "cards": "Vista a schede"
     },
     "status": {
       "locked": "Bloccato"
@@ -903,11 +912,6 @@
       "loadFailed": "Impossibile caricare il rilevamento (Errore {status}). Prova ad aggiornare la pagina.",
       "noIdProvided": "Nessun ID di rilevamento fornito.",
       "fetchFailed": "Recupero dei rilevamenti non riuscito"
-    },
-    "viewToggle": {
-      "label": "Modalità visualizzazione",
-      "table": "Vista tabella",
-      "cards": "Vista a schede"
     }
   },
   "species": {
@@ -1118,6 +1122,86 @@
         "detections": "Rilevamenti",
         "fetchFailed": "Impossibile recuperare statistiche database"
       },
+      "dashboard": {
+        "title": "Dashboard database",
+        "fetchFailed": "Impossibile recuperare la panoramica del database",
+        "loading": "Caricamento...",
+        "metrics": {
+          "readLatency": "Latenza lettura",
+          "writeLatency": "Latenza scrittura",
+          "queriesPerSec": "Query/sec",
+          "database": "Database",
+          "avg": "media",
+          "max": "max",
+          "lastHour": "{count} nell'ultima ora",
+          "slowQueries": "{count} lenti"
+        },
+        "details": {
+          "title": "Dettagli database",
+          "engine": "Motore",
+          "journal": "Giornale",
+          "pageSize": "Dimensione pagina",
+          "cacheHit": "Cache hit",
+          "integrity": "Integrità",
+          "lastVacuum": "Ultimo VACUUM"
+        },
+        "locksWal": {
+          "title": "Blocchi e WAL",
+          "lockWaits": "Attese blocco",
+          "lockTimeouts": "Timeout blocco",
+          "avgWait": "Attesa media",
+          "busyTimeouts": "Timeout occupato",
+          "walSize": "Dimensione WAL",
+          "checkpoints": "Checkpoint",
+          "freelistPages": "Pagine freelist",
+          "cacheSize": "Dimensione cache"
+        },
+        "connectionPool": {
+          "title": "Pool di connessioni",
+          "poolUsage": "Utilizzo pool",
+          "active": "attivo",
+          "idle": "inattivo",
+          "waiting": "in attesa",
+          "totalCreated": "Totale creati",
+          "connErrors": "Errori di connessione",
+          "threads": "Thread",
+          "running": "in esecuzione",
+          "cached": "in cache"
+        },
+        "innodb": {
+          "title": "InnoDB e blocchi",
+          "bufferPoolHitRate": "Tasso di hit del buffer pool",
+          "bufferPoolSize": "Dimensione buffer pool",
+          "lockWaits": "Attese blocco",
+          "deadlocks": "Deadlock",
+          "avgLockWait": "Attesa media blocco",
+          "tableLocksWaited": "Blocchi tabella in attesa",
+          "tableLocksImmediate": "Blocchi tabella immediati"
+        },
+        "detectionRate": {
+          "title": "Tasso di rilevamento (24h)",
+          "chartLabel": "Tasso di rilevamento nelle ultime 24 ore",
+          "detectionsTooltip": "{count} rilevamenti",
+          "perHour": "/ora",
+          "min": "min",
+          "avg": "media",
+          "max": "max",
+          "lastBackup": "Ultimo backup",
+          "backupSize": "Dimensione backup",
+          "createBackup": "Crea backup",
+          "mysqlHost": "Host",
+          "mysqlBackupNote": "I backup MySQL devono essere gestiti tramite mysqldump o i tuoi strumenti di amministrazione MySQL."
+        },
+        "tables": {
+          "title": "Tabelle",
+          "total": "Totale",
+          "table": "Tabella",
+          "engine": "Motore",
+          "rows": "Righe",
+          "size": "Dimensione",
+          "usage": "Utilizzo"
+        }
+      },
       "backup": {
         "download": "Scarica Backup",
         "downloading": "Download in corso...",
@@ -1202,6 +1286,29 @@
           "calculating": "Calcolo in corso...",
           "dirtyWriteFailed": "{count} record non scritti — verranno riconciliati durante la validazione"
         },
+        "details": {
+          "title": "Dettagli database",
+          "detections": "{count} rilevamenti",
+          "lastBackup": "Ultimo backup: {date}",
+          "noBackups": "Nessun backup",
+          "integrity": "Integrità: {status}"
+        },
+        "strip": {
+          "legacy": "Legacy",
+          "v2Target": "V2 (Destinazione)",
+          "active": "Attivo",
+          "migration": "Migrazione",
+          "complete": "Completato",
+          "recordsMigrated": "{count} record migrati",
+          "readyToMigrate": "Pronto per la migrazione",
+          "recordsInLegacy": "{count} record nel legacy",
+          "comparingRecords": "Confronto conteggio record...",
+          "validationFailed": "Validazione fallita",
+          "rate": "Frequenza",
+          "recPerSec": "{rate} rec/s",
+          "dayAvg": "~{count} / media giornaliera",
+          "dayHistory": "Storico 30 giorni"
+        },
         "phase": {
           "indicator": "Fase {current} di {total}: ",
           "detections": "Migrazione rilevamenti primari",
@@ -1250,8 +1357,8 @@
           "resumeFailed": "Impossibile riprendere la migrazione",
           "cancelFailed": "Impossibile annullare la migrazione",
           "rollbackFailed": "Impossibile eseguire il rollback della migrazione",
-          "fetchFailed": "Impossibile recuperare lo stato della migrazione",
-          "retryValidationFailed": "Impossibile riprovare la validazione"
+          "retryValidationFailed": "Impossibile riprovare la validazione",
+          "fetchFailed": "Impossibile recuperare lo stato della migrazione"
         },
         "worker": {
           "running": "Worker In Esecuzione",
@@ -1267,6 +1374,19 @@
           "warningsCount": "{count} avviso/i",
           "running": "Esecuzione controlli pre-migrazione...",
           "checkingStep": "Passo {current} di {total}",
+          "passedCount": "{passed}/{total} superati",
+          "criticalCount": "{count} critici",
+          "warningCount": "{count} avviso/i",
+          "rerun": "Riesegui",
+          "showDetails": "Mostra dettagli",
+          "hideDetails": "Nascondi dettagli",
+          "status": {
+            "passed": "Superato",
+            "failed": "Fallito",
+            "error": "Errore",
+            "warning": "Avviso",
+            "skipped": "Saltato"
+          },
           "errors": {
             "fetchFailed": "Impossibile recuperare i prerequisiti"
           },
@@ -1310,123 +1430,7 @@
             "mysql_timeout": {
               "name": "Timeout MySQL"
             }
-          },
-          "passedCount": "{passed}/{total} superati",
-          "criticalCount": "{count} critici",
-          "warningCount": "{count} avviso/i",
-          "rerun": "Riesegui",
-          "showDetails": "Mostra dettagli",
-          "hideDetails": "Nascondi dettagli",
-          "status": {
-            "passed": "Superato",
-            "failed": "Fallito",
-            "error": "Errore",
-            "warning": "Avviso",
-            "skipped": "Saltato"
           }
-        },
-        "details": {
-          "title": "Dettagli database",
-          "detections": "{count} rilevamenti",
-          "lastBackup": "Ultimo backup: {date}",
-          "noBackups": "Nessun backup",
-          "integrity": "Integrità: {status}"
-        },
-        "strip": {
-          "legacy": "Legacy",
-          "v2Target": "V2 (Destinazione)",
-          "active": "Attivo",
-          "migration": "Migrazione",
-          "complete": "Completato",
-          "recordsMigrated": "{count} record migrati",
-          "readyToMigrate": "Pronto per la migrazione",
-          "recordsInLegacy": "{count} record nel legacy",
-          "comparingRecords": "Confronto conteggio record...",
-          "validationFailed": "Validazione fallita",
-          "rate": "Frequenza",
-          "recPerSec": "{rate} rec/s",
-          "dayAvg": "~{count} / media giornaliera",
-          "dayHistory": "Storico 30 giorni"
-        }
-      },
-      "dashboard": {
-        "title": "Dashboard database",
-        "fetchFailed": "Impossibile recuperare la panoramica del database",
-        "loading": "Caricamento...",
-        "metrics": {
-          "readLatency": "Latenza lettura",
-          "writeLatency": "Latenza scrittura",
-          "queriesPerSec": "Query/sec",
-          "database": "Database",
-          "avg": "media",
-          "max": "max",
-          "lastHour": "{count} nell'ultima ora",
-          "slowQueries": "{count} lenti"
-        },
-        "details": {
-          "title": "Dettagli database",
-          "engine": "Motore",
-          "journal": "Giornale",
-          "pageSize": "Dimensione pagina",
-          "cacheHit": "Cache hit",
-          "integrity": "Integrità",
-          "lastVacuum": "Ultimo VACUUM"
-        },
-        "locksWal": {
-          "title": "Blocchi e WAL",
-          "lockWaits": "Attese blocco",
-          "lockTimeouts": "Timeout blocco",
-          "avgWait": "Attesa media",
-          "busyTimeouts": "Timeout occupato",
-          "walSize": "Dimensione WAL",
-          "checkpoints": "Checkpoint",
-          "freelistPages": "Pagine freelist",
-          "cacheSize": "Dimensione cache"
-        },
-        "connectionPool": {
-          "title": "Pool di connessioni",
-          "poolUsage": "Utilizzo pool",
-          "active": "attivo",
-          "idle": "inattivo",
-          "waiting": "in attesa",
-          "totalCreated": "Totale creati",
-          "connErrors": "Errori di connessione",
-          "threads": "Thread",
-          "running": "in esecuzione",
-          "cached": "in cache"
-        },
-        "innodb": {
-          "title": "InnoDB e blocchi",
-          "bufferPoolHitRate": "Tasso di hit del buffer pool",
-          "bufferPoolSize": "Dimensione buffer pool",
-          "lockWaits": "Attese blocco",
-          "deadlocks": "Deadlock",
-          "avgLockWait": "Attesa media blocco",
-          "tableLocksWaited": "Blocchi tabella in attesa",
-          "tableLocksImmediate": "Blocchi tabella immediati"
-        },
-        "detectionRate": {
-          "title": "Tasso di rilevamento (24h)",
-          "chartLabel": "Tasso di rilevamento nelle ultime 24 ore",
-          "detectionsTooltip": "{count} rilevamenti",
-          "perHour": "/ora",
-          "min": "min",
-          "avg": "media",
-          "max": "max",
-          "lastBackup": "Ultimo backup",
-          "backupSize": "Dimensione backup",
-          "createBackup": "Crea backup",
-          "mysqlHost": "Host",
-          "mysqlBackupNote": "I backup MySQL devono essere gestiti tramite mysqldump o i tuoi strumenti di amministrazione MySQL."
-        },
-        "tables": {
-          "title": "Tabelle",
-          "total": "Totale",
-          "table": "Tabella",
-          "engine": "Motore",
-          "rows": "Righe",
-          "size": "Dimensione",
-          "usage": "Utilizzo"
         }
       }
     },
@@ -1440,12 +1444,12 @@
       "available": "disp.",
       "min": "Min",
       "max": "Max",
+      "limit": "Limite",
       "tempUnavailable": "Non disponibile",
       "online": "Online",
       "uptime": "Tempo attivo",
       "host": "Host",
       "model": "Modello",
-      "limit": "Limite",
       "inference": "Inferenza",
       "avgTime": "Med",
       "noInference": "Nessun dato",
@@ -1459,6 +1463,30 @@
       "free": "libero",
       "ram": "RAM"
     }
+  },
+  "terminal": {
+    "title": "Terminale",
+    "disabled": "Terminale disabilitato",
+    "disabledDescription": "Il terminale del browser è disabilitato. Abilitarlo in Impostazioni → Sicurezza per utilizzare questa funzione.",
+    "connected": "Connesso",
+    "disconnected": "Disconnesso",
+    "connecting": "Connessione in corso...",
+    "connectionError": "Connessione non riuscita",
+    "connectionClosed": "Connessione chiusa",
+    "securityWarning": "Avviso: Questo terminale fornisce accesso diretto alla shell del sistema host. Abilitare solo su reti attendibili.",
+    "copySelection": "Copia selezione",
+    "expand": "Espandi",
+    "collapse": "Comprimi",
+    "fullscreen": "Schermo intero",
+    "exitFullscreen": "Esci da schermo intero",
+    "colorTheme": "Tema colori",
+    "themeDark": "Scuro",
+    "themeLight": "Chiaro",
+    "themeHighContrast": "Alto contrasto",
+    "detach": "Apri in nuova finestra",
+    "detached": "Terminale separato",
+    "detachedDescription": "Il terminale è in esecuzione in una finestra separata. Chiudere quella finestra per riportarlo qui.",
+    "reattach": "Riattacca"
   },
   "analytics": {
     "title": "Panoramica",
@@ -1620,19 +1648,19 @@
           "species": "Specie"
         }
       },
-      "aria": {
-        "startDate": "Data inizio",
-        "endDate": "Data fine",
-        "loadingAnalytics": "Caricamento dati analitici",
-        "loadingTrends": "Caricamento dati trend",
-        "loadingDiversity": "Caricamento dati di diversità"
-      },
       "categories": {
         "birds": "Uccelli"
       },
       "filters": {
         "startDate": "Data inizio",
         "endDate": "Data fine"
+      },
+      "aria": {
+        "startDate": "Data inizio",
+        "endDate": "Data fine",
+        "loadingAnalytics": "Caricamento dati analitici",
+        "loadingTrends": "Caricamento dati trend",
+        "loadingDiversity": "Caricamento dati di diversità"
       }
     },
     "errors": {
@@ -1643,6 +1671,7 @@
     "title": "Impostazioni - BirdNET-Go",
     "loading": "Caricamento impostazioni...",
     "sections": {
+      "analysis": "Analisi",
       "node": "Generali",
       "userinterface": "Interfaccia",
       "audio": "Audio",
@@ -1666,6 +1695,12 @@
       "savingAriaLabel": "Salvataggio modifiche...",
       "unsavedChanges": "Modifiche non salvate",
       "toolbar": "Azioni impostazioni"
+    },
+    "errors": {
+      "loadFailed": "Caricamento delle impostazioni non riuscito",
+      "saveFailed": "Salvataggio delle impostazioni non riuscito",
+      "databaseStatsFailed": "Caricamento delle statistiche del database non riuscito",
+      "csvDownloadFailed": "Download del CSV non riuscito"
     },
     "card": {
       "changed": "modificato",
@@ -2800,6 +2835,10 @@
           "refresh": "Aggiorna Dispositivi"
         }
       },
+      "noSources": {
+        "warning": "Nessuna Sorgente Audio Configurata",
+        "description": "BirdNET-Go necessita di un input audio per rilevare uccelli. Per favore configura almeno una sorgente nella scheda Scheda Audio o Flussi."
+      },
       "soundCards": {
         "summary": "{count} sorgente/i scheda audio",
         "addSource": "Aggiungi scheda audio",
@@ -2844,10 +2883,6 @@
           "recommendedSampleRate": "{rate}kHz consigliato per i migliori risultati",
           "atLeastOneModel": "È necessario selezionare almeno un modello"
         }
-      },
-      "noSources": {
-        "warning": "Nessuna Sorgente Audio Configurata",
-        "description": "BirdNET-Go necessita di un input audio per rilevare uccelli. Per favore configura almeno una sorgente nella scheda Scheda Audio o Flussi."
       },
       "audioCapture": {
         "title": "Configurazione Scheda Audio",
@@ -3524,6 +3559,8 @@
         "parameters": {
           "label": "Parametri",
           "helpText": "Questi valori saranno passati al tuo comando nell'ordine elencato",
+          "placeholder": "Clicca i pulsanti qui sotto per aggiungere parametri o digita manualmente",
+          "tooltip": "Usa i pulsanti qui sotto o digita direttamente (separati da virgola)",
           "availableTitle": "Parametri Disponibili",
           "buttons": {
             "commonName": "NomeComune",
@@ -3532,9 +3569,7 @@
             "time": "Ora",
             "source": "Sorgente",
             "clearParameters": "Pulisci Parametri"
-          },
-          "placeholder": "Clicca i pulsanti qui sotto per aggiungere parametri o digita manualmente",
-          "tooltip": "Usa i pulsanti qui sotto o digita direttamente (separati da virgola)"
+          }
         },
         "executeDefaults": {
           "label": "Esegui anche azioni predefinite (archiviazione database, notifiche, ecc.)",
@@ -3543,6 +3578,7 @@
       },
       "add": "Aggiungi",
       "remove": "Rimuovi",
+      "suggestions": "Suggerimenti specie",
       "addSpeciesToInclude": "Aggiungi specie da includere",
       "addSpeciesToIncludeLabel": "Aggiungi Nuova Specie da Includere",
       "addSpeciesToExclude": "Aggiungi specie da escludere",
@@ -3685,8 +3721,7 @@
         "resetAllError": "Impossibile resettare soglie",
         "expand": "Mostra cronologia eventi",
         "collapse": "Nascondi cronologia eventi"
-      },
-      "suggestions": "Suggerimenti specie"
+      }
     },
     "database": {
       "sqlitePlaceholder": "Inserisci percorso database SQLite",
@@ -3901,12 +3936,6 @@
         }
       }
     },
-    "errors": {
-      "loadFailed": "Caricamento delle impostazioni non riuscito",
-      "saveFailed": "Salvataggio delle impostazioni non riuscito",
-      "databaseStatsFailed": "Caricamento delle statistiche del database non riuscito",
-      "csvDownloadFailed": "Download del CSV non riuscito"
-    },
     "appearance": {
       "colorScheme": "Schema colori",
       "colorSchemeDescription": "Scegli uno schema di colori per l'interfaccia",
@@ -4028,13 +4057,13 @@
     "labels": {
       "showPassword": "Mostra password",
       "hidePassword": "Nascondi password",
-      "copyToClipboard": "Copia negli appunti",
-      "clearSelection": "Pulisci selezione",
-      "selectOption": "Seleziona un'opzione",
       "secretSet": "Imposta",
       "changeSecret": "Modifica",
       "cancelChange": "Annulla",
-      "enterNewSecret": "Inserisci nuovo valore"
+      "enterNewSecret": "Inserisci nuovo valore",
+      "copyToClipboard": "Copia negli appunti",
+      "clearSelection": "Pulisci selezione",
+      "selectOption": "Seleziona un'opzione"
     },
     "help": {
       "passwordStrength": "Forza password: {strength}",
@@ -4260,30 +4289,6 @@
       "download": "Scarica"
     }
   },
-  "terminal": {
-    "title": "Terminale",
-    "disabled": "Terminale disabilitato",
-    "disabledDescription": "Il terminale del browser è disabilitato. Abilitarlo in Impostazioni → Sicurezza per utilizzare questa funzione.",
-    "connected": "Connesso",
-    "disconnected": "Disconnesso",
-    "connecting": "Connessione in corso...",
-    "connectionError": "Connessione non riuscita",
-    "connectionClosed": "Connessione chiusa",
-    "securityWarning": "Avviso: Questo terminale fornisce accesso diretto alla shell del sistema host. Abilitare solo su reti attendibili.",
-    "copySelection": "Copia selezione",
-    "expand": "Espandi",
-    "collapse": "Comprimi",
-    "fullscreen": "Schermo intero",
-    "exitFullscreen": "Esci da schermo intero",
-    "colorTheme": "Tema colori",
-    "themeDark": "Scuro",
-    "themeLight": "Chiaro",
-    "themeHighContrast": "Alto contrasto",
-    "detach": "Apri in nuova finestra",
-    "detached": "Terminale separato",
-    "detachedDescription": "Il terminale è in esecuzione in una finestra separata. Chiudere quella finestra per riportarlo qui.",
-    "reattach": "Riattacca"
-  },
   "quietHours": {
     "indicator": {
       "tooltip": "Ore silenziose attive — {count} sorgente/i in pausa"
@@ -4502,7 +4507,18 @@
     }
   },
   "analysis": {
+    "title": "Analysis",
+    "tabs": {
+      "settings": "Settings",
+      "models": "Models"
+    },
     "detection": {
+      "title": "Detection Settings",
+      "description": "Configure confidence thresholds and language for species classification.",
+      "confidenceThreshold": {
+        "label": "Confidence Threshold",
+        "helpText": "Minimum confidence score (0.0 - 1.0) required for a detection to be recorded."
+      },
       "batThreshold": {
         "label": "Soglia di rilevamento pipistrelli",
         "helpText": "Punteggio di confidenza minimo per i rilevamenti delle specie di pipistrelli. Si applica solo ai modelli classificatori di pipistrelli."
@@ -4518,7 +4534,95 @@
       "batUltrasonicFilter": {
         "label": "Validazione post-rilevamento",
         "helpText": "Quando abilitato, i rilevamenti di pipistrelli vengono validati analizzando i pattern di energia ultrasonica nell'audio sorgente. I rilevamenti privi di caratteristiche di ecolocalizzazione vengono contrassegnati come improbabili."
+      },
+      "locale": {
+        "label": "Species Language",
+        "helpText": "Language used for species common names in the interface."
       }
+    },
+    "rangeFilter": {
+      "birdOnlyNote": "Range filter applies to bird classifiers only. Bat models use their own species lists.",
+      "status": {
+        "title": "Range Filter Overview",
+        "geomodelInfo": "Geomodel {version} - {species} known species",
+        "autoSelected": "Auto-selected",
+        "manual": "Manual",
+        "classifier": "Classifier",
+        "totalSpecies": "Total Species",
+        "withRangeData": "With Range Data",
+        "withoutRangeData": "Without Range Data",
+        "withRangeDataTooltip": "Species that the geomodel can evaluate for geographic probability at your location",
+        "withoutRangeDataTooltip": "Species without geographic data in the geomodel, handled by the unmapped species setting below",
+        "noFilter": "No range filter active",
+        "passUnmapped": {
+          "label": "Allow species without range data",
+          "helpText": "Allow detections of species the geomodel has no geographic data for. When disabled, these species are always filtered out."
+        }
+      }
+    },
+    "advanced": {
+      "title": "Advanced",
+      "description": "Processing and custom model configuration."
+    },
+    "gallery": {
+      "title": "Model Gallery",
+      "description": "Manage classifier models for bird and bat detection.",
+      "tabs": {
+        "installed": "Installed",
+        "available": "Available"
+      },
+      "loading": "Loading models...",
+      "retry": "Retry",
+      "builtIn": "Built-in",
+      "builtInDescription": "Built-in bird species classifier by the BirdNET team.",
+      "species": "{count} species",
+      "install": "Install",
+      "installing": "Installing...",
+      "remove": "Remove",
+      "removing": "Removing...",
+      "noInstalledModels": "No additional models installed. Browse the Available tab to add more classifiers.",
+      "noAvailableModels": "No additional models available for your platform.",
+      "categories": {
+        "wildlife": "Wildlife Classifiers",
+        "bird": "Bird Classifiers",
+        "bat": "Bat Classifiers"
+      },
+      "progress": {
+        "downloading": "Downloading...",
+        "verifying": "Verifying...",
+        "loading": "Loading...",
+        "complete": "Installed successfully",
+        "failed": "Failed"
+      },
+      "license": {
+        "title": "License Agreement",
+        "model": "Model",
+        "author": "Author",
+        "license": "License",
+        "commercialUse": "Commercial Use",
+        "downloadSize": "Download Size",
+        "allowed": "Allowed",
+        "notAllowed": "Not allowed",
+        "commercialUseAllowed": "Commercial use allowed",
+        "nonCommercialOnly": "Non-commercial use only",
+        "nonCommercialWarning": "This model is licensed for non-commercial use only. By installing, you agree to comply with the license terms.",
+        "acceptAndInstall": "Accept & Install"
+      },
+      "removeDialog": {
+        "title": "Remove {name}?",
+        "confirmation": "This will remove the model files from disk. Label data is retained for existing detections."
+      },
+      "errors": {
+        "catalogLoadFailed": "Failed to load model catalog",
+        "installFailed": "Failed to start model installation",
+        "removeFailed": "Failed to remove model"
+      },
+      "regionLabel": "Region",
+      "speciesLabel": "Species",
+      "reinstall": "Reinstall",
+      "reinstalling": "Reinstalling...",
+      "reinstallComplete": "Files verified successfully",
+      "geomodelBadge": "Includes BirdNET v3.0 geomodel"
     }
   },
   "restart": {

--- a/frontend/static/messages/lv.json
+++ b/frontend/static/messages/lv.json
@@ -12,6 +12,7 @@
     "refresh": "Atsvaidzināt",
     "delete": "Dzēst",
     "edit": "Rediģēt",
+    "enabled": "Iespējots",
     "search": "Meklēt",
     "filter": "Filtrs",
     "sort": "Kārtot",
@@ -659,6 +660,8 @@
       },
       "actions": {
         "menuLabel": "Darbības ar sugu {species}",
+        "markCorrect": "Pareizs",
+        "markFalsePositive": "Nepareizs",
         "review": "Pārskatīt atklāšanu",
         "showSpecies": "Rādīt sugu",
         "ignoreSpecies": "Ignorēt sugu",
@@ -764,6 +767,7 @@
     "headers": {
       "dateTime": "Datums un laiks",
       "weather": "Laikapstākļi",
+      "source": "Avots",
       "species": "Suga",
       "confidence": "Ticamība",
       "thumbnail": "Sīktēls",
@@ -1667,6 +1671,7 @@
     "title": "Iestatījumi - BirdNET-Go",
     "loading": "Ielādē iestatījumus...",
     "sections": {
+      "analysis": "Analīze",
       "node": "Galvenie",
       "userinterface": "Saskarne",
       "audio": "Audio",
@@ -2830,6 +2835,10 @@
           "refresh": "Atsvaidzināt ierīces"
         }
       },
+      "noSources": {
+        "warning": "Nav konfigurētu audio avotu",
+        "description": "BirdNET-Go nepieciešama audio ievade, lai noteiktu putnus. Lūdzu, konfigurējiet vismaz vienu avotu cilnē Skaņas karte vai Straumes."
+      },
       "soundCards": {
         "summary": "{count} skaņas kartes avots(-i)",
         "addSource": "Pievienot skaņas karti",
@@ -2874,10 +2883,6 @@
           "recommendedSampleRate": "{rate}kHz ieteicams labākajiem rezultātiem",
           "atLeastOneModel": "Jāizvēlas vismaz viens modelis"
         }
-      },
-      "noSources": {
-        "warning": "Nav konfigurētu audio avotu",
-        "description": "BirdNET-Go nepieciešama audio ievade, lai noteiktu putnus. Lūdzu, konfigurējiet vismaz vienu avotu cilnē Skaņas karte vai Straumes."
       },
       "audioCapture": {
         "title": "Skaņas kartes konfigurācija",
@@ -4052,13 +4057,13 @@
     "labels": {
       "showPassword": "Rādīt paroli",
       "hidePassword": "Slēpt paroli",
-      "copyToClipboard": "Kopēt starpliktuvē",
-      "clearSelection": "Notīrīt atlasi",
-      "selectOption": "Izvēlieties opciju",
       "secretSet": "Iestatīts",
       "changeSecret": "Mainīt",
       "cancelChange": "Atcelt",
-      "enterNewSecret": "Ievadiet jaunu vērtību"
+      "enterNewSecret": "Ievadiet jaunu vērtību",
+      "copyToClipboard": "Kopēt starpliktuvē",
+      "clearSelection": "Notīrīt atlasi",
+      "selectOption": "Izvēlieties opciju"
     },
     "help": {
       "passwordStrength": "Paroles stiprums: {strength}",
@@ -4159,11 +4164,11 @@
       "spectrogramLoading": "Ielādē spektrogrammu...",
       "spectrogramLoaded": "Spektrogramma ielādēta",
       "spectrogramLoadingAria": "Ielādē spektrogrammu",
+      "spectrogramAlt": "Audio spektrogramma",
       "spectrogramGeneratingAria": "Ģenerē spektrogrammu",
       "generating": "Ģenerē...",
       "queuePosition": "Rinda: {position}",
-      "loadError": "Neizdevās ielādēt audio",
-      "spectrogramAlt": "Audio spektrogramma"
+      "loadError": "Neizdevās ielādēt audio"
     },
     "forms": {
       "numberField": {
@@ -4502,7 +4507,18 @@
     }
   },
   "analysis": {
+    "title": "Analīze",
+    "tabs": {
+      "settings": "Settings",
+      "models": "Models"
+    },
     "detection": {
+      "title": "Detection Settings",
+      "description": "Configure confidence thresholds and language for species classification.",
+      "confidenceThreshold": {
+        "label": "Confidence Threshold",
+        "helpText": "Minimum confidence score (0.0 - 1.0) required for a detection to be recorded."
+      },
       "batThreshold": {
         "label": "Sikspārņu noteikšanas slieksnis",
         "helpText": "Minimālais ticamības rādītājs sikspārņu sugu noteikšanai. Attiecas tikai uz sikspārņu klasifikatora modeļiem."
@@ -4518,7 +4534,95 @@
       "batUltrasonicFilter": {
         "label": "Pēcnoteikšanas validācija",
         "helpText": "Kad iespējots, sikspārņu noteikšana tiek pārbaudīta, analizējot ultraskaņas enerģijas modeļus avota ierakstā. Noteikšanas bez eholokācijas pazīmēm tiek atzīmētas kā maz ticamas."
+      },
+      "locale": {
+        "label": "Species Language",
+        "helpText": "Language used for species common names in the interface."
       }
+    },
+    "rangeFilter": {
+      "birdOnlyNote": "Range filter applies to bird classifiers only. Bat models use their own species lists.",
+      "status": {
+        "title": "Range Filter Overview",
+        "geomodelInfo": "Geomodel {version} - {species} known species",
+        "autoSelected": "Auto-selected",
+        "manual": "Manual",
+        "classifier": "Classifier",
+        "totalSpecies": "Total Species",
+        "withRangeData": "With Range Data",
+        "withoutRangeData": "Without Range Data",
+        "withRangeDataTooltip": "Species that the geomodel can evaluate for geographic probability at your location",
+        "withoutRangeDataTooltip": "Species without geographic data in the geomodel, handled by the unmapped species setting below",
+        "noFilter": "No range filter active",
+        "passUnmapped": {
+          "label": "Allow species without range data",
+          "helpText": "Allow detections of species the geomodel has no geographic data for. When disabled, these species are always filtered out."
+        }
+      }
+    },
+    "advanced": {
+      "title": "Advanced",
+      "description": "Processing and custom model configuration."
+    },
+    "gallery": {
+      "title": "Model Gallery",
+      "description": "Manage classifier models for bird and bat detection.",
+      "tabs": {
+        "installed": "Installed",
+        "available": "Available"
+      },
+      "loading": "Loading models...",
+      "retry": "Retry",
+      "builtIn": "Built-in",
+      "builtInDescription": "Built-in bird species classifier by the BirdNET team.",
+      "species": "{count} species",
+      "install": "Install",
+      "installing": "Installing...",
+      "remove": "Remove",
+      "removing": "Removing...",
+      "noInstalledModels": "No additional models installed. Browse the Available tab to add more classifiers.",
+      "noAvailableModels": "No additional models available for your platform.",
+      "categories": {
+        "wildlife": "Wildlife Classifiers",
+        "bird": "Bird Classifiers",
+        "bat": "Bat Classifiers"
+      },
+      "progress": {
+        "downloading": "Downloading...",
+        "verifying": "Verifying...",
+        "loading": "Loading...",
+        "complete": "Installed successfully",
+        "failed": "Failed"
+      },
+      "license": {
+        "title": "License Agreement",
+        "model": "Model",
+        "author": "Author",
+        "license": "License",
+        "commercialUse": "Commercial Use",
+        "downloadSize": "Download Size",
+        "allowed": "Allowed",
+        "notAllowed": "Not allowed",
+        "commercialUseAllowed": "Commercial use allowed",
+        "nonCommercialOnly": "Non-commercial use only",
+        "nonCommercialWarning": "This model is licensed for non-commercial use only. By installing, you agree to comply with the license terms.",
+        "acceptAndInstall": "Accept & Install"
+      },
+      "removeDialog": {
+        "title": "Remove {name}?",
+        "confirmation": "This will remove the model files from disk. Label data is retained for existing detections."
+      },
+      "errors": {
+        "catalogLoadFailed": "Failed to load model catalog",
+        "installFailed": "Failed to start model installation",
+        "removeFailed": "Failed to remove model"
+      },
+      "regionLabel": "Region",
+      "speciesLabel": "Species",
+      "reinstall": "Reinstall",
+      "reinstalling": "Reinstalling...",
+      "reinstallComplete": "Files verified successfully",
+      "geomodelBadge": "Includes BirdNET v3.0 geomodel"
     }
   },
   "restart": {

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -12,6 +12,7 @@
     "refresh": "Obnoviť",
     "delete": "Odstrániť",
     "edit": "Upraviť",
+    "enabled": "Povolené",
     "search": "Hľadať",
     "filter": "Filter",
     "sort": "Zoradiť",
@@ -659,6 +660,8 @@
       },
       "actions": {
         "menuLabel": "Akcie pre {species}",
+        "markCorrect": "Správne",
+        "markFalsePositive": "Nesprávne",
         "review": "Skontrolovať detekciu",
         "showSpecies": "Zobraziť druh",
         "ignoreSpecies": "Ignorovať druh",
@@ -764,12 +767,18 @@
     "headers": {
       "dateTime": "Dátum a čas",
       "weather": "Počasie",
+      "source": "Zdroj",
       "species": "Druh",
       "confidence": "Istota",
       "thumbnail": "Náhľad",
       "status": "Stav",
       "recording": "Nahrávka",
       "actions": "Akcie"
+    },
+    "viewToggle": {
+      "label": "Režim zobrazenia",
+      "table": "Zobrazenie tabuľky",
+      "cards": "Zobrazenie kariet"
     },
     "status": {
       "locked": "Uzamknuté"
@@ -903,11 +912,6 @@
       "loadFailed": "Nepodarilo sa načítať detekciu (Chyba {status}). Skúste obnoviť stránku.",
       "noIdProvided": "Nebolo poskytnuté žiadne ID detekcie.",
       "fetchFailed": "Nepodarilo sa načítať detekcie"
-    },
-    "viewToggle": {
-      "label": "Režim zobrazenia",
-      "table": "Zobrazenie tabuľky",
-      "cards": "Zobrazenie kariet"
     }
   },
   "species": {
@@ -1118,6 +1122,86 @@
         "detections": "Detekcie",
         "fetchFailed": "Nepodarilo sa získať štatistiky databázy"
       },
+      "dashboard": {
+        "title": "Prehľad databázy",
+        "fetchFailed": "Nepodarilo sa načítať prehľad databázy",
+        "loading": "Načítavanie...",
+        "metrics": {
+          "readLatency": "Latencia čítania",
+          "writeLatency": "Latencia zápisu",
+          "queriesPerSec": "Dotazy/sek",
+          "database": "Databáza",
+          "avg": "priemer",
+          "max": "max",
+          "lastHour": "{count} za poslednú hodinu",
+          "slowQueries": "{count} pomalých"
+        },
+        "details": {
+          "title": "Podrobnosti databázy",
+          "engine": "Motor",
+          "journal": "Denník",
+          "pageSize": "Veľkosť stránky",
+          "cacheHit": "Zásah cache",
+          "integrity": "Integrita",
+          "lastVacuum": "Posledný VACUUM"
+        },
+        "locksWal": {
+          "title": "Zámky a WAL",
+          "lockWaits": "Čakania na zámok",
+          "lockTimeouts": "Časové limity zámkov",
+          "avgWait": "Priemer čakania",
+          "busyTimeouts": "Časové limity zaneprázdnenia",
+          "walSize": "Veľkosť WAL",
+          "checkpoints": "Kontrolné body",
+          "freelistPages": "Stránky voľného zoznamu",
+          "cacheSize": "Veľkosť cache"
+        },
+        "connectionPool": {
+          "title": "Pool pripojení",
+          "poolUsage": "Využitie poolu",
+          "active": "aktívny",
+          "idle": "nečinný",
+          "waiting": "čakajúci",
+          "totalCreated": "Celkom vytvorené",
+          "connErrors": "Chyby pripojenia",
+          "threads": "Vlákna",
+          "running": "beží",
+          "cached": "v cache"
+        },
+        "innodb": {
+          "title": "InnoDB a zámky",
+          "bufferPoolHitRate": "Úspešnosť buffer poolu",
+          "bufferPoolSize": "Veľkosť buffer poolu",
+          "lockWaits": "Čakania na zámok",
+          "deadlocks": "Deadlocky",
+          "avgLockWait": "Priemer čakania na zámok",
+          "tableLocksWaited": "Čakané zámky tabuliek",
+          "tableLocksImmediate": "Okamžité zámky tabuliek"
+        },
+        "detectionRate": {
+          "title": "Miera detekcií (24h)",
+          "chartLabel": "Miera detekcií za 24 hodín",
+          "detectionsTooltip": "{count} detekcií",
+          "perHour": "/hod",
+          "min": "min",
+          "avg": "priemer",
+          "max": "max",
+          "lastBackup": "Posledná záloha",
+          "backupSize": "Veľkosť zálohy",
+          "createBackup": "Vytvoriť zálohu",
+          "mysqlHost": "Hostiteľ",
+          "mysqlBackupNote": "MySQL zálohy by mali byť spravované cez mysqldump alebo vaše MySQL administračné nástroje."
+        },
+        "tables": {
+          "title": "Tabuľky",
+          "total": "Celkom",
+          "table": "Tabuľka",
+          "engine": "Motor",
+          "rows": "Riadky",
+          "size": "Veľkosť",
+          "usage": "Využitie"
+        }
+      },
       "backup": {
         "download": "Stiahnuť zálohu",
         "downloading": "Sťahuje sa...",
@@ -1202,6 +1286,29 @@
           "calculating": "Výpočet...",
           "dirtyWriteFailed": "{count} záznamov sa nepodarilo zapísať — budú zosúladené počas validácie"
         },
+        "details": {
+          "title": "Podrobnosti databázy",
+          "detections": "{count} detekcií",
+          "lastBackup": "Posledná záloha: {date}",
+          "noBackups": "Žiadne zálohy",
+          "integrity": "Integrita: {status}"
+        },
+        "strip": {
+          "legacy": "Legacy",
+          "v2Target": "V2 (Cieľ)",
+          "active": "Aktívny",
+          "migration": "Migrácia",
+          "complete": "Dokončené",
+          "recordsMigrated": "{count} záznamov migrovaných",
+          "readyToMigrate": "Pripravené na migráciu",
+          "recordsInLegacy": "{count} záznamov v legacy",
+          "comparingRecords": "Porovnávanie počtu záznamov...",
+          "validationFailed": "Validácia zlyhala",
+          "rate": "Frekvencia",
+          "recPerSec": "{rate} záz/s",
+          "dayAvg": "~{count} / denný priemer",
+          "dayHistory": "História za 30 dní"
+        },
         "phase": {
           "indicator": "Fáza {current} z {total}: ",
           "detections": "Migrujú sa primárne detekcie",
@@ -1250,8 +1357,8 @@
           "resumeFailed": "Nepodarilo sa pokračovať v migrácii",
           "cancelFailed": "Nepodarilo sa zrušiť migráciu",
           "rollbackFailed": "Nepodarilo sa vykonať rollback migrácie",
-          "fetchFailed": "Nepodarilo sa získať stav migrácie",
-          "retryValidationFailed": "Nepodarilo sa zopakovať validáciu"
+          "retryValidationFailed": "Nepodarilo sa zopakovať validáciu",
+          "fetchFailed": "Nepodarilo sa získať stav migrácie"
         },
         "worker": {
           "running": "Worker beží",
@@ -1267,6 +1374,19 @@
           "warningsCount": "{count} varovaní",
           "running": "Prebiehajú kontroly pred migráciou...",
           "checkingStep": "Krok {current} z {total}",
+          "passedCount": "{passed}/{total} úspešných",
+          "criticalCount": "{count} kritických",
+          "warningCount": "{count} upozornení",
+          "rerun": "Spustiť znova",
+          "showDetails": "Zobraziť podrobnosti",
+          "hideDetails": "Skryť podrobnosti",
+          "status": {
+            "passed": "Úspešné",
+            "failed": "Zlyhané",
+            "error": "Chyba",
+            "warning": "Upozornenie",
+            "skipped": "Preskočené"
+          },
           "errors": {
             "fetchFailed": "Nepodarilo sa získať prerekvizity"
           },
@@ -1310,123 +1430,7 @@
             "mysql_timeout": {
               "name": "MySQL Timeout"
             }
-          },
-          "passedCount": "{passed}/{total} úspešných",
-          "criticalCount": "{count} kritických",
-          "warningCount": "{count} upozornení",
-          "rerun": "Spustiť znova",
-          "showDetails": "Zobraziť podrobnosti",
-          "hideDetails": "Skryť podrobnosti",
-          "status": {
-            "passed": "Úspešné",
-            "failed": "Zlyhané",
-            "error": "Chyba",
-            "warning": "Upozornenie",
-            "skipped": "Preskočené"
           }
-        },
-        "details": {
-          "title": "Podrobnosti databázy",
-          "detections": "{count} detekcií",
-          "lastBackup": "Posledná záloha: {date}",
-          "noBackups": "Žiadne zálohy",
-          "integrity": "Integrita: {status}"
-        },
-        "strip": {
-          "legacy": "Legacy",
-          "v2Target": "V2 (Cieľ)",
-          "active": "Aktívny",
-          "migration": "Migrácia",
-          "complete": "Dokončené",
-          "recordsMigrated": "{count} záznamov migrovaných",
-          "readyToMigrate": "Pripravené na migráciu",
-          "recordsInLegacy": "{count} záznamov v legacy",
-          "comparingRecords": "Porovnávanie počtu záznamov...",
-          "validationFailed": "Validácia zlyhala",
-          "rate": "Frekvencia",
-          "recPerSec": "{rate} záz/s",
-          "dayAvg": "~{count} / denný priemer",
-          "dayHistory": "História za 30 dní"
-        }
-      },
-      "dashboard": {
-        "title": "Prehľad databázy",
-        "fetchFailed": "Nepodarilo sa načítať prehľad databázy",
-        "loading": "Načítavanie...",
-        "metrics": {
-          "readLatency": "Latencia čítania",
-          "writeLatency": "Latencia zápisu",
-          "queriesPerSec": "Dotazy/sek",
-          "database": "Databáza",
-          "avg": "priemer",
-          "max": "max",
-          "lastHour": "{count} za poslednú hodinu",
-          "slowQueries": "{count} pomalých"
-        },
-        "details": {
-          "title": "Podrobnosti databázy",
-          "engine": "Motor",
-          "journal": "Denník",
-          "pageSize": "Veľkosť stránky",
-          "cacheHit": "Zásah cache",
-          "integrity": "Integrita",
-          "lastVacuum": "Posledný VACUUM"
-        },
-        "locksWal": {
-          "title": "Zámky a WAL",
-          "lockWaits": "Čakania na zámok",
-          "lockTimeouts": "Časové limity zámkov",
-          "avgWait": "Priemer čakania",
-          "busyTimeouts": "Časové limity zaneprázdnenia",
-          "walSize": "Veľkosť WAL",
-          "checkpoints": "Kontrolné body",
-          "freelistPages": "Stránky voľného zoznamu",
-          "cacheSize": "Veľkosť cache"
-        },
-        "connectionPool": {
-          "title": "Pool pripojení",
-          "poolUsage": "Využitie poolu",
-          "active": "aktívny",
-          "idle": "nečinný",
-          "waiting": "čakajúci",
-          "totalCreated": "Celkom vytvorené",
-          "connErrors": "Chyby pripojenia",
-          "threads": "Vlákna",
-          "running": "beží",
-          "cached": "v cache"
-        },
-        "innodb": {
-          "title": "InnoDB a zámky",
-          "bufferPoolHitRate": "Úspešnosť buffer poolu",
-          "bufferPoolSize": "Veľkosť buffer poolu",
-          "lockWaits": "Čakania na zámok",
-          "deadlocks": "Deadlocky",
-          "avgLockWait": "Priemer čakania na zámok",
-          "tableLocksWaited": "Čakané zámky tabuliek",
-          "tableLocksImmediate": "Okamžité zámky tabuliek"
-        },
-        "detectionRate": {
-          "title": "Miera detekcií (24h)",
-          "chartLabel": "Miera detekcií za 24 hodín",
-          "detectionsTooltip": "{count} detekcií",
-          "perHour": "/hod",
-          "min": "min",
-          "avg": "priemer",
-          "max": "max",
-          "lastBackup": "Posledná záloha",
-          "backupSize": "Veľkosť zálohy",
-          "createBackup": "Vytvoriť zálohu",
-          "mysqlHost": "Hostiteľ",
-          "mysqlBackupNote": "MySQL zálohy by mali byť spravované cez mysqldump alebo vaše MySQL administračné nástroje."
-        },
-        "tables": {
-          "title": "Tabuľky",
-          "total": "Celkom",
-          "table": "Tabuľka",
-          "engine": "Motor",
-          "rows": "Riadky",
-          "size": "Veľkosť",
-          "usage": "Využitie"
         }
       }
     },
@@ -1440,12 +1444,12 @@
       "available": "dost.",
       "min": "Min",
       "max": "Max",
+      "limit": "Limit",
       "tempUnavailable": "Nedostupná",
       "online": "Online",
       "uptime": "Doba behu",
       "host": "Hostiteľ",
       "model": "Model",
-      "limit": "Limit",
       "inference": "Inferencia",
       "avgTime": "Priemer",
       "noInference": "Žiadne dáta",
@@ -1459,6 +1463,30 @@
       "free": "voľné",
       "ram": "RAM"
     }
+  },
+  "terminal": {
+    "title": "Terminál",
+    "disabled": "Terminál je zakázaný",
+    "disabledDescription": "Terminál prehliadača je zakázaný. Povoľte ho v Nastavenia → Zabezpečenie pre použitie tejto funkcie.",
+    "connected": "Pripojené",
+    "disconnected": "Odpojené",
+    "connecting": "Pripája sa...",
+    "connectionError": "Pripojenie zlyhalo",
+    "connectionClosed": "Pripojenie zatvorené",
+    "securityWarning": "Upozornenie: Tento terminál poskytuje priamy prístup k shellu hostiteľského systému. Povoľte iba v dôveryhodných sieťach.",
+    "copySelection": "Kopírovať výber",
+    "expand": "Rozbaliť",
+    "collapse": "Zbaliť",
+    "fullscreen": "Celá obrazovka",
+    "exitFullscreen": "Ukončiť celú obrazovku",
+    "colorTheme": "Farebná téma",
+    "themeDark": "Tmavá",
+    "themeLight": "Svetlá",
+    "themeHighContrast": "Vysoký kontrast",
+    "detach": "Otvoriť v novom okne",
+    "detached": "Terminál je odpojený",
+    "detachedDescription": "Terminál beží v samostatnom okne. Zatvorte ho, aby ste ho vrátili sem.",
+    "reattach": "Pripojiť späť"
   },
   "analytics": {
     "title": "Prehľad",
@@ -1643,6 +1671,7 @@
     "title": "Nastavenia - BirdNET-Go",
     "loading": "Načítavajú sa nastavenia...",
     "sections": {
+      "analysis": "Analýza",
       "node": "Hlavné",
       "userinterface": "Rozhranie",
       "audio": "Zvuk",
@@ -1666,6 +1695,12 @@
       "savingAriaLabel": "Ukladajú sa zmeny...",
       "unsavedChanges": "Neuložené zmeny",
       "toolbar": "Akcie nastavení"
+    },
+    "errors": {
+      "loadFailed": "Nepodarilo sa načítať nastavenia",
+      "saveFailed": "Nepodarilo sa uložiť nastavenia",
+      "databaseStatsFailed": "Nepodarilo sa načítať štatistiky databázy",
+      "csvDownloadFailed": "Nepodarilo sa stiahnuť CSV"
     },
     "card": {
       "changed": "zmenené",
@@ -2800,6 +2835,10 @@
           "refresh": "Obnoviť zariadenia"
         }
       },
+      "noSources": {
+        "warning": "Žiadne nakonfigurované zdroje zvuku",
+        "description": "BirdNET-Go potrebuje zvukový vstup na detekciu vtákov. Nakonfigurujte aspoň jeden zdroj na karte Zvuková karta alebo Streamy."
+      },
       "soundCards": {
         "summary": "{count} zdroj(e/ov) zvukovej karty",
         "addSource": "Pridať zvukovú kartu",
@@ -2844,10 +2883,6 @@
           "recommendedSampleRate": "{rate}kHz odporúčané pre najlepšie výsledky",
           "atLeastOneModel": "Musí byť vybraný aspoň jeden model"
         }
-      },
-      "noSources": {
-        "warning": "Žiadne nakonfigurované zdroje zvuku",
-        "description": "BirdNET-Go potrebuje zvukový vstup na detekciu vtákov. Nakonfigurujte aspoň jeden zdroj na karte Zvuková karta alebo Streamy."
       },
       "audioCapture": {
         "title": "Konfigurácia zvukovej karty",
@@ -3524,6 +3559,8 @@
         "parameters": {
           "label": "Parametre",
           "helpText": "Tieto hodnoty budú odovzdané vášmu príkazu v uvedenom poradí",
+          "placeholder": "Kliknite na tlačidlá nižšie pre pridanie parametrov alebo zadajte ručne",
+          "tooltip": "Použite tlačidlá nižšie alebo zadajte priamo (oddelené čiarkou)",
           "availableTitle": "Dostupné parametre",
           "buttons": {
             "commonName": "CommonName",
@@ -3532,9 +3569,7 @@
             "time": "Čas",
             "source": "Zdroj",
             "clearParameters": "Vymazať parametre"
-          },
-          "placeholder": "Kliknite na tlačidlá nižšie pre pridanie parametrov alebo zadajte ručne",
-          "tooltip": "Použite tlačidlá nižšie alebo zadajte priamo (oddelené čiarkou)"
+          }
         },
         "executeDefaults": {
           "label": "Spustiť aj predvolené akcie (uloženie do databázy, upozornenia atď.)",
@@ -3543,6 +3578,7 @@
       },
       "add": "Pridať",
       "remove": "Odstrániť",
+      "suggestions": "Návrhy druhov",
       "addSpeciesToInclude": "Pridať druh na zahrnutie",
       "addSpeciesToIncludeLabel": "Pridať nový druh na zahrnutie",
       "addSpeciesToExclude": "Pridať druh na vylúčenie",
@@ -3685,8 +3721,7 @@
         "resetAllError": "Nepodarilo sa resetovať prahy",
         "expand": "Zobraziť históriu udalostí",
         "collapse": "Skryť históriu udalostí"
-      },
-      "suggestions": "Návrhy druhov"
+      }
     },
     "database": {
       "sqlitePlaceholder": "Zadajte cestu k databáze SQLite",
@@ -3901,12 +3936,6 @@
         }
       }
     },
-    "errors": {
-      "loadFailed": "Nepodarilo sa načítať nastavenia",
-      "saveFailed": "Nepodarilo sa uložiť nastavenia",
-      "databaseStatsFailed": "Nepodarilo sa načítať štatistiky databázy",
-      "csvDownloadFailed": "Nepodarilo sa stiahnuť CSV"
-    },
     "appearance": {
       "colorScheme": "Farebná schéma",
       "colorSchemeDescription": "Vyberte farebnú schému pre rozhranie",
@@ -4028,13 +4057,13 @@
     "labels": {
       "showPassword": "Zobraziť heslo",
       "hidePassword": "Skryť heslo",
-      "copyToClipboard": "Kopírovať do schránky",
-      "clearSelection": "Vymazať výber",
-      "selectOption": "Vyberte možnosť",
       "secretSet": "Nastaviť",
       "changeSecret": "Zmeniť",
       "cancelChange": "Zrušiť",
-      "enterNewSecret": "Zadajte novú hodnotu"
+      "enterNewSecret": "Zadajte novú hodnotu",
+      "copyToClipboard": "Kopírovať do schránky",
+      "clearSelection": "Vymazať výber",
+      "selectOption": "Vyberte možnosť"
     },
     "help": {
       "passwordStrength": "Sila hesla: {strength}",
@@ -4260,30 +4289,6 @@
       "download": "Stiahnuť"
     }
   },
-  "terminal": {
-    "title": "Terminál",
-    "disabled": "Terminál je zakázaný",
-    "disabledDescription": "Terminál prehliadača je zakázaný. Povoľte ho v Nastavenia → Zabezpečenie pre použitie tejto funkcie.",
-    "connected": "Pripojené",
-    "disconnected": "Odpojené",
-    "connecting": "Pripája sa...",
-    "connectionError": "Pripojenie zlyhalo",
-    "connectionClosed": "Pripojenie zatvorené",
-    "securityWarning": "Upozornenie: Tento terminál poskytuje priamy prístup k shellu hostiteľského systému. Povoľte iba v dôveryhodných sieťach.",
-    "copySelection": "Kopírovať výber",
-    "expand": "Rozbaliť",
-    "collapse": "Zbaliť",
-    "fullscreen": "Celá obrazovka",
-    "exitFullscreen": "Ukončiť celú obrazovku",
-    "colorTheme": "Farebná téma",
-    "themeDark": "Tmavá",
-    "themeLight": "Svetlá",
-    "themeHighContrast": "Vysoký kontrast",
-    "detach": "Otvoriť v novom okne",
-    "detached": "Terminál je odpojený",
-    "detachedDescription": "Terminál beží v samostatnom okne. Zatvorte ho, aby ste ho vrátili sem.",
-    "reattach": "Pripojiť späť"
-  },
   "quietHours": {
     "indicator": {
       "tooltip": "Tiché hodiny aktívne — {count} zdroj(e) pozastavený(é)"
@@ -4502,7 +4507,18 @@
     }
   },
   "analysis": {
+    "title": "Analýza",
+    "tabs": {
+      "settings": "Settings",
+      "models": "Models"
+    },
     "detection": {
+      "title": "Detection Settings",
+      "description": "Configure confidence thresholds and language for species classification.",
+      "confidenceThreshold": {
+        "label": "Confidence Threshold",
+        "helpText": "Minimum confidence score (0.0 - 1.0) required for a detection to be recorded."
+      },
       "batThreshold": {
         "label": "Prah detekcie netopierov",
         "helpText": "Minimálne skóre spoľahlivosti pre detekcie druhov netopierov. Platí len pre klasifikačné modely netopierov."
@@ -4518,7 +4534,95 @@
       "batUltrasonicFilter": {
         "label": "Overenie po detekcii",
         "helpText": "Keď je zapnuté, detekcie netopierov sa overujú analýzou ultrazvukových energetických vzorcov v zdrojovom zvuku. Detekcie bez charakteristík echolokácie sú označené ako nepravdepodobné."
+      },
+      "locale": {
+        "label": "Species Language",
+        "helpText": "Language used for species common names in the interface."
       }
+    },
+    "rangeFilter": {
+      "birdOnlyNote": "Range filter applies to bird classifiers only. Bat models use their own species lists.",
+      "status": {
+        "title": "Range Filter Overview",
+        "geomodelInfo": "Geomodel {version} - {species} known species",
+        "autoSelected": "Auto-selected",
+        "manual": "Manual",
+        "classifier": "Classifier",
+        "totalSpecies": "Total Species",
+        "withRangeData": "With Range Data",
+        "withoutRangeData": "Without Range Data",
+        "withRangeDataTooltip": "Species that the geomodel can evaluate for geographic probability at your location",
+        "withoutRangeDataTooltip": "Species without geographic data in the geomodel, handled by the unmapped species setting below",
+        "noFilter": "No range filter active",
+        "passUnmapped": {
+          "label": "Allow species without range data",
+          "helpText": "Allow detections of species the geomodel has no geographic data for. When disabled, these species are always filtered out."
+        }
+      }
+    },
+    "advanced": {
+      "title": "Advanced",
+      "description": "Processing and custom model configuration."
+    },
+    "gallery": {
+      "title": "Model Gallery",
+      "description": "Manage classifier models for bird and bat detection.",
+      "tabs": {
+        "installed": "Installed",
+        "available": "Available"
+      },
+      "loading": "Loading models...",
+      "retry": "Retry",
+      "builtIn": "Built-in",
+      "builtInDescription": "Built-in bird species classifier by the BirdNET team.",
+      "species": "{count} species",
+      "install": "Install",
+      "installing": "Installing...",
+      "remove": "Remove",
+      "removing": "Removing...",
+      "noInstalledModels": "No additional models installed. Browse the Available tab to add more classifiers.",
+      "noAvailableModels": "No additional models available for your platform.",
+      "categories": {
+        "wildlife": "Wildlife Classifiers",
+        "bird": "Bird Classifiers",
+        "bat": "Bat Classifiers"
+      },
+      "progress": {
+        "downloading": "Downloading...",
+        "verifying": "Verifying...",
+        "loading": "Loading...",
+        "complete": "Installed successfully",
+        "failed": "Failed"
+      },
+      "license": {
+        "title": "License Agreement",
+        "model": "Model",
+        "author": "Author",
+        "license": "License",
+        "commercialUse": "Commercial Use",
+        "downloadSize": "Download Size",
+        "allowed": "Allowed",
+        "notAllowed": "Not allowed",
+        "commercialUseAllowed": "Commercial use allowed",
+        "nonCommercialOnly": "Non-commercial use only",
+        "nonCommercialWarning": "This model is licensed for non-commercial use only. By installing, you agree to comply with the license terms.",
+        "acceptAndInstall": "Accept & Install"
+      },
+      "removeDialog": {
+        "title": "Remove {name}?",
+        "confirmation": "This will remove the model files from disk. Label data is retained for existing detections."
+      },
+      "errors": {
+        "catalogLoadFailed": "Failed to load model catalog",
+        "installFailed": "Failed to start model installation",
+        "removeFailed": "Failed to remove model"
+      },
+      "regionLabel": "Region",
+      "speciesLabel": "Species",
+      "reinstall": "Reinstall",
+      "reinstalling": "Reinstalling...",
+      "reinstallComplete": "Files verified successfully",
+      "geomodelBadge": "Includes BirdNET v3.0 geomodel"
     }
   },
   "restart": {

--- a/frontend/static/messages/sv.json
+++ b/frontend/static/messages/sv.json
@@ -12,6 +12,7 @@
     "refresh": "Uppdatera",
     "delete": "Radera",
     "edit": "Redigera",
+    "enabled": "Aktiverad",
     "search": "Sök",
     "filter": "Filter",
     "sort": "Sortera",
@@ -659,6 +660,8 @@
       },
       "actions": {
         "menuLabel": "Åtgärder för {species}",
+        "markCorrect": "Korrekt",
+        "markFalsePositive": "Felaktig",
         "review": "Granska detektering",
         "showSpecies": "Visa art",
         "ignoreSpecies": "Ignorera art",
@@ -764,6 +767,7 @@
     "headers": {
       "dateTime": "Datum och tid",
       "weather": "Väder",
+      "source": "Källa",
       "species": "Art",
       "confidence": "Konfidens",
       "thumbnail": "Miniatyrbild",
@@ -1667,6 +1671,7 @@
     "title": "Inställningar - BirdNET-Go",
     "loading": "Laddar inställningar...",
     "sections": {
+      "analysis": "Analys",
       "node": "Allmänt",
       "userinterface": "Gränssnitt",
       "audio": "Ljud",
@@ -2830,6 +2835,10 @@
           "refresh": "Uppdatera enheter"
         }
       },
+      "noSources": {
+        "warning": "Inga ljudkällor konfigurerade",
+        "description": "BirdNET-Go behöver en ljudingång för att detektera fåglar. Konfigurera minst en källa i fliken Ljudkort eller Strömmar."
+      },
       "soundCards": {
         "summary": "{count} ljudkortskälla/-or",
         "addSource": "Lägg till ljudkort",
@@ -2874,10 +2883,6 @@
           "recommendedSampleRate": "{rate}kHz rekommenderat för bästa resultat",
           "atLeastOneModel": "Minst en modell måste väljas"
         }
-      },
-      "noSources": {
-        "warning": "Inga ljudkällor konfigurerade",
-        "description": "BirdNET-Go behöver en ljudingång för att detektera fåglar. Konfigurera minst en källa i fliken Ljudkort eller Strömmar."
       },
       "audioCapture": {
         "title": "Ljudkortskonfiguration",
@@ -4052,13 +4057,13 @@
     "labels": {
       "showPassword": "Visa lösenord",
       "hidePassword": "Dölj lösenord",
-      "copyToClipboard": "Kopiera till urklipp",
-      "clearSelection": "Rensa val",
-      "selectOption": "Välj ett alternativ",
       "secretSet": "Inställd",
       "changeSecret": "Ändra",
       "cancelChange": "Avbryt",
-      "enterNewSecret": "Ange nytt värde"
+      "enterNewSecret": "Ange nytt värde",
+      "copyToClipboard": "Kopiera till urklipp",
+      "clearSelection": "Rensa val",
+      "selectOption": "Välj ett alternativ"
     },
     "help": {
       "passwordStrength": "Lösenordsstyrka: {strength}",
@@ -4159,11 +4164,11 @@
       "spectrogramLoading": "Laddar spektrogram...",
       "spectrogramLoaded": "Spektrogram laddat",
       "spectrogramLoadingAria": "Laddar spektrogram",
+      "spectrogramAlt": "Ljudspektrogram",
       "spectrogramGeneratingAria": "Genererar spektrogram",
       "generating": "Genererar...",
       "queuePosition": "Kö: {position}",
-      "loadError": "Kunde inte ladda ljud",
-      "spectrogramAlt": "Ljudspektrogram"
+      "loadError": "Kunde inte ladda ljud"
     },
     "forms": {
       "numberField": {
@@ -4502,7 +4507,18 @@
     }
   },
   "analysis": {
+    "title": "Analys",
+    "tabs": {
+      "settings": "Settings",
+      "models": "Models"
+    },
     "detection": {
+      "title": "Detection Settings",
+      "description": "Configure confidence thresholds and language for species classification.",
+      "confidenceThreshold": {
+        "label": "Confidence Threshold",
+        "helpText": "Minimum confidence score (0.0 - 1.0) required for a detection to be recorded."
+      },
       "batThreshold": {
         "label": "Tröskel för fladdermöss-detektion",
         "helpText": "Minsta konfidenspoäng för detektering av fladdermusarter. Gäller endast för klassificeringsmodeller för fladdermöss."
@@ -4518,7 +4534,95 @@
       "batUltrasonicFilter": {
         "label": "Validering efter detektion",
         "helpText": "När aktiverat valideras fladdermusdetektioner genom att analysera ultraljudsenergi i källljudet. Detektioner utan ekolokationsegenskaper markeras som osannolika."
+      },
+      "locale": {
+        "label": "Species Language",
+        "helpText": "Language used for species common names in the interface."
       }
+    },
+    "rangeFilter": {
+      "birdOnlyNote": "Range filter applies to bird classifiers only. Bat models use their own species lists.",
+      "status": {
+        "title": "Range Filter Overview",
+        "geomodelInfo": "Geomodel {version} - {species} known species",
+        "autoSelected": "Auto-selected",
+        "manual": "Manual",
+        "classifier": "Classifier",
+        "totalSpecies": "Total Species",
+        "withRangeData": "With Range Data",
+        "withoutRangeData": "Without Range Data",
+        "withRangeDataTooltip": "Species that the geomodel can evaluate for geographic probability at your location",
+        "withoutRangeDataTooltip": "Species without geographic data in the geomodel, handled by the unmapped species setting below",
+        "noFilter": "No range filter active",
+        "passUnmapped": {
+          "label": "Allow species without range data",
+          "helpText": "Allow detections of species the geomodel has no geographic data for. When disabled, these species are always filtered out."
+        }
+      }
+    },
+    "advanced": {
+      "title": "Advanced",
+      "description": "Processing and custom model configuration."
+    },
+    "gallery": {
+      "title": "Model Gallery",
+      "description": "Manage classifier models for bird and bat detection.",
+      "tabs": {
+        "installed": "Installed",
+        "available": "Available"
+      },
+      "loading": "Loading models...",
+      "retry": "Retry",
+      "builtIn": "Built-in",
+      "builtInDescription": "Built-in bird species classifier by the BirdNET team.",
+      "species": "{count} species",
+      "install": "Install",
+      "installing": "Installing...",
+      "remove": "Remove",
+      "removing": "Removing...",
+      "noInstalledModels": "No additional models installed. Browse the Available tab to add more classifiers.",
+      "noAvailableModels": "No additional models available for your platform.",
+      "categories": {
+        "wildlife": "Wildlife Classifiers",
+        "bird": "Bird Classifiers",
+        "bat": "Bat Classifiers"
+      },
+      "progress": {
+        "downloading": "Downloading...",
+        "verifying": "Verifying...",
+        "loading": "Loading...",
+        "complete": "Installed successfully",
+        "failed": "Failed"
+      },
+      "license": {
+        "title": "License Agreement",
+        "model": "Model",
+        "author": "Author",
+        "license": "License",
+        "commercialUse": "Commercial Use",
+        "downloadSize": "Download Size",
+        "allowed": "Allowed",
+        "notAllowed": "Not allowed",
+        "commercialUseAllowed": "Commercial use allowed",
+        "nonCommercialOnly": "Non-commercial use only",
+        "nonCommercialWarning": "This model is licensed for non-commercial use only. By installing, you agree to comply with the license terms.",
+        "acceptAndInstall": "Accept & Install"
+      },
+      "removeDialog": {
+        "title": "Remove {name}?",
+        "confirmation": "This will remove the model files from disk. Label data is retained for existing detections."
+      },
+      "errors": {
+        "catalogLoadFailed": "Failed to load model catalog",
+        "installFailed": "Failed to start model installation",
+        "removeFailed": "Failed to remove model"
+      },
+      "regionLabel": "Region",
+      "speciesLabel": "Species",
+      "reinstall": "Reinstall",
+      "reinstalling": "Reinstalling...",
+      "reinstallComplete": "Files verified successfully",
+      "geomodelBadge": "Includes BirdNET v3.0 geomodel"
     }
   },
   "restart": {


### PR DESCRIPTION
## Summary

- Adds 73 missing leaf-level translation keys to 6 locales (Danish, Hungarian, Italian, Latvian, Slovak, Swedish) using English fallback values
- All 6 locales now have 3,314 leaf keys, matching `en.json` exactly
- Existing translations are preserved; only gaps are filled with English text

### Missing key families added
- `analysis.gallery.*` (model gallery UI, 35 keys)
- `analysis.rangeFilter.status.*` (range filter status, 10 keys)
- `analysis.detection.*` (detection settings, 7 keys)
- `analysis.tabs.*`, `analysis.title`, `analysis.advanced.*` (5 keys)
- `dashboard.recentDetections.actions.markCorrect/markFalsePositive`
- `detections.headers.source`, `common.enabled`, `settings.sections.analysis`

### Approach
Deep-merged `en.json` as a base into each locale file so that missing keys get English fallback values while existing translations take priority. The jq merge may reorder some keys within objects; this is cosmetic and does not affect functionality.

## Test plan
- [ ] Verify UI renders correctly in each of the 6 locales (no missing key errors)
- [ ] Spot-check that existing translations (e.g., `settings.title`) remain in their original language
- [ ] Confirm model gallery page displays with English fallbacks in these locales

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Localization & Translations**
  * Updated multiple locales (DA, HU, IT, LV, SK, SV): added common "enabled", detection "source" header, recent-detections review actions ("Correct"/"Incorrect"), spectrogram alt/text and ARIA, and reordered/expanded secret/form labels.
* **New Features**
  * Added an "Analysis" settings section (confidence threshold, range/advanced options, locale) and a Model Gallery (install/remove/license, progress/errors).
* **UI**
  * Improved audio empty-state messaging and adjusted spectrogram label placement.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3076)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->