### PR TITLE
feat(processor): add bat false positive filter, fix model-aware thresholds

### DIFF
--- a/frontend/src/lib/desktop/features/settings/pages/AnalysisSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/AnalysisSettingsPage.svelte
@@ -1057,6 +1057,7 @@
               <input
                 id="bat-false-positive-filter-level"
                 type="range"
+                aria-describedby="bat-false-positive-filter-help"
                 class="w-full h-2 bg-[var(--color-base-300)] rounded-lg appearance-none cursor-pointer accent-[var(--color-primary)]"
                 min={0}
                 max={5}
@@ -1066,7 +1067,10 @@
                 disabled={store.isLoading || store.isSaving}
               />
               <div class="mt-1">
-                <span class="text-xs text-[var(--color-base-content)] opacity-60">
+                <span
+                  id="bat-false-positive-filter-help"
+                  class="text-xs text-[var(--color-base-content)] opacity-60"
+                >
                   {getBatFalsePositiveFilterDescription(batFPLevel)}
                 </span>
               </div>

--- a/frontend/src/lib/desktop/features/settings/pages/AnalysisSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/AnalysisSettingsPage.svelte
@@ -143,12 +143,14 @@
       threshold: 0.5,
       filterEnabled: false,
       nighttimeOnly: true,
+      falsePositiveFilter: { level: 0 },
       ultrasonicFilter: { enabled: true },
     }
   );
 
   // Check if a bat model is installed
   const hasBatModel = $derived(catalog.some(e => e.installed && e.category === 'bat'));
+  const batFPLevel = $derived(bat.falsePositiveFilter?.level ?? 0);
 
   // ── Derived catalog views ─────────────────────────────────────────────
   const installedEntries = $derived(catalog.filter(e => e.installed));
@@ -685,6 +687,40 @@
     });
   }
 
+  function updateBatFalsePositiveFilterLevel(newLevel: number) {
+    settingsActions.updateSection('bat', {
+      falsePositiveFilter: { level: newLevel },
+    });
+  }
+
+  // Bat FP filter calculation helpers.
+  // The bat model uses a fixed 50% overlap (1.5s step for 3s clip),
+  // yielding 4 possible detections in a 6-second reference window.
+  const BAT_MAX_DETECTIONS_IN_WINDOW = 4;
+
+  function calculateBatMinDetections(level: number): number {
+    if (level === 0) return 1;
+    const levelData = safeArrayAccess(falsePositiveFilterLevels, level);
+    if (!levelData) return 1;
+    const required = BAT_MAX_DETECTIONS_IN_WINDOW * levelData.threshold - FLOAT_EPSILON;
+    return Math.max(1, Math.ceil(required));
+  }
+
+  function getBatFalsePositiveFilterDescription(level: number): string {
+    const levelData = safeArrayAccess(falsePositiveFilterLevels, level);
+    if (!levelData) return '';
+
+    const minDet = calculateBatMinDetections(level);
+    const baseDescription = t(levelData.descriptionKey);
+
+    if (level === 0) return baseDescription;
+
+    return t('settings.main.sections.falsePositiveFilter.detectionCount', {
+      count: minDet.toString(),
+      description: baseDescription,
+    });
+  }
+
   function updateThreshold(value: number) {
     settingsActions.updateSection('birdnet', { threshold: value });
   }
@@ -919,6 +955,7 @@
         batThreshold: store.originalData.bat?.threshold,
         batNighttimeOnly: store.originalData.bat?.nighttimeOnly,
         batUltrasonicFilter: store.originalData.bat?.ultrasonicFilter?.enabled ?? true,
+        batFPFilter: store.originalData.bat?.falsePositiveFilter?.level ?? 0,
       }}
       currentData={{
         threshold: birdnet?.threshold,
@@ -926,6 +963,7 @@
         batThreshold: bat.threshold,
         batNighttimeOnly: bat.nighttimeOnly,
         batUltrasonicFilter: bat.ultrasonicFilter?.enabled ?? true,
+        batFPFilter: batFPLevel,
       }}
     >
       <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
@@ -996,6 +1034,44 @@
             disabled={store.isLoading || store.isSaving}
             onchange={updateBatUltrasonicFilter}
           />
+
+          <!-- Bat False Positive Filter -->
+          <div class="md:col-span-2">
+            <div class="min-w-0">
+              <label
+                for="bat-false-positive-filter-level"
+                class="flex items-center justify-between mb-2"
+              >
+                <span class="text-sm font-medium text-[var(--color-base-content)]">
+                  {t('analysis.detection.batFalsePositiveFilter.label')}
+                </span>
+                <span
+                  class={cn(
+                    'inline-flex items-center justify-center px-2 py-0.5 text-xs font-medium rounded-full',
+                    getFalsePositiveFilterBadgeClass(batFPLevel)
+                  )}
+                >
+                  {getFalsePositiveFilterLevelName(batFPLevel)}
+                </span>
+              </label>
+              <input
+                id="bat-false-positive-filter-level"
+                type="range"
+                class="w-full h-2 bg-[var(--color-base-300)] rounded-lg appearance-none cursor-pointer accent-[var(--color-primary)]"
+                min={0}
+                max={5}
+                step={1}
+                value={batFPLevel}
+                oninput={e => updateBatFalsePositiveFilterLevel(parseInt(e.currentTarget.value))}
+                disabled={store.isLoading || store.isSaving}
+              />
+              <div class="mt-1">
+                <span class="text-xs text-[var(--color-base-content)] opacity-60">
+                  {getBatFalsePositiveFilterDescription(batFPLevel)}
+                </span>
+              </div>
+            </div>
+          </div>
         {/if}
       </div>
     </SettingsSection>

--- a/frontend/src/lib/stores/settings.ts
+++ b/frontend/src/lib/stores/settings.ts
@@ -116,6 +116,9 @@ export interface BatSettings {
   locale?: string;
   filterEnabled: boolean;
   nighttimeOnly: boolean;
+  falsePositiveFilter?: {
+    level: number;
+  };
   ultrasonicFilter?: {
     enabled: boolean;
   };

--- a/frontend/static/messages/da.json
+++ b/frontend/static/messages/da.json
@@ -4535,6 +4535,10 @@
         "label": "Validering efter detektion",
         "helpText": "Når aktiveret, valideres flagermusdetektioner ved at analysere ultralydsmønstre i kildeoptagelsen. Detektioner uden typiske flagermus-ekkolokationskarakteristika markeres som usandsynlige."
       },
+      "batFalsePositiveFilter": {
+        "label": "Flagermus falsk-positiv filter",
+        "helpText": "Kræver flere bekræftelser af en flagermusdetektion inden for et glidende vindue, før den accepteres. Højere niveauer kræver flere bekræftelser, hvilket reducerer falske positiver. Flagermusmodellen bruger et fast 50% overlap, så ingen overlapjustering er nødvendig."
+      },
       "locale": {
         "label": "Species Language",
         "helpText": "Language used for species common names in the interface."

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -4535,6 +4535,10 @@
         "label": "Nachträgliche Validierung",
         "helpText": "Wenn aktiviert, werden Fledermauserkennungen durch Analyse der Ultraschall-Energiemuster in der Quellaufnahme validiert. Erkennungen ohne typische Echoortungsmerkmale werden als unwahrscheinlich markiert."
       },
+      "batFalsePositiveFilter": {
+        "label": "Fledermaus-Falsch-Positiv-Filter",
+        "helpText": "Erfordert mehrere Bestätigungen einer Fledermauserkennung innerhalb eines gleitenden Fensters, bevor sie akzeptiert wird. Höhere Stufen erfordern mehr Bestätigungen und reduzieren Fehlerkennungen. Das Fledermausmodell verwendet eine feste 50%-Überlappung, daher ist keine Überlappungsanpassung erforderlich."
+      },
       "locale": {
         "label": "Species Language",
         "helpText": "Language used for species common names in the interface."

--- a/frontend/static/messages/en.json
+++ b/frontend/static/messages/en.json
@@ -4535,6 +4535,10 @@
         "label": "Post Detection Validation",
         "helpText": "When enabled, bat detections are validated by analyzing ultrasonic energy patterns in the source audio. Detections that lack bat echolocation characteristics are tagged as unlikely."
       },
