### PR TITLE
feat(frontend): System Health diagnostics page

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -36,6 +36,7 @@
   let About = $state<Component | null>(null);
   let Help = $state<Component | null>(null);
   let ReportBug = $state<Component | null>(null);
+  let SystemHealth = $state<Component | null>(null);
   let System = $state<Component | null>(null);
   let Settings = $state<Component | null>(null);
   let Notifications = $state<Component | null>(null);
@@ -131,6 +132,12 @@
       titleKey: 'navigation.reportBug',
       component: 'report-bug',
     },
+    {
+      route: 'system-health',
+      page: 'help/system-health',
+      titleKey: 'health.title',
+      component: 'system-health',
+    },
     { route: 'system', page: 'system', titleKey: 'navigation.system', component: 'system' },
     { route: 'settings', page: 'settings', titleKey: 'navigation.settings', component: 'settings' },
   ];
@@ -209,6 +216,12 @@
           if (!ReportBug) {
             const module = await import('./lib/desktop/views/ReportBug.svelte');
             ReportBug = module.default;
+          }
+          break;
+        case 'system-health':
+          if (!SystemHealth) {
+            const module = await import('./lib/desktop/views/SystemHealth.svelte');
+            SystemHealth = module.default;
           }
           break;
         case 'system':
@@ -321,6 +334,7 @@
     [uiPath('about')]: findRouteConfig('about'),
     [uiPath('help')]: findRouteConfig('help'),
     [uiPath('help', 'report-bug')]: findRouteConfig('report-bug'),
+    [uiPath('help', 'system-health')]: findRouteConfig('system-health'),
     [uiPath('system')]: findRouteConfig('system'),
     [uiPath('settings')]: findRouteConfig('settings'),
   });
@@ -601,6 +615,8 @@
       {@render renderRoute(Help)}
     {:else if currentRoute === 'report-bug'}
       {@render renderRoute(ReportBug)}
+    {:else if currentRoute === 'system-health'}
+      {@render renderRoute(SystemHealth)}
     {:else if currentRoute === 'system'}
       {@render renderRoute(System)}
     {:else if currentRoute === 'settings'}

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -132,13 +132,13 @@
       titleKey: 'navigation.reportBug',
       component: 'report-bug',
     },
+    { route: 'system', page: 'system', titleKey: 'navigation.system', component: 'system' },
     {
       route: 'system-health',
-      page: 'help/system-health',
+      page: 'system/health',
       titleKey: 'health.title',
       component: 'system-health',
     },
-    { route: 'system', page: 'system', titleKey: 'navigation.system', component: 'system' },
     { route: 'settings', page: 'settings', titleKey: 'navigation.settings', component: 'settings' },
   ];
 
@@ -334,8 +334,8 @@
     [uiPath('about')]: findRouteConfig('about'),
     [uiPath('help')]: findRouteConfig('help'),
     [uiPath('help', 'report-bug')]: findRouteConfig('report-bug'),
-    [uiPath('help', 'system-health')]: findRouteConfig('system-health'),
     [uiPath('system')]: findRouteConfig('system'),
+    [uiPath('system', 'health')]: findRouteConfig('system-health'),
     [uiPath('settings')]: findRouteConfig('settings'),
   });
 
@@ -391,6 +391,14 @@
 
     // Handle system and settings subpages
     if (UI_SYSTEM_PREFIX_RE.test(path)) {
+      const exactMatch = pathToRouteMap.get(path);
+      if (exactMatch) {
+        currentRoute = exactMatch.route;
+        currentPage = exactMatch.page;
+        pageTitleKey = exactMatch.titleKey;
+        if (exactMatch.component) loadComponent(exactMatch.component);
+        return;
+      }
       handleSubpageRouting(path, 'system', systemSubpages, 'pageTitle.systemNotAvailable');
       return;
     }

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -391,7 +391,8 @@
 
     // Handle system and settings subpages
     if (UI_SYSTEM_PREFIX_RE.test(path)) {
-      const exactMatch = pathToRouteMap.get(path);
+      const normalizedPath = path.endsWith('/') && path.length > 1 ? path.slice(0, -1) : path;
+      const exactMatch = pathToRouteMap.get(normalizedPath);
       if (exactMatch) {
         currentRoute = exactMatch.route;
         currentPage = exactMatch.page;

--- a/frontend/src/lib/desktop/layouts/DesktopSidebar.svelte
+++ b/frontend/src/lib/desktop/layouts/DesktopSidebar.svelte
@@ -247,10 +247,10 @@ Performance Optimizations:
     systemOverview: actualRoute === '/ui/system',
     systemDatabase: actualRoute === '/ui/system/database',
     systemTerminal: actualRoute === '/ui/system/terminal',
+    systemHealth: actualRoute === '/ui/system/health',
     help: actualRoute.startsWith('/ui/help'),
     helpExact: actualRoute === '/ui/help',
     helpReportBug: actualRoute === '/ui/help/report-bug',
-    helpSystemHealth: actualRoute === '/ui/help/system-health',
     settings: actualRoute.startsWith('/ui/settings'),
     settingsAnalysis: actualRoute === '/ui/settings/analysis',
     settingsMain: actualRoute === '/ui/settings/main',
@@ -296,10 +296,10 @@ Performance Optimizations:
     about: onNavigate ? '/about' : '/ui/about',
     help: onNavigate ? '/help' : '/ui/help',
     helpReportBug: onNavigate ? '/help/report-bug' : '/ui/help/report-bug',
-    helpSystemHealth: onNavigate ? '/help/system-health' : '/ui/help/system-health',
     systemOverview: onNavigate ? '/system' : '/ui/system',
     systemDatabase: onNavigate ? '/system/database' : '/ui/system/database',
     systemTerminal: onNavigate ? '/system/terminal' : '/ui/system/terminal',
+    systemHealth: onNavigate ? '/system/health' : '/ui/system/health',
     settingsAnalysis: onNavigate ? '/settings/analysis' : '/ui/settings/analysis',
     settingsMain: onNavigate ? '/settings/main' : '/ui/settings/main',
     settingsAudio: onNavigate ? '/settings/audio' : '/ui/settings/audio',
@@ -743,6 +743,17 @@ Performance Optimizations:
                     >
                       <Terminal class="size-4 shrink-0" />{t('system.sections.terminal')}
                     </button>
+                    <button
+                      onclick={() => navigate(navigationUrls.systemHealth)}
+                      class={cn(
+                        'flex items-center gap-2 w-full px-3 py-2 rounded-md text-sm transition-colors duration-150',
+                        routeCache.systemHealth
+                          ? 'menu-subitem-active'
+                          : 'text-[var(--color-base-content)]/80 hover:text-[var(--color-base-content)] hover:menu-hover'
+                      )}
+                    >
+                      <Activity class="size-4 shrink-0" />{t('navigation.health')}
+                    </button>
                   </div>
                 </div>
               {/if}
@@ -805,6 +816,17 @@ Performance Optimizations:
                     )}
                   >
                     <Terminal class="size-4 shrink-0" />{t('system.sections.terminal')}
+                  </button>
+                  <button
+                    onclick={() => navigate(navigationUrls.systemHealth)}
+                    class={cn(
+                      'flex items-center gap-2 px-3 py-2 rounded-md text-sm transition-colors duration-150',
+                      routeCache.systemHealth
+                        ? 'menu-subitem-active'
+                        : 'text-[var(--color-base-content)]/80 hover:text-[var(--color-base-content)] hover:menu-hover'
+                    )}
+                  >
+                    <Activity class="size-4 shrink-0" />{t('navigation.health')}
                   </button>
                 </div>
               {/if}
@@ -873,18 +895,6 @@ Performance Optimizations:
                       <Bug class="size-4 shrink-0" />
                       {t('navigation.reportBug')}
                     </button>
-                    <button
-                      onclick={() => navigate(navigationUrls.helpSystemHealth)}
-                      class={cn(
-                        'flex items-center gap-2 w-full px-3 py-2 rounded-md text-sm transition-colors duration-150',
-                        routeCache.helpSystemHealth
-                          ? 'menu-subitem-active'
-                          : 'text-[var(--color-base-content)]/80 hover:text-[var(--color-base-content)] hover:menu-hover'
-                      )}
-                    >
-                      <Activity class="size-4 shrink-0" />
-                      {t('navigation.systemHealth')}
-                    </button>
                     <a
                       href={GITHUB_DISCUSSIONS_URL}
                       target="_blank"
@@ -948,18 +958,6 @@ Performance Optimizations:
                   >
                     <Bug class="size-4 shrink-0" />
                     {t('navigation.reportBug')}
-                  </button>
-                  <button
-                    onclick={() => navigate(navigationUrls.helpSystemHealth)}
-                    class={cn(
-                      'flex items-center gap-2 px-3 py-2 rounded-md text-sm transition-colors duration-150',
-                      routeCache.helpSystemHealth
-                        ? 'menu-subitem-active'
-                        : 'text-[var(--color-base-content)]/80 hover:text-[var(--color-base-content)] hover:menu-hover'
-                    )}
-                  >
-                    <Activity class="size-4 shrink-0" />
-                    {t('navigation.systemHealth')}
                   </button>
                   <a
                     href={GITHUB_DISCUSSIONS_URL}

--- a/frontend/src/lib/desktop/layouts/DesktopSidebar.svelte
+++ b/frontend/src/lib/desktop/layouts/DesktopSidebar.svelte
@@ -76,6 +76,7 @@ Performance Optimizations:
     Bug,
     MessageCircleQuestion,
     ExternalLink,
+    Activity,
   } from '@lucide/svelte';
   import { flyout } from '$lib/utils/transitions';
   import { t } from '$lib/i18n';
@@ -249,6 +250,7 @@ Performance Optimizations:
     help: actualRoute.startsWith('/ui/help'),
     helpExact: actualRoute === '/ui/help',
     helpReportBug: actualRoute === '/ui/help/report-bug',
+    helpSystemHealth: actualRoute === '/ui/help/system-health',
     settings: actualRoute.startsWith('/ui/settings'),
     settingsAnalysis: actualRoute === '/ui/settings/analysis',
     settingsMain: actualRoute === '/ui/settings/main',
@@ -294,6 +296,7 @@ Performance Optimizations:
     about: onNavigate ? '/about' : '/ui/about',
     help: onNavigate ? '/help' : '/ui/help',
     helpReportBug: onNavigate ? '/help/report-bug' : '/ui/help/report-bug',
+    helpSystemHealth: onNavigate ? '/help/system-health' : '/ui/help/system-health',
     systemOverview: onNavigate ? '/system' : '/ui/system',
     systemDatabase: onNavigate ? '/system/database' : '/ui/system/database',
     systemTerminal: onNavigate ? '/system/terminal' : '/ui/system/terminal',
@@ -870,6 +873,18 @@ Performance Optimizations:
                       <Bug class="size-4 shrink-0" />
                       {t('navigation.reportBug')}
                     </button>
