### PR TITLE
refactor(datastore): deduplicate database stats queries and fix TOCTOU races

### DIFF
--- a/internal/api/v2/diagnostics.go
+++ b/internal/api/v2/diagnostics.go
@@ -123,11 +123,12 @@ func (c *Controller) registerHealthChecks() {
 			return avgMS, p99MS, windowMS
 		}),
 		checks.NewDetectionRateCheck(func(ctx context.Context, hours int) (int, error) {
-			if c.DS == nil {
+			ds := c.DS
+			if ds == nil {
 				return 0, errors.NewStd("datastore unavailable")
 			}
 			since := time.Now().Add(-time.Duration(hours) * time.Hour)
-			return c.DS.CountDetectionsSince(ctx, since)
+			return ds.CountDetectionsSince(ctx, since)
 		}),
 		checks.NewQueueDepthCheck(func() (int, int) {
 			q := classifier.ResultsQueue
@@ -154,10 +155,11 @@ func (c *Controller) registerHealthChecks() {
 			return true, dbType + " (auto-migrated at startup)", nil
 		}),
 		checks.NewDatabasePerformanceCheck(func(ctx context.Context) (time.Duration, error) {
-			if c.DS == nil {
+			ds := c.DS
+			if ds == nil {
 				return 0, errors.NewStd("datastore unavailable")
 			}
-			return c.DS.PingWithLatency(ctx)
+			return ds.PingWithLatency(ctx)
 		}),
 
 		// Network checks

--- a/internal/api/v2/system.go
+++ b/internal/api/v2/system.go
@@ -1582,11 +1582,13 @@ func (c *Controller) getV2ManagerStats(ctx context.Context) (*datastore.Database
 	} else {
 		prefix := mgr.TablePrefix()
 		if prefix != "" {
+			// Escape underscore for MySQL LIKE (underscore is single-char wildcard)
+			escaped := strings.ReplaceAll(prefix, "_", "\\_")
 			if err := db.WithContext(ctx).Raw(`
 				SELECT COALESCE(SUM(data_length + index_length), 0)
 				FROM information_schema.TABLES
 				WHERE table_schema = DATABASE() AND table_name LIKE ?
-			`, prefix+"%").Scan(&stats.SizeBytes).Error; err != nil {
+			`, escaped+"%").Scan(&stats.SizeBytes).Error; err != nil {
 				c.logWarnIfEnabled("Failed to get v2 MySQL database size", logger.Error(err))
 			}
 		} else {

--- a/internal/api/v2/system.go
+++ b/internal/api/v2/system.go
@@ -1479,9 +1479,8 @@ func (c *Controller) GetEqualizerConfig(ctx echo.Context) error {
 }
 
 // GetDatabaseStats handles GET /api/v2/system/database/stats
-// This endpoint returns statistics for the primary database.
-// In v2-only mode (fresh install or post-migration), it returns v2 database stats.
-// In legacy mode, it returns legacy database stats.
+// Delegates to c.DS.GetDatabaseStats which returns the correct stats
+// for the active store (legacy SQLite/MySQL or v2only.Datastore).
 func (c *Controller) GetDatabaseStats(ctx echo.Context) error {
 	ip, path := ctx.RealIP(), ctx.Request().URL.Path
 	c.logInfoIfEnabled("Getting database statistics",
@@ -1489,8 +1488,8 @@ func (c *Controller) GetDatabaseStats(ctx echo.Context) error {
 		logger.String("ip", ip),
 	)
 
-	// Check if datastore is available
-	if c.DS == nil {
+	ds := c.DS
+	if ds == nil {
 		c.logErrorIfEnabled("Datastore not available",
 			logger.String("path", path),
 			logger.String("ip", ip),
@@ -1498,8 +1497,7 @@ func (c *Controller) GetDatabaseStats(ctx echo.Context) error {
 		return c.HandleError(ctx, fmt.Errorf("datastore not available"), "Database not configured", http.StatusServiceUnavailable)
 	}
 
-	// Get database stats from the datastore
-	stats, err := c.DS.GetDatabaseStats(ctx.Request().Context())
+	stats, err := ds.GetDatabaseStats(ctx.Request().Context())
 
 	// Handle errors first
 	isPartialStats := false
@@ -1556,38 +1554,45 @@ func (c *Controller) GetDatabaseStats(ctx echo.Context) error {
 
 // getV2ManagerStats retrieves v2 database statistics directly from V2Manager.
 func (c *Controller) getV2ManagerStats(ctx context.Context) (*datastore.DatabaseStats, bool) {
-	if c.V2Manager == nil || !c.V2Manager.Exists() {
+	mgr := c.V2Manager
+	if mgr == nil || !mgr.Exists() {
 		return nil, false
 	}
 
 	stats := &datastore.DatabaseStats{
 		Type:      datastore.DialectSQLite,
-		Location:  c.V2Manager.Path(),
+		Location:  mgr.Path(),
 		Connected: true,
 	}
 
-	if c.V2Manager.IsMySQL() {
+	if mgr.IsMySQL() {
 		stats.Type = datastore.DialectMySQL
 	}
 
-	db := c.V2Manager.DB()
+	db := mgr.DB()
 	if db == nil {
 		stats.Connected = false
 		return stats, true
 	}
 
-	if !c.V2Manager.IsMySQL() {
-		_ = db.WithContext(ctx).Raw("SELECT page_count * page_size FROM pragma_page_count(), pragma_page_size()").Scan(&stats.SizeBytes).Error
+	if !mgr.IsMySQL() {
+		if err := db.WithContext(ctx).Raw("SELECT page_count * page_size FROM pragma_page_count(), pragma_page_size()").Scan(&stats.SizeBytes).Error; err != nil {
+			c.logWarnIfEnabled("Failed to get v2 SQLite database size", logger.Error(err))
+		}
 	} else {
-		_ = db.WithContext(ctx).Raw(`
+		if err := db.WithContext(ctx).Raw(`
 			SELECT COALESCE(SUM(data_length + index_length), 0)
 			FROM information_schema.TABLES
 			WHERE table_schema = DATABASE()
-		`).Scan(&stats.SizeBytes).Error
+		`).Scan(&stats.SizeBytes).Error; err != nil {
+			c.logWarnIfEnabled("Failed to get v2 MySQL database size", logger.Error(err))
+		}
 	}
 
 	var count int64
-	if err := db.WithContext(ctx).Table("detections").Count(&count).Error; err == nil {
+	if err := db.WithContext(ctx).Table("detections").Count(&count).Error; err != nil {
+		c.logWarnIfEnabled("Failed to count v2 detections", logger.Error(err))
+	} else {
 		stats.TotalDetections = count
 	}
 
@@ -1650,11 +1655,12 @@ func (c *Controller) DownloadDatabaseBackup(ctx echo.Context) error {
 		dbPath = c.Settings.Output.SQLite.Path
 
 		// Get the underlying GORM DB from the datastore
-		if c.DS == nil {
+		ds := c.DS
+		if ds == nil {
 			return c.HandleError(ctx, fmt.Errorf("datastore not available"),
 				"Database not configured", http.StatusServiceUnavailable)
 		}
-		sqliteStore, ok := c.DS.(*datastore.SQLiteStore)
+		sqliteStore, ok := ds.(*datastore.SQLiteStore)
 		if !ok {
 			return c.HandleError(ctx, fmt.Errorf("unsupported datastore type"),
 				"Cannot perform backup on this datastore type", http.StatusInternalServerError)
@@ -1662,17 +1668,18 @@ func (c *Controller) DownloadDatabaseBackup(ctx echo.Context) error {
 		gormDB = sqliteStore.DB
 	} else {
 		// V2 database
-		if c.V2Manager == nil {
+		mgr := c.V2Manager
+		if mgr == nil {
 			return c.HandleError(ctx, fmt.Errorf("v2 not available"),
 				"V2 database not initialized", http.StatusNotFound)
 		}
-		if c.V2Manager.IsMySQL() {
+		if mgr.IsMySQL() {
 			return c.HandleError(ctx, fmt.Errorf("not sqlite"),
 				"Backup download only available for SQLite databases. Use MySQL tools for MySQL backup.",
 				http.StatusBadRequest)
 		}
-		dbPath = c.V2Manager.Path()
-		gormDB = c.V2Manager.DB()
+		dbPath = mgr.Path()
+		gormDB = mgr.DB()
 	}
 
 	// Verify we have a valid database handle before proceeding

--- a/internal/api/v2/system.go
+++ b/internal/api/v2/system.go
@@ -1580,17 +1580,28 @@ func (c *Controller) getV2ManagerStats(ctx context.Context) (*datastore.Database
 			c.logWarnIfEnabled("Failed to get v2 SQLite database size", logger.Error(err))
 		}
 	} else {
-		if err := db.WithContext(ctx).Raw(`
-			SELECT COALESCE(SUM(data_length + index_length), 0)
-			FROM information_schema.TABLES
-			WHERE table_schema = DATABASE()
-		`).Scan(&stats.SizeBytes).Error; err != nil {
-			c.logWarnIfEnabled("Failed to get v2 MySQL database size", logger.Error(err))
+		prefix := mgr.TablePrefix()
+		if prefix != "" {
+			if err := db.WithContext(ctx).Raw(`
+				SELECT COALESCE(SUM(data_length + index_length), 0)
+				FROM information_schema.TABLES
+				WHERE table_schema = DATABASE() AND table_name LIKE ?
+			`, prefix+"%").Scan(&stats.SizeBytes).Error; err != nil {
+				c.logWarnIfEnabled("Failed to get v2 MySQL database size", logger.Error(err))
+			}
+		} else {
+			if err := db.WithContext(ctx).Raw(`
+				SELECT COALESCE(SUM(data_length + index_length), 0)
+				FROM information_schema.TABLES
+				WHERE table_schema = DATABASE()
+			`).Scan(&stats.SizeBytes).Error; err != nil {
+				c.logWarnIfEnabled("Failed to get v2 MySQL database size", logger.Error(err))
+			}
 		}
 	}
 
 	var count int64
-	if err := db.WithContext(ctx).Table("detections").Count(&count).Error; err != nil {
+	if err := db.WithContext(ctx).Table(mgr.TablePrefix() + "detections").Count(&count).Error; err != nil {
 		c.logWarnIfEnabled("Failed to count v2 detections", logger.Error(err))
 	} else {
 		stats.TotalDetections = count

--- a/internal/api/v2/system.go
+++ b/internal/api/v2/system.go
@@ -1489,36 +1489,6 @@ func (c *Controller) GetDatabaseStats(ctx echo.Context) error {
 		logger.String("ip", ip),
 	)
 
-	// In enhanced database mode, return v2 database stats as the primary database
-	if isV2OnlyMode {
-		c.logInfoIfEnabled("Running in enhanced database mode, returning v2 database as primary",
-			logger.String("path", path),
-			logger.String("ip", ip),
-		)
-		// Get v2 database stats
-		v2Stats, ok := c.getV2Stats(path, ip)
-		if ok {
-			// Return v2 stats as the primary database stats
-			return ctx.JSON(http.StatusOK, &datastore.DatabaseStats{
-				Type:            v2Stats.Type,
-				Location:        v2Stats.Location,
-				SizeBytes:       v2Stats.SizeBytes,
-				TotalDetections: v2Stats.TotalDetections,
-				Connected:       v2Stats.Connected,
-			})
-		}
-		// V2 database not available, return disconnected state
-		c.logWarnIfEnabled("Enhanced database mode but v2 database not available",
-			logger.String("path", path),
-			logger.String("ip", ip),
-		)
-		return ctx.JSON(http.StatusOK, &datastore.DatabaseStats{
-			Type:      "none",
-			Connected: false,
-			Location:  "",
-		})
-	}
-
 	// Check if datastore is available
 	if c.DS == nil {
 		c.logErrorIfEnabled("Datastore not available",
@@ -1584,92 +1554,44 @@ func (c *Controller) GetDatabaseStats(ctx echo.Context) error {
 	return ctx.JSON(http.StatusOK, stats)
 }
 
-// V2DatabaseStatsResponse represents v2 database statistics.
-type V2DatabaseStatsResponse struct {
-	Type            string `json:"type"`
-	Location        string `json:"location"`
-	SizeBytes       int64  `json:"size_bytes"`
-	TotalDetections int64  `json:"total_detections"`
-	Connected       bool   `json:"connected"`
-}
-
-// getV2Stats is a helper method that retrieves v2 database statistics.
-// It returns the stats and a boolean indicating if stats were successfully retrieved.
-// If the v2 database is not available, it returns nil and false.
-func (c *Controller) getV2Stats(logPath, logIP string) (*V2DatabaseStatsResponse, bool) {
-	// Check if V2Manager is available
-	if c.V2Manager == nil {
-		c.logInfoIfEnabled("V2 database not initialized",
-			logger.String("path", logPath), logger.String("ip", logIP))
+// getV2ManagerStats retrieves v2 database statistics directly from V2Manager.
+func (c *Controller) getV2ManagerStats(ctx context.Context) (*datastore.DatabaseStats, bool) {
+	if c.V2Manager == nil || !c.V2Manager.Exists() {
 		return nil, false
 	}
 
-	// Check if database exists
-	if !c.V2Manager.Exists() {
-		c.logInfoIfEnabled("V2 database does not exist yet",
-			logger.String("path", logPath), logger.String("ip", logIP))
-		return nil, false
-	}
-
-	// Build response
-	response := &V2DatabaseStatsResponse{
+	stats := &datastore.DatabaseStats{
 		Type:      datastore.DialectSQLite,
 		Location:  c.V2Manager.Path(),
 		Connected: true,
 	}
 
-	// Adjust type for MySQL
 	if c.V2Manager.IsMySQL() {
-		response.Type = datastore.DialectMySQL
+		stats.Type = datastore.DialectMySQL
 	}
 
-	// Get database size
 	db := c.V2Manager.DB()
+	if db == nil {
+		stats.Connected = false
+		return stats, true
+	}
+
 	if !c.V2Manager.IsMySQL() {
-		// SQLite: get file size
-		if fi, err := os.Stat(c.V2Manager.Path()); err == nil {
-			response.SizeBytes = fi.Size()
-		}
-	} else if db != nil {
-		// MySQL: query information_schema for database size
-		// Extract database name from location (format: host:port/database)
-		location := c.V2Manager.Path()
-		if idx := strings.LastIndex(location, "/"); idx != -1 {
-			dbName := location[idx+1:]
-			var sizeBytes int64
-			err := db.Raw(`
-				SELECT COALESCE(SUM(data_length + index_length), 0) as size
-				FROM information_schema.TABLES
-				WHERE table_schema = ?
-			`, dbName).Scan(&sizeBytes).Error
-			if err == nil {
-				response.SizeBytes = sizeBytes
-			} else {
-				c.logWarnIfEnabled("Failed to get MySQL database size",
-					logger.Error(err), logger.String("path", logPath), logger.String("ip", logIP))
-			}
-		}
+		_ = db.WithContext(ctx).Raw("SELECT page_count * page_size FROM pragma_page_count(), pragma_page_size()").Scan(&stats.SizeBytes).Error
+	} else {
+		_ = db.WithContext(ctx).Raw(`
+			SELECT COALESCE(SUM(data_length + index_length), 0)
+			FROM information_schema.TABLES
+			WHERE table_schema = DATABASE()
+		`).Scan(&stats.SizeBytes).Error
 	}
 
-	// Count total detections from v2 database
-	if db != nil {
-		var count int64
-		if err := db.Table("detections").Count(&count).Error; err == nil {
-			response.TotalDetections = count
-		} else {
-			c.logWarnIfEnabled("Failed to count v2 detections",
-				logger.Error(err), logger.String("path", logPath), logger.String("ip", logIP))
-		}
+	var count int64
+	if err := db.WithContext(ctx).Table("detections").Count(&count).Error; err == nil {
+		stats.TotalDetections = count
 	}
 
-	c.logInfoIfEnabled("V2 database statistics retrieved successfully",
-		logger.String("type", response.Type),
-		logger.Any("size_bytes", response.SizeBytes),
-		logger.Any("total_detections", response.TotalDetections),
-		logger.Bool("connected", response.Connected),
-		logger.String("path", logPath), logger.String("ip", logIP))
-
-	return response, true
+	return stats, true
 }
 
 // GetV2DatabaseStats handles GET /api/v2/system/database/v2/stats
@@ -1678,7 +1600,7 @@ func (c *Controller) GetV2DatabaseStats(ctx echo.Context) error {
 	c.logInfoIfEnabled("Getting v2 database statistics",
 		logger.String("path", path), logger.String("ip", ip))
 
-	stats, ok := c.getV2Stats(path, ip)
+	stats, ok := c.getV2ManagerStats(ctx.Request().Context())
 	if !ok {
 		return c.HandleError(ctx, fmt.Errorf("v2 database not available"),
 			"V2 database not initialized", http.StatusNotFound)

--- a/internal/datastore/detection_repository.go
+++ b/internal/datastore/detection_repository.go
@@ -556,11 +556,10 @@ func (r *detectionRepository) parseDateWithDefault(dateStr string, defaultToNow 
 }
 
 // CountAll returns the total count of all detections.
-// This is a lightweight count operation that doesn't load any data.
 func (r *detectionRepository) CountAll(ctx context.Context) (int64, error) {
-	stats, err := r.store.GetDatabaseStats(ctx)
+	count, err := r.store.CountDetectionsSince(ctx, time.Time{})
 	if err != nil {
 		return 0, fmt.Errorf("failed to count detections: %w", err)
 	}
-	return stats.TotalDetections, nil
+	return int64(count), nil
 }

--- a/internal/datastore/detection_repository_test.go
+++ b/internal/datastore/detection_repository_test.go
@@ -23,18 +23,11 @@ func TestCountAll_DirectCount(t *testing.T) {
 		Return(42, nil).
 		Once()
 
-	// Ensure GetDatabaseStats is NOT called
-	mockStore.EXPECT().
-		GetDatabaseStats(mock.Anything).
-		Return(nil, fmt.Errorf("should not be called")).
-		Maybe()
-
 	repo := datastore.NewDetectionRepository(mockStore, time.UTC)
 	count, err := repo.CountAll(t.Context())
 
 	require.NoError(t, err)
 	assert.Equal(t, int64(42), count)
-
 	mockStore.AssertNotCalled(t, "GetDatabaseStats", mock.Anything)
 }
 

--- a/internal/datastore/detection_repository_test.go
+++ b/internal/datastore/detection_repository_test.go
@@ -1,0 +1,59 @@
+package datastore_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"github.com/tphakala/birdnet-go/internal/datastore"
+	"github.com/tphakala/birdnet-go/internal/datastore/mocks"
+)
+
+func TestCountAll_DirectCount(t *testing.T) {
+	t.Parallel()
+
+	mockStore := mocks.NewMockInterface(t)
+
+	// Expect CountDetectionsSince called with zero time (matches all records)
+	mockStore.EXPECT().
+		CountDetectionsSince(mock.Anything, time.Time{}).
+		Return(42, nil).
+		Once()
+
+	// Ensure GetDatabaseStats is NOT called
+	mockStore.EXPECT().
+		GetDatabaseStats(mock.Anything).
+		Return(nil, fmt.Errorf("should not be called")).
+		Maybe()
+
+	repo := datastore.NewDetectionRepository(mockStore, time.UTC)
+	count, err := repo.CountAll(t.Context())
+
+	require.NoError(t, err)
+	assert.Equal(t, int64(42), count)
+
+	mockStore.AssertNotCalled(t, "GetDatabaseStats", mock.Anything)
+}
+
+func TestCountAll_Error(t *testing.T) {
+	t.Parallel()
+
+	mockStore := mocks.NewMockInterface(t)
+
+	expectedErr := fmt.Errorf("database connection lost")
+	mockStore.EXPECT().
+		CountDetectionsSince(mock.Anything, time.Time{}).
+		Return(0, expectedErr).
+		Once()
+
+	repo := datastore.NewDetectionRepository(mockStore, time.UTC)
+	count, err := repo.CountAll(t.Context())
+
+	require.Error(t, err)
+	assert.Equal(t, int64(0), count)
+	assert.Contains(t, err.Error(), "failed to count detections")
+	assert.ErrorIs(t, err, expectedErr)
+}


### PR DESCRIPTION
## Summary

- **CountAll direct count**: `detectionRepository.CountAll` now calls `CountDetectionsSince(ctx, time.Time{})` (single query) instead of delegating to `GetDatabaseStats` which ran 3 queries (PingContext + getDatabaseSize + getTableRowCount)
- **TOCTOU race fix**: Snapshot `c.DS` and `c.V2Manager` into local variables before nil-check and use in health check closures, `GetDatabaseStats`, `getV2ManagerStats`, and `DownloadDatabaseBackup` to prevent panics during concurrent shutdown
- **getV2Stats elimination**: Remove `getV2Stats` and `V2DatabaseStatsResponse` (87 lines). In v2-only mode, `c.DS.GetDatabaseStats` already returns correct stats. New `getV2ManagerStats` uses PRAGMA for SQLite size and `DATABASE()` for MySQL (matching canonical patterns in monitoring.go), replacing `os.Stat` and manual string parsing
- **Error observability**: Size and count query errors in `getV2ManagerStats` are now logged instead of silently swallowed

## Test Plan

- [x] 2 new unit tests for CountAll (direct count + error propagation)
- [x] All 756 datastore tests pass with `-race`
- [x] All 2008 api/v2 tests pass with `-race`
- [x] `golangci-lint run -v` clean
- [x] Gate pre-push review (2 passes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Health checks now reliably handle unavailable datastores.

* **Refactor**
  * Unified database stats and backup flows for consistent v2/datastore behavior.
  * Detection counting now uses a direct store count instead of database-stats heuristics.

* **Tests**
  * Added unit tests verifying detection counting and error propagation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3154?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->