### PR TITLE
fix(classifier): make PassUnmappedSpecies effective for species inclusion

### DIFF
--- a/internal/classifier/range_filter.go
+++ b/internal/classifier/range_filter.go
@@ -69,12 +69,16 @@ func BuildRangeFilter(o *Orchestrator) error {
 		// Sync unmappedScore with the current PassUnmappedSpecies setting so
 		// that the legacy predictFilter path (which calls Predict()) sees the
 		// correct value without requiring a full ReloadRangeFilter.
+		// Also capture the pre-computed classifier-to-geomodel mapping to
+		// avoid rebuilding it after the lock is released.
+		var cachedMapping []int
 		if mrf, ok := rf.(*mappedRangeFilter); ok {
 			var score float32
 			if settings.BirdNET.RangeFilter.PassUnmappedSpecies {
 				score = 1.0
 			}
 			mrf.unmappedScore = score
+			cachedMapping = mrf.classifierToGeo
 		}
 		o.primary.mu.Unlock()
 
@@ -106,7 +110,10 @@ func BuildRangeFilter(o *Orchestrator) error {
 			for _, s := range includedSpecies {
 				seen[s] = true
 			}
-			mapping := buildSpeciesMapping(settings.BirdNET.Labels, allGeoLabels)
+			mapping := cachedMapping
+			if mapping == nil {
+				mapping = buildSpeciesMapping(settings.BirdNET.Labels, allGeoLabels)
+			}
 			for i, geoIdx := range mapping {
 				if geoIdx == -1 {
 					label := settings.BirdNET.Labels[i]
@@ -300,6 +307,10 @@ func (bn *BirdNET) getProbableSpecies(date time.Time, week float32, settings *co
 	up, isUniversal := bn.rangeFilter.(UniversalSpeciesPredictor)
 	if isUniversal {
 		allGeoLabels := up.GeomodelLabels()
+		var cachedMapping []int
+		if mrf, ok := bn.rangeFilter.(*mappedRangeFilter); ok {
+			cachedMapping = mrf.classifierToGeo
+		}
 		scores, err := up.PredictSpeciesScores(
 			float32(settings.BirdNET.Latitude),
 			float32(settings.BirdNET.Longitude),
@@ -331,7 +342,10 @@ func (bn *BirdNET) getProbableSpecies(date time.Time, week float32, settings *co
 			for _, ss := range speciesScores {
 				seen[ss.Label] = true
 			}
-			mapping := buildSpeciesMapping(settings.BirdNET.Labels, allGeoLabels)
+			mapping := cachedMapping
+			if mapping == nil {
+				mapping = buildSpeciesMapping(settings.BirdNET.Labels, allGeoLabels)
+			}
 			for i, geoIdx := range mapping {
 				if geoIdx == -1 {
 					label := settings.BirdNET.Labels[i]

--- a/internal/classifier/range_filter.go
+++ b/internal/classifier/range_filter.go
@@ -65,12 +65,24 @@ func BuildRangeFilter(o *Orchestrator) error {
 			getWeekForFilter(today),
 			threshold,
 		)
+		if err != nil {
+			o.primary.mu.Unlock()
+			return errors.New(err).
+				Category(errors.CategoryValidation).
+				Context("date", today.Format(time.DateOnly)).
+				Context("latitude", settings.BirdNET.Latitude).
+				Context("longitude", settings.BirdNET.Longitude).
+				Timing("range-filter-build", time.Since(start)).
+				Build()
+		}
 
 		// Sync unmappedScore with the current PassUnmappedSpecies setting so
 		// that the legacy predictFilter path (which calls Predict()) sees the
 		// correct value without requiring a full ReloadRangeFilter.
 		// Also capture the pre-computed classifier-to-geomodel mapping to
 		// avoid rebuilding it after the lock is released.
+		// Done after the error check so that a failed prediction does not
+		// leave unmappedScore inconsistent with the inclusion list.
 		var cachedMapping []int
 		if mrf, ok := rf.(*mappedRangeFilter); ok {
 			var score float32
@@ -81,16 +93,6 @@ func BuildRangeFilter(o *Orchestrator) error {
 			cachedMapping = mrf.classifierToGeo
 		}
 		o.primary.mu.Unlock()
-
-		if err != nil {
-			return errors.New(err).
-				Category(errors.CategoryValidation).
-				Context("date", today.Format(time.DateOnly)).
-				Context("latitude", settings.BirdNET.Latitude).
-				Context("longitude", settings.BirdNET.Longitude).
-				Timing("range-filter-build", time.Since(start)).
-				Build()
-		}
 
 		includedSpecies = make([]string, 0, len(scores))
 		for _, ss := range scores {

--- a/internal/classifier/range_filter.go
+++ b/internal/classifier/range_filter.go
@@ -65,6 +65,17 @@ func BuildRangeFilter(o *Orchestrator) error {
 			getWeekForFilter(today),
 			threshold,
 		)
+
+		// Sync unmappedScore with the current PassUnmappedSpecies setting so
+		// that the legacy predictFilter path (which calls Predict()) sees the
+		// correct value without requiring a full ReloadRangeFilter.
+		if mrf, ok := rf.(*mappedRangeFilter); ok {
+			var score float32
+			if settings.BirdNET.RangeFilter.PassUnmappedSpecies {
+				score = 1.0
+			}
+			mrf.unmappedScore = score
+		}
 		o.primary.mu.Unlock()
 
 		if err != nil {
@@ -86,9 +97,32 @@ func BuildRangeFilter(o *Orchestrator) error {
 
 		addUserOverrideSpecies(&includedSpecies, settings, allGeoLabels)
 
+		// When PassUnmappedSpecies is enabled, add classifier species that
+		// have no corresponding entry in the geomodel so they are not
+		// silently blocked by the species inclusion check in the processor.
+		var unmappedCount int
+		if settings.BirdNET.RangeFilter.PassUnmappedSpecies {
+			seen := make(map[string]bool, len(includedSpecies))
+			for _, s := range includedSpecies {
+				seen[s] = true
+			}
+			mapping := buildSpeciesMapping(settings.BirdNET.Labels, allGeoLabels)
+			for i, geoIdx := range mapping {
+				if geoIdx == -1 {
+					label := settings.BirdNET.Labels[i]
+					if !seen[label] && !isSpeciesExcluded(label, settings.Realtime.Species.Exclude) {
+						includedSpecies = append(includedSpecies, label)
+						seen[label] = true
+						unmappedCount++
+					}
+				}
+			}
+		}
+
 		GetLogger().Info("Range filter updated via universal geomodel path",
 			logger.Int("geomodel_species", len(scores)),
 			logger.Int("included_species", len(includedSpecies)),
+			logger.Int("unmapped_species_added", unmappedCount),
 			logger.Float64("threshold", float64(threshold)),
 			logger.String("duration", time.Since(start).String()))
 	} else {
@@ -291,6 +325,24 @@ func (bn *BirdNET) getProbableSpecies(date time.Time, week float32, settings *co
 		}
 
 		addUserOverrideSpeciesScores(bn, &speciesScores, settings, allGeoLabels)
+
+		if settings.BirdNET.RangeFilter.PassUnmappedSpecies {
+			seen := make(map[string]bool, len(speciesScores))
+			for _, ss := range speciesScores {
+				seen[ss.Label] = true
+			}
+			mapping := buildSpeciesMapping(settings.BirdNET.Labels, allGeoLabels)
+			for i, geoIdx := range mapping {
+				if geoIdx == -1 {
+					label := settings.BirdNET.Labels[i]
+					if !seen[label] && !isSpeciesExcluded(label, settings.Realtime.Species.Exclude) {
+						speciesScores = append(speciesScores, SpeciesScore{Score: 0.0, Label: label})
+						seen[label] = true
+					}
+				}
+			}
+		}
+
 		sort.Sort(ByScore(speciesScores))
 		return speciesScores, nil
 	}

--- a/internal/classifier/range_filter_test.go
+++ b/internal/classifier/range_filter_test.go
@@ -1,0 +1,347 @@
+package classifier
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/conf"
+)
+
+// fakeUniversalRangeFilter implements inference.RangeFilter and
+// UniversalSpeciesPredictor for testing BuildRangeFilter.
+type fakeUniversalRangeFilter struct {
+	geoLabels []string
+	scores    []SpeciesScore
+	rawScores []float32
+	err       error
+}
+
+func (f *fakeUniversalRangeFilter) Predict(_, _, _ float32) ([]float32, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	out := make([]float32, len(f.rawScores))
+	copy(out, f.rawScores)
+	return out, nil
+}
+
+func (f *fakeUniversalRangeFilter) NumSpecies() int { return len(f.rawScores) }
+func (f *fakeUniversalRangeFilter) Close()          {}
+
+func (f *fakeUniversalRangeFilter) PredictSpeciesScores(_, _, _, _ float32) ([]SpeciesScore, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	out := make([]SpeciesScore, len(f.scores))
+	copy(out, f.scores)
+	return out, nil
+}
+
+func (f *fakeUniversalRangeFilter) GeomodelLabels() []string {
+	return f.geoLabels
+}
+
+// buildTestOrchestrator creates a minimal Orchestrator with the given range
+// filter and settings suitable for testing BuildRangeFilter.
+func buildTestOrchestrator(t *testing.T, settings *conf.Settings, rf interface{ Close() }) *Orchestrator {
+	t.Helper()
+	bn := &BirdNET{
+		Settings:     settings,
+		speciesCache: make(map[string]*speciesCacheEntry),
+	}
+	if irf, ok := rf.(interface {
+		Predict(float32, float32, float32) ([]float32, error)
+		NumSpecies() int
+		Close()
+	}); ok {
+		bn.rangeFilter = irf
+	}
+	return &Orchestrator{
+		Settings: settings,
+		primary:  bn,
+	}
+}
+
+func TestBuildRangeFilter_PassUnmappedSpecies(t *testing.T) {
+	geoLabels := []string{
+		"Turdus merula_Common Blackbird",
+		"Parus major_Great Tit",
+		"Corvus corax_Northern Raven",
+	}
+
+	classifierLabels := []string{
+		"Turdus merula_Common Blackbird",
+		"Parus major_Great Tit",
+		"Ficedula hypoleuca_Pied Flycatcher", // not in geomodel
+		"Regulus regulus_Goldcrest",          // not in geomodel
+	}
+
+	geoScores := []SpeciesScore{
+		{Score: 0.9, Label: "Turdus merula_Common Blackbird"},
+		{Score: 0.8, Label: "Parus major_Great Tit"},
+	}
+
+	tests := []struct {
+		name              string
+		passUnmapped      bool
+		wantMinSpecies    int
+		wantUnmappedInSet []string
+	}{
+		{
+			name:           "disabled: only geomodel species included",
+			passUnmapped:   false,
+			wantMinSpecies: 2,
+		},
+		{
+			name:           "enabled: unmapped classifier species added",
+			passUnmapped:   true,
+			wantMinSpecies: 4,
+			wantUnmappedInSet: []string{
+				"Ficedula hypoleuca_Pied Flycatcher",
+				"Regulus regulus_Goldcrest",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			settings := conf.GetTestSettings()
+			settings.BirdNET.Latitude = 60.0
+			settings.BirdNET.Longitude = 25.0
+			settings.BirdNET.LocationConfigured = true
+			settings.BirdNET.RangeFilter.Threshold = 0.01
+			settings.BirdNET.RangeFilter.PassUnmappedSpecies = tt.passUnmapped
+			settings.BirdNET.Labels = classifierLabels
+			conf.SetTestSettings(settings)
+			t.Cleanup(func() { conf.SetTestSettings(nil) })
+
+			rf := &fakeUniversalRangeFilter{
+				geoLabels: geoLabels,
+				scores:    geoScores,
+				rawScores: []float32{0.9, 0.8, 0.3},
+			}
+
+			o := buildTestOrchestrator(t, settings, rf)
+			err := BuildRangeFilter(o)
+			require.NoError(t, err)
+
+			included := conf.GetSettings().GetIncludedSpecies()
+			assert.GreaterOrEqual(t, len(included), tt.wantMinSpecies,
+				"included species count should be at least %d", tt.wantMinSpecies)
+
+			for _, want := range tt.wantUnmappedInSet {
+				assert.Contains(t, included, want,
+					"unmapped species %q should be in included set", want)
+			}
+		})
+	}
+}
+
+func TestBuildRangeFilter_PassUnmappedSpecies_RespectsExcludeList(t *testing.T) {
+	geoLabels := []string{
+		"Turdus merula_Common Blackbird",
+	}
+	classifierLabels := []string{
+		"Turdus merula_Common Blackbird",
+		"Ficedula hypoleuca_Pied Flycatcher", // unmapped
+		"Regulus regulus_Goldcrest",          // unmapped, excluded
+	}
+	geoScores := []SpeciesScore{
+		{Score: 0.9, Label: "Turdus merula_Common Blackbird"},
+	}
+
+	settings := conf.GetTestSettings()
+	settings.BirdNET.Latitude = 60.0
+	settings.BirdNET.Longitude = 25.0
+	settings.BirdNET.LocationConfigured = true
+	settings.BirdNET.RangeFilter.Threshold = 0.01
+	settings.BirdNET.RangeFilter.PassUnmappedSpecies = true
+	settings.BirdNET.Labels = classifierLabels
+	settings.Realtime.Species.Exclude = []string{"Goldcrest"}
+	conf.SetTestSettings(settings)
+	t.Cleanup(func() { conf.SetTestSettings(nil) })
+
+	rf := &fakeUniversalRangeFilter{
+		geoLabels: geoLabels,
+		scores:    geoScores,
+		rawScores: []float32{0.9},
+	}
+
+	o := buildTestOrchestrator(t, settings, rf)
+	err := BuildRangeFilter(o)
+	require.NoError(t, err)
+
+	included := conf.GetSettings().GetIncludedSpecies()
+	assert.Contains(t, included, "Ficedula hypoleuca_Pied Flycatcher",
+		"unmapped, non-excluded species should be included")
+	assert.NotContains(t, included, "Regulus regulus_Goldcrest",
+		"unmapped but excluded species should not be included")
+}
+
+func TestBuildRangeFilter_UpdatesUnmappedScore(t *testing.T) {
+	geoLabels := []string{
+		"Turdus merula_Common Blackbird",
+		"Parus major_Great Tit",
+	}
+	classifierLabels := []string{
+		"Turdus merula_Common Blackbird",
+		"Ficedula hypoleuca_Pied Flycatcher",
+	}
+
+	inner := &fakeRangeFilter{
+		scores: []float32{0.9, 0.8},
+	}
+	mrf := newMappedRangeFilter(inner, classifierLabels, geoLabels, 0.0)
+	require.InDelta(t, 0.0, float64(mrf.unmappedScore), 0.001,
+		"initial unmappedScore should be 0.0")
+
+	settings := conf.GetTestSettings()
+	settings.BirdNET.Latitude = 60.0
+	settings.BirdNET.Longitude = 25.0
+	settings.BirdNET.LocationConfigured = true
+	settings.BirdNET.RangeFilter.Threshold = 0.01
+	settings.BirdNET.RangeFilter.PassUnmappedSpecies = true
+	settings.BirdNET.Labels = classifierLabels
+	conf.SetTestSettings(settings)
+	t.Cleanup(func() { conf.SetTestSettings(nil) })
+
+	bn := &BirdNET{
+		Settings:     settings,
+		rangeFilter:  mrf,
+		speciesCache: make(map[string]*speciesCacheEntry),
+	}
+	o := &Orchestrator{
+		Settings: settings,
+		primary:  bn,
+	}
+
+	err := BuildRangeFilter(o)
+	require.NoError(t, err)
+	assert.InDelta(t, 1.0, float64(mrf.unmappedScore), 0.001,
+		"unmappedScore should be 1.0 after rebuild with PassUnmappedSpecies=true")
+
+	// Toggle off and rebuild
+	settings2 := conf.CloneSettings(settings)
+	settings2.BirdNET.RangeFilter.PassUnmappedSpecies = false
+	conf.SetTestSettings(settings2)
+
+	err = BuildRangeFilter(o)
+	require.NoError(t, err)
+	assert.InDelta(t, 0.0, float64(mrf.unmappedScore), 0.001,
+		"unmappedScore should be 0.0 after rebuild with PassUnmappedSpecies=false")
+}
+
+func TestGetProbableSpecies_PassUnmappedSpecies(t *testing.T) {
+	geoLabels := []string{
+		"Turdus merula_Common Blackbird",
+		"Parus major_Great Tit",
+	}
+	classifierLabels := []string{
+		"Turdus merula_Common Blackbird",
+		"Parus major_Great Tit",
+		"Ficedula hypoleuca_Pied Flycatcher",
+	}
+
+	tests := []struct {
+		name           string
+		passUnmapped   bool
+		wantUnmappedIn bool
+		wantMinSpecies int
+	}{
+		{
+			name:           "disabled: only geomodel species returned",
+			passUnmapped:   false,
+			wantUnmappedIn: false,
+			wantMinSpecies: 2,
+		},
+		{
+			name:           "enabled: unmapped classifier species included with score 0",
+			passUnmapped:   true,
+			wantUnmappedIn: true,
+			wantMinSpecies: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			settings := conf.GetTestSettings()
+			settings.BirdNET.Latitude = 60.0
+			settings.BirdNET.Longitude = 25.0
+			settings.BirdNET.LocationConfigured = true
+			settings.BirdNET.RangeFilter.Threshold = 0.01
+			settings.BirdNET.RangeFilter.PassUnmappedSpecies = tt.passUnmapped
+			settings.BirdNET.Labels = classifierLabels
+
+			rf := &fakeUniversalRangeFilter{
+				geoLabels: geoLabels,
+				scores: []SpeciesScore{
+					{Score: 0.9, Label: "Turdus merula_Common Blackbird"},
+					{Score: 0.8, Label: "Parus major_Great Tit"},
+				},
+				rawScores: []float32{0.9, 0.8},
+			}
+
+			bn := &BirdNET{
+				Settings:     settings,
+				rangeFilter:  rf,
+				speciesCache: make(map[string]*speciesCacheEntry),
+			}
+
+			scores, err := bn.getProbableSpecies(time.Now(), 0, settings)
+			require.NoError(t, err)
+			assert.GreaterOrEqual(t, len(scores), tt.wantMinSpecies)
+
+			hasUnmapped := false
+			for _, ss := range scores {
+				if ss.Label == "Ficedula hypoleuca_Pied Flycatcher" {
+					hasUnmapped = true
+					assert.InDelta(t, 0.0, ss.Score, 0.001,
+						"unmapped species should have score 0.0")
+				}
+			}
+			assert.Equal(t, tt.wantUnmappedIn, hasUnmapped,
+				"unmapped species presence should match expectation")
+		})
+	}
+}
+
+func TestBuildRangeFilter_UnmappedSpeciesInIsSpeciesIncluded(t *testing.T) {
+	geoLabels := []string{
+		"Turdus merula_Common Blackbird",
+	}
+	classifierLabels := []string{
+		"Turdus merula_Common Blackbird",
+		"Ficedula hypoleuca_Pied Flycatcher",
+	}
+	geoScores := []SpeciesScore{
+		{Score: 0.9, Label: "Turdus merula_Common Blackbird"},
+	}
+
+	settings := conf.GetTestSettings()
+	settings.BirdNET.Latitude = 60.0
+	settings.BirdNET.Longitude = 25.0
+	settings.BirdNET.LocationConfigured = true
+	settings.BirdNET.RangeFilter.Threshold = 0.01
+	settings.BirdNET.RangeFilter.PassUnmappedSpecies = true
+	settings.BirdNET.Labels = classifierLabels
+	conf.SetTestSettings(settings)
+	t.Cleanup(func() { conf.SetTestSettings(nil) })
+
+	rf := &fakeUniversalRangeFilter{
+		geoLabels: geoLabels,
+		scores:    geoScores,
+		rawScores: []float32{0.9},
+	}
+
+	o := buildTestOrchestrator(t, settings, rf)
+	err := BuildRangeFilter(o)
+	require.NoError(t, err)
+
+	updated := conf.GetSettings()
+	assert.True(t, updated.IsSpeciesIncluded("Turdus merula_Common Blackbird"),
+		"mapped species should be included")
+	assert.True(t, updated.IsSpeciesIncluded("Ficedula hypoleuca_Pied Flycatcher"),
+		"unmapped species should be included when PassUnmappedSpecies is true")
+}


### PR DESCRIPTION
## Summary

- `BuildRangeFilter()` now appends unmapped classifier species (those absent from the geomodel) to the species inclusion list when `PassUnmappedSpecies` is enabled, so the processor's `IsSpeciesIncluded()` check no longer silently blocks them
- `BuildRangeFilter()` syncs `mappedRangeFilter.unmappedScore` under the existing mutex when rebuilding, so toggling the setting takes effect without a full `ReloadRangeFilter`
- `getProbableSpecies()` universal geomodel path now includes unmapped species (score 0.0) so API endpoints (species scores, rarity, CSV export) stay consistent with the detection filter

Previously, the "Allow species without range data" toggle had no visible effect: the species count shown in the UI stayed the same because `PredictSpeciesScores()` only returns geomodel species above threshold, and classifier-only species (~314 for BirdNET V2.4) were never added to the inclusion set.

## Test Plan

- [x] `go test -race ./internal/classifier/...` (568 tests pass)
- [x] `go test -race ./internal/conf/...` (1174 tests pass)
- [x] `golangci-lint run -v` (zero issues)
- [x] New tests verify: toggle on/off, exclude list interaction, unmappedScore lifecycle, `IsSpeciesIncluded` end-to-end, `getProbableSpecies` consistency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optionally include unmapped classifier labels in species results when enabled; they appear with score 0.0, respect the exclusion list, avoid duplicates, and are counted in logs.

* **Tests**
  * Added comprehensive tests covering unmapped-species inclusion, exclusion-list behavior, score handling, and result ordering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3099)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->