### PR TITLE
fix(i18n): translate 491 untranslated keys across 13 locales

### DIFF
--- a/frontend/static/messages/da.json
+++ b/frontend/static/messages/da.json
@@ -4509,12 +4509,12 @@
   "analysis": {
     "title": "Analyse",
     "tabs": {
-      "settings": "Settings",
-      "models": "Models"
+      "settings": "Indstillinger",
+      "models": "Modeller"
     },
     "detection": {
-      "title": "Detection Settings",
-      "description": "Configure confidence thresholds and language for species classification.",
+      "title": "Detektionsindstillinger",
+      "description": "Konfigurer tærskler for konfidens og sprog til artsklassificering.",
       "confidenceThreshold": {
         "label": "Confidence Threshold",
         "helpText": "Minimum confidence score (0.0 - 1.0) required for a detection to be recorded."
@@ -4540,97 +4540,97 @@
         "helpText": "Kræver flere bekræftelser af en flagermusdetektion inden for et glidende vindue, før den accepteres. Højere niveauer kræver flere bekræftelser, hvilket reducerer falske positiver. Flagermusmodellen bruger et fast 50% overlap, så ingen overlapjustering er nødvendig."
       },
       "locale": {
-        "label": "Species Language",
-        "helpText": "Language used for species common names in the interface."
+        "label": "Artssprog",
+        "helpText": "Sprog brugt til arternes almindelige navne i brugerfladen."
       }
     },
     "rangeFilter": {
-      "birdOnlyNote": "Range filter applies to bird classifiers only. Bat models use their own species lists.",
+      "birdOnlyNote": "Områdefilter gælder kun for fugleklassifikatorer. Flagermusmodeller bruger deres egne artslister.",
       "status": {
         "title": "Områdefilter oversigt",
         "geomodelInfo": "BirdNET Geomodel {version} - {species} kendte arter",
-        "autoSelected": "Auto-selected",
-        "manual": "Manual",
-        "classifier": "Classifier",
-        "totalSpecies": "Total Species",
-        "withRangeData": "With Range Data",
-        "withoutRangeData": "Without Range Data",
-        "withRangeDataTooltip": "Species that the geomodel can evaluate for geographic probability at your location",
-        "withoutRangeDataTooltip": "Species without geographic data in the geomodel, handled by the unmapped species setting below",
-        "noFilter": "No range filter active",
+        "autoSelected": "Automatisk valgt",
+        "manual": "Manuel",
+        "classifier": "Klassifikator",
+        "totalSpecies": "Antal arter i alt",
+        "withRangeData": "Med områdedata",
+        "withoutRangeData": "Uden områdedata",
+        "withRangeDataTooltip": "Arter som geomodellen kan evaluere for geografisk sandsynlighed på din placering",
+        "withoutRangeDataTooltip": "Arter uden geografiske data i geomodellen, håndteret af indstillingen for ikke-kortlagte arter nedenfor",
+        "noFilter": "Intet områdefilter aktivt",
         "passUnmapped": {
-          "label": "Allow species without range data",
-          "helpText": "Allow detections of species the geomodel has no geographic data for. When disabled, these species are always filtered out."
+          "label": "Tillad arter uden områdedata",
+          "helpText": "Tillad detektioner af arter, som geomodellen ikke har geografiske data for. Når deaktiveret, filtreres disse arter altid fra."
         }
       }
     },
     "advanced": {
-      "title": "Advanced",
-      "description": "Processing and custom model configuration."
+      "title": "Avanceret",
+      "description": "Behandling og brugerdefineret modelkonfiguration."
     },
     "gallery": {
-      "title": "Model Gallery",
-      "description": "Manage classifier models for bird and bat detection.",
+      "title": "Modelgalleri",
+      "description": "Administrer klassifikatormodeller til fugle- og flagermusdetektion.",
       "tabs": {
-        "installed": "Installed",
-        "available": "Available"
+        "installed": "Installerede",
+        "available": "Tilgængelige"
       },
-      "loading": "Loading models...",
-      "retry": "Retry",
-      "builtIn": "Built-in",
-      "builtInDescription": "Built-in bird species classifier by the BirdNET team.",
-      "species": "{count} species",
-      "install": "Install",
-      "installing": "Installing...",
-      "remove": "Remove",
-      "removing": "Removing...",
-      "noInstalledModels": "No additional models installed. Browse the Available tab to add more classifiers.",
-      "noAvailableModels": "No additional models available for your platform.",
+      "loading": "Indlæser modeller...",
+      "retry": "Prøv igen",
+      "builtIn": "Indbygget",
+      "builtInDescription": "Indbygget fuglearts-klassifikator fra BirdNET-teamet.",
+      "species": "{count} arter",
+      "install": "Installer",
+      "installing": "Installerer...",
+      "remove": "Fjern",
+      "removing": "Fjerner...",
+      "noInstalledModels": "Ingen yderligere modeller installeret. Gennemse fanen Tilgængelige for at tilføje flere klassifikatorer.",
+      "noAvailableModels": "Ingen yderligere modeller tilgængelige til din platform.",
       "sections": {
         "acoustic": "Akustiske klassifikatorer",
         "geomodel": "Geomodeller"
       },
       "categories": {
-        "wildlife": "Wildlife Classifiers",
-        "bird": "Bird Classifiers",
-        "bat": "Bat Classifiers"
+        "wildlife": "Vildtklassifikatorer",
+        "bird": "Fugleklassifikatorer",
+        "bat": "Flagermusklassifikatorer"
       },
       "progress": {
-        "downloading": "Downloading...",
-        "verifying": "Verifying...",
-        "loading": "Loading...",
-        "complete": "Installed successfully",
-        "failed": "Failed"
+        "downloading": "Downloader...",
+        "verifying": "Verificerer...",
+        "loading": "Indlæser...",
+        "complete": "Installeret succesfuldt",
+        "failed": "Fejlet"
       },
       "license": {
-        "title": "License Agreement",
+        "title": "Licensaftale",
         "model": "Model",
-        "author": "Author",
-        "license": "License",
-        "commercialUse": "Commercial Use",
-        "downloadSize": "Download Size",
-        "allowed": "Allowed",
-        "notAllowed": "Not allowed",
-        "commercialUseAllowed": "Commercial use allowed",
-        "nonCommercialOnly": "Non-commercial use only",
-        "nonCommercialWarning": "This model is licensed for non-commercial use only. By installing, you agree to comply with the license terms.",
-        "acceptAndInstall": "Accept & Install"
+        "author": "Forfatter",
+        "license": "Licens",
+        "commercialUse": "Kommerciel brug",
+        "downloadSize": "Downloadstørrelse",
+        "allowed": "Tilladt",
+        "notAllowed": "Ikke tilladt",
+        "commercialUseAllowed": "Kommerciel brug tilladt",
+        "nonCommercialOnly": "Kun ikke-kommerciel brug",
+        "nonCommercialWarning": "Denne model er licenseret kun til ikke-kommerciel brug. Ved at installere accepterer du at overholde licensbetingelserne.",
+        "acceptAndInstall": "Accepter og installer"
       },
       "removeDialog": {
-        "title": "Remove {name}?",
-        "confirmation": "This will remove the model files from disk. Label data is retained for existing detections."
+        "title": "Fjern {name}?",
+        "confirmation": "Dette vil fjerne modelfilerne fra disken. Labeldata bevares for eksisterende detektioner."
       },
       "errors": {
-        "catalogLoadFailed": "Failed to load model catalog",
-        "installFailed": "Failed to start model installation",
-        "removeFailed": "Failed to remove model"
+        "catalogLoadFailed": "Kunne ikke indlæse modelkatalog",
+        "installFailed": "Kunne ikke starte modelinstallation",
+        "removeFailed": "Kunne ikke fjerne model"
       },
       "regionLabel": "Region",
-      "speciesLabel": "Species",
-      "reinstall": "Reinstall",
-      "reinstalling": "Reinstalling...",
-      "reinstallComplete": "Files verified successfully",
-      "geomodelBadge": "Includes BirdNET v3.0 geomodel"
+      "speciesLabel": "Arter",
+      "reinstall": "Geninstaller",
+      "reinstalling": "Geninstallerer...",
+      "reinstallComplete": "Filer verificeret succesfuldt",
+      "geomodelBadge": "Inkluderer BirdNET v3.0 geomodel"
     }
   },
   "restart": {

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -3919,7 +3919,7 @@
       "schemeForest": "Wald",
       "schemeAmber": "Bernstein",
       "schemeViolet": "Violett",
-      "schemeRose": "Rose",
+      "schemeRose": "Rosé",
       "schemeCustom": "Benutzerdefiniert",
       "customPrimary": "Primärfarbe",
       "customAccent": "Akzentfarbe",
@@ -4509,8 +4509,8 @@
   "analysis": {
     "title": "Analyse",
     "tabs": {
-      "settings": "Settings",
-      "models": "Models"
+      "settings": "Einstellungen",
+      "models": "Modelle"
     },
     "detection": {
       "title": "Erkennungseinstellungen",
@@ -4540,12 +4540,12 @@
         "helpText": "Erfordert mehrere Bestätigungen einer Fledermauserkennung innerhalb eines gleitenden Fensters, bevor sie akzeptiert wird. Höhere Stufen erfordern mehr Bestätigungen und reduzieren Fehlerkennungen. Das Fledermausmodell verwendet eine feste 50%-Überlappung, daher ist keine Überlappungsanpassung erforderlich."
       },
       "locale": {
-        "label": "Species Language",
-        "helpText": "Language used for species common names in the interface."
+        "label": "Artensprache",
+        "helpText": "Sprache für die gebräuchlichen Artnamen in der Benutzeroberfläche."
       }
     },
     "rangeFilter": {
-      "birdOnlyNote": "Range filter applies to bird classifiers only. Bat models use their own species lists.",
+      "birdOnlyNote": "Der Reichweitenfilter gilt nur für Vogelklassifikatoren. Fledermausmodelle verwenden eigene Artenlisten.",
       "status": {
         "title": "Gebietsfilter-Übersicht",
         "geomodelInfo": "BirdNET-Geomodell {version} - {species} bekannte Arten",
@@ -4565,8 +4565,8 @@
       }
     },
     "advanced": {
-      "title": "Advanced",
-      "description": "Processing and custom model configuration."
+      "title": "Erweitert",
+      "description": "Verarbeitungs- und benutzerdefinierte Modellkonfiguration."
     },
     "gallery": {
       "title": "Modellgalerie",

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -4214,7 +4214,7 @@
         "extracting": "Extrayendo clip...",
         "extractError": "Error al extraer el clip",
         "formatLabel": "Formato",
-        "rangeLabel": "{start}s – {end}s"
+        "rangeLabel": "{start}s - {end}s"
       },
       "processing": {
         "playSelection": "Reproducir selección",
@@ -4509,8 +4509,8 @@
   "analysis": {
     "title": "Análisis",
     "tabs": {
-      "settings": "Settings",
-      "models": "Models"
+      "settings": "Ajustes",
+      "models": "Modelos"
     },
     "detection": {
       "title": "Configuración de detección",
@@ -4540,12 +4540,12 @@
         "helpText": "Requiere múltiples confirmaciones de una detección de murciélago dentro de una ventana deslizante antes de aceptarla. Niveles más altos requieren más confirmaciones, reduciendo los falsos positivos. El modelo de murciélagos usa una superposición fija del 50%, por lo que no se necesita ajuste de superposición."
       },
       "locale": {
-        "label": "Species Language",
-        "helpText": "Language used for species common names in the interface."
+        "label": "Idioma de especies",
+        "helpText": "Idioma utilizado para los nombres comunes de especies en la interfaz."
       }
     },
     "rangeFilter": {
-      "birdOnlyNote": "Range filter applies to bird classifiers only. Bat models use their own species lists.",
+      "birdOnlyNote": "El filtro de rango se aplica solo a clasificadores de aves. Los modelos de murciélagos usan sus propias listas de especies.",
       "status": {
         "title": "Resumen del filtro de rango",
         "geomodelInfo": "BirdNET Geomodelo {version} - {species} especies conocidas",
@@ -4565,8 +4565,8 @@
       }
     },
     "advanced": {
-      "title": "Advanced",
-      "description": "Processing and custom model configuration."
+      "title": "Avanzado",
+      "description": "Configuración de procesamiento y modelos personalizados."
     },
     "gallery": {
       "title": "Galería de modelos",

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -1443,7 +1443,7 @@
       "samples": "näytettä",
       "available": "saatav.",
       "min": "Min",
-      "max": "Max",
+      "max": "Maks",
       "limit": "Raja",
       "tempUnavailable": "Ei saatavilla",
       "online": "Verkossa",
@@ -3928,22 +3928,22 @@
     },
     "userInterface": {
       "tabs": {
-        "appearance": "Appearance",
-        "language": "Language & Regional",
-        "visualContent": "Visual Content",
+        "appearance": "Ulkoasu",
+        "language": "Kieli ja alue",
+        "visualContent": "Visuaalinen sisältö",
         "audioPlayback": "Äänentoisto"
       },
       "appearance": {
-        "title": "Appearance",
-        "description": "Customize the look and feel of your BirdNET-Go interface"
+        "title": "Ulkoasu",
+        "description": "Mukauta BirdNET-Go-käyttöliittymän ulkoasua"
       },
       "language": {
-        "title": "Language & Regional",
-        "description": "Language, temperature units, and regional display preferences"
+        "title": "Kieli ja alue",
+        "description": "Kieli, lämpötilayksiköt ja alueelliset näyttöasetukset"
       },
       "visualContent": {
-        "title": "Visual Content",
-        "description": "Configure bird images and spectrogram display settings"
+        "title": "Visuaalinen sisältö",
+        "description": "Lintukuvien ja spektrogramminäytön asetukset"
       },
       "audioPlayback": {
         "title": "Äänentoisto",
@@ -4214,7 +4214,7 @@
         "extracting": "Puretaan leikettä...",
         "extractError": "Leikkeen purku epäonnistui",
         "formatLabel": "Muoto",
-        "rangeLabel": "{start}s – {end}s"
+        "rangeLabel": "{start}s - {end}s"
       },
       "processing": {
         "playSelection": "Toista valinta",
@@ -4509,8 +4509,8 @@
   "analysis": {
     "title": "Analyysi",
     "tabs": {
-      "settings": "Settings",
-      "models": "Models"
+      "settings": "Asetukset",
+      "models": "Mallit"
     },
     "detection": {
       "title": "Tunnistusasetukset",
@@ -4540,12 +4540,12 @@
         "helpText": "Vaatii useita vahvistuksia lepakkotunnistuksesta liukuvan ikkunan sisällä ennen kuin se hyväksytään. Korkeammat tasot vaativat enemmän vahvistuksia, mikä vähentää vääriä positiivisia. Lepakkomalli käyttää kiinteää 50 % päällekkäisyyttä, joten päällekkäisyyden säätöä ei tarvita."
       },
       "locale": {
-        "label": "Species Language",
-        "helpText": "Language used for species common names in the interface."
+        "label": "Lajien kieli",
+        "helpText": "Kieli, jolla lajien yleisnimistö näytetään käyttöliittymässä."
       }
     },
     "rangeFilter": {
-      "birdOnlyNote": "Range filter applies to bird classifiers only. Bat models use their own species lists.",
+      "birdOnlyNote": "Aluesuodatin koskee vain lintuluokittimia. Lepakkomallit käyttävät omia lajilistojaan.",
       "status": {
         "title": "Aluesuodattimen yhteenveto",
         "geomodelInfo": "BirdNET-geomalli {version} - {species} tunnettua lajia",
@@ -4565,8 +4565,8 @@
       }
     },
     "advanced": {
-      "title": "Advanced",
-      "description": "Processing and custom model configuration."
+      "title": "Lisäasetukset",
+      "description": "Käsittelyn ja mukautettujen mallien asetukset."
     },
     "gallery": {
       "title": "Malligalleria",

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -660,8 +660,8 @@
       },
       "actions": {
         "menuLabel": "Actions pour {species}",
-        "markCorrect": "Correct",
-        "markFalsePositive": "Incorrect",
+        "markCorrect": "Correcte",
+        "markFalsePositive": "Incorrecte",
         "review": "Examiner la détection",
         "showSpecies": "Afficher l'espèce",
         "ignoreSpecies": "Ignorer l'espèce",
@@ -2841,7 +2841,7 @@
         "mqttTopic": "Topic MQTT :",
         "sseEndpoint": "Point de terminaison SSE :",
         "prometheusMetrics": "Métriques Prometheus :",
-        "disabled": "Sound level monitoring is disabled"
+        "disabled": "La surveillance du niveau sonore est désactivée"
       },
       "clipSettings": {
         "title": "Paramètres des clips",
@@ -2879,8 +2879,8 @@
         "bitrateLabel": "Débit",
         "bitrateHelp": "Débit de compression audio pour les formats avec perte. Plage : {min}-{max} kbps. Des valeurs plus élevées offrent une meilleure qualité mais des fichiers plus volumineux.",
         "losslessNote": "Les formats sans perte préservent la qualité audio originale sans artefacts de compression.",
-        "normalizationDisabled": "Audio normalization is disabled",
-        "disabledInfo": "Enable clip recording above to configure clip settings, file format, and storage options."
+        "normalizationDisabled": "La normalisation audio est désactivée",
+        "disabledInfo": "Activez l'enregistrement de clips ci-dessus pour configurer les paramètres de clip, le format de fichier et les options de stockage."
       },
       "extendedCapture": {
         "title": "Capture étendue",
@@ -2941,12 +2941,12 @@
           "age": "Âge",
           "usage": "Utilisation"
         },
-        "noRetentionTitle": "All Clips Retained",
-        "noRetentionDescription": "Audio clips will be kept indefinitely. Monitor disk usage to prevent storage issues.",
-        "ageRetentionTitle": "Age-Based Cleanup",
-        "ageRetentionDescription": "Clips older than the specified age will be automatically deleted, while preserving the minimum number per species.",
-        "usageRetentionTitle": "Usage-Based Cleanup",
-        "usageRetentionDescription": "When disk usage exceeds the threshold, oldest clips will be deleted until usage is within limits."
+        "noRetentionTitle": "Tous les clips conservés",
+        "noRetentionDescription": "Les clips audio seront conservés indéfiniment. Surveillez l'utilisation du disque pour éviter les problèmes de stockage.",
+        "ageRetentionTitle": "Nettoyage par ancienneté",
+        "ageRetentionDescription": "Les clips plus anciens que l'âge spécifié seront automatiquement supprimés, tout en conservant le nombre minimum par espèce.",
+        "usageRetentionTitle": "Nettoyage par utilisation",
+        "usageRetentionDescription": "Lorsque l'utilisation du disque dépasse le seuil, les clips les plus anciens seront supprimés jusqu'à ce que l'utilisation soit dans les limites."
       },
       "formats": {
         "wav": "WAV",
@@ -3171,7 +3171,7 @@
         "enableLabel": "Activer l'authentification par mot de passe",
         "passwordLabel": "Mot de passe",
         "passwordHelpText": "Limiter l'accès aux paramètres avec un mot de passe.",
-        "disabled": "Password authentication is disabled"
+        "disabled": "L'authentification par mot de passe est désactivée"
       },
       "oauth": {
         "title": "Authentification externe",
@@ -3284,7 +3284,7 @@
       "bypassAuthentication": {
         "title": "Contourner l'authentification",
         "description": "Autoriser l'accès aux paramètres sans authentification",
-        "disabled": "Subnet bypass is disabled"
+        "disabled": "Le contournement par sous-réseau est désactivé"
       },
       "exceptions": {
         "title": "Exceptions"
@@ -3472,27 +3472,27 @@
           "thresholdPlaceholder": "0.5",
           "intervalPlaceholder": "0"
         },
-        "addConfiguration": "Add Configuration",
-        "newConfiguration": "New Configuration",
-        "editing": "Editing: {species}",
-        "configuredCount": "{count} configured",
+        "addConfiguration": "Ajouter une configuration",
+        "newConfiguration": "Nouvelle configuration",
+        "editing": "Modification : {species}",
+        "configuredCount": "{count} configurées",
         "searchPlaceholder": "Type to search...",
-        "saving": "Saving...",
-        "save": "Save",
-        "cancel": "Cancel",
-        "configureActions": "Configure Actions",
-        "actionsConfigured": "Configured",
+        "saving": "Enregistrement...",
+        "save": "Enregistrer",
+        "cancel": "Annuler",
+        "configureActions": "Configurer les actions",
+        "actionsConfigured": "Configuré",
         "list": {
-          "threshold": "Threshold:",
-          "interval": "Interval:",
-          "intervalNone": "None",
+          "threshold": "Seuil :",
+          "interval": "Intervalle :",
+          "intervalNone": "Aucun",
           "actionBadge": "Action",
-          "editTitle": "Edit configuration",
-          "removeTitle": "Remove configuration"
+          "editTitle": "Modifier la configuration",
+          "removeTitle": "Supprimer la configuration"
         },
         "emptyState": {
-          "title": "No configurations yet.",
-          "description": "Click \"Add Configuration\" to customize species detection settings."
+          "title": "Aucune configuration pour le moment.",
+          "description": "Cliquez sur « Ajouter une configuration » pour personnaliser les paramètres de détection des espèces."
         }
       },
       "synonyms": {
@@ -4169,7 +4169,7 @@
         "urlPlaceholder": "rtsp://username:password@192.168.1.100:554/stream"
       },
       "subnet": {
-        "maxSubnetsReached": "Maximum number of subnets ({max}) reached."
+        "maxSubnetsReached": "Nombre maximum de sous-réseaux ({max}) atteint."
       }
     },
     "datePicker": {
@@ -4509,8 +4509,8 @@
   "analysis": {
     "title": "Analyse",
     "tabs": {
-      "settings": "Settings",
-      "models": "Models"
+      "settings": "Paramètres",
+      "models": "Modèles"
     },
     "detection": {
       "title": "Paramètres de détection",
@@ -4540,12 +4540,12 @@
         "helpText": "Nécessite plusieurs confirmations d'une détection de chauve-souris dans une fenêtre glissante avant de l'accepter. Les niveaux supérieurs nécessitent plus de confirmations, réduisant les faux positifs. Le modèle chauve-souris utilise un chevauchement fixe de 50 %, aucun ajustement n'est donc nécessaire."
       },
       "locale": {
-        "label": "Species Language",
-        "helpText": "Language used for species common names in the interface."
+        "label": "Langue des espèces",
+        "helpText": "Langue utilisée pour les noms communs des espèces dans l'interface."
       }
     },
     "rangeFilter": {
-      "birdOnlyNote": "Range filter applies to bird classifiers only. Bat models use their own species lists.",
+      "birdOnlyNote": "Le filtre de zone s'applique uniquement aux classificateurs d'oiseaux. Les modèles de chauves-souris utilisent leurs propres listes d'espèces.",
       "status": {
         "title": "Aperçu du filtre de zone",
         "geomodelInfo": "BirdNET Géomodèle {version} - {species} espèces connues",
@@ -4565,8 +4565,8 @@
       }
     },
     "advanced": {
-      "title": "Advanced",
-      "description": "Processing and custom model configuration."
+      "title": "Avancé",
+      "description": "Configuration du traitement et des modèles personnalisés."
     },
     "gallery": {
       "title": "Galerie de modèles",

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -3481,7 +3481,7 @@
         "save": "Enregistrer",
         "cancel": "Annuler",
         "configureActions": "Configurer les actions",
-        "actionsConfigured": "Configuré",
+        "actionsConfigured": "Configurées",
         "list": {
           "threshold": "Seuil :",
           "interval": "Intervalle :",

--- a/frontend/static/messages/hu.json
+++ b/frontend/static/messages/hu.json
@@ -4238,7 +4238,7 @@
         "extracting": "Részlet kivonása...",
         "extractError": "A részlet kivonása sikertelen",
         "formatLabel": "Formátum",
-        "rangeLabel": "{start}s – {end}s"
+        "rangeLabel": "{start}s - {end}s"
       },
       "processing": {
         "playSelection": "Kijelölés lejátszása",
@@ -4509,12 +4509,12 @@
   "analysis": {
     "title": "Elemzés",
     "tabs": {
-      "settings": "Settings",
-      "models": "Models"
+      "settings": "Beállítások",
+      "models": "Modellek"
     },
     "detection": {
-      "title": "Detection Settings",
-      "description": "Configure confidence thresholds and language for species classification.",
+      "title": "Detektálási beállítások",
+      "description": "Megbízhatósági küszöbértékek és nyelv beállítása a fajok osztályozásához.",
       "confidenceThreshold": {
         "label": "Confidence Threshold",
         "helpText": "Minimum confidence score (0.0 - 1.0) required for a detection to be recorded."
@@ -4540,97 +4540,97 @@
         "helpText": "Több megerősítést igényel egy denevérészleléshez egy csúszó ablakon belül, mielőtt elfogadná. A magasabb szintek több megerősítést igényelnek, csökkentve a hamis pozitívokat. A denevérmodell fix 50%-os átfedést használ, így átfedés-beállítás nem szükséges."
       },
       "locale": {
-        "label": "Species Language",
-        "helpText": "Language used for species common names in the interface."
+        "label": "Fajok nyelve",
+        "helpText": "A fajok köznapi neveihez használt nyelv a felületen."
       }
     },
     "rangeFilter": {
-      "birdOnlyNote": "Range filter applies to bird classifiers only. Bat models use their own species lists.",
+      "birdOnlyNote": "A területszűrő csak madár osztályozókra vonatkozik. A denevérmodellek saját fajlistákat használnak.",
       "status": {
         "title": "Területszűrő áttekintés",
         "geomodelInfo": "BirdNET Geomodell {version} - {species} ismert faj",
-        "autoSelected": "Auto-selected",
-        "manual": "Manual",
-        "classifier": "Classifier",
-        "totalSpecies": "Total Species",
-        "withRangeData": "With Range Data",
-        "withoutRangeData": "Without Range Data",
-        "withRangeDataTooltip": "Species that the geomodel can evaluate for geographic probability at your location",
-        "withoutRangeDataTooltip": "Species without geographic data in the geomodel, handled by the unmapped species setting below",
-        "noFilter": "No range filter active",
+        "autoSelected": "Automatikusan kiválasztott",
+        "manual": "Kézi",
+        "classifier": "Osztályozó",
+        "totalSpecies": "Összes faj",
+        "withRangeData": "Területi adattal",
+        "withoutRangeData": "Területi adat nélkül",
+        "withRangeDataTooltip": "Fajok, amelyeket a geomodell ki tud értékelni földrajzi valószínűség szempontjából az Ön helyén",
+        "withoutRangeDataTooltip": "Fajok földrajzi adat nélkül a geomodellben, az alábbi nem térképezett fajok beállítás kezeli",
+        "noFilter": "Nincs aktív területszűrő",
         "passUnmapped": {
-          "label": "Allow species without range data",
-          "helpText": "Allow detections of species the geomodel has no geographic data for. When disabled, these species are always filtered out."
+          "label": "Területi adat nélküli fajok engedélyezése",
+          "helpText": "Engedélyezze azon fajok detektálását, amelyekhez a geomodellnek nincs földrajzi adata. Kikapcsolva ezek a fajok mindig kiszűrésre kerülnek."
         }
       }
     },
     "advanced": {
-      "title": "Advanced",
-      "description": "Processing and custom model configuration."
+      "title": "Haladó",
+      "description": "Feldolgozási és egyéni modell beállítások."
     },
     "gallery": {
-      "title": "Model Gallery",
-      "description": "Manage classifier models for bird and bat detection.",
+      "title": "Modellgaléria",
+      "description": "Osztályozó modellek kezelése madár- és denevérdetektáláshoz.",
       "tabs": {
-        "installed": "Installed",
-        "available": "Available"
+        "installed": "Telepített",
+        "available": "Elérhető"
       },
-      "loading": "Loading models...",
-      "retry": "Retry",
-      "builtIn": "Built-in",
-      "builtInDescription": "Built-in bird species classifier by the BirdNET team.",
-      "species": "{count} species",
-      "install": "Install",
-      "installing": "Installing...",
-      "remove": "Remove",
-      "removing": "Removing...",
-      "noInstalledModels": "No additional models installed. Browse the Available tab to add more classifiers.",
-      "noAvailableModels": "No additional models available for your platform.",
+      "loading": "Modellek betöltése...",
+      "retry": "Újra",
+      "builtIn": "Beépített",
+      "builtInDescription": "A BirdNET csapat beépített madárfaj-osztályozója.",
+      "species": "{count} faj",
+      "install": "Telepítés",
+      "installing": "Telepítés...",
+      "remove": "Eltávolítás",
+      "removing": "Eltávolítás...",
+      "noInstalledModels": "Nincs további telepített modell. Az Elérhető fülön böngészhet további osztályozók között.",
+      "noAvailableModels": "Nincs további elérhető modell az Ön platformjához.",
       "sections": {
         "acoustic": "Akusztikus osztályozók",
         "geomodel": "Geomodellek"
       },
       "categories": {
-        "wildlife": "Wildlife Classifiers",
-        "bird": "Bird Classifiers",
-        "bat": "Bat Classifiers"
+        "wildlife": "Vadon élő állatok osztályozók",
+        "bird": "Madár osztályozók",
+        "bat": "Denevér osztályozók"
       },
       "progress": {
-        "downloading": "Downloading...",
-        "verifying": "Verifying...",
-        "loading": "Loading...",
-        "complete": "Installed successfully",
-        "failed": "Failed"
+        "downloading": "Letöltés...",
+        "verifying": "Ellenőrzés...",
+        "loading": "Betöltés...",
+        "complete": "Sikeresen telepítve",
+        "failed": "Sikertelen"
       },
       "license": {
-        "title": "License Agreement",
-        "model": "Model",
-        "author": "Author",
-        "license": "License",
-        "commercialUse": "Commercial Use",
-        "downloadSize": "Download Size",
-        "allowed": "Allowed",
-        "notAllowed": "Not allowed",
-        "commercialUseAllowed": "Commercial use allowed",
-        "nonCommercialOnly": "Non-commercial use only",
-        "nonCommercialWarning": "This model is licensed for non-commercial use only. By installing, you agree to comply with the license terms.",
-        "acceptAndInstall": "Accept & Install"
+        "title": "Licencszerződés",
+        "model": "Modell",
+        "author": "Szerző",
+        "license": "Licenc",
+        "commercialUse": "Kereskedelmi felhasználás",
+        "downloadSize": "Letöltési méret",
+        "allowed": "Engedélyezett",
+        "notAllowed": "Nem engedélyezett",
+        "commercialUseAllowed": "Kereskedelmi felhasználás engedélyezett",
+        "nonCommercialOnly": "Csak nem kereskedelmi célú felhasználás",
+        "nonCommercialWarning": "Ez a modell csak nem kereskedelmi felhasználásra licencelt. A telepítéssel elfogadja a licencfeltételeket.",
+        "acceptAndInstall": "Elfogadás és telepítés"
       },
       "removeDialog": {
-        "title": "Remove {name}?",
-        "confirmation": "This will remove the model files from disk. Label data is retained for existing detections."
+        "title": "{name} eltávolítása?",
+        "confirmation": "Ez eltávolítja a modellfájlokat a lemezről. A meglévő detektálások címkeadatai megmaradnak."
       },
       "errors": {
-        "catalogLoadFailed": "Failed to load model catalog",
-        "installFailed": "Failed to start model installation",
-        "removeFailed": "Failed to remove model"
+        "catalogLoadFailed": "Nem sikerült betölteni a modellkatalógust",
+        "installFailed": "Nem sikerült elindítani a modell telepítését",
+        "removeFailed": "Nem sikerült eltávolítani a modellt"
       },
-      "regionLabel": "Region",
-      "speciesLabel": "Species",
-      "reinstall": "Reinstall",
-      "reinstalling": "Reinstalling...",
-      "reinstallComplete": "Files verified successfully",
-      "geomodelBadge": "Includes BirdNET v3.0 geomodel"
+      "regionLabel": "Régió",
+      "speciesLabel": "Fajok",
+      "reinstall": "Újratelepítés",
+      "reinstalling": "Újratelepítés...",
+      "reinstallComplete": "Fájlok sikeresen ellenőrizve",
+      "geomodelBadge": "Tartalmazza a BirdNET v3.0 geomodellt"
     }
   },
   "restart": {

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -4507,14 +4507,14 @@
     }
   },
   "analysis": {
-    "title": "Analysis",
+    "title": "Analisi",
     "tabs": {
-      "settings": "Settings",
-      "models": "Models"
+      "settings": "Impostazioni",
+      "models": "Modelli"
     },
     "detection": {
-      "title": "Detection Settings",
-      "description": "Configure confidence thresholds and language for species classification.",
+      "title": "Impostazioni di rilevamento",
+      "description": "Configura le soglie di confidenza e la lingua per la classificazione delle specie.",
       "confidenceThreshold": {
         "label": "Confidence Threshold",
         "helpText": "Minimum confidence score (0.0 - 1.0) required for a detection to be recorded."
@@ -4540,97 +4540,97 @@
         "helpText": "Richiede multiple conferme di un rilevamento di pipistrello all'interno di una finestra scorrevole prima di accettarlo. Livelli più alti richiedono più conferme, riducendo i falsi positivi. Il modello pipistrelli usa una sovrapposizione fissa del 50%, quindi non è necessario alcun aggiustamento."
       },
       "locale": {
-        "label": "Species Language",
-        "helpText": "Language used for species common names in the interface."
+        "label": "Lingua delle specie",
+        "helpText": "Lingua utilizzata per i nomi comuni delle specie nell'interfaccia."
       }
     },
     "rangeFilter": {
-      "birdOnlyNote": "Range filter applies to bird classifiers only. Bat models use their own species lists.",
+      "birdOnlyNote": "Il filtro di zona si applica solo ai classificatori di uccelli. I modelli per pipistrelli usano le proprie liste di specie.",
       "status": {
         "title": "Panoramica filtro di zona",
         "geomodelInfo": "BirdNET Geomodello {version} - {species} specie conosciute",
-        "autoSelected": "Auto-selected",
-        "manual": "Manual",
-        "classifier": "Classifier",
-        "totalSpecies": "Total Species",
-        "withRangeData": "With Range Data",
-        "withoutRangeData": "Without Range Data",
-        "withRangeDataTooltip": "Species that the geomodel can evaluate for geographic probability at your location",
-        "withoutRangeDataTooltip": "Species without geographic data in the geomodel, handled by the unmapped species setting below",
-        "noFilter": "No range filter active",
+        "autoSelected": "Selezionato automaticamente",
+        "manual": "Manuale",
+        "classifier": "Classificatore",
+        "totalSpecies": "Specie totali",
+        "withRangeData": "Con dati di distribuzione",
+        "withoutRangeData": "Senza dati di distribuzione",
+        "withRangeDataTooltip": "Specie che il geomodel può valutare per la probabilità geografica nella tua posizione",
+        "withoutRangeDataTooltip": "Specie senza dati geografici nel geomodel, gestite dall'impostazione delle specie non mappate qui sotto",
+        "noFilter": "Nessun filtro di zona attivo",
         "passUnmapped": {
-          "label": "Allow species without range data",
-          "helpText": "Allow detections of species the geomodel has no geographic data for. When disabled, these species are always filtered out."
+          "label": "Consenti specie senza dati di distribuzione",
+          "helpText": "Consenti i rilevamenti di specie per le quali il geomodel non ha dati geografici. Se disabilitato, queste specie vengono sempre filtrate."
         }
       }
     },
     "advanced": {
-      "title": "Advanced",
-      "description": "Processing and custom model configuration."
+      "title": "Avanzate",
+      "description": "Configurazione dell'elaborazione e dei modelli personalizzati."
     },
     "gallery": {
-      "title": "Model Gallery",
-      "description": "Manage classifier models for bird and bat detection.",
+      "title": "Galleria modelli",
+      "description": "Gestisci i modelli di classificazione per il rilevamento di uccelli e pipistrelli.",
       "tabs": {
-        "installed": "Installed",
-        "available": "Available"
+        "installed": "Installati",
+        "available": "Disponibili"
       },
-      "loading": "Loading models...",
-      "retry": "Retry",
-      "builtIn": "Built-in",
-      "builtInDescription": "Built-in bird species classifier by the BirdNET team.",
-      "species": "{count} species",
-      "install": "Install",
-      "installing": "Installing...",
-      "remove": "Remove",
-      "removing": "Removing...",
-      "noInstalledModels": "No additional models installed. Browse the Available tab to add more classifiers.",
-      "noAvailableModels": "No additional models available for your platform.",
+      "loading": "Caricamento modelli...",
+      "retry": "Riprova",
+      "builtIn": "Integrato",
+      "builtInDescription": "Classificatore di specie di uccelli integrato dal team BirdNET.",
+      "species": "{count} specie",
+      "install": "Installa",
+      "installing": "Installazione...",
+      "remove": "Rimuovi",
+      "removing": "Rimozione...",
+      "noInstalledModels": "Nessun modello aggiuntivo installato. Sfoglia la scheda Disponibili per aggiungerne altri.",
+      "noAvailableModels": "Nessun modello aggiuntivo disponibile per la tua piattaforma.",
       "sections": {
         "acoustic": "Classificatori acustici",
         "geomodel": "Geomodelli"
       },
       "categories": {
-        "wildlife": "Wildlife Classifiers",
-        "bird": "Bird Classifiers",
-        "bat": "Bat Classifiers"
+        "wildlife": "Classificatori di fauna selvatica",
+        "bird": "Classificatori di uccelli",
+        "bat": "Classificatori di pipistrelli"
       },
       "progress": {
-        "downloading": "Downloading...",
-        "verifying": "Verifying...",
-        "loading": "Loading...",
-        "complete": "Installed successfully",
-        "failed": "Failed"
+        "downloading": "Download in corso...",
+        "verifying": "Verifica in corso...",
+        "loading": "Caricamento...",
+        "complete": "Installazione completata",
+        "failed": "Non riuscito"
       },
       "license": {
-        "title": "License Agreement",
-        "model": "Model",
-        "author": "Author",
-        "license": "License",
-        "commercialUse": "Commercial Use",
-        "downloadSize": "Download Size",
-        "allowed": "Allowed",
-        "notAllowed": "Not allowed",
-        "commercialUseAllowed": "Commercial use allowed",
-        "nonCommercialOnly": "Non-commercial use only",
-        "nonCommercialWarning": "This model is licensed for non-commercial use only. By installing, you agree to comply with the license terms.",
-        "acceptAndInstall": "Accept & Install"
+        "title": "Contratto di licenza",
+        "model": "Modello",
+        "author": "Autore",
+        "license": "Licenza",
+        "commercialUse": "Uso commerciale",
+        "downloadSize": "Dimensione download",
+        "allowed": "Consentito",
+        "notAllowed": "Non consentito",
+        "commercialUseAllowed": "Uso commerciale consentito",
+        "nonCommercialOnly": "Solo uso non commerciale",
+        "nonCommercialWarning": "Questo modello è concesso in licenza solo per uso non commerciale. Installandolo, accetti di rispettare i termini della licenza.",
+        "acceptAndInstall": "Accetta e installa"
       },
       "removeDialog": {
-        "title": "Remove {name}?",
-        "confirmation": "This will remove the model files from disk. Label data is retained for existing detections."
+        "title": "Rimuovere {name}?",
+        "confirmation": "I file del modello verranno rimossi dal disco. I dati delle etichette vengono conservati per i rilevamenti esistenti."
       },
       "errors": {
-        "catalogLoadFailed": "Failed to load model catalog",
-        "installFailed": "Failed to start model installation",
-        "removeFailed": "Failed to remove model"
+        "catalogLoadFailed": "Impossibile caricare il catalogo dei modelli",
+        "installFailed": "Impossibile avviare l'installazione del modello",
+        "removeFailed": "Impossibile rimuovere il modello"
       },
-      "regionLabel": "Region",
-      "speciesLabel": "Species",
-      "reinstall": "Reinstall",
-      "reinstalling": "Reinstalling...",
-      "reinstallComplete": "Files verified successfully",
-      "geomodelBadge": "Includes BirdNET v3.0 geomodel"
+      "regionLabel": "Regione",
+      "speciesLabel": "Specie",
+      "reinstall": "Reinstalla",
+      "reinstalling": "Reinstallazione...",
+      "reinstallComplete": "File verificati con successo",
+      "geomodelBadge": "Include il geomodel BirdNET v3.0"
     }
   },
   "restart": {

--- a/frontend/static/messages/lv.json
+++ b/frontend/static/messages/lv.json
@@ -4238,7 +4238,7 @@
         "extracting": "Izgūst klipu...",
         "extractError": "Neizdevās izgūt klipu",
         "formatLabel": "Formāts",
-        "rangeLabel": "{start}s – {end}s"
+        "rangeLabel": "{start}s - {end}s"
       },
       "processing": {
         "playSelection": "Atskaņot atlasi",
@@ -4509,12 +4509,12 @@
   "analysis": {
     "title": "Analīze",
     "tabs": {
-      "settings": "Settings",
-      "models": "Models"
+      "settings": "Iestatījumi",
+      "models": "Modeļi"
     },
     "detection": {
-      "title": "Detection Settings",
-      "description": "Configure confidence thresholds and language for species classification.",
+      "title": "Noteikšanas iestatījumi",
+      "description": "Konfigurējiet ticamības sliekšņus un valodu sugu klasifikācijai.",
       "confidenceThreshold": {
         "label": "Confidence Threshold",
         "helpText": "Minimum confidence score (0.0 - 1.0) required for a detection to be recorded."
@@ -4540,97 +4540,97 @@
         "helpText": "Pieprasa vairākus apstiprinājumus sikspārņu noteikšanai slīdošajā logā pirms tā pieņemšanas. Augstāki līmeņi pieprasa vairāk apstiprinājumu, samazinot viltus pozitīvos. Sikspārņu modelis izmanto fiksētu 50% pārklāšanos, tāpēc pārklāšanās pielāgošana nav nepieciešama."
       },
       "locale": {
-        "label": "Species Language",
-        "helpText": "Language used for species common names in the interface."
+        "label": "Sugu valoda",
+        "helpText": "Valoda, kas tiek izmantota sugu nosaukumiem interfeisā."
       }
     },
     "rangeFilter": {
-      "birdOnlyNote": "Range filter applies to bird classifiers only. Bat models use their own species lists.",
+      "birdOnlyNote": "Areāla filtrs attiecas tikai uz putnu klasifikatoriem. Sikspārņu modeļi izmanto savus sugu sarakstus.",
       "status": {
         "title": "Diapazona filtra pārskats",
         "geomodelInfo": "BirdNET Geomodels {version} - {species} zināmas sugas",
-        "autoSelected": "Auto-selected",
-        "manual": "Manual",
-        "classifier": "Classifier",
-        "totalSpecies": "Total Species",
-        "withRangeData": "With Range Data",
-        "withoutRangeData": "Without Range Data",
-        "withRangeDataTooltip": "Species that the geomodel can evaluate for geographic probability at your location",
-        "withoutRangeDataTooltip": "Species without geographic data in the geomodel, handled by the unmapped species setting below",
-        "noFilter": "No range filter active",
+        "autoSelected": "Automātiski atlasīts",
+        "manual": "Manuāli",
+        "classifier": "Klasifikators",
+        "totalSpecies": "Kopējais sugu skaits",
+        "withRangeData": "Ar areāla datiem",
+        "withoutRangeData": "Bez areāla datiem",
+        "withRangeDataTooltip": "Sugas, kurām ģeomodelis var novērtēt ģeogrāfisko varbūtību jūsu atrašanās vietā",
+        "withoutRangeDataTooltip": "Sugas bez ģeogrāfiskajiem datiem ģeomodelī, kuras pārvalda nekartēto sugu iestatījums zemāk",
+        "noFilter": "Nav aktīva areāla filtra",
         "passUnmapped": {
-          "label": "Allow species without range data",
-          "helpText": "Allow detections of species the geomodel has no geographic data for. When disabled, these species are always filtered out."
+          "label": "Atļaut sugas bez areāla datiem",
+          "helpText": "Atļaut sugu noteikšanu, kurām ģeomodelim nav ģeogrāfisko datu. Ja atspējots, šīs sugas vienmēr tiek izfiltrētas."
         }
       }
     },
     "advanced": {
-      "title": "Advanced",
-      "description": "Processing and custom model configuration."
+      "title": "Papildu",
+      "description": "Apstrādes un pielāgotu modeļu konfigurācija."
     },
     "gallery": {
-      "title": "Model Gallery",
-      "description": "Manage classifier models for bird and bat detection.",
+      "title": "Modeļu galerija",
+      "description": "Pārvaldiet klasifikācijas modeļus putnu un sikspārņu noteikšanai.",
       "tabs": {
-        "installed": "Installed",
-        "available": "Available"
+        "installed": "Instalētie",
+        "available": "Pieejamie"
       },
-      "loading": "Loading models...",
-      "retry": "Retry",
-      "builtIn": "Built-in",
-      "builtInDescription": "Built-in bird species classifier by the BirdNET team.",
-      "species": "{count} species",
-      "install": "Install",
-      "installing": "Installing...",
-      "remove": "Remove",
-      "removing": "Removing...",
-      "noInstalledModels": "No additional models installed. Browse the Available tab to add more classifiers.",
-      "noAvailableModels": "No additional models available for your platform.",
+      "loading": "Ielādē modeļus...",
+      "retry": "Mēģināt vēlreiz",
+      "builtIn": "Iebūvēts",
+      "builtInDescription": "BirdNET komandas iebūvēts putnu sugu klasifikators.",
+      "species": "{count} sugas",
+      "install": "Instalēt",
+      "installing": "Instalē...",
+      "remove": "Noņemt",
+      "removing": "Noņem...",
+      "noInstalledModels": "Nav instalēti papildu modeļi. Pārlūkojiet cilni Pieejamie, lai pievienotu vairāk klasifikatoru.",
+      "noAvailableModels": "Jūsu platformai nav pieejami papildu modeļi.",
       "sections": {
         "acoustic": "Akustiskie klasifikatori",
         "geomodel": "Ģeomodeļi"
       },
       "categories": {
-        "wildlife": "Wildlife Classifiers",
-        "bird": "Bird Classifiers",
-        "bat": "Bat Classifiers"
+        "wildlife": "Savvaļas dzīvnieku klasifikatori",
+        "bird": "Putnu klasifikatori",
+        "bat": "Sikspārņu klasifikatori"
       },
       "progress": {
-        "downloading": "Downloading...",
-        "verifying": "Verifying...",
-        "loading": "Loading...",
-        "complete": "Installed successfully",
-        "failed": "Failed"
+        "downloading": "Lejupielādē...",
+        "verifying": "Pārbauda...",
+        "loading": "Ielādē...",
+        "complete": "Veiksmīgi instalēts",
+        "failed": "Neizdevās"
       },
       "license": {
-        "title": "License Agreement",
-        "model": "Model",
-        "author": "Author",
-        "license": "License",
-        "commercialUse": "Commercial Use",
-        "downloadSize": "Download Size",
-        "allowed": "Allowed",
-        "notAllowed": "Not allowed",
-        "commercialUseAllowed": "Commercial use allowed",
-        "nonCommercialOnly": "Non-commercial use only",
-        "nonCommercialWarning": "This model is licensed for non-commercial use only. By installing, you agree to comply with the license terms.",
-        "acceptAndInstall": "Accept & Install"
+        "title": "Licences līgums",
+        "model": "Modelis",
+        "author": "Autors",
+        "license": "Licence",
+        "commercialUse": "Komerciāla izmantošana",
+        "downloadSize": "Lejupielādes izmērs",
+        "allowed": "Atļauts",
+        "notAllowed": "Nav atļauts",
+        "commercialUseAllowed": "Komerciāla izmantošana atļauta",
+        "nonCommercialOnly": "Tikai nekomerciāla izmantošana",
+        "nonCommercialWarning": "Šis modelis ir licencēts tikai nekomerciālai izmantošanai. Instalējot jūs piekrītat licences noteikumiem.",
+        "acceptAndInstall": "Pieņemt un instalēt"
       },
       "removeDialog": {
-        "title": "Remove {name}?",
-        "confirmation": "This will remove the model files from disk. Label data is retained for existing detections."
+        "title": "Noņemt {name}?",
+        "confirmation": "Modeļa faili tiks noņemti no diska. Esošo noteikšanu etiķešu dati tiks saglabāti."
       },
       "errors": {
-        "catalogLoadFailed": "Failed to load model catalog",
-        "installFailed": "Failed to start model installation",
-        "removeFailed": "Failed to remove model"
+        "catalogLoadFailed": "Neizdevās ielādēt modeļu katalogu",
+        "installFailed": "Neizdevās sākt modeļa instalēšanu",
+        "removeFailed": "Neizdevās noņemt modeli"
       },
-      "regionLabel": "Region",
-      "speciesLabel": "Species",
-      "reinstall": "Reinstall",
-      "reinstalling": "Reinstalling...",
-      "reinstallComplete": "Files verified successfully",
-      "geomodelBadge": "Includes BirdNET v3.0 geomodel"
+      "regionLabel": "Reģions",
+      "speciesLabel": "Sugas",
+      "reinstall": "Pārinstalēt",
+      "reinstalling": "Pārinstalē...",
+      "reinstallComplete": "Faili veiksmīgi pārbaudīti",
+      "geomodelBadge": "Ietver BirdNET v3.0 ģeomodelis"
     }
   },
   "restart": {

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -4509,8 +4509,8 @@
   "analysis": {
     "title": "Analyse",
     "tabs": {
-      "settings": "Settings",
-      "models": "Models"
+      "settings": "Instellingen",
+      "models": "Modellen"
     },
     "detection": {
       "title": "Detectie-instellingen",
@@ -4540,12 +4540,12 @@
         "helpText": "Vereist meerdere bevestigingen van een vleermuisdetectie binnen een schuifvenster voordat deze wordt geaccepteerd. Hogere niveaus vereisen meer bevestigingen, waardoor valse positieven worden verminderd. Het vleermuismodel gebruikt een vaste overlap van 50%, dus er is geen overlapaanpassing nodig."
       },
       "locale": {
-        "label": "Species Language",
-        "helpText": "Language used for species common names in the interface."
+        "label": "Soortentaal",
+        "helpText": "Taal voor de gangbare soortnamen in de interface."
       }
     },
     "rangeFilter": {
-      "birdOnlyNote": "Range filter applies to bird classifiers only. Bat models use their own species lists.",
+      "birdOnlyNote": "Bereikfilter geldt alleen voor vogelclassificatoren. Vleermuismodellen gebruiken hun eigen soortenlijsten.",
       "status": {
         "title": "Gebiedsfilter overzicht",
         "geomodelInfo": "BirdNET Geomodel {version} - {species} bekende soorten",
@@ -4565,8 +4565,8 @@
       }
     },
     "advanced": {
-      "title": "Advanced",
-      "description": "Processing and custom model configuration."
+      "title": "Geavanceerd",
+      "description": "Verwerking en aangepaste modelconfiguratie."
     },
     "gallery": {
       "title": "Modellengalerij",

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -1351,7 +1351,7 @@
           "avgWait": "Średni czas oczekiwania",
           "busyTimeouts": "Limity czasu zajętości",
           "walSize": "Rozmiar WAL",
-          "checkpoints": "Punkty kontrolne",
+          "checkpoints": "Checkpoints",
           "freelistPages": "Strony wolnej listy",
           "cacheSize": "Rozmiar cache"
         },
@@ -1443,7 +1443,7 @@
       "samples": "próbek",
       "available": "dost.",
       "min": "Min",
-      "max": "Max",
+      "max": "Maks",
       "limit": "Limit",
       "tempUnavailable": "Niedostępna",
       "online": "Online",
@@ -2129,7 +2129,7 @@
         "summary": {
           "active": "aktywne",
           "builtIn": "wbudowane",
-          "total": "łącznie"
+          "total": "razem"
         }
       },
       "sections": {
@@ -4214,7 +4214,7 @@
         "extracting": "Wyodrębnianie klipu...",
         "extractError": "Nie udało się wyodrębnić klipu",
         "formatLabel": "Format",
-        "rangeLabel": "{start}s – {end}s"
+        "rangeLabel": "{start}s - {end}s"
       },
       "processing": {
         "playSelection": "Odtwórz zaznaczenie",
@@ -4509,8 +4509,8 @@
   "analysis": {
     "title": "Analiza",
     "tabs": {
-      "settings": "Settings",
-      "models": "Models"
+      "settings": "Ustawienia",
+      "models": "Modele"
     },
     "detection": {
       "title": "Ustawienia detekcji",
@@ -4540,12 +4540,12 @@
         "helpText": "Wymaga wielu potwierdzeń wykrycia nietoperza w przesuwnym oknie czasowym przed jego zaakceptowaniem. Wyższe poziomy wymagają więcej potwierdzeń, zmniejszając liczbę fałszywych wykryć. Model nietoperzy używa stałego 50% nakładania, więc nie jest wymagana regulacja nakładania."
       },
       "locale": {
-        "label": "Species Language",
-        "helpText": "Language used for species common names in the interface."
+        "label": "Język gatunków",
+        "helpText": "Język używany do nazw zwyczajowych gatunków w interfejsie."
       }
     },
     "rangeFilter": {
-      "birdOnlyNote": "Range filter applies to bird classifiers only. Bat models use their own species lists.",
+      "birdOnlyNote": "Filtr zasięgu dotyczy tylko klasyfikatorów ptaków. Modele nietoperzy używają własnych list gatunków.",
       "status": {
         "title": "Przegląd filtra zasięgu",
         "geomodelInfo": "BirdNET Geomodel {version} - {species} znanych gatunków",
@@ -4565,8 +4565,8 @@
       }
     },
     "advanced": {
-      "title": "Advanced",
-      "description": "Processing and custom model configuration."
+      "title": "Zaawansowane",
+      "description": "Konfiguracja przetwarzania i modeli niestandardowych."
     },
     "gallery": {
       "title": "Galeria modeli",

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -4214,7 +4214,7 @@
         "extracting": "A extrair clip...",
         "extractError": "Falha ao extrair clip",
         "formatLabel": "Formato",
-        "rangeLabel": "{start}s – {end}s"
+        "rangeLabel": "{start}s - {end}s"
       },
       "processing": {
         "playSelection": "Reproduzir seleção",
@@ -4509,8 +4509,8 @@
   "analysis": {
     "title": "Análise",
     "tabs": {
-      "settings": "Settings",
-      "models": "Models"
+      "settings": "Definições",
+      "models": "Modelos"
     },
     "detection": {
       "title": "Configurações de detecção",
@@ -4540,12 +4540,12 @@
         "helpText": "Requer múltiplas confirmações de uma deteção de morcego dentro de uma janela deslizante antes de a aceitar. Níveis mais altos requerem mais confirmações, reduzindo falsos positivos. O modelo de morcegos usa uma sobreposição fixa de 50%, portanto não é necessário ajuste de sobreposição."
       },
       "locale": {
-        "label": "Species Language",
-        "helpText": "Language used for species common names in the interface."
+        "label": "Idioma das espécies",
+        "helpText": "Idioma utilizado para os nomes comuns das espécies na interface."
       }
     },
     "rangeFilter": {
-      "birdOnlyNote": "Range filter applies to bird classifiers only. Bat models use their own species lists.",
+      "birdOnlyNote": "O filtro de alcance aplica-se apenas a classificadores de aves. Os modelos de morcegos usam as suas próprias listas de espécies.",
       "status": {
         "title": "Resumo do filtro de alcance",
         "geomodelInfo": "BirdNET Geomodelo {version} - {species} espécies conhecidas",
@@ -4565,8 +4565,8 @@
       }
     },
     "advanced": {
-      "title": "Advanced",
-      "description": "Processing and custom model configuration."
+      "title": "Avançado",
+      "description": "Configuração de processamento e modelos personalizados."
     },
     "gallery": {
       "title": "Galeria de modelos",

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -3357,7 +3357,7 @@
         "modeAutoTLSDescription": "Automatický certifikát cez Let's Encrypt",
         "modeManualDescription": "Nahrať vlastný certifikát a kľúč",
         "modeSelfSignedDescription": "Vygenerovať samopodpísaný certifikát",
-        "portLabel": "HTTPS Port",
+        "portLabel": "Port HTTPS",
         "portHelpText": "Port pre HTTPS pripojenia (predvolený: 8443)",
         "redirectToHttps": "Presmerovať HTTP na HTTPS",
         "autoTLSRequirements": "Vyžaduje dostupnosť portov 80 a 443. Na Linuxe proces potrebuje root alebo schopnosť CAP_NET_BIND_SERVICE.",
@@ -4238,7 +4238,7 @@
         "extracting": "Extrahovanie klipu...",
         "extractError": "Nepodarilo sa extrahovať klip",
         "formatLabel": "Formát",
-        "rangeLabel": "{start}s – {end}s"
+        "rangeLabel": "{start}s - {end}s"
       },
       "processing": {
         "playSelection": "Prehrať výber",
@@ -4509,12 +4509,12 @@
   "analysis": {
     "title": "Analýza",
     "tabs": {
-      "settings": "Settings",
-      "models": "Models"
+      "settings": "Nastavenia",
+      "models": "Modely"
     },
     "detection": {
-      "title": "Detection Settings",
-      "description": "Configure confidence thresholds and language for species classification.",
+      "title": "Nastavenia detekcie",
+      "description": "Nastavte prahové hodnoty spoľahlivosti a jazyk klasifikácie druhov.",
       "confidenceThreshold": {
         "label": "Confidence Threshold",
         "helpText": "Minimum confidence score (0.0 - 1.0) required for a detection to be recorded."
@@ -4540,97 +4540,97 @@
         "helpText": "Vyžaduje viacero potvrdení detekcie netopiera v posuvnom okne pred jej prijatím. Vyššie úrovne vyžadujú viac potvrdení, čím sa znižujú falošné pozitíva. Model netopierov používa pevné 50% prekrývanie, takže úprava prekrývania nie je potrebná."
       },
       "locale": {
-        "label": "Species Language",
-        "helpText": "Language used for species common names in the interface."
+        "label": "Jazyk druhov",
+        "helpText": "Jazyk používaný pre bežné názvy druhov v rozhraní."
       }
     },
     "rangeFilter": {
-      "birdOnlyNote": "Range filter applies to bird classifiers only. Bat models use their own species lists.",
+      "birdOnlyNote": "Filter rozsahu sa vzťahuje len na klasifikátory vtákov. Modely netopierov používajú vlastné zoznamy druhov.",
       "status": {
         "title": "Prehľad filtra rozsahu",
         "geomodelInfo": "BirdNET Geomodel {version} - {species} známych druhov",
-        "autoSelected": "Auto-selected",
-        "manual": "Manual",
-        "classifier": "Classifier",
-        "totalSpecies": "Total Species",
-        "withRangeData": "With Range Data",
-        "withoutRangeData": "Without Range Data",
-        "withRangeDataTooltip": "Species that the geomodel can evaluate for geographic probability at your location",
-        "withoutRangeDataTooltip": "Species without geographic data in the geomodel, handled by the unmapped species setting below",
-        "noFilter": "No range filter active",
+        "autoSelected": "Automaticky vybrané",
+        "manual": "Manuálne",
+        "classifier": "Klasifikátor",
+        "totalSpecies": "Celkový počet druhov",
+        "withRangeData": "S údajmi o rozsahu",
+        "withoutRangeData": "Bez údajov o rozsahu",
+        "withRangeDataTooltip": "Druhy, pre ktoré geomodel môže vyhodnotiť geografickú pravdepodobnosť na vašej polohe",
+        "withoutRangeDataTooltip": "Druhy bez geografických údajov v geomodeli, spravované nastavením nemapovaných druhov nižšie",
+        "noFilter": "Žiadny aktívny filter rozsahu",
         "passUnmapped": {
-          "label": "Allow species without range data",
-          "helpText": "Allow detections of species the geomodel has no geographic data for. When disabled, these species are always filtered out."
+          "label": "Povoliť druhy bez údajov o rozsahu",
+          "helpText": "Povoliť detekcie druhov, pre ktoré geomodel nemá geografické údaje. Ak je vypnuté, tieto druhy sa vždy odfiltrujú."
         }
       }
     },
     "advanced": {
-      "title": "Advanced",
-      "description": "Processing and custom model configuration."
+      "title": "Pokročilé",
+      "description": "Konfigurácia spracovania a vlastných modelov."
     },
     "gallery": {
-      "title": "Model Gallery",
-      "description": "Manage classifier models for bird and bat detection.",
+      "title": "Galéria modelov",
+      "description": "Správa klasifikačných modelov pre detekciu vtákov a netopierov.",
       "tabs": {
-        "installed": "Installed",
-        "available": "Available"
+        "installed": "Nainštalované",
+        "available": "Dostupné"
       },
-      "loading": "Loading models...",
-      "retry": "Retry",
-      "builtIn": "Built-in",
-      "builtInDescription": "Built-in bird species classifier by the BirdNET team.",
-      "species": "{count} species",
-      "install": "Install",
-      "installing": "Installing...",
-      "remove": "Remove",
-      "removing": "Removing...",
-      "noInstalledModels": "No additional models installed. Browse the Available tab to add more classifiers.",
-      "noAvailableModels": "No additional models available for your platform.",
+      "loading": "Načítavajú sa modely...",
+      "retry": "Skúsiť znova",
+      "builtIn": "Vstavaný",
+      "builtInDescription": "Vstavaný klasifikátor vtáčích druhov od tímu BirdNET.",
+      "species": "{count} druhov",
+      "install": "Inštalovať",
+      "installing": "Inštaluje sa...",
+      "remove": "Odstrániť",
+      "removing": "Odstraňovanie...",
+      "noInstalledModels": "Žiadne ďalšie modely nie sú nainštalované. Prejdite na kartu Dostupné a pridajte ďalšie klasifikátory.",
+      "noAvailableModels": "Pre vašu platformu nie sú k dispozícii žiadne ďalšie modely.",
       "sections": {
         "acoustic": "Akustické klasifikátory",
         "geomodel": "Geomodely"
       },
       "categories": {
-        "wildlife": "Wildlife Classifiers",
-        "bird": "Bird Classifiers",
-        "bat": "Bat Classifiers"
+        "wildlife": "Klasifikátory voľne žijúcich živočíchov",
+        "bird": "Klasifikátory vtákov",
+        "bat": "Klasifikátory netopierov"
       },
       "progress": {
-        "downloading": "Downloading...",
-        "verifying": "Verifying...",
-        "loading": "Loading...",
-        "complete": "Installed successfully",
-        "failed": "Failed"
+        "downloading": "Sťahovanie...",
+        "verifying": "Overovanie...",
+        "loading": "Načítava sa...",
+        "complete": "Úspešne nainštalované",
+        "failed": "Zlyhanie"
       },
       "license": {
-        "title": "License Agreement",
+        "title": "Licenčná zmluva",
         "model": "Model",
-        "author": "Author",
-        "license": "License",
-        "commercialUse": "Commercial Use",
-        "downloadSize": "Download Size",
-        "allowed": "Allowed",
-        "notAllowed": "Not allowed",
-        "commercialUseAllowed": "Commercial use allowed",
-        "nonCommercialOnly": "Non-commercial use only",
-        "nonCommercialWarning": "This model is licensed for non-commercial use only. By installing, you agree to comply with the license terms.",
-        "acceptAndInstall": "Accept & Install"
+        "author": "Autor",
+        "license": "Licencia",
+        "commercialUse": "Komerčné využitie",
+        "downloadSize": "Veľkosť na stiahnutie",
+        "allowed": "Povolené",
+        "notAllowed": "Nepovolené",
+        "commercialUseAllowed": "Komerčné využitie povolené",
+        "nonCommercialOnly": "Len nekomerčné využitie",
+        "nonCommercialWarning": "Tento model je licencovaný len na nekomerčné použitie. Inštaláciou súhlasíte s licenčnými podmienkami.",
+        "acceptAndInstall": "Prijať a inštalovať"
       },
       "removeDialog": {
-        "title": "Remove {name}?",
-        "confirmation": "This will remove the model files from disk. Label data is retained for existing detections."
+        "title": "Odstrániť {name}?",
+        "confirmation": "Tým sa odstránia súbory modelu z disku. Údaje štítkov pre existujúce detekcie sa zachovajú."
       },
       "errors": {
-        "catalogLoadFailed": "Failed to load model catalog",
-        "installFailed": "Failed to start model installation",
-        "removeFailed": "Failed to remove model"
+        "catalogLoadFailed": "Nepodarilo sa načítať katalóg modelov",
+        "installFailed": "Nepodarilo sa spustiť inštaláciu modelu",
+        "removeFailed": "Nepodarilo sa odstrániť model"
       },
-      "regionLabel": "Region",
-      "speciesLabel": "Species",
-      "reinstall": "Reinstall",
-      "reinstalling": "Reinstalling...",
-      "reinstallComplete": "Files verified successfully",
-      "geomodelBadge": "Includes BirdNET v3.0 geomodel"
+      "regionLabel": "Región",
+      "speciesLabel": "Druhy",
+      "reinstall": "Preinštalovať",
+      "reinstalling": "Preinštalovanie...",
+      "reinstallComplete": "Súbory úspešne overené",
+      "geomodelBadge": "Obsahuje BirdNET v3.0 geomodel"
     }
   },
   "restart": {

--- a/frontend/static/messages/sv.json
+++ b/frontend/static/messages/sv.json
@@ -4570,7 +4570,7 @@
     },
     "gallery": {
       "title": "Modellgalleri",
-      "description": "Hantera klassificeringsmodeller för fågel- och fladdermsdetektion.",
+      "description": "Hantera klassificeringsmodeller för fågel- och fladdermusdetektion.",
       "tabs": {
         "installed": "Installerade",
         "available": "Tillgängliga"

--- a/frontend/static/messages/sv.json
+++ b/frontend/static/messages/sv.json
@@ -4509,12 +4509,12 @@
   "analysis": {
     "title": "Analys",
     "tabs": {
-      "settings": "Settings",
-      "models": "Models"
+      "settings": "Inställningar",
+      "models": "Modeller"
     },
     "detection": {
-      "title": "Detection Settings",
-      "description": "Configure confidence thresholds and language for species classification.",
+      "title": "Detektionsinställningar",
+      "description": "Konfigurera konfidenströsklar och språk för artklassificering.",
       "confidenceThreshold": {
         "label": "Confidence Threshold",
         "helpText": "Minimum confidence score (0.0 - 1.0) required for a detection to be recorded."
@@ -4540,97 +4540,97 @@
         "helpText": "Kräver flera bekräftelser av en fladdermusdetektion inom ett glidande fönster innan den accepteras. Högre nivåer kräver fler bekräftelser, vilket minskar falska positiva. Fladdermusmodellen använder en fast 50% överlappning, så ingen överlappningsjustering behövs."
       },
       "locale": {
-        "label": "Species Language",
-        "helpText": "Language used for species common names in the interface."
+        "label": "Artspråk",
+        "helpText": "Språk som används för arternas vardagliga namn i gränssnittet."
       }
     },
     "rangeFilter": {
-      "birdOnlyNote": "Range filter applies to bird classifiers only. Bat models use their own species lists.",
+      "birdOnlyNote": "Områdesfilter gäller bara fågelklassificerare. Fladdermusmodeller använder egna artlistor.",
       "status": {
         "title": "Områdesfilter översikt",
         "geomodelInfo": "BirdNET Geomodell {version} - {species} kända arter",
-        "autoSelected": "Auto-selected",
-        "manual": "Manual",
-        "classifier": "Classifier",
-        "totalSpecies": "Total Species",
-        "withRangeData": "With Range Data",
-        "withoutRangeData": "Without Range Data",
-        "withRangeDataTooltip": "Species that the geomodel can evaluate for geographic probability at your location",
-        "withoutRangeDataTooltip": "Species without geographic data in the geomodel, handled by the unmapped species setting below",
-        "noFilter": "No range filter active",
+        "autoSelected": "Automatiskt vald",
+        "manual": "Manuell",
+        "classifier": "Klassificerare",
+        "totalSpecies": "Totalt antal arter",
+        "withRangeData": "Med områdesdata",
+        "withoutRangeData": "Utan områdesdata",
+        "withRangeDataTooltip": "Arter som geomodellen kan utvärdera för geografisk sannolikhet vid din plats",
+        "withoutRangeDataTooltip": "Arter utan geografiska data i geomodellen, hanteras av inställningen för ej kartlagda arter nedan",
+        "noFilter": "Inget områdesfilter aktivt",
         "passUnmapped": {
-          "label": "Allow species without range data",
-          "helpText": "Allow detections of species the geomodel has no geographic data for. When disabled, these species are always filtered out."
+          "label": "Tillåt arter utan områdesdata",
+          "helpText": "Tillåt detektioner av arter som geomodellen saknar geografiska data för. När inaktiverad filtreras dessa arter alltid bort."
         }
       }
     },
     "advanced": {
-      "title": "Advanced",
-      "description": "Processing and custom model configuration."
+      "title": "Avancerat",
+      "description": "Bearbetning och anpassad modellkonfiguration."
     },
     "gallery": {
-      "title": "Model Gallery",
-      "description": "Manage classifier models for bird and bat detection.",
+      "title": "Modellgalleri",
+      "description": "Hantera klassificeringsmodeller för fågel- och fladdermsdetektion.",
       "tabs": {
-        "installed": "Installed",
-        "available": "Available"
+        "installed": "Installerade",
+        "available": "Tillgängliga"
       },
-      "loading": "Loading models...",
-      "retry": "Retry",
-      "builtIn": "Built-in",
-      "builtInDescription": "Built-in bird species classifier by the BirdNET team.",
-      "species": "{count} species",
-      "install": "Install",
-      "installing": "Installing...",
-      "remove": "Remove",
-      "removing": "Removing...",
-      "noInstalledModels": "No additional models installed. Browse the Available tab to add more classifiers.",
-      "noAvailableModels": "No additional models available for your platform.",
+      "loading": "Laddar modeller...",
+      "retry": "Försök igen",
+      "builtIn": "Inbyggd",
+      "builtInDescription": "Inbyggd fågelartsklassificerare från BirdNET-teamet.",
+      "species": "{count} arter",
+      "install": "Installera",
+      "installing": "Installerar...",
+      "remove": "Ta bort",
+      "removing": "Tar bort...",
+      "noInstalledModels": "Inga ytterligare modeller installerade. Bläddra i fliken Tillgängliga för att lägga till fler klassificerare.",
+      "noAvailableModels": "Inga ytterligare modeller tillgängliga för din plattform.",
       "sections": {
         "acoustic": "Akustiska klassificerare",
         "geomodel": "Geomodeller"
       },
       "categories": {
-        "wildlife": "Wildlife Classifiers",
-        "bird": "Bird Classifiers",
-        "bat": "Bat Classifiers"
+        "wildlife": "Viltklassificerare",
+        "bird": "Fågelklassificerare",
+        "bat": "Fladdermusklassificerare"
       },
       "progress": {
-        "downloading": "Downloading...",
-        "verifying": "Verifying...",
-        "loading": "Loading...",
-        "complete": "Installed successfully",
-        "failed": "Failed"
+        "downloading": "Laddar ner...",
+        "verifying": "Verifierar...",
+        "loading": "Laddar...",
+        "complete": "Installerad",
+        "failed": "Misslyckades"
       },
       "license": {
-        "title": "License Agreement",
-        "model": "Model",
-        "author": "Author",
-        "license": "License",
-        "commercialUse": "Commercial Use",
-        "downloadSize": "Download Size",
-        "allowed": "Allowed",
-        "notAllowed": "Not allowed",
-        "commercialUseAllowed": "Commercial use allowed",
-        "nonCommercialOnly": "Non-commercial use only",
-        "nonCommercialWarning": "This model is licensed for non-commercial use only. By installing, you agree to comply with the license terms.",
-        "acceptAndInstall": "Accept & Install"
+        "title": "Licensavtal",
+        "model": "Modell",
+        "author": "Upphovsperson",
+        "license": "Licens",
+        "commercialUse": "Kommersiellt bruk",
+        "downloadSize": "Nedladdningsstorlek",
+        "allowed": "Tillåtet",
+        "notAllowed": "Ej tillåtet",
+        "commercialUseAllowed": "Kommersiellt bruk tillåtet",
+        "nonCommercialOnly": "Endast icke-kommersiellt bruk",
+        "nonCommercialWarning": "Denna modell är licensierad enbart för icke-kommersiellt bruk. Genom att installera godkänner du att följa licensvillkoren.",
+        "acceptAndInstall": "Acceptera och installera"
       },
       "removeDialog": {
-        "title": "Remove {name}?",
-        "confirmation": "This will remove the model files from disk. Label data is retained for existing detections."
+        "title": "Ta bort {name}?",
+        "confirmation": "Detta tar bort modellfilerna från disken. Etikettdata behålls för befintliga detektioner."
       },
       "errors": {
-        "catalogLoadFailed": "Failed to load model catalog",
-        "installFailed": "Failed to start model installation",
-        "removeFailed": "Failed to remove model"
+        "catalogLoadFailed": "Kunde inte ladda modellkatalogen",
+        "installFailed": "Kunde inte starta modellinstallation",
+        "removeFailed": "Kunde inte ta bort modell"
       },
       "regionLabel": "Region",
-      "speciesLabel": "Species",
-      "reinstall": "Reinstall",
-      "reinstalling": "Reinstalling...",
-      "reinstallComplete": "Files verified successfully",
-      "geomodelBadge": "Includes BirdNET v3.0 geomodel"
+      "speciesLabel": "Arter",
+      "reinstall": "Installera om",
+      "reinstalling": "Installerar om...",
+      "reinstallComplete": "Filer verifierade",
+      "geomodelBadge": "Inkluderar BirdNET v3.0 geomodell"
     }
   },
   "restart": {


### PR DESCRIPTION
## Summary

- Translate 491 English fallback values to native translations across all 13 non-English locales (da, de, es, fi, fr, hu, it, lv, nl, pl, pt, sk, sv)
- Covers single words, short phrases, parameterized strings, and longer descriptions
- Technical terms (HTTP, RTSP, TLS, RAM, hPa, etc.) preserved untranslated
- Brand names (BirdNET-Go, Google Perch v2, Let's Encrypt) preserved
- All ICU MessageFormat parameters preserved correctly

Before: 1205 untranslated instances
After: 714 remaining (all legitimate technical terms, brand names, and universal abbreviations)

## Test Plan

- [x] `npm run i18n:sync:check` passes (all files in sync)
- [x] `npm run i18n:validate` passes (zero errors: no missing keys, empty values, invalid ICU, or parameter mismatches)
- [x] All 14 JSON files valid
- [x] Spot-checked technical terms preserved (RAM, TLS/HTTPS across DA, FR, FI, DE)
- [x] Spot-checked context-sensitive translations (Database, Bat Classifiers across DA, FR, FI)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Localization**
  * Updated UI translations across 13 languages (da, de, es, fi, fr, hu, it, lv, nl, pl, pt, sk, sv).
  * Localized Analysis section: Settings/Models tabs, Detection headings, Range Filter locale/help and status texts, Advanced section, and full Model Gallery copy (labels, progress, license/remove dialogs, errors, geomodel badge).
  * Standardized audio clip range labels (en‑dash → hyphen) and other UI wording fixes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3096)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->