+                    <button
+                      onclick={() => navigate(navigationUrls.helpSystemHealth)}
+                      class={cn(
+                        'flex items-center gap-2 w-full px-3 py-2 rounded-md text-sm transition-colors duration-150',
+                        routeCache.helpSystemHealth
+                          ? 'menu-subitem-active'
+                          : 'text-[var(--color-base-content)]/80 hover:text-[var(--color-base-content)] hover:menu-hover'
+                      )}
+                    >
+                      <Activity class="size-4 shrink-0" />
+                      {t('navigation.systemHealth')}
+                    </button>
                     <a
                       href={GITHUB_DISCUSSIONS_URL}
                       target="_blank"
@@ -933,6 +948,18 @@ Performance Optimizations:
                   >
                     <Bug class="size-4 shrink-0" />
                     {t('navigation.reportBug')}
+                  </button>
+                  <button
+                    onclick={() => navigate(navigationUrls.helpSystemHealth)}
+                    class={cn(
+                      'flex items-center gap-2 px-3 py-2 rounded-md text-sm transition-colors duration-150',
+                      routeCache.helpSystemHealth
+                        ? 'menu-subitem-active'
+                        : 'text-[var(--color-base-content)]/80 hover:text-[var(--color-base-content)] hover:menu-hover'
+                    )}
+                  >
+                    <Activity class="size-4 shrink-0" />
+                    {t('navigation.systemHealth')}
                   </button>
                   <a
                     href={GITHUB_DISCUSSIONS_URL}

