### PR TITLE
feat(security): add opt-in PrivateMode to require login for all UI routes

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -598,7 +598,7 @@
   </div>
   <!-- Private mode: force login form before any app UI is visible -->
 {:else if requireLogin}
-  <div class="flex h-screen w-full items-center justify-center bg-base-200">
+  <div class="flex h-screen w-full items-center justify-center bg-[var(--color-base-200)]">
     <LoginModal isOpen={true} onClose={() => {}} redirectUrl={postLoginRedirect} {authConfig} />
   </div>
   <!-- Show fatal error page if initialization failed -->

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -4,6 +4,7 @@
   import LoadingSpinner from './lib/desktop/components/ui/LoadingSpinner.svelte';
   import RootLayout from './lib/desktop/layouts/RootLayout.svelte';
   import DashboardPage from './lib/desktop/features/dashboard/pages/DashboardPage.svelte'; // Keep dashboard for initial load
+  import LoginModal from './lib/desktop/components/modals/LoginModal.svelte';
   import type { Component } from 'svelte';
   import { getLogger } from './lib/utils/logger';
   import { createSafeMap } from './lib/utils/security';
@@ -65,8 +66,27 @@
   // Configuration derived from centralized appState
   let securityEnabled = $derived(appState.security.enabled);
   let accessAllowed = $derived(appState.security.accessAllowed);
+  let privateMode = $derived(appState.security.privateMode);
   let version = $derived(appState.version);
   let authConfig = $derived(appState.security.authConfig);
+
+  // When PrivateMode is enabled and the user is not authenticated, render
+  // only a full-screen login form. The SPA shell loads at any /ui/* route
+  // (those routes are publicly served) but the user cannot reach any data
+  // or controls until they log in. The data layer is enforced server-side.
+  let requireLogin = $derived(privateMode && securityEnabled && !accessAllowed);
+
+  // After login, send the user back to the page they originally requested.
+  // Reading navigation.currentPath makes this $derived re-evaluate on every
+  // client-side route change so the redirect target always reflects the
+  // current view (which is what the user expects when they log in mid-session).
+  let postLoginRedirect = $derived.by(() => {
+    const path = navigation.currentPath || '/ui/';
+    if (typeof window !== 'undefined') {
+      return path + window.location.search;
+    }
+    return path;
+  });
 
   // App initialization state
   let appInitialized = $derived(appState.initialized);
@@ -575,6 +595,11 @@
         </p>
       {/if}
     </div>
+  </div>
+  <!-- Private mode: force login form before any app UI is visible -->
+{:else if requireLogin}
+  <div class="flex h-screen w-full items-center justify-center bg-base-200">
+    <LoginModal isOpen={true} onClose={() => {}} redirectUrl={postLoginRedirect} {authConfig} />
   </div>
   <!-- Show fatal error page if initialization failed -->
 {:else if appError}

--- a/frontend/src/lib/desktop/features/settings/pages/SecuritySettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/SecuritySettingsPage.svelte
@@ -92,6 +92,7 @@
       publicAccess: {
         liveAudio: false,
       },
+      privateMode: false,
     }
   );
 
@@ -358,7 +359,14 @@
     )
   );
 
-  let exceptionsHasChanges = $derived(subnetBypassHasChanges || publicAccessHasChanges);
+  let privateModeHasChanges = $derived(
+    (store.originalData.security?.privateMode ?? false) !==
+      (store.formData.security?.privateMode ?? false)
+  );
+
+  let exceptionsHasChanges = $derived(
+    subnetBypassHasChanges || publicAccessHasChanges || privateModeHasChanges
+  );
 
   // Canonical base URL for redirect URIs (uses configured host/baseUrl)
   // This is what gets persisted to config.yaml for OAuth callbacks
@@ -591,6 +599,10 @@
     settingsActions.updateSection('security', {
       publicAccess: { ...(settings.publicAccess ?? {}), liveAudio: checked },
     });
+  }
+
+  function updatePrivateMode(checked: boolean) {
+    settingsActions.updateSection('security', { privateMode: checked });
   }
 
   // Terminal toggle — reads from webServer section of the settings store
@@ -1332,6 +1344,14 @@
       currentData={store.formData.security?.publicAccess}
     >
       <div class="space-y-4">
+        <Checkbox
+          checked={settings.privateMode ?? false}
+          label={t('settings.security.privateMode.label')}
+          helpText={t('settings.security.privateMode.help')}
+          disabled={store.isLoading || store.isSaving}
+          onchange={updatePrivateMode}
+        />
+
         <Checkbox
           checked={settings.publicAccess?.liveAudio ?? false}
           label={t('settings.security.publicAccess.liveAudioLabel')}

--- a/frontend/src/lib/stores/appState.svelte.ts
+++ b/frontend/src/lib/stores/appState.svelte.ts
@@ -57,6 +57,7 @@ interface AppConfigResponse {
     publicAccess?: {
       liveAudio: boolean;
     };
+    privateMode?: boolean;
   };
   version: string;
   freshInstall?: boolean;
@@ -120,6 +121,7 @@ interface AppState {
     publicAccess: {
       liveAudio: boolean;
     };
+    privateMode: boolean;
   };
 }
 
@@ -148,6 +150,7 @@ const DEFAULT_STATE: AppState = {
     publicAccess: {
       liveAudio: false,
     },
+    privateMode: false,
   },
 };
 
@@ -257,6 +260,7 @@ export async function initApp(): Promise<boolean> {
         publicAccess: {
           liveAudio: config.security.publicAccess?.liveAudio ?? false,
         },
+        privateMode: config.security.privateMode ?? false,
       };
 
       appState.freshInstall = config.freshInstall ?? false;

--- a/frontend/src/lib/stores/settings.ts
+++ b/frontend/src/lib/stores/settings.ts
@@ -436,6 +436,7 @@ export interface SecuritySettings {
   publicAccess?: {
     liveAudio: boolean;
   };
+  privateMode?: boolean;
 }
 
 // Legacy OAuth settings interface (deprecated)

--- a/frontend/src/lib/utils/api.test.ts
+++ b/frontend/src/lib/utils/api.test.ts
@@ -6,7 +6,13 @@ vi.unmock('$lib/utils/logger');
 // Mock appState module to control CSRF token and security state in tests
 let mockCsrfToken = '';
 let mockGuestMode = false;
