### PR TITLE
fix(api,processor): expose unlikely field in REST API, fix source display names

### DIFF
--- a/internal/analysis/processor/processor.go
+++ b/internal/analysis/processor/processor.go
@@ -618,7 +618,7 @@ func (p *Processor) startDetectionProcessor() {
 func (p *Processor) processDetections(item classifier.Results) {
 	// Add structured logging for detection pipeline entry
 	GetLogger().Debug("Processing detections from queue",
-		logger.String("source", item.Source.DisplayName),
+		logger.String("source", p.getDisplayNameForSource(item.Source.ID)),
 		logger.String("model_id", item.ModelID),
 		logger.Time("start_time", item.StartTime),
 		logger.Int("results_count", len(item.Results)),
@@ -693,7 +693,7 @@ func (p *Processor) processDetections(item classifier.Results) {
 			GetLogger().Info("Created new pending detection",
 				logger.String("species", commonName),
 				logger.Float64("confidence", confidence),
-				logger.String("source", item.Source.DisplayName),
+				logger.String("source", p.getDisplayNameForSource(item.Source.ID)),
 				logger.String("model_id", item.ModelID),
 				logger.Time("flush_deadline", now.Add(detectionWindow)),
 				logger.String("operation", "create_pending_detection"))
@@ -813,7 +813,8 @@ func (p *Processor) applyUltrasonicFilter(settings *conf.Settings, item classifi
 		return
 	}
 
-	sourceRate := p.resolveAudioSource(item.Source).SampleRate
+	resolved := p.resolveAudioSource(item.Source)
+	sourceRate := resolved.SampleRate
 	if sourceRate <= 0 || sourceRate <= filterCfg.FrequencySplitHz*2 {
 		return
 	}
@@ -824,30 +825,30 @@ func (p *Processor) applyUltrasonicFilter(settings *conf.Settings, item classifi
 
 	samples := convert.BytesToFloat64PCM16(item.PCMdata)
 	cv, ok := ultrasonic.ComputeUSFrameCV(samples, sourceRate, filterCfg)
+	sourceName := resolved.DisplayName
 	if !ok {
 		GetLogger().Debug("ultrasonic filter: insufficient data for CV computation",
-			logger.String("source", item.Source.DisplayName),
+			logger.String("source", sourceName),
 			logger.Int("sample_count", len(samples)),
 			logger.Int("sample_rate", sourceRate))
 		return
 	}
 
 	unlikely := ultrasonic.IsUnlikely(cv, filterCfg)
-	GetLogger().Debug("ultrasonic validation filter result",
+	logFields := []logger.Field{
 		logger.Float64("us_frame_cv", cv),
 		logger.Float64("threshold", filterCfg.CVThreshold),
 		logger.Bool("unlikely", unlikely),
-		logger.String("source", item.Source.DisplayName),
-		logger.Int("detections", len(detections)))
-
+		logger.String("source", sourceName),
+		logger.Int("detections", len(detections)),
+	}
 	if unlikely {
+		GetLogger().Info("ultrasonic validation: detections tagged unlikely", logFields...)
 		for i := range detections {
 			detections[i].Result.Unlikely = true
 		}
-		GetLogger().Info("bat detections tagged as unlikely by ultrasonic filter",
-			logger.Float64("us_frame_cv", cv),
-			logger.String("source", item.Source.DisplayName),
-			logger.Int("detections", len(detections)))
+	} else {
+		GetLogger().Debug("ultrasonic validation filter result", logFields...)
 	}
 }
 
@@ -1195,7 +1196,7 @@ func (p *Processor) handleDogDetection(settings *conf.Settings, item classifier.
 		GetLogger().Info("dog detection filtered",
 			logger.Float32("confidence", result.Confidence),
 			logger.Float32("threshold", float32(settings.Realtime.DogBarkFilter.Confidence)),
-			logger.String("source", item.Source.DisplayName),
+			logger.String("source", p.getDisplayNameForSource(item.Source.ID)),
 			logger.String("operation", "dog_bark_filter"))
 		p.detectionMutex.Lock()
 		p.LastDogDetection[item.Source.ID] = item.StartTime
@@ -1213,7 +1214,7 @@ func (p *Processor) handleHumanDetection(settings *conf.Settings, item classifie
 		GetLogger().Info("human detection filtered",
 			logger.Float32("confidence", result.Confidence),
 			logger.Float32("threshold", float32(settings.Realtime.PrivacyFilter.Confidence)),
-			logger.String("source", item.Source.DisplayName),
+			logger.String("source", p.getDisplayNameForSource(item.Source.ID)),
 			logger.String("operation", "privacy_filter"))
 		// put human detection timestamp into LastHumanDetection map. This is used to discard
 		// bird detections if a human vocalization is detected after the first detection

--- a/internal/api/v2/detections.go
+++ b/internal/api/v2/detections.go
@@ -171,6 +171,7 @@ type DetectionResponse struct {
 	Confidence         float64           `json:"confidence"`
 	Verified           string            `json:"verified"`
 	Locked             bool              `json:"locked"`
+	Unlikely           bool              `json:"unlikely,omitempty"`
 	Comments           []CommentResponse `json:"comments,omitempty"`
 	Weather            *WeatherInfo      `json:"weather,omitempty"`
 	TimeOfDay          string            `json:"timeOfDay,omitempty"`
@@ -653,6 +654,7 @@ func (c *Controller) noteToDetectionResponse(note *datastore.Note, includeWeathe
 		CommonName:     note.CommonName,
 		Confidence:     note.Confidence,
 		Locked:         note.Locked,
+		Unlikely:       note.Unlikely,
 	}
 
 	// populate source info if available


### PR DESCRIPTION
## Summary
- Add missing `unlikely` field to the REST API `DetectionResponse` struct and `noteToDetectionResponse()` mapper, fixing the bat detection unlikely badge never showing in the UI
- Replace all raw `item.Source.DisplayName` usages in the processor with `getDisplayNameForSource()` for proper user-configured name resolution and RTSP credential sanitization in logs
- Consolidate ultrasonic filter logging: Info when detections are tagged unlikely, Debug for routine results (eliminates redundant duplicate log and log noise)

## Context
The ultrasonic validation filter (PR #3072) correctly computes US frame CV and tags bat false positives as unlikely in the database. However, the REST API detection endpoints used a separate `DetectionResponse` struct that was never updated with the `Unlikely` field. The SSE and DTO paths already had it, but the main `/api/v2/detections` endpoints did not, so the frontend badge never rendered.

Additionally, processor log messages used raw `item.Source.DisplayName` which at that pipeline stage contains internal IDs (e.g., `audio_card_23c3adc8`) rather than user-configured names (e.g., `Äänikortti`).

## Test plan
- [x] `go build` compiles cleanly
- [x] `golangci-lint run` passes with zero issues
- [x] 679 processor tests pass with `-race`
- [x] 1926 API v2 tests pass (1 pre-existing failure in unrelated `TestDashboardLayoutWidthPersistence`)
- [x] 11 ultrasonic filter unit tests pass
- [ ] Verify `GET /api/v2/detections/:id` response includes `"unlikely": true` for tagged detections
- [ ] Verify log source names show user-configured display names

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Detection API responses now include an "Unlikely" field to indicate whether a detection is marked as unlikely.

* **Improvements**
  * Enhanced detection logging with improved source identification and handling of unlikely detections.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3079)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->