### PR TITLE
feat(health): add diagnostic health check system backend

### DIFF
--- a/internal/api/v2/README.md
+++ b/internal/api/v2/README.md
@@ -539,6 +539,23 @@ Requires enhanced (v2) database. Returns 409 Conflict if not available.
 }
 ```
 
+### Diagnostics (`diagnostics.go`)
+
+| Method | Route                            | Handler                  | Auth | Description                    |
+| ------ | -------------------------------- | ------------------------ | ---- | ------------------------------ |
+| GET    | `/system/diagnostics/status`     | `GetDiagnosticsStatus`   | ✅   | Health summary for UI badge    |
+| POST   | `/system/diagnostics/run`        | `RunDiagnostics`         | ✅   | Run full diagnostic suite      |
+| GET    | `/system/diagnostics/report/:id` | `GetDiagnosticsReport`   | ✅   | Retrieve completed report      |
+| GET    | `/system/diagnostics/errors`     | `GetRecentErrors`        | ✅   | Recent error log entries       |
+
+**GET /api/v2/system/diagnostics/status** - Returns the overall health status and per-category breakdown from the most recent diagnostic run. Returns `{"status": "unknown"}` if no diagnostics have been run yet.
+
+**POST /api/v2/system/diagnostics/run** - Executes all registered health checks in parallel (31 checks across 8 categories: system, audio, analysis, streams, database, network, config, logs). Returns a full `DiagnosticsReport` with per-check results, timing, and summary.
+
+**GET /api/v2/system/diagnostics/report/:id** - Retrieves a previously completed diagnostics report by its UUID. Up to 10 reports are cached in memory.
+
+**GET /api/v2/system/diagnostics/errors** - Returns recent warn/error/fatal log entries from the in-memory ring buffer. Supports `?limit=N` query parameter (default 50, max 200).
+
 ## Legend
 
 - ✅ = Authentication required

--- a/internal/api/v2/api.go
+++ b/internal/api/v2/api.go
@@ -32,6 +32,7 @@ import (
 	"github.com/tphakala/birdnet-go/internal/datastore/v2/repository"
 	"github.com/tphakala/birdnet-go/internal/ebird"
 	"github.com/tphakala/birdnet-go/internal/errors"
+	"github.com/tphakala/birdnet-go/internal/health"
 	"github.com/tphakala/birdnet-go/internal/imageprovider"
 	"github.com/tphakala/birdnet-go/internal/logger"
 	"github.com/tphakala/birdnet-go/internal/observability"
@@ -134,6 +135,11 @@ type Controller struct {
 	// Stored atomically because it is set during pipeline Start() and read
 	// concurrently by HTTP handlers.
 	audioWatchdog atomic.Pointer[audiocore.LivenessWatchdog]
+
+	// Health check infrastructure for the diagnostics endpoints.
+	healthRegistry *health.Registry
+	healthReports  *health.ReportStore
+	healthErrors   *health.ErrorRingBuffer
 
 	// sourceRestarter restarts a single audio source by ID. Set during
 	// pipeline Start() and called by the restart-source control endpoint.
@@ -642,6 +648,7 @@ func (c *Controller) initRoutes() {
 		{"model routes", c.initModelRoutes},
 		{"insights routes", c.initInsightsRoutes},
 		{"tls routes", c.initTLSRoutes},
+		{"diagnostics routes", c.initDiagnosticsRoutes},
 	}
 
 	for _, initializer := range routeInitializers {

--- a/internal/api/v2/diagnostics.go
+++ b/internal/api/v2/diagnostics.go
@@ -1,0 +1,212 @@
+// internal/api/v2/diagnostics.go
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"path/filepath"
+	"strconv"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+	"github.com/tphakala/birdnet-go/internal/audiocore"
+	"github.com/tphakala/birdnet-go/internal/health"
+	"github.com/tphakala/birdnet-go/internal/health/checks"
+)
+
+// diagnosticsStatusResponse is the quick health summary returned by GET /status.
+type diagnosticsStatusResponse struct {
+	Status     health.Status                     `json:"status"`
+	Categories map[health.Category]health.Status `json:"categories"`
+	LastRun    *time.Time                        `json:"last_run"`
+}
+
+// initDiagnosticsRoutes initializes health check infrastructure and registers
+// the diagnostics API endpoints.
+func (c *Controller) initDiagnosticsRoutes() {
+	c.healthReports = health.NewReportStore(10)
+	c.healthErrors = health.NewErrorRingBuffer(500)
+	c.healthRegistry = health.NewRegistry()
+
+	c.registerHealthChecks()
+
+	diagnosticsGroup := c.Group.Group("/system/diagnostics", c.authMiddleware)
+	diagnosticsGroup.GET("/status", c.GetDiagnosticsStatus)
+	diagnosticsGroup.POST("/run", c.RunDiagnostics)
+	diagnosticsGroup.GET("/report/:id", c.GetDiagnosticsReport)
+	diagnosticsGroup.GET("/errors", c.GetRecentErrors)
+}
+
+// registerHealthChecks registers all health checks with dependency injection closures.
+func (c *Controller) registerHealthChecks() {
+	snapshotProvider := func() []audiocore.SourceHealthSnapshot {
+		w := c.audioWatchdog.Load()
+		if w == nil {
+			return nil
+		}
+		return w.Snapshot()
+	}
+
+	c.healthRegistry.RegisterAll(
+		// System checks
+		checks.NewDiskSpaceCheck(c.getDataPaths()),
+		checks.NewMemoryCheck(),
+		checks.NewCPULoadCheck(GetCachedCPUUsage),
+		checks.NewTemperatureCheck(func() (float64, error) {
+			return 0, fmt.Errorf("not available")
+		}),
+		checks.NewUptimeCheck(c.startTime),
+
+		// Audio checks
+		checks.NewSourceStatusCheck(snapshotProvider),
+		checks.NewPipelineLivenessCheck(snapshotProvider),
+		checks.NewBufferDropsCheck(),
+		checks.NewAudioLevelCheck(),
+		checks.NewBufferOverrunCheck(),
+		checks.NewCaptureBufferCheck(),
+
+		// Analysis checks
+		checks.NewModelLoadedCheck(
+			func() bool { return true }, // model is always loaded if server is running
+			func() string { return c.currentSettings().BirdNET.ModelPath },
+		),
+		checks.NewInferenceLatencyCheck(func() (float64, float64, float64) {
+			return 0, 0, 0 // TODO: wire to actual inference stats
+		}),
+		checks.NewDetectionRateCheck(func(hours int) (int, error) {
+			return 0, fmt.Errorf("not yet wired") // TODO: wire to datastore
+		}),
+		checks.NewQueueDepthCheck(func() (int, int) {
+			return 0, 100 // TODO: wire to actual queue
+		}),
+
+		// Stream checks
+		checks.NewStreamConnectivityCheck(func() []checks.StreamHealthInfo {
+			return nil // TODO: wire to RTSP manager
+		}),
+		checks.NewStreamErrorRateCheck(func() []checks.StreamHealthInfo {
+			return nil // TODO: wire to RTSP manager
+		}),
+		checks.NewFFmpegHealthCheck(func() []checks.StreamHealthInfo {
+			return nil // TODO: wire to RTSP manager
+		}),
+
+		// Database checks
+		checks.NewDatabaseSizeCheck(func() string {
+			return c.currentSettings().Output.SQLite.Path
+		}),
+		checks.NewMigrationStatusCheck(func() (bool, string, error) {
+			return true, "current", nil // TODO: wire to migration checker
+		}),
+		checks.NewDatabasePerformanceCheck(func() (time.Duration, error) {
+			return 0, fmt.Errorf("not yet wired") // TODO: wire to datastore
+		}),
+
+		// Network checks
+		checks.NewMQTTCheck(
+			func() bool { return c.currentSettings().Realtime.MQTT.Enabled },
+			func() bool { return false }, // TODO: wire actual MQTT connection status
+		),
+		checks.NewBirdWeatherCheck(
+			func() bool { return c.currentSettings().Realtime.Birdweather.Enabled },
+			func() (bool, string) { return false, "status check not yet wired" },
+		),
+		checks.NewNotificationProvidersCheck(),
+		checks.NewWeatherCheck(func() bool { return false }), // TODO: wire to weather config
+
+		// Config checks
+		checks.NewPathAccessCheck(map[string]string{
+			"data": filepath.Dir(c.currentSettings().Output.SQLite.Path),
+		}),
+		checks.NewConfigConsistencyCheck(func() []string { return nil }),
+		checks.NewDiskBudgetCheck(
+			func() bool { return false }, // TODO: wire when disk budget feature exists
+			func() (int64, int64) { return 0, 0 },
+		),
+
+		// Log checks
+		checks.NewRecentErrorsCheck(c.healthErrors),
+		checks.NewErrorTrendCheck(c.healthErrors),
+		checks.NewCriticalEventsCheck(c.healthErrors),
+	)
+}
+
+// getDataPaths returns filesystem paths that should be monitored for disk space.
+func (c *Controller) getDataPaths() []string {
+	settings := c.currentSettings()
+	var paths []string
+	if settings.Output.SQLite.Path != "" {
+		paths = append(paths, filepath.Dir(settings.Output.SQLite.Path))
+	}
+	// Add log file directory if file output is configured
+	if settings.Logging.FileOutput != nil && settings.Logging.FileOutput.Path != "" {
+		paths = append(paths, filepath.Dir(settings.Logging.FileOutput.Path))
+	}
+	if len(paths) == 0 {
+		paths = append(paths, ".")
+	}
+	return paths
+}
+
+// GetDiagnosticsStatus returns a quick health summary from the latest stored report.
+func (c *Controller) GetDiagnosticsStatus(ctx echo.Context) error {
+	latest := c.healthReports.Latest()
+	if latest == nil {
+		return ctx.JSON(http.StatusOK, diagnosticsStatusResponse{
+			Status:     health.StatusUnknown,
+			Categories: map[health.Category]health.Status{},
+			LastRun:    nil,
+		})
+	}
+
+	return ctx.JSON(http.StatusOK, diagnosticsStatusResponse{
+		Status:     latest.Status,
+		Categories: latest.Summary,
+		LastRun:    &latest.StartedAt,
+	})
+}
+
+// RunDiagnostics executes all registered health checks and stores the report.
+func (c *Controller) RunDiagnostics(ctx echo.Context) error {
+	id := uuid.New().String()
+	startedAt := time.Now()
+
+	results := c.healthRegistry.RunAll(ctx.Request().Context())
+	report := health.NewReport(id, startedAt, results)
+	c.healthReports.Save(report)
+
+	return ctx.JSON(http.StatusOK, report)
+}
+
+// GetDiagnosticsReport retrieves a stored diagnostics report by ID.
+func (c *Controller) GetDiagnosticsReport(ctx echo.Context) error {
+	id := ctx.Param("id")
+	report, ok := c.healthReports.Get(id)
+	if !ok {
+		return ctx.JSON(http.StatusNotFound, map[string]string{
+			"error": "report not found",
+		})
+	}
+	return ctx.JSON(http.StatusOK, report)
+}
+
+// GetRecentErrors returns recent error log entries from the error ring buffer.
+func (c *Controller) GetRecentErrors(ctx echo.Context) error {
+	const defaultLimit = 50
+	const maxLimit = 200
+
+	limit := defaultLimit
+	if limitStr := ctx.QueryParam("limit"); limitStr != "" {
+		parsed, err := strconv.Atoi(limitStr)
+		if err == nil && parsed > 0 {
+			limit = parsed
+		}
+	}
+	if limit > maxLimit {
+		limit = maxLimit
+	}
+
+	entries := c.healthErrors.Recent(limit)
+	return ctx.JSON(http.StatusOK, entries)
+}

--- a/internal/api/v2/diagnostics.go
+++ b/internal/api/v2/diagnostics.go
@@ -2,7 +2,6 @@
 package api
 
 import (
-	"fmt"
 	"net/http"
 	"path/filepath"
 	"strconv"
@@ -53,9 +52,7 @@ func (c *Controller) registerHealthChecks() {
 		checks.NewDiskSpaceCheck(c.getDataPaths()),
 		checks.NewMemoryCheck(),
 		checks.NewCPULoadCheck(GetCachedCPUUsage),
-		checks.NewTemperatureCheck(func() (float64, error) {
-			return 0, fmt.Errorf("not available")
-		}),
+		checks.NewTemperatureCheck(nil), // TODO: wire to platform temperature sensor
 		checks.NewUptimeCheck(c.startTime),
 
 		// Audio checks
@@ -71,13 +68,9 @@ func (c *Controller) registerHealthChecks() {
 			func() bool { return true }, // model is always loaded if server is running
 			func() string { return c.currentSettings().BirdNET.ModelPath },
 		),
-		checks.NewInferenceLatencyCheck(func() (float64, float64, float64) {
-			return 0, 0, 0 // TODO: wire to actual inference stats
-		}),
-		checks.NewDetectionRateCheck(nil), // TODO: wire to datastore
-		checks.NewQueueDepthCheck(func() (int, int) {
-			return 0, 100 // TODO: wire to actual queue
-		}),
+		checks.NewInferenceLatencyCheck(nil), // TODO: wire to actual inference stats
+		checks.NewDetectionRateCheck(nil),    // TODO: wire to datastore
+		checks.NewQueueDepthCheck(nil),       // TODO: wire to actual queue
 
 		// Stream checks
 		checks.NewStreamConnectivityCheck(func() []checks.StreamHealthInfo {

--- a/internal/api/v2/diagnostics.go
+++ b/internal/api/v2/diagnostics.go
@@ -102,11 +102,11 @@ func (c *Controller) registerHealthChecks() {
 		// Network checks
 		checks.NewMQTTCheck(
 			func() bool { return c.currentSettings().Realtime.MQTT.Enabled },
-			func() bool { return false }, // TODO: wire actual MQTT connection status
+			nil, // TODO: wire actual MQTT connection status
 		),
 		checks.NewBirdWeatherCheck(
 			func() bool { return c.currentSettings().Realtime.Birdweather.Enabled },
-			func() (bool, string) { return false, "status check not yet wired" },
+			nil, // TODO: wire actual BirdWeather status
 		),
 		checks.NewNotificationProvidersCheck(),
 		checks.NewWeatherCheck(func() bool { return false }), // TODO: wire to weather config
@@ -180,9 +180,7 @@ func (c *Controller) GetDiagnosticsReport(ctx echo.Context) error {
 	id := ctx.Param("id")
 	report, ok := c.healthReports.Get(id)
 	if !ok {
-		return ctx.JSON(http.StatusNotFound, map[string]string{
-			"error": "report not found",
-		})
+		return c.HandleError(ctx, nil, "report not found", http.StatusNotFound)
 	}
 	return ctx.JSON(http.StatusOK, report)
 }

--- a/internal/api/v2/diagnostics.go
+++ b/internal/api/v2/diagnostics.go
@@ -74,9 +74,7 @@ func (c *Controller) registerHealthChecks() {
 		checks.NewInferenceLatencyCheck(func() (float64, float64, float64) {
 			return 0, 0, 0 // TODO: wire to actual inference stats
 		}),
-		checks.NewDetectionRateCheck(func(hours int) (int, error) {
-			return 0, fmt.Errorf("not yet wired") // TODO: wire to datastore
-		}),
+		checks.NewDetectionRateCheck(nil), // TODO: wire to datastore
 		checks.NewQueueDepthCheck(func() (int, int) {
 			return 0, 100 // TODO: wire to actual queue
 		}),
@@ -99,9 +97,7 @@ func (c *Controller) registerHealthChecks() {
 		checks.NewMigrationStatusCheck(func() (bool, string, error) {
 			return true, "current", nil // TODO: wire to migration checker
 		}),
-		checks.NewDatabasePerformanceCheck(func() (time.Duration, error) {
-			return 0, fmt.Errorf("not yet wired") // TODO: wire to datastore
-		}),
+		checks.NewDatabasePerformanceCheck(nil), // TODO: wire to datastore
 
 		// Network checks
 		checks.NewMQTTCheck(

--- a/internal/api/v2/diagnostics.go
+++ b/internal/api/v2/diagnostics.go
@@ -131,13 +131,20 @@ func (c *Controller) registerHealthChecks() {
 // getDataPaths returns filesystem paths that should be monitored for disk space.
 func (c *Controller) getDataPaths() []string {
 	settings := c.currentSettings()
+	seen := make(map[string]struct{})
 	var paths []string
-	if settings.Output.SQLite.Path != "" {
-		paths = append(paths, filepath.Dir(settings.Output.SQLite.Path))
+	addPath := func(p string) {
+		dir := filepath.Dir(p)
+		if _, ok := seen[dir]; !ok {
+			seen[dir] = struct{}{}
+			paths = append(paths, dir)
+		}
 	}
-	// Add log file directory if file output is configured
+	if settings.Output.SQLite.Path != "" {
+		addPath(settings.Output.SQLite.Path)
+	}
 	if settings.Logging.FileOutput != nil && settings.Logging.FileOutput.Path != "" {
-		paths = append(paths, filepath.Dir(settings.Logging.FileOutput.Path))
+		addPath(settings.Logging.FileOutput.Path)
 	}
 	if len(paths) == 0 {
 		paths = append(paths, ".")

--- a/internal/health/check.go
+++ b/internal/health/check.go
@@ -1,0 +1,95 @@
+// internal/health/check.go
+package health
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+)
+
+// Status represents the health status of a check.
+type Status string
+
+const (
+	StatusHealthy  Status = "healthy"
+	StatusWarning  Status = "warning"
+	StatusCritical Status = "critical"
+	StatusUnknown  Status = "unknown"
+	StatusSkipped  Status = "skipped"
+)
+
+// Category groups related checks together.
+type Category string
+
+const (
+	CategorySystem   Category = "system"
+	CategoryAudio    Category = "audio"
+	CategoryAnalysis Category = "analysis"
+	CategoryStreams  Category = "streams"
+	CategoryDatabase Category = "database"
+	CategoryNetwork  Category = "network"
+	CategoryConfig   Category = "config"
+	CategoryLogs     Category = "logs"
+)
+
+// AllCategories returns categories in display order.
+func AllCategories() []Category {
+	return []Category{
+		CategorySystem, CategoryAudio, CategoryAnalysis, CategoryStreams,
+		CategoryDatabase, CategoryNetwork, CategoryConfig, CategoryLogs,
+	}
+}
+
+// Result is the outcome of a single health check.
+type Result struct {
+	Name       string         `json:"name"`
+	Category   Category       `json:"category"`
+	Status     Status         `json:"status"`
+	Message    string         `json:"message"`
+	Details    map[string]any `json:"details,omitempty"`
+	DurationMS float64        `json:"duration_ms"`
+	Timestamp  time.Time      `json:"timestamp"`
+}
+
+// MarshalJSON customizes JSON output for Result.
+func (r *Result) MarshalJSON() ([]byte, error) {
+	type Alias Result
+	return json.Marshal(&struct {
+		*Alias
+	}{
+		Alias: (*Alias)(r),
+	})
+}
+
+// Check is the interface all health checks implement.
+type Check interface {
+	Name() string
+	Category() Category
+	Run(ctx context.Context) Result
+}
+
+// WorstStatus returns the most severe status from a slice of results.
+func WorstStatus(results []Result) Status {
+	worst := StatusHealthy
+	for _, r := range results {
+		if severity(r.Status) > severity(worst) {
+			worst = r.Status
+		}
+	}
+	return worst
+}
+
+func severity(s Status) int {
+	switch s {
+	case StatusHealthy:
+		return 0
+	case StatusSkipped, StatusUnknown:
+		return 1
+	case StatusWarning:
+		return 2
+	case StatusCritical:
+		return 3
+	default:
+		return 0
+	}
+}

--- a/internal/health/check.go
+++ b/internal/health/check.go
@@ -3,7 +3,6 @@ package health
 
 import (
 	"context"
-	"encoding/json"
 	"time"
 )
 
@@ -49,16 +48,6 @@ type Result struct {
 	Details    map[string]any `json:"details,omitempty"`
 	DurationMS float64        `json:"duration_ms"`
 	Timestamp  time.Time      `json:"timestamp"`
-}
-
-// MarshalJSON customizes JSON output for Result.
-func (r *Result) MarshalJSON() ([]byte, error) {
-	type Alias Result
-	return json.Marshal(&struct {
-		*Alias
-	}{
-		Alias: (*Alias)(r),
-	})
 }
 
 // Check is the interface all health checks implement.

--- a/internal/health/check_test.go
+++ b/internal/health/check_test.go
@@ -1,0 +1,94 @@
+// internal/health/check_test.go
+package health
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWorstStatus_Empty(t *testing.T) {
+	t.Parallel()
+	got := WorstStatus([]Result{})
+	assert.Equal(t, StatusHealthy, got)
+}
+
+func TestWorstStatus_AllHealthy(t *testing.T) {
+	t.Parallel()
+	results := []Result{
+		{Status: StatusHealthy},
+		{Status: StatusHealthy},
+		{Status: StatusHealthy},
+	}
+	got := WorstStatus(results)
+	assert.Equal(t, StatusHealthy, got)
+}
+
+func TestWorstStatus_MixedStatuses(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		statuses []Status
+		want     Status
+	}{
+		{
+			name:     "warning beats healthy",
+			statuses: []Status{StatusHealthy, StatusWarning, StatusHealthy},
+			want:     StatusWarning,
+		},
+		{
+			name:     "critical beats warning",
+			statuses: []Status{StatusHealthy, StatusWarning, StatusCritical},
+			want:     StatusCritical,
+		},
+		{
+			name:     "skipped beats healthy",
+			statuses: []Status{StatusHealthy, StatusSkipped},
+			want:     StatusSkipped,
+		},
+		{
+			name:     "unknown beats healthy",
+			statuses: []Status{StatusHealthy, StatusUnknown},
+			want:     StatusUnknown,
+		},
+		{
+			name:     "critical beats all",
+			statuses: []Status{StatusSkipped, StatusUnknown, StatusWarning, StatusCritical},
+			want:     StatusCritical,
+		},
+		{
+			name:     "single critical",
+			statuses: []Status{StatusCritical},
+			want:     StatusCritical,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			results := make([]Result, len(tt.statuses))
+			for i, s := range tt.statuses {
+				results[i] = Result{Status: s}
+			}
+			got := WorstStatus(results)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestSeverityOrdering(t *testing.T) {
+	t.Parallel()
+	// Verify the ordering: healthy < skipped == unknown < warning < critical
+	assert.Less(t, severity(StatusHealthy), severity(StatusSkipped))
+	assert.Less(t, severity(StatusHealthy), severity(StatusUnknown))
+	assert.Equal(t, severity(StatusSkipped), severity(StatusUnknown))
+	assert.Less(t, severity(StatusSkipped), severity(StatusWarning))
+	assert.Less(t, severity(StatusUnknown), severity(StatusWarning))
+	assert.Less(t, severity(StatusWarning), severity(StatusCritical))
+}
+
+func TestSeverityUnknownStatus(t *testing.T) {
+	t.Parallel()
+	// An unrecognised status string should map to severity 0 (same as healthy)
+	assert.Equal(t, severity(StatusHealthy), severity(Status("bogus")))
+}

--- a/internal/health/checks/analysis.go
+++ b/internal/health/checks/analysis.go
@@ -1,0 +1,254 @@
+package checks
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/tphakala/birdnet-go/internal/health"
+)
+
+// ModelLoadedCheck verifies that the BirdNET analysis model is loaded and ready.
+type ModelLoadedCheck struct {
+	isLoaded  func() bool
+	modelName func() string
+}
+
+// NewModelLoadedCheck creates a ModelLoadedCheck using the given predicate and name provider.
+func NewModelLoadedCheck(isLoaded func() bool, modelName func() string) *ModelLoadedCheck {
+	return &ModelLoadedCheck{isLoaded: isLoaded, modelName: modelName}
+}
+
+// Name returns the check identifier.
+func (c *ModelLoadedCheck) Name() string { return "model_loaded" }
+
+// Category returns the analysis category.
+func (c *ModelLoadedCheck) Category() health.Category { return health.CategoryAnalysis }
+
+// Run verifies that the analysis model is loaded.
+func (c *ModelLoadedCheck) Run(_ context.Context) health.Result {
+	start := time.Now()
+
+	name := ""
+	if c.modelName != nil {
+		name = c.modelName()
+	}
+
+	status := health.StatusHealthy
+	msg := fmt.Sprintf("Model loaded: %s", name)
+	if name == "" {
+		msg = "Model loaded"
+	}
+
+	if !c.isLoaded() {
+		status = health.StatusCritical
+		msg = "Analysis model is not loaded"
+		if name != "" {
+			msg = fmt.Sprintf("Analysis model not loaded: %s", name)
+		}
+	}
+
+	return health.Result{
+		Name:     c.Name(),
+		Category: c.Category(),
+		Status:   status,
+		Message:  msg,
+		Details: map[string]any{
+			"model_name": name,
+		},
+		DurationMS: float64(time.Since(start).Microseconds()) / 1000,
+		Timestamp:  time.Now(),
+	}
+}
+
+// InferenceLatencyCheck verifies that inference latency is within acceptable bounds
+// relative to the analysis window size.
+type InferenceLatencyCheck struct {
+	getStats func() (avgMS, p99MS, windowMS float64)
+}
+
+// NewInferenceLatencyCheck creates an InferenceLatencyCheck using the given stats provider.
+func NewInferenceLatencyCheck(getStats func() (avgMS, p99MS, windowMS float64)) *InferenceLatencyCheck {
+	return &InferenceLatencyCheck{getStats: getStats}
+}
+
+// Name returns the check identifier.
+func (c *InferenceLatencyCheck) Name() string { return "inference_latency" }
+
+// Category returns the analysis category.
+func (c *InferenceLatencyCheck) Category() health.Category { return health.CategoryAnalysis }
+
+// Run evaluates inference latency against the analysis window duration.
+func (c *InferenceLatencyCheck) Run(_ context.Context) health.Result {
+	start := time.Now()
+
+	avgMS, p99MS, windowMS := c.getStats()
+
+	if windowMS <= 0 {
+		return health.Result{
+			Name:       c.Name(),
+			Category:   c.Category(),
+			Status:     health.StatusUnknown,
+			Message:    "Inference stats not available",
+			DurationMS: float64(time.Since(start).Microseconds()) / 1000,
+			Timestamp:  time.Now(),
+		}
+	}
+
+	ratio := p99MS / windowMS
+	status := health.StatusHealthy
+	msg := fmt.Sprintf("Inference latency OK (p99=%.1fms, window=%.1fms)", p99MS, windowMS)
+
+	switch {
+	case ratio >= 0.90:
+		status = health.StatusCritical
+		msg = fmt.Sprintf("Inference p99 (%.1fms) exceeds 90%% of analysis window (%.1fms)", p99MS, windowMS)
+	case ratio >= 0.50:
+		status = health.StatusWarning
+		msg = fmt.Sprintf("Inference p99 (%.1fms) exceeds 50%% of analysis window (%.1fms)", p99MS, windowMS)
+	}
+
+	return health.Result{
+		Name:     c.Name(),
+		Category: c.Category(),
+		Status:   status,
+		Message:  msg,
+		Details: map[string]any{
+			"avg_ms":    avgMS,
+			"p99_ms":    p99MS,
+			"window_ms": windowMS,
+		},
+		DurationMS: float64(time.Since(start).Microseconds()) / 1000,
+		Timestamp:  time.Now(),
+	}
+}
+
+// DetectionRateCheck monitors whether detections are occurring at expected intervals.
+type DetectionRateCheck struct {
+	getRecentCount func(hours int) (int, error)
+}
+
+// NewDetectionRateCheck creates a DetectionRateCheck using the given count provider.
+func NewDetectionRateCheck(getRecentCount func(hours int) (int, error)) *DetectionRateCheck {
+	return &DetectionRateCheck{getRecentCount: getRecentCount}
+}
+
+// Name returns the check identifier.
+func (c *DetectionRateCheck) Name() string { return "detection_rate" }
+
+// Category returns the analysis category.
+func (c *DetectionRateCheck) Category() health.Category { return health.CategoryAnalysis }
+
+// Run checks recent detection counts for signs of stalled analysis.
+func (c *DetectionRateCheck) Run(_ context.Context) health.Result {
+	start := time.Now()
+
+	count6h, err6h := c.getRecentCount(6)
+	count24h, err24h := c.getRecentCount(24)
+
+	if err6h != nil || err24h != nil {
+		msg := "Unable to query detection counts"
+		if err6h != nil {
+			msg = fmt.Sprintf("Detection count query failed: %v", err6h)
+		}
+		return health.Result{
+			Name:       c.Name(),
+			Category:   c.Category(),
+			Status:     health.StatusUnknown,
+			Message:    msg,
+			DurationMS: float64(time.Since(start).Microseconds()) / 1000,
+			Timestamp:  time.Now(),
+		}
+	}
+
+	status := health.StatusHealthy
+	msg := fmt.Sprintf("Detection rate OK (%d in 6h, %d in 24h)", count6h, count24h)
+
+	hour := time.Now().Hour()
+	isDaytime := hour >= 6 && hour < 22
+
+	switch {
+	case count24h == 0:
+		status = health.StatusCritical
+		msg = "No detections recorded in the past 24 hours"
+	case count6h == 0 && isDaytime:
+		status = health.StatusWarning
+		msg = "No detections recorded in the past 6 hours during daytime"
+	}
+
+	return health.Result{
+		Name:     c.Name(),
+		Category: c.Category(),
+		Status:   status,
+		Message:  msg,
+		Details: map[string]any{
+			"count_6h":  count6h,
+			"count_24h": count24h,
+		},
+		DurationMS: float64(time.Since(start).Microseconds()) / 1000,
+		Timestamp:  time.Now(),
+	}
+}
+
+// QueueDepthCheck monitors the analysis queue to detect backpressure.
+type QueueDepthCheck struct {
+	getQueueStats func() (int, int)
+}
+
+// NewQueueDepthCheck creates a QueueDepthCheck using the given queue stats provider.
+// The returned function must return (currentDepth, maxDepth).
+func NewQueueDepthCheck(getQueueStats func() (int, int)) *QueueDepthCheck {
+	return &QueueDepthCheck{getQueueStats: getQueueStats}
+}
+
+// Name returns the check identifier.
+func (c *QueueDepthCheck) Name() string { return "queue_depth" }
+
+// Category returns the analysis category.
+func (c *QueueDepthCheck) Category() health.Category { return health.CategoryAnalysis }
+
+// Run evaluates queue utilization.
+func (c *QueueDepthCheck) Run(_ context.Context) health.Result {
+	start := time.Now()
+
+	depth, capacity := c.getQueueStats()
+
+	if capacity <= 0 {
+		return health.Result{
+			Name:       c.Name(),
+			Category:   c.Category(),
+			Status:     health.StatusUnknown,
+			Message:    "Queue stats not available",
+			DurationMS: float64(time.Since(start).Microseconds()) / 1000,
+			Timestamp:  time.Now(),
+		}
+	}
+
+	percent := float64(depth) / float64(capacity) * 100
+
+	status := health.StatusHealthy
+	msg := fmt.Sprintf("Queue OK (%d/%d, %.0f%%)", depth, capacity, percent)
+
+	switch {
+	case percent >= 80:
+		status = health.StatusCritical
+		msg = fmt.Sprintf("Analysis queue nearly full (%d/%d, %.0f%%)", depth, capacity, percent)
+	case percent >= 50:
+		status = health.StatusWarning
+		msg = fmt.Sprintf("Analysis queue filling up (%d/%d, %.0f%%)", depth, capacity, percent)
+	}
+
+	return health.Result{
+		Name:     c.Name(),
+		Category: c.Category(),
+		Status:   status,
+		Message:  msg,
+		Details: map[string]any{
+			"current": depth,
+			"max":     capacity,
+			"percent": percent,
+		},
+		DurationMS: float64(time.Since(start).Microseconds()) / 1000,
+		Timestamp:  time.Now(),
+	}
+}

--- a/internal/health/checks/analysis.go
+++ b/internal/health/checks/analysis.go
@@ -3,6 +3,7 @@ package checks
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/tphakala/birdnet-go/internal/health"
@@ -28,6 +29,10 @@ func (c *ModelLoadedCheck) Category() health.Category { return health.CategoryAn
 // Run verifies that the analysis model is loaded.
 func (c *ModelLoadedCheck) Run(_ context.Context) health.Result {
 	start := time.Now()
+
+	if c.isLoaded == nil {
+		return skippedResult(c.Name(), c.Category(), start)
+	}
 
 	name := ""
 	if c.modelName != nil {
@@ -81,6 +86,10 @@ func (c *InferenceLatencyCheck) Category() health.Category { return health.Categ
 // Run evaluates inference latency against the analysis window duration.
 func (c *InferenceLatencyCheck) Run(_ context.Context) health.Result {
 	start := time.Now()
+
+	if c.getStats == nil {
+		return skippedResult(c.Name(), c.Category(), start)
+	}
 
 	avgMS, p99MS, windowMS := c.getStats()
 
@@ -151,10 +160,14 @@ func (c *DetectionRateCheck) Run(_ context.Context) health.Result {
 	count24h, err24h := c.getRecentCount(24)
 
 	if err6h != nil || err24h != nil {
-		msg := "Unable to query detection counts"
+		var errParts []string
 		if err6h != nil {
-			msg = fmt.Sprintf("Detection count query failed: %v", err6h)
+			errParts = append(errParts, fmt.Sprintf("6h: %v", err6h))
 		}
+		if err24h != nil {
+			errParts = append(errParts, fmt.Sprintf("24h: %v", err24h))
+		}
+		msg := fmt.Sprintf("Detection count query failed: %s", strings.Join(errParts, "; "))
 		return health.Result{
 			Name:       c.Name(),
 			Category:   c.Category(),
@@ -214,6 +227,10 @@ func (c *QueueDepthCheck) Category() health.Category { return health.CategoryAna
 // Run evaluates queue utilization.
 func (c *QueueDepthCheck) Run(_ context.Context) health.Result {
 	start := time.Now()
+
+	if c.getQueueStats == nil {
+		return skippedResult(c.Name(), c.Category(), start)
+	}
 
 	depth, capacity := c.getQueueStats()
 

--- a/internal/health/checks/analysis.go
+++ b/internal/health/checks/analysis.go
@@ -143,6 +143,10 @@ func (c *DetectionRateCheck) Category() health.Category { return health.Category
 func (c *DetectionRateCheck) Run(_ context.Context) health.Result {
 	start := time.Now()
 
+	if c.getRecentCount == nil {
+		return skippedResult(c.Name(), c.Category(), start)
+	}
+
 	count6h, err6h := c.getRecentCount(6)
 	count24h, err24h := c.getRecentCount(24)
 

--- a/internal/health/checks/audio.go
+++ b/internal/health/checks/audio.go
@@ -1,0 +1,247 @@
+package checks
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/tphakala/birdnet-go/internal/audiocore"
+	"github.com/tphakala/birdnet-go/internal/health"
+)
+
+// SourceStatusCheck monitors the health state of audio sources via the liveness watchdog.
+type SourceStatusCheck struct {
+	getSnapshots func() []audiocore.SourceHealthSnapshot
+}
+
+// NewSourceStatusCheck creates a SourceStatusCheck using the given snapshot provider.
+func NewSourceStatusCheck(getSnapshots func() []audiocore.SourceHealthSnapshot) *SourceStatusCheck {
+	return &SourceStatusCheck{getSnapshots: getSnapshots}
+}
+
+// Name returns the check identifier.
+func (c *SourceStatusCheck) Name() string { return "source_status" }
+
+// Category returns the audio category.
+func (c *SourceStatusCheck) Category() health.Category { return health.CategoryAudio }
+
+// Run evaluates the health state of all audio sources.
+func (c *SourceStatusCheck) Run(_ context.Context) health.Result {
+	start := time.Now()
+
+	if c.getSnapshots == nil {
+		return skippedResult(c.Name(), c.Category(), start)
+	}
+
+	snaps := c.getSnapshots()
+	if len(snaps) == 0 {
+		return skippedResult(c.Name(), c.Category(), start)
+	}
+
+	type sourceEntry struct {
+		ID    string `json:"id"`
+		State string `json:"state"`
+	}
+
+	entries := make([]sourceEntry, 0, len(snaps))
+	status := health.StatusHealthy
+	var msg string
+
+	for _, s := range snaps {
+		entries = append(entries, sourceEntry{ID: s.SourceID, State: s.State})
+		switch s.State {
+		case "failed", "escalated":
+			status = health.StatusCritical
+		case "alarmed":
+			if status != health.StatusCritical {
+				status = health.StatusWarning
+			}
+		}
+	}
+
+	switch status {
+	case health.StatusCritical:
+		msg = "One or more audio sources have failed or escalated"
+	case health.StatusWarning:
+		msg = "One or more audio sources are alarmed"
+	default:
+		msg = "All audio sources healthy"
+	}
+
+	return health.Result{
+		Name:       c.Name(),
+		Category:   c.Category(),
+		Status:     status,
+		Message:    msg,
+		Details:    map[string]any{"sources": entries},
+		DurationMS: float64(time.Since(start).Microseconds()) / 1000,
+		Timestamp:  time.Now(),
+	}
+}
+
+// PipelineLivenessCheck monitors how recently each audio source dispatched frames.
+type PipelineLivenessCheck struct {
+	getSnapshots func() []audiocore.SourceHealthSnapshot
+}
+
+// NewPipelineLivenessCheck creates a PipelineLivenessCheck using the given snapshot provider.
+func NewPipelineLivenessCheck(getSnapshots func() []audiocore.SourceHealthSnapshot) *PipelineLivenessCheck {
+	return &PipelineLivenessCheck{getSnapshots: getSnapshots}
+}
+
+// Name returns the check identifier.
+func (c *PipelineLivenessCheck) Name() string { return "pipeline_liveness" }
+
+// Category returns the audio category.
+func (c *PipelineLivenessCheck) Category() health.Category { return health.CategoryAudio }
+
+// Run evaluates whether audio sources are dispatching frames in a timely manner.
+func (c *PipelineLivenessCheck) Run(_ context.Context) health.Result {
+	start := time.Now()
+
+	if c.getSnapshots == nil {
+		return skippedResult(c.Name(), c.Category(), start)
+	}
+
+	snaps := c.getSnapshots()
+	if len(snaps) == 0 {
+		return skippedResult(c.Name(), c.Category(), start)
+	}
+
+	const warnAge = 30 * time.Second
+	const critAge = 2 * time.Minute
+
+	type dispatchEntry struct {
+		ID           string `json:"id"`
+		LastDispatch string `json:"last_dispatch"`
+	}
+
+	now := time.Now()
+	entries := make([]dispatchEntry, 0, len(snaps))
+	status := health.StatusHealthy
+	var msg string
+
+	for _, s := range snaps {
+		lastDispatch := "never"
+		if !s.LastDispatch.IsZero() {
+			lastDispatch = s.LastDispatch.Format(time.RFC3339)
+		}
+		entries = append(entries, dispatchEntry{ID: s.SourceID, LastDispatch: lastDispatch})
+
+		if s.LastDispatch.IsZero() {
+			continue
+		}
+		age := now.Sub(s.LastDispatch)
+		switch {
+		case age > critAge:
+			status = health.StatusCritical
+		case age > warnAge:
+			if status != health.StatusCritical {
+				status = health.StatusWarning
+			}
+		}
+	}
+
+	switch status {
+	case health.StatusCritical:
+		msg = fmt.Sprintf("One or more sources have not dispatched frames for over %s", critAge)
+	case health.StatusWarning:
+		msg = fmt.Sprintf("One or more sources have not dispatched frames for over %s", warnAge)
+	default:
+		msg = "All audio sources dispatching frames normally"
+	}
+
+	return health.Result{
+		Name:       c.Name(),
+		Category:   c.Category(),
+		Status:     status,
+		Message:    msg,
+		Details:    map[string]any{"sources": entries},
+		DurationMS: float64(time.Since(start).Microseconds()) / 1000,
+		Timestamp:  time.Now(),
+	}
+}
+
+// BufferDropsCheck monitors audio buffer drop statistics.
+// Metrics are not yet collected; this check always returns StatusSkipped.
+type BufferDropsCheck struct{}
+
+// NewBufferDropsCheck creates a BufferDropsCheck.
+func NewBufferDropsCheck() *BufferDropsCheck { return &BufferDropsCheck{} }
+
+// Name returns the check identifier.
+func (c *BufferDropsCheck) Name() string { return "buffer_drops" }
+
+// Category returns the audio category.
+func (c *BufferDropsCheck) Category() health.Category { return health.CategoryAudio }
+
+// Run returns StatusSkipped because buffer drop metrics are not yet available.
+func (c *BufferDropsCheck) Run(_ context.Context) health.Result {
+	return skippedResult(c.Name(), c.Category(), time.Now())
+}
+
+// AudioLevelCheck monitors audio input levels for silence or clipping.
+// Metrics are not yet collected; this check always returns StatusSkipped.
+type AudioLevelCheck struct{}
+
+// NewAudioLevelCheck creates an AudioLevelCheck.
+func NewAudioLevelCheck() *AudioLevelCheck { return &AudioLevelCheck{} }
+
+// Name returns the check identifier.
+func (c *AudioLevelCheck) Name() string { return "audio_level" }
+
+// Category returns the audio category.
+func (c *AudioLevelCheck) Category() health.Category { return health.CategoryAudio }
+
+// Run returns StatusSkipped because audio level metrics are not yet available.
+func (c *AudioLevelCheck) Run(_ context.Context) health.Result {
+	return skippedResult(c.Name(), c.Category(), time.Now())
+}
+
+// BufferOverrunCheck monitors the audio capture ring buffer for overrun events.
+// Metrics are not yet collected; this check always returns StatusSkipped.
+type BufferOverrunCheck struct{}
+
+// NewBufferOverrunCheck creates a BufferOverrunCheck.
+func NewBufferOverrunCheck() *BufferOverrunCheck { return &BufferOverrunCheck{} }
+
+// Name returns the check identifier.
+func (c *BufferOverrunCheck) Name() string { return "buffer_overrun" }
+
+// Category returns the audio category.
+func (c *BufferOverrunCheck) Category() health.Category { return health.CategoryAudio }
+
+// Run returns StatusSkipped because buffer overrun metrics are not yet available.
+func (c *BufferOverrunCheck) Run(_ context.Context) health.Result {
+	return skippedResult(c.Name(), c.Category(), time.Now())
+}
+
+// CaptureBufferCheck monitors the health of the audio capture buffer.
+// Metrics are not yet collected; this check always returns StatusSkipped.
+type CaptureBufferCheck struct{}
+
+// NewCaptureBufferCheck creates a CaptureBufferCheck.
+func NewCaptureBufferCheck() *CaptureBufferCheck { return &CaptureBufferCheck{} }
+
+// Name returns the check identifier.
+func (c *CaptureBufferCheck) Name() string { return "capture_buffer" }
+
+// Category returns the audio category.
+func (c *CaptureBufferCheck) Category() health.Category { return health.CategoryAudio }
+
+// Run returns StatusSkipped because capture buffer metrics are not yet available.
+func (c *CaptureBufferCheck) Run(_ context.Context) health.Result {
+	return skippedResult(c.Name(), c.Category(), time.Now())
+}
+
+// skippedResult is a helper that builds a StatusSkipped Result for checks without available data.
+func skippedResult(name string, category health.Category, start time.Time) health.Result {
+	return health.Result{
+		Name:       name,
+		Category:   category,
+		Status:     health.StatusSkipped,
+		Message:    "Metrics not yet available",
+		DurationMS: float64(time.Since(start).Microseconds()) / 1000,
+		Timestamp:  time.Now(),
+	}
+}

--- a/internal/health/checks/audio.go
+++ b/internal/health/checks/audio.go
@@ -233,15 +233,3 @@ func (c *CaptureBufferCheck) Category() health.Category { return health.Category
 func (c *CaptureBufferCheck) Run(_ context.Context) health.Result {
 	return skippedResult(c.Name(), c.Category(), time.Now())
 }
-
-// skippedResult is a helper that builds a StatusSkipped Result for checks without available data.
-func skippedResult(name string, category health.Category, start time.Time) health.Result {
-	return health.Result{
-		Name:       name,
-		Category:   category,
-		Status:     health.StatusSkipped,
-		Message:    "Metrics not yet available",
-		DurationMS: float64(time.Since(start).Microseconds()) / 1000,
-		Timestamp:  time.Now(),
-	}
-}

--- a/internal/health/checks/config.go
+++ b/internal/health/checks/config.go
@@ -1,0 +1,218 @@
+package checks
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/tphakala/birdnet-go/internal/health"
+)
+
+// PathAccessCheck verifies write access to configured filesystem paths.
+type PathAccessCheck struct {
+	paths map[string]string // label -> path
+}
+
+// NewPathAccessCheck creates a PathAccessCheck for the given labelled paths.
+// The paths map keys are human-readable labels; values are filesystem paths to test.
+func NewPathAccessCheck(paths map[string]string) *PathAccessCheck {
+	return &PathAccessCheck{paths: paths}
+}
+
+// Name returns the check identifier.
+func (c *PathAccessCheck) Name() string { return "path_access" }
+
+// Category returns the config category.
+func (c *PathAccessCheck) Category() health.Category { return health.CategoryConfig }
+
+// Run tests write access to each configured path by creating and removing a temporary file.
+func (c *PathAccessCheck) Run(_ context.Context) health.Result {
+	start := time.Now()
+
+	if len(c.paths) == 0 {
+		return health.Result{
+			Name:       c.Name(),
+			Category:   c.Category(),
+			Status:     health.StatusSkipped,
+			Message:    "No paths configured",
+			DurationMS: float64(time.Since(start).Microseconds()) / 1000,
+			Timestamp:  time.Now(),
+		}
+	}
+
+	type pathResult struct {
+		Label  string `json:"label"`
+		Path   string `json:"path"`
+		Access string `json:"access"`
+	}
+
+	results := make([]pathResult, 0, len(c.paths))
+	var failed []string
+
+	for label, path := range c.paths {
+		access := "ok"
+		tmpPath := filepath.Join(path, ".health_check_tmp")
+		f, err := os.CreateTemp(path, ".health_check_tmp_*")
+		if err != nil {
+			access = "inaccessible"
+			failed = append(failed, label)
+		} else {
+			name := f.Name()
+			_ = f.Close()
+			_ = os.Remove(name)
+			_ = tmpPath // suppress unused warning
+		}
+		results = append(results, pathResult{Label: label, Path: path, Access: access})
+	}
+
+	status := health.StatusHealthy
+	msg := "All configured paths are accessible"
+	if len(failed) > 0 {
+		status = health.StatusWarning
+		msg = fmt.Sprintf("Path(s) not writable: %s", strings.Join(failed, ", "))
+	}
+
+	return health.Result{
+		Name:     c.Name(),
+		Category: c.Category(),
+		Status:   status,
+		Message:  msg,
+		Details: map[string]any{
+			"paths": results,
+		},
+		DurationMS: float64(time.Since(start).Microseconds()) / 1000,
+		Timestamp:  time.Now(),
+	}
+}
+
+// ConfigConsistencyCheck validates the application configuration for logical inconsistencies.
+type ConfigConsistencyCheck struct {
+	validate func() []string
+}
+
+// NewConfigConsistencyCheck creates a ConfigConsistencyCheck using the given validator.
+// validate must return a slice of human-readable issue descriptions; an empty slice means healthy.
+func NewConfigConsistencyCheck(validate func() []string) *ConfigConsistencyCheck {
+	return &ConfigConsistencyCheck{validate: validate}
+}
+
+// Name returns the check identifier.
+func (c *ConfigConsistencyCheck) Name() string { return "config_consistency" }
+
+// Category returns the config category.
+func (c *ConfigConsistencyCheck) Category() health.Category { return health.CategoryConfig }
+
+// Run validates the current configuration and reports any issues found.
+func (c *ConfigConsistencyCheck) Run(_ context.Context) health.Result {
+	start := time.Now()
+
+	issues := c.validate()
+	if len(issues) == 0 {
+		return health.Result{
+			Name:       c.Name(),
+			Category:   c.Category(),
+			Status:     health.StatusHealthy,
+			Message:    "Configuration is consistent",
+			DurationMS: float64(time.Since(start).Microseconds()) / 1000,
+			Timestamp:  time.Now(),
+		}
+	}
+
+	return health.Result{
+		Name:     c.Name(),
+		Category: c.Category(),
+		Status:   health.StatusWarning,
+		Message:  fmt.Sprintf("Configuration has %d issue(s)", len(issues)),
+		Details: map[string]any{
+			"issues": issues,
+		},
+		DurationMS: float64(time.Since(start).Microseconds()) / 1000,
+		Timestamp:  time.Now(),
+	}
+}
+
+// DiskBudgetCheck monitors disk usage relative to a configured storage budget.
+type DiskBudgetCheck struct {
+	isEnabled func() bool
+	getUsage  func() (usedBytes, budgetBytes int64)
+}
+
+// NewDiskBudgetCheck creates a DiskBudgetCheck using the given enable predicate and usage provider.
+// getUsage must return (usedBytes, budgetBytes).
+func NewDiskBudgetCheck(isEnabled func() bool, getUsage func() (int64, int64)) *DiskBudgetCheck {
+	return &DiskBudgetCheck{isEnabled: isEnabled, getUsage: getUsage}
+}
+
+// Name returns the check identifier.
+func (c *DiskBudgetCheck) Name() string { return "disk_budget" }
+
+// Category returns the config category.
+func (c *DiskBudgetCheck) Category() health.Category { return health.CategoryConfig }
+
+// warnBudgetPercent is the usage ratio above which a warning is issued.
+const warnBudgetPercent = 0.80
+
+// critBudgetPercent is the usage ratio above which the check is marked critical.
+const critBudgetPercent = 0.95
+
+// Run checks disk usage against the configured budget.
+func (c *DiskBudgetCheck) Run(_ context.Context) health.Result {
+	start := time.Now()
+
+	if !c.isEnabled() {
+		return health.Result{
+			Name:       c.Name(),
+			Category:   c.Category(),
+			Status:     health.StatusSkipped,
+			Message:    "Disk budget is disabled",
+			DurationMS: float64(time.Since(start).Microseconds()) / 1000,
+			Timestamp:  time.Now(),
+		}
+	}
+
+	usedBytes, budgetBytes := c.getUsage()
+	if budgetBytes <= 0 {
+		return health.Result{
+			Name:       c.Name(),
+			Category:   c.Category(),
+			Status:     health.StatusUnknown,
+			Message:    "Disk budget not configured",
+			DurationMS: float64(time.Since(start).Microseconds()) / 1000,
+			Timestamp:  time.Now(),
+		}
+	}
+
+	ratio := float64(usedBytes) / float64(budgetBytes)
+	percent := ratio * 100
+	usedMB := float64(usedBytes) / (1 << 20)
+	budgetMB := float64(budgetBytes) / (1 << 20)
+
+	status := health.StatusHealthy
+	msg := fmt.Sprintf("Disk usage OK (%.1f MB / %.1f MB, %.0f%%)", usedMB, budgetMB, percent)
+
+	switch {
+	case ratio >= critBudgetPercent:
+		status = health.StatusCritical
+		msg = fmt.Sprintf("Disk usage critical (%.1f MB / %.1f MB, %.0f%%)", usedMB, budgetMB, percent)
+	case ratio >= warnBudgetPercent:
+		status = health.StatusWarning
+		msg = fmt.Sprintf("Disk usage elevated (%.1f MB / %.1f MB, %.0f%%)", usedMB, budgetMB, percent)
+	}
+
+	return health.Result{
+		Name:     c.Name(),
+		Category: c.Category(),
+		Status:   status,
+		Message:  msg,
+		Details: map[string]any{
+			"used_bytes":   usedBytes,
+			"budget_bytes": budgetBytes,
+			"percent":      percent,
+		},
+		DurationMS: float64(time.Since(start).Microseconds()) / 1000,
+		Timestamp:  time.Now(),
+	}
+}

--- a/internal/health/checks/config.go
+++ b/internal/health/checks/config.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -54,7 +53,6 @@ func (c *PathAccessCheck) Run(_ context.Context) health.Result {
 
 	for label, path := range c.paths {
 		access := "ok"
-		tmpPath := filepath.Join(path, ".health_check_tmp")
 		f, err := os.CreateTemp(path, ".health_check_tmp_*")
 		if err != nil {
 			access = "inaccessible"
@@ -63,7 +61,6 @@ func (c *PathAccessCheck) Run(_ context.Context) health.Result {
 			name := f.Name()
 			_ = f.Close()
 			_ = os.Remove(name)
-			_ = tmpPath // suppress unused warning
 		}
 		results = append(results, pathResult{Label: label, Path: path, Access: access})
 	}

--- a/internal/health/checks/config.go
+++ b/internal/health/checks/config.go
@@ -106,6 +106,10 @@ func (c *ConfigConsistencyCheck) Category() health.Category { return health.Cate
 func (c *ConfigConsistencyCheck) Run(_ context.Context) health.Result {
 	start := time.Now()
 
+	if c.validate == nil {
+		return skippedResult(c.Name(), c.Category(), start)
+	}
+
 	issues := c.validate()
 	if len(issues) == 0 {
 		return health.Result{
@@ -158,6 +162,10 @@ const critBudgetPercent = 0.95
 // Run checks disk usage against the configured budget.
 func (c *DiskBudgetCheck) Run(_ context.Context) health.Result {
 	start := time.Now()
+
+	if c.isEnabled == nil || c.getUsage == nil {
+		return skippedResult(c.Name(), c.Category(), start)
+	}
 
 	if !c.isEnabled() {
 		return health.Result{

--- a/internal/health/checks/database.go
+++ b/internal/health/checks/database.go
@@ -32,6 +32,10 @@ const warnSizeBytes int64 = 1 << 30
 func (c *DatabaseSizeCheck) Run(_ context.Context) health.Result {
 	start := time.Now()
 
+	if c.getDBPath == nil {
+		return skippedResult(c.Name(), c.Category(), start)
+	}
+
 	path := c.getDBPath()
 	if path == "" {
 		return health.Result{
@@ -102,6 +106,10 @@ func (c *MigrationStatusCheck) Category() health.Category { return health.Catego
 // Run verifies that all database migrations have been applied.
 func (c *MigrationStatusCheck) Run(_ context.Context) health.Result {
 	start := time.Now()
+
+	if c.checkMigration == nil {
+		return skippedResult(c.Name(), c.Category(), start)
+	}
 
 	upToDate, version, err := c.checkMigration()
 	if err != nil {

--- a/internal/health/checks/database.go
+++ b/internal/health/checks/database.go
@@ -1,0 +1,208 @@
+package checks
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/tphakala/birdnet-go/internal/health"
+)
+
+// DatabaseSizeCheck reports the size of the SQLite database file and warns when it is large.
+type DatabaseSizeCheck struct {
+	getDBPath func() string
+}
+
+// NewDatabaseSizeCheck creates a DatabaseSizeCheck using the given path provider.
+func NewDatabaseSizeCheck(getDBPath func() string) *DatabaseSizeCheck {
+	return &DatabaseSizeCheck{getDBPath: getDBPath}
+}
+
+// Name returns the check identifier.
+func (c *DatabaseSizeCheck) Name() string { return "database_size" }
+
+// Category returns the database category.
+func (c *DatabaseSizeCheck) Category() health.Category { return health.CategoryDatabase }
+
+// warnSizeBytes is the threshold above which a size warning is issued (1 GB).
+const warnSizeBytes int64 = 1 << 30
+
+// Run checks the database file size and warns if it exceeds 1 GB.
+func (c *DatabaseSizeCheck) Run(_ context.Context) health.Result {
+	start := time.Now()
+
+	path := c.getDBPath()
+	if path == "" {
+		return health.Result{
+			Name:       c.Name(),
+			Category:   c.Category(),
+			Status:     health.StatusUnknown,
+			Message:    "Database path not configured",
+			DurationMS: float64(time.Since(start).Microseconds()) / 1000,
+			Timestamp:  time.Now(),
+		}
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		return health.Result{
+			Name:       c.Name(),
+			Category:   c.Category(),
+			Status:     health.StatusUnknown,
+			Message:    fmt.Sprintf("Unable to stat database file: %v", err),
+			Details:    map[string]any{"path": path},
+			DurationMS: float64(time.Since(start).Microseconds()) / 1000,
+			Timestamp:  time.Now(),
+		}
+	}
+
+	sizeBytes := info.Size()
+	sizeMB := float64(sizeBytes) / (1 << 20)
+
+	status := health.StatusHealthy
+	msg := fmt.Sprintf("Database size OK (%.1f MB)", sizeMB)
+	if sizeBytes > warnSizeBytes {
+		status = health.StatusWarning
+		msg = fmt.Sprintf("Database file is large (%.1f MB)", sizeMB)
+	}
+
+	return health.Result{
+		Name:     c.Name(),
+		Category: c.Category(),
+		Status:   status,
+		Message:  msg,
+		Details: map[string]any{
+			"path":       path,
+			"size_bytes": sizeBytes,
+			"size_mb":    sizeMB,
+		},
+		DurationMS: float64(time.Since(start).Microseconds()) / 1000,
+		Timestamp:  time.Now(),
+	}
+}
+
+// MigrationStatusCheck verifies that the database schema is up to date.
+type MigrationStatusCheck struct {
+	checkMigration func() (bool, string, error)
+}
+
+// NewMigrationStatusCheck creates a MigrationStatusCheck using the given migration predicate.
+// The function must return (upToDate, version, err).
+func NewMigrationStatusCheck(checkMigration func() (bool, string, error)) *MigrationStatusCheck {
+	return &MigrationStatusCheck{checkMigration: checkMigration}
+}
+
+// Name returns the check identifier.
+func (c *MigrationStatusCheck) Name() string { return "migration_status" }
+
+// Category returns the database category.
+func (c *MigrationStatusCheck) Category() health.Category { return health.CategoryDatabase }
+
+// Run verifies that all database migrations have been applied.
+func (c *MigrationStatusCheck) Run(_ context.Context) health.Result {
+	start := time.Now()
+
+	upToDate, version, err := c.checkMigration()
+	if err != nil {
+		return health.Result{
+			Name:       c.Name(),
+			Category:   c.Category(),
+			Status:     health.StatusCritical,
+			Message:    fmt.Sprintf("Migration check failed: %v", err),
+			DurationMS: float64(time.Since(start).Microseconds()) / 1000,
+			Timestamp:  time.Now(),
+		}
+	}
+
+	if !upToDate {
+		return health.Result{
+			Name:     c.Name(),
+			Category: c.Category(),
+			Status:   health.StatusCritical,
+			Message:  "Database schema is not up to date",
+			Details: map[string]any{
+				"version": version,
+			},
+			DurationMS: float64(time.Since(start).Microseconds()) / 1000,
+			Timestamp:  time.Now(),
+		}
+	}
+
+	return health.Result{
+		Name:     c.Name(),
+		Category: c.Category(),
+		Status:   health.StatusHealthy,
+		Message:  fmt.Sprintf("Database schema is up to date (version %s)", version),
+		Details: map[string]any{
+			"version": version,
+		},
+		DurationMS: float64(time.Since(start).Microseconds()) / 1000,
+		Timestamp:  time.Now(),
+	}
+}
+
+// DatabasePerformanceCheck measures a simple database query latency and reports degradation.
+type DatabasePerformanceCheck struct {
+	queryTimer func() (time.Duration, error)
+}
+
+// NewDatabasePerformanceCheck creates a DatabasePerformanceCheck using the given latency probe.
+func NewDatabasePerformanceCheck(queryTimer func() (time.Duration, error)) *DatabasePerformanceCheck {
+	return &DatabasePerformanceCheck{queryTimer: queryTimer}
+}
+
+// Name returns the check identifier.
+func (c *DatabasePerformanceCheck) Name() string { return "database_performance" }
+
+// Category returns the database category.
+func (c *DatabasePerformanceCheck) Category() health.Category { return health.CategoryDatabase }
+
+// warnQueryLatency is the threshold above which a performance warning is issued.
+const warnQueryLatency = 100 * time.Millisecond
+
+// critQueryLatency is the threshold above which the check is marked critical.
+const critQueryLatency = 500 * time.Millisecond
+
+// Run measures query latency and reports degradation.
+func (c *DatabasePerformanceCheck) Run(_ context.Context) health.Result {
+	start := time.Now()
+
+	elapsed, err := c.queryTimer()
+	if err != nil {
+		return health.Result{
+			Name:       c.Name(),
+			Category:   c.Category(),
+			Status:     health.StatusCritical,
+			Message:    fmt.Sprintf("Database query failed: %v", err),
+			DurationMS: float64(time.Since(start).Microseconds()) / 1000,
+			Timestamp:  time.Now(),
+		}
+	}
+
+	latencyMS := float64(elapsed.Microseconds()) / 1000
+
+	status := health.StatusHealthy
+	msg := fmt.Sprintf("Database query latency OK (%.1f ms)", latencyMS)
+
+	switch {
+	case elapsed >= critQueryLatency:
+		status = health.StatusCritical
+		msg = fmt.Sprintf("Database query latency critical (%.1f ms)", latencyMS)
+	case elapsed >= warnQueryLatency:
+		status = health.StatusWarning
+		msg = fmt.Sprintf("Database query latency elevated (%.1f ms)", latencyMS)
+	}
+
+	return health.Result{
+		Name:     c.Name(),
+		Category: c.Category(),
+		Status:   status,
+		Message:  msg,
+		Details: map[string]any{
+			"latency_ms": latencyMS,
+		},
+		DurationMS: float64(time.Since(start).Microseconds()) / 1000,
+		Timestamp:  time.Now(),
+	}
+}

--- a/internal/health/checks/database.go
+++ b/internal/health/checks/database.go
@@ -168,6 +168,10 @@ const critQueryLatency = 500 * time.Millisecond
 func (c *DatabasePerformanceCheck) Run(_ context.Context) health.Result {
 	start := time.Now()
 
+	if c.queryTimer == nil {
+		return skippedResult(c.Name(), c.Category(), start)
+	}
+
 	elapsed, err := c.queryTimer()
 	if err != nil {
 		return health.Result{

--- a/internal/health/checks/helpers.go
+++ b/internal/health/checks/helpers.go
@@ -1,0 +1,19 @@
+package checks
+
+import (
+	"time"
+
+	"github.com/tphakala/birdnet-go/internal/health"
+)
+
+// skippedResult builds a StatusSkipped Result for checks without available data.
+func skippedResult(name string, category health.Category, start time.Time) health.Result {
+	return health.Result{
+		Name:       name,
+		Category:   category,
+		Status:     health.StatusSkipped,
+		Message:    "Metrics not yet available",
+		DurationMS: float64(time.Since(start).Microseconds()) / 1000,
+		Timestamp:  time.Now(),
+	}
+}

--- a/internal/health/checks/logs.go
+++ b/internal/health/checks/logs.go
@@ -1,0 +1,200 @@
+package checks
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/tphakala/birdnet-go/internal/health"
+)
+
+// recentErrorWindow is the lookback period used by RecentErrorsCheck.
+const recentErrorWindow = time.Hour
+
+// recentErrorWarnThreshold is the error count above which a warning is issued.
+const recentErrorWarnThreshold = 10
+
+// recentErrorCritThreshold is the error count above which the check is marked critical.
+const recentErrorCritThreshold = 50
+
+// RecentErrorsCheck counts errors recorded in the last hour and warns when the count is high.
+type RecentErrorsCheck struct {
+	errorBuffer *health.ErrorRingBuffer
+}
+
+// NewRecentErrorsCheck creates a RecentErrorsCheck backed by the given error ring buffer.
+func NewRecentErrorsCheck(errorBuffer *health.ErrorRingBuffer) *RecentErrorsCheck {
+	return &RecentErrorsCheck{errorBuffer: errorBuffer}
+}
+
+// Name returns the check identifier.
+func (c *RecentErrorsCheck) Name() string { return "recent_errors" }
+
+// Category returns the logs category.
+func (c *RecentErrorsCheck) Category() health.Category { return health.CategoryLogs }
+
+// Run counts errors in the last hour and reports degraded status when the count is elevated.
+func (c *RecentErrorsCheck) Run(_ context.Context) health.Result {
+	start := time.Now()
+
+	since := time.Now().Add(-recentErrorWindow)
+	count := c.errorBuffer.CountSince(since)
+
+	status := health.StatusHealthy
+	msg := fmt.Sprintf("Error count OK (%d in last hour)", count)
+
+	switch {
+	case count > recentErrorCritThreshold:
+		status = health.StatusCritical
+		msg = fmt.Sprintf("High error rate (%d errors in last hour)", count)
+	case count > recentErrorWarnThreshold:
+		status = health.StatusWarning
+		msg = fmt.Sprintf("Elevated error count (%d errors in last hour)", count)
+	}
+
+	return health.Result{
+		Name:     c.Name(),
+		Category: c.Category(),
+		Status:   status,
+		Message:  msg,
+		Details: map[string]any{
+			"count_last_hour": count,
+		},
+		DurationMS: float64(time.Since(start).Microseconds()) / 1000,
+		Timestamp:  time.Now(),
+	}
+}
+
+// trendHalfWindow is the half-period used for error trend comparison (30 minutes each half).
+const trendHalfWindow = 30 * time.Minute
+
+// trendRatioThreshold is the ratio of recent to previous errors above which a warning is issued.
+const trendRatioThreshold = 1.5
+
+// trendMinCount is the minimum recent error count required to trigger a trend warning.
+const trendMinCount = 5
+
+// ErrorTrendCheck compares error counts in the last 30 minutes against the preceding 30 minutes.
+// A warning is issued when the recent count exceeds 1.5x the previous count and is above a minimum.
+type ErrorTrendCheck struct {
+	errorBuffer *health.ErrorRingBuffer
+}
+
+// NewErrorTrendCheck creates an ErrorTrendCheck backed by the given error ring buffer.
+func NewErrorTrendCheck(errorBuffer *health.ErrorRingBuffer) *ErrorTrendCheck {
+	return &ErrorTrendCheck{errorBuffer: errorBuffer}
+}
+
+// Name returns the check identifier.
+func (c *ErrorTrendCheck) Name() string { return "error_trend" }
+
+// Category returns the logs category.
+func (c *ErrorTrendCheck) Category() health.Category { return health.CategoryLogs }
+
+// Run compares recent versus previous error counts and warns on an increasing trend.
+func (c *ErrorTrendCheck) Run(_ context.Context) health.Result {
+	start := time.Now()
+	now := time.Now()
+
+	midpoint := now.Add(-trendHalfWindow)
+	periodStart := now.Add(-2 * trendHalfWindow)
+
+	recent := c.errorBuffer.CountSince(midpoint)
+	total := c.errorBuffer.CountSince(periodStart)
+	previous := total - recent
+
+	status := health.StatusHealthy
+	msg := fmt.Sprintf("Error trend stable (recent=%d, previous=%d)", recent, previous)
+
+	if previous > 0 {
+		ratio := float64(recent) / float64(previous)
+		if ratio > trendRatioThreshold && recent > trendMinCount {
+			status = health.StatusWarning
+			msg = fmt.Sprintf("Error rate increasing (recent=%d, previous=%d, ratio=%.1fx)", recent, previous, ratio)
+		}
+	} else if recent > trendMinCount {
+		status = health.StatusWarning
+		msg = fmt.Sprintf("Error rate increasing (recent=%d, previous=0)", recent)
+	}
+
+	return health.Result{
+		Name:     c.Name(),
+		Category: c.Category(),
+		Status:   status,
+		Message:  msg,
+		Details: map[string]any{
+			"recent_30m":   recent,
+			"previous_30m": previous,
+		},
+		DurationMS: float64(time.Since(start).Microseconds()) / 1000,
+		Timestamp:  time.Now(),
+	}
+}
+
+// criticalEventLookback is how far back CriticalEventsCheck scans for fatal/panic entries.
+const criticalEventLookback = 100
+
+// CriticalEventsCheck scans recent log entries for fatal or panic-level events.
+type CriticalEventsCheck struct {
+	errorBuffer *health.ErrorRingBuffer
+}
+
+// NewCriticalEventsCheck creates a CriticalEventsCheck backed by the given error ring buffer.
+func NewCriticalEventsCheck(errorBuffer *health.ErrorRingBuffer) *CriticalEventsCheck {
+	return &CriticalEventsCheck{errorBuffer: errorBuffer}
+}
+
+// Name returns the check identifier.
+func (c *CriticalEventsCheck) Name() string { return "critical_events" }
+
+// Category returns the logs category.
+func (c *CriticalEventsCheck) Category() health.Category { return health.CategoryLogs }
+
+// Run scans recent log entries for fatal or panic-level events and fails if any are found.
+func (c *CriticalEventsCheck) Run(_ context.Context) health.Result {
+	start := time.Now()
+
+	entries := c.errorBuffer.Recent(criticalEventLookback)
+
+	type eventEntry struct {
+		Level     string    `json:"level"`
+		Message   string    `json:"message"`
+		Component string    `json:"component,omitempty"`
+		Timestamp time.Time `json:"timestamp"`
+	}
+
+	var criticalFound []eventEntry
+	for _, e := range entries {
+		if e.Level == "fatal" || e.Level == "panic" {
+			criticalFound = append(criticalFound, eventEntry{
+				Level:     e.Level,
+				Message:   e.Message,
+				Component: e.Component,
+				Timestamp: e.Timestamp,
+			})
+		}
+	}
+
+	if len(criticalFound) > 0 {
+		return health.Result{
+			Name:     c.Name(),
+			Category: c.Category(),
+			Status:   health.StatusCritical,
+			Message:  fmt.Sprintf("Found %d critical event(s) (fatal/panic) in recent log entries", len(criticalFound)),
+			Details: map[string]any{
+				"events": criticalFound,
+			},
+			DurationMS: float64(time.Since(start).Microseconds()) / 1000,
+			Timestamp:  time.Now(),
+		}
+	}
+
+	return health.Result{
+		Name:       c.Name(),
+		Category:   c.Category(),
+		Status:     health.StatusHealthy,
+		Message:    "No critical events in recent log entries",
+		DurationMS: float64(time.Since(start).Microseconds()) / 1000,
+		Timestamp:  time.Now(),
+	}
+}

--- a/internal/health/checks/logs.go
+++ b/internal/health/checks/logs.go
@@ -37,7 +37,11 @@ func (c *RecentErrorsCheck) Category() health.Category { return health.CategoryL
 func (c *RecentErrorsCheck) Run(_ context.Context) health.Result {
 	start := time.Now()
 
-	since := time.Now().Add(-recentErrorWindow)
+	if c.errorBuffer.Count() == 0 {
+		return skippedResult(c.Name(), c.Category(), start)
+	}
+
+	since := start.Add(-recentErrorWindow)
 	count := c.errorBuffer.CountSince(since)
 
 	status := health.StatusHealthy
@@ -94,10 +98,13 @@ func (c *ErrorTrendCheck) Category() health.Category { return health.CategoryLog
 // Run compares recent versus previous error counts and warns on an increasing trend.
 func (c *ErrorTrendCheck) Run(_ context.Context) health.Result {
 	start := time.Now()
-	now := time.Now()
 
-	midpoint := now.Add(-trendHalfWindow)
-	periodStart := now.Add(-2 * trendHalfWindow)
+	if c.errorBuffer.Count() == 0 {
+		return skippedResult(c.Name(), c.Category(), start)
+	}
+
+	midpoint := start.Add(-trendHalfWindow)
+	periodStart := start.Add(-2 * trendHalfWindow)
 
 	recent := c.errorBuffer.CountSince(midpoint)
 	total := c.errorBuffer.CountSince(periodStart)
@@ -153,6 +160,10 @@ func (c *CriticalEventsCheck) Category() health.Category { return health.Categor
 // Run scans recent log entries for fatal or panic-level events and fails if any are found.
 func (c *CriticalEventsCheck) Run(_ context.Context) health.Result {
 	start := time.Now()
+
+	if c.errorBuffer.Count() == 0 {
+		return skippedResult(c.Name(), c.Category(), start)
+	}
 
 	entries := c.errorBuffer.Recent(criticalEventLookback)
 

--- a/internal/health/checks/network.go
+++ b/internal/health/checks/network.go
@@ -1,0 +1,185 @@
+package checks
+
+import (
+	"context"
+	"time"
+
+	"github.com/tphakala/birdnet-go/internal/health"
+)
+
+// MQTTCheck verifies connectivity to the MQTT broker when MQTT is enabled.
+type MQTTCheck struct {
+	isEnabled   func() bool
+	isConnected func() bool
+}
+
+// NewMQTTCheck creates an MQTTCheck using the given enable and connection predicates.
+func NewMQTTCheck(isEnabled, isConnected func() bool) *MQTTCheck {
+	return &MQTTCheck{isEnabled: isEnabled, isConnected: isConnected}
+}
+
+// Name returns the check identifier.
+func (c *MQTTCheck) Name() string { return "mqtt" }
+
+// Category returns the network category.
+func (c *MQTTCheck) Category() health.Category { return health.CategoryNetwork }
+
+// Run verifies MQTT broker connectivity when MQTT is enabled.
+func (c *MQTTCheck) Run(_ context.Context) health.Result {
+	start := time.Now()
+
+	if !c.isEnabled() {
+		return health.Result{
+			Name:       c.Name(),
+			Category:   c.Category(),
+			Status:     health.StatusSkipped,
+			Message:    "MQTT is disabled",
+			DurationMS: float64(time.Since(start).Microseconds()) / 1000,
+			Timestamp:  time.Now(),
+		}
+	}
+
+	if !c.isConnected() {
+		return health.Result{
+			Name:       c.Name(),
+			Category:   c.Category(),
+			Status:     health.StatusWarning,
+			Message:    "MQTT broker is not connected",
+			DurationMS: float64(time.Since(start).Microseconds()) / 1000,
+			Timestamp:  time.Now(),
+		}
+	}
+
+	return health.Result{
+		Name:       c.Name(),
+		Category:   c.Category(),
+		Status:     health.StatusHealthy,
+		Message:    "MQTT broker connected",
+		DurationMS: float64(time.Since(start).Microseconds()) / 1000,
+		Timestamp:  time.Now(),
+	}
+}
+
+// BirdWeatherCheck verifies connectivity to the BirdWeather service when it is enabled.
+type BirdWeatherCheck struct {
+	isEnabled func() bool
+	getStatus func() (bool, string)
+}
+
+// NewBirdWeatherCheck creates a BirdWeatherCheck using the given enable predicate and status provider.
+// getStatus must return (connected, statusMessage).
+func NewBirdWeatherCheck(isEnabled func() bool, getStatus func() (bool, string)) *BirdWeatherCheck {
+	return &BirdWeatherCheck{isEnabled: isEnabled, getStatus: getStatus}
+}
+
+// Name returns the check identifier.
+func (c *BirdWeatherCheck) Name() string { return "birdweather" }
+
+// Category returns the network category.
+func (c *BirdWeatherCheck) Category() health.Category { return health.CategoryNetwork }
+
+// Run verifies BirdWeather service connectivity when the integration is enabled.
+func (c *BirdWeatherCheck) Run(_ context.Context) health.Result {
+	start := time.Now()
+
+	if !c.isEnabled() {
+		return health.Result{
+			Name:       c.Name(),
+			Category:   c.Category(),
+			Status:     health.StatusSkipped,
+			Message:    "BirdWeather integration is disabled",
+			DurationMS: float64(time.Since(start).Microseconds()) / 1000,
+			Timestamp:  time.Now(),
+		}
+	}
+
+	connected, statusMsg := c.getStatus()
+	if !connected {
+		return health.Result{
+			Name:       c.Name(),
+			Category:   c.Category(),
+			Status:     health.StatusWarning,
+			Message:    statusMsg,
+			DurationMS: float64(time.Since(start).Microseconds()) / 1000,
+			Timestamp:  time.Now(),
+		}
+	}
+
+	return health.Result{
+		Name:       c.Name(),
+		Category:   c.Category(),
+		Status:     health.StatusHealthy,
+		Message:    statusMsg,
+		DurationMS: float64(time.Since(start).Microseconds()) / 1000,
+		Timestamp:  time.Now(),
+	}
+}
+
+// NotificationProvidersCheck reports the connectivity state of configured notification providers.
+// Probe infrastructure is not yet available; this check always returns StatusSkipped.
+type NotificationProvidersCheck struct{}
+
+// NewNotificationProvidersCheck creates a NotificationProvidersCheck.
+func NewNotificationProvidersCheck() *NotificationProvidersCheck {
+	return &NotificationProvidersCheck{}
+}
+
+// Name returns the check identifier.
+func (c *NotificationProvidersCheck) Name() string { return "notification_providers" }
+
+// Category returns the network category.
+func (c *NotificationProvidersCheck) Category() health.Category { return health.CategoryNetwork }
+
+// Run returns StatusSkipped because notification probe infrastructure is not yet available.
+func (c *NotificationProvidersCheck) Run(_ context.Context) health.Result {
+	return health.Result{
+		Name:       c.Name(),
+		Category:   c.Category(),
+		Status:     health.StatusSkipped,
+		Message:    "Probe infrastructure not yet available",
+		DurationMS: 0,
+		Timestamp:  time.Now(),
+	}
+}
+
+// WeatherCheck verifies connectivity to the configured weather provider.
+// Probe infrastructure is not yet available; enabled instances return StatusSkipped.
+type WeatherCheck struct {
+	isEnabled func() bool
+}
+
+// NewWeatherCheck creates a WeatherCheck using the given enable predicate.
+func NewWeatherCheck(isEnabled func() bool) *WeatherCheck {
+	return &WeatherCheck{isEnabled: isEnabled}
+}
+
+// Name returns the check identifier.
+func (c *WeatherCheck) Name() string { return "weather" }
+
+// Category returns the network category.
+func (c *WeatherCheck) Category() health.Category { return health.CategoryNetwork }
+
+// Run returns StatusSkipped when disabled, or StatusSkipped with a not-yet-available message when enabled.
+func (c *WeatherCheck) Run(_ context.Context) health.Result {
+	start := time.Now()
+
+	if !c.isEnabled() {
+		return health.Result{
+			Name:       c.Name(),
+			Category:   c.Category(),
+			Status:     health.StatusSkipped,
+			Message:    "Weather integration is disabled",
+			DurationMS: float64(time.Since(start).Microseconds()) / 1000,
+			Timestamp:  time.Now(),
+		}
+	}
+
+	return health.Result{
+		Name:       c.Name(),
+		Category:   c.Category(),
+		Status:     health.StatusSkipped,
+		Message:    "Probe infrastructure not yet available",
+		DurationMS: float64(time.Since(start).Microseconds()) / 1000,
+		Timestamp:  time.Now(),
+	}
+}

--- a/internal/health/checks/network.go
+++ b/internal/health/checks/network.go
@@ -132,14 +132,7 @@ func (c *NotificationProvidersCheck) Category() health.Category { return health.
 
 // Run returns StatusSkipped because notification probe infrastructure is not yet available.
 func (c *NotificationProvidersCheck) Run(_ context.Context) health.Result {
-	return health.Result{
-		Name:       c.Name(),
-		Category:   c.Category(),
-		Status:     health.StatusSkipped,
-		Message:    "Probe infrastructure not yet available",
-		DurationMS: 0,
-		Timestamp:  time.Now(),
-	}
+	return skippedResult(c.Name(), c.Category(), time.Now())
 }
 
 // WeatherCheck verifies connectivity to the configured weather provider.

--- a/internal/health/checks/network.go
+++ b/internal/health/checks/network.go
@@ -28,6 +28,10 @@ func (c *MQTTCheck) Category() health.Category { return health.CategoryNetwork }
 func (c *MQTTCheck) Run(_ context.Context) health.Result {
 	start := time.Now()
 
+	if c.isEnabled == nil {
+		return skippedResult(c.Name(), c.Category(), start)
+	}
+
 	if !c.isEnabled() {
 		return health.Result{
 			Name:       c.Name(),
@@ -37,6 +41,10 @@ func (c *MQTTCheck) Run(_ context.Context) health.Result {
 			DurationMS: float64(time.Since(start).Microseconds()) / 1000,
 			Timestamp:  time.Now(),
 		}
+	}
+
+	if c.isConnected == nil {
+		return skippedResult(c.Name(), c.Category(), start)
 	}
 
 	if !c.isConnected() {
@@ -82,6 +90,10 @@ func (c *BirdWeatherCheck) Category() health.Category { return health.CategoryNe
 func (c *BirdWeatherCheck) Run(_ context.Context) health.Result {
 	start := time.Now()
 
+	if c.isEnabled == nil {
+		return skippedResult(c.Name(), c.Category(), start)
+	}
+
 	if !c.isEnabled() {
 		return health.Result{
 			Name:       c.Name(),
@@ -91,6 +103,10 @@ func (c *BirdWeatherCheck) Run(_ context.Context) health.Result {
 			DurationMS: float64(time.Since(start).Microseconds()) / 1000,
 			Timestamp:  time.Now(),
 		}
+	}
+
+	if c.getStatus == nil {
+		return skippedResult(c.Name(), c.Category(), start)
 	}
 
 	connected, statusMsg := c.getStatus()
@@ -155,6 +171,10 @@ func (c *WeatherCheck) Category() health.Category { return health.CategoryNetwor
 // Run returns StatusSkipped when disabled, or StatusSkipped with a not-yet-available message when enabled.
 func (c *WeatherCheck) Run(_ context.Context) health.Result {
 	start := time.Now()
+
+	if c.isEnabled == nil {
+		return skippedResult(c.Name(), c.Category(), start)
+	}
 
 	if !c.isEnabled() {
 		return health.Result{

--- a/internal/health/checks/streams.go
+++ b/internal/health/checks/streams.go
@@ -1,0 +1,228 @@
+package checks
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/tphakala/birdnet-go/internal/health"
+)
+
+// StreamHealthInfo is a snapshot of a single RTSP stream's health.
+type StreamHealthInfo struct {
+	// URL is the RTSP source URL.
+	URL string
+	// IsHealthy indicates whether the stream is considered healthy.
+	IsHealthy bool
+	// ProcessState is the current state of the underlying FFmpeg process (e.g. "running", "dead").
+	ProcessState string
+	// RestartCount is the number of times this stream has been restarted.
+	RestartCount int
+	// Error holds the most recent error message, if any.
+	Error string
+}
+
+// StreamConnectivityCheck verifies that all configured RTSP streams are reachable and healthy.
+type StreamConnectivityCheck struct {
+	getStreams func() []StreamHealthInfo
+}
+
+// NewStreamConnectivityCheck creates a StreamConnectivityCheck using the given stream provider.
+func NewStreamConnectivityCheck(getStreams func() []StreamHealthInfo) *StreamConnectivityCheck {
+	return &StreamConnectivityCheck{getStreams: getStreams}
+}
+
+// Name returns the check identifier.
+func (c *StreamConnectivityCheck) Name() string { return "stream_connectivity" }
+
+// Category returns the streams category.
+func (c *StreamConnectivityCheck) Category() health.Category { return health.CategoryStreams }
+
+// Run evaluates the connectivity health of all RTSP streams.
+func (c *StreamConnectivityCheck) Run(_ context.Context) health.Result {
+	start := time.Now()
+
+	if c.getStreams == nil {
+		return skippedResult(c.Name(), c.Category(), start)
+	}
+
+	streams := c.getStreams()
+	if len(streams) == 0 {
+		return skippedResult(c.Name(), c.Category(), start)
+	}
+
+	unhealthy := 0
+	for _, s := range streams {
+		if !s.IsHealthy {
+			unhealthy++
+		}
+	}
+
+	status := health.StatusHealthy
+	msg := fmt.Sprintf("All %d streams connected", len(streams))
+
+	switch {
+	case unhealthy > 1:
+		status = health.StatusCritical
+		msg = fmt.Sprintf("%d of %d streams are not healthy", unhealthy, len(streams))
+	case unhealthy == 1:
+		status = health.StatusWarning
+		msg = fmt.Sprintf("1 of %d streams is not healthy", len(streams))
+	}
+
+	return health.Result{
+		Name:     c.Name(),
+		Category: c.Category(),
+		Status:   status,
+		Message:  msg,
+		Details: map[string]any{
+			"total":     len(streams),
+			"unhealthy": unhealthy,
+		},
+		DurationMS: float64(time.Since(start).Microseconds()) / 1000,
+		Timestamp:  time.Now(),
+	}
+}
+
+// StreamErrorRateCheck monitors RTSP stream restart counts to detect error loops.
+type StreamErrorRateCheck struct {
+	getStreams func() []StreamHealthInfo
+}
+
+// NewStreamErrorRateCheck creates a StreamErrorRateCheck using the given stream provider.
+func NewStreamErrorRateCheck(getStreams func() []StreamHealthInfo) *StreamErrorRateCheck {
+	return &StreamErrorRateCheck{getStreams: getStreams}
+}
+
+// Name returns the check identifier.
+func (c *StreamErrorRateCheck) Name() string { return "stream_error_rate" }
+
+// Category returns the streams category.
+func (c *StreamErrorRateCheck) Category() health.Category { return health.CategoryStreams }
+
+// Run evaluates the restart count of each RTSP stream.
+func (c *StreamErrorRateCheck) Run(_ context.Context) health.Result {
+	start := time.Now()
+
+	if c.getStreams == nil {
+		return skippedResult(c.Name(), c.Category(), start)
+	}
+
+	streams := c.getStreams()
+	if len(streams) == 0 {
+		return skippedResult(c.Name(), c.Category(), start)
+	}
+
+	const warnRestarts = 3
+	const critRestarts = 10
+
+	status := health.StatusHealthy
+	var msg string
+	warnCount := 0
+	critCount := 0
+
+	for _, s := range streams {
+		switch {
+		case s.RestartCount > critRestarts:
+			critCount++
+		case s.RestartCount > warnRestarts:
+			warnCount++
+		}
+	}
+
+	switch {
+	case critCount > 0:
+		status = health.StatusCritical
+		msg = fmt.Sprintf("%d stream(s) have restarted more than %d times", critCount, critRestarts)
+	case warnCount > 0:
+		status = health.StatusWarning
+		msg = fmt.Sprintf("%d stream(s) have restarted more than %d times", warnCount, warnRestarts)
+	default:
+		msg = "Stream restart counts within normal range"
+	}
+
+	return health.Result{
+		Name:     c.Name(),
+		Category: c.Category(),
+		Status:   status,
+		Message:  msg,
+		Details: map[string]any{
+			"streams_above_warn_threshold": warnCount,
+			"streams_above_crit_threshold": critCount,
+			"warn_threshold":               warnRestarts,
+			"crit_threshold":               critRestarts,
+		},
+		DurationMS: float64(time.Since(start).Microseconds()) / 1000,
+		Timestamp:  time.Now(),
+	}
+}
+
+// FFmpegHealthCheck monitors the process state of the FFmpeg processes backing each RTSP stream.
+type FFmpegHealthCheck struct {
+	getStreams func() []StreamHealthInfo
+}
+
+// NewFFmpegHealthCheck creates an FFmpegHealthCheck using the given stream provider.
+func NewFFmpegHealthCheck(getStreams func() []StreamHealthInfo) *FFmpegHealthCheck {
+	return &FFmpegHealthCheck{getStreams: getStreams}
+}
+
+// Name returns the check identifier.
+func (c *FFmpegHealthCheck) Name() string { return "ffmpeg_health" }
+
+// Category returns the streams category.
+func (c *FFmpegHealthCheck) Category() health.Category { return health.CategoryStreams }
+
+// Run evaluates the process state of each stream's FFmpeg instance.
+func (c *FFmpegHealthCheck) Run(_ context.Context) health.Result {
+	start := time.Now()
+
+	if c.getStreams == nil {
+		return skippedResult(c.Name(), c.Category(), start)
+	}
+
+	streams := c.getStreams()
+	if len(streams) == 0 {
+		return skippedResult(c.Name(), c.Category(), start)
+	}
+
+	deadCount := 0
+	notRunningCount := 0
+
+	for _, s := range streams {
+		switch s.ProcessState {
+		case "dead":
+			deadCount++
+		case "running":
+			// healthy
+		default:
+			notRunningCount++
+		}
+	}
+
+	status := health.StatusHealthy
+	msg := fmt.Sprintf("All %d FFmpeg processes running", len(streams))
+
+	switch {
+	case deadCount > 0:
+		status = health.StatusCritical
+		msg = fmt.Sprintf("%d FFmpeg process(es) are dead", deadCount)
+	case notRunningCount > 0:
+		status = health.StatusWarning
+		msg = fmt.Sprintf("%d FFmpeg process(es) are not in running state", notRunningCount)
+	}
+
+	return health.Result{
+		Name:     c.Name(),
+		Category: c.Category(),
+		Status:   status,
+		Message:  msg,
+		Details: map[string]any{
+			"total":       len(streams),
+			"dead":        deadCount,
+			"not_running": notRunningCount,
+		},
+		DurationMS: float64(time.Since(start).Microseconds()) / 1000,
+		Timestamp:  time.Now(),
+	}
+}

--- a/internal/health/checks/system.go
+++ b/internal/health/checks/system.go
@@ -192,6 +192,10 @@ func (c *CPULoadCheck) Category() health.Category { return health.CategorySystem
 func (c *CPULoadCheck) Run(_ context.Context) health.Result {
 	start := time.Now()
 
+	if c.getCPU == nil {
+		return skippedResult(c.Name(), c.Category(), start)
+	}
+
 	percents := c.getCPU()
 	if len(percents) == 0 {
 		return health.Result{
@@ -258,6 +262,10 @@ func (c *TemperatureCheck) Category() health.Category { return health.CategorySy
 // Run executes the temperature check.
 func (c *TemperatureCheck) Run(_ context.Context) health.Result {
 	start := time.Now()
+
+	if c.getTemp == nil {
+		return skippedResult(c.Name(), c.Category(), start)
+	}
 
 	tempC, err := c.getTemp()
 	if err != nil {

--- a/internal/health/checks/system.go
+++ b/internal/health/checks/system.go
@@ -57,7 +57,9 @@ func (c *DiskSpaceCheck) Run(_ context.Context) health.Result {
 	for _, p := range c.paths {
 		usage, err := disk.Usage(p)
 		if err != nil {
-			worst = health.StatusWarning
+			if health.StatusCritical != worst {
+				worst = health.StatusWarning
+			}
 			messages = append(messages, fmt.Sprintf("%s: unable to read (%v)", p, err))
 			continue
 		}

--- a/internal/health/checks/system.go
+++ b/internal/health/checks/system.go
@@ -1,0 +1,361 @@
+// Package checks provides concrete health check implementations for BirdNET-Go.
+package checks
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/shirou/gopsutil/v3/disk"
+	"github.com/shirou/gopsutil/v3/mem"
+	"github.com/tphakala/birdnet-go/internal/health"
+)
+
+// DiskSpaceCheck verifies that monitored filesystem paths have sufficient free space.
+type DiskSpaceCheck struct {
+	paths []string
+}
+
+// NewDiskSpaceCheck creates a DiskSpaceCheck that monitors the given filesystem paths.
+func NewDiskSpaceCheck(paths []string) *DiskSpaceCheck {
+	return &DiskSpaceCheck{paths: paths}
+}
+
+// Name returns the check identifier.
+func (c *DiskSpaceCheck) Name() string { return "disk_space" }
+
+// Category returns the system category.
+func (c *DiskSpaceCheck) Category() health.Category { return health.CategorySystem }
+
+// Run executes the disk space check against all configured paths.
+func (c *DiskSpaceCheck) Run(_ context.Context) health.Result {
+	start := time.Now()
+
+	if len(c.paths) == 0 {
+		return health.Result{
+			Name:       c.Name(),
+			Category:   c.Category(),
+			Status:     health.StatusSkipped,
+			Message:    "No paths configured",
+			DurationMS: float64(time.Since(start).Microseconds()) / 1000,
+			Timestamp:  time.Now(),
+		}
+	}
+
+	type pathInfo struct {
+		Path    string  `json:"path"`
+		Total   uint64  `json:"total_bytes"`
+		Used    uint64  `json:"used_bytes"`
+		Free    uint64  `json:"free_bytes"`
+		Percent float64 `json:"percent_used"`
+	}
+
+	worst := health.StatusHealthy
+	var messages []string
+	pathDetails := make([]pathInfo, 0, len(c.paths))
+
+	for _, p := range c.paths {
+		usage, err := disk.Usage(p)
+		if err != nil {
+			worst = health.StatusWarning
+			messages = append(messages, fmt.Sprintf("%s: unable to read (%v)", p, err))
+			continue
+		}
+
+		info := pathInfo{
+			Path:    p,
+			Total:   usage.Total,
+			Used:    usage.Used,
+			Free:    usage.Free,
+			Percent: usage.UsedPercent,
+		}
+		pathDetails = append(pathDetails, info)
+
+		freePercent := 100 - usage.UsedPercent
+		switch {
+		case freePercent < 5:
+			worst = health.StatusCritical
+			messages = append(messages, fmt.Sprintf("%s: critical (%.1f%% free)", p, freePercent))
+		case freePercent < 10:
+			if health.StatusCritical != worst {
+				worst = health.StatusWarning
+			}
+			messages = append(messages, fmt.Sprintf("%s: low (%.1f%% free)", p, freePercent))
+		}
+	}
+
+	msg := "Disk space OK"
+	if len(messages) > 0 {
+		msg = messages[0]
+		if len(messages) > 1 {
+			msg = fmt.Sprintf("%s (and %d more)", msg, len(messages)-1)
+		}
+	}
+
+	details := map[string]any{"paths": pathDetails}
+
+	return health.Result{
+		Name:       c.Name(),
+		Category:   c.Category(),
+		Status:     worst,
+		Message:    msg,
+		Details:    details,
+		DurationMS: float64(time.Since(start).Microseconds()) / 1000,
+		Timestamp:  time.Now(),
+	}
+}
+
+// MemoryCheck verifies that the system has sufficient available memory.
+type MemoryCheck struct{}
+
+// NewMemoryCheck creates a MemoryCheck.
+func NewMemoryCheck() *MemoryCheck { return &MemoryCheck{} }
+
+// Name returns the check identifier.
+func (c *MemoryCheck) Name() string { return "memory" }
+
+// Category returns the system category.
+func (c *MemoryCheck) Category() health.Category { return health.CategorySystem }
+
+// Run executes the memory check.
+func (c *MemoryCheck) Run(_ context.Context) health.Result {
+	start := time.Now()
+
+	vm, err := mem.VirtualMemory()
+	if err != nil {
+		return health.Result{
+			Name:       c.Name(),
+			Category:   c.Category(),
+			Status:     health.StatusUnknown,
+			Message:    fmt.Sprintf("Unable to read memory stats: %v", err),
+			DurationMS: float64(time.Since(start).Microseconds()) / 1000,
+			Timestamp:  time.Now(),
+		}
+	}
+
+	const (
+		warnPercent  = 85.0
+		critPercent  = 95.0
+		warnMinBytes = 256 * 1024 * 1024 // 256 MB
+		critMinBytes = 128 * 1024 * 1024 // 128 MB
+	)
+
+	status := health.StatusHealthy
+	msg := "Memory OK"
+
+	switch {
+	case vm.UsedPercent >= critPercent || vm.Available < critMinBytes:
+		status = health.StatusCritical
+		msg = fmt.Sprintf("Memory critical: %.1f%% used, %d MB available",
+			vm.UsedPercent, vm.Available/1024/1024)
+	case vm.UsedPercent >= warnPercent || vm.Available < warnMinBytes:
+		status = health.StatusWarning
+		msg = fmt.Sprintf("Memory warning: %.1f%% used, %d MB available",
+			vm.UsedPercent, vm.Available/1024/1024)
+	}
+
+	return health.Result{
+		Name:     c.Name(),
+		Category: c.Category(),
+		Status:   status,
+		Message:  msg,
+		Details: map[string]any{
+			"total_bytes":     vm.Total,
+			"used_bytes":      vm.Used,
+			"available_bytes": vm.Available,
+			"percent_used":    vm.UsedPercent,
+		},
+		DurationMS: float64(time.Since(start).Microseconds()) / 1000,
+		Timestamp:  time.Now(),
+	}
+}
+
+// CPULoadCheck verifies that CPU utilization is within acceptable bounds.
+type CPULoadCheck struct {
+	getCPU func() []float64
+}
+
+// NewCPULoadCheck creates a CPULoadCheck that uses getCPU to obtain per-core utilization values.
+func NewCPULoadCheck(getCPU func() []float64) *CPULoadCheck {
+	return &CPULoadCheck{getCPU: getCPU}
+}
+
+// Name returns the check identifier.
+func (c *CPULoadCheck) Name() string { return "cpu_load" }
+
+// Category returns the system category.
+func (c *CPULoadCheck) Category() health.Category { return health.CategorySystem }
+
+// Run executes the CPU load check.
+func (c *CPULoadCheck) Run(_ context.Context) health.Result {
+	start := time.Now()
+
+	percents := c.getCPU()
+	if len(percents) == 0 {
+		return health.Result{
+			Name:       c.Name(),
+			Category:   c.Category(),
+			Status:     health.StatusUnknown,
+			Message:    "No CPU data available",
+			DurationMS: float64(time.Since(start).Microseconds()) / 1000,
+			Timestamp:  time.Now(),
+		}
+	}
+
+	var sum float64
+	for _, p := range percents {
+		sum += p
+	}
+	avg := sum / float64(len(percents))
+
+	const warnPercent = 80.0
+	const critPercent = 95.0
+
+	status := health.StatusHealthy
+	msg := fmt.Sprintf("CPU load OK (avg %.1f%%)", avg)
+
+	switch {
+	case avg >= critPercent:
+		status = health.StatusCritical
+		msg = fmt.Sprintf("CPU overloaded: avg %.1f%%", avg)
+	case avg >= warnPercent:
+		status = health.StatusWarning
+		msg = fmt.Sprintf("CPU load high: avg %.1f%%", avg)
+	}
+
+	return health.Result{
+		Name:     c.Name(),
+		Category: c.Category(),
+		Status:   status,
+		Message:  msg,
+		Details: map[string]any{
+			"per_core_percent": percents,
+			"average_percent":  avg,
+		},
+		DurationMS: float64(time.Since(start).Microseconds()) / 1000,
+		Timestamp:  time.Now(),
+	}
+}
+
+// TemperatureCheck verifies that the system temperature is within safe bounds.
+type TemperatureCheck struct {
+	getTemp func() (float64, error)
+}
+
+// NewTemperatureCheck creates a TemperatureCheck that uses getTemp to obtain the current temperature in Celsius.
+func NewTemperatureCheck(getTemp func() (float64, error)) *TemperatureCheck {
+	return &TemperatureCheck{getTemp: getTemp}
+}
+
+// Name returns the check identifier.
+func (c *TemperatureCheck) Name() string { return "temperature" }
+
+// Category returns the system category.
+func (c *TemperatureCheck) Category() health.Category { return health.CategorySystem }
+
+// Run executes the temperature check.
+func (c *TemperatureCheck) Run(_ context.Context) health.Result {
+	start := time.Now()
+
+	tempC, err := c.getTemp()
+	if err != nil {
+		return health.Result{
+			Name:       c.Name(),
+			Category:   c.Category(),
+			Status:     health.StatusUnknown,
+			Message:    fmt.Sprintf("Temperature unavailable: %v", err),
+			DurationMS: float64(time.Since(start).Microseconds()) / 1000,
+			Timestamp:  time.Now(),
+		}
+	}
+
+	const warnTemp = 75.0
+	const critTemp = 85.0
+
+	status := health.StatusHealthy
+	msg := fmt.Sprintf("Temperature OK (%.1f C)", tempC)
+
+	switch {
+	case tempC >= critTemp:
+		status = health.StatusCritical
+		msg = fmt.Sprintf("Temperature critical: %.1f C", tempC)
+	case tempC >= warnTemp:
+		status = health.StatusWarning
+		msg = fmt.Sprintf("Temperature high: %.1f C", tempC)
+	}
+
+	return health.Result{
+		Name:     c.Name(),
+		Category: c.Category(),
+		Status:   status,
+		Message:  msg,
+		Details: map[string]any{
+			"temperature_c": tempC,
+		},
+		DurationMS: float64(time.Since(start).Microseconds()) / 1000,
+		Timestamp:  time.Now(),
+	}
+}
+
+// UptimeCheck reports concerns when the process has recently started, which may
+// indicate a crash-restart loop.
+type UptimeCheck struct {
+	startTime *time.Time
+}
+
+// NewUptimeCheck creates an UptimeCheck using the given process start time pointer.
+func NewUptimeCheck(startTime *time.Time) *UptimeCheck {
+	return &UptimeCheck{startTime: startTime}
+}
+
+// Name returns the check identifier.
+func (c *UptimeCheck) Name() string { return "uptime" }
+
+// Category returns the system category.
+func (c *UptimeCheck) Category() health.Category { return health.CategorySystem }
+
+// Run executes the uptime check.
+func (c *UptimeCheck) Run(_ context.Context) health.Result {
+	start := time.Now()
+
+	if c.startTime == nil {
+		return health.Result{
+			Name:       c.Name(),
+			Category:   c.Category(),
+			Status:     health.StatusUnknown,
+			Message:    "Start time not available",
+			DurationMS: float64(time.Since(start).Microseconds()) / 1000,
+			Timestamp:  time.Now(),
+		}
+	}
+
+	uptime := time.Since(*c.startTime)
+
+	const critThreshold = 5 * time.Minute
+	const warnThreshold = time.Hour
+
+	status := health.StatusHealthy
+	msg := fmt.Sprintf("Uptime OK (%.0f seconds)", uptime.Seconds())
+
+	switch {
+	case uptime < critThreshold:
+		status = health.StatusCritical
+		msg = fmt.Sprintf("Process started very recently (%.0f seconds ago), possible crash loop", uptime.Seconds())
+	case uptime < warnThreshold:
+		status = health.StatusWarning
+		msg = fmt.Sprintf("Process started recently (%.0f seconds ago)", uptime.Seconds())
+	}
+
+	return health.Result{
+		Name:     c.Name(),
+		Category: c.Category(),
+		Status:   status,
+		Message:  msg,
+		Details: map[string]any{
+			"uptime_seconds": uptime.Seconds(),
+			"started_at":     c.startTime.Format(time.RFC3339),
+		},
+		DurationMS: float64(time.Since(start).Microseconds()) / 1000,
+		Timestamp:  time.Now(),
+	}
+}

--- a/internal/health/error_buffer.go
+++ b/internal/health/error_buffer.go
@@ -1,0 +1,103 @@
+// internal/health/error_buffer.go
+package health
+
+import (
+	"sync"
+	"time"
+)
+
+// LogEntry represents a captured log entry from the application logger.
+type LogEntry struct {
+	Level     string         `json:"level"`
+	Message   string         `json:"message"`
+	Component string         `json:"component,omitempty"`
+	Timestamp time.Time      `json:"timestamp"`
+	Fields    map[string]any `json:"fields,omitempty"`
+}
+
+// ErrorRingBuffer is a thread-safe fixed-size ring buffer for log entries.
+type ErrorRingBuffer struct {
+	mu      sync.RWMutex
+	entries []LogEntry
+	head    int
+	count   int
+	maxSize int
+}
+
+// NewErrorRingBuffer creates a buffer that keeps the most recent maxSize entries.
+func NewErrorRingBuffer(maxSize int) *ErrorRingBuffer {
+	return &ErrorRingBuffer{
+		entries: make([]LogEntry, maxSize),
+		maxSize: maxSize,
+	}
+}
+
+// Add inserts a log entry into the buffer. Oldest entries are overwritten.
+func (b *ErrorRingBuffer) Add(entry *LogEntry) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.entries[b.head] = *entry
+	b.head = (b.head + 1) % b.maxSize
+	if b.count < b.maxSize {
+		b.count++
+	}
+}
+
+// Entries returns all entries in chronological order (oldest first).
+func (b *ErrorRingBuffer) Entries() []LogEntry {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	result := make([]LogEntry, 0, b.count)
+	if b.count < b.maxSize {
+		result = append(result, b.entries[:b.count]...)
+	} else {
+		result = append(result, b.entries[b.head:]...)
+		result = append(result, b.entries[:b.head]...)
+	}
+	return result
+}
+
+// Recent returns the most recent n entries in reverse chronological order (newest first).
+func (b *ErrorRingBuffer) Recent(n int) []LogEntry {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	if n > b.count {
+		n = b.count
+	}
+	result := make([]LogEntry, n)
+	for i := range n {
+		idx := (b.head - 1 - i + b.maxSize) % b.maxSize
+		result[i] = b.entries[idx]
+	}
+	return result
+}
+
+// Count returns the number of entries currently in the buffer.
+func (b *ErrorRingBuffer) Count() int {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return b.count
+}
+
+// CountSince returns the number of entries at or after the given time.
+func (b *ErrorRingBuffer) CountSince(since time.Time) int {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	count := 0
+	for i := range b.count {
+		idx := (b.head - 1 - i + b.maxSize) % b.maxSize
+		if b.entries[idx].Timestamp.Before(since) {
+			break
+		}
+		count++
+	}
+	return count
+}
+
+// Clear removes all entries from the buffer.
+func (b *ErrorRingBuffer) Clear() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.head = 0
+	b.count = 0
+}

--- a/internal/health/error_buffer.go
+++ b/internal/health/error_buffer.go
@@ -2,6 +2,7 @@
 package health
 
 import (
+	"maps"
 	"sync"
 	"time"
 )
@@ -25,7 +26,11 @@ type ErrorRingBuffer struct {
 }
 
 // NewErrorRingBuffer creates a buffer that keeps the most recent maxSize entries.
+// If maxSize is less than or equal to zero, it is set to 1.
 func NewErrorRingBuffer(maxSize int) *ErrorRingBuffer {
+	if maxSize <= 0 {
+		maxSize = 1
+	}
 	return &ErrorRingBuffer{
 		entries: make([]LogEntry, maxSize),
 		maxSize: maxSize,
@@ -33,41 +38,67 @@ func NewErrorRingBuffer(maxSize int) *ErrorRingBuffer {
 }
 
 // Add inserts a log entry into the buffer. Oldest entries are overwritten.
+// The Fields map is deep-copied to prevent mutation of the caller's map.
 func (b *ErrorRingBuffer) Add(entry *LogEntry) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	b.entries[b.head] = *entry
+	e := *entry
+	if e.Fields != nil {
+		e.Fields = maps.Clone(e.Fields)
+	}
+	b.entries[b.head] = e
 	b.head = (b.head + 1) % b.maxSize
 	if b.count < b.maxSize {
 		b.count++
 	}
 }
 
+// cloneEntry returns a copy of e with a deep-copied Fields map.
+func cloneEntry(e *LogEntry) LogEntry {
+	out := *e
+	if e.Fields != nil {
+		out.Fields = maps.Clone(e.Fields)
+	}
+	return out
+}
+
 // Entries returns all entries in chronological order (oldest first).
+// Each returned entry has its own copy of the Fields map.
 func (b *ErrorRingBuffer) Entries() []LogEntry {
 	b.mu.RLock()
 	defer b.mu.RUnlock()
 	result := make([]LogEntry, 0, b.count)
 	if b.count < b.maxSize {
-		result = append(result, b.entries[:b.count]...)
+		for i := range b.count {
+			result = append(result, cloneEntry(&b.entries[i]))
+		}
 	} else {
-		result = append(result, b.entries[b.head:]...)
-		result = append(result, b.entries[:b.head]...)
+		for i := range b.entries[b.head:] {
+			result = append(result, cloneEntry(&b.entries[b.head+i]))
+		}
+		for i := range b.head {
+			result = append(result, cloneEntry(&b.entries[i]))
+		}
 	}
 	return result
 }
 
 // Recent returns the most recent n entries in reverse chronological order (newest first).
+// Each returned entry has its own copy of the Fields map.
+// If n is less than or equal to zero, an empty slice is returned.
 func (b *ErrorRingBuffer) Recent(n int) []LogEntry {
 	b.mu.RLock()
 	defer b.mu.RUnlock()
+	if n <= 0 {
+		return []LogEntry{}
+	}
 	if n > b.count {
 		n = b.count
 	}
 	result := make([]LogEntry, n)
 	for i := range n {
 		idx := (b.head - 1 - i + b.maxSize) % b.maxSize
-		result[i] = b.entries[idx]
+		result[i] = cloneEntry(&b.entries[idx])
 	}
 	return result
 }
@@ -94,10 +125,13 @@ func (b *ErrorRingBuffer) CountSince(since time.Time) int {
 	return count
 }
 
-// Clear removes all entries from the buffer.
+// Clear removes all entries from the buffer, zeroing the backing slice to release references.
 func (b *ErrorRingBuffer) Clear() {
 	b.mu.Lock()
 	defer b.mu.Unlock()
+	for i := range b.entries {
+		b.entries[i] = LogEntry{}
+	}
 	b.head = 0
 	b.count = 0
 }

--- a/internal/health/error_buffer_test.go
+++ b/internal/health/error_buffer_test.go
@@ -1,0 +1,184 @@
+// internal/health/error_buffer_test.go
+package health
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func makeEntry(msg string, ts time.Time) *LogEntry {
+	return &LogEntry{
+		Level:     "error",
+		Message:   msg,
+		Timestamp: ts,
+	}
+}
+
+func TestErrorRingBuffer_AddAndCount(t *testing.T) {
+	t.Parallel()
+	buf := NewErrorRingBuffer(5)
+	assert.Equal(t, 0, buf.Count())
+
+	buf.Add(makeEntry("first", time.Now()))
+	assert.Equal(t, 1, buf.Count())
+
+	buf.Add(makeEntry("second", time.Now()))
+	assert.Equal(t, 2, buf.Count())
+}
+
+func TestErrorRingBuffer_EntriesChronological(t *testing.T) {
+	t.Parallel()
+	buf := NewErrorRingBuffer(5)
+	base := time.Now()
+
+	for i := range 3 {
+		buf.Add(makeEntry(fmt.Sprintf("msg-%d", i), base.Add(time.Duration(i)*time.Second)))
+	}
+
+	entries := buf.Entries()
+	require.Len(t, entries, 3)
+	assert.Equal(t, "msg-0", entries[0].Message)
+	assert.Equal(t, "msg-1", entries[1].Message)
+	assert.Equal(t, "msg-2", entries[2].Message)
+}
+
+func TestErrorRingBuffer_RecentReverseChronological(t *testing.T) {
+	t.Parallel()
+	buf := NewErrorRingBuffer(5)
+	base := time.Now()
+
+	for i := range 5 {
+		buf.Add(makeEntry(fmt.Sprintf("msg-%d", i), base.Add(time.Duration(i)*time.Second)))
+	}
+
+	recent := buf.Recent(3)
+	require.Len(t, recent, 3)
+	// Newest first.
+	assert.Equal(t, "msg-4", recent[0].Message)
+	assert.Equal(t, "msg-3", recent[1].Message)
+	assert.Equal(t, "msg-2", recent[2].Message)
+}
+
+func TestErrorRingBuffer_RecentNLargerThanCount(t *testing.T) {
+	t.Parallel()
+	buf := NewErrorRingBuffer(10)
+	buf.Add(makeEntry("only", time.Now()))
+
+	recent := buf.Recent(100)
+	require.Len(t, recent, 1)
+	assert.Equal(t, "only", recent[0].Message)
+}
+
+func TestErrorRingBuffer_RecentZero(t *testing.T) {
+	t.Parallel()
+	buf := NewErrorRingBuffer(5)
+	buf.Add(makeEntry("msg", time.Now()))
+
+	recent := buf.Recent(0)
+	assert.Empty(t, recent)
+}
+
+func TestErrorRingBuffer_Overflow(t *testing.T) {
+	t.Parallel()
+	const maxSize = 3
+	buf := NewErrorRingBuffer(maxSize)
+	base := time.Now()
+
+	// Add more entries than the buffer can hold.
+	for i := range maxSize + 2 {
+		buf.Add(makeEntry(fmt.Sprintf("msg-%d", i), base.Add(time.Duration(i)*time.Second)))
+	}
+
+	// Count must be capped at maxSize.
+	assert.Equal(t, maxSize, buf.Count())
+
+	// Entries should contain the most recent maxSize messages in chronological order.
+	entries := buf.Entries()
+	require.Len(t, entries, maxSize)
+	assert.Equal(t, "msg-2", entries[0].Message)
+	assert.Equal(t, "msg-3", entries[1].Message)
+	assert.Equal(t, "msg-4", entries[2].Message)
+}
+
+func TestErrorRingBuffer_CountSince(t *testing.T) {
+	t.Parallel()
+	buf := NewErrorRingBuffer(10)
+	base := time.Now()
+
+	for i := range 5 {
+		buf.Add(makeEntry(fmt.Sprintf("msg-%d", i), base.Add(time.Duration(i)*time.Second)))
+	}
+
+	// Count entries at or after base+2s: messages 2, 3, 4.
+	cutoff := base.Add(2 * time.Second)
+	assert.Equal(t, 3, buf.CountSince(cutoff))
+
+	// Count entries at or after base+4s: message 4 only.
+	assert.Equal(t, 1, buf.CountSince(base.Add(4*time.Second)))
+
+	// Future cutoff: none.
+	assert.Equal(t, 0, buf.CountSince(base.Add(10*time.Second)))
+
+	// Past cutoff: all entries.
+	assert.Equal(t, 5, buf.CountSince(base.Add(-time.Second)))
+}
+
+func TestErrorRingBuffer_Clear(t *testing.T) {
+	t.Parallel()
+	buf := NewErrorRingBuffer(5)
+	for i := range 3 {
+		buf.Add(makeEntry(fmt.Sprintf("msg-%d", i), time.Now()))
+	}
+	require.Equal(t, 3, buf.Count())
+
+	buf.Clear()
+
+	assert.Equal(t, 0, buf.Count())
+	assert.Empty(t, buf.Entries())
+	assert.Empty(t, buf.Recent(5))
+}
+
+func TestErrorRingBuffer_ClearThenRefill(t *testing.T) {
+	t.Parallel()
+	buf := NewErrorRingBuffer(5)
+	buf.Add(makeEntry("before-clear", time.Now()))
+	buf.Clear()
+
+	buf.Add(makeEntry("after-clear", time.Now()))
+	assert.Equal(t, 1, buf.Count())
+	entries := buf.Entries()
+	require.Len(t, entries, 1)
+	assert.Equal(t, "after-clear", entries[0].Message)
+}
+
+func TestErrorRingBuffer_ConcurrentAdd(t *testing.T) {
+	t.Parallel()
+	const workers = 10
+	const perWorker = 100
+	const maxSize = 200
+
+	buf := NewErrorRingBuffer(maxSize)
+	var wg sync.WaitGroup
+
+	for w := range workers {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for i := range perWorker {
+				buf.Add(makeEntry(fmt.Sprintf("w%d-msg%d", id, i), time.Now()))
+			}
+		}(w)
+	}
+
+	wg.Wait()
+
+	// Count should be capped at maxSize; no panic or data race.
+	count := buf.Count()
+	assert.LessOrEqual(t, count, maxSize)
+	assert.Positive(t, count)
+}

--- a/internal/health/registry.go
+++ b/internal/health/registry.go
@@ -21,18 +21,25 @@ func NewRegistry() *Registry {
 	return &Registry{}
 }
 
-// Register adds a check to the registry.
+// Register adds a check to the registry. Nil checks are silently ignored.
 func (r *Registry) Register(c Check) {
+	if c == nil {
+		return
+	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.checks = append(r.checks, c)
 }
 
-// RegisterAll adds multiple checks at once.
+// RegisterAll adds multiple checks at once. Nil checks are silently ignored.
 func (r *Registry) RegisterAll(checks ...Check) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	r.checks = append(r.checks, checks...)
+	for _, c := range checks {
+		if c != nil {
+			r.checks = append(r.checks, c)
+		}
+	}
 }
 
 // RunAll executes all checks in parallel with per-check timeout.

--- a/internal/health/registry.go
+++ b/internal/health/registry.go
@@ -1,0 +1,123 @@
+// internal/health/registry.go
+package health
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// DefaultTimeout is the per-check timeout.
+const DefaultTimeout = 10 * time.Second
+
+// Registry stores health checks and runs them.
+type Registry struct {
+	mu     sync.RWMutex
+	checks []Check
+}
+
+// NewRegistry creates an empty registry.
+func NewRegistry() *Registry {
+	return &Registry{}
+}
+
+// Register adds a check to the registry.
+func (r *Registry) Register(c Check) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.checks = append(r.checks, c)
+}
+
+// RegisterAll adds multiple checks at once.
+func (r *Registry) RegisterAll(checks ...Check) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.checks = append(r.checks, checks...)
+}
+
+// RunAll executes all checks in parallel with per-check timeout.
+func (r *Registry) RunAll(ctx context.Context) []Result {
+	r.mu.RLock()
+	checks := make([]Check, len(r.checks))
+	copy(checks, r.checks)
+	r.mu.RUnlock()
+
+	results := make([]Result, len(checks))
+	var wg sync.WaitGroup
+
+	for i, c := range checks {
+		wg.Add(1)
+		go func(idx int, check Check) {
+			defer wg.Done()
+			checkCtx, cancel := context.WithTimeout(ctx, DefaultTimeout)
+			defer cancel()
+			start := time.Now()
+			result := check.Run(checkCtx)
+			result.DurationMS = float64(time.Since(start).Microseconds()) / 1000.0
+			if result.Timestamp.IsZero() {
+				result.Timestamp = time.Now()
+			}
+			results[idx] = result
+		}(i, c)
+	}
+
+	wg.Wait()
+	return results
+}
+
+// RunCategory executes only checks matching the given category.
+func (r *Registry) RunCategory(ctx context.Context, cat Category) []Result {
+	r.mu.RLock()
+	var filtered []Check
+	for _, c := range r.checks {
+		if c.Category() == cat {
+			filtered = append(filtered, c)
+		}
+	}
+	r.mu.RUnlock()
+
+	results := make([]Result, len(filtered))
+	var wg sync.WaitGroup
+
+	for i, c := range filtered {
+		wg.Add(1)
+		go func(idx int, check Check) {
+			defer wg.Done()
+			checkCtx, cancel := context.WithTimeout(ctx, DefaultTimeout)
+			defer cancel()
+			start := time.Now()
+			result := check.Run(checkCtx)
+			result.DurationMS = float64(time.Since(start).Microseconds()) / 1000.0
+			if result.Timestamp.IsZero() {
+				result.Timestamp = time.Now()
+			}
+			results[idx] = result
+		}(i, c)
+	}
+
+	wg.Wait()
+	return results
+}
+
+// Count returns the number of registered checks.
+func (r *Registry) Count() int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return len(r.checks)
+}
+
+// Categories returns the distinct categories of registered checks.
+func (r *Registry) Categories() []Category {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	seen := make(map[Category]bool)
+	var cats []Category
+	for _, c := range r.checks {
+		if !seen[c.Category()] {
+			seen[c.Category()] = true
+			cats = append(cats, c.Category())
+		}
+	}
+	return cats
+}

--- a/internal/health/registry.go
+++ b/internal/health/registry.go
@@ -42,27 +42,7 @@ func (r *Registry) RunAll(ctx context.Context) []Result {
 	copy(checks, r.checks)
 	r.mu.RUnlock()
 
-	results := make([]Result, len(checks))
-	var wg sync.WaitGroup
-
-	for i, c := range checks {
-		wg.Add(1)
-		go func(idx int, check Check) {
-			defer wg.Done()
-			checkCtx, cancel := context.WithTimeout(ctx, DefaultTimeout)
-			defer cancel()
-			start := time.Now()
-			result := check.Run(checkCtx)
-			result.DurationMS = float64(time.Since(start).Microseconds()) / 1000.0
-			if result.Timestamp.IsZero() {
-				result.Timestamp = time.Now()
-			}
-			results[idx] = result
-		}(i, c)
-	}
-
-	wg.Wait()
-	return results
+	return runChecks(ctx, checks)
 }
 
 // RunCategory executes only checks matching the given category.
@@ -76,10 +56,15 @@ func (r *Registry) RunCategory(ctx context.Context, cat Category) []Result {
 	}
 	r.mu.RUnlock()
 
-	results := make([]Result, len(filtered))
+	return runChecks(ctx, filtered)
+}
+
+// runChecks executes the given checks in parallel with per-check timeout.
+func runChecks(ctx context.Context, checks []Check) []Result {
+	results := make([]Result, len(checks))
 	var wg sync.WaitGroup
 
-	for i, c := range filtered {
+	for i, c := range checks {
 		wg.Add(1)
 		go func(idx int, check Check) {
 			defer wg.Done()

--- a/internal/health/registry_test.go
+++ b/internal/health/registry_test.go
@@ -1,0 +1,192 @@
+// internal/health/registry_test.go
+package health
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockCheck implements Check for testing.
+type mockCheck struct {
+	name     string
+	category Category
+	result   Result
+	delay    time.Duration
+}
+
+func (m *mockCheck) Name() string       { return m.name }
+func (m *mockCheck) Category() Category { return m.category }
+func (m *mockCheck) Run(ctx context.Context) Result {
+	if m.delay > 0 {
+		select {
+		case <-time.After(m.delay):
+		case <-ctx.Done():
+			return Result{
+				Name:     m.name,
+				Category: m.category,
+				Status:   StatusUnknown,
+				Message:  "timed out",
+			}
+		}
+	}
+	return m.result
+}
+
+func TestRegistry_RegisterAndCount(t *testing.T) {
+	t.Parallel()
+	r := NewRegistry()
+	assert.Equal(t, 0, r.Count())
+
+	r.Register(&mockCheck{name: "check-a", category: CategorySystem})
+	assert.Equal(t, 1, r.Count())
+
+	r.Register(&mockCheck{name: "check-b", category: CategoryAudio})
+	assert.Equal(t, 2, r.Count())
+}
+
+func TestRegistry_RegisterAll(t *testing.T) {
+	t.Parallel()
+	r := NewRegistry()
+	r.RegisterAll(
+		&mockCheck{name: "check-a", category: CategorySystem},
+		&mockCheck{name: "check-b", category: CategoryAudio},
+		&mockCheck{name: "check-c", category: CategoryDatabase},
+	)
+	assert.Equal(t, 3, r.Count())
+}
+
+func TestRegistry_RunAll(t *testing.T) {
+	t.Parallel()
+	r := NewRegistry()
+	r.RegisterAll(
+		&mockCheck{
+			name:     "sys",
+			category: CategorySystem,
+			result:   Result{Name: "sys", Category: CategorySystem, Status: StatusHealthy},
+		},
+		&mockCheck{
+			name:     "audio",
+			category: CategoryAudio,
+			result:   Result{Name: "audio", Category: CategoryAudio, Status: StatusWarning},
+		},
+	)
+
+	ctx := t.Context()
+	results := r.RunAll(ctx)
+
+	require.Len(t, results, 2)
+
+	// Build a map for order-independent assertion (results run in parallel).
+	byName := make(map[string]Result, len(results))
+	for _, res := range results {
+		byName[res.Name] = res
+	}
+
+	assert.Equal(t, StatusHealthy, byName["sys"].Status)
+	assert.Equal(t, StatusWarning, byName["audio"].Status)
+	// DurationMS should be set by RunAll.
+	assert.GreaterOrEqual(t, byName["sys"].DurationMS, 0.0)
+	// Timestamp should be populated.
+	assert.False(t, byName["sys"].Timestamp.IsZero())
+}
+
+func TestRegistry_RunAll_Empty(t *testing.T) {
+	t.Parallel()
+	r := NewRegistry()
+	results := r.RunAll(t.Context())
+	assert.Empty(t, results)
+}
+
+func TestRegistry_RunCategory(t *testing.T) {
+	t.Parallel()
+	r := NewRegistry()
+	r.RegisterAll(
+		&mockCheck{
+			name:     "sys",
+			category: CategorySystem,
+			result:   Result{Name: "sys", Category: CategorySystem, Status: StatusHealthy},
+		},
+		&mockCheck{
+			name:     "audio",
+			category: CategoryAudio,
+			result:   Result{Name: "audio", Category: CategoryAudio, Status: StatusWarning},
+		},
+		&mockCheck{
+			name:     "sys2",
+			category: CategorySystem,
+			result:   Result{Name: "sys2", Category: CategorySystem, Status: StatusCritical},
+		},
+	)
+
+	ctx := t.Context()
+	results := r.RunCategory(ctx, CategorySystem)
+
+	require.Len(t, results, 2)
+	for _, res := range results {
+		assert.Equal(t, CategorySystem, res.Category)
+	}
+}
+
+func TestRegistry_RunCategory_NoMatch(t *testing.T) {
+	t.Parallel()
+	r := NewRegistry()
+	r.Register(&mockCheck{name: "sys", category: CategorySystem, result: Result{Status: StatusHealthy}})
+
+	results := r.RunCategory(t.Context(), CategoryNetwork)
+	assert.Empty(t, results)
+}
+
+func TestRegistry_Timeout(t *testing.T) {
+	t.Parallel()
+	r := NewRegistry()
+	// A check that takes longer than the context deadline.
+	r.Register(&mockCheck{
+		name:     "slow",
+		category: CategorySystem,
+		delay:    5 * time.Second,
+		result:   Result{Name: "slow", Category: CategorySystem, Status: StatusHealthy},
+	})
+
+	// Cancel the context immediately so the check observes cancellation.
+	ctx, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)
+	defer cancel()
+
+	results := r.RunAll(ctx)
+	require.Len(t, results, 1)
+	// The check should have returned StatusUnknown on context cancellation.
+	assert.Equal(t, StatusUnknown, results[0].Status)
+	assert.Equal(t, "timed out", results[0].Message)
+}
+
+func TestRegistry_Categories(t *testing.T) {
+	t.Parallel()
+	r := NewRegistry()
+	r.RegisterAll(
+		&mockCheck{name: "a", category: CategorySystem},
+		&mockCheck{name: "b", category: CategoryAudio},
+		&mockCheck{name: "c", category: CategorySystem}, // duplicate category
+		&mockCheck{name: "d", category: CategoryDatabase},
+	)
+
+	cats := r.Categories()
+	// Expect exactly 3 distinct categories.
+	require.Len(t, cats, 3)
+
+	catSet := make(map[Category]bool, len(cats))
+	for _, c := range cats {
+		catSet[c] = true
+	}
+	assert.True(t, catSet[CategorySystem])
+	assert.True(t, catSet[CategoryAudio])
+	assert.True(t, catSet[CategoryDatabase])
+}
+
+func TestRegistry_Categories_Empty(t *testing.T) {
+	t.Parallel()
+	r := NewRegistry()
+	assert.Empty(t, r.Categories())
+}

--- a/internal/health/report.go
+++ b/internal/health/report.go
@@ -1,0 +1,104 @@
+// internal/health/report.go
+package health
+
+import (
+	"sync"
+	"time"
+)
+
+// DiagnosticsReport is the full output of a diagnostic run.
+type DiagnosticsReport struct {
+	ID            string              `json:"id"`
+	Status        Status              `json:"status"`
+	StartedAt     time.Time           `json:"started_at"`
+	CompletedAt   time.Time           `json:"completed_at"`
+	DurationMS    float64             `json:"duration_ms"`
+	TotalChecks   int                 `json:"total_checks"`
+	Results       []Result            `json:"results"`
+	Summary       map[Category]Status `json:"summary"`
+	CountByStatus map[Status]int      `json:"count_by_status"`
+}
+
+// NewReport creates a DiagnosticsReport from a slice of results.
+func NewReport(id string, startedAt time.Time, results []Result) *DiagnosticsReport {
+	completedAt := time.Now()
+	summary := make(map[Category]Status)
+	countByStatus := make(map[Status]int)
+
+	catResults := make(map[Category][]Result)
+	for _, r := range results {
+		catResults[r.Category] = append(catResults[r.Category], r)
+		countByStatus[r.Status]++
+	}
+	for cat, rs := range catResults {
+		summary[cat] = WorstStatus(rs)
+	}
+
+	return &DiagnosticsReport{
+		ID:            id,
+		Status:        WorstStatus(results),
+		StartedAt:     startedAt,
+		CompletedAt:   completedAt,
+		DurationMS:    float64(completedAt.Sub(startedAt).Microseconds()) / 1000.0,
+		TotalChecks:   len(results),
+		Results:       results,
+		Summary:       summary,
+		CountByStatus: countByStatus,
+	}
+}
+
+// ReportStore keeps recent reports in memory.
+type ReportStore struct {
+	mu      sync.RWMutex
+	reports map[string]*DiagnosticsReport
+	maxSize int
+}
+
+// NewReportStore creates a store that keeps up to maxSize reports.
+func NewReportStore(maxSize int) *ReportStore {
+	return &ReportStore{
+		reports: make(map[string]*DiagnosticsReport),
+		maxSize: maxSize,
+	}
+}
+
+// Save stores a report. If the store is full, the oldest report is evicted.
+func (s *ReportStore) Save(report *DiagnosticsReport) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.reports) >= s.maxSize {
+		var oldestID string
+		var oldestTime time.Time
+		for id, r := range s.reports {
+			if oldestID == "" || r.StartedAt.Before(oldestTime) {
+				oldestID = id
+				oldestTime = r.StartedAt
+			}
+		}
+		if oldestID != "" {
+			delete(s.reports, oldestID)
+		}
+	}
+	s.reports[report.ID] = report
+}
+
+// Get retrieves a report by ID.
+func (s *ReportStore) Get(id string) (*DiagnosticsReport, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	r, ok := s.reports[id]
+	return r, ok
+}
+
+// Latest returns the most recent report, or nil if empty.
+func (s *ReportStore) Latest() *DiagnosticsReport {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	var latest *DiagnosticsReport
+	for _, r := range s.reports {
+		if latest == nil || r.StartedAt.After(latest.StartedAt) {
+			latest = r
+		}
+	}
+	return latest
+}

--- a/internal/health/report.go
+++ b/internal/health/report.go
@@ -63,7 +63,11 @@ func NewReportStore(maxSize int) *ReportStore {
 }
 
 // Save stores a report. If the store is full, the oldest report is evicted.
+// Nil reports are silently ignored.
 func (s *ReportStore) Save(report *DiagnosticsReport) {
+	if report == nil {
+		return
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if len(s.reports) >= s.maxSize {

--- a/internal/health/report_test.go
+++ b/internal/health/report_test.go
@@ -1,0 +1,163 @@
+// internal/health/report_test.go
+package health
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewReport_BasicFields(t *testing.T) {
+	t.Parallel()
+	startedAt := time.Now().Add(-50 * time.Millisecond)
+	results := []Result{
+		{Name: "check-a", Category: CategorySystem, Status: StatusHealthy},
+		{Name: "check-b", Category: CategoryAudio, Status: StatusWarning},
+		{Name: "check-c", Category: CategorySystem, Status: StatusCritical},
+	}
+
+	report := NewReport("report-1", startedAt, results)
+
+	assert.Equal(t, "report-1", report.ID)
+	assert.Equal(t, 3, report.TotalChecks)
+	assert.Equal(t, results, report.Results)
+	assert.Equal(t, startedAt, report.StartedAt)
+	assert.False(t, report.CompletedAt.IsZero())
+	assert.GreaterOrEqual(t, report.DurationMS, 0.0)
+}
+
+func TestNewReport_OverallStatus(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		statuses []Status
+		want     Status
+	}{
+		{"all healthy", []Status{StatusHealthy, StatusHealthy}, StatusHealthy},
+		{"warning present", []Status{StatusHealthy, StatusWarning}, StatusWarning},
+		{"critical wins", []Status{StatusWarning, StatusCritical}, StatusCritical},
+		{"empty results", []Status{}, StatusHealthy},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			results := make([]Result, len(tt.statuses))
+			for i, s := range tt.statuses {
+				results[i] = Result{Name: "c", Category: CategorySystem, Status: s}
+			}
+			report := NewReport("id", time.Now(), results)
+			assert.Equal(t, tt.want, report.Status)
+		})
+	}
+}
+
+func TestNewReport_SummaryPerCategory(t *testing.T) {
+	t.Parallel()
+	results := []Result{
+		{Name: "s1", Category: CategorySystem, Status: StatusHealthy},
+		{Name: "s2", Category: CategorySystem, Status: StatusWarning},
+		{Name: "a1", Category: CategoryAudio, Status: StatusCritical},
+		{Name: "a2", Category: CategoryAudio, Status: StatusHealthy},
+		{Name: "d1", Category: CategoryDatabase, Status: StatusHealthy},
+	}
+
+	report := NewReport("id", time.Now(), results)
+
+	// System: worst of healthy + warning = warning
+	assert.Equal(t, StatusWarning, report.Summary[CategorySystem])
+	// Audio: worst of critical + healthy = critical
+	assert.Equal(t, StatusCritical, report.Summary[CategoryAudio])
+	// Database: only healthy
+	assert.Equal(t, StatusHealthy, report.Summary[CategoryDatabase])
+}
+
+func TestNewReport_CountByStatus(t *testing.T) {
+	t.Parallel()
+	results := []Result{
+		{Status: StatusHealthy},
+		{Status: StatusHealthy},
+		{Status: StatusWarning},
+		{Status: StatusCritical},
+	}
+
+	report := NewReport("id", time.Now(), results)
+
+	assert.Equal(t, 2, report.CountByStatus[StatusHealthy])
+	assert.Equal(t, 1, report.CountByStatus[StatusWarning])
+	assert.Equal(t, 1, report.CountByStatus[StatusCritical])
+	assert.Equal(t, 0, report.CountByStatus[StatusUnknown])
+}
+
+func TestReportStore_SaveAndGet(t *testing.T) {
+	t.Parallel()
+	store := NewReportStore(10)
+
+	report := NewReport("abc", time.Now(), nil)
+	store.Save(report)
+
+	got, ok := store.Get("abc")
+	require.True(t, ok)
+	assert.Equal(t, "abc", got.ID)
+}
+
+func TestReportStore_GetMissing(t *testing.T) {
+	t.Parallel()
+	store := NewReportStore(10)
+
+	got, ok := store.Get("missing")
+	assert.False(t, ok)
+	assert.Nil(t, got)
+}
+
+func TestReportStore_Latest(t *testing.T) {
+	t.Parallel()
+	store := NewReportStore(10)
+
+	base := time.Now()
+	older := NewReport("older", base, nil)
+	newer := NewReport("newer", base.Add(time.Second), nil)
+
+	store.Save(older)
+	store.Save(newer)
+
+	latest := store.Latest()
+	require.NotNil(t, latest)
+	assert.Equal(t, "newer", latest.ID)
+}
+
+func TestReportStore_Latest_Empty(t *testing.T) {
+	t.Parallel()
+	store := NewReportStore(10)
+	assert.Nil(t, store.Latest())
+}
+
+func TestReportStore_Eviction(t *testing.T) {
+	t.Parallel()
+	const maxSize = 3
+	store := NewReportStore(maxSize)
+
+	base := time.Now()
+	// Fill the store.
+	for i := range maxSize {
+		id := string(rune('a' + i))
+		r := NewReport(id, base.Add(time.Duration(i)*time.Second), nil)
+		store.Save(r)
+	}
+
+	// Verify all 3 are present.
+	_, ok := store.Get("a")
+	require.True(t, ok)
+
+	// Add a 4th report; the oldest ("a") should be evicted.
+	newest := NewReport("d", base.Add(time.Duration(maxSize)*time.Second), nil)
+	store.Save(newest)
+
+	_, ok = store.Get("a")
+	assert.False(t, ok, "oldest report should have been evicted")
+
+	_, ok = store.Get("d")
+	assert.True(t, ok, "new report should be present")
+}


### PR DESCRIPTION
## Summary

Adds a user-facing diagnostic and health monitoring system backend. A Check Registry holds 31 checks across 8 categories (system, audio, analysis, streams, database, network, config, logs). The `POST /api/v2/system/diagnostics/run` endpoint executes all checks in parallel and returns a `DiagnosticsReport`. Reports are cached in memory (keyed by UUID) for retrieval. An `ErrorRingBuffer` provides infrastructure for capturing recent warn+ log entries.

### Core health package (`internal/health/`)

- `check.go`: Status, Category, Result types, Check interface, WorstStatus severity logic
- `registry.go`: Registry with parallel execution, per-check 10s timeout, shared runChecks helper
- `report.go`: DiagnosticsReport, NewReport factory, ReportStore with LRU eviction (max 10)
- `error_buffer.go`: Thread-safe ring buffer for LogEntry (max 500 entries)
- `checks/helpers.go`: Shared skippedResult helper for unwired checks

### 31 health checks in `internal/health/checks/`

| Category | File | Checks | Wired |
|----------|------|--------|-------|
| System | system.go | disk_space, memory, cpu_load, temperature, uptime | 4 of 5 |
| Audio | audio.go | source_status, pipeline_liveness + 4 stubs | 2 of 6 |
| Analysis | analysis.go | model_loaded, inference_latency, detection_rate, queue_depth | 1 of 4 |
| Streams | streams.go | stream_connectivity, stream_error_rate, ffmpeg_health | 0 of 3 |
| Database | database.go | database_size, migration_status, database_performance | 1 of 3 |
| Network | network.go | mqtt, birdweather, notification_providers, weather | 2 partial |
| Config | config.go | path_access, config_consistency, disk_budget | 1 of 3 |
| Logs | logs.go | recent_errors, error_trend, critical_events | 0 of 3 |

Unwired checks return `StatusSkipped` rather than misleading healthy/error results.

### API endpoints (`internal/api/v2/diagnostics.go`)

| Method | Route | Description |
|--------|-------|-------------|
| GET | `/system/diagnostics/status` | Quick health summary from latest report |
| POST | `/system/diagnostics/run` | Run all 31 checks in parallel |
| GET | `/system/diagnostics/report/:id` | Retrieve stored report by UUID |
| GET | `/system/diagnostics/errors` | Recent error log entries (limit param) |

All endpoints are auth-protected via `c.authMiddleware`.

### Architecture

All checks receive dependencies via function closures (dependency injection, no circular imports). The registry stamps DurationMS after each check completes for accurate timing. A gate review caught and fixed a severity downgrade bug in DiskSpaceCheck, no-op MarshalJSON allocations, and TODO stubs that would cause permanent Critical/Unknown status.

## Test Plan

- [x] 43 unit tests pass with `-race` (`go test -race -v ./internal/health/...`)
- [x] `golangci-lint run -v` reports zero issues
- [x] Full project `go build ./...` succeeds
- [x] Pre-push gate review completed (4 Claude agents + Gemini cross-validation)
- [ ] Frontend page (SystemHealth.svelte) planned as separate follow-up PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added system diagnostics API: status, run, report-by-ID, and recent-errors endpoints with in-memory cached reports (limited).
  * Implemented a comprehensive health-check framework with checks for system, audio, analysis, streams, database, logs, network, and configuration.

* **Documentation**
  * Added a Diagnostics section documenting endpoints, response semantics, and caching behavior.

* **Tests**
  * Added unit tests for health logic, registry, report store, and the error ring buffer.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3132?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->