--- a/frontend/src/lib/desktop/views/Help.svelte
+++ b/frontend/src/lib/desktop/views/Help.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import Card from '$lib/desktop/components/ui/Card.svelte';
   import {
+    Activity,
     Bug,
     MessageCircleQuestion,
     ExternalLink,
@@ -54,7 +55,24 @@
     </div>
   </Card>
 
-  <!-- Card 2: Ask a Question -->
+  <!-- Card 2: System Health -->
+  <Card title={t('health.title')} className="bg-[var(--color-base-100)] shadow-sm">
+    <p class="text-[var(--color-base-content)] opacity-80">
+      {t('health.subtitle')}
+    </p>
+
+    <div class="mt-4">
+      <button
+        onclick={() => navigation.navigate('/ui/help/system-health')}
+        class="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-md transition-all bg-[var(--color-primary)] text-[var(--color-primary-content)] hover:bg-[var(--color-primary-hover)] focus-visible:outline-2 focus-visible:outline-[var(--color-primary)] focus-visible:outline-offset-2"
+      >
+        <Activity class="size-4" />
+        {t('health.title')}
+      </button>
+    </div>
+  </Card>
+
+  <!-- Card 3: Ask a Question -->
   <Card title={t('navigation.askQuestion')} className="bg-[var(--color-base-100)] shadow-sm">
     <p class="text-[var(--color-base-content)] opacity-80">
       {t('help.askQuestion.description')}

--- a/frontend/src/lib/desktop/views/Help.svelte
+++ b/frontend/src/lib/desktop/views/Help.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import Card from '$lib/desktop/components/ui/Card.svelte';
   import {
-    Activity,
     Bug,
     MessageCircleQuestion,
     ExternalLink,
@@ -55,24 +54,7 @@
     </div>
   </Card>
 
-  <!-- Card 2: System Health -->
-  <Card title={t('health.title')} className="bg-[var(--color-base-100)] shadow-sm">
-    <p class="text-[var(--color-base-content)] opacity-80">
-      {t('health.subtitle')}
-    </p>
-
-    <div class="mt-4">
-      <button
-        onclick={() => navigation.navigate('/ui/help/system-health')}
-        class="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-md transition-all bg-[var(--color-primary)] text-[var(--color-primary-content)] hover:bg-[var(--color-primary-hover)] focus-visible:outline-2 focus-visible:outline-[var(--color-primary)] focus-visible:outline-offset-2"
-      >
-        <Activity class="size-4" />
-        {t('health.title')}
-      </button>
-    </div>
-  </Card>
-
-  <!-- Card 3: Ask a Question -->
+  <!-- Card 2: Ask a Question -->
   <Card title={t('navigation.askQuestion')} className="bg-[var(--color-base-100)] shadow-sm">
     <p class="text-[var(--color-base-content)] opacity-80">
       {t('help.askQuestion.description')}

--- a/frontend/src/lib/desktop/views/SystemHealth.svelte
+++ b/frontend/src/lib/desktop/views/SystemHealth.svelte
@@ -14,6 +14,7 @@
     Clock,
     Loader2,
   } from '@lucide/svelte';
+  import { onMount } from 'svelte';
   import { t } from '$lib/i18n';
   import { api } from '$lib/utils/api';
 
@@ -67,6 +68,12 @@
   let copied = $state(false);
   let copyTimer: ReturnType<typeof setTimeout> | null = null;
 
+  onMount(() => {
+    return () => {
+      if (copyTimer !== null) clearTimeout(copyTimer);
+    };
+  });
+
   let groupedResults = $derived.by(() => {
     if (!report) return new Map<HealthCategory, DiagnosticsResult[]>();
     const groups = new Map<HealthCategory, DiagnosticsResult[]>();
@@ -114,11 +121,11 @@
   function buildTextReport(): string {
     if (!report) return '';
     const lines: string[] = [];
-    lines.push(`BirdNET-Go System Health Report`);
-    lines.push(`Status: ${report.status}`);
-    lines.push(`Time: ${new Date(report.started_at).toLocaleString()}`);
-    lines.push(`Duration: ${report.duration_ms.toFixed(0)}ms`);
-    lines.push(`Checks: ${report.total_checks}`);
+    lines.push(t('health.export.reportTitle'));
+    lines.push(`${t('health.export.statusLabel')}: ${t(`health.status.${report.status}`)}`);
+    lines.push(`${t('health.export.timeLabel')}: ${new Date(report.started_at).toLocaleString()}`);
+    lines.push(`${t('health.export.durationLabel')}: ${report.duration_ms.toFixed(0)}ms`);
+    lines.push(`${t('health.export.checksLabel')}: ${report.total_checks}`);
     lines.push('');
 
     for (const [cat, results] of groupedResults) {
@@ -165,7 +172,7 @@
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
     a.href = url;
-    a.download = `health-report-${report.id.slice(0, 8)}.json`;
+    a.download = `health-report-${report.id?.slice(0, 8) ?? 'unknown'}.json`;
     document.body.appendChild(a);
     a.click();
     document.body.removeChild(a);

--- a/frontend/src/lib/desktop/views/SystemHealth.svelte
+++ b/frontend/src/lib/desktop/views/SystemHealth.svelte
@@ -17,6 +17,7 @@
   import { onMount } from 'svelte';
   import { t } from '$lib/i18n';
   import { api } from '$lib/utils/api';
+  import { getLocalDateString, getLocalTimeString } from '$lib/utils/date';
 
   type HealthStatus = 'healthy' | 'warning' | 'critical' | 'unknown' | 'skipped';
   type HealthCategory =
@@ -77,10 +78,20 @@
   let groupedResults = $derived.by(() => {
     if (!report) return new Map<HealthCategory, DiagnosticsResult[]>();
     const groups = new Map<HealthCategory, DiagnosticsResult[]>();
+    const seen = new Set<HealthCategory>();
     for (const cat of categoryOrder) {
       const results = report.results.filter(r => r.category === cat);
       if (results.length > 0) {
         groups.set(cat, results);
+      }
+      seen.add(cat);
+    }
+    for (const r of report.results) {
+      if (!seen.has(r.category)) {
+        const existing = groups.get(r.category) ?? [];
+        existing.push(r);
+        groups.set(r.category, existing);
+        seen.add(r.category);
       }
     }
     return groups;
@@ -123,7 +134,9 @@
     const lines: string[] = [];
     lines.push(t('health.export.reportTitle'));
     lines.push(`${t('health.export.statusLabel')}: ${t(`health.status.${report.status}`)}`);
-    lines.push(`${t('health.export.timeLabel')}: ${new Date(report.started_at).toLocaleString()}`);
+    lines.push(
+      `${t('health.export.timeLabel')}: ${getLocalDateString(new Date(report.started_at))} ${getLocalTimeString(new Date(report.started_at))}`
+    );
     lines.push(`${t('health.export.durationLabel')}: ${report.duration_ms.toFixed(0)}ms`);
     lines.push(`${t('health.export.checksLabel')}: ${report.total_checks}`);
     lines.push('');
@@ -152,8 +165,9 @@
         textarea.style.opacity = '0';
         document.body.appendChild(textarea);
         textarea.select();
-        document.execCommand('copy');
+        const ok = document.execCommand('copy');
         document.body.removeChild(textarea);
+        if (!ok) return;
       }
       copied = true;
       if (copyTimer !== null) clearTimeout(copyTimer);
@@ -219,6 +233,7 @@
     <Card className="bg-[var(--color-base-100)] shadow-sm">
       <div
         role="alert"
+        aria-live="assertive"
         class="flex items-center gap-3 p-3 rounded-lg bg-[color-mix(in_srgb,var(--color-error)_10%,transparent)]"
       >
         <XCircle class="size-5 shrink-0 text-[var(--color-error)]" />
@@ -243,7 +258,7 @@
   {#if report}
     <!-- Summary Bar -->
     <Card className="bg-[var(--color-base-100)] shadow-sm">
-      <div class="flex flex-wrap items-center gap-4">
+      <div class="flex flex-wrap items-center gap-4 pt-6">
         <div class="flex items-center gap-2">
           <StatusPill
             variant={statusToVariant(report.status)}

--- a/frontend/src/lib/desktop/views/SystemHealth.svelte
+++ b/frontend/src/lib/desktop/views/SystemHealth.svelte
@@ -1,0 +1,342 @@
+<script lang="ts">
+  import Card from '$lib/desktop/components/ui/Card.svelte';
+  import StatusPill from '$lib/desktop/components/ui/StatusPill.svelte';
+  import type { StatusVariant } from '$lib/desktop/components/ui/StatusPill.svelte';
+  import {
+    Activity,
+    Play,
+    Download,
+    ClipboardCopy,
+    CheckCircle,
+    AlertTriangle,
+    XCircle,
+    SkipForward,
+    Clock,
+    Loader2,
+  } from '@lucide/svelte';
+  import { t } from '$lib/i18n';
+  import { api } from '$lib/utils/api';
+
+  type HealthStatus = 'healthy' | 'warning' | 'critical' | 'unknown' | 'skipped';
+  type HealthCategory =
+    | 'system'
+    | 'audio'
+    | 'analysis'
+    | 'streams'
+    | 'database'
+    | 'network'
+    | 'config'
+    | 'logs';
+
+  interface DiagnosticsResult {
+    name: string;
+    category: HealthCategory;
+    status: HealthStatus;
+    message: string;
+    details?: Record<string, unknown>;
+    duration_ms: number;
+    timestamp: string;
+  }
+
+  interface DiagnosticsReport {
+    id: string;
+    status: HealthStatus;
+    started_at: string;
+    completed_at: string;
+    duration_ms: number;
+    total_checks: number;
+    results: DiagnosticsResult[];
+    summary: Record<string, HealthStatus>;
+    count_by_status: Record<string, number>;
+  }
+
+  const categoryOrder: HealthCategory[] = [
+    'system',
+    'audio',
+    'analysis',
+    'streams',
+    'database',
+    'network',
+    'config',
+    'logs',
+  ];
+
+  let report = $state<DiagnosticsReport | null>(null);
+  let running = $state(false);
+  let error = $state<string | null>(null);
+  let copied = $state(false);
+  let copyTimer: ReturnType<typeof setTimeout> | null = null;
+
+  let groupedResults = $derived.by(() => {
+    if (!report) return new Map<HealthCategory, DiagnosticsResult[]>();
+    const groups = new Map<HealthCategory, DiagnosticsResult[]>();
+    for (const cat of categoryOrder) {
+      const results = report.results.filter(r => r.category === cat);
+      if (results.length > 0) {
+        groups.set(cat, results);
+      }
+    }
+    return groups;
+  });
+
+  function statusToVariant(status: HealthStatus): StatusVariant {
+    switch (status) {
+      case 'healthy':
+        return 'success';
+      case 'warning':
+        return 'warning';
+      case 'critical':
+        return 'error';
+      default:
+        return 'neutral';
+    }
+  }
+
+  async function runDiagnostics() {
+    running = true;
+    error = null;
+    try {
+      report = await api.post<DiagnosticsReport>('/api/v2/system/diagnostics/run');
+    } catch {
+      error = t('health.errors.fetchFailed');
+    } finally {
+      running = false;
+    }
+  }
+
+  function formatCheckName(name: string): string {
+    return name
+      .split('_')
+      .map(w => w.charAt(0).toUpperCase() + w.slice(1))
+      .join(' ');
+  }
+
+  function buildTextReport(): string {
+    if (!report) return '';
+    const lines: string[] = [];
+    lines.push(`BirdNET-Go System Health Report`);
+    lines.push(`Status: ${report.status}`);
+    lines.push(`Time: ${new Date(report.started_at).toLocaleString()}`);
+    lines.push(`Duration: ${report.duration_ms.toFixed(0)}ms`);
+    lines.push(`Checks: ${report.total_checks}`);
+    lines.push('');
+
+    for (const [cat, results] of groupedResults) {
+      const catLabel = t(`health.categories.${cat}`);
+      lines.push(`--- ${catLabel} ---`);
+      for (const r of results) {
+        const statusLabel = t(`health.status.${r.status}`);
+        lines.push(`  [${statusLabel}] ${formatCheckName(r.name)}: ${r.message}`);
+      }
+      lines.push('');
+    }
+    return lines.join('\n');
+  }
+
+  async function copyReport() {
+    const text = buildTextReport();
+    try {
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(text);
+      } else {
+        const textarea = document.createElement('textarea');
+        textarea.value = text;
+        textarea.style.position = 'fixed';
+        textarea.style.opacity = '0';
+        document.body.appendChild(textarea);
+        textarea.select();
+        document.execCommand('copy');
+        document.body.removeChild(textarea);
+      }
+      copied = true;
+      if (copyTimer !== null) clearTimeout(copyTimer);
+      copyTimer = setTimeout(() => {
+        copied = false;
+        copyTimer = null;
+      }, 2000);
+    } catch {
+      // Clipboard access denied or unavailable
+    }
+  }
+
+  function downloadJSON() {
+    if (!report) return;
+    const blob = new Blob([JSON.stringify(report, null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `health-report-${report.id.slice(0, 8)}.json`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  }
+</script>
+
+<div class="col-span-12 space-y-4">
+  <!-- Page Header -->
+  <Card className="bg-[var(--color-base-100)] shadow-sm">
+    <div class="flex flex-col items-center text-center pt-2">
+      <div
+        class="w-20 h-20 rounded-full bg-gradient-to-b from-[var(--surface-200)] to-[var(--color-base-100)] flex items-center justify-center border border-[var(--border-100)]"
+      >
+        <Activity class="size-10 text-[var(--color-primary)]" />
+      </div>
+      <div class="mt-3">
+        <h1 class="text-3xl font-bold">{t('health.title')}</h1>
+        <p class="text-[var(--color-base-content)] opacity-70 text-base mt-2">
+          {t('health.subtitle')}
+        </p>
+      </div>
+
+      <div class="mt-4">
+        <button
+          onclick={runDiagnostics}
+          disabled={running}
+          class="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-md transition-all bg-[var(--color-primary)] text-[var(--color-primary-content)] hover:bg-[var(--color-primary-hover)] focus-visible:outline-2 focus-visible:outline-[var(--color-primary)] focus-visible:outline-offset-2 disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {#if running}
+            <Loader2 class="size-4 animate-spin" />
+            {t('health.running')}
+          {:else}
+            <Play class="size-4" />
+            {t('health.runDiagnostics')}
+          {/if}
+        </button>
+      </div>
+    </div>
+  </Card>
+
+  <!-- Error State -->
+  {#if error}
+    <Card className="bg-[var(--color-base-100)] shadow-sm">
+      <div
+        role="alert"
+        class="flex items-center gap-3 p-3 rounded-lg bg-[color-mix(in_srgb,var(--color-error)_10%,transparent)]"
+      >
+        <XCircle class="size-5 shrink-0 text-[var(--color-error)]" />
+        <p class="text-sm text-[var(--color-base-content)]">{error}</p>
+      </div>
+    </Card>
+  {/if}
+
+  <!-- No Results State -->
+  {#if !report && !running && !error}
+    <Card className="bg-[var(--color-base-100)] shadow-sm">
+      <div class="flex flex-col items-center py-6 text-center">
+        <Activity class="size-12 text-[var(--color-base-content)] opacity-20 mb-3" />
+        <p class="text-[var(--color-base-content)] opacity-60 text-sm">
+          {t('health.noResults')}
+        </p>
+      </div>
+    </Card>
+  {/if}
+
+  <!-- Results -->
+  {#if report}
+    <!-- Summary Bar -->
+    <Card className="bg-[var(--color-base-100)] shadow-sm">
+      <div class="flex flex-wrap items-center gap-4">
+        <div class="flex items-center gap-2">
+          <StatusPill
+            variant={statusToVariant(report.status)}
+            label={t(`health.status.${report.status}`)}
+            size="md"
+          />
+        </div>
+
+        <div class="flex items-center gap-3 text-sm text-[var(--color-base-content)] opacity-70">
+          {#if report.count_by_status.healthy}
+            <span class="flex items-center gap-1">
+              <CheckCircle class="size-3.5 text-[var(--color-success)]" />
+              {report.count_by_status.healthy}
+              {t('health.summary.healthy')}
+            </span>
+          {/if}
+          {#if report.count_by_status.warning}
+            <span class="flex items-center gap-1">
+              <AlertTriangle class="size-3.5 text-[var(--color-warning)]" />
+              {report.count_by_status.warning}
+              {t('health.summary.warnings')}
+            </span>
+          {/if}
+          {#if report.count_by_status.critical}
+            <span class="flex items-center gap-1">
+              <XCircle class="size-3.5 text-[var(--color-error)]" />
+              {report.count_by_status.critical}
+              {t('health.summary.critical')}
+            </span>
+          {/if}
+          {#if report.count_by_status.skipped}
+            <span class="flex items-center gap-1">
+              <SkipForward class="size-3.5 opacity-40" />
+              {report.count_by_status.skipped}
+              {t('health.summary.skipped')}
+            </span>
+          {/if}
+        </div>
+
+        <div
+          class="ml-auto flex items-center gap-2 text-xs text-[var(--color-base-content)] opacity-50"
+        >
+          <Clock class="size-3.5" />
+          {report.duration_ms.toFixed(0)}ms
+        </div>
+      </div>
+
+      <!-- Export Buttons -->
+      <div class="flex items-center gap-2 mt-3 pt-3 border-t border-[var(--color-base-200)]">
+        <button
+          onclick={copyReport}
+          class="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md transition-all bg-[var(--color-base-200)] text-[var(--color-base-content)] hover:bg-[var(--color-base-300)]"
+        >
+          {#if copied}
+            <CheckCircle class="size-3.5 text-[var(--color-success)]" />
+            {t('health.copied')}
+          {:else}
+            <ClipboardCopy class="size-3.5" />
+            {t('health.exportText')}
+          {/if}
+        </button>
+        <button
+          onclick={downloadJSON}
+          class="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md transition-all bg-[var(--color-base-200)] text-[var(--color-base-content)] hover:bg-[var(--color-base-300)]"
+        >
+          <Download class="size-3.5" />
+          {t('health.exportJSON')}
+        </button>
+      </div>
+    </Card>
+
+    <!-- Category Results -->
+    {#each [...groupedResults] as [category, results] (category)}
+      <Card
+        title={t(`health.categories.${category}`)}
+        className="bg-[var(--color-base-100)] shadow-sm"
+      >
+        <div class="space-y-2">
+          {#each results as result (result.name)}
+            <div
+              class="flex items-center gap-3 px-3 py-2.5 rounded-lg bg-[var(--color-base-200)]/50"
+            >
+              <StatusPill
+                variant={statusToVariant(result.status)}
+                label={t(`health.status.${result.status}`)}
+                size="xs"
+              />
+              <div class="flex-1 min-w-0">
+                <span class="text-sm font-medium">{formatCheckName(result.name)}</span>
+                <p class="text-xs text-[var(--color-base-content)] opacity-60 truncate">
+                  {result.message}
+                </p>
+              </div>
+              <span class="text-xs text-[var(--color-base-content)] opacity-40 shrink-0">
+                {result.duration_ms.toFixed(1)}ms
+              </span>
+            </div>
+          {/each}
+        </div>
+      </Card>
+    {/each}
+  {/if}
+</div>

--- a/frontend/static/messages/cs.json
+++ b/frontend/static/messages/cs.json
@@ -236,7 +236,8 @@
     "askQuestion": "Položit dotaz",
     "reportBugAriaLabel": "Nahlásit chybu na GitHubu (otevře se v novém okně)",
     "askQuestionAriaLabel": "Položit dotaz na GitHub Discussions (otevře se v novém okně)",
-    "viewOnGithubAriaLabel": "Zobrazit BirdNET-Go na GitHubu (otevře se v novém okně)"
+    "viewOnGithubAriaLabel": "Zobrazit BirdNET-Go na GitHubu (otevře se v novém okně)",
+    "systemHealth": "System Health"
   },
   "about": {
     "title": "BirdNET-Go",
@@ -4762,6 +4763,47 @@
       "title": "Otevřít hlášení na GitHubu",
       "description": "Jakmile shromáždíte výše uvedené informace a vygenerujete diagnostický balíček, otevřete hlášení na GitHubu a popište problém.",
       "button": "Otevřít hlášení na GitHubu"
+    }
+  },
+  "health": {
+    "title": "System Health",
+    "subtitle": "Run diagnostics to check your system's health and identify potential issues",
+    "runDiagnostics": "Run Diagnostics",
+    "running": "Running diagnostics...",
+    "lastRun": "Last run",
+    "noResults": "No diagnostics have been run yet. Click 'Run Diagnostics' to check your system.",
+    "exportText": "Copy Report",
+    "exportJSON": "Download JSON",
+    "copied": "Report copied to clipboard",
+    "duration": "Duration",
+    "summary": {
+      "healthy": "Healthy",
+      "warnings": "Warnings",
+      "critical": "Critical",
+      "skipped": "Skipped",
+      "total": "Total checks"
+    },
+    "categories": {
+      "system": "System",
+      "audio": "Audio Pipeline",
+      "analysis": "Analysis",
+      "streams": "RTSP Streams",
+      "database": "Database",
+      "network": "Network",
+      "config": "Configuration",
+      "logs": "Logs"
+    },
+    "status": {
+      "healthy": "Healthy",
+      "warning": "Warning",
+      "critical": "Critical",
+      "unknown": "Unknown",
+      "skipped": "Skipped"
+    },
+    "errors": {
+      "title": "Recent Errors",
+      "noErrors": "No recent errors",
+      "fetchFailed": "Failed to load diagnostics"
     }
   }
 }

--- a/frontend/static/messages/cs.json
+++ b/frontend/static/messages/cs.json
@@ -237,7 +237,7 @@
     "reportBugAriaLabel": "Nahlásit chybu na GitHubu (otevře se v novém okně)",
     "askQuestionAriaLabel": "Položit dotaz na GitHub Discussions (otevře se v novém okně)",
     "viewOnGithubAriaLabel": "Zobrazit BirdNET-Go na GitHubu (otevře se v novém okně)",
-    "systemHealth": "System Health"
+    "health": "Health"
   },
   "about": {
     "title": "BirdNET-Go",
@@ -4787,7 +4787,7 @@
       "system": "System",
       "audio": "Audio Pipeline",
       "analysis": "Analysis",
-      "streams": "RTSP Streams",
+      "streams": "Audio Streams",
       "database": "Database",
       "network": "Network",
       "config": "Configuration",
@@ -4804,6 +4804,13 @@
       "title": "Recent Errors",
       "noErrors": "No recent errors",
       "fetchFailed": "Failed to load diagnostics"
+    },
+    "export": {
+      "reportTitle": "BirdNET-Go System Health Report",
+      "statusLabel": "Status",
+      "timeLabel": "Time",
+      "durationLabel": "Duration",
+      "checksLabel": "Checks"
     }
   }
 }

--- a/frontend/static/messages/da.json
+++ b/frontend/static/messages/da.json
@@ -237,7 +237,7 @@
     "reportBugAriaLabel": "Rapportér en fejl på GitHub (åbner i nyt vindue)",
     "askQuestionAriaLabel": "Stil et spørgsmål på GitHub Discussions (åbner i nyt vindue)",
     "viewOnGithubAriaLabel": "Se BirdNET-Go på GitHub (åbner i nyt vindue)",
-    "systemHealth": "System Health"
+    "health": "Health"
   },
   "about": {
     "title": "BirdNET-Go",
@@ -4787,7 +4787,7 @@
       "system": "System",
       "audio": "Audio Pipeline",
       "analysis": "Analysis",
-      "streams": "RTSP Streams",
+      "streams": "Audio Streams",
       "database": "Database",
       "network": "Network",
       "config": "Configuration",
@@ -4804,6 +4804,13 @@
       "title": "Recent Errors",
       "noErrors": "No recent errors",
       "fetchFailed": "Failed to load diagnostics"
+    },
+    "export": {
+      "reportTitle": "BirdNET-Go System Health Report",
+      "statusLabel": "Status",
+      "timeLabel": "Time",
+      "durationLabel": "Duration",
+      "checksLabel": "Checks"
     }
   }
 }

--- a/frontend/static/messages/da.json
+++ b/frontend/static/messages/da.json
@@ -236,7 +236,8 @@
     "askQuestion": "Stil et spørgsmål",
     "reportBugAriaLabel": "Rapportér en fejl på GitHub (åbner i nyt vindue)",
     "askQuestionAriaLabel": "Stil et spørgsmål på GitHub Discussions (åbner i nyt vindue)",
-    "viewOnGithubAriaLabel": "Se BirdNET-Go på GitHub (åbner i nyt vindue)"
+    "viewOnGithubAriaLabel": "Se BirdNET-Go på GitHub (åbner i nyt vindue)",
+    "systemHealth": "System Health"
   },
   "about": {
     "title": "BirdNET-Go",
@@ -4762,6 +4763,47 @@
       "title": "Åbn en GitHub-sag",
       "description": "Når du har samlet ovenstående oplysninger og genereret en supportpakke, åbn en sag på GitHub for at beskrive problemet.",
       "button": "Åbn sag på GitHub"
+    }
+  },
+  "health": {
+    "title": "System Health",
+    "subtitle": "Run diagnostics to check your system's health and identify potential issues",
+    "runDiagnostics": "Run Diagnostics",
+    "running": "Running diagnostics...",
+    "lastRun": "Last run",
+    "noResults": "No diagnostics have been run yet. Click 'Run Diagnostics' to check your system.",
+    "exportText": "Copy Report",
+    "exportJSON": "Download JSON",
+    "copied": "Report copied to clipboard",
+    "duration": "Duration",
+    "summary": {
+      "healthy": "Healthy",
+      "warnings": "Warnings",
+      "critical": "Critical",
+      "skipped": "Skipped",
+      "total": "Total checks"
+    },
+    "categories": {
+      "system": "System",
+      "audio": "Audio Pipeline",
+      "analysis": "Analysis",
+      "streams": "RTSP Streams",
+      "database": "Database",
+      "network": "Network",
+      "config": "Configuration",
+      "logs": "Logs"
+    },
+    "status": {
+      "healthy": "Healthy",
+      "warning": "Warning",
+      "critical": "Critical",
+      "unknown": "Unknown",
+      "skipped": "Skipped"
+    },
+    "errors": {
+      "title": "Recent Errors",
+      "noErrors": "No recent errors",
+      "fetchFailed": "Failed to load diagnostics"
     }
   }
 }

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -237,7 +237,7 @@
     "reportBugAriaLabel": "Einen Fehler auf GitHub melden (öffnet in neuem Fenster)",
     "askQuestionAriaLabel": "Eine Frage in GitHub Discussions stellen (öffnet in neuem Fenster)",
     "viewOnGithubAriaLabel": "BirdNET-Go auf GitHub ansehen (öffnet in neuem Fenster)",
-    "systemHealth": "System Health"
+    "health": "Health"
   },
   "about": {
     "title": "BirdNET-Go",
@@ -4787,7 +4787,7 @@
       "system": "System",
       "audio": "Audio Pipeline",
       "analysis": "Analysis",
-      "streams": "RTSP Streams",
+      "streams": "Audio Streams",
       "database": "Database",
       "network": "Network",
       "config": "Configuration",
@@ -4804,6 +4804,13 @@
       "title": "Recent Errors",
       "noErrors": "No recent errors",
       "fetchFailed": "Failed to load diagnostics"
+    },
+    "export": {
+      "reportTitle": "BirdNET-Go System Health Report",
+      "statusLabel": "Status",
+      "timeLabel": "Time",
+      "durationLabel": "Duration",
+      "checksLabel": "Checks"
     }
   }
 }

--- a/frontend/static/messages/de.json
+++ b/frontend/static/messages/de.json
@@ -236,7 +236,8 @@
     "askQuestion": "Frage stellen",
     "reportBugAriaLabel": "Einen Fehler auf GitHub melden (öffnet in neuem Fenster)",
     "askQuestionAriaLabel": "Eine Frage in GitHub Discussions stellen (öffnet in neuem Fenster)",
-    "viewOnGithubAriaLabel": "BirdNET-Go auf GitHub ansehen (öffnet in neuem Fenster)"
+    "viewOnGithubAriaLabel": "BirdNET-Go auf GitHub ansehen (öffnet in neuem Fenster)",
+    "systemHealth": "System Health"
   },
   "about": {
     "title": "BirdNET-Go",
@@ -4762,6 +4763,47 @@
       "title": "GitHub-Issue erstellen",
       "description": "Sobald Sie die obigen Informationen gesammelt und ein Support-Paket erstellt haben, eröffnen Sie ein Issue auf GitHub, um das Problem zu beschreiben.",
       "button": "Issue auf GitHub erstellen"
+    }
+  },
+  "health": {
+    "title": "System Health",
+    "subtitle": "Run diagnostics to check your system's health and identify potential issues",
+    "runDiagnostics": "Run Diagnostics",
+    "running": "Running diagnostics...",
+    "lastRun": "Last run",
+    "noResults": "No diagnostics have been run yet. Click 'Run Diagnostics' to check your system.",
+    "exportText": "Copy Report",
+    "exportJSON": "Download JSON",
+    "copied": "Report copied to clipboard",
+    "duration": "Duration",
+    "summary": {
+      "healthy": "Healthy",
+      "warnings": "Warnings",
+      "critical": "Critical",
+      "skipped": "Skipped",
+      "total": "Total checks"
+    },
+    "categories": {
+      "system": "System",
+      "audio": "Audio Pipeline",
+      "analysis": "Analysis",
+      "streams": "RTSP Streams",
+      "database": "Database",
+      "network": "Network",
+      "config": "Configuration",
+      "logs": "Logs"
+    },
+    "status": {
+      "healthy": "Healthy",
+      "warning": "Warning",
+      "critical": "Critical",
+      "unknown": "Unknown",
+      "skipped": "Skipped"
+    },
+    "errors": {
+      "title": "Recent Errors",
+      "noErrors": "No recent errors",
+      "fetchFailed": "Failed to load diagnostics"
     }
   }
 }

--- a/frontend/static/messages/en.json
+++ b/frontend/static/messages/en.json
@@ -237,7 +237,7 @@
     "reportBugAriaLabel": "Report a bug on GitHub (opens in new window)",
     "askQuestionAriaLabel": "Ask a question on GitHub Discussions (opens in new window)",
     "viewOnGithubAriaLabel": "View BirdNET-Go on GitHub (opens in new window)",
-    "systemHealth": "System Health"
+    "health": "Health"
   },
   "about": {
     "title": "BirdNET-Go",
@@ -4787,7 +4787,7 @@
       "system": "System",
       "audio": "Audio Pipeline",
       "analysis": "Analysis",
-      "streams": "RTSP Streams",
+      "streams": "Audio Streams",
       "database": "Database",
       "network": "Network",
       "config": "Configuration",
@@ -4804,6 +4804,13 @@
       "title": "Recent Errors",
       "noErrors": "No recent errors",
       "fetchFailed": "Failed to load diagnostics"
+    },
+    "export": {
+      "reportTitle": "BirdNET-Go System Health Report",
+      "statusLabel": "Status",
+      "timeLabel": "Time",
+      "durationLabel": "Duration",
+      "checksLabel": "Checks"
     }
   }
 }

