### PR TITLE
fix(api): snapshot c.Processor and c.BirdImageCache to eliminate TOCTOU races

### DIFF
--- a/internal/api/v2/analytics.go
+++ b/internal/api/v2/analytics.go
@@ -491,7 +491,7 @@ func (c *Controller) batchFetchSpeciesStatus(scientificNames []string, statusTim
 	if proc == nil || len(scientificNames) == 0 {
 		return nil
 	}
-	tracker := proc.NewSpeciesTracker
+	tracker := proc.GetNewSpeciesTracker()
 	if tracker == nil {
 		return nil
 	}

--- a/internal/api/v2/analytics.go
+++ b/internal/api/v2/analytics.go
@@ -457,11 +457,12 @@ func collectSpeciesWithDetections(aggregatedData map[string]aggregatedBirdInfo) 
 // batchFetchCachedThumbnails fetches thumbnail URLs from cache only
 func (c *Controller) batchFetchCachedThumbnails(scientificNames []string) map[string]string {
 	thumbnailURLs := make(map[string]string)
-	if c.BirdImageCache == nil || len(scientificNames) == 0 {
+	cache := c.BirdImageCache
+	if cache == nil || len(scientificNames) == 0 {
 		return thumbnailURLs
 	}
 
-	batchResults := c.BirdImageCache.GetBatchCachedOnly(scientificNames)
+	batchResults := cache.GetBatchCachedOnly(scientificNames)
 	for name := range batchResults {
 		if img := batchResults[name]; img.URL != "" && !img.IsNegativeEntry() {
 			thumbnailURLs[name] = imageprovider.ProxyImageURL(name)
@@ -485,10 +486,16 @@ func parseStatusTimeFromDate(selectedDate string) time.Time {
 
 // batchFetchSpeciesStatus fetches species tracking status to avoid N+1 queries
 func (c *Controller) batchFetchSpeciesStatus(scientificNames []string, statusTime time.Time) map[string]species.SpeciesStatus {
-	if c.Processor == nil || c.Processor.NewSpeciesTracker == nil || len(scientificNames) == 0 {
+	// Snapshot processor and tracker to avoid TOCTOU race
+	proc := c.Processor
+	if proc == nil || len(scientificNames) == 0 {
 		return nil
 	}
-	return c.Processor.NewSpeciesTracker.GetBatchSpeciesStatus(scientificNames, statusTime)
+	tracker := proc.NewSpeciesTracker
+	if tracker == nil {
+		return nil
+	}
+	return tracker.GetBatchSpeciesStatus(scientificNames, statusTime)
 }
 
 // getThumbnailWithFallback returns thumbnail URL or placeholder
@@ -621,7 +628,8 @@ func extractScientificNames(summaryData []datastore.SpeciesSummaryData) []string
 
 // batchFetchThumbnailsWithLogging fetches thumbnails with debug logging
 func (c *Controller) batchFetchThumbnailsWithLogging(scientificNames []string, ip, path string) map[string]imageprovider.BirdImage {
-	if c.BirdImageCache == nil || len(scientificNames) == 0 {
+	cache := c.BirdImageCache
+	if cache == nil || len(scientificNames) == 0 {
 		return nil
 	}
 
@@ -631,7 +639,7 @@ func (c *Controller) batchFetchThumbnailsWithLogging(scientificNames []string, i
 		logger.String("path", path),
 	)
 	thumbStart := time.Now()
-	thumbnailURLs := c.BirdImageCache.GetBatchCachedOnly(scientificNames)
+	thumbnailURLs := cache.GetBatchCachedOnly(scientificNames)
 	thumbDuration := time.Since(thumbStart)
 	c.logInfoIfEnabled("Cached thumbnail fetch completed",
 		logger.Int64("duration_ms", thumbDuration.Milliseconds()),
@@ -1160,11 +1168,12 @@ func extractNewSpeciesNames(data []datastore.NewSpeciesData) []string {
 // batchFetchThumbnailURLs fetches thumbnail URLs from cache
 func (c *Controller) batchFetchThumbnailURLs(scientificNames []string) map[string]string {
 	thumbnailURLs := make(map[string]string)
-	if c.BirdImageCache == nil {
+	cache := c.BirdImageCache
+	if cache == nil {
 		return thumbnailURLs
 	}
 
-	batchResults := c.BirdImageCache.GetBatch(scientificNames)
+	batchResults := cache.GetBatch(scientificNames)
 	for name := range batchResults {
 		if img := batchResults[name]; img.URL != "" && !img.IsNegativeEntry() {
 			thumbnailURLs[name] = imageprovider.ProxyImageURL(name)
@@ -1272,16 +1281,15 @@ func (c *Controller) GetSpeciesThumbnails(ctx echo.Context) error {
 func (c *Controller) buildThumbnailMap(speciesParams []string) map[string]string {
 	result := make(map[string]string)
 
-	if c.BirdImageCache == nil {
-		// No image cache, return placeholders for all
+	cache := c.BirdImageCache
+	if cache == nil {
 		for _, name := range speciesParams {
 			result[name] = placeholderImageURL
 		}
 		return result
 	}
 
-	// Get thumbnails in batch from cache
-	images := c.BirdImageCache.GetBatch(speciesParams)
+	images := cache.GetBatch(speciesParams)
 
 	// Convert to simple map of scientific name -> proxy URL
 	for name := range images {

--- a/internal/api/v2/detections.go
+++ b/internal/api/v2/detections.go
@@ -743,7 +743,7 @@ func (c *Controller) applySpeciesTrackingMetadata(detection *DetectionResponse, 
 	if proc == nil {
 		return
 	}
-	tracker := proc.NewSpeciesTracker
+	tracker := proc.GetNewSpeciesTracker()
 	if tracker == nil {
 		return
 	}

--- a/internal/api/v2/detections.go
+++ b/internal/api/v2/detections.go
@@ -738,14 +738,20 @@ func (c *Controller) noteToDetectionResponse(note *datastore.Note, includeWeathe
 // Without this, all detections of a recently-first-seen species would incorrectly
 // show isNewSpecies=true instead of only the actual first detection.
 func (c *Controller) applySpeciesTrackingMetadata(detection *DetectionResponse, scientificName, detectionDate string) {
-	if c.Processor == nil || c.Processor.NewSpeciesTracker == nil {
+	// Snapshot processor and tracker to avoid TOCTOU race
+	proc := c.Processor
+	if proc == nil {
+		return
+	}
+	tracker := proc.NewSpeciesTracker
+	if tracker == nil {
 		return
 	}
 	// GetSpeciesStatus is called with time.Now() intentionally: the "days since"
 	// counters (DaysSinceFirstSeen, DaysThisYear, DaysThisSeason) describe the
 	// species' current tracking state, not the state at the detection's time.
 	// The boolean flags (IsNew*) are computed below using date comparison instead.
-	status := c.Processor.NewSpeciesTracker.GetSpeciesStatus(scientificName, time.Now())
+	status := tracker.GetSpeciesStatus(scientificName, time.Now())
 
 	// Set flags based on whether THIS detection's date matches the first-seen date
 	// for each tracking period, rather than using the tracker's window-based "IsNew" flag.

--- a/internal/api/v2/diagnostics.go
+++ b/internal/api/v2/diagnostics.go
@@ -171,10 +171,11 @@ func (c *Controller) registerHealthChecks() {
 		checks.NewMQTTCheck(
 			func() bool { return c.currentSettings().Realtime.MQTT.Enabled },
 			func() bool {
-				if c.Processor == nil {
+				proc := c.Processor
+				if proc == nil {
 					return false
 				}
-				client := c.Processor.GetMQTTClient()
+				client := proc.GetMQTTClient()
 				if client == nil {
 					return false
 				}

--- a/internal/api/v2/dynamic_thresholds.go
+++ b/internal/api/v2/dynamic_thresholds.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
+	"github.com/tphakala/birdnet-go/internal/analysis/processor"
 	"github.com/tphakala/birdnet-go/internal/errors"
 )
 
@@ -86,15 +87,18 @@ func (c *Controller) parseSpeciesParam(ctx echo.Context) (string, error) {
 	return species, nil
 }
 
-// requireProcessor checks if the processor is available and returns an error if not.
-func (c *Controller) requireProcessor(ctx echo.Context) error {
-	if c.Processor == nil {
-		return c.HandleError(ctx, errors.Newf("processor not available").
+// requireProcessor snapshots c.Processor and returns it if non-nil.
+// Callers must use the returned pointer for all subsequent accesses
+// to avoid a TOCTOU race between the nil check and usage.
+func (c *Controller) requireProcessor(ctx echo.Context) (*processor.Processor, error) {
+	proc := c.Processor
+	if proc == nil {
+		return nil, c.HandleError(ctx, errors.Newf("processor not available").
 			Category(errors.CategorySystem).
 			Component("api-dynamic-thresholds").
 			Build(), "Processor not available", http.StatusServiceUnavailable)
 	}
-	return nil
+	return proc, nil
 }
 
 // applyMemoryOverlay updates a threshold response with in-memory data.
@@ -219,10 +223,11 @@ func (c *Controller) addDatabaseThresholds(thresholdMap map[string]*DynamicThres
 // addMemoryThresholds adds/updates thresholds from processor memory.
 // If processor is unavailable, this function returns early without modification.
 func (c *Controller) addMemoryThresholds(thresholdMap map[string]*DynamicThresholdResponse) {
-	if c.Processor == nil {
+	proc := c.Processor
+	if proc == nil {
 		return
 	}
-	memoryData := c.Processor.GetDynamicThresholdData()
+	memoryData := proc.GetDynamicThresholdData()
 	baseThreshold := c.currentSettings().BirdNET.Threshold
 
 	for _, dt := range memoryData {
@@ -315,9 +320,11 @@ func (c *Controller) GetDynamicThreshold(ctx echo.Context) error {
 		IsActive:       dt.ExpiresAt.After(time.Now()),
 	}
 
-	// Try to get more current data from processor memory
-	if c.Processor != nil {
-		for _, md := range c.Processor.GetDynamicThresholdData() {
+	// Try to get more current data from processor memory.
+	// Snapshot c.Processor to avoid a TOCTOU race between the nil check and usage.
+	proc := c.Processor
+	if proc != nil {
+		for _, md := range proc.GetDynamicThresholdData() {
 			if strings.EqualFold(md.SpeciesName, species) {
 				applyMemoryOverlay(&response, md.Level, md.HighConfCount, md.CurrentValue, md.ExpiresAt, md.IsActive, md.ScientificName)
 				break
@@ -371,7 +378,8 @@ func (c *Controller) GetThresholdEvents(ctx echo.Context) error {
 // ResetDynamicThreshold resets a single species threshold
 // DELETE /api/v2/dynamic-thresholds/:species
 func (c *Controller) ResetDynamicThreshold(ctx echo.Context) error {
-	if err := c.requireProcessor(ctx); err != nil {
+	proc, err := c.requireProcessor(ctx)
+	if err != nil {
 		return err
 	}
 
@@ -381,7 +389,7 @@ func (c *Controller) ResetDynamicThreshold(ctx echo.Context) error {
 	}
 
 	// Use processor's reset method which handles both memory and database
-	if err := c.Processor.ResetDynamicThreshold(species); err != nil {
+	if err := proc.ResetDynamicThreshold(species); err != nil {
 		return c.HandleError(ctx, err, "Failed to reset threshold", http.StatusInternalServerError)
 	}
 
@@ -395,7 +403,8 @@ func (c *Controller) ResetDynamicThreshold(ctx echo.Context) error {
 // ResetAllDynamicThresholds resets all dynamic thresholds
 // DELETE /api/v2/dynamic-thresholds?confirm=true
 func (c *Controller) ResetAllDynamicThresholds(ctx echo.Context) error {
-	if err := c.requireProcessor(ctx); err != nil {
+	proc, err := c.requireProcessor(ctx)
+	if err != nil {
 		return err
 	}
 
@@ -409,7 +418,7 @@ func (c *Controller) ResetAllDynamicThresholds(ctx echo.Context) error {
 	}
 
 	// Use processor's reset all method which handles both memory and database
-	count, err := c.Processor.ResetAllDynamicThresholds()
+	count, err := proc.ResetAllDynamicThresholds()
 	if err != nil {
 		return c.HandleError(ctx, err, "Failed to reset all thresholds", http.StatusInternalServerError)
 	}

--- a/internal/api/v2/dynamic_thresholds.go
+++ b/internal/api/v2/dynamic_thresholds.go
@@ -93,10 +93,12 @@ func (c *Controller) parseSpeciesParam(ctx echo.Context) (string, error) {
 func (c *Controller) requireProcessor(ctx echo.Context) (*processor.Processor, error) {
 	proc := c.Processor
 	if proc == nil {
-		return nil, c.HandleError(ctx, errors.Newf("processor not available").
+		err := errors.Newf("processor not available").
 			Category(errors.CategorySystem).
 			Component("api-dynamic-thresholds").
-			Build(), "Processor not available", http.StatusServiceUnavailable)
+			Build()
+		_ = c.HandleError(ctx, err, "Processor not available", http.StatusServiceUnavailable)
+		return nil, err
 	}
 	return proc, nil
 }

--- a/internal/api/v2/integrations.go
+++ b/internal/api/v2/integrations.go
@@ -765,13 +765,14 @@ func (c *Controller) TriggerHomeAssistantDiscovery(ctx echo.Context) error {
 		logger.String("path", ctx.Request().URL.Path),
 		logger.String("ip", ctx.RealIP()))
 
-	// Check if processor is available
-	if c.Processor == nil {
+	// Snapshot processor to avoid TOCTOU race
+	proc := c.Processor
+	if proc == nil {
 		return c.HandleErrorWithKey(ctx, nil, "Processor not available", http.StatusServiceUnavailable, notification.MsgErrIntegProcessorUnavail, nil)
 	}
 
 	// Trigger discovery
-	if err := c.Processor.TriggerHomeAssistantDiscovery(ctx.Request().Context()); err != nil {
+	if err := proc.TriggerHomeAssistantDiscovery(ctx.Request().Context()); err != nil {
 		return c.HandleErrorWithKey(ctx, err, "Failed to trigger Home Assistant discovery", http.StatusBadRequest, notification.MsgErrIntegDiscoveryFailed, nil)
 	}
 

--- a/internal/api/v2/media.go
+++ b/internal/api/v2/media.go
@@ -2806,11 +2806,12 @@ func (c *Controller) GetSpeciesImageInfo(ctx echo.Context) error {
 		return c.HandleError(ctx, fmt.Errorf("scientific name contains only whitespace"), "Valid scientific name is required", http.StatusBadRequest)
 	}
 
-	if c.BirdImageCache == nil {
+	cache := c.BirdImageCache
+	if cache == nil {
 		return c.HandleError(ctx, ErrImageProviderNotAvailable, "Image service unavailable", http.StatusServiceUnavailable)
 	}
 
-	birdImage, err := c.BirdImageCache.Get(scientificName)
+	birdImage, err := cache.Get(scientificName)
 	if err != nil {
 		if errors.Is(err, imageprovider.ErrImageNotFound) {
 			ctx.Response().Header().Set("Cache-Control", fmt.Sprintf("public, max-age=%d", NotFoundCacheSeconds))
@@ -2852,12 +2853,13 @@ func (c *Controller) ServeSpeciesImageProxy(ctx echo.Context) error {
 		return c.HandleError(ctx, fmt.Errorf("invalid scientific name"), "Invalid species name", http.StatusBadRequest)
 	}
 
-	if c.BirdImageCache == nil {
+	cache := c.BirdImageCache
+	if cache == nil {
 		return c.HandleError(ctx, ErrImageProviderNotAvailable, "Image service unavailable", http.StatusServiceUnavailable)
 	}
 
 	// Look up metadata to know which provider owns this image
-	birdImage, err := c.BirdImageCache.Get(scientificName)
+	birdImage, err := cache.Get(scientificName)
 	if err != nil {
 		if errors.Is(err, imageprovider.ErrImageNotFound) {
 			ctx.Response().Header().Set("Cache-Control", fmt.Sprintf("public, max-age=%d", NotFoundCacheSeconds))
@@ -2873,7 +2875,7 @@ func (c *Controller) ServeSpeciesImageProxy(ctx echo.Context) error {
 	}
 
 	// Get the file cache from the BirdImageCache
-	fileCache := c.BirdImageCache.GetFileCache()
+	fileCache := cache.GetFileCache()
 	if fileCache == nil {
 		// No file cache configured, redirect to external URL
 		return ctx.Redirect(http.StatusFound, birdImage.URL)
@@ -2881,7 +2883,7 @@ func (c *Controller) ServeSpeciesImageProxy(ctx echo.Context) error {
 
 	provider := birdImage.SourceProvider
 	if provider == "" {
-		provider = c.BirdImageCache.GetProviderName()
+		provider = cache.GetProviderName()
 	}
 
 	// Try to serve from file cache

--- a/internal/api/v2/range.go
+++ b/internal/api/v2/range.go
@@ -65,10 +65,12 @@ func calculateWeek(date time.Time) float32 {
 
 // getBirdNETInstance returns the BirdNET instance or an error if unavailable.
 func (c *Controller) getBirdNETInstance() (*classifier.Orchestrator, error) {
-	if c.Processor == nil {
+	// Snapshot processor to avoid TOCTOU race
+	proc := c.Processor
+	if proc == nil {
 		return nil, fmt.Errorf("BirdNET processor not available")
 	}
-	instance := c.Processor.GetBirdNET()
+	instance := proc.GetBirdNET()
 	if instance == nil {
 		return nil, fmt.Errorf("BirdNET instance not available")
 	}

--- a/internal/api/v2/settings.go
+++ b/internal/api/v2/settings.go
@@ -2502,12 +2502,13 @@ func capitalizeProviderName(name string) string {
 func (c *Controller) collectImageProviders(ctx echo.Context) (providers []ImageProviderOption, count int) {
 	providers = []ImageProviderOption{{Value: "auto", Display: "Auto (Default)"}}
 
-	if c.BirdImageCache == nil {
+	cache := c.BirdImageCache
+	if cache == nil {
 		c.logAPIRequest(ctx, logger.LogLevelWarn, "BirdImageCache is nil, cannot get provider names")
 		return providers, count
 	}
 
-	registry := c.BirdImageCache.GetRegistry()
+	registry := cache.GetRegistry()
 	if registry == nil {
 		c.logAPIRequest(ctx, logger.LogLevelWarn, "ImageProviderRegistry is nil, cannot get provider names")
 		return providers, count

--- a/internal/api/v2/species.go
+++ b/internal/api/v2/species.go
@@ -183,15 +183,16 @@ func (c *Controller) GetSpeciesInfo(ctx echo.Context) error {
 
 // getSpeciesInfo retrieves species information including rarity status
 func (c *Controller) getSpeciesInfo(ctx context.Context, scientificName string) (*SpeciesInfo, error) {
-	// Get the BirdNET instance from the processor
-	if c.Processor == nil || c.Processor.Bn == nil {
+	// Snapshot to avoid TOCTOU race on c.Processor
+	proc := c.Processor
+	if proc == nil || proc.Bn == nil {
 		return nil, errors.Newf("BirdNET processor not available").
 			Category(errors.CategorySystem).
 			Component("api-species").
 			Build()
 	}
 
-	bn := c.Processor.Bn
+	bn := proc.Bn
 
 	// Find the full label for this species from BirdNET labels
 	var matchedLabel string
@@ -583,16 +584,17 @@ func (c *Controller) GetSpeciesThumbnail(ctx echo.Context) error {
 		logger.String("path", ctx.Request().URL.Path),
 	)
 
-	// Check if BirdNET processor is available
-	if c.Processor == nil || c.Processor.Bn == nil {
+	// Snapshot to avoid TOCTOU race on c.Processor
+	proc := c.Processor
+	if proc == nil || proc.Bn == nil {
 		return c.HandleError(ctx, errors.Newf("BirdNET processor not available").
 			Category(errors.CategorySystem).
 			Component("api-species").
 			Build(), "BirdNET service unavailable", http.StatusServiceUnavailable)
 	}
 
-	// Check if BirdImageCache is available
-	if c.BirdImageCache == nil {
+	cache := c.BirdImageCache
+	if cache == nil {
 		return c.HandleError(ctx, errors.Newf("image service unavailable").
 			Category(errors.CategorySystem).
 			Component("api-species").
@@ -600,7 +602,7 @@ func (c *Controller) GetSpeciesThumbnail(ctx echo.Context) error {
 	}
 
 	// Get species name from the taxonomy map using the species code
-	bn := c.Processor.Bn
+	bn := proc.Bn
 	speciesName, exists := classifier.GetSpeciesNameFromCode(bn.TaxonomyMap, speciesCode)
 
 	if !exists {

--- a/internal/api/v2/sse.go
+++ b/internal/api/v2/sse.go
@@ -882,7 +882,7 @@ func (c *Controller) BroadcastDetection(note *datastore.Note, birdImage *imagepr
 	// recently-first-seen species.
 	// Snapshot processor and tracker to avoid TOCTOU race.
 	if proc := c.Processor; proc != nil {
-		if tracker := proc.NewSpeciesTracker; tracker != nil {
+		if tracker := proc.GetNewSpeciesTracker(); tracker != nil {
 			status := tracker.GetSpeciesStatus(note.ScientificName, time.Now())
 			detection.IsNewSpecies = !status.FirstSeenTime.IsZero() &&
 				note.Date == status.FirstSeenTime.Format(time.DateOnly)

--- a/internal/api/v2/sse.go
+++ b/internal/api/v2/sse.go
@@ -880,11 +880,14 @@ func (c *Controller) BroadcastDetection(note *datastore.Note, birdImage *imagepr
 	// Compare the detection date with the species' first-seen date so the flag
 	// is true only for the actual first detection, not for every detection of a
 	// recently-first-seen species.
-	if c.Processor != nil && c.Processor.NewSpeciesTracker != nil {
-		status := c.Processor.NewSpeciesTracker.GetSpeciesStatus(note.ScientificName, time.Now())
-		detection.IsNewSpecies = !status.FirstSeenTime.IsZero() &&
-			note.Date == status.FirstSeenTime.Format(time.DateOnly)
-		detection.DaysSinceFirstSeen = status.DaysSinceFirst
+	// Snapshot processor and tracker to avoid TOCTOU race.
+	if proc := c.Processor; proc != nil {
+		if tracker := proc.NewSpeciesTracker; tracker != nil {
+			status := tracker.GetSpeciesStatus(note.ScientificName, time.Now())
+			detection.IsNewSpecies = !status.FirstSeenTime.IsZero() &&
+				note.Date == status.FirstSeenTime.Format(time.DateOnly)
+			detection.DaysSinceFirstSeen = status.DaysSinceFirst
+		}
 	}
 
 	c.sseManager.BroadcastDetection(&detection)

--- a/internal/api/v2/system.go
+++ b/internal/api/v2/system.go
@@ -224,8 +224,8 @@ func (c *Controller) GetJobQueueStats(ctx echo.Context) error {
 		logger.String("ip", ctx.RealIP()),
 	)
 
-	// Check if processor is available
-	if c.Processor == nil {
+	proc := c.Processor
+	if proc == nil {
 		c.logErrorIfEnabled("Processor not available for job queue stats",
 			logger.String("path", ctx.Request().URL.Path),
 			logger.String("ip", ctx.RealIP()),
@@ -233,8 +233,8 @@ func (c *Controller) GetJobQueueStats(ctx echo.Context) error {
 		return c.HandleError(ctx, fmt.Errorf("processor not available"), "Processor not available", http.StatusInternalServerError)
 	}
 
-	// Check if job queue is available
-	if c.Processor.JobQueue == nil {
+	jq := proc.JobQueue
+	if jq == nil {
 		c.logErrorIfEnabled("Job queue not available",
 			logger.String("path", ctx.Request().URL.Path),
 			logger.String("ip", ctx.RealIP()),
@@ -242,8 +242,7 @@ func (c *Controller) GetJobQueueStats(ctx echo.Context) error {
 		return c.HandleError(ctx, fmt.Errorf("job queue not available"), "Job queue not available", http.StatusInternalServerError)
 	}
 
-	// Get job queue stats
-	stats := c.Processor.JobQueue.GetStats()
+	stats := jq.GetStats()
 
 	// Convert to JSON
 	jsonStats, err := stats.ToJSON()
@@ -808,19 +807,21 @@ func getDeviceBaseName(device string) string {
 	return base
 }
 
+// remoteFsTypes maps filesystem types that are network mounts.
+var remoteFsTypes = map[string]bool{
+	"nfs":        true,
+	"nfs4":       true,
+	"cifs":       true,
+	"smbfs":      true,
+	"sshfs":      true,
+	"fuse.sshfs": true,
+	"afs":        true,
+	"9p":         true,
+	"ncpfs":      true,
+}
+
 // isRemoteFilesystem returns true if the filesystem is a network mount
 func isRemoteFilesystem(fstype string) bool {
-	remoteFsTypes := map[string]bool{
-		"nfs":        true,
-		"nfs4":       true,
-		"cifs":       true,
-		"smbfs":      true,
-		"sshfs":      true,
-		"fuse.sshfs": true,
-		"afs":        true,
-		"9p":         true,
-		"ncpfs":      true,
-	}
 	return remoteFsTypes[fstype]
 }
 
@@ -1442,22 +1443,18 @@ var fsTypeCategories = map[string]FileSystemCategory{
 	"rpc_pipefs":  SpecialFS,
 }
 
+// skipFsPrefixes lists filesystem type prefixes that indicate virtual or system filesystems.
+var skipFsPrefixes = [...]string{"fuse", "cgroup", "proc", "sys", "dev"}
+
 // skipFilesystem returns true if the filesystem type should be skipped
 func skipFilesystem(fstype string) bool {
-	// Check if we have a category for this filesystem type
 	if _, exists := fsTypeCategories[fstype]; exists {
 		return true
 	}
 
-	// Additional checks for common patterns in filesystem types
-	// that might indicate a virtual or system filesystem
-	if len(fstype) >= minRequiredElements {
-		// Check for common filesystem type prefixes
-		commonPrefixes := []string{"fuse", "cgroup", "proc", "sys", "dev"}
-		for _, prefix := range commonPrefixes {
-			if len(fstype) >= len(prefix) && fstype[:len(prefix)] == prefix {
-				return true
-			}
+	for _, prefix := range skipFsPrefixes {
+		if strings.HasPrefix(fstype, prefix) {
+			return true
 		}
 	}
 

--- a/internal/health/checks/system.go
+++ b/internal/health/checks/system.go
@@ -28,7 +28,7 @@ func (c *DiskSpaceCheck) Name() string { return "disk_space" }
 func (c *DiskSpaceCheck) Category() health.Category { return health.CategorySystem }
 
 // Run executes the disk space check against all configured paths.
-func (c *DiskSpaceCheck) Run(_ context.Context) health.Result {
+func (c *DiskSpaceCheck) Run(ctx context.Context) health.Result {
 	start := time.Now()
 
 	if len(c.paths) == 0 {
@@ -55,7 +55,7 @@ func (c *DiskSpaceCheck) Run(_ context.Context) health.Result {
 	pathDetails := make([]pathInfo, 0, len(c.paths))
 
 	for _, p := range c.paths {
-		usage, err := disk.Usage(p)
+		usage, err := disk.UsageWithContext(ctx, p)
 		if err != nil {
 			if health.StatusCritical != worst {
 				worst = health.StatusWarning
@@ -120,10 +120,10 @@ func (c *MemoryCheck) Name() string { return "memory" }
 func (c *MemoryCheck) Category() health.Category { return health.CategorySystem }
 
 // Run executes the memory check.
-func (c *MemoryCheck) Run(_ context.Context) health.Result {
+func (c *MemoryCheck) Run(ctx context.Context) health.Result {
 	start := time.Now()
 
-	vm, err := mem.VirtualMemory()
+	vm, err := mem.VirtualMemoryWithContext(ctx)
 	if err != nil {
 		return health.Result{
 			Name:       c.Name(),


### PR DESCRIPTION
## Summary

- Snapshot `c.Processor` and `c.BirdImageCache` into local variables before nil-checking and dereferencing across all API controller call sites (12 files, 20+ sites). Prevents potential nil pointer panics during concurrent shutdown where the field could be set to nil between the check and the use.
- Refactor `requireProcessor` to return `(*processor.Processor, error)` so callers use the snapshot instead of re-reading the field.
- Promote `remoteFsTypes` map and `skipFsPrefixes` slice from per-call allocations to package-level vars. Replace manual prefix comparison with `strings.HasPrefix`.
- Propagate context through `DiskSpaceCheck.Run` and `MemoryCheck.Run` using `disk.UsageWithContext` and `mem.VirtualMemoryWithContext`.

## Test Plan

- [x] `go build ./internal/api/v2/ ./internal/health/checks/` passes
- [x] `golangci-lint run -v` reports zero issues
- [x] `go test -race ./internal/health/checks/` passes
- [x] No remaining unsnapshot `c.Processor` or `c.BirdImageCache` accesses (verified by grep)
- [x] Two-pass gate review with 4 agents + Gemini cross-validation: zero blocking issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved robustness by snapshotting core components before use across API endpoints, reducing race conditions and stabilizing species tracking, thumbnail/image handling, integrations, media endpoints, SSE broadcasts, and job-queue stats.

* **Chores**
  * Health checks now use context-aware disk/memory APIs; methods updated to accept context for better cancellation and responsiveness.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3156?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->