### PR TITLE
fix: CSRF logout skip, Service Worker notifications, clipboard error, eBird Sentry noise

### DIFF
--- a/frontend/src/lib/desktop/components/ui/NotificationBell.svelte
+++ b/frontend/src/lib/desktop/components/ui/NotificationBell.svelte
@@ -349,15 +349,32 @@
     }
   }
 
-  // Show browser notification
-  function showBrowserNotification(notification: Notification) {
-    if ('Notification' in globalThis.window && globalThis.Notification.permission === 'granted') {
-      const translated = translateNotification(notification);
-      new globalThis.Notification(sanitizeNotificationMessage(translated.title), {
-        body: sanitizeNotificationMessage(translated.message),
-        icon: buildAppUrl(NOTIFICATION_ICON_PATH),
-        tag: notification.id,
-      });
+  // Show browser notification (Service Worker-aware)
+  async function showBrowserNotification(notification: Notification) {
+    if (
+      !('Notification' in globalThis.window) ||
+      globalThis.Notification.permission !== 'granted'
+    ) {
+      return;
+    }
+
+    const translated = translateNotification(notification);
+    const options = {
+      body: sanitizeNotificationMessage(translated.message),
+      icon: buildAppUrl(NOTIFICATION_ICON_PATH),
+      tag: notification.id,
+    };
+    const title = sanitizeNotificationMessage(translated.title);
+
+    try {
+      if ('serviceWorker' in navigator && navigator.serviceWorker.controller) {
+        const registration = await navigator.serviceWorker.ready;
+        await registration.showNotification(title, options);
+      } else {
+        new globalThis.Notification(title, options);
+      }
+    } catch {
+      // Notification constructor can fail if Service Worker state changes mid-call
     }
   }
 

--- a/frontend/src/lib/desktop/components/ui/NotificationBell.svelte
+++ b/frontend/src/lib/desktop/components/ui/NotificationBell.svelte
@@ -373,8 +373,11 @@
       } else {
         new globalThis.Notification(title, options);
       }
-    } catch {
-      // Notification constructor can fail if Service Worker state changes mid-call
+    } catch (error) {
+      logger.debug('Failed to show browser notification', error, {
+        component: 'NotificationBell',
+        action: 'showBrowserNotification',
+      });
     }
   }
 

--- a/frontend/src/lib/desktop/features/system/TerminalPage.svelte
+++ b/frontend/src/lib/desktop/features/system/TerminalPage.svelte
@@ -558,16 +558,21 @@
       copyBtn?.addEventListener('click', () => {
         const text = popupTerm.getSelection();
         if (text) {
-          navigator.clipboard.writeText(text).then(() => {
-            copyBtn.classList.add('copied');
-            copyBtn.innerHTML =
-              '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>';
-            popup.setTimeout(() => {
-              copyBtn.classList.remove('copied');
+          navigator.clipboard
+            .writeText(text)
+            .then(() => {
+              copyBtn.classList.add('copied');
               copyBtn.innerHTML =
-                '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>';
-            }, 2000);
-          });
+                '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>';
+              popup.setTimeout(() => {
+                copyBtn.classList.remove('copied');
+                copyBtn.innerHTML =
+                  '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>';
+              }, 2000);
+            })
+            .catch(() => {
+              // Clipboard write can fail if the document isn't focused
+            });
         }
         popupTerm.focus();
       });

--- a/internal/api/middleware/csrf.go
+++ b/internal/api/middleware/csrf.go
@@ -140,8 +140,10 @@ func DefaultCSRFSkipper(c echo.Context) bool {
 		return isSafeHTTPMethod(c.Request().Method)
 	}
 
-	// Skip for auth endpoints (login needs to work before CSRF token exists)
+	// Skip for auth endpoints (login needs to work before CSRF token exists,
+	// logout must work even with expired CSRF tokens on long-lived pages)
 	if path == "/api/v2/auth/login" ||
+		path == "/api/v2/auth/logout" ||
 		strings.HasPrefix(path, "/api/v2/auth/callback") {
 		return true
 	}

