### PR TITLE
fix(inference): export LoadLabels and replace magic threshold constant

### DIFF
--- a/internal/classifier/model_onnx.go
+++ b/internal/classifier/model_onnx.go
@@ -1,14 +1,13 @@
 package classifier
 
 import (
-	"bufio"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/errors"
 	"github.com/tphakala/birdnet-go/internal/inference"
+	onnx "github.com/tphakala/birdnet-go/internal/inference/onnx"
 	"github.com/tphakala/birdnet-go/internal/logger"
 )
 
@@ -145,7 +144,7 @@ func (bn *BirdNET) initializeV3GeoModel() error {
 
 	// Load geomodel labels from file
 	log.Debug("V3 geomodel: loading labels", logger.String("path", labelsPath))
-	geoLabels, err := loadLabelsFromFile(labelsPath)
+	geoLabels, err := onnx.LoadLabels(labelsPath)
 	if err != nil {
 		return errors.New(err).
 			Category(errors.CategoryModelInit).
@@ -203,26 +202,4 @@ func (bn *BirdNET) initializeV3GeoModel() error {
 
 	bn.rangeFilter = mapped
 	return nil
-}
-
-// loadLabelsFromFile reads species labels from a text file, one per line.
-func loadLabelsFromFile(path string) ([]string, error) {
-	f, err := os.Open(path) //nolint:gosec // G304: path is from application settings
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = f.Close() }()
-
-	var labels []string
-	scanner := bufio.NewScanner(f)
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		if line != "" {
-			labels = append(labels, line)
-		}
-	}
-	if err := scanner.Err(); err != nil {
-		return nil, err
-	}
-	return labels, nil
 }

--- a/internal/inference/onnx/classifier.go
+++ b/internal/inference/onnx/classifier.go
@@ -228,7 +228,7 @@ func resolveLabels(cfg *classifierConfig) ([]string, error) {
 		return cfg.labels, nil
 	}
 	if cfg.labelsPath != "" {
-		return loadLabels(cfg.labelsPath)
+		return LoadLabels(cfg.labelsPath)
 	}
 	return nil, ErrLabelsRequired
 }

--- a/internal/inference/onnx/custom_classifier.go
+++ b/internal/inference/onnx/custom_classifier.go
@@ -100,7 +100,7 @@ func (b *CustomClassifierBuilder) Build() (*CustomClassifier, error) {
 	case len(b.labels) > 0:
 		labels = b.labels
 	case b.labelsPath != "":
-		labels, err = loadLabels(b.labelsPath)
+		labels, err = LoadLabels(b.labelsPath)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/inference/onnx/labels.go
+++ b/internal/inference/onnx/labels.go
@@ -11,8 +11,9 @@ import (
 	"strings"
 )
 
-// LoadLabels reads species labels from a file. Supports .txt (one per line),
-// .csv (auto-detects label column), and .json (array or object formats).
+// LoadLabels reads species labels from a file. Supports .csv (auto-detects
+// label column) and .json (array or object formats). Files with .txt or
+// unknown/missing extensions are parsed as plain text (one label per line).
 func LoadLabels(path string) ([]string, error) {
 	data, err := os.ReadFile(path) //nolint:gosec // Path provided by caller
 	if err != nil {

--- a/internal/inference/onnx/labels.go
+++ b/internal/inference/onnx/labels.go
@@ -11,7 +11,9 @@ import (
 	"strings"
 )
 
-func loadLabels(path string) ([]string, error) {
+// LoadLabels reads species labels from a file. Supports .txt (one per line),
+// .csv (auto-detects label column), and .json (array or object formats).
+func LoadLabels(path string) ([]string, error) {
 	data, err := os.ReadFile(path) //nolint:gosec // Path provided by caller
 	if err != nil {
 		return nil, &LabelLoadError{Path: path, Reason: err.Error()}

--- a/internal/inference/onnx/labels.go
+++ b/internal/inference/onnx/labels.go
@@ -28,14 +28,12 @@ func LoadLabels(path string) ([]string, error) {
 
 func loadLabelsFromBytes(data []byte, ext string) ([]string, error) {
 	switch ext {
-	case ".txt":
-		return loadLabelsText(data)
 	case ".csv":
 		return loadLabelsCSV(data)
 	case ".json":
 		return loadLabelsJSON(data)
 	default:
-		return nil, &LabelLoadError{Path: "(bytes)", Reason: "unsupported label file extension: " + ext}
+		return loadLabelsText(data)
 	}
 }
 

--- a/internal/inference/onnx/rangefilter.go
+++ b/internal/inference/onnx/rangefilter.go
@@ -7,6 +7,9 @@ import (
 	ort "github.com/yalue/onnxruntime_go"
 )
 
+// DefaultRangeFilterThreshold is the minimum location score for a species to pass the range filter.
+const DefaultRangeFilterThreshold float32 = 0.03
+
 // RangeFilter uses the BirdNET meta model to filter species by geographic location and date.
 type RangeFilter struct {
 	session   *ort.DynamicAdvancedSession
@@ -20,7 +23,7 @@ func NewRangeFilter(modelPath string, opts ...RangeFilterOption) (*RangeFilter, 
 		return nil, ErrModelPathRequired
 	}
 
-	cfg := &rangeFilterConfig{threshold: 0.03}
+	cfg := &rangeFilterConfig{threshold: DefaultRangeFilterThreshold}
 	for _, opt := range opts {
 		opt(cfg)
 	}
@@ -92,7 +95,7 @@ func resolveRangeFilterLabels(cfg *rangeFilterConfig) ([]string, error) {
 		return cfg.labels, nil
 	}
 	if cfg.labelsPath != "" {
-		return loadLabels(cfg.labelsPath)
+		return LoadLabels(cfg.labelsPath)
 	}
 	return nil, ErrLabelsRequired
 }


### PR DESCRIPTION
## Summary

- Export `onnx.LoadLabels` for cross-package reuse and remove the duplicate `loadLabelsFromFile` from the classifier package (-21 lines). The onnx version also supports CSV and JSON label formats in addition to plain text.
- Replace the magic number `0.03` with a named `DefaultRangeFilterThreshold` constant in the range filter.

## Test plan

- [x] All 580 existing unit tests pass (`go test -race ./internal/inference/... ./internal/classifier/...`)
- [x] `golangci-lint run -v` clean
- [ ] CI passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated label-loading across the classification pipeline for consistent behavior.

* **New Features**
  * Added a public label loader that accepts .txt, .csv, and .json formats, with plain-text fallback for unknown extensions.
  * Introduced a standardized default threshold for the range filter to ensure consistent filtering behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3109?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->