### PR TITLE
fix(audiocore): add defaultBitDepth fallback and fix ReconfigureSource buffer leak

### DIFF
--- a/internal/audiocore/engine/engine.go
+++ b/internal/audiocore/engine/engine.go
@@ -50,6 +50,9 @@ const (
 
 	// defaultChannels is used when a source config has no channel count set.
 	defaultChannels = 1
+
+	// defaultBitDepth is used when a source config has no bit depth set.
+	defaultBitDepth = 16
 )
 
 // Config holds the configuration needed to create an AudioEngine.
@@ -283,13 +286,17 @@ func (e *AudioEngine) StartStream(sourceID, url, transport string) error {
 	if channels <= 0 {
 		channels = defaultChannels
 	}
+	bitDepth := src.BitDepth
+	if bitDepth <= 0 {
+		bitDepth = defaultBitDepth
+	}
 	streamCfg := &ffmpeg.StreamConfig{
 		SourceID:         sourceID,
 		SourceName:       src.DisplayName,
 		URL:              url,
 		Type:             string(src.Type),
 		SampleRate:       sampleRate,
-		BitDepth:         src.BitDepth,
+		BitDepth:         bitDepth,
 		Channels:         channels,
 		FFmpegPath:       e.ffmpegPath,
 		Transport:        transport,
@@ -381,6 +388,10 @@ func (e *AudioEngine) AddSource(cfg *audiocore.SourceConfig) error {
 	if channels <= 0 {
 		channels = defaultChannels
 	}
+	bitDepth := cfg.BitDepth
+	if bitDepth <= 0 {
+		bitDepth = defaultBitDepth
+	}
 
 	e.logger.Info("allocated primary analysis buffer",
 		logger.String("source_id", sourceID),
@@ -415,7 +426,7 @@ func (e *AudioEngine) AddSource(cfg *audiocore.SourceConfig) error {
 			URL:              cfg.ConnectionString,
 			Type:             string(cfg.Type),
 			SampleRate:       sampleRate,
-			BitDepth:         cfg.BitDepth,
+			BitDepth:         bitDepth,
 			Channels:         channels,
 			FFmpegPath:       e.ffmpegPath,
 			Transport:        e.transport,
@@ -436,14 +447,14 @@ func (e *AudioEngine) AddSource(cfg *audiocore.SourceConfig) error {
 	} else if cfg.Type == audiocore.SourceTypeAudioCard {
 		devCfg := audiocore.DeviceConfig{
 			SampleRate: sampleRate,
-			BitDepth:   cfg.BitDepth,
+			BitDepth:   bitDepth,
 			Channels:   channels,
 		}
 		e.logger.Info("starting audio card capture",
 			logger.String("source_id", sourceID),
 			logger.String("device_id", cfg.ConnectionString),
 			logger.Int("sample_rate", sampleRate),
-			logger.Int("bit_depth", cfg.BitDepth),
+			logger.Int("bit_depth", bitDepth),
 			logger.Int("channels", channels))
 		if err := e.deviceMgr.StartCapture(sourceID, cfg.ConnectionString, devCfg); err != nil {
 			e.logger.Error("audio card capture failed",
@@ -464,7 +475,7 @@ func (e *AudioEngine) AddSource(cfg *audiocore.SourceConfig) error {
 
 	// 6. Sync defaulted audio params back to registry so downstream consumers
 	// see the effective values (not the raw config which may have been zero).
-	e.registry.UpdateAudioParams(sourceID, sampleRate, cfg.BitDepth, channels)
+	e.registry.UpdateAudioParams(sourceID, sampleRate, bitDepth, channels)
 
 	e.logger.Info("source added",
 		logger.String("source_id", sourceID),
@@ -561,6 +572,10 @@ func (e *AudioEngine) ReconfigureSource(sourceID string, newCfg *audiocore.Sourc
 	if channels <= 0 {
 		channels = defaultChannels
 	}
+	bitDepth := newCfg.BitDepth
+	if bitDepth <= 0 {
+		bitDepth = defaultBitDepth
+	}
 	if err := e.bufferMgr.AllocateAnalysis(
 		sourceID,
 		e.primaryModelID,
@@ -612,7 +627,7 @@ func (e *AudioEngine) ReconfigureSource(sourceID string, newCfg *audiocore.Sourc
 			URL:              newCfg.ConnectionString,
 			Type:             string(newType),
 			SampleRate:       sampleRate,
-			BitDepth:         newCfg.BitDepth,
+			BitDepth:         bitDepth,
 			Channels:         channels,
 			FFmpegPath:       e.ffmpegPath,
 			Transport:        e.transport,
@@ -621,7 +636,7 @@ func (e *AudioEngine) ReconfigureSource(sourceID string, newCfg *audiocore.Sourc
 			Debug:            e.debug,
 		}
 		if err := e.ffmpegMgr.StartStream(streamCfg); err != nil {
-			// Source stays registered; mark it as errored so callers can see the failure.
+			e.bufferMgr.DeallocateSource(sourceID)
 			_ = e.registry.UpdateState(sourceID, audiocore.SourceError)
 			return errors.New(err).
 				Component("audiocore.engine").
@@ -633,11 +648,11 @@ func (e *AudioEngine) ReconfigureSource(sourceID string, newCfg *audiocore.Sourc
 	} else if newType == audiocore.SourceTypeAudioCard {
 		devCfg := audiocore.DeviceConfig{
 			SampleRate: sampleRate,
-			BitDepth:   newCfg.BitDepth,
+			BitDepth:   bitDepth,
 			Channels:   channels,
 		}
 		if err := e.deviceMgr.StartCapture(sourceID, newCfg.ConnectionString, devCfg); err != nil {
-			// Source stays registered; mark it as errored so callers can see the failure.
+			e.bufferMgr.DeallocateSource(sourceID)
 			_ = e.registry.UpdateState(sourceID, audiocore.SourceError)
 			return errors.New(err).
 				Component("audiocore.engine").
@@ -649,7 +664,7 @@ func (e *AudioEngine) ReconfigureSource(sourceID string, newCfg *audiocore.Sourc
 	}
 
 	// 6. Update registry so downstream consumers see the new audio params.
-	e.registry.UpdateAudioParams(sourceID, sampleRate, newCfg.BitDepth, channels)
+	e.registry.UpdateAudioParams(sourceID, sampleRate, bitDepth, channels)
 
 	e.logger.Info("source reconfigured",
 		logger.String("source_id", sourceID),

--- a/internal/audiocore/engine/engine.go
+++ b/internal/audiocore/engine/engine.go
@@ -42,9 +42,6 @@ const (
 	// + pre-capture offset. Matches conf.DefaultCaptureBufferSeconds.
 	defaultCaptureBufferSeconds = conf.DefaultCaptureBufferSeconds
 
-	// defaultBytesPerSample is the default PCM bytes per sample (16-bit).
-	defaultBytesPerSample = 2
-
 	// defaultSampleRate is used when a source config has no sample rate set.
 	defaultSampleRate = 48000
 
@@ -53,6 +50,9 @@ const (
 
 	// defaultBitDepth is used when a source config has no bit depth set.
 	defaultBitDepth = 16
+
+	// defaultBytesPerSample is the default PCM bytes per sample, derived from defaultBitDepth.
+	defaultBytesPerSample = defaultBitDepth / 8
 )
 
 // Config holds the configuration needed to create an AudioEngine.

--- a/internal/audiocore/engine/engine_test.go
+++ b/internal/audiocore/engine/engine_test.go
@@ -496,3 +496,37 @@ func TestEngine_ReconfigureSource_ZeroAudioParams(t *testing.T) {
 	assert.Equal(t, defaultChannels, src.Channels,
 		"registry Channels should be defaulted after reconfigure")
 }
+
+// TestEngine_StartStream_ZeroBitDepthFallback verifies that StartStream
+// applies the defaultBitDepth fallback when the registry has zero BitDepth.
+// In practice this can't happen because AddSource always defaults, but
+// StartStream must be independently safe.
+func TestEngine_StartStream_ZeroBitDepthFallback(t *testing.T) {
+	t.Parallel()
+	eng, stop := newTestEngine(t)
+	defer stop()
+
+	cfg := &audiocore.SourceConfig{
+		ID:               "test_startstream_bitdepth",
+		DisplayName:      "StartStream BitDepth Test",
+		Type:             audiocore.SourceTypeRTSP,
+		ConnectionString: "rtsp://192.168.1.100/stream",
+		SampleRate:       48000,
+		BitDepth:         16,
+		Channels:         1,
+	}
+	require.NoError(t, eng.AddSource(cfg))
+
+	// Stop the stream started by AddSource so we can restart it.
+	require.NoError(t, eng.FFmpegManager().StopStream("test_startstream_bitdepth"))
+
+	// Manually zero out BitDepth in the registry to simulate an edge case.
+	eng.Registry().UpdateAudioParams("test_startstream_bitdepth", 48000, 0, 1)
+
+	// StartStream should not fail even with zero BitDepth in registry.
+	err := eng.StartStream("test_startstream_bitdepth", "rtsp://192.168.1.100/stream2", "")
+	require.NoError(t, err)
+
+	health := eng.FFmpegManager().AllStreamHealth()
+	assert.Contains(t, health, "test_startstream_bitdepth")
+}

--- a/internal/audiocore/engine/engine_test.go
+++ b/internal/audiocore/engine/engine_test.go
@@ -383,3 +383,116 @@ func TestErrEngineStopped_IsSentinel(t *testing.T) {
 	assert.True(t, errors.Is(ErrEngineStopped, ErrEngineStopped))
 	assert.Contains(t, ErrEngineStopped.Error(), "stop requested")
 }
+
+// TestEngine_AddSource_ZeroAudioParams verifies that zero-value SampleRate,
+// BitDepth, and Channels are defaulted before being stored in the registry
+// and passed to stream/device configs.
+func TestEngine_AddSource_ZeroAudioParams(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		sampleRate       int
+		bitDepth         int
+		channels         int
+		expectSampleRate int
+		expectBitDepth   int
+		expectChannels   int
+	}{
+		{
+			name:             "all zero defaults",
+			sampleRate:       0,
+			bitDepth:         0,
+			channels:         0,
+			expectSampleRate: defaultSampleRate,
+			expectBitDepth:   defaultBitDepth,
+			expectChannels:   defaultChannels,
+		},
+		{
+			name:             "negative values default",
+			sampleRate:       -1,
+			bitDepth:         -1,
+			channels:         -1,
+			expectSampleRate: defaultSampleRate,
+			expectBitDepth:   defaultBitDepth,
+			expectChannels:   defaultChannels,
+		},
+		{
+			name:             "explicit values preserved",
+			sampleRate:       96000,
+			bitDepth:         24,
+			channels:         2,
+			expectSampleRate: 96000,
+			expectBitDepth:   24,
+			expectChannels:   2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			eng, stop := newTestEngine(t)
+			defer stop()
+
+			sourceID := fmt.Sprintf("test_zero_%s", tt.name)
+			cfg := &audiocore.SourceConfig{
+				ID:               sourceID,
+				DisplayName:      "Zero Params Test",
+				Type:             audiocore.SourceTypeRTSP,
+				ConnectionString: "rtsp://192.168.1.100/zero",
+				SampleRate:       tt.sampleRate,
+				BitDepth:         tt.bitDepth,
+				Channels:         tt.channels,
+			}
+
+			err := eng.AddSource(cfg)
+			require.NoError(t, err)
+
+			src, ok := eng.Registry().Get(sourceID)
+			require.True(t, ok, "source should be registered")
+			assert.Equal(t, tt.expectSampleRate, src.SampleRate,
+				"registry SampleRate should be defaulted")
+			assert.Equal(t, tt.expectBitDepth, src.BitDepth,
+				"registry BitDepth should be defaulted")
+			assert.Equal(t, tt.expectChannels, src.Channels,
+				"registry Channels should be defaulted")
+		})
+	}
+}
+
+// TestEngine_ReconfigureSource_ZeroAudioParams verifies that zero-value
+// audio parameters are defaulted during reconfiguration and the registry
+// is updated with the effective values.
+func TestEngine_ReconfigureSource_ZeroAudioParams(t *testing.T) {
+	t.Parallel()
+	eng, stop := newTestEngine(t)
+	defer stop()
+
+	cfg := &audiocore.SourceConfig{
+		ID:               "test_reconfig_zero",
+		DisplayName:      "Reconfigure Zero Test",
+		Type:             audiocore.SourceTypeRTSP,
+		ConnectionString: "rtsp://192.168.1.100/zero",
+		SampleRate:       48000,
+		BitDepth:         16,
+		Channels:         1,
+	}
+	require.NoError(t, eng.AddSource(cfg))
+
+	newCfg := &audiocore.SourceConfig{
+		ConnectionString: "rtsp://192.168.1.100/zero_v2",
+		SampleRate:       0,
+		BitDepth:         0,
+		Channels:         0,
+	}
+	require.NoError(t, eng.ReconfigureSource("test_reconfig_zero", newCfg))
+
+	src, ok := eng.Registry().Get("test_reconfig_zero")
+	require.True(t, ok)
+	assert.Equal(t, defaultSampleRate, src.SampleRate,
+		"registry SampleRate should be defaulted after reconfigure")
+	assert.Equal(t, defaultBitDepth, src.BitDepth,
+		"registry BitDepth should be defaulted after reconfigure")
+	assert.Equal(t, defaultChannels, src.Channels,
+		"registry Channels should be defaulted after reconfigure")
+}


### PR DESCRIPTION
## Summary

- Add `defaultBitDepth = 16` constant and apply the same `<= 0` fallback in `StartStream`, `AddSource`, and `ReconfigureSource`, closing the gap where BitDepth was the only audio parameter without defensive defaulting
- Fix buffer leak in `ReconfigureSource`: when `StartStream` or `StartCapture` fails, newly allocated analysis and capture buffers are now deallocated (matching `AddSource`'s cleanup pattern)
- Add tests verifying zero-value audio params (SampleRate, BitDepth, Channels) are properly defaulted in both `AddSource` and `ReconfigureSource`

## Test plan

- [x] `go test -race ./internal/audiocore/...` passes (765 tests, 11 packages)
- [x] New tests: `TestEngine_AddSource_ZeroAudioParams` (3 subtests), `TestEngine_ReconfigureSource_ZeroAudioParams`
- [x] `golangci-lint run -v` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Audio bit depth now consistently defaults when unset or invalid during source add, reconfigure, and stream start; logs reflect the effective bit depth.
  * Engine now deallocates source buffers on reconfigure failures to avoid leaked resources.

* **Tests**
  * Added tests verifying defaulting behavior for audio parameters and stream start fallback when bit depth is zero.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3146?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->