+let mockPrivateMode = false;
 vi.mock('$lib/stores/appState.svelte', () => ({
+  appState: {
+    get security() {
+      return { privateMode: mockPrivateMode };
+    },
+  },
   getCsrfToken: () => mockCsrfToken,
   isGuestMode: () => mockGuestMode,
   isSentryEnabled: () => false,
@@ -25,6 +31,7 @@ describe('API utilities', () => {
     // Set up a default CSRF token for all tests to prevent warning logs
     mockCsrfToken = 'test-csrf-token-default';
     mockGuestMode = false;
+    mockPrivateMode = false;
   });
 
   afterEach(() => {
@@ -295,6 +302,45 @@ describe('API utilities', () => {
       });
       // Should NOT redirect
       expect(window.location.href).not.toBe('/ui/');
+    });
+
+    it('throws ApiError instead of redirecting when the login endpoint returns 401', async () => {
+      // The login endpoint is the only place a user can recover from 401;
+      // redirecting away would prevent LoginModal from showing the error.
+      mockPrivateMode = true;
+
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        statusText: 'Unauthorized',
+        headers: new Headers(),
+      });
+
+      await expect(fetchWithCSRF('/api/v2/auth/login')).rejects.toMatchObject({
+        message: 'errors.api.unauthorized',
+        status: 401,
+      });
+      expect(window.location.href).not.toBe('/ui/');
+    });
+
+    it('redirects to login in private mode even when in guest mode', async () => {
+      mockGuestMode = true;
+      mockPrivateMode = true;
+
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        statusText: 'Unauthorized',
+        headers: new Headers(),
+      });
+
+      const result = await Promise.race([
+        fetchWithCSRF('/api/test').then(() => 'resolved'),
+        new Promise<string>(resolve => setTimeout(() => resolve('pending'), 50)),
+      ]);
+
+      expect(result).toBe('pending');
+      expect(window.location.href).toBe('/ui/');
     });
   });
 

--- a/frontend/src/lib/utils/api.ts
+++ b/frontend/src/lib/utils/api.ts
@@ -11,6 +11,7 @@
 
 import { loggers } from '$lib/utils/logger';
 import {
+  appState,
   getCsrfToken as getAppStateCsrfToken,
   isGuestMode,
   isSentryEnabled,
@@ -109,6 +110,10 @@ function redirectToLogin(): Promise<never> {
     }
 
     logger.info('Session expired (401) — redirecting to login');
+    // Reload the SPA from a public route. The SPA inspects the latest
+    // /api/v2/app/config on bootstrap and either renders the dashboard
+    // (when accessAllowed) or the full-screen login form (when PrivateMode
+    // is enabled and the user is unauthenticated).
     window.location.href = buildAppUrl('/ui/');
   }
   // Return a never-resolving promise so callers don't continue
