### PR TITLE
feat: expose RestartSource API endpoint and add watchdog settings

### DIFF
--- a/internal/analysis/audio_pipeline_service.go
+++ b/internal/analysis/audio_pipeline_service.go
@@ -95,6 +95,31 @@ func (p *AudioPipelineService) Name() string {
 	return audioPipelineServiceName
 }
 
+// buildLivenessConfig creates a LivenessConfig from user settings, falling back
+// to production defaults for any zero-valued field.
+func buildLivenessConfig(ws conf.WatchdogSettings) audiocore.LivenessConfig {
+	cfg := audiocore.DefaultLivenessConfig()
+	if ws.CheckInterval > 0 {
+		cfg.CheckInterval = time.Duration(ws.CheckInterval) * time.Second
+	}
+	if ws.SilenceThreshold > 0 {
+		cfg.SilenceThreshold = time.Duration(ws.SilenceThreshold) * time.Second
+	}
+	if ws.MaxRetries > 0 {
+		cfg.MaxRetries = ws.MaxRetries
+	}
+	if ws.RetryBackoff > 0 {
+		cfg.RetryBackoff = time.Duration(ws.RetryBackoff) * time.Second
+	}
+	if ws.Cooldown > 0 {
+		cfg.CooldownAfterRecov = time.Duration(ws.Cooldown) * time.Second
+	}
+	if ws.EscalationTimeout > 0 {
+		cfg.EscalationTimeout = time.Duration(ws.EscalationTimeout) * time.Second
+	}
+	return cfg
+}
+
 // Watchdog returns the audio liveness watchdog, or nil if not started.
 func (p *AudioPipelineService) Watchdog() *audiocore.LivenessWatchdog {
 	return p.watchdog
@@ -280,15 +305,16 @@ func (p *AudioPipelineService) Start(_ context.Context) error {
 		},
 	}
 	p.watchdog = audiocore.NewLivenessWatchdog(
-		audiocore.DefaultLivenessConfig(),
+		buildLivenessConfig(settings.Realtime.Audio.Watchdog),
 		p.engine.Router(),
 		watchdogCallbacks,
 	)
 	p.watchdog.Start()
 
-	// Expose the watchdog to the API controller for the /health/audio endpoint.
+	// Expose the watchdog and source restarter to the API controller.
 	if ctrl := p.apiService.APIController(); ctrl != nil {
 		ctrl.SetAudioWatchdog(p.watchdog)
+		ctrl.SetSourceRestarter(p.RestartSource)
 	}
 
 	// Inject suncalc into the orchestrator for bat nighttime scheduling.

--- a/internal/analysis/audio_pipeline_service_test.go
+++ b/internal/analysis/audio_pipeline_service_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/app"
+	"github.com/tphakala/birdnet-go/internal/audiocore"
 	"github.com/tphakala/birdnet-go/internal/classifier"
 	"github.com/tphakala/birdnet-go/internal/conf"
 )
@@ -117,4 +118,57 @@ func TestResolveModelTargets_KnownButNotLoaded(t *testing.T) {
 	targets := resolveModelTargets([]string{"birdnet", "perch_v2"}, loaded)
 	require.Len(t, targets, 1, "only birdnet should resolve, perch_v2 is not loaded")
 	assert.Equal(t, "BirdNET_V2.4", targets[0].ID)
+}
+
+func TestBuildLivenessConfig_AllDefaults(t *testing.T) {
+	t.Parallel()
+
+	cfg := buildLivenessConfig(conf.WatchdogSettings{})
+	defaults := audiocore.DefaultLivenessConfig()
+
+	assert.Equal(t, defaults.CheckInterval, cfg.CheckInterval)
+	assert.Equal(t, defaults.SilenceThreshold, cfg.SilenceThreshold)
+	assert.Equal(t, defaults.MaxRetries, cfg.MaxRetries)
+	assert.Equal(t, defaults.RetryBackoff, cfg.RetryBackoff)
+	assert.Equal(t, defaults.CooldownAfterRecov, cfg.CooldownAfterRecov)
+	assert.Equal(t, defaults.EscalationTimeout, cfg.EscalationTimeout)
+}
+
+func TestBuildLivenessConfig_CustomValues(t *testing.T) {
+	t.Parallel()
+
+	ws := conf.WatchdogSettings{
+		CheckInterval:     5,
+		SilenceThreshold:  60,
+		MaxRetries:        5,
+		RetryBackoff:      10,
+		Cooldown:          120,
+		EscalationTimeout: 90,
+	}
+	cfg := buildLivenessConfig(ws)
+
+	assert.Equal(t, 5*time.Second, cfg.CheckInterval)
+	assert.Equal(t, 60*time.Second, cfg.SilenceThreshold)
+	assert.Equal(t, 5, cfg.MaxRetries)
+	assert.Equal(t, 10*time.Second, cfg.RetryBackoff)
+	assert.Equal(t, 120*time.Second, cfg.CooldownAfterRecov)
+	assert.Equal(t, 90*time.Second, cfg.EscalationTimeout)
+}
+
+func TestBuildLivenessConfig_PartialOverride(t *testing.T) {
+	t.Parallel()
+
+	ws := conf.WatchdogSettings{
+		SilenceThreshold: 45,
+		MaxRetries:       10,
+	}
+	cfg := buildLivenessConfig(ws)
+	defaults := audiocore.DefaultLivenessConfig()
+
+	assert.Equal(t, defaults.CheckInterval, cfg.CheckInterval, "unset field should use default")
+	assert.Equal(t, 45*time.Second, cfg.SilenceThreshold)
+	assert.Equal(t, 10, cfg.MaxRetries)
+	assert.Equal(t, defaults.RetryBackoff, cfg.RetryBackoff, "unset field should use default")
+	assert.Equal(t, defaults.CooldownAfterRecov, cfg.CooldownAfterRecov, "unset field should use default")
+	assert.Equal(t, defaults.EscalationTimeout, cfg.EscalationTimeout, "unset field should use default")
 }

