### PR TITLE
fix: defer Float32Pool return to prevent leak on inference panic

### DIFF
--- a/internal/analysis/process.go
+++ b/internal/analysis/process.go
@@ -213,14 +213,9 @@ func ProcessData(ctx context.Context, bn *classifier.Orchestrator, bufMgr *buffe
 			Build()
 	}
 
-	// Run inference on the specified model via the Orchestrator.
-	inferenceStart := time.Now()
-	results, err := bn.PredictModel(ctx, modelID, sampleData)
-	inferenceDuration := time.Since(inferenceStart)
-
-	// Return float32 buffer to pool after prediction. The Manager's lazy
-	// per-size pool map routes the slice back to the pool sized for its
-	// actual length, so non-standard sizes are handled too.
+	// Defer pool return so the buffer is reclaimed even if PredictModel panics.
+	// The Manager's lazy per-size pool map routes the slice back to the pool
+	// sized for its actual length, so non-standard sizes are handled too.
 	//
 	// INVARIANT: bn.PredictModel must copy the samples into the model's
 	// input tensor before returning; it must not retain a reference to
@@ -231,9 +226,14 @@ func ProcessData(ctx context.Context, bn *classifier.Orchestrator, bufMgr *buffe
 	// internal/classifier for the implementing side.
 	if conf.BitDepth == 16 && len(sampleData) > 0 {
 		if pool := bufMgr.Float32PoolFor(len(sampleData[0])); pool != nil {
-			pool.Put(sampleData[0])
+			defer pool.Put(sampleData[0])
 		}
 	}
+
+	// Run inference on the specified model via the Orchestrator.
+	inferenceStart := time.Now()
+	results, err := bn.PredictModel(ctx, modelID, sampleData)
+	inferenceDuration := time.Since(inferenceStart)
 
 	// Record inference duration metric (always, even on error)
 	pm := processMetrics.Load()


### PR DESCRIPTION
## Summary

If `PredictModel` panics (e.g., ONNX runtime crash), the pooled float32 buffer was never returned because `pool.Put()` was placed synchronously after the call. The panic propagates to the goroutine recovery handler in `buffer_manager.go`, permanently leaking the buffer.

Fix: defer `pool.Put()` immediately after obtaining the buffer, before calling `PredictModel`. The buffer is returned at function exit regardless of panic or normal return.

Safe because `PredictModel` copies samples into the model's input tensor before returning (verified in both TFLite and ONNX backends), so the deferred Put cannot cause use-after-free.

## Test Plan

- [x] `go build ./internal/analysis/...` compiles cleanly
- [x] `go test -race -v ./internal/analysis/` passes
- [x] `golangci-lint run -v ./internal/analysis/` has zero findings
- [x] Gate review (4 agents + Gemini cross-validation) passed clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced robustness of audio processing operations to guarantee proper resource management and cleanup during inference, improving system stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3115?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->