--- a/frontend/static/messages/en.json
+++ b/frontend/static/messages/en.json
@@ -236,7 +236,8 @@
     "askQuestion": "Ask a Question",
     "reportBugAriaLabel": "Report a bug on GitHub (opens in new window)",
     "askQuestionAriaLabel": "Ask a question on GitHub Discussions (opens in new window)",
-    "viewOnGithubAriaLabel": "View BirdNET-Go on GitHub (opens in new window)"
+    "viewOnGithubAriaLabel": "View BirdNET-Go on GitHub (opens in new window)",
+    "systemHealth": "System Health"
   },
   "about": {
     "title": "BirdNET-Go",
@@ -4762,6 +4763,47 @@
       "title": "Open a GitHub Issue",
       "description": "Once you have gathered the information above and generated a support dump, open an issue on GitHub to describe the problem.",
       "button": "Open Issue on GitHub"
+    }
+  },
+  "health": {
+    "title": "System Health",
+    "subtitle": "Run diagnostics to check your system's health and identify potential issues",
+    "runDiagnostics": "Run Diagnostics",
+    "running": "Running diagnostics...",
+    "lastRun": "Last run",
+    "noResults": "No diagnostics have been run yet. Click 'Run Diagnostics' to check your system.",
+    "exportText": "Copy Report",
+    "exportJSON": "Download JSON",
+    "copied": "Report copied to clipboard",
+    "duration": "Duration",
+    "summary": {
+      "healthy": "Healthy",
+      "warnings": "Warnings",
+      "critical": "Critical",
+      "skipped": "Skipped",
+      "total": "Total checks"
+    },
+    "categories": {
+      "system": "System",
+      "audio": "Audio Pipeline",
+      "analysis": "Analysis",
+      "streams": "RTSP Streams",
+      "database": "Database",
+      "network": "Network",
+      "config": "Configuration",
+      "logs": "Logs"
+    },
+    "status": {
+      "healthy": "Healthy",
+      "warning": "Warning",
+      "critical": "Critical",
+      "unknown": "Unknown",
+      "skipped": "Skipped"
+    },
+    "errors": {
+      "title": "Recent Errors",
+      "noErrors": "No recent errors",
+      "fetchFailed": "Failed to load diagnostics"
     }
   }
 }

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -236,7 +236,8 @@
     "askQuestion": "Hacer una pregunta",
     "reportBugAriaLabel": "Reportar un error en GitHub (abre en una nueva ventana)",
     "askQuestionAriaLabel": "Hacer una pregunta en GitHub Discussions (abre en una nueva ventana)",
