### PR TITLE
feat(classifier): serialize multi-model inference, fix ONNX thread defaults

### DIFF
--- a/cmd/perch-benchmark/main.go
+++ b/cmd/perch-benchmark/main.go
@@ -38,8 +38,10 @@ type benchConfig struct {
 	warmup     int
 	iterations int
 	threads    []int
+	batches    []int
 	verify     bool
 	audioPath  string
+	xnnpack    bool
 }
 
 type benchStats struct {
@@ -95,7 +97,9 @@ func run() error {
 	// Print system info
 	printSystemInfo()
 	fmt.Printf("Warmup: %d iterations, Benchmark: %d iterations\n", cfg.warmup, cfg.iterations)
-	fmt.Printf("Thread configs: %v\n\n", cfg.threads)
+	fmt.Printf("Thread configs: %v\n", cfg.threads)
+	fmt.Printf("Batch sizes: %v\n", cfg.batches)
+	fmt.Printf("XNNPACK EP: %v\n\n", cfg.xnnpack)
 
 	var allResults []resultEntry
 
@@ -107,20 +111,29 @@ func run() error {
 		fmt.Printf("========================================\n")
 
 		for _, threads := range cfg.threads {
-			fmt.Printf("\n  Threads: %d (intra-op = inter-op = %d)\n", threads, threads)
+			for _, batchSize := range cfg.batches {
+				fmt.Printf("\n  Threads: %d, Batch: %d\n", threads, batchSize)
 
-			stats, err := runBenchmark(modelPath, labels, audio, threads, cfg.warmup, cfg.iterations)
-			if err != nil {
-				fmt.Printf("  ERROR: %v\n", err)
-				continue
+				var stats benchStats
+				var err error
+				if batchSize <= 1 {
+					stats, err = runBenchmark(modelPath, labels, audio, threads, cfg.xnnpack, cfg.warmup, cfg.iterations)
+				} else {
+					stats, err = runBatchBenchmark(modelPath, labels, audio, threads, batchSize, cfg.xnnpack, cfg.warmup, cfg.iterations)
+				}
+				if err != nil {
+					fmt.Printf("  ERROR: %v\n", err)
+					continue
+				}
+
+				printBatchStats(stats, batchSize)
+				allResults = append(allResults, resultEntry{
+					model:   modelName,
+					threads: threads,
+					batch:   batchSize,
+					stats:   stats,
+				})
 			}
-
-			printStats(stats)
-			allResults = append(allResults, resultEntry{
-				model:   modelName,
-				threads: threads,
-				stats:   stats,
-			})
 		}
 		fmt.Println()
 	}
@@ -145,7 +158,7 @@ func run() error {
 }
 
 func parseFlags() benchConfig {
-	var modelsStr, threadsStr string
+	var modelsStr, threadsStr, batchStr string
 
 	cfg := benchConfig{}
 	flag.StringVar(&modelsStr, "models", "", "comma-separated ONNX model paths")
@@ -154,6 +167,8 @@ func parseFlags() benchConfig {
 	flag.IntVar(&cfg.warmup, "warmup", defaultWarmup, "warmup iterations per config")
 	flag.IntVar(&cfg.iterations, "iters", defaultIters, "benchmark iterations per config")
 	flag.StringVar(&threadsStr, "threads", "1,2,4", "comma-separated thread counts to test")
+	flag.StringVar(&batchStr, "batch", "1", "comma-separated batch sizes to test")
+	flag.BoolVar(&cfg.xnnpack, "xnnpack", false, "use XNNPACK execution provider")
 	flag.BoolVar(&cfg.verify, "verify", true, "verify output equivalence between models")
 	flag.StringVar(&cfg.audioPath, "audio", "", "path to raw float32 PCM file (random if empty)")
 	flag.Parse()
@@ -161,17 +176,28 @@ func parseFlags() benchConfig {
 	if modelsStr != "" {
 		cfg.modelPaths = strings.Split(modelsStr, ",")
 	}
-	if threadsStr != "" {
-		for s := range strings.SplitSeq(threadsStr, ",") {
-			s = strings.TrimSpace(s)
-			var n int
-			if _, err := fmt.Sscanf(s, "%d", &n); err == nil && n > 0 {
-				cfg.threads = append(cfg.threads, n)
+	for _, str := range []struct {
+		raw string
+		dst *[]int
+	}{
+		{threadsStr, &cfg.threads},
+		{batchStr, &cfg.batches},
+	} {
+		if str.raw != "" {
+			for s := range strings.SplitSeq(str.raw, ",") {
+				s = strings.TrimSpace(s)
+				var n int
+				if _, err := fmt.Sscanf(s, "%d", &n); err == nil && n >= 0 {
+					*str.dst = append(*str.dst, n)
+				}
 			}
 		}
 	}
 	if len(cfg.threads) == 0 {
 		cfg.threads = []int{1, 2, 4}
+	}
+	if len(cfg.batches) == 0 {
+		cfg.batches = []int{1}
 	}
 
 	return cfg
@@ -230,8 +256,8 @@ func printSystemInfo() {
 	fmt.Printf("\nSystem: %s/%s, %d CPUs\n", runtime.GOOS, runtime.GOARCH, runtime.NumCPU())
 }
 
-func runBenchmark(modelPath string, labels []string, audio []float32, threads, warmup, iterations int) (benchStats, error) {
-	classifier, err := createClassifier(modelPath, labels, threads)
+func runBenchmark(modelPath string, labels []string, audio []float32, threads int, useXNNPACK bool, warmup, iterations int) (benchStats, error) {
+	classifier, err := createClassifier(modelPath, labels, threads, useXNNPACK)
 	if err != nil {
 		return benchStats{}, fmt.Errorf("create classifier: %w", err)
 	}
@@ -257,18 +283,65 @@ func runBenchmark(modelPath string, labels []string, audio []float32, threads, w
 	return computeStats(durations), nil
 }
 
-func createClassifier(modelPath string, labels []string, threads int) (*onnx.Classifier, error) {
-	opts := []onnx.ClassifierOption{
+func runBatchBenchmark(modelPath string, labels []string, audio []float32, threads, batchSize int, useXNNPACK bool, warmup, iterations int) (benchStats, error) {
+	classifier, err := createClassifier(modelPath, labels, threads, useXNNPACK)
+	if err != nil {
+		return benchStats{}, fmt.Errorf("create classifier: %w", err)
+	}
+	defer func() { _ = classifier.Close() }()
+
+	segments := make([][]float32, batchSize)
+	for i := range batchSize {
+		segments[i] = make([]float32, len(audio))
+		copy(segments[i], audio)
+	}
+
+	// Warmup
+	for range warmup {
+		if _, err := classifier.PredictBatch(segments); err != nil {
+			return benchStats{}, fmt.Errorf("batch warmup failed: %w", err)
+		}
+	}
+
+	// Timed runs
+	durations := make([]time.Duration, iterations)
+	for i := range iterations {
+		start := time.Now()
+		if _, err := classifier.PredictBatch(segments); err != nil {
+			return benchStats{}, fmt.Errorf("batch inference %d failed: %w", i, err)
+		}
+		durations[i] = time.Since(start)
+	}
+
+	return computeStats(durations), nil
+}
+
+func createClassifier(modelPath string, labels []string, threads int, useXNNPACK bool) (*onnx.Classifier, error) {
+	opts := make([]onnx.ClassifierOption, 0, 5)
+	opts = append(opts,
 		onnx.WithLabels(labels),
 		onnx.WithTopK(0),
 		onnx.WithMinConfidence(0),
 		onnx.WithSkipLabelValidation(),
-	}
-	if threads > 0 {
-		opts = append(opts, onnx.WithSessionOptions(func(so *ortlib.SessionOptions) {
-			_ = so.SetIntraOpNumThreads(threads)
-			_ = so.SetInterOpNumThreads(threads)
-		}))
+	)
+	var configErr error
+	opts = append(opts, onnx.WithSessionOptions(func(so *ortlib.SessionOptions) {
+		if threads > 0 {
+			if err := so.SetIntraOpNumThreads(threads); err != nil && configErr == nil {
+				configErr = fmt.Errorf("failed to set IntraOpNumThreads to %d: %w", threads, err)
+			}
+			if err := so.SetInterOpNumThreads(threads); err != nil && configErr == nil {
+				configErr = fmt.Errorf("failed to set InterOpNumThreads to %d: %w", threads, err)
+			}
+		}
+		if useXNNPACK {
+			if err := so.AppendExecutionProvider("XNNPACK", map[string]string{}); err != nil && configErr == nil {
+				configErr = fmt.Errorf("failed to append XNNPACK EP: %w", err)
+			}
+		}
+	}))
+	if configErr != nil {
+		return nil, configErr
 	}
 	return onnx.NewClassifier(modelPath, opts...)
 }
@@ -312,14 +385,16 @@ func computeStats(durations []time.Duration) benchStats {
 	}
 }
 
-func printStats(s benchStats) {
+func printBatchStats(s benchStats, batchSize int) {
 	fmt.Printf("  Mean:   %v\n", s.mean.Round(time.Millisecond))
 	fmt.Printf("  Median: %v\n", s.median.Round(time.Millisecond))
 	fmt.Printf("  Min:    %v\n", s.min.Round(time.Millisecond))
 	fmt.Printf("  Max:    %v\n", s.max.Round(time.Millisecond))
 	fmt.Printf("  P95:    %v\n", s.p95.Round(time.Millisecond))
 	fmt.Printf("  Stddev: %v\n", s.stddev.Round(time.Millisecond))
-	fmt.Printf("  Throughput: %.2f inferences/sec\n", 1.0/s.mean.Seconds())
+	batchThroughput := float64(batchSize) / s.mean.Seconds()
+	perSegment := s.mean / time.Duration(batchSize)
+	fmt.Printf("  Throughput: %.2f segments/sec (%.0fms per segment)\n", batchThroughput, float64(perSegment.Milliseconds()))
 }
 
 func verifyEquivalence(modelPaths, labels []string, audio []float32) {
@@ -330,7 +405,7 @@ func verifyEquivalence(modelPaths, labels []string, audio []float32) {
 	outputs := make([]modelOutput, 0, len(modelPaths))
 
 	for _, path := range modelPaths {
-		classifier, err := createClassifier(path, labels, 1)
+		classifier, err := createClassifier(path, labels, 1, false)
 		if err != nil {
 			fmt.Printf("  ERROR creating classifier for %s: %v\n", filepath.Base(path), err)
 			return
@@ -387,31 +462,39 @@ func verifyEquivalence(modelPaths, labels []string, audio []float32) {
 type resultEntry struct {
 	model   string
 	threads int
+	batch   int
 	stats   benchStats
 }
 
 func printSummary(results []resultEntry) {
-	fmt.Printf("\n  %-30s  Threads  Mean         Median       P95          Throughput\n", "Model")
-	fmt.Printf("  %-30s  -------  -----------  -----------  -----------  ----------\n", strings.Repeat("-", 30))
+	fmt.Printf("\n  %-25s  Threads  Batch  Mean         Median       P95          Seg/s    ms/seg\n", "Model")
+	fmt.Printf("  %-25s  -------  -----  -----------  -----------  -----------  -------  ------\n", strings.Repeat("-", 25))
 
 	for _, r := range results {
-		fmt.Printf("  %-30s  %5d    %10v   %10v   %10v   %5.2f/s\n",
-			r.model, r.threads,
+		segPerSec := float64(r.batch) / r.stats.mean.Seconds()
+		msPerSeg := float64(r.stats.mean.Milliseconds()) / float64(r.batch)
+		fmt.Printf("  %-25s  %5d    %3d    %10v   %10v   %10v   %5.2f    %5.0f\n",
+			r.model, r.threads, r.batch,
 			r.stats.mean.Round(time.Millisecond),
 			r.stats.median.Round(time.Millisecond),
 			r.stats.p95.Round(time.Millisecond),
-			1.0/r.stats.mean.Seconds(),
+			segPerSec, msPerSeg,
 		)
 	}
 
-	// Find best config
+	// Find best throughput (segments per second)
 	if len(results) > 0 {
 		best := results[0]
+		bestThroughput := float64(best.batch) / best.stats.mean.Seconds()
 		for _, r := range results[1:] {
-			if r.stats.mean < best.stats.mean {
+			t := float64(r.batch) / r.stats.mean.Seconds()
+			if t > bestThroughput {
 				best = r
+				bestThroughput = t
 			}
 		}
-		fmt.Printf("\n  Best: %s @ %d threads (%.0fms mean)\n", best.model, best.threads, float64(best.stats.mean.Milliseconds()))
+		fmt.Printf("\n  Best throughput: %s @ %d threads, batch %d (%.2f seg/s, %.0fms/seg)\n",
+			best.model, best.threads, best.batch, bestThroughput,
+			float64(best.stats.mean.Milliseconds())/float64(best.batch))
 	}
 }

--- a/cmd/perch-benchmark/main.go
+++ b/cmd/perch-benchmark/main.go
@@ -9,6 +9,7 @@
 package main
 
 import (
+	"encoding/binary"
 	"flag"
 	"fmt"
 	"math"
@@ -232,8 +233,7 @@ func prepareAudio(audioPath string) []float32 {
 			if samples >= perchSampleCount {
 				audio := make([]float32, perchSampleCount)
 				for i := range perchSampleCount {
-					offset := i * 4
-					bits := uint32(data[offset]) | uint32(data[offset+1])<<8 | uint32(data[offset+2])<<16 | uint32(data[offset+3])<<24
+					bits := binary.LittleEndian.Uint32(data[i*4 : i*4+4])
 					audio[i] = math.Float32frombits(bits)
 				}
 				fmt.Printf("Using audio from: %s\n", audioPath)
@@ -340,10 +340,15 @@ func createClassifier(modelPath string, labels []string, threads int, useXNNPACK
 			}
 		}
 	}))
+	classifier, err := onnx.NewClassifier(modelPath, opts...)
+	if err != nil {
+		return nil, err
+	}
 	if configErr != nil {
+		_ = classifier.Close()
 		return nil, configErr
 	}
-	return onnx.NewClassifier(modelPath, opts...)
+	return classifier, nil
 }
 
 func computeStats(durations []time.Duration) benchStats {

--- a/cmd/perch-benchmark/main.go
+++ b/cmd/perch-benchmark/main.go
@@ -1,0 +1,417 @@
+// Standalone benchmark tool for comparing Perch v2 ONNX model variants.
+// Measures inference latency across different thread configurations and
+// optionally verifies output equivalence between models.
+//
+// Usage:
+//
+//	go build -o perch-benchmark ./cmd/perch-benchmark
+//	./perch-benchmark -labels labels.txt -models model_a.onnx,model_b.onnx
+package main
+
+import (
+	"flag"
+	"fmt"
+	"math"
+	"math/rand/v2"
+	"os"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/tphakala/birdnet-go/internal/inference"
+	"github.com/tphakala/birdnet-go/internal/inference/onnx"
+	ortlib "github.com/yalue/onnxruntime_go"
+)
+
+const (
+	perchSampleCount = 160000 // 32kHz * 5s
+	defaultWarmup    = 5
+	defaultIters     = 30
+)
+
+type benchConfig struct {
+	modelPaths []string
+	labelPath  string
+	ortLibPath string
+	warmup     int
+	iterations int
+	threads    []int
+	verify     bool
+	audioPath  string
+}
+
+type benchStats struct {
+	mean   time.Duration
+	median time.Duration
+	min    time.Duration
+	max    time.Duration
+	p95    time.Duration
+	stddev time.Duration
+	count  int
+}
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	cfg := parseFlags()
+
+	if len(cfg.modelPaths) == 0 {
+		return fmt.Errorf("at least one model path required (-models)")
+	}
+	if cfg.labelPath == "" {
+		return fmt.Errorf("label file required (-labels)")
+	}
+
+	for _, p := range cfg.modelPaths {
+		if _, err := os.Stat(p); err != nil {
+			return fmt.Errorf("model file not found: %s", p)
+		}
+	}
+	if _, err := os.Stat(cfg.labelPath); err != nil {
+		return fmt.Errorf("label file not found: %s", cfg.labelPath)
+	}
+
+	if err := inference.InitONNXRuntime(cfg.ortLibPath); err != nil {
+		return fmt.Errorf("failed to init ONNX Runtime: %w", err)
+	}
+	defer func() { _ = inference.DestroyONNXRuntime() }()
+
+	labels, err := loadLabels(cfg.labelPath)
+	if err != nil {
+		return fmt.Errorf("failed to load labels: %w", err)
+	}
+	fmt.Printf("Loaded %d labels from %s\n", len(labels), filepath.Base(cfg.labelPath))
+
+	// Prepare audio input
+	audio := prepareAudio(cfg.audioPath)
+
+	// Print system info
+	printSystemInfo()
+	fmt.Printf("Warmup: %d iterations, Benchmark: %d iterations\n", cfg.warmup, cfg.iterations)
+	fmt.Printf("Thread configs: %v\n\n", cfg.threads)
+
+	var allResults []resultEntry
+
+	// Run benchmarks
+	for _, modelPath := range cfg.modelPaths {
+		modelName := filepath.Base(modelPath)
+		fmt.Printf("========================================\n")
+		fmt.Printf("Model: %s\n", modelName)
+		fmt.Printf("========================================\n")
+
+		for _, threads := range cfg.threads {
+			fmt.Printf("\n  Threads: %d (intra-op = inter-op = %d)\n", threads, threads)
+
+			stats, err := runBenchmark(modelPath, labels, audio, threads, cfg.warmup, cfg.iterations)
+			if err != nil {
+				fmt.Printf("  ERROR: %v\n", err)
+				continue
+			}
+
+			printStats(stats)
+			allResults = append(allResults, resultEntry{
+				model:   modelName,
+				threads: threads,
+				stats:   stats,
+			})
+		}
+		fmt.Println()
+	}
+
+	// Output equivalence verification
+	if cfg.verify && len(cfg.modelPaths) >= 2 {
+		fmt.Printf("========================================\n")
+		fmt.Printf("Output Equivalence Check\n")
+		fmt.Printf("========================================\n")
+		verifyEquivalence(cfg.modelPaths, labels, audio)
+	}
+
+	// Summary comparison table
+	if len(allResults) > 1 {
+		fmt.Printf("\n========================================\n")
+		fmt.Printf("Summary\n")
+		fmt.Printf("========================================\n")
+		printSummary(allResults)
+	}
+
+	return nil
+}
+
+func parseFlags() benchConfig {
+	var modelsStr, threadsStr string
+
+	cfg := benchConfig{}
+	flag.StringVar(&modelsStr, "models", "", "comma-separated ONNX model paths")
+	flag.StringVar(&cfg.labelPath, "labels", "", "path to labels.txt")
+	flag.StringVar(&cfg.ortLibPath, "ort-lib", "", "path to libonnxruntime.so (auto-detect if empty)")
+	flag.IntVar(&cfg.warmup, "warmup", defaultWarmup, "warmup iterations per config")
+	flag.IntVar(&cfg.iterations, "iters", defaultIters, "benchmark iterations per config")
+	flag.StringVar(&threadsStr, "threads", "1,2,4", "comma-separated thread counts to test")
+	flag.BoolVar(&cfg.verify, "verify", true, "verify output equivalence between models")
+	flag.StringVar(&cfg.audioPath, "audio", "", "path to raw float32 PCM file (random if empty)")
+	flag.Parse()
+
+	if modelsStr != "" {
+		cfg.modelPaths = strings.Split(modelsStr, ",")
+	}
+	if threadsStr != "" {
+		for s := range strings.SplitSeq(threadsStr, ",") {
+			s = strings.TrimSpace(s)
+			var n int
+			if _, err := fmt.Sscanf(s, "%d", &n); err == nil && n > 0 {
+				cfg.threads = append(cfg.threads, n)
+			}
+		}
+	}
+	if len(cfg.threads) == 0 {
+		cfg.threads = []int{1, 2, 4}
+	}
+
+	return cfg
+}
+
+func loadLabels(path string) ([]string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var labels []string
+	for line := range strings.Lines(string(data)) {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			labels = append(labels, line)
+		}
+	}
+	if len(labels) == 0 {
+		return nil, fmt.Errorf("no labels found in %s", path)
+	}
+	return labels, nil
+}
+
+func prepareAudio(audioPath string) []float32 {
+	if audioPath != "" {
+		data, err := os.ReadFile(audioPath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "warning: could not read audio file %s: %v, using random\n", audioPath, err)
+		} else {
+			// Interpret as raw float32 PCM
+			samples := len(data) / 4
+			if samples >= perchSampleCount {
+				audio := make([]float32, perchSampleCount)
+				for i := range perchSampleCount {
+					offset := i * 4
+					bits := uint32(data[offset]) | uint32(data[offset+1])<<8 | uint32(data[offset+2])<<16 | uint32(data[offset+3])<<24
+					audio[i] = math.Float32frombits(bits)
+				}
+				fmt.Printf("Using audio from: %s\n", audioPath)
+				return audio
+			}
+			fmt.Fprintf(os.Stderr, "warning: audio file too short (%d samples, need %d), using random\n", samples, perchSampleCount)
+		}
+	}
+
+	// Generate random audio in [-1.0, 1.0] range
+	audio := make([]float32, perchSampleCount)
+	for i := range audio {
+		audio[i] = rand.Float32()*2 - 1
+	}
+	fmt.Println("Using random audio input")
+	return audio
+}
+
+func printSystemInfo() {
+	fmt.Printf("\nSystem: %s/%s, %d CPUs\n", runtime.GOOS, runtime.GOARCH, runtime.NumCPU())
+}
+
+func runBenchmark(modelPath string, labels []string, audio []float32, threads, warmup, iterations int) (benchStats, error) {
+	classifier, err := createClassifier(modelPath, labels, threads)
+	if err != nil {
+		return benchStats{}, fmt.Errorf("create classifier: %w", err)
+	}
+	defer func() { _ = classifier.Close() }()
+
+	// Warmup
+	for range warmup {
+		if _, err := classifier.PredictRaw(audio); err != nil {
+			return benchStats{}, fmt.Errorf("warmup inference failed: %w", err)
+		}
+	}
+
+	// Timed runs
+	durations := make([]time.Duration, iterations)
+	for i := range iterations {
+		start := time.Now()
+		if _, err := classifier.PredictRaw(audio); err != nil {
+			return benchStats{}, fmt.Errorf("inference %d failed: %w", i, err)
+		}
+		durations[i] = time.Since(start)
+	}
+
+	return computeStats(durations), nil
+}
+
+func createClassifier(modelPath string, labels []string, threads int) (*onnx.Classifier, error) {
+	opts := []onnx.ClassifierOption{
+		onnx.WithLabels(labels),
+		onnx.WithTopK(0),
+		onnx.WithMinConfidence(0),
+		onnx.WithSkipLabelValidation(),
+	}
+	if threads > 0 {
+		opts = append(opts, onnx.WithSessionOptions(func(so *ortlib.SessionOptions) {
+			_ = so.SetIntraOpNumThreads(threads)
+			_ = so.SetInterOpNumThreads(threads)
+		}))
+	}
+	return onnx.NewClassifier(modelPath, opts...)
+}
+
+func computeStats(durations []time.Duration) benchStats {
+	if len(durations) == 0 {
+		return benchStats{}
+	}
+
+	sorted := make([]time.Duration, len(durations))
+	copy(sorted, durations)
+	slices.Sort(sorted)
+
+	var sum float64
+	for _, d := range durations {
+		sum += float64(d)
+	}
+	mean := sum / float64(len(durations))
+
+	var varianceSum float64
+	for _, d := range durations {
+		diff := float64(d) - mean
+		varianceSum += diff * diff
+	}
+	stddev := math.Sqrt(varianceSum / float64(len(durations)))
+
+	n := len(sorted)
+	p95idx := int(float64(n) * 0.95)
+	if p95idx >= n {
+		p95idx = n - 1
+	}
+
+	return benchStats{
+		mean:   time.Duration(mean),
+		median: sorted[n/2],
+		min:    sorted[0],
+		max:    sorted[n-1],
+		p95:    sorted[p95idx],
+		stddev: time.Duration(stddev),
+		count:  n,
+	}
+}
+
+func printStats(s benchStats) {
+	fmt.Printf("  Mean:   %v\n", s.mean.Round(time.Millisecond))
+	fmt.Printf("  Median: %v\n", s.median.Round(time.Millisecond))
+	fmt.Printf("  Min:    %v\n", s.min.Round(time.Millisecond))
+	fmt.Printf("  Max:    %v\n", s.max.Round(time.Millisecond))
+	fmt.Printf("  P95:    %v\n", s.p95.Round(time.Millisecond))
+	fmt.Printf("  Stddev: %v\n", s.stddev.Round(time.Millisecond))
+	fmt.Printf("  Throughput: %.2f inferences/sec\n", 1.0/s.mean.Seconds())
+}
+
+func verifyEquivalence(modelPaths, labels []string, audio []float32) {
+	type modelOutput struct {
+		path   string
+		logits []float32
+	}
+	outputs := make([]modelOutput, 0, len(modelPaths))
+
+	for _, path := range modelPaths {
+		classifier, err := createClassifier(path, labels, 1)
+		if err != nil {
+			fmt.Printf("  ERROR creating classifier for %s: %v\n", filepath.Base(path), err)
+			return
+		}
+		logits, err := classifier.PredictRaw(audio)
+		_ = classifier.Close()
+		if err != nil {
+			fmt.Printf("  ERROR running inference on %s: %v\n", filepath.Base(path), err)
+			return
+		}
+		outputs = append(outputs, modelOutput{path: path, logits: logits})
+	}
+
+	// Compare each pair
+	for i := range len(outputs) - 1 {
+		for j := i + 1; j < len(outputs); j++ {
+			a, b := outputs[i], outputs[j]
+			nameA, nameB := filepath.Base(a.path), filepath.Base(b.path)
+
+			if len(a.logits) != len(b.logits) {
+				fmt.Printf("\n  %s vs %s: DIFFERENT output sizes (%d vs %d)\n", nameA, nameB, len(a.logits), len(b.logits))
+				continue
+			}
+
+			var maxDiff, sumDiff float64
+			maxDiffIdx := 0
+			for k := range a.logits {
+				diff := math.Abs(float64(a.logits[k] - b.logits[k]))
+				sumDiff += diff
+				if diff > maxDiff {
+					maxDiff = diff
+					maxDiffIdx = k
+				}
+			}
+			meanDiff := sumDiff / float64(len(a.logits))
+
+			fmt.Printf("\n  %s vs %s:\n", nameA, nameB)
+			fmt.Printf("    Output size:    %d\n", len(a.logits))
+			fmt.Printf("    Max difference: %.7f (at index %d)\n", maxDiff, maxDiffIdx)
+			fmt.Printf("    Mean difference: %.7f\n", meanDiff)
+
+			switch {
+			case maxDiff < 1e-3:
+				fmt.Printf("    Verdict: EQUIVALENT (within 1e-3 tolerance)\n")
+			case maxDiff < 1e-2:
+				fmt.Printf("    Verdict: CLOSE (within 1e-2 tolerance)\n")
+			default:
+				fmt.Printf("    Verdict: DIVERGENT (max diff exceeds 1e-2)\n")
+			}
+		}
+	}
+}
+
+type resultEntry struct {
+	model   string
+	threads int
+	stats   benchStats
+}
+
+func printSummary(results []resultEntry) {
+	fmt.Printf("\n  %-30s  Threads  Mean         Median       P95          Throughput\n", "Model")
+	fmt.Printf("  %-30s  -------  -----------  -----------  -----------  ----------\n", strings.Repeat("-", 30))
+
+	for _, r := range results {
+		fmt.Printf("  %-30s  %5d    %10v   %10v   %10v   %5.2f/s\n",
+			r.model, r.threads,
+			r.stats.mean.Round(time.Millisecond),
+			r.stats.median.Round(time.Millisecond),
+			r.stats.p95.Round(time.Millisecond),
+			1.0/r.stats.mean.Seconds(),
+		)
+	}
+
+	// Find best config
+	if len(results) > 0 {
+		best := results[0]
+		for _, r := range results[1:] {
+			if r.stats.mean < best.stats.mean {
+				best = r
+			}
+		}
+		fmt.Printf("\n  Best: %s @ %d threads (%.0fms mean)\n", best.model, best.threads, float64(best.stats.mean.Milliseconds()))
+	}
+}

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"sync"
 	"sync/atomic"
@@ -27,6 +28,13 @@ type modelEntry struct {
 // Orchestrator manages classifier model instances and provides the primary
 // inference API. It replaces direct *BirdNET usage at all call sites.
 // Supports multiple models with per-model locking and name resolution.
+//
+// Lock ordering (acquire in this order to prevent deadlocks):
+//  1. mu (RWMutex) - protects models map; released before inference
+//  2. inferenceMu (Mutex) - serializes inference across all models
+//  3. entry.mu (Mutex) - per-model; guards instance lifecycle
+//
+// Delete/UnloadModel acquire mu + entry.mu but NOT inferenceMu.
 type Orchestrator struct {
 	// Public fields — same layout as BirdNET for drop-in caller migration.
 	Settings        *conf.Settings
@@ -42,10 +50,11 @@ type Orchestrator struct {
 	// NOTE: models map is keyed by ModelInfo.ID at construction time. If ReloadModel
 	// changes the model ID, the key goes stale. Delete() iterates values so cleanup
 	// is unaffected. ReloadModel re-keys the map after reload.
-	mu        sync.RWMutex // protects the models map
-	models    map[string]*modelEntry
-	primary   *BirdNET // direct access to the primary model
-	modelsDir string   // base directory for gallery-installed models
+	mu          sync.RWMutex // protects the models map
+	inferenceMu sync.Mutex   // serializes inference across all models
+	models      map[string]*modelEntry
+	primary     *BirdNET // direct access to the primary model
+	modelsDir   string   // base directory for gallery-installed models
 
 	// Nighttime scheduling for bat model. Stored as atomic.Pointer so
 	// IsModelActive (called on every monitor tick) reads lock-free.
@@ -270,9 +279,11 @@ func (o *Orchestrator) Predict(ctx context.Context, sample [][]float32) ([]datas
 }
 
 // PredictModel runs inference on a specific model identified by modelID.
-// It uses a two-level locking protocol: a read lock on the models map to fetch
-// the entry (fast), then a per-model lock for inference (slow). The map lock is
-// released before acquiring the model lock to prevent deadlocks with ReloadModel.
+// It uses a three-level locking protocol: a read lock on the models map to
+// fetch the entry (fast), then inferenceMu to serialize inference across all
+// models (only one model runs at a time), then entry.mu for instance lifecycle.
+// The map lock is released before acquiring inference/model locks to prevent
+// deadlocks with ReloadModel and Delete.
 func (o *Orchestrator) PredictModel(ctx context.Context, modelID string, sample [][]float32) ([]datastore.Results, error) {
 	log := GetLogger()
 
@@ -289,6 +300,9 @@ func (o *Orchestrator) PredictModel(ctx context.Context, modelID string, sample 
 			Context("model_id", modelID).
 			Build()
 	}
+
+	o.inferenceMu.Lock()
+	defer o.inferenceMu.Unlock()
 
 	entry.mu.Lock()
 	defer entry.mu.Unlock()
@@ -666,10 +680,12 @@ func (o *Orchestrator) LoadModel(registryID string) error {
 			Build()
 	}
 
-	// Allocate a single thread for the new model. The thread count defaults
-	// to 1 because the primary model's thread allocation was computed at
-	// startup and should not be reduced by a dynamic load.
-	const dynamicThreads = 1
+	// Give the new model the full thread budget. Inference is serialized by
+	// inferenceMu so concurrent CPU contention cannot occur.
+	dynamicThreads := o.Settings.BirdNET.Threads
+	if dynamicThreads <= 0 {
+		dynamicThreads = runtime.NumCPU()
+	}
 
 	log.Info("Loading model dynamically",
 		logger.String("registry_id", registryID),
@@ -803,8 +819,8 @@ func (o *Orchestrator) ModelInfos() []ModelInfo {
 }
 
 // computeThreadAllocation pre-computes thread distribution for all models
-// that will be loaded. This runs before loading additional models so
-// constructors receive their allocated thread count.
+// that will be loaded. Inference is serialized by inferenceMu, so each model
+// gets the full thread budget (they never run simultaneously).
 func (o *Orchestrator) computeThreadAllocation(settings *conf.Settings, primaryID string) map[string]int {
 	// Collect unique model IDs that will be loaded. Deduplicates
 	// case variants like ["perch_v2", "PERCH_V2"] that resolve to the same ID.
@@ -819,11 +835,19 @@ func (o *Orchestrator) computeThreadAllocation(settings *conf.Settings, primaryI
 		modelIDs = append(modelIDs, registryID)
 	}
 
-	alloc := divideThreads(settings.BirdNET.Threads, modelIDs, primaryID)
+	total := settings.BirdNET.Threads
+	if total <= 0 {
+		total = runtime.NumCPU()
+	}
+
+	alloc := make(map[string]int, len(modelIDs))
+	for _, id := range modelIDs {
+		alloc[id] = total
+	}
 
 	if len(modelIDs) > 1 {
-		GetLogger().Info("Thread allocation for multi-model",
-			logger.Int("total_threads", settings.BirdNET.Threads),
+		GetLogger().Info("Thread allocation for multi-model (serialized inference)",
+			logger.Int("threads_per_model", total),
 			logger.Int("model_count", len(modelIDs)))
 		for id, threads := range alloc {
 			GetLogger().Debug("Model thread allocation",

--- a/internal/classifier/orchestrator_test.go
+++ b/internal/classifier/orchestrator_test.go
@@ -142,14 +142,27 @@ func TestOrchestrator_PredictModel_UnknownModel(t *testing.T) {
 	assert.Contains(t, err.Error(), "nonexistent")
 }
 
-func TestOrchestrator_PredictModel_NoCrossModelBlocking(t *testing.T) {
+func TestOrchestrator_PredictModel_SerializedInference(t *testing.T) {
 	t.Parallel()
 
+	// Track the order of inference events to verify serialization.
+	var events []string
+	var eventsMu sync.Mutex
+	addEvent := func(name string) {
+		eventsMu.Lock()
+		events = append(events, name)
+		eventsMu.Unlock()
+	}
+
+	slowStarted := make(chan struct{})
 	slowMock := &mockModelInstance{
 		id:   "slow-model",
 		spec: ModelSpec{SampleRate: 48000, ClipLength: 3 * time.Second},
 		predict: func(_ context.Context, _ [][]float32) ([]datastore.Results, error) {
+			addEvent("slow-start")
+			close(slowStarted)
 			time.Sleep(100 * time.Millisecond)
+			addEvent("slow-end")
 			return []datastore.Results{{Species: "Slow Bird", Confidence: 0.5}}, nil
 		},
 	}
@@ -157,6 +170,8 @@ func TestOrchestrator_PredictModel_NoCrossModelBlocking(t *testing.T) {
 		id:   "fast-model",
 		spec: ModelSpec{SampleRate: 48000, ClipLength: 3 * time.Second},
 		predict: func(_ context.Context, _ [][]float32) ([]datastore.Results, error) {
+			addEvent("fast-start")
+			addEvent("fast-end")
 			return []datastore.Results{{Species: "Fast Bird", Confidence: 0.9}}, nil
 		},
 	}
@@ -164,35 +179,31 @@ func TestOrchestrator_PredictModel_NoCrossModelBlocking(t *testing.T) {
 	o := newTestOrchestrator(t, slowMock, fastMock)
 
 	var wg sync.WaitGroup
-	fastDone := make(chan time.Time, 1)
-	slowDone := make(chan time.Time, 1)
-
 	sample := [][]float32{{0.1, 0.2}}
 	ctx := t.Context()
 
 	// Launch slow model first
 	wg.Go(func() {
 		_, _ = o.PredictModel(ctx, "slow-model", sample)
-		slowDone <- time.Now()
 	})
 
-	// Launch fast model immediately after
+	// Wait for slow model to actually start inference, then launch fast model.
+	// The fast model should be blocked by inferenceMu until slow finishes.
+	<-slowStarted
 	wg.Go(func() {
 		_, _ = o.PredictModel(ctx, "fast-model", sample)
-		fastDone <- time.Now()
 	})
 
 	wg.Wait()
 
-	fastFinish := <-fastDone
-	slowFinish := <-slowDone
+	eventsMu.Lock()
+	defer eventsMu.Unlock()
 
-	// Fast model should finish well before slow model (at least 50ms earlier).
-	// If per-model locking is broken and they share a lock, fast would be blocked
-	// until slow finishes.
-	assert.True(t, fastFinish.Before(slowFinish),
-		"fast model should finish before slow model; fast=%v slow=%v",
-		fastFinish, slowFinish)
+	require.Len(t, events, 4, "expected 4 inference events")
+	assert.Equal(t, "slow-start", events[0])
+	assert.Equal(t, "slow-end", events[1])
+	assert.Equal(t, "fast-start", events[2])
+	assert.Equal(t, "fast-end", events[3])
 }
 
 func TestOrchestrator_ModelInfos(t *testing.T) {

--- a/internal/classifier/threads.go
+++ b/internal/classifier/threads.go
@@ -3,6 +3,10 @@ package classifier
 // divideThreads distributes a total thread count among models.
 // Each model gets at least 1 thread. The remainder goes to the primary model.
 // Callers must ensure primaryID is present in modelIDs.
+//
+// Note: the orchestrator gives each model the full thread budget because
+// inference is serialized (inferenceMu). This function is retained for
+// testing and potential future parallel-inference mode.
 func divideThreads(total int, modelIDs []string, primaryID string) map[string]int {
 	n := len(modelIDs)
 	if n == 0 {

--- a/internal/inference/onnx.go
+++ b/internal/inference/onnx.go
@@ -48,18 +48,19 @@ func NewONNXClassifier(modelPath string, opts ONNXClassifierOptions) (Classifier
 	if opts.SkipLabelValidation {
 		classifierOpts = append(classifierOpts, ort.WithSkipLabelValidation())
 	}
-	var configErr error
-	if opts.Threads > 0 {
-		threads := opts.Threads
-		classifierOpts = append(classifierOpts, ort.WithSessionOptions(func(so *ortlib.SessionOptions) {
-			if err := so.SetIntraOpNumThreads(threads); err != nil && configErr == nil {
-				configErr = fmt.Errorf("failed to set IntraOpNumThreads to %d: %w", threads, err)
-			}
-			if err := so.SetInterOpNumThreads(threads); err != nil && configErr == nil {
-				configErr = fmt.Errorf("failed to set InterOpNumThreads to %d: %w", threads, err)
-			}
-		}))
+	threads := opts.Threads
+	if threads <= 0 {
+		threads = runtime.NumCPU()
 	}
+	var configErr error
+	classifierOpts = append(classifierOpts, ort.WithSessionOptions(func(so *ortlib.SessionOptions) {
+		if err := so.SetIntraOpNumThreads(threads); err != nil && configErr == nil {
+			configErr = fmt.Errorf("failed to set IntraOpNumThreads to %d: %w", threads, err)
+		}
+		if err := so.SetInterOpNumThreads(threads); err != nil && configErr == nil {
+			configErr = fmt.Errorf("failed to set InterOpNumThreads to %d: %w", threads, err)
+		}
+	}))
 	classifier, err := ort.NewClassifier(modelPath, classifierOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create ONNX classifier: %w", err)
@@ -125,18 +126,19 @@ func NewONNXCustomClassifier(modelPath string, opts ONNXCustomClassifierOptions)
 		return nil, fmt.Errorf("ONNX custom classifier requires labels or labels path")
 	}
 
-	var configErr error
-	if opts.Threads > 0 {
-		threads := opts.Threads
-		builder = builder.SessionOptions(func(so *ortlib.SessionOptions) {
-			if err := so.SetIntraOpNumThreads(threads); err != nil && configErr == nil {
-				configErr = fmt.Errorf("failed to set IntraOpNumThreads to %d: %w", threads, err)
-			}
-			if err := so.SetInterOpNumThreads(threads); err != nil && configErr == nil {
-				configErr = fmt.Errorf("failed to set InterOpNumThreads to %d: %w", threads, err)
-			}
-		})
+	threads := opts.Threads
+	if threads <= 0 {
+		threads = runtime.NumCPU()
 	}
+	var configErr error
+	builder = builder.SessionOptions(func(so *ortlib.SessionOptions) {
+		if err := so.SetIntraOpNumThreads(threads); err != nil && configErr == nil {
+			configErr = fmt.Errorf("failed to set IntraOpNumThreads to %d: %w", threads, err)
+		}
+		if err := so.SetInterOpNumThreads(threads); err != nil && configErr == nil {
+			configErr = fmt.Errorf("failed to set InterOpNumThreads to %d: %w", threads, err)
+		}
+	})
 
 	cc, err := builder.Build()
 	if err != nil {


### PR DESCRIPTION
## Summary

Serialize inference across models so only one runs at a time, and fix ONNX thread defaults to use all available CPU cores.

- Add `inferenceMu sync.Mutex` to Orchestrator that serializes all `PredictModel` calls. On RPi5 (4 cores, 4GB RAM), concurrent BirdNET + Perch inference causes memory bandwidth contention that degrades both models. Serial execution eliminates contention and lets each model use all cores.
- Each model now gets the full `settings.BirdNET.Threads` budget (not divided) since they never run simultaneously. This also resolves the thread over-allocation issue where BirdNET was constructed before `computeThreadAllocation` ran.
- Fix ONNX `Threads=0` default: resolve to `runtime.NumCPU()` instead of skipping thread configuration entirely, which left ONNX Runtime at single-threaded default. On RPi5 this cuts default-config Perch inference from **630ms to 270ms** (2.3x).
- Benchmark tool: add `-batch` flag for batch inference testing and `-xnnpack` flag for XNNPACK EP benchmarking.

Lock ordering (verified deadlock-free by 3 independent review agents):
1. `mu` (RWMutex) - models map
2. `inferenceMu` (Mutex) - inference serialization
3. `entry.mu` (Mutex) - per-model lifecycle

## Benchmark Results (RPi5, Perch v2)

| Config | Before | After | Improvement |
|--------|--------|-------|-------------|
| `threads=0` (default) | 630ms | 270ms | **2.3x faster** |
| Multi-model contention | Both models degrade | Serialized, no contention | Predictable latency |

## Test Plan

- [x] `go test -race -v ./internal/classifier/...` (551 tests pass)
- [x] `go test -race -v ./internal/inference/...` (all pass)
- [x] `golangci-lint run -v` (zero warnings)
- [x] Benchmark on RPi5 confirms 2.3x improvement for default config
- [x] Serialization test verifies slow model completes before fast model starts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a standalone CLI benchmark tool for measuring model inference latency, throughput, and output equivalence.

* **Improvements**
  * Serialized inference ordering to ensure predictable, non-overlapping model execution.
  * Revised thread allocation to use the configured CPU budget per model for consistent performance.
  * Always apply ONNX Runtime session thread configuration for reliable resource use.

* **Tests**
  * Replaced concurrency test to assert strict serialized inference ordering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3088)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->