### PR TITLE
fix(audiocore): apply defaultChannels fallback consistently across stream start paths

### DIFF
--- a/internal/audiocore/engine/engine.go
+++ b/internal/audiocore/engine/engine.go
@@ -462,6 +462,10 @@ func (e *AudioEngine) AddSource(cfg *audiocore.SourceConfig) error {
 	}
 	// File-type sources: registered + buffers allocated, but no long-running capture.
 
+	// 6. Sync defaulted audio params back to registry so downstream consumers
+	// see the effective values (not the raw config which may have been zero).
+	e.registry.UpdateAudioParams(sourceID, sampleRate, cfg.BitDepth, channels)
+
 	e.logger.Info("source added",
 		logger.String("source_id", sourceID),
 		logger.String("type", cfg.Type.String()),

--- a/internal/audiocore/engine/engine.go
+++ b/internal/audiocore/engine/engine.go
@@ -372,10 +372,14 @@ func (e *AudioEngine) AddSource(cfg *audiocore.SourceConfig) error {
 			Build()
 	}
 
-	// 3. Default and validate sample rate for capture buffer and stream config.
+	// 3. Default and validate sample rate and channels for capture buffer and stream config.
 	sampleRate := cfg.SampleRate
 	if sampleRate <= 0 {
 		sampleRate = defaultSampleRate
+	}
+	channels := cfg.Channels
+	if channels <= 0 {
+		channels = defaultChannels
 	}
 
 	e.logger.Info("allocated primary analysis buffer",
@@ -412,7 +416,7 @@ func (e *AudioEngine) AddSource(cfg *audiocore.SourceConfig) error {
 			Type:             string(cfg.Type),
 			SampleRate:       sampleRate,
 			BitDepth:         cfg.BitDepth,
-			Channels:         cfg.Channels,
+			Channels:         channels,
 			FFmpegPath:       e.ffmpegPath,
 			Transport:        e.transport,
 			FFmpegParameters: e.ffmpegParameters,
@@ -433,14 +437,14 @@ func (e *AudioEngine) AddSource(cfg *audiocore.SourceConfig) error {
 		devCfg := audiocore.DeviceConfig{
 			SampleRate: sampleRate,
 			BitDepth:   cfg.BitDepth,
-			Channels:   cfg.Channels,
+			Channels:   channels,
 		}
 		e.logger.Info("starting audio card capture",
 			logger.String("source_id", sourceID),
 			logger.String("device_id", cfg.ConnectionString),
 			logger.Int("sample_rate", sampleRate),
 			logger.Int("bit_depth", cfg.BitDepth),
-			logger.Int("channels", cfg.Channels))
+			logger.Int("channels", channels))
 		if err := e.deviceMgr.StartCapture(sourceID, cfg.ConnectionString, devCfg); err != nil {
 			e.logger.Error("audio card capture failed",
 				logger.String("source_id", sourceID),
@@ -549,6 +553,10 @@ func (e *AudioEngine) ReconfigureSource(sourceID string, newCfg *audiocore.Sourc
 	if sampleRate <= 0 {
 		sampleRate = defaultSampleRate
 	}
+	channels := newCfg.Channels
+	if channels <= 0 {
+		channels = defaultChannels
+	}
 	if err := e.bufferMgr.AllocateAnalysis(
 		sourceID,
 		e.primaryModelID,
@@ -601,7 +609,7 @@ func (e *AudioEngine) ReconfigureSource(sourceID string, newCfg *audiocore.Sourc
 			Type:             string(newType),
 			SampleRate:       sampleRate,
 			BitDepth:         newCfg.BitDepth,
-			Channels:         newCfg.Channels,
+			Channels:         channels,
 			FFmpegPath:       e.ffmpegPath,
 			Transport:        e.transport,
 			FFmpegParameters: e.ffmpegParameters,
@@ -622,7 +630,7 @@ func (e *AudioEngine) ReconfigureSource(sourceID string, newCfg *audiocore.Sourc
 		devCfg := audiocore.DeviceConfig{
 			SampleRate: sampleRate,
 			BitDepth:   newCfg.BitDepth,
-			Channels:   newCfg.Channels,
+			Channels:   channels,
 		}
 		if err := e.deviceMgr.StartCapture(sourceID, newCfg.ConnectionString, devCfg); err != nil {
 			// Source stays registered; mark it as errored so callers can see the failure.
@@ -637,7 +645,7 @@ func (e *AudioEngine) ReconfigureSource(sourceID string, newCfg *audiocore.Sourc
 	}
 
 	// 6. Update registry so downstream consumers see the new audio params.
-	e.registry.UpdateAudioParams(sourceID, sampleRate, newCfg.BitDepth, newCfg.Channels)
+	e.registry.UpdateAudioParams(sourceID, sampleRate, newCfg.BitDepth, channels)
 
 	e.logger.Info("source reconfigured",
 		logger.String("source_id", sourceID),


### PR DESCRIPTION
## Summary

- Apply the same `defaultChannels = 1` fallback in `AddSource()` and `ReconfigureSource()` that already existed in `StartStream()`
- Ensures streams registered with `Channels == 0` behave identically whether started at registration, after reconfiguration, or after quiet-hours restart
- Also passes the defaulted value to `UpdateAudioParams` in `ReconfigureSource` so the registry stays consistent

## Test plan

- [x] `go test -race ./internal/audiocore/...` passes (760 tests)
- [x] `golangci-lint run -v` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio channel validation and defaulting when adding or reconfiguring audio sources to ensure consistent channel settings across source types.
  * Ensured effective sample rate, bit depth, and validated channel counts are synchronized back to the system registry for reliable audio processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3143?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->