### PR TITLE
fix(api): unify query routing to prevent silent filter dropping

### DIFF
--- a/internal/api/v2/detection_routing_test.go
+++ b/internal/api/v2/detection_routing_test.go
@@ -95,7 +95,7 @@ func TestNeedsAdvancedRouting(t *testing.T) {
 			expected: true,
 		},
 
-		// --- Cross-type filter checks (the bug from Forgejo #708) ---
+		// --- Cross-type filter checks (date/hour/species/search on non-native query types) ---
 
 		// Species on non-species query types
 		{

--- a/internal/api/v2/detection_routing_test.go
+++ b/internal/api/v2/detection_routing_test.go
@@ -1,0 +1,196 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNeedsAdvancedRouting(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		params   detectionQueryParams
+		expected bool
+	}{
+		// --- Basic cases: no filters should not trigger advanced routing ---
+		{
+			name:     "empty params",
+			params:   detectionQueryParams{},
+			expected: false,
+		},
+		{
+			name:     "hourly with just date and hour",
+			params:   detectionQueryParams{QueryType: queryTypeHourly, Date: "2025-06-01", Hour: "10"},
+			expected: false,
+		},
+		{
+			name:     "species with just species and date",
+			params:   detectionQueryParams{QueryType: queryTypeSpecies, Species: "Turdus merula", Date: "2025-06-01"},
+			expected: false,
+		},
+		{
+			name:     "search with just search term",
+			params:   detectionQueryParams{QueryType: queryTypeSearch, Search: "robin"},
+			expected: false,
+		},
+
+		// --- Advanced filters always trigger routing ---
+		{
+			name:     "confidence triggers advanced",
+			params:   detectionQueryParams{Confidence: "0.8"},
+			expected: true,
+		},
+		{
+			name:     "timeOfDay triggers advanced",
+			params:   detectionQueryParams{TimeOfDay: "morning"},
+			expected: true,
+		},
+		{
+			name:     "verified triggers advanced",
+			params:   detectionQueryParams{Verified: "correct"},
+			expected: true,
+		},
+		{
+			name:     "location triggers advanced",
+			params:   detectionQueryParams{Location: "backyard"},
+			expected: true,
+		},
+		{
+			name:     "locked triggers advanced",
+			params:   detectionQueryParams{Locked: "true"},
+			expected: true,
+		},
+		{
+			name:     "hourRange triggers advanced",
+			params:   detectionQueryParams{HourRange: "6-18"},
+			expected: true,
+		},
+		{
+			name:     "startDate triggers advanced",
+			params:   detectionQueryParams{StartDate: "2025-01-01"},
+			expected: true,
+		},
+		{
+			name:     "endDate triggers advanced",
+			params:   detectionQueryParams{EndDate: "2025-12-31"},
+			expected: true,
+		},
+
+		// --- Sort behavior ---
+		{
+			name:     "non-default sort triggers advanced for default queryType",
+			params:   detectionQueryParams{SortBy: "confidence_desc"},
+			expected: true,
+		},
+		{
+			name:     "date_desc sort does not trigger advanced for default queryType",
+			params:   detectionQueryParams{SortBy: sortByDateDesc},
+			expected: false,
+		},
+		{
+			name:     "any sort triggers advanced for hourly",
+			params:   detectionQueryParams{QueryType: queryTypeHourly, SortBy: sortByDateDesc},
+			expected: true,
+		},
+
+		// --- Cross-type filter checks (the bug from Forgejo #708) ---
+
+		// Species on non-species query types
+		{
+			name:     "species on search queryType triggers advanced",
+			params:   detectionQueryParams{QueryType: queryTypeSearch, Search: "robin", Species: "Turdus merula"},
+			expected: true,
+		},
+		{
+			name:     "species on default queryType triggers advanced",
+			params:   detectionQueryParams{Species: "Turdus merula"},
+			expected: true,
+		},
+		{
+			name:     "species on hourly queryType triggers advanced",
+			params:   detectionQueryParams{QueryType: queryTypeHourly, Hour: "10", Species: "Turdus merula"},
+			expected: true,
+		},
+		{
+			name:     "species on species queryType does NOT trigger (handled natively)",
+			params:   detectionQueryParams{QueryType: queryTypeSpecies, Species: "Turdus merula"},
+			expected: false,
+		},
+
+		// Search on non-search query types
+		{
+			name:     "search on default queryType triggers advanced",
+			params:   detectionQueryParams{Search: "robin"},
+			expected: true,
+		},
+		{
+			name:     "search on hourly queryType triggers advanced",
+			params:   detectionQueryParams{QueryType: queryTypeHourly, Hour: "10", Search: "robin"},
+			expected: true,
+		},
+		{
+			name:     "search on species queryType triggers advanced",
+			params:   detectionQueryParams{QueryType: queryTypeSpecies, Species: "Turdus merula", Search: "robin"},
+			expected: true,
+		},
+		{
+			name:     "search on search queryType does NOT trigger (handled natively)",
+			params:   detectionQueryParams{QueryType: queryTypeSearch, Search: "robin"},
+			expected: false,
+		},
+
+		// Date on query types that don't handle it natively
+		{
+			name:     "date on search queryType triggers advanced",
+			params:   detectionQueryParams{QueryType: queryTypeSearch, Search: "robin", Date: "2025-06-01"},
+			expected: true,
+		},
+		{
+			name:     "date on default queryType triggers advanced",
+			params:   detectionQueryParams{Date: "2025-06-01"},
+			expected: true,
+		},
+		{
+			name:     "date on hourly queryType does NOT trigger (handled natively)",
+			params:   detectionQueryParams{QueryType: queryTypeHourly, Hour: "10", Date: "2025-06-01"},
+			expected: false,
+		},
+		{
+			name:     "date on species queryType does NOT trigger (handled natively)",
+			params:   detectionQueryParams{QueryType: queryTypeSpecies, Species: "Turdus merula", Date: "2025-06-01"},
+			expected: false,
+		},
+
+		// Hour on query types that don't handle it natively
+		{
+			name:     "hour on search queryType triggers advanced",
+			params:   detectionQueryParams{QueryType: queryTypeSearch, Search: "robin", Hour: "14"},
+			expected: true,
+		},
+		{
+			name:     "hour on default queryType triggers advanced",
+			params:   detectionQueryParams{Hour: "14"},
+			expected: true,
+		},
+		{
+			name:     "hour on hourly queryType does NOT trigger (handled natively)",
+			params:   detectionQueryParams{QueryType: queryTypeHourly, Hour: "14"},
+			expected: false,
+		},
+		{
+			name:     "hour on species queryType does NOT trigger (handled natively)",
+			params:   detectionQueryParams{QueryType: queryTypeSpecies, Species: "Turdus merula", Hour: "14"},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := tt.params.needsAdvancedRouting()
+			assert.Equal(t, tt.expected, result, "needsAdvancedRouting() mismatch")
+		})
+	}
+}

