### PR TITLE
feat(processor,frontend): add unlikely badge to detail page, auto-comment on unlikely detections

### DIFF
--- a/frontend/src/lib/desktop/components/modals/SpeciesBadges.svelte
+++ b/frontend/src/lib/desktop/components/modals/SpeciesBadges.svelte
@@ -98,7 +98,7 @@
 
   <!-- Lock Status Badge -->
   {#if detection.locked}
-    <span class={`badge ${badgeSize} badge-warning gap-1`}>
+    <span class={`badge ${badgeSize} ${gapSize} badge-warning`}>
       <svg
         xmlns="http://www.w3.org/2000/svg"
         fill="none"
@@ -119,7 +119,7 @@
 
   <!-- Unlikely Badge -->
   {#if detection.unlikely}
-    <span class={`badge ${badgeSize} badge-warning gap-1`}>
+    <span class={`badge ${badgeSize} ${gapSize} badge-warning`}>
       <CircleHelp class={iconSize} />
       {t('common.review.status.unlikely')}
     </span>

--- a/frontend/src/lib/desktop/components/modals/SpeciesBadges.svelte
+++ b/frontend/src/lib/desktop/components/modals/SpeciesBadges.svelte
@@ -17,7 +17,7 @@
 -->
 <script lang="ts">
   import { t } from '$lib/i18n';
-  import { CircleCheck, X } from '@lucide/svelte';
+  import { CircleCheck, CircleHelp, X } from '@lucide/svelte';
   import type { Detection } from '$lib/types/detection.types';
 
   interface Props {
@@ -114,6 +114,14 @@
         />
       </svg>
       {t('detections.status.locked')}
+    </span>
+  {/if}
+
+  <!-- Unlikely Badge -->
+  {#if detection.unlikely}
+    <span class={`badge ${badgeSize} badge-warning gap-1`}>
+      <CircleHelp class={iconSize} />
+      {t('common.review.status.unlikely')}
     </span>
   {/if}
 </div>

--- a/internal/analysis/processor/actions_database.go
+++ b/internal/analysis/processor/actions_database.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strconv"
 	"time"
 
 	"github.com/tphakala/birdnet-go/internal/audiocore/convert"
@@ -149,6 +150,21 @@ func (a *DatabaseAction) ExecuteContext(ctx context.Context, _ any) error {
 	// Share the database ID with downstream actions (MQTT, SSE) immediately.
 	if a.DetectionCtx != nil {
 		a.DetectionCtx.NoteID.Store(uint64(a.Result.ID))
+	}
+
+	// Add an explanatory comment when the ultrasonic validation filter tagged this detection as unlikely.
+	if a.Result.Unlikely && a.Result.ID != 0 && a.Repo != nil {
+		locale := a.Settings.Realtime.Dashboard.Locale
+		comment := formatUnlikelyComment(locale, a.Result.UltrasonicCV, a.Result.UltrasonicCVThreshold)
+		noteID := strconv.FormatUint(uint64(a.Result.ID), 10)
+		if err := a.Repo.AddComment(ctx, noteID, comment); err != nil {
+			GetLogger().Warn("failed to add unlikely comment to detection",
+				logger.String("detection_id", a.CorrelationID),
+				logger.Uint64("note_id", uint64(a.Result.ID)),
+				logger.String("species", a.Result.Species.CommonName),
+				logger.Error(err),
+				logger.String("operation", "unlikely_comment"))
+		}
 	}
 
 	// After successful save, publish detection event to the event bus.

--- a/internal/analysis/processor/processor.go
+++ b/internal/analysis/processor/processor.go
@@ -846,6 +846,8 @@ func (p *Processor) applyUltrasonicFilter(settings *conf.Settings, item classifi
 		GetLogger().Info("ultrasonic validation: detections tagged unlikely", logFields...)
 		for i := range detections {
 			detections[i].Result.Unlikely = true
+			detections[i].Result.UltrasonicCV = cv
+			detections[i].Result.UltrasonicCVThreshold = filterCfg.CVThreshold
 		}
 	} else {
 		GetLogger().Debug("ultrasonic validation filter result", logFields...)

--- a/internal/analysis/processor/unlikely_comments.go
+++ b/internal/analysis/processor/unlikely_comments.go
@@ -1,0 +1,40 @@
+package processor
+
+import "fmt"
+
+// unlikelyCommentTemplates maps UI locale codes to format strings for the
+// automatic comment added when the ultrasonic validation filter tags a bat
+// detection as unlikely. The two format verbs are CV value (%.3f) and
+// threshold (%.2f).
+//
+//nolint:misspell // Foreign language translations; false positives from English spell checker.
+var unlikelyCommentTemplates = map[string]string{
+	"da": "Ultralydsvalidering: lav tidsmæssig variation i ultralydsfrekvensområdet (CV: %.3f, tærskel: %.2f). Ingen signifikant flagermusekkolokalisering detekteret i lyden.",
+	"de": "Ultraschallvalidierung: geringe zeitliche Variabilität im Ultraschallfrequenzbereich (CV: %.3f, Schwellenwert: %.2f). Keine signifikante Fledermaus-Echoortung im Audio erkannt.",
+	"en": "Ultrasonic validation: low temporal variability in ultrasonic frequency range (CV: %.3f, threshold: %.2f). No significant bat echolocation activity detected in the audio.",
+	"es": "Validación ultrasónica: baja variabilidad temporal en el rango de frecuencia ultrasónica (CV: %.3f, umbral: %.2f). No se detectó actividad significativa de ecolocalización de murciélagos en el audio.",
+	"fi": "Ultraäänivalidointi: matala ajallinen vaihtelu ultraäänitaajuusalueella (CV: %.3f, kynnys: %.2f). Merkittävää lepakon kaikuluotaustoimintaa ei havaittu äänessä.",
+	"fr": "Validation ultrasonique : faible variabilité temporelle dans la plage de fréquences ultrasoniques (CV : %.3f, seuil : %.2f). Aucune activité significative d'écholocalisation de chauve-souris détectée dans l'audio.",
+	"hu": "Ultrahangos validáció: alacsony időbeli variabilitás az ultrahang-frekvenciatartományban (CV: %.3f, küszöb: %.2f). Nem észlelhető jelentős denevér-echolokációs tevékenység a hangfelvételben.",
+	"it": "Validazione ultrasonica: bassa variabilità temporale nella gamma di frequenze ultrasoniche (CV: %.3f, soglia: %.2f). Nessuna attività significativa di ecolocalizzazione di pipistrelli rilevata nell'audio.",
+	"lv": "Ultraskaņas validācija: zema laiciskā mainība ultraskaņas frekvenču diapazonā (CV: %.3f, slieksnis: %.2f). Audio nav konstatēta nozīmīga sikspārņu eholokācijas aktivitāte.",
+	"nl": "Ultrasone validatie: lage temporele variabiliteit in het ultrasone frequentiebereik (CV: %.3f, drempel: %.2f). Geen significante echolocatie-activiteit van vleermuizen gedetecteerd in de audio.",
+	"pl": "Walidacja ultradźwiękowa: niska zmienność czasowa w zakresie częstotliwości ultradźwiękowych (CV: %.3f, próg: %.2f). Nie wykryto znaczącej aktywności echolokacyjnej nietoperzy w nagraniu.",
+	"pt": "Validação ultrassônica: baixa variabilidade temporal na faixa de frequência ultrassônica (CV: %.3f, limiar: %.2f). Nenhuma atividade significativa de ecolocalização de morcegos detectada no áudio.",
+	"sk": "Ultrazvuková validácia: nízka časová variabilita v ultrazvukovom frekvenčnom rozsahu (CV: %.3f, prah: %.2f). V zvukovom zázname nebola zistená žiadna významná echolokačná aktivita netopierov.",
+	"sv": "Ultraljudsvalidering: låg tidsmässig variabilitet i ultraljudsfrekvensområdet (CV: %.3f, tröskel: %.2f). Ingen signifikant ekolokaliseringsaktivitet från fladdermöss detekterad i ljudet.",
+}
+
+// defaultUnlikelyCommentLocale is the fallback locale when the configured
+// dashboard locale has no translation.
+const defaultUnlikelyCommentLocale = "en"
+
+// formatUnlikelyComment returns a localized comment explaining why a detection
+// was tagged as unlikely by the ultrasonic validation filter.
+func formatUnlikelyComment(locale string, cv, threshold float64) string {
+	tmpl, ok := unlikelyCommentTemplates[locale]
+	if !ok {
+		tmpl = unlikelyCommentTemplates[defaultUnlikelyCommentLocale]
+	}
+	return fmt.Sprintf(tmpl, cv, threshold)
+}

--- a/internal/detection/result.go
+++ b/internal/detection/result.go
@@ -48,8 +48,10 @@ type Result struct {
 	Unlikely bool // Tagged by the ultrasonic validation filter when source audio lacks bat echolocation characteristics
 
 	// Runtime-only data (not persisted)
-	Occurrence         float64                       // Probability 0-1 based on location/time/season
-	ModelContributions map[string]ResultModelContrib // Per-model detection data from cross-model consensus, keyed by model ID
+	Occurrence            float64                       // Probability 0-1 based on location/time/season
+	ModelContributions    map[string]ResultModelContrib // Per-model detection data from cross-model consensus, keyed by model ID
+	UltrasonicCV          float64                       // US frame CV value from validation filter (for comment generation)
+	UltrasonicCVThreshold float64                       // CV threshold used by validation filter (for comment generation)
 
 	// Review status (populated from DB relations when loaded)
 	Verified string


### PR DESCRIPTION
## Summary

- Add the "unlikely" badge to the detection detail page (`SpeciesBadges.svelte`) so the validation status is visible when viewing individual detections, not just in list views
- Automatically add a localized explanatory comment when the ultrasonic validation filter tags a bat detection as unlikely, explaining the low temporal variability in the ultrasonic frequency range with the measured CV value and threshold
- Support all 14 UI locales (da, de, en, es, fi, fr, hu, it, lv, nl, pl, pt, sk, sv) with English fallback for the auto-generated comment
- Carry the CV value and threshold through the detection pipeline via runtime-only fields on `detection.Result` for comment generation

## Changes

- `SpeciesBadges.svelte`: Add CircleHelp icon import and unlikely badge with warning styling
- `detection/result.go`: Add `UltrasonicCV` and `UltrasonicCVThreshold` runtime-only fields
- `processor/processor.go`: Set CV/threshold fields alongside `Unlikely = true` in `applyUltrasonicFilter()`
- `processor/unlikely_comments.go`: New file with localized comment templates for all 14 locales
- `processor/actions_database.go`: After saving an unlikely detection, add a localized comment via `Repo.AddComment()`

## Test Plan

- [x] `go test -race ./internal/detection/...` (14 tests pass)
- [x] `go test -race ./internal/analysis/processor/...` (679 tests pass)
- [x] `golangci-lint run -v` (clean, 0 issues)
- [x] Frontend typecheck passes
- [ ] Verify unlikely badge appears on detection detail page for detection #363786
- [ ] Verify auto-generated comment appears in the Notes tab

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detection results now show an "Unlikely" badge when validation marks a detection as unlikely.
  * Validation details (computed score and threshold) are recorded as non-blocking comments on flagged detections for review.

* **Style**
  * Badge spacing adjusted so layout spacing is consistent across badges.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3082)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->