### PR TITLE
fix(api): guard controlChan sends against panic during shutdown

### DIFF
--- a/internal/api/v2/api_goroutine_test.go
+++ b/internal/api/v2/api_goroutine_test.go
@@ -3,12 +3,15 @@
 package api
 
 import (
+	"context"
 	"testing"
 
 	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tphakala/birdnet-go/internal/conf"
 	"github.com/tphakala/birdnet-go/internal/datastore/mocks"
+	"github.com/tphakala/birdnet-go/internal/logger"
 	"github.com/tphakala/birdnet-go/internal/observability"
 	"go.uber.org/goleak"
 )
@@ -68,6 +71,64 @@ func TestControllerShutdownCleansUpGoroutines(t *testing.T) {
 
 	// Close control channel to prevent any lingering goroutines
 	close(controlChan)
+}
+
+// TestSendReconfigActionsExitsOnShutdown verifies that sendReconfigActions
+// stops sending when the controller context is cancelled during shutdown.
+func TestSendReconfigActionsExitsOnShutdown(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	controlChan := make(chan string, 1)
+	c := &Controller{
+		controlChan: controlChan,
+		ctx:         ctx,
+		cancel:      cancel,
+		apiLogger:   logger.Global().Module("api"),
+	}
+
+	actions := []string{"action_one", "action_two", "action_three"}
+
+	// Read the first action, then cancel context before the goroutine can
+	// finish sending all three.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		c.sendReconfigActions(actions, false)
+	}()
+
+	first := <-controlChan
+	assert.Equal(t, "action_one", first)
+	cancel()
+	<-done
+
+	// At most one more action may have been buffered before ctx check.
+	remaining := len(controlChan)
+	assert.LessOrEqual(t, remaining, 1, "should stop sending after context cancellation")
+}
+
+// TestSendReconfigActionsRecoverOnClosedChannel verifies that the recover
+// guard catches a send-on-closed-channel panic (the shutdown TOCTOU race).
+func TestSendReconfigActionsRecoverOnClosedChannel(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	controlChan := make(chan string, 1)
+	c := &Controller{
+		controlChan: controlChan,
+		ctx:         ctx,
+		cancel:      cancel,
+		apiLogger:   logger.Global().Module("api"),
+	}
+
+	close(controlChan)
+
+	// Must not panic.
+	assert.NotPanics(t, func() {
+		c.sendReconfigActions([]string{"boom"}, false)
+	})
 }
 
 // TestGoroutineCleanupWithoutRoutes verifies that creating a controller without

