### PR TITLE
perf(heatmap): IoBinding tensor reuse eliminates per-batch allocation overhead

### DIFF
--- a/internal/api/v2/heatmap.go
+++ b/internal/api/v2/heatmap.go
@@ -370,7 +370,7 @@ func (c *Controller) computeHeatmapGrid(birdnet *classifier.Orchestrator, params
 // HeatmapInferenceService with IoBinding for tensor reuse across all weeks.
 func (c *Controller) computeHeatmapGridOptimized(ctx context.Context, service *classifier.HeatmapInferenceService, params *heatmapParams) ([]float32, error) {
 	totalCells := params.rows * params.cols
-	weeksToCompute := bnhmWeeks / params.stride
+	weeksToCompute := (bnhmWeeks + params.stride - 1) / params.stride
 	result := make([]float32, weeksToCompute*totalCells)
 
 	coords := make([]float32, totalCells*2)
@@ -486,7 +486,7 @@ func (c *Controller) getHeatmapOptimized(ctx echo.Context, service *classifier.H
 			return nil, err
 		}
 
-		weeksComputed := bnhmWeeks / params.stride
+		weeksComputed := (bnhmWeeks + params.stride - 1) / params.stride
 		encoded := encodeBNHMWithWeeks(params.cols, params.rows, weeksComputed,
 			float32(params.south), float32(params.west), float32(params.resolution), data)
 

--- a/internal/api/v2/heatmap.go
+++ b/internal/api/v2/heatmap.go
@@ -367,60 +367,26 @@ func (c *Controller) computeHeatmapGrid(birdnet *classifier.Orchestrator, params
 }
 
 // computeHeatmapGridOptimized generates heatmap data using the dedicated
-// HeatmapInferenceService with larger batches, stride-aware week iteration,
-// and context cancellation support.
+// HeatmapInferenceService with IoBinding for tensor reuse across all weeks.
 func (c *Controller) computeHeatmapGridOptimized(ctx context.Context, service *classifier.HeatmapInferenceService, params *heatmapParams, speciesIdx int) ([]float32, error) {
 	totalCells := params.rows * params.cols
 	weeksToCompute := bnhmWeeks / params.stride
 	result := make([]float32, weeksToCompute*totalCells)
 
-	// Pre-allocate input triples; only the week value changes per iteration.
-	inputs := make([]float32, totalCells*3)
+	coords := make([]float32, totalCells*2)
 	for row := range params.rows {
 		lat := float32(params.south + (float64(row)+0.5)*params.resolution)
 		for col := range params.cols {
 			lon := float32(params.west + (float64(col)+0.5)*params.resolution)
-			idx := (row*params.cols + col) * 3
-			inputs[idx] = lat
-			inputs[idx+1] = lon
+			idx := (row*params.cols + col) * 2
+			coords[idx] = lat
+			coords[idx+1] = lon
 		}
 	}
 
-	weekIdx := 0
-	for week := 1; week <= bnhmWeeks; week += params.stride {
-		if err := ctx.Err(); err != nil {
-			return nil, err
-		}
-
-		weekOffset := weekIdx * totalCells
-
-		// Update week value for all grid points in-place
-		weekF := float32(week)
-		for i := 2; i < len(inputs); i += 3 {
-			inputs[i] = weekF
-		}
-
-		// Process in chunks of heatmapOptBatchSize
-		for chunkStart := 0; chunkStart < totalCells; chunkStart += heatmapOptBatchSize {
-			if err := ctx.Err(); err != nil {
-				return nil, err
-			}
-
-			chunkEnd := chunkStart + heatmapOptBatchSize
-			if chunkEnd > totalCells {
-				chunkEnd = totalCells
-			}
-			chunkSize := chunkEnd - chunkStart
-
-			chunkInputs := inputs[chunkStart*3 : chunkEnd*3]
-			dst := result[weekOffset+chunkStart : weekOffset+chunkStart+chunkSize]
-
-			if err := service.PredictBatchExtractSpecies(ctx, chunkInputs, chunkSize, speciesIdx, dst); err != nil {
-				return nil, fmt.Errorf("heatmap inference failed at week %d chunk %d: %w", week, chunkStart, err)
-			}
-		}
-
-		weekIdx++
+	if err := service.ComputeGridWithBinding(ctx, coords, totalCells, speciesIdx,
+		params.stride, bnhmWeeks, heatmapOptBatchSize, result); err != nil {
+		return nil, fmt.Errorf("heatmap grid computation failed: %w", err)
 	}
 
 	return result, nil

--- a/internal/api/v2/heatmap.go
+++ b/internal/api/v2/heatmap.go
@@ -368,7 +368,7 @@ func (c *Controller) computeHeatmapGrid(birdnet *classifier.Orchestrator, params
 
 // computeHeatmapGridOptimized generates heatmap data using the dedicated
 // HeatmapInferenceService with IoBinding for tensor reuse across all weeks.
-func (c *Controller) computeHeatmapGridOptimized(ctx context.Context, service *classifier.HeatmapInferenceService, params *heatmapParams, speciesIdx int) ([]float32, error) {
+func (c *Controller) computeHeatmapGridOptimized(ctx context.Context, service *classifier.HeatmapInferenceService, params *heatmapParams) ([]float32, error) {
 	totalCells := params.rows * params.cols
 	weeksToCompute := bnhmWeeks / params.stride
 	result := make([]float32, weeksToCompute*totalCells)
@@ -384,7 +384,7 @@ func (c *Controller) computeHeatmapGridOptimized(ctx context.Context, service *c
 		}
 	}
 
-	if err := service.ComputeGridWithBinding(ctx, coords, totalCells, speciesIdx,
+	if err := service.ComputeGridWithBinding(ctx, coords, totalCells, params.species,
 		params.stride, bnhmWeeks, heatmapOptBatchSize, result); err != nil {
 		return nil, fmt.Errorf("heatmap grid computation failed: %w", err)
 	}
@@ -467,11 +467,6 @@ func (c *Controller) GetHeatmapGrid(ctx echo.Context) error {
 // getHeatmapOptimized uses the dedicated HeatmapInferenceService with
 // singleflight deduplication and concurrency limiting.
 func (c *Controller) getHeatmapOptimized(ctx echo.Context, service *classifier.HeatmapInferenceService, params *heatmapParams, cache *heatmapLRU, cacheKey string) error {
-	speciesIdx, ok := service.SpeciesIndex(params.species)
-	if !ok {
-		return c.HandleError(ctx, nil, "Species not found in geomodel", http.StatusBadRequest)
-	}
-
 	reqCtx := ctx.Request().Context()
 
 	// Use singleflight to deduplicate concurrent identical requests.
@@ -486,7 +481,7 @@ func (c *Controller) getHeatmapOptimized(ctx echo.Context, service *classifier.H
 		// Snapshot cache generation for poisoning prevention
 		_, missGen, _ := cache.get(cacheKey)
 
-		data, err := c.computeHeatmapGridOptimized(context.Background(), service, params, speciesIdx)
+		data, err := c.computeHeatmapGridOptimized(context.Background(), service, params)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/classifier/heatmap_service.go
+++ b/internal/classifier/heatmap_service.go
@@ -169,7 +169,14 @@ func (s *HeatmapInferenceService) ComputeGridWithBinding(
 			Build()
 	}
 
-	weeksToCompute := totalWeeks / stride
+	if stride <= 0 || totalWeeks <= 0 || batchSize <= 0 {
+		return errors.Newf("heatmap service: stride, totalWeeks, and batchSize must be > 0").
+			Component("classifier.heatmap_service").
+			Category(errors.CategoryValidation).
+			Build()
+	}
+
+	weeksToCompute := (totalWeeks + stride - 1) / stride
 	expectedResultLen := weeksToCompute * totalCells
 	if len(result) < expectedResultLen {
 		return errors.Newf("heatmap service: result length %d < expected %d", len(result), expectedResultLen).

--- a/internal/classifier/heatmap_service.go
+++ b/internal/classifier/heatmap_service.go
@@ -17,6 +17,7 @@ import (
 const (
 	heatmapIntraOpThreads = 4
 	heatmapInterOpThreads = 2
+	heatmapCoordWidth     = 2 // [lat, lon] per grid cell
 )
 
 // HeatmapInferenceService provides dedicated batch inference for heatmap
@@ -24,31 +25,25 @@ const (
 // its own ONNX session with multi-threaded configuration optimized for
 // throughput rather than latency.
 type HeatmapInferenceService struct {
-	mu       sync.RWMutex
-	session  atomic.Pointer[ort.DynamicAdvancedSession]
-	labels   []string
-	indexMap map[string]int // species label -> index in output
-	inflight sync.WaitGroup
-	closed   atomic.Bool
+	mu         sync.RWMutex
+	session    atomic.Pointer[ort.DynamicAdvancedSession]
+	labels     []string
+	indexMap   map[string]int // species label -> index in output
+	inputName  string         // ONNX input tensor name (from model metadata)
+	outputName string         // ONNX output tensor name (from model metadata)
+	inflight   sync.WaitGroup
+	closed     atomic.Bool
 }
 
-// NewHeatmapInferenceService creates a heatmap inference service with a
-// dedicated multi-threaded ONNX session.
-func NewHeatmapInferenceService(modelPath string, labels []string) (*HeatmapInferenceService, error) {
-	session, err := createHeatmapSession(modelPath)
-	if err != nil {
-		return nil, err
-	}
-
-	s := &HeatmapInferenceService{
-		labels: labels,
-	}
-	s.session.Store(session)
-	s.indexMap = buildSpeciesIndexMap(labels)
-	return s, nil
+// heatmapModelMeta holds tensor name metadata extracted from a geomodel ONNX file.
+type heatmapModelMeta struct {
+	inputNames  []string
+	outputNames []string
+	inputName   string // first input tensor name (for IoBinding)
+	outputName  string // first output tensor name (for IoBinding)
 }
 
-func createHeatmapSession(modelPath string) (*ort.DynamicAdvancedSession, error) {
+func loadHeatmapModelMeta(modelPath string) (*heatmapModelMeta, error) {
 	inputInfos, outputInfos, err := ort.GetInputOutputInfo(modelPath)
 	if err != nil {
 		return nil, errors.Newf("heatmap service: failed to load model metadata: %v", err).
@@ -56,7 +51,6 @@ func createHeatmapSession(modelPath string) (*ort.DynamicAdvancedSession, error)
 			Category(errors.CategoryModelInit).
 			Build()
 	}
-
 	if len(inputInfos) == 0 || len(outputInfos) == 0 {
 		return nil, errors.Newf("heatmap service: model has no input or output tensors").
 			Component("classifier.heatmap_service").
@@ -73,6 +67,38 @@ func createHeatmapSession(modelPath string) (*ort.DynamicAdvancedSession, error)
 		outputNames[i] = outputInfos[i].Name
 	}
 
+	return &heatmapModelMeta{
+		inputNames:  inputNames,
+		outputNames: outputNames,
+		inputName:   inputInfos[0].Name,
+		outputName:  outputInfos[0].Name,
+	}, nil
+}
+
+// NewHeatmapInferenceService creates a heatmap inference service with a
+// dedicated multi-threaded ONNX session.
+func NewHeatmapInferenceService(modelPath string, labels []string) (*HeatmapInferenceService, error) {
+	meta, err := loadHeatmapModelMeta(modelPath)
+	if err != nil {
+		return nil, err
+	}
+
+	session, err := createHeatmapSession(modelPath, meta.inputNames, meta.outputNames)
+	if err != nil {
+		return nil, err
+	}
+
+	s := &HeatmapInferenceService{
+		labels:     labels,
+		inputName:  meta.inputName,
+		outputName: meta.outputName,
+	}
+	s.session.Store(session)
+	s.indexMap = buildSpeciesIndexMap(labels)
+	return s, nil
+}
+
+func createHeatmapSession(modelPath string, inputNames, outputNames []string) (*ort.DynamicAdvancedSession, error) {
 	sessOpts, err := ort.NewSessionOptions()
 	if err != nil {
 		return nil, errors.Newf("heatmap service: failed to create session options: %v", err).
@@ -114,31 +140,44 @@ func buildSpeciesIndexMap(labels []string) map[string]int {
 	return m
 }
 
-// PredictBatchExtractSpecies runs batch inference and extracts only the target
-// species scores, avoiding a full output copy. This is the primary hot path
-// for heatmap computation.
-func (s *HeatmapInferenceService) PredictBatchExtractSpecies(ctx context.Context, inputs []float32, batchSize, speciesIdx int, dst []float32) error {
+// ComputeGridWithBinding runs batch inference across all weeks for a grid,
+// reusing pre-allocated tensors via IoBinding. The chunks-outer/weeks-inner
+// loop order minimizes coordinate copies and partial-batch rebinding.
+//
+// coords contains [lat, lon] pairs (totalCells * 2 floats).
+// result is the output buffer sized [weeksComputed * totalCells].
+func (s *HeatmapInferenceService) ComputeGridWithBinding(
+	ctx context.Context,
+	coords []float32,
+	totalCells int,
+	speciesIdx int,
+	stride int,
+	totalWeeks int,
+	batchSize int,
+	result []float32,
+) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
 
-	const inputWidth = 3
-	if batchSize <= 0 || len(inputs) != batchSize*inputWidth {
-		return errors.Newf("heatmap service: inputs length %d does not match batchSize %d * %d",
-			len(inputs), batchSize, inputWidth).
-			Component("classifier.heatmap_service").
-			Category(errors.CategoryValidation).
-			Build()
-	}
-	if len(dst) < batchSize {
-		return errors.Newf("heatmap service: dst length %d < batchSize %d", len(dst), batchSize).
+	const coordWidth = heatmapCoordWidth
+	if totalCells <= 0 || len(coords) != totalCells*coordWidth {
+		return errors.Newf("heatmap service: coords length %d does not match totalCells %d * %d",
+			len(coords), totalCells, coordWidth).
 			Component("classifier.heatmap_service").
 			Category(errors.CategoryValidation).
 			Build()
 	}
 
-	// Check closed before Add to follow WaitGroup contract: Add must not race
-	// with Wait when counter is zero. Close/Rebuild set closed before Wait.
+	weeksToCompute := totalWeeks / stride
+	expectedResultLen := weeksToCompute * totalCells
+	if len(result) < expectedResultLen {
+		return errors.Newf("heatmap service: result length %d < expected %d", len(result), expectedResultLen).
+			Component("classifier.heatmap_service").
+			Category(errors.CategoryValidation).
+			Build()
+	}
+
 	if s.closed.Load() {
 		return errors.Newf("heatmap service: session closed").
 			Component("classifier.heatmap_service").
@@ -157,9 +196,10 @@ func (s *HeatmapInferenceService) PredictBatchExtractSpecies(ctx context.Context
 			Build()
 	}
 
-	// Read numSpecies under RLock to prevent race with Rebuild
 	s.mu.RLock()
 	numSpecies := len(s.labels)
+	inputName := s.inputName
+	outputName := s.outputName
 	s.mu.RUnlock()
 
 	if speciesIdx < 0 || speciesIdx >= numSpecies {
@@ -169,7 +209,12 @@ func (s *HeatmapInferenceService) PredictBatchExtractSpecies(ctx context.Context
 			Build()
 	}
 
-	inputTensor, err := ort.NewTensor(ort.NewShape(int64(batchSize), 3), inputs)
+	effectiveBatch := min(totalCells, batchSize)
+
+	inputData := make([]float32, effectiveBatch*3)
+	outputData := make([]float32, effectiveBatch*numSpecies)
+
+	inputTensor, err := ort.NewTensor(ort.NewShape(int64(effectiveBatch), 3), inputData)
 	if err != nil {
 		return errors.Newf("heatmap service: failed to create input tensor: %v", err).
 			Component("classifier.heatmap_service").
@@ -178,7 +223,7 @@ func (s *HeatmapInferenceService) PredictBatchExtractSpecies(ctx context.Context
 	}
 	defer func() { _ = inputTensor.Destroy() }()
 
-	outputTensor, err := ort.NewEmptyTensor[float32](ort.NewShape(int64(batchSize), int64(numSpecies)))
+	outputTensor, err := ort.NewTensor(ort.NewShape(int64(effectiveBatch), int64(numSpecies)), outputData)
 	if err != nil {
 		return errors.Newf("heatmap service: failed to create output tensor: %v", err).
 			Component("classifier.heatmap_service").
@@ -187,18 +232,190 @@ func (s *HeatmapInferenceService) PredictBatchExtractSpecies(ctx context.Context
 	}
 	defer func() { _ = outputTensor.Destroy() }()
 
-	if err := session.Run([]ort.Value{inputTensor}, []ort.Value{outputTensor}); err != nil {
-		return errors.Newf("heatmap service: inference failed: %v", err).
+	binding, err := session.CreateIoBinding()
+	if err != nil {
+		return errors.Newf("heatmap service: failed to create IoBinding: %v", err).
+			Component("classifier.heatmap_service").
+			Category(errors.CategoryModelLoad).
+			Build()
+	}
+	defer func() { _ = binding.Destroy() }()
+
+	if err := binding.BindInput(inputName, inputTensor); err != nil {
+		return errors.Newf("heatmap service: failed to bind input: %v", err).
+			Component("classifier.heatmap_service").
+			Category(errors.CategoryModelLoad).
+			Build()
+	}
+	if err := binding.BindOutput(outputName, outputTensor); err != nil {
+		return errors.Newf("heatmap service: failed to bind output: %v", err).
 			Component("classifier.heatmap_service").
 			Category(errors.CategoryModelLoad).
 			Build()
 	}
 
-	// Extract target species score directly from tensor-backed memory.
-	// CRITICAL: complete extraction before outputTensor.Destroy() in defer.
-	data := outputTensor.GetData()
-	for i := range batchSize {
-		dst[i] = data[i*numSpecies+speciesIdx]
+	gp := &gridParams{
+		session:    session,
+		binding:    binding,
+		inputName:  inputName,
+		outputName: outputName,
+		inputData:  inputData,
+		outputData: outputData,
+		coords:     coords,
+		result:     result,
+		totalCells: totalCells,
+		numSpecies: numSpecies,
+		speciesIdx: speciesIdx,
+		stride:     stride,
+		totalWeeks: totalWeeks,
+	}
+
+	for chunkStart := 0; chunkStart < totalCells; chunkStart += effectiveBatch {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if s.closed.Load() {
+			return errSessionClosedDuringComputation
+		}
+
+		chunkEnd := min(chunkStart+effectiveBatch, totalCells)
+		chunkSize := chunkEnd - chunkStart
+
+		if err := s.processChunk(ctx, gp, chunkStart, chunkSize, effectiveBatch); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// gridParams groups the state shared across chunks during grid computation.
+type gridParams struct {
+	session    *ort.DynamicAdvancedSession
+	binding    *ort.IoBinding
+	inputName  string
+	outputName string
+	inputData  []float32
+	outputData []float32
+	coords     []float32
+	result     []float32
+	totalCells int
+	numSpecies int
+	speciesIdx int
+	stride     int
+	totalWeeks int
+}
+
+var errSessionClosedDuringComputation = errors.Newf("heatmap service: session closed during computation").
+	Component("classifier.heatmap_service").
+	Category(errors.CategoryValidation).
+	Build()
+
+// processChunk runs the inner week loop for one spatial chunk. For the last
+// (potentially partial) chunk it creates smaller tensors and rebinds.
+func (s *HeatmapInferenceService) processChunk(
+	ctx context.Context,
+	gp *gridParams,
+	chunkStart, chunkSize, effectiveBatch int,
+) error {
+	const coordWidth = heatmapCoordWidth
+
+	for i := range chunkSize {
+		srcIdx := (chunkStart + i) * coordWidth
+		dstIdx := i * 3
+		gp.inputData[dstIdx] = gp.coords[srcIdx]
+		gp.inputData[dstIdx+1] = gp.coords[srcIdx+1]
+	}
+
+	if chunkSize < effectiveBatch {
+		return s.processPartialChunk(ctx, gp, chunkStart, chunkSize)
+	}
+
+	return s.runWeekLoop(ctx, gp, chunkStart, chunkSize)
+}
+
+// processPartialChunk handles the last chunk when it is smaller than the
+// batch size. Creates smaller tensor wrappers over the existing buffers
+// and rebinds them for inference. Does not restore the full-size binding
+// because partial chunks are always the final iteration of the outer loop.
+func (s *HeatmapInferenceService) processPartialChunk(
+	ctx context.Context,
+	gp *gridParams,
+	chunkStart, chunkSize int,
+) error {
+	partialInput, err := ort.NewTensor(
+		ort.NewShape(int64(chunkSize), 3), gp.inputData[:chunkSize*3])
+	if err != nil {
+		return errors.Newf("heatmap service: failed to create partial input tensor: %v", err).
+			Component("classifier.heatmap_service").
+			Category(errors.CategoryModelLoad).
+			Build()
+	}
+	defer func() { _ = partialInput.Destroy() }()
+
+	partialOutput, err := ort.NewTensor(
+		ort.NewShape(int64(chunkSize), int64(gp.numSpecies)),
+		gp.outputData[:chunkSize*gp.numSpecies])
+	if err != nil {
+		return errors.Newf("heatmap service: failed to create partial output tensor: %v", err).
+			Component("classifier.heatmap_service").
+			Category(errors.CategoryModelLoad).
+			Build()
+	}
+	defer func() { _ = partialOutput.Destroy() }()
+
+	if err := gp.binding.BindInput(gp.inputName, partialInput); err != nil {
+		return errors.Newf("heatmap service: failed to bind partial input: %v", err).
+			Component("classifier.heatmap_service").
+			Category(errors.CategoryModelLoad).
+			Build()
+	}
+	if err := gp.binding.BindOutput(gp.outputName, partialOutput); err != nil {
+		return errors.Newf("heatmap service: failed to bind partial output: %v", err).
+			Component("classifier.heatmap_service").
+			Category(errors.CategoryModelLoad).
+			Build()
+	}
+
+	return s.runWeekLoop(ctx, gp, chunkStart, chunkSize)
+}
+
+// runWeekLoop iterates over all weeks for a single chunk, running inference
+// and extracting the target species scores.
+func (s *HeatmapInferenceService) runWeekLoop(
+	ctx context.Context,
+	gp *gridParams,
+	chunkStart, chunkSize int,
+) error {
+	weekIdx := 0
+	for week := 1; week <= gp.totalWeeks; week += gp.stride {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if s.closed.Load() {
+			return errSessionClosedDuringComputation
+		}
+
+		weekF := float32(week)
+		limit := chunkSize * 3
+		for i := 2; i < limit; i += 3 {
+			gp.inputData[i] = weekF
+		}
+
+		if err := gp.session.RunWithBinding(gp.binding); err != nil {
+			return errors.Newf("heatmap service: inference failed at week %d chunk %d: %v",
+				week, chunkStart, err).
+				Component("classifier.heatmap_service").
+				Category(errors.CategoryModelLoad).
+				Build()
+		}
+
+		weekOffset := weekIdx * gp.totalCells
+		for i := range chunkSize {
+			gp.result[weekOffset+chunkStart+i] = gp.outputData[i*gp.numSpecies+gp.speciesIdx]
+		}
+
+		weekIdx++
 	}
 
 	return nil
@@ -222,7 +439,12 @@ func (s *HeatmapInferenceService) SpeciesIndex(label string) (int, bool) {
 // Rebuild replaces the ONNX session with a new one for an updated model.
 // Waits for all in-flight inferences to complete before destroying the old session.
 func (s *HeatmapInferenceService) Rebuild(modelPath string, labels []string) error {
-	newSession, err := createHeatmapSession(modelPath)
+	meta, err := loadHeatmapModelMeta(modelPath)
+	if err != nil {
+		return err
+	}
+
+	newSession, err := createHeatmapSession(modelPath, meta.inputNames, meta.outputNames)
 	if err != nil {
 		return err
 	}
@@ -231,6 +453,8 @@ func (s *HeatmapInferenceService) Rebuild(modelPath string, labels []string) err
 	oldSession := s.session.Swap(newSession)
 	s.labels = labels
 	s.indexMap = buildSpeciesIndexMap(labels)
+	s.inputName = meta.inputName
+	s.outputName = meta.outputName
 	s.mu.Unlock()
 
 	// Wait for in-flight inferences on old session to finish

--- a/internal/classifier/heatmap_service.go
+++ b/internal/classifier/heatmap_service.go
@@ -150,7 +150,7 @@ func (s *HeatmapInferenceService) ComputeGridWithBinding(
 	ctx context.Context,
 	coords []float32,
 	totalCells int,
-	speciesIdx int,
+	speciesLabel string,
 	stride int,
 	totalWeeks int,
 	batchSize int,
@@ -188,7 +188,16 @@ func (s *HeatmapInferenceService) ComputeGridWithBinding(
 	s.inflight.Add(1)
 	defer s.inflight.Done()
 
+	// Snapshot session and metadata together under RLock to prevent mismatch
+	// during Rebuild (which swaps session and updates names atomically).
+	s.mu.RLock()
 	session := s.session.Load()
+	numSpecies := len(s.labels)
+	inputName := s.inputName
+	outputName := s.outputName
+	speciesIdx, speciesFound := s.indexMap[speciesLabel]
+	s.mu.RUnlock()
+
 	if session == nil {
 		return errors.Newf("heatmap service: session not available").
 			Component("classifier.heatmap_service").
@@ -196,14 +205,8 @@ func (s *HeatmapInferenceService) ComputeGridWithBinding(
 			Build()
 	}
 
-	s.mu.RLock()
-	numSpecies := len(s.labels)
-	inputName := s.inputName
-	outputName := s.outputName
-	s.mu.RUnlock()
-
-	if speciesIdx < 0 || speciesIdx >= numSpecies {
-		return errors.Newf("heatmap service: speciesIdx %d out of range [0, %d)", speciesIdx, numSpecies).
+	if !speciesFound {
+		return errors.Newf("heatmap service: species %q not found in geomodel", speciesLabel).
 			Component("classifier.heatmap_service").
 			Category(errors.CategoryValidation).
 			Build()


### PR DESCRIPTION
## Summary

- Replace per-batch tensor allocation/destruction with ONNX Runtime IoBinding, reusing pre-allocated tensors across all week iterations within a single heatmap computation
- Chunks-outer/weeks-inner loop order reduces lat/lon copies and makes partial-batch rebinding happen at most once instead of 48 times
- Periodic `s.closed.Load()` checks prevent long computations from blocking model reload callbacks
- Extract `loadHeatmapModelMeta` helper to deduplicate metadata loading between constructor and Rebuild
- Remove dead `PredictBatchExtractSpecies` (replaced by `ComputeGridWithBinding`)

**Before:** 48 x ~192 MB tensor alloc/free cycles per request (9.2 GB GC churn)
**After:** 1 x ~192 MB allocation reused across all 48 weeks

Follow-up to #3116 (dedicated multi-threaded ONNX session). Part of Migration Explorer (#3092).

## Test plan

- [ ] Verify 2-degree heatmap still works (regression)
- [ ] Verify 1-degree heatmap still works (regression)
- [ ] Benchmark 0.5-degree heatmap for latency improvement
- [ ] Verify cache hit still returns instantly (~9ms)
- [ ] Verify range filter reload rebuilds heatmap service correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Heatmap computation reworked for single-pass, chunked processing and reduced per-step overhead.
* **Performance & Reliability**
  * Faster grid generation with fewer redundant model calls, reduced memory churn, and safer handling of session reloads mid-computation.
* **Stability**
  * Model metadata handling improved to make model reloads and inference more robust.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3120?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->