--- a/internal/api/v2/README.md
+++ b/internal/api/v2/README.md
@@ -94,15 +94,15 @@ Lightweight connectivity check. Returns a minimal response with no database quer
 
 ### Control Operations (`control.go`)
 
-| Method | Route                          | Handler               | Auth | Description                           |
-| ------ | ------------------------------ | --------------------- | ---- | ------------------------------------- |
-| POST   | `/control/restart`             | `RestartAnalysis`     | ✅   | Restart analysis engine               |
-| POST   | `/control/reload`              | `ReloadModel`         | ✅   | Reload BirdNET model                  |
-| POST   | `/control/rebuild-filter`      | `RebuildFilter`       | ✅   | Rebuild range filter                  |
-| POST   | `/control/restart-server`      | `RestartServer`       | ✅   | Restart the server binary             |
-| POST   | `/control/restart-container`   | `RestartContainer`    | ✅   | Restart the container (container only)|
-| POST   | `/control/restart-source/:id`  | `RestartAudioSource`  | ✅   | Restart a single audio source by ID   |
-| GET    | `/control/actions`             | `GetAvailableActions` | ✅   | List available control actions        |
+| Method | Route                         | Handler               | Auth | Description                            |
+| ------ | ----------------------------- | --------------------- | ---- | -------------------------------------- |
+| POST   | `/control/restart`            | `RestartAnalysis`     | ✅   | Restart analysis engine                |
+| POST   | `/control/reload`             | `ReloadModel`         | ✅   | Reload BirdNET model                   |
+| POST   | `/control/rebuild-filter`     | `RebuildFilter`       | ✅   | Rebuild range filter                   |
+| POST   | `/control/restart-server`     | `RestartServer`       | ✅   | Restart the server binary              |
+| POST   | `/control/restart-container`  | `RestartContainer`    | ✅   | Restart the container (container only) |
+| POST   | `/control/restart-source/:id` | `RestartAudioSource`  | ✅   | Restart a single audio source by ID    |
+| GET    | `/control/actions`            | `GetAvailableActions` | ✅   | List available control actions         |
 
 ### Debug (`debug.go`)
 
@@ -128,17 +128,17 @@ Lightweight connectivity check. Returns a minimal response with no database quer
 
 ### Integrations (`integrations.go`)
 
-| Method | Route                                        | Handler                         | Auth | Description                           |
-| ------ | -------------------------------------------- | ------------------------------- | ---- | ------------------------------------- |
-| GET    | `/integrations/mqtt/status`                  | `GetMQTTStatus`                 | ✅   | MQTT connection status                |
-| POST   | `/integrations/mqtt/test`                    | `TestMQTTConnection`            | ✅   | Test MQTT connection                  |
-| POST   | `/integrations/mqtt/homeassistant/discovery` | `TriggerHomeAssistantDiscovery` | ✅   | Trigger Home Assistant MQTT discovery |
-| GET    | `/integrations/mqtt/tls/certificate`         | `GetMQTTTLSCertificate`         | ✅   | Get MQTT TLS certificate status       |
-| POST   | `/integrations/mqtt/tls/certificate`         | `UploadMQTTTLSCertificate`      | ✅   | Upload MQTT TLS certificates          |
-| DELETE | `/integrations/mqtt/tls/certificate`         | `DeleteMQTTTLSCertificate`      | ✅   | Remove MQTT TLS certificates          |
-| GET    | `/integrations/birdweather/status`           | `GetBirdWeatherStatus`          | ✅   | BirdWeather integration status        |
-| POST   | `/integrations/birdweather/test`             | `TestBirdWeatherConnection`     | ✅   | Test BirdWeather connection           |
-| POST   | `/integrations/weather/test`                 | `TestWeatherConnection`         | ✅   | Test weather provider connection      |
+| Method | Route                                        | Handler                         | Auth | Description                                    |
+| ------ | -------------------------------------------- | ------------------------------- | ---- | ---------------------------------------------- |
+| GET    | `/integrations/mqtt/status`                  | `GetMQTTStatus`                 | ✅   | MQTT connection status                         |
+| POST   | `/integrations/mqtt/test`                    | `TestMQTTConnection`            | ✅   | Test MQTT connection                           |
+| POST   | `/integrations/mqtt/homeassistant/discovery` | `TriggerHomeAssistantDiscovery` | ✅   | Trigger Home Assistant MQTT discovery          |
+| GET    | `/integrations/mqtt/tls/certificate`         | `GetMQTTTLSCertificate`         | ✅   | Get MQTT TLS certificate status                |
+| POST   | `/integrations/mqtt/tls/certificate`         | `UploadMQTTTLSCertificate`      | ✅   | Upload MQTT TLS certificates                   |
+| DELETE | `/integrations/mqtt/tls/certificate`         | `DeleteMQTTTLSCertificate`      | ✅   | Remove MQTT TLS certificates                   |
+| GET    | `/integrations/birdweather/status`           | `GetBirdWeatherStatus`          | ✅   | BirdWeather integration status                 |
+| POST   | `/integrations/birdweather/test`             | `TestBirdWeatherConnection`     | ✅   | Test BirdWeather connection                    |
+| POST   | `/integrations/weather/test`                 | `TestWeatherConnection`         | ✅   | Test weather provider connection               |
 | POST   | `/integrations/ebird/test`                   | `TestEBirdConnection`           | ✅   | Test eBird API connectivity and authentication |
 
 ### Media (`media.go`)
@@ -157,30 +157,30 @@ Lightweight connectivity check. Returns a minimal response with no database quer
 
 ### Notifications (`notifications.go`)
 
