### PR TITLE
fix(frontend): centralize crypto.randomUUID with try/catch for non-HTTPS

### DIFF
--- a/frontend/src/lib/components/ui/SpeciesSelector.svelte
+++ b/frontend/src/lib/components/ui/SpeciesSelector.svelte
@@ -3,6 +3,7 @@
   import type { Snippet } from 'svelte';
   import { createEventDispatcher, onDestroy } from 'svelte';
   import { cn } from '$lib/utils/cn.js';
+  import { generateId } from '$lib/utils/uuid';
   import { X, Trash2, Plus, Search, TriangleAlert } from '@lucide/svelte';
   import type { Species } from '$lib/types/species';
 
@@ -238,11 +239,7 @@
   // Initialize dropdownId on client mount to avoid SSR hydration mismatch
   $effect(() => {
     if (typeof window !== 'undefined' && dropdownId === '') {
-      if (typeof crypto !== 'undefined' && crypto.randomUUID) {
-        dropdownId = `species-dropdown-${crypto.randomUUID().slice(0, 8)}`;
-      } else {
-        dropdownId = `species-dropdown-${Math.random().toString(36).slice(2, 9)}`;
-      }
+      dropdownId = generateId('species-dropdown');
     }
   });
 

--- a/frontend/src/lib/desktop/components/forms/InlineSlider.svelte
+++ b/frontend/src/lib/desktop/components/forms/InlineSlider.svelte
@@ -31,6 +31,7 @@
 -->
 <script lang="ts">
   import { cn } from '$lib/utils/cn.js';
+  import { generateId } from '$lib/utils/uuid';
 
   interface Props {
     label: string;
@@ -64,15 +65,7 @@
     helpText = '',
   }: Props = $props();
 
-  // Generate unique suffix once on component creation (not reactive)
-  const generatedIdSuffix = (() => {
-    // Use crypto.randomUUID if available (modern browsers)
-    if (typeof crypto !== 'undefined' && crypto.randomUUID) {
-      return crypto.randomUUID();
-    }
-    // Fallback for older browsers
-    return `${Math.random().toString(36).slice(2, 11)}-${Date.now()}`;
-  })();
+  const generatedIdSuffix = generateId();
 
   // Derived IDs - react to prop changes while maintaining stable suffix
   const inputId = $derived(id || `inline-slider-${generatedIdSuffix}`);

--- a/frontend/src/lib/desktop/components/forms/PasswordField.svelte
+++ b/frontend/src/lib/desktop/components/forms/PasswordField.svelte
@@ -1,19 +1,12 @@
 <script lang="ts">
   import { cn } from '$lib/utils/cn.js';
+  import { generateId } from '$lib/utils/uuid';
   import type { HTMLAttributes } from 'svelte/elements';
   import { Eye, EyeOff, Pencil, X, TriangleAlert } from '@lucide/svelte';
   import { t } from '$lib/i18n';
 
   /** The redacted placeholder the backend sends for configured secrets. */
   const REDACTED_VALUE = '**********';
-
-  // Generate unique ID using crypto.randomUUID for SSR compatibility
-  const generateUniqueId = () => {
-    if (typeof crypto !== 'undefined' && crypto.randomUUID) {
-      return `password-field-${crypto.randomUUID()}`;
-    }
-    return `password-field-${Math.random().toString(36).substr(2, 9)}-${Date.now()}`;
-  };
 
   interface Props extends HTMLAttributes<HTMLDivElement> {
     label: string;
@@ -48,8 +41,7 @@
     ...rest
   }: Props = $props();
 
-  // Generate unique ID for this component instance (captured at creation, intentionally non-reactive)
-  const fieldId = (() => name || generateUniqueId())();
+  const fieldId = name || generateId('password-field');
 
   let showPassword = $state(false);
 

--- a/frontend/src/lib/desktop/components/forms/PasswordField.svelte
+++ b/frontend/src/lib/desktop/components/forms/PasswordField.svelte
@@ -41,7 +41,8 @@
     ...rest
   }: Props = $props();
 
