### PR TITLE
fix(frontend): fallback for empty statusText in dashboard errors

### DIFF
--- a/frontend/src/lib/desktop/features/dashboard/components/DailySummaryCard.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/components/DailySummaryCard.svelte
@@ -358,7 +358,14 @@ Responsive Breakpoints:
         if (selectedDate === currentDate) {
           hourlyWeather = data;
           // Build hour-keyed map for O(1) lookup
-          hourlyWeatherMap = new Map(data.map(w => [parseInt(w.time.split(':')[0], 10), w]));
+          hourlyWeatherMap = new Map(
+            data
+              .filter(
+                (w): w is typeof w & { time: string } =>
+                  typeof w.time === 'string' && w.time.includes(':')
+              )
+              .map(w => [parseInt(w.time.split(':')[0], 10), w])
+          );
         }
       });
     }

--- a/frontend/src/lib/desktop/features/dashboard/components/DailySummaryCard.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/components/DailySummaryCard.svelte
@@ -362,7 +362,7 @@ Responsive Breakpoints:
             data
               .filter(
                 (w): w is typeof w & { time: string } =>
-                  typeof w.time === 'string' && w.time.includes(':')
+                  !!w && typeof w.time === 'string' && w.time.includes(':')
               )
               .map(w => [parseInt(w.time.split(':')[0], 10), w])
           );

--- a/frontend/src/lib/desktop/features/dashboard/pages/DashboardPage.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/pages/DashboardPage.svelte
@@ -376,7 +376,11 @@ Performance Optimizations:
         buildAppUrl(`/api/v2/analytics/species/daily?date=${selectedDate}&limit=${summaryLimit}`)
       );
       if (!response.ok) {
-        throw new Error(t('dashboard.errors.dailySummaryFetch', { status: response.statusText }));
+        throw new Error(
+          t('dashboard.errors.dailySummaryFetch', {
+            status: response.statusText || `HTTP ${response.status}`,
+          })
+        );
       }
       const data = await response.json();
 
@@ -460,7 +464,9 @@ Performance Optimizations:
       );
       if (!response.ok) {
         throw new Error(
-          t('dashboard.errors.recentDetectionsFetch', { status: response.statusText })
+          t('dashboard.errors.recentDetectionsFetch', {
+            status: response.statusText || `HTTP ${response.status}`,
+          })
         );
       }
       const rawData = await response.json();
@@ -1235,7 +1241,9 @@ Performance Optimizations:
       )
         .then(response => {
           if (!response.ok) {
-            throw new Error(`Batch preload failed: ${response.statusText}`);
+            throw new Error(
+              `Batch preload failed: ${response.statusText || `HTTP ${response.status}`}`
+            );
           }
           return response.json();
         })

--- a/frontend/static/messages/cs.json
+++ b/frontend/static/messages/cs.json
@@ -801,6 +801,25 @@
     "pagination": {
       "showing": "Zobrazuje se {from} až {to} z {total} výsledků"
     },