-    "viewOnGithubAriaLabel": "Ver BirdNET-Go en GitHub (abre en una nueva ventana)"
+    "viewOnGithubAriaLabel": "Ver BirdNET-Go en GitHub (abre en una nueva ventana)",
+    "systemHealth": "System Health"
   },
   "about": {
     "title": "BirdNET-Go",
@@ -4762,6 +4763,47 @@
       "title": "Abrir issue en GitHub",
       "description": "Una vez que hayas recopilado la información anterior y generado un paquete de soporte, abre un issue en GitHub para describir el problema.",
       "button": "Abrir issue en GitHub"
+    }
+  },
+  "health": {
+    "title": "System Health",
+    "subtitle": "Run diagnostics to check your system's health and identify potential issues",
+    "runDiagnostics": "Run Diagnostics",
+    "running": "Running diagnostics...",
+    "lastRun": "Last run",
+    "noResults": "No diagnostics have been run yet. Click 'Run Diagnostics' to check your system.",
+    "exportText": "Copy Report",
+    "exportJSON": "Download JSON",
+    "copied": "Report copied to clipboard",
+    "duration": "Duration",
+    "summary": {
+      "healthy": "Healthy",
+      "warnings": "Warnings",
+      "critical": "Critical",
+      "skipped": "Skipped",
+      "total": "Total checks"
+    },
+    "categories": {
+      "system": "System",
+      "audio": "Audio Pipeline",
+      "analysis": "Analysis",
+      "streams": "RTSP Streams",
+      "database": "Database",
+      "network": "Network",
+      "config": "Configuration",
+      "logs": "Logs"
+    },
+    "status": {
+      "healthy": "Healthy",
+      "warning": "Warning",
+      "critical": "Critical",
+      "unknown": "Unknown",
+      "skipped": "Skipped"
+    },
+    "errors": {
+      "title": "Recent Errors",
+      "noErrors": "No recent errors",
+      "fetchFailed": "Failed to load diagnostics"
     }
   }
 }

--- a/frontend/static/messages/es.json
+++ b/frontend/static/messages/es.json
@@ -237,7 +237,7 @@
     "reportBugAriaLabel": "Reportar un error en GitHub (abre en una nueva ventana)",
     "askQuestionAriaLabel": "Hacer una pregunta en GitHub Discussions (abre en una nueva ventana)",
     "viewOnGithubAriaLabel": "Ver BirdNET-Go en GitHub (abre en una nueva ventana)",
-    "systemHealth": "System Health"
+    "health": "Health"
   },
   "about": {
     "title": "BirdNET-Go",
@@ -4787,7 +4787,7 @@
       "system": "System",
       "audio": "Audio Pipeline",
       "analysis": "Analysis",
-      "streams": "RTSP Streams",
+      "streams": "Audio Streams",
       "database": "Database",
       "network": "Network",
       "config": "Configuration",
@@ -4804,6 +4804,13 @@
       "title": "Recent Errors",
       "noErrors": "No recent errors",
       "fetchFailed": "Failed to load diagnostics"
+    },
+    "export": {
+      "reportTitle": "BirdNET-Go System Health Report",
+      "statusLabel": "Status",
+      "timeLabel": "Time",
+      "durationLabel": "Duration",
+      "checksLabel": "Checks"
     }
   }
 }

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -237,7 +237,7 @@
     "reportBugAriaLabel": "Ilmoita virheestä GitHubissa (avautuu uuteen ikkunaan)",
     "askQuestionAriaLabel": "Esitä kysymys GitHub Discussions -foorumilla (avautuu uuteen ikkunaan)",
     "viewOnGithubAriaLabel": "Näytä BirdNET-Go GitHubissa (avautuu uuteen ikkunaan)",
-    "systemHealth": "System Health"
+    "health": "Health"
   },
   "about": {
     "title": "BirdNET-Go",
@@ -4787,7 +4787,7 @@
       "system": "System",
       "audio": "Audio Pipeline",
       "analysis": "Analysis",
-      "streams": "RTSP Streams",
+      "streams": "Audio Streams",
       "database": "Database",
       "network": "Network",
       "config": "Configuration",
@@ -4804,6 +4804,13 @@
       "title": "Recent Errors",
       "noErrors": "No recent errors",
       "fetchFailed": "Failed to load diagnostics"
+    },
+    "export": {
+      "reportTitle": "BirdNET-Go System Health Report",
+      "statusLabel": "Status",
+      "timeLabel": "Time",
+      "durationLabel": "Duration",
+      "checksLabel": "Checks"
     }
   }
 }

--- a/frontend/static/messages/fi.json
+++ b/frontend/static/messages/fi.json
@@ -236,7 +236,8 @@
     "askQuestion": "Esitä kysymys",
     "reportBugAriaLabel": "Ilmoita virheestä GitHubissa (avautuu uuteen ikkunaan)",
     "askQuestionAriaLabel": "Esitä kysymys GitHub Discussions -foorumilla (avautuu uuteen ikkunaan)",
-    "viewOnGithubAriaLabel": "Näytä BirdNET-Go GitHubissa (avautuu uuteen ikkunaan)"
+    "viewOnGithubAriaLabel": "Näytä BirdNET-Go GitHubissa (avautuu uuteen ikkunaan)",
+    "systemHealth": "System Health"
   },
   "about": {
     "title": "BirdNET-Go",
@@ -4762,6 +4763,47 @@
       "title": "Avaa GitHub-raportti",
       "description": "Kun olet kerännyt yllä olevat tiedot ja luonut tukipaketin, avaa raportti GitHubissa ongelman kuvaamiseksi.",
       "button": "Avaa raportti GitHubissa"
+    }
+  },
+  "health": {
+    "title": "System Health",
+    "subtitle": "Run diagnostics to check your system's health and identify potential issues",
+    "runDiagnostics": "Run Diagnostics",
+    "running": "Running diagnostics...",
+    "lastRun": "Last run",
+    "noResults": "No diagnostics have been run yet. Click 'Run Diagnostics' to check your system.",
+    "exportText": "Copy Report",
+    "exportJSON": "Download JSON",
+    "copied": "Report copied to clipboard",
+    "duration": "Duration",
+    "summary": {
+      "healthy": "Healthy",
+      "warnings": "Warnings",
+      "critical": "Critical",
+      "skipped": "Skipped",
+      "total": "Total checks"
+    },
+    "categories": {
+      "system": "System",
+      "audio": "Audio Pipeline",
+      "analysis": "Analysis",
+      "streams": "RTSP Streams",
+      "database": "Database",
+      "network": "Network",
+      "config": "Configuration",
+      "logs": "Logs"
+    },
+    "status": {
+      "healthy": "Healthy",
+      "warning": "Warning",
+      "critical": "Critical",
+      "unknown": "Unknown",
+      "skipped": "Skipped"
+    },
+    "errors": {
+      "title": "Recent Errors",
+      "noErrors": "No recent errors",
+      "fetchFailed": "Failed to load diagnostics"
     }
   }
 }

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -236,7 +236,8 @@
     "askQuestion": "Poser une question",
     "reportBugAriaLabel": "Signaler un bug sur GitHub (ouvre dans une nouvelle fenêtre)",
     "askQuestionAriaLabel": "Poser une question sur GitHub Discussions (ouvre dans une nouvelle fenêtre)",
-    "viewOnGithubAriaLabel": "Voir BirdNET-Go sur GitHub (ouvre dans une nouvelle fenêtre)"
+    "viewOnGithubAriaLabel": "Voir BirdNET-Go sur GitHub (ouvre dans une nouvelle fenêtre)",
+    "systemHealth": "System Health"
   },
   "about": {
     "title": "BirdNET-Go",
@@ -4762,6 +4763,47 @@
       "title": "Ouvrir un ticket sur GitHub",
       "description": "Une fois les informations ci-dessus rassemblées et le rapport de support généré, ouvrez un ticket sur GitHub pour décrire le problème.",
       "button": "Ouvrir un ticket sur GitHub"
+    }
+  },
+  "health": {
+    "title": "System Health",
+    "subtitle": "Run diagnostics to check your system's health and identify potential issues",
+    "runDiagnostics": "Run Diagnostics",
+    "running": "Running diagnostics...",
+    "lastRun": "Last run",
+    "noResults": "No diagnostics have been run yet. Click 'Run Diagnostics' to check your system.",
+    "exportText": "Copy Report",
+    "exportJSON": "Download JSON",
+    "copied": "Report copied to clipboard",
+    "duration": "Duration",
+    "summary": {
+      "healthy": "Healthy",
+      "warnings": "Warnings",
+      "critical": "Critical",
+      "skipped": "Skipped",
+      "total": "Total checks"
+    },
+    "categories": {
+      "system": "System",
+      "audio": "Audio Pipeline",
+      "analysis": "Analysis",
+      "streams": "RTSP Streams",
+      "database": "Database",
+      "network": "Network",
+      "config": "Configuration",
+      "logs": "Logs"
+    },
+    "status": {
+      "healthy": "Healthy",
+      "warning": "Warning",
+      "critical": "Critical",
+      "unknown": "Unknown",
+      "skipped": "Skipped"
+    },
+    "errors": {
+      "title": "Recent Errors",
+      "noErrors": "No recent errors",
+      "fetchFailed": "Failed to load diagnostics"
     }
   }
 }

--- a/frontend/static/messages/fr.json
+++ b/frontend/static/messages/fr.json
@@ -237,7 +237,7 @@
     "reportBugAriaLabel": "Signaler un bug sur GitHub (ouvre dans une nouvelle fenêtre)",
     "askQuestionAriaLabel": "Poser une question sur GitHub Discussions (ouvre dans une nouvelle fenêtre)",
     "viewOnGithubAriaLabel": "Voir BirdNET-Go sur GitHub (ouvre dans une nouvelle fenêtre)",
