### PR TITLE
refactor(api): promote per-call allocations and fix c.Processor TOCTOU races

### DIFF
--- a/internal/api/v2/system.go
+++ b/internal/api/v2/system.go
@@ -807,22 +807,14 @@ func getDeviceBaseName(device string) string {
 	return base
 }
 
-// remoteFsTypes maps filesystem types that are network mounts.
-var remoteFsTypes = map[string]bool{
-	"nfs":        true,
-	"nfs4":       true,
-	"cifs":       true,
-	"smbfs":      true,
-	"sshfs":      true,
-	"fuse.sshfs": true,
-	"afs":        true,
-	"9p":         true,
-	"ncpfs":      true,
-}
-
 // isRemoteFilesystem returns true if the filesystem is a network mount
 func isRemoteFilesystem(fstype string) bool {
-	return remoteFsTypes[fstype]
+	switch fstype {
+	case "nfs", "nfs4", "cifs", "smbfs", "sshfs", "fuse.sshfs", "afs", "9p", "ncpfs":
+		return true
+	default:
+		return false
+	}
 }
 
 // isReadOnlyMount returns true if the filesystem is mounted as read-only


### PR DESCRIPTION
## Summary
- Promote `remoteFsTypes` map and `skipFsPrefixes` slice from per-call allocations to package-level vars in `system.go`, eliminating heap allocations on every call to `isRemoteFilesystem` and `skipFilesystem`
- Replace manual prefix comparison with `strings.HasPrefix` in `skipFilesystem`
- Fix `c.Processor` TOCTOU race in `GetJobQueueStats` and MQTT health check closure by snapshotting into a local variable before nil-check and dereference

## Test plan
- [x] `golangci-lint` clean
- [x] Build compiles successfully
- [x] No behavioral changes; all fixes are defensive

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal code efficiency for network filesystem type detection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3157?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->