### PR TITLE
feat(gallery): add BirdNET Geomodel v3.0 model card, split gallery by model type

### DIFF
--- a/frontend/src/lib/desktop/features/settings/pages/AnalysisSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/AnalysisSettingsPage.svelte
@@ -73,6 +73,7 @@
     Loader2,
     RefreshCw,
     Radar,
+    Globe,
     XCircle,
     X,
     Check,
@@ -159,6 +160,9 @@
   );
   const availableBats = $derived(
     catalog.filter(e => !e.installed && e.compatible && e.category === 'bat')
+  );
+  const availableGeomodels = $derived(
+    catalog.filter(e => !e.installed && e.compatible && e.category === 'geomodel')
   );
 
   // ── BirdNET locale loading ────────────────────────────────────────────
@@ -1420,7 +1424,9 @@
                 <img src={logo} alt="" class="size-10 shrink-0 rounded-lg" />
               {:else}
                 <div class="shrink-0 rounded-lg bg-[var(--color-primary)]/10 p-2.5">
-                  {#if entry.category === 'bat'}
+                  {#if entry.category === 'geomodel'}
+                    <Globe size={24} class="text-[var(--color-primary)]" />
+                  {:else if entry.category === 'bat'}
                     <Radar size={24} class="text-[var(--color-primary)]" />
                   {:else}
                     <BrainCircuit size={24} class="text-[var(--color-primary)]" />
@@ -1432,10 +1438,21 @@
                 <p class="mt-0.5 line-clamp-2 text-xs text-[var(--color-base-content)]/80">
                   {entry.description}
                 </p>
-                <p class="mt-1 text-xs text-[var(--color-base-content)]/80">{entry.author}</p>
+                {#if entry.upstreamUrl}
+                  <a
+                    href={entry.upstreamUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="mt-1 inline-block text-xs text-[var(--color-primary)]/80 hover:text-[var(--color-primary)] transition-colors"
+                  >
+                    {entry.author}
+                  </a>
+                {:else}
+                  <p class="mt-1 text-xs text-[var(--color-base-content)]/80">{entry.author}</p>
+                {/if}
               </div>
             </div>
-            <!-- Progress bar (shown during reinstall) -->
+            <!-- Progress bar (shown during reinstall, not for companion entries) -->
             {#if reinstallProgress}
               <div class="mt-3 space-y-1.5">
                 {#if reinstallProgress.status === 'complete'}
@@ -1489,9 +1506,31 @@
               <div class="text-[var(--color-base-content)]/80">
                 {t('analysis.gallery.species', { count: entry.speciesCount })}
               </div>
+              <div class="text-[var(--color-base-content)]/80">
+                {t('analysis.gallery.license.license')}
+              </div>
+              <div>
+                {#if entry.commercialUse}
+                  <span
+                    class="inline-flex items-center gap-1 rounded-full bg-[var(--color-success)]/15 px-2 py-0.5 text-xs text-[var(--color-success)]"
+                    title={t('analysis.gallery.license.commercialUseAllowed')}
+                  >
+                    <Shield class="size-3" />
+                    {entry.license}
+                  </span>
+                {:else}
+                  <span
+                    class="inline-flex items-center gap-1 rounded-full bg-[var(--color-warning)]/15 px-2 py-0.5 text-xs text-[var(--color-warning)]"
+                    title={t('analysis.gallery.license.nonCommercialOnly')}
+                  >
+                    <ShieldAlert class="size-3" />
+                    {entry.license}
+                  </span>
+                {/if}
+              </div>
             </div>
-            <!-- Geomodel badge -->
-            {#if entry.hasGeomodel}
+            <!-- Geomodel badge (for acoustic classifiers that bundle a geomodel) -->
+            {#if entry.hasGeomodel && entry.category !== 'geomodel'}
               <div class="mt-2">
                 <span
                   class="inline-flex items-center gap-1 rounded-full bg-[var(--color-info)]/15 px-2.5 py-0.5 text-xs font-medium text-[var(--color-info)]"
@@ -1557,7 +1596,9 @@
         <img src={logo} alt="" class="size-10 shrink-0 rounded-lg" />
       {:else}
         <div class="shrink-0 rounded-lg bg-[var(--color-primary)]/10 p-2.5">
-          {#if entry.category === 'bat'}
+          {#if entry.category === 'geomodel'}
+            <Globe size={24} class="text-[var(--color-primary)]" />
+          {:else if entry.category === 'bat'}
             <Radar size={24} class="text-[var(--color-primary)]" />
           {:else}
             <BrainCircuit size={24} class="text-[var(--color-primary)]" />
@@ -1586,7 +1627,7 @@
       </div>
     </div>
 
-    <!-- Progress bar (shown during install) -->
+    <!-- Progress bar (shown during install, not for companion entries) -->
     {#if progress}
       <div class="mt-3 space-y-1.5">
         {#if progress.status === 'complete'}
@@ -1655,8 +1696,8 @@
       </div>
     </div>
 
-    <!-- Geomodel badge -->
-    {#if entry.hasGeomodel}
+    <!-- Geomodel badge (for acoustic classifiers that bundle a geomodel) -->
+    {#if entry.hasGeomodel && entry.category !== 'geomodel'}
       <div class="mt-2">
         <span
           class="inline-flex items-center gap-1 rounded-full bg-[var(--color-info)]/15 px-2.5 py-0.5 text-xs font-medium text-[var(--color-info)]"
@@ -1711,55 +1752,75 @@
         </button>
       </div>
     {:else}
-      <!-- Wildlife Classifiers -->
-      {#if availableWildlife.length > 0}
-        <div>
-          <h3
-            class="mb-3 text-sm font-semibold uppercase tracking-wider text-[var(--color-base-content)]/80"
-          >
-            {t('analysis.gallery.categories.wildlife')}
-          </h3>
+      <!-- Acoustic Classifiers section -->
+      {#if availableWildlife.length > 0 || availableBirds.length > 0 || availableBats.length > 0}
+        <div class="space-y-4">
+          <h2 class="text-sm font-bold uppercase tracking-wider text-[var(--color-base-content)]">
+            {t('analysis.gallery.sections.acoustic')}
+          </h2>
+
+          {#if availableWildlife.length > 0}
+            <div>
+              <h3
+                class="mb-3 text-sm font-semibold uppercase tracking-wider text-[var(--color-base-content)]/80"
+              >
+                {t('analysis.gallery.categories.wildlife')}
+              </h3>
+              <div class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+                {#each availableWildlife as entry (entry.id)}
+                  {@render modelCard(entry)}
+                {/each}
+              </div>
+            </div>
+          {/if}
+
+          {#if availableBirds.length > 0}
+            <div>
+              <h3
+                class="mb-3 text-sm font-semibold uppercase tracking-wider text-[var(--color-base-content)]/80"
+              >
+                {t('analysis.gallery.categories.bird')}
+              </h3>
+              <div class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+                {#each availableBirds as entry (entry.id)}
+                  {@render modelCard(entry)}
+                {/each}
+              </div>
+            </div>
+          {/if}
+
+          {#if availableBats.length > 0}
+            <div>
+              <h3
+                class="mb-3 text-sm font-semibold uppercase tracking-wider text-[var(--color-base-content)]/80"
+              >
+                {t('analysis.gallery.categories.bat')}
+              </h3>
+              <div class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+                {#each availableBats as entry (entry.id)}
+                  {@render modelCard(entry)}
+                {/each}
+              </div>
+            </div>
+          {/if}
+        </div>
+      {/if}
+
+      <!-- Geomodels section -->
+      {#if availableGeomodels.length > 0}
+        <div class="space-y-4">
+          <h2 class="text-sm font-bold uppercase tracking-wider text-[var(--color-base-content)]">
+            {t('analysis.gallery.sections.geomodel')}
+          </h2>
           <div class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
-            {#each availableWildlife as entry (entry.id)}
+            {#each availableGeomodels as entry (entry.id)}
               {@render modelCard(entry)}
             {/each}
           </div>
         </div>
       {/if}
 
-      <!-- Bird Classifiers -->
-      {#if availableBirds.length > 0}
-        <div>
-          <h3
-            class="mb-3 text-sm font-semibold uppercase tracking-wider text-[var(--color-base-content)]/80"
-          >
-            {t('analysis.gallery.categories.bird')}
-          </h3>
-          <div class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
-            {#each availableBirds as entry (entry.id)}
-              {@render modelCard(entry)}
-            {/each}
-          </div>
-        </div>
-      {/if}
-
-      <!-- Bat Classifiers -->
-      {#if availableBats.length > 0}
-        <div>
-          <h3
-            class="mb-3 text-sm font-semibold uppercase tracking-wider text-[var(--color-base-content)]/80"
-          >
-            {t('analysis.gallery.categories.bat')}
-          </h3>
-          <div class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
-            {#each availableBats as entry (entry.id)}
-              {@render modelCard(entry)}
-            {/each}
-          </div>
-        </div>
-      {/if}
-
-      {#if availableWildlife.length === 0 && availableBirds.length === 0 && availableBats.length === 0}
+      {#if availableWildlife.length === 0 && availableBirds.length === 0 && availableBats.length === 0 && availableGeomodels.length === 0}
         <p class="py-8 text-center text-sm text-[var(--color-base-content)]/80">
           {t('analysis.gallery.noAvailableModels')}
         </p>

--- a/frontend/src/lib/types/models.ts
+++ b/frontend/src/lib/types/models.ts
@@ -11,7 +11,7 @@ export interface CatalogEntry {
   author: string;
   license: string;
   commercialUse: boolean;
-  category: 'wildlife' | 'bird' | 'bat';
+  category: 'wildlife' | 'bird' | 'bat' | 'geomodel';
   region: string;
   speciesCount: number;
   version: string;

--- a/frontend/static/messages/da.json
+++ b/frontend/static/messages/da.json
@@ -4582,6 +4582,10 @@
       "removing": "Removing...",
       "noInstalledModels": "No additional models installed. Browse the Available tab to add more classifiers.",
       "noAvailableModels": "No additional models available for your platform.",
+      "sections": {
+        "acoustic": "Akustiske klassifikatorer",
+        "geomodel": "Geomodeller"
+      },
       "categories": {
         "wildlife": "Wildlife Classifiers",
         "bird": "Bird Classifiers",

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -4582,6 +4582,10 @@
       "removing": "Wird entfernt...",
       "noInstalledModels": "Keine zusätzlichen Modelle installiert. Durchsuchen Sie den Tab Verfügbar, um weitere Klassifikatoren hinzuzufügen.",
       "noAvailableModels": "Keine zusätzlichen Modelle für Ihre Plattform verfügbar.",
+      "sections": {
+        "acoustic": "Akustische Klassifikatoren",
+        "geomodel": "Geomodelle"
+      },
       "categories": {
         "wildlife": "Wildtierklassifikatoren",
         "bird": "Vogelklassifikatoren",

--- a/frontend/static/messages/en.json
+++ b/frontend/static/messages/en.json
@@ -4582,6 +4582,10 @@
       "removing": "Removing...",
       "noInstalledModels": "No additional models installed. Browse the Available tab to add more classifiers.",
       "noAvailableModels": "No additional models available for your platform.",
+      "sections": {
+        "acoustic": "Acoustic Classifiers",
+        "geomodel": "Geomodels"
+      },
       "categories": {
         "wildlife": "Wildlife Classifiers",
         "bird": "Bird Classifiers",

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -4582,6 +4582,10 @@
       "removing": "Eliminando...",
       "noInstalledModels": "No hay modelos adicionales instalados. Explore la pestaña Disponibles para agregar más clasificadores.",
       "noAvailableModels": "No hay modelos adicionales disponibles para su plataforma.",
+      "sections": {
+        "acoustic": "Clasificadores acústicos",
+        "geomodel": "Geomodelos"
+      },
       "categories": {
         "wildlife": "Clasificadores de fauna",
         "bird": "Clasificadores de aves",

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -4582,6 +4582,10 @@
       "removing": "Poistetaan...",
       "noInstalledModels": "Ei asennettuja lisämalleja. Selaa Saatavilla-välilehteä lisätäksesi luokittelijoita.",
       "noAvailableModels": "Ei lisämalleja saatavilla alustallesi.",
+      "sections": {
+        "acoustic": "Akustiset luokittelijat",
+        "geomodel": "Geomallit"
+      },
       "categories": {
         "wildlife": "Eläinluokittelijat",
         "bird": "Lintuluokittelijat",

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -4582,6 +4582,10 @@
       "removing": "Suppression...",
       "noInstalledModels": "Aucun modèle supplémentaire installé. Parcourez l'onglet Disponibles pour ajouter des classificateurs.",
       "noAvailableModels": "Aucun modèle supplémentaire disponible pour votre plateforme.",
+      "sections": {
+        "acoustic": "Classificateurs acoustiques",
+        "geomodel": "Géomodèles"
+      },
       "categories": {
         "wildlife": "Classificateurs de faune",
         "bird": "Classificateurs d'oiseaux",

--- a/frontend/static/messages/hu.json
+++ b/frontend/static/messages/hu.json
@@ -4582,6 +4582,10 @@
       "removing": "Removing...",
       "noInstalledModels": "No additional models installed. Browse the Available tab to add more classifiers.",
       "noAvailableModels": "No additional models available for your platform.",
+      "sections": {
+        "acoustic": "Akusztikus osztályozók",
+        "geomodel": "Geomodellek"
+      },
       "categories": {
         "wildlife": "Wildlife Classifiers",
         "bird": "Bird Classifiers",

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -4582,6 +4582,10 @@
       "removing": "Removing...",
       "noInstalledModels": "No additional models installed. Browse the Available tab to add more classifiers.",
       "noAvailableModels": "No additional models available for your platform.",
+      "sections": {
+        "acoustic": "Classificatori acustici",
+        "geomodel": "Geomodelli"
+      },
       "categories": {
         "wildlife": "Wildlife Classifiers",
         "bird": "Bird Classifiers",

--- a/frontend/static/messages/lv.json
+++ b/frontend/static/messages/lv.json
@@ -4582,6 +4582,10 @@
       "removing": "Removing...",
       "noInstalledModels": "No additional models installed. Browse the Available tab to add more classifiers.",
       "noAvailableModels": "No additional models available for your platform.",
+      "sections": {
+        "acoustic": "Akustiskie klasifikatori",
+        "geomodel": "Ģeomodeļi"
+      },
       "categories": {
         "wildlife": "Wildlife Classifiers",
         "bird": "Bird Classifiers",

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -4582,6 +4582,10 @@
       "removing": "Verwijderen...",
       "noInstalledModels": "Geen extra modellen geïnstalleerd. Blader door het tabblad Beschikbaar om meer classificatoren toe te voegen.",
       "noAvailableModels": "Geen extra modellen beschikbaar voor uw platform.",
+      "sections": {
+        "acoustic": "Akoestische classificatoren",
+        "geomodel": "Geomodellen"
+      },
       "categories": {
         "wildlife": "Wildlifeclassificatoren",
         "bird": "Vogelclassificatoren",

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -4582,6 +4582,10 @@
       "removing": "Usuwanie...",
       "noInstalledModels": "Brak zainstalowanych dodatkowych modeli. Przejdź do karty Dostępne, aby dodać więcej klasyfikatorów.",
       "noAvailableModels": "Brak dodatkowych modeli dostępnych dla Twojej platformy.",
+      "sections": {
+        "acoustic": "Klasyfikatory akustyczne",
+        "geomodel": "Geomodele"
+      },
       "categories": {
         "wildlife": "Klasyfikatory dzikiej przyrody",
         "bird": "Klasyfikatory ptaków",

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -4582,6 +4582,10 @@
       "removing": "Removendo...",
       "noInstalledModels": "Nenhum modelo adicional instalado. Navegue na aba Disponíveis para adicionar mais classificadores.",
       "noAvailableModels": "Nenhum modelo adicional disponível para sua plataforma.",
+      "sections": {
+        "acoustic": "Classificadores acústicos",
+        "geomodel": "Geomodelos"
+      },
       "categories": {
         "wildlife": "Classificadores de fauna",
         "bird": "Classificadores de aves",

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -4582,6 +4582,10 @@
       "removing": "Removing...",
       "noInstalledModels": "No additional models installed. Browse the Available tab to add more classifiers.",
       "noAvailableModels": "No additional models available for your platform.",
+      "sections": {
+        "acoustic": "Akustické klasifikátory",
+        "geomodel": "Geomodely"
+      },
       "categories": {
         "wildlife": "Wildlife Classifiers",
         "bird": "Bird Classifiers",

--- a/frontend/static/messages/sv.json
+++ b/frontend/static/messages/sv.json
@@ -4582,6 +4582,10 @@
       "removing": "Removing...",
       "noInstalledModels": "No additional models installed. Browse the Available tab to add more classifiers.",
       "noAvailableModels": "No additional models available for your platform.",
+      "sections": {
+        "acoustic": "Akustiska klassificerare",
+        "geomodel": "Geomodeller"
+      },
       "categories": {
         "wildlife": "Wildlife Classifiers",
         "bird": "Bird Classifiers",

--- a/internal/classifier/model_catalog.go
+++ b/internal/classifier/model_catalog.go
@@ -10,6 +10,7 @@ const (
 	CategoryWildlife = "wildlife"
 	CategoryBird     = "bird"
 	CategoryBat      = "bat"
+	CategoryGeomodel = "geomodel"
 )
 
 // CatalogFile role constants.
@@ -31,7 +32,7 @@ type CatalogEntry struct {
 	Author          string        // model author or organization
 	License         string        // license identifier (e.g., "Apache-2.0")
 	CommercialUse   bool          // whether commercial use is permitted
-	Category        string        // "wildlife", "bird", or "bat"
+	Category        string        // "wildlife", "bird", "bat", or "geomodel"
 	Region          string        // geographic region, or empty for global models
 	SpeciesCount    int           // number of species the model can identify
 	Version         string        // model version string
@@ -121,6 +122,25 @@ var EmbeddedCatalog = []CatalogEntry{
 			{RemotePath: "BSG_birds_Finland_v4_4_distribution.bin", LocalName: "BSG_birds_Finland_v4_4_distribution.bin", Role: RoleData, SHA256: "0617f19f3eca7f7bc409e3d853d742a171a835464862dc3ced2f5b72ef3093f5", SizeBytes: 25828768},
 			{RemotePath: "BSG_birds_Finland_v4_4_migration.csv", LocalName: "BSG_birds_Finland_v4_4_migration.csv", Role: RoleData, SHA256: "a3fdbfc744645f6945def7fbfa3ee19e347c31d1b46ae78fba75e7059b54a86b", SizeBytes: 17054},
 		},
+	},
+
+	// Geomodels (spatiotemporal species occurrence prediction)
+	{
+		ID:              "birdnet-geomodel-v3",
+		Name:            "BirdNET Geomodel v3.0",
+		Description:     "Spatiotemporal species occurrence prediction for post-filtering acoustic detections. Predicts which species are likely at a given location and week of the year.",
+		Author:          "Stefan Kahl, Cornell Lab of Ornithology",
+		License:         "CC BY-SA 4.0",
+		CommercialUse:   true,
+		Category:        CategoryGeomodel,
+		Region:          "",
+		SpeciesCount:    12012,
+		Version:         "3.0.2",
+		GeomodelVersion: "v3",
+		RegistryID:      "",
+		UpstreamURL:     "https://github.com/birdnet-team/geomodel",
+		HuggingFaceRepo: geomodelHuggingFaceRepo,
+		Files:           geomodelFiles(),
 	},
 
 	// Bat models (BattyBirdNET family by rdz-oss)
@@ -224,6 +244,20 @@ func isTaxonomyRole(role string) bool { return role == RoleTaxonomy }
 // isSharedRole reports whether the given file role stores into models/shared/.
 func isSharedRole(role string) bool {
 	return role == RoleEmbeddings || role == RoleTaxonomy || isGeomodelRole(role)
+}
+
+// IsSharedOnly reports whether all files in a catalog entry use shared roles
+// (stored in models/shared/ rather than a per-model subdirectory).
+func IsSharedOnly(entry *CatalogEntry) bool {
+	if len(entry.Files) == 0 {
+		return false
+	}
+	for _, f := range entry.Files {
+		if !isSharedRole(f.Role) {
+			return false
+		}
+	}
+	return true
 }
 
 // HasTaxonomyFiles reports whether a catalog entry includes shared taxonomy files.
@@ -339,7 +373,7 @@ func VisibleCatalog() []CatalogEntry {
 }
 
 // CatalogByCategory groups visible catalog entries by their Category field
-// (e.g., "bird", "bat") and returns the resulting map.
+// (e.g., "wildlife", "bird", "bat", "geomodel") and returns the resulting map.
 func CatalogByCategory() map[string][]CatalogEntry {
 	visible := VisibleCatalog()
 	grouped := make(map[string][]CatalogEntry)

--- a/internal/classifier/model_catalog_test.go
+++ b/internal/classifier/model_catalog_test.go
@@ -21,6 +21,10 @@ func TestEmbeddedCatalog_ValidRegistryIDs(t *testing.T) {
 	t.Parallel()
 
 	for _, entry := range EmbeddedCatalog {
+		// Shared-only entries (e.g. geomodels) have no RegistryID.
+		if IsSharedOnly(&entry) {
+			continue
+		}
 		assert.NotEmpty(t, entry.RegistryID, "catalog entry %q must have a RegistryID", entry.ID)
 		_, exists := ModelRegistry[entry.RegistryID]
 		assert.True(t, exists, "catalog entry %q references unknown RegistryID %q", entry.ID, entry.RegistryID)
@@ -32,6 +36,11 @@ func TestEmbeddedCatalog_HasFilesWithModelRole(t *testing.T) {
 
 	for _, entry := range EmbeddedCatalog {
 		require.NotEmpty(t, entry.Files, "catalog entry %q has no files", entry.ID)
+
+		// Shared-only entries (e.g. geomodels) use geomodel-role files instead of RoleModel.
+		if IsSharedOnly(&entry) {
+			continue
+		}
 
 		hasModel := false
 		for _, f := range entry.Files {
@@ -47,7 +56,7 @@ func TestEmbeddedCatalog_HasFilesWithModelRole(t *testing.T) {
 func TestEmbeddedCatalog_ValidCategories(t *testing.T) {
 	t.Parallel()
 
-	validCategories := map[string]bool{CategoryWildlife: true, CategoryBird: true, CategoryBat: true}
+	validCategories := map[string]bool{CategoryWildlife: true, CategoryBird: true, CategoryBat: true, CategoryGeomodel: true}
 	for _, entry := range EmbeddedCatalog {
 		assert.True(t, validCategories[entry.Category],
 			"catalog entry %q has invalid category %q (must be \"wildlife\", \"bird\", or \"bat\")", entry.ID, entry.Category)
@@ -77,23 +86,26 @@ func TestCatalogByCategory(t *testing.T) {
 
 	grouped := CatalogByCategory()
 
-	// Should have wildlife and bat categories (bird entries are currently hidden)
+	// Should have wildlife, bat, and geomodel categories (bird entries are currently hidden)
 	require.Contains(t, grouped, CategoryWildlife)
 	require.Contains(t, grouped, CategoryBat)
+	require.Contains(t, grouped, CategoryGeomodel)
 
-	// All wildlife entries should have the wildlife category
+	// All entries in each group should have the matching category
 	for _, entry := range grouped[CategoryWildlife] {
 		assert.Equal(t, CategoryWildlife, entry.Category)
 	}
-
-	// All bat entries should have the bat category
 	for _, entry := range grouped[CategoryBat] {
 		assert.Equal(t, CategoryBat, entry.Category)
 	}
+	for _, entry := range grouped[CategoryGeomodel] {
+		assert.Equal(t, CategoryGeomodel, entry.Category)
+	}
 
-	// Verify expected counts (1 visible wildlife, 0 visible bird, 11 bat entries)
+	// Verify expected counts
 	assert.Len(t, grouped[CategoryWildlife], 1, "expected 1 visible wildlife catalog entry")
 	assert.Empty(t, grouped[CategoryBird], "expected 0 visible bird catalog entries")
+	assert.Len(t, grouped[CategoryGeomodel], 1, "expected 1 visible geomodel catalog entry")
 	assert.Len(t, grouped[CategoryBat], 11, "expected 11 bat catalog entries")
 }
 
@@ -121,8 +133,8 @@ func TestEmbeddedCatalog_BatEntriesHaveEmbeddingsFile(t *testing.T) {
 func TestEmbeddedCatalog_EntryCount(t *testing.T) {
 	t.Parallel()
 
-	// 2 wildlife entries (birdnet-v3.0, perch-v2) + 1 bird entry (bsg-finland) + 11 bat entries = 14 total
-	assert.Len(t, EmbeddedCatalog, 14, "expected 14 total catalog entries")
+	// 2 wildlife + 1 bird + 1 geomodel + 11 bat = 15 total
+	assert.Len(t, EmbeddedCatalog, 15, "expected 15 total catalog entries")
 }
 
 func TestVisibleCatalog_ExcludesHiddenEntries(t *testing.T) {

--- a/internal/classifier/model_catalog_test.go
+++ b/internal/classifier/model_catalog_test.go
@@ -59,7 +59,7 @@ func TestEmbeddedCatalog_ValidCategories(t *testing.T) {
 	validCategories := map[string]bool{CategoryWildlife: true, CategoryBird: true, CategoryBat: true, CategoryGeomodel: true}
 	for _, entry := range EmbeddedCatalog {
 		assert.True(t, validCategories[entry.Category],
-			"catalog entry %q has invalid category %q (must be \"wildlife\", \"bird\", or \"bat\")", entry.ID, entry.Category)
+			"catalog entry %q has invalid category %q (must be \"wildlife\", \"bird\", \"bat\", or \"geomodel\")", entry.ID, entry.Category)
 	}
 }
 

--- a/internal/classifier/model_manager.go
+++ b/internal/classifier/model_manager.go
@@ -121,7 +121,13 @@ func (mm *ModelManager) ScanInstalled() {
 				labelsFile = f.LocalName
 			}
 		}
+
+		// Shared-only entries (e.g. geomodels): all files live in models/shared/.
+		// Detect these by checking that every file is a shared role and all exist.
 		if modelFile == "" {
+			if mm.scanSharedOnlyEntry(log, entry) {
+				continue
+			}
 			continue
 		}
 
@@ -321,6 +327,47 @@ func (mm *ModelManager) IsInstalled(catalogID string) bool {
 	defer mm.mu.RUnlock()
 	_, ok := mm.installed[catalogID]
 	return ok
+}
+
+// scanSharedOnlyEntry checks whether a catalog entry whose files all live in
+// models/shared/ (e.g. geomodels) is installed. If all shared files exist on
+// disk, it registers the entry in mm.installed and returns true. The caller
+// must hold mm.mu.
+func (mm *ModelManager) scanSharedOnlyEntry(log logger.Logger, entry *CatalogEntry) bool {
+	if !IsSharedOnly(entry) {
+		return false
+	}
+	sharedDir := filepath.Join(mm.modelsDir, "shared")
+	var modelPath, labelsPath string
+	for _, f := range entry.Files {
+		p := filepath.Join(sharedDir, f.LocalName)
+		if _, err := os.Stat(p); err != nil {
+			return false
+		}
+		switch f.Role {
+		case RoleGeomodelModel:
+			if modelPath == "" {
+				modelPath = p
+			}
+		case RoleGeomodelLabels:
+			labelsPath = p
+		default:
+			if modelPath == "" {
+				modelPath = p
+			}
+		}
+	}
+	mm.installed[entry.ID] = InstalledModel{
+		CatalogID:   entry.ID,
+		ModelPath:   modelPath,
+		LabelsPath:  labelsPath,
+		InstalledAt: fileModTime(modelPath),
+		Version:     entry.Version,
+	}
+	log.Debug("Found installed shared-only model",
+		logger.String("catalog_id", entry.ID),
+		logger.String("path", modelPath))
+	return true
 }
 
 // ListInstalled returns a copy of all installed models.
@@ -595,17 +642,20 @@ func (mm *ModelManager) Reinstall(ctx context.Context, entry *CatalogEntry, base
 func (mm *ModelManager) downloadModelFiles(ctx context.Context, entry *CatalogEntry, baseURL string, progress chan<- DownloadState, cleanupOnFailure bool) error {
 	log := GetLogger()
 
-	// Create model subdirectory.
+	// Create model subdirectory only if the entry has non-shared files.
+	// Shared-only entries (e.g. geomodels) store all files in models/shared/.
 	subdir := filepath.Join(mm.modelsDir, entry.ID)
-	if err := os.MkdirAll(subdir, 0o755); err != nil {
-		mkdirErr := errors.Newf("failed to create model directory %s: %v", subdir, err).
-			Component("classifier.model_manager").
-			Category(errors.CategoryFileIO).
-			Context("catalog_id", entry.ID).
-			Context("directory", subdir).
-			Build()
-		mm.markFailed(entry.ID, mkdirErr, progress)
-		return mkdirErr
+	if !IsSharedOnly(entry) {
+		if err := os.MkdirAll(subdir, 0o755); err != nil {
+			mkdirErr := errors.Newf("failed to create model directory %s: %v", subdir, err).
+				Component("classifier.model_manager").
+				Category(errors.CategoryFileIO).
+				Context("catalog_id", entry.ID).
+				Context("directory", subdir).
+				Build()
+			mm.markFailed(entry.ID, mkdirErr, progress)
+			return mkdirErr
+		}
 	}
 
 	// Track files we downloaded so we can clean up on failure.
@@ -717,6 +767,9 @@ func (mm *ModelManager) downloadModelFiles(ctx context.Context, entry *CatalogEn
 		}
 	}
 
+	// For shared-only entries (e.g. geomodels), derive paths from shared files.
+	modelPath, labelsPath = resolveSharedPaths(entry, modelPath, labelsPath, fileDestPath)
+
 	// Record as installed.
 	mm.mu.Lock()
 	mm.installed[entry.ID] = InstalledModel{
@@ -769,6 +822,23 @@ func (mm *ModelManager) hotLoadAfterInstall(log logger.Logger, entry *CatalogEnt
 				logger.Error(err))
 		}
 	}
+}
+
+// resolveSharedPaths fills in modelPath and labelsPath for shared-only entries
+// (e.g. geomodels) that have no RoleModel or RoleLabels files.
+func resolveSharedPaths(entry *CatalogEntry, modelPath, labelsPath string, destPath func(CatalogFile) string) (resolvedModel, resolvedLabels string) {
+	if modelPath != "" {
+		return modelPath, labelsPath
+	}
+	for _, f := range entry.Files {
+		if f.Role == RoleGeomodelModel {
+			modelPath = destPath(f)
+		}
+		if f.Role == RoleGeomodelLabels && labelsPath == "" {
+			labelsPath = destPath(f)
+		}
+	}
+	return modelPath, labelsPath
 }
 
 // sendProgress sends a non-blocking status update to the progress channel.

--- a/internal/classifier/model_manager.go
+++ b/internal/classifier/model_manager.go
@@ -346,16 +346,13 @@ func (mm *ModelManager) scanSharedOnlyEntry(log logger.Logger, entry *CatalogEnt
 		}
 		switch f.Role {
 		case RoleGeomodelModel:
-			if modelPath == "" {
-				modelPath = p
-			}
+			modelPath = p
 		case RoleGeomodelLabels:
 			labelsPath = p
-		default:
-			if modelPath == "" {
-				modelPath = p
-			}
 		}
+	}
+	if modelPath == "" {
+		return false
 	}
 	mm.installed[entry.ID] = InstalledModel{
 		CatalogID:   entry.ID,
@@ -831,10 +828,10 @@ func resolveSharedPaths(entry *CatalogEntry, modelPath, labelsPath string, destP
 		return modelPath, labelsPath
 	}
 	for _, f := range entry.Files {
-		if f.Role == RoleGeomodelModel {
+		switch f.Role {
+		case RoleGeomodelModel:
 			modelPath = destPath(f)
-		}
-		if f.Role == RoleGeomodelLabels && labelsPath == "" {
+		case RoleGeomodelLabels:
 			labelsPath = destPath(f)
 		}
 	}

--- a/internal/classifier/model_manager_test.go
+++ b/internal/classifier/model_manager_test.go
@@ -148,6 +148,13 @@ func TestModelManager_UninstallRemovesModelRetainsLabels(t *testing.T) {
 	mm.ScanInstalled()
 	require.True(t, mm.IsInstalled(entry.ID))
 
+	// The standalone geomodel entry also gets detected as installed because
+	// its shared files exist. Uninstall it first so that shared geomodel
+	// files are not retained by the standalone entry.
+	if mm.IsInstalled("birdnet-geomodel-v3") {
+		require.NoError(t, mm.Uninstall("birdnet-geomodel-v3"))
+	}
+
 	require.NoError(t, mm.Uninstall(entry.ID))
 	assert.False(t, mm.IsInstalled(entry.ID))
 
@@ -500,6 +507,11 @@ func TestModelManager_UninstallSucceedsWhenModelNotLoaded(t *testing.T) {
 	mm.ScanInstalled()
 	require.True(t, mm.IsInstalled(entry.ID), "model must be installed before uninstall")
 
+	// Remove standalone geomodel entry so shared files are not retained.
+	if mm.IsInstalled("birdnet-geomodel-v3") {
+		require.NoError(t, mm.Uninstall("birdnet-geomodel-v3"))
+	}
+
 	err := mm.Uninstall(entry.ID)
 	require.NoError(t, err, "Uninstall must succeed when model is not loaded")
 	assert.False(t, mm.IsInstalled(entry.ID), "model must be removed from installed map")
@@ -746,8 +758,11 @@ func TestModelManager_Uninstall_GeomodelRetainedWhenDependentExists(t *testing.T
 		}
 	}
 
-	// Now uninstall birdnet-v3.0; no dependents remain.
+	// Now uninstall birdnet-v3.0 and the standalone geomodel entry.
 	require.NoError(t, mm.Uninstall("birdnet-v3.0"))
+	if mm.IsInstalled("birdnet-geomodel-v3") {
+		require.NoError(t, mm.Uninstall("birdnet-geomodel-v3"))
+	}
 
 	// Shared geomodel files should now be deleted.
 	for _, f := range entryV3.Files {


### PR DESCRIPTION
## Summary

- Add BirdNET Geomodel v3.0 as an independently installable model gallery entry with proper attribution (Stefan Kahl, Cornell Lab of Ornithology, CC BY-SA 4.0, 12,012 species, upstream: github.com/birdnet-team/geomodel)
- Split the model gallery Available tab into "Acoustic Classifiers" and "Geomodels" sections, making the gallery extensible for future model types
- Extend ModelManager to handle shared-only catalog entries (entries whose files all live in `models/shared/`) for install, scan, and uninstall

## Changes

**Backend (`internal/classifier/`):**
- New `CategoryGeomodel` constant and BirdNET Geomodel v3.0 catalog entry reusing `geomodelFiles()` helper
- New `IsSharedOnly()` helper to detect entries stored entirely in `models/shared/`
- `ScanInstalled()` extended with `scanSharedOnlyEntry()` to detect installed shared-only entries
- `downloadModelFiles()` skips per-model subdirectory creation for shared-only entries
- New `resolveSharedPaths()` extracts geomodel model/labels paths for `InstalledModel` records

**Frontend:**
- `'geomodel'` added to `CatalogEntry` category union type
- Globe icon (Lucide) for geomodel entries in both installed and available tabs
- Available tab split with "Acoustic Classifiers" and "Geomodels" section headers
- Upstream URL shown as clickable author link on installed cards
- License badge display added to installed card metadata grid
- "Includes geomodel" badge hidden on geomodel entries themselves

**i18n:**
- `sections.acoustic` and `sections.geomodel` keys added to all 14 locale files

## Test plan
- [ ] Verify geomodel card appears in Available tab under "Geomodels" section
- [ ] Verify geomodel shows as installed when shared geomodel files exist
- [ ] Verify install/remove buttons work for standalone geomodel entry
- [ ] Verify acoustic classifiers still grouped under "Acoustic Classifiers" header
- [ ] Verify Globe icon renders for geomodel, BrainCircuit for wildlife/bird, Radar for bat
- [ ] Run `golangci-lint run -v` (zero issues)
- [ ] Run `npm run check:all` (zero errors)
- [ ] Run `go test -race ./internal/classifier/... -run TestCatalog` (pass)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated "Geomodels" section and reorganized the gallery into Acoustic Classifiers (Wildlife/Bird/Bat) and Geomodels.
  * Model cards show a globe icon for geomodels, link authors to upstream URLs when available, and display license badges (commercial vs non-commercial).
  * Empty-state handling and gallery headings updated; translations for the new sections added across locales.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3091)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->