### PR TITLE
fix(sorting): route hourly/species queries through advanced search for sorting

### DIFF
--- a/frontend/src/lib/desktop/features/detections/DetectionsPage.svelte
+++ b/frontend/src/lib/desktop/features/detections/DetectionsPage.svelte
@@ -27,6 +27,8 @@
     'date_desc',
     'date_asc',
     'species_asc',
+    'species_desc',
+    'confidence_asc',
     'confidence_desc',
     'status',
   ]);

--- a/frontend/src/lib/desktop/features/detections/components/DetectionsList.svelte
+++ b/frontend/src/lib/desktop/features/detections/components/DetectionsList.svelte
@@ -177,6 +177,10 @@
         return { field: 'dateTime', direction: 'asc' };
       case 'species_asc':
         return { field: 'species', direction: 'asc' };
+      case 'species_desc':
+        return { field: 'species', direction: 'desc' };
+      case 'confidence_asc':
+        return { field: 'confidence', direction: 'asc' };
       case 'confidence_desc':
         return { field: 'confidence', direction: 'desc' };
       case 'status':
@@ -192,9 +196,9 @@
       case 'dateTime':
         return direction === 'asc' ? 'date_asc' : 'date_desc';
       case 'species':
-        return 'species_asc';
+        return direction === 'asc' ? 'species_asc' : 'species_desc';
       case 'confidence':
-        return 'confidence_desc';
+        return direction === 'asc' ? 'confidence_asc' : 'confidence_desc';
       case 'status':
         return 'status';
     }
@@ -224,11 +228,7 @@
       sortField = field;
       sortDirection = field === 'dateTime' ? 'desc' : 'asc';
     }
-    const newBackendSort = toBackendSortBy(sortField, sortDirection);
-    // For columns with a fixed backend direction, snap the visual direction to match
-    const parsed = parseSortBy(newBackendSort);
-    sortDirection = parsed.direction;
-    onSortChange?.(newBackendSort);
+    onSortChange?.(toBackendSortBy(sortField, sortDirection));
   }
 
   // Mobile audio player state

--- a/frontend/src/lib/types/detection.types.ts
+++ b/frontend/src/lib/types/detection.types.ts
@@ -81,6 +81,8 @@ export type DetectionSortBy =
   | 'date_desc'
   | 'date_asc'
   | 'species_asc'
+  | 'species_desc'
+  | 'confidence_asc'
   | 'confidence_desc'
   | 'status';
 

--- a/internal/api/v2/detections.go
+++ b/internal/api/v2/detections.go
@@ -267,12 +267,12 @@ type detectionQueryParams struct {
 // advancedSearchCacheKey generates a deterministic cache key for advanced search queries.
 // Includes all filter parameters to avoid cache collisions.
 func (p *detectionQueryParams) advancedSearchCacheKey() string {
-	return fmt.Sprintf("adv_search:%s:%d:%d:%s:%s:%s:%s:%s:%s:%s:%s:%s:%s",
+	return fmt.Sprintf("adv_search:%s:%d:%d:%s:%s:%s:%s:%s:%s:%s:%s:%s:%s:%s:%s:%d",
 		p.Search, p.NumResults, p.Offset,
 		p.Confidence, p.TimeOfDay, p.HourRange,
 		p.Verified, p.Location, p.Locked,
 		p.Species, p.Date, p.StartDate+":"+p.EndDate,
-		p.SortBy)
+		p.SortBy, p.QueryType, p.Hour, p.Duration)
 }
 
 // parseDetectionQueryParams extracts and validates query parameters from the request
@@ -337,6 +337,8 @@ func (c *Controller) parseDetectionQueryParams(ctx echo.Context) (*detectionQuer
 			"date_desc":       {},
 			"date_asc":        {},
 			"species_asc":     {},
+			"species_desc":    {},
+			"confidence_asc":  {},
 			"confidence_desc": {},
 			"status":          {},
 		}
@@ -613,19 +615,32 @@ func (c *Controller) getDetectionsByQueryType(params *detectionQueryParams) ([]d
 		params.Search = resolved
 	}
 
+	// Filters beyond what the simple hourly/species query functions support.
+	// Separated from hasAdvancedFilters because date is always present for
+	// hourly and species queries and should not force the advanced path.
+	hasNonDefaultSort := params.SortBy != "" && params.SortBy != "date_desc"
+	hasExtraFilters := params.Confidence != "" || params.TimeOfDay != "" ||
+		params.HourRange != "" || params.Verified != "" ||
+		params.Location != "" || params.Locked != "" ||
+		params.StartDate != "" || params.EndDate != ""
+
 	switch params.QueryType {
 	case "hourly":
+		if hasNonDefaultSort || hasExtraFilters {
+			return c.getSearchDetectionsAdvanced(params)
+		}
 		return c.getHourlyDetections(params.Date, params.Hour, params.Duration, params.NumResults, params.Offset)
 	case queryTypeSpecies:
+		if hasNonDefaultSort || hasExtraFilters {
+			return c.getSearchDetectionsAdvanced(params)
+		}
 		return c.getSpeciesDetections(params.Species, params.Date, params.Hour, params.Duration, params.NumResults, params.Offset)
 	case queryTypeSearch:
-		// Use advanced search if filters are present
 		if hasAdvancedFilters {
 			return c.getSearchDetectionsAdvanced(params)
 		}
 		return c.getSearchDetections(params.Search, params.NumResults, params.Offset)
 	default: // "all" or any other value
-		// Check if there are filters even without explicit search text
 		if hasAdvancedFilters {
 			return c.getSearchDetectionsAdvanced(params)
 		}
@@ -1012,9 +1027,13 @@ func (c *Controller) buildAdvancedSearchFilters(params *detectionQueryParams) da
 		hourParam = params.Hour
 	}
 	if hourFilter := parseHourFilter(hourParam); hourFilter != nil {
+		endHour := hourFilter.End
+		if hourFilter.Start == hourFilter.End && params.Duration > 1 {
+			endHour = (hourFilter.Start + params.Duration - 1) % 24
+		}
 		filters.Hour = &datastore.HourFilter{
 			Start: hourFilter.Start,
-			End:   hourFilter.End,
+			End:   endHour,
 		}
 	}
 

--- a/internal/api/v2/detections.go
+++ b/internal/api/v2/detections.go
@@ -303,6 +303,9 @@ func (c *Controller) parseDetectionQueryParams(ctx echo.Context) (*detectionQuer
 	if duration <= 0 {
 		duration = 1
 	}
+	if duration > 24 {
+		return nil, echo.NewHTTPError(http.StatusBadRequest, "duration must be between 1 and 24 hours")
+	}
 	params.Duration = duration
 
 	// Validate dates

--- a/internal/api/v2/detections.go
+++ b/internal/api/v2/detections.go
@@ -981,9 +981,18 @@ func (c *Controller) getSpeciesDetections(species, date, hour string, duration, 
 
 // getSearchDetectionsAdvanced handles advanced search with filters
 func (c *Controller) getSearchDetectionsAdvanced(params *detectionQueryParams) ([]datastore.Note, int64, error) {
+	cacheKey := params.advancedSearchCacheKey()
+
+	if cachedData, found := c.detectionCache.Get(cacheKey); found {
+		cachedResult := cachedData.(struct {
+			Notes []datastore.Note
+			Total int64
+		})
+		return cachedResult.Notes, cachedResult.Total, nil
+	}
+
 	filters := c.buildAdvancedSearchFilters(params)
 
-	// Use the advanced search method
 	notes, totalCount, err := c.DS.SearchNotesAdvanced(&filters)
 	if err != nil {
 		c.logErrorIfEnabled("Failed to perform advanced search",
@@ -993,8 +1002,7 @@ func (c *Controller) getSearchDetectionsAdvanced(params *detectionQueryParams) (
 		return nil, 0, err
 	}
 
-	// Cache the results with key that includes all filter parameters
-	c.detectionCache.Set(params.advancedSearchCacheKey(), struct {
+	c.detectionCache.Set(cacheKey, struct {
 		Notes []datastore.Note
 		Total int64
 	}{notes, totalCount}, cache.DefaultExpiration)

--- a/internal/api/v2/search.go
+++ b/internal/api/v2/search.go
@@ -331,7 +331,10 @@ func (c *Controller) validateSearchSortBy(path, ip string, req *SearchRequest) e
 		"date_desc":       {},
 		"date_asc":        {},
 		"species_asc":     {},
+		"species_desc":    {},
+		"confidence_asc":  {},
 		"confidence_desc": {},
+		"status":          {},
 	}
 	if req.SortBy != "" { // Allow empty string for default sorting (handled by datastore)
 		if _, ok := allowedSortBy[req.SortBy]; !ok {

--- a/internal/datastore/interfaces.go
+++ b/internal/datastore/interfaces.go
@@ -2433,10 +2433,14 @@ func (ds *DataStore) SearchDetections(filters *SearchFilters) ([]DetectionRecord
 		query = query.Order("notes.date ASC, notes.time ASC")
 	case "species_asc":
 		query = query.Order("notes.common_name ASC")
+	case "species_desc":
+		query = query.Order("notes.common_name DESC")
+	case "confidence_asc":
+		query = query.Order("notes.confidence ASC")
 	case "confidence_desc":
 		query = query.Order("notes.confidence DESC")
 	default:
-		query = query.Order("notes.date DESC, notes.time DESC") // Default sort by date, newest first
+		query = query.Order("notes.date DESC, notes.time DESC")
 	}
 
 	// Apply pagination (PerPage and Page are already sanitised)

--- a/internal/datastore/search_advanced.go
+++ b/internal/datastore/search_advanced.go
@@ -22,7 +22,7 @@ type AdvancedSearchFilters struct {
 	Location      []string // Maps to source_node column
 	Locked        *bool
 	SortAscending bool
-	SortBy        string // "date_desc", "date_asc", "species_asc", "confidence_desc", "status"
+	SortBy        string // "date_desc", "date_asc", "species_asc", "species_desc", "confidence_asc", "confidence_desc", "status"
 	Limit         int
 	Offset        int
 	// MinID filters to records with ID > MinID (cursor-based pagination for migration)
@@ -142,7 +142,7 @@ func (ds *DataStore) SearchNotesAdvanced(filters *AdvancedSearchFilters) ([]Note
 				query = query.Joins("LEFT JOIN note_reviews ON note_reviews.note_id = notes.id")
 			}
 			query = query.Order("CASE WHEN note_reviews.verified = 'correct' THEN 0 WHEN note_reviews.verified IS NULL OR note_reviews.verified = '' THEN 1 ELSE 2 END ASC")
-		default: // "date_desc" or empty — use SortAscending for backward compatibility
+		default: // "date_desc" or empty - use SortAscending for backward compatibility
 			if filters.SortAscending {
 				query = query.Order("date ASC, time ASC")
 			} else {

--- a/internal/datastore/search_advanced.go
+++ b/internal/datastore/search_advanced.go
@@ -134,6 +134,10 @@ func (ds *DataStore) SearchNotesAdvanced(filters *AdvancedSearchFilters) ([]Note
 			query = query.Order("date ASC, time ASC")
 		case "species_asc":
 			query = query.Order("common_name ASC")
+		case "species_desc":
+			query = query.Order("common_name DESC")
+		case "confidence_asc":
+			query = query.Order("confidence ASC")
 		case "confidence_desc":
 			query = query.Order("confidence DESC")
 		case "status":

--- a/internal/datastore/v2/repository/filter_conversion.go
+++ b/internal/datastore/v2/repository/filter_conversion.go
@@ -575,16 +575,20 @@ func ConvertSearchFilters(
 		sf.SortBy = SortFieldDetectedAt
 		sf.SortDesc = true
 	case "species_asc":
-		// WARNING: label_id is an auto-increment integer with no correlation to
-		// alphabetical species names. This provides stable grouping by species,
-		// but NOT alphabetical ordering. True species sorting requires a JOIN
-		// with the labels table, which is not implemented.
-		// TODO(#1905): Implement proper species sorting via label JOIN
-		sf.SortBy = "label_id"
+		sf.SortBy = SortFieldSpecies
+		sf.SortDesc = false
+	case "species_desc":
+		sf.SortBy = SortFieldSpecies
+		sf.SortDesc = true
+	case "confidence_asc":
+		sf.SortBy = SortFieldConfidence
 		sf.SortDesc = false
 	case "confidence_desc":
 		sf.SortBy = SortFieldConfidence
 		sf.SortDesc = true
+	case "status":
+		sf.SortBy = SortFieldStatus
+		sf.SortDesc = false
 	}
 
 	// Pagination: convert Page/PerPage to Limit/Offset
@@ -667,13 +671,19 @@ func ConvertAdvancedFilters(
 	case "species_asc":
 		sf.SortBy = SortFieldSpecies
 		sf.SortDesc = false
+	case "species_desc":
+		sf.SortBy = SortFieldSpecies
+		sf.SortDesc = true
+	case "confidence_asc":
+		sf.SortBy = SortFieldConfidence
+		sf.SortDesc = false
 	case "confidence_desc":
 		sf.SortBy = SortFieldConfidence
 		sf.SortDesc = true
 	case "status":
 		sf.SortBy = SortFieldStatus
 		sf.SortDesc = false
-	default: // "date_desc" or empty — use SortAscending for backward compatibility
+	default: // "date_desc" or empty
 		sf.SortBy = SortFieldDetectedAt
 		// sf.SortDesc already set from !filters.SortAscending above
 	}

--- a/internal/datastore/v2/repository/filter_conversion_test.go
+++ b/internal/datastore/v2/repository/filter_conversion_test.go
@@ -397,6 +397,33 @@ func TestConvertAdvancedFilters(t *testing.T) {
 		// UTC should have offset 0
 		assert.Equal(t, 0, result.TimezoneOffset)
 	})
+
+	t.Run("sort field mapping", func(t *testing.T) {
+		tests := []struct {
+			sortBy   string
+			wantBy   string
+			wantDesc bool
+		}{
+			{"date_desc", SortFieldDetectedAt, true},
+			{"date_asc", SortFieldDetectedAt, false},
+			{"species_asc", SortFieldSpecies, false},
+			{"species_desc", SortFieldSpecies, true},
+			{"confidence_asc", SortFieldConfidence, false},
+			{"confidence_desc", SortFieldConfidence, true},
+			{"status", SortFieldStatus, false},
+			{"", SortFieldDetectedAt, true},
+		}
+
+		for _, tt := range tests {
+			t.Run("sort_"+tt.sortBy, func(t *testing.T) {
+				filters := &datastore.AdvancedSearchFilters{SortBy: tt.sortBy}
+				result, err := ConvertAdvancedFilters(ctx, filters, nil, tz)
+				require.NoError(t, err)
+				assert.Equal(t, tt.wantBy, result.SortBy)
+				assert.Equal(t, tt.wantDesc, result.SortDesc)
+			})
+		}
+	})
 }
 
 // =============================================================================
@@ -906,8 +933,11 @@ func TestConvertSearchFilters(t *testing.T) {
 		}{
 			{"date_desc", SortFieldDetectedAt, true},
 			{"date_asc", SortFieldDetectedAt, false},
+			{"species_asc", SortFieldSpecies, false},
+			{"species_desc", SortFieldSpecies, true},
+			{"confidence_asc", SortFieldConfidence, false},
 			{"confidence_desc", SortFieldConfidence, true},
-			{"species_asc", "label_id", false},
+			{"status", SortFieldStatus, false},
 			{"", SortFieldDetectedAt, true}, // Default
 		}
 


### PR DESCRIPTION
## Summary
- Sorting was silently ignored for "hourly" and "species" queryTypes because they routed to dedicated functions that don't accept sort parameters. Now these query types route through `getSearchDetectionsAdvanced` when non-default sort or extra filters are present.
- Added bi-directional sort support for species (asc/desc) and confidence (asc/desc) columns. Previously these columns were locked to a single sort direction in the frontend.
- Fixed cache key collision: `advancedSearchCacheKey` now includes `Hour`, `Duration`, and `QueryType` to prevent hourly/species queries from returning cached results from "all" queries.
- Fixed lost `Duration` parameter when hourly queries with multi-hour spans route through the advanced search path.
- Aligned `validateSearchSortBy` in search.go and `ConvertSearchFilters` with the new sort values.

## Test Plan
- [x] Unit tests pass for `ConvertAdvancedFilters` sort mapping (8 cases)
- [x] Unit tests pass for `ConvertSearchFilters` sort mapping (8 cases)
- [ ] Navigate to detections from dashboard species card, click sort headers, verify order changes
- [ ] Navigate to detections from dashboard hourly bucket, click sort headers, verify order changes
- [ ] Sort by species ascending, then descending, verify data reorders
- [ ] Sort by confidence ascending, then descending, verify data reorders

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detections can now be sorted by species (descending) and confidence (ascending); these options persist across views.

* **Bug Fixes**
  * Advanced detection queries now reject invalid duration values (>24) and correctly handle multi-hour ranges, including wrap-around behavior.
  * Search/sort behavior improved to keep UI sort state consistent when applying backend sort keys.

* **Tests**
  * Added/expanded tests for detection sort-field mappings and behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3139?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->