### PR TITLE
perf(heatmap): dedicated multi-threaded ONNX session for inference

### DIFF
--- a/internal/api/v2/heatmap.go
+++ b/internal/api/v2/heatmap.go
@@ -2,12 +2,16 @@ package api
 
 import (
 	"container/list"
+	"context"
 	"encoding/binary"
 	"fmt"
 	"math"
 	"net/http"
+	"strconv"
 	"sync"
 	"sync/atomic"
+
+	"golang.org/x/sync/singleflight"
 
 	"github.com/labstack/echo/v4"
 	"github.com/tphakala/birdnet-go/internal/classifier"
@@ -28,7 +32,20 @@ const (
 	heatmapMaxResolution = 5.0
 	heatmapMaxGridCells  = 50000
 	heatmapBatchSize     = 512
+	heatmapOptBatchSize  = 4096
+	heatmapMaxConcurrent = 2
 )
+
+// Valid stride values (divisors of 48)
+var validStrides = map[int]bool{
+	1: true, 2: true, 4: true, 6: true, 8: true, 12: true, 16: true, 24: true, 48: true,
+}
+
+// heatmapFlight deduplicates concurrent identical heatmap requests.
+var heatmapFlight singleflight.Group
+
+// heatmapSem limits concurrent heatmap computations to prevent memory exhaustion.
+var heatmapSem = make(chan struct{}, heatmapMaxConcurrent)
 
 // heatmapLRU is a thread-safe LRU cache for pre-encoded BNHM responses.
 // Keyed by normalized request parameters; values are ready-to-send []byte.
@@ -128,6 +145,12 @@ func heatmapCacheKey(species string, south, north, west, east, resolution float6
 // encodeBNHM encodes a heatmap grid into the BNHM binary format.
 // data layout: float32[weeks][rows][cols], little-endian.
 func encodeBNHM(cols, rows int, south, west, resolution float32, data []float32) []byte {
+	return encodeBNHMWithWeeks(cols, rows, bnhmWeeks, south, west, resolution, data)
+}
+
+// encodeBNHMWithWeeks encodes a heatmap grid with a custom week count.
+// Used when stride > 1 reduces the number of computed weeks.
+func encodeBNHMWithWeeks(cols, rows, weeks int, south, west, resolution float32, data []float32) []byte {
 	size := bnhmHeaderSize + len(data)*4
 	buf := make([]byte, size)
 
@@ -135,7 +158,7 @@ func encodeBNHM(cols, rows int, south, west, resolution float32, data []float32)
 	binary.LittleEndian.PutUint32(buf[4:8], bnhmVersion)
 	binary.LittleEndian.PutUint32(buf[8:12], uint32(cols))
 	binary.LittleEndian.PutUint32(buf[12:16], uint32(rows))
-	binary.LittleEndian.PutUint32(buf[16:20], bnhmWeeks)
+	binary.LittleEndian.PutUint32(buf[16:20], uint32(weeks))
 	binary.LittleEndian.PutUint32(buf[20:24], math.Float32bits(south))
 	binary.LittleEndian.PutUint32(buf[24:28], math.Float32bits(west))
 	binary.LittleEndian.PutUint32(buf[28:32], math.Float32bits(resolution))
@@ -207,6 +230,7 @@ type heatmapParams struct {
 	resolution float64
 	rows       int
 	cols       int
+	stride     int
 }
 
 // validateHeatmapParams parses and validates heatmap query parameters.
@@ -261,6 +285,16 @@ func (c *Controller) validateHeatmapParams(ctx echo.Context) (*heatmapParams, er
 		return nil, fmt.Errorf("grid too large: %d cells exceeds maximum %d", rows*cols, heatmapMaxGridCells)
 	}
 
+	// Parse optional stride parameter (default 1 = all 48 weeks)
+	stride := 1
+	if strideStr := ctx.QueryParam("stride"); strideStr != "" {
+		s, err := strconv.Atoi(strideStr)
+		if err != nil || !validStrides[s] {
+			return nil, fmt.Errorf("invalid stride: must be a divisor of 48 (1,2,4,6,8,12,16,24,48)")
+		}
+		stride = s
+	}
+
 	return &heatmapParams{
 		species:    species,
 		south:      south,
@@ -270,6 +304,7 @@ func (c *Controller) validateHeatmapParams(ctx echo.Context) (*heatmapParams, er
 		resolution: resolution,
 		rows:       rows,
 		cols:       cols,
+		stride:     stride,
 	}, nil
 }
 
@@ -331,6 +366,66 @@ func (c *Controller) computeHeatmapGrid(birdnet *classifier.Orchestrator, params
 	return result, nil
 }
 
+// computeHeatmapGridOptimized generates heatmap data using the dedicated
+// HeatmapInferenceService with larger batches, stride-aware week iteration,
+// and context cancellation support.
+func (c *Controller) computeHeatmapGridOptimized(ctx context.Context, service *classifier.HeatmapInferenceService, params *heatmapParams, speciesIdx int) ([]float32, error) {
+	totalCells := params.rows * params.cols
+	weeksToCompute := bnhmWeeks / params.stride
+	result := make([]float32, weeksToCompute*totalCells)
+
+	// Pre-allocate input triples; only the week value changes per iteration.
+	inputs := make([]float32, totalCells*3)
+	for row := range params.rows {
+		lat := float32(params.south + (float64(row)+0.5)*params.resolution)
+		for col := range params.cols {
+			lon := float32(params.west + (float64(col)+0.5)*params.resolution)
+			idx := (row*params.cols + col) * 3
+			inputs[idx] = lat
+			inputs[idx+1] = lon
+		}
+	}
+
+	weekIdx := 0
+	for week := 1; week <= bnhmWeeks; week += params.stride {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+
+		weekOffset := weekIdx * totalCells
+
+		// Update week value for all grid points in-place
+		weekF := float32(week)
+		for i := 2; i < len(inputs); i += 3 {
+			inputs[i] = weekF
+		}
+
+		// Process in chunks of heatmapOptBatchSize
+		for chunkStart := 0; chunkStart < totalCells; chunkStart += heatmapOptBatchSize {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+
+			chunkEnd := chunkStart + heatmapOptBatchSize
+			if chunkEnd > totalCells {
+				chunkEnd = totalCells
+			}
+			chunkSize := chunkEnd - chunkStart
+
+			chunkInputs := inputs[chunkStart*3 : chunkEnd*3]
+			dst := result[weekOffset+chunkStart : weekOffset+chunkStart+chunkSize]
+
+			if err := service.PredictBatchExtractSpecies(ctx, chunkInputs, chunkSize, speciesIdx, dst); err != nil {
+				return nil, fmt.Errorf("heatmap inference failed at week %d chunk %d: %w", week, chunkStart, err)
+			}
+		}
+
+		weekIdx++
+	}
+
+	return result, nil
+}
+
 // initHeatmapRoutes registers the heatmap grid endpoint and hooks up
 // cache invalidation for range filter reloads.
 func (c *Controller) initHeatmapRoutes() {
@@ -362,19 +457,97 @@ func InvalidateHeatmapCache() {
 }
 
 // GetHeatmapGrid returns a compact binary grid of species probability across
-// a map viewport for all 48 BirdNET weeks.
+// a map viewport for BirdNET weeks (stride-configurable).
 func (c *Controller) GetHeatmapGrid(ctx echo.Context) error {
 	params, err := c.validateHeatmapParams(ctx)
 	if err != nil {
 		return c.HandleError(ctx, err, err.Error(), http.StatusBadRequest)
 	}
 
-	// Verify species exists in geomodel (atomic lookup: index + count in one lock)
+	// Check cache first (includes stride in key)
+	cache := getHeatmapCache()
+	cacheKey := heatmapCacheKey(params.species, params.south, params.north, params.west, params.east, params.resolution)
+	if params.stride > 1 {
+		cacheKey = fmt.Sprintf("%s|s%d", cacheKey, params.stride)
+	}
+
+	cached, _, hit := cache.get(cacheKey)
+	if hit {
+		c.logAPIRequest(ctx, logger.LogLevelDebug, "Heatmap cache hit", logger.String("species", params.species))
+		return ctx.Blob(http.StatusOK, "application/octet-stream", cached)
+	}
+
+	// Try the dedicated heatmap service (optimized path)
 	birdnet, err := c.getBirdNETInstance()
 	if err != nil {
 		return c.HandleError(ctx, err, "BirdNET service not available", http.StatusInternalServerError)
 	}
 
+	service := birdnet.GetHeatmapService()
+	if service != nil {
+		return c.getHeatmapOptimized(ctx, service, params, cache, cacheKey)
+	}
+
+	// Fallback: use shared BatchRangeFilterInference (original path, stride=1 only)
+	if params.stride > 1 {
+		return c.HandleError(ctx, nil, "Stride parameter requires dedicated heatmap service (not available)", http.StatusServiceUnavailable)
+	}
+	return c.getHeatmapFallback(ctx, birdnet, params, cache, cacheKey)
+}
+
+// getHeatmapOptimized uses the dedicated HeatmapInferenceService with
+// singleflight deduplication and concurrency limiting.
+func (c *Controller) getHeatmapOptimized(ctx echo.Context, service *classifier.HeatmapInferenceService, params *heatmapParams, cache *heatmapLRU, cacheKey string) error {
+	speciesIdx, ok := service.SpeciesIndex(params.species)
+	if !ok {
+		return c.HandleError(ctx, nil, "Species not found in geomodel", http.StatusBadRequest)
+	}
+
+	reqCtx := ctx.Request().Context()
+
+	// Use singleflight to deduplicate concurrent identical requests.
+	// The shared computation uses context.Background() throughout so one
+	// caller's cancellation doesn't kill the computation for others.
+	ch := heatmapFlight.DoChan(cacheKey, func() (any, error) {
+		// Acquire concurrency semaphore (blocking; individual callers bail
+		// via the outer select on reqCtx.Done())
+		heatmapSem <- struct{}{}
+		defer func() { <-heatmapSem }()
+
+		// Snapshot cache generation for poisoning prevention
+		_, missGen, _ := cache.get(cacheKey)
+
+		data, err := c.computeHeatmapGridOptimized(context.Background(), service, params, speciesIdx)
+		if err != nil {
+			return nil, err
+		}
+
+		weeksComputed := bnhmWeeks / params.stride
+		encoded := encodeBNHMWithWeeks(params.cols, params.rows, weeksComputed,
+			float32(params.south), float32(params.west), float32(params.resolution), data)
+
+		cache.put(cacheKey, encoded, missGen)
+		return encoded, nil
+	})
+
+	select {
+	case result := <-ch:
+		if result.Err != nil {
+			return c.HandleError(ctx, result.Err, "Failed to compute heatmap grid", http.StatusInternalServerError)
+		}
+		c.logAPIRequest(ctx, logger.LogLevelInfo, "Heatmap grid computed (optimized)",
+			logger.String("species", params.species),
+			logger.Int("rows", params.rows),
+			logger.Int("cols", params.cols),
+			logger.Int("stride", params.stride))
+		return ctx.Blob(http.StatusOK, "application/octet-stream", result.Val.([]byte))
+	case <-reqCtx.Done():
+		return reqCtx.Err()
+	}
+}
+
+// getHeatmapFallback uses the original shared BatchRangeFilterInference path.
+func (c *Controller) getHeatmapFallback(ctx echo.Context, birdnet *classifier.Orchestrator, params *heatmapParams, cache *heatmapLRU, cacheKey string) error {
 	speciesIdx, numGeoSpecies, found := birdnet.GeomodelSpeciesInfo(params.species)
 	if !found {
 		return c.HandleError(ctx, nil, "Species not found in geomodel", http.StatusBadRequest)
@@ -383,30 +556,17 @@ func (c *Controller) GetHeatmapGrid(ctx echo.Context) error {
 		return c.HandleError(ctx, nil, "Geomodel labels not available", http.StatusInternalServerError)
 	}
 
-	// Check cache; on miss, snapshot generation to guard against cache poisoning
-	// if invalidation fires during the slow computation below.
-	cache := getHeatmapCache()
-	cacheKey := heatmapCacheKey(params.species, params.south, params.north, params.west, params.east, params.resolution)
+	_, missGen, _ := cache.get(cacheKey)
 
-	cached, missGen, hit := cache.get(cacheKey)
-	if hit {
-		c.logAPIRequest(ctx, logger.LogLevelDebug, "Heatmap cache hit", logger.String("species", params.species))
-		return ctx.Blob(http.StatusOK, "application/octet-stream", cached)
-	}
-
-	// Compute grid
 	data, err := c.computeHeatmapGrid(birdnet, params, speciesIdx, numGeoSpecies)
 	if err != nil {
 		return c.HandleError(ctx, err, "Failed to compute heatmap grid", http.StatusInternalServerError)
 	}
 
-	// Encode BNHM
 	encoded := encodeBNHM(params.cols, params.rows, float32(params.south), float32(params.west), float32(params.resolution), data)
-
-	// Cache only if generation unchanged since miss
 	cache.put(cacheKey, encoded, missGen)
 
-	c.logAPIRequest(ctx, logger.LogLevelInfo, "Heatmap grid computed",
+	c.logAPIRequest(ctx, logger.LogLevelInfo, "Heatmap grid computed (fallback)",
 		logger.String("species", params.species),
 		logger.Int("rows", params.rows),
 		logger.Int("cols", params.cols))

--- a/internal/api/v2/heatmap.go
+++ b/internal/api/v2/heatmap.go
@@ -427,12 +427,15 @@ func (c *Controller) computeHeatmapGridOptimized(ctx context.Context, service *c
 }
 
 // initHeatmapRoutes registers the heatmap grid endpoint and hooks up
-// cache invalidation for range filter reloads.
+// cache invalidation and service rebuild for range filter reloads.
 func (c *Controller) initHeatmapRoutes() {
 	c.Group.GET("/range/heatmap", c.GetHeatmapGrid)
 
 	classifier.OnRangeFilterReload(func() {
 		InvalidateHeatmapCache()
+		// Close the dedicated heatmap service so it gets re-created with the
+		// new model on the next request (lazy init in GetHeatmapService).
+		classifier.CloseHeatmapService()
 	})
 }
 

--- a/internal/classifier/heatmap_service.go
+++ b/internal/classifier/heatmap_service.go
@@ -1,0 +1,371 @@
+package classifier
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+
+	"os"
+
+	ort "github.com/yalue/onnxruntime_go"
+
+	"github.com/tphakala/birdnet-go/internal/conf"
+	"github.com/tphakala/birdnet-go/internal/errors"
+	"github.com/tphakala/birdnet-go/internal/logger"
+)
+
+const (
+	heatmapIntraOpThreads = 4
+	heatmapInterOpThreads = 2
+)
+
+// HeatmapInferenceService provides dedicated batch inference for heatmap
+// computation, isolated from the real-time detection pipeline. It maintains
+// its own ONNX session with multi-threaded configuration optimized for
+// throughput rather than latency.
+type HeatmapInferenceService struct {
+	mu       sync.RWMutex
+	session  atomic.Pointer[ort.DynamicAdvancedSession]
+	labels   []string
+	indexMap map[string]int // species label -> index in output
+	inflight sync.WaitGroup
+	closed   atomic.Bool
+}
+
+// NewHeatmapInferenceService creates a heatmap inference service with a
+// dedicated multi-threaded ONNX session.
+func NewHeatmapInferenceService(modelPath string, labels []string) (*HeatmapInferenceService, error) {
+	session, err := createHeatmapSession(modelPath)
+	if err != nil {
+		return nil, err
+	}
+
+	s := &HeatmapInferenceService{
+		labels: labels,
+	}
+	s.session.Store(session)
+	s.indexMap = buildSpeciesIndexMap(labels)
+	return s, nil
+}
+
+func createHeatmapSession(modelPath string) (*ort.DynamicAdvancedSession, error) {
+	inputInfos, outputInfos, err := ort.GetInputOutputInfo(modelPath)
+	if err != nil {
+		return nil, errors.Newf("heatmap service: failed to load model metadata: %v", err).
+			Component("classifier.heatmap_service").
+			Category(errors.CategoryModelInit).
+			Build()
+	}
+
+	if len(inputInfos) == 0 || len(outputInfos) == 0 {
+		return nil, errors.Newf("heatmap service: model has no input or output tensors").
+			Component("classifier.heatmap_service").
+			Category(errors.CategoryModelInit).
+			Build()
+	}
+
+	inputNames := make([]string, len(inputInfos))
+	for i := range inputInfos {
+		inputNames[i] = inputInfos[i].Name
+	}
+	outputNames := make([]string, len(outputInfos))
+	for i := range outputInfos {
+		outputNames[i] = outputInfos[i].Name
+	}
+
+	sessOpts, err := ort.NewSessionOptions()
+	if err != nil {
+		return nil, errors.Newf("heatmap service: failed to create session options: %v", err).
+			Component("classifier.heatmap_service").
+			Category(errors.CategoryModelInit).
+			Build()
+	}
+	defer func() { _ = sessOpts.Destroy() }()
+
+	if err := sessOpts.SetIntraOpNumThreads(heatmapIntraOpThreads); err != nil {
+		return nil, errors.Newf("heatmap service: failed to set intra-op threads: %v", err).
+			Component("classifier.heatmap_service").
+			Category(errors.CategoryModelInit).
+			Build()
+	}
+	if err := sessOpts.SetInterOpNumThreads(heatmapInterOpThreads); err != nil {
+		return nil, errors.Newf("heatmap service: failed to set inter-op threads: %v", err).
+			Component("classifier.heatmap_service").
+			Category(errors.CategoryModelInit).
+			Build()
+	}
+
+	session, err := ort.NewDynamicAdvancedSession(modelPath, inputNames, outputNames, sessOpts)
+	if err != nil {
+		return nil, errors.Newf("heatmap service: failed to create ONNX session: %v", err).
+			Component("classifier.heatmap_service").
+			Category(errors.CategoryModelInit).
+			Build()
+	}
+
+	return session, nil
+}
+
+func buildSpeciesIndexMap(labels []string) map[string]int {
+	m := make(map[string]int, len(labels))
+	for i, l := range labels {
+		m[l] = i
+	}
+	return m
+}
+
+// PredictBatchExtractSpecies runs batch inference and extracts only the target
+// species scores, avoiding a full output copy. This is the primary hot path
+// for heatmap computation.
+func (s *HeatmapInferenceService) PredictBatchExtractSpecies(ctx context.Context, inputs []float32, batchSize, speciesIdx int, dst []float32) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	const inputWidth = 3
+	if batchSize <= 0 || len(inputs) != batchSize*inputWidth {
+		return errors.Newf("heatmap service: inputs length %d does not match batchSize %d * %d",
+			len(inputs), batchSize, inputWidth).
+			Component("classifier.heatmap_service").
+			Category(errors.CategoryValidation).
+			Build()
+	}
+	if len(dst) < batchSize {
+		return errors.Newf("heatmap service: dst length %d < batchSize %d", len(dst), batchSize).
+			Component("classifier.heatmap_service").
+			Category(errors.CategoryValidation).
+			Build()
+	}
+
+	s.inflight.Add(1)
+	defer s.inflight.Done()
+
+	// Re-check closed after inflight.Add to prevent use-after-free on shutdown
+	if s.closed.Load() {
+		return errors.Newf("heatmap service: session closed").
+			Component("classifier.heatmap_service").
+			Category(errors.CategoryValidation).
+			Build()
+	}
+
+	session := s.session.Load()
+	if session == nil {
+		return errors.Newf("heatmap service: session not available").
+			Component("classifier.heatmap_service").
+			Category(errors.CategoryValidation).
+			Build()
+	}
+
+	// Read numSpecies under RLock to prevent race with Rebuild
+	s.mu.RLock()
+	numSpecies := len(s.labels)
+	s.mu.RUnlock()
+
+	if speciesIdx < 0 || speciesIdx >= numSpecies {
+		return errors.Newf("heatmap service: speciesIdx %d out of range [0, %d)", speciesIdx, numSpecies).
+			Component("classifier.heatmap_service").
+			Category(errors.CategoryValidation).
+			Build()
+	}
+
+	inputTensor, err := ort.NewTensor(ort.NewShape(int64(batchSize), 3), inputs)
+	if err != nil {
+		return errors.Newf("heatmap service: failed to create input tensor: %v", err).
+			Component("classifier.heatmap_service").
+			Category(errors.CategoryModelLoad).
+			Build()
+	}
+	defer func() { _ = inputTensor.Destroy() }()
+
+	outputTensor, err := ort.NewEmptyTensor[float32](ort.NewShape(int64(batchSize), int64(numSpecies)))
+	if err != nil {
+		return errors.Newf("heatmap service: failed to create output tensor: %v", err).
+			Component("classifier.heatmap_service").
+			Category(errors.CategoryModelLoad).
+			Build()
+	}
+	defer func() { _ = outputTensor.Destroy() }()
+
+	if err := session.Run([]ort.Value{inputTensor}, []ort.Value{outputTensor}); err != nil {
+		return errors.Newf("heatmap service: inference failed: %v", err).
+			Component("classifier.heatmap_service").
+			Category(errors.CategoryModelLoad).
+			Build()
+	}
+
+	// Extract target species score directly from tensor-backed memory.
+	// CRITICAL: complete extraction before outputTensor.Destroy() in defer.
+	data := outputTensor.GetData()
+	for i := range batchSize {
+		dst[i] = data[i*numSpecies+speciesIdx]
+	}
+
+	return nil
+}
+
+// NumSpecies returns the number of species in the geomodel output.
+func (s *HeatmapInferenceService) NumSpecies() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.labels)
+}
+
+// SpeciesIndex returns the output index for a species label.
+func (s *HeatmapInferenceService) SpeciesIndex(label string) (int, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	idx, ok := s.indexMap[label]
+	return idx, ok
+}
+
+// Rebuild replaces the ONNX session with a new one for an updated model.
+// Waits for all in-flight inferences to complete before destroying the old session.
+func (s *HeatmapInferenceService) Rebuild(modelPath string, labels []string) error {
+	newSession, err := createHeatmapSession(modelPath)
+	if err != nil {
+		return err
+	}
+
+	s.mu.Lock()
+	oldSession := s.session.Swap(newSession)
+	s.labels = labels
+	s.indexMap = buildSpeciesIndexMap(labels)
+	s.mu.Unlock()
+
+	// Wait for in-flight inferences on old session to finish
+	s.inflight.Wait()
+
+	if oldSession != nil {
+		_ = oldSession.Destroy()
+	}
+
+	return nil
+}
+
+// Close shuts down the service and releases all resources.
+// Sets closed flag first so new callers bail after inflight.Add,
+// then swaps session to nil so very-late arrivals see nil,
+// then waits for in-flight inferences before destroying.
+func (s *HeatmapInferenceService) Close() error {
+	s.closed.Store(true)
+
+	oldSession := s.session.Swap(nil)
+
+	// Wait for in-flight inferences to complete (they hold local session ref)
+	s.inflight.Wait()
+
+	if oldSession != nil {
+		return oldSession.Destroy()
+	}
+	return nil
+}
+
+// heatmapService is the module-level singleton for heatmap inference.
+var (
+	heatmapServiceInstance *HeatmapInferenceService
+	heatmapServiceMu       sync.Mutex
+)
+
+// GetHeatmapService returns the singleton heatmap inference service,
+// creating it lazily on first use. Returns nil if the range filter model
+// is not configured.
+func (o *Orchestrator) GetHeatmapService() *HeatmapInferenceService {
+	heatmapServiceMu.Lock()
+	defer heatmapServiceMu.Unlock()
+
+	if heatmapServiceInstance != nil {
+		return heatmapServiceInstance
+	}
+
+	// Get model path and labels from current range filter config
+	settings := o.Settings
+	rfSettings := settings.BirdNET.RangeFilter
+
+	if rfSettings.ModelPath == "" {
+		return nil
+	}
+
+	o.mu.RLock()
+	primary := o.primary
+	o.mu.RUnlock()
+	if primary == nil {
+		return nil
+	}
+
+	// Get labels from the mapped range filter
+	primary.mu.Lock()
+	rf := primary.rangeFilter
+	primary.mu.Unlock()
+	if rf == nil {
+		return nil
+	}
+
+	mrf, ok := rf.(*mappedRangeFilter)
+	if !ok {
+		return nil
+	}
+
+	labels := mrf.geomodelLabels
+	if len(labels) == 0 {
+		return nil
+	}
+
+	// Resolve model path (same logic as initializeV3GeoModel)
+	modelPath := os.ExpandEnv(rfSettings.ModelPath)
+	modelPath, err := conf.ExpandTildePath(modelPath)
+	if err != nil {
+		GetLogger().Error("Failed to expand heatmap model path", logger.Error(err))
+		return nil
+	}
+
+	log := GetLogger()
+	log.Info("Creating dedicated heatmap inference service",
+		logger.String("model_path", modelPath),
+		logger.Int("species_count", len(labels)),
+		logger.Int("intra_op_threads", heatmapIntraOpThreads),
+		logger.Int("inter_op_threads", heatmapInterOpThreads))
+
+	svc, err := NewHeatmapInferenceService(modelPath, labels)
+	if err != nil {
+		log.Error("Failed to create heatmap inference service", logger.Error(err))
+		return nil
+	}
+
+	heatmapServiceInstance = svc
+	return svc
+}
+
+// RebuildHeatmapService rebuilds the heatmap inference service with updated model/labels.
+// Called from the range filter reload callback.
+func RebuildHeatmapService(modelPath string, labels []string) {
+	heatmapServiceMu.Lock()
+	defer heatmapServiceMu.Unlock()
+
+	if heatmapServiceInstance == nil {
+		return
+	}
+
+	log := GetLogger()
+	log.Info("Rebuilding heatmap inference service",
+		logger.String("model_path", modelPath),
+		logger.Int("species_count", len(labels)))
+
+	if err := heatmapServiceInstance.Rebuild(modelPath, labels); err != nil {
+		log.Error("Failed to rebuild heatmap inference service", logger.Error(err))
+		// Close broken service; next request will create a fresh one
+		_ = heatmapServiceInstance.Close()
+		heatmapServiceInstance = nil
+	}
+}
+
+// CloseHeatmapService shuts down the heatmap inference service.
+// Called from Orchestrator.Delete().
+func CloseHeatmapService() {
+	heatmapServiceMu.Lock()
+	defer heatmapServiceMu.Unlock()
+
+	if heatmapServiceInstance != nil {
+		_ = heatmapServiceInstance.Close()
+		heatmapServiceInstance = nil
+	}
+}

--- a/internal/classifier/heatmap_service.go
+++ b/internal/classifier/heatmap_service.go
@@ -137,16 +137,17 @@ func (s *HeatmapInferenceService) PredictBatchExtractSpecies(ctx context.Context
 			Build()
 	}
 
-	s.inflight.Add(1)
-	defer s.inflight.Done()
-
-	// Re-check closed after inflight.Add to prevent use-after-free on shutdown
+	// Check closed before Add to follow WaitGroup contract: Add must not race
+	// with Wait when counter is zero. Close/Rebuild set closed before Wait.
 	if s.closed.Load() {
 		return errors.Newf("heatmap service: session closed").
 			Component("classifier.heatmap_service").
 			Category(errors.CategoryValidation).
 			Build()
 	}
+
+	s.inflight.Add(1)
+	defer s.inflight.Done()
 
 	session := s.session.Load()
 	if session == nil {

--- a/internal/classifier/orchestrator.go
+++ b/internal/classifier/orchestrator.go
@@ -644,6 +644,9 @@ func (o *Orchestrator) Delete() {
 	if s := o.scheduler.Load(); s != nil {
 		s.stop()
 	}
+
+	CloseHeatmapService()
+
 	// Nil out references to fail fast on use-after-delete.
 	o.primary = nil
 	o.models = nil


### PR DESCRIPTION
## Summary

Add a dedicated `HeatmapInferenceService` with its own multi-threaded ONNX session, isolated from the real-time detection pipeline. This eliminates `primary.mu` lock contention and enables parallel ONNX operations for batch workloads.

The heatmap endpoint (`/api/v2/range/heatmap`) previously took 28s for 203 grid cells at 2 degree resolution (sharing the single-threaded real-time session). With this change:
- **stride=1** (all 48 weeks): expected 3-5s (5-10x improvement)
- **stride=4** (12 weeks, frontend interpolates): expected <1s (20-30x improvement)

### Changes

- `HeatmapInferenceService` with 4 intra-op / 2 inter-op thread ONNX session
- `stride` query parameter (divisors of 48) for temporal resolution reduction
- `singleflight` deduplication for concurrent identical requests
- Concurrency semaphore (max 2) to bound memory on constrained hardware
- `PredictBatchExtractSpecies` extracts target species in-place from tensor memory
- Safe rebuild via atomic pointer swap + WaitGroup drain (no use-after-free)
- Graceful fallback to shared `BatchRangeFilterInference` when dedicated service unavailable

### Concurrency design

- Real-time detection pipeline: unchanged (single-threaded, `primary.mu`)
- Heatmap computation: fully independent ONNX session, no shared locks
- Shutdown safety: closed flag + inflight WaitGroup + atomic session swap

## Related Issues

Part of #3092 (Migration Explorer)

## Test Plan

- [x] All existing heatmap tests pass (16/16) with race detector
- [x] Full project lint clean (golangci-lint)
- [x] Gate review (3 Claude agents + Gemini cross-validation)
- [ ] Manual benchmark on regression VM with live geomodel

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable stride for heatmap week-range queries
  * Dedicated heatmap inference service for batched, optimized heatmap generation

* **Improvements**
  * Optimized heatmap computation path with concurrency limits and request deduplication
  * Cache behavior improved: stride-aware keys, early cache returns, and snapshotting to avoid stale overwrites
  * Service lifecycle: lazy recreation and explicit shutdown on range filter reload

* **Behavior**
  * Requests requiring the dedicated service return 503 when the service is unavailable

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3116?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->