### PR TITLE
fix: geomodel auto-selection, species dedup, atomic metrics, tracker cleanup

### DIFF
--- a/internal/analysis/control_monitor.go
+++ b/internal/analysis/control_monitor.go
@@ -286,10 +286,10 @@ func (cm *ControlMonitor) handleRebuildRangeFilter() {
 	// for maintenance tasks. Future maintainers: this is just opportunistic cleanup,
 	// not a functional requirement of range filter rebuilding.
 	if cm.proc != nil {
-		// Clean entries older than 1 hour
 		cm.proc.CleanupLogDeduplicator(time.Hour)
 		cm.proc.CleanupEventTracker(time.Hour)
 	}
+	CleanupOverrunTrackers(time.Hour)
 }
 
 // handleReloadBirdnet reloads the BirdNET model
@@ -382,6 +382,7 @@ func (cm *ControlMonitor) handleReconfigureMQTT() {
 func (cm *ControlMonitor) handleReconfigureStreams() {
 	audiocore.GetLogger().Info("Reconfiguring audio streams")
 
+	ResetOverrunTrackers()
 	cm.reconfigureSourcesFn()
 
 	// Re-evaluate quiet hours after stream reconfiguration to ensure
@@ -754,6 +755,8 @@ func (cm *ControlMonitor) handleRebuildExtendedCapture() {
 // diff-based reconfiguration used for RTSP stream changes.
 func (cm *ControlMonitor) handleReconfigureAudioSources() {
 	audiocore.GetLogger().Info("Reconfiguring audio sources")
+
+	ResetOverrunTrackers()
 
 	defer func() {
 		if r := recover(); r != nil {

--- a/internal/analysis/process.go
+++ b/internal/analysis/process.go
@@ -22,11 +22,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/telemetry"
 )
 
-var (
-	processMetrics      *metrics.MyAudioMetrics // Global metrics instance for audio processing operations
-	processMetricsMutex sync.RWMutex            // Mutex for thread-safe access to processMetrics
-	processMetricsOnce  sync.Once               // Ensures metrics are only set once
-)
+var processMetrics atomic.Pointer[metrics.MyAudioMetrics]
 
 const (
 	// Float32BufferSize is the number of float32 samples in a standard buffer.
@@ -73,6 +69,30 @@ func getOverrunTracker(source, modelID string) *bufferOverrunTracker {
 	t := &bufferOverrunTracker{}
 	overrunTrackers[key] = t
 	return t
+}
+
+// CleanupOverrunTrackers removes tracker entries that have been idle longer than maxAge.
+func CleanupOverrunTrackers(maxAge time.Duration) {
+	now := time.Now()
+	overrunTrackersMu.Lock()
+	defer overrunTrackersMu.Unlock()
+	for key, tracker := range overrunTrackers {
+		tracker.mu.Lock()
+		idle := !tracker.windowStart.IsZero() && now.Sub(tracker.windowStart) > maxAge
+		noActivity := tracker.windowStart.IsZero() && tracker.overrunCount == 0
+		tracker.mu.Unlock()
+		if idle || noActivity {
+			delete(overrunTrackers, key)
+		}
+	}
+}
+
+// ResetOverrunTrackers removes all tracker entries. Called when audio sources
+// are reconfigured to prevent stale entries from accumulating.
+func ResetOverrunTrackers() {
+	overrunTrackersMu.Lock()
+	clear(overrunTrackers)
+	overrunTrackersMu.Unlock()
 }
 
 // lastQueueOverflowReport tracks the last time a queue overflow was reported to Sentry.
@@ -137,14 +157,9 @@ func reportBufferOverruns(count int64, maxElapsed, bufferLen, window time.Durati
 }
 
 // SetProcessMetrics sets the metrics instance for audio processing operations.
-// This function is thread-safe and ensures metrics are only set once per process lifetime.
-// Subsequent calls will be ignored due to sync.Once (idempotent behavior).
+// Thread-safe; only the first call wins (subsequent calls are no-ops).
 func SetProcessMetrics(myAudioMetrics *metrics.MyAudioMetrics) {
-	processMetricsOnce.Do(func() {
-		processMetricsMutex.Lock()
-		defer processMetricsMutex.Unlock()
-		processMetrics = myAudioMetrics
-	})
+	processMetrics.CompareAndSwap(nil, myAudioMetrics)
 }
 
 // ProcessData processes the given audio data to detect bird species, logs the
@@ -201,9 +216,7 @@ func ProcessData(ctx context.Context, bn *classifier.Orchestrator, bufMgr *buffe
 	}
 
 	// Record inference duration metric (always, even on error)
-	processMetricsMutex.RLock()
-	pm := processMetrics
-	processMetricsMutex.RUnlock()
+	pm := processMetrics.Load()
 	if pm != nil {
 		pm.RecordAudioInferenceDuration(source, inferenceDuration.Seconds())
 	}
@@ -270,9 +283,7 @@ func ProcessData(ctx context.Context, bn *classifier.Orchestrator, bufMgr *buffe
 			logger.String("source", source))
 		recordBufferOverrun(getOverrunTracker(source, modelID), elapsedTime, effectiveBufferDuration)
 
-		processMetricsMutex.RLock()
-		m := processMetrics
-		processMetricsMutex.RUnlock()
+		m := processMetrics.Load()
 		if m != nil {
 			m.RecordBirdNETProcessingOverrun(source, elapsedTime.Seconds(), effectiveBufferDuration.Seconds())
 		}

--- a/internal/classifier/birdnet.go
+++ b/internal/classifier/birdnet.go
@@ -369,7 +369,7 @@ func (bn *BirdNET) initializeMetaModel() error {
 	// Auto-select v3 geomodel for compatible classifiers when files exist on disk.
 	// Only applies locally for routing; does NOT publish settings to avoid
 	// inconsistency if the backend fails to initialize.
-	if bn.modelsDir != "" && shouldAutoSelectV3Geomodel(bn.ModelInfo.ID, bn.modelsDir) {
+	if rf.Model == "" && bn.modelsDir != "" && shouldAutoSelectV3Geomodel(bn.ModelInfo.ID, bn.modelsDir) {
 		localSettings := conf.CloneSettings(settings)
 		applyAutoSelectedGeomodelPaths(localSettings, bn.modelsDir)
 		rf = localSettings.BirdNET.RangeFilter

--- a/internal/classifier/range_filter.go
+++ b/internal/classifier/range_filter.go
@@ -316,13 +316,18 @@ func (bn *BirdNET) getProbableSpecies(date time.Time, week float32, settings *co
 		}
 	}
 
+	seen := make(map[string]bool, len(speciesScores))
+	for _, ss := range speciesScores {
+		seen[ss.Label] = true
+	}
+
 	processedSpecies := make(map[string]bool)
 	labels := settings.BirdNET.Labels
 	for _, includedSpecies := range settings.Realtime.Species.Include {
-		addSpeciesWithMaxScore(bn, &speciesScores, includedSpecies, processedSpecies, labels)
+		addSpeciesWithMaxScore(bn, &speciesScores, includedSpecies, processedSpecies, labels, seen)
 	}
 	for species := range settings.Realtime.Species.Config {
-		addSpeciesWithMaxScore(bn, &speciesScores, species, processedSpecies, labels)
+		addSpeciesWithMaxScore(bn, &speciesScores, species, processedSpecies, labels, seen)
 	}
 
 	sort.Sort(ByScore(speciesScores))
@@ -342,9 +347,8 @@ func zeroScoresForAllLabels(labels, excludeList []string) []SpeciesScore {
 	return speciesScores
 }
 
-// addSpeciesWithMaxScore adds all matching species to the scores list with maximum score
-func addSpeciesWithMaxScore(bn *BirdNET, speciesScores *[]SpeciesScore, speciesName string, processedSpecies map[string]bool, labels []string) {
-	// Skip if already processed
+// addSpeciesWithMaxScore adds all matching species to the scores list with maximum score.
+func addSpeciesWithMaxScore(bn *BirdNET, speciesScores *[]SpeciesScore, speciesName string, processedSpecies map[string]bool, labels []string, seen map[string]bool) {
 	if processedSpecies[speciesName] {
 		return
 	}
@@ -352,8 +356,11 @@ func addSpeciesWithMaxScore(bn *BirdNET, speciesScores *[]SpeciesScore, speciesN
 	matchFound := false
 	for _, label := range labels {
 		if matchesSpecies(label, speciesName) {
-			bn.Debug("Adding species with max score: %s (matched with: %s)", label, speciesName)
-			*speciesScores = append(*speciesScores, SpeciesScore{Score: 1.0, Label: label})
+			if !seen[label] {
+				bn.Debug("Adding species with max score: %s (matched with: %s)", label, speciesName)
+				*speciesScores = append(*speciesScores, SpeciesScore{Score: 1.0, Label: label})
+				seen[label] = true
+			}
 			matchFound = true
 		}
 	}


### PR DESCRIPTION
## Summary

- Gate geomodel auto-selection on `rf.Model == ""` so explicit user config (e.g., `rangefilter.model: legacy`) is not silently overridden (Forgejo #603)
- Add `seen` map to legacy `addSpeciesWithMaxScore` path to prevent duplicate species when a species appears in both range filter output and include/config lists (Forgejo #633)
- Replace `processMetrics` RWMutex+Once with `atomic.Pointer`, matching the pattern from PR #3015 (Forgejo #639)
- Add `CleanupOverrunTrackers` and `ResetOverrunTrackers` with wiring into control monitor and source reconfiguration handlers (Forgejo #640)

## Test plan

- [x] `go test -race ./internal/classifier/...` passes
- [x] `go test -race ./internal/analysis/...` passes
- [x] `golangci-lint run -v` clean
- [x] Pre-push gate: 0 blocking findings in changed code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved audio processing overrun tracking and cleanup reliability
  * Fixed potential duplicate species entries in classification results
  * Enhanced geomodel auto-selection to respect existing configurations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3087)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->