-| Method | Route                              | Handler                            | Auth | Description                                                                                                                                                   |
-| ------ | ---------------------------------- | ---------------------------------- | ---- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| GET    | `/notifications/stream`            | `StreamNotifications`              | ❌⚡ | SSE notification & toast stream (public read-only, rate-limited). Used by dashboard NotificationBell.                                                         |
-| GET    | `/notifications`                   | `GetNotifications`                 | ❌   | List notifications (public read-only). Used by dashboard NotificationBell.                                                                                    |
-| GET    | `/notifications/:id`               | `GetNotification`                  | ✅   | Get specific notification                                                                                                                                     |
-| PUT    | `/notifications/read-all`          | `MarkAllNotificationsRead`         | ✅   | Mark all unread notifications as read in one call. Returns `{"count": N}`.                                                                                    |
-| PUT    | `/notifications/:id/read`          | `MarkNotificationRead`             | ✅   | Mark notification as read                                                                                                                                     |
-| PUT    | `/notifications/:id/acknowledge`   | `MarkNotificationAcknowledged`     | ✅   | Acknowledge notification                                                                                                                                      |
-| DELETE | `/notifications/:id`               | `DeleteNotification`               | ✅   | Delete notification                                                                                                                                           |
-| GET    | `/notifications/unread/count`      | `GetUnreadCount`                   | ❌   | Count unread notifications (public read-only). Used by dashboard NotificationBell.                                                                            |
-| POST   | `/notifications/test/new-species`  | `CreateTestNewSpeciesNotification` | ✅   | Create test new-species notification                                                                                                                          |
-| GET    | `/notifications/check-ntfy-server` | `CheckNtfyServer`                  | ✅   | Probe NTFY host for HTTPS/HTTP connectivity (authenticated to prevent SSRF relay). Query: `host=<hostname[:port]>`.                                           |
+| Method | Route                              | Handler                            | Auth | Description                                                                                                         |
+| ------ | ---------------------------------- | ---------------------------------- | ---- | ------------------------------------------------------------------------------------------------------------------- |
+| GET    | `/notifications/stream`            | `StreamNotifications`              | ❌⚡ | SSE notification & toast stream (public read-only, rate-limited). Used by dashboard NotificationBell.               |
+| GET    | `/notifications`                   | `GetNotifications`                 | ❌   | List notifications (public read-only). Used by dashboard NotificationBell.                                          |
+| GET    | `/notifications/:id`               | `GetNotification`                  | ✅   | Get specific notification                                                                                           |
+| PUT    | `/notifications/read-all`          | `MarkAllNotificationsRead`         | ✅   | Mark all unread notifications as read in one call. Returns `{"count": N}`.                                          |
+| PUT    | `/notifications/:id/read`          | `MarkNotificationRead`             | ✅   | Mark notification as read                                                                                           |
+| PUT    | `/notifications/:id/acknowledge`   | `MarkNotificationAcknowledged`     | ✅   | Acknowledge notification                                                                                            |
+| DELETE | `/notifications/:id`               | `DeleteNotification`               | ✅   | Delete notification                                                                                                 |
+| GET    | `/notifications/unread/count`      | `GetUnreadCount`                   | ❌   | Count unread notifications (public read-only). Used by dashboard NotificationBell.                                  |
+| POST   | `/notifications/test/new-species`  | `CreateTestNewSpeciesNotification` | ✅   | Create test new-species notification                                                                                |
+| GET    | `/notifications/check-ntfy-server` | `CheckNtfyServer`                  | ✅   | Probe NTFY host for HTTPS/HTTP connectivity (authenticated to prevent SSRF relay). Query: `host=<hostname[:port]>`. |
 
 ### Range Filter (`range.go`)
 
-| Method | Route                   | Handler                        | Auth | Description                                                      |
-| ------ | ----------------------- | ------------------------------ | ---- | ---------------------------------------------------------------- |
-| GET    | `/range/status`         | `GetRangeFilterStatus`         | ❌   | Per-classifier geomodel coverage, auto-selection, threshold      |
-| GET    | `/range/species/scores` | `GetRangeFilterSpeciesScores`  | ❌   | All species with raw geomodel scores (no threshold cutoff)       |
-| GET    | `/range/species/count`  | `GetRangeFilterSpeciesCount`   | ❌   | Species count with range filter                                  |
-| GET    | `/range/species/list`   | `GetRangeFilterSpeciesList`    | ❌   | Species list with taxonomy groups                                |
-| GET    | `/range/species/csv`    | `GetRangeFilterSpeciesCSV`     | ❌   | Export species list as CSV download                              |
-| POST   | `/range/species/test`   | `TestRangeFilter`              | ❌   | Test range filter configuration                                  |
-| POST   | `/range/rebuild`        | `RebuildRangeFilter`           | ❌   | Rebuild range filter data                                        |
+| Method | Route                   | Handler                       | Auth | Description                                                 |
+| ------ | ----------------------- | ----------------------------- | ---- | ----------------------------------------------------------- |
+| GET    | `/range/status`         | `GetRangeFilterStatus`        | ❌   | Per-classifier geomodel coverage, auto-selection, threshold |
+| GET    | `/range/species/scores` | `GetRangeFilterSpeciesScores` | ❌   | All species with raw geomodel scores (no threshold cutoff)  |
+| GET    | `/range/species/count`  | `GetRangeFilterSpeciesCount`  | ❌   | Species count with range filter                             |
+| GET    | `/range/species/list`   | `GetRangeFilterSpeciesList`   | ❌   | Species list with taxonomy groups                           |
+| GET    | `/range/species/csv`    | `GetRangeFilterSpeciesCSV`    | ❌   | Export species list as CSV download                         |
+| POST   | `/range/species/test`   | `TestRangeFilter`             | ❌   | Test range filter configuration                             |
+| POST   | `/range/rebuild`        | `RebuildRangeFilter`          | ❌   | Rebuild range filter data                                   |
 
 ### Search (`search.go`)
 
