### PR TITLE
feat(health): add context.Context to datastore health check methods

### DIFF
--- a/internal/analysis/processor/mock_datastore_test.go
+++ b/internal/analysis/processor/mock_datastore_test.go
@@ -352,11 +352,15 @@ func (m *ActionMockDatastore) DeleteExpiredNotificationHistory(_ time.Time) (int
 }
 func (m *ActionMockDatastore) SchemaVersion() string     { return datastore.SchemaVersionLegacy }
 func (m *ActionMockDatastore) UpdateNameMaps(_ []string) {}
-func (m *ActionMockDatastore) GetDatabaseStats() (*datastore.DatabaseStats, error) {
+func (m *ActionMockDatastore) GetDatabaseStats(_ context.Context) (*datastore.DatabaseStats, error) {
 	return &datastore.DatabaseStats{Type: "mock", Connected: true}, nil
 }
-func (m *ActionMockDatastore) PingWithLatency() (time.Duration, error)       { return 0, nil }
-func (m *ActionMockDatastore) CountDetectionsSince(_ time.Time) (int, error) { return 0, nil }
+func (m *ActionMockDatastore) PingWithLatency(_ context.Context) (time.Duration, error) {
+	return 0, nil
+}
+func (m *ActionMockDatastore) CountDetectionsSince(_ context.Context, _ time.Time) (int, error) {
+	return 0, nil
+}
 
 // Migration bulk fetch methods
 func (m *ActionMockDatastore) GetAllReviews() ([]datastore.NoteReview, error)   { return nil, nil }

--- a/internal/analysis/processor/threshold_persistence_test.go
+++ b/internal/analysis/processor/threshold_persistence_test.go
@@ -347,14 +347,16 @@ func (m *MockDatastore) DeleteExpiredNotificationHistory(before time.Time) (int6
 
 func (m *MockDatastore) SchemaVersion() string     { return datastore.SchemaVersionLegacy }
 func (m *MockDatastore) UpdateNameMaps(_ []string) {}
-func (m *MockDatastore) GetDatabaseStats() (*datastore.DatabaseStats, error) {
+func (m *MockDatastore) GetDatabaseStats(_ context.Context) (*datastore.DatabaseStats, error) {
 	return &datastore.DatabaseStats{
 		Type:      "mock",
 		Connected: true,
 	}, nil
 }
-func (m *MockDatastore) PingWithLatency() (time.Duration, error)       { return 0, nil }
-func (m *MockDatastore) CountDetectionsSince(_ time.Time) (int, error) { return 0, nil }
+func (m *MockDatastore) PingWithLatency(_ context.Context) (time.Duration, error) { return 0, nil }
+func (m *MockDatastore) CountDetectionsSince(_ context.Context, _ time.Time) (int, error) {
+	return 0, nil
+}
 
 // Migration bulk fetch methods
 func (m *MockDatastore) GetAllReviews() ([]datastore.NoteReview, error) {

--- a/internal/api/v2/database_overview.go
+++ b/internal/api/v2/database_overview.go
@@ -46,7 +46,7 @@ const detectionRateCacheTTL = 5 * time.Minute
 // into a single response.
 func (c *Controller) GetDatabaseOverview(ctx echo.Context) error {
 	// Get basic database stats from the store
-	basicStats, err := c.DS.GetDatabaseStats()
+	basicStats, err := c.DS.GetDatabaseStats(ctx.Request().Context())
 	if err != nil || basicStats == nil {
 		if err != nil {
 			c.logDebugIfEnabled("Database stats unavailable", logger.Error(err))

--- a/internal/api/v2/diagnostics.go
+++ b/internal/api/v2/diagnostics.go
@@ -2,6 +2,7 @@
 package api
 
 import (
+	"context"
 	"net/http"
 	"path/filepath"
 	"strconv"
@@ -121,12 +122,12 @@ func (c *Controller) registerHealthChecks() {
 			windowMS = stride * 1000.0
 			return avgMS, p99MS, windowMS
 		}),
-		checks.NewDetectionRateCheck(func(hours int) (int, error) {
+		checks.NewDetectionRateCheck(func(ctx context.Context, hours int) (int, error) {
 			if c.DS == nil {
 				return 0, errors.NewStd("datastore unavailable")
 			}
 			since := time.Now().Add(-time.Duration(hours) * time.Hour)
-			return c.DS.CountDetectionsSince(since)
+			return c.DS.CountDetectionsSince(ctx, since)
 		}),
 		checks.NewQueueDepthCheck(func() (int, int) {
 			q := classifier.ResultsQueue
@@ -152,11 +153,11 @@ func (c *Controller) registerHealthChecks() {
 			}
 			return true, dbType + " (auto-migrated at startup)", nil
 		}),
-		checks.NewDatabasePerformanceCheck(func() (time.Duration, error) {
+		checks.NewDatabasePerformanceCheck(func(ctx context.Context) (time.Duration, error) {
 			if c.DS == nil {
 				return 0, errors.NewStd("datastore unavailable")
 			}
-			return c.DS.PingWithLatency()
+			return c.DS.PingWithLatency(ctx)
 		}),
 
 		// Network checks

--- a/internal/api/v2/system.go
+++ b/internal/api/v2/system.go
@@ -1529,7 +1529,7 @@ func (c *Controller) GetDatabaseStats(ctx echo.Context) error {
 	}
 
 	// Get database stats from the datastore
-	stats, err := c.DS.GetDatabaseStats()
+	stats, err := c.DS.GetDatabaseStats(ctx.Request().Context())
 
 	// Handle errors first
 	isPartialStats := false

--- a/internal/datastore/detection_repository.go
+++ b/internal/datastore/detection_repository.go
@@ -558,7 +558,7 @@ func (r *detectionRepository) parseDateWithDefault(dateStr string, defaultToNow 
 // CountAll returns the total count of all detections.
 // This is a lightweight count operation that doesn't load any data.
 func (r *detectionRepository) CountAll(ctx context.Context) (int64, error) {
-	stats, err := r.store.GetDatabaseStats()
+	stats, err := r.store.GetDatabaseStats(ctx)
 	if err != nil {
 		return 0, fmt.Errorf("failed to count detections: %w", err)
 	}

--- a/internal/datastore/interfaces.go
+++ b/internal/datastore/interfaces.go
@@ -220,11 +220,11 @@ type Interface interface {
 	GetActiveNotificationHistory(after time.Time) ([]NotificationHistory, error)
 	DeleteExpiredNotificationHistory(before time.Time) (int64, error) // Returns count deleted
 	// Database stats method for runtime statistics
-	GetDatabaseStats() (*DatabaseStats, error)
+	GetDatabaseStats(ctx context.Context) (*DatabaseStats, error)
 	// PingWithLatency executes a trivial query (SELECT 1) and returns the round-trip time.
-	PingWithLatency() (time.Duration, error)
+	PingWithLatency(ctx context.Context) (time.Duration, error)
 	// CountDetectionsSince returns the number of detections recorded since the given time.
-	CountDetectionsSince(since time.Time) (int, error)
+	CountDetectionsSince(ctx context.Context, since time.Time) (int, error)
 	// SchemaVersion returns the datastore schema version ("legacy" or "v2").
 	SchemaVersion() string
 	// UpdateNameMaps rebuilds species name lookup maps from updated BirdNET labels.
@@ -258,25 +258,25 @@ type DataStore struct {
 }
 
 // PingWithLatency executes SELECT 1 and returns the round-trip time.
-func (ds *DataStore) PingWithLatency() (time.Duration, error) {
+func (ds *DataStore) PingWithLatency(ctx context.Context) (time.Duration, error) {
 	if ds.DB == nil {
 		return 0, ErrDBNotConnected
 	}
 	start := time.Now()
 	var result int
-	if err := ds.DB.Raw("SELECT 1").Scan(&result).Error; err != nil {
+	if err := ds.DB.WithContext(ctx).Raw("SELECT 1").Scan(&result).Error; err != nil {
 		return 0, fmt.Errorf("database ping failed: %w", err)
 	}
 	return time.Since(start), nil
 }
 
 // CountDetectionsSince returns the number of detections recorded since the given time.
-func (ds *DataStore) CountDetectionsSince(since time.Time) (int, error) {
+func (ds *DataStore) CountDetectionsSince(ctx context.Context, since time.Time) (int, error) {
 	if ds.DB == nil {
 		return 0, ErrDBNotConnected
 	}
 	var count int64
-	if err := ds.DB.Model(&Note{}).Where("begin_time >= ?", since).Count(&count).Error; err != nil {
+	if err := ds.DB.WithContext(ctx).Model(&Note{}).Where("begin_time >= ?", since).Count(&count).Error; err != nil {
 		return 0, fmt.Errorf("count detections failed: %w", err)
 	}
 	return int(count), nil

--- a/internal/datastore/mocks/mock_Interface.go
+++ b/internal/datastore/mocks/mock_Interface.go
@@ -177,9 +177,9 @@ func (_c *MockInterface_Close_Call) RunAndReturn(run func() error) *MockInterfac
 	return _c
 }
 
-// CountDetectionsSince provides a mock function with given fields: since
-func (_m *MockInterface) CountDetectionsSince(since time.Time) (int, error) {
-	ret := _m.Called(since)
+// CountDetectionsSince provides a mock function with given fields: ctx, since
+func (_m *MockInterface) CountDetectionsSince(ctx context.Context, since time.Time) (int, error) {
+	ret := _m.Called(ctx, since)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CountDetectionsSince")
@@ -187,17 +187,17 @@ func (_m *MockInterface) CountDetectionsSince(since time.Time) (int, error) {
 
 	var r0 int
 	var r1 error
-	if rf, ok := ret.Get(0).(func(time.Time) (int, error)); ok {
-		return rf(since)
+	if rf, ok := ret.Get(0).(func(context.Context, time.Time) (int, error)); ok {
+		return rf(ctx, since)
 	}
-	if rf, ok := ret.Get(0).(func(time.Time) int); ok {
-		r0 = rf(since)
+	if rf, ok := ret.Get(0).(func(context.Context, time.Time) int); ok {
+		r0 = rf(ctx, since)
 	} else {
 		r0 = ret.Get(0).(int)
 	}
 
-	if rf, ok := ret.Get(1).(func(time.Time) error); ok {
-		r1 = rf(since)
+	if rf, ok := ret.Get(1).(func(context.Context, time.Time) error); ok {
+		r1 = rf(ctx, since)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -211,14 +211,15 @@ type MockInterface_CountDetectionsSince_Call struct {
 }
 
 // CountDetectionsSince is a helper method to define mock.On call
+//   - ctx context.Context
 //   - since time.Time
-func (_e *MockInterface_Expecter) CountDetectionsSince(since interface{}) *MockInterface_CountDetectionsSince_Call {
-	return &MockInterface_CountDetectionsSince_Call{Call: _e.mock.On("CountDetectionsSince", since)}
+func (_e *MockInterface_Expecter) CountDetectionsSince(ctx interface{}, since interface{}) *MockInterface_CountDetectionsSince_Call {
+	return &MockInterface_CountDetectionsSince_Call{Call: _e.mock.On("CountDetectionsSince", ctx, since)}
 }
 
-func (_c *MockInterface_CountDetectionsSince_Call) Run(run func(since time.Time)) *MockInterface_CountDetectionsSince_Call {
+func (_c *MockInterface_CountDetectionsSince_Call) Run(run func(ctx context.Context, since time.Time)) *MockInterface_CountDetectionsSince_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(time.Time))
+		run(args[0].(context.Context), args[1].(time.Time))
 	})
 	return _c
 }
@@ -228,7 +229,7 @@ func (_c *MockInterface_CountDetectionsSince_Call) Return(_a0 int, _a1 error) *M
 	return _c
 }
 
-func (_c *MockInterface_CountDetectionsSince_Call) RunAndReturn(run func(time.Time) (int, error)) *MockInterface_CountDetectionsSince_Call {
+func (_c *MockInterface_CountDetectionsSince_Call) RunAndReturn(run func(context.Context, time.Time) (int, error)) *MockInterface_CountDetectionsSince_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -1838,9 +1839,9 @@ func (_c *MockInterface_GetDailyEvents_Call) RunAndReturn(run func(string) (data
 	return _c
 }
 
-// GetDatabaseStats provides a mock function with no fields
-func (_m *MockInterface) GetDatabaseStats() (*datastore.DatabaseStats, error) {
-	ret := _m.Called()
+// GetDatabaseStats provides a mock function with given fields: ctx
+func (_m *MockInterface) GetDatabaseStats(ctx context.Context) (*datastore.DatabaseStats, error) {
+	ret := _m.Called(ctx)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetDatabaseStats")
@@ -1848,19 +1849,19 @@ func (_m *MockInterface) GetDatabaseStats() (*datastore.DatabaseStats, error) {
 
 	var r0 *datastore.DatabaseStats
 	var r1 error
-	if rf, ok := ret.Get(0).(func() (*datastore.DatabaseStats, error)); ok {
-		return rf()
+	if rf, ok := ret.Get(0).(func(context.Context) (*datastore.DatabaseStats, error)); ok {
+		return rf(ctx)
 	}
-	if rf, ok := ret.Get(0).(func() *datastore.DatabaseStats); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(context.Context) *datastore.DatabaseStats); ok {
+		r0 = rf(ctx)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*datastore.DatabaseStats)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
+	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = rf(ctx)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1874,13 +1875,14 @@ type MockInterface_GetDatabaseStats_Call struct {
 }
 
 // GetDatabaseStats is a helper method to define mock.On call
-func (_e *MockInterface_Expecter) GetDatabaseStats() *MockInterface_GetDatabaseStats_Call {
-	return &MockInterface_GetDatabaseStats_Call{Call: _e.mock.On("GetDatabaseStats")}
+//   - ctx context.Context
+func (_e *MockInterface_Expecter) GetDatabaseStats(ctx interface{}) *MockInterface_GetDatabaseStats_Call {
+	return &MockInterface_GetDatabaseStats_Call{Call: _e.mock.On("GetDatabaseStats", ctx)}
 }
 
-func (_c *MockInterface_GetDatabaseStats_Call) Run(run func()) *MockInterface_GetDatabaseStats_Call {
+func (_c *MockInterface_GetDatabaseStats_Call) Run(run func(ctx context.Context)) *MockInterface_GetDatabaseStats_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		run(args[0].(context.Context))
 	})
 	return _c
 }
@@ -1890,7 +1892,7 @@ func (_c *MockInterface_GetDatabaseStats_Call) Return(_a0 *datastore.DatabaseSta
 	return _c
 }
 
-func (_c *MockInterface_GetDatabaseStats_Call) RunAndReturn(run func() (*datastore.DatabaseStats, error)) *MockInterface_GetDatabaseStats_Call {
+func (_c *MockInterface_GetDatabaseStats_Call) RunAndReturn(run func(context.Context) (*datastore.DatabaseStats, error)) *MockInterface_GetDatabaseStats_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -3821,9 +3823,9 @@ func (_c *MockInterface_Optimize_Call) RunAndReturn(run func(context.Context) er
 	return _c
 }
 
-// PingWithLatency provides a mock function with no fields
-func (_m *MockInterface) PingWithLatency() (time.Duration, error) {
-	ret := _m.Called()
+// PingWithLatency provides a mock function with given fields: ctx
+func (_m *MockInterface) PingWithLatency(ctx context.Context) (time.Duration, error) {
+	ret := _m.Called(ctx)
 
 	if len(ret) == 0 {
 		panic("no return value specified for PingWithLatency")
@@ -3831,17 +3833,17 @@ func (_m *MockInterface) PingWithLatency() (time.Duration, error) {
 
 	var r0 time.Duration
 	var r1 error
-	if rf, ok := ret.Get(0).(func() (time.Duration, error)); ok {
-		return rf()
+	if rf, ok := ret.Get(0).(func(context.Context) (time.Duration, error)); ok {
+		return rf(ctx)
 	}
-	if rf, ok := ret.Get(0).(func() time.Duration); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(context.Context) time.Duration); ok {
+		r0 = rf(ctx)
 	} else {
 		r0 = ret.Get(0).(time.Duration)
 	}
 
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
+	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = rf(ctx)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -3855,13 +3857,14 @@ type MockInterface_PingWithLatency_Call struct {
 }
 
 // PingWithLatency is a helper method to define mock.On call
-func (_e *MockInterface_Expecter) PingWithLatency() *MockInterface_PingWithLatency_Call {
-	return &MockInterface_PingWithLatency_Call{Call: _e.mock.On("PingWithLatency")}
+//   - ctx context.Context
+func (_e *MockInterface_Expecter) PingWithLatency(ctx interface{}) *MockInterface_PingWithLatency_Call {
+	return &MockInterface_PingWithLatency_Call{Call: _e.mock.On("PingWithLatency", ctx)}
 }
 
-func (_c *MockInterface_PingWithLatency_Call) Run(run func()) *MockInterface_PingWithLatency_Call {
+func (_c *MockInterface_PingWithLatency_Call) Run(run func(ctx context.Context)) *MockInterface_PingWithLatency_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		run(args[0].(context.Context))
 	})
 	return _c
 }
@@ -3871,7 +3874,7 @@ func (_c *MockInterface_PingWithLatency_Call) Return(_a0 time.Duration, _a1 erro
 	return _c
 }
 
-func (_c *MockInterface_PingWithLatency_Call) RunAndReturn(run func() (time.Duration, error)) *MockInterface_PingWithLatency_Call {
+func (_c *MockInterface_PingWithLatency_Call) RunAndReturn(run func(context.Context) (time.Duration, error)) *MockInterface_PingWithLatency_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/datastore/monitoring.go
+++ b/internal/datastore/monitoring.go
@@ -87,7 +87,7 @@ func (ds *DataStore) startDatabaseMonitoring(ctx context.Context, interval time.
 				ds.metricsMu.RUnlock()
 
 				// Update database size metrics
-				if dbSize, err := ds.getDatabaseSize(); err == nil && metrics != nil {
+				if dbSize, err := ds.getDatabaseSize(ctx); err == nil && metrics != nil {
 					metrics.UpdateDatabaseSize(dbSize)
 				} else if err != nil {
 					GetLogger().Error("Failed to get database size",
@@ -97,7 +97,7 @@ func (ds *DataStore) startDatabaseMonitoring(ctx context.Context, interval time.
 				// Update table row counts
 				tables := []string{"notes", "results", "image_caches", "note_reviews", "note_locks"}
 				for _, table := range tables {
-					if count, err := ds.getTableRowCount(table); err == nil && metrics != nil {
+					if count, err := ds.getTableRowCount(ctx, table); err == nil && metrics != nil {
 						metrics.UpdateTableRowCount(table, count)
 					} else if err != nil {
 						GetLogger().Error("Failed to get table row count",
@@ -119,13 +119,13 @@ func (ds *DataStore) startDatabaseMonitoring(ctx context.Context, interval time.
 }
 
 // getDatabaseSize returns the total size of the database in bytes
-func (ds *DataStore) getDatabaseSize() (int64, error) {
+func (ds *DataStore) getDatabaseSize(ctx context.Context) (int64, error) {
 	var size int64
 
 	// SQLite-specific query
 	if strings.ToLower(ds.DB.Name()) == "sqlite" {
 		// For SQLite, we use page_count * page_size
-		err := ds.DB.Raw("SELECT page_count * page_size FROM pragma_page_count(), pragma_page_size()").Row().Scan(&size)
+		err := ds.DB.WithContext(ctx).Raw("SELECT page_count * page_size FROM pragma_page_count(), pragma_page_size()").Row().Scan(&size)
 		if err != nil {
 			return 0, fmt.Errorf("failed to get SQLite database size: %w", err)
 		}
@@ -135,13 +135,13 @@ func (ds *DataStore) getDatabaseSize() (int64, error) {
 	// MySQL-specific query
 	if strings.ToLower(ds.DB.Name()) == "mysql" {
 		var dbName string
-		if err := ds.DB.Raw("SELECT DATABASE()").Scan(&dbName).Error; err != nil {
+		if err := ds.DB.WithContext(ctx).Raw("SELECT DATABASE()").Scan(&dbName).Error; err != nil {
 			return 0, fmt.Errorf("failed to get current database name: %w", err)
 		}
 
-		err := ds.DB.Raw(`
-			SELECT SUM(data_length + index_length) 
-			FROM information_schema.tables 
+		err := ds.DB.WithContext(ctx).Raw(`
+			SELECT SUM(data_length + index_length)
+			FROM information_schema.tables
 			WHERE table_schema = ?
 		`, dbName).Scan(&size).Error
 		if err != nil {
@@ -154,9 +154,9 @@ func (ds *DataStore) getDatabaseSize() (int64, error) {
 }
 
 // getTableRowCount returns the number of rows in a specific table
-func (ds *DataStore) getTableRowCount(table string) (int64, error) {
+func (ds *DataStore) getTableRowCount(ctx context.Context, table string) (int64, error) {
 	var count int64
-	err := ds.DB.Table(table).Count(&count).Error
+	err := ds.DB.WithContext(ctx).Table(table).Count(&count).Error
 	if err != nil {
 		return 0, fmt.Errorf("failed to count rows in table %s: %w", table, err)
 	}

--- a/internal/datastore/monitoring.go
+++ b/internal/datastore/monitoring.go
@@ -107,7 +107,7 @@ func (ds *DataStore) startDatabaseMonitoring(ctx context.Context, interval time.
 				}
 
 				// Update active lock count
-				if lockCount, err := ds.getActiveLockCount(); err == nil && metrics != nil {
+				if lockCount, err := ds.getActiveLockCount(ctx); err == nil && metrics != nil {
 					metrics.UpdateActiveLockCount(lockCount)
 				} else if err != nil {
 					GetLogger().Error("Failed to get active lock count",
@@ -164,9 +164,9 @@ func (ds *DataStore) getTableRowCount(ctx context.Context, table string) (int64,
 }
 
 // getActiveLockCount returns the number of active note locks
-func (ds *DataStore) getActiveLockCount() (int, error) {
+func (ds *DataStore) getActiveLockCount(ctx context.Context) (int, error) {
 	var count int64
-	err := ds.DB.Model(&NoteLock{}).Count(&count).Error
+	err := ds.DB.WithContext(ctx).Model(&NoteLock{}).Count(&count).Error
 	if err != nil {
 		return 0, fmt.Errorf("failed to count active locks: %w", err)
 	}

--- a/internal/datastore/monitoring.go
+++ b/internal/datastore/monitoring.go
@@ -125,8 +125,7 @@ func (ds *DataStore) getDatabaseSize(ctx context.Context) (int64, error) {
 	// SQLite-specific query
 	if strings.ToLower(ds.DB.Name()) == "sqlite" {
 		// For SQLite, we use page_count * page_size
-		err := ds.DB.WithContext(ctx).Raw("SELECT page_count * page_size FROM pragma_page_count(), pragma_page_size()").Row().Scan(&size)
-		if err != nil {
+		if err := ds.DB.WithContext(ctx).Raw("SELECT page_count * page_size FROM pragma_page_count(), pragma_page_size()").Scan(&size).Error; err != nil {
 			return 0, fmt.Errorf("failed to get SQLite database size: %w", err)
 		}
 		return size, nil

--- a/internal/datastore/mysql.go
+++ b/internal/datastore/mysql.go
@@ -265,7 +265,7 @@ func (m *MySQLStore) SchemaVersion() string {
 // GetDatabaseStats returns basic runtime statistics about the MySQL database.
 // Returns partial stats with ErrDBNotConnected if the database is unreachable.
 // The Connected field in the returned stats indicates if the DB is reachable.
-func (m *MySQLStore) GetDatabaseStats() (*DatabaseStats, error) {
+func (m *MySQLStore) GetDatabaseStats(ctx context.Context) (*DatabaseStats, error) {
 	// Defensive guard for nil Settings (e.g., in custom test setups)
 	location := ""
 	if m.Settings != nil {
@@ -291,18 +291,18 @@ func (m *MySQLStore) GetDatabaseStats() (*DatabaseStats, error) {
 		return stats, ErrDBNotConnected
 	}
 
-	if err := sqlDB.Ping(); err != nil {
+	if err := sqlDB.PingContext(ctx); err != nil {
 		return stats, ErrDBNotConnected
 	}
 	stats.Connected = true
 
 	// Get database size (ignore errors, size stays 0)
-	if size, sizeErr := m.getDatabaseSize(); sizeErr == nil {
+	if size, sizeErr := m.getDatabaseSize(ctx); sizeErr == nil {
 		stats.SizeBytes = size
 	}
 
 	// Get total detections (ignore errors, count stays 0)
-	if count, countErr := m.getTableRowCount("notes"); countErr == nil {
+	if count, countErr := m.getTableRowCount(ctx, "notes"); countErr == nil {
 		stats.TotalDetections = count
 	}
 

--- a/internal/datastore/sqlite.go
+++ b/internal/datastore/sqlite.go
@@ -623,7 +623,7 @@ func (s *SQLiteStore) SchemaVersion() string {
 // GetDatabaseStats returns basic runtime statistics about the SQLite database.
 // Returns partial stats with ErrDBNotConnected if the database is unreachable.
 // The Connected field in the returned stats indicates if the DB is reachable.
-func (s *SQLiteStore) GetDatabaseStats() (*DatabaseStats, error) {
+func (s *SQLiteStore) GetDatabaseStats(ctx context.Context) (*DatabaseStats, error) {
 	// Defensive guard for nil Settings (e.g., in custom test setups)
 	location := ""
 	if s.Settings != nil {
@@ -646,18 +646,18 @@ func (s *SQLiteStore) GetDatabaseStats() (*DatabaseStats, error) {
 		return stats, ErrDBNotConnected
 	}
 
-	if err := sqlDB.Ping(); err != nil {
+	if err := sqlDB.PingContext(ctx); err != nil {
 		return stats, ErrDBNotConnected
 	}
 	stats.Connected = true
 
 	// Get database size (ignore errors, size stays 0)
-	if size, sizeErr := s.getDatabaseSize(); sizeErr == nil {
+	if size, sizeErr := s.getDatabaseSize(ctx); sizeErr == nil {
 		stats.SizeBytes = size
 	}
 
 	// Get total detections (ignore errors, count stays 0)
-	if count, countErr := s.getTableRowCount("notes"); countErr == nil {
+	if count, countErr := s.getTableRowCount(ctx, "notes"); countErr == nil {
 		stats.TotalDetections = count
 	}
 

--- a/internal/datastore/v2/migration/testutil/setup.go
+++ b/internal/datastore/v2/migration/testutil/setup.go
@@ -793,11 +793,17 @@ func (s *testLegacyInterface) GetNotificationHistory(_, _ string) (*datastore.No
 func (s *testLegacyInterface) DeleteExpiredNotificationHistory(_ time.Time) (int64, error) {
 	return 0, nil
 }
-func (s *testLegacyInterface) SchemaVersion() string                               { return datastore.SchemaVersionLegacy }
-func (s *testLegacyInterface) UpdateNameMaps(_ []string)                           {}
-func (s *testLegacyInterface) GetDatabaseStats() (*datastore.DatabaseStats, error) { return nil, nil } //nolint:nilnil // stub
-func (s *testLegacyInterface) PingWithLatency() (time.Duration, error)             { return 0, nil }
-func (s *testLegacyInterface) CountDetectionsSince(_ time.Time) (int, error)       { return 0, nil }
+func (s *testLegacyInterface) SchemaVersion() string     { return datastore.SchemaVersionLegacy }
+func (s *testLegacyInterface) UpdateNameMaps(_ []string) {}
+func (s *testLegacyInterface) GetDatabaseStats(_ context.Context) (*datastore.DatabaseStats, error) {
+	return nil, nil //nolint:nilnil // stub
+}
+func (s *testLegacyInterface) PingWithLatency(_ context.Context) (time.Duration, error) {
+	return 0, nil
+}
+func (s *testLegacyInterface) CountDetectionsSince(_ context.Context, _ time.Time) (int, error) {
+	return 0, nil
+}
 
 // Migration bulk fetch methods - query actual database for integration tests
 

--- a/internal/datastore/v2only/datastore.go
+++ b/internal/datastore/v2only/datastore.go
@@ -472,16 +472,13 @@ func (ds *Datastore) GetDatabaseStats(ctx context.Context) (*datastore.DatabaseS
 	// Get database size (best-effort); guard against nil DB after concurrent Close()
 	if db := ds.manager.DB(); db != nil {
 		if !ds.manager.IsMySQL() {
-			var pageCount, pageSize int64
-			db.WithContext(ctx).Raw("PRAGMA page_count").Scan(&pageCount)
-			db.WithContext(ctx).Raw("PRAGMA page_size").Scan(&pageSize)
-			stats.SizeBytes = pageCount * pageSize
+			_ = db.WithContext(ctx).Raw("SELECT page_count * page_size FROM pragma_page_count(), pragma_page_size()").Scan(&stats.SizeBytes).Error
 		} else {
-			db.WithContext(ctx).Raw(`
+			_ = db.WithContext(ctx).Raw(`
 				SELECT SUM(DATA_LENGTH + INDEX_LENGTH)
 				FROM information_schema.TABLES
 				WHERE TABLE_SCHEMA = DATABASE()
-			`).Scan(&stats.SizeBytes)
+			`).Scan(&stats.SizeBytes).Error
 		}
 	}
 

--- a/internal/datastore/v2only/datastore.go
+++ b/internal/datastore/v2only/datastore.go
@@ -424,35 +424,34 @@ func (ds *Datastore) SchemaVersion() string {
 }
 
 // PingWithLatency executes SELECT 1 and returns the round-trip time.
-func (ds *Datastore) PingWithLatency() (time.Duration, error) {
+func (ds *Datastore) PingWithLatency(ctx context.Context) (time.Duration, error) {
 	db := ds.manager.DB()
 	if db == nil {
 		return 0, datastore.ErrDBNotConnected
 	}
 	start := time.Now()
 	var result int
-	if err := db.Raw("SELECT 1").Scan(&result).Error; err != nil {
+	if err := db.WithContext(ctx).Raw("SELECT 1").Scan(&result).Error; err != nil {
 		return 0, fmt.Errorf("database ping failed: %w", err)
 	}
 	return time.Since(start), nil
 }
 
 // CountDetectionsSince returns the number of detections recorded since the given time.
-func (ds *Datastore) CountDetectionsSince(since time.Time) (int, error) {
+func (ds *Datastore) CountDetectionsSince(ctx context.Context, since time.Time) (int, error) {
 	db := ds.manager.DB()
 	if db == nil {
 		return 0, datastore.ErrDBNotConnected
 	}
 	var count int64
-	if err := db.Model(&entities.Detection{}).Where("detected_at >= ?", since.Unix()).Count(&count).Error; err != nil {
+	if err := db.WithContext(ctx).Model(&entities.Detection{}).Where("detected_at >= ?", since.Unix()).Count(&count).Error; err != nil {
 		return 0, fmt.Errorf("count detections failed: %w", err)
 	}
 	return int(count), nil
 }
 
 // GetDatabaseStats returns database statistics.
-func (ds *Datastore) GetDatabaseStats() (*datastore.DatabaseStats, error) {
-	ctx := context.Background()
+func (ds *Datastore) GetDatabaseStats(ctx context.Context) (*datastore.DatabaseStats, error) {
 	count, err := ds.detection.CountAll(ctx)
 	if err != nil {
 		return nil, err
@@ -474,12 +473,12 @@ func (ds *Datastore) GetDatabaseStats() (*datastore.DatabaseStats, error) {
 	if !ds.manager.IsMySQL() {
 		var pageCount, pageSize int64
 		db := ds.manager.DB()
-		db.Raw("PRAGMA page_count").Scan(&pageCount)
-		db.Raw("PRAGMA page_size").Scan(&pageSize)
+		db.WithContext(ctx).Raw("PRAGMA page_count").Scan(&pageCount)
+		db.WithContext(ctx).Raw("PRAGMA page_size").Scan(&pageSize)
 		stats.SizeBytes = pageCount * pageSize
 	} else {
 		db := ds.manager.DB()
-		db.Raw(`
+		db.WithContext(ctx).Raw(`
 			SELECT SUM(DATA_LENGTH + INDEX_LENGTH)
 			FROM information_schema.TABLES
 			WHERE TABLE_SCHEMA = DATABASE()

--- a/internal/datastore/v2only/datastore.go
+++ b/internal/datastore/v2only/datastore.go
@@ -469,20 +469,20 @@ func (ds *Datastore) GetDatabaseStats(ctx context.Context) (*datastore.DatabaseS
 		Location:        ds.manager.Path(),
 	}
 
-	// Get database size (best-effort)
-	if !ds.manager.IsMySQL() {
-		var pageCount, pageSize int64
-		db := ds.manager.DB()
-		db.WithContext(ctx).Raw("PRAGMA page_count").Scan(&pageCount)
-		db.WithContext(ctx).Raw("PRAGMA page_size").Scan(&pageSize)
-		stats.SizeBytes = pageCount * pageSize
-	} else {
-		db := ds.manager.DB()
-		db.WithContext(ctx).Raw(`
-			SELECT SUM(DATA_LENGTH + INDEX_LENGTH)
-			FROM information_schema.TABLES
-			WHERE TABLE_SCHEMA = DATABASE()
-		`).Scan(&stats.SizeBytes)
+	// Get database size (best-effort); guard against nil DB after concurrent Close()
+	if db := ds.manager.DB(); db != nil {
+		if !ds.manager.IsMySQL() {
+			var pageCount, pageSize int64
+			db.WithContext(ctx).Raw("PRAGMA page_count").Scan(&pageCount)
+			db.WithContext(ctx).Raw("PRAGMA page_size").Scan(&pageSize)
+			stats.SizeBytes = pageCount * pageSize
+		} else {
+			db.WithContext(ctx).Raw(`
+				SELECT SUM(DATA_LENGTH + INDEX_LENGTH)
+				FROM information_schema.TABLES
+				WHERE TABLE_SCHEMA = DATABASE()
+			`).Scan(&stats.SizeBytes)
+		}
 	}
 
 	return stats, nil

--- a/internal/datastore/v2only/datastore_test.go
+++ b/internal/datastore/v2only/datastore_test.go
@@ -703,7 +703,7 @@ func TestV2OnlyDatastore_GetDatabaseStats(t *testing.T) {
 	require.NoError(t, err)
 
 	// Get stats
-	stats, err := ds.GetDatabaseStats()
+	stats, err := ds.GetDatabaseStats(t.Context())
 	require.NoError(t, err)
 	assert.Equal(t, "sqlite", stats.Type)
 	assert.Equal(t, int64(1), stats.TotalDetections)

--- a/internal/health/checks/analysis.go
+++ b/internal/health/checks/analysis.go
@@ -134,11 +134,11 @@ func (c *InferenceLatencyCheck) Run(_ context.Context) health.Result {
 
 // DetectionRateCheck monitors whether detections are occurring at expected intervals.
 type DetectionRateCheck struct {
-	getRecentCount func(hours int) (int, error)
+	getRecentCount func(ctx context.Context, hours int) (int, error)
 }
 
 // NewDetectionRateCheck creates a DetectionRateCheck using the given count provider.
-func NewDetectionRateCheck(getRecentCount func(hours int) (int, error)) *DetectionRateCheck {
+func NewDetectionRateCheck(getRecentCount func(ctx context.Context, hours int) (int, error)) *DetectionRateCheck {
 	return &DetectionRateCheck{getRecentCount: getRecentCount}
 }
 
@@ -149,15 +149,15 @@ func (c *DetectionRateCheck) Name() string { return "detection_rate" }
 func (c *DetectionRateCheck) Category() health.Category { return health.CategoryAnalysis }
 
 // Run checks recent detection counts for signs of stalled analysis.
-func (c *DetectionRateCheck) Run(_ context.Context) health.Result {
+func (c *DetectionRateCheck) Run(ctx context.Context) health.Result {
 	start := time.Now()
 
 	if c.getRecentCount == nil {
 		return skippedResult(c.Name(), c.Category(), start)
 	}
 
-	count6h, err6h := c.getRecentCount(6)
-	count24h, err24h := c.getRecentCount(24)
+	count6h, err6h := c.getRecentCount(ctx, 6)
+	count24h, err24h := c.getRecentCount(ctx, 24)
 
 	if err6h != nil || err24h != nil {
 		var errParts []string

--- a/internal/health/checks/database.go
+++ b/internal/health/checks/database.go
@@ -152,11 +152,11 @@ func (c *MigrationStatusCheck) Run(_ context.Context) health.Result {
 
 // DatabasePerformanceCheck measures a simple database query latency and reports degradation.
 type DatabasePerformanceCheck struct {
-	queryTimer func() (time.Duration, error)
+	queryTimer func(ctx context.Context) (time.Duration, error)
 }
 
 // NewDatabasePerformanceCheck creates a DatabasePerformanceCheck using the given latency probe.
-func NewDatabasePerformanceCheck(queryTimer func() (time.Duration, error)) *DatabasePerformanceCheck {
+func NewDatabasePerformanceCheck(queryTimer func(ctx context.Context) (time.Duration, error)) *DatabasePerformanceCheck {
 	return &DatabasePerformanceCheck{queryTimer: queryTimer}
 }
 
@@ -173,14 +173,14 @@ const warnQueryLatency = 100 * time.Millisecond
 const critQueryLatency = 500 * time.Millisecond
 
 // Run measures query latency and reports degradation.
-func (c *DatabasePerformanceCheck) Run(_ context.Context) health.Result {
+func (c *DatabasePerformanceCheck) Run(ctx context.Context) health.Result {
 	start := time.Now()
 
 	if c.queryTimer == nil {
 		return skippedResult(c.Name(), c.Category(), start)
 	}
 
-	elapsed, err := c.queryTimer()
+	elapsed, err := c.queryTimer(ctx)
 	if err != nil {
 		return health.Result{
 			Name:       c.Name(),

--- a/internal/imageprovider/imageprovider_test.go
+++ b/internal/imageprovider/imageprovider_test.go
@@ -315,14 +315,16 @@ func (m *mockStore) DeleteExpiredNotificationHistory(before time.Time) (int64, e
 
 func (m *mockStore) SchemaVersion() string     { return datastore.SchemaVersionLegacy }
 func (m *mockStore) UpdateNameMaps(_ []string) {}
-func (m *mockStore) GetDatabaseStats() (*datastore.DatabaseStats, error) {
+func (m *mockStore) GetDatabaseStats(_ context.Context) (*datastore.DatabaseStats, error) {
 	return &datastore.DatabaseStats{
 		Type:      "mock",
 		Connected: true,
 	}, nil
 }
-func (m *mockStore) PingWithLatency() (time.Duration, error)       { return 0, nil }
-func (m *mockStore) CountDetectionsSince(_ time.Time) (int, error) { return 0, nil }
+func (m *mockStore) PingWithLatency(_ context.Context) (time.Duration, error) { return 0, nil }
+func (m *mockStore) CountDetectionsSince(_ context.Context, _ time.Time) (int, error) {
+	return 0, nil
+}
 
 func (m *mockStore) GetAllDailyEvents() ([]datastore.DailyEvents, error) {
 	return nil, nil


### PR DESCRIPTION
## Summary

- Add `context.Context` as the first parameter to `PingWithLatency`, `CountDetectionsSince`, and `GetDatabaseStats` on the datastore `Interface`
- Thread context from the health check runner through closures and into GORM queries via `.WithContext(ctx)` and `PingContext(ctx)`
- The health check registry's per-check 10-second timeout now actually cancels hung database operations instead of leaking goroutines
- Add nil guard for DB handle in `v2only.GetDatabaseStats` size queries to prevent potential panic during concurrent `Close()`
- Consolidate two separate PRAGMA queries into one combined query in v2only (matching the existing `monitoring.go` pattern)
- Add context propagation to `getActiveLockCount` in monitoring for consistency

Updated all implementations (DataStore base, SQLiteStore, MySQLStore, v2only.Datastore), health check closure signatures, API handler callsites, and test mocks (4 manual + mockery-generated).

## Test Plan

- [x] `go build ./...` passes
- [x] `golangci-lint run -v` reports zero issues
- [x] `go test -race` passes on all affected packages (datastore, v2only, health, api/v2, processor, imageprovider)
- [x] Pre-existing `TestDashboardLayoutWidthPersistence` race confirmed on clean main (unrelated)