### PR TITLE
fix(inference): add macOS dylib version parsing and complete ORT pre-checks

### DIFF
--- a/internal/classifier/model_onnx.go
+++ b/internal/classifier/model_onnx.go
@@ -16,6 +16,21 @@ func (bn *BirdNET) initializeONNXModel() error {
 	start := time.Now()
 	log := GetLogger()
 
+	// Pre-check ORT availability before attempting model load.
+	ortStatus := inference.CheckORTAvailability(bn.Settings.BirdNET.ONNXRuntimePath)
+	if !ortStatus.Available {
+		log.Warn("ONNX classifier requires ONNX Runtime which is not available",
+			logger.String("error", ortStatus.Error))
+		emitORTUnavailableNotification("BirdNET ONNX Classifier", ortStatus.Error)
+		return errors.Newf("ONNX classifier requires ONNX Runtime %s: %s",
+			inference.ORTRequiredVersion(), ortStatus.Error).
+			Category(errors.CategoryModelInit).
+			Context("model", "onnx_classifier").
+			Context("ort_error", ortStatus.Error).
+			Timing("ort-check", time.Since(start)).
+			Build()
+	}
+
 	// Initialize ONNX Runtime if not already done
 	if err := inference.InitONNXRuntime(bn.Settings.BirdNET.ONNXRuntimePath); err != nil {
 		return errors.New(err).
@@ -56,6 +71,22 @@ func (bn *BirdNET) initializeONNXMetaModel() error {
 	}
 
 	start := time.Now()
+	log := GetLogger()
+
+	// Pre-check ORT availability before attempting range filter load.
+	ortStatus := inference.CheckORTAvailability(settings.BirdNET.ONNXRuntimePath)
+	if !ortStatus.Available {
+		log.Warn("ONNX range filter requires ONNX Runtime which is not available",
+			logger.String("error", ortStatus.Error))
+		emitORTUnavailableNotification("BirdNET Range Filter", ortStatus.Error)
+		return errors.Newf("ONNX range filter requires ONNX Runtime %s: %s",
+			inference.ORTRequiredVersion(), ortStatus.Error).
+			Category(errors.CategoryModelInit).
+			Context("model", "range_filter").
+			Context("ort_error", ortStatus.Error).
+			Timing("ort-check", time.Since(start)).
+			Build()
+	}
 
 	// Ensure ONNX Runtime is initialized (idempotent - may already be init from classifier)
 	if err := inference.InitONNXRuntime(settings.BirdNET.ONNXRuntimePath); err != nil {

--- a/internal/classifier/orchestrator_bat_onnx.go
+++ b/internal/classifier/orchestrator_bat_onnx.go
@@ -2,6 +2,7 @@ package classifier
 
 import (
 	"github.com/tphakala/birdnet-go/internal/errors"
+	"github.com/tphakala/birdnet-go/internal/inference"
 	"github.com/tphakala/birdnet-go/internal/logger"
 )
 
@@ -24,6 +25,21 @@ func (o *Orchestrator) loadBat(threads int) error {
 		if embeddingModel == "" {
 			embeddingModel = e
 		}
+	}
+
+	// Pre-check ORT availability before attempting bat model load.
+	ortStatus := inference.CheckORTAvailability(o.Settings.BirdNET.ONNXRuntimePath)
+	if !ortStatus.Available {
+		log.Warn("Bat model requires ONNX Runtime which is not available",
+			logger.String("error", ortStatus.Error))
+		emitORTUnavailableNotification("Bat Model", ortStatus.Error)
+		return errors.Newf("Bat model requires ONNX Runtime %s: %s",
+			inference.ORTRequiredVersion(), ortStatus.Error).
+			Component("classifier.orchestrator").
+			Category(errors.CategoryModelInit).
+			Context("model", "Bat").
+			Context("ort_error", ortStatus.Error).
+			Build()
 	}
 
 	cfg := BatModelConfig{

--- a/internal/inference/ort_status.go
+++ b/internal/inference/ort_status.go
@@ -68,7 +68,7 @@ func CheckORTAvailability(configuredPath string) ORTStatus {
 	}
 
 	// If we could determine the version and it is incompatible, reject early.
-	// If version is empty (e.g. Windows/macOS where filename lacks version),
+	// If version is empty (e.g. Windows where filename lacks version),
 	// be optimistic: the library exists, actual compatibility is verified at
 	// init time when the binding calls OrtGetApiBase.
 	if version != "" && !isVersionCompatible(version) {
@@ -123,10 +123,19 @@ func inferVersionFromPath(libPath string) string {
 
 	base := filepath.Base(resolved)
 
-	// Look for a version suffix after ".so." (Linux convention).
-	// Example: "libonnxruntime.so.1.25.1" -> "1.25.1"
+	// Linux convention: "libonnxruntime.so.1.25.1" -> "1.25.1"
 	if idx := strings.Index(base, ".so."); idx >= 0 {
 		return base[idx+len(".so."):]
+	}
+
+	// macOS convention: "libonnxruntime.1.25.1.dylib" -> "1.25.1"
+	if strings.HasSuffix(base, ".dylib") {
+		name := strings.TrimSuffix(base, ".dylib")
+		for i := range len(name) {
+			if name[i] == '.' && i+1 < len(name) && name[i+1] >= '0' && name[i+1] <= '9' {
+				return name[i+1:]
+			}
+		}
 	}
 
 	return ""

--- a/internal/inference/ort_status_test.go
+++ b/internal/inference/ort_status_test.go
@@ -2,6 +2,7 @@ package inference
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -69,7 +70,7 @@ func TestInferVersionFromPath(t *testing.T) {
 	t.Run("macOS dylib with version", func(t *testing.T) {
 		t.Parallel()
 		dir := t.TempDir()
-		dylib := dir + "/libonnxruntime.1.25.1.dylib"
+		dylib := filepath.Join(dir, "libonnxruntime.1.25.1.dylib")
 		require.NoError(t, os.WriteFile(dylib, nil, 0o644))
 		assert.Equal(t, "1.25.1", inferVersionFromPath(dylib))
 	})
@@ -77,8 +78,8 @@ func TestInferVersionFromPath(t *testing.T) {
 	t.Run("macOS dylib symlink to versioned", func(t *testing.T) {
 		t.Parallel()
 		dir := t.TempDir()
-		versioned := dir + "/libonnxruntime.1.25.1.dylib"
-		link := dir + "/libonnxruntime.dylib"
+		versioned := filepath.Join(dir, "libonnxruntime.1.25.1.dylib")
+		link := filepath.Join(dir, "libonnxruntime.dylib")
 		require.NoError(t, os.WriteFile(versioned, nil, 0o644))
 		require.NoError(t, os.Symlink(versioned, link))
 		assert.Equal(t, "1.25.1", inferVersionFromPath(link))
@@ -87,7 +88,7 @@ func TestInferVersionFromPath(t *testing.T) {
 	t.Run("macOS dylib with dotted prefix", func(t *testing.T) {
 		t.Parallel()
 		dir := t.TempDir()
-		dylib := dir + "/my.custom.lib.1.25.1.dylib"
+		dylib := filepath.Join(dir, "my.custom.lib.1.25.1.dylib")
 		require.NoError(t, os.WriteFile(dylib, nil, 0o644))
 		assert.Equal(t, "1.25.1", inferVersionFromPath(dylib))
 	})
@@ -95,7 +96,7 @@ func TestInferVersionFromPath(t *testing.T) {
 	t.Run("macOS dylib without version", func(t *testing.T) {
 		t.Parallel()
 		dir := t.TempDir()
-		dylib := dir + "/libonnxruntime.dylib"
+		dylib := filepath.Join(dir, "libonnxruntime.dylib")
 		require.NoError(t, os.WriteFile(dylib, nil, 0o644))
 		assert.Empty(t, inferVersionFromPath(dylib))
 	})

--- a/internal/inference/ort_status_test.go
+++ b/internal/inference/ort_status_test.go
@@ -66,6 +66,40 @@ func TestInferVersionFromPath(t *testing.T) {
 		assert.Equal(t, "1.25.1", inferVersionFromPath(link))
 	})
 
+	t.Run("macOS dylib with version", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		dylib := dir + "/libonnxruntime.1.25.1.dylib"
+		require.NoError(t, os.WriteFile(dylib, nil, 0o644))
+		assert.Equal(t, "1.25.1", inferVersionFromPath(dylib))
+	})
+
+	t.Run("macOS dylib symlink to versioned", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		versioned := dir + "/libonnxruntime.1.25.1.dylib"
+		link := dir + "/libonnxruntime.dylib"
+		require.NoError(t, os.WriteFile(versioned, nil, 0o644))
+		require.NoError(t, os.Symlink(versioned, link))
+		assert.Equal(t, "1.25.1", inferVersionFromPath(link))
+	})
+
+	t.Run("macOS dylib with dotted prefix", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		dylib := dir + "/my.custom.lib.1.25.1.dylib"
+		require.NoError(t, os.WriteFile(dylib, nil, 0o644))
+		assert.Equal(t, "1.25.1", inferVersionFromPath(dylib))
+	})
+
+	t.Run("macOS dylib without version", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		dylib := dir + "/libonnxruntime.dylib"
+		require.NoError(t, os.WriteFile(dylib, nil, 0o644))
+		assert.Empty(t, inferVersionFromPath(dylib))
+	})
+
 	t.Run("windows dll", func(t *testing.T) {
 		t.Parallel()
 		assert.Empty(t, inferVersionFromPath("C:\\onnxruntime.dll"))


### PR DESCRIPTION
## Summary
- Add macOS `.dylib` naming convention support to `inferVersionFromPath` so version inference works for `libonnxruntime.X.Y.Z.dylib` filenames. The parser finds the first dot followed by a digit to handle dotted library name prefixes correctly.
- Add the ORT pre-check + notification pattern to `initializeONNXModel`, `initializeONNXMetaModel` (legacy range filter), and `loadBat`, matching the existing pattern in `initializeV3GeoModel` and `loadPerch`. Users now get a friendly notification instead of a cryptic init error when ORT is missing.

## Test plan
- [x] New test cases for macOS dylib version parsing (versioned, symlinked, unversioned, dotted prefix)
- [x] All existing ORT status tests pass with `-race`
- [x] `golangci-lint` clean
- [x] Build compiles successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ONNX Runtime availability checks with clearer error messaging, logging and user-facing notifications; models (including range filter and Bat) now fail gracefully when ORT is unavailable.
  * Added support for ONNX Runtime library detection on macOS.

* **Tests**
  * Expanded test coverage for runtime version detection on macOS platforms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3155?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->