### PR TITLE
fix(api): convert Controller.engine to atomic.Pointer for thread safety

### DIFF
--- a/internal/api/v2/api.go
+++ b/internal/api/v2/api.go
@@ -99,7 +99,9 @@ type Controller struct {
 	audioLevelChan chan audiocore.AudioLevelData
 
 	// engine provides access to the unified audio subsystem (sources, buffers, routing).
-	engine *engine.AudioEngine
+	// Stored atomically: written once via WithAudioEngine after Controller init,
+	// read concurrently by HTTP handlers.
+	engine atomic.Pointer[engine.AudioEngine]
 
 	// V2Manager provides access to the v2 normalized database for stats and backup
 	V2Manager datastoreV2.Manager
@@ -196,7 +198,7 @@ func WithV2Manager(mgr datastoreV2.Manager) Option {
 // WithAudioEngine sets the AudioEngine for audio subsystem access.
 func WithAudioEngine(e *engine.AudioEngine) Option {
 	return func(c *Controller) {
-		c.engine = e
+		c.engine.Store(e)
 	}
 }
 
@@ -812,7 +814,6 @@ func (c *Controller) Shutdown() {
 	c.Debug("API Controller shutdown complete")
 }
 
-// SetShutdownRequester sets the shutdown requester for programmatic restart.
 // SetShutdownRequester sets the shutdown requester for programmatic restart.
 // Thread-safe: may be called after the HTTP server starts accepting requests.
 func (c *Controller) SetShutdownRequester(sr ShutdownRequester) {

--- a/internal/api/v2/api_engine_test.go
+++ b/internal/api/v2/api_engine_test.go
@@ -1,0 +1,38 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/audiocore/engine"
+)
+
+func TestEngineAtomicLoadStore(t *testing.T) {
+	t.Parallel()
+	e := echo.New()
+	c := getTestController(t, e)
+
+	// Initially nil.
+	assert.Nil(t, c.engine.Load())
+
+	// Store and load back.
+	eng := engine.New(t.Context(), &engine.Config{}, nil)
+	defer eng.Stop()
+	c.engine.Store(eng)
+	require.Same(t, eng, c.engine.Load())
+}
+
+func TestWithAudioEngineOption(t *testing.T) {
+	t.Parallel()
+	e := echo.New()
+	c := getTestController(t, e)
+
+	eng := engine.New(t.Context(), &engine.Config{}, nil)
+	defer eng.Stop()
+
+	opt := WithAudioEngine(eng)
+	opt(c)
+	require.Same(t, eng, c.engine.Load())
+}

--- a/internal/api/v2/audio_hls.go
+++ b/internal/api/v2/audio_hls.go
@@ -326,7 +326,11 @@ func (c *Controller) StartHLSStream(ctx echo.Context) error {
 		logger.Bool("force_restart", forceRestart))
 
 	// Verify source exists by checking for a capture buffer
-	if _, bufErr := c.engine.BufferManager().CaptureBuffer(sourceID); bufErr != nil {
+	eng := c.engine.Load()
+	if eng == nil {
+		return c.HandleError(ctx, nil, "Audio engine not initialized", http.StatusServiceUnavailable)
+	}
+	if _, bufErr := eng.BufferManager().CaptureBuffer(sourceID); bufErr != nil {
 		return c.HandleError(ctx, nil, "Audio source not found", http.StatusNotFound)
 	}
 
@@ -1592,14 +1596,20 @@ func (c *Controller) setupAudioCallback(sourceID string) (audioChan chan []byte,
 		channels: 1,
 	}
 
+	// Load the engine once for all registry/router operations in this section.
+	eng := c.engine.Load()
+	if eng == nil {
+		return nil, nil, fmt.Errorf("audio engine not initialized")
+	}
+
 	// Look up per-source gain from the registry so HLS listeners
 	// hear the same gain-adjusted audio as the analysis pipeline.
-	gainDB, _ := c.engine.Registry().GetGain(sourceID)
+	gainDB, _ := eng.Registry().GetGain(sourceID)
 
 	// Resolve EQ filter chain for this source so HLS listeners
 	// hear the same filtered audio as the analysis pipeline.
 	settings := conf.Setting()
-	src, _ := c.engine.Registry().Get(sourceID)
+	src, _ := eng.Registry().Get(sourceID)
 	sourceName := sourceID
 	if src != nil {
 		sourceName = src.DisplayName
@@ -1608,14 +1618,14 @@ func (c *Controller) setupAudioCallback(sourceID string) (audioChan chan []byte,
 	eqChain := equalizer.BuildFilterChainWithOverride(override, settings.Realtime.Audio.Equalizer, sourceName, sampleRate)
 
 	// Add route on the AudioRouter
-	if routeErr := c.engine.Router().AddRoute(sourceID, consumer, sampleRate, gainDB, eqChain); routeErr != nil {
+	if routeErr := eng.Router().AddRoute(sourceID, consumer, sampleRate, gainDB, eqChain); routeErr != nil {
 		return nil, nil, fmt.Errorf("failed to add HLS route: %w", routeErr)
 	}
 
 	GetLogger().Debug("Registered HLS audio route", logger.String("source_id", privacy.SanitizeRTSPUrl(sourceID)), logger.String("consumer_id", consumerID))
 
 	cleanup = func() {
-		c.engine.Router().RemoveRoute(sourceID, consumerID)
+		eng.Router().RemoveRoute(sourceID, consumerID)
 		GetLogger().Debug("Removed HLS audio route", logger.String("source_id", privacy.SanitizeRTSPUrl(sourceID)), logger.String("consumer_id", consumerID))
 	}
 

--- a/internal/api/v2/audio_level.go
+++ b/internal/api/v2/audio_level.go
@@ -342,7 +342,11 @@ func (c *Controller) StreamAudioLevel(ctx echo.Context) error {
 
 		case <-activityCheck.C:
 			// Prune sources that have been removed/disabled since the session started.
-			registry := c.engine.Registry()
+			eng := c.engine.Load()
+			if eng == nil {
+				continue
+			}
+			registry := eng.Registry()
 			pruned := registry != nil && c.pruneRemovedSources(registry, levels, lastUpdateTime, lastNonZeroTime)
 			// Check for inactive sources and zero them out.
 			if updated := c.checkSourceActivity(levels, lastUpdateTime, lastNonZeroTime); updated || pruned {
@@ -381,7 +385,11 @@ func createAudioLevelEntry(sourceID, displayName string) audiocore.AudioLevelDat
 // initializeAudioLevels creates the initial levels map with configured sources
 func (c *Controller) initializeAudioLevels(isAuthenticated bool) map[string]audiocore.AudioLevelData {
 	levels := make(map[string]audiocore.AudioLevelData)
-	registry := c.engine.Registry()
+	eng := c.engine.Load()
+	if eng == nil {
+		return levels
+	}
+	registry := eng.Registry()
 	if registry == nil {
 		return levels
 	}
@@ -440,7 +448,11 @@ func (c *Controller) updateAudioLevel(
 	isAuthenticated bool,
 ) {
 	now := time.Now()
-	registry := c.engine.Registry()
+	eng := c.engine.Load()
+	var registry *audiocore.SourceRegistry
+	if eng != nil {
+		registry = eng.Registry()
+	}
 
 	// Determine display name based on authentication
 	if registry != nil {

--- a/internal/api/v2/audio_sources.go
+++ b/internal/api/v2/audio_sources.go
@@ -58,11 +58,12 @@ func (c *Controller) listSources(ctx echo.Context, label string, filter func(aud
 
 	resp := AudioSourceListResponse{Sources: []AudioSourceInfo{}}
 
-	if c.engine == nil {
+	eng := c.engine.Load()
+	if eng == nil {
 		return ctx.JSON(http.StatusOK, resp)
 	}
 
-	registry := c.engine.Registry()
+	registry := eng.Registry()
 	if registry == nil {
 		return ctx.JSON(http.StatusOK, resp)
 	}

--- a/internal/api/v2/audio_sources_test.go
+++ b/internal/api/v2/audio_sources_test.go
@@ -41,8 +41,8 @@ func setupAudioSourcesTestEnv(t *testing.T, sources []*audiocore.SourceConfig) (
 		Echo:     e,
 		Group:    e.Group("/api/v2"),
 		Settings: &conf.Settings{},
-		engine:   eng,
 	}
+	controller.engine.Store(eng)
 	return e, controller
 }
 

--- a/internal/api/v2/control.go
+++ b/internal/api/v2/control.go
@@ -293,11 +293,12 @@ func (c *Controller) RestartAudioSource(ctx echo.Context) error {
 		logger.String("ip", ctx.RealIP()),
 	)
 
-	if c.engine == nil {
+	eng := c.engine.Load()
+	if eng == nil {
 		return c.HandleError(ctx, fmt.Errorf("audio engine not initialized"),
 			"Audio engine not available", http.StatusInternalServerError)
 	}
-	if _, ok := c.engine.Registry().Get(sourceID); !ok {
+	if _, ok := eng.Registry().Get(sourceID); !ok {
 		return c.HandleError(ctx, fmt.Errorf("source %s not found", sourceID),
 			"Audio source not found", http.StatusNotFound)
 	}

--- a/internal/api/v2/control_restart_source_test.go
+++ b/internal/api/v2/control_restart_source_test.go
@@ -36,7 +36,7 @@ func TestRestartAudioSource_SourceNotFound(t *testing.T) {
 
 	eng := engine.New(t.Context(), &engine.Config{}, nil)
 	defer eng.Stop()
-	c.engine = eng
+	c.engine.Store(eng)
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v2/control/restart-source/nonexistent", http.NoBody)
 	rec := httptest.NewRecorder()
@@ -55,7 +55,7 @@ func TestRestartAudioSource_NoPipeline(t *testing.T) {
 
 	eng := engine.New(t.Context(), &engine.Config{}, nil)
 	defer eng.Stop()
-	c.engine = eng
+	c.engine.Store(eng)
 
 	src := &audiocore.SourceConfig{
 		ID:          "test-src",
@@ -82,7 +82,7 @@ func TestRestartAudioSource_Success(t *testing.T) {
 
 	eng := engine.New(t.Context(), &engine.Config{}, nil)
 	defer eng.Stop()
-	c.engine = eng
+	c.engine.Store(eng)
 
 	src := &audiocore.SourceConfig{
 		ID:          "test-src",
@@ -124,7 +124,7 @@ func TestRestartAudioSource_RestartError(t *testing.T) {
 
 	eng := engine.New(t.Context(), &engine.Config{}, nil)
 	defer eng.Stop()
-	c.engine = eng
+	c.engine.Store(eng)
 
 	src := &audiocore.SourceConfig{
 		ID:          "test-src",

--- a/internal/api/v2/diagnostics.go
+++ b/internal/api/v2/diagnostics.go
@@ -205,13 +205,14 @@ var errNoTempSensors = errors.NewStd("no temperature sensors found")
 
 // buildStreamHealthProvider returns a closure that bridges the FFmpegManager's
 // stream health data to the checks.StreamHealthInfo format. The closure
-// nil-checks c.engine at call time because it is set after Controller init.
+// atomically loads c.engine at call time because it is set after Controller init.
 func (c *Controller) buildStreamHealthProvider() func() []checks.StreamHealthInfo {
 	return func() []checks.StreamHealthInfo {
-		if c.engine == nil {
+		eng := c.engine.Load()
+		if eng == nil {
 			return nil
 		}
-		mgr := c.engine.FFmpegManager()
+		mgr := eng.FFmpegManager()
 		if mgr == nil {
 			return nil
 		}
@@ -219,7 +220,7 @@ func (c *Controller) buildStreamHealthProvider() func() []checks.StreamHealthInf
 		if len(healthMap) == 0 {
 			return nil
 		}
-		registry := c.engine.Registry()
+		registry := eng.Registry()
 		infos := make([]checks.StreamHealthInfo, 0, len(healthMap))
 		for sourceID, sh := range healthMap {
 			url := sourceID

--- a/internal/api/v2/quiet_hours.go
+++ b/internal/api/v2/quiet_hours.go
@@ -42,8 +42,8 @@ func (c *Controller) initQuietHoursRoutes() {
 func (c *Controller) GetQuietHoursStatus(ctx echo.Context) error {
 	settings := c.Settings
 	var scheduler *schedule.QuietHoursScheduler
-	if c.engine != nil {
-		scheduler = c.engine.Scheduler()
+	if eng := c.engine.Load(); eng != nil {
+		scheduler = eng.Scheduler()
 	}
 
 	response := QuietHoursStatusResponse{

--- a/internal/api/v2/settings_audio.go
+++ b/internal/api/v2/settings_audio.go
@@ -132,14 +132,15 @@ func equalizerSettingsChanged(oldSettings, newSettings conf.EqualizerSettings) b
 // registered sources (both sound cards and streams). Each source's effective EQ
 // is resolved via Settings.ResolveEQOverride using the registry DisplayName.
 func (c *Controller) handleEqualizerChange(currentSettings *conf.Settings) error {
-	if c.engine == nil {
+	eng := c.engine.Load()
+	if eng == nil {
 		return nil
 	}
 
-	router := c.engine.Router()
+	router := eng.Router()
 	globalEQ := currentSettings.Realtime.Audio.Equalizer
 
-	for _, src := range c.engine.Registry().List() {
+	for _, src := range eng.Registry().List() {
 		displayName := src.DisplayName
 		override := currentSettings.ResolveEQOverride(displayName)
 		router.UpdateFilterChain(src.ID, func(sampleRate int) *equalizer.FilterChain {
@@ -265,8 +266,8 @@ func (c *Controller) handleAudioSettingsChanges(oldSettings, currentSettings *co
 	// Detect source/stream name changes and sync DisplayName in the registry.
 	// Each function detects renames and updates the registry in a single pass.
 	var registry sourceNameUpdater
-	if c.engine != nil {
-		registry = c.engine.Registry()
+	if eng := c.engine.Load(); eng != nil {
+		registry = eng.Registry()
 	}
 	srcNameChanged := syncAudioSourceNames(oldSettings, currentSettings, registry)
 	strmNameChanged := syncStreamNames(oldSettings, currentSettings, registry)

--- a/internal/api/v2/streams_health.go
+++ b/internal/api/v2/streams_health.go
@@ -203,16 +203,17 @@ func (c *Controller) getStreamInfo(rawURL string) streamInfo {
 // @Failure 503 {object} ErrorResponse "Audio engine not initialized"
 // @Router /api/v2/streams/health [get]
 func (c *Controller) GetAllStreamsHealth(ctx echo.Context) error {
-	if c.engine == nil {
-		// No engine — we cannot report real stream health. Signal the
+	eng := c.engine.Load()
+	if eng == nil {
+		// No engine - we cannot report real stream health. Signal the
 		// caller with 503 rather than fabricating misleading zero counts.
 		return c.HandleError(ctx, nil, "Audio engine not initialized", http.StatusServiceUnavailable)
 	}
 	// Get health data from the FFmpeg manager (keyed by sourceID)
-	healthData := c.engine.FFmpegManager().AllStreamHealth()
+	healthData := eng.FFmpegManager().AllStreamHealth()
 
 	// Look up the connection URL from the registry for each source
-	registry := c.engine.Registry()
+	registry := eng.Registry()
 
 	// Convert to API response format
 	// Use a slice instead of map to avoid collisions when multiple URLs
@@ -259,15 +260,16 @@ func (c *Controller) GetStreamHealth(ctx echo.Context) error {
 		return c.HandleError(ctx, err, "Invalid URL encoding", http.StatusBadRequest)
 	}
 
-	if c.engine == nil {
+	eng := c.engine.Load()
+	if eng == nil {
 		// Match GetAllStreamsHealth / GetStreamsStatusSummary: 503, not
-		// 404. The stream may very well exist in config — we just cannot
+		// 404. The stream may very well exist in config, we just cannot
 		// inspect its health without the audio engine running.
 		return c.HandleError(ctx, nil, "Audio engine not initialized", http.StatusServiceUnavailable)
 	}
 	// Try to find stream by sourceID first, then by connection URL
-	registry := c.engine.Registry()
-	ffmpegMgr := c.engine.FFmpegManager()
+	registry := eng.Registry()
+	ffmpegMgr := eng.FFmpegManager()
 
 	// First: try direct sourceID lookup
 	fh, lookupErr := ffmpegMgr.StreamHealth(decodedURL)
@@ -315,15 +317,16 @@ func (c *Controller) GetStreamHealth(ctx echo.Context) error {
 // @Failure 503 {object} ErrorResponse "Audio engine not initialized"
 // @Router /api/v2/streams/status [get]
 func (c *Controller) GetStreamsStatusSummary(ctx echo.Context) error {
-	if c.engine == nil {
+	eng := c.engine.Load()
+	if eng == nil {
 		// Zero counts would be technically accurate but misleading: clients
 		// cannot tell "no streams configured" apart from "audio engine not
 		// up yet". Return 503 so the UI can surface a proper state.
 		return c.HandleError(ctx, nil, "Audio engine not initialized", http.StatusServiceUnavailable)
 	}
 	// Get health data from the FFmpeg manager (keyed by sourceID)
-	healthData := c.engine.FFmpegManager().AllStreamHealth()
-	registry := c.engine.Registry()
+	healthData := eng.FFmpegManager().AllStreamHealth()
+	registry := eng.Registry()
 
 	// Build summary
 	summary := StreamsStatusSummaryResponse{
@@ -485,9 +488,14 @@ func (c *Controller) handleStreamHealthHeartbeat(ctx echo.Context, clientID stri
 
 // handleStreamHealthPoll polls for stream health changes and processes updates.
 func (c *Controller) handleStreamHealthPoll(ctx echo.Context, clientID string, previousState map[string]streamHealthSnapshot) error {
-	healthData := c.engine.FFmpegManager().AllStreamHealth()
+	eng := c.engine.Load()
+	if eng == nil {
+		return nil
+	}
+	healthData := eng.FFmpegManager().AllStreamHealth()
+	registry := eng.Registry()
 
-	if err := c.processStreamHealthUpdates(ctx, clientID, healthData, previousState); err != nil {
+	if err := c.processStreamHealthUpdates(ctx, clientID, healthData, registry, previousState); err != nil {
 		return err
 	}
 	return c.processRemovedStreams(ctx, clientID, healthData, previousState)
@@ -497,8 +505,12 @@ func (c *Controller) handleStreamHealthPoll(ctx echo.Context, clientID string, p
 // This enables real-time bandwidth and bytes display in the UI regardless of state changes.
 // Note: This sends a lightweight payload without history arrays to reduce bandwidth.
 func (c *Controller) handleStreamStatsUpdate(ctx echo.Context, clientID string) error {
-	healthData := c.engine.FFmpegManager().AllStreamHealth()
-	registry := c.engine.Registry()
+	eng := c.engine.Load()
+	if eng == nil {
+		return nil
+	}
+	healthData := eng.FFmpegManager().AllStreamHealth()
+	registry := eng.Registry()
 
 	for sourceID, fh := range healthData {
 		rawURL := c.resolveSourceURL(registry, sourceID)
@@ -524,7 +536,8 @@ func (c *Controller) handleStreamStatsUpdate(ctx echo.Context, clientID string) 
 // @Failure 503 {object} ErrorResponse "Audio engine not initialized"
 // @Router /api/v2/streams/health/stream [get]
 func (c *Controller) StreamHealthUpdates(ctx echo.Context) error {
-	if c.engine == nil {
+	eng := c.engine.Load()
+	if eng == nil {
 		return c.HandleError(ctx, nil, "Audio engine not initialized", http.StatusServiceUnavailable)
 	}
 
@@ -546,7 +559,7 @@ func (c *Controller) StreamHealthUpdates(ctx echo.Context) error {
 	}
 
 	// Pre-allocate state tracking based on initial stream count
-	previousState := make(map[string]streamHealthSnapshot, len(c.engine.FFmpegManager().AllStreamHealth()))
+	previousState := make(map[string]streamHealthSnapshot, len(eng.FFmpegManager().AllStreamHealth()))
 
 	ticker := time.NewTicker(streamHealthPollInterval)
 	defer ticker.Stop()
@@ -649,8 +662,7 @@ func determineEventType(prev, current *streamHealthSnapshot) string {
 }
 
 // processStreamHealthUpdates processes health updates for all active streams.
-func (c *Controller) processStreamHealthUpdates(ctx echo.Context, clientID string, healthData map[string]*ffmpeg.StreamHealth, previousState map[string]streamHealthSnapshot) error {
-	registry := c.engine.Registry()
+func (c *Controller) processStreamHealthUpdates(ctx echo.Context, clientID string, healthData map[string]*ffmpeg.StreamHealth, registry *audiocore.SourceRegistry, previousState map[string]streamHealthSnapshot) error {
 
 	for sourceID, health := range healthData {
 		// Resolve the connection URL for SSE events (sourceID is an internal key, not a URL)


### PR DESCRIPTION
## Summary

- Replace the plain `*engine.AudioEngine` pointer on `Controller` with `atomic.Pointer[engine.AudioEngine]` to eliminate a data race between `WithAudioEngine` (write during pipeline start) and concurrent HTTP handler reads
- Every read site (38 across 9 files) now loads once into a local variable, nil-checks it, and uses the local for all subsequent calls within that scope
- Follows the same pattern already used by `audioWatchdog` and `sourceRestarter` on the same struct
- Threads registry through `processStreamHealthUpdates` as a parameter to avoid a redundant atomic load
- Adds defensive nil guards to previously unguarded internal methods (SSE helpers, audio level handlers)
- Adds unit tests for atomic load/store and the `WithAudioEngine` option

## Test Plan

- [x] All 1974 v2 tests pass with `-race` (1 pre-existing flaky test `TestDashboardLayoutWidthPersistence` excluded)
- [x] `golangci-lint run ./internal/api/v2/...` reports zero issues
- [x] `go build ./...` compiles cleanly
- [x] `grep -rn 'c\.engine' internal/api/v2/ | grep -v '.Load()' | grep -v '.Store('` returns zero matches

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive test coverage for audio engine initialization and configuration across multiple API handlers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3141?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->