### PR TITLE
fix(classifier): rebuild species list after range filter hot-reload

### DIFF
--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -471,7 +471,9 @@ func (o *Orchestrator) RangeFilterStatus() RangeFilterStatusResponse {
 }
 
 // ReloadRangeFilter reinitializes the range filter on the primary model
-// from current settings without a full model reload.
+// from current settings without a full model reload, then rebuilds the
+// species inclusion list so the processor's detection filter reflects
+// the new backend immediately.
 func (o *Orchestrator) ReloadRangeFilter() error {
 	o.mu.RLock()
 	primary := o.primary
@@ -479,7 +481,10 @@ func (o *Orchestrator) ReloadRangeFilter() error {
 	if primary == nil {
 		return nil
 	}
-	return primary.ReloadRangeFilter()
+	if err := primary.ReloadRangeFilter(); err != nil {
+		return err
+	}
+	return BuildRangeFilter(o)
 }
 
 // ReloadBatFilter rebuilds the bat model's high-pass filter from current settings.


### PR DESCRIPTION
## Summary

- After installing a geomodel from the model gallery, `ReloadRangeFilter()` reinitialized the ONNX backend but never called `BuildRangeFilter()` to refresh the species inclusion list (`settings.BirdNET.RangeFilter.Species`)
- The processor's detection filter (`IsSpeciesIncluded`) kept using the stale list from startup, causing incorrect species filtering until the next daily rebuild (first detection after midnight)
- Fix: add `BuildRangeFilter(o)` call to `Orchestrator.ReloadRangeFilter()` so all three callers (install, uninstall, upgrade scan) automatically get an up-to-date species list

## Root cause

Two-layer architecture: the range filter has a **backend layer** (ONNX model that predicts scores) and a **species list layer** (the included species stored in settings). `ReloadRangeFilter()` only refreshed the backend; the species list was orphaned.

## Test plan

- [x] `go test -race ./internal/classifier/` (551 tests pass)
- [x] `go test -race ./internal/conf/` (1174 tests pass)
- [x] `go test -race ./internal/analysis/...` (1587 tests pass)
- [x] `golangci-lint run -v` clean
- [x] Pre-push gate (4 agents + Gemini): 0 findings in changed code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved range filter reloading behavior to ensure filters are properly refreshed and rebuilt immediately when updates occur.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3086)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->