### PR TITLE
feat(analysis): log model-to-source assignment at info level

### DIFF
--- a/internal/analysis/audio_pipeline_service.go
+++ b/internal/analysis/audio_pipeline_service.go
@@ -937,6 +937,18 @@ func (p *AudioPipelineService) registerConsumersForSources(sourceIDs []string, s
 			}
 		}
 
+		// Log final model-to-source assignment for diagnostics.
+		modelIDs := make([]string, len(targets))
+		for i, t := range targets {
+			modelIDs[i] = t.ModelID
+		}
+		log.Info("registering models for audio source",
+			logger.String("source_id", sid),
+			logger.String("source_name", sourceName),
+			logger.String("models", strings.Join(modelIDs, ", ")),
+			logger.Int("model_count", len(targets)),
+			logger.String("operation", operation))
+
 		// Use per-source sample rate when available; fall back to global constant.
 		sourceSampleRate := conf.SampleRate
 		if src != nil && src.SampleRate > 0 {
@@ -1029,6 +1041,13 @@ func (p *AudioPipelineService) reconfigureChangedSources(audioLevelChan chan aud
 			alreadyRunning[connStr] = src.ID
 			sourceModelMap[src.ID] = scm.modelIDs
 			keptCount++
+
+			log.Info("reconfigure: source model assignment",
+				logger.String("source_id", src.ID),
+				logger.String("source_name", src.DisplayName),
+				logger.String("models", strings.Join(scm.modelIDs, ", ")),
+				logger.Int("model_count", len(scm.modelIDs)),
+				logger.String("operation", "reconfigure_diff"))
 
 			// Detect audio parameter changes (sample rate, bit depth, channels)
 			// that require a full source reconfigure (stop + route removal +


### PR DESCRIPTION
## Summary

- Add info-level logging showing which models are registered to each audio source at startup and during hot-reload reconfiguration
- Helps diagnose multi-model issues where users report models like Perch not processing audio from certain sources

## Changes

Two new log points in `audio_pipeline_service.go`:

1. **`registerConsumersForSources`**: logs the final model targets after buffer allocation, showing the effective model list per source (fires at startup)
2. **`reconfigureChangedSources`**: logs model assignments for kept sources during hot-reload, making it visible whether the desired models match what the pipeline is using

## Test plan

- [x] `go build ./internal/analysis/` passes
- [x] `golangci-lint run ./internal/analysis/` passes with zero issues
- [ ] Start with multi-model config (birdnet + perch), verify log lines appear at startup
- [ ] Change model assignment via UI, verify reconfigure log lines appear

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced diagnostic logging for audio source configuration, including detailed reporting of assigned models, source assignments, and reconfiguration status to improve system observability and troubleshooting capabilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/birdnet-go/pull/3181?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->