### PR TITLE
feat(inference): add batch geomodel inference for range filter

### DIFF
--- a/internal/inference/backend.go
+++ b/internal/inference/backend.go
@@ -59,3 +59,13 @@ type RangeFilter interface {
 	// Close releases all runtime resources.
 	Close()
 }
+
+// BatchRangeFilter extends RangeFilter with batch inference support.
+// Implementations are NOT goroutine-safe; callers must synchronize access.
+type BatchRangeFilter interface {
+	RangeFilter
+	// PredictBatch runs inference on multiple location/week inputs in a single batch.
+	// inputs is a flat slice of [lat, lon, week] triples: len(inputs) must equal batchSize * 3.
+	// Returns a flat slice of [batchSize * numSpecies] scores in row-major order.
+	PredictBatch(inputs []float32, batchSize int) ([]float32, error)
+}

--- a/internal/inference/onnx.go
+++ b/internal/inference/onnx.go
@@ -292,7 +292,7 @@ func findONNXRuntimeLibrary() string {
 // Resets initialization state so InitONNXRuntime can be called again.
 func DestroyONNXRuntime() error {
 	ortInitMu.Lock()
+	defer ortInitMu.Unlock()
 	ortInitialized = false
-	ortInitMu.Unlock()
 	return ort.DestroyORT()
 }

--- a/internal/inference/onnx.go
+++ b/internal/inference/onnx.go
@@ -170,11 +170,17 @@ func (c *onnxCustomClassifier) PredictEmbedding(embeddings []float32) ([]float32
 
 // NumClasses returns the number of output classes.
 func (c *onnxCustomClassifier) NumClasses() int {
+	if c.classifier == nil {
+		return 0
+	}
 	return c.classifier.NumClasses()
 }
 
 // Labels returns the classification labels.
 func (c *onnxCustomClassifier) Labels() []string {
+	if c.classifier == nil {
+		return nil
+	}
 	return c.classifier.Labels()
 }
 

--- a/internal/inference/onnx.go
+++ b/internal/inference/onnx.go
@@ -78,11 +78,17 @@ func NewONNXClassifier(modelPath string, opts ONNXClassifierOptions) (Classifier
 
 // Predict runs ONNX inference, returning raw logits (pre-activation).
 func (c *onnxClassifier) Predict(samples []float32) ([]float32, error) {
+	if c.classifier == nil {
+		return nil, ort.ErrSessionClosed
+	}
 	return c.classifier.PredictRaw(samples)
 }
 
 // PredictWithEmbeddings runs ONNX inference, returning both raw logits and embedding vector.
 func (c *onnxClassifier) PredictWithEmbeddings(samples []float32) (logits, embeddings []float32, err error) {
+	if c.classifier == nil {
+		return nil, nil, ort.ErrSessionClosed
+	}
 	return c.classifier.PredictRawWithEmbeddings(samples)
 }
 
@@ -156,6 +162,9 @@ func NewONNXCustomClassifier(modelPath string, opts ONNXCustomClassifierOptions)
 
 // PredictEmbedding runs inference on an embedding vector.
 func (c *onnxCustomClassifier) PredictEmbedding(embeddings []float32) ([]float32, error) {
+	if c.classifier == nil {
+		return nil, ort.ErrSessionClosed
+	}
 	return c.classifier.PredictRaw(embeddings)
 }
 
@@ -213,6 +222,9 @@ func NewONNXRangeFilter(modelPath string, opts ONNXRangeFilterOptions) (RangeFil
 
 // Predict returns species occurrence scores for a geographic location and week.
 func (r *onnxRangeFilter) Predict(latitude, longitude, week float32) ([]float32, error) {
+	if r.filter == nil {
+		return nil, ort.ErrSessionClosed
+	}
 	return r.filter.PredictRaw(latitude, longitude, week)
 }
 
@@ -220,6 +232,9 @@ func (r *onnxRangeFilter) Predict(latitude, longitude, week float32) ([]float32,
 // inputs is a flat slice of [lat, lon, week] triples: len(inputs) must equal batchSize * 3.
 // Returns a flat slice of [batchSize * numSpecies] scores in row-major order.
 func (r *onnxRangeFilter) PredictBatch(inputs []float32, batchSize int) ([]float32, error) {
+	if r.filter == nil {
+		return nil, ort.ErrSessionClosed
+	}
 	return r.filter.PredictBatchRaw(inputs, batchSize)
 }
 

--- a/internal/inference/onnx.go
+++ b/internal/inference/onnx.go
@@ -183,6 +183,9 @@ type ONNXRangeFilterOptions struct {
 	Labels []string
 }
 
+// Compile-time check: onnxRangeFilter satisfies BatchRangeFilter.
+var _ BatchRangeFilter = (*onnxRangeFilter)(nil)
+
 // onnxRangeFilter implements RangeFilter using an ONNX Runtime session.
 type onnxRangeFilter struct {
 	filter     *ort.RangeFilter
@@ -211,6 +214,13 @@ func NewONNXRangeFilter(modelPath string, opts ONNXRangeFilterOptions) (RangeFil
 // Predict returns species occurrence scores for a geographic location and week.
 func (r *onnxRangeFilter) Predict(latitude, longitude, week float32) ([]float32, error) {
 	return r.filter.PredictRaw(latitude, longitude, week)
+}
+
+// PredictBatch runs batch inference on multiple location/week inputs.
+// inputs is a flat slice of [lat, lon, week] triples: len(inputs) must equal batchSize * 3.
+// Returns a flat slice of [batchSize * numSpecies] scores in row-major order.
+func (r *onnxRangeFilter) PredictBatch(inputs []float32, batchSize int) ([]float32, error) {
+	return r.filter.PredictBatchRaw(inputs, batchSize)
 }
 
 // NumSpecies returns the number of species in the range filter model output.

--- a/internal/inference/onnx/classifier.go
+++ b/internal/inference/onnx/classifier.go
@@ -258,6 +258,9 @@ func (c *Classifier) PredictRaw(audio []float32) ([]float32, error) {
 // PredictRawWithEmbeddings runs inference and returns both raw logits and embedding vector.
 // Returns nil embeddings if the model does not produce embeddings.
 func (c *Classifier) PredictRawWithEmbeddings(audio []float32) (logits, embeddings []float32, err error) {
+	if c.session == nil {
+		return nil, nil, ErrSessionClosed
+	}
 	if len(audio) != c.config.SampleCount {
 		return nil, nil, &InputSizeError{Expected: c.config.SampleCount, Got: len(audio)}
 	}
@@ -315,6 +318,9 @@ func (c *Classifier) PredictRawWithEmbeddings(audio []float32) (logits, embeddin
 // The audio slice must contain exactly Config().SampleCount float32 samples
 // (mono, at the model's sample rate, normalized to [-1.0, 1.0]).
 func (c *Classifier) Predict(audio []float32) (*Result, error) {
+	if c.session == nil {
+		return nil, ErrSessionClosed
+	}
 	if len(audio) != c.config.SampleCount {
 		return nil, &InputSizeError{Expected: c.config.SampleCount, Got: len(audio)}
 	}
@@ -352,6 +358,9 @@ func (c *Classifier) Predict(audio []float32) (*Result, error) {
 // PredictBatch runs inference on multiple audio segments in a single batch.
 // Each segment must contain exactly Config().SampleCount samples.
 func (c *Classifier) PredictBatch(segments [][]float32) ([]*Result, error) {
+	if c.session == nil {
+		return nil, ErrSessionClosed
+	}
 	if len(segments) == 0 {
 		return nil, ErrEmptyBatch
 	}

--- a/internal/inference/onnx/custom_classifier.go
+++ b/internal/inference/onnx/custom_classifier.go
@@ -146,6 +146,9 @@ func (c *CustomClassifier) Predict(embeddings []float32) ([]Prediction, error) {
 // PredictRaw runs inference on a single embedding vector and returns all
 // sigmoid-applied scores as a flat array (no topK filtering).
 func (c *CustomClassifier) PredictRaw(embeddings []float32) ([]float32, error) {
+	if c.session == nil {
+		return nil, ErrSessionClosed
+	}
 	if len(embeddings) != c.inputDim {
 		return nil, &EmbeddingDimMismatchError{Expected: c.inputDim, Got: len(embeddings)}
 	}
@@ -172,6 +175,9 @@ func (c *CustomClassifier) PredictRaw(embeddings []float32) ([]float32, error) {
 
 // PredictBatch runs inference on multiple embedding vectors in a single batch.
 func (c *CustomClassifier) PredictBatch(embeddings [][]float32) ([][]Prediction, error) {
+	if c.session == nil {
+		return nil, ErrSessionClosed
+	}
 	if len(embeddings) == 0 {
 		return nil, ErrEmptyBatch
 	}

--- a/internal/inference/onnx/errors.go
+++ b/internal/inference/onnx/errors.go
@@ -84,3 +84,16 @@ type InvalidDateError struct {
 func (e *InvalidDateError) Error() string {
 	return fmt.Sprintf("birdnet: invalid date (month=%d, day=%d): %s", e.Month, e.Day, e.Reason)
 }
+
+// ErrEmptyRangeFilterBatch is returned when PredictBatchRaw receives zero inputs.
+var ErrEmptyRangeFilterBatch = errors.New("birdnet: range filter batch must contain at least one input")
+
+// RangeFilterBatchInputError is returned when the input slice length doesn't match batchSize * 3.
+type RangeFilterBatchInputError struct {
+	Expected int
+	Got      int
+}
+
+func (e *RangeFilterBatchInputError) Error() string {
+	return fmt.Sprintf("birdnet: range filter batch input has %d values, expected %d (batchSize * 3)", e.Got, e.Expected)
+}

--- a/internal/inference/onnx/errors.go
+++ b/internal/inference/onnx/errors.go
@@ -9,6 +9,7 @@ var (
 	ErrModelPathRequired = errors.New("birdnet: model path is required")
 	ErrLabelsRequired    = errors.New("birdnet: labels are required")
 	ErrEmptyBatch        = errors.New("birdnet: batch must contain at least one segment")
+	ErrSessionClosed     = errors.New("birdnet: session is closed")
 )
 
 type InputSizeError struct {

--- a/internal/inference/onnx/rangefilter.go
+++ b/internal/inference/onnx/rangefilter.go
@@ -165,6 +165,9 @@ func (r *RangeFilter) PredictBatchRaw(inputs []float32, batchSize int) ([]float3
 
 	data := outputTensor.GetData()
 	totalScores := batchSize * numSpecies
+	if len(data) < totalScores {
+		return nil, fmt.Errorf("birdnet: range filter batch output has %d values, expected %d", len(data), totalScores)
+	}
 	scores := make([]float32, totalScores)
 	copy(scores, data[:totalScores])
 	return scores, nil

--- a/internal/inference/onnx/rangefilter.go
+++ b/internal/inference/onnx/rangefilter.go
@@ -133,6 +133,43 @@ func (r *RangeFilter) PredictRaw(latitude, longitude, week float32) ([]float32, 
 	return scores, nil
 }
 
+// PredictBatchRaw runs inference on multiple location/week inputs in a single batch.
+// inputs is a flat slice of [lat, lon, week] triples: len(inputs) must equal batchSize * 3.
+// Returns a flat slice of [batchSize * numSpecies] scores in row-major order.
+func (r *RangeFilter) PredictBatchRaw(inputs []float32, batchSize int) ([]float32, error) {
+	if batchSize <= 0 {
+		return nil, ErrEmptyRangeFilterBatch
+	}
+	expected := batchSize * 3
+	if len(inputs) != expected {
+		return nil, &RangeFilterBatchInputError{Expected: expected, Got: len(inputs)}
+	}
+
+	numSpecies := len(r.labels)
+
+	inputTensor, err := ort.NewTensor(ort.NewShape(int64(batchSize), 3), inputs)
+	if err != nil {
+		return nil, fmt.Errorf("birdnet: failed to create range filter batch input tensor: %w", err)
+	}
+	defer func() { _ = inputTensor.Destroy() }()
+
+	outputTensor, err := ort.NewEmptyTensor[float32](ort.NewShape(int64(batchSize), int64(numSpecies)))
+	if err != nil {
+		return nil, fmt.Errorf("birdnet: failed to create range filter batch output tensor: %w", err)
+	}
+	defer func() { _ = outputTensor.Destroy() }()
+
+	if err := r.session.Run([]ort.Value{inputTensor}, []ort.Value{outputTensor}); err != nil {
+		return nil, fmt.Errorf("birdnet: range filter batch inference failed: %w", err)
+	}
+
+	data := outputTensor.GetData()
+	totalScores := batchSize * numSpecies
+	scores := make([]float32, totalScores)
+	copy(scores, data[:totalScores])
+	return scores, nil
+}
+
 // Predict runs the range filter and returns labeled species occurrence scores.
 func (r *RangeFilter) Predict(latitude, longitude float32, month, day int) ([]LocationScore, error) {
 	if err := ValidateCoordinates(latitude, longitude); err != nil {

--- a/internal/inference/onnx/rangefilter.go
+++ b/internal/inference/onnx/rangefilter.go
@@ -104,6 +104,9 @@ func resolveRangeFilterLabels(cfg *rangeFilterConfig) ([]string, error) {
 // PredictRaw runs inference and returns raw species occurrence scores as a flat []float32 slice.
 // This is used by adapters that handle their own label pairing and filtering.
 func (r *RangeFilter) PredictRaw(latitude, longitude, week float32) ([]float32, error) {
+	if r.session == nil {
+		return nil, ErrSessionClosed
+	}
 	input := []float32{latitude, longitude, week}
 
 	inputTensor, err := ort.NewTensor(ort.NewShape(1, 3), input)
@@ -137,6 +140,9 @@ func (r *RangeFilter) PredictRaw(latitude, longitude, week float32) ([]float32, 
 // inputs is a flat slice of [lat, lon, week] triples: len(inputs) must equal batchSize * 3.
 // Returns a flat slice of [batchSize * numSpecies] scores in row-major order.
 func (r *RangeFilter) PredictBatchRaw(inputs []float32, batchSize int) ([]float32, error) {
+	if r.session == nil {
+		return nil, ErrSessionClosed
+	}
 	if batchSize <= 0 {
 		return nil, ErrEmptyRangeFilterBatch
 	}
@@ -175,6 +181,9 @@ func (r *RangeFilter) PredictBatchRaw(inputs []float32, batchSize int) ([]float3
 
 // Predict runs the range filter and returns labeled species occurrence scores.
 func (r *RangeFilter) Predict(latitude, longitude float32, month, day int) ([]LocationScore, error) {
+	if r.session == nil {
+		return nil, ErrSessionClosed
+	}
 	if err := ValidateCoordinates(latitude, longitude); err != nil {
 		return nil, err
 	}
@@ -278,11 +287,21 @@ func ValidateDate(month, day int) error {
 // filterPredictions removes predictions for species with location scores below threshold.
 // If rerank is true, confidence is multiplied by location score and results are re-sorted.
 func filterPredictions(predictions []Prediction, scores []LocationScore, threshold float32, rerank bool) []Prediction {
+	scoreMap := buildScoreMap(scores)
+	return filterPredictionsWithMap(predictions, scoreMap, threshold, rerank)
+}
+
+// buildScoreMap creates a species-to-score lookup map from location scores.
+func buildScoreMap(scores []LocationScore) map[string]float32 {
 	scoreMap := make(map[string]float32, len(scores))
 	for _, s := range scores {
 		scoreMap[s.Species] = s.Score
 	}
+	return scoreMap
+}
 
+// filterPredictionsWithMap filters predictions using a pre-built score map.
+func filterPredictionsWithMap(predictions []Prediction, scoreMap map[string]float32, threshold float32, rerank bool) []Prediction {
 	var result []Prediction
 	for _, p := range predictions {
 		locScore, ok := scoreMap[p.Species]
@@ -312,9 +331,10 @@ func filterPredictions(predictions []Prediction, scores []LocationScore, thresho
 
 // filterBatchPredictions applies filterPredictions to each batch of predictions.
 func filterBatchPredictions(batches [][]Prediction, scores []LocationScore, threshold float32, rerank bool) [][]Prediction {
+	scoreMap := buildScoreMap(scores)
 	result := make([][]Prediction, len(batches))
 	for i, batch := range batches {
-		result[i] = filterPredictions(batch, scores, threshold, rerank)
+		result[i] = filterPredictionsWithMap(batch, scoreMap, threshold, rerank)
 	}
 	return result
 }

--- a/internal/inference/onnx/rangefilter_test.go
+++ b/internal/inference/onnx/rangefilter_test.go
@@ -3,14 +3,26 @@ package onnx
 import (
 	"testing"
 
+	ort "github.com/yalue/onnxruntime_go"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
+// newTestRangeFilter creates a RangeFilter with a non-nil (but unusable) session
+// for testing input validation paths that must pass the nil-session guard.
+func newTestRangeFilter(t *testing.T, numLabels int) *RangeFilter {
+	t.Helper()
+	return &RangeFilter{
+		session: &ort.DynamicAdvancedSession{},
+		labels:  make([]string, numLabels),
+	}
+}
+
 func TestPredictBatchRaw_EmptyBatch(t *testing.T) {
 	t.Parallel()
 
-	r := &RangeFilter{labels: make([]string, 10)}
+	r := newTestRangeFilter(t, 10)
 
 	_, err := r.PredictBatchRaw([]float32{1, 2, 3}, 0)
 	require.Error(t, err)
@@ -20,7 +32,7 @@ func TestPredictBatchRaw_EmptyBatch(t *testing.T) {
 func TestPredictBatchRaw_NegativeBatchSize(t *testing.T) {
 	t.Parallel()
 
-	r := &RangeFilter{labels: make([]string, 10)}
+	r := newTestRangeFilter(t, 10)
 
 	_, err := r.PredictBatchRaw([]float32{1, 2, 3}, -1)
 	require.Error(t, err)
@@ -30,7 +42,7 @@ func TestPredictBatchRaw_NegativeBatchSize(t *testing.T) {
 func TestPredictBatchRaw_InputLengthMismatch(t *testing.T) {
 	t.Parallel()
 
-	r := &RangeFilter{labels: make([]string, 10)}
+	r := newTestRangeFilter(t, 10)
 
 	tests := []struct {
 		name      string
@@ -89,4 +101,31 @@ func TestErrEmptyRangeFilterBatch_Message(t *testing.T) {
 	t.Parallel()
 
 	assert.Contains(t, ErrEmptyRangeFilterBatch.Error(), "at least one input")
+}
+
+func TestRangeFilter_SessionClosed(t *testing.T) {
+	t.Parallel()
+
+	r := &RangeFilter{labels: make([]string, 10)}
+
+	t.Run("PredictRaw", func(t *testing.T) {
+		t.Parallel()
+		_, err := r.PredictRaw(60.0, 25.0, 20.0)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrSessionClosed)
+	})
+
+	t.Run("PredictBatchRaw", func(t *testing.T) {
+		t.Parallel()
+		_, err := r.PredictBatchRaw([]float32{60, 25, 20}, 1)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrSessionClosed)
+	})
+
+	t.Run("Predict", func(t *testing.T) {
+		t.Parallel()
+		_, err := r.Predict(60.0, 25.0, 6, 15)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrSessionClosed)
+	})
 }

--- a/internal/inference/onnx/rangefilter_test.go
+++ b/internal/inference/onnx/rangefilter_test.go
@@ -1,0 +1,92 @@
+package onnx
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPredictBatchRaw_EmptyBatch(t *testing.T) {
+	t.Parallel()
+
+	r := &RangeFilter{labels: make([]string, 10)}
+
+	_, err := r.PredictBatchRaw([]float32{1, 2, 3}, 0)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrEmptyRangeFilterBatch)
+}
+
+func TestPredictBatchRaw_NegativeBatchSize(t *testing.T) {
+	t.Parallel()
+
+	r := &RangeFilter{labels: make([]string, 10)}
+
+	_, err := r.PredictBatchRaw([]float32{1, 2, 3}, -1)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrEmptyRangeFilterBatch)
+}
+
+func TestPredictBatchRaw_InputLengthMismatch(t *testing.T) {
+	t.Parallel()
+
+	r := &RangeFilter{labels: make([]string, 10)}
+
+	tests := []struct {
+		name      string
+		inputs    []float32
+		batchSize int
+		wantGot   int
+		wantExp   int
+	}{
+		{
+			name:      "too few inputs",
+			inputs:    []float32{1, 2},
+			batchSize: 1,
+			wantGot:   2,
+			wantExp:   3,
+		},
+		{
+			name:      "too many inputs",
+			inputs:    []float32{1, 2, 3, 4},
+			batchSize: 1,
+			wantGot:   4,
+			wantExp:   3,
+		},
+		{
+			name:      "batch of 3 with wrong count",
+			inputs:    []float32{1, 2, 3, 4, 5, 6, 7},
+			batchSize: 3,
+			wantGot:   7,
+			wantExp:   9,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := r.PredictBatchRaw(tt.inputs, tt.batchSize)
+			require.Error(t, err)
+
+			var batchErr *RangeFilterBatchInputError
+			require.ErrorAs(t, err, &batchErr)
+			assert.Equal(t, tt.wantExp, batchErr.Expected)
+			assert.Equal(t, tt.wantGot, batchErr.Got)
+		})
+	}
+}
+
+func TestRangeFilterBatchInputError_Message(t *testing.T) {
+	t.Parallel()
+
+	err := &RangeFilterBatchInputError{Expected: 9, Got: 7}
+	assert.Contains(t, err.Error(), "7 values")
+	assert.Contains(t, err.Error(), "expected 9")
+}
+
+func TestErrEmptyRangeFilterBatch_Message(t *testing.T) {
+	t.Parallel()
+
+	assert.Contains(t, ErrEmptyRangeFilterBatch.Error(), "at least one input")
+}


### PR DESCRIPTION
## Summary

- Add `BatchRangeFilter` interface and `PredictBatchRaw` method to the ONNX range filter, enabling the upcoming heatmap API to compute species scores across thousands of grid points in a single `session.Run()` call instead of one per point
- Follow the same pattern as `Classifier.PredictBatch`: flat input slice, single tensor allocation, copy output before tensor destruction
- Add `ErrSessionClosed` sentinel and nil-session guards to all inference methods across `RangeFilter`, `Classifier`, and `CustomClassifier` (previously panicked on nil pointer dereference after `Close()`)
- Fix pre-existing race in `DestroyONNXRuntime` where the mutex was unlocked before `ort.DestroyORT()` completed
- Refactor `filterBatchPredictions` to build the scoreMap once instead of rebuilding per batch iteration

Part of the Migration Explorer feature (#3092), PR 1 of 4.

## Test plan

- [x] Input validation tests: empty batch, negative batch size, length mismatch
- [x] Session-closed guard tests for all three RangeFilter methods
- [x] Error message format tests
- [x] Compile-time interface satisfaction check (`var _ BatchRangeFilter`)
- [x] All 580+ existing tests pass with `-race`
- [x] `golangci-lint run -v` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added batch inference for range-based predictions to process multiple locations/weeks in one request.

* **Bug Fixes**
  * Improved handling when inference sessions are closed and when batch inputs are invalid, returning clear errors instead of runtime failures.

* **Tests**
  * Added unit tests for batch prediction validation, input/output length checks, and session-closed behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3105?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->