--- a/internal/api/middleware/csrf_test.go
+++ b/internal/api/middleware/csrf_test.go
@@ -167,8 +167,10 @@ func TestDefaultCSRFSkipper(t *testing.T) {
 		{"GET auth callback", http.MethodGet, "/api/v2/auth/callback/google", true},
 		{"GET social OAuth", http.MethodGet, "/auth/google", true},
 
+		// Logout — skipped (must work even with expired CSRF tokens)
+		{"POST auth logout", http.MethodPost, "/api/v2/auth/logout", true},
+
 		// Regular API paths — never skipped
-		{"GET auth logout", http.MethodGet, "/api/v2/auth/logout", false},
 		{"GET detections", http.MethodGet, "/api/v2/detections/1", false},
 		{"POST settings", http.MethodPost, "/api/v2/settings", false},
 	}

--- a/internal/errors/telemetry_integration.go
+++ b/internal/errors/telemetry_integration.go
@@ -223,11 +223,12 @@ func shouldReportToSentry(ee *EnhancedError) bool {
 		}
 	}
 
-	// Filter out "note not found" errors — these are expected transient conditions caused by
-	// race between write commit and read, or retention cleanup deleting records between
-	// ID assignment and lookup. Not code bugs.
+	// Filter out expected not-found conditions that are not code bugs:
+	// - "note not found": transient race between write commit and read, or retention cleanup
+	// - "not found in ebird taxonomy": non-bird species (e.g., Canis latrans) detected by BirdNET
 	if ee.Category == CategoryNotFound {
-		if strings.Contains(errorMsg, "note not found") {
+		if strings.Contains(errorMsg, "note not found") ||
+			strings.Contains(errorMsg, "not found in ebird taxonomy") {
 			return false
 		}
 	}

--- a/internal/errors/telemetry_integration_test.go
+++ b/internal/errors/telemetry_integration_test.go
@@ -106,6 +106,16 @@ func TestShouldReportToSentry_FiltersNoteNotFound(t *testing.T) {
 	assert.False(t, shouldReportToSentry(ee))
 }
 
+func TestShouldReportToSentry_FiltersEBirdTaxonomyNotFound(t *testing.T) {
+	t.Parallel()
+	// Non-bird species (e.g., Canis latrans) are expected to be absent from eBird
+	ee := New(fmt.Errorf("species not found in eBird taxonomy: Canis latrans")).
+		Component("ebird").
+		Category(CategoryNotFound).
+		Build()
+	assert.False(t, shouldReportToSentry(ee))
+}
+
 func TestShouldReportToSentry_AllowsNetworkCategoryCodeBugs(t *testing.T) {
 	t.Parallel()
 	// Network category error that is NOT environmental noise should still report


### PR DESCRIPTION
## Summary

Four targeted bug fixes addressing Sentry-reported errors and a CSRF token expiration issue:

- **CSRF logout 403**: Add `/api/v2/auth/logout` to the CSRF skip list so logout works even when the CSRF token has expired on long-lived pages (e.g., live-stream). The endpoint remains protected by auth middleware (session cookie required).
- **NotificationBell illegal constructor**: Use `ServiceWorkerRegistration.showNotification()` when a Service Worker is active, falling back to the `Notification` constructor otherwise. Prevents `TypeError: Illegal constructor` in browsers with registered Service Workers.
- **Terminal popup clipboard error**: Add `.catch()` to the popup terminal's `clipboard.writeText()` promise chain. Prevents unhandled `NotAllowedError` when the document loses focus before the async clipboard call completes.
- **eBird taxonomy Sentry noise**: Filter "not found in eBird taxonomy" errors from Sentry reporting. Non-bird species detected by BirdNET (e.g., Canis latrans) are expected to be absent from eBird.

## Test Plan

- [x] CSRF test updated: POST logout now expects skip=true
- [x] Telemetry test added: eBird taxonomy not-found filtered from Sentry
- [x] Existing telemetry test: generic taxonomy not-found still reports (line 92)
- [x] `go test -race` passes for `internal/errors/` and `internal/api/middleware/`
- [x] `svelte-check` passes with 0 errors
- [x] ESLint passes on changed Svelte files
- [x] `golangci-lint run -v` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notification reliability with Service Worker–aware delivery and guarded error handling.
  * Fixed unhandled promise rejections when copying text in detached terminal windows.
  * Logout works correctly even when CSRF tokens have expired.

* **Tests**
  * Added a test to ensure certain expected taxonomy lookup failures are filtered from error reporting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3117?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->