### PR TITLE
fix: concurrency, resource leaks, and silent log loss

### DIFF
--- a/frontend/src/lib/desktop/features/settings/pages/AnalysisSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/AnalysisSettingsPage.svelte
@@ -466,8 +466,11 @@
 
   let debounceTimer: ReturnType<typeof setTimeout> | undefined;
   let loadingDelayTimer: ReturnType<typeof setTimeout> | undefined;
+  let rangeFilterAbortController: AbortController | null = null;
 
   function debouncedTestRangeFilter() {
+    rangeFilterAbortController?.abort();
+    rangeFilterAbortController = null;
     clearTimeout(debounceTimer);
     debounceTimer = setTimeout(() => {
       testCurrentRangeFilter();
@@ -497,6 +500,7 @@
     }, 100);
 
     rangeFilterState.error = null;
+    rangeFilterAbortController = new AbortController();
 
     try {
       const data = await api.post<{ count: number; species?: RangeFilterSpecies[] }>(
@@ -505,7 +509,8 @@
           latitude: birdnet?.latitude,
           longitude: birdnet?.longitude,
           threshold: birdnet?.rangeFilter?.threshold,
-        }
+        },
+        { signal: rangeFilterAbortController.signal }
       );
 
       rangeFilterState.speciesCount = data.count;
@@ -514,12 +519,14 @@
         rangeFilterState.species = data.species || [];
       }
     } catch (err) {
+      if (err instanceof Error && err.name === 'AbortError') return;
       logger.error('Failed to test range filter:', err);
       rangeFilterState.error = t('settings.main.errors.rangeFilterTestFailed');
       rangeFilterState.speciesCount = null;
     } finally {
       clearTimeout(loadingDelayTimer);
       rangeFilterState.testing = false;
+      rangeFilterAbortController = null;
     }
   }
 
@@ -560,6 +567,7 @@
     return () => {
       clearTimeout(debounceTimer);
       clearTimeout(loadingDelayTimer);
+      rangeFilterAbortController?.abort();
     };
   });
 

--- a/internal/analysis/audio_pipeline_service.go
+++ b/internal/analysis/audio_pipeline_service.go
@@ -387,6 +387,7 @@ func (p *AudioPipelineService) removeAllSources(operation string) {
 	// router state so the next registerSoundLevelConsumers call (e.g. after
 	// restartAudioCapture) does not skip sources due to stale entries.
 	p.untrackAllSoundLevelConsumers()
+	ResetOverrunTrackers()
 }
 
 // setupAudioSources builds source configs from current settings, adds them to