--- a/internal/api/v2/detections.go
+++ b/internal/api/v2/detections.go
@@ -603,11 +603,9 @@ func (c *Controller) GetDetections(ctx echo.Context) error {
 }
 
 // needsAdvancedRouting reports whether the query parameters require routing
-// through the advanced search path instead of the dedicated hourly/species
-// handlers. It checks for a non-default sort (for hourly queries ANY explicit
-// sort is non-default since the handler natively sorts by time ASC; for other
-// types only sorts other than date_desc are non-default) and for cross-type
-// filters that the simple handlers would silently ignore.
+// through the advanced search path instead of the dedicated handlers.
+// It checks for advanced filters, non-default sort, and cross-type parameters
+// that the simple handlers would silently ignore.
 func (p *detectionQueryParams) needsAdvancedRouting() bool {
 	if p.Confidence != "" || p.TimeOfDay != "" ||
 		p.HourRange != "" || p.Verified != "" ||
@@ -629,20 +627,19 @@ func (p *detectionQueryParams) needsAdvancedRouting() bool {
 		return true
 	}
 
+	// Date and Hour are handled natively by hourly and species handlers.
+	// For search and default query types, they must trigger advanced routing.
+	if p.QueryType != queryTypeHourly && p.QueryType != queryTypeSpecies {
+		if p.Date != "" || p.Hour != "" {
+			return true
+		}
+	}
+
 	return false
 }
 
 // getDetectionsByQueryType retrieves detections based on the query type
 func (c *Controller) getDetectionsByQueryType(params *detectionQueryParams) ([]datastore.Note, int64, error) {
-	// Check if advanced filters are present (non-default sort counts as advanced).
-	// Date parameters are included so that ?date=2025-03-07 without an explicit
-	// queryType routes through the advanced search path instead of being ignored.
-	hasAdvancedFilters := params.Confidence != "" || params.TimeOfDay != "" ||
-		params.HourRange != "" || params.Verified != "" ||
-		params.Location != "" || params.Locked != "" ||
-		params.Date != "" || params.StartDate != "" || params.EndDate != "" ||
-		(params.SortBy != "" && params.SortBy != sortByDateDesc)
-
 	// Resolve locale common names to scientific names before routing so every
 	// query type benefits without per-case duplication.
 	if resolved, hit := c.resolveSpeciesToScientific(params.Species); hit {
@@ -664,12 +661,12 @@ func (c *Controller) getDetectionsByQueryType(params *detectionQueryParams) ([]d
 		}
 		return c.getSpeciesDetections(params.Species, params.Date, params.Hour, params.Duration, params.NumResults, params.Offset)
 	case queryTypeSearch:
-		if hasAdvancedFilters {
+		if params.needsAdvancedRouting() {
 			return c.getSearchDetectionsAdvanced(params)
 		}
 		return c.getSearchDetections(params.Search, params.NumResults, params.Offset)
-	default: // "all" or any other value
-		if hasAdvancedFilters {
+	default:
+		if params.needsAdvancedRouting() {
 			return c.getSearchDetectionsAdvanced(params)
 		}
 		return c.getAllDetections(params.NumResults, params.Offset)


### PR DESCRIPTION
## Summary

- Consolidate `hasAdvancedFilters` variable into the existing `needsAdvancedRouting()` method, creating a single source of truth for query routing decisions
- Add Date and Hour cross-type checks so search/default query types correctly route to the advanced handler when these parameters are present
- Use `needsAdvancedRouting()` for all four query type branches in the switch (previously only used for hourly/species)
- Add comprehensive unit tests (32 table-driven cases) covering all routing scenarios

## Problem

The `hasAdvancedFilters` variable (used for `queryTypeSearch` and default query types) was missing checks for Species, Search, Date, and Hour parameters. This caused API requests with contradictory parameter combinations to silently drop filters:

- `queryType=all&search=robin` would ignore the search filter
- `queryType=search&species=Turdus+merula` would ignore the species filter  
- `queryType=search&date=2025-06-01` would ignore the date filter
- `queryType=all&hour=14` would ignore the hour filter

The auto-inference logic mitigated the common case (no explicit queryType), but explicit contradictory parameters from API clients were affected.

## Test plan

- [x] 32 table-driven unit tests covering all query type and parameter combinations
- [x] Tests verified RED before implementation (4 failures for Date/Hour on search/default)
- [x] All tests pass with `-race` flag
- [x] golangci-lint clean
- [x] Gate review passed (4 Claude agents + Gemini cross-validation, zero issues)