### PR TITLE
fix(analysis): make buffer overrun monitor model-aware

### DIFF
--- a/internal/analysis/process.go
+++ b/internal/analysis/process.go
@@ -255,23 +255,21 @@ func ProcessData(ctx context.Context, bn *classifier.Orchestrator, bufMgr *buffe
 		}
 	}
 
-	// Get the current settings
-	settings := conf.Setting()
+	// Derive the analysis buffer interval from the model's spec. If
+	// inference exceeds this interval the pipeline falls behind real-time.
+	effectiveBufferDuration := 3 * time.Second / 2 // fallback: BirdNET v2.4
+	if spec, ok := bn.ModelSpecFor(modelID); ok {
+		effectiveBufferDuration = spec.BufferInterval()
+	}
 
-	// Calculate the effective buffer duration
-	bufferDuration := 3 * time.Second // base duration
-	overlapDuration := time.Duration(settings.BirdNET.Overlap * float64(time.Second))
-	effectiveBufferDuration := bufferDuration - overlapDuration
-
-	// Check if processing time exceeds effective buffer duration
 	if elapsedTime > effectiveBufferDuration {
-		log.Warn("BirdNET processing time exceeded buffer length",
+		log.Warn("processing time exceeded buffer interval",
 			logger.Duration("elapsed_time", elapsedTime),
-			logger.Duration("buffer_length", effectiveBufferDuration),
+			logger.Duration("buffer_interval", effectiveBufferDuration),
+			logger.String("model_id", modelID),
 			logger.String("source", source))
 		recordBufferOverrun(getOverrunTracker(source, modelID), elapsedTime, effectiveBufferDuration)
 
-		// Record Prometheus metrics for observability
 		processMetricsMutex.RLock()
 		m := processMetrics
 		processMetricsMutex.RUnlock()

--- a/internal/classifier/model.go
+++ b/internal/classifier/model.go
@@ -36,6 +36,13 @@ func (s ModelSpec) BufferDimensions() (clipBytes, overlapBytes, readSize int) {
 	return
 }
 
+// BufferInterval returns how often a new analysis window is produced,
+// derived from 50% overlap: ClipLength / 2. If inference exceeds this
+// interval the pipeline falls behind real-time input.
+func (s ModelSpec) BufferInterval() time.Duration {
+	return s.ClipLength / 2
+}
+
 // EffectiveSampleRate returns the sample rate the model expects to receive
 // audio at. When RawSampleRate is set, the model needs raw audio at that
 // rate (e.g. 256kHz bat audio fed without resampling). Otherwise, the

--- a/internal/classifier/model_test.go
+++ b/internal/classifier/model_test.go
@@ -18,6 +18,26 @@ func TestModelSpecDefaults(t *testing.T) {
 	assert.Equal(t, 3*time.Second, spec.ClipLength)
 }
 
+func TestModelSpec_BufferInterval(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		clip     time.Duration
+		expected time.Duration
+	}{
+		{"BirdNET v2.4 (3s)", 3 * time.Second, 1500 * time.Millisecond},
+		{"Perch v2 (5s)", 5 * time.Second, 2500 * time.Millisecond},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			spec := ModelSpec{SampleRate: 48000, ClipLength: tt.clip}
+			assert.Equal(t, tt.expected, spec.BufferInterval())
+		})
+	}
+}
+
 func TestModelSpec_EffectiveSampleRate(t *testing.T) {
 	t.Parallel()
 

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -189,6 +189,23 @@ func (o *Orchestrator) IsModelActive(modelID string) bool {
 	return s.isActive()
 }
 
+// ModelSpecFor returns the ModelSpec for the given model ID.
+// Returns the zero value and false if the model is not loaded.
+func (o *Orchestrator) ModelSpecFor(modelID string) (ModelSpec, bool) {
+	o.mu.RLock()
+	entry, ok := o.models[modelID]
+	o.mu.RUnlock()
+	if !ok {
+		return ModelSpec{}, false
+	}
+	entry.mu.Lock()
+	defer entry.mu.Unlock()
+	if entry.instance == nil {
+		return ModelSpec{}, false
+	}
+	return entry.instance.Spec(), true
+}
+
 // startBatScheduler creates a fresh scheduler (preserving the suncalc
 // reference from an existing one if present) and starts it. Handles the
 // unload/reload case where the previous scheduler's stopChan is closed.

--- a/internal/classifier/orchestrator_test.go
+++ b/internal/classifier/orchestrator_test.go
@@ -231,6 +231,54 @@ func TestOrchestrator_LoadAdditionalModels_UnknownModelSkipped(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestOrchestrator_ModelSpecFor(t *testing.T) {
+	t.Parallel()
+
+	birdnet := &mockModelInstance{
+		id:   "BirdNET_V2.4",
+		spec: ModelSpec{SampleRate: 48000, ClipLength: 3 * time.Second},
+	}
+	perch := &mockModelInstance{
+		id:   "Google_Perch_V2",
+		spec: ModelSpec{SampleRate: 32000, ClipLength: 5 * time.Second},
+	}
+
+	o := newTestOrchestrator(t, birdnet, perch)
+
+	t.Run("returns BirdNET spec", func(t *testing.T) {
+		t.Parallel()
+		spec, ok := o.ModelSpecFor("BirdNET_V2.4")
+		require.True(t, ok)
+		assert.Equal(t, 3*time.Second, spec.ClipLength)
+		assert.Equal(t, 48000, spec.SampleRate)
+	})
+
+	t.Run("returns Perch spec", func(t *testing.T) {
+		t.Parallel()
+		spec, ok := o.ModelSpecFor("Google_Perch_V2")
+		require.True(t, ok)
+		assert.Equal(t, 5*time.Second, spec.ClipLength)
+		assert.Equal(t, 32000, spec.SampleRate)
+	})
+
+	t.Run("unknown model returns false", func(t *testing.T) {
+		t.Parallel()
+		_, ok := o.ModelSpecFor("nonexistent")
+		assert.False(t, ok)
+	})
+
+	t.Run("nil instance returns false", func(t *testing.T) {
+		t.Parallel()
+		o2 := &Orchestrator{
+			models: map[string]*modelEntry{
+				"closed": {instance: nil},
+			},
+		}
+		_, ok := o2.ModelSpecFor("closed")
+		assert.False(t, ok)
+	})
+}
+
 func TestOrchestrator_ModelInfos_SkipsNilInstances(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- The buffer overrun monitor hardcoded BirdNET v2.4's 3s clip length and used `settings.BirdNET.Overlap` for all models, producing false warnings for Perch v2 (5s clips, 695ms inference well within its 2.5s effective window)
- Add `Orchestrator.ModelSpecFor(modelID)` to look up a loaded model's `ModelSpec` by ID, following the two-level locking protocol (map RLock, then per-model Lock) to prevent TOCTOU races during concurrent unload
- Add `ModelSpec.BufferInterval()` helper that derives the analysis window interval from 50% overlap (`ClipLength / 2`), centralizing the overlap assumption alongside `BufferDimensions()`
- `ProcessData` now uses the model's actual `BufferInterval()` instead of a hardcoded BirdNET-specific calculation

## Test Plan
- [x] `TestOrchestrator_ModelSpecFor` covers BirdNET spec, Perch spec, unknown model, and nil instance paths
- [x] `TestModelSpec_BufferInterval` verifies interval derivation for 3s and 5s clip lengths
- [x] All 689 tests pass across `internal/classifier/` and `internal/analysis/` with `-race`
- [x] `golangci-lint run -v` clean on both packages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved buffer-overrun detection to use model-specific intervals instead of global settings, with automatic fallback handling for enhanced accuracy.

* **Tests**
  * Added comprehensive unit tests for buffer interval calculations and model configuration retrieval across different model types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3085)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->