### PR TITLE
fix(api): eliminate race in handleSettingsChanges goroutine

### DIFF
--- a/internal/api/v2/settings.go
+++ b/internal/api/v2/settings.go
@@ -2124,11 +2124,16 @@ func (c *Controller) handleSettingsChanges(oldSettings, currentSettings *conf.Se
 	}
 	reconfigActions = append(reconfigActions, audioActions...)
 
-	// Trigger reconfigurations asynchronously
+	// Trigger reconfigurations asynchronously.
+	// Capture debug flag from the settings snapshot so the goroutine never
+	// reads c.Settings (which may be overwritten by a concurrent update).
 	if len(reconfigActions) > 0 {
+		debugEnabled := currentSettings.WebServer.Debug
 		go func(actions []string) {
 			for _, action := range actions {
-				c.Debug("Asynchronously executing action: %s", action)
+				if debugEnabled {
+					c.logDebugIfEnabled("Asynchronously executing action", logger.String("action", action))
+				}
 				c.controlChan <- action
 				time.Sleep(actionDelay)
 			}


### PR DESCRIPTION
## Summary

- Fix data race in the goroutine spawned by `handleSettingsChanges` that called `c.Debug()`, which falls back to reading `c.Settings` (unguarded pointer) when `conf.GetSettings()` returns nil (test environment)
- The race caused `TestDashboardLayoutWidthPersistence` to fail consistently under `-race -count=10+`
- Fix captures the debug-enabled flag from the settings snapshot already available as a parameter, using structured logging directly

## Details

The goroutine at `settings.go:2129` previously called `c.Debug("Asynchronously executing action: %s", action)`. The `Debug` method reads `conf.GetSettings()` (atomic, safe), but falls back to `c.Settings` when the global is nil. In tests with standalone controllers (no global singleton), this fallback path races with the write at `c.Settings = updated` in the next `UpdateSectionSettings` call.

The fix eliminates the `c.Settings` read entirely by capturing `currentSettings.WebServer.Debug` (a bool, value-copied) before spawning the goroutine, then calling `c.logDebugIfEnabled` with structured logging fields directly.

## Test plan

- [x] `go test -race -count=50 -run TestDashboardLayoutWidthPersistence ./internal/api/v2/` passes (0 failures)
- [x] Full API v2 test suite passes with race detector (1974 tests)
- [x] `golangci-lint run ./internal/api/v2/` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined debug logging behavior to only generate debug logs when the debug flag is enabled, reducing unnecessary output during normal operation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3145?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->