@@ -190,15 +190,15 @@ Lightweight connectivity check. Returns a minimal response with no database quer
 
 ### Settings (`settings.go`)
 
-| Method | Route                      | Handler                 | Auth | Description                                                    |
-| ------ | -------------------------- | ----------------------- | ---- | -------------------------------------------------------------- |
-| GET    | `/settings`                | `GetAllSettings`        | ✅   | Get all configuration settings                                 |
-| GET    | `/settings/locales`        | `GetLocales`            | ✅   | Get available locales                                          |
-| GET    | `/settings/imageproviders` | `GetImageProviders`     | ✅   | Get image provider options                                     |
-| GET    | `/settings/systemid`       | `GetSystemID`           | ✅   | Get system identifier                                          |
-| GET    | `/settings/dashboard`      | `GetDashboardSettings`  | ❌   | Get dashboard display preferences (public, non-sensitive)      |
-| GET    | `/settings/:section`       | `GetSectionSettings`    | ✅   | Get specific settings section (other sections remain protected) |
-| PUT    | `/settings`                | `UpdateSettings`        | ✅   | Update all settings                                            |
+| Method | Route                      | Handler                 | Auth | Description                                                         |
+| ------ | -------------------------- | ----------------------- | ---- | ------------------------------------------------------------------- |
+| GET    | `/settings`                | `GetAllSettings`        | ✅   | Get all configuration settings                                      |
+| GET    | `/settings/locales`        | `GetLocales`            | ✅   | Get available locales                                               |
+| GET    | `/settings/imageproviders` | `GetImageProviders`     | ✅   | Get image provider options                                          |
+| GET    | `/settings/systemid`       | `GetSystemID`           | ✅   | Get system identifier                                               |
+| GET    | `/settings/dashboard`      | `GetDashboardSettings`  | ❌   | Get dashboard display preferences (public, non-sensitive)           |
+| GET    | `/settings/:section`       | `GetSectionSettings`    | ✅   | Get specific settings section (other sections remain protected)     |
+| PUT    | `/settings`                | `UpdateSettings`        | ✅   | Update all settings                                                 |
 | PATCH  | `/settings/:section`       | `UpdateSectionSettings` | ✅   | Update settings section (writes to `/dashboard` still require auth) |
 
 The `GET /settings/dashboard` endpoint is intentionally public so that unauthenticated guests can render the SPA dashboard (species summary limit, layout, locale, thumbnails). The Dashboard section contains no secrets, tokens, or PII, and the layout is already exposed via `/app/config`. All mutations (PATCH) on the dashboard section remain auth-protected.
@@ -236,10 +236,10 @@ The `GET /settings/dashboard` endpoint is intentionally public so that unauthent
 
 ### Audio Level SSE (`audio_level.go`) and Stream Sources (`audio_sources.go`)
 
-| Method | Route                  | Handler              | Auth | Description                              |
-| ------ | ---------------------- | -------------------- | ---- | ---------------------------------------- |
-| GET    | `/streams/audio-level` | `StreamAudioLevel`   | ❌   | Real-time audio level SSE                |
-| GET    | `/streams/sources`     | `ListStreamSources`  | ❌   | Active stream sources (RTSP, HTTP, etc.) |
+| Method | Route                  | Handler             | Auth | Description                              |
+| ------ | ---------------------- | ------------------- | ---- | ---------------------------------------- |
+| GET    | `/streams/audio-level` | `StreamAudioLevel`  | ❌   | Real-time audio level SSE                |
+| GET    | `/streams/sources`     | `ListStreamSources` | ❌   | Active stream sources (RTSP, HTTP, etc.) |
 
 **Features:**
 
@@ -284,14 +284,14 @@ Returns an empty `sources` array when no sources are configured. The `type` fiel
 
 ### HLS Streaming (`audio_hls.go`)
 
-| Method | Route                                            | Handler            | Auth                 | Description                    |
-| ------ | ------------------------------------------------ | ------------------ | -------------------- | ------------------------------ |
-| POST   | `/streams/hls/:sourceID/start`                   | `StartHLSStream`   | ✅                   | Start HLS stream for source    |
-| POST   | `/streams/hls/:sourceID/stop`                    | `StopHLSStream`    | ✅                   | Stop HLS stream                |
-| POST   | `/streams/hls/heartbeat`                         | `HLSHeartbeat`     | ✅ publicLiveAudio   | Keep HLS stream alive          |
-| GET    | `/streams/hls/status`                            | `GetHLSStatus`     | ✅ publicLiveAudio   | Get status of all HLS streams  |
-| GET    | `/streams/hls/t/:streamToken/playlist.m3u8`      | `ServeHLSPlaylist` | 🔑 token             | Get HLS playlist via token     |
-| GET    | `/streams/hls/t/:streamToken/*`                  | `ServeHLSContent`  | 🔑 token             | Serve HLS segments via token   |
+| Method | Route                                       | Handler            | Auth               | Description                   |
+| ------ | ------------------------------------------- | ------------------ | ------------------ | ----------------------------- |
+| POST   | `/streams/hls/:sourceID/start`              | `StartHLSStream`   | ✅                 | Start HLS stream for source   |
+| POST   | `/streams/hls/:sourceID/stop`               | `StopHLSStream`    | ✅                 | Stop HLS stream               |
+| POST   | `/streams/hls/heartbeat`                    | `HLSHeartbeat`     | ✅ publicLiveAudio | Keep HLS stream alive         |
+| GET    | `/streams/hls/status`                       | `GetHLSStatus`     | ✅ publicLiveAudio | Get status of all HLS streams |
+| GET    | `/streams/hls/t/:streamToken/playlist.m3u8` | `ServeHLSPlaylist` | 🔑 token           | Get HLS playlist via token    |
+| GET    | `/streams/hls/t/:streamToken/*`             | `ServeHLSContent`  | 🔑 token           | Serve HLS segments via token  |
 
 **Token-Based Authentication:**
 