-    "systemHealth": "System Health"
+    "health": "Health"
   },
   "about": {
     "title": "BirdNET-Go",
@@ -4787,7 +4787,7 @@
       "system": "System",
       "audio": "Audio Pipeline",
       "analysis": "Analysis",
-      "streams": "RTSP Streams",
+      "streams": "Audio Streams",
       "database": "Database",
       "network": "Network",
       "config": "Configuration",
@@ -4804,6 +4804,13 @@
       "title": "Recent Errors",
       "noErrors": "No recent errors",
       "fetchFailed": "Failed to load diagnostics"
+    },
+    "export": {
+      "reportTitle": "BirdNET-Go System Health Report",
+      "statusLabel": "Status",
+      "timeLabel": "Time",
+      "durationLabel": "Duration",
+      "checksLabel": "Checks"
     }
   }
 }

--- a/frontend/static/messages/hu.json
+++ b/frontend/static/messages/hu.json
@@ -237,7 +237,7 @@
     "reportBugAriaLabel": "Hiba bejelentése a GitHubon (új ablakban nyílik meg)",
     "askQuestionAriaLabel": "Kérdés feltevése a GitHub Discussions oldalon (új ablakban nyílik meg)",
     "viewOnGithubAriaLabel": "BirdNET-Go megtekintése a GitHubon (új ablakban nyílik meg)",
-    "systemHealth": "System Health"
+    "health": "Health"
   },
   "about": {
     "title": "BirdNET-Go",
@@ -4787,7 +4787,7 @@
       "system": "System",
       "audio": "Audio Pipeline",
       "analysis": "Analysis",
-      "streams": "RTSP Streams",
+      "streams": "Audio Streams",
       "database": "Database",
       "network": "Network",
       "config": "Configuration",
@@ -4804,6 +4804,13 @@
       "title": "Recent Errors",
       "noErrors": "No recent errors",
       "fetchFailed": "Failed to load diagnostics"
+    },
+    "export": {
+      "reportTitle": "BirdNET-Go System Health Report",
+      "statusLabel": "Status",
+      "timeLabel": "Time",
+      "durationLabel": "Duration",
+      "checksLabel": "Checks"
     }
   }
 }

--- a/frontend/static/messages/hu.json
+++ b/frontend/static/messages/hu.json
@@ -236,7 +236,8 @@
     "askQuestion": "Kérdés feltevése",
     "reportBugAriaLabel": "Hiba bejelentése a GitHubon (új ablakban nyílik meg)",
     "askQuestionAriaLabel": "Kérdés feltevése a GitHub Discussions oldalon (új ablakban nyílik meg)",
-    "viewOnGithubAriaLabel": "BirdNET-Go megtekintése a GitHubon (új ablakban nyílik meg)"
+    "viewOnGithubAriaLabel": "BirdNET-Go megtekintése a GitHubon (új ablakban nyílik meg)",
+    "systemHealth": "System Health"
   },
   "about": {
     "title": "BirdNET-Go",
@@ -4762,6 +4763,47 @@
       "title": "GitHub issue megnyitása",
       "description": "Miután összegyűjtötte a fenti információkat és létrehozta a támogatási csomagot, nyisson egy issue-t a GitHubon a probléma leírásához.",
       "button": "Issue megnyitása a GitHubon"
+    }
+  },
+  "health": {
+    "title": "System Health",
+    "subtitle": "Run diagnostics to check your system's health and identify potential issues",
+    "runDiagnostics": "Run Diagnostics",
+    "running": "Running diagnostics...",
+    "lastRun": "Last run",
+    "noResults": "No diagnostics have been run yet. Click 'Run Diagnostics' to check your system.",
+    "exportText": "Copy Report",
+    "exportJSON": "Download JSON",
+    "copied": "Report copied to clipboard",
+    "duration": "Duration",
+    "summary": {
+      "healthy": "Healthy",
+      "warnings": "Warnings",
+      "critical": "Critical",
+      "skipped": "Skipped",
+      "total": "Total checks"
+    },
+    "categories": {
+      "system": "System",
+      "audio": "Audio Pipeline",
+      "analysis": "Analysis",
+      "streams": "RTSP Streams",
+      "database": "Database",
+      "network": "Network",
+      "config": "Configuration",
+      "logs": "Logs"
+    },
+    "status": {
+      "healthy": "Healthy",
+      "warning": "Warning",
+      "critical": "Critical",
+      "unknown": "Unknown",
+      "skipped": "Skipped"
+    },
+    "errors": {
+      "title": "Recent Errors",
+      "noErrors": "No recent errors",
+      "fetchFailed": "Failed to load diagnostics"
     }
   }
 }

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -237,7 +237,7 @@
     "reportBugAriaLabel": "Segnala un bug su GitHub (si apre in una nuova finestra)",
     "askQuestionAriaLabel": "Fai una domanda su GitHub Discussions (si apre in una nuova finestra)",
     "viewOnGithubAriaLabel": "Visualizza BirdNET-Go su GitHub (si apre in una nuova finestra)",
-    "systemHealth": "System Health"
+    "health": "Health"
   },
   "about": {
     "title": "BirdNET-Go",
@@ -4787,7 +4787,7 @@
       "system": "System",
       "audio": "Audio Pipeline",
       "analysis": "Analysis",
-      "streams": "RTSP Streams",
+      "streams": "Audio Streams",
       "database": "Database",
       "network": "Network",
       "config": "Configuration",
@@ -4804,6 +4804,13 @@
       "title": "Recent Errors",
       "noErrors": "No recent errors",
       "fetchFailed": "Failed to load diagnostics"
+    },
+    "export": {
+      "reportTitle": "BirdNET-Go System Health Report",
+      "statusLabel": "Status",
+      "timeLabel": "Time",
+      "durationLabel": "Duration",
+      "checksLabel": "Checks"
     }
   }
 }

--- a/frontend/static/messages/it.json
+++ b/frontend/static/messages/it.json
@@ -236,7 +236,8 @@
     "askQuestion": "Fai una domanda",
     "reportBugAriaLabel": "Segnala un bug su GitHub (si apre in una nuova finestra)",
     "askQuestionAriaLabel": "Fai una domanda su GitHub Discussions (si apre in una nuova finestra)",
-    "viewOnGithubAriaLabel": "Visualizza BirdNET-Go su GitHub (si apre in una nuova finestra)"
+    "viewOnGithubAriaLabel": "Visualizza BirdNET-Go su GitHub (si apre in una nuova finestra)",
+    "systemHealth": "System Health"
   },
   "about": {
     "title": "BirdNET-Go",
@@ -4762,6 +4763,47 @@
       "title": "Apri una segnalazione su GitHub",
       "description": "Una volta raccolte le informazioni sopra e generato il pacchetto di supporto, apri una segnalazione su GitHub per descrivere il problema.",
       "button": "Apri segnalazione su GitHub"
+    }
+  },
+  "health": {
+    "title": "System Health",
+    "subtitle": "Run diagnostics to check your system's health and identify potential issues",
+    "runDiagnostics": "Run Diagnostics",
+    "running": "Running diagnostics...",
+    "lastRun": "Last run",
+    "noResults": "No diagnostics have been run yet. Click 'Run Diagnostics' to check your system.",
+    "exportText": "Copy Report",
+    "exportJSON": "Download JSON",
+    "copied": "Report copied to clipboard",
+    "duration": "Duration",
+    "summary": {
+      "healthy": "Healthy",
+      "warnings": "Warnings",
+      "critical": "Critical",
+      "skipped": "Skipped",
+      "total": "Total checks"
+    },
+    "categories": {
+      "system": "System",
+      "audio": "Audio Pipeline",
+      "analysis": "Analysis",
+      "streams": "RTSP Streams",
+      "database": "Database",
+      "network": "Network",
+      "config": "Configuration",
+      "logs": "Logs"
+    },
+    "status": {
+      "healthy": "Healthy",
+      "warning": "Warning",
+      "critical": "Critical",
+      "unknown": "Unknown",
+      "skipped": "Skipped"
+    },
+    "errors": {
+      "title": "Recent Errors",
+      "noErrors": "No recent errors",
+      "fetchFailed": "Failed to load diagnostics"
     }
   }
 }

--- a/frontend/static/messages/lv.json
+++ b/frontend/static/messages/lv.json
@@ -237,7 +237,7 @@
     "reportBugAriaLabel": "Ziņot par kļūdu GitHub (atveras jaunā logā)",
     "askQuestionAriaLabel": "Uzdot jautājumu GitHub Discussions (atveras jaunā logā)",
     "viewOnGithubAriaLabel": "Skatīt BirdNET-Go GitHub (atveras jaunā logā)",
-    "systemHealth": "System Health"
+    "health": "Health"
   },
   "about": {
     "title": "BirdNET-Go",
@@ -4787,7 +4787,7 @@
       "system": "System",
       "audio": "Audio Pipeline",
       "analysis": "Analysis",
-      "streams": "RTSP Streams",
+      "streams": "Audio Streams",
       "database": "Database",
       "network": "Network",
       "config": "Configuration",
@@ -4804,6 +4804,13 @@
       "title": "Recent Errors",
       "noErrors": "No recent errors",
       "fetchFailed": "Failed to load diagnostics"
+    },
+    "export": {
+      "reportTitle": "BirdNET-Go System Health Report",
+      "statusLabel": "Status",
+      "timeLabel": "Time",
+      "durationLabel": "Duration",
+      "checksLabel": "Checks"
     }
   }
 }

--- a/frontend/static/messages/lv.json
+++ b/frontend/static/messages/lv.json
@@ -236,7 +236,8 @@
     "askQuestion": "Uzdot jautājumu",
     "reportBugAriaLabel": "Ziņot par kļūdu GitHub (atveras jaunā logā)",
     "askQuestionAriaLabel": "Uzdot jautājumu GitHub Discussions (atveras jaunā logā)",
-    "viewOnGithubAriaLabel": "Skatīt BirdNET-Go GitHub (atveras jaunā logā)"
+    "viewOnGithubAriaLabel": "Skatīt BirdNET-Go GitHub (atveras jaunā logā)",
+    "systemHealth": "System Health"
   },
   "about": {
     "title": "BirdNET-Go",
@@ -4762,6 +4763,47 @@
       "title": "Atvērt GitHub ziņojumu",
       "description": "Kad esat savācis iepriekš minēto informāciju un izveidojis atbalsta pakotni, atveriet ziņojumu GitHub, lai aprakstītu problēmu.",
       "button": "Atvērt ziņojumu GitHub"
+    }
+  },
+  "health": {
+    "title": "System Health",
+    "subtitle": "Run diagnostics to check your system's health and identify potential issues",
+    "runDiagnostics": "Run Diagnostics",
+    "running": "Running diagnostics...",
+    "lastRun": "Last run",
+    "noResults": "No diagnostics have been run yet. Click 'Run Diagnostics' to check your system.",
+    "exportText": "Copy Report",
+    "exportJSON": "Download JSON",
+    "copied": "Report copied to clipboard",
+    "duration": "Duration",
+    "summary": {
+      "healthy": "Healthy",
+      "warnings": "Warnings",
+      "critical": "Critical",
+      "skipped": "Skipped",
+      "total": "Total checks"
+    },
+    "categories": {
+      "system": "System",
+      "audio": "Audio Pipeline",
+      "analysis": "Analysis",
+      "streams": "RTSP Streams",
+      "database": "Database",
+      "network": "Network",
+      "config": "Configuration",
+      "logs": "Logs"
+    },
+    "status": {
+      "healthy": "Healthy",
+      "warning": "Warning",
+      "critical": "Critical",
+      "unknown": "Unknown",
+      "skipped": "Skipped"
+    },
+    "errors": {
+      "title": "Recent Errors",
+      "noErrors": "No recent errors",
+      "fetchFailed": "Failed to load diagnostics"
     }
   }
 }

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -237,7 +237,7 @@
     "reportBugAriaLabel": "Meld een bug op GitHub (opent in nieuw venster)",
     "askQuestionAriaLabel": "Stel een vraag op GitHub Discussions (opent in nieuw venster)",
     "viewOnGithubAriaLabel": "Bekijk BirdNET-Go op GitHub (opent in nieuw venster)",