+      "batFalsePositiveFilter": {
+        "label": "Bat False Positive Filter",
+        "helpText": "Requires multiple confirmations of a bat detection within a sliding window before accepting it. Higher levels require more confirmations, reducing false positives. The bat model uses a fixed 50% overlap, so no overlap adjustment is needed."
+      },
       "locale": {
         "label": "Species Language",
         "helpText": "Language used for species common names in the interface."

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -4535,6 +4535,10 @@
         "label": "Validación posterior a la detección",
         "helpText": "Cuando está activado, las detecciones de murciélagos se validan analizando los patrones de energía ultrasónica en el audio fuente. Las detecciones sin características de ecolocalización se marcan como improbables."
       },
+      "batFalsePositiveFilter": {
+        "label": "Filtro de falsos positivos de murciélagos",
+        "helpText": "Requiere múltiples confirmaciones de una detección de murciélago dentro de una ventana deslizante antes de aceptarla. Niveles más altos requieren más confirmaciones, reduciendo los falsos positivos. El modelo de murciélagos usa una superposición fija del 50%, por lo que no se necesita ajuste de superposición."
+      },
       "locale": {
         "label": "Species Language",
         "helpText": "Language used for species common names in the interface."

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -4535,6 +4535,10 @@
         "label": "Tunnistuksen jälkitarkistus",
         "helpText": "Kun käytössä, lepakkotunnistukset validoidaan analysoimalla ultraäänienergiakuvioita lähdeäänitteestä. Tunnistukset, joista puuttuvat kaikuluotausominaisuudet, merkitään epätodennäköisiksi."
       },
+      "batFalsePositiveFilter": {
+        "label": "Lepakon väärien positiivisten suodatin",
+        "helpText": "Vaatii useita vahvistuksia lepakkotunnistuksesta liukuvan ikkunan sisällä ennen kuin se hyväksytään. Korkeammat tasot vaativat enemmän vahvistuksia, mikä vähentää vääriä positiivisia. Lepakkomalli käyttää kiinteää 50 % päällekkäisyyttä, joten päällekkäisyyden säätöä ei tarvita."
+      },
       "locale": {
         "label": "Species Language",
         "helpText": "Language used for species common names in the interface."

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -4535,6 +4535,10 @@
         "label": "Validation post-détection",
         "helpText": "Lorsqu'activé, les détections de chauves-souris sont validées en analysant les motifs d'énergie ultrasonique dans l'audio source. Les détections sans caractéristiques d'écholocation sont marquées comme improbables."
       },
+      "batFalsePositiveFilter": {
+        "label": "Filtre de faux positifs chauves-souris",
+        "helpText": "Nécessite plusieurs confirmations d'une détection de chauve-souris dans une fenêtre glissante avant de l'accepter. Les niveaux supérieurs nécessitent plus de confirmations, réduisant les faux positifs. Le modèle chauve-souris utilise un chevauchement fixe de 50 %, aucun ajustement n'est donc nécessaire."
+      },
       "locale": {
         "label": "Species Language",
         "helpText": "Language used for species common names in the interface."

--- a/frontend/static/messages/hu.json
+++ b/frontend/static/messages/hu.json
@@ -4535,6 +4535,10 @@
         "label": "Utólagos érzékelés-ellenőrzés",
         "helpText": "Bekapcsolva a denevérészleléseket az ultrahang-energiaminták elemzésével ellenőrzi a forrásanyagban. Az echolokációs jellemzőkkel nem rendelkező észleléseket valószínűtlenként jelöli meg."
       },
+      "batFalsePositiveFilter": {
+        "label": "Denevér hamis pozitív szűrő",
+        "helpText": "Több megerősítést igényel egy denevérészleléshez egy csúszó ablakon belül, mielőtt elfogadná. A magasabb szintek több megerősítést igényelnek, csökkentve a hamis pozitívokat. A denevérmodell fix 50%-os átfedést használ, így átfedés-beállítás nem szükséges."
+      },
       "locale": {
         "label": "Species Language",
         "helpText": "Language used for species common names in the interface."

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -4535,6 +4535,10 @@
         "label": "Validazione post-rilevamento",
         "helpText": "Quando abilitato, i rilevamenti di pipistrelli vengono validati analizzando i pattern di energia ultrasonica nell'audio sorgente. I rilevamenti privi di caratteristiche di ecolocalizzazione vengono contrassegnati come improbabili."
       },
+      "batFalsePositiveFilter": {
+        "label": "Filtro falsi positivi pipistrelli",
+        "helpText": "Richiede multiple conferme di un rilevamento di pipistrello all'interno di una finestra scorrevole prima di accettarlo. Livelli più alti richiedono più conferme, riducendo i falsi positivi. Il modello pipistrelli usa una sovrapposizione fissa del 50%, quindi non è necessario alcun aggiustamento."
+      },
       "locale": {
         "label": "Species Language",
         "helpText": "Language used for species common names in the interface."

--- a/frontend/static/messages/lv.json
+++ b/frontend/static/messages/lv.json
@@ -4535,6 +4535,10 @@
         "label": "Pēcnoteikšanas validācija",
         "helpText": "Kad iespējots, sikspārņu noteikšana tiek pārbaudīta, analizējot ultraskaņas enerģijas modeļus avota ierakstā. Noteikšanas bez eholokācijas pazīmēm tiek atzīmētas kā maz ticamas."
       },
+      "batFalsePositiveFilter": {
+        "label": "Sikspārņu viltus pozitīvo filtrs",
+        "helpText": "Pieprasa vairākus apstiprinājumus sikspārņu noteikšanai slīdošajā logā pirms tā pieņemšanas. Augstāki līmeņi pieprasa vairāk apstiprinājumu, samazinot viltus pozitīvos. Sikspārņu modelis izmanto fiksētu 50% pārklāšanos, tāpēc pārklāšanās pielāgošana nav nepieciešama."
+      },
       "locale": {
         "label": "Species Language",
         "helpText": "Language used for species common names in the interface."

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -4535,6 +4535,10 @@
         "label": "Validatie na detectie",
         "helpText": "Indien ingeschakeld worden vleermuisdetecties gevalideerd door analyse van ultrasone energiepatronen in de bronaudio. Detecties zonder echolocatiekenmerken worden gemarkeerd als onwaarschijnlijk."
       },
+      "batFalsePositiveFilter": {
+        "label": "Vleermuis vals-positief filter",
+        "helpText": "Vereist meerdere bevestigingen van een vleermuisdetectie binnen een schuifvenster voordat deze wordt geaccepteerd. Hogere niveaus vereisen meer bevestigingen, waardoor valse positieven worden verminderd. Het vleermuismodel gebruikt een vaste overlap van 50%, dus er is geen overlapaanpassing nodig."
+      },
       "locale": {
         "label": "Species Language",
         "helpText": "Language used for species common names in the interface."

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -4535,6 +4535,10 @@
         "label": "Walidacja po wykryciu",
         "helpText": "Po włączeniu wykrycia nietoperzy są weryfikowane przez analizę wzorców energii ultradźwiękowej w nagraniu źródłowym. Wykrycia bez cech echolokacji są oznaczane jako mało prawdopodobne."
       },