@@ -361,17 +361,17 @@ HLS playlist and segment routes use token-based authentication instead of standa
 
 ### Stream Health Monitoring (`streams_health.go`)
 
-| Method | Route                    | Handler                   | Auth | Description                                               |
-| ------ | ------------------------ | ------------------------- | ---- | --------------------------------------------------------- |
-| GET    | `/streams/health`        | `GetAllStreamsHealth`     | ✅   | Get detailed health status of all RTSP streams (settings-only; URLs sanitized)        |
-| GET    | `/streams/health/:url`   | `GetStreamHealth`         | ✅   | Get detailed health status of a specific RTSP stream (settings-only; URLs sanitized)  |
-| GET    | `/streams/status`        | `GetStreamsStatusSummary` | ✅   | Get high-level summary of all stream statuses with counts (settings-only)             |
-| GET    | `/streams/health/stream` | `StreamHealthUpdates`     | ✅⚡ | Real-time stream health updates via SSE (settings page, not dashboard)                |
+| Method | Route                    | Handler                   | Auth | Description                                                                          |
+| ------ | ------------------------ | ------------------------- | ---- | ------------------------------------------------------------------------------------ |
+| GET    | `/streams/health`        | `GetAllStreamsHealth`     | ✅   | Get detailed health status of all RTSP streams (settings-only; URLs sanitized)       |
+| GET    | `/streams/health/:url`   | `GetStreamHealth`         | ✅   | Get detailed health status of a specific RTSP stream (settings-only; URLs sanitized) |
+| GET    | `/streams/status`        | `GetStreamsStatusSummary` | ✅   | Get high-level summary of all stream statuses with counts (settings-only)            |
+| GET    | `/streams/health/stream` | `StreamHealthUpdates`     | ✅⚡ | Real-time stream health updates via SSE (settings page, not dashboard)               |
 
 ### Quiet Hours Status (`quiet_hours.go`)
 
-| Method | Route                         | Handler               | Auth | Description                                               |
-| ------ | ----------------------------- | --------------------- | ---- | --------------------------------------------------------- |
+| Method | Route                         | Handler               | Auth | Description                                                                                                             |
+| ------ | ----------------------------- | --------------------- | ---- | ----------------------------------------------------------------------------------------------------------------------- |
 | GET    | `/streams/quiet-hours/status` | `GetQuietHoursStatus` | ❌   | Get current quiet hours suppression state for all sources (URLs sanitized). Used by dashboard "Currently Hearing" card. |
 
 **Response Format:**
@@ -484,15 +484,15 @@ Requires enhanced (v2) database. Returns 409 Conflict if not available.
 
 ### Models (`models.go`)
 
-| Method | Route                         | Handler                 | Auth | Description                                          |
-| ------ | ----------------------------- | ----------------------- | ---- | ---------------------------------------------------- |
-| GET    | `/models`                     | `ListModels`            | ❌   | List available classifier models                     |
-| GET    | `/models/catalog`             | `GetModelCatalog`       | ❌   | Model gallery catalog with install status            |
-| GET    | `/models/installed`           | `GetInstalledModels`    | ❌   | List downloaded models                               |
-| POST   | `/models/install/:id`         | `InstallModel`          | ✅   | Download and install a catalog model                 |
-| POST   | `/models/reinstall/:id`       | `ReinstallModel`        | ✅   | Re-download missing/corrupt files for installed model |
-| DELETE | `/models/installed/:id`       | `UninstallModel`        | ✅   | Remove an installed model from disk                  |
-| GET    | `/models/install/:id/progress`| `StreamInstallProgress` | ❌   | SSE stream for install/reinstall progress            |
+| Method | Route                          | Handler                 | Auth | Description                                           |
+| ------ | ------------------------------ | ----------------------- | ---- | ----------------------------------------------------- |
+| GET    | `/models`                      | `ListModels`            | ❌   | List available classifier models                      |
+| GET    | `/models/catalog`              | `GetModelCatalog`       | ❌   | Model gallery catalog with install status             |
+| GET    | `/models/installed`            | `GetInstalledModels`    | ❌   | List downloaded models                                |
+| POST   | `/models/install/:id`          | `InstallModel`          | ✅   | Download and install a catalog model                  |
+| POST   | `/models/reinstall/:id`        | `ReinstallModel`        | ✅   | Re-download missing/corrupt files for installed model |
+| DELETE | `/models/installed/:id`        | `UninstallModel`        | ✅   | Remove an installed model from disk                   |
+| GET    | `/models/install/:id/progress` | `StreamInstallProgress` | ❌   | SSE stream for install/reinstall progress             |
 
 **GET /api/v2/models** — Returns all classifier models registered in the model registry. Each entry includes a config alias (used in audio source configuration) and a human-readable display name.
 
@@ -954,7 +954,6 @@ Updates are sent only when changes are detected, reducing bandwidth compared to 
 ### Integration Tips
 
 1. **Choose the Right Endpoint** (all require authentication — settings page only):
-
    - Use SSE (`/streams/health/stream`) for real-time settings-page monitoring
    - Use REST polling (`/streams/status`) for periodic background checks on the settings page
    - Use REST (`/streams/health/:url`) for on-demand detailed diagnostics

--- a/internal/api/v2/README.md
+++ b/internal/api/v2/README.md
@@ -94,12 +94,15 @@ Lightweight connectivity check. Returns a minimal response with no database quer
 
 ### Control Operations (`control.go`)
 