-    "systemHealth": "System Health"
+    "health": "Health"
   },
   "about": {
     "title": "BirdNET-Go",
@@ -4787,7 +4787,7 @@
       "system": "System",
       "audio": "Audio Pipeline",
       "analysis": "Analysis",
-      "streams": "RTSP Streams",
+      "streams": "Audio Streams",
       "database": "Database",
       "network": "Network",
       "config": "Configuration",
@@ -4804,6 +4804,13 @@
       "title": "Recent Errors",
       "noErrors": "No recent errors",
       "fetchFailed": "Failed to load diagnostics"
+    },
+    "export": {
+      "reportTitle": "BirdNET-Go System Health Report",
+      "statusLabel": "Status",
+      "timeLabel": "Time",
+      "durationLabel": "Duration",
+      "checksLabel": "Checks"
     }
   }
 }

--- a/frontend/static/messages/nl.json
+++ b/frontend/static/messages/nl.json
@@ -236,7 +236,8 @@
     "askQuestion": "Stel een vraag",
     "reportBugAriaLabel": "Meld een bug op GitHub (opent in nieuw venster)",
     "askQuestionAriaLabel": "Stel een vraag op GitHub Discussions (opent in nieuw venster)",
-    "viewOnGithubAriaLabel": "Bekijk BirdNET-Go op GitHub (opent in nieuw venster)"
+    "viewOnGithubAriaLabel": "Bekijk BirdNET-Go op GitHub (opent in nieuw venster)",
+    "systemHealth": "System Health"
   },
   "about": {
     "title": "BirdNET-Go",
@@ -4762,6 +4763,47 @@
       "title": "GitHub-issue openen",
       "description": "Zodra u de bovenstaande informatie heeft verzameld en een ondersteuningspakket heeft gegenereerd, open een issue op GitHub om het probleem te beschrijven.",
       "button": "Issue openen op GitHub"
+    }
+  },
+  "health": {
+    "title": "System Health",
+    "subtitle": "Run diagnostics to check your system's health and identify potential issues",
+    "runDiagnostics": "Run Diagnostics",
+    "running": "Running diagnostics...",
+    "lastRun": "Last run",
+    "noResults": "No diagnostics have been run yet. Click 'Run Diagnostics' to check your system.",
+    "exportText": "Copy Report",
+    "exportJSON": "Download JSON",
+    "copied": "Report copied to clipboard",
+    "duration": "Duration",
+    "summary": {
+      "healthy": "Healthy",
+      "warnings": "Warnings",
+      "critical": "Critical",
+      "skipped": "Skipped",
+      "total": "Total checks"
+    },
+    "categories": {
+      "system": "System",
+      "audio": "Audio Pipeline",
+      "analysis": "Analysis",
+      "streams": "RTSP Streams",
+      "database": "Database",
+      "network": "Network",
+      "config": "Configuration",
+      "logs": "Logs"
+    },
+    "status": {
+      "healthy": "Healthy",
+      "warning": "Warning",
+      "critical": "Critical",
+      "unknown": "Unknown",
+      "skipped": "Skipped"
+    },
+    "errors": {
+      "title": "Recent Errors",
+      "noErrors": "No recent errors",
+      "fetchFailed": "Failed to load diagnostics"
     }
   }
 }

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -237,7 +237,7 @@
     "reportBugAriaLabel": "Zgłoś błąd na GitHubie (otwiera się w nowym oknie)",
     "askQuestionAriaLabel": "Zadaj pytanie na GitHub Discussions (otwiera się w nowym oknie)",
     "viewOnGithubAriaLabel": "Zobacz BirdNET-Go na GitHubie (otwiera się w nowym oknie)",
-    "systemHealth": "System Health"
+    "health": "Health"
   },
   "about": {
     "title": "BirdNET-Go",
@@ -4787,7 +4787,7 @@
       "system": "System",
       "audio": "Audio Pipeline",
       "analysis": "Analysis",
-      "streams": "RTSP Streams",
+      "streams": "Audio Streams",
       "database": "Database",
       "network": "Network",
       "config": "Configuration",
@@ -4804,6 +4804,13 @@
       "title": "Recent Errors",
       "noErrors": "No recent errors",
       "fetchFailed": "Failed to load diagnostics"
+    },
+    "export": {
+      "reportTitle": "BirdNET-Go System Health Report",
+      "statusLabel": "Status",
+      "timeLabel": "Time",
+      "durationLabel": "Duration",
+      "checksLabel": "Checks"
     }
   }
 }

--- a/frontend/static/messages/pl.json
+++ b/frontend/static/messages/pl.json
@@ -236,7 +236,8 @@
     "askQuestion": "Zadaj pytanie",
     "reportBugAriaLabel": "Zgłoś błąd na GitHubie (otwiera się w nowym oknie)",
     "askQuestionAriaLabel": "Zadaj pytanie na GitHub Discussions (otwiera się w nowym oknie)",
-    "viewOnGithubAriaLabel": "Zobacz BirdNET-Go na GitHubie (otwiera się w nowym oknie)"
+    "viewOnGithubAriaLabel": "Zobacz BirdNET-Go na GitHubie (otwiera się w nowym oknie)",
+    "systemHealth": "System Health"
   },
   "about": {
     "title": "BirdNET-Go",
@@ -4762,6 +4763,47 @@
       "title": "Otwórz zgłoszenie na GitHubie",
       "description": "Po zebraniu powyższych informacji i wygenerowaniu pakietu wsparcia, otwórz zgłoszenie na GitHubie, aby opisać problem.",
       "button": "Otwórz zgłoszenie na GitHubie"
+    }
+  },
+  "health": {
+    "title": "System Health",
+    "subtitle": "Run diagnostics to check your system's health and identify potential issues",
+    "runDiagnostics": "Run Diagnostics",
+    "running": "Running diagnostics...",
+    "lastRun": "Last run",
+    "noResults": "No diagnostics have been run yet. Click 'Run Diagnostics' to check your system.",
+    "exportText": "Copy Report",
+    "exportJSON": "Download JSON",
+    "copied": "Report copied to clipboard",
+    "duration": "Duration",
+    "summary": {
+      "healthy": "Healthy",
+      "warnings": "Warnings",
+      "critical": "Critical",
+      "skipped": "Skipped",
+      "total": "Total checks"
+    },
+    "categories": {
+      "system": "System",
+      "audio": "Audio Pipeline",
+      "analysis": "Analysis",
+      "streams": "RTSP Streams",
+      "database": "Database",
+      "network": "Network",
+      "config": "Configuration",
+      "logs": "Logs"
+    },
+    "status": {
+      "healthy": "Healthy",
+      "warning": "Warning",
+      "critical": "Critical",
+      "unknown": "Unknown",
+      "skipped": "Skipped"
+    },
+    "errors": {
+      "title": "Recent Errors",
+      "noErrors": "No recent errors",
+      "fetchFailed": "Failed to load diagnostics"
     }
   }
 }

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -237,7 +237,7 @@
     "reportBugAriaLabel": "Reportar um erro no GitHub (abre em nova janela)",
     "askQuestionAriaLabel": "Fazer uma pergunta no GitHub Discussions (abre em nova janela)",
     "viewOnGithubAriaLabel": "Ver BirdNET-Go no GitHub (abre em nova janela)",
-    "systemHealth": "System Health"
+    "health": "Health"
   },
   "about": {
     "title": "BirdNET-Go",
@@ -4787,7 +4787,7 @@
       "system": "System",
       "audio": "Audio Pipeline",
       "analysis": "Analysis",
-      "streams": "RTSP Streams",
+      "streams": "Audio Streams",
       "database": "Database",
       "network": "Network",
       "config": "Configuration",
@@ -4804,6 +4804,13 @@
       "title": "Recent Errors",
       "noErrors": "No recent errors",
       "fetchFailed": "Failed to load diagnostics"
+    },
+    "export": {
+      "reportTitle": "BirdNET-Go System Health Report",
+      "statusLabel": "Status",
+      "timeLabel": "Time",
+      "durationLabel": "Duration",
+      "checksLabel": "Checks"
     }
   }
 }

--- a/frontend/static/messages/pt.json
+++ b/frontend/static/messages/pt.json
@@ -236,7 +236,8 @@
     "askQuestion": "Fazer uma pergunta",
     "reportBugAriaLabel": "Reportar um erro no GitHub (abre em nova janela)",
     "askQuestionAriaLabel": "Fazer uma pergunta no GitHub Discussions (abre em nova janela)",
-    "viewOnGithubAriaLabel": "Ver BirdNET-Go no GitHub (abre em nova janela)"
+    "viewOnGithubAriaLabel": "Ver BirdNET-Go no GitHub (abre em nova janela)",
+    "systemHealth": "System Health"
   },
   "about": {
     "title": "BirdNET-Go",
@@ -4762,6 +4763,47 @@
       "title": "Abrir issue no GitHub",
       "description": "Depois de reunir as informações acima e gerar um pacote de suporte, abra um issue no GitHub para descrever o problema.",
       "button": "Abrir issue no GitHub"
+    }
+  },
+  "health": {
+    "title": "System Health",
+    "subtitle": "Run diagnostics to check your system's health and identify potential issues",
+    "runDiagnostics": "Run Diagnostics",
+    "running": "Running diagnostics...",
+    "lastRun": "Last run",
+    "noResults": "No diagnostics have been run yet. Click 'Run Diagnostics' to check your system.",
+    "exportText": "Copy Report",
+    "exportJSON": "Download JSON",
+    "copied": "Report copied to clipboard",
+    "duration": "Duration",
+    "summary": {
+      "healthy": "Healthy",
+      "warnings": "Warnings",
+      "critical": "Critical",
+      "skipped": "Skipped",
+      "total": "Total checks"
+    },
+    "categories": {
+      "system": "System",
+      "audio": "Audio Pipeline",
+      "analysis": "Analysis",
+      "streams": "RTSP Streams",
+      "database": "Database",
+      "network": "Network",
+      "config": "Configuration",
+      "logs": "Logs"
+    },
+    "status": {
+      "healthy": "Healthy",
+      "warning": "Warning",
+      "critical": "Critical",
+      "unknown": "Unknown",
+      "skipped": "Skipped"
+    },
+    "errors": {
+      "title": "Recent Errors",
+      "noErrors": "No recent errors",
+      "fetchFailed": "Failed to load diagnostics"
     }
   }
 }

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -237,7 +237,7 @@
     "reportBugAriaLabel": "Nahlásiť chybu na GitHube (otvorí sa v novom okne)",
     "askQuestionAriaLabel": "Položiť otázku na GitHub Discussions (otvorí sa v novom okne)",
     "viewOnGithubAriaLabel": "Zobraziť BirdNET-Go na GitHube (otvorí sa v novom okne)",