-  const fieldId = name || generateId('password-field');
+  const generatedFieldId = generateId('password-field');
+  const fieldId = $derived(name || generatedFieldId);
 
   let showPassword = $state(false);
 

--- a/frontend/src/lib/desktop/components/forms/RTSPUrlManager.svelte
+++ b/frontend/src/lib/desktop/components/forms/RTSPUrlManager.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { cn } from '$lib/utils/cn.js';
+  import { generateId } from '$lib/utils/uuid';
   import FormField from './FormField.svelte';
   import ToggleField from './ToggleField.svelte';
   import type { HTMLAttributes } from 'svelte/elements';
@@ -83,8 +84,8 @@
     return null;
   }
 
-  function generateId(): string {
-    return `rtsp-${crypto?.randomUUID?.() ?? Math.random().toString(36).substring(2, 11)}`;
+  function generateRtspId(): string {
+    return generateId('rtsp');
   }
 
   function addUrl() {
@@ -110,7 +111,7 @@
     }
 
     const newRTSPUrl: RTSPUrl = {
-      id: generateId(),
+      id: generateRtspId(),
       url: trimmedUrl,
       name: trimmedName,
       active: true,

--- a/frontend/src/lib/desktop/components/forms/SliderField.svelte
+++ b/frontend/src/lib/desktop/components/forms/SliderField.svelte
@@ -1,17 +1,8 @@
 <script lang="ts">
   import FormField from './FormField.svelte';
   import { cn } from '$lib/utils/cn.js';
+  import { generateId } from '$lib/utils/uuid';
   import type { HTMLAttributes } from 'svelte/elements';
-
-  // Generate unique ID using crypto.randomUUID for SSR compatibility
-  const generateUniqueId = () => {
-    // Use crypto.randomUUID if available (modern browsers and Node.js 14.17+)
-    if (typeof crypto !== 'undefined' && crypto.randomUUID) {
-      return `slider-field-${crypto.randomUUID()}`;
-    }
-    // Fallback for older environments
-    return `slider-field-${Math.random().toString(36).substr(2, 9)}-${Date.now()}`;
-  };
 
   interface Props extends HTMLAttributes<HTMLDivElement> {
     label: string;
@@ -48,8 +39,7 @@
     ...rest
   }: Props = $props();
 
-  // Generate unique ID for proper label association - each component instance gets its own ID
-  const fieldId = generateUniqueId();
+  const fieldId = generateId('slider-field');
 
   let displayValue = $derived(formatValue ? formatValue(value) : `${value}${unit}`);
 

--- a/frontend/src/lib/desktop/components/forms/SoundCardCard.svelte
+++ b/frontend/src/lib/desktop/components/forms/SoundCardCard.svelte
@@ -17,6 +17,7 @@
   @component
 -->
 <script lang="ts">
+  import { generateId } from '$lib/utils/uuid';
   import {
     Settings,
     Trash2,
@@ -174,7 +175,7 @@
             enabled: editEqualizer.enabled,
             filters: editEqualizer.filters.map(f => ({
               ...f,
-              id: f.id || (crypto?.randomUUID?.() ?? Math.random().toString(36).slice(2, 11)),
+              id: f.id || generateId(),
             })),
           }
         : undefined;

--- a/frontend/src/lib/desktop/components/forms/SoundCardManager.svelte
+++ b/frontend/src/lib/desktop/components/forms/SoundCardManager.svelte
@@ -18,6 +18,7 @@
   import { slide } from 'svelte/transition';
   import { t } from '$lib/i18n';
   import { loggers } from '$lib/utils/logger';
+  import { generateId } from '$lib/utils/uuid';
   import { fetchDeviceCapabilities as fetchCapabilities } from '$lib/utils/audio/sampleRate';
   import { toastActions } from '$lib/stores/toast';
   import { cn } from '$lib/utils/cn';
@@ -185,7 +186,7 @@
             enabled: newEqualizer.enabled,
             filters: newEqualizer.filters.map(f => ({
               ...f,
-              id: f.id || (crypto?.randomUUID?.() ?? Math.random().toString(36).slice(2, 11)),
+              id: f.id || generateId(),
             })),
           }
         : undefined;

--- a/frontend/src/lib/desktop/components/forms/SpeciesManager.svelte
+++ b/frontend/src/lib/desktop/components/forms/SpeciesManager.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { cn } from '$lib/utils/cn';
+  import { generateId } from '$lib/utils/uuid';
   import { tick } from 'svelte';
   import {
     filterSpeciesForAutocomplete,
@@ -46,9 +47,8 @@
   let editingValue = $state('');
   let draggedIndex = $state<number | null>(null);
   let dragOverIndex = $state<number | null>(null);
-  // Generate unique IDs for accessibility - use crypto.randomUUID() with fallback
-  let inputId = `species-input-${crypto?.randomUUID?.() ?? Math.random().toString(36).substr(2, 9)}`;
-  let listId = `species-list-${crypto?.randomUUID?.() ?? Math.random().toString(36).substr(2, 9)}`;
+  let inputId = generateId('species-input');
+  let listId = generateId('species-list');
 
   // Derived
   let canAddMore = $derived(!maxItems || species.length < maxItems);

--- a/frontend/src/lib/desktop/components/forms/StreamCard.svelte
+++ b/frontend/src/lib/desktop/components/forms/StreamCard.svelte
@@ -19,6 +19,7 @@
 -->
 <script lang="ts">
   import { getContext } from 'svelte';
+  import { generateId } from '$lib/utils/uuid';
   import {
     Settings,
     Trash2,
@@ -333,7 +334,7 @@
               enabled: editEqualizer.enabled,
               filters: editEqualizer.filters.map(f => ({
                 ...f,
-                id: f.id || (crypto?.randomUUID?.() ?? Math.random().toString(36).substr(2, 9)),
+                id: f.id || generateId(),
               })),
             }
           : undefined;

--- a/frontend/src/lib/desktop/components/forms/ToggleField.svelte
+++ b/frontend/src/lib/desktop/components/forms/ToggleField.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { cn } from '$lib/utils/cn.js';
+  import { generateId } from '$lib/utils/uuid';
   import type { HTMLAttributes } from 'svelte/elements';
   import type { Component } from 'svelte';
 
@@ -32,8 +33,7 @@
     ...rest
   }: Props = $props();
 
-  // Generate unique ID using crypto.randomUUID() with fallback
-  const fieldId = `toggle-${crypto?.randomUUID?.() ?? Math.random().toString(36).substr(2, 9)}`;
+  const fieldId = generateId('toggle');
 
   function handleChange(event: Event) {
     const target = event.target as HTMLInputElement;

--- a/frontend/src/lib/desktop/features/settings/components/AlertRuleEditor.svelte
+++ b/frontend/src/lib/desktop/features/settings/components/AlertRuleEditor.svelte
@@ -15,6 +15,7 @@
   @component
 -->
 <script lang="ts">
+  import { generateId } from '$lib/utils/uuid';
   import {
     Plus,
     Trash2,
@@ -71,8 +72,7 @@
     duration_sec: number;
   }
 
-  const newConditionId = () =>
-    crypto?.randomUUID?.() ?? Math.random().toString(36).substring(2, 11);
+  const newConditionId = () => generateId();
 
   interface EditorAction {
     target: string;

--- a/frontend/src/lib/desktop/features/settings/components/editor/EditorSlider.svelte
+++ b/frontend/src/lib/desktop/features/settings/components/editor/EditorSlider.svelte
@@ -11,6 +11,8 @@
   @component
 -->
 <script lang="ts">
+  import { generateId } from '$lib/utils/uuid';
+
   interface Props {
     label: string;
     value: number;
@@ -35,8 +37,7 @@
     id,
   }: Props = $props();
 
-  // Unique suffix per instance to prevent ID collisions when labels repeat
-  const idSuffix = crypto?.randomUUID?.().slice(0, 8) ?? Math.random().toString(36).slice(2, 10);
+  const idSuffix = generateId();
 
   const fieldId = $derived(
     id ||

--- a/frontend/src/lib/desktop/features/settings/components/editor/EditorTextField.svelte
+++ b/frontend/src/lib/desktop/features/settings/components/editor/EditorTextField.svelte
@@ -11,6 +11,8 @@
   @component
 -->
 <script lang="ts">
+  import { generateId } from '$lib/utils/uuid';
+
   interface Props {
     label: string;
     value: string | number;
@@ -39,8 +41,7 @@
     id,
   }: Props = $props();
 
-  // Unique suffix per instance to prevent ID collisions when labels repeat
-  const idSuffix = crypto?.randomUUID?.().slice(0, 8) ?? Math.random().toString(36).slice(2, 10);
+  const idSuffix = generateId();
 
   const fieldId = $derived(
     id ||

--- a/frontend/src/lib/utils/session.ts
+++ b/frontend/src/lib/utils/session.ts
@@ -1,11 +1,7 @@
-/**
- * Generate a unique session ID for per-tab/component tracking.
- * Uses crypto.randomUUID() when available, with a fallback for
- * environments without Web Crypto API support.
- */
 export function generateSessionId(): string {
-  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+  try {
     return crypto.randomUUID();
+  } catch {
+    return `fallback-${Date.now()}-${Math.random().toString(36).slice(2)}`;
   }
-  return `fallback-${Date.now()}-${Math.random().toString(36).slice(2)}`;
 }

--- a/frontend/src/lib/utils/uuid.ts
+++ b/frontend/src/lib/utils/uuid.ts
@@ -1,0 +1,13 @@
+function fallbackId(): string {
+  return Math.random().toString(36).slice(2, 10);
+}
+
+export function generateId(prefix?: string): string {
+  let id: string;
+  try {
+    id = crypto.randomUUID().slice(0, 8);
+  } catch {
+    id = fallbackId();
+  }
+  return prefix ? `${prefix}-${id}` : id;
+}

--- a/frontend/src/lib/utils/uuid.ts
+++ b/frontend/src/lib/utils/uuid.ts
@@ -1,5 +1,5 @@
 function fallbackId(): string {
-  return Math.random().toString(36).slice(2, 10);
+  return Array.from({ length: 8 }, () => Math.floor(Math.random() * 36).toString(36)).join('');
 }
 
 export function generateId(prefix?: string): string {


### PR DESCRIPTION
## Summary

- Created shared `generateId()` utility (`uuid.ts`) using try/catch to safely handle `crypto.randomUUID()` in non-HTTPS environments where the property exists but throws TypeError
- Replaced all 15 unsafe call sites across 13 components with the centralized utility
- Fixed `session.ts` to use try/catch instead of the insufficient `'randomUUID' in crypto` guard

## Context

BirdNET-Go commonly runs over plain HTTP on home networks. In some browsers (Firefox, certain Chrome versions), `crypto.randomUUID` exists as a property on the crypto object even in non-secure contexts, but calling it throws `TypeError`. This means optional chaining (`crypto?.randomUUID?.()`), typeof checks, and `'in'` operator checks all fail to prevent the crash. The only reliable pattern is try/catch.

This was a recurring bug class (previously fixed in PRs #2024 and #2905 for other components), and continued appearing as new components were added with the same unsafe patterns.

## Test plan

- [ ] All frontend lint checks pass (`npm run check:all`)
- [ ] All 1942 frontend tests pass (`npm test`)
- [ ] Verify no remaining `crypto.randomUUID` calls outside `uuid.ts` and `session.ts`
- [ ] Manual: open any settings page over plain HTTP; confirm no console errors from ID generation

## Preflight Status

- [x] Single concern: all changes replace unsafe crypto.randomUUID patterns
- [x] Preflight passed: 4/4 reviewers passed clean
- [x] Linters clean: `npm run check:all` passes (zero errors)
- [x] Tests pass: all 1942 tests pass
- [x] No unrelated changes
- [x] Scope complete: all 15 call sites replaced
- [x] i18n complete: no user-facing string changes
- [x] No secrets or PII

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified ID generation across components using a shared utility, improving consistency and stability of element identifiers and accessibility linkages throughout the app.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3152?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->