--- a/internal/api/v2/control.go
+++ b/internal/api/v2/control.go
@@ -143,7 +143,9 @@ func (c *Controller) handleControlSignal(ctx echo.Context, signal, action, logMe
 	// Get request context
 	reqCtx := ctx.Request().Context()
 
-	// Send signal with context timeout awareness
+	// Send signal with context timeout and shutdown awareness.
+	// The c.ctx.Done() case prevents a send-on-closed-channel panic if shutdown
+	// closes controlChan while an HTTP request is still in-flight.
 	select {
 	case c.controlChan <- signal:
 		c.logInfoIfEnabled("Control signal sent successfully",
@@ -151,7 +153,9 @@ func (c *Controller) handleControlSignal(ctx echo.Context, signal, action, logMe
 			logger.String("path", ctx.Request().URL.Path),
 			logger.String("ip", ctx.RealIP()),
 		)
-		// Signal sent successfully
+	case <-c.ctx.Done():
+		return c.HandleError(ctx, c.ctx.Err(),
+			"Server is shutting down", http.StatusServiceUnavailable)
 	case <-reqCtx.Done():
 		err := reqCtx.Err()
 		c.logErrorIfEnabled("Request timeout/cancel while sending control signal",
@@ -160,7 +164,6 @@ func (c *Controller) handleControlSignal(ctx echo.Context, signal, action, logMe
 			logger.String("path", ctx.Request().URL.Path),
 			logger.String("ip", ctx.RealIP()),
 		)
-		// Request context is done (timeout or cancelled)
 		return c.HandleError(ctx, err,
 			"Request timeout while sending control signal", http.StatusRequestTimeout)
 	}

--- a/internal/api/v2/settings.go
+++ b/internal/api/v2/settings.go
@@ -2147,7 +2147,7 @@ func (c *Controller) handleSettingsChanges(oldSettings, currentSettings *conf.Se
 func (c *Controller) sendReconfigActions(actions []string, debugEnabled bool) {
 	defer func() {
 		if r := recover(); r != nil {
-			GetLogger().Warn("Recovered from send on closed controlChan during shutdown",
+			c.logWarnIfEnabled("Recovered from send on closed controlChan during shutdown",
 				logger.Any("panic", r))
 		}
 	}()

--- a/internal/api/v2/settings.go
+++ b/internal/api/v2/settings.go
@@ -2129,18 +2129,45 @@ func (c *Controller) handleSettingsChanges(oldSettings, currentSettings *conf.Se
 	// reads c.Settings (which may be overwritten by a concurrent update).
 	if len(reconfigActions) > 0 {
 		debugEnabled := currentSettings.WebServer.Debug
-		go func(actions []string) {
-			for _, action := range actions {
-				if debugEnabled {
-					c.logDebugIfEnabled("Asynchronously executing action", logger.String("action", action))
-				}
-				c.controlChan <- action
-				time.Sleep(actionDelay)
-			}
-		}(reconfigActions)
+		c.wg.Go(func() {
+			c.sendReconfigActions(reconfigActions, debugEnabled)
+		})
 	}
 
 	return nil
+}
+
+// sendReconfigActions sends reconfig actions to controlChan with a delay between
+// each to avoid overwhelming the control monitor with rapid-fire reconfiguration.
+// Unlike quiet_hours.go:trySendSoundCardSignal (which drops signals via a default
+// branch), this blocks until either the send succeeds or shutdown cancels the
+// context, because settings reconfig actions are order-dependent and must not be
+// lost. The recover guard is defense-in-depth against a TOCTOU race where
+// api_service.go closes controlChan before the context cancellation propagates.
+func (c *Controller) sendReconfigActions(actions []string, debugEnabled bool) {
+	defer func() {
+		if r := recover(); r != nil {
+			GetLogger().Warn("Recovered from send on closed controlChan during shutdown",
+				logger.Any("panic", r))
+		}
+	}()
+
+	for _, action := range actions {
+		if debugEnabled {
+			c.logDebugIfEnabled("Asynchronously executing action", logger.String("action", action))
+		}
+		select {
+		case <-c.ctx.Done():
+			return
+		case c.controlChan <- action:
+		}
+
+		select {
+		case <-c.ctx.Done():
+			return
+		case <-time.After(actionDelay):
+		}
+	}
 }
 
 // intervalSettingsChanged checks if species interval or global interval settings have changed.


### PR DESCRIPTION
## Summary

- Extract `handleSettingsChanges` goroutine into `sendReconfigActions` with three shutdown guards: `select` on `c.ctx.Done()` before each send and sleep, `defer recover()` for TOCTOU defense-in-depth, and `c.wg.Go()` so `Controller.Shutdown()` waits for completion
- Add `c.ctx.Done()` case to `handleControlSignal`'s select to protect HTTP-handler sends from the same shutdown race
- Add two targeted tests: context-cancellation exit and closed-channel recover

## Test Plan

- [x] `TestSendReconfigActionsExitsOnShutdown` - verifies goroutine exits when context cancelled
- [x] `TestSendReconfigActionsRecoverOnClosedChannel` - verifies no panic on closed channel
- [x] Full API v2 test suite (1976 tests) passes with `-race`
- [x] `golangci-lint` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved graceful shutdown handling to prevent potential panics during service reconfiguration.
  * Enhanced signal handling to properly manage in-flight requests when the service is shutting down, returning appropriate error responses.
  * Added cancellation support for pending reconfiguration actions during shutdown.

* **Tests**
  * Added tests to verify proper shutdown behavior and error handling during service reconfiguration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3149?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->