### PR TITLE
fix(health): scan all entries in ErrorRingBuffer.CountSince

### DIFF
--- a/internal/health/error_buffer.go
+++ b/internal/health/error_buffer.go
@@ -144,16 +144,17 @@ func (b *ErrorRingBuffer) Count() int {
 }
 
 // CountSince returns the number of entries at or after the given time.
+// All valid entries are scanned because insertion order may not match
+// chronological order under concurrent writers.
 func (b *ErrorRingBuffer) CountSince(since time.Time) int {
 	b.mu.RLock()
 	defer b.mu.RUnlock()
 	count := 0
 	for i := range b.count {
 		idx := (b.head - 1 - i + b.maxSize) % b.maxSize
-		if b.entries[idx].Timestamp.Before(since) {
-			break
+		if !b.entries[idx].Timestamp.Before(since) {
+			count++
 		}
-		count++
 	}
 	return count
 }

--- a/internal/health/error_buffer.go
+++ b/internal/health/error_buffer.go
@@ -151,8 +151,7 @@ func (b *ErrorRingBuffer) CountSince(since time.Time) int {
 	defer b.mu.RUnlock()
 	count := 0
 	for i := range b.count {
-		idx := (b.head - 1 - i + b.maxSize) % b.maxSize
-		if !b.entries[idx].Timestamp.Before(since) {
+		if !b.entries[i].Timestamp.Before(since) {
 			count++
 		}
 	}

--- a/internal/health/error_buffer_test.go
+++ b/internal/health/error_buffer_test.go
@@ -128,6 +128,30 @@ func TestErrorRingBuffer_CountSince(t *testing.T) {
 	assert.Equal(t, 5, buf.CountSince(base.Add(-time.Second)))
 }
 
+func TestErrorRingBuffer_CountSince_OutOfOrder(t *testing.T) {
+	t.Parallel()
+	buf := NewErrorRingBuffer(10)
+	base := time.Now()
+
+	// Simulate out-of-order timestamps from concurrent callers:
+	// entries added as: t+0, t+3, t+1, t+4, t+2
+	buf.Add(makeEntry("msg-0", base))
+	buf.Add(makeEntry("msg-3", base.Add(3*time.Second)))
+	buf.Add(makeEntry("msg-1", base.Add(1*time.Second)))
+	buf.Add(makeEntry("msg-4", base.Add(4*time.Second)))
+	buf.Add(makeEntry("msg-2", base.Add(2*time.Second)))
+
+	// Count entries at or after base+2s: msg-3 (t+3), msg-4 (t+4), msg-2 (t+2) = 3
+	cutoff := base.Add(2 * time.Second)
+	assert.Equal(t, 3, buf.CountSince(cutoff))
+
+	// All entries should be counted regardless of insertion order.
+	assert.Equal(t, 5, buf.CountSince(base))
+
+	// Future cutoff: none.
+	assert.Equal(t, 0, buf.CountSince(base.Add(10*time.Second)))
+}
+
 func TestErrorRingBuffer_Clear(t *testing.T) {
 	t.Parallel()
 	buf := NewErrorRingBuffer(5)


### PR DESCRIPTION
## Summary

- `CountSince()` assumed entries were in strict chronological order and broke early on the first entry before the threshold. Under concurrent writers, timestamps may arrive slightly out of order, causing the early break to undercount.
- Replaced the early-break optimization with a full scan of all valid entries, checking each timestamp individually.
- Added a regression test with out-of-order timestamps that fails on the old code and passes on the fix.

Fixes Forgejo #697

## Test plan

- [x] New test `TestErrorRingBuffer_CountSince_OutOfOrder` validates out-of-order timestamps
- [x] Existing `TestErrorRingBuffer_CountSince` still passes (in-order case)
- [x] All 50 health package tests pass with `-race`
- [x] `golangci-lint` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect error count calculations when errors are logged out of chronological order, ensuring accurate error counts in monitoring and health checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3144?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->