### PR TITLE
fix: fullscreen crash guard, prerenderer shutdown safety, LocationConfigured for hemisphere

### DIFF
--- a/frontend/src/lib/desktop/features/live-stream/pages/LiveStreamPage.svelte
+++ b/frontend/src/lib/desktop/features/live-stream/pages/LiveStreamPage.svelte
@@ -595,9 +595,12 @@
     } else if (typeof cardEl.requestFullscreen === 'function') {
       cardEl.requestFullscreen().catch(() => {});
     } else {
-      const el = cardEl as unknown as { webkitRequestFullscreen?: () => void };
+      const el = cardEl as unknown as { webkitRequestFullscreen?: () => void | Promise<void> };
       if (typeof el.webkitRequestFullscreen === 'function') {
-        el.webkitRequestFullscreen();
+        const result = el.webkitRequestFullscreen();
+        if (result instanceof Promise) {
+          result.catch(() => {});
+        }
       }
     }
   }

--- a/frontend/src/lib/desktop/features/live-stream/pages/LiveStreamPage.svelte
+++ b/frontend/src/lib/desktop/features/live-stream/pages/LiveStreamPage.svelte
@@ -592,8 +592,13 @@
     if (!cardEl) return;
     if (document.fullscreenElement) {
       document.exitFullscreen().catch(() => {});
-    } else {
+    } else if (typeof cardEl.requestFullscreen === 'function') {
       cardEl.requestFullscreen().catch(() => {});
+    } else {
+      const el = cardEl as unknown as { webkitRequestFullscreen?: () => void };
+      if (typeof el.webkitRequestFullscreen === 'function') {
+        el.webkitRequestFullscreen();
+      }
     }
   }
 

