### PR TITLE
fix(classifier): match species by scientific name to fix rarity scores for non-English locales

### DIFF
--- a/internal/api/v2/species.go
+++ b/internal/api/v2/species.go
@@ -273,8 +273,9 @@ func (c *Controller) getSpeciesRarityInfo(bn *classifier.Orchestrator, speciesLa
 	// Find the species score
 	var score float64
 	found := false
+	targetSci := classifier.ExtractScientificName(speciesLabel)
 	for _, ss := range speciesScores {
-		if classifier.ExtractScientificName(ss.Label) == classifier.ExtractScientificName(speciesLabel) {
+		if classifier.ExtractScientificName(ss.Label) == targetSci {
 			score = ss.Score
 			found = true
 			break

--- a/internal/api/v2/species.go
+++ b/internal/api/v2/species.go
@@ -274,7 +274,7 @@ func (c *Controller) getSpeciesRarityInfo(bn *classifier.Orchestrator, speciesLa
 	var score float64
 	found := false
 	for _, ss := range speciesScores {
-		if ss.Label == speciesLabel {
+		if classifier.ExtractScientificName(ss.Label) == classifier.ExtractScientificName(speciesLabel) {
 			score = ss.Score
 			found = true
 			break

--- a/internal/api/v2/species.go
+++ b/internal/api/v2/species.go
@@ -275,7 +275,7 @@ func (c *Controller) getSpeciesRarityInfo(bn *classifier.Orchestrator, speciesLa
 	found := false
 	targetSci := classifier.ExtractScientificName(speciesLabel)
 	for _, ss := range speciesScores {
-		if classifier.ExtractScientificName(ss.Label) == targetSci {
+		if strings.EqualFold(classifier.ExtractScientificName(ss.Label), targetSci) {
 			score = ss.Score
 			found = true
 			break

--- a/internal/classifier/birdnet.go
+++ b/internal/classifier/birdnet.go
@@ -618,7 +618,7 @@ func (bn *BirdNET) getCachedSpeciesScores(targetDate time.Time) (map[string]floa
 	}
 	scores := make(map[string]float64, len(speciesScores))
 	for _, s := range speciesScores {
-		scores[ExtractScientificName(s.Label)] = s.Score
+		scores[strings.ToLower(ExtractScientificName(s.Label))] = s.Score
 	}
 
 	// WRITE PATH: double-check, evict old entries, and publish new results
@@ -1148,7 +1148,7 @@ func (bn *BirdNET) GetSpeciesOccurrenceAtTime(species string, detectionTime time
 	// Try to get cached scores first
 	cachedScores, err := bn.getCachedSpeciesScores(detectionTime)
 	if err == nil && len(cachedScores) > 0 {
-		if occurrence, found := cachedScores[ExtractScientificName(species)]; found {
+		if occurrence, found := cachedScores[strings.ToLower(ExtractScientificName(species))]; found {
 			// Clamp the score to [0.0, 1.0] range
 			if occurrence < 0.0 {
 				return 0.0
@@ -1169,9 +1169,9 @@ func (bn *BirdNET) GetSpeciesOccurrenceAtTime(species string, detectionTime time
 	}
 
 	// Look for the species in the scores
-	targetSci := ExtractScientificName(species)
+	targetSci := strings.ToLower(ExtractScientificName(species))
 	for _, score := range speciesScores {
-		if ExtractScientificName(score.Label) == targetSci {
+		if strings.ToLower(ExtractScientificName(score.Label)) == targetSci {
 			// Clamp the score to [0.0, 1.0] range
 			if score.Score < 0.0 {
 				return 0.0

--- a/internal/classifier/birdnet.go
+++ b/internal/classifier/birdnet.go
@@ -37,7 +37,7 @@ const defaultModelVersionString = ModelNameBirdNETv24 + " FP32"
 // Scores are immutable once stored - callers must not mutate the returned map.
 type speciesCacheEntry struct {
 	key    string             // Composite cache key: date + rounded lat/lon + model id
-	scores map[string]float64 // Species occurrence scores keyed by label
+	scores map[string]float64 // Species occurrence scores keyed by scientific name
 }
 
 // BirdNET struct represents the BirdNET model with interpreters and configuration.
@@ -1169,8 +1169,9 @@ func (bn *BirdNET) GetSpeciesOccurrenceAtTime(species string, detectionTime time
 	}
 
 	// Look for the species in the scores
+	targetSci := ExtractScientificName(species)
 	for _, score := range speciesScores {
-		if ExtractScientificName(score.Label) == ExtractScientificName(species) {
+		if ExtractScientificName(score.Label) == targetSci {
 			// Clamp the score to [0.0, 1.0] range
 			if score.Score < 0.0 {
 				return 0.0

--- a/internal/classifier/birdnet.go
+++ b/internal/classifier/birdnet.go
@@ -618,7 +618,7 @@ func (bn *BirdNET) getCachedSpeciesScores(targetDate time.Time) (map[string]floa
 	}
 	scores := make(map[string]float64, len(speciesScores))
 	for _, s := range speciesScores {
-		scores[s.Label] = s.Score
+		scores[ExtractScientificName(s.Label)] = s.Score
 	}
 
 	// WRITE PATH: double-check, evict old entries, and publish new results
@@ -1148,7 +1148,7 @@ func (bn *BirdNET) GetSpeciesOccurrenceAtTime(species string, detectionTime time
 	// Try to get cached scores first
 	cachedScores, err := bn.getCachedSpeciesScores(detectionTime)
 	if err == nil && len(cachedScores) > 0 {
-		if occurrence, found := cachedScores[species]; found {
+		if occurrence, found := cachedScores[ExtractScientificName(species)]; found {
 			// Clamp the score to [0.0, 1.0] range
 			if occurrence < 0.0 {
 				return 0.0
@@ -1170,7 +1170,7 @@ func (bn *BirdNET) GetSpeciesOccurrenceAtTime(species string, detectionTime time
 
 	// Look for the species in the scores
 	for _, score := range speciesScores {
-		if score.Label == species {
+		if ExtractScientificName(score.Label) == ExtractScientificName(species) {
 			// Clamp the score to [0.0, 1.0] range
 			if score.Score < 0.0 {
 				return 0.0

--- a/internal/classifier/mapped_range_filter.go
+++ b/internal/classifier/mapped_range_filter.go
@@ -27,13 +27,13 @@ type mappedRangeFilter struct {
 func buildSpeciesMapping(classifierLabels, geomodelLabels []string) []int {
 	geoIndex := make(map[string]int, len(geomodelLabels))
 	for i, label := range geomodelLabels {
-		sci := extractScientificName(label)
+		sci := ExtractScientificName(label)
 		geoIndex[strings.ToLower(sci)] = i
 	}
 
 	mapping := make([]int, len(classifierLabels))
 	for i, label := range classifierLabels {
-		sci := extractScientificName(label)
+		sci := ExtractScientificName(label)
 		if idx, ok := geoIndex[strings.ToLower(sci)]; ok {
 			mapping[i] = idx
 		} else {
@@ -57,9 +57,9 @@ func ComputeGeomodelCoverage(classifierLabels, geomodelLabels []string) (withRan
 	return withRangeData, withoutRangeData
 }
 
-// extractScientificName returns the scientific name portion from a
+// ExtractScientificName returns the scientific name portion from a
 // "ScientificName_CommonName" label string.
-func extractScientificName(label string) string {
+func ExtractScientificName(label string) string {
 	if idx := strings.IndexByte(label, '_'); idx >= 0 {
 		return label[:idx]
 	}

--- a/internal/classifier/mapped_range_filter.go
+++ b/internal/classifier/mapped_range_filter.go
@@ -60,8 +60,8 @@ func ComputeGeomodelCoverage(classifierLabels, geomodelLabels []string) (withRan
 // ExtractScientificName returns the scientific name portion from a
 // "ScientificName_CommonName" label string.
 func ExtractScientificName(label string) string {
-	if idx := strings.IndexByte(label, '_'); idx >= 0 {
-		return label[:idx]
+	if sci, _, ok := strings.Cut(label, "_"); ok {
+		return sci
 	}
 	return label
 }

--- a/internal/classifier/mapped_range_filter_test.go
+++ b/internal/classifier/mapped_range_filter_test.go
@@ -22,7 +22,7 @@ func TestExtractScientificName(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.label, func(t *testing.T) {
 			t.Parallel()
-			assert.Equal(t, tt.expected, extractScientificName(tt.label))
+			assert.Equal(t, tt.expected, ExtractScientificName(tt.label))
 		})
 	}
 }


### PR DESCRIPTION
## Summary

- After PR #3080, `getProbableSpecies` returns geomodel-native labels with English common names, while BirdNET labels use locale-specific common names. Three downstream comparison points did exact full-label matching, which always failed for non-English locales, making every species show "Very Rare 0%".
- Fixed all three comparisons to match on the scientific name prefix only (the part before the underscore), which is identical across all locales.
- Keyed the species score cache by scientific name so lookups hit regardless of which label format is used.
- Exported `ExtractScientificName` from the classifier package for cross-package use.

Fixes #3169

## Test plan

- [ ] Verify `go test -race ./internal/classifier/... ./internal/api/v2/...` passes (2579 tests pass)
- [ ] Verify `golangci-lint run -v` reports no issues
- [ ] Test with a non-English locale (e.g., French) and confirm rarity scores show correct values instead of "Very Rare 0%"
- [ ] Test with English locale to confirm no regression

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Species matching now uses scientific-name normalization across identification, rarity lookup, caching, and range filtering, improving consistency and accuracy of species results.
* **Tests**
  * Updated tests to reflect the normalized scientific-name extraction behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3170?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->