-    "systemHealth": "System Health"
+    "health": "Health"
   },
   "about": {
     "title": "BirdNET-Go",
@@ -4787,7 +4787,7 @@
       "system": "System",
       "audio": "Audio Pipeline",
       "analysis": "Analysis",
-      "streams": "RTSP Streams",
+      "streams": "Audio Streams",
       "database": "Database",
       "network": "Network",
       "config": "Configuration",
@@ -4804,6 +4804,13 @@
       "title": "Recent Errors",
       "noErrors": "No recent errors",
       "fetchFailed": "Failed to load diagnostics"
+    },
+    "export": {
+      "reportTitle": "BirdNET-Go System Health Report",
+      "statusLabel": "Status",
+      "timeLabel": "Time",
+      "durationLabel": "Duration",
+      "checksLabel": "Checks"
     }
   }
 }

--- a/frontend/static/messages/sk.json
+++ b/frontend/static/messages/sk.json
@@ -236,7 +236,8 @@
     "askQuestion": "Položiť otázku",
     "reportBugAriaLabel": "Nahlásiť chybu na GitHube (otvorí sa v novom okne)",
     "askQuestionAriaLabel": "Položiť otázku na GitHub Discussions (otvorí sa v novom okne)",
-    "viewOnGithubAriaLabel": "Zobraziť BirdNET-Go na GitHube (otvorí sa v novom okne)"
+    "viewOnGithubAriaLabel": "Zobraziť BirdNET-Go na GitHube (otvorí sa v novom okne)",
+    "systemHealth": "System Health"
   },
   "about": {
     "title": "BirdNET-Go",
@@ -4762,6 +4763,47 @@
       "title": "Otvoriť hlásenie na GitHube",
       "description": "Keď zhromaždíte vyššie uvedené informácie a vygenerujete diagnostický balíček, otvorte hlásenie na GitHube a opíšte problém.",
       "button": "Otvoriť hlásenie na GitHube"
+    }
+  },
+  "health": {
+    "title": "System Health",
+    "subtitle": "Run diagnostics to check your system's health and identify potential issues",
+    "runDiagnostics": "Run Diagnostics",
+    "running": "Running diagnostics...",
+    "lastRun": "Last run",
+    "noResults": "No diagnostics have been run yet. Click 'Run Diagnostics' to check your system.",
+    "exportText": "Copy Report",
+    "exportJSON": "Download JSON",
+    "copied": "Report copied to clipboard",
+    "duration": "Duration",
+    "summary": {
+      "healthy": "Healthy",
+      "warnings": "Warnings",
+      "critical": "Critical",
+      "skipped": "Skipped",
+      "total": "Total checks"
+    },
+    "categories": {
+      "system": "System",
+      "audio": "Audio Pipeline",
+      "analysis": "Analysis",
+      "streams": "RTSP Streams",
+      "database": "Database",
+      "network": "Network",
+      "config": "Configuration",
+      "logs": "Logs"
+    },
+    "status": {
+      "healthy": "Healthy",
+      "warning": "Warning",
+      "critical": "Critical",
+      "unknown": "Unknown",
+      "skipped": "Skipped"
+    },
+    "errors": {
+      "title": "Recent Errors",
+      "noErrors": "No recent errors",
+      "fetchFailed": "Failed to load diagnostics"
     }
   }
 }

--- a/frontend/static/messages/sv.json
+++ b/frontend/static/messages/sv.json
@@ -236,7 +236,8 @@
     "askQuestion": "Ställ en fråga",
     "reportBugAriaLabel": "Rapportera en bugg på GitHub (öppnas i nytt fönster)",
     "askQuestionAriaLabel": "Ställ en fråga på GitHub Discussions (öppnas i nytt fönster)",
-    "viewOnGithubAriaLabel": "Visa BirdNET-Go på GitHub (öppnas i nytt fönster)"
+    "viewOnGithubAriaLabel": "Visa BirdNET-Go på GitHub (öppnas i nytt fönster)",
+    "systemHealth": "System Health"
   },
   "about": {
     "title": "BirdNET-Go",
@@ -4762,6 +4763,47 @@
       "title": "Öppna ett GitHub-ärende",
       "description": "När du har samlat informationen ovan och genererat ett supportpaket, öppna ett ärende på GitHub för att beskriva problemet.",
       "button": "Öppna ärende på GitHub"
+    }
+  },
+  "health": {
+    "title": "System Health",
+    "subtitle": "Run diagnostics to check your system's health and identify potential issues",
+    "runDiagnostics": "Run Diagnostics",
+    "running": "Running diagnostics...",
+    "lastRun": "Last run",
+    "noResults": "No diagnostics have been run yet. Click 'Run Diagnostics' to check your system.",
+    "exportText": "Copy Report",
+    "exportJSON": "Download JSON",
+    "copied": "Report copied to clipboard",
+    "duration": "Duration",
+    "summary": {
+      "healthy": "Healthy",
+      "warnings": "Warnings",
+      "critical": "Critical",
+      "skipped": "Skipped",
+      "total": "Total checks"
+    },
+    "categories": {
+      "system": "System",
+      "audio": "Audio Pipeline",
+      "analysis": "Analysis",
+      "streams": "RTSP Streams",
+      "database": "Database",
+      "network": "Network",
+      "config": "Configuration",
+      "logs": "Logs"
+    },
+    "status": {
+      "healthy": "Healthy",
+      "warning": "Warning",
+      "critical": "Critical",
+      "unknown": "Unknown",
+      "skipped": "Skipped"
+    },
+    "errors": {
+      "title": "Recent Errors",
+      "noErrors": "No recent errors",
+      "fetchFailed": "Failed to load diagnostics"
     }
   }
 }

--- a/frontend/static/messages/sv.json
+++ b/frontend/static/messages/sv.json
@@ -237,7 +237,7 @@
     "reportBugAriaLabel": "Rapportera en bugg på GitHub (öppnas i nytt fönster)",
     "askQuestionAriaLabel": "Ställ en fråga på GitHub Discussions (öppnas i nytt fönster)",
     "viewOnGithubAriaLabel": "Visa BirdNET-Go på GitHub (öppnas i nytt fönster)",
-    "systemHealth": "System Health"
+    "health": "Health"
   },
   "about": {
     "title": "BirdNET-Go",
@@ -4787,7 +4787,7 @@
       "system": "System",
       "audio": "Audio Pipeline",
       "analysis": "Analysis",
-      "streams": "RTSP Streams",
+      "streams": "Audio Streams",
       "database": "Database",
       "network": "Network",
       "config": "Configuration",
@@ -4804,6 +4804,13 @@
       "title": "Recent Errors",
       "noErrors": "No recent errors",
       "fetchFailed": "Failed to load diagnostics"
+    },
+    "export": {
+      "reportTitle": "BirdNET-Go System Health Report",
+      "statusLabel": "Status",
+      "timeLabel": "Time",
+      "durationLabel": "Duration",
+      "checksLabel": "Checks"
     }
   }
 }

--- a/internal/api/v2/diagnostics.go
+++ b/internal/api/v2/diagnostics.go
@@ -10,6 +10,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 	"github.com/tphakala/birdnet-go/internal/audiocore"
+	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/health"
 	"github.com/tphakala/birdnet-go/internal/health/checks"
 )
@@ -104,7 +105,7 @@ func (c *Controller) registerHealthChecks() {
 		checks.NewNotificationProvidersCheck(),
 		checks.NewWeatherCheck(func() bool {
 			p := c.currentSettings().Realtime.Weather.Provider
-			return p != "" && p != "none"
+			return p != "" && p != string(conf.WeatherNone)
 		}),
 
 		// Config checks

--- a/internal/api/v2/diagnostics.go
+++ b/internal/api/v2/diagnostics.go
@@ -102,7 +102,10 @@ func (c *Controller) registerHealthChecks() {
 			nil, // TODO: wire actual BirdWeather status
 		),
 		checks.NewNotificationProvidersCheck(),
-		checks.NewWeatherCheck(func() bool { return false }), // TODO: wire to weather config
+		checks.NewWeatherCheck(func() bool {
+			p := c.currentSettings().Realtime.Weather.Provider
+			return p != "" && p != "none"
+		}),
 
 		// Config checks
 		checks.NewPathAccessCheck(map[string]string{

--- a/internal/health/checks/system.go
+++ b/internal/health/checks/system.go
@@ -341,17 +341,12 @@ func (c *UptimeCheck) Run(_ context.Context) health.Result {
 
 	uptime := time.Since(*c.startTime)
 
-	const critThreshold = 5 * time.Minute
-	const warnThreshold = time.Hour
+	const warnThreshold = 5 * time.Minute
 
 	status := health.StatusHealthy
 	msg := fmt.Sprintf("Uptime OK (%.0f seconds)", uptime.Seconds())
 
-	switch {
-	case uptime < critThreshold:
-		status = health.StatusCritical
-		msg = fmt.Sprintf("Process started very recently (%.0f seconds ago), possible crash loop", uptime.Seconds())
-	case uptime < warnThreshold:
+	if uptime < warnThreshold {
 		status = health.StatusWarning
 		msg = fmt.Sprintf("Process started recently (%.0f seconds ago)", uptime.Seconds())
 	}


### PR DESCRIPTION
## Summary

- Add System Health diagnostics page at `/ui/help/system-health` with run diagnostics, category-grouped results, status pills, export (clipboard + JSON)
- Register route, dynamic import, and path mapping in App.svelte
- Add System Health nav item to sidebar Help menu (both collapsed flyout and expanded views)
- Add System Health card on the Help & Support page
- Add 32 i18n keys (`navigation.systemHealth` + `health.*` section) synced to all 15 locales

Frontend companion to backend PR #3132. Uses `POST /api/v2/system/diagnostics/run` endpoint.

## Test plan

- [ ] Navigate to Help > System Health from sidebar
- [ ] Click "Run Diagnostics" and verify results load grouped by category
- [ ] Verify status pills show correct colors (green/yellow/red/gray)
- [ ] Test "Copy Report" exports text to clipboard
- [ ] Test "Download JSON" downloads a valid JSON file
- [ ] Verify Help page shows the new System Health card with working link
- [ ] Test sidebar collapsed flyout shows System Health button
- [ ] Verify active route highlighting works in sidebar

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added System Health page to run diagnostics and view results by category with status indicators
  * Export diagnostic reports as text (clipboard) or JSON download
  * System Health menu item in the navigation sidebar

* **Bug Fixes**
  * Weather health check now respects configuration
  * System uptime alert thresholds adjusted to reduce false-critical alerts

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3133?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->