### PR TITLE
fix(frontend): improve StatusPill contrast and sizing for readability

### DIFF
--- a/frontend/src/lib/desktop/components/ui/StatusPill.svelte
+++ b/frontend/src/lib/desktop/components/ui/StatusPill.svelte
@@ -60,12 +60,12 @@
   const getPillStyles = (variant: StatusVariant) => {
     const varName = safeGet(cssVarNames, variant, '--color-base-content');
     return variant === 'neutral'
-      ? `background-color: color-mix(in srgb, var(${varName}) 5%, transparent); ` +
-          `color: color-mix(in srgb, var(${varName}) 60%, transparent); ` +
-          `border-color: color-mix(in srgb, var(${varName}) 10%, transparent);`
-      : `background-color: color-mix(in srgb, var(${varName}) 10%, transparent); ` +
+      ? `background-color: color-mix(in srgb, var(${varName}) 8%, transparent); ` +
+          `color: color-mix(in srgb, var(${varName}) 70%, transparent); ` +
+          `border-color: color-mix(in srgb, var(${varName}) 15%, transparent);`
+      : `background-color: color-mix(in srgb, var(${varName}) 15%, transparent); ` +
           `color: var(${varName}); ` +
-          `border-color: color-mix(in srgb, var(${varName}) 20%, transparent);`;
+          `border-color: color-mix(in srgb, var(${varName}) 30%, transparent);`;
   };
 
   // Dot color styles using CSS variables
@@ -78,9 +78,9 @@
 
   // Size styles for the pill
   const sizeStyles: Record<StatusSize, string> = {
-    xs: 'text-[10px] px-1.5 py-0.5 gap-1',
-    sm: 'text-xs px-2 py-1 gap-1.5',
-    md: 'text-sm px-2.5 py-1.5 gap-2',
+    xs: 'text-[11px] px-2 py-0.5 gap-1',
+    sm: 'text-xs px-2.5 py-1 gap-1.5',
+    md: 'text-sm px-3 py-1.5 gap-2',
   };
 
   // Dot sizes

--- a/frontend/src/lib/desktop/views/SystemHealth.svelte
+++ b/frontend/src/lib/desktop/views/SystemHealth.svelte
@@ -93,7 +93,6 @@
         const existing = groups.get(r.category) ?? [];
         existing.push(r);
         groups.set(r.category, existing);
-        seen.add(r.category);
       }
     }
     return groups;
@@ -113,6 +112,7 @@
   }
 
   async function runDiagnostics() {
+    if (running) return;
     running = true;
     error = null;
     try {
@@ -323,7 +323,7 @@
               <StatusPill
                 variant={statusToVariant(result.status)}
                 label={t(`health.status.${result.status}`)}
-                size="xs"
+                size="sm"
               />
               <div class="flex-1 min-w-0">
                 <span class="text-sm font-medium">{formatCheckName(result.name)}</span>


### PR DESCRIPTION
## Summary
- Increased color-mix opacity values for stronger pill backgrounds (10% to 15%) and borders (20% to 30%) to improve contrast and readability
- Bumped text sizes and padding across all StatusPill size tiers (xs, sm, md)
- Upgraded system health page check result badges from xs to sm for better legibility
- Fixed pre-existing bug where unknown category results could be silently dropped in health diagnostics grouping
- Added double-click guard on Run Diagnostics button to prevent concurrent API calls

## Test plan
- [ ] Verify StatusPill badges on system health page are larger and more readable
- [ ] Verify stream status pills on audio settings page look correct
- [ ] Run diagnostics and confirm no visual regressions
- [ ] Verify dark mode contrast is still good