### PR TITLE
fix: classifier safety batch (panic-safe locks, Sentry context, uninstall ordering)

### DIFF
--- a/internal/analysis/process.go
+++ b/internal/analysis/process.go
@@ -42,6 +42,8 @@ const (
 // When the window expires and enough overruns have accumulated, a single Sentry event is sent.
 type bufferOverrunTracker struct {
 	mu           sync.Mutex
+	source       string
+	modelID      string
 	overrunCount int64
 	windowStart  time.Time
 	maxElapsed   time.Duration
@@ -67,7 +69,7 @@ func getOverrunTracker(source, modelID string) *bufferOverrunTracker {
 	if t, ok := overrunTrackers[key]; ok {
 		return t
 	}
-	t := &bufferOverrunTracker{}
+	t := &bufferOverrunTracker{source: source, modelID: modelID}
 	overrunTrackers[key] = t
 	return t
 }
@@ -127,9 +129,11 @@ func recordBufferOverrun(tracker *bufferOverrunTracker, elapsed, bufferLen time.
 
 	// Check if window has expired
 	if now.Sub(tracker.windowStart) >= bufferOverrunReportCooldown {
-		// Window expired — report if threshold met
+		// Window expired; report if threshold met
 		if tracker.overrunCount >= bufferOverrunMinCount {
 			reportBufferOverruns(
+				tracker.source,
+				tracker.modelID,
 				tracker.overrunCount,
 				tracker.maxElapsed,
 				tracker.bufferLength,
@@ -151,12 +155,14 @@ func recordBufferOverrun(tracker *bufferOverrunTracker, elapsed, bufferLen time.
 }
 
 // reportBufferOverruns sends a rate-limited Sentry event with overrun statistics.
-func reportBufferOverruns(count int64, maxElapsed, bufferLen, window time.Duration) {
+func reportBufferOverruns(source, modelID string, count int64, maxElapsed, bufferLen, window time.Duration) {
 	if !telemetry.IsTelemetryEnabled() {
 		return
 	}
 
 	extras := map[string]any{
+		"source":                   source,
+		"model_id":                 modelID,
 		"overrun_count":            count,
 		"max_elapsed_ms":           maxElapsed.Milliseconds(),
 		"buffer_length_ms":         bufferLen.Milliseconds(),

--- a/internal/classifier/model_manager.go
+++ b/internal/classifier/model_manager.go
@@ -469,25 +469,38 @@ func (mm *ModelManager) Uninstall(catalogID string) error {
 		}
 	}
 
-	// Clean up shared embeddings, geomodel, and taxonomy files if no other dependent models remain.
-	mm.cleanupSharedFiles(log, catalogID, &entry, HasEmbeddingsFiles, isEmbeddingsRole, "embeddings")
-	mm.cleanupSharedFiles(log, catalogID, &entry, HasGeomodelFiles, isGeomodelRole, "geomodel")
-	mm.cleanupSharedFiles(log, catalogID, &entry, HasTaxonomyFiles, isTaxonomyRole, "taxonomy")
-
-	// Labels are intentionally retained on disk.
-
+	// Update installed map and config BEFORE reloading range filter so the
+	// reload sees the cleared geomodel path and does not re-acquire the handle.
 	delete(mm.installed, catalogID)
-
 	mm.applyConfigForUninstall(&entry)
 
-	// If geomodel was cleared during uninstall, reload the range filter
-	// so the primary model falls back to the embedded TFLite filter.
+	// Reload range filter with updated config (geomodel cleared), then delete files.
+	// Skip geomodel file deletion if reload fails (session may still hold handles).
+	geomodelReloadOK := true
 	if mm.orchestrator != nil && HasGeomodelFiles(&entry) {
 		if err := mm.orchestrator.ReloadRangeFilter(); err != nil {
-			log.Warn("Failed to hot-reload range filter after geomodel uninstall",
+			geomodelReloadOK = false
+			log.Warn("Range filter reload failed after geomodel uninstall, retaining geomodel files",
 				logger.String("catalog_id", catalogID),
 				logger.Error(err))
 		}
+	}
+
+	// Clean up shared embeddings, geomodel, and taxonomy files if no other dependent models remain.
+	mm.cleanupSharedFiles(log, catalogID, &entry, HasEmbeddingsFiles, isEmbeddingsRole, "embeddings")
+	if geomodelReloadOK {
+		mm.cleanupSharedFiles(log, catalogID, &entry, HasGeomodelFiles, isGeomodelRole, "geomodel")
+	}
+	mm.cleanupSharedFiles(log, catalogID, &entry, HasTaxonomyFiles, isTaxonomyRole, "taxonomy")
+
+	// Remove the per-model subdirectory if it is now empty (labels are retained,
+	// so Remove will fail with ENOTEMPTY if any remain, which is the desired behavior).
+	if err := os.Remove(subdir); err == nil {
+		log.Info("Removed empty model directory",
+			logger.String("path", subdir))
+	} else if !os.IsNotExist(err) {
+		log.Debug("Model directory not removed (likely non-empty)",
+			logger.String("path", subdir))
 	}
 
 	log.Info("Model uninstalled",
@@ -501,7 +514,7 @@ func (mm *ModelManager) Uninstall(catalogID string) error {
 // depends on the same files.
 // hasFiles checks whether a catalog entry depends on this kind of shared file.
 // matchRole checks whether a CatalogFile belongs to this kind.
-// The caller must hold mm.mu, and catalogID must still be in mm.installed.
+// The caller must hold mm.mu.
 func (mm *ModelManager) cleanupSharedFiles(log logger.Logger, catalogID string, entry *CatalogEntry, hasFiles func(*CatalogEntry) bool, matchRole func(string) bool, label string) {
 	if !hasFiles(entry) {
 		return

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -586,12 +586,15 @@ func (o *Orchestrator) ReloadModel() error {
 			Build()
 	}
 
-	entry.mu.Lock()
-	if err := primary.ReloadModel(); err != nil {
-		entry.mu.Unlock()
-		return err
+	var reloadErr error
+	func() {
+		entry.mu.Lock()
+		defer entry.mu.Unlock()
+		reloadErr = primary.ReloadModel()
+	}()
+	if reloadErr != nil {
+		return reloadErr
 	}
-	entry.mu.Unlock()
 
 	// Step 2: write lock to re-sync shared state and re-key if model ID changed.
 	o.mu.Lock()

--- a/internal/logger/config.go
+++ b/internal/logger/config.go
@@ -154,7 +154,15 @@ func applyConfigDefaults(cfg *LoggingConfig) {
 	ensureModuleOutput(cfg, "spectrogram.prerenderer", DefaultSpectrogramLogPath) // Same file
 
 	// Classifier orchestrator and scheduler logs
-	ensureModuleOutput(cfg, "birdnet", DefaultClassifierLogPath)
+	// ConsoleAlso is true so bat scheduler transitions and model reload events
+	// are visible in journal/container environments.
+	if _, exists := cfg.ModuleOutputs["birdnet"]; !exists {
+		cfg.ModuleOutputs["birdnet"] = ModuleOutput{
+			Enabled:     true,
+			FilePath:    DefaultClassifierLogPath,
+			ConsoleAlso: true,
+		}
+	}
 
 	// Action processing logs (command execution, database saves, notifications)
 	// ConsoleAlso is true so errors are visible in container environments

--- a/internal/telemetry/sentry.go
+++ b/internal/telemetry/sentry.go
@@ -508,11 +508,12 @@ func removePrivacyExtraFields(extra map[string]any) int {
 		"max_attempts":      true,
 		// HTTP response diagnostics (numeric, no PII)
 		"status_code": true,
-		// Audio processing performance diagnostics (numeric only)
+		// Audio processing performance diagnostics (numeric + identifiers)
 		"overrun_count":            true,
 		"max_elapsed_ms":           true,
 		"buffer_length_ms":         true,
 		"reporting_window_minutes": true,
+		"model_id":                 true, // classifier model registry identifier
 		// Audiocore diagnostic fields (identifiers, enumerations, numeric values)
 		"source_id": true, // opaque source identifier (uuid-based)
 		"source":    true, // alias used by capture buffer


### PR DESCRIPTION
## Summary

Batch of 5 related safety/correctness fixes in the classifier and analysis packages:

- **ReloadModel panic safety**: wrap entry.mu in closure with defer to prevent lock leak on panic
- **Buffer overrun telemetry**: add source and model_id to Sentry extras; store identifiers on tracker struct to avoid parameter sprawl; add model_id to telemetry allowlist
- **Uninstall ordering**: update config before reloading range filter so reload sees cleared geomodel path (prevents re-acquiring the ONNX handle); skip geomodel file deletion if reload fails
- **Empty directory cleanup**: attempt os.Remove on per-model subdirectory after uninstall (fails harmlessly with ENOTEMPTY if labels remain)
- **Logger visibility**: enable ConsoleAlso for birdnet module so orchestrator and bat scheduler logs appear in systemd journal and container stdout

## Test Plan

- [x] `go build ./...` passes
- [x] `go test -race ./internal/classifier/` (560 tests pass including all Uninstall tests)
- [x] `go test -race ./internal/analysis/` (141 tests pass)
- [x] `go test -race ./internal/logger/` (113 tests pass)
- [x] `golangci-lint run -v` (zero issues)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of model uninstallation by ensuring range-filter reloads before cleaning shared files.

* **Improvements**
  * Buffer overrun diagnostics now include source and model identifiers for clearer troubleshooting.
  * BirdNET classifier logs are routed to the console by default for better visibility.
  * Telemetry now preserves classifier model identifiers in event extras for more informative diagnostics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3114?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->