+    "selection": {
+      "select": "Select",
+      "nSelected": "{count} selected",
+      "selectAllMatching": "Select all {count} matching detections",
+      "allSelected": "All {count} selected",
+      "clear": "Clear selection",
+      "toolbarLabel": "Bulk actions",
+      "confirmBulkDelete": "Delete {count} detections? This cannot be undone.",
+      "confirmBulkMarkCorrect": "Mark {count} detections as correct?",
+      "confirmBulkMarkFalsePositive": "Mark {count} detections as false positive?",
+      "confirmBulkLock": "Lock {count} detections?",
+      "confirmBulkUnlock": "Unlock {count} detections?",
+      "bulkSuccess": "{count} detections updated",
+      "bulkDeleteSuccess": "{count} detections deleted",
+      "bulkPartial": "{processed} updated, {skipped} skipped (locked)",
+      "tooManyDetections": "Too many detections ({count}). Narrow your filters to select fewer than 500.",
+      "bulkError": "Bulk operation failed. Please try again.",
+      "switchToTable": "Switch to table view to select detections"
+    },
     "weather": {
       "title": "Informace o počasí",
       "noData": "Žádná data o počasí",
@@ -869,7 +888,9 @@
       }
     },
     "row": {
-      "viewDetails": "Zobrazit podrobnosti pro {species}"
+      "viewDetails": "Zobrazit podrobnosti pro {species}",
+      "play": "Play",
+      "playAudio": "Play audio"
     },
     "media": {
       "title": "Nahrávka a spektrogram",

--- a/frontend/static/messages/da.json
+++ b/frontend/static/messages/da.json
@@ -424,7 +424,7 @@
       },
       "buffer": {
         "overloadTitle": "Lydanalyse overbelastet",
-        "overloadMessage": "Dit system dropper {dropRate}% af lydprøverne for kilden '{sourceName}', fordi det ikke kan følge med analysen. Reducer BirdNET-overlapværdien i detektionsindstillingerne eller overvej at opgradere til en hurtigere CPU."
+        "overloadMessage": "Dit system dropper {dropRate}% af lydprøverne for kilden ''{sourceName}'', fordi det ikke kan følge med analysen. Reducer BirdNET-overlapværdien i detektionsindstillingerne eller overvej at opgradere til en hurtigere CPU."
       },
       "alert": {
         "firedTitle": "{rule_name}",

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -424,7 +424,7 @@
       },
       "buffer": {
         "overloadTitle": "Audioanalyse überlastet",
-        "overloadMessage": "Ihr System verwirft {dropRate} % der Audioaufnahmen der Quelle '{sourceName}', da es mit der Analyse nicht Schritt halten kann. Reduzieren Sie den BirdNET-Überlappungswert in den Erkennungseinstellungen oder erwägen Sie ein Upgrade auf eine schnellere CPU."
+        "overloadMessage": "Ihr System verwirft {dropRate} % der Audioaufnahmen der Quelle ''{sourceName}'', da es mit der Analyse nicht Schritt halten kann. Reduzieren Sie den BirdNET-Überlappungswert in den Erkennungseinstellungen oder erwägen Sie ein Upgrade auf eine schnellere CPU."
       },
       "alert": {
         "firedTitle": "{rule_name}",

--- a/frontend/static/messages/en.json
+++ b/frontend/static/messages/en.json
@@ -424,7 +424,7 @@
       },
       "buffer": {
         "overloadTitle": "Audio Analysis Overloaded",
-        "overloadMessage": "Your system is dropping {dropRate}% of audio samples for source '{sourceName}' because it cannot keep up with analysis. Reduce the BirdNET overlap value in detection settings or consider upgrading to a faster CPU."
+        "overloadMessage": "Your system is dropping {dropRate}% of audio samples for source ''{sourceName}'' because it cannot keep up with analysis. Reduce the BirdNET overlap value in detection settings or consider upgrading to a faster CPU."
       },
       "alert": {
         "firedTitle": "{rule_name}",

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -424,7 +424,7 @@
       },
       "buffer": {
         "overloadTitle": "Análisis de audio sobrecargado",
-        "overloadMessage": "Su sistema está descartando el {dropRate} % de las muestras de audio de la fuente '{sourceName}' porque no puede seguir el ritmo del análisis. Reduzca el valor de superposición de BirdNET en los ajustes de detección o considere actualizar a una CPU más rápida."
+        "overloadMessage": "Su sistema está descartando el {dropRate} % de las muestras de audio de la fuente ''{sourceName}'' porque no puede seguir el ritmo del análisis. Reduzca el valor de superposición de BirdNET en los ajustes de detección o considere actualizar a una CPU más rápida."
       },
       "alert": {
         "firedTitle": "{rule_name}",

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -424,7 +424,7 @@
       },
       "buffer": {
         "overloadTitle": "Äänianalyysi ylikuormitettu",
-        "overloadMessage": "Järjestelmäsi hylkää {dropRate} % lähteen '{sourceName}' ääninäytteistä, koska se ei pysy analyysin tahdissa. Pienennä BirdNET-päällekkäisyysarvoa tunnistusasetuksista tai harkitse nopeamman suorittimen hankkimista."
+        "overloadMessage": "Järjestelmäsi hylkää {dropRate} % lähteen ''{sourceName}'' ääninäytteistä, koska se ei pysy analyysin tahdissa. Pienennä BirdNET-päällekkäisyysarvoa tunnistusasetuksista tai harkitse nopeamman suorittimen hankkimista."
       },
       "alert": {
         "firedTitle": "{rule_name}",

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -424,7 +424,7 @@
       },
       "buffer": {
         "overloadTitle": "Analyse audio surchargée",
-        "overloadMessage": "Votre système perd {dropRate} % des échantillons audio de la source '{sourceName}' car il ne peut pas suivre le rythme de l'analyse. Réduisez la valeur de chevauchement BirdNET dans les paramètres de détection ou envisagez de passer à un processeur plus rapide."
+        "overloadMessage": "Votre système perd {dropRate} % des échantillons audio de la source ''{sourceName}'' car il ne peut pas suivre le rythme de l'analyse. Réduisez la valeur de chevauchement BirdNET dans les paramètres de détection ou envisagez de passer à un processeur plus rapide."
       },
       "alert": {
         "firedTitle": "{rule_name}",

--- a/frontend/static/messages/hu.json
+++ b/frontend/static/messages/hu.json
@@ -424,7 +424,7 @@
       },
       "buffer": {
         "overloadTitle": "Hang elemzés túlterhelve",
-        "overloadMessage": "A rendszere {dropRate}% hangmintát dob el a '{sourceName}' forrásból, mert nem bírja az elemzést. Csökkentse a BirdNET átfedési értékét a detektálási beállításokban, vagy fontoljon meg egy gyorsabb CPU-ra való váltást."
+        "overloadMessage": "A rendszere {dropRate}% hangmintát dob el a ''{sourceName}'' forrásból, mert nem bírja az elemzést. Csökkentse a BirdNET átfedési értékét a detektálási beállításokban, vagy fontoljon meg egy gyorsabb CPU-ra való váltást."
       },
       "alert": {
         "firedTitle": "{rule_name}",

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -424,7 +424,7 @@
       },
       "buffer": {
         "overloadTitle": "Analisi audio sovraccaricata",
-        "overloadMessage": "Il sistema sta scartando il {dropRate} % dei campioni audio della sorgente '{sourceName}' perché non riesce a tenere il passo con l'analisi. Riduci il valore di sovrapposizione BirdNET nelle impostazioni di rilevamento o considera l'aggiornamento a una CPU più veloce."
+        "overloadMessage": "Il sistema sta scartando il {dropRate} % dei campioni audio della sorgente ''{sourceName}'' perché non riesce a tenere il passo con l'analisi. Riduci il valore di sovrapposizione BirdNET nelle impostazioni di rilevamento o considera l'aggiornamento a una CPU più veloce."
       },
       "alert": {
         "firedTitle": "{rule_name}",

--- a/frontend/static/messages/lv.json
+++ b/frontend/static/messages/lv.json
@@ -424,7 +424,7 @@
       },
       "buffer": {
         "overloadTitle": "Audio analīze pārslogota",
-        "overloadMessage": "Jūsu sistēma izlaiž {dropRate}% audio paraugu avotam '{sourceName}', jo tā nespēj sekot līdzi analīzei. Samaziniet BirdNET pārklāšanās vērtību noteikšanas iestatījumos vai apsveriet jaudīgāka procesora izmantošanu."
+        "overloadMessage": "Jūsu sistēma izlaiž {dropRate}% audio paraugu avotam ''{sourceName}'', jo tā nespēj sekot līdzi analīzei. Samaziniet BirdNET pārklāšanās vērtību noteikšanas iestatījumos vai apsveriet jaudīgāka procesora izmantošanu."
       },
       "alert": {
         "firedTitle": "{rule_name}",

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -424,7 +424,7 @@
       },
       "buffer": {
         "overloadTitle": "Audio-analyse overbelast",
-        "overloadMessage": "Uw systeem verliest {dropRate} % van de audiosamples van bron '{sourceName}' omdat het de analyse niet kan bijhouden. Verlaag de BirdNET-overlappingswaarde in de detectie-instellingen of overweeg een snellere CPU."
+        "overloadMessage": "Uw systeem verliest {dropRate} % van de audiosamples van bron ''{sourceName}'' omdat het de analyse niet kan bijhouden. Verlaag de BirdNET-overlappingswaarde in de detectie-instellingen of overweeg een snellere CPU."
       },
       "alert": {
         "firedTitle": "{rule_name}",

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -424,7 +424,7 @@
       },
       "buffer": {
         "overloadTitle": "Analiza dźwięku przeciążona",
-        "overloadMessage": "System odrzuca {dropRate} % próbek dźwięku ze źródła '{sourceName}', ponieważ nie nadąża z analizą. Zmniejsz wartość nakładania BirdNET w ustawieniach wykrywania lub rozważ wymianę procesora na szybszy."
+        "overloadMessage": "System odrzuca {dropRate} % próbek dźwięku ze źródła ''{sourceName}'', ponieważ nie nadąża z analizą. Zmniejsz wartość nakładania BirdNET w ustawieniach wykrywania lub rozważ wymianę procesora na szybszy."
       },
       "alert": {
         "firedTitle": "{rule_name}",

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -424,7 +424,7 @@
       },
       "buffer": {
         "overloadTitle": "Análise de áudio sobrecarregada",
-        "overloadMessage": "O seu sistema está a descartar {dropRate} % das amostras de áudio da fonte '{sourceName}' porque não consegue acompanhar a análise. Reduza o valor de sobreposição do BirdNET nas definições de deteção ou considere atualizar para um CPU mais rápido."
+        "overloadMessage": "O seu sistema está a descartar {dropRate} % das amostras de áudio da fonte ''{sourceName}'' porque não consegue acompanhar a análise. Reduza o valor de sobreposição do BirdNET nas definições de deteção ou considere atualizar para um CPU mais rápido."
       },
       "alert": {
         "firedTitle": "{rule_name}",

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -424,7 +424,7 @@
       },
       "buffer": {
         "overloadTitle": "Analýza zvuku preťažená",
-        "overloadMessage": "Váš systém zahadzuje {dropRate} % zvukových vzoriek zo zdroja '{sourceName}', pretože nestíha analýzu. Znížte hodnotu prekrytia BirdNET v nastaveniach detekcie alebo zvážte rýchlejší procesor."
+        "overloadMessage": "Váš systém zahadzuje {dropRate} % zvukových vzoriek zo zdroja ''{sourceName}'', pretože nestíha analýzu. Znížte hodnotu prekrytia BirdNET v nastaveniach detekcie alebo zvážte rýchlejší procesor."
       },
       "alert": {
         "firedTitle": "{rule_name}",

--- a/frontend/static/messages/sv.json
+++ b/frontend/static/messages/sv.json
@@ -424,7 +424,7 @@
       },
       "buffer": {
         "overloadTitle": "Ljudanalys överbelastad",
-        "overloadMessage": "Ditt system förlorar {dropRate}% av ljudsamplingarna för källa '{sourceName}' eftersom det inte kan hålla jämna steg med analysen. Minska BirdNET-överlappningsvärdet i detektionsinställningarna eller överväg att uppgradera till en snabbare CPU."
+        "overloadMessage": "Ditt system förlorar {dropRate}% av ljudsamplingarna för källa ''{sourceName}'' eftersom det inte kan hålla jämna steg med analysen. Minska BirdNET-överlappningsvärdet i detektionsinställningarna eller överväg att uppgradera till en snabbare CPU."
       },
       "alert": {
         "firedTitle": "{rule_name}",


### PR DESCRIPTION
## Summary

- Add `|| \`HTTP ${response.status}\`` fallback to 3 error-throw sites in DashboardPage.svelte where `response.statusText` was the only error detail
- Add defensive `.filter()` to hourly weather map builder in DailySummaryCard.svelte to handle malformed `time` fields gracefully

HTTP/2 and HTTP/3 do not transmit reason phrases, so `response.statusText` is empty in modern browsers using these protocols. This caused error messages like "Fehler beim Abrufen der Tageszusammenfassung: " (trailing colon, no detail) reported in Sentry as BIRDNET-GO-1MH.

## Test plan

- [ ] Verify dashboard loads normally with no regressions
- [ ] Simulate a 500 error (e.g., stop backend) and confirm error message shows "HTTP 500" instead of empty string

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More robust hourly weather parsing to avoid malformed hourly entries.
  * Dashboard error messages now include HTTP status fallback for clearer error text.

* **Localization**
  * Adjusted placeholder quoting in buffer-overload notifications across many languages for consistent rendering.
  * Added Czech detection selection strings and updated several detection-related UI labels to English.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3125?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->