### PR TITLE
refactor(inference): consolidate range filter methods and expose batch return type

### DIFF
--- a/internal/inference/onnx.go
+++ b/internal/inference/onnx.go
@@ -198,17 +198,14 @@ type ONNXRangeFilterOptions struct {
 	Labels []string
 }
 
-// Compile-time check: onnxRangeFilter satisfies BatchRangeFilter.
-var _ BatchRangeFilter = (*onnxRangeFilter)(nil)
-
-// onnxRangeFilter implements RangeFilter using an ONNX Runtime session.
+// onnxRangeFilter implements BatchRangeFilter using an ONNX Runtime session.
 type onnxRangeFilter struct {
 	filter     *ort.RangeFilter
 	numSpecies int
 }
 
-// NewONNXRangeFilter creates a RangeFilter backed by an ONNX Runtime meta model.
-func NewONNXRangeFilter(modelPath string, opts ONNXRangeFilterOptions) (RangeFilter, error) {
+// NewONNXRangeFilter creates a BatchRangeFilter backed by an ONNX Runtime meta model.
+func NewONNXRangeFilter(modelPath string, opts ONNXRangeFilterOptions) (BatchRangeFilter, error) {
 	if len(opts.Labels) == 0 {
 		return nil, fmt.Errorf("ONNX range filter requires labels")
 	}

--- a/internal/inference/onnx/rangefilter.go
+++ b/internal/inference/onnx/rangefilter.go
@@ -9,11 +9,9 @@ import (
 
 // RangeFilter uses the BirdNET meta model to filter species by geographic location and date.
 type RangeFilter struct {
-	session    *ort.DynamicAdvancedSession
-	labels     []string
-	threshold  float32
-	inputName  string
-	outputName string
+	session   *ort.DynamicAdvancedSession
+	labels    []string
+	threshold float32
 }
 
 // NewRangeFilter creates a new RangeFilter from a BirdNET meta model ONNX file.
@@ -83,11 +81,9 @@ func NewRangeFilter(modelPath string, opts ...RangeFilterOption) (*RangeFilter, 
 	}
 
 	return &RangeFilter{
-		session:    session,
-		labels:     labels,
-		threshold:  cfg.threshold,
-		inputName:  inputNames[0],
-		outputName: outputNames[0],
+		session:   session,
+		labels:    labels,
+		threshold: cfg.threshold,
 	}, nil
 }
 
@@ -103,37 +99,9 @@ func resolveRangeFilterLabels(cfg *rangeFilterConfig) ([]string, error) {
 
 // PredictRaw runs inference and returns raw species occurrence scores as a flat []float32 slice.
 // This is used by adapters that handle their own label pairing and filtering.
+// Delegates to PredictBatchRaw with batchSize=1.
 func (r *RangeFilter) PredictRaw(latitude, longitude, week float32) ([]float32, error) {
-	if r.session == nil {
-		return nil, ErrSessionClosed
-	}
-	input := []float32{latitude, longitude, week}
-
-	inputTensor, err := ort.NewTensor(ort.NewShape(1, 3), input)
-	if err != nil {
-		return nil, fmt.Errorf("birdnet: failed to create range filter input tensor: %w", err)
-	}
-	defer func() { _ = inputTensor.Destroy() }()
-
-	outputTensor, err := ort.NewEmptyTensor[float32](ort.NewShape(1, int64(len(r.labels))))
-	if err != nil {
-		return nil, fmt.Errorf("birdnet: failed to create range filter output tensor: %w", err)
-	}
-	defer func() { _ = outputTensor.Destroy() }()
-
-	err = r.session.Run([]ort.Value{inputTensor}, []ort.Value{outputTensor})
-	if err != nil {
-		return nil, fmt.Errorf("birdnet: range filter inference failed: %w", err)
-	}
-
-	data := outputTensor.GetData()
-	numSpecies := len(r.labels)
-	if len(data) < numSpecies {
-		return nil, fmt.Errorf("birdnet: range filter output has %d values but %d labels were provided", len(data), numSpecies)
-	}
-	scores := make([]float32, numSpecies)
-	copy(scores, data[:numSpecies])
-	return scores, nil
+	return r.PredictBatchRaw([]float32{latitude, longitude, week}, 1)
 }
 
 // PredictBatchRaw runs inference on multiple location/week inputs in a single batch.
@@ -180,10 +148,8 @@ func (r *RangeFilter) PredictBatchRaw(inputs []float32, batchSize int) ([]float3
 }
 
 // Predict runs the range filter and returns labeled species occurrence scores.
+// Delegates to PredictRaw for inference, then pairs results with labels.
 func (r *RangeFilter) Predict(latitude, longitude float32, month, day int) ([]LocationScore, error) {
-	if r.session == nil {
-		return nil, ErrSessionClosed
-	}
 	if err := ValidateCoordinates(latitude, longitude); err != nil {
 		return nil, err
 	}
@@ -192,34 +158,16 @@ func (r *RangeFilter) Predict(latitude, longitude float32, month, day int) ([]Lo
 	}
 
 	week := CalculateWeek(month, day)
-	input := []float32{latitude, longitude, week}
-
-	inputTensor, err := ort.NewTensor(ort.NewShape(1, 3), input)
+	rawScores, err := r.PredictRaw(latitude, longitude, week)
 	if err != nil {
-		return nil, fmt.Errorf("birdnet: failed to create range filter input tensor: %w", err)
-	}
-	defer func() { _ = inputTensor.Destroy() }()
-
-	outputTensor, err := ort.NewEmptyTensor[float32](ort.NewShape(1, int64(len(r.labels))))
-	if err != nil {
-		return nil, fmt.Errorf("birdnet: failed to create range filter output tensor: %w", err)
-	}
-	defer func() { _ = outputTensor.Destroy() }()
-
-	err = r.session.Run([]ort.Value{inputTensor}, []ort.Value{outputTensor})
-	if err != nil {
-		return nil, fmt.Errorf("birdnet: range filter inference failed: %w", err)
+		return nil, err
 	}
 
-	data := outputTensor.GetData()
-	if len(data) < len(r.labels) {
-		return nil, fmt.Errorf("birdnet: range filter output has %d values but %d labels were provided", len(data), len(r.labels))
-	}
 	scores := make([]LocationScore, len(r.labels))
 	for i, label := range r.labels {
 		scores[i] = LocationScore{
 			Species: label,
-			Score:   data[i],
+			Score:   rawScores[i],
 			Index:   i,
 		}
 	}
@@ -350,7 +298,11 @@ type rangeFilterConfig struct {
 
 // WithRangeFilterLabels provides labels directly.
 func WithRangeFilterLabels(labels []string) RangeFilterOption {
-	return func(c *rangeFilterConfig) { c.labels = labels }
+	return func(c *rangeFilterConfig) {
+		cp := make([]string, len(labels))
+		copy(cp, labels)
+		c.labels = cp
+	}
 }
 
 // WithRangeFilterLabelsPath loads labels from a file.

--- a/internal/inference/onnx/rangefilter_integration_test.go
+++ b/internal/inference/onnx/rangefilter_integration_test.go
@@ -198,8 +198,7 @@ func BenchmarkPredictBatchRaw(b *testing.B) {
 
 	b.Run("Sequential_500", func(b *testing.B) {
 		b.ReportAllocs()
-		b.ResetTimer()
-		for range b.N {
+		for b.Loop() {
 			for _, p := range points {
 				_, err := rf.PredictRaw(p.lat, p.lon, p.week)
 				if err != nil {
@@ -211,8 +210,7 @@ func BenchmarkPredictBatchRaw(b *testing.B) {
 
 	b.Run("Batch_500", func(b *testing.B) {
 		b.ReportAllocs()
-		b.ResetTimer()
-		for range b.N {
+		for b.Loop() {
 			_, err := rf.PredictBatchRaw(batchInput, batchSize)
 			if err != nil {
 				b.Fatal(err)

--- a/internal/inference/onnx/rangefilter_integration_test.go
+++ b/internal/inference/onnx/rangefilter_integration_test.go
@@ -1,0 +1,222 @@
+//go:build onnx
+
+package onnx
+
+import (
+	"math"
+	"math/rand/v2"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	defaultGeomodelPath = "testdata/geomodel.onnx"
+	defaultLabelsPath   = "testdata/labels.txt"
+	envGeomodelPath     = "BIRDNET_GEOMODEL_PATH"
+	envLabelsPath       = "BIRDNET_GEOMODEL_LABELS_PATH"
+)
+
+func geomodelPath(t *testing.T) string {
+	t.Helper()
+	if p := os.Getenv(envGeomodelPath); p != "" {
+		return p
+	}
+	return defaultGeomodelPath
+}
+
+func labelsPath(t *testing.T) string {
+	t.Helper()
+	if p := os.Getenv(envLabelsPath); p != "" {
+		return p
+	}
+	return defaultLabelsPath
+}
+
+func skipIfNoModel(t *testing.T) {
+	t.Helper()
+	path := geomodelPath(t)
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		t.Skipf("geomodel not found at %s (set %s to override)", path, envGeomodelPath)
+	}
+	lpath := labelsPath(t)
+	if _, err := os.Stat(lpath); os.IsNotExist(err) {
+		t.Skipf("labels not found at %s (set %s to override)", lpath, envLabelsPath)
+	}
+}
+
+func loadTestRangeFilter(t *testing.T) *RangeFilter {
+	t.Helper()
+	skipIfNoModel(t)
+
+	MustInitORT("")
+	t.Cleanup(func() { _ = DestroyORT() })
+
+	rf, err := NewRangeFilter(geomodelPath(t),
+		WithRangeFilterLabelsPath(labelsPath(t)),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = rf.Close() })
+	return rf
+}
+
+func TestPredictBatchRaw_MatchesSinglePredict(t *testing.T) {
+	rf := loadTestRangeFilter(t)
+
+	const numPoints = 10
+	type point struct {
+		lat, lon, week float32
+	}
+
+	rng := rand.New(rand.NewPCG(42, 0))
+	points := make([]point, numPoints)
+	for i := range points {
+		points[i] = point{
+			lat:  rng.Float32()*180 - 90,
+			lon:  rng.Float32()*360 - 180,
+			week: float32(rng.IntN(48) + 1),
+		}
+	}
+
+	singleResults := make([][]float32, numPoints)
+	for i, p := range points {
+		scores, err := rf.PredictRaw(p.lat, p.lon, p.week)
+		require.NoError(t, err, "PredictRaw failed for point %d", i)
+		singleResults[i] = scores
+	}
+
+	batchInput := make([]float32, 0, numPoints*3)
+	for _, p := range points {
+		batchInput = append(batchInput, p.lat, p.lon, p.week)
+	}
+	batchScores, err := rf.PredictBatchRaw(batchInput, numPoints)
+	require.NoError(t, err)
+
+	numSpecies := len(rf.labels)
+	for i := range numPoints {
+		start := i * numSpecies
+		end := start + numSpecies
+		batchSlice := batchScores[start:end]
+
+		for j := range numSpecies {
+			diff := float64(batchSlice[j] - singleResults[i][j])
+			assert.LessOrEqual(t, math.Abs(diff), 1e-6,
+				"point %d, species %d: batch=%.8f, single=%.8f",
+				i, j, batchSlice[j], singleResults[i][j])
+		}
+	}
+}
+
+func TestPredictBatchRaw_SingleElement(t *testing.T) {
+	rf := loadTestRangeFilter(t)
+
+	lat, lon, week := float32(60.17), float32(24.94), float32(20)
+
+	singleScores, err := rf.PredictRaw(lat, lon, week)
+	require.NoError(t, err)
+
+	batchScores, err := rf.PredictBatchRaw([]float32{lat, lon, week}, 1)
+	require.NoError(t, err)
+
+	require.Equal(t, len(singleScores), len(batchScores))
+	for i := range singleScores {
+		diff := float64(batchScores[i] - singleScores[i])
+		assert.LessOrEqual(t, math.Abs(diff), 1e-6,
+			"species %d: batch=%.8f, single=%.8f",
+			i, batchScores[i], singleScores[i])
+	}
+}
+
+func TestPredict_DelegationChain(t *testing.T) {
+	rf := loadTestRangeFilter(t)
+
+	lat, lon := float32(60.17), float32(24.94)
+	month, day := 6, 15
+
+	scores, err := rf.Predict(lat, lon, month, day)
+	require.NoError(t, err)
+	require.Equal(t, len(rf.labels), len(scores))
+
+	week := CalculateWeek(month, day)
+	rawScores, err := rf.PredictRaw(lat, lon, week)
+	require.NoError(t, err)
+
+	for i, ls := range scores {
+		assert.Equal(t, rf.labels[i], ls.Species, "species mismatch at index %d", i)
+		assert.Equal(t, i, ls.Index, "index mismatch at index %d", i)
+		diff := float64(ls.Score - rawScores[i])
+		assert.LessOrEqual(t, math.Abs(diff), 1e-6,
+			"score mismatch at index %d: predict=%.8f, raw=%.8f",
+			i, ls.Score, rawScores[i])
+	}
+}
+
+func BenchmarkPredictBatchRaw(b *testing.B) {
+	path := os.Getenv(envGeomodelPath)
+	if path == "" {
+		path = defaultGeomodelPath
+	}
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		b.Skipf("geomodel not found at %s", path)
+	}
+	lpath := os.Getenv(envLabelsPath)
+	if lpath == "" {
+		lpath = defaultLabelsPath
+	}
+	if _, err := os.Stat(lpath); os.IsNotExist(err) {
+		b.Skipf("labels not found at %s", lpath)
+	}
+
+	MustInitORT("")
+	b.Cleanup(func() { _ = DestroyORT() })
+
+	rf, err := NewRangeFilter(path, WithRangeFilterLabelsPath(lpath))
+	require.NoError(b, err)
+	b.Cleanup(func() { _ = rf.Close() })
+
+	const batchSize = 500
+	rng := rand.New(rand.NewPCG(42, 0))
+
+	type point struct {
+		lat, lon, week float32
+	}
+	points := make([]point, batchSize)
+	for i := range points {
+		points[i] = point{
+			lat:  rng.Float32()*180 - 90,
+			lon:  rng.Float32()*360 - 180,
+			week: float32(rng.IntN(48) + 1),
+		}
+	}
+
+	batchInput := make([]float32, 0, batchSize*3)
+	for _, p := range points {
+		batchInput = append(batchInput, p.lat, p.lon, p.week)
+	}
+
+	b.Run("Sequential_500", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for range b.N {
+			for _, p := range points {
+				_, err := rf.PredictRaw(p.lat, p.lon, p.week)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		}
+	})
+
+	b.Run("Batch_500", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for range b.N {
+			_, err := rf.PredictBatchRaw(batchInput, batchSize)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- **PredictRaw** now delegates to `PredictBatchRaw` with `batchSize=1`, eliminating ~25 lines of duplicated tensor creation boilerplate
- **Predict** now delegates to `PredictRaw`, eliminating another ~25 lines of duplication; all three methods flow through a single inference path
- **NewONNXRangeFilter** returns `BatchRangeFilter` instead of `RangeFilter`, making batch capability visible to callers without type assertions (prerequisite for the heatmap API)
- Bonus cleanup from gate review: removed unused `inputName`/`outputName` struct fields, added defensive slice copying in `WithRangeFilterLabels`
- Added ONNX integration tests behind `//go:build onnx` build tag: batch-vs-single equivalence, single-element batch, `Predict` delegation chain, and batch throughput benchmark

## Test plan

- [x] All 580 existing unit tests pass (`go test -race ./internal/inference/... ./internal/classifier/...`)
- [x] `golangci-lint run -v` clean
- [x] `go vet -tags onnx` clean
- [x] Integration tests compile with `//go:build onnx` tag
- [ ] CI passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit batch-processing support for range-filter inference.

* **Tests**
  * Added integration tests ensuring batch and single-item predictions match.
  * Added benchmarks comparing sequential vs. batched inference performance.

* **Refactor**
  * Prediction logic unified to use batched inference; label handling now copies input slices to avoid shared-mutation issues.

* **Breaking Change**
  * Constructor now returns the batch-capable range filter type (API update).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3108?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->