### PR TITLE
fix: suppress context.Canceled Sentry noise and non-finite duration crashes

### DIFF
--- a/frontend/src/lib/desktop/components/media/AudioPlayer.svelte
+++ b/frontend/src/lib/desktop/components/media/AudioPlayer.svelte
@@ -301,7 +301,7 @@
 
   // Convert mouse/touch X position to time in seconds
   const xToTime = (clientX: number): number => {
-    if (!playerContainer || duration <= 0) return 0;
+    if (!playerContainer || !isFinite(duration) || duration <= 0) return 0;
     const rect = playerContainer.getBoundingClientRect();
     const relativeX = Math.max(0, Math.min(clientX - rect.left, rect.width));
     return (relativeX / rect.width) * duration;
@@ -309,7 +309,7 @@
 
   // Convert time in seconds to percentage of container width
   const timeToPercent = (timeSec: number): number => {
-    if (duration <= 0) return 0;
+    if (!isFinite(duration) || duration <= 0) return 0;
     return (timeSec / duration) * 100;
   };
 
@@ -372,7 +372,7 @@
   };
 
   const handleSelectionMouseDown = (e: MouseEvent) => {
-    if (!enableClipExtraction || duration <= 0) return;
+    if (!enableClipExtraction || !isFinite(duration) || duration <= 0) return;
     if (e.button !== 0) return;
 
     // Ignore clicks on interactive elements (toolbar buttons, controls, sliders, popups, etc.)
@@ -521,7 +521,7 @@
   };
 
   const handleSelectionTouchStart = (e: TouchEvent) => {
-    if (!enableClipExtraction || duration <= 0 || !e.touches[0]) return;
+    if (!enableClipExtraction || !isFinite(duration) || duration <= 0 || !e.touches[0]) return;
 
     // Ignore touches on interactive elements (buttons, sliders, popups, etc.)
     const target = e.target as HTMLElement;
@@ -920,7 +920,7 @@
     extractionFormat = format;
     if (selectionStartSec === null || selectionEndSec === null) {
       // No selection — export full file (guard against unloaded metadata)
-      if (duration <= 0) return;
+      if (!isFinite(duration) || duration <= 0) return;
       extractClip(0, duration);
     } else {
       extractClip();
@@ -1020,7 +1020,7 @@
   };
 
   const handleProgressClick = (event: MouseEvent) => {
-    if (!audioElement || duration <= 0) return;
+    if (!audioElement || !isFinite(duration) || duration <= 0) return;
 
     // Use the toolbar's own progress bar if the event target is inside one,
     // otherwise fall back to playerContainer (always rendered).

--- a/frontend/src/lib/desktop/features/dashboard/components/PlayOverlay.svelte
+++ b/frontend/src/lib/desktop/features/dashboard/components/PlayOverlay.svelte
@@ -266,7 +266,7 @@
 
   // Seek to position when clicking on the overlay area
   function handleSeek(event: MouseEvent) {
-    if (!audioElement || !overlayElement || duration === 0) return;
+    if (!audioElement || !overlayElement || !isFinite(duration) || duration <= 0) return;
 
     const rect = overlayElement.getBoundingClientRect();
     const clickX = event.clientX - rect.left;
@@ -475,7 +475,7 @@
   aria-valuetext={`${formatTime(currentTime)} of ${formatTime(duration)}`}
   onmousedown={handleMouseDown}
   onkeydown={e => {
-    if (!audioElement || duration === 0) return;
+    if (!audioElement || !isFinite(duration) || duration <= 0) return;
     const SMALL_SKIP = 5;
     const LARGE_SKIP = 10;
 

--- a/frontend/src/lib/utils/useAudioPlayback.svelte.ts
+++ b/frontend/src/lib/utils/useAudioPlayback.svelte.ts
@@ -274,7 +274,7 @@ export function useAudioPlayback(options: AudioPlaybackOptions): AudioPlaybackSt
   }
 
   function seek(timeSec: number) {
-    if (!audioElement || duration <= 0) return;
+    if (!audioElement || !isFinite(duration) || duration <= 0) return;
     const clamped = Math.max(0, Math.min(timeSec, duration));
     audioElement.currentTime = clamped;
     currentTime = clamped;

--- a/internal/api/v2/api.go
+++ b/internal/api/v2/api.go
@@ -926,6 +926,11 @@ func (c *Controller) reportErrorToTelemetry(ctx echo.Context, err error, message
 		}
 	}
 
+	// Client disconnects and request timeouts are not server bugs.
+	if err != nil && (errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)) {
+		return
+	}
+
 	path := ctx.Request().URL.Path
 	method := ctx.Request().Method
 

--- a/internal/errors/telemetry_integration.go
+++ b/internal/errors/telemetry_integration.go
@@ -166,15 +166,13 @@ func shouldReportToSentry(ee *EnhancedError) bool {
 		return true
 	}
 
-	// Database operations frequently observe context.Canceled and
-	// context.DeadlineExceeded during graceful shutdown and request-timeout
-	// conditions (e.g. an HTTP client disconnects mid-query, or a caller's
-	// ctx.Done() fires while a long row iteration is in progress). These are
-	// not code bugs — the query layer correctly surfaces the cancellation to
-	// the caller, and the caller is expected to handle it. Suppressing here
-	// prevents hundreds of duplicate "[database] context canceled" events
-	// per day from drowning legitimate database errors.
-	if ee.Category == CategoryDatabase && isContextCancellation(ee.Err) {
+	// Database and system operations frequently observe context.Canceled and
+	// context.DeadlineExceeded during graceful shutdown and client-disconnect
+	// conditions (e.g. an HTTP client disconnects mid-query, or Sox/FFmpeg is
+	// killed when the requesting client navigates away). These are not code
+	// bugs; suppressing here prevents hundreds of duplicate events per day
+	// from drowning legitimate errors.
+	if (ee.Category == CategoryDatabase || ee.Category == CategorySystem) && isContextCancellation(ee.Err) {
 		return false
 	}
 


### PR DESCRIPTION
## Summary

- **API telemetry**: skip Sentry reporting when the error wraps `context.Canceled` or `context.DeadlineExceeded`, since these indicate client disconnects, not server bugs (~183 events eliminated)
- **Telemetry filter**: extend the existing `CategoryDatabase` context-cancellation suppression to also cover `CategorySystem`, eliminating Sox/FFmpeg cancellations from client navigation (~118 events)
- **Frontend audio guards**: replace `duration === 0` / `duration <= 0` guards with `!isFinite(duration) || duration <= 0` across PlayOverlay, AudioPlayer, and useAudioPlayback to prevent TypeError when audio metadata hasn't loaded (duration is NaN) or for streaming audio (duration is Infinity)

## Test Plan

- [ ] Backend: `go test -race ./internal/errors/...` passes (81 tests)
- [ ] Frontend: `npm run check:all` passes (0 errors)
- [ ] Verify audio seeking still works normally in the dashboard player
- [ ] Verify spectrograms still load and display correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio playback stability by adding safeguards against invalid duration values in clip extraction and seeking operations.
  * Refined error reporting to reduce noise by excluding expected client disconnections and timeout errors from telemetry logging.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3128?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->