@@ -895,22 +896,24 @@ func (p *AudioPipelineService) reconfigureChangedSources(audioLevelChan chan aud
 	}
 	var removedCount int
 	for _, src := range registry.List() {
-		if !keepIDs[src.ID] {
-			removedCount++
-			log.Info("removing stream no longer in config",
-				logger.String("source_id", src.ID),
-				logger.String("operation", "reconfigure_diff"))
-			if err := p.engine.RemoveSource(src.ID); err != nil {
-				log.Warn("failed to remove source during reconfigure",
-					logger.String("source_id", src.ID),
-					logger.Error(err))
-			}
-			// engine.RemoveSource also removes the soundlevel route. Drop the
-			// tracking entry so the idempotency check in
-			// registerSoundLevelConsumers does not skip this ID if the same
-			// source is re-added later.
-			p.untrackSoundLevelConsumer(src.ID)
+		if keepIDs[src.ID] {
+			continue
 		}
+		removedCount++
+		log.Info("removing stream no longer in config",
+			logger.String("source_id", src.ID),
+			logger.String("operation", "reconfigure_diff"))
+		if err := p.engine.RemoveSource(src.ID); err != nil {
+			log.Warn("failed to remove source during reconfigure",
+				logger.String("source_id", src.ID),
+				logger.Error(err))
+		}
+		// engine.RemoveSource also removes the soundlevel route. Drop the
+		// tracking entry so the idempotency check in
+		// registerSoundLevelConsumers does not skip this ID if the same
+		// source is re-added later.
+		p.untrackSoundLevelConsumer(src.ID)
+		RemoveOverrunTrackers(src.ID)
 	}
 
 	// Register consumers and monitors only for newly added sources.

--- a/internal/analysis/process.go
+++ b/internal/analysis/process.go
@@ -6,6 +6,7 @@ package analysis
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -93,6 +94,19 @@ func ResetOverrunTrackers() {
 	overrunTrackersMu.Lock()
 	clear(overrunTrackers)
 	overrunTrackersMu.Unlock()
+}
+
+// RemoveOverrunTrackers removes all tracker entries for the given source ID.
+// Called when a source is removed to prevent unbounded map growth.
+func RemoveOverrunTrackers(sourceID string) {
+	prefix := sourceID + ":"
+	overrunTrackersMu.Lock()
+	defer overrunTrackersMu.Unlock()
+	for key := range overrunTrackers {
+		if strings.HasPrefix(key, prefix) {
+			delete(overrunTrackers, key)
+		}
+	}
 }
 
 // lastQueueOverflowReport tracks the last time a queue overflow was reported to Sentry.

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -439,27 +439,41 @@ func (o *Orchestrator) RangeFilterStatus() RangeFilterStatusResponse {
 		labels []string
 	}
 
-	var tasks []modelTask
+	type entryRef struct {
+		id    string
+		entry *modelEntry
+	}
+
+	var refs []entryRef
 	o.mu.RLock()
 	for id, entry := range o.models {
-		if entry.instance == nil || id == primary.ModelInfo.ID {
+		if id == primary.ModelInfo.ID || id == RegistryIDBat {
 			continue
 		}
-		if id == RegistryIDBat {
+		refs = append(refs, entryRef{id: id, entry: entry})
+	}
+	o.mu.RUnlock()
+
+	var tasks []modelTask
+	for _, ref := range refs {
+		ref.entry.mu.Lock()
+		if ref.entry.instance == nil {
+			ref.entry.mu.Unlock()
 			continue
 		}
-		info, exists := ModelRegistry[id]
-		name := id
+		info, exists := ModelRegistry[ref.id]
+		name := ref.id
 		if exists {
 			name = info.Name
 		}
+		labels := ref.entry.instance.Labels()
+		ref.entry.mu.Unlock()
 		tasks = append(tasks, modelTask{
-			id:     id,
+			id:     ref.id,
 			name:   name,
-			labels: entry.instance.Labels(),
+			labels: labels,
 		})
 	}
-	o.mu.RUnlock()
 
 	for _, task := range tasks {
 		cov := ClassifierCoverage{
@@ -792,27 +806,39 @@ func (o *Orchestrator) Debug(format string, v ...any) {
 // ModelInfos returns ModelInfo for all registered models. Thread-safe.
 // Used by the pipeline to build ModelTarget lists for buffer fan-out.
 func (o *Orchestrator) ModelInfos() []ModelInfo {
-	o.mu.RLock()
-	defer o.mu.RUnlock()
-
-	if o.models == nil {
-		return nil
+	type entryRef struct {
+		id    string
+		entry *modelEntry
 	}
 
-	infos := make([]ModelInfo, 0, len(o.models))
+	o.mu.RLock()
+	if o.models == nil {
+		o.mu.RUnlock()
+		return nil
+	}
+	refs := make([]entryRef, 0, len(o.models))
 	for id, entry := range o.models {
-		if entry.instance == nil {
+		refs = append(refs, entryRef{id: id, entry: entry})
+	}
+	o.mu.RUnlock()
+
+	infos := make([]ModelInfo, 0, len(refs))
+	for _, ref := range refs {
+		ref.entry.mu.Lock()
+		if ref.entry.instance == nil {
+			ref.entry.mu.Unlock()
 			continue
 		}
-		info, exists := ModelRegistry[id]
+		info, exists := ModelRegistry[ref.id]
 		if !exists {
 			info = ModelInfo{
-				ID:         entry.instance.ModelID(),
-				Name:       entry.instance.ModelName(),
-				Spec:       entry.instance.Spec(),
-				NumSpecies: entry.instance.NumSpecies(),
+				ID:         ref.entry.instance.ModelID(),
+				Name:       ref.entry.instance.ModelName(),
+				Spec:       ref.entry.instance.Spec(),
+				NumSpecies: ref.entry.instance.NumSpecies(),
 			}
 		}
+		ref.entry.mu.Unlock()
 		infos = append(infos, info)
 	}
 	return infos

--- a/internal/logger/config.go
+++ b/internal/logger/config.go
@@ -60,6 +60,7 @@ const (
 	DefaultImageproviderLogPath = "logs/imageprovider.log"
 	DefaultSpectrogramLogPath   = "logs/spectrogram.log"
 	DefaultActionsLogPath       = "logs/actions.log"
+	DefaultClassifierLogPath    = "logs/classifier.log"
 	DefaultMaxSize              = 100   // MB before rotation
 	DefaultMaxAge               = 30    // days to keep rotated files
 	DefaultMaxRotatedFiles      = 10    // max number of rotated files
@@ -151,6 +152,9 @@ func applyConfigDefaults(cfg *LoggingConfig) {
 	// Spectrogram generation logs
 	ensureModuleOutput(cfg, "spectrogram", DefaultSpectrogramLogPath)
 	ensureModuleOutput(cfg, "spectrogram.prerenderer", DefaultSpectrogramLogPath) // Same file
+
+	// Classifier orchestrator and scheduler logs
+	ensureModuleOutput(cfg, "birdnet", DefaultClassifierLogPath)
 
 	// Action processing logs (command execution, database saves, notifications)
 	// ConsoleAlso is true so errors are visible in container environments


### PR DESCRIPTION
## Summary

Fixes four concurrency/correctness bugs found during code quality session:

- **Logger:** Register "birdnet" module in logger defaults so orchestrator and nighttime scheduler logs are no longer silently lost (writes to `logs/classifier.log`)
- **OverrunTrackers:** Add `RemoveOverrunTrackers(sourceID)` to prevent unbounded map growth when audio sources are removed or reconfigured
- **Orchestrator:** Acquire `entry.mu` in `RangeFilterStatus` and `ModelInfos` before accessing `entry.instance`, matching the safe pattern used by `PredictModel`/`ModelSpecFor`
- **Frontend:** Add AbortController to range filter test endpoint to cancel stale in-flight requests when new tests are initiated

Also refactors `reconfigureChangedSources` loop to early-continue (gocritic nestingReduce fix).

## Test Plan

- [x] All 2315 tests pass with `-race` flag
- [x] `golangci-lint run` clean (0 issues)
- [x] `svelte-check` clean (0 errors)
- [x] Gate review (4 agents + Gemini cross-validation) passed