+      "batFalsePositiveFilter": {
+        "label": "Filtr fałszywie pozytywnych nietoperzy",
+        "helpText": "Wymaga wielu potwierdzeń wykrycia nietoperza w przesuwnym oknie czasowym przed jego zaakceptowaniem. Wyższe poziomy wymagają więcej potwierdzeń, zmniejszając liczbę fałszywych wykryć. Model nietoperzy używa stałego 50% nakładania, więc nie jest wymagana regulacja nakładania."
+      },
       "locale": {
         "label": "Species Language",
         "helpText": "Language used for species common names in the interface."

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -4535,6 +4535,10 @@
         "label": "Validação pós-deteção",
         "helpText": "Quando ativado, as deteções de morcegos são validadas pela análise dos padrões de energia ultrassónica no áudio de origem. Deteções sem características de ecolocalização são marcadas como improváveis."
       },
+      "batFalsePositiveFilter": {
+        "label": "Filtro de falsos positivos de morcegos",
+        "helpText": "Requer múltiplas confirmações de uma deteção de morcego dentro de uma janela deslizante antes de a aceitar. Níveis mais altos requerem mais confirmações, reduzindo falsos positivos. O modelo de morcegos usa uma sobreposição fixa de 50%, portanto não é necessário ajuste de sobreposição."
+      },
       "locale": {
         "label": "Species Language",
         "helpText": "Language used for species common names in the interface."

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -4535,6 +4535,10 @@
         "label": "Overenie po detekcii",
         "helpText": "Keď je zapnuté, detekcie netopierov sa overujú analýzou ultrazvukových energetických vzorcov v zdrojovom zvuku. Detekcie bez charakteristík echolokácie sú označené ako nepravdepodobné."
       },
+      "batFalsePositiveFilter": {
+        "label": "Filter falošne pozitívnych netopierov",
+        "helpText": "Vyžaduje viacero potvrdení detekcie netopiera v posuvnom okne pred jej prijatím. Vyššie úrovne vyžadujú viac potvrdení, čím sa znižujú falošné pozitíva. Model netopierov používa pevné 50% prekrývanie, takže úprava prekrývania nie je potrebná."
+      },
       "locale": {
         "label": "Species Language",
         "helpText": "Language used for species common names in the interface."

--- a/frontend/static/messages/sv.json
+++ b/frontend/static/messages/sv.json
@@ -4535,6 +4535,10 @@
         "label": "Validering efter detektion",
         "helpText": "När aktiverat valideras fladdermusdetektioner genom att analysera ultraljudsenergi i källljudet. Detektioner utan ekolokationsegenskaper markeras som osannolika."
       },
+      "batFalsePositiveFilter": {
+        "label": "Fladdermus falskt-positiv filter",
+        "helpText": "Kräver flera bekräftelser av en fladdermusdetektion inom ett glidande fönster innan den accepteras. Högre nivåer kräver fler bekräftelser, vilket minskar falska positiva. Fladdermusmodellen använder en fast 50% överlappning, så ingen överlappningsjustering behövs."
+      },
       "locale": {
         "label": "Species Language",
         "helpText": "Language used for species common names in the interface."

--- a/internal/analysis/processor/dynamic_threshold.go
+++ b/internal/analysis/processor/dynamic_threshold.go
@@ -290,7 +290,7 @@ func (p *Processor) updateDynamicThreshold(modelID, commonName string, confidenc
 
 		// Check if the species already has a dynamic threshold
 		// Note: scientific name not available in this context, but common name lookup is sufficient
-		if dt, exists := p.DynamicThresholds[key]; exists && confidence > float64(p.getBaseConfidenceThreshold(settings, commonName, "")) {
+		if dt, exists := p.DynamicThresholds[key]; exists && confidence > float64(p.getBaseConfidenceThreshold(settings, commonName, "", modelID)) {
 			// Update the timer to extend the threshold's validity
 			// Note: dt is a pointer, so this directly mutates the struct in the map
 			dt.Timer = time.Now().Add(time.Duration(dt.ValidHours) * time.Hour)

--- a/internal/analysis/processor/false_positive_filter.go
+++ b/internal/analysis/processor/false_positive_filter.go
@@ -1,6 +1,13 @@
 // false_positive_filter.go
 package processor
 
+import (
+	"math"
+
+	"github.com/tphakala/birdnet-go/internal/classifier"
+	"github.com/tphakala/birdnet-go/internal/conf"
+)
+
 // getMinimumOverlapForLevel returns the minimum overlap required for each filtering level.
 // Higher levels require higher overlap to generate more detections for filtering.
 //
@@ -102,6 +109,38 @@ func getRecommendedLevelForOverlap(overlap float64) (level int, overlapSufficien
 	// If we get here, overlap is too low even for Level 0
 	// This shouldn't happen since Level 0 requires 0.0 overlap
 	return 0, true
+}
+
+// calculateMinDetectionsForModel routes to the correct minDetections calculation
+// based on the model ID. Bat models use a fixed 50% overlap instead of the
+// user-configurable BirdNET overlap, and read from a separate filter config.
+func calculateMinDetectionsForModel(settings *conf.Settings, modelID string) int {
+	if modelID == classifier.RegistryIDBat {
+		return calculateBatMinDetections(settings)
+	}
+	return calculateMinDetectionsFromSettings(settings)
+}
+
+// calculateBatMinDetections computes the minimum detection count for bat models.
+// The bat model's buffer overlap is fixed at 50% (hardcoded in BufferDimensions),
+// giving a 1.5-second step for a 3-second clip. Within a 6-second reference
+// window, this yields 4 possible detections.
+func calculateBatMinDetections(settings *conf.Settings) int {
+	const chunkDurationSeconds = 3.0
+	const referenceWindowSeconds = 6.0
+	const batOverlapSeconds = 1.5 // fixed 50% of 3s clip
+	const epsilon = 1e-9
+
+	level := settings.Bat.FalsePositiveFilter.Level
+	if level == 0 {
+		return 1
+	}
+
+	segmentLength := chunkDurationSeconds - batOverlapSeconds
+	maxDetections := referenceWindowSeconds / segmentLength
+	threshold := getThresholdForLevel(level)
+	required := maxDetections*threshold - epsilon
+	return int(math.Max(1, math.Ceil(required)))
 }
 
 // getLevelDescription returns a detailed description of what each level does.

--- a/internal/analysis/processor/false_positive_filter.go
+++ b/internal/analysis/processor/false_positive_filter.go
@@ -143,6 +143,31 @@ func calculateBatMinDetections(settings *conf.Settings) int {
 	return int(math.Max(1, math.Ceil(required)))
 }
 
+// visibilityThresholds holds precomputed per-model visibility thresholds.
+// The map key is the model ID; unknown model IDs fall back to the bird threshold.
+type visibilityThresholds map[string]int
+
+// precomputeVisibilityThresholds calculates visibility thresholds for bird and
+// bat models once per settings snapshot so callers can look up by model ID
+// without recomputing inside a loop or under a lock.
+func precomputeVisibilityThresholds(settings *conf.Settings) visibilityThresholds {
+	birdVis := CalculateVisibilityThreshold(calculateMinDetectionsFromSettings(settings))
+	batVis := CalculateVisibilityThreshold(calculateBatMinDetections(settings))
+	return visibilityThresholds{
+		"":                       birdVis, // default for unknown model IDs
+		classifier.RegistryIDBat: batVis,
+	}
+}
+
+// getThreshold returns the visibility threshold for a model ID, falling back
+// to the bird threshold for unknown model IDs.
+func (vt visibilityThresholds) getThreshold(modelID string) int {
+	if t, ok := vt[modelID]; ok {
+		return t
+	}
+	return vt[""]
+}
+
 // getLevelDescription returns a detailed description of what each level does.
 func getLevelDescription(level int) string {
 	switch level {

--- a/internal/analysis/processor/mindetections_test.go
+++ b/internal/analysis/processor/mindetections_test.go
@@ -914,3 +914,119 @@ func TestValidateAndLogFilterConfig_InvalidLevel(t *testing.T) {
 		})
 	}
 }
+
+// TestCalculateBatMinDetections verifies the bat-specific minDetections calculation
+// for all filter levels. The bat model uses a fixed 50% overlap (1.5s step for 3s clip),
+// yielding 4 possible detections in a 6-second reference window.
+func TestCalculateBatMinDetections(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		level       int
+		expectedMin int
+	}{
+		{name: "level_0_off", level: 0, expectedMin: 1},
+		{name: "level_1_lenient", level: 1, expectedMin: 1},  // ceil(4 * 0.20) = 1
+		{name: "level_2_moderate", level: 2, expectedMin: 2}, // ceil(4 * 0.30) = 2
+		{name: "level_3_balanced", level: 3, expectedMin: 2}, // ceil(4 * 0.50) = 2
+		{name: "level_4_strict", level: 4, expectedMin: 3},   // ceil(4 * 0.60) = 3
+		{name: "level_5_maximum", level: 5, expectedMin: 3},  // ceil(4 * 0.70) = 3
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			settings := &conf.Settings{}
+			settings.Bat.FalsePositiveFilter.Level = tt.level
+			result := calculateBatMinDetections(settings)
+			assert.Equal(t, tt.expectedMin, result,
+				"bat level %d should require %d detections", tt.level, tt.expectedMin)
+		})
+	}
+}
+
+// TestCalculateMinDetectionsForModel verifies that the model-aware router
+// dispatches to the correct calculation based on model ID.
+func TestCalculateMinDetectionsForModel(t *testing.T) {
+	t.Parallel()
+
+	settings := &conf.Settings{}
+	settings.Realtime.FalsePositiveFilter.Level = 3
+	settings.BirdNET.Overlap = 2.4
+	settings.Bat.FalsePositiveFilter.Level = 3
+
+	birdResult := calculateMinDetectionsForModel(settings, "BirdNET_V2.4")
+	batResult := calculateMinDetectionsForModel(settings, "Bat")
+
+	// Bird: level 3, overlap 2.4, step 0.6s, max 10, 50% = 5
+	assert.Equal(t, 5, birdResult, "BirdNET model should use bird FP filter calculation")
+	// Bat: level 3, fixed 1.5s step, max 4, 50% = 2
+	assert.Equal(t, 2, batResult, "Bat model should use bat FP filter calculation")
+}
+
+// TestGetBaseConfidenceThreshold_BatModel verifies that bat detections
+// use settings.Bat.Threshold instead of settings.BirdNET.Threshold.
+func TestGetBaseConfidenceThreshold_BatModel(t *testing.T) {
+	t.Parallel()
+
+	settings := &conf.Settings{}
+	settings.BirdNET.Threshold = 0.7
+	settings.Bat.Threshold = 0.3
+
+	p := &Processor{Settings: settings}
+
+	birdThreshold := p.getBaseConfidenceThreshold(settings, "Common Pipistrelle", "Pipistrellus pipistrellus", "BirdNET_V2.4")
+	batThreshold := p.getBaseConfidenceThreshold(settings, "Common Pipistrelle", "Pipistrellus pipistrellus", "Bat")
+
+	assert.InDelta(t, 0.7, float64(birdThreshold), 0.001, "bird model should use BirdNET threshold")
+	assert.InDelta(t, 0.3, float64(batThreshold), 0.001, "bat model should use Bat threshold")
+}
+
+// TestGetBaseConfidenceThreshold_CustomOverridesModel verifies that per-species
+// custom thresholds take precedence over model-specific global thresholds.
+func TestGetBaseConfidenceThreshold_CustomOverridesModel(t *testing.T) {
+	t.Parallel()
+
+	settings := &conf.Settings{}
+	settings.BirdNET.Threshold = 0.7
+	settings.Bat.Threshold = 0.3
+	settings.Realtime.Species.Config = map[string]conf.SpeciesConfig{
+		"common pipistrelle": {Threshold: 0.5},
+	}
+
+	p := &Processor{Settings: settings}
+
+	threshold := p.getBaseConfidenceThreshold(settings, "Common Pipistrelle", "Pipistrellus pipistrellus", "Bat")
+	assert.InDelta(t, 0.5, float64(threshold), 0.001, "custom species threshold should override bat global threshold")
+}
+
+// TestValidateAndLogBatFilterConfig verifies that invalid bat FP filter levels
+// are reset to 0 and valid levels are accepted.
+func TestValidateAndLogBatFilterConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid_level_preserved", func(t *testing.T) {
+		t.Parallel()
+		settings := &conf.Settings{}
+		settings.Bat.FalsePositiveFilter.Level = 3
+		validateAndLogBatFilterConfig(settings)
+		assert.Equal(t, 3, settings.Bat.FalsePositiveFilter.Level)
+	})
+
+	t.Run("invalid_level_reset_to_0", func(t *testing.T) {
+		t.Parallel()
+		settings := &conf.Settings{}
+		settings.Bat.FalsePositiveFilter.Level = 99
+		validateAndLogBatFilterConfig(settings)
+		assert.Equal(t, 0, settings.Bat.FalsePositiveFilter.Level)
+	})
+
+	t.Run("level_0_accepted", func(t *testing.T) {
+		t.Parallel()
+		settings := &conf.Settings{}
+		settings.Bat.FalsePositiveFilter.Level = 0
+		validateAndLogBatFilterConfig(settings)
+		assert.Equal(t, 0, settings.Bat.FalsePositiveFilter.Level)
+	})
+}

