### PR TITLE
fix(audiocore): wire stream manager and fix source ID mismatch in quiet hours

### DIFF
--- a/internal/analysis/audio_pipeline_service.go
+++ b/internal/analysis/audio_pipeline_service.go
@@ -300,8 +300,7 @@ func (p *AudioPipelineService) Start(_ context.Context) error {
 			if ok && src.Type == audiocore.SourceTypeAudioCard {
 				return p.quietHoursScheduler.IsSoundCardSuppressed()
 			}
-			suppressed := p.quietHoursScheduler.GetSuppressedStreams()
-			return suppressed[sourceID]
+			return p.quietHoursScheduler.IsStreamSuppressed(sourceID)
 		},
 	}
 	p.watchdog = audiocore.NewLivenessWatchdog(

--- a/internal/audiocore/engine/engine.go
+++ b/internal/audiocore/engine/engine.go
@@ -232,6 +232,76 @@ func (e *AudioEngine) Scheduler() *schedule.QuietHoursScheduler {
 // resources (SunCalc, ControlChan) only available after service startup.
 func (e *AudioEngine) SetScheduler(s *schedule.QuietHoursScheduler) {
 	e.scheduler.Store(s)
+	if s != nil {
+		s.SetStreamManager(func() schedule.StreamManager { return e })
+	}
+}
+
+// GetActiveStreamIDs returns the runtime source IDs currently tracked by FFmpeg.
+func (e *AudioEngine) GetActiveStreamIDs() []string {
+	return e.ffmpegMgr.GetActiveStreamIDs()
+}
+
+// GetActiveStreamURLs returns active runtime sourceID -> raw stream URL.
+func (e *AudioEngine) GetActiveStreamURLs() map[string]string {
+	ids := e.ffmpegMgr.GetActiveStreamIDs()
+	urls := make(map[string]string, len(ids))
+	for _, sourceID := range ids {
+		if url, ok := e.registry.ConnectionStringByID(sourceID); ok {
+			urls[sourceID] = url
+		}
+	}
+	return urls
+}
+
+// StopStream stops the FFmpeg stream for sourceID while keeping the registered
+// source, routes, and buffers available for a later quiet-hours restart.
+func (e *AudioEngine) StopStream(sourceID string) error {
+	if err := e.ffmpegMgr.StopStream(sourceID); err != nil {
+		return err
+	}
+	_ = e.registry.UpdateState(sourceID, audiocore.SourceStopped)
+	return nil
+}
+
+// StartStream restarts a quiet-hours-suppressed FFmpeg stream under its
+// existing runtime sourceID.
+func (e *AudioEngine) StartStream(sourceID, url, transport string) error {
+	src, ok := e.registry.Get(sourceID)
+	if !ok {
+		return fmt.Errorf("restart stream: %w: %s", audiocore.ErrSourceNotFound, sourceID)
+	}
+	if transport == "" {
+		transport = e.transport
+	}
+	sampleRate := src.SampleRate
+	if sampleRate <= 0 {
+		sampleRate = defaultSampleRate
+	}
+	channels := src.Channels
+	if channels <= 0 {
+		channels = 1
+	}
+	streamCfg := &ffmpeg.StreamConfig{
+		SourceID:         sourceID,
+		SourceName:       src.DisplayName,
+		URL:              url,
+		Type:             string(src.Type),
+		SampleRate:       sampleRate,
+		BitDepth:         src.BitDepth,
+		Channels:         channels,
+		FFmpegPath:       e.ffmpegPath,
+		Transport:        transport,
+		FFmpegParameters: e.ffmpegParameters,
+		LogLevel:         e.logLevel,
+		Debug:            e.debug,
+	}
+	if err := e.ffmpegMgr.StartStream(streamCfg); err != nil {
+		_ = e.registry.UpdateState(sourceID, audiocore.SourceError)
+		return err
+	}
+	_ = e.registry.UpdateState(sourceID, audiocore.SourceRunning)
+	return nil
 }
 
 // SetPrimaryModel sets the model identifier and analysis buffer dimensions

--- a/internal/audiocore/engine/engine.go
+++ b/internal/audiocore/engine/engine.go
@@ -47,6 +47,9 @@ const (
 
 	// defaultSampleRate is used when a source config has no sample rate set.
 	defaultSampleRate = 48000
+
+	// defaultChannels is used when a source config has no channel count set.
+	defaultChannels = 1
 )
 
 // Config holds the configuration needed to create an AudioEngine.
@@ -191,9 +194,7 @@ func New(ctx context.Context, cfg *Config, scheduler *schedule.QuietHoursSchedul
 		debug:                cfg.Debug,
 		captureBufferSeconds: captureBufferSecs(cfg.CaptureBufferSeconds),
 	}
-	if scheduler != nil {
-		e.scheduler.Store(scheduler)
-	}
+	e.SetScheduler(scheduler)
 	return e
 }
 
@@ -280,7 +281,7 @@ func (e *AudioEngine) StartStream(sourceID, url, transport string) error {
 	}
 	channels := src.Channels
 	if channels <= 0 {
-		channels = 1
+		channels = defaultChannels
 	}
 	streamCfg := &ffmpeg.StreamConfig{
 		SourceID:         sourceID,

--- a/internal/audiocore/schedule/quiet_hours.go
+++ b/internal/audiocore/schedule/quiet_hours.go
@@ -37,14 +37,18 @@ const (
 	SignalQuietHoursStartSoundCard = "quiet_hours_start_soundcard"
 )
 
-// streamManager is the interface used by the scheduler to stop/start streams.
+// StreamManager is the interface used by the scheduler to stop/start streams.
 // Implemented by a wrapper around ffmpeg.Manager; can be replaced with a mock in tests.
 //
-// sourceID is the unique identifier for the stream (typically the stream URL).
+// sourceID is the unique runtime identifier for the stream (for example,
+// "rtsp_<hash>"). It is not necessarily the configured stream URL.
 // url is the stream URL. transport is the RTSP transport protocol (e.g., "tcp").
-type streamManager interface {
+type StreamManager interface {
 	// GetActiveStreamIDs returns the sourceIDs of all currently active streams.
 	GetActiveStreamIDs() []string
+
+	// GetActiveStreamURLs returns active sourceID -> configured stream URL.
+	GetActiveStreamURLs() map[string]string
 
 	// StopStream stops the stream identified by sourceID.
 	StopStream(sourceID string) error
@@ -92,12 +96,17 @@ type QuietHoursScheduler struct {
 
 	// getManager returns the stream manager used by Evaluate.
 	// Overridden in tests to inject a mock.
-	getManager func() streamManager
+	getManager func() StreamManager
 
 	// Track which streams are currently suppressed by quiet hours.
-	// Key is the stream sourceID (URL), value is true if currently suppressed.
+	// Key is the runtime stream sourceID, value is true if currently suppressed.
 	suppressed map[string]bool
-	mu         sync.Mutex
+
+	// Tracks configured stream URL -> runtime sourceID for streams stopped by
+	// quiet hours. Stopped streams are no longer active in the stream manager, so
+	// the scheduler must keep this mapping to restart the same sourceID later.
+	suppressedURLs map[string]string
+	mu             sync.Mutex
 
 	// Sound card suppression state.
 	soundCardSuppressed bool
@@ -119,18 +128,19 @@ func NewQuietHoursScheduler(cfg QuietHoursConfig) *QuietHoursScheduler {
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	return &QuietHoursScheduler{
-		ctx:         ctx,
-		cancel:      cancel,
-		sunCalc:     cfg.SunCalc,
-		controlChan: cfg.ControlChan,
-		log:         log,
-		suppressed:  make(map[string]bool),
+		ctx:            ctx,
+		cancel:         cancel,
+		sunCalc:        cfg.SunCalc,
+		controlChan:    cfg.ControlChan,
+		log:            log,
+		suppressed:     make(map[string]bool),
+		suppressedURLs: make(map[string]string),
 	}
 }
 
 // SetStreamManager overrides the stream manager used by Evaluate.
 // Intended for testing; call before Start.
-func (s *QuietHoursScheduler) SetStreamManager(fn func() streamManager) {
+func (s *QuietHoursScheduler) SetStreamManager(fn func() StreamManager) {
 	s.getManager = fn
 }
 
@@ -203,25 +213,41 @@ func (s *QuietHoursScheduler) Evaluate() {
 	for _, id := range manager.GetActiveStreamIDs() {
 		activeStreams[id] = true
 	}
+	activeSourceIDByURL := make(map[string]string)
+	for sourceID, url := range manager.GetActiveStreamURLs() {
+		activeSourceIDByURL[url] = sourceID
+	}
 
 	// Phase 1: Determine actions under lock (no external calls).
 	var actions []streamAction
 	var soundCardSignal string // "" = no action
 
 	s.mu.Lock()
+	if s.suppressedURLs == nil {
+		s.suppressedURLs = make(map[string]string)
+	}
 
 	for _, stream := range settings.Realtime.RTSP.AllStreams() {
 		if !stream.IsEnabled() {
-			delete(s.suppressed, stream.URL)
+			if sourceID, ok := s.suppressedURLs[stream.URL]; ok {
+				delete(s.suppressed, sourceID)
+				delete(s.suppressedURLs, stream.URL)
+			}
 			continue
 		}
-		// Use URL as the sourceID (mirrors the old behaviour).
-		sourceID := stream.URL
+		activeSourceID, isActive := activeSourceIDByURL[stream.URL]
+		if !isActive && activeStreams[stream.URL] {
+			// Backward compatibility for tests or legacy managers that still use
+			// the URL as the sourceID and cannot expose sourceID -> URL metadata.
+			activeSourceID = stream.URL
+			isActive = true
+		}
+		suppressedSourceID, isSuppressed := s.suppressedURLs[stream.URL]
 
 		if !stream.QuietHours.Enabled {
-			if s.suppressed[sourceID] {
+			if isSuppressed {
 				actions = append(actions, streamAction{
-					sourceID:  sourceID,
+					sourceID:  suppressedSourceID,
 					url:       stream.URL,
 					name:      stream.Name,
 					transport: stream.Transport,
@@ -233,16 +259,16 @@ func (s *QuietHoursScheduler) Evaluate() {
 
 		inQuietHours := s.isInQuietHours(&stream.QuietHours, now)
 
-		if inQuietHours && activeStreams[sourceID] && !s.suppressed[sourceID] {
+		if inQuietHours && isActive && !s.suppressed[activeSourceID] {
 			actions = append(actions, streamAction{
-				sourceID: sourceID,
+				sourceID: activeSourceID,
 				url:      stream.URL,
 				name:     stream.Name,
 				stop:     true,
 			})
-		} else if !inQuietHours && s.suppressed[sourceID] {
+		} else if !inQuietHours && isSuppressed {
 			actions = append(actions, streamAction{
-				sourceID:  sourceID,
+				sourceID:  suppressedSourceID,
 				url:       stream.URL,
 				name:      stream.Name,
 				transport: stream.Transport,
@@ -252,13 +278,14 @@ func (s *QuietHoursScheduler) Evaluate() {
 	}
 
 	// Clean up suppressed entries for streams no longer in config.
-	configuredIDs := make(map[string]bool, len(settings.Realtime.RTSP.Streams))
+	configuredURLs := make(map[string]bool, len(settings.Realtime.RTSP.Streams))
 	for _, stream := range settings.Realtime.RTSP.EnabledStreams() {
-		configuredIDs[stream.URL] = true
+		configuredURLs[stream.URL] = true
 	}
-	for id := range s.suppressed {
-		if !configuredIDs[id] {
-			delete(s.suppressed, id)
+	for url, sourceID := range s.suppressedURLs {
+		if !configuredURLs[url] {
+			delete(s.suppressed, sourceID)
+			delete(s.suppressedURLs, url)
 		}
 	}
 
@@ -282,6 +309,7 @@ func (s *QuietHoursScheduler) Evaluate() {
 			} else {
 				s.mu.Lock()
 				s.suppressed[action.sourceID] = true
+				s.suppressedURLs[action.url] = action.sourceID
 				s.mu.Unlock()
 			}
 		} else {
@@ -295,6 +323,7 @@ func (s *QuietHoursScheduler) Evaluate() {
 			} else {
 				s.mu.Lock()
 				delete(s.suppressed, action.sourceID)
+				delete(s.suppressedURLs, action.url)
 				s.mu.Unlock()
 			}
 		}
@@ -479,14 +508,21 @@ func (s *QuietHoursScheduler) IsSoundCardSuppressed() bool {
 	return s.soundCardSuppressed
 }
 
-// GetSuppressedStreams returns a map of stream sourceIDs to their suppression state.
+// GetSuppressedStreams returns a map of stream URLs to their suppression state.
 // Only streams currently suppressed by quiet hours are included.
 func (s *QuietHoursScheduler) GetSuppressedStreams() map[string]bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	result := make(map[string]bool, len(s.suppressed))
+	reported := make(map[string]bool, len(s.suppressedURLs))
+	for url, sourceID := range s.suppressedURLs {
+		if s.suppressed[sourceID] {
+			result[url] = true
+			reported[sourceID] = true
+		}
+	}
 	for id, suppressed := range s.suppressed {
-		if suppressed {
+		if suppressed && !reported[id] {
 			result[id] = true
 		}
 	}

--- a/internal/audiocore/schedule/quiet_hours.go
+++ b/internal/audiocore/schedule/quiet_hours.go
@@ -508,8 +508,18 @@ func (s *QuietHoursScheduler) IsSoundCardSuppressed() bool {
 	return s.soundCardSuppressed
 }
 
+// IsStreamSuppressed reports whether the given runtime sourceID is currently
+// suppressed by quiet hours.
+func (s *QuietHoursScheduler) IsStreamSuppressed(sourceID string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.suppressed[sourceID]
+}
+
 // GetSuppressedStreams returns a map of stream URLs to their suppression state.
-// Only streams currently suppressed by quiet hours are included.
+// Only streams currently suppressed by quiet hours are included. The keys are
+// configured stream URLs when available, falling back to runtime sourceIDs for
+// legacy entries.
 func (s *QuietHoursScheduler) GetSuppressedStreams() map[string]bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/internal/audiocore/schedule/quiet_hours_test.go
+++ b/internal/audiocore/schedule/quiet_hours_test.go
@@ -30,9 +30,10 @@ func inactiveQuietWindow() (start, end string) {
 	return fmt.Sprintf("%02d:00", h), fmt.Sprintf("%02d:01", h)
 }
 
-// mockManager implements streamManager for testing Evaluate().
+// mockManager implements StreamManager for testing Evaluate().
 type mockManager struct {
 	activeStreams []string
+	streamURLs    map[string]string
 	stopped       []string
 	started       []struct{ sourceID, url, transport string }
 	stopErr       error
@@ -41,6 +42,10 @@ type mockManager struct {
 
 func (m *mockManager) GetActiveStreamIDs() []string {
 	return m.activeStreams
+}
+
+func (m *mockManager) GetActiveStreamURLs() map[string]string {
+	return m.streamURLs
 }
 
 func (m *mockManager) StopStream(sourceID string) error {
@@ -59,7 +64,7 @@ func newTestScheduler(t *testing.T, mock *mockManager) *QuietHoursScheduler {
 	s := NewQuietHoursScheduler(QuietHoursConfig{
 		ControlChan: make(chan string, 1),
 	})
-	s.SetStreamManager(func() streamManager { return mock })
+	s.SetStreamManager(func() StreamManager { return mock })
 	return s
 }
 
@@ -345,8 +350,12 @@ func TestGetSolarEventTime(t *testing.T) {
 
 // TestQuietHours_Evaluate verifies suppression during quiet hours.
 func TestQuietHours_Evaluate(t *testing.T) {
-	t.Run("stops stream during quiet hours", func(t *testing.T) {
-		mock := &mockManager{activeStreams: []string{"rtsp://cam1"}}
+	t.Run("stops stream during quiet hours using production source id", func(t *testing.T) {
+		const sourceID = "rtsp_abc123"
+		mock := &mockManager{
+			activeStreams: []string{sourceID},
+			streamURLs:    map[string]string{sourceID: "rtsp://cam1"},
+		}
 
 		settings := conf.GetTestSettings()
 		settings.Realtime.RTSP.Streams = []conf.StreamConfig{
@@ -365,12 +374,14 @@ func TestQuietHours_Evaluate(t *testing.T) {
 		s := newTestScheduler(t, mock)
 		s.Evaluate()
 
-		assert.Equal(t, []string{"rtsp://cam1"}, mock.stopped, "should stop stream during quiet hours")
+		assert.Equal(t, []string{sourceID}, mock.stopped, "should stop stream during quiet hours")
 		assert.Empty(t, mock.started, "should not start any streams")
-		assert.True(t, s.suppressed["rtsp://cam1"], "stream should be marked suppressed")
+		assert.True(t, s.suppressed[sourceID], "stream should be marked suppressed by runtime source ID")
+		assert.Equal(t, sourceID, s.suppressedURLs["rtsp://cam1"], "configured URL should map to stopped source ID")
 	})
 
-	t.Run("restarts stream after quiet hours", func(t *testing.T) {
+	t.Run("restarts stream after quiet hours using stopped source id", func(t *testing.T) {
+		const sourceID = "rtsp_abc123"
 		mock := &mockManager{activeStreams: []string{}}
 
 		qhStart, qhEnd := inactiveQuietWindow()
@@ -389,18 +400,21 @@ func TestQuietHours_Evaluate(t *testing.T) {
 		setTestSettings(t, settings)
 
 		s := newTestScheduler(t, mock)
-		s.suppressed["rtsp://cam1"] = true // previously suppressed
+		s.suppressed[sourceID] = true // previously suppressed
+		s.suppressedURLs["rtsp://cam1"] = sourceID
 		s.Evaluate()
 
 		assert.Empty(t, mock.stopped, "should not stop any streams")
 		assert.Len(t, mock.started, 1, "should restart previously suppressed stream")
-		assert.Equal(t, "rtsp://cam1", mock.started[0].sourceID)
+		assert.Equal(t, sourceID, mock.started[0].sourceID)
 		assert.Equal(t, "rtsp://cam1", mock.started[0].url)
 		assert.Equal(t, "tcp", mock.started[0].transport)
-		assert.False(t, s.suppressed["rtsp://cam1"], "stream should no longer be suppressed")
+		assert.False(t, s.suppressed[sourceID], "stream should no longer be suppressed")
+		assert.NotContains(t, s.suppressedURLs, "rtsp://cam1", "URL mapping should be cleared after restart")
 	})
 
 	t.Run("disabled quiet hours restores suppressed stream", func(t *testing.T) {
+		const sourceID = "rtsp_abc123"
 		mock := &mockManager{activeStreams: []string{}}
 
 		settings := conf.GetTestSettings()
@@ -413,15 +427,20 @@ func TestQuietHours_Evaluate(t *testing.T) {
 		setTestSettings(t, settings)
 
 		s := newTestScheduler(t, mock)
-		s.suppressed["rtsp://cam1"] = true // was suppressed
+		s.suppressed[sourceID] = true // was suppressed
+		s.suppressedURLs["rtsp://cam1"] = sourceID
 		s.Evaluate()
 
 		assert.Len(t, mock.started, 1, "should restart stream when quiet hours disabled")
-		assert.Equal(t, "rtsp://cam1", mock.started[0].sourceID)
+		assert.Equal(t, sourceID, mock.started[0].sourceID)
 	})
 
 	t.Run("disabled stream is ignored and stale suppression is cleared", func(t *testing.T) {
-		mock := &mockManager{activeStreams: []string{"rtsp://cam1"}}
+		const sourceID = "rtsp_abc123"
+		mock := &mockManager{
+			activeStreams: []string{sourceID},
+			streamURLs:    map[string]string{sourceID: "rtsp://cam1"},
+		}
 
 		settings := conf.GetTestSettings()
 		settings.Realtime.RTSP.Streams = []conf.StreamConfig{
@@ -441,16 +460,22 @@ func TestQuietHours_Evaluate(t *testing.T) {
 		setTestSettings(t, settings)
 
 		s := newTestScheduler(t, mock)
-		s.suppressed["rtsp://cam1"] = true
+		s.suppressed[sourceID] = true
+		s.suppressedURLs["rtsp://cam1"] = sourceID
 		s.Evaluate()
 
 		assert.Empty(t, mock.stopped, "disabled streams should not be stopped by quiet hours")
 		assert.Empty(t, mock.started, "disabled streams should not be restarted by quiet hours")
-		assert.False(t, s.suppressed["rtsp://cam1"], "stale suppression should be cleared for disabled streams")
+		assert.False(t, s.suppressed[sourceID], "stale suppression should be cleared for disabled streams")
+		assert.NotContains(t, s.suppressedURLs, "rtsp://cam1", "stale URL mapping should be cleared")
 	})
 
 	t.Run("no action when not in quiet hours", func(t *testing.T) {
-		mock := &mockManager{activeStreams: []string{"rtsp://cam1"}}
+		const sourceID = "rtsp_abc123"
+		mock := &mockManager{
+			activeStreams: []string{sourceID},
+			streamURLs:    map[string]string{sourceID: "rtsp://cam1"},
+		}
 
 		qhStart, qhEnd := inactiveQuietWindow()
 		settings := conf.GetTestSettings()
@@ -478,7 +503,7 @@ func TestQuietHours_Evaluate(t *testing.T) {
 		s := NewQuietHoursScheduler(QuietHoursConfig{
 			ControlChan: make(chan string, 1),
 		})
-		s.SetStreamManager(func() streamManager { return nil })
+		s.SetStreamManager(func() StreamManager { return nil })
 		// Should not panic.
 		s.Evaluate()
 	})
@@ -557,8 +582,12 @@ func TestGetSuppressedStreams(t *testing.T) {
 
 	s := &QuietHoursScheduler{
 		suppressed: map[string]bool{
-			"rtsp://cam1": true,
-			"rtsp://cam2": false,
+			"rtsp_abc123": true,
+			"rtsp_def456": false,
+		},
+		suppressedURLs: map[string]string{
+			"rtsp://cam1": "rtsp_abc123",
+			"rtsp://cam2": "rtsp_def456",
 		},
 	}
 


### PR DESCRIPTION
## Summary

Fixes a regression introduced by the audiocore refactor (PR #2489) that silently broke quiet hours enforcement for RTSP streams. The original PR #2066 was working when it was opened, but the refactor introduced two separate wiring bugs that together caused the scheduler to have no effect.

### Root cause

1. **`SetScheduler` never wired the stream manager**: The `SetStreamManager` call was missing, so the scheduler's `getManager` func was always nil. At evaluation time the scheduler bailed out early with "stream manager not available" and did nothing.

2. **`New()` bypassed `SetScheduler`**: When a scheduler was passed to `New()`, it called `e.scheduler.Store(scheduler)` directly, skipping `SetScheduler` entirely, so the wiring fix in `SetScheduler` would not apply to schedulers set at construction time.

3. **Source ID mismatch**: The scheduler used `stream.URL` as the source ID to call `StopStream`/`StartStream`, but the engine's `SourceRegistry` generates hashed IDs (`rtsp_<hex>`, e.g. `rtsp_a1b2c3d4`). The stop/start calls were targeting IDs that never existed.

### Fix

- **`engine.go`**: `SetScheduler` now calls `s.SetStreamManager(...)` after storing the scheduler. `New()` now delegates to `SetScheduler` instead of calling `e.scheduler.Store` directly.
- **`quiet_hours.go`**: Added `GetActiveStreamURLs() map[string]string` to the `StreamManager` interface (returns URL→sourceID map). The scheduler now builds a reverse lookup at evaluation time and uses the real runtime source IDs when calling `StopStream`/`StartStream`. A `suppressedURLs` map tracks which URLs were stopped (and their runtime IDs) so they can be correctly restarted.
- **`quiet_hours_test.go`**: Updated `mockManager` to implement the new interface and all test cases use realistic hashed source IDs.
- **`engine.go`**: Replaced magic number `1` with named constant `defaultChannels` per project conventions.

## Test plan

- [ ] Existing unit tests pass: `go test ./internal/audiocore/...`
- [ ] Quiet hours stop/start verified manually with an RTSP stream configured
- [ ] `golangci-lint run -v` clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Start and stop individual streams at runtime from the service.
  * Query active stream IDs and their connection URLs.

* **Improvements**
  * Quiet-hours management now tracks suppression by runtime stream identity and reliably restarts the same runtime stream.
  * GetSuppressedStreams() reporting improved to return suppression keyed by stream URL (with legacy fallback), and a new query lets callers check suppression by runtime stream ID.

* **Tests**
  * Quiet-hours behavior covered by updated tests reflecting runtime IDs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3127?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->