### PR TITLE
refactor(frontend): extract shared utilities and CollapsibleNavSection

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
   import { onMount } from 'svelte';
+  import Button from './lib/desktop/components/ui/Button.svelte';
+  import LoadingSpinner from './lib/desktop/components/ui/LoadingSpinner.svelte';
   import RootLayout from './lib/desktop/layouts/RootLayout.svelte';
   import DashboardPage from './lib/desktop/features/dashboard/pages/DashboardPage.svelte'; // Keep dashboard for initial load
   import type { Component } from 'svelte';
@@ -563,12 +565,12 @@
 
 <!-- Show loading screen during initialization -->
 {#if appLoading || (!appInitialized && !appError)}
-  <div class="flex h-screen w-full items-center justify-center bg-base-200">
+  <div class="flex h-screen w-full items-center justify-center bg-[var(--color-base-200)]">
     <div class="flex flex-col items-center gap-4">
-      <span class="loading loading-spinner loading-lg text-primary"></span>
-      <p class="text-base-content/70">{t('common.loading')}</p>
+      <LoadingSpinner size="lg" />
+      <p class="text-[var(--color-base-content)]/70">{t('common.loading')}</p>
       {#if appState.retryCount > 0}
-        <p class="text-sm text-warning">
+        <p class="text-sm text-[var(--color-warning)]">
           {t('common.retrying')} ({appState.retryCount}/{MAX_RETRIES})...
         </p>
       {/if}
@@ -576,19 +578,21 @@
   </div>
   <!-- Show fatal error page if initialization failed -->
 {:else if appError}
-  <div class="flex min-h-screen flex-col items-center justify-center bg-base-200 p-4">
-    <div class="card max-w-lg bg-base-100 shadow-xl">
-      <div class="card-body items-center text-center">
-        <div class="mb-4 text-6xl text-error">500</div>
-        <h2 class="card-title text-error">{t('error.server.title')}</h2>
-        <p class="text-base-content/70">{t('error.server.description')}</p>
-        <div class="mt-4 rounded-lg bg-base-200 p-4 text-left">
-          <p class="font-mono text-sm text-error">{appError}</p>
+  <div
+    class="flex min-h-screen flex-col items-center justify-center bg-[var(--color-base-200)] p-4"
+  >
+    <div class="max-w-lg rounded-lg bg-[var(--color-base-100)] shadow-xl">
+      <div class="flex flex-col items-center p-6 text-center">
+        <div class="mb-4 text-6xl text-[var(--color-error)]">500</div>
+        <h2 class="text-xl font-semibold text-[var(--color-error)]">{t('error.server.title')}</h2>
+        <p class="mt-1 text-[var(--color-base-content)]/70">{t('error.server.description')}</p>
+        <div class="mt-4 w-full rounded-lg bg-[var(--color-base-200)] p-4 text-left">
+          <p class="font-mono text-sm text-[var(--color-error)]">{appError}</p>
         </div>
-        <div class="card-actions mt-6">
-          <button class="btn btn-primary" onclick={() => window.location.reload()}>
+        <div class="mt-6">
+          <Button variant="primary" size="md" onclick={() => window.location.reload()}>
             {t('common.retry')}
-          </button>
+          </Button>
         </div>
       </div>
     </div>

--- a/frontend/src/lib/desktop/components/database/DatabaseStatsCard.svelte
+++ b/frontend/src/lib/desktop/components/database/DatabaseStatsCard.svelte
@@ -20,6 +20,7 @@
   import { connectionState } from '$lib/stores/connectionState.svelte';
   import { formatBytes } from '$lib/utils/formatters';
   import { buildAppUrl } from '$lib/utils/urlHelpers';
+  import { downloadBlob } from '$lib/utils/fileHelpers';
   import { Database, Download, X } from '@lucide/svelte';
 
   interface DatabaseStats {
@@ -287,12 +288,7 @@
 
       // Trigger browser download
       const blob = await response.blob();
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = filename;
-      a.click();
-      URL.revokeObjectURL(url);
+      downloadBlob(blob, filename);
 
       // Reset state after successful download
       resetBackupState();

--- a/frontend/src/lib/desktop/features/analytics/pages/Species.svelte
+++ b/frontend/src/lib/desktop/features/analytics/pages/Species.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { t } from '$lib/i18n';
   import { getLocalDateString, parseLocalDateString } from '$lib/utils/date';
+  import { downloadBlob } from '$lib/utils/fileHelpers';
   import { loggers } from '$lib/utils/logger';
   import { buildAppUrl } from '$lib/utils/urlHelpers';
   import { onMount } from 'svelte';
@@ -357,16 +358,7 @@
 
     // Create and download file
     const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
-    const link = document.createElement('a');
-    const url = URL.createObjectURL(blob);
-
-    link.setAttribute('href', url);
-    link.setAttribute('download', `birdnet-species-${getLocalDateString()}.csv`);
-    link.style.visibility = 'hidden';
-
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
+    downloadBlob(blob, `birdnet-species-${getLocalDateString()}.csv`);
   }
 
   let searchDebounce: ReturnType<typeof setTimeout> | undefined;

--- a/frontend/src/lib/desktop/features/settings/pages/AnalysisSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/AnalysisSettingsPage.svelte
@@ -27,6 +27,7 @@
 -->
 <script lang="ts">
   import { onMount } from 'svelte';
+  import { downloadBlob } from '$lib/utils/fileHelpers';
   import type { CatalogEntry, DownloadProgress } from '$lib/types/models';
   import {
     fetchCatalog,
@@ -628,14 +629,7 @@
       }
 
       const blob = await response.blob();
-      const url = window.URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = filename;
-      document.body.appendChild(a);
-      a.click();
-      document.body.removeChild(a);
-      window.URL.revokeObjectURL(url);
+      downloadBlob(blob, filename);
 
       toastActions.success(t('settings.main.sections.rangeFilter.csvDownloaded'));
     } catch (err) {

--- a/frontend/src/lib/desktop/features/settings/pages/NotificationsSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/NotificationsSettingsPage.svelte
@@ -20,6 +20,7 @@
 -->
 <script lang="ts">
   import { onMount } from 'svelte';
+  import { downloadBlob } from '$lib/utils/fileHelpers';
   import Checkbox from '$lib/desktop/components/forms/Checkbox.svelte';
   import TextInput from '$lib/desktop/components/forms/TextInput.svelte';
   import SelectDropdown from '$lib/desktop/components/forms/SelectDropdown.svelte';
@@ -1245,12 +1246,7 @@
     try {
       const data = await exportAlertRules();
       const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = 'alert-rules.json';
-      a.click();
-      URL.revokeObjectURL(url);
+      downloadBlob(blob, 'alert-rules.json');
       showRuleStatus(t('settings.alerts.status.exported'), 'success');
     } catch (err) {
       logger.error('Failed to export rules', err, { component: 'NotificationsSettingsPage' });

--- a/frontend/src/lib/desktop/features/settings/pages/SpeciesSettingsPage.svelte
+++ b/frontend/src/lib/desktop/features/settings/pages/SpeciesSettingsPage.svelte
@@ -27,6 +27,7 @@
 -->
 <script lang="ts">
   import { onMount, onDestroy, untrack, tick } from 'svelte';
+  import { downloadBlob } from '$lib/utils/fileHelpers';
   import SpeciesInput from '$lib/desktop/components/forms/SpeciesInput.svelte';
   import TextInput from '$lib/desktop/components/forms/TextInput.svelte';
   import Checkbox from '$lib/desktop/components/forms/Checkbox.svelte';
@@ -720,12 +721,7 @@
       '\n'
     );
     const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
-    const url = URL.createObjectURL(blob);
-    const link = document.createElement('a');
-    link.href = url;
-    link.download = `active-species-${getLocalDateString()}.csv`;
-    link.click();
-    URL.revokeObjectURL(url);
+    downloadBlob(blob, `active-species-${getLocalDateString()}.csv`);
   }
 
   // Format relative time for last updated

--- a/frontend/src/lib/desktop/layouts/CollapsibleNavSection.svelte
+++ b/frontend/src/lib/desktop/layouts/CollapsibleNavSection.svelte
@@ -1,0 +1,217 @@
+<script lang="ts">
+  import { cn } from '$lib/utils/cn';
+  import { ChevronDown } from '@lucide/svelte';
+  import { flyout } from '$lib/utils/transitions';
+  import type { Component } from 'svelte';
+
+  export interface NavButtonItem {
+    type?: 'button';
+    icon: Component;
+    label: string;
+    url: string;
+    routeKey: string;
+  }
+
+  export interface NavLinkItem {
+    type: 'link';
+    icon: Component;
+    label: string;
+    href: string;
+    ariaLabel?: string;
+    trailingIcon?: Component;
+  }
+
+  export type NavItem = NavButtonItem | NavLinkItem;
+
+  interface Props {
+    icon: Component;
+    label: string;
+    ariaLabel?: string;
+    items: NavItem[];
+    isCollapsed: boolean;
+    expanded: boolean;
+    routeActive: boolean;
+    routeCache: Record<string, boolean>;
+    onToggleExpanded: () => void;
+    onNavigate: (_url: string) => void;
+    showTooltip: (_event: MouseEvent, _text: string) => void;
+    hideTooltip: () => void;
+    activeFlyout: string | null;
+    sectionId: string;
+    onToggleFlyout: (_sectionId: string) => void;
+  }
+
+  let {
+    icon: Icon,
+    label,
+    ariaLabel,
+    items,
+    isCollapsed,
+    expanded,
+    routeActive,
+    routeCache,
+    onToggleExpanded,
+    onNavigate,
+    showTooltip,
+    hideTooltip,
+    activeFlyout,
+    sectionId,
+    onToggleFlyout,
+  }: Props = $props();
+
+  let buttonRef = $state<HTMLButtonElement | null>(null);
+  let flyoutPosition = $state({ top: 0, left: 0 });
+
+  let flyoutOpen = $derived(activeFlyout === sectionId);
+
+  function handleToggleFlyout() {
+    hideTooltip();
+    if (!flyoutOpen && buttonRef) {
+      const rect = buttonRef.getBoundingClientRect();
+      flyoutPosition = {
+        top: rect.top,
+        left: rect.right + 8,
+      };
+    }
+    onToggleFlyout(sectionId);
+  }
+
+  const menuItemBase =
+    'flex items-center gap-2 w-full px-3 py-2 rounded-lg text-sm font-medium transition-colors duration-150';
+  const menuItemCollapsed = 'justify-center';
+  const subitemClass =
+    'flex items-center gap-2 w-full px-3 py-2 rounded-md text-sm transition-colors duration-150';
+</script>
+
+<div class="flex flex-col relative flyout-container">
+  {#if isCollapsed}
+    <!-- Collapsed: Icon with flyout -->
+    <div class="relative">
+      <button
+        bind:this={buttonRef}
+        onclick={handleToggleFlyout}
+        onmouseenter={e => !flyoutOpen && showTooltip(e, label)}
+        onmouseleave={hideTooltip}
+        class={cn(
+          menuItemBase,
+          menuItemCollapsed,
+          routeActive ? 'text-[var(--color-primary)]' : 'text-[var(--color-base-content)]/80',
+          'hover:text-[var(--color-base-content)] hover:menu-hover'
+        )}
+        aria-expanded={flyoutOpen}
+        aria-label={ariaLabel ?? label}
+      >
+        <Icon class="size-5 shrink-0" />
+      </button>
+    </div>
+    <!-- Flyout submenu (fixed positioning to escape overflow container) -->
+    {#if flyoutOpen}
+      <div
+        in:flyout
+        out:flyout={{ duration: 100 }}
+        class="fixed bg-[var(--color-base-100)] border border-[var(--color-base-200)] rounded-lg shadow-xl min-w-48 z-[100]"
+        style:top="{flyoutPosition.top}px"
+        style:left="{flyoutPosition.left}px"
+      >
+        <div
+          class="px-3 py-2 border-b border-[var(--color-base-200)] font-medium text-sm text-[var(--color-base-content)]"
+        >
+          {label}
+        </div>
+        <div class="p-1 max-h-[calc(100vh-8rem)] overflow-y-auto">
+          {#each items as item (item.type === 'link' ? item.label : item.routeKey)}
+            {#if item.type === 'link'}
+              <a
+                href={item.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                class={cn(
+                  subitemClass,
+                  'text-[var(--color-base-content)]/80 hover:text-[var(--color-base-content)] hover:menu-hover'
+                )}
+                aria-label={item.ariaLabel}
+              >
+                <item.icon class="size-4 shrink-0" />
+                {item.label}
+                {#if item.trailingIcon}
+                  <item.trailingIcon class="size-3 opacity-40 ml-auto" />
+                {/if}
+              </a>
+            {:else}
+              <button
+                onclick={() => onNavigate(item.url)}
+                class={cn(
+                  subitemClass,
+                  routeCache[item.routeKey]
+                    ? 'menu-subitem-active'
+                    : 'text-[var(--color-base-content)]/80 hover:text-[var(--color-base-content)] hover:menu-hover'
+                )}
+              >
+                <item.icon class="size-4 shrink-0" />{item.label}
+              </button>
+            {/if}
+          {/each}
+        </div>
+      </div>
+    {/if}
+  {:else}
+    <!-- Expanded: Regular collapsible -->
+    <button
+      onclick={onToggleExpanded}
+      class={cn(
+        menuItemBase,
+        routeActive ? 'text-[var(--color-primary)]' : 'text-[var(--color-base-content)]/80',
+        'hover:text-[var(--color-base-content)] hover:menu-hover'
+      )}
+      aria-expanded={expanded}
+    >
+      <Icon class="size-5 shrink-0" />
+      <span class="flex-1">{label}</span>
+      <ChevronDown
+        class={cn('size-4 shrink-0 transition-transform duration-200', {
+          'rotate-180': expanded,
+        })}
+      />
+    </button>
+
+    {#if expanded}
+      <div
+        class="ml-4 pl-4 border-l-2 mt-1 flex flex-col gap-0.5"
+        style:border-color="color-mix(in oklch, var(--color-primary) 30%, transparent)"
+      >
+        {#each items as item (item.type === 'link' ? item.label : item.routeKey)}
+          {#if item.type === 'link'}
+            <a
+              href={item.href}
+              target="_blank"
+              rel="noopener noreferrer"
+              class={cn(
+                subitemClass,
+                'text-[var(--color-base-content)]/80 hover:text-[var(--color-base-content)] hover:menu-hover'
+              )}
+              aria-label={item.ariaLabel}
+            >
+              <item.icon class="size-4 shrink-0" />
+              {item.label}
+              {#if item.trailingIcon}
+                <item.trailingIcon class="size-3 opacity-40 ml-auto" />
+              {/if}
+            </a>
+          {:else}
+            <button
+              onclick={() => onNavigate(item.url)}
+              class={cn(
+                subitemClass,
+                routeCache[item.routeKey]
+                  ? 'menu-subitem-active'
+                  : 'text-[var(--color-base-content)]/80 hover:text-[var(--color-base-content)] hover:menu-hover'
+              )}
+            >
+              <item.icon class="size-4 shrink-0" />{item.label}
+            </button>
+          {/if}
+        {/each}
+      </div>
+    {/if}
+  {/if}
+</div>

--- a/frontend/src/lib/desktop/layouts/DesktopSidebar.svelte
+++ b/frontend/src/lib/desktop/layouts/DesktopSidebar.svelte
@@ -54,7 +54,6 @@ Performance Optimizations:
     Settings,
     LogOut,
     LogIn,
-    ChevronDown,
     ChevronsLeft,
     ChevronsRight,
     LineChart,
@@ -78,8 +77,9 @@ Performance Optimizations:
     ExternalLink,
     Activity,
   } from '@lucide/svelte';
-  import { flyout } from '$lib/utils/transitions';
   import { t } from '$lib/i18n';
+  import CollapsibleNavSection from './CollapsibleNavSection.svelte';
+  import type { NavItem } from './CollapsibleNavSection.svelte';
   import { GITHUB_REPO_URL, GITHUB_DISCUSSIONS_URL } from '$lib/utils/externalUrls';
   import { hasLiveAudioAccess } from '$lib/stores/appState.svelte';
   import { resetDateToToday } from '$lib/utils/datePersistence';
@@ -125,17 +125,8 @@ Performance Optimizations:
   let systemExpanded = $state(false);
   let helpExpanded = $state(false);
 
-  // Flyout state for collapsed mode
-  let analyticsFlyoutOpen = $state(false);
-  let settingsFlyoutOpen = $state(false);
-  let systemFlyoutOpen = $state(false);
-  let helpFlyoutOpen = $state(false);
-
-  // Flyout position (for fixed positioning to escape overflow container)
-  let analyticsFlyoutPosition = $state({ top: 0, left: 0 });
-  let settingsFlyoutPosition = $state({ top: 0, left: 0 });
-  let systemFlyoutPosition = $state({ top: 0, left: 0 });
-  let helpFlyoutPosition = $state({ top: 0, left: 0 });
+  // Single flyout state (mutual exclusion built-in)
+  let activeFlyout = $state<string | null>(null);
 
   // Tooltip state for fixed positioning (escapes overflow containers)
   let tooltipText = $state('');
@@ -159,71 +150,8 @@ Performance Optimizations:
     tooltipVisible = false;
   }
 
-  // Button refs for position calculation
-  let analyticsButtonRef = $state<HTMLButtonElement | null>(null);
-  let settingsButtonRef = $state<HTMLButtonElement | null>(null);
-  let systemButtonRef = $state<HTMLButtonElement | null>(null);
-  let helpButtonRef = $state<HTMLButtonElement | null>(null);
-
-  // Toggle flyout with position calculation
-  function toggleAnalyticsFlyout() {
-    hideTooltip(); // Hide tooltip when opening flyout
-    if (!analyticsFlyoutOpen && analyticsButtonRef) {
-      const rect = analyticsButtonRef.getBoundingClientRect();
-      analyticsFlyoutPosition = {
-        top: rect.top,
-        left: rect.right + 8, // 8px gap (ml-2)
-      };
-    }
-    analyticsFlyoutOpen = !analyticsFlyoutOpen;
-    settingsFlyoutOpen = false;
-    systemFlyoutOpen = false;
-    helpFlyoutOpen = false;
-  }
-
-  function toggleSettingsFlyout() {
-    hideTooltip(); // Hide tooltip when opening flyout
-    if (!settingsFlyoutOpen && settingsButtonRef) {
-      const rect = settingsButtonRef.getBoundingClientRect();
-      settingsFlyoutPosition = {
-        top: rect.top,
-        left: rect.right + 8, // 8px gap (ml-2)
-      };
-    }
-    settingsFlyoutOpen = !settingsFlyoutOpen;
-    analyticsFlyoutOpen = false;
-    systemFlyoutOpen = false;
-    helpFlyoutOpen = false;
-  }
-
-  function toggleSystemFlyout() {
-    hideTooltip(); // Hide tooltip when opening flyout
-    if (!systemFlyoutOpen && systemButtonRef) {
-      const rect = systemButtonRef.getBoundingClientRect();
-      systemFlyoutPosition = {
-        top: rect.top,
-        left: rect.right + 8, // 8px gap (ml-2)
-      };
-    }
-    systemFlyoutOpen = !systemFlyoutOpen;
-    analyticsFlyoutOpen = false;
-    settingsFlyoutOpen = false;
-    helpFlyoutOpen = false;
-  }
-
-  function toggleHelpFlyout() {
-    hideTooltip();
-    if (!helpFlyoutOpen && helpButtonRef) {
-      const rect = helpButtonRef.getBoundingClientRect();
-      helpFlyoutPosition = {
-        top: rect.top,
-        left: rect.right + 8,
-      };
-    }
-    helpFlyoutOpen = !helpFlyoutOpen;
-    analyticsFlyoutOpen = false;
-    settingsFlyoutOpen = false;
-    systemFlyoutOpen = false;
+  function toggleFlyout(sectionId: string) {
+    activeFlyout = activeFlyout === sectionId ? null : sectionId;
   }
 
   // Get collapsed state from store (using $ prefix for auto-subscription)
@@ -278,10 +206,7 @@ Performance Optimizations:
   function handleClickOutside(event: MouseEvent) {
     const target = event.target as HTMLElement;
     if (!target.closest('.flyout-container')) {
-      analyticsFlyoutOpen = false;
-      settingsFlyoutOpen = false;
-      systemFlyoutOpen = false;
-      helpFlyoutOpen = false;
+      activeFlyout = null;
     }
   }
 
@@ -312,15 +237,147 @@ Performance Optimizations:
     settingsUserInterface: onNavigate ? '/settings/userinterface' : '/ui/settings/userinterface',
   });
 
+  // Nav item definitions for collapsible sections
+  let analyticsItems: NavItem[] = $derived([
+    {
+      icon: LineChart,
+      label: t('analytics.title'),
+      url: navigationUrls.analytics,
+      routeKey: 'analyticsExact',
+    },
+    {
+      icon: Bird,
+      label: t('analytics.species.title'),
+      url: navigationUrls.analyticsSpecies,
+      routeKey: 'analyticsSpecies',
+    },
+    {
+      icon: TrendingUp,
+      label: t('analytics.advanced.title'),
+      url: navigationUrls.analyticsAdvanced,
+      routeKey: 'analyticsAdvanced',
+    },
+  ]);
+
+  let systemItems: NavItem[] = $derived([
+    {
+      icon: Monitor,
+      label: t('system.sections.overview'),
+      url: navigationUrls.systemOverview,
+      routeKey: 'systemOverview',
+    },
+    {
+      icon: Database,
+      label: t('system.sections.database'),
+      url: navigationUrls.systemDatabase,
+      routeKey: 'systemDatabase',
+    },
+    {
+      icon: Terminal,
+      label: t('system.sections.terminal'),
+      url: navigationUrls.systemTerminal,
+      routeKey: 'systemTerminal',
+    },
+    {
+      icon: Activity,
+      label: t('navigation.health'),
+      url: navigationUrls.systemHealth,
+      routeKey: 'systemHealth',
+    },
+  ]);
+
+  let helpItems: NavItem[] = $derived([
+    {
+      icon: LifeBuoy,
+      label: t('navigation.helpAndSupport'),
+      url: navigationUrls.help,
+      routeKey: 'helpExact',
+    },
+    {
+      icon: Bug,
+      label: t('navigation.reportBug'),
+      url: navigationUrls.helpReportBug,
+      routeKey: 'helpReportBug',
+    },
+    {
+      type: 'link',
+      icon: MessageCircleQuestion,
+      label: t('navigation.askQuestion'),
+      href: GITHUB_DISCUSSIONS_URL,
+      ariaLabel: t('navigation.askQuestionAriaLabel'),
+      trailingIcon: ExternalLink,
+    },
+  ]);
+
+  let settingsItems: NavItem[] = $derived([
+    {
+      icon: SlidersHorizontal,
+      label: t('settings.sections.node'),
+      url: navigationUrls.settingsMain,
+      routeKey: 'settingsMain',
+    },
+    {
+      icon: Paintbrush,
+      label: t('settings.sections.userinterface'),
+      url: navigationUrls.settingsUserInterface,
+      routeKey: 'settingsUserInterface',
+    },
+    {
+      icon: Volume2,
+      label: t('settings.sections.audio'),
+      url: navigationUrls.settingsAudio,
+      routeKey: 'settingsAudio',
+    },
+    {
+      icon: Brain,
+      label: t('settings.sections.analysis'),
+      url: navigationUrls.settingsAnalysis,
+      routeKey: 'settingsAnalysis',
+    },
+    {
+      icon: Bird,
+      label: t('settings.sections.species'),
+      url: navigationUrls.settingsSpecies,
+      routeKey: 'settingsSpecies',
+    },
+    {
+      icon: Filter,
+      label: t('settings.sections.filters'),
+      url: navigationUrls.settingsFilters,
+      routeKey: 'settingsFilters',
+    },
+    {
+      icon: Bell,
+      label: t('settings.sections.notifications'),
+      url: navigationUrls.settingsNotifications,
+      routeKey: 'settingsNotifications',
+    },
+    {
+      icon: Puzzle,
+      label: t('settings.sections.integration'),
+      url: navigationUrls.settingsIntegrations,
+      routeKey: 'settingsIntegrations',
+    },
+    {
+      icon: Shield,
+      label: t('settings.sections.security'),
+      url: navigationUrls.settingsSecurity,
+      routeKey: 'settingsSecurity',
+    },
+    {
+      icon: LifeBuoy,
+      label: t('settings.sections.support'),
+      url: navigationUrls.settingsSupport,
+      routeKey: 'settingsSupport',
+    },
+  ]);
+
   function navigate(url: string) {
     if (url === navigationUrls.dashboard) {
       resetDateToToday();
     }
     // Close flyouts on navigation
-    analyticsFlyoutOpen = false;
-    settingsFlyoutOpen = false;
-    systemFlyoutOpen = false;
-    helpFlyoutOpen = false;
+    activeFlyout = null;
     // Close the mobile drawer on navigation by unchecking the toggle.
     // Dispatch a synthetic event so Svelte's bind:checked stays in sync.
     const drawer = document.getElementById('my-drawer') as HTMLInputElement | null;
@@ -487,145 +544,23 @@ Performance Optimizations:
         {/if}
 
         <!-- Analytics (Collapsible) -->
-        <div class="flex flex-col relative flyout-container">
-          {#if isCollapsed}
-            <!-- Collapsed: Icon with flyout -->
-            <div class="relative">
-              <button
-                bind:this={analyticsButtonRef}
-                onclick={toggleAnalyticsFlyout}
-                onmouseenter={e =>
-                  !analyticsFlyoutOpen && showTooltip(e, t('navigation.analytics'))}
-                onmouseleave={hideTooltip}
-                class={cn(
-                  menuItemBase,
-                  menuItemCollapsed,
-                  routeCache.analytics
-                    ? 'text-[var(--color-primary)]'
-                    : 'text-[var(--color-base-content)]/80',
-                  'hover:text-[var(--color-base-content)] hover:menu-hover'
-                )}
-                aria-expanded={analyticsFlyoutOpen}
-                aria-label={t('navigation.analyticsSubmenu')}
-              >
-                <BarChart3 class="size-5 shrink-0" />
-              </button>
-            </div>
-            <!-- Flyout submenu (fixed positioning to escape overflow container) -->
-            {#if analyticsFlyoutOpen}
-              <div
-                in:flyout
-                out:flyout={{ duration: 100 }}
-                class="fixed bg-[var(--color-base-100)] border border-[var(--color-base-200)] rounded-lg shadow-xl min-w-48 z-[100]"
-                style:top="{analyticsFlyoutPosition.top}px"
-                style:left="{analyticsFlyoutPosition.left}px"
-              >
-                <div
-                  class="px-3 py-2 border-b border-[var(--color-base-200)] font-medium text-sm text-[var(--color-base-content)]"
-                >
-                  {t('navigation.analytics')}
-                </div>
-                <div class="p-1 max-h-[calc(100vh-8rem)] overflow-y-auto">
-                  <button
-                    onclick={() => navigate(navigationUrls.analytics)}
-                    class={cn(
-                      'flex items-center gap-2 w-full px-3 py-2 rounded-md text-sm transition-colors duration-150',
-                      routeCache.analyticsExact
-                        ? 'menu-subitem-active'
-                        : 'text-[var(--color-base-content)]/80 hover:text-[var(--color-base-content)] hover:menu-hover'
-                    )}
-                  >
-                    <LineChart class="size-4 shrink-0" />{t('analytics.title')}
-                  </button>
-                  <button
-                    onclick={() => navigate(navigationUrls.analyticsSpecies)}
-                    class={cn(
-                      'flex items-center gap-2 w-full px-3 py-2 rounded-md text-sm transition-colors duration-150',
-                      routeCache.analyticsSpecies
-                        ? 'menu-subitem-active'
-                        : 'text-[var(--color-base-content)]/80 hover:text-[var(--color-base-content)] hover:menu-hover'
-                    )}
-                  >
-                    <Bird class="size-4 shrink-0" />{t('analytics.species.title')}
-                  </button>
-                  <button
-                    onclick={() => navigate(navigationUrls.analyticsAdvanced)}
-                    class={cn(
-                      'flex items-center gap-2 w-full px-3 py-2 rounded-md text-sm transition-colors duration-150',
-                      routeCache.analyticsAdvanced
-                        ? 'menu-subitem-active'
-                        : 'text-[var(--color-base-content)]/80 hover:text-[var(--color-base-content)] hover:menu-hover'
-                    )}
-                  >
-                    <TrendingUp class="size-4 shrink-0" />{t('analytics.advanced.title')}
-                  </button>
-                </div>
-              </div>
-            {/if}
-          {:else}
-            <!-- Expanded: Regular collapsible -->
-            <button
-              onclick={() => (analyticsExpanded = !analyticsExpanded)}
-              class={cn(
-                menuItemBase,
-                routeCache.analytics
-                  ? 'text-[var(--color-primary)]'
-                  : 'text-[var(--color-base-content)]/80',
-                'hover:text-[var(--color-base-content)] hover:menu-hover'
-              )}
-              aria-expanded={analyticsExpanded}
-            >
-              <BarChart3 class="size-5 shrink-0" />
-              <span class="flex-1">{t('navigation.analytics')}</span>
-              <ChevronDown
-                class={cn('size-4 shrink-0 transition-transform duration-200', {
-                  'rotate-180': analyticsExpanded,
-                })}
-              />
-            </button>
-
-            {#if analyticsExpanded}
-              <div
-                class="ml-4 pl-4 border-l-2 border-[var(--color-primary)] mt-1 flex flex-col gap-0.5"
-                style:border-color="color-mix(in oklch, var(--color-primary) 30%, transparent)"
-              >
-                <button
-                  onclick={() => navigate(navigationUrls.analytics)}
-                  class={cn(
-                    'flex items-center gap-2 px-3 py-2 rounded-md text-sm transition-colors duration-150',
-                    routeCache.analyticsExact
-                      ? 'menu-subitem-active'
-                      : 'text-[var(--color-base-content)]/80 hover:text-[var(--color-base-content)] hover:menu-hover'
-                  )}
-                >
-                  <LineChart class="size-4 shrink-0" />{t('analytics.title')}
-                </button>
-                <button
-                  onclick={() => navigate(navigationUrls.analyticsSpecies)}
-                  class={cn(
-                    'flex items-center gap-2 px-3 py-2 rounded-md text-sm transition-colors duration-150',
-                    routeCache.analyticsSpecies
-                      ? 'menu-subitem-active'
-                      : 'text-[var(--color-base-content)]/80 hover:text-[var(--color-base-content)] hover:menu-hover'
-                  )}
-                >
-                  <Bird class="size-4 shrink-0" />{t('analytics.species.title')}
-                </button>
-                <button
-                  onclick={() => navigate(navigationUrls.analyticsAdvanced)}
-                  class={cn(
-                    'flex items-center gap-2 px-3 py-2 rounded-md text-sm transition-colors duration-150',
-                    routeCache.analyticsAdvanced
-                      ? 'menu-subitem-active'
-                      : 'text-[var(--color-base-content)]/80 hover:text-[var(--color-base-content)] hover:menu-hover'
-                  )}
-                >
-                  <TrendingUp class="size-4 shrink-0" />{t('analytics.advanced.title')}
-                </button>
-              </div>
-            {/if}
-          {/if}
-        </div>
+        <CollapsibleNavSection
+          icon={BarChart3}
+          label={t('navigation.analytics')}
+          ariaLabel={t('navigation.analyticsSubmenu')}
+          items={analyticsItems}
+          {isCollapsed}
+          expanded={analyticsExpanded}
+          routeActive={routeCache.analytics}
+          {routeCache}
+          onToggleExpanded={() => (analyticsExpanded = !analyticsExpanded)}
+          onNavigate={navigate}
+          {showTooltip}
+          {hideTooltip}
+          {activeFlyout}
+          sectionId="analytics"
+          onToggleFlyout={toggleFlyout}
+        />
 
         <!-- Search -->
         <div class="relative">
@@ -672,603 +607,61 @@ Performance Optimizations:
           <div class="my-2 border-t border-[var(--color-base-200)]/50"></div>
 
           <!-- System (Collapsible) -->
-          <div class="flex flex-col relative flyout-container">
-            {#if isCollapsed}
-              <!-- Collapsed: Icon with flyout -->
-              <div class="relative">
-                <button
-                  bind:this={systemButtonRef}
-                  onclick={toggleSystemFlyout}
-                  onmouseenter={e => !systemFlyoutOpen && showTooltip(e, t('navigation.system'))}
-                  onmouseleave={hideTooltip}
-                  class={cn(
-                    menuItemBase,
-                    menuItemCollapsed,
-                    routeCache.system
-                      ? 'text-[var(--color-primary)]'
-                      : 'text-[var(--color-base-content)]/80',
-                    'hover:text-[var(--color-base-content)] hover:menu-hover'
-                  )}
-                  aria-expanded={systemFlyoutOpen}
-                  aria-label={t('navigation.systemSubmenu')}
-                >
-                  <Cpu class="size-5 shrink-0" />
-                </button>
-              </div>
-              <!-- Flyout submenu (fixed positioning to escape overflow container) -->
-              {#if systemFlyoutOpen}
-                <div
-                  in:flyout
-                  out:flyout={{ duration: 100 }}
-                  class="fixed bg-[var(--color-base-100)] border border-[var(--color-base-200)] rounded-lg shadow-xl min-w-48 z-[100]"
-                  style:top="{systemFlyoutPosition.top}px"
-                  style:left="{systemFlyoutPosition.left}px"
-                >
-                  <div
-                    class="px-3 py-2 border-b border-[var(--color-base-200)] font-medium text-sm text-[var(--color-base-content)]"
-                  >
-                    {t('navigation.system')}
-                  </div>
-                  <div class="p-1 max-h-[calc(100vh-8rem)] overflow-y-auto">
-                    <button
-                      onclick={() => navigate(navigationUrls.systemOverview)}
-                      class={cn(
-                        'flex items-center gap-2 w-full px-3 py-2 rounded-md text-sm transition-colors duration-150',
-                        routeCache.systemOverview
-                          ? 'menu-subitem-active'
-                          : 'text-[var(--color-base-content)]/80 hover:text-[var(--color-base-content)] hover:menu-hover'
-                      )}
-                    >
-                      <Monitor class="size-4 shrink-0" />{t('system.sections.overview')}
-                    </button>
-                    <button
-                      onclick={() => navigate(navigationUrls.systemDatabase)}
-                      class={cn(
-                        'flex items-center gap-2 w-full px-3 py-2 rounded-md text-sm transition-colors duration-150',
-                        routeCache.systemDatabase
-                          ? 'menu-subitem-active'
-                          : 'text-[var(--color-base-content)]/80 hover:text-[var(--color-base-content)] hover:menu-hover'
-                      )}
-                    >
-                      <Database class="size-4 shrink-0" />{t('system.sections.database')}
-                    </button>
-                    <button
-                      onclick={() => navigate(navigationUrls.systemTerminal)}
-                      class={cn(
-                        'flex items-center gap-2 w-full px-3 py-2 rounded-md text-sm transition-colors duration-150',
-                        routeCache.systemTerminal
-                          ? 'menu-subitem-active'
-                          : 'text-[var(--color-base-content)]/80 hover:text-[var(--color-base-content)] hover:menu-hover'
-                      )}
-                    >
-                      <Terminal class="size-4 shrink-0" />{t('system.sections.terminal')}
-                    </button>
-                    <button
-                      onclick={() => navigate(navigationUrls.systemHealth)}
-                      class={cn(
-                        'flex items-center gap-2 w-full px-3 py-2 rounded-md text-sm transition-colors duration-150',
-                        routeCache.systemHealth
-                          ? 'menu-subitem-active'
-                          : 'text-[var(--color-base-content)]/80 hover:text-[var(--color-base-content)] hover:menu-hover'
-                      )}
-                    >
-                      <Activity class="size-4 shrink-0" />{t('navigation.health')}
-                    </button>
-                  </div>
-                </div>
-              {/if}
-            {:else}
-              <!-- Expanded: Regular collapsible -->
-              <button
-                onclick={() => (systemExpanded = !systemExpanded)}
-                class={cn(
-                  menuItemBase,
-                  routeCache.system
-                    ? 'text-[var(--color-primary)]'
-                    : 'text-[var(--color-base-content)]/80',
-                  'hover:text-[var(--color-base-content)] hover:menu-hover'
-                )}
-                aria-expanded={systemExpanded}
-              >
-                <Cpu class="size-5 shrink-0" />
-                <span class="flex-1">{t('navigation.system')}</span>
-                <ChevronDown
-                  class={cn('size-4 shrink-0 transition-transform duration-200', {
-                    'rotate-180': systemExpanded,
-                  })}
-                />
-              </button>
-
-              {#if systemExpanded}
-                <div
-                  class="ml-4 pl-4 border-l-2 border-[var(--color-primary)] mt-1 flex flex-col gap-0.5"
-                  style:border-color="color-mix(in oklch, var(--color-primary) 30%, transparent)"
-                >
-                  <button
-                    onclick={() => navigate(navigationUrls.systemOverview)}
-                    class={cn(
-                      'flex items-center gap-2 px-3 py-2 rounded-md text-sm transition-colors duration-150',
-                      routeCache.systemOverview
-                        ? 'menu-subitem-active'
-                        : 'text-[var(--color-base-content)]/80 hover:text-[var(--color-base-content)] hover:menu-hover'
-                    )}
-                  >
-                    <Monitor class="size-4 shrink-0" />{t('system.sections.overview')}
-                  </button>
-                  <button
-                    onclick={() => navigate(navigationUrls.systemDatabase)}
-                    class={cn(
-                      'flex items-center gap-2 px-3 py-2 rounded-md text-sm transition-colors duration-150',
-                      routeCache.systemDatabase
-                        ? 'menu-subitem-active'
-                        : 'text-[var(--color-base-content)]/80 hover:text-[var(--color-base-content)] hover:menu-hover'
-                    )}
-                  >
-                    <Database class="size-4 shrink-0" />{t('system.sections.database')}
-                  </button>
-                  <button
-                    onclick={() => navigate(navigationUrls.systemTerminal)}
-                    class={cn(
-                      'flex items-center gap-2 px-3 py-2 rounded-md text-sm transition-colors duration-150',
-                      routeCache.systemTerminal
-                        ? 'menu-subitem-active'
-                        : 'text-[var(--color-base-content)]/80 hover:text-[var(--color-base-content)] hover:menu-hover'
-                    )}
-                  >
-                    <Terminal class="size-4 shrink-0" />{t('system.sections.terminal')}
-                  </button>
-                  <button
-                    onclick={() => navigate(navigationUrls.systemHealth)}
-                    class={cn(
-                      'flex items-center gap-2 px-3 py-2 rounded-md text-sm transition-colors duration-150',
-                      routeCache.systemHealth
-                        ? 'menu-subitem-active'
-                        : 'text-[var(--color-base-content)]/80 hover:text-[var(--color-base-content)] hover:menu-hover'
-                    )}
-                  >
-                    <Activity class="size-4 shrink-0" />{t('navigation.health')}
-                  </button>
-                </div>
-              {/if}
-            {/if}
-          </div>
+          <CollapsibleNavSection
+            icon={Cpu}
+            label={t('navigation.system')}
+            ariaLabel={t('navigation.systemSubmenu')}
+            items={systemItems}
+            {isCollapsed}
+            expanded={systemExpanded}
+            routeActive={routeCache.system}
+            {routeCache}
+            onToggleExpanded={() => (systemExpanded = !systemExpanded)}
+            onNavigate={navigate}
+            {showTooltip}
+            {hideTooltip}
+            {activeFlyout}
+            sectionId="system"
+            onToggleFlyout={toggleFlyout}
+          />
 
           <!-- Help (Collapsible) -->
-          <div class="flex flex-col relative flyout-container">
-            {#if isCollapsed}
-              <!-- Collapsed: Icon with flyout -->
-              <div class="relative">
-                <button
-                  bind:this={helpButtonRef}
-                  onclick={toggleHelpFlyout}
-                  onmouseenter={e => !helpFlyoutOpen && showTooltip(e, t('navigation.help'))}
-                  onmouseleave={hideTooltip}
-                  class={cn(
-                    menuItemBase,
-                    menuItemCollapsed,
-                    routeCache.help
-                      ? 'text-[var(--color-primary)]'
-                      : 'text-[var(--color-base-content)]/80',
-                    'hover:text-[var(--color-base-content)] hover:menu-hover'
-                  )}
-                  aria-expanded={helpFlyoutOpen}
-                  aria-label={t('navigation.helpSubmenu')}
-                >
-                  <CircleHelp class="size-5 shrink-0" />
-                </button>
-              </div>
-              <!-- Flyout submenu -->
-              {#if helpFlyoutOpen}
-                <div
-                  in:flyout
-                  out:flyout={{ duration: 100 }}
-                  class="fixed bg-[var(--color-base-100)] border border-[var(--color-base-200)] rounded-lg shadow-xl min-w-48 z-[100]"
-                  style:top="{helpFlyoutPosition.top}px"
-                  style:left="{helpFlyoutPosition.left}px"
-                >
-                  <div
-                    class="px-3 py-2 border-b border-[var(--color-base-200)] font-medium text-sm text-[var(--color-base-content)]"
-                  >
-                    {t('navigation.help')}
-                  </div>
-                  <div class="p-1 max-h-[calc(100vh-8rem)] overflow-y-auto">
-                    <button
-                      onclick={() => navigate(navigationUrls.help)}
-                      class={cn(
-                        'flex items-center gap-2 w-full px-3 py-2 rounded-md text-sm transition-colors duration-150',
-                        routeCache.helpExact
-                          ? 'menu-subitem-active'
-                          : 'text-[var(--color-base-content)]/80 hover:text-[var(--color-base-content)] hover:menu-hover'
-                      )}
-                    >
-                      <LifeBuoy class="size-4 shrink-0" />{t('navigation.helpAndSupport')}
-                    </button>
-                    <button
-                      onclick={() => navigate(navigationUrls.helpReportBug)}
-                      class={cn(
-                        'flex items-center gap-2 w-full px-3 py-2 rounded-md text-sm transition-colors duration-150',
-                        routeCache.helpReportBug
-                          ? 'menu-subitem-active'
-                          : 'text-[var(--color-base-content)]/80 hover:text-[var(--color-base-content)] hover:menu-hover'
-                      )}
-                    >
-                      <Bug class="size-4 shrink-0" />
-                      {t('navigation.reportBug')}
-                    </button>
-                    <a
-                      href={GITHUB_DISCUSSIONS_URL}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      class="flex items-center gap-2 w-full px-3 py-2 rounded-md text-sm transition-colors duration-150 text-[var(--color-base-content)]/80 hover:text-[var(--color-base-content)] hover:menu-hover"
-                      aria-label={t('navigation.askQuestionAriaLabel')}
-                    >
-                      <MessageCircleQuestion class="size-4 shrink-0" />
-                      {t('navigation.askQuestion')}
-                      <ExternalLink class="size-3 opacity-40 ml-auto" />
-                    </a>
-                  </div>
-                </div>
-              {/if}
-            {:else}
-              <!-- Expanded: Regular collapsible -->
-              <button
-                onclick={() => (helpExpanded = !helpExpanded)}
-                class={cn(
-                  menuItemBase,
-                  routeCache.help
-                    ? 'text-[var(--color-primary)]'
-                    : 'text-[var(--color-base-content)]/80',
-                  'hover:text-[var(--color-base-content)] hover:menu-hover'
-                )}
-                aria-expanded={helpExpanded}
-              >
-                <CircleHelp class="size-5 shrink-0" />
-                <span class="flex-1">{t('navigation.help')}</span>
-                <ChevronDown
-                  class={cn('size-4 shrink-0 transition-transform duration-200', {
-                    'rotate-180': helpExpanded,
-                  })}
-                />
-              </button>
-
-              {#if helpExpanded}
-                <div
-                  class="ml-4 pl-4 border-l-2 mt-1 flex flex-col gap-0.5"
-                  style:border-color="color-mix(in oklch, var(--color-primary) 30%, transparent)"
-                >
-                  <button
-                    onclick={() => navigate(navigationUrls.help)}
-                    class={cn(
-                      'flex items-center gap-2 px-3 py-2 rounded-md text-sm transition-colors duration-150',
-                      routeCache.helpExact
-                        ? 'menu-subitem-active'
-                        : 'text-[var(--color-base-content)]/80 hover:text-[var(--color-base-content)] hover:menu-hover'
-                    )}
-                  >
-                    <LifeBuoy class="size-4 shrink-0" />{t('navigation.helpAndSupport')}
-                  </button>
-                  <button
-                    onclick={() => navigate(navigationUrls.helpReportBug)}
-                    class={cn(
-                      'flex items-center gap-2 px-3 py-2 rounded-md text-sm transition-colors duration-150',
-                      routeCache.helpReportBug
-                        ? 'menu-subitem-active'
-                        : 'text-[var(--color-base-content)]/80 hover:text-[var(--color-base-content)] hover:menu-hover'
-                    )}
-                  >
-                    <Bug class="size-4 shrink-0" />
-                    {t('navigation.reportBug')}
-                  </button>
-                  <a
-                    href={GITHUB_DISCUSSIONS_URL}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    class="flex items-center gap-2 px-3 py-2 rounded-md text-sm transition-colors duration-150 text-[var(--color-base-content)]/80 hover:text-[var(--color-base-content)] hover:menu-hover"
-                    aria-label={t('navigation.askQuestionAriaLabel')}
-                  >
-                    <MessageCircleQuestion class="size-4 shrink-0" />
-                    {t('navigation.askQuestion')}
-                    <ExternalLink class="size-3 opacity-40 ml-auto" />
-                  </a>
-                </div>
-              {/if}
-            {/if}
-          </div>
+          <CollapsibleNavSection
+            icon={CircleHelp}
+            label={t('navigation.help')}
+            ariaLabel={t('navigation.helpSubmenu')}
+            items={helpItems}
+            {isCollapsed}
+            expanded={helpExpanded}
+            routeActive={routeCache.help}
+            {routeCache}
+            onToggleExpanded={() => (helpExpanded = !helpExpanded)}
+            onNavigate={navigate}
+            {showTooltip}
+            {hideTooltip}
+            {activeFlyout}
+            sectionId="help"
+            onToggleFlyout={toggleFlyout}
+          />
 
           <!-- Settings (Collapsible) -->
-          <div class="flex flex-col relative flyout-container">
-            {#if isCollapsed}
-              <!-- Collapsed: Icon with flyout -->
-              <div class="relative">
-                <button
-                  bind:this={settingsButtonRef}
-                  onclick={toggleSettingsFlyout}
-                  onmouseenter={e =>
-                    !settingsFlyoutOpen && showTooltip(e, t('navigation.settings'))}
-                  onmouseleave={hideTooltip}
-                  class={cn(
-                    menuItemBase,
-                    menuItemCollapsed,
-                    routeCache.settings
-                      ? 'text-[var(--color-primary)]'
-                      : 'text-[var(--color-base-content)]/80',
-                    'hover:text-[var(--color-base-content)] hover:menu-hover'
-                  )}
-                  aria-expanded={settingsFlyoutOpen}
-                  aria-label={t('navigation.settingsSubmenu')}
-                >
-                  <Settings class="size-5 shrink-0" />
-                </button>
-              </div>
-              <!-- Flyout submenu (fixed positioning to escape overflow container) -->
-              {#if settingsFlyoutOpen}
-                <div
-                  in:flyout
-                  out:flyout={{ duration: 100 }}
-                  class="fixed bg-[var(--color-base-100)] border border-[var(--color-base-200)] rounded-lg shadow-xl min-w-48 z-[100]"
-                  style:top="{settingsFlyoutPosition.top}px"
-                  style:left="{settingsFlyoutPosition.left}px"
-                >
-                  <div
-                    class="px-3 py-2 border-b border-[var(--color-base-200)] font-medium text-sm text-[var(--color-base-content)]"
-                  >
-                    {t('navigation.settings')}
-                  </div>
-                  <div class="p-1 max-h-[calc(100vh-8rem)] overflow-y-auto">
-                    <button
-                      onclick={() => navigate(navigationUrls.settingsMain)}
-                      class={cn(
-                        'flex items-center gap-2 w-full px-3 py-2 rounded-md text-sm transition-colors duration-150',
-                        routeCache.settingsMain
-                          ? 'menu-subitem-active'
-                          : 'text-[var(--color-base-content)]/80 hover:text-[var(--color-base-content)] hover:menu-hover'
-                      )}
-                    >
-                      <SlidersHorizontal class="size-4 shrink-0" />{t('settings.sections.node')}
-                    </button>
-                    <button
-                      onclick={() => navigate(navigationUrls.settingsUserInterface)}
-                      class={cn(
-                        'flex items-center gap-2 w-full px-3 py-2 rounded-md text-sm transition-colors duration-150',
-                        routeCache.settingsUserInterface
-                          ? 'menu-subitem-active'
-                          : 'text-[var(--color-base-content)]/80 hover:text-[var(--color-base-content)] hover:menu-hover'
-                      )}
-                    >
-                      <Paintbrush class="size-4 shrink-0" />{t('settings.sections.userinterface')}
-                    </button>
-                    <button
-                      onclick={() => navigate(navigationUrls.settingsAudio)}
-                      class={cn(
-                        'flex items-center gap-2 w-full px-3 py-2 rounded-md text-sm transition-colors duration-150',
-                        routeCache.settingsAudio
-                          ? 'menu-subitem-active'
-                          : 'text-[var(--color-base-content)]/80 hover:text-[var(--color-base-content)] hover:menu-hover'
-                      )}
-                    >
-                      <Volume2 class="size-4 shrink-0" />{t('settings.sections.audio')}
-                    </button>
-                    <button
-                      onclick={() => navigate(navigationUrls.settingsAnalysis)}
-                      class={cn(
-                        'flex items-center gap-2 w-full px-3 py-2 rounded-md text-sm transition-colors duration-150',
-                        routeCache.settingsAnalysis
-                          ? 'menu-subitem-active'
-                          : 'text-[var(--color-base-content)]/80 hover:text-[var(--color-base-content)] hover:menu-hover'
-                      )}
-                    >
-                      <Brain class="size-4 shrink-0" />{t('settings.sections.analysis')}
-                    </button>
-                    <button
-                      onclick={() => navigate(navigationUrls.settingsSpecies)}
-                      class={cn(
-                        'flex items-center gap-2 w-full px-3 py-2 rounded-md text-sm transition-colors duration-150',
-                        routeCache.settingsSpecies
-                          ? 'menu-subitem-active'
-                          : 'text-[var(--color-base-content)]/80 hover:text-[var(--color-base-content)] hover:menu-hover'
-                      )}
-                    >
-                      <Bird class="size-4 shrink-0" />{t('settings.sections.species')}
-                    </button>
-                    <button
-                      onclick={() => navigate(navigationUrls.settingsFilters)}
-                      class={cn(
-                        'flex items-center gap-2 w-full px-3 py-2 rounded-md text-sm transition-colors duration-150',
-                        routeCache.settingsFilters
-                          ? 'menu-subitem-active'
-                          : 'text-[var(--color-base-content)]/80 hover:text-[var(--color-base-content)] hover:menu-hover'
-                      )}
-                    >
-                      <Filter class="size-4 shrink-0" />{t('settings.sections.filters')}
-                    </button>
-                    <button
-                      onclick={() => navigate(navigationUrls.settingsNotifications)}
-                      class={cn(
-                        'flex items-center gap-2 w-full px-3 py-2 rounded-md text-sm transition-colors duration-150',
-                        routeCache.settingsNotifications
-                          ? 'menu-subitem-active'
-                          : 'text-[var(--color-base-content)]/80 hover:text-[var(--color-base-content)] hover:menu-hover'
-                      )}
-                    >
-                      <Bell class="size-4 shrink-0" />{t('settings.sections.notifications')}
-                    </button>
-                    <button
-                      onclick={() => navigate(navigationUrls.settingsIntegrations)}
-                      class={cn(
-                        'flex items-center gap-2 w-full px-3 py-2 rounded-md text-sm transition-colors duration-150',
-                        routeCache.settingsIntegrations
-                          ? 'menu-subitem-active'
-                          : 'text-[var(--color-base-content)]/80 hover:text-[var(--color-base-content)] hover:menu-hover'
-                      )}
-                    >
-                      <Puzzle class="size-4 shrink-0" />{t('settings.sections.integration')}
-                    </button>
-                    <button
-                      onclick={() => navigate(navigationUrls.settingsSecurity)}
-                      class={cn(
-                        'flex items-center gap-2 w-full px-3 py-2 rounded-md text-sm transition-colors duration-150',
-                        routeCache.settingsSecurity
-                          ? 'menu-subitem-active'
-                          : 'text-[var(--color-base-content)]/80 hover:text-[var(--color-base-content)] hover:menu-hover'
-                      )}
-                    >
-                      <Shield class="size-4 shrink-0" />{t('settings.sections.security')}
-                    </button>
-                    <button
-                      onclick={() => navigate(navigationUrls.settingsSupport)}
-                      class={cn(
-                        'flex items-center gap-2 w-full px-3 py-2 rounded-md text-sm transition-colors duration-150',
-                        routeCache.settingsSupport
-                          ? 'menu-subitem-active'
-                          : 'text-[var(--color-base-content)]/80 hover:text-[var(--color-base-content)] hover:menu-hover'
-                      )}
-                    >
-                      <LifeBuoy class="size-4 shrink-0" />{t('settings.sections.support')}
-                    </button>
-                  </div>
-                </div>
-              {/if}
-            {:else}
-              <!-- Expanded: Regular collapsible -->
-              <button
-                onclick={() => (settingsExpanded = !settingsExpanded)}
-                class={cn(
-                  menuItemBase,
-                  routeCache.settings
-                    ? 'text-[var(--color-primary)]'
-                    : 'text-[var(--color-base-content)]/80',
-                  'hover:text-[var(--color-base-content)] hover:menu-hover'
-                )}
-                aria-expanded={settingsExpanded}
-              >
-                <Settings class="size-5 shrink-0" />
-                <span class="flex-1">{t('navigation.settings')}</span>
-                <ChevronDown
-                  class={cn('size-4 shrink-0 transition-transform duration-200', {
-                    'rotate-180': settingsExpanded,
-                  })}
-                />
-              </button>
-
-              {#if settingsExpanded}
-                <div
-                  class="ml-4 pl-4 border-l-2 mt-1 flex flex-col gap-0.5"
-                  style:border-color="color-mix(in oklch, var(--color-primary) 30%, transparent)"
-                >
-                  <button
-                    onclick={() => navigate(navigationUrls.settingsMain)}
-                    class={cn(
-                      'flex items-center gap-2 px-3 py-2 rounded-md text-sm transition-colors duration-150',
-                      routeCache.settingsMain
-                        ? 'menu-subitem-active'
-                        : 'text-[var(--color-base-content)]/80 hover:text-[var(--color-base-content)] hover:menu-hover'
-                    )}
-                  >
-                    <SlidersHorizontal class="size-4 shrink-0" />{t('settings.sections.node')}
-                  </button>
-                  <button
-                    onclick={() => navigate(navigationUrls.settingsUserInterface)}
-                    class={cn(
-                      'flex items-center gap-2 px-3 py-2 rounded-md text-sm transition-colors duration-150',
-                      routeCache.settingsUserInterface
-                        ? 'menu-subitem-active'
-                        : 'text-[var(--color-base-content)]/80 hover:text-[var(--color-base-content)] hover:menu-hover'
-                    )}
-                  >
-                    <Paintbrush class="size-4 shrink-0" />{t('settings.sections.userinterface')}
-                  </button>
-                  <button
-                    onclick={() => navigate(navigationUrls.settingsAudio)}
-                    class={cn(
-                      'flex items-center gap-2 px-3 py-2 rounded-md text-sm transition-colors duration-150',
-                      routeCache.settingsAudio
-                        ? 'menu-subitem-active'
-                        : 'text-[var(--color-base-content)]/80 hover:text-[var(--color-base-content)] hover:menu-hover'
-                    )}
-                  >
-                    <Volume2 class="size-4 shrink-0" />{t('settings.sections.audio')}
-                  </button>
-                  <button
-                    onclick={() => navigate(navigationUrls.settingsAnalysis)}
-                    class={cn(
-                      'flex items-center gap-2 px-3 py-2 rounded-md text-sm transition-colors duration-150',
-                      routeCache.settingsAnalysis
-                        ? 'menu-subitem-active'
-                        : 'text-[var(--color-base-content)]/80 hover:text-[var(--color-base-content)] hover:menu-hover'
-                    )}
-                  >
-                    <Brain class="size-4 shrink-0" />{t('settings.sections.analysis')}
-                  </button>
-                  <button
-                    onclick={() => navigate(navigationUrls.settingsSpecies)}
-                    class={cn(
-                      'flex items-center gap-2 px-3 py-2 rounded-md text-sm transition-colors duration-150',
-                      routeCache.settingsSpecies
-                        ? 'menu-subitem-active'
-                        : 'text-[var(--color-base-content)]/80 hover:text-[var(--color-base-content)] hover:menu-hover'
-                    )}
-                  >
-                    <Bird class="size-4 shrink-0" />{t('settings.sections.species')}
-                  </button>
-                  <button
-                    onclick={() => navigate(navigationUrls.settingsFilters)}
-                    class={cn(
-                      'flex items-center gap-2 px-3 py-2 rounded-md text-sm transition-colors duration-150',
-                      routeCache.settingsFilters
-                        ? 'menu-subitem-active'
-                        : 'text-[var(--color-base-content)]/80 hover:text-[var(--color-base-content)] hover:menu-hover'
-                    )}
-                  >
-                    <Filter class="size-4 shrink-0" />{t('settings.sections.filters')}
-                  </button>
-                  <button
-                    onclick={() => navigate(navigationUrls.settingsNotifications)}
-                    class={cn(
-                      'flex items-center gap-2 px-3 py-2 rounded-md text-sm transition-colors duration-150',
-                      routeCache.settingsNotifications
-                        ? 'menu-subitem-active'
-                        : 'text-[var(--color-base-content)]/80 hover:text-[var(--color-base-content)] hover:menu-hover'
-                    )}
-                  >
-                    <Bell class="size-4 shrink-0" />{t('settings.sections.notifications')}
-                  </button>
-                  <button
-                    onclick={() => navigate(navigationUrls.settingsIntegrations)}
-                    class={cn(
-                      'flex items-center gap-2 px-3 py-2 rounded-md text-sm transition-colors duration-150',
-                      routeCache.settingsIntegrations
-                        ? 'menu-subitem-active'
-                        : 'text-[var(--color-base-content)]/80 hover:text-[var(--color-base-content)] hover:menu-hover'
-                    )}
-                  >
-                    <Puzzle class="size-4 shrink-0" />{t('settings.sections.integration')}
-                  </button>
-                  <button
-                    onclick={() => navigate(navigationUrls.settingsSecurity)}
-                    class={cn(
-                      'flex items-center gap-2 px-3 py-2 rounded-md text-sm transition-colors duration-150',
-                      routeCache.settingsSecurity
-                        ? 'menu-subitem-active'
-                        : 'text-[var(--color-base-content)]/80 hover:text-[var(--color-base-content)] hover:menu-hover'
-                    )}
-                  >
-                    <Shield class="size-4 shrink-0" />{t('settings.sections.security')}
-                  </button>
-                  <button
-                    onclick={() => navigate(navigationUrls.settingsSupport)}
-                    class={cn(
-                      'flex items-center gap-2 px-3 py-2 rounded-md text-sm transition-colors duration-150',
-                      routeCache.settingsSupport
-                        ? 'menu-subitem-active'
-                        : 'text-[var(--color-base-content)]/80 hover:text-[var(--color-base-content)] hover:menu-hover'
-                    )}
-                  >
-                    <LifeBuoy class="size-4 shrink-0" />{t('settings.sections.support')}
-                  </button>
-                </div>
-              {/if}
-            {/if}
-          </div>
+          <CollapsibleNavSection
+            icon={Settings}
+            label={t('navigation.settings')}
+            ariaLabel={t('navigation.settingsSubmenu')}
+            items={settingsItems}
+            {isCollapsed}
+            expanded={settingsExpanded}
+            routeActive={routeCache.settings}
+            {routeCache}
+            onToggleExpanded={() => (settingsExpanded = !settingsExpanded)}
+            onNavigate={navigate}
+            {showTooltip}
+            {hideTooltip}
+            {activeFlyout}
+            sectionId="settings"
+            onToggleFlyout={toggleFlyout}
+          />
         {/if}
       </div>
     </div>

--- a/frontend/src/lib/desktop/views/ReportBug.svelte
+++ b/frontend/src/lib/desktop/views/ReportBug.svelte
@@ -5,7 +5,7 @@
   import { onMount } from 'svelte';
   import { t } from '$lib/i18n';
   import { api } from '$lib/utils/api';
-  import { copyToClipboard } from '$lib/utils/clipboard';
+  import { copyToClipboard, COPY_FEEDBACK_TIMEOUT_MS } from '$lib/utils/clipboard';
   import { GITHUB_ISSUES_URL } from '$lib/utils/externalUrls';
 
   interface HealthResponse {
@@ -78,7 +78,7 @@
     copyTimer = setTimeout(() => {
       copied = false;
       copyTimer = null;
-    }, 2000);
+    }, COPY_FEEDBACK_TIMEOUT_MS);
   }
 
   onMount(() => {

--- a/frontend/src/lib/desktop/views/ReportBug.svelte
+++ b/frontend/src/lib/desktop/views/ReportBug.svelte
@@ -5,6 +5,7 @@
   import { onMount } from 'svelte';
   import { t } from '$lib/i18n';
   import { api } from '$lib/utils/api';
+  import { copyToClipboard } from '$lib/utils/clipboard';
   import { GITHUB_ISSUES_URL } from '$lib/utils/externalUrls';
 
   interface HealthResponse {
@@ -70,28 +71,14 @@
     if (systemInfo.environment) lines.push(`Environment: ${systemInfo.environment}`);
     lines.push(`Browser: ${navigator.userAgent}`);
 
-    const text = lines.join('\n');
-    try {
-      if (navigator.clipboard?.writeText) {
-        await navigator.clipboard.writeText(text);
-      } else {
-        const textarea = document.createElement('textarea');
-        textarea.value = text;
-        textarea.style.position = 'fixed';
-        textarea.style.opacity = '0';
-        document.body.appendChild(textarea);
-        textarea.select();
-        document.execCommand('copy');
-        document.body.removeChild(textarea);
-      }
-      copied = true;
-      copyTimer = setTimeout(() => {
-        copied = false;
-        copyTimer = null;
-      }, 2000);
-    } catch {
-      // Clipboard access denied or unavailable
-    }
+    const ok = await copyToClipboard(lines.join('\n'));
+    if (!ok) return;
+    copied = true;
+    if (copyTimer !== null) clearTimeout(copyTimer);
+    copyTimer = setTimeout(() => {
+      copied = false;
+      copyTimer = null;
+    }, 2000);
   }
 
   onMount(() => {

--- a/frontend/src/lib/desktop/views/SystemHealth.svelte
+++ b/frontend/src/lib/desktop/views/SystemHealth.svelte
@@ -17,7 +17,9 @@
   import { onMount } from 'svelte';
   import { t } from '$lib/i18n';
   import { api } from '$lib/utils/api';
+  import { copyToClipboard } from '$lib/utils/clipboard';
   import { getLocalDateString, getLocalTimeString } from '$lib/utils/date';
+  import { downloadBlob } from '$lib/utils/fileHelpers';
 
   type HealthStatus = 'healthy' | 'warning' | 'critical' | 'unknown' | 'skipped';
   type HealthCategory =
@@ -154,43 +156,20 @@
   }
 
   async function copyReport() {
-    const text = buildTextReport();
-    try {
-      if (navigator.clipboard?.writeText) {
-        await navigator.clipboard.writeText(text);
-      } else {
-        const textarea = document.createElement('textarea');
-        textarea.value = text;
-        textarea.style.position = 'fixed';
-        textarea.style.opacity = '0';
-        document.body.appendChild(textarea);
-        textarea.select();
-        const ok = document.execCommand('copy');
-        document.body.removeChild(textarea);
-        if (!ok) return;
-      }
-      copied = true;
-      if (copyTimer !== null) clearTimeout(copyTimer);
-      copyTimer = setTimeout(() => {
-        copied = false;
-        copyTimer = null;
-      }, 2000);
-    } catch {
-      // Clipboard access denied or unavailable
-    }
+    const ok = await copyToClipboard(buildTextReport());
+    if (!ok) return;
+    copied = true;
+    if (copyTimer !== null) clearTimeout(copyTimer);
+    copyTimer = setTimeout(() => {
+      copied = false;
+      copyTimer = null;
+    }, 2000);
   }
 
   function downloadJSON() {
     if (!report) return;
     const blob = new Blob([JSON.stringify(report, null, 2)], { type: 'application/json' });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = `health-report-${report.id?.slice(0, 8) ?? 'unknown'}.json`;
-    document.body.appendChild(a);
-    a.click();
-    document.body.removeChild(a);
-    URL.revokeObjectURL(url);
+    downloadBlob(blob, `health-report-${report.id?.slice(0, 8) ?? 'unknown'}.json`);
   }
 </script>
 

--- a/frontend/src/lib/desktop/views/SystemHealth.svelte
+++ b/frontend/src/lib/desktop/views/SystemHealth.svelte
@@ -17,7 +17,7 @@
   import { onMount } from 'svelte';
   import { t } from '$lib/i18n';
   import { api } from '$lib/utils/api';
-  import { copyToClipboard } from '$lib/utils/clipboard';
+  import { copyToClipboard, COPY_FEEDBACK_TIMEOUT_MS } from '$lib/utils/clipboard';
   import { getLocalDateString, getLocalTimeString } from '$lib/utils/date';
   import { downloadBlob } from '$lib/utils/fileHelpers';
 
@@ -163,7 +163,7 @@
     copyTimer = setTimeout(() => {
       copied = false;
       copyTimer = null;
-    }, 2000);
+    }, COPY_FEEDBACK_TIMEOUT_MS);
   }
 
   function downloadJSON() {

--- a/frontend/src/lib/utils/clipboard.ts
+++ b/frontend/src/lib/utils/clipboard.ts
@@ -1,0 +1,24 @@
+/**
+ * Copy text to clipboard with execCommand fallback for non-HTTPS contexts.
+ * Returns true if the copy succeeded.
+ */
+export async function copyToClipboard(text: string): Promise<boolean> {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- clipboard API is undefined on plain HTTP
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text);
+      return true;
+    }
+    const textarea = document.createElement('textarea');
+    textarea.value = text;
+    textarea.style.position = 'fixed';
+    textarea.style.opacity = '0';
+    document.body.appendChild(textarea);
+    textarea.select();
+    const ok = document.execCommand('copy');
+    document.body.removeChild(textarea);
+    return ok;
+  } catch {
+    return false;
+  }
+}

--- a/frontend/src/lib/utils/clipboard.ts
+++ b/frontend/src/lib/utils/clipboard.ts
@@ -1,24 +1,35 @@
+export const COPY_FEEDBACK_TIMEOUT_MS = 2000;
+
 /**
  * Copy text to clipboard with execCommand fallback for non-HTTPS contexts.
+ * Falls back to textarea if the Clipboard API is unavailable or rejects.
  * Returns true if the copy succeeded.
  */
 export async function copyToClipboard(text: string): Promise<boolean> {
-  try {
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- clipboard API is undefined on plain HTTP
-    if (navigator.clipboard?.writeText) {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- clipboard API is undefined on plain HTTP
+  if (navigator.clipboard?.writeText) {
+    try {
       await navigator.clipboard.writeText(text);
       return true;
+    } catch {
+      // Permission denied or other failure; fall through to textarea fallback
     }
-    const textarea = document.createElement('textarea');
-    textarea.value = text;
-    textarea.style.position = 'fixed';
-    textarea.style.opacity = '0';
-    document.body.appendChild(textarea);
+  }
+  return fallbackCopy(text);
+}
+
+function fallbackCopy(text: string): boolean {
+  const textarea = document.createElement('textarea');
+  textarea.value = text;
+  textarea.style.position = 'fixed';
+  textarea.style.opacity = '0';
+  document.body.appendChild(textarea);
+  try {
     textarea.select();
-    const ok = document.execCommand('copy');
-    document.body.removeChild(textarea);
-    return ok;
+    return document.execCommand('copy');
   } catch {
     return false;
+  } finally {
+    document.body.removeChild(textarea);
   }
 }

--- a/frontend/src/lib/utils/fileHelpers.ts
+++ b/frontend/src/lib/utils/fileHelpers.ts
@@ -1,3 +1,17 @@
+/**
+ * Trigger a browser download for an in-memory Blob.
+ */
+export function downloadBlob(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
 const DEFAULT_MAX_SIZE_BYTES = 1_048_576; // 1 MB
 
 /**

--- a/frontend/src/lib/utils/fileHelpers.ts
+++ b/frontend/src/lib/utils/fileHelpers.ts
@@ -4,6 +4,7 @@
 export function downloadBlob(blob: Blob, filename: string): void {
   const url = URL.createObjectURL(blob);
   const a = document.createElement('a');
+  a.style.display = 'none';
   a.href = url;
   a.download = filename;
   document.body.appendChild(a);

--- a/frontend/src/lib/utils/fileHelpers.ts
+++ b/frontend/src/lib/utils/fileHelpers.ts
@@ -9,7 +9,7 @@ export function downloadBlob(blob: Blob, filename: string): void {
   document.body.appendChild(a);
   a.click();
   document.body.removeChild(a);
-  URL.revokeObjectURL(url);
+  setTimeout(() => URL.revokeObjectURL(url), 100);
 }
 
 const DEFAULT_MAX_SIZE_BYTES = 1_048_576; // 1 MB

--- a/internal/alerting/dispatcher.go
+++ b/internal/alerting/dispatcher.go
@@ -111,7 +111,9 @@ func (d *ActionDispatcher) dispatchNotification(target, title, message string, r
 				logger.String("target", target),
 				logger.Uint64("rule_id", uint64(rule.ID)),
 				logger.Error(err))
-			d.telemetry.ReportDispatchFailed(target, err.Error())
+			if d.telemetry != nil {
+				d.telemetry.ReportDispatchFailed(target, err.Error())
+			}
 		}
 		return
 	}
@@ -127,7 +129,9 @@ func (d *ActionDispatcher) dispatchNotification(target, title, message string, r
 			logger.String("target", target),
 			logger.Uint64("rule_id", uint64(rule.ID)),
 			logger.Error(err))
-		d.telemetry.ReportDispatchFailed(target, err.Error())
+		if d.telemetry != nil {
+			d.telemetry.ReportDispatchFailed(target, err.Error())
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- Extract shared `copyToClipboard()` utility with HTTP fallback into `clipboard.ts`, replacing duplicate implementations in SystemHealth and ReportBug
- Extract shared `downloadBlob()` utility into `fileHelpers.ts`, replacing 6 inline blob download patterns across settings pages, analytics, and database components
- Replace daisyUI classes in App.svelte loading/error screens with native Tailwind CSS variables and existing Button/LoadingSpinner components
- Extract reusable `CollapsibleNavSection` component from DesktopSidebar, reducing it from 1374 to ~670 lines by replacing 4 identical collapsible section templates with data-driven component instances
- Replace 4 individual boolean flyout states with a single `activeFlyout` string for automatic mutual exclusion
- Fix missing `clearTimeout` guard in ReportBug clipboard handler (rapid-click safety)

Net change: -650 lines across 12 files.

## Test plan

- [ ] Verify sidebar navigation works in both expanded and collapsed modes
- [ ] Verify flyout submenus appear correctly when sidebar is collapsed
- [ ] Verify only one flyout opens at a time (mutual exclusion)
- [ ] Verify route highlighting works for all nav sections
- [ ] Verify app loading spinner and error screen render correctly
- [ ] Verify clipboard copy works in SystemHealth and ReportBug pages
- [ ] Verify blob downloads work (export alert rules, download species CSV, database backup, health report JSON)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved navigation sidebar with collapsible sections and flyout menus.
  * Refreshed loading and fatal-error UI with updated controls and visuals.

* **Refactor**
  * Centralized download and clipboard utilities; CSV/JSON export and copy flows now use shared helpers and unified feedback timing.
  * Sidebar refactored to reuse a single collapsible section component.

* **Bug Fixes**
  * Guarded telemetry call to prevent a dispatch-time error.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3138?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->