### PR TITLE
feat(api): add heatmap grid endpoint with binary BNHM format

### DIFF
--- a/internal/api/v2/api.go
+++ b/internal/api/v2/api.go
@@ -623,6 +623,7 @@ func (c *Controller) initRoutes() {
 		{"auth routes", c.initAuthRoutes},
 		{"media routes", c.initMediaRoutes},
 		{"range routes", c.initRangeRoutes},
+		{"heatmap routes", c.initHeatmapRoutes},
 		{"sse routes", c.initSSERoutes},
 		{"metrics history routes", c.initMetricsHistoryRoutes},
 		{"notification routes", c.initNotificationRoutes},

--- a/internal/api/v2/heatmap.go
+++ b/internal/api/v2/heatmap.go
@@ -277,7 +277,6 @@ func (c *Controller) validateHeatmapParams(ctx echo.Context) (*heatmapParams, er
 // for each week across all grid points, then extracting the target species scores.
 // Returns float32[weeks][rows][cols] in flat layout.
 func (c *Controller) computeHeatmapGrid(birdnet *classifier.Orchestrator, params *heatmapParams, speciesIdx, numGeoSpecies int) ([]float32, error) {
-	log := GetLogger()
 	totalCells := params.rows * params.cols
 	result := make([]float32, bnhmWeeks*totalCells)
 
@@ -317,20 +316,14 @@ func (c *Controller) computeHeatmapGrid(birdnet *classifier.Orchestrator, params
 			}
 
 			expectedLen := chunkSize * numGeoSpecies
-			if len(scores) < expectedLen {
-				log.Warn("PredictBatch returned fewer scores than expected",
-					logger.Int("expected", expectedLen),
-					logger.Int("got", len(scores)),
-					logger.Int("week", week),
-					logger.Int("chunk_start", chunkStart))
+			if len(scores) != expectedLen {
+				return nil, fmt.Errorf("batch inference size mismatch at week %d chunk %d: got %d scores, want %d",
+					week, chunkStart, len(scores), expectedLen)
 			}
 
 			// Extract the target species score from each point's output
 			for i := range chunkSize {
-				scoreIdx := i*numGeoSpecies + speciesIdx
-				if scoreIdx < len(scores) {
-					result[weekOffset+chunkStart+i] = scores[scoreIdx]
-				}
+				result[weekOffset+chunkStart+i] = scores[i*numGeoSpecies+speciesIdx]
 			}
 		}
 	}

--- a/internal/api/v2/heatmap.go
+++ b/internal/api/v2/heatmap.go
@@ -1,0 +1,396 @@
+package api
+
+import (
+	"container/list"
+	"encoding/binary"
+	"fmt"
+	"math"
+	"net/http"
+	"sync"
+	"sync/atomic"
+
+	"github.com/labstack/echo/v4"
+	"github.com/tphakala/birdnet-go/internal/classifier"
+	"github.com/tphakala/birdnet-go/internal/logger"
+)
+
+// BNHM binary format constants
+const (
+	bnhmMagic      = "BNHM"
+	bnhmVersion    = 1
+	bnhmHeaderSize = 40
+	bnhmWeeks      = 48
+)
+
+// Heatmap validation constraints
+const (
+	heatmapMinResolution = 0.1
+	heatmapMaxResolution = 5.0
+	heatmapMaxGridCells  = 50000
+	heatmapBatchSize     = 512
+)
+
+// heatmapLRU is a thread-safe LRU cache for pre-encoded BNHM responses.
+// Keyed by normalized request parameters; values are ready-to-send []byte.
+type heatmapLRU struct {
+	mu         sync.Mutex
+	maxEntries int
+	generation atomic.Uint64
+	items      map[string]*list.Element
+	order      *list.List
+}
+
+type heatmapCacheEntry struct {
+	key        string
+	value      []byte
+	generation uint64
+}
+
+func newHeatmapLRU(maxEntries int) *heatmapLRU {
+	return &heatmapLRU{
+		maxEntries: maxEntries,
+		items:      make(map[string]*list.Element, maxEntries),
+		order:      list.New(),
+	}
+}
+
+func (c *heatmapLRU) get(key string) ([]byte, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	elem, ok := c.items[key]
+	if !ok {
+		return nil, false
+	}
+
+	entry := elem.Value.(*heatmapCacheEntry)
+	if entry.generation != c.generation.Load() {
+		c.order.Remove(elem)
+		delete(c.items, key)
+		return nil, false
+	}
+
+	c.order.MoveToFront(elem)
+	return entry.value, true
+}
+
+func (c *heatmapLRU) put(key string, value []byte) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if elem, ok := c.items[key]; ok {
+		c.order.MoveToFront(elem)
+		entry := elem.Value.(*heatmapCacheEntry)
+		entry.value = value
+		entry.generation = c.generation.Load()
+		return
+	}
+
+	entry := &heatmapCacheEntry{
+		key:        key,
+		value:      value,
+		generation: c.generation.Load(),
+	}
+	elem := c.order.PushFront(entry)
+	c.items[key] = elem
+
+	for c.order.Len() > c.maxEntries {
+		oldest := c.order.Back()
+		if oldest == nil {
+			break
+		}
+		c.order.Remove(oldest)
+		delete(c.items, oldest.Value.(*heatmapCacheEntry).key)
+	}
+}
+
+func (c *heatmapLRU) invalidate() {
+	c.generation.Add(1)
+}
+
+// heatmapCacheKey builds a normalized cache key from request parameters.
+func heatmapCacheKey(species string, south, north, west, east, resolution float64) string {
+	return fmt.Sprintf("%s|%.6f|%.6f|%.6f|%.6f|%.6f",
+		species, south, north, west, east, resolution)
+}
+
+// encodeBNHM encodes a heatmap grid into the BNHM binary format.
+// data layout: float32[weeks][rows][cols], little-endian.
+func encodeBNHM(cols, rows int, south, west, resolution float32, data []float32) []byte {
+	size := bnhmHeaderSize + len(data)*4
+	buf := make([]byte, size)
+
+	copy(buf[0:4], bnhmMagic)
+	binary.LittleEndian.PutUint32(buf[4:8], bnhmVersion)
+	binary.LittleEndian.PutUint32(buf[8:12], uint32(cols))
+	binary.LittleEndian.PutUint32(buf[12:16], uint32(rows))
+	binary.LittleEndian.PutUint32(buf[16:20], bnhmWeeks)
+	binary.LittleEndian.PutUint32(buf[20:24], math.Float32bits(south))
+	binary.LittleEndian.PutUint32(buf[24:28], math.Float32bits(west))
+	binary.LittleEndian.PutUint32(buf[28:32], math.Float32bits(resolution))
+	// bytes 32-39: reserved (already zeroed)
+
+	offset := bnhmHeaderSize
+	for _, v := range data {
+		binary.LittleEndian.PutUint32(buf[offset:offset+4], math.Float32bits(v))
+		offset += 4
+	}
+
+	return buf
+}
+
+// bnhmHeader holds the decoded fields from a BNHM binary payload header.
+type bnhmHeader struct {
+	Cols       int
+	Rows       int
+	Weeks      int
+	South      float32
+	West       float32
+	Resolution float32
+}
+
+// decodeBNHMHeader parses the header from a BNHM binary payload.
+func decodeBNHMHeader(buf []byte) (bnhmHeader, error) {
+	if len(buf) < bnhmHeaderSize {
+		return bnhmHeader{}, fmt.Errorf("buffer too small: %d < %d", len(buf), bnhmHeaderSize)
+	}
+	if string(buf[0:4]) != bnhmMagic {
+		return bnhmHeader{}, fmt.Errorf("invalid magic: %q", buf[0:4])
+	}
+	version := binary.LittleEndian.Uint32(buf[4:8])
+	if version != bnhmVersion {
+		return bnhmHeader{}, fmt.Errorf("unsupported version: %d", version)
+	}
+
+	return bnhmHeader{
+		Cols:       int(binary.LittleEndian.Uint32(buf[8:12])),
+		Rows:       int(binary.LittleEndian.Uint32(buf[12:16])),
+		Weeks:      int(binary.LittleEndian.Uint32(buf[16:20])),
+		South:      math.Float32frombits(binary.LittleEndian.Uint32(buf[20:24])),
+		West:       math.Float32frombits(binary.LittleEndian.Uint32(buf[24:28])),
+		Resolution: math.Float32frombits(binary.LittleEndian.Uint32(buf[28:32])),
+	}, nil
+}
+
+// heatmapGridDimensions computes the number of rows and columns for a grid
+// covering the given bounding box at the specified resolution.
+func heatmapGridDimensions(south, north, west, east, resolution float64) (rows, cols int) {
+	rows = int(math.Ceil((north - south) / resolution))
+	cols = int(math.Ceil((east - west) / resolution))
+	if rows < 1 {
+		rows = 1
+	}
+	if cols < 1 {
+		cols = 1
+	}
+	return rows, cols
+}
+
+// heatmapParams holds validated request parameters for heatmap generation.
+type heatmapParams struct {
+	species    string
+	south      float64
+	north      float64
+	west       float64
+	east       float64
+	resolution float64
+	rows       int
+	cols       int
+}
+
+// validateHeatmapParams parses and validates heatmap query parameters.
+func (c *Controller) validateHeatmapParams(ctx echo.Context) (*heatmapParams, error) {
+	species := ctx.QueryParam("species")
+	if species == "" {
+		return nil, fmt.Errorf("species parameter is required")
+	}
+
+	south, err := parseFloat64(ctx.QueryParam("south"))
+	if err != nil {
+		return nil, fmt.Errorf("invalid south parameter: %w", err)
+	}
+	north, err := parseFloat64(ctx.QueryParam("north"))
+	if err != nil {
+		return nil, fmt.Errorf("invalid north parameter: %w", err)
+	}
+	west, err := parseFloat64(ctx.QueryParam("west"))
+	if err != nil {
+		return nil, fmt.Errorf("invalid west parameter: %w", err)
+	}
+	east, err := parseFloat64(ctx.QueryParam("east"))
+	if err != nil {
+		return nil, fmt.Errorf("invalid east parameter: %w", err)
+	}
+	resolution, err := parseFloat64(ctx.QueryParam("resolution"))
+	if err != nil {
+		return nil, fmt.Errorf("invalid resolution parameter: %w", err)
+	}
+
+	if south < -90 || south > 90 || north < -90 || north > 90 {
+		return nil, fmt.Errorf("latitude must be between -90 and 90")
+	}
+	if west < -180 || west > 180 || east < -180 || east > 180 {
+		return nil, fmt.Errorf("longitude must be between -180 and 180")
+	}
+	if south >= north {
+		return nil, fmt.Errorf("south must be less than north")
+	}
+	if west >= east {
+		return nil, fmt.Errorf("west must be less than east")
+	}
+	if resolution < heatmapMinResolution || resolution > heatmapMaxResolution {
+		return nil, fmt.Errorf("resolution must be between %.1f and %.1f degrees", heatmapMinResolution, heatmapMaxResolution)
+	}
+
+	rows, cols := heatmapGridDimensions(south, north, west, east, resolution)
+	if rows*cols > heatmapMaxGridCells {
+		return nil, fmt.Errorf("grid too large: %d cells exceeds maximum %d", rows*cols, heatmapMaxGridCells)
+	}
+
+	return &heatmapParams{
+		species:    species,
+		south:      south,
+		north:      north,
+		west:       west,
+		east:       east,
+		resolution: resolution,
+		rows:       rows,
+		cols:       cols,
+	}, nil
+}
+
+// computeHeatmapGrid generates the heatmap data by running batch geomodel inference
+// for each week across all grid points, then extracting the target species scores.
+// Returns float32[weeks][rows][cols] in flat layout.
+func (c *Controller) computeHeatmapGrid(params *heatmapParams, speciesIdx, numGeoSpecies int) ([]float32, error) {
+	totalCells := params.rows * params.cols
+	result := make([]float32, bnhmWeeks*totalCells)
+
+	birdnet, err := c.getBirdNETInstance()
+	if err != nil {
+		return nil, err
+	}
+
+	for week := 1; week <= bnhmWeeks; week++ {
+		weekOffset := (week - 1) * totalCells
+
+		// Build input triples for all grid points in this week
+		inputs := make([]float32, 0, totalCells*3)
+		for row := range params.rows {
+			lat := params.south + (float64(row)+0.5)*params.resolution
+			for col := range params.cols {
+				lon := params.west + (float64(col)+0.5)*params.resolution
+				inputs = append(inputs, float32(lat), float32(lon), float32(week))
+			}
+		}
+
+		// Process in chunks of heatmapBatchSize to release the lock between calls
+		for chunkStart := 0; chunkStart < totalCells; chunkStart += heatmapBatchSize {
+			chunkEnd := chunkStart + heatmapBatchSize
+			if chunkEnd > totalCells {
+				chunkEnd = totalCells
+			}
+			chunkSize := chunkEnd - chunkStart
+
+			chunkInputs := inputs[chunkStart*3 : chunkEnd*3]
+			scores, err := birdnet.BatchRangeFilterInference(chunkInputs, chunkSize)
+			if err != nil {
+				return nil, fmt.Errorf("batch inference failed at week %d chunk %d: %w", week, chunkStart, err)
+			}
+
+			// Extract the target species score from each point's output
+			for i := range chunkSize {
+				scoreIdx := i*numGeoSpecies + speciesIdx
+				if scoreIdx < len(scores) {
+					result[weekOffset+chunkStart+i] = scores[scoreIdx]
+				}
+			}
+		}
+	}
+
+	return result, nil
+}
+
+// initHeatmapRoutes registers the heatmap grid endpoint and hooks up
+// cache invalidation for range filter reloads.
+func (c *Controller) initHeatmapRoutes() {
+	c.Group.GET("/range/heatmap", c.GetHeatmapGrid)
+
+	classifier.OnRangeFilterReload(func() {
+		InvalidateHeatmapCache()
+	})
+}
+
+// heatmapCache is the module-level LRU cache for heatmap responses.
+// Initialized lazily on first use via initHeatmapCache.
+var (
+	heatmapCacheInstance *heatmapLRU
+	heatmapCacheOnce     sync.Once
+)
+
+func getHeatmapCache() *heatmapLRU {
+	heatmapCacheOnce.Do(func() {
+		heatmapCacheInstance = newHeatmapLRU(64)
+	})
+	return heatmapCacheInstance
+}
+
+// InvalidateHeatmapCache bumps the generation counter, causing all cached
+// entries to be treated as stale on next access.
+func InvalidateHeatmapCache() {
+	getHeatmapCache().invalidate()
+}
+
+// GetHeatmapGrid returns a compact binary grid of species probability across
+// a map viewport for all 48 BirdNET weeks.
+func (c *Controller) GetHeatmapGrid(ctx echo.Context) error {
+	params, err := c.validateHeatmapParams(ctx)
+	if err != nil {
+		return c.HandleError(ctx, err, err.Error(), http.StatusBadRequest)
+	}
+
+	// Verify species exists in geomodel
+	birdnet, err := c.getBirdNETInstance()
+	if err != nil {
+		return c.HandleError(ctx, err, "BirdNET service not available", http.StatusInternalServerError)
+	}
+
+	speciesIdx, found := birdnet.GeomodelSpeciesIndex(params.species)
+	if !found {
+		return c.HandleError(ctx, nil, "Species not found in geomodel", http.StatusBadRequest)
+	}
+
+	labels := birdnet.GeomodelLabels()
+	if len(labels) == 0 {
+		return c.HandleError(ctx, nil, "Geomodel labels not available", http.StatusInternalServerError)
+	}
+	numGeoSpecies := len(labels)
+
+	// Check cache
+	cache := getHeatmapCache()
+	cacheKey := heatmapCacheKey(params.species, params.south, params.north, params.west, params.east, params.resolution)
+
+	if cached, ok := cache.get(cacheKey); ok {
+		c.logAPIRequest(ctx, logger.LogLevelDebug, "Heatmap cache hit", logger.String("species", params.species))
+		return ctx.Blob(http.StatusOK, "application/octet-stream", cached)
+	}
+
+	// Compute grid
+	data, err := c.computeHeatmapGrid(params, speciesIdx, numGeoSpecies)
+	if err != nil {
+		return c.HandleError(ctx, err, "Failed to compute heatmap grid", http.StatusInternalServerError)
+	}
+
+	// Encode BNHM
+	encoded := encodeBNHM(params.cols, params.rows, float32(params.south), float32(params.west), float32(params.resolution), data)
+
+	// Cache the result
+	cache.put(cacheKey, encoded)
+
+	c.logAPIRequest(ctx, logger.LogLevelInfo, "Heatmap grid computed",
+		logger.String("species", params.species),
+		logger.Int("rows", params.rows),
+		logger.Int("cols", params.cols))
+
+	return ctx.Blob(http.StatusOK, "application/octet-stream", encoded)
+}

--- a/internal/api/v2/heatmap.go
+++ b/internal/api/v2/heatmap.go
@@ -54,42 +54,53 @@ func newHeatmapLRU(maxEntries int) *heatmapLRU {
 	}
 }
 
