### PR TITLE
fix(api,i18n): locale-aware species names and BirdNET geomodel attribution

### DIFF
--- a/frontend/static/messages/da.json
+++ b/frontend/static/messages/da.json
@@ -4543,8 +4543,8 @@
     "rangeFilter": {
       "birdOnlyNote": "Range filter applies to bird classifiers only. Bat models use their own species lists.",
       "status": {
-        "title": "Range Filter Overview",
-        "geomodelInfo": "Geomodel {version} - {species} known species",
+        "title": "Områdefilter oversigt",
+        "geomodelInfo": "BirdNET Geomodel {version} - {species} kendte arter",
         "autoSelected": "Auto-selected",
         "manual": "Manual",
         "classifier": "Classifier",

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -4544,7 +4544,7 @@
       "birdOnlyNote": "Range filter applies to bird classifiers only. Bat models use their own species lists.",
       "status": {
         "title": "Gebietsfilter-Übersicht",
-        "geomodelInfo": "Geomodell {version} - {species} bekannte Arten",
+        "geomodelInfo": "BirdNET-Geomodell {version} - {species} bekannte Arten",
         "autoSelected": "Automatisch ausgewählt",
         "manual": "Manuell",
         "classifier": "Klassifikator",

--- a/frontend/static/messages/en.json
+++ b/frontend/static/messages/en.json
@@ -4544,7 +4544,7 @@
       "birdOnlyNote": "Range filter applies to bird classifiers only. Bat models use their own species lists.",
       "status": {
         "title": "Range Filter Overview",
-        "geomodelInfo": "Geomodel {version} - {species} known species",
+        "geomodelInfo": "BirdNET Geomodel {version} - {species} known species",
         "autoSelected": "Auto-selected",
         "manual": "Manual",
         "classifier": "Classifier",

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -4544,7 +4544,7 @@
       "birdOnlyNote": "Range filter applies to bird classifiers only. Bat models use their own species lists.",
       "status": {
         "title": "Resumen del filtro de rango",
-        "geomodelInfo": "Geomodelo {version} - {species} especies conocidas",
+        "geomodelInfo": "BirdNET Geomodelo {version} - {species} especies conocidas",
         "autoSelected": "Seleccionado automáticamente",
         "manual": "Manual",
         "classifier": "Clasificador",

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -4544,7 +4544,7 @@
       "birdOnlyNote": "Range filter applies to bird classifiers only. Bat models use their own species lists.",
       "status": {
         "title": "Aluesuodattimen yhteenveto",
-        "geomodelInfo": "Geomalli {version} - {species} tunnettua lajia",
+        "geomodelInfo": "BirdNET-geomalli {version} - {species} tunnettua lajia",
         "autoSelected": "Automaattisesti valittu",
         "manual": "Manuaalinen",
         "classifier": "Luokittelija",

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -4544,7 +4544,7 @@
       "birdOnlyNote": "Range filter applies to bird classifiers only. Bat models use their own species lists.",
       "status": {
         "title": "Aperçu du filtre de zone",
-        "geomodelInfo": "Géomodèle {version} - {species} espèces connues",
+        "geomodelInfo": "BirdNET Géomodèle {version} - {species} espèces connues",
         "autoSelected": "Sélectionné automatiquement",
         "manual": "Manuel",
         "classifier": "Classificateur",

--- a/frontend/static/messages/hu.json
+++ b/frontend/static/messages/hu.json
@@ -4543,8 +4543,8 @@
     "rangeFilter": {
       "birdOnlyNote": "Range filter applies to bird classifiers only. Bat models use their own species lists.",
       "status": {
-        "title": "Range Filter Overview",
-        "geomodelInfo": "Geomodel {version} - {species} known species",
+        "title": "Területszűrő áttekintés",
+        "geomodelInfo": "BirdNET Geomodell {version} - {species} ismert faj",
         "autoSelected": "Auto-selected",
         "manual": "Manual",
         "classifier": "Classifier",

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -4543,8 +4543,8 @@
     "rangeFilter": {
       "birdOnlyNote": "Range filter applies to bird classifiers only. Bat models use their own species lists.",
       "status": {
-        "title": "Range Filter Overview",
-        "geomodelInfo": "Geomodel {version} - {species} known species",
+        "title": "Panoramica filtro di zona",
+        "geomodelInfo": "BirdNET Geomodello {version} - {species} specie conosciute",
         "autoSelected": "Auto-selected",
         "manual": "Manual",
         "classifier": "Classifier",

--- a/frontend/static/messages/lv.json
+++ b/frontend/static/messages/lv.json
@@ -4543,8 +4543,8 @@
     "rangeFilter": {
       "birdOnlyNote": "Range filter applies to bird classifiers only. Bat models use their own species lists.",
       "status": {
-        "title": "Range Filter Overview",
-        "geomodelInfo": "Geomodel {version} - {species} known species",
+        "title": "Diapazona filtra pārskats",
+        "geomodelInfo": "BirdNET Geomodels {version} - {species} zināmas sugas",
         "autoSelected": "Auto-selected",
         "manual": "Manual",
         "classifier": "Classifier",

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -4544,7 +4544,7 @@
       "birdOnlyNote": "Range filter applies to bird classifiers only. Bat models use their own species lists.",
       "status": {
         "title": "Gebiedsfilter overzicht",
-        "geomodelInfo": "Geomodel {version} - {species} bekende soorten",
+        "geomodelInfo": "BirdNET Geomodel {version} - {species} bekende soorten",
         "autoSelected": "Automatisch geselecteerd",
         "manual": "Handmatig",
         "classifier": "Classificator",

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -4544,7 +4544,7 @@
       "birdOnlyNote": "Range filter applies to bird classifiers only. Bat models use their own species lists.",
       "status": {
         "title": "Przegląd filtra zasięgu",
-        "geomodelInfo": "Geomodel {version} - {species} znanych gatunków",
+        "geomodelInfo": "BirdNET Geomodel {version} - {species} znanych gatunków",
         "autoSelected": "Wybrano automatycznie",
         "manual": "Ręczny",
         "classifier": "Klasyfikator",

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -4544,7 +4544,7 @@
       "birdOnlyNote": "Range filter applies to bird classifiers only. Bat models use their own species lists.",
       "status": {
         "title": "Resumo do filtro de alcance",
-        "geomodelInfo": "Geomodelo {version} - {species} espécies conhecidas",
+        "geomodelInfo": "BirdNET Geomodelo {version} - {species} espécies conhecidas",
         "autoSelected": "Selecionado automaticamente",
         "manual": "Manual",
         "classifier": "Classificador",

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -4543,8 +4543,8 @@
     "rangeFilter": {
       "birdOnlyNote": "Range filter applies to bird classifiers only. Bat models use their own species lists.",
       "status": {
-        "title": "Range Filter Overview",
-        "geomodelInfo": "Geomodel {version} - {species} known species",
+        "title": "Prehľad filtra rozsahu",
+        "geomodelInfo": "BirdNET Geomodel {version} - {species} známych druhov",
         "autoSelected": "Auto-selected",
         "manual": "Manual",
         "classifier": "Classifier",

--- a/frontend/static/messages/sv.json
+++ b/frontend/static/messages/sv.json
@@ -4543,8 +4543,8 @@
     "rangeFilter": {
       "birdOnlyNote": "Range filter applies to bird classifiers only. Bat models use their own species lists.",
       "status": {
-        "title": "Range Filter Overview",
-        "geomodelInfo": "Geomodel {version} - {species} known species",
+        "title": "Områdesfilter översikt",
+        "geomodelInfo": "BirdNET Geomodell {version} - {species} kända arter",
         "autoSelected": "Auto-selected",
         "manual": "Manual",
         "classifier": "Classifier",

--- a/internal/api/v2/range.go
+++ b/internal/api/v2/range.go
@@ -75,6 +75,14 @@ func (c *Controller) getBirdNETInstance() (*classifier.Orchestrator, error) {
 	return instance, nil
 }
 
+// currentLocale returns the BirdNET locale from the current settings.
+func (c *Controller) currentLocale() string {
+	c.settingsMutex.RLock()
+	locale := conf.CurrentOrFallback(c.Settings).BirdNET.Locale
+	c.settingsMutex.RUnlock()
+	return locale
+}
+
 // buildTestSettings creates a settings snapshot with the given test coordinates
 // and threshold for range filter testing. The snapshot is a clone of the
 // current settings with only the test values overridden, so it can be passed
@@ -91,9 +99,22 @@ func (c *Controller) buildTestSettings(lat, lon float64, threshold float32) *con
 	return testSnapshot
 }
 
+// resolveLocalizedName returns a locale-appropriate common name for the given
+// species. It tries the name resolver first; if that returns empty it falls
+// back to the common name parsed from the label string.
+func resolveLocalizedName(resolver *classifier.Orchestrator, locale string, sp detection.Species) string {
+	if resolver != nil && locale != "" {
+		if resolved := resolver.ResolveName(sp.ScientificName, locale); resolved != "" {
+			return resolved
+		}
+	}
+	return sp.CommonName
+}
+
 // convertSpeciesScores converts classifier.SpeciesScore entries to the API
-// response format with probability score pointers.
-func convertSpeciesScores(scores []classifier.SpeciesScore) []RangeFilterSpecies {
+// response format with probability score pointers. When resolver and locale
+// are provided, common names are resolved to the user's locale.
+func convertSpeciesScores(scores []classifier.SpeciesScore, resolver *classifier.Orchestrator, locale string) []RangeFilterSpecies {
 	species := make([]RangeFilterSpecies, 0, len(scores))
 	for _, s := range scores {
 		sp := detection.ParseSpeciesString(s.Label)
@@ -101,7 +122,7 @@ func convertSpeciesScores(scores []classifier.SpeciesScore) []RangeFilterSpecies
 		species = append(species, RangeFilterSpecies{
 			Label:          s.Label,
 			ScientificName: sp.ScientificName,
-			CommonName:     sp.CommonName,
+			CommonName:     resolveLocalizedName(resolver, locale, sp),
 			Score:          &score,
 		})
 	}
@@ -109,14 +130,16 @@ func convertSpeciesScores(scores []classifier.SpeciesScore) []RangeFilterSpecies
 }
 
 // convertLabels converts string labels to the API response format without scores.
-func convertLabels(labels []string) []RangeFilterSpecies {
+// When resolver and locale are provided, common names are resolved to the
+// user's locale.
+func convertLabels(labels []string, resolver *classifier.Orchestrator, locale string) []RangeFilterSpecies {
 	species := make([]RangeFilterSpecies, 0, len(labels))
 	for _, label := range labels {
 		sp := detection.ParseSpeciesString(label)
 		species = append(species, RangeFilterSpecies{
 			Label:          label,
 			ScientificName: sp.ScientificName,
-			CommonName:     sp.CommonName,
+			CommonName:     resolveLocalizedName(resolver, locale, sp),
 		})
 	}
 	return species
@@ -252,6 +275,7 @@ func (c *Controller) GetRangeFilterSpeciesScores(ctx echo.Context) error {
 	settings := conf.CurrentOrFallback(c.Settings)
 	lat := settings.BirdNET.Latitude
 	lon := settings.BirdNET.Longitude
+	locale := settings.BirdNET.Locale
 	c.settingsMutex.RUnlock()
 
 	// Override with query params if provided
@@ -301,7 +325,7 @@ func (c *Controller) GetRangeFilterSpeciesScores(ctx echo.Context) error {
 		return c.HandleError(ctx, err, "Failed to get species scores", http.StatusInternalServerError)
 	}
 
-	speciesList := convertSpeciesScores(speciesScores)
+	speciesList := convertSpeciesScores(speciesScores, birdnetInstance, locale)
 
 	response := RangeFilterScoresResponse{
 		Species:   speciesList,
@@ -358,7 +382,9 @@ func (c *Controller) GetRangeFilterSpeciesList(ctx echo.Context) error {
 	settings := conf.CurrentOrFallback(c.Settings)
 	c.settingsMutex.RUnlock()
 	includedSpecies := settings.GetIncludedSpecies()
-	speciesList := convertLabels(includedSpecies)
+
+	birdnetInstance, _ := c.getBirdNETInstance()
+	speciesList := convertLabels(includedSpecies, birdnetInstance, settings.BirdNET.Locale)
 
 	// Extract taxonomy groups from species list via taxonomy DB
 	var genera []string
@@ -487,7 +513,7 @@ func (c *Controller) TestRangeFilter(ctx echo.Context) error {
 		return c.HandleError(ctx, err, "Failed to get probable species", http.StatusInternalServerError)
 	}
 
-	speciesList := convertSpeciesScores(speciesScores)
+	speciesList := convertSpeciesScores(speciesScores, birdnetInstance, c.currentLocale())
 
 	response := RangeFilterTestResponse{
 		Species:   speciesList,
@@ -592,7 +618,8 @@ func (c *Controller) GetRangeFilterSpeciesCSV(ctx echo.Context) error {
 		settings := conf.CurrentOrFallback(c.Settings)
 		c.settingsMutex.RUnlock()
 
-		speciesList = convertLabels(settings.GetIncludedSpecies())
+		birdnetInstance, _ := c.getBirdNETInstance()
+		speciesList = convertLabels(settings.GetIncludedSpecies(), birdnetInstance, settings.BirdNET.Locale)
 		location = Location{
 			Latitude:  settings.BirdNET.Latitude,
 			Longitude: settings.BirdNET.Longitude,
@@ -641,7 +668,7 @@ func (c *Controller) getTestSpeciesList(req RangeFilterTestRequest) ([]RangeFilt
 		return nil, Location{}, 0, err
 	}
 
-	speciesList := convertSpeciesScores(speciesScores)
+	speciesList := convertSpeciesScores(speciesScores, birdnetInstance, c.currentLocale())
 
 	location := Location{
 		Latitude:  req.Latitude,

--- a/internal/classifier/birdnet.go
+++ b/internal/classifier/birdnet.go
@@ -1294,8 +1294,13 @@ func (bn *BirdNET) PrimaryRangeFilterCoverage() (geomodel *GeomodelStatus, prima
 		primary.WithoutRangeData = mrf.numClassifier - mrf.mappedCount
 		geoLabels = mrf.geomodelLabels
 
+		version := rf.Model
+		if version == "v3" {
+			version = "v3.0"
+		}
+
 		geomodel = &GeomodelStatus{
-			Version:      rf.Model,
+			Version:      version,
 			TotalSpecies: mrf.inner.NumSpecies(),
 		}
 	}

--- a/internal/classifier/birdnet_test.go
+++ b/internal/classifier/birdnet_test.go
@@ -259,7 +259,7 @@ func TestPrimaryRangeFilterCoverage_WithMappedFilter(t *testing.T) {
 	geomodel, primary, geoLabels, autoSelected := bn.PrimaryRangeFilterCoverage()
 
 	require.NotNil(t, geomodel)
-	assert.Equal(t, "v3", geomodel.Version)
+	assert.Equal(t, "v3.0", geomodel.Version)
 	assert.Equal(t, len(geomodelLabels), geomodel.TotalSpecies)
 	assert.True(t, geomodel.AutoSelected)
 	assert.True(t, autoSelected)
@@ -344,7 +344,7 @@ func TestRangeFilterStatus_PerClassifierCoverage(t *testing.T) {
 	resp := orch.RangeFilterStatus()
 
 	require.NotNil(t, resp.Geomodel)
-	assert.Equal(t, "v3", resp.Geomodel.Version)
+	assert.Equal(t, "v3.0", resp.Geomodel.Version)
 	assert.Equal(t, len(geomodelLabels), resp.Geomodel.TotalSpecies)
 	assert.True(t, resp.Geomodel.AutoSelected)
 


### PR DESCRIPTION
## Summary

- Species common names in range filter API responses now use the user's configured locale instead of always returning English names from the geomodel labels file. The `convertSpeciesScores()` and `convertLabels()` helpers use `Orchestrator.ResolveName()` with the TaxonomyResolver chain (29 languages), falling back to the label's English common name when no translation is available.
- Restored "BirdNET" attribution in the geomodel display string across all 14 locale files (regression from PR #3075 which dropped it).
- Backend maps internal `"v3"` config value to `"v3.0"` for display in the `GeomodelStatus` API response, so the UI shows "BirdNET Geomodel v3.0" instead of "Geomodel v3".
- Translated the Range Filter Overview title and geomodel info string for 6 newer locales (da, hu, it, lv, sk, sv) that had untranslated English fallbacks.

## Test Plan

- [x] `go build ./...` passes
- [x] `golangci-lint run -v` clean
- [x] `go test -race ./internal/classifier/` passes (543 tests)
- [x] `go test -race ./internal/api/v2/` passes
- [x] Updated 2 test assertions for v3 -> v3.0 version mapping

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved and standardized Range Filter localization across 14 languages with consistent "BirdNET" branding in geomodel information.
  * Normalized geomodel version format to display as "v3.0" instead of "v3" for clarity.

* **Improvements**
  * API responses now return localized common names for species across Range Filter endpoints.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3083)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->