--- a/internal/analysis/processor/pending_broadcast.go
+++ b/internal/analysis/processor/pending_broadcast.go
@@ -132,14 +132,17 @@ func CalculateVisibilityThreshold(minDetections int) int {
 
 // SnapshotVisiblePending returns all pending detections that have accumulated
 // enough hits to pass the visibility threshold. Results have status "active".
+// The visibility threshold is computed per-item using BestModelID so that bat
+// and bird models each use their own false positive filter configuration.
 // The caller must NOT hold pendingMutex.
-func (p *Processor) SnapshotVisiblePending(minDetections int) []SSEPendingDetection {
-	threshold := CalculateVisibilityThreshold(minDetections)
+func (p *Processor) SnapshotVisiblePending() []SSEPendingDetection {
+	settings := p.currentSettings()
 
 	p.pendingMutex.RLock()
 	result := make([]SSEPendingDetection, 0, len(p.pendingDetections))
 	for key := range p.pendingDetections {
 		item := p.pendingDetections[key]
+		threshold := CalculateVisibilityThreshold(calculateMinDetectionsForModel(settings, item.BestModelID))
 		if item.Count < threshold {
 			continue
 		}

--- a/internal/analysis/processor/pending_broadcast.go
+++ b/internal/analysis/processor/pending_broadcast.go
@@ -137,13 +137,13 @@ func CalculateVisibilityThreshold(minDetections int) int {
 // The caller must NOT hold pendingMutex.
 func (p *Processor) SnapshotVisiblePending() []SSEPendingDetection {
 	settings := p.currentSettings()
+	visThresholds := precomputeVisibilityThresholds(settings)
 
 	p.pendingMutex.RLock()
 	result := make([]SSEPendingDetection, 0, len(p.pendingDetections))
 	for key := range p.pendingDetections {
 		item := p.pendingDetections[key]
-		threshold := CalculateVisibilityThreshold(calculateMinDetectionsForModel(settings, item.BestModelID))
-		if item.Count < threshold {
+		if item.Count < visThresholds.getThreshold(item.BestModelID) {
 			continue
 		}
 		result = append(result, p.buildPendingDTO(&item, PendingStatusActive))

--- a/internal/analysis/processor/pending_broadcast_test.go
+++ b/internal/analysis/processor/pending_broadcast_test.go
@@ -49,11 +49,38 @@ func TestCalculateVisibilityThreshold(t *testing.T) {
 	})
 }
 
+// settingsForBirdMinDetections returns settings that produce the given
+// minDetections value for bird models via calculateMinDetectionsFromSettings.
+func settingsForBirdMinDetections(t *testing.T, wantMinDet int) *conf.Settings {
+	t.Helper()
+	type pair struct {
+		level   int
+		overlap float64
+	}
+	// Pre-computed (level, overlap) pairs that yield specific minDetections values.
+	known := map[int]pair{
+		1:  {level: 0, overlap: 0},   // level 0 always returns 1
+		2:  {level: 1, overlap: 2.0}, // 6/1.0*0.20 = 1.2, ceil = 2
+		4:  {level: 2, overlap: 2.5}, // 6/0.5*0.30 = 3.6, ceil = 4
+		5:  {level: 3, overlap: 2.4}, // 6/0.6*0.50 = 5.0, ceil = 5
+		12: {level: 4, overlap: 2.7}, // 6/0.3*0.60 = 12.0, ceil = 12
+		21: {level: 5, overlap: 2.8}, // 6/0.2*0.70 = 21.0, ceil = 21
+	}
+	p, ok := known[wantMinDet]
+	if !ok {
+		t.Fatalf("no known (level, overlap) pair for minDetections=%d", wantMinDet)
+	}
+	s := &conf.Settings{}
+	s.Realtime.FalsePositiveFilter.Level = p.level
+	s.BirdNET.Overlap = p.overlap
+	return s
+}
+
 func TestSnapshotVisiblePending_FiltersByThreshold(t *testing.T) {
 	t.Parallel()
 
 	p := &Processor{
-		Settings: &conf.Settings{},
+		Settings: settingsForBirdMinDetections(t, 12),
 		pendingDetections: map[string]PendingDetection{
 			"src1:species_a": {
 				Detection: Detections{
@@ -103,7 +130,7 @@ func TestSnapshotVisiblePending_FiltersByThreshold(t *testing.T) {
 		},
 	}
 
-	result := p.SnapshotVisiblePending(12) // minDetections=12 → threshold=3
+	result := p.SnapshotVisiblePending() // minDetections=12 → threshold=3
 
 	// Should include Species A (count=5) and Species C (count=3), but not Species B (count=1)
 	require.Len(t, result, 2)
@@ -142,11 +169,11 @@ func TestSnapshotVisiblePending_EmptyMap(t *testing.T) {
 	t.Parallel()
 
 	p := &Processor{
-		Settings:          &conf.Settings{},
+		Settings:          settingsForBirdMinDetections(t, 12),
 		pendingDetections: make(map[string]PendingDetection),
 	}
 
-	result := p.SnapshotVisiblePending(12)
+	result := p.SnapshotVisiblePending()
 	assert.Empty(t, result)
 }
 
@@ -154,7 +181,7 @@ func TestSnapshotVisiblePending_AllBelowThreshold(t *testing.T) {
 	t.Parallel()
 
 	p := &Processor{
-		Settings: &conf.Settings{},
+		Settings: settingsForBirdMinDetections(t, 12),
 		pendingDetections: map[string]PendingDetection{
 			"src1:species_a": {
 				Detection: Detections{
@@ -174,7 +201,7 @@ func TestSnapshotVisiblePending_AllBelowThreshold(t *testing.T) {
 		},
 	}
 
-	result := p.SnapshotVisiblePending(12) // threshold=3
+	result := p.SnapshotVisiblePending() // threshold=3
 	assert.Empty(t, result)
 }
 
@@ -256,7 +283,7 @@ func TestSnapshotVisiblePending_UsesCreatedAtNotFirstDetected(t *testing.T) {
 	realCreationTime := time.Date(2026, 3, 7, 10, 0, 13, 0, time.UTC) // 13s later
 
 	p := &Processor{
-		Settings: &conf.Settings{},
+		Settings: settingsForBirdMinDetections(t, 4),
 		pendingDetections: map[string]PendingDetection{
 			"src1:test_species": {
 				Detection: Detections{
@@ -275,7 +302,7 @@ func TestSnapshotVisiblePending_UsesCreatedAtNotFirstDetected(t *testing.T) {
 		},
 	}
 
-	result := p.SnapshotVisiblePending(4) // threshold = max(2, 4/4) = 2, count=5 passes
+	result := p.SnapshotVisiblePending() // threshold = max(2, 4/4) = 2, count=5 passes
 	require.Len(t, result, 1)
 
 	// The SSE firstDetected field should use CreatedAt (real time), NOT FirstDetected (back-dated)
@@ -318,7 +345,7 @@ func TestSnapshotVisiblePending_IncludesHitCount(t *testing.T) {
 	t.Parallel()
 
 	p := &Processor{
-		Settings: &conf.Settings{},
+		Settings: settingsForBirdMinDetections(t, 4),
 		pendingDetections: map[string]PendingDetection{
 			"src1:species_a": {
 				Detection: Detections{
@@ -336,7 +363,7 @@ func TestSnapshotVisiblePending_IncludesHitCount(t *testing.T) {
 		},
 	}
 
-	result := p.SnapshotVisiblePending(4) // threshold = 2, count=7 passes
+	result := p.SnapshotVisiblePending() // threshold = 2, count=7 passes
 	require.Len(t, result, 1)
 	assert.Equal(t, 7, result[0].HitCount, "HitCount should match pending detection Count")
 }
@@ -482,7 +509,7 @@ func TestSnapshotVisiblePending_IncludesLastUpdated(t *testing.T) {
 	lastUpdated := time.Date(2026, 3, 7, 10, 0, 18, 0, time.UTC) // 18s after creation
 
 	p := &Processor{
-		Settings: &conf.Settings{},
+		Settings: settingsForBirdMinDetections(t, 4),
 		pendingDetections: map[string]PendingDetection{
 			"src1:species_a": {
 				Detection: Detections{
@@ -501,7 +528,7 @@ func TestSnapshotVisiblePending_IncludesLastUpdated(t *testing.T) {
 		},
 	}
 
-	result := p.SnapshotVisiblePending(4) // threshold=2, count=5 passes
+	result := p.SnapshotVisiblePending() // threshold=2, count=5 passes
 	require.Len(t, result, 1)
 	assert.Equal(t, lastUpdated.Unix(), result[0].LastUpdated,
 		"SSE LastUpdated should reflect the most recent inference hit time")
@@ -512,7 +539,7 @@ func TestSnapshotVisiblePending_IncludesAudioCapturedAt(t *testing.T) {
 
 	captureTime := time.Date(2026, 3, 21, 12, 0, 0, 0, time.UTC)
 	p := &Processor{
-		Settings: &conf.Settings{},
+		Settings: settingsForBirdMinDetections(t, 2),
 		pendingDetections: map[string]PendingDetection{
 			"src1:robin": {
 				Detection: Detections{
@@ -532,7 +559,7 @@ func TestSnapshotVisiblePending_IncludesAudioCapturedAt(t *testing.T) {
 		},
 	}
 
-	snapshot := p.SnapshotVisiblePending(2)
+	snapshot := p.SnapshotVisiblePending()
 	require.Len(t, snapshot, 1)
 	assert.Equal(t, captureTime.Unix(), snapshot[0].AudioCapturedAt)
 	// Verify existing fields unchanged

--- a/internal/analysis/processor/processor.go
+++ b/internal/analysis/processor/processor.go
@@ -1431,11 +1431,11 @@ func (p *Processor) processApprovedDetection(item *PendingDetection, speciesName
 		logger.String("operation", "approve_detection"))
 
 	// Learn from each contributing model's approved detection for dynamic threshold adjustment.
-	// Only learn for models whose max confidence exceeds the base threshold to avoid
-	// lowering thresholds based on weak signals that rode on another model's strength.
+	// Only learn for models whose max confidence exceeds that model's own base threshold
+	// to avoid lowering thresholds based on weak signals that rode on another model's strength.
 	scientificName := item.Detection.Result.Species.ScientificName
-	baseThreshold := float64(p.getBaseConfidenceThreshold(settings, speciesName, scientificName, item.BestModelID))
 	for modelID, contrib := range item.ModelContributions {
+		baseThreshold := float64(p.getBaseConfidenceThreshold(settings, speciesName, scientificName, modelID))
 		if contrib.MaxConfidence >= baseThreshold {
 			p.LearnFromApprovedDetection(modelID, speciesName, scientificName, float32(contrib.MaxConfidence))
 		}
@@ -1670,6 +1670,28 @@ func (p *Processor) flushPendingDetections() (pendingCount, flushedCount int) {
 	return pendingCount, flushedCount
 }
 
+// logMinDetectionsChanges logs when bird or bat minDetections values change
+// due to a config hot-reload, helping operators verify that FP filter
+// adjustments took effect.
+func logMinDetectionsChanges(settings *conf.Settings, lastBird, lastBat *int) {
+	bird := calculateMinDetectionsFromSettings(settings)
+	bat := calculateBatMinDetections(settings)
+	if *lastBird != -1 && bird != *lastBird {
+		GetLogger().Info("bird minDetections updated due to config change",
+			logger.Int("old_value", *lastBird),
+			logger.Int("new_value", bird),
+			logger.String("operation", "pending_flusher_config_update"))
+	}
+	if *lastBat != -1 && bat != *lastBat {
+		GetLogger().Info("bat minDetections updated due to config change",
+			logger.Int("old_value", *lastBat),
+			logger.Int("new_value", bat),
+			logger.String("operation", "pending_flusher_config_update"))
+	}
+	*lastBird = bird
+	*lastBat = bat
+}
+
 // pendingDetectionsFlusher runs a goroutine that periodically checks the pending detections
 // and flushes them to the worker queue if their deadline has passed.
 func (p *Processor) pendingDetectionsFlusher() {
@@ -1681,9 +1703,12 @@ func (p *Processor) pendingDetectionsFlusher() {
 		ticker := time.NewTicker(DefaultFlushInterval)
 		defer ticker.Stop()
 
+		lastBirdMinDet, lastBatMinDet := -1, -1
+
 		for {
 			select {
 			case <-ticker.C:
+				logMinDetectionsChanges(p.currentSettings(), &lastBirdMinDet, &lastBatMinDet)
 				pendingCount, flushedCount := p.flushPendingDetections()
 
 				if pendingCount > 0 || flushedCount > 0 {

--- a/internal/analysis/processor/processor.go
+++ b/internal/analysis/processor/processor.go
@@ -1592,6 +1592,7 @@ func (p *Processor) calculateMinDetections() int {
 func (p *Processor) flushPendingDetections() (pendingCount, flushedCount int) {
 	now := time.Now()
 	settings := p.currentSettings()
+	visThresholds := precomputeVisibilityThresholds(settings)
 
 	var terminalNotifs []SSEPendingDetection
 	var broadcastSnapshot []SSEPendingDetection
@@ -1620,7 +1621,7 @@ func (p *Processor) flushPendingDetections() (pendingCount, flushedCount int) {
 				logger.String("operation", "discard_detection"))
 			delete(p.pendingDetections, mapKey)
 
-			if item.Count >= CalculateVisibilityThreshold(itemMinDetections) {
+			if item.Count >= visThresholds.getThreshold(item.BestModelID) {
 				terminalNotifs = append(terminalNotifs, p.buildFlushNotification(&item, PendingStatusRejected))
 			}
 
@@ -1641,7 +1642,7 @@ func (p *Processor) flushPendingDetections() (pendingCount, flushedCount int) {
 		delete(p.pendingDetections, mapKey)
 		flushedCount++
 
-		if item.Count >= CalculateVisibilityThreshold(itemMinDetections) {
+		if item.Count >= visThresholds.getThreshold(item.BestModelID) {
 			terminalNotifs = append(terminalNotifs, p.buildFlushNotification(&item, PendingStatusApproved))
 		}
 	}
@@ -1651,8 +1652,7 @@ func (p *Processor) flushPendingDetections() (pendingCount, flushedCount int) {
 		broadcastSnapshot = make([]SSEPendingDetection, 0, len(p.pendingDetections)+len(terminalNotifs))
 		for key := range p.pendingDetections {
 			item := p.pendingDetections[key]
-			threshold := CalculateVisibilityThreshold(calculateMinDetectionsForModel(settings, item.BestModelID))
-			if item.Count >= threshold {
+			if item.Count >= visThresholds.getThreshold(item.BestModelID) {
 				broadcastSnapshot = append(broadcastSnapshot, p.buildPendingDTO(&item, PendingStatusActive))
 			}
 		}

--- a/internal/analysis/processor/processor.go
+++ b/internal/analysis/processor/processor.go
@@ -337,6 +337,31 @@ func validateAndLogFilterConfig(settings *conf.Settings) {
 	}
 }
 
+// validateAndLogBatFilterConfig validates the bat false positive filter configuration
+// and logs the effective minDetections. The bat model uses a fixed 50% overlap,
+// so there are no overlap-related warnings.
+func validateAndLogBatFilterConfig(settings *conf.Settings) {
+	if err := settings.Bat.FalsePositiveFilter.Validate(); err != nil {
+		GetLogger().Error("Invalid bat false positive filter configuration, falling back to level 0",
+			logger.Error(err),
+			logger.Int("fallback_level", 0),
+			logger.String("operation", "bat_false_positive_filter_validation"))
+		settings.Bat.FalsePositiveFilter.Level = 0
+	}
+
+	level := settings.Bat.FalsePositiveFilter.Level
+	if level == 0 {
+		return
+	}
+
+	minDetections := calculateBatMinDetections(settings)
+	GetLogger().Info("Bat false positive filter active",
+		logger.Int("level", level),
+		logger.String("level_name", getLevelName(level)),
+		logger.Int("min_detections", minDetections),
+		logger.String("operation", "bat_false_positive_filter_config"))
+}
+
 // initLogDeduplicator creates and configures the log deduplicator.
 func initLogDeduplicator(settings *conf.Settings) *LogDeduplicator {
 	healthCheckInterval := 60 * time.Second
@@ -510,6 +535,7 @@ func New(settings *conf.Settings, ds datastore.Interface, bn *classifier.Orchest
 
 	// Validate and log false positive filter configuration
 	validateAndLogFilterConfig(settings)
+	validateAndLogBatFilterConfig(settings)
 
 	// Validate user-configured custom ExecuteCommand action paths up front
 	// so that a misconfigured command path produces a single user-facing
@@ -734,8 +760,7 @@ func (p *Processor) processDetections(item classifier.Results) {
 
 	// Broadcast updated pending detections snapshot for "currently hearing" UI.
 	// This runs after all new detections are incorporated into pendingDetections.
-	minDet := calculateMinDetectionsFromSettings(settings)
-	snapshot := p.SnapshotVisiblePending(minDet)
+	snapshot := p.SnapshotVisiblePending()
 	p.broadcastPendingSnapshot(snapshot)
 }
 
@@ -779,7 +804,7 @@ func (p *Processor) processResults(settings *conf.Settings, item classifier.Resu
 		p.handleHumanDetection(settings, item, speciesLowercase, result)
 
 		// Determine confidence threshold and check filters
-		baseThreshold := p.getBaseConfidenceThreshold(settings, commonName, scientificName)
+		baseThreshold := p.getBaseConfidenceThreshold(settings, commonName, scientificName, item.ModelID)
 
 		// Check if detection should be filtered
 		shouldSkip, _ := p.shouldFilterDetection(settings, result, commonName, scientificName, speciesLowercase, baseThreshold, item.Source.ID, item.ModelID)
@@ -1228,7 +1253,9 @@ func (p *Processor) handleHumanDetection(settings *conf.Settings, item classifie
 
 // getBaseConfidenceThreshold retrieves the confidence threshold for a species, using custom or global thresholds.
 // It supports lookup by both common name and scientific name for consistency with include/exclude matching.
-func (p *Processor) getBaseConfidenceThreshold(settings *conf.Settings, commonName, scientificName string) float32 {
+// The modelID parameter selects which global threshold to use when no per-species config exists:
+// bat models use settings.Bat.Threshold, all others use settings.BirdNET.Threshold.
+func (p *Processor) getBaseConfidenceThreshold(settings *conf.Settings, commonName, scientificName, modelID string) float32 {
 	// Check if species has a custom threshold using both common and scientific name lookup
 	if config, exists := lookupSpeciesConfig(settings.Realtime.Species.Config, commonName, scientificName); exists {
 		if settings.Debug {
@@ -1241,7 +1268,10 @@ func (p *Processor) getBaseConfidenceThreshold(settings *conf.Settings, commonNa
 		return float32(config.Threshold)
 	}
 
-	// Fall back to global threshold
+	// Fall back to model-specific global threshold
+	if modelID == classifier.RegistryIDBat {
+		return float32(settings.Bat.Threshold)
+	}
 	return float32(settings.BirdNET.Threshold)
 }
 
@@ -1303,13 +1333,13 @@ func (p *Processor) buildClipPath(settings *conf.Settings, scientificName string
 	return filepath.ToSlash(filepath.Join(year, month, filename))
 }
 
-// shouldDiscardDetection checks if a detection should be discarded based on various criteria
-func (p *Processor) shouldDiscardDetection(item *PendingDetection, minDetections int) (shouldDiscard bool, reason string) {
-	settings := p.currentSettings()
-
+// shouldDiscardDetection checks if a detection should be discarded based on various criteria.
+// The caller provides a settings snapshot and the precomputed minDetections (from
+// calculateMinDetectionsForModel) to avoid redundant settings fetches and ensure
+// consistency within a single flush cycle.
+func (p *Processor) shouldDiscardDetection(item *PendingDetection, settings *conf.Settings, minDetections int) (shouldDiscard bool, reason string) {
 	// Check minimum detection count
 	if item.Count < minDetections {
-		// Add structured logging for minimum count filtering
 		GetLogger().Debug("Detection discarded due to insufficient count",
 			logger.String("species", item.Detection.Result.Species.CommonName),
 			logger.Int("count", item.Count),
@@ -1404,7 +1434,7 @@ func (p *Processor) processApprovedDetection(item *PendingDetection, speciesName
 	// Only learn for models whose max confidence exceeds the base threshold to avoid
 	// lowering thresholds based on weak signals that rode on another model's strength.
 	scientificName := item.Detection.Result.Species.ScientificName
-	baseThreshold := float64(p.getBaseConfidenceThreshold(settings, speciesName, scientificName))
+	baseThreshold := float64(p.getBaseConfidenceThreshold(settings, speciesName, scientificName, item.BestModelID))
 	for modelID, contrib := range item.ModelContributions {
 		if contrib.MaxConfidence >= baseThreshold {
 			p.LearnFromApprovedDetection(modelID, speciesName, scientificName, float32(contrib.MaxConfidence))
@@ -1556,9 +1586,12 @@ func (p *Processor) calculateMinDetections() int {
 }
 
 // flushPendingDetections processes one flush cycle, flushing eligible detections.
+// minDetections is computed per-item using the item's BestModelID so that bat
+// and bird models each apply their own false positive filter configuration.
 // Returns the count of pending and flushed detections for logging.
-func (p *Processor) flushPendingDetections(minDetections int) (pendingCount, flushedCount int) {
+func (p *Processor) flushPendingDetections() (pendingCount, flushedCount int) {
 	now := time.Now()
+	settings := p.currentSettings()
 
 	var terminalNotifs []SSEPendingDetection
 	var broadcastSnapshot []SSEPendingDetection
@@ -1573,12 +1606,10 @@ func (p *Processor) flushPendingDetections(minDetections int) (pendingCount, flu
 			continue
 		}
 
-		// Get species name from the detection data (not the map key,
-		// since source IDs like RTSP URLs may contain colons).
-		// Lowercase to match the convention used in processDetections and dynamic thresholds.
 		speciesName := strings.ToLower(item.Detection.Result.Species.CommonName)
+		itemMinDetections := calculateMinDetectionsForModel(settings, item.BestModelID)
 
-		if shouldDiscard, reason := p.shouldDiscardDetection(&item, minDetections); shouldDiscard {
+		if shouldDiscard, reason := p.shouldDiscardDetection(&item, settings, itemMinDetections); shouldDiscard {
 			GetLogger().Info("discarding detection",
 				logger.String("species", speciesName),
 				logger.String("source", p.getDisplayNameForSource(item.Source)),
@@ -1589,8 +1620,7 @@ func (p *Processor) flushPendingDetections(minDetections int) (pendingCount, flu
 				logger.String("operation", "discard_detection"))
 			delete(p.pendingDetections, mapKey)
 
-			// Collect rejected notification if species was visible
-			if item.Count >= CalculateVisibilityThreshold(minDetections) {
+			if item.Count >= CalculateVisibilityThreshold(itemMinDetections) {
 				terminalNotifs = append(terminalNotifs, p.buildFlushNotification(&item, PendingStatusRejected))
 			}
 
@@ -1604,53 +1634,40 @@ func (p *Processor) flushPendingDetections(minDetections int) (pendingCount, flu
 			logger.Bool("deadline_reached", true),
 			logger.Int("total_count", item.Count),
 			logger.Int("model_count", len(item.ModelContributions)),
-			logger.Int("required", minDetections),
+			logger.Int("required", itemMinDetections),
 			logger.String("operation", "flush_detection"))
 
 		p.processApprovedDetection(&item, speciesName)
 		delete(p.pendingDetections, mapKey)
 		flushedCount++
 
-		// Collect approved notification if species was visible
-		if item.Count >= CalculateVisibilityThreshold(minDetections) {
+		if item.Count >= CalculateVisibilityThreshold(itemMinDetections) {
 			terminalNotifs = append(terminalNotifs, p.buildFlushNotification(&item, PendingStatusApproved))
 		}
 	}
 
 	// Build snapshot while still holding the lock, then release before broadcasting.
 	if len(terminalNotifs) > 0 || flushedCount > 0 {
-		threshold := CalculateVisibilityThreshold(minDetections)
 		broadcastSnapshot = make([]SSEPendingDetection, 0, len(p.pendingDetections)+len(terminalNotifs))
 		for key := range p.pendingDetections {
 			item := p.pendingDetections[key]
+			threshold := CalculateVisibilityThreshold(calculateMinDetectionsForModel(settings, item.BestModelID))
 			if item.Count >= threshold {
 				broadcastSnapshot = append(broadcastSnapshot, p.buildPendingDTO(&item, PendingStatusActive))
 			}
 		}
 		logPendingBroadcast(len(broadcastSnapshot), len(terminalNotifs))
 		broadcastSnapshot = append(broadcastSnapshot, terminalNotifs...)
-		// Sort for stable comparison in broadcastPendingSnapshot.
 		sortPendingSnapshot(broadcastSnapshot)
 	}
 
 	p.pendingMutex.Unlock()
 
-	// Broadcast outside the lock to avoid blocking processDetections.
 	if broadcastSnapshot != nil {
 		p.broadcastPendingSnapshot(broadcastSnapshot)
 	}
 
 	return pendingCount, flushedCount
-}
-
-// logMinDetectionsChange logs when minDetections changes due to config update.
-func logMinDetectionsChange(lastValue, newValue int) {
-	if lastValue != -1 && newValue != lastValue {
-		GetLogger().Info("minDetections updated due to config change",
-			logger.Int("old_value", lastValue),
-			logger.Int("new_value", newValue),
-			logger.String("operation", "pending_flusher_config_update"))
-	}
 }
 
 // pendingDetectionsFlusher runs a goroutine that periodically checks the pending detections
@@ -1664,16 +1681,10 @@ func (p *Processor) pendingDetectionsFlusher() {
 		ticker := time.NewTicker(DefaultFlushInterval)
 		defer ticker.Stop()
 
-		lastMinDetections := -1
-
 		for {
 			select {
 			case <-ticker.C:
-				minDetections := p.calculateMinDetections()
-				logMinDetectionsChange(lastMinDetections, minDetections)
-				lastMinDetections = minDetections
-
-				pendingCount, flushedCount := p.flushPendingDetections(minDetections)
+				pendingCount, flushedCount := p.flushPendingDetections()
 
 				if pendingCount > 0 || flushedCount > 0 {
 					GetLogger().Debug("Pending detections flusher cycle",

--- a/internal/analysis/processor/threshold_persistence.go
+++ b/internal/analysis/processor/threshold_persistence.go
@@ -138,7 +138,7 @@ func (p *Processor) convertThresholdsForPersistence(settings *conf.Settings) (db
 		// Extract model name and species name from composite key
 		modelName, speciesName := splitDynamicThresholdKey(compositeKey)
 
-		baseThreshold := p.getBaseConfidenceThreshold(settings, speciesName, "")
+		baseThreshold := p.getBaseConfidenceThreshold(settings, speciesName, "", modelName)
 		dbThresholds = append(dbThresholds, datastore.DynamicThreshold{
 			SpeciesName:    speciesName,
 			ModelName:      modelName,

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -1183,16 +1183,17 @@ type PerchConfig struct {
 
 // BatConfig holds configuration for bat detection using BirdNET v2.4 embeddings.
 type BatConfig struct {
-	EmbeddingModel   string                 `yaml:"embeddingmodel,omitempty" json:"embeddingModel,omitempty"`   // path to BirdNET v2.4 embeddings ONNX model
-	ClassifierModel  string                 `yaml:"classifiermodel,omitempty" json:"classifierModel,omitempty"` // path to bat species classifier ONNX model
-	LabelPath        string                 `yaml:"labelpath,omitempty" json:"labelPath,omitempty"`             // path to bat species labels file
-	Threshold        float64                `yaml:"threshold" json:"threshold"`                                 // confidence threshold for bat detections
-	Locale           string                 `yaml:"locale,omitempty" json:"locale,omitempty"`                   // locale for species label translation
-	FilterEnabled    bool                   `yaml:"filterenabled" json:"filterEnabled"`                         // enable high-pass filter for bat audio
-	FilterCutoffHz   float64                `yaml:"filtercutoffhz,omitempty" json:"filterCutoffHz,omitempty"`   // high-pass filter cutoff frequency in Hz
-	FilterPassCount  int                    `yaml:"filterpasscount,omitempty" json:"filterPassCount,omitempty"` // number of filter passes for steeper rolloff
-	NighttimeOnly    bool                   `yaml:"nighttimeonly" json:"nighttimeOnly"`                         // restrict bat detection to nighttime (civil dusk to civil dawn)
-	UltrasonicFilter UltrasonicFilterConfig `yaml:"ultrasonicfilter" json:"ultrasonicFilter"`                   // post-detection ultrasonic validation filter
+	EmbeddingModel      string                      `yaml:"embeddingmodel,omitempty" json:"embeddingModel,omitempty"`   // path to BirdNET v2.4 embeddings ONNX model
+	ClassifierModel     string                      `yaml:"classifiermodel,omitempty" json:"classifierModel,omitempty"` // path to bat species classifier ONNX model
+	LabelPath           string                      `yaml:"labelpath,omitempty" json:"labelPath,omitempty"`             // path to bat species labels file
+	Threshold           float64                     `yaml:"threshold" json:"threshold"`                                 // confidence threshold for bat detections
+	Locale              string                      `yaml:"locale,omitempty" json:"locale,omitempty"`                   // locale for species label translation
+	FilterEnabled       bool                        `yaml:"filterenabled" json:"filterEnabled"`                         // enable high-pass filter for bat audio
+	FilterCutoffHz      float64                     `yaml:"filtercutoffhz,omitempty" json:"filterCutoffHz,omitempty"`   // high-pass filter cutoff frequency in Hz
+	FilterPassCount     int                         `yaml:"filterpasscount,omitempty" json:"filterPassCount,omitempty"` // number of filter passes for steeper rolloff
+	NighttimeOnly       bool                        `yaml:"nighttimeonly" json:"nighttimeOnly"`                         // restrict bat detection to nighttime (civil dusk to civil dawn)
+	FalsePositiveFilter FalsePositiveFilterSettings `yaml:"falsepositivefilter" json:"falsePositiveFilter"`             // false positive filtering for bat detections (level 0-5)
+	UltrasonicFilter    UltrasonicFilterConfig      `yaml:"ultrasonicfilter" json:"ultrasonicFilter"`                   // post-detection ultrasonic validation filter
 }
 
 // UltrasonicFilterConfig controls the post-detection ultrasonic validation filter for bat detections.

--- a/internal/conf/defaults.go
+++ b/internal/conf/defaults.go
@@ -89,6 +89,7 @@ func setDefaultConfig() {
 	viper.SetDefault("bat.filtercutoffhz", 4000.0)
 	viper.SetDefault("bat.filterpasscount", 1)
 	viper.SetDefault("bat.nighttimeonly", true)
+	viper.SetDefault("bat.falsepositivefilter.level", 2)
 	viper.SetDefault("bat.ultrasonicfilter.enabled", true)
 	viper.SetDefault("bat.ultrasonicfilter.cvthreshold", 0.15)
 	viper.SetDefault("bat.ultrasonicfilter.fftsize", 8192)


### PR DESCRIPTION
## Summary

- Add false positive filter for bat detections with its own config (`bat.falsePositiveFilter.level`), separate from the bird FP filter
- Fix processor to use `settings.Bat.Threshold` for bat models instead of always falling back to `settings.BirdNET.Threshold`
- Make `shouldDiscardDetection`, `flushPendingDetections`, and `SnapshotVisiblePending` compute minDetections per-item from `BestModelID`
- Add bat FP filter slider to Settings > Analysis (visible only when bat model is installed)
- Default bat FP filter to level 2 (Moderate, 2 confirmations)
- i18n translations for all 14 languages

## Context

The processor was bird-model-centric. `calculateMinDetectionsFromSettings()` used bird-specific overlap/FP settings, and `getBaseConfidenceThreshold()` always fell back to `settings.BirdNET.Threshold`. Bat detections that already passed `settings.Bat.Threshold` in the classifier got re-evaluated against the bird threshold in the processor, causing legitimate bat detections to be filtered when BirdNET threshold > Bat threshold.

The bat model uses a fixed 50% overlap (hardcoded in `BufferDimensions()`), giving 4 possible detections in a 6-second reference window. This means the same FP filter levels yield fewer required confirmations for bat vs bird:

| Level | Bird (typical) | Bat |
|-------|---------------|-----|
| 0 Off | 1 | 1 |
| 1 Lenient | 2 | 1 |
| 2 Moderate | 3 | 2 |
| 3 Balanced | 5 | 2 |
| 4 Strict | 12 | 3 |
| 5 Maximum | 21 | 3 |

## Test plan

- [x] `go test -race ./internal/analysis/processor/...` (693 tests pass)
- [x] `golangci-lint run -v` (clean)
- [x] `npx svelte-check` (0 errors, 0 warnings)
- [x] All 14 JSON translation files validated
- [x] New tests: `TestCalculateBatMinDetections`, `TestCalculateMinDetectionsForModel`, `TestGetBaseConfidenceThreshold_BatModel`, `TestGetBaseConfidenceThreshold_CustomOverridesModel`, `TestValidateAndLogBatFilterConfig`
- [ ] Build and verify bat FP filter slider appears only when bat model installed
- [ ] Verify settings save/reload round-trip

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exposed a "Bat False Positive Filter" slider in Analysis Settings when a bat model is present (level badge, descriptive help). Default level set to 2.
  * Detection visibility now respects model-specific confirmation requirements, reducing bat false positives by requiring multiple confirmations within a sliding window.

* **Localization**
  * Added translations for the bat false-positive filter in 13 languages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3094)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->