-func (c *heatmapLRU) get(key string) ([]byte, bool) {
+// get returns the cached value and true on hit. On miss it returns the current
+// generation so the caller can pass it to put for generation-aware insertion.
+func (c *heatmapLRU) get(key string) (value []byte, gen uint64, ok bool) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	elem, ok := c.items[key]
-	if !ok {
-		return nil, false
+	currentGen := c.generation.Load()
+
+	elem, found := c.items[key]
+	if !found {
+		return nil, currentGen, false
 	}
 
 	entry := elem.Value.(*heatmapCacheEntry)
-	if entry.generation != c.generation.Load() {
+	if entry.generation != currentGen {
 		c.order.Remove(elem)
 		delete(c.items, key)
-		return nil, false
+		return nil, currentGen, false
 	}
 
 	c.order.MoveToFront(elem)
-	return entry.value, true
+	return entry.value, currentGen, true
 }
 
-func (c *heatmapLRU) put(key string, value []byte) {
+// put stores a value only if the generation has not changed since the cache miss.
+// This prevents stale computation results from poisoning the cache when an
+// invalidation fires between the miss and the put.
+func (c *heatmapLRU) put(key string, value []byte, expectedGen uint64) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+
+	if c.generation.Load() != expectedGen {
+		return
+	}
 
 	if elem, ok := c.items[key]; ok {
 		c.order.MoveToFront(elem)
 		entry := elem.Value.(*heatmapCacheEntry)
 		entry.value = value
-		entry.generation = c.generation.Load()
+		entry.generation = expectedGen
 		return
 	}
 
 	entry := &heatmapCacheEntry{
 		key:        key,
 		value:      value,
-		generation: c.generation.Load(),
+		generation: expectedGen,
 	}
 	elem := c.order.PushFront(entry)
 	c.items[key] = elem
@@ -226,6 +237,9 @@ func (c *Controller) validateHeatmapParams(ctx echo.Context) (*heatmapParams, er
 		return nil, fmt.Errorf("invalid resolution parameter: %w", err)
 	}
 
+	if math.IsNaN(south) || math.IsNaN(north) || math.IsNaN(west) || math.IsNaN(east) || math.IsNaN(resolution) {
+		return nil, fmt.Errorf("parameters must not be NaN")
+	}
 	if south < -90 || south > 90 || north < -90 || north > 90 {
 		return nil, fmt.Errorf("latitude must be between -90 and 90")
 	}
@@ -376,11 +390,13 @@ func (c *Controller) GetHeatmapGrid(ctx echo.Context) error {
 		return c.HandleError(ctx, nil, "Geomodel labels not available", http.StatusInternalServerError)
 	}
 
-	// Check cache
+	// Check cache; on miss, snapshot generation to guard against cache poisoning
+	// if invalidation fires during the slow computation below.
 	cache := getHeatmapCache()
 	cacheKey := heatmapCacheKey(params.species, params.south, params.north, params.west, params.east, params.resolution)
 
-	if cached, ok := cache.get(cacheKey); ok {
+	cached, missGen, hit := cache.get(cacheKey)
+	if hit {
 		c.logAPIRequest(ctx, logger.LogLevelDebug, "Heatmap cache hit", logger.String("species", params.species))
 		return ctx.Blob(http.StatusOK, "application/octet-stream", cached)
 	}
@@ -394,8 +410,8 @@ func (c *Controller) GetHeatmapGrid(ctx echo.Context) error {
 	// Encode BNHM
 	encoded := encodeBNHM(params.cols, params.rows, float32(params.south), float32(params.west), float32(params.resolution), data)
 
-	// Cache the result
-	cache.put(cacheKey, encoded)
+	// Cache only if generation unchanged since miss
+	cache.put(cacheKey, encoded, missGen)
 
 	c.logAPIRequest(ctx, logger.LogLevelInfo, "Heatmap grid computed",
 		logger.String("species", params.species),

--- a/internal/api/v2/heatmap.go
+++ b/internal/api/v2/heatmap.go
@@ -19,7 +19,7 @@ const (
 	bnhmMagic      = "BNHM"
 	bnhmVersion    = 1
 	bnhmHeaderSize = 40
-	bnhmWeeks      = 48
+	bnhmWeeks      = weeksPerYear // 48 BirdNET weeks, matches range.go
 )
 
 // Heatmap validation constraints
@@ -262,26 +262,30 @@ func (c *Controller) validateHeatmapParams(ctx echo.Context) (*heatmapParams, er
 // computeHeatmapGrid generates the heatmap data by running batch geomodel inference
 // for each week across all grid points, then extracting the target species scores.
 // Returns float32[weeks][rows][cols] in flat layout.
-func (c *Controller) computeHeatmapGrid(params *heatmapParams, speciesIdx, numGeoSpecies int) ([]float32, error) {
+func (c *Controller) computeHeatmapGrid(birdnet *classifier.Orchestrator, params *heatmapParams, speciesIdx, numGeoSpecies int) ([]float32, error) {
+	log := GetLogger()
 	totalCells := params.rows * params.cols
 	result := make([]float32, bnhmWeeks*totalCells)
 
-	birdnet, err := c.getBirdNETInstance()
-	if err != nil {
-		return nil, err
+	// Pre-allocate input triples once; only the week value changes per iteration.
+	inputs := make([]float32, totalCells*3)
+	for row := range params.rows {
+		lat := float32(params.south + (float64(row)+0.5)*params.resolution)
+		for col := range params.cols {
+			lon := float32(params.west + (float64(col)+0.5)*params.resolution)
+			idx := (row*params.cols + col) * 3
+			inputs[idx] = lat
+			inputs[idx+1] = lon
+		}
 	}
 
 	for week := 1; week <= bnhmWeeks; week++ {
 		weekOffset := (week - 1) * totalCells
 
-		// Build input triples for all grid points in this week
-		inputs := make([]float32, 0, totalCells*3)
-		for row := range params.rows {
-			lat := params.south + (float64(row)+0.5)*params.resolution
-			for col := range params.cols {
-				lon := params.west + (float64(col)+0.5)*params.resolution
-				inputs = append(inputs, float32(lat), float32(lon), float32(week))
-			}
+		// Update week value for all grid points in-place
+		weekF := float32(week)
+		for i := 2; i < len(inputs); i += 3 {
+			inputs[i] = weekF
 		}
 
 		// Process in chunks of heatmapBatchSize to release the lock between calls
@@ -296,6 +300,15 @@ func (c *Controller) computeHeatmapGrid(params *heatmapParams, speciesIdx, numGe
 			scores, err := birdnet.BatchRangeFilterInference(chunkInputs, chunkSize)
 			if err != nil {
 				return nil, fmt.Errorf("batch inference failed at week %d chunk %d: %w", week, chunkStart, err)
+			}
+
+			expectedLen := chunkSize * numGeoSpecies
+			if len(scores) < expectedLen {
+				log.Warn("PredictBatch returned fewer scores than expected",
+					logger.Int("expected", expectedLen),
+					logger.Int("got", len(scores)),
+					logger.Int("week", week),
+					logger.Int("chunk_start", chunkStart))
 			}
 
 			// Extract the target species score from each point's output
@@ -349,22 +362,19 @@ func (c *Controller) GetHeatmapGrid(ctx echo.Context) error {
 		return c.HandleError(ctx, err, err.Error(), http.StatusBadRequest)
 	}
 
-	// Verify species exists in geomodel
+	// Verify species exists in geomodel (atomic lookup: index + count in one lock)
 	birdnet, err := c.getBirdNETInstance()
 	if err != nil {
 		return c.HandleError(ctx, err, "BirdNET service not available", http.StatusInternalServerError)
 	}
 
-	speciesIdx, found := birdnet.GeomodelSpeciesIndex(params.species)
+	speciesIdx, numGeoSpecies, found := birdnet.GeomodelSpeciesInfo(params.species)
 	if !found {
 		return c.HandleError(ctx, nil, "Species not found in geomodel", http.StatusBadRequest)
 	}
-
-	labels := birdnet.GeomodelLabels()
-	if len(labels) == 0 {
+	if numGeoSpecies == 0 {
 		return c.HandleError(ctx, nil, "Geomodel labels not available", http.StatusInternalServerError)
 	}
-	numGeoSpecies := len(labels)
 
 	// Check cache
 	cache := getHeatmapCache()
@@ -376,7 +386,7 @@ func (c *Controller) GetHeatmapGrid(ctx echo.Context) error {
 	}
 
 	// Compute grid
-	data, err := c.computeHeatmapGrid(params, speciesIdx, numGeoSpecies)
+	data, err := c.computeHeatmapGrid(birdnet, params, speciesIdx, numGeoSpecies)
 	if err != nil {
 		return c.HandleError(ctx, err, "Failed to compute heatmap grid", http.StatusInternalServerError)
 	}

--- a/internal/api/v2/heatmap_test.go
+++ b/internal/api/v2/heatmap_test.go
@@ -134,18 +134,19 @@ func TestHeatmapLRU_BasicOperations(t *testing.T) {
 	cache := newHeatmapLRU(3)
 
 	// Miss on empty cache
-	_, ok := cache.get("key1")
+	_, gen, ok := cache.get("key1")
 	assert.False(t, ok)
 
 	// Put and get
-	cache.put("key1", []byte("value1"))
-	val, ok := cache.get("key1")
+	cache.put("key1", []byte("value1"), gen)
+	val, _, ok := cache.get("key1")
 	assert.True(t, ok)
 	assert.Equal(t, []byte("value1"), val)
 
 	// Overwrite existing
-	cache.put("key1", []byte("updated"))
-	val, ok = cache.get("key1")
+	_, gen, _ = cache.get("key1")
+	cache.put("key1", []byte("updated"), gen)
+	val, _, ok = cache.get("key1")
 	assert.True(t, ok)
 	assert.Equal(t, []byte("updated"), val)
 }
@@ -155,18 +156,19 @@ func TestHeatmapLRU_Eviction(t *testing.T) {
 
 	cache := newHeatmapLRU(2)
 
-	cache.put("key1", []byte("v1"))
-	cache.put("key2", []byte("v2"))
-	cache.put("key3", []byte("v3")) // should evict key1
+	_, gen, _ := cache.get("key1")
+	cache.put("key1", []byte("v1"), gen)
+	cache.put("key2", []byte("v2"), gen)
+	cache.put("key3", []byte("v3"), gen) // should evict key1
 
-	_, ok := cache.get("key1")
+	_, _, ok := cache.get("key1")
 	assert.False(t, ok, "key1 should have been evicted")
 
-	val, ok := cache.get("key2")
+	val, _, ok := cache.get("key2")
 	assert.True(t, ok)
 	assert.Equal(t, []byte("v2"), val)
 
-	val, ok = cache.get("key3")
+	val, _, ok = cache.get("key3")
 	assert.True(t, ok)
 	assert.Equal(t, []byte("v3"), val)
 }
@@ -176,19 +178,20 @@ func TestHeatmapLRU_LRUOrder(t *testing.T) {
 
 	cache := newHeatmapLRU(2)
 
-	cache.put("key1", []byte("v1"))
-	cache.put("key2", []byte("v2"))
+	_, gen, _ := cache.get("key1")
+	cache.put("key1", []byte("v1"), gen)
+	cache.put("key2", []byte("v2"), gen)
 
 	// Access key1 to make it most recently used
 	cache.get("key1")
 
 	// Adding key3 should evict key2 (least recently used)
-	cache.put("key3", []byte("v3"))
+	cache.put("key3", []byte("v3"), gen)
 
-	_, ok := cache.get("key2")
+	_, _, ok := cache.get("key2")
 	assert.False(t, ok, "key2 should have been evicted")
 
-	val, ok := cache.get("key1")
+	val, _, ok := cache.get("key1")
 	assert.True(t, ok)
 	assert.Equal(t, []byte("v1"), val)
 }
@@ -198,21 +201,48 @@ func TestHeatmapLRU_GenerationInvalidation(t *testing.T) {
 
 	cache := newHeatmapLRU(10)
 
-	cache.put("key1", []byte("v1"))
-	cache.put("key2", []byte("v2"))
+	_, gen, _ := cache.get("key1")
+	cache.put("key1", []byte("v1"), gen)
+	cache.put("key2", []byte("v2"), gen)
 
 	// Invalidate
 	cache.invalidate()
 
 	// Old entries should be treated as stale
-	_, ok := cache.get("key1")
+	_, _, ok := cache.get("key1")
 	assert.False(t, ok, "key1 should be stale after invalidation")
 
 	// New entries after invalidation should work
-	cache.put("key3", []byte("v3"))
-	val, ok := cache.get("key3")
+	_, newGen, _ := cache.get("key3")
+	cache.put("key3", []byte("v3"), newGen)
+	val, _, ok := cache.get("key3")
 	assert.True(t, ok)
 	assert.Equal(t, []byte("v3"), val)
+}
+
+func TestHeatmapLRU_PutRejectsStaleGeneration(t *testing.T) {
+	t.Parallel()
+
+	cache := newHeatmapLRU(10)
+
+	// Get generation before invalidation
+	_, oldGen, _ := cache.get("key1")
+
+	// Invalidate bumps generation
+	cache.invalidate()
+
+	// Put with old generation should be rejected (prevents cache poisoning)
+	cache.put("key1", []byte("stale-data"), oldGen)
+
+	_, _, ok := cache.get("key1")
+	assert.False(t, ok, "stale-generation put should be rejected")
+
+	// Put with current generation should succeed
+	_, newGen, _ := cache.get("key1")
+	cache.put("key1", []byte("fresh-data"), newGen)
+	val, _, ok := cache.get("key1")
+	assert.True(t, ok)
+	assert.Equal(t, []byte("fresh-data"), val)
 }
 
 func TestHeatmapCacheKey(t *testing.T) {
@@ -226,24 +256,26 @@ func TestInvalidateHeatmapCache_ClearsEntries(t *testing.T) {
 	t.Parallel()
 
 	cache := newHeatmapLRU(10)
-	cache.put("k1", []byte("data1"))
-	cache.put("k2", []byte("data2"))
+	_, gen, _ := cache.get("k1")
+	cache.put("k1", []byte("data1"), gen)
+	cache.put("k2", []byte("data2"), gen)
 
 	// Entries exist before invalidation
-	_, ok := cache.get("k1")
+	_, _, ok := cache.get("k1")
 	assert.True(t, ok)
 
 	cache.invalidate()
 
 	// Entries are stale after invalidation
-	_, ok = cache.get("k1")
+	_, _, ok = cache.get("k1")
 	assert.False(t, ok)
-	_, ok = cache.get("k2")
+	_, _, ok = cache.get("k2")
 	assert.False(t, ok)
 
 	// New entries work after invalidation
-	cache.put("k3", []byte("data3"))
-	val, ok := cache.get("k3")
+	_, newGen, _ := cache.get("k3")
+	cache.put("k3", []byte("data3"), newGen)
+	val, _, ok := cache.get("k3")
 	assert.True(t, ok)
 	assert.Equal(t, []byte("data3"), val)
 }

--- a/internal/api/v2/heatmap_test.go
+++ b/internal/api/v2/heatmap_test.go
@@ -1,0 +1,249 @@
+package api
+
+import (
+	"encoding/binary"
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEncodeBNHM_Roundtrip(t *testing.T) {
+	t.Parallel()
+
+	cols, rows := 3, 2
+	south := float32(60.0)
+	west := float32(24.0)
+	resolution := float32(0.5)
+
+	data := make([]float32, bnhmWeeks*rows*cols)
+	for i := range data {
+		data[i] = float32(i) * 0.001
+	}
+
+	encoded := encodeBNHM(cols, rows, south, west, resolution, data)
+
+	// Verify header
+	assert.Len(t, encoded, bnhmHeaderSize+len(data)*4)
+	assert.Equal(t, "BNHM", string(encoded[0:4]))
+	assert.Equal(t, uint32(1), binary.LittleEndian.Uint32(encoded[4:8]))
+	assert.Equal(t, uint32(cols), binary.LittleEndian.Uint32(encoded[8:12]))
+	assert.Equal(t, uint32(rows), binary.LittleEndian.Uint32(encoded[12:16]))
+	assert.Equal(t, uint32(bnhmWeeks), binary.LittleEndian.Uint32(encoded[16:20]))
+	assert.InDelta(t, south, math.Float32frombits(binary.LittleEndian.Uint32(encoded[20:24])), 0.0001)
+	assert.InDelta(t, west, math.Float32frombits(binary.LittleEndian.Uint32(encoded[24:28])), 0.0001)
+	assert.InDelta(t, resolution, math.Float32frombits(binary.LittleEndian.Uint32(encoded[28:32])), 0.0001)
+
+	// Verify data via decodeBNHMHeader
+	hdr, err := decodeBNHMHeader(encoded)
+	require.NoError(t, err)
+	assert.Equal(t, cols, hdr.Cols)
+	assert.Equal(t, rows, hdr.Rows)
+	assert.Equal(t, bnhmWeeks, hdr.Weeks)
+	assert.InDelta(t, south, hdr.South, 0.0001)
+	assert.InDelta(t, west, hdr.West, 0.0001)
+	assert.InDelta(t, resolution, hdr.Resolution, 0.0001)
+
+	// Verify data values roundtrip
+	for i, expected := range data {
+		offset := bnhmHeaderSize + i*4
+		got := math.Float32frombits(binary.LittleEndian.Uint32(encoded[offset : offset+4]))
+		assert.InDelta(t, expected, got, 0.0001, "data[%d] mismatch", i)
+	}
+}
+
+func TestDecodeBNHMHeader_InvalidMagic(t *testing.T) {
+	t.Parallel()
+
+	buf := make([]byte, bnhmHeaderSize)
+	copy(buf[0:4], "XXXX")
+	_, err := decodeBNHMHeader(buf)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid magic")
+}
+
+func TestDecodeBNHMHeader_BufferTooSmall(t *testing.T) {
+	t.Parallel()
+
+	buf := make([]byte, 10)
+	_, err := decodeBNHMHeader(buf)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "buffer too small")
+}
+
+func TestDecodeBNHMHeader_UnsupportedVersion(t *testing.T) {
+	t.Parallel()
+
+	buf := make([]byte, bnhmHeaderSize)
+	copy(buf[0:4], bnhmMagic)
+	binary.LittleEndian.PutUint32(buf[4:8], 99)
+	_, err := decodeBNHMHeader(buf)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported version")
+}
+
+func TestHeatmapGridDimensions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                       string
+		south, north, west, east   float64
+		resolution                 float64
+		expectedRows, expectedCols int
+	}{
+		{
+			name:  "simple 1 degree grid",
+			south: 60, north: 62, west: 24, east: 26,
+			resolution:   1.0,
+			expectedRows: 2, expectedCols: 2,
+		},
+		{
+			name:  "fractional grid rounds up",
+			south: 60, north: 61.5, west: 24, east: 25.5,
+			resolution:   1.0,
+			expectedRows: 2, expectedCols: 2,
+		},
+		{
+			name:  "finland at 0.25 degrees",
+			south: 59.5, north: 70.0, west: 19.0, east: 31.5,
+			resolution:   0.25,
+			expectedRows: 42, expectedCols: 50,
+		},
+		{
+			name:  "tiny area",
+			south: 60, north: 60.05, west: 24, east: 24.05,
+			resolution:   0.1,
+			expectedRows: 1, expectedCols: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			rows, cols := heatmapGridDimensions(tt.south, tt.north, tt.west, tt.east, tt.resolution)
+			assert.Equal(t, tt.expectedRows, rows)
+			assert.Equal(t, tt.expectedCols, cols)
+		})
+	}
+}
+
+func TestHeatmapLRU_BasicOperations(t *testing.T) {
+	t.Parallel()
+
+	cache := newHeatmapLRU(3)
+
+	// Miss on empty cache
+	_, ok := cache.get("key1")
+	assert.False(t, ok)
+
+	// Put and get
+	cache.put("key1", []byte("value1"))
+	val, ok := cache.get("key1")
+	assert.True(t, ok)
+	assert.Equal(t, []byte("value1"), val)
+
+	// Overwrite existing
+	cache.put("key1", []byte("updated"))
+	val, ok = cache.get("key1")
+	assert.True(t, ok)
+	assert.Equal(t, []byte("updated"), val)
+}
+
+func TestHeatmapLRU_Eviction(t *testing.T) {
+	t.Parallel()
+
+	cache := newHeatmapLRU(2)
+
+	cache.put("key1", []byte("v1"))
+	cache.put("key2", []byte("v2"))
+	cache.put("key3", []byte("v3")) // should evict key1
+
+	_, ok := cache.get("key1")
+	assert.False(t, ok, "key1 should have been evicted")
+
+	val, ok := cache.get("key2")
+	assert.True(t, ok)
+	assert.Equal(t, []byte("v2"), val)
+
+	val, ok = cache.get("key3")
+	assert.True(t, ok)
+	assert.Equal(t, []byte("v3"), val)
+}
+
+func TestHeatmapLRU_LRUOrder(t *testing.T) {
+	t.Parallel()
+
+	cache := newHeatmapLRU(2)
+
+	cache.put("key1", []byte("v1"))
+	cache.put("key2", []byte("v2"))
+
+	// Access key1 to make it most recently used
+	cache.get("key1")
+
+	// Adding key3 should evict key2 (least recently used)
+	cache.put("key3", []byte("v3"))
+
+	_, ok := cache.get("key2")
+	assert.False(t, ok, "key2 should have been evicted")
+
+	val, ok := cache.get("key1")
+	assert.True(t, ok)
+	assert.Equal(t, []byte("v1"), val)
+}
+
+func TestHeatmapLRU_GenerationInvalidation(t *testing.T) {
+	t.Parallel()
+
+	cache := newHeatmapLRU(10)
+
+	cache.put("key1", []byte("v1"))
+	cache.put("key2", []byte("v2"))
+
+	// Invalidate
+	cache.invalidate()
+
+	// Old entries should be treated as stale
+	_, ok := cache.get("key1")
+	assert.False(t, ok, "key1 should be stale after invalidation")
+
+	// New entries after invalidation should work
+	cache.put("key3", []byte("v3"))
+	val, ok := cache.get("key3")
+	assert.True(t, ok)
+	assert.Equal(t, []byte("v3"), val)
+}
+
+func TestHeatmapCacheKey(t *testing.T) {
+	t.Parallel()
+
+	key := heatmapCacheKey("Turdus_merula_Eurasian_Blackbird", 59.5, 70.0, 19.0, 31.5, 0.5)
+	assert.Equal(t, "Turdus_merula_Eurasian_Blackbird|59.500000|70.000000|19.000000|31.500000|0.500000", key)
+}
+
+func TestInvalidateHeatmapCache_ClearsEntries(t *testing.T) {
+	t.Parallel()
+
+	cache := newHeatmapLRU(10)
+	cache.put("k1", []byte("data1"))
+	cache.put("k2", []byte("data2"))
+
+	// Entries exist before invalidation
+	_, ok := cache.get("k1")
+	assert.True(t, ok)
+
+	cache.invalidate()
+
+	// Entries are stale after invalidation
+	_, ok = cache.get("k1")
+	assert.False(t, ok)
+	_, ok = cache.get("k2")
+	assert.False(t, ok)
+
+	// New entries work after invalidation
+	cache.put("k3", []byte("data3"))
+	val, ok := cache.get("k3")
+	assert.True(t, ok)
+	assert.Equal(t, []byte("data3"), val)
+}

--- a/internal/api/v2/heatmap_test.go
+++ b/internal/api/v2/heatmap_test.go
@@ -252,7 +252,7 @@ func TestHeatmapCacheKey(t *testing.T) {
 	assert.Equal(t, "Turdus_merula_Eurasian_Blackbird|59.500000|70.000000|19.000000|31.500000|0.500000", key)
 }
 
-func TestInvalidateHeatmapCache_ClearsEntries(t *testing.T) {
+func TestHeatmapLRU_InvalidationClearsEntries(t *testing.T) {
 	t.Parallel()
 
 	cache := newHeatmapLRU(10)

--- a/internal/api/v2/range.go
+++ b/internal/api/v2/range.go
@@ -777,14 +777,11 @@ func (c *Controller) RebuildRangeFilter(ctx echo.Context) error {
 		return c.HandleError(ctx, err, "BirdNET service not available", http.StatusInternalServerError)
 	}
 
-	// Rebuild the range filter
+	// Rebuild the range filter (triggers heatmap cache invalidation via callback)
 	err = classifier.BuildRangeFilter(birdnetInstance)
 	if err != nil {
 		return c.HandleError(ctx, err, "Failed to rebuild range filter", http.StatusInternalServerError)
 	}
-
-	// Invalidate heatmap cache since the geomodel data has changed
-	InvalidateHeatmapCache()
 
 	// Read from the latest published snapshot so the just-published rebuild
 	// result is reflected immediately.

--- a/internal/api/v2/range.go
+++ b/internal/api/v2/range.go
@@ -783,6 +783,9 @@ func (c *Controller) RebuildRangeFilter(ctx echo.Context) error {
 		return c.HandleError(ctx, err, "Failed to rebuild range filter", http.StatusInternalServerError)
 	}
 
+	// Invalidate heatmap cache since the geomodel data has changed
+	InvalidateHeatmapCache()
+
 	// Read from the latest published snapshot so the just-published rebuild
 	// result is reflected immediately.
 	c.settingsMutex.RLock()

--- a/internal/classifier/mapped_range_filter.go
+++ b/internal/classifier/mapped_range_filter.go
@@ -13,11 +13,12 @@ import (
 // changing predictFilter() or any downstream code.
 type mappedRangeFilter struct {
 	inner           inference.RangeFilter
-	classifierToGeo []int    // classifierIndex -> geomodelIndex; -1 means no match
-	numClassifier   int      // len(classifierLabels)
-	mappedCount     int      // number of classifier species with a geomodel match
-	unmappedScore   float32  // score for classifier species absent from geomodel
-	geomodelLabels  []string // geomodel label set in geomodel output order
+	classifierToGeo []int          // classifierIndex -> geomodelIndex; -1 means no match
+	numClassifier   int            // len(classifierLabels)
+	mappedCount     int            // number of classifier species with a geomodel match
+	unmappedScore   float32        // score for classifier species absent from geomodel
+	geomodelLabels  []string       // geomodel label set in geomodel output order
+	geomodelIndex   map[string]int // label -> index for O(1) lookup
 }
 
 // buildSpeciesMapping creates the classifier-to-geomodel index mapping by
@@ -78,6 +79,11 @@ func newMappedRangeFilter(inner inference.RangeFilter, classifierLabels, geomode
 			mapped++
 		}
 	}
+	geoIdx := make(map[string]int, len(geomodelLabels))
+	for i, label := range geomodelLabels {
+		geoIdx[label] = i
+	}
+
 	return &mappedRangeFilter{
 		inner:           inner,
 		classifierToGeo: mapping,
@@ -85,6 +91,7 @@ func newMappedRangeFilter(inner inference.RangeFilter, classifierLabels, geomode
 		mappedCount:     mapped,
 		unmappedScore:   unmappedScore,
 		geomodelLabels:  geomodelLabels,
+		geomodelIndex:   geoIdx,
 	}
 }
 

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -15,6 +15,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/datastore"
 	"github.com/tphakala/birdnet-go/internal/errors"
+	"github.com/tphakala/birdnet-go/internal/inference"
 	"github.com/tphakala/birdnet-go/internal/logger"
 	"github.com/tphakala/birdnet-go/internal/suncalc"
 )
@@ -512,7 +513,35 @@ func (o *Orchestrator) ReloadRangeFilter() error {
 	if err := primary.ReloadRangeFilter(); err != nil {
 		return err
 	}
-	return BuildRangeFilter(o)
+	if err := BuildRangeFilter(o); err != nil {
+		return err
+	}
+	o.notifyRangeFilterReload()
+	return nil
+}
+
+// rangeFilterReloadFn is an optional callback invoked after the range filter
+// is reloaded. Used by the API layer to invalidate caches.
+var (
+	rangeFilterReloadMu sync.Mutex
+	rangeFilterReloadFn func()
+)
+
+// OnRangeFilterReload registers a callback that fires after every successful
+// range filter reload. Only one callback is supported; later calls replace earlier ones.
+func OnRangeFilterReload(fn func()) {
+	rangeFilterReloadMu.Lock()
+	rangeFilterReloadFn = fn
+	rangeFilterReloadMu.Unlock()
+}
+
+func (o *Orchestrator) notifyRangeFilterReload() {
+	rangeFilterReloadMu.Lock()
+	fn := rangeFilterReloadFn
+	rangeFilterReloadMu.Unlock()
+	if fn != nil {
+		fn()
+	}
 }
 
 // ReloadBatFilter rebuilds the bat model's high-pass filter from current settings.
@@ -796,6 +825,116 @@ func (o *Orchestrator) UnloadModel(registryID string) error {
 	}
 
 	return nil
+}
+
+// BatchRangeFilterInference runs batch geomodel inference on multiple location/week
+// inputs. The caller provides a flat slice of [lat, lon, week] triples and a batch
+// size. Returns a flat slice of [batchSize * numGeoSpecies] scores in row-major order.
+//
+// The method acquires primary.mu for the duration of one PredictBatch call. Callers
+// that need to process many grid points should chunk externally and call this method
+// once per chunk, allowing the detection pipeline to interleave between calls.
+func (o *Orchestrator) BatchRangeFilterInference(inputs []float32, batchSize int) ([]float32, error) {
+	o.mu.RLock()
+	primary := o.primary
+	o.mu.RUnlock()
+
+	if primary == nil {
+		return nil, errors.Newf("primary model not available").
+			Component("classifier.orchestrator").
+			Category(errors.CategoryValidation).
+			Build()
+	}
+
+	primary.mu.Lock()
+	defer primary.mu.Unlock()
+
+	rf := primary.rangeFilter
+	if rf == nil {
+		return nil, errors.Newf("range filter not loaded").
+			Component("classifier.orchestrator").
+			Category(errors.CategoryValidation).
+			Build()
+	}
+
+	// Unwrap mappedRangeFilter to get the inner BatchRangeFilter.
+	mrf, ok := rf.(*mappedRangeFilter)
+	if !ok {
+		return nil, errors.Newf("range filter does not support batch inference").
+			Component("classifier.orchestrator").
+			Category(errors.CategoryValidation).
+			Build()
+	}
+
+	brf, ok := mrf.inner.(inference.BatchRangeFilter)
+	if !ok {
+		return nil, errors.Newf("underlying range filter does not support batch inference").
+			Component("classifier.orchestrator").
+			Category(errors.CategoryValidation).
+			Build()
+	}
+
+	return brf.PredictBatch(inputs, batchSize)
+}
+
+// GeomodelLabels returns the geomodel's full label set. Returns nil if no
+// range filter is loaded or the filter is not a mapped range filter.
+func (o *Orchestrator) GeomodelLabels() []string {
+	o.mu.RLock()
+	primary := o.primary
+	o.mu.RUnlock()
+
+	if primary == nil {
+		return nil
+	}
+
+	primary.mu.Lock()
+	defer primary.mu.Unlock()
+
+	rf := primary.rangeFilter
+	if rf == nil {
+		return nil
+	}
+
+	mrf, ok := rf.(*mappedRangeFilter)
+	if !ok {
+		return nil
+	}
+
+	return mrf.geomodelLabels
+}
+
+// GeomodelSpeciesIndex returns the index of the given label in the geomodel's
+// label set. Returns (index, true) if found, or (0, false) if the label does
+// not exist in the geomodel or no range filter is loaded.
+func (o *Orchestrator) GeomodelSpeciesIndex(label string) (int, bool) {
+	o.mu.RLock()
+	primary := o.primary
+	o.mu.RUnlock()
+
+	if primary == nil {
+		return 0, false
+	}
+
+	primary.mu.Lock()
+	defer primary.mu.Unlock()
+
+	rf := primary.rangeFilter
+	if rf == nil {
+		return 0, false
+	}
+
+	mrf, ok := rf.(*mappedRangeFilter)
+	if !ok {
+		return 0, false
+	}
+
+	for i, l := range mrf.geomodelLabels {
+		if l == label {
+			return i, true
+		}
+	}
+	return 0, false
 }
 
 // Debug prints debug messages if debug mode is enabled.

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -875,6 +875,20 @@ func (o *Orchestrator) lockedMappedRangeFilter() (*BirdNET, *mappedRangeFilter, 
 // chunk externally and call this method once per chunk, allowing the detection
 // pipeline to interleave between calls.
 func (o *Orchestrator) BatchRangeFilterInference(inputs []float32, batchSize int) ([]float32, error) {
+	const inputWidth = 3 // [lat, lon, week]
+	if batchSize <= 0 {
+		return nil, errors.Newf("batchSize must be positive, got %d", batchSize).
+			Component("classifier.orchestrator").
+			Category(errors.CategoryValidation).
+			Build()
+	}
+	if len(inputs) != batchSize*inputWidth {
+		return nil, errors.Newf("inputs length %d does not match batchSize %d * %d", len(inputs), batchSize, inputWidth).
+			Component("classifier.orchestrator").
+			Category(errors.CategoryValidation).
+			Build()
+	}
+
 	primary, mrf, err := o.lockedMappedRangeFilter()
 	if err != nil {
 		return nil, err

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -513,11 +513,7 @@ func (o *Orchestrator) ReloadRangeFilter() error {
 	if err := primary.ReloadRangeFilter(); err != nil {
 		return err
 	}
-	if err := BuildRangeFilter(o); err != nil {
-		return err
-	}
-	o.notifyRangeFilterReload()
-	return nil
+	return BuildRangeFilter(o)
 }
 
 // rangeFilterReloadFn is an optional callback invoked after the range filter

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -827,44 +827,59 @@ func (o *Orchestrator) UnloadModel(registryID string) error {
 	return nil
 }
 
-// BatchRangeFilterInference runs batch geomodel inference on multiple location/week
-// inputs. The caller provides a flat slice of [lat, lon, week] triples and a batch
-// size. Returns a flat slice of [batchSize * numGeoSpecies] scores in row-major order.
-//
-// The method acquires primary.mu for the duration of one PredictBatch call. Callers
-// that need to process many grid points should chunk externally and call this method
-// once per chunk, allowing the detection pipeline to interleave between calls.
-func (o *Orchestrator) BatchRangeFilterInference(inputs []float32, batchSize int) ([]float32, error) {
+// lockedMappedRangeFilter snapshots primary under o.mu.RLock, then acquires
+// primary.mu and unwraps the range filter to *mappedRangeFilter.
+// The caller MUST defer primary.mu.Unlock() after using the returned filter.
+// Returns (primary, mappedRangeFilter, error). On error, no locks are held.
+func (o *Orchestrator) lockedMappedRangeFilter() (*BirdNET, *mappedRangeFilter, error) {
 	o.mu.RLock()
 	primary := o.primary
 	o.mu.RUnlock()
 
 	if primary == nil {
-		return nil, errors.Newf("primary model not available").
+		return nil, nil, errors.Newf("primary model not available").
 			Component("classifier.orchestrator").
 			Category(errors.CategoryValidation).
 			Build()
 	}
 
 	primary.mu.Lock()
-	defer primary.mu.Unlock()
 
 	rf := primary.rangeFilter
 	if rf == nil {
-		return nil, errors.Newf("range filter not loaded").
+		primary.mu.Unlock()
+		return nil, nil, errors.Newf("range filter not loaded").
 			Component("classifier.orchestrator").
 			Category(errors.CategoryValidation).
 			Build()
 	}
 
-	// Unwrap mappedRangeFilter to get the inner BatchRangeFilter.
 	mrf, ok := rf.(*mappedRangeFilter)
 	if !ok {
-		return nil, errors.Newf("range filter does not support batch inference").
+		primary.mu.Unlock()
+		return nil, nil, errors.Newf("range filter does not support batch inference").
 			Component("classifier.orchestrator").
 			Category(errors.CategoryValidation).
 			Build()
 	}
+
+	return primary, mrf, nil
+}
+
+// BatchRangeFilterInference runs batch geomodel inference on multiple location/week
+// inputs. The caller provides a flat slice of [lat, lon, week] triples and a batch
+// size. Returns a flat slice of [batchSize * numGeoSpecies] scores in row-major order.
+//
+// Acquires primary.mu (not inferenceMu) because the range filter and classifier use
+// independent ONNX sessions. Callers that need to process many grid points should
+// chunk externally and call this method once per chunk, allowing the detection
+// pipeline to interleave between calls.
+func (o *Orchestrator) BatchRangeFilterInference(inputs []float32, batchSize int) ([]float32, error) {
+	primary, mrf, err := o.lockedMappedRangeFilter()
+	if err != nil {
+		return nil, err
+	}
+	defer primary.mu.Unlock()
 
 	brf, ok := mrf.inner.(inference.BatchRangeFilter)
 	if !ok {
@@ -877,64 +892,23 @@ func (o *Orchestrator) BatchRangeFilterInference(inputs []float32, batchSize int
 	return brf.PredictBatch(inputs, batchSize)
 }
 
-// GeomodelLabels returns the geomodel's full label set. Returns nil if no
-// range filter is loaded or the filter is not a mapped range filter.
-func (o *Orchestrator) GeomodelLabels() []string {
-	o.mu.RLock()
-	primary := o.primary
-	o.mu.RUnlock()
-
-	if primary == nil {
-		return nil
+// GeomodelSpeciesInfo looks up a species label in the geomodel and returns
+// its index and the total number of geomodel species, atomically under a
+// single lock acquisition. This avoids TOCTOU issues from separate calls.
+// Returns (speciesIndex, numGeoSpecies, true) on success, or (0, 0, false)
+// if the species is not found or no range filter is loaded.
+func (o *Orchestrator) GeomodelSpeciesInfo(label string) (speciesIdx, numGeoSpecies int, found bool) {
+	primary, mrf, err := o.lockedMappedRangeFilter()
+	if err != nil {
+		return 0, 0, false
 	}
-
-	primary.mu.Lock()
 	defer primary.mu.Unlock()
 
-	rf := primary.rangeFilter
-	if rf == nil {
-		return nil
-	}
-
-	mrf, ok := rf.(*mappedRangeFilter)
+	idx, ok := mrf.geomodelIndex[label]
 	if !ok {
-		return nil
+		return 0, 0, false
 	}
-
-	return mrf.geomodelLabels
-}
-
-// GeomodelSpeciesIndex returns the index of the given label in the geomodel's
-// label set. Returns (index, true) if found, or (0, false) if the label does
-// not exist in the geomodel or no range filter is loaded.
-func (o *Orchestrator) GeomodelSpeciesIndex(label string) (int, bool) {
-	o.mu.RLock()
-	primary := o.primary
-	o.mu.RUnlock()
-
-	if primary == nil {
-		return 0, false
-	}
-
-	primary.mu.Lock()
-	defer primary.mu.Unlock()
-
-	rf := primary.rangeFilter
-	if rf == nil {
-		return 0, false
-	}
-
-	mrf, ok := rf.(*mappedRangeFilter)
-	if !ok {
-		return 0, false
-	}
-
-	for i, l := range mrf.geomodelLabels {
-		if l == label {
-			return i, true
-		}
-	}
-	return 0, false
+	return idx, len(mrf.geomodelLabels), true
 }
 
 // Debug prints debug messages if debug mode is enabled.

--- a/internal/classifier/range_filter.go
+++ b/internal/classifier/range_filter.go
@@ -174,6 +174,7 @@ func BuildRangeFilter(o *Orchestrator) error {
 	}
 
 	conf.UpdateIncludedSpecies(includedSpecies)
+	o.notifyRangeFilterReload()
 	return nil
 }
 


### PR DESCRIPTION
## Summary

Add `GET /api/v2/range/heatmap` endpoint that computes species probability grids across a map viewport for all 48 BirdNET weeks, returning a compact binary payload (BNHM format).

Key components:
- BNHM binary format: 40-byte header + float32[weeks][rows][cols] data, little-endian
- Atomic `GeomodelSpeciesInfo` method: returns species index + total count in one lock acquisition (prevents TOCTOU)
- `BatchRangeFilterInference` with input shape validation
- In-memory LRU cache (64 entries) with generation-counter invalidation (prevents cache poisoning on concurrent reload)
- Grid validation: 50K cell cap, resolution bounds [0.1, 5.0], bbox checks, NaN rejection
- Cache invalidation on range filter reload via callback hook
- O(1) species lookup via `geomodelIndex` map on `mappedRangeFilter`
- Fail-fast on batch output size mismatch (never serve corrupted heatmaps)

## Related Issues

Relates to #3092 (Migration Explorer)

Builds on #3105 (batch inference, merged)

## Test Plan

- [x] BNHM encode/decode roundtrip
- [x] Grid dimension calculations (various bboxes)
- [x] LRU cache: basic ops, eviction, LRU order, generation invalidation
- [x] Cache poisoning prevention (stale-generation put rejected)
- [x] Header decode error cases (invalid magic, buffer too small, bad version)
- [x] All tests pass with `-race` flag (16 tests)
- [x] Zero lint issues (`golangci-lint run`)
- [x] Full project build succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a heatmap API endpoint (GET /range/heatmap) returning per-week species scores as a compact binary grid.
  * Heatmap responses are cached for faster repeated requests; cache is invalidated when range filters are reloaded.

* **Tests**
  * Added comprehensive unit tests for heatmap encoding/decoding, grid sizing, and cache behavior (LRU, eviction, generation invalidation).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3111?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->