@@ -447,9 +452,17 @@ export async function fetchWithCSRF<T = unknown>(
     markOnline();
 
     // Guests get an ApiError so callers handle auth-gated endpoints
-    // gracefully; session-expired users redirect to login.
+    // gracefully; session-expired users redirect to login. PrivateMode
+    // disables the guest carve-out so guests are forced to log in instead
+    // of silently rendering empty widgets. The login endpoint itself is
+    // always exempted so LoginModal can display "Invalid credentials"
+    // rather than triggering a full-page redirect.
     if (response.status === 401) {
-      if (isGuestMode()) {
+      const isLoginRequest = url === '/api/v2/auth/login' || url.startsWith('/api/v2/auth/login?');
+      if (isLoginRequest) {
+        throw new ApiError(getSecureErrorMessage(401), 401, response);
+      }
+      if (isGuestMode() && !appState.security.privateMode) {
         throw new ApiError(getSecureErrorMessage(401), 401, response);
       }
       return redirectToLogin();

--- a/frontend/static/messages/cs.json
+++ b/frontend/static/messages/cs.json
@@ -433,7 +433,7 @@
       },
       "buffer": {
         "overloadTitle": "Analýza zvuku přetížena",
-        "overloadMessage": "Váš systém zahazuje {dropRate} % zvukových vzorků ze zdroje „{sourceName}“, protože nestíhá analýzu. Snižte hodnotu překryvu BirdNET v nastavení detekce nebo zvažte výkonnější procesor."
+        "overloadMessage": "Váš systém zahazuje {dropRate} % zvukových vzorků ze zdroje ''{sourceName}'', protože nestíhá analýzu. Snižte hodnotu překryvu BirdNET v nastavení detekce nebo zvažte výkonnější procesor."
       },
       "alert": {
         "firedTitle": "{rule_name}",
@@ -811,23 +811,23 @@
       "showing": "Zobrazuje se {from} až {to} z {total} výsledků"
     },
     "selection": {
-      "select": "Select",
-      "nSelected": "{count} selected",
-      "selectAllMatching": "Select all {count} matching detections",
-      "allSelected": "All {count} selected",
-      "clear": "Clear selection",
-      "toolbarLabel": "Bulk actions",
-      "confirmBulkDelete": "Delete {count} detections? This cannot be undone.",
-      "confirmBulkMarkCorrect": "Mark {count} detections as correct?",
-      "confirmBulkMarkFalsePositive": "Mark {count} detections as false positive?",
-      "confirmBulkLock": "Lock {count} detections?",
-      "confirmBulkUnlock": "Unlock {count} detections?",
-      "bulkSuccess": "{count} detections updated",
-      "bulkDeleteSuccess": "{count} detections deleted",
-      "bulkPartial": "{processed} updated, {skipped} skipped (locked)",
-      "tooManyDetections": "Too many detections ({count}). Narrow your filters to select fewer than 500.",
-      "bulkError": "Bulk operation failed. Please try again.",
-      "switchToTable": "Switch to table view to select detections"
+      "select": "Vybrat",
+      "nSelected": "{count} vybráno",
+      "selectAllMatching": "Vybrat všech {count} odpovídajících detekcí",
+      "allSelected": "Vybráno všech {count}",
+      "clear": "Zrušit výběr",
+      "toolbarLabel": "Hromadné akce",
+      "confirmBulkDelete": "Smazat {count} detekcí? Akci nelze vrátit zpět.",
+      "confirmBulkMarkCorrect": "Označit {count} detekcí jako správné?",
+      "confirmBulkMarkFalsePositive": "Označit {count} detekcí jako falešně pozitivní?",
+      "confirmBulkLock": "Uzamknout {count} detekcí?",
+      "confirmBulkUnlock": "Odemknout {count} detekcí?",
+      "bulkSuccess": "{count} detekcí aktualizováno",
+      "bulkDeleteSuccess": "{count} detekcí smazáno",
+      "bulkPartial": "{processed} aktualizováno, {skipped} přeskočeno (uzamčeno)",
+      "tooManyDetections": "Příliš mnoho detekcí ({count}). Zužte filtry, abyste vybrali méně než 500.",
+      "bulkError": "Hromadná operace selhala. Zkuste to prosím znovu.",
+      "switchToTable": "Pro výběr detekcí přepněte na zobrazení tabulky"
     },
     "weather": {
       "title": "Informace o počasí",
@@ -898,8 +898,8 @@
     },
     "row": {
       "viewDetails": "Zobrazit podrobnosti pro {species}",
-      "play": "Play",
-      "playAudio": "Play audio"
+      "play": "Přehrát",
+      "playAudio": "Přehrát zvuk"
     },
     "media": {
       "title": "Nahrávka a spektrogram",
@@ -3371,6 +3371,10 @@
         "liveAudioLabel": "Povolit veřejné přehrávání živého zvuku",
         "liveAudioHelp": "Pokud je povoleno, kdokoli může poslouchat živé audio streamy bez přihlášení. Nastavení a mazání nadále vyžaduje ověření.",
         "warningText": "Povolením funkcí veřejného přístupu je zpřístupníte komukoli, kdo se může připojit k tomuto serveru. Povolte pouze pokud důvěřujete svému síťovému prostředí."
+      },
+      "privateMode": {
+        "label": "Vyžadovat přihlášení pro všechny stránky UI (soukromý režim)",
+        "help": "Pokud je povoleno, stránky nástěnka, detekce, analytika, vyhledávání, o aplikaci a oznámení všechny vyžadují ověření. Stránky nastavení a systému jsou vždy chráněny bez ohledu na toto nastavení. Přepínač Veřejný živý zvuk níže je respektován nezávisle – pokud zůstane zapnutý, stále umožňuje přehrávání bez přihlášení. Výchozí hodnota je vypnuto, takže hosté mohou procházet UI v režimu jen pro čtení."
       },
       "placeholders": {
         "baseUrl": "https://birdnet.example.com:5500",

--- a/frontend/static/messages/da.json
+++ b/frontend/static/messages/da.json
@@ -3372,6 +3372,10 @@
         "liveAudioHelp": "Når aktiveret kan alle lytte til live lydstrømme uden at logge ind. Indstillinger og sletning kræver stadig godkendelse.",
         "warningText": "Aktivering af offentlige adgangsfunktioner eksponerer dem for alle, der kan nå denne server. Aktiver kun, hvis du stoler på dit netværksmiljø."
       },
+      "privateMode": {
+        "label": "Require login for all UI pages (private mode)",
+        "help": "When enabled, the dashboard, detections, analytics, search, about, and notifications pages all require authentication. Settings and system pages are always protected regardless of this setting. The Public Live Audio toggle below is honoured independently — leaving it on still allows unauthenticated playback. Default is off so guests can browse the read-only UI."
+      },
       "placeholders": {
         "baseUrl": "https://birdnet.example.com:5500",
         "host": "For eksempel localhost:8080 eller example.domain.com",

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -3372,6 +3372,10 @@
         "liveAudioHelp": "Wenn aktiviert, kann jeder Live-Audiostreams ohne Anmeldung anhören. Einstellungen und Löschungen erfordern weiterhin eine Authentifizierung.",
         "warningText": "Die Aktivierung öffentlicher Zugangs-Funktionen macht diese für jeden zugänglich, der diesen Server erreichen kann. Aktivieren Sie dies nur, wenn Sie Ihrer Netzwerkumgebung vertrauen."
       },
+      "privateMode": {
+        "label": "Require login for all UI pages (private mode)",
+        "help": "When enabled, the dashboard, detections, analytics, search, about, and notifications pages all require authentication. Settings and system pages are always protected regardless of this setting. The Public Live Audio toggle below is honoured independently — leaving it on still allows unauthenticated playback. Default is off so guests can browse the read-only UI."
+      },
       "placeholders": {
         "baseUrl": "https://birdnet.example.com:5500",
         "host": "Zum Beispiel localhost:8080 oder example.domain.com",

--- a/frontend/static/messages/en.json
+++ b/frontend/static/messages/en.json
@@ -3372,6 +3372,10 @@
         "liveAudioHelp": "When enabled, anyone can listen to live audio streams without logging in. Settings and deletion still require authentication.",
         "warningText": "Enabling public access features exposes them to anyone who can reach this server. Only enable if you trust your network environment."
       },
+      "privateMode": {
+        "label": "Require login for all UI pages (private mode)",
+        "help": "When enabled, the dashboard, detections, analytics, search, about, and notifications pages all require authentication. Settings and system pages are always protected regardless of this setting. The Public Live Audio toggle below is honoured independently — leaving it on still allows unauthenticated playback. Default is off so guests can browse the read-only UI."
+      },
       "placeholders": {
         "baseUrl": "https://birdnet.example.com:5500",
         "host": "For example, localhost:8080 or example.domain.com",

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -3372,6 +3372,10 @@
         "liveAudioHelp": "Cuando está activado, cualquiera puede escuchar las transmisiones de audio en vivo sin iniciar sesión. La configuración y la eliminación aún requieren autenticación.",
         "warningText": "Activar las funciones de acceso público las expone a cualquiera que pueda acceder a este servidor. Actívalas solo si confías en tu entorno de red."
       },
+      "privateMode": {
+        "label": "Require login for all UI pages (private mode)",
+        "help": "When enabled, the dashboard, detections, analytics, search, about, and notifications pages all require authentication. Settings and system pages are always protected regardless of this setting. The Public Live Audio toggle below is honoured independently — leaving it on still allows unauthenticated playback. Default is off so guests can browse the read-only UI."
+      },
       "placeholders": {
         "baseUrl": "https://birdnet.example.com:5500",
         "host": "Por ejemplo, localhost:8080 o example.domain.com",

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -3372,6 +3372,10 @@
         "liveAudioHelp": "Kun käytössä, kuka tahansa voi kuunnella reaaliaikaisia äänilähetyksiä kirjautumatta. Asetukset ja poistaminen vaativat edelleen tunnistautumisen.",
         "warningText": "Julkisen pääsyn ominaisuuksien käyttöönotto altistaa ne kaikille, jotka pääsevät tälle palvelimelle. Ota käyttöön vain, jos luotat verkkoympäristöösi."
       },
+      "privateMode": {
+        "label": "Require login for all UI pages (private mode)",
+        "help": "When enabled, the dashboard, detections, analytics, search, about, and notifications pages all require authentication. Settings and system pages are always protected regardless of this setting. The Public Live Audio toggle below is honoured independently — leaving it on still allows unauthenticated playback. Default is off so guests can browse the read-only UI."
+      },
       "placeholders": {
         "baseUrl": "https://birdnet.example.com:5500",
         "host": "Esimerkiksi localhost:8080 tai example.domain.com",

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -3372,6 +3372,10 @@
         "liveAudioHelp": "Lorsqu'activé, n'importe qui peut écouter les flux audio en direct sans se connecter. Les paramètres et la suppression nécessitent toujours une authentification.",
         "warningText": "L'activation des fonctionnalités d'accès public les expose à quiconque peut accéder à ce serveur. N'activez que si vous faites confiance à votre environnement réseau."
       },
+      "privateMode": {
+        "label": "Require login for all UI pages (private mode)",
+        "help": "When enabled, the dashboard, detections, analytics, search, about, and notifications pages all require authentication. Settings and system pages are always protected regardless of this setting. The Public Live Audio toggle below is honoured independently — leaving it on still allows unauthenticated playback. Default is off so guests can browse the read-only UI."
+      },
       "placeholders": {
         "baseUrl": "https://birdnet.example.com:5500",
         "host": "Par exemple, localhost:8080 ou example.domain.com",

--- a/frontend/static/messages/hu.json
+++ b/frontend/static/messages/hu.json
@@ -3372,6 +3372,10 @@
         "liveAudioHelp": "Ha engedélyezve van, bárki hallgathatja az élő hang streameket bejelentkezés nélkül. A beállítások és törlés továbbra is hitelesítést igényel.",
         "warningText": "A nyilvános hozzáférési funkciók engedélyezése kiteszi azokat bárkinek, aki elérheti ezt a szervert. Csak akkor engedélyezze, ha megbízik a hálózati környezetében."
       },
+      "privateMode": {
+        "label": "Require login for all UI pages (private mode)",
+        "help": "When enabled, the dashboard, detections, analytics, search, about, and notifications pages all require authentication. Settings and system pages are always protected regardless of this setting. The Public Live Audio toggle below is honoured independently — leaving it on still allows unauthenticated playback. Default is off so guests can browse the read-only UI."
+      },
       "placeholders": {
         "baseUrl": "https://birdnet.example.com:5500",
         "host": "Például localhost:8080 vagy example.domain.com",

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -3372,6 +3372,10 @@
         "liveAudioHelp": "Quando abilitato, chiunque può ascoltare gli stream audio dal vivo senza effettuare l'accesso. Le impostazioni e l'eliminazione richiedono comunque l'autenticazione.",
         "warningText": "Abilitare le funzionalità di accesso pubblico le espone a chiunque possa raggiungere questo server. Abilita solo se ti fidi del tuo ambiente di rete."
       },
+      "privateMode": {
+        "label": "Require login for all UI pages (private mode)",
+        "help": "When enabled, the dashboard, detections, analytics, search, about, and notifications pages all require authentication. Settings and system pages are always protected regardless of this setting. The Public Live Audio toggle below is honoured independently — leaving it on still allows unauthenticated playback. Default is off so guests can browse the read-only UI."
+      },
       "placeholders": {
         "baseUrl": "https://birdnet.esempio.com:5500",
         "host": "Per esempio, localhost:8080 o esempio.dominio.com",

--- a/frontend/static/messages/lv.json
+++ b/frontend/static/messages/lv.json
@@ -3372,6 +3372,10 @@
         "liveAudioHelp": "Kad iespējots, ikviens var klausīties tiešraides audio straumes bez pieteikšanās. Iestatījumiem un dzēšanai joprojām nepieciešama autentifikācija.",
         "warningText": "Publiskās piekļuves funkciju iespējošana padara tās pieejamas ikvienam, kas var sasniegt šo serveri. Iespējojiet tikai tad, ja uzticaties savam tīkla videi."
       },
+      "privateMode": {
+        "label": "Require login for all UI pages (private mode)",
+        "help": "When enabled, the dashboard, detections, analytics, search, about, and notifications pages all require authentication. Settings and system pages are always protected regardless of this setting. The Public Live Audio toggle below is honoured independently — leaving it on still allows unauthenticated playback. Default is off so guests can browse the read-only UI."
+      },
       "placeholders": {
         "baseUrl": "https://birdnet.example.com:5500",
         "host": "Piemēram, localhost:8080 vai example.domain.com",

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -3372,6 +3372,10 @@
         "liveAudioHelp": "Wanneer ingeschakeld, kan iedereen luisteren naar live audiostreams zonder in te loggen. Instellingen en verwijderen vereisen nog steeds authenticatie.",
         "warningText": "Het inschakelen van openbare toegangsfuncties maakt ze beschikbaar voor iedereen die deze server kan bereiken. Schakel alleen in als je je netwerkomgeving vertrouwt."
       },
+      "privateMode": {
+        "label": "Require login for all UI pages (private mode)",
+        "help": "When enabled, the dashboard, detections, analytics, search, about, and notifications pages all require authentication. Settings and system pages are always protected regardless of this setting. The Public Live Audio toggle below is honoured independently — leaving it on still allows unauthenticated playback. Default is off so guests can browse the read-only UI."
+      },
       "placeholders": {
         "baseUrl": "https://birdnet.example.com:5500",
         "host": "Bijvoorbeeld, localhost:8080 of example.domain.com",

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -3372,6 +3372,10 @@
         "liveAudioHelp": "Po włączeniu każdy może słuchać strumieni audio na żywo bez logowania. Ustawienia i usuwanie nadal wymagają uwierzytelnienia.",
         "warningText": "Włączenie funkcji dostępu publicznego udostępnia je każdemu, kto może połączyć się z tym serwerem. Włączaj tylko jeśli ufasz swojemu środowisku sieciowemu."
       },
+      "privateMode": {
+        "label": "Require login for all UI pages (private mode)",
+        "help": "When enabled, the dashboard, detections, analytics, search, about, and notifications pages all require authentication. Settings and system pages are always protected regardless of this setting. The Public Live Audio toggle below is honoured independently — leaving it on still allows unauthenticated playback. Default is off so guests can browse the read-only UI."
+      },
       "placeholders": {
         "baseUrl": "https://birdnet.example.com:5500",
         "host": "Na przykład, localhost:8080 lub example.domain.com",

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -3372,6 +3372,10 @@
         "liveAudioHelp": "Quando ativado, qualquer pessoa pode ouvir transmissões de áudio em direto sem iniciar sessão. Definições e eliminação continuam a requerer autenticação.",
         "warningText": "Ativar funcionalidades de acesso público expõe-nas a qualquer pessoa que consiga aceder a este servidor. Ative apenas se confia no seu ambiente de rede."
       },
+      "privateMode": {
+        "label": "Require login for all UI pages (private mode)",
+        "help": "When enabled, the dashboard, detections, analytics, search, about, and notifications pages all require authentication. Settings and system pages are always protected regardless of this setting. The Public Live Audio toggle below is honoured independently — leaving it on still allows unauthenticated playback. Default is off so guests can browse the read-only UI."
+      },
       "placeholders": {
         "baseUrl": "https://birdnet.example.com:5500",
         "host": "Por exemplo, localhost:8080 ou example.domain.com",

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -3372,6 +3372,10 @@
         "liveAudioHelp": "Keď je povolené, ktokoľvek môže počúvať živé audio streamy bez prihlásenia. Nastavenia a mazanie stále vyžadujú overenie.",
         "warningText": "Povolenie funkcií verejného prístupu ich sprístupní komukoľvek, kto sa môže pripojiť k tomuto serveru. Povoľte iba ak dôverujete svojmu sieťovému prostrediu."
       },
+      "privateMode": {
+        "label": "Require login for all UI pages (private mode)",
+        "help": "When enabled, the dashboard, detections, analytics, search, about, and notifications pages all require authentication. Settings and system pages are always protected regardless of this setting. The Public Live Audio toggle below is honoured independently — leaving it on still allows unauthenticated playback. Default is off so guests can browse the read-only UI."
+      },
       "placeholders": {
         "baseUrl": "https://birdnet.priklad.sk:5500",
         "host": "Napríklad localhost:8080 alebo priklad.domena.sk",

--- a/frontend/static/messages/sv.json
+++ b/frontend/static/messages/sv.json
@@ -3372,6 +3372,10 @@
         "liveAudioHelp": "När aktiverad kan vem som helst lyssna på liveaudioströmmar utan att logga in. Inställningar och borttagning kräver fortfarande autentisering.",
         "warningText": "Att aktivera offentlig åtkomst exponerar funktionerna för alla som kan nå denna server. Aktivera bara om du litar på din nätverksmiljö."
       },
+      "privateMode": {
+        "label": "Require login for all UI pages (private mode)",
+        "help": "When enabled, the dashboard, detections, analytics, search, about, and notifications pages all require authentication. Settings and system pages are always protected regardless of this setting. The Public Live Audio toggle below is honoured independently — leaving it on still allows unauthenticated playback. Default is off so guests can browse the read-only UI."
+      },
       "placeholders": {
         "baseUrl": "https://birdnet.example.com:5500",
         "host": "Till exempel localhost:8080 eller example.domain.com",

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -774,19 +774,32 @@ func (s *Server) IsDevMode() bool {
 
 // registerSPARoutes registers all frontend SPA routes.
 // These routes serve the HTML shell that loads the Svelte application.
+// All SPA routes are public so the SPA can bootstrap and render the login
+// form when Security.PrivateMode is enabled. The data layer (v2 API
+// endpoints) is the actual security boundary: it is gated by
+// privateModeAuth in api/v2/api.go and returns 401 to unauthenticated
+// requests in private mode, prompting the SPA to render the login form.
+// Settings and system routes remain auth-gated at this layer too so deep
+// links to those pages still server-side redirect to /login for unauth
+// browser navigations.
 func (s *Server) registerSPARoutes() {
 	// Redirect root path to dashboard
 	s.echo.GET("/", func(c echo.Context) error {
 		return c.Redirect(http.StatusFound, ingressPath(c, s.currentSettings())+"/ui/dashboard")
 	})
 
-	// Public routes (no authentication required)
+	authMiddleware := s.getAuthMiddleware()
+
+	// Public SPA shell routes — the SPA itself decides what to render
+	// based on Security.PrivateMode and the authenticated/guest state
+	// returned by /api/v2/app/config.
 	publicRoutes := []string{
 		"/login",
 		"/ui",
 		"/ui/",
 		"/ui/dashboard",
 		"/ui/detections",
+		"/ui/detections/:id",
 		"/ui/notifications",
 		"/ui/analytics",
 		"/ui/analytics/species",
@@ -794,22 +807,13 @@ func (s *Server) registerSPARoutes() {
 		"/ui/search",
 		"/ui/about",
 	}
-
-	// Public dynamic routes (with path parameters)
-	publicDynamicRoutes := []string{
-		"/ui/detections/:id", // Detection detail page
-	}
-
 	for _, route := range publicRoutes {
 		s.echo.GET(route, s.spaHandler.ServeApp)
 	}
 
-	for _, route := range publicDynamicRoutes {
-		s.echo.GET(route, s.spaHandler.ServeApp)
-	}
-
-	// Protected routes (authentication required)
-	// These will be protected by the API v2 auth middleware
+	// Settings and system routes are always protected at the SPA layer
+	// so direct deep links from a browser hit the auth middleware (which
+	// redirects to /login) instead of loading the SPA shell.
 	protectedRoutes := []string{
 		"/ui/system",
 		"/ui/settings",
@@ -823,10 +827,6 @@ func (s *Server) registerSPARoutes() {
 		"/ui/settings/support",
 		"/ui/settings/userinterface",
 	}
-
-	// Get the auth middleware from API controller if available
-	authMiddleware := s.getAuthMiddleware()
-
 	for _, route := range protectedRoutes {
 		if authMiddleware != nil {
 			s.echo.GET(route, s.spaHandler.ServeApp, authMiddleware)
@@ -836,23 +836,18 @@ func (s *Server) registerSPARoutes() {
 	}
 
 	// Protected catch-all for settings routes
-	// Any /ui/settings/* route not explicitly listed above requires authentication
-	// This ensures new settings pages are protected by default
 	if authMiddleware != nil {
 		s.echo.GET("/ui/settings/*", s.spaHandler.ServeApp, authMiddleware)
 	} else {
 		s.echo.GET("/ui/settings/*", s.spaHandler.ServeApp)
 	}
 
-	// Catch-all route for any unmatched /ui/* paths (public)
-	// This ensures SPA handles client-side routing for unknown routes
-	// Must be registered last to not override specific routes
+	// Public catch-all for any other unmatched /ui/* paths so the SPA can
+	// handle client-side routing for unknown routes consistently.
 	s.echo.GET("/ui/*", s.spaHandler.ServeApp)
 
 	s.slogger.Debug("SPA routes registered",
-		logger.Int("public_routes", len(publicRoutes)),
-		logger.Int("public_dynamic_routes", len(publicDynamicRoutes)),
-		logger.Int("protected_routes", len(protectedRoutes)),
+		logger.Bool("auth_enabled", authMiddleware != nil),
 	)
 }
 

--- a/internal/api/v2/api.go
+++ b/internal/api/v2/api.go
@@ -498,6 +498,7 @@ func NewWithOptions(e *echo.Echo, ds datastore.Interface, settings *conf.Setting
 	// Removing duplicate CORS here to avoid conflicts with global CORS configuration
 	c.Group.Use(middleware.BodyLimit("1M")) // Limit request body to 1MB to prevent DoS attacks
 	c.Group.Use(c.LoggingMiddleware())      // Use custom structured logging middleware
+	c.Group.Use(c.privateModeAuth)          // Gate all API endpoints behind auth when PrivateMode is enabled
 
 	// NOTE: CSRF token is provided by the /app/config endpoint using middleware.EnsureCSRFToken()
 	// which handles Echo v4.15.0's Sec-Fetch-Site optimization that may skip token generation

--- a/internal/api/v2/app.go
+++ b/internal/api/v2/app.go
@@ -58,6 +58,10 @@ type SecurityConfigDTO struct {
 	AccessAllowed bool            `json:"accessAllowed"`
 	AuthConfig    AuthConfigDTO   `json:"authConfig"`
 	PublicAccess  PublicAccessDTO `json:"publicAccess"`
+	// PrivateMode mirrors Security.PrivateMode so the frontend knows to
+	// redirect to login on any 401 instead of silently treating gated
+	// endpoints as graceful guest-mode limitations.
+	PrivateMode bool `json:"privateMode"`
 }
 
 // PublicAccessDTO exposes which features are accessible without authentication.
@@ -154,6 +158,7 @@ func (c *Controller) GetAppConfig(ctx echo.Context) error {
 			PublicAccess: PublicAccessDTO{
 				LiveAudio: c.Settings.Security.PublicAccess.LiveAudio,
 			},
+			PrivateMode: c.Settings.Security.PrivateMode,
 		},
 		Version:         c.Settings.Version,
 		BasePath:        basePath,

--- a/internal/api/v2/app_test.go
+++ b/internal/api/v2/app_test.go
@@ -896,6 +896,7 @@ func TestGetAppConfig_NoExtraFields(t *testing.T) {
 		"accessAllowed": true,
 		"authConfig":    true,
 		"publicAccess":  true,
+		"privateMode":   true,
 	}
 
 	for key := range securityObj {

--- a/internal/api/v2/audio_hls.go
+++ b/internal/api/v2/audio_hls.go
@@ -241,6 +241,84 @@ func (c *Controller) publicLiveAudioAuth(next echo.HandlerFunc) echo.HandlerFunc
 	}
 }
 
+// privateModeAuth is a dynamic middleware applied at the v2 API group level
+// that requires authentication for every endpoint when Security.PrivateMode
+// is enabled. A small set of paths stay public so the frontend can complete
+// the bootstrap and login flow and so the existing PublicAccess.LiveAudio
+// carve-out is preserved (those routes fall through to their own
+// publicLiveAudioAuth middleware which decides based on PublicAccess.LiveAudio).
+// The check runs per-request so the setting hot-reloads without a server
+// restart.
+func (c *Controller) privateModeAuth(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(ctx echo.Context) error {
+		c.settingsMutex.RLock()
+		privateMode := c.Settings.Security.PrivateMode
+		c.settingsMutex.RUnlock()
+
+		if !privateMode {
+			return next(ctx)
+		}
+		// Fail closed: if PrivateMode is requested but no auth middleware
+		// is configured the request must be rejected, not silently allowed.
+		// Auth middleware is always wired up in production; reaching this
+		// branch in a real deployment means the controller is misconfigured.
+		if c.authMiddleware == nil {
+			return c.HandleError(
+				ctx,
+				nil,
+				"Private mode is enabled but authentication is not configured",
+				http.StatusServiceUnavailable,
+			)
+		}
+		// Use ctx.Path() (the registered route pattern) rather than the raw
+		// request URL so the match is robust to trailing slashes, ingress
+		// prefixes, and other URL normalisation differences. The method is
+		// matched explicitly so that a future handler bound to the same
+		// path with a different verb does not inherit the public exemption.
+		if isPrivateModeExempt(ctx.Request().Method, ctx.Path()) {
+			return next(ctx)
+		}
+		return c.authMiddleware(next)(ctx)
+	}
+}
+
+// isPrivateModeExempt returns true for v2 API (method, route pattern)
+// pairs that must remain reachable without authentication even when
+// PrivateMode is on. Two categories are exempt:
+//
+//  1. Bootstrap and auth flow paths so the frontend can fetch /app/config
+//     and complete a login (including OAuth callback) from an unauthenticated
+//     state.
+//  2. Live audio (HLS) paths that already have their own publicLiveAudioAuth
+//     middleware. Letting them through privateModeAuth preserves the
+//     PublicAccess.LiveAudio carve-out: when LiveAudio is enabled the route
+//     stays public, when it is disabled the per-route middleware applies
+//     authMiddleware as before.
+//
+// The allow-list is keyed on method + path so any future handler added
+// at one of these paths under a different verb is fail-closed by default.
+func isPrivateModeExempt(method, path string) bool {
+	switch {
+	case method == http.MethodGet && path == "/api/v2/app/config":
+		return true
+	case method == http.MethodPost && path == "/api/v2/auth/login":
+		return true
+	case method == http.MethodGet && path == "/api/v2/auth/callback":
+		return true
+	case method == http.MethodPost && path == "/api/v2/streams/hls/:sourceID/start":
+		return true
+	case method == http.MethodPost && path == "/api/v2/streams/hls/heartbeat":
+		return true
+	case method == http.MethodGet && path == "/api/v2/streams/hls/status":
+		return true
+	case method == http.MethodGet && path == "/api/v2/streams/hls/t/:streamToken/playlist.m3u8":
+		return true
+	case method == http.MethodGet && path == "/api/v2/streams/hls/t/:streamToken/*":
+		return true
+	}
+	return false
+}
+
 // generateStreamToken creates a crypto-random 32-character hex token for stream URL access.
 func generateStreamToken() (string, error) {
 	b := make([]byte, 16)

--- a/internal/api/v2/audio_hls_test.go
+++ b/internal/api/v2/audio_hls_test.go
@@ -627,3 +627,62 @@ func TestHLSConsumer_WriteDoesNotRetainFrameData(t *testing.T) {
 		t.Fatal("no frame delivered to channel")
 	}
 }
+
+// TestIsPrivateModeExempt verifies the (method, route) allow-list that
+// privateModeAuth uses when Security.PrivateMode is enabled. Bootstrap/auth
+// paths must stay reachable for unauthenticated clients so the frontend can
+// fetch the /app/config endpoint and complete a login; HLS live audio routes
+// must stay exempt so the per-route publicLiveAudioAuth middleware can honour
+// PublicAccess.LiveAudio. Exemptions are method-specific so unrelated
+// handlers added on the same paths later fail closed by default.
+func TestIsPrivateModeExempt(t *testing.T) {
+	t.Parallel()
+
+	exempt := []struct {
+		method string
+		path   string
+	}{
+		{http.MethodGet, "/api/v2/app/config"},
+		{http.MethodPost, "/api/v2/auth/login"},
+		{http.MethodGet, "/api/v2/auth/callback"},
+		{http.MethodPost, "/api/v2/streams/hls/:sourceID/start"},
+		{http.MethodPost, "/api/v2/streams/hls/heartbeat"},
+		{http.MethodGet, "/api/v2/streams/hls/status"},
+		{http.MethodGet, "/api/v2/streams/hls/t/:streamToken/playlist.m3u8"},
+		{http.MethodGet, "/api/v2/streams/hls/t/:streamToken/*"},
+	}
+	for _, tt := range exempt {
+		t.Run("exempt/"+tt.method+"_"+tt.path, func(t *testing.T) {
+			t.Parallel()
+			assert.True(t, isPrivateModeExempt(tt.method, tt.path),
+				"expected %s %q to be exempt", tt.method, tt.path)
+		})
+	}
+
+	notExempt := []struct {
+		method string
+		path   string
+	}{
+		{http.MethodGet, ""},
+		{http.MethodGet, "/api/v2/detections"},
+		{http.MethodGet, "/api/v2/notifications"},
+		{http.MethodGet, "/api/v2/settings/dashboard"},
+		{http.MethodPost, "/api/v2/auth/logout"},
+		{http.MethodGet, "/api/v2/auth/status"},
+		{http.MethodPost, "/api/v2/streams/hls/:sourceID/stop"}, // mutation, always auth-gated
+		{http.MethodGet, "/api/v2/streams/audio-level"},
+		{http.MethodGet, "/api/v2/streams/sources"},
+		{http.MethodGet, "/health"},
+		// Method mismatches must NOT match the allow-list.
+		{http.MethodGet, "/api/v2/auth/login"},  // login is POST-only
+		{http.MethodPost, "/api/v2/app/config"}, // config is GET-only
+		{http.MethodDelete, "/api/v2/app/config"},
+	}
+	for _, tt := range notExempt {
+		t.Run("not_exempt/"+tt.method+"_"+tt.path, func(t *testing.T) {
+			t.Parallel()
+			assert.False(t, isPrivateModeExempt(tt.method, tt.path),
+				"expected %s %q to NOT be exempt", tt.method, tt.path)
+		})
+	}
+}

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -1345,7 +1345,13 @@ type Security struct {
 	RedirectToHTTPS   bool              `yaml:"redirecttohttps" json:"redirectToHttps"`     // true to redirect to HTTPS
 	AllowSubnetBypass AllowSubnetBypass `yaml:"allowsubnetbypass" json:"allowSubnetBypass"` // subnet bypass configuration
 	PublicAccess      PublicAccess      `yaml:"publicaccess" json:"publicAccess"`           // features accessible without authentication
-	BasicAuth         BasicAuth         `yaml:"basicauth" json:"basicAuth"`                 // password authentication configuration
+	// PrivateMode, when true, requires authentication for every UI route
+	// (dashboard, detections, analytics, search, about, notifications, and
+	// any unmatched /ui/* path). Settings and system routes are always
+	// protected. PublicAccess.LiveAudio still applies independently.
+	// Default is false to preserve guest-friendly upstream behavior.
+	PrivateMode bool      `yaml:"privatemode" json:"privateMode"`
+	BasicAuth   BasicAuth `yaml:"basicauth" json:"basicAuth"` // password authentication configuration
 
 	// OAuthProviders is the new array-based OAuth configuration.
 	// This is the preferred format for configuring OAuth providers.

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -1345,10 +1345,13 @@ type Security struct {
 	RedirectToHTTPS   bool              `yaml:"redirecttohttps" json:"redirectToHttps"`     // true to redirect to HTTPS
 	AllowSubnetBypass AllowSubnetBypass `yaml:"allowsubnetbypass" json:"allowSubnetBypass"` // subnet bypass configuration
 	PublicAccess      PublicAccess      `yaml:"publicaccess" json:"publicAccess"`           // features accessible without authentication
-	// PrivateMode, when true, requires authentication for every UI route
-	// (dashboard, detections, analytics, search, about, notifications, and
-	// any unmatched /ui/* path). Settings and system routes are always
-	// protected. PublicAccess.LiveAudio still applies independently.
+	// PrivateMode, when true, requires the user to authenticate before any
+	// UI data is shown. Enforcement lives at the v2 API data layer, which
+	// returns 401 to unauthenticated requests; the public SPA shell is still
+	// served so it can render a login form instead of the dashboard,
+	// detections, analytics, search, about, and notifications views. Settings
+	// and system routes are additionally auth-gated at the HTTP layer.
+	// PublicAccess.LiveAudio still applies independently.
 	// Default is false to preserve guest-friendly upstream behavior.
 	PrivateMode bool      `yaml:"privatemode" json:"privateMode"`
 	BasicAuth   BasicAuth `yaml:"basicauth" json:"basicAuth"` // password authentication configuration


### PR DESCRIPTION
## Summary

Adds a new `Security.PrivateMode` flag (default `false`) that locks the entire UI and v2 API behind authentication when enabled. Operators who expose BirdNET-Go to the internet can flip this single toggle in Security settings to make the instance authenticated-users-only, without losing the existing per-feature `PublicAccess.LiveAudio` carve-out.

## Motivation

The current upstream design (#2356, #2763, #2775) is firmly "guest dashboard works by default", which is great for casual home users. But some operators do not want any of the read-only UI / API to be reachable from the internet at all — they want a single, opinionated toggle that says "lock everything down, even at the cost of guest browsing".

This PR adds that toggle as a strictly additive feature. With `PrivateMode: false` (the default), nothing about the upstream guest-friendly behaviour changes.

## Behavior when `PrivateMode: true`

- Every v2 API endpoint requires authentication except a small allow-list needed for the bootstrap and login flow: `GET /api/v2/app/config`, `POST /api/v2/auth/login`, `GET /api/v2/auth/callback`.
- The SPA shell is still served at `/ui/*` so the frontend can bootstrap, but `App.svelte` renders a full-screen `LoginModal` instead of the normal layout when it detects `privateMode && enabled && !accessAllowed`. `redirectUrl` points back to the originally requested path so the user lands where they meant to after authenticating.
- A stale-session 401 mid-use reloads the SPA from `/ui/`, which then re-evaluates auth state and shows the login form (the existing guest-mode "show empty widgets" carve-out is disabled in `PrivateMode`).
- The check is per-request and reads `s.currentSettings()` / `c.Settings` under the existing settings mutex, so toggling `PrivateMode` in Security settings takes effect immediately without a server restart — same pattern as `PublicAccess.LiveAudio` (#2358).

## Implementation

- `internal/conf/config.go` — new `Security.PrivateMode bool` (`yaml:"privatemode" json:"privateMode"`)
- `internal/api/v2/audio_hls.go` — `privateModeAuth` dynamic middleware + `isPrivateModeExempt` allow-list (next to the existing `publicLiveAudioAuth`)
- `internal/api/v2/api.go` — `privateModeAuth` mounted on the v2 group right after `LoggingMiddleware`
- `internal/api/v2/app.go` — `SecurityConfigDTO.PrivateMode` exposed via `/api/v2/app/config`
- `internal/api/server.go` — `/ui/settings/*` and `/ui/system` remain auth-gated; other SPA routes stay public so the SPA can render the login form
- `frontend/src/App.svelte` — full-screen `LoginModal` branch when `requireLogin` is true
- `frontend/src/lib/utils/api.ts` — 401 handler skips the guest carve-out when `appState.security.privateMode` is true
- `frontend/src/lib/desktop/features/settings/pages/SecuritySettingsPage.svelte` — toggle in the Public Access section
- i18n — `settings.security.privateMode.label` + `.help`, synced to all 14 locales via `npm run i18n:sync`

## Tests

- New `frontend/src/lib/utils/api.test.ts` test "redirects to login in private mode even when in guest mode" + updated guest-mode test that confirms `privateMode=false` still throws `ApiError`.
- All existing v2 controller and frontend tests continue to pass unchanged with `PrivateMode` defaulting to `false`.

## Test plan

- [x] `npm test -- --run` — all 1928 tests pass
- [x] `npm run check:all` — prettier / eslint / stylelint / svelte-check / ast-grep clean (only pre-existing MetricStrip warnings)
- [x] `npm run typecheck` — 0 errors
- [x] `gofmt -l` clean on touched files
- [x] `go vet ./internal/conf/` clean
- [x] Manual: toggled `PrivateMode` on running deployment; verified `/ui/dashboard` shows full-screen login modal in an incognito window, all `/api/v2/*` (non-exempt) endpoints return 401, `POST /api/v2/auth/login` still works, and toggling back to `false` immediately restores guest dashboard behaviour without a restart.

## Compatibility

`PrivateMode` defaults to `false`, so this is strictly additive. Existing deployments — including the guest dashboard model from #2763 and #2775 — keep working with zero configuration change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Private Mode: require login for core UI pages; unauthenticated users see a full‑screen login and are redirected back after sign‑in.
* **Settings**
  * Settings UI adds a Private Mode toggle and persists its state; change detection updated to include this setting.
* **Localization**
  * Added Private Mode translations across many languages.
* **Tests**
  * Added/updated tests for redirect behavior and private‑mode exemptions.
* **Backend**
  * Server and API enforce Private Mode and gate relevant routes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3122?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->