--- a/frontend/src/lib/desktop/features/system/TerminalPage.svelte
+++ b/frontend/src/lib/desktop/features/system/TerminalPage.svelte
@@ -275,9 +275,14 @@
       if (typeof cardElement.requestFullscreen === 'function') {
         cardElement.requestFullscreen().catch(() => {});
       } else {
-        const el = cardElement as unknown as { webkitRequestFullscreen?: () => void };
+        const el = cardElement as unknown as {
+          webkitRequestFullscreen?: () => void | Promise<void>;
+        };
         if (typeof el.webkitRequestFullscreen === 'function') {
-          el.webkitRequestFullscreen();
+          const result = el.webkitRequestFullscreen();
+          if (result instanceof Promise) {
+            result.catch(() => {});
+          }
         }
       }
     } else {

--- a/frontend/src/lib/desktop/features/system/TerminalPage.svelte
+++ b/frontend/src/lib/desktop/features/system/TerminalPage.svelte
@@ -270,9 +270,16 @@
 
   function toggleFullscreen() {
     if (!cardElement) return;
-    // State is updated by the fullscreenchange listener — no eager assignment needed.
+    // State is updated by the fullscreenchange listener.
     if (!document.fullscreenElement) {
-      cardElement.requestFullscreen().catch(() => {});
+      if (typeof cardElement.requestFullscreen === 'function') {
+        cardElement.requestFullscreen().catch(() => {});
+      } else {
+        const el = cardElement as unknown as { webkitRequestFullscreen?: () => void };
+        if (typeof el.webkitRequestFullscreen === 'function') {
+          el.webkitRequestFullscreen();
+        }
+      }
     } else {
       document.exitFullscreen().catch(() => {});
     }

--- a/internal/conf/examples_test.go
+++ b/internal/conf/examples_test.go
@@ -141,6 +141,7 @@ func ExampleValidateWebhookProvider() {
 // This function is used internally by SaveSettings to add default seasons based on latitude.
 func Example_prepareSettingsForSave() {
 	settings := &Settings{}
+	settings.BirdNET.LocationConfigured = true
 	settings.Realtime.SpeciesTracking.SeasonalTracking.Enabled = true
 	// No seasons defined yet
 

--- a/internal/conf/prepare_settings_test.go
+++ b/internal/conf/prepare_settings_test.go
@@ -57,6 +57,7 @@ func TestPrepareSettingsForSave_EnabledWithExistingSeasons(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			settings := &Settings{}
+			settings.BirdNET.LocationConfigured = true
 			settings.Realtime.SpeciesTracking.SeasonalTracking.Enabled = true
 			settings.Realtime.SpeciesTracking.SeasonalTracking.Seasons = maps.Clone(customSeasons)
 
@@ -96,6 +97,7 @@ func TestPrepareSettingsForSave_NorthernHemisphere(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			settings := &Settings{}
+			settings.BirdNET.LocationConfigured = true
 			settings.Realtime.SpeciesTracking.SeasonalTracking.Enabled = true
 			settings.Realtime.SpeciesTracking.SeasonalTracking.Seasons = nil
 
@@ -131,6 +133,7 @@ func TestPrepareSettingsForSave_SouthernHemisphere(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			settings := &Settings{}
+			settings.BirdNET.LocationConfigured = true
 			settings.Realtime.SpeciesTracking.SeasonalTracking.Enabled = true
 			settings.Realtime.SpeciesTracking.SeasonalTracking.Seasons = nil
 
@@ -177,6 +180,7 @@ func TestPrepareSettingsForSave_CorrectsSouthernHemisphere(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			settings := &Settings{}
+			settings.BirdNET.LocationConfigured = true
 			settings.Realtime.SpeciesTracking.SeasonalTracking.Enabled = true
 			settings.Realtime.SpeciesTracking.SeasonalTracking.Seasons = maps.Clone(nhDefaults)
 
@@ -208,6 +212,7 @@ func TestPrepareSettingsForSave_PreservesNorthernForNorthern(t *testing.T) {
 	}
 
 	settings := &Settings{}
+	settings.BirdNET.LocationConfigured = true
 	settings.Realtime.SpeciesTracking.SeasonalTracking.Enabled = true
 	settings.Realtime.SpeciesTracking.SeasonalTracking.Seasons = maps.Clone(nhDefaults)
 
@@ -231,6 +236,7 @@ func TestPrepareSettingsForSave_EquatorialRegion(t *testing.T) {
 	}{
 		{"slightly north", 5.0},
 		{"slightly south", -5.0},
+		{"exact equator", 0.0},
 		{"northern threshold boundary", NorthernHemisphereThreshold - 0.1},
 		{"southern threshold boundary", SouthernHemisphereThreshold + 0.1},
 	}
@@ -239,6 +245,7 @@ func TestPrepareSettingsForSave_EquatorialRegion(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			settings := &Settings{}
+			settings.BirdNET.LocationConfigured = true
 			settings.Realtime.SpeciesTracking.SeasonalTracking.Enabled = true
 			settings.Realtime.SpeciesTracking.SeasonalTracking.Seasons = nil
 
@@ -251,9 +258,10 @@ func TestPrepareSettingsForSave_EquatorialRegion(t *testing.T) {
 	}
 }
 
-// TestPrepareSettingsForSave_SkipsUnconfiguredLatitude verifies that latitude 0
-// (location not yet configured) preserves existing seasons without adjustment.
-func TestPrepareSettingsForSave_SkipsUnconfiguredLatitude(t *testing.T) {
+// TestPrepareSettingsForSave_SkipsUnconfiguredLocation verifies that
+// LocationConfigured=false preserves existing seasons without adjustment,
+// even when a non-zero latitude is provided.
+func TestPrepareSettingsForSave_SkipsUnconfiguredLocation(t *testing.T) {
 	t.Parallel()
 
 	nhDefaults := map[string]Season{
@@ -264,14 +272,17 @@ func TestPrepareSettingsForSave_SkipsUnconfiguredLatitude(t *testing.T) {
 	}
 
 	settings := &Settings{}
+	// LocationConfigured deliberately left false (zero value)
 	settings.Realtime.SpeciesTracking.SeasonalTracking.Enabled = true
 	settings.Realtime.SpeciesTracking.SeasonalTracking.Seasons = maps.Clone(nhDefaults)
 
-	result := prepareSettingsForSave(settings, 0.0)
+	// Pass southern hemisphere latitude to verify that LocationConfigured
+	// gates the adjustment, not the latitude value itself.
+	result := prepareSettingsForSave(settings, -33.9)
 
 	spring := result.Realtime.SpeciesTracking.SeasonalTracking.Seasons["spring"]
 	assert.Equal(t, 3, spring.StartMonth,
-		"Seasons should be unchanged when latitude is 0 (unconfigured)")
+		"Seasons should be unchanged when LocationConfigured is false")
 }
 
 // TestPrepareSettingsForSave_PreservesCustomSeasonNames verifies that non-standard
@@ -285,6 +296,7 @@ func TestPrepareSettingsForSave_PreservesCustomSeasonNames(t *testing.T) {
 	}
 
 	settings := &Settings{}
+	settings.BirdNET.LocationConfigured = true
 	settings.Realtime.SpeciesTracking.SeasonalTracking.Enabled = true
 	settings.Realtime.SpeciesTracking.SeasonalTracking.Seasons = maps.Clone(customSeasons)
 
@@ -305,6 +317,7 @@ func TestPrepareSettingsForSave_PreservesCustomSeasonNames(t *testing.T) {
 func TestPrepareSettingsForSave_DoesNotMutateInput(t *testing.T) {
 	t.Parallel()
 	originalSettings := &Settings{}
+	originalSettings.BirdNET.LocationConfigured = true
 	originalSettings.Realtime.SpeciesTracking.SeasonalTracking.Enabled = true
 	originalSettings.Realtime.SpeciesTracking.SeasonalTracking.Seasons = nil
 
@@ -336,6 +349,7 @@ func TestPrepareSettingsForSave_DifferentLatitudes(t *testing.T) {
 		t.Run(lat.expectedHemisphere, func(t *testing.T) {
 			t.Parallel()
 			settings := &Settings{}
+			settings.BirdNET.LocationConfigured = true
 			settings.Realtime.SpeciesTracking.SeasonalTracking.Enabled = true
 			settings.Realtime.SpeciesTracking.SeasonalTracking.Seasons = nil
 
@@ -350,6 +364,7 @@ func TestPrepareSettingsForSave_DifferentLatitudes(t *testing.T) {
 // BenchmarkPrepareSettingsForSave benchmarks the preparation function.
 func BenchmarkPrepareSettingsForSave(b *testing.B) {
 	settings := &Settings{}
+	settings.BirdNET.LocationConfigured = true
 	settings.Realtime.SpeciesTracking.SeasonalTracking.Enabled = true
 	settings.Realtime.SpeciesTracking.SeasonalTracking.Seasons = nil
 
@@ -363,6 +378,7 @@ func BenchmarkPrepareSettingsForSave(b *testing.B) {
 // BenchmarkPrepareSettingsForSave_WithExistingSeasons benchmarks with existing seasons.
 func BenchmarkPrepareSettingsForSave_WithExistingSeasons(b *testing.B) {
 	settings := &Settings{}
+	settings.BirdNET.LocationConfigured = true
 	settings.Realtime.SpeciesTracking.SeasonalTracking.Enabled = true
 	settings.Realtime.SpeciesTracking.SeasonalTracking.Seasons = map[string]Season{
 		"winter": {StartMonth: 1, StartDay: 1},

--- a/internal/conf/storage.go
+++ b/internal/conf/storage.go
@@ -155,7 +155,7 @@ func Load() (*Settings, error) {
 	// API returns correct season dates from the start. Without this,
 	// Viper defaults (Northern Hemisphere) would be served regardless
 	// of the configured latitude.
-	locationConfigured := settings.BirdNET.Latitude != 0 || settings.BirdNET.Longitude != 0
+	locationConfigured := settings.BirdNET.LocationConfigured
 	if settings.Realtime.SpeciesTracking.SeasonalTracking.Enabled && locationConfigured {
 		settings.Realtime.SpeciesTracking.SeasonalTracking = GetSeasonalTrackingWithHemisphere(
 			settings.Realtime.SpeciesTracking.SeasonalTracking,
@@ -419,7 +419,7 @@ func Setting() *Settings {
 func prepareSettingsForSave(s *Settings, latitude float64) Settings {
 	settingsCopy := *s
 
-	locationConfigured := latitude != 0 || s.BirdNET.Longitude != 0
+	locationConfigured := s.BirdNET.LocationConfigured
 	if settingsCopy.Realtime.SpeciesTracking.SeasonalTracking.Enabled && locationConfigured {
 		settingsCopy.Realtime.SpeciesTracking.SeasonalTracking = GetSeasonalTrackingWithHemisphere(
 			settingsCopy.Realtime.SpeciesTracking.SeasonalTracking,

--- a/internal/spectrogram/prerenderer.go
+++ b/internal/spectrogram/prerenderer.go
@@ -160,11 +160,10 @@ func (pr *PreRenderer) Start() {
 func (pr *PreRenderer) Stop() {
 	pr.logger.Info("Stopping spectrogram pre-renderer")
 
-	// Cancel context to signal workers to stop
+	// Cancel context to signal workers to stop.
+	// Workers exit via pr.ctx.Done(); the jobs channel is left open
+	// so Submit() cannot panic on a closed-channel send.
 	pr.cancel()
-
-	// Close job channel to prevent new submissions
-	close(pr.jobs)
 
 	// Wait for workers to finish with timeout
 	done := make(chan struct{})
@@ -236,7 +235,7 @@ func (pr *PreRenderer) Submit(jobDTO interface {
 
 	// Path-traversal guard: ensure spectrogram path is within export directory
 	// Use SecureFS base dir (resolved to absolute at init time) instead of
-	// filepath.Abs() which depends on os.Getwd() — unreliable on Windows
+	// filepath.Abs() which depends on os.Getwd(), unreliable on Windows
 	// when running as a service without a working directory set (#2342).
 	absRoot := pr.sfs.BaseDir()
 
@@ -278,28 +277,7 @@ func (pr *PreRenderer) Submit(jobDTO interface {
 		return nil
 	}
 
-	// Panic protection for concurrent channel close
-	defer func() {
-		if r := recover(); r != nil {
-			pr.logger.Error("Panic during job submission (channel likely closed)",
-				logger.Any("note_id", job.NoteID),
-				logger.Any("panic", r))
-			pr.mu.Lock()
-			pr.stats.Failed++
-			pr.mu.Unlock()
-			// Set named return value to report the panic as an error
-			err = errors.Newf("panic during job submission: %v", r).
-				Component("spectrogram").
-				Category(errors.CategorySystem).
-				Context("operation", "submit_job").
-				Context("note_id", job.NoteID).
-				Build()
-		}
-	}()
-
-	// Check context first to avoid select race with closed channel
-	// When Stop() is called, context is cancelled before channel is closed,
-	// so checking this first ensures we don't race with channel closure
+	// Check context first to reject jobs after Stop()
 	select {
 	case <-pr.ctx.Done():
 		// Context cancelled, don't attempt to send
@@ -366,11 +344,7 @@ func (pr *PreRenderer) worker(id int) {
 		case <-pr.ctx.Done():
 			pr.logger.Debug("Pre-render worker stopping", logger.Int("worker_id", id))
 			return
-		case job, ok := <-pr.jobs:
-			if !ok {
-				pr.logger.Debug("Pre-render worker channel closed", logger.Int("worker_id", id))
-				return
-			}
+		case job := <-pr.jobs:
 			pr.processJob(job, id)
 		}
 	}
@@ -381,7 +355,7 @@ func (pr *PreRenderer) processJob(job *Job, workerID int) {
 	start := time.Now()
 
 	// Capture a single settings snapshot for this job so size, raw, and
-	// export path are read from the same view — a UI edit that lands
+	// export path are read from the same view. A UI edit that lands
 	// mid-job can't produce a mix of old/new values. The Generator below
 	// captures its own snapshot when its public entry point runs; that is
 	// a deliberate per-component boundary (Size/Raw are per-call inputs

--- a/internal/spectrogram/prerenderer_test.go
+++ b/internal/spectrogram/prerenderer_test.go
@@ -119,7 +119,7 @@ func TestPreRenderer_Stats(t *testing.T) {
 func TestPreRenderer_Submit_AfterStop(t *testing.T) {
 	pr, env := createTestPreRenderer(t, nil)
 	pr.Start()
-	pr.Stop() // Closes channel and cancels context
+	pr.Stop() // Cancels context, workers exit via ctx.Done()
 
 	job := createTestJob(filepath.Join(env.TempDir, "test.wav"), 1)
 


### PR DESCRIPTION
## Summary

Three correctness fixes for edge cases:

- **Fullscreen crash guard**: `requestFullscreen()` called without checking the method exists, crashing on browsers with prefixed-only APIs (Safari) or restricted contexts. Added `typeof` guard with `webkitRequestFullscreen` fallback in both LiveStreamPage and TerminalPage.

- **Pre-renderer shutdown safety**: `Stop()` closed the jobs channel, creating a race with `Submit()` that could panic on send-to-closed-channel. The code had an 18-line `defer/recover` block as a workaround. Removed `close(pr.jobs)` since workers already exit via context cancellation, then removed the dead `defer/recover` and `!ok` branch.

- **LocationConfigured for hemisphere detection**: `Load()` and `prepareSettingsForSave()` used `Latitude != 0 || Longitude != 0` as a proxy for "location is configured." This incorrectly skipped hemisphere adjustment for users at the equator (latitude 0). Replaced with the existing `LocationConfigured` boolean flag, which is set by `MigrateLocationConfigured`. Updated all tests to set `LocationConfigured` explicitly and added an exact-equator test case.

## Test Plan

- [x] All 1319 Go tests pass with `-race` in affected packages
- [x] Frontend `check:all` passes (0 errors, 0 warnings)
- [x] `golangci-lint` reports no issues
- [x] Gate review (4 parallel agents) found no critical/high issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fullscreen behavior for better browser compatibility
  * Prevented crashes in concurrent spectrogram processing
  * Corrected seasonal tracking so location configuration is respected during save/load

* **Tests**
  * Updated tests and examples to reflect the location-configured behavior and worker stop semantics

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3129?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->