### PR TITLE
fix(alerting): route notifications by delivery target (#3134)

### DIFF
--- a/internal/alerting/dispatcher.go
+++ b/internal/alerting/dispatcher.go
@@ -20,12 +20,12 @@ import (
 // notifications with template metadata (bg_image_url, bg_confidence_percent, etc.)
 // for webhook templates.
 type NotificationCreator interface {
-	CreateAndBroadcast(notifType notification.Type, title, message string, eventProps map[string]any) error
-	CreateAndBroadcastWithKeys(notifType notification.Type, title, message, titleKey string, titleParams map[string]any, messageKey string, messageParams map[string]any, eventProps map[string]any) error
+	CreateAndBroadcast(target string, notifType notification.Type, title, message string, eventProps map[string]any) error
+	CreateAndBroadcastWithKeys(target string, notifType notification.Type, title, message, titleKey string, titleParams map[string]any, messageKey string, messageParams map[string]any, eventProps map[string]any) error
 	// CreateAndBroadcastTest creates a notification for a test rule fire.
-	CreateAndBroadcastTest(notifType notification.Type, title, message string, eventProps map[string]any) error
+	CreateAndBroadcastTest(target string, notifType notification.Type, title, message string, eventProps map[string]any) error
 	// CreateAndBroadcastTestWithKeys is the i18n-aware variant of CreateAndBroadcastTest.
-	CreateAndBroadcastTestWithKeys(notifType notification.Type, title, message, titleKey string, titleParams map[string]any, messageKey string, messageParams map[string]any, eventProps map[string]any) error
+	CreateAndBroadcastTestWithKeys(target string, notifType notification.Type, title, message, titleKey string, titleParams map[string]any, messageKey string, messageParams map[string]any, eventProps map[string]any) error
 }
 
 // ActionDispatcher routes alert rule actions to the notification bell
@@ -60,7 +60,7 @@ func (d *ActionDispatcher) dispatchInternal(rule *entities.AlertRule, event *Ale
 	if event == nil {
 		event = &AlertEvent{}
 	}
-	defaultDispatched := false
+	defaultDispatchedForTarget := make(map[string]bool, 2)
 	for i := range rule.Actions {
 		action := &rule.Actions[i]
 		title := renderTitle(action.TemplateTitle, rule, event)
@@ -69,15 +69,12 @@ func (d *ActionDispatcher) dispatchInternal(rule *entities.AlertRule, event *Ale
 		switch action.Target {
 		case TargetBell, TargetPush:
 			hasCustomTemplate := action.TemplateTitle != "" || action.TemplateMessage != ""
-			// Both targets broadcast through the same path. Deduplicate
-			// only when multiple actions use default templates, since
-			// they produce identical notifications.
-			if !hasCustomTemplate && defaultDispatched {
+			if !hasCustomTemplate && defaultDispatchedForTarget[action.Target] {
 				continue
 			}
 			d.dispatchNotification(action.Target, title, message, rule, event, hasCustomTemplate, isTest)
 			if !hasCustomTemplate {
-				defaultDispatched = true
+				defaultDispatchedForTarget[action.Target] = true
 			}
 		default:
 			d.log.Warn("unknown alert action target",
@@ -102,11 +99,11 @@ func (d *ActionDispatcher) dispatchNotification(target, title, message string, r
 		var err error
 		if isTest {
 			err = d.notifCreator.CreateAndBroadcastTestWithKeys(
-				notifType, title, fallbackMsg, titleKey, titleParams, msgKey, msgParams, event.Properties,
+				target, notifType, title, fallbackMsg, titleKey, titleParams, msgKey, msgParams, event.Properties,
 			)
 		} else {
 			err = d.notifCreator.CreateAndBroadcastWithKeys(
-				notifType, title, fallbackMsg, titleKey, titleParams, msgKey, msgParams, event.Properties,
+				target, notifType, title, fallbackMsg, titleKey, titleParams, msgKey, msgParams, event.Properties,
 			)
 		}
 		if err != nil {
@@ -121,9 +118,9 @@ func (d *ActionDispatcher) dispatchNotification(target, title, message string, r
 
 	var err error
 	if isTest {
-		err = d.notifCreator.CreateAndBroadcastTest(notifType, title, message, event.Properties)
+		err = d.notifCreator.CreateAndBroadcastTest(target, notifType, title, message, event.Properties)
 	} else {
-		err = d.notifCreator.CreateAndBroadcast(notifType, title, message, event.Properties)
+		err = d.notifCreator.CreateAndBroadcast(target, notifType, title, message, event.Properties)
 	}
 	if err != nil {
 		d.log.Error("failed to dispatch notification",

--- a/internal/alerting/dispatcher_test.go
+++ b/internal/alerting/dispatcher_test.go
@@ -14,11 +14,13 @@ import (
 
 type mockNotifCreator struct {
 	calls []struct {
+		target         string
 		notifType      notification.Type
 		title, message string
 		eventProps     map[string]any
 	}
 	keyCalls []struct {
+		target                   string
 		notifType                notification.Type
 		title, message, titleKey string
 		titleParams              map[string]any
@@ -27,11 +29,13 @@ type mockNotifCreator struct {
 		eventProps               map[string]any
 	}
 	testCalls []struct {
+		target         string
 		notifType      notification.Type
 		title, message string
 		eventProps     map[string]any
 	}
 	testKeyCalls []struct {
+		target                   string
 		notifType                notification.Type
 		title, message, titleKey string
 		titleParams              map[string]any
@@ -41,51 +45,55 @@ type mockNotifCreator struct {
 	}
 }
 
-func (m *mockNotifCreator) CreateAndBroadcast(notifType notification.Type, title, message string, eventProps map[string]any) error {
+func (m *mockNotifCreator) CreateAndBroadcast(target string, notifType notification.Type, title, message string, eventProps map[string]any) error {
 	m.calls = append(m.calls, struct {
+		target         string
 		notifType      notification.Type
 		title, message string
 		eventProps     map[string]any
-	}{notifType, title, message, eventProps})
+	}{target, notifType, title, message, eventProps})
 	return nil
 }
 
 func (m *mockNotifCreator) CreateAndBroadcastWithKeys(
-	notifType notification.Type, title, message, titleKey string, titleParams map[string]any,
+	target string, notifType notification.Type, title, message, titleKey string, titleParams map[string]any,
 	messageKey string, messageParams map[string]any, eventProps map[string]any,
 ) error {
 	m.keyCalls = append(m.keyCalls, struct {
+		target                   string
 		notifType                notification.Type
 		title, message, titleKey string
 		titleParams              map[string]any
 		messageKey               string
 		messageParams            map[string]any
 		eventProps               map[string]any
-	}{notifType, title, message, titleKey, titleParams, messageKey, messageParams, eventProps})
+	}{target, notifType, title, message, titleKey, titleParams, messageKey, messageParams, eventProps})
 	return nil
 }
 
-func (m *mockNotifCreator) CreateAndBroadcastTest(notifType notification.Type, title, message string, eventProps map[string]any) error {
+func (m *mockNotifCreator) CreateAndBroadcastTest(target string, notifType notification.Type, title, message string, eventProps map[string]any) error {
 	m.testCalls = append(m.testCalls, struct {
+		target         string
 		notifType      notification.Type
 		title, message string
 		eventProps     map[string]any
-	}{notifType, title, message, eventProps})
+	}{target, notifType, title, message, eventProps})
 	return nil
 }
 
 func (m *mockNotifCreator) CreateAndBroadcastTestWithKeys(
-	notifType notification.Type, title, message, titleKey string, titleParams map[string]any,
+	target string, notifType notification.Type, title, message, titleKey string, titleParams map[string]any,
 	messageKey string, messageParams map[string]any, eventProps map[string]any,
 ) error {
 	m.testKeyCalls = append(m.testKeyCalls, struct {
+		target                   string
 		notifType                notification.Type
 		title, message, titleKey string
 		titleParams              map[string]any
 		messageKey               string
 		messageParams            map[string]any
 		eventProps               map[string]any
-	}{notifType, title, message, titleKey, titleParams, messageKey, messageParams, eventProps})
+	}{target, notifType, title, message, titleKey, titleParams, messageKey, messageParams, eventProps})
 	return nil
 }
 
@@ -113,6 +121,7 @@ func TestDispatcher_BellAction(t *testing.T) {
 	dispatcher.Dispatch(rule, event)
 
 	require.Len(t, mock.calls, 1)
+	assert.Equal(t, TargetBell, mock.calls[0].target)
 	assert.Equal(t, notification.TypeWarning, mock.calls[0].notifType, "stream disconnect should use TypeWarning")
 	assert.Equal(t, "Stream lost", mock.calls[0].title)
 	assert.Equal(t, "A stream disconnected", mock.calls[0].message)
@@ -141,6 +150,7 @@ func TestDispatcher_DefaultTemplate_UsesKeys(t *testing.T) {
 
 	assert.Empty(t, mock.calls, "default template should use CreateAndBroadcastWithKeys")
 	require.Len(t, mock.keyCalls, 1)
+	assert.Equal(t, TargetBell, mock.keyCalls[0].target)
 	assert.Equal(t, MsgAlertFiredTitle, mock.keyCalls[0].titleKey)
 	assert.Equal(t, "CPU High", mock.keyCalls[0].titleParams["rule_name"])
 	assert.Equal(t, RuleKeyHighCPUName, mock.keyCalls[0].titleParams["rule_name_key"])
@@ -249,6 +259,7 @@ func TestDispatcher_PushAction(t *testing.T) {
 	dispatcher.Dispatch(rule, event)
 
 	require.Len(t, mock.calls, 1, "push target should create a notification")
+	assert.Equal(t, TargetPush, mock.calls[0].target)
 	assert.Equal(t, notification.TypeDetection, mock.calls[0].notifType)
 	assert.Equal(t, "Pigeon detected", mock.calls[0].title)
 	assert.Equal(t, "A pigeon was seen", mock.calls[0].message)
@@ -279,6 +290,7 @@ func TestDispatcher_PushAction_DefaultTemplate(t *testing.T) {
 
 	assert.Empty(t, mock.calls, "push with default template should use keyed variant")
 	require.Len(t, mock.keyCalls, 1)
+	assert.Equal(t, TargetPush, mock.keyCalls[0].target)
 	assert.Equal(t, notification.TypeDetection, mock.keyCalls[0].notifType)
 	assert.Equal(t, MsgAlertDetectionOccurred, mock.keyCalls[0].messageKey)
 }
@@ -308,7 +320,9 @@ func TestDispatcher_BellAndPush_DefaultTemplates_Deduplicated(t *testing.T) {
 	dispatcher.Dispatch(rule, event)
 
 	assert.Empty(t, mock.calls, "deduplicated actions should not produce non-keyed calls")
-	assert.Len(t, mock.keyCalls, 1, "bell+push with identical default templates should deduplicate to one notification")
+	require.Len(t, mock.keyCalls, 2, "bell+push with default templates should dispatch once per target")
+	assert.Equal(t, TargetBell, mock.keyCalls[0].target)
+	assert.Equal(t, TargetPush, mock.keyCalls[1].target)
 }
 
 func TestDispatcher_BellCustom_PushDefault(t *testing.T) {
@@ -336,7 +350,9 @@ func TestDispatcher_BellCustom_PushDefault(t *testing.T) {
 	dispatcher.Dispatch(rule, event)
 
 	require.Len(t, mock.calls, 1, "bell with custom template should dispatch")
+	assert.Equal(t, TargetBell, mock.calls[0].target)
 	require.Len(t, mock.keyCalls, 1, "push with default template should also dispatch")
+	assert.Equal(t, TargetPush, mock.keyCalls[0].target)
 }
 
 func TestDispatcher_BellDefault_PushCustom(t *testing.T) {
@@ -364,7 +380,9 @@ func TestDispatcher_BellDefault_PushCustom(t *testing.T) {
 	dispatcher.Dispatch(rule, event)
 
 	require.Len(t, mock.keyCalls, 1, "bell with default template should dispatch")
+	assert.Equal(t, TargetBell, mock.keyCalls[0].target)
 	require.Len(t, mock.calls, 1, "push with custom template should also dispatch")
+	assert.Equal(t, TargetPush, mock.calls[0].target)
 }
 
 func TestDispatcher_BellAndPush_DifferentTemplates(t *testing.T) {
@@ -684,6 +702,7 @@ func TestDispatchTest_CustomTemplate_UsesTestMethod(t *testing.T) {
 	assert.Empty(t, mock.calls, "DispatchTest should not use CreateAndBroadcast")
 	assert.Empty(t, mock.keyCalls, "DispatchTest should not use CreateAndBroadcastWithKeys")
 	require.Len(t, mock.testCalls, 1)
+	assert.Equal(t, TargetBell, mock.testCalls[0].target)
 	assert.Equal(t, notification.TypeWarning, mock.testCalls[0].notifType, "stream disconnect test should use TypeWarning")
 	assert.Equal(t, "Stream lost", mock.testCalls[0].title)
 	assert.Equal(t, "A stream disconnected", mock.testCalls[0].message)
@@ -838,6 +857,7 @@ func TestDispatchTest_DefaultTemplate_UsesTestKeysMethod(t *testing.T) {
 	assert.Empty(t, mock.keyCalls, "DispatchTest should not use CreateAndBroadcastWithKeys")
 	require.Len(t, mock.testKeyCalls, 1)
 	call := mock.testKeyCalls[0]
+	assert.Equal(t, TargetBell, call.target)
 	assert.Equal(t, notification.TypeDetection, call.notifType, "detection test event should use TypeDetection")
 	assert.Equal(t, MsgAlertFiredTitle, call.titleKey)
 	assert.Equal(t, "New species detected", call.titleParams["rule_name"])

--- a/internal/alerting/init.go
+++ b/internal/alerting/init.go
@@ -18,19 +18,20 @@ import (
 // alerting and notification subsystems.
 type notificationAdapter struct{}
 
-func (a *notificationAdapter) CreateAndBroadcast(notifType notification.Type, title, message string, eventProps map[string]any) error {
+func (a *notificationAdapter) CreateAndBroadcast(target string, notifType notification.Type, title, message string, eventProps map[string]any) error {
 	svc := notification.GetService()
 	if svc == nil {
 		return nil // notification service not yet initialized
 	}
 	title, message = applyDetectionTemplates(notifType, title, message, eventProps)
-	notif := notification.NewNotification(notifType, notification.PriorityHigh, title, message)
+	notif := notification.NewNotification(notifType, notification.PriorityHigh, title, message).
+		WithDeliveryTarget(target)
 	notif = enrichFromEventProps(notif, notifType, eventProps)
 	return svc.CreateWithMetadata(notif)
 }
 
 func (a *notificationAdapter) CreateAndBroadcastWithKeys(
-	notifType notification.Type, title, message, titleKey string, titleParams map[string]any,
+	target string, notifType notification.Type, title, message, titleKey string, titleParams map[string]any,
 	messageKey string, messageParams map[string]any, eventProps map[string]any,
 ) error {
 	svc := notification.GetService()
@@ -39,6 +40,7 @@ func (a *notificationAdapter) CreateAndBroadcastWithKeys(
 	}
 	title, message = applyDetectionTemplates(notifType, title, message, eventProps)
 	notif := notification.NewNotification(notifType, notification.PriorityHigh, title, message).
+		WithDeliveryTarget(target).
 		WithTitleKey(titleKey, titleParams)
 	if messageKey != "" {
 		notif = notif.WithMessageKey(messageKey, messageParams)
@@ -47,18 +49,19 @@ func (a *notificationAdapter) CreateAndBroadcastWithKeys(
 	return svc.CreateWithMetadata(notif)
 }
 
-func (a *notificationAdapter) CreateAndBroadcastTest(notifType notification.Type, title, message string, eventProps map[string]any) error {
+func (a *notificationAdapter) CreateAndBroadcastTest(target string, notifType notification.Type, title, message string, eventProps map[string]any) error {
 	svc := notification.GetService()
 	if svc == nil {
 		return nil // notification service not yet initialized
 	}
-	notif := notification.NewNotification(notifType, notification.PriorityHigh, title, message)
+	notif := notification.NewNotification(notifType, notification.PriorityHigh, title, message).
+		WithDeliveryTarget(target)
 	notif = enrichFromEventProps(notif, notifType, eventProps)
 	return svc.CreateWithMetadata(notif)
 }
 
 func (a *notificationAdapter) CreateAndBroadcastTestWithKeys(
-	notifType notification.Type, title, message, titleKey string, titleParams map[string]any,
+	target string, notifType notification.Type, title, message, titleKey string, titleParams map[string]any,
 	messageKey string, messageParams map[string]any, eventProps map[string]any,
 ) error {
 	svc := notification.GetService()
@@ -66,6 +69,7 @@ func (a *notificationAdapter) CreateAndBroadcastTestWithKeys(
 		return nil // notification service not yet initialized
 	}
 	notif := notification.NewNotification(notifType, notification.PriorityHigh, title, message).
+		WithDeliveryTarget(target).
 		WithTitleKey(titleKey, titleParams)
 	if messageKey != "" {
 		notif = notif.WithMessageKey(messageKey, messageParams)

--- a/internal/notification/push_dispatcher.go
+++ b/internal/notification/push_dispatcher.go
@@ -284,6 +284,12 @@ func (d *pushDispatcher) runDispatchLoop(ctx context.Context, ch <-chan *Notific
 					logger.String("type", string(notif.Type)))
 				continue
 			}
+			if notif.DeliveryTarget == DeliveryTargetBell {
+				d.log.Debug("skipping bell-only notification in dispatch loop",
+					logger.String("operation", "dispatch_loop"),
+					logger.String("notification_id", notif.ID))
+				continue
+			}
 			d.log.Debug("notification received in dispatch loop, dispatching to providers",
 				logger.String("operation", "dispatch_loop"),
 				logger.String("notification_id", notif.ID),
@@ -308,6 +314,13 @@ func (d *pushDispatcher) startHealthChecker(ctx context.Context) {
 }
 
 func (d *pushDispatcher) dispatch(ctx context.Context, notif *Notification) {
+	if notif.DeliveryTarget == DeliveryTargetBell {
+		d.log.Debug("skipping bell-only notification in push dispatch",
+			logger.String("operation", "dispatch"),
+			logger.String("notification_id", notif.ID))
+		return
+	}
+
 	matchedCount := 0
 	for i := range d.providers {
 		ep := &d.providers[i]

--- a/internal/notification/push_dispatcher_test.go
+++ b/internal/notification/push_dispatcher_test.go
@@ -1275,7 +1275,8 @@ func TestIsPrivateOrLocalURL(t *testing.T) {
 	}
 }
 
-func newTestDispatcher(fp *fakeProvider) *pushDispatcher {
+func newTestDispatcher(t *testing.T, fp *fakeProvider) *pushDispatcher {
+	t.Helper()
 	log := logger.NewSlogLogger(nil, logger.LogLevelError, nil)
 	return &pushDispatcher{
 		providers: []enhancedProvider{
@@ -1293,7 +1294,7 @@ func TestPushDispatcher_SkipsBellOnlyNotification(t *testing.T) {
 	t.Parallel()
 
 	fp := newFakeProvider("test-push", true)
-	d := newTestDispatcher(fp)
+	d := newTestDispatcher(t, fp)
 
 	bellNotif := NewNotification(TypeDetection, PriorityHigh, "Bell Only", "Should be skipped").
 		WithDeliveryTarget(DeliveryTargetBell)
@@ -1303,8 +1304,8 @@ func TestPushDispatcher_SkipsBellOnlyNotification(t *testing.T) {
 	select {
 	case <-fp.recvCh:
 		require.Fail(t, "bell-only notification should not reach push provider")
-	case <-time.After(50 * time.Millisecond):
-		// expected: nothing received
+	default:
+		// expected: dispatch returns synchronously for bell-only, nothing received
 	}
 }
 
@@ -1312,7 +1313,7 @@ func TestPushDispatcher_ForwardsPushNotification(t *testing.T) {
 	t.Parallel()
 
 	fp := newFakeProvider("test-push", true)
-	d := newTestDispatcher(fp)
+	d := newTestDispatcher(t, fp)
 
 	pushNotif := NewNotification(TypeDetection, PriorityHigh, "Push Target", "Should be forwarded").
 		WithDeliveryTarget(DeliveryTargetPush)
@@ -1331,7 +1332,7 @@ func TestPushDispatcher_ForwardsNoTargetNotification(t *testing.T) {
 	t.Parallel()
 
 	fp := newFakeProvider("test-push", true)
-	d := newTestDispatcher(fp)
+	d := newTestDispatcher(t, fp)
 
 	notif := NewNotification(TypeDetection, PriorityHigh, "No Target", "Backwards compat")
 

--- a/internal/notification/push_dispatcher_test.go
+++ b/internal/notification/push_dispatcher_test.go
@@ -1275,13 +1275,9 @@ func TestIsPrivateOrLocalURL(t *testing.T) {
 	}
 }
 
-func TestPushDispatcher_SkipsBellOnlyNotification(t *testing.T) {
-	t.Parallel()
-
-	fp := newFakeProvider("test-push", true)
+func newTestDispatcher(fp *fakeProvider) *pushDispatcher {
 	log := logger.NewSlogLogger(nil, logger.LogLevelError, nil)
-
-	d := &pushDispatcher{
+	return &pushDispatcher{
 		providers: []enhancedProvider{
 			{prov: fp, name: fp.name},
 		},
@@ -1291,6 +1287,13 @@ func TestPushDispatcher_SkipsBellOnlyNotification(t *testing.T) {
 		concurrencySem:    semaphore.NewWeighted(defaultMaxConcurrentJobs),
 		errorSuppressor:   NewErrorSuppressor(log, nil),
 	}
+}
+
+func TestPushDispatcher_SkipsBellOnlyNotification(t *testing.T) {
+	t.Parallel()
+
+	fp := newFakeProvider("test-push", true)
+	d := newTestDispatcher(fp)
 
 	bellNotif := NewNotification(TypeDetection, PriorityHigh, "Bell Only", "Should be skipped").
 		WithDeliveryTarget(DeliveryTargetBell)
@@ -1309,18 +1312,7 @@ func TestPushDispatcher_ForwardsPushNotification(t *testing.T) {
 	t.Parallel()
 
 	fp := newFakeProvider("test-push", true)
-	log := logger.NewSlogLogger(nil, logger.LogLevelError, nil)
-
-	d := &pushDispatcher{
-		providers: []enhancedProvider{
-			{prov: fp, name: fp.name},
-		},
-		log:               log,
-		enabled:           true,
-		maxConcurrentJobs: defaultMaxConcurrentJobs,
-		concurrencySem:    semaphore.NewWeighted(defaultMaxConcurrentJobs),
-		errorSuppressor:   NewErrorSuppressor(log, nil),
-	}
+	d := newTestDispatcher(fp)
 
 	pushNotif := NewNotification(TypeDetection, PriorityHigh, "Push Target", "Should be forwarded").
 		WithDeliveryTarget(DeliveryTargetPush)
@@ -1339,18 +1331,7 @@ func TestPushDispatcher_ForwardsNoTargetNotification(t *testing.T) {
 	t.Parallel()
 
 	fp := newFakeProvider("test-push", true)
-	log := logger.NewSlogLogger(nil, logger.LogLevelError, nil)
-
-	d := &pushDispatcher{
-		providers: []enhancedProvider{
-			{prov: fp, name: fp.name},
-		},
-		log:               log,
-		enabled:           true,
-		maxConcurrentJobs: defaultMaxConcurrentJobs,
-		concurrencySem:    semaphore.NewWeighted(defaultMaxConcurrentJobs),
-		errorSuppressor:   NewErrorSuppressor(log, nil),
-	}
+	d := newTestDispatcher(fp)
 
 	notif := NewNotification(TypeDetection, PriorityHigh, "No Target", "Backwards compat")
 

--- a/internal/notification/push_dispatcher_test.go
+++ b/internal/notification/push_dispatcher_test.go
@@ -1274,3 +1274,92 @@ func TestIsPrivateOrLocalURL(t *testing.T) {
 		})
 	}
 }
+
+func TestPushDispatcher_SkipsBellOnlyNotification(t *testing.T) {
+	t.Parallel()
+
+	fp := newFakeProvider("test-push", true)
+	log := logger.NewSlogLogger(nil, logger.LogLevelError, nil)
+
+	d := &pushDispatcher{
+		providers: []enhancedProvider{
+			{prov: fp, name: fp.name},
+		},
+		log:               log,
+		enabled:           true,
+		maxConcurrentJobs: defaultMaxConcurrentJobs,
+		concurrencySem:    semaphore.NewWeighted(defaultMaxConcurrentJobs),
+		errorSuppressor:   NewErrorSuppressor(log, nil),
+	}
+
+	bellNotif := NewNotification(TypeDetection, PriorityHigh, "Bell Only", "Should be skipped").
+		WithDeliveryTarget(DeliveryTargetBell)
+
+	d.dispatch(t.Context(), bellNotif)
+
+	select {
+	case <-fp.recvCh:
+		require.Fail(t, "bell-only notification should not reach push provider")
+	case <-time.After(50 * time.Millisecond):
+		// expected: nothing received
+	}
+}
+
+func TestPushDispatcher_ForwardsPushNotification(t *testing.T) {
+	t.Parallel()
+
+	fp := newFakeProvider("test-push", true)
+	log := logger.NewSlogLogger(nil, logger.LogLevelError, nil)
+
+	d := &pushDispatcher{
+		providers: []enhancedProvider{
+			{prov: fp, name: fp.name},
+		},
+		log:               log,
+		enabled:           true,
+		maxConcurrentJobs: defaultMaxConcurrentJobs,
+		concurrencySem:    semaphore.NewWeighted(defaultMaxConcurrentJobs),
+		errorSuppressor:   NewErrorSuppressor(log, nil),
+	}
+
+	pushNotif := NewNotification(TypeDetection, PriorityHigh, "Push Target", "Should be forwarded").
+		WithDeliveryTarget(DeliveryTargetPush)
+
+	d.dispatch(t.Context(), pushNotif)
+
+	select {
+	case received := <-fp.recvCh:
+		assert.Equal(t, "Push Target", received.Title)
+	case <-time.After(500 * time.Millisecond):
+		require.Fail(t, "push-targeted notification should reach push provider")
+	}
+}
+
+func TestPushDispatcher_ForwardsNoTargetNotification(t *testing.T) {
+	t.Parallel()
+
+	fp := newFakeProvider("test-push", true)
+	log := logger.NewSlogLogger(nil, logger.LogLevelError, nil)
+
+	d := &pushDispatcher{
+		providers: []enhancedProvider{
+			{prov: fp, name: fp.name},
+		},
+		log:               log,
+		enabled:           true,
+		maxConcurrentJobs: defaultMaxConcurrentJobs,
+		concurrencySem:    semaphore.NewWeighted(defaultMaxConcurrentJobs),
+		errorSuppressor:   NewErrorSuppressor(log, nil),
+	}
+
+	notif := NewNotification(TypeDetection, PriorityHigh, "No Target", "Backwards compat")
+
+	d.dispatch(t.Context(), notif)
+
+	select {
+	case received := <-fp.recvCh:
+		assert.Equal(t, "No Target", received.Title)
+	case <-time.After(500 * time.Millisecond):
+		require.Fail(t, "no-target notification should reach push provider (backwards compat)")
+	}
+}

--- a/internal/notification/service_extensions.go
+++ b/internal/notification/service_extensions.go
@@ -52,16 +52,18 @@ func (s *Service) CreateWithMetadata(notification *Notification) error {
 			logger.Int("metadata_keys", len(notification.Metadata)))
 	}
 
-	// Save to store
-	if err := s.store.Save(notification); err != nil {
-		return errors.New(err).
-			Component("notification").
-			Category(errors.CategorySystem).
-			Context("operation", "save_notification").
-			Build()
+	// Save to store unless targeted only at push providers
+	if notification.DeliveryTarget != DeliveryTargetPush {
+		if err := s.store.Save(notification); err != nil {
+			return errors.New(err).
+				Component("notification").
+				Category(errors.CategorySystem).
+				Context("operation", "save_notification").
+				Build()
+		}
 	}
 
-	// Broadcast to subscribers
+	// Always broadcast so push dispatcher can receive push-targeted notifications
 	s.broadcast(notification)
 
 	if s.config.Debug {

--- a/internal/notification/service_extensions_test.go
+++ b/internal/notification/service_extensions_test.go
@@ -261,6 +261,82 @@ func TestService_CreateWithMetadata_WithFailingStore(t *testing.T) {
 	assert.NotEmpty(t, err.Error(), "Error should have a meaningful message")
 }
 
+func TestCreateWithMetadata_PushTarget_SkipsStore(t *testing.T) {
+	t.Parallel()
+
+	service := createTestService()
+
+	notif := NewNotification(TypeDetection, PriorityHigh, "Push Only", "Should not be stored").
+		WithDeliveryTarget(DeliveryTargetPush)
+
+	err := service.CreateWithMetadata(notif)
+	require.NoError(t, err)
+
+	_, err = service.Get(notif.ID)
+	assert.Error(t, err, "push-only notification should not be in store")
+}
+
+func TestCreateWithMetadata_BellTarget_SavesAndBroadcasts(t *testing.T) {
+	t.Parallel()
+
+	service := createTestService()
+	ch, _ := service.Subscribe()
+	defer service.Unsubscribe(ch)
+
+	notif := NewNotification(TypeDetection, PriorityHigh, "Bell Only", "Should be stored").
+		WithDeliveryTarget(DeliveryTargetBell)
+
+	err := service.CreateWithMetadata(notif)
+	require.NoError(t, err)
+
+	stored, err := service.Get(notif.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "Bell Only", stored.Title)
+
+	select {
+	case received := <-ch:
+		assert.Equal(t, notif.ID, received.ID)
+	case <-time.After(100 * time.Millisecond):
+		require.Fail(t, "bell notification should be broadcast")
+	}
+}
+
+func TestCreateWithMetadata_NoTarget_SavesAndBroadcasts(t *testing.T) {
+	t.Parallel()
+
+	service := createTestService()
+
+	notif := NewNotification(TypeInfo, PriorityLow, "Default", "Backwards compat")
+
+	err := service.CreateWithMetadata(notif)
+	require.NoError(t, err)
+
+	stored, err := service.Get(notif.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "Default", stored.Title)
+}
+
+func TestCreateWithMetadata_PushTarget_StillBroadcasts(t *testing.T) {
+	t.Parallel()
+
+	service := createTestService()
+	ch, _ := service.Subscribe()
+	defer service.Unsubscribe(ch)
+
+	notif := NewNotification(TypeDetection, PriorityHigh, "Push Broadcast", "Should reach subscribers").
+		WithDeliveryTarget(DeliveryTargetPush)
+
+	err := service.CreateWithMetadata(notif)
+	require.NoError(t, err)
+
+	select {
+	case received := <-ch:
+		assert.Equal(t, notif.ID, received.ID)
+	case <-time.After(100 * time.Millisecond):
+		require.Fail(t, "push notification should still be broadcast to subscribers")
+	}
+}
+
 // Benchmark for CreateWithMetadata performance
 func BenchmarkService_CreateWithMetadata(b *testing.B) {
 	config := &ServiceConfig{

--- a/internal/notification/service_extensions_test.go
+++ b/internal/notification/service_extensions_test.go
@@ -337,6 +337,39 @@ func TestCreateWithMetadata_PushTarget_StillBroadcasts(t *testing.T) {
 	}
 }
 
+func TestClone_PreservesDeliveryTarget(t *testing.T) {
+	t.Parallel()
+
+	original := NewNotification(TypeDetection, PriorityHigh, "Test", "Clone test").
+		WithDeliveryTarget(DeliveryTargetPush)
+
+	clone := original.Clone()
+
+	assert.Equal(t, DeliveryTargetPush, clone.DeliveryTarget, "Clone must preserve DeliveryTarget")
+}
+
+func TestCreateWithMetadata_PushTarget_BroadcastPreservesTarget(t *testing.T) {
+	t.Parallel()
+
+	service := createTestService()
+	ch, _ := service.Subscribe()
+	defer service.Unsubscribe(ch)
+
+	notif := NewNotification(TypeDetection, PriorityHigh, "Push Via Broadcast", "Should preserve target").
+		WithDeliveryTarget(DeliveryTargetPush)
+
+	err := service.CreateWithMetadata(notif)
+	require.NoError(t, err)
+
+	select {
+	case received := <-ch:
+		assert.Equal(t, DeliveryTargetPush, received.DeliveryTarget,
+			"broadcast must preserve DeliveryTarget through Clone")
+	case <-time.After(100 * time.Millisecond):
+		require.Fail(t, "should have received notification")
+	}
+}
+
 // Benchmark for CreateWithMetadata performance
 func BenchmarkService_CreateWithMetadata(b *testing.B) {
 	config := &ServiceConfig{

--- a/internal/notification/types.go
+++ b/internal/notification/types.go
@@ -236,16 +236,17 @@ func (n *Notification) Clone() *Notification {
 	}
 
 	clone := &Notification{
-		ID:         n.ID,
-		Type:       n.Type,
-		Priority:   n.Priority,
-		Status:     n.Status,
-		Title:      n.Title,
-		Message:    n.Message,
-		Component:  n.Component,
-		Timestamp:  n.Timestamp,
-		TitleKey:   n.TitleKey,
-		MessageKey: n.MessageKey,
+		ID:             n.ID,
+		Type:           n.Type,
+		Priority:       n.Priority,
+		Status:         n.Status,
+		Title:          n.Title,
+		Message:        n.Message,
+		Component:      n.Component,
+		Timestamp:      n.Timestamp,
+		TitleKey:       n.TitleKey,
+		MessageKey:     n.MessageKey,
+		DeliveryTarget: n.DeliveryTarget,
 	}
 
 	// Deep copy ExpiresAt

--- a/internal/notification/types.go
+++ b/internal/notification/types.go
@@ -68,6 +68,13 @@ const (
 	MetadataKeyIsToast = "isToast"
 )
 
+// Delivery target constants control where a notification is routed.
+const (
+	DeliveryTargetAll  = ""     // default: deliver to all channels
+	DeliveryTargetBell = "bell" // in-app notification store only
+	DeliveryTargetPush = "push" // push providers only
+)
+
 // isToastNotification checks if a notification is a toast notification
 // by examining its metadata for the isToast flag
 func isToastNotification(notif *Notification) bool {
@@ -115,6 +122,12 @@ type Notification struct {
 	// MessageParams contains interpolation parameters for the message translation.
 	// Values must be scalar types (string, int, float64, bool) for safe frontend interpolation.
 	MessageParams map[string]any `json:"message_params,omitempty"`
+
+	// DeliveryTarget controls where this notification is delivered.
+	// Empty string means "all channels" (backwards-compatible default).
+	// Set to "bell" for in-app only, "push" for push providers only.
+	// Transient routing field; never serialized or persisted.
+	DeliveryTarget string `json:"-"`
 }
 
 // NewNotification creates a new notification with a unique ID and timestamp
@@ -168,6 +181,12 @@ func (n *Notification) WithTitleKey(key string, params map[string]any) *Notifica
 func (n *Notification) WithMessageKey(key string, params map[string]any) *Notification {
 	n.MessageKey = key
 	n.MessageParams = sanitizeParams(params)
+	return n
+}
+
+// WithDeliveryTarget sets the delivery target and returns the notification for chaining.
+func (n *Notification) WithDeliveryTarget(target string) *Notification {
+	n.DeliveryTarget = target
 	return n
 }
 


### PR DESCRIPTION
## Summary

The alert dispatcher ignored the action Target field ("bell" or "push") and always sent notifications through both channels. A push-only rule still rang the in-app bell; a bell-only rule still reached push providers.

- Add a transient `DeliveryTarget` field to the `Notification` struct (`json:"-"`, never persisted) that controls routing
- Pass the alert action's target through the `NotificationCreator` interface (new `target string` parameter on all 4 methods)
- `CreateWithMetadata` skips the in-memory store save for push-only notifications
- Push dispatcher skips bell-only notifications in both `runDispatchLoop` and `dispatch`
- Change deduplication from global `defaultDispatched` bool to per-target map, so a rule with both bell and push actions using default templates correctly dispatches to both channels
- Copy `DeliveryTarget` in `Clone()` so routing survives the broadcast path

Non-alert notifications (detection consumer, toasts, system) are unaffected: their `DeliveryTarget` defaults to empty, preserving existing behavior.

## Related Issues

Fixes #3134

## Test Plan

- [ ] Verify bell-only rule produces in-app notification but not push
- [ ] Verify push-only rule produces push notification but not bell
- [ ] Verify both-selected rule produces both notifications
- [ ] Verify non-alert notifications (toasts, detection consumer) are unaffected
- [ ] Run `go test -race ./internal/alerting/... ./internal/notification/...` (899 tests pass)
- [ ] Run `golangci-lint run` (zero issues)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added notification delivery targeting (all/bell/push) and a way to set/preserve target on notifications.

* **Bug Fixes**
  * Deduplication now works per delivery target to avoid intra-target duplicates.
  * Bell-only notifications are excluded from push dispatch.
  * Push-only notifications skip persistent storage but are still broadcast.

* **Tests**
  * Added tests covering delivery routing, deduplication, persistence, and cloning of targets.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3136?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->