### PR TITLE
feat(i18n): add Czech locale

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -27,8 +27,9 @@ frontend/
 │   ├── pages/
 │   ├── stores/
 │   └── utils/
-├── static/messages/       # Translation files (14 locales)
+├── static/messages/       # Translation files (15 locales)
 │   ├── en.json           # English (primary)
+│   ├── cs.json           # Czech
 │   ├── da.json           # Danish
 │   ├── de.json           # German
 │   ├── es.json           # Spanish
@@ -54,6 +55,7 @@ All translation files are in `frontend/static/messages/`:
 ```bash
 frontend/static/messages/
 ├── en.json  # English (primary - update this first)
+├── cs.json  # Czech
 ├── da.json  # Danish
 ├── de.json  # German
 ├── es.json  # Spanish

--- a/frontend/src/lib/i18n/config.ts
+++ b/frontend/src/lib/i18n/config.ts
@@ -4,6 +4,7 @@
  */
 
 export const LOCALES = {
+  cs: { name: 'Čeština' },
   da: { name: 'Dansk' },
   en: { name: 'English' },
   de: { name: 'Deutsch' },

--- a/frontend/static/messages/CLAUDE.md
+++ b/frontend/static/messages/CLAUDE.md
@@ -31,7 +31,7 @@ This directory contains the internationalization (i18n) message files for BirdNE
 
 **When adding or modifying translations, ALL translation files must be updated.**
 
-Add new keys to `en.json` first, then run `npm run i18n:sync` from the `frontend/` directory to propagate the key structure to all 14 locale files (da, de, en, es, fi, fr, hu, it, lv, nl, pl, pt, sk, sv). The sync script fills missing keys with the English value as fallback; translate those fallbacks afterward.
+Add new keys to `en.json` first, then run `npm run i18n:sync` from the `frontend/` directory to propagate the key structure to all 15 locale files (cs, da, de, en, es, fi, fr, hu, it, lv, nl, pl, pt, sk, sv). The sync script fills missing keys with the English value as fallback; translate those fallbacks afterward.
 
 The pre-commit hook runs `i18n:sync --check` and blocks commits if locale files are out of sync.
 

--- a/frontend/static/messages/README.md
+++ b/frontend/static/messages/README.md
@@ -7,14 +7,20 @@ This directory contains translation files for the BirdNET-Go frontend applicatio
 Translation files are organized by language code:
 
 - `en.json` - English (default)
+- `cs.json` - Czech
+- `da.json` - Danish
 - `de.json` - German
 - `es.json` - Spanish
 - `fi.json` - Finnish
 - `fr.json` - French
+- `hu.json` - Hungarian
+- `it.json` - Italian
+- `lv.json` - Latvian
 - `nl.json` - Dutch
 - `pl.json` - Polish
 - `pt.json` - Portuguese
 - `sk.json` - Slovak
+- `sv.json` - Swedish
 
 ## Translation Key Organization
 

--- a/frontend/static/messages/cs.json
+++ b/frontend/static/messages/cs.json
@@ -1,0 +1,4676 @@
+{
+  "common": {
+    "loading": "Načítání…",
+    "error": "Chyba",
+    "unknown": "Neznámé",
+    "retry": "Zkusit znovu",
+    "retrying": "Opakování pokusu",
+    "save": "Uložit",
+    "cancel": "Zrušit",
+    "confirm": "Potvrdit",
+    "reset": "Resetovat",
+    "refresh": "Obnovit",
+    "delete": "Smazat",
+    "edit": "Upravit",
+    "enabled": "Povoleno",
+    "search": "Hledat",
+    "filter": "Filtr",
+    "sort": "Seřadit",
+    "settings": "Nastavení",
+    "close": "Zavřít",
+    "back": "Zpět",
+    "next": "Další",
+    "previous": "Předchozí",
+    "yes": "Ano",
+    "no": "Ne",
+    "ok": "OK",
+    "apply": "Použít",
+    "clear": "Vymazat",
+    "done": "Hotovo",
+    "goToDashboard": "Přejít na Dashboard",
+    "reportIssue": "Nahlásit problém",
+    "loginToViewDetails": "Pro zobrazení podrobností se přihlaste",
+    "pageNotFound": "Stránka nenalezena",
+    "internalServerError": "Interní chyba serveru",
+    "actions": {
+      "download": "Stáhnout",
+      "review": "Zkontrolovat",
+      "play": "Přehrát",
+      "view": "Zobrazit"
+    },
+    "buttons": {
+      "save": "Uložit změny",
+      "reset": "Resetovat",
+      "delete": "Smazat",
+      "cancel": "Zrušit",
+      "apply": "Použít",
+      "confirm": "Potvrdit",
+      "edit": "Upravit",
+      "close": "Zavřít",
+      "back": "Zpět",
+      "next": "Další",
+      "previous": "Předchozí",
+      "yes": "Ano",
+      "no": "Ne",
+      "ok": "OK",
+      "clear": "Vymazat",
+      "edit-config": "Upravit konfiguraci",
+      "add-action": "Přidat akci",
+      "learnMore": "Zjistit více",
+      "create": "Vytvořit"
+    },
+    "ui": {
+      "loading": "Načítání…",
+      "noData": "Žádná data nejsou k dispozici",
+      "empty": "Nenalezeny žádné položky",
+      "error": "Došlo k chybě",
+      "retry": "Zkusit znovu",
+      "dismiss": "Zavřít",
+      "showMore": "Zobrazit více",
+      "showLess": "Zobrazit méně",
+      "selectAll": "Vybrat vše",
+      "selectNone": "Zrušit výběr",
+      "required": "Povinné",
+      "optional": "Volitelné",
+      "noAudioSources": "Žádné zvukové zdroje nejsou k dispozici",
+      "noNotifications": "Žádná oznámení",
+      "silent": "(ticho)",
+      "loadingSettings": "Načítání nastavení…",
+      "settingsNotFound": "Nastavení nenalezeno",
+      "sectionNotFound": "Požadovanou sekci nastavení „{section}“ se nepodařilo najít.",
+      "loadingMap": "Načítání mapy…",
+      "mapZoomHelp": "Pro přiblížení podržte Ctrl (nebo Cmd na Macu) a posouvejte kolečkem. Kliknutím nastavíte polohu.",
+      "mapSetLocationHelp": "Klikněte na mapu nebo přetáhněte značku pro nastavení polohy",
+      "imageNotAvailable": "Obrázek není k dispozici",
+      "search": "Hledat…"
+    },
+    "status": {
+      "success": "Úspěch",
+      "error": "Chyba",
+      "warning": "Upozornění",
+      "info": "Informace",
+      "pending": "Čeká se",
+      "processing": "Zpracovává se",
+      "completed": "Dokončeno",
+      "failed": "Selhalo"
+    },
+    "validation": {
+      "required": "Toto pole je povinné",
+      "invalid": "Neplatná hodnota",
+      "minLength": "Musí obsahovat alespoň {min} znaků",
+      "maxLength": "Může obsahovat nejvýše {max} znaků",
+      "minValue": "Musí být alespoň {min}",
+      "maxValue": "Může být nejvýše {max}",
+      "email": "Neplatná e-mailová adresa",
+      "url": "Neplatná URL adresa",
+      "pattern": "Neplatný formát"
+    },
+    "aria": {
+      "closeModal": "Zavřít modální okno",
+      "dismissAlert": "Zavřít upozornění",
+      "closeNotification": "Zavřít oznámení",
+      "toggleDropdown": "Přepnout rozbalovací nabídku",
+      "sortAscending": "Seřadit vzestupně",
+      "selectLanguage": "Vybrat jazyk",
+      "sortDescending": "Seřadit sestupně",
+      "expandSection": "Rozbalit sekci",
+      "collapseSection": "Sbalit sekci",
+      "playAudio": "Přehrát zvuk",
+      "pauseAudio": "Pozastavit zvuk",
+      "loading": "Načítání obsahu",
+      "saveChanges": "Uložit změny",
+      "cancelEdit": "Zrušit úpravy",
+      "editSpecies": "Upravit druh",
+      "removeSpecies": "Odebrat druh",
+      "dismissError": "Zavřít chybu",
+      "datePickerCalendar": "Kalendář pro výběr data",
+      "selectDate": "Vybrat datum",
+      "previousMonth": "Předchozí měsíc",
+      "nextMonth": "Následující měsíc",
+      "selectToday": "Vybrat dnešek",
+      "dateSelected": "Vybrané datum: {date}",
+      "calendarNavigation": "Pro pohyb v kalendáři použijte šipky, Enter pro výběr, Escape pro zavření",
+      "downloadCsv": "Stáhnout seznam druhů jako CSV",
+      "visitEbirdLink": "Otevřít eBird.org v nové kartě",
+      "learnEbirdTaxonomyLink": "Otevřít taxonomii eBird v nové kartě",
+      "resizeHandle": "Tažením změníte velikost"
+    },
+    "labels": {
+      "confidence": "Spolehlivost",
+      "github": "GitHub"
+    },
+    "values": {
+      "yes": "Ano",
+      "no": "Ne",
+      "unknown": "Neznámé"
+    },
+    "modal": {
+      "confirmAction": "Potvrdit akci",
+      "confirmMessage": "Opravdu chcete tuto akci provést?"
+    },
+    "review": {
+      "modalTitle": "Kontrola detekce: {species}",
+      "status": {
+        "verifiedCorrect": "Ověřeno jako správné",
+        "falsePositive": "Falešně pozitivní",
+        "notReviewed": "Nezkontrolováno",
+        "locked": "Uzamčeno",
+        "unlikely": "Nepravděpodobné"
+      },
+      "form": {
+        "correctDetection": "Správná detekce",
+        "falsePositiveLabel": "Falešně pozitivní",
+        "reviewDetectionTitle": "Zkontrolovat detekci",
+        "lockDetection": "Po uložení tuto detekci uzamknout",
+        "lockDetectionHelp": "Uzamčením této detekce zabráníte jejímu smazání během pravidelného úklidu.",
+        "unlockDetection": "Po uložení tuto detekci odemknout",
+        "unlockDetectionHelp": "Odemčením umožníte smazání této detekce během pravidelného úklidu.",
+        "ignoreSpecies": "Ignorovat tento druh",
+        "ignoreSpeciesHelp": "Ignorováním tohoto druhu zabráníte budoucím detekcím tohoto druhu. Stávající detekce nebudou odstraněny.",
+        "detectionLocked": "Tato detekce je momentálně uzamčena.",
+        "comment": "Komentář",
+        "addComment": "Přidat komentář",
+        "hideComment": "Skrýt komentář",
+        "commentPlaceholder": "Přidejte komentář k této detekci…",
+        "commentCount": "({chars} znaků)",
+        "chars": "znaků",
+        "commentsLabel": "Komentáře",
+        "currentStatusTitle": "Aktuální stav",
+        "detectionStatusTitle": "Stav detekce",
+        "lockLabel": "Stav uzamčení",
+        "reviewLabel": "Stav kontroly",
+        "saveReview": "Uložit kontrolu"
+      },
+      "errors": {
+        "saveFailed": "Kontrolu se nepodařilo uložit. Zkuste to prosím znovu.",
+        "noAudio": "Pro tuto detekci není k dispozici žádná zvuková nahrávka.",
+        "commentFailed": "Komentář se nepodařilo uložit. Zkuste to prosím znovu.",
+        "lockStatusFailed": "Stav uzamčení se nepodařilo aktualizovat. Zkuste to prosím znovu.",
+        "verificationFailed": "Stav ověření se nepodařilo aktualizovat. Zkuste to prosím znovu."
+      }
+    },
+    "errors": {
+      "unknownError": "Došlo k neznámé chybě"
+    },
+    "toggle": "Přepnout",
+    "image": "Obrázek",
+    "actionsColumn": "Akce",
+    "closeModal": "Zavřít dialog",
+    "hoursShort": "h"
+  },
+  "pageTitle": {
+    "settings": "Nastavení – BirdNET-Go",
+    "pageNotFound": "404 – Stránka nenalezena",
+    "serverError": "500 – Interní chyba serveru",
+    "componentError": "Chyba načítání komponenty",
+    "speciesAnalytics": "Analýza druhů",
+    "advancedAnalytics": "Pokročilá analýza",
+    "detectionDetails": "Podrobnosti detekce",
+    "settingsNotAvailable": "Nastavení není k dispozici"
+  },
+  "navigation": {
+    "dashboard": "Dashboard",
+    "settingsMenu": "Nabídka nastavení",
+    "theme": "Motiv",
+    "github": "GitHub",
+    "detections": "Detekce",
+    "search": "Hledat",
+    "analytics": "Analýza",
+    "notifications": "Oznámení",
+    "system": "Systém",
+    "settings": "Nastavení",
+    "about": "O aplikaci",
+    "toggleSidebar": "Přepnout boční panel",
+    "mainNavigation": "Hlavní navigace",
+    "closeSidebar": "Zavřít boční panel",
+    "collapseSidebar": "Sbalit boční panel",
+    "expandSidebar": "Rozbalit boční panel",
+    "analyticsSubmenu": "Podnabídka analýzy",
+    "settingsSubmenu": "Podnabídka nastavení",
+    "systemSubmenu": "Podnabídka systému",
+    "systemTerminal": "Terminál"
+  },
+  "about": {
+    "title": "BirdNET-Go",
+    "subtitle": "Moderní rozhraní pro detekci a klasifikaci ptačího zpěvu v reálném čase",
+    "logoAlt": "Logo BirdNET-Go",
+    "overview": "Přehled",
+    "overviewText": "BirdNET-Go je implementace v jazyce Go pro detekci a klasifikaci ptačího zpěvu v reálném čase, postavená na základech projektu BirdNET. Aplikace nabízí uživatelsky přívětivé rozhraní pro nepřetržité monitorování a analýzu ptačího zpěvu.",
+    "birdnetProject": "Projekt BirdNET",
+    "birdnetDescription": "BirdNET-Go by nebyl možný bez průkopnické práce projektu BirdNET. Model umělé inteligence, který pohání detekční schopnosti BirdNET-Go, je výsledkem inovativního výzkumu a vývoje projektu BirdNET.",
+    "developedBy": "Vyvinuto",
+    "developersText": "K. Lisa Yang Center for Conservation Bioacoustics na Cornell Lab of Ornithology ve spolupráci s Chemnitz University of Technology:",
+    "visitBirdnetAnalyzer": "Navštívit projekt BirdNET-Analyzer",
+    "visitBirdnetAnalyzerAriaLabel": "Navštívit GitHub repozitář BirdNET-Analyzer",
+    "contributors": "Přispěvatelé",
+    "contributorsText": "BirdNET-Go rostl a zlepšoval se díky společnému úsilí mnoha jednotlivců. Jejich příspěvky, od vylepšení kódu až po návrhy funkcí, byly neocenitelné při zlepšování tohoto projektu.",
+    "mainDeveloper": "Hlavní vývojář",
+    "githubContributors": "Přispěvatelé na GitHubu",
+    "contributorsNote": "Zvláštní poděkování patří těmto přispěvatelům za jejich cennou práci na zlepšování BirdNET-Go:",
+    "communityAcknowledgment": "Poděkování komunitě",
+    "communityText": "Rádi bychom také vyjádřili vděčnost všem uživatelům, kteří přispěli prostřednictvím:",
+    "bugReports": "Hlášení chyb a sledování problémů",
+    "featureSuggestions": "Návrhy funkcí a zpětná vazba",
+    "testing": "Testování a ověřování",
+    "documentation": "Vylepšení dokumentace",
+    "additionalCredits": "Další poděkování",
+    "birdnetPiProject": "Projekt BirdNET-Pi",
+    "birdnetPiDescription": "Zvláštní poděkování patří Patricku McGuireovi za jeho inspirativní práci na BirdNET-Pi, která ovlivnila vývoj BirdNET-Go. BirdNET-Pi ukazuje potenciál detekce ptačího zpěvu na vestavěných zařízeních a nastavil vysoký standard pro vývoj řízený komunitou.",
+    "visitBirdnetPi": "Navštívit projekt BirdNET-Pi",
+    "labelTranslations": "Překlady štítků BirdNET",
+    "labelTranslationsBy": "Poskytl Patrick Levin pro projekt BirdNET-Pi od Patricka McGuirea",
+    "patrickLevinGithub": "GitHub Patricka Levina",
+    "versionInformation": "Informace o verzi",
+    "currentVersion": "Aktuální verze",
+    "buildDate": "Datum sestavení",
+    "developmentBuild": "Vývojové sestavení",
+    "unknown": "Neznámé",
+    "licenseInformation": "Informace o licenci",
+    "licenseText": "Model BirdNET AI i BirdNET-Go jsou licencovány pod",
+    "ccLicense": "Creative Commons Uveďte původ-Neužívejte komerčně-Zachovejte licenci 4.0 Mezinárodní licence",
+    "licenseDescription": "Tato licence umožňuje ostatním upravovat, přizpůsobovat a stavět na tomto díle nekomerčně, pokud je uveden patřičný kredit a nová díla jsou licencována pod stejnými podmínkami.",
+    "dependencyLicenses": "Licence závislostí",
+    "taxonomyDataTitle": "Taxonomická data",
+    "taxonomyDataIntro": "BirdNET-Go obsahuje vestavěná data o taxonomii ptáků odvozená z eBird/Clements Checklist, což umožňuje rychlé lokální vyhledávání rodů a čeledí.",
+    "source": "Zdroj",
+    "ebirdApiV2": "eBird API v2",
+    "copyright": "Autorská práva",
+    "coverage": "Pokrytí",
+    "taxonomyCoverage": "2 374 rodů, 254 čeledí, 11 145 druhů",
+    "visitEbird": "Navštívit eBird.org",
+    "ebirdOrg": "eBird.org",
+    "learnEbirdTaxonomy": "Dozvědět se o taxonomii eBird",
+    "avicommonsTitle": "Náhledy ptáků",
+    "avicommonsDescription": "BirdNET-Go používá vybrané obrázky ptáků z Avicommons, knihovny ručně vybraných, oříznutých a orientovaných fotografií ptáků licencovaných pod licencemi Creative Commons.",
+    "githubStarPrompt": "Pokud považujete BirdNET-Go za užitečný, zvažte přidání hvězdičky projektu na GitHubu. Hvězdičky pomáhají ostatním objevit tento projekt a podporují jeho další vývoj.",
+    "viewOnGithub": "Zobrazit projekt na GitHubu",
+    "visitGithubAriaLabel": "Navštívit GitHub repozitář BirdNET-Go",
+    "visitAvicommonsGithub": "Navštívit GitHub repozitář Avicommons"
+  },
+  "notifications": {
+    "title": "Oznámení",
+    "subtitle": "Zobrazit a spravovat všechna systémová oznámení",
+    "filters": {
+      "label": "Filtry",
+      "allStatus": "Všechny stavy",
+      "unread": "Nepřečtené",
+      "read": "Přečtené",
+      "acknowledged": "Potvrzené",
+      "allTypes": "Všechny typy",
+      "errors": "Chyby",
+      "warnings": "Varování",
+      "info": "Informace",
+      "system": "Systém",
+      "detections": "Detekce",
+      "allPriorities": "Všechny priority",
+      "critical": "Kritická",
+      "high": "Vysoká",
+      "medium": "Střední",
+      "low": "Nízká"
+    },
+    "actions": {
+      "markAllRead": "Označit vše jako přečtené",
+      "refresh": "Obnovit oznámení",
+      "markAsRead": "Označit jako přečtené",
+      "acknowledge": "Potvrdit",
+      "delete": "Odstranit",
+      "confirmDelete": "Potvrdit odstranění",
+      "deleteConfirmation": "Opravdu chcete odstranit toto oznámení?",
+      "viewAll": "Zobrazit všechna oznámení"
+    },
+    "aria": {
+      "filterByStatus": "Filtrovat podle stavu",
+      "filterByType": "Filtrovat podle typu",
+      "filterByPriority": "Filtrovat podle priority"
+    },
+    "empty": {
+      "title": "Nebyla nalezena žádná oznámení",
+      "subtitle": "Upravte filtry nebo to zkuste později"
+    },
+    "errors": {
+      "loadFailed": "Nepodařilo se načíst oznámení. Zkuste to prosím znovu.",
+      "deleteFailed": "Nepodařilo se odstranit oznámení. Zkuste to prosím znovu.",
+      "networkError": "Došlo k chybě sítě. Zkuste to prosím znovu.",
+      "markReadFailed": "Nepodařilo se označit oznámení jako přečtené. Zkuste to prosím znovu."
+    },
+    "timeAgo": {
+      "justNow": "Právě teď",
+      "minutesAgo": "před {minutes} min",
+      "hoursAgo": "před {hours} h",
+      "daysAgo": "před {days} dny"
+    },
+    "viewMode": {
+      "label": "Režim zobrazení",
+      "grouped": "Seskupené zobrazení",
+      "flat": "Ploché zobrazení"
+    },
+    "groups": {
+      "markAllRead": "Označit vše jako přečtené",
+      "dismissAll": "Zavřít vše",
+      "unread": "{count} nepřečtených",
+      "confirmBulkDelete": "Odstranit více oznámení",
+      "bulkDeleteConfirmation": "Opravdu chcete odstranit {count} oznámení?"
+    },
+    "content": {
+      "startup": {
+        "title": "BirdNET-Go spuštěn",
+        "message": "Aplikace úspěšně spuštěna (v{version})"
+      },
+      "shutdown": {
+        "title": "BirdNET-Go se vypíná",
+        "message": "Aplikace se řádně vypíná"
+      },
+      "detection": {
+        "title": "Detekováno: {species}",
+        "message": "Spolehlivost: {confidence} %"
+      },
+      "integration": {
+        "failedTitle": "Integrace {integration} selhala",
+        "failedMessage": "Připojení k {integration} selhalo. Zkontrolujte konfiguraci a logy."
+      },
+      "resource": {
+        "highUsage": "Vysoké využití zdroje {resource}",
+        "criticalUsage": "Kritické využití zdroje {resource}",
+        "recovered": "Využití zdroje {resource} se vrátilo do normálu",
+        "currentUsage": "Aktuálně na {current}{unit} (práh: {threshold}{unit})"
+      },
+      "error": {
+        "criticalSystem": "Kritická systémová chyba",
+        "application": "Chyba aplikace",
+        "imageProvider": "Upozornění poskytovatele obrázků",
+        "categoryError": "Chyba kategorie {category}",
+        "burstTitle": "Více chyb v komponentě {component}",
+        "burstMessage": "{count} chyb za posledních {window_minutes} minut: {sample_error}"
+      },
+      "settings": {
+        "reloadingBirdnet": "Aplikuji nová nastavení analýzy…",
+        "rebuildingRangeFilter": "Přestavuji filtr výskytu druhů…",
+        "updatingIntervals": "Aktualizuji intervaly detekce…",
+        "reconfiguringMqtt": "Aktualizuji připojení MQTT…",
+        "reconfiguringBirdweather": "Aktualizuji integraci BirdWeather…",
+        "reconfiguringStreams": "Aktualizuji audio streamy…",
+        "reconfiguringTelemetry": "Aktualizuji nastavení telemetrie…",
+        "reconfiguringPushNotifications": "Překonfiguruji poskytovatele push oznámení…",
+        "reconfiguringSpeciesTracking": "Aktualizuji sledování druhů…",
+        "recalculatingThresholds": "Přepočítávám dynamické prahy pro novou základní hodnotu",
+        "reconfiguringDynamicThresholds": "Překonfiguruji dynamické prahy…",
+        "webserverRestartRequired": "Nastavení webového serveru byla změněna. Je vyžadován restart.",
+        "reconfiguringSoundLevel": "Aktualizuji monitorování hladiny zvuku…",
+        "reconfiguringAudioSources": "Překonfiguruji zdroje zvuku…",
+        "rebuildingExtendedCapture": "Přestavuji filtr rozšířeného nahrávání…",
+        "extendedCaptureRestartRequired": "Nastavení rozšířeného nahrávání byla změněna. Je vyžadován restart.",
+        "equalizerUpdateFailed": "Nepodařilo se aktualizovat nastavení audio ekvalizéru",
+        "equalizerUpdated": "Nastavení audio ekvalizéru aktualizováno",
+        "savedSuccessfully": "Nastavení úspěšně uloženo",
+        "saveFailed": "Uložení nastavení selhalo"
+      },
+      "migration": {
+        "startedTitle": "Migrace databáze zahájena",
+        "startedMessage": "Migrace byla zahájena. Může to chvíli trvat v závislosti na počtu detekcí.",
+        "pausedTitle": "Migrace databáze pozastavena",
+        "pausedMessage": "Migrace databáze byla pozastavena. Můžete ji kdykoli obnovit v nastavení databáze.",
+        "cancelledTitle": "Migrace databáze zrušena",
+        "cancelledMessage": "Migrace databáze byla zrušena. Novou migraci můžete kdykoli spustit v nastavení databáze.",
+        "completedTitle": "Migrace databáze dokončena",
+        "completedMessage": "Migrace dokončena. Pro přepnutí na novou databázi restartujte BirdNET-Go.",
+        "errorTitle": "Chyba migrace databáze",
+        "errorMessage": "Migrace pozastavena kvůli chybám. Zkontrolujte logy a zkuste pokračovat."
+      },
+      "cleanup": {
+        "completeTitle": "Vyčištění staré databáze dokončeno",
+        "completeMessage": "Uvolněno {space} místa na disku.",
+        "failedTitle": "Vyčištění staré databáze selhalo",
+        "failedMessage": "Nepodařilo se odstranit starou databázi. Podrobnosti najdete v logu."
+      },
+      "buffer": {
+        "overloadTitle": "Analýza zvuku přetížena",
+        "overloadMessage": "Váš systém zahazuje {dropRate} % zvukových vzorků ze zdroje „{sourceName}“, protože nestíhá analýzu. Snižte hodnotu překryvu BirdNET v nastavení detekce nebo zvažte výkonnější procesor."
+      },
+      "alert": {
+        "firedTitle": "{rule_name}",
+        "metricExceeded": "Aktuální hodnota: {value} % (práh: {threshold} %)",
+        "detectionOccurred": "{species_name} detekován se spolehlivostí {confidence} %",
+        "errorOccurred": "{error}",
+        "disconnected": "{source_name} odpojen",
+        "error": {
+          "authError": "Ověření selhalo — zkontrolujte API klíč nebo přihlašovací údaje",
+          "rateLimited": "Dosažen limit požadavků — požadavky se automaticky zpomalí",
+          "gatewayTimeout": "Služba může být přetížena",
+          "serverError": "Služba je dočasně nedostupná",
+          "connectionRefused": "Služba je nedostupná — zkontrolujte adresu a zda je spuštěná",
+          "dnsError": "Nepodařilo se přeložit název hostitele — zkontrolujte adresu",
+          "tlsError": "Chyba TLS/certifikátu — zkontrolujte nastavení zabezpečení",
+          "timeout": "Vypršel časový limit připojení — služba může být pomalá nebo nedostupná",
+          "connectionInterrupted": "Připojení bylo přerušeno — automaticky se zkusí znovu",
+          "diskFull": "Disk je plný — uvolněte místo",
+          "permissionDenied": "Přístup odepřen — zkontrolujte oprávnění souboru nebo služby"
+        }
+      }
+    },
+    "loading": "Načítání oznámení…"
+  },
+  "search": {
+    "title": "Filtry vyhledávání",
+    "results": "Výsledky vyhledávání",
+    "resultsCountZero": "Žádné výsledky",
+    "resultsCountOne": "1 výsledek",
+    "resultsCountOther": "{count} výsledků",
+    "noSearchPerformed": "Zatím nebylo provedeno žádné vyhledávání",
+    "noSearchPerformedHint": "Pomocí filtrů vyhledávání výše najděte detekce ptáků",
+    "loadingResults": "Načítání výsledků…",
+    "noResultsFound": "Nebyly nalezeny žádné výsledky",
+    "noResultsHint": "Zkuste upravit filtry vyhledávání",
+    "fields": {
+      "species": "Druh",
+      "speciesPlaceholder": "Zadejte název druhu",
+      "speciesHelp": "Zadejte celý nebo částečný název druhu (nerozlišují se malá a velká písmena)",
+      "dateRange": "Rozsah dat",
+      "dateRangeHelp": "Filtrovat detekce podle rozsahu dat (ponechte prázdné pro všechna data)",
+      "from": "Od",
+      "to": "Do",
+      "confidenceRange": "Rozsah spolehlivosti (%)",
+      "confidenceMin": "Minimální procento spolehlivosti",
+      "confidenceMax": "Maximální procento spolehlivosti",
+      "verifiedStatus": "Stav ověření",
+      "lockedStatus": "Stav uzamčení",
+      "timeOfDay": "Denní doba"
+    },
+    "advancedFilters": "Pokročilé filtry",
+    "showAdvancedFilters": "Zobrazit pokročilé filtry",
+    "hideAdvancedFilters": "Skrýt pokročilé filtry",
+    "verifiedOptions": {
+      "any": "Jakýkoli stav",
+      "verified": "Pouze ověřené",
+      "unverified": "Pouze neověřené"
+    },
+    "lockedOptions": {
+      "any": "Jakýkoli stav",
+      "locked": "Pouze uzamčené",
+      "unlocked": "Pouze odemčené"
+    },
+    "timeOfDayOptions": {
+      "any": "Kdykoli",
+      "day": "Pouze den",
+      "night": "Pouze noc",
+      "sunrise": "Východ slunce +/- 30 min",
+      "sunset": "Západ slunce +/- 30 min"
+    },
+    "sortOptions": {
+      "dateDesc": "Datum (od nejnovějších)",
+      "dateAsc": "Datum (od nejstarších)",
+      "speciesAsc": "Druh (A–Z)",
+      "confidenceDesc": "Spolehlivost (od nejvyšší)"
+    },
+    "tableHeaders": {
+      "dateTime": "Datum a čas",
+      "timeOfDay": "Denní doba",
+      "species": "Druh",
+      "confidence": "Spolehlivost",
+      "status": "Stav",
+      "actions": "Akce"
+    },
+    "statusBadges": {
+      "verified": "Ověřeno",
+      "false": "Nesprávné",
+      "unverified": "Neověřeno",
+      "locked": "Uzamčeno",
+      "unlocked": "Odemčeno",
+      "unlikely": "Nepravděpodobné"
+    },
+    "review": {
+      "review": "Zkontrolovat",
+      "reviewDetection": "Zkontrolovat detekci {species}",
+      "markCorrect": "Označit jako správné",
+      "markFalsePositive": "Označit jako falešnou detekci",
+      "markedCorrect": "Detekce označena jako správná",
+      "markedFalsePositive": "Detekce označena jako falešná",
+      "failed": "Nepodařilo se aktualizovat stav ověření"
+    },
+    "detailsPanel": {
+      "audioPlayer": "Přehrávač zvuku",
+      "expandDetails": "Rozbalit podrobnosti pro {species}",
+      "collapseDetails": "Sbalit podrobnosti pro {species}",
+      "playAudio": "Přehrát zvuk pro {species}",
+      "viewDetails": "Zobrazit podrobnosti pro {species}",
+      "unknownSpecies": "Neznámý druh",
+      "clickToCollapse": "Kliknutím sbalíte"
+    },
+    "errors": {
+      "searchFailed": "Vyhledávání selhalo: {error}",
+      "minMaxConfidence": "Minimální spolehlivost nemůže být větší než maximální spolehlivost."
+    },
+    "pagination": {
+      "page": "Stránka {current} z {total}",
+      "goToPrevious": "Přejít na předchozí stránku",
+      "goToNext": "Přejít na další stránku"
+    }
+  },
+  "error": {
+    "404": {
+      "code": "404",
+      "title": "Stránka nenalezena",
+      "goToDashboard": "Přejít na Dashboard"
+    },
+    "500": {
+      "code": "500",
+      "title": "Interní chyba serveru",
+      "defaultMessage": "Došlo k interní chybě serveru.",
+      "goToDashboard": "Přejít na Dashboard"
+    },
+    "server": {
+      "title": "Chyba připojení k serveru",
+      "description": "Nelze se připojit k serveru. Zkontrolujte své připojení a zkuste to znovu."
+    },
+    "generic": {
+      "errorDetails": "Podrobnosti chyby",
+      "stackTrace": "Trasování zásobníku",
+      "goToDashboard": "Přejít na Dashboard",
+      "reportIssue": "Nahlásit problém",
+      "loginToViewDetails": "Pro zobrazení podrobností se přihlaste",
+      "componentLoadError": "Chyba načítání komponenty",
+      "failedToLoadComponent": "Nepodařilo se načíst požadovanou komponentu"
+    }
+  },
+  "dashboard": {
+    "approved": "Schváleno",
+    "currentlyHearing": {
+      "title": "Právě slyšíme",
+      "subtitle": "Druhy identifikované v reálném čase",
+      "empty": "Vše je v klidu — momentálně nejsou detekováni žádní ptáci"
+    },
+    "rejected": "Zamítnuto",
+    "dailySummary": {
+      "title": "Denní aktivita",
+      "subtitle": "Detekce druhů podle hodin",
+      "columns": {
+        "species": "Druh",
+        "detections": "Detekce"
+      },
+      "daylight": {
+        "label": "Denní světlo",
+        "sunrise": "Východ slunce v {time}",
+        "sunset": "Západ slunce v {time}"
+      },
+      "weather": {
+        "label": "Počasí"
+      },
+      "legend": {
+        "less": "Méně",
+        "more": "Více"
+      },
+      "navigation": {
+        "previousDay": "Předchozí den",
+        "nextDay": "Následující den",
+        "today": "Dnes"
+      },
+      "tooltips": {
+        "viewHourly": "Zobrazit všechny detekce pro {hour}:00",
+        "viewBiHourly": "Zobrazit všechny detekce pro {startHour}:00–{endHour}:00",
+        "viewSixHourly": "Zobrazit všechny detekce pro {startHour}:00–{endHour}:00",
+        "hourlyDetections": "{count} detekcí v {hour}:00 – kliknutím zobrazíte",
+        "biHourlyDetections": "{count} detekcí od {startHour}:00 do {endHour}:00 – kliknutím zobrazíte",
+        "sixHourlyDetections": "{count} detekcí od {startHour}:00 do {endHour}:00 – kliknutím zobrazíte"
+      },
+      "loading": {
+        "preparing": "Připravuji data…",
+        "fetching": "Načítám detekce…",
+        "error": "Nepodařilo se načíst data",
+        "complete": "Data úspěšně načtena"
+      },
+      "noSpecies": "V tento den nebyly detekovány žádné druhy"
+    },
+    "recentDetections": {
+      "title": "Nedávné detekce",
+      "subtitle": "Naposledy identifikované druhy",
+      "controls": {
+        "show": "Zobrazit:",
+        "refresh": "Obnovit detekce",
+        "refreshPaused": "Obnovování pozastaveno během aktivní interakce"
+      },
+      "headers": {
+        "dateTime": "Datum a čas",
+        "time": "Čas",
+        "commonName": "Běžný název",
+        "species": "Druh",
+        "weather": "Počasí",
+        "confidence": "Spolehlivost",
+        "thumbnail": "Náhled",
+        "status": "Stav",
+        "recording": "Nahrávka",
+        "actions": "Akce"
+      },
+      "status": {
+        "verified": "Ověřeno",
+        "false": "Nesprávné",
+        "unverified": "Neověřeno",
+        "locked": "Uzamčeno",
+        "unlikely": "Nepravděpodobné"
+      },
+      "modals": {
+        "showSpecies": "Zobrazovat druh {species}",
+        "ignoreSpecies": "Ignorovat druh {species}",
+        "showSpeciesConfirm": "Opravdu chcete v budoucnu zobrazovat detekce druhu {species}?",
+        "ignoreSpeciesConfirm": "Opravdu chcete v budoucnu ignorovat detekce druhu {species}? Ovlivní to pouze nové detekce – stávající detekce v databázi zůstanou.",
+        "unlockDetection": "Odemknout detekci",
+        "lockDetection": "Uzamknout detekci",
+        "unlockDetectionConfirm": "Opravdu chcete odemknout tuto detekci druhu {species}? To umožní její smazání během pravidelného čištění.",
+        "lockDetectionConfirm": "Opravdu chcete uzamknout tuto detekci druhu {species}? To zabrání jejímu smazání během pravidelného čištění.",
+        "deleteDetection": "Odstranit detekci druhu {species}",
+        "deleteDetectionConfirm": "Opravdu chcete odstranit detekci druhu {species}? Tuto akci nelze vrátit zpět."
+      },
+      "actions": {
+        "menuLabel": "Akce pro {species}",
+        "markCorrect": "Správně",
+        "markFalsePositive": "Nesprávně",
+        "review": "Zkontrolovat detekci",
+        "showSpecies": "Zobrazovat druh",
+        "ignoreSpecies": "Ignorovat druh",
+        "lockDetection": "Uzamknout detekci",
+        "unlockDetection": "Odemknout detekci",
+        "deleteDetection": "Odstranit detekci"
+      },
+      "noDetections": "Žádné nedávné detekce",
+      "errors": {
+        "toggleSpeciesFailed": "Aktualizace vyloučení druhu selhala. Zkuste to prosím znovu.",
+        "toggleLockFailed": "Aktualizace stavu uzamčení selhala. Zkuste to prosím znovu.",
+        "deleteFailed": "Odstranění detekce selhalo. Zkuste to prosím znovu."
+      }
+    },
+    "errors": {
+      "dailySummaryFetch": "Nepodařilo se získat denní souhrn: {status}",
+      "dailySummaryLoad": "Nepodařilo se načíst denní souhrn",
+      "recentDetectionsFetch": "Nepodařilo se získat nedávné detekce: {status}",
+      "recentDetectionsLoad": "Nepodařilo se načíst nedávné detekce",
+      "configFetch": "Nepodařilo se získat konfiguraci dashboardu: {status}"
+    },
+    "banner": {
+      "title": "Název",
+      "titlePlaceholder": "Moje ptačí stanice",
+      "description": "Popis",
+      "descriptionPlaceholder": "Stručný popis vaší stanice pro pozorování ptáků…",
+      "subElements": "Podprvky",
+      "showImage": "Zobrazit vlastní obrázek",
+      "imageUrl": "URL nebo cesta k obrázku",
+      "imageUrlPlaceholder": "https://example.com/station-photo.jpg",
+      "imageUrlHelp": "Zadejte URL obrázku. Nahrávání obrázků bude k dispozici v budoucí aktualizaci.",
+      "showLocationMap": "Zobrazit mapu polohy",
+      "showLocationMapHelp": "Zobrazí malou mapu s využitím zeměpisné šířky/délky z hlavních nastavení",
+      "showWeather": "Zobrazit aktuální počasí",
+      "showWeatherHelp": "Zobrazí aktuální povětrnostní podmínky (vyžaduje zapnutou integraci počasí)",
+      "timeFormat": "Formát času",
+      "mapZoom": "Přiblížení mapy",
+      "showPin": "Zobrazit značku polohy",
+      "mapExpandable": "Povolit zvětšení mapy",
+      "expandMap": "Zvětšit mapu",
+      "expandedMapLabel": "Zvětšená mapa polohy",
+      "closeExpandedMap": "Zavřít zvětšenou mapu"
+    },
+    "videoEmbed": {
+      "youtubeUrl": "URL YouTube",
+      "youtubeUrlPlaceholder": "https://www.youtube.com/watch?v=...",
+      "youtubeUrlHelp": "Vložte libovolnou URL adresu YouTube (watch, embed nebo krátký odkaz). Bude převedena na vložení s vylepšeným soukromím.",
+      "titleLabel": "Název (volitelný)",
+      "titlePlaceholder": "Zadejte název videa (volitelné)"
+    },
+    "editMode": {
+      "editing": "Úprava Dashboardu",
+      "save": "Uložit",
+      "saving": "Ukládání…",
+      "cancel": "Zrušit",
+      "disabled": "skryto",
+      "noConfig": "Zatím nejsou k dispozici žádné další možnosti konfigurace.",
+      "currentlyHearingNote": "Tento prvek zobrazuje aktuálně detekované ptáky při zobrazení dnešního data. Není potřeba žádná další konfigurace.",
+      "notAvailable": "Konfigurace pro tento typ prvku zatím není k dispozici.",
+      "configureElement": "Konfigurovat prvek",
+      "closeModal": "Zavřít",
+      "configureTitle": "Konfigurovat {element}",
+      "weatherPlaceholder": "Povětrnostní podmínky se zde zobrazí, jakmile budou dostupné",
+      "stationBanner": "Banner stanice",
+      "liveBirdFeed": "Živý přenos ptáků",
+      "hideElement": "Skrýt prvek",
+      "unhideElement": "Zobrazit prvek",
+      "deleteElement": "Odstranit prvek",
+      "deleteConfirm": "Odstranit tento prvek? Jeho konfigurace bude ztracena.",
+      "addElement": "Přidat prvek",
+      "noElementsAvailable": "Všechny typy prvků jsou již na Dashboardu.",
+      "editDashboard": "Upravit Dashboard",
+      "widthFull": "Plná šířka",
+      "widthHalf": "Poloviční šířka",
+      "fullWidthOnly": "Pouze plná šířka",
+      "settings": "Nastavení",
+      "resetDashboard": "Obnovit Dashboard",
+      "resetConfirm": "Obnovit Dashboard na výchozí rozložení? Veškeré úpravy budou odstraněny.",
+      "resetting": "Obnovování…"
+    },
+    "elements": {
+      "banner": "Banner Dashboardu",
+      "dailySummary": "Denní souhrn",
+      "currentlyHearing": "Právě slyšíme",
+      "detectionsGrid": "Nedávné detekce",
+      "liveSpectrogram": "Živý spektrogram",
+      "videoEmbed": "Vložené video"
+    }
+  },
+  "detections": {
+    "title": "Detekce",
+    "titles": {
+      "hourly": "Hodinové výsledky pro {hour}:00 dne {date}",
+      "hourlyRange": "Hodinové výsledky od {startHour}:00 do {endHour}:00 dne {date}",
+      "species": "Výsledky pro druh {species} dne {date}",
+      "search": "Výsledky vyhledávání pro „{query}“",
+      "allDetections": "Všechny detekce ze dne {date}"
+    },
+    "detail": {
+      "species": "Druh",
+      "observation": "Pozorování"
+    },
+    "headers": {
+      "dateTime": "Datum a čas",
+      "weather": "Počasí",
+      "source": "Zdroj",
+      "species": "Druh",
+      "confidence": "Spolehlivost",
+      "thumbnail": "Náhled",
+      "status": "Stav",
+      "recording": "Nahrávka",
+      "actions": "Akce"
+    },
+    "viewToggle": {
+      "label": "Režim zobrazení",
+      "table": "Zobrazení tabulky",
+      "cards": "Zobrazení karet"
+    },
+    "status": {
+      "locked": "Uzamčeno"
+    },
+    "timeOfDay": {
+      "day": "Den",
+      "night": "Noc",
+      "sunrise": "Východ slunce",
+      "sunset": "Západ slunce",
+      "any": "Jakákoli",
+      "unknown": "Neznámá"
+    },
+    "table": {
+      "caption": "Seznam detekcí ptáků s informacemi o datu, druhu, spolehlivosti a stavu"
+    },
+    "empty": {
+      "title": "Nebyly nalezeny žádné detekce",
+      "description": "Zkuste upravit filtry nebo kritéria vyhledávání"
+    },
+    "pagination": {
+      "showing": "Zobrazuje se {from} až {to} z {total} výsledků"
+    },
+    "weather": {
+      "title": "Informace o počasí",
+      "noData": "Žádná data o počasí",
+      "noDataAvailable": "Data o počasí nejsou k dispozici",
+      "loading": "Načítání informací o počasí…",
+      "labels": {
+        "temperature": "Teplota",
+        "weather": "Počasí",
+        "wind": "Vítr",
+        "humidity": "Vlhkost",
+        "pressure": "Tlak",
+        "cloudCover": "Oblačnost"
+      },
+      "units": {
+        "temperature": "°C",
+        "temperatureFahrenheit": "°F",
+        "windSpeed": "m/s",
+        "windSpeedImperial": "mph",
+        "humidity": "%",
+        "pressure": "hPa"
+      },
+      "conditions": {
+        "clearsky": "Jasno",
+        "cloudy": "Zataženo",
+        "fair": "Skoro jasno",
+        "fog": "Mlha",
+        "heavyrain": "Silný déšť",
+        "heavyrainandthunder": "Silný déšť s bouřkou",
+        "heavyrainshowers": "Silné přeháňky",
+        "heavyrainshowersandthunder": "Silné přeháňky s bouřkou",
+        "heavysleet": "Silný déšť se sněhem",
+        "heavysleetandthunder": "Silný déšť se sněhem a bouřkou",
+        "heavysleetshowers": "Silné přeháňky s deštěm a sněhem",
+        "heavysleetshowersandthunder": "Silné přeháňky s deštěm, sněhem a bouřkou",
+        "heavysnow": "Silné sněžení",
+        "heavysnowandthunder": "Silné sněžení s bouřkou",
+        "heavysnowshowers": "Silné sněhové přeháňky",
+        "heavysnowshowersandthunder": "Silné sněhové přeháňky s bouřkou",
+        "lightrain": "Slabý déšť",
+        "lightrainandthunder": "Slabý déšť s bouřkou",
+        "lightrainshowers": "Slabé přeháňky",
+        "lightrainshowersandthunder": "Slabé přeháňky s bouřkou",
+        "lightsleet": "Slabý déšť se sněhem",
+        "lightsleetandthunder": "Slabý déšť se sněhem a bouřkou",
+        "lightsleetshowers": "Slabé přeháňky s deštěm a sněhem",
+        "lightsnow": "Slabé sněžení",
+        "lightsnowandthunder": "Slabé sněžení s bouřkou",
+        "lightsnowshowers": "Slabé sněhové přeháňky",
+        "lightssleetshowersandthunder": "Slabé přeháňky s deštěm, sněhem a bouřkou",
+        "lightssnowshowersandthunder": "Slabé sněhové přeháňky s bouřkou",
+        "partlycloudy": "Polojasno",
+        "rain": "Déšť",
+        "rainandthunder": "Déšť s bouřkou",
+        "rainshowers": "Přeháňky",
+        "rainshowersandthunder": "Přeháňky s bouřkou",
+        "sleet": "Déšť se sněhem",
+        "sleetandthunder": "Déšť se sněhem a bouřkou",
+        "sleetshowers": "Přeháňky s deštěm a sněhem",
+        "sleetshowersandthunder": "Přeháňky s deštěm, sněhem a bouřkou",
+        "snow": "Sněžení",
+        "snowandthunder": "Sněžení s bouřkou",
+        "snowshowers": "Sněhové přeháňky",
+        "snowshowersandthunder": "Sněhové přeháňky s bouřkou",
+        "thunder": "Bouřka",
+        "unknown": "Neznámé"
+      }
+    },
+    "row": {
+      "viewDetails": "Zobrazit podrobnosti pro {species}"
+    },
+    "media": {
+      "title": "Nahrávka a spektrogram",
+      "clipHint": "Klikněte a táhněte na spektrogramu pro výběr rozsahu k exportu klipu"
+    },
+    "tabs": {
+      "overview": "Přehled",
+      "taxonomy": "Taxonomie",
+      "history": "Historie",
+      "notes": "Poznámky"
+    },
+    "environmental": {
+      "title": "Podmínky prostředí"
+    },
+    "metadata": {
+      "title": "Metadata detekce",
+      "source": "Zdroj",
+      "duration": "Doba trvání",
+      "status": "Stav",
+      "locked": "Uzamčeno"
+    },
+    "history": {
+      "title": "Historie detekcí",
+      "comingSoon": "Sledování historie bude brzy k dispozici…"
+    },
+    "notes": {
+      "title": "Poznámky a komentáře",
+      "noComments": "K této detekci nejsou žádné komentáře ani poznámky."
+    },
+    "aria": {
+      "loading": "Načítání podrobností detekce…",
+      "loaded": "Podrobnosti detekce načteny pro {species}",
+      "error": "Chyba při načítání detekce: {error}"
+    },
+    "errors": {
+      "notFound": "Detekce nebyla nalezena. Možná byla odstraněna nebo je ID nesprávné.",
+      "noPermission": "Nemáte oprávnění k zobrazení této detekce.",
+      "loginRequired": "Pro zobrazení této detekce se prosím přihlaste.",
+      "serverError": "Chyba serveru. Zkuste to prosím později nebo kontaktujte podporu, pokud problém přetrvává.",
+      "loadFailed": "Nepodařilo se načíst detekci (chyba {status}). Zkuste stránku obnovit.",
+      "noIdProvided": "Nebylo poskytnuto žádné ID detekce.",
+      "fetchFailed": "Nepodařilo se načíst detekce"
+    }
+  },
+  "species": {
+    "rarity": {
+      "title": "Vzácnost druhu",
+      "score": "Skóre",
+      "basedOnLocation": "Na základě polohy: {latitude}, {longitude}",
+      "statuses": {
+        "very_common": "Velmi běžný",
+        "common": "Běžný",
+        "uncommon": "Méně častý",
+        "rare": "Vzácný",
+        "very_rare": "Velmi vzácný",
+        "unknown": "Neznámý"
+      }
+    },
+    "taxonomy": {
+      "hierarchy": "Taxonomická klasifikace",
+      "subspecies": "Poddruh",
+      "noData": "Taxonomická data nejsou k dispozici.",
+      "labels": {
+        "kingdom": "Říše",
+        "phylum": "Kmen",
+        "class": "Třída",
+        "order": "Řád",
+        "family": "Čeleď",
+        "genus": "Rod",
+        "species": "Druh"
+      }
+    },
+    "synonyms": {
+      "tabLabel": "Taxonomická synonyma",
+      "description": "Přepsat mapování vědeckých názvů používaných pro vyhledávání obrázků ptáků. BirdNET používá taxonomii 2021E, ale zdroje obrázků mohou používat aktualizované názvy. Vestavěná mapování jsou vždy načtena; vaše přepisy je doplňují nebo nahrazují.",
+      "birdnetName": "Název BirdNET",
+      "updatedName": "Aktualizovaný název",
+      "addButton": "Přidat synonymum",
+      "emptyState": "Nejsou nakonfigurována žádná vlastní taxonomická synonyma.",
+      "errors": {
+        "unknownSpecies": "Druh nebyl nalezen ve štítcích BirdNET",
+        "duplicateKey": "Synonymum pro tento druh již existuje",
+        "emptyUpdatedName": "Aktualizovaný název je povinný"
+      }
+    },
+    "tracking": {
+      "title": "Sledování druhů",
+      "newSpecies": "Nový druh",
+      "newThisYear": "Poprvé letos",
+      "newThisSeason": "Poprvé v této sezóně",
+      "daysSinceFirst": "Dní od prvního pozorování"
+    }
+  },
+  "spectrogram": {
+    "controls": {
+      "frequencyRange": "Frekvenční rozsah",
+      "colorMap": "Barevná mapa",
+      "gain": "Zesílení",
+      "gainTooltip": "Zesílení vizualizace spektrogramu",
+      "mute": "Ztlumit zvukový výstup",
+      "unmute": "Zapnout zvukový výstup",
+      "frequencyRangeMin": "Minimální frekvence",
+      "frequencyRangeMax": "Maximální frekvence",
+      "audioMonitor": "Audio monitor"
+    },
+    "error": {
+      "unsupported": "Váš prohlížeč nepodporuje analýzu zvuku",
+      "connectionFailed": "Nepodařilo se připojit k živému audio streamu",
+      "accessDenied": "Přístup k živému zvuku vyžaduje ověření. Pro použití této funkce se přihlaste."
+    },
+    "dashboard": {
+      "toggle": "Živý spektrogram",
+      "audioToggle": "Povolit zvuk"
+    },
+    "gain": {
+      "muted": "Ztlumeno",
+      "level": "Zesílení: {value} dB"
+    },
+    "page": {
+      "title": "Živý zvuk",
+      "sourceLabel": "Zdroj zvuku",
+      "connected": "Připojeno",
+      "enterFullscreen": "Celá obrazovka",
+      "exitFullscreen": "Ukončit celou obrazovku"
+    },
+    "colorMaps": {
+      "inferno": "Inferno",
+      "viridis": "Viridis",
+      "grayscale": "Odstíny šedé"
+    },
+    "labels": {
+      "toggle": "Přepnout štítky detekcí"
+    }
+  },
+  "system": {
+    "title": "Systémový přehled",
+    "refreshData": "Obnovit data",
+    "aria": {
+      "refreshData": "Obnovit systémová data",
+      "dashboard": "Systémový přehled s metrikami výkonu a informacemi"
+    },
+    "systemInfo": {
+      "title": "Informace o systému",
+      "os": "Operační systém",
+      "hostname": "Název hostitele",
+      "uptime": "Doba provozu",
+      "cpus": "Procesory (CPU)",
+      "model": "Model systému",
+      "timezone": "Časové pásmo",
+      "temperature": "Teplota CPU",
+      "temperatureValue": "{temp}°C",
+      "temperatureUnavailable": "Údaje o teplotě nejsou k dispozici",
+      "cpuCores": "Jádra CPU",
+      "cpuDetails": "Procesor",
+      "environment": "Prostředí"
+    },
+    "diskUsage": {
+      "title": "Využití disku",
+      "emptyMessage": "Žádné informace o disku nejsou k dispozici"
+    },
+    "memoryUsage": {
+      "title": "Využití paměti",
+      "ramUsage": "Využití RAM",
+      "labels": {
+        "free": "Volná",
+        "available": "Dostupná",
+        "buffCache": "Buff/Cache"
+      }
+    },
+    "progress": {
+      "labels": {
+        "overallProgress": "Celkový průběh",
+        "progress": "Průběh"
+      }
+    },
+    "processInfo": {
+      "title": "Informace o procesech",
+      "loading": "Načítají se informace o procesech...",
+      "noProcesses": "Žádné informace o procesech nejsou k dispozici",
+      "headers": {
+        "pid": "PID",
+        "name": "Název",
+        "status": "Stav",
+        "cpu": "CPU",
+        "memory": "Paměť",
+        "uptime": "Doba provozu",
+        "process": "Proces"
+      },
+      "showAll": "Zobrazit všechny procesy",
+      "showBirdnetOnly": "Zobrazit pouze BirdNET",
+      "table": {
+        "process": "Proces",
+        "status": "Stav",
+        "cpu": "CPU",
+        "memory": "Paměť",
+        "uptime": "Doba provozu",
+        "showAllProcesses": "Zobrazit všechny procesy"
+      }
+    },
+    "errors": {
+      "systemInfo": "Nepodařilo se načíst informace o systému: {error}",
+      "diskUsage": "Nepodařilo se načíst využití disku: {error}",
+      "memoryUsage": "Nepodařilo se načíst využití paměti: {error}",
+      "temperature": "Nepodařilo se načíst teplotu: {error}",
+      "processes": "Nepodařilo se načíst informace o procesech: {error}"
+    },
+    "sections": {
+      "overview": "Přehled",
+      "database": "Databáze",
+      "terminal": "Terminál"
+    },
+    "database": {
+      "title": "Správa databáze",
+      "description": "Spravovat migraci schématu databáze",
+      "legacy": {
+        "title": "Původní databáze",
+        "fetchFailed": "Nepodařilo se získat stav původní databáze",
+        "cleanup": {
+          "title": "Vyčištění původní databáze",
+          "description": "Tato databáze je nyní offline a již se nepoužívá. Všechna vaše data byla migrována do vylepšené databáze.",
+          "recommendation": "Doporučuje se tuto databázi smazat a uvolnit tak místo na disku.",
+          "location": "Umístění",
+          "size": "Velikost",
+          "records": "Záznamy",
+          "detections": "detekcí",
+          "lastModified": "Poslední změna",
+          "warning": "Upozornění: Tuto akci nelze vrátit zpět",
+          "backupReminder": "Před smazáním původní databáze se ujistěte, že máte zálohu.",
+          "deleteButton": "Smazat původní databázi",
+          "inProgress": "Mazání...",
+          "success": "Bylo uvolněno {size} místa na disku",
+          "failed": "Vyčištění selhalo",
+          "notAvailable": "Vyčištění není k dispozici",
+          "confirmTitle": "Smazat původní databázi?",
+          "confirmMessage": "Chystáte se trvale smazat původní databázi ({size}). Tuto akci nelze vrátit zpět.",
+          "confirmCheckbox": "Rozumím, že tímto trvale smažu původní databázi",
+          "cancelButton": "Zrušit",
+          "deleteConfirmButton": "Trvale smazat"
+        }
+      },
+      "v2": {
+        "title": "Vylepšená databáze"
+      },
+      "stats": {
+        "connected": "Připojeno",
+        "disconnected": "Odpojeno",
+        "type": "Typ",
+        "location": "Umístění",
+        "size": "Velikost",
+        "detections": "Detekce",
+        "fetchFailed": "Nepodařilo se získat statistiky databáze"
+      },
+      "dashboard": {
+        "title": "Přehled databáze",
+        "fetchFailed": "Nepodařilo se načíst přehled databáze",
+        "loading": "Načítání...",
+        "metrics": {
+          "readLatency": "Latence čtení",
+          "writeLatency": "Latence zápisu",
+          "queriesPerSec": "Dotazy/s",
+          "database": "Databáze",
+          "avg": "průměr",
+          "max": "max",
+          "lastHour": "{count} za poslední hodinu",
+          "slowQueries": "{count} pomalých"
+        },
+        "details": {
+          "title": "Podrobnosti databáze",
+          "engine": "Engine",
+          "journal": "Žurnál",
+          "pageSize": "Velikost stránky",
+          "cacheHit": "Zásah cache",
+          "integrity": "Integrita",
+          "lastVacuum": "Poslední VACUUM"
+        },
+        "locksWal": {
+          "title": "Zámky a WAL",
+          "lockWaits": "Čekání na zámek",
+          "lockTimeouts": "Časové limity zámků",
+          "avgWait": "Průměrné čekání",
+          "busyTimeouts": "Časové limity zaneprázdnění",
+          "walSize": "Velikost WAL",
+          "checkpoints": "Kontrolní body",
+          "freelistPages": "Stránky volného seznamu",
+          "cacheSize": "Velikost cache"
+        },
+        "connectionPool": {
+          "title": "Pool připojení",
+          "poolUsage": "Využití poolu",
+          "active": "aktivních",
+          "idle": "nečinných",
+          "waiting": "čekajících",
+          "totalCreated": "Celkem vytvořeno",
+          "connErrors": "Chyby připojení",
+          "threads": "Vlákna",
+          "running": "běží",
+          "cached": "v cache"
+        },
+        "innodb": {
+          "title": "InnoDB a zámky",
+          "bufferPoolHitRate": "Úspěšnost buffer poolu",
+          "bufferPoolSize": "Velikost buffer poolu",
+          "lockWaits": "Čekání na zámek",
+          "deadlocks": "Deadlocky",
+          "avgLockWait": "Průměrné čekání na zámek",
+          "tableLocksWaited": "Čekané zámky tabulek",
+          "tableLocksImmediate": "Okamžité zámky tabulek"
+        },
+        "detectionRate": {
+          "title": "Míra detekcí (24h)",
+          "chartLabel": "Míra detekcí za 24 hodin",
+          "detectionsTooltip": "{count} detekcí",
+          "perHour": "/h",
+          "min": "min",
+          "avg": "průměr",
+          "max": "max",
+          "lastBackup": "Poslední záloha",
+          "backupSize": "Velikost zálohy",
+          "createBackup": "Vytvořit zálohu",
+          "mysqlHost": "Hostitel",
+          "mysqlBackupNote": "Zálohy MySQL by měly být spravovány pomocí mysqldump nebo administračních nástrojů MySQL."
+        },
+        "tables": {
+          "title": "Tabulky",
+          "total": "Celkem",
+          "table": "Tabulka",
+          "engine": "Engine",
+          "rows": "Řádky",
+          "size": "Velikost",
+          "usage": "Využití"
+        }
+      },
+      "backup": {
+        "download": "Stáhnout zálohu",
+        "downloading": "Stahování...",
+        "starting": "Zahajuje se zálohování...",
+        "creating": "Vytváří se záloha...",
+        "cancel": "Zrušit",
+        "retry": "Opakovat zálohování",
+        "mysqlNote": "Záloha MySQL vyžaduje externí nástroje (mysqldump)",
+        "history": {
+          "title": "Historie záloh",
+          "creating": "Vytváření...",
+          "createBackup": "Vytvořit zálohu",
+          "noBackups": "Zatím žádné zálohy",
+          "download": "Stáhnout",
+          "failed": "Selhalo",
+          "columns": {
+            "date": "Datum",
+            "database": "Databáze",
+            "size": "Velikost",
+            "status": "Stav",
+            "actions": "Akce"
+          },
+          "status": {
+            "pending": "Čeká",
+            "in_progress": "Probíhá",
+            "completed": "Dokončeno",
+            "failed": "Selhalo"
+          }
+        }
+      },
+      "notInitialized": "Neinicializováno",
+      "migration": {
+        "title": "Migrace databáze",
+        "description": "Migrovat z původního schématu na normalizované schéma v2",
+        "requiredNote": "Migrace databáze je nutná pro nadcházející funkce BirdNET-Go, které se spoléhají na nové normalizované schéma databáze. Nové funkce nebudou k dispozici, dokud migrace neproběhne.",
+        "completedTitle": "Migrace dokončena",
+        "completedNote": "Vaše databáze byla úspěšně migrována na nové schéma. Restartujte BirdNET-Go pro přepnutí na novou databázi. Poznámka: Nová databáze je menší, protože ukládá data efektivněji – to je očekávané a všechna vaše data jsou zachována.",
+        "starting": "Zahajuje se migrace...",
+        "status": {
+          "idle": "Připraveno ke spuštění",
+          "initializing": "Inicializace",
+          "dual_write": "Duální zápis aktivní",
+          "migrating": "Migrace primární",
+          "migrating_predictions": "Migrace sekundární",
+          "paused": "Pozastaveno",
+          "validating": "Ověřování",
+          "cutover": "Probíhá přepnutí",
+          "completed": "Migrace dokončena",
+          "failed": "Ověření selhalo"
+        },
+        "progress": {
+          "title": "Průběh migrace",
+          "records": "záznamů",
+          "paused": "Migrace pozastavena",
+          "percent": "{percent}%",
+          "rate": "{rate} záznamů/s",
+          "rateValue": "{rate} zázn./s",
+          "remaining": "Odhadovaný zbývající čas: {time}",
+          "eta": "Odhadovaný zbývající čas",
+          "dirtyIds": "{count} záznamů čeká na opětovnou synchronizaci",
+          "completedTitle": "Migrace dokončena",
+          "completedBody": "Všech {count} záznamů bylo úspěšně migrováno do databáze V2. Aplikace bude po restartu používat V2 jako primární databázi.",
+          "restartTitle": "Vyžadován restart",
+          "restartBody": "Restartujte aplikaci pro přepnutí na databázi V2. Vyčištění původní databáze bude k dispozici po restartu.",
+          "fallbackError": "Nesoulad počtu záznamů mezi původní a V2 databází. Některé záznamy se možná nemigrovaly správně.",
+          "migrateInfo": "Migrace přenese {count} záznamů z původní databáze do nového schématu V2. Režim duálního zápisu zajišťuje nulovou ztrátu dat během migrace.",
+          "sourceLegacy": "Zdroj (původní)",
+          "targetV2": "Cíl (V2)",
+          "recordsLabel": "Záznamy",
+          "sizeLabel": "Velikost",
+          "prerequisitesNotMet": "Předpoklady nesplněny – vyřešte kritické problémy níže",
+          "validatingTitle": "Ověřování dat",
+          "validatingBody": "Porovnávání {count} původních záznamů s databází V2...",
+          "dirtyRecordsCatchup": "{count} nesynchronizovaných záznamů – proběhne pokus o dodatečné srovnání",
+          "cutoverTitle": "Dokončování přepnutí",
+          "cutoverBody": "Finalizace přechodu na databázi V2...",
+          "migratingPhase": "Migrace: {phase}",
+          "progressLabel": "Průběh",
+          "ofRecords": "/ {count} záznamů",
+          "percentComplete": "{percent}% dokončeno",
+          "recordsPerSec": "{rate} záznamů/s",
+          "calculating": "Výpočet...",
+          "dirtyWriteFailed": "{count} záznamů se nepodařilo zapsat – budou srovnány během ověřování"
+        },
+        "details": {
+          "title": "Podrobnosti databáze",
+          "detections": "{count} detekcí",
+          "lastBackup": "Poslední záloha: {date}",
+          "noBackups": "Žádné zálohy",
+          "integrity": "Integrita: {status}"
+        },
+        "strip": {
+          "legacy": "Původní",
+          "v2Target": "V2 (cíl)",
+          "active": "Aktivní",
+          "migration": "Migrace",
+          "complete": "Dokončeno",
+          "recordsMigrated": "{count} záznamů migrováno",
+          "readyToMigrate": "Připraveno k migraci",
+          "recordsInLegacy": "{count} záznamů v původní DB",
+          "comparingRecords": "Porovnávání počtu záznamů...",
+          "validationFailed": "Ověření selhalo",
+          "rate": "Rychlost",
+          "recPerSec": "{rate} zázn./s",
+          "dayAvg": "~{count} / denní průměr",
+          "dayHistory": "Historie za 30 dní"
+        },
+        "phase": {
+          "indicator": "Fáze {current} z {total}: ",
+          "detections": "Migrace primárních detekcí",
+          "predictions": "Migrace sekundárních detekcí",
+          "reviews": "Migrace recenzí",
+          "comments": "Migrace komentářů",
+          "locks": "Migrace zámků"
+        },
+        "notes": {
+          "in_progress": "Systém můžete dále běžně používat, zatímco migrace běží na pozadí.",
+          "dual_write": "Migrace probíhá. Vaše data jsou v bezpečí – všechny nové detekce se ukládají do obou databází.",
+          "migrating": "Kopírují se vaše stávající detekce do nové databáze.",
+          "validating": "Ověřuje se, zda byly všechny záznamy zkopírovány správně. Téměř hotovo!",
+          "cutover": "Přepínání na novou databázi. Zabere to jen okamžik.",
+          "paused": "Migrace je pozastavena. Vaše data jsou v bezpečí. Pokračujte, až budete připraveni."
+        },
+        "actions": {
+          "start": "Spustit migraci",
+          "pause": "Pozastavit",
+          "resume": "Pokračovat",
+          "cancel": "Zrušit",
+          "rollback": "Vrátit zpět",
+          "retryValidation": "Opakovat ověření"
+        },
+        "confirmDialog": {
+          "title": "Spustit migraci databáze",
+          "message": "Migrace zkopíruje vaše data detekcí ze stávající databáze do nové normalizované databáze. Vaše původní databáze zůstane beze změny. Přesto se doporučuje vytvořit zálohu pro případ nečekaných problémů.",
+          "checkbox": "Potvrzuji, že jsem si zazálohoval databázi, nebo rozumím rizikům pokračování bez zálohy.",
+          "note": "Zálohu si můžete stáhnout tlačítkem \"Stáhnout zálohu\" výše."
+        },
+        "confirmCancel": {
+          "title": "Zrušit migraci?",
+          "message": "Tímto se migrace zastaví a vrátí do nečinného stavu. Migraci můžete bezpečně spustit znovu později – záznamy nebudou duplikovány.",
+          "confirm": "Ano, zrušit",
+          "dismiss": "Ne, ponechat běžící"
+        },
+        "confirmRollback": {
+          "title": "Vrátit migraci zpět?",
+          "message": "Tímto se vrátíte k původní databázi. Nové detekce zaznamenané od migrace budou zachovány ve vylepšené databázi, ale nebudou viditelné, dokud nebude migrace spuštěna znovu.",
+          "confirm": "Ano, vrátit zpět",
+          "dismiss": "Ne, ponechat vylepšenou"
+        },
+        "errors": {
+          "startFailed": "Nepodařilo se spustit migraci",
+          "pauseFailed": "Nepodařilo se pozastavit migraci",
+          "resumeFailed": "Nepodařilo se obnovit migraci",
+          "cancelFailed": "Nepodařilo se zrušit migraci",
+          "rollbackFailed": "Nepodařilo se vrátit migraci zpět",
+          "retryValidationFailed": "Nepodařilo se zopakovat ověření",
+          "fetchFailed": "Nepodařilo se získat stav migrace"
+        },
+        "worker": {
+          "running": "Worker běží",
+          "paused": "Worker pozastaven",
+          "stopped": "Worker zastaven"
+        },
+        "prerequisites": {
+          "title": "Kontroly před migrací",
+          "rerunChecks": "Spustit kontroly znovu",
+          "critical": "Kritické",
+          "allPassed": "Všechny kontroly prošly – připraveno k migraci",
+          "criticalIssues": "{count} kritických problémů je nutné vyřešit",
+          "warningsCount": "{count} varování",
+          "running": "Probíhají kontroly před migrací...",
+          "checkingStep": "Krok {current} z {total}",
+          "passedCount": "{passed}/{total} úspěšných",
+          "criticalCount": "{count} kritických",
+          "warningCount": "{count} varování",
+          "rerun": "Spustit znovu",
+          "showDetails": "Zobrazit podrobnosti",
+          "hideDetails": "Skrýt podrobnosti",
+          "status": {
+            "passed": "Úspěšné",
+            "failed": "Selhalo",
+            "error": "Chyba",
+            "warning": "Varování",
+            "skipped": "Přeskočeno"
+          },
+          "errors": {
+            "fetchFailed": "Nepodařilo se získat předpoklady"
+          },
+          "checks": {
+            "state_idle": {
+              "name": "Stav migrace"
+            },
+            "disk_space": {
+              "name": "Místo na disku"
+            },
+            "legacy_accessible": {
+              "name": "Připojení k databázi"
+            },
+            "sqlite_integrity": {
+              "name": "Integrita databáze"
+            },
+            "mysql_table_health": {
+              "name": "Stav tabulek"
+            },
+            "write_permission": {
+              "name": "Oprávnění k zápisu"
+            },
+            "mysql_permissions": {
+              "name": "Oprávnění MySQL"
+            },
+            "record_count": {
+              "name": "Počet záznamů"
+            },
+            "existing_v2_data": {
+              "name": "Existující migrační data"
+            },
+            "no_active_locks": {
+              "name": "Aktivní zámky"
+            },
+            "memory_available": {
+              "name": "Dostupná paměť"
+            },
+            "mysql_max_packet": {
+              "name": "MySQL Max Packet"
+            },
+            "mysql_timeout": {
+              "name": "MySQL Timeout"
+            }
+          }
+        }
+      }
+    },
+    "metrics": {
+      "cpu": "CPU",
+      "memory": "Paměť",
+      "temperature": "Teplota",
+      "system": "Systém",
+      "cores": "jader",
+      "samples": "vzorků",
+      "available": "dost.",
+      "min": "Min",
+      "max": "Max",
+      "limit": "Limit",
+      "tempUnavailable": "Nedostupná",
+      "online": "Online",
+      "uptime": "Doba provozu",
+      "host": "Hostitel",
+      "model": "Model",
+      "inference": "Inference",
+      "avgTime": "Průměr",
+      "noInference": "Žádná data",
+      "statusOk": "OK",
+      "statusWarning": "Varování",
+      "statusCritical": "Kritický"
+    },
+    "storage": {
+      "title": "Úložiště",
+      "used": "použito",
+      "free": "volné",
+      "ram": "RAM"
+    }
+  },
+  "terminal": {
+    "title": "Terminál",
+    "disabled": "Terminál je zakázán",
+    "disabledDescription": "Terminál v prohlížeči je zakázán. Pro použití této funkce ho povolte v Nastavení → Zabezpečení.",
+    "connected": "Připojeno",
+    "disconnected": "Odpojeno",
+    "connecting": "Připojování…",
+    "connectionError": "Připojení selhalo",
+    "connectionClosed": "Připojení uzavřeno",
+    "securityWarning": "Upozornění: Tento terminál poskytuje přímý přístup k shellu hostitelského systému. Povolujte ho pouze v důvěryhodných sítích.",
+    "copySelection": "Kopírovat výběr",
+    "expand": "Rozbalit",
+    "collapse": "Sbalit",
+    "fullscreen": "Celá obrazovka",
+    "exitFullscreen": "Ukončit celou obrazovku",
+    "colorTheme": "Barevné téma",
+    "themeDark": "Tmavé",
+    "themeLight": "Světlé",
+    "themeHighContrast": "Vysoký kontrast",
+    "detach": "Otevřít v novém okně",
+    "detached": "Terminál je odpojen",
+    "detachedDescription": "Terminál běží v samostatném okně. Zavřete ho, abyste ho vrátili sem.",
+    "reattach": "Připojit zpět"
+  },
+  "analytics": {
+    "title": "Přehled",
+    "loadingError": "Nepodařilo se načíst některá analytická data. Zkuste to prosím později.",
+    "stats": {
+      "totalDetections": "Celkem detekcí",
+      "uniqueSpecies": "Unikátní druhy",
+      "avgConfidence": "Průměrná spolehlivost",
+      "mostCommon": "Nejčastější",
+      "none": "Žádné",
+      "detections": "detekcí",
+      "totalSpecies": "Celkem druhů",
+      "overallAverage": "Celkový průměr"
+    },
+    "periods": {
+      "today": "Dnes",
+      "lastWeek": "Posledních 7 dní",
+      "lastMonth": "Posledních 30 dní",
+      "last90Days": "Posledních 90 dní",
+      "lastYear": "Posledních 12 měsíců",
+      "customRange": "Vlastní rozsah",
+      "allTime": "Celá doba"
+    },
+    "filters": {
+      "title": "Filtrovat data",
+      "timePeriod": "Časové období",
+      "from": "Od",
+      "to": "Do",
+      "sortBy": "Seřadit podle",
+      "searchSpecies": "Hledat druhy",
+      "searchPlaceholder": "Hledat podle názvu…",
+      "reset": "Resetovat",
+      "applyFilters": "Použít filtry",
+      "exportCsv": "Exportovat CSV",
+      "species": "druhy",
+      "filtered": "(filtrováno)"
+    },
+    "timePeriodOptions": {
+      "allTime": "Celá doba",
+      "today": "Dnes",
+      "lastWeek": "Posledních 7 dní",
+      "lastMonth": "Posledních 30 dní",
+      "last90Days": "Posledních 90 dní",
+      "lastYear": "Posledních 12 měsíců",
+      "customRange": "Vlastní rozsah"
+    },
+    "sortOptions": {
+      "mostDetections": "Nejvíce detekcí",
+      "fewestDetections": "Nejméně detekcí",
+      "nameAZ": "Název (A–Z)",
+      "nameZA": "Název (Z–A)",
+      "recentlyFirstSeen": "Naposledy poprvé spatřeno",
+      "earliestFirstSeen": "Nejdříve poprvé spatřeno",
+      "recentlyLastSeen": "Naposledy spatřeno",
+      "highestConfidence": "Nejvyšší spolehlivost"
+    },
+    "charts": {
+      "top10Species": "Top 10 druhů",
+      "detectionsByTimeOfDay": "Detekce podle denní doby",
+      "detectionTrends": "Trendy detekcí",
+      "newSpeciesDetected": "Nově detekované druhy",
+      "noNewSpecies": "V tomto období nebyly detekovány žádné nové druhy.",
+      "noDataAvailable": "Data nejsou k dispozici",
+      "numberOfDetections": "Počet detekcí",
+      "detections": "Detekce",
+      "timePeriod": "Časové období",
+      "dailyDetections": "Denní detekce",
+      "date": "Datum",
+      "firstHeardOn": "Poprvé slyšeno dne",
+      "firstHeardDate": "Datum prvního slyšení",
+      "firstHeard": "Poprvé slyšeno"
+    },
+    "recentDetections": {
+      "title": "Nedávné detekce",
+      "headers": {
+        "dateTime": "Datum a čas",
+        "species": "Druh",
+        "confidence": "Spolehlivost",
+        "timeOfDay": "Denní doba"
+      },
+      "noRecentDetections": "Nebyly nalezeny žádné nedávné detekce",
+      "unknownSpecies": "Neznámý",
+      "unknown": "Neznámé"
+    },
+    "species": {
+      "title": "Druhy",
+      "subtitle": "Kompletní seznam všech ptačích druhů, které byly detekovány",
+      "speciesList": "Seznam druhů",
+      "switchToGrid": "Přepnout na mřížku",
+      "switchToList": "Přepnout na seznam",
+      "noSpeciesFound": "Nebyly nalezeny žádné druhy odpovídající vašim filtrům.",
+      "headers": {
+        "species": "Druh",
+        "detections": "Detekce",
+        "avgConfidence": "Průměrná spolehlivost",
+        "maxConfidence": "Maximální spolehlivost",
+        "firstDetected": "Poprvé detekováno",
+        "lastDetected": "Naposledy detekováno"
+      },
+      "card": {
+        "detections": "Detekce:",
+        "confidence": "Spolehlivost:",
+        "first": "Poprvé:"
+      }
+    },
+    "advanced": {
+      "title": "Pokročilá analytika",
+      "chartControls": "Ovládání grafu",
+      "dateRange": "Rozsah dat",
+      "chartOptions": "Možnosti grafu",
+      "speciesSelection": "Výběr druhů ({count}/{max})",
+      "speciesSelectionHint": "Hledejte nebo klikněte na štítky níže",
+      "speciesPlaceholder": "Vyhledejte a vyberte druhy k analýze…",
+      "noSpeciesFound": "Pro vybraný rozsah dat nebyly nalezeny žádné druhy",
+      "detections": "{count} detekcí",
+      "dateRangeOptions": {
+        "week": "Poslední týden",
+        "month": "Poslední měsíc",
+        "quarter": "Poslední čtvrtletí",
+        "year": "Poslední rok",
+        "custom": "Vlastní rozsah"
+      },
+      "options": {
+        "relativeTrends": "Relativní trendy",
+        "zoomPan": "Přiblížení a posun",
+        "brushSelection": "Výběr štětcem"
+      },
+      "charts": {
+        "timeOfDay": {
+          "title": "Vzorce detekcí podle denní doby",
+          "description": "Zobrazuje průměrný počet detekcí během dne pro vybrané druhy",
+          "noData": "Data o denní době nejsou k dispozici",
+          "noDataHint": "Vyberte druhy a rozsah dat pro zobrazení vzorců",
+          "axisTime": "Denní doba",
+          "axisCount": "Počet detekcí"
+        },
+        "dailyTrend": {
+          "title": "Trendy detekcí druhů",
+          "description": "Zobrazuje trendy detekcí v čase pro vybrané druhy",
+          "noData": "Data o trendech nejsou k dispozici",
+          "noDataHint": "Vyberte druhy a rozsah dat pro zobrazení trendů",
+          "axisDate": "Datum",
+          "axisCount": "Počet detekcí",
+          "axisPercentage": "Procento celkových detekcí"
+        },
+        "diversity": {
+          "title": "Druhová rozmanitost v čase",
+          "description": "Zobrazuje počet unikátních druhů detekovaných za den napříč všemi detekcemi",
+          "noData": "Data o rozmanitosti nejsou k dispozici",
+          "noDataHint": "Pro zobrazení trendů druhové rozmanitosti vyberte rozsah dat",
+          "axisDate": "Datum",
+          "axisUniqueSpecies": "Unikátní druhy"
+        },
+        "tooltips": {
+          "date": "Datum",
+          "percentage": "Procento",
+          "detections": "Detekce",
+          "time": "Čas",
+          "species": "Druh"
+        }
+      },
+      "categories": {
+        "birds": "Ptáci"
+      },
+      "filters": {
+        "startDate": "Datum začátku",
+        "endDate": "Datum konce"
+      },
+      "aria": {
+        "startDate": "Datum začátku",
+        "endDate": "Datum konce",
+        "loadingAnalytics": "Načítání analytických dat",
+        "loadingTrends": "Načítání dat trendů",
+        "loadingDiversity": "Načítání dat o rozmanitosti"
+      }
+    },
+    "errors": {
+      "loadFailed": "Nepodařilo se načíst analytická data. Zkuste to prosím znovu."
+    }
+  },
+  "settings": {
+    "title": "Nastavení – BirdNET-Go",
+    "loading": "Načítají se nastavení...",
+    "sections": {
+      "analysis": "Analýza",
+      "node": "Obecné",
+      "userinterface": "Rozhraní",
+      "audio": "Zvuk",
+      "filters": "Filtry",
+      "integration": "Integrace",
+      "security": "Zabezpečení",
+      "species": "Druhy",
+      "notifications": "Upozornění",
+      "support": "Podpora"
+    },
+    "notFound": {
+      "title": "Nastavení nenalezeno",
+      "message": "Požadovanou sekci nastavení \"{section}\" se nepodařilo najít."
+    },
+    "actions": {
+      "save": "Uložit změny",
+      "saving": "Ukládání...",
+      "reset": "Resetovat",
+      "resetAriaLabel": "Resetovat všechny změny",
+      "saveAriaLabel": "Uložit změny",
+      "savingAriaLabel": "Ukládání změn...",
+      "unsavedChanges": "Neuložené změny",
+      "toolbar": "Akce nastavení"
+    },
+    "errors": {
+      "loadFailed": "Nepodařilo se načíst nastavení",
+      "saveFailed": "Nepodařilo se uložit nastavení",
+      "databaseStatsFailed": "Nepodařilo se načíst statistiky databáze",
+      "csvDownloadFailed": "Nepodařilo se stáhnout CSV"
+    },
+    "card": {
+      "changed": "změněno",
+      "changedAriaLabel": "Nastavení změněno"
+    },
+    "tabs": {
+      "navigation": "Navigační karty nastavení",
+      "hasChanges": "Tato karta má neuložené změny",
+      "setAsDefault": "Nastavit jako výchozí",
+      "defaultIndicator": "Výchozí zdroj vstupu"
+    },
+    "main": {
+      "tabs": {
+        "general": "Obecné",
+        "detection": "Detekce",
+        "location": "Poloha",
+        "database": "Databáze"
+      },
+      "sections": {
+        "main": {
+          "title": "Hlavní nastavení",
+          "description": "Konfigurace hlavních nastavení aplikace"
+        },
+        "birdnet": {
+          "title": "Nastavení BirdNET",
+          "description": "Konfigurace nastavení specifických pro model BirdNET AI"
+        },
+        "ui": {
+          "title": "Nastavení uživatelského rozhraní",
+          "description": "Přizpůsobení uživatelského rozhraní"
+        },
+        "customClassifier": {
+          "title": "Vlastní klasifikátor BirdNET",
+          "description": "Konfigurace vlastního modelu BirdNET a souborů štítků pro specializovanou detekci",
+          "modelPath": {
+            "label": "Cesta k modelu (vyžaduje restart pro aplikaci změn)",
+            "placeholder": "Cesta k souboru modelu",
+            "helpText": "Cesta k externímu souboru modelu BirdNET. Zadejte absolutní nebo relativní cestu k binárce birdnet-go. Ponechte prázdné pro použití výchozího vestavěného modelu."
+          },
+          "labelPath": {
+            "label": "Cesta ke štítkům (vyžaduje restart pro aplikaci změn)",
+            "placeholder": "Cesta k souboru štítků",
+            "helpText": "Cesta k souboru štítků externího modelu, soubor .zip nebo .txt. Zadejte absolutní nebo relativní cestu k binárce birdnet-go. Ponechte prázdné pro použití výchozích vestavěných štítků."
+          }
+        },
+        "dynamicThreshold": {
+          "title": "Dynamický práh",
+          "description": "Automaticky upravovat citlivost detekce na základě předchozích pozorování",
+          "enable": {
+            "label": "Povolit dynamický práh (funkce specifická pro BirdNET-Go)",
+            "helpText": "Povolí funkci dynamického prahu spolehlivosti pro adaptivnější detekci ptačího zpěvu."
+          },
+          "trigger": {
+            "label": "Spouštěcí práh",
+            "helpText": "Úroveň spolehlivosti, při které se aktivuje dynamický práh. Pokud je ptačí zpěv detekován se spolehlivostí nad touto hodnotou, práh pro pozitivní shody tohoto druhu se pro následující volání sníží."
+          },
+          "minimum": {
+            "label": "Minimální dynamický práh",
+            "helpText": "Minimální hodnota, na kterou lze dynamický práh snížit. Tím se zajistí, že práh neklesne pod nežádoucí úroveň."
+          },
+          "expireTime": {
+            "label": "Doba platnosti dynamického prahu (hodiny)",
+            "helpText": "Počet hodin, po které zůstávají úpravy dynamického prahu platné. Po této době se dynamický práh resetuje."
+          }
+        },
+        "falsePositiveFilter": {
+          "title": "Filtr falešně pozitivních detekcí",
+          "description": "Sníží počet falešných detekcí vyžadováním více potvrzení napříč překrývajícími se zvukovými segmenty",
+          "level": {
+            "label": "Úroveň filtru"
+          },
+          "detectionCount": "Vyžadováno {count} potvrzení. {description}",
+          "levels": {
+            "off": "Bez filtrování – první detekci přijme okamžitě",
+            "lenient": "Pro nekvalitní zvuk (RTSP kamery, mikrofony webkamer)",
+            "moderate": "Vyvážené pro typické hobby konfigurace",
+            "balanced": "Původní chování před zářím 2025",
+            "strict": "Vyžaduje RPi 4+. Pro kvalitní mikrofony",
+            "maximum": "Vyžaduje RPi 4+. Pro mikrofony profesionální třídy"
+          },
+          "hardwareNote": "Úrovně Přísný a Maximální vyžadují vyšší nastavení překryvu a více CPU prostředků. Pro tyto úrovně je nutný hardware RPi 4 nebo lepší.",
+          "overlapAdjusted": "Nastavení překryvu bylo automaticky upraveno na {overlap}s, aby splnilo požadavky filtru",
+          "overlapReduced": "Nastavení překryvu bylo sníženo na {overlap}s, aby odpovídalo úrovni filtru",
+          "levelNames": {
+            "off": "Vypnuto",
+            "lenient": "Mírný",
+            "moderate": "Střední",
+            "balanced": "Vyvážený",
+            "strict": "Přísný",
+            "maximum": "Maximální",
+            "unknown": "Neznámý"
+          },
+          "warningOff": "Při vypnutém filtrování je každá detekce nad prahem spolehlivosti okamžitě přijata. To obvykle vede k několika falešným detekcím denně. I mírné filtrování výrazně zlepšuje kvalitu výsledků."
+        },
+        "rangeFilter": {
+          "title": "Filtr výskytu",
+          "description": "Omezit detekci na druhy pravděpodobné ve vašem geografickém regionu",
+          "stationLocation": {
+            "label": "Poloha stanice",
+            "helpText": "Poloha stanice, používaná pro data o počasí a k omezení druhů ptáků na ty, které jsou v regionu pravděpodobné."
+          },
+          "latitude": {
+            "label": "Zeměpisná šířka",
+            "helpText": "Zeměpisná šířka stanice, používaná pro data o počasí a filtrování výskytu druhů."
+          },
+          "longitude": {
+            "label": "Zeměpisná délka",
+            "helpText": "Zeměpisná délka stanice, používaná pro data o počasí a filtrování výskytu druhů."
+          },
+          "model": {
+            "label": "Model filtru výskytu",
+            "helpText": "Verze modelu filtru výskytu BirdNET: nejnovější (latest) nebo původní (legacy)."
+          },
+          "threshold": {
+            "label": "Práh",
+            "helpText": "Řídí, které druhy jsou zahrnuty na základě pravděpodobnosti jejich výskytu pro vaši polohu a roční období. Pro většinu uživatelů se doporučuje výchozí hodnota (0.01). Vyšší hodnoty (0.05–0.3) zahrnují méně druhů s vyšší pravděpodobností výskytu. Velmi vysoké hodnoty (0.5+) zahrnují pouze nejběžnější druhy."
+          },
+          "speciesCount": {
+            "label": "Aktuální počet druhů",
+            "helpText": "Počet druhů zahrnutých ve filtru výskytu. Aktualizuje se automaticky při změně prahu, zeměpisné šířky nebo délky.",
+            "loading": "Načítání...",
+            "viewSpecies": "Zobrazit druhy"
+          },
+          "downloadTitle": "Stáhnout seznam druhů jako CSV",
+          "csvDownloaded": "Seznam druhů byl úspěšně stažen",
+          "csvDownloadFailed": "Nepodařilo se stáhnout seznam druhů. Zkuste to znovu.",
+          "modal": {
+            "title": "Druhy filtru výskytu",
+            "speciesCount": "Počet druhů:",
+            "threshold": "Práh:",
+            "latitude": "Zeměpisná šířka:",
+            "longitude": "Zeměpisná délka:",
+            "loadingSpecies": "Načítají se druhy...",
+            "noSpeciesFound": "S aktuálním nastavením nebyly nalezeny žádné druhy",
+            "close": "Zavřít"
+          }
+        },
+        "database": {
+          "title": "Nastavení databáze",
+          "description": "Nastavení databáze detekcí",
+          "type": {
+            "label": "Vyberte typ databáze",
+            "helpText": "Vyberte typ databáze, který se použije pro ukládání detekcí."
+          },
+          "sqlite": {
+            "title": "Konfigurace SQLite",
+            "description": "Konfigurace umístění souboru databáze SQLite",
+            "note": "SQLite je doporučený typ databáze pro většinu uživatelů.",
+            "path": {
+              "label": "Cesta k databázi SQLite",
+              "placeholder": "Zadejte cestu k databázi SQLite",
+              "helpText": "Cesta k souboru databáze SQLite relativně k adresáři aplikace"
+            }
+          },
+          "mysql": {
+            "title": "Konfigurace MySQL",
+            "description": "Konfigurace nastavení připojení k databázovému serveru MySQL",
+            "host": {
+              "label": "Hostitel MySQL",
+              "placeholder": "Zadejte hostitele MySQL",
+              "helpText": "Hostitel databáze MySQL (IP nebo název hostitele)"
+            },
+            "port": {
+              "label": "Port MySQL",
+              "helpText": "Port databáze MySQL (výchozí 3306/TCP)"
+            },
+            "username": {
+              "label": "Uživatelské jméno MySQL",
+              "placeholder": "Zadejte uživatelské jméno MySQL",
+              "helpText": "Uživatelské jméno databáze MySQL"
+            },
+            "password": {
+              "label": "Heslo MySQL",
+              "placeholder": "Zadejte heslo MySQL",
+              "helpText": "Heslo databáze MySQL"
+            },
+            "database": {
+              "label": "Databáze MySQL",
+              "placeholder": "Zadejte název databáze MySQL",
+              "helpText": "Název databáze MySQL"
+            }
+          },
+          "stats": {
+            "title": "Statistiky databáze",
+            "description": "Informace o vaší databázi za běhu",
+            "loading": "Načítají se statistiky databáze...",
+            "retry": "Zkusit znovu",
+            "refresh": "Obnovit",
+            "noData": "Nejsou k dispozici žádné statistiky databáze.",
+            "type": "Typ",
+            "status": "Stav",
+            "size": "Velikost",
+            "totalDetections": "Detekcí celkem",
+            "location": "Umístění",
+            "connected": "Připojeno",
+            "disconnected": "Odpojeno"
+          },
+          "errors": {
+            "backupStartFailed": "Nepodařilo se spustit zálohování",
+            "backupStatusFailed": "Nepodařilo se získat stav zálohování",
+            "backupFailed": "Zálohování selhalo",
+            "backupDownloadFailed": "Nepodařilo se stáhnout zálohu"
+          }
+        },
+        "interface": {
+          "title": "Rozhraní",
+          "description": "Konfigurace jazyka, předvoleb zobrazení a limitů přehledu"
+        },
+        "visualContent": {
+          "title": "Vizuální obsah",
+          "description": "Konfigurace obrázků ptáků a možností zobrazení spektrogramu"
+        },
+        "userInterface": {
+          "title": "Nastavení uživatelského rozhraní",
+          "description": "Přizpůsobení uživatelského rozhraní",
+          "interface": {
+            "title": "Nastavení rozhraní",
+            "description": "Vyberte si preferovaný jazyk",
+            "locale": {
+              "label": "Jazyk zobrazení",
+              "helpText": "Vyberte jazyk pro uživatelské rozhraní"
+            }
+          },
+          "language": {
+            "title": "Jazyk",
+            "description": "Konfigurace jazyka zobrazení pro uživatelské rozhraní",
+            "locale": {
+              "label": "Jazyk rozhraní",
+              "helpText": "Vyberte jazyk pro uživatelské rozhraní"
+            }
+          },
+          "dashboard": {
+            "title": "Zobrazení přehledu",
+            "description": "Konfigurace způsobu zobrazování detekcí na přehledu",
+            "displaySettings": {
+              "title": "Nastavení zobrazení",
+              "description": "Konfigurace obecných možností zobrazení přehledu, jako jsou limity druhů."
+            },
+            "birdImages": {
+              "title": "Obrázky ptáků",
+              "description": "Konfigurace náhledových obrázků ptačích druhů pro seznamy detekcí."
+            },
+            "spectrogramGeneration": {
+              "title": "Generování spektrogramu",
+              "description": "Konfigurace kdy a jak se generují zvukové spektrogramy pro detekce."
+            },
+            "general": {
+              "title": "Obecná nastavení"
+            },
+            "summaryLimit": {
+              "label": "Maximální počet druhů v tabulce denního souhrnu",
+              "helpText": "Maximální počet druhů zobrazených v tabulce denního souhrnu (hodnota mezi 10 a 1000)"
+            },
+            "thumbnails": {
+              "title": "Zobrazení náhledů",
+              "summary": {
+                "label": "Zobrazit náhledy v tabulce denního souhrnu",
+                "helpText": "Povolte zobrazení náhledů detekovaných druhů v tabulce denního souhrnu"
+              },
+              "recent": {
+                "label": "Zobrazit náhledy v seznamu nedávných detekcí",
+                "helpText": "Povolte zobrazení náhledů detekovaných druhů v seznamu nedávných detekcí"
+              },
+              "imageProvider": {
+                "label": "Poskytovatel obrázků",
+                "helpText": "Vyberte preferovaného poskytovatele obrázků pro náhledy ptáků"
+              },
+              "fallbackPolicy": {
+                "label": "Záložní politika",
+                "helpText": "Vyberte, co se stane, když preferovaný poskytovatel obrázek nenajde",
+                "options": {
+                  "all": "Vyzkoušet všechny poskytovatele postupně",
+                  "none": "Použít pouze vybraného poskytovatele"
+                }
+              }
+            },
+            "spectrogram": {
+              "title": "Generování spektrogramu",
+              "mode": {
+                "label": "Režim generování",
+                "auto": {
+                  "label": "Automaticky (doporučeno)",
+                  "helpText": "Spektrogramy se generují automaticky při zobrazení detekce v uživatelském rozhraní. U dlouhých seznamů detekcí může generování spektrogramů trvat dlouho na systémech s omezenými prostředky CPU."
+                },
+                "prerender": {
+                  "label": "Předgenerování na pozadí",
+                  "helpText": "Generovat spektrogramy automaticky při ukládání zvukového klipu. Na systémech s omezenými prostředky, jako je Raspberry Pi Zero nebo 3, to poskytuje plynulejší uživatelské rozhraní díky tomu, že se spektrogramy generují na pozadí. Tento režim však spotřebuje více místa na disku, protože se spektrogramy vytvářejí pro každou detekci."
+                },
+                "userRequested": {
+                  "label": "Pouze na žádost uživatele",
+                  "helpText": "Generovat spektrogramy pouze po kliknutí na tlačítko generovat. Ideální pro systémy s omezenými prostředky (Raspberry Pi 3/Zero) – nulová automatická režie, vy řídíte, kdy se používá CPU."
+                }
+              },
+              "style": {
+                "label": "Styl spektrogramu",
+                "helpText": "Vyberte vizuální vzhled generovaných spektrogramů.",
+                "preview": "Náhled",
+                "previewAlt": "Náhled stylu spektrogramu",
+                "options": {
+                  "default": "Výchozí (barevný)",
+                  "scientificDark": "Vědecký (tmavý)",
+                  "highContrastDark": "Vysoký kontrast (tmavý)",
+                  "scientific": "Vědecký (světlý)"
+                },
+                "descriptions": {
+                  "default": "Barevný spektrogram s tmavým pozadím",
+                  "scientificDark": "Stupně šedi s Dolphovým oknem, tmavé pozadí",
+                  "highContrastDark": "Vysoká sytost barev s tmavým pozadím",
+                  "scientific": "Stupně šedi s Dolphovým oknem, světlé pozadí (styl xeno-canto)"
+                }
+              },
+              "dynamicRange": {
+                "label": "Dynamický rozsah",
+                "helpText": "Řídí kontrast – nižší hodnoty zvýrazňují slabé signály, vyšší hodnoty zobrazují více detailů.",
+                "options": {
+                  "highContrast": "Vysoký kontrast (80 dB)",
+                  "standard": "Standardní (100 dB)",
+                  "extended": "Rozšířený (120 dB)"
+                },
+                "descriptions": {
+                  "highContrast": "Nejlepší pro slabé signály. Ptačí zpěv jasně vyniká ze šumu pozadí. Doporučeno pro vědecké styly / styly ve stupních šedi.",
+                  "standard": "Výchozí vyvážené nastavení. Dobré pro většinu případů použití.",
+                  "extended": "Viditelnost více detailů, ale nižší kontrast. Výchozí hodnota SoX."
+                }
+              },
+              "enabled": {
+                "label": "Povolit předgenerování spektrogramu",
+                "helpText": "ZASTARALÉ: Použijte raději Režim generování. Generujte spektrogramy na pozadí při ukládání detekcí, abyste eliminovali zpoždění UI."
+              }
+            }
+          }
+        }
+      },
+      "fields": {
+        "nodeName": {
+          "label": "Název uzlu",
+          "placeholder": "Zadejte název uzlu",
+          "helpText": "Název uzlu slouží k identifikaci zdrojového systému v nastavení s více uzly, používá se také jako identifikátor pro zprávy MQTT."
+        },
+        "sensitivity": {
+          "label": "Citlivost",
+          "helpText": "Citlivost detekce. Vyšší hodnoty znamenají vyšší citlivost. Hodnoty mezi 0.5 a 1.5."
+        },
+        "threshold": {
+          "label": "Práh",
+          "helpText": "Minimální práh spolehlivosti. Hodnoty mezi 0.01 a 0.99."
+        },
+        "overlap": {
+          "label": "Překryv",
+          "helpText": "Překryv segmentů predikce. Hodnoty mezi 0.0 a 2.9."
+        },
+        "locale": {
+          "label": "Lokalizace",
+          "helpText": "Lokalizace pro přeložené běžné názvy druhů."
+        },
+        "tensorflowThreads": {
+          "label": "CPU vlákna TensorFlow",
+          "helpText": "Počet CPU vláken. Nastavte na 0 pro použití všech dostupných vláken."
+        }
+      },
+      "errors": {
+        "localesLoadFailed": "Nepodařilo se načíst možnosti jazyka. Používají se výchozí nastavení.",
+        "providersLoadFailed": "Nepodařilo se načíst poskytovatele obrázků. Používají se výchozí nastavení.",
+        "rangeFilterTestFailed": "Nepodařilo se otestovat nastavení filtru výskytu",
+        "rangeFilterLoadFailed": "Nepodařilo se načíst seznam druhů",
+        "rangeFilterCountFailed": "Nepodařilo se načíst počet druhů",
+        "mapLibraryLoadFailed": "Nepodařilo se načíst knihovnu map. Obnovte stránku.",
+        "mapLoadFailed": "Nepodařilo se načíst mapu. Zkuste obnovit stránku.",
+        "modalMapLoadFailed": "Nepodařilo se načíst modální mapu. Zkuste okno zavřít a znovu otevřít.",
+        "mapUnavailable": "Mapa není k dispozici: WebGL není v tomto prohlížeči podporováno. Polohu můžete stále nastavit pomocí polí souřadnic výše."
+      }
+    },
+    "support": {
+      "sections": {
+        "telemetry": {
+          "title": "Sledování chyb a telemetrie",
+          "description": "Volitelné sledování chyb, které pomáhá zlepšovat spolehlivost a výkon BirdNET-Go"
+        },
+        "diagnostics": {
+          "title": "Podpora a diagnostika",
+          "description": "Pomozte vývojářům rychleji vyřešit vaše problémy poskytnutím základních diagnostických informací"
+        }
+      },
+      "telemetry": {
+        "privacyNotice": "Oznámení o ochraně soukromí",
+        "privacyPoints": {
+          "noPersonalData": "Neshromažďují se žádná osobní data",
+          "anonymousData": "Všechna telemetrická data jsou anonymní",
+          "helpImprove": "Telemetrická data pomáhají vývojářům identifikovat a opravovat problémy v BirdNET-Go"
+        },
+        "enableTracking": "Povolit sledování chyb (opt-in)"
+      },
+      "systemId": {
+        "label": "Vaše ID systému",
+        "description": "Toto ID použijte při hlášení problémů",
+        "copyButton": "Kopírovat",
+        "errorLoading": "Chyba při načítání ID systému"
+      },
+      "diagnostics": {
+        "includeRecentLogs": "Zahrnout nedávné záznamy",
+        "includeConfiguration": "Zahrnout konfiguraci (citlivá data odstraněna)",
+        "includeSystemInfo": "Zahrnout informace o systému"
+      },
+      "supportReport": {
+        "title": "Vygenerovat zprávu podpory",
+        "description": {
+          "intro": "Zprávy podpory jsou **nezbytné pro řešení problémů** a dramaticky zlepšují naši schopnost vyřešit problémy, se kterými se setkáváte. Vývojářům poskytují klíčový kontext o konfiguraci vašeho systému, nedávných záznamech aplikace a vzorcích chyb, které by jinak nebylo možné diagnostikovat."
+        },
+        "githubRequired": {
+          "title": "Vyžadováno: GitHub issue pro nahrání podpory",
+          "description": "<strong>Nahrání podpory vyžaduje číslo GitHub issue.</strong> Prosím <a href=\"https://github.com/tphakala/birdnet-go/issues/new\" target=\"_blank\" class=\"underline font-semibold\">vytvořte GitHub issue</a> popisující váš problém <strong>před</strong> vygenerováním zprávy podpory. Bez propojené issue nemohou vývojáři s vašimi daty podpory pracovat."
+        },
+        "githubIssue": {
+          "label": "Číslo GitHub issue",
+          "placeholder": "např. 123 nebo #123",
+          "helper": "<a href=\"https://github.com/tphakala/birdnet-go/issues\" target=\"_blank\" class=\"link link-primary\">Zobrazit existující issue</a> nebo nejprve <a href=\"https://github.com/tphakala/birdnet-go/issues/new\" target=\"_blank\" class=\"link link-primary\">vytvořte novou issue</a>"
+        },
+        "whatsIncluded": {
+          "title": "Co je ve zprávě zahrnuto:",
+          "applicationLogs": "**Záznamy aplikace** – nedávné chyby a ladicí informace",
+          "configuration": "**Konfigurace** – vaše nastavení s odstraněnými citlivými daty",
+          "systemInfo": "**Informace o systému** – verze OS, paměť a podrobnosti o runtime",
+          "notIncluded": "**NENÍ zahrnuto** – zvukové soubory, detekce ptáků nebo osobní data"
+        },
+        "userMessage": {
+          "label": "Popište problém",
+          "placeholder": "Popište problém a uveďte odkaz na GitHub issue, pokud je k dispozici (např. #123)",
+          "githubTip": "💡 Tip: Pokud máte GitHub issue, uveďte prosím číslo issue (např. #123) a v GitHub issue zmiňte své ID systému {systemId}, aby vývojářům pomohlo propojit vaše data podpory.",
+          "labelOptional": "Další podrobnosti (volitelné)",
+          "placeholderOptional": "Uveďte jakýkoli další kontext k problému, který není ve vaší GitHub issue",
+          "systemIdNote": "💡 Tip: Vaše ID systému {systemId} bude do nahrání automaticky zahrnuto"
+        },
+        "uploadOption": {
+          "label": "Nahrát vývojářům (doporučeno)",
+          "labelWithRequirement": "Nahrát vývojářům (vyžaduje číslo GitHub issue)",
+          "details": {
+            "sentryUpload": "Data se nahrávají do cloudové služby [Sentry](https://sentry.io)",
+            "euDataCenter": "Uloženo v datovém centru v EU (Frankfurt, Německo)",
+            "privacyCompliant": "V souladu s ochranou soukromí, citlivá data jsou odstraněna",
+            "manualWarning": "Zaškrtnutí zrušte, pouze pokud preferujete manuální zpracování souboru podpory"
+          }
+        },
+        "generateButton": {
+          "upload": "Vygenerovat a nahrát",
+          "download": "Vygenerovat a stáhnout"
+        },
+        "statusMessages": {
+          "preparing": "Připravuje se výpis podpory...",
+          "uploadSuccess": "Výpis podpory byl úspěšně nahrán vývojářům!",
+          "uploadSuccessWithId": "Výpis podpory byl úspěšně nahrán vývojářům! Referenční ID: {dumpId}",
+          "downloadSuccess": "Výpis podpory byl úspěšně vygenerován! Stahování...",
+          "generateSuccess": "Výpis podpory byl úspěšně vygenerován!",
+          "generateFailed": "Nepodařilo se vygenerovat výpis podpory: {message}",
+          "error": "Chyba: {message}",
+          "githubIssueRequired": "Pro nahrání dat podpory zadejte číslo GitHub issue"
+        }
+      }
+    },
+    "notifications": {
+      "tabs": {
+        "channels": "Kanály",
+        "rules": "Pravidla",
+        "history": "Historie"
+      },
+      "rules": {
+        "summary": {
+          "active": "aktivní",
+          "builtIn": "vestavěná",
+          "total": "celkem"
+        }
+      },
+      "sections": {
+        "testing": {
+          "title": "Testovací oznámení",
+          "description": "Odešlete testovací oznámení a ověřte, že váš systém oznámení funguje správně"
+        },
+        "info": {
+          "title": "Systémové informace",
+          "description": "Zjistěte, jak zobrazovat a spravovat svá oznámení"
+        }
+      },
+      "templates": {
+        "title": "Šablony oznámení",
+        "description": "Přizpůsobte zprávy oznámení o nových detekcích druhů pomocí proměnných šablony",
+        "newSpeciesTitle": "Šablona oznámení o novém druhu",
+        "titleLabel": "Šablona názvu",
+        "titlePlaceholder": "např. Nový druh: {{.CommonName}}",
+        "messageLabel": "Šablona zprávy",
+        "messagePlaceholder": "např. První detekce druhu {{.CommonName}} ({{.ScientificName}}) s jistotou {{.ConfidencePercent}}%",
+        "resetButton": "Obnovit",
+        "saveButton": "Uložit šablony",
+        "saveButtonUnsaved": "Uložit šablony *",
+        "testButton": "Test",
+        "savingButton": "Ukládá se...",
+        "sendingButton": "Odesílá se...",
+        "resetConfirm": "Obnovit šablony na výchozí hodnoty? Tímto se zahodí vaše aktuální změny a obnoví se výchozí hodnoty šablon.",
+        "unsavedChangesWarning": "Máte neuložené změny v šablonách. Test použije aktuálně uložené šablony, nikoli vaše úpravy. Pokračovat?",
+        "testWithUnsavedChanges": "Varování: Máte neuložené změny. Test použije uložené šablony.",
+        "testNormal": "Odeslat testovací oznámení",
+        "saveSuccess": "Šablony byly úspěšně uloženy!",
+        "saveError": "Chyba: {message}",
+        "availableVariables": "Dostupné proměnné šablony",
+        "variablesDescription": "Použijte tyto proměnné ve svých šablonách se syntaxí",
+        "loading": "Načítá se...",
+        "fields": {
+          "commonName": "Běžný název ptáka (např. \"Kardinál červený\")",
+          "scientificName": "Vědecký název (např. \"Cardinalis cardinalis\")",
+          "confidence": "Hodnota jistoty (0,0 až 1,0)",
+          "confidencePercent": "Jistota v procentech (např. \"99\")",
+          "detectionTime": "Čas detekce (např. \"14:30:45\")",
+          "detectionDate": "Datum detekce (např. \"2024-10-05\")",
+          "latitude": "Souřadnice GPS zeměpisné šířky",
+          "longitude": "Souřadnice GPS zeměpisné délky",
+          "location": "Formátované souřadnice (např. \"42.360100, -71.058900\")",
+          "detectionId": "ID číslo detekce (např. \"1234\")",
+          "detectionPath": "Relativní cesta k detekci (např. \"/ui/detections/1234\")",
+          "detectionUrl": "Úplná URL adresa detekce v UI",
+          "imageUrl": "Odkaz na obrázek druhu",
+          "daysSinceFirstSeen": "Počet dní od první detekce"
+        }
+      },
+      "testNotification": {
+        "title": "Odeslat testovací oznámení o novém druhu",
+        "description": "Vygenerujte testovací oznámení o detekci nového druhu a ověřte, že váš systém oznámení funguje",
+        "whatHappens": "Co se stane, když kliknete na 'Odeslat test':",
+        "sendButton": "Odeslat test",
+        "sendingButton": "Odesílá se...",
+        "statusMessages": {
+          "sending": "Odesílá se testovací oznámení...",
+          "success": "Testovací oznámení bylo úspěšně odesláno! Zkontrolujte zvoneček oznámení.",
+          "error": "Nepodařilo se odeslat testovací oznámení: {message}",
+          "serviceUnavailable": "Služba oznámení není k dispozici. Zkontrolujte nastavení oznámení."
+        }
+      },
+      "statusMessages": {
+        "sending": "Odesílá se testovací oznámení...",
+        "success": "Testovací oznámení bylo úspěšně odesláno!",
+        "error": "Nepodařilo se odeslat testovací oznámení: {message}",
+        "serviceUnavailable": "Služba oznámení není k dispozici. Zkontrolujte nastavení oznámení."
+      },
+      "systemInfo": {
+        "howToView": "Jak zobrazit oznámení:",
+        "technicalDetails": "Technické podrobnosti o oznámeních v BirdNET-Go:"
+      },
+      "privacy": {
+        "title": "Upozornění o ochraně osobních údajů pro externí webhooky",
+        "description": "Oznámení o detekcích mohou při odesílání externím službám obsahovat citlivá data:",
+        "gps": "Souřadnice GPS",
+        "gpsDetails": "Přesná poloha (zeměpisná šířka/délka), pokud je nakonfigurována",
+        "urls": "URL adresy detekcí",
+        "urlsDetails": "Mohou odhalit informace o interní síti",
+        "species": "Údaje o druzích",
+        "speciesDetails": "Jací ptáci byli detekováni a kdy",
+        "recommendation": "Externí webhooky povolte pouze tehdy, pokud důvěřujete přijímající službě nebo používáte self-hosted/lokální služby."
+      },
+      "push": {
+        "title": "Push oznámení",
+        "description": "Odesílejte oznámení externím službám jako Discord, Telegram, Slack a další",
+        "enable": "Povolit push oznámení",
+        "disabled": "Push oznámení jsou zakázána",
+        "enabledDescription": "Push oznámení budou odesílána všem povoleným poskytovatelům níže",
+        "filters": {
+          "title": "Filtry detekce",
+          "description": "Řídí, které detekce ptáků spouštějí push oznámení",
+          "minConfidence": {
+            "label": "Minimální jistota",
+            "helpText": "Odesílat oznámení pouze pro detekce nad touto úrovní jistoty. Nastavte na 0 pro vypnutí."
+          },
+          "speciesCooldown": {
+            "label": "Prodleva mezi druhy",
+            "unit": "min",
+            "helpText": "Zabrání opakovaným oznámením pro stejný druh v tomto časovém okně. Nastavte na 0 pro vypnutí."
+          }
+        },
+        "noProviders": "Žádní nakonfigurovaní poskytovatelé",
+        "noProvidersDescription": "Přidejte poskytovatele a začněte přijímat push oznámení",
+        "providers": {
+          "title": "Poskytovatelé oznámení",
+          "addButton": "Přidat poskytovatele",
+          "editButton": "Upravit",
+          "deleteButton": "Odstranit",
+          "enableToggle": "Povolit poskytovatele",
+          "urlsPreview": "Nakonfigurováno {count} URL adres",
+          "deleteConfirm": "Odstranit poskytovatele \"{name}\"? Tuto akci nelze vrátit zpět.",
+          "typeBadge": {
+            "shoutrrr": "Shoutrrr",
+            "webhook": "Webhook"
+          }
+        },
+        "form": {
+          "addTitle": "Přidat poskytovatele oznámení",
+          "editTitle": "Upravit poskytovatele oznámení",
+          "name": {
+            "label": "Název poskytovatele",
+            "placeholder": "např. Discord Alerts",
+            "helpText": "Popisný název pro identifikaci tohoto poskytovatele"
+          },
+          "urls": {
+            "label": "URL adresa (adresy) služby",
+            "placeholder": "discord://token@webhookid",
+            "helpText": "Zadejte jednu Shoutrrr URL adresu na řádek. Více adres odešle zprávu více službám.",
+            "validation": {
+              "required": "Je vyžadována alespoň jedna URL adresa",
+              "invalidFormat": "Neplatný formát URL. URL adresy by měly začínat prefixem služby (např. discord://, telegram://)"
+            }
+          },
+          "notificationTypes": {
+            "label": "Typy oznámení",
+            "helpText": "Vyberte, které typy oznámení se mají odesílat tomuto poskytovateli",
+            "detection": "Detekce ptáků",
+            "error": "Chyby",
+            "warning": "Varování",
+            "info": "Informace",
+            "system": "Systémové události"
+          },
+          "urlFormats": {
+            "title": "Běžné formáty URL",
+            "discord": "Discord",
+            "discordFormat": "discord://token@webhookid",
+            "telegram": "Telegram",
+            "telegramFormat": "telegram://token@telegram?chats=@channel",
+            "slack": "Slack",
+            "slackFormat": "slack://token-a/token-b/token-c",
+            "pushover": "Pushover",
+            "pushoverFormat": "pushover://shoutrrr:apiToken@userKey",
+            "gotify": "Gotify",
+            "gotifyFormat": "gotify://hostname/token",
+            "ntfy": "ntfy",
+            "ntfyFormat": "ntfy://ntfy.sh/mytopic",
+            "moreServices": "Zobrazit všechny podporované služby",
+            "shoutrrrDocs": "https://github.com/nicholas-fedor/shoutrrr?tab=readme-ov-file#supported-services"
+          },
+          "saveButton": "Uložit poskytovatele",
+          "savingButton": "Ukládá se...",
+          "cancelButton": "Zrušit",
+          "testButton": "Test",
+          "testingButton": "Testuje se..."
+        },
+        "test": {
+          "button": "Otestovat poskytovatele",
+          "description": "Odešlete testovací oznámení a ověřte, že tento poskytovatel funguje",
+          "success": "Testovací oznámení bylo úspěšně odesláno!",
+          "error": "Test se nezdařil: {message}",
+          "requiresUrl": "Zadejte URL k testování",
+          "requiresEnabled": "Pro testování povolte poskytovatele"
+        },
+        "validation": {
+          "nameRequired": "Název poskytovatele je povinný",
+          "urlRequired": "Je vyžadována alespoň jedna URL adresa",
+          "invalidUrl": "Neplatný formát URL"
+        },
+        "autoName": {
+          "discord": "Discord",
+          "telegram": "Telegram",
+          "slack": "Slack",
+          "pushover": "Pushover",
+          "gotify": "Gotify",
+          "ntfy": "ntfy",
+          "email": "E-mail",
+          "generic": "Shoutrrr",
+          "numbered": "{service} #{number}"
+        },
+        "services": {
+          "selectLabel": "Služba",
+          "selectHelpText": "Vyberte službu oznámení, kterou chcete nakonfigurovat",
+          "discord": {
+            "name": "Discord",
+            "webhookUrl": {
+              "label": "URL Discord webhooku",
+              "placeholder": "https://discord.com/api/webhooks/...",
+              "helpText": "Vložte úplnou URL adresu Discord webhooku"
+            },
+            "invalidUrl": "Neplatná URL Discord webhooku. URL by měla obsahovat discord.com/api/webhooks/"
+          },
+          "telegram": {
+            "name": "Telegram",
+            "botToken": {
+              "label": "Token bota",
+              "placeholder": "123456789:ABCdef...",
+              "helpText": "Token od @BotFather"
+            },
+            "chatId": {
+              "label": "ID chatu",
+              "placeholder": "-1001234567890 nebo @channel",
+              "helpText": "ID chatu, ID skupiny nebo @username"
+            },
+            "incomplete": "Vyžaduje se token bota i ID chatu"
+          },
+          "ntfy": {
+            "name": "ntfy",
+            "server": {
+              "label": "Server",
+              "placeholder": "ntfy.sh",
+              "helpText": "Ponechte ntfy.sh pro veřejný server nebo zadejte svůj self-hosted server"
+            },
+            "protocol": {
+              "label": "Protokol"
+            },
+            "testConnection": "Otestovat připojení",
+            "connectionOk": {
+              "https": "HTTPS funguje",
+              "http": "HTTP funguje — server nepoužívá HTTPS"
+            },
+            "connectionFailed": "Nelze se připojit — zkontrolujte název hostitele a stav serveru",
+            "auth": {
+              "label": "Ověření (volitelné)",
+              "username": {
+                "label": "Uživatelské jméno",
+                "placeholder": "admin"
+              },
+              "password": {
+                "label": "Heslo / Přístupový token",
+                "placeholder": "tk_AgQdq7mVBoFD37zQVN29RioLJNGht"
+              }
+            },
+            "topic": {
+              "label": "Téma",
+              "placeholder": "moje-ptaci-upozorneni",
+              "helpText": "Název tématu pro vaše oznámení"
+            },
+            "incomplete": "Téma je povinné"
+          },
+          "gotify": {
+            "name": "Gotify",
+            "server": {
+              "label": "URL serveru",
+              "placeholder": "gotify.example.com:8070",
+              "helpText": "Název hostitele a port vašeho serveru Gotify"
+            },
+            "protocol": {
+              "label": "Protokol"
+            },
+            "token": {
+              "label": "Token aplikace",
+              "placeholder": "A...",
+              "helpText": "Token ze stránky Gotify Apps"
+            },
+            "incomplete": "Vyžaduje se server i token"
+          },
+          "pushover": {
+            "name": "Pushover",
+            "apiToken": {
+              "label": "API token",
+              "placeholder": "az...",
+              "helpText": "API token aplikace"
+            },
+            "userKey": {
+              "label": "Uživatelský klíč",
+              "placeholder": "u...",
+              "helpText": "Váš uživatelský nebo skupinový klíč"
+            },
+            "incomplete": "Vyžaduje se API token i uživatelský klíč"
+          },
+          "slack": {
+            "name": "Slack",
+            "webhookUrl": {
+              "label": "URL Slack webhooku",
+              "placeholder": "https://hooks.slack.com/services/...",
+              "helpText": "Vložte úplnou URL adresu Slack webhooku"
+            },
+            "invalidUrl": "Neplatná URL Slack webhooku. URL by měla obsahovat hooks.slack.com/services/"
+          },
+          "ifttt": {
+            "name": "IFTTT",
+            "webhookKey": {
+              "label": "Klíč webhooku",
+              "placeholder": "abc123xyz...",
+              "helpText": "Váš klíč IFTTT Webhooku z nastavení Maker Webhooks"
+            },
+            "eventName": {
+              "label": "Název události",
+              "placeholder": "bird_detected",
+              "helpText": "Název události, který se má spustit ve vašem IFTTT appletu"
+            },
+            "incomplete": "Vyžaduje se klíč webhooku i název události"
+          },
+          "webhook": {
+            "name": "Webhook",
+            "url": {
+              "label": "URL webhooku",
+              "placeholder": "https://api.example.com/webhook",
+              "helpText": "Endpoint HTTP(S), na který se mají odesílat oznámení"
+            },
+            "method": {
+              "label": "HTTP metoda",
+              "helpText": "HTTP metoda použitá pro požadavek (výchozí: POST)"
+            },
+            "auth": {
+              "label": "Ověření",
+              "none": "Žádné",
+              "bearer": "Bearer Token",
+              "basic": "Basic Auth",
+              "helpText": "Volitelné ověření pro endpoint webhooku"
+            },
+            "bearerToken": {
+              "label": "Bearer Token",
+              "placeholder": "vas-api-token",
+              "helpText": "Token odeslaný v hlavičce Authorization: Bearer"
+            },
+            "basicUser": {
+              "label": "Uživatelské jméno",
+              "placeholder": "username"
+            },
+            "basicPass": {
+              "label": "Heslo",
+              "placeholder": "heslo"
+            },
+            "basicAuth": {
+              "helpText": "Přihlašovací údaje odeslané pomocí HTTP Basic Authentication"
+            },
+            "invalidUrl": "Neplatná URL. Musí začínat na http:// nebo https://",
+            "tokenRequired": "Při použití ověření Bearer je vyžadován Bearer token",
+            "credentialsRequired": "Při použití ověření Basic je vyžadováno uživatelské jméno a heslo"
+          },
+          "custom": {
+            "name": "Vlastní URL",
+            "url": {
+              "label": "Shoutrrr URL",
+              "placeholder": "service://credentials@host",
+              "helpText": "Zadejte čistou Shoutrrr URL pro libovolnou podporovanou službu"
+            },
+            "invalidUrl": "Neplatný formát URL. URL by měla začínat na service://"
+          }
+        }
+      }
+    },
+    "filters": {
+      "title": "Filtry",
+      "privacyFiltering": {
+        "title": "Filtrování soukromí",
+        "description": "Filtrování soukromí zabraňuje ukládání zvukových klipů, když jsou detekovány lidské hlasy",
+        "enable": "Povolit filtrování soukromí",
+        "disabled": "Filtrování soukromí je vypnuté",
+        "confidenceLabel": "Práh spolehlivosti pro detekci lidí",
+        "confidenceHelp": "Nastavte úroveň spolehlivosti pro detekci lidského hlasu, nižší hodnota dělá filtr citlivějším"
+      },
+      "falsePositivePrevention": {
+        "title": "Prevence falešně pozitivních detekcí",
+        "description": "Konfigurace filtrů falešných detekcí",
+        "enableDogBark": "Povolit filtr psího štěkání",
+        "disabled": "Filtr psího štěkání je vypnutý",
+        "confidenceLabel": "Práh spolehlivosti",
+        "confidenceHelp": "Nastavte úroveň spolehlivosti pro detekci psího štěkání, nižší hodnota dělá filtr citlivějším",
+        "expireTimeLabel": "Doba platnosti psího štěkání (minuty)",
+        "expireTimeHelp": "Nastavte, jak dlouho si má systém pamatovat detekované psí štěkání",
+        "addDogBarkSpeciesLabel": "Přidat druhy zaměnitelné se štěkáním",
+        "addDogBarkSpeciesHelp": "Vyhledejte a přidejte druhy, které by mohly být zaměněny s psím štěkáním",
+        "addSpeciesButton": "Přidat"
+      },
+      "speciesNamePlaceholder": "Název druhu",
+      "typeSpeciesName": "Zadejte název druhu...",
+      "dogBarkSpeciesList": "Seznam druhů zaměnitelných se štěkáním",
+      "daylightFilter": {
+        "title": "Filtr denního světla",
+        "description": "Odfiltrovat detekce nočních druhů během denního světla. Používá hranice občanského úsvitu/soumraku z vaší nakonfigurované polohy.",
+        "enable": "Povolit filtr denního světla",
+        "disabled": "Filtr denního světla je vypnutý",
+        "offsetLabel": "Posun okna denního světla (hodiny)",
+        "offsetHelp": "Upraví okno denního světla. Kladné hodnoty jej zmenšují (tolerantnější, např. +1 = začíná 1 h po úsvitu). Záporné hodnoty jej rozšiřují (přísnější, např. -1 = začíná 1 h před úsvitem).",
+        "speciesListLabel": "Seznam nočních druhů",
+        "addSpeciesLabel": "Přidat noční druh",
+        "addSpeciesHelp": "Vyhledejte a přidejte druhy, rody, čeledi nebo řády k filtrování během dne. Výchozí: Strigiformes (všechny sovy). Poznámka: prázdný seznam vypne filtrování nočních druhů během dne."
+      },
+      "errors": {
+        "speciesLoadFailed": "Nepodařilo se načíst seznam druhů. Zkuste to znovu."
+      }
+    },
+    "integration": {
+      "birdweather": {
+        "title": "BirdWeather",
+        "description": "Nahrávat detekce do BirdWeather",
+        "ffmpegWarning": {
+          "title": "FFmpeg nebyl nalezen",
+          "message": "Nainstalujte prosím FFmpeg pro povolení podpory kódování FLAC. BirdWeather ukončuje podporu nahrávání WAV ve prospěch komprimovaných zvukových souborů FLAC."
+        },
+        "enable": "Povolit nahrávání do BirdWeather",
+        "token": {
+          "label": "Token BirdWeather",
+          "helpText": "Váš jedinečný token BirdWeather."
+        },
+        "threshold": {
+          "label": "Práh nahrávání",
+          "helpText": "Minimální práh jistoty pro nahrávání predikcí do BirdWeather."
+        },
+        "test": {
+          "button": "Otestovat připojení k BirdWeather",
+          "loading": "Testuje se...",
+          "enabledRequired": "Pro testování musí být BirdWeather povolen",
+          "tokenRequired": "Musí být zadán token BirdWeather",
+          "inProgress": "Test probíhá...",
+          "description": "Otestovat připojení k BirdWeather"
+        }
+      },
+      "mqtt": {
+        "title": "MQTT",
+        "description": "Konfigurace připojení k MQTT brokeru",
+        "enable": "Povolit integraci MQTT",
+        "broker": {
+          "label": "MQTT broker",
+          "placeholder": "mqtt://localhost:1883"
+        },
+        "topic": {
+          "label": "MQTT téma",
+          "placeholder": "birdnet/detections"
+        },
+        "authentication": {
+          "title": "Ověření",
+          "username": {
+            "label": "Uživatelské jméno"
+          },
+          "password": {
+            "label": "Heslo",
+            "helpText": "Heslo k MQTT."
+          }
+        },
+        "tls": {
+          "title": "Zabezpečení TLS/SSL",
+          "enable": "Povolit TLS/SSL",
+          "skipVerify": "Přeskočit ověření certifikátu",
+          "configNote": "<strong>Konfigurace TLS:</strong><br />• Standardní TLS: Pro veřejné brokery ponechte certifikáty prázdné<br />• Self-signed certifikáty: Poskytněte CA certifikát<br />• Mutual TLS (mTLS): Poskytněte všechny tři certifikáty",
+          "certificates": {
+            "title": "Správa certifikátů",
+            "description": "Nahrajte certifikáty pro zabezpečená připojení k MQTT brokeru",
+            "caLabel": "CA certifikát",
+            "caPlaceholder": "-----BEGIN CERTIFICATE-----",
+            "caHelpText": "Certifikát certifikační autority pro ověření identity brokera",
+            "clientCertLabel": "Klientský certifikát",
+            "clientCertPlaceholder": "-----BEGIN CERTIFICATE-----",
+            "clientCertHelpText": "Klientský certifikát pro vzájemné ověření TLS",
+            "clientKeyLabel": "Soukromý klíč klienta",
+            "clientKeyPlaceholder": "-----BEGIN PRIVATE KEY-----",
+            "clientKeyHelpText": "Soukromý klíč odpovídající klientskému certifikátu",
+            "uploadButton": "Nahrát certifikáty",
+            "uploadSuccess": "Certifikáty MQTT TLS byly úspěšně nahrány. Pro ověření použijte Otestovat připojení.",
+            "uploadError": "Nepodařilo se nahrát certifikáty MQTT TLS",
+            "deleteConfirm": "Odstranit všechny certifikáty MQTT TLS? MQTT klient se bude muset znovu připojit.",
+            "deleteSuccess": "Certifikáty MQTT TLS byly odstraněny",
+            "deleteError": "Nepodařilo se odstranit certifikáty MQTT TLS",
+            "loadError": "Nepodařilo se načíst informace o certifikátu",
+            "reconnectNote": "Pro ověření nové konfigurace TLS použijte tlačítko Otestovat připojení níže."
+          }
+        },
+        "homeAssistant": {
+          "title": "Automatické zjišťování Home Assistant",
+          "enable": "Povolit zjišťování MQTT pro Home Assistant",
+          "description": "Když je povoleno, BirdNET-Go automaticky registruje zařízení a senzory v Home Assistant prostřednictvím protokolu zjišťování MQTT. Zařízení se objeví v registru zařízení Home Assistant bez nutnosti ruční konfigurace YAML.",
+          "discoveryPrefix": {
+            "label": "Prefix zjišťování",
+            "helpText": "Prefix MQTT tématu pro zprávy o zjišťování Home Assistant. Výchozí hodnota je 'homeassistant'. Toto změňte pouze tehdy, pokud jste v Home Assistant nakonfigurovali vlastní prefix zjišťování."
+          },
+          "deviceName": {
+            "label": "Název zařízení",
+            "helpText": "Základní název zařízení, jak se zobrazují v Home Assistant. Každý zdroj zvuku bude mít své vlastní zařízení propojené s tímto hlavním zařízením BirdNET-Go."
+          },
+          "sensorsNote": "<strong>Vytvořené senzory:</strong> Pro každý zdroj zvuku Home Assistant obdrží: Poslední druh, Jistotu, Vědecký název a Úroveň zvuku (pokud je povolena). Můstkové zařízení obsahuje stav dostupnosti online/offline.",
+          "discovery": {
+            "button": "Odeslat zjišťování",
+            "success": "Zprávy o zjišťování byly odeslány do Home Assistant",
+            "error": "Nepodařilo se odeslat zprávy o zjišťování",
+            "saveFirst": "Před odesláním zjišťování uložte nastavení"
+          },
+          "retain": {
+            "label": "Retain zprávy",
+            "note": "<strong>Doporučeno:</strong> Povolte příznak retain, aby MQTT senzory zobrazovaly hodnoty po restartu Home Assistant."
+          }
+        },
+        "test": {
+          "button": "Otestovat připojení k MQTT",
+          "loading": "Testuje se...",
+          "enabledRequired": "Pro testování musí být MQTT povoleno",
+          "brokerRequired": "Musí být zadán MQTT broker",
+          "inProgress": "Test probíhá...",
+          "description": "Otestovat připojení k MQTT"
+        }
+      },
+      "observability": {
+        "title": "Pozorovatelnost (Observability)",
+        "description": "Sledujte výkon BirdNET-Go a metriky detekce ptáků prostřednictvím endpointu kompatibilního s Prometheus",
+        "enable": "Povolit integraci pozorovatelnosti",
+        "disabled": "Integrace pozorovatelnosti není povolena",
+        "listenAddress": {
+          "label": "Adresa naslouchání",
+          "placeholder": "0.0.0.0:8090",
+          "ipLabel": "Adresa pro bind",
+          "portLabel": "Port",
+          "allInterfaces": "Všechna rozhraní",
+          "loopback": "Loopback",
+          "customAddress": "Vlastní adresa",
+          "interfaceDown": "neaktivní"
+        }
+      },
+      "weather": {
+        "title": "Počasí",
+        "description": "Konfigurace sběru dat o počasí",
+        "provider": {
+          "label": "Poskytovatel počasí",
+          "options": {
+            "none": "Žádný",
+            "yrno": "Yr.no",
+            "openweather": "OpenWeather",
+            "wunderground": "Weather Underground"
+          }
+        },
+        "wunderground": {
+          "apiKey": {
+            "label": "API klíč Weather Underground",
+            "helpText": "Zadejte svůj API klíč Weather Underground. Vyžaduje se pro data o počasí."
+          },
+          "stationId": {
+            "label": "ID stanice",
+            "helpText": "Vaše ID stanice Weather Underground PWS (např. KCAOAKLA12)."
+          },
+          "endpoint": {
+            "label": "API endpoint",
+            "helpText": "V případě potřeby přepište výchozí endpoint API Weather Underground. Pokud zůstane prázdný, použije se ve výchozím nastavení https://api.weather.com/v2/pws/observations/current."
+          },
+          "units": {
+            "label": "Jednotky",
+            "helpText": "Vyberte jednotky pro teplotu a rychlost větru (m = metrické, e = imperiální, h = UK hybridní)."
+          }
+        },
+        "notes": {
+          "none": "Nebudou získávána žádná data o počasí.",
+          "yrno": {
+            "description": "Data předpovědi počasí poskytuje Yr.no, společná služba Norského meteorologického institutu (met.no) a Norské rozhlasové a televizní společnosti (NRK).",
+            "freeService": "Yr je bezplatná služba dat o počasí. Pro více informací navštivte <a href=\"https://hjelp.yr.no/hc/en-us/articles/206550539-Facts-about-Yr\" class=\"link link-primary\" target=\"_blank\" rel=\"noopener noreferrer\">Yr.no</a>."
+          },
+          "openweather": "Použití OpenWeather vyžaduje API klíč, zaregistrujte se pro bezplatný API klíč na <a href=\"https://home.openweathermap.org/users/sign_up\" class=\"link link-primary\" target=\"_blank\" rel=\"noopener noreferrer\">OpenWeather</a>.",
+          "wunderground": "Vyžaduje API klíč Weather Underground a platné ID stanice PWS. Podrobnosti najdete na <a href=\"https://www.wunderground.com/member/devices\" class=\"link link-primary\" target=\"_blank\" rel=\"noopener noreferrer\">Weather Underground</a>."
+        },
+        "apiKey": {
+          "label": "API klíč",
+          "helpText": "Váš API klíč pro vybraného poskytovatele počasí. Udržujte ho v tajnosti!"
+        },
+        "units": {
+          "label": "Měrné jednotky",
+          "options": {
+            "standard": "Standardní",
+            "metric": "Metrické",
+            "imperial": "Imperiální",
+            "ukhybrid": "UK hybridní"
+          }
+        },
+        "test": {
+          "button": "Otestovat poskytovatele počasí",
+          "loading": "Testuje se...",
+          "noProvider": "Není vybrán žádný poskytovatel počasí",
+          "apiKeyRequired": "Musí být zadán API klíč",
+          "inProgress": "Test probíhá...",
+          "description": "Otestovat připojení k poskytovateli počasí"
+        },
+        "temperatureUnit": {
+          "label": "Jednotka zobrazení teploty",
+          "helpText": "Vyberte, jak se budou teploty zobrazovat v celé aplikaci.",
+          "options": {
+            "celsius": "Celsius (°C)",
+            "fahrenheit": "Fahrenheit (°F)"
+          }
+        }
+      },
+      "errors": {
+        "connectionError": "Chyba připojení",
+        "responseStreamFailed": "Nepodařilo se přečíst stream odpovědi",
+        "configurationCheck": "Kontrola konfigurace",
+        "testStageFallback": "Fáze testu"
+      },
+      "ebird": {
+        "title": "eBird",
+        "description": "Připojení k taxonomické databázi eBird pro obohacená data o druzích včetně taxonomické klasifikace a informací o poddruzích.",
+        "enable": "Povolit integraci eBird",
+        "enabledRequired": "Integrace eBird není povolena",
+        "apiKey": {
+          "label": "API klíč eBird",
+          "helpText": "Váš API klíč eBird. Získejte ho na portálu API eBird."
+        },
+        "locale": {
+          "label": "Jazyk názvů druhů"
+        },
+        "cacheTTL": {
+          "label": "Doba platnosti cache (hodiny)",
+          "helpText": "Jak dlouho uchovávat taxonomická data z eBird ve vyrovnávací paměti. Taxonomie se mění zřídka, proto delší doby cache snižují počet volání API."
+        },
+        "note": "eBird poskytuje taxonomická data používaná pro klasifikaci druhů a analýzy. API klíč je zdarma a dostupný z Cornell Lab of Ornithology.",
+        "apiKeyInfo": "Pro použití této integrace je potřeba osobní API klíč eBird. Bezplatný klíč si můžete vyžádat na <a href=\"https://ebird.org/api/keygen\" class=\"link link-primary\" target=\"_blank\" rel=\"noopener noreferrer\">ebird.org/api/keygen</a>.",
+        "test": {
+          "button": "Otestovat připojení k eBird",
+          "loading": "Testuje se...",
+          "enabledRequired": "Nejprve povolte integraci eBird",
+          "apiKeyRequired": "API klíč je povinný",
+          "inProgress": "Test probíhá...",
+          "description": "Otestovat připojení a ověření API eBird"
+        }
+      }
+    },
+    "audio": {
+      "loading": "Načítají se zvuková zařízení...",
+      "tabs": {
+        "soundCard": "Zvuková karta",
+        "streams": "Streamy",
+        "processing": "Zpracování",
+        "recording": "Nahrávání",
+        "retention": "Uchování"
+      },
+      "emptyStates": {
+        "soundCard": {
+          "title": "Nebyly nalezeny žádné zvukové karty",
+          "description": "V tomto systému nebyla nalezena žádná lokální zvuková vstupní zařízení. To je normální při nasazení v kontejnerech nebo na serverech bez grafického rozhraní.",
+          "errorTitle": "Chyba při načítání zařízení",
+          "hintsTitle": "Můžete:",
+          "hints": {
+            "container": "Toto je normální při nasazení v kontejnerech/headless režimu",
+            "streams": "Místo toho nakonfigurujte síťové streamy na kartě Streamy",
+            "usb": "Připojte USB mikrofon a obnovte seznam"
+          },
+          "refresh": "Obnovit zařízení",
+          "retry": "Zkusit znovu"
+        },
+        "streams": {
+          "title": "Žádné nakonfigurované streamy",
+          "description": "Přidejte RTSP nebo síťové zvukové streamy z IP kamer, mikrofonových serverů nebo jiných streamovacích zdrojů.",
+          "hintsTitle": "Začínáme:",
+          "hints": {
+            "rtsp": "Zadejte URL adresy RTSP ve formátu: rtsp://ip:port/stream",
+            "multiple": "Můžete přidat více streamů pro různá místa",
+            "protocol": "Vyberte TCP pro spolehlivost nebo UDP pro nižší latenci"
+          }
+        }
+      },
+      "soundCard": {
+        "title": "Zvuková karta",
+        "description": "Konfigurace lokálního zvukového vstupního zařízení",
+        "audioSourceLabel": "Zdroj zvuku (vyžaduje restart aplikace)",
+        "audioSourceHelp": "Vyberte zvukové vstupní zařízení pro detekci ptačího zpěvu. Změny vyžadují restart aplikace.",
+        "noSoundCardCapture": "Žádný záznam ze zvukové karty",
+        "empty": {
+          "title": "Nebyly nalezeny žádné zvukové karty",
+          "description": "V tomto systému nebyla nalezena žádná lokální zvuková vstupní zařízení. To je normální při nasazení v kontejnerech nebo na serverech bez grafického rozhraní.",
+          "hintsTitle": "Můžete:",
+          "hintStream": "Nakonfigurujte síťové streamy na kartě Streamy",
+          "hintUsb": "Připojte USB mikrofon a obnovte seznam",
+          "goToStreams": "Přejít na Streamy",
+          "refresh": "Obnovit zařízení"
+        }
+      },
+      "noSources": {
+        "warning": "Žádné nakonfigurované zdroje zvuku",
+        "description": "BirdNET-Go potřebuje zvukový vstup pro detekci ptáků. Nakonfigurujte prosím alespoň jeden zdroj na kartě Zvuková karta nebo Streamy."
+      },
+      "soundCards": {
+        "summary": "Zdroj(e) zvukové karty: {count}",
+        "addSource": "Přidat zvukovou kartu",
+        "nameLabel": "Název zdroje",
+        "namePlaceholder": "např. Mikrofon v přední zahradě",
+        "nameHelp": "Popisný název pro tento zdroj zvuku",
+        "deviceLabel": "Zvukové zařízení",
+        "devicePlaceholder": "Vyberte zvukové zařízení",
+        "gainLabel": "Zesílení (dB)",
+        "gainHelp": "Úprava zesílení zvukového vstupu (-40 až +40 dB)",
+        "sampleRateLabel": "Vzorkovací frekvence",
+        "sampleRateUnverified": "Podporované frekvence nelze pro toto zařízení ověřit",
+        "sampleRateProbing": "Zjišťování podporovaných frekvencí...",
+        "sampleRateExclusive": "Frekvence nad 48 kHz používají v Linuxu výhradní přístup k zařízení, což brání ostatním aplikacím ve sdílení zvukové karty",
+        "modelLabel": "Detekční modely",
+        "modelHelp": "Vyberte, které AI modely se mají spustit na tomto zdroji zvuku",
+        "deleteConfirm": "Odstranit tento zdroj zvukové karty?",
+        "emptyState": {
+          "title": "Nejsou nakonfigurovány žádné zdroje zvukové karty",
+          "description": "Přidejte zdroj zvukové karty a začněte zachytávat zvuk pro detekci ptáků.",
+          "hintsTitle": "Začínáme",
+          "hints": {
+            "device": "Vyberte z dostupných zvukových vstupních zařízení ve vašem systému",
+            "multiple": "Můžete nakonfigurovat více zvukových karet pro různá umístění",
+            "model": "Každý zdroj může používat jiný detekční model (BirdNET, Perch, Bat)"
+          }
+        },
+        "models": {
+          "birdnetDefault": "BirdNET (výchozí)",
+          "birdnet": "BirdNET",
+          "perchV2": "Google Perch v2",
+          "bat": "Detekce netopýrů"
+        },
+        "errors": {
+          "nameRequired": "Název zdroje je povinný",
+          "deviceRequired": "Zvukové zařízení je povinné",
+          "duplicateName": "Zdroj s tímto názvem již existuje",
+          "duplicateDevice": "Toto zařízení je již nakonfigurováno"
+        },
+        "compatibility": {
+          "minSampleRate": "Vyžaduje minimálně {rate}kHz vzorkovací frekvenci",
+          "recommendedSampleRate": "{rate}kHz doporučeno pro nejlepší výsledky",
+          "atLeastOneModel": "Musí být vybrán alespoň jeden model"
+        }
+      },
+      "audioCapture": {
+        "title": "Konfigurace zvukové karty",
+        "description": "Vyberte zvukové vstupní zařízení pro detekci ptačího zpěvu. Změny vyžadují restart aplikace.",
+        "soundCardSource": "Zdroj zvukové karty",
+        "audioSourceLabel": "Zdroj zvuku (vyžaduje restart aplikace)",
+        "audioSourceHelp": "Vyberte zvukové vstupní zařízení pro detekci ptačího zpěvu. Změny vyžadují restart aplikace.",
+        "noSoundCardCapture": "Žádný záznam ze zvukové karty",
+        "noDeviceSelected": "Není vybráno žádné zvukové zařízení",
+        "refreshDevices": "Obnovit",
+        "rtspSource": "RTSP zdroj",
+        "rtspTransportLabel": "Transportní protokol RTSP",
+        "rtspTransportHelp": "TCP je spolehlivější, ale může mít vyšší latenci. UDP je rychlejší, ale na špatných sítích může docházet ke ztrátě paketů.",
+        "rtspUrlsLabel": "URL adresy RTSP streamů",
+        "rtspUrlsHelp": "Zadejte jednu nebo více URL adres RTSP streamů pro síťové zdroje zvuku. Formát: rtsp://ip:port/stream. Poznámka: Přihlašovací údaje by měly být z bezpečnostních důvodů nakonfigurovány samostatně na vašem RTSP serveru.",
+        "deviceSelected": "Zvuková karta vybrána a připravena k záznamu",
+        "availableDevices": "Dostupná zvuková zařízení",
+        "active": "Aktivní",
+        "streamsConfigured": "Nakonfigurováno {count} streamů"
+      },
+      "quietHours": {
+        "title": "Tiché hodiny",
+        "sectionTitle": "Tiché hodiny",
+        "sectionDescription": "Pozastavit záznam zvuku během nakonfigurovaných časových oken pro snížení využití CPU, když ptáci pravděpodobně nejsou aktivní.",
+        "modeLabel": "Režim plánování",
+        "modeFixed": "Pevné časy",
+        "modeSolar": "Východ/Západ slunce",
+        "startTime": "Čas začátku",
+        "endTime": "Čas konce",
+        "startEvent": "Událost začátku",
+        "endEvent": "Událost konce",
+        "offsetMinutes": "Posun (min)",
+        "sunrise": "Východ slunce",
+        "sunset": "Západ slunce",
+        "fixedHint": "Záznam se denně pozastavuje mezi časy začátku a konce. Noční okna (např. 22:00 až 06:00) jsou podporována.",
+        "solarHint": "Časy se počítají na základě východu/západu slunce ve vaší nakonfigurované poloze. Použijte záporné posuny před událostí, kladné po ní.",
+        "badge": "Ticho",
+        "enabledBadge": "Tiché hodiny povoleny pro tento stream"
+      },
+      "rtspStreams": {
+        "title": "Konfigurace zvukových streamů",
+        "description": "Nakonfigurujte síťové zvukové streamy pro vzdálený záznam zvuku. Podporuje protokoly RTSP, HTTP, HLS, RTMP a UDP.",
+        "noStreamsConfigured": "Žádné nakonfigurované streamy"
+      },
+      "streams": {
+        "streamLabel": "Stream",
+        "nameLabel": "Název streamu",
+        "enabled": "Zapnuto",
+        "disabled": "Vypnuto",
+        "namePlaceholder": "např. Krmítko před domem",
+        "nameHelp": "Popisný název pro identifikaci tohoto zvukového streamu",
+        "urlLabel": "URL streamu",
+        "urlHelp": "Zadejte URL streamu s volitelnými přihlašovacími údaji (např. rtsp://host:port/path). Pro přihlašovací údaje použijte proměnné prostředí.",
+        "typeLabel": "Typ streamu",
+        "typeHelp": "Protokol streamu – automaticky zjištěn z URL",
+        "transportLabel": "Protokol",
+        "summary": "Nakonfigurováno {count} streamů",
+        "healthy": "v pořádku",
+        "unhealthy": "v nepořádku",
+        "unknown": "neznámý",
+        "refresh": "Obnovit",
+        "addStream": "Přidat stream",
+        "deleteConfirm": "Odstranit tento stream?",
+        "restartCount": "Restartováno {count}krát",
+        "healthLoadError": "Nepodařilo se načíst stav streamu",
+        "status": {
+          "connected": "Připojeno",
+          "connecting": "Připojuje se",
+          "error": "Chyba",
+          "idle": "Nečinný",
+          "suppressed": "Tiché hodiny",
+          "unknown": "Neznámý"
+        },
+        "emptyState": {
+          "title": "Žádné nakonfigurované streamy",
+          "description": "Přidejte zvukové streamy z IP kamer, serverů Icecast nebo jiných síťových zdrojů.",
+          "hintsTitle": "Začínáme",
+          "hints": {
+            "rtsp": "Podporuje streamy RTSP, HTTP, HLS, RTMP a UDP/RTP",
+            "credentials": "Přihlašovací údaje mohou být zahrnuty v URL nebo použijte proměnné prostředí",
+            "protocol": "TCP je spolehlivější pro RTSP, UDP má nižší latenci"
+          }
+        },
+        "errors": {
+          "nameRequired": "Název streamu je povinný",
+          "duplicateName": "Stream s tímto názvem již existuje",
+          "urlRequired": "URL streamu je povinná",
+          "invalidUrl": "Neplatný formát URL streamu",
+          "duplicate": "Tato URL streamu již existuje"
+        },
+        "timeline": {
+          "error": "Chyba",
+          "noHistory": "Žádná historie stavů nebo chyb není k dispozici.",
+          "stateChange": "Změna stavu",
+          "host": "Hostitel",
+          "troubleshooting": "Řešení problémů",
+          "from": "Z",
+          "to": "Na",
+          "reason": "Důvod",
+          "eventAt": "Událost v {time}"
+        },
+        "diagnostics": {
+          "toggleDiagnostics": "Přepnout diagnostiku",
+          "processState": "Stav procesu",
+          "lastData": "Poslední data",
+          "restartCount": "Počet restartů",
+          "connection": "Připojení",
+          "stateErrorHistory": "Historie stavů a chyb"
+        },
+        "connectionStatus": {
+          "stable": "Stabilní",
+          "degraded": "Zhoršené",
+          "failed": "Selhalo",
+          "unknown": "Neznámé"
+        }
+      },
+      "audioFilters": {
+        "title": "Zvukové filtry",
+        "description": "Konfigurace výchozích zvukových filtrů aplikovaných na všechny zdroje. Přepsání EQ pro jednotlivé zdroje je k dispozici v nastavení každé zvukové karty.",
+        "enableEqualizer": "Povolit zvukový ekvalizér",
+        "enableEqualizerHelp": "Použijte frekvenční filtrování pro zlepšení detekce ptačího zpěvu snížením nežádoucího hluku a frekvencí.",
+        "filterType": "Typ filtru",
+        "newFilterType": "Nový typ filtru",
+        "selectFilterType": "Vyberte typ filtru",
+        "addFilter": "Přidat filtr",
+        "remove": "Odebrat",
+        "frequencyResponse": "Frekvenční odezva",
+        "cutoffFrequency": "Mezní frekvence",
+        "cutoffFrequencyHelp": "Frekvence, při které filtr začíná tlumit signály. Ptačí zpěv se obvykle pohybuje v rozmezí 1–10 kHz.",
+        "qFactor": "Q faktor",
+        "qFactorHelp": "Činitel jakosti (Q faktor) řídí ostrost filtru. Nižší hodnoty (0,1–1) vytvářejí jemnější sklony, vyšší hodnoty (1–10) vytvářejí strmější řezy.",
+        "gain": "Zesílení",
+        "gainHelp": "Úroveň zesílení nebo útlumu v decibelech (dB).",
+        "attenuation": "Útlum",
+        "attenuationHelp": "Rychlost poklesu filtru. Vyšší hodnoty poskytují strmější tlumení filtrovaných frekvencí.",
+        "attenuationLevels": {
+          "0db": "0dB",
+          "12db": "12dB",
+          "24db": "24dB",
+          "36db": "36dB",
+          "48db": "48dB"
+        },
+        "filterHelp": "Přidejte více filtrů pro tvarování frekvenční odezvy pro optimální detekci ptáků ve vašem prostředí.",
+        "graph": {
+          "flatResponse": "Plochá odezva (žádné filtry nejsou použity)",
+          "frequency": "Frekvence (Hz)",
+          "gain": "Zesílení (dB)"
+        }
+      },
+      "soundLevelMonitoring": {
+        "title": "Sledování úrovně zvuku",
+        "description": "Sledování a hlášení úrovní zvuku v prostředí",
+        "enable": "Povolit sledování úrovně zvuku",
+        "enableHelp": "Sledujte úrovně hluku v okolí, abyste porozuměli svému nahrávacímu prostředí a dali je do souvislosti se vzorci aktivity ptáků.",
+        "disabled": "Sledování úrovně zvuku je vypnuto",
+        "intervalLabel": "Interval měření (sekundy)",
+        "intervalHelp": "Jak často se mají měřit a hlásit úrovně zvuku. Nižší hodnoty poskytují podrobnější data, ale spotřebovávají více zdrojů. Minimum 5 sekund, doporučeno 60 sekund.",
+        "dataOutputTitle": "Výstup dat o úrovni zvuku",
+        "dataOutputDescription": "Pokud je povoleno, měření úrovně zvuku jsou zveřejňována prostřednictvím:",
+        "mqttTopic": "MQTT téma:",
+        "sseEndpoint": "SSE endpoint:",
+        "prometheusMetrics": "Metriky Prometheus:"
+      },
+      "clipSettings": {
+        "title": "Nastavení klipů",
+        "description": "Konfigurace zachytávání a zpracování zvukových klipů pro identifikovaný ptačí zpěv"
+      },
+      "clipRecording": {
+        "title": "Nahrávání klipů",
+        "description": "Nakonfigurujte, kdy a jak jsou zachytávány zvukové klipy pro detekovaný ptačí zpěv.",
+        "enable": "Povolit nahrávání klipů",
+        "enableHelp": "Ukládejte zvukové klipy detekovaného ptačího zpěvu pro kontrolu, sdílení nebo budování vlastních datových sad.",
+        "disabled": "Nahrávání klipů je vypnuto",
+        "captureSettings": "Nastavení záznamu",
+        "lengthLabel": "Délka záznamu",
+        "lengthHelp": "Délka zvuku, který se má zachytit pro každou detekci (10–60 sekund). Delší klipy poskytují více kontextu, ale spotřebovávají více úložiště.",
+        "preCaptureLabel": "Buffer před detekcí",
+        "preCaptureHelp": "Sekundy zvuku, které se mají zahrnout před detekcí ptáka (0–{max} sekund). Zajišťuje zachycení celého ptačího zpěvu od jeho začátku.",
+        "gainLabel": "Zesílení zvuku",
+        "gainHelp": "Zesílení zvuku pro uložené klipy v decibelech (0 až 20 dB). Učiní uložené zvukové klipy hlasitější pro snadnější poslech. Neovlivňuje detekci. 0 dB znamená žádné zesílení.",
+        "normalization": "Normalizace zvuku",
+        "normalizationEnable": "Povolit normalizaci hlasitosti",
+        "normalizationHelp": "Automaticky upravit úrovně zvuku na vysílací standard EBU R128 pro konzistentní hlasitost přehrávání ve všech klipech.",
+        "normalizationDisabled": "Normalizace zvuku je vypnuta",
+        "targetLUFSLabel": "Cílová hlasitost (LUFS)",
+        "targetLUFSHelp": "Cílová integrovaná hlasitost v LUFS (Loudness Units relative to Full Scale). -23 LUFS je vysílací standard EBU R128. Rozsah: -40 až -10 LUFS.",
+        "loudnessRangeLabel": "Rozsah hlasitosti (LU)",
+        "loudnessRangeHelp": "Maximální variace hlasitosti v rámci klipu (0–20 LU). Nižší hodnoty vytvářejí konzistentnější hlasitost, ale mohou snížit dynamiku.",
+        "truePeakLabel": "Limit True Peak (dBTP)",
+        "truePeakHelp": "Maximální úroveň True Peak pro zabránění digitálnímu ořezání (clippingu) (-10 až 0 dBTP). -2 dBTP poskytuje bezpečnou rezervu pro většinu přehrávacích systémů.",
+        "normalizationNote": "Standard EBU R128",
+        "normalizationNoteDescription": "Normalizace zvuku se řídí vysílacím standardem EBU R128, čímž zajišťuje konzistentní úrovně přehrávání na různých zařízeních a zabraňuje ořezání.",
+        "fileSettings": "Nastavení souborů",
+        "pathLabel": "Složka s klipy",
+        "pathHelp": "Adresář, kam se budou ukládat zvukové klipy. Relativní cesty jsou vůči adresáři aplikace. Příklad: 'clips/' nebo '/var/audio/birds/'",
+        "typeLabel": "Formát zvuku",
+        "typeHelp": "Formát zvuku pro uložené klipy. WAV a FLAC jsou bezeztrátové (nejlepší kvalita, větší soubory). MP3, AAC a Opus jsou ztrátové (menší soubory, mírná ztráta kvality).",
+        "bitrateLabel": "Datový tok",
+        "bitrateHelp": "Datový tok komprese zvuku pro ztrátové formáty. Rozsah: {min}–{max} kbps. Vyšší hodnoty poskytují lepší kvalitu, ale větší soubory.",
+        "losslessNote": "Bezeztrátové formáty zachovávají původní kvalitu zvuku bez artefaktů komprese.",
+        "disabledInfo": "Povolte nahrávání klipů výše, abyste mohli konfigurovat nastavení klipů, formát souboru a možnosti úložiště."
+      },
+      "extendedCapture": {
+        "title": "Rozšířený záznam",
+        "description": "Nahrává delší zvukové klipy, když druh opakovaně zpívá, a vytváří jedinou kombinovanou nahrávku namísto mnoha krátkých klipů.",
+        "ramWarning": "Rozšířený záznam vyžaduje dodatečnou paměť RAM pro zvukové buffery. Nedoporučuje se pro zařízení s 512 MB RAM nebo méně (např. Raspberry Pi Zero).",
+        "enable": "Povolit rozšířený záznam",
+        "enableHelp": "Pokud je povoleno, opakované detekce nakonfigurovaných druhů jsou sloučeny do jediné delší nahrávky.",
+        "maxDurationLabel": "Maximální délka",
+        "maxDurationHelp": "Maximální délka klipu rozšířeného záznamu. Nahrávka roste s pokračujícími detekcemi až do tohoto limitu.",
+        "speciesListLabel": "Druhy pro rozšířený záznam",
+        "addSpeciesLabel": "Přidat druh",
+        "addSpeciesHelp": "Druhy, které spouštějí rozšířený záznam. Podporuje běžné názvy, vědecké názvy a shodu na úrovni rodu (např. „Strix“ zahrnuje všechny sovy rodu Strix).",
+        "addSpeciesButton": "Přidat",
+        "disabled": "Rozšířený záznam je vypnut"
+      },
+      "fileSettings": {
+        "title": "Nastavení souborů",
+        "description": "Konfigurace umístění úložiště a formátu zvuku pro uložené klipy.",
+        "pathLabel": "Složka s klipy",
+        "pathHelp": "Adresář, kam se budou ukládat zvukové klipy. Relativní cesty jsou vůči adresáři aplikace. Příklad: 'clips/' nebo '/var/audio/birds/'",
+        "typeLabel": "Formát zvuku",
+        "typeHelp": "Formát zvuku pro uložené klipy. WAV a FLAC jsou bezeztrátové (nejlepší kvalita, větší soubory). MP3, AAC a Opus jsou ztrátové (menší soubory, mírná ztráta kvality).",
+        "bitrateLabel": "Datový tok",
+        "bitrateHelp": "Datový tok komprese zvuku pro ztrátové formáty. Rozsah: {min}–{max} kbps. Vyšší hodnoty poskytují lepší kvalitu, ale větší soubory.",
+        "losslessNote": "Bezeztrátové formáty zachovávají původní kvalitu zvuku bez artefaktů komprese."
+      },
+      "audioNormalization": {
+        "title": "Normalizace zvuku",
+        "description": "Upravte úrovně zvuku pro konzistentní hlasitost přehrávání ve všech klipech.",
+        "enable": "Povolit normalizaci hlasitosti",
+        "enableHelp": "Automaticky upravit úrovně zvuku na vysílací standard EBU R128 pro konzistentní hlasitost přehrávání ve všech klipech.",
+        "disabled": "Normalizace zvuku je vypnuta",
+        "requiresRecording": "Pro použití normalizace zvuku povolte nahrávání klipů na kartě Nahrávání.",
+        "targetLUFSLabel": "Cílová hlasitost (LUFS)",
+        "targetLUFSHelp": "Cílová integrovaná hlasitost v LUFS (Loudness Units relative to Full Scale). -23 LUFS je vysílací standard EBU R128. Rozsah: -40 až -10 LUFS.",
+        "loudnessRangeLabel": "Rozsah hlasitosti (LU)",
+        "loudnessRangeHelp": "Maximální variace hlasitosti v rámci klipu (0–20 LU). Nižší hodnoty vytvářejí konzistentnější hlasitost, ale mohou snížit dynamiku.",
+        "truePeakLabel": "Limit True Peak (dBTP)",
+        "truePeakHelp": "Maximální úroveň True Peak pro zabránění digitálnímu ořezání (clippingu) (-10 až 0 dBTP). -2 dBTP poskytuje bezpečnou rezervu pro většinu přehrávacích systémů.",
+        "noteTitle": "Standard EBU R128",
+        "noteDescription": "Normalizace zvuku se řídí vysílacím standardem EBU R128, čímž zajišťuje konzistentní úrovně přehrávání na různých zařízeních a zabraňuje ořezání."
+      },
+      "audioClipRetention": {
+        "title": "Uchování zvukových klipů",
+        "description": "Konfigurace automatického čištění uložených zvukových klipů",
+        "policyLabel": "Pravidla uchování",
+        "policyHelp": "Vyberte, jak se mají zvukové klipy automaticky mazat. Žádná: ponechat všechny klipy. Stáří: smazat klipy starší než zadaný čas. Využití: smazat nejstarší klipy, když využití disku překročí limit.",
+        "maxAgeLabel": "Maximální stáří",
+        "maxAgeHelp": "Smazat zvukové klipy starší než toto trvání. Formát: číslo následované jednotkou (h=hodiny, d=dny, w=týdny, m=měsíce). Příklady: '7d' pro 7 dní, '4w' pro 4 týdny.",
+        "maxUsageLabel": "Maximální využití disku",
+        "maxUsageHelp": "Smazat nejstarší klipy, když adresář se zvukem využívá více než toto procento dostupného místa na disku.",
+        "minClipsLabel": "Minimální počet klipů na druh",
+        "minClipsHelp": "Vždy ponechat alespoň tento počet klipů pro každý druh ptáka bez ohledu na stáří nebo využití disku. Pomáhá zachovat vzácné nahrávky.",
+        "keepSpectrograms": "Ponechat obrázky spektrogramů",
+        "keepSpectrogramsHelp": "Ponechat obrázky spektrogramů i po smazání zvukových klipů. Spektrogramy zabírají méně místa a poskytují vizuální referenci.",
+        "policies": {
+          "none": "Žádná – ponechat vše",
+          "age": "Podle stáří",
+          "usage": "Podle využití disku"
+        },
+        "noRetentionTitle": "Všechny klipy ponechány",
+        "noRetentionDescription": "Zvukové klipy budou uchovávány po neomezenou dobu. Sledujte využití disku, abyste předešli problémům s úložištěm.",
+        "ageRetentionTitle": "Čištění podle stáří",
+        "ageRetentionDescription": "Klipy starší než zadané stáří budou automaticky smazány, přičemž se zachová minimální počet na druh.",
+        "usageRetentionTitle": "Čištění podle využití",
+        "usageRetentionDescription": "Když využití disku překročí prahovou hodnotu, budou nejstarší klipy mazány, dokud se využití nedostane v rámci limitů."
+      },
+      "formats": {
+        "wav": "WAV",
+        "flac": "FLAC",
+        "aac": "AAC",
+        "opus": "Opus",
+        "mp3": "MP3"
+      },
+      "transport": {
+        "tcp": "TCP",
+        "udp": "UDP"
+      },
+      "filterTypes": {
+        "lowpass": "Dolnopropustný filtr (Lowpass)",
+        "highpass": "Hornopropustný filtr (Highpass)",
+        "bandpass": "Pásmová propust (Bandpass)",
+        "bandstop": "Pásmová zádrž (Bandstop)"
+      },
+      "errors": {
+        "devicesLoadFailed": "Nepodařilo se načíst zvuková zařízení. Zkontrolujte oprávnění systému.",
+        "invalidBitrate": "Neplatná hodnota datového toku",
+        "invalidRetentionPolicy": "Neplatná pravidla uchování"
+      }
+    },
+    "security": {
+      "pageLabel": "Nastavení zabezpečení",
+      "baseUrlLabel": "Základní URL (Base URL)",
+      "baseUrlHelp": "Úplná externí URL pro nastavení reverzní proxy. Pokud je nastavena, použije se tato URL beze změny pro oznámení a OAuth přesměrování, přičemž se ignorují nastavení Host a AutoTLS.",
+      "baseUrlValidation": "Zadejte platnou URL začínající http:// nebo https:// a obsahující název hostitele",
+      "hostLabel": "Adresa hostitele (Host)",
+      "hostHelp": "Veřejný název hostitele nebo IP adresa vašeho serveru (např. birdnet.example.com). Vyžadováno pro přihlášení přes OAuth a TLS certifikáty. Pokud používáte reverzní proxy, použijte místo toho Base URL.",
+      "allowSubnetBypassLabel": "Povolit přístup z podsítě k obejití autentizace",
+      "allowedSubnetsLabel": "Povolené podsítě",
+      "allowedSubnetsHelp": "Povolené síťové rozsahy k obejití přihlášení (notace CIDR, seznam oddělený čárkami)",
+      "securityWarningTitle": "Bezpečnostní upozornění:",
+      "subnetWarningText": "Zařízení z těchto podsítí budou mít neomezený přístup. Zahrňte pouze důvěryhodné interní sítě.",
+      "httpsSettingsTitle": "Nastavení HTTPS",
+      "httpsSettingsDescription": "Zabezpečený přístup pomocí šifrování SSL/TLS",
+      "basicAuthTitle": "Základní autentizace (Basic Auth)",
+      "basicAuthDescription": "Zabezpečený přístup pomocí jednoduchého hesla",
+      "serverConfiguration": {
+        "title": "Konfigurace serveru",
+        "description": "Konfigurace nastavení HTTPS a SSL/TLS",
+        "autoTlsLabel": "Automatická správa SSL certifikátů (AutoTLS)",
+        "autoTlsRequirements": {
+          "title": "Požadavky AutoTLS:",
+          "domainRequired": "Vyžaduje se registrovaný název domény",
+          "domainPointing": "Doména musí směrovat na veřejnou IP adresu tohoto serveru",
+          "portsAccessible": "Porty 80 a 443 musí být přístupné z internetu"
+        }
+      },
+      "basicAuthentication": {
+        "title": "Základní autentizace",
+        "description": "Zabezpečený přístup pomocí jednoduchého hesla",
+        "enableLabel": "Povolit ověření heslem",
+        "disabled": "Ověření heslem je vypnuto",
+        "passwordLabel": "Heslo",
+        "passwordHelpText": "Omezit přístup k nastavení pomocí hesla."
+      },
+      "oauth": {
+        "title": "Externí autentizace",
+        "description": "Přihlášení pomocí externího poskytovatele identity nebo OIDC",
+        "form": {
+          "editTitle": "Upravit poskytovatele OAuth",
+          "addTitle": "Přidat poskytovatele OAuth",
+          "providerLabel": "Poskytovatel",
+          "providerHelpText": "Vyberte poskytovatele OAuth, kterého chcete nakonfigurovat",
+          "cancelButton": "Zrušit",
+          "saveButton": "Uložit"
+        },
+        "providers": {
+          "title": "Nakonfigurovaní poskytovatelé",
+          "addButton": "Přidat poskytovatele",
+          "enableToggle": "Přepnout stav povolení poskytovatele",
+          "editButton": "Upravit nastavení poskytovatele",
+          "deleteButton": "Odstranit poskytovatele",
+          "deleteConfirm": "Opravdu chcete odstranit poskytovatele OAuth {provider}?"
+        },
+        "hostRequiredWarning": "Adresa hostitele nebo Base URL není nakonfigurována",
+        "hostRequiredWarningDescription": "Přihlášení přes OAuth vyžaduje, aby byla na záložce Konfigurace serveru nastavena adresa hostitele nebo Base URL. Bez ní poskytovatelé OAuth nemohou vytvořit callback URL a přihlášení selže.",
+        "redirectUriNotConfigured": "Není nakonfigurováno – nastavte adresu hostitele nebo Base URL na záložce Konfigurace serveru",
+        "noProviders": "Žádní nakonfigurovaní poskytovatelé OAuth",
+        "noProvidersDescription": "Přidejte poskytovatele pro povolení přihlášení přes Google, GitHub, Microsoft, LINE, Kakao nebo vlastního poskytovatele OIDC.",
+        "enableProviderLabel": "Povolit tohoto poskytovatele",
+        "getCredentialsLabel": "Získejte své přihlašovací údaje od {provider}",
+        "redirectUriTitle": "URI přesměrování:",
+        "clientIdLabel": "Client ID",
+        "clientIdHelpText": "OAuth 2.0 Client ID z vývojářské konzole vašeho poskytovatele",
+        "clientSecretLabel": "Client Secret",
+        "clientSecretHelpText": "OAuth 2.0 Client Secret z vývojářské konzole vašeho poskytovatele",
+        "userIdLabel": "ID uživatele (volitelné)",
+        "userIdHelpText": "Omezit přístup na konkrétní uživatelský účet podle e-mailu nebo ID",
+        "google": {
+          "title": "Google OAuth",
+          "enableLabel": "Povolit přihlášení OAuth2 přes Google",
+          "redirectUriTitle": "Redirect URI pro Google Cloud Console:",
+          "getCredentialsLabel": "Získejte své přihlašovací údaje z Google Cloud Console",
+          "clientIdLabel": "Client ID",
+          "clientIdHelpText": "OAuth 2.0 Client ID získané z Google Cloud Console při nastavování pověření OAuth.",
+          "clientSecretLabel": "Client Secret",
+          "clientSecretHelpText": "OAuth 2.0 Client Secret získané z Google Cloud Console při nastavování pověření OAuth.",
+          "userIdLabel": "ID uživatele"
+        },
+        "github": {
+          "title": "GitHub OAuth",
+          "enableLabel": "Povolit přihlášení OAuth2 přes GitHub",
+          "redirectUriTitle": "Redirect URI pro GitHub Developer Settings:",
+          "getCredentialsLabel": "Získejte své přihlašovací údaje z GitHub Developer Settings",
+          "clientIdLabel": "Client ID",
+          "clientIdHelpText": "OAuth 2.0 Client ID získané z GitHub Developer Settings při nastavování pověření OAuth.",
+          "clientSecretLabel": "Client Secret",
+          "clientSecretHelpText": "OAuth 2.0 Client Secret získané z GitHub Developer Settings při nastavování pověření OAuth.",
+          "userIdLabel": "ID uživatele"
+        },
+        "microsoft": {
+          "title": "Účet Microsoft",
+          "enableLabel": "Povolit přihlášení OAuth2 přes účet Microsoft",
+          "redirectUriTitle": "Redirect URI pro Azure App Registration:",
+          "getCredentialsLabel": "Získejte své přihlašovací údaje z Azure Portal",
+          "clientIdLabel": "Client ID",
+          "clientIdHelpText": "Application (client) ID získané z Azure App Registration.",
+          "clientSecretLabel": "Client Secret",
+          "clientSecretHelpText": "Hodnota client secret získaná z Azure App Registration.",
+          "userIdLabel": "ID uživatele"
+        },
+        "line": {
+          "title": "Přihlášení LINE",
+          "enableLabel": "Povolit přihlášení OAuth2 přes LINE",
+          "redirectUriTitle": "Redirect URI pro LINE Developers Console:",
+          "getCredentialsLabel": "Získejte své přihlašovací údaje z LINE Developers Console",
+          "clientIdLabel": "Channel ID",
+          "clientIdHelpText": "Channel ID získané z LINE Developers Console při nastavování LINE Login.",
+          "clientSecretLabel": "Channel Secret",
+          "clientSecretHelpText": "Channel Secret získané z LINE Developers Console při nastavování LINE Login.",
+          "userIdLabel": "ID uživatele"
+        },
+        "kakao": {
+          "title": "Přihlášení Kakao",
+          "enableLabel": "Povolit přihlášení OAuth2 přes Kakao",
+          "redirectUriTitle": "Redirect URI pro Kakao Developers Console:",
+          "getCredentialsLabel": "Získejte své přihlašovací údaje z Kakao Developers Console",
+          "clientIdLabel": "REST API Key",
+          "clientIdHelpText": "REST API Key získaný z Kakao Developers Console při nastavování Kakao Login.",
+          "clientSecretLabel": "Client Secret",
+          "clientSecretHelpText": "Client Secret získaný z Kakao Developers Console při nastavování Kakao Login.",
+          "userIdLabel": "ID uživatele"
+        },
+        "oidc": {
+          "title": "Poskytovatel OIDC",
+          "enableLabel": "Povolit ověření OIDC",
+          "redirectUriTitle": "URI přesměrování",
+          "getCredentialsLabel": "Nakonfigurujte ve svém poskytovateli identity",
+          "clientIdLabel": "Client ID",
+          "clientIdHelpText": "Client ID z vašeho poskytovatele identity OIDC",
+          "clientSecretLabel": "Client Secret",
+          "clientSecretHelpText": "Client Secret z vašeho poskytovatele identity OIDC",
+          "userIdLabel": "Povolený uživatel (e-mail nebo sub claim)",
+          "issuerUrlLabel": "URL vydavatele",
+          "issuerUrlHelpText": "URL vydavatele vašeho poskytovatele identity OpenID Connect (např. https://auth.example.com)",
+          "issuerUrlPlaceholder": "https://auth.example.com",
+          "issuerUrlRequired": "URL vydavatele je u poskytovatelů OIDC povinná",
+          "issuerUrlInvalid": "URL vydavatele musí být platná HTTP nebo HTTPS URL",
+          "scopesLabel": "Rozsahy (scopes)",
+          "scopesHelpText": "Seznam OIDC rozsahů oddělených čárkou (výchozí: openid, profile, email)",
+          "scopesPlaceholder": "openid, profile, email"
+        }
+      },
+      "bypassAuthentication": {
+        "title": "Obejít autentizaci",
+        "description": "Povolit přístup k nastavení bez autentizace",
+        "disabled": "Obcházení podsítěmi je vypnuto"
+      },
+      "exceptions": {
+        "title": "Výjimky"
+      },
+      "publicAccess": {
+        "title": "Veřejný přístup",
+        "description": "Umožnit přístup ke konkrétním funkcím bez ověření.",
+        "liveAudioLabel": "Povolit veřejné přehrávání živého zvuku",
+        "liveAudioHelp": "Pokud je povoleno, kdokoli může poslouchat živé audio streamy bez přihlášení. Nastavení a mazání nadále vyžaduje ověření.",
+        "warningText": "Povolením funkcí veřejného přístupu je zpřístupníte komukoli, kdo se může připojit k tomuto serveru. Povolte pouze pokud důvěřujete svému síťovému prostředí."
+      },
+      "placeholders": {
+        "baseUrl": "https://birdnet.example.com:5500",
+        "host": "Například localhost:8080 nebo example.domain.com",
+        "allowedUsers": "Zadejte jeden nebo více e-mailů povolených uživatelů",
+        "subnet": "Zadejte CIDR podsíť (např. 192.168.1.0/24)"
+      },
+      "terminal": {
+        "title": "Terminál v prohlížeči",
+        "enableLabel": "Povolit terminál v prohlížeči",
+        "enableHelpText": "Umožňuje přístup k shellu hostitelského systému z libovolné ověřené relace prohlížeče. Pokud se nepoužívá, zakažte.",
+        "securityWarning": "Povolením terminálu v prohlížeči poskytujete přímý přístup k shellu hostitelského operačního systému. Kdokoli s platnými přihlašovacími údaji může spouštět libovolné příkazy. Tuto funkci povolte pouze v důvěryhodných sítích. Pokud ji nepotřebujete, zakažte ji.",
+        "confirmEnable": "Opravdu chcete povolit terminál v prohlížeči? Tím udělíte přístup k shellu hostitelského systému. Dělejte to pouze v důvěryhodných sítích."
+      },
+      "tls": {
+        "title": "TLS / HTTPS",
+        "description": "Konfigurace šifrování TLS/HTTPS pro bezpečná připojení",
+        "modeLabel": "Režim TLS",
+        "modeNone": "Žádný (HTTP)",
+        "modeLetsEncrypt": "Let's Encrypt",
+        "modeManual": "Manuální certifikát",
+        "modeSelfSigned": "Self-signed",
+        "modeNoneDescription": "Prosté HTTP bez šifrování",
+        "modeAutoTLSDescription": "Automatický certifikát přes Let's Encrypt",
+        "modeManualDescription": "Nahrát vlastní certifikát a klíč",
+        "modeSelfSignedDescription": "Vygenerovat self-signed certifikát",
+        "portLabel": "Port HTTPS",
+        "portHelpText": "Port pro připojení HTTPS (výchozí: 8443)",
+        "redirectToHttps": "Přesměrovat HTTP na HTTPS",
+        "autoTLSRequirements": "Vyžaduje dostupnost portů 80 a 443. Na Linuxu proces potřebuje root nebo schopnost CAP_NET_BIND_SERVICE.",
+        "validityLabel": "Platnost certifikátu",
+        "validityHelpText": "Jak dlouho má být certifikát platný",
+        "validity365d": "1 rok",
+        "validity730d": "2 roky",
+        "generateButton": "Vygenerovat certifikát",
+        "regenerateButton": "Regenerovat certifikát",
+        "generating": "Generování...",
+        "certificateLabel": "Certifikát (PEM)",
+        "privateKeyLabel": "Soukromý klíč (PEM)",
+        "caCertificateLabel": "CA certifikát (PEM, volitelný)",
+        "uploadButton": "Nahrát certifikát",
+        "uploading": "Nahrávání...",
+        "browseFile": "Procházet...",
+        "plaintextWarning": "Upozornění: Váš soukromý klíč bude přenášen v nešifrované podobě přes HTTP. Certifikáty nahrávejte pouze přes důvěryhodnou síť nebo localhost.",
+        "certificateInstalled": "Nainstalovaný certifikát",
+        "subject": "Předmět",
+        "issuer": "Vydavatel",
+        "validFrom": "Platný od",
+        "validUntil": "Platný do",
+        "daysRemaining": "Zbývající dny",
+        "sans": "Alternativní jména subjektu",
+        "fingerprint": "Otisk",
+        "expiryWarning": "Platnost certifikátu brzy vyprší",
+        "loading": "Načítání informací o certifikátu...",
+        "loadError": "Nepodařilo se načíst informace o certifikátu",
+        "generateSuccess": "Self-signed certifikát byl úspěšně vygenerován",
+        "generateError": "Nepodařilo se vygenerovat certifikát",
+        "uploadSuccess": "Certifikát byl úspěšně nahrán",
+        "uploadError": "Nepodařilo se nahrát certifikát",
+        "deleteSuccess": "Certifikát byl úspěšně odstraněn",
+        "deleteError": "Nepodařilo se odstranit certifikát",
+        "removeCertificate": "Odstranit certifikát",
+        "deleteConfirm": "Opravdu chcete odstranit nainstalovaný TLS certifikát? Režim TLS bude resetován na Žádný.",
+        "restartRequired": "Změny TLS vyžadují restart serveru, aby se projevily.",
+        "noCertificate": "Není nainstalován žádný certifikát",
+        "validity1825d": "5 let",
+        "autoTLSHostRequired": "Pro Let’s Encrypt je vyžadován název hostitele. Zadejte svůj veřejný název domény do pole Host výše.",
+        "autoTLSNoIP": "Let’s Encrypt vyžaduje název domény, nikoli IP adresu. Zadejte veřejnou doménu jako birds.example.com.",
+        "autoTLSNeedsFQDN": "Let’s Encrypt vyžaduje plně kvalifikovaný název domény (např. birds.example.com), nikoli holý název hostitele.",
+        "autoTLSNoLocalhost": "Let’s Encrypt nemůže vydávat certifikáty pro localhost.",
+        "autoTLSPrivateTLD": "Let’s Encrypt nemůže vydávat certifikáty pro soukromé domény ({tld} není veřejně rozeznatelná).",
+        "downloadCertificate": "Stáhnout certifikát",
+        "downloadCertificateHelp": "Nainstalujte tento certifikát do úložiště důvěryhodných certifikátů vašeho operačního systému, abyste se vyhnuli bezpečnostním upozorněním prohlížeče.",
+        "fileReadError": "Nepodařilo se přečíst vybraný soubor"
+      }
+    },
+    "species": {
+      "pageLabel": "Nastavení druhů",
+      "saveError": "Uložení konfigurace pro \"{species}\" selhalo. Zkuste to prosím znovu.",
+      "configUpdated": "Konfigurace pro \"{species}\" byla aktualizována",
+      "configAdded": "Konfigurace pro \"{species}\" byla přidána",
+      "duplicateConfigError": "Druh \"{species}\" již má konfiguraci. Zvolte prosím jiný název.",
+      "activeSpecies": {
+        "title": "Aktivní druhy",
+        "tabLabel": "Aktivní",
+        "description": "Druhy, které budou detekovány na základě vaší aktuální polohy a nastavení filtru",
+        "stats": {
+          "species": "Druhy",
+          "location": "Poloha",
+          "threshold": "Práh",
+          "updated": "Aktualizováno",
+          "justNow": "Právě teď",
+          "minutesAgo": "před {count}m",
+          "hoursAgo": "před {count}h"
+        },
+        "search": {
+          "placeholder": "Hledat druhy..."
+        },
+        "badges": {
+          "included": "Zahrnuto",
+          "configured": "Nakonfigurováno"
+        },
+        "empty": {
+          "title": "Nebyly nalezeny žádné druhy",
+          "description": "Nakonfigurujte svou polohu v Hlavních nastaveních, abyste viděli dostupné druhy"
+        },
+        "noResults": "Žádné druhy neodpovídají vašemu vyhledávání",
+        "infoNote": "Tento seznam je založen na vaší poloze a prahu filtru rozsahu. Ručně zahrnuté druhy jsou vždy přidány.",
+        "retry": "Zkusit znovu",
+        "expand": "Rozbalit seznam",
+        "collapse": "Sbalit seznam",
+        "downloadCsv": "Stáhnout CSV",
+        "errors": {
+          "loadFailed": "Nepodařilo se načíst seznam aktivních druhů"
+        },
+        "locationNotConfigured": {
+          "title": "Poloha není nakonfigurována",
+          "description": "Nastavte svou polohu v Hlavních nastaveních, abyste viděli druhy dostupné ve vaší oblasti. Filtr rozsahu používá vaši polohu k určení, které druhy se pravděpodobně vyskytují v okolí.",
+          "action": "Nakonfigurovat polohu"
+        },
+        "columns": {
+          "commonName": "Název",
+          "scientificName": "Vědecký název",
+          "score": "Skóre",
+          "status": "Stav"
+        }
+      },
+      "alwaysInclude": {
+        "title": "Vždy zahrnout druhy",
+        "tabLabel": "Zahrnout",
+        "description": "Druhy v tomto seznamu budou vždy zahrnuty v rozsahu detekovaných druhů",
+        "noSpeciesMessage": "Do seznamu zahrnutých druhů nebyly přidány žádné druhy"
+      },
+      "alwaysExclude": {
+        "title": "Vždy vyloučit druhy",
+        "tabLabel": "Vyloučit",
+        "description": "Druhy v tomto seznamu budou vždy vyloučeny z detekce",
+        "noSpeciesMessage": "Do seznamu vyloučených druhů nebyly přidány žádné druhy"
+      },
+      "customConfiguration": {
+        "title": "Vlastní konfigurace druhů",
+        "tabLabel": "Vlastní",
+        "description": "Hodnoty prahu specifické pro druhy, intervaly detekce a akce",
+        "helpText": {
+          "intro": "Nakonfigurujte nastavení specifická pro druhy:",
+          "threshold": "Práh: Minimální skóre spolehlivosti (0–1) vyžadované pro detekci",
+          "interval": "Interval: Minimální čas v sekundách mezi detekcemi stejného druhu (0 = použít globální výchozí hodnotu)",
+          "actions": "Akce: Vlastní příkazy, které se mají provést při detekci tohoto druhu"
+        },
+        "columnHeaders": {
+          "species": "Druh",
+          "settings": "Nastavení",
+          "actions": "Akce"
+        },
+        "badges": {
+          "threshold": "Práh: {value}",
+          "interval": "Interval: {value}s",
+          "customAction": "Vlastní akce",
+          "executeDefaults": "+Výchozí"
+        },
+        "dropdown": {
+          "editConfig": "Upravit konfiguraci",
+          "addAction": "Přidat akci",
+          "remove": "Odstranit"
+        },
+        "labels": {
+          "threshold": "Práh",
+          "interval": "Interval",
+          "intervalSeconds": "Interval (s)",
+          "addButton": "Přidat"
+        },
+        "noConfigurationsMessage": "Nebyly přidány žádné vlastní konfigurace druhů",
+        "addForm": {
+          "speciesPlaceholder": "Název druhu",
+          "thresholdPlaceholder": "0.5",
+          "intervalPlaceholder": "0"
+        },
+        "addConfiguration": "Přidat konfiguraci",
+        "newConfiguration": "Nová konfigurace",
+        "editing": "Upravuje se: {species}",
+        "configuredCount": "{count} nakonfigurováno",
+        "searchPlaceholder": "Pište pro vyhledávání...",
+        "saving": "Ukládá se...",
+        "save": "Uložit",
+        "cancel": "Zrušit",
+        "configureActions": "Nakonfigurovat akce",
+        "actionsConfigured": "Nakonfigurováno",
+        "list": {
+          "threshold": "Práh:",
+          "interval": "Interval:",
+          "intervalNone": "Žádný",
+          "actionBadge": "Akce",
+          "editTitle": "Upravit konfiguraci",
+          "removeTitle": "Odstranit konfiguraci"
+        },
+        "emptyState": {
+          "title": "Zatím žádné konfigurace.",
+          "description": "Klikněte na \"Přidat konfiguraci\" pro přizpůsobení nastavení detekce druhů."
+        }
+      },
+      "synonyms": {
+        "tabLabel": "Synonyma",
+        "description": "Přiřaďte vědecké názvy BirdNET k jejich aktualizovaným ekvivalentům v novější taxonomii. Používá se pouze jako záložní možnost při vyhledávání fotografií ptáků na Wikipedii a AviCommons; nepřejmenovává druhy v detekcích ani na nástěnce.",
+        "helpText": "Chcete-li změnit, pod jakým názvem se druh zobrazuje v rozhraní, upravte soubor štítků BirdNET (nastavení \"Cesta ke štítkům\" v Hlavních nastaveních).",
+        "birdnetName": "Název BirdNET",
+        "updatedName": "Aktualizovaný vědecký název",
+        "addButton": "Přidat synonymum",
+        "emptyState": "Žádná taxonomická synonyma nejsou nakonfigurována",
+        "errors": {
+          "unknownSpecies": "Druh nebyl nalezen ve štítcích BirdNET",
+          "duplicateKey": "Pro tento druh již synonymum existuje",
+          "emptyUpdatedName": "Aktualizovaný název je povinný"
+        }
+      },
+      "actionsModal": {
+        "title": "Akce pro {species}",
+        "actionType": {
+          "label": "Typ akce",
+          "executeCommand": "Provést příkaz",
+          "onlySupported": "V současnosti jsou podporovány pouze akce Provést příkaz"
+        },
+        "command": {
+          "label": "Příkaz",
+          "helpText": "Uveďte úplnou cestu k příkazu nebo skriptu, který chcete provést"
+        },
+        "parameters": {
+          "label": "Parametry",
+          "helpText": "Tyto hodnoty budou předány vašemu příkazu v uvedeném pořadí",
+          "placeholder": "Klikněte na tlačítka níže pro přidání parametrů nebo zadejte ručně",
+          "tooltip": "Použijte tlačítka níže nebo zadejte přímo (oddělené čárkou)",
+          "availableTitle": "Dostupné parametry",
+          "buttons": {
+            "commonName": "CommonName",
+            "scientificName": "ScientificName",
+            "confidence": "Confidence",
+            "time": "Time",
+            "source": "Source",
+            "clearParameters": "Vymazat parametry"
+          }
+        },
+        "executeDefaults": {
+          "label": "Spustit také výchozí akce (uložení do databáze, oznámení atd.)",
+          "helpText": "Pokud je povoleno, spustí se jak vaše vlastní akce, tak výchozí systémové akce. Pokud je zakázáno, provede se pouze vaše vlastní akce."
+        }
+      },
+      "add": "Přidat",
+      "remove": "Odstranit",
+      "suggestions": "Návrhy druhů",
+      "addSpeciesToInclude": "Přidat druh k zahrnutí",
+      "addSpeciesToIncludeLabel": "Přidat nový druh k zahrnutí",
+      "addSpeciesToExclude": "Přidat druh k vyloučení",
+      "addSpeciesToExcludeLabel": "Přidat nový druh k vyloučení",
+      "commandPathPlaceholder": "/cesta/k/vasemu/prikazu",
+      "parametersPlaceholder": "Parametry se zobrazí zde",
+      "errors": {
+        "speciesLoadFailed": "Nepodařilo se načíst seznam druhů. Zkuste to prosím znovu."
+      },
+      "tracking": {
+        "title": "Sledování druhů",
+        "tabLabel": "Sledování",
+        "description": "Konfigurace sledování nových detekcí druhů na základě časových období",
+        "enabled": {
+          "label": "Povolit sledování druhů",
+          "helpText": "Pokud je povoleno, systém sleduje nové detekce druhů a může posílat oznámení"
+        },
+        "newSpeciesWindowDays": {
+          "label": "Okno pro nové druhy (dny)",
+          "helpText": "Počet dní, po které je druh považován za „nový“ po první detekci (1–365)"
+        },
+        "syncIntervalMinutes": {
+          "label": "Interval synchronizace (minuty)",
+          "helpText": "Jak často synchronizovat data sledování s databází (1–1440)"
+        },
+        "notificationSuppressionHours": {
+          "label": "Potlačení oznámení (hodiny)",
+          "helpText": "Hodiny pro potlačení duplicitních oznámení pro tentýž druh (0–8760)"
+        },
+        "yearly": {
+          "title": "Roční sledování",
+          "description": "Sledovat první přílety druhů každý rok",
+          "enabled": {
+            "label": "Povolit roční sledování",
+            "helpText": "Sledovat a upozornit, když je druh detekován poprvé v daném roce"
+          },
+          "resetMonth": {
+            "label": "Měsíc resetu",
+            "helpText": "Měsíc, kdy se resetuje roční sledování (1–12)"
+          },
+          "resetDay": {
+            "label": "Den resetu",
+            "helpText": "Den v měsíci, kdy se resetuje roční sledování"
+          },
+          "windowDays": {
+            "label": "Okno (dny)",
+            "helpText": "Dny pro zobrazení indikátoru „nový tento rok“ (1–365)"
+          }
+        },
+        "seasonal": {
+          "title": "Sezónní sledování",
+          "description": "Sledovat první přílety druhů každou sezónu",
+          "enabled": {
+            "label": "Povolit sezónní sledování",
+            "helpText": "Sledovat a upozornit, když je druh detekován poprvé v dané sezóně"
+          },
+          "windowDays": {
+            "label": "Okno (dny)",
+            "helpText": "Dny pro zobrazení indikátoru „nový tuto sezónu“ (1–365)"
+          },
+          "seasons": {
+            "title": "Definice sezón",
+            "description": "Definujte, kdy začíná každá sezóna. Sezóny se automaticky přizpůsobují podle polokoule vaší polohy.",
+            "spring": "Jaro",
+            "summer": "Léto",
+            "fall": "Podzim",
+            "winter": "Zima",
+            "wet1": "Období dešťů 1",
+            "dry1": "Období sucha 1",
+            "wet2": "Období dešťů 2",
+            "dry2": "Období sucha 2",
+            "startMonth": "Měsíc začátku",
+            "startDay": "Den začátku",
+            "hemisphereNote": "Data sezón jsou automaticky konfigurována podle vaší zeměpisné šířky. Severní polokoule používá standardní sezóny, jižní polokoule má posunutá data a rovníkové oblasti používají období dešťů/sucha."
+          }
+        },
+        "months": {
+          "january": "Leden",
+          "february": "Únor",
+          "march": "Březen",
+          "april": "Duben",
+          "may": "Květen",
+          "june": "Červen",
+          "july": "Červenec",
+          "august": "Srpen",
+          "september": "Září",
+          "october": "Říjen",
+          "november": "Listopad",
+          "december": "Prosinec"
+        },
+        "units": {
+          "days": "dny",
+          "min": "min",
+          "hours": "hod"
+        }
+      },
+      "dynamicThreshold": {
+        "tabLabel": "Naučené",
+        "title": "Naučené prahy",
+        "description": "Tato stránka zobrazuje runtime data dynamického prahu. Pokud je povolen v Hlavních nastaveních → Detekce, prahy se automaticky upravují na základě více detekcí s vysokou spolehlivostí. Druhy zde zobrazené se považují za existující na tomto místě.",
+        "stats": {
+          "active": "Aktivní",
+          "atMinimum": "Na minimu",
+          "minThreshold": "Min. práh",
+          "validityPeriod": "Období platnosti"
+        },
+        "header": {
+          "species": "Druh",
+          "threshold": "Práh",
+          "expires": "Vyprší"
+        },
+        "searchPlaceholder": "Hledat druhy...",
+        "threshold": "Práh",
+        "level": "Úroveň",
+        "expires": "Vyprší",
+        "expired": "Vypršelo",
+        "confidence": "Spolehlivost",
+        "requiredConfidence": "Vyžadovaná spolehlivost",
+        "resetAll": "Resetovat vše",
+        "resetSpecies": "Resetovat práh pro tento druh",
+        "noEvents": "Žádná historie změn prahu",
+        "changeReason": {
+          "highConfidence": "Detekce s vysokou spolehlivostí",
+          "expiry": "Platnost prahu vypršela",
+          "manualReset": "Ruční reset"
+        },
+        "note": "Detekce s vysokou spolehlivostí potvrzují, které druhy na tomto místě existují. Po více shodách s vysokou spolehlivostí se práh detekce bezpečně sníží, aby se zachytilo více volání bez výrazného rizika falešně pozitivních výsledků. Prahy se automaticky resetují po uplynutí nakonfigurovaného období platnosti.",
+        "empty": {
+          "title": "Žádné naučené prahy",
+          "description": "Detekce s vysokou spolehlivostí automaticky vytvoří naučené prahy pro druhy"
+        },
+        "resetAllConfirm": {
+          "title": "Resetovat všechny prahy",
+          "message": "Tímto se resetuje všech {count} naučených prahů. Druhy budou muset být znovu detekovány s vysokou spolehlivostí, aby se jejich prahy snížily."
+        },
+        "loadError": "Nepodařilo se načíst dynamické prahy",
+        "resetSuccess": "Práh resetován pro druh {species}",
+        "resetError": "Nepodařilo se resetovat práh",
+        "resetAllSuccess": "Resetováno {count} prahů",
+        "resetAllError": "Nepodařilo se resetovat prahy",
+        "expand": "Zobrazit historii událostí",
+        "collapse": "Skrýt historii událostí"
+      }
+    },
+    "database": {
+      "sqlitePlaceholder": "Zadejte cestu k databázi SQLite",
+      "mysqlHostPlaceholder": "Zadejte hostitele MySQL",
+      "mysqlUsernamePlaceholder": "Zadejte uživatelské jméno MySQL"
+    },
+    "alerts": {
+      "sections": {
+        "history": {
+          "title": "Historie upozornění",
+          "description": "Zobrazte předchozí události upozornění a jejich výsledky."
+        }
+      },
+      "filters": {
+        "objectType": "Typ objektu",
+        "status": "Stav",
+        "allTypes": "Všechny typy",
+        "allStates": "Všechny stavy",
+        "enabled": "Povoleno",
+        "disabled": "Zakázáno"
+      },
+      "builtIn": "Vestavěné",
+      "enabled": "Povoleno",
+      "disabled": "Zakázáno",
+      "trigger": "Spouštěč",
+      "conditions": "Podmínky",
+      "actions": "Akce",
+      "cooldown": "Doba čekání",
+      "noConditions": "Žádné podmínky",
+      "noActions": "Žádné akce",
+      "noRules": "Nejsou nakonfigurována žádná pravidla upozornění.",
+      "noMatchingRules": "Žádná pravidla neodpovídají aktuálním filtrům.",
+      "noHistory": "Žádná historie upozornění.",
+      "confirmDelete": "Opravdu chcete smazat pravidlo \"{name}\"?",
+      "newRule": "Nové pravidlo",
+      "resetDefaults": "Obnovit výchozí",
+      "resetting": "Obnovování...",
+      "clearHistory": "Vymazat historii",
+      "clearing": "Mazání...",
+      "historyCount": "{total} záznamů celkem",
+      "actionsExecuted": "Vykonané akce",
+      "actionLabels": {
+        "edit": "Upravit pravidlo",
+        "enable": "Povolit pravidlo",
+        "disable": "Zakázat pravidlo",
+        "test": "Otestovat pravidlo",
+        "delete": "Smazat pravidlo"
+      },
+      "status": {
+        "enabled": "Pravidlo povoleno",
+        "disabled": "Pravidlo zakázáno",
+        "deleted": "Pravidlo smazáno",
+        "testFired": "Testovací upozornění odesláno",
+        "defaultsReset": "Výchozí obnoveny",
+        "historyCleared": "Historie vymazána",
+        "created": "Pravidlo vytvořeno",
+        "updated": "Pravidlo aktualizováno",
+        "exported": "Pravidla exportována",
+        "imported": "Importováno {imported} z {total} pravidel"
+      },
+      "errors": {
+        "loadFailed": "Nepodařilo se načíst pravidla upozornění",
+        "historyFailed": "Nepodařilo se načíst historii upozornění",
+        "toggleFailed": "Nepodařilo se přepnout pravidlo",
+        "deleteFailed": "Nepodařilo se smazat pravidlo",
+        "testFailed": "Nepodařilo se otestovat pravidlo",
+        "resetFailed": "Nepodařilo se obnovit výchozí",
+        "clearHistoryFailed": "Nepodařilo se vymazat historii",
+        "saveFailed": "Nepodařilo se uložit pravidlo",
+        "exportFailed": "Nepodařilo se exportovat pravidla",
+        "importFailed": "Nepodařilo se importovat pravidla",
+        "schemaLoadFailed": "Nepodařilo se načíst schéma upozornění. Obnovte stránku."
+      },
+      "editor": {
+        "createTitle": "Vytvořit pravidlo upozornění",
+        "editTitle": "Upravit pravidlo upozornění",
+        "name": "Název",
+        "namePlaceholder": "Zadejte název pravidla",
+        "description": "Popis",
+        "descriptionPlaceholder": "Volitelný popis",
+        "enabled": "Povoleno",
+        "triggerSection": "Spouštěč",
+        "objectType": "Typ objektu",
+        "triggerType": "Typ spouštěče",
+        "triggerEvent": "Událost",
+        "triggerMetric": "Metrika",
+        "event": "Událost",
+        "metric": "Metrika",
+        "conditionsSection": "Podmínky",
+        "property": "Vlastnost",
+        "operator": "Operátor",
+        "value": "Hodnota",
+        "valuePlaceholder": "Zadejte hodnotu",
+        "duration": "Trvání (s)",
+        "addCondition": "Přidat podmínku",
+        "removeCondition": "Odebrat podmínku",
+        "actionsSection": "Akce",
+        "actionBell": "Upozornění v aplikaci",
+        "actionPush": "Push upozornění",
+        "optionsSection": "Možnosti",
+        "cooldownSeconds": "Doba čekání (sekundy)",
+        "templateTitle": "Šablona titulku",
+        "templateTitlePlaceholder": "Ponechte prázdné pro výchozí",
+        "templateMessage": "Šablona zprávy",
+        "templateMessagePlaceholder": "Ponechte prázdné pro výchozí",
+        "noConditionsEvent": "Žádné podmínky — pravidlo se spustí při každé události",
+        "noConditionsMetric": "Žádné podmínky — pravidlo se spustí při každé aktualizaci metriky",
+        "eventsCount": "událostí",
+        "metricsCount": "metrik",
+        "durationFor": "po dobu",
+        "durationSec": "s"
+      },
+      "export": "Exportovat",
+      "import": "Importovat",
+      "exporting": "Exportování...",
+      "importing": "Importování...",
+      "schema": {
+        "objectTypes": {
+          "stream": "Audio stream",
+          "detection": "Detekce",
+          "application": "Aplikace",
+          "integration": "Integrace",
+          "device": "Zařízení",
+          "system": "Systém"
+        },
+        "events": {
+          "stream_connected": "Stream připojen",
+          "stream_disconnected": "Stream odpojen",
+          "stream_error": "Chyba streamu",
+          "detection_new_species": "Detekován nový druh",
+          "detection_occurred": "Proběhla detekce",
+          "application_started": "Aplikace spuštěna",
+          "application_stopped": "Aplikace zastavena",
+          "integration_birdweather_failed": "Nahrání do BirdWeather selhalo",
+          "integration_mqtt_connected": "MQTT připojeno",
+          "integration_mqtt_disconnected": "MQTT odpojeno",
+          "integration_mqtt_publish_failed": "Publikování MQTT selhalo",
+          "device_started": "Zařízení spuštěno",
+          "device_stopped": "Zařízení zastaveno",
+          "device_error": "Chyba zařízení"
+        },
+        "metrics": {
+          "system_cpu_usage": "Využití CPU",
+          "system_memory_usage": "Využití paměti",
+          "system_disk_usage": "Využití disku"
+        },
+        "properties": {
+          "value": "Hodnota",
+          "species_name": "Název druhu",
+          "scientific_name": "Vědecký název",
+          "confidence": "Spolehlivost",
+          "location": "Poloha",
+          "stream_name": "Název streamu",
+          "stream_url": "URL streamu",
+          "device_name": "Název zařízení",
+          "error": "Chybová zpráva",
+          "broker": "Broker"
+        },
+        "operators": {
+          "is": "je",
+          "is_not": "není",
+          "contains": "obsahuje",
+          "not_contains": "neobsahuje",
+          "greater_than": "větší než",
+          "less_than": "menší než",
+          "greater_or_equal": "větší nebo rovno",
+          "less_or_equal": "menší nebo rovno"
+        }
+      },
+      "v2Required": "Pravidla upozornění vyžadují aktualizované schéma databáze. Databázi můžete aktualizovat na",
+      "v2RequiredLink": "stránce Databáze v sekci Systém.",
+      "builtInRules": {
+        "newSpecies": {
+          "name": "Detekován nový druh",
+          "description": "Upozorní, když je druh detekován poprvé"
+        },
+        "streamDisconnected": {
+          "name": "Audio stream odpojen",
+          "description": "Upozorní, když RTSP nebo audio stream ztratí spojení"
+        },
+        "streamError": {
+          "name": "Chyba audio streamu",
+          "description": "Upozorní, když audio stream narazí na chybu"
+        },
+        "deviceError": {
+          "name": "Chyba audio zařízení",
+          "description": "Upozorní, když lokální zařízení pro záznam zvuku narazí na chybu"
+        },
+        "highCpu": {
+          "name": "Vysoké využití CPU",
+          "description": "Upozorní, když využití CPU překročí 90 % po dobu 5 minut"
+        },
+        "highMemory": {
+          "name": "Vysoké využití paměti",
+          "description": "Upozorní, když využití paměti překročí 90 % po dobu 5 minut"
+        },
+        "lowDisk": {
+          "name": "Málo místa na disku",
+          "description": "Upozorní, když využití disku překročí 85 % po dobu 5 minut"
+        },
+        "mqttDisconnected": {
+          "name": "MQTT odpojeno",
+          "description": "Upozorní, když dojde ke ztrátě spojení s MQTT brokerem"
+        },
+        "mqttPublishFailed": {
+          "name": "Publikování MQTT selhalo",
+          "description": "Upozorní, když selže publikování zprávy MQTT"
+        },
+        "birdWeatherFailed": {
+          "name": "Nahrání do BirdWeather selhalo",
+          "description": "Upozorní, když selže nahrávání do BirdWeather"
+        }
+      }
+    },
+    "appearance": {
+      "colorScheme": "Barevné schéma",
+      "colorSchemeDescription": "Vyberte barevné schéma pro rozhraní",
+      "schemeBlue": "Modré",
+      "schemeForest": "Lesní",
+      "schemeAmber": "Jantarové",
+      "schemeViolet": "Fialové",
+      "schemeRose": "Růžové",
+      "schemeCustom": "Vlastní",
+      "customPrimary": "Primární barva",
+      "customAccent": "Akcentová barva",
+      "logoGradient": "Logo s přechodem",
+      "logoGradientDescription": "Použít efekt přechodu na logo bočního panelu"
+    },
+    "userInterface": {
+      "tabs": {
+        "appearance": "Vzhled",
+        "language": "Jazyk a region",
+        "visualContent": "Vizuální obsah",
+        "audioPlayback": "Přehrávání zvuku"
+      },
+      "appearance": {
+        "title": "Vzhled",
+        "description": "Přizpůsobte vzhled svého rozhraní BirdNET-Go"
+      },
+      "language": {
+        "title": "Jazyk a region",
+        "description": "Jazyk, jednotky teploty a regionální předvolby zobrazení"
+      },
+      "visualContent": {
+        "title": "Vizuální obsah",
+        "description": "Nakonfigurujte obrázky ptáků a nastavení zobrazení spektrogramu"
+      },
+      "audioPlayback": {
+        "title": "Přehrávání zvuku",
+        "description": "Výchozí nastavení pro přehrávání nahrávek ptáků.",
+        "defaultGain": "Výchozí zesílení hlasitosti",
+        "defaultGainHelpText": "Počáteční zesílení při přehrávání nahrávek. Zvuky ptáků jsou často tiché, proto se doporučuje zesílení 6–12 dB.",
+        "defaultGainUnit": "dB"
+      }
+    },
+    "restartRequired": "Některé změny vyžadují restart serveru. Restartujte prosím BirdNET-Go."
+  },
+  "auth": {
+    "login": "Přihlášení",
+    "logout": "Odhlášení",
+    "openLoginModal": "Otevřít okno přihlášení",
+    "loginTitle": "Přihlásit se",
+    "loginSubtitle": "Přístup do vašeho dashboardu BirdNET-Go",
+    "password": "Heslo",
+    "passwordPlaceholder": "Zadejte své heslo",
+    "enterPassword": "Zadejte své heslo",
+    "continue": "Pokračovat",
+    "or": "nebo",
+    "loginWithGoogle": "Přihlásit se přes Google",
+    "loginWithGithub": "Přihlásit se přes GitHub",
+    "loginWithMicrosoft": "Přihlásit se přes Microsoft",
+    "continueWithGoogle": "Pokračovat přes Google",
+    "continueWithGithub": "Pokračovat přes GitHub",
+    "continueWithMicrosoft": "Pokračovat přes Microsoft",
+    "continueWithLine": "Pokračovat přes LINE",
+    "continueWithKakao": "Pokračovat přes Kakao",
+    "continueWithOidc": "Pokračovat přes OIDC",
+    "errors": {
+      "loginFailed": "Přihlášení se nezdařilo. Zkontrolujte své heslo a zkuste to znovu.",
+      "passwordRequired": "Heslo je povinné.",
+      "passwordTooLong": "Heslo je příliš dlouhé.",
+      "invalidCharacters": "Heslo obsahuje neplatné znaky.",
+      "invalidCredentials": "Neplatné uživatelské jméno nebo heslo.",
+      "tooManyAttempts": "Příliš mnoho pokusů o přihlášení. Zkuste to prosím později.",
+      "serverError": "Došlo k chybě serveru. Zkuste to prosím později.",
+      "rateLimited": "Příliš mnoho pokusů. Než to zkusíte znovu, počkejte {minutes} minut.",
+      "configurationError": "Chyba konfigurace ověřování. Kontaktujte prosím podporu.",
+      "invalidInput": "Byly zadány neplatné údaje."
+    }
+  },
+  "dataDisplay": {
+    "table": {
+      "noData": "Žádná data nejsou k dispozici",
+      "loading": "Načítání dat…",
+      "error": "Data se nepodařilo načíst",
+      "sortBy": "Seřadit podle {column}",
+      "rowsPerPage": "Řádků na stránku",
+      "pageInfo": "Zobrazuje se {from} až {to} z {total} výsledků"
+    },
+    "pagination": {
+      "ariaLabel": "Navigace stránkováním",
+      "previous": "Předchozí",
+      "next": "Další",
+      "page": "Stránka {current} z {total}",
+      "goToPage": "Přejít na stránku {page}",
+      "goToPreviousPage": "Přejít na předchozí stránku",
+      "goToNextPage": "Přejít na další stránku",
+      "firstPage": "První stránka",
+      "lastPage": "Poslední stránka"
+    },
+    "stats": {
+      "total": "Celkem",
+      "average": "Průměr",
+      "min": "Minimum",
+      "max": "Maximum",
+      "count": "Počet"
+    }
+  },
+  "forms": {
+    "placeholders": {
+      "text": "Zadejte {field}",
+      "select": "Vyberte {field}",
+      "search": "Hledat…",
+      "date": "Vyberte datum",
+      "dateRange": "Vyberte rozsah dat",
+      "number": "Zadejte číslo",
+      "password": "Zadejte heslo",
+      "url": "Zadejte URL",
+      "email": "Zadejte e-mail",
+      "selectFilterType": "Vyberte typ filtru",
+      "speciesName": "Název druhu"
+    },
+    "labels": {
+      "showPassword": "Zobrazit heslo",
+      "hidePassword": "Skrýt heslo",
+      "secretSet": "Nastaveno",
+      "changeSecret": "Změnit",
+      "cancelChange": "Zrušit",
+      "enterNewSecret": "Zadejte novou hodnotu",
+      "copyToClipboard": "Kopírovat do schránky",
+      "clearSelection": "Zrušit výběr",
+      "selectOption": "Vyberte možnost"
+    },
+    "help": {
+      "passwordStrength": "Síla hesla: {strength}",
+      "charactersRemaining": "Zbývá {count} znaků",
+      "dateFormat": "Formát: {format}"
+    },
+    "password": {
+      "strength": {
+        "label": "Síla hesla:",
+        "levels": {
+          "weak": "Slabé",
+          "fair": "Postačující",
+          "good": "Dobré",
+          "strong": "Silné"
+        },
+        "suggestions": {
+          "title": "Doporučení:",
+          "minLength": "Alespoň 8 znaků",
+          "mixedCase": "Kombinace velkých a malých písmen",
+          "number": "Alespoň jedno číslo",
+          "special": "Alespoň jeden speciální znak"
+        }
+      }
+    },
+    "errors": {
+      "radioValueRequired": "Vlastnost radioValue je povinná pro přepínače (radio)"
+    },
+    "dateRange": {
+      "labels": {
+        "startDate": "Datum začátku",
+        "endDate": "Datum konce",
+        "quickSelect": "Rychlý výběr",
+        "selected": "Vybráno: {startDate} – {endDate}"
+      },
+      "presets": {
+        "today": "Dnes",
+        "yesterday": "Včera",
+        "last7Days": "Posledních 7 dní",
+        "last30Days": "Posledních 30 dní",
+        "thisMonth": "Tento měsíc",
+        "lastMonth": "Minulý měsíc",
+        "thisYear": "Tento rok"
+      },
+      "errors": {
+        "invalidStartDate": "Neplatné datum začátku",
+        "invalidEndDate": "Neplatné datum konce",
+        "startAfterEnd": "Datum začátku nemůže být po datu konce",
+        "endBeforeStart": "Datum konce nemůže být před datem začátku"
+      }
+    },
+    "species": {
+      "placeholder": "Zadejte název druhu…",
+      "empty": "Nebyly přidány žádné druhy",
+      "maxReached": "Dosažen maximální počet {maxItems} druhů",
+      "aria": {
+        "dragToReorder": "Tažením změníte pořadí druhu {species}",
+        "edit": "Upravit druh",
+        "remove": "Odebrat druh"
+      }
+    }
+  },
+  "media": {
+    "audio": {
+      "settings": "Nastavení zvuku",
+      "play": "Přehrát",
+      "pause": "Pozastavit",
+      "stop": "Zastavit",
+      "volume": "Hlasitost",
+      "mute": "Ztlumit",
+      "unmute": "Zrušit ztlumení",
+      "download": "Stáhnout zvuk",
+      "currentTime": "{current} / {total}",
+      "loading": "Načítání zvuku…",
+      "error": "Nepodařilo se načíst zvuk",
+      "errorShort": "Chyba",
+      "playError": "Nepodařilo se přehrát zvuk",
+      "volumeGain": "Ovládání zesílení hlasitosti: {value} dB",
+      "filterControl": "Ovládání filtru",
+      "highPassFilter": "Ovládání horní propusti: {freq} Hz",
+      "seekProgress": "Posun v nahrávce: {current} / {total} sekund",
+      "playbackSpeed": "Rychlost přehrávání",
+      "speed": "Rychlost",
+      "loop": "Přepnout opakování",
+      "player": "Přehrávač zvuku"
+    },
+    "spectrogram": {
+      "notGenerated": "Spektrogram zatím nebyl vygenerován",
+      "generate": "Vygenerovat spektrogram",
+      "generateButton": "Vygenerovat",
+      "generating": "Generování…",
+      "generationFailed": "Nepodařilo se vygenerovat spektrogram",
+      "generationSuccess": "Spektrogram byl úspěšně vygenerován"
+    }
+  },
+  "components": {
+    "audio": {
+      "spectrogramUnavailable": "Spektrogram není k dispozici",
+      "spectrogramLoading": "Načítání spektrogramu…",
+      "spectrogramLoaded": "Spektrogram načten",
+      "spectrogramLoadingAria": "Načítání spektrogramu",
+      "spectrogramAlt": "Zvukový spektrogram",
+      "spectrogramGeneratingAria": "Generování spektrogramu",
+      "generating": "Generování…",
+      "queuePosition": "Pořadí: {position}",
+      "loadError": "Zvuk se nepodařilo načíst"
+    },
+    "forms": {
+      "numberField": {
+        "adjustedToMinimum": "Hodnota byla upravena na minimum ({value})",
+        "adjustedToMaximum": "Hodnota byla upravena na maximum ({value})"
+      },
+      "rtsp": {
+        "addNewStream": "Přidat nový RTSP stream",
+        "maxStreamsReached": "Dosažen maximální počet RTSP streamů ({max}).",
+        "cameraPlaceholder": "Kamera 1",
+        "urlPlaceholder": "rtsp://username:password@192.168.1.100:554/stream"
+      },
+      "subnet": {
+        "maxSubnetsReached": "Dosažen maximální počet podsítí ({max})."
+      },
+      "species": {
+        "loadingSpecies": "Načítání druhů…",
+        "typePlaceholder": "Zadejte název druhu…",
+        "suggestionsAvailable": "K dispozici je {count} návrhů druhů. Pro pohyb použijte šipky.",
+        "noSuggestions": "Nejsou k dispozici žádné návrhy druhů."
+      },
+      "select": {
+        "searchPlaceholder": "Hledat…",
+        "searchOptions": "Hledat ve volbách",
+        "noOptions": "Nebyly nalezeny žádné možnosti"
+      }
+    },
+    "datePicker": {
+      "today": "Dnes",
+      "feedback": {
+        "endDateCleared": "Datum konce bylo vymazáno pro zachování platného rozsahu",
+        "startDateCleared": "Datum začátku bylo vymazáno pro zachování platného rozsahu",
+        "invalidDateFormat": "Neplatný formát data. Použijte formát RRRR-MM-DD",
+        "dateOutOfRange": "Vybrané datum je mimo povolený rozsah",
+        "futureDate": "Nelze vybrat datum v budoucnosti",
+        "pastDate": "Nelze vybrat datum v minulosti"
+      },
+      "aria": {
+        "dateSelected": "Datum {date} vybráno",
+        "calendarOpened": "Kalendář otevřen pro výběr data",
+        "calendarClosed": "Kalendář zavřen",
+        "monthChanged": "Zobrazuje se {month} {year}",
+        "dayUnavailable": "Den {day} není k dispozici pro výběr",
+        "todayButton": "Vybrat dnešní datum: {today}"
+      },
+      "status": {
+        "loading": "Načítání kalendáře…",
+        "error": "Chyba při načítání kalendáře"
+      }
+    },
+    "audioPlayer": {
+      "errors": {
+        "generationFailedStatus": "Generování selhalo se stavem {status}",
+        "spectrogramFailed": "Spektrogram se nepodařilo vygenerovat"
+      },
+      "clipExtraction": {
+        "selectRange": "Klikněte a tažením vyberte rozsah",
+        "playSelection": "Přehrát vybraný rozsah",
+        "pauseSelection": "Pozastavit přehrávání",
+        "reviewSelection": "Přejít na začátek výběru",
+        "selectionStart": "Úchyt začátku výběru",
+        "selectionEnd": "Úchyt konce výběru",
+        "lossless": "Bezztrátový",
+        "lossy": "Ztrátový",
+        "extractClip": "Stáhnout vybraný klip",
+        "clearSelection": "Zrušit výběr",
+        "extracting": "Extrahování klipu…",
+        "extractError": "Klip se nepodařilo extrahovat",
+        "formatLabel": "Formát",
+        "rangeLabel": "{start} s – {end} s"
+      },
+      "processing": {
+        "playSelection": "Přehrát výběr",
+        "skipToStart": "Přejít na začátek výběru",
+        "clearSelection": "Zrušit výběr",
+        "gain": "Zesílení (dB)",
+        "denoise": "Odšumění",
+        "denoiseOff": "Vypnuto",
+        "denoiseLight": "Slabé",
+        "denoiseMedium": "Střední",
+        "denoiseHeavy": "Silné",
+        "normalize": "Normalizovat zvuk",
+        "normalizeTooltip": "Normalizace EBU R128",
+        "export": "Exportovat",
+        "exportOriginal": "Originál",
+        "processingActive": "Zpracování aktivní"
+      }
+    },
+    "weatherInfo": {
+      "errors": {
+        "loadFailed": "Data o počasí se nepodařilo načíst"
+      }
+    },
+    "tls": {
+      "certificateInstalled": "Certifikát nainstalován",
+      "browseFile": "Procházet",
+      "subject": "Subjekt",
+      "issuer": "Vydavatel",
+      "sans": "Alternativní názvy subjektu",
+      "validUntil": "Platný do",
+      "daysRemaining": "Zbývá dní",
+      "fingerprint": "Otisk",
+      "expiryWarning": "Platnost certifikátu brzy vyprší. Zvažte jeho obnovení.",
+      "downloadCertificate": "Stáhnout certifikát",
+      "regenerateButton": "Vygenerovat znovu",
+      "removeCertificate": "Odstranit certifikát",
+      "fileReadError": "Soubor se nepodařilo přečíst",
+      "loading": "Načítání informací o certifikátu…"
+    }
+  },
+  "connectivity": {
+    "offline": "Spojení se serverem bylo ztraceno. Pokouším se znovu připojit…"
+  },
+  "detection": {
+    "actions": {
+      "back": "Zpět",
+      "review": "Zkontrolovat",
+      "download": "Stáhnout"
+    }
+  },
+  "quietHours": {
+    "indicator": {
+      "tooltip": "Tiché hodiny aktivní – pozastaveno {count} zdrojů"
+    }
+  },
+  "errors": {
+    "auth": {
+      "tooManyAttempts": "Příliš mnoho pokusů o přihlášení. Zkuste to prosím znovu za 15 minut.",
+      "credentialsRequired": "Uživatelské jméno a heslo jsou povinné",
+      "invalidCredentials": "Neplatné přihlašovací údaje",
+      "missingCode": "Chybí autorizační kód",
+      "serviceUnavailable": "Ověřovací služba není k dispozici. Zkuste to prosím později.",
+      "timeout": "Vypršel čas přihlášení. Zkuste to prosím znovu.",
+      "exchangeFailed": "Přihlášení nelze v tuto chvíli dokončit. Zkuste to prosím znovu.",
+      "sessionError": "Chyba relace během přihlášení. Zkuste to prosím znovu."
+    },
+    "alert": {
+      "v2Required": "Pravidla výstrah vyžadují rozšířenou databázi (v2)",
+      "invalidID": "Neplatné ID pravidla",
+      "notFound": "Pravidlo výstrahy nenalezeno",
+      "invalidBody": "Neplatné tělo požadavku",
+      "nameRequired": "Název pravidla je povinný",
+      "typesRequired": "Typ objektu a typ spouštěče jsou povinné",
+      "duplicateName": "Pravidlo s tímto názvem již existuje",
+      "invalidJSON": "Neplatný JSON",
+      "invalidEscalation": "Eskalační kroky jsou neplatné"
+    },
+    "detection": {
+      "invalidDate": "Neplatný formát {paramName}, použijte RRRR-MM-DD"
+    },
+    "backup": {
+      "invalidType": "Typ musí být „legacy“ nebo „v2“",
+      "alreadyRunning": "Zálohování již probíhá",
+      "dbInfoFailed": "Informace o databázi se nepodařilo získat",
+      "diskSpaceCheck": "Kontrola místa na disku selhala",
+      "insufficientSpace": "Nedostatek místa na disku. Potřeba: {needed}, dostupné: {available}",
+      "createFailed": "Úlohu zálohování se nepodařilo vytvořit",
+      "notFound": "Úloha zálohování nebyla nalezena nebo její platnost vypršela",
+      "notReady": "Záloha není připravena ke stažení",
+      "fileNotFound": "Soubor zálohy nebyl nalezen – platnost úlohy mohla vypršet",
+      "sqliteOnly": "Zálohování je k dispozici pouze pro databáze SQLite",
+      "dbNotConfigured": "Databáze není nakonfigurována",
+      "unsupportedType": "Pro tento typ úložiště nelze provést zálohu",
+      "v2NotInitialized": "Databáze V2 není inicializována"
+    },
+    "migration": {
+      "notConfigured": "Migrace není nakonfigurována",
+      "preFlightFailed": "Předběžné kontroly selhaly",
+      "invalidBody": "Neplatné tělo požadavku",
+      "recordCountFailed": "Celkový počet záznamů se nepodařilo určit",
+      "startFailed": "Migraci se nepodařilo spustit",
+      "initFailed": "Migraci se nepodařilo inicializovat",
+      "resumeFailed": "Migraci se nepodařilo obnovit"
+    },
+    "cleanup": {
+      "noLegacyDB": "Stará databáze nebyla nalezena",
+      "accessFailed": "Ke staré databázi nelze přistoupit",
+      "restartRequired": "Aplikaci je nutné po migraci restartovat, aby bylo k dispozici vyčištění",
+      "safetyCheck": "Cílový soubor vypadá jako databáze V2 – z bezpečnostních důvodů není vyčištění povoleno",
+      "noLegacyTables": "Nebyly nalezeny žádné staré tabulky",
+      "restartNeeded": "Vyčištění není možné: aplikaci je nutné po migraci restartovat",
+      "alreadyRunning": "Vyčištění již probíhá"
+    },
+    "integration": {
+      "mqttDisabled": "MQTT není v nastavení povoleno",
+      "mqttNotConfigured": "MQTT broker není nakonfigurován",
+      "mqttMetricsUnavailable": "Instance metrik není k dispozici pro test MQTT",
+      "mqttClientFailed": "MQTT klienta se nepodařilo vytvořit",
+      "birdweatherDisabled": "Integrace BirdWeather není povolena",
+      "birdweatherNotConfigured": "ID stanice BirdWeather není nakonfigurováno",
+      "birdweatherClientFailed": "BirdWeather klienta se nepodařilo vytvořit",
+      "noWeatherProvider": "Není vybrán žádný poskytovatel počasí",
+      "openWeatherKeyRequired": "API klíč OpenWeather je povinný",
+      "processorUnavailable": "Procesor není k dispozici",
+      "discoveryFailed": "Objevování zařízení Home Assistant se nepodařilo spustit"
+    },
+    "notification": {
+      "serviceUnavailable": "Služba oznámení není k dispozici",
+      "idRequired": "ID oznámení je povinné",
+      "notFound": "Oznámení nenalezeno",
+      "hostRequired": "Parametr hostitele je povinný",
+      "invalidHost": "Neplatný parametr hostitele",
+      "rateLimit": "Příliš mnoho pokusů o připojení k proudu oznámení, počkejte prosím chvíli a zkuste to znovu"
+    },
+    "debug": {
+      "notEnabled": "Režim ladění není povolen"
+    },
+    "terminal": {
+      "disabled": "Terminál je zakázán. Povolte jej v nastavení."
+    },
+    "api": {
+      "badRequest": "Neplatný požadavek. Zkontrolujte zadané údaje a zkuste to znovu.",
+      "unauthorized": "Vyžaduje se ověření. Přihlaste se a zkuste to znovu.",
+      "forbidden": "K provedení této akce nemáte oprávnění.",
+      "notFound": "Požadovaný zdroj nebyl nalezen.",
+      "conflict": "Tato akce je v rozporu s aktuálním stavem. Obnovte stránku a zkuste to znovu.",
+      "validationFailed": "Byl zadán neplatný vstup. Zkontrolujte data a zkuste to znovu.",
+      "tooManyRequests": "Příliš mnoho požadavků. Počkejte prosím a zkuste to znovu.",
+      "serverError": "Došlo k chybě serveru. Zkuste to prosím později.",
+      "clientError": "Došlo k chybě klienta. Zkontrolujte svůj požadavek a zkuste to znovu.",
+      "unknownError": "Došlo k neočekávané chybě. Zkuste to prosím znovu.",
+      "validationCheck": "Ověření selhalo. Zkontrolujte zadané údaje.",
+      "conflictData": "Tato akce je v rozporu se stávajícími daty.",
+      "requestTimeout": "Vypršel časový limit požadavku.",
+      "networkError": "Došlo k chybě sítě. Zkontrolujte své připojení."
+    }
+  },
+  "weather": {
+    "moon": {
+      "newMoon": "Nov",
+      "waxingCrescent": "Dorůstající srpek",
+      "firstQuarter": "První čtvrť",
+      "waxingGibbous": "Dorůstající měsíc",
+      "fullMoon": "Úplněk",
+      "waningGibbous": "Couvající měsíc",
+      "lastQuarter": "Poslední čtvrť",
+      "waningCrescent": "Couvající srpek"
+    },
+    "birding": {
+      "excellent": "Bezvětří – vynikající podmínky pro poslech ptačího zpěvu",
+      "moderate": "Mírný vítr – některé ptačí hlasy mohou být hůře slyšitelné",
+      "poor": "Silný vítr – ptačí hlasy jsou téměř neslyšitelné"
+    }
+  },
+  "wizard": {
+    "skip": "Přeskočit",
+    "back": "Zpět",
+    "next": "Další",
+    "done": "Hotovo",
+    "progress": "Krok {current} z {total}",
+    "progressLabel": "Průběh průvodce",
+    "whatsNew": {
+      "title": "Co je nového ve verzi {version}"
+    },
+    "steps": {
+      "welcome": {
+        "title": "Vítejte",
+        "heading": "Vítejte v BirdNET-Go!",
+        "description": "BirdNET-Go je open-source systém pro identifikaci ptačího zpěvu, který v reálném čase poslouchá zvuk z vašeho mikrofonu nebo streamu a rozpoznává druhy ptáků.",
+        "credit": "Využívá model BirdNET vyvinutý v K. Lisa Yang Center for Conservation Bioacoustics na Cornellově ornitologické laboratoři a Technické univerzitě v Chemnitz. BirdNET-Go je nezávislý komunitní projekt, který není přidružen k týmu BirdNET ani jím nijak podporován.",
+        "learnMore": "Více informací o BirdNET",
+        "cta": "Pojďme nastavit vaši stanici pro sledování ptáků."
+      },
+      "locationLanguage": {
+        "title": "Poloha a jazyk",
+        "uiLanguageLabel": "Jazyk rozhraní",
+        "uiLanguageHelp": "Jazyk používaný pro webové rozhraní",
+        "speciesLanguageLabel": "Jazyk názvů druhů",
+        "speciesLanguageHelp": "Jazyk používaný pro názvy druhů ptáků v detekcích",
+        "locationLabel": "Poloha stanice",
+        "locationHelp": "Vaše poloha pomáhá filtrovat druhy na ty, které jsou ve vaší oblasti pravděpodobné",
+        "latitudeLabel": "Zeměpisná šířka",
+        "longitudeLabel": "Zeměpisná délka",
+        "useMyLocation": "Použít moji polohu",
+        "locationDetected": "Poloha zjištěna",
+        "locationError": "Polohu se nepodařilo zjistit. Zadejte prosím souřadnice ručně.",
+        "locationDenied": "Přístup k poloze byl odepřen. Zadejte prosím souřadnice ručně.",
+        "geolocationRequiresHttps": "Poloha v prohlížeči vyžaduje HTTPS. Zadejte prosím souřadnice ručně nebo použijte mapu.",
+        "geolocationDenied": "Oprávnění k poloze bylo odepřeno. Zadejte prosím souřadnice ručně nebo použijte mapu.",
+        "geolocationFailed": "Vaši polohu se nepodařilo určit. Zadejte prosím souřadnice ručně nebo použijte mapu.",
+        "localesLoading": "Načítání jazyků…",
+        "localesLoadFailed": "Nepodařilo se načíst jazykové možnosti. Jako výchozí byla zvolena angličtina."
+      },
+      "audioSource": {
+        "title": "Zdroj zvuku",
+        "sourceTypeLabel": "Typ zdroje",
+        "soundcard": "Mikrofon / zvuková karta",
+        "rtspStream": "RTSP stream",
+        "deviceLabel": "Zvukové zařízení",
+        "deviceLoading": "Načítání zvukových zařízení…",
+        "noDevicesFound": "Nebyla zjištěna žádná zvuková zařízení. Zkuste místo toho nakonfigurovat RTSP stream.",
+        "rtspUrlLabel": "URL streamu",
+        "rtspUrlPlaceholder": "rtsp://user:password@host:port/stream",
+        "rtspUrlHelp": "Zadejte URL vašeho RTSP audio streamu",
+        "additionalSourcesHint": "Další zvukové zdroje můžete přidat později v Nastavení.",
+        "configureLater": "Přeskočit – nastavit později"
+      },
+      "detection": {
+        "title": "Práh detekce",
+        "description": "Vyberte, jak přísná má identifikace ptáků být. Toto můžete později změnit v Nastavení.",
+        "balanced": "Vyvážený",
+        "balancedDesc": "Dobrý poměr přesnosti a citlivosti",
+        "balancedRecommended": "Doporučeno",
+        "highAccuracy": "Vysoká přesnost",
+        "highAccuracyDesc": "Méně falešně pozitivních, ale může některé ptáky minout",
+        "highSensitivity": "Vysoká citlivost",
+        "highSensitivityDesc": "Více detekcí, ale i více falešně pozitivních",
+        "threshold": "Práh spolehlivosti",
+        "fpFilterNote": "Až bude váš systém běžet a osvědčí se, můžete v Nastavení povolit filtr falešně pozitivních detekcí pro další snížení nesprávných detekcí."
+      },
+      "integration": {
+        "title": "Soukromí a integrace",
+        "privacyFilterLabel": "Povolit filtr soukromí",
+        "privacyFilterHelp": "Odfiltruje detekce, když jsou v blízkosti mikrofonu zachyceny lidské hlasy",
+        "birdweatherLabel": "Sdílet detekce se službou BirdWeather",
+        "birdweatherHelp": "Přispějte svými detekcemi ptáků do komunitní sítě BirdWeather",
+        "birdweatherIdLabel": "ID stanice BirdWeather",
+        "birdweatherIdPlaceholder": "Zadejte ID vaší stanice BirdWeather",
+        "errorReportingLabel": "Odesílat anonymní hlášení chyb",
+        "errorReportingHelp": "Pomozte vylepšit BirdNET-Go odesíláním anonymních hlášení chyb, když něco selže"
+      },
+      "responsibleUse": {
+        "title": "Zodpovědné používání BirdNET-Go",
+        "intro": "BirdNET-Go je výkonný nástroj, který obohacuje vaše pozorování ptáků o identifikaci s pomocí AI. Pro nejlepší výsledky v pozorování i ochraně přírody:",
+        "point1": "Před sdílením pozorování detekce zkontrolujte a ověřte",
+        "point2": "Skóre spolehlivosti berte jako vodítko, nikoli jako absolutní pravdu",
+        "point3": "Porovnávejte s atlasy a místními odborníky",
+        "point4": "Zohledněte sezónní výskyt a vhodnost biotopu",
+        "citizenScienceHeading": "Při přispívání do občanské vědy:",
+        "citizenPoint1": "Odesílejte pouze pozorování, která jste osobně ověřili",
+        "citizenPoint2": "Doplňte poznámky o vizuálním nebo behaviorálním potvrzení",
+        "citizenPoint3": "AI detekce použijte jako výchozí bod pro vaše vlastní pozorování",
+        "outro": "Tento přístup zajišťuje kvalitu dat pro vědecký výzkum a zároveň maximalizuje vaše poznávání a radost z ptactva.",
+        "acknowledge": "Rozumím"
+      }
+    }
+  },
+  "analysis": {
+    "title": "Analýza",
+    "tabs": {
+      "settings": "Nastavení",
+      "models": "Modely"
+    },
+    "detection": {
+      "title": "Nastavení detekce",
+      "description": "Nakonfigurujte prahy spolehlivosti a jazyk klasifikace druhů.",
+      "confidenceThreshold": {
+        "label": "Práh spolehlivosti",
+        "helpText": "Minimální skóre spolehlivosti (0,0 – 1,0) potřebné pro zaznamenání detekce."
+      },
+      "batThreshold": {
+        "label": "Práh detekce netopýrů",
+        "helpText": "Minimální skóre spolehlivosti pro detekce druhů netopýrů. Platí pouze pro klasifikační modely netopýrů."
+      },
+      "batFilter": {
+        "label": "Horní propust pro audio netopýrů",
+        "helpText": "Odfiltruje frekvence slyšitelné lidským uchem před analýzou netopýrů, aby se snížil počet falešných detekcí způsobených ptačím zpěvem a okolním hlukem."
+      },
+      "batNighttimeOnly": {
+        "label": "Pouze v noci",
+        "helpText": "Pokud je zapnuto, detekce netopýrů běží pouze mezi občanským soumrakem a občanským svítáním. Vyžaduje nakonfigurovanou polohu. Vypněte pro nepřetržitou detekci netopýrů."
+      },
+      "batUltrasonicFilter": {
+        "label": "Ověření po detekci",
+        "helpText": "Pokud je zapnuto, detekce netopýrů se ověřují analýzou vzorů ultrazvukové energie ve zdrojovém zvuku. Detekce bez charakteristik echolokace netopýrů jsou označeny jako nepravděpodobné."
+      },
+      "batFalsePositiveFilter": {
+        "label": "Filtr falešných detekcí netopýrů",
+        "helpText": "Vyžaduje více potvrzení detekce netopýra v rámci posuvného okna před jejím přijetím. Vyšší úrovně vyžadují více potvrzení, čímž se snižuje počet falešných detekcí. Model netopýrů používá pevné 50% překrytí, takže úprava překrytí není potřeba.",
+        "levels": {
+          "off": "Žádné filtrování; jakákoli detekce netopýra je přijata okamžitě.",
+          "moderate": "Dobrá rovnováha pro většinu nastavení. Výrazně snižuje falešné detekce.",
+          "strict": "Maximální filtrování pro nejvyšší přesnost."
+        },
+        "detectionCount": "Vyžaduje se {count} potvrzení. {description}",
+        "warningOff": "Bez filtrování je vysoká pravděpodobnost falešných detekcí. Zapnutí filtrování výrazně zlepšuje přesnost."
+      },
+      "locale": {
+        "label": "Jazyk druhů",
+        "helpText": "Jazyk používaný pro běžné názvy druhů v rozhraní."
+      }
+    },
+    "rangeFilter": {
+      "birdOnlyNote": "Filtr rozsahu se vztahuje pouze na klasifikátory ptáků. Modely netopýrů používají vlastní seznamy druhů.",
+      "status": {
+        "title": "Přehled filtru rozsahu",
+        "geomodelInfo": "BirdNET Geomodel {version} – {species} známých druhů",
+        "autoSelected": "Automaticky vybráno",
+        "manual": "Ručně",
+        "classifier": "Klasifikátor",
+        "totalSpecies": "Celkem druhů",
+        "withRangeData": "S daty o rozsahu",
+        "withoutRangeData": "Bez dat o rozsahu",
+        "withRangeDataTooltip": "Druhy, u kterých geomodel dokáže vyhodnotit geografickou pravděpodobnost ve vaší poloze",
+        "withoutRangeDataTooltip": "Druhy bez geografických dat v geomodelu, řízené nastavením nemapovaných druhů níže",
+        "noFilter": "Žádný aktivní filtr rozsahu",
+        "passUnmapped": {
+          "label": "Povolit druhy bez dat o rozsahu",
+          "helpText": "Povolit detekce druhů, pro které geomodel nemá geografická data. Pokud je vypnuto, tyto druhy jsou vždy odfiltrovány."
+        }
+      }
+    },
+    "advanced": {
+      "title": "Pokročilé",
+      "description": "Konfigurace zpracování a vlastních modelů."
+    },
+    "gallery": {
+      "title": "Galerie modelů",
+      "description": "Správa klasifikačních modelů pro detekci ptáků a netopýrů.",
+      "tabs": {
+        "installed": "Nainstalované",
+        "available": "Dostupné"
+      },
+      "loading": "Načítání modelů…",
+      "retry": "Zkusit znovu",
+      "builtIn": "Vestavěný",
+      "builtInDescription": "Vestavěný klasifikátor ptačích druhů od týmu BirdNET.",
+      "species": "{count} druhů",
+      "install": "Nainstalovat",
+      "installing": "Instaluji…",
+      "remove": "Odstranit",
+      "removing": "Odstraňuji…",
+      "noInstalledModels": "Nejsou nainstalovány žádné další modely. Pro přidání dalších klasifikátorů přejděte na záložku Dostupné.",
+      "noAvailableModels": "Pro vaši platformu nejsou k dispozici žádné další modely.",
+      "sections": {
+        "acoustic": "Akustické klasifikátory",
+        "geomodel": "Geomodely"
+      },
+      "categories": {
+        "wildlife": "Klasifikátory volně žijících živočichů",
+        "bird": "Klasifikátory ptáků",
+        "bat": "Klasifikátory netopýrů"
+      },
+      "progress": {
+        "downloading": "Stahování…",
+        "verifying": "Ověřování…",
+        "loading": "Načítání…",
+        "complete": "Úspěšně nainstalováno",
+        "failed": "Selhalo"
+      },
+      "license": {
+        "title": "Licenční smlouva",
+        "model": "Model",
+        "author": "Autor",
+        "license": "Licence",
+        "commercialUse": "Komerční použití",
+        "downloadSize": "Velikost ke stažení",
+        "allowed": "Povoleno",
+        "notAllowed": "Nepovoleno",
+        "commercialUseAllowed": "Komerční použití povoleno",
+        "nonCommercialOnly": "Pouze nekomerční použití",
+        "nonCommercialWarning": "Tento model je licencován pouze pro nekomerční použití. Instalací souhlasíte s podmínkami licence.",
+        "acceptAndInstall": "Přijmout a nainstalovat"
+      },
+      "removeDialog": {
+        "title": "Odstranit {name}?",
+        "confirmation": "Tím se odstraní soubory modelu z disku. Data štítků pro stávající detekce zůstanou zachována."
+      },
+      "errors": {
+        "catalogLoadFailed": "Nepodařilo se načíst katalog modelů",
+        "installFailed": "Nepodařilo se spustit instalaci modelu",
+        "removeFailed": "Nepodařilo se odstranit model"
+      },
+      "regionLabel": "Region",
+      "speciesLabel": "Druhy",
+      "reinstall": "Přeinstalovat",
+      "reinstalling": "Přeinstalování…",
+      "reinstallComplete": "Soubory úspěšně ověřeny",
+      "geomodelBadge": "Obsahuje BirdNET v3.0 geomodel"
+    },
+    "bird": {
+      "title": "Detekce ptáků",
+      "description": "Nakonfigurujte práh spolehlivosti, jazyk druhů a filtrování falešných detekcí pro klasifikátory ptáků."
+    },
+    "bat": {
+      "title": "Detekce netopýrů",
+      "description": "Nakonfigurujte práh, plánování a filtrování falešných detekcí pro klasifikátory netopýrů."
+    },
+    "dynamicThreshold": {
+      "birdOnlyNote": "Dynamický práh se vztahuje pouze na klasifikátory ptáků."
+    }
+  },
+  "restart": {
+    "applicationRestart": "Restartovat aplikaci",
+    "containerRestart": "Restartovat kontejner",
+    "confirmTitle": "Potvrdit restart",
+    "confirmApplicationMessage": "Server se restartuje. Budete dočasně odpojeni.",
+    "confirmContainerMessage": "Kontejner se restartuje. Budete dočasně odpojeni.",
+    "inProgress": "Restartování…",
+    "bannerTitle": "Vyžadován restart",
+    "bannerMessage": "Změny konfigurace vyžadují restart, aby se projevily:",
+    "bannerAction": "Restartovat nyní",
+    "restartFailed": "Restart se nepodařilo spustit"
+  }
+}


### PR DESCRIPTION
## Summary

Adds Czech (`cs`) as the 15th supported locale. Slovak (`sk`) was already supported, and there is a sizeable Czech-speaking community of casual birders that would benefit from a first-class native translation.

## Changes

* `frontend/src/lib/i18n/config.ts` — register `cs: { name: 'Čeština' }`
* `frontend/static/messages/cs.json` — 3344 translated keys, mirrors `en.json` exactly
* `frontend/CLAUDE.md`, `frontend/static/messages/CLAUDE.md`, `frontend/static/messages/README.md` — bump locale count 14 → 15 and add `cs` to the documented lists

## Translation quality

* Produced natively in Czech (not Slovak with diacritic tweaks). The Slovak file was only used as register guidance for tone consistency.
* Software-UI register for technical strings (settings, alerts, OAuth, MQTT, audio capture/EQ, security) — concise and unambiguous.
* Natural phrasing for user-facing copy: dashboard widgets, wizard, weather strings, moon phases, "Currently Hearing" / "Recent Detections", etc.
* Code-like identifiers that flow into command-line argument lists (e.g. `CommonName`, `ScientificName`, `Confidence` parameter labels under `settings.species.actionsModal.parameters.buttons`) are kept as English literals so downstream parameter passing isn't broken — matches what `settings.species.actionsModal.examples.params` uses on the command-line side.
* Technical identifiers (RTSP, HLS, OAuth, OIDC, MQTT, FFmpeg, FLAC, BirdNET, eBird, BirdWeather, Home Assistant, etc.) kept verbatim per the project's existing convention.

## Verification

* Placeholder integrity verified end-to-end: every `{name}`, `{count}`, Go template (`{{.CommonName}}`, `{{.ScientificName}}`, …), HTML tag, anchor and emoji is preserved byte-identically to en.json — no missing or extra placeholders in any of the 3344 strings.
* `npm run i18n:sync` reports all locale files in sync (`cs.json` matches `en.json` structure exactly).
* `npm run typecheck` — 0 errors.
* `npm test -- --run` — all 1929 tests pass.
* `npm run check:all` — prettier / eslint / stylelint / ast-grep clean.

## Notes for review

I'm a Czech native speaker; happy to iterate on terminology choices if any feel off. The trickiest calls were:

* "Dashboard" — kept as-is. Established Czech IT loanword; translating to "Přehled" or "Nástěnka" feels less natural to a Czech tech user.
* "Confidence" → "Spolehlivost". Matches how the BirdNET community refers to confidence scores in Czech bird-watching contexts.
* "Detection" → "Detekce" (event noun). "Detekovat" for the verb. "Identifikace" was the alternative but reads more medical/forensic.
* "Live audio" → "živý zvuk" / "živé audio" depending on context (heading vs. inline).
* "Quiet hours" → "Tiché hodiny" (mirrors what Apple/Microsoft use in Czech localisations).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Czech (Čeština) language support to the application.

* **Documentation**
  * Updated locale configuration and translation documentation to reflect the new language availability (15 supported locales).
  * Updated i18n management instructions to reflect the expanded locale coverage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3124?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->