-| Method | Route                     | Handler               | Auth | Description                    |
-| ------ | ------------------------- | --------------------- | ---- | ------------------------------ |
-| POST   | `/control/restart`        | `RestartAnalysis`     | ✅   | Restart analysis engine        |
-| POST   | `/control/reload`         | `ReloadModel`         | ✅   | Reload BirdNET model           |
-| POST   | `/control/rebuild-filter` | `RebuildFilter`       | ✅   | Rebuild range filter           |
-| GET    | `/control/actions`        | `GetAvailableActions` | ✅   | List available control actions |
+| Method | Route                          | Handler               | Auth | Description                           |
+| ------ | ------------------------------ | --------------------- | ---- | ------------------------------------- |
+| POST   | `/control/restart`             | `RestartAnalysis`     | ✅   | Restart analysis engine               |
+| POST   | `/control/reload`              | `ReloadModel`         | ✅   | Reload BirdNET model                  |
+| POST   | `/control/rebuild-filter`      | `RebuildFilter`       | ✅   | Rebuild range filter                  |
+| POST   | `/control/restart-server`      | `RestartServer`       | ✅   | Restart the server binary             |
+| POST   | `/control/restart-container`   | `RestartContainer`    | ✅   | Restart the container (container only)|
+| POST   | `/control/restart-source/:id`  | `RestartAudioSource`  | ✅   | Restart a single audio source by ID   |
+| GET    | `/control/actions`             | `GetAvailableActions` | ✅   | List available control actions        |
 
 ### Debug (`debug.go`)
 

--- a/internal/api/v2/api.go
+++ b/internal/api/v2/api.go
@@ -134,7 +134,14 @@ type Controller struct {
 	// Stored atomically because it is set during pipeline Start() and read
 	// concurrently by HTTP handlers.
 	audioWatchdog atomic.Pointer[audiocore.LivenessWatchdog]
+
+	// sourceRestarter restarts a single audio source by ID. Set during
+	// pipeline Start() and called by the restart-source control endpoint.
+	sourceRestarter atomic.Pointer[SourceRestarterFunc]
 }
+
+// SourceRestarterFunc restarts a single audio source identified by sourceID.
+type SourceRestarterFunc func(sourceID string) error
 
 // ShutdownRequester allows triggering a programmatic shutdown.
 type ShutdownRequester interface {

--- a/internal/api/v2/control.go
+++ b/internal/api/v2/control.go
@@ -272,6 +272,10 @@ func (c *Controller) RestartContainer(ctx echo.Context) error {
 
 // SetSourceRestarter injects the function used by the restart-source endpoint.
 func (c *Controller) SetSourceRestarter(fn SourceRestarterFunc) {
+	if fn == nil {
+		c.sourceRestarter.Store(nil)
+		return
+	}
 	c.sourceRestarter.Store(&fn)
 }
 

--- a/internal/api/v2/control.go
+++ b/internal/api/v2/control.go
@@ -30,11 +30,12 @@ type ControlResult struct {
 
 // Available control actions
 const (
-	ActionRestartAnalysis  = "restart_analysis"
-	ActionReloadModel      = "reload_model"
-	ActionRebuildFilter    = "rebuild_filter"
-	ActionRestartServer    = "restart_server"
-	ActionRestartContainer = "restart_container"
+	ActionRestartAnalysis    = "restart_analysis"
+	ActionReloadModel        = "reload_model"
+	ActionRebuildFilter      = "rebuild_filter"
+	ActionRestartServer      = "restart_server"
+	ActionRestartContainer   = "restart_container"
+	ActionRestartAudioSource = "restart_audio_source"
 )
 
 // Control channel signals
@@ -57,6 +58,7 @@ func (c *Controller) initControlRoutes() {
 	controlGroup.POST("/rebuild-filter", c.RebuildFilter)
 	controlGroup.POST("/restart-server", c.RestartServer)
 	controlGroup.POST("/restart-container", c.RestartContainer)
+	controlGroup.POST("/restart-source/:id", c.RestartAudioSource)
 	controlGroup.GET("/actions", c.GetAvailableActions)
 
 	c.logInfoIfEnabled("Control routes initialized successfully")
@@ -86,6 +88,10 @@ func (c *Controller) GetAvailableActions(ctx echo.Context) error {
 		{
 			Action:      ActionRestartServer,
 			Description: "Restart the server binary",
+		},
+		{
+			Action:      ActionRestartAudioSource,
+			Description: "Restart a single audio source by ID",
 		},
 	}
 
@@ -262,4 +268,62 @@ func (c *Controller) RestartContainer(ctx echo.Context) error {
 	}
 
 	return c.handleRestartRequest(ctx, ActionRestartContainer, restart.SetContainerRestart, "Container restart initiated")
+}
+
+// SetSourceRestarter injects the function used by the restart-source endpoint.
+func (c *Controller) SetSourceRestarter(fn SourceRestarterFunc) {
+	c.sourceRestarter.Store(&fn)
+}
+
+// RestartAudioSource handles POST /api/v2/control/restart-source/:id
+// Restarts a single audio source without affecting the rest of the pipeline.
+func (c *Controller) RestartAudioSource(ctx echo.Context) error {
+	sourceID := ctx.Param("id")
+	if sourceID == "" {
+		return c.HandleError(ctx, nil, "Source ID is required", http.StatusBadRequest)
+	}
+
+	c.logInfoIfEnabled("Received request to restart audio source",
+		logger.String("source_id", sourceID),
+		logger.String("path", ctx.Request().URL.Path),
+		logger.String("ip", ctx.RealIP()),
+	)
+
+	if c.engine == nil {
+		return c.HandleError(ctx, fmt.Errorf("audio engine not initialized"),
+			"Audio engine not available", http.StatusInternalServerError)
+	}
+	if _, ok := c.engine.Registry().Get(sourceID); !ok {
+		return c.HandleError(ctx, fmt.Errorf("source %s not found", sourceID),
+			"Audio source not found", http.StatusNotFound)
+	}
+
+	fn := c.sourceRestarter.Load()
+	if fn == nil {
+		return c.HandleError(ctx, fmt.Errorf("source restarter not initialized"),
+			"Audio pipeline not started", http.StatusServiceUnavailable)
+	}
+
+	if err := (*fn)(sourceID); err != nil {
+		c.logErrorIfEnabled("Failed to restart audio source",
+			logger.String("source_id", sourceID),
+			logger.Error(err),
+			logger.String("path", ctx.Request().URL.Path),
+			logger.String("ip", ctx.RealIP()),
+		)
+		return c.HandleError(ctx, err, "Failed to restart audio source", http.StatusInternalServerError)
+	}
+
+	c.logInfoIfEnabled("Audio source restarted successfully",
+		logger.String("source_id", sourceID),
+		logger.String("path", ctx.Request().URL.Path),
+		logger.String("ip", ctx.RealIP()),
+	)
+
+	return ctx.JSON(http.StatusOK, ControlResult{
+		Success:   true,
+		Message:   fmt.Sprintf("Audio source %s restarted", sourceID),
+		Action:    ActionRestartAudioSource,
+		Timestamp: time.Now(),
+	})
 }

--- a/internal/api/v2/control_restart_source_test.go
+++ b/internal/api/v2/control_restart_source_test.go
@@ -1,0 +1,165 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/audiocore"
+	"github.com/tphakala/birdnet-go/internal/audiocore/engine"
+)
+
+func TestRestartAudioSource_NoEngine(t *testing.T) {
+	t.Parallel()
+	e := echo.New()
+	c := getTestController(t, e)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v2/control/restart-source/test-src", http.NoBody)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+	ctx.SetParamNames("id")
+	ctx.SetParamValues("test-src")
+
+	err := c.RestartAudioSource(ctx)
+	assertControllerError(t, err, rec, http.StatusInternalServerError, "Audio engine not available")
+}
+
+func TestRestartAudioSource_SourceNotFound(t *testing.T) {
+	t.Parallel()
+	e := echo.New()
+	c := getTestController(t, e)
+
+	eng := engine.New(t.Context(), &engine.Config{}, nil)
+	defer eng.Stop()
+	c.engine = eng
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v2/control/restart-source/nonexistent", http.NoBody)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+	ctx.SetParamNames("id")
+	ctx.SetParamValues("nonexistent")
+
+	err := c.RestartAudioSource(ctx)
+	assertControllerError(t, err, rec, http.StatusNotFound, "Audio source not found")
+}
+
+func TestRestartAudioSource_NoPipeline(t *testing.T) {
+	t.Parallel()
+	e := echo.New()
+	c := getTestController(t, e)
+
+	eng := engine.New(t.Context(), &engine.Config{}, nil)
+	defer eng.Stop()
+	c.engine = eng
+
+	src := &audiocore.SourceConfig{
+		ID:          "test-src",
+		DisplayName: "Test Source",
+		Type:        audiocore.SourceTypeAudioCard,
+	}
+	_, err := eng.Registry().Register(src)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v2/control/restart-source/test-src", http.NoBody)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+	ctx.SetParamNames("id")
+	ctx.SetParamValues("test-src")
+
+	err = c.RestartAudioSource(ctx)
+	assertControllerError(t, err, rec, http.StatusServiceUnavailable, "Audio pipeline not started")
+}
+
+func TestRestartAudioSource_Success(t *testing.T) {
+	t.Parallel()
+	e := echo.New()
+	c := getTestController(t, e)
+
+	eng := engine.New(t.Context(), &engine.Config{}, nil)
+	defer eng.Stop()
+	c.engine = eng
+
+	src := &audiocore.SourceConfig{
+		ID:          "test-src",
+		DisplayName: "Test Source",
+		Type:        audiocore.SourceTypeAudioCard,
+	}
+	_, err := eng.Registry().Register(src)
+	require.NoError(t, err)
+
+	called := false
+	restarter := SourceRestarterFunc(func(sourceID string) error {
+		called = true
+		assert.Equal(t, "test-src", sourceID)
+		return nil
+	})
+	c.sourceRestarter.Store(&restarter)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v2/control/restart-source/test-src", http.NoBody)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+	ctx.SetParamNames("id")
+	ctx.SetParamValues("test-src")
+
+	err = c.RestartAudioSource(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.True(t, called)
+
+	var result ControlResult
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &result))
+	assert.True(t, result.Success)
+	assert.Equal(t, ActionRestartAudioSource, result.Action)
+}
+
+func TestRestartAudioSource_RestartError(t *testing.T) {
+	t.Parallel()
+	e := echo.New()
+	c := getTestController(t, e)
+
+	eng := engine.New(t.Context(), &engine.Config{}, nil)
+	defer eng.Stop()
+	c.engine = eng
+
+	src := &audiocore.SourceConfig{
+		ID:          "test-src",
+		DisplayName: "Test Source",
+		Type:        audiocore.SourceTypeAudioCard,
+	}
+	_, err := eng.Registry().Register(src)
+	require.NoError(t, err)
+
+	restarter := SourceRestarterFunc(func(_ string) error {
+		return fmt.Errorf("device disconnected")
+	})
+	c.sourceRestarter.Store(&restarter)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v2/control/restart-source/test-src", http.NoBody)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+	ctx.SetParamNames("id")
+	ctx.SetParamValues("test-src")
+
+	err = c.RestartAudioSource(ctx)
+	assertControllerError(t, err, rec, http.StatusInternalServerError, "Failed to restart audio source")
+}
+
+func TestRestartAudioSource_EmptyID(t *testing.T) {
+	t.Parallel()
+	e := echo.New()
+	c := getTestController(t, e)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v2/control/restart-source/", http.NoBody)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+	ctx.SetParamNames("id")
+	ctx.SetParamValues("")
+
+	err := c.RestartAudioSource(ctx)
+	assertControllerError(t, err, rec, http.StatusBadRequest, "Source ID is required")
+}

--- a/internal/api/v2/control_test.go
+++ b/internal/api/v2/control_test.go
@@ -202,14 +202,14 @@ func TestGetAvailableActions(t *testing.T) {
 		require.NoError(t, err)
 
 		// Expected action count depends on container environment
-		expectedCount := 4 // base actions + restart_server
+		expectedCount := 5 // base actions + restart_server + restart_audio_source
 		if sysinfo.IsContainer() {
-			expectedCount = 5 // + restart_container
+			expectedCount = 6 // + restart_container
 		}
 		require.Len(t, actions, expectedCount, "Should have expected control actions")
 
 		// Verify actions include all expected types
-		var hasRestartAction, hasReloadAction, hasRebuildFilterAction, hasRestartServerAction, hasRestartContainerAction bool
+		var hasRestartAction, hasReloadAction, hasRebuildFilterAction, hasRestartServerAction, hasRestartContainerAction, hasRestartAudioSourceAction bool
 		for _, action := range actions {
 			switch action.Action {
 			case ActionRestartAnalysis:
@@ -227,6 +227,9 @@ func TestGetAvailableActions(t *testing.T) {
 			case ActionRestartContainer:
 				hasRestartContainerAction = true
 				assert.Contains(t, action.Description, "Restart")
+			case ActionRestartAudioSource:
+				hasRestartAudioSourceAction = true
+				assert.Contains(t, action.Description, "Restart")
 			}
 		}
 
@@ -235,6 +238,7 @@ func TestGetAvailableActions(t *testing.T) {
 		assert.True(t, hasReloadAction, "Missing reload_model action")
 		assert.True(t, hasRebuildFilterAction, "Missing rebuild_filter action")
 		assert.True(t, hasRestartServerAction, "Missing restart_server action")
+		assert.True(t, hasRestartAudioSourceAction, "Missing restart_audio_source action")
 		if sysinfo.IsContainer() {
 			assert.True(t, hasRestartContainerAction, "Missing restart_container action")
 		}

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -108,6 +108,19 @@ type AudioSettings struct {
 
 	Equalizer  EqualizerSettings `yaml:"equalizer" json:"equalizer"`                             // equalizer settings (global default)
 	QuietHours QuietHoursConfig  `yaml:"quietHours" json:"quietHours" mapstructure:"quietHours"` // quiet hours (global default, legacy)
+	Watchdog   WatchdogSettings  `yaml:"watchdog" json:"watchdog" mapstructure:"watchdog"`       // liveness watchdog tuning (0 = use default)
+}
+
+// WatchdogSettings holds user-tunable parameters for the audio liveness watchdog.
+// All fields are in seconds (except MaxRetries which is a count). Zero values
+// mean "use production default", so existing configs work without changes.
+type WatchdogSettings struct {
+	CheckInterval     int `yaml:"checkInterval" json:"checkInterval" mapstructure:"checkInterval"`             // tick period (default 10s)
+	SilenceThreshold  int `yaml:"silenceThreshold" json:"silenceThreshold" mapstructure:"silenceThreshold"`    // silence before alarm (default 30s)
+	MaxRetries        int `yaml:"maxRetries" json:"maxRetries" mapstructure:"maxRetries"`                      // restart attempts before escalation (default 3)
+	RetryBackoff      int `yaml:"retryBackoff" json:"retryBackoff" mapstructure:"retryBackoff"`                // wait between retries (default 5s)
+	Cooldown          int `yaml:"cooldown" json:"cooldown" mapstructure:"cooldown"`                            // alarm suppression after recovery (default 60s)
+	EscalationTimeout int `yaml:"escalationTimeout" json:"escalationTimeout" mapstructure:"escalationTimeout"` // time in ESCALATED before FAILED (default 60s)
 }
 
 // FindSourceByID returns a pointer to the AudioSourceConfig matching the given


### PR DESCRIPTION
## Summary

- Add `POST /api/v2/control/restart-source/:id` endpoint to restart a single audio source without restarting the entire pipeline. The existing `RestartSource` method is injected into the API controller via `atomic.Pointer`, matching the `audioWatchdog` pattern.
- Add `WatchdogSettings` to `conf.AudioSettings` so users can tune liveness watchdog parameters (check interval, silence threshold, max retries, retry backoff, cooldown, escalation timeout) via config. Zero values fall back to production defaults.
- Fix pre-existing README gap: document `restart-server` and `restart-container` control endpoints.

## Test Plan

- [x] 6 unit tests for `RestartAudioSource` handler (no engine, source not found, no pipeline, success, restart error, empty ID)
- [x] 3 unit tests for `buildLivenessConfig` (all defaults, custom values, partial override)
- [x] All tests pass with `-race`
- [x] `golangci-lint` clean
- [x] 53 existing control/health tests pass (no regressions)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Restart individual audio sources via new /control/restart-source/:id endpoint.
  * Configurable audio watchdog parameters for liveness detection (check interval, silence threshold, retries/backoff, cooldown, escalation timeout).
  * Added additional restart control endpoints for server and container.

* **Documentation**
  * Updated API v2 docs to list new control endpoints and adjusted endpoint tables/layout.

* **Tests**
  * Added tests covering the restart-by-source endpoint and watchdog config behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3112?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->