### PR TITLE
fix(api): make query routing aware of hourly default sort and cross-type filters

### DIFF
--- a/internal/api/v2/detections.go
+++ b/internal/api/v2/detections.go
@@ -47,6 +47,9 @@ const (
 	queryTypeHourly  = "hourly"
 	queryTypeSpecies = "species"
 	queryTypeSearch  = "search"
+
+	// Default sort order for non-hourly query types
+	sortByDateDesc = "date_desc"
 )
 
 // Regex to validate YYYY-MM-DD format and check for unwanted characters
@@ -614,7 +617,7 @@ func (p *detectionQueryParams) needsAdvancedRouting() bool {
 	}
 
 	if p.SortBy != "" {
-		if p.QueryType == queryTypeHourly || p.SortBy != "date_desc" {
+		if p.QueryType == queryTypeHourly || p.SortBy != sortByDateDesc {
 			return true
 		}
 	}
@@ -638,7 +641,7 @@ func (c *Controller) getDetectionsByQueryType(params *detectionQueryParams) ([]d
 		params.HourRange != "" || params.Verified != "" ||
 		params.Location != "" || params.Locked != "" ||
 		params.Date != "" || params.StartDate != "" || params.EndDate != "" ||
-		(params.SortBy != "" && params.SortBy != "date_desc")
+		(params.SortBy != "" && params.SortBy != sortByDateDesc)
 
 	// Resolve locale common names to scientific names before routing so every
 	// query type benefits without per-case duplication.

--- a/internal/api/v2/detections.go
+++ b/internal/api/v2/detections.go
@@ -599,19 +599,34 @@ func (c *Controller) GetDetections(ctx echo.Context) error {
 	return ctx.JSON(http.StatusOK, response)
 }
 
-// needsAdvancedRouting checks whether the query parameters require routing
+// needsAdvancedRouting reports whether the query parameters require routing
 // through the advanced search path instead of the dedicated hourly/species
-// handlers. It returns two flags: whether a non-default sort is requested and
-// whether filters beyond what the simple handlers support are present.
-func (p *detectionQueryParams) needsAdvancedRouting() (hasNonDefaultSort, hasExtraFilters bool) {
-	hasNonDefaultSort = p.SortBy != "" && (p.QueryType == queryTypeHourly || p.SortBy != "date_desc")
-	hasExtraFilters = p.Confidence != "" || p.TimeOfDay != "" ||
+// handlers. It checks for a non-default sort (for hourly queries ANY explicit
+// sort is non-default since the handler natively sorts by time ASC; for other
+// types only sorts other than date_desc are non-default) and for cross-type
+// filters that the simple handlers would silently ignore.
+func (p *detectionQueryParams) needsAdvancedRouting() bool {
+	if p.Confidence != "" || p.TimeOfDay != "" ||
 		p.HourRange != "" || p.Verified != "" ||
 		p.Location != "" || p.Locked != "" ||
-		p.StartDate != "" || p.EndDate != "" ||
-		(p.QueryType == queryTypeHourly && p.Species != "") ||
-		(p.QueryType != queryTypeSearch && p.Search != "")
-	return
+		p.StartDate != "" || p.EndDate != "" {
+		return true
+	}
+
+	if p.SortBy != "" {
+		if p.QueryType == queryTypeHourly || p.SortBy != "date_desc" {
+			return true
+		}
+	}
+
+	if p.QueryType != queryTypeSpecies && p.Species != "" {
+		return true
+	}
+	if p.QueryType != queryTypeSearch && p.Search != "" {
+		return true
+	}
+
+	return false
 }
 
 // getDetectionsByQueryType retrieves detections based on the query type
@@ -634,16 +649,14 @@ func (c *Controller) getDetectionsByQueryType(params *detectionQueryParams) ([]d
 		params.Search = resolved
 	}
 
-	hasNonDefaultSort, hasExtraFilters := params.needsAdvancedRouting()
-
 	switch params.QueryType {
 	case queryTypeHourly:
-		if hasNonDefaultSort || hasExtraFilters {
+		if params.needsAdvancedRouting() {
 			return c.getSearchDetectionsAdvanced(params)
 		}
 		return c.getHourlyDetections(params.Date, params.Hour, params.Duration, params.NumResults, params.Offset)
 	case queryTypeSpecies:
-		if hasNonDefaultSort || hasExtraFilters {
+		if params.needsAdvancedRouting() {
 			return c.getSearchDetectionsAdvanced(params)
 		}
 		return c.getSpeciesDetections(params.Species, params.Date, params.Hour, params.Duration, params.NumResults, params.Offset)

--- a/internal/api/v2/detections.go
+++ b/internal/api/v2/detections.go
@@ -44,6 +44,7 @@ const (
 	minHourRangeParts     = 2                // Minimum parts for hour range parsing
 
 	// queryType values for detection queries
+	queryTypeHourly  = "hourly"
 	queryTypeSpecies = "species"
 	queryTypeSearch  = "search"
 )
@@ -365,7 +366,7 @@ func (c *Controller) parseDetectionQueryParams(ctx echo.Context) (*detectionQuer
 	}
 
 	// Validate hour parameter based on query type
-	if params.QueryType == "hourly" {
+	if params.QueryType == queryTypeHourly {
 		// Hourly queries require a single valid integer hour (0-23), not a range
 		if params.Hour == "" {
 			return nil, echo.NewHTTPError(http.StatusBadRequest, "hour parameter is required for hourly query type")
@@ -598,6 +599,21 @@ func (c *Controller) GetDetections(ctx echo.Context) error {
 	return ctx.JSON(http.StatusOK, response)
 }
 
+// needsAdvancedRouting checks whether the query parameters require routing
+// through the advanced search path instead of the dedicated hourly/species
+// handlers. It returns two flags: whether a non-default sort is requested and
+// whether filters beyond what the simple handlers support are present.
+func (p *detectionQueryParams) needsAdvancedRouting() (hasNonDefaultSort, hasExtraFilters bool) {
+	hasNonDefaultSort = p.SortBy != "" && (p.QueryType == queryTypeHourly || p.SortBy != "date_desc")
+	hasExtraFilters = p.Confidence != "" || p.TimeOfDay != "" ||
+		p.HourRange != "" || p.Verified != "" ||
+		p.Location != "" || p.Locked != "" ||
+		p.StartDate != "" || p.EndDate != "" ||
+		(p.QueryType == queryTypeHourly && p.Species != "") ||
+		(p.QueryType != queryTypeSearch && p.Search != "")
+	return
+}
+
 // getDetectionsByQueryType retrieves detections based on the query type
 func (c *Controller) getDetectionsByQueryType(params *detectionQueryParams) ([]datastore.Note, int64, error) {
 	// Check if advanced filters are present (non-default sort counts as advanced).
@@ -618,17 +634,10 @@ func (c *Controller) getDetectionsByQueryType(params *detectionQueryParams) ([]d
 		params.Search = resolved
 	}
 
-	// Filters beyond what the simple hourly/species query functions support.
-	// Separated from hasAdvancedFilters because date is always present for
-	// hourly and species queries and should not force the advanced path.
-	hasNonDefaultSort := params.SortBy != "" && params.SortBy != "date_desc"
-	hasExtraFilters := params.Confidence != "" || params.TimeOfDay != "" ||
-		params.HourRange != "" || params.Verified != "" ||
-		params.Location != "" || params.Locked != "" ||
-		params.StartDate != "" || params.EndDate != ""
+	hasNonDefaultSort, hasExtraFilters := params.needsAdvancedRouting()
 
 	switch params.QueryType {
-	case "hourly":
+	case queryTypeHourly:
 		if hasNonDefaultSort || hasExtraFilters {
 			return c.getSearchDetectionsAdvanced(params)
 		}


### PR DESCRIPTION
## Summary

- For hourly queries, any explicit sort (including `date_desc`) now routes through the advanced search path, since the dedicated hourly handler sorts by time ASC natively
- Species filter on hourly queries and search filter on non-search queries now trigger advanced routing instead of being silently dropped
- Extracted `needsAdvancedRouting()` helper to reduce cyclomatic complexity and added `queryTypeHourly` constant

## Test plan

- [x] `go test ./internal/api/v2/ -race -v` passes (all detection tests green)
- [x] `golangci-lint run -v ./internal/api/v2/` clean (0 issues)
- [ ] Manual: hourly view with explicit `date_desc` sort returns results in descending order
- [ ] Manual: hourly view with species filter returns filtered results

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Search routing updated so complex filters (confidence, time-of-day, hour ranges, verification, location, locked status, date ranges) automatically use the advanced search path for accurate results.
  * Hourly, species, and general searches now select the most appropriate handler and enforce consistent sorting and parameter behavior for more reliable and predictable search outcomes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3142?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->