### PR TITLE
fix: concurrency, resource leaks, and log noise in audio pipeline

### DIFF
--- a/internal/analysis/audio_pipeline_service.go
+++ b/internal/analysis/audio_pipeline_service.go
@@ -690,6 +690,15 @@ func (p *AudioPipelineService) registerSoundLevelConsumers(sourceIDs []string, o
 				logger.String("operation", operation))
 			continue
 		}
+		if _, raced := p.soundLevelConsumers[sid]; raced {
+			p.soundLevelMu.Unlock()
+			p.engine.Router().RemoveRoute(sid, consumerID)
+			log.Debug("sound level consumer already registered concurrently, dropped duplicate route",
+				logger.String("source_id", sid),
+				logger.String("consumer_id", consumerID),
+				logger.String("operation", operation))
+			continue
+		}
 		if p.soundLevelConsumers == nil {
 			p.soundLevelConsumers = make(map[string]string)
 		}

--- a/internal/analysis/audio_pipeline_service.go
+++ b/internal/analysis/audio_pipeline_service.go
@@ -1266,111 +1266,83 @@ func (p *AudioPipelineService) startWeatherPolling(metrics *observability.Metric
 }
 
 // clipCleanupMonitor monitors the database and deletes clips that meet the retention policy.
-// It also performs periodic cleanup of log deduplicator states to prevent memory growth.
 func clipCleanupMonitor(quitChan chan struct{}, dataStore datastore.Interface) {
-	// Get configurable cleanup check interval, with fallback to default
+	log := GetLogger()
+
+	// Read initial interval for the startup log message.
 	retention := conf.Setting().Realtime.Audio.Export.Retention
 	checkInterval := retention.CheckInterval
 	if checkInterval <= 0 {
 		checkInterval = conf.DefaultCleanupCheckInterval
 	}
-
-	// Create a ticker that triggers at the configured interval to perform cleanup
-	ticker := time.NewTicker(time.Duration(checkInterval) * time.Minute)
-	defer ticker.Stop() // Ensure the ticker is stopped to prevent leaks
-
-	// Get the shared disk manager logger
-	diskManagerLogger := diskmanager.GetLogger()
-
-	policy := retention.Policy
-	GetLogger().Info("clip cleanup monitor initialized",
-		logger.String("policy", policy),
+	log.Info("clip cleanup monitor initialized",
+		logger.String("policy", retention.Policy),
 		logger.Int("check_interval_minutes", checkInterval),
 		logger.String("operation", "clip_cleanup_init"))
-	diskManagerLogger.Info("Cleanup timer started",
-		logger.String("policy", policy),
-		logger.Int("interval_minutes", checkInterval),
-		logger.String("timestamp", time.Now().Format(time.RFC3339)))
 
 	for {
+		// Re-read interval each iteration so hot-reload takes effect.
+		interval := conf.Setting().Realtime.Audio.Export.Retention.CheckInterval
+		if interval <= 0 {
+			interval = conf.DefaultCleanupCheckInterval
+		}
+		timer := time.NewTimer(time.Duration(interval) * time.Minute)
+
 		select {
 		case <-quitChan:
-			// Handle quit signal to stop the monitor
-			diskManagerLogger.Info("Cleanup timer stopped",
-				logger.String("reason", "quit signal received"),
-				logger.String("timestamp", time.Now().Format(time.RFC3339)))
+			timer.Stop()
+			log.Debug("clip cleanup monitor stopped",
+				logger.String("operation", "clip_cleanup_stop"))
 			return
 
-		case t := <-ticker.C:
-			GetLogger().Info("starting clip cleanup task",
+		case t := <-timer.C:
+			currentPolicy := conf.Setting().Realtime.Audio.Export.Retention.Policy
+			log.Info("starting clip cleanup task",
 				logger.String("timestamp", t.Format(time.RFC3339)),
-				logger.String("policy", conf.Setting().Realtime.Audio.Export.Retention.Policy),
+				logger.String("policy", currentPolicy),
 				logger.String("operation", "clip_cleanup_task"))
-			diskManagerLogger.Info("Cleanup timer triggered",
-				logger.String("timestamp", t.Format(time.RFC3339)),
-				logger.String("policy", conf.Setting().Realtime.Audio.Export.Retention.Policy))
 
-			// age based cleanup method
-			if conf.Setting().Realtime.Audio.Export.Retention.Policy == "age" {
-				diskManagerLogger.Debug("Starting age-based cleanup via timer")
+			if currentPolicy == "age" {
 				result := diskmanager.AgeBasedCleanup(quitChan, dataStore)
 				if result.Err != nil {
-					GetLogger().Error("age-based cleanup failed",
+					log.Error("age-based cleanup failed",
 						logger.Error(result.Err),
 						logger.String("operation", "age_based_cleanup"))
-					diskManagerLogger.Error("Age-based cleanup failed",
-						logger.Error(result.Err),
-						logger.String("timestamp", time.Now().Format(time.RFC3339)))
 				} else {
-					GetLogger().Info("age-based cleanup completed successfully",
+					log.Info("age-based cleanup completed",
 						logger.Int("clips_removed", result.ClipsRemoved),
 						logger.Int("disk_utilization_percent", result.DiskUtilization),
 						logger.String("operation", "age_based_cleanup"))
-					diskManagerLogger.Info("Age-based cleanup completed via timer",
-						logger.Int("clips_removed", result.ClipsRemoved),
-						logger.Int("disk_utilization", result.DiskUtilization),
-						logger.String("timestamp", time.Now().Format(time.RFC3339)))
 				}
 			}
 
-			// priority based cleanup method
-			if conf.Setting().Realtime.Audio.Export.Retention.Policy == "usage" {
-				retention := conf.Setting().Realtime.Audio.Export.Retention
+			if currentPolicy == "usage" {
+				currentRetention := conf.Setting().Realtime.Audio.Export.Retention
 				baseDir := conf.Setting().Realtime.Audio.Export.Path
 
-				// Check if we can skip cleanup
-				skip, utilization, err := diskmanager.ShouldSkipUsageBasedCleanup(&retention, baseDir)
-
+				skip, utilization, err := diskmanager.ShouldSkipUsageBasedCleanup(&currentRetention, baseDir)
 				if err != nil {
-					diskManagerLogger.Warn("Failed to check disk usage for early exit via timer",
+					log.Warn("failed to check disk usage",
 						logger.Error(err),
-						logger.Bool("continuing_with_cleanup", true))
+						logger.Bool("continuing_with_cleanup", true),
+						logger.String("operation", "usage_based_cleanup"))
 				} else if skip {
-					diskManagerLogger.Info("Disk usage below threshold via timer, skipping cleanup",
-						logger.Int("current_usage", utilization),
-						logger.String("timestamp", time.Now().Format(time.RFC3339)))
-					continue // Skip to next timer tick
+					log.Debug("disk usage below threshold, skipping cleanup",
+						logger.Int("disk_utilization_percent", utilization),
+						logger.String("operation", "usage_based_cleanup"))
+					continue
 				}
 
-				// Proceed with cleanup
-				diskManagerLogger.Debug("Starting usage-based cleanup via timer")
 				result := diskmanager.UsageBasedCleanup(quitChan, dataStore)
 				if result.Err != nil {
-					GetLogger().Error("usage-based cleanup failed",
+					log.Error("usage-based cleanup failed",
 						logger.Error(result.Err),
 						logger.String("operation", "usage_based_cleanup"))
-					diskManagerLogger.Error("Usage-based cleanup failed",
-						logger.Error(result.Err),
-						logger.String("timestamp", time.Now().Format(time.RFC3339)))
 				} else {
-					GetLogger().Info("usage-based cleanup completed successfully",
+					log.Info("usage-based cleanup completed",
 						logger.Int("clips_removed", result.ClipsRemoved),
 						logger.Int("disk_utilization_percent", result.DiskUtilization),
 						logger.String("operation", "usage_based_cleanup"))
-					diskManagerLogger.Info("Usage-based cleanup completed via timer",
-						logger.Int("clips_removed", result.ClipsRemoved),
-						logger.Int("disk_utilization", result.DiskUtilization),
-						logger.String("timestamp", time.Now().Format(time.RFC3339)))
 				}
 			}
 		}

--- a/internal/analysis/audio_pipeline_service.go
+++ b/internal/analysis/audio_pipeline_service.go
@@ -705,8 +705,7 @@ func (p *AudioPipelineService) registerSoundLevelConsumers(sourceIDs []string, o
 		}
 		if _, raced := p.soundLevelConsumers[sid]; raced {
 			p.soundLevelMu.Unlock()
-			p.engine.Router().RemoveRoute(sid, consumerID)
-			log.Debug("sound level consumer already registered concurrently, dropped duplicate route",
+			log.Debug("sound level consumer already registered concurrently, skipping",
 				logger.String("source_id", sid),
 				logger.String("consumer_id", consumerID),
 				logger.String("operation", operation))

--- a/internal/analysis/audio_pipeline_service.go
+++ b/internal/analysis/audio_pipeline_service.go
@@ -59,6 +59,13 @@ type AudioPipelineService struct {
 	doneOnce            sync.Once
 	wg                  sync.WaitGroup
 
+	// sourcesMu serializes operations that mutate the set of active audio
+	// sources: restartAudioCapture (restart loop goroutine), RestartSource
+	// (watchdog goroutine), and reconfigureChangedSources (control monitor
+	// goroutine). Without this, concurrent execution can cause duplicate
+	// source initialization and conflicting router states.
+	sourcesMu sync.Mutex
+
 	// soundLevelMu guards soundLevelConsumers. It is held only while mutating
 	// the map; router and engine calls happen outside the critical section so
 	// that Router.RemoveRoute (which itself takes a write lock and waits for
@@ -426,6 +433,9 @@ func (p *AudioPipelineService) Stop(ctx context.Context) error {
 // restartAudioCapture restarts the audio capture by removing and re-adding
 // all sources via the AudioEngine.
 func (p *AudioPipelineService) restartAudioCapture() {
+	p.sourcesMu.Lock()
+	defer p.sourcesMu.Unlock()
+
 	audiocore.GetLogger().Info("restarting audio capture",
 		logger.String("operation", "restart_audio_capture"))
 
@@ -441,6 +451,9 @@ func (p *AudioPipelineService) restartAudioCapture() {
 // Follows the same cleanup pattern as reconfigureChangedSources: remove routes,
 // clean up overrun trackers, untrack sound level, stop capture, then re-add.
 func (p *AudioPipelineService) RestartSource(sourceID string) error {
+	p.sourcesMu.Lock()
+	defer p.sourcesMu.Unlock()
+
 	log := audiocore.GetLogger()
 	log.Info("restarting single audio source",
 		logger.String("source_id", sourceID),
@@ -962,6 +975,9 @@ func sourceNeedsReconfigure(running *audiocore.AudioSource, desired *audiocore.S
 // changed are touched - unchanged streams keep their capture buffers and
 // source IDs intact.
 func (p *AudioPipelineService) reconfigureChangedSources(audioLevelChan chan audiocore.AudioLevelData) {
+	p.sourcesMu.Lock()
+	defer p.sourcesMu.Unlock()
+
 	log := audiocore.GetLogger()
 
 	// Build desired config keyed by connection string, including model IDs.

--- a/internal/audiocore/router.go
+++ b/internal/audiocore/router.go
@@ -503,21 +503,43 @@ func (r *AudioRouter) stopRoute(route *Route) {
 
 	select {
 	case <-route.stopped:
-		// Drainer exited cleanly — safe to close resources.
+		// Drainer exited cleanly or via recovered panic. Close resources
+		// with panic guards so a misbehaving Close() cannot crash the
+		// caller (RemoveRoute, RemoveAllRoutes, or router.Close).
 		if route.resampler != nil {
-			if err := route.resampler.Close(); err != nil {
-				r.log.Debug("resampler close error",
+			func() {
+				defer func() {
+					if rp := recover(); rp != nil {
+						r.log.Warn("panic closing resampler in stopRoute",
+							logger.String("source_id", route.SourceID),
+							logger.String("consumer_id", route.Consumer.ID()),
+							logger.Any("panic", rp))
+					}
+				}()
+				if err := route.resampler.Close(); err != nil {
+					r.log.Debug("resampler close error",
+						logger.String("source_id", route.SourceID),
+						logger.String("consumer_id", route.Consumer.ID()),
+						logger.Error(err))
+				}
+			}()
+		}
+		func() {
+			defer func() {
+				if rp := recover(); rp != nil {
+					r.log.Warn("panic closing consumer in stopRoute",
+						logger.String("source_id", route.SourceID),
+						logger.String("consumer_id", route.Consumer.ID()),
+						logger.Any("panic", rp))
+				}
+			}()
+			if err := route.Consumer.Close(); err != nil {
+				r.log.Debug("consumer close error",
 					logger.String("source_id", route.SourceID),
 					logger.String("consumer_id", route.Consumer.ID()),
 					logger.Error(err))
 			}
-		}
-		if err := route.Consumer.Close(); err != nil {
-			r.log.Debug("consumer close error",
-				logger.String("source_id", route.SourceID),
-				logger.String("consumer_id", route.Consumer.ID()),
-				logger.Error(err))
-		}
+		}()
 	case <-time.After(drainerStopTimeout):
 		// Drainer is leaked and may still reference the resampler/consumer.
 		// Do NOT close them — leave for GC to reclaim.
@@ -561,7 +583,11 @@ func (r *AudioRouter) drainRoute(route *Route) {
 				Priority(errors.PriorityCritical).
 				Build()
 			// Remove the dead route from the map so HasConsumers/Dispatch
-			// stop sending frames to an inbox nobody drains.
+			// stop sending frames to an inbox nobody drains. Track whether
+			// we found it: if router.Close() already snapshotted and cleared
+			// the map, the route won't be here and stopRoute will handle
+			// resource cleanup instead.
+			removed := false
 			r.mu.Lock()
 			routes := r.routes[route.SourceID]
 			for i, rt := range routes {
@@ -574,6 +600,7 @@ func (r *AudioRouter) drainRoute(route *Route) {
 				if len(r.routes[route.SourceID]) == 0 {
 					delete(r.routes, route.SourceID)
 				}
+				removed = true
 				break
 			}
 			r.mu.Unlock()
@@ -583,33 +610,35 @@ func (r *AudioRouter) drainRoute(route *Route) {
 			// per panicking route would stay outstanding (the slices still
 			// GC, so this is pool-efficiency rather than a hard leak).
 			drainInboxRefs(route.inbox)
-			// Best-effort Close of consumer and resampler, each wrapped
-			// in its own recover to prevent secondary panics from
-			// propagating.
-			if route.resampler != nil {
+			// Only close resources if we successfully removed the route.
+			// If the route was not in the map (router.Close() already took
+			// ownership), stopRoute will close them after route.stopped fires.
+			if removed {
+				if route.resampler != nil {
+					func() {
+						defer func() {
+							if rp := recover(); rp != nil {
+								r.log.Warn("secondary panic closing resampler after drainer panic",
+									logger.String("source_id", route.SourceID),
+									logger.String("consumer_id", route.Consumer.ID()),
+									logger.Any("secondary_panic", rp))
+							}
+						}()
+						_ = route.resampler.Close()
+					}()
+				}
 				func() {
 					defer func() {
 						if rp := recover(); rp != nil {
-							r.log.Warn("secondary panic closing resampler after drainer panic",
+							r.log.Warn("secondary panic closing consumer after drainer panic",
 								logger.String("source_id", route.SourceID),
 								logger.String("consumer_id", route.Consumer.ID()),
 								logger.Any("secondary_panic", rp))
 						}
 					}()
-					_ = route.resampler.Close()
+					_ = route.Consumer.Close()
 				}()
 			}
-			func() {
-				defer func() {
-					if rp := recover(); rp != nil {
-						r.log.Warn("secondary panic closing consumer after drainer panic",
-							logger.String("source_id", route.SourceID),
-							logger.String("consumer_id", route.Consumer.ID()),
-							logger.Any("secondary_panic", rp))
-					}
-				}()
-				_ = route.Consumer.Close()
-			}()
 		}
 	}()
 	for {

--- a/internal/audiocore/router.go
+++ b/internal/audiocore/router.go
@@ -583,11 +583,33 @@ func (r *AudioRouter) drainRoute(route *Route) {
 			// per panicking route would stay outstanding (the slices still
 			// GC, so this is pool-efficiency rather than a hard leak).
 			drainInboxRefs(route.inbox)
-			// Goroutine returns here. The route is removed from the map.
-			// Note: consumer and resampler are intentionally NOT closed here
-			// to avoid potential secondary panics during cleanup. They will
-			// be reclaimed by GC. The stopped channel is closed by the outer
-			// defer for consistency.
+			// Best-effort Close of consumer and resampler, each wrapped
+			// in its own recover to prevent secondary panics from
+			// propagating.
+			if route.resampler != nil {
+				func() {
+					defer func() {
+						if rp := recover(); rp != nil {
+							r.log.Warn("secondary panic closing resampler after drainer panic",
+								logger.String("source_id", route.SourceID),
+								logger.String("consumer_id", route.Consumer.ID()),
+								logger.Any("secondary_panic", rp))
+						}
+					}()
+					_ = route.resampler.Close()
+				}()
+			}
+			func() {
+				defer func() {
+					if rp := recover(); rp != nil {
+						r.log.Warn("secondary panic closing consumer after drainer panic",
+							logger.String("source_id", route.SourceID),
+							logger.String("consumer_id", route.Consumer.ID()),
+							logger.Any("secondary_panic", rp))
+					}
+				}()
+				_ = route.Consumer.Close()
+			}()
 		}
 	}()
 	for {

--- a/internal/audiocore/router_test.go
+++ b/internal/audiocore/router_test.go
@@ -401,6 +401,56 @@ func (c *panicOnWriteConsumer) Write(_ AudioFrame) error { //nolint:gocritic // 
 	panic("consumer exploded")
 }
 
+// panicOnWriteCloseTracker panics on Write and tracks whether Close was called.
+type panicOnWriteCloseTracker struct {
+	id         string
+	sampleRate int
+	closed     atomic.Bool
+}
+
+func (c *panicOnWriteCloseTracker) ID() string      { return c.id }
+func (c *panicOnWriteCloseTracker) SampleRate() int { return c.sampleRate }
+func (c *panicOnWriteCloseTracker) BitDepth() int   { return 16 }
+func (c *panicOnWriteCloseTracker) Channels() int   { return 1 }
+func (c *panicOnWriteCloseTracker) Close() error    { c.closed.Store(true); return nil }
+func (c *panicOnWriteCloseTracker) Write(_ AudioFrame) error { //nolint:gocritic // hugeParam: signature required by AudioConsumer interface
+	panic("consumer exploded")
+}
+
+// TestDrainRoutePanicCallsClose verifies that when a consumer panics during
+// Write, the panic recovery handler still calls Close() on the consumer so
+// that resources (file descriptors, CGO allocations) are released.
+func TestDrainRoutePanicCallsClose(t *testing.T) {
+	t.Parallel()
+
+	router := NewAudioRouter(GetLogger(), nil)
+	t.Cleanup(func() { router.Close() })
+
+	consumer := &panicOnWriteCloseTracker{
+		id:         "panic-close-tracker",
+		sampleRate: 48000,
+	}
+
+	err := router.AddRoute("src1", consumer, 48000, 0.0, nil)
+	require.NoError(t, err)
+
+	// Dispatch a frame; the consumer will panic on Write, triggering recovery.
+	router.Dispatch(AudioFrame{
+		SourceID:   "src1",
+		Data:       make([]byte, 100),
+		SampleRate: 48000,
+		BitDepth:   16,
+		Channels:   1,
+		Timestamp:  time.Now(),
+	})
+
+	// The drainer should recover from the panic and call Close().
+	require.Eventually(t, func() bool {
+		return consumer.closed.Load()
+	}, 2*time.Second, 10*time.Millisecond,
+		"expected Close() to be called on consumer after panic recovery")
+}
+
 // TestRouter_DrainRouteAppliesGain verifies that per-route gain amplifies,
 // attenuates, or leaves audio data unchanged depending on the dB value.
 func TestRouter_DrainRouteAppliesGain(t *testing.T) {


### PR DESCRIPTION
## Summary

- **drainRoute panic recovery**: safely call Close() on consumer/resampler in panic handler (each wrapped in own recover); only close if we successfully removed the route from the map (prevents double-close when router.Close() races the panic recovery)
- **stopRoute panic guards**: wrap Close() calls in normal shutdown path with recover to prevent misbehaving consumers from crashing the caller goroutine
- **clipCleanupMonitor**: consolidate double-logging (removed diskManagerLogger, single structured logger); replace one-shot ticker with per-iteration timer that re-reads interval from conf.Setting() for hot-reload support
- **registerSoundLevelConsumers TOCTOU**: re-check soundLevelConsumers map after re-acquiring mutex to prevent orphaned routes when concurrent goroutines register the same source
- **sourcesMu orchestration mutex**: serialize restartAudioCapture, RestartSource, and reconfigureChangedSources to prevent conflicting router states when watchdog escalation races hot-reload reconfiguration

## Test Plan

- [x] 275 tests pass with `-race` (137 audiocore + 138 analysis)
- [x] New test: `TestDrainRoutePanicCallsClose` verifies Close() is called after panic
- [x] golangci-lint: zero issues
- [x] Full build: `go build ./...` succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of concurrent audio source operations and reconfiguration to prevent conflicting updates.
  * Enhanced shutdown/error recovery to avoid panics and ensure resources are reliably cleaned up.
  * Added detection to prevent duplicate consumer registrations.
  * Refactored clip cleanup logic to support hot-reload of retention policy and more reliable task handling.

* **Tests**
  * Added test coverage for error recovery during audio dispatch.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3110?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->