### PR TITLE
feat: audio liveness watchdog with tiered recovery

### DIFF
--- a/internal/analysis/audio_pipeline_service.go
+++ b/internal/analysis/audio_pipeline_service.go
@@ -279,6 +279,11 @@ func (p *AudioPipelineService) Start(_ context.Context) error {
 	)
 	p.watchdog.Start()
 
+	// Expose the watchdog to the API controller for the /health/audio endpoint.
+	if ctrl := p.apiService.APIController(); ctrl != nil {
+		ctrl.SetAudioWatchdog(p.watchdog)
+	}
+
 	// Inject suncalc into the orchestrator for bat nighttime scheduling.
 	bn.SetSunCalc(p.apiService.SunCalc())
 

--- a/internal/analysis/audio_pipeline_service.go
+++ b/internal/analysis/audio_pipeline_service.go
@@ -23,6 +23,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/diskmanager"
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/logger"
+	"github.com/tphakala/birdnet-go/internal/notification"
 	"github.com/tphakala/birdnet-go/internal/observability"
 	"github.com/tphakala/birdnet-go/internal/privacy"
 	"github.com/tphakala/birdnet-go/internal/weather"
@@ -48,6 +49,7 @@ type AudioPipelineService struct {
 	apiService *APIServerService
 	engine     *engine.AudioEngine
 
+	watchdog            *audiocore.LivenessWatchdog
 	bufferMgr           *BufferManager
 	ctrlMonitor         *ControlMonitor
 	quietHoursScheduler *schedule.QuietHoursScheduler
@@ -84,6 +86,11 @@ func NewAudioPipelineService(settings *conf.Settings, bnAnalyzer *BirdNETAnalyze
 // Name returns a human-readable identifier for logging and diagnostics.
 func (p *AudioPipelineService) Name() string {
 	return audioPipelineServiceName
+}
+
+// Watchdog returns the audio liveness watchdog, or nil if not started.
+func (p *AudioPipelineService) Watchdog() *audiocore.LivenessWatchdog {
+	return p.watchdog
 }
 
 // Start initializes and starts the audio capture pipeline, buffer management,
@@ -224,6 +231,54 @@ func (p *AudioPipelineService) Start(_ context.Context) error {
 	p.engine.SetScheduler(p.quietHoursScheduler)
 	p.quietHoursScheduler.Start()
 
+	// Start audio liveness watchdog for detecting silent capture deaths.
+	notifSvc := notification.GetService()
+	watchdogCallbacks := audiocore.LivenessCallbacks{
+		RestartSource: p.RestartSource,
+		Escalate: func(_ string) {
+			select {
+			case p.restartChan <- struct{}{}:
+			default:
+			}
+		},
+		Notify: func(sourceID string, state audiocore.LivenessState, msg string) {
+			if notifSvc == nil {
+				return
+			}
+			priority := notification.PriorityHigh
+			title := "Audio source " + msg
+			body := "Source " + sourceID + ": " + msg
+			if state == audiocore.StateFailed || state == audiocore.StateEscalated || state == audiocore.StateAlarmed {
+				priority = notification.PriorityCritical
+			}
+			if _, err := notifSvc.CreateWithComponent(
+				notification.TypeSystem, priority,
+				title, body, "audiocore.liveness",
+			); err != nil {
+				audiocore.GetLogger().Warn("failed to send liveness notification",
+					logger.Error(err),
+					logger.String("operation", "liveness_notify"))
+			}
+		},
+		IsQuietHours: func(sourceID string) bool {
+			if p.quietHoursScheduler == nil {
+				return false
+			}
+			src, ok := p.engine.Registry().Get(sourceID)
+			if ok && src.Type == audiocore.SourceTypeAudioCard {
+				return p.quietHoursScheduler.IsSoundCardSuppressed()
+			}
+			suppressed := p.quietHoursScheduler.GetSuppressedStreams()
+			return suppressed[sourceID]
+		},
+	}
+	p.watchdog = audiocore.NewLivenessWatchdog(
+		audiocore.DefaultLivenessConfig(),
+		p.engine.Router(),
+		watchdogCallbacks,
+	)
+	p.watchdog.Start()
+
 	// Inject suncalc into the orchestrator for bat nighttime scheduling.
 	bn.SetSunCalc(p.apiService.SunCalc())
 
@@ -318,6 +373,12 @@ func (p *AudioPipelineService) Stop(ctx context.Context) error {
 	cleanupHLSWithTimeout(ctx)
 
 	// NOTE: FFmpeg manager shutdown is handled by engine.Stop() in serve.go.
+
+	// Stop liveness watchdog before quiet hours scheduler so that
+	// IsQuietHours callbacks do not race with scheduler teardown.
+	if p.watchdog != nil {
+		p.watchdog.Stop()
+	}
 
 	// Stop quiet hours scheduler.
 	if p.quietHoursScheduler != nil {

--- a/internal/analysis/audio_pipeline_service.go
+++ b/internal/analysis/audio_pipeline_service.go
@@ -371,6 +371,100 @@ func (p *AudioPipelineService) restartAudioCapture() {
 	p.setupAudioSources(audioLevelChan, "restart")
 }
 
+// RestartSource tears down and reinitializes a single audio source.
+// Follows the same cleanup pattern as reconfigureChangedSources: remove routes,
+// clean up overrun trackers, untrack sound level, stop capture, then re-add.
+func (p *AudioPipelineService) RestartSource(sourceID string) error {
+	log := audiocore.GetLogger()
+	log.Info("restarting single audio source",
+		logger.String("source_id", sourceID),
+		logger.String("operation", "restart_source"))
+
+	registry := p.engine.Registry()
+
+	// Save connection string before removal (needed to look up config).
+	// ConnectionStringByID reads the private field directly from the registry,
+	// unlike Get() which returns a copy with the field cleared for safety.
+	connStr, ok := registry.ConnectionStringByID(sourceID)
+	if !ok {
+		return fmt.Errorf("restart source: source %s not found in registry", sourceID)
+	}
+
+	// 1. Remove routes for the source.
+	p.engine.Router().RemoveAllRoutes(sourceID)
+
+	// 2. Clean up overrun tracker state.
+	RemoveOverrunTrackers(sourceID)
+
+	// 3. Untrack sound level consumer (route already removed above).
+	p.untrackSoundLevelConsumer(sourceID)
+
+	// 4. Remove source from engine (stops capture, deallocates buffers, unregisters).
+	if err := p.engine.RemoveSource(sourceID); err != nil {
+		log.Error("failed to remove source during restart",
+			logger.String("source_id", sourceID),
+			logger.Error(err),
+			logger.String("operation", "restart_source"))
+		return fmt.Errorf("restart source: remove failed: %w", err)
+	}
+
+	// 5. Rebuild source config from current settings.
+	sourceConfigs := p.buildSourceConfigsWithModels()
+	var targetConfig *sourceConfigWithModels
+	for i := range sourceConfigs {
+		if sourceConfigs[i].config.ConnectionString == connStr {
+			targetConfig = &sourceConfigs[i]
+			break
+		}
+	}
+	if targetConfig == nil {
+		log.Warn("source config no longer in settings after removal",
+			logger.String("source_id", sourceID),
+			logger.String("operation", "restart_source"))
+		return fmt.Errorf("restart source: config for %s no longer exists in settings", sourceID)
+	}
+
+	// 6. Re-add source via engine.
+	if err := p.engine.AddSource(targetConfig.config); err != nil {
+		log.Error("failed to re-add source during restart",
+			logger.String("source_id", sourceID),
+			logger.Error(err),
+			logger.String("operation", "restart_source"))
+		return fmt.Errorf("restart source: add failed: %w", err)
+	}
+
+	// The source may get a new ID from the registry. Look it up.
+	newSrc, found := registry.GetByConnection(connStr)
+	if !found {
+		return fmt.Errorf("restart source: source re-added but not found in registry")
+	}
+	newSourceID := newSrc.ID
+
+	// 7. Re-register consumers and monitors.
+	audioLevelChan := p.apiService.AudioLevelChan()
+	sourceModelMap := map[string][]string{newSourceID: targetConfig.modelIDs}
+	p.registerConsumersForSources([]string{newSourceID}, sourceModelMap, audioLevelChan, "restart_source")
+	p.registerSoundLevelConsumers([]string{newSourceID}, "restart_source")
+
+	// Update buffer monitors.
+	if monErr := p.bufferMgr.AddMonitor(newSourceID); monErr != nil {
+		log.Warn("buffer monitor update failed during source restart",
+			logger.String("source_id", newSourceID),
+			logger.Error(monErr),
+			logger.String("operation", "restart_source"))
+	}
+
+	// Reset dispatch timestamp so watchdog starts fresh.
+	p.engine.Router().ResetDispatchTime(newSourceID)
+
+	log.Info("single source restart complete",
+		logger.String("old_source_id", sourceID),
+		logger.String("new_source_id", newSourceID),
+		logger.String("operation", "restart_source"))
+
+	return nil
+}
+
 // removeAllSources removes all audio sources from the engine.
 // The operation parameter is used for log messages to distinguish callers.
 func (p *AudioPipelineService) removeAllSources(operation string) {

--- a/internal/analysis/audio_pipeline_service.go
+++ b/internal/analysis/audio_pipeline_service.go
@@ -248,7 +248,7 @@ func (p *AudioPipelineService) Start(_ context.Context) error {
 			priority := notification.PriorityHigh
 			title := "Audio source " + msg
 			body := "Source " + sourceID + ": " + msg
-			if state == audiocore.StateFailed || state == audiocore.StateEscalated || state == audiocore.StateAlarmed {
+			if state == audiocore.StateFailed || state == audiocore.StateEscalated {
 				priority = notification.PriorityCritical
 			}
 			if _, err := notifSvc.CreateWithComponent(
@@ -456,16 +456,13 @@ func (p *AudioPipelineService) RestartSource(sourceID string) error {
 		return fmt.Errorf("restart source: source %s not found in registry", sourceID)
 	}
 
-	// 1. Remove routes for the source.
-	p.engine.Router().RemoveAllRoutes(sourceID)
-
-	// 2. Clean up overrun tracker state.
+	// 1. Clean up overrun tracker state.
 	RemoveOverrunTrackers(sourceID)
 
-	// 3. Untrack sound level consumer (route already removed above).
+	// 2. Untrack sound level consumer (engine.RemoveSource removes the route).
 	p.untrackSoundLevelConsumer(sourceID)
 
-	// 4. Remove source from engine (stops capture, deallocates buffers, unregisters).
+	// 3. Remove source from engine (stops capture, removes routes, deallocates buffers, unregisters).
 	if err := p.engine.RemoveSource(sourceID); err != nil {
 		log.Error("failed to remove source during restart",
 			logger.String("source_id", sourceID),

--- a/internal/api/v2/api.go
+++ b/internal/api/v2/api.go
@@ -131,7 +131,9 @@ type Controller struct {
 	goroutinesStarted chan struct{} // signals when all background goroutines have started (nil if routes not initialized)
 
 	// audioWatchdog provides liveness state for audio health endpoints.
-	audioWatchdog *audiocore.LivenessWatchdog
+	// Stored atomically because it is set during pipeline Start() and read
+	// concurrently by HTTP handlers.
+	audioWatchdog atomic.Pointer[audiocore.LivenessWatchdog]
 }
 
 // ShutdownRequester allows triggering a programmatic shutdown.

--- a/internal/api/v2/api.go
+++ b/internal/api/v2/api.go
@@ -129,6 +129,9 @@ type Controller struct {
 	// This is primarily used in testing to ensure proper setup before assertions.
 	// Only created when routes are initialized (production mode or specific tests).
 	goroutinesStarted chan struct{} // signals when all background goroutines have started (nil if routes not initialized)
+
+	// audioWatchdog provides liveness state for audio health endpoints.
+	audioWatchdog *audiocore.LivenessWatchdog
 }
 
 // ShutdownRequester allows triggering a programmatic shutdown.
@@ -609,6 +612,7 @@ func (c *Controller) initRoutes() {
 		{"settings routes", c.initSettingsRoutes},
 		{"filesystem routes", c.initFileSystemRoutes},
 		{"stream health routes", c.initStreamHealthRoutes},
+		{"audio health routes", c.initAudioHealthRoutes},
 		{"quiet hours routes", c.initQuietHoursRoutes},
 		{"audio level routes", c.initAudioLevelRoutes},
 		{"hls streaming routes", c.initHLSRoutes},

--- a/internal/api/v2/audio_health.go
+++ b/internal/api/v2/audio_health.go
@@ -1,4 +1,3 @@
-// internal/api/v2/audio_health.go
 package api
 
 import (
@@ -20,18 +19,19 @@ func (c *Controller) initAudioHealthRoutes() {
 
 // SetAudioWatchdog injects the liveness watchdog for the health endpoint.
 func (c *Controller) SetAudioWatchdog(w *audiocore.LivenessWatchdog) {
-	c.audioWatchdog = w
+	c.audioWatchdog.Store(w)
 }
 
 // GetAudioHealth returns the current liveness state for all monitored audio sources.
 func (c *Controller) GetAudioHealth(ctx echo.Context) error {
-	if c.audioWatchdog == nil {
+	w := c.audioWatchdog.Load()
+	if w == nil {
 		return ctx.JSON(http.StatusOK, AudioHealthResponse{
 			Sources: []audiocore.SourceHealthSnapshot{},
 		})
 	}
 
 	return ctx.JSON(http.StatusOK, AudioHealthResponse{
-		Sources: c.audioWatchdog.Snapshot(),
+		Sources: w.Snapshot(),
 	})
 }

--- a/internal/api/v2/audio_health.go
+++ b/internal/api/v2/audio_health.go
@@ -1,0 +1,37 @@
+// internal/api/v2/audio_health.go
+package api
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	"github.com/tphakala/birdnet-go/internal/audiocore"
+)
+
+// AudioHealthResponse wraps the per-source health snapshots.
+type AudioHealthResponse struct {
+	Sources []audiocore.SourceHealthSnapshot `json:"sources"`
+}
+
+// initAudioHealthRoutes registers the audio liveness health endpoints.
+func (c *Controller) initAudioHealthRoutes() {
+	c.Group.GET("/health/audio", c.GetAudioHealth, c.authMiddleware)
+}
+
+// SetAudioWatchdog injects the liveness watchdog for the health endpoint.
+func (c *Controller) SetAudioWatchdog(w *audiocore.LivenessWatchdog) {
+	c.audioWatchdog = w
+}
+
+// GetAudioHealth returns the current liveness state for all monitored audio sources.
+func (c *Controller) GetAudioHealth(ctx echo.Context) error {
+	if c.audioWatchdog == nil {
+		return ctx.JSON(http.StatusOK, AudioHealthResponse{
+			Sources: []audiocore.SourceHealthSnapshot{},
+		})
+	}
+
+	return ctx.JSON(http.StatusOK, AudioHealthResponse{
+		Sources: c.audioWatchdog.Snapshot(),
+	})
+}

--- a/internal/api/v2/audio_health_test.go
+++ b/internal/api/v2/audio_health_test.go
@@ -1,0 +1,55 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/audiocore"
+)
+
+func TestGetAudioHealth_NoWatchdog(t *testing.T) {
+	e := echo.New()
+	c := getTestController(t, e)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v2/health/audio", http.NoBody)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+
+	err := c.GetAudioHealth(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp AudioHealthResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Empty(t, resp.Sources)
+}
+
+func TestGetAudioHealth_WithWatchdog(t *testing.T) {
+	e := echo.New()
+	c := getTestController(t, e)
+
+	router := audiocore.NewAudioRouter(audiocore.GetLogger(), nil)
+	defer router.Close()
+
+	cfg := audiocore.DefaultLivenessConfig()
+	callbacks := audiocore.LivenessCallbacks{}
+	watchdog := audiocore.NewLivenessWatchdog(cfg, router, callbacks)
+	c.SetAudioWatchdog(watchdog)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v2/health/audio", http.NoBody)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+
+	err := c.GetAudioHealth(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp AudioHealthResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Empty(t, resp.Sources, "no sources tracked without active routes")
+}

--- a/internal/audiocore/liveness.go
+++ b/internal/audiocore/liveness.go
@@ -175,22 +175,27 @@ func (w *LivenessWatchdog) Start() {
 		w.mu.Unlock()
 		return
 	}
-	w.started = true
-	w.mu.Unlock()
-
 	ctx, cancel := context.WithCancel(context.Background())
 	w.cancel = cancel
 	w.done = make(chan struct{})
+	w.started = true
+	w.mu.Unlock()
+
 	go w.run(ctx)
 }
 
 // Stop signals the monitoring goroutine to exit and waits for it to finish.
 func (w *LivenessWatchdog) Stop() {
-	if w.cancel != nil {
-		w.cancel()
+	w.mu.Lock()
+	cancel := w.cancel
+	done := w.done
+	w.mu.Unlock()
+
+	if cancel != nil {
+		cancel()
 	}
-	if w.done != nil {
-		<-w.done
+	if done != nil {
+		<-done
 	}
 }
 

--- a/internal/audiocore/liveness.go
+++ b/internal/audiocore/liveness.go
@@ -1,0 +1,418 @@
+// liveness.go - LivenessWatchdog monitors audio source health with a per-source
+// state machine and tiered recovery (restart, escalate, notify).
+package audiocore
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/tphakala/birdnet-go/internal/errors"
+	"github.com/tphakala/birdnet-go/internal/logger"
+)
+
+// LivenessState represents the health state of a single audio source
+// as tracked by the LivenessWatchdog.
+type LivenessState int
+
+const (
+	// StateHealthy means the source is dispatching frames normally.
+	StateHealthy LivenessState = iota
+	// StateAlarmed means silence has been detected; a restart will be attempted next tick.
+	StateAlarmed
+	// StateRecovering means a restart has been requested and the watchdog is
+	// waiting for frames to resume.
+	StateRecovering
+	// StateEscalated means all restart retries have been exhausted.
+	StateEscalated
+	// StateFailed is terminal; the escalation timeout has elapsed with no recovery.
+	StateFailed
+)
+
+// String returns a human-readable label for the state.
+func (s LivenessState) String() string {
+	switch s {
+	case StateHealthy:
+		return "HEALTHY"
+	case StateAlarmed:
+		return "ALARMED"
+	case StateRecovering:
+		return "RECOVERING"
+	case StateEscalated:
+		return "ESCALATED"
+	case StateFailed:
+		return "FAILED"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+// LivenessConfig holds tunable parameters for the watchdog.
+type LivenessConfig struct {
+	// CheckInterval is the tick period for the monitoring loop.
+	CheckInterval time.Duration
+
+	// SilenceThreshold is how long a source can go without dispatching frames
+	// before an alarm is raised.
+	SilenceThreshold time.Duration
+
+	// MaxRetries is the number of restart attempts before escalating.
+	MaxRetries int
+
+	// RetryBackoff is the minimum wait between successive restart attempts.
+	RetryBackoff time.Duration
+
+	// CooldownAfterRecov suppresses alarms after a successful recovery.
+	CooldownAfterRecov time.Duration
+
+	// EscalationTimeout is how long to wait in ESCALATED before transitioning
+	// to FAILED.
+	EscalationTimeout time.Duration
+}
+
+// DefaultLivenessConfig returns production defaults.
+func DefaultLivenessConfig() LivenessConfig {
+	return LivenessConfig{
+		CheckInterval:      10 * time.Second,
+		SilenceThreshold:   30 * time.Second,
+		MaxRetries:         3,
+		RetryBackoff:       5 * time.Second,
+		CooldownAfterRecov: 60 * time.Second,
+		EscalationTimeout:  60 * time.Second,
+	}
+}
+
+// sourceHealth tracks per-source watchdog state.
+type sourceHealth struct {
+	state         LivenessState
+	retries       int
+	lastRestart   time.Time
+	stateEntered  time.Time
+	cooldownEnd   time.Time
+	wasQuietHours bool // true if previous tick was in quiet hours for this source
+}
+
+// SourceHealthSnapshot is the read-only view of a source's health for API
+// consumers. Exported field names use JSON-friendly casing via struct tags.
+type SourceHealthSnapshot struct {
+	SourceID     string        `json:"source_id"`
+	State        string        `json:"state"`
+	Retries      int           `json:"retries"`
+	LastRestart  time.Time     `json:"last_restart,omitempty"`
+	StateEntered time.Time     `json:"state_entered"`
+	LastDispatch time.Time     `json:"last_dispatch,omitempty"`
+	RawState     LivenessState `json:"-"`
+}
+
+// LivenessCallbacks contains the external actions the watchdog can trigger.
+// All callbacks are optional; nil callbacks are silently skipped.
+type LivenessCallbacks struct {
+	// RestartSource attempts to restart the given source. Returns an error if
+	// the restart could not be initiated.
+	RestartSource func(sourceID string) error
+
+	// Escalate is called when all restart retries are exhausted.
+	Escalate func(sourceID string)
+
+	// Notify sends a user-facing notification about a source state change.
+	Notify func(sourceID string, state LivenessState, msg string)
+
+	// IsQuietHours returns true when monitoring should be suppressed for the
+	// given source. Per-source granularity is required because sound card and
+	// RTSP sources have independent quiet hours schedules.
+	IsQuietHours func(sourceID string) bool
+}
+
+// LivenessWatchdog monitors audio sources for silence and drives a tiered
+// recovery state machine. It queries the AudioRouter for frame timestamps
+// and invokes callbacks for restart/escalation/notification.
+type LivenessWatchdog struct {
+	cfg       LivenessConfig
+	router    *AudioRouter
+	callbacks LivenessCallbacks
+	log       logger.Logger
+
+	mu      sync.Mutex
+	sources map[string]*sourceHealth
+
+	cancel context.CancelFunc
+	done   chan struct{}
+}
+
+// NewLivenessWatchdog creates a watchdog that is ready to start.
+func NewLivenessWatchdog(cfg LivenessConfig, router *AudioRouter, cb LivenessCallbacks) *LivenessWatchdog {
+	return &LivenessWatchdog{
+		cfg:       cfg,
+		router:    router,
+		callbacks: cb,
+		log:       GetLogger().With(logger.String("component", "liveness")),
+		sources:   make(map[string]*sourceHealth),
+	}
+}
+
+// Start launches the monitoring goroutine. It is safe to call Start only once.
+func (w *LivenessWatchdog) Start() {
+	ctx, cancel := context.WithCancel(context.Background())
+	w.cancel = cancel
+	w.done = make(chan struct{})
+	go w.run(ctx)
+}
+
+// Stop signals the monitoring goroutine to exit and waits for it to finish.
+func (w *LivenessWatchdog) Stop() {
+	if w.cancel != nil {
+		w.cancel()
+	}
+	if w.done != nil {
+		<-w.done
+	}
+}
+
+// Snapshot returns a point-in-time view of all tracked source health states.
+func (w *LivenessWatchdog) Snapshot() []SourceHealthSnapshot {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	snaps := make([]SourceHealthSnapshot, 0, len(w.sources))
+	for id, h := range w.sources {
+		snaps = append(snaps, SourceHealthSnapshot{
+			SourceID:     id,
+			State:        h.state.String(),
+			Retries:      h.retries,
+			LastRestart:  h.lastRestart,
+			StateEntered: h.stateEntered,
+			LastDispatch: w.router.LastDispatchTime(id),
+			RawState:     h.state,
+		})
+	}
+	return snaps
+}
+
+// run is the main monitoring loop, ticking every CheckInterval.
+func (w *LivenessWatchdog) run(ctx context.Context) {
+	defer close(w.done)
+
+	ticker := time.NewTicker(w.cfg.CheckInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			w.checkAll()
+		}
+	}
+}
+
+// checkAll evaluates every active source and cleans up stale entries.
+func (w *LivenessWatchdog) checkAll() {
+	activeIDs := w.router.ActiveSourceIDs()
+	activeSet := make(map[string]struct{}, len(activeIDs))
+	for _, id := range activeIDs {
+		activeSet[id] = struct{}{}
+	}
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	// Ensure every active source has a tracking entry.
+	now := time.Now()
+	for _, id := range activeIDs {
+		if _, ok := w.sources[id]; !ok {
+			w.sources[id] = &sourceHealth{
+				state:        StateHealthy,
+				stateEntered: now,
+			}
+		}
+	}
+
+	// Remove sources that are no longer active.
+	for id := range w.sources {
+		if _, ok := activeSet[id]; !ok {
+			delete(w.sources, id)
+		}
+	}
+
+	// Evaluate each source, handling quiet hours per-source.
+	for _, id := range activeIDs {
+		h := w.sources[id]
+		if h == nil {
+			continue
+		}
+
+		quietNow := w.callbacks.IsQuietHours != nil && w.callbacks.IsQuietHours(id)
+
+		// Handle per-source quiet hours transition.
+		if h.wasQuietHours && !quietNow {
+			w.router.ResetDispatchTime(id)
+			h.state = StateHealthy
+			h.retries = 0
+			h.stateEntered = now
+			w.log.Info("quiet hours ended, resetting liveness state",
+				logger.String("source_id", id))
+		}
+		h.wasQuietHours = quietNow
+
+		if quietNow {
+			continue
+		}
+
+		w.checkSource(id)
+	}
+}
+
+// checkSource drives the state machine for a single source.
+// The caller must hold w.mu.
+//
+//nolint:gocognit // state machine is inherently complex; splitting would obscure the flow
+func (w *LivenessWatchdog) checkSource(sourceID string) {
+	h := w.sources[sourceID]
+	if h == nil {
+		return
+	}
+
+	now := time.Now()
+	lastFrame := w.router.LastDispatchTime(sourceID)
+	framesFlowing := !lastFrame.IsZero() && now.Sub(lastFrame) < w.cfg.SilenceThreshold
+
+	switch h.state {
+	case StateHealthy:
+		if framesFlowing {
+			return
+		}
+		// In cooldown after recovery: suppress alarm.
+		if !h.cooldownEnd.IsZero() && now.Before(h.cooldownEnd) {
+			return
+		}
+		// Silence detected.
+		h.state = StateAlarmed
+		h.stateEntered = now
+		h.retries = 0
+
+		w.log.Error("audio source silence detected",
+			logger.String("source_id", sourceID),
+			logger.Duration("silence", now.Sub(lastFrame)),
+		)
+		// Emit Sentry error for observability.
+		_ = errors.Newf("audio source silence detected: %s", sourceID).
+			Component("audiocore.liveness").
+			Category(errors.CategoryAudioSource).
+			Context("source_id", sourceID).
+			Context("silence_duration", now.Sub(lastFrame).String()).
+			Build()
+
+		if w.callbacks.Notify != nil {
+			w.callbacks.Notify(sourceID, StateAlarmed, "silence detected")
+		}
+
+	case StateAlarmed:
+		if framesFlowing {
+			w.recover(h, sourceID)
+			return
+		}
+		// Transition to RECOVERING and attempt first restart.
+		h.state = StateRecovering
+		h.stateEntered = now
+		w.attemptRestart(h, sourceID)
+
+	case StateRecovering:
+		if framesFlowing {
+			w.recover(h, sourceID)
+			return
+		}
+		// Check if retries are exhausted.
+		if h.retries >= w.cfg.MaxRetries {
+			h.state = StateEscalated
+			h.stateEntered = now
+
+			w.log.Error("audio source escalated after max retries",
+				logger.String("source_id", sourceID),
+				logger.Int("retries", h.retries),
+			)
+			_ = errors.Newf("audio source escalated: %s", sourceID).
+				Component("audiocore.liveness").
+				Category(errors.CategoryAudioSource).
+				Context("source_id", sourceID).
+				Context("retries_exhausted", h.retries).
+				Build()
+
+			if w.callbacks.Escalate != nil {
+				w.callbacks.Escalate(sourceID)
+			}
+			if w.callbacks.Notify != nil {
+				w.callbacks.Notify(sourceID, StateEscalated, "retries exhausted")
+			}
+			return
+		}
+		// Wait for backoff before retrying.
+		if now.Sub(h.lastRestart) < w.cfg.RetryBackoff {
+			return
+		}
+		w.attemptRestart(h, sourceID)
+
+	case StateEscalated:
+		if framesFlowing {
+			w.recover(h, sourceID)
+			return
+		}
+		if now.Sub(h.stateEntered) >= w.cfg.EscalationTimeout {
+			h.state = StateFailed
+			h.stateEntered = now
+
+			w.log.Error("audio source failed",
+				logger.String("source_id", sourceID),
+			)
+			if w.callbacks.Notify != nil {
+				w.callbacks.Notify(sourceID, StateFailed, "escalation timeout elapsed")
+			}
+		}
+
+	case StateFailed:
+		// Terminal state, but recovery is still possible if frames resume.
+		if framesFlowing {
+			w.recover(h, sourceID)
+		}
+	}
+}
+
+// attemptRestart calls the RestartSource callback and updates retry tracking.
+// The caller must hold w.mu.
+func (w *LivenessWatchdog) attemptRestart(h *sourceHealth, sourceID string) {
+	h.retries++
+	h.lastRestart = time.Now()
+
+	w.log.Info("attempting source restart",
+		logger.String("source_id", sourceID),
+		logger.Int("retry", h.retries),
+		logger.Int("max_retries", w.cfg.MaxRetries),
+	)
+
+	if w.callbacks.RestartSource != nil {
+		if err := w.callbacks.RestartSource(sourceID); err != nil {
+			w.log.Error("source restart failed",
+				logger.String("source_id", sourceID),
+				logger.Error(err),
+			)
+		}
+	}
+}
+
+// recover transitions a source back to HEALTHY with a cooldown period.
+// The caller must hold w.mu.
+func (w *LivenessWatchdog) recover(h *sourceHealth, sourceID string) {
+	prevState := h.state
+	h.state = StateHealthy
+	h.stateEntered = time.Now()
+	h.cooldownEnd = time.Now().Add(w.cfg.CooldownAfterRecov)
+	h.retries = 0
+
+	w.log.Info("audio source recovered",
+		logger.String("source_id", sourceID),
+		logger.String("from_state", prevState.String()),
+	)
+
+	if w.callbacks.Notify != nil {
+		w.callbacks.Notify(sourceID, StateHealthy, "recovered")
+	}
+}

--- a/internal/audiocore/liveness.go
+++ b/internal/audiocore/liveness.go
@@ -123,6 +123,22 @@ type LivenessCallbacks struct {
 	IsQuietHours func(sourceID string) bool
 }
 
+// livenessAction describes a callback to execute outside the mutex.
+type livenessAction struct {
+	sourceID string
+	kind     actionKind
+	state    LivenessState
+	msg      string
+}
+
+type actionKind int
+
+const (
+	actionNotify actionKind = iota
+	actionRestart
+	actionEscalate
+)
+
 // LivenessWatchdog monitors audio sources for silence and drives a tiered
 // recovery state machine. It queries the AudioRouter for frame timestamps
 // and invokes callbacks for restart/escalation/notification.
@@ -205,7 +221,9 @@ func (w *LivenessWatchdog) run(ctx context.Context) {
 	}
 }
 
-// checkAll evaluates every active source and cleans up stale entries.
+// checkAll evaluates every active source, collects pending actions under the
+// mutex, then executes callbacks (restart, escalate, notify) outside the mutex
+// so that long-running operations like RestartSource do not block Snapshot().
 func (w *LivenessWatchdog) checkAll() {
 	activeIDs := w.router.ActiveSourceIDs()
 	activeSet := make(map[string]struct{}, len(activeIDs))
@@ -213,10 +231,10 @@ func (w *LivenessWatchdog) checkAll() {
 		activeSet[id] = struct{}{}
 	}
 
-	w.mu.Lock()
-	defer w.mu.Unlock()
+	var actions []livenessAction
 
-	// Ensure every active source has a tracking entry.
+	w.mu.Lock()
+
 	now := time.Now()
 	for _, id := range activeIDs {
 		if _, ok := w.sources[id]; !ok {
@@ -227,14 +245,12 @@ func (w *LivenessWatchdog) checkAll() {
 		}
 	}
 
-	// Remove sources that are no longer active.
 	for id := range w.sources {
 		if _, ok := activeSet[id]; !ok {
 			delete(w.sources, id)
 		}
 	}
 
-	// Evaluate each source, handling quiet hours per-source.
 	for _, id := range activeIDs {
 		h := w.sources[id]
 		if h == nil {
@@ -243,7 +259,6 @@ func (w *LivenessWatchdog) checkAll() {
 
 		quietNow := w.callbacks.IsQuietHours != nil && w.callbacks.IsQuietHours(id)
 
-		// Handle per-source quiet hours transition.
 		if h.wasQuietHours && !quietNow {
 			w.router.ResetDispatchTime(id)
 			h.state = StateHealthy
@@ -258,70 +273,72 @@ func (w *LivenessWatchdog) checkAll() {
 			continue
 		}
 
-		w.checkSource(id)
+		actions = w.checkSource(id, now, actions)
 	}
+
+	w.mu.Unlock()
+
+	w.executeActions(actions)
 }
 
-// checkSource drives the state machine for a single source.
-// The caller must hold w.mu.
+// checkSource drives the state machine for a single source. State transitions
+// happen under the mutex; callbacks are collected into actions for deferred
+// execution. The caller must hold w.mu.
 //
 //nolint:gocognit // state machine is inherently complex; splitting would obscure the flow
-func (w *LivenessWatchdog) checkSource(sourceID string) {
+func (w *LivenessWatchdog) checkSource(sourceID string, now time.Time, actions []livenessAction) []livenessAction {
 	h := w.sources[sourceID]
 	if h == nil {
-		return
+		return actions
 	}
 
-	now := time.Now()
 	lastFrame := w.router.LastDispatchTime(sourceID)
-	framesFlowing := !lastFrame.IsZero() && now.Sub(lastFrame) < w.cfg.SilenceThreshold
+
+	// A source that has never dispatched is still initializing; skip it to
+	// avoid false alarms during RTSP connection setup or device enumeration.
+	if lastFrame.IsZero() {
+		return actions
+	}
+
+	framesFlowing := now.Sub(lastFrame) < w.cfg.SilenceThreshold
 
 	switch h.state {
 	case StateHealthy:
 		if framesFlowing {
-			return
+			return actions
 		}
-		// In cooldown after recovery: suppress alarm.
 		if !h.cooldownEnd.IsZero() && now.Before(h.cooldownEnd) {
-			return
+			return actions
 		}
-		// Silence detected.
+
+		silenceDur := now.Sub(lastFrame)
 		h.state = StateAlarmed
 		h.stateEntered = now
 		h.retries = 0
 
 		w.log.Error("audio source silence detected",
 			logger.String("source_id", sourceID),
-			logger.Duration("silence", now.Sub(lastFrame)),
+			logger.Duration("silence", silenceDur),
 		)
-		// Emit Sentry error for observability.
-		_ = errors.Newf("audio source silence detected: %s", sourceID).
-			Component("audiocore.liveness").
-			Category(errors.CategoryAudioSource).
-			Context("source_id", sourceID).
-			Context("silence_duration", now.Sub(lastFrame).String()).
-			Build()
-
-		if w.callbacks.Notify != nil {
-			w.callbacks.Notify(sourceID, StateAlarmed, "silence detected")
-		}
+		actions = append(actions, livenessAction{
+			sourceID: sourceID, kind: actionNotify,
+			state: StateAlarmed, msg: "silence detected",
+		})
 
 	case StateAlarmed:
 		if framesFlowing {
-			w.recover(h, sourceID)
-			return
+			actions = w.collectRecover(h, sourceID, now, actions)
+			return actions
 		}
-		// Transition to RECOVERING and attempt first restart.
 		h.state = StateRecovering
 		h.stateEntered = now
-		w.attemptRestart(h, sourceID)
+		actions = w.collectRestart(h, sourceID, now, actions)
 
 	case StateRecovering:
 		if framesFlowing {
-			w.recover(h, sourceID)
-			return
+			actions = w.collectRecover(h, sourceID, now, actions)
+			return actions
 		}
-		// Check if retries are exhausted.
 		if h.retries >= w.cfg.MaxRetries {
 			h.state = StateEscalated
 			h.stateEntered = now
@@ -337,24 +354,21 @@ func (w *LivenessWatchdog) checkSource(sourceID string) {
 				Context("retries_exhausted", h.retries).
 				Build()
 
-			if w.callbacks.Escalate != nil {
-				w.callbacks.Escalate(sourceID)
-			}
-			if w.callbacks.Notify != nil {
-				w.callbacks.Notify(sourceID, StateEscalated, "retries exhausted")
-			}
-			return
+			actions = append(actions,
+				livenessAction{sourceID: sourceID, kind: actionEscalate},
+				livenessAction{sourceID: sourceID, kind: actionNotify, state: StateEscalated, msg: "retries exhausted"},
+			)
+			return actions
 		}
-		// Wait for backoff before retrying.
 		if now.Sub(h.lastRestart) < w.cfg.RetryBackoff {
-			return
+			return actions
 		}
-		w.attemptRestart(h, sourceID)
+		actions = w.collectRestart(h, sourceID, now, actions)
 
 	case StateEscalated:
 		if framesFlowing {
-			w.recover(h, sourceID)
-			return
+			actions = w.collectRecover(h, sourceID, now, actions)
+			return actions
 		}
 		if now.Sub(h.stateEntered) >= w.cfg.EscalationTimeout {
 			h.state = StateFailed
@@ -363,24 +377,26 @@ func (w *LivenessWatchdog) checkSource(sourceID string) {
 			w.log.Error("audio source failed",
 				logger.String("source_id", sourceID),
 			)
-			if w.callbacks.Notify != nil {
-				w.callbacks.Notify(sourceID, StateFailed, "escalation timeout elapsed")
-			}
+			actions = append(actions, livenessAction{
+				sourceID: sourceID, kind: actionNotify,
+				state: StateFailed, msg: "escalation timeout elapsed",
+			})
 		}
 
 	case StateFailed:
-		// Terminal state, but recovery is still possible if frames resume.
 		if framesFlowing {
-			w.recover(h, sourceID)
+			actions = w.collectRecover(h, sourceID, now, actions)
 		}
 	}
+
+	return actions
 }
 
-// attemptRestart calls the RestartSource callback and updates retry tracking.
+// collectRestart updates retry tracking and appends a restart action.
 // The caller must hold w.mu.
-func (w *LivenessWatchdog) attemptRestart(h *sourceHealth, sourceID string) {
+func (w *LivenessWatchdog) collectRestart(h *sourceHealth, sourceID string, now time.Time, actions []livenessAction) []livenessAction {
 	h.retries++
-	h.lastRestart = time.Now()
+	h.lastRestart = now
 
 	w.log.Info("attempting source restart",
 		logger.String("source_id", sourceID),
@@ -388,23 +404,18 @@ func (w *LivenessWatchdog) attemptRestart(h *sourceHealth, sourceID string) {
 		logger.Int("max_retries", w.cfg.MaxRetries),
 	)
 
-	if w.callbacks.RestartSource != nil {
-		if err := w.callbacks.RestartSource(sourceID); err != nil {
-			w.log.Error("source restart failed",
-				logger.String("source_id", sourceID),
-				logger.Error(err),
-			)
-		}
-	}
+	return append(actions, livenessAction{
+		sourceID: sourceID, kind: actionRestart,
+	})
 }
 
-// recover transitions a source back to HEALTHY with a cooldown period.
+// collectRecover transitions a source back to HEALTHY and appends a notify action.
 // The caller must hold w.mu.
-func (w *LivenessWatchdog) recover(h *sourceHealth, sourceID string) {
+func (w *LivenessWatchdog) collectRecover(h *sourceHealth, sourceID string, now time.Time, actions []livenessAction) []livenessAction {
 	prevState := h.state
 	h.state = StateHealthy
-	h.stateEntered = time.Now()
-	h.cooldownEnd = time.Now().Add(w.cfg.CooldownAfterRecov)
+	h.stateEntered = now
+	h.cooldownEnd = now.Add(w.cfg.CooldownAfterRecov)
 	h.retries = 0
 
 	w.log.Info("audio source recovered",
@@ -412,7 +423,34 @@ func (w *LivenessWatchdog) recover(h *sourceHealth, sourceID string) {
 		logger.String("from_state", prevState.String()),
 	)
 
-	if w.callbacks.Notify != nil {
-		w.callbacks.Notify(sourceID, StateHealthy, "recovered")
+	return append(actions, livenessAction{
+		sourceID: sourceID, kind: actionNotify,
+		state: StateHealthy, msg: "recovered",
+	})
+}
+
+// executeActions runs collected callbacks outside the mutex.
+func (w *LivenessWatchdog) executeActions(actions []livenessAction) {
+	for i := range actions {
+		a := &actions[i]
+		switch a.kind {
+		case actionRestart:
+			if w.callbacks.RestartSource != nil {
+				if err := w.callbacks.RestartSource(a.sourceID); err != nil {
+					w.log.Error("source restart failed",
+						logger.String("source_id", a.sourceID),
+						logger.Error(err),
+					)
+				}
+			}
+		case actionEscalate:
+			if w.callbacks.Escalate != nil {
+				w.callbacks.Escalate(a.sourceID)
+			}
+		case actionNotify:
+			if w.callbacks.Notify != nil {
+				w.callbacks.Notify(a.sourceID, a.state, a.msg)
+			}
+		}
 	}
 }

--- a/internal/audiocore/liveness.go
+++ b/internal/audiocore/liveness.go
@@ -151,8 +151,9 @@ type LivenessWatchdog struct {
 	mu      sync.Mutex
 	sources map[string]*sourceHealth
 
-	cancel context.CancelFunc
-	done   chan struct{}
+	cancel  context.CancelFunc
+	done    chan struct{}
+	started bool
 }
 
 // NewLivenessWatchdog creates a watchdog that is ready to start.
@@ -166,8 +167,17 @@ func NewLivenessWatchdog(cfg LivenessConfig, router *AudioRouter, cb LivenessCal
 	}
 }
 
-// Start launches the monitoring goroutine. It is safe to call Start only once.
+// Start launches the monitoring goroutine. Safe to call multiple times;
+// subsequent calls are no-ops.
 func (w *LivenessWatchdog) Start() {
+	w.mu.Lock()
+	if w.started {
+		w.mu.Unlock()
+		return
+	}
+	w.started = true
+	w.mu.Unlock()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	w.cancel = cancel
 	w.done = make(chan struct{})

--- a/internal/audiocore/liveness_test.go
+++ b/internal/audiocore/liveness_test.go
@@ -1,0 +1,376 @@
+package audiocore
+
+import (
+	"sync"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// nullConsumer implements AudioConsumer with no-op writes.
+// Used to register routes so ActiveSourceIDs returns results.
+type nullConsumer struct {
+	id         string
+	sampleRate int
+}
+
+func (c *nullConsumer) ID() string               { return c.id }
+func (c *nullConsumer) SampleRate() int          { return c.sampleRate }
+func (c *nullConsumer) BitDepth() int            { return 16 }
+func (c *nullConsumer) Channels() int            { return 1 }
+func (c *nullConsumer) Write(_ AudioFrame) error { return nil } //nolint:gocritic // hugeParam: signature required by AudioConsumer interface
+func (c *nullConsumer) Close() error             { return nil }
+
+// fastConfig returns a LivenessConfig with short intervals suitable for
+// deterministic tests under synctest.
+func fastConfig() LivenessConfig {
+	return LivenessConfig{
+		CheckInterval:      100 * time.Millisecond,
+		SilenceThreshold:   300 * time.Millisecond,
+		MaxRetries:         3,
+		RetryBackoff:       100 * time.Millisecond,
+		CooldownAfterRecov: 500 * time.Millisecond,
+		EscalationTimeout:  500 * time.Millisecond,
+	}
+}
+
+// setupRouter creates a router with a single source that has an active route.
+func setupRouter(t *testing.T, sourceID string) *AudioRouter {
+	t.Helper()
+	r := NewAudioRouter(GetLogger(), nil)
+	consumer := &nullConsumer{id: "null-consumer", sampleRate: 48000}
+	err := r.AddRoute(sourceID, consumer, 48000, 0, nil)
+	require.NoError(t, err)
+	return r
+}
+
+// dispatchFrame sends a minimal audio frame through the router, which updates
+// the last dispatch timestamp for the source.
+func dispatchFrame(r *AudioRouter, sourceID string) {
+	r.Dispatch(AudioFrame{
+		SourceID:   sourceID,
+		Data:       []byte{0, 0},
+		SampleRate: 48000,
+		BitDepth:   16,
+		Channels:   1,
+		Timestamp:  time.Now(),
+	})
+}
+
+func TestLiveness_HealthyWithFrames(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		const src = "src-1"
+		r := setupRouter(t, src)
+		defer r.Close()
+
+		cfg := fastConfig()
+		var mu sync.Mutex
+		var lastState LivenessState = -1
+
+		w := NewLivenessWatchdog(cfg, r, LivenessCallbacks{
+			Notify: func(_ string, state LivenessState, _ string) {
+				mu.Lock()
+				lastState = state
+				mu.Unlock()
+			},
+		})
+		w.Start()
+		defer w.Stop()
+
+		// Keep dispatching frames faster than the silence threshold.
+		for range 5 {
+			dispatchFrame(r, src)
+			time.Sleep(cfg.CheckInterval)
+		}
+
+		snaps := w.Snapshot()
+		require.Len(t, snaps, 1)
+		assert.Equal(t, "HEALTHY", snaps[0].State)
+
+		mu.Lock()
+		assert.Equal(t, LivenessState(-1), lastState, "notify should not be called when healthy")
+		mu.Unlock()
+	})
+}
+
+func TestLiveness_SilenceTriggersAlarm(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		const src = "src-1"
+		r := setupRouter(t, src)
+		defer r.Close()
+
+		cfg := fastConfig()
+		restarts := make(chan string, 10)
+
+		w := NewLivenessWatchdog(cfg, r, LivenessCallbacks{
+			RestartSource: func(id string) error {
+				restarts <- id
+				return nil
+			},
+		})
+
+		// Dispatch once to seed the timestamp, then let silence accumulate.
+		dispatchFrame(r, src)
+
+		w.Start()
+		defer w.Stop()
+
+		// Wait past silence threshold + two ticks (alarm then recovering).
+		time.Sleep(cfg.SilenceThreshold + 2*cfg.CheckInterval)
+
+		snaps := w.Snapshot()
+		require.Len(t, snaps, 1)
+		assert.Equal(t, "RECOVERING", snaps[0].State)
+
+		// At least one restart should have been attempted.
+		assert.NotEmpty(t, restarts, "expected at least one restart attempt")
+	})
+}
+
+func TestLiveness_RecoveryAfterRestart(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		const src = "src-1"
+		r := setupRouter(t, src)
+		defer r.Close()
+
+		cfg := fastConfig()
+		var mu sync.Mutex
+		states := make([]LivenessState, 0, 8)
+
+		w := NewLivenessWatchdog(cfg, r, LivenessCallbacks{
+			RestartSource: func(_ string) error { return nil },
+			Notify: func(_ string, state LivenessState, _ string) {
+				mu.Lock()
+				states = append(states, state)
+				mu.Unlock()
+			},
+		})
+
+		// Seed a frame, then let silence build up.
+		dispatchFrame(r, src)
+		w.Start()
+		defer w.Stop()
+
+		// Wait for alarm + recovery attempt.
+		time.Sleep(cfg.SilenceThreshold + 2*cfg.CheckInterval)
+
+		// Resume frames and wait for two ticks so the watchdog sees the fresh frame.
+		dispatchFrame(r, src)
+		time.Sleep(2 * cfg.CheckInterval)
+
+		snaps := w.Snapshot()
+		require.Len(t, snaps, 1)
+		assert.Equal(t, "HEALTHY", snaps[0].State)
+
+		mu.Lock()
+		assert.Contains(t, states, StateHealthy, "should have notified recovery")
+		mu.Unlock()
+	})
+}
+
+func TestLiveness_EscalationAfterMaxRetries(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		const src = "src-1"
+		r := setupRouter(t, src)
+		defer r.Close()
+
+		cfg := fastConfig()
+		cfg.MaxRetries = 2
+		cfg.RetryBackoff = 50 * time.Millisecond
+
+		escalated := make(chan string, 1)
+
+		w := NewLivenessWatchdog(cfg, r, LivenessCallbacks{
+			RestartSource: func(_ string) error { return nil },
+			Escalate: func(id string) {
+				escalated <- id
+			},
+		})
+
+		dispatchFrame(r, src)
+		w.Start()
+		defer w.Stop()
+
+		// Wait long enough for: silence detection + alarm + retries exhausted.
+		// silence threshold + alarm tick + (maxRetries * backoff) + extra ticks
+		waitTime := cfg.SilenceThreshold + cfg.CheckInterval*(time.Duration(cfg.MaxRetries)+5)
+		time.Sleep(waitTime)
+
+		snaps := w.Snapshot()
+		require.Len(t, snaps, 1)
+		assert.Contains(t, []string{"ESCALATED", "FAILED"}, snaps[0].State,
+			"should have escalated or failed after retries exhausted")
+		assert.NotEmpty(t, escalated, "escalate callback should have been called")
+	})
+}
+
+func TestLiveness_FailedAfterEscalationTimeout(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		const src = "src-1"
+		r := setupRouter(t, src)
+		defer r.Close()
+
+		cfg := fastConfig()
+		cfg.MaxRetries = 1
+		cfg.RetryBackoff = 50 * time.Millisecond
+		cfg.EscalationTimeout = 200 * time.Millisecond
+
+		var mu sync.Mutex
+		notifiedStates := make([]LivenessState, 0, 8)
+
+		w := NewLivenessWatchdog(cfg, r, LivenessCallbacks{
+			RestartSource: func(_ string) error { return nil },
+			Escalate:      func(_ string) {},
+			Notify: func(_ string, state LivenessState, _ string) {
+				mu.Lock()
+				notifiedStates = append(notifiedStates, state)
+				mu.Unlock()
+			},
+		})
+
+		dispatchFrame(r, src)
+		w.Start()
+		defer w.Stop()
+
+		// Wait for full progression: alarm -> recovering -> escalated -> failed.
+		waitTime := cfg.SilenceThreshold + cfg.EscalationTimeout +
+			cfg.CheckInterval*20
+		time.Sleep(waitTime)
+
+		snaps := w.Snapshot()
+		require.Len(t, snaps, 1)
+		assert.Equal(t, "FAILED", snaps[0].State)
+
+		mu.Lock()
+		assert.Contains(t, notifiedStates, StateFailed, "should have notified FAILED")
+		mu.Unlock()
+	})
+}
+
+func TestLiveness_QuietHoursSuppressesAlarm(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		const src = "src-1"
+		r := setupRouter(t, src)
+		defer r.Close()
+
+		cfg := fastConfig()
+		notifyCalled := false
+
+		w := NewLivenessWatchdog(cfg, r, LivenessCallbacks{
+			IsQuietHours: func(_ string) bool { return true },
+			Notify: func(_ string, _ LivenessState, _ string) {
+				notifyCalled = true
+			},
+		})
+
+		// Seed a frame, then let silence accumulate during quiet hours.
+		dispatchFrame(r, src)
+		w.Start()
+		defer w.Stop()
+
+		time.Sleep(cfg.SilenceThreshold + 3*cfg.CheckInterval)
+
+		snaps := w.Snapshot()
+		// During quiet hours no sources should be tracked (checkAll returns early).
+		for _, s := range snaps {
+			assert.Equal(t, "HEALTHY", s.State,
+				"no alarm should be raised during quiet hours")
+		}
+		assert.False(t, notifyCalled, "notify should not be called during quiet hours")
+	})
+}
+
+func TestLiveness_QuietHoursEndResetsTimestamp(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		const src = "src-1"
+		r := setupRouter(t, src)
+		defer r.Close()
+
+		cfg := fastConfig()
+		var mu sync.Mutex
+		quiet := true
+
+		w := NewLivenessWatchdog(cfg, r, LivenessCallbacks{
+			IsQuietHours: func(_ string) bool {
+				mu.Lock()
+				defer mu.Unlock()
+				return quiet
+			},
+			RestartSource: func(_ string) error { return nil },
+		})
+
+		// Seed a frame.
+		dispatchFrame(r, src)
+		w.Start()
+		defer w.Stop()
+
+		// Run a few ticks in quiet hours so the frame timestamp gets stale.
+		time.Sleep(cfg.SilenceThreshold + 2*cfg.CheckInterval)
+
+		// Transition out of quiet hours.
+		mu.Lock()
+		quiet = false
+		mu.Unlock()
+
+		// After transition, dispatch time should be reset. The source should
+		// stay healthy because the watchdog reset timestamps.
+		time.Sleep(2 * cfg.CheckInterval)
+
+		snaps := w.Snapshot()
+		require.Len(t, snaps, 1)
+		assert.Equal(t, "HEALTHY", snaps[0].State,
+			"source should be healthy after quiet hours end with reset timestamp")
+	})
+}
+
+func TestLiveness_SnapshotIsEmpty(t *testing.T) {
+	r := NewAudioRouter(GetLogger(), nil)
+	defer r.Close()
+
+	w := NewLivenessWatchdog(DefaultLivenessConfig(), r, LivenessCallbacks{})
+	snaps := w.Snapshot()
+	assert.Empty(t, snaps, "snapshot should be empty when no sources are tracked")
+}
+
+func TestLiveness_RecoveryFromFailed(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		const src = "src-1"
+		r := setupRouter(t, src)
+		defer r.Close()
+
+		cfg := fastConfig()
+		cfg.MaxRetries = 1
+		cfg.RetryBackoff = 50 * time.Millisecond
+		cfg.EscalationTimeout = 200 * time.Millisecond
+
+		w := NewLivenessWatchdog(cfg, r, LivenessCallbacks{
+			RestartSource: func(_ string) error { return nil },
+			Escalate:      func(_ string) {},
+		})
+
+		dispatchFrame(r, src)
+		w.Start()
+		defer w.Stop()
+
+		// Wait for FAILED state.
+		waitTime := cfg.SilenceThreshold + cfg.EscalationTimeout +
+			cfg.CheckInterval*20
+		time.Sleep(waitTime)
+
+		snaps := w.Snapshot()
+		require.Len(t, snaps, 1)
+		require.Equal(t, "FAILED", snaps[0].State, "should reach FAILED first")
+
+		// Resume frames and verify recovery.
+		dispatchFrame(r, src)
+		time.Sleep(2 * cfg.CheckInterval)
+
+		snaps = w.Snapshot()
+		require.Len(t, snaps, 1)
+		assert.Equal(t, "HEALTHY", snaps[0].State,
+			"should recover from FAILED when frames resume")
+	})
+}

--- a/internal/audiocore/liveness_test.go
+++ b/internal/audiocore/liveness_test.go
@@ -257,12 +257,15 @@ func TestLiveness_QuietHoursSuppressesAlarm(t *testing.T) {
 		defer r.Close()
 
 		cfg := fastConfig()
+		var mu sync.Mutex
 		notifyCalled := false
 
 		w := NewLivenessWatchdog(cfg, r, LivenessCallbacks{
 			IsQuietHours: func(_ string) bool { return true },
 			Notify: func(_ string, _ LivenessState, _ string) {
+				mu.Lock()
 				notifyCalled = true
+				mu.Unlock()
 			},
 		})
 
@@ -274,12 +277,13 @@ func TestLiveness_QuietHoursSuppressesAlarm(t *testing.T) {
 		time.Sleep(cfg.SilenceThreshold + 3*cfg.CheckInterval)
 
 		snaps := w.Snapshot()
-		// During quiet hours no sources should be tracked (checkAll returns early).
 		for _, s := range snaps {
 			assert.Equal(t, "HEALTHY", s.State,
 				"no alarm should be raised during quiet hours")
 		}
+		mu.Lock()
 		assert.False(t, notifyCalled, "notify should not be called during quiet hours")
+		mu.Unlock()
 	})
 }
 

--- a/internal/audiocore/router.go
+++ b/internal/audiocore/router.go
@@ -4,7 +4,9 @@ package audiocore
 import (
 	"context"
 	"fmt"
+	"maps"
 	"math"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -141,6 +143,10 @@ type AudioRouter struct {
 	// ctx and cancel control the lifetime of all drainer goroutines.
 	ctx    context.Context
 	cancel context.CancelFunc
+
+	// lastDispatch stores the most recent Dispatch timestamp per source ID.
+	// Key: string (sourceID), Value: *atomic.Int64 (UnixNano).
+	lastDispatch sync.Map
 }
 
 // NewAudioRouter creates an AudioRouter ready to accept routes and dispatch
@@ -340,6 +346,9 @@ func (r *AudioRouter) Dispatch(frame AudioFrame) { //nolint:gocritic // hugePara
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
+	// Record frame arrival for liveness monitoring.
+	r.getOrCreateDispatchTimestamp(frame.SourceID).Store(time.Now().UnixNano())
+
 	for _, rt := range r.routes[frame.SourceID] {
 		// Retain BEFORE attempting the send so the drainer cannot observe a
 		// stale zero count and release the slice prematurely. If the send
@@ -412,6 +421,47 @@ func (r *AudioRouter) Routes(sourceID string) []RouteInfo {
 		})
 	}
 	return infos
+}
+
+// LastDispatchTime returns the last time Dispatch was called for sourceID.
+// Returns zero time if the source has never dispatched.
+func (r *AudioRouter) LastDispatchTime(sourceID string) time.Time {
+	if v, ok := r.lastDispatch.Load(sourceID); ok {
+		nanos := v.(*atomic.Int64).Load()
+		if nanos > 0 {
+			return time.Unix(0, nanos)
+		}
+	}
+	return time.Time{}
+}
+
+// ResetDispatchTime sets the last dispatch time for sourceID to now.
+// Used when quiet hours end to avoid false alarms from stale timestamps.
+func (r *AudioRouter) ResetDispatchTime(sourceID string) {
+	ts := r.getOrCreateDispatchTimestamp(sourceID)
+	ts.Store(time.Now().UnixNano())
+}
+
+// ClearDispatchTime removes the dispatch timestamp for sourceID.
+// Called when a source is permanently removed.
+func (r *AudioRouter) ClearDispatchTime(sourceID string) {
+	r.lastDispatch.Delete(sourceID)
+}
+
+// ActiveSourceIDs returns the source IDs that have active routes.
+func (r *AudioRouter) ActiveSourceIDs() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return slices.Collect(maps.Keys(r.routes))
+}
+
+func (r *AudioRouter) getOrCreateDispatchTimestamp(sourceID string) *atomic.Int64 {
+	if v, ok := r.lastDispatch.Load(sourceID); ok {
+		return v.(*atomic.Int64)
+	}
+	ts := &atomic.Int64{}
+	actual, _ := r.lastDispatch.LoadOrStore(sourceID, ts)
+	return actual.(*atomic.Int64)
 }
 
 // Close stops all drainer goroutines and closes every registered consumer.

--- a/internal/audiocore/router.go
+++ b/internal/audiocore/router.go
@@ -278,6 +278,8 @@ func (r *AudioRouter) RemoveAllRoutes(sourceID string) {
 		r.stopRoute(rt)
 	}
 
+	r.ClearDispatchTime(sourceID)
+
 	if len(routes) > 0 {
 		r.log.Info("all routes removed",
 			logger.String("source_id", sourceID),

--- a/internal/audiocore/router_liveness_test.go
+++ b/internal/audiocore/router_liveness_test.go
@@ -1,0 +1,60 @@
+package audiocore
+
+import (
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRouter_LastDispatchTime_NoDispatch(t *testing.T) {
+	r := NewAudioRouter(GetLogger(), nil)
+	defer r.Close()
+
+	ts := r.LastDispatchTime("nonexistent")
+	assert.True(t, ts.IsZero(), "expected zero time for unknown source")
+}
+
+func TestRouter_LastDispatchTime_AfterDispatch(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		r := NewAudioRouter(GetLogger(), nil)
+		defer r.Close()
+
+		frame := AudioFrame{SourceID: "test-src", Data: []byte{0, 0}}
+		r.Dispatch(frame)
+
+		ts := r.LastDispatchTime("test-src")
+		require.False(t, ts.IsZero(), "expected non-zero time after dispatch")
+		assert.WithinDuration(t, time.Now(), ts, time.Second)
+	})
+}
+
+func TestRouter_ResetDispatchTime(t *testing.T) {
+	r := NewAudioRouter(GetLogger(), nil)
+	defer r.Close()
+
+	r.ResetDispatchTime("src-1")
+	ts := r.LastDispatchTime("src-1")
+	require.False(t, ts.IsZero())
+	assert.WithinDuration(t, time.Now(), ts, time.Second)
+}
+
+func TestRouter_ClearDispatchTime(t *testing.T) {
+	r := NewAudioRouter(GetLogger(), nil)
+	defer r.Close()
+
+	r.ResetDispatchTime("src-1")
+	require.False(t, r.LastDispatchTime("src-1").IsZero())
+
+	r.ClearDispatchTime("src-1")
+	assert.True(t, r.LastDispatchTime("src-1").IsZero())
+}
+
+func TestRouter_ActiveSourceIDs(t *testing.T) {
+	r := NewAudioRouter(GetLogger(), nil)
+	defer r.Close()
+
+	assert.Empty(t, r.ActiveSourceIDs())
+}

--- a/internal/audiocore/router_liveness_test.go
+++ b/internal/audiocore/router_liveness_test.go
@@ -57,4 +57,26 @@ func TestRouter_ActiveSourceIDs(t *testing.T) {
 	defer r.Close()
 
 	assert.Empty(t, r.ActiveSourceIDs())
+
+	consumer := &nullConsumer{id: "test-consumer", sampleRate: 48000}
+	require.NoError(t, r.AddRoute("src-1", consumer, 48000, 0, nil))
+
+	ids := r.ActiveSourceIDs()
+	assert.Len(t, ids, 1)
+	assert.Contains(t, ids, "src-1")
+}
+
+func TestRouter_ClearDispatchTime_OnRemoveAllRoutes(t *testing.T) {
+	r := NewAudioRouter(GetLogger(), nil)
+	defer r.Close()
+
+	consumer := &nullConsumer{id: "test-consumer", sampleRate: 48000}
+	require.NoError(t, r.AddRoute("src-1", consumer, 48000, 0, nil))
+
+	r.Dispatch(AudioFrame{SourceID: "src-1", Data: []byte{0, 0}})
+	require.False(t, r.LastDispatchTime("src-1").IsZero())
+
+	r.RemoveAllRoutes("src-1")
+	assert.True(t, r.LastDispatchTime("src-1").IsZero(),
+		"dispatch timestamp should be cleared when all routes are removed")
 }


### PR DESCRIPTION
## Summary

- Add per-source dispatch timestamp tracking in `AudioRouter.Dispatch()` via atomic `sync.Map` entries, enabling external watchdogs to detect when audio frames stop flowing
- Implement `LivenessWatchdog` with a per-source state machine (HEALTHY -> ALARMED -> RECOVERING -> ESCALATED -> FAILED) that detects silent audio capture death and orchestrates tiered recovery: single-source restart, then full app restart, then terminal failure with notification at every step
- Add `RestartSource()` to `AudioPipelineService` for single-source teardown and reinit following the established `reconfigureChangedSources` cleanup pattern
- Wire watchdog into pipeline `Start()`/`Stop()` with callbacks for restart, escalation (via `restartChan`), notification (via `notification.Service`), and per-source quiet hours awareness (`IsSoundCardSuppressed`/`GetSuppressedStreams`)
- Add `GET /api/v2/health/audio` endpoint exposing per-source watchdog state, retry count, and last dispatch time (auth-protected)
- Callbacks execute outside the watchdog mutex to prevent blocking the health API during long-running restart operations

## Background

Production incident on 2026-05-16: the miniaudio C audio thread stopped invoking the Go callback after USB URB failures. The service remained running (systemd active, web UI responsive) but produced zero detections for 4+ hours with no error logged and no alert fired. This watchdog detects the silence and recovers automatically.

## Test Plan

- [x] 9 synctest-based unit tests covering all state machine transitions (alarm, recovery, escalation, failure, quiet hours suppression, quiet hours end reset, recovery from failed)
- [x] 7 router liveness tests (dispatch timestamps, reset, clear, active source IDs with routes, ClearDispatchTime on RemoveAllRoutes)
- [x] 2 API endpoint tests (no watchdog, with watchdog)
- [x] Full test suites pass: audiocore (758), analysis (1601), api/v2 (1929)
- [x] Zero linter issues (`golangci-lint run -v`)
- [x] Gate review passed (3 Claude agents + Gemini cross-validation)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an audio health endpoint returning per-source status snapshots.
  * Introduced a liveness watchdog with silence detection, notifications, automatic per-source restarts, retry/backoff, escalation on persistent failure, cooldown after recovery, and quiet‑hours suppression.
  * Router now tracks per-source dispatch activity and exposes reset/clear APIs to support health monitoring and quiet‑hours behavior.

* **Tests**
  * Added comprehensive tests for the audio health endpoint, watchdog state transitions, per-source restart/escalation behavior, router timestamp